### PR TITLE
kernel: make IPC optional

### DIFF
--- a/boards/ek-tm4c1294xl/src/main.rs
+++ b/boards/ek-tm4c1294xl/src/main.rs
@@ -204,5 +204,5 @@ pub unsafe fn reset_handler() {
         &mut PROCESSES,
         FAULT_RESPONSE,
     );
-    kernel::main(&tm4c1294, &mut chip, &mut PROCESSES, &tm4c1294.ipc);
+    kernel::main(&tm4c1294, &mut chip, &mut PROCESSES, Some(&tm4c1294.ipc));
 }

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -496,5 +496,5 @@ pub unsafe fn reset_handler() {
         &mut PROCESSES,
         FAULT_RESPONSE,
     );
-    kernel::main(&hail, &mut chip, &mut PROCESSES, &hail.ipc);
+    kernel::main(&hail, &mut chip, &mut PROCESSES, Some(&hail.ipc));
 }

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -652,5 +652,5 @@ pub unsafe fn reset_handler() {
         FAULT_RESPONSE,
     );
 
-    kernel::main(&imix, &mut chip, &mut PROCESSES, &imix.ipc);
+    kernel::main(&imix, &mut chip, &mut PROCESSES, Some(&imix.ipc));
 }

--- a/boards/launchxl/src/main.rs
+++ b/boards/launchxl/src/main.rs
@@ -227,6 +227,6 @@ pub unsafe fn reset_handler() {
         &launchxl,
         &mut chip,
         &mut PROCESSES,
-        &kernel::ipc::IPC::new(),
+        Some(&kernel::ipc::IPC::new()),
     );
 }

--- a/boards/nrf51dk/src/main.rs
+++ b/boards/nrf51dk/src/main.rs
@@ -366,6 +366,6 @@ pub unsafe fn reset_handler() {
         &platform,
         &mut chip,
         &mut PROCESSES,
-        &kernel::ipc::IPC::new(),
+        Some(&kernel::ipc::IPC::new()),
     );
 }

--- a/boards/nrf52dk/src/main.rs
+++ b/boards/nrf52dk/src/main.rs
@@ -388,5 +388,5 @@ pub unsafe fn reset_handler() {
         FAULT_RESPONSE,
     );
 
-    kernel::main(&platform, &mut chip, &mut PROCESSES, &platform.ipc);
+    kernel::main(&platform, &mut chip, &mut PROCESSES, Some(&platform.ipc));
 }

--- a/doc/courses/sensys/exercises/board/src/main.rs
+++ b/doc/courses/sensys/exercises/board/src/main.rs
@@ -488,5 +488,5 @@ pub unsafe fn reset_handler() {
     );
 
     // Begin kernel main loop
-    kernel::main(&hail, &mut chip, &mut PROCESSES, &hail.ipc);
+    kernel::main(&hail, &mut chip, &mut PROCESSES, Some(&hail.ipc));
 }

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -54,7 +54,7 @@ pub fn main<P: Platform, C: Chip>(
     platform: &P,
     chip: &mut C,
     processes: &'static mut [Option<&mut process::Process<'static>>],
-    ipc: &ipc::IPC,
+    ipc: Option<&ipc::IPC>,
 ) {
     let processes = unsafe {
         process::PROCS = processes;

--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -21,7 +21,7 @@ pub unsafe fn do_process<P: Platform, C: Chip>(
     chip: &mut C,
     process: &mut Process,
     appid: ::AppId,
-    ipc: &::ipc::IPC,
+    ipc: Option<&::ipc::IPC>,
 ) {
     let systick = chip.systick();
     systick.reset();
@@ -52,7 +52,9 @@ pub unsafe fn do_process<P: Platform, C: Chip>(
                             process.push_function_call(ccb);
                         }
                         Task::IPC((otherapp, ipc_type)) => {
-                            ipc.schedule_callback(appid, otherapp, ipc_type);
+                            ipc.map(|ipc| {
+                                ipc.schedule_callback(appid, otherapp, ipc_type);
+                            });
                         }
                     }
                     continue;


### PR DESCRIPTION
Some boards may not want to use applications, and therefore do not need
to support IPC. This commit wraps the IPC mechanism passed to the kernel
in an option so that a board can pass in None.

This is motivated by the bootloader, which does not support
applications.



### Testing Strategy

This pull request was tested by running the `rot_` apps on hail.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Kernel: Updated the relevant files in `/docs`, or no updates are required. I grepped for "ipc" and didn't see anything in the docs folder.
- [x] Userland: Added/updated the application README, if needed.

### Formatting

- [x] Ran `make formatall`.
