### PR TITLE
doc/Syscalls.md: replace Hail with TestBoard

### DIFF
--- a/doc/Syscalls.md
+++ b/doc/Syscalls.md
@@ -327,7 +327,7 @@ struct TestBoard {
     console: &'static Console<'static, usart::USART>,
 }
 
-impl Platform for Hail {
+impl Platform for TestBoard {
     fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
         where F: FnOnce(Option<&kernel::Driver>) -> R
     {


### PR DESCRIPTION
Just a typo fix in documentation.