### PR TITLE
Assign proper gpio pins to nRF52-DK

### DIFF
--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -17,6 +17,8 @@ extern crate nrf52;
 extern crate nrf52dk_base;
 extern crate nrf5x;
 
+use nrf52dk_base::{SpiMX25R6435FPins, SpiPins, UartPins};
+
 // The nRF52840DK LEDs (see back of board)
 const LED1_PIN: usize = 13;
 const LED2_PIN: usize = 14;
@@ -30,14 +32,14 @@ const BUTTON3_PIN: usize = 24;
 const BUTTON4_PIN: usize = 25;
 const BUTTON_RST_PIN: usize = 18;
 
-const UART_RTS: u32 = 5;
-const UART_TXD: u32 = 6;
-const UART_CTS: u32 = 7;
-const UART_RXD: u32 = 8;
+const UART_RTS: usize = 5;
+const UART_TXD: usize = 6;
+const UART_CTS: usize = 7;
+const UART_RXD: usize = 8;
 
-const SPI_MOSI: u32 = 20;
-const SPI_MISO: u32 = 21;
-const SPI_CLK: u32 = 19;
+const SPI_MOSI: usize = 20;
+const SPI_MISO: usize = 21;
+const SPI_CLK: usize = 19;
 
 const SPI_MX25R6435F_DEVICE: usize = 17;
 const SPI_MX25R6435F_CLIENT: usize = 22;
@@ -143,18 +145,13 @@ pub unsafe fn reset_handler() {
         LED2_PIN,
         LED3_PIN,
         led_pins,
-        UART_RTS,
-        UART_TXD,
-        UART_CTS,
-        UART_RXD,
-        SPI_MOSI,
-        SPI_MISO,
-        SPI_CLK,
-        &Some([
+        &UartPins::new(UART_RTS, UART_TXD, UART_RXD, UART_CTS),
+        &SpiPins::new(SPI_MOSI, SPI_MISO, SPI_CLK),
+        &Some(SpiMX25R6435FPins::new(
             SPI_MX25R6435F_DEVICE,
             SPI_MX25R6435F_CLIENT,
             SPI_MX25R6435F_CLIENT_SECTOR,
-        ]),
+        )),
         button_pins,
         &mut APP_MEMORY,
         &mut PROCESSES,

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -30,6 +30,19 @@ const BUTTON3_PIN: usize = 24;
 const BUTTON4_PIN: usize = 25;
 const BUTTON_RST_PIN: usize = 18;
 
+const UART_RTS: u32 = 5;
+const UART_TXD: u32 = 6;
+const UART_CTS: u32 = 7;
+const UART_RXD: u32 = 8;
+
+const SPI_MOSI: u32 = 20;
+const SPI_MISO: u32 = 21;
+const SPI_CLK: u32 = 19;
+
+const SPI_MX25R6435F_DEVICE: usize = 17;
+const SPI_MX25R6435F_CLIENT: usize = 22;
+const SPI_MX25R6435F_CLIENT_SECTOR: usize = 23;
+
 /// UART Writer
 #[macro_use]
 pub mod io;
@@ -130,10 +143,21 @@ pub unsafe fn reset_handler() {
         LED2_PIN,
         LED3_PIN,
         led_pins,
+        UART_RTS,
+        UART_TXD,
+        UART_CTS,
+        UART_RXD,
+        SPI_MOSI,
+        SPI_MISO,
+        SPI_CLK,
+        &Some([
+            SPI_MX25R6435F_DEVICE,
+            SPI_MX25R6435F_CLIENT,
+            SPI_MX25R6435F_CLIENT_SECTOR,
+        ]),
         button_pins,
         &mut APP_MEMORY,
         &mut PROCESSES,
         FAULT_RESPONSE,
-        true,
     );
 }

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -41,9 +41,9 @@ const SPI_MOSI: usize = 20;
 const SPI_MISO: usize = 21;
 const SPI_CLK: usize = 19;
 
