### PR TITLE
Add I2C master driver for CC26x2

### DIFF
--- a/boards/launchxl/src/i2c_tests.rs
+++ b/boards/launchxl/src/i2c_tests.rs
@@ -1,0 +1,146 @@
+//! A dummy I2C client
+
+use cc26x2::i2c;
+use core::cell::Cell;
+use kernel::hil;
+use kernel::hil::i2c::I2CMaster;
+
+// ===========================================
+// Scan for I2C Slaves
+// ===========================================
+
+struct ScanClient {
+    dev_id: Cell<u8>,
+}
+
+static mut SCAN_CLIENT: ScanClient = ScanClient {
+    dev_id: Cell::new(1),
+};
+
+impl hil::i2c::I2CHwMasterClient for ScanClient {
+    fn command_complete(&self, buffer: &'static mut [u8], error: hil::i2c::Error) {
+        let mut dev_id = self.dev_id.get();
+
+        if error != hil::i2c::Error::AddressNak {
+            debug!("{:#x} {:?}", dev_id, error);
+        }
+
+        let dev: &mut I2CMaster = unsafe { &mut i2c::I2C0 };
+        if dev_id < 0x7F {
+            dev_id += 1;
+            self.dev_id.set(dev_id);
+            dev.write(dev_id, buffer, 2);
+        } else {
+            debug!(
+                "Done scanning for I2C devices. Buffer len: {}",
+                buffer.len()
+            );
+        }
+    }
+}
+
+pub fn i2c_scan_slaves() {
+    static mut DATA: [u8; 0x7F] = [0x01; 0x7F];
+
+    let dev = unsafe { &mut i2c::I2C0 };
+
+    let i2c_client = unsafe { &SCAN_CLIENT };
+    dev.set_client(i2c_client);
+
+    let dev: &I2CMaster = dev;
+    dev.enable();
+
+    //debug!("Scanning for I2C devices...");
+    dev.write(i2c_client.dev_id.get(), unsafe { &mut DATA }, 2);
+}
+
+// ===========================================
+// Test FXOS8700CQ
+// ===========================================
+
+#[derive(Copy, Clone)]
+enum AccelClientState {
+    ReadingWhoami,
+    Activating,
+    Deactivating,
+    ReadingAccelData,
+}
+
+struct AccelClient {
+    state: Cell<AccelClientState>,
+}
+
+static mut ACCEL_CLIENT: AccelClient = AccelClient {
+    state: Cell::new(AccelClientState::ReadingWhoami),
+};
+
+impl hil::i2c::I2CHwMasterClient for AccelClient {
+    fn command_complete(&self, buffer: &'static mut [u8], error: hil::i2c::Error) {
+        let dev = unsafe { &mut i2c::I2C0 };
+
+        match self.state.get() {
+            AccelClientState::ReadingWhoami => {
+                //debug!("WHOAMI Register 0x{:x} ({})", buffer[0], error);
+                //debug!("Activating Sensor...");
+                buffer[0] = 0x2A as u8; // CTRL_REG1
+                buffer[1] = 1; // Bit 1 sets `active`
+                dev.write(0x1e, buffer, 2);
+                self.state.set(AccelClientState::Activating);
+            }
+            AccelClientState::Activating => {
+                //debug!("Sensor Activated ({})", error);
+                buffer[0] = 0x01 as u8; // X-MSB register
+                                        // Reading 6 bytes will increment the register pointer through
+                                        // X-MSB, X-LSB, Y-MSB, Y-LSB, Z-MSB, Z-LSB
+                dev.write_read(0x1e, buffer, 1, 6);
+                self.state.set(AccelClientState::ReadingAccelData);
+            }
+            AccelClientState::ReadingAccelData => {
+                let x = (((buffer[0] as u16) << 8) | buffer[1] as u16) as usize;
+                let y = (((buffer[2] as u16) << 8) | buffer[3] as u16) as usize;
+                let z = (((buffer[4] as u16) << 8) | buffer[5] as u16) as usize;
+
+                let x = ((x >> 2) * 976) / 1000;
+                let y = ((y >> 2) * 976) / 1000;
+                let z = ((z >> 2) * 976) / 1000;
+
+                debug!(
+                    "Accel data ready x: {}, y: {}, z: {} ({})",
+                    x >> 2,
+                    y >> 2,
+                    z >> 2,
+                    error
+                );
+
+                buffer[0] = 0x01 as u8; // X-MSB register
+                                        // Reading 6 bytes will increment the register pointer through
+                                        // X-MSB, X-LSB, Y-MSB, Y-LSB, Z-MSB, Z-LSB
+                dev.write_read(0x1e, buffer, 1, 6);
+                self.state.set(AccelClientState::ReadingAccelData);
+            }
+            AccelClientState::Deactivating => {
+                debug!("Sensor deactivated ({})", error);
+                debug!("Reading Accel's WHOAMI...");
+                buffer[0] = 0x0D as u8; // 0x0D == WHOAMI register
+                dev.write_read(0x1e, buffer, 1, 1);
+                self.state.set(AccelClientState::ReadingWhoami);
+            }
+        }
+    }
+}
+
+pub fn i2c_accel_test() {
+    static mut DATA: [u8; 255] = [0; 255];
+
+    let dev = unsafe { &mut i2c::I2C0 };
+
+    let i2c_client = unsafe { &ACCEL_CLIENT };
+    dev.set_client(i2c_client);
+    dev.enable();
+
+    let buf = unsafe { &mut DATA };
+    //debug!("Reading Accel's WHOAMI...");
+    buf[0] = 0x0D as u8; // 0x0D == WHOAMI register
+    dev.write_read(0x1e, buf, 1, 1);
+    i2c_client.state.set(AccelClientState::ReadingWhoami);
+}

