### PR TITLE
Repair the 6LoWPAN IPv6 tx/rx kernel test

### DIFF
--- a/boards/imix/src/ipv6_lowpan_test.rs
+++ b/boards/imix/src/ipv6_lowpan_test.rs
@@ -444,7 +444,7 @@ impl<'a, A: time::Alarm> TxClient for LowpanTest<'a, A> {
             // a race condition on the receiver
             //it is sorta complicated bc I was having some trouble with dead code elimination
             let mut i = 0;
-            while i < 10000000 {
+            while i < 4000000 {
                 ARRAY[i % 100] = (i % 100) as u8;
                 i = i + 1;
                 if i % 1000000 == 0 {

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -563,8 +563,8 @@ pub unsafe fn reset_handler() {
     mac_device.set_device_procedure(radio_driver);
     radio_mac.set_transmit_client(radio_driver);
     radio_mac.set_receive_client(radio_driver);
-    radio_mac.set_pan(0xABCD);
-    radio_mac.set_address(0x1008);
+    radio_mac.set_pan(0x0000);
+    radio_mac.set_address(0xbbbb);
 
     // Configure the USB controller
     let usb_client = static_init!(

--- a/capsules/src/net/ipv6/ip_utils.rs
+++ b/capsules/src/net/ipv6/ip_utils.rs
@@ -81,8 +81,8 @@ pub fn compute_udp_checksum(
 ) -> u16 {
     //This checksum is calculated according to some of the recommendations found in RFC 1071.
 
-    let src_port = udp_header.src_port;
-    let dst_port = udp_header.dst_port;
+    let src_port = udp_header.get_src_port();
+    let dst_port = udp_header.get_dst_port();
     let mut sum: u32 = 0;
     {
         //First, iterate through src/dst address and add them to the sum
@@ -101,7 +101,7 @@ pub fn compute_udp_checksum(
             i += 2; //Iterate two bytes at a time bc 16 bit checksum
         }
     }
-    sum += udp_header.len as u32;
+    sum += udp_header.get_len() as u32;
     //Finally, add UDP next header
     sum += 17; //was "padded next header"
 
@@ -109,7 +109,7 @@ pub fn compute_udp_checksum(
     //Next, add the UDP header elements to the sum
     sum += src_port as u32;
     sum += dst_port as u32;
-    sum += udp_header.len as u32;
+    sum += udp_header.get_len() as u32;
     //Now just need to iterate thru data and add it to the sum
     {
         let mut i: usize = 0;
@@ -121,7 +121,6 @@ pub fn compute_udp_checksum(
 
             i += 2; //Iterate two bytes at a time bc 16 bit checksum
         }
-        //debug!("Checksum is currently: {:?}", sum);
     }
     //now all 16 bit addition has occurred
 
@@ -134,7 +133,7 @@ pub fn compute_udp_checksum(
     //Finally, flip all bits
     sum = !sum;
     sum = sum & 65535; //Remove upper 16 bits (which should be FFFF after flip)
-    (sum as u16) //Return result as u16 in host byte order
+    (sum as u16) //Return result as u16 in host byte order */
 }
 
 pub fn compute_icmp_checksum(

--- a/capsules/src/net/ipv6/ipv6.rs
+++ b/capsules/src/net/ipv6/ipv6.rs
@@ -396,7 +396,7 @@ impl IP6Packet<'a> {
     }
 
     pub fn set_transport_checksum(&mut self) {
-        //Looks at internal buffer assuming
+        // Looks at internal buffer assuming
         // it contains a valid IP packet, checks the payload type. If the payload
         // type requires a cksum calculation, this function calculates the
         // psuedoheader cksum and calls the appropriate transport packet function

--- a/capsules/src/net/sixlowpan/sixlowpan_compression.rs
+++ b/capsules/src/net/sixlowpan/sixlowpan_compression.rs
@@ -773,6 +773,7 @@ pub fn decompress(
             ip6_nh::UDP => {
                 // UDP length includes UDP header and data in bytes
                 let udp_length = dgram_size - written as u16; //UDP nh must be last per 6282
+
                 // Decompress UDP header fields
                 let (src_port, dst_port) = decompress_udp_ports(nhc_header, &buf, &mut consumed);
                 // Fill in uncompressed UDP header

--- a/capsules/src/net/sixlowpan/sixlowpan_compression.rs
+++ b/capsules/src/net/sixlowpan/sixlowpan_compression.rs
@@ -591,8 +591,9 @@ fn compress_multicast(
 }
 
 fn compress_udp_ports(udp_header: &UDPHeader, buf: &mut [u8], written: &mut usize) -> u8 {
-    let src_port = udp_header.get_src_port();
-    let dst_port = udp_header.get_dst_port();
+    // Need to deal with fields in network byte order when writing directly to buf
+    let src_port = udp_header.get_src_port().to_be();
+    let dst_port = udp_header.get_dst_port().to_be();
 
     let mut udp_port_nhc = 0;
     if (src_port & nhc::UDP_4BIT_PORT_MASK) == nhc::UDP_4BIT_PORT
@@ -630,7 +631,8 @@ fn compress_udp_ports(udp_header: &UDPHeader, buf: &mut [u8], written: &mut usiz
 // NOTE: We currently only support (or intend to support) carrying the UDP
 // checksum inline.
 fn compress_udp_checksum(udp_header: &UDPHeader, buf: &mut [u8], written: &mut usize) -> u8 {
-    let cksum = udp_header.get_cksum();
+    // get_cksum returns cksum in host byte order
+    let cksum = udp_header.get_cksum().to_be();
     buf[*written] = cksum as u8;
     buf[*written + 1] = (cksum >> 8) as u8;
     *written += 2;
@@ -777,9 +779,13 @@ pub fn decompress(
                 // Decompress UDP header fields
                 let (src_port, dst_port) = decompress_udp_ports(nhc_header, &buf, &mut consumed);
                 // Fill in uncompressed UDP header
+                // TODO: The current implementation works, but I don't understand the calls to
+                // to_be(), because src_port.to_be() returns the src_port in little endian..
+                // Accordingly, the udp_length must also be written in little endian for this
+                // to work.
                 u16_to_slice(src_port.to_be(), &mut next_headers[0..2]);
                 u16_to_slice(dst_port.to_be(), &mut next_headers[2..4]);
-                u16_to_slice(udp_length.to_be(), &mut next_headers[4..6]);
+                u16_to_slice(udp_length, &mut next_headers[4..6]);
                 // Need to fill in header values before computing the checksum
                 let udp_checksum = decompress_udp_checksum(
                     nhc_header,

--- a/capsules/src/net/sixlowpan/sixlowpan_compression.rs
+++ b/capsules/src/net/sixlowpan/sixlowpan_compression.rs
@@ -772,7 +772,7 @@ pub fn decompress(
             }
             ip6_nh::UDP => {
                 // UDP length includes UDP header and data in bytes
-                let udp_length = (8 + (buf.len() - consumed)) as u16;
+                let udp_length = dgram_size - written as u16; //UDP nh must be last per 6282
                 // Decompress UDP header fields
                 let (src_port, dst_port) = decompress_udp_ports(nhc_header, &buf, &mut consumed);
                 // Fill in uncompressed UDP header

--- a/capsules/src/net/udp/udp.rs
+++ b/capsules/src/net/udp/udp.rs
@@ -7,6 +7,8 @@ use net::stream::decode_u16;
 use net::stream::encode_u16;
 use net::stream::SResult;
 
+// Note: All UDP Header fields are stored in network byte order
+
 /// The `UDPHeader` struct follows the layout for the UDP packet header.
 /// Note that the implementation of this struct provides getters and setters
 /// for the various fields of the header, to avoid confusion with endian-ness.
@@ -39,34 +41,34 @@ impl UDPHeader {
     }
 
     pub fn set_dst_port(&mut self, port: u16) {
-        self.dst_port = port;
+        self.dst_port = port.to_be();
     }
     pub fn set_src_port(&mut self, port: u16) {
-        self.src_port = port;
+        self.src_port = port.to_be();
     }
 
     pub fn set_len(&mut self, len: u16) {
-        self.len = len;
+        self.len = len.to_be();
     }
 
     pub fn set_cksum(&mut self, cksum: u16) {
-        self.cksum = cksum;
+        self.cksum = cksum.to_be();
     }
 
     pub fn get_src_port(&self) -> u16 {
-        self.src_port
+        u16::from_be(self.src_port)
     }
 
     pub fn get_dst_port(&self) -> u16 {
-        self.dst_port
+        u16::from_be(self.dst_port)
     }
 
     pub fn get_len(&self) -> u16 {
-        self.len
+        u16::from_be(self.len)
     }
 
     pub fn get_cksum(&self) -> u16 {
-        self.cksum
+        u16::from_be(self.cksum)
     }
 
     pub fn get_hdr_size(&self) -> usize {


### PR DESCRIPTION
### Pull Request Overview

When I started to look into moving the 6LoWPAN stack over to the component interface, I realized that the ipv6_lowpan_test fails every time.
This pull request fixes the ipv6_lowpan_test kernel test so that following the instructions in the file leads to a successful execution of the test.
This PR includes fixes to addresses so that the receiving Imix will receive packets bound for its MAC address. This PR also includes a fix to the logic for inferring the UDP length field per RFC 6282. 

This PR also fixes the UDP checksum and some issues with byte ordering.


### Testing Strategy

Tested by configuring ipv6_lowpan_test on two imixes and running the test to completion, and by sniffing the packets sent by these tests and using wireshark to check the output and checksum are correct.

### Documentation Updated

- [x] Updated the relevant comments in ipv6_lowpan_test.rs so that following the instructions to the letter on two Imix boards leads to a successful execution of the 6LoWPAN test.
