### PR TITLE
Sam4l staticref

### DIFF
--- a/chips/sam4l/src/bpm.rs
+++ b/chips/sam4l/src/bpm.rs
@@ -1,6 +1,7 @@
 //! Implementation of the BPM peripheral.
 
 use kernel::common::regs::{ReadOnly, ReadWrite, WriteOnly};
+use kernel::common::StaticRef;
 
 #[repr(C)]
 struct BpmRegisters {
@@ -125,10 +126,9 @@ register_bitfields![u32,
     ]
 ];
 
-const BPM_BASE: usize = 0x400F0000;
 const BPM_UNLOCK_KEY: u32 = 0xAA;
 
-static mut BPM: *mut BpmRegisters = BPM_BASE as *mut BpmRegisters;
+const BPM: StaticRef<BpmRegisters> = unsafe { StaticRef::new(0x400F0000 as *const BpmRegisters) };
 
 /// Which power scaling mode the chip should use for internal voltages
 ///
@@ -166,21 +166,19 @@ pub enum CK32Source {
 
 #[inline(never)]
 pub unsafe fn set_ck32source(source: CK32Source) {
-    let control = (*BPM).pmcon.extract();
+    let control = BPM.pmcon.extract();
     unlock_register(0x1c); // Control
-    (*BPM)
-        .pmcon
+    BPM.pmcon
         .modify_no_read(control, PowerModeControl::CK32S.val(source as u32));
 }
 
 unsafe fn unlock_register(register_offset: u32) {
-    (*BPM)
-        .unlock
+    BPM.unlock
         .write(Unlock::KEY.val(BPM_UNLOCK_KEY) + Unlock::ADDR.val(register_offset));
 }
 
 unsafe fn power_scaling_ok() -> bool {
-    (*BPM).sr.is_set(Status::PSOK)
+    BPM.sr.is_set(Status::PSOK)
 }
 
 // This approach based on `bpm_power_scaling_cpu` from ASF
@@ -189,13 +187,13 @@ pub unsafe fn set_power_scaling(ps_value: PowerScaling) {
     // doesn't as far as I can tell, but it seems like a good idea
     while !power_scaling_ok() {}
 
-    let control = (*BPM).pmcon.extract();
+    let control = BPM.pmcon.extract();
 
     // Unlock PMCON register
     unlock_register(0x1c); // Control
 
     // Actually change power scaling
-    (*BPM).pmcon.modify_no_read(
+    BPM.pmcon.modify_no_read(
         control,
         PowerModeControl::PS.val(ps_value as u32) + PowerModeControl::PSCM::WithoutCpuHalt
             + PowerModeControl::PSCREQ::PowerScalingRequested,

--- a/chips/sam4l/src/bscif.rs
+++ b/chips/sam4l/src/bscif.rs
@@ -1,6 +1,7 @@
 //! Implementation of the Backup System Control Interface (BSCIF) peripheral.
 
 use kernel::common::regs::{ReadOnly, ReadWrite, WriteOnly};
+use kernel::common::StaticRef;
 
 #[repr(C)]
 struct BscifRegisters {
@@ -314,69 +315,69 @@ register_bitfields![u32,
     ]
 ];
 
-const BSCIF_BASE: usize = 0x400F0400;
-static mut BSCIF: *mut BscifRegisters = BSCIF_BASE as *mut BscifRegisters;
+const BSCIF: StaticRef<BscifRegisters> =
+    unsafe { StaticRef::new(0x400F0400 as *const BscifRegisters) };
 
 /// Setup the internal 32kHz RC oscillator.
-pub unsafe fn enable_rc32k() {
-    let rc32kcr = (*BSCIF).rc32kcr.extract();
+pub fn enable_rc32k() {
+    let rc32kcr = BSCIF.rc32kcr.extract();
     // Unlock the BSCIF::RC32KCR register
-    (*BSCIF)
+    BSCIF
         .unlock
         .write(Unlock::KEY.val(0xAA) + Unlock::ADDR.val(0x24));
     // Write the BSCIF::RC32KCR register.
     // Enable the generic clock source, the temperature compensation, and the
     // 32k output.
-    (*BSCIF).rc32kcr.modify_no_read(
+    BSCIF.rc32kcr.modify_no_read(
         rc32kcr,
         RC32Control::EN32K::OutputEnable + RC32Control::TCEN::TempCompensated
             + RC32Control::EN::GclkSourceEnable,
     );
     // Wait for it to be ready, although it feels like this won't do anything
-    while !(*BSCIF).rc32kcr.is_set(RC32Control::EN) {}
+    while !BSCIF.rc32kcr.is_set(RC32Control::EN) {}
 
     // Load magic calibration value for the 32KHz RC oscillator
     //
     // Unlock the BSCIF::RC32KTUNE register
-    (*BSCIF)
+    BSCIF
         .unlock
         .write(Unlock::KEY.val(0xAA) + Unlock::ADDR.val(0x28));
     // Write the BSCIF::RC32KTUNE register
-    (*BSCIF)
+    BSCIF
         .rc32ktune
         .write(RC32kTuning::COARSE.val(0x1d) + RC32kTuning::FINE.val(0x15));
 }
 
-pub unsafe fn rc32k_enabled() -> bool {
-    return (*BSCIF).rc32kcr.is_set(RC32Control::EN);
+pub fn rc32k_enabled() -> bool {
+    return BSCIF.rc32kcr.is_set(RC32Control::EN);
 }
 
-pub unsafe fn setup_rc_1mhz() {
-    let rc1mcr = (*BSCIF).rc1mcr.extract();
+pub fn setup_rc_1mhz() {
+    let rc1mcr = BSCIF.rc1mcr.extract();
     // Unlock the BSCIF::RC32KCR register
-    (*BSCIF)
+    BSCIF
         .unlock
         .write(Unlock::KEY.val(0xAA) + Unlock::ADDR.val(0x58));
     // Enable the RC1M
-    (*BSCIF)
+    BSCIF
         .rc1mcr
         .modify_no_read(rc1mcr, RC1MClockConfig::CLKOEN::Output);
 
     // Wait for the RC1M to be enabled
-    while !(*BSCIF).rc1mcr.is_set(RC1MClockConfig::CLKOEN) {}
+    while !BSCIF.rc1mcr.is_set(RC1MClockConfig::CLKOEN) {}
 }
 
 pub unsafe fn disable_rc_1mhz() {
-    let rc1mcr = (*BSCIF).rc1mcr.extract();
+    let rc1mcr = BSCIF.rc1mcr.extract();
     // Unlock the BSCIF::RC32KCR register
-    (*BSCIF)
+    BSCIF
         .unlock
         .write(Unlock::KEY.val(0xAA) + Unlock::ADDR.val(0x58));
     // Disable the RC1M
-    (*BSCIF)
+    BSCIF
         .rc1mcr
         .modify_no_read(rc1mcr, RC1MClockConfig::CLKOEN::NotOutput);
 
     // Wait for the RC1M to be disabled
-    while (*BSCIF).rc1mcr.is_set(RC1MClockConfig::CLKOEN) {}
+    while BSCIF.rc1mcr.is_set(RC1MClockConfig::CLKOEN) {}
 }


### PR DESCRIPTION
### Pull Request Overview

This pull request updates the SAM4L to use `StaticRef`.


### Testing Strategy

Need to run some test apps.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Kernel: Updated the relevant files in `/docs`, or no updates are required.
- [x] Userland: Added/updated the application README, if needed.

### Formatting

- [x] Ran `make formatall`.


### Notes about unsafe

Running `git grep unsafe` in the sam4l crate returns:

```
src/adc.rs:    unsafe { StaticRef::new(0x40038000 as *const AdcRegisters) };
src/adc.rs:                let buf_ptr = unsafe { mem::transmute::<*mut u8, *mut u16>(dma_buf.as_mut_ptr()) };
src/adc.rs:                let buf = unsafe { slice::from_raw_parts_mut(buf_ptr, dma_buf.len() / 2) };
src/adc.rs:            // this is unsafe but acceptable for the following reasons
src/adc.rs:            let dma_buf_ptr = unsafe { mem::transmute::<*mut u16, *mut u8>(buffer1.as_mut_ptr()) };
src/adc.rs:            let dma_buf = unsafe { slice::from_raw_parts_mut(dma_buf_ptr, buffer1.len() * 2) };
src/adc.rs:                    // this is unsafe but acceptable for the following reasons
src/adc.rs:                        unsafe { mem::transmute::<*mut u16, *mut u8>(buf.as_mut_ptr()) };
src/adc.rs:                    let dma_buf = unsafe { slice::from_raw_parts_mut(dma_buf_ptr, buf.len() * 2) };
src/adc.rs:                        unsafe { mem::transmute::<*mut u8, *mut u16>(dma_buf.as_mut_ptr()) };
src/adc.rs:                    let buf = unsafe { slice::from_raw_parts_mut(buf_ptr, dma_buf.len() / 2) };
src/aes.rs:    unsafe { StaticRef::new(0x400B0000 as *const AesRegisters) };
src/ast.rs:    unsafe { StaticRef::new(0x400F0800 as *const AstRegisters) };
src/bpm.rs:const BPM: StaticRef<BpmRegisters> = unsafe { StaticRef::new(0x400F0000 as *const BpmRegisters) };
src/bpm.rs:pub unsafe fn set_ck32source(source: CK32Source) {
src/bpm.rs:unsafe fn unlock_register(register_offset: u32) {
src/bpm.rs:unsafe fn power_scaling_ok() -> bool {
src/bpm.rs:pub unsafe fn set_power_scaling(ps_value: PowerScaling) {
src/bscif.rs:    unsafe { StaticRef::new(0x400F0400 as *const BscifRegisters) };
src/bscif.rs:pub unsafe fn disable_rc_1mhz() {
src/chip.rs:    pub unsafe fn new() -> Sam4l {
src/chip.rs:        unsafe {
src/chip.rs:        unsafe { cortexm4::nvic::has_pending() || deferred_call::has_tasks() }
src/chip.rs:            unsafe {
src/chip.rs:            unsafe {
src/chip.rs:        unsafe {
src/chip.rs:    unsafe fn atomic<F, R>(&self, f: F) -> R
src/crccu.rs:    unsafe { StaticRef::new(0x400A4000 as *const CrccuRegisters) };
src/crccu.rs:        let d = unsafe { &mut *self.descriptor() };
src/crccu.rs:        let d = unsafe { &*self.descriptor() };
src/dac.rs:    unsafe { StaticRef::new(0x4003C000 as *const DacRegisters) };
src/dma.rs:            registers: unsafe {
src/dma.rs:            unsafe {
src/dma.rs:            unsafe {
src/flashcalw.rs:    unsafe { StaticRef::new(0x400A0000 as *const FlashcalwRegisters) };
src/flashcalw.rs:static DEFERRED_CALL: DeferredCall<Task> = unsafe { DeferredCall::new(Task::Flashcalw) };
src/flashcalw.rs:            unsafe {
src/flashcalw.rs:        unsafe {
src/gpio.rs:    port: unsafe { StaticRef::new((BASE_ADDRESS + 0 * SIZE) as *const GpioRegisters) },
src/gpio.rs:    port: unsafe { StaticRef::new((BASE_ADDRESS + 1 * SIZE) as *const GpioRegisters) },
src/gpio.rs:    port: unsafe { StaticRef::new((BASE_ADDRESS + 2 * SIZE) as *const GpioRegisters) },
src/gpio.rs:            port: unsafe {
src/i2c.rs:const I2C_BASE_ADDRS: [StaticRef<TWIMRegisters>; 4] = unsafe {
src/i2c.rs:const I2C_SLAVE_BASE_ADDRS: [StaticRef<TWISRegisters>; 2] = unsafe {
src/lib.rs:unsafe extern "C" fn unhandled_interrupt() {
src/lib.rs:pub static BASE_VECTORS: [unsafe extern "C" fn(); 16] = [
src/lib.rs:pub static IRQS: [unsafe extern "C" fn(); 80] = [generic_isr; 80];
src/lib.rs:pub unsafe fn init() {
src/lib.rs:unsafe extern "C" fn hard_fault_handler() {
src/pm.rs:const PM_REGS: StaticRef<PmRegisters> = unsafe { StaticRef::new(PM_BASE as *const PmRegisters) };
src/pm.rs:    pub unsafe fn setup_system_clock(&self, clock_source: SystemClockSource) {
src/pm.rs:    pub unsafe fn disable_system_clock(&self, clock_source: SystemClockSource) {
src/pm.rs:    pub unsafe fn change_system_clock(&self, clock_source: SystemClockSource) {
src/pm.rs:unsafe fn configure_48mhz_dfll() {
src/pm.rs:unsafe fn configure_external_oscillator(
src/pm.rs:unsafe fn configure_external_oscillator_pll(
src/pm.rs:unsafe fn configure_80mhz_rc() {
src/pm.rs:unsafe fn configure_rcfast(frequency: RcfastFrequency) {
src/pm.rs:unsafe fn configure_1mhz_rc() {
src/pm.rs:    unsafe {
src/scif.rs:    unsafe { StaticRef::new(0x400E0800 as *const ScifRegisters) };
src/scif.rs:pub unsafe fn disable_dfll_rc32k() {
src/scif.rs:pub unsafe fn setup_osc_16mhz_fast_startup() {
src/scif.rs:pub unsafe fn setup_osc_16mhz_slow_startup() {
src/scif.rs:pub unsafe fn disable_osc_16mhz() {
src/scif.rs:pub unsafe fn setup_pll_osc_48mhz() {
src/scif.rs:pub unsafe fn disable_pll() {
src/scif.rs:pub unsafe fn setup_rc_80mhz() {
src/scif.rs:pub unsafe fn disable_rc_80mhz() {
src/scif.rs:pub unsafe fn setup_rcfast_4mhz() {
src/scif.rs:pub unsafe fn setup_rcfast_8mhz() {
src/scif.rs:pub unsafe fn setup_rcfast_12mhz() {
src/scif.rs:pub unsafe fn disable_rcfast() {
src/spi.rs:    unsafe { StaticRef::new(0x40008000 as *const SpiRegisters) };
src/trng.rs:    unsafe { StaticRef::new(0x40068000 as *const TrngRegisters) };
src/usart.rs:const USART_BASE_ADDRS: [StaticRef<UsartRegisters>; 4] = unsafe {
src/usbc/mod.rs:    unsafe { StaticRef::new(0x400A5000 as *const UsbcRegisters) };
src/usbc/mod.rs:                unsafe {
src/wdt.rs:    unsafe { StaticRef::new(WDT_BASE as *const WdtRegisters) };
```

so there is still a way to go.
