### PR TITLE
kernel: make HAVE_WORK a member variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+Since 1.2
+=========
+
+  * [#1044](https://github.com/tock/tock/pull/1044) creates a `Kernel` struct
+    with a method for the kernel's main loop, instead of a global function in
+    the kernel's base module. Board configurations (i.e. each board's
+    `main.rs`), as a result needs to instantiate a statically allocate this new
+    struct.  Arguments to the main loop haven't changed:
+
+    ```rust
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new());
+
+    board_kernel.kernel_loop(&hail, &mut chip, &mut PROCESSES, Some(&hail.ipc));
+    ```
+

--- a/boards/ek-tm4c1294xl/src/main.rs
+++ b/boards/ek-tm4c1294xl/src/main.rs
@@ -199,6 +199,8 @@ pub unsafe fn reset_handler() {
 
     debug!("Initialization complete. Entering main loop...\r");
 
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new());
+
     extern "C" {
         /// Beginning of the ROM region containing app images.
         ///
@@ -206,10 +208,11 @@ pub unsafe fn reset_handler() {
         static _sapps: u8;
     }
     kernel::procs::load_processes(
+        board_kernel,
         &_sapps as *const u8,
         &mut APP_MEMORY,
         &mut PROCESSES,
         FAULT_RESPONSE,
     );
-    kernel::kernel_loop(&tm4c1294, &mut chip, &mut PROCESSES, Some(&tm4c1294.ipc));
+    board_kernel.kernel_loop(&tm4c1294, &mut chip, &mut PROCESSES, Some(&tm4c1294.ipc));
 }

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -488,6 +488,8 @@ pub unsafe fn reset_handler() {
 
     // debug!("Initialization complete. Entering main loop");
 
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new());
+
     extern "C" {
         /// Beginning of the ROM region containing app images.
         ///
@@ -496,10 +498,11 @@ pub unsafe fn reset_handler() {
     }
 
     kernel::procs::load_processes(
+        board_kernel,
         &_sapps as *const u8,
         &mut APP_MEMORY,
         &mut PROCESSES,
         FAULT_RESPONSE,
     );
-    kernel::kernel_loop(&hail, &mut chip, &mut PROCESSES, Some(&hail.ipc));
+    board_kernel.kernel_loop(&hail, &mut chip, &mut PROCESSES, Some(&hail.ipc));
 }

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -648,16 +648,20 @@ pub unsafe fn reset_handler() {
     rf233.start();
 
     debug!("Initialization complete. Entering main loop");
+
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new());
+
     extern "C" {
         /// Beginning of the ROM region containing app images.
         static _sapps: u8;
     }
     kernel::procs::load_processes(
+        board_kernel,
         &_sapps as *const u8,
         &mut APP_MEMORY,
         &mut PROCESSES,
         FAULT_RESPONSE,
     );
 
-    kernel::kernel_loop(&imix, &mut chip, &mut PROCESSES, Some(&imix.ipc));
+    board_kernel.kernel_loop(&imix, &mut chip, &mut PROCESSES, Some(&imix.ipc));
 }

--- a/boards/launchxl/src/main.rs
+++ b/boards/launchxl/src/main.rs
@@ -218,19 +218,22 @@ pub unsafe fn reset_handler() {
 
     let mut chip = cc26x2::chip::Cc26X2::new();
 
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new());
+
     extern "C" {
         /// Beginning of the ROM region containing app images.
         static _sapps: u8;
     }
 
     kernel::procs::load_processes(
+        board_kernel,
         &_sapps as *const u8,
         &mut APP_MEMORY,
         &mut PROCESSES,
         FAULT_RESPONSE,
     );
 
