### PR TITLE
Improve systick precision

### DIFF
--- a/arch/cortex-m3/src/systick.rs
+++ b/arch/cortex-m3/src/systick.rs
@@ -1,6 +1,5 @@
-//! ARM SysTick peripheral.
+//! ARM Cortex-M3 SysTick peripheral.
 
-use core::cmp;
 use kernel;
 use kernel::common::VolatileCell;
 
@@ -12,6 +11,8 @@ struct Registers {
 }
 
 /// The ARM Cortex-M3 SysTick peripheral
+///
+/// Documented in the Cortex-M3 Devices Generic User Guide, Chapter 4.4
 pub struct SysTick {
     regs: &'static Registers,
     hertz: u32,
@@ -61,52 +62,34 @@ impl SysTick {
 
 impl kernel::SysTick for SysTick {
     fn set_timer(&self, us: u32) {
-        let reload = if us == 0 {
-            0
-        } else {
-            // only support values up to 1 second. That's twice as much as the
-            // interface promises, so we're good. This makes computing hertz
-            // safer
-            let us = cmp::min(us, 1_000_000);
-            let hertz = self.hertz();
+        let reload = {
+            // We need to convert from microseconds to native tics, which could overflow in 32-bit
+            // arithmetic. So we convert to 64-bit. 64-bit division is an expensive subroutine, but
+            // if `us` is a power of 10 it can be simplified with the 1_000_000 divisor instead.
+            let us = us as u64;
+            let hertz = self.hertz() as u64;
 
-            // What we actually want is:
-            //
-            // reload = hertz * us / 1000000
-            //
-            // But that can overflow if hertz and us are sufficiently large.
-            // Dividing first may, instead, result in a reload value that's off
-            // by a lot (because integer division rounds down).
-            //
-            // We use division to compute the reload value to avoid
-            // multiplication overflows.
-            //
-            // 0 < us <= 1_000_000 so the divisions are never by zero
-            //
-            // As a result that the reload value might be slightly less
-            // accurate. For example, with a 48MHz clock, the reload value for
-            // 11ms should be 528000, but using integer division we'll get
-            // 533333. A small price to pay for not crashing.
-            hertz / (1_000_000 / us)
+            hertz * us / 1_000_000
         };
 
         self.regs.value.set(0);
-        self.regs.reload.set(reload);
+        self.regs.reload.set(reload as u32);
     }
 
-    fn value(&self) -> u32 {
-        let hertz = self.hertz();
-        let value = self.regs.value.get() & 0xffffff;
+    fn greater_than(&self, us: u32) -> bool {
+        let tics = {
+            // We need to convert from microseconds to native tics, which could overflow in 32-bit
+            // arithmetic. So we convert to 64-bit. 64-bit division is an expensive subroutine, but
+            // if `us` is a power of 10 the compiler will simplify it with the 1_000_000 divisor
+            // instead.
+            let us = us as u64;
+            let hertz = self.hertz() as u64;
 
-        // Just the opposite computation as in `set_timer` with the same
-        // drawbacks
-        if hertz > 1_000_000 {
-            // More accurate
-            value / (hertz / 1_000_000)
-        } else {
-            // Using the previous branch would divide by zero
-            (value / hertz) / 1_000_000
-        }
+            (hertz * us / 1_000_000) as u32
+        };
+
+        let value = self.regs.value.get() & 0xffffff;
+        value > tics
     }
 
     fn overflowed(&self) -> bool {

--- a/kernel/src/platform/systick.rs
+++ b/kernel/src/platform/systick.rs
@@ -18,8 +18,8 @@ pub trait SysTick {
     /// accurate and values up to 400ms are valid.
     fn set_timer(&self, us: u32);
 
-    /// Returns the time left in microseconds
-    fn value(&self) -> u32;
+    /// Returns if there is at least `us` microseconds left
+    fn greater_than(&self, us: u32) -> bool;
 
     /// Returns true if the timer has expired
     fn overflowed(&self) -> bool;
@@ -53,7 +53,7 @@ impl SysTick for () {
         false
     }
 
-    fn value(&self) -> u32 {
-        !0
+    fn greater_than(&self, _: u32) -> bool {
+        true
     }
 }

--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -30,7 +30,7 @@ pub unsafe fn do_process<P: Platform, C: Chip>(
 
     loop {
         if chip.has_pending_interrupts() || systick.overflowed()
-            || systick.value() <= MIN_QUANTA_THRESHOLD_US
+            || !systick.greater_than(MIN_QUANTA_THRESHOLD_US)
         {
             break;
         }


### PR DESCRIPTION
### Pull Request Overview

Use 64-bit arithmetic in the systick implementations to convert from
microseconds to tics.

64-bit division is a _very_ expensive operation in
Thumb, but as long as the microsecond value is a reasonably
large multiple of 10, the conversion is optimized by the compiler to
simple 32-bit division/multiplication.

To facilitate this optimization, the PR also changes the systick
interface by replacing the `value` method with a `greater_than` method,
since we only ever use the value in order to do a comparison with a
relatively large multiple of 10 (500).

Closes #907

### Testing Strategy

I ran several apps on Hail alongside an app that busy loops and blinks some LEDs to _at least_ make sure preemption works as expected. I didn't actually test the conversion correctness, and suggestions for what is worth testing are welcome.

### TODO or Help Wanted

Review my math please... I got it wrong last time :/

### Documentation Updated

- [X] Kernel: Updated the relevant files in `/docs`, or no updates are required.
- [X] Userland: Added/updated the application README, if needed.

### Formatting

- [X] Ran `make formatall`.
