### PR TITLE
Kernel doctests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,12 +46,16 @@ ci-travis:
 	@printf "$$(tput bold)*****************$$(tput sgr0)\n"
 	@printf "$$(tput bold)* CI: Libraries *$$(tput sgr0)\n"
 	@printf "$$(tput bold)*****************$$(tput sgr0)\n"
-	@CI=true cd libraries/tock-cells && cargo test
-	@CI=true cd libraries/tock-register-interface && cargo test
+	@cd libraries/tock-cells && CI=true cargo test
+	@cd libraries/tock-register-interface && CI=true cargo test
 	@printf "$$(tput bold)**************$$(tput sgr0)\n"
 	@printf "$$(tput bold)* CI: Syntax *$$(tput sgr0)\n"
 	@printf "$$(tput bold)**************$$(tput sgr0)\n"
 	@CI=true $(MAKE) allcheck
+	@printf "$$(tput bold)****************$$(tput sgr0)\n"
+	@printf "$$(tput bold)* CI: DocTests *$$(tput sgr0)\n"
+	@printf "$$(tput bold)****************$$(tput sgr0)\n"
+	@cd kernel && CI=true TOCK_KERNEL_VERSION=ci_test cargo test
 	@printf "$$(tput bold)*******************$$(tput sgr0)\n"
 	@printf "$$(tput bold)* CI: Compilation *$$(tput sgr0)\n"
 	@printf "$$(tput bold)*******************$$(tput sgr0)\n"

--- a/kernel/src/common/peripherals.rs
+++ b/kernel/src/common/peripherals.rs
@@ -7,6 +7,9 @@
 //! Generally, Tock peripherals are modeled by two structures, such as:
 //!
 //! ```rust
+//! # use kernel::common::cells::VolatileCell;
+//! # use kernel::common::StaticRef;
+//! # struct ChipSpecificPeripheralClock {};
 //! /// The MMIO Structure.
 //! #[repr(C)]
 //! #[allow(dead_code)]
@@ -16,9 +19,9 @@
 //! }
 //!
 //! /// The Tock object that holds all information for this peripheral.
-//! pub struct PeripheralHardware {
+//! pub struct PeripheralHardware<'a> {
 //!     mmio_address: StaticRef<PeripheralRegisters>,
-//!     clock: &ChipSpecificPeripheralClock,
+//!     clock: &'a ChipSpecificPeripheralClock,
 //! }
 //! ```
 //!
@@ -29,23 +32,57 @@
 //! MMIO pointer safely, Tock provides the PeripheralManager interface:
 //!
 //! ```rust
+//! # use kernel::common::cells::VolatileCell;
+//! # use kernel::common::peripherals::PeripheralManager;
+//! # use kernel::common::StaticRef;
+//! # use kernel::hil;
+//! # use kernel::ReturnCode;
+//! # struct PeripheralRegisters { control: VolatileCell<u32> };
+//! # struct PeripheralHardware { mmio_address: StaticRef<PeripheralRegisters> };
 //! impl hil::uart::UART for PeripheralHardware {
-//!    fn init(&self, params: hil::uart::UARTParams) {
-//!        let peripheral = &PeripheralManager::new(self);
-//!        peripheral.registers.control.set(0x0);
-//!        //         ^^^^^^^^^-- This is type &PeripheralRegisters
+//!     fn configure(&self, params: hil::uart::UARTParameters) -> ReturnCode {
+//!         let peripheral = &PeripheralManager::new(self);
+//!         peripheral.registers.control.set(0x0);
+//!         //         ^^^^^^^^^-- This is type &PeripheralRegisters
+//!         ReturnCode::SUCCESS
+//!     }
+//!     # fn set_client(&self, _client: &'static hil::uart::Client) {}
+//!     # fn transmit(&self, _tx_data: &'static mut [u8], _tx_len: usize) {}
+//!     # fn receive(&self, _rx_buffer: &'static mut [u8], _rx_len: usize) {}
+//!     # fn abort_receive(&self) {}
+//! }
+//! # use kernel::common::peripherals::PeripheralManagement;
+//! # use kernel::NoClockControl;
+//! # impl PeripheralManagement<NoClockControl> for PeripheralHardware {
+//! #     type RegisterType = PeripheralRegisters;
+//!
+//! #     fn get_registers(&self) -> &PeripheralRegisters {
+//! #         &*self.mmio_address
+//! #     }
+//! #     fn get_clock(&self) -> &NoClockControl { unsafe { &kernel::NO_CLOCK_CONTROL } }
+//! #     fn before_peripheral_access(&self, _c: &NoClockControl, _r: &Self::RegisterType) {}
+//! #     fn after_peripheral_access(&self, _c: &NoClockControl, _r: &Self::RegisterType) {}
+//! # }
 //! ```
 //!
 //! Each peripheral must tell the kernel where its registers live in memory:
 //!
 //! ```rust
