### PR TITLE
Rng lifetimes

### DIFF
--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -19,6 +19,7 @@ use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use capsules::virtual_i2c::{I2CDevice, MuxI2C};
 use capsules::virtual_spi::{MuxSpiMaster, VirtualSpiMasterDevice};
 use kernel::hil;
+use kernel::hil::rng::RNG;
 use kernel::hil::spi::SpiMaster;
 use kernel::hil::Controller;
 use kernel::Platform;

--- a/boards/launchxl/src/main.rs
+++ b/boards/launchxl/src/main.rs
@@ -15,6 +15,8 @@ extern crate kernel;
 use cc26xx::aon;
 use cc26xx::prcm;
 
+use kernel::hil::rng::RNG;
+
 #[macro_use]
 pub mod io;
 
@@ -44,7 +46,7 @@ pub struct Platform {
         'static,
         capsules::virtual_alarm::VirtualMuxAlarm<'static, cc26xx::rtc::Rtc>,
     >,
-    rng: &'static capsules::rng::SimpleRng<'static, cc26xx::trng::Trng>,
+    rng: &'static capsules::rng::SimpleRng<'static, cc26xx::trng::Trng<'static>>,
 }
 
 impl kernel::Platform for Platform {

--- a/boards/nordic/nrf51dk/src/main.rs
+++ b/boards/nordic/nrf51dk/src/main.rs
@@ -57,6 +57,7 @@ extern crate nrf5x;
 
 use capsules::alarm::AlarmDriver;
 use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
+use kernel::hil::rng::RNG;
 use kernel::hil::uart::UART;
 use kernel::{Chip, SysTick};
 use nrf5x::pinmux::Pinmux;

--- a/boards/nordic/nrf52dk_base/src/lib.rs
+++ b/boards/nordic/nrf52dk_base/src/lib.rs
@@ -10,6 +10,7 @@ extern crate nrf52;
 extern crate nrf5x;
 
 use capsules::virtual_alarm::VirtualMuxAlarm;
+use kernel::hil::rng::RNG;
 use nrf5x::rtc::Rtc;
 
 /// Supported drivers by the platform

--- a/capsules/src/ieee802154/xmac.rs
+++ b/capsules/src/ieee802154/xmac.rs
@@ -145,7 +145,7 @@ pub struct XMacHeaderInfo {
 pub struct XMac<'a, R: radio::Radio, A: Alarm> {
     radio: &'a R,
     alarm: &'a A,
-    rng: &'a RNG,
+    rng: &'a RNG<'a>,
     tx_client: Cell<Option<&'static radio::TxClient>>,
     rx_client: Cell<Option<&'static radio::RxClient>>,
     state: Cell<XMacState>,
@@ -163,7 +163,7 @@ pub struct XMac<'a, R: radio::Radio, A: Alarm> {
 }
 
 impl<R: radio::Radio, A: Alarm> XMac<'a, R, A> {
-    pub fn new(radio: &'a R, alarm: &'a A, rng: &'a RNG) -> XMac<'a, R, A> {
+    pub fn new(radio: &'a R, alarm: &'a A, rng: &'a RNG<'a>) -> XMac<'a, R, A> {
         XMac {
             radio: radio,
             alarm: alarm,

--- a/capsules/src/rng.rs
+++ b/capsules/src/rng.rs
@@ -39,13 +39,13 @@ impl Default for App {
     }
 }
 
-pub struct SimpleRng<'a, RNG: rng::RNG> {
+pub struct SimpleRng<'a, RNG: rng::RNG<'a>> {
     rng: &'a RNG,
     apps: Grant<App>,
     getting_randomness: Cell<bool>,
 }
 
-impl<RNG: rng::RNG> SimpleRng<'a, RNG> {
+impl<RNG: rng::RNG<'a>> SimpleRng<'a, RNG> {
     pub fn new(rng: &'a RNG, grant: Grant<App>) -> SimpleRng<'a, RNG> {
         SimpleRng {
             rng: rng,
@@ -55,7 +55,7 @@ impl<RNG: rng::RNG> SimpleRng<'a, RNG> {
     }
 }
 
-impl<RNG: rng::RNG> rng::Client for SimpleRng<'a, RNG> {
+impl<RNG: rng::RNG<'a>> rng::Client for SimpleRng<'a, RNG> {
     fn randomness_available(&self, randomness: &mut Iterator<Item = u32>) -> rng::Continue {
         let mut done = true;
         for cntr in self.apps.iter() {
@@ -129,7 +129,7 @@ impl<RNG: rng::RNG> rng::Client for SimpleRng<'a, RNG> {
     }
 }
 
-impl<RNG: rng::RNG> Driver for SimpleRng<'a, RNG> {
+impl<RNG: rng::RNG<'a>> Driver for SimpleRng<'a, RNG> {
     fn allow(
         &self,
         appid: AppId,

--- a/chips/cc26xx/src/trng.rs
+++ b/chips/cc26xx/src/trng.rs
@@ -138,7 +138,6 @@ impl<'a> Trng<'a> {
 
         ((regs.out0.get() as u64) << 32) | (regs.out1.get() as u64)
     }
-
 }
 
 impl<'a> Iterator for Trng<'a> {
@@ -162,5 +161,4 @@ impl<'a> rng::RNG<'a> for Trng<'a> {
     fn set_client(&self, client: &'a rng::Client) {
         self.client.set(Some(client));
     }
-
 }

--- a/chips/cc26xx/src/trng.rs
+++ b/chips/cc26xx/src/trng.rs
@@ -67,15 +67,15 @@ register_bitfields![
 const RNG_BASE: StaticRef<RngRegisters> =
     unsafe { StaticRef::new(0x40028000 as *const RngRegisters) };
 
-pub static mut TRNG: Trng = Trng::new();
-
-pub struct Trng {
+pub struct Trng<'a> {
     registers: StaticRef<RngRegisters>,
-    client: Cell<Option<&'static rng::Client>>,
+    client: Cell<Option<&'a rng::Client>>,
 }
 
-impl Trng {
-    const fn new() -> Trng {
+pub static mut TRNG: Trng<'static> = Trng::new();
+
+impl<'a> Trng<'a> {
+    const fn new() -> Trng<'a> {
         Trng {
             registers: RNG_BASE,
             client: Cell::new(None),
@@ -139,12 +139,9 @@ impl Trng {
         ((regs.out0.get() as u64) << 32) | (regs.out1.get() as u64)
     }
 
-    pub fn set_client(&self, client: &'static rng::Client) {
-        self.client.set(Some(client));
-    }
 }
 
-impl Iterator for Trng {
+impl<'a> Iterator for Trng<'a> {
     type Item = u32;
 
     fn next(&mut self) -> Option<u32> {
@@ -157,8 +154,13 @@ impl Iterator for Trng {
     }
 }
 
-impl rng::RNG for Trng {
+impl<'a> rng::RNG<'a> for Trng<'a> {
     fn get(&self) {
         self.enable();
     }
+
+    fn set_client(&self, client: &'a rng::Client) {
+        self.client.set(Some(client));
+    }
+
 }

--- a/chips/nrf5x/src/trng.rs
+++ b/chips/nrf5x/src/trng.rs
@@ -163,11 +163,6 @@ impl Trng<'a> {
         }
     }
 
-    /// Configure client
-    pub fn set_client(&self, client: &'a rng::Client) {
-        self.client.set(Some(client));
-    }
-
     fn enable_interrupts(&self) {
         let regs = &*self.registers;
         regs.intenset.write(Intenset::VALRDY::SET);
@@ -210,8 +205,14 @@ impl Iterator for TrngIter<'a, 'b> {
     }
 }
 
-impl rng::RNG for Trng<'a> {
+impl rng::RNG<'a> for Trng<'a> {
     fn get(&self) {
         self.start_rng()
     }
+
+    /// Configure client
+    fn set_client(&self, client: &'a rng::Client) {
+        self.client.set(Some(client));
+    }
+
 }

--- a/chips/nrf5x/src/trng.rs
+++ b/chips/nrf5x/src/trng.rs
@@ -214,5 +214,4 @@ impl rng::RNG<'a> for Trng<'a> {
     fn set_client(&self, client: &'a rng::Client) {
         self.client.set(Some(client));
     }
-
 }

--- a/chips/sam4l/src/trng.rs
+++ b/chips/sam4l/src/trng.rs
@@ -109,5 +109,4 @@ impl rng::RNG<'a> for Trng<'a> {
     fn set_client(&self, client: &'a rng::Client) {
         self.client.set(Some(client));
     }
-
 }

--- a/chips/sam4l/src/trng.rs
+++ b/chips/sam4l/src/trng.rs
@@ -79,10 +79,6 @@ impl Trng<'a> {
             }
         });
     }
-
-    pub fn set_client(&self, client: &'a rng::Client) {
-        self.client.set(Some(client));
-    }
 }
 
 struct TrngIter<'a, 'b: 'a>(&'a Trng<'b>);
@@ -100,7 +96,7 @@ impl Iterator for TrngIter<'a, 'b> {
     }
 }
 
-impl rng::RNG for Trng<'a> {
+impl rng::RNG<'a> for Trng<'a> {
     fn get(&self) {
         let regs = &*self.regs;
         pm::enable_clock(pm::Clock::PBA(pm::PBAClock::TRNG));
@@ -109,4 +105,9 @@ impl rng::RNG for Trng<'a> {
             .write(Control::KEY.val(KEY) + Control::ENABLE::Enable);
         regs.ier.write(Interrupt::DATRDY::SET);
     }
+
+    fn set_client(&self, client: &'a rng::Client) {
+        self.client.set(Some(client));
+    }
+
 }

--- a/kernel/src/hil/rng.rs
+++ b/kernel/src/hil/rng.rs
@@ -70,12 +70,15 @@ pub enum Continue {
 ///
 /// Implementors should assume the client implements the
 /// [Client](trait.Client.html) trait.
-pub trait RNG {
+pub trait RNG<'a> {
     /// Initiate the aquisition of new random number generation.
     ///
     /// The implementor may ignore this command if the generation proccess is
     /// already in progress.
     fn get(&self);
+
+    /// Set the callback for when random bits are ready.
+    fn set_client(&self, &'a Client);
 }
 
 /// An [RNG](trait.RNG.html) client


### PR DESCRIPTION
### Pull Request Overview

This pull request updates the RNG HIL to make it in line with more modern HIL traits. In particular, it moves `set_client()` into the HIL, which enables more generic virtualization approaches, and in order to support this the trait also has a lifetime parameter.

It also updates the documentation for the RNG HIL, fixing a few typos and commenting on the expected vs. guaranteed entropy of each sample.


### Testing Strategy

This pull request was tested by compiling imix, hail, launchxl, ek-tm4c1294xl, nordic/nrf51dk, nordic/nrf52840dk, and nordic/nrf52dk.


### TODO or Help Wanted


### Documentation Updated

Documentation on the trait updated.

- [x] Updated the relevant files in `/docs`, or no updates are required.



### Formatting

- [x] Ran `make formatall`.
