### PR TITLE
kernel: move main to sched.rs

### DIFF
--- a/boards/ek-tm4c1294xl/src/main.rs
+++ b/boards/ek-tm4c1294xl/src/main.rs
@@ -204,5 +204,5 @@ pub unsafe fn reset_handler() {
         &mut PROCESSES,
         FAULT_RESPONSE,
     );
-    kernel::main(&tm4c1294, &mut chip, &mut PROCESSES, Some(&tm4c1294.ipc));
+    kernel::kernel_loop(&tm4c1294, &mut chip, &mut PROCESSES, Some(&tm4c1294.ipc));
 }

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -496,5 +496,5 @@ pub unsafe fn reset_handler() {
         &mut PROCESSES,
         FAULT_RESPONSE,
     );
-    kernel::main(&hail, &mut chip, &mut PROCESSES, Some(&hail.ipc));
+    kernel::kernel_loop(&hail, &mut chip, &mut PROCESSES, Some(&hail.ipc));
 }

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -652,5 +652,5 @@ pub unsafe fn reset_handler() {
         FAULT_RESPONSE,
     );
 
-    kernel::main(&imix, &mut chip, &mut PROCESSES, Some(&imix.ipc));
+    kernel::kernel_loop(&imix, &mut chip, &mut PROCESSES, Some(&imix.ipc));
 }

--- a/boards/launchxl/src/main.rs
+++ b/boards/launchxl/src/main.rs
@@ -224,7 +224,7 @@ pub unsafe fn reset_handler() {
         FAULT_RESPONSE,
     );
 
-    kernel::main(
+    kernel::kernel_loop(
         &launchxl,
         &mut chip,
         &mut PROCESSES,

--- a/boards/nordic/nrf51dk/src/main.rs
+++ b/boards/nordic/nrf51dk/src/main.rs
@@ -345,7 +345,7 @@ pub unsafe fn reset_handler() {
         FAULT_RESPONSE,
     );
 
-    kernel::main(
+    kernel::kernel_loop(
         &platform,
         &mut chip,
         &mut PROCESSES,

--- a/boards/nordic/nrf52dk_base/Cargo.lock
+++ b/boards/nordic/nrf52dk_base/Cargo.lock
@@ -1,9 +1,4 @@
 [[package]]
-name = "bitfield"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "capsules"
 version = "0.1.0"
 dependencies = [
@@ -30,7 +25,6 @@ version = "0.1.0"
 name = "nrf52"
 version = "0.1.0"
 dependencies = [
- "bitfield 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cortexm4 0.1.0",
  "kernel 0.1.0",
  "nrf5x 0.1.0",
@@ -54,5 +48,3 @@ dependencies = [
  "kernel 0.1.0",
 ]
 
-[metadata]
-"checksum bitfield 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f989ae9b9fff3271a712a309fce47f0c46dd3476cb40074ddfcc06ad4a76cf6a"

--- a/boards/nordic/nrf52dk_base/src/lib.rs
+++ b/boards/nordic/nrf52dk_base/src/lib.rs
@@ -234,5 +234,5 @@ pub unsafe fn setup_board(
         app_fault_response,
     );
 
-    kernel::main(&platform, &mut chip, process_pointers, Some(&platform.ipc));
+    kernel::kernel_loop(&platform, &mut chip, process_pointers, Some(&platform.ipc));
 }

--- a/doc/courses/sensys/exercises/board/src/main.rs
+++ b/doc/courses/sensys/exercises/board/src/main.rs
@@ -486,5 +486,5 @@ pub unsafe fn reset_handler() {
     );
 
     // Begin kernel main loop
-    kernel::main(&hail, &mut chip, &mut PROCESSES, Some(&hail.ipc));
+    kernel::kernel_loop(&hail, &mut chip, &mut PROCESSES, Some(&hail.ipc));
 }

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -37,6 +37,7 @@ pub use platform::systick::SysTick;
 pub use platform::{mpu, Chip, Platform};
 pub use platform::{ClockInterface, NoClockControl, NO_CLOCK_CONTROL};
 pub use returncode::ReturnCode;
+pub use sched::kernel_loop;
 
 // Export only select items from the process module. To remove the name conflict
 // this cannot be called `process`, so we use a shortened version. These
@@ -44,38 +45,4 @@ pub use returncode::ReturnCode;
 // processes.
 pub mod procs {
     pub use process::{load_processes, FaultResponse, Process};
-}
-
-/// Main loop.
-pub fn main<P: Platform, C: Chip>(
-    platform: &P,
-    chip: &mut C,
-    processes: &'static mut [Option<&mut process::Process<'static>>],
-    ipc: Option<&ipc::IPC>,
-) {
-    let processes = unsafe {
-        process::PROCS = processes;
-        &mut process::PROCS
-    };
-
-    loop {
-        unsafe {
-            chip.service_pending_interrupts();
-
-            for (i, p) in processes.iter_mut().enumerate() {
-                p.as_mut().map(|process| {
-                    sched::do_process(platform, chip, process, callback::AppId::new(i), ipc);
-                });
-                if chip.has_pending_interrupts() {
-                    break;
-                }
-            }
-
-            chip.atomic(|| {
-                if !chip.has_pending_interrupts() && process::processes_blocked() {
-                    chip.sleep();
-                }
-            });
-        };
-    }
 }


### PR DESCRIPTION
### Pull Request Overview

`main()` was in lib.rs, which was a little tricky to find. Also `do_process()` in sched.rs had to be public, but is only called in one place. This merges the two, so all scheduling and main loop code is in the same place, and renames the file to main.rs so it is obvious where everything starts.



### Testing Strategy

This pull request was tested by compiling.


### TODO or Help Wanted

I think this is easier to understand, but there may be good reasons to leave it as it was.


### Documentation Updated

- [x] Kernel: Updated the relevant files in `/docs`, or no updates are required.
- [x] Userland: Added/updated the application README, if needed.

### Formatting

- [x] Ran `make formatall`.
