### PR TITLE
sam4l: CRC to new register interface

### DIFF
--- a/capsules/src/crc.rs
+++ b/capsules/src/crc.rs
@@ -228,11 +228,7 @@ impl<'a, C: hil::crc::CRC> Driver for Crc<'a, C> {
     ///
     /// ### Command Numbers
     ///
-    ///   *   `0`: Returns non-zero to indicate the driver is present
-    ///
-    ///   *   `1`: Returns the CRC unit's version value.  This is provided
-    ///       in order to be complete, but has limited utility as no
-    ///       consistent semantics are specified.
+    ///   *   `0`: Returns non-zero to indicate the driver is present.
     ///
     ///   *   `2`: Requests that a CRC be computed over the buffer
     ///       previously provided by `allow`.  If none was provided,
@@ -290,11 +286,6 @@ impl<'a, C: hil::crc::CRC> Driver for Crc<'a, C> {
         match command_num {
             // This driver is present
             0 => ReturnCode::SUCCESS,
-
-            // Get version of CRC unit
-            1 => ReturnCode::SuccessWithValue {
-                value: self.crc_unit.get_version() as usize,
-            },
 
             // Request a CRC computation
             2 => {

--- a/chips/sam4l/src/crccu.rs
+++ b/chips/sam4l/src/crccu.rs
@@ -49,78 +49,94 @@
 // - Support continuous-mode CRC
 
 use core::cell::Cell;
+use kernel::common::regs::{FieldValue, ReadOnly, ReadWrite, WriteOnly};
 use kernel::hil::crc::{self, CrcAlg};
 use kernel::ReturnCode;
 use pm::{disable_clock, enable_clock, Clock, HSBClock, PBBClock};
 
-// A memory-mapped register
-struct Reg(*mut u32);
-
-impl Reg {
-    fn read(self) -> u32 {
-        unsafe { ::core::ptr::read_volatile(self.0) }
-    }
-
-    fn write(self, n: u32) {
-        unsafe {
-            ::core::ptr::write_volatile(self.0, n);
-        }
-    }
-}
-
 // Base address of CRCCU registers.  See "7.1 Product Mapping"
-const CRCCU_BASE: u32 = 0x400A4000;
+const BASE_ADDRESS: *mut CrccuRegisters = 0x400A4000 as *mut CrccuRegisters;
 
-// The following macro expands a list of expressions like this:
-//
-//    { 0x00, "Descriptor Base Register", DSCR, "RW" },
-//
-// into a series of items like this:
-//
-//    #[allow(dead_code)]
-//    const DSCR: Reg = Reg((CRCCU_BASE + 0x00) as *mut u32);
-
-macro_rules! registers {
-    [ $( { $offset:expr, $description:expr, $name:ident, $access:expr } ),* ] => {
-        $( #[allow(dead_code)]
-           const $name: Reg = Reg((CRCCU_BASE + $offset) as *mut u32); )*
-    };
+#[repr(C)]
+pub struct CrccuRegisters {
+    // From page 1005 of SAM4L manual
+    dscr: ReadWrite<u32, DescriptorBaseAddress::Register>,
+    _reserved0: u32,
+    dmaen: WriteOnly<u32, DmaEnable::Register>,
+    dmadis: WriteOnly<u32, DmaDisable::Register>,
+    dmasr: ReadOnly<u32, DmaStatus::Register>,
+    dmaier: WriteOnly<u32, DmaInterrupt::Register>,
+    dmaidr: WriteOnly<u32, DmaInterrupt::Register>,
+    dmaimr: ReadOnly<u32, DmaInterrupt::Register>,
+    dmaisr: ReadOnly<u32, DmaInterrupt::Register>,
+    _reserved1: [u32; 4],
+    cr: WriteOnly<u32, Control::Register>,
+    mr: ReadWrite<u32, Mode::Register>,
+    sr: ReadOnly<u32, Status::Register>,
+    ier: WriteOnly<u32, Interrupt::Register>,
+    idr: WriteOnly<u32, Interrupt::Register>,
+    imr: ReadOnly<u32, Interrupt::Register>,
+    isr: ReadOnly<u32, Interrupt::Register>,
 }
 
-// CRCCU Registers (from Table 41.1 in Section 41.6):
-registers![
-    // Address of descriptor (512-byte aligned)
-    { 0x00, "Descriptor Base Register", DSCR, "RW" },
-    // Write a one to enable DMA channel
-    { 0x08, "DMA Enable Register", DMAEN, "W" },
-    // Write a one to disable DMA channel
-    { 0x0C, "DMA Disable Register", DMADIS, "W" },
-    // DMA channel enabled?
-    { 0x10, "DMA Status Register", DMASR, "R" },
-    // Write a one to enable DMA interrupt
-    { 0x14, "DMA Interrupt Enable Register", DMAIER, "W" },
-    // Write a one to disable DMA interrupt
-    { 0x18, "DMA Interrupt Disable Register", DMAIDR, "W" },
-    // DMA interrupt enabled?
-    { 0x1C, "DMA Interrupt Mask Register", DMAIMR, "R" },
-    // DMA transfer completed? (cleared when read)
-    { 0x20, "DMA Interrupt Status Register", DMAISR, "R" },
-    // Write a one to reset SR
-    { 0x34, "Control Register", CR, "W" },
-    // Bandwidth divider, Polynomial type, Compare?, Enable?
-    { 0x38, "Mode Register", MR, "RW" },
-    // CRC result (unreadable if MR.COMPARE=1)
-    { 0x3C, "Status Register", SR, "R" },
-    // Write one to set IMR.ERR bit (zero no effect)
-    { 0x40, "Interrupt Enable Register", IER, "W" },
-    // Write zero to clear IMR.ERR bit (one no effect)
-    { 0x44, "Interrupt Disable Register", IDR, "W" },
-    // If IMR.ERR bit is set, error-interrupt (for compare) is enabled
-    { 0x48, "Interrupt Mask Register", IMR, "R" },
-    // CRC error (for compare)? (cleared when read)
-    { 0x4C, "Interrupt Status Register", ISR, "R" },
-    // 12 low-order bits: version of this module.  = 0x00000202
-    { 0xFC, "Version Register", VERSION, "R" }
+register_bitfields![u32,
+    DescriptorBaseAddress [
+        /// Description Base Address
+        DSCR OFFSET(9) NUMBITS(23) []
+    ],
+
+    DmaEnable [
+        /// DMA Enable
+        DMAEN 0
+    ],
+
+    DmaDisable [
+        /// DMA Disable
+        DMADIS 0
+    ],
+
+    DmaStatus [
+        /// DMA Channel Status
+        DMASR 0
+    ],
+
+    DmaInterrupt [
+        /// DMA Interrupt
+        DMA 0
+    ],
+
+    Control [
+        /// Reset CRC Computation
+        RESET 0
+    ],
+
+    Mode [
+        /// Bandwidth Divider
+        DIVIDER OFFSET(4) NUMBITS(4) [],
+        /// Polynomial Type
+        PTYPE OFFSET(2) NUMBITS(2) [
+            Ccit8023 = 0,
+            Castagnoli = 1,
+            Ccit16 = 2
+        ],
+        /// CRC Compare
+        COMPARE OFFSET(1) NUMBITS(1) [],
+        /// CRC Computation Enable
+        ENABLE OFFSET(0) NUMBITS(1) [
+            Enabled = 1,
+            Disabled = 0
+        ]
+    ],
+
+    Status [
+        /// Cyclic Redundancy Check Value
+        CRC OFFSET(0) NUMBITS(32)
+    ],
+
+    Interrupt [
+        /// CRC Error Interrupt Status
+        ERR 0
+    ]
 ];
 
 // CRCCU Descriptor (from Table 41.2 in Section 41.6):
@@ -156,20 +172,13 @@ impl TCR {
     }
 }
 
-#[derive(Copy, Clone)]
-enum Polynomial {
-    CCIT8023,   // Polynomial 0x04C11DB7
-    CASTAGNOLI, // Polynomial 0x1EDC6F41
-    CCIT16,     // Polynomial 0x1021
-}
-
-fn poly_for_alg(alg: CrcAlg) -> Polynomial {
+fn poly_for_alg(alg: CrcAlg) -> FieldValue<u32, Mode::Register> {
     match alg {
-        CrcAlg::Crc32 => Polynomial::CCIT8023,
-        CrcAlg::Crc32C => Polynomial::CASTAGNOLI,
-        CrcAlg::Sam4L16 => Polynomial::CCIT16,
-        CrcAlg::Sam4L32 => Polynomial::CCIT8023,
-        CrcAlg::Sam4L32C => Polynomial::CASTAGNOLI,
+        CrcAlg::Crc32 => Mode::PTYPE::Ccit8023,
+        CrcAlg::Crc32C => Mode::PTYPE::Castagnoli,
+        CrcAlg::Sam4L16 => Mode::PTYPE::Ccit16,
+        CrcAlg::Sam4L32 => Mode::PTYPE::Ccit8023,
+        CrcAlg::Sam4L32C => Mode::PTYPE::Castagnoli,
     }
 }
 
@@ -193,9 +202,7 @@ fn reverse_and_invert(n: u32) -> u32 {
     }
 
     // Bit-invert
-    out ^= 0xffffffff;
-
-    out
+    out ^ 0xffffffff
 }
 
 /// Transfer width for DMA
@@ -203,21 +210,6 @@ pub enum TrWidth {
     Byte,
     HalfWord,
     Word,
-}
-
-// Mode Register (see Section 41.6.10)
-struct Mode(u32);
-
-impl Mode {
-    fn new(divider: u8, ptype: Polynomial, compare: bool, enable: bool) -> Self {
-        Mode(
-            (((divider & 0x0f) as u32) << 4) | (ptype as u32) << 2 | (compare as u32) << 1
-                | (enable as u32),
-        )
-    }
-    fn disabled() -> Self {
-        Mode::new(0, Polynomial::CCIT8023, false, false)
-    }
 }
 
 #[derive(Copy, Clone, PartialEq)]
@@ -229,6 +221,7 @@ enum State {
 
 /// State for managing the CRCCU
 pub struct Crccu<'a> {
+    registers: *mut CrccuRegisters,
     client: Option<&'a crc::Client>,
     state: Cell<State>,
     alg: Cell<CrcAlg>,
@@ -241,8 +234,9 @@ pub struct Crccu<'a> {
 const DSCR_RESERVE: usize = 512 + 5 * 4;
 
 impl<'a> Crccu<'a> {
-    const fn new() -> Self {
+    const fn new(base_address: *mut CrccuRegisters) -> Self {
         Crccu {
+            registers: base_address,
             client: None,
             state: Cell::new(State::Invalid),
             alg: Cell::new(CrcAlg::Crc32C),
@@ -310,30 +304,32 @@ impl<'a> Crccu<'a> {
 
     /// Handle an interrupt from the CRCCU
     pub fn handle_interrupt(&mut self) {
-        if ISR.read() & 1 == 1 {
+        let regs: &CrccuRegisters = unsafe { &*self.registers };
+
+        if regs.isr.is_set(Interrupt::ERR) {
             // A CRC error has occurred
         }
 
-        if DMAISR.read() & 1 == 1 {
+        if regs.dmaisr.is_set(DmaInterrupt::DMA) {
             // A DMA transfer has completed
 
             if self.get_tcr().interrupt_enabled() {
                 if let Some(client) = self.get_client() {
-                    let result = post_process(SR.read(), self.alg.get());
+                    let result = post_process(regs.sr.read(Status::CRC), self.alg.get());
                     client.receive_result(result);
                 }
 
                 // Disable the unit
-                MR.write(Mode::disabled().0);
+                regs.mr.write(Mode::ENABLE::Disabled);
 
                 // Reset CTRL.IEN (for our own statekeeping)
                 self.set_descriptor(0, TCR::default(), 0);
 
                 // Disable DMA interrupt
-                DMAIDR.write(1);
+                regs.dmaidr.write(DmaInterrupt::DMA::SET);
 
                 // Disable DMA channel
-                DMADIS.write(1);
+                regs.dmadis.write(DmaDisable::DMADIS::SET);
             }
         }
     }
@@ -341,11 +337,9 @@ impl<'a> Crccu<'a> {
 
 // Implement the generic CRC interface with the CRCCU
 impl<'a> crc::CRC for Crccu<'a> {
-    fn get_version(&self) -> u32 {
-        VERSION.read()
-    }
-
     fn compute(&self, data: &[u8], alg: CrcAlg) -> ReturnCode {
+        let regs: &CrccuRegisters = unsafe { &*self.registers };
+
         self.init();
 
         if self.get_tcr().interrupt_enabled() {
@@ -362,13 +356,13 @@ impl<'a> crc::CRC for Crccu<'a> {
         self.enable();
 
         // Enable DMA interrupt
-        DMAIER.write(1);
+        regs.dmaier.write(DmaInterrupt::DMA::SET);
 
         // Enable error interrupt
-        IER.write(1);
+        regs.ier.write(Interrupt::ERR::SET);
 
         // Reset intermediate CRC value
-        CR.write(1);
+        regs.cr.write(Control::RESET::SET);
 
         // Configure the data transfer
         let addr = data.as_ptr() as u32;
@@ -383,20 +377,18 @@ impl<'a> crc::CRC for Crccu<'a> {
         let ctrl = TCR::new(true, tr_width, len);
         let crc = 0;
         self.set_descriptor(addr, ctrl, crc);
-        DSCR.write(self.descriptor() as u32);
+        regs.dscr.set(self.descriptor() as u32);
 
         // Record what algorithm was requested
         self.alg.set(alg);
 
         // Configure the unit to compute a checksum
-        let divider = 0;
-        let compare = false;
-        let enable = true;
-        let mode = Mode::new(divider, poly_for_alg(alg), compare, enable);
-        MR.write(mode.0);
+        regs.mr.write(
+            Mode::DIVIDER.val(0) + poly_for_alg(alg) + Mode::COMPARE::CLEAR + Mode::ENABLE::Enabled,
+        );
 
         // Enable DMA channel
-        DMAEN.write(1);
+        regs.dmaen.write(DmaEnable::DMAEN::SET);
 
         return ReturnCode::SUCCESS;
     }
@@ -407,4 +399,4 @@ impl<'a> crc::CRC for Crccu<'a> {
 }
 
 /// Static state to manage the CRCCU
-pub static mut CRCCU: Crccu<'static> = Crccu::new();
+pub static mut CRCCU: Crccu<'static> = Crccu::new(BASE_ADDRESS);

--- a/kernel/Cargo.lock
+++ b/kernel/Cargo.lock
@@ -1,4 +1,4 @@
-[root]
+[[package]]
 name = "kernel"
 version = "0.1.0"
 

--- a/kernel/src/hil/crc.rs
+++ b/kernel/src/hil/crc.rs
@@ -25,9 +25,6 @@ pub enum CrcAlg {
 }
 
 pub trait CRC {
-    /// Get the version of the CRC unit
-    fn get_version(&self) -> u32;
-
     /// Initiate a CRC calculation
     fn compute(&self, data: &[u8], CrcAlg) -> ReturnCode;
 

--- a/userland/examples/tests/crc/main.c
+++ b/userland/examples/tests/crc/main.c
@@ -30,6 +30,8 @@ uint32_t procid;
 int main(void) {
   int r;
 
+  printf("[CRC Test] This app tests the CRC syscall interface\n");
+
   // Get a random number to distinguish this app instance
   if ((r = rng_sync((uint8_t *) &procid, 4, 4)) != 4) {
     printf("RNG failure\n");
@@ -38,12 +40,6 @@ int main(void) {
 
   if (!crc_exists()) {
     printf("CRC driver does not exist\n");
-    exit(1);
-  }
-
-  uint32_t v = crc_version();
-  if (v != 0x00000202) {
-    printf("CRC version unexpected: %lu\n", v);
     exit(1);
   }
 

--- a/userland/libtock/crc.c
+++ b/userland/libtock/crc.c
@@ -4,10 +4,6 @@ int crc_exists(void) {
   return command(DRIVER_NUM_CRC, 0, 0, 0) >= 0;
 }
 
-uint32_t crc_version(void) {
-  return command(DRIVER_NUM_CRC, 1, 0, 0);
-}
-
 int crc_request(enum crc_alg alg) {
   return command(DRIVER_NUM_CRC, 2, alg, 0);
 }

--- a/userland/libtock/crc.h
+++ b/userland/libtock/crc.h
@@ -39,9 +39,6 @@ int crc_exists(void);
 // Returns ESIZE if the buffer is too big for the unit.
 int crc_compute(const void *buf, size_t buflen, enum crc_alg, uint32_t *result);
 
-// Get the version of the CRC firmware
-uint32_t crc_version(void);
-
 // Register a callback to receive CRC results
 //
 // The callback will receive these parameters, in order:


### PR DESCRIPTION
### Pull Request Overview

This pull request:

- updates the CRC module to the new register interface
- removes the `get_version` syscall which is sam4l specific


### Testing Strategy

This pull request was tested by running the crc test app on hail.




### Documentation Updated

- [x] Kernel: Updated the relevant files in `/docs`, or no updates are required.
- [x] Userland: Added/updated the application README, if needed.

### Formatting

- [x] Ran `make formatall`.
