### PR TITLE
kernel: allow multiple LEDs for panic blinks

### DIFF
--- a/boards/ek-tm4c1294xl/src/io.rs
+++ b/boards/ek-tm4c1294xl/src/io.rs
@@ -44,5 +44,5 @@ impl Write for Writer {
 pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
     let led = &mut led::LedLow::new(&mut tm4c129x::gpio::PF[0]);
     let writer = &mut WRITER;
-    debug::panic(led, writer, pi, &cortexm4::support::nop)
+    debug::panic(&mut [led], writer, pi, &cortexm4::support::nop)
 }

--- a/boards/hail/src/io.rs
+++ b/boards/hail/src/io.rs
@@ -51,5 +51,5 @@ pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
 
     let led_red = &mut led::LedLow::new(&mut sam4l::gpio::PA[13]);
     let writer = &mut WRITER;
-    debug::panic(led_red, writer, pi, &cortexm4::support::nop)
+    debug::panic(&mut [led_red], writer, pi, &cortexm4::support::nop)
 }

--- a/boards/imix/src/io.rs
+++ b/boards/imix/src/io.rs
@@ -42,5 +42,5 @@ impl Write for Writer {
 pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
     let led = &mut led::LedLow::new(&mut sam4l::gpio::PC[10]);
     let writer = &mut WRITER;
-    debug::panic(led, writer, pi, &cortexm4::support::nop)
+    debug::panic(&mut [led], writer, pi, &cortexm4::support::nop)
 }

--- a/boards/launchxl/src/io.rs
+++ b/boards/launchxl/src/io.rs
@@ -41,5 +41,5 @@ pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
 
     let led = &mut led::LedLow::new(&mut cc26xx::gpio::PORT[LED_PIN]);
     let writer = &mut WRITER;
-    debug::panic(led, writer, pi, &cortexm4::support::nop)
+    debug::panic(&mut [led], writer, pi, &cortexm4::support::nop)
 }

--- a/boards/nordic/nrf51dk/src/io.rs
+++ b/boards/nordic/nrf51dk/src/io.rs
@@ -44,5 +44,5 @@ pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
     const LED1_PIN: usize = 21;
     let led = &mut led::LedLow::new(&mut nrf5x::gpio::PORT[LED1_PIN]);
     let writer = &mut WRITER;
-    debug::panic(led, writer, pi, &cortexm0::support::nop)
+    debug::panic(&mut [led], writer, pi, &cortexm0::support::nop)
 }

--- a/boards/nordic/nrf52840dk/src/io.rs
+++ b/boards/nordic/nrf52840dk/src/io.rs
@@ -44,5 +44,5 @@ pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
     const LED1_PIN: usize = 13;
     let led = &mut led::LedLow::new(&mut nrf5x::gpio::PORT[LED1_PIN]);
     let writer = &mut WRITER;
-    debug::panic(led, writer, pi, &cortexm4::support::nop)
+    debug::panic(&mut [led], writer, pi, &cortexm4::support::nop)
 }

--- a/boards/nordic/nrf52dk/src/io.rs
+++ b/boards/nordic/nrf52dk/src/io.rs
@@ -44,5 +44,5 @@ pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
     const LED1_PIN: usize = 17;
     let led = &mut led::LedLow::new(&mut nrf5x::gpio::PORT[LED1_PIN]);
     let writer = &mut WRITER;
-    debug::panic(led, writer, pi, &cortexm4::support::nop)
+    debug::panic(&mut [led], writer, pi, &cortexm4::support::nop)
 }

--- a/doc/courses/sensys/exercises/board/src/io.rs
+++ b/doc/courses/sensys/exercises/board/src/io.rs
@@ -51,5 +51,5 @@ pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
 
     let led_red = &mut led::LedLow::new(&mut sam4l::gpio::PA[13]);
     let writer = &mut WRITER;
-    debug::panic(led_red, writer, pi, &cortexm4::support::nop)
+    debug::panic(&mut [led_red], writer, pi, &cortexm4::support::nop)
 }

--- a/kernel/src/debug.rs
+++ b/kernel/src/debug.rs
@@ -124,6 +124,12 @@ pub unsafe fn panic_process_info<W: Write>(writer: &mut W) {
 ///
 /// If a multi-color LED is used for the panic pattern, it is
 /// advised to turn off other LEDs before calling this method.
+///
+/// Generally, boards should blink red during panic if possible,
+/// otherwise choose the 'first' or most prominent LED. Some
+/// boards may find it appropriate to blink multiple LEDs (e.g.
+/// one on the top and one on the bottom), thus this method
+/// accepts an array, however most will only need one.
 pub fn panic_blink_forever<L: hil::led::Led>(leds: &mut [&mut L]) -> ! {
     leds.iter_mut().for_each(|led| led.init());
     loop {

--- a/kernel/src/debug.rs
+++ b/kernel/src/debug.rs
@@ -52,7 +52,7 @@ use returncode::ReturnCode;
 ///
 /// **NOTE:** The supplied `writer` must be synchronous.
 pub unsafe fn panic<L: hil::led::Led, W: Write>(
-    led: &mut L,
+    leds: &mut [&mut L],
     writer: &mut W,
     panic_info: &PanicInfo,
     nop: &Fn(),
@@ -62,7 +62,7 @@ pub unsafe fn panic<L: hil::led::Led, W: Write>(
     // Flush debug buffer if needed
     flush(writer);
     panic_process_info(writer);
-    panic_blink_forever(led)
+    panic_blink_forever(leds)
 }
 
 /// Generic panic entry.
@@ -124,20 +124,20 @@ pub unsafe fn panic_process_info<W: Write>(writer: &mut W) {
 ///
 /// If a multi-color LED is used for the panic pattern, it is
 /// advised to turn off other LEDs before calling this method.
-pub fn panic_blink_forever<L: hil::led::Led>(led: &mut L) -> ! {
-    led.init();
+pub fn panic_blink_forever<L: hil::led::Led>(leds: &mut [&mut L]) -> ! {
+    leds.iter_mut().for_each(|led| led.init());
     loop {
         for _ in 0..1000000 {
-            led.on();
+            leds.iter_mut().for_each(|led| led.on());
         }
         for _ in 0..100000 {
-            led.off();
+            leds.iter_mut().for_each(|led| led.off());
         }
         for _ in 0..1000000 {
-            led.on();
+            leds.iter_mut().for_each(|led| led.on());
         }
         for _ in 0..500000 {
-            led.off();
+            leds.iter_mut().for_each(|led| led.off());
         }
     }
 }


### PR DESCRIPTION
### Pull Request Overview

This is motivated by Signpost, where some boards would like to blink
both the panic LED on the board and another one on the backplane.
Generally, it's probably better to be flexible and let board authors
blink as many LEDs as they'd like.

### Testing Strategy

crash_dummy on hail

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
