### PR TITLE
capsules: add analog_sensors.rs

### DIFF
--- a/capsules/README.md
+++ b/capsules/README.md
@@ -28,6 +28,7 @@ The list of Tock capsules and a brief description.
 
 These implement a driver to setup and read various physical sensors.
 
+- **[Analog Sensors](src/analog_sensor.rs)**: Single ADC pin sensors.
 - **[FXOS8700CQ](src/fxos8700cq.rs)**: Accelerometer and magnetometer.
 - **[ISL29035](src/isl29035.rs)**: Light sensor.
 - **[LPS25HB](src/lps25hb.rs)**: Pressure sensor.

--- a/capsules/src/analog_sensor.rs
+++ b/capsules/src/analog_sensor.rs
@@ -1,0 +1,118 @@
+//! Capsule for analog sensors.
+//!
+//! This capsule provides the sensor HIL interfaces for sensors which only need
+//! an ADC.
+//!
+//! It includes support for analog light sensors and analog temperature sensors.
+
+use kernel::common::cells::OptionalCell;
+use kernel::hil;
+use kernel::ReturnCode;
+
+/// The type of the sensor implies how the raw ADC reading should be converted
+/// to a light value.
+pub enum AnalogLightSensorType {
+    LightDependentResistor,
+}
+
+pub struct AnalogLightSensor<'a, A: hil::adc::Adc> {
+    adc: &'a A,
+    channel: &'a <A as hil::adc::Adc>::Channel,
+    sensor_type: AnalogLightSensorType,
+    client: OptionalCell<&'a hil::sensors::AmbientLightClient>,
+}
+
+impl<A: hil::adc::Adc> AnalogLightSensor<'a, A> {
+    pub fn new(
+        adc: &'a A,
+        channel: &'a <A as hil::adc::Adc>::Channel,
+        sensor_type: AnalogLightSensorType,
+    ) -> AnalogLightSensor<'a, A> {
+        AnalogLightSensor {
+            adc: adc,
+            channel: channel,
+            sensor_type: sensor_type,
+            client: OptionalCell::empty(),
+        }
+    }
+}
+
+/// Callbacks from the ADC driver
+impl<A: hil::adc::Adc> hil::adc::Client for AnalogLightSensor<'a, A> {
+    fn sample_ready(&self, sample: u16) {
+        // TODO: calculate the actual light reading.
+        let measurement: usize = match self.sensor_type {
+            AnalogLightSensorType::LightDependentResistor => {
+                // TODO: need to determine the actual value that the 5000 should be
+                (sample as usize * 5000) / 65535
+            }
+        };
+        self.client.map(|client| client.callback(measurement));
+    }
+}
+
+impl<A: hil::adc::Adc> hil::sensors::AmbientLight for AnalogLightSensor<'a, A> {
+    fn set_client(&self, client: &'static hil::sensors::AmbientLightClient) {
+        self.client.set(client);
+    }
+
+    fn read_light_intensity(&self) -> ReturnCode {
+        self.adc.sample(self.channel)
+    }
+}
+
+/// The type of the sensor implies how the raw ADC reading should be converted
+/// to a temperature value.
+pub enum AnalogTemperatureSensorType {
+    MicrochipMcp9700,
+}
+
+pub struct AnalogTemperatureSensor<'a, A: hil::adc::Adc> {
+    adc: &'a A,
+    channel: &'a <A as hil::adc::Adc>::Channel,
+    sensor_type: AnalogTemperatureSensorType,
+    client: OptionalCell<&'a hil::sensors::TemperatureClient>,
+}
+
+impl<A: hil::adc::Adc> AnalogTemperatureSensor<'a, A> {
+    pub fn new(
+        adc: &'a A,
+        channel: &'a <A as hil::adc::Adc>::Channel,
+        sensor_type: AnalogLightSensorType,
+    ) -> AnalogLightSensor<'a, A> {
+        AnalogLightSensor {
+            adc: adc,
+            channel: channel,
+            sensor_type: sensor_type,
+            client: OptionalCell::empty(),
+        }
+    }
+}
+
+/// Callbacks from the ADC driver
+impl<A: hil::adc::Adc> hil::adc::Client for AnalogTemperatureSensor<'a, A> {
+    fn sample_ready(&self, sample: u16) {
+        // TODO: calculate the actual temperature reading.
+        let measurement: usize = match self.sensor_type {
+            // 𝑉out = 500𝑚𝑉 + 10𝑚𝑉/C ∗ 𝑇A
+            AnalogTemperatureSensorType::MicrochipMcp9700 => {
+                let ref_mv = self.adc.get_voltage_reference_mv().unwrap_or(3300);
+                // reading_mv = (ADC / (2^16-1)) * ref_voltage
+                let reading_mv = (sample as usize * ref_mv) / 65535;
+                // need 0.01°C
+                (reading_mv - 500) * 10
+            }
+        };
+        self.client.map(|client| client.callback(measurement));
+    }
+}
+
+impl<A: hil::adc::Adc> hil::sensors::TemperatureDriver for AnalogTemperatureSensor<'a, A> {
+    fn set_client(&self, client: &'static hil::sensors::TemperatureClient) {
+        self.client.set(client);
+    }
+
+    fn read_temperature(&self) -> ReturnCode {
+        self.adc.sample(self.channel)
+    }
+}

--- a/capsules/src/lib.rs
+++ b/capsules/src/lib.rs
@@ -18,6 +18,7 @@ pub mod aes_ccm;
 pub mod alarm;
 pub mod ambient_light;
 pub mod analog_comparator;
+pub mod analog_sensor;
 pub mod app_flash_driver;
 pub mod ble_advertising_driver;
 pub mod button;


### PR DESCRIPTION
This is a capsule that provides the sensor HILs for simple analog sensors that only require a single ADC pin.

Blocked on ADC HIL updates.

### Testing Strategy

Todo. My plan is test things on the ADC when everything isn't in a thousand separate branches.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make formatall`.
