### PR TITLE
Kernel: Move `PROCS` array to `Kernel` struct

### DIFF
--- a/boards/ek-tm4c1294xl/src/io.rs
+++ b/boards/ek-tm4c1294xl/src/io.rs
@@ -7,6 +7,8 @@ use kernel::hil::led;
 use kernel::hil::uart::{self, UART};
 use tm4c129x;
 
+use PROCESSES;
+
 pub struct Writer {
     initialized: bool,
 }
@@ -44,5 +46,5 @@ impl Write for Writer {
 pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
     let led = &mut led::LedLow::new(&mut tm4c129x::gpio::PF[0]);
     let writer = &mut WRITER;
-    debug::panic(&mut [led], writer, pi, &cortexm4::support::nop)
+    debug::panic(&mut [led], writer, pi, &cortexm4::support::nop, &PROCESSES)
 }

--- a/boards/ek-tm4c1294xl/src/main.rs
+++ b/boards/ek-tm4c1294xl/src/main.rs
@@ -101,7 +101,7 @@ pub unsafe fn reset_handler() {
             115200,
             &mut capsules::console::WRITE_BUF,
             &mut capsules::console::READ_BUF,
-            kernel::Grant::create(board_kernel)
+            board_kernel.create_grant()
         )
     );
     hil::uart::UART::set_client(console_uart, console);
@@ -139,7 +139,7 @@ pub unsafe fn reset_handler() {
     );
     let alarm = static_init!(
         capsules::alarm::AlarmDriver<'static, VirtualMuxAlarm<'static, tm4c129x::gpt::AlarmTimer>>,
-        capsules::alarm::AlarmDriver::new(virtual_alarm1, kernel::Grant::create(board_kernel))
+        capsules::alarm::AlarmDriver::new(virtual_alarm1, board_kernel.create_grant())
     );
     virtual_alarm1.set_client(alarm);
 
