### PR TITLE
boards: debug: build lst seperately

### DIFF
--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -102,13 +102,16 @@ ifneq ($(V),)
 endif
 
 .PHONY: all
-all:	target/$(TARGET)/release/$(PLATFORM).bin
+all: target/$(TARGET)/release/$(PLATFORM).bin
 
 .PHONY: lst
-lst:	target/$(TARGET)/release/$(PLATFORM).lst
+lst: target/$(TARGET)/release/$(PLATFORM).lst
 
 .PHONY: debug
-debug:	target/$(TARGET)/debug/$(PLATFORM).bin
+debug: target/$(TARGET)/debug/$(PLATFORM).bin
+
+.PHONY: debug-lst
+debug-lst: target/$(TARGET)/debug/$(PLATFORM).lst
 
 target:
 	@mkdir -p target
@@ -131,10 +134,12 @@ target/$(TARGET)/release/$(PLATFORM):
 target/$(TARGET)/debug/$(PLATFORM).elf: target/$(TARGET)/debug/$(PLATFORM)
 	$(Q)cp target/$(TARGET)/debug/$(PLATFORM) target/$(TARGET)/debug/$(PLATFORM).elf
 
+target/$(TARGET)/debug/$(PLATFORM).lst: target/$(TARGET)/debug/$(PLATFORM).elf
+	$(Q)$(OBJDUMP) $(OBJDUMP_FLAGS) $< > target/$(TARGET)/debug/$(PLATFORM).lst
+
 .PHONY: target/$(TARGET)/debug/$(PLATFORM)
 target/$(TARGET)/debug/$(PLATFORM):
 	$(Q)RUSTFLAGS=$(RUSTFLAGS_FOR_CARGO_LINKING) $(CARGO) build $(VERBOSE) --target=$(TARGET)
-	$(Q)$(OBJDUMP) $(OBJDUMP_FLAGS) $@ > target/$(TARGET)/debug/$(PLATFORM).lst
 	$(Q)$(SIZE) $@
 
 target/$(TARGET)/release/$(PLATFORM).hex: target/$(TARGET)/release/$(PLATFORM).elf

--- a/boards/ek-tm4c1294xl/Cargo.toml
+++ b/boards/ek-tm4c1294xl/Cargo.toml
@@ -6,7 +6,7 @@ build = "build.rs"
 
 [profile.dev]
 panic = "abort"
-lto = true
+lto = false
 opt-level = 0
 debug = true
 

--- a/boards/hail/Cargo.toml
+++ b/boards/hail/Cargo.toml
@@ -6,7 +6,7 @@ build = "build.rs"
 
 [profile.dev]
 panic = "abort"
-lto = true
+lto = false
 opt-level = "z"
 debug = true
 

--- a/boards/imix/Cargo.toml
+++ b/boards/imix/Cargo.toml
@@ -6,7 +6,7 @@ build = "build.rs"
 
 [profile.dev]
 panic = "abort"
-lto = true
+lto = false
 opt-level = "z"
 debug = true
 

--- a/boards/launchxl/Cargo.toml
+++ b/boards/launchxl/Cargo.toml
@@ -6,7 +6,7 @@ build = "build.rs"
 
 [profile.dev]
 panic = "abort"
-lto = true
+lto = false
 opt-level = "z"
 debug = true
 

--- a/boards/nrf51dk/Cargo.toml
+++ b/boards/nrf51dk/Cargo.toml
@@ -6,7 +6,7 @@ build = "build.rs"
 
 [profile.dev]
 panic = "abort"
-lto = true
+lto = false
 opt-level = "z"
 debug = true
 

--- a/boards/nrf52dk/Cargo.toml
+++ b/boards/nrf52dk/Cargo.toml
@@ -6,7 +6,7 @@ build = "build.rs"
 
 [profile.dev]
 panic = "abort"
-lto = true
+lto = false
 opt-level = "z"
 debug = true
 


### PR DESCRIPTION
This commit adds a make target for boards called `debug-lst` which
builds the debug version LST file.

It also disables LTO on debug builds since when it is set to true the
debug builds don't compile and throw this error:

```
make debug
   Compiling kernel v0.1.0 (file:///Users/bradjc/git/tock/kernel)
   Compiling imix v0.1.0 (file:///Users/bradjc/git/tock/boards/imix)
   Compiling cortexm4 v0.1.0 (file:///Users/bradjc/git/tock/arch/cortex-m4)
   Compiling capsules v0.1.0 (file:///Users/bradjc/git/tock/capsules)
   Compiling sam4l v0.1.0 (file:///Users/bradjc/git/tock/chips/sam4l)
error: can't perform LTO when compiling incrementally

error: Could not compile `imix`.

To learn more, run the command again with --verbose.
make: *** [target/thumbv7em-none-eabi/debug/imix] Error 101
```

Fixes #731




### Testing Strategy

This pull request was tested by running `make debug` and `make debug-lst` and seeing that it completes without erring. I have no idea what the value of `make debug` is so I'm not sure how to test it.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Kernel: Updated the relevant files in `/docs`, or no updates are required.
- [x] Userland: Added/updated the application README, if needed.

### Formatting

- [x] Ran `make formatall`.
