### PR TITLE
kernel: keep track of dropped callbacks

### DIFF
--- a/doc/Userland.md
+++ b/doc/Userland.md
@@ -192,7 +192,8 @@ Hard Fault Status Register (HFSR):  0x40000000
 
 ---| App Status |---
 App: printf_long   -   [Yielded]
- Events Queued: 0   Syscall Count: 12   Last Syscall: YIELD
+ Events Queued: 0   Syscall Count: 12   Dropped Callback Count: 0
+ Last Syscall: YIELD
 
  ╔═══════════╤══════════════════════════════════════════╗
  ║  Address  │ Region Name    Used | Allocated (bytes)  ║

--- a/kernel/Cargo.lock
+++ b/kernel/Cargo.lock
@@ -1,4 +1,4 @@
-[root]
+[[package]]
 name = "kernel"
 version = "0.1.0"
 


### PR DESCRIPTION
If the callback queue allocated for the process is too short, right now
the callback just silently gets dropped. This at least records that the
event happened, so a developer can use this for debugging purposes after
the fact.

Fixes #536




### Testing Strategy

This pull request was tested by running crash dummy on hail and checking that it the debug output looks correct.



### Documentation Updated

- [x] Kernel: Updated the relevant files in `/docs`, or no updates are required.
- [x] Userland: Added/updated the application README, if needed.

### Formatting

- [x] Ran `make formatall`.


