### PR TITLE
kernel: add capabilities

### DIFF
--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -10,7 +10,7 @@
 
 extern crate capsules;
 #[allow(unused_imports)]
-#[macro_use(debug, debug_gpio, static_init, create_capability)]
+#[macro_use(create_capability, debug, debug_gpio, static_init)]
 extern crate kernel;
 extern crate cortexm4;
 extern crate sam4l;
@@ -205,9 +205,10 @@ pub unsafe fn reset_handler() {
 
     // Create capabilities that the board needs to call certain protected kernel
     // functions.
-    let process_mgmt_cap = create_capability!(capabilities::ProcessManagementCapability);
-    let main_cap = create_capability!(capabilities::MainLoopCapability);
-    let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
+    let process_management_capability =
+        create_capability!(capabilities::ProcessManagementCapability);
+    let main_loop_capability = create_capability!(capabilities::MainLoopCapability);
+    let memory_allocation_capability = create_capability!(capabilities::MemoryAllocationCapability);
 
     // Configure kernel debug gpios as early as possible
     kernel::debug::assign_gpios(
@@ -242,7 +243,7 @@ pub unsafe fn reset_handler() {
             115200,
             &mut capsules::console::WRITE_BUF,
             &mut capsules::console::READ_BUF,
-            board_kernel.create_grant(&grant_cap)
+            board_kernel.create_grant(&memory_allocation_capability)
         )
     );
     hil::uart::UART::set_client(console_uart, console);
@@ -297,14 +298,17 @@ pub unsafe fn reset_handler() {
         capsules::temperature::TemperatureSensor<'static>,
         capsules::temperature::TemperatureSensor::new(
             si7021,
-            board_kernel.create_grant(&grant_cap)
+            board_kernel.create_grant(&memory_allocation_capability)
         )
     );
     kernel::hil::sensors::TemperatureDriver::set_client(si7021, temp);
 
     let humidity = static_init!(
         capsules::humidity::HumiditySensor<'static>,
-        capsules::humidity::HumiditySensor::new(si7021, board_kernel.create_grant(&grant_cap))
+        capsules::humidity::HumiditySensor::new(
+            si7021,
+            board_kernel.create_grant(&memory_allocation_capability)
+        )
     );
     kernel::hil::sensors::HumidityDriver::set_client(si7021, humidity);
 
@@ -327,7 +331,10 @@ pub unsafe fn reset_handler() {
 
     let ambient_light = static_init!(
         capsules::ambient_light::AmbientLight<'static>,
-        capsules::ambient_light::AmbientLight::new(isl29035, board_kernel.create_grant(&grant_cap))
+        capsules::ambient_light::AmbientLight::new(
+            isl29035,
+            board_kernel.create_grant(&memory_allocation_capability)
+        )
     );
     hil::sensors::AmbientLight::set_client(isl29035, ambient_light);
 
@@ -338,7 +345,10 @@ pub unsafe fn reset_handler() {
     );
     let alarm = static_init!(
         capsules::alarm::AlarmDriver<'static, VirtualMuxAlarm<'static, sam4l::ast::Ast>>,
-        capsules::alarm::AlarmDriver::new(virtual_alarm1, board_kernel.create_grant(&grant_cap))
+        capsules::alarm::AlarmDriver::new(
+            virtual_alarm1,
+            board_kernel.create_grant(&memory_allocation_capability)
+        )
     );
     virtual_alarm1.set_client(alarm);
 
@@ -357,7 +367,10 @@ pub unsafe fn reset_handler() {
 
     let ninedof = static_init!(
         capsules::ninedof::NineDof<'static>,
-        capsules::ninedof::NineDof::new(fxos8700, board_kernel.create_grant(&grant_cap))
+        capsules::ninedof::NineDof::new(
+            fxos8700,
+            board_kernel.create_grant(&memory_allocation_capability)
+        )
     );
     hil::sensors::NineDof::set_client(fxos8700, ninedof);
 
@@ -420,7 +433,10 @@ pub unsafe fn reset_handler() {
     );
     let button = static_init!(
         capsules::button::Button<'static, sam4l::gpio::GPIOPin>,
-        capsules::button::Button::new(button_pins, board_kernel.create_grant(&grant_cap))
+        capsules::button::Button::new(
+            button_pins,
+            board_kernel.create_grant(&memory_allocation_capability)
+        )
     );
     for &(btn, _) in button_pins.iter() {
         btn.set_client(button);
@@ -453,7 +469,10 @@ pub unsafe fn reset_handler() {
     // Setup RNG
     let rng = static_init!(
         capsules::rng::SimpleRng<'static, sam4l::trng::Trng>,
-        capsules::rng::SimpleRng::new(&sam4l::trng::TRNG, board_kernel.create_grant(&grant_cap))
+        capsules::rng::SimpleRng::new(
+            &sam4l::trng::TRNG,
+            board_kernel.create_grant(&memory_allocation_capability)
+        )
     );
     sam4l::trng::TRNG.set_client(rng);
 
@@ -480,7 +499,7 @@ pub unsafe fn reset_handler() {
         capsules::crc::Crc<'static, sam4l::crccu::Crccu<'static>>,
         capsules::crc::Crc::new(
             &mut sam4l::crccu::CRCCU,
-            board_kernel.create_grant(&grant_cap)
+            board_kernel.create_grant(&memory_allocation_capability)
         )
     );
     sam4l::crccu::CRCCU.set_client(crc);
@@ -505,7 +524,7 @@ pub unsafe fn reset_handler() {
         led: led,
         button: button,
         rng: rng,
-        ipc: kernel::ipc::IPC::new(board_kernel, &grant_cap),
+        ipc: kernel::ipc::IPC::new(board_kernel, &memory_allocation_capability),
         crc: crc,
         dac: dac,
     };
@@ -554,7 +573,7 @@ pub unsafe fn reset_handler() {
         &mut APP_MEMORY,
         &mut PROCESSES,
         FAULT_RESPONSE,
-        &process_mgmt_cap,
+        &process_management_capability,
     );
-    board_kernel.kernel_loop(&hail, &mut chip, Some(&hail.ipc), &main_cap);
+    board_kernel.kernel_loop(&hail, &mut chip, Some(&hail.ipc), &main_loop_capability);
 }

--- a/boards/imix/src/components/button.rs
+++ b/boards/imix/src/components/button.rs
@@ -17,6 +17,7 @@
 
 use capsules::button;
 use kernel;
+use kernel::capabilities;
 use kernel::component::Component;
 use sam4l;
 
@@ -36,6 +37,8 @@ impl Component for ButtonComponent {
     type Output = &'static button::Button<'static, sam4l::gpio::GPIOPin>;
 
     unsafe fn finalize(&mut self) -> Self::Output {
+        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
+
         let button_pins = static_init!(
             [(&'static sam4l::gpio::GPIOPin, button::GpioMode); 1],
             [(&sam4l::gpio::PC[24], button::GpioMode::LowWhenPressed)]
@@ -43,7 +46,7 @@ impl Component for ButtonComponent {
 
         let button = static_init!(
             button::Button<'static, sam4l::gpio::GPIOPin>,
-            button::Button::new(button_pins, self.board_kernel.create_grant())
+            button::Button::new(button_pins, self.board_kernel.create_grant(&grant_cap))
         );
         for &(btn, _) in button_pins.iter() {
             btn.set_client(button);

--- a/boards/imix/src/components/console.rs
+++ b/boards/imix/src/components/console.rs
@@ -21,6 +21,7 @@ use capsules::console;
 use capsules::virtual_uart::{UartDevice, UartMux};
 use hil;
 use kernel;
+use kernel::capabilities;
 use kernel::component::Component;
 
 pub struct ConsoleComponent {
@@ -47,9 +48,12 @@ impl Component for ConsoleComponent {
     type Output = &'static console::Console<'static, UartDevice<'static>>;
 
     unsafe fn finalize(&mut self) -> Self::Output {
+        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
+
         // Create virtual device for console.
         let console_uart = static_init!(UartDevice, UartDevice::new(self.uart_mux, true));
         console_uart.setup();
+
         let console = static_init!(
             console::Console<UartDevice>,
             console::Console::new(
@@ -57,7 +61,7 @@ impl Component for ConsoleComponent {
                 self.baud_rate,
                 &mut console::WRITE_BUF,
                 &mut console::READ_BUF,
-                self.board_kernel.create_grant()
+                self.board_kernel.create_grant(&grant_cap)
             )
         );
         hil::uart::UART::set_client(console_uart, console);

--- a/boards/imix/src/components/crc.rs
+++ b/boards/imix/src/components/crc.rs
@@ -17,6 +17,7 @@
 
 use capsules::crc;
 use kernel;
+use kernel::capabilities;
 use kernel::component::Component;
 use sam4l;
 
@@ -36,9 +37,14 @@ impl Component for CrcComponent {
     type Output = &'static crc::Crc<'static, sam4l::crccu::Crccu<'static>>;
 
     unsafe fn finalize(&mut self) -> Self::Output {
+        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
+
         let crc = static_init!(
             crc::Crc<'static, sam4l::crccu::Crccu<'static>>,
-            crc::Crc::new(&mut sam4l::crccu::CRCCU, self.board_kernel.create_grant())
+            crc::Crc::new(
+                &mut sam4l::crccu::CRCCU,
+                self.board_kernel.create_grant(&grant_cap)
+            )
         );
 
         crc

--- a/boards/imix/src/components/fxos8700.rs
+++ b/boards/imix/src/components/fxos8700.rs
@@ -27,6 +27,7 @@ use capsules::ninedof::NineDof;
 use capsules::virtual_i2c::{I2CDevice, MuxI2C};
 use hil;
 use kernel;
+use kernel::capabilities;
 use kernel::component::Component;
 use kernel::Grant;
 use sam4l;
@@ -87,6 +88,8 @@ impl Component for NineDofComponent {
     type Output = &'static NineDof<'static>;
 
     unsafe fn finalize(&mut self) -> Self::Output {
+        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
+
         let fxos8700_i2c = static_init!(I2CDevice, I2CDevice::new(self.i2c_mux, 0x1e));
         let fxos8700 = static_init!(
             fxos8700cq::Fxos8700cq<'static>,
@@ -97,7 +100,7 @@ impl Component for NineDofComponent {
 
         let ninedof = static_init!(
             NineDof<'static>,
-            NineDof::new(fxos8700, self.board_kernel.create_grant())
+            NineDof::new(fxos8700, self.board_kernel.create_grant(&grant_cap))
         );
         hil::sensors::NineDof::set_client(fxos8700, ninedof);
 

--- a/boards/imix/src/components/isl29035.rs
+++ b/boards/imix/src/components/isl29035.rs
@@ -27,6 +27,7 @@ use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use capsules::virtual_i2c::{I2CDevice, MuxI2C};
 use hil;
 use kernel;
+use kernel::capabilities;
 use kernel::component::Component;
 use sam4l;
 
@@ -98,6 +99,8 @@ impl Component for AmbientLightComponent {
     type Output = &'static AmbientLight<'static>;
 
     unsafe fn finalize(&mut self) -> Self::Output {
+        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
+
         let isl29035_i2c = static_init!(I2CDevice, I2CDevice::new(self.i2c_mux, 0x44));
         let isl29035_virtual_alarm = static_init!(
             VirtualMuxAlarm<'static, sam4l::ast::Ast>,
@@ -111,7 +114,7 @@ impl Component for AmbientLightComponent {
         isl29035_virtual_alarm.set_client(isl29035);
         let ambient_light = static_init!(
             AmbientLight<'static>,
-            AmbientLight::new(isl29035, self.board_kernel.create_grant())
+            AmbientLight::new(isl29035, self.board_kernel.create_grant(&grant_cap))
         );
         hil::sensors::AmbientLight::set_client(isl29035, ambient_light);
         ambient_light

--- a/boards/imix/src/components/nonvolatile_storage.rs
+++ b/boards/imix/src/components/nonvolatile_storage.rs
@@ -19,6 +19,7 @@ use capsules;
 use capsules::nonvolatile_storage_driver::NonvolatileStorage;
 use capsules::nonvolatile_to_pages::NonvolatileToPages;
 use kernel;
+use kernel::capabilities;
 use kernel::component::Component;
 use kernel::hil;
 use sam4l;
@@ -39,6 +40,8 @@ impl Component for NonvolatileStorageComponent {
     type Output = &'static NonvolatileStorage<'static>;
 
     unsafe fn finalize(&mut self) -> Self::Output {
+        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
+
         sam4l::flashcalw::FLASH_CONTROLLER.configure();
         pub static mut FLASH_PAGEBUFFER: sam4l::flashcalw::Sam4lPage =
             sam4l::flashcalw::Sam4lPage::new();
@@ -67,7 +70,7 @@ impl Component for NonvolatileStorageComponent {
             NonvolatileStorage<'static>,
             NonvolatileStorage::new(
                 nv_to_page,
-                self.board_kernel.create_grant(),
+                self.board_kernel.create_grant(&grant_cap),
                 0x60000,      // Start address for userspace accessible region
                 0x20000,      // Length of userspace accessible region
                 kernel_start, // Start address of kernel region

--- a/boards/imix/src/components/radio.rs
+++ b/boards/imix/src/components/radio.rs
@@ -21,6 +21,7 @@ use capsules::ieee802154::mac::{AwakeMac, Mac};
 use capsules::virtual_spi::VirtualSpiMasterDevice;
 
 use kernel;
+use kernel::capabilities;
 use kernel::component::Component;
 use kernel::hil::radio;
 use kernel::hil::radio::RadioData;
@@ -71,6 +72,8 @@ impl Component for RadioComponent {
     type Output = &'static capsules::ieee802154::RadioDriver<'static>;
 
     unsafe fn finalize(&mut self) -> Self::Output {
+        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
+
         let aes_ccm = static_init!(
             capsules::aes_ccm::AES128CCM<'static, sam4l::aes::Aes<'static>>,
             capsules::aes_ccm::AES128CCM::new(&sam4l::aes::AES, &mut CRYPT_BUF)
@@ -114,7 +117,7 @@ impl Component for RadioComponent {
             capsules::ieee802154::RadioDriver<'static>,
             capsules::ieee802154::RadioDriver::new(
                 radio_mac,
-                self.board_kernel.create_grant(),
+                self.board_kernel.create_grant(&grant_cap),
                 &mut RADIO_BUF
             )
         );

--- a/boards/imix/src/components/si7021.rs
+++ b/boards/imix/src/components/si7021.rs
@@ -26,6 +26,7 @@ use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use capsules::virtual_i2c::{I2CDevice, MuxI2C};
 use hil;
 use kernel;
+use kernel::capabilities;
 use kernel::component::Component;
 use sam4l;
 
@@ -89,9 +90,11 @@ impl Component for TemperatureComponent {
     type Output = &'static TemperatureSensor<'static>;
 
     unsafe fn finalize(&mut self) -> Self::Output {
+        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
+
         let temp = static_init!(
             TemperatureSensor<'static>,
-            TemperatureSensor::new(self.si7021, self.board_kernel.create_grant())
+            TemperatureSensor::new(self.si7021, self.board_kernel.create_grant(&grant_cap))
         );
 
         hil::sensors::TemperatureDriver::set_client(self.si7021, temp);
@@ -120,9 +123,11 @@ impl Component for HumidityComponent {
     type Output = &'static HumiditySensor<'static>;
 
     unsafe fn finalize(&mut self) -> Self::Output {
+        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
+
         let hum = static_init!(
             HumiditySensor<'static>,
-            HumiditySensor::new(self.si7021, self.board_kernel.create_grant())
+            HumiditySensor::new(self.si7021, self.board_kernel.create_grant(&grant_cap))
         );
 
         hil::sensors::HumidityDriver::set_client(self.si7021, hum);

--- a/boards/nordic/nrf51dk/src/main.rs
+++ b/boards/nordic/nrf51dk/src/main.rs
@@ -49,7 +49,7 @@
 
 extern crate capsules;
 #[allow(unused_imports)]
-#[macro_use(debug, debug_verbose, debug_gpio, static_init)]
+#[macro_use(debug, debug_verbose, debug_gpio, static_init, create_capability)]
 extern crate kernel;
 extern crate cortexm0;
 extern crate nrf51;
@@ -58,6 +58,7 @@ extern crate nrf5x;
 use capsules::alarm::AlarmDriver;
 use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use capsules::virtual_uart::{UartDevice, UartMux};
+use kernel::capabilities;
 use kernel::hil;
 use kernel::hil::uart::UART;
 use kernel::{Chip, SysTick};
@@ -143,6 +144,12 @@ pub unsafe fn reset_handler() {
 
     let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
 
+    // Create capabilities that the board needs to call certain protected kernel
+    // functions.
+    let process_mgmt_cap = create_capability!(capabilities::ProcessManagementCapability);
+    let main_cap = create_capability!(capabilities::MainLoopCapability);
+    let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
+
     // LEDs
     let led_pins = static_init!(
         [(&'static nrf5x::gpio::GPIOPin, capsules::led::ActivationMode); 4],
@@ -193,7 +200,7 @@ pub unsafe fn reset_handler() {
     );
     let button = static_init!(
         capsules::button::Button<'static, nrf5x::gpio::GPIOPin>,
-        capsules::button::Button::new(button_pins, board_kernel.create_grant())
+        capsules::button::Button::new(button_pins, board_kernel.create_grant(&grant_cap))
     );
     for &(btn, _) in button_pins.iter() {
         use kernel::hil::gpio::PinCtl;
@@ -262,7 +269,7 @@ pub unsafe fn reset_handler() {
             115200,
             &mut capsules::console::WRITE_BUF,
             &mut capsules::console::READ_BUF,
-            board_kernel.create_grant()
+            board_kernel.create_grant(&grant_cap)
         )
     );
     UART::set_client(console_uart, console);
@@ -298,7 +305,7 @@ pub unsafe fn reset_handler() {
     );
     let alarm = static_init!(
         AlarmDriver<'static, VirtualMuxAlarm<'static, Rtc>>,
-        AlarmDriver::new(virtual_alarm1, board_kernel.create_grant())
+        AlarmDriver::new(virtual_alarm1, board_kernel.create_grant(&grant_cap))
     );
     virtual_alarm1.set_client(alarm);
 
@@ -311,14 +318,17 @@ pub unsafe fn reset_handler() {
         capsules::temperature::TemperatureSensor<'static>,
         capsules::temperature::TemperatureSensor::new(
             &mut nrf5x::temperature::TEMP,
-            board_kernel.create_grant()
+            board_kernel.create_grant(&grant_cap)
         )
     );
     kernel::hil::sensors::TemperatureDriver::set_client(&nrf5x::temperature::TEMP, temp);
 
     let rng = static_init!(
         capsules::rng::SimpleRng<'static, nrf5x::trng::Trng>,
-        capsules::rng::SimpleRng::new(&mut nrf5x::trng::TRNG, board_kernel.create_grant())
+        capsules::rng::SimpleRng::new(
+            &mut nrf5x::trng::TRNG,
+            board_kernel.create_grant(&grant_cap)
+        )
     );
     nrf5x::trng::TRNG.set_client(rng);
 
@@ -330,7 +340,7 @@ pub unsafe fn reset_handler() {
         >,
         capsules::ble_advertising_driver::BLE::new(
             &mut nrf51::radio::RADIO,
-            board_kernel.create_grant(),
+            board_kernel.create_grant(&grant_cap),
             &mut capsules::ble_advertising_driver::BUF,
             ble_radio_virtual_alarm
         )
@@ -387,11 +397,13 @@ pub unsafe fn reset_handler() {
         &mut APP_MEMORY,
         &mut PROCESSES,
         FAULT_RESPONSE,
+        &process_mgmt_cap,
     );
 
     board_kernel.kernel_loop(
         &platform,
         &mut chip,
-        Some(&kernel::ipc::IPC::new(board_kernel)),
+        Some(&kernel::ipc::IPC::new(board_kernel, &grant_cap)),
+        &main_cap,
     );
 }

--- a/boards/nordic/nrf52dk_base/src/lib.rs
+++ b/boards/nordic/nrf52dk_base/src/lib.rs
@@ -5,7 +5,7 @@
 extern crate capsules;
 extern crate cortexm4;
 #[allow(unused_imports)]
-#[macro_use(debug, debug_verbose, debug_gpio, static_init, create_capability)]
+#[macro_use(create_capability, debug, debug_verbose, debug_gpio, static_init)]
 extern crate kernel;
 extern crate nrf52;
 extern crate nrf5x;
@@ -139,9 +139,10 @@ pub unsafe fn setup_board(
 
     // Create capabilities that the board needs to call certain protected kernel
     // functions.
-    let process_mgmt_cap = create_capability!(capabilities::ProcessManagementCapability);
-    let main_cap = create_capability!(capabilities::MainLoopCapability);
-    let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
+    let process_management_capability =
+        create_capability!(capabilities::ProcessManagementCapability);
+    let main_loop_capability = create_capability!(capabilities::MainLoopCapability);
+    let memory_allocation_capability = create_capability!(capabilities::MemoryAllocationCapability);
 
     // Configure kernel debug gpios as early as possible
     kernel::debug::assign_gpios(
@@ -167,7 +168,10 @@ pub unsafe fn setup_board(
     // Buttons
     let button = static_init!(
         capsules::button::Button<'static, nrf5x::gpio::GPIOPin>,
-        capsules::button::Button::new(button_pins, board_kernel.create_grant(&grant_cap))
+        capsules::button::Button::new(
+            button_pins,
+            board_kernel.create_grant(&memory_allocation_capability)
+        )
     );
     for &(btn, _) in button_pins.iter() {
         use kernel::hil::gpio::PinCtl;
@@ -192,7 +196,10 @@ pub unsafe fn setup_board(
             'static,
             capsules::virtual_alarm::VirtualMuxAlarm<'static, nrf5x::rtc::Rtc>,
         >,
-        capsules::alarm::AlarmDriver::new(virtual_alarm1, board_kernel.create_grant(&grant_cap))
+        capsules::alarm::AlarmDriver::new(
+            virtual_alarm1,
+            board_kernel.create_grant(&memory_allocation_capability)
+        )
     );
     virtual_alarm1.set_client(alarm);
     let ble_radio_virtual_alarm = static_init!(
@@ -228,7 +235,7 @@ pub unsafe fn setup_board(
             115200,
             &mut capsules::console::WRITE_BUF,
             &mut capsules::console::READ_BUF,
-            board_kernel.create_grant(&grant_cap)
+            board_kernel.create_grant(&memory_allocation_capability)
         )
     );
     kernel::hil::uart::UART::set_client(console_uart, console);
@@ -261,7 +268,7 @@ pub unsafe fn setup_board(
         >,
         capsules::ble_advertising_driver::BLE::new(
             &mut nrf52::radio::RADIO,
-            board_kernel.create_grant(&grant_cap),
+            board_kernel.create_grant(&memory_allocation_capability),
             &mut capsules::ble_advertising_driver::BUF,
             ble_radio_virtual_alarm
         )
@@ -280,7 +287,7 @@ pub unsafe fn setup_board(
         capsules::temperature::TemperatureSensor<'static>,
         capsules::temperature::TemperatureSensor::new(
             &mut nrf5x::temperature::TEMP,
-            board_kernel.create_grant(&grant_cap)
+            board_kernel.create_grant(&memory_allocation_capability)
         )
     );
     kernel::hil::sensors::TemperatureDriver::set_client(&nrf5x::temperature::TEMP, temp);
@@ -289,7 +296,7 @@ pub unsafe fn setup_board(
         capsules::rng::SimpleRng<'static, nrf5x::trng::Trng>,
         capsules::rng::SimpleRng::new(
             &mut nrf5x::trng::TRNG,
-            board_kernel.create_grant(&grant_cap)
+            board_kernel.create_grant(&memory_allocation_capability)
         )
     );
     nrf5x::trng::TRNG.set_client(rng);
@@ -366,7 +373,7 @@ pub unsafe fn setup_board(
             capsules::nonvolatile_storage_driver::NonvolatileStorage<'static>,
             capsules::nonvolatile_storage_driver::NonvolatileStorage::new(
                 nv_to_page,
-                board_kernel.create_grant(&grant_cap),
+                board_kernel.create_grant(&memory_allocation_capability),
                 0x60000, // Start address for userspace accessible region
                 0x20000, // Length of userspace accessible region
                 0,       // Start address of kernel accessible region
@@ -402,7 +409,7 @@ pub unsafe fn setup_board(
         temp: temp,
         alarm: alarm,
         nonvolatile_storage: nonvolatile_storage,
-        ipc: kernel::ipc::IPC::new(board_kernel, &grant_cap),
+        ipc: kernel::ipc::IPC::new(board_kernel, &memory_allocation_capability),
     };
 
     let mut chip = nrf52::chip::NRF52::new();
@@ -421,8 +428,13 @@ pub unsafe fn setup_board(
         app_memory,
         process_pointers,
         app_fault_response,
-        &process_mgmt_cap,
+        &process_management_capability,
     );
 
-    board_kernel.kernel_loop(&platform, &mut chip, Some(&platform.ipc), &main_cap);
+    board_kernel.kernel_loop(
+        &platform,
+        &mut chip,
+        Some(&platform.ipc),
+        &main_loop_capability,
+    );
 }

--- a/doc/Soundness.md
+++ b/doc/Soundness.md
@@ -5,6 +5,18 @@ An operating system necessarily must use unsafe code. This document explains
 the rationale behind some of the key mechanisms in Tock that do use unsafe code
 but should still preserve safety in the overall OS.
 
+<!-- npm i -g markdown-toc; markdown-toc -i Soundness.md -->
+
+<!-- toc -->
+
+- [`static_init!`](#static_init)
+  * [Use](#use)
+  * [Soundness](#soundness)
+  * [Alternatives](#alternatives)
+- [Capabilities: Restricting Access to Certain Functions and Operations](#capabilities-restricting-access-to-certain-functions-and-operations)
+  * [Capability Examples](#capability-examples)
+
+<!-- tocstop -->
 
 ## `static_init!`
 
@@ -90,3 +102,74 @@ Also, something something static variables of type `Option` everywhere (ugh...
 but maybe reasonable).
 
 
+## Capabilities: Restricting Access to Certain Functions and Operations
+
+Certain operations and functions, particularly those in the kernel crate, are
+not "unsafe" from a language perspective, but are unsafe from an isolation and
+system operation perspective. For example, restarting a process, conceptually,
+does not violate type or memory safety (even though the specific implementation
+in Tock does), but it would violate overall system safety if any code in the
+kernel could restart any arbitrary process. Therefore, Tock must be careful with
+how it provides a function like `restart_process()`, and, in particular, must
+not allow capsules, which are untrusted code that must be sandboxed by Rust, to
+have access to the `restart_process()` function.
+
+Luckily, Rust provides a primitive for doing this restriction: use of the
+`unsafe` keyword. Any function marked as `unsafe` can only be called from a
+different `unsafe` function or from an `unsafe` block. Therefore, by removing
+the ability to define an `unsafe` block, using the `#![forbid(unsafe_code)]`
+attribute in a crate, all modules in that crate cannot call any functions marked
+with `unsafe`. In the case of Tock, the capsules crate is marked with this
+attribute, and therefore all capsules cannot use `unsafe` functions. While this
+approach is effective, it is very coarse-grained: it provides either access to
+all `unsafe` functions or none. To provide more nuanced control, Tock includes
+a mechanism called Capabilities.
+
+Capabilities are essentially zero-memory objects that are required to call
+certain functions. Abstractly, restricted functions, like `restart_process()`,
+would require that the caller has a certain capability:
+
+    restart_process(process_id: usize, capability: ProcessRestartCapability) {}
+
+Any attempt to call that function without possessing that capability would
+result in code that does not compile. To prevent unauthorized uses of
+capabilities, capabilities can only be created by trusted code. In Tock, this is
+implemented by defining capabilities as unsafe traits, which can only be
+implemented for an object by code capable of calling `unsafe`. Therefore, code
+in the untrusted capsules crate cannot generate a capability on its own, and
+instead must be passed the capability by module in a different crate.
+
+Capabilities can be defined for very broad purposes or very narrowly, and code
+can "request" multiple capabilities. Multiple capabilities in Tock can be passed
+by implementing multiple capability traits for a single object.
+
+### Capability Examples
+
+1. One example of how capabilities are useful in Tock is with loading processes.
+   Loading processes is left as a responsibility of the board, since a board may
+   choose to handle its processes in a certain way, or not support userland
+   processes at all. However, the kernel crate provides a helpful function
+   called `load_processes()` that provides the Tock standard method for finding
+   and loading processes. This function is defined in the kernel crate so that
+   all Tock boards can share it, which necessitates that the function be made
+   public. This has the effect that _all_ modules with access to the kernel
+   crate can call `load_processes()`, even though calling it twice would lead to
+   unwanted behavior. One approach is to mark the function as `unsafe`, so only
+   trusted code can call it. This is effective, but not explicit, and conflates
+   language-level safety with system operation-level safety. By instead
+   requiring that the caller of `load_processes()` has a certain capability, the
+   expectations of the caller are more explicit, and the unsafe function does
+   not have to be repurposed.
+
+2. A similar example is a function like `restart_all_processes()` which causes
+   all processes on the board to enter a fault state and restart from their
+   original `_start` point with all grants removed. Again, this is a function
+   that could violate the system-level goals, but could be very useful in
+   certain situations or for debugging grant cleanup when apps fail. Unlike
+   `load_processes()`, however, it might make sense for a capsule to be able to
+   call `restart_all_processes()`, in response to a certain event or to act as a
+   watchdog. In that case, restricting access by marking it as `unsafe` will not
+   work: capsules cannot call unsafe code. By using capabilities, only a caller
+   with the correct capability can call `restart_all_processes()`, and
+   individual boards can be very explicit about which capsules they grant which
+   capabilities.

--- a/kernel/src/capabilities.rs
+++ b/kernel/src/capabilities.rs
@@ -1,0 +1,50 @@
+//! Special restricted capabilities.
+//!
+//! Rust provides a mechanism for restricting certain operations to only be used
+//! by trusted code through the `unsafe` keyword. This is very useful, but
+//! doesn't provide very granular access: code can either access _all_ `unsafe`
+//! things, or none.
+//!
+//! Capabilities are the mechanism in Tock that provides more granular access.
+//! For sensitive operations (e.g. operations that could violate isolation)
+//! callers must have a particular capability. The type system ensures that the
+//! caller does in fact have the capability, and `unsafe` is used to ensure that
+//! callers cannot create the capability type themselves.
+//!
+//! Capabilities are passed to modules from trusted code (i.e. code that can
+//! call `unsafe`).
+//!
+//! Capabilities are expressed as `unsafe` traits. Only code that can use
+//! `unsafe` mechanisms can instantiate an object that provides an `unsafe`
+//! trait. Functions that require certain capabilities require that they are
+//! passed an object that provides the correct capability trait. The object
+//! itself does not have to be marked `unsafe`.
+//!
+//! Creating an object that expresses a capability is straightforward:
+//!
+//! ```
+//! struct ProcessMgmtCap;
+//! unsafe impl ProcessManagementCapability for ProcessMgmtCap {}
+//! ```
+//!
+//! Now anything that has a ProcessMgmtCap can call any function that requires
+//! the `ProcessManagementCapability` capability.
+//!
+//! Requiring a certain capability is also straightforward:
+//!
+//! ```
+//! pub fn manage_process<C: ProcessManagementCapability>(_c: &C) {
+//!    unsafe {
+//!        ...
+//!    }
+//! }
+//! ```
+//!
+//! Anything that calls `manage_process` must have a reference to some object
+//! that provides the `ProcessManagementCapability` trait, which proves that it
+//! has the correct capability.
+
+/// The `ProcessManagementCapability` capability allows the holder to call
+/// various functions related to creating, restarting, and otherwise managing
+/// processes.
+pub unsafe trait ProcessManagementCapability {}

--- a/kernel/src/capabilities.rs
+++ b/kernel/src/capabilities.rs
@@ -48,3 +48,11 @@
 /// various functions related to creating, restarting, and otherwise managing
 /// processes.
 pub unsafe trait ProcessManagementCapability {}
+
+/// The `MainLoopCapability` capability allows the holder to start executing
+/// the main scheduler loop in Tock.
+pub unsafe trait MainLoopCapability {}
+
+/// The `MemoryAllocationCapability` capability allows the holder to allocate
+/// memory, for example by creating grants.
+pub unsafe trait MemoryAllocationCapability {}

--- a/kernel/src/capabilities.rs
+++ b/kernel/src/capabilities.rs
@@ -23,6 +23,8 @@
 //! Creating an object that expresses a capability is straightforward:
 //!
 //! ```
+//! use kernel::capabilities::ProcessManagementCapability;
+//!
 //! struct ProcessMgmtCap;
 //! unsafe impl ProcessManagementCapability for ProcessMgmtCap {}
 //! ```
@@ -32,7 +34,7 @@
 //!
 //! Requiring a certain capability is also straightforward:
 //!
-//! ```
+//! ```ignore
 //! pub fn manage_process<C: ProcessManagementCapability>(_c: &C) {
 //!    unsafe {
 //!        ...

--- a/kernel/src/common/utils.rs
+++ b/kernel/src/common/utils.rs
@@ -62,7 +62,13 @@ macro_rules! storage_volume {
 
 /// Create an object with the given capability.
 ///
-///     let process_mgmt_cap = create_capability!(ProcessManagementCapability);
+/// ```ignore
+/// use kernel::capabilities::ProcessManagementCapability;
+/// #[macro_use(create_capability)]
+/// use kernel;
+///
+/// let process_mgmt_cap = create_capability!(ProcessManagementCapability);
+/// ```
 ///
 /// This helper macro can only be called in an `unsafe` block, and is used by
 /// trusted code to generate a capability that it can either use or pass to

--- a/kernel/src/common/utils.rs
+++ b/kernel/src/common/utils.rs
@@ -59,3 +59,19 @@ macro_rules! storage_volume {
         pub static $N: [u8; $kB * 1024] = [0x00; $kB * 1024];
     };
 }
+
+/// Create an object with the given capability.
+///
+///     let process_mgmt_cap = create_capability!(ProcessManagementCapability);
+///
+/// This helper macro can only be called in an `unsafe` block, and is used by
+/// trusted code to generate a capability that it can either use or pass to
+/// another module.
+#[macro_export]
+macro_rules! create_capability {
+    ($T:ty) => {{
+        struct Cap;
+        unsafe impl $T for Cap {}
+        Cap
+    };};
+}

--- a/kernel/src/ipc.rs
+++ b/kernel/src/ipc.rs
@@ -7,6 +7,7 @@
 pub const DRIVER_NUM: usize = 0x00010000;
 
 use callback::{AppId, Callback};
+use capabilities::MemoryAllocationCapability;
 use driver::Driver;
 use grant::Grant;
 use mem::{AppSlice, Shared};
@@ -35,9 +36,9 @@ pub struct IPC {
 }
 
 impl IPC {
-    pub unsafe fn new(kernel: &'static Kernel) -> IPC {
+    pub fn new(kernel: &'static Kernel, capability: &MemoryAllocationCapability) -> IPC {
         IPC {
-            data: kernel.create_grant(),
+            data: kernel.create_grant(capability),
         }
     }
 

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -17,6 +17,7 @@ extern crate tock_registers;
 
 pub use tock_registers::{register_bitfields, register_bitmasks};
 
+pub mod capabilities;
 #[macro_use]
 pub mod common;
 pub mod component;

--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -6,6 +6,7 @@ use core::ptr::NonNull;
 
 use callback;
 use callback::{AppId, Callback};
+use capabilities;
 use common::cells::NumericCellExt;
 use grant::Grant;
 use ipc;
@@ -132,7 +133,14 @@ impl Kernel {
     /// Processes use the number of grants that have been allocated to correctly
     /// initialize the process's memory with a pointer for each grant. If a
     /// grant is created after processes are initialized this will panic.
-    pub fn create_grant<T: Default>(&'static self) -> Grant<T> {
+    ///
+    /// Calling this function is restricted to only certain users, and to
+    /// enforce this calling this function requires the
+    /// `MemoryAllocationCapability` capability.
+    pub fn create_grant<T: Default>(
+        &'static self,
+        _capability: &capabilities::MemoryAllocationCapability,
+    ) -> Grant<T> {
         if self.grants_finalized.get() {
             panic!("Grants finalized. Cannot create a new grant.");
         }
@@ -161,6 +169,7 @@ impl Kernel {
         platform: &P,
         chip: &mut C,
         ipc: Option<&ipc::IPC>,
+        _capability: &capabilities::MainLoopCapability,
     ) {
         loop {
             unsafe {


### PR DESCRIPTION
### Pull Request Overview

This pull request adds a new concept to the kernel crate: capabilities. Capabilities are a mechanism for restricting access to certain functions to only callers that can prove they have been granted the correct capability.

Right now, we are doing this by marking functions as `unsafe` to restrict which code can call them. This works, but is very blunt: modules can either call all or none of the functions. Capabilities provide a mechanism for more nuanced access.

Ultimately, however, we are relying on rust and `unsafe` to limit what code can grant capabilities. Only crates that can use `unsafe` can grant capabilities.

The goal is that board setup files can generate capabilities, and will selectively pass capabilities to capsules.

For more, see the comments in `capabilities.rs` and #957.




### Testing Strategy

This pull request was tested by compiling.


### TODO or Help Wanted

Credit for this largely goes to Amit. This is probably only a starting point, but it would be good to see if there are changes we should make before adding this concept to Tock.


### Documentation Updated

- [ ] Kernel: Updated the relevant files in `/docs`, or no updates are required.
- [ ] Userland: Added/updated the application README, if needed.

### Formatting

- [ ] Ran `make formatall`.
