### PR TITLE
Replace Default implementation with derived Default in RNG capsule

### DIFF
--- a/capsules/src/rng.rs
+++ b/capsules/src/rng.rs
@@ -21,22 +21,12 @@ use kernel::{AppId, AppSlice, Callback, Driver, Grant, ReturnCode, Shared};
 /// Syscall number
 pub const DRIVER_NUM: usize = 0x40001;
 
+#[derive(Default)]
 pub struct App {
     callback: Option<Callback>,
     buffer: Option<AppSlice<Shared, u8>>,
     remaining: usize,
     idx: usize,
-}
-
-impl Default for App {
-    fn default() -> App {
-        App {
-            callback: None,
-            buffer: None,
-            remaining: 0,
-            idx: 0,
-        }
-    }
 }
 
 pub struct SimpleRng<'a, RNG: rng::RNG> {


### PR DESCRIPTION
### Pull Request Overview

This pull request removes the needless default implementation for `App` in the rng capsule!

### Testing Strategy

This pull request was tested by compiles

### TODO or Help Wanted

N/A

### Documentation Updated

~~- [ ] Updated the relevant files in `/docs`, or no updates are required.~~

### Formatting

- [x] Ran `make formatall`.
