### PR TITLE
sam4l: fix some mistakes with protected registers

### DIFF
--- a/chips/sam4l/src/bpm.rs
+++ b/chips/sam4l/src/bpm.rs
@@ -166,10 +166,11 @@ pub enum CK32Source {
 
 #[inline(never)]
 pub unsafe fn set_ck32source(source: CK32Source) {
+    let control = (*BPM).pmcon.extract();
     unlock_register(0x1c); // Control
     (*BPM)
         .pmcon
-        .modify(PowerModeControl::CK32S.val(source as u32));
+        .modify_no_read(control, PowerModeControl::CK32S.val(source as u32));
 }
 
 unsafe fn unlock_register(register_offset: u32) {
@@ -188,11 +189,14 @@ pub unsafe fn set_power_scaling(ps_value: PowerScaling) {
     // doesn't as far as I can tell, but it seems like a good idea
     while !power_scaling_ok() {}
 
+    let control = (*BPM).pmcon.extract();
+
     // Unlock PMCON register
     unlock_register(0x1c); // Control
 
     // Actually change power scaling
-    (*BPM).pmcon.modify(
+    (*BPM).pmcon.modify_no_read(
+        control,
         PowerModeControl::PS.val(ps_value as u32) + PowerModeControl::PSCM::WithoutCpuHalt
             + PowerModeControl::PSCREQ::PowerScalingRequested,
     );

--- a/chips/sam4l/src/bpm.rs
+++ b/chips/sam4l/src/bpm.rs
@@ -77,7 +77,7 @@ register_bitfields![u32,
         /// bit 3 ('PSCM' bit) of the PMCON register, which is *blank* (not a '-')
         /// in the datasheet with supporting comments that this allows a change
         /// 'without CPU halt'
-        PSCM OFFSET(4) NUMBITS(1) [
+        PSCM OFFSET(3) NUMBITS(1) [
             WithCpuHalt = 0,
             WithoutCpuHalt = 1
         ],

--- a/chips/sam4l/src/bscif.rs
+++ b/chips/sam4l/src/bscif.rs
@@ -319,6 +319,7 @@ static mut BSCIF: *mut BscifRegisters = BSCIF_BASE as *mut BscifRegisters;
 
 /// Setup the internal 32kHz RC oscillator.
 pub unsafe fn enable_rc32k() {
+    let rc32kcr = (*BSCIF).rc32kcr.extract();
     // Unlock the BSCIF::RC32KCR register
     (*BSCIF)
         .unlock
@@ -326,7 +327,8 @@ pub unsafe fn enable_rc32k() {
     // Write the BSCIF::RC32KCR register.
     // Enable the generic clock source, the temperature compensation, and the
     // 32k output.
-    (*BSCIF).rc32kcr.modify(
+    (*BSCIF).rc32kcr.modify_no_read(
+        rc32kcr,
         RC32Control::EN32K::OutputEnable + RC32Control::TCEN::TempCompensated
             + RC32Control::EN::GclkSourceEnable,
     );

--- a/kernel/src/common/regs/README.md
+++ b/kernel/src/common/regs/README.md
@@ -130,6 +130,9 @@ ReadWrite<T: IntLike, R: RegisterLongName = ()>
                                                //  overwriting other fields to zero
 .modify(value: FieldValue<T, R>)               // Write the value of one or more fields,
                                                //  leaving other fields unchanged
+.modify_no_read(                               // Write the value of one or more fields,
+      original: LocalRegisterCopy<T, R>,       //  leaving other fields unchanged, but pass in
+      value: FieldValue<T, R>)                 //  the original value, instead of doing a register read
 .is_set(field: Field<T, R>) -> bool            // Check if one or more bits in a field are set
 .matches_any(value: FieldValue<T, R>) -> bool  // Check if any specified parts of a field match
 .matches_all(value: FieldValue<T, R>) -> bool  // Check if all specified parts of a field match
@@ -188,6 +191,12 @@ regs.cr.modify(Control::EN::CLEAR + Control::RANGE::Low); // INT unchanged
 
 // Any number of non-overlapping fields can be combined:
 regs.cr.modify(Control::EN::CLEAR + Control::RANGE::High + CR::INT::SET);
+
+// In some cases (such as a protected register) .modify() may not be appropriate.
+// To enable updating a register without coupling the read and write, use
+// modify_no_read():
+let original = regs.cr.extract();
+regs.cr.modify_no_read(original, Control::EN::CLEAR);
 
 
 // -----------------------------------------------------------------------------

--- a/kernel/src/common/regs/mod.rs
+++ b/kernel/src/common/regs/mod.rs
@@ -135,6 +135,11 @@ impl<T: IntLike, R: RegisterLongName> ReadWrite<T, R> {
     }
 
     #[inline]
+    pub fn modify_no_read(&self, original: LocalRegisterCopy<T, R>, field: FieldValue<T, R>) {
+        self.set((original.get() & !field.mask) | field.value);
+    }
+
+    #[inline]
     pub fn is_set(&self, field: Field<T, R>) -> bool {
         self.read(field) != T::zero()
     }


### PR DESCRIPTION
### Pull Request Overview

Well, the problem with abstraction is it hides things, and in this case it hid the fact that a `.modify()` is really two register calls: a read and a write. Normally this is fine, but with protected registers the unlock command only applies to the read, and the write doesn't go through.

In the sam4l this means that some of our clock code isn't working. And, I believe we only didn't notice because the bootloader was setting it up for us. However, when writing a new bootloader, that oversight becomes a real issue.

Also, in moving to the new register interface, I got the offset wrong for one of the bits. But, since it was never actually doing anything, I didn't notice.

This also adds `modify_no_read()` to the register interface so we can nicely handle these situations.


### Testing Strategy

This pull request was tested by running the hail app on hail with the new tock-bootloader.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Kernel: Updated the relevant files in `/docs`, or no updates are required.
- [x] Userland: Added/updated the application README, if needed.

### Formatting

- [x] Ran `make formatall`.
