### PR TITLE
doc: use consistent language for unused arguments

### DIFF
--- a/doc/syscalls/00000_alarm.md
+++ b/doc/syscalls/00000_alarm.md
@@ -29,7 +29,7 @@ The alarm's frequency is platform-specific, but must be _at least_ 1kHz.
 
     **Description**: Returns the clock frequency of the alarm.
 
-    **Argument 1**: Ignored.
+    **Argument 1**: unused
 
     **Argument 2**: unused
 
@@ -39,7 +39,7 @@ The alarm's frequency is platform-specific, but must be _at least_ 1kHz.
 
     **Description**: Read the current counter tic value.
 
-    **Argument 1**: Ignored.
+    **Argument 1**: unused
 
     **Argument 2**: unused
 

--- a/doc/syscalls/memop.md
+++ b/doc/syscalls/memop.md
@@ -41,7 +41,7 @@ memop(op_type: u32, argument: u32) -> [[ VARIES ]] as u32
     **Description**: Get the address of the start of the application's RAM
     allocation.
 
-    **Argument 1**: Ignored.
+    **Argument 1**: unused
 
     **Returns** `as *u8`: The address.
 
@@ -50,7 +50,7 @@ memop(op_type: u32, argument: u32) -> [[ VARIES ]] as u32
     **Description**: Get the address pointing to the first address after the
     end of the application's RAM allocation.
 
-    **Argument 1**: Ignored.
+    **Argument 1**: unused
 
     **Returns** `as *u8`: The address.
 
@@ -59,7 +59,7 @@ memop(op_type: u32, argument: u32) -> [[ VARIES ]] as u32
     **Description**: Get the address of the start of the application's flash
     region. This is where the TBF header is located.
 
-    **Argument 1**: Ignored.
+    **Argument 1**: unused
 
     **Returns** `as *u8`: The address.
 
@@ -68,7 +68,7 @@ memop(op_type: u32, argument: u32) -> [[ VARIES ]] as u32
     **Description**: Get the address pointing to the first address after the
     end of the application's flash region.
 
-    **Argument 1**: Ignored.
+    **Argument 1**: unused
 
     **Returns** `as *u8`: The address.
 
@@ -78,7 +78,7 @@ memop(op_type: u32, argument: u32) -> [[ VARIES ]] as u32
     for the app. (Note: the grant end is by definition the memory end, so there
     is no corresponding grant end syscall.)
 
-    **Argument 1**: Ignored.
+    **Argument 1**: unused
 
     **Returns** `as *u8`: The address.
 
@@ -87,7 +87,7 @@ memop(op_type: u32, argument: u32) -> [[ VARIES ]] as u32
     **Description**: Get the number of writeable flash regions defined in the
     header of this app.
 
-    **Argument 1**: Ignored.
+    **Argument 1**: unused
 
     **Returns** `as u32`: The number of regions.
 


### PR DESCRIPTION
### Pull Request Overview

We referred to these two different ways. We have more `unused`
than `Ignored.` so push them all that way.

### Testing Strategy

N/A

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