-const SPI_MX25R6435F_DEVICE: usize = 17;
-const SPI_MX25R6435F_CLIENT: usize = 22;
-const SPI_MX25R6435F_CLIENT_SECTOR: usize = 23;
+const SPI_MX25R6435F_CHIP_SELECT: usize = 17;
+const SPI_MX25R6435F_WRITE_PROTECT_PIN: usize = 22;
+const SPI_MX25R6435F_HOLD_PIN: usize = 23;
 
 /// UART Writer
 #[macro_use]
@@ -148,9 +148,9 @@ pub unsafe fn reset_handler() {
         &UartPins::new(UART_RTS, UART_TXD, UART_RXD, UART_CTS),
         &SpiPins::new(SPI_MOSI, SPI_MISO, SPI_CLK),
         &Some(SpiMX25R6435FPins::new(
-            SPI_MX25R6435F_DEVICE,
-            SPI_MX25R6435F_CLIENT,
-            SPI_MX25R6435F_CLIENT_SECTOR,
+            SPI_MX25R6435F_CHIP_SELECT,
+            SPI_MX25R6435F_WRITE_PROTECT_PIN,
+            SPI_MX25R6435F_HOLD_PIN,
         )),
         button_pins,
         &mut APP_MEMORY,

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -74,6 +74,8 @@ extern crate nrf52;
 extern crate nrf52dk_base;
 extern crate nrf5x;
 
+use nrf52dk_base::{SpiPins, UartPins};
+
 // The nRF52 DK LEDs (see back of board)
 const LED1_PIN: usize = 17;
 const LED2_PIN: usize = 18;
@@ -87,14 +89,14 @@ const BUTTON3_PIN: usize = 15;
 const BUTTON4_PIN: usize = 16;
 const BUTTON_RST_PIN: usize = 21;
 
-const UART_RTS: u32 = 5;
-const UART_TXD: u32 = 6;
-const UART_CTS: u32 = 7;
-const UART_RXD: u32 = 8;
+const UART_RTS: usize = 5;
+const UART_TXD: usize = 6;
+const UART_CTS: usize = 7;
+const UART_RXD: usize = 8;
 
-const SPI_MOSI: u32 = 22;
-const SPI_MISO: u32 = 23;
-const SPI_CLK: u32 = 24;
+const SPI_MOSI: usize = 22;
+const SPI_MISO: usize = 23;
+const SPI_CLK: usize = 24;
 
 /// UART Writer
 #[macro_use]
@@ -201,13 +203,8 @@ pub unsafe fn reset_handler() {
         LED2_PIN,
         LED3_PIN,
         led_pins,
-        UART_RTS,
-        UART_TXD,
-        UART_CTS,
-        UART_RXD,
-        SPI_MOSI,
-        SPI_MISO,
-        SPI_CLK,
+        &UartPins::new(UART_RTS, UART_TXD, UART_RXD, UART_CTS),
+        &SpiPins::new(SPI_MOSI, SPI_MISO, SPI_CLK),
         &None,
         button_pins,
         &mut APP_MEMORY,

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -87,6 +87,15 @@ const BUTTON3_PIN: usize = 15;
 const BUTTON4_PIN: usize = 16;
 const BUTTON_RST_PIN: usize = 21;
 
+const UART_RTS: u32 = 5;
+const UART_TXD: u32 = 6;
+const UART_CTS: u32 = 7;
+const UART_RXD: u32 = 8;
+
+const SPI_MOSI: u32 = 22;
+const SPI_MISO: u32 = 23;
+const SPI_CLK: u32 = 24;
+
 /// UART Writer
 #[macro_use]
 pub mod io;
@@ -123,7 +132,7 @@ pub unsafe fn reset_handler() {
 
     // GPIOs
     let gpio_pins = static_init!(
-        [&'static nrf5x::gpio::GPIOPin; 15],
+        [&'static nrf5x::gpio::GPIOPin; 12],
         [
             &nrf5x::gpio::PORT[3], // Bottom right header on DK board
             &nrf5x::gpio::PORT[4],
@@ -136,10 +145,7 @@ pub unsafe fn reset_handler() {
             &nrf5x::gpio::PORT[27], // Top left header on DK board
             &nrf5x::gpio::PORT[26],
             &nrf5x::gpio::PORT[2],
-            &nrf5x::gpio::PORT[25],
-            &nrf5x::gpio::PORT[24],
-            &nrf5x::gpio::PORT[23],
-            &nrf5x::gpio::PORT[22], // -----
+            &nrf5x::gpio::PORT[25]
         ]
     );
 
@@ -195,10 +201,17 @@ pub unsafe fn reset_handler() {
         LED2_PIN,
         LED3_PIN,
         led_pins,
+        UART_RTS,
+        UART_TXD,
+        UART_CTS,
+        UART_RXD,
+        SPI_MOSI,
+        SPI_MISO,
+        SPI_CLK,
+        &None,
         button_pins,
         &mut APP_MEMORY,
         &mut PROCESSES,
         FAULT_RESPONSE,
-        false,
     );
 }

--- a/boards/nordic/nrf52dk_base/src/lib.rs
+++ b/boards/nordic/nrf52dk_base/src/lib.rs
@@ -17,17 +17,17 @@ use nrf5x::rtc::Rtc;
 /// Pins for SPI for the flash chip MX25R6435F
 #[derive(Debug)]
 pub struct SpiMX25R6435FPins {
-    device: usize,
-    client: usize,
-    client_sector: usize,
+    chip_select: usize,
+    write_protect_pin: usize,
+    hold_pin: usize,
 }
 
 impl SpiMX25R6435FPins {
-    pub fn new(device: usize, client: usize, client_sector: usize) -> Self {
+    pub fn new(chip_select: usize, write_protect_pin: usize, hold_pin: usize) -> Self {
         Self {
-            device,
-            client,
-            client_sector,
+            chip_select,
+            write_protect_pin,
+            hold_pin,
         }
     }
 }
@@ -274,7 +274,7 @@ pub unsafe fn setup_board(
             capsules::virtual_spi::VirtualSpiMasterDevice<'static, nrf52::spi::SPIM>,
             capsules::virtual_spi::VirtualSpiMasterDevice::new(
                 mux_spi,
-                &nrf5x::gpio::PORT[driver.device]
+                &nrf5x::gpio::PORT[driver.chip_select]
             )
         );
         // Create an alarm for this chip.
@@ -295,8 +295,8 @@ pub unsafe fn setup_board(
                 mx25r6435f_virtual_alarm,
                 &mut capsules::mx25r6435f::TXBUFFER,
                 &mut capsules::mx25r6435f::RXBUFFER,
-                Some(&nrf5x::gpio::PORT[driver.client]),
-                Some(&nrf5x::gpio::PORT[driver.client_sector])
+                Some(&nrf5x::gpio::PORT[driver.write_protect_pin]),
+                Some(&nrf5x::gpio::PORT[driver.hold_pin])
             )
         );
         mx25r6435f_spi.set_client(mx25r6435f);

--- a/boards/nordic/nrf52dk_base/src/lib.rs
+++ b/boards/nordic/nrf52dk_base/src/lib.rs
@@ -108,6 +108,7 @@ impl kernel::Platform for Platform {
 }
 
 /// Generic function for starting an nrf52dk board.
+#[inline]
 pub unsafe fn setup_board(
     button_rst_pin: usize,
     gpio_pins: &'static mut [&'static nrf5x::gpio::GPIOPin],


### PR DESCRIPTION
### Pull Request Overview

In `nrf52dk_base` we had assumed some pins are the same but they were
not. Because for `nRF52DK` pin 19 and pin 20 were assigned to both the
LEDS and the SPI drivers!

However, now `setup_board` takes very many parameters which is not
efficient i.e, can't go in the registers but since this is during
the initialization I guess it is ok!

Closes #1079 

### Testing Strategy

This pull request was tested on `nRF52-DK`


### TODO or Help Wanted

- [x] test on nRF52840DK

### Documentation Updated

~- [ ] Updated the relevant files in `/docs`, or no updates are required.~

### Formatting

- [x] Ran `make formatall`.
