### PR TITLE
new svd2regs tool

### DIFF
--- a/tools/svd2regs.py
+++ b/tools/svd2regs.py
@@ -129,22 +129,17 @@ class PeripheralStructField(CodeBlock):
                 return ""
             return ", {}::Register".format(reg.name)
 
-        def mode(access):
-            mode_map = {
-                "read-only": "ReadOnly",
-                "read-write": "ReadWrite",
-                "write-only": "WriteOnly",
-            }
-            if access == None:
-                return mode_map['read-write']
-            else:
-                return mode_map[access]
+        mode_map = {
+            "read-only": "ReadOnly",
+            "read-write": "ReadWrite",
+            "write-only": "WriteOnly",
+        }
 
         return {
             "comment": comment(register.description),
             "name": identifier(register.name),
             "size": register._size,
-            "mode": mode(register._access),
+            "mode": mode_map.get(register._access, "ReadWrite"),
             "definition": definition(register),
         }
 

--- a/tools/svd2regs.py
+++ b/tools/svd2regs.py
@@ -247,6 +247,7 @@ def parse(peripheral_name, mcu, svd, group):
 
 
 def generate(name, peripherals):
+    peripherals = list(peripherals)
     main_peripheral = peripherals[0]
     return Includes() \
            + generate_peripheral_struct(name, main_peripheral) \
@@ -272,8 +273,8 @@ def rustfmt(code, path, *args):
     fmt = Popen(cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE)
     out, err = fmt.communicate(code)
     if err:
-        print code
-        print err
+        print(code)
+        print(err)
         sys.exit()
 
     return out

--- a/tools/svd2regs.py
+++ b/tools/svd2regs.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 #
-# usage: svd2regs.py [-h] (--mcu VENDOR MCU | --svd SVD) [--save FILE]
-#                    [--fmt] [--path PATH] [--args ARGS]
+# usage: svd2regs.py [-h] [--group] (--mcu VENDOR MCU | --svd [SVD])
+#                    [--save FILE] [--fmt ['ARG ..']] [--path PATH]
 #                    peripheral
 #
 # positional arguments:
@@ -11,7 +11,7 @@
 #   -h, --help        show this help message and exit
 #   --group, -g       Peripheral is a group with several instances
 #   --mcu VENDOR MCU  Vendor and MCU (Database from cmsis-svd)
-#   --svd SVD         Path to SVD-File
+#   --svd [SVD]         Path to SVD-File
 #   --save FILE       Save generated Code to file
 #
 # rustfmt:
@@ -250,7 +250,7 @@ def get_parser(mcu, svd):
     try:
         if mcu:
             return SVDParser.for_packaged_svd(mcu[0], "{}.svd".format(mcu[1]))
-        return SVDParser(ET.fromstring(svd.read()))
+        return SVDParser(ET.ElementTree(ET.fromstring(svd.read())))
     except IOError:
         print("No SVD file found")
         sys.exit()
@@ -304,8 +304,8 @@ def parse_args():
     xor = parser.add_mutually_exclusive_group(required=True)
     xor.add_argument('--mcu', nargs=2, metavar=('VENDOR', 'MCU'),
                      help='Vendor and MCU (Database from cmsis-svd)')
-    xor.add_argument('--svd', type=argparse.FileType('r'), default=sys.stdin,
-                     help='Path to SVD-File')
+    xor.add_argument('--svd', type=argparse.FileType('r'), const=sys.stdin,
+                     nargs="?", metavar="SVD", help='Path to SVD-File')
     parser.add_argument("--save", type=argparse.FileType('w'), metavar="FILE",
                         default=sys.stdout, help="Save generated Code to file")
     fmt = parser.add_argument_group('rustfmt',

--- a/tools/svd2regs.py
+++ b/tools/svd2regs.py
@@ -298,6 +298,11 @@ def parse(peripheral_name, mcu, svd, group):
 
 def generate(name, peripherals, dev):
     peripherals = list(peripherals)
+
+    if len(peripherals) == 0:
+        print('Error: no peripheral found.')
+        return ''
+
     main_peripheral = peripherals[0]
     return Includes() \
            + PeripheralStruct(name, main_peripheral, dev) \

--- a/tools/svd2regs.py
+++ b/tools/svd2regs.py
@@ -118,12 +118,6 @@ class PeripheralStructField(CodeBlock):
 
     @staticmethod
     def fields(register):
-        mode_map = {
-            "read-only": "ReadOnly",
-            "read-write": "ReadWrite",
-            "write-only": "WriteOnly",
-        }
-
         def identifier(name):
             identifier =  name.lower()
             if identifier in RUST_KEYWORDS:
@@ -135,11 +129,22 @@ class PeripheralStructField(CodeBlock):
                 return ""
             return ", {}::Register".format(reg.name)
 
+        def mode(access):
+            mode_map = {
+                "read-only": "ReadOnly",
+                "read-write": "ReadWrite",
+                "write-only": "WriteOnly",
+            }
+            if access == None:
+                return mode_map['read-write']
+            else:
+                return mode_map[access]
+
         return {
             "comment": comment(register.description),
             "name": identifier(register.name),
             "size": register._size,
-            "mode": mode_map[register._access],
+            "mode": mode(register._access),
             "definition": definition(register),
         }
 

--- a/tools/svd2regs.py
+++ b/tools/svd2regs.py
@@ -137,10 +137,14 @@ class PeripheralStructField(CodeBlock):
             "write-only": "WriteOnly",
         }
 
