### PR TITLE
adc: remove `initialize()` from HIL

### DIFF
--- a/capsules/src/adc.rs
+++ b/capsules/src/adc.rs
@@ -112,12 +112,6 @@ impl<'a, A: hil::adc::Adc + hil::adc::AdcHighSpeed + 'a> Adc<'a, A> {
         }
     }
 
-    /// Initialize the ADC
-    /// This can be called harmlessly if the ADC has already been initialized
-    fn initialize(&self) -> ReturnCode {
-        self.adc.initialize()
-    }
-
     /// Store a buffer we've regained ownership of and return a handle to it
     /// The handle can have `map` called on it in order to process the data in
     /// the buffer
@@ -164,12 +158,6 @@ impl<'a, A: hil::adc::Adc + hil::adc::AdcHighSpeed + 'a> Adc<'a, A> {
             return ReturnCode::EBUSY;
         }
 
-        // always initialize. Initialization will be skipped if already complete
-        let res = self.initialize();
-        if res != ReturnCode::SUCCESS {
-            return res;
-        }
-
         // convert channel index
         if channel >= self.channels.len() {
             return ReturnCode::EINVAL;
@@ -202,12 +190,6 @@ impl<'a, A: hil::adc::Adc + hil::adc::AdcHighSpeed + 'a> Adc<'a, A> {
         // only one sample at a time
         if self.active.get() {
             return ReturnCode::EBUSY;
-        }
-
-        // always initialize. Initialization will be skipped if already complete
-        let res = self.initialize();
-        if res != ReturnCode::SUCCESS {
-            return res;
         }
 
         // convert channel index
@@ -244,12 +226,6 @@ impl<'a, A: hil::adc::Adc + hil::adc::AdcHighSpeed + 'a> Adc<'a, A> {
         // only one sample at a time
         if self.active.get() {
             return ReturnCode::EBUSY;
-        }
-
-        // always initialize. Initialization will be skipped if already complete
-        let res = self.initialize();
-        if res != ReturnCode::SUCCESS {
-            return res;
         }
 
         // convert channel index
@@ -334,12 +310,6 @@ impl<'a, A: hil::adc::Adc + hil::adc::AdcHighSpeed + 'a> Adc<'a, A> {
         // only one sample at a time
         if self.active.get() {
             return ReturnCode::EBUSY;
-        }
-
-        // always initialize. Initialization will be skipped if already complete
-        let res = self.initialize();
-        if res != ReturnCode::SUCCESS {
-            return res;
         }
 
         // convert channel index

--- a/chips/sam4l/src/adc.rs
+++ b/chips/sam4l/src/adc.rs
@@ -596,13 +596,6 @@ impl Adc {
 impl hil::adc::Adc for Adc {
     type Channel = AdcChannel;
 
-    /// Enable and configure the ADC.
-    /// This can be called multiple times with no side effects.
-    fn initialize(&self) -> ReturnCode {
-        // always configure to 1KHz to get the slowest clock
-        self.config_and_enable(1000)
-    }
-
     /// Capture a single analog sample, calling the client when complete.
     /// Returns an error if the ADC is already sampling.
     ///

--- a/kernel/src/hil/adc.rs
+++ b/kernel/src/hil/adc.rs
@@ -9,9 +9,6 @@ pub trait Adc {
     /// The chip-dependent type of an ADC channel.
     type Channel;
 
-    /// Initialize must be called before taking a sample.
-    fn initialize(&self) -> ReturnCode;
-
     /// Request a single ADC sample on a particular channel.
     /// Used for individual samples that have no timing requirements.
     fn sample(&self, channel: &Self::Channel) -> ReturnCode;


### PR DESCRIPTION
See https://github.com/tock/tock/issues/1008 for more information.

### Pull Request Overview

This pull request removes the `initialize()` function from the ADC HIL. This seems to be a consensus in https://github.com/tock/tock/issues/1008.


### Testing Strategy

This pull request was tested by running hail on hail.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
