### PR TITLE
kernel: don't silently drop IPC tasks

### DIFF
--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -52,9 +52,17 @@ pub unsafe fn do_process<P: Platform, C: Chip>(
                             process.push_function_call(ccb);
                         }
                         Task::IPC((otherapp, ipc_type)) => {
-                            ipc.map(|ipc| {
-                                ipc.schedule_callback(appid, otherapp, ipc_type);
-                            });
+                            ipc.map_or_else(
+                                || {
+                                    assert!(
+                                        false,
+                                        "Kernel consistency error: IPC Task with no IPC"
+                                    );
+                                },
+                                |ipc| {
+                                    ipc.schedule_callback(appid, otherapp, ipc_type);
+                                },
+                            );
                         }
                     }
                     continue;


### PR DESCRIPTION
### Pull Request Overview

kernel: don't silently drop IPC tasks

I think #931 got merged prematurely without fixing this.

### Documentation Updated

- [x] Kernel: Updated the relevant files in `/docs`, or no updates are required.
- [x] Userland: Added/updated the application README, if needed.

### Formatting

- [x] Ran `make formatall`.