+//! # use kernel::common::peripherals::PeripheralManagement;
+//! # use kernel::common::StaticRef;
+//! # pub struct PeripheralRegisters {};
+//! # pub struct PeripheralHardware { mmio_address: StaticRef<PeripheralRegisters> };
 //! /// Teaching the kernel how to create PeripheralRegisters.
-//! impl PeripheralManagement<pm::Clock> for PeripheralHardware {
+//! use kernel::NoClockControl;
+//! impl PeripheralManagement<NoClockControl> for PeripheralHardware {
 //!     type RegisterType = PeripheralRegisters;
 //!
 //!     fn get_registers(&self) -> &PeripheralRegisters {
 //!         &*self.mmio_address
 //!     }
+//!     # fn get_clock(&self) -> &NoClockControl { unsafe { &kernel::NO_CLOCK_CONTROL } }
+//!     # fn before_peripheral_access(&self, _c: &NoClockControl, _r: &Self::RegisterType) {}
+//!     # fn after_peripheral_access(&self, _c: &NoClockControl, _r: &Self::RegisterType) {}
 //! }
 //! ```
 //!
@@ -68,18 +105,40 @@
 //! without enabling clocks if needed if they use hardware for bookkeeping.
 //!
 //! ```rust
-//! /// Teaching the kernel which clock controls SpiHw.
-//! impl PeripheralManagement<pm::Clock> for SpiHw {
-//!     fn get_clock(&self) -> &pm::Clock {
-//!         &pm::Clock::PBA(pm::PBAClock::SPI)
-//!     }
+//! use kernel::common::peripherals::PeripheralManagement;
+//! use kernel::common::StaticRef;
+//! use kernel::ClockInterface;
+//! // A dummy clock for this example.
+//! // Real peripherals that do not have clocks should use NoClockControl from this module.
+//! struct ExampleClock {};
+//! impl ClockInterface for ExampleClock {
+//!     fn is_enabled(&self) -> bool { true }
+//!     fn enable(&self) { }
+//!     fn disable(&self) { }
+//! }
 //!
-//!     fn before_mmio_access(&self, clock: &pm::Clock, _registers: &SpiRegisters) {
+//! // Dummy hardware for this example.
+//! struct SpiRegisters {};
+//! struct SpiHw<'a> {
+//!     mmio_address: StaticRef<SpiRegisters>,
+//!     clock: &'a ExampleClock,
+//!     busy: bool,
+//! };
+//!
+//! /// Teaching the kernel which clock controls SpiHw.
+//! impl<'a> PeripheralManagement<ExampleClock> for SpiHw<'a> {
+//!     type RegisterType = SpiRegisters;
+//!
+//!     fn get_registers(&self) -> &SpiRegisters { &*self.mmio_address }
+//!
+//!     fn get_clock(&self) -> &ExampleClock { self.clock }
+//!
+//!     fn before_peripheral_access(&self, clock: &ExampleClock, _registers: &SpiRegisters) {
 //!         clock.enable();
 //!     }
 //!
-//!     fn after_mmio_access(&self, clock: &pm::Clock, _registers: &SpiRegisters) {
-//!         if !self.is_busy() {
+//!     fn after_peripheral_access(&self, clock: &ExampleClock, _registers: &SpiRegisters) {
+//!         if !self.busy {
 //!             clock.disable();
 //!         }
 //!     }
@@ -120,9 +179,30 @@ where
 /// PeripheralManagement trait) should instantiate an instance of this
 /// method to accesss memory mapped registers.
 ///
-/// ```rust
-/// let peripheral = &PeripheralManager::new(self);
-/// peripheral.registers.control.set(0x1);
+/// ```
+/// # use kernel::common::cells::VolatileCell;
+/// # use kernel::common::peripherals::PeripheralManager;
+/// # use kernel::common::StaticRef;
+/// # pub struct PeripheralRegisters { control: VolatileCell<u32> };
+/// # pub struct PeripheralHardware { mmio_address: StaticRef<PeripheralRegisters> };
+/// impl PeripheralHardware {
+///     fn example(&self) {
+///         let peripheral = &PeripheralManager::new(self);
+///         peripheral.registers.control.set(0x1);
+///     }
+/// }
+/// # use kernel::common::peripherals::PeripheralManagement;
+/// # use kernel::NoClockControl;
+/// # impl PeripheralManagement<NoClockControl> for PeripheralHardware {
+/// #     type RegisterType = PeripheralRegisters;
+///
+/// #     fn get_registers(&self) -> &PeripheralRegisters {
+/// #         &*self.mmio_address
+/// #     }
+/// #     fn get_clock(&self) -> &NoClockControl { unsafe { &kernel::NO_CLOCK_CONTROL } }
+/// #     fn before_peripheral_access(&self, _c: &NoClockControl, _r: &Self::RegisterType) {}
+/// #     fn after_peripheral_access(&self, _c: &NoClockControl, _r: &Self::RegisterType) {}
+/// # }
 /// ```
 pub struct PeripheralManager<'a, H, C>
 where

