### PR TITLE
Instructions for flashing processes on launchxl

### DIFF
--- a/boards/launchxl/README.md
+++ b/boards/launchxl/README.md
@@ -146,13 +146,20 @@ JLinkExe:
 $ make flash-jlink       # make and flash the kernel
 ```
 
-### Flashing apps
+### Flashing processes
 
-You can flash apps by navigating to their directory, and by invoking `make
-flash` once again, or call Tockloader directly:
+You can flash processes using Tockloader.
+
+OpenOCD:
 
 ```bash
-$ tockloader install --board launchxl-cc26x2r1 --openocd
+$ tockloader install --board launchxl-cc26x2r1 --openocd [PATH_TO_PROCESS]
+```
+
+JLinkExe:
+
+```bash
+$ tockloader install --board launchxl-cc26x2r1 --jlink [PATH_TO_PROCESS]
 ```
 
 ### Debugging


### PR DESCRIPTION
### Pull Request Overview

Adds instructions in the launchxl board's README for how to flash processes using both OpenOCD and JLink (supported now thanks to tock/tockloader#34).

### Testing Strategy

N/A

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
