### PR TITLE
kernel: use as_ptr() in appslice

### DIFF
--- a/kernel/src/mem.rs
+++ b/kernel/src/mem.rs
@@ -76,7 +76,7 @@ impl<L, T> AppSlice<L, T> {
     }
 
     pub fn ptr(&self) -> *const T {
-        unsafe { self.ptr.ptr.as_ref() as *const T }
+        self.ptr.ptr.as_ptr()
     }
 
     pub unsafe fn expose_to(&self, appid: AppId) -> bool {


### PR DESCRIPTION
We do not need to use `as_ref()` which requires `unsafe`.

Relevant documentation is here: https://doc.rust-lang.org/1.26.0/core/ptr/struct.Unique.html


### Testing Strategy

This pull request was tested by running the adc test app on hail, and it seems to still work.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
