### PR TITLE
Fix Process Loading with App State Section

### DIFF
--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -375,7 +375,7 @@ impl TbfHeader {
         match *self {
             TbfHeader::TbfHeaderV1(hd) => hd.entry_offset,
             TbfHeader::TbfHeaderV2(hd) =>
-                hd.main.map_or(0, |m| m.init_fn_offset) + (hd.base.header_size as u32),
+                hd.main.map_or(0, |m| m.init_fn_offset + m.protected_size) + (hd.base.header_size as u32),
             _ => 0,
         }
     }

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -375,7 +375,7 @@ impl TbfHeader {
         match *self {
             TbfHeader::TbfHeaderV1(hd) => hd.entry_offset,
             TbfHeader::TbfHeaderV2(hd) =>
-                hd.main.map_or(0, |m| m.init_fn_offset + m.protected_size) + (hd.base.header_size as u32),
+                hd.main.map_or(0, |m| m.init_fn_offset) + (hd.base.header_size as u32) + self.get_total_writeable_flash_size(),
             _ => 0,
         }
     }
@@ -427,6 +427,15 @@ impl TbfHeader {
             }
             _ => (0, 0),
         }
+    }
+
+    /// Get the total size of writable flash regions.
+    fn get_total_writeable_flash_size(&self) -> u32 {
+        let mut total_size = 0;
+        for region_index in 0..self.number_writeable_flash_regions() {
+            total_size += self.get_writeable_flash_region(region_index).1
+        }
+        total_size
     }
 }
 
@@ -1029,7 +1038,7 @@ impl<'a> Process<'a> {
                 }
 
                 let flash_protected_size = process.header.get_protected_size() as usize;
