### PR TITLE
tools: remove all uses of `sed`

### DIFF
--- a/doc/Getting_Started.md
+++ b/doc/Getting_Started.md
@@ -9,7 +9,7 @@ developing Tock.
 1. [Rust](http://www.rust-lang.org/)
 2. [rustup](https://rustup.rs/) to install Rust (version >= 1.11.0)
 3. [arm-none-eabi toolchain](https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads) (version >= 5.2)
-4. Command line utilities: wget, sed, make, cmake
+4. Command line utilities: wget, make, cmake
 
 ### Super Quick Setup
 

--- a/doc/courses/rustconf/README.md
+++ b/doc/courses/rustconf/README.md
@@ -27,7 +27,7 @@ time:
 1. A laptop running Linux or OS X. Linux in a VM will work just fine, see below
    for a pre-made image with all the dependencies.
 
-2. Command line utilities: wget, sed, make, cmake, git
+2. Command line utilities: wget, make, cmake, git
 
 4. Python 3 and pip
 

--- a/tools/build-all-docs.sh
+++ b/tools/build-all-docs.sh
@@ -5,9 +5,7 @@ set -e
 # Parse a search-index.js file to get the known crates.
 function get_known_crates {
 	FILE=$1
-
-	# This sed seems to be okay x-platform bsd/gnu
-	FOUND_CRATES=`sed -nE "s/.*searchIndex\[\"([a-z0-9_-]*)\"\].*/\1/gp" $FILE`
+	FOUND_CRATES=$(grep -o 'searchIndex\["[a-zA-Z0-9_-]*"\]' $FILE | cut -d'"' -f2)
 	echo $FOUND_CRATES
 }
 


### PR DESCRIPTION
### Pull Request Overview

We only had one place we were still using sed, and it's pretty
easily replaced by grep. This lets us drop another one of the listed
required tools (though who doesn't have sed?).

I'm more enthused to do this because sed tends to have more cross
platform issues than other tools, so adopting the habit of not using
it will likely minimize future issues.

### Testing Strategy

`make alldoc`

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
