### PR TITLE
Add a Nix-shell script

### DIFF
--- a/doc/Getting_Started.md
+++ b/doc/Getting_Started.md
@@ -13,6 +13,11 @@ developing Tock.
 
 ### Super Quick Setup
 
+Nix:
+```
+$ nix-shell
+```
+
 MacOS:
 ```
 $ curl https://sh.rustup.rs -sSf | sh

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,32 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+with builtins;
+let
+  inherit (pkgs) stdenv;
+  pythonPackages = stdenv.lib.fix' (self: with self; pkgs.python3Packages //
+  {
+
+    tockloader = buildPythonPackage rec {
+      pname = "tockloader";
+      version = "1.1.0";
+      name = "${pname}-${version}";
+
+      propagatedBuildInputs = [ argcomplete colorama crcmod pyserial pytoml ];
+
+      src = fetchPypi {
+        inherit pname version;
+        sha256 = "0j15hrz45ay396n94m5i5pca5lrym1qjnj06b2lq9r67ks136333";
+      };
+    };
+  });
+in
+  with pkgs;
+  stdenv.mkDerivation {
+    name = "moz_overlay_shell";
+    buildInputs = [
+      rustup
+      gcc-arm-embedded
+      python3Full
+      pythonPackages.tockloader
+      ];
+  }


### PR DESCRIPTION
### Pull Request Overview

For Nix package manager users (or NixOS users), the new `shell.nix`
script plops you into an environment with all the tools necessary for
general Tock development:

  * `rustup`
  * `gcc-arm-embedded` (I think this one can go away when we switch to
LLVM tools that ship with Rust)
  * `tockloader`, which is used for interacting with the dev boards

### Testing Strategy

I've been using it myself on my laptop. I actually don't promise this is bug-free, but the three other NixOS users out there might find the bugs eventually.

Also, OS X users can try using Nix package manager instead of (or in addition) to brew and will no longer have to compile everything from source.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
