### PR TITLE
Move architecture-dependent debugging print code to arch/cortex-m

### DIFF
--- a/arch/cortex-m/src/syscall.rs
+++ b/arch/cortex-m/src/syscall.rs
@@ -229,7 +229,7 @@ impl kernel::syscall::UserspaceKernelBoundary for SysCall {
         (new_stack_pointer as *mut usize, switch_reason)
     }
 
-    unsafe fn fault_str(&self, writer: &mut Write) {
+    unsafe fn fault_fmt(&self, writer: &mut Write) {
         let _ccr = SCB_REGISTERS[0];
         let cfsr = SCB_REGISTERS[1];
         let hfsr = SCB_REGISTERS[2];
@@ -407,7 +407,7 @@ impl kernel::syscall::UserspaceKernelBoundary for SysCall {
         }
     }
 
-    unsafe fn print_process_arch_detail(
+    unsafe fn process_detail_fmt(
         &self,
         stack_pointer: *const usize,
         state: &CortexMStoredState,

--- a/kernel/src/debug.rs
+++ b/kernel/src/debug.rs
@@ -118,7 +118,7 @@ pub unsafe fn panic_process_info<W: Write>(
     // Print fault status once
     if !procs.is_empty() {
         procs[0].as_ref().map(|process| {
-            process.fault_str(writer);
+            process.fault_fmt(writer);
         });
     }
 
@@ -126,7 +126,7 @@ pub unsafe fn panic_process_info<W: Write>(
     let _ = writer.write_fmt(format_args!("\r\n---| App Status |---\r\n"));
     for idx in 0..procs.len() {
         procs[idx].as_ref().map(|process| {
-            process.statistics_str(writer);
+            process.process_detail_fmt(writer);
         });
     }
 }

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -47,8 +47,6 @@ pub use platform::{ClockInterface, NoClockControl, NO_CLOCK_CONTROL};
 pub use returncode::ReturnCode;
 pub use sched::Kernel;
 
-pub use process::SCB_REGISTERS;
-
 // Export only select items from the process module. To remove the name conflict
 // this cannot be called `process`, so we use a shortened version. These
 // functions and types are used by board files to setup the platform and setup

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -187,8 +187,8 @@ pub trait ProcessType {
     /// Context switch to a specific process.
     unsafe fn switch_to(&self) -> Option<syscall::ContextSwitchReason>;
 
-    unsafe fn fault_str(&self, writer: &mut Write);
-    unsafe fn statistics_str(&self, writer: &mut Write);
+    unsafe fn fault_fmt(&self, writer: &mut Write);
+    unsafe fn process_detail_fmt(&self, writer: &mut Write);
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -785,11 +785,11 @@ impl<S: UserspaceKernelBoundary> ProcessType for Process<'a, S> {
         })
     }
 
-    unsafe fn fault_str(&self, writer: &mut Write) {
-        self.syscall.fault_str(writer);
+    unsafe fn fault_fmt(&self, writer: &mut Write) {
+        self.syscall.fault_fmt(writer);
     }
 
-    unsafe fn statistics_str(&self, writer: &mut Write) {
+    unsafe fn process_detail_fmt(&self, writer: &mut Write) {
         // Flash
         let flash_end = self.flash.as_ptr().offset(self.flash.len() as isize) as usize;
         let flash_start = self.flash.as_ptr() as usize;
@@ -905,7 +905,7 @@ impl<S: UserspaceKernelBoundary> ProcessType for Process<'a, S> {
 
         self.stored_state.map(|stored_state| {
             self.syscall
-                .print_process_arch_detail(self.sp(), &stored_state, writer);
+                .process_detail_fmt(self.sp(), &stored_state, writer);
         });
 
         let _ = writer.write_fmt(format_args!(

--- a/kernel/src/syscall.rs
+++ b/kernel/src/syscall.rs
@@ -118,11 +118,11 @@ pub trait UserspaceKernelBoundary {
     ) -> (*mut usize, ContextSwitchReason);
 
     /// Display any general information about the fault.
-    unsafe fn fault_str(&self, writer: &mut Write);
+    unsafe fn fault_fmt(&self, writer: &mut Write);
 
     /// Display architecture specific (e.g. CPU registers or status flags) data
     /// for a process identified by its stack pointer.
-    unsafe fn print_process_arch_detail(
+    unsafe fn process_detail_fmt(
         &self,
         stack_pointer: *const usize,
         state: &Self::StoredState,

--- a/kernel/src/syscall.rs
+++ b/kernel/src/syscall.rs
@@ -1,5 +1,7 @@
 //! Tock syscall number definitions and arch-agnostic interface trait.
 
+use core::fmt::Write;
+
 use process;
 
 /// The syscall number assignments.
@@ -114,4 +116,16 @@ pub trait UserspaceKernelBoundary {
         stack_pointer: *const usize,
         state: &mut Self::StoredState,
     ) -> (*mut usize, ContextSwitchReason);
+
+    /// Display any general information about the fault.
+    unsafe fn fault_str(&self, writer: &mut Write);
+
+    /// Display architecture specific (e.g. CPU registers or status flags) data
+    /// for a process identified by its stack pointer.
+    unsafe fn print_process_arch_detail(
+        &self,
+        stack_pointer: *const usize,
+        state: &Self::StoredState,
+        writer: &mut Write,
+    );
 }


### PR DESCRIPTION
### Pull Request Overview

This pull finishes up #1113 by moving the `SCB_REGISTERS` variable to the cortex-m crate and all of the printing code that is architecture specific to the cortex-m crate.

I believe this is the last step to having process.rs be architecture agnostic.

~~Blocked on #1113.~~


### Testing Strategy

This pull request was tested by running crash dummy and hail on hail and seeing the panic output.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
