### PR TITLE
Launchxl Alarm Bug: Fix issue of board main.rs calling wrong rtc

### DIFF
--- a/boards/launchxl/src/main.rs
+++ b/boards/launchxl/src/main.rs
@@ -12,8 +12,8 @@ extern crate cc26xx;
 #[macro_use(debug, debug_gpio, static_init)]
 extern crate kernel;
 
-use cc26xx::aon;
-use cc26xx::prcm;
+use cc26x2::aon;
+use cc26x2::prcm;
 
 #[macro_use]
 pub mod io;
@@ -42,7 +42,7 @@ pub struct Platform {
     button: &'static capsules::button::Button<'static, cc26xx::gpio::GPIOPin>,
     alarm: &'static capsules::alarm::AlarmDriver<
         'static,
-        capsules::virtual_alarm::VirtualMuxAlarm<'static, cc26xx::rtc::Rtc>,
+        capsules::virtual_alarm::VirtualMuxAlarm<'static, cc26x2::rtc::Rtc>,
     >,
     rng: &'static capsules::rng::SimpleRng<'static, cc26xx::trng::Trng>,
 }
@@ -69,7 +69,7 @@ pub unsafe fn reset_handler() {
     cc26x2::init();
 
     // Setup AON event defaults
-    aon::AON_EVENT.setup();
+    aon::AON.setup();
 
     // Power on peripherals (eg. GPIO)
     prcm::Power::enable_domain(prcm::PowerDomain::Peripherals);
@@ -179,23 +179,23 @@ pub unsafe fn reset_handler() {
         pin.set_client(gpio);
     }
 
-    let rtc = &cc26xx::rtc::RTC;
+    let rtc = &cc26x2::rtc::RTC;
     rtc.start();
 
     let mux_alarm = static_init!(
-        capsules::virtual_alarm::MuxAlarm<'static, cc26xx::rtc::Rtc>,
-        capsules::virtual_alarm::MuxAlarm::new(&cc26xx::rtc::RTC)
+        capsules::virtual_alarm::MuxAlarm<'static, cc26x2::rtc::Rtc>,
+        capsules::virtual_alarm::MuxAlarm::new(&cc26x2::rtc::RTC)
     );
     rtc.set_client(mux_alarm);
 
     let virtual_alarm1 = static_init!(
-        capsules::virtual_alarm::VirtualMuxAlarm<'static, cc26xx::rtc::Rtc>,
+        capsules::virtual_alarm::VirtualMuxAlarm<'static, cc26x2::rtc::Rtc>,
         capsules::virtual_alarm::VirtualMuxAlarm::new(mux_alarm)
     );
     let alarm = static_init!(
         capsules::alarm::AlarmDriver<
             'static,
-            capsules::virtual_alarm::VirtualMuxAlarm<'static, cc26xx::rtc::Rtc>,
+            capsules::virtual_alarm::VirtualMuxAlarm<'static, cc26x2::rtc::Rtc>,
         >,
         capsules::alarm::AlarmDriver::new(virtual_alarm1, kernel::Grant::create())
     );

--- a/chips/cc26x2/Cargo.lock
+++ b/chips/cc26x2/Cargo.lock
@@ -33,10 +33,15 @@ dependencies = [
 name = "kernel"
 version = "0.1.0"
 dependencies = [
- "tock-regs 0.1.0",
+ "tock-cells 0.1.0",
+ "tock-registers 0.1.0",
 ]
 
 [[package]]
-name = "tock-regs"
+name = "tock-cells"
+version = "0.1.0"
+
+[[package]]
+name = "tock-registers"
 version = "0.1.0"
 

--- a/chips/cc26x2/src/rtc.rs
+++ b/chips/cc26x2/src/rtc.rs
@@ -1,6 +1,6 @@
 //! RTC driver
 
-use core::cell::Cell;
+use kernel::common::cells::OptionalCell;
 use kernel::common::registers::{ReadOnly, ReadWrite};
 use kernel::common::StaticRef;
 use kernel::hil::time::{self, Alarm, Frequency, Time};
@@ -62,7 +62,7 @@ const RTC_BASE: StaticRef<RtcRegisters> =
 
 pub struct Rtc {
     registers: StaticRef<RtcRegisters>,
-    callback: Cell<Option<&'static time::Client>>,
+    callback: OptionalCell<&'static time::Client>,
 }
 
 pub static mut RTC: Rtc = Rtc::new();
@@ -71,7 +71,7 @@ impl Rtc {
     const fn new() -> Rtc {
         Rtc {
             registers: RTC_BASE,
-            callback: Cell::new(None),
+            callback: OptionalCell::empty(),
         }
     }
 
@@ -129,11 +129,11 @@ impl Rtc {
 
         regs.sync.get();
 
-        self.callback.get().map(|cb| cb.fired());
+        self.callback.map(|cb| cb.fired());
     }
 
     pub fn set_client(&self, client: &'static time::Client) {
-        self.callback.set(Some(client));
+        self.callback.set(client);
     }
 
     pub fn set_upd_en(&self, value: bool) {


### PR DESCRIPTION
Alarm will not call correctly otherwise

### Pull Request Overview

This pull request fixes a bug where the kernel will seem to run correctly but no Alarm callback is called because launchxl main.rs implements Platform { ... alarm: ...} with the wrong rtc, breaking the AlarmDriver. 

### Testing Strategy

Tested by running blink application which uses alarm for toggling the LED's

### Formatting

- [ ] Ran `make formatall`.
