### PR TITLE
Adds RTC, AON, PRCM driver to CC26x2

### DIFF
--- a/chips/cc26x2/src/aon.rs
+++ b/chips/cc26x2/src/aon.rs
@@ -1,0 +1,179 @@
+//! Always On Module (AON) management
+//!
+//! AON is a set of peripherals which is _always on_ (eg. the RTC, MCU, etc).
+//!
+//! The current configuration disables all wake-up selectors, since the
+//! MCU never go to sleep and is always active.
+use kernel::common::cells::VolatileCell;
+use kernel::common::registers::{ReadOnly, ReadWrite};
+use kernel::common::StaticRef;
+use rtc;
+
+#[repr(C)]
+pub struct AonIocRegisters {
+    _reserved0: [u32; 3],
+    ioc_clk32k_ctl: ReadWrite<u32, IocClk::Register>,
+}
+
+#[repr(C)]
+pub struct AonEventRegisters {
+    mcu_wu_sel: VolatileCell<u32>,       // MCU Wake-up selector
+    aux_wu_sel: VolatileCell<u32>,       // AUX Wake-up selector
+    event_to_mcu_sel: VolatileCell<u32>, // Event selector for MCU Events
+    rtc_sel: VolatileCell<u32>,          // RTC Capture event selector for AON_RTC
+}
+
+#[repr(C)]
+struct AonPmCtlRegisters {
+    aux_clk: ReadWrite<u32, AuxClk::Register>,
+    ram_cfg: ReadWrite<u32, RamCfg::Register>,
+    pwr_ctl: ReadWrite<u32, PwrCtl::Register>,
+    pwr_stat: ReadOnly<u32, PwrStat::Register>,
+    shutdown: ReadWrite<u32, Shutdown::Register>,
+    _recharge: [u32; 4],
+}
+
+register_bitfields![
+    u32,
+    AuxClk [
+        SRC     OFFSET(0) NUMBITS(1) [
+            SCLK_HFDIV2 = 0x00,
+            SCLK_MF = 0x01
+        ],
+        PWR_DWN_SRC OFFSET(8) NUMBITS(1) [
+            NO_CLOCK = 0b0,
+            SCLK_LF = 0b1
+        ]
+    ],
+    RamCfg [
+        AUX_SRAM_PWR_OFF_OFF    OFFSET(17) NUMBITS(1) [],
+        AUX_SRAM_RET_EN OFFSET(16) NUMBITS(1) [],
+
+        //  SRAM Retention enabled
+        //  0x00 - Retention disabled
+        //  0x01 - Retention enabled for BANK0
+        //  0x03 - Retention enabled for BANK0, BANK1
+        //  0x07 - Retention enabled for BANK0, BANK1, BANK2
+        //  0x0F - Retention enabled for BANK0, BANK1, BANK2, BANK3
+        BUS_SRAM_RET_EN OFFSET(0)  NUMBITS(4) [
+            OFF = 0x00,
+            ON = 0x0F   // Default to enable retention in all banks
+        ]
+    ],
+    PwrCtl [
+        // 0 = use GLDO in active mode, 1 = use DCDC in active mode
+        DCDC_ACTIVE  OFFSET(2) NUMBITS(1) [],
+        // 0 = DCDC/GLDO are used, 1 = DCDC/GLDO are bypassed and using a external regulater
+        EXT_REG_MODE OFFSET(1) NUMBITS(1) [],
+        // 0 = use GDLO for recharge, 1 = use DCDC for recharge
+        DCDC_EN      OFFSET(0) NUMBITS(1) []
+    ],
+    PwrStat [
+        JTAG_PD_ON  OFFSET(2) NUMBITS(1) [],
+        AUX_BUS_RESET_DONE OFFSET(1) NUMBITS(1) [],
+        AUX_RESET_DONE OFFSET(0) NUMBITS(1) []
+    ],
+    Shutdown [
+        // Controls whether MCU & AUX requesting to be powered off
+        // will enable a transition to powerdown (0 = Enabled, 1 = Disabled)
+        PWR_DWN_DIS     OFFSET(0) NUMBITS(1) []
+    ],
+    IocClk [
+        EN  OFFSET(0) NUMBITS(1) []
+    ]
+
+];
+
+const AON_EVENT_BASE: StaticRef<AonEventRegisters> =
+    unsafe { StaticRef::new(0x4009_3000 as *const AonEventRegisters) };
+const AON_PMCTL_BASE: StaticRef<AonPmCtlRegisters> =
+    unsafe { StaticRef::new(0x4009_0000 as *const AonPmCtlRegisters) };
+const AON_IOC_BASE: StaticRef<AonIocRegisters> =
+    unsafe { StaticRef::new(0x4009_4000 as *const AonIocRegisters) };
+
+pub struct Aon {
+    event_regs: StaticRef<AonEventRegisters>,
+}
+
+pub const AON: Aon = Aon::new();
+
+impl Aon {
+    const fn new() -> Aon {
+        Aon {
+            event_regs: AON_EVENT_BASE,
+        }
+    }
+
+    pub fn setup(&self) {
+        let regs = &*self.event_regs;
+
+        // Default to no events at all
+        regs.aux_wu_sel.set(0x3F3F3F3F);
+
+        // Set RTC CH1 as a wakeup source by default
+        regs.mcu_wu_sel.set(0x3F3F3F24);
+
+        // Disable RTC combined event
+        regs.rtc_sel.set(0x0000003F);
+
+        // The default reset value is 0x002B2B2B. However, 0x2b for each
+        // programmable event corresponds to a JTAG event; which is fired
+        // *all* the time during debugging through JTAG. It is better to
+        // ignore it in this case.
+        //      NOTE: the aon programmable interrupt will still be fired
+        //            once a debugger is attached through JTAG.
+        regs.event_to_mcu_sel.set(0x003F3F3F);
+    }
+
+    pub fn set_dcdc_enabled(&self, enabled: bool) {
+        let regs = AON_PMCTL_BASE;
+        if enabled {
+            regs.pwr_ctl
+                .modify(PwrCtl::DCDC_ACTIVE::SET + PwrCtl::DCDC_EN::SET);
+        } else {
+            regs.pwr_ctl
+                .modify(PwrCtl::DCDC_ACTIVE::CLEAR + PwrCtl::DCDC_EN::CLEAR);
+        }
+    }
+
+    pub fn lfclk_enable(&self, enable: bool) {
+        let regs = AON_IOC_BASE;
+        if enable {
+            regs.ioc_clk32k_ctl.write(IocClk::EN::SET);
+        } else {
+            regs.ioc_clk32k_ctl.write(IocClk::EN::CLEAR);
+        }
+    }
+
+    pub fn aux_set_ram_retention(&self, enabled: bool) {
+        let regs = AON_PMCTL_BASE;
+        regs.ram_cfg.modify({
+            if enabled {
+                RamCfg::AUX_SRAM_RET_EN::SET
+            } else {
+                RamCfg::AUX_SRAM_RET_EN::CLEAR
+            }
+        });
+    }
+
+    pub fn mcu_set_ram_retention(&self, on: bool) {
+        let regs = AON_PMCTL_BASE;
+        regs.ram_cfg.modify({
+            if on {
+                RamCfg::BUS_SRAM_RET_EN::ON
+            } else {
+                RamCfg::BUS_SRAM_RET_EN::OFF
+            }
+        });
+    }
+
+    pub fn shutdown(&self) {
+        let regs = AON_PMCTL_BASE;
+        regs.shutdown.modify(Shutdown::PWR_DWN_DIS::SET);
+    }
+    /// Await a cycle of the AON domain in order
+    /// to sync with it.
+    pub fn sync(&self) {
+        unsafe { rtc::RTC.sync() };
+    }
+}

