### PR TITLE
kernel: charge the process struct to app memory

### DIFF
--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -37,7 +37,7 @@ static mut SPI_WRITE_BUF: [u8; 64] = [0; 64];
 // State for loading and holding applications.
 
 // Number of concurrent processes this platform supports.
-const NUM_PROCS: usize = 4;
+const NUM_PROCS: usize = 20;
 
 // How should the kernel respond when a process faults.
 const FAULT_RESPONSE: kernel::process::FaultResponse = kernel::process::FaultResponse::Panic;
@@ -47,7 +47,10 @@ const FAULT_RESPONSE: kernel::process::FaultResponse = kernel::process::FaultRes
 static mut APP_MEMORY: [u8; 49152] = [0; 49152];
 
 // Actual memory for holding the active process structures.
-static mut PROCESSES: [Option<kernel::Process<'static>>; NUM_PROCS] = [None, None, None, None];
+static mut PROCESSES: [Option<&'static mut kernel::Process<'static>>; NUM_PROCS] = [
+    None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
+    None, None, None, None,
+];
 
 /// A structure representing this platform that holds references to all
 /// capsules for this platform.

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -63,7 +63,7 @@ const FAULT_RESPONSE: kernel::process::FaultResponse = kernel::process::FaultRes
 #[link_section = ".app_memory"]
 static mut APP_MEMORY: [u8; 16384] = [0; 16384];
 
-static mut PROCESSES: [Option<kernel::Process<'static>>; NUM_PROCS] = [None, None];
+static mut PROCESSES: [Option<&'static mut kernel::Process<'static>>; NUM_PROCS] = [None, None];
 
 // Save some deep nesting
 type RF233Device =

--- a/boards/launchxl/src/main.rs
+++ b/boards/launchxl/src/main.rs
@@ -23,7 +23,7 @@ const FAULT_RESPONSE: kernel::process::FaultResponse = kernel::process::FaultRes
 
 // Number of concurrent processes this platform supports.
 const NUM_PROCS: usize = 2;
-static mut PROCESSES: [Option<kernel::Process<'static>>; NUM_PROCS] = [None, None];
+static mut PROCESSES: [Option<&'static mut kernel::Process<'static>>; NUM_PROCS] = [None, None];
 
 #[link_section = ".app_memory"]
 // Give half of RAM to be dedicated APP memory

--- a/boards/nrf51dk/src/main.rs
+++ b/boards/nrf51dk/src/main.rs
@@ -91,7 +91,7 @@ const NUM_PROCS: usize = 1;
 #[link_section = ".app_memory"]
 static mut APP_MEMORY: [u8; 8192] = [0; 8192];
 
-static mut PROCESSES: [Option<kernel::Process<'static>>; NUM_PROCS] = [None];
+static mut PROCESSES: [Option<&'static mut kernel::Process<'static>>; NUM_PROCS] = [None];
 
 /// Supported drivers by the platform
 pub struct Platform {

--- a/boards/nrf52dk/src/main.rs
+++ b/boards/nrf52dk/src/main.rs
@@ -106,7 +106,8 @@ const NUM_PROCS: usize = 4;
 #[link_section = ".app_memory"]
 static mut APP_MEMORY: [u8; 32768] = [0; 32768];
 
-static mut PROCESSES: [Option<kernel::Process<'static>>; NUM_PROCS] = [None, None, None, None];
+static mut PROCESSES: [Option<&'static mut kernel::Process<'static>>; NUM_PROCS] =
+    [None, None, None, None];
 
 /// Supported drivers by the platform
 pub struct Platform {

--- a/doc/courses/sensys/exercises/board/src/main.rs
+++ b/doc/courses/sensys/exercises/board/src/main.rs
@@ -42,7 +42,8 @@ const FAULT_RESPONSE: kernel::process::FaultResponse = kernel::process::FaultRes
 static mut APP_MEMORY: [u8; 49152] = [0; 49152];
 
 // Actual memory for holding the active process structures.
-static mut PROCESSES: [Option<kernel::Process<'static>>; NUM_PROCS] = [None, None, None, None];
+static mut PROCESSES: [Option<&'static mut kernel::Process<'static>>; NUM_PROCS] =
+    [None, None, None, None];
 
 /// A structure representing this platform that holds references to all
 /// capsules for this platform.

--- a/kernel/src/grant.rs
+++ b/kernel/src/grant.rs
@@ -44,7 +44,7 @@ impl<T> AppliedGrant<T> {
 }
 
 pub struct Allocator<'a> {
-    app: Option<&'a mut process::Process<'a>>,
+    app: Option<&'a mut &'a mut process::Process<'a>>,
     app_id: usize,
 }
 

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -52,7 +52,7 @@ pub use returncode::ReturnCode;
 pub fn main<P: Platform, C: Chip>(
     platform: &P,
     chip: &mut C,
-    processes: &'static mut [Option<process::Process<'static>>],
+    processes: &'static mut [Option<&mut process::Process<'static>>],
     ipc: &ipc::IPC,
 ) {
     let processes = unsafe {

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -40,7 +40,7 @@ extern "C" {
                           -> *mut u8;
 }
 
-pub static mut PROCS: &'static mut [Option<Process<'static>>] = &mut [];
+pub static mut PROCS: &'static mut [Option<&mut Process<'static>>] = &mut [];
 
 /// Helper function to load processes from flash into an array of active
 /// processes. This is the default template for loading processes, but a board
@@ -54,7 +54,7 @@ pub static mut PROCS: &'static mut [Option<Process<'static>>] = &mut [];
 /// selected.
 pub unsafe fn load_processes(start_of_flash: *const u8,
                              app_memory: &mut [u8],
-                             procs: &mut [Option<Process<'static>>],
+                             procs: &mut [Option<&mut Process<'static>>],
                              fault_response: FaultResponse) {
     let mut apps_in_flash_ptr = start_of_flash;
     let mut app_memory_ptr = app_memory.as_mut_ptr();
@@ -913,7 +913,7 @@ impl<'a> Process<'a> {
                          remaining_app_memory: *mut u8,
                          remaining_app_memory_size: usize,
                          fault_response: FaultResponse)
-                         -> (Option<Process<'a>>, usize, usize) {
+                         -> (Option<&'static mut Process<'a>>, usize, usize) {
         if let Some(tbf_header) = parse_and_validate_tbf_header(app_flash_address) {
             let app_flash_size = tbf_header.get_total_size() as usize;
 
@@ -947,10 +947,13 @@ impl<'a> Process<'a> {
                 let callback_len = 10;
                 let callbacks_offset = callback_len * callback_size;
 
+                // Make room to store this process's metadata.
+                let process_struct_offset = mem::size_of::<Process>();
+
                 // Need to make sure that the amount of memory we allocate for
                 // this process at least covers this state.
-                if min_app_ram_size < (grant_ptrs_offset + callbacks_offset) as u32 {
-                    min_app_ram_size = (grant_ptrs_offset + callbacks_offset) as u32;
+                if min_app_ram_size < (grant_ptrs_offset + callbacks_offset + process_struct_offset) as u32 {
+                    min_app_ram_size = (grant_ptrs_offset + callbacks_offset + process_struct_offset) as u32;
                 }
 
                 // TODO round app_ram_size up to a closer MPU unit.
@@ -992,6 +995,10 @@ impl<'a> Process<'a> {
                                                              callback_len);
                 let tasks = RingBuffer::new(callback_buf);
 
+                // Last thing is the process struct.
+                kernel_memory_break = kernel_memory_break.offset(-(process_struct_offset as isize));
+                let process_struct_memory_location = kernel_memory_break;
+
                 // Determine the debug information to the best of our
                 // understanding. If the app is doing all of the PIC fixup and
                 // memory management we don't know much.
@@ -1002,40 +1009,39 @@ impl<'a> Process<'a> {
                     app_stack_start_pointer = Some(load_result.initial_stack_pointer);
                 }
 
-                let mut process = Process {
-                    memory: app_memory,
+                // Create the Process struct in the app grant region.
+                let mut process: &mut Process = mem::transmute(process_struct_memory_location);
 
-                    header: load_result.header,
+                process.memory = app_memory;
+                process.header = load_result.header;
+                process.kernel_memory_break = kernel_memory_break;
+                process.app_break = load_result.initial_sbrk_pointer;
+                process.current_stack_pointer = load_result.initial_stack_pointer;
 
-                    kernel_memory_break: kernel_memory_break,
-                    app_break: load_result.initial_sbrk_pointer,
-                    current_stack_pointer: load_result.initial_stack_pointer,
+                process.text = slice::from_raw_parts(app_flash_address, app_flash_size);
 
-                    text: slice::from_raw_parts(app_flash_address, app_flash_size),
+                process.stored_regs = Default::default();
+                process.yield_pc = init_fn;
+                // Set the Thumb bit and clear everything else
+                process.psr = 0x01000000;
 
-                    stored_regs: Default::default(),
-                    yield_pc: init_fn,
-                    // Set the Thumb bit and clear everything else
-                    psr: 0x01000000,
+                process.state = State::Yielded;
+                process.fault_response = fault_response;
 
-                    state: State::Yielded,
-                    fault_response: fault_response,
+                process.mpu_regions = [Cell::new((ptr::null(), math::PowerOfTwo::zero())),
+                              Cell::new((ptr::null(), math::PowerOfTwo::zero())),
+                              Cell::new((ptr::null(), math::PowerOfTwo::zero())),
+                              Cell::new((ptr::null(), math::PowerOfTwo::zero())),
+                              Cell::new((ptr::null(), math::PowerOfTwo::zero()))];
+                process.tasks = tasks;
+                process.package_name = package_name;
 
-                    mpu_regions: [Cell::new((ptr::null(), math::PowerOfTwo::zero())),
-                                  Cell::new((ptr::null(), math::PowerOfTwo::zero())),
-                                  Cell::new((ptr::null(), math::PowerOfTwo::zero())),
-                                  Cell::new((ptr::null(), math::PowerOfTwo::zero())),
-                                  Cell::new((ptr::null(), math::PowerOfTwo::zero()))],
-                    tasks: tasks,
-                    package_name: package_name,
-
-                    debug: ProcessDebug {
-                        app_heap_start_pointer: app_heap_start_pointer,
-                        app_stack_start_pointer: app_stack_start_pointer,
-                        min_stack_pointer: load_result.initial_stack_pointer,
-                        syscall_count: Cell::new(0),
-                        last_syscall: Cell::new(None),
-                    }
+                process.debug = ProcessDebug {
+                    app_heap_start_pointer: app_heap_start_pointer,
+                    app_stack_start_pointer: app_stack_start_pointer,
+                    min_stack_pointer: load_result.initial_stack_pointer,
+                    syscall_count: Cell::new(0),
+                    last_syscall: Cell::new(None),
                 };
 
                 if (init_fn & 0x1) != 1 {


### PR DESCRIPTION


### Pull Request Overview

This pull request changes how app "metadata" is stored in the kernel. Before it is stored in an array defined in the main.rs file of the board. Now, it is stored in the grant region of the app. There is still an array in the board file, but it only contains pointers to the `Process` struct which now resides in the application's grant memory.


### Testing Strategy

This pull request was tested by running 6 apps on hail.


### TODO or Help Wanted

I'm not sure this is the best way to do this from a rust implementation standpoint. I think this PR is useful because I've always disliked the artificial limit of how many apps a Tock board can support. Now the issue is RAM exhaustion (I ran out of room to load apps at app #7). I think that is primarily due to having to round up the RAM to a power of 2, however.

It is possible we don't want this for some reason.


### Documentation Updated

- [ ] Kernel: Updated the relevant files in `/docs`, or no updates are required.
- [x] Userland: Added/updated the application README, if needed.

### Formatting

- [x] Ran `make formatall`.
