### PR TITLE
rustfmt.toml is redundant

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,0 @@
-format_strings = false
-reorder_imports = true


### PR DESCRIPTION


### Pull Request Overview

This pull request removes rustfmt.toml as our settings are the default.


### Testing Strategy

n/a


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Kernel: Updated the relevant files in `/docs`, or no updates are required.
- [x] Userland: Added/updated the application README, if needed.

### Formatting

- [x] Ran `make formatall`.
