### PR TITLE
Add MPU configuration to panic output

### DIFF
--- a/arch/cortex-m4/src/mpu.rs
+++ b/arch/cortex-m4/src/mpu.rs
@@ -2,6 +2,8 @@ use kernel;
 use kernel::common::math::PowerOfTwo;
 use kernel::common::volatile_cell::VolatileCell;
 
+use core::fmt::Write;
+
 /// Indicates whether the MPU is present and, if so, how many regions it
 /// supports.
 #[repr(C,packed)]
@@ -216,9 +218,29 @@ impl kernel::mpu::MPU for MPU {
         }
     }
 
+    fn debug_region<W: Write>(_: &mut W, _: Region) {
+        /*
+        let enable = region.attributes & 0x1;
+        let size = (region.attributes >> 1) & 0x1f;  // size is 2^(size+1)
+        let subregion_disable_bits = (region.attributes >> 8) & 0xff; // 1->disabled
+        let B = (region.attributes >> 16) & 0x1;
+        let C = (region.attributes >> 17) & 0x1;
+        let S = (region.attributes >> 18) & 0x1; // shareable?
+        let tex = (region.attributes >> 19) & 0x7;
+        let ap = (region.attributes >> 24) & 0x7;
+        let xn = (region.attributes >> 28) & 0x1; // executable?
+
+        // N = Log2(Region size in bytes) = "size" + 1
+        let N = size + 1;
+        let region_number = region.base_address & 0xf;
+        let region_start = region.base_address & !((1<<N) - 1) // bits [31:N]
+        */
+    }
+
     fn set_mpu(&self, region: Region) {
         let regs = unsafe { &*self.0 };
 
+        debug!("{:#010x} {:#010x}", region.base_address(), region.attributes());
         regs.region_base_address.set(region.base_address());
 
         regs.region_attributes_and_size.set(region.attributes());

--- a/kernel/src/debug.rs
+++ b/kernel/src/debug.rs
@@ -12,7 +12,7 @@ pub const APPID_IDX: usize = 255;
 pub struct DebugWriter {
     driver: Option<&'static Driver>,
     pub container: Option<*mut u8>,
-    output_buffer: [u8; 1024],
+    output_buffer: [u8; 4096],
     output_head: usize,
     output_tail: usize,
     output_active_len: usize,
@@ -22,7 +22,7 @@ pub struct DebugWriter {
 static mut DEBUG_WRITER: DebugWriter = DebugWriter {
     driver: None,
     container: None,
-    output_buffer: [0; 1024],
+    output_buffer: [0; 4096],
     output_head: 0, // ........ first valid index in output_buffer
     output_tail: 0, // ........ one past last valid index (wraps to 0)
     output_active_len: 0, //... how big is the current transaction?

--- a/kernel/src/platform/mpu.rs
+++ b/kernel/src/platform/mpu.rs
@@ -1,3 +1,5 @@
+use core::fmt::Write;
+
 #[derive(Debug)]
 pub enum AccessPermission {
     //                                 Privileged  Unprivileged
@@ -19,8 +21,9 @@ pub enum ExecutePermission {
 }
 
 pub struct Region {
-    base_address: u32,
-    attributes: u32,
+    // HACK: Make these pub
+    pub base_address: u32,
+    pub attributes: u32,
 }
 
 impl Region {
@@ -68,6 +71,9 @@ pub trait MPU {
                      access: AccessPermission)
                      -> Option<Region>;
 
+    /// Debugging tool that `write`s a human-friendly intepretation of a region
+    fn debug_region<W: Write>(writer: &mut W, region: Region);
+
     /// Sets the base address, size and access attributes of the given MPU
     /// region number.
     fn set_mpu(&self, region: Region);
@@ -84,6 +90,10 @@ impl MPU for () {
                      _: AccessPermission)
                      -> Option<Region> {
         Some(Region::empty())
+    }
+
+    fn debug_region<W: Write>(writer: &mut W, _: Region) {
+        let _ = writer.write_fmt(format_args!("No MPU. Unused Region.\r\n"));
     }
 
     fn set_mpu(&self, _: Region) {}


### PR DESCRIPTION
This updates the panic! output to include the MPU Configuration:

    MPU Configuration:
     0: 0x00030000-0x00030200 Sub ✘'s 0x00 S ✘ X ✔ B ✘ C ✘ TEX 0 AP 6
     1: 0x20004000-0x20006000 Sub ✘'s 0x00 S ✘ X ✔ B ✘ C ✘ TEX 0 AP 3
     2: Disabled.
     3: Disabled.
     4: Disabled.
     5: Disabled.
     6: Disabled.
     7: Disabled.

As implemented, this is a big bucket of hacks. We don't currently save
the `Region`s created by `setup_mpu`, which means that the panic would
need to recreate them, but panic isn't passed a chip MPU instance, so
it can't.

I don't want to trample over the work that @alevy is doing to refactor
the MPU stuff, but this is immediately useful for debugging, hence
throwing this out into the world.

@alevy: Grab the printing bits from `debug_mpu_hack` and add it to
arch/cortex-m4 whenever that's ready