### PR TITLE
Add bors integration for merging PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,21 @@ sudo: false
 language: rust
 
 
-# bors configuration
+# bors default configuration:
+#branches:
+#  only:
+#    # This is where pull requests from "bors r+" are built.
+#    - staging
+#    # This is where pull requests from "bors try" are built.
+#    - trying
+#    # Uncomment this to enable building pull requests.
+#    - master
+#
+# Instead, I think we just want to disable to bors temp branch
 branches:
-  only:
-    # This is where pull requests from "bors r+" are built.
-    - staging
-    # This is where pull requests from "bors try" are built.
-    - trying
-    # Uncomment this to enable building pull requests.
-    - master
+  except:
+    - staging.tmp
+    - trying.tmp
 
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,18 @@
 sudo: false
 language: rust
 
+
+# bors configuration
+branches:
+  only:
+    # This is where pull requests from "bors r+" are built.
+    - staging
+    # This is where pull requests from "bors try" are built.
+    - trying
+    # Uncomment this to enable building pull requests.
+    - master
+
+
 cache:
   cargo: true
   directories:

--- a/README.md
+++ b/README.md
@@ -58,3 +58,35 @@ post series highlights what's new in Tock. Also, follow
 You can also browse our
 [email group](https://groups.google.com/forum/#!forum/tock-dev) to see
 discussions on Tock development.
+
+
+License
+-------
+
+Licensed under either of
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or
+  http://www.apache.org/licenses/LICENSE-2.0)
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or
+  http://opensource.org/licenses/MIT)
+
+at your option.
+
+
+Contributions
+-------------
+
+We welcome contributions from all. The Tock code review process is documented
+[here](doc/CodeReview.md), but to get started, just go ahead and submit a PR,
+we'll happily guide you through any needed changes.
+
+We use the bors-ng bot to merge PRs. In short, when someone replies `bors r+`,
+your PR has been scheduled for final tests and will be automatically merged. If
+a maintainer replies `bors delegate+`, then you have been granted the authority
+to merge your own PR (usually this will happen if there are some trivial
+changes required). For a full list of bors commands,
+[see the bors documentation](https://bors.tech/documentation/).
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you, as defined in the Apache-2.0 license, shall
+be dual licensed as above, without any additional terms or conditions.

--- a/bors.toml
+++ b/bors.toml
@@ -1,0 +1,18 @@
+# List of commit statuses that must pass on the merge commit before it is
+# pushed to master.
+status = [
+  "continuous-integration/travis-ci/push",
+]
+
+# List of PR labels that may not be attached to a PR when it is r+-ed.
+block_labels = [
+  "blocked",
+]
+
+# Number of seconds from when a merge commit is created to when its statuses
+# must pass. (Default = 3600).
+#timeout_sec = 7200
+
+# If set to true, and if the PR branch is on the same repository that bors-ng
+# itself is on, the branch will be deleted.
+delete_merged_branches = true

--- a/doc/CodeReview.md
+++ b/doc/CodeReview.md
@@ -47,7 +47,6 @@ see implications that others may not.
 
 **Upkeep pull requests** can be merged by any member of the core team. That
 person is responsible for the merge and backing out the merge if needed.
-This is the basic process we use now.
 
 **Significant pull requests** require review by the entire core team. Each
 core team member is expected to respond within one week. There are three


### PR DESCRIPTION
Rust has spun out their automated build and merge tool bors, [as a service](https://bors.tech/). It looks pretty easy to integrate. I believe basically the contents of this PR plus flipping a switch on the bors website.

The big change that bors provides over our current system is that currently Travis builds when branches are pushed, which considers whether the code will build if merged with master at the time the PR is created. It does not test again at the time the PR is approved, which means if another PR is merged in the interim, merging a PR that passed checks could break the build. This is unlikely to happen often, but [has happened to use before](https://github.com/tock/tock/issues/835). (And, happens to be currently set up to happen again with the split OptionalCell PRs).

The greater motivation for me is that bors also brings a bit more clarity of intent to approvals. In particular, I tend to view a github 'approval' as 'this is clear to merge right now', but I don't think that's a universal sentiment (e.g. any `P-Upkeep` that was approved and not immediately merged, or many of the OptionalCell PRs that are currently approved but have not yet been tested on hardware). Using bors affords us the opportunity to disentangle approving a set of changes from an intent to merge. GitHub approvals can continue to work as they do without change, which is nice as it lets us keep our `P-Significant` workflow the same. However, now there is an option for an explicit 'intent to merge' in `bors r+`.

It looks like there is a healthy number of other projects ([google](https://www.google.com/search?q=github+bors.toml)) using bors, though interestingly a number of them seem to be the embedded rust folks (or google's just biasing my search results). I've looked into this a few times before, but it was too much manual effort to set up an get working before. It looks like bors-as-a-service has finally matured to a point where it's stable enough that I think we should consider adopting it.