--- a/chips/cc26x2/src/chip.rs
+++ b/chips/cc26x2/src/chip.rs
@@ -2,6 +2,7 @@ use cc26xx::gpio;
 use cc26xx::peripheral_interrupts;
 use cc26xx::uart;
 use cortexm4::{self, nvic};
+use i2c;
 use kernel;
 use rtc;
 
@@ -38,6 +39,7 @@ impl kernel::Chip for Cc26X2 {
                     peripheral_interrupts::GPIO => gpio::PORT.handle_interrupt(),
                     peripheral_interrupts::AON_RTC => rtc::RTC.handle_interrupt(),
                     peripheral_interrupts::UART0 => uart::UART0.handle_interrupt(),
+                    peripheral_interrupts::I2C => i2c::I2C0.handle_interrupt(),
                     // AON Programmable interrupt
                     // We need to ignore JTAG events since some debuggers emit these
                     peripheral_interrupts::AON_PROG => (),

--- a/chips/cc26x2/src/i2c.rs
+++ b/chips/cc26x2/src/i2c.rs
@@ -27,7 +27,7 @@ mod regs {
         /// The control register modality
         ctrl: WriteOnly<u32, super::Control::Register>,
         /// The status register modality
-        stat: ReadOnly<u32, super::Status::Register>
+        stat: ReadOnly<u32, super::Status::Register>,
     }
 
     // This implements access to the union fields as methods, since access to untagged union fields is

--- a/chips/cc26x2/src/i2c.rs
+++ b/chips/cc26x2/src/i2c.rs
@@ -1,0 +1,247 @@
+//! I2C driver, cc26x2 family
+
+use core::cmp;
+use kernel::common::cells::{MapCell, OptionalCell};
+use kernel::common::registers::{ReadOnly, ReadWrite, WriteOnly};
+use kernel::common::StaticRef;
+use kernel::hil::i2c;
+
+#[repr(C)]
+struct I2CMasterRegisters {
+    /// Master slave address
+    msa: ReadWrite<u32, Address::Register>,
+    //mstat: ReadOnly<u32, Status::Register>,
+    mctrl: WriteOnly<u32, Control::Register>,
+    mdr: ReadWrite<u8>,
+    _reserved: [u8; 3],
+    mtpr: ReadWrite<u32, TimerPeriod::Register>,
+    mimr: ReadWrite<u32, Interrupt::Register>,
+    mris: ReadOnly<u32, Interrupt::Register>,
+    mmis: ReadOnly<u32, Interrupt::Register>,
+    micr: WriteOnly<u32, Interrupt::Register>,
+    mcr: ReadWrite<u32, Configuration::Register>,
+}
+
+register_bitfields![
+    u32,
+    Address [
+        RS OFFSET(0) NUMBITS(1) [
+            Transmit = 0,
+            Receive = 1
+        ],
+        SA OFFSET(1) NUMBITS(7) []
+    ],
+    Status [
+        BUSY OFFSET(0) NUMBITS(1) [],
+        ERR OFFSET(1) NUMBITS(1) [],
+        ADRACK_N OFFSET(2) NUMBITS(1) [],
+        DATACK_N OFFSET(3) NUMBITS(1) [],
+        ARBLST OFFSET(4) NUMBITS(1) [],
+        IDLE OFFSET(5) NUMBITS(1) [],
+        BUSBSY OFFSET(6) NUMBITS(1) []
+    ],
+    Control [
+        RUN OFFSET(0) NUMBITS(1) [],
+        START OFFSET(1) NUMBITS(1) [],
+        STOP OFFSET(2) NUMBITS(1) [],
+        ACK OFFSET(3) NUMBITS(1) []
+    ],
+    TimerPeriod [
+        TPR OFFSET(0) NUMBITS(7) [],
+        WRITE OFFSET(7) NUMBITS(1) [
+            Valid = 0,
+            Ignore = 1
+        ]
+    ],
+    Interrupt [
+        IM OFFSET(0) NUMBITS(1) []
+    ],
+    Configuration [
+        LPBK OFFSET(0) NUMBITS(1) [],
+        MFE OFFSET(4) NUMBITS(1) [],
+        SFE OFFSET(5) NUMBITS(1) []
+    ]
+];
+
+struct Transfer {
+    mode: TransferMode,
+    buf: &'static mut [u8],
+    index: usize,
+    len: usize,
+}
+
+#[derive(Copy, Clone)]
+enum TransferMode {
+    Transmit,
+    Receive,
+    TransmitThenReceive(usize),
+}
+
+const I2C0REGISTERS: StaticRef<I2CMasterRegisters> =
+    unsafe { StaticRef::new(0x4000_2800 as *const _) };
+
+pub static mut I2C0: I2CMaster = I2CMaster::new(I2C0REGISTERS);
+
+pub struct I2CMaster<'a> {
+    registers: StaticRef<I2CMasterRegisters>,
+    client: OptionalCell<&'a i2c::I2CHwMasterClient>,
+    transfer: MapCell<Transfer>,
+}
+
+impl<'a> I2CMaster<'a> {
+    const fn new(registers: StaticRef<I2CMasterRegisters>) -> I2CMaster<'a> {
+        I2CMaster {
+            registers: registers,
+            client: OptionalCell::empty(),
+            transfer: MapCell::empty(),
+        }
+    }
+
+    pub fn set_client(&'a self, client: &'a i2c::I2CHwMasterClient) {
+        self.client.set(client)
+    }
+
+    /// Initiate writing a single byte. An interrupt becomes pending upon completion of the write.
+    ///
+    /// * `byte`  - the byte to send
+    /// * `first` - whether this is the first byte in a transfer (i.e. whether to include a "START"
+    ///             condition)
+    /// * `last`  - whether this is the last byte in a transfer (i.e. whether to include a "STOP"
+    ///             condition)
+    fn write_byte(&self, byte: u8, first: bool, last: bool) {
+        self.registers.mdr.set(byte);
+        self.registers.mctrl.write(
+            Control::RUN.val(1) + Control::START.val(first as u32) + Control::STOP.val(last as u32),
+        );
+    }
+
+    /// Initiate reading a single byte. An interrupt becomes pending when the byte is available in
+    /// the MDR register.
+    ///
+    /// * `first` - whether this is the first byte in a transfer (i.e. whether to include a "START"
+    ///             condition)
+    /// * `last`  - whether this is the last byte in a transfer (i.e. whether to include a "STOP"
+    ///             condition)
+    fn read_byte(&self, first: bool, last: bool) {
+        self.registers.mctrl.write(
+            Control::RUN.val(1)
+                + Control::ACK.val(1)
+                + Control::START.val(first as u32)
+                + Control::STOP.val(last as u32),
+        );
+    }
+
+    pub fn handle_interrupt(&self) {
+        self.registers.micr.write(Interrupt::IM::SET);
+        if let Some(mut transfer) = self.transfer.take() {
+            match transfer.mode {
+                TransferMode::Transmit => {
+                    if transfer.len > transfer.index {
+                        self.write_byte(
+                            transfer.buf[transfer.index],
+                            false,
+                            transfer.len == transfer.index + 1,
+                        );
+                        transfer.index += 1;
+                        self.transfer.put(transfer);
+                    } else {
+                        self.client.map(move |client| {
+                            client.command_complete(transfer.buf, i2c::Error::CommandComplete)
+                        });
+                    }
+                }
+                TransferMode::Receive => {
+                    if transfer.len > transfer.index {
+                        transfer.buf[transfer.index] = self.registers.mdr.get();
+                        self.read_byte(false, transfer.len == transfer.index + 1);
+                        self.transfer.put(transfer);
+                    } else {
+                        self.client.map(move |client| {
+                            client.command_complete(transfer.buf, i2c::Error::CommandComplete)
+                        });
+                    }
+                }
+                TransferMode::TransmitThenReceive(read_len) => {
+                    if transfer.len > transfer.index {
+                        self.write_byte(
+                            transfer.buf[transfer.index],
+                            false,
+                            transfer.len == transfer.index + 1,
+                        );
+                        transfer.index += 1;
+                        self.transfer.put(transfer);
+                    } else {
+                        transfer.index = 0;
+                        transfer.len = cmp::min(read_len, transfer.buf.len());
+                        transfer.mode = TransferMode::Receive;
+                        self.registers.msa.modify(Address::RS::Receive);
+                        self.read_byte(false, transfer.len == transfer.index + 1);
+                        self.transfer.put(transfer);
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl<'a> i2c::I2CMaster for I2CMaster<'a> {
+    fn enable(&self) {
+        self.registers.mcr.write(Configuration::MFE::SET);
+        self.registers
+            .mtpr
+            .write(TimerPeriod::WRITE::Valid + TimerPeriod::TPR.val(0xb));
+        self.registers.mimr.write(Interrupt::IM::SET);
+    }
+
+    fn disable(&self) {
+        self.registers.mcr.modify(Configuration::MFE.val(0))
+    }
+
+    fn write_read(&self, addr: u8, data: &'static mut [u8], write_len: u8, read_len: u8) {
+        self.registers
+            .msa
+            .write(Address::RS::Transmit + Address::SA.val(addr as u32));
+        let len = cmp::min(write_len as usize, data.len());
+        if len > 0 {
+            self.write_byte(data[0], true, len == 1);
+            self.transfer.put(Transfer {
+                mode: TransferMode::TransmitThenReceive(read_len as usize),
+                buf: data,
+                index: 1,
+                len: len,
+            });
+        }
+    }
+
+    fn write(&self, addr: u8, data: &'static mut [u8], len: u8) {
+        self.registers
+            .msa
+            .write(Address::RS::Transmit + Address::SA.val(addr as u32));
+        let len = cmp::min(len as usize, data.len());
+        if len > 0 {
+            self.write_byte(data[0], true, len == 1);
+            self.transfer.put(Transfer {
+                mode: TransferMode::Transmit,
+                buf: data,
+                index: 1,
+                len: len,
+            });
+        }
+    }
+
+    fn read(&self, addr: u8, buffer: &'static mut [u8], len: u8) {
+        self.registers
+            .msa
+            .write(Address::RS::Receive + Address::SA.val(addr as u32));
+        let len = cmp::min(len as usize, buffer.len());
+        if len > 0 {
+            self.read_byte(true, len == 1);
+            self.transfer.put(Transfer {
+                mode: TransferMode::Receive,
+                buf: buffer,
+                index: 1,
+                len: len,
+            });
+        }
+    }
+}

--- a/chips/cc26x2/src/lib.rs
+++ b/chips/cc26x2/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(const_fn, used)]
+#![feature(const_fn, untagged_unions, used)]
 #![no_std]
 #![crate_name = "cc26x2"]
 #![crate_type = "rlib"]

--- a/chips/cc26x2/src/lib.rs
+++ b/chips/cc26x2/src/lib.rs
@@ -11,6 +11,7 @@ extern crate kernel;
 pub mod aon;
 pub mod chip;
 pub mod crt1;
+pub mod i2c;
 pub mod prcm;
 pub mod rtc;
 

--- a/chips/cc26x2/src/prcm.rs
+++ b/chips/cc26x2/src/prcm.rs
@@ -373,6 +373,16 @@ impl Clock {
         prcm_commit();
     }
 
+    /// Enables I2C clocks for run, sleep and deep sleep mode.
+    pub fn enable_i2c() {
+        let regs = PRCM_BASE;
+        regs.i2c_clk_gate_run.modify(ClockGate::CLK_EN::SET);
+        regs.i2c_clk_gate_sleep.modify(ClockGate::CLK_EN::SET);
+        regs.i2c_clk_gate_deep_sleep.modify(ClockGate::CLK_EN::SET);
+
+        prcm_commit();
+    }
+
     pub fn set_power_down_source(source: u32) {
         let regs = AON_PMCTL_BASE;
         regs.mcu_clk.set(source & 0x01);


### PR DESCRIPTION
### Pull Request Overview

Implements the I2C master driver for CC26x2. The I2C controller doesn't
support using the uDMA on the chip, so this driver _has_ to be operated
byte-by-byte.

There is currently some overlap in the functionality implemented in CC26x2 and CC26xx crates, specifically for power management. When in doubt, I implemented logic in the CC26x2 version
since (a) I can't test on a CC2650, and (b) we should probably just remove the CC26xx crate anyway.

### Testing Strategy

 I've tested this with a modified version of `boards/imix/src/i2c_dummy.rs` for the launchxl board that:

  (a) enumerate I2C devices on the bus, and a logic analyzer monitoring the bus for acknowledgements

  (b) reads/writes registers to an FXOS8700CQ acceleromter (on an imix), also with a logic analyzer attached. This one hasn't really worked in the sense that the values I'm getting back from the accelerometer don't make sense (e.g the WHOAMI register is 0x0, and the acceleration numbers are constants), but they are consistent with what I'm seeing on the bus from the logic analyzer, so I _think_ the problem is that i'm not powering the accelerometer on the imix properly...

### TODO or Help Wanted

The launchxl board doesn't have any I2C devices on-board, instead, we should maybe use the BoosterPack pinout (which uses the two bottom-right pin headers as I2C SCL/SDA), and export the I2C system-call driver.

  - [x] Test with at least one actual I2C device to validate `read`
  - [x] Incorporate the driver into the launchxl board

### Documentation Updated

- [X] ~~Updated the relevant files in `/docs`, or no updates are required.~~

### Formatting

- [x] Ran `make formatall`.
