### PR TITLE
Add read_as_enum() to LocalRegisterCopy

### DIFF
--- a/libraries/tock-register-interface/CHANGELOG.md
+++ b/libraries/tock-register-interface/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## v0.2
+
+ - #1161: Add `read_as_enum` to `LocalRegisterCopy`; thanks @andre-richter
+
+## v0.1 - Initial Release

--- a/libraries/tock-register-interface/Cargo.lock
+++ b/libraries/tock-register-interface/Cargo.lock
@@ -1,4 +1,4 @@
 [[package]]
 name = "tock-registers"
-version = "0.1.0"
+version = "0.2.0"
 

--- a/libraries/tock-register-interface/Cargo.toml
+++ b/libraries/tock-register-interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tock-registers"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
 description = "Memory-Mapped I/O and register interface developed for Tock."
 homepage = "https://www.tockos.org/"

--- a/libraries/tock-register-interface/src/registers.rs
+++ b/libraries/tock-register-interface/src/registers.rs
@@ -289,6 +289,13 @@ impl<T: IntLike, R: RegisterLongName> LocalRegisterCopy<T, R> {
     }
 
     #[inline]
+    pub fn read_as_enum<E: TryFromValue<T, EnumType = E>>(&self, field: Field<T, R>) -> Option<E> {
+        let val: T = self.read(field);
+
+        E::try_from(val)
+    }
+
+    #[inline]
     pub fn is_set(&self, field: Field<T, R>) -> bool {
         self.read(field) != T::zero()
     }


### PR DESCRIPTION
I just hit a case where I wanted to use this. I think it makes sense to add?