### PR TITLE
arch: scb register map fix

### DIFF
--- a/arch/cortex-m/src/scb.rs
+++ b/arch/cortex-m/src/scb.rs
@@ -13,7 +13,7 @@ struct ScbRegisters {
     aircr: VolatileCell<u32>,
     scr: VolatileCell<u32>,
     ccr: VolatileCell<u32>,
-    shp: [VolatileCell<u32>; 12],
+    shp: [VolatileCell<u32>; 3],
     shcsr: VolatileCell<u32>,
     cfsr: VolatileCell<u32>,
     hfsr: VolatileCell<u32>,


### PR DESCRIPTION
There are only 3 `SHP` registers, not 12.

<img width="817" alt="image" src="https://user-images.githubusercontent.com/1467890/41685752-8ba8a446-74af-11e8-96e7-f41e047ccb23.png">

<img width="1024" alt="image" src="https://user-images.githubusercontent.com/1467890/41685830-c9164f86-74af-11e8-8c59-29975fdb1593.png">


### Testing Strategy

This pull request was tested by looking at a lot of datasheets.


### TODO or Help Wanted

Someone to double check.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
