### PR TITLE
Use several nice newish Rust features

### DIFF
--- a/boards/imix/src/icmp_lowpan_test.rs
+++ b/boards/imix/src/icmp_lowpan_test.rs
@@ -65,7 +65,7 @@ pub static mut RF233_BUF: [u8; radio::MAX_BUF_SIZE] = [0 as u8; radio::MAX_BUF_S
 
 //Use a global variable option, initialize as None, then actually initialize in initialize all
 
-pub struct LowpanICMPTest<'a, A: time::Alarm + 'a> {
+pub struct LowpanICMPTest<'a, A: time::Alarm> {
     alarm: A,
     //sixlowpan_tx: TxState<'a>,
     //radio: &'a Mac<'a>,
@@ -147,7 +147,7 @@ impl<'a, A: time::Alarm> capsules::net::icmpv6::icmpv6_send::ICMP6SendClient
     }
 }
 
-impl<'a, A: time::Alarm + 'a> LowpanICMPTest<'a, A> {
+impl<'a, A: time::Alarm> LowpanICMPTest<'a, A> {
     pub fn new(
         //sixlowpan_tx: TxState<'a>,
         //radio: &'a Mac<'a>,

--- a/boards/imix/src/icmp_lowpan_test.rs
+++ b/boards/imix/src/icmp_lowpan_test.rs
@@ -147,7 +147,7 @@ impl<'a, A: time::Alarm> capsules::net::icmpv6::icmpv6_send::ICMP6SendClient
     }
 }
 
