### PR TITLE
word-align binary section boundaries

### DIFF
--- a/userland/userland_generic.ld
+++ b/userland/userland_generic.ld
@@ -74,6 +74,7 @@ SECTIONS {
     .app_state :
     {
         KEEP (*(.app_state))
+        . = ALIGN(4); /* Make sure we're word-aligned here */
     } > FLASH =0xFF
 
     /* Global Offset Table */
@@ -82,6 +83,7 @@ SECTIONS {
         _got = .;
         *(.got*)
         *(.got.plt*)
+        . = ALIGN(4); /* Make sure we're word-aligned here */
     } > SRAM AT > FLASH
 
     /* Data section, static initialized variables
@@ -92,6 +94,7 @@ SECTIONS {
     {
         _data = .;
         KEEP(*(.data*))
+        . = ALIGN(4); /* Make sure we're word-aligned here */
     } > SRAM AT > FLASH
 
     /* BSS section, static uninitialized variables */
@@ -100,6 +103,7 @@ SECTIONS {
         _bss = .;
         KEEP(*(.bss*))
         *(COMMON)
+        . = ALIGN(4); /* Make sure we're word-aligned here */
     } > SRAM
 
     /*
@@ -109,16 +113,19 @@ SECTIONS {
     .stack :
     {
         . += STACK_SIZE;
+        . = ALIGN(4); /* Make sure we're word-aligned here */
     } > SRAM
 
     .app_heap :
     {
         . += APP_HEAP_SIZE;
+        . = ALIGN(4); /* Make sure we're word-aligned here */
     } > SRAM
 
     .kernel_heap :
     {
         . += KERNEL_HEAP_SIZE;
+        . = ALIGN(4); /* Make sure we're word-aligned here */
     } > SRAM
 
     _sram_end = .;


### PR DESCRIPTION
### Pull Request Overview

This pull request aligns all section boundaries in the binary to words.

This gets rid of the hard faults in #820. I am not sure that all of these changes are required, but the net result was that the binary grew by just three bytes (because .data grew from 369 to 372 bytes, which is divisible by 4), so they seem not to do much harm, either.

### Testing Strategy

I compiled the sensors app that used to hard fault on my micro:bit (NRF51, Cortex-M0) and it did no longer crash.

### TODO or Help Wanted

Somebody should check that all those changes are in fact harmless in other situations.
 
### Documentation Updated

- [ ] Kernel: Updated the relevant files in `/docs`, or no updates are required.
- [ ] Userland: Added/updated the application README, if needed.

### Formatting

- [ ] Ran `make formatall`.
