### PR TITLE
Make most of `kernel` crate-visible only, rather than public.

### DIFF
--- a/kernel/src/callback.rs
+++ b/kernel/src/callback.rs
@@ -14,11 +14,11 @@ pub struct AppId {
 const KERNEL_APPID_BOUNDARY: usize = 100;
 
 impl AppId {
-    pub(crate) fn new(idx: usize) -> AppId {
+    crate fn new(idx: usize) -> AppId {
         AppId { idx: idx }
     }
 
-    pub(crate) const fn kernel_new(idx: usize) -> AppId {
+    crate const fn kernel_new(idx: usize) -> AppId {
         AppId { idx: idx }
     }
 
@@ -40,7 +40,7 @@ impl AppId {
 }
 
 #[derive(Clone, Copy, Debug)]
-pub enum RustOrRawFnPtr {
+crate enum RustOrRawFnPtr {
     Raw {
         ptr: NonNull<*mut ()>,
     },
@@ -58,7 +58,7 @@ pub struct Callback {
 }
 
 impl Callback {
-    pub(crate) fn new(appid: AppId, appdata: usize, fn_ptr: NonNull<*mut ()>) -> Callback {
+    crate fn new(appid: AppId, appdata: usize, fn_ptr: NonNull<*mut ()>) -> Callback {
         Callback {
             app_id: appid,
             appdata: appdata,
@@ -66,10 +66,7 @@ impl Callback {
         }
     }
 
-    pub(crate) const fn kernel_new(
-        appid: AppId,
-        fn_ptr: fn(usize, usize, usize, usize),
-    ) -> Callback {
+    crate const fn kernel_new(appid: AppId, fn_ptr: fn(usize, usize, usize, usize)) -> Callback {
         Callback {
             app_id: appid,
             appdata: 0,

--- a/kernel/src/common/deferred_call.rs
+++ b/kernel/src/common/deferred_call.rs
@@ -23,21 +23,21 @@ struct AtomicUsize {
 }
 
 impl AtomicUsize {
-    pub const fn new(v: usize) -> AtomicUsize {
+    crate const fn new(v: usize) -> AtomicUsize {
         AtomicUsize {
             v: UnsafeCell::new(v),
         }
     }
 
-    pub fn load_relaxed(&self) -> usize {
+    crate fn load_relaxed(&self) -> usize {
         unsafe { intrinsics::atomic_load_relaxed(self.v.get()) }
     }
 
-    pub fn store_relaxed(&self, val: usize) {
+    crate fn store_relaxed(&self, val: usize) {
         unsafe { intrinsics::atomic_store_relaxed(self.v.get(), val) }
     }
 
-    pub fn fetch_or_relaxed(&self, val: usize) {
+    crate fn fetch_or_relaxed(&self, val: usize) {
         unsafe { intrinsics::atomic_store_relaxed(self.v.get(), self.load_relaxed() | val) }
     }
 }

--- a/kernel/src/grant.rs
+++ b/kernel/src/grant.rs
@@ -8,7 +8,7 @@ use core::ptr::{read_volatile, write_volatile, Unique};
 use debug;
 use process::{self, Error};
 
-pub static mut CONTAINER_COUNTER: usize = 0;
+crate static mut CONTAINER_COUNTER: usize = 0;
 
 pub struct Grant<T: Default> {
     grant_num: usize,
@@ -26,7 +26,7 @@ pub struct AppliedGrant<T> {
 /// stored in a processes array, and finding apps is a matter of iterating that
 /// array. Kernel "apps" currently (June 2018) have no such structure, so
 /// finding them is a bit more ad-hoc.
-pub unsafe fn kernel_grant_for<T>(app_id: usize) -> *mut T {
+crate unsafe fn kernel_grant_for<T>(app_id: usize) -> *mut T {
     match app_id {
         debug::APPID_IDX => debug::get_grant(),
         _ => panic!("lookup for invalid kernel grant {}", app_id),

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -8,7 +8,8 @@
 
 #![feature(asm, core_intrinsics, unique, ptr_internals, const_fn)]
 #![feature(use_extern_macros, try_from, used)]
-#![feature(in_band_lifetimes)]
+#![feature(in_band_lifetimes, crate_visibility_modifier)]
+#![warn(unreachable_pub)]
 #![no_std]
 
 extern crate tock_cells;

--- a/kernel/src/mem.rs
+++ b/kernel/src/mem.rs
@@ -62,7 +62,7 @@ pub struct AppSlice<L, T> {
 }
 
 impl<L, T> AppSlice<L, T> {
-    pub(crate) fn new(ptr: *mut T, len: usize, appid: AppId) -> AppSlice<L, T> {
+    crate fn new(ptr: *mut T, len: usize, appid: AppId) -> AppSlice<L, T> {
         unsafe {
             AppSlice {
                 ptr: AppPtr::new(ptr, appid),
@@ -79,7 +79,7 @@ impl<L, T> AppSlice<L, T> {
         unsafe { self.ptr.ptr.as_ref() as *const T }
     }
 
-    pub unsafe fn expose_to(&self, appid: AppId) -> bool {
+    crate unsafe fn expose_to(&self, appid: AppId) -> bool {
         let ps = &mut process::PROCS;
         if appid.idx() != self.ptr.process.idx() && ps.len() > appid.idx() {
             ps[appid.idx()]

--- a/kernel/src/memop.rs
+++ b/kernel/src/memop.rs
@@ -36,7 +36,7 @@ use returncode::ReturnCode;
 ///   where the app has put the start of its heap. This is not strictly
 ///   necessary for correct operation, but allows for better debugging if the
 ///   app crashes.
-pub fn memop(process: &mut Process) -> ReturnCode {
+crate fn memop(process: &mut Process) -> ReturnCode {
     let op_type = process.r0();
     let r1 = process.r1();
 

--- a/kernel/src/platform/mod.rs
+++ b/kernel/src/platform/mod.rs
@@ -3,7 +3,7 @@
 use driver::Driver;
 
 pub mod mpu;
-pub mod systick;
+crate mod systick;
 
 /// Interface for individual boards.
 pub trait Platform {

--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -36,13 +36,13 @@ impl Kernel {
     }
 
     /// Something was scheduled for a process, so there is more work to do.
-    pub fn increment_work(&self) {
+    crate fn increment_work(&self) {
         self.work.increment();
     }
 
     /// Something finished for a process, so we decrement how much work there is
     /// to do.
-    pub fn decrement_work(&self) {
+    crate fn decrement_work(&self) {
         self.work.decrement();
     }
 

--- a/kernel/src/syscall.rs
+++ b/kernel/src/syscall.rs
@@ -2,7 +2,7 @@
 
 /// The syscall number assignments.
 #[derive(Copy, Clone, Debug)]
-pub enum Syscall {
+crate enum Syscall {
     /// Return to the kernel to allow other processes to execute or to wait for
     /// interrupts and callbacks.
     YIELD = 0,

--- a/kernel/src/tbfheader.rs
+++ b/kernel/src/tbfheader.rs
@@ -22,7 +22,7 @@ macro_rules! align4 {
 /// to support any apps that were compiled with an older version of elf2tbf.
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
-pub(crate) struct TbfHeaderV1 {
+crate struct TbfHeaderV1 {
     version: u32,
     total_size: u32,
     entry_offset: u32,
@@ -47,7 +47,7 @@ pub(crate) struct TbfHeaderV1 {
 /// TBF fields that must be present in all v2 headers.
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
-pub(crate) struct TbfHeaderV2Base {
+crate struct TbfHeaderV2Base {
     version: u16,
     header_size: u16,
     total_size: u32,
@@ -59,7 +59,7 @@ pub(crate) struct TbfHeaderV2Base {
 #[repr(u16)]
 #[derive(Clone, Copy, Debug)]
 #[allow(dead_code)]
-pub(crate) enum TbfHeaderTypes {
+crate enum TbfHeaderTypes {
     TbfHeaderMain = 1,
     TbfHeaderWriteableFlashRegions = 2,
     TbfHeaderPackageName = 3,
@@ -69,7 +69,7 @@ pub(crate) enum TbfHeaderTypes {
 /// The TLV header (T and L).
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
-pub(crate) struct TbfHeaderTlv {
+crate struct TbfHeaderTlv {
     tipe: TbfHeaderTypes,
     length: u16,
 }
@@ -80,7 +80,7 @@ pub(crate) struct TbfHeaderTlv {
 /// only padding.
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
-pub(crate) struct TbfHeaderV2Main {
+crate struct TbfHeaderV2Main {
     init_fn_offset: u32,
     protected_size: u32,
     minimum_ram_size: u32,
@@ -92,7 +92,7 @@ pub(crate) struct TbfHeaderV2Main {
 /// struct.
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
-pub(crate) struct TbfHeaderV2WriteableFlashRegion {
+crate struct TbfHeaderV2WriteableFlashRegion {
     writeable_flash_region_offset: u32,
     writeable_flash_region_size: u32,
 }
@@ -103,7 +103,7 @@ pub(crate) struct TbfHeaderV2WriteableFlashRegion {
 /// block so the kernel knows where sections are in the app binary.
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
-pub(crate) struct PicOption1Fields {
+crate struct PicOption1Fields {
     text_offset: u32,
     data_offset: u32,
     data_size: u32,
@@ -118,7 +118,7 @@ pub(crate) struct PicOption1Fields {
 
 /// Single header that can contain all parts of a v2 header.
 #[derive(Clone, Copy, Debug)]
-pub(crate) struct TbfHeaderV2 {
+crate struct TbfHeaderV2 {
     base: &'static TbfHeaderV2Base,
     main: Option<&'static TbfHeaderV2Main>,
     package_name: Option<&'static str>,
@@ -132,7 +132,7 @@ pub(crate) struct TbfHeaderV2 {
 /// The kernel can also use this header to keep persistent state about
 /// the application.
 #[derive(Debug)]
-pub(crate) enum TbfHeader {
+crate enum TbfHeader {
     TbfHeaderV1(&'static TbfHeaderV1),
     TbfHeaderV2(TbfHeaderV2),
     Padding(&'static TbfHeaderV2Base),
@@ -140,7 +140,7 @@ pub(crate) enum TbfHeader {
 
 impl TbfHeader {
     /// Return whether this is an app or just padding between apps.
-    pub(crate) fn is_app(&self) -> bool {
+    crate fn is_app(&self) -> bool {
         match *self {
             TbfHeader::TbfHeaderV1(_) => true,
             TbfHeader::TbfHeaderV2(_) => true,
@@ -150,7 +150,7 @@ impl TbfHeader {
 
     /// Return whether the application is enabled or not.
     /// Disabled applications are not started by the kernel.
-    pub(crate) fn enabled(&self) -> bool {
+    crate fn enabled(&self) -> bool {
         match *self {
             // Header v1 has no flag for this, and therefore all apps are
             // always enabled.
@@ -164,7 +164,7 @@ impl TbfHeader {
     }
 
     /// Get the total size in flash of this app or padding.
-    pub(crate) fn get_total_size(&self) -> u32 {
+    crate fn get_total_size(&self) -> u32 {
         match *self {
             TbfHeader::TbfHeaderV1(hd) => hd.total_size,
             TbfHeader::TbfHeaderV2(hd) => hd.base.total_size,
@@ -175,7 +175,7 @@ impl TbfHeader {
     /// Add up all of the relevant fields in header version 1, or just used the
     /// app provided value in version 2 to get the total amount of RAM that is
     /// needed for this app.
-    pub(crate) fn get_minimum_app_ram_size(&self) -> u32 {
+    crate fn get_minimum_app_ram_size(&self) -> u32 {
         match *self {
             TbfHeader::TbfHeaderV1(hd) => {
                 let heap_len = align8!(hd.min_app_heap_len) + align8!(hd.min_kernel_heap_len);
@@ -190,7 +190,7 @@ impl TbfHeader {
 
     /// Get the number of bytes from the start of the app's region in flash that
     /// is for kernel use only. The app cannot write this region.
-    pub(crate) fn get_protected_size(&self) -> u32 {
+    crate fn get_protected_size(&self) -> u32 {
         match *self {
             TbfHeader::TbfHeaderV1(_) => mem::size_of::<TbfHeaderV1>() as u32,
             TbfHeader::TbfHeaderV2(hd) => {
@@ -202,7 +202,7 @@ impl TbfHeader {
 
     /// Get the offset from the beginning of the app's flash region where the
     /// app should start executing.
-    pub(crate) fn get_init_function_offset(&self) -> u32 {
+    crate fn get_init_function_offset(&self) -> u32 {
         match *self {
             TbfHeader::TbfHeaderV1(hd) => hd.entry_offset,
             TbfHeader::TbfHeaderV2(hd) => {
@@ -213,7 +213,7 @@ impl TbfHeader {
     }
 
     /// Get the name of the app.
-    pub(crate) fn get_package_name(&self, flash_start_addr: *const u8) -> &'static str {
+    crate fn get_package_name(&self, flash_start_addr: *const u8) -> &'static str {
         match *self {
             TbfHeader::TbfHeaderV1(hd) => unsafe {
                 let package_name_byte_array = slice::from_raw_parts(
@@ -232,7 +232,7 @@ impl TbfHeader {
     }
 
     /// Get the number of flash regions this app has specified in its header.
-    pub(crate) fn number_writeable_flash_regions(&self) -> usize {
+    crate fn number_writeable_flash_regions(&self) -> usize {
         match *self {
             TbfHeader::TbfHeaderV1(_) => 0,
             TbfHeader::TbfHeaderV2(hd) => hd.writeable_regions.map_or(0, |wr| wr.len()),
@@ -241,7 +241,7 @@ impl TbfHeader {
     }
 
     /// Get the offset and size of a given flash region.
-    pub(crate) fn get_writeable_flash_region(&self, index: usize) -> (u32, u32) {
+    crate fn get_writeable_flash_region(&self, index: usize) -> (u32, u32) {
         match *self {
             TbfHeader::TbfHeaderV1(_) => (0, 0),
             TbfHeader::TbfHeaderV2(hd) => hd.writeable_regions.map_or((0, 0), |wr| {
@@ -264,7 +264,7 @@ impl TbfHeader {
 /// This function takes a pointer to arbitrary memory and optionally returns a
 /// TBF header struct. This function will validate the header checksum, but does
 /// not perform sanity or security checking on the structure.
-pub(crate) unsafe fn parse_and_validate_tbf_header(address: *const u8) -> Option<TbfHeader> {
+crate unsafe fn parse_and_validate_tbf_header(address: *const u8) -> Option<TbfHeader> {
     let version = *(address as *const u16);
 
     match version {


### PR DESCRIPTION
An enhancement to Rust is the `crate` visibility modifier (https://github.com/rust-lang/rust/issues/44660). This can be used instead of `pub` for things which should only be available within the crate, and not publicly available to all users of the crate.

This PR updates the kernel crate to use this in many places where functions and variables shouldn't be accessible outside of the kernel crate.

This is part of tracking issue #1088.




### Testing Strategy

This pull request was tested by compiling. It doesn't actually make any logic changes.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
