### PR TITLE
Create crate for Tock Registers

### DIFF
--- a/boards/ek-tm4c1294xl/Cargo.lock
+++ b/boards/ek-tm4c1294xl/Cargo.lock
@@ -33,6 +33,9 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.1.0"
+dependencies = [
+ "tock-regs 0.1.0",
+]
 
 [[package]]
 name = "tm4c129x"
@@ -41,4 +44,8 @@ dependencies = [
  "cortexm4 0.1.0",
  "kernel 0.1.0",
 ]
+
+[[package]]
+name = "tock-regs"
+version = "0.1.0"
 

--- a/boards/hail/Cargo.lock
+++ b/boards/hail/Cargo.lock
@@ -33,6 +33,9 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.1.0"
+dependencies = [
+ "tock-regs 0.1.0",
+]
 
 [[package]]
 name = "sam4l"
@@ -41,4 +44,8 @@ dependencies = [
  "cortexm4 0.1.0",
  "kernel 0.1.0",
 ]
+
+[[package]]
+name = "tock-regs"
+version = "0.1.0"
 

--- a/boards/imix/Cargo.lock
+++ b/boards/imix/Cargo.lock
@@ -33,6 +33,9 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.1.0"
+dependencies = [
+ "tock-regs 0.1.0",
+]
 
 [[package]]
 name = "sam4l"
@@ -41,4 +44,8 @@ dependencies = [
  "cortexm4 0.1.0",
  "kernel 0.1.0",
 ]
+
+[[package]]
+name = "tock-regs"
+version = "0.1.0"
 

--- a/boards/launchxl/Cargo.lock
+++ b/boards/launchxl/Cargo.lock
@@ -39,6 +39,9 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.1.0"
+dependencies = [
+ "tock-regs 0.1.0",
+]
 
 [[package]]
 name = "launchxl"
@@ -50,4 +53,8 @@ dependencies = [
  "cortexm4 0.1.0",
  "kernel 0.1.0",
 ]
+
+[[package]]
+name = "tock-regs"
+version = "0.1.0"
 

--- a/boards/nordic/nrf51dk/Cargo.lock
+++ b/boards/nordic/nrf51dk/Cargo.lock
@@ -23,6 +23,9 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.1.0"
+dependencies = [
+ "tock-regs 0.1.0",
+]
 
 [[package]]
 name = "nrf51"
@@ -50,4 +53,8 @@ version = "0.1.0"
 dependencies = [
  "kernel 0.1.0",
 ]
+
+[[package]]
+name = "tock-regs"
+version = "0.1.0"
 

--- a/boards/nordic/nrf52840dk/Cargo.lock
+++ b/boards/nordic/nrf52840dk/Cargo.lock
@@ -23,6 +23,9 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.1.0"
+dependencies = [
+ "tock-regs 0.1.0",
+]
 
 [[package]]
 name = "nrf52"
@@ -62,4 +65,8 @@ version = "0.1.0"
 dependencies = [
  "kernel 0.1.0",
 ]
+
+[[package]]
+name = "tock-regs"
+version = "0.1.0"
 

--- a/boards/nordic/nrf52dk/Cargo.lock
+++ b/boards/nordic/nrf52dk/Cargo.lock
@@ -23,6 +23,9 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.1.0"
+dependencies = [
+ "tock-regs 0.1.0",
+]
 
 [[package]]
 name = "nrf52"
@@ -62,4 +65,8 @@ version = "0.1.0"
 dependencies = [
  "kernel 0.1.0",
 ]
+
+[[package]]
+name = "tock-regs"
+version = "0.1.0"
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -20,6 +20,7 @@ Tock Guides
 - **[Tock Binary Format](TockBinaryFormat.md)** - How Tock application binaries are specified.
 - **[Memory Layout](Memory_Layout.md)** - How memory is divided for Tock.
 - **[Memory Isolation](Memory_Isolation.md)** - How memory is isolated in Tock.
+- **[Registers](../tools/tock-register-interface/README.md)** - How memory-mapped registers are handled in Tock.
 - **[Startup](Startup.md)** - What happens when Tock boots.
 - **[Syscalls](Syscalls.md)** - Kernel/Userland abstraction.
 - **[Userland](Userland.md)** - Description of userland applications.

