### PR TITLE
Refactor debug.rs to not be implemented as a kernel process

### DIFF
--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -18,6 +18,7 @@ extern crate sam4l;
 use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use capsules::virtual_i2c::{I2CDevice, MuxI2C};
 use capsules::virtual_spi::{MuxSpiMaster, VirtualSpiMasterDevice};
+use capsules::virtual_uart::{UartDevice, UartMux};
 use kernel::hil;
 use kernel::hil::spi::SpiMaster;
 use kernel::hil::Controller;
@@ -60,7 +61,7 @@ pub static mut STACK_MEMORY: [u8; 0x1000] = [0; 0x1000];
 /// A structure representing this platform that holds references to all
 /// capsules for this platform.
 struct Hail {
-    console: &'static capsules::console::Console<'static, sam4l::usart::USART>,
+    console: &'static capsules::console::Console<'static, UartDevice<'static>>,
     gpio: &'static capsules::gpio::GPIO<'static, sam4l::gpio::GPIOPin>,
     alarm: &'static capsules::alarm::AlarmDriver<
         'static,
@@ -202,17 +203,28 @@ pub unsafe fn reset_handler() {
 
     // Initialize USART0 for Uart
     sam4l::usart::USART0.set_mode(sam4l::usart::UsartMode::Uart);
+
+    // Create a shared UART channel for the console and for kernel debug.
+    let uart_mux = static_init!(
+        UartMux<'static>,
+        UartMux::new(&sam4l::usart::USART0, &mut capsules::virtual_uart::RX_BUF)
+    );
+    hil::uart::UART::set_client(&sam4l::usart::USART0, uart_mux);
+
+    // Create a UartDevice for the console.
+    let console_uart = static_init!(UartDevice, UartDevice::new(uart_mux, true));
+    console_uart.setup();
     let console = static_init!(
-        capsules::console::Console<sam4l::usart::USART>,
+        capsules::console::Console<UartDevice>,
         capsules::console::Console::new(
-            &sam4l::usart::USART0,
+            console_uart,
             115200,
             &mut capsules::console::WRITE_BUF,
             &mut capsules::console::READ_BUF,
             kernel::Grant::create()
         )
     );
-    hil::uart::UART::set_client(&sam4l::usart::USART0, console);
+    hil::uart::UART::set_client(console_uart, console);
 
     // Initialize USART3 for Uart
     sam4l::usart::USART3.set_mode(sam4l::usart::UsartMode::Uart);
@@ -472,9 +484,25 @@ pub unsafe fn reset_handler() {
     };
 
     hail.console.initialize();
-    // Attach the kernel debug interface to this console
-    let kc = static_init!(capsules::console::App, capsules::console::App::default());
-    kernel::debug::assign_console_driver(Some(hail.console), kc);
+
+    // Create virtual device for kernel debug.
+    let debugger_uart = static_init!(UartDevice, UartDevice::new(uart_mux, false));
+    debugger_uart.setup();
+    let debugger = static_init!(
+        kernel::debug::DebugWriter,
+        kernel::debug::DebugWriter::new(
+            debugger_uart,
+            &mut kernel::debug::OUTPUT_BUF,
+            &mut kernel::debug::INTERNAL_BUF,
+        )
+    );
+    hil::uart::UART::set_client(debugger_uart, debugger);
+
+    let debug_wrapper = static_init!(
+        kernel::debug::DebugWriterWrapper,
+        kernel::debug::DebugWriterWrapper::new(debugger)
+    );
+    kernel::debug::set_debug_writer_wrapper(debug_wrapper);
 
     // Reset the nRF and setup the UART bus.
     hail.nrf51822.reset();
@@ -483,7 +511,7 @@ pub unsafe fn reset_handler() {
     // Uncomment to measure overheads for TakeCell and MapCell:
     // test_take_map_cell::test_take_map_cell();
 
-    // debug!("Initialization complete. Entering main loop");
+    debug!("Initialization complete. Entering main loop");
 
     let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new());
 

--- a/boards/launchxl/src/main.rs
+++ b/boards/launchxl/src/main.rs
@@ -12,8 +12,10 @@ extern crate cc26xx;
 #[macro_use(debug, debug_gpio, static_init)]
 extern crate kernel;
 
+use capsules::virtual_uart::{UartDevice, UartMux};
 use cc26x2::aon;
 use cc26x2::prcm;
+use kernel::hil;
 
 #[macro_use]
 pub mod io;
@@ -38,7 +40,7 @@ pub static mut STACK_MEMORY: [u8; 0x1000] = [0; 0x1000];
 pub struct Platform {
     gpio: &'static capsules::gpio::GPIO<'static, cc26xx::gpio::GPIOPin>,
     led: &'static capsules::led::LED<'static, cc26xx::gpio::GPIOPin>,
-    console: &'static capsules::console::Console<'static, cc26xx::uart::UART>,
+    console: &'static capsules::console::Console<'static, UartDevice<'static>>,
     button: &'static capsules::button::Button<'static, cc26xx::gpio::GPIOPin>,
     alarm: &'static capsules::alarm::AlarmDriver<
         'static,
@@ -125,23 +127,51 @@ pub unsafe fn reset_handler() {
     }
 
     // UART
+
+    // Create a shared UART channel for the console and for kernel debug.
+    let uart_mux = static_init!(
+        UartMux<'static>,
+        UartMux::new(&cc26xx::uart::UART0, &mut capsules::virtual_uart::RX_BUF)
+    );
+    hil::uart::UART::set_client(&cc26xx::uart::UART0, uart_mux);
+
+    // Create a UartDevice for the console.
+    let console_uart = static_init!(UartDevice, UartDevice::new(uart_mux, true));
+    console_uart.setup();
+
     cc26xx::uart::UART0.initialize_and_set_pins(3, 2);
+
     let console = static_init!(
-        capsules::console::Console<cc26xx::uart::UART>,
+        capsules::console::Console<UartDevice>,
         capsules::console::Console::new(
-            &cc26xx::uart::UART0,
+            console_uart,
             115200,
             &mut capsules::console::WRITE_BUF,
             &mut capsules::console::READ_BUF,
             kernel::Grant::create()
         )
     );
-    kernel::hil::uart::UART::set_client(&cc26xx::uart::UART0, console);
+    kernel::hil::uart::UART::set_client(console_uart, console);
     console.initialize();
 
-    // Attach the kernel debug interface to this console
-    let kc = static_init!(capsules::console::App, capsules::console::App::default());
-    kernel::debug::assign_console_driver(Some(console), kc);
+    // Create virtual device for kernel debug.
+    let debugger_uart = static_init!(UartDevice, UartDevice::new(uart_mux, false));
+    debugger_uart.setup();
+    let debugger = static_init!(
+        kernel::debug::DebugWriter,
+        kernel::debug::DebugWriter::new(
+            debugger_uart,
+            &mut kernel::debug::OUTPUT_BUF,
+            &mut kernel::debug::INTERNAL_BUF,
+        )
+    );
+    hil::uart::UART::set_client(debugger_uart, debugger);
+
+    let debug_wrapper = static_init!(
+        kernel::debug::DebugWriterWrapper,
+        kernel::debug::DebugWriterWrapper::new(debugger)
+    );
+    kernel::debug::set_debug_writer_wrapper(debug_wrapper);
 
     // Setup for remaining GPIO pins
     let gpio_pins = static_init!(

--- a/boards/nordic/nrf52dk_base/Cargo.lock
+++ b/boards/nordic/nrf52dk_base/Cargo.lock
@@ -25,7 +25,7 @@ name = "kernel"
 version = "0.1.0"
 dependencies = [
  "tock-cells 0.1.0",
- "tock-regs 0.1.0",
+ "tock-registers 0.1.0",
 ]
 
 [[package]]
@@ -60,6 +60,6 @@ name = "tock-cells"
 version = "0.1.0"
 
 [[package]]
-name = "tock-regs"
+name = "tock-registers"
 version = "0.1.0"
 

--- a/kernel/src/callback.rs
+++ b/kernel/src/callback.rs
@@ -9,25 +9,9 @@ pub struct AppId {
     idx: usize,
 }
 
-/// The kernel can masquerade as an app. IDs >= this value are the kernel.
-/// These IDs are used to identify which kernel container is being accessed.
-const KERNEL_APPID_BOUNDARY: usize = 100;
-
 impl AppId {
     crate fn new(idx: usize) -> AppId {
         AppId { idx: idx }
-    }
-
-    crate const fn kernel_new(idx: usize) -> AppId {
-        AppId { idx: idx }
-    }
-
-    pub const fn is_kernel(self) -> bool {
-        self.idx >= KERNEL_APPID_BOUNDARY
-    }
-
-    pub const fn is_kernel_idx(idx: usize) -> bool {
-        idx >= KERNEL_APPID_BOUNDARY
     }
 
     pub fn idx(&self) -> usize {
@@ -39,22 +23,12 @@ impl AppId {
     }
 }
 
-#[derive(Clone, Copy, Debug)]
-crate enum RustOrRawFnPtr {
-    Raw {
-        ptr: NonNull<*mut ()>,
-    },
-    Rust {
-        func: fn(usize, usize, usize, usize),
-    },
-}
-
 /// Wrapper around a function pointer.
 #[derive(Clone, Copy, Debug)]
 pub struct Callback {
     app_id: AppId,
     appdata: usize,
-    fn_ptr: RustOrRawFnPtr,
+    fn_ptr: NonNull<*mut ()>,
 }
 
 impl Callback {
@@ -62,45 +36,20 @@ impl Callback {
         Callback {
             app_id: appid,
             appdata: appdata,
-            fn_ptr: RustOrRawFnPtr::Raw { ptr: fn_ptr },
-        }
-    }
-
-    crate const fn kernel_new(appid: AppId, fn_ptr: fn(usize, usize, usize, usize)) -> Callback {
-        Callback {
-            app_id: appid,
-            appdata: 0,
-            fn_ptr: RustOrRawFnPtr::Rust { func: fn_ptr },
+            fn_ptr: fn_ptr,
         }
     }
 
     pub fn schedule(&mut self, r0: usize, r1: usize, r2: usize) -> bool {
-        if self.app_id.is_kernel() {
-            let fn_ptr = match self.fn_ptr {
-                RustOrRawFnPtr::Raw { ptr } => {
-                    panic!("Attempt to rust_call a raw function pointer: ptr {:?}", ptr)
-                }
-                RustOrRawFnPtr::Rust { func } => func,
-            };
-            fn_ptr(r0, r1, r2, self.appdata);
-            true
-        } else {
-            let fn_ptr = match self.fn_ptr {
-                RustOrRawFnPtr::Raw { ptr } => ptr,
-                RustOrRawFnPtr::Rust { func } => {
-                    panic!("Attempt to schedule rust function: func {:?}", func)
-                }
-            };
-            process::schedule(
-                process::FunctionCall {
-                    r0: r0,
-                    r1: r1,
-                    r2: r2,
-                    r3: self.appdata,
-                    pc: fn_ptr.as_ptr() as usize,
-                },
-                self.app_id,
-            )
-        }
+        process::schedule(
+            process::FunctionCall {
+                r0: r0,
+                r1: r1,
+                r2: r2,
+                r3: self.appdata,
+                pc: self.fn_ptr.as_ptr() as usize,
+            },
+            self.app_id,
+        )
     }
 }

--- a/kernel/src/grant.rs
+++ b/kernel/src/grant.rs
@@ -5,7 +5,6 @@ use core::marker::PhantomData;
 use core::mem::size_of;
 use core::ops::{Deref, DerefMut};
 use core::ptr::{read_volatile, write_volatile, Unique};
-use debug;
 use process::{self, Error};
 
 crate static mut CONTAINER_COUNTER: usize = 0;
@@ -21,39 +20,18 @@ pub struct AppliedGrant<T> {
     _phantom: PhantomData<T>,
 }
 
-/// This function contains the mapping of kernel "app" numbers to their
-/// functions for getting a pointer to their grant region. Normal apps are
-/// stored in a processes array, and finding apps is a matter of iterating that
-/// array. Kernel "apps" currently (June 2018) have no such structure, so
-/// finding them is a bit more ad-hoc.
-crate unsafe fn kernel_grant_for<T>(app_id: usize) -> *mut T {
-    match app_id {
-        debug::APPID_IDX => debug::get_grant(),
-        _ => panic!("lookup for invalid kernel grant {}", app_id),
-    }
-}
-
 impl<T> AppliedGrant<T> {
     pub fn enter<F, R>(self, fun: F) -> R
     where
         F: FnOnce(&mut Owned<T>, &mut Allocator) -> R,
         R: Copy,
     {
-        if AppId::is_kernel_idx(self.appid) {
-            let mut allocator = Allocator {
-                app: None,
-                app_id: self.appid,
-            };
-            let mut root = unsafe { Owned::new(self.grant, self.appid) };
-            fun(&mut root, &mut allocator)
-        } else {
-            let mut allocator = Allocator {
-                app: unsafe { process::PROCS[self.appid].as_mut() },
-                app_id: self.appid,
-            };
-            let mut root = unsafe { Owned::new(self.grant, self.appid) };
-            fun(&mut root, &mut allocator)
-        }
+        let mut allocator = Allocator {
+            app: unsafe { process::PROCS[self.appid].as_mut() },
+            app_id: self.appid,
+        };
+        let mut root = unsafe { Owned::new(self.grant, self.appid) };
+        fun(&mut root, &mut allocator)
     }
 }
 
@@ -85,15 +63,10 @@ impl<T: ?Sized> Drop for Owned<T> {
         unsafe {
             let app_id = self.app_id;
             let data = self.data.as_ptr() as *mut u8;
-            if AppId::is_kernel_idx(app_id) {
-                /* kernel free is nop */
-;
-            } else {
-                match process::PROCS[app_id] {
-                    None => {}
-                    Some(ref mut app) => {
-                        app.free(data);
-                    }
+            match process::PROCS[app_id] {
+                None => {}
+                Some(ref mut app) => {
+                    app.free(data);
                 }
             }
         }
@@ -126,9 +99,6 @@ impl Allocator<'a> {
                         Ok(owned)
                     }),
                 None => {
-                    if !AppId::is_kernel_idx(app_id) {
-                        panic!("No app for allocator for {}", app_id);
-                    }
                     panic!("Request to allocate in kernel grant");
                 }
             }
@@ -180,29 +150,20 @@ impl<T: Default> Grant<T> {
     pub fn grant(&self, appid: AppId) -> Option<AppliedGrant<T>> {
         unsafe {
             let app_id = appid.idx();
-            if AppId::is_kernel(appid) {
-                let cntr = kernel_grant_for::<T>(app_id);
-                Some(AppliedGrant {
-                    appid: app_id,
-                    grant: cntr,
-                    _phantom: PhantomData,
-                })
-            } else {
-                match process::PROCS[app_id] {
-                    Some(ref mut app) => {
-                        let cntr = app.grant_for::<T>(self.grant_num);
-                        if cntr.is_null() {
-                            None
-                        } else {
-                            Some(AppliedGrant {
-                                appid: app_id,
-                                grant: cntr,
-                                _phantom: PhantomData,
-                            })
-                        }
+            match process::PROCS[app_id] {
+                Some(ref mut app) => {
+                    let cntr = app.grant_for::<T>(self.grant_num);
+                    if cntr.is_null() {
+                        None
+                    } else {
+                        Some(AppliedGrant {
+                            appid: app_id,
+                            grant: cntr,
+                            _phantom: PhantomData,
+                        })
                     }
-                    None => None,
                 }
+                None => None,
             }
         }
     }
@@ -214,31 +175,20 @@ impl<T: Default> Grant<T> {
     {
         unsafe {
             let app_id = appid.idx();
-            if AppId::is_kernel(appid) {
-                let root_ptr = kernel_grant_for::<T>(app_id);
-                let mut root = Borrowed::new(&mut *root_ptr, app_id);
-                let mut allocator = Allocator {
-                    app: None,
-                    app_id: app_id,
-                };
-                let res = fun(&mut root, &mut allocator);
-                Ok(res)
-            } else {
-                match process::PROCS[app_id] {
-                    Some(ref mut app) => app.grant_for_or_alloc::<T>(self.grant_num).map_or(
-                        Err(Error::OutOfMemory),
-                        move |root_ptr| {
-                            let mut root = Borrowed::new(&mut *root_ptr, app_id);
-                            let mut allocator = Allocator {
-                                app: Some(app),
-                                app_id: app_id,
-                            };
-                            let res = fun(&mut root, &mut allocator);
-                            Ok(res)
-                        },
-                    ),
-                    None => Err(Error::NoSuchApp),
-                }
+            match process::PROCS[app_id] {
+                Some(ref mut app) => app.grant_for_or_alloc::<T>(self.grant_num).map_or(
+                    Err(Error::OutOfMemory),
+                    move |root_ptr| {
+                        let mut root = Borrowed::new(&mut *root_ptr, app_id);
+                        let mut allocator = Allocator {
+                            app: Some(app),
+                            app_id: app_id,
+                        };
+                        let res = fun(&mut root, &mut allocator);
+                        Ok(res)
+                    },
+                ),
+                None => Err(Error::NoSuchApp),
             }
         }
     }
@@ -255,12 +205,6 @@ impl<T: Default> Grant<T> {
                     let mut root = Owned::new(root_ptr, app_id);
                     fun(&mut root);
                 }
-            }
-            // After iterating all possible normal apps, try the debug app.
-            let root_ptr = kernel_grant_for::<T>(debug::APPID_IDX);
-            if !root_ptr.is_null() {
-                let mut root = Owned::new(root_ptr, debug::APPID_IDX);
-                fun(&mut root);
             }
         }
     }
@@ -290,15 +234,6 @@ impl<T: Default> Iterator for Iter<'a, T> {
             let idx = self.index;
             self.index += 1;
             let res = self.grant.grant(AppId::new(idx));
-            if res.is_some() {
-                return res;
-            }
-        }
-        // After running through all real apps, pass the debug app (idx 255) to
-        // the grant iterator in case it has state the capsule needs to process.
-        if self.index == self.len {
-            self.index += 1;
-            let res = self.grant.grant(AppId::new(debug::APPID_IDX));
             if res.is_some() {
                 return res;
             }


### PR DESCRIPTION
### Pull Request Overview

This pull request changes the debug module to use a normal `uart::UART` interface rather than acting as a process. This simplifies some kernel data structures as they no longer have to handle the case where an app can be a normal app or a kernel app. It also allows boards to easily use a different uart interface (like segger RTT) without having to implement the `Driver` interface as well.

~~This is blocked on #1045 but you can help test anyway!~~


### Testing Strategy

This pull request was tested by running hail app and doing debug!()s from a capsule.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
