### PR TITLE
UART HIL Changes

### DIFF
--- a/capsules/src/nrf51822_serialization.rs
+++ b/capsules/src/nrf51822_serialization.rs
@@ -18,7 +18,7 @@
 
 use core::cmp;
 use kernel::common::cells::{MapCell, TakeCell};
-use kernel::hil::uart::{self, Client, UARTAdvanced};
+use kernel::hil::uart::{self, Client, UARTReceiveAdvanced};
 use kernel::{AppId, AppSlice, Callback, Driver, ReturnCode, Shared};
 
 /// Syscall number
@@ -51,14 +51,14 @@ pub static mut READ_BUF: [u8; 600] = [0; 600];
 
 // We need two resources: a UART HW driver and driver state for each
 // application.
-pub struct Nrf51822Serialization<'a, U: UARTAdvanced + 'a> {
+pub struct Nrf51822Serialization<'a, U: UARTReceiveAdvanced + 'a> {
     uart: &'a U,
     app: MapCell<App>,
     tx_buffer: TakeCell<'static, [u8]>,
     rx_buffer: TakeCell<'static, [u8]>,
 }
 
-impl<'a, U: UARTAdvanced> Nrf51822Serialization<'a, U> {
+impl<'a, U: UARTReceiveAdvanced> Nrf51822Serialization<'a, U> {
     pub fn new(
         uart: &'a U,
         tx_buffer: &'static mut [u8],
@@ -82,7 +82,7 @@ impl<'a, U: UARTAdvanced> Nrf51822Serialization<'a, U> {
     }
 }
 
-impl<'a, U: UARTAdvanced> Driver for Nrf51822Serialization<'a, U> {
+impl<'a, U: UARTReceiveAdvanced> Driver for Nrf51822Serialization<'a, U> {
     /// Pass application space memory to this driver.
     ///
     /// ### `allow_num`
@@ -179,7 +179,7 @@ impl<'a, U: UARTAdvanced> Driver for Nrf51822Serialization<'a, U> {
 }
 
 // Callbacks from the underlying UART driver.
-impl<'a, U: UARTAdvanced> Client for Nrf51822Serialization<'a, U> {
+impl<'a, U: UARTReceiveAdvanced> Client for Nrf51822Serialization<'a, U> {
     // Called when the UART TX has finished.
     fn transmit_complete(&self, buffer: &'static mut [u8], _error: uart::Error) {
         self.tx_buffer.replace(buffer);

--- a/chips/sam4l/src/usart.rs
+++ b/chips/sam4l/src/usart.rs
@@ -882,7 +882,7 @@ impl hil::uart::UART for USART {
     }
 }
 
-impl hil::uart::UARTAdvanced for USART {
+impl hil::uart::UARTReceiveAdvanced for USART {
     fn receive_automatic(&self, rx_buffer: &'static mut [u8], interbyte_timeout: u8) {
         let usart = &USARTRegManager::new(&self);
 

--- a/chips/sam4l/src/usart.rs
+++ b/chips/sam4l/src/usart.rs
@@ -665,11 +665,6 @@ impl USART {
         usart.registers.idr.write(Interrupt::TIMEOUT::SET);
     }
 
-    fn enable_rx_terminator(&self, _regs_manage: &USARTRegManager, _terminator: u8) {
-        // XXX: implement me
-        panic!("didn't write terminator stuff yet");
-    }
-
     // for use by panic in io.rs
     pub fn send_byte(&self, usart: &USARTRegManager, byte: u8) {
         usart
@@ -901,29 +896,6 @@ impl hil::uart::UARTAdvanced for USART {
 
         // enable receive timeout
         self.enable_rx_timeout(usart, interbyte_timeout);
-
-        // set up dma transfer and start reception
-        self.rx_dma.get().map(move |dma| {
-            dma.enable();
-            let length = rx_buffer.len();
-            dma.do_transfer(self.rx_dma_peripheral, rx_buffer, length);
-            self.rx_len.set(length);
-        });
-    }
-
-    fn receive_until_terminator(&self, rx_buffer: &'static mut [u8], terminator: u8) {
-        let usart = &USARTRegManager::new(&self);
-
-        // quit current reception if any
-        self.abort_rx(usart, hil::uart::Error::RepeatCallError);
-
-        // enable RX
-        self.enable_rx(usart);
-        self.enable_rx_error_interrupts(usart);
-        self.usart_rx_state.set(USARTStateRX::DMA_Receiving);
-
-        // enable receive terminator
-        self.enable_rx_terminator(usart, terminator);
 
         // set up dma transfer and start reception
         self.rx_dma.get().map(move |dma| {

--- a/kernel/src/hil/uart.rs
+++ b/kernel/src/hil/uart.rs
@@ -71,12 +71,6 @@ pub trait UARTAdvanced: UART {
     ///
     /// * `interbyte_timeout`: number of bit periods since last data received.
     fn receive_automatic(&self, rx_buffer: &'static mut [u8], interbyte_timeout: u8);
-
-    /// Receive data until `terminator` data byte has been received or buffer
-    /// is full
-    ///
-    /// * `terminator`: data byte terminating a reception.
-    fn receive_until_terminator(&self, rx_buffer: &'static mut [u8], terminator: u8);
 }
 
 /// Implement Client to receive callbacks from UART.

--- a/kernel/src/hil/uart.rs
+++ b/kernel/src/hil/uart.rs
@@ -64,7 +64,24 @@ pub trait UART {
     fn abort_receive(&self);
 }
 
-pub trait UARTAdvanced: UART {
+/// Trait that isn't required for basic UART operation, but provides useful
+/// abstractions that capsules may want to be able to leverage.
+///
+/// The interfaces are included here because some hardware platforms may be able
+/// to directly implement them, while others platforms may need to emulate them
+/// in software. The ones that can implement them in hardware should be able to
+/// leverage that efficiency, and by placing the interfaces here in the HIL they
+/// can do that.
+///
+/// Other interface ideas that have been discussed, but are not included due to
+/// the lack of a clear use case, but are noted here in case they might help
+/// someone in the future:
+/// - `receive_until_terminator`: This would read in bytes until a specified
+///   byte is received (or the buffer is full) and then return to the client.
+/// - `receive_len_then_message`: This would do a one byte read to get a length
+///   byte and then read that many more bytes from UART before returning to the
+///   client.
+pub trait UARTReceiveAdvanced: UART {
     /// Receive data until `interbyte_timeout` bit periods have passed since the
     /// last byte or buffer is full. Does not timeout until at least one byte
     /// has been received.


### PR DESCRIPTION
### Pull Request Overview

This pull request removes the `receive_until_terminator` interface from the UART HIL and renames `receive_automatic` to `receive_timeout`.

I imagine this one will be a little controversial with @brghena, but it has been two years and `receive_until_terminator` has never been implemented much less used.

It also renames the trait from `UARTAdvanced` to `UARTReceiveTimeout` to be a little more specific.


### Testing Strategy

This pull request was tested by compiling the hail board.


### TODO or Help Wanted

I think we could do without this PR, but given that the bootloader needs the `receive_automatic` interface, I think it is a good time to revisit the advanced uart interface.


### Documentation Updated

- [x] Kernel: Updated the relevant files in `/docs`, or no updates are required.
- [x] Userland: Added/updated the application README, if needed.

### Formatting

- [x] Ran `make formatall`.
