### PR TITLE
Ensure symbols reach the linker with `#[used]`

### DIFF
--- a/chips/cc26x2/src/crt1.rs
+++ b/chips/cc26x2/src/crt1.rs
@@ -23,8 +23,8 @@ unsafe extern "C" fn hard_fault_handler() {
 }
 
 #[link_section = ".vectors"]
-// no_mangle Ensures that the symbol is kept until the final binary
-#[no_mangle]
+// used Ensures that the symbol is kept until the final binary
+#[used]
 pub static BASE_VECTORS: [unsafe extern "C" fn(); 50] = [
     _estack,
     reset_handler,

--- a/chips/cc26x2/src/lib.rs
+++ b/chips/cc26x2/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(used)]
 #![no_std]
 #![crate_name = "cc26x2"]
 #![crate_type = "rlib"]

--- a/chips/cc26xx/src/ccfg.rs
+++ b/chips/cc26xx/src/ccfg.rs
@@ -4,7 +4,7 @@
 //!
 //! Currently setup to use the default settings.
 
-#[no_mangle]
+#[used]
 #[link_section = ".ccfg"]
 pub static CCFG_CONF: [u32; 22] = [
     0x01800000, 0xFF820010, 0x0058FFFD, 0xF3FFFF3A, //0xF3BFFF3A,

--- a/chips/cc26xx/src/lib.rs
+++ b/chips/cc26xx/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(const_fn)]
+#![feature(const_fn, used)]
 #![no_std]
 #![crate_name = "cc26xx"]
 #![crate_type = "rlib"]

--- a/chips/nrf51/src/crt1.rs
+++ b/chips/nrf51/src/crt1.rs
@@ -38,8 +38,8 @@ unsafe extern "C" fn hard_fault_handler() {
 }
 
 #[link_section = ".vectors"]
-// no_mangle Ensures that the symbol is kept until the final binary
-#[no_mangle]
+// used Ensures that the symbol is kept until the final binary
+#[used]
 pub static BASE_VECTORS: [unsafe extern "C" fn(); 16] = [
     _estack,
     reset_handler,
@@ -60,7 +60,7 @@ pub static BASE_VECTORS: [unsafe extern "C" fn(); 16] = [
 ];
 
 #[link_section = ".vectors"]
-#[no_mangle] // Ensures that the symbol is kept until the final binary
+#[used] // Ensures that the symbol is kept until the final binary
 pub static IRQS: [unsafe extern "C" fn(); 80] = [generic_isr; 80];
 
 #[no_mangle]

--- a/chips/nrf51/src/lib.rs
+++ b/chips/nrf51/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(asm, concat_idents, const_fn, const_cell_new, try_from)]
+#![feature(asm, concat_idents, const_fn, const_cell_new, try_from, used)]
 #![no_std]
 #![crate_name = "nrf51"]
 #![crate_type = "rlib"]

--- a/chips/nrf52/src/crt1.rs
+++ b/chips/nrf52/src/crt1.rs
@@ -229,7 +229,7 @@ unsafe extern "C" fn hard_fault_handler() {
 }
 
 #[link_section = ".vectors"]
-#[no_mangle] // ensures that the symbol is kept until the final binary
+#[used] // ensures that the symbol is kept until the final binary
 /// ARM Cortex M Vector Table
 pub static BASE_VECTORS: [unsafe extern "C" fn(); 16] = [
     // Stack Pointer
@@ -267,7 +267,7 @@ pub static BASE_VECTORS: [unsafe extern "C" fn(); 16] = [
 ];
 
 #[link_section = ".vectors"]
-#[no_mangle] // Ensures that the symbol is kept until the final binary
+#[used] // Ensures that the symbol is kept until the final binary
 pub static IRQS: [unsafe extern "C" fn(); 80] = [generic_isr; 80];
 
 #[no_mangle]

--- a/chips/nrf52/src/lib.rs
+++ b/chips/nrf52/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(asm, const_fn, core_intrinsics, try_from)]
+#![feature(asm, const_fn, core_intrinsics, try_from, used)]
 #![no_std]
 #![crate_name = "nrf52"]
 #![crate_type = "rlib"]

--- a/chips/sam4l/src/lib.rs
+++ b/chips/sam4l/src/lib.rs
@@ -4,7 +4,7 @@
 
 #![crate_name = "sam4l"]
 #![crate_type = "rlib"]
-#![feature(asm, concat_idents, const_fn, core_intrinsics, try_from)]
+#![feature(asm, concat_idents, const_fn, core_intrinsics, try_from, used)]
 #![no_std]
 
 extern crate cortexm4;
