### PR TITLE
Fix a bug on TBFheader version 2 parsing.

### DIFF
--- a/kernel/src/tbfheader.rs
+++ b/kernel/src/tbfheader.rs
@@ -312,12 +312,10 @@ crate unsafe fn parse_and_validate_tbf_header(address: *const u8) -> Option<TbfH
             // Calculate checksum. The checksum is the XOR of each 4 byte word
             // in the header.
             let mut chunks = tbf_header_base.header_size as usize / 4;
-            let leftover_bytes = if chunks * 4 != tbf_header_base.header_size as usize {
+            let leftover_bytes = tbf_header_base.header_size as usize % 4;
+            if leftover_bytes != 0 {
                 chunks += 1;
-                tbf_header_base.header_size as usize - (chunks * 4)
-            } else {
-                0
-            };
+            }
             let mut checksum: u32 = 0;
             let header = slice::from_raw_parts(address as *const u32, chunks);
             for (i, chunk) in header.iter().enumerate() {


### PR DESCRIPTION
### Pull Request Overview
Fix a bug when parsing the version 2 of TBF header.
The bug happens when the header was a not a multiple of 4 bytes.
The result of the bug was panic, since it was setting a UINT to a negative value.

One example of the bug happening is if tbf_header_base.header_size was 99. Chunks would be set to 25, and leftover_bytes would be set to -3 (and then panic)

### Testing Strategy
--

### TODO or Help Wanted
Not applicable.


### Documentation Updated

- [x] No updates are required.
Now the file matches the behavior in the documentation
### Formatting
- [x] Ran `make formatall`.


## Comment
If there is a reason not to use "%", one could instead change line 317 to 
```  tbf_header_base.header_size as usize - ((chunks-1) * 4)```