### PR TITLE
kernel: must export symbols used by other crates

### DIFF
--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -45,6 +45,10 @@ pub use platform::{ClockInterface, NoClockControl, NO_CLOCK_CONTROL};
 pub use returncode::ReturnCode;
 pub use sched::kernel_loop;
 
+// These symbols must be exported for the arch crate to access them.
+pub use process::APP_FAULT;
+pub use process::SYSCALL_FIRED;
+
 // Export only select items from the process module. To remove the name conflict
 // this cannot be called `process`, so we use a shortened version. These
 // functions and types are used by board files to setup the platform and setup

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -17,16 +17,14 @@ use syscall::Syscall;
 use tbfheader;
 
 /// This is used in the hardfault handler.
-#[allow(private_no_mangle_statics)]
 #[no_mangle]
 #[used]
-static mut SYSCALL_FIRED: usize = 0;
+pub static mut SYSCALL_FIRED: usize = 0;
 
 /// This is used in the hardfault handler.
-#[allow(private_no_mangle_statics)]
 #[no_mangle]
 #[used]
-static mut APP_FAULT: usize = 0;
+pub static mut APP_FAULT: usize = 0;
 
 /// This is used in the hardfault handler.
 #[allow(private_no_mangle_statics)]


### PR DESCRIPTION
### Pull Request Overview

#955 was a bit too overzealous in the `pub`s it removed.

These are global symbols referenced by the arch crate (and the chips crate), so they must
be exported. Building with LTO hid this error, but if you disable LTO
then the linker will (correctly) complain about missing symbols as
these symbols aren't visible to the arch crate.

@JayKickliter this fixes so I can build without LTO enabled.

### Testing Strategy

Compile-tested only.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
