### PR TITLE
regs/macro.rs: add optional conversion from value into bit field enum member

### DIFF
--- a/libraries/tock-register-interface/README.md
+++ b/libraries/tock-register-interface/README.md
@@ -110,6 +110,7 @@ There are three types provided by the register interface: `ReadOnly`,
 ReadOnly<T: IntLike, R: RegisterLongName = ()>
 .get() -> T                                    // Get the raw register value
 .read(field: Field<T, R>) -> T                 // Read the value of the given field
+.read_as_enum<E>(field: Field<T, R>) -> Option<E> // Read value of the given field as a enum member
 .is_set(field: Field<T, R>) -> bool            // Check if one or more bits in a field are set
 .matches_any(value: FieldValue<T, R>) -> bool  // Check if any specified parts of a field match
 .matches_all(value: FieldValue<T, R>) -> bool  // Check if all specified parts of a field match
@@ -126,6 +127,7 @@ ReadWrite<T: IntLike, R: RegisterLongName = ()>
 .get() -> T                                    // Get the raw register value
 .set(value: T)                                 // Set the raw register value
 .read(field: Field<T, R>) -> T                 // Read the value of the given field
+.read_as_enum<E>(field: Field<T, R>) -> Option<E> // Read value of the given field as a enum member
 .write(value: FieldValue<T, R>)                // Write the value of one or more fields,
                                                //  overwriting other fields to zero
 .modify(value: FieldValue<T, R>)               // Write the value of one or more fields,
@@ -164,6 +166,17 @@ regs.cr.set(regs.cr.get() + 1);
 // `range` will contain the value of the RANGE field, e.g. 0, 1, 2, or 3.
 // The type annotation is not necessary, but provided for clarity here.
 let range: u8 = regs.cr.read(Control::RANGE);
+
+// Or one can read `range` as a enum and `match` over it.
+let range = regs.cr.read_as_enum(Control::RANGE);
+match range {
+    Some(Control::RANGE::Value::Zero) => { /* ... */ }
+    Some(Control::RANGE::Value::One) => { /* ... */ }
+    Some(Control::RANGE::Value::Two) => { /* ... */ }
+    Some(Control::RANGE::Value::Three) => { /* ... */ }
+    
+    None => unreachable!("invalid value")
+}
 
 // `en` will be 0 or 1
 let en: u8 = regs.cr.read(Control::EN);
