### PR TITLE
kernel: ring_buffer: remove volatile reads

### DIFF
--- a/kernel/src/common/ring_buffer.rs
+++ b/kernel/src/common/ring_buffer.rs
@@ -1,7 +1,6 @@
 //! Implementation of a ring buffer.
 
 use common::queue;
-use core::ptr::read_volatile;
 
 pub struct RingBuffer<'a, T: 'a> {
     ring: &'a mut [T],
@@ -21,25 +20,18 @@ impl<'a, T: Copy> RingBuffer<'a, T> {
 
 impl<'a, T: Copy> queue::Queue<T> for RingBuffer<'a, T> {
     fn has_elements(&self) -> bool {
-        unsafe {
-            let head = read_volatile(&self.head);
-            let tail = read_volatile(&self.tail);
-            head != tail
-        }
+        self.head != self.tail
     }
 
     fn is_full(&self) -> bool {
-        unsafe { read_volatile(&self.head) == ((read_volatile(&self.tail) + 1) % self.ring.len()) }
+        self.head == ((self.tail + 1) % self.ring.len())
     }
 
     fn len(&self) -> usize {
-        let head = unsafe { read_volatile(&self.head) };
-        let tail = unsafe { read_volatile(&self.tail) };
-
-        if tail > head {
-            tail - head
-        } else if tail < head {
-            (self.ring.len() - head) + tail
+        if self.tail > self.head {
+            self.tail - self.head
+        } else if self.tail < self.head {
+            (self.ring.len() - self.head) + self.tail
         } else {
             // head equals tail, length is zero
             0
@@ -47,16 +39,13 @@ impl<'a, T: Copy> queue::Queue<T> for RingBuffer<'a, T> {
     }
 
     fn enqueue(&mut self, val: T) -> bool {
-        unsafe {
-            let head = read_volatile(&self.head);
-            if ((self.tail + 1) % self.ring.len()) == head {
-                // Incrementing tail will overwrite head
-                return false;
-            } else {
-                self.ring[self.tail] = val;
-                self.tail = (self.tail + 1) % self.ring.len();
-                return true;
-            }
+        if ((self.tail + 1) % self.ring.len()) == self.head {
+            // Incrementing tail will overwrite head
+            return false;
+        } else {
+            self.ring[self.tail] = val;
+            self.tail = (self.tail + 1) % self.ring.len();
+            return true;
         }
     }
 


### PR DESCRIPTION
### Pull Request Overview

This removes the need for unsafe in `ring_buffer.rs`, and it isn't clear why the reads needed to be volatile.

### Testing Strategy

This pull request was tested by running the hail app.


### TODO or Help Wanted

Anyone know if those volatile reads and writes are still useful?


### Documentation Updated

- [x] Kernel: Updated the relevant files in `/docs`, or no updates are required.
- [x] Userland: Added/updated the application README, if needed.

### Formatting

- [x] Ran `make formatall`.