@@ -70,8 +70,8 @@ extern "C" {
 }
 
 #[link_section = ".vectors"]
-// no_mangle Ensures that the symbol is kept until the final binary
-#[no_mangle]
+// used Ensures that the symbol is kept until the final binary
+#[used]
 pub static BASE_VECTORS: [unsafe extern "C" fn(); 16] = [
     _estack,
     reset_handler,
@@ -92,7 +92,7 @@ pub static BASE_VECTORS: [unsafe extern "C" fn(); 16] = [
 ];
 
 #[link_section = ".vectors"]
-#[no_mangle] // Ensures that the symbol is kept until the final binary
+#[used] // Ensures that the symbol is kept until the final binary
 pub static IRQS: [unsafe extern "C" fn(); 80] = [generic_isr; 80];
 
 pub unsafe fn init() {

--- a/chips/tm4c129x/src/lib.rs
+++ b/chips/tm4c129x/src/lib.rs
@@ -1,6 +1,6 @@
 #![crate_name = "tm4c129x"]
 #![crate_type = "rlib"]
-#![feature(asm, const_fn, core_intrinsics)]
+#![feature(asm, const_fn, core_intrinsics, used)]
 #![no_std]
 
 extern crate cortexm4;
@@ -50,8 +50,8 @@ extern "C" {
 }
 
 #[link_section = ".vectors"]
-// no_mangle Ensures that the symbol is kept until the final binary
-#[no_mangle]
+// used Ensures that the symbol is kept until the final binary
+#[used]
 pub static BASE_VECTORS: [unsafe extern "C" fn(); 16] = [
     _estack,
     reset_handler,
@@ -72,7 +72,7 @@ pub static BASE_VECTORS: [unsafe extern "C" fn(); 16] = [
 ];
 
 #[link_section = ".vectors"]
-#[no_mangle] // Ensures that the symbol is kept until the final binary
+#[used] // Ensures that the symbol is kept until the final binary
 pub static IRQS: [unsafe extern "C" fn(); 111] = [generic_isr; 111];
 
 pub unsafe fn init() {

--- a/doc/Startup.md
+++ b/doc/Startup.md
@@ -47,7 +47,7 @@ marked to be placed into the `.vectors` section.
 In Rust, a vector table will look something like this:
 ```rust
 #[link_section=".vectors"]
-#[no_mangle] // Ensures that the symbol is kept until the final binary
+#[used] // Ensures that the symbol is kept until the final binary
 pub static BASE_VECTORS: [unsafe extern fn(); 16] = [
     _estack,                        // Initial stack pointer value
     tock_kernel_reset_handler,      // Tock's reset handler function

--- a/kernel/src/common/utils.rs
+++ b/kernel/src/common/utils.rs
@@ -55,7 +55,7 @@ macro_rules! static_init {
 macro_rules! storage_volume {
     ($N:ident, $kB:expr) => {
         #[link_section = ".storage"]
-        #[no_mangle]
+        #[used]
         pub static $N: [u8; $kB * 1024] = [0x00; $kB * 1024];
     };
 }

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -7,7 +7,7 @@
 //! Most `unsafe` code is in this kernel crate.
 
 #![feature(asm, core_intrinsics, unique, ptr_internals, const_fn)]
-#![feature(use_extern_macros, try_from)]
+#![feature(use_extern_macros, try_from, used)]
 #![no_std]
 
 extern crate tock_cells;

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -32,16 +32,19 @@ macro_rules! align4 {
 /// This is used in the hardfault handler.
 #[allow(private_no_mangle_statics)]
 #[no_mangle]
+#[used]
 static mut SYSCALL_FIRED: usize = 0;
 
 /// This is used in the hardfault handler.
 #[allow(private_no_mangle_statics)]
 #[no_mangle]
+#[used]
 static mut APP_FAULT: usize = 0;
 
 /// This is used in the hardfault handler.
 #[allow(private_no_mangle_statics)]
 #[no_mangle]
+#[used]
 static mut SCB_REGISTERS: [u32; 5] = [0; 5];
 
 #[allow(improper_ctypes)]


### PR DESCRIPTION
We had been using `#[no_mangle]` which is a workaround to ensure that the compiler doesn't drop important symbols. `#[used]` is designed explicitly for this purpose.

It is also on the path to be stabilized: https://github.com/rust-lang/rust/pull/51363



### Testing Strategy

This pull request was tested by compiling.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
