### PR TITLE
tools: fix build-all-docs script

### DIFF
--- a/tools/build-all-docs.sh
+++ b/tools/build-all-docs.sh
@@ -34,11 +34,13 @@ function add_board {
 		cp -r boards/$BOARD/target/thumb*-none-eabi*/doc/$item doc/rustdoc/
 
 		# Add the line to the search-index.js file.
-		SEARCHINDEX=`grep "searchIndex\[\"$item\"\]" boards/$BOARD/target/thumb*-none-eabi*/doc/search-index.js`
+		grep "searchIndex\[\"$item\"\]" boards/$BOARD/target/thumb*-none-eabi*/doc/search-index.js >> doc/rustdoc/search-index.js
 
-		# nothing in-place is x-platform bsd/gnu (os x defaults...)
-		/usr/bin/awk -v var="$SEARCHINDEX" "/initSearch/{print var}1" doc/rustdoc/search-index.js > doc/rustdoc/search-index-new.js
-		mv doc/rustdoc/search-index-new.js doc/rustdoc/search-index.js
+		# Then need to move `initSearch(searchIndex);` to the bottom.
+		# First remove it.
+		sed -i'' '/initSearch(searchIndex);/d' doc/rustdoc/search-index.js
+		# Then add it again.
+		echo "initSearch(searchIndex);" >> doc/rustdoc/search-index.js
 	done
 }
 

--- a/tools/build-all-docs.sh
+++ b/tools/build-all-docs.sh
@@ -37,10 +37,15 @@ function add_board {
 		grep "searchIndex\[\"$item\"\]" boards/$BOARD/target/thumb*-none-eabi*/doc/search-index.js >> doc/rustdoc/search-index.js
 
 		# Then need to move `initSearch(searchIndex);` to the bottom.
+		#
+		# Nothing in-place (i.e. `sed -i`) is safely cross-platform, so
+		# just use a temporary file.
+		#
 		# First remove it.
-		sed -i'' '/initSearch(searchIndex);/d' doc/rustdoc/search-index.js
+		grep -v 'initSearch(searchIndex);' doc/rustdoc/search-index.js > doc/rustdoc/search-index-temp.js
 		# Then add it again.
-		echo "initSearch(searchIndex);" >> doc/rustdoc/search-index.js
+		echo "initSearch(searchIndex);" >> doc/rustdoc/search-index-temp.js
+		mv doc/rustdoc/search-index-temp.js doc/rustdoc/search-index.js
 	done
 }
 


### PR DESCRIPTION
The old method was making a call to `awk` that was too long on linux. This method avoids that. No functionality changed.

Tested that search-index.js looks correct on mac and linux.

This should allow #1019 to pass travis.




### Testing Strategy

This pull request was tested by running the script on both mac and linux.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
