### PR TITLE
Add more Cell types

### DIFF
--- a/kernel/src/common/mod.rs
+++ b/kernel/src/common/mod.rs
@@ -14,18 +14,21 @@ pub mod volatile_cell;
 #[macro_use]
 pub mod regs;
 
+mod num_cell;
+
 pub use self::list::{List, ListLink, ListNode};
 pub use self::queue::Queue;
 pub use self::ring_buffer::RingBuffer;
 pub use self::static_ref::StaticRef;
 
-/// Create a "fake" module inside of `commmon` for all of the Tock `Cell` types.
+/// Create a "fake" module inside of `common` for all of the Tock `Cell` types.
 ///
 /// To use `TakeCell`, for example, users should use:
 ///
 ///     use kernel::common::cells::TakeCell;
 pub mod cells {
     pub use common::map_cell::MapCell;
+    pub use common::num_cell::NumCell;
     pub use common::take_cell::TakeCell;
     pub use common::volatile_cell::VolatileCell;
 }

--- a/kernel/src/common/mod.rs
+++ b/kernel/src/common/mod.rs
@@ -15,6 +15,7 @@ pub mod volatile_cell;
 pub mod regs;
 
 mod num_cell;
+mod optional_cell;
 
 pub use self::list::{List, ListLink, ListNode};
 pub use self::queue::Queue;
@@ -29,6 +30,7 @@ pub use self::static_ref::StaticRef;
 pub mod cells {
     pub use common::map_cell::MapCell;
     pub use common::num_cell::NumCell;
+    pub use common::optional_cell::OptionalCell;
     pub use common::take_cell::TakeCell;
     pub use common::volatile_cell::VolatileCell;
 }

--- a/kernel/src/common/num_cell.rs
+++ b/kernel/src/common/num_cell.rs
@@ -1,0 +1,57 @@
+//! NumCell convenience type
+
+use core::cell::Cell;
+use core::marker::Copy;
+use core::ops::{Add, Sub};
+
+/// `NumCell` is a simple wrapper around a `Cell` that restricts the type
+/// `T` to a number. `NumCell` then provides convenient methods, like
+/// `increment` and `add`. This means instead of this code:
+///
+///     cell_item.set(cell_item.get() + 10);
+///
+/// the code can look like:
+///
+///     cell_item.add(10);
+pub struct NumCell<T: Add + Sub + Copy + From<usize>> {
+    value: Cell<T>,
+}
+
+impl<T: Add<Output = T> + Sub<Output = T> + Copy + From<usize>> NumCell<T> {
+    /// Create a new NumCell.
+    pub const fn new(value: T) -> NumCell<T> {
+        NumCell {
+            value: Cell::new(value),
+        }
+    }
+
+    /// Return a copy of the stored value.
+    pub fn get(&self) -> T {
+        self.value.get()
+    }
+
+    /// Update the stored value.
+    pub fn set(&self, val: T) {
+        self.value.set(val);
+    }
+
+    /// Add 1 to the stored value.
+    pub fn increment(&self) {
+        self.value.set(self.value.get() + T::from(1 as usize));
+    }
+
+    /// Subtract 1 from the stored value.
+    pub fn decrement(&self) {
+        self.value.set(self.value.get() - T::from(1 as usize));
+    }
+
+    /// Add the passed in value to the stored value.
+    pub fn add(&self, val: T) {
+        self.value.set(self.value.get() + val);
+    }
+
+    /// Subtract the passed in value from the stored value.
+    pub fn subtract(&self, val: T) {
+        self.value.set(self.value.get() - val);
+    }
+}

--- a/kernel/src/common/optional_cell.rs
+++ b/kernel/src/common/optional_cell.rs
@@ -1,0 +1,44 @@
+//! OptionalCell convenience type
+
+use core::cell::Cell;
+use core::marker::Copy;
+
+/// `OptionalCell` is a `Cell` that wraps an `Option`. This is helper type
+/// that makes keeping types that can be `None` a little cleaner.
+pub struct OptionalCell<T: Copy> {
+    value: Cell<Option<T>>,
+}
+
+impl<T: Copy> OptionalCell<T> {
+    /// Create a new OptionalCell.
+    pub const fn new(val: T) -> OptionalCell<T> {
+        OptionalCell {
+            value: Cell::new(Some(val)),
+        }
+    }
+
+    /// Create an empty `OptionalCell` (contains just `None`).
+    pub const fn empty() -> OptionalCell<T> {
+        OptionalCell {
+            value: Cell::new(None),
+        }
+    }
+
+    /// Update the stored value.
+    pub fn set(&self, val: T) {
+        self.value.set(Some(val));
+    }
+
+    /// Reset the stored value to `None`.
+    pub fn clear(&self) {
+        self.value.set(None);
+    }
+
+    /// Call a closure on the value if the value exists.
+    pub fn map<F, R>(&self, closure: F) -> Option<R>
+    where
+        F: FnOnce(&mut T) -> R,
+    {
+        self.value.get().map(|mut val| closure(&mut val))
+    }
+}


### PR DESCRIPTION
### Pull Request Overview

I'm not sure what the appetite is for this, but this PR adds two new cell types to Tock: `NumCell` and `OptionalCell`. `NumCell` is just like a normal `Cell` but can only contain numbers, and provides some convenient functions (`add()` and `subtract()`, for example). `OptionalCell` is a cell that wraps its contents in an Option, so that `None` can be stored instead of a value.

The motivation for `NumCell` is that this code: `my_cell.set(my_cell.get() + 1)` is a little tedious after a while. I think it is a little easier to understand `my_cell.increment()` (or `my_cell.add(1)`). The downside is that it adds a new Cell type that someone has to think about, but given it is a very slim wrapper over a standard Rust Cell I don't think it is too much of a burden.

The motivation for `OptionalCell` is to fill in the gap between a `TakeCell` and a regular `Cell`, where `TakeCell` conveniently wraps an option as well, and hides that nicely from the user, but for things where a `TakeCell` is inappropriate we are left using `Cell<Option<T>>`. `OptionalCell` hides that `Option` and makes things a bit cleaner. So instead of `my_optional_cell.get().map(|| {})`, the code can mirror TakeCell and be: `my_optional_cell.map(|| {})`. We use this a lot for storing clients for capsules.

As an example I have updated the `nonvolatile_to_pages` capsule with these new types where they can be useful.


### Testing Strategy

todo


### TODO or Help Wanted

What are people's thoughts on complexity/abstraction versus convenience? I think because these are such small wrappers over Cells they should be easy to understand but make capsule and kernel code more readable.


### Documentation Updated

- [x] Kernel: Updated the relevant files in `/docs`, or no updates are required.
- [x] Userland: Added/updated the application README, if needed.

### Formatting

- [x] Ran `make formatall`.
