### PR TITLE
Move userland docs to libtock-c

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Learn More
 
 How would you like to get started?
 
-### Learn How Tock Works 
+### Learn How Tock Works
 
 Tock is documented in the [doc](doc) folder. Read through the guides there to
 learn about the overview and design of Tock, its implementation, and much
@@ -30,12 +30,15 @@ more.
 ### Use Tock
 
 Follow our [getting started guide](doc/Getting_Started.md) to set up your
-system to compile Tock and Tock applications.
+system to compile Tock.
 
 Head to the [hardware page](https://www.tockos.org/hardware/)
 to learn about the hardware platforms Tock supports. Also check out the
 [workshop-style courses](doc/courses) to get started running apps with TockOS.
 
+Find example applications that run on top of the Tock kernel written in both
+[Rust](https://github.com/tock/libtock-rs) and
+[C](https://github.com/tock/libtock-c).
 
 ### Develop Tock
 

--- a/doc/Compilation.md
+++ b/doc/Compilation.md
@@ -18,16 +18,6 @@ of how platforms program each onto an actual board.
   * [Tock Application Bundle](#tock-application-bundle)
     + [TAB Format](#tab-format)
     + [Metadata](#metadata)
-  * [Tock userland compilation environment](#tock-userland-compilation-environment)
-    + [Customizing the build](#customizing-the-build)
-      - [Flags](#flags)
-      - [Application configuration](#application-configuration)
-      - [Advanced](#advanced)
-    + [Compiling Libraries for Tock](#compiling-libraries-for-tock)
-      - [Let Tock do the work: TockLibrary.mk](#let-tock-do-the-work-tocklibrarymk)
-      - [Developing (building) libraries concurrently with applications](#developing-building-libraries-concurrently-with-applications)
-      - [Pre-built libraries](#pre-built-libraries)
-      - [Manually including libraries](#manually-including-libraries)
 - [Loading the kernel and processes onto a board](#loading-the-kernel-and-processes-onto-a-board)
 
 <!-- tocstop -->
@@ -100,8 +90,7 @@ Unlike many other embedded systems, compilation of application code is entirely
 separated from the kernel in Tock. An application is combined with at least two
 libraries: `libtock` and `newlib` and built into a free-standing binary. The
 binary can then be uploaded onto a Tock platform with an already existing
-kernel to be loaded and run. For more details about application code, see
-[Userland](./Userland.md).
+kernel to be loaded and run.
 
 Currently, all Tock platforms are ARM Cortex-M processors and all existing
 applications are written in C. Therefore, compilation uses `arm-none-eabi-gcc`.
@@ -165,11 +154,9 @@ Format](TockBinaryFormat.md). This means the use of a linker script following
 specific rules and a header for the binary so that Tock can load the application
 correctly.
 
-Each Tock application uses a
-[linker script](https://github.com/tock/tock/blob/master/userland/userland_generic.ld)
-that places Flash at address `0x80000000` and SRAM at address `0x00000000`.
-This allows relocations pointing at Flash to be easily differentiated from
-relocations pointing at RAM.
+Each Tock application uses a linker script that places Flash at address
+`0x80000000` and SRAM at address `0x00000000`. This allows relocations pointing
+at Flash to be easily differentiated from relocations pointing at RAM.
 
 Each Tock application begins with a header that is today defined as:
 
@@ -266,11 +253,10 @@ The sticky bit also enables "library" applications (e.g. a radio stack) to
 be persistent even when other apps are being developed.
 
 In practice, this is automatically handled for applications. As part of the
-compilation process, a tool called
-[Elf to TAB](https://github.com/tock/tock/tree/master/userland/tools/elf2tab)
+compilation process, a tool called [Elf to TAB](https://github.com/tock/elf2tab)
 does the conversion from ELF to Tock's expected binary format, ensuring that
-sections are placed in the expected order, adding a section that lists
-necessary load-time relocations, and creating the TBF header.
+sections are placed in the expected order, adding a section that lists necessary
+load-time relocations, and creating the TBF header.
 
 
 ### Tock Application Bundle
@@ -304,174 +290,6 @@ name = "<package name>"                 // Package name of the application
 only-for-boards = <list of boards>      // Optional list of board kernels that this application supports
 build-date = 2017-03-20T19:37:11Z       // When the application was compiled
 ```
-
-### Tock userland compilation environment
-
-Tock aims to provide a build environment that is easy for application authors
-to integrate with. Check out the [examples](../userland/examples) folder for
-sample applications. The Tock userland build system will automatically build
-with all of the correct flags and generate TABs for all supported Tock
-architectures.
-
-To leverage the Tock build system, you must:
-
-  1. Set `TOCK_USERLAND_BASE_DIR` to the path to the Tock userland.
-  2. `include $(TOCK_USERLAND_BASE_DIR)/AppMakefile.mk`.
-
-This `include` should be the _last_ line of the Makefile for most applications.
-
-In addition, you must specify the sources for your application:
-
-  - `C_SRCS`: A list of C files to compile.
-  - `CXX_SRCS`: A list of C++ files to compile.
-  - `AS_SRCS`: A list of assembly files to compile.
-  - `EXTERN_LIBS`: A list of directories for libraries [**compiled for Tock**](#compiling-libraries-for-tock).
-
-#### Customizing the build
-
-##### Flags
-
-The build system respects all of the standard `CFLAGS` (C only), `CXXFLAGS`
-(C++ only), `CPPFLAGS` (C and C++), `ASFLAGS` (asm only).
-
-By default, if you run something like `make CPPFLAGS=-Og`, make will use _only_
-the flags specified on the command line, but that means that Tock would lose all
-of its PIC-related flags. For that reason, Tock specifies all variables using
-make's [override directive](https://www.gnu.org/software/make/manual/html_node/Override-Directive.html).
-
-If you wish to set additional flags in your application Makefiles, you must also
-use `override`, or they will be ignored. That is, in your Makefile you must write
-`override CPPFLAGS += -Og` rather than just `CPPFLAGS += -Og`.
-
-If you are adding supplemental flags, you can put them anywhere. If you want to
-override Tock defaults, you'll need to place these _after_ the `include` directive
-in your Makefile.
-
-##### Application configuration
-
-Several Tock-specific variables are also useful:
-
-  - `STACK_SIZE`: The minimum application stack size.
-  - `APP_HEAP_SIZE`: The minimum heap size for your application.
-  - `KERNEL_HEAP_SIZE`: The minimum grant size for your application.
-  - `PACKAGE_NAME`: The name for your application. Defaults to current folder.
-
-##### Advanced
-
-If you want to see a verbose build that prints all the commands as run, simply
-run `make V=1`.
-
-The build system is broken across three files in the `tock/userland` folder:
-
-  - `Configuration.mk`: Sets most variables used.
-  - `Helpers.mk`: Generic rules and functions to support the build.
-  - `AppMakefile.mk`: Includes the above files and supplies build recipes.
-
-Applications wishing to define their own build rules can include only the
-`Configuration.mk` file to ensure all of the flags needed for Tock applications
-are included.
-
-#### Compiling Libraries for Tock
-
-Libraries used by Tock need all of the same position-independent build flags as
-the final application. As Tock builds for all supported architectures by
-default, libraries should include images for each supported Tock architecture.
-
-##### Let Tock do the work: TockLibrary.mk
-
-As the Tock build requirements (PIC, multiple architectures) are fairly complex,
-Tock provides a Makefile that will ensure everything is set up correctly and
-generate build rules for you. An example Makefile for `libexample`:
-
-> **libexample/Makefile**
-```make
-# Base definitions
-TOCK_USERLAND_BASE_DIR ?= ..
-LIBNAME := libexample
-
-# Careful! Must be a path that resolves correctly **from where make is invoked**
-#
-# If you are only ever compiling a standalone library, then it's fine to simply set
-$(LIBNAME)_DIR := .
-#
-# If you will be asking applications to rebuild this library (see the development
-# section below), then you'll need to ensure that this directory is still correct
-# when invoked from inside the application folder.
-#
-# Tock accomplishes this for in-tree libraries by having all makefiles
-# conditionally set the TOCK_USERLAND_BASE_DIR variable, so that there
-# is a common relative path everywhere.
-$(LIBNAME)_DIR := $(TOCK_USERLAND_BASE_DIR)/$(LIBNAME)
-
-# Grab all relevant source files. You can list them directly:
-$(LIBNAME)_SRCS :=                                      \
-    $($LIBNAME)_DIR)\libexample.c                       \
-    $($LIBNAME)_DIR)\libexample_helper.c                \
-    $($LIBNAME)_DIR)\subfolders_are_fine\otherfile.c
-
-# Or let make find them automatically:
-$(LIBNAME)_SRCS  :=                                     \
-    $(wildcard $($(LIBNAME)_DIR)/*.c)                   \
-    $(wildcard $($(LIBNAME)_DIR)/*.cxx)                 \ # or .cpp or .cc
-    $(wildcard $($(LIBNAME)_DIR)/*.s)
-
-include $(TOCK_USERLAND_BASE_DIR)/TockLibrary.mk
-```
-
-> __Note! `:=` is NOT the same as `=` in make. You must use `:=`.__
-
-##### Developing (building) libraries concurrently with applications
-
-When developing a library, often it's useful to have the library rebuild automatically
-as part of the application build. Assuming that your library is using `TockLibrary.mk`,
-you can simply include the library's Makefile in your application's Makefile:
-
-```make
-include $(TOCK_USERLAND_BASE_DIR)/libexample/Makefile
-include ../../AppMakefile.mk
-```
-
-**Example:** We don't have an in-tree example of a single app that rebuilds
-a dedicated library in the Tock repository, but libtock is effectively treated
-this way as its Makefile is
-[included by AppMakefile.mk](https://github.com/tock/tock/blob/master/userland/AppMakefile.mk#L17).
-
-##### Pre-built libraries
-
-You can also include pre-built libraries, but recall that Tock supports multiple
-architectures, which means you must supply a pre-built image for each.
-
-Pre-built libraries must adhere to the following folder structure:
-
-```
-For the library "example"
-
-libexample/                <-- Folder name must match library name
-├── Makefile.app           <-- Optional additional rules to include when building apps
-├── build
-│   ├── cortex-m0          <-- Architecture names match gcc's -mcpu= flag
-│   │   └── libexample.a   <-- Library name must match folder name
-│   └── cortex-m4
-│       └── libexample.a   <-- Library name must match folder name
-│
-└── root_header.h          <-- The root directory will always be added to include path
-└── include                <-- An include/ directory will be added too if it exists
-    └── example.h
-```
-
-To include a pre-built library, add the _path_ to the root folder to the
-variable `EXTERN_LIBS` in your application Makefile, e.g.
-`EXTERN_LIBS += ../../libexample`.
-
-**Example:** In the Tock repository, lua53
-[ships a pre-built archive](https://github.com/tock/tock/tree/master/userland/lua53/build/cortex-m4).
-
-##### Manually including libraries
-
-To manually include an external library, add the library to each `LIBS_$(arch)`
-(i.e. `LIBS_cortex-m0`) variable. You can include header paths using the
-standard search mechanisms (i.e. `CPPFLAGS += -I<path>`).
-
 
 ## Loading the kernel and processes onto a board
 

--- a/doc/Userland.md
+++ b/doc/Userland.md
@@ -18,17 +18,7 @@ thoughts behind how applications function.
 - [Application Entry Point](#application-entry-point)
 - [Stack and Heap](#stack-and-heap)
 - [Debugging](#debugging)
-- [C Applications](#c-applications)
-  * [Entry Point](#entry-point)
-  * [Stack and Heap](#stack-and-heap-1)
-  * [Libraries](#libraries)
-    + [Newlib](#newlib)
-    + [libtock](#libtock)
-    + [libc++](#libc)
-    + [libnrfserialization](#libnrfserialization)
-    + [lua53](#lua53)
-  * [Style & Format](#style--format)
-- [Rust Applications](#rust-applications)
+- [Applications](#applications)
 
 <!-- tocstop -->
 
@@ -73,8 +63,7 @@ communication with other application code, and many others. In practice,
 system calls are made through library code and the application need not
 deal with them directly.
 
-For example the following is the system call handling the `gpio_set` command
-from [gpio.c](../userland/libtock/gpio.c):
+For example, consider the following system call that sets a GPIO pin high:
 
 ```c
 int gpio_set(GPIO_Pin_t pin) {
@@ -83,7 +72,7 @@ int gpio_set(GPIO_Pin_t pin) {
 ```
 
 The command system call itself is implemented as the ARM assembly instruction
-`svc` (service call) in [tock.c](../userland/libtock/tock.c):
+`svc` (service call):
 
 ```c
 int __attribute__((naked))
@@ -143,7 +132,7 @@ client can call `ipc_notify_svc()`. If the app wants to get notifications from
 the service, it must call `ipc_register_client_cb()` to receive events from when
 the service when the service calls `ipc_notify_client()`.
 
-See `ipc.h` in `libtock` for more information on these functions.
+See `ipc.h` in `libtock-c` for more information on these functions.
 
 ## Application Entry Point
 
@@ -238,107 +227,9 @@ App: printf_long   -   [Yielded]
  in the app's folder.
 ```
 
-## C Applications
+## Applications
 
-The bulk of Tock applications are written in C.
+For example applications, see the language specific userland repos:
 
-### Entry Point
-
-Applications written in C that compile against libtock should define a `main`
-method with the following signature:
-
-```c
-int main(void);
-```
-
-Applications **should** return 0 from `main`. Returning non-zero is undefined and the
-behavior may change in future versions of `libtock`.
-Today, `main` is called from `_start` and includes an implicit `while()` loop:
-
-```c
-void _start(void* text_start, void* mem_start, void* memory_len, void* app_heap_break) {
-  main();
-  while (1) {
-    yield();
-  }
-}
-```
-
-Applications should set up a series of event subscriptions in their `main`
-method and then return.
-
-### Stack and Heap
-
-Applications can specify their required stack and heap sizes by defining the
-make variables `STACK_SIZE` and `APP_HEAP_SIZE`, which default to 2K and 1K
-respectively as of this writing.
-
-`libtock` will set the stack pointer during startup. To allow each application
-to set its own stack size, the linker script expects a symbol `STACK_SIZE` to
-be defined. The Tock build system will define this symbol during linking, using
-the make variable `STACK_SIZE`. A consequence of this technique is that
-changing the stack size requires that any source file also be touched so that
-the app will re-link.
-
-### Libraries
-
-Application code does not need to stand alone, libraries are available that can
-be utilized!
-
-#### Newlib
-Application code written in C has access to most of the [C standard
-library](https://en.wikipedia.org/wiki/C_standard_library) which is implemented
-by [Newlib](https://en.wikipedia.org/wiki/Newlib). Newlib is focused on
-providing capabilities for embedded systems. It provides interfaces such as
-`printf`, `malloc`, and `memcpy`. Most, but not all features of the standard
-library are available to applications. The built configuration of Newlib is
-specified in [build.sh](../userland/newlib/build.sh).
-
-#### libtock
-In order to interact with the Tock kernel, application code can use the
-`libtock` library. The majority of `libtock` are wrappers for interacting
-with Tock drivers through system calls. They provide the user a meaningful
-function name and arguments and then internally translate these into a
-`command`, `subscribe`, etc. Where it makes sense, the libraries also provide
-a synchronous interface to a driver using an internal callback and `yield_for`
-(example:
-[`tmp006_read_sync`](https://github.com/tock/tock/blob/master/userland/libtock/tmp006.c#L19))
-
-`libtock` also provides the startup code for applications
-([`crt0.c`](../userland/libtock/crt0.c)),
-an implementation for the system calls
-([`tock.c`](../userland/libtock/tock.c)),
-and pin definitions for platforms.
-
-#### libc++
-Provides support for C++ apps. See `examples/cxx_hello`.
-
-#### libnrfserialization
-Provides a pre-compiled library for using the Nordic nRF serialization library
-for writing BLE apps.
-
-#### lua53
-Provides support for running a lua runtime as a Tock app. See
-`examples/lua-hello`.
-
-### Style & Format
-
-We try to keep a consistent style in mainline userland code. For C/C++, we use
-[uncrustify](https://github.com/uncrustify/uncrustify). High level:
-
-  - Two space character indents.
-  - Braces on the same line.
-  - Spaces around most operators.
-
-For details, see the [configuration](../userland/tools/uncrustify).
-
-Travis will automatically check formatting. You can format code locally using
-`make format`, or check the whole codebase with
-[format_all.sh](../userland/examples/format_all.sh). Formatting will overwrite
-files when it runs.
-
-
-## Rust Applications
-
-See the [libtock-rs](https://github.com/tock/libtock-rs) repo for more
-information on writing userland rust apps.
+- [libtock-c](https://github.com/tock/libtock-c): C and C++ apps.
+- [libtock-rs](https://github.com/tock/libtock-rs): Rust apps.

--- a/doc/tutorials/01_running_blink.md
+++ b/doc/tutorials/01_running_blink.md
@@ -53,18 +53,27 @@ kernel is installed on your board two options are supported: `program` and
     re-programming the kernel.
 
 3. **Load an Application**. For this introduction, we will program the blink
-app. The app can be found in the `userland/examples` directory, and is
-compiled and loaded much like the kernel is. See the
-[getting started README](../Getting_Started.md) for how applications are
-installed on your board.
+app. Tockloader supports installing apps from a repository, so installing the
+blink app is simple:
 
     ```bash
-    cd userland/examples/blink
-    make TOCK_BOARD=imix program  # Load code via bootloader
-      -- or --    # Check the README in your board folder
-    make TOCK_BOARD=imix flash    # Load code via jtag
+    tockloader install blink
     ```
 
-    If you have another board than Imix replace imix with your board.
-    When the `make` command finishes you should see the LEDs on the board blinking.
-    Congratulations! You have just programmed your first Tock application.
+    Your specific board may require additional arguments, please see the readme
+    in the `boards/` folder for more details.
+
+    We can also compile the blink app and load our compiled version. The basic C
+    version of blink is located in the
+    [libtock-c](https://github.com/tock/libtock-c) repository. Clone that
+    repository, then navigate to `examples/blink`. From there, you should be
+    able to compile it and install it by:
+
+    ```bash
+    make
+    tockloader install
+    ```
+
+    When the blink app is installed you should see the LEDs on the board
+    blinking. Congratulations! You have just programmed your first Tock
+    application.

--- a/doc/tutorials/02_button_print.md
+++ b/doc/tutorials/02_button_print.md
@@ -129,28 +129,11 @@ kernel how many there are. This is done by calling `button_count()`.
     }
     ```
 
-5. **Run the application**. To try this tutorial application, you can find
-it in the [tutorials app folder](../../userland/examples/tutorials/02_button_print).
-See the [getting started README](../Getting_Started.md) for how applications are
-installed on your board.
-In that directory:
+5. **Run the application**. To try this tutorial application, you can find it in
+   the [tutorials app
+   folder](https://github.com/tock/libtock-c/tree/master/examples/tutorials/02_button_print).
+   See the first tutorial for details on how to compile and install a C
+   application.
 
-    ```bash
-    make program  # Load code via bootloader
-      -- or --    # Check the README in your board folder
-    make flash    # Load code via jtag
-    ```
-
-    Ensure there is already a kernel flashed onto the target board.
-    See the [blink tutorial](01_running_blink.md) for instructions
-    on how to compile and load a Tock kernel.
-
-    Then, make sure you have a terminal listening for the UART print messages
-    from the board. You can do this with `tockloader`:
-
-    ```bash
-    $ tockloader listen
-    ```
-
-    Now, when you press the button, you should see "Hello!" printed
+    Once installed, when you press the button, you should see "Hello!" printed
     to the terminal!

--- a/doc/tutorials/03_ble_scan.md
+++ b/doc/tutorials/03_ble_scan.md
@@ -128,8 +128,8 @@ packet.
     ```
 
 6. **Run the app and see the packets!** To try this tutorial application, you
-can find it in the
-[tutorials app folder](../../userland/examples/tutorials/03_ble_scan).
+   can find it in the [tutorials app
+   folder](https://github.com/tock/libtock-c/tree/master/examples/tutorials/03_ble_scan).
 
     For any new applications, ensure that the following is in the makefile
     so that the BLE serialization library is included.

--- a/doc/tutorials/04_sensors_and_drivers.md
+++ b/doc/tutorials/04_sensors_and_drivers.md
@@ -159,6 +159,6 @@ the Tock Standard Library:
     }
     ```
 
-5. **Explore more sensors**. This tutorial highlights only one sensor.
-See the [sensors](../../userland/examples/sensors) app for a more complete
-sensing application.
+5. **Explore more sensors**. This tutorial highlights only one sensor. See the
+   [sensors](https://github.com/tock/libtock-c/tree/master/examples/sensors) app
+   for a more complete sensing application.

--- a/doc/tutorials/05_ipc.md
+++ b/doc/tutorials/05_ipc.md
@@ -219,12 +219,13 @@ to do is set a flag to signal the end of the `yield_for`.
 Try It Out
 ----------
 
-To test this out, see the complete apps in the
-[IPC tutorial example](../../userland/examples/tutorials/05_ipc) folder.
+To test this out, see the complete apps in the [IPC tutorial
+example](https://github.com/tock/libtock-c/tree/master/examples/tutorials/05_ipc)
+folder.
 
 To install all of the apps on a board:
 
-    $ cd tock/userland/examples/tutorials/05_ipc
+    $ cd examples/tutorials/05_ipc
     $ tockloader erase-apps
     $ pushd led && make && tockloader install && popd
     $ pushd rng && make && tockloader install && popd


### PR DESCRIPTION
### Pull Request Overview

These docs are now in the libtock-c repo.


### Testing Strategy

n/a


### TODO or Help Wanted

Please add any commits that are needed if you see other old references.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