+        size = register._size
+        if size is None:
+            size = register.parent.parent.width
+
         return {
             "comment": comment(register.description),
             "name": identifier(register.name),
-            "size": register._size,
+            "size": size,
             "mode": mode_map.get(register._access, "ReadWrite"),
             "definition": definition(register),
         }

--- a/tools/svd2regs.py
+++ b/tools/svd2regs.py
@@ -190,7 +190,7 @@ class ReservedStructField(CodeBlock):
     def fields(cnt, size):
         return {
             "cnt": cnt,
-            "size": size,
+            "size": int(size),
         }
 
 

--- a/tools/svd2regs.py
+++ b/tools/svd2regs.py
@@ -94,7 +94,7 @@ const {name}_BASE: StaticRef<{title}Registers> =
 
 class PeripheralStruct(CodeBlock):
     TEMPLATE = """{comment}
-#[repr(C, packed)]
+#[repr(C)]
 struct {name}Registers {{
 {fields}
 }}

--- a/tools/svd2regs.py
+++ b/tools/svd2regs.py
@@ -1,0 +1,306 @@
+# usage: svd2regs.py [-h] (--mcu VENDOR MCU | --svd SVD) [--save FILE] [--fmt]
+# [--path PATH] [--args ARGS]
+# [PERIPHERAL [PERIPHERAL ...]]
+#
+# positional arguments:
+# PERIPHERAL        Name of the Peripheral
+#
+# optional arguments:
+# -h, --help        show this help message and exit
+# --mcu VENDOR MCU  Vendor and MCU (Database from cmsis-svd)
+# --svd SVD         Path to SVD-File
+# --save FILE       Save generated Code to file
+#
+# rustfmt:
+# Format with rustfmt
+#
+# --fmt ['ARG ..']  enable rustfmt with optional arguments
+# --path PATH       path to rustfmt
+#
+# Examples:
+#   SIM peripheral from Database
+#     svd2regs.py SIM --mcu Freescale MK64F12
+#
+#   Format with rustfmt
+#     svd2regs.py SIM --svd mcu.svd --fmt
+#
+#   Format with rustfmt --force
+#     svd2regs.py SIM --svd mcu.svd --fmt '--force'
+#
+#   Format with rustfmt not in PATH
+#     svd2regs.py SIM --svd mcu.svd --fmt --path /home/tock/bin/
+#
+#   Save to file
+#     svd2regs.py SIM --svd mcu.svd --fmt '--force' --save src/peripherals.rs
+#
+#   With stdin pipe
+#     cat mcu.svd | svd2regs.py SIM --svd --fmt '--force' | tee src/mcu.rs
+#
+# Required Python Packages:
+#   cmsis-svd
+#   pydentifier
+#
+# Author: Stefan Hoelzl <stefan.hoelzl@posteo.de>
+
+import sys
+import argparse
+from subprocess import Popen, PIPE
+from xml.etree import ElementTree as ET
+
+from cmsis_svd.parser import SVDParser
+import pydentifier
+
+RUST_KEYWORDS = ["mod"]
+COMMENT_MAX_LENGTH = 80
+
+
+def comment(text):
+    return "/// {}".format(text[:COMMENT_MAX_LENGTH].strip())
+
+
+class CodeBlock(str):
+    TEMPLATE = ""
+
+    def __new__(cls, obj=None):
+        return cls.TEMPLATE.format(**cls.fields(obj))
+
+    @staticmethod
+    def fields(obj):
+        return {}
+
+
+class Includes(CodeBlock):
+    TEMPLATE = """
+use kernel::StaticRef;
+use kernel::common::regs::{{self, ReadOnly, ReadWrite, WriteOnly}};
+    """
+
+
+class PeripheralBaseDeclaration(CodeBlock):
+    TEMPLATE = """
+const {name}_BASE: StaticRef<{title}Registers> =
+    unsafe {{ StaticRef::new(0x{base:8X} as *const {title}Registers) }};
+"""
+
+    @staticmethod
+    def fields(peripheral):
+        return {
+            "name": peripheral.name,
+            "title": peripheral.name.title(),
+            "base": peripheral.base_address,
+        }
+
+
+class PeripheralStruct(CodeBlock):
+    TEMPLATE = """{comment}
+#[repr(C, packed)]
+struct {name}Registers {{
+{fields}
+}}
+"""
+
+    @staticmethod
+    def fields(peripheral):
+        return {
+            "comment": comment(peripheral.description),
+            "name": peripheral.name.title(),
+            "fields": "\n".join(
+                PeripheralStructField(register)
+                for register in peripheral.registers
+            )
+        }
+
+
+class PeripheralStructField(CodeBlock):
+    TEMPLATE = """{comment}
+{name}: {mode}<u{size}{definition}>,"""
+
+    @staticmethod
+    def fields(register):
+        mode_map = {
+            "read-only": "ReadOnly",
+            "read-write": "ReadWrite",
+            "write-only": "WriteOnly",
+        }
+
+        def identifier(name):
+            identifier =  name.lower()
+            if identifier in RUST_KEYWORDS:
+                identifier = "{}_".format(identifier)
+            return identifier
+
+        def definition(reg):
+            if len(reg._fields) == 1:
+                return ""
+            return ", {}::Register".format(reg.name)
+
+        return {
+            "comment": comment(register.description),
+            "name": identifier(register.name),
+            "size": register._size,
+            "mode": mode_map[register._access],
+            "definition": definition(register),
+        }
+
+
+class BitfieldsMacro(CodeBlock):
+    TEMPLATE = """register_bitfields![u{size},{bitfields}
+];"""
+
+    @staticmethod
+    def fields(registers):
+        bitfields = ",".join(Bitfield(register) for register in registers)
+        return {
+            "size": 32,
+            "bitfields": bitfields
+        }
+
+
+class Bitfield(CodeBlock):
+    TEMPLATE = """
+{name} [
+{fields}
+]"""
+
+    @staticmethod
+    def fields(register):
+        fields = ",\n".join(BitfieldField(field) for field in register._fields)
+        return {
+            "name": register.name,
+            "fields": fields,
+        }
+
+
+class BitfieldField(CodeBlock):
+    TEMPLATE = """    {comment}
+    {name} OFFSET({offset}) NUMBITS({size}) {enums}"""
+
+    @staticmethod
+    def enumerated_values(field):
+        values = []
+        for value in field.enumerated_values:
+            if value.description not in [v.description for v in values]:
+                values.append(value)
+        return values
+
+    @staticmethod
+    def fields(field):
+        if not field.is_enumerated_type:
+            enums = "[]"
+        else:
+            enums = ",\n".join(BitfieldFieldEnum(enum)
+                               for enum in BitfieldField.enumerated_values(field))
+            enums = "[\n{}\n    ]".format(enums)
+        return {
+            "comment": comment(field.description),
+            "name": field.name,
+            "offset": field.bit_offset,
+            "size": field.bit_width,
+            "enums": enums,
+        }
+
+
+class BitfieldFieldEnum(CodeBlock):
+    TEMPLATE = """        {comment}
+        {name} = {value}"""
+
+    @staticmethod
+    def fields(enum):
+        def identifier(desc):
+            if any(desc.startswith(str(digit)) for digit in range(10)):
+                desc = "_{}".format(desc)
+            i = pydentifier.upper_camel(desc)
+            return i if len(i) < 80 else None
+
+        def enum_identifier(e):
+            for t in [e.description, e.name, e.value]:
+                i = identifier(t)
+                if i:
+                    return i
+
+        return {
+            "comment": comment(enum.description),
+            "name": enum_identifier(enum),
+            "value": enum.value,
+        }
+
+
+def get_parser(mcu, svd):
+    try:
+        if mcu:
+            return SVDParser.for_packaged_svd(mcu[0], "{}.svd".format(mcu[1]))
+        return SVDParser(ET.fromstring(svd.read()))
+    except IOError:
+        print("No SVD file found")
+        sys.exit()
+
+
+def parse(peripherals, mcu, svd):
+    svd_parser = get_parser(mcu, svd)
+    dev = svd_parser.get_device()
+    if not peripherals:
+        peripherals = [peripheral.name for peripheral in dev.peripherals]
+    return filter(lambda p: p.name in peripherals, dev.peripherals)
+
+
+def generate(peripherals):
+    return Includes() + "\n".join(generate_peripherial(p) for p in peripherals)
+
+
+def generate_peripherial(peripheral):
+    return generate_peripheral_struct(peripheral) \
+           + generate_bitfields_macro(filter(lambda r: len(r._fields) > 1,
+                                      peripheral.registers)) \
+           + PeripheralBaseDeclaration(peripheral)
+
+
+def generate_peripheral_struct(peripheral):
+    return PeripheralStruct(peripheral)
+
+
+def generate_bitfields_macro(registers):
+    return BitfieldsMacro(registers)
+
+
+def rustfmt(code, path, *args):
+    cmd = ["{}rustfmt".format(path)]
+    cmd.extend(args)
+    fmt = Popen(cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE)
+    out, err = fmt.communicate(code)
+    if err:
+        print code
+        print err
+        sys.exit()
+
+    return out
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("peripherals", nargs="*", metavar="PERIPHERAL",
+                        help="Name of the Peripheral")
+    xor = parser.add_mutually_exclusive_group(required=True)
+    xor.add_argument('--mcu', nargs=2, metavar=('VENDOR', 'MCU'),
+                     help='Vendor and MCU (Database from cmsis-svd)')
+    xor.add_argument('--svd', type=argparse.FileType('r'), default=sys.stdin,
+                     help='Path to SVD-File')
+    parser.add_argument("--save", type=argparse.FileType('w'), metavar="FILE",
+                        default=sys.stdout, help="Save generated Code to file")
+    fmt = parser.add_argument_group('rustfmt',
+                                    'Format with rustfmt')
+    fmt.add_argument("--fmt", nargs="?", const='', metavar="'ARG ..'",
+                     help="enable rustfmt with optional arguments")
+    fmt.add_argument("--path", help="path to rustfmt", default="")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    code = generate(parse(args.peripherals, args.mcu, args.svd))
+    if args.fmt is not None:
+        code = rustfmt(code, args.path, *args.fmt.strip("'").split(" "))
+    args.save.write(code)
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/svd2regs.py
+++ b/tools/svd2regs.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python
+#
 # usage: svd2regs.py [-h] (--mcu VENDOR MCU | --svd SVD) [--save FILE]
 #                    [--fmt] [--path PATH] [--args ARGS]
 #                    peripheral

--- a/tools/svd2regs.py
+++ b/tools/svd2regs.py
@@ -130,17 +130,19 @@ struct {name}Registers {{
                 fields.append(ReservedStructField(cnt, diff))
                 cnt += 1
                 offset += diff
-            if offset != register.address_offset:
-                raise Exception(
+            if offset == register.address_offset:
+                size = get_register_size(register)
+                fields.append(PeripheralStructField(register, size))
+                offset += size / 8
+            else:
+                # TODO: handle overlapping registers better (Unions?)
+                print(
                     "Offset Mismatch at register {} ({} != {})".format(
                         register.name,
                         register.address_offset,
                         offset
                     )
                 )
-            size = get_register_size(register)
-            fields.append(PeripheralStructField(register, size))
-            offset += size / 8
 
         return {
             "comment": comment(peripheral.description),

--- a/tools/svd2regs.py
+++ b/tools/svd2regs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # usage: svd2regs.py [-h] [--group] (--mcu VENDOR MCU | --svd [SVD])
 #                    [--save FILE] [--fmt ['ARG ..']] [--path PATH]
@@ -50,8 +50,19 @@ import argparse
 from subprocess import Popen, PIPE
 from xml.etree import ElementTree as ET
 
-from cmsis_svd.parser import SVDParser
-import pydentifier
+try:
+    from cmsis_svd.parser import SVDParser
+except ImportError:
+    print('Could not import CMSIS SVD library')
+    print('pip install cmsis-svd')
+    sys.exit(1)
+
+try:
+    import pydentifier
+except ImportError:
+    print('Could not import Pydentifier library')
+    print('pip install pydentifier')
+    sys.exit(1)
 
 RUST_KEYWORDS = ["mod"]
 COMMENT_MAX_LENGTH = 80


### PR DESCRIPTION
### Pull Request Overview

This pull request adds a new tool to generate TockOS-conform Peripheral structs and bitfield_macros from SVD-files.


### Testing Strategy

This pull request was tested with the Kinetis MK64F12 SVD and the SIM, PMC peripheral.


### TODO or Help Wanted

- Use it with different MCUs/Peripherals and report bugs


### Documentation Updated

- [X] Kernel: Updated the relevant files in `/docs`, or no updates are required.
- [X] Userland: Added/updated the application README, if needed.

### Formatting

- [X] Ran `make formatall`.

[example_output.txt](https://github.com/helena-project/tock/files/1910580/example_output.txt)
