### PR TITLE
sam4l: rename `xfer` to `transfer`

### DIFF
--- a/boards/imix/src/spi_slave_dummy.rs
+++ b/boards/imix/src/spi_slave_dummy.rs
@@ -77,7 +77,7 @@ pub unsafe fn spi_slave_dummy_test() {
 
     // Hint: Temporarily, when switching between master and slave dummy code,
     // - uncomment the right line at the end of reset_handler in main.rs
-    // - uncomment the right client at the end of xfer_done in spi.rs
+    // - uncomment the right client at the end of transfer_done in spi.rs
     // - uncomment 240-242 in main.rs for slave and comment it for master
 
     // YES interrupts are up, prints 0x07 all the way

--- a/chips/sam4l/src/adc.rs
+++ b/chips/sam4l/src/adc.rs
@@ -773,7 +773,7 @@ impl hil::adc::Adc for Adc {
             // stop DMA transfer if going. This should safely return a None if
             // the DMA was not being used
             let dma_buffer = self.rx_dma.get().map_or(None, |rx_dma| {
-                let dma_buf = rx_dma.abort_xfer();
+                let dma_buf = rx_dma.abort_transfer();
                 rx_dma.disable();
                 dma_buf
             });
@@ -901,7 +901,7 @@ impl hil::adc::AdcHighSpeed for Adc {
                 self.dma_running.set(true);
                 dma.enable();
                 self.rx_length.set(dma_len);
-                dma.do_xfer(self.rx_dma_peripheral, dma_buf, dma_len);
+                dma.do_transfer(self.rx_dma_peripheral, dma_buf, dma_len);
             });
 
             // start timer
@@ -969,7 +969,7 @@ impl dma::DMAClient for Adc {
     /// Handler for DMA transfer completion.
     ///
     /// - `pid`: the DMA peripheral that is complete
-    fn xfer_done(&self, pid: dma::DMAPeripheral) {
+    fn transfer_done(&self, pid: dma::DMAPeripheral) {
         // check if this was an RX transfer
         if pid == self.rx_dma_peripheral {
             // RX transfer was completed
@@ -977,7 +977,7 @@ impl dma::DMAClient for Adc {
             // get buffer filled with samples from DMA
             let dma_buffer = self.rx_dma.get().map_or(None, |rx_dma| {
                 self.dma_running.set(false);
-                let dma_buf = rx_dma.abort_xfer();
+                let dma_buf = rx_dma.abort_transfer();
                 rx_dma.disable();
                 dma_buf
             });
@@ -1014,7 +1014,7 @@ impl dma::DMAClient for Adc {
                         self.dma_running.set(true);
                         dma.enable();
                         self.rx_length.set(dma_len);
-                        dma.do_xfer(self.rx_dma_peripheral, dma_buf, dma_len);
+                        dma.do_transfer(self.rx_dma_peripheral, dma_buf, dma_len);
                     });
                 } else {
                     // if length was zero, just keep the buffer in the takecell

--- a/chips/sam4l/src/dma.rs
+++ b/chips/sam4l/src/dma.rs
@@ -200,7 +200,7 @@ pub struct DMAChannel {
 }
 
 pub trait DMAClient {
-    fn xfer_done(&self, pid: DMAPeripheral);
+    fn transfer_done(&self, pid: DMAPeripheral);
 }
 
 impl DMAChannel {
@@ -268,16 +268,16 @@ impl DMAChannel {
         let channel = registers.psr.get();
 
         self.client.get().as_mut().map(|client| {
-            client.xfer_done(channel);
+            client.transfer_done(channel);
         });
     }
 
-    pub fn start_xfer(&self) {
+    pub fn start_transfer(&self) {
         let registers: &DMARegisters = unsafe { &*self.registers };
         registers.cr.write(Control::TEN::SET);
     }
 
-    pub fn prepare_xfer(&self, pid: DMAPeripheral, buf: &'static mut [u8], mut len: usize) {
+    pub fn prepare_transfer(&self, pid: DMAPeripheral, buf: &'static mut [u8], mut len: usize) {
         // TODO(alevy): take care of zero length case
 
         let registers: &DMARegisters = unsafe { &*self.registers };
@@ -303,14 +303,14 @@ impl DMAChannel {
         self.buffer.replace(buf);
     }
 
-    pub fn do_xfer(&self, pid: DMAPeripheral, buf: &'static mut [u8], len: usize) {
-        self.prepare_xfer(pid, buf, len);
-        self.start_xfer();
+    pub fn do_transfer(&self, pid: DMAPeripheral, buf: &'static mut [u8], len: usize) {
+        self.prepare_transfer(pid, buf, len);
+        self.start_transfer();
     }
 
     /// Aborts any current transactions and returns the buffer used in the
     /// transaction.
-    pub fn abort_xfer(&self) -> Option<&'static mut [u8]> {
+    pub fn abort_transfer(&self) -> Option<&'static mut [u8]> {
         let registers: &DMARegisters = unsafe { &*self.registers };
         registers
             .idr

--- a/chips/sam4l/src/i2c.rs
+++ b/chips/sam4l/src/i2c.rs
@@ -787,7 +787,7 @@ impl I2CHw {
                     self.master_client.get().map(|client| {
                         let buf = match self.dma.get() {
                             Some(dma) => {
-                                let b = dma.abort_xfer();
+                                let b = dma.abort_transfer();
                                 self.dma.set(Some(dma));
                                 b
                             }
@@ -829,7 +829,7 @@ impl I2CHw {
                         self.master_client.get().map(|client| {
                             let buf = match self.dma.get() {
                                 Some(dma) => {
-                                    let b = dma.abort_xfer();
+                                    let b = dma.abort_transfer();
                                     self.dma.set(Some(dma));
                                     b
                                 }
@@ -852,16 +852,16 @@ impl I2CHw {
                         );
                     }
                     self.dma.get().map(|dma| {
-                        let buf = dma.abort_xfer().unwrap();
-                        dma.prepare_xfer(dma_periph, buf, len);
-                        dma.start_xfer();
+                        let buf = dma.abort_transfer().unwrap();
+                        dma.prepare_transfer(dma_periph, buf, len);
+                        dma.start_transfer();
                     });
                 }
             }
         }
     }
 
-    fn setup_xfer(
+    fn setup_transfer(
         &self,
         twim: &TWIMRegisterManager,
         chip: u8,
@@ -921,10 +921,10 @@ impl I2CHw {
         let twim = &TWIMRegisterManager::new(&self);
         self.dma.get().map(move |dma| {
             dma.enable();
-            dma.prepare_xfer(self.dma_pids.1, data, len as usize);
-            self.setup_xfer(twim, chip, flags, Command::READ::Transmit, len);
+            dma.prepare_transfer(self.dma_pids.1, data, len as usize);
+            self.setup_transfer(twim, chip, flags, Command::READ::Transmit, len);
             self.master_enable(twim);
-            dma.start_xfer();
+            dma.start_transfer();
         });
     }
 
@@ -938,10 +938,10 @@ impl I2CHw {
         let twim = &TWIMRegisterManager::new(&self);
         self.dma.get().map(move |dma| {
             dma.enable();
-            dma.prepare_xfer(self.dma_pids.0, data, len as usize);
-            self.setup_xfer(twim, chip, flags, Command::READ::Receive, len);
+            dma.prepare_transfer(self.dma_pids.0, data, len as usize);
+            self.setup_transfer(twim, chip, flags, Command::READ::Receive, len);
             self.master_enable(twim);
-            dma.start_xfer();
+            dma.start_transfer();
         });
     }
 
@@ -949,8 +949,8 @@ impl I2CHw {
         let twim = &TWIMRegisterManager::new(&self);
         self.dma.get().map(move |dma| {
             dma.enable();
-            dma.prepare_xfer(self.dma_pids.1, data, split as usize);
-            self.setup_xfer(
+            dma.prepare_transfer(self.dma_pids.1, data, split as usize);
+            self.setup_transfer(
                 twim,
                 chip,
                 Command::START::StartCondition,
@@ -965,7 +965,7 @@ impl I2CHw {
                 read_len,
             );
             self.on_deck.set(Some((self.dma_pids.0, read_len as usize)));
-            dma.start_xfer();
+            dma.start_transfer();
         });
     }
 
@@ -1282,7 +1282,7 @@ impl I2CHw {
 }
 
 impl DMAClient for I2CHw {
-    fn xfer_done(&self, _pid: DMAPeripheral) {}
+    fn transfer_done(&self, _pid: DMAPeripheral) {}
 }
 
 impl hil::i2c::I2CMaster for I2CHw {

--- a/chips/sam4l/src/spi.rs
+++ b/chips/sam4l/src/spi.rs
@@ -472,7 +472,7 @@ impl SpiHw {
                 .set(self.transfers_in_progress.get() + 1);
             self.dma_write.get().map(move |write| {
                 write.enable();
-                write.do_xfer(DMAPeripheral::SPI_TX, wbuf, count);
+                write.do_transfer(DMAPeripheral::SPI_TX, wbuf, count);
             });
         });
 
@@ -483,7 +483,7 @@ impl SpiHw {
                 .set(self.transfers_in_progress.get() + 1);
             self.dma_read.get().map(move |read| {
                 read.enable();
-                read.do_xfer(DMAPeripheral::SPI_RX, rbuf, count);
+                read.do_transfer(DMAPeripheral::SPI_RX, rbuf, count);
             });
         });
 
@@ -658,7 +658,7 @@ impl spi::SpiSlave for SpiHw {
 }
 
 impl DMAClient for SpiHw {
-    fn xfer_done(&self, _pid: DMAPeripheral) {
+    fn transfer_done(&self, _pid: DMAPeripheral) {
         // Only callback that the transfer is done if either:
         // 1) The transfer was TX only and TX finished
         // 2) The transfer was TX and RX, in that case wait for both of them to complete. Although
@@ -672,13 +672,13 @@ impl DMAClient for SpiHw {
         if self.transfers_in_progress.get() == 0 {
             self.disable();
             let txbuf = self.dma_write.get().map_or(None, |dma| {
-                let buf = dma.abort_xfer();
+                let buf = dma.abort_transfer();
                 dma.disable();
                 buf
             });
 
             let rxbuf = self.dma_read.get().map_or(None, |dma| {
-                let buf = dma.abort_xfer();
+                let buf = dma.abort_transfer();
                 dma.disable();
                 buf
             });

--- a/chips/sam4l/src/usart.rs
+++ b/chips/sam4l/src/usart.rs
@@ -473,7 +473,7 @@ impl USART {
             let mut length = 0;
             let buffer = self.rx_dma.get().map_or(None, |rx_dma| {
                 length = self.rx_len.get() - rx_dma.transfer_counter();
-                let buf = rx_dma.abort_xfer();
+                let buf = rx_dma.abort_transfer();
                 rx_dma.disable();
                 buf
             });
@@ -501,7 +501,7 @@ impl USART {
             let mut length = 0;
             let buffer = self.tx_dma.get().map_or(None, |tx_dma| {
                 length = self.tx_len.get() - tx_dma.transfer_counter();
-                let buf = tx_dma.abort_xfer();
+                let buf = tx_dma.abort_transfer();
                 tx_dma.disable();
                 buf
             });
@@ -594,7 +594,7 @@ impl USART {
             // state machine, and clients cannot issue other USART calls from
             // the callback.
             let buffer = self.tx_dma.get().map_or(None, |tx_dma| {
-                let buf = tx_dma.abort_xfer();
+                let buf = tx_dma.abort_transfer();
                 tx_dma.disable();
                 buf
             });
@@ -685,7 +685,7 @@ impl USART {
 }
 
 impl dma::DMAClient for USART {
-    fn xfer_done(&self, pid: dma::DMAPeripheral) {
+    fn transfer_done(&self, pid: dma::DMAPeripheral) {
         let usart = &USARTRegManager::new(&self);
 
         match self.usart_mode.get() {
@@ -701,7 +701,7 @@ impl dma::DMAClient for USART {
 
                     // get buffer
                     let buffer = self.rx_dma.get().map_or(None, |rx_dma| {
-                        let buf = rx_dma.abort_xfer();
+                        let buf = rx_dma.abort_transfer();
                         rx_dma.disable();
                         buf
                     });
@@ -760,13 +760,13 @@ impl dma::DMAClient for USART {
 
                     // get buffer
                     let txbuf = self.tx_dma.get().map_or(None, |dma| {
-                        let buf = dma.abort_xfer();
+                        let buf = dma.abort_transfer();
                         dma.disable();
                         buf
                     });
 
                     let rxbuf = self.rx_dma.get().map_or(None, |dma| {
-                        let buf = dma.abort_xfer();
+                        let buf = dma.abort_transfer();
                         dma.disable();
                         buf
                     });
@@ -850,7 +850,7 @@ impl hil::uart::UART for USART {
         // set up dma transfer and start transmission
         self.tx_dma.get().map(move |dma| {
             dma.enable();
-            dma.do_xfer(self.tx_dma_peripheral, tx_data, tx_len);
+            dma.do_transfer(self.tx_dma_peripheral, tx_data, tx_len);
             self.tx_len.set(tx_len);
         });
     }
@@ -875,7 +875,7 @@ impl hil::uart::UART for USART {
         // set up dma transfer and start reception
         self.rx_dma.get().map(move |dma| {
             dma.enable();
-            dma.do_xfer(self.rx_dma_peripheral, rx_buffer, length);
+            dma.do_transfer(self.rx_dma_peripheral, rx_buffer, length);
             self.rx_len.set(rx_len);
         });
     }
@@ -906,7 +906,7 @@ impl hil::uart::UARTAdvanced for USART {
         self.rx_dma.get().map(move |dma| {
             dma.enable();
             let length = rx_buffer.len();
-            dma.do_xfer(self.rx_dma_peripheral, rx_buffer, length);
+            dma.do_transfer(self.rx_dma_peripheral, rx_buffer, length);
             self.rx_len.set(length);
         });
     }
@@ -929,7 +929,7 @@ impl hil::uart::UARTAdvanced for USART {
         self.rx_dma.get().map(move |dma| {
             dma.enable();
             let length = rx_buffer.len();
-            dma.do_xfer(self.rx_dma_peripheral, rx_buffer, length);
+            dma.do_transfer(self.rx_dma_peripheral, rx_buffer, length);
             self.rx_len.set(length);
         });
     }
@@ -1010,12 +1010,12 @@ impl hil::spi::SpiMaster for USART {
                         self.usart_tx_state.set(USARTStateTX::DMA_Transmitting);
                         self.usart_rx_state.set(USARTStateRX::Idle);
                         dma.enable();
-                        dma.do_xfer(self.tx_dma_peripheral, write_buffer, count);
+                        dma.do_transfer(self.tx_dma_peripheral, write_buffer, count);
 
                         // Start the read transaction.
                         self.usart_rx_state.set(USARTStateRX::DMA_Receiving);
                         read.enable();
-                        read.do_xfer(self.rx_dma_peripheral, rbuf, count);
+                        read.do_transfer(self.rx_dma_peripheral, rbuf, count);
                     });
                 });
             });
@@ -1025,7 +1025,7 @@ impl hil::spi::SpiMaster for USART {
                 self.usart_tx_state.set(USARTStateTX::DMA_Transmitting);
                 self.usart_rx_state.set(USARTStateRX::Idle);
                 dma.enable();
-                dma.do_xfer(self.tx_dma_peripheral, write_buffer, count);
+                dma.do_transfer(self.tx_dma_peripheral, write_buffer, count);
             });
         }
 

--- a/doc/Mutable_References.md
+++ b/doc/Mutable_References.md
@@ -130,7 +130,7 @@ buffer in the current transaction from the TakeCell with a
 call to `take`:
 
 ```rust
-pub fn abort_xfer(&self) -> Option<&'static mut [u8]> {
+pub fn abort_transfer(&self) -> Option<&'static mut [u8]> {
     let registers: &DMARegisters = unsafe { &*self.registers };
     registers.interrupt_disable.set(!0);
     // Reset counter


### PR DESCRIPTION
### Pull Request Overview

sam4l: rename `xfer` to `transfer`

Inspired by https://github.com/tock/tock-sensortag/pull/2#discussion_r190281794

We can afford the four extra characters.

### Documentation Updated

- [x] Kernel: Updated the relevant files in `/docs`, or no updates are required.
- [x] Userland: Added/updated the application README, if needed.

### Formatting

- [x] Ran `make formatall`.
