### PR TITLE
New MPU Interface

### DIFF
--- a/arch/cortex-m4/src/mpu.rs
+++ b/arch/cortex-m4/src/mpu.rs
@@ -1,28 +1,11 @@
 //! Implementation of the ARM memory protection unit.
 
 use kernel;
-use kernel::common::cells::VolatileCell;
 use kernel::common::math::PowerOfTwo;
+use kernel::common::registers::{ReadOnly, ReadWrite};
 use kernel::common::StaticRef;
-
-/// Indicates whether the MPU is present and, if so, how many regions it
-/// supports.
-#[repr(C)]
-pub struct MpuType {
-    /// Indicates whether the processor support unified (0) or separate
-    /// (1) instruction and data regions. Always reads 0 on the
-    /// Cortex-M4.
-    pub is_separate: VolatileCell<u8>,
-
-    /// The number of data regions supported. If this field reads-as-zero the
-    /// processor does not implement an MPU
-    pub data_regions: VolatileCell<u8>,
-
-    /// The number of instructions regions supported. Always reads 0.
-    pub instruction_regions: VolatileCell<u8>,
-
-    _reserved: u8,
-}
+use kernel::mpu::{Permission, Region};
+use kernel::ReturnCode;
 
 #[repr(C)]
 /// MPU Registers for the Cortex-M4 family
@@ -30,79 +13,93 @@ pub struct MpuType {
 /// Described in section 4.5 of
 /// <http://infocenter.arm.com/help/topic/com.arm.doc.dui0553a/DUI0553A_cortex_m4_dgug.pdf>
 pub struct MpuRegisters {
-    pub mpu_type: VolatileCell<MpuType>,
-
-    /// The control register:
-    ///
-    ///   * Enables the MPU (bit 0).
-    ///   * Enables MPU in hard-fault, non-maskable interrupt (NMI) and
-    ///     FAULTMASK escalated handlers (bit 1).
-    ///   * Enables the default memory map background region in privileged mode
-    ///     (bit 2).
-    ///
-    /// ```text
-    /// Bit   | Name       | Function
-    /// ----- | ---------- | -----------------------------
-    /// 0     | ENABLE     | Enable the MPU (1=enabled)
-    /// 1     | HFNMIENA   | 0=MPU disabled during HardFault, NMI, and FAULTMASK
-    ///       |            | regardless of bit 0. 1 leaves enabled.
-    /// 2     | PRIVDEFENA | 0=Any memory access not explicitly enabled causes fault
-    ///       |            | 1=Privledged mode code can read any memory address
-    /// ```
-    pub control: VolatileCell<u32>,
-
-    /// Selects the region number (zero-indexed) referenced by the region base
-    /// address and region attribute and size registers.
-    ///
-    /// ```text
-    /// Bit   | Name     | Function
-    /// ----- | -------- | -----------------------------
-    /// [7:0] | REGION   | Region for writes to MPU_RBAR or MPU_RASR. Range 0-7.
-    /// ```
-    pub region_number: VolatileCell<u32>,
-
-    /// Defines the base address of the currently selected MPU region.
-    ///
-    /// When writing, the first 3 bits select a new region if bit-4 is set.
-    ///
-    /// The top bits set the base address of the register, with the bottom 32-N
-    /// bits masked based on the region size (set in the region attribute and
-    /// size register) according to:
-    ///
-    ///   N = Log2(Region size in bytes)
-    ///
-    /// ```text
-    /// Bit       | Name    | Function
-    /// --------- | ------- | -----------------------------
-    /// [31:N]    | ADDR    | Region base address
-    /// [(N-1):5] |         | Reserved
-    /// [4]       | VALID   | {RZ} 0=Use region_number reg, 1=Use REGION
-    ///           |         |      Update base address for chosen region
-    /// [3:0]     | REGION  | {W} (see VALID) ; {R} return region_number reg
-    /// ```
-    pub region_base_address: VolatileCell<u32>,
-
-    /// Defines the region size and memory attributes of the selected MPU
-    /// region. The bits are defined as in 4.5.5 of the Cortex-M4 user guide:
-    ///
-    /// ```text
-    /// Bit   | Name   | Function
-    /// ----- | ------ | -----------------------------
-    /// 0     | ENABLE | Region enable
-    /// 5:1   | SIZE   | Region size is 2^(SIZE+1) (minimum 3)
-    /// 7:6   |        | Unused
-    /// 15:8  | SRD    | Subregion disable bits (0 is enable, 1 is disable)
-    /// 16    | B      | Memory access attribute
-    /// 17    | C      | Memory access attribute
-    /// 18    | S      | Shareable
-    /// 21:19 | TEX    | Memory access attribute
-    /// 23:22 |        | Unused
-    /// 26:24 | AP     | Access permission field
-    /// 27    |        | Unused
-    /// 28    | XN     | Instruction access disable
-    /// ```
-    pub region_attributes_and_size: VolatileCell<u32>,
+    pub mpu_type: ReadOnly<u32, Type::Register>,
+    pub ctrl: ReadWrite<u32, Control::Register>,
+    pub rnr: ReadWrite<u32, RegionNumber::Register>,
+    pub rbar: ReadWrite<u32, RegionBaseAddress::Register>,
+    pub rasr: ReadWrite<u32, RegionAttributes::Register>,
 }
+
+register_bitfields![u32,
+    Type [
+        /// The number of MPU instructions regions supported. Always reads 0.
+        IREGION OFFSET(16) NUMBITS(8) [],
+        /// The number of data regions supported. If this field reads-as-zero the
+        /// processor does not implement an MPU
+        DREGION OFFSET(8) NUMBITS(8) [],
+        /// Indicates whether the processor support unified (0) or separate
+        /// (1) instruction and data regions. Always reads 0 on the
+        /// Cortex-M4.
+        SEPARATE OFFSET(0) NUMBITS(1) []
+    ],
+
+    Control [
+        /// Enables privileged software access to the default
+        /// memory map
+        PRIVDEFENA OFFSET(2) NUMBITS(1) [
+            Enable = 0,
+            Disable = 1
+        ],
+        /// Enables the operation of MPU during hard fault, NMI, 
+        /// and FAULTMASK handlers
+        HFNMIENA OFFSET(1) NUMBITS(1) [
+            Enable = 0,
+            Disable = 1
+        ],
+        /// Enables the MPU
+        ENABLE OFFSET(0) NUMBITS(1) [
+            Disable = 0,
+            Enable = 1
+        ]
+    ],
+
+    RegionNumber [
+        /// Region indicating the MPU region referenced by the MPU_RBAR and
+        /// MPU_RASR registers. Range 0-7 corresponding to the MPU regions.
+        REGION OFFSET(0) NUMBITS(8) []
+    ],
+
+    RegionBaseAddress [
+        /// Base address of the currently selected MPU region.
+        ADDR OFFSET(5) NUMBITS(27) [],
+        /// MPU Region Number valid bit.
+        VALID OFFSET(4) NUMBITS(1) [
+            /// Use the base address specified in Region Number Register (RNR)
+            UseRNR = 0,
+            /// Use the value of the REGION field in this register (RBAR)
+            UseRBAR = 1
+        ],
+        /// Specifies which MPU region to set if VALID is set to 1.
+        REGION OFFSET(0) NUMBITS(4) []
+    ],
+
+    RegionAttributes [
+        /// Enables instruction fetches/execute permission
+        XN OFFSET(28) NUMBITS(1) [
+            Enable = 0,
+            Disable = 1
+        ],
+        /// Defines access permissions
+        AP OFFSET(24) NUMBITS(3) [
+            //                                 Privileged  Unprivileged
+            //                                 Access      Access
+            NoAccess = 0b000,               // --          --
+            PrivilegedOnly = 0b001,         // RW          --
+            UnprivilegedReadOnly = 0b010,   // RW          R-
+            ReadWrite = 0b011,              // RW          RW
+            Reserved = 0b100,               // undef       undef
+            PrivilegedOnlyReadOnly = 0b101, // R-          --
+            ReadOnly = 0b110,               // R-          R-
+            ReadOnlyAlias = 0b111           // R-          R-
+        ],
+        /// Subregion disable bits
+        SRD OFFSET(8) NUMBITS(8) [],
+        /// Specifies the region size, being 2^(SIZE+1) (minimum 3)
+        SIZE OFFSET(1) NUMBITS(5) [],
+        /// Enables the region
+        ENABLE OFFSET(0) NUMBITS(1) []
+    ]
+];
 
 const MPU_BASE_ADDRESS: StaticRef<MpuRegisters> =
     unsafe { StaticRef::new(0xE000ED90 as *const MpuRegisters) };
@@ -114,44 +111,59 @@ impl MPU {
     pub const unsafe fn new() -> MPU {
         MPU(MPU_BASE_ADDRESS)
     }
-}
 
-type Region = kernel::mpu::Region;
-
-impl kernel::mpu::MPU for MPU {
-    fn enable_mpu(&self) {
+    fn allocate_region(&self, region: &Region, region_num: usize) -> ReturnCode {
         let regs = &*self.0;
 
-        // Enable the MPU, disable it during HardFault/NMI handlers, allow
-        // privileged code access to all unprotected memory.
-        regs.control.set(0b101);
-
-        let mpu_type = regs.mpu_type.get();
-        let regions = mpu_type.data_regions.get();
-        if regions != 8 {
-            panic!(
-                "Tock currently assumes 8 MPU regions. This chip has {}",
-                regions
-            );
-        }
-    }
-
-    fn disable_mpu(&self) {
-        let regs = &*self.0;
-        regs.control.set(0b0);
-    }
-
-    fn create_region(
-        region_num: usize,
-        start: usize,
-        len: usize,
-        execute: kernel::mpu::ExecutePermission,
-        access: kernel::mpu::AccessPermission,
-    ) -> Option<Region> {
         if region_num >= 8 {
             // There are only 8 (0-indexed) regions available
-            return None;
+            return ReturnCode::FAIL;
         }
+
+        let start = region.get_start();
+        let len = region.get_len();
+        let read = region.get_read_permission();
+        let write = region.get_write_permission();
+        let execute = region.get_execute_permission();
+
+        let region_value = (region_num & 0xf) as u32;
+
+        // Empty region
+        if len == 0 {
+            regs.rbar.write(
+                RegionBaseAddress::VALID::UseRBAR + RegionBaseAddress::REGION.val(region_value),
+            );
+            regs.rasr.set(0);
+            return ReturnCode::SUCCESS;
+        }
+
+        // Convert execute permission to a bitfield
+        let execute_value = match execute {
+            Permission::NoAccess => RegionAttributes::XN::Disable,
+            Permission::Full => RegionAttributes::XN::Enable,
+            _ => {
+                return ReturnCode::FAIL;
+            } // Not supported
+        };
+
+        // Convert read & write permissions to bitfields
+        let access_value = match read {
+            Permission::NoAccess => RegionAttributes::AP::NoAccess,
+            Permission::PrivilegedOnly => {
+                match write {
+                    Permission::NoAccess => RegionAttributes::AP::PrivilegedOnlyReadOnly,
+                    Permission::PrivilegedOnly => RegionAttributes::AP::PrivilegedOnly,
+                    _ => {
+                        return ReturnCode::FAIL;
+                    } // Not supported
+                }
+            }
+            Permission::Full => match write {
+                Permission::NoAccess => RegionAttributes::AP::ReadOnly,
+                Permission::PrivilegedOnly => RegionAttributes::AP::UnprivilegedReadOnly,
+                Permission::Full => RegionAttributes::AP::ReadWrite,
+            },
+        };
 
         // There are two possibilities we support:
         //
@@ -163,26 +175,40 @@ impl kernel::mpu::MPU for MPU {
         //    subregions, as long as the memory region's base address is aligned
         //    to 1/8th of a larger region size.
 
+        // Possibility 1
         if start % len == 0 {
             // Memory base aligned to memory size - straight forward case
             let region_len = PowerOfTwo::floor(len as u32);
-            if region_len.exp::<u32>() < 5 {
+
+            // exponent = log2(region_len)
+            let exponent = region_len.exp::<u32>();
+
+            if exponent < 5 {
                 // Region sizes must be 32 Bytes or larger
-                return None;
-            } else if region_len.exp::<u32>() > 32 {
+                return ReturnCode::FAIL;
+            } else if exponent > 32 {
                 // Region sizes must be 4GB or smaller
-                return None;
+                return ReturnCode::FAIL;
             }
 
-            let xn = execute as u32;
-            let ap = access as u32;
-            Some(unsafe {
-                Region::new(
-                    (start | 1 << 4 | (region_num & 0xf)) as u32,
-                    1 | (region_len.exp::<u32>() - 1) << 1 | ap << 24 | xn << 28,
-                )
-            })
-        } else {
+            let address_value = (start >> 5) as u32;
+            let region_len_value = exponent - 1;
+
+            regs.rbar.write(
+                RegionBaseAddress::ADDR.val(address_value)
+                    + RegionBaseAddress::VALID::UseRBAR
+                    + RegionBaseAddress::REGION.val(region_value),
+            );
+
+            regs.rasr.write(
+                RegionAttributes::ENABLE::SET
+                    + RegionAttributes::SIZE.val(region_len_value)
+                    + access_value
+                    + execute_value,
+            );
+        }
+        // Possibility 2
+        else {
             // Memory base not aligned to memory size
 
             // Which (power-of-two) subregion size would align with the base
@@ -215,13 +241,13 @@ impl kernel::mpu::MPU for MPU {
                 // Sanity check that the amount left over space in the region
                 // after `start` is at least as large as the memory region we
                 // want to reference.
-                return None;
+                return ReturnCode::FAIL;
             }
             if len % subregion_size != 0 {
                 // Sanity check that there is some integer X such that
                 // subregion_size * X == len so none of `len` is left over when
                 // we take the max_subregion.
-                return None;
+                return ReturnCode::FAIL;
             }
 
             // The index of the first subregion to activate is the number of
@@ -233,12 +259,14 @@ impl kernel::mpu::MPU for MPU {
             let max_subregion = min_subregion + len / subregion_size - 1;
 
             let region_len = PowerOfTwo::floor(region_size as u32);
-            if region_len.exp::<u32>() < 7 {
+            // exponent = log2(region_len)
+            let exponent = region_len.exp::<u32>();
+            if exponent < 7 {
                 // Subregions only supported for regions sizes 128 bytes and up.
-                return None;
-            } else if region_len.exp::<u32>() > 32 {
+                return ReturnCode::FAIL;
+            } else if exponent > 32 {
                 // Region sizes must be 4GB or smaller
-                return None;
+                return ReturnCode::FAIL;
             }
 
             // Turn the min/max subregion into a bitfield where all bits are `1`
@@ -250,26 +278,53 @@ impl kernel::mpu::MPU for MPU {
             let subregion_mask =
                 (min_subregion..(max_subregion + 1)).fold(!0, |res, i| res & !(1 << i)) & 0xff;
 
-            let xn = execute as u32;
-            let ap = access as u32;
-            Some(unsafe {
-                Region::new(
-                    (region_start | 1 << 4 | (region_num & 0xf)) as u32,
-                    1
-                        | subregion_mask << 8
-                        | (region_len.exp::<u32>() - 1) << 1
-                        | ap << 24
-                        | xn << 28,
-                )
-            })
-        }
-    }
+            let address_value = (region_start >> 5) as u32;
+            let region_len_value = exponent - 1;
 
-    fn set_mpu(&self, region: Region) {
+            regs.rbar.write(
+                RegionBaseAddress::ADDR.val(address_value)
+                    + RegionBaseAddress::VALID::UseRBAR
+                    + RegionBaseAddress::REGION.val(region_value),
+            );
+
+            regs.rasr.write(
+                RegionAttributes::ENABLE::SET
+                    + RegionAttributes::SRD.val(subregion_mask)
+                    + RegionAttributes::SIZE.val(region_len_value)
+                    + access_value
+                    + execute_value,
+            );
+        }
+        ReturnCode::SUCCESS
+    }
+}
+
+impl kernel::mpu::MPU for MPU {
+    fn enable_mpu(&self) {
         let regs = &*self.0;
 
-        regs.region_base_address.set(region.base_address());
+        // Enable the MPU, disable it during HardFault/NMI handlers, and allow
+        // privileged code access to all unprotected memory.
+        regs.ctrl
+            .write(Control::ENABLE::SET + Control::HFNMIENA::CLEAR + Control::PRIVDEFENA::SET);
+    }
 
-        regs.region_attributes_and_size.set(region.attributes());
+    fn disable_mpu(&self) {
+        let regs = &*self.0;
+        regs.ctrl.write(Control::ENABLE::CLEAR);
+    }
+
+    fn num_supported_regions(&self) -> u32 {
+        let regs = &*self.0;
+        regs.mpu_type.read(Type::DREGION)
+    }
+
+    fn allocate_regions(&self, regions: &[Region]) -> Result<(), usize> {
+        for (index, region) in regions.iter().enumerate() {
+            if let ReturnCode::FAIL = self.allocate_region(region, index) {
+                return Err(index);
+            }
+        }
+        Ok(())
     }
 }

--- a/kernel/src/platform/mpu.rs
+++ b/kernel/src/platform/mpu.rs
@@ -1,103 +1,109 @@
 //! Interface for configuring the Memory Protection Unit.
 
-#[derive(Debug)]
-pub enum AccessPermission {
-    //                                 Privileged  Unprivileged
-    //                                 Access      Access
-    NoAccess = 0b000,               // --          --
-    PrivilegedOnly = 0b001,         // RW          --
-    UnprivilegedReadOnly = 0b010,   // RW          R-
-    ReadWrite = 0b011,              // RW          RW
-    Reserved = 0b100,               // undef       undef
-    PrivilegedOnlyReadOnly = 0b101, // R-          --
-    ReadOnly = 0b110,               // R-          R-
-    ReadOnlyAlias = 0b111,          // R-          R-
+#[derive(Copy, Clone)]
+pub enum Permission {
+    //                 Privileged  Unprivileged
+    //                 Access      Access
+    NoAccess,       // --          --
+    PrivilegedOnly, // V           --
+    Full,           // V           V
 }
 
-#[derive(Debug)]
-pub enum ExecutePermission {
-    ExecutionPermitted = 0b0,
-    ExecutionNotPermitted = 0b1,
-}
-
+#[derive(Copy, Clone)]
 pub struct Region {
-    base_address: u32,
-    attributes: u32,
+    start: usize,
+    len: usize,
+    read: Permission,
+    write: Permission,
+    execute: Permission,
 }
 
 impl Region {
-    pub unsafe fn new(base_address: u32, attributes: u32) -> Region {
+    pub fn new(
+        start: usize,
+        len: usize,
+        read: Permission,
+        write: Permission,
+        execute: Permission,
+    ) -> Region {
         Region {
-            base_address: base_address,
-            attributes: attributes,
+            start: start,
+            len: len,
+            read: read,
+            write: write,
+            execute: execute,
         }
     }
 
-    pub fn empty(region_num: usize) -> Region {
+    pub fn empty() -> Region {
         Region {
-            base_address: (region_num as u32) | 1 << 4,
-            attributes: 0,
+            start: 0,
+            len: 0,
+            read: Permission::NoAccess,
+            write: Permission::NoAccess,
+            execute: Permission::NoAccess,
         }
     }
 
-    pub fn base_address(&self) -> u32 {
-        self.base_address
+    pub fn get_start(&self) -> usize {
+        self.start
     }
 
-    pub fn attributes(&self) -> u32 {
-        self.attributes
+    pub fn get_len(&self) -> usize {
+        self.len
+    }
+
+    pub fn get_read_permission(&self) -> Permission {
+        self.read
+    }
+
+    pub fn get_write_permission(&self) -> Permission {
+        self.write
+    }
+
+    pub fn get_execute_permission(&self) -> Permission {
+        self.execute
     }
 }
 
 pub trait MPU {
-    /// Enable the MPU.
-    ///
-    /// Both privileged and unprivileged code are subject to the constraints of
-    /// the active MPU regions. However, while unprivileged code cannot access
-    /// any memory space that is is not explicitly authorized to, privileged
-    /// code can access all unprotected (background) memory.
+    /// Enables the MPU.
     fn enable_mpu(&self);
 
-    /// Completely disable the MPU.
+    /// Disables the MPU.
     fn disable_mpu(&self);
 
-    /// Creates a new MPU-specific memory protection region
-    ///
-    /// `region_num`: an MPU region number 0-7
-    /// `start_addr`: the region base address. Lower bits will be masked
-    ///               according to the region size.
-    /// `len`       : region size as a PowerOfTwo (e.g. `16` for 64KB)
-    /// `execute`   : whether to enable code execution from this region
-    /// `ap`        : access permissions as defined in Table 4.47 of the user
-    ///               guide.
-    fn create_region(
-        region_num: usize,
-        start: usize,
-        len: usize,
-        execute: ExecutePermission,
-        access: AccessPermission,
-    ) -> Option<Region>;
+    /// Returns the number of supported MPU regions.
+    fn num_supported_regions(&self) -> u32;
 
-    /// Sets the base address, size and access attributes of the given MPU
-    /// region number.
-    fn set_mpu(&self, region: Region);
+    /// Allocates memory protection regions.
+    ///
+    /// # Arguments
+    ///
+    /// `regions`: array of regions to be allocated. The index of the array
+    ///            encodes the priority of the region. In the event of an
+    ///            overlap between regions, the implementor must ensure
+    ///            that the permissions of the region with higher priority
+    ///            take precendence.
+    ///
+    /// # Return Value
+    ///
+    /// If it is infeasible to allocate a memory region, returns its index
+    /// wrapped in a Result.
+    fn allocate_regions(&self, regions: &[Region]) -> Result<(), usize>;
 }
 
-/// Noop implementation of MPU trait
+/// No-op implementation of MPU trait
 impl MPU for () {
     fn enable_mpu(&self) {}
 
     fn disable_mpu(&self) {}
 
-    fn create_region(
-        _: usize,
-        _: usize,
-        _: usize,
-        _: ExecutePermission,
-        _: AccessPermission,
-    ) -> Option<Region> {
-        Some(Region::empty(0))
+    fn num_supported_regions(&self) -> u32 {
+        8
     }
 
-    fn set_mpu(&self, _: Region) {}
+    fn allocate_regions(&self, _: &[Region]) -> Result<(), usize> {
+        Ok(())
+    }
 }


### PR DESCRIPTION
### Pull Request Overview

This introduces an updated MPU interface that is no longer Cortex-M4 specific. The `setup_mpu` function in process.rs is refactored to make use of this interface, and the interface is implemented for the Cortex-M4. The Cortex-M4 MPU implementation is also moved over to the new register interface.

This PR represents a first step in a plan to create an architecture-agnostic interface to isolating process memory (e.g. using the CortexM's memory protection unit). During the design process, we realized that, at a high level there seems to be a trade-off between an interface that is simple to implement (for each architecture) and use (for `process.rs`) and one that is efficient for a variety of types of MPUs, not just the Cortex-M.

There's a [thread on Tock Dev](https://groups.google.com/forum/#!msg/tock-dev/Fduxk_0xvUE/r8Cw7XbjBAAJ) with discussion of some design considerations.

This step represents a first attempt to optimize the former. In particular, it requires very minimal changes to process.rs, and the Cortex-M implementation is relatively simple.

This will serve as a benchmark to measure future designs against: how much more complicated does an efficiency-friendly interface make implementations? is it worth it? etc.

### Testing Strategy

Ran the `mpu_stack_growth` test app.

### TODO or Help Wanted

@dverhaert and I are currently working on a second version of this interface that, among other things, reduces the overhead during context switches by disentangling allocation of regions from switching to a region configuration (thus removing allocation from the hot path in `setup_mpu`).

### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