--- a/kernel/src/debug.rs
+++ b/kernel/src/debug.rs
@@ -6,7 +6,7 @@
 //!
 //! Before debug interfaces can be used, the board file must assign them hardware:
 //!
-//! ```rust
+//! ```ignore
 //! kernel::debug::assign_gpios(
 //!     Some(&sam4l::gpio::PA[13]),
 //!     Some(&sam4l::gpio::PA[15]),
@@ -22,13 +22,17 @@
 //! Example
 //! -------
 //!
-//! ```rust
+//! ```no_run
+//! # #[macro_use] extern crate kernel;
+//! # fn main() {
+//! # let i = 42;
 //! debug!("Yes the code gets here with value {}", i);
 //! debug_verbose!("got here"); // includes message count, file, and line
 //! debug_gpio!(0, toggle); // Toggles the first debug GPIO
+//! # }
 //! ```
 //!
-//! ```
+//! ```text
 //! Yes the code gets here with value 42
 //! TOCK_DEBUG(0): /tock/capsules/src/sensys.rs:24: got here
 //! ```

--- a/kernel/src/hil/rng.rs
+++ b/kernel/src/hil/rng.rs
@@ -21,12 +21,15 @@
 //! once a second using the `Alarm` and `RNG` traits.
 //!
 //! ```
-//! struct RngTest<'a, A: Alarm > {
-//!     rng: &'a RNG,
+//! use kernel::hil;
+//! use kernel::hil::time::Frequency;
+//!
+//! struct RngTest<'a, A: 'a + hil::time::Alarm> {
+//!     rng: &'a hil::rng::RNG,
 //!     alarm: &'a A
 //! }
 //!
-//! impl<A: Alarm> RngTest<'a, A> {
+//! impl<'a, A: hil::time::Alarm> RngTest<'a, A> {
 //!     pub fn initialize(&self) {
 //!         let interval = 1 * <A::Frequency>::frequency();
 //!         let tics = self.alarm.now().wrapping_add(interval);
@@ -34,23 +37,23 @@
 //!     }
 //! }
 //!
-//! impl<A: Alarm> time::Client for RngTest<'a, A> {
+//! impl<'a, A: hil::time::Alarm> hil::time::Client for RngTest<'a, A> {
 //!     fn fired(&self) {
 //!         self.rng.get();
 //!     }
 //! }
 //!
-//! impl<A: Alarm> rng::Client for RngTest<'a, A> {
-//!     fn randomness_available(&self, randomness: &mut Iterator<Item = u32>) -> rng::Continue {
+//! impl<'a, A: hil::time::Alarm> hil::rng::Client for RngTest<'a, A> {
+//!     fn randomness_available(&self, randomness: &mut Iterator<Item = u32>) -> hil::rng::Continue {
 //!         match randomness.next() {
 //!             Some(random) => {
 //!                 println!("Rand {}", random);
 //!                 let interval = 1 * <A::Frequency>::frequency();
 //!                 let tics = self.alarm.now().wrapping_add(interval);
 //!                 self.alarm.set_alarm(tics);
-//!                 rng::Continue::Done
+//!                 hil::rng::Continue::Done
 //!             },
-//!             None => rng::Continue::More
+//!             None => hil::rng::Continue::More
 //!         }
 //!     }
 //! }

--- a/kernel/src/hil/time.rs
+++ b/kernel/src/hil/time.rs
@@ -72,7 +72,7 @@ pub trait Alarm: Time {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```ignore
     /// let delta = 1337;
     /// let tics = alarm.now().wrapping_add(delta);
     /// alarm.set_alarm(tics);


### PR DESCRIPTION
### Pull Request Overview

This adds CI checks to validate that our example code in documentation is correct by running doctests. This also fixes up some broken documentation :)

This PR is just for the kernel crate.

Some notes:

 - Lines prefixed with `# ` in doc comments are not rendered
 - All fenced blocks are assumed to be rust unless stated otherwise, so rustdoc repurposes the code identifier a bit, e.g. a block with ` ```ignore ` will render as rust code but will not be tested
 - The peripherals docs are a bit messy to look at in source code form. Personally I think this is a shortcoming of rustdoc, but I think it's good to see an example of how you handle situations where there's a sort of "continuing example" throughout the documentation (you have to keep repeating the "hidden" code with `# `)

### Testing Strategy

Compiling.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