-                let flash_app_start = app_flash_address as usize + flash_protected_size;
+                let flash_app_start = app_flash_address as usize + flash_protected_size + process.header.get_total_writeable_flash_size() as usize;
 
                 process.tasks.enqueue(Task::FunctionCall(FunctionCall {
                     pc: init_fn,
@@ -1400,7 +1409,9 @@ impl<'a> Process<'a> {
         let flash_end = self.text.as_ptr().offset(self.text.len() as isize) as usize;
         let flash_start = self.text.as_ptr() as usize;
         let flash_protected_size = self.header.get_protected_size() as usize;
-        let flash_app_start = flash_start + flash_protected_size;
+        let flash_writeable_size = self.header.get_total_writeable_flash_size() as usize;
+        let flash_writeable_start = flash_start + flash_protected_size;
+        let flash_app_start = flash_start + flash_protected_size + flash_writeable_size;
         let flash_app_size = flash_end - flash_app_start;
         let flash_init_fn = flash_start + self.header.get_init_function_offset() as usize;
 
@@ -1485,11 +1496,13 @@ impl<'a> Process<'a> {
 \r\n             │ Unused\
   \r\n  {:#010X} ┴───────────────────────────────────────────\
 \r\n             .....\
-  \r\n  {:#010X} ┬─────────────────────────────────────────── F\
-\r\n             │ App Flash    {:6}                        L\
-  \r\n  {:#010X} ┼─────────────────────────────────────────── A\
-\r\n             │ Protected    {:6}                        S\
-  \r\n  {:#010X} ┴─────────────────────────────────────────── H\
+  \r\n  {:#010X} ┬───────────────────────────────────────────\
+\r\n             │ App Flash    {:6}                        F\
+  \r\n  {:#010X} ┼─────────────────────────────────────────── L\
+\r\n             │ App State    {:6}                        A\
+  \r\n  {:#010X} ┼─────────────────────────────────────────── S\
+\r\n             │ Protected    {:6}                        H\
+  \r\n  {:#010X} ┴───────────────────────────────────────────\
 \r\n\
   \r\n  R0 : {:#010X}    R6 : {:#010X}\
   \r\n  R1 : {:#010X}    R7 : {:#010X}\
@@ -1517,6 +1530,8 @@ impl<'a> Process<'a> {
   flash_end,
   flash_app_size,
   flash_app_start,
+  flash_writeable_size,
+  flash_writeable_start,
   flash_protected_size,
   flash_start,
   r0, self.stored_regs.r6,

--- a/userland/tools/elf2tbf/src/main.rs
+++ b/userland/tools/elf2tbf/src/main.rs
@@ -253,7 +253,7 @@ fn do_work(
 
     // To start we just restrict the app from writing all of the space before
     // its actual code and whatnot.
-    let protected_size = 0;
+    let mut protected_size = 0;
 
     // First up is the app writeable app_state section. If this is not used or
     // non-existent, it will just be zero and won't matter. But we put it first
@@ -269,6 +269,8 @@ fn do_work(
     let bss_size = bss.shdr.size as u32;
     let minimum_ram_size =
         stack_len + app_heap_len + kernel_heap_len + got_size + data_size + bss_size;
+    // Account for the size of the writeable flash region
+    protected_size += appstate_size;
 
     // Flags default to app is enabled.
     let flags = 0x00000001;

--- a/userland/tools/elf2tbf/src/main.rs
+++ b/userland/tools/elf2tbf/src/main.rs
@@ -253,7 +253,7 @@ fn do_work(
 
     // To start we just restrict the app from writing all of the space before
     // its actual code and whatnot.
-    let mut protected_size = 0;
+    let protected_size = 0;
 
     // First up is the app writeable app_state section. If this is not used or
     // non-existent, it will just be zero and won't matter. But we put it first
@@ -269,8 +269,6 @@ fn do_work(
     let bss_size = bss.shdr.size as u32;
     let minimum_ram_size =
         stack_len + app_heap_len + kernel_heap_len + got_size + data_size + bss_size;
-    // Account for the size of the writeable flash region
-    protected_size += appstate_size;
 
     // Flags default to app is enabled.
     let flags = 0x00000001;

--- a/userland/userland_generic.ld
+++ b/userland/userland_generic.ld
@@ -148,4 +148,5 @@ SECTIONS {
       *(.ARM.exidx* .gnu.linkonce.armexidx.*)
     } > FLASH
     PROVIDE_HIDDEN (__exidx_end = .);
+
 }

--- a/userland/userland_generic.ld
+++ b/userland/userland_generic.ld
@@ -20,6 +20,14 @@ MEMORY {
 }
 
 SECTIONS {
+    /* App state section. Used for persistent app data.
+     * Goes before the Text section in Flash.
+     */
+    .app_state :
+    {
+        KEEP (*(.app_state))
+    } > FLASH =0xFF
+
     /* Text section, Code! */
     .text :
     {
@@ -140,10 +148,4 @@ SECTIONS {
       *(.ARM.exidx* .gnu.linkonce.armexidx.*)
     } > FLASH
     PROVIDE_HIDDEN (__exidx_end = .);
-
-    /* App state section. Used for persistent app data. */
-    .app_state :
-    {
-        KEEP (*(.app_state))
-    } > FLASH =0xFF
 }

--- a/userland/userland_generic.ld
+++ b/userland/userland_generic.ld
@@ -70,12 +70,6 @@ SECTIONS {
     } > FLASH =0xFF
 
 
-    /* App state section. Used for persistent app data. */
-    .app_state :
-    {
-        KEEP (*(.app_state))
-    } > FLASH =0xFF
-
     /* Global Offset Table */
     .got :
     {
@@ -147,4 +141,9 @@ SECTIONS {
     } > FLASH
     PROVIDE_HIDDEN (__exidx_end = .);
 
+    /* App state section. Used for persistent app data. */
+    /*.app_state :
+    {
+        KEEP (*(.app_state))
+    } > FLASH =0xFF*/
 }

--- a/userland/userland_generic.ld
+++ b/userland/userland_generic.ld
@@ -142,8 +142,8 @@ SECTIONS {
     PROVIDE_HIDDEN (__exidx_end = .);
 
     /* App state section. Used for persistent app data. */
-    /*.app_state :
+    .app_state :
     {
         KEEP (*(.app_state))
-    } > FLASH =0xFF*/
+    } > FLASH =0xFF
 }


### PR DESCRIPTION
### Pull Request Overview

Fix process loading with app state section

This commit allows processes using App State to properly load by:
 - Fixing elf2tbf so that the size of the app_state region is accounted for and noted in a tbf header as a protected region.
- Changing proccess.rs so that it takes this protected region into account when calculating the init address of the process.
- Moving the AppState region in the linker file so that it doesn't improperly offset the other sections.


### Testing Strategy

Testing still required.

### TODO or Help Wanted

Processes using App State now load without crashing. App State does not work because the app state section is still marked as a 'protected region' by process.rs. We should discuss the intent behind the protected region and either move the protected region to include the app state section or make a new region for app state.

### Documentation Updated

- [ ] Kernel: Updated the relevant files in `/docs`, or no updates are required.
- [ ] Userland: Added/updated the application README, if needed.

### Formatting

- [ ] Ran `make formatall`.
