### PR TITLE
uart: remove `initialize` from the UART HIL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+Since 1.2
+=========
+
+* UART HIL Refinements: This release saw several updates to the UART HIL,
+  summarized in the [UART HIL tracking issue](https://github.com/tock/tock/issues/1072).
+
+  - [#1073](https://github.com/tock/tock/pull/1073) removes `initialize` from
+    the UART HIL. Implementations will need to disentangle board-specific
+    initialization code, such as enabling the peripheral or assigning pins,
+    from UART configuration code, such as baud rate or parity. Initialization
+    is no longer part of the UART HIL and should be performed by the top-level
+    board before passing the UART object to any other code. UART configuration
+    is now controlled by the new `configure` HIL method:
+
+    ```rust
+    /// Configure UART
+    ///
+    /// Returns SUCCESS, or
+    ///
+    /// - EOFF: The underlying hardware is currently not available, perhaps
+    ///         because it has not been initialized or in the case of a shared
+    ///         hardware USART controller because it is set up for SPI.
+    /// - EINVAL: Impossible parameters (e.g. a `baud_rate` of 0)
+    /// - ENOSUPPORT: The underlying UART cannot satisfy this configuration.
+    fn configure(&self, params: UARTParameters) -> ReturnCode;
+    ```

--- a/boards/ek-tm4c1294xl/src/io.rs
+++ b/boards/ek-tm4c1294xl/src/io.rs
@@ -18,7 +18,7 @@ impl Write for Writer {
         let uart = unsafe { &mut tm4c129x::uart::UART0 };
         if !self.initialized {
             self.initialized = true;
-            uart.init(uart::UARTParams {
+            uart.configure(uart::UARTParameters {
                 baud_rate: 115200,
                 stop_bits: uart::StopBits::One,
                 parity: uart::Parity::None,

--- a/boards/hail/src/io.rs
+++ b/boards/hail/src/io.rs
@@ -19,7 +19,7 @@ impl Write for Writer {
         let regs_manager = &sam4l::usart::USARTRegManager::panic_new(&uart);
         if !self.initialized {
             self.initialized = true;
-            uart.init(uart::UARTParams {
+            uart.configure(uart::UARTParameters {
                 baud_rate: 115200,
                 stop_bits: uart::StopBits::One,
                 parity: uart::Parity::None,

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -200,6 +200,8 @@ pub unsafe fn reset_handler() {
 
     let mut chip = sam4l::chip::Sam4l::new();
 
+    // Initialize USART0 for Uart
+    sam4l::usart::USART0.set_mode(sam4l::usart::UsartMode::Uart);
     let console = static_init!(
         capsules::console::Console<sam4l::usart::USART>,
         capsules::console::Console::new(
@@ -212,6 +214,8 @@ pub unsafe fn reset_handler() {
     );
     hil::uart::UART::set_client(&sam4l::usart::USART0, console);
 
+    // Initialize USART3 for Uart
+    sam4l::usart::USART3.set_mode(sam4l::usart::UsartMode::Uart);
     // Create the Nrf51822Serialization driver for passing BLE commands
     // over UART to the nRF51822 radio.
     let nrf_serialization = static_init!(

--- a/boards/imix/src/io.rs
+++ b/boards/imix/src/io.rs
@@ -18,7 +18,7 @@ impl Write for Writer {
         let regs_manager = &sam4l::usart::USARTRegManager::panic_new(&uart);
         if !self.initialized {
             self.initialized = true;
-            uart.init(uart::UARTParams {
+            uart.configure(uart::UARTParameters {
                 baud_rate: 115200,
                 stop_bits: uart::StopBits::One,
                 parity: uart::Parity::None,

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -255,6 +255,8 @@ pub unsafe fn reset_handler() {
 
     // # CONSOLE
 
+    // Initialize USART3 for Uart
+    sam4l::usart::USART3.set_mode(sam4l::usart::UsartMode::Uart);
     let console = static_init!(
         capsules::console::Console<sam4l::usart::USART>,
         capsules::console::Console::new(
@@ -272,6 +274,8 @@ pub unsafe fn reset_handler() {
     let kc = static_init!(capsules::console::App, capsules::console::App::default());
     kernel::debug::assign_console_driver(Some(console), kc);
 
+    // Initialize USART2 for Uart
+    sam4l::usart::USART2.set_mode(sam4l::usart::UsartMode::Uart);
     // Create the Nrf51822Serialization driver for passing BLE commands
     // over UART to the nRF51822 radio.
     let nrf_serialization = static_init!(

--- a/boards/launchxl/src/io.rs
+++ b/boards/launchxl/src/io.rs
@@ -17,7 +17,7 @@ impl Write for Writer {
         let uart = unsafe { &mut cc26xx::uart::UART0 };
         if !self.initialized {
             self.initialized = true;
-            uart.init(uart::UARTParams {
+            uart.configure(uart::UARTParameters {
                 baud_rate: 115200,
                 stop_bits: uart::StopBits::One,
                 parity: uart::Parity::None,

--- a/boards/launchxl/src/main.rs
+++ b/boards/launchxl/src/main.rs
@@ -125,7 +125,7 @@ pub unsafe fn reset_handler() {
     }
 
     // UART
-    cc26xx::uart::UART0.set_pins(3, 2);
+    cc26xx::uart::UART0.initialize_and_set_pins(3, 2);
     let console = static_init!(
         capsules::console::Console<cc26xx::uart::UART>,
         capsules::console::Console::new(

--- a/boards/nordic/nrf51dk/src/io.rs
+++ b/boards/nordic/nrf51dk/src/io.rs
@@ -18,7 +18,7 @@ impl Write for Writer {
         let uart = unsafe { &mut nrf51::uart::UART0 };
         if !self.initialized {
             self.initialized = true;
-            uart.init(uart::UARTParams {
+            uart.configure(uart::UARTParameters {
                 baud_rate: 115200,
                 stop_bits: uart::StopBits::One,
                 parity: uart::Parity::None,

--- a/boards/nordic/nrf51dk/src/main.rs
+++ b/boards/nordic/nrf51dk/src/main.rs
@@ -229,7 +229,7 @@ pub unsafe fn reset_handler() {
         pin.set_client(gpio);
     }
 
-    nrf51::uart::UART0.configure(
+    nrf51::uart::UART0.initialize(
         Pinmux::new(9),  /*. tx  */
         Pinmux::new(11), /* rx  */
         Pinmux::new(10), /* cts */

--- a/boards/nordic/nrf52840dk/src/io.rs
+++ b/boards/nordic/nrf52840dk/src/io.rs
@@ -18,7 +18,7 @@ impl Write for Writer {
         let uart = unsafe { &mut nrf52::uart::UARTE0 };
         if !self.initialized {
             self.initialized = true;
-            uart.init(uart::UARTParams {
+            uart.configure(uart::UARTParameters {
                 baud_rate: 115200,
                 stop_bits: uart::StopBits::One,
                 parity: uart::Parity::None,

--- a/boards/nordic/nrf52dk/src/io.rs
+++ b/boards/nordic/nrf52dk/src/io.rs
@@ -18,7 +18,7 @@ impl Write for Writer {
         let uart = unsafe { &mut nrf52::uart::UARTE0 };
         if !self.initialized {
             self.initialized = true;
-            uart.init(uart::UARTParams {
+            uart.configure(uart::UARTParameters {
                 baud_rate: 115200,
                 stop_bits: uart::StopBits::One,
                 parity: uart::Parity::None,

--- a/boards/nordic/nrf52dk_base/src/lib.rs
+++ b/boards/nordic/nrf52dk_base/src/lib.rs
@@ -142,12 +142,12 @@ pub unsafe fn setup_board(
         capsules::virtual_alarm::VirtualMuxAlarm::new(mux_alarm)
     );
 
-    nrf52::uart::UARTE0.configure(
+    nrf52::uart::UARTE0.initialize(
         nrf5x::pinmux::Pinmux::new(6), // tx
         nrf5x::pinmux::Pinmux::new(8), // rx
         nrf5x::pinmux::Pinmux::new(7), // cts
-        nrf5x::pinmux::Pinmux::new(5),
-    ); // rts
+        nrf5x::pinmux::Pinmux::new(5), // rts
+    );
     let console = static_init!(
         capsules::console::Console<nrf52::uart::Uarte>,
         capsules::console::Console::new(

--- a/capsules/src/console.rs
+++ b/capsules/src/console.rs
@@ -104,7 +104,7 @@ impl<U: UART> Console<'a, U> {
     }
 
     pub fn initialize(&self) {
-        self.uart.init(uart::UARTParams {
+        self.uart.configure(uart::UARTParameters {
             baud_rate: self.baud_rate,
             stop_bits: uart::StopBits::One,
             parity: uart::Parity::None,

--- a/capsules/src/nrf51822_serialization.rs
+++ b/capsules/src/nrf51822_serialization.rs
@@ -73,7 +73,7 @@ impl<U: UARTReceiveAdvanced> Nrf51822Serialization<'a, U> {
     }
 
     pub fn initialize(&self) {
-        self.uart.init(uart::UARTParams {
+        self.uart.configure(uart::UARTParameters {
             baud_rate: 250000,
             stop_bits: uart::StopBits::One,
             parity: uart::Parity::Even,

--- a/capsules/src/segger_rtt.rs
+++ b/capsules/src/segger_rtt.rs
@@ -93,6 +93,7 @@
 use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::hil;
 use kernel::hil::time::Frequency;
+use kernel::ReturnCode;
 
 /// Buffer for transmitting to the host.
 pub static mut UP_BUFFER: [u8; 1024] = [0; 1024];
@@ -186,7 +187,9 @@ impl<A: hil::time::Alarm> hil::uart::UART for SeggerRtt<'a, A> {
         self.client.set(client);
     }
 
-    fn init(&self, _params: hil::uart::UARTParams) {}
+    fn configure(&self, _params: hil::uart::UARTParameters) -> ReturnCode {
+        ReturnCode::SUCCESS
+    }
 
     fn transmit(&self, tx_data: &'static mut [u8], tx_len: usize) {
         self.up_buffer.map(|buffer| {

--- a/chips/nrf51/src/uart.rs
+++ b/chips/nrf51/src/uart.rs
@@ -3,6 +3,7 @@ use kernel::common::cells::TakeCell;
 use kernel::common::cells::VolatileCell;
 use kernel::common::StaticRef;
 use kernel::hil::uart;
+use kernel::ReturnCode;
 use nrf5x::pinmux::Pinmux;
 
 pub static mut UART0: UART = UART::new();
@@ -82,13 +83,15 @@ impl UART {
     /// * pin  9: TX
     /// * pin 10: CTS
     /// * pin 11: RX
-    pub fn configure(&self, tx: Pinmux, rx: Pinmux, cts: Pinmux, rts: Pinmux) {
+    pub fn initialize(&self, tx: Pinmux, rx: Pinmux, cts: Pinmux, rts: Pinmux) {
         let regs = &*self.registers;
 
         regs.pseltxd.set(tx);
         regs.pselrxd.set(rx);
         regs.pselcts.set(cts);
         regs.pselrts.set(rts);
+
+        self.enable();
     }
 
     fn set_baud_rate(&self, baud_rate: u32) {
@@ -195,9 +198,22 @@ impl uart::UART for UART {
         self.client.set(Some(client));
     }
 
-    fn init(&self, params: uart::UARTParams) {
-        self.enable();
+    fn configure(&self, params: uart::UARTParameters) -> ReturnCode {
+        // These could probably be implemented, but are currently ignored, so
+        // throw an error.
+        if params.stop_bits != uart::StopBits::One {
+            return ReturnCode::ENOSUPPORT;
+        }
+        if params.parity != uart::Parity::None {
+            return ReturnCode::ENOSUPPORT;
+        }
+        if params.hw_flow_control != false {
+            return ReturnCode::ENOSUPPORT;
+        }
+
         self.set_baud_rate(params.baud_rate);
+
+        ReturnCode::SUCCESS
     }
 
     fn transmit(&self, tx_data: &'static mut [u8], tx_len: usize) {

--- a/chips/tm4c129x/src/uart.rs
+++ b/chips/tm4c129x/src/uart.rs
@@ -5,6 +5,7 @@ use kernel::common::cells::TakeCell;
 use kernel::common::cells::VolatileCell;
 use kernel::common::StaticRef;
 use kernel::hil;
+use kernel::ReturnCode;
 use sysctl;
 
 #[repr(C)]
@@ -169,9 +170,24 @@ impl hil::uart::UART for UART {
         self.client.set(Some(client));
     }
 
-    fn init(&self, params: hil::uart::UARTParams) {
+    fn configure(&self, params: hil::uart::UARTParameters) -> ReturnCode {
         self.enable();
-        self.set_baud_rate(params.baud_rate)
+
+        // These could probably be implemented, but are currently ignored, so
+        // throw an error.
+        if params.stop_bits != hil::uart::StopBits::One {
+            return ReturnCode::ENOSUPPORT;
+        }
+        if params.parity != hil::uart::Parity::None {
+            return ReturnCode::ENOSUPPORT;
+        }
+        if params.hw_flow_control != false {
+            return ReturnCode::ENOSUPPORT;
+        }
+
+        self.set_baud_rate(params.baud_rate);
+
+        ReturnCode::SUCCESS
     }
 
     fn transmit(&self, tx_data: &'static mut [u8], tx_len: usize) {

--- a/kernel/src/hil/uart.rs
+++ b/kernel/src/hil/uart.rs
@@ -1,12 +1,14 @@
 //! Interfaces for UART communications.
 
-#[derive(Copy, Clone, Debug)]
+use returncode::ReturnCode;
+
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub enum StopBits {
     One = 0,
     Two = 2,
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub enum Parity {
     None = 0,
     Odd = 1,
@@ -14,7 +16,7 @@ pub enum Parity {
 }
 
 #[derive(Copy, Clone, Debug)]
-pub struct UARTParams {
+pub struct UARTParameters {
     pub baud_rate: u32, // baud rate in bit/s
     pub stop_bits: StopBits,
     pub parity: Parity,
@@ -48,10 +50,16 @@ pub trait UART {
     /// called when events finish.
     fn set_client(&self, client: &'static Client);
 
-    /// Initialize UART
+    /// Configure UART
     ///
-    /// Panics if UARTParams are invalid for the current chip.
-    fn init(&self, params: UARTParams);
+    /// Returns SUCCESS, or
+    ///
+    /// - EOFF: The underlying hardware is currently not available, perhaps
+    ///         because it has not been initialized or in the case of a shared
+    ///         hardware USART controller because it is set up for SPI.
+    /// - EINVAL: Impossible parameters (e.g. a `baud_rate` of 0)
+    /// - ENOSUPPORT: The underlying UART cannot satisfy this configuration.
+    fn configure(&self, params: UARTParameters) -> ReturnCode;
 
     /// Transmit data.
     fn transmit(&self, tx_data: &'static mut [u8], tx_len: usize);


### PR DESCRIPTION
### Pull Request Overview

This implements RFC #1035 for the UART HIL. It splits the hardware-specific
initialization (power, clock assignment, pin assignment) from the uart-specific
configuration (baud rate, parity, stop bits, flow control), which is now
controlled by a new `configure` method for the UART HIL.

### Testing Strategy / Help Wanted

- [ ] Testing on hail/imix
- [ ] Testing on nrf family
- [ ] Testing on launchxl
- [ ] Testing on ek-tm4c1294xl

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