--- a/doc/courses/sensys/exercises/board/Cargo.lock
+++ b/doc/courses/sensys/exercises/board/Cargo.lock
@@ -34,6 +34,9 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.1.0"
+dependencies = [
+ "tock-regs 0.1.0",
+]
 
 [[package]]
 name = "sam4l"
@@ -49,4 +52,8 @@ version = "0.1.0"
 dependencies = [
  "kernel 0.1.0",
 ]
+
+[[package]]
+name = "tock-regs"
+version = "0.1.0"
 

--- a/kernel/src/common/mod.rs
+++ b/kernel/src/common/mod.rs
@@ -6,12 +6,12 @@
 //! they provide safe wrappers around unsafe interface so that other kernel
 //! crates do not need to use unsafe code.
 
+pub use tock_regs::*;
+
 pub mod deferred_call;
 pub mod list;
 pub mod math;
 pub mod peripherals;
-#[macro_use]
-pub mod regs;
 pub mod utils;
 
 mod map_cell;

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -9,7 +9,12 @@
 #![feature(asm, core_intrinsics, unique, nonzero, ptr_internals)]
 #![feature(const_fn, const_cell_new, const_unsafe_cell_new, lang_items)]
 #![feature(nonnull_cast)]
+#![feature(use_extern_macros)]
 #![no_std]
+
+extern crate tock_regs;
+
+pub use tock_regs::{register_bitfields, register_bitmasks};
 
 #[macro_use]
 pub mod common;

--- a/tools/tock-register-interface/Cargo.lock
+++ b/tools/tock-register-interface/Cargo.lock
@@ -1,0 +1,4 @@
+[root]
+name = "tock-regs"
+version = "0.1.0"
+

--- a/tools/tock-register-interface/Cargo.toml
+++ b/tools/tock-register-interface/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
-name = "kernel"
+name = "tock-regs"
 version = "0.1.0"
+description = "Register interface used for Tock"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
 
 [dependencies]
-tock-regs = { path = "../tools/tock-register-interface" }

--- a/tools/tock-register-interface/README.md
+++ b/tools/tock-register-interface/README.md
@@ -1,4 +1,4 @@
-# Register/Bitfield Interface for Tock
+# Tock Register Interface
 
 This module provides an interface for defining and manipulating memory mapped
 registers and bitfields.

--- a/tools/tock-register-interface/README.md
+++ b/tools/tock-register-interface/README.md
@@ -1,11 +1,11 @@
 # Tock Register Interface
 
-This module provides an interface for defining and manipulating memory mapped
+This crate provides an interface for defining and manipulating memory mapped
 registers and bitfields.
 
 ## Defining registers
 
-The module provides three types for working with memory mapped registers:
+The crate provides three types for working with memory mapped registers:
 `ReadWrite`, `ReadOnly`, and `WriteOnly`, providing read-write, read-only, and
 write-only functionality, respectively.
 
@@ -13,7 +13,7 @@ Defining the registers is similar to the C-style approach, where each register
 is a field in a packed struct:
 
 ```rust
-use common::regs::{ReadOnly, ReadWrite, WriteOnly};
+use tock_regs::regs::{ReadOnly, ReadWrite, WriteOnly};
 
 #[repr(C)]
 struct Registers {
@@ -253,8 +253,6 @@ fields simultaneously.
 
 ## Performance
 
-TODO: specific study
-
 Examining the binaries while testing this interface, everything compiles
 down to the optimal inclined bit twiddling instructions--in other words, there is
 zero runtime cost, as far as my informal preliminary study has found. I will
@@ -285,7 +283,7 @@ There are several related names in the register definitions. Below is a
 description of the naming convention for each:
 
 ```rust
