### PR TITLE
[tock-cells] Fix unit tests embedded in rustdocs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ alldoc:
 .PHONY: ci-travis
 ci-travis:
 	@CI=true ./tools/run_cargo_fmt.sh diff
+	@CI=true cd libraries/tock-cells && cargo test
 	@CI=true make allboards
 	@CI=true make -C boards/nordic/nrf52dk debug
 	@CI=true tools/toc.sh

--- a/libraries/tock-cells/src/map_cell.rs
+++ b/libraries/tock-cells/src/map_cell.rs
@@ -47,6 +47,9 @@ impl<T> MapCell<T> {
     /// # Examples
     ///
     /// ```
+    /// extern crate tock_cells;
+    /// use tock_cells::map_cell::MapCell;
+    ///
     /// let cell = MapCell::new(1234);
     /// let x = &cell;
     /// let y = &cell;
@@ -88,13 +91,16 @@ impl<T> MapCell<T> {
     /// # Examples
     ///
     /// ```
+    /// extern crate tock_cells;
+    /// use tock_cells::map_cell::MapCell;
+    ///
     /// let cell = MapCell::new(1234);
     /// let x = &cell;
     /// let y = &cell;
     ///
     /// x.map(|value| {
     ///     // We have mutable access to the value while in the closure
-    ///     value += 1;
+    ///     *value += 1;
     /// });
     ///
     /// // After the closure completes, the mutable memory is still in the cell,

--- a/libraries/tock-cells/src/numeric_cell_ext.rs
+++ b/libraries/tock-cells/src/numeric_cell_ext.rs
@@ -8,7 +8,8 @@
 //! To use these traits, simply pull them into scope:
 //!
 //! ```rust
-//! use kernel::common::cells::numeric_cell_ext;
+//! extern crate tock_cells;
+//! use tock_cells::numeric_cell_ext::NumericCellExt;
 //! ```
 
 use core::cell::Cell;

--- a/libraries/tock-cells/src/take_cell.rs
+++ b/libraries/tock-cells/src/take_cell.rs
@@ -45,7 +45,9 @@ impl<'a, T: ?Sized> TakeCell<'a, T> {
     /// # Examples
     ///
     /// ```
-    /// use kernel::common::cells::TakeCell;
+    /// extern crate tock_cells;
+    /// use tock_cells::take_cell::TakeCell;
+    ///
     /// let mut value = 1234;
     /// let cell = TakeCell::new(&mut value);
     /// let x = &cell;
@@ -88,7 +90,9 @@ impl<'a, T: ?Sized> TakeCell<'a, T> {
     /// # Examples
     ///
     /// ```
-    /// use kernel::common::cells::TakeCell;
+    /// extern crate tock_cells;
+    /// use tock_cells::take_cell::TakeCell;
+    ///
     /// let mut value = 1234;
     /// let cell = TakeCell::new(&mut value);
     /// let x = &cell;


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes unit tests that failed!


### Testing Strategy

```bash
$  cd libraries/tock-cells && cargo test
```

### TODO or Help Wanted

N/A

### Documentation Updated

~- [ ] Updated the relevant files in `/docs`, or no updates are required.~

### Formatting

~- [ ] Ran `make formatall`.~
