### PR TITLE
Add function that enables FPU for cortex-m4 MCUs

### DIFF
--- a/arch/cortex-m/src/scb.rs
+++ b/arch/cortex-m/src/scb.rs
@@ -54,3 +54,13 @@ pub unsafe fn reset() {
     let reset = (0x5FA << 16) | (aircr & (0x7 << 8)) | (1 << 2);
     SCB.aircr.set(reset);
 }
+
+/// Enables Floating Point Unit. Section 4.6.6.
+/// http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dui0553a/BEHBJHIG.html
+/// http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dai0298a/CEGJEIGH.html
+pub unsafe fn enable_fpu() {
+    let cpacr = (*SCB).cpacr.get();
+
+    // Enable coprocessors CP10 and CP11 thus enabling FPU
+    (*SCB).cpacr.set(cpacr | (3u32 << 10 * 2) | (3u32 << 11 * 2));
+}

--- a/arch/cortex-m/src/scb.rs
+++ b/arch/cortex-m/src/scb.rs
@@ -13,7 +13,7 @@ struct ScbRegisters {
     aircr: VolatileCell<u32>,
     scr: VolatileCell<u32>,
     ccr: VolatileCell<u32>,
-    shp: [VolatileCell<u32>; 12],
+    shp: [VolatileCell<u32>; 3],
     shcsr: VolatileCell<u32>,
     cfsr: VolatileCell<u32>,
     hfsr: VolatileCell<u32>,
@@ -58,6 +58,7 @@ pub unsafe fn reset() {
 /// Enables Floating Point Unit. Section 4.6.6.
 /// http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dui0553a/BEHBJHIG.html
 /// http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dai0298a/CEGJEIGH.html
+#[cfg(feature = "fpu")]
 pub unsafe fn enable_fpu() {
     let cpacr = SCB.cpacr.get();
 

--- a/arch/cortex-m/src/scb.rs
+++ b/arch/cortex-m/src/scb.rs
@@ -59,8 +59,8 @@ pub unsafe fn reset() {
 /// http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dui0553a/BEHBJHIG.html
 /// http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dai0298a/CEGJEIGH.html
 pub unsafe fn enable_fpu() {
-    let cpacr = (*SCB).cpacr.get();
+    let cpacr = SCB.cpacr.get();
 
     // Enable coprocessors CP10 and CP11 thus enabling FPU
-    (*SCB).cpacr.set(cpacr | (3u32 << 10 * 2) | (3u32 << 11 * 2));
+    SCB.cpacr.set(cpacr | (3u32 << 10 * 2) | (3u32 << 11 * 2));
 }


### PR DESCRIPTION
### Pull Request Overview

This pull request adds a function that enables Cortex-M4's Floating Point Unit (FPU).

As said in the [User Guide](http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dui0553a/BEHBJHIG.html), [here](http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dai0298a/CEGJEIGH.html) and also [here](https://www.silabs.com/community/mcu/32-bit/knowledge-base.entry.html/2014/04/16/how_to_enable_hardwa-vM9u), firmware must manually enable FPU to perform floating-point operations, so it would be nice if that function is available to user.

### Testing Strategy

This pull request was tested by `code compilation`.

### TODO or Help Wanted

This pull request adds a function that still needs a some `#[cfg()]` gate to make sure this function available to use only on Cortex-M4 MCUs, since `scb.rs` module is moved from `cortex-m4` into generic `cortex-m` module.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make formatall`.
