### PR TITLE
Prevent Allocator from dropping uninitialized memory

### DIFF
--- a/kernel/src/grant.rs
+++ b/kernel/src/grant.rs
@@ -3,7 +3,7 @@
 use core::marker::PhantomData;
 use core::mem::size_of;
 use core::ops::{Deref, DerefMut};
-use core::ptr::Unique;
+use core::ptr::{write, Unique};
 
 use callback::AppId;
 use process::Error;
@@ -90,9 +90,11 @@ impl Allocator {
                     process
                         .alloc(size_of::<T>())
                         .map_or(Err(Error::OutOfMemory), |arr| {
-                            let mut owned = Owned::new(arr.as_mut_ptr() as *mut T, self.appid);
-                            *owned = data;
-                            Ok(owned)
+                            let ptr = arr.as_mut_ptr() as *mut T;
+                            // We use `ptr::write` to avoid `Drop`ping the uninitialized memory in
+                            // case `T` implements the `Drop` trait.
+                            write(ptr, data);
+                            Ok(Owned::new(ptr, self.appid))
                         })
                 })
         }


### PR DESCRIPTION
### Pull Request Overview

Fixes #1140

"The `alloc` method of the Allocator might cause the drop method to be called (if one exists) with a reference to uninitialized memory"

Thanks to @codido for both noticing this bug and suggesting the fix to it.

### Testing Strategy

Ran several of the example applications, though _nothing_ uses the `Allocator` so this code path isn't actually being exercised.

### TODO or Help Wanted

NA

### Documentation Updated

- [X] ~~Updated the relevant files in `/docs`, or no updates are required.~~

### Formatting

- [X] Ran `make formatall`.
