### PR TITLE
Typo in mutable_references.md

### DIFF
--- a/doc/Mutable_References.md
+++ b/doc/Mutable_References.md
@@ -276,7 +276,7 @@ txbuf.map_or_else(|| {
 });
 ```
 
-Not in both the `.map_or()` and `.map_or_else()` cases, the first argument
+Note, in both the `.map_or()` and `.map_or_else()` cases, the first argument
 corresponds to when the `TakeCell` is empty.
 
 


### PR DESCRIPTION
### Pull Request Overview
This pull request fixes a typo in ```mutable_references.md```
```Not in both the```  -> ```Note, in both the```



### Testing Strategy
N/A


### TODO or Help Wanted
N/A


### Documentation Updated

- ~[ ] Updated the relevant files in `/docs`, or no updates are required.~

### Formatting

- ~[ ] Ran `make formatall`.~