-    kernel::kernel_loop(
+    board_kernel.kernel_loop(
         &launchxl,
         &mut chip,
         &mut PROCESSES,

--- a/boards/nordic/nrf51dk/src/main.rs
+++ b/boards/nordic/nrf51dk/src/main.rs
@@ -340,18 +340,22 @@ pub unsafe fn reset_handler() {
     chip.systick().enable(true);
 
     debug!("Initialization complete. Entering main loop");
+
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new());
+
     extern "C" {
         /// Beginning of the ROM region containing app images.
         static _sapps: u8;
     }
     kernel::procs::load_processes(
+        board_kernel,
         &_sapps as *const u8,
         &mut APP_MEMORY,
         &mut PROCESSES,
         FAULT_RESPONSE,
     );
 
-    kernel::kernel_loop(
+    board_kernel.kernel_loop(
         &platform,
         &mut chip,
         &mut PROCESSES,

--- a/boards/nordic/nrf52dk_base/Cargo.lock
+++ b/boards/nordic/nrf52dk_base/Cargo.lock
@@ -8,6 +8,9 @@ dependencies = [
 [[package]]
 name = "cortexm"
 version = "0.1.0"
+dependencies = [
+ "kernel 0.1.0",
+]
 
 [[package]]
 name = "cortexm4"
@@ -20,6 +23,10 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.1.0"
+dependencies = [
+ "tock-cells 0.1.0",
+ "tock-regs 0.1.0",
+]
 
 [[package]]
 name = "nrf52"
@@ -47,4 +54,12 @@ version = "0.1.0"
 dependencies = [
  "kernel 0.1.0",
 ]
+
+[[package]]
+name = "tock-cells"
+version = "0.1.0"
+
+[[package]]
+name = "tock-regs"
+version = "0.1.0"
 

--- a/boards/nordic/nrf52dk_base/src/lib.rs
+++ b/boards/nordic/nrf52dk_base/src/lib.rs
@@ -223,16 +223,19 @@ pub unsafe fn setup_board(
     debug!("Initialization complete. Entering main loop\r");
     debug!("{}", &nrf52::ficr::FICR_INSTANCE);
 
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new());
+
     extern "C" {
         /// Beginning of the ROM region containing app images.
         static _sapps: u8;
     }
     kernel::procs::load_processes(
+        board_kernel,
         &_sapps as *const u8,
         app_memory,
         process_pointers,
         app_fault_response,
     );
 
-    kernel::kernel_loop(&platform, &mut chip, process_pointers, Some(&platform.ipc));
+    board_kernel.kernel_loop(&platform, &mut chip, process_pointers, Some(&platform.ipc));
 }

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -43,7 +43,7 @@ pub use platform::systick::SysTick;
 pub use platform::{mpu, Chip, Platform};
 pub use platform::{ClockInterface, NoClockControl, NO_CLOCK_CONTROL};
 pub use returncode::ReturnCode;
-pub use sched::kernel_loop;
+pub use sched::Kernel;
 
 // Export only select items from the process module. To remove the name conflict
 // this cannot be called `process`, so we use a shortened version. These

--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -5,6 +5,7 @@ use core::ptr::NonNull;
 
 use callback;
 use callback::{AppId, Callback};
+use common::cells::NumCell;
 use ipc;
 use mem::AppSlice;
 use memop;
@@ -21,170 +22,206 @@ const KERNEL_TICK_DURATION_US: u32 = 10000;
 /// Skip re-scheduling a process if its quanta is nearly exhausted
 const MIN_QUANTA_THRESHOLD_US: u32 = 500;
 
-/// Main loop.
-pub fn kernel_loop<P: Platform, C: Chip>(
-    platform: &P,
-    chip: &mut C,
-    processes: &'static mut [Option<&mut process::Process<'static>>],
-    ipc: Option<&ipc::IPC>,
-) {
-    let processes = unsafe {
-        process::PROCS = processes;
-        &mut process::PROCS
-    };
-
-    loop {
-        unsafe {
-            chip.service_pending_interrupts();
-
-            for (i, p) in processes.iter_mut().enumerate() {
-                p.as_mut().map(|process| {
-                    do_process(platform, chip, process, callback::AppId::new(i), ipc);
-                });
-                if chip.has_pending_interrupts() {
-                    break;
-                }
-            }
-
-            chip.atomic(|| {
-                if !chip.has_pending_interrupts() && process::processes_blocked() {
-                    chip.sleep();
-                }
-            });
-        };
-    }
+/// Main object for the kernel. Each board will need to create one.
+pub struct Kernel {
+    /// How many "to-do" items exist at any given time. These include
+    /// outstanding callbacks and processes in the Running state.
+    work: NumCell<usize>,
 }
 
-unsafe fn do_process<P: Platform, C: Chip>(
-    platform: &P,
-    chip: &mut C,
-    process: &mut Process,
-    appid: AppId,
-    ipc: Option<&::ipc::IPC>,
-) {
-    let systick = chip.systick();
-    systick.reset();
-    systick.set_timer(KERNEL_TICK_DURATION_US);
-    systick.enable(true);
-
-    loop {
-        if chip.has_pending_interrupts()
-            || systick.overflowed()
-            || !systick.greater_than(MIN_QUANTA_THRESHOLD_US)
-        {
-            break;
-        }
-
-        match process.current_state() {
-            process::State::Running => {
-                process.setup_mpu(chip.mpu());
-                chip.mpu().enable_mpu();
-                systick.enable(true);
-                process.switch_to();
-                systick.enable(false);
-                chip.mpu().disable_mpu();
-            }
-            process::State::Yielded => match process.dequeue_task() {
-                None => break,
-                Some(cb) => {
-                    match cb {
-                        Task::FunctionCall(ccb) => {
-                            process.push_function_call(ccb);
-                        }
-                        Task::IPC((otherapp, ipc_type)) => {
-                            ipc.map_or_else(
-                                || {
-                                    assert!(
-                                        false,
-                                        "Kernel consistency error: IPC Task with no IPC"
-                                    );
-                                },
-                                |ipc| {
-                                    ipc.schedule_callback(appid, otherapp, ipc_type);
-                                },
-                            );
-                        }
-                    }
-                    continue;
-                }
-            },
-            process::State::Fault => {
-                // we should never be scheduling a process in fault
-                panic!("Attempted to schedule a faulty process");
-            }
-        }
-
-        if !process.syscall_fired() {
-            break;
-        }
-
-        // check if the app had a fault
-        if process.app_fault() {
-            // let process deal with it as appropriate
-            process.fault_state();
-            continue;
-        }
-
-        // process had a system call, count it
-        process.incr_syscall_count();
-        match process.svc_number() {
-            Some(Syscall::MEMOP) => {
-                let res = memop::memop(process);
-                process.set_return_code(res);
-            }
-            Some(Syscall::YIELD) => {
-                process.yield_state();
-                process.pop_syscall_stack();
-
-                // There might be already enqueued callbacks
-                continue;
-            }
-            Some(Syscall::SUBSCRIBE) => {
-                let driver_num = process.r0();
-                let subdriver_num = process.r1();
-                let callback_ptr_raw = process.r2() as *mut ();
-                let appdata = process.r3();
-
-                let callback_ptr = NonNull::new(callback_ptr_raw);
-                let callback = callback_ptr.map(|ptr| Callback::new(appid, appdata, ptr.cast()));
-
-                let res = platform.with_driver(driver_num, |driver| match driver {
-                    Some(d) => d.subscribe(subdriver_num, callback, appid),
-                    None => ReturnCode::ENODEVICE,
-                });
-                process.set_return_code(res);
-            }
-            Some(Syscall::COMMAND) => {
-                let res = platform.with_driver(process.r0(), |driver| match driver {
-                    Some(d) => d.command(process.r1(), process.r2(), process.r3(), appid),
-                    None => ReturnCode::ENODEVICE,
-                });
-                process.set_return_code(res);
-            }
-            Some(Syscall::ALLOW) => {
-                let res = platform.with_driver(process.r0(), |driver| {
-                    match driver {
-                        Some(d) => {
-                            let start_addr = process.r2() as *mut u8;
-                            if start_addr != ptr::null_mut() {
-                                let size = process.r3();
-                                if process.in_exposed_bounds(start_addr, size) {
-                                    let slice = AppSlice::new(start_addr as *mut u8, size, appid);
-                                    d.allow(appid, process.r1(), Some(slice))
-                                } else {
-                                    ReturnCode::EINVAL /* memory not allocated to process */
-                                }
-                            } else {
-                                d.allow(appid, process.r1(), None)
-                            }
-                        }
-                        None => ReturnCode::ENODEVICE,
-                    }
-                });
-                process.set_return_code(res);
-            }
-            _ => {}
+impl Kernel {
+    pub fn new() -> Kernel {
+        Kernel {
+            work: NumCell::new(0),
         }
     }
-    systick.reset();
+
+    /// Something was scheduled for a process, so there is more work to do.
+    pub fn increment_work(&self) {
+        self.work.increment();
+    }
+
+    /// Something finished for a process, so we decrement how much work there is
+    /// to do.
+    pub fn decrement_work(&self) {
+        self.work.decrement();
+    }
+
+    /// Helper function for determining if we should service processes or go to
+    /// sleep.
+    fn processes_blocked(&self) -> bool {
+        self.work.get() == 0
+    }
+
+    /// Main loop.
+    pub fn kernel_loop<P: Platform, C: Chip>(
+        &self,
+        platform: &P,
+        chip: &mut C,
+        processes: &'static mut [Option<&mut process::Process<'static>>],
+        ipc: Option<&ipc::IPC>,
+    ) {
+        let processes = unsafe {
+            process::PROCS = processes;
+            &mut process::PROCS
+        };
+
+        loop {
+            unsafe {
+                chip.service_pending_interrupts();
+
+                for (i, p) in processes.iter_mut().enumerate() {
+                    p.as_mut().map(|process| {
+                        self.do_process(platform, chip, process, callback::AppId::new(i), ipc);
+                    });
+                    if chip.has_pending_interrupts() {
+                        break;
+                    }
+                }
+
+                chip.atomic(|| {
+                    if !chip.has_pending_interrupts() && self.processes_blocked() {
+                        chip.sleep();
+                    }
+                });
+            };
+        }
+    }
+
+    unsafe fn do_process<P: Platform, C: Chip>(
+        &self,
+        platform: &P,
+        chip: &mut C,
+        process: &mut Process,
+        appid: AppId,
+        ipc: Option<&::ipc::IPC>,
+    ) {
+        let systick = chip.systick();
+        systick.reset();
+        systick.set_timer(KERNEL_TICK_DURATION_US);
+        systick.enable(true);
+
+        loop {
+            if chip.has_pending_interrupts()
+                || systick.overflowed()
+                || !systick.greater_than(MIN_QUANTA_THRESHOLD_US)
+            {
+                break;
+            }
+
+            match process.current_state() {
+                process::State::Running => {
+                    process.setup_mpu(chip.mpu());
+                    chip.mpu().enable_mpu();
+                    systick.enable(true);
+                    process.switch_to();
+                    systick.enable(false);
+                    chip.mpu().disable_mpu();
+                }
+                process::State::Yielded => match process.dequeue_task() {
+                    None => break,
+                    Some(cb) => {
+                        match cb {
+                            Task::FunctionCall(ccb) => {
+                                process.push_function_call(ccb);
+                            }
+                            Task::IPC((otherapp, ipc_type)) => {
+                                ipc.map_or_else(
+                                    || {
+                                        assert!(
+                                            false,
+                                            "Kernel consistency error: IPC Task with no IPC"
+                                        );
+                                    },
+                                    |ipc| {
+                                        ipc.schedule_callback(appid, otherapp, ipc_type);
+                                    },
+                                );
+                            }
+                        }
+                        continue;
+                    }
+                },
+                process::State::Fault => {
+                    // we should never be scheduling a process in fault
+                    panic!("Attempted to schedule a faulty process");
+                }
+            }
+
+            if !process.syscall_fired() {
+                break;
+            }
+
+            // check if the app had a fault
+            if process.app_fault() {
+                // let process deal with it as appropriate
+                process.fault_state();
+                continue;
+            }
+
+            // process had a system call, count it
+            process.incr_syscall_count();
+            match process.svc_number() {
+                Some(Syscall::MEMOP) => {
+                    let res = memop::memop(process);
+                    process.set_return_code(res);
+                }
+                Some(Syscall::YIELD) => {
+                    process.yield_state();
+                    process.pop_syscall_stack();
+
+                    // There might be already enqueued callbacks
+                    continue;
+                }
+                Some(Syscall::SUBSCRIBE) => {
+                    let driver_num = process.r0();
+                    let subdriver_num = process.r1();
+                    let callback_ptr_raw = process.r2() as *mut ();
+                    let appdata = process.r3();
+
+                    let callback_ptr = NonNull::new(callback_ptr_raw);
+                    let callback =
+                        callback_ptr.map(|ptr| Callback::new(appid, appdata, ptr.cast()));
+
+                    let res = platform.with_driver(driver_num, |driver| match driver {
+                        Some(d) => d.subscribe(subdriver_num, callback, appid),
+                        None => ReturnCode::ENODEVICE,
+                    });
+                    process.set_return_code(res);
+                }
+                Some(Syscall::COMMAND) => {
+                    let res = platform.with_driver(process.r0(), |driver| match driver {
+                        Some(d) => d.command(process.r1(), process.r2(), process.r3(), appid),
+                        None => ReturnCode::ENODEVICE,
+                    });
+                    process.set_return_code(res);
+                }
+                Some(Syscall::ALLOW) => {
+                    let res = platform.with_driver(process.r0(), |driver| {
+                        match driver {
+                            Some(d) => {
+                                let start_addr = process.r2() as *mut u8;
+                                if start_addr != ptr::null_mut() {
+                                    let size = process.r3();
+                                    if process.in_exposed_bounds(start_addr, size) {
+                                        let slice =
+                                            AppSlice::new(start_addr as *mut u8, size, appid);
+                                        d.allow(appid, process.r1(), Some(slice))
+                                    } else {
+                                        ReturnCode::EINVAL /* memory not allocated to process */
+                                    }
+                                } else {
+                                    d.allow(appid, process.r1(), None)
+                                }
+                            }
+                            None => ReturnCode::ENODEVICE,
+                        }
+                    });
+                    process.set_return_code(res);
+                }
+                _ => {}
+            }
+        }
+        systick.reset();
+    }
 }


### PR DESCRIPTION
`HAVE_WORK` is currently a process.rs global static variable. This is probably not what we really want, as it requires `unsafe` to use. This creates a `Kernel` struct and stores the number of callbacks waiting as a member variable in that struct. In the process, I counted 5 uses of `unsafe` that are now gone.

Now, before HAVE_WORK was a `VolatileCell`. I'm not sure why that is needed, so I made it a `NumCell` instead (essentially just a `Cell`). If someone knows why it must be volatile then it can be changed back.

Also, this moves the schedule function to a be a class function of `Process`, where it probably should have been anyway.




### Testing Strategy

This pull request was tested by running hail on hail.


### TODO or Help Wanted

n/a


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
