### PR TITLE
[WIP] UART + SPI HIL generic lifetimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+Since 1.2
+=========
+
+* UART HIL Refinements: This release saw several updates to the UART HIL,
+  summarized in the [UART HIL tracking issue](https://github.com/tock/tock/issues/1072).
+
+  - [#1073](https://github.com/tock/tock/pull/1073) removes `initialize` from
+    the UART HIL. Implementations will need to disentangle board-specific
+    initialization code, such as enabling the peripheral or assigning pins,
+    from UART configuration code, such as baud rate or parity. Initialization
+    is no longer part of the UART HIL and should be performed by the top-level
+    board before passing the UART object to any other code. UART configuration
+    is now controlled by the new `configure` HIL method:
+
+    ```rust
+    /// Configure UART
+    ///
+    /// Returns SUCCESS, or
+    ///
+    /// - EOFF: The underlying hardware is currently not available, perhaps
+    ///         because it has not been initialized or in the case of a shared
+    ///         hardware USART controller because it is set up for SPI.
+    /// - EINVAL: Impossible parameters (e.g. a `baud_rate` of 0)
+    /// - ENOSUPPORT: The underlying UART cannot satisfy this configuration.
+    fn configure(&self, params: UARTParameters) -> ReturnCode;
+    ```

--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -109,7 +109,7 @@ target/$(TARGET)/release/$(PLATFORM).lst: target/$(TARGET)/release/$(PLATFORM).e
 
 .PHONY: target/$(TARGET)/release/$(PLATFORM)
 target/$(TARGET)/release/$(PLATFORM):
-	$(Q)RUSTFLAGS=$(RUSTFLAGS_FOR_CARGO_LINKING) $(CARGO) build --target=$(TARGET) $(VERBOSE) --release
+	$(Q)RUSTFLAGS=$(RUSTFLAGS_FOR_CARGO_LINKING) $(CARGO) build --target=$(TARGET) $(VERBOSE) --release -j1
 	$(Q)$(SIZE) $@
 
 target/$(TARGET)/debug/$(PLATFORM).elf: target/$(TARGET)/debug/$(PLATFORM)

--- a/boards/ek-tm4c1294xl/src/io.rs
+++ b/boards/ek-tm4c1294xl/src/io.rs
@@ -18,7 +18,7 @@ impl Write for Writer {
         let uart = unsafe { &mut tm4c129x::uart::UART0 };
         if !self.initialized {
             self.initialized = true;
-            uart.init(uart::UARTParams {
+            uart.configure(uart::UARTParameters {
                 baud_rate: 115200,
                 stop_bits: uart::StopBits::One,
                 parity: uart::Parity::None,

--- a/boards/hail/src/io.rs
+++ b/boards/hail/src/io.rs
@@ -19,7 +19,7 @@ impl Write for Writer {
         let regs_manager = &sam4l::usart::USARTRegManager::panic_new(&uart);
         if !self.initialized {
             self.initialized = true;
-            uart.init(uart::UARTParams {
+            uart.configure(uart::UARTParameters {
                 baud_rate: 115200,
                 stop_bits: uart::StopBits::One,
                 parity: uart::Parity::None,

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -200,6 +200,8 @@ pub unsafe fn reset_handler() {
 
     let mut chip = sam4l::chip::Sam4l::new();
 
+    // Initialize USART0 for Uart
+    sam4l::usart::USART0.set_mode(sam4l::usart::UsartMode::Uart);
     let console = static_init!(
         capsules::console::Console<sam4l::usart::USART>,
         capsules::console::Console::new(
@@ -212,6 +214,8 @@ pub unsafe fn reset_handler() {
     );
     hil::uart::UART::set_client(&sam4l::usart::USART0, console);
 
+    // Initialize USART3 for Uart
+    sam4l::usart::USART3.set_mode(sam4l::usart::UsartMode::Uart);
     // Create the Nrf51822Serialization driver for passing BLE commands
     // over UART to the nRF51822 radio.
     let nrf_serialization = static_init!(

--- a/boards/imix/src/io.rs
+++ b/boards/imix/src/io.rs
@@ -18,7 +18,7 @@ impl Write for Writer {
         let regs_manager = &sam4l::usart::USARTRegManager::panic_new(&uart);
         if !self.initialized {
             self.initialized = true;
-            uart.init(uart::UARTParams {
+            uart.configure(uart::UARTParameters {
                 baud_rate: 115200,
                 stop_bits: uart::StopBits::One,
                 parity: uart::Parity::None,

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -255,6 +255,8 @@ pub unsafe fn reset_handler() {
 
     // # CONSOLE
 
+    // Initialize USART3 for Uart
+    sam4l::usart::USART3.set_mode(sam4l::usart::UsartMode::Uart);
     let console = static_init!(
         capsules::console::Console<sam4l::usart::USART>,
         capsules::console::Console::new(
@@ -272,6 +274,8 @@ pub unsafe fn reset_handler() {
     let kc = static_init!(capsules::console::App, capsules::console::App::default());
     kernel::debug::assign_console_driver(Some(console), kc);
 
+    // Initialize USART2 for Uart
+    sam4l::usart::USART2.set_mode(sam4l::usart::UsartMode::Uart);
     // Create the Nrf51822Serialization driver for passing BLE commands
     // over UART to the nRF51822 radio.
     let nrf_serialization = static_init!(

--- a/boards/launchxl/src/io.rs
+++ b/boards/launchxl/src/io.rs
@@ -17,7 +17,7 @@ impl Write for Writer {
         let uart = unsafe { &mut cc26xx::uart::UART0 };
         if !self.initialized {
             self.initialized = true;
-            uart.init(uart::UARTParams {
+            uart.configure(uart::UARTParameters {
                 baud_rate: 115200,
                 stop_bits: uart::StopBits::One,
                 parity: uart::Parity::None,

--- a/boards/launchxl/src/main.rs
+++ b/boards/launchxl/src/main.rs
@@ -125,7 +125,7 @@ pub unsafe fn reset_handler() {
     }
 
     // UART
-    cc26xx::uart::UART0.set_pins(3, 2);
+    cc26xx::uart::UART0.initialize_and_set_pins(3, 2);
     let console = static_init!(
         capsules::console::Console<cc26xx::uart::UART>,
         capsules::console::Console::new(

--- a/boards/nordic/nrf51dk/src/io.rs
+++ b/boards/nordic/nrf51dk/src/io.rs
@@ -18,7 +18,7 @@ impl Write for Writer {
         let uart = unsafe { &mut nrf51::uart::UART0 };
         if !self.initialized {
             self.initialized = true;
-            uart.init(uart::UARTParams {
+            uart.configure(uart::UARTParameters {
                 baud_rate: 115200,
                 stop_bits: uart::StopBits::One,
                 parity: uart::Parity::None,

--- a/boards/nordic/nrf51dk/src/main.rs
+++ b/boards/nordic/nrf51dk/src/main.rs
@@ -229,7 +229,7 @@ pub unsafe fn reset_handler() {
         pin.set_client(gpio);
     }
 
-    nrf51::uart::UART0.configure(
+    nrf51::uart::UART0.initialize(
         Pinmux::new(9),  /*. tx  */
         Pinmux::new(11), /* rx  */
         Pinmux::new(10), /* cts */

--- a/boards/nordic/nrf52840dk/src/io.rs
+++ b/boards/nordic/nrf52840dk/src/io.rs
@@ -18,7 +18,7 @@ impl Write for Writer {
         let uart = unsafe { &mut nrf52::uart::UARTE0 };
         if !self.initialized {
             self.initialized = true;
-            uart.init(uart::UARTParams {
+            uart.configure(uart::UARTParameters {
                 baud_rate: 115200,
                 stop_bits: uart::StopBits::One,
                 parity: uart::Parity::None,

--- a/boards/nordic/nrf52dk/src/io.rs
+++ b/boards/nordic/nrf52dk/src/io.rs
@@ -18,7 +18,7 @@ impl Write for Writer {
         let uart = unsafe { &mut nrf52::uart::UARTE0 };
         if !self.initialized {
             self.initialized = true;
-            uart.init(uart::UARTParams {
+            uart.configure(uart::UARTParameters {
                 baud_rate: 115200,
                 stop_bits: uart::StopBits::One,
                 parity: uart::Parity::None,

--- a/boards/nordic/nrf52dk_base/src/lib.rs
+++ b/boards/nordic/nrf52dk_base/src/lib.rs
@@ -142,12 +142,12 @@ pub unsafe fn setup_board(
         capsules::virtual_alarm::VirtualMuxAlarm::new(mux_alarm)
     );
 
-    nrf52::uart::UARTE0.configure(
+    nrf52::uart::UARTE0.initialize(
         nrf5x::pinmux::Pinmux::new(6), // tx
         nrf5x::pinmux::Pinmux::new(8), // rx
         nrf5x::pinmux::Pinmux::new(7), // cts
-        nrf5x::pinmux::Pinmux::new(5),
-    ); // rts
+        nrf5x::pinmux::Pinmux::new(5), // rts
+    );
     let console = static_init!(
         capsules::console::Console<nrf52::uart::Uarte>,
         capsules::console::Console::new(

--- a/capsules/src/app_flash_driver.rs
+++ b/capsules/src/app_flash_driver.rs
@@ -48,17 +48,17 @@ impl Default for App {
 }
 
 pub struct AppFlash<'a> {
-    driver: &'a hil::nonvolatile_storage::NonvolatileStorage,
+    driver: &'a hil::nonvolatile_storage::NonvolatileStorage<'a>,
     apps: Grant<App>,
     current_app: Cell<Option<AppId>>,
-    buffer: TakeCell<'static, [u8]>,
+    buffer: TakeCell<'a, [u8]>,
 }
 
 impl AppFlash<'a> {
     pub fn new(
-        driver: &'a hil::nonvolatile_storage::NonvolatileStorage,
+        driver: &'a hil::nonvolatile_storage::NonvolatileStorage<'a>,
         grant: Grant<App>,
-        buffer: &'static mut [u8],
+        buffer: &'a mut [u8],
     ) -> AppFlash<'a> {
         AppFlash {
             driver: driver,
@@ -116,10 +116,10 @@ impl AppFlash<'a> {
     }
 }
 
-impl hil::nonvolatile_storage::NonvolatileStorageClient for AppFlash<'a> {
-    fn read_done(&self, _buffer: &'static mut [u8], _length: usize) {}
+impl hil::nonvolatile_storage::NonvolatileStorageClient<'a> for AppFlash<'a> {
+    fn read_done(&self, _buffer: &'a mut [u8], _length: usize) {}
 
-    fn write_done(&self, buffer: &'static mut [u8], _length: usize) {
+    fn write_done(&self, buffer: &'a mut [u8], _length: usize) {
         // Put our write buffer back.
         self.buffer.replace(buffer);
 

--- a/capsules/src/console.rs
+++ b/capsules/src/console.rs
@@ -104,7 +104,7 @@ impl<U: UART> Console<'a, U> {
     }
 
     pub fn initialize(&self) {
-        self.uart.init(uart::UARTParams {
+        self.uart.configure(uart::UARTParameters {
             baud_rate: self.baud_rate,
             stop_bits: uart::StopBits::One,
             parity: uart::Parity::None,

--- a/capsules/src/ieee802154/driver.rs
+++ b/capsules/src/ieee802154/driver.rs
@@ -188,14 +188,14 @@ pub struct RadioDriver<'a> {
     current_app: Cell<Option<AppId>>,
 
     /// Buffer that stores the IEEE 802.15.4 frame to be transmitted.
-    kernel_tx: TakeCell<'static, [u8]>,
+    kernel_tx: TakeCell<'a, [u8]>,
 }
 
 impl RadioDriver<'a> {
     pub fn new(
         mac: &'a device::MacDevice<'a>,
         grant: Grant<App>,
-        kernel_tx: &'static mut [u8],
+        kernel_tx: &'a mut [u8],
     ) -> RadioDriver<'a> {
         RadioDriver {
             mac: mac,
@@ -795,8 +795,8 @@ impl Driver for RadioDriver<'a> {
     }
 }
 
-impl device::TxClient for RadioDriver<'a> {
-    fn send_done(&self, spi_buf: &'static mut [u8], acked: bool, result: ReturnCode) {
+impl device::TxClient<'a> for RadioDriver<'a> {
+    fn send_done(&self, spi_buf: &'a mut [u8], acked: bool, result: ReturnCode) {
         self.kernel_tx.replace(spi_buf);
         self.current_app.get().map(|appid| {
             let _ = self.apps.enter(appid, |app, _| {

--- a/capsules/src/nrf51822_serialization.rs
+++ b/capsules/src/nrf51822_serialization.rs
@@ -73,7 +73,7 @@ impl<U: UARTReceiveAdvanced> Nrf51822Serialization<'a, U> {
     }
 
     pub fn initialize(&self) {
-        self.uart.init(uart::UARTParams {
+        self.uart.configure(uart::UARTParameters {
             baud_rate: 250000,
             stop_bits: uart::StopBits::One,
             parity: uart::Parity::Even,

--- a/capsules/src/segger_rtt.rs
+++ b/capsules/src/segger_rtt.rs
@@ -93,6 +93,7 @@
 use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::hil;
 use kernel::hil::time::Frequency;
+use kernel::ReturnCode;
 
 /// Buffer for transmitting to the host.
 pub static mut UP_BUFFER: [u8; 1024] = [0; 1024];
@@ -186,7 +187,9 @@ impl<A: hil::time::Alarm> hil::uart::UART for SeggerRtt<'a, A> {
         self.client.set(client);
     }
 
-    fn init(&self, _params: hil::uart::UARTParams) {}
+    fn configure(&self, _params: hil::uart::UARTParameters) -> ReturnCode {
+        ReturnCode::SUCCESS
+    }
 
     fn transmit(&self, tx_data: &'static mut [u8], tx_len: usize) {
         self.up_buffer.map(|buffer| {

--- a/capsules/src/segger_rtt.rs
+++ b/capsules/src/segger_rtt.rs
@@ -157,19 +157,19 @@ impl SeggerRttMemory {
 
 pub struct SeggerRtt<'a, A: hil::time::Alarm> {
     alarm: &'a A, // Dummy alarm so we can get a callback.
-    config: TakeCell<'static, SeggerRttMemory>,
-    up_buffer: TakeCell<'static, [u8]>,
-    _down_buffer: TakeCell<'static, [u8]>,
-    client: OptionalCell<&'static hil::uart::Client>,
-    client_buffer: TakeCell<'static, [u8]>,
+    config: TakeCell<'a, SeggerRttMemory>,
+    up_buffer: TakeCell<'a, [u8]>,
+    _down_buffer: TakeCell<'a, [u8]>,
+    client: OptionalCell<&'a hil::uart::Client<'a>>,
+    client_buffer: TakeCell<'a, [u8]>,
 }
 
 impl<A: hil::time::Alarm> SeggerRtt<'a, A> {
     pub fn new(
         alarm: &'a A,
-        config: &'static mut SeggerRttMemory,
-        up_buffer: &'static mut [u8],
-        down_buffer: &'static mut [u8],
+        config: &'a mut SeggerRttMemory,
+        up_buffer: &'a mut [u8],
+        down_buffer: &'a mut [u8],
     ) -> SeggerRtt<'a, A> {
         SeggerRtt {
             alarm: alarm,
@@ -182,8 +182,8 @@ impl<A: hil::time::Alarm> SeggerRtt<'a, A> {
     }
 }
 
-impl<A: hil::time::Alarm> hil::uart::UART for SeggerRtt<'a, A> {
-    fn set_client(&self, client: &'static hil::uart::Client) {
+impl<A: hil::time::Alarm> hil::uart::UART<'a> for SeggerRtt<'a, A> {
+    fn set_client(&self, client: &'a hil::uart::Client<'a>) {
         self.client.set(client);
     }
 
@@ -191,7 +191,7 @@ impl<A: hil::time::Alarm> hil::uart::UART for SeggerRtt<'a, A> {
         ReturnCode::SUCCESS
     }
 
-    fn transmit(&self, tx_data: &'static mut [u8], tx_len: usize) {
+    fn transmit(&self, tx_data: &'a mut [u8], tx_len: usize) {
         self.up_buffer.map(|buffer| {
             self.config.map(|config| {
                 // Copy the incoming data into the buffer. Once we increment
@@ -219,7 +219,7 @@ impl<A: hil::time::Alarm> hil::uart::UART for SeggerRtt<'a, A> {
         self.alarm.set_alarm(tics);
     }
 
-    fn receive(&self, _rx_buf: &'static mut [u8], _rx_len: usize) {}
+    fn receive(&self, _rx_buf: &'a mut [u8], _rx_len: usize) {}
 
     fn abort_receive(&self) {}
 }

--- a/capsules/src/test/aes_ccm.rs
+++ b/capsules/src/test/aes_ccm.rs
@@ -8,23 +8,16 @@ use kernel::ReturnCode;
 pub struct Test<'a, A: AES128CCM<'a>> {
     aes_ccm: &'a A,
 
-    buf: TakeCell<'static, [u8]>,
+    buf: TakeCell<'a, [u8]>,
     current_test: Cell<usize>,
     encrypting: Cell<bool>,
 
     // (a_data, m_data, c_data, nonce, confidential, mic_len)
-    tests: [(
-        &'static [u8],
-        &'static [u8],
-        &'static [u8],
-        &'static [u8],
-        bool,
-        usize,
-    ); 3],
+    tests: [(&'a [u8], &'a [u8], &'a [u8], &'a [u8], bool, usize); 3],
 }
 
 impl<A: AES128CCM<'a>> Test<'a, A> {
-    pub fn new(aes_ccm: &'a A, buf: &'static mut [u8]) -> Test<'a, A> {
+    pub fn new(aes_ccm: &'a A, buf: &'a mut [u8]) -> Test<'a, A> {
         Test {
             aes_ccm: aes_ccm,
             buf: TakeCell::new(buf),
@@ -184,8 +177,8 @@ impl<A: AES128CCM<'a>> Test<'a, A> {
     }
 }
 
-impl<A: AES128CCM<'a>> CCMClient for Test<'a, A> {
-    fn crypt_done(&self, buf: &'static mut [u8], res: ReturnCode, tag_is_valid: bool) {
+impl<A: AES128CCM<'a>> CCMClient<'a> for Test<'a, A> {
+    fn crypt_done(&self, buf: &'a mut [u8], res: ReturnCode, tag_is_valid: bool) {
         self.buf.replace(buf);
         if res != ReturnCode::SUCCESS {
             debug!("Test failed: crypt_done returned {:?}", res);

--- a/chips/nrf51/src/uart.rs
+++ b/chips/nrf51/src/uart.rs
@@ -3,6 +3,7 @@ use kernel::common::cells::TakeCell;
 use kernel::common::cells::VolatileCell;
 use kernel::common::StaticRef;
 use kernel::hil::uart;
+use kernel::ReturnCode;
 use nrf5x::pinmux::Pinmux;
 
 pub static mut UART0: UART = UART::new();
@@ -82,13 +83,15 @@ impl UART {
     /// * pin  9: TX
     /// * pin 10: CTS
     /// * pin 11: RX
-    pub fn configure(&self, tx: Pinmux, rx: Pinmux, cts: Pinmux, rts: Pinmux) {
+    pub fn initialize(&self, tx: Pinmux, rx: Pinmux, cts: Pinmux, rts: Pinmux) {
         let regs = &*self.registers;
 
         regs.pseltxd.set(tx);
         regs.pselrxd.set(rx);
         regs.pselcts.set(cts);
         regs.pselrts.set(rts);
+
+        self.enable();
     }
 
     fn set_baud_rate(&self, baud_rate: u32) {
@@ -195,9 +198,22 @@ impl uart::UART for UART {
         self.client.set(Some(client));
     }
 
-    fn init(&self, params: uart::UARTParams) {
-        self.enable();
+    fn configure(&self, params: uart::UARTParameters) -> ReturnCode {
+        // These could probably be implemented, but are currently ignored, so
+        // throw an error.
+        if params.stop_bits != uart::StopBits::One {
+            return ReturnCode::ENOSUPPORT;
+        }
+        if params.parity != uart::Parity::None {
+            return ReturnCode::ENOSUPPORT;
+        }
+        if params.hw_flow_control != false {
+            return ReturnCode::ENOSUPPORT;
+        }
+
         self.set_baud_rate(params.baud_rate);
+
+        ReturnCode::SUCCESS
     }
 
     fn transmit(&self, tx_data: &'static mut [u8], tx_len: usize) {

--- a/chips/sam4l/src/adc.rs
+++ b/chips/sam4l/src/adc.rs
@@ -118,7 +118,7 @@ pub struct Adc {
     timer_counts: Cell<u8>,
 
     // DMA peripheral, buffers, and length
-    rx_dma: OptionalCell<&'static dma::DMAChannel>,
+    rx_dma: OptionalCell<&'static dma::DMAChannel<'static>>,
     rx_dma_peripheral: dma::DMAPeripheral,
     rx_length: Cell<usize>,
     next_dma_buffer: TakeCell<'static, [u16]>,

--- a/chips/sam4l/src/i2c.rs
+++ b/chips/sam4l/src/i2c.rs
@@ -546,7 +546,7 @@ pub struct I2CHw {
     slave_mmio_address: Option<StaticRef<TWISRegisters>>,
     master_clock: TWIMClock,
     slave_clock: TWISClock,
-    dma: OptionalCell<&'static DMAChannel>,
+    dma: OptionalCell<&'static DMAChannel<'static>>,
     dma_pids: (DMAPeripheral, DMAPeripheral),
     master_client: Cell<Option<&'static hil::i2c::I2CHwMasterClient>>,
     slave_client: Cell<Option<&'static hil::i2c::I2CHwSlaveClient>>,

--- a/chips/sam4l/src/spi.rs
+++ b/chips/sam4l/src/spi.rs
@@ -182,8 +182,8 @@ pub enum SpiRole {
 /// Abstraction of the SPI Hardware
 pub struct SpiHw {
     client: OptionalCell<&'static SpiMasterClient>,
-    dma_read: OptionalCell<&'static DMAChannel>,
-    dma_write: OptionalCell<&'static DMAChannel>,
+    dma_read: OptionalCell<&'static DMAChannel<'static>>,
+    dma_write: OptionalCell<&'static DMAChannel<'static>>,
     // keep track of which how many DMA transfers are pending to correctly
     // issue completion event only after both complete.
     transfers_in_progress: Cell<u8>,

--- a/chips/sam4l/src/spi.rs
+++ b/chips/sam4l/src/spi.rs
@@ -180,24 +180,24 @@ pub enum SpiRole {
 }
 
 /// Abstraction of the SPI Hardware
-pub struct SpiHw {
-    client: OptionalCell<&'static SpiMasterClient>,
-    dma_read: OptionalCell<&'static DMAChannel<'static>>,
-    dma_write: OptionalCell<&'static DMAChannel<'static>>,
+pub struct SpiHw<'a> {
+    client: OptionalCell<&'a SpiMasterClient>,
+    dma_read: OptionalCell<&'a DMAChannel<'a>>,
+    dma_write: OptionalCell<&'a DMAChannel<'a>>,
     // keep track of which how many DMA transfers are pending to correctly
     // issue completion event only after both complete.
     transfers_in_progress: Cell<u8>,
     dma_length: Cell<usize>,
 
     // Slave client is distinct from master client
-    slave_client: OptionalCell<&'static SpiSlaveClient>,
+    slave_client: OptionalCell<&'a SpiSlaveClient>,
     role: Cell<SpiRole>,
 }
 
 const SPI_BASE: StaticRef<SpiRegisters> =
     unsafe { StaticRef::new(0x40008000 as *const SpiRegisters) };
 
-impl PeripheralManagement<pm::Clock> for SpiHw {
+impl PeripheralManagement<pm::Clock> for SpiHw<'a> {
     type RegisterType = SpiRegisters;
 
     fn get_registers(&self) -> &SpiRegisters {
@@ -223,7 +223,7 @@ type SpiRegisterManager<'a> = PeripheralManager<'a, SpiHw, pm::Clock>;
 
 pub static mut SPI: SpiHw = SpiHw::new();
 
-impl SpiHw {
+impl SpiHw<'a> {
     /// Creates a new SPI object, with peripheral 0 selected
     const fn new() -> SpiHw {
         SpiHw {
@@ -417,7 +417,7 @@ impl SpiHw {
     }
 
     /// Set the DMA channels used for reading and writing.
-    pub fn set_dma(&mut self, read: &'static DMAChannel, write: &'static DMAChannel) {
+    pub fn set_dma(&mut self, read: &'a DMAChannel, write: &'a DMAChannel) {
         self.dma_read.set(read);
         self.dma_write.set(write);
     }

--- a/chips/tm4c129x/src/lib.rs
+++ b/chips/tm4c129x/src/lib.rs
@@ -1,6 +1,8 @@
 #![crate_name = "tm4c129x"]
 #![crate_type = "rlib"]
 #![feature(asm, const_fn, core_intrinsics, used)]
+#![feature(in_band_lifetimes)]
+#![feature(infer_outlives_requirements)]
 #![no_std]
 
 extern crate cortexm4;

--- a/chips/tm4c129x/src/uart.rs
+++ b/chips/tm4c129x/src/uart.rs
@@ -5,6 +5,7 @@ use kernel::common::cells::TakeCell;
 use kernel::common::cells::VolatileCell;
 use kernel::common::StaticRef;
 use kernel::hil;
+use kernel::ReturnCode;
 use sysctl;
 
 #[repr(C)]
@@ -169,9 +170,24 @@ impl hil::uart::UART for UART {
         self.client.set(Some(client));
     }
 
-    fn init(&self, params: hil::uart::UARTParams) {
+    fn configure(&self, params: hil::uart::UARTParameters) -> ReturnCode {
         self.enable();
-        self.set_baud_rate(params.baud_rate)
+
+        // These could probably be implemented, but are currently ignored, so
+        // throw an error.
+        if params.stop_bits != hil::uart::StopBits::One {
+            return ReturnCode::ENOSUPPORT;
+        }
+        if params.parity != hil::uart::Parity::None {
+            return ReturnCode::ENOSUPPORT;
+        }
+        if params.hw_flow_control != false {
+            return ReturnCode::ENOSUPPORT;
+        }
+
+        self.set_baud_rate(params.baud_rate);
+
+        ReturnCode::SUCCESS
     }
 
     fn transmit(&self, tx_data: &'static mut [u8], tx_len: usize) {

--- a/chips/tm4c129x/src/uart.rs
+++ b/chips/tm4c129x/src/uart.rs
@@ -166,7 +166,7 @@ impl UART {
 }
 
 impl hil::uart::UART for UART {
-    fn set_client(&self, client: &'static hil::uart::Client) {
+    fn set_client(&self, client: &'a hil::uart::Client) {
         self.client.set(Some(client));
     }
 
@@ -190,7 +190,7 @@ impl hil::uart::UART for UART {
         ReturnCode::SUCCESS
     }
 
-    fn transmit(&self, tx_data: &'static mut [u8], tx_len: usize) {
+    fn transmit(&self, tx_data: &'a mut [u8], tx_len: usize) {
         self.buffer.replace(tx_data);
         self.offset.set(0);
         self.remaining.set(tx_len);
@@ -199,7 +199,7 @@ impl hil::uart::UART for UART {
         self.send_next();
     }
 
-    fn receive(&self, _rx_buffer: &'static mut [u8], _rx_len: usize) {
+    fn receive(&self, _rx_buffer: &'a mut [u8], _rx_len: usize) {
         unimplemented!()
     }
 

--- a/kernel/src/hil/nonvolatile_storage.rs
+++ b/kernel/src/hil/nonvolatile_storage.rs
@@ -4,29 +4,29 @@ use returncode::ReturnCode;
 
 /// Simple interface for reading and writing nonvolatile memory. It is expected
 /// that drivers for nonvolatile memory would implement this trait.
-pub trait NonvolatileStorage {
-    fn set_client(&self, client: &'static NonvolatileStorageClient);
+pub trait NonvolatileStorage<'a> {
+    fn set_client(&self, client: &'a NonvolatileStorageClient<'a>);
 
     /// Read `length` bytes starting at address `address` in to the provided
     /// buffer. The buffer must be at least `length` bytes long. The address
     /// must be in the address space of the physical storage.
-    fn read(&self, buffer: &'static mut [u8], address: usize, length: usize) -> ReturnCode;
+    fn read(&self, buffer: &'a mut [u8], address: usize, length: usize) -> ReturnCode;
 
     /// Write `length` bytes starting at address `address` from the provided
     /// buffer. The buffer must be at least `length` bytes long. This address
     /// must be in the address space of the physical storage.
-    fn write(&self, buffer: &'static mut [u8], address: usize, length: usize) -> ReturnCode;
+    fn write(&self, buffer: &'a mut [u8], address: usize, length: usize) -> ReturnCode;
 }
 
 /// Client interface for nonvolatile storage.
-pub trait NonvolatileStorageClient {
+pub trait NonvolatileStorageClient<'a> {
     /// `read_done` is called when the implementor is finished reading in to the
     /// buffer. The callback returns the buffer and the number of bytes that
     /// were actually read.
-    fn read_done(&self, buffer: &'static mut [u8], length: usize);
+    fn read_done(&self, buffer: &'a mut [u8], length: usize);
 
     /// `write_done` is called when the implementor is finished writing from the
     /// buffer. The callback returns the buffer and the number of bytes that
     /// were actually written.
-    fn write_done(&self, buffer: &'static mut [u8], length: usize);
+    fn write_done(&self, buffer: &'a mut [u8], length: usize);
 }

--- a/kernel/src/hil/radio.rs
+++ b/kernel/src/hil/radio.rs
@@ -8,14 +8,14 @@
 //! config_commit. Please see the relevant TRD for more details.
 
 use returncode::ReturnCode;
-pub trait TxClient {
-    fn send_done(&self, buf: &'static mut [u8], acked: bool, result: ReturnCode);
+pub trait TxClient<'a> {
+    fn send_done(&self, buf: &'a mut [u8], acked: bool, result: ReturnCode);
 }
 
-pub trait RxClient {
+pub trait RxClient<'a> {
     fn receive(
         &self,
-        buf: &'static mut [u8],
+        buf: &'a mut [u8],
         frame_len: usize,
         crc_valid: bool,
         result: ReturnCode,
@@ -61,17 +61,17 @@ pub const PSDU_OFFSET: usize = 2;
 pub const MAX_BUF_SIZE: usize = PSDU_OFFSET + MAX_MTU;
 pub const MIN_PAYLOAD_OFFSET: usize = PSDU_OFFSET + MIN_MHR_SIZE;
 
-pub trait Radio: RadioConfig + RadioData {}
+pub trait Radio<'a>: RadioConfig<'a> + RadioData<'a> {}
 
 /// Configure the 802.15.4 radio.
-pub trait RadioConfig {
+pub trait RadioConfig<'a> {
     /// buf must be at least MAX_BUF_SIZE in length, and
     /// reg_read and reg_write must be 2 bytes.
     fn initialize(
         &self,
-        spi_buf: &'static mut [u8],
-        reg_write: &'static mut [u8],
-        reg_read: &'static mut [u8],
+        spi_buf: &'a mut [u8],
+        reg_write: &'a mut [u8],
+        reg_read: &'a mut [u8],
     ) -> ReturnCode;
     fn reset(&self) -> ReturnCode;
     fn start(&self) -> ReturnCode;
@@ -79,13 +79,13 @@ pub trait RadioConfig {
     fn is_on(&self) -> bool;
     fn busy(&self) -> bool;
 
-    fn set_power_client(&self, client: &'static PowerClient);
+    fn set_power_client(&self, client: &'a PowerClient);
 
     /// Commit the config calls to hardware, changing the address,
     /// PAN ID, TX power, and channel to the specified values, issues
     /// a callback to the config client when done.
     fn config_commit(&self);
-    fn set_config_client(&self, client: &'static ConfigClient);
+    fn set_config_client(&self, client: &'a ConfigClient);
 
     fn get_address(&self) -> u16; //....... The local 16-bit address
     fn get_address_long(&self) -> [u8; 8]; // 64-bit address
@@ -100,14 +100,14 @@ pub trait RadioConfig {
     fn set_channel(&self, chan: u8) -> ReturnCode;
 }
 
-pub trait RadioData {
-    fn set_transmit_client(&self, client: &'static TxClient);
-    fn set_receive_client(&self, client: &'static RxClient, receive_buffer: &'static mut [u8]);
-    fn set_receive_buffer(&self, receive_buffer: &'static mut [u8]);
+pub trait RadioData<'a> {
+    fn set_transmit_client(&self, client: &'a TxClient<'a>);
+    fn set_receive_client(&self, client: &'a RxClient<'a>, receive_buffer: &'a mut [u8]);
+    fn set_receive_buffer(&self, receive_buffer: &'a mut [u8]);
 
     fn transmit(
         &self,
-        spi_buf: &'static mut [u8],
+        spi_buf: &'a mut [u8],
         frame_len: usize,
-    ) -> (ReturnCode, Option<&'static mut [u8]>);
+    ) -> (ReturnCode, Option<&'a mut [u8]>);
 }

--- a/kernel/src/hil/spi.rs
+++ b/kernel/src/hil/spi.rs
@@ -24,12 +24,12 @@ pub enum ClockPhase {
     SampleTrailing,
 }
 
-pub trait SpiMasterClient {
+pub trait SpiMasterClient<'a> {
     /// Called when a read/write operation finishes
     fn read_write_done(
         &self,
-        write_buffer: &'static mut [u8],
-        read_buffer: Option<&'static mut [u8]>,
+        write_buffer: &'a mut [u8],
+        read_buffer: Option<&'a mut [u8]>,
         len: usize,
     );
 }
@@ -72,10 +72,10 @@ pub trait SpiMasterClient {
 ///   pin_b.set();
 ///   write_byte(0xaa); // Uses SampleTrailing
 ///
-pub trait SpiMaster {
+pub trait SpiMaster<'a> {
     type ChipSelect: Copy;
 
-    fn set_client(&self, client: &'static SpiMasterClient);
+    fn set_client(&self, client: &'a SpiMasterClient);
 
     fn init(&self);
     fn is_busy(&self) -> bool;
@@ -88,8 +88,8 @@ pub trait SpiMaster {
     /// the two buffers.
     fn read_write_bytes(
         &self,
-        write_buffer: &'static mut [u8],
-        read_buffer: Option<&'static mut [u8]>,
+        write_buffer: &'a mut [u8],
+        read_buffer: Option<&'a mut [u8]>,
         len: usize,
     ) -> ReturnCode;
     fn write_byte(&self, val: u8);
@@ -125,7 +125,7 @@ pub trait SpiMaster {
 /// SPIMasterDevice provides a chip-specific interface to the SPI Master
 /// hardware. The interface wraps the chip select line so that chip drivers
 /// cannot communicate with different SPI devices.
-pub trait SpiMasterDevice {
+pub trait SpiMasterDevice<'a> {
     /// Setup the SPI settings and speed of the bus.
     fn configure(&self, cpol: ClockPolarity, cpal: ClockPhase, rate: u32);
 
@@ -137,8 +137,8 @@ pub trait SpiMasterDevice {
     /// the two buffers.
     fn read_write_bytes(
         &self,
-        write_buffer: &'static mut [u8],
-        read_buffer: Option<&'static mut [u8]>,
+        write_buffer: &'a mut [u8],
+        read_buffer: Option<&'a mut [u8]>,
         len: usize,
     ) -> ReturnCode;
 
@@ -151,31 +151,31 @@ pub trait SpiMasterDevice {
     fn get_rate(&self) -> u32;
 }
 
-pub trait SpiSlaveClient {
+pub trait SpiSlaveClient<'a> {
     /// This is called whenever the slave is selected by the master
     fn chip_selected(&self);
 
     /// This is called as a DMA interrupt when a transfer has completed
     fn read_write_done(
         &self,
-        write_buffer: Option<&'static mut [u8]>,
-        read_buffer: Option<&'static mut [u8]>,
+        write_buffer: Option<&'a mut [u8]>,
+        read_buffer: Option<&'a mut [u8]>,
         len: usize,
     );
 }
 
-pub trait SpiSlave {
+pub trait SpiSlave<'a> {
     fn init(&self);
     /// Returns true if there is a client.
     fn has_client(&self) -> bool;
 
-    fn set_client(&self, client: Option<&'static SpiSlaveClient>);
+    fn set_client(&self, client: Option<&'a SpiSlaveClient>);
 
     fn set_write_byte(&self, write_byte: u8);
     fn read_write_bytes(
         &self,
-        write_buffer: Option<&'static mut [u8]>,
-        read_buffer: Option<&'static mut [u8]>,
+        write_buffer: Option<&'a mut [u8]>,
+        read_buffer: Option<&'a mut [u8]>,
         len: usize,
     ) -> ReturnCode;
 
@@ -188,7 +188,7 @@ pub trait SpiSlave {
 /// SPISlaveDevice provides a chip-specific interface to the SPI Slave
 /// hardware. The interface wraps the chip select line so that chip drivers
 /// cannot communicate with different SPI devices.
-pub trait SpiSlaveDevice {
+pub trait SpiSlaveDevice<'a> {
     /// Setup the SPI settings and speed of the bus.
     fn configure(&self, cpol: ClockPolarity, cpal: ClockPhase);
 
@@ -199,8 +199,8 @@ pub trait SpiSlaveDevice {
     /// minimum of the size of the two buffers.
     fn read_write_bytes(
         &self,
-        write_buffer: Option<&'static mut [u8]>,
-        read_buffer: Option<&'static mut [u8]>,
+        write_buffer: Option<&'a mut [u8]>,
+        read_buffer: Option<&'a mut [u8]>,
         len: usize,
     ) -> ReturnCode;
 

--- a/kernel/src/hil/symmetric_encryption.rs
+++ b/kernel/src/hil/symmetric_encryption.rs
@@ -96,21 +96,21 @@ pub trait AES128CBC {
     fn set_mode_aes128cbc(&self, encrypting: bool);
 }
 
-pub trait CCMClient {
+pub trait CCMClient<'a> {
     /// `res` is SUCCESS if the encryption/decryption process succeeded. This
     /// does not mean that the message has been verified in the case of
     /// decryption.
     /// If we are encrypting: `tag_is_valid` is `true` iff `res` is SUCCESS.
     /// If we are decrypting: `tag_is_valid` is `true` iff `res` is SUCCESS and the
     /// message authentication tag is valid.
-    fn crypt_done(&self, buf: &'static mut [u8], res: ReturnCode, tag_is_valid: bool);
+    fn crypt_done(&self, buf: &'a mut [u8], res: ReturnCode, tag_is_valid: bool);
 }
 
 pub const CCM_NONCE_LENGTH: usize = 13;
 
 pub trait AES128CCM<'a> {
     /// Set the client instance which will receive `crypt_done()` callbacks
-    fn set_client(&'a self, client: &'a CCMClient);
+    fn set_client(&'a self, client: &'a CCMClient<'a>);
 
     /// Set the key to be used for CCM encryption
     fn set_key(&self, key: &[u8]) -> ReturnCode;
@@ -121,12 +121,12 @@ pub trait AES128CCM<'a> {
     /// Try to begin the encryption/decryption process
     fn crypt(
         &self,
-        buf: &'static mut [u8],
+        buf: &'a mut [u8],
         a_off: usize,
         m_off: usize,
         m_len: usize,
         mic_len: usize,
         confidential: bool,
         encrypting: bool,
-    ) -> (ReturnCode, Option<&'static mut [u8]>);
+    ) -> (ReturnCode, Option<&'a mut [u8]>);
 }

--- a/kernel/src/hil/uart.rs
+++ b/kernel/src/hil/uart.rs
@@ -1,12 +1,14 @@
 //! Interfaces for UART communications.
 
-#[derive(Copy, Clone, Debug)]
+use returncode::ReturnCode;
+
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub enum StopBits {
     One = 0,
     Two = 2,
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub enum Parity {
     None = 0,
     Odd = 1,
@@ -14,7 +16,7 @@ pub enum Parity {
 }
 
 #[derive(Copy, Clone, Debug)]
-pub struct UARTParams {
+pub struct UARTParameters {
     pub baud_rate: u32, // baud rate in bit/s
     pub stop_bits: StopBits,
     pub parity: Parity,
@@ -48,10 +50,16 @@ pub trait UART {
     /// called when events finish.
     fn set_client(&self, client: &'static Client);
 
-    /// Initialize UART
+    /// Configure UART
     ///
-    /// Panics if UARTParams are invalid for the current chip.
-    fn init(&self, params: UARTParams);
+    /// Returns SUCCESS, or
+    ///
+    /// - EOFF: The underlying hardware is currently not available, perhaps
+    ///         because it has not been initialized or in the case of a shared
+    ///         hardware USART controller because it is set up for SPI.
+    /// - EINVAL: Impossible parameters (e.g. a `baud_rate` of 0)
+    /// - ENOSUPPORT: The underlying UART cannot satisfy this configuration.
+    fn configure(&self, params: UARTParameters) -> ReturnCode;
 
     /// Transmit data.
     fn transmit(&self, tx_data: &'static mut [u8], tx_len: usize);

--- a/kernel/src/hil/uart.rs
+++ b/kernel/src/hil/uart.rs
@@ -45,10 +45,10 @@ pub enum Error {
     CommandComplete,
 }
 
-pub trait UART {
+pub trait UART<'a> {
     /// Set the client for this UART peripheral. The client will be
     /// called when events finish.
-    fn set_client(&self, client: &'static Client);
+    fn set_client(&'a self, client: &'a Client<'a>);
 
     /// Configure UART
     ///
@@ -59,17 +59,17 @@ pub trait UART {
     ///         hardware USART controller because it is set up for SPI.
     /// - EINVAL: Impossible parameters (e.g. a `baud_rate` of 0)
     /// - ENOSUPPORT: The underlying UART cannot satisfy this configuration.
-    fn configure(&self, params: UARTParameters) -> ReturnCode;
+    fn configure(&'a self, params: UARTParameters) -> ReturnCode;
 
     /// Transmit data.
-    fn transmit(&self, tx_data: &'static mut [u8], tx_len: usize);
+    fn transmit(&'a self, tx_data: &'a mut [u8], tx_len: usize);
 
     /// Receive data until buffer is full.
-    fn receive(&self, rx_buffer: &'static mut [u8], rx_len: usize);
+    fn receive(&'a self, rx_buffer: &'a mut [u8], rx_len: usize);
 
     /// Abort any ongoing receive transfers and return what is in the
     /// receive buffer with the `receive_complete` callback.
-    fn abort_receive(&self);
+    fn abort_receive(&'a self);
 }
 
 /// Trait that isn't required for basic UART operation, but provides useful
@@ -89,20 +89,20 @@ pub trait UART {
 /// - `receive_len_then_message`: This would do a one byte read to get a length
 ///   byte and then read that many more bytes from UART before returning to the
 ///   client.
-pub trait UARTReceiveAdvanced: UART {
+pub trait UARTReceiveAdvanced<'a>: UART<'a> {
     /// Receive data until `interbyte_timeout` bit periods have passed since the
     /// last byte or buffer is full. Does not timeout until at least one byte
     /// has been received.
     ///
     /// * `interbyte_timeout`: number of bit periods since last data received.
-    fn receive_automatic(&self, rx_buffer: &'static mut [u8], interbyte_timeout: u8);
+    fn receive_automatic(&self, rx_buffer: &'a mut [u8], interbyte_timeout: u8);
 }
 
 /// Implement Client to receive callbacks from UART.
-pub trait Client {
+pub trait Client<'a> {
     /// UART transmit complete.
-    fn transmit_complete(&self, tx_buffer: &'static mut [u8], error: Error);
+    fn transmit_complete(&self, tx_buffer: &'a mut [u8], error: Error);
 
     /// UART receive complete.
-    fn receive_complete(&self, rx_buffer: &'static mut [u8], rx_len: usize, error: Error);
+    fn receive_complete(&self, rx_buffer: &'a mut [u8], rx_len: usize, error: Error);
 }


### PR DESCRIPTION
### Pull Request Overview

Implements RFC #1074 for UART and SPI.

I started this a few days ago, but it became a bit of a 'give a mouse a cookie' situation. The goal was to make the UART HIL generic, but because the Sam4l USART mixes UART and SPI, this required making the SPI HIL support generic lifetimes as well. Then we're down a rabbit hole of co-dependencies, as making SPI support generic lifetimes required the Flash (which begat nonvolatile) and Radio (which begat crypto) HILs to update as well.

The current state is stuck on some lifetime issue in the networking stack that I haven't quite been able to resolve yet. However, I'm not going to be able to pick up this thread again for a few days at least, so I wanted to throw this out here in case anyone wanted to build on it.

### Testing Strategy

(Failing to) compile.


### TODO or Help Wanted

This pull request still needs to fixup some more lifetimes.

### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make formatall`.