@@ -230,6 +243,16 @@ while !regs.s.matches_all(Status::TXCOMPLETE::SET +
 
 // Or for checking whether any interrupts are enabled:
 let any_ints = regs.s.matches_any(Status::TXINTERRUPT + Status::RXINTERRUPT);
+
+// Also you can read a register with set of enumerated values as a enum and `match` over it:
+let mode = regs.cr.read_as_enum(Status::MODE);
+
+match mode {
+    Some(Status::MODE::FullDuplex) => { /* ... */ }
+    Some(Status::MODE::HalfDuplex) => { /* ... */ }
+    
+    None => unreachable!("invalid value")
+}
 
 // -----------------------------------------------------------------------------
 // LOCAL COPY

--- a/libraries/tock-register-interface/src/macros.rs
+++ b/libraries/tock-register-interface/src/macros.rs
@@ -63,7 +63,7 @@ macro_rules! register_bitmasks {
         $(#[$outer])*
         pub mod $field {
             #[allow(unused_imports)]
-            use $crate::regs::{ TryFromValue, FieldValue };
+            use $crate::regs::{FieldValue, TryFromValue};
             use super::$reg_desc;
 
             $(

--- a/libraries/tock-register-interface/src/macros.rs
+++ b/libraries/tock-register-interface/src/macros.rs
@@ -63,7 +63,7 @@ macro_rules! register_bitmasks {
         $(#[$outer])*
         pub mod $field {
             #[allow(unused_imports)]
-            use $crate::regs::FieldValue;
+            use $crate::regs::{ TryFromValue, FieldValue };
             use super::$reg_desc;
 
             $(
@@ -97,15 +97,17 @@ macro_rules! register_bitmasks {
                 )*
             }
 
-            impl Value {
-                pub fn try_from(v: $valtype) -> Option<Value> {
+            impl TryFromValue<$valtype> for Value {
+                type EnumType = Value;
+
+                fn try_from(v: $valtype) -> Option<Self::EnumType> {
                     match v {
-                    	$(
+                        $(
                             $(#[$inner])*
                             x if x == Value::$valname as $valtype => Some(Value::$valname),
-                    	)*
+                        )*
 
-                    	_ => Option::None
+                        _ => Option::None
                     }
                 }
             }

--- a/libraries/tock-register-interface/src/macros.rs
+++ b/libraries/tock-register-interface/src/macros.rs
@@ -96,6 +96,19 @@ macro_rules! register_bitmasks {
                     $valname = $value,
                 )*
             }
+                
+            impl Value {
+                pub fn try_from(v: $valtype) -> Option<Value> {
+                    match v {
+                    	$(
+                            $(#[$inner])*
+                            x if x == Value::$valname as $valtype => Some(Value::$valname),
+                    	)*
+
+                    	_ => None
+                    }
+                }
+            }
         }
     };
 }

--- a/libraries/tock-register-interface/src/macros.rs
+++ b/libraries/tock-register-interface/src/macros.rs
@@ -105,7 +105,7 @@ macro_rules! register_bitmasks {
                             x if x == Value::$valname as $valtype => Some(Value::$valname),
                     	)*
 
-                    	_ => None
+                    	_ => Option::None
                     }
                 }
             }

--- a/libraries/tock-register-interface/src/macros.rs
+++ b/libraries/tock-register-interface/src/macros.rs
@@ -96,7 +96,7 @@ macro_rules! register_bitmasks {
                     $valname = $value,
                 )*
             }
-                
+
             impl Value {
                 pub fn try_from(v: $valtype) -> Option<Value> {
                     match v {

--- a/libraries/tock-register-interface/src/regs.rs
+++ b/libraries/tock-register-interface/src/regs.rs
@@ -125,14 +125,14 @@ impl<T: IntLike, R: RegisterLongName> ReadWrite<T, R> {
     pub fn read(&self, field: Field<T, R>) -> T {
         (self.get() & (field.mask << field.shift)) >> field.shift
     }
-    
+
     #[inline]
-    pub fn read_as_enum<E: TryFromValue<T, EnumType=E>>(&self, field: Field<T, R>) -> Option<E> {
+    pub fn read_as_enum<E: TryFromValue<T, EnumType = E>>(&self, field: Field<T, R>) -> Option<E> {
         let val: T = self.read(field);
 
         E::try_from(val)
     }
-    
+
     #[inline]
     pub fn extract(&self) -> LocalRegisterCopy<T, R> {
         LocalRegisterCopy::new(self.get())
@@ -187,9 +187,9 @@ impl<T: IntLike, R: RegisterLongName> ReadOnly<T, R> {
     pub fn read(&self, field: Field<T, R>) -> T {
         (self.get() & (field.mask << field.shift)) >> field.shift
     }
-    
+
     #[inline]
-    pub fn read_as_enum<E: TryFromValue<T, EnumType=E>>(&self, field: Field<T, R>) -> Option<E> {
+    pub fn read_as_enum<E: TryFromValue<T, EnumType = E>>(&self, field: Field<T, R>) -> Option<E> {
         let val: T = self.read(field);
 
         E::try_from(val)


### PR DESCRIPTION
### Pull Request Overview

This pull request adds a function:
```rust
pub fn read_as_enum<E: TryFromValue<T, EnumType=E>>(&self, field: Field<T, R>) -> Option<E>
```

for types `ReadOnly<T, R>` and `ReadWrite<T, R>` of `regs.rs`.

This function enables optional conversion from arbitrary integer value of a bitfield into one of the possible enumerated values specified for the bitfield.

Since for some bit fields there can be a set of enumerated values associated with it, it would be great if one could read a bit field and `match` over those values.

For example, consider following register and its bit fields:

```rust
register_bitfields![
CLK_CTRL [
    /* ---%< -snip- %<--- */

    /// Select SYS_CLK source
    SYS_CLK_SEL OFFSET(30) NUMBITS(2) [
        /// 32M internal clock
        _32MInternalClock = 0,
        /// external crystal clock
        ExternalCrystalClock = 1,
        /// 32K clock
        _32KClock = 2
    ]
],
]
```

If one wants to read this register and do something for each or some of its possible enumerated values, one could write like this:

```rust
let clk_sel_val = syscon.clk_ctrl.read(CLK_CTRL::SYS_CLK_SEL);
match clk_sel_val {
    0 => do_stuff_with_32mhz_int(),
    1 => do_stuff_with_32mhz_ext(),
    2 => do_stuff_with_32khz(),

    _ => panic!(""),
}
```

For now, one can only read bitfield's value as an integer, and to match on possible values of bitfield it is required to know exact integer representation (iotw, variant number) of those values. Needless to say that such approach can easily lead to a bug.

As an alternative, there are `match_all()` or `match_any()` functions that can be used to check whether bitfield contains a value:

```rust
let clk_sel_val = syscon.clk_ctrl.read(CLK_CTRL::SYS_CLK_SEL);

if syscon.clk_ctrl.matches_all(CLK_CTRL::SYS_CLK_SEL::_32MInternalClock) {
    do_stuff_with_32mhz_int();
} else if syscon.clk_ctrl.matches_all(CLK_CTRL::SYS_CLK_SEL::ExternalCrystalClock) {
    do_stuff_with_32mhz_ext();
} else if syscon.clk_ctrl.matches_all(CLK_CTRL::SYS_CLK_SEL::_32KClock) {
    do_stuff_with_32khz();
} else {
    // Invalid value read from bit field
    panic!("")
}
```

But this approach tends to produce a hard-to-read chain of `if` and `else`, doesn't exploit powerful `match` machinery of Rust and won't work well for bit fields with more than one or two possible enumerated values.

This pull request is extending a `register_bitfield![]` macro and `Read(Only/Write)<T, R>` types such that it is possible to read bitfield value and perform a `match` over it as `enum`:

```rust
let clk_sel_val = syscon.clk_ctrl.read_as_enum(CLK_CTRL::SYS_CLK_SEL);

match clk_sel_val {
    Some(CLK_CTRL::SYS_CLK_SEL::Value::_32MInternalClock) => do_stuff_with_32mhz_int(),
    Some(CLK_CTRL::SYS_CLK_SEL::Value::ExternalCrystalClock) => do_stuff_with_32mhz_ext(),
    Some(CLK_CTRL::SYS_CLK_SEL::Value::_32KClock) => do_stuff_with_32khz(),

    None => panic!(""),
}
```

or:

```rust
let clk_sel_val = syscon.clk_ctrl.read_as_enum(CLK_CTRL::SYS_CLK_SEL);

if let Some(clk_sel_val) = clk_sel_val {
    match clk_sel_val {
        CLK_CTRL::SYS_CLK_SEL::Value::_32MInternalClock => do_stuff_with_32mhz_int(),
        CLK_CTRL::SYS_CLK_SEL::Value::ExternalCrystalClock => do_stuff_with_32mhz_ext(),
        CLK_CTRL::SYS_CLK_SEL::Value::_32KClock => do_stuff_with_32khz(),
    }
} else {
      // Invalid value read from bit field
      panic!("");
}
```

### Testing Strategy

This pull request was tested by `make allboards`


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
