### PR TITLE
nrf52: remove bitfield dependency

### DIFF
--- a/boards/nordic/nrf52840dk/Cargo.lock
+++ b/boards/nordic/nrf52840dk/Cargo.lock
@@ -1,9 +1,4 @@
 [[package]]
-name = "bitfield"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "capsules"
 version = "0.1.0"
 dependencies = [
@@ -30,7 +25,6 @@ version = "0.1.0"
 name = "nrf52"
 version = "0.1.0"
 dependencies = [
- "bitfield 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cortexm4 0.1.0",
  "kernel 0.1.0",
  "nrf5x 0.1.0",
@@ -66,5 +60,3 @@ dependencies = [
  "kernel 0.1.0",
 ]
 
-[metadata]
-"checksum bitfield 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f989ae9b9fff3271a712a309fce47f0c46dd3476cb40074ddfcc06ad4a76cf6a"

--- a/boards/nordic/nrf52dk/Cargo.lock
+++ b/boards/nordic/nrf52dk/Cargo.lock
@@ -1,9 +1,4 @@
 [[package]]
-name = "bitfield"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "capsules"
 version = "0.1.0"
 dependencies = [
@@ -30,7 +25,6 @@ version = "0.1.0"
 name = "nrf52"
 version = "0.1.0"
 dependencies = [
- "bitfield 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cortexm4 0.1.0",
  "kernel 0.1.0",
  "nrf5x 0.1.0",
@@ -66,5 +60,3 @@ dependencies = [
  "kernel 0.1.0",
 ]
 
-[metadata]
-"checksum bitfield 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f989ae9b9fff3271a712a309fce47f0c46dd3476cb40074ddfcc06ad4a76cf6a"

--- a/chips/nrf52/Cargo.lock
+++ b/chips/nrf52/Cargo.lock
@@ -1,7 +1,6 @@
 [[package]]
-name = "bitfield"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+name = "cortexm"
+version = "0.1.0"
 
 [[package]]
 name = "cortexm"
@@ -23,7 +22,6 @@ version = "0.1.0"
 name = "nrf52"
 version = "0.1.0"
 dependencies = [
- "bitfield 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cortexm4 0.1.0",
  "kernel 0.1.0",
  "nrf5x 0.1.0",
@@ -36,5 +34,3 @@ dependencies = [
  "kernel 0.1.0",
 ]
 
-[metadata]
-"checksum bitfield 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f989ae9b9fff3271a712a309fce47f0c46dd3476cb40074ddfcc06ad4a76cf6a"

--- a/chips/nrf52/Cargo.toml
+++ b/chips/nrf52/Cargo.toml
@@ -6,7 +6,6 @@ authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
 [dependencies]
 cortexm4 = { path = "../../arch/cortex-m4" }
 kernel = { path = "../../kernel" }
-bitfield = "0.11.0"
 
 [dependencies.nrf5x]
 path = "../nrf5x"

--- a/chips/nrf52/src/lib.rs
+++ b/chips/nrf52/src/lib.rs
@@ -7,9 +7,6 @@
 extern crate cortexm4;
 extern crate nrf5x;
 
-#[macro_use]
-extern crate bitfield;
-
 #[allow(unused)]
 #[macro_use(debug, debug_verbose, debug_gpio, register_bitfields, register_bitmasks)]
 extern crate kernel;


### PR DESCRIPTION
### Pull Request Overview

This pull request removes an unused dependency in the nrf52 crate.


### Testing Strategy

n/a


### TODO or Help Wanted

Blocked on the two nrf52 to new register PRs.


### Documentation Updated

- [x] Kernel: Updated the relevant files in `/docs`, or no updates are required.
- [x] Userland: Added/updated the application README, if needed.

### Formatting

- [x] Ran `make formatall`.
