### PR TITLE
WIP: nrf51: I2C (TWIM) support

### DIFF
--- a/capsules/src/i2c_master_slave_driver.rs
+++ b/capsules/src/i2c_master_slave_driver.rs
@@ -87,6 +87,7 @@ impl<'a> hil::i2c::I2CHwMasterClient for I2CMasterSlaveDriver<'a> {
             hil::i2c::Error::AddressNak => -1,
             hil::i2c::Error::DataNak => -2,
             hil::i2c::Error::ArbitrationLost => -3,
+            hil::i2c::Error::Overrun => -4,
             hil::i2c::Error::CommandComplete => 0,
         };
 

--- a/chips/nrf51/Cargo.lock
+++ b/chips/nrf51/Cargo.lock
@@ -1,0 +1,27 @@
+[[package]]
+name = "cortexm0"
+version = "0.1.0"
+dependencies = [
+ "kernel 0.1.0",
+]
+
+[[package]]
+name = "kernel"
+version = "0.1.0"
+
+[[package]]
+name = "nrf51"
+version = "0.1.0"
+dependencies = [
+ "cortexm0 0.1.0",
+ "kernel 0.1.0",
+ "nrf5x 0.1.0",
+]
+
+[[package]]
+name = "nrf5x"
+version = "0.1.0"
+dependencies = [
+ "kernel 0.1.0",
+]
+

--- a/chips/nrf51/src/chip.rs
+++ b/chips/nrf51/src/chip.rs
@@ -1,4 +1,5 @@
 use cortexm0::nvic;
+use i2c;
 use kernel;
 use kernel::support;
 use nrf5x;
@@ -40,6 +41,38 @@ impl kernel::Chip for NRF51 {
                     TIMER1 => nrf5x::timer::ALARM1.handle_interrupt(),
                     TIMER2 => nrf5x::timer::TIMER2.handle_interrupt(),
                     UART0 => uart::UART0.handle_interrupt(),
+                    SPI0_TWI0 => {
+                        // SPI0 and TWI0 share interrupts.
+                        // Dispatch the correct handler.
+                        // match (spi::SPIM0.is_enabled(), i2c::TWIM0.is_enabled()) {
+                        match (false, i2c::TWIM0.is_enabled()) {
+                            (false, false) => (),
+                            (true, false) => panic!("SPI is not yet implemented"),
+                            // spi::SPIM0.handle_interrupt(),
+                            (false, true) => i2c::TWIM0.handle_interrupt(),
+                            (true, true) => debug_assert!(
+                                false,
+                                "SPIM0 and TWIM0 cannot be \
+                                 enabled at the same time."
+                            ),
+                        }
+                    }
+                    SPI1_TWI1 => {
+                        // SPI1 and TWI1 share interrupts.
+                        // Dispatch the correct handler.
+                        // match (spi::SPIM1.is_enabled(), i2c::TWIM1.is_enabled()) {
+                        match (false, i2c::TWIM1.is_enabled()) {
+                            (false, false) => (),
+                            (true, false) => panic!("SPI is not yet implemented"),
+                            // spi::SPIM1.handle_interrupt(),
+                            (false, true) => i2c::TWIM1.handle_interrupt(),
+                            (true, true) => debug_assert!(
+                                false,
+                                "SPIM1 and TWIM1 cannot be \
+                                 enabled at the same time."
+                            ),
+                        }
+                    }
                     _ => debug!("NvicIdx not supported by Tock"),
                 }
                 let n = nvic::Nvic::new(interrupt);