-use common::regs::ReadWrite;
+use tock_regs::regs::ReadWrite;
 
 #[repr(C)]
 struct Registers {

--- a/tools/tock-register-interface/src/lib.rs
+++ b/tools/tock-register-interface/src/lib.rs
@@ -1,0 +1,11 @@
+//! Tock Register Interface
+//!
+//!
+
+#![feature(const_fn)]
+#![no_std]
+
+pub mod regs;
+
+#[macro_use]
+pub mod macros;

--- a/tools/tock-register-interface/src/macros.rs
+++ b/tools/tock-register-interface/src/macros.rs
@@ -63,7 +63,7 @@ macro_rules! register_bitmasks {
         $(#[$outer])*
         pub mod $field {
             #[allow(unused_imports)]
-            use $crate::common::regs::FieldValue;
+            use $crate::regs::FieldValue;
             use super::$reg_desc;
 
             $(
@@ -112,9 +112,9 @@ macro_rules! register_bitfields {
             pub mod $reg {
                 #[derive(Clone, Copy)]
                 pub struct Register;
-                impl $crate::common::regs::RegisterLongName for Register {}
+                impl $crate::regs::RegisterLongName for Register {}
 
-                use $crate::common::regs::Field;
+                use $crate::regs::Field;
 
                 register_bitmasks!( $valtype, Register, $fields );
             }

--- a/tools/tock-register-interface/src/regs.rs
+++ b/tools/tock-register-interface/src/regs.rs
@@ -290,8 +290,8 @@ impl<R: RegisterLongName> From<LocalRegisterCopy<u32, R>> for u32 {
 /// Specific section of a register.
 #[derive(Copy, Clone)]
 pub struct Field<T: IntLike, R: RegisterLongName> {
-    mask: T,
-    shift: u32,
+    pub mask: T,
+    pub shift: u32,
     associated_register: PhantomData<R>,
 }
 
@@ -343,8 +343,8 @@ impl<R: RegisterLongName> Field<u32, R> {
 // location in the register.
 #[derive(Copy, Clone)]
 pub struct FieldValue<T: IntLike, R: RegisterLongName> {
-    mask: T,
-    value: T,
+    pub mask: T,
+    pub value: T,
     associated_register: PhantomData<R>,
 }
 

--- a/tools/tock-register-interface/src/regs.rs
+++ b/tools/tock-register-interface/src/regs.rs
@@ -26,16 +26,13 @@
 //!         MODE        OFFSET(4) NUMBITS(3) [
 //!             FullDuplex = 0,
 //!             HalfDuplex = 1,
-//!         Loopback = 2,
+//!             Loopback = 2,
 //!             Disabled = 3
 //!         ],
 //!         ERRORCOUNT OFFSET(6) NUMBITS(3) []
 //!     ]
 //! ];
 //! ```
-
-#[macro_use]
-pub mod macros;
 
 use core::fmt;
 use core::marker::PhantomData;

--- a/tools/tock-register-interface/src/regs.rs
+++ b/tools/tock-register-interface/src/regs.rs
@@ -33,6 +33,10 @@
 //!     ]
 //! ];
 //! ```
+//!
+//! Author
+//! ------
+//! - Shane Leonard <shanel@stanford.edu>
 
 use core::fmt;
 use core::marker::PhantomData;


### PR DESCRIPTION
### Pull Request Overview

This PR creates a separate crate for the Tock register interface (named `tock-regs`) and moves the code to `tools/tock-register-interface/`. While this change affects many files throughout Tock, almost all of them are just changes to the import statement. Additionally, `Cargo.toml` files have changed to reference the new crate, and documentation has been updated.

The driver for this change is to allow other projects to use or extend Tock registers. In order to support this, the `mask` and `shift` fields of `Field` as well as the `mask` and `value` fields of `FieldValue` are made public.

An example of using this crate in an external project can be found [here](https://github.com/brghena/tock-register-example) based off of examples from @niklasad1 and @andre-richter. This example both uses Tock registers and extends them with additional functionality. Unfortunately, the first build of this example repo takes a considerable amount of time (several minutes) because using the Tock registers crate requires a clone of the entire Tock repo. Subsequent builds are quick, however.

Closes #930.

### Testing Strategy

Compiling all boards.


### TODO or Help Wanted

None


### Documentation Updated

- [X] Kernel: Updated the relevant files in `/docs`, or no updates are required.
- N/A ~Userland: Added/updated the application README, if needed.~

### Formatting

- [X] Ran `make formatall`.
