### PR TITLE
Fix bad use of optioncell introduced by #1057

### DIFF
--- a/capsules/src/adc.rs
+++ b/capsules/src/adc.rs
@@ -817,7 +817,7 @@ impl<A: hil::adc::Adc + hil::adc::AdcHighSpeed> Driver for Adc<'a, A> {
             // subscribe to ADC sample done (from all types of sampling)
             0 => {
                 // set callback
-                self.callback.replace(callback);
+                self.callback.insert(callback);
                 ReturnCode::SUCCESS
             }
 

--- a/capsules/src/gpio.rs
+++ b/capsules/src/gpio.rs
@@ -135,7 +135,7 @@ impl<G: Pin + PinCtl> Driver for GPIO<'a, G> {
             // subscribe to all pin interrupts (no affect or reliance on
             // individual pins being configured as interrupts)
             0 => {
-                self.callback.replace(callback);
+                self.callback.insert(callback);
                 ReturnCode::SUCCESS
             }
 

--- a/capsules/src/gpio_async.rs
+++ b/capsules/src/gpio_async.rs
@@ -104,13 +104,13 @@ impl<Port: hil::gpio_async::Port> Driver for GPIOAsync<'a, Port> {
         match subscribe_num {
             // Set callback for `done()` events
             0 => {
-                self.callback.replace(callback);
+                self.callback.insert(callback);
                 ReturnCode::SUCCESS
             }
 
             // Set callback for pin interrupts
             1 => {
-                self.interrupt_callback.replace(callback);
+                self.interrupt_callback.insert(callback);
                 ReturnCode::SUCCESS
             }
 

--- a/capsules/src/lps25hb.rs
+++ b/capsules/src/lps25hb.rs
@@ -229,7 +229,7 @@ impl Driver for LPS25HB<'a> {
             // Set a callback
             0 => {
                 // Set callback function
-                self.callback.replace(callback);
+                self.callback.insert(callback);
                 ReturnCode::SUCCESS
             }
             // default

--- a/capsules/src/ltc294x.rs
+++ b/capsules/src/ltc294x.rs
@@ -488,7 +488,7 @@ impl Driver for LTC294XDriver<'a> {
     ) -> ReturnCode {
         match subscribe_num {
             0 => {
-                self.callback.replace(callback);
+                self.callback.insert(callback);
                 ReturnCode::SUCCESS
             }
 

--- a/capsules/src/max17205.rs
+++ b/capsules/src/max17205.rs
@@ -421,7 +421,7 @@ impl Driver for MAX17205Driver<'a> {
     ) -> ReturnCode {
         match subscribe_num {
             0 => {
-                self.callback.replace(callback);
+                self.callback.insert(callback);
                 ReturnCode::SUCCESS
             }
 

--- a/capsules/src/pca9544a.rs
+++ b/capsules/src/pca9544a.rs
@@ -160,7 +160,7 @@ impl Driver for PCA9544A<'a> {
     ) -> ReturnCode {
         match subscribe_num {
             0 => {
-                self.callback.replace(callback);
+                self.callback.insert(callback);
                 ReturnCode::SUCCESS
             }
 

--- a/capsules/src/tmp006.rs
+++ b/capsules/src/tmp006.rs
@@ -283,7 +283,7 @@ impl Driver for TMP006<'a> {
                 self.repeated_mode.set(false);
 
                 // set callback function
-                self.callback.replace(callback);
+                self.callback.insert(callback);
 
                 // enable sensor
                 //  turn up the sampling rate so we get the sample faster
@@ -298,7 +298,7 @@ impl Driver for TMP006<'a> {
                 self.repeated_mode.set(true);
 
                 // set callback function
-                self.callback.replace(callback);
+                self.callback.insert(callback);
 
                 // enable temperature sensor
                 self.enable_sensor(self.sampling_period.get());

--- a/capsules/src/tsl2561.rs
+++ b/capsules/src/tsl2561.rs
@@ -446,7 +446,7 @@ impl Driver for TSL2561<'a> {
             // Set a callback
             0 => {
                 // Set callback function
-                self.callback.replace(callback);
+                self.callback.insert(callback);
                 ReturnCode::SUCCESS
             }
             // default


### PR DESCRIPTION
### Pull Request Overview

I merged #1057 when master had changed underneath it, so travis didn't
catch a misuse of the OptionCell type.

It's a simple fix, just need to replace instances of `OptionCell#replace(callback)` with `OptionCell#insert(callback)`.

### Testing Strategy

Compiles and builds now

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make formatall`.