--- a/chips/nrf51/src/i2c.rs
+++ b/chips/nrf51/src/i2c.rs
@@ -72,7 +72,7 @@ impl TWIM {
 
     /// Enables hardware TWIM peripheral.
     pub fn enable(&self) {
-        self.regs().enable.set(5); //write(Twim::ENABLE::ON);
+        self.regs().enable.write(Twim::ENABLE::ON);
     }
 
     /// Disables hardware TWIM peripheral.

--- a/chips/nrf51/src/i2c.rs
+++ b/chips/nrf51/src/i2c.rs
@@ -1,0 +1,404 @@
+//! Implementation of I2C for nRF51.
+//!
+//! This module supports nRF51's two I2C master (`TWIM`) peripherals.
+
+extern crate nrf5x;
+
+use core::cell::Cell;
+use kernel::common::regs::{FieldValue, ReadOnly, ReadWrite, WriteOnly};
+use kernel::common::take_cell::TakeCell;
+use kernel::common::VolatileCell;
+use kernel::hil::i2c;
+use nrf5x::gpio;
+use nrf5x::pinmux::Pinmux;
+
+/// An I2C master device.
+///
+/// A `TWIM` instance wraps a `registers::TWIM` together with
+/// additional data necessary to implement an asynchronous interface.
+pub struct TWIM {
+    registers: *const TwimRegisters,
+    client: Cell<Option<&'static i2c::I2CHwMasterClient>>,
+    txlen: Cell<u8>,
+    rxlen: Cell<u8>,
+    pos: VolatileCell<usize>,
+    buf: TakeCell<'static, [u8]>,
+}
+
+impl TWIM {
+    const fn new(instance: usize) -> TWIM {
+        TWIM {
+            registers: TWIM_BASE[instance],
+            client: Cell::new(None),
+            txlen: Cell::new(0),
+            rxlen: Cell::new(0),
+            pos: VolatileCell::new(0),
+            buf: TakeCell::empty(),
+        }
+    }
+
+    pub fn set_client(&self, client: &'static i2c::I2CHwMasterClient) {
+        debug_assert!(self.client.get().is_none());
+        self.client.set(Some(client));
+    }
+
+    fn regs(&self) -> &TwimRegisters {
+        unsafe { &*self.registers }
+    }
+
+    /// Configures an already constructed `TWIM`.
+    pub fn configure(&self, scl: Pinmux, sda: Pinmux) {
+        let sclix: u32 = scl.into();
+        let sdaix: u32 = sda.into();
+
+        // configure pins as inputs with drive strength S0D1
+        unsafe {
+            let sdapin = &nrf5x::gpio::PORT[sdaix as usize];
+            sdapin.write_config(gpio::PinConfig::DRIVE::S0D1);
+            let sclpin = &nrf5x::gpio::PORT[sclix as usize];
+            sclpin.write_config(gpio::PinConfig::DRIVE::S0D1);
+        }
+
+        let regs = self.regs();
+        regs.psel_scl.set(sclix);
+        regs.psel_sda.set(sdaix);
+    }
+
+    /// Sets the I2C bus speed to one of three possible values
+    /// enumerated in `Speed`.
+    pub fn set_speed(&self, speed: FieldValue<u32, Frequency::Register>) {
+        self.regs().frequency.write(speed);
+    }
+
+    /// Enables hardware TWIM peripheral.
+    pub fn enable(&self) {
+        self.regs().enable.set(5); //write(Twim::ENABLE::ON);
+    }
+
+    /// Disables hardware TWIM peripheral.
+    pub fn disable(&self) {
+        self.regs().enable.write(Twim::ENABLE::OFF);
+    }
+
+    fn start_read(&self) {
+        if self.rxlen.get() == 1 {
+            self.regs().shorts.write(Shorts::BB_STOP::SET);
+        } else {
+            self.regs().shorts.write(Shorts::BB_SUSPEND::SET);
+        }
+        self.txlen.set(0);
+        self.pos.set(0);
+        let regs = self.regs();
+        regs.intenset.write(InterruptEnable::RXREADY::SET);
+        regs.intenset.write(InterruptEnable::ERROR::SET);
+        // start the transfer
+        regs.tasks_startrx.write(Task::ENABLE::SET);
+    }
+
+    fn reply(&self, result: i2c::Error) {
+        match self.client.get() {
+            None => (),
+            Some(client) => match self.buf.take() {
+                None => (),
+                Some(buf) => {
+                    client.command_complete(buf, result);
+                }
+            },
+        }
+    }
+
+    // The SPI0_TWI0 and SPI1_TWI1 interrupts are dispatched to the
+    // correct handler by the service_pending_interrupts() routine in
+    // chip.rs based on which peripheral is enabled.
+
+    pub fn handle_interrupt(&self) {
+        let regs = self.regs();
+        if regs.events_rxdreceived.get() == 1 {
+            regs.events_rxdreceived.set(0);
+            let pos = self.pos.get();
+            self.pos.set(pos + 1);
+            if self.pos.get() < self.rxlen.get() as usize {
+                let v = regs.rxd.read(Data::DATA);
+                self.buf.map(|buf| buf[pos] = v as u8);
+                if pos == self.rxlen.get() as usize - 2 {
+                    regs.shorts.write(Shorts::BB_STOP::SET);
+                };
+                regs.tasks_resume.write(Task::ENABLE::SET);
+            } else {
+                regs.shorts.set(0);
+                let v = regs.rxd.read(Data::DATA);
+                self.buf.map(|buf| buf[pos] = v as u8);
+                regs.intenclr.write(InterruptEnable::RXREADY::SET);
+                regs.intenclr.write(InterruptEnable::ERROR::SET);
+                self.reply(i2c::Error::CommandComplete);
+                self.pos.set(0);
+            }
+        };
+        if regs.events_txdsent.get() == 1 {
+            regs.events_txdsent.set(0);
+            let pos = self.pos.get() + 1;
+            self.pos.set(pos);
+            if pos < self.txlen.get() as usize {
+                self.buf.map(|buf| regs.txd.set(buf[pos].into()));
+            } else {
+                if self.rxlen.get() > 0 {
+                    regs.intenclr.write(InterruptEnable::TXSENT::SET);
+                    self.start_read();
+                } else {
+                    regs.tasks_stop.write(Task::ENABLE::SET);
+                    regs.intenclr.write(InterruptEnable::TXSENT::SET);
+                    regs.intenclr.write(InterruptEnable::ERROR::SET);
+                    self.reply(i2c::Error::CommandComplete);
+                }
+            }
+        };
+        if regs.events_error.get() == 1 {
+            regs.events_error.set(0);
+            let errorsrc = if regs.errorsrc.is_set(ErrorSrc::OVERRUN) {
+                i2c::Error::Overrun
+            } else if regs.errorsrc.is_set(ErrorSrc::ADDRESSNACK) {
+                i2c::Error::AddressNak
+            } else if regs.errorsrc.is_set(ErrorSrc::DATANACK) {
+                i2c::Error::DataNak
+            } else {
+                i2c::Error::CommandComplete
+            };
+            regs.errorsrc.set(0);
+            self.reply(errorsrc);
+        }
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        self.regs().enable.get() == 5
+    }
+}
+
+impl i2c::I2CMaster for TWIM {
+    fn enable(&self) {
+        self.enable();
+    }
+
+    fn disable(&self) {
+        self.disable();
+    }
+
+    fn write_read(&self, addr: u8, data: &'static mut [u8], write_len: u8, read_len: u8) {
+        let regs = self.regs();
+        self.txlen.set(write_len);
+        self.rxlen.set(read_len);
+        regs.intenset.write(InterruptEnable::TXSENT::SET);
+        regs.intenset.write(InterruptEnable::ERROR::SET);
+        // start the transfer
+        self.pos.set(0);
+        regs.address.write(Address::ADDRESS.val(addr.into()));
+        regs.tasks_resume.write(Task::ENABLE::SET);
+        regs.tasks_starttx.write(Task::ENABLE::SET);
+        regs.txd.set(data[0].into());
+        self.buf.replace(data);
+    }
+
+    fn write(&self, addr: u8, data: &'static mut [u8], len: u8) {
+        self.write_read(addr, data, len, 0);
+    }
+
+    fn read(&self, addr: u8, buffer: &'static mut [u8], len: u8) {
+        self.regs().address.set(addr as u32);
+        self.rxlen.set(len);
+        self.regs().tasks_resume.write(Task::ENABLE::SET);
+        self.start_read();
+        self.buf.replace(buffer);
+    }
+}
+
+impl i2c::I2CSlave for TWIM {
+    fn enable(&self) {
+        panic!("nRF51 does not support I2C slave mode");
+    }
+    fn disable(&self) {
+        panic!("nRF51 does not support I2C slave mode");
+    }
+    fn set_address(&self, _addr: u8) {
+        panic!("nRF51 does not support I2C slave mode");
+    }
+    fn write_receive(&self, _data: &'static mut [u8], _max_len: u8) {
+        panic!("nRF51 does not support I2C slave mode");
+    }
+    fn read_send(&self, _data: &'static mut [u8], _max_len: u8) {
+        panic!("nRF51 does not support I2C slave mode");
+    }
+    fn listen(&self) {
+        panic!("nRF51 does not support I2C slave mode");
+    }
+}
+
+impl i2c::I2CMasterSlave for TWIM {}
+
+/// I2C master instace 0.
+pub static mut TWIM0: TWIM = TWIM::new(0);
+/// I2C master instace 1.
+pub static mut TWIM1: TWIM = TWIM::new(1);
+
+register_bitfields! [u32,
+                     /// Start task
+                     Task [
+                         ENABLE OFFSET(0) NUMBITS(1)
+                     ],
+                     /// Events
+                     Event [
+                         OCCURED OFFSET(0) NUMBITS(1) []
+                     ],
+                     /// Shortcuts
+                     Shorts [
+                         BB_SUSPEND OFFSET(0) NUMBITS(1) [],
+                         BB_STOP OFFSET(1) NUMBITS(1) []
+                     ],
+                     /// Interrupts
+                     InterruptEnable [
+                         STOPPED OFFSET(1) NUMBITS(1) [],
+                         RXREADY OFFSET(2) NUMBITS(1) [],
+                         TXSENT OFFSET(7) NUMBITS(1) [],
+                         ERROR OFFSET(9) NUMBITS(1) [],
+                         BB OFFSET(14) NUMBITS(1) []
+                     ],
+                     ErrorSrc [
+                         OVERRUN OFFSET(0) NUMBITS(1) [],
+                         ADDRESSNACK OFFSET(1) NUMBITS(1) [],
+                         DATANACK OFFSET(2) NUMBITS(1) []
+                     ],
+                     /// TWIM enable
+                     Twim [
+                         ENABLE OFFSET(0) NUMBITS(3) [
+                             ON = 5,
+                             OFF = 0
+                         ]
+                     ],
+                     Psel [
+                         PIN OFFSET(0) NUMBITS(32) []
+                     ],
+                     Data [
+                         DATA OFFSET(0) NUMBITS(8) []
+                     ],
+                     Frequency [
+                         FREQUENCY OFFSET(0) NUMBITS(32) [
+                             K100 = 0x01980000,
+                             K250 = 0x04000000,
+                             K400 = 0x06680000
+                         ]
+                     ],
+                     Address [
+                         ADDRESS OFFSET(0) NUMBITS(8) []
+                     ]
+];
+
+/// Uninitialized `TWIM` instances.
+pub const TWIM_BASE: [*const TwimRegisters; 2] = [
+    0x40003000 as *const TwimRegisters,
+    0x40004000 as *const TwimRegisters,
+];
+
+#[repr(C)]
+pub struct TwimRegisters {
+    /// Start TWI receive sequence
+    ///
+    /// addr = base + 0x000
+    pub tasks_startrx: WriteOnly<u32, Task::Register>,
+    _reserved_0: [u32; 1],
+    /// Start TWI transmit sequence
+    ///
+    /// addr = base + 0x008
+    pub tasks_starttx: WriteOnly<u32, Task::Register>,
+    _reserved_1: [u32; 2],
+    /// Stop TWI transaction_ Must be issued while the TWI master is not suspended_
+    ///
+    /// addr = base + 0x014
+    pub tasks_stop: WriteOnly<u32, Task::Register>,
+    _reserved_2: [u32; 1],
+    /// Suspend TWI transaction
+    ///
+    /// addr = base + 0x01C
+    pub tasks_suspend: WriteOnly<u32, Task::Register>,
+    /// Resume TWI transaction
+    ///
+    /// addr = base + 0x020
+    pub tasks_resume: WriteOnly<u32, Task::Register>,
+    _reserved_3: [u32; 56],
+    /// TWI stopped
+    ///
+    /// addr = base + 0x104
+    pub events_stopped: ReadWrite<u32, Event::Register>,
+    /// TWI RXD byte received
+    ///
+    /// addr = base + 0x108
+    pub events_rxdreceived: ReadWrite<u32, Event::Register>,
+    _reserved_4: [u32; 4],
+    /// TWI TXD byte sent
+    ///
+    /// addr = base + 0x11c
+    pub events_txdsent: ReadWrite<u32, Event::Register>,
+    _reserved_5: [u32; 1],
+    /// TWI error
+    ///
+    /// addr = base + 0x124
+    pub events_error: ReadWrite<u32, Event::Register>,
+    _reserved_6: [u32; 4],
+    /// TWI byte boundary
+    ///
+    /// addr = base + 0x138
+    pub events_bb: ReadWrite<u32, Event::Register>,
+    _reserved_7: [u32; 49],
+    /// Shortcut register
+    ///
+    /// addr = base + 0x200
+    pub shorts: ReadWrite<u32, Shorts::Register>,
+    _reserved_8: [u32; 63],
+    /// Enable or disable interrupt
+    ///
+    /// addr = base + 0x300
+    pub inten: ReadOnly<u32, InterruptEnable::Register>,
+    /// Enable interrupt
+    ///
+    /// addr = base + 0x304
+    pub intenset: WriteOnly<u32, InterruptEnable::Register>,
+    /// Disable interrupt
+    ///
+    /// addr = base + 0x308
+    pub intenclr: WriteOnly<u32, InterruptEnable::Register>,
+    _reserved_9: [u32; 110],
+    /// Error source
+    ///
+    /// addr = base + 0x4C4
+    pub errorsrc: ReadWrite<u32, ErrorSrc::Register>,
+    _reserved_10: [u32; 14],
+    /// Enable TWIM
+    ///
+    /// addr = base + 0x500
+    pub enable: ReadWrite<u32, Twim::Register>,
+    _reserved_11: [u32; 1],
+    /// Pin select for SCL signal
+    ///
+    /// addr = base + 0x508
+    pub psel_scl: ReadWrite<u32, Psel::Register>,
+    /// Pin select for SDA signal
+    ///
+    /// addr = base + 0x50C
+    pub psel_sda: ReadWrite<u32, Psel::Register>,
+    _reserved_12: [u32; 2],
+    /// RXD register
+    ///
+    /// addr = base + 0x518
+    pub rxd: ReadOnly<u32, Data::Register>,
+    /// TXD register
+    ///
+    /// addr = base + 0x51C
+    pub txd: ReadWrite<u32, Data::Register>,
+    _reserved_13: [u32; 1],
+    /// TWI frequency
+    ///
+    /// addr = base + 0x524
+    pub frequency: ReadWrite<u32, Frequency::Register>,
+    _reserved_14: [u32; 24],
+    /// Address used in the TWI transfer
+    ///
+    /// addr = base + 0x588
+    pub address: ReadWrite<u32, Address::Register>,
+}

--- a/chips/nrf51/src/i2c.rs
+++ b/chips/nrf51/src/i2c.rs
@@ -2,15 +2,12 @@
 //!
 //! This module supports nRF51's two I2C master (`TWIM`) peripherals.
 
-extern crate nrf5x;
-
 use core::cell::Cell;
 use core::cmp;
 use kernel::common::regs::{FieldValue, ReadOnly, ReadWrite, WriteOnly};
 use kernel::common::take_cell::TakeCell;
 use kernel::hil::i2c;
-use nrf5x::gpio;
-use nrf5x::pinmux::Pinmux;
+use {nrf5x, nrf5x::gpio, nrf5x::pinmux::Pinmux};
 
 /// An I2C master device.
 ///

--- a/chips/nrf51/src/lib.rs
+++ b/chips/nrf51/src/lib.rs
@@ -7,12 +7,13 @@ extern crate cortexm0;
 extern crate nrf5x;
 
 #[allow(unused_imports)]
-#[macro_use(debug, debug_verbose, debug_gpio)]
+#[macro_use(debug, debug_verbose, debug_gpio, register_bitfields, register_bitmasks)]
 extern crate kernel;
 
 pub mod chip;
 pub mod clock;
 pub mod crt1;
+pub mod i2c;
 pub mod radio;
 pub mod uart;
 

--- a/chips/nrf52/src/i2c.rs
+++ b/chips/nrf52/src/i2c.rs
@@ -222,9 +222,9 @@ pub static mut TWIM0: TWIM = TWIM::new(0);
 /// I2C master instace 1.
 pub static mut TWIM1: TWIM = TWIM::new(1);
 
-// SPI0_TWI0_Handler and SPI1_TWI1_Handler live in
-// `spi.rs`. `service_pending_interrupts` dispatches the correct
-// handler based on which peripheral is enabled.
+// The SPI0_TWI0 and SPI1_TWI1 interrupts are dispatched to the
+// correct handler by the service_pending_interrupts() routine in
+// chip.rs based on which peripheral is enabled.
 
 mod registers {
     #![allow(dead_code)]

--- a/kernel/src/hil/i2c.rs
+++ b/kernel/src/hil/i2c.rs
@@ -2,7 +2,7 @@
 
 use core::fmt::{Display, Formatter, Result};
 
-/// The type of error encoutered during an I2C command transmission.
+/// The type of error encoutered during I2C communication.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Error {
     /// The slave did not acknowledge the chip address. Most likely the address
@@ -17,6 +17,10 @@ pub enum Error {
     /// higher-priority transmission is in progress by a different master.
     ArbitrationLost,
 
+    /// A start condition was received before received data has been read
+    /// from the receive register.
+    Overrun,
+
     /// No error occured and the command completed successfully.
     CommandComplete,
 }
@@ -27,6 +31,7 @@ impl Display for Error {
             Error::AddressNak => "I2C Address Not Acknowledged",
             Error::DataNak => "I2C Data Not Acknowledged",
             Error::ArbitrationLost => "I2C Bus Arbitration Lost",
+            Error::Overrun => "I2C receive overrun",
             Error::CommandComplete => "I2C Command Completed",
         };
         write!(fmt, "{}", display_str)


### PR DESCRIPTION
### Pull Request Overview

This pull request adds adds I2C master support for the NRF51

### Testing Strategy

It was tested by running the sensors app using the I2C accelerometer on a BBC micro:bit.

### TODO or Help Wanted

I am still having trouble talking to the magnetometer on the micro:bit, which is a bit picky about the drive strength settings, so there may still be something wrong there (it used to work before I rebased to the current master, I'll look into the issue next week when I'll have access to a logic analyzer to see what is actually happening on the bus).

This adds a new kind of error in kernel/src/hil/i2c.rs which will probably have knock on effects, what is the best strategy to find all these?

### Documentation Updated
 
No updates needed, as far as I can see.

### Formatting

- [X] Ran `make formatall`.
