### PR TITLE
Travis: Include one debug build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,5 +25,6 @@ script:
   - export PATH=$HOME/.cargo/bin:$PATH
   - tools/run_cargo_fmt.sh diff
   - make allboards
+  - make -C boards/nordic/nrf52dk debug
   - tools/toc.sh
 

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -45,6 +45,10 @@ pub use platform::{ClockInterface, NoClockControl, NO_CLOCK_CONTROL};
 pub use returncode::ReturnCode;
 pub use sched::kernel_loop;
 
+// These symbols must be exported for the arch crate to access them.
+pub use process::APP_FAULT;
+pub use process::SYSCALL_FIRED;
+
 // Export only select items from the process module. To remove the name conflict
 // this cannot be called `process`, so we use a shortened version. These
 // functions and types are used by board files to setup the platform and setup

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -17,16 +17,14 @@ use syscall::Syscall;
 use tbfheader;
 
 /// This is used in the hardfault handler.
-#[allow(private_no_mangle_statics)]
 #[no_mangle]
 #[used]
-static mut SYSCALL_FIRED: usize = 0;
+pub static mut SYSCALL_FIRED: usize = 0;
 
 /// This is used in the hardfault handler.
-#[allow(private_no_mangle_statics)]
 #[no_mangle]
 #[used]
-static mut APP_FAULT: usize = 0;
+pub static mut APP_FAULT: usize = 0;
 
 /// This is used in the hardfault handler.
 #[allow(private_no_mangle_statics)]


### PR DESCRIPTION
### Pull Request Overview

This updates travis to build one board in the `debug` configuration. There's a tradeoff to building all of them (time) and at least one to catch errors like #1054.

Just building one is further motivated by the fact that hail and imix don't fit in ROM anymore (they're somewhere between 1-2k over) without LTO enabled.

This PR depends on #1054.
@brghena Your comment there was just a little too fast for me, I was working on it! :)

### Testing Strategy

Compiling.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
