### PR TITLE
Replace trivial implementations of Default with #[derive(Default)]

### DIFF
--- a/capsules/src/adc.rs
+++ b/capsules/src/adc.rs
@@ -77,18 +77,10 @@ enum AdcMode {
 }
 
 /// Holds buffers that the application has passed us
+#[derive(Default)]
 pub struct App {
     app_buf1: Option<AppSlice<Shared, u8>>,
     app_buf2: Option<AppSlice<Shared, u8>>,
-}
-
-impl Default for App {
-    fn default() -> App {
-        App {
-            app_buf1: None,
-            app_buf2: None,
-        }
-    }
 }
 
 /// Buffers to use for DMA transfers

--- a/capsules/src/app_flash_driver.rs
+++ b/capsules/src/app_flash_driver.rs
@@ -29,22 +29,12 @@ use kernel::{AppId, AppSlice, Callback, Driver, Grant, ReturnCode, Shared};
 /// Syscall driver number.
 pub const DRIVER_NUM: usize = 0x50000;
 
+#[derive(Default)]
 pub struct App {
     callback: Option<Callback>,
     buffer: Option<AppSlice<Shared, u8>>,
     pending_command: bool,
     flash_address: usize,
-}
-
-impl Default for App {
-    fn default() -> App {
-        App {
-            callback: None,
-            buffer: None,
-            pending_command: false,
-            flash_address: 0,
-        }
-    }
 }
 
 pub struct AppFlash<'a> {

--- a/capsules/src/console.rs
+++ b/capsules/src/console.rs
@@ -43,6 +43,7 @@ use kernel::{AppId, AppSlice, Callback, Driver, Grant, ReturnCode, Shared};
 /// Syscall driver number.
 pub const DRIVER_NUM: usize = 0x00000001;
 
+#[derive(Default)]
 pub struct App {
     write_callback: Option<Callback>,
     write_buffer: Option<AppSlice<Shared, u8>>,
@@ -53,22 +54,6 @@ pub struct App {
     read_callback: Option<Callback>,
     read_buffer: Option<AppSlice<Shared, u8>>,
     read_len: usize,
-}
-
-impl Default for App {
-    fn default() -> App {
-        App {
-            write_callback: None,
-            write_buffer: None,
-            write_len: 0,
-            write_remaining: 0,
-            pending_write: false,
-
-            read_callback: None,
-            read_buffer: None,
-            read_len: 0,
-        }
-    }
 }
 
 pub static mut WRITE_BUF: [u8; 64] = [0; 64];

--- a/capsules/src/i2c_master_slave_driver.rs
+++ b/capsules/src/i2c_master_slave_driver.rs
@@ -24,24 +24,13 @@ pub static mut BUFFER3: [u8; 256] = [0; 256];
 
 pub const DRIVER_NUM: usize = 0x80020006;
 
+#[derive(Default)]
 pub struct App {
     callback: Option<Callback>,
     master_tx_buffer: Option<AppSlice<Shared, u8>>,
     master_rx_buffer: Option<AppSlice<Shared, u8>>,
     slave_tx_buffer: Option<AppSlice<Shared, u8>>,
     slave_rx_buffer: Option<AppSlice<Shared, u8>>,
-}
-
-impl Default for App {
-    fn default() -> App {
-        App {
-            callback: None,
-            master_tx_buffer: None,
-            master_rx_buffer: None,
-            slave_tx_buffer: None,
-            slave_rx_buffer: None,
-        }
-    }
 }
 
 #[derive(Clone, Copy, PartialEq)]

--- a/capsules/src/nrf51822_serialization.rs
+++ b/capsules/src/nrf51822_serialization.rs
@@ -24,24 +24,13 @@ use kernel::{AppId, AppSlice, Callback, Driver, ReturnCode, Shared};
 /// Syscall number
 pub const DRIVER_NUM: usize = 0x80004;
 
+#[derive(Default)]
 struct App {
     callback: Option<Callback>,
     tx_buffer: Option<AppSlice<Shared, u8>>,
     rx_buffer: Option<AppSlice<Shared, u8>>,
     rx_recv_so_far: usize, // How many RX bytes we have currently received.
     rx_recv_total: usize,  // The total number of bytes we expect to receive.
-}
-
-impl Default for App {
-    fn default() -> App {
-        App {
-            callback: None,
-            tx_buffer: None,
-            rx_buffer: None,
-            rx_recv_so_far: 0,
-            rx_recv_total: 0,
-        }
-    }
 }
 
 // Local buffer for passing data between applications and the underlying

--- a/capsules/src/sdcard.rs
+++ b/capsules/src/sdcard.rs
@@ -1391,20 +1391,11 @@ pub struct SDCardDriver<'a, A: hil::time::Alarm> {
 }
 
 /// Holds buffers and whatnot that the application has passed us.
+#[derive(Default)]
 struct App {
     callback: Option<Callback>,
     write_buffer: Option<AppSlice<Shared, u8>>,
     read_buffer: Option<AppSlice<Shared, u8>>,
-}
-
-impl Default for App {
-    fn default() -> App {
-        App {
-            callback: None,
-            write_buffer: None,
-            read_buffer: None,
-        }
-    }
 }
 
 /// Buffer for SD card driver, assigned in board `main.rs` files

--- a/capsules/src/spi.rs
+++ b/capsules/src/spi.rs
@@ -21,6 +21,7 @@ pub const DRIVER_NUM: usize = 0x20001;
 // operation, while the index variable keeps track of the
 // index an ongoing operation is at in the buffers.
 
+#[derive(Default)]
 struct App {
     callback: Option<Callback>,
     app_read: Option<AppSlice<Shared, u8>>,
@@ -29,21 +30,10 @@ struct App {
     index: usize,
 }
 
-impl Default for App {
-    fn default() -> App {
-        App {
-            callback: None,
-            app_read: None,
-            app_write: None,
-            len: 0,
-            index: 0,
-        }
-    }
-}
-
 // Since we provide an additional callback in slave mode for
 // when the chip is selected, we have added a "SlaveApp" struct
 // that includes this new callback field.
+#[derive(Default)]
 struct SlaveApp {
     callback: Option<Callback>,
     selected_callback: Option<Callback>,
@@ -51,19 +41,6 @@ struct SlaveApp {
     app_write: Option<AppSlice<Shared, u8>>,
     len: usize,
     index: usize,
-}
-
-impl Default for SlaveApp {
-    fn default() -> SlaveApp {
-        SlaveApp {
-            callback: None,
-            selected_callback: None,
-            app_read: None,
-            app_write: None,
-            len: 0,
-            index: 0,
-        }
-    }
 }
 
 pub struct Spi<'a, S: SpiMasterDevice> {


### PR DESCRIPTION
### Pull Request Overview

This pull request removes needless handwritten default implementations in the capsules


### Testing Strategy

This pull request was tested by...


### TODO or Help Wanted

This pull request has been tested on:

- [x] ADC
- [X] IPC
- [ ] AppFlash
- [x] UART
- [x] I2C (failed on nRF52, need to activate the driver)
- [ ] SD-card
- [ ] SPI 

(affects all boards but this changes `_should_` be safe because all impls in the standard library is ok, https://doc.rust-lang.org/src/core/default.rs.html#139-#158 but I haven't check all impls in Tock but I assume that all options has `None` as default value!)

### Documentation Updated

~- [ ] Updated the relevant files in `/docs`, or no updates are required.~

### Formatting

- [x] Ran `make formatall`.
