### PR TITLE
cc26xx: correct timing issues in RTC

### DIFF
--- a/chips/cc26xx/src/rtc.rs
+++ b/chips/cc26xx/src/rtc.rs
@@ -2,7 +2,7 @@
 
 use core::cell::Cell;
 use kernel::common::regs::{ReadOnly, ReadWrite};
-use kernel::hil::time::{self, Alarm, Freq32KHz, Time};
+use kernel::hil::time::{self, Alarm, Frequency, Time};
 
 #[repr(C)]
 pub struct RtcRegisters {
@@ -129,8 +129,19 @@ impl Rtc {
     }
 }
 
+pub struct RtcFreq(());
+
+impl Frequency for RtcFreq {
+    // The RTC Frequency is tuned, as there is exactly 0xFFFF (64kHz)
+    // subsec increments to reach a second, this yields the correct
+    // `tics` to set the comparator correctly.
+    fn frequency() -> u32 {
+        0xFFFF
+    }
+}
+
 impl Time for Rtc {
-    type Frequency = Freq32KHz;
+    type Frequency = RtcFreq;
 
     fn disable(&self) {
         let regs: &RtcRegisters = unsafe { &*self.regs };


### PR DESCRIPTION
### Pull Request Overview

The RTC clock is set by setting the comparator to `(seconds << 16 |
subseconds & 0xFFFF)`, the frequency then becomes 0xFFFF Hz = 64kHz (number of subseconds per second). It works regardless of what frequency the actual RTC uses :)

This fixes timing issues that arose from the former RTC implementation.

### Testing Strategy

Not yet tested.

### Documentation Updated

- [x] Kernel: Updated the relevant files in `/docs`, or no updates are required.
- [x] ~Userland: Added/updated the application README, if needed.~

### Formatting

- [x] Ran `make formatall`.