### PR TITLE
kernel: remove asm

### DIFF
--- a/boards/ek-tm4c1294xl/src/io.rs
+++ b/boards/ek-tm4c1294xl/src/io.rs
@@ -1,5 +1,6 @@
 use core::fmt::*;
 use core::str;
+use cortexm4;
 use kernel::debug;
 use kernel::hil::led;
 use kernel::hil::uart::{self, UART};
@@ -42,5 +43,5 @@ impl Write for Writer {
 pub unsafe extern "C" fn panic_fmt(args: Arguments, file: &'static str, line: u32) -> ! {
     let led = &mut led::LedLow::new(&mut tm4c129x::gpio::PF[0]);
     let writer = &mut WRITER;
-    debug::panic(led, writer, args, file, line)
+    debug::panic(led, writer, args, file, line, &cortexm4::support::nop)
 }

--- a/boards/ek-tm4c1294xl/src/main.rs
+++ b/boards/ek-tm4c1294xl/src/main.rs
@@ -3,10 +3,12 @@
 #![no_std]
 #![no_main]
 #![feature(asm, const_fn, lang_items)]
+
 extern crate capsules;
 #[allow(unused_imports)]
 #[macro_use(debug, static_init)]
 extern crate kernel;
+extern crate cortexm4;
 extern crate tm4c129x;
 
 use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};

--- a/boards/hail/src/io.rs
+++ b/boards/hail/src/io.rs
@@ -1,5 +1,6 @@
 use core::fmt::*;
 use core::str;
+use cortexm4;
 use kernel::debug;
 use kernel::hil::led;
 use kernel::hil::uart::{self, UART};
@@ -49,5 +50,5 @@ pub unsafe extern "C" fn panic_fmt(args: Arguments, file: &'static str, line: u3
 
     let led_red = &mut led::LedLow::new(&mut sam4l::gpio::PA[13]);
     let writer = &mut WRITER;
-    debug::panic(led_red, writer, args, file, line)
+    debug::panic(led_red, writer, args, file, line, &cortexm4::support::nop)
 }

--- a/boards/imix/src/io.rs
+++ b/boards/imix/src/io.rs
@@ -1,4 +1,5 @@
 use core::fmt::*;
+use cortexm4;
 use kernel::debug;
 use kernel::hil::led;
 use kernel::hil::uart::{self, UART};