@@ -189,7 +189,7 @@ pub unsafe fn reset_handler() {
     );
     let button = static_init!(
         capsules::button::Button<'static, tm4c129x::gpio::GPIOPin>,
-        capsules::button::Button::new(button_pins, kernel::Grant::create(board_kernel))
+        capsules::button::Button::new(button_pins, board_kernel.create_grant())
     );
     for &(btn, _) in button_pins.iter() {
         btn.set_client(button);

--- a/boards/ek-tm4c1294xl/src/main.rs
+++ b/boards/ek-tm4c1294xl/src/main.rs
@@ -33,7 +33,7 @@ const FAULT_RESPONSE: kernel::procs::FaultResponse = kernel::procs::FaultRespons
 static mut APP_MEMORY: [u8; 10240] = [0; 10240];
 
 // Actual memory for holding the active process structures.
-static mut PROCESSES: [Option<&'static mut kernel::procs::Process<'static>>; NUM_PROCS] =
+static mut PROCESSES: [Option<&'static kernel::procs::Process<'static>>; NUM_PROCS] =
     [None, None, None, None];
 
 /// Dummy buffer that causes the linker to reserve enough space for the stack.
@@ -81,6 +81,8 @@ pub unsafe fn reset_handler() {
     tm4c129x::sysctl::PSYSCTLM
         .setup_system_clock(tm4c129x::sysctl::SystemClockSource::PllPioscAt120MHz);
 
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
+
     // Create a shared UART channel for the console and for kernel debug.
     let uart_mux = static_init!(
         UartMux<'static>,
@@ -99,7 +101,7 @@ pub unsafe fn reset_handler() {
             115200,
             &mut capsules::console::WRITE_BUF,
             &mut capsules::console::READ_BUF,
-            kernel::Grant::create()
+            kernel::Grant::create(board_kernel)
         )
     );
     hil::uart::UART::set_client(console_uart, console);
@@ -137,7 +139,7 @@ pub unsafe fn reset_handler() {
     );
     let alarm = static_init!(
         capsules::alarm::AlarmDriver<'static, VirtualMuxAlarm<'static, tm4c129x::gpt::AlarmTimer>>,
-        capsules::alarm::AlarmDriver::new(virtual_alarm1, kernel::Grant::create())
+        capsules::alarm::AlarmDriver::new(virtual_alarm1, kernel::Grant::create(board_kernel))
     );
     virtual_alarm1.set_client(alarm);
 
@@ -187,7 +189,7 @@ pub unsafe fn reset_handler() {
     );
     let button = static_init!(
         capsules::button::Button<'static, tm4c129x::gpio::GPIOPin>,
-        capsules::button::Button::new(button_pins, kernel::Grant::create())
+        capsules::button::Button::new(button_pins, kernel::Grant::create(board_kernel))
     );
     for &(btn, _) in button_pins.iter() {
         btn.set_client(button);
@@ -215,7 +217,7 @@ pub unsafe fn reset_handler() {
         console: console,
         alarm: alarm,
         gpio: gpio,
-        ipc: kernel::ipc::IPC::new(),
+        ipc: kernel::ipc::IPC::new(board_kernel),
         led: led,
         button: button,
     };
@@ -225,8 +227,6 @@ pub unsafe fn reset_handler() {
     tm4c1294.console.initialize();
 
     debug!("Initialization complete. Entering main loop...\r");
-
-    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new());
 
     extern "C" {
         /// Beginning of the ROM region containing app images.
@@ -241,5 +241,5 @@ pub unsafe fn reset_handler() {
         &mut PROCESSES,
         FAULT_RESPONSE,
     );
-    board_kernel.kernel_loop(&tm4c1294, &mut chip, &mut PROCESSES, Some(&tm4c1294.ipc));
+    board_kernel.kernel_loop(&tm4c1294, &mut chip, Some(&tm4c1294.ipc));
 }

--- a/boards/hail/src/io.rs
+++ b/boards/hail/src/io.rs
@@ -7,6 +7,8 @@ use kernel::hil::led;
 use kernel::hil::uart::{self, UART};
 use sam4l;
 
+use PROCESSES;
+
 struct Writer {
     initialized: bool,
 }
@@ -51,5 +53,11 @@ pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
 
     let led_red = &mut led::LedLow::new(&mut sam4l::gpio::PA[13]);
     let writer = &mut WRITER;
-    debug::panic(&mut [led_red], writer, pi, &cortexm4::support::nop)
+    debug::panic(
+        &mut [led_red],
+        writer,
+        pi,
+        &cortexm4::support::nop,
+        &PROCESSES,
+    )
 }

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -223,7 +223,7 @@ pub unsafe fn reset_handler() {
             115200,
             &mut capsules::console::WRITE_BUF,
             &mut capsules::console::READ_BUF,
-            kernel::Grant::create(board_kernel)
+            board_kernel.create_grant()
         )
     );
     hil::uart::UART::set_client(console_uart, console);
@@ -276,13 +276,13 @@ pub unsafe fn reset_handler() {
 
     let temp = static_init!(
         capsules::temperature::TemperatureSensor<'static>,
-        capsules::temperature::TemperatureSensor::new(si7021, kernel::Grant::create(board_kernel))
+        capsules::temperature::TemperatureSensor::new(si7021, board_kernel.create_grant())
     );
     kernel::hil::sensors::TemperatureDriver::set_client(si7021, temp);
 
     let humidity = static_init!(
         capsules::humidity::HumiditySensor<'static>,
-        capsules::humidity::HumiditySensor::new(si7021, kernel::Grant::create(board_kernel))
+        capsules::humidity::HumiditySensor::new(si7021, board_kernel.create_grant())
     );
     kernel::hil::sensors::HumidityDriver::set_client(si7021, humidity);
 
@@ -305,7 +305,7 @@ pub unsafe fn reset_handler() {
 
     let ambient_light = static_init!(
         capsules::ambient_light::AmbientLight<'static>,
-        capsules::ambient_light::AmbientLight::new(isl29035, kernel::Grant::create(board_kernel))
+        capsules::ambient_light::AmbientLight::new(isl29035, board_kernel.create_grant())
     );
     hil::sensors::AmbientLight::set_client(isl29035, ambient_light);
 
@@ -316,7 +316,7 @@ pub unsafe fn reset_handler() {
     );
     let alarm = static_init!(
         capsules::alarm::AlarmDriver<'static, VirtualMuxAlarm<'static, sam4l::ast::Ast>>,
-        capsules::alarm::AlarmDriver::new(virtual_alarm1, kernel::Grant::create(board_kernel))
+        capsules::alarm::AlarmDriver::new(virtual_alarm1, board_kernel.create_grant())
     );
     virtual_alarm1.set_client(alarm);
 
@@ -335,7 +335,7 @@ pub unsafe fn reset_handler() {
 
     let ninedof = static_init!(
         capsules::ninedof::NineDof<'static>,
-        capsules::ninedof::NineDof::new(fxos8700, kernel::Grant::create(board_kernel))
+        capsules::ninedof::NineDof::new(fxos8700, board_kernel.create_grant())
     );
     hil::sensors::NineDof::set_client(fxos8700, ninedof);
 
@@ -398,7 +398,7 @@ pub unsafe fn reset_handler() {
     );
     let button = static_init!(
         capsules::button::Button<'static, sam4l::gpio::GPIOPin>,
-        capsules::button::Button::new(button_pins, kernel::Grant::create(board_kernel))
+        capsules::button::Button::new(button_pins, board_kernel.create_grant())
     );
     for &(btn, _) in button_pins.iter() {
         btn.set_client(button);
@@ -431,7 +431,7 @@ pub unsafe fn reset_handler() {
     // Setup RNG
     let rng = static_init!(
         capsules::rng::SimpleRng<'static, sam4l::trng::Trng>,
-        capsules::rng::SimpleRng::new(&sam4l::trng::TRNG, kernel::Grant::create(board_kernel))
+        capsules::rng::SimpleRng::new(&sam4l::trng::TRNG, board_kernel.create_grant())
     );
     sam4l::trng::TRNG.set_client(rng);
 
@@ -456,10 +456,7 @@ pub unsafe fn reset_handler() {
     // CRC
     let crc = static_init!(
         capsules::crc::Crc<'static, sam4l::crccu::Crccu<'static>>,
-        capsules::crc::Crc::new(
-            &mut sam4l::crccu::CRCCU,
-            kernel::Grant::create(board_kernel)
-        )
+        capsules::crc::Crc::new(&mut sam4l::crccu::CRCCU, board_kernel.create_grant())
     );
     sam4l::crccu::CRCCU.set_client(crc);
 

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -48,7 +48,7 @@ const FAULT_RESPONSE: kernel::procs::FaultResponse = kernel::procs::FaultRespons
 static mut APP_MEMORY: [u8; 49152] = [0; 49152];
 
 // Actual memory for holding the active process structures.
-static mut PROCESSES: [Option<&'static mut kernel::procs::Process<'static>>; NUM_PROCS] = [
+static mut PROCESSES: [Option<&'static kernel::procs::Process<'static>>; NUM_PROCS] = [
     None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None,
     None, None, None, None,
 ];
@@ -192,6 +192,8 @@ pub unsafe fn reset_handler() {
 
     set_pin_primary_functions();
 
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
+
     // Configure kernel debug gpios as early as possible
     kernel::debug::assign_gpios(
         Some(&sam4l::gpio::PA[13]),
@@ -221,7 +223,7 @@ pub unsafe fn reset_handler() {
             115200,
             &mut capsules::console::WRITE_BUF,
             &mut capsules::console::READ_BUF,
-            kernel::Grant::create()
+            kernel::Grant::create(board_kernel)
         )
     );
     hil::uart::UART::set_client(console_uart, console);
@@ -274,13 +276,13 @@ pub unsafe fn reset_handler() {
 
     let temp = static_init!(
         capsules::temperature::TemperatureSensor<'static>,
-        capsules::temperature::TemperatureSensor::new(si7021, kernel::Grant::create())
+        capsules::temperature::TemperatureSensor::new(si7021, kernel::Grant::create(board_kernel))
     );
     kernel::hil::sensors::TemperatureDriver::set_client(si7021, temp);
 
     let humidity = static_init!(
         capsules::humidity::HumiditySensor<'static>,
-        capsules::humidity::HumiditySensor::new(si7021, kernel::Grant::create())
+        capsules::humidity::HumiditySensor::new(si7021, kernel::Grant::create(board_kernel))
     );
     kernel::hil::sensors::HumidityDriver::set_client(si7021, humidity);
 
@@ -303,7 +305,7 @@ pub unsafe fn reset_handler() {
 
     let ambient_light = static_init!(
         capsules::ambient_light::AmbientLight<'static>,
-        capsules::ambient_light::AmbientLight::new(isl29035, kernel::Grant::create())
+        capsules::ambient_light::AmbientLight::new(isl29035, kernel::Grant::create(board_kernel))
     );
     hil::sensors::AmbientLight::set_client(isl29035, ambient_light);
 
@@ -314,7 +316,7 @@ pub unsafe fn reset_handler() {
     );
     let alarm = static_init!(
         capsules::alarm::AlarmDriver<'static, VirtualMuxAlarm<'static, sam4l::ast::Ast>>,
-        capsules::alarm::AlarmDriver::new(virtual_alarm1, kernel::Grant::create())
+        capsules::alarm::AlarmDriver::new(virtual_alarm1, kernel::Grant::create(board_kernel))
     );
     virtual_alarm1.set_client(alarm);
 
@@ -333,7 +335,7 @@ pub unsafe fn reset_handler() {
 
     let ninedof = static_init!(
         capsules::ninedof::NineDof<'static>,
-        capsules::ninedof::NineDof::new(fxos8700, kernel::Grant::create())
+        capsules::ninedof::NineDof::new(fxos8700, kernel::Grant::create(board_kernel))
     );
     hil::sensors::NineDof::set_client(fxos8700, ninedof);
 
@@ -396,7 +398,7 @@ pub unsafe fn reset_handler() {
     );
     let button = static_init!(
         capsules::button::Button<'static, sam4l::gpio::GPIOPin>,
-        capsules::button::Button::new(button_pins, kernel::Grant::create())
+        capsules::button::Button::new(button_pins, kernel::Grant::create(board_kernel))
     );
     for &(btn, _) in button_pins.iter() {
         btn.set_client(button);
@@ -429,7 +431,7 @@ pub unsafe fn reset_handler() {
     // Setup RNG
     let rng = static_init!(
         capsules::rng::SimpleRng<'static, sam4l::trng::Trng>,
-        capsules::rng::SimpleRng::new(&sam4l::trng::TRNG, kernel::Grant::create())
+        capsules::rng::SimpleRng::new(&sam4l::trng::TRNG, kernel::Grant::create(board_kernel))
     );
     sam4l::trng::TRNG.set_client(rng);
 
@@ -454,7 +456,10 @@ pub unsafe fn reset_handler() {
     // CRC
     let crc = static_init!(
         capsules::crc::Crc<'static, sam4l::crccu::Crccu<'static>>,
-        capsules::crc::Crc::new(&mut sam4l::crccu::CRCCU, kernel::Grant::create())
+        capsules::crc::Crc::new(
+            &mut sam4l::crccu::CRCCU,
+            kernel::Grant::create(board_kernel)
+        )
     );
     sam4l::crccu::CRCCU.set_client(crc);
 
@@ -478,7 +483,7 @@ pub unsafe fn reset_handler() {
         led: led,
         button: button,
         rng: rng,
-        ipc: kernel::ipc::IPC::new(),
+        ipc: kernel::ipc::IPC::new(board_kernel),
         crc: crc,
         dac: dac,
     };
@@ -513,8 +518,6 @@ pub unsafe fn reset_handler() {
 
     debug!("Initialization complete. Entering main loop");
 
-    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new());
-
     extern "C" {
         /// Beginning of the ROM region containing app images.
         ///
@@ -529,5 +532,5 @@ pub unsafe fn reset_handler() {
         &mut PROCESSES,
         FAULT_RESPONSE,
     );
-    board_kernel.kernel_loop(&hail, &mut chip, &mut PROCESSES, Some(&hail.ipc));
+    board_kernel.kernel_loop(&hail, &mut chip, Some(&hail.ipc));
 }

--- a/boards/imix/src/components/alarm.rs
+++ b/boards/imix/src/components/alarm.rs
@@ -21,12 +21,19 @@ use kernel::component::Component;
 use sam4l;
 
 pub struct AlarmDriverComponent {
+    board_kernel: &'static kernel::Kernel,
     alarm_mux: &'static MuxAlarm<'static, sam4l::ast::Ast<'static>>,
 }
 
 impl AlarmDriverComponent {
-    pub fn new(mux: &'static MuxAlarm<'static, sam4l::ast::Ast>) -> AlarmDriverComponent {
-        AlarmDriverComponent { alarm_mux: mux }
+    pub fn new(
+        board_kernel: &'static kernel::Kernel,
+        mux: &'static MuxAlarm<'static, sam4l::ast::Ast>,
+    ) -> AlarmDriverComponent {
+        AlarmDriverComponent {
+            board_kernel: board_kernel,
+            alarm_mux: mux,
+        }
     }
 }
 
@@ -40,7 +47,7 @@ impl Component for AlarmDriverComponent {
         );
         let alarm = static_init!(
             AlarmDriver<'static, VirtualMuxAlarm<'static, sam4l::ast::Ast>>,
-            AlarmDriver::new(virtual_alarm1, kernel::Grant::create())
+            AlarmDriver::new(virtual_alarm1, kernel::Grant::create(self.board_kernel))
         );
 
         virtual_alarm1.set_client(alarm);

--- a/boards/imix/src/components/alarm.rs
+++ b/boards/imix/src/components/alarm.rs
@@ -47,7 +47,7 @@ impl Component for AlarmDriverComponent {
         );
         let alarm = static_init!(
             AlarmDriver<'static, VirtualMuxAlarm<'static, sam4l::ast::Ast>>,
-            AlarmDriver::new(virtual_alarm1, kernel::Grant::create(self.board_kernel))
+            AlarmDriver::new(virtual_alarm1, self.board_kernel.create_grant())
         );
 
         virtual_alarm1.set_client(alarm);

--- a/boards/imix/src/components/button.rs
+++ b/boards/imix/src/components/button.rs
@@ -20,11 +20,15 @@ use kernel;
 use kernel::component::Component;
 use sam4l;
 
-pub struct ButtonComponent {}
+pub struct ButtonComponent {
+    board_kernel: &'static kernel::Kernel,
+}
 
 impl ButtonComponent {
-    pub fn new() -> ButtonComponent {
-        ButtonComponent {}
+    pub fn new(board_kernel: &'static kernel::Kernel) -> ButtonComponent {
+        ButtonComponent {
+            board_kernel: board_kernel,
+        }
     }
 }
 
@@ -39,7 +43,7 @@ impl Component for ButtonComponent {
 
         let button = static_init!(
             button::Button<'static, sam4l::gpio::GPIOPin>,
-            button::Button::new(button_pins, kernel::Grant::create())
+            button::Button::new(button_pins, kernel::Grant::create(self.board_kernel))
         );
         for &(btn, _) in button_pins.iter() {
             btn.set_client(button);

--- a/boards/imix/src/components/button.rs
+++ b/boards/imix/src/components/button.rs
@@ -43,7 +43,7 @@ impl Component for ButtonComponent {
 
         let button = static_init!(
             button::Button<'static, sam4l::gpio::GPIOPin>,
-            button::Button::new(button_pins, kernel::Grant::create(self.board_kernel))
+            button::Button::new(button_pins, self.board_kernel.create_grant())
         );
         for &(btn, _) in button_pins.iter() {
             btn.set_client(button);

--- a/boards/imix/src/components/console.rs
+++ b/boards/imix/src/components/console.rs
@@ -22,7 +22,6 @@ use capsules::virtual_uart::{UartDevice, UartMux};
 use hil;
 use kernel;
 use kernel::component::Component;
-use kernel::Grant;
 
 pub struct ConsoleComponent {
     board_kernel: &'static kernel::Kernel,
@@ -58,7 +57,7 @@ impl Component for ConsoleComponent {
                 self.baud_rate,
                 &mut console::WRITE_BUF,
                 &mut console::READ_BUF,
-                Grant::create(self.board_kernel)
+                self.board_kernel.create_grant()
             )
         );
         hil::uart::UART::set_client(console_uart, console);

--- a/boards/imix/src/components/console.rs
+++ b/boards/imix/src/components/console.rs
@@ -25,13 +25,19 @@ use kernel::component::Component;
 use kernel::Grant;
 
 pub struct ConsoleComponent {
+    board_kernel: &'static kernel::Kernel,
     uart_mux: &'static UartMux<'static>,
     baud_rate: u32,
 }
 
 impl ConsoleComponent {
-    pub fn new(uart_mux: &'static UartMux, rate: u32) -> ConsoleComponent {
+    pub fn new(
+        board_kernel: &'static kernel::Kernel,
+        uart_mux: &'static UartMux,
+        rate: u32,
+    ) -> ConsoleComponent {
         ConsoleComponent {
+            board_kernel: board_kernel,
             uart_mux: uart_mux,
             baud_rate: rate,
         }
@@ -52,7 +58,7 @@ impl Component for ConsoleComponent {
                 self.baud_rate,
                 &mut console::WRITE_BUF,
                 &mut console::READ_BUF,
-                Grant::create()
+                Grant::create(self.board_kernel)
             )
         );
         hil::uart::UART::set_client(console_uart, console);

--- a/boards/imix/src/components/crc.rs
+++ b/boards/imix/src/components/crc.rs
@@ -38,10 +38,7 @@ impl Component for CrcComponent {
     unsafe fn finalize(&mut self) -> Self::Output {
         let crc = static_init!(
             crc::Crc<'static, sam4l::crccu::Crccu<'static>>,
-            crc::Crc::new(
-                &mut sam4l::crccu::CRCCU,
-                kernel::Grant::create(self.board_kernel)
-            )
+            crc::Crc::new(&mut sam4l::crccu::CRCCU, self.board_kernel.create_grant())
         );
 
         crc

--- a/boards/imix/src/components/crc.rs
+++ b/boards/imix/src/components/crc.rs
@@ -20,11 +20,15 @@ use kernel;
 use kernel::component::Component;
 use sam4l;
 
-pub struct CrcComponent {}
+pub struct CrcComponent {
+    board_kernel: &'static kernel::Kernel,
+}
 
 impl CrcComponent {
-    pub fn new() -> CrcComponent {
-        CrcComponent {}
+    pub fn new(board_kernel: &'static kernel::Kernel) -> CrcComponent {
+        CrcComponent {
+            board_kernel: board_kernel,
+        }
     }
 }
 
@@ -34,7 +38,10 @@ impl Component for CrcComponent {
     unsafe fn finalize(&mut self) -> Self::Output {
         let crc = static_init!(
             crc::Crc<'static, sam4l::crccu::Crccu<'static>>,
-            crc::Crc::new(&mut sam4l::crccu::CRCCU, kernel::Grant::create())
+            crc::Crc::new(
+                &mut sam4l::crccu::CRCCU,
+                kernel::Grant::create(self.board_kernel)
+            )
         );
 
         crc

--- a/boards/imix/src/components/fxos8700.rs
+++ b/boards/imix/src/components/fxos8700.rs
@@ -97,7 +97,7 @@ impl Component for NineDofComponent {
 
         let ninedof = static_init!(
             NineDof<'static>,
-            NineDof::new(fxos8700, Grant::create(self.board_kernel))
+            NineDof::new(fxos8700, self.board_kernel.create_grant())
         );
         hil::sensors::NineDof::set_client(fxos8700, ninedof);
 

--- a/boards/imix/src/components/fxos8700.rs
+++ b/boards/imix/src/components/fxos8700.rs
@@ -26,6 +26,7 @@ use capsules::fxos8700cq;
 use capsules::ninedof::NineDof;
 use capsules::virtual_i2c::{I2CDevice, MuxI2C};
 use hil;
+use kernel;
 use kernel::component::Component;
 use kernel::Grant;
 use sam4l;
@@ -63,16 +64,19 @@ impl Component for Fxos8700Component {
 }
 
 pub struct NineDofComponent {
+    board_kernel: &'static kernel::Kernel,
     i2c_mux: &'static MuxI2C<'static>,
     gpio: &'static sam4l::gpio::GPIOPin,
 }
 
 impl NineDofComponent {
     pub fn new(
+        board_kernel: &'static kernel::Kernel,
         i2c: &'static MuxI2C<'static>,
         gpio: &'static sam4l::gpio::GPIOPin,
     ) -> NineDofComponent {
         NineDofComponent {
+            board_kernel: board_kernel,
             i2c_mux: i2c,
             gpio: gpio,
         }
@@ -91,7 +95,10 @@ impl Component for NineDofComponent {
         fxos8700_i2c.set_client(fxos8700);
         self.gpio.set_client(fxos8700);
 
-        let ninedof = static_init!(NineDof<'static>, NineDof::new(fxos8700, Grant::create()));
+        let ninedof = static_init!(
+            NineDof<'static>,
+            NineDof::new(fxos8700, Grant::create(self.board_kernel))
+        );
         hil::sensors::NineDof::set_client(fxos8700, ninedof);
 
         ninedof

--- a/boards/imix/src/components/isl29035.rs
+++ b/boards/imix/src/components/isl29035.rs
@@ -28,7 +28,6 @@ use capsules::virtual_i2c::{I2CDevice, MuxI2C};
 use hil;
 use kernel;
 use kernel::component::Component;
-use kernel::Grant;
 use sam4l;
 
 pub struct Isl29035Component {
@@ -112,7 +111,7 @@ impl Component for AmbientLightComponent {
         isl29035_virtual_alarm.set_client(isl29035);
         let ambient_light = static_init!(
             AmbientLight<'static>,
-            AmbientLight::new(isl29035, Grant::create(self.board_kernel))
+            AmbientLight::new(isl29035, self.board_kernel.create_grant())
         );
         hil::sensors::AmbientLight::set_client(isl29035, ambient_light);
         ambient_light

--- a/boards/imix/src/components/nonvolatile_storage.rs
+++ b/boards/imix/src/components/nonvolatile_storage.rs
@@ -23,11 +23,15 @@ use kernel::component::Component;
 use kernel::hil;
 use sam4l;
 
-pub struct NonvolatileStorageComponent;
+pub struct NonvolatileStorageComponent {
+    board_kernel: &'static kernel::Kernel,
+}
 
 impl NonvolatileStorageComponent {
-    pub fn new() -> Self {
-        NonvolatileStorageComponent {}
+    pub fn new(board_kernel: &'static kernel::Kernel) -> Self {
+        NonvolatileStorageComponent {
+            board_kernel: board_kernel,
+        }
     }
 }
 
@@ -63,7 +67,7 @@ impl Component for NonvolatileStorageComponent {
             NonvolatileStorage<'static>,
             NonvolatileStorage::new(
                 nv_to_page,
-                kernel::Grant::create(),
+                kernel::Grant::create(self.board_kernel),
                 0x60000,      // Start address for userspace accessible region
                 0x20000,      // Length of userspace accessible region
                 kernel_start, // Start address of kernel region

--- a/boards/imix/src/components/nonvolatile_storage.rs
+++ b/boards/imix/src/components/nonvolatile_storage.rs
@@ -67,7 +67,7 @@ impl Component for NonvolatileStorageComponent {
             NonvolatileStorage<'static>,
             NonvolatileStorage::new(
                 nv_to_page,
-                kernel::Grant::create(self.board_kernel),
+                self.board_kernel.create_grant(),
                 0x60000,      // Start address for userspace accessible region
                 0x20000,      // Length of userspace accessible region
                 kernel_start, // Start address of kernel region

--- a/boards/imix/src/components/radio.rs
+++ b/boards/imix/src/components/radio.rs
@@ -114,7 +114,7 @@ impl Component for RadioComponent {
             capsules::ieee802154::RadioDriver<'static>,
             capsules::ieee802154::RadioDriver::new(
                 radio_mac,
-                kernel::Grant::create(self.board_kernel),
+                self.board_kernel.create_grant(),
                 &mut RADIO_BUF
             )
         );

--- a/boards/imix/src/components/radio.rs
+++ b/boards/imix/src/components/radio.rs
@@ -33,6 +33,7 @@ type RF233Device =
     capsules::rf233::RF233<'static, VirtualSpiMasterDevice<'static, sam4l::spi::SpiHw>>;
 
 pub struct RadioComponent {
+    board_kernel: &'static kernel::Kernel,
     rf233: &'static RF233Device,
     pan_id: capsules::net::ieee802154::PanID,
     short_addr: u16,
@@ -40,11 +41,13 @@ pub struct RadioComponent {
 
 impl RadioComponent {
     pub fn new(
+        board_kernel: &'static kernel::Kernel,
         rf233: &'static RF233Device,
         pan_id: capsules::net::ieee802154::PanID,
         addr: u16,
     ) -> RadioComponent {
         RadioComponent {
+            board_kernel: board_kernel,
             rf233: rf233,
             pan_id: pan_id,
             short_addr: addr,
@@ -111,7 +114,7 @@ impl Component for RadioComponent {
             capsules::ieee802154::RadioDriver<'static>,
             capsules::ieee802154::RadioDriver::new(
                 radio_mac,
-                kernel::Grant::create(),
+                kernel::Grant::create(self.board_kernel),
                 &mut RADIO_BUF
             )
         );

--- a/boards/imix/src/components/si7021.rs
+++ b/boards/imix/src/components/si7021.rs
@@ -27,7 +27,6 @@ use capsules::virtual_i2c::{I2CDevice, MuxI2C};
 use hil;
 use kernel;
 use kernel::component::Component;
-use kernel::Grant;
 use sam4l;
 
 pub struct SI7021Component {
@@ -92,7 +91,7 @@ impl Component for TemperatureComponent {
     unsafe fn finalize(&mut self) -> Self::Output {
         let temp = static_init!(
             TemperatureSensor<'static>,
-            TemperatureSensor::new(self.si7021, Grant::create(self.board_kernel))
+            TemperatureSensor::new(self.si7021, self.board_kernel.create_grant())
         );
 
         hil::sensors::TemperatureDriver::set_client(self.si7021, temp);
@@ -123,7 +122,7 @@ impl Component for HumidityComponent {
     unsafe fn finalize(&mut self) -> Self::Output {
         let hum = static_init!(
             HumiditySensor<'static>,
-            HumiditySensor::new(self.si7021, Grant::create(self.board_kernel))
+            HumiditySensor::new(self.si7021, self.board_kernel.create_grant())
         );
 
         hil::sensors::HumidityDriver::set_client(self.si7021, hum);

--- a/boards/imix/src/components/usb.rs
+++ b/boards/imix/src/components/usb.rs
@@ -19,7 +19,9 @@ use kernel;
 use kernel::component::Component;
 use sam4l;
 
-pub struct UsbComponent {}
+pub struct UsbComponent {
+    board_kernel: &'static kernel::Kernel,
+}
 
 type UsbDevice = capsules::usb_user::UsbSyscallDriver<
     'static,
@@ -27,8 +29,10 @@ type UsbDevice = capsules::usb_user::UsbSyscallDriver<
 >;
 
 impl UsbComponent {
-    pub fn new() -> UsbComponent {
-        UsbComponent {}
+    pub fn new(board_kernel: &'static kernel::Kernel) -> UsbComponent {
+        UsbComponent {
+            board_kernel: board_kernel,
+        }
     }
 }
 
@@ -49,7 +53,10 @@ impl Component for UsbComponent {
                 'static,
                 capsules::usbc_client::Client<'static, sam4l::usbc::Usbc<'static>>,
             >,
-            capsules::usb_user::UsbSyscallDriver::new(usb_client, kernel::Grant::create())
+            capsules::usb_user::UsbSyscallDriver::new(
+                usb_client,
+                kernel::Grant::create(self.board_kernel)
+            )
         );
 
         usb_driver

--- a/boards/imix/src/components/usb.rs
+++ b/boards/imix/src/components/usb.rs
@@ -53,10 +53,7 @@ impl Component for UsbComponent {
                 'static,
                 capsules::usbc_client::Client<'static, sam4l::usbc::Usbc<'static>>,
             >,
-            capsules::usb_user::UsbSyscallDriver::new(
-                usb_client,
-                kernel::Grant::create(self.board_kernel)
-            )
+            capsules::usb_user::UsbSyscallDriver::new(usb_client, self.board_kernel.create_grant())
         );
 
         usb_driver

--- a/boards/imix/src/io.rs
+++ b/boards/imix/src/io.rs
@@ -6,6 +6,8 @@ use kernel::hil::led;
 use kernel::hil::uart::{self, UART};
 use sam4l;
 
+use PROCESSES;
+
 struct Writer {
     initialized: bool,
 }
@@ -42,5 +44,5 @@ impl Write for Writer {
 pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
     let led = &mut led::LedLow::new(&mut sam4l::gpio::PC[10]);
     let writer = &mut WRITER;
-    debug::panic(&mut [led], writer, pi, &cortexm4::support::nop)
+    debug::panic(&mut [led], writer, pi, &cortexm4::support::nop, &PROCESSES)
 }

--- a/boards/launchxl/src/io.rs
+++ b/boards/launchxl/src/io.rs
@@ -6,6 +6,8 @@ use kernel::debug;
 use kernel::hil::led;
 use kernel::hil::uart::{self, UART};
 
+use PROCESSES;
+
 struct Writer {
     initialized: bool,
 }
@@ -41,5 +43,5 @@ pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
 
     let led = &mut led::LedLow::new(&mut cc26xx::gpio::PORT[LED_PIN]);
     let writer = &mut WRITER;
-    debug::panic(&mut [led], writer, pi, &cortexm4::support::nop)
+    debug::panic(&mut [led], writer, pi, &cortexm4::support::nop, &PROCESSES)
 }

--- a/boards/launchxl/src/main.rs
+++ b/boards/launchxl/src/main.rs
@@ -25,8 +25,7 @@ const FAULT_RESPONSE: kernel::procs::FaultResponse = kernel::procs::FaultRespons
 
 // Number of concurrent processes this platform supports.
 const NUM_PROCS: usize = 2;
-static mut PROCESSES: [Option<&'static mut kernel::procs::Process<'static>>; NUM_PROCS] =
-    [None, None];
+static mut PROCESSES: [Option<&'static kernel::procs::Process<'static>>; NUM_PROCS] = [None, None];
 
 #[link_section = ".app_memory"]
 // Give half of RAM to be dedicated APP memory
@@ -79,6 +78,8 @@ pub unsafe fn reset_handler() {
     // Wait for it to turn on until we continue
     while !prcm::Power::is_enabled(prcm::PowerDomain::Peripherals) {}
 
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
+
     // Enable the GPIO clocks
     prcm::Clock::enable_gpio();
 
@@ -120,7 +121,7 @@ pub unsafe fn reset_handler() {
     );
     let button = static_init!(
         capsules::button::Button<'static, cc26xx::gpio::GPIOPin>,
-        capsules::button::Button::new(button_pins, kernel::Grant::create())
+        capsules::button::Button::new(button_pins, kernel::Grant::create(board_kernel))
     );
     for &(btn, _) in button_pins.iter() {
         btn.set_client(button);
@@ -148,7 +149,7 @@ pub unsafe fn reset_handler() {
             115200,
             &mut capsules::console::WRITE_BUF,
             &mut capsules::console::READ_BUF,
-            kernel::Grant::create()
+            kernel::Grant::create(board_kernel)
         )
     );
     kernel::hil::uart::UART::set_client(console_uart, console);
@@ -227,13 +228,13 @@ pub unsafe fn reset_handler() {
             'static,
             capsules::virtual_alarm::VirtualMuxAlarm<'static, cc26x2::rtc::Rtc>,
         >,
-        capsules::alarm::AlarmDriver::new(virtual_alarm1, kernel::Grant::create())
+        capsules::alarm::AlarmDriver::new(virtual_alarm1, kernel::Grant::create(board_kernel))
     );
     virtual_alarm1.set_client(alarm);
 
     let rng = static_init!(
         capsules::rng::SimpleRng<'static, cc26xx::trng::Trng>,
-        capsules::rng::SimpleRng::new(&cc26xx::trng::TRNG, kernel::Grant::create())
+        capsules::rng::SimpleRng::new(&cc26xx::trng::TRNG, kernel::Grant::create(board_kernel))
     );
     cc26xx::trng::TRNG.set_client(rng);
 
@@ -247,8 +248,6 @@ pub unsafe fn reset_handler() {
     };
 
     let mut chip = cc26x2::chip::Cc26X2::new();
-
-    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new());
 
     extern "C" {
         /// Beginning of the ROM region containing app images.
@@ -266,7 +265,6 @@ pub unsafe fn reset_handler() {
     board_kernel.kernel_loop(
         &launchxl,
         &mut chip,
-        &mut PROCESSES,
-        Some(&kernel::ipc::IPC::new()),
+        Some(&kernel::ipc::IPC::new(board_kernel)),
     );
 }

--- a/boards/launchxl/src/main.rs
+++ b/boards/launchxl/src/main.rs
@@ -121,7 +121,7 @@ pub unsafe fn reset_handler() {
     );
     let button = static_init!(
         capsules::button::Button<'static, cc26xx::gpio::GPIOPin>,
-        capsules::button::Button::new(button_pins, kernel::Grant::create(board_kernel))
+        capsules::button::Button::new(button_pins, board_kernel.create_grant())
     );
     for &(btn, _) in button_pins.iter() {
         btn.set_client(button);
@@ -149,7 +149,7 @@ pub unsafe fn reset_handler() {
             115200,
             &mut capsules::console::WRITE_BUF,
             &mut capsules::console::READ_BUF,
-            kernel::Grant::create(board_kernel)
+            board_kernel.create_grant()
         )
     );
     kernel::hil::uart::UART::set_client(console_uart, console);
@@ -228,13 +228,13 @@ pub unsafe fn reset_handler() {
             'static,
             capsules::virtual_alarm::VirtualMuxAlarm<'static, cc26x2::rtc::Rtc>,
         >,
-        capsules::alarm::AlarmDriver::new(virtual_alarm1, kernel::Grant::create(board_kernel))
+        capsules::alarm::AlarmDriver::new(virtual_alarm1, board_kernel.create_grant())
     );
     virtual_alarm1.set_client(alarm);
 
     let rng = static_init!(
         capsules::rng::SimpleRng<'static, cc26xx::trng::Trng>,
-        capsules::rng::SimpleRng::new(&cc26xx::trng::TRNG, kernel::Grant::create(board_kernel))
+        capsules::rng::SimpleRng::new(&cc26xx::trng::TRNG, board_kernel.create_grant())
     );
     cc26xx::trng::TRNG.set_client(rng);
 

--- a/boards/nordic/nrf51dk/src/io.rs
+++ b/boards/nordic/nrf51dk/src/io.rs
@@ -7,6 +7,8 @@ use kernel::hil::uart::{self, UART};
 use nrf51;
 use nrf5x;
 
+use PROCESSES;
+
 struct Writer {
     initialized: bool,
 }
@@ -44,5 +46,5 @@ pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
     const LED1_PIN: usize = 21;
     let led = &mut led::LedLow::new(&mut nrf5x::gpio::PORT[LED1_PIN]);
     let writer = &mut WRITER;
-    debug::panic(&mut [led], writer, pi, &cortexm0::support::nop)
+    debug::panic(&mut [led], writer, pi, &cortexm0::support::nop, &PROCESSES)
 }

--- a/boards/nordic/nrf51dk/src/main.rs
+++ b/boards/nordic/nrf51dk/src/main.rs
@@ -193,7 +193,7 @@ pub unsafe fn reset_handler() {
     );
     let button = static_init!(
         capsules::button::Button<'static, nrf5x::gpio::GPIOPin>,
-        capsules::button::Button::new(button_pins, kernel::Grant::create(board_kernel))
+        capsules::button::Button::new(button_pins, board_kernel.create_grant())
     );
     for &(btn, _) in button_pins.iter() {
         use kernel::hil::gpio::PinCtl;
@@ -258,7 +258,7 @@ pub unsafe fn reset_handler() {
             115200,
             &mut capsules::console::WRITE_BUF,
             &mut capsules::console::READ_BUF,
-            kernel::Grant::create(board_kernel)
+            board_kernel.create_grant()
         )
     );
     UART::set_client(console_uart, console);
@@ -294,7 +294,7 @@ pub unsafe fn reset_handler() {
     );
     let alarm = static_init!(
         AlarmDriver<'static, VirtualMuxAlarm<'static, Rtc>>,
-        AlarmDriver::new(virtual_alarm1, kernel::Grant::create(board_kernel))
+        AlarmDriver::new(virtual_alarm1, board_kernel.create_grant())
     );
     virtual_alarm1.set_client(alarm);
 
@@ -307,14 +307,14 @@ pub unsafe fn reset_handler() {
         capsules::temperature::TemperatureSensor<'static>,
         capsules::temperature::TemperatureSensor::new(
             &mut nrf5x::temperature::TEMP,
-            kernel::Grant::create(board_kernel)
+            board_kernel.create_grant()
         )
     );
     kernel::hil::sensors::TemperatureDriver::set_client(&nrf5x::temperature::TEMP, temp);
 
     let rng = static_init!(
         capsules::rng::SimpleRng<'static, nrf5x::trng::Trng>,
-        capsules::rng::SimpleRng::new(&mut nrf5x::trng::TRNG, kernel::Grant::create(board_kernel))
+        capsules::rng::SimpleRng::new(&mut nrf5x::trng::TRNG, board_kernel.create_grant())
     );
     nrf5x::trng::TRNG.set_client(rng);
 
@@ -326,7 +326,7 @@ pub unsafe fn reset_handler() {
         >,
         capsules::ble_advertising_driver::BLE::new(
             &mut nrf51::radio::RADIO,
-            kernel::Grant::create(board_kernel),
+            board_kernel.create_grant(),
             &mut capsules::ble_advertising_driver::BUF,
             ble_radio_virtual_alarm
         )

--- a/boards/nordic/nrf51dk/src/main.rs
+++ b/boards/nordic/nrf51dk/src/main.rs
@@ -93,7 +93,7 @@ const NUM_PROCS: usize = 1;
 #[link_section = ".app_memory"]
 static mut APP_MEMORY: [u8; 8192] = [0; 8192];
 
-static mut PROCESSES: [Option<&'static mut kernel::procs::Process<'static>>; NUM_PROCS] = [None];
+static mut PROCESSES: [Option<&'static kernel::procs::Process<'static>>; NUM_PROCS] = [None];
 
 /// Dummy buffer that causes the linker to reserve enough space for the stack.
 #[no_mangle]
@@ -140,6 +140,8 @@ impl kernel::Platform for Platform {
 pub unsafe fn reset_handler() {
     // Loads relocations and clears BSS
     nrf51::init();
+
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
 
     // LEDs
     let led_pins = static_init!(
@@ -191,7 +193,7 @@ pub unsafe fn reset_handler() {
     );
     let button = static_init!(
         capsules::button::Button<'static, nrf5x::gpio::GPIOPin>,
-        capsules::button::Button::new(button_pins, kernel::Grant::create())
+        capsules::button::Button::new(button_pins, kernel::Grant::create(board_kernel))
     );
     for &(btn, _) in button_pins.iter() {
         use kernel::hil::gpio::PinCtl;
@@ -256,7 +258,7 @@ pub unsafe fn reset_handler() {
             115200,
             &mut capsules::console::WRITE_BUF,
             &mut capsules::console::READ_BUF,
-            kernel::Grant::create()
+            kernel::Grant::create(board_kernel)
         )
     );
     UART::set_client(console_uart, console);
@@ -292,7 +294,7 @@ pub unsafe fn reset_handler() {
     );
     let alarm = static_init!(
         AlarmDriver<'static, VirtualMuxAlarm<'static, Rtc>>,
-        AlarmDriver::new(virtual_alarm1, kernel::Grant::create())
+        AlarmDriver::new(virtual_alarm1, kernel::Grant::create(board_kernel))
     );
     virtual_alarm1.set_client(alarm);
 
@@ -305,14 +307,14 @@ pub unsafe fn reset_handler() {
         capsules::temperature::TemperatureSensor<'static>,
         capsules::temperature::TemperatureSensor::new(
             &mut nrf5x::temperature::TEMP,
-            kernel::Grant::create()
+            kernel::Grant::create(board_kernel)
         )
     );
     kernel::hil::sensors::TemperatureDriver::set_client(&nrf5x::temperature::TEMP, temp);
 
     let rng = static_init!(
         capsules::rng::SimpleRng<'static, nrf5x::trng::Trng>,
-        capsules::rng::SimpleRng::new(&mut nrf5x::trng::TRNG, kernel::Grant::create())
+        capsules::rng::SimpleRng::new(&mut nrf5x::trng::TRNG, kernel::Grant::create(board_kernel))
     );
     nrf5x::trng::TRNG.set_client(rng);
 
@@ -324,7 +326,7 @@ pub unsafe fn reset_handler() {
         >,
         capsules::ble_advertising_driver::BLE::new(
             &mut nrf51::radio::RADIO,
-            kernel::Grant::create(),
+            kernel::Grant::create(board_kernel),
             &mut capsules::ble_advertising_driver::BUF,
             ble_radio_virtual_alarm
         )
@@ -370,8 +372,6 @@ pub unsafe fn reset_handler() {
 
     debug!("Initialization complete. Entering main loop");
 
-    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new());
-
     extern "C" {
         /// Beginning of the ROM region containing app images.
         static _sapps: u8;
@@ -387,7 +387,6 @@ pub unsafe fn reset_handler() {
     board_kernel.kernel_loop(
         &platform,
         &mut chip,
-        &mut PROCESSES,
-        Some(&kernel::ipc::IPC::new()),
+        Some(&kernel::ipc::IPC::new(board_kernel)),
     );
 }

--- a/boards/nordic/nrf52840dk/src/io.rs
+++ b/boards/nordic/nrf52840dk/src/io.rs
@@ -7,6 +7,8 @@ use kernel::hil::uart::{self, UART};
 use nrf52;
 use nrf5x;
 
+use PROCESSES;
+
 struct Writer {
     initialized: bool,
 }
@@ -44,5 +46,5 @@ pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
     const LED1_PIN: usize = 13;
     let led = &mut led::LedLow::new(&mut nrf5x::gpio::PORT[LED1_PIN]);
     let writer = &mut WRITER;
-    debug::panic(&mut [led], writer, pi, &cortexm4::support::nop)
+    debug::panic(&mut [led], writer, pi, &cortexm4::support::nop, &PROCESSES)
 }

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -59,7 +59,7 @@ const NUM_PROCS: usize = 8;
 #[link_section = ".app_memory"]
 static mut APP_MEMORY: [u8; 245760] = [0; 245760];
 
-static mut PROCESSES: [Option<&'static mut kernel::procs::Process<'static>>; NUM_PROCS] =
+static mut PROCESSES: [Option<&'static kernel::procs::Process<'static>>; NUM_PROCS] =
     [None, None, None, None, None, None, None, None];
 
 /// Dummy buffer that causes the linker to reserve enough space for the stack.
@@ -138,7 +138,10 @@ pub unsafe fn reset_handler() {
         ]
     );
 
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
+
     nrf52dk_base::setup_board(
+        board_kernel,
         BUTTON_RST_PIN,
         gpio_pins,
         LED1_PIN,

--- a/boards/nordic/nrf52dk/src/io.rs
+++ b/boards/nordic/nrf52dk/src/io.rs
@@ -7,6 +7,8 @@ use kernel::hil::uart::{self, UART};
 use nrf52;
 use nrf5x;
 
+use PROCESSES;
+
 struct Writer {
     initialized: bool,
 }
@@ -44,5 +46,5 @@ pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
     const LED1_PIN: usize = 17;
     let led = &mut led::LedLow::new(&mut nrf5x::gpio::PORT[LED1_PIN]);
     let writer = &mut WRITER;
-    debug::panic(&mut [led], writer, pi, &cortexm4::support::nop)
+    debug::panic(&mut [led], writer, pi, &cortexm4::support::nop, &PROCESSES)
 }

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -118,7 +118,7 @@ const NUM_PROCS: usize = 4;
 #[link_section = ".app_memory"]
 static mut APP_MEMORY: [u8; 32768] = [0; 32768];
 
-static mut PROCESSES: [Option<&'static mut kernel::procs::Process<'static>>; NUM_PROCS] =
+static mut PROCESSES: [Option<&'static kernel::procs::Process<'static>>; NUM_PROCS] =
     [None, None, None, None];
 
 /// Dummy buffer that causes the linker to reserve enough space for the stack.
@@ -196,7 +196,10 @@ pub unsafe fn reset_handler() {
         ]
     );
 
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
+
     nrf52dk_base::setup_board(
+        board_kernel,
         BUTTON_RST_PIN,
         gpio_pins,
         LED1_PIN,

--- a/boards/nordic/nrf52dk_base/src/lib.rs
+++ b/boards/nordic/nrf52dk_base/src/lib.rs
@@ -111,6 +111,7 @@ impl kernel::Platform for Platform {
 /// Generic function for starting an nrf52dk board.
 #[inline]
 pub unsafe fn setup_board(
+    board_kernel: &'static kernel::Kernel,
     button_rst_pin: usize,
     gpio_pins: &'static mut [&'static nrf5x::gpio::GPIOPin],
     debug_pin1_index: usize,
@@ -123,7 +124,7 @@ pub unsafe fn setup_board(
     button_pins: &'static mut [(&'static nrf5x::gpio::GPIOPin, capsules::button::GpioMode)],
     app_memory: &mut [u8],
     process_pointers: &'static mut [core::option::Option<
-        &'static mut kernel::procs::Process<'static>,
+        &'static kernel::procs::Process<'static>,
     >],
     app_fault_response: kernel::procs::FaultResponse,
 ) {
@@ -160,7 +161,7 @@ pub unsafe fn setup_board(
     // Buttons
     let button = static_init!(
         capsules::button::Button<'static, nrf5x::gpio::GPIOPin>,
-        capsules::button::Button::new(button_pins, kernel::Grant::create())
+        capsules::button::Button::new(button_pins, kernel::Grant::create(board_kernel))
     );
     for &(btn, _) in button_pins.iter() {
         use kernel::hil::gpio::PinCtl;
@@ -185,7 +186,7 @@ pub unsafe fn setup_board(
             'static,
             capsules::virtual_alarm::VirtualMuxAlarm<'static, nrf5x::rtc::Rtc>,
         >,
-        capsules::alarm::AlarmDriver::new(virtual_alarm1, kernel::Grant::create())
+        capsules::alarm::AlarmDriver::new(virtual_alarm1, kernel::Grant::create(board_kernel))
     );
     virtual_alarm1.set_client(alarm);
     let ble_radio_virtual_alarm = static_init!(
@@ -217,7 +218,7 @@ pub unsafe fn setup_board(
             115200,
             &mut capsules::console::WRITE_BUF,
             &mut capsules::console::READ_BUF,
-            kernel::Grant::create()
+            kernel::Grant::create(board_kernel)
         )
     );
     kernel::hil::uart::UART::set_client(console_uart, console);
@@ -250,7 +251,7 @@ pub unsafe fn setup_board(
         >,
         capsules::ble_advertising_driver::BLE::new(
             &mut nrf52::radio::RADIO,
-            kernel::Grant::create(),
+            kernel::Grant::create(board_kernel),
             &mut capsules::ble_advertising_driver::BUF,
             ble_radio_virtual_alarm
         )
@@ -269,14 +270,14 @@ pub unsafe fn setup_board(
         capsules::temperature::TemperatureSensor<'static>,
         capsules::temperature::TemperatureSensor::new(
             &mut nrf5x::temperature::TEMP,
-            kernel::Grant::create()
+            kernel::Grant::create(board_kernel)
         )
     );
     kernel::hil::sensors::TemperatureDriver::set_client(&nrf5x::temperature::TEMP, temp);
 
     let rng = static_init!(
         capsules::rng::SimpleRng<'static, nrf5x::trng::Trng>,
-        capsules::rng::SimpleRng::new(&mut nrf5x::trng::TRNG, kernel::Grant::create())
+        capsules::rng::SimpleRng::new(&mut nrf5x::trng::TRNG, kernel::Grant::create(board_kernel))
     );
     nrf5x::trng::TRNG.set_client(rng);
 
@@ -352,7 +353,7 @@ pub unsafe fn setup_board(
             capsules::nonvolatile_storage_driver::NonvolatileStorage<'static>,
             capsules::nonvolatile_storage_driver::NonvolatileStorage::new(
                 nv_to_page,
-                kernel::Grant::create(),
+                kernel::Grant::create(board_kernel),
                 0x60000, // Start address for userspace accessible region
                 0x20000, // Length of userspace accessible region
                 0,       // Start address of kernel accessible region
@@ -388,15 +389,13 @@ pub unsafe fn setup_board(
         temp: temp,
         alarm: alarm,
         nonvolatile_storage: nonvolatile_storage,
-        ipc: kernel::ipc::IPC::new(),
+        ipc: kernel::ipc::IPC::new(board_kernel),
     };
 
     let mut chip = nrf52::chip::NRF52::new();
 
     debug!("Initialization complete. Entering main loop\r");
     debug!("{}", &nrf52::ficr::FICR_INSTANCE);
-
-    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new());
 
     extern "C" {
         /// Beginning of the ROM region containing app images.
@@ -410,5 +409,5 @@ pub unsafe fn setup_board(
         app_fault_response,
     );
 
-    board_kernel.kernel_loop(&platform, &mut chip, process_pointers, Some(&platform.ipc));
+    board_kernel.kernel_loop(&platform, &mut chip, Some(&platform.ipc));
 }

--- a/boards/nordic/nrf52dk_base/src/lib.rs
+++ b/boards/nordic/nrf52dk_base/src/lib.rs
@@ -161,7 +161,7 @@ pub unsafe fn setup_board(
     // Buttons
     let button = static_init!(
         capsules::button::Button<'static, nrf5x::gpio::GPIOPin>,
-        capsules::button::Button::new(button_pins, kernel::Grant::create(board_kernel))
+        capsules::button::Button::new(button_pins, board_kernel.create_grant())
     );
     for &(btn, _) in button_pins.iter() {
         use kernel::hil::gpio::PinCtl;
@@ -186,7 +186,7 @@ pub unsafe fn setup_board(
             'static,
             capsules::virtual_alarm::VirtualMuxAlarm<'static, nrf5x::rtc::Rtc>,
         >,
-        capsules::alarm::AlarmDriver::new(virtual_alarm1, kernel::Grant::create(board_kernel))
+        capsules::alarm::AlarmDriver::new(virtual_alarm1, board_kernel.create_grant())
     );
     virtual_alarm1.set_client(alarm);
     let ble_radio_virtual_alarm = static_init!(
@@ -218,7 +218,7 @@ pub unsafe fn setup_board(
             115200,
             &mut capsules::console::WRITE_BUF,
             &mut capsules::console::READ_BUF,
-            kernel::Grant::create(board_kernel)
+            board_kernel.create_grant()
         )
     );
     kernel::hil::uart::UART::set_client(console_uart, console);
@@ -251,7 +251,7 @@ pub unsafe fn setup_board(
         >,
         capsules::ble_advertising_driver::BLE::new(
             &mut nrf52::radio::RADIO,
-            kernel::Grant::create(board_kernel),
+            board_kernel.create_grant(),
             &mut capsules::ble_advertising_driver::BUF,
             ble_radio_virtual_alarm
         )
@@ -270,14 +270,14 @@ pub unsafe fn setup_board(
         capsules::temperature::TemperatureSensor<'static>,
         capsules::temperature::TemperatureSensor::new(
             &mut nrf5x::temperature::TEMP,
-            kernel::Grant::create(board_kernel)
+            board_kernel.create_grant()
         )
     );
     kernel::hil::sensors::TemperatureDriver::set_client(&nrf5x::temperature::TEMP, temp);
 
     let rng = static_init!(
         capsules::rng::SimpleRng<'static, nrf5x::trng::Trng>,
-        capsules::rng::SimpleRng::new(&mut nrf5x::trng::TRNG, kernel::Grant::create(board_kernel))
+        capsules::rng::SimpleRng::new(&mut nrf5x::trng::TRNG, board_kernel.create_grant())
     );
     nrf5x::trng::TRNG.set_client(rng);
 
@@ -353,7 +353,7 @@ pub unsafe fn setup_board(
             capsules::nonvolatile_storage_driver::NonvolatileStorage<'static>,
             capsules::nonvolatile_storage_driver::NonvolatileStorage::new(
                 nv_to_page,
-                kernel::Grant::create(board_kernel),
+                board_kernel.create_grant(),
                 0x60000, // Start address for userspace accessible region
                 0x20000, // Length of userspace accessible region
                 0,       // Start address of kernel accessible region

--- a/kernel/src/callback.rs
+++ b/kernel/src/callback.rs
@@ -1,5 +1,6 @@
 //! Data structure for storing a callback to userspace or kernelspace.
 
+use core::fmt;
 use core::ptr::NonNull;
 
 use process;
@@ -10,6 +11,20 @@ use sched::Kernel;
 pub struct AppId {
     crate kernel: &'static Kernel,
     idx: usize,
+}
+
+impl PartialEq for AppId {
+    fn eq(&self, other: &AppId) -> bool {
+        self.idx == other.idx
+    }
+}
+
+impl Eq for AppId {}
+
+impl fmt::Debug for AppId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.idx)
+    }
 }
 
 impl AppId {

--- a/kernel/src/grant.rs
+++ b/kernel/src/grant.rs
@@ -3,13 +3,11 @@
 use core::marker::PhantomData;
 use core::mem::size_of;
 use core::ops::{Deref, DerefMut};
-use core::ptr::{read_volatile, write_volatile, Unique};
+use core::ptr::Unique;
 
 use callback::AppId;
 use process::Error;
 use sched::Kernel;
-
-crate static mut CONTAINER_COUNTER: usize = 0;
 
 pub struct Grant<T: Default> {
     crate kernel: &'static Kernel,
@@ -133,12 +131,10 @@ impl<T: 'a + ?Sized> DerefMut for Borrowed<'a, T> {
 }
 
 impl<T: Default> Grant<T> {
-    pub unsafe fn create(kernel: &'static Kernel) -> Grant<T> {
-        let ctr = read_volatile(&CONTAINER_COUNTER);
-        write_volatile(&mut CONTAINER_COUNTER, ctr + 1);
+    crate fn new(kernel: &'static Kernel, grant_index: usize) -> Grant<T> {
         Grant {
             kernel: kernel,
-            grant_num: ctr,
+            grant_num: grant_index,
             ptr: PhantomData,
         }
     }

--- a/kernel/src/grant.rs
+++ b/kernel/src/grant.rs
@@ -1,21 +1,24 @@
 //! Data structure to store a list of userspace applications.
 
-use callback::AppId;
 use core::marker::PhantomData;
 use core::mem::size_of;
 use core::ops::{Deref, DerefMut};
 use core::ptr::{read_volatile, write_volatile, Unique};
-use process::{self, Error};
+
+use callback::AppId;
+use process::Error;
+use sched::Kernel;
 
 crate static mut CONTAINER_COUNTER: usize = 0;
 
 pub struct Grant<T: Default> {
+    crate kernel: &'static Kernel,
     grant_num: usize,
     ptr: PhantomData<T>,
 }
 
 pub struct AppliedGrant<T> {
-    appid: usize,
+    appid: AppId,
     grant: *mut T,
     _phantom: PhantomData<T>,
 }
@@ -26,54 +29,43 @@ impl<T> AppliedGrant<T> {
         F: FnOnce(&mut Owned<T>, &mut Allocator) -> R,
         R: Copy,
     {
-        let proc = unsafe {
-            process::PROCS[self.appid]
-                .as_mut()
-                .expect("Request to allocate in nonexistent app")
-        };
-        let mut allocator = Allocator {
-            app: proc,
-            app_id: self.appid,
-        };
+        let mut allocator = Allocator { appid: self.appid };
         let mut root = unsafe { Owned::new(self.grant, self.appid) };
         fun(&mut root, &mut allocator)
     }
 }
 
-pub struct Allocator<'a> {
-    app: &'a mut process::Process<'a>,
-    app_id: usize,
+pub struct Allocator {
+    appid: AppId,
 }
 
 pub struct Owned<T: ?Sized> {
     data: Unique<T>,
-    app_id: usize,
+    appid: AppId,
 }
 
 impl<T: ?Sized> Owned<T> {
-    unsafe fn new(data: *mut T, app_id: usize) -> Owned<T> {
+    unsafe fn new(data: *mut T, appid: AppId) -> Owned<T> {
         Owned {
             data: Unique::new_unchecked(data),
-            app_id: app_id,
+            appid: appid,
         }
     }
 
     pub fn appid(&self) -> AppId {
-        AppId::new(self.app_id)
+        self.appid
     }
 }
 
 impl<T: ?Sized> Drop for Owned<T> {
     fn drop(&mut self) {
         unsafe {
-            let app_id = self.app_id;
             let data = self.data.as_ptr() as *mut u8;
-            match process::PROCS[app_id] {
-                None => {}
-                Some(ref mut app) => {
-                    app.free(data);
-                }
-            }
+            self.appid
+                .kernel
+                .process_map_or((), self.appid.idx(), |process| {
+                    process.free(data);
+                });
         }
     }
 }
@@ -91,16 +83,19 @@ impl<T: ?Sized> DerefMut for Owned<T> {
     }
 }
 
-impl Allocator<'a> {
+impl Allocator {
     pub fn alloc<T>(&mut self, data: T) -> Result<Owned<T>, Error> {
         unsafe {
-            let app_id = self.app_id;
-            self.app
-                .alloc(size_of::<T>())
-                .map_or(Err(Error::OutOfMemory), |arr| {
-                    let mut owned = Owned::new(arr.as_mut_ptr() as *mut T, app_id);
-                    *owned = data;
-                    Ok(owned)
+            self.appid
+                .kernel
+                .process_map_or(Err(Error::NoSuchApp), self.appid.idx(), |process| {
+                    process
+                        .alloc(size_of::<T>())
+                        .map_or(Err(Error::OutOfMemory), |arr| {
+                            let mut owned = Owned::new(arr.as_mut_ptr() as *mut T, self.appid);
+                            *owned = data;
+                            Ok(owned)
+                        })
                 })
         }
     }
@@ -108,19 +103,19 @@ impl Allocator<'a> {
 
 pub struct Borrowed<'a, T: 'a + ?Sized> {
     data: &'a mut T,
-    app_id: usize,
+    appid: AppId,
 }
 
 impl<T: 'a + ?Sized> Borrowed<'a, T> {
-    pub fn new(data: &'a mut T, app_id: usize) -> Borrowed<T> {
+    pub fn new(data: &'a mut T, appid: AppId) -> Borrowed<'a, T> {
         Borrowed {
             data: data,
-            app_id: app_id,
+            appid: appid,
         }
     }
 
     pub fn appid(&self) -> AppId {
-        AppId::new(self.app_id)
+        self.appid
     }
 }
 
@@ -138,10 +133,11 @@ impl<T: 'a + ?Sized> DerefMut for Borrowed<'a, T> {
 }
 
 impl<T: Default> Grant<T> {
-    pub unsafe fn create() -> Grant<T> {
+    pub unsafe fn create(kernel: &'static Kernel) -> Grant<T> {
         let ctr = read_volatile(&CONTAINER_COUNTER);
         write_volatile(&mut CONTAINER_COUNTER, ctr + 1);
         Grant {
+            kernel: kernel,
             grant_num: ctr,
             ptr: PhantomData,
         }
@@ -149,22 +145,18 @@ impl<T: Default> Grant<T> {
 
     pub fn grant(&self, appid: AppId) -> Option<AppliedGrant<T>> {
         unsafe {
-            let app_id = appid.idx();
-            match process::PROCS[app_id] {
-                Some(ref mut app) => {
-                    let cntr = app.grant_for::<T>(self.grant_num);
-                    if cntr.is_null() {
-                        None
-                    } else {
-                        Some(AppliedGrant {
-                            appid: app_id,
-                            grant: cntr,
-                            _phantom: PhantomData,
-                        })
-                    }
+            appid.kernel.process_map_or(None, appid.idx(), |process| {
+                let cntr = process.grant_for::<T>(self.grant_num);
+                if cntr.is_null() {
+                    None
+                } else {
+                    Some(AppliedGrant {
+                        appid: appid,
+                        grant: cntr,
+                        _phantom: PhantomData,
+                    })
                 }
-                None => None,
-            }
+            })
         }
     }
 
@@ -174,22 +166,19 @@ impl<T: Default> Grant<T> {
         R: Copy,
     {
         unsafe {
-            let app_id = appid.idx();
-            match process::PROCS[app_id] {
-                Some(ref mut app) => app.grant_for_or_alloc::<T>(self.grant_num).map_or(
-                    Err(Error::OutOfMemory),
-                    move |root_ptr| {
-                        let mut root = Borrowed::new(&mut *root_ptr, app_id);
-                        let mut allocator = Allocator {
-                            app: app,
-                            app_id: app_id,
-                        };
-                        let res = fun(&mut root, &mut allocator);
-                        Ok(res)
-                    },
-                ),
-                None => Err(Error::NoSuchApp),
-            }
+            appid
+                .kernel
+                .process_map_or(Err(Error::NoSuchApp), appid.idx(), |process| {
+                    process.grant_for_or_alloc::<T>(self.grant_num).map_or(
+                        Err(Error::OutOfMemory),
+                        move |root_ptr| {
+                            let mut root = Borrowed::new(&mut *root_ptr, appid);
+                            let mut allocator = Allocator { appid: appid };
+                            let res = fun(&mut root, &mut allocator);
+                            Ok(res)
+                        },
+                    )
+                })
         }
     }
 
@@ -197,25 +186,21 @@ impl<T: Default> Grant<T> {
     where
         F: Fn(&mut Owned<T>),
     {
-        unsafe {
-            let itr = process::PROCS.iter_mut().filter_map(|p| p.as_mut());
-            for (app_id, app) in itr.enumerate() {
-                let root_ptr = app.grant_for::<T>(self.grant_num);
+        self.kernel
+            .process_each_enumerate(|app_id, process| unsafe {
+                let root_ptr = process.grant_for::<T>(self.grant_num);
                 if !root_ptr.is_null() {
-                    let mut root = Owned::new(root_ptr, app_id);
+                    let mut root = Owned::new(root_ptr, AppId::new(self.kernel, app_id));
                     fun(&mut root);
                 }
-            }
-        }
+            });
     }
 
     pub fn iter(&self) -> Iter<T> {
-        unsafe {
-            Iter {
-                grant: self,
-                index: 0,
-                len: process::PROCS.len(),
-            }
+        Iter {
+            grant: self,
+            index: 0,
+            len: self.kernel.number_of_process_slots(),
         }
     }
 }
@@ -233,7 +218,7 @@ impl<T: Default> Iterator for Iter<'a, T> {
         while self.index < self.len {
             let idx = self.index;
             self.index += 1;
-            let res = self.grant.grant(AppId::new(idx));
+            let res = self.grant.grant(AppId::new(self.grant.kernel, idx));
             if res.is_some() {
                 return res;
             }

--- a/kernel/src/ipc.rs
+++ b/kernel/src/ipc.rs
@@ -12,6 +12,7 @@ use grant::Grant;
 use mem::{AppSlice, Shared};
 use process;
 use returncode::ReturnCode;
+use sched::Kernel;
 
 struct IPCData {
     shared_memory: [Option<AppSlice<Shared, u8>>; 8],
@@ -34,9 +35,9 @@ pub struct IPC {
 }
 
 impl IPC {
-    pub unsafe fn new() -> IPC {
+    pub unsafe fn new(kernel: &'static Kernel) -> IPC {
         IPC {
-            data: Grant::create(),
+            data: Grant::create(kernel),
         }
     }
 
@@ -136,6 +137,8 @@ impl Driver for IPC {
     /// and notifying an IPC client is done by setting client_or_svc to 1.
     /// In either case, the target_id is the same number as provided in a notify
     /// callback or as returned by allow.
+    ///
+    /// Returns EINVAL if the other process doesn't exist.
     fn command(
         &self,
         target_id: usize,
@@ -143,24 +146,18 @@ impl Driver for IPC {
         _: usize,
         appid: AppId,
     ) -> ReturnCode {
-        let procs = unsafe { &mut process::PROCS };
-        if target_id == 0 || target_id > procs.len() {
-            return ReturnCode::EINVAL; /* Request to IPC to impossible process */
-        }
-
         let cb_type = if client_or_svc == 0 {
             process::IPCType::Service
         } else {
             process::IPCType::Client
         };
 
-        procs[target_id - 1]
-            .as_mut()
-            .map(|target| {
+        self.data
+            .kernel
+            .process_map_or(ReturnCode::EINVAL, target_id - 1, |target| {
                 target.schedule_ipc(appid, cb_type);
                 ReturnCode::SUCCESS
             })
-            .unwrap_or(ReturnCode::EINVAL) /* Request to IPC to unknown process */
     }
 
     /// allow enables processes to discover IPC services on the platform or
@@ -185,22 +182,21 @@ impl Driver for IPC {
         if target_id == 0 {
             match slice {
                 Some(slice_data) => {
-                    let procs = unsafe { &mut process::PROCS };
-                    for (i, process) in procs.iter().enumerate() {
-                        match process {
-                            Some(p) => {
-                                let s = p.package_name.as_bytes();
-                                // are slices equal?
-                                if s.len() == slice_data.len()
-                                    && s.iter().zip(slice_data.iter()).all(|(c1, c2)| c1 == c2)
-                                {
-                                    return ReturnCode::SuccessWithValue {
-                                        value: (i as usize) + 1,
-                                    };
-                                }
+                    let ret = self.data.kernel.process_each_enumerate_stop(|i, p| {
+                        let s = p.package_name.as_bytes();
+                        // are slices equal?
+                        if s.len() == slice_data.len()
+                            && s.iter().zip(slice_data.iter()).all(|(c1, c2)| c1 == c2)
+                        {
+                            ReturnCode::SuccessWithValue {
+                                value: (i as usize) + 1,
                             }
-                            None => {}
+                        } else {
+                            ReturnCode::FAIL
                         }
+                    });
+                    if ret != ReturnCode::FAIL {
+                        return ret;
                     }
                 }
                 None => {}

--- a/kernel/src/ipc.rs
+++ b/kernel/src/ipc.rs
@@ -37,7 +37,7 @@ pub struct IPC {
 impl IPC {
     pub unsafe fn new(kernel: &'static Kernel) -> IPC {
         IPC {
-            data: Grant::create(kernel),
+            data: kernel.create_grant(),
         }
     }
 

--- a/kernel/src/mem.rs
+++ b/kernel/src/mem.rs
@@ -6,7 +6,6 @@ use core::ptr::Unique;
 use core::slice;
 
 use callback::AppId;
-use process;
 
 #[derive(Debug)]
 pub struct Private;
@@ -45,14 +44,11 @@ impl<L, T> DerefMut for AppPtr<L, T> {
 
 impl<L, T> Drop for AppPtr<L, T> {
     fn drop(&mut self) {
-        unsafe {
-            let ps = &mut process::PROCS;
-            if ps.len() > self.process.idx() {
-                ps[self.process.idx()]
-                    .as_mut()
-                    .map(|process| process.free(self.ptr.as_mut()));
-            }
-        }
+        self.process
+            .kernel
+            .process_map_or((), self.process.idx(), |process| unsafe {
+                process.free(self.ptr.as_mut())
+            })
     }
 }
 
@@ -80,12 +76,13 @@ impl<L, T> AppSlice<L, T> {
     }
 
     crate unsafe fn expose_to(&self, appid: AppId) -> bool {
-        let ps = &mut process::PROCS;
-        if appid.idx() != self.ptr.process.idx() && ps.len() > appid.idx() {
-            ps[appid.idx()]
-                .as_ref()
-                .map(|process| process.add_mpu_region(self.ptr() as *const u8, self.len() as u32))
-                .unwrap_or(false)
+        if appid.idx() != self.ptr.process.idx() {
+            self.ptr
+                .process
+                .kernel
+                .process_map_or(false, appid.idx(), |process| {
+                    process.add_mpu_region(self.ptr() as *const u8, self.len() as u32)
+                })
         } else {
             false
         }

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -10,7 +10,6 @@ use core::{mem, ptr, slice, str};
 
 use common::cells::MapCell;
 use common::math;
-use grant;
 use platform::mpu;
 use returncode::ReturnCode;
 use sched::Kernel;
@@ -602,7 +601,7 @@ impl Process<'a> {
 
             // Make room for grant pointers.
             let grant_ptr_size = mem::size_of::<*const usize>();
-            let grant_ptrs_num = read_volatile(&grant::CONTAINER_COUNTER);
+            let grant_ptrs_num = kernel.get_grant_count_and_finalize();
             let grant_ptrs_offset = grant_ptrs_num * grant_ptr_size;
 
             // Allocate memory for callback ring buffer.
@@ -791,7 +790,7 @@ impl Process<'a> {
 
     /// Reset all `grant_ptr`s to NULL.
     unsafe fn grant_ptrs_reset(&self) {
-        let grant_ptrs_num = read_volatile(&grant::CONTAINER_COUNTER);
+        let grant_ptrs_num = self.kernel.get_grant_count_and_finalize();
         for grant_num in 0..grant_ptrs_num {
             let grant_num = grant_num as isize;
             let ctr_ptr = (self.mem_end() as *mut *mut usize).offset(-(grant_num + 1));

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -52,7 +52,7 @@ pub unsafe fn load_processes(
     kernel: &'static Kernel,
     start_of_flash: *const u8,
     app_memory: &mut [u8],
-    procs: &mut [Option<&mut Process<'static>>],
+    procs: &mut [Option<&Process<'static>>],
     fault_response: FaultResponse,
 ) {
     let mut apps_in_flash_ptr = start_of_flash;
@@ -576,7 +576,7 @@ impl Process<'a> {
         remaining_app_memory: *mut u8,
         remaining_app_memory_size: usize,
         fault_response: FaultResponse,
-    ) -> (Option<&'static mut Process<'a>>, usize, usize) {
+    ) -> (Option<&'static Process<'a>>, usize, usize) {
         if let Some(tbf_header) = tbfheader::parse_and_validate_tbf_header(app_flash_address) {
             let app_flash_size = tbf_header.get_total_size() as usize;
 

--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -7,6 +7,7 @@ use core::ptr::NonNull;
 use callback;
 use callback::{AppId, Callback};
 use common::cells::NumericCellExt;
+use grant::Grant;
 use ipc;
 use mem::AppSlice;
 use memop;
@@ -30,6 +31,15 @@ pub struct Kernel {
     work: Cell<usize>,
     /// This holds a pointer to the static array of Process pointers.
     processes: &'static [Option<&'static Process<'static>>],
+    /// How many grant regions have been setup. This is incremented on every
+    /// call to `create_grant()`. We need to explicitly track this so that when
+    /// processes are created they can allocated pointers for each grant.
+    grant_counter: Cell<usize>,
+    /// Flag to mark that grants have been finalized. This means that the kernel
+    /// cannot support creating new grants because processes have already been
+    /// created and the data structures for grants have already been
+    /// established.
+    grants_finalized: Cell<bool>,
 }
 
 impl Kernel {
@@ -37,6 +47,8 @@ impl Kernel {
         Kernel {
             work: Cell::new(0),
             processes: processes,
+            grant_counter: Cell::new(0),
+            grants_finalized: Cell::new(false),
         }
     }
 
@@ -114,6 +126,36 @@ impl Kernel {
     /// Return how many processes this board supports.
     crate fn number_of_process_slots(&self) -> usize {
         self.processes.len()
+    }
+
+    /// Create a new grant. This is used in board initialization to setup grants
+    /// that capsules use to interact with processes.
+    ///
+    /// Grants **must** only be created _before_ processes are initialized.
+    /// Processes use the number of grants that have been allocated to correctly
+    /// initialize the process's memory with a pointer for each grant. If a
+    /// grant is created after processes are initialized this will panic.
+    pub fn create_grant<T: Default>(&'static self) -> Grant<T> {
+        if self.grants_finalized.get() {
+            panic!("Grants finalized. Cannot create a new grant.");
+        }
+
+        // Create and return a new grant.
+        let grant_index = self.grant_counter.get();
+        self.grant_counter.increment();
+        Grant::new(self, grant_index)
+    }
+
+    /// Returns the number of grants that have been setup in the system and
+    /// marks the grants as "finalized". This means that no more grants can
+    /// be created because data structures have been setup based on the number
+    /// of grants when this function is called.
+    ///
+    /// In practice, this is called when processes are created, and the process
+    /// memory is setup based on the number of current grants.
+    crate fn get_grant_count_and_finalize(&self) -> usize {
+        self.grants_finalized.set(true);
+        self.grant_counter.get()
     }
 
     /// Main loop.

--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -29,11 +29,11 @@ pub struct Kernel {
     /// outstanding callbacks and processes in the Running state.
     work: Cell<usize>,
     /// This holds a pointer to the static array of Process pointers.
-    processes: &'static [Option<&'static mut Process<'static>>],
+    processes: &'static [Option<&'static Process<'static>>],
 }
 
 impl Kernel {
-    pub fn new(processes: &'static [Option<&'static mut Process<'static>>]) -> Kernel {
+    pub fn new(processes: &'static [Option<&'static Process<'static>>]) -> Kernel {
         Kernel {
             work: Cell::new(0),
             processes: processes,

--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -28,11 +28,16 @@ pub struct Kernel {
     /// How many "to-do" items exist at any given time. These include
     /// outstanding callbacks and processes in the Running state.
     work: Cell<usize>,
+    /// This holds a pointer to the static array of Process pointers.
+    processes: &'static [Option<&'static mut Process<'static>>],
 }
 
 impl Kernel {
-    pub fn new() -> Kernel {
-        Kernel { work: Cell::new(0) }
+    pub fn new(processes: &'static [Option<&'static mut Process<'static>>]) -> Kernel {
+        Kernel {
+            work: Cell::new(0),
+            processes: processes,
+        }
     }
 
     /// Something was scheduled for a process, so there is more work to do.
@@ -52,26 +57,85 @@ impl Kernel {
         self.work.get() == 0
     }
 
+    /// Run a closure on a specific process if it exists. If the process does
+    /// not exist (i.e. it is `None` in the `processes` array) then `default`
+    /// will be returned. Otherwise the closure will executed and passed a
+    /// reference to the process.
+    crate fn process_map_or<F, R>(&self, default: R, process_index: usize, closure: F) -> R
+    where
+        F: FnOnce(&Process) -> R,
+    {
+        if process_index > self.processes.len() {
+            return default;
+        }
+        self.processes[process_index]
+            .as_ref()
+            .map_or(default, |process| closure(process))
+    }
+
+    /// Run a closure on every valid process. This will iterate the array of
+    /// processes and call the closure on every process that exists.
+    crate fn process_each_enumerate<F>(&self, closure: F)
+    where
+        F: Fn(usize, &Process),
+    {
+        for (i, process) in self.processes.iter().enumerate() {
+            match process {
+                Some(ref p) => {
+                    closure(i, p);
+                }
+                None => {}
+            }
+        }
+    }
+
+    /// Run a closure on every process, but only continue if the closure returns
+    /// `FAIL`. That is, if the closure returns any other return code than
+    /// `FAIL`, that value will be returned from this function and the iteration
+    /// of the array of processes will stop.
+    crate fn process_each_enumerate_stop<F>(&self, closure: F) -> ReturnCode
+    where
+        F: Fn(usize, &Process) -> ReturnCode,
+    {
+        for (i, process) in self.processes.iter().enumerate() {
+            match process {
+                Some(ref p) => {
+                    let ret = closure(i, p);
+                    if ret != ReturnCode::FAIL {
+                        return ret;
+                    }
+                }
+                None => {}
+            }
+        }
+        ReturnCode::FAIL
+    }
+
+    /// Return how many processes this board supports.
+    crate fn number_of_process_slots(&self) -> usize {
+        self.processes.len()
+    }
+
     /// Main loop.
     pub fn kernel_loop<P: Platform, C: Chip>(
-        &self,
+        &'static self,
         platform: &P,
         chip: &mut C,
-        processes: &'static mut [Option<&mut process::Process<'static>>],
         ipc: Option<&ipc::IPC>,
     ) {
-        let processes = unsafe {
-            process::PROCS = processes;
-            &mut process::PROCS
-        };
-
         loop {
             unsafe {
                 chip.service_pending_interrupts();
 
-                for (i, p) in processes.iter().enumerate() {
+                for (i, p) in self.processes.iter().enumerate() {
                     p.as_ref().map(|process| {
-                        self.do_process(platform, chip, process, callback::AppId::new(i), ipc);
+                        self.do_process(
+                            platform,
+                            chip,
+                            process,
+                            callback::AppId::new(self, i),
+                            ipc,
+                        );
                     });
                     if chip.has_pending_interrupts() {
                         break;


### PR DESCRIPTION
### Pull Request Overview

As a part of #1043, this moves the PROCS array to no longer be a static global variable but instead be a member of the `Kernel` struct. This is needed for at least three reasons:

1. The `Process` type needs to be templated across architectures, and that doesn't seem possible with the static array (because the kernel crate doesn't know what type it will actually be).
2. This will help with the MPU changes.
3. It is generally better to not have global variables that need `unsafe` to access.

After #1109, this is relatively straightforward, with a couple things of note:

- To access the `Kernel` struct, many data structures need to keep a reference to the kernel struct, and these have been added.
- debug.rs cannot directly access the `PROCS` array, so it must be passed in during a panic.

~~This is blocked on #1046~~
### Testing Strategy

Running hail on hail.


### TODO or Help Wanted

  - [ ] Update CHANGELOG

  - [ ] Test


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
