### PR TITLE
kernel: format process.rs

### DIFF
--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -23,13 +23,8 @@ pub mod hil;
 pub mod ipc;
 pub mod mem;
 pub mod memop;
-pub mod returncode;
-
-// Work around https://github.com/rust-lang-nursery/rustfmt/issues/6
-// It's a little sad that we have to skip the whole module, but that's
-// better than the unmaintainable pile 'o strings IMO
-#[cfg_attr(rustfmt, rustfmt_skip)]
 pub mod process;
+pub mod returncode;
 
 pub mod support;
 


### PR DESCRIPTION
Hasn't been possible previously, but with some recent fixes to rustfmt it now does not error on process.rs.




### Testing Strategy

This pull request was tested by compiling the hail board.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Kernel: Updated the relevant files in `/docs`, or no updates are required.
- [x] Userland: Added/updated the application README, if needed.

### Formatting

- [x] Ran `make formatall`.
