### PR TITLE
Code Review: remove inactive core members

### DIFF
--- a/doc/CodeReview.md
+++ b/doc/CodeReview.md
@@ -82,10 +82,8 @@ The members of the core team are:
  * Hudson Ayers - [hudson-ayers](https://github.com/hudson-ayers)
  * Brad Campbell - [bradjc](https://github.com/bradjc)
  * Branden Ghena - [brghena](https://github.com/brghena)
- * Daniel Giffin - [daniel-scs](https://github.com/daniel-scs)
  * Philip Levis - [phil-levis](https://github.com/phil-levis)
  * Amit Levy - [alevy](https://github.com/alevy)
- * Olaf Landsiedel - [olafland](https://github.com/olafland)
  * Pat Pannuto - [ppannuto](https://github.com/ppannuto)
 
 ## 4. Release process


### PR DESCRIPTION
### Pull Request Overview

Most of the `P-Significant` pull requests have been getting responses from only a subset of "core team" members. As a result, having a larger core team including members who are mostly inactive (or no longer active) makes progress slower that it could be.

> If a core team member stops responding to many significant pull requests they may be removed from the core team.

This PR removes two members from the core team: @daniel-scs and @olafland.

@daniel-scs is moving on to greener pastures (literally), and will hopefully still be involved in whatever capacity he is able to.

@olafland mostly contributes via supervised students, just doesn't review PRs.

### Testing Strategy

n/a


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Kernel: Updated the relevant files in `/docs`, or no updates are required.
- [x] Userland: Added/updated the application README, if needed.

### Formatting

- [x] Ran `make formatall`.
