### PR TITLE
Fix virtual_uart receive semantics

### DIFF
--- a/boards/ek-tm4c1294xl/src/main.rs
+++ b/boards/ek-tm4c1294xl/src/main.rs
@@ -86,7 +86,11 @@ pub unsafe fn reset_handler() {
     // Create a shared UART channel for the console and for kernel debug.
     let uart_mux = static_init!(
         UartMux<'static>,
-        UartMux::new(&tm4c129x::uart::UART0, &mut capsules::virtual_uart::RX_BUF)
+        UartMux::new(
+            &tm4c129x::uart::UART0,
+            &mut capsules::virtual_uart::RX_BUF,
+            115200
+        )
     );
     hil::uart::UART::set_client(&tm4c129x::uart::UART0, uart_mux);
 

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -209,7 +209,11 @@ pub unsafe fn reset_handler() {
     // Create a shared UART channel for the console and for kernel debug.
     let uart_mux = static_init!(
         UartMux<'static>,
-        UartMux::new(&sam4l::usart::USART0, &mut capsules::virtual_uart::RX_BUF)
+        UartMux::new(
+            &sam4l::usart::USART0,
+            &mut capsules::virtual_uart::RX_BUF,
+            115200
+        )
     );
     hil::uart::UART::set_client(&sam4l::usart::USART0, uart_mux);
 

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -18,7 +18,6 @@ extern crate cortexm4;
 extern crate sam4l;
 
 mod components;
-
 use capsules::alarm::AlarmDriver;
 use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use capsules::virtual_i2c::MuxI2C;
@@ -75,6 +74,9 @@ mod aes_ccm_test;
 
 #[allow(dead_code)]
 mod power;
+
+#[allow(dead_code)]
+mod virtual_uart_rx_test;
 
 // State for loading apps.
 
@@ -261,7 +263,11 @@ pub unsafe fn reset_handler() {
     sam4l::usart::USART3.set_mode(sam4l::usart::UsartMode::Uart);
     let uart_mux = static_init!(
         UartMux<'static>,
-        UartMux::new(&sam4l::usart::USART3, &mut capsules::virtual_uart::RX_BUF)
+        UartMux::new(
+            &sam4l::usart::USART3,
+            &mut capsules::virtual_uart::RX_BUF,
+            115200
+        )
     );
     hil::uart::UART::set_client(&sam4l::usart::USART3, uart_mux);
 
@@ -356,6 +362,8 @@ pub unsafe fn reset_handler() {
     rf233.reset();
     rf233.start();
 
+    //    debug!("Starting virtual read test.");
+    //    virtual_uart_rx_test::run_virtual_uart_receive(uart_mux);
     debug!("Initialization complete. Entering main loop");
 
     extern "C" {

--- a/boards/imix/src/virtual_uart_rx_test.rs
+++ b/boards/imix/src/virtual_uart_rx_test.rs
@@ -1,0 +1,39 @@
+use capsules::test::virtual_uart::TestVirtualUartReceive;
+use capsules::virtual_uart::{UartDevice, UartMux};
+use kernel::hil::uart::UART;
+
+pub unsafe fn run_virtual_uart_receive(mux: &'static UartMux<'static>) {
+    debug!("Starting virtual reads.");
+    let small = static_init_test_receive_small(mux);
+    let large = static_init_test_receive_large(mux);
+    small.run();
+    large.run();
+}
+
+unsafe fn static_init_test_receive_small(
+    mux: &'static UartMux<'static>,
+) -> &'static TestVirtualUartReceive {
+    static mut SMALL: [u8; 3] = [0; 3];
+    let device = static_init!(UartDevice<'static>, UartDevice::new(mux, true));
+    device.setup();
+    let test = static_init!(
+        TestVirtualUartReceive,
+        TestVirtualUartReceive::new(device, &mut SMALL)
+    );
+    device.set_client(test);
+    test
+}
+
+unsafe fn static_init_test_receive_large(
+    mux: &'static UartMux<'static>,
+) -> &'static TestVirtualUartReceive {
+    static mut BUFFER: [u8; 7] = [0; 7];
+    let device = static_init!(UartDevice<'static>, UartDevice::new(mux, true));
+    device.setup();
+    let test = static_init!(
+        TestVirtualUartReceive,
+        TestVirtualUartReceive::new(device, &mut BUFFER)
+    );
+    device.set_client(test);
+    test
+}

--- a/boards/launchxl/src/main.rs
+++ b/boards/launchxl/src/main.rs
@@ -132,7 +132,11 @@ pub unsafe fn reset_handler() {
     // Create a shared UART channel for the console and for kernel debug.
     let uart_mux = static_init!(
         UartMux<'static>,
-        UartMux::new(&cc26xx::uart::UART0, &mut capsules::virtual_uart::RX_BUF)
+        UartMux::new(
+            &cc26xx::uart::UART0,
+            &mut capsules::virtual_uart::RX_BUF,
+            115200
+        )
     );
     hil::uart::UART::set_client(&cc26xx::uart::UART0, uart_mux);
 

--- a/boards/nordic/nrf51dk/src/main.rs
+++ b/boards/nordic/nrf51dk/src/main.rs
@@ -243,7 +243,11 @@ pub unsafe fn reset_handler() {
     // Create a shared UART channel for the console and for kernel debug.
     let uart_mux = static_init!(
         UartMux<'static>,
-        UartMux::new(&nrf51::uart::UART0, &mut capsules::virtual_uart::RX_BUF)
+        UartMux::new(
+            &nrf51::uart::UART0,
+            &mut capsules::virtual_uart::RX_BUF,
+            115200
+        )
     );
     hil::uart::UART::set_client(&nrf51::uart::UART0, uart_mux);
 

--- a/boards/nordic/nrf52dk_base/src/lib.rs
+++ b/boards/nordic/nrf52dk_base/src/lib.rs
@@ -197,7 +197,11 @@ pub unsafe fn setup_board(
     // Create a shared UART channel for the console and for kernel debug.
     let uart_mux = static_init!(
         UartMux<'static>,
-        UartMux::new(&nrf52::uart::UARTE0, &mut capsules::virtual_uart::RX_BUF)
+        UartMux::new(
+            &nrf52::uart::UARTE0,
+            &mut capsules::virtual_uart::RX_BUF,
+            115200
+        )
     );
     hil::uart::UART::set_client(&nrf52::uart::UARTE0, uart_mux);
 

--- a/capsules/src/test/mod.rs
+++ b/capsules/src/test/mod.rs
@@ -1,2 +1,3 @@
 pub mod aes;
 pub mod aes_ccm;
+pub mod virtual_uart;

--- a/capsules/src/test/virtual_uart.rs
+++ b/capsules/src/test/virtual_uart.rs
@@ -1,0 +1,47 @@
+//! Test reception on the virtualized UART: best if multiple Tests are
+//! instantiated and tested in parallel.
+
+use kernel::common::cells::TakeCell;
+use kernel::hil;
+use kernel::hil::uart::Client;
+use kernel::hil::uart::UART;
+use virtual_uart::UartDevice;
+
+pub struct TestVirtualUartReceive {
+    device: &'static UartDevice<'static>,
+    buffer: TakeCell<'static, [u8]>,
+}
+
+impl TestVirtualUartReceive {
+    pub fn new(device: &'static UartDevice<'static>, buffer: &'static mut [u8]) -> Self {
+        TestVirtualUartReceive {
+            device: device,
+            buffer: TakeCell::new(buffer),
+        }
+    }
+
+    pub fn run(&self) {
+        let buf = self.buffer.take().unwrap();
+        let len = buf.len();
+        debug!("Starting receive of length {}", len);
+        self.device.receive(buf, len);
+    }
+}
+
+impl Client for TestVirtualUartReceive {
+    fn transmit_complete(&self, _tx_buffer: &'static mut [u8], _error: hil::uart::Error) {}
+
+    fn receive_complete(
+        &self,
+        rx_buffer: &'static mut [u8],
+        rx_len: usize,
+        error: hil::uart::Error,
+    ) {
+        debug!("Virtual uart read complete: {:?}: ", error);
+        for i in 0..rx_len {
+            debug!("{:02x} ", rx_buffer[i]);
+        }
+        debug!("Starting receive of length {}", rx_len);
+        self.device.receive(rx_buffer, rx_len);
+    }
+}

--- a/chips/sam4l/src/usart.rs
+++ b/chips/sam4l/src/usart.rs
@@ -904,7 +904,7 @@ impl hil::uart::UART for USART {
     fn abort_receive(&self) {
         let usart = &USARTRegManager::new(&self);
         self.disable_rx_timeout(usart);
-        self.abort_rx(usart, hil::uart::Error::CommandComplete);
+        self.abort_rx(usart, hil::uart::Error::Aborted);
     }
 }
 

--- a/chips/sam4l/src/usart.rs
+++ b/chips/sam4l/src/usart.rs
@@ -744,7 +744,6 @@ impl USART {
 impl dma::DMAClient for USART {
     fn transfer_done(&self, pid: dma::DMAPeripheral) {
         let usart = &USARTRegManager::new(&self);
-
         match self.usart_mode.get() {
             UsartMode::Uart => {
                 // determine if it was an RX or TX transfer
@@ -767,6 +766,7 @@ impl dma::DMAClient for USART {
                     self.client.map(|usartclient| {
                         buffer.map(|buf| {
                             let length = self.rx_len.get();
+                            self.rx_len.set(0);
                             match usartclient {
                                 UsartClient::Uart(client) => {
                                     client.receive_complete(
@@ -779,7 +779,6 @@ impl dma::DMAClient for USART {
                             }
                         });
                     });
-                    self.rx_len.set(0);
                 } else if pid == self.tx_dma_peripheral {
                     // TX transfer was completed
 
@@ -894,12 +893,11 @@ impl hil::uart::UART for USART {
         self.enable_rx(usart);
         self.enable_rx_error_interrupts(usart);
         self.usart_rx_state.set(USARTStateRX::DMA_Receiving);
-
         // set up dma transfer and start reception
         self.rx_dma.get().map(move |dma| {
             dma.enable();
+            self.rx_len.set(length);
             dma.do_transfer(self.rx_dma_peripheral, rx_buffer, length);
-            self.rx_len.set(rx_len);
         });
     }
 

--- a/kernel/src/hil/uart.rs
+++ b/kernel/src/hil/uart.rs
@@ -24,7 +24,7 @@ pub struct UARTParameters {
 }
 
 /// The type of error encountered during UART transaction.
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub enum Error {
     /// Parity error during receive
     ParityError,
@@ -40,6 +40,9 @@ pub enum Error {
 
     /// UART hardware was reset
     ResetError,
+
+    /// Read or write was aborted early
+    Aborted,
 
     /// No error occurred and the command completed successfully
     CommandComplete,


### PR DESCRIPTION
### Pull Request Overview

Fixes the semantics of the `virtual_uart` on the receive path. In particular, it fixes a problem that occurs when client reads of different sizes are pending.

This changes the semantics to copy the underlying UART read into each of the client buffers. If the underlying read completes a client read, issue a callback to that client. In the meanwhile, compute the length of the next underlying UART read: if any client has more to read, issue another underlying read.

Note to @phil-levis or @bradjc, the description above ^ is unclear to me, I mostly just copied it from the comments. Please fix the description if you can.

This also makes two small changes to the SAM4L USART driver. All state updates need to be done before callbacks or other modules are called, in case those callbacks or other modules call the USART driver. If not, then the USART has the wrong state and those function calls will likely fail.

### Testing Strategy

The PR includes a test for the virtual uart in `capsules/src/test/virtual_uart.rs`

### TODO or Help Wanted

### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make formatall`.
