### PR TITLE
Timer updates to prepare for NRF52 connection driver PR

### DIFF
--- a/chips/nrf5x/src/timer.rs
+++ b/chips/nrf5x/src/timer.rs
@@ -152,19 +152,19 @@ impl Timer {
         self.timer().cc[1].get()
     }
     pub fn set_cc1(&self, val: u32) {
-        self.timer().cc[0].set(val);
+        self.timer().cc[1].set(val);
     }
     pub fn get_cc2(&self) -> u32 {
         self.timer().cc[2].get()
     }
     pub fn set_cc2(&self, val: u32) {
-        self.timer().cc[0].set(val);
+        self.timer().cc[2].set(val);
     }
     pub fn get_cc3(&self) -> u32 {
         self.timer().cc[3].get()
     }
     pub fn set_cc3(&self, val: u32) {
-        self.timer().cc[0].set(val);
+        self.timer().cc[3].set(val);
     }
 
     pub fn enable_interrupts(&self, interrupts: u32) {

--- a/chips/nrf5x/src/timer.rs
+++ b/chips/nrf5x/src/timer.rs
@@ -26,6 +26,7 @@ use core::cell::Cell;
 use core::mem;
 use kernel::hil;
 use peripheral_registers;
+use kernel::common::VolatileCell;
 
 #[derive(Copy, Clone)]
 pub enum Location {
@@ -176,12 +177,8 @@ impl Timer {
         self.timer().cc[3].set(val);
     }
 
-    pub fn set_events_compare(&self, index: usize, val: u32) {
-        self.timer().event_compare[index].set(val);
-    }
-
-    pub fn get_events_compare(&self, index: usize) -> u32 {
-        self.timer().event_compare[index].get()
+    pub fn events_compare(&self) -> &[VolatileCell<u32>] {
+        &self.timer().event_compare
     }
 
     pub fn enable_interrupts(&self, interrupts: u32) {

--- a/chips/nrf5x/src/timer.rs
+++ b/chips/nrf5x/src/timer.rs
@@ -167,6 +167,14 @@ impl Timer {
         self.timer().cc[3].set(val);
     }
 
+    pub fn set_events_compare(&self, index: usize, val: u32) {
+        self.timer().event_compare[index].set(val);
+    }
+
+    pub fn get_events_compare(&self, index: usize) -> u32 {
+        self.timer().event_compare[index].get()
+    }
+
     pub fn enable_interrupts(&self, interrupts: u32) {
         self.timer().intenset.set(interrupts << 16);
     }

--- a/chips/nrf5x/src/timer.rs
+++ b/chips/nrf5x/src/timer.rs
@@ -98,6 +98,10 @@ impl Timer {
         self.timer().task_clear.set(1);
     }
 
+    pub fn set_bitmode(&self, bitmode: u32) {
+        self.timer().bitmode.set(bitmode);
+    }
+
     /// Capture the current timer value into the CC register
     /// specified by which, and return the value.
     pub fn capture(&self, which: u8) -> u32 {

--- a/chips/nrf5x/src/timer.rs
+++ b/chips/nrf5x/src/timer.rs
@@ -49,6 +49,13 @@ pub static mut TIMER2: Timer = Timer {
     client: Cell::new(None),
 };
 
+pub enum BitmodeValue {
+    Size16Bits = 0,
+    Size8Bits = 1,
+    Size24Bits = 2,
+    Size32Bits = 3,
+}
+
 #[allow(non_snake_case)]
 fn TIMER(location: Location) -> &'static peripheral_registers::TIMER {
     let ptr =
@@ -98,8 +105,10 @@ impl Timer {
         self.timer().task_clear.set(1);
     }
 
-    pub fn set_bitmode(&self, bitmode: u32) {
-        self.timer().bitmode.set(bitmode);
+    ///Sets the number of bits used by the TIMER
+    pub fn set_bitmode(&self, bitmode: BitmodeValue) {
+
+        self.timer().bitmode.set(bitmode as u32);
     }
 
     /// Capture the current timer value into the CC register


### PR DESCRIPTION
We found copy-paste bugs in the get_cc methods. Also exposing more of registers to be accessed from radio. (Separated out from #915)