### PR TITLE
kernel: remove TBF header v1

### DIFF
--- a/doc/Compilation.md
+++ b/doc/Compilation.md
@@ -213,21 +213,6 @@ struct TbfHeaderMain {
     minimum_ram_size: u32,   // How much RAM the application is requesting
 }
 
-// Specifications for instructing the kernel to do PIC fixups for the application.
-struct TbfHeaderPicOption1Fields {
-    base: TbfHeaderTlv,
-    text_offset: u32,            // Offset in memory to start of text segment
-    data_offset: u32,            // Offset in memory to start of data
-    data_size: u32,              // Length of data segment in bytes
-    bss_memory_offset: u32,      // Offset in memory to start of BSS
-    bss_size: u32,               // Length of BSS segment in bytes
-    relocation_data_offset: u32, // Offset in memory to start of relocation data
-    relocation_data_size: u32,   // Length of relocation data segment in bytes
-    got_offset: u32,             // Offset in memory to start of GOT
-    got_size: u32,               // Length of GOT segment in bytes
-    minimum_stack_length: u32,   // Minimum stack size
-}
-
 // Optional package name for the app.
 struct TbfHeaderPackageName {
     base: TbfHeaderTlv,

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -1194,7 +1194,7 @@ impl<S: 'static + UserspaceKernelBoundary> Process<'a, S> {
 
             // Otherwise, actually load the app.
             let mut min_app_ram_size = tbf_header.get_minimum_app_ram_size();
-            let process_name = tbf_header.get_package_name(app_flash_address);
+            let process_name = tbf_header.get_package_name();
             let init_fn =
                 app_flash_address.offset(tbf_header.get_init_function_offset() as isize) as usize;
 

--- a/kernel/src/tbfheader.rs
+++ b/kernel/src/tbfheader.rs
@@ -2,46 +2,11 @@
 
 use core::{mem, slice, str};
 
-/// Takes a value and rounds it up to be aligned % 8
-macro_rules! align8 {
-    ($e:expr) => {
-        ($e) + ((8 - (($e) % 8)) % 8)
-    };
-}
-
 /// Takes a value and rounds it up to be aligned % 4
 macro_rules! align4 {
     ($e:expr) => {
         ($e) + ((4 - (($e) % 4)) % 4)
     };
-}
-
-/// Legacy Tock Binary Format header.
-///
-/// Version 1 of the header is deprecated but can still be parsed by the kernel
-/// to support any apps that were compiled with an older version of elf2tbf.
-#[repr(C)]
-#[derive(Clone, Copy, Debug)]
-crate struct TbfHeaderV1 {
-    version: u32,
-    total_size: u32,
-    entry_offset: u32,
-    rel_data_offset: u32,
-    rel_data_size: u32,
-    text_offset: u32,
-    text_size: u32,
-    got_offset: u32,
-    got_size: u32,
-    data_offset: u32,
-    data_size: u32,
-    bss_mem_offset: u32,
-    bss_size: u32,
-    min_stack_len: u32,
-    min_app_heap_len: u32,
-    min_kernel_heap_len: u32,
-    pkg_name_offset: u32,
-    pkg_name_size: u32,
-    checksum: u32,
 }
 
 /// TBF fields that must be present in all v2 headers.
@@ -97,25 +62,6 @@ crate struct TbfHeaderV2WriteableFlashRegion {
     writeable_flash_region_size: u32,
 }
 
-/// PIC fields for kernel provided PIC fixup.
-///
-/// If an app wants the kernel to do the PIC fixup for it, it must pass this
-/// block so the kernel knows where sections are in the app binary.
-#[repr(C)]
-#[derive(Clone, Copy, Debug)]
-crate struct PicOption1Fields {
-    text_offset: u32,
-    data_offset: u32,
-    data_size: u32,
-    bss_memory_offset: u32,
-    bss_size: u32,
-    relocation_data_offset: u32,
-    relocation_data_size: u32,
-    got_offset: u32,
-    got_size: u32,
-    minimum_stack_length: u32,
-}
-
 /// Single header that can contain all parts of a v2 header.
 #[derive(Clone, Copy, Debug)]
 crate struct TbfHeaderV2 {
@@ -133,7 +79,6 @@ crate struct TbfHeaderV2 {
 /// the application.
 #[derive(Debug)]
 crate enum TbfHeader {
-    TbfHeaderV1(&'static TbfHeaderV1),
     TbfHeaderV2(TbfHeaderV2),
     Padding(&'static TbfHeaderV2Base),
 }
@@ -142,7 +87,6 @@ impl TbfHeader {
     /// Return whether this is an app or just padding between apps.
     crate fn is_app(&self) -> bool {
         match *self {
-            TbfHeader::TbfHeaderV1(_) => true,
             TbfHeader::TbfHeaderV2(_) => true,
             TbfHeader::Padding(_) => false,
         }
@@ -152,9 +96,6 @@ impl TbfHeader {
     /// Disabled applications are not started by the kernel.
     crate fn enabled(&self) -> bool {
         match *self {
-            // Header v1 has no flag for this, and therefore all apps are
-            // always enabled.
-            TbfHeader::TbfHeaderV1(_) => true,
             TbfHeader::TbfHeaderV2(hd) => {
                 // Bit 1 of flags is the enable/disable bit.
                 hd.base.flags & 0x00000001 == 1
@@ -166,7 +107,6 @@ impl TbfHeader {
     /// Get the total size in flash of this app or padding.
     crate fn get_total_size(&self) -> u32 {
         match *self {
-            TbfHeader::TbfHeaderV1(hd) => hd.total_size,
             TbfHeader::TbfHeaderV2(hd) => hd.base.total_size,
             TbfHeader::Padding(hd) => hd.total_size,
         }
@@ -177,12 +117,6 @@ impl TbfHeader {
     /// needed for this app.
     crate fn get_minimum_app_ram_size(&self) -> u32 {
         match *self {
-            TbfHeader::TbfHeaderV1(hd) => {
-                let heap_len = align8!(hd.min_app_heap_len) + align8!(hd.min_kernel_heap_len);
-                let data_len = hd.data_size + hd.got_size + hd.bss_size;
-                let stack_size = align8!(hd.min_stack_len);
-                align8!(data_len + stack_size) + heap_len
-            }
             TbfHeader::TbfHeaderV2(hd) => hd.main.map_or(0, |m| m.minimum_ram_size),
             _ => 0,
         }
@@ -192,7 +126,6 @@ impl TbfHeader {
     /// is for kernel use only. The app cannot write this region.
     crate fn get_protected_size(&self) -> u32 {
         match *self {
-            TbfHeader::TbfHeaderV1(_) => mem::size_of::<TbfHeaderV1>() as u32,
             TbfHeader::TbfHeaderV2(hd) => {
                 hd.main.map_or(0, |m| m.protected_size) + (hd.base.header_size as u32)
             }
@@ -204,7 +137,6 @@ impl TbfHeader {
     /// app should start executing.
     crate fn get_init_function_offset(&self) -> u32 {
         match *self {
-            TbfHeader::TbfHeaderV1(hd) => hd.entry_offset,
             TbfHeader::TbfHeaderV2(hd) => {
                 hd.main.map_or(0, |m| m.init_fn_offset) + (hd.base.header_size as u32)
             }
@@ -213,19 +145,8 @@ impl TbfHeader {
     }
 
     /// Get the name of the app.
-    crate fn get_package_name(&self, flash_start_addr: *const u8) -> &'static str {
+    crate fn get_package_name(&self) -> &'static str {
         match *self {
-            TbfHeader::TbfHeaderV1(hd) => unsafe {
-                let package_name_byte_array = slice::from_raw_parts(
-                    flash_start_addr.offset(hd.pkg_name_offset as isize),
-                    hd.pkg_name_size as usize,
-                );
-                let mut app_name_str = "";
-                let _ = str::from_utf8(package_name_byte_array).map(|name_str| {
-                    app_name_str = name_str;
-                });
-                app_name_str
-            },
             TbfHeader::TbfHeaderV2(hd) => hd.package_name.unwrap_or(""),
             _ => "",
         }
@@ -234,7 +155,6 @@ impl TbfHeader {
     /// Get the number of flash regions this app has specified in its header.
     crate fn number_writeable_flash_regions(&self) -> usize {
         match *self {
-            TbfHeader::TbfHeaderV1(_) => 0,
             TbfHeader::TbfHeaderV2(hd) => hd.writeable_regions.map_or(0, |wr| wr.len()),
             _ => 0,
         }
@@ -243,7 +163,6 @@ impl TbfHeader {
     /// Get the offset and size of a given flash region.
     crate fn get_writeable_flash_region(&self, index: usize) -> (u32, u32) {
         match *self {
-            TbfHeader::TbfHeaderV1(_) => (0, 0),
             TbfHeader::TbfHeaderV2(hd) => hd.writeable_regions.map_or((0, 0), |wr| {
                 if wr.len() > index {
                     (
@@ -268,35 +187,6 @@ crate unsafe fn parse_and_validate_tbf_header(address: *const u8) -> Option<TbfH
     let version = *(address as *const u16);
 
     match version {
-        1 => {
-            let tbf_header = &*(address as *const TbfHeaderV1);
-
-            let checksum = tbf_header.version
-                ^ tbf_header.total_size
-                ^ tbf_header.entry_offset
-                ^ tbf_header.rel_data_offset
-                ^ tbf_header.rel_data_size
-                ^ tbf_header.text_offset
-                ^ tbf_header.text_size
-                ^ tbf_header.got_offset
-                ^ tbf_header.got_size
-                ^ tbf_header.data_offset
-                ^ tbf_header.data_size
-                ^ tbf_header.bss_mem_offset
-                ^ tbf_header.bss_size
-                ^ tbf_header.min_stack_len
-                ^ tbf_header.min_app_heap_len
-                ^ tbf_header.min_kernel_heap_len
-                ^ tbf_header.pkg_name_offset
-                ^ tbf_header.pkg_name_size;
-
-            if checksum != tbf_header.checksum {
-                None
-            } else {
-                Some(TbfHeader::TbfHeaderV1(tbf_header))
-            }
-        }
-
         2 => {
             let tbf_header_base = &*(address as *const TbfHeaderV2Base);
 
@@ -415,6 +305,8 @@ crate unsafe fn parse_and_validate_tbf_header(address: *const u8) -> Option<TbfH
             }
         }
 
+        // If we don't recognize the version number, we assume this is not a
+        // valid app.
         _ => None,
     }
 }


### PR DESCRIPTION
V1 of the TBF header has been deprecated for a while now, and there is very little chance that any boards still have apps with the old tbf header version.

This also removes the PIC options field that is not supported by the kernel, not standardized, and not something we want the kernel to have to support in the future. It is also, as far as we know, unused.

~~Blocked because #1113 _needs_ to be merged.~~

Fixes #1147.


### Testing Strategy

This pull request was tested by compiling.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
