### PR TITLE
Don't allow grant region to extend to previously valid AppSlice memory

### DIFF
--- a/kernel/src/grant.rs
+++ b/kernel/src/grant.rs
@@ -233,14 +233,13 @@ impl<T: Default> Grant<T> {
     where
         F: Fn(&mut Owned<T>),
     {
-        self.kernel
-            .process_each_enumerate(|app_id, process| unsafe {
-                let root_ptr = *(process.grant_ptr(self.grant_num) as *mut *mut T);
-                if !root_ptr.is_null() {
-                    let mut root = Owned::new(root_ptr, AppId::new(self.kernel, app_id));
-                    fun(&mut root);
-                }
-            });
+        self.kernel.process_each(|process| unsafe {
+            let root_ptr = *(process.grant_ptr(self.grant_num) as *mut *mut T);
+            if !root_ptr.is_null() {
+                let mut root = Owned::new(root_ptr, process.appid());
+                fun(&mut root);
+            }
+        });
     }
 
     pub fn iter(&self) -> Iter<T> {

--- a/kernel/src/introspection.rs
+++ b/kernel/src/introspection.rs
@@ -34,7 +34,7 @@ impl Introspection {
     /// long as it has been loaded.
     pub fn number_loaded_processes(&self, _capability: &ProcessManagementCapability) -> usize {
         let count: Cell<usize> = Cell::new(0);
-        self.kernel.process_each_enumerate(|_, _| count.increment());
+        self.kernel.process_each(|_| count.increment());
         count.get()
     }
 
@@ -46,7 +46,7 @@ impl Introspection {
     pub fn number_active_processes(&self, _capability: &ProcessManagementCapability) -> usize {
         let count: Cell<usize> = Cell::new(0);
         self.kernel
-            .process_each_enumerate(|_, process| match process.get_state() {
+            .process_each(|process| match process.get_state() {
                 process::State::Running => count.increment(),
                 process::State::Yielded => count.increment(),
                 process::State::Fault => {}
@@ -60,7 +60,7 @@ impl Introspection {
     pub fn number_inactive_processes(&self, _capability: &ProcessManagementCapability) -> usize {
         let count: Cell<usize> = Cell::new(0);
         self.kernel
-            .process_each_enumerate(|_, process| match process.get_state() {
+            .process_each(|process| match process.get_state() {
                 process::State::Running => {}
                 process::State::Yielded => {}
                 process::State::Fault => count.increment(),

--- a/kernel/src/ipc.rs
+++ b/kernel/src/ipc.rs
@@ -181,14 +181,14 @@ impl Driver for IPC {
         if target_id == 0 {
             match slice {
                 Some(slice_data) => {
-                    let ret = self.data.kernel.process_each_enumerate_stop(|i, p| {
+                    let ret = self.data.kernel.process_until(|p| {
                         let s = p.get_process_name().as_bytes();
                         // are slices equal?
                         if s.len() == slice_data.len()
                             && s.iter().zip(slice_data.iter()).all(|(c1, c2)| c1 == c2)
                         {
                             ReturnCode::SuccessWithValue {
-                                value: (i as usize) + 1,
+                                value: (p.appid().idx() as usize) + 1,
                             }
                         } else {
                             ReturnCode::FAIL

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -9,6 +9,8 @@ use callback::AppId;
 use capabilities::ProcessManagementCapability;
 use common::cells::MapCell;
 use common::{Queue, RingBuffer};
+use core::cmp::max;
+use mem::{AppSlice, Shared};
 use platform::mpu::{self, MPU};
 use returncode::ReturnCode;
 use sched::Kernel;
@@ -71,6 +73,9 @@ pub fn load_processes<S: UserspaceKernelBoundary, M: MPU>(
 
 /// This trait is implemented by process structs.
 pub trait ProcessType {
+    /// Returns the process's identifier
+    fn appid(&self) -> AppId;
+
     /// Queue a `Task` for the process. This will be added to a per-process
     /// buffer and executed by the scheduler. `Task`s are some function the app
     /// should run, for example a callback or an IPC call.
@@ -146,11 +151,18 @@ pub trait ProcessType {
 
     // additional memop like functions
 
-    /// Check if the buffer address and size is contained within the memory
-    /// owned by this process. This isn't quite the same as the memory allocated
-    /// to the process as this does not include the grant region which is owned
-    /// by the kernel.
-    fn in_app_owned_memory(&self, buf_start_addr: *const u8, size: usize) -> bool;
+    /// Creates an `AppSlice` from the given offset and size in process memory.
+    ///
+    /// ## Returns
+    ///
+    /// If the buffer is null (a zero-valued offset), return None, signaling the capsule to delete
+    /// the entry.  If the buffer is within the process's accessible memory, returns an AppSlice
+    /// wrapping that buffer. Otherwise, returns an error `ReturnCode`.
+    fn allow(
+        &self,
+        buf_start_addr: *const u8,
+        size: usize,
+    ) -> Result<Option<AppSlice<Shared, u8>>, ReturnCode>;
 
     /// Get the first address of process's flash that isn't protected by the
     /// kernel. The protected range of flash contains the TBF header and
@@ -316,6 +328,11 @@ struct ProcessDebug {
 }
 
 pub struct Process<'a, S: 'static + UserspaceKernelBoundary, M: 'static + MPU> {
+    /// Index of the process in the process table.
+    ///
+    /// Corresponds to AppId
+    app_idx: usize,
+
     /// Pointer to the main Kernel struct.
     kernel: &'static Kernel,
 
@@ -361,6 +378,9 @@ pub struct Process<'a, S: 'static + UserspaceKernelBoundary, M: 'static + MPU> {
     app_break: Cell<*const u8>,
     original_app_break: *const u8,
 
+    /// Pointer to high water mark for process buffers shared through `allow`
+    allow_high_water_mark: Cell<*const u8>,
+
     /// Saved when the app switches to the kernel.
     current_stack_pointer: Cell<*const u8>,
     original_stack_pointer: *const u8,
@@ -403,6 +423,10 @@ pub struct Process<'a, S: 'static + UserspaceKernelBoundary, M: 'static + MPU> {
 }
 
 impl<S: UserspaceKernelBoundary, M: MPU> ProcessType for Process<'a, S, M> {
+    fn appid(&self) -> AppId {
+        AppId::new(self.kernel, self.app_idx)
+    }
+
     fn enqueue_task(&self, task: Task) -> bool {
         // If this app is in the `Fault` state then we shouldn't schedule
         // any work for it.
@@ -613,7 +637,7 @@ impl<S: UserspaceKernelBoundary, M: MPU> ProcessType for Process<'a, S, M> {
     fn brk(&self, new_break: *const u8) -> Result<*const u8, Error> {
         self.mpu_config
             .map_or(Err(Error::KernelError), |mut config| {
-                if new_break < self.mem_start() || new_break >= self.mem_end() {
+                if new_break < self.allow_high_water_mark.get() || new_break >= self.mem_end() {
                     Err(Error::AddressOutOfBounds)
                 } else if new_break > self.kernel_memory_break.get() {
                     Err(Error::OutOfMemory)
@@ -633,17 +657,28 @@ impl<S: UserspaceKernelBoundary, M: MPU> ProcessType for Process<'a, S, M> {
             })
     }
 
-    /// Checks if the buffer represented by the passed in base pointer and size
-    /// are within the memory bounds currently exposed to the processes (i.e.
-    /// ending at `kernel_memory_break`. If this method returns true, the buffer
-    /// is guaranteed to be accessible to the process and to not overlap with
-    /// the grant region.
-    fn in_app_owned_memory(&self, buf_start_addr: *const u8, size: usize) -> bool {
-        let buf_end_addr = buf_start_addr.wrapping_offset(size as isize);
-
-        buf_end_addr >= buf_start_addr
-            && buf_start_addr >= self.mem_start()
-            && buf_end_addr <= self.mem_break()
+    fn allow(
+        &self,
+        buf_start_addr: *const u8,
+        size: usize,
+    ) -> Result<Option<AppSlice<Shared, u8>>, ReturnCode> {
+        if buf_start_addr == ptr::null_mut() {
+            // A null buffer means pass in `None` to the capsule
+            Ok(None)
+        } else if self.in_app_owned_memory(buf_start_addr, size) {
+            // Valid slice, we need to adjust the app's watermark
+            // in_app_owned_memory eliminates this offset actually wrapping
+            let buf_end_addr = buf_start_addr.wrapping_offset(size as isize);
+            let new_water_mark = max(self.allow_high_water_mark.get(), buf_end_addr);
+            self.allow_high_water_mark.set(new_water_mark);
+            Ok(Some(AppSlice::new(
+                buf_start_addr as *mut u8,
+                size,
+                self.appid(),
+            )))
+        } else {
+            Err(ReturnCode::EINVAL)
+        }
     }
 
     unsafe fn alloc(&self, size: usize) -> Option<&mut [u8]> {
@@ -1070,6 +1105,7 @@ impl<S: 'static + UserspaceKernelBoundary, M: 'static + MPU> Process<'a, S, M> {
             process.original_kernel_memory_break = kernel_memory_break;
             process.app_break = Cell::new(initial_sbrk_pointer);
             process.original_app_break = initial_sbrk_pointer;
+            process.allow_high_water_mark = Cell::new(remaining_app_memory);
             process.current_stack_pointer = Cell::new(initial_stack_pointer);
             process.original_stack_pointer = initial_stack_pointer;
 
@@ -1135,12 +1171,21 @@ impl<S: 'static + UserspaceKernelBoundary, M: 'static + MPU> Process<'a, S, M> {
         (None, 0, 0)
     }
 
-    fn mem_break(&self) -> *const u8 {
-        self.kernel_memory_break.get()
-    }
-
     fn sp(&self) -> *const usize {
         self.current_stack_pointer.get() as *const usize
+    }
+
+    /// Checks if the buffer represented by the passed in base pointer and size
+    /// are within the memory bounds currently exposed to the processes (i.e.
+    /// ending at `app_break`. If this method returns true, the buffer
+    /// is guaranteed to be accessible to the process and to not overlap with
+    /// the grant region.
+    fn in_app_owned_memory(&self, buf_start_addr: *const u8, size: usize) -> bool {
+        let buf_end_addr = buf_start_addr.wrapping_offset(size as isize);
+
+        buf_end_addr >= buf_start_addr
+            && buf_start_addr >= self.mem_start()
+            && buf_end_addr <= self.app_break.get()
     }
 
     /// Reset all `grant_ptr`s to NULL.

--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -1,16 +1,13 @@
 //! Tock core scheduler.
 
 use core::cell::Cell;
-use core::ptr;
 use core::ptr::NonNull;
 
-use callback;
-use callback::{AppId, Callback};
+use callback::Callback;
 use capabilities;
 use common::cells::NumericCellExt;
 use grant::Grant;
 use ipc;
-use mem::AppSlice;
 use memop;
 use platform::mpu::MPU;
 use platform::systick::SysTick;
@@ -85,14 +82,14 @@ impl Kernel {
 
     /// Run a closure on every valid process. This will iterate the array of
     /// processes and call the closure on every process that exists.
-    crate fn process_each_enumerate<F>(&self, closure: F)
+    crate fn process_each<F>(&self, closure: F)
     where
-        F: Fn(usize, &process::ProcessType),
+        F: Fn(&process::ProcessType),
     {
-        for (i, process) in self.processes.iter().enumerate() {
+        for process in self.processes.iter() {
             match process {
                 Some(p) => {
-                    closure(i, *p);
+                    closure(*p);
                 }
                 None => {}
             }
@@ -103,14 +100,14 @@ impl Kernel {
     /// `FAIL`. That is, if the closure returns any other return code than
     /// `FAIL`, that value will be returned from this function and the iteration
     /// of the array of processes will stop.
-    crate fn process_each_enumerate_stop<F>(&self, closure: F) -> ReturnCode
+    crate fn process_until<F>(&self, closure: F) -> ReturnCode
     where
-        F: Fn(usize, &process::ProcessType) -> ReturnCode,
+        F: Fn(&process::ProcessType) -> ReturnCode,
     {
-        for (i, process) in self.processes.iter().enumerate() {
+        for process in self.processes.iter() {
             match process {
                 Some(p) => {
-                    let ret = closure(i, *p);
+                    let ret = closure(*p);
                     if ret != ReturnCode::FAIL {
                         return ret;
                     }
@@ -193,15 +190,9 @@ impl Kernel {
             unsafe {
                 chip.service_pending_interrupts();
 
-                for (i, p) in self.processes.iter().enumerate() {
+                for p in self.processes.iter() {
                     p.map(|process| {
-                        self.do_process(
-                            platform,
-                            chip,
-                            process,
-                            callback::AppId::new(self, i),
-                            ipc,
-                        );
+                        self.do_process(platform, chip, process, ipc);
                     });
                     if chip.has_pending_interrupts() {
                         break;
@@ -222,9 +213,9 @@ impl Kernel {
         platform: &P,
         chip: &C,
         process: &process::ProcessType,
-        appid: AppId,
         ipc: Option<&::ipc::IPC>,
     ) {
+        let appid = process.appid();
         let systick = chip.systick();
         systick.reset();
         systick.set_timer(KERNEL_TICK_DURATION_US);
@@ -320,26 +311,11 @@ impl Kernel {
                                     let res = platform.with_driver(driver_number, |driver| {
                                         match driver {
                                             Some(d) => {
-                                                if allow_address != ptr::null_mut() {
-                                                    if process.in_app_owned_memory(
-                                                        allow_address,
-                                                        allow_size,
-                                                    ) {
-                                                        let slice = AppSlice::new(
-                                                            allow_address,
-                                                            allow_size,
-                                                            appid,
-                                                        );
-                                                        d.allow(
-                                                            appid,
-                                                            subdriver_number,
-                                                            Some(slice),
-                                                        )
-                                                    } else {
-                                                        ReturnCode::EINVAL /* memory not allocated to process */
+                                                match process.allow(allow_address, allow_size) {
+                                                    Ok(oslice) => {
+                                                        d.allow(appid, subdriver_number, oslice)
                                                     }
-                                                } else {
-                                                    d.allow(appid, subdriver_number, None)
+                                                    Err(err) => err, /* memory not valid */
                                                 }
                                             }
                                             None => ReturnCode::ENODEVICE,


### PR DESCRIPTION
### Pull Request Overview

Fixes #1141

The problem: you share an buffer from process memory with `allow` from somewhere on your heap. Then, you call `brk` to reduce your process memory break, invalidating much of your heap, including the location of the buffer you just shared. Now one of the drivers has an `AppSlice` reference that refers to invalid memory, in praticular, memory that _could_ become occupied by a grant allocated to another capsule. This. Can. Break. Type. Safety.

The fix: keep track of a high water mark for memory that has been shared through `allow`, and never let the `app_memory_break` drop below that water mark. In practice, processes _should_ be `allow`ing buffers allocated in static memory, or on the stack, which is below anywhere a malloc implementation would reasonably give up with sbrk, so this should have relatively limited impact on "normal" applications.

To make this work cleanly, it made sense to move the `allow` logic into the process struct, and make the process struct aware of it's own identifier. Then it also made sense to remove spurious creations of `Appid` used in a few other parts of the kernel crate. This has the ancillary benefit of making fewer parts of the kernel crate aware of the implementation of AppId, which should make it simpler to change (which we kind of want to do).

However, that change might make this PR slightly harder to review. If that's the case i can probably make a different version with fewer changes that still accomplishes the same task.

### Testing Strategy

Not tested properly yet

### TODO or Help Wanted

Testing

### Documentation Updated

- [ ] ~~Updated the relevant files in `/docs`, or no updates are required.~~

### Formatting

- [x] Ran `make formatall`.
