### PR TITLE
Updates to tock-registers for publishing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ ci-travis:
 	@printf "$$(tput bold)* CI: Libraries *$$(tput sgr0)\n"
 	@printf "$$(tput bold)*****************$$(tput sgr0)\n"
 	@CI=true cd libraries/tock-cells && cargo test
+	@CI=true cd libraries/tock-register-interface && cargo test
 	@printf "$$(tput bold)**************$$(tput sgr0)\n"
 	@printf "$$(tput bold)* CI: Syntax *$$(tput sgr0)\n"
 	@printf "$$(tput bold)**************$$(tput sgr0)\n"

--- a/libraries/tock-register-interface/Cargo.toml
+++ b/libraries/tock-register-interface/Cargo.toml
@@ -1,7 +1,14 @@
 [package]
 name = "tock-registers"
 version = "0.1.0"
-description = "Register interface used for Tock"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+description = "Memory-Mapped I/O and register interface developed for Tock."
+homepage = "https://www.tockos.org/"
+repository = "https://github.com/tock/tock/tree/master/libraries/tock-register-interface"
+readme = "README.md"
+keywords = ["tock", "embedded", "registers", "mmio", "bare-metal"]
+categories = ["data-structures", "embedded", "no-std"]
+license = "MIT/Apache-2.0"
 
-[dependencies]
+[badges]
+travis-ci = { repository = "tock/tock", branch = "master" }

--- a/libraries/tock-register-interface/src/lib.rs
+++ b/libraries/tock-register-interface/src/lib.rs
@@ -5,7 +5,7 @@
 #![feature(const_fn)]
 #![no_std]
 
-pub mod registers;
-
 #[macro_use]
 pub mod macros;
+
+pub mod registers;

--- a/libraries/tock-register-interface/src/registers.rs
+++ b/libraries/tock-register-interface/src/registers.rs
@@ -1,10 +1,16 @@
 //! Implementation of registers and bitfields.
 //!
-//! Allows register maps to be specified like this:
+//! Provides efficient mechanisms to express and use type-checked memory mapped
+//! registers and bitfields.
 //!
 //! ```rust
-//! use common::registers::{ReadOnly, ReadWrite, WriteOnly};
+//! # #[macro_use]
+//! # extern crate tock_registers;
+//! # fn main() {}
 //!
+//! use tock_registers::registers::{ReadOnly, ReadWrite};
+//!
+//! // Register maps are specified like this:
 //! #[repr(C)]
 //! struct Registers {
 //!     // Control register: read-write
@@ -12,12 +18,22 @@
 //!     // Status register: read-only
 //!     s: ReadOnly<u32, Status::Register>,
 //! }
-//! ```
 //!
-//! and register fields and definitions to look like:
-//!
-//! ```rust
+//! // Register fields and definitions look like this:
 //! register_bitfields![u32,
+//!     // Simpler bitfields are expressed concisely:
+//!     Control [
+//!         /// Stop the Current Transfer
+//!         STOP 8,
+//!         /// Software Reset
+//!         SWRST 7,
+//!         /// Master Disable
+//!         MDIS 1,
+//!         /// Master Enable
+//!         MEN 0
+//!     ],
+//!
+//!     // More complex registers can express subtypes:
 //!     Status [
 //!         TXCOMPLETE  OFFSET(0) NUMBITS(1) [],
 //!         TXINTERRUPT OFFSET(1) NUMBITS(1) [],


### PR DESCRIPTION
### Pull Request Overview

This is blocked on #1105.

This finishes the remaining bits for publishing, specifically fixing up doctests and adding metadata to the manifest.

### Testing Strategy

Compiling.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