@@ -40,5 +41,5 @@ impl Write for Writer {
 pub unsafe extern "C" fn panic_fmt(args: Arguments, file: &'static str, line: u32) -> ! {
     let led = &mut led::LedLow::new(&mut sam4l::gpio::PC[10]);
     let writer = &mut WRITER;
-    debug::panic(led, writer, args, file, line)
+    debug::panic(led, writer, args, file, line, &cortexm4::support::nop)
 }

--- a/boards/launchxl/src/io.rs
+++ b/boards/launchxl/src/io.rs
@@ -1,5 +1,6 @@
 use cc26xx;
 use core::fmt::{Arguments, Write};
+use cortexm4;
 use kernel::debug;
 use kernel::hil::led;
 use kernel::hil::uart::{self, UART};
@@ -39,5 +40,5 @@ pub unsafe extern "C" fn rust_begin_unwind(args: Arguments, file: &'static str, 
 
     let led = &mut led::LedLow::new(&mut cc26xx::gpio::PORT[LED_PIN]);
     let writer = &mut WRITER;
-    debug::panic(led, writer, args, file, line)
+    debug::panic(led, writer, args, file, line, &cortexm4::support::nop)
 }

--- a/boards/launchxl/src/main.rs
+++ b/boards/launchxl/src/main.rs
@@ -3,6 +3,7 @@
 #![feature(lang_items, asm)]
 
 extern crate capsules;
+extern crate cortexm4;
 
 extern crate cc26x2;
 extern crate cc26xx;

--- a/boards/nordic/nrf51dk/src/io.rs
+++ b/boards/nordic/nrf51dk/src/io.rs
@@ -1,4 +1,5 @@
 use core::fmt::{Arguments, Write};
+use cortexm0;
 use kernel::debug;
 use kernel::hil::led;
 use kernel::hil::uart::{self, UART};
@@ -42,5 +43,5 @@ pub unsafe extern "C" fn panic_fmt(args: Arguments, file: &'static str, line: u3
     const LED1_PIN: usize = 21;
     let led = &mut led::LedLow::new(&mut nrf5x::gpio::PORT[LED1_PIN]);
     let writer = &mut WRITER;
-    debug::panic(led, writer, args, file, line)
+    debug::panic(led, writer, args, file, line, &cortexm0::support::nop)
 }

--- a/boards/nordic/nrf51dk/src/main.rs
+++ b/boards/nordic/nrf51dk/src/main.rs
@@ -51,6 +51,7 @@ extern crate capsules;
 #[allow(unused_imports)]
 #[macro_use(debug, debug_verbose, debug_gpio, static_init)]
 extern crate kernel;
+extern crate cortexm0;
 extern crate nrf51;
 extern crate nrf5x;
 

--- a/boards/nordic/nrf52840dk/src/io.rs
+++ b/boards/nordic/nrf52840dk/src/io.rs
@@ -1,4 +1,5 @@
 use core::fmt::{Arguments, Write};
+use cortexm4;
 use kernel::debug;
 use kernel::hil::led;
 use kernel::hil::uart::{self, UART};
@@ -42,5 +43,5 @@ pub unsafe extern "C" fn panic_fmt(args: Arguments, file: &'static str, line: u3
     const LED1_PIN: usize = 13;
     let led = &mut led::LedLow::new(&mut nrf5x::gpio::PORT[LED1_PIN]);
     let writer = &mut WRITER;
-    debug::panic(led, writer, args, file, line)
+    debug::panic(led, writer, args, file, line, &cortexm4::support::nop)
 }

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -12,6 +12,7 @@ extern crate capsules;
 #[allow(unused_imports)]
 #[macro_use(debug, debug_verbose, debug_gpio, static_init)]
 extern crate kernel;
+extern crate cortexm4;
 extern crate nrf52;
 extern crate nrf52dk_base;
 extern crate nrf5x;

--- a/boards/nordic/nrf52dk/src/io.rs
+++ b/boards/nordic/nrf52dk/src/io.rs
@@ -1,4 +1,5 @@
 use core::fmt::{Arguments, Write};
+use cortexm4;
 use kernel::debug;
 use kernel::hil::led;
 use kernel::hil::uart::{self, UART};
@@ -42,5 +43,5 @@ pub unsafe extern "C" fn panic_fmt(args: Arguments, file: &'static str, line: u3
     const LED1_PIN: usize = 17;
     let led = &mut led::LedLow::new(&mut nrf5x::gpio::PORT[LED1_PIN]);
     let writer = &mut WRITER;
-    debug::panic(led, writer, args, file, line)
+    debug::panic(led, writer, args, file, line, &cortexm4::support::nop)
 }

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -69,6 +69,7 @@ extern crate capsules;
 #[allow(unused_imports)]
 #[macro_use(debug, debug_verbose, debug_gpio, static_init)]
 extern crate kernel;
+extern crate cortexm4;
 extern crate nrf52;
 extern crate nrf52dk_base;
 extern crate nrf5x;

--- a/doc/courses/sensys/exercises/board/src/io.rs
+++ b/doc/courses/sensys/exercises/board/src/io.rs
@@ -1,5 +1,6 @@
 use core::fmt::*;
 use core::str;
+use cortexm4;
 use kernel::debug;
 use kernel::hil::led;
 use kernel::hil::uart::{self, UART};
@@ -49,5 +50,5 @@ pub unsafe extern "C" fn panic_fmt(args: Arguments, file: &'static str, line: u3
 
     let led_red = &mut led::LedLow::new(&mut sam4l::gpio::PA[13]);
     let writer = &mut WRITER;
-    debug::panic(led_red, writer, args, file, line)
+    debug::panic(led_red, writer, args, file, line, &cortexm4::support::nop)
 }

--- a/doc/courses/sensys/exercises/board/src/main.rs
+++ b/doc/courses/sensys/exercises/board/src/main.rs
@@ -11,6 +11,7 @@ extern crate capsules;
 #[allow(unused_imports)]
 #[macro_use(debug, static_init)]
 extern crate kernel;
+extern crate cortexm4;
 extern crate sam4l;
 extern crate sensys;
 

--- a/kernel/Cargo.lock
+++ b/kernel/Cargo.lock
@@ -1,4 +1,11 @@
 [[package]]
 name = "kernel"
 version = "0.1.0"
+dependencies = [
+ "tock-regs 0.1.0",
+]
+
+[[package]]
+name = "tock-regs"
+version = "0.1.0"
 

--- a/kernel/src/debug.rs
+++ b/kernel/src/debug.rs
@@ -56,8 +56,9 @@ pub unsafe fn panic<L: hil::led::Led, W: Write>(
     args: Arguments,
     file: &'static str,
     line: u32,
+    nop: &Fn(),
 ) -> ! {
-    panic_begin();
+    panic_begin(nop);
     panic_banner(writer, args, file, line);
     // Flush debug buffer if needed
     flush(writer);
@@ -70,15 +71,11 @@ pub unsafe fn panic<L: hil::led::Led, W: Write>(
 /// This opaque method should always be called at the beginning of a board's
 /// panic method to allow hooks for any core kernel cleanups that may be
 /// appropriate.
-pub unsafe fn panic_begin() {
+pub unsafe fn panic_begin(nop: &Fn()) {
     // Let any outstanding uart DMA's finish
-    asm!("nop");
-    asm!("nop");
     for _ in 0..200000 {
-        asm!("nop");
+        nop();
     }
-    asm!("nop");
-    asm!("nop");
 }
 
 /// Lightweight prints about the current panic and kernel version.

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -6,7 +6,7 @@
 //!
 //! Most `unsafe` code is in this kernel crate.
 
-#![feature(asm, core_intrinsics, unique, nonzero, ptr_internals)]
+#![feature(core_intrinsics, unique, nonzero, ptr_internals)]
 #![feature(const_fn, const_cell_new, const_unsafe_cell_new, lang_items)]
 #![feature(nonnull_cast)]
 #![feature(use_extern_macros)]


### PR DESCRIPTION
asm!() is architecture specific, so we shouldn't have it in the kernel crate.

This is part of #985.




### Testing Strategy

This pull request was tested by compiling.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
