### PR TITLE
ble/capsule `unwrap_or` -> `unwrap_or_else`

### DIFF
--- a/capsules/src/ble_advertising_driver.rs
+++ b/capsules/src/ble_advertising_driver.rs
@@ -268,9 +268,9 @@ impl App {
                         ble.kernel_tx.replace(result);
                         ReturnCode::SUCCESS
                     })
-                    .unwrap_or(ReturnCode::FAIL)
+                    .unwrap_or_else(|| ReturnCode::FAIL)
             })
-            .unwrap_or(ReturnCode::FAIL)
+            .unwrap_or_else(|| ReturnCode::FAIL)
     }
 
     // Returns a new pseudo-random number and updates the randomness state.


### PR DESCRIPTION
### Pull Request Overview

`unwrap_or_else` is lazily evaluated should be preferred over `unwrap_or` which
is eagerly evaluated. In this case it doesn't matter (probably) because it is
likely to inlined because it is an enum.

However, it is more `idiomatic Rust` to use `unwrap_or_else` and should preferred
especially if something more `costly` such as calling another
function in the `else` case!

### Testing Strategy

Compiles!


### TODO or Help Wanted

N/A

### Documentation Updated

~- [ ] Kernel: Updated the relevant files in `/docs`, or no updates are required.~
~- [ ] Userland: Added/updated the application README, if needed.~

### Formatting

- [x] Ran `make formatall`.