-impl<'a, A: time::Alarm> LowpanICMPTest<'a, A> {
+impl<A: time::Alarm> LowpanICMPTest<'a, A> {
     pub fn new(
         //sixlowpan_tx: TxState<'a>,
         //radio: &'a Mac<'a>,

--- a/boards/imix/src/ipv6_lowpan_test.rs
+++ b/boards/imix/src/ipv6_lowpan_test.rs
@@ -134,7 +134,7 @@ static mut UDP_DGRAM: [u8; PAYLOAD_LEN - UDP_HDR_SIZE] = [0; PAYLOAD_LEN - UDP_H
 static mut IP6_DG_OPT: Option<IP6Packet> = None;
 //END changes
 
-pub struct LowpanTest<'a, A: time::Alarm + 'a> {
+pub struct LowpanTest<'a, A: time::Alarm> {
     alarm: A,
     sixlowpan_tx: TxState<'a>,
     radio: &'a MacDevice<'a>,

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -5,6 +5,8 @@
 
 #![no_std]
 #![no_main]
+#![feature(in_band_lifetimes)]
+#![feature(infer_outlives_requirements)]
 #![feature(panic_implementation)]
 #![deny(missing_docs)]
 

--- a/boards/imix/src/sixlowpan_dummy.rs
+++ b/boards/imix/src/sixlowpan_dummy.rs
@@ -83,13 +83,13 @@ enum DAC {
 pub const TEST_DELAY_MS: u32 = 1000;
 pub const TEST_LOOP: bool = false;
 
-pub struct LowpanTest<'a, R: radio::Radio + 'a, A: time::Alarm + 'a> {
+pub struct LowpanTest<'a, R: radio::Radio , A: time::Alarm > {
     radio: &'a R,
     alarm: &'a A,
     test_counter: Cell<usize>,
 }
 
-impl<'a, R: radio::Radio + 'a, A: time::Alarm + 'a>
+impl<'a, R: radio::Radio , A: time::Alarm >
 LowpanTest<'a, R, A> {
     pub fn new(radio: &'a R, alarm: &'a A) -> LowpanTest<'a, R, A> {
         LowpanTest {
@@ -167,7 +167,7 @@ LowpanTest<'a, R, A> {
     }
 }
 
-impl<'a, R: radio::Radio + 'a, A: time::Alarm + 'a>
+impl<'a, R: radio::Radio , A: time::Alarm >
 time::Client for LowpanTest<'a, R, A> {
     fn fired(&self) {
         self.run_test_and_increment();

--- a/boards/imix/src/udp_lowpan_test.rs
+++ b/boards/imix/src/udp_lowpan_test.rs
@@ -64,7 +64,7 @@ pub static mut RF233_BUF: [u8; radio::MAX_BUF_SIZE] = [0 as u8; radio::MAX_BUF_S
 
 //Use a global variable option, initialize as None, then actually initialize in initialize all
 
-pub struct LowpanTest<'a, A: time::Alarm + 'a> {
+pub struct LowpanTest<'a, A: time::Alarm> {
     alarm: A,
     //sixlowpan_tx: TxState<'a>,
     //radio: &'a Mac<'a>,
@@ -160,7 +160,7 @@ impl<'a, A: time::Alarm> capsules::net::udp::udp_send::UDPSendClient for LowpanT
     }
 }
 
-impl<'a, A: time::Alarm + 'a> LowpanTest<'a, A> {
+impl<'a, A: time::Alarm> LowpanTest<'a, A> {
     pub fn new(
         //sixlowpan_tx: TxState<'a>,
         //radio: &'a Mac<'a>,

--- a/capsules/examples/traitobj_list.rs
+++ b/capsules/examples/traitobj_list.rs
@@ -20,18 +20,18 @@ use kernel::common::list::*;
 
 pub trait Funky<'a> {
     fn name(&self) -> &'static str;
-    fn next_funky_thing(&'a self) -> &'a ListLink<'a, Funky<'a> + 'a>;
+    fn next_funky_thing(&'a self) -> &'a ListLink<'a, Funky<'a>>;
 }
 
-impl<'a> ListNode<'a, Funky<'a> + 'a> for Funky<'a> + 'a {
-    fn next(&'a self) -> &'a ListLink<'a, Funky<'a> + 'a> {
+impl<'a> ListNode<'a, Funky<'a>> for Funky<'a> {
+    fn next(&'a self) -> &'a ListLink<'a, Funky<'a>> {
         &self.next_funky_thing()
     }
 }
 
 // A manager holds a list of funky things
 pub struct Manager<'a> {
-    funky_things: List<'a, Funky<'a> + 'a>,
+    funky_things: List<'a, Funky<'a>>,
 }
 
 impl<'a> Manager<'a> {
@@ -41,7 +41,7 @@ impl<'a> Manager<'a> {
         }
     }
 
-    pub fn manage(&mut self, thing: &'a (Funky<'a> + 'a)) {
+    pub fn manage(&mut self, thing: &'a (Funky<'a>)) {
         self.funky_things.push_head(thing);
     }
 
@@ -70,7 +70,7 @@ impl<'a> Funky<'a> for Jazz<'a> {
         "Jazz"
     }
 
-    fn next_funky_thing(&'a self) -> &'a ListLink<'a, Funky<'a> + 'a> {
+    fn next_funky_thing(&'a self) -> &'a ListLink<'a, Funky<'a>> {
         &self.next
     }
 }
@@ -92,7 +92,7 @@ impl<'a> Funky<'a> for Cheese<'a> {
     fn name(&self) -> &'static str {
         "Cheese"
     }
-    fn next_funky_thing(&'a self) -> &'a ListLink<'a, Funky<'a> + 'a> {
+    fn next_funky_thing(&'a self) -> &'a ListLink<'a, Funky<'a>> {
         &self.next
     }
 }

--- a/capsules/src/adc.rs
+++ b/capsules/src/adc.rs
@@ -100,7 +100,7 @@ pub static mut ADC_BUFFER2: [u16; 128] = [0; 128];
 pub static mut ADC_BUFFER3: [u16; 128] = [0; 128];
 
 /// Functions to create, initialize, and interact with the ADC
-impl<'a, A: hil::adc::Adc + hil::adc::AdcHighSpeed> Adc<'a, A> {
+impl<A: hil::adc::Adc + hil::adc::AdcHighSpeed> Adc<'a, A> {
     /// Create a new Adc application interface
     ///
     /// adc - ADC driver to provide application access to
@@ -496,7 +496,7 @@ impl<'a, A: hil::adc::Adc + hil::adc::AdcHighSpeed> Adc<'a, A> {
 }
 
 /// Callbacks from the ADC driver
-impl<'a, A: hil::adc::Adc + hil::adc::AdcHighSpeed> hil::adc::Client for Adc<'a, A> {
+impl<A: hil::adc::Adc + hil::adc::AdcHighSpeed> hil::adc::Client for Adc<'a, A> {
     /// Single sample operation complete
     /// Collects the sample and provides a callback to the application
     ///
@@ -536,7 +536,7 @@ impl<'a, A: hil::adc::Adc + hil::adc::AdcHighSpeed> hil::adc::Client for Adc<'a,
 }
 
 /// Callbacks from the High Speed ADC driver
-impl<'a, A: hil::adc::Adc + hil::adc::AdcHighSpeed> hil::adc::HighSpeedClient for Adc<'a, A> {
+impl<A: hil::adc::Adc + hil::adc::AdcHighSpeed> hil::adc::HighSpeedClient for Adc<'a, A> {
     /// Internal buffer has filled from a buffered sampling operation.
     /// Copies data over to application buffer, determines if more data is
     /// needed, and performs a callback to the application if ready. If
@@ -793,7 +793,7 @@ impl<'a, A: hil::adc::Adc + hil::adc::AdcHighSpeed> hil::adc::HighSpeedClient fo
 }
 
 /// Implementations of application syscalls
-impl<'a, A: hil::adc::Adc + hil::adc::AdcHighSpeed> Driver for Adc<'a, A> {
+impl<A: hil::adc::Adc + hil::adc::AdcHighSpeed> Driver for Adc<'a, A> {
     /// Provides access to a buffer from the application to store data in or
     /// read data from
     ///

--- a/capsules/src/adc.rs
+++ b/capsules/src/adc.rs
@@ -40,7 +40,7 @@ pub const DRIVER_NUM: usize = 0x00000005;
 
 /// ADC application driver, used by applications to interact with ADC.
 /// Not currently virtualized, only one application can use it at a time.
-pub struct Adc<'a, A: hil::adc::Adc + hil::adc::AdcHighSpeed + 'a> {
+pub struct Adc<'a, A: hil::adc::Adc + hil::adc::AdcHighSpeed> {
     // ADC driver
     adc: &'a A,
     channels: &'a [&'a <A as hil::adc::Adc>::Channel],
@@ -100,7 +100,7 @@ pub static mut ADC_BUFFER2: [u16; 128] = [0; 128];
 pub static mut ADC_BUFFER3: [u16; 128] = [0; 128];
 
 /// Functions to create, initialize, and interact with the ADC
-impl<'a, A: hil::adc::Adc + hil::adc::AdcHighSpeed + 'a> Adc<'a, A> {
+impl<'a, A: hil::adc::Adc + hil::adc::AdcHighSpeed> Adc<'a, A> {
     /// Create a new Adc application interface
     ///
     /// adc - ADC driver to provide application access to
@@ -496,7 +496,7 @@ impl<'a, A: hil::adc::Adc + hil::adc::AdcHighSpeed + 'a> Adc<'a, A> {
 }
 
 /// Callbacks from the ADC driver
-impl<'a, A: hil::adc::Adc + hil::adc::AdcHighSpeed + 'a> hil::adc::Client for Adc<'a, A> {
+impl<'a, A: hil::adc::Adc + hil::adc::AdcHighSpeed> hil::adc::Client for Adc<'a, A> {
     /// Single sample operation complete
     /// Collects the sample and provides a callback to the application
     ///
@@ -536,7 +536,7 @@ impl<'a, A: hil::adc::Adc + hil::adc::AdcHighSpeed + 'a> hil::adc::Client for Ad
 }
 
 /// Callbacks from the High Speed ADC driver
-impl<'a, A: hil::adc::Adc + hil::adc::AdcHighSpeed + 'a> hil::adc::HighSpeedClient for Adc<'a, A> {
+impl<'a, A: hil::adc::Adc + hil::adc::AdcHighSpeed> hil::adc::HighSpeedClient for Adc<'a, A> {
     /// Internal buffer has filled from a buffered sampling operation.
     /// Copies data over to application buffer, determines if more data is
     /// needed, and performs a callback to the application if ready. If
@@ -793,7 +793,7 @@ impl<'a, A: hil::adc::Adc + hil::adc::AdcHighSpeed + 'a> hil::adc::HighSpeedClie
 }
 
 /// Implementations of application syscalls
-impl<'a, A: hil::adc::Adc + hil::adc::AdcHighSpeed + 'a> Driver for Adc<'a, A> {
+impl<'a, A: hil::adc::Adc + hil::adc::AdcHighSpeed> Driver for Adc<'a, A> {
     /// Provides access to a buffer from the application to store data in or
     /// read data from
     ///

--- a/capsules/src/aes_ccm.rs
+++ b/capsules/src/aes_ccm.rs
@@ -86,7 +86,7 @@ pub struct AES128CCM<'a, A: AES128<'a> + AES128Ctr + AES128CBC> {
     saved_tag: Cell<[u8; AES128_BLOCK_SIZE]>,
 }
 
-impl<'a, A: AES128<'a> + AES128Ctr + AES128CBC> AES128CCM<'a, A> {
+impl<A: AES128<'a> + AES128Ctr + AES128CBC> AES128CCM<'a, A> {
     pub fn new(aes: &'a A, crypt_buf: &'static mut [u8]) -> AES128CCM<'a, A> {
         AES128CCM {
             aes: aes,
@@ -414,7 +414,7 @@ impl<'a, A: AES128<'a> + AES128Ctr + AES128CBC> AES128CCM<'a, A> {
     }
 }
 
-impl<'a, A: AES128<'a> + AES128Ctr + AES128CBC> symmetric_encryption::AES128CCM<'a>
+impl<A: AES128<'a> + AES128Ctr + AES128CBC> symmetric_encryption::AES128CCM<'a>
     for AES128CCM<'a, A>
 {
     fn set_client(&self, client: &'a symmetric_encryption::CCMClient) {
@@ -492,9 +492,7 @@ impl<'a, A: AES128<'a> + AES128Ctr + AES128CBC> symmetric_encryption::AES128CCM<
     }
 }
 
-impl<'a, A: AES128<'a> + AES128Ctr + AES128CBC> symmetric_encryption::Client<'a>
-    for AES128CCM<'a, A>
-{
+impl<A: AES128<'a> + AES128Ctr + AES128CBC> symmetric_encryption::Client<'a> for AES128CCM<'a, A> {
     fn crypt_done(&self, _: Option<&'a mut [u8]>, crypt_buf: &'a mut [u8]) {
         self.crypt_buf.replace(crypt_buf);
         match self.state.get() {

--- a/capsules/src/aes_ccm.rs
+++ b/capsules/src/aes_ccm.rs
@@ -68,7 +68,7 @@ enum CCMState {
     Encrypt,
 }
 
-pub struct AES128CCM<'a, A: AES128<'a> + AES128Ctr + AES128CBC + 'a> {
+pub struct AES128CCM<'a, A: AES128<'a> + AES128Ctr + AES128CBC> {
     aes: &'a A,
     crypt_buf: TakeCell<'a, [u8]>,
     crypt_auth_len: Cell<usize>,
@@ -86,7 +86,7 @@ pub struct AES128CCM<'a, A: AES128<'a> + AES128Ctr + AES128CBC + 'a> {
     saved_tag: Cell<[u8; AES128_BLOCK_SIZE]>,
 }
 
-impl<'a, A: AES128<'a> + AES128Ctr + AES128CBC + 'a> AES128CCM<'a, A> {
+impl<'a, A: AES128<'a> + AES128Ctr + AES128CBC> AES128CCM<'a, A> {
     pub fn new(aes: &'a A, crypt_buf: &'static mut [u8]) -> AES128CCM<'a, A> {
         AES128CCM {
             aes: aes,
@@ -414,7 +414,7 @@ impl<'a, A: AES128<'a> + AES128Ctr + AES128CBC + 'a> AES128CCM<'a, A> {
     }
 }
 
-impl<'a, A: AES128<'a> + AES128Ctr + AES128CBC + 'a> symmetric_encryption::AES128CCM<'a>
+impl<'a, A: AES128<'a> + AES128Ctr + AES128CBC> symmetric_encryption::AES128CCM<'a>
     for AES128CCM<'a, A>
 {
     fn set_client(&self, client: &'a symmetric_encryption::CCMClient) {

--- a/capsules/src/alarm.rs
+++ b/capsules/src/alarm.rs
@@ -35,7 +35,7 @@ pub struct AlarmDriver<'a, A: Alarm> {
     prev: Cell<u32>,
 }
 
-impl<'a, A: Alarm> AlarmDriver<'a, A> {
+impl<A: Alarm> AlarmDriver<'a, A> {
     pub const fn new(alarm: &'a A, grant: Grant<AlarmData>) -> AlarmDriver<'a, A> {
         AlarmDriver {
             alarm: alarm,
@@ -70,7 +70,7 @@ impl<'a, A: Alarm> AlarmDriver<'a, A> {
     }
 }
 
-impl<'a, A: Alarm> Driver for AlarmDriver<'a, A> {
+impl<A: Alarm> Driver for AlarmDriver<'a, A> {
     /// Subscribe to alarm expiration
     ///
     /// ### `_subscribe_num`
@@ -161,7 +161,7 @@ fn has_expired(alarm: u32, now: u32, prev: u32) -> bool {
     now.wrapping_sub(prev) >= alarm.wrapping_sub(prev)
 }
 
-impl<'a, A: Alarm> time::Client for AlarmDriver<'a, A> {
+impl<A: Alarm> time::Client for AlarmDriver<'a, A> {
     fn fired(&self) {
         let now = self.alarm.now();
         self.app_alarm.each(|alarm| {

--- a/capsules/src/alarm.rs
+++ b/capsules/src/alarm.rs
@@ -28,7 +28,7 @@ impl Default for AlarmData {
     }
 }
 
-pub struct AlarmDriver<'a, A: Alarm + 'a> {
+pub struct AlarmDriver<'a, A: Alarm> {
     alarm: &'a A,
     num_armed: Cell<usize>,
     app_alarm: Grant<AlarmData>,

--- a/capsules/src/ambient_light.rs
+++ b/capsules/src/ambient_light.rs
@@ -30,7 +30,7 @@ pub struct AmbientLight<'a> {
     apps: Grant<App>,
 }
 
-impl<'a> AmbientLight<'a> {
+impl AmbientLight<'a> {
     pub fn new(sensor: &'a hil::sensors::AmbientLight, grant: Grant<App>) -> AmbientLight {
         AmbientLight {
             sensor: sensor,
@@ -57,7 +57,7 @@ impl<'a> AmbientLight<'a> {
     }
 }
 
-impl<'a> Driver for AmbientLight<'a> {
+impl Driver for AmbientLight<'a> {
     /// Subscribe to light intensity readings
     ///
     /// ### `subscribe`
@@ -105,7 +105,7 @@ impl<'a> Driver for AmbientLight<'a> {
     }
 }
 
-impl<'a> hil::sensors::AmbientLightClient for AmbientLight<'a> {
+impl hil::sensors::AmbientLightClient for AmbientLight<'a> {
     fn callback(&self, lux: usize) {
         self.command_pending.set(false);
         self.apps.each(|app| {

--- a/capsules/src/app_flash_driver.rs
+++ b/capsules/src/app_flash_driver.rs
@@ -54,7 +54,7 @@ pub struct AppFlash<'a> {
     buffer: TakeCell<'static, [u8]>,
 }
 
-impl<'a> AppFlash<'a> {
+impl AppFlash<'a> {
     pub fn new(
         driver: &'a hil::nonvolatile_storage::NonvolatileStorage,
         grant: Grant<App>,
@@ -116,7 +116,7 @@ impl<'a> AppFlash<'a> {
     }
 }
 
-impl<'a> hil::nonvolatile_storage::NonvolatileStorageClient for AppFlash<'a> {
+impl hil::nonvolatile_storage::NonvolatileStorageClient for AppFlash<'a> {
     fn read_done(&self, _buffer: &'static mut [u8], _length: usize) {}
 
     fn write_done(&self, buffer: &'static mut [u8], _length: usize) {
@@ -169,7 +169,7 @@ impl<'a> hil::nonvolatile_storage::NonvolatileStorageClient for AppFlash<'a> {
     }
 }
 
-impl<'a> Driver for AppFlash<'a> {
+impl Driver for AppFlash<'a> {
     /// Setup buffer to write from.
     ///
     /// ### `allow_num`

--- a/capsules/src/ble_advertising_driver.rs
+++ b/capsules/src/ble_advertising_driver.rs
@@ -231,8 +231,8 @@ impl App {
 
     fn send_advertisement<'a, B, A>(&self, ble: &BLE<'a, B, A>, channel: RadioChannel) -> ReturnCode
     where
-        B: ble_advertising::BleAdvertisementDriver + ble_advertising::BleConfig + 'a,
-        A: kernel::hil::time::Alarm + 'a,
+        B: ble_advertising::BleAdvertisementDriver + ble_advertising::BleConfig,
+        A: kernel::hil::time::Alarm,
     {
         self.adv_data
             .as_ref()
@@ -300,8 +300,8 @@ impl App {
 
 pub struct BLE<'a, B, A>
 where
-    B: ble_advertising::BleAdvertisementDriver + ble_advertising::BleConfig + 'a,
-    A: kernel::hil::time::Alarm + 'a,
+    B: ble_advertising::BleAdvertisementDriver + ble_advertising::BleConfig,
+    A: kernel::hil::time::Alarm,
 {
     radio: &'a B,
     busy: Cell<bool>,
@@ -314,8 +314,8 @@ where
 
 impl<'a, B, A> BLE<'a, B, A>
 where
-    B: ble_advertising::BleAdvertisementDriver + ble_advertising::BleConfig + 'a,
-    A: kernel::hil::time::Alarm + 'a,
+    B: ble_advertising::BleAdvertisementDriver + ble_advertising::BleConfig,
+    A: kernel::hil::time::Alarm,
 {
     pub fn new(
         radio: &'a B,
@@ -366,8 +366,8 @@ where
 // Timer alarm
 impl<'a, B, A> kernel::hil::time::Client for BLE<'a, B, A>
 where
-    B: ble_advertising::BleAdvertisementDriver + ble_advertising::BleConfig + 'a,
-    A: kernel::hil::time::Alarm + 'a,
+    B: ble_advertising::BleAdvertisementDriver + ble_advertising::BleConfig,
+    A: kernel::hil::time::Alarm,
 {
     // When an alarm is fired, we find which apps have expired timers. Expired
     // timers indicate a desire to perform some operation (e.g. start an
@@ -435,8 +435,8 @@ where
 // Callback from the radio once a RX event occur
 impl<'a, B, A> ble_advertising::RxClient for BLE<'a, B, A>
 where
-    B: ble_advertising::BleAdvertisementDriver + ble_advertising::BleConfig + 'a,
-    A: kernel::hil::time::Alarm + 'a,
+    B: ble_advertising::BleAdvertisementDriver + ble_advertising::BleConfig,
+    A: kernel::hil::time::Alarm,
 {
     fn receive_event(&self, buf: &'static mut [u8], len: u8, result: ReturnCode) {
         if let Some(appid) = self.receiving_app.get() {
@@ -502,8 +502,8 @@ where
 // Callback from the radio once a TX event occur
 impl<'a, B, A> ble_advertising::TxClient for BLE<'a, B, A>
 where
-    B: ble_advertising::BleAdvertisementDriver + ble_advertising::BleConfig + 'a,
-    A: kernel::hil::time::Alarm + 'a,
+    B: ble_advertising::BleAdvertisementDriver + ble_advertising::BleConfig,
+    A: kernel::hil::time::Alarm,
 {
     // The ReturnCode indicates valid CRC or not, not used yet but could be used for
     // re-transmissions for invalid CRCs
@@ -543,8 +543,8 @@ where
 // System Call implementation
 impl<'a, B, A> kernel::Driver for BLE<'a, B, A>
 where
-    B: ble_advertising::BleAdvertisementDriver + ble_advertising::BleConfig + 'a,
-    A: kernel::hil::time::Alarm + 'a,
+    B: ble_advertising::BleAdvertisementDriver + ble_advertising::BleConfig,
+    A: kernel::hil::time::Alarm,
 {
     fn command(
         &self,

--- a/capsules/src/ble_advertising_driver.rs
+++ b/capsules/src/ble_advertising_driver.rs
@@ -312,7 +312,7 @@ where
     receiving_app: Cell<Option<kernel::AppId>>,
 }
 
-impl<'a, B, A> BLE<'a, B, A>
+impl<B, A> BLE<'a, B, A>
 where
     B: ble_advertising::BleAdvertisementDriver + ble_advertising::BleConfig,
     A: kernel::hil::time::Alarm,
@@ -364,7 +364,7 @@ where
 }
 
 // Timer alarm
-impl<'a, B, A> kernel::hil::time::Client for BLE<'a, B, A>
+impl<B, A> kernel::hil::time::Client for BLE<'a, B, A>
 where
     B: ble_advertising::BleAdvertisementDriver + ble_advertising::BleConfig,
     A: kernel::hil::time::Alarm,
@@ -433,7 +433,7 @@ where
 }
 
 // Callback from the radio once a RX event occur
-impl<'a, B, A> ble_advertising::RxClient for BLE<'a, B, A>
+impl<B, A> ble_advertising::RxClient for BLE<'a, B, A>
 where
     B: ble_advertising::BleAdvertisementDriver + ble_advertising::BleConfig,
     A: kernel::hil::time::Alarm,
@@ -500,7 +500,7 @@ where
 }
 
 // Callback from the radio once a TX event occur
-impl<'a, B, A> ble_advertising::TxClient for BLE<'a, B, A>
+impl<B, A> ble_advertising::TxClient for BLE<'a, B, A>
 where
     B: ble_advertising::BleAdvertisementDriver + ble_advertising::BleConfig,
     A: kernel::hil::time::Alarm,
@@ -541,7 +541,7 @@ where
 }
 
 // System Call implementation
-impl<'a, B, A> kernel::Driver for BLE<'a, B, A>
+impl<B, A> kernel::Driver for BLE<'a, B, A>
 where
     B: ble_advertising::BleAdvertisementDriver + ble_advertising::BleConfig,
     A: kernel::hil::time::Alarm,

--- a/capsules/src/button.rs
+++ b/capsules/src/button.rs
@@ -85,7 +85,7 @@ pub struct Button<'a, G: hil::gpio::Pin> {
     apps: Grant<(Option<Callback>, SubscribeMap)>,
 }
 
-impl<'a, G: hil::gpio::Pin + hil::gpio::PinCtl> Button<'a, G> {
+impl<G: hil::gpio::Pin + hil::gpio::PinCtl> Button<'a, G> {
     pub fn new(
         pins: &'a [(&'a G, GpioMode)],
         grant: Grant<(Option<Callback>, SubscribeMap)>,
@@ -115,7 +115,7 @@ impl<'a, G: hil::gpio::Pin + hil::gpio::PinCtl> Button<'a, G> {
     }
 }
 
-impl<'a, G: hil::gpio::Pin + hil::gpio::PinCtl> Driver for Button<'a, G> {
+impl<G: hil::gpio::Pin + hil::gpio::PinCtl> Driver for Button<'a, G> {
     /// Set callbacks.
     ///
     /// ### `subscribe_num`
@@ -236,7 +236,7 @@ impl<'a, G: hil::gpio::Pin + hil::gpio::PinCtl> Driver for Button<'a, G> {
     }
 }
 
-impl<'a, G: hil::gpio::Pin + hil::gpio::PinCtl> Client for Button<'a, G> {
+impl<G: hil::gpio::Pin + hil::gpio::PinCtl> Client for Button<'a, G> {
     fn fired(&self, pin_num: usize) {
         // Read the value of the pin and get the button state.
         let button_state = self.get_button_state(pin_num);

--- a/capsules/src/button.rs
+++ b/capsules/src/button.rs
@@ -80,7 +80,7 @@ pub enum ButtonState {
 
 /// Manages the list of GPIO pins that are connected to buttons and which apps
 /// are listening for interrupts from which buttons.
-pub struct Button<'a, G: hil::gpio::Pin + 'a> {
+pub struct Button<'a, G: hil::gpio::Pin> {
     pins: &'a [(&'a G, GpioMode)],
     apps: Grant<(Option<Callback>, SubscribeMap)>,
 }

--- a/capsules/src/console.rs
+++ b/capsules/src/console.rs
@@ -84,7 +84,7 @@ pub struct Console<'a, U: UART> {
     baud_rate: u32,
 }
 
-impl<'a, U: UART> Console<'a, U> {
+impl<U: UART> Console<'a, U> {
     pub fn new(
         uart: &'a U,
         baud_rate: u32,
@@ -208,7 +208,7 @@ impl<'a, U: UART> Console<'a, U> {
     }
 }
 
-impl<'a, U: UART> Driver for Console<'a, U> {
+impl<U: UART> Driver for Console<'a, U> {
     /// Setup shared buffers.
     ///
     /// ### `allow_num`
@@ -303,7 +303,7 @@ impl<'a, U: UART> Driver for Console<'a, U> {
     }
 }
 
-impl<'a, U: UART> Client for Console<'a, U> {
+impl<U: UART> Client for Console<'a, U> {
     fn transmit_complete(&self, buffer: &'static mut [u8], _error: uart::Error) {
         // Either print more from the AppSlice or send a callback to the
         // application.

--- a/capsules/src/console.rs
+++ b/capsules/src/console.rs
@@ -74,7 +74,7 @@ impl Default for App {
 pub static mut WRITE_BUF: [u8; 64] = [0; 64];
 pub static mut READ_BUF: [u8; 64] = [0; 64];
 
-pub struct Console<'a, U: UART + 'a> {
+pub struct Console<'a, U: UART> {
     uart: &'a U,
     apps: Grant<App>,
     tx_in_progress: Cell<Option<AppId>>,

--- a/capsules/src/crc.rs
+++ b/capsules/src/crc.rs
@@ -92,7 +92,7 @@ pub struct Crc<'a, C: hil::crc::CRC> {
     serving_app: Cell<Option<AppId>>,
 }
 
-impl<'a, C: hil::crc::CRC> Crc<'a, C> {
+impl<C: hil::crc::CRC> Crc<'a, C> {
     /// Create a `Crc` driver
     ///
     /// The argument `crc_unit` must implement the abstract `CRC`
@@ -164,7 +164,7 @@ impl<'a, C: hil::crc::CRC> Crc<'a, C> {
 /// the `subscribe` system call and `allow`s the driver access to the buffer over-which to compute.
 /// Then, it initiates a CRC computation using the `command` system call. See function-specific
 /// comments for details.
-impl<'a, C: hil::crc::CRC> Driver for Crc<'a, C> {
+impl<C: hil::crc::CRC> Driver for Crc<'a, C> {
     /// The `allow` syscall for this driver supports the single
     /// `allow_num` zero, which is used to provide a buffer over which
     /// to compute a CRC computation.
@@ -321,7 +321,7 @@ impl<'a, C: hil::crc::CRC> Driver for Crc<'a, C> {
     }
 }
 
-impl<'a, C: hil::crc::CRC> hil::crc::Client for Crc<'a, C> {
+impl<C: hil::crc::CRC> hil::crc::Client for Crc<'a, C> {
     fn receive_result(&self, result: u32) {
         if let Some(appid) = self.serving_app.get() {
             self.apps

--- a/capsules/src/crc.rs
+++ b/capsules/src/crc.rs
@@ -86,7 +86,7 @@ pub struct App {
 
 /// Struct that holds the state of the CRC driver and implements the `Driver` trait for use by
 /// processes through the system call interface.
-pub struct Crc<'a, C: hil::crc::CRC + 'a> {
+pub struct Crc<'a, C: hil::crc::CRC> {
     crc_unit: &'a C,
     apps: Grant<App>,
     serving_app: Cell<Option<AppId>>,

--- a/capsules/src/dac.rs
+++ b/capsules/src/dac.rs
@@ -19,13 +19,13 @@ pub struct Dac<'a> {
     dac: &'a hil::dac::DacChannel,
 }
 
-impl<'a> Dac<'a> {
+impl Dac<'a> {
     pub fn new(dac: &'a hil::dac::DacChannel) -> Dac<'a> {
         Dac { dac: dac }
     }
 }
 
-impl<'a> Driver for Dac<'a> {
+impl Driver for Dac<'a> {
     /// Control the DAC.
     ///
     /// ### `command_num`

--- a/capsules/src/fm25cl.rs
+++ b/capsules/src/fm25cl.rs
@@ -87,7 +87,7 @@ pub trait FM25CLClient {
     fn done(&self, buffer: &'static mut [u8]);
 }
 
-pub struct FM25CL<'a, S: hil::spi::SpiMasterDevice + 'a> {
+pub struct FM25CL<'a, S: hil::spi::SpiMasterDevice> {
     spi: &'a S,
     state: Cell<State>,
     txbuffer: TakeCell<'static, [u8]>,
@@ -99,7 +99,7 @@ pub struct FM25CL<'a, S: hil::spi::SpiMasterDevice + 'a> {
     client_write_len: Cell<u16>,
 }
 
-impl<'a, S: hil::spi::SpiMasterDevice + 'a> FM25CL<'a, S> {
+impl<'a, S: hil::spi::SpiMasterDevice> FM25CL<'a, S> {
     pub fn new(
         spi: &'a S,
         txbuffer: &'static mut [u8],
@@ -179,7 +179,7 @@ impl<'a, S: hil::spi::SpiMasterDevice + 'a> FM25CL<'a, S> {
     }
 }
 
-impl<'a, S: hil::spi::SpiMasterDevice + 'a> hil::spi::SpiMasterClient for FM25CL<'a, S> {
+impl<'a, S: hil::spi::SpiMasterDevice> hil::spi::SpiMasterClient for FM25CL<'a, S> {
     fn read_write_done(
         &self,
         write_buffer: &'static mut [u8],
@@ -267,7 +267,7 @@ impl<'a, S: hil::spi::SpiMasterDevice + 'a> hil::spi::SpiMasterClient for FM25CL
 }
 
 // Implement the custom interface that exposes chip-specific commands.
-impl<'a, S: hil::spi::SpiMasterDevice + 'a> FM25CLCustom for FM25CL<'a, S> {
+impl<'a, S: hil::spi::SpiMasterDevice> FM25CLCustom for FM25CL<'a, S> {
     fn read_status(&self) -> ReturnCode {
         self.configure_spi();
 
@@ -291,7 +291,7 @@ impl<'a, S: hil::spi::SpiMasterDevice + 'a> FM25CLCustom for FM25CL<'a, S> {
 
 /// Implement the generic `NonvolatileStorage` interface common to chips that
 /// provide nonvolatile memory.
-impl<'a, S: hil::spi::SpiMasterDevice + 'a> hil::nonvolatile_storage::NonvolatileStorage
+impl<'a, S: hil::spi::SpiMasterDevice> hil::nonvolatile_storage::NonvolatileStorage
     for FM25CL<'a, S>
 {
     fn set_client(&self, client: &'static hil::nonvolatile_storage::NonvolatileStorageClient) {

--- a/capsules/src/fm25cl.rs
+++ b/capsules/src/fm25cl.rs
@@ -99,7 +99,7 @@ pub struct FM25CL<'a, S: hil::spi::SpiMasterDevice> {
     client_write_len: Cell<u16>,
 }
 
-impl<'a, S: hil::spi::SpiMasterDevice> FM25CL<'a, S> {
+impl<S: hil::spi::SpiMasterDevice> FM25CL<'a, S> {
     pub fn new(
         spi: &'a S,
         txbuffer: &'static mut [u8],
@@ -179,7 +179,7 @@ impl<'a, S: hil::spi::SpiMasterDevice> FM25CL<'a, S> {
     }
 }
 
-impl<'a, S: hil::spi::SpiMasterDevice> hil::spi::SpiMasterClient for FM25CL<'a, S> {
+impl<S: hil::spi::SpiMasterDevice> hil::spi::SpiMasterClient for FM25CL<'a, S> {
     fn read_write_done(
         &self,
         write_buffer: &'static mut [u8],
@@ -267,7 +267,7 @@ impl<'a, S: hil::spi::SpiMasterDevice> hil::spi::SpiMasterClient for FM25CL<'a, 
 }
 
 // Implement the custom interface that exposes chip-specific commands.
-impl<'a, S: hil::spi::SpiMasterDevice> FM25CLCustom for FM25CL<'a, S> {
+impl<S: hil::spi::SpiMasterDevice> FM25CLCustom for FM25CL<'a, S> {
     fn read_status(&self) -> ReturnCode {
         self.configure_spi();
 
@@ -291,9 +291,7 @@ impl<'a, S: hil::spi::SpiMasterDevice> FM25CLCustom for FM25CL<'a, S> {
 
 /// Implement the generic `NonvolatileStorage` interface common to chips that
 /// provide nonvolatile memory.
-impl<'a, S: hil::spi::SpiMasterDevice> hil::nonvolatile_storage::NonvolatileStorage
-    for FM25CL<'a, S>
-{
+impl<S: hil::spi::SpiMasterDevice> hil::nonvolatile_storage::NonvolatileStorage for FM25CL<'a, S> {
     fn set_client(&self, client: &'static hil::nonvolatile_storage::NonvolatileStorageClient) {
         self.client.set(Some(client));
     }

--- a/capsules/src/fxos8700cq.rs
+++ b/capsules/src/fxos8700cq.rs
@@ -182,7 +182,7 @@ pub struct Fxos8700cq<'a> {
     callback: Cell<Option<&'static hil::sensors::NineDofClient>>,
 }
 
-impl<'a> Fxos8700cq<'a> {
+impl Fxos8700cq<'a> {
     pub fn new(
         i2c: &'a I2CDevice,
         interrupt_pin1: &'a gpio::Pin,
@@ -224,7 +224,7 @@ impl<'a> Fxos8700cq<'a> {
     }
 }
 
-impl<'a> gpio::Client for Fxos8700cq<'a> {
+impl gpio::Client for Fxos8700cq<'a> {
     fn fired(&self, _: usize) {
         self.buffer.take().map(|buffer| {
             self.interrupt_pin1.disable_interrupt();
@@ -238,7 +238,7 @@ impl<'a> gpio::Client for Fxos8700cq<'a> {
     }
 }
 
-impl<'a> I2CClient for Fxos8700cq<'a> {
+impl I2CClient for Fxos8700cq<'a> {
     fn command_complete(&self, buffer: &'static mut [u8], _error: Error) {
         match self.state.get() {
             State::ReadAccelSetup => {
@@ -316,7 +316,7 @@ impl<'a> I2CClient for Fxos8700cq<'a> {
     }
 }
 
-impl<'a> hil::sensors::NineDof for Fxos8700cq<'a> {
+impl hil::sensors::NineDof for Fxos8700cq<'a> {
     fn set_client(&self, client: &'static hil::sensors::NineDofClient) {
         self.callback.set(Some(client));
     }

--- a/capsules/src/gpio.rs
+++ b/capsules/src/gpio.rs
@@ -55,7 +55,7 @@ pub struct GPIO<'a, G: Pin> {
     callback: Cell<Option<Callback>>,
 }
 
-impl<'a, G: Pin + PinCtl> GPIO<'a, G> {
+impl<G: Pin + PinCtl> GPIO<'a, G> {
     pub fn new(pins: &'a [&'a G]) -> GPIO<'a, G> {
         GPIO {
             pins: pins,
@@ -106,7 +106,7 @@ impl<'a, G: Pin + PinCtl> GPIO<'a, G> {
     }
 }
 
-impl<'a, G: Pin> Client for GPIO<'a, G> {
+impl<G: Pin> Client for GPIO<'a, G> {
     fn fired(&self, pin_num: usize) {
         // read the value of the pin
         let pins = self.pins.as_ref();
@@ -119,7 +119,7 @@ impl<'a, G: Pin> Client for GPIO<'a, G> {
     }
 }
 
-impl<'a, G: Pin + PinCtl> Driver for GPIO<'a, G> {
+impl<G: Pin + PinCtl> Driver for GPIO<'a, G> {
     /// Subscribe to GPIO pin events.
     ///
     /// ### `subscribe_num`

--- a/capsules/src/gpio.rs
+++ b/capsules/src/gpio.rs
@@ -50,7 +50,7 @@ use core::cell::Cell;
 use kernel::hil::gpio::{Client, InputMode, InterruptMode, Pin, PinCtl};
 use kernel::{AppId, Callback, Driver, ReturnCode};
 
-pub struct GPIO<'a, G: Pin + 'a> {
+pub struct GPIO<'a, G: Pin> {
     pins: &'a [&'a G],
     callback: Cell<Option<Callback>>,
 }

--- a/capsules/src/gpio_async.rs
+++ b/capsules/src/gpio_async.rs
@@ -31,7 +31,7 @@ use kernel::{AppId, Callback, Driver};
 /// Syscall driver number.
 pub const DRIVER_NUM: usize = 0x80003;
 
-pub struct GPIOAsync<'a, Port: hil::gpio_async::Port + 'a> {
+pub struct GPIOAsync<'a, Port: hil::gpio_async::Port> {
     ports: &'a [&'a Port],
     callback: Cell<Option<Callback>>,
     interrupt_callback: Cell<Option<Callback>>,

--- a/capsules/src/gpio_async.rs
+++ b/capsules/src/gpio_async.rs
@@ -37,7 +37,7 @@ pub struct GPIOAsync<'a, Port: hil::gpio_async::Port> {
     interrupt_callback: Cell<Option<Callback>>,
 }
 
-impl<'a, Port: hil::gpio_async::Port> GPIOAsync<'a, Port> {
+impl<Port: hil::gpio_async::Port> GPIOAsync<'a, Port> {
     pub fn new(ports: &'a [&'a Port]) -> GPIOAsync<'a, Port> {
         GPIOAsync {
             ports: ports,
@@ -69,7 +69,7 @@ impl<'a, Port: hil::gpio_async::Port> GPIOAsync<'a, Port> {
     }
 }
 
-impl<'a, Port: hil::gpio_async::Port> hil::gpio_async::Client for GPIOAsync<'a, Port> {
+impl<Port: hil::gpio_async::Port> hil::gpio_async::Client for GPIOAsync<'a, Port> {
     fn fired(&self, pin: usize, identifier: usize) {
         self.interrupt_callback
             .get()
@@ -81,7 +81,7 @@ impl<'a, Port: hil::gpio_async::Port> hil::gpio_async::Client for GPIOAsync<'a, 
     }
 }
 
-impl<'a, Port: hil::gpio_async::Port> Driver for GPIOAsync<'a, Port> {
+impl<Port: hil::gpio_async::Port> Driver for GPIOAsync<'a, Port> {
     /// Setup callbacks for gpio_async events.
     ///
     /// ### `subscribe_num`

--- a/capsules/src/humidity.rs
+++ b/capsules/src/humidity.rs
@@ -72,7 +72,7 @@ pub struct HumiditySensor<'a> {
     busy: Cell<bool>,
 }
 
-impl<'a> HumiditySensor<'a> {
+impl HumiditySensor<'a> {
     pub fn new(driver: &'a hil::sensors::HumidityDriver, grant: Grant<App>) -> HumiditySensor<'a> {
         HumiditySensor {
             driver: driver,
@@ -112,7 +112,7 @@ impl<'a> HumiditySensor<'a> {
     }
 }
 
-impl<'a> hil::sensors::HumidityClient for HumiditySensor<'a> {
+impl hil::sensors::HumidityClient for HumiditySensor<'a> {
     fn callback(&self, tmp_val: usize) {
         for cntr in self.apps.iter() {
             cntr.enter(|app, _| {
@@ -126,7 +126,7 @@ impl<'a> hil::sensors::HumidityClient for HumiditySensor<'a> {
     }
 }
 
-impl<'a> Driver for HumiditySensor<'a> {
+impl Driver for HumiditySensor<'a> {
     fn subscribe(
         &self,
         subscribe_num: usize,

--- a/capsules/src/i2c_master_slave_driver.rs
+++ b/capsules/src/i2c_master_slave_driver.rs
@@ -61,7 +61,7 @@ pub struct I2CMasterSlaveDriver<'a> {
     app: MapCell<App>,
 }
 
-impl<'a> I2CMasterSlaveDriver<'a> {
+impl I2CMasterSlaveDriver<'a> {
     pub fn new(
         i2c: &'a hil::i2c::I2CMasterSlave,
         master_buffer: &'static mut [u8],
@@ -80,7 +80,7 @@ impl<'a> I2CMasterSlaveDriver<'a> {
     }
 }
 
-impl<'a> hil::i2c::I2CHwMasterClient for I2CMasterSlaveDriver<'a> {
+impl hil::i2c::I2CHwMasterClient for I2CMasterSlaveDriver<'a> {
     fn command_complete(&self, buffer: &'static mut [u8], error: hil::i2c::Error) {
         // Map I2C error to a number we can pass back to the application
         let err: isize = match error {
@@ -146,7 +146,7 @@ impl<'a> hil::i2c::I2CHwMasterClient for I2CMasterSlaveDriver<'a> {
     }
 }
 
-impl<'a> hil::i2c::I2CHwSlaveClient for I2CMasterSlaveDriver<'a> {
+impl hil::i2c::I2CHwSlaveClient for I2CMasterSlaveDriver<'a> {
     fn command_complete(
         &self,
         buffer: &'static mut [u8],
@@ -218,7 +218,7 @@ impl<'a> hil::i2c::I2CHwSlaveClient for I2CMasterSlaveDriver<'a> {
     }
 }
 
-impl<'a> Driver for I2CMasterSlaveDriver<'a> {
+impl Driver for I2CMasterSlaveDriver<'a> {
     fn allow(
         &self,
         _appid: AppId,

--- a/capsules/src/ieee802154/driver.rs
+++ b/capsules/src/ieee802154/driver.rs
@@ -98,7 +98,7 @@ fn decode_key_id(buf: &[u8]) -> SResult<KeyId> {
     }
 }
 
-impl<'a> From<&'a KeyId> for KeyIdModeUserland {
+impl From<&'a KeyId> for KeyIdModeUserland {
     fn from(key_id: &'a KeyId) -> Self {
         match *key_id {
             KeyId::Implicit => KeyIdModeUserland::Implicit,
@@ -191,7 +191,7 @@ pub struct RadioDriver<'a> {
     kernel_tx: TakeCell<'static, [u8]>,
 }
 
-impl<'a> RadioDriver<'a> {
+impl RadioDriver<'a> {
     pub fn new(
         mac: &'a device::MacDevice<'a>,
         grant: Grant<App>,
@@ -493,7 +493,7 @@ impl<'a> RadioDriver<'a> {
     }
 }
 
-impl<'a> framer::DeviceProcedure for RadioDriver<'a> {
+impl framer::DeviceProcedure for RadioDriver<'a> {
     /// Gets the long address corresponding to the neighbor that matches the given
     /// MAC address. If no such neighbor exists, returns `None`.
     fn lookup_addr_long(&self, addr: MacAddress) -> Option<([u8; 8])> {
@@ -509,7 +509,7 @@ impl<'a> framer::DeviceProcedure for RadioDriver<'a> {
     }
 }
 
-impl<'a> framer::KeyProcedure for RadioDriver<'a> {
+impl framer::KeyProcedure for RadioDriver<'a> {
     /// Gets the key corresponding to the key that matches the given security
     /// level `level` and key ID `key_id`. If no such key matches, returns
     /// `None`.
@@ -523,7 +523,7 @@ impl<'a> framer::KeyProcedure for RadioDriver<'a> {
     }
 }
 
-impl<'a> Driver for RadioDriver<'a> {
+impl Driver for RadioDriver<'a> {
     /// Setup buffers to read/write from.
     ///
     /// ### `allow_num`
@@ -795,7 +795,7 @@ impl<'a> Driver for RadioDriver<'a> {
     }
 }
 
-impl<'a> device::TxClient for RadioDriver<'a> {
+impl device::TxClient for RadioDriver<'a> {
     fn send_done(&self, spi_buf: &'static mut [u8], acked: bool, result: ReturnCode) {
         self.kernel_tx.replace(spi_buf);
         self.current_app.get().map(|appid| {
@@ -826,7 +826,7 @@ fn encode_address(addr: &Option<MacAddress>) -> usize {
     ((AddressMode::from(addr) as usize) << 16) | short_addr_only
 }
 
-impl<'a> device::RxClient for RadioDriver<'a> {
+impl device::RxClient for RadioDriver<'a> {
     fn receive<'b>(&self, buf: &'b [u8], header: Header<'b>, data_offset: usize, data_len: usize) {
         self.apps.each(|app| {
             app.app_read.take().as_mut().map(|rbuf| {

--- a/capsules/src/ieee802154/framer.rs
+++ b/capsules/src/ieee802154/framer.rs
@@ -289,7 +289,7 @@ enum RxState {
 /// machines corresponding to the transmission, reception and
 /// encryption/decryption pipelines. See the documentation in
 /// `capsules/src/mac.rs` for more details.
-pub struct Framer<'a, M: Mac + 'a, A: AES128CCM<'a> + 'a> {
+pub struct Framer<'a, M: Mac, A: AES128CCM<'a>> {
     mac: &'a M,
     aes_ccm: &'a A,
     data_sequence: Cell<u8>,
@@ -312,7 +312,7 @@ pub struct Framer<'a, M: Mac + 'a, A: AES128CCM<'a> + 'a> {
     rx_client: Cell<Option<&'a RxClient>>,
 }
 
-impl<'a, M: Mac + 'a, A: AES128CCM<'a> + 'a> Framer<'a, M, A> {
+impl<'a, M: Mac, A: AES128CCM<'a>> Framer<'a, M, A> {
     pub fn new(mac: &'a M, aes_ccm: &'a A) -> Framer<'a, M, A> {
         Framer {
             mac: mac,
@@ -645,7 +645,7 @@ impl<'a, M: Mac + 'a, A: AES128CCM<'a> + 'a> Framer<'a, M, A> {
     }
 }
 
-impl<'a, M: Mac + 'a, A: AES128CCM<'a> + 'a> MacDevice<'a> for Framer<'a, M, A> {
+impl<'a, M: Mac, A: AES128CCM<'a>> MacDevice<'a> for Framer<'a, M, A> {
     fn set_transmit_client(&self, client: &'a TxClient) {
         self.tx_client.set(Some(client));
     }
@@ -785,7 +785,7 @@ impl<'a, M: Mac + 'a, A: AES128CCM<'a> + 'a> MacDevice<'a> for Framer<'a, M, A> 
     }
 }
 
-impl<'a, M: Mac + 'a, A: AES128CCM<'a> + 'a> radio::TxClient for Framer<'a, M, A> {
+impl<'a, M: Mac, A: AES128CCM<'a>> radio::TxClient for Framer<'a, M, A> {
     fn send_done(&self, buf: &'static mut [u8], acked: bool, result: ReturnCode) {
         self.data_sequence.set(self.data_sequence.get() + 1);
         self.tx_client.get().map(move |client| {
@@ -794,7 +794,7 @@ impl<'a, M: Mac + 'a, A: AES128CCM<'a> + 'a> radio::TxClient for Framer<'a, M, A
     }
 }
 
-impl<'a, M: Mac + 'a, A: AES128CCM<'a> + 'a> radio::RxClient for Framer<'a, M, A> {
+impl<'a, M: Mac, A: AES128CCM<'a>> radio::RxClient for Framer<'a, M, A> {
     fn receive(&self, buf: &'static mut [u8], frame_len: usize, crc_valid: bool, _: ReturnCode) {
         // Drop all frames with invalid CRC
         if !crc_valid {
@@ -824,7 +824,7 @@ impl<'a, M: Mac + 'a, A: AES128CCM<'a> + 'a> radio::RxClient for Framer<'a, M, A
     }
 }
 
-impl<'a, M: Mac + 'a, A: AES128CCM<'a> + 'a> radio::ConfigClient for Framer<'a, M, A> {
+impl<'a, M: Mac, A: AES128CCM<'a>> radio::ConfigClient for Framer<'a, M, A> {
     fn config_done(&self, _: ReturnCode) {
         // The transmission pipeline is the only state machine that
         // waits for the configuration procedure to complete before
@@ -839,7 +839,7 @@ impl<'a, M: Mac + 'a, A: AES128CCM<'a> + 'a> radio::ConfigClient for Framer<'a, 
     }
 }
 
-impl<'a, M: Mac + 'a, A: AES128CCM<'a> + 'a> CCMClient for Framer<'a, M, A> {
+impl<'a, M: Mac, A: AES128CCM<'a>> CCMClient for Framer<'a, M, A> {
     fn crypt_done(&self, buf: &'static mut [u8], res: ReturnCode, tag_is_valid: bool) {
         let mut tx_waiting = false;
         let mut rx_waiting = false;

--- a/capsules/src/ieee802154/framer.rs
+++ b/capsules/src/ieee802154/framer.rs
@@ -312,7 +312,7 @@ pub struct Framer<'a, M: Mac, A: AES128CCM<'a>> {
     rx_client: Cell<Option<&'a RxClient>>,
 }
 
-impl<'a, M: Mac, A: AES128CCM<'a>> Framer<'a, M, A> {
+impl<M: Mac, A: AES128CCM<'a>> Framer<'a, M, A> {
     pub fn new(mac: &'a M, aes_ccm: &'a A) -> Framer<'a, M, A> {
         Framer {
             mac: mac,
@@ -645,7 +645,7 @@ impl<'a, M: Mac, A: AES128CCM<'a>> Framer<'a, M, A> {
     }
 }
 
-impl<'a, M: Mac, A: AES128CCM<'a>> MacDevice<'a> for Framer<'a, M, A> {
+impl<M: Mac, A: AES128CCM<'a>> MacDevice<'a> for Framer<'a, M, A> {
     fn set_transmit_client(&self, client: &'a TxClient) {
         self.tx_client.set(Some(client));
     }
@@ -785,7 +785,7 @@ impl<'a, M: Mac, A: AES128CCM<'a>> MacDevice<'a> for Framer<'a, M, A> {
     }
 }
 
-impl<'a, M: Mac, A: AES128CCM<'a>> radio::TxClient for Framer<'a, M, A> {
+impl<M: Mac, A: AES128CCM<'a>> radio::TxClient for Framer<'a, M, A> {
     fn send_done(&self, buf: &'static mut [u8], acked: bool, result: ReturnCode) {
         self.data_sequence.set(self.data_sequence.get() + 1);
         self.tx_client.get().map(move |client| {
@@ -794,7 +794,7 @@ impl<'a, M: Mac, A: AES128CCM<'a>> radio::TxClient for Framer<'a, M, A> {
     }
 }
 
-impl<'a, M: Mac, A: AES128CCM<'a>> radio::RxClient for Framer<'a, M, A> {
+impl<M: Mac, A: AES128CCM<'a>> radio::RxClient for Framer<'a, M, A> {
     fn receive(&self, buf: &'static mut [u8], frame_len: usize, crc_valid: bool, _: ReturnCode) {
         // Drop all frames with invalid CRC
         if !crc_valid {
@@ -824,7 +824,7 @@ impl<'a, M: Mac, A: AES128CCM<'a>> radio::RxClient for Framer<'a, M, A> {
     }
 }
 
-impl<'a, M: Mac, A: AES128CCM<'a>> radio::ConfigClient for Framer<'a, M, A> {
+impl<M: Mac, A: AES128CCM<'a>> radio::ConfigClient for Framer<'a, M, A> {
     fn config_done(&self, _: ReturnCode) {
         // The transmission pipeline is the only state machine that
         // waits for the configuration procedure to complete before
@@ -839,7 +839,7 @@ impl<'a, M: Mac, A: AES128CCM<'a>> radio::ConfigClient for Framer<'a, M, A> {
     }
 }
 
-impl<'a, M: Mac, A: AES128CCM<'a>> CCMClient for Framer<'a, M, A> {
+impl<M: Mac, A: AES128CCM<'a>> CCMClient for Framer<'a, M, A> {
     fn crypt_done(&self, buf: &'static mut [u8], res: ReturnCode, tag_is_valid: bool) {
         let mut tx_waiting = false;
         let mut rx_waiting = false;

--- a/capsules/src/ieee802154/mac.rs
+++ b/capsules/src/ieee802154/mac.rs
@@ -66,14 +66,14 @@ pub trait Mac {
 /// implementation and the underlying radio::Radio device. Does not change the power
 /// state of the radio during operation.
 ///
-pub struct AwakeMac<'a, R: radio::Radio + 'a> {
+pub struct AwakeMac<'a, R: radio::Radio> {
     radio: &'a R,
 
     tx_client: Cell<Option<&'static radio::TxClient>>,
     rx_client: Cell<Option<&'static radio::RxClient>>,
 }
 
-impl<'a, R: radio::Radio + 'a> AwakeMac<'a, R> {
+impl<'a, R: radio::Radio> AwakeMac<'a, R> {
     pub fn new(radio: &'a R) -> AwakeMac<'a, R> {
         AwakeMac {
             radio: radio,
@@ -83,7 +83,7 @@ impl<'a, R: radio::Radio + 'a> AwakeMac<'a, R> {
     }
 }
 
-impl<'a, R: radio::Radio + 'a> Mac for AwakeMac<'a, R> {
+impl<'a, R: radio::Radio> Mac for AwakeMac<'a, R> {
     fn initialize(&self, _mac_buf: &'static mut [u8]) -> ReturnCode {
         // do nothing, extra buffer unnecessary
         ReturnCode::SUCCESS
@@ -146,7 +146,7 @@ impl<'a, R: radio::Radio + 'a> Mac for AwakeMac<'a, R> {
     }
 }
 
-impl<'a, R: radio::Radio + 'a> radio::TxClient for AwakeMac<'a, R> {
+impl<'a, R: radio::Radio> radio::TxClient for AwakeMac<'a, R> {
     fn send_done(&self, buf: &'static mut [u8], acked: bool, result: ReturnCode) {
         self.tx_client.get().map(move |c| {
             c.send_done(buf, acked, result);
@@ -154,7 +154,7 @@ impl<'a, R: radio::Radio + 'a> radio::TxClient for AwakeMac<'a, R> {
     }
 }
 
-impl<'a, R: radio::Radio + 'a> radio::RxClient for AwakeMac<'a, R> {
+impl<'a, R: radio::Radio> radio::RxClient for AwakeMac<'a, R> {
     fn receive(
         &self,
         buf: &'static mut [u8],

--- a/capsules/src/ieee802154/mac.rs
+++ b/capsules/src/ieee802154/mac.rs
@@ -73,7 +73,7 @@ pub struct AwakeMac<'a, R: radio::Radio> {
     rx_client: Cell<Option<&'static radio::RxClient>>,
 }
 
-impl<'a, R: radio::Radio> AwakeMac<'a, R> {
+impl<R: radio::Radio> AwakeMac<'a, R> {
     pub fn new(radio: &'a R) -> AwakeMac<'a, R> {
         AwakeMac {
             radio: radio,
@@ -83,7 +83,7 @@ impl<'a, R: radio::Radio> AwakeMac<'a, R> {
     }
 }
 
-impl<'a, R: radio::Radio> Mac for AwakeMac<'a, R> {
+impl<R: radio::Radio> Mac for AwakeMac<'a, R> {
     fn initialize(&self, _mac_buf: &'static mut [u8]) -> ReturnCode {
         // do nothing, extra buffer unnecessary
         ReturnCode::SUCCESS
@@ -146,7 +146,7 @@ impl<'a, R: radio::Radio> Mac for AwakeMac<'a, R> {
     }
 }
 
-impl<'a, R: radio::Radio> radio::TxClient for AwakeMac<'a, R> {
+impl<R: radio::Radio> radio::TxClient for AwakeMac<'a, R> {
     fn send_done(&self, buf: &'static mut [u8], acked: bool, result: ReturnCode) {
         self.tx_client.get().map(move |c| {
             c.send_done(buf, acked, result);
@@ -154,7 +154,7 @@ impl<'a, R: radio::Radio> radio::TxClient for AwakeMac<'a, R> {
     }
 }
 
-impl<'a, R: radio::Radio> radio::RxClient for AwakeMac<'a, R> {
+impl<R: radio::Radio> radio::RxClient for AwakeMac<'a, R> {
     fn receive(
         &self,
         buf: &'static mut [u8],

--- a/capsules/src/ieee802154/virtual_mac.rs
+++ b/capsules/src/ieee802154/virtual_mac.rs
@@ -42,7 +42,7 @@ pub struct MuxMac<'a> {
     inflight: Cell<Option<&'a MacUser<'a>>>,
 }
 
-impl<'a> device::TxClient for MuxMac<'a> {
+impl device::TxClient for MuxMac<'a> {
     fn send_done(&self, spi_buf: &'static mut [u8], acked: bool, result: ReturnCode) {
         self.inflight.get().map(move |user| {
             self.inflight.set(None);
@@ -52,7 +52,7 @@ impl<'a> device::TxClient for MuxMac<'a> {
     }
 }
 
-impl<'a> device::RxClient for MuxMac<'a> {
+impl device::RxClient for MuxMac<'a> {
     fn receive<'b>(&self, buf: &'b [u8], header: Header<'b>, data_offset: usize, data_len: usize) {
         for user in self.users.iter() {
             user.receive(buf, header, data_offset, data_len);
@@ -60,7 +60,7 @@ impl<'a> device::RxClient for MuxMac<'a> {
     }
 }
 
-impl<'a> MuxMac<'a> {
+impl MuxMac<'a> {
     pub const fn new(mac: &'a device::MacDevice<'a>) -> MuxMac<'a> {
         MuxMac {
             mac: mac,
@@ -192,7 +192,7 @@ pub struct MacUser<'a> {
     rx_client: Cell<Option<&'a device::RxClient>>,
 }
 
-impl<'a> MacUser<'a> {
+impl MacUser<'a> {
     pub const fn new(mux: &'a MuxMac<'a>) -> MacUser<'a> {
         MacUser {
             mux: mux,
@@ -204,7 +204,7 @@ impl<'a> MacUser<'a> {
     }
 }
 
-impl<'a> MacUser<'a> {
+impl MacUser<'a> {
     fn send_done(&self, spi_buf: &'static mut [u8], acked: bool, result: ReturnCode) {
         self.tx_client
             .get()
@@ -218,13 +218,13 @@ impl<'a> MacUser<'a> {
     }
 }
 
-impl<'a> ListNode<'a, MacUser<'a>> for MacUser<'a> {
+impl ListNode<'a, MacUser<'a>> for MacUser<'a> {
     fn next(&'a self) -> &'a ListLink<'a, MacUser<'a>> {
         &self.next
     }
 }
 
-impl<'a> device::MacDevice<'a> for MacUser<'a> {
+impl device::MacDevice<'a> for MacUser<'a> {
     fn set_transmit_client(&self, client: &'a device::TxClient) {
         self.tx_client.set(Some(client));
     }

--- a/capsules/src/ieee802154/xmac.rs
+++ b/capsules/src/ieee802154/xmac.rs
@@ -162,7 +162,7 @@ pub struct XMac<'a, R: radio::Radio, A: Alarm> {
     rx_pending: Cell<bool>,
 }
 
-impl<'a, R: radio::Radio, A: Alarm> XMac<'a, R, A> {
+impl<R: radio::Radio, A: Alarm> XMac<'a, R, A> {
     pub fn new(radio: &'a R, alarm: &'a A, rng: &'a RNG) -> XMac<'a, R, A> {
         XMac {
             radio: radio,
@@ -308,7 +308,7 @@ impl<'a, R: radio::Radio, A: Alarm> XMac<'a, R, A> {
     }
 }
 
-impl<'a, R: radio::Radio, A: Alarm> rng::Client for XMac<'a, R, A> {
+impl<R: radio::Radio, A: Alarm> rng::Client for XMac<'a, R, A> {
     fn randomness_available(&self, randomness: &mut Iterator<Item = u32>) -> rng::Continue {
         match randomness.next() {
             Some(random) => {
@@ -335,7 +335,7 @@ impl<'a, R: radio::Radio, A: Alarm> rng::Client for XMac<'a, R, A> {
 }
 
 // The vast majority of these calls pass through to the underlying radio driver.
-impl<'a, R: radio::Radio, A: Alarm> Mac for XMac<'a, R, A> {
+impl<R: radio::Radio, A: Alarm> Mac for XMac<'a, R, A> {
     fn initialize(&self, mac_buf: &'static mut [u8]) -> ReturnCode {
         self.tx_preamble_buf.replace(mac_buf);
         self.state.set(XMacState::STARTUP);
@@ -456,7 +456,7 @@ impl<'a, R: radio::Radio, A: Alarm> Mac for XMac<'a, R, A> {
 
 // Core of the XMAC protocol - when the timer fires, the protocol state
 // indicates the next state/action to take.
-impl<'a, R: radio::Radio, A: Alarm> time::Client for XMac<'a, R, A> {
+impl<R: radio::Radio, A: Alarm> time::Client for XMac<'a, R, A> {
     fn fired(&self) {
         match self.state.get() {
             XMacState::SLEEP => {
@@ -496,7 +496,7 @@ impl<'a, R: radio::Radio, A: Alarm> time::Client for XMac<'a, R, A> {
     }
 }
 
-impl<'a, R: radio::Radio, A: Alarm> radio::PowerClient for XMac<'a, R, A> {
+impl<R: radio::Radio, A: Alarm> radio::PowerClient for XMac<'a, R, A> {
     fn changed(&self, on: bool) {
         // If the radio turns on and we're in STARTUP, then either transition to
         // listening for incoming preambles or start transmitting preambles if
@@ -517,7 +517,7 @@ impl<'a, R: radio::Radio, A: Alarm> radio::PowerClient for XMac<'a, R, A> {
     }
 }
 
-impl<'a, R: radio::Radio, A: Alarm> radio::TxClient for XMac<'a, R, A> {
+impl<R: radio::Radio, A: Alarm> radio::TxClient for XMac<'a, R, A> {
     fn send_done(&self, buf: &'static mut [u8], acked: bool, result: ReturnCode) {
         match self.state.get() {
             // Completed a data transmission to the destination node
@@ -551,7 +551,7 @@ impl<'a, R: radio::Radio, A: Alarm> radio::TxClient for XMac<'a, R, A> {
 // destination node is receiving packets/awake while we are attempting a
 // transmission, we put the radio in promiscuous mode. Not a huge issue, but
 // we need to be wary of incoming packets not actually addressed to our node.
-impl<'a, R: radio::Radio, A: Alarm> radio::RxClient for XMac<'a, R, A> {
+impl<R: radio::Radio, A: Alarm> radio::RxClient for XMac<'a, R, A> {
     fn receive(
         &self,
         buf: &'static mut [u8],

--- a/capsules/src/ieee802154/xmac.rs
+++ b/capsules/src/ieee802154/xmac.rs
@@ -142,7 +142,7 @@ pub struct XMacHeaderInfo {
 // the tx/rx client, and the underlying radio driver. The transmit buffer can
 // also hold the actual data packet contents while preambles are being
 // transmitted.
-pub struct XMac<'a, R: radio::Radio + 'a, A: Alarm + 'a> {
+pub struct XMac<'a, R: radio::Radio, A: Alarm> {
     radio: &'a R,
     alarm: &'a A,
     rng: &'a RNG,
@@ -162,7 +162,7 @@ pub struct XMac<'a, R: radio::Radio + 'a, A: Alarm + 'a> {
     rx_pending: Cell<bool>,
 }
 
-impl<'a, R: radio::Radio + 'a, A: Alarm + 'a> XMac<'a, R, A> {
+impl<'a, R: radio::Radio, A: Alarm> XMac<'a, R, A> {
     pub fn new(radio: &'a R, alarm: &'a A, rng: &'a RNG) -> XMac<'a, R, A> {
         XMac {
             radio: radio,
@@ -308,7 +308,7 @@ impl<'a, R: radio::Radio + 'a, A: Alarm + 'a> XMac<'a, R, A> {
     }
 }
 
-impl<'a, R: radio::Radio + 'a, A: Alarm + 'a> rng::Client for XMac<'a, R, A> {
+impl<'a, R: radio::Radio, A: Alarm> rng::Client for XMac<'a, R, A> {
     fn randomness_available(&self, randomness: &mut Iterator<Item = u32>) -> rng::Continue {
         match randomness.next() {
             Some(random) => {
@@ -335,7 +335,7 @@ impl<'a, R: radio::Radio + 'a, A: Alarm + 'a> rng::Client for XMac<'a, R, A> {
 }
 
 // The vast majority of these calls pass through to the underlying radio driver.
-impl<'a, R: radio::Radio + 'a, A: Alarm> Mac for XMac<'a, R, A> {
+impl<'a, R: radio::Radio, A: Alarm> Mac for XMac<'a, R, A> {
     fn initialize(&self, mac_buf: &'static mut [u8]) -> ReturnCode {
         self.tx_preamble_buf.replace(mac_buf);
         self.state.set(XMacState::STARTUP);
@@ -456,7 +456,7 @@ impl<'a, R: radio::Radio + 'a, A: Alarm> Mac for XMac<'a, R, A> {
 
 // Core of the XMAC protocol - when the timer fires, the protocol state
 // indicates the next state/action to take.
-impl<'a, R: radio::Radio + 'a, A: Alarm + 'a> time::Client for XMac<'a, R, A> {
+impl<'a, R: radio::Radio, A: Alarm> time::Client for XMac<'a, R, A> {
     fn fired(&self) {
         match self.state.get() {
             XMacState::SLEEP => {
@@ -496,7 +496,7 @@ impl<'a, R: radio::Radio + 'a, A: Alarm + 'a> time::Client for XMac<'a, R, A> {
     }
 }
 
-impl<'a, R: radio::Radio + 'a, A: Alarm + 'a> radio::PowerClient for XMac<'a, R, A> {
+impl<'a, R: radio::Radio, A: Alarm> radio::PowerClient for XMac<'a, R, A> {
     fn changed(&self, on: bool) {
         // If the radio turns on and we're in STARTUP, then either transition to
         // listening for incoming preambles or start transmitting preambles if
@@ -517,7 +517,7 @@ impl<'a, R: radio::Radio + 'a, A: Alarm + 'a> radio::PowerClient for XMac<'a, R,
     }
 }
 
-impl<'a, R: radio::Radio + 'a, A: Alarm + 'a> radio::TxClient for XMac<'a, R, A> {
+impl<'a, R: radio::Radio, A: Alarm> radio::TxClient for XMac<'a, R, A> {
     fn send_done(&self, buf: &'static mut [u8], acked: bool, result: ReturnCode) {
         match self.state.get() {
             // Completed a data transmission to the destination node
@@ -551,7 +551,7 @@ impl<'a, R: radio::Radio + 'a, A: Alarm + 'a> radio::TxClient for XMac<'a, R, A>
 // destination node is receiving packets/awake while we are attempting a
 // transmission, we put the radio in promiscuous mode. Not a huge issue, but
 // we need to be wary of incoming packets not actually addressed to our node.
-impl<'a, R: radio::Radio + 'a, A: Alarm + 'a> radio::RxClient for XMac<'a, R, A> {
+impl<'a, R: radio::Radio, A: Alarm> radio::RxClient for XMac<'a, R, A> {
     fn receive(
         &self,
         buf: &'static mut [u8],

--- a/capsules/src/isl29035.rs
+++ b/capsules/src/isl29035.rs
@@ -51,7 +51,7 @@ pub struct Isl29035<'a, A: time::Alarm> {
     client: Cell<Option<&'a AmbientLightClient>>,
 }
 
-impl<'a, A: time::Alarm> Isl29035<'a, A> {
+impl<A: time::Alarm> Isl29035<'a, A> {
     pub fn new(i2c: &'a I2CDevice, alarm: &'a A, buffer: &'static mut [u8]) -> Isl29035<'a, A> {
         Isl29035 {
             i2c: i2c,
@@ -86,7 +86,7 @@ impl<'a, A: time::Alarm> Isl29035<'a, A> {
     }
 }
 
-impl<'a, A: time::Alarm> AmbientLight for Isl29035<'a, A> {
+impl<A: time::Alarm> AmbientLight for Isl29035<'a, A> {
     fn set_client(&self, client: &'static AmbientLightClient) {
         self.client.set(Some(client));
     }
@@ -97,7 +97,7 @@ impl<'a, A: time::Alarm> AmbientLight for Isl29035<'a, A> {
     }
 }
 
-impl<'a, A: time::Alarm> time::Client for Isl29035<'a, A> {
+impl<A: time::Alarm> time::Client for Isl29035<'a, A> {
     fn fired(&self) {
         self.buffer.take().map(|buffer| {
             // Turn on i2c to send commands.
@@ -110,7 +110,7 @@ impl<'a, A: time::Alarm> time::Client for Isl29035<'a, A> {
     }
 }
 
-impl<'a, A: time::Alarm> I2CClient for Isl29035<'a, A> {
+impl<A: time::Alarm> I2CClient for Isl29035<'a, A> {
     fn command_complete(&self, buffer: &'static mut [u8], _error: Error) {
         // TODO(alevy): handle I2C errors
         match self.state.get() {

--- a/capsules/src/isl29035.rs
+++ b/capsules/src/isl29035.rs
@@ -43,7 +43,7 @@ enum State {
     Disabling(usize),
 }
 
-pub struct Isl29035<'a, A: time::Alarm + 'a> {
+pub struct Isl29035<'a, A: time::Alarm> {
     i2c: &'a I2CDevice,
     alarm: &'a A,
     state: Cell<State>,
@@ -51,7 +51,7 @@ pub struct Isl29035<'a, A: time::Alarm + 'a> {
     client: Cell<Option<&'a AmbientLightClient>>,
 }
 
-impl<'a, A: time::Alarm + 'a> Isl29035<'a, A> {
+impl<'a, A: time::Alarm> Isl29035<'a, A> {
     pub fn new(i2c: &'a I2CDevice, alarm: &'a A, buffer: &'static mut [u8]) -> Isl29035<'a, A> {
         Isl29035 {
             i2c: i2c,
@@ -86,7 +86,7 @@ impl<'a, A: time::Alarm + 'a> Isl29035<'a, A> {
     }
 }
 
-impl<'a, A: time::Alarm + 'a> AmbientLight for Isl29035<'a, A> {
+impl<'a, A: time::Alarm> AmbientLight for Isl29035<'a, A> {
     fn set_client(&self, client: &'static AmbientLightClient) {
         self.client.set(Some(client));
     }
@@ -97,7 +97,7 @@ impl<'a, A: time::Alarm + 'a> AmbientLight for Isl29035<'a, A> {
     }
 }
 
-impl<'a, A: time::Alarm + 'a> time::Client for Isl29035<'a, A> {
+impl<'a, A: time::Alarm> time::Client for Isl29035<'a, A> {
     fn fired(&self) {
         self.buffer.take().map(|buffer| {
             // Turn on i2c to send commands.
@@ -110,7 +110,7 @@ impl<'a, A: time::Alarm + 'a> time::Client for Isl29035<'a, A> {
     }
 }
 
-impl<'a, A: time::Alarm + 'a> I2CClient for Isl29035<'a, A> {
+impl<'a, A: time::Alarm> I2CClient for Isl29035<'a, A> {
     fn command_complete(&self, buffer: &'static mut [u8], _error: Error) {
         // TODO(alevy): handle I2C errors
         match self.state.get() {

--- a/capsules/src/led.rs
+++ b/capsules/src/led.rs
@@ -63,7 +63,7 @@ pub enum ActivationMode {
 
 /// Holds the array of GPIO pins attached to the LEDs and implements a `Driver`
 /// interface to control them.
-pub struct LED<'a, G: hil::gpio::Pin + 'a> {
+pub struct LED<'a, G: hil::gpio::Pin> {
     pins_init: &'a [(&'a G, ActivationMode)],
 }
 

--- a/capsules/src/led.rs
+++ b/capsules/src/led.rs
@@ -67,7 +67,7 @@ pub struct LED<'a, G: hil::gpio::Pin> {
     pins_init: &'a [(&'a G, ActivationMode)],
 }
 
-impl<'a, G: hil::gpio::Pin + hil::gpio::PinCtl> LED<'a, G> {
+impl<G: hil::gpio::Pin + hil::gpio::PinCtl> LED<'a, G> {
     pub fn new(pins_init: &'a [(&'a G, ActivationMode)]) -> LED<'a, G> {
         // Make all pins output and off
         for &(pin, mode) in pins_init.as_ref().iter() {
@@ -84,7 +84,7 @@ impl<'a, G: hil::gpio::Pin + hil::gpio::PinCtl> LED<'a, G> {
     }
 }
 
-impl<'a, G: hil::gpio::Pin + hil::gpio::PinCtl> Driver for LED<'a, G> {
+impl<G: hil::gpio::Pin + hil::gpio::PinCtl> Driver for LED<'a, G> {
     /// Control the LEDs.
     ///
     /// ### `command_num`

--- a/capsules/src/lib.rs
+++ b/capsules/src/lib.rs
@@ -1,4 +1,5 @@
 #![feature(const_fn)]
+#![feature(infer_outlives_requirements)]
 #![forbid(unsafe_code)]
 #![no_std]
 

--- a/capsules/src/lib.rs
+++ b/capsules/src/lib.rs
@@ -1,5 +1,5 @@
 #![feature(const_fn)]
-#![feature(infer_outlives_requirements)]
+#![feature(infer_outlives_requirements, in_band_lifetimes)]
 #![forbid(unsafe_code)]
 #![no_std]
 

--- a/capsules/src/lps25hb.rs
+++ b/capsules/src/lps25hb.rs
@@ -98,7 +98,7 @@ pub struct LPS25HB<'a> {
     buffer: TakeCell<'static, [u8]>,
 }
 
-impl<'a> LPS25HB<'a> {
+impl LPS25HB<'a> {
     pub fn new(
         i2c: &'a i2c::I2CDevice,
         interrupt_pin: &'a gpio::Pin,
@@ -145,7 +145,7 @@ impl<'a> LPS25HB<'a> {
     }
 }
 
-impl<'a> i2c::I2CClient for LPS25HB<'a> {
+impl i2c::I2CClient for LPS25HB<'a> {
     fn command_complete(&self, buffer: &'static mut [u8], _error: i2c::Error) {
         match self.state.get() {
             State::SelectWhoAmI => {
@@ -205,7 +205,7 @@ impl<'a> i2c::I2CClient for LPS25HB<'a> {
     }
 }
 
-impl<'a> gpio::Client for LPS25HB<'a> {
+impl gpio::Client for LPS25HB<'a> {
     fn fired(&self, _: usize) {
         self.buffer.take().map(|buf| {
             // turn on i2c to send commands
@@ -219,7 +219,7 @@ impl<'a> gpio::Client for LPS25HB<'a> {
     }
 }
 
-impl<'a> Driver for LPS25HB<'a> {
+impl Driver for LPS25HB<'a> {
     fn subscribe(
         &self,
         subscribe_num: usize,

--- a/capsules/src/ltc294x.rs
+++ b/capsules/src/ltc294x.rs
@@ -135,7 +135,7 @@ pub struct LTC294X<'a> {
     client: Cell<Option<&'static LTC294XClient>>,
 }
 
-impl<'a> LTC294X<'a> {
+impl LTC294X<'a> {
     pub fn new(
         i2c: &'a i2c::I2CDevice,
         interrupt_pin: Option<&'a gpio::Pin>,
@@ -319,7 +319,7 @@ impl<'a> LTC294X<'a> {
     }
 }
 
-impl<'a> i2c::I2CClient for LTC294X<'a> {
+impl i2c::I2CClient for LTC294X<'a> {
     fn command_complete(&self, buffer: &'static mut [u8], _error: i2c::Error) {
         match self.state.get() {
             State::ReadStatus => {
@@ -392,7 +392,7 @@ impl<'a> i2c::I2CClient for LTC294X<'a> {
     }
 }
 
-impl<'a> gpio::Client for LTC294X<'a> {
+impl gpio::Client for LTC294X<'a> {
     fn fired(&self, _: usize) {
         self.client.get().map(|client| {
             client.interrupt();
@@ -407,7 +407,7 @@ pub struct LTC294XDriver<'a> {
     callback: Cell<Option<Callback>>,
 }
 
-impl<'a> LTC294XDriver<'a> {
+impl LTC294XDriver<'a> {
     pub fn new(ltc: &'a LTC294X) -> LTC294XDriver<'a> {
         LTC294XDriver {
             ltc294x: ltc,
@@ -416,7 +416,7 @@ impl<'a> LTC294XDriver<'a> {
     }
 }
 
-impl<'a> LTC294XClient for LTC294XDriver<'a> {
+impl LTC294XClient for LTC294XDriver<'a> {
     fn interrupt(&self) {
         self.callback.get().map(|mut cb| {
             cb.schedule(0, 0, 0);
@@ -466,7 +466,7 @@ impl<'a> LTC294XClient for LTC294XDriver<'a> {
     }
 }
 
-impl<'a> Driver for LTC294XDriver<'a> {
+impl Driver for LTC294XDriver<'a> {
     /// Setup callbacks.
     ///
     /// ### `subscribe_num`

--- a/capsules/src/max17205.rs
+++ b/capsules/src/max17205.rs
@@ -103,7 +103,7 @@ pub struct MAX17205<'a> {
     client: Cell<Option<&'static MAX17205Client>>,
 }
 
-impl<'a> MAX17205<'a> {
+impl MAX17205<'a> {
     pub fn new(
         i2c_lower: &'a i2c::I2CDevice,
         i2c_upper: &'a i2c::I2CDevice,
@@ -193,7 +193,7 @@ impl<'a> MAX17205<'a> {
     }
 }
 
-impl<'a> i2c::I2CClient for MAX17205<'a> {
+impl i2c::I2CClient for MAX17205<'a> {
     fn command_complete(&self, buffer: &'static mut [u8], _error: i2c::Error) {
         match self.state.get() {
             State::SetupReadStatus => {
@@ -362,7 +362,7 @@ pub struct MAX17205Driver<'a> {
     callback: Cell<Option<Callback>>,
 }
 
-impl<'a> MAX17205Driver<'a> {
+impl MAX17205Driver<'a> {
     pub fn new(max: &'a MAX17205) -> MAX17205Driver<'a> {
         MAX17205Driver {
             max17205: max,
@@ -371,7 +371,7 @@ impl<'a> MAX17205Driver<'a> {
     }
 }
 
-impl<'a> MAX17205Client for MAX17205Driver<'a> {
+impl MAX17205Client for MAX17205Driver<'a> {
     fn status(&self, status: u16, error: ReturnCode) {
         self.callback
             .get()
@@ -411,7 +411,7 @@ impl<'a> MAX17205Client for MAX17205Driver<'a> {
     }
 }
 
-impl<'a> Driver for MAX17205Driver<'a> {
+impl Driver for MAX17205Driver<'a> {
     /// Setup callback.
     ///
     /// ### `subscribe_num`

--- a/capsules/src/mcp23008.rs
+++ b/capsules/src/mcp23008.rs
@@ -124,7 +124,7 @@ pub struct MCP23008<'a> {
     client: Cell<Option<&'static hil::gpio_async::Client>>,
 }
 
-impl<'a> MCP23008<'a> {
+impl MCP23008<'a> {
     pub fn new(
         i2c: &'a hil::i2c::I2CDevice,
         interrupt_pin: Option<&'static hil::gpio::Pin>,
@@ -314,7 +314,7 @@ impl<'a> MCP23008<'a> {
     }
 }
 
-impl<'a> hil::i2c::I2CClient for MCP23008<'a> {
+impl hil::i2c::I2CClient for MCP23008<'a> {
     fn command_complete(&self, buffer: &'static mut [u8], _error: hil::i2c::Error) {
         match self.state.get() {
             State::SelectIoDir(pin_number, direction) => {
@@ -456,7 +456,7 @@ impl<'a> hil::i2c::I2CClient for MCP23008<'a> {
     }
 }
 
-impl<'a> hil::gpio::Client for MCP23008<'a> {
+impl hil::gpio::Client for MCP23008<'a> {
     fn fired(&self, _: usize) {
         self.buffer.take().map(|buffer| {
             self.i2c.enable();
@@ -470,7 +470,7 @@ impl<'a> hil::gpio::Client for MCP23008<'a> {
     }
 }
 
-impl<'a> hil::gpio_async::Port for MCP23008<'a> {
+impl hil::gpio_async::Port for MCP23008<'a> {
     fn disable(&self, pin: usize) -> ReturnCode {
         // Best we can do is make this an input.
         self.set_direction(pin as u8, Direction::Input)

--- a/capsules/src/net/icmpv6/icmpv6_send.rs
+++ b/capsules/src/net/icmpv6/icmpv6_send.rs
@@ -54,7 +54,7 @@ pub struct ICMP6SendStruct<'a, T: IP6Sender<'a>> {
     client: Cell<Option<&'a ICMP6SendClient>>,
 }
 
-impl<'a, T: IP6Sender<'a>> ICMP6SendStruct<'a, T> {
+impl<T: IP6Sender<'a>> ICMP6SendStruct<'a, T> {
     pub fn new(ip_send_struct: &'a T) -> ICMP6SendStruct<'a, T> {
         ICMP6SendStruct {
             ip_send_struct: ip_send_struct,
@@ -63,7 +63,7 @@ impl<'a, T: IP6Sender<'a>> ICMP6SendStruct<'a, T> {
     }
 }
 
-impl<'a, T: IP6Sender<'a>> ICMP6Sender<'a> for ICMP6SendStruct<'a, T> {
+impl<T: IP6Sender<'a>> ICMP6Sender<'a> for ICMP6SendStruct<'a, T> {
     fn set_client(&self, client: &'a ICMP6SendClient) {
         self.client.set(Some(client));
     }
@@ -76,7 +76,7 @@ impl<'a, T: IP6Sender<'a>> ICMP6Sender<'a> for ICMP6SendStruct<'a, T> {
     }
 }
 
-impl<'a, T: IP6Sender<'a>> IP6Client for ICMP6SendStruct<'a, T> {
+impl<T: IP6Sender<'a>> IP6Client for ICMP6SendStruct<'a, T> {
     /// Forwards callback received from the `IP6Sender` to the
     /// `ICMP6SendClient`.
     fn send_done(&self, result: ReturnCode) {

--- a/capsules/src/net/icmpv6/icmpv6_send.rs
+++ b/capsules/src/net/icmpv6/icmpv6_send.rs
@@ -49,7 +49,7 @@ pub trait ICMP6Sender<'a> {
 }
 
 /// A struct that implements the `ICMP6Sender` trait.
-pub struct ICMP6SendStruct<'a, T: IP6Sender<'a> + 'a> {
+pub struct ICMP6SendStruct<'a, T: IP6Sender<'a>> {
     ip_send_struct: &'a T,
     client: Cell<Option<&'a ICMP6SendClient>>,
 }

--- a/capsules/src/net/ieee802154.rs
+++ b/capsules/src/net/ieee802154.rs
@@ -109,7 +109,7 @@ pub enum AddressMode {
     Long = 0b11,
 }
 
-impl<'a> From<&'a Option<MacAddress>> for AddressMode {
+impl From<&'a Option<MacAddress>> for AddressMode {
     fn from(opt_addr: &'a Option<MacAddress>) -> Self {
         match *opt_addr {
             None => AddressMode::NotPresent,
@@ -252,7 +252,7 @@ impl KeyId {
     }
 }
 
-impl<'a> From<&'a KeyId> for KeyIdMode {
+impl From<&'a KeyId> for KeyIdMode {
     fn from(key_id: &'a KeyId) -> Self {
         match *key_id {
             KeyId::Implicit => KeyIdMode::Implicit,
@@ -353,13 +353,13 @@ pub enum HeaderIE<'a> {
     Termination2,
 }
 
-impl<'a> Default for HeaderIE<'a> {
+impl Default for HeaderIE<'a> {
     fn default() -> Self {
         HeaderIE::Termination1
     }
 }
 
-impl<'a> HeaderIE<'a> {
+impl HeaderIE<'a> {
     pub fn is_termination(&self) -> bool {
         match *self {
             HeaderIE::Termination1 | HeaderIE::Termination2 => true,
@@ -425,13 +425,13 @@ pub enum PayloadIE<'a> {
     Termination,
 }
 
-impl<'a> Default for PayloadIE<'a> {
+impl Default for PayloadIE<'a> {
     fn default() -> Self {
         PayloadIE::Termination
     }
 }
 
-impl<'a> PayloadIE<'a> {
+impl PayloadIE<'a> {
     pub fn is_termination(&self) -> bool {
         match *self {
             PayloadIE::Termination => true,
@@ -508,7 +508,7 @@ pub struct Header<'a> {
     pub payload_ies_len: usize,
 }
 
-impl<'a> Header<'a> {
+impl Header<'a> {
     pub fn encode(&self, buf: &mut [u8], has_payload: bool) -> SResult<usize> {
         // The frame control field is collected in the course of encoding the
         // various other fields of the header and then written only at the end

--- a/capsules/src/net/ipv6/ipv6.rs
+++ b/capsules/src/net/ipv6/ipv6.rs
@@ -262,7 +262,7 @@ pub struct IPPayload<'a> {
     pub payload: &'a mut [u8],
 }
 
-impl<'a> IPPayload<'a> {
+impl IPPayload<'a> {
     /// This function constructs a new `IPPayload` struct
     ///
     /// # Arguments
@@ -358,7 +358,7 @@ pub struct IP6Packet<'a> {
 // Note: We want to have the IP6Header struct implement these methods,
 // as there are cases where we want to allocate/modify the IP6Header without
 // allocating/modifying the entire IP6Packet
-impl<'a> IP6Packet<'a> {
+impl IP6Packet<'a> {
     // Sets fields to appropriate defaults
 
     /// This function returns a new `IP6Packet` struct. Note that the

--- a/capsules/src/net/ipv6/ipv6_send.rs
+++ b/capsules/src/net/ipv6/ipv6_send.rs
@@ -97,7 +97,7 @@ pub struct IP6SendStruct<'a> {
     client: Cell<Option<&'a IP6Client>>,
 }
 
-impl<'a> IP6Sender<'a> for IP6SendStruct<'a> {
+impl IP6Sender<'a> for IP6SendStruct<'a> {
     fn set_client(&self, client: &'a IP6Client) {
         self.client.set(Some(client));
     }
@@ -127,7 +127,7 @@ impl<'a> IP6Sender<'a> for IP6SendStruct<'a> {
     }
 }
 
-impl<'a> IP6SendStruct<'a> {
+impl IP6SendStruct<'a> {
     pub fn new(
         ip6_packet: &'static mut IP6Packet<'static>,
         tx_buf: &'static mut [u8],
@@ -190,7 +190,7 @@ impl<'a> IP6SendStruct<'a> {
     }
 }
 
-impl<'a> TxClient for IP6SendStruct<'a> {
+impl TxClient for IP6SendStruct<'a> {
     fn send_done(&self, tx_buf: &'static mut [u8], acked: bool, result: ReturnCode) {
         self.tx_buf.replace(tx_buf);
         debug!("sendDone return code is: {:?}, acked: {}", result, acked);

--- a/capsules/src/net/sixlowpan/sixlowpan_state.rs
+++ b/capsules/src/net/sixlowpan/sixlowpan_state.rs
@@ -327,7 +327,7 @@ pub struct TxState<'a> {
     sixlowpan: &'a SixlowpanState<'a>,
 }
 
-impl<'a> TxState<'a> {
+impl TxState<'a> {
     /// Creates a new `TxState`
     ///
     /// # Arguments
@@ -635,13 +635,13 @@ pub struct RxState<'a> {
     next: ListLink<'a, RxState<'a>>,
 }
 
-impl<'a> ListNode<'a, RxState<'a>> for RxState<'a> {
+impl ListNode<'a, RxState<'a>> for RxState<'a> {
     fn next(&'a self) -> &'a ListLink<RxState<'a>> {
         &self.next
     }
 }
 
-impl<'a> RxState<'a> {
+impl RxState<'a> {
     /// Creates a new `RxState`
     ///
     /// # Arguments
@@ -789,7 +789,7 @@ pub struct Sixlowpan<'a, A: time::Alarm, C: ContextStore> {
 }
 
 // This function is called after receiving a frame
-impl<'a, A: time::Alarm, C: ContextStore> RxClient for Sixlowpan<'a, A, C> {
+impl<A: time::Alarm, C: ContextStore> RxClient for Sixlowpan<'a, A, C> {
     fn receive<'b>(&self, buf: &'b [u8], header: Header<'b>, data_offset: usize, data_len: usize) {
         // We return if retcode is not valid, as it does not make sense to issue
         // a callback for an invalid frame reception
@@ -810,7 +810,7 @@ impl<'a, A: time::Alarm, C: ContextStore> RxClient for Sixlowpan<'a, A, C> {
     }
 }
 
-impl<'a, A: time::Alarm, C: ContextStore> SixlowpanState<'a> for Sixlowpan<'a, A, C> {
+impl<A: time::Alarm, C: ContextStore> SixlowpanState<'a> for Sixlowpan<'a, A, C> {
     fn next_dgram_tag(&self) -> u16 {
         // Increment dgram_tag
         let dgram_tag = if (self.tx_dgram_tag.get() + 1) == 0 {
@@ -841,7 +841,7 @@ impl<'a, A: time::Alarm, C: ContextStore> SixlowpanState<'a> for Sixlowpan<'a, A
     }
 }
 
-impl<'a, A: time::Alarm, C: ContextStore> Sixlowpan<'a, A, C> {
+impl<A: time::Alarm, C: ContextStore> Sixlowpan<'a, A, C> {
     /// Creates a new `Sixlowpan`
     ///
     /// # Arguments

--- a/capsules/src/net/sixlowpan/sixlowpan_state.rs
+++ b/capsules/src/net/sixlowpan/sixlowpan_state.rs
@@ -778,7 +778,7 @@ impl<'a> RxState<'a> {
 ///
 /// Finally, `set_client` controls the client that will receive transmission
 /// completion and reception callbacks.
-pub struct Sixlowpan<'a, A: time::Alarm + 'a, C: ContextStore> {
+pub struct Sixlowpan<'a, A: time::Alarm, C: ContextStore> {
     pub ctx_store: C,
     clock: &'a A,
     tx_dgram_tag: Cell<u16>,

--- a/capsules/src/net/tcp.rs
+++ b/capsules/src/net/tcp.rs
@@ -15,7 +15,7 @@ pub struct TCPHeader {
 }
 
 /*
-impl<'a> TCPPacket<'a> {
+impl TCPPacket<'a> {
     pub fn new(buf: &mut [u8]) -> TCPPacket<'a> {
         let header = TCPHeader {
             src_port: 0,

--- a/capsules/src/net/thread/tlv.rs
+++ b/capsules/src/net/thread/tlv.rs
@@ -119,7 +119,7 @@ pub enum Tlv<'a> {
     PendingOperationalDataset(&'a [u8]),
 }
 
-impl<'a> Tlv<'a> {
+impl Tlv<'a> {
     /// Serializes TLV data in `buf` into the format specific to the TLV
     /// type.
     pub fn encode(&self, buf: &mut [u8]) -> SResult {
@@ -568,7 +568,7 @@ pub enum NetworkDataTlv<'a> {
     },
 }
 
-impl<'a> NetworkDataTlv<'a> {
+impl NetworkDataTlv<'a> {
     /// Serializes TLV data in `buf` into the format specific to the
     /// Network Data TLV type.
     pub fn encode(&self, buf: &mut [u8], stable: bool) -> SResult {
@@ -751,7 +751,7 @@ pub enum PrefixSubTlv<'a> {
     },
 }
 
-impl<'a> PrefixSubTlv<'a> {
+impl PrefixSubTlv<'a> {
     /// Serializes TLV data in `buf` into the format specific to the
     /// Prefix sub-TLV type.
     pub fn encode(&self, buf: &mut [u8], stable: bool) -> SResult {
@@ -958,7 +958,7 @@ pub enum ServiceSubTlv {
     },
 }
 
-impl<'a> ServiceSubTlv {
+impl ServiceSubTlv {
     /// Serializes TLV data in `buf` into the format specific to the
     /// Service sub-TLV type.
     pub fn encode(&self, buf: &mut [u8], stable: bool) -> SResult {
@@ -1034,7 +1034,7 @@ impl From<u8> for ServiceSubTlvType {
     }
 }
 
-impl<'a> From<&'a ServiceSubTlv> for ServiceSubTlvType {
+impl From<&'a ServiceSubTlv> for ServiceSubTlvType {
     fn from(service_sub_tlv: &'a ServiceSubTlv) -> Self {
         match *service_sub_tlv {
             ServiceSubTlv::Server { .. } => ServiceSubTlvType::Server,
@@ -1080,7 +1080,7 @@ pub enum NetworkManagementTlv<'a> {
     ChannelMask(&'a [u8]),
 }
 
-impl<'a> NetworkManagementTlv<'a> {
+impl NetworkManagementTlv<'a> {
     /// Serializes TLV data in `buf` into the format specific to the
     /// Network Management TLV type.
     pub fn encode(&self, buf: &mut [u8]) -> SResult {
@@ -1475,7 +1475,7 @@ pub struct ChannelMaskEntry {
     channel_mask: [u8; MAX_VALUE_FIELD_LENGTH],
 }
 
-impl<'a> ChannelMaskEntry {
+impl ChannelMaskEntry {
     /// Serializes this Channel Mask Entry into `buf`.
     pub fn encode(&self, buf: &mut [u8]) -> SResult {
         let mut offset = enc_consume!(buf, 0; encode_u8, self.channel_page);

--- a/capsules/src/net/udp/udp_send.rs
+++ b/capsules/src/net/udp/udp_send.rs
@@ -64,7 +64,7 @@ pub trait UDPSender<'a> {
 /// This is a specific instantiation of the `UDPSender` trait. Note
 /// that this struct contains a reference to an `IP6Sender` which it
 /// forwards packets to (and receives callbacks from).
-pub struct UDPSendStruct<'a, T: IP6Sender<'a> + 'a> {
+pub struct UDPSendStruct<'a, T: IP6Sender<'a>> {
     ip_send_struct: &'a T,
     client: Cell<Option<&'a UDPSendClient>>,
 }

--- a/capsules/src/net/udp/udp_send.rs
+++ b/capsules/src/net/udp/udp_send.rs
@@ -71,7 +71,7 @@ pub struct UDPSendStruct<'a, T: IP6Sender<'a>> {
 
 /// Below is the implementation of the `UDPSender` traits for the
 /// `UDPSendStruct`.
-impl<'a, T: IP6Sender<'a>> UDPSender<'a> for UDPSendStruct<'a, T> {
+impl<T: IP6Sender<'a>> UDPSender<'a> for UDPSendStruct<'a, T> {
     fn set_client(&self, client: &'a UDPSendClient) {
         self.client.set(Some(client));
     }
@@ -91,7 +91,7 @@ impl<'a, T: IP6Sender<'a>> UDPSender<'a> for UDPSendStruct<'a, T> {
     }
 }
 
-impl<'a, T: IP6Sender<'a>> UDPSendStruct<'a, T> {
+impl<T: IP6Sender<'a>> UDPSendStruct<'a, T> {
     pub fn new(ip_send_struct: &'a T) -> UDPSendStruct<'a, T> {
         UDPSendStruct {
             ip_send_struct: ip_send_struct,
@@ -103,7 +103,7 @@ impl<'a, T: IP6Sender<'a>> UDPSendStruct<'a, T> {
 /// This function implements the `IP6Client` trait for the `UDPSendStruct`,
 /// and is necessary to receive callbacks from the lower (IP) layer. When
 /// the UDP layer receives this callback, it forwards it to the `UDPSendClient`.
-impl<'a, T: IP6Sender<'a>> IP6Client for UDPSendStruct<'a, T> {
+impl<T: IP6Sender<'a>> IP6Client for UDPSendStruct<'a, T> {
     fn send_done(&self, result: ReturnCode) {
         self.client.get().map(|client| client.send_done(result));
     }

--- a/capsules/src/ninedof.rs
+++ b/capsules/src/ninedof.rs
@@ -52,7 +52,7 @@ pub struct NineDof<'a> {
     current_app: Cell<Option<AppId>>,
 }
 
-impl<'a> NineDof<'a> {
+impl NineDof<'a> {
     pub fn new(driver: &'a hil::sensors::NineDof, grant: Grant<App>) -> NineDof<'a> {
         NineDof {
             driver: driver,
@@ -94,7 +94,7 @@ impl<'a> NineDof<'a> {
     }
 }
 
-impl<'a> hil::sensors::NineDofClient for NineDof<'a> {
+impl hil::sensors::NineDofClient for NineDof<'a> {
     fn callback(&self, arg1: usize, arg2: usize, arg3: usize) {
         // Notify the current application that the command finished.
         // Also keep track of what just finished to see if we can re-use
@@ -142,7 +142,7 @@ impl<'a> hil::sensors::NineDofClient for NineDof<'a> {
     }
 }
 
-impl<'a> Driver for NineDof<'a> {
+impl Driver for NineDof<'a> {
     fn subscribe(
         &self,
         subscribe_num: usize,

--- a/capsules/src/nonvolatile_storage_driver.rs
+++ b/capsules/src/nonvolatile_storage_driver.rs
@@ -138,7 +138,7 @@ pub struct NonvolatileStorage<'a> {
     kernel_readwrite_address: Cell<usize>,
 }
 
-impl<'a> NonvolatileStorage<'a> {
+impl NonvolatileStorage<'a> {
     pub fn new(
         driver: &'a hil::nonvolatile_storage::NonvolatileStorage,
         grant: Grant<App>,
@@ -385,7 +385,7 @@ impl<'a> NonvolatileStorage<'a> {
 }
 
 /// This is the callback client for the underlying physical storage driver.
-impl<'a> hil::nonvolatile_storage::NonvolatileStorageClient for NonvolatileStorage<'a> {
+impl hil::nonvolatile_storage::NonvolatileStorageClient for NonvolatileStorage<'a> {
     fn read_done(&self, buffer: &'static mut [u8], length: usize) {
         // Switch on which user of this capsule generated this callback.
         self.current_user.get().map(|user| {
@@ -448,7 +448,7 @@ impl<'a> hil::nonvolatile_storage::NonvolatileStorageClient for NonvolatileStora
 }
 
 /// Provide an interface for the kernel.
-impl<'a> hil::nonvolatile_storage::NonvolatileStorage for NonvolatileStorage<'a> {
+impl hil::nonvolatile_storage::NonvolatileStorage for NonvolatileStorage<'a> {
     fn set_client(&self, client: &'static hil::nonvolatile_storage::NonvolatileStorageClient) {
         self.kernel_client.set(Some(client));
     }
@@ -465,7 +465,7 @@ impl<'a> hil::nonvolatile_storage::NonvolatileStorage for NonvolatileStorage<'a>
 }
 
 /// Provide an interface for userland.
-impl<'a> Driver for NonvolatileStorage<'a> {
+impl Driver for NonvolatileStorage<'a> {
     /// Setup shared buffers.
     ///
     /// ### `allow_num`

--- a/capsules/src/nonvolatile_to_pages.rs
+++ b/capsules/src/nonvolatile_to_pages.rs
@@ -68,7 +68,7 @@ pub struct NonvolatileToPages<'a, F: hil::flash::Flash + 'static> {
     buffer_index: Cell<usize>,
 }
 
-impl<'a, F: hil::flash::Flash> NonvolatileToPages<'a, F> {
+impl<F: hil::flash::Flash> NonvolatileToPages<'a, F> {
     pub fn new(driver: &'a F, buffer: &'static mut F::Page) -> NonvolatileToPages<'a, F> {
         NonvolatileToPages {
             driver: driver,
@@ -84,7 +84,7 @@ impl<'a, F: hil::flash::Flash> NonvolatileToPages<'a, F> {
     }
 }
 
-impl<'a, F: hil::flash::Flash> hil::nonvolatile_storage::NonvolatileStorage
+impl<F: hil::flash::Flash> hil::nonvolatile_storage::NonvolatileStorage
     for NonvolatileToPages<'a, F>
 {
     fn set_client(&self, client: &'static hil::nonvolatile_storage::NonvolatileStorageClient) {
@@ -152,7 +152,7 @@ impl<'a, F: hil::flash::Flash> hil::nonvolatile_storage::NonvolatileStorage
     }
 }
 
-impl<'a, F: hil::flash::Flash> hil::flash::Client<F> for NonvolatileToPages<'a, F> {
+impl<F: hil::flash::Flash> hil::flash::Client<F> for NonvolatileToPages<'a, F> {
     fn read_complete(&self, pagebuffer: &'static mut F::Page, _error: hil::flash::Error) {
         match self.state.get() {
             State::Read => {

--- a/capsules/src/nonvolatile_to_pages.rs
+++ b/capsules/src/nonvolatile_to_pages.rs
@@ -68,7 +68,7 @@ pub struct NonvolatileToPages<'a, F: hil::flash::Flash + 'static> {
     buffer_index: Cell<usize>,
 }
 
-impl<'a, F: hil::flash::Flash + 'a> NonvolatileToPages<'a, F> {
+impl<'a, F: hil::flash::Flash> NonvolatileToPages<'a, F> {
     pub fn new(driver: &'a F, buffer: &'static mut F::Page) -> NonvolatileToPages<'a, F> {
         NonvolatileToPages {
             driver: driver,
@@ -84,7 +84,7 @@ impl<'a, F: hil::flash::Flash + 'a> NonvolatileToPages<'a, F> {
     }
 }
 
-impl<'a, F: hil::flash::Flash + 'a> hil::nonvolatile_storage::NonvolatileStorage
+impl<'a, F: hil::flash::Flash> hil::nonvolatile_storage::NonvolatileStorage
     for NonvolatileToPages<'a, F>
 {
     fn set_client(&self, client: &'static hil::nonvolatile_storage::NonvolatileStorageClient) {
@@ -152,7 +152,7 @@ impl<'a, F: hil::flash::Flash + 'a> hil::nonvolatile_storage::NonvolatileStorage
     }
 }
 
-impl<'a, F: hil::flash::Flash + 'a> hil::flash::Client<F> for NonvolatileToPages<'a, F> {
+impl<'a, F: hil::flash::Flash> hil::flash::Client<F> for NonvolatileToPages<'a, F> {
     fn read_complete(&self, pagebuffer: &'static mut F::Page, _error: hil::flash::Error) {
         match self.state.get() {
             State::Read => {

--- a/capsules/src/nrf51822_serialization.rs
+++ b/capsules/src/nrf51822_serialization.rs
@@ -58,7 +58,7 @@ pub struct Nrf51822Serialization<'a, U: UARTReceiveAdvanced> {
     rx_buffer: TakeCell<'static, [u8]>,
 }
 
-impl<'a, U: UARTReceiveAdvanced> Nrf51822Serialization<'a, U> {
+impl<U: UARTReceiveAdvanced> Nrf51822Serialization<'a, U> {
     pub fn new(
         uart: &'a U,
         tx_buffer: &'static mut [u8],
@@ -82,7 +82,7 @@ impl<'a, U: UARTReceiveAdvanced> Nrf51822Serialization<'a, U> {
     }
 }
 
-impl<'a, U: UARTReceiveAdvanced> Driver for Nrf51822Serialization<'a, U> {
+impl<U: UARTReceiveAdvanced> Driver for Nrf51822Serialization<'a, U> {
     /// Pass application space memory to this driver.
     ///
     /// ### `allow_num`
@@ -179,7 +179,7 @@ impl<'a, U: UARTReceiveAdvanced> Driver for Nrf51822Serialization<'a, U> {
 }
 
 // Callbacks from the underlying UART driver.
-impl<'a, U: UARTReceiveAdvanced> Client for Nrf51822Serialization<'a, U> {
+impl<U: UARTReceiveAdvanced> Client for Nrf51822Serialization<'a, U> {
     // Called when the UART TX has finished.
     fn transmit_complete(&self, buffer: &'static mut [u8], _error: uart::Error) {
         self.tx_buffer.replace(buffer);

--- a/capsules/src/nrf51822_serialization.rs
+++ b/capsules/src/nrf51822_serialization.rs
@@ -51,7 +51,7 @@ pub static mut READ_BUF: [u8; 600] = [0; 600];
 
 // We need two resources: a UART HW driver and driver state for each
 // application.
-pub struct Nrf51822Serialization<'a, U: UARTReceiveAdvanced + 'a> {
+pub struct Nrf51822Serialization<'a, U: UARTReceiveAdvanced> {
     uart: &'a U,
     app: MapCell<App>,
     tx_buffer: TakeCell<'static, [u8]>,

--- a/capsules/src/pca9544a.rs
+++ b/capsules/src/pca9544a.rs
@@ -59,7 +59,7 @@ pub struct PCA9544A<'a> {
     callback: Cell<Option<Callback>>,
 }
 
-impl<'a> PCA9544A<'a> {
+impl PCA9544A<'a> {
     pub fn new(i2c: &'a i2c::I2CDevice, buffer: &'static mut [u8]) -> PCA9544A<'a> {
         PCA9544A {
             i2c: i2c,
@@ -117,7 +117,7 @@ impl<'a> PCA9544A<'a> {
     }
 }
 
-impl<'a> i2c::I2CClient for PCA9544A<'a> {
+impl i2c::I2CClient for PCA9544A<'a> {
     fn command_complete(&self, buffer: &'static mut [u8], _error: i2c::Error) {
         match self.state.get() {
             State::ReadControl(field) => {
@@ -146,7 +146,7 @@ impl<'a> i2c::I2CClient for PCA9544A<'a> {
     }
 }
 
-impl<'a> Driver for PCA9544A<'a> {
+impl Driver for PCA9544A<'a> {
     /// Setup callback for event done.
     ///
     /// ### `subscribe_num`

--- a/capsules/src/rf233.rs
+++ b/capsules/src/rf233.rs
@@ -176,7 +176,7 @@ enum InternalState {
 // and waits for the interrupt specifying the entire packet has been
 // received.
 
-pub struct RF233<'a, S: spi::SpiMasterDevice + 'a> {
+pub struct RF233<'a, S: spi::SpiMasterDevice> {
     spi: &'a S,
     radio_on: Cell<bool>,
     transmitting: Cell<bool>,
@@ -267,7 +267,7 @@ fn interrupt_included(mask: u8, interrupt: u8) -> bool {
     (mask & interrupt) == interrupt
 }
 
-impl<'a, S: spi::SpiMasterDevice + 'a> spi::SpiMasterClient for RF233<'a, S> {
+impl<'a, S: spi::SpiMasterDevice> spi::SpiMasterClient for RF233<'a, S> {
     // This function is a bit confusing because the order of the logic in the
     // function is different than the order of operations during transmission
     // and reception.
@@ -1002,7 +1002,7 @@ impl<'a, S: spi::SpiMasterDevice + 'a> spi::SpiMasterClient for RF233<'a, S> {
     }
 }
 
-impl<'a, S: spi::SpiMasterDevice + 'a> gpio::Client for RF233<'a, S> {
+impl<'a, S: spi::SpiMasterDevice> gpio::Client for RF233<'a, S> {
     fn fired(&self, identifier: usize) {
         if identifier == INTERRUPT_ID {
             self.handle_interrupt();
@@ -1010,7 +1010,7 @@ impl<'a, S: spi::SpiMasterDevice + 'a> gpio::Client for RF233<'a, S> {
     }
 }
 
-impl<'a, S: spi::SpiMasterDevice + 'a> RF233<'a, S> {
+impl<'a, S: spi::SpiMasterDevice> RF233<'a, S> {
     pub fn new(
         spi: &'a S,
         reset: &'a gpio::Pin,
@@ -1150,9 +1150,9 @@ impl<'a, S: spi::SpiMasterDevice + 'a> RF233<'a, S> {
     }
 }
 
-impl<'a, S: spi::SpiMasterDevice + 'a> radio::Radio for RF233<'a, S> {}
+impl<'a, S: spi::SpiMasterDevice> radio::Radio for RF233<'a, S> {}
 
-impl<'a, S: spi::SpiMasterDevice + 'a> radio::RadioConfig for RF233<'a, S> {
+impl<'a, S: spi::SpiMasterDevice> radio::RadioConfig for RF233<'a, S> {
     fn initialize(
         &self,
         buf: &'static mut [u8],
@@ -1317,7 +1317,7 @@ impl<'a, S: spi::SpiMasterDevice + 'a> radio::RadioConfig for RF233<'a, S> {
     }
 }
 
-impl<'a, S: spi::SpiMasterDevice + 'a> radio::RadioData for RF233<'a, S> {
+impl<'a, S: spi::SpiMasterDevice> radio::RadioData for RF233<'a, S> {
     fn set_transmit_client(&self, client: &'static radio::TxClient) {
         self.tx_client.set(Some(client));
     }

--- a/capsules/src/rf233.rs
+++ b/capsules/src/rf233.rs
@@ -267,7 +267,7 @@ fn interrupt_included(mask: u8, interrupt: u8) -> bool {
     (mask & interrupt) == interrupt
 }
 
-impl<'a, S: spi::SpiMasterDevice> spi::SpiMasterClient for RF233<'a, S> {
+impl<S: spi::SpiMasterDevice> spi::SpiMasterClient for RF233<'a, S> {
     // This function is a bit confusing because the order of the logic in the
     // function is different than the order of operations during transmission
     // and reception.
@@ -1002,7 +1002,7 @@ impl<'a, S: spi::SpiMasterDevice> spi::SpiMasterClient for RF233<'a, S> {
     }
 }
 
-impl<'a, S: spi::SpiMasterDevice> gpio::Client for RF233<'a, S> {
+impl<S: spi::SpiMasterDevice> gpio::Client for RF233<'a, S> {
     fn fired(&self, identifier: usize) {
         if identifier == INTERRUPT_ID {
             self.handle_interrupt();
@@ -1010,7 +1010,7 @@ impl<'a, S: spi::SpiMasterDevice> gpio::Client for RF233<'a, S> {
     }
 }
 
-impl<'a, S: spi::SpiMasterDevice> RF233<'a, S> {
+impl<S: spi::SpiMasterDevice> RF233<'a, S> {
     pub fn new(
         spi: &'a S,
         reset: &'a gpio::Pin,
@@ -1150,9 +1150,9 @@ impl<'a, S: spi::SpiMasterDevice> RF233<'a, S> {
     }
 }
 
-impl<'a, S: spi::SpiMasterDevice> radio::Radio for RF233<'a, S> {}
+impl<S: spi::SpiMasterDevice> radio::Radio for RF233<'a, S> {}
 
-impl<'a, S: spi::SpiMasterDevice> radio::RadioConfig for RF233<'a, S> {
+impl<S: spi::SpiMasterDevice> radio::RadioConfig for RF233<'a, S> {
     fn initialize(
         &self,
         buf: &'static mut [u8],
@@ -1317,7 +1317,7 @@ impl<'a, S: spi::SpiMasterDevice> radio::RadioConfig for RF233<'a, S> {
     }
 }
 
-impl<'a, S: spi::SpiMasterDevice> radio::RadioData for RF233<'a, S> {
+impl<S: spi::SpiMasterDevice> radio::RadioData for RF233<'a, S> {
     fn set_transmit_client(&self, client: &'static radio::TxClient) {
         self.tx_client.set(Some(client));
     }

--- a/capsules/src/rng.rs
+++ b/capsules/src/rng.rs
@@ -39,7 +39,7 @@ impl Default for App {
     }
 }
 
-pub struct SimpleRng<'a, RNG: rng::RNG + 'a> {
+pub struct SimpleRng<'a, RNG: rng::RNG> {
     rng: &'a RNG,
     apps: Grant<App>,
     getting_randomness: Cell<bool>,

--- a/capsules/src/rng.rs
+++ b/capsules/src/rng.rs
@@ -45,7 +45,7 @@ pub struct SimpleRng<'a, RNG: rng::RNG> {
     getting_randomness: Cell<bool>,
 }
 
-impl<'a, RNG: rng::RNG> SimpleRng<'a, RNG> {
+impl<RNG: rng::RNG> SimpleRng<'a, RNG> {
     pub fn new(rng: &'a RNG, grant: Grant<App>) -> SimpleRng<'a, RNG> {
         SimpleRng {
             rng: rng,
@@ -55,7 +55,7 @@ impl<'a, RNG: rng::RNG> SimpleRng<'a, RNG> {
     }
 }
 
-impl<'a, RNG: rng::RNG> rng::Client for SimpleRng<'a, RNG> {
+impl<RNG: rng::RNG> rng::Client for SimpleRng<'a, RNG> {
     fn randomness_available(&self, randomness: &mut Iterator<Item = u32>) -> rng::Continue {
         let mut done = true;
         for cntr in self.apps.iter() {
@@ -129,7 +129,7 @@ impl<'a, RNG: rng::RNG> rng::Client for SimpleRng<'a, RNG> {
     }
 }
 
-impl<'a, RNG: rng::RNG> Driver for SimpleRng<'a, RNG> {
+impl<RNG: rng::RNG> Driver for SimpleRng<'a, RNG> {
     fn allow(
         &self,
         appid: AppId,

--- a/capsules/src/sdcard.rs
+++ b/capsules/src/sdcard.rs
@@ -56,7 +56,7 @@ pub static mut TXBUFFER: [u8; 515] = [0; 515];
 pub static mut RXBUFFER: [u8; 515] = [0; 515];
 
 /// SD Card capsule, capable of being built on top of by other kernel capsules
-pub struct SDCard<'a, A: hil::time::Alarm + 'a> {
+pub struct SDCard<'a, A: hil::time::Alarm> {
     spi: &'a hil::spi::SpiMasterDevice,
     state: Cell<SpiState>,
     after_state: Cell<SpiState>,
@@ -189,7 +189,7 @@ pub trait SDCardClient {
 }
 
 /// Functions for initializing and accessing an SD card
-impl<'a, A: hil::time::Alarm + 'a> SDCard<'a, A> {
+impl<'a, A: hil::time::Alarm> SDCard<'a, A> {
     /// Create a new SD card interface
     ///
     /// spi - virtualized SPI to use for communication with SD card
@@ -1329,7 +1329,7 @@ impl<'a, A: hil::time::Alarm + 'a> SDCard<'a, A> {
 }
 
 /// Handle callbacks from the SPI peripheral
-impl<'a, A: hil::time::Alarm + 'a> hil::spi::SpiMasterClient for SDCard<'a, A> {
+impl<'a, A: hil::time::Alarm> hil::spi::SpiMasterClient for SDCard<'a, A> {
     fn read_write_done(
         &self,
         mut write_buffer: &'static mut [u8],
@@ -1344,14 +1344,14 @@ impl<'a, A: hil::time::Alarm + 'a> hil::spi::SpiMasterClient for SDCard<'a, A> {
 }
 
 /// Handle callbacks from the timer
-impl<'a, A: hil::time::Alarm + 'a> hil::time::Client for SDCard<'a, A> {
+impl<'a, A: hil::time::Alarm> hil::time::Client for SDCard<'a, A> {
     fn fired(&self) {
         self.process_alarm_states();
     }
 }
 
 /// Handle callbacks from the card detection pin
-impl<'a, A: hil::time::Alarm + 'a> hil::gpio::Client for SDCard<'a, A> {
+impl<'a, A: hil::time::Alarm> hil::gpio::Client for SDCard<'a, A> {
     fn fired(&self, _: usize) {
         // check if there was an open transaction with the sd card
         if self.alarm_state.get() != AlarmState::Idle || self.state.get() != SpiState::Idle {
@@ -1384,7 +1384,7 @@ impl<'a, A: hil::time::Alarm + 'a> hil::gpio::Client for SDCard<'a, A> {
 /// This is used if the SDCard is going to be attached directly to userspace
 /// syscalls. SDCardDriver can be ignored if another capsule is going to build
 /// off of the SDCard instead
-pub struct SDCardDriver<'a, A: hil::time::Alarm + 'a> {
+pub struct SDCardDriver<'a, A: hil::time::Alarm> {
     sdcard: &'a SDCard<'a, A>,
     app: MapCell<App>,
     kernel_buf: TakeCell<'static, [u8]>,
@@ -1411,7 +1411,7 @@ impl Default for App {
 pub static mut KERNEL_BUFFER: [u8; 512] = [0; 512];
 
 /// Functions for SDCardDriver
-impl<'a, A: hil::time::Alarm + 'a> SDCardDriver<'a, A> {
+impl<'a, A: hil::time::Alarm> SDCardDriver<'a, A> {
     /// Create new SD card userland interface
     ///
     /// sdcard - SDCard interface to provide application access to
@@ -1431,7 +1431,7 @@ impl<'a, A: hil::time::Alarm + 'a> SDCardDriver<'a, A> {
 }
 
 /// Handle callbacks from SDCard
-impl<'a, A: hil::time::Alarm + 'a> SDCardClient for SDCardDriver<'a, A> {
+impl<'a, A: hil::time::Alarm> SDCardClient for SDCardDriver<'a, A> {
     fn card_detection_changed(&self, installed: bool) {
         self.app.map(|app| {
             app.callback.map(|mut cb| {
@@ -1495,7 +1495,7 @@ impl<'a, A: hil::time::Alarm + 'a> SDCardClient for SDCardDriver<'a, A> {
 }
 
 /// Connections to userspace syscalls
-impl<'a, A: hil::time::Alarm + 'a> Driver for SDCardDriver<'a, A> {
+impl<'a, A: hil::time::Alarm> Driver for SDCardDriver<'a, A> {
     fn allow(
         &self,
         _appid: AppId,

--- a/capsules/src/sdcard.rs
+++ b/capsules/src/sdcard.rs
@@ -189,7 +189,7 @@ pub trait SDCardClient {
 }
 
 /// Functions for initializing and accessing an SD card
-impl<'a, A: hil::time::Alarm> SDCard<'a, A> {
+impl<A: hil::time::Alarm> SDCard<'a, A> {
     /// Create a new SD card interface
     ///
     /// spi - virtualized SPI to use for communication with SD card
@@ -1329,7 +1329,7 @@ impl<'a, A: hil::time::Alarm> SDCard<'a, A> {
 }
 
 /// Handle callbacks from the SPI peripheral
-impl<'a, A: hil::time::Alarm> hil::spi::SpiMasterClient for SDCard<'a, A> {
+impl<A: hil::time::Alarm> hil::spi::SpiMasterClient for SDCard<'a, A> {
     fn read_write_done(
         &self,
         mut write_buffer: &'static mut [u8],
@@ -1344,14 +1344,14 @@ impl<'a, A: hil::time::Alarm> hil::spi::SpiMasterClient for SDCard<'a, A> {
 }
 
 /// Handle callbacks from the timer
-impl<'a, A: hil::time::Alarm> hil::time::Client for SDCard<'a, A> {
+impl<A: hil::time::Alarm> hil::time::Client for SDCard<'a, A> {
     fn fired(&self) {
         self.process_alarm_states();
     }
 }
 
 /// Handle callbacks from the card detection pin
-impl<'a, A: hil::time::Alarm> hil::gpio::Client for SDCard<'a, A> {
+impl<A: hil::time::Alarm> hil::gpio::Client for SDCard<'a, A> {
     fn fired(&self, _: usize) {
         // check if there was an open transaction with the sd card
         if self.alarm_state.get() != AlarmState::Idle || self.state.get() != SpiState::Idle {
@@ -1411,7 +1411,7 @@ impl Default for App {
 pub static mut KERNEL_BUFFER: [u8; 512] = [0; 512];
 
 /// Functions for SDCardDriver
-impl<'a, A: hil::time::Alarm> SDCardDriver<'a, A> {
+impl<A: hil::time::Alarm> SDCardDriver<'a, A> {
     /// Create new SD card userland interface
     ///
     /// sdcard - SDCard interface to provide application access to
@@ -1431,7 +1431,7 @@ impl<'a, A: hil::time::Alarm> SDCardDriver<'a, A> {
 }
 
 /// Handle callbacks from SDCard
-impl<'a, A: hil::time::Alarm> SDCardClient for SDCardDriver<'a, A> {
+impl<A: hil::time::Alarm> SDCardClient for SDCardDriver<'a, A> {
     fn card_detection_changed(&self, installed: bool) {
         self.app.map(|app| {
             app.callback.map(|mut cb| {
@@ -1495,7 +1495,7 @@ impl<'a, A: hil::time::Alarm> SDCardClient for SDCardDriver<'a, A> {
 }
 
 /// Connections to userspace syscalls
-impl<'a, A: hil::time::Alarm> Driver for SDCardDriver<'a, A> {
+impl<A: hil::time::Alarm> Driver for SDCardDriver<'a, A> {
     fn allow(
         &self,
         _appid: AppId,

--- a/capsules/src/segger_rtt.rs
+++ b/capsules/src/segger_rtt.rs
@@ -154,7 +154,7 @@ impl SeggerRttMemory {
     }
 }
 
-pub struct SeggerRtt<'a, A: hil::time::Alarm + 'a> {
+pub struct SeggerRtt<'a, A: hil::time::Alarm> {
     alarm: &'a A, // Dummy alarm so we can get a callback.
     config: TakeCell<'static, SeggerRttMemory>,
     up_buffer: TakeCell<'static, [u8]>,
@@ -163,7 +163,7 @@ pub struct SeggerRtt<'a, A: hil::time::Alarm + 'a> {
     client_buffer: TakeCell<'static, [u8]>,
 }
 
-impl<'a, A: hil::time::Alarm + 'a> SeggerRtt<'a, A> {
+impl<'a, A: hil::time::Alarm> SeggerRtt<'a, A> {
     pub fn new(
         alarm: &'a A,
         config: &'static mut SeggerRttMemory,
@@ -181,7 +181,7 @@ impl<'a, A: hil::time::Alarm + 'a> SeggerRtt<'a, A> {
     }
 }
 
-impl<'a, A: hil::time::Alarm + 'a> hil::uart::UART for SeggerRtt<'a, A> {
+impl<'a, A: hil::time::Alarm> hil::uart::UART for SeggerRtt<'a, A> {
     fn set_client(&self, client: &'static hil::uart::Client) {
         self.client.set(client);
     }
@@ -221,7 +221,7 @@ impl<'a, A: hil::time::Alarm + 'a> hil::uart::UART for SeggerRtt<'a, A> {
     fn abort_receive(&self) {}
 }
 
-impl<'a, A: hil::time::Alarm + 'a> hil::time::Client for SeggerRtt<'a, A> {
+impl<'a, A: hil::time::Alarm> hil::time::Client for SeggerRtt<'a, A> {
     fn fired(&self) {
         self.client.map(|client| {
             self.client_buffer.take().map(|buffer| {

--- a/capsules/src/segger_rtt.rs
+++ b/capsules/src/segger_rtt.rs
@@ -163,7 +163,7 @@ pub struct SeggerRtt<'a, A: hil::time::Alarm> {
     client_buffer: TakeCell<'static, [u8]>,
 }
 
-impl<'a, A: hil::time::Alarm> SeggerRtt<'a, A> {
+impl<A: hil::time::Alarm> SeggerRtt<'a, A> {
     pub fn new(
         alarm: &'a A,
         config: &'static mut SeggerRttMemory,
@@ -181,7 +181,7 @@ impl<'a, A: hil::time::Alarm> SeggerRtt<'a, A> {
     }
 }
 
-impl<'a, A: hil::time::Alarm> hil::uart::UART for SeggerRtt<'a, A> {
+impl<A: hil::time::Alarm> hil::uart::UART for SeggerRtt<'a, A> {
     fn set_client(&self, client: &'static hil::uart::Client) {
         self.client.set(client);
     }
@@ -221,7 +221,7 @@ impl<'a, A: hil::time::Alarm> hil::uart::UART for SeggerRtt<'a, A> {
     fn abort_receive(&self) {}
 }
 
-impl<'a, A: hil::time::Alarm> hil::time::Client for SeggerRtt<'a, A> {
+impl<A: hil::time::Alarm> hil::time::Client for SeggerRtt<'a, A> {
     fn fired(&self) {
         self.client.map(|client| {
             self.client_buffer.take().map(|buffer| {

--- a/capsules/src/si7021.rs
+++ b/capsules/src/si7021.rs
@@ -93,7 +93,7 @@ enum OnDeck {
     Humidity,
 }
 
-pub struct SI7021<'a, A: time::Alarm + 'a> {
+pub struct SI7021<'a, A: time::Alarm> {
     i2c: &'a i2c::I2CDevice,
     alarm: &'a A,
     temp_callback: Cell<Option<&'static kernel::hil::sensors::TemperatureClient>>,
@@ -103,7 +103,7 @@ pub struct SI7021<'a, A: time::Alarm + 'a> {
     buffer: TakeCell<'static, [u8]>,
 }
 
-impl<'a, A: time::Alarm + 'a> SI7021<'a, A> {
+impl<'a, A: time::Alarm> SI7021<'a, A> {
     pub fn new(i2c: &'a i2c::I2CDevice, alarm: &'a A, buffer: &'static mut [u8]) -> SI7021<'a, A> {
         // setup and return struct
         SI7021 {
@@ -147,7 +147,7 @@ impl<'a, A: time::Alarm + 'a> SI7021<'a, A> {
     }
 }
 
-impl<'a, A: time::Alarm + 'a> i2c::I2CClient for SI7021<'a, A> {
+impl<'a, A: time::Alarm> i2c::I2CClient for SI7021<'a, A> {
     fn command_complete(&self, buffer: &'static mut [u8], _error: i2c::Error) {
         match self.state.get() {
             State::SelectElectronicId1 => {
@@ -237,7 +237,7 @@ impl<'a, A: time::Alarm + 'a> i2c::I2CClient for SI7021<'a, A> {
     }
 }
 
-impl<'a, A: time::Alarm + 'a> kernel::hil::sensors::TemperatureDriver for SI7021<'a, A> {
+impl<'a, A: time::Alarm> kernel::hil::sensors::TemperatureDriver for SI7021<'a, A> {
     fn read_temperature(&self) -> kernel::ReturnCode {
         self.buffer
             .take()
@@ -265,7 +265,7 @@ impl<'a, A: time::Alarm + 'a> kernel::hil::sensors::TemperatureDriver for SI7021
     }
 }
 
-impl<'a, A: time::Alarm + 'a> kernel::hil::sensors::HumidityDriver for SI7021<'a, A> {
+impl<'a, A: time::Alarm> kernel::hil::sensors::HumidityDriver for SI7021<'a, A> {
     fn read_humidity(&self) -> kernel::ReturnCode {
         self.buffer
             .take()
@@ -293,7 +293,7 @@ impl<'a, A: time::Alarm + 'a> kernel::hil::sensors::HumidityDriver for SI7021<'a
     }
 }
 
-impl<'a, A: time::Alarm + 'a> time::Client for SI7021<'a, A> {
+impl<'a, A: time::Alarm> time::Client for SI7021<'a, A> {
     fn fired(&self) {
         self.buffer.take().map(|buffer| {
             // turn on i2c to send commands

--- a/capsules/src/si7021.rs
+++ b/capsules/src/si7021.rs
@@ -103,7 +103,7 @@ pub struct SI7021<'a, A: time::Alarm> {
     buffer: TakeCell<'static, [u8]>,
 }
 
-impl<'a, A: time::Alarm> SI7021<'a, A> {
+impl<A: time::Alarm> SI7021<'a, A> {
     pub fn new(i2c: &'a i2c::I2CDevice, alarm: &'a A, buffer: &'static mut [u8]) -> SI7021<'a, A> {
         // setup and return struct
         SI7021 {
@@ -147,7 +147,7 @@ impl<'a, A: time::Alarm> SI7021<'a, A> {
     }
 }
 
-impl<'a, A: time::Alarm> i2c::I2CClient for SI7021<'a, A> {
+impl<A: time::Alarm> i2c::I2CClient for SI7021<'a, A> {
     fn command_complete(&self, buffer: &'static mut [u8], _error: i2c::Error) {
         match self.state.get() {
             State::SelectElectronicId1 => {
@@ -237,7 +237,7 @@ impl<'a, A: time::Alarm> i2c::I2CClient for SI7021<'a, A> {
     }
 }
 
-impl<'a, A: time::Alarm> kernel::hil::sensors::TemperatureDriver for SI7021<'a, A> {
+impl<A: time::Alarm> kernel::hil::sensors::TemperatureDriver for SI7021<'a, A> {
     fn read_temperature(&self) -> kernel::ReturnCode {
         self.buffer
             .take()
@@ -265,7 +265,7 @@ impl<'a, A: time::Alarm> kernel::hil::sensors::TemperatureDriver for SI7021<'a, 
     }
 }
 
-impl<'a, A: time::Alarm> kernel::hil::sensors::HumidityDriver for SI7021<'a, A> {
+impl<A: time::Alarm> kernel::hil::sensors::HumidityDriver for SI7021<'a, A> {
     fn read_humidity(&self) -> kernel::ReturnCode {
         self.buffer
             .take()
@@ -293,7 +293,7 @@ impl<'a, A: time::Alarm> kernel::hil::sensors::HumidityDriver for SI7021<'a, A> 
     }
 }
 
-impl<'a, A: time::Alarm> time::Client for SI7021<'a, A> {
+impl<A: time::Alarm> time::Client for SI7021<'a, A> {
     fn fired(&self) {
         self.buffer.take().map(|buffer| {
             // turn on i2c to send commands

--- a/capsules/src/spi.rs
+++ b/capsules/src/spi.rs
@@ -84,7 +84,7 @@ pub struct SpiSlave<'a, S: SpiSlaveDevice> {
     kernel_len: Cell<usize>,
 }
 
-impl<'a, S: SpiMasterDevice> Spi<'a, S> {
+impl<S: SpiMasterDevice> Spi<'a, S> {
     pub fn new(spi_master: &'a S) -> Spi<'a, S> {
         Spi {
             spi_master: spi_master,
@@ -126,7 +126,7 @@ impl<'a, S: SpiMasterDevice> Spi<'a, S> {
     }
 }
 
-impl<'a, S: SpiMasterDevice> Driver for Spi<'a, S> {
+impl<S: SpiMasterDevice> Driver for Spi<'a, S> {
     fn allow(
         &self,
         _appid: AppId,
@@ -276,7 +276,7 @@ impl<'a, S: SpiMasterDevice> Driver for Spi<'a, S> {
     }
 }
 
-impl<'a, S: SpiMasterDevice> SpiMasterClient for Spi<'a, S> {
+impl<S: SpiMasterDevice> SpiMasterClient for Spi<'a, S> {
     fn read_write_done(
         &self,
         writebuf: &'static mut [u8],
@@ -313,7 +313,7 @@ impl<'a, S: SpiMasterDevice> SpiMasterClient for Spi<'a, S> {
     }
 }
 
-impl<'a, S: SpiSlaveDevice> SpiSlave<'a, S> {
+impl<S: SpiSlaveDevice> SpiSlave<'a, S> {
     pub fn new(spi_slave: &'a S) -> SpiSlave<'a, S> {
         SpiSlave {
             spi_slave: spi_slave,
@@ -352,7 +352,7 @@ impl<'a, S: SpiSlaveDevice> SpiSlave<'a, S> {
     }
 }
 
-impl<'a, S: SpiSlaveDevice> Driver for SpiSlave<'a, S> {
+impl<S: SpiSlaveDevice> Driver for SpiSlave<'a, S> {
     /// Provide read/write buffers to SpiSlave
     ///
     /// - allow_num 0: Provides an app_read buffer to receive transfers into.
@@ -493,7 +493,7 @@ impl<'a, S: SpiSlaveDevice> Driver for SpiSlave<'a, S> {
     }
 }
 
-impl<'a, S: SpiSlaveDevice> SpiSlaveClient for SpiSlave<'a, S> {
+impl<S: SpiSlaveDevice> SpiSlaveClient for SpiSlave<'a, S> {
     fn read_write_done(
         &self,
         writebuf: Option<&'static mut [u8]>,

--- a/capsules/src/spi.rs
+++ b/capsules/src/spi.rs
@@ -66,7 +66,7 @@ impl Default for SlaveApp {
     }
 }
 
-pub struct Spi<'a, S: SpiMasterDevice + 'a> {
+pub struct Spi<'a, S: SpiMasterDevice> {
     spi_master: &'a S,
     busy: Cell<bool>,
     app: MapCell<App>,
@@ -75,7 +75,7 @@ pub struct Spi<'a, S: SpiMasterDevice + 'a> {
     kernel_len: Cell<usize>,
 }
 
-pub struct SpiSlave<'a, S: SpiSlaveDevice + 'a> {
+pub struct SpiSlave<'a, S: SpiSlaveDevice> {
     spi_slave: &'a S,
     busy: Cell<bool>,
     app: MapCell<SlaveApp>,

--- a/capsules/src/temperature.rs
+++ b/capsules/src/temperature.rs
@@ -66,7 +66,7 @@ pub struct TemperatureSensor<'a> {
     busy: Cell<bool>,
 }
 
-impl<'a> TemperatureSensor<'a> {
+impl TemperatureSensor<'a> {
     pub fn new(
         driver: &'a hil::sensors::TemperatureDriver,
         grant: Grant<App>,
@@ -102,7 +102,7 @@ impl<'a> TemperatureSensor<'a> {
     }
 }
 
-impl<'a> hil::sensors::TemperatureClient for TemperatureSensor<'a> {
+impl hil::sensors::TemperatureClient for TemperatureSensor<'a> {
     fn callback(&self, temp_val: usize) {
         for cntr in self.apps.iter() {
             cntr.enter(|app, _| {
@@ -116,7 +116,7 @@ impl<'a> hil::sensors::TemperatureClient for TemperatureSensor<'a> {
     }
 }
 
-impl<'a> Driver for TemperatureSensor<'a> {
+impl Driver for TemperatureSensor<'a> {
     fn subscribe(
         &self,
         subscribe_num: usize,

--- a/capsules/src/test/aes.rs
+++ b/capsules/src/test/aes.rs
@@ -35,7 +35,7 @@ pub struct TestAes128Cbc<'a, A: 'a> {
 const DATA_OFFSET: usize = AES128_BLOCK_SIZE;
 const DATA_LEN: usize = 4 * AES128_BLOCK_SIZE;
 
-impl<'a, A: AES128<'a> + AES128Ctr> TestAes128Ctr<'a, A> {
+impl<A: AES128<'a> + AES128Ctr> TestAes128Ctr<'a, A> {
     pub fn new(
         aes: &'a A,
         key: &'a mut [u8],
@@ -135,7 +135,7 @@ impl<'a, A: AES128<'a> + AES128Ctr> TestAes128Ctr<'a, A> {
     }
 }
 
-impl<'a, A: AES128<'a> + AES128Ctr> hil::symmetric_encryption::Client<'a> for TestAes128Ctr<'a, A> {
+impl<A: AES128<'a> + AES128Ctr> hil::symmetric_encryption::Client<'a> for TestAes128Ctr<'a, A> {
     fn crypt_done(&'a self, source: Option<&'a mut [u8]>, dest: &'a mut [u8]) {
         if self.use_source.get() {
             // Take back the source buffer
@@ -177,7 +177,7 @@ impl<'a, A: AES128<'a> + AES128Ctr> hil::symmetric_encryption::Client<'a> for Te
     }
 }
 
-impl<'a, A: AES128<'a> + AES128CBC> TestAes128Cbc<'a, A> {
+impl<A: AES128<'a> + AES128CBC> TestAes128Cbc<'a, A> {
     pub fn new(
         aes: &'a A,
         key: &'a mut [u8],
@@ -278,7 +278,7 @@ impl<'a, A: AES128<'a> + AES128CBC> TestAes128Cbc<'a, A> {
     }
 }
 
-impl<'a, A: AES128<'a> + AES128CBC> hil::symmetric_encryption::Client<'a> for TestAes128Cbc<'a, A> {
+impl<A: AES128<'a> + AES128CBC> hil::symmetric_encryption::Client<'a> for TestAes128Cbc<'a, A> {
     fn crypt_done(&'a self, source: Option<&'a mut [u8]>, dest: &'a mut [u8]) {
         if self.use_source.get() {
             // Take back the source buffer

--- a/capsules/src/test/aes_ccm.rs
+++ b/capsules/src/test/aes_ccm.rs
@@ -5,7 +5,7 @@ use kernel::common::cells::TakeCell;
 use kernel::hil::symmetric_encryption::{AES128CCM, AES128_KEY_SIZE, CCMClient, CCM_NONCE_LENGTH};
 use kernel::ReturnCode;
 
-pub struct Test<'a, A: AES128CCM<'a> + 'a> {
+pub struct Test<'a, A: AES128CCM<'a>> {
     aes_ccm: &'a A,
 
     buf: TakeCell<'static, [u8]>,
@@ -23,7 +23,7 @@ pub struct Test<'a, A: AES128CCM<'a> + 'a> {
     ); 3],
 }
 
-impl<'a, A: AES128CCM<'a> + 'a> Test<'a, A> {
+impl<'a, A: AES128CCM<'a>> Test<'a, A> {
     pub fn new(aes_ccm: &'a A, buf: &'static mut [u8]) -> Test<'a, A> {
         Test {
             aes_ccm: aes_ccm,
@@ -184,7 +184,7 @@ impl<'a, A: AES128CCM<'a> + 'a> Test<'a, A> {
     }
 }
 
-impl<'a, A: AES128CCM<'a> + 'a> CCMClient for Test<'a, A> {
+impl<'a, A: AES128CCM<'a>> CCMClient for Test<'a, A> {
     fn crypt_done(&self, buf: &'static mut [u8], res: ReturnCode, tag_is_valid: bool) {
         self.buf.replace(buf);
         if res != ReturnCode::SUCCESS {

--- a/capsules/src/test/aes_ccm.rs
+++ b/capsules/src/test/aes_ccm.rs
@@ -23,7 +23,7 @@ pub struct Test<'a, A: AES128CCM<'a>> {
     ); 3],
 }
 
-impl<'a, A: AES128CCM<'a>> Test<'a, A> {
+impl<A: AES128CCM<'a>> Test<'a, A> {
     pub fn new(aes_ccm: &'a A, buf: &'static mut [u8]) -> Test<'a, A> {
         Test {
             aes_ccm: aes_ccm,
@@ -184,7 +184,7 @@ impl<'a, A: AES128CCM<'a>> Test<'a, A> {
     }
 }
 
-impl<'a, A: AES128CCM<'a>> CCMClient for Test<'a, A> {
+impl<A: AES128CCM<'a>> CCMClient for Test<'a, A> {
     fn crypt_done(&self, buf: &'static mut [u8], res: ReturnCode, tag_is_valid: bool) {
         self.buf.replace(buf);
         if res != ReturnCode::SUCCESS {

--- a/capsules/src/tmp006.rs
+++ b/capsules/src/tmp006.rs
@@ -105,7 +105,7 @@ pub struct TMP006<'a> {
     buffer: TakeCell<'static, [u8]>,
 }
 
-impl<'a> TMP006<'a> {
+impl TMP006<'a> {
     /// The `interrupt_pin` must be pulled-up since the TMP006 is open-drain.
     pub fn new(
         i2c: &'a i2c::I2CDevice,
@@ -189,7 +189,7 @@ fn calculate_temperature(sensor_voltage: i16, die_temperature: i16) -> f32 {
     t_celsius
 }
 
-impl<'a> i2c::I2CClient for TMP006<'a> {
+impl i2c::I2CClient for TMP006<'a> {
     fn command_complete(&self, buffer: &'static mut [u8], _error: i2c::Error) {
         // TODO(alevy): handle protocol errors
         match self.protocol_state.get() {
@@ -257,7 +257,7 @@ impl<'a> i2c::I2CClient for TMP006<'a> {
     }
 }
 
-impl<'a> Client for TMP006<'a> {
+impl Client for TMP006<'a> {
     fn fired(&self, _: usize) {
         self.buffer.take().map(|buf| {
             // turn on i2c to send commands
@@ -271,7 +271,7 @@ impl<'a> Client for TMP006<'a> {
     }
 }
 
-impl<'a> Driver for TMP006<'a> {
+impl Driver for TMP006<'a> {
     fn subscribe(
         &self,
         subscribe_num: usize,

--- a/capsules/src/tsl2561.rs
+++ b/capsules/src/tsl2561.rs
@@ -208,7 +208,7 @@ pub struct TSL2561<'a> {
     buffer: TakeCell<'static, [u8]>,
 }
 
-impl<'a> TSL2561<'a> {
+impl TSL2561<'a> {
     pub fn new(
         i2c: &'a i2c::I2CDevice,
         interrupt_pin: &'a gpio::Pin,
@@ -344,7 +344,7 @@ impl<'a> TSL2561<'a> {
     }
 }
 
-impl<'a> i2c::I2CClient for TSL2561<'a> {
+impl i2c::I2CClient for TSL2561<'a> {
     fn command_complete(&self, buffer: &'static mut [u8], _error: i2c::Error) {
         match self.state.get() {
             State::SelectId => {
@@ -421,7 +421,7 @@ impl<'a> i2c::I2CClient for TSL2561<'a> {
     }
 }
 
-impl<'a> gpio::Client for TSL2561<'a> {
+impl gpio::Client for TSL2561<'a> {
     fn fired(&self, _: usize) {
         self.buffer.take().map(|buffer| {
             // turn on i2c to send commands
@@ -435,7 +435,7 @@ impl<'a> gpio::Client for TSL2561<'a> {
     }
 }
 
-impl<'a> Driver for TSL2561<'a> {
+impl Driver for TSL2561<'a> {
     fn subscribe(
         &self,
         subscribe_num: usize,

--- a/capsules/src/usb.rs
+++ b/capsules/src/usb.rs
@@ -498,7 +498,7 @@ pub struct LanguagesDescriptor<'a> {
     pub langs: &'a [u16],
 }
 
-impl<'a> Descriptor for LanguagesDescriptor<'a> {
+impl Descriptor for LanguagesDescriptor<'a> {
     fn size(&self) -> usize {
         2 + (2 * self.langs.len())
     }
@@ -518,7 +518,7 @@ pub struct StringDescriptor<'a> {
     pub string: &'a str,
 }
 
-impl<'a> Descriptor for StringDescriptor<'a> {
+impl Descriptor for StringDescriptor<'a> {
     fn size(&self) -> usize {
         let mut len = 2;
         for ch in self.string.chars() {

--- a/capsules/src/usb_user.rs
+++ b/capsules/src/usb_user.rs
@@ -43,7 +43,7 @@ pub struct UsbSyscallDriver<'a, C: hil::usb::Client> {
     serving_app: Cell<Option<AppId>>,
 }
 
-impl<'a, C> UsbSyscallDriver<'a, C>
+impl<C> UsbSyscallDriver<'a, C>
 where
     C: hil::usb::Client,
 {
@@ -98,7 +98,7 @@ enum Request {
     EnableAndAttach,
 }
 
-impl<'a, C> Driver for UsbSyscallDriver<'a, C>
+impl<C> Driver for UsbSyscallDriver<'a, C>
 where
     C: hil::usb::Client,
 {

--- a/capsules/src/usb_user.rs
+++ b/capsules/src/usb_user.rs
@@ -37,7 +37,7 @@ pub struct App {
     awaiting: Option<Request>,
 }
 
-pub struct UsbSyscallDriver<'a, C: hil::usb::Client + 'a> {
+pub struct UsbSyscallDriver<'a, C: hil::usb::Client> {
     usbc_client: &'a C,
     apps: Grant<App>,
     serving_app: Cell<Option<AppId>>,

--- a/capsules/src/usbc_client.rs
+++ b/capsules/src/usbc_client.rs
@@ -71,7 +71,7 @@ impl Default for State {
     }
 }
 
-impl<'a, C: UsbController> Client<'a, C> {
+impl<C: UsbController> Client<'a, C> {
     pub fn new(controller: &'a C) -> Self {
         Client {
             controller: controller,
@@ -108,7 +108,7 @@ impl<'a, C: UsbController> Client<'a, C> {
     }
 }
 
-impl<'a, C: UsbController> hil::usb::Client for Client<'a, C> {
+impl<C: UsbController> hil::usb::Client for Client<'a, C> {
     fn enable(&self) {
         // Set up the default control endpoint
         self.controller.endpoint_set_buffer(0, &self.buffers[0]);

--- a/capsules/src/virtual_alarm.rs
+++ b/capsules/src/virtual_alarm.rs
@@ -5,7 +5,7 @@ use core::cell::Cell;
 use kernel::common::{List, ListLink, ListNode};
 use kernel::hil::time::{self, Alarm, Time};
 
-pub struct VirtualMuxAlarm<'a, Alrm: Alarm + 'a> {
+pub struct VirtualMuxAlarm<'a, Alrm: Alarm> {
     mux: &'a MuxAlarm<'a, Alrm>,
     when: Cell<u32>,
     armed: Cell<bool>,
@@ -105,7 +105,7 @@ impl<'a, Alrm: Alarm> time::Client for VirtualMuxAlarm<'a, Alrm> {
 
 // MuxAlarm
 
-pub struct MuxAlarm<'a, Alrm: Alarm + 'a> {
+pub struct MuxAlarm<'a, Alrm: Alarm> {
     virtual_alarms: List<'a, VirtualMuxAlarm<'a, Alrm>>,
     enabled: Cell<usize>,
     prev: Cell<u32>,

--- a/capsules/src/virtual_alarm.rs
+++ b/capsules/src/virtual_alarm.rs
@@ -13,13 +13,13 @@ pub struct VirtualMuxAlarm<'a, Alrm: Alarm> {
     client: Cell<Option<&'a time::Client>>,
 }
 
-impl<'a, A: Alarm> ListNode<'a, VirtualMuxAlarm<'a, A>> for VirtualMuxAlarm<'a, A> {
+impl<A: Alarm> ListNode<'a, VirtualMuxAlarm<'a, A>> for VirtualMuxAlarm<'a, A> {
     fn next(&self) -> &'a ListLink<VirtualMuxAlarm<'a, A>> {
         &self.next
     }
 }
 
-impl<'a, Alrm: Alarm> VirtualMuxAlarm<'a, Alrm> {
+impl<Alrm: Alarm> VirtualMuxAlarm<'a, Alrm> {
     pub fn new(mux_alarm: &'a MuxAlarm<'a, Alrm>) -> VirtualMuxAlarm<'a, Alrm> {
         VirtualMuxAlarm {
             mux: mux_alarm,
@@ -38,7 +38,7 @@ impl<'a, Alrm: Alarm> VirtualMuxAlarm<'a, Alrm> {
     }
 }
 
-impl<'a, Alrm: Alarm> Time for VirtualMuxAlarm<'a, Alrm> {
+impl<Alrm: Alarm> Time for VirtualMuxAlarm<'a, Alrm> {
     type Frequency = Alrm::Frequency;
 
     fn disable(&self) {
@@ -63,7 +63,7 @@ impl<'a, Alrm: Alarm> Time for VirtualMuxAlarm<'a, Alrm> {
     }
 }
 
-impl<'a, Alrm: Alarm> Alarm for VirtualMuxAlarm<'a, Alrm> {
+impl<Alrm: Alarm> Alarm for VirtualMuxAlarm<'a, Alrm> {
     fn now(&self) -> u32 {
         self.mux.alarm.now()
     }
@@ -97,7 +97,7 @@ impl<'a, Alrm: Alarm> Alarm for VirtualMuxAlarm<'a, Alrm> {
     }
 }
 
-impl<'a, Alrm: Alarm> time::Client for VirtualMuxAlarm<'a, Alrm> {
+impl<Alrm: Alarm> time::Client for VirtualMuxAlarm<'a, Alrm> {
     fn fired(&self) {
         self.client.get().map(|client| client.fired());
     }
@@ -112,7 +112,7 @@ pub struct MuxAlarm<'a, Alrm: Alarm> {
     alarm: &'a Alrm,
 }
 
-impl<'a, Alrm: Alarm> MuxAlarm<'a, Alrm> {
+impl<Alrm: Alarm> MuxAlarm<'a, Alrm> {
     pub const fn new(alarm: &'a Alrm) -> MuxAlarm<'a, Alrm> {
         MuxAlarm {
             virtual_alarms: List::new(),
@@ -127,7 +127,7 @@ fn has_expired(alarm: u32, now: u32, prev: u32) -> bool {
     now.wrapping_sub(prev) >= alarm.wrapping_sub(prev)
 }
 
-impl<'a, Alrm: Alarm> time::Client for MuxAlarm<'a, Alrm> {
+impl<Alrm: Alarm> time::Client for MuxAlarm<'a, Alrm> {
     fn fired(&self) {
         let now = self.alarm.now();
 

--- a/capsules/src/virtual_flash.rs
+++ b/capsules/src/virtual_flash.rs
@@ -39,7 +39,7 @@ pub struct MuxFlash<'a, F: hil::flash::Flash + 'static> {
     inflight: Cell<Option<&'a FlashUser<'a, F>>>,
 }
 
-impl<'a, F: hil::flash::Flash> hil::flash::Client<F> for MuxFlash<'a, F> {
+impl<F: hil::flash::Flash> hil::flash::Client<F> for MuxFlash<'a, F> {
     fn read_complete(&self, pagebuffer: &'static mut F::Page, error: hil::flash::Error) {
         self.inflight.get().map(move |user| {
             self.inflight.set(None);
@@ -65,7 +65,7 @@ impl<'a, F: hil::flash::Flash> hil::flash::Client<F> for MuxFlash<'a, F> {
     }
 }
 
-impl<'a, F: hil::flash::Flash> MuxFlash<'a, F> {
+impl<F: hil::flash::Flash> MuxFlash<'a, F> {
     pub const fn new(flash: &'a F) -> MuxFlash<'a, F> {
         MuxFlash {
             flash: flash,
@@ -135,7 +135,7 @@ pub struct FlashUser<'a, F: hil::flash::Flash + 'static> {
     client: Cell<Option<&'a hil::flash::Client<FlashUser<'a, F>>>>,
 }
 
-impl<'a, F: hil::flash::Flash> FlashUser<'a, F> {
+impl<F: hil::flash::Flash> FlashUser<'a, F> {
     pub const fn new(mux: &'a MuxFlash<'a, F>) -> FlashUser<'a, F> {
         FlashUser {
             mux: mux,
@@ -147,7 +147,7 @@ impl<'a, F: hil::flash::Flash> FlashUser<'a, F> {
     }
 }
 
-impl<'a, F: hil::flash::Flash, C: hil::flash::Client<Self>> hil::flash::HasClient<'a, C>
+impl<F: hil::flash::Flash, C: hil::flash::Client<Self>> hil::flash::HasClient<'a, C>
     for FlashUser<'a, F>
 {
     fn set_client(&'a self, client: &'a C) {
@@ -156,7 +156,7 @@ impl<'a, F: hil::flash::Flash, C: hil::flash::Client<Self>> hil::flash::HasClien
     }
 }
 
-impl<'a, F: hil::flash::Flash> hil::flash::Client<F> for FlashUser<'a, F> {
+impl<F: hil::flash::Flash> hil::flash::Client<F> for FlashUser<'a, F> {
     fn read_complete(&self, pagebuffer: &'static mut F::Page, error: hil::flash::Error) {
         self.client.get().map(move |client| {
             client.read_complete(pagebuffer, error);
@@ -176,13 +176,13 @@ impl<'a, F: hil::flash::Flash> hil::flash::Client<F> for FlashUser<'a, F> {
     }
 }
 
-impl<'a, F: hil::flash::Flash> ListNode<'a, FlashUser<'a, F>> for FlashUser<'a, F> {
+impl<F: hil::flash::Flash> ListNode<'a, FlashUser<'a, F>> for FlashUser<'a, F> {
     fn next(&'a self) -> &'a ListLink<'a, FlashUser<'a, F>> {
         &self.next
     }
 }
 
-impl<'a, F: hil::flash::Flash> hil::flash::Flash for FlashUser<'a, F> {
+impl<F: hil::flash::Flash> hil::flash::Flash for FlashUser<'a, F> {
     type Page = F::Page;
 
     fn read_page(&self, page_number: usize, buf: &'static mut Self::Page) -> ReturnCode {

--- a/capsules/src/virtual_flash.rs
+++ b/capsules/src/virtual_flash.rs
@@ -39,7 +39,7 @@ pub struct MuxFlash<'a, F: hil::flash::Flash + 'static> {
     inflight: Cell<Option<&'a FlashUser<'a, F>>>,
 }
 
-impl<'a, F: hil::flash::Flash + 'a> hil::flash::Client<F> for MuxFlash<'a, F> {
+impl<'a, F: hil::flash::Flash> hil::flash::Client<F> for MuxFlash<'a, F> {
     fn read_complete(&self, pagebuffer: &'static mut F::Page, error: hil::flash::Error) {
         self.inflight.get().map(move |user| {
             self.inflight.set(None);
@@ -65,7 +65,7 @@ impl<'a, F: hil::flash::Flash + 'a> hil::flash::Client<F> for MuxFlash<'a, F> {
     }
 }
 
-impl<'a, F: hil::flash::Flash + 'a> MuxFlash<'a, F> {
+impl<'a, F: hil::flash::Flash> MuxFlash<'a, F> {
     pub const fn new(flash: &'a F) -> MuxFlash<'a, F> {
         MuxFlash {
             flash: flash,
@@ -135,7 +135,7 @@ pub struct FlashUser<'a, F: hil::flash::Flash + 'static> {
     client: Cell<Option<&'a hil::flash::Client<FlashUser<'a, F>>>>,
 }
 
-impl<'a, F: hil::flash::Flash + 'a> FlashUser<'a, F> {
+impl<'a, F: hil::flash::Flash> FlashUser<'a, F> {
     pub const fn new(mux: &'a MuxFlash<'a, F>) -> FlashUser<'a, F> {
         FlashUser {
             mux: mux,
@@ -147,7 +147,7 @@ impl<'a, F: hil::flash::Flash + 'a> FlashUser<'a, F> {
     }
 }
 
-impl<'a, F: hil::flash::Flash + 'a, C: hil::flash::Client<Self>> hil::flash::HasClient<'a, C>
+impl<'a, F: hil::flash::Flash, C: hil::flash::Client<Self>> hil::flash::HasClient<'a, C>
     for FlashUser<'a, F>
 {
     fn set_client(&'a self, client: &'a C) {
@@ -156,7 +156,7 @@ impl<'a, F: hil::flash::Flash + 'a, C: hil::flash::Client<Self>> hil::flash::Has
     }
 }
 
-impl<'a, F: hil::flash::Flash + 'a> hil::flash::Client<F> for FlashUser<'a, F> {
+impl<'a, F: hil::flash::Flash> hil::flash::Client<F> for FlashUser<'a, F> {
     fn read_complete(&self, pagebuffer: &'static mut F::Page, error: hil::flash::Error) {
         self.client.get().map(move |client| {
             client.read_complete(pagebuffer, error);
@@ -176,13 +176,13 @@ impl<'a, F: hil::flash::Flash + 'a> hil::flash::Client<F> for FlashUser<'a, F> {
     }
 }
 
-impl<'a, F: hil::flash::Flash + 'a> ListNode<'a, FlashUser<'a, F>> for FlashUser<'a, F> {
+impl<'a, F: hil::flash::Flash> ListNode<'a, FlashUser<'a, F>> for FlashUser<'a, F> {
     fn next(&'a self) -> &'a ListLink<'a, FlashUser<'a, F>> {
         &self.next
     }
 }
 
-impl<'a, F: hil::flash::Flash + 'a> hil::flash::Flash for FlashUser<'a, F> {
+impl<'a, F: hil::flash::Flash> hil::flash::Flash for FlashUser<'a, F> {
     type Page = F::Page;
 
     fn read_page(&self, page_number: usize, buf: &'static mut Self::Page) -> ReturnCode {

--- a/capsules/src/virtual_i2c.rs
+++ b/capsules/src/virtual_i2c.rs
@@ -15,7 +15,7 @@ pub struct MuxI2C<'a> {
     inflight: Cell<Option<&'a I2CDevice<'a>>>,
 }
 
-impl<'a> I2CHwMasterClient for MuxI2C<'a> {
+impl I2CHwMasterClient for MuxI2C<'a> {
     fn command_complete(&self, buffer: &'static mut [u8], error: Error) {
         self.inflight.get().map(move |device| {
             self.inflight.set(None);
@@ -25,7 +25,7 @@ impl<'a> I2CHwMasterClient for MuxI2C<'a> {
     }
 }
 
-impl<'a> MuxI2C<'a> {
+impl MuxI2C<'a> {
     pub const fn new(i2c: &'a i2c::I2CMaster) -> MuxI2C<'a> {
         MuxI2C {
             i2c: i2c,
@@ -93,7 +93,7 @@ pub struct I2CDevice<'a> {
     client: Cell<Option<&'a I2CClient>>,
 }
 
-impl<'a> I2CDevice<'a> {
+impl I2CDevice<'a> {
     pub const fn new(mux: &'a MuxI2C<'a>, addr: u8) -> I2CDevice<'a> {
         I2CDevice {
             mux: mux,
@@ -112,7 +112,7 @@ impl<'a> I2CDevice<'a> {
     }
 }
 
-impl<'a> I2CClient for I2CDevice<'a> {
+impl I2CClient for I2CDevice<'a> {
     fn command_complete(&self, buffer: &'static mut [u8], error: Error) {
         self.client.get().map(move |client| {
             client.command_complete(buffer, error);
@@ -120,13 +120,13 @@ impl<'a> I2CClient for I2CDevice<'a> {
     }
 }
 
-impl<'a> ListNode<'a, I2CDevice<'a>> for I2CDevice<'a> {
+impl ListNode<'a, I2CDevice<'a>> for I2CDevice<'a> {
     fn next(&'a self) -> &'a ListLink<'a, I2CDevice<'a>> {
         &self.next
     }
 }
 
-impl<'a> i2c::I2CDevice for I2CDevice<'a> {
+impl i2c::I2CDevice for I2CDevice<'a> {
     fn enable(&self) {
         if !self.enabled.get() {
             self.enabled.set(true);

--- a/capsules/src/virtual_spi.rs
+++ b/capsules/src/virtual_spi.rs
@@ -8,7 +8,7 @@ use kernel::ReturnCode;
 
 /// The Mux struct manages multiple Spi clients. Each client may have
 /// at most one outstanding Spi request.
-pub struct MuxSpiMaster<'a, Spi: hil::spi::SpiMaster + 'a> {
+pub struct MuxSpiMaster<'a, Spi: hil::spi::SpiMaster> {
     spi: &'a Spi,
     devices: List<'a, VirtualSpiMasterDevice<'a, Spi>>,
     inflight: Cell<Option<&'a VirtualSpiMasterDevice<'a, Spi>>>,
@@ -92,7 +92,7 @@ enum Op {
     SetRate(u32),
 }
 
-pub struct VirtualSpiMasterDevice<'a, Spi: hil::spi::SpiMaster + 'a> {
+pub struct VirtualSpiMasterDevice<'a, Spi: hil::spi::SpiMaster> {
     mux: &'a MuxSpiMaster<'a, Spi>,
     chip_select: Cell<Spi::ChipSelect>,
     txbuffer: TakeCell<'static, [u8]>,
@@ -192,7 +192,7 @@ impl<'a, Spi: hil::spi::SpiMaster> hil::spi::SpiMasterDevice for VirtualSpiMaste
     }
 }
 
-pub struct VirtualSpiSlaveDevice<'a, Spi: hil::spi::SpiSlave + 'a> {
+pub struct VirtualSpiSlaveDevice<'a, Spi: hil::spi::SpiSlave> {
     spi: &'a Spi,
     client: Cell<Option<&'a hil::spi::SpiSlaveClient>>,
 }

--- a/capsules/src/virtual_spi.rs
+++ b/capsules/src/virtual_spi.rs
@@ -14,7 +14,7 @@ pub struct MuxSpiMaster<'a, Spi: hil::spi::SpiMaster> {
     inflight: Cell<Option<&'a VirtualSpiMasterDevice<'a, Spi>>>,
 }
 
-impl<'a, Spi: hil::spi::SpiMaster> hil::spi::SpiMasterClient for MuxSpiMaster<'a, Spi> {
+impl<Spi: hil::spi::SpiMaster> hil::spi::SpiMasterClient for MuxSpiMaster<'a, Spi> {
     fn read_write_done(
         &self,
         write_buffer: &'static mut [u8],
@@ -29,7 +29,7 @@ impl<'a, Spi: hil::spi::SpiMaster> hil::spi::SpiMasterClient for MuxSpiMaster<'a
     }
 }
 
-impl<'a, Spi: hil::spi::SpiMaster> MuxSpiMaster<'a, Spi> {
+impl<Spi: hil::spi::SpiMaster> MuxSpiMaster<'a, Spi> {
     pub const fn new(spi: &'a Spi) -> MuxSpiMaster<'a, Spi> {
         MuxSpiMaster {
             spi: spi,
@@ -102,7 +102,7 @@ pub struct VirtualSpiMasterDevice<'a, Spi: hil::spi::SpiMaster> {
     client: Cell<Option<&'a hil::spi::SpiMasterClient>>,
 }
 
-impl<'a, Spi: hil::spi::SpiMaster> VirtualSpiMasterDevice<'a, Spi> {
+impl<Spi: hil::spi::SpiMaster> VirtualSpiMasterDevice<'a, Spi> {
     pub const fn new(
         mux: &'a MuxSpiMaster<'a, Spi>,
         chip_select: Spi::ChipSelect,
@@ -124,7 +124,7 @@ impl<'a, Spi: hil::spi::SpiMaster> VirtualSpiMasterDevice<'a, Spi> {
     }
 }
 
-impl<'a, Spi: hil::spi::SpiMaster> hil::spi::SpiMasterClient for VirtualSpiMasterDevice<'a, Spi> {
+impl<Spi: hil::spi::SpiMaster> hil::spi::SpiMasterClient for VirtualSpiMasterDevice<'a, Spi> {
     fn read_write_done(
         &self,
         write_buffer: &'static mut [u8],
@@ -137,7 +137,7 @@ impl<'a, Spi: hil::spi::SpiMaster> hil::spi::SpiMasterClient for VirtualSpiMaste
     }
 }
 
-impl<'a, Spi: hil::spi::SpiMaster> ListNode<'a, VirtualSpiMasterDevice<'a, Spi>>
+impl<Spi: hil::spi::SpiMaster> ListNode<'a, VirtualSpiMasterDevice<'a, Spi>>
     for VirtualSpiMasterDevice<'a, Spi>
 {
     fn next(&'a self) -> &'a ListLink<'a, VirtualSpiMasterDevice<'a, Spi>> {
@@ -145,7 +145,7 @@ impl<'a, Spi: hil::spi::SpiMaster> ListNode<'a, VirtualSpiMasterDevice<'a, Spi>>
     }
 }
 
-impl<'a, Spi: hil::spi::SpiMaster> hil::spi::SpiMasterDevice for VirtualSpiMasterDevice<'a, Spi> {
+impl<Spi: hil::spi::SpiMaster> hil::spi::SpiMasterDevice for VirtualSpiMasterDevice<'a, Spi> {
     fn configure(&self, cpol: hil::spi::ClockPolarity, cpal: hil::spi::ClockPhase, rate: u32) {
         self.operation.set(Op::Configure(cpol, cpal, rate));
         self.mux.do_next_op();
@@ -197,7 +197,7 @@ pub struct VirtualSpiSlaveDevice<'a, Spi: hil::spi::SpiSlave> {
     client: Cell<Option<&'a hil::spi::SpiSlaveClient>>,
 }
 
-impl<'a, Spi: hil::spi::SpiSlave> VirtualSpiSlaveDevice<'a, Spi> {
+impl<Spi: hil::spi::SpiSlave> VirtualSpiSlaveDevice<'a, Spi> {
     pub const fn new(spi: &'a Spi) -> VirtualSpiSlaveDevice<'a, Spi> {
         VirtualSpiSlaveDevice {
             spi: spi,
@@ -210,7 +210,7 @@ impl<'a, Spi: hil::spi::SpiSlave> VirtualSpiSlaveDevice<'a, Spi> {
     }
 }
 
-impl<'a, Spi: hil::spi::SpiSlave> hil::spi::SpiSlaveClient for VirtualSpiSlaveDevice<'a, Spi> {
+impl<Spi: hil::spi::SpiSlave> hil::spi::SpiSlaveClient for VirtualSpiSlaveDevice<'a, Spi> {
     fn read_write_done(
         &self,
         write_buffer: Option<&'static mut [u8]>,
@@ -229,7 +229,7 @@ impl<'a, Spi: hil::spi::SpiSlave> hil::spi::SpiSlaveClient for VirtualSpiSlaveDe
     }
 }
 
-impl<'a, Spi: hil::spi::SpiSlave> hil::spi::SpiSlaveDevice for VirtualSpiSlaveDevice<'a, Spi> {
+impl<Spi: hil::spi::SpiSlave> hil::spi::SpiSlaveDevice for VirtualSpiSlaveDevice<'a, Spi> {
     fn configure(&self, cpol: hil::spi::ClockPolarity, cpal: hil::spi::ClockPhase) {
         self.spi.set_clock(cpol);
         self.spi.set_phase(cpal);

--- a/chips/nrf5x/src/aes.rs
+++ b/chips/nrf5x/src/aes.rs
@@ -134,7 +134,7 @@ pub struct AesECB<'a> {
 
 pub static mut AESECB: AesECB = AesECB::new();
 
-impl<'a> AesECB<'a> {
+impl AesECB<'a> {
     const fn new() -> AesECB<'a> {
         AesECB {
             registers: AESECB_BASE,
@@ -253,7 +253,7 @@ impl<'a> AesECB<'a> {
     }
 }
 
-impl<'a> kernel::hil::symmetric_encryption::AES128<'a> for AesECB<'a> {
+impl kernel::hil::symmetric_encryption::AES128<'a> for AesECB<'a> {
     fn enable(&self) {
         self.set_dma();
     }
@@ -332,7 +332,7 @@ impl<'a> kernel::hil::symmetric_encryption::AES128<'a> for AesECB<'a> {
     }
 }
 
-impl<'a> kernel::hil::symmetric_encryption::AES128Ctr for AesECB<'a> {
+impl kernel::hil::symmetric_encryption::AES128Ctr for AesECB<'a> {
     // not needed by NRF5x (the configuration is the same for encryption and decryption)
     fn set_mode_aes128ctr(&self, _encrypting: bool) {
         ()

--- a/chips/nrf5x/src/lib.rs
+++ b/chips/nrf5x/src/lib.rs
@@ -1,4 +1,5 @@
 #![feature(const_fn, try_from)]
+#![feature(in_band_lifetimes)]
 #![no_std]
 
 #[allow(unused_imports)]

--- a/chips/nrf5x/src/trng.rs
+++ b/chips/nrf5x/src/trng.rs
@@ -111,7 +111,7 @@ pub struct Trng<'a> {
 
 pub static mut TRNG: Trng<'static> = Trng::new();
 
-impl<'a> Trng<'a> {
+impl Trng<'a> {
     const fn new() -> Trng<'a> {
         Trng {
             registers: RNG_BASE,
@@ -194,7 +194,7 @@ impl<'a> Trng<'a> {
 
 struct TrngIter<'a, 'b: 'a>(&'a Trng<'b>);
 
-impl<'a, 'b> Iterator for TrngIter<'a, 'b> {
+impl Iterator for TrngIter<'a, 'b> {
     type Item = u32;
 
     fn next(&mut self) -> Option<u32> {
@@ -210,7 +210,7 @@ impl<'a, 'b> Iterator for TrngIter<'a, 'b> {
     }
 }
 
-impl<'a> rng::RNG for Trng<'a> {
+impl rng::RNG for Trng<'a> {
     fn get(&self) {
         self.start_rng()
     }

--- a/chips/sam4l/src/aes.rs
+++ b/chips/sam4l/src/aes.rs
@@ -159,7 +159,7 @@ pub struct Aes<'a> {
     stop_index: Cell<usize>,
 }
 
-impl<'a> Aes<'a> {
+impl Aes<'a> {
     const fn new() -> Aes<'a> {
         Aes {
             registers: AES_BASE,
@@ -402,7 +402,7 @@ impl<'a> Aes<'a> {
     }
 }
 
-impl<'a> hil::symmetric_encryption::AES128<'a> for Aes<'a> {
+impl hil::symmetric_encryption::AES128<'a> for Aes<'a> {
     fn enable(&self) {
         let regs: &AesRegisters = &*self.registers;
         self.enable_clock();
@@ -501,13 +501,13 @@ impl<'a> hil::symmetric_encryption::AES128<'a> for Aes<'a> {
     }
 }
 
-impl<'a> hil::symmetric_encryption::AES128Ctr for Aes<'a> {
+impl hil::symmetric_encryption::AES128Ctr for Aes<'a> {
     fn set_mode_aes128ctr(&self, encrypting: bool) {
         self.set_mode(encrypting, ConfidentialityMode::CTR);
     }
 }
 
-impl<'a> hil::symmetric_encryption::AES128CBC for Aes<'a> {
+impl hil::symmetric_encryption::AES128CBC for Aes<'a> {
     fn set_mode_aes128cbc(&self, encrypting: bool) {
         self.set_mode(encrypting, ConfidentialityMode::CBC);
     }

--- a/chips/sam4l/src/ast.rs
+++ b/chips/sam4l/src/ast.rs
@@ -174,7 +174,7 @@ pub static mut AST: Ast<'static> = Ast {
     callback: Cell::new(None),
 };
 
-impl<'a> Controller for Ast<'a> {
+impl Controller for Ast<'a> {
     type Config = &'static time::Client;
 
     fn configure(&self, client: &'a time::Client) {
@@ -200,7 +200,7 @@ enum Clock {
     Clock1K = 4,
 }
 
-impl<'a> Ast<'a> {
+impl Ast<'a> {
     fn clock_busy(&self) -> bool {
         let regs: &AstRegisters = &*self.registers;
         regs.sr.is_set(Status::CLKBUSY)
@@ -302,7 +302,7 @@ impl<'a> Ast<'a> {
     }
 }
 
-impl<'a> Time for Ast<'a> {
+impl Time for Ast<'a> {
     type Frequency = Freq16KHz;
 
     fn disable(&self) {
@@ -315,7 +315,7 @@ impl<'a> Time for Ast<'a> {
     }
 }
 
-impl<'a> Alarm for Ast<'a> {
+impl Alarm for Ast<'a> {
     fn now(&self) -> u32 {
         self.get_counter()
     }

--- a/chips/sam4l/src/crccu.rs
+++ b/chips/sam4l/src/crccu.rs
@@ -236,7 +236,7 @@ pub struct Crccu<'a> {
 
 const DSCR_RESERVE: usize = 512 + 5 * 4;
 
-impl<'a> Crccu<'a> {
+impl Crccu<'a> {
     const fn new(base_address: StaticRef<CrccuRegisters>) -> Self {
         Crccu {
             registers: base_address,
@@ -339,7 +339,7 @@ impl<'a> Crccu<'a> {
 }
 
 // Implement the generic CRC interface with the CRCCU
-impl<'a> crc::CRC for Crccu<'a> {
+impl crc::CRC for Crccu<'a> {
     fn compute(&self, data: &[u8], alg: CrcAlg) -> ReturnCode {
         let regs: &CrccuRegisters = &*self.registers;
 

--- a/chips/sam4l/src/lib.rs
+++ b/chips/sam4l/src/lib.rs
@@ -5,6 +5,7 @@
 #![crate_name = "sam4l"]
 #![crate_type = "rlib"]
 #![feature(asm, concat_idents, const_fn, core_intrinsics, try_from, used)]
+#![feature(in_band_lifetimes)]
 #![no_std]
 
 extern crate cortexm4;

--- a/chips/sam4l/src/trng.rs
+++ b/chips/sam4l/src/trng.rs
@@ -51,7 +51,7 @@ pub struct Trng<'a> {
 pub static mut TRNG: Trng<'static> = Trng::new();
 const KEY: u32 = 0x524e47;
 
-impl<'a> Trng<'a> {
+impl Trng<'a> {
     const fn new() -> Trng<'a> {
         Trng {
             regs: BASE_ADDRESS,
@@ -87,7 +87,7 @@ impl<'a> Trng<'a> {
 
 struct TrngIter<'a, 'b: 'a>(&'a Trng<'b>);
 
-impl<'a, 'b> Iterator for TrngIter<'a, 'b> {
+impl Iterator for TrngIter<'a, 'b> {
     type Item = u32;
 
     fn next(&mut self) -> Option<u32> {
@@ -100,7 +100,7 @@ impl<'a, 'b> Iterator for TrngIter<'a, 'b> {
     }
 }
 
-impl<'a> rng::RNG for Trng<'a> {
+impl rng::RNG for Trng<'a> {
     fn get(&self) {
         let regs = &*self.regs;
         pm::enable_clock(pm::Clock::PBA(pm::PBAClock::TRNG));

--- a/chips/sam4l/src/usart.rs
+++ b/chips/sam4l/src/usart.rs
@@ -288,7 +288,7 @@ pub struct USARTRegManager<'a> {
 
 static IS_PANICING: AtomicBool = AtomicBool::new(false);
 
-impl<'a> USARTRegManager<'a> {
+impl USARTRegManager<'a> {
     fn real_new(usart: &USART) -> USARTRegManager {
         if pm::is_clock_enabled(usart.clock) == false {
             pm::enable_clock(usart.clock);
@@ -312,7 +312,7 @@ impl<'a> USARTRegManager<'a> {
     }
 }
 
-impl<'a> Drop for USARTRegManager<'a> {
+impl Drop for USARTRegManager<'a> {
     fn drop(&mut self) {
         // Anything listening for RX or TX interrupts?
         let ints_active = self.registers.imr.matches_any(

--- a/chips/sam4l/src/usbc/debug.rs
+++ b/chips/sam4l/src/usbc/debug.rs
@@ -2,7 +2,7 @@ use core::fmt;
 
 pub struct HexBuf<'a>(pub &'a [u8]);
 
-impl<'a> fmt::Debug for HexBuf<'a> {
+impl fmt::Debug for HexBuf<'a> {
     #[allow(unused_must_use)]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "[");

--- a/chips/sam4l/src/usbc/mod.rs
+++ b/chips/sam4l/src/usbc/mod.rs
@@ -415,7 +415,7 @@ register_bitfields![u32,
     ]
 ];
 
-impl<'a> Usbc<'a> {
+impl Usbc<'a> {
     const fn new() -> Self {
         Usbc {
             client: None,
@@ -1408,7 +1408,7 @@ fn endpoint_enable_interrupts(endpoint: usize, mask: FieldValue<u32, EndpointCon
     usbc_regs().ueconset[endpoint].write(mask);
 }
 
-impl<'a> UsbController for Usbc<'a> {
+impl UsbController for Usbc<'a> {
     fn endpoint_set_buffer<'b>(&'b self, endpoint: usize, buf: &[VolatileCell<u8>]) {
         if buf.len() != 8 {
             client_err!("Bad endpoint buffer size");

--- a/kernel/src/common/list.rs
+++ b/kernel/src/common/list.rs
@@ -4,7 +4,7 @@ use core::cell::Cell;
 
 pub struct ListLink<'a, T: 'a + ?Sized>(Cell<Option<&'a T>>);
 
-impl<'a, T: ?Sized> ListLink<'a, T> {
+impl<T: ?Sized> ListLink<'a, T> {
     pub const fn empty() -> ListLink<'a, T> {
         ListLink(Cell::new(None))
     }
@@ -22,7 +22,7 @@ pub struct ListIterator<'a, T: 'a + ?Sized + ListNode<'a, T>> {
     cur: Option<&'a T>,
 }
 
-impl<'a, T: ?Sized + ListNode<'a, T>> Iterator for ListIterator<'a, T> {
+impl<T: ?Sized + ListNode<'a, T>> Iterator for ListIterator<'a, T> {
     type Item = &'a T;
 
     fn next(&mut self) -> Option<&'a T> {
@@ -36,7 +36,7 @@ impl<'a, T: ?Sized + ListNode<'a, T>> Iterator for ListIterator<'a, T> {
     }
 }
 
-impl<'a, T: ?Sized + ListNode<'a, T>> List<'a, T> {
+impl<T: ?Sized + ListNode<'a, T>> List<'a, T> {
     pub const fn new() -> List<'a, T> {
         List {
             head: ListLink(Cell::new(None)),

--- a/kernel/src/common/peripherals.rs
+++ b/kernel/src/common/peripherals.rs
@@ -134,7 +134,7 @@ where
     clock: &'a C,
 }
 
-impl<'a, H, C> PeripheralManager<'a, H, C>
+impl<H, C> PeripheralManager<'a, H, C>
 where
     H: 'a + PeripheralManagement<C>,
     C: 'a + ClockInterface,
@@ -151,7 +151,7 @@ where
     }
 }
 
-impl<'a, H, C> Drop for PeripheralManager<'a, H, C>
+impl<H, C> Drop for PeripheralManager<'a, H, C>
 where
     H: 'a + PeripheralManagement<C>,
     C: 'a + ClockInterface,

--- a/kernel/src/common/ring_buffer.rs
+++ b/kernel/src/common/ring_buffer.rs
@@ -8,7 +8,7 @@ pub struct RingBuffer<'a, T: 'a> {
     tail: usize,
 }
 
-impl<'a, T: Copy> RingBuffer<'a, T> {
+impl<T: Copy> RingBuffer<'a, T> {
     pub fn new(ring: &'a mut [T]) -> RingBuffer<'a, T> {
         RingBuffer {
             head: 0,
@@ -18,7 +18,7 @@ impl<'a, T: Copy> RingBuffer<'a, T> {
     }
 }
 
-impl<'a, T: Copy> queue::Queue<T> for RingBuffer<'a, T> {
+impl<T: Copy> queue::Queue<T> for RingBuffer<'a, T> {
     fn has_elements(&self) -> bool {
         self.head != self.tail
     }

--- a/kernel/src/grant.rs
+++ b/kernel/src/grant.rs
@@ -113,7 +113,7 @@ impl<T: ?Sized> DerefMut for Owned<T> {
     }
 }
 
-impl<'a> Allocator<'a> {
+impl Allocator<'a> {
     pub fn alloc<T>(&mut self, data: T) -> Result<Owned<T>, Error> {
         unsafe {
             let app_id = self.app_id;
@@ -141,7 +141,7 @@ pub struct Borrowed<'a, T: 'a + ?Sized> {
     app_id: usize,
 }
 
-impl<'a, T: 'a + ?Sized> Borrowed<'a, T> {
+impl<T: 'a + ?Sized> Borrowed<'a, T> {
     pub fn new(data: &'a mut T, app_id: usize) -> Borrowed<T> {
         Borrowed {
             data: data,
@@ -154,14 +154,14 @@ impl<'a, T: 'a + ?Sized> Borrowed<'a, T> {
     }
 }
 
-impl<'a, T: 'a + ?Sized> Deref for Borrowed<'a, T> {
+impl<T: 'a + ?Sized> Deref for Borrowed<'a, T> {
     type Target = T;
     fn deref(&self) -> &T {
         self.data
     }
 }
 
-impl<'a, T: 'a + ?Sized> DerefMut for Borrowed<'a, T> {
+impl<T: 'a + ?Sized> DerefMut for Borrowed<'a, T> {
     fn deref_mut(&mut self) -> &mut T {
         self.data
     }
@@ -282,7 +282,7 @@ pub struct Iter<'a, T: 'a + Default> {
     len: usize,
 }
 
-impl<'a, T: Default> Iterator for Iter<'a, T> {
+impl<T: Default> Iterator for Iter<'a, T> {
     type Item = AppliedGrant<T>;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/kernel/src/hil/flash.rs
+++ b/kernel/src/hil/flash.rs
@@ -65,7 +65,7 @@
 //!     buffer: TakeCell<'static, F::Page>,
 //! }
 //!
-//! impl<'a, F: hil::flash::Flash > FlashUser<'a, F> {
+//! impl<F: hil::flash::Flash > FlashUser<'a, F> {
 //!     pub fn new(driver: &'a F, buffer: &'static mut F::Page) -> FlashUser<'a, F> {
 //!         FlashUser {
 //!             driver: driver,
@@ -74,7 +74,7 @@
 //!     }
 //! }
 //!
-//! impl<'a, F: hil::flash::Flash > hil::flash::Client<F> for FlashUser<'a, F> {
+//! impl<F: hil::flash::Flash > hil::flash::Client<F> for FlashUser<'a, F> {
 //!     fn read_complete(&self, buffer: &'static mut F::Page, error: hil::flash::Error) {}
 //!     fn write_complete(&self, buffer: &'static mut F::Page, error: hil::flash::Error) { }
 //!     fn erase_complete(&self, error: hil::flash::Error) {}

--- a/kernel/src/hil/flash.rs
+++ b/kernel/src/hil/flash.rs
@@ -65,7 +65,7 @@
 //!     buffer: TakeCell<'static, F::Page>,
 //! }
 //!
-//! impl<'a, F: hil::flash::Flash + 'a> FlashUser<'a, F> {
+//! impl<'a, F: hil::flash::Flash > FlashUser<'a, F> {
 //!     pub fn new(driver: &'a F, buffer: &'static mut F::Page) -> FlashUser<'a, F> {
 //!         FlashUser {
 //!             driver: driver,
@@ -74,7 +74,7 @@
 //!     }
 //! }
 //!
-//! impl<'a, F: hil::flash::Flash + 'a> hil::flash::Client<F> for FlashUser<'a, F> {
+//! impl<'a, F: hil::flash::Flash > hil::flash::Client<F> for FlashUser<'a, F> {
 //!     fn read_complete(&self, buffer: &'static mut F::Page, error: hil::flash::Error) {}
 //!     fn write_complete(&self, buffer: &'static mut F::Page, error: hil::flash::Error) { }
 //!     fn erase_complete(&self, error: hil::flash::Error) {}

--- a/kernel/src/hil/rng.rs
+++ b/kernel/src/hil/rng.rs
@@ -21,7 +21,7 @@
 //! once a second using the `Alarm` and `RNG` traits.
 //!
 //! ```
-//! struct RngTest<'a, A: Alarm + 'a> {
+//! struct RngTest<'a, A: Alarm > {
 //!     rng: &'a RNG,
 //!     alarm: &'a A
 //! }

--- a/kernel/src/hil/rng.rs
+++ b/kernel/src/hil/rng.rs
@@ -26,7 +26,7 @@
 //!     alarm: &'a A
 //! }
 //!
-//! impl<'a, A: Alarm> RngTest<'a, A> {
+//! impl<A: Alarm> RngTest<'a, A> {
 //!     pub fn initialize(&self) {
 //!         let interval = 1 * <A::Frequency>::frequency();
 //!         let tics = self.alarm.now().wrapping_add(interval);
@@ -34,13 +34,13 @@
 //!     }
 //! }
 //!
-//! impl<'a, A: Alarm> time::Client for RngTest<'a, A> {
+//! impl<A: Alarm> time::Client for RngTest<'a, A> {
 //!     fn fired(&self) {
 //!         self.rng.get();
 //!     }
 //! }
 //!
-//! impl<'a, A: Alarm> rng::Client for RngTest<'a, A> {
+//! impl<A: Alarm> rng::Client for RngTest<'a, A> {
 //!     fn randomness_available(&self, randomness: &mut Iterator<Item = u32>) -> rng::Continue {
 //!         match randomness.next() {
 //!             Some(random) => {

--- a/kernel/src/ipc.rs
+++ b/kernel/src/ipc.rs
@@ -188,7 +188,7 @@ impl Driver for IPC {
                     let procs = unsafe { &mut process::PROCS };
                     for (i, process) in procs.iter().enumerate() {
                         match process {
-                            &Some(ref p) => {
+                            Some(p) => {
                                 let s = p.package_name.as_bytes();
                                 // are slices equal?
                                 if s.len() == slice_data.len()
@@ -199,7 +199,7 @@ impl Driver for IPC {
                                     };
                                 }
                             }
-                            &None => {}
+                            None => {}
                         }
                     }
                 }

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -8,6 +8,7 @@
 
 #![feature(asm, core_intrinsics, unique, ptr_internals, const_fn)]
 #![feature(use_extern_macros, try_from, used)]
+#![feature(in_band_lifetimes)]
 #![no_std]
 
 extern crate tock_cells;

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -749,7 +749,7 @@ pub fn processes_blocked() -> bool {
     unsafe { HAVE_WORK.get() == 0 }
 }
 
-impl<'a> Process<'a> {
+impl Process<'a> {
     pub fn schedule_ipc(&mut self, from: AppId, cb_type: IPCType) {
         unsafe {
             HAVE_WORK.set(HAVE_WORK.get() + 1);


### PR DESCRIPTION
### Pull Request Overview

As a push towards "Rust 2018", Rust is advertising several new features that are actually quite nice for Tock. This site: https://rust-lang-nursery.github.io/edition-guide/2018/index.html explains them.

What we really benefit from is that before we had to do:

```rust
impl<'a, A: Alarm + 'a> MyStruct<'a, A>
```

Now rust will just figure all that out, and we only need:

```rust
impl<A: Alarm> MyStruct<'a, A>
```

And the simple case is clean now. Before:

```rust
impl<'a> MyOtherStruct<'a>
```

now:

```rust
impl MyOtherStruct<'a>
```

This is I think a lot closer to what someone new to rust would try to write.


### Testing Strategy

This pull request was tested by compiling.


### TODO or Help Wanted
n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
