### PR TITLE
Kernel: add comments

### DIFF
--- a/kernel/src/callback.rs
+++ b/kernel/src/callback.rs
@@ -39,6 +39,10 @@ impl AppId {
         self.idx
     }
 
+    /// Returns the full address of the start and end of the flash region that
+    /// the app owns and can write to. This includes the app's code and data and
+    /// any padding at the end of the app. It does not include the TBF header,
+    /// or any space that the kernel is using for any potential bookkeeping.
     pub fn get_editable_flash_range(&self) -> (usize, usize) {
         self.kernel.process_map_or((0, 0), self.idx, |process| {
             let start = process.flash_non_protected_start() as usize;
@@ -48,7 +52,9 @@ impl AppId {
     }
 }
 
-/// Wrapper around a function pointer.
+/// Type for calling a callback in a process.
+///
+/// This is essentially a wrapper around a function pointer.
 #[derive(Clone, Copy)]
 pub struct Callback {
     app_id: AppId,
@@ -65,6 +71,14 @@ impl Callback {
         }
     }
 
+    /// Actually trigger the callback.
+    ///
+    /// This will queue the `Callback` for the associated process. It returns
+    /// `false` if the queue for the process is full and the callback could not
+    /// be scheduled.
+    ///
+    /// The arguments (`r0-r2`) are the values passed back to the process and
+    /// are specific to the individual `Driver` interfaces.
     pub fn schedule(&mut self, r0: usize, r1: usize, r2: usize) -> bool {
         self.app_id
             .kernel

--- a/kernel/src/common/queue.rs
+++ b/kernel/src/common/queue.rs
@@ -1,10 +1,19 @@
 //! Interface for queue structure.
 
 pub trait Queue<T> {
+    /// Returns true if there are any items in the queue, false otherwise.
     fn has_elements(&self) -> bool;
+
+    /// Returns true if the queue is full, false otherwise.
     fn is_full(&self) -> bool;
+
+    /// Returns how many elements are in the queue.
     fn len(&self) -> usize;
+
+    /// Add a new element to the back of the queue.
     fn enqueue(&mut self, val: T) -> bool;
+
+    /// Remove the element from the front of the queue.
     fn dequeue(&mut self) -> Option<T>;
 
     /// Remove all elements from the ring buffer.

--- a/kernel/src/mem.rs
+++ b/kernel/src/mem.rs
@@ -12,6 +12,8 @@ pub struct Private;
 #[derive(Debug)]
 pub struct Shared;
 
+/// Base type for an AppSlice that holds the raw pointer to the memory region
+/// the app shared with the kernel.
 pub struct AppPtr<L, T> {
     ptr: Unique<T>,
     process: AppId,
@@ -52,6 +54,9 @@ impl<L, T> Drop for AppPtr<L, T> {
     }
 }
 
+/// Buffer of memory shared from an app to the kernel.
+///
+/// This is the type created after an app calls the `allow` syscall.
 pub struct AppSlice<L, T> {
     ptr: AppPtr<L, T>,
     len: usize,
@@ -67,14 +72,19 @@ impl<L, T> AppSlice<L, T> {
         }
     }
 
+    /// Number of bytes in the `AppSlice`.
     pub fn len(&self) -> usize {
         self.len
     }
 
+    /// Get the raw pointer to the buffer. This will be a pointer inside of the
+    /// app's memory region.
     pub fn ptr(&self) -> *const T {
         self.ptr.ptr.as_ptr()
     }
 
+    /// Provide access to one app's AppSlice to another app. This is used for
+    /// IPC.
     crate unsafe fn expose_to(&self, appid: AppId) -> bool {
         if appid.idx() != self.ptr.process.idx() {
             self.ptr

--- a/kernel/src/returncode.rs
+++ b/kernel/src/returncode.rs
@@ -1,26 +1,42 @@
 //! Standard return type for invoking operations, returning success or an error
 //! code.
 //!
-//!  Author: Philip Levis <pal@cs.stanford.edu>
-//!  Date: Dec 22, 2016
+//! - Author: Philip Levis <pal@cs.stanford.edu>
+//! - Date: Dec 22, 2016
 
+/// Standard return errors in Tock.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ReturnCode {
-    SuccessWithValue { value: usize }, // Success value must be positive
+    /// Success value must be positive
+    SuccessWithValue { value: usize },
+    /// Operation completed successfully
     SUCCESS,
-    FAIL,         // Generic failure condition
-    EBUSY,        // Underlying system is busy; retry
-    EALREADY,     // The state requested is already set
-    EOFF,         // The component is powered down
-    ERESERVE,     // Reservation required before use
-    EINVAL,       // An invalid parameter was passed
-    ESIZE,        // Parameter passed was too large
-    ECANCEL,      // Operation canceled by a call
-    ENOMEM,       // Memory required not available
-    ENOSUPPORT,   // Operation or command is unsupported
-    ENODEVICE,    // Device does not exist
-    EUNINSTALLED, // Device is not physically installed
-    ENOACK,       // Packet transmission not acknowledged
+    /// Generic failure condition
+    FAIL,
+    /// Underlying system is busy; retry
+    EBUSY,
+    /// The state requested is already set
+    EALREADY,
+    /// The component is powered down
+    EOFF,
+    /// Reservation required before use
+    ERESERVE,
+    /// An invalid parameter was passed
+    EINVAL,
+    /// Parameter passed was too large
+    ESIZE,
+    /// Operation canceled by a call
+    ECANCEL,
+    /// Memory required not available
+    ENOMEM,
+    /// Operation or command is unsupported
+    ENOSUPPORT,
+    /// Device does not exist
+    ENODEVICE,
+    /// Device is not physically installed
+    EUNINSTALLED,
+    /// Packet transmission not acknowledged
+    ENOACK,
 }
 
 impl From<ReturnCode> for isize {


### PR DESCRIPTION
### Pull Request Overview

This pull request:

- Adds comments to data structures in the kernel.
- ~~Removes the need for `Callback` to be `mut` (which has ramifications for the capsules).~~
- ~~Removes the need for `Allocator` to be `mut`.~~

~~Blocked on #1115.~~

### Testing Strategy

This pull request was tested by compiling.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
