### PR TITLE
fix dangling reference to NumCell

### DIFF
--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -1,11 +1,12 @@
 //! Tock core scheduler.
 
+use core::cell::Cell;
 use core::ptr;
 use core::ptr::NonNull;
 
 use callback;
 use callback::{AppId, Callback};
-use common::cells::NumCell;
+use common::cells::NumericCellExt;
 use ipc;
 use mem::AppSlice;
 use memop;
@@ -26,14 +27,12 @@ const MIN_QUANTA_THRESHOLD_US: u32 = 500;
 pub struct Kernel {
     /// How many "to-do" items exist at any given time. These include
     /// outstanding callbacks and processes in the Running state.
-    work: NumCell<usize>,
+    work: Cell<usize>,
 }
 
 impl Kernel {
     pub fn new() -> Kernel {
-        Kernel {
-            work: NumCell::new(0),
-        }
+        Kernel { work: Cell::new(0) }
     }
 
     /// Something was scheduled for a process, so there is more work to do.


### PR DESCRIPTION
### Pull Request Overview

#1044 and #1064 were ships passing in the night. This fixes `master` to build again.

For the record, I swear I did not plan this, but this is exactly the problem that #1068 would fix.

### Testing Strategy

Compiling.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
