### PR TITLE
kernel: hide constructors

### DIFF
--- a/kernel/src/callback.rs
+++ b/kernel/src/callback.rs
@@ -14,11 +14,11 @@ pub struct AppId {
 const KERNEL_APPID_BOUNDARY: usize = 100;
 
 impl AppId {
-    pub fn new(idx: usize) -> AppId {
+    pub(crate) fn new(idx: usize) -> AppId {
         AppId { idx: idx }
     }
 
-    pub const fn kernel_new(idx: usize) -> AppId {
+    pub(crate) const fn kernel_new(idx: usize) -> AppId {
         AppId { idx: idx }
     }
 
@@ -58,7 +58,7 @@ pub struct Callback {
 }
 
 impl Callback {
-    pub fn new(appid: AppId, appdata: usize, fn_ptr: NonNull<*mut ()>) -> Callback {
+    pub(crate) fn new(appid: AppId, appdata: usize, fn_ptr: NonNull<*mut ()>) -> Callback {
         Callback {
             app_id: appid,
             appdata: appdata,
@@ -66,7 +66,10 @@ impl Callback {
         }
     }
 
-    pub const fn kernel_new(appid: AppId, fn_ptr: fn(usize, usize, usize, usize)) -> Callback {
+    pub(crate) const fn kernel_new(
+        appid: AppId,
+        fn_ptr: fn(usize, usize, usize, usize),
+    ) -> Callback {
         Callback {
             app_id: appid,
             appdata: 0,

--- a/kernel/src/grant.rs
+++ b/kernel/src/grant.rs
@@ -54,7 +54,7 @@ pub struct Owned<T: ?Sized> {
 }
 
 impl<T: ?Sized> Owned<T> {
-    pub unsafe fn new(data: *mut T, app_id: usize) -> Owned<T> {
+    unsafe fn new(data: *mut T, app_id: usize) -> Owned<T> {
         Owned {
             data: Unique::new_unchecked(data),
             app_id: app_id,

--- a/kernel/src/mem.rs
+++ b/kernel/src/mem.rs
@@ -20,7 +20,7 @@ pub struct AppPtr<L, T> {
 }
 
 impl<L, T> AppPtr<L, T> {
-    pub unsafe fn new(ptr: *mut T, appid: AppId) -> AppPtr<L, T> {
+    unsafe fn new(ptr: *mut T, appid: AppId) -> AppPtr<L, T> {
         AppPtr {
             ptr: Unique::new_unchecked(ptr),
             process: appid,

--- a/kernel/src/mem.rs
+++ b/kernel/src/mem.rs
@@ -62,10 +62,12 @@ pub struct AppSlice<L, T> {
 }
 
 impl<L, T> AppSlice<L, T> {
-    pub unsafe fn new(ptr: *mut T, len: usize, appid: AppId) -> AppSlice<L, T> {
-        AppSlice {
-            ptr: AppPtr::new(ptr, appid),
-            len: len,
+    pub(crate) fn new(ptr: *mut T, len: usize, appid: AppId) -> AppSlice<L, T> {
+        unsafe {
+            AppSlice {
+                ptr: AppPtr::new(ptr, appid),
+                len: len,
+            }
         }
     }
 


### PR DESCRIPTION
### Pull Request Overview

A couple of kernel data structures had public constructors (the `new()` function) while also being exported publicly from the kernel crate. This means that any code could create these data structures, which violates the safety expectations of the kernel.

These structs need to be public outside of the kernel crate so that capsules and other modules can use them. However, the constructor should be private to the kernel create. One sorta solution is to mark the constructors as `unsafe`. This restricts capsules from creating them, but would allow other trusted code to errantly create them.

The solution this PR uses is to make the constructor private, but then add a helper function in the same module that calls the constructor. So:

```rust
// This struct is public and exported outside of the kernel crate.
pub struct AppId {}

impl AppId {
  // This constructor is private to just this module.
  fn new(...) -> AppId {
    AppId {
      ..
    }
  }
}

// This function is public, but isn't exported outside
// the kernel crate. Therefore kernel modules can create
// AppIds, but not any other code.
pub fn create_appid(...) -> AppId {
  AppId::new(...)
}
```


### Testing Strategy

This pull request was tested by compiling.


### TODO or Help Wanted

There may be other ways to do this. The main downside that I can see is that this is very implicit in nature: it only works if we are careful about what `lib.rs` exports. For example, adding `create_appid()` to what is publicly exported from the kernel crate completely defeats this, yet requires no changes to the callback.rs file.


### Documentation Updated

- [x] Kernel: Updated the relevant files in `/docs`, or no updates are required.
- [x] Userland: Added/updated the application README, if needed.

### Formatting

- [x] Ran `make formatall`.
