### PR TITLE
kernel: debug: fix print

### DIFF
--- a/kernel/Cargo.lock
+++ b/kernel/Cargo.lock
@@ -3,7 +3,7 @@ name = "kernel"
 version = "0.1.0"
 dependencies = [
  "tock-cells 0.1.0",
- "tock-regs 0.1.0",
+ "tock-registers 0.1.0",
 ]
 
 [[package]]
@@ -11,6 +11,6 @@ name = "tock-cells"
 version = "0.1.0"
 
 [[package]]
-name = "tock-regs"
+name = "tock-registers"
 version = "0.1.0"
 

--- a/kernel/src/debug.rs
+++ b/kernel/src/debug.rs
@@ -90,6 +90,9 @@ pub unsafe fn panic_banner<W: Write>(writer: &mut W, panic_info: &PanicInfo) {
     } else {
         let _ = writer.write_fmt(format_args!("\r\n\nKernel panic:\r\n\t\""));
     }
+    if let Some(args) = panic_info.message() {
+        let _ = write(writer, *args);
+    }
     let _ = writer.write_str("\"\r\n");
 
     // Print version of the kernel

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -7,7 +7,7 @@
 //! Most `unsafe` code is in this kernel crate.
 
 #![feature(asm, core_intrinsics, unique, ptr_internals, const_fn)]
-#![feature(use_extern_macros, try_from, used)]
+#![feature(use_extern_macros, try_from, used, panic_info_message)]
 #![feature(in_band_lifetimes, crate_visibility_modifier)]
 #![warn(unreachable_pub)]
 #![no_std]


### PR DESCRIPTION
Accidentally removed the actual panic message with the update to the new nightly. This adds it back.




### Testing Strategy

Seeing a panic! on hail.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
