### PR TITLE
sam4l: usart: move tx done callback

### DIFF
--- a/chips/sam4l/Cargo.lock
+++ b/chips/sam4l/Cargo.lock
@@ -1,11 +1,3 @@
-[root]
-name = "sam4l"
-version = "0.1.0"
-dependencies = [
- "cortexm4 0.1.0",
- "kernel 0.1.0",
-]
-
 [[package]]
 name = "cortexm4"
 version = "0.1.0"
@@ -16,4 +8,12 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.1.0"
+
+[[package]]
+name = "sam4l"
+version = "0.1.0"
+dependencies = [
+ "cortexm4 0.1.0",
+ "kernel 0.1.0",
+]
 

--- a/chips/sam4l/src/usart.rs
+++ b/chips/sam4l/src/usart.rs
@@ -586,6 +586,28 @@ impl USART {
             self.disable_tx_empty_interrupt(usart);
             self.disable_tx(usart);
             self.usart_tx_state.set(USARTStateTX::Idle);
+
+            // Now that we know the TX transaction is finished we can get the
+            // buffer back from DMA and pass it back to the client. If we don't
+            // wait until we are completely finished, then the
+            // `transmit_complete` callback is in a "bad" part of the USART
+            // state machine, and clients cannot issue other USART calls from
+            // the callback.
+            let buffer = self.tx_dma.get().map_or(None, |tx_dma| {
+                let buf = tx_dma.abort_xfer();
+                tx_dma.disable();
+                buf
+            });
+
+            // alert client
+            self.client.get().map(|usartclient| {
+                buffer.map(|buf| match usartclient {
+                    UsartClient::Uart(client) => {
+                        client.transmit_complete(buf, hil::uart::Error::CommandComplete);
+                    }
+                    UsartClient::SpiMaster(_) => {}
+                });
+            });
         } else if usart.registers.csr.is_set(ChannelStatus::PARE) {
             self.abort_rx(usart, hil::uart::Error::ParityError);
         } else if usart.registers.csr.is_set(ChannelStatus::FRAME) {
@@ -708,23 +730,6 @@ impl dma::DMAClient for USART {
                     // there may still be bytes left in the TX buffer.
                     self.usart_tx_state.set(USARTStateTX::Transfer_Completing);
                     self.enable_tx_empty_interrupt(usart);
-
-                    // get buffer
-                    let buffer = self.tx_dma.get().map_or(None, |tx_dma| {
-                        let buf = tx_dma.abort_xfer();
-                        tx_dma.disable();
-                        buf
-                    });
-
-                    // alert client
-                    self.client.get().map(|usartclient| {
-                        buffer.map(|buf| match usartclient {
-                            UsartClient::Uart(client) => {
-                                client.transmit_complete(buf, hil::uart::Error::CommandComplete);
-                            }
-                            UsartClient::SpiMaster(_) => {}
-                        });
-                    });
                     self.tx_len.set(0);
                 }
             }


### PR DESCRIPTION
### Pull Request Overview

This commit moves where the `transmit_complete` callback is fired from
when the DMA is done to when the USART done interrupt occurs. In the
USART state machine, the callback was being triggered when the USART was
in a "Completing TX" state, which means that any USART commands called
in the callback likely didn't work. By moving the callback to when we
actually declare the TX finished (and back to idle) the transmit
complete callback can be used for additional USART commands.

This was not an issue for us before because we were never using the
transmit complete callback to start new USART commands. All USART
actions were directed by an application syscall, which gave the USART HW
enough time to get to idle (or at least that is what I believe is
happening).





This pull request adds/changes/fixes...


### Testing Strategy

I've tested this by running the Hail app on Hail, and verifying that
both the console prints work and the BLE advertisements work.





### Documentation Updated

- [x] Kernel: Updated the relevant files in `/docs`, or no updates are required.
- [x] Userland: Added/updated the application README, if needed.

### Formatting

- [x] Ran `make formatall`.
