### PR TITLE
Create a capsule that can restart all apps.

### DIFF
--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -510,6 +510,28 @@ pub unsafe fn reset_handler() {
         capsules::dac::Dac::new(&mut sam4l::dac::DAC)
     );
 
+    // // DEBUG Restart All Apps
+    // //
+    // // Uncomment to enable a button press to restart all apps.
+    // //
+    // // Create a dummy object that provides the `ProcessManagementCapability` to
+    // // the `debug_process_restart` capsule.
+    // struct ProcessMgmtCap;
+    // unsafe impl capabilities::ProcessManagementCapability for ProcessMgmtCap {}
+    // let debug_process_restart = static_init!(
+    //     capsules::debug_process_restart::DebugProcessRestart<
+    //         'static,
+    //         sam4l::gpio::GPIOPin,
+    //         ProcessMgmtCap,
+    //     >,
+    //     capsules::debug_process_restart::DebugProcessRestart::new(
+    //         board_kernel,
+    //         &sam4l::gpio::PA[16],
+    //         ProcessMgmtCap
+    //     )
+    // );
+    // sam4l::gpio::PA[16].set_client(debug_process_restart);
+
     let hail = Hail {
         console: console,
         gpio: gpio,

--- a/capsules/README.md
+++ b/capsules/README.md
@@ -132,4 +132,4 @@ These are selectively included on a board to help with testing and debugging
 various elements of Tock.
 
 - **[Debug Process Restart](src/debug_process_restart.rs)**: Force all processes
-  to enter a fault state and restart.
+  to enter a fault state when a button is pressed.

--- a/capsules/README.md
+++ b/capsules/README.md
@@ -124,3 +124,12 @@ Other capsules that implement reusable logic.
 - **[Nonvolatile to Pages](src/nonvolatile_to_pages.rs)**: Map arbitrary reads
   and writes to flash pages.
 - **[AES Encryption](src/aes_ccm.rs)**: AES-CCM encryption.
+
+
+### Debugging Capsules
+
+These are selectively included on a board to help with testing and debugging
+various elements of Tock.
+
+- **[Debug Process Restart](src/debug_process_restart.rs)**: Force all processes
+  to enter a fault state and restart.

--- a/capsules/src/debug_process_restart.rs
+++ b/capsules/src/debug_process_restart.rs
@@ -29,30 +29,24 @@ use kernel::hil;
 use kernel::hil::gpio::{Client, InterruptMode};
 use kernel::Kernel;
 
-pub struct DebugProcessRestart<'a, G: hil::gpio::Pin + 'a, C: ProcessManagementCapability> {
+pub struct DebugProcessRestart<C: ProcessManagementCapability> {
     kernel: &'static Kernel,
-    _pin: &'a G,
     capability: C,
 }
 
-impl<'a, G: hil::gpio::Pin + hil::gpio::PinCtl, C: ProcessManagementCapability>
-    DebugProcessRestart<'a, G, C>
-{
-    pub fn new(kernel: &'static Kernel, pin: &'a G, cap: C) -> DebugProcessRestart<'a, G, C> {
+impl<'a, C: ProcessManagementCapability> DebugProcessRestart<C> {
+    pub fn new(kernel: &'static Kernel, pin: &'a hil::gpio::Pin, cap: C) -> DebugProcessRestart<C> {
         pin.make_input();
         pin.enable_interrupt(0, InterruptMode::RisingEdge);
 
         DebugProcessRestart {
             kernel: kernel,
-            _pin: pin,
             capability: cap,
         }
     }
 }
 
-impl<'a, G: hil::gpio::Pin + hil::gpio::PinCtl, C: ProcessManagementCapability> Client
-    for DebugProcessRestart<'a, G, C>
-{
+impl<'a, C: ProcessManagementCapability> Client for DebugProcessRestart<C> {
     fn fired(&self, _pin_num: usize) {
         self.kernel.hardfault_all_apps(&self.capability);
     }

--- a/capsules/src/debug_process_restart.rs
+++ b/capsules/src/debug_process_restart.rs
@@ -1,0 +1,59 @@
+//! Debug capsule to cause a button press to restart all apps.
+//!
+//! This is useful for debugging that capsules and apps work when they are
+//! restarted by the kernel.
+//!
+//! Usage
+//! -----
+//!
+//! ```rust
+//! struct ProcessMgmtCap;
+//! unsafe impl capabilities::ProcessManagementCapability for ProcessMgmtCap {}
+//! let debug_process_restart = static_init!(
+//!     capsules::debug_process_restart::DebugProcessRestart<
+//!         'static,
+//!         sam4l::gpio::GPIOPin,
+//!         ProcessMgmtCap,
+//!     >,
+//!     capsules::debug_process_restart::DebugProcessRestart::new(
+//!         board_kernel,
+//!         &sam4l::gpio::PA[16],
+//!         ProcessMgmtCap
+//!     )
+//! );
+//! sam4l::gpio::PA[16].set_client(debug_process_restart);
+//! ```
+
+use kernel::capabilities::ProcessManagementCapability;
+use kernel::hil;
+use kernel::hil::gpio::{Client, InterruptMode};
+use kernel::Kernel;
+
+pub struct DebugProcessRestart<'a, G: hil::gpio::Pin + 'a, C: ProcessManagementCapability> {
+    kernel: &'static Kernel,
+    _pin: &'a G,
+    capability: C,
+}
+
+impl<'a, G: hil::gpio::Pin + hil::gpio::PinCtl, C: ProcessManagementCapability>
+    DebugProcessRestart<'a, G, C>
+{
+    pub fn new(kernel: &'static Kernel, pin: &'a G, cap: C) -> DebugProcessRestart<'a, G, C> {
+        pin.make_input();
+        pin.enable_interrupt(0, InterruptMode::RisingEdge);
+
+        DebugProcessRestart {
+            kernel: kernel,
+            _pin: pin,
+            capability: cap,
+        }
+    }
+}
+
+impl<'a, G: hil::gpio::Pin + hil::gpio::PinCtl, C: ProcessManagementCapability> Client
+    for DebugProcessRestart<'a, G, C>
+{
+    fn fired(&self, _pin_num: usize) {
+        self.kernel.hardfault_all_apps(&self.capability);
+    }
+}

--- a/capsules/src/debug_process_restart.rs
+++ b/capsules/src/debug_process_restart.rs
@@ -1,4 +1,4 @@
-//! Debug capsule to cause a button press to restart all apps.
+//! Debug capsule to cause a button press to make all apps fault.
 //!
 //! This is useful for debugging that capsules and apps work when they are
 //! restarted by the kernel.

--- a/capsules/src/lib.rs
+++ b/capsules/src/lib.rs
@@ -24,6 +24,7 @@ pub mod button;
 pub mod console;
 pub mod crc;
 pub mod dac;
+pub mod debug_process_restart;
 pub mod fm25cl;
 pub mod fxos8700cq;
 pub mod gpio;

--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -163,6 +163,24 @@ impl Kernel {
         self.grant_counter.get()
     }
 
+    /// Cause all apps to fault.
+    ///
+    /// This will call `set_fault_state()` on each app, causing the app to enter
+    /// the state as if it had crashed (for example with an MPU violation). If
+    /// the process is configured to be restarted it will be.
+    ///
+    /// Only callers with the `ProcessManagementCapability` can call this
+    /// function. This restricts general capsules from being able to call this
+    /// function, since capsules should not be able to arbitrarily restart all
+    /// apps.
+    pub fn hardfault_all_apps<C: capabilities::ProcessManagementCapability>(&self, _c: &C) {
+        for p in self.processes.iter() {
+            p.map(|process| {
+                process.set_fault_state();
+            });
+        }
+    }
+
     /// Main loop.
     pub fn kernel_loop<P: Platform, C: Chip>(
         &'static self,


### PR DESCRIPTION
### Pull Request Overview

This pull request is to help testing app restarting. It includes a capsule that, when included on a board, enables a button press to restart all apps.

~~This is blocked on #941 and will be more clear when that is merged.~~


### Testing Strategy

This pull request was tested by pressing a button and seeing the hail app restart. Now it doesn't actually run correctly when restarted, but it does print some messages before blocking somewhere.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Kernel: Updated the relevant files in `/docs`, or no updates are required.
- [x] Userland: Added/updated the application README, if needed.

### Formatting

- [x] Ran `make formatall`.