--- a/chips/cc26x2/src/aon.rs
+++ b/chips/cc26x2/src/aon.rs
@@ -4,7 +4,6 @@
 //!
 //! The current configuration disables all wake-up selectors, since the
 //! MCU never go to sleep and is always active.
-use kernel::common::cells::VolatileCell;
 use kernel::common::registers::{ReadOnly, ReadWrite};
 use kernel::common::StaticRef;
 use rtc;
@@ -17,10 +16,10 @@ pub struct AonIocRegisters {
 
 #[repr(C)]
 pub struct AonEventRegisters {
-    mcu_wu_sel: VolatileCell<u32>,       // MCU Wake-up selector
-    aux_wu_sel: VolatileCell<u32>,       // AUX Wake-up selector
-    event_to_mcu_sel: VolatileCell<u32>, // Event selector for MCU Events
-    rtc_sel: VolatileCell<u32>,          // RTC Capture event selector for AON_RTC
+    mcu_wu_sel: ReadWrite<u32>,       // MCU Wake-up selector
+    aux_wu_sel: ReadWrite<u32>,       // AUX Wake-up selector
+    event_to_mcu_sel: ReadWrite<u32>, // Event selector for MCU Events
+    rtc_sel: ReadWrite<u32>,          // RTC Capture event selector for AON_RTC
 }
 
 #[repr(C)]

--- a/chips/cc26x2/src/chip.rs
+++ b/chips/cc26x2/src/chip.rs
@@ -1,11 +1,9 @@
-//! Configuration and interrupt handling.
-
 use cc26xx::gpio;
 use cc26xx::peripheral_interrupts;
-use cc26xx::rtc;
 use cc26xx::uart;
 use cortexm4::{self, nvic};
 use kernel;
+use rtc;
 
 pub struct Cc26X2 {
     mpu: cortexm4::mpu::MPU,
@@ -33,7 +31,6 @@ impl kernel::Chip for Cc26X2 {
     fn systick(&self) -> &Self::SysTick {
         &self.systick
     }
-
     fn service_pending_interrupts(&mut self) {
         unsafe {
             while let Some(interrupt) = nvic::next_pending() {
@@ -44,7 +41,7 @@ impl kernel::Chip for Cc26X2 {
                     // AON Programmable interrupt
                     // We need to ignore JTAG events since some debuggers emit these
                     peripheral_interrupts::AON_PROG => (),
-                    _ => panic!("unhandled interrupt {:?}", interrupt),
+                    _ => panic!("unhandled interrupt {}", interrupt),
                 }
                 let n = nvic::Nvic::new(interrupt);
                 n.clear_pending();

--- a/chips/cc26x2/src/lib.rs
+++ b/chips/cc26x2/src/lib.rs
@@ -1,14 +1,17 @@
-#![feature(used)]
+#![feature(const_fn, used)]
 #![no_std]
 #![crate_name = "cc26x2"]
 #![crate_type = "rlib"]
 extern crate cc26xx;
 extern crate cortexm4;
 #[allow(unused_imports)]
-#[macro_use(debug)]
+#[macro_use]
 extern crate kernel;
 
+pub mod aon;
 pub mod chip;
 pub mod crt1;
+pub mod prcm;
+pub mod rtc;
 
 pub use crt1::init;

--- a/chips/cc26x2/src/prcm.rs
+++ b/chips/cc26x2/src/prcm.rs
@@ -14,8 +14,13 @@
 use kernel::common::registers::{ReadOnly, ReadWrite, WriteOnly};
 use kernel::common::StaticRef;
 
+// The AON Power Management Control registers are required here to select the clock source for
+// wake up and power down control. If they are not initialized/deactivated properly when attempting
+// to power down and back up the radio module, the sleep and restart modes will fail. This is not
+// specifically stated in the techinical reference manual but can be found here via TI's web
+// resources: http://dev.ti.com/tirex/content/simplelink_cc13x2_sdk_1_60_00_29/docs/driverlib_cc13xx_cc26xx/cc13x2_cc26x2/register_descriptions/CPU_MMAP/AON_PMCTL.html
 #[repr(C)]
-struct AonWucRegisters {
+struct AonPMCtlRegisters {
     mcu_clk: ReadWrite<u32>,
 }
 
@@ -161,8 +166,8 @@ register_bitfields![
 
 const PRCM_BASE: StaticRef<PrcmRegisters> =
     unsafe { StaticRef::new(0x4008_2000 as *mut PrcmRegisters) };
-const AON_WUC_BASE: StaticRef<AonWucRegisters> =
-    unsafe { StaticRef::new(0x4009_1000 as *mut AonWucRegisters) };
+const AON_PMCTL_BASE: StaticRef<AonPMCtlRegisters> =
+    unsafe { StaticRef::new(0x4009_0010 as *mut AonPMCtlRegisters) };
 
 // In order to save changes to the PRCM, we need to
 // trigger the load register
@@ -369,7 +374,7 @@ impl Clock {
     }
 
     pub fn set_power_down_source(source: u32) {
-        let regs = AON_WUC_BASE;
+        let regs = AON_PMCTL_BASE;
         regs.mcu_clk.set(source & 0x01);
     }
 }

--- a/chips/cc26x2/src/prcm.rs
+++ b/chips/cc26x2/src/prcm.rs
@@ -1,0 +1,380 @@
+//! Power, Clock, and Reset Management (PRCM)
+//!
+//! For details see pg 451-566 of the cc13x2/cc26x2 Technical Reference Manual.
+//!
+//! PRCM manages different power domains on the boards, specifically:
+//!
+//!     * RF Power domain
+//!     * Serial Power domain
+//!     * Peripheral Power domain
+//!
+//! It also manages the clocks attached to almost every peripheral, which needs to
+//! be enabled before usage.
+//!
+use kernel::common::registers::{ReadOnly, ReadWrite, WriteOnly};
+use kernel::common::StaticRef;
+
+#[repr(C)]
+struct AonWucRegisters {
+    mcu_clk: ReadWrite<u32>,
+}
+
+register_bitfields! [
+    u32,
+    MCUClockControl [
+        PWR_DWN_SRC OFFSET(0) NUMBITS(2) [
+            NO_CLOCK = 0b00,
+            SCLK_LF = 0b01
+        ]
+    ]
+];
+
+#[repr(C)]
+struct PrcmRegisters {
+    // leaving INFRCLKDIVR/INFRCLKDIVRS/INFRCLKDIVD unimplemented for now
+    _reserved0: [ReadOnly<u8>; 0x0C],
+
+    // MCU Voltage Domain Control
+    pub vd_ctl: ReadWrite<u32, VDControl::Register>,
+
+    _reserved1: [ReadOnly<u8>; 0x18],
+
+    // Write 1 in order to load prcm settings to CLKCTL power domain
+    pub clk_load_ctl: ReadWrite<u32, ClockLoad::Register>,
+
+    // RFC Clock Gate
+    pub rfc_clk_gate: ReadWrite<u32, ClockGate::Register>,
+
+    _reserved2: [ReadOnly<u8>; 0xC],
+
+    // TRNG, Crypto, and UDMA
+    pub sec_dma_clk_run: ReadWrite<u32, SECDMAClockGate::Register>,
+    pub sec_dma_clk_sleep: ReadWrite<u32, SECDMAClockGate::Register>,
+    pub sec_dma_clk_deep_sleep: ReadWrite<u32, SECDMAClockGate::Register>,
+
+    // GPIO Clock Gate for run, sleep, and deep sleep modes
+    pub gpio_clk_gate_run: ReadWrite<u32, ClockGate::Register>,
+    pub gpio_clk_gate_sleep: ReadWrite<u32, ClockGate::Register>,
+    pub gpio_clk_gate_deep_sleep: ReadWrite<u32, ClockGate::Register>,
+
+    // GPT Clock Gate for run, sleep, and deep sleep modes
+    pub gpt_clk_gate_run: ReadWrite<u32, ClockGate::Register>,
+    pub gpt_clk_gate_sleep: ReadWrite<u32, ClockGate::Register>,
+    pub gpt_clk_gate_deep_sleep: ReadWrite<u32, ClockGate::Register>,
+
+    // I2C Clock Gate for run, sleep, and deep sleep modes
+    pub i2c_clk_gate_run: ReadWrite<u32, ClockGate::Register>,
+    pub i2c_clk_gate_sleep: ReadWrite<u32, ClockGate::Register>,
+    pub i2c_clk_gate_deep_sleep: ReadWrite<u32, ClockGate::Register>,
+
+    // UART Clock Gate for run, sleep, and deep sleep modes
+    pub uart_clk_gate_run: ReadWrite<u32, ClockGate::Register>,
+    pub uart_clk_gate_sleep: ReadWrite<u32, ClockGate::Register>,
+    pub uart_clk_gate_deep_sleep: ReadWrite<u32, ClockGate::Register>,
+
+    _reserved4: [ReadOnly<u8>; 0xB4],
+
+    // Power Domain Control 0
+    pub pd_ctl0: ReadWrite<u32, PowerDomain0::Register>,
+    pub pd_ctl0_rfc: WriteOnly<u32, PowerDomainSingle::Register>,
+    pub pd_ctl0_serial: WriteOnly<u32, PowerDomainSingle::Register>,
+    pub pd_ctl0_peripheral: WriteOnly<u32, PowerDomainSingle::Register>,
+
+    _reserved5: [ReadOnly<u8>; 0x04],
+
+    // Power Domain Status 0
+    pub pd_stat0: ReadOnly<u32, PowerDomainStatus0::Register>,
+    pub pd_stat0_rfc: ReadOnly<u32, PowerDomainSingle::Register>,
+    pub pd_stat0_serial: ReadOnly<u32, PowerDomainSingle::Register>,
+    pub pd_stat0_periph: ReadOnly<u32, PowerDomainSingle::Register>,
+
+    _reserved7: [ReadOnly<u8>; 0x2C],
+
+    // Power Domain Control 1
+    pub pd_ctl1: ReadWrite<u32, PowerDomain1::Register>,
+
+    _reserved8: [ReadOnly<u8>; 0x14],
+
+    // Power Domain Status 1
+    pub pd_stat1: ReadOnly<u32, PowerDomainStatus1::Register>,
+
+    _reserved9: [ReadOnly<u8>; 0x38],
+
+    // RF
+    pub rfc_mode_sel: ReadWrite<u32>,
+}
+
+register_bitfields![
+    u32,
+    VDControl [
+        // SPARE1 (bits 1-31)
+        ULDO              OFFSET(0) NUMBITS(1) []
+    ],
+    ClockLoad [
+        // RESERVED (bits 2-31)
+        LOAD_DONE   OFFSET(1) NUMBITS(1) [],
+        LOAD        OFFSET(0) NUMBITS(1) []
+    ],
+    SECDMAClockGate [
+        //RESERVED (bits 25-31)
+        // Force Clock Enable for Crypto, TRNG, DMA, PKA not implemented here (bits 16, 17, 18 , 24
+        // respectively)
+        DMA_CLK_EN      OFFSET(8) NUMBITS(1) [],
+        // RESERVED (bits 3-7)
+        // PKA Clock not implemented (bit 2)
+        TRNG_CLK_EN     OFFSET(1) NUMBITS(1) [],
+        CRYPTO_CLK_EN   OFFSET(0) NUMBITS(1) []
+    ],
+    ClockGate [
+        // RESERVED (bits 1-31)
+        CLK_EN      OFFSET(0) NUMBITS(1) []
+    ],
+    PowerDomain0 [
+        // RESERVED (bits 3-31)
+        PERIPH_ON   OFFSET(2) NUMBITS(1) [],
+        SERIAL_ON   OFFSET(1) NUMBITS(1) [],
+        RFC_ON      OFFSET(0) NUMBITS(1) []
+    ],
+    PowerDomainSingle [
+        // RESERVED (bits 1-31)
+        ON          OFFSET(0) NUMBITS(1) []
+    ],
+    PowerDomainStatus0 [
+        // RESERVED (bits 1-31)
+        PERIPH_ON   OFFSET(2) NUMBITS(1) [],
+        SERIAL_ON   OFFSET(1) NUMBITS(1) [],
+        RFC_ON      OFFSET(0) NUMBITS(1) []
+    ],
+    PowerDomain1 [
+        // RESERVED (bits 1-31)
+        VIMS_ON   OFFSET(2) NUMBITS(1) [],
+        RFC_ON   OFFSET(1) NUMBITS(1) [],
+        CPU_ON      OFFSET(0) NUMBITS(1) []
+    ],
+    PowerDomainStatus1 [
+        // RESERVED (bits 3-31)
+        VIMS_ON     OFFSET(2) NUMBITS(1) [],
+        RFC_ON      OFFSET(1) NUMBITS(1) [],
+        CPU_ON      OFFSET(0) NUMBITS(1) []
+    ]
+];
+
+const PRCM_BASE: StaticRef<PrcmRegisters> =
+    unsafe { StaticRef::new(0x4008_2000 as *mut PrcmRegisters) };
+const AON_WUC_BASE: StaticRef<AonWucRegisters> =
+    unsafe { StaticRef::new(0x4009_1000 as *mut AonWucRegisters) };
+
+// In order to save changes to the PRCM, we need to
+// trigger the load register
+
+fn prcm_commit() {
+    let regs = PRCM_BASE;
+    regs.clk_load_ctl.write(ClockLoad::LOAD::SET);
+    // Wait for the settings to take effect
+    while !regs.clk_load_ctl.is_set(ClockLoad::LOAD_DONE) {}
+}
+
+pub fn force_disable_dma_and_crypto() {
+    let regs = PRCM_BASE;
+    if regs.sec_dma_clk_run.is_set(SECDMAClockGate::DMA_CLK_EN) {
+        regs.sec_dma_clk_deep_sleep
+            .modify(SECDMAClockGate::DMA_CLK_EN::CLEAR);
+    }
+    if regs.sec_dma_clk_run.is_set(SECDMAClockGate::CRYPTO_CLK_EN) {
+        regs.sec_dma_clk_deep_sleep
+            .modify(SECDMAClockGate::CRYPTO_CLK_EN::CLEAR);
+    }
+
+    prcm_commit();
+}
+
+/// The ULDO power source is a temporary power source
+/// which could be enable to drive Peripherals in deep sleep.
+pub fn acquire_uldo() {
+    let regs = PRCM_BASE;
+    regs.vd_ctl.modify(VDControl::ULDO::SET);
+}
+
+/// It is no use to enable the ULDO power source constantly,
+/// and it would need to be released once we go out of deep sleep
+pub fn release_uldo() {
+    let regs = PRCM_BASE;
+    regs.vd_ctl.modify(VDControl::ULDO::CLEAR);
+}
+
+pub enum PowerDomain {
+    // Note: when RFC is to be enabled, you are required to use both
+    // power domains (i.e enable RFC on both PowerDomain0 and PowerDomain1)
+    RFC,
+    Serial,
+    Peripherals,
+    VIMS,
+    CPU,
+}
+
+impl From<u32> for PowerDomain {
+    fn from(n: u32) -> Self {
+        match n {
+            0 => PowerDomain::RFC,
+            1 => PowerDomain::Serial,
+            2 => PowerDomain::Peripherals,
+            3 => PowerDomain::VIMS,
+            4 => PowerDomain::CPU,
+            _ => unimplemented!(),
+        }
+    }
+}
+
+pub struct Power(());
+
+impl Power {
+    pub fn enable_domain(domain: PowerDomain) {
+        let regs = PRCM_BASE;
+
+        match domain {
+            PowerDomain::Peripherals => {
+                regs.pd_ctl0.modify(PowerDomain0::PERIPH_ON::SET);
+            }
+            PowerDomain::Serial => {
+                regs.pd_ctl0.modify(PowerDomain0::SERIAL_ON::SET);
+            }
+            PowerDomain::RFC => {
+                regs.pd_ctl0.modify(PowerDomain0::RFC_ON::SET);
+                regs.pd_ctl1.modify(PowerDomain1::RFC_ON::SET);
+                while !Power::is_enabled(PowerDomain::RFC) {}
+            }
+            PowerDomain::CPU => {
+                regs.pd_ctl1.modify(PowerDomain1::CPU_ON::SET);
+                while !Power::is_enabled(PowerDomain::CPU) {}
+            }
+            PowerDomain::VIMS => {
+                regs.pd_ctl1.modify(PowerDomain1::VIMS_ON::SET);
+                while !Power::is_enabled(PowerDomain::VIMS) {}
+            }
+        }
+    }
+
+    pub fn disable_domain(domain: PowerDomain) {
+        let regs = PRCM_BASE;
+
+        match domain {
+            PowerDomain::Peripherals => {
+                regs.pd_ctl0.modify(PowerDomain0::PERIPH_ON::CLEAR);
+            }
+            PowerDomain::Serial => {
+                regs.pd_ctl0.modify(PowerDomain0::SERIAL_ON::CLEAR);
+            }
+            PowerDomain::RFC => {
+                regs.pd_ctl0.modify(PowerDomain0::RFC_ON::CLEAR);
+                regs.pd_ctl1.modify(PowerDomain1::RFC_ON::CLEAR);
+            }
+            PowerDomain::CPU => {
+                regs.pd_ctl1.modify(PowerDomain1::CPU_ON::CLEAR);
+            }
+            PowerDomain::VIMS => {
+                regs.pd_ctl1.modify(PowerDomain1::VIMS_ON::CLEAR);
+            }
+        }
+    }
+
+    pub fn is_enabled(domain: PowerDomain) -> bool {
+        let regs = PRCM_BASE;
+        match domain {
+            PowerDomain::Peripherals => regs.pd_stat0_periph.is_set(PowerDomainSingle::ON),
+            PowerDomain::Serial => regs.pd_stat0_serial.is_set(PowerDomainSingle::ON),
+            PowerDomain::RFC => {
+                regs.pd_stat0.is_set(PowerDomainStatus0::RFC_ON)
+                    && regs.pd_stat1.is_set(PowerDomainStatus1::RFC_ON)
+            }
+            PowerDomain::VIMS => regs.pd_stat1.is_set(PowerDomainStatus1::VIMS_ON),
+            PowerDomain::CPU => regs.pd_stat1.is_set(PowerDomainStatus1::CPU_ON),
+        }
+    }
+}
+
+pub struct Clock(());
+
+impl Clock {
+    pub fn enable_gpio() {
+        let regs = PRCM_BASE;
+        regs.gpio_clk_gate_run.write(ClockGate::CLK_EN::SET);
+        regs.gpio_clk_gate_sleep.write(ClockGate::CLK_EN::SET);
+        regs.gpio_clk_gate_deep_sleep.write(ClockGate::CLK_EN::SET);
+
+        prcm_commit();
+    }
+
+    pub fn enable_trng() {
+        let regs = PRCM_BASE;
+        regs.sec_dma_clk_run
+            .modify(SECDMAClockGate::TRNG_CLK_EN::SET);
+        regs.sec_dma_clk_sleep
+            .modify(SECDMAClockGate::TRNG_CLK_EN::SET);
+        regs.sec_dma_clk_deep_sleep
+            .modify(SECDMAClockGate::TRNG_CLK_EN::SET);
+
+        prcm_commit();
+    }
+
+    /// Enables UART clocks for run, sleep and deep sleep mode.
+    pub fn enable_uart() {
+        let regs = PRCM_BASE;
+        regs.uart_clk_gate_run.modify(ClockGate::CLK_EN::SET);
+        regs.uart_clk_gate_sleep.modify(ClockGate::CLK_EN::SET);
+        regs.uart_clk_gate_deep_sleep.modify(ClockGate::CLK_EN::SET);
+
+        prcm_commit();
+    }
+
+    pub fn disable_uart() {
+        let regs = PRCM_BASE;
+        regs.uart_clk_gate_run.modify(ClockGate::CLK_EN::CLEAR);
+        regs.uart_clk_gate_sleep.modify(ClockGate::CLK_EN::CLEAR);
+        regs.uart_clk_gate_deep_sleep
+            .modify(ClockGate::CLK_EN::CLEAR);
+
+        prcm_commit();
+    }
+
+    pub fn enable_rfc() {
+        let regs = PRCM_BASE;
+        regs.rfc_clk_gate.write(ClockGate::CLK_EN::SET);
+
+        prcm_commit();
+    }
+
+    pub fn disable_rfc() {
+        let regs = PRCM_BASE;
+        regs.rfc_clk_gate.write(ClockGate::CLK_EN::CLEAR);
+
+        prcm_commit();
+    }
+
+    pub fn enable_gpt() {
+        let regs = PRCM_BASE;
+        regs.gpt_clk_gate_run.write(ClockGate::CLK_EN::SET);
+        regs.gpt_clk_gate_sleep.write(ClockGate::CLK_EN::SET);
+        regs.gpt_clk_gate_deep_sleep.write(ClockGate::CLK_EN::SET);
+
+        prcm_commit();
+    }
+
+    pub fn disable_gpt() {
+        let regs = PRCM_BASE;
+        regs.gpt_clk_gate_run.write(ClockGate::CLK_EN::CLEAR);
+        regs.gpt_clk_gate_sleep.write(ClockGate::CLK_EN::CLEAR);
+        regs.gpt_clk_gate_deep_sleep.write(ClockGate::CLK_EN::CLEAR);
+
+        prcm_commit();
+    }
+
+    pub fn set_power_down_source(source: u32) {
+        let regs = AON_WUC_BASE;
+        regs.mcu_clk.set(source & 0x01);
+    }
+}
+
+pub fn rf_mode_sel(mode: u32) {
+    let regs = PRCM_BASE;
+    regs.rfc_mode_sel.set(mode);
+}

--- a/chips/cc26x2/src/rtc.rs
+++ b/chips/cc26x2/src/rtc.rs
@@ -1,0 +1,195 @@
+//! RTC driver
+
+use core::cell::Cell;
+use kernel::common::registers::{ReadOnly, ReadWrite};
+use kernel::common::StaticRef;
+use kernel::hil::time::{self, Alarm, Frequency, Time};
+
+#[repr(C)]
+struct RtcRegisters {
+    ctl: ReadWrite<u32, Control::Register>,
+
+    // Event flags
+    evflags: ReadWrite<u32, EvFlags::Register>,
+
+    // Integer part
+    sec: ReadWrite<u32>,
+    // Fractional part (1/32kHz parts of a second)
+    subsec: ReadOnly<u32>,
+
+    _subsec_inc: ReadOnly<u32>,
+    channel_ctl: ReadWrite<u32, ChannelControl::Register>,
+    _channel0_cmp: ReadOnly<u32>,
+    channel1_cmp: ReadWrite<u32>,
+    _channel2_cmp: ReadOnly<u32>,
+    _channel2_cmp_inc: ReadOnly<u32>,
+    _channel1_capture: ReadOnly<u32>,
+
+    // A read request to the sync register will not return
+    // until all outstanding writes have properly propagated to the RTC domain
+    sync: ReadOnly<u32>,
+}
+
+register_bitfields![
+    u32,
+    Control [
+        COMB_EV_MASK OFFSET(16) NUMBITS(3) [
+            NoEvent = 0b00,
+            Channel0 = 0b01,
+            Channel1 = 0b10,
+            Channel2 = 0b11
+        ],
+        RESET       OFFSET(7) NUMBITS(1) [],
+        RTC_UPD_EN  OFFSET(1) NUMBITS(1) [],
+        ENABLE      OFFSET(0) NUMBITS(1) []
+    ],
+    EvFlags [
+        CH2 OFFSET(16) NUMBITS(1) [],
+        CH1 OFFSET(8)  NUMBITS(1) [],
+        CH0 OFFSET(0)  NUMBITS(1) []
+    ],
+    ChannelControl [
+        CH2_CONT_EN OFFSET(18)  NUMBITS(1) [],
+        CH2_EN      OFFSET(16)  NUMBITS(1) [],
+        CH1_CAPT_EN OFFSET(9)   NUMBITS(1) [],
+        CH1_EN      OFFSET(8)   NUMBITS(1) [],
+        CH0_EN      OFFSET(0)   NUMBITS(1) []
+    ]
+];
+
+const RTC_BASE: StaticRef<RtcRegisters> =
+    unsafe { StaticRef::new(0x40092000 as *const RtcRegisters) };
+
+pub struct Rtc {
+    registers: StaticRef<RtcRegisters>,
+    callback: Cell<Option<&'static time::Client>>,
+}
+
+pub static mut RTC: Rtc = Rtc::new();
+
+impl Rtc {
+    const fn new() -> Rtc {
+        Rtc {
+            registers: RTC_BASE,
+            callback: Cell::new(None),
+        }
+    }
+
+    pub fn start(&self) {
+        let regs = &*self.registers;
+        regs.ctl.write(Control::ENABLE::SET);
+
+        regs.sync.get();
+    }
+
+    pub fn stop(&self) {
+        let regs = &*self.registers;
+        regs.ctl.write(Control::ENABLE::CLEAR);
+
+        regs.sync.get();
+    }
+
+    pub fn sync(&self) {
+        let regs = &*self.registers;
+
+        regs.sync.get();
+    }
+    fn read_counter(&self) -> u32 {
+        let regs = &*self.registers;
+
+        /*
+            SEC can change during the SUBSEC read, so we need to be certain
+            that the SUBSEC we read belong to the correct SEC counterpart.
+        */
+        let mut current_sec: u32 = 0;
+        let mut current_subsec: u32 = 0;
+        let mut after_subsec_read: u32 = 1;
+        while current_sec != after_subsec_read {
+            current_sec = regs.sec.get();
+            current_subsec = regs.subsec.get();
+            after_subsec_read = regs.sec.get();
+        }
+
+        return (current_sec << 16) | (current_subsec >> 16);
+    }
+
+    pub fn is_running(&self) -> bool {
+        let regs = &*self.registers;
+        regs.channel_ctl.read(ChannelControl::CH1_EN) != 0
+    }
+
+    pub fn handle_interrupt(&self) {
+        let regs = &*self.registers;
+
+        // Event flag is cleared when you set it
+        regs.evflags.write(EvFlags::CH1::SET);
+        regs.ctl.modify(Control::COMB_EV_MASK::NoEvent);
+        regs.channel_ctl.modify(ChannelControl::CH1_EN::CLEAR);
+
+        regs.sync.get();
+
+        self.callback.get().map(|cb| cb.fired());
+    }
+
+    pub fn set_client(&self, client: &'static time::Client) {
+        self.callback.set(Some(client));
+    }
+
+    pub fn set_upd_en(&self, value: bool) {
+        let regs = &*self.registers;
+        if value {
+            regs.ctl.set(regs.ctl.get() | 0x02);
+        } else {
+            regs.ctl.set(regs.ctl.get() & !0x02);
+        }
+    }
+}
+
+pub struct RtcFreq(());
+
+impl Frequency for RtcFreq {
+    // The RTC Frequency is tuned, as there is exactly 0xFFFF (64kHz)
+    // subsec increments to reach a second, this yields the correct
+    // `tics` to set the comparator correctly.
+    fn frequency() -> u32 {
+        0xFFFF
+    }
+}
+
+impl Time for Rtc {
+    type Frequency = RtcFreq;
+
+    fn disable(&self) {
+        let regs = &*self.registers;
+
+        regs.ctl.modify(Control::COMB_EV_MASK::NoEvent);
+        regs.channel_ctl.modify(ChannelControl::CH1_EN::CLEAR);
+
+        regs.sync.get();
+    }
+
+    fn is_armed(&self) -> bool {
+        self.is_running()
+    }
+}
+
+impl Alarm for Rtc {
+    fn now(&self) -> u32 {
+        self.read_counter()
+    }
+
+    fn set_alarm(&self, tics: u32) {
+        let regs = &*self.registers;
+
+        regs.ctl.modify(Control::COMB_EV_MASK::Channel1);
+        regs.channel1_cmp.set(tics);
+        regs.channel_ctl.modify(ChannelControl::CH1_EN::SET);
+
+        regs.sync.get();
+    }
+
+    fn get_alarm(&self) -> u32 {
+        let regs = &*self.registers;
+        regs.channel1_cmp.get()
+    }
+}

--- a/chips/cc26x2/src/rtc.rs
+++ b/chips/cc26x2/src/rtc.rs
@@ -89,6 +89,7 @@ impl Rtc {
         regs.sync.get();
     }
 
+    // This method is used by the RAT to sync the radio and MCU clocks when changing power modes
     pub fn sync(&self) {
         let regs = &*self.registers;
 


### PR DESCRIPTION
### Pull Request Overview

Add support for RTC, power domain and clock control to the cc26x2 chip.

### Testing Strategy

This PR was tested by initializing dependent peripherals (RFCore from a separate PR) and passing is_enabled() checks. Panic on fail. 

### TODO or Help Wanted

n/a

### Documentation Updated

- [ ] ~~Updated the relevant files in `/docs`, or no updates are required.~~

### Formatting

- [x] Ran `make formatall`.
