### PR TITLE
capsules: add reset function to nrf serialization

### DIFF
--- a/boards/imix/src/components/nrf51822.rs
+++ b/boards/imix/src/components/nrf51822.rs
@@ -21,11 +21,18 @@ use sam4l;
 
 pub struct Nrf51822Component {
     uart: &'static sam4l::usart::USART,
+    reset_pin: &'static sam4l::gpio::GPIOPin,
 }
 
 impl Nrf51822Component {
-    pub fn new(uart: &'static sam4l::usart::USART) -> Nrf51822Component {
-        Nrf51822Component { uart: uart }
+    pub fn new(
+        uart: &'static sam4l::usart::USART,
+        reset_pin: &'static sam4l::gpio::GPIOPin,
+    ) -> Nrf51822Component {
+        Nrf51822Component {
+            uart: uart,
+            reset_pin: reset_pin,
+        }
     }
 }
 
@@ -39,6 +46,7 @@ impl Component for Nrf51822Component {
             nrf51822_serialization::Nrf51822Serialization<sam4l::usart::USART>,
             nrf51822_serialization::Nrf51822Serialization::new(
                 self.uart,
+                self.reset_pin,
                 &mut nrf51822_serialization::WRITE_BUF,
                 &mut nrf51822_serialization::READ_BUF
             )

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -257,7 +257,8 @@ pub unsafe fn reset_handler() {
     let console = ConsoleComponent::new(&sam4l::usart::USART3, 115200).finalize();
 
     // Allow processes to communicate over BLE through the nRF51822
-    let nrf_serialization = Nrf51822Component::new(&sam4l::usart::USART2).finalize();
+    let nrf_serialization =
+        Nrf51822Component::new(&sam4l::usart::USART2, &sam4l::gpio::PB[07]).finalize();
 
     // # TIMER
     let ast = &sam4l::ast::AST;
@@ -336,15 +337,7 @@ pub unsafe fn reset_handler() {
     let mut chip = sam4l::chip::Sam4l::new();
 
     // Need to reset the nRF on boot, toggle it's SWDIO
-    sam4l::gpio::PB[07].enable();
-    sam4l::gpio::PB[07].enable_output();
-    sam4l::gpio::PB[07].clear();
-    // minimum hold time is 200ns, ~20ns per instruction, so overshoot a bit
-    for _ in 0..10 {
-        cortexm4::support::nop();
-    }
-    sam4l::gpio::PB[07].set();
-
+    imix.nrf51822.reset();
     imix.nrf51822.initialize();
 
     // These two lines need to be below the creation of the chip for


### PR DESCRIPTION
### Pull Request Overview

This pull request moves the reset operation of the nrf51822 serialization capsule into the capsule itself. That it was ever in the board file is probably an artifact of when that capsule was written more than anything else. It also exposes the reset function as a command in the syscall interface.

I believe this is necessary to make apps that use nrf serialization able to restart on faults.


### Testing Strategy

This pull request was tested by verifying the hail app still sends packets.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required. (nrf_serialization doesn't have a doc in the syscalls folder)

### Formatting

- [x] Ran `make formatall`.
