### PR TITLE
Cortex-m3 crate didn't build

### DIFF
--- a/arch/cortex-m3/src/lib.rs
+++ b/arch/cortex-m3/src/lib.rs
@@ -3,8 +3,8 @@
 
 #[allow(unused_imports)]
 #[macro_use(debug, debug_gpio, register_bitfields, register_bitmasks)]
-extern crate cortexm;
 extern crate kernel;
+extern crate cortexm;
 
 // Re-export the base generic cortex-m functions here as they are
 // valid on cortex-m3.


### PR DESCRIPTION
### Pull Request Overview

The cortex-m3 arch crate builds again.

The deeper question is whether the cortex-m3 crate should be part of mainline Tock at all if nothing is using it. Unless we change our build system to build that crate particularly, it's going to get out of date again.


### Testing Strategy

Set Hail to require cortex-m3 arch in its Cargo.toml and built. Hail fails to build (missing cortex-m4), but the cortex-m3 crate itself now does.


### TODO or Help Wanted

None


### Documentation Updated

- N/A ~Kernel: Updated the relevant files in `/docs`, or no updates are required.~
- N/A ~Userland: Added/updated the application README, if needed.~

### Formatting

- [X] Ran `make formatall`.
