### PR TITLE
UDP Port binding + Driver Improvements

### DIFF
--- a/boards/imix/src/components/udp_6lowpan.rs
+++ b/boards/imix/src/components/udp_6lowpan.rs
@@ -14,6 +14,7 @@
 //! ```
 
 // Author: Hudson Ayers <hayers@stanford.edu>
+// Last Modified: 8/26/2018
 
 #![allow(dead_code)] // Components are intended to be conditionally included
 
@@ -73,7 +74,7 @@ const PAYLOAD_LEN: usize = 200; //The max size UDP message that can be sent by u
 //
 //   1. RF233_BUF: buffer the IP6_Sender uses to pass frames to the radio after fragmentation
 //   2. SIXLOWPAN_RX_BUF: Buffer to hold full IP packets after they are decompressed by 6LoWPAN
-//   4. UDP_DGRAM: The payload of the IP6_Packet, which holds full IP Packets before they are tx'd
+//   3. UDP_DGRAM: The payload of the IP6_Packet, which holds full IP Packets before they are tx'd
 
 const UDP_HDR_SIZE: usize = 8;
 static mut RF233_BUF: [u8; radio::MAX_BUF_SIZE] = [0x00; radio::MAX_BUF_SIZE];

--- a/boards/imix/src/components/udp_6lowpan.rs
+++ b/boards/imix/src/components/udp_6lowpan.rs
@@ -135,7 +135,10 @@ impl Component for UDPComponent {
         let ip6_dg = static_init!(IP6Packet<'static>, IP6Packet::new(ip_pyld));
 
         let ip_send = static_init!(
-            capsules::net::ipv6::ipv6_send::IP6SendStruct<'static, VirtualMuxAlarm<'static, sam4l::ast::Ast>>,
+            capsules::net::ipv6::ipv6_send::IP6SendStruct<
+                'static,
+                VirtualMuxAlarm<'static, sam4l::ast::Ast>,
+            >,
             capsules::net::ipv6::ipv6_send::IP6SendStruct::new(
                 ip6_dg,
                 ipsender_virtual_alarm,
@@ -154,7 +157,13 @@ impl Component for UDPComponent {
         udp_mac.set_transmit_client(ip_send);
 
         let udp_send = static_init!(
-            UDPSendStruct<'static, capsules::net::ipv6::ipv6_send::IP6SendStruct<'static, VirtualMuxAlarm<'static, sam4l::ast::Ast<'static>>>>,
+            UDPSendStruct<
+                'static,
+                capsules::net::ipv6::ipv6_send::IP6SendStruct<
+                    'static,
+                    VirtualMuxAlarm<'static, sam4l::ast::Ast<'static>>,
+                >,
+            >,
             UDPSendStruct::new(ip_send)
         );
         ip_send.set_client(udp_send);

--- a/boards/imix/src/icmp_lowpan_test.rs
+++ b/boards/imix/src/icmp_lowpan_test.rs
@@ -107,8 +107,8 @@ pub unsafe fn initialize_all(
     let ip6_dg = static_init!(IP6Packet<'static>, IP6Packet::new(ip_pyld));
 
     let ipsender_virtual_alarm = static_init!(
-         VirtualMuxAlarm<'static, sam4l::ast::Ast>,
-         VirtualMuxAlarm::new(mux_alarm)
+        VirtualMuxAlarm<'static, sam4l::ast::Ast>,
+        VirtualMuxAlarm::new(mux_alarm)
     );
 
     let ip6_sender = static_init!(
@@ -126,7 +126,10 @@ pub unsafe fn initialize_all(
     radio_mac.set_transmit_client(ip6_sender);
 
     let icmp_send_struct = static_init!(
-        ICMP6SendStruct<'static, IP6SendStruct<'static, VirtualMuxAlarm<'static, sam4l::ast::Ast<'static>>>>,
+        ICMP6SendStruct<
+            'static,
+            IP6SendStruct<'static, VirtualMuxAlarm<'static, sam4l::ast::Ast<'static>>>,
+        >,
         ICMP6SendStruct::new(ip6_sender)
     );
 

--- a/boards/imix/src/icmp_lowpan_test.rs
+++ b/boards/imix/src/icmp_lowpan_test.rs
@@ -70,8 +70,6 @@ pub static mut RF233_BUF: [u8; radio::MAX_BUF_SIZE] = [0 as u8; radio::MAX_BUF_S
 
 pub struct LowpanICMPTest<'a, A: time::Alarm> {
     alarm: A,
-    //sixlowpan_tx: TxState<'a>,
-    //radio: &'a Mac<'a>,
     test_counter: Cell<usize>,
     icmp_sender: &'a ICMP6Sender<'a>,
 }
@@ -108,10 +106,16 @@ pub unsafe fn initialize_all(
 
     let ip6_dg = static_init!(IP6Packet<'static>, IP6Packet::new(ip_pyld));
 
+    let ipsender_virtual_alarm = static_init!(
+         VirtualMuxAlarm<'static, sam4l::ast::Ast>,
+         VirtualMuxAlarm::new(mux_alarm)
+    );
+
     let ip6_sender = static_init!(
-        IP6SendStruct<'static>,
+        IP6SendStruct<'static, VirtualMuxAlarm<'static, sam4l::ast::Ast<'static>>>,
         IP6SendStruct::new(
             ip6_dg,
+            ipsender_virtual_alarm,
             &mut RF233_BUF,
             sixlowpan_tx,
             radio_mac,
@@ -122,7 +126,7 @@ pub unsafe fn initialize_all(
     radio_mac.set_transmit_client(ip6_sender);
 
     let icmp_send_struct = static_init!(
-        ICMP6SendStruct<'static, IP6SendStruct<'static>>,
+        ICMP6SendStruct<'static, IP6SendStruct<'static, VirtualMuxAlarm<'static, sam4l::ast::Ast<'static>>>>,
         ICMP6SendStruct::new(ip6_sender)
     );
 

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -384,6 +384,7 @@ pub unsafe fn reset_handler() {
         DST_MAC_ADDR,
         SRC_MAC_ADDR,
         &LOCAL_IP_IFACES,
+        mux_alarm,
     ).finalize();
 
     let imix = Imix {

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -118,7 +118,7 @@ static mut PROCESSES: [Option<&'static kernel::procs::ProcessType>; NUM_PROCS] =
 /// Dummy buffer that causes the linker to reserve enough space for the stack.
 #[no_mangle]
 #[link_section = ".stack_buffer"]
-pub static mut STACK_MEMORY: [u8; 0x1000] = [0; 0x1000];
+pub static mut STACK_MEMORY: [u8; 0x2000] = [0; 0x2000];
 
 struct Imix {
     console: &'static capsules::console::Console<'static, UartDevice<'static>>,

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -376,8 +376,6 @@ pub unsafe fn reset_handler() {
     let usb_driver = UsbComponent::new(board_kernel).finalize();
     let nonvolatile_storage = NonvolatileStorageComponent::new(board_kernel).finalize();
 
-    // ** UDP **
-
     let udp_driver = UDPComponent::new(
         board_kernel,
         mux_mac,

--- a/boards/imix/src/udp_lowpan_test.rs
+++ b/boards/imix/src/udp_lowpan_test.rs
@@ -125,8 +125,8 @@ pub unsafe fn initialize_all(
     let ip6_dg = static_init!(IP6Packet<'static>, IP6Packet::new(ip_pyld));
 
     let ipsender_virtual_alarm = static_init!(
-         VirtualMuxAlarm<'static, sam4l::ast::Ast>,
-         VirtualMuxAlarm::new(mux_alarm)
+        VirtualMuxAlarm<'static, sam4l::ast::Ast>,
+        VirtualMuxAlarm::new(mux_alarm)
     );
 
     let ip6_sender = static_init!(
@@ -144,7 +144,10 @@ pub unsafe fn initialize_all(
     radio_mac.set_transmit_client(ip6_sender);
 
     let udp_send_struct = static_init!(
-        UDPSendStruct<'static, IP6SendStruct<'static, VirtualMuxAlarm<'static, sam4l::ast::Ast<'static>>>>,
+        UDPSendStruct<
+            'static,
+            IP6SendStruct<'static, VirtualMuxAlarm<'static, sam4l::ast::Ast<'static>>>,
+        >,
         UDPSendStruct::new(ip6_sender)
     );
 

--- a/boards/imix/src/udp_lowpan_test.rs
+++ b/boards/imix/src/udp_lowpan_test.rs
@@ -124,10 +124,16 @@ pub unsafe fn initialize_all(
 
     let ip6_dg = static_init!(IP6Packet<'static>, IP6Packet::new(ip_pyld));
 
+    let ipsender_virtual_alarm = static_init!(
+         VirtualMuxAlarm<'static, sam4l::ast::Ast>,
+         VirtualMuxAlarm::new(mux_alarm)
+    );
+
     let ip6_sender = static_init!(
-        IP6SendStruct<'static>,
+        IP6SendStruct<'static, VirtualMuxAlarm<'static, sam4l::ast::Ast<'static>>>,
         IP6SendStruct::new(
             ip6_dg,
+            ipsender_virtual_alarm,
             &mut RF233_BUF,
             sixlowpan_tx,
             radio_mac,
@@ -138,7 +144,7 @@ pub unsafe fn initialize_all(
     radio_mac.set_transmit_client(ip6_sender);
 
     let udp_send_struct = static_init!(
-        UDPSendStruct<'static, IP6SendStruct<'static>>,
+        UDPSendStruct<'static, IP6SendStruct<'static, VirtualMuxAlarm<'static, sam4l::ast::Ast<'static>>>>,
         UDPSendStruct::new(ip6_sender)
     );
 

--- a/capsules/src/ieee802154/mac.rs
+++ b/capsules/src/ieee802154/mac.rs
@@ -174,7 +174,7 @@ impl<R: radio::Radio> radio::RxClient for AwakeMac<'a, R> {
         }
 
         if addr_match {
-            debug!("match!!!!");
+            debug!("[AwakeMAC] Rcvd a 15.4 frame addressed to this device");
             self.rx_client.map(move |c| {
                 c.receive(buf, frame_len, crc_valid, result);
             });

--- a/capsules/src/ieee802154/mac.rs
+++ b/capsules/src/ieee802154/mac.rs
@@ -174,11 +174,13 @@ impl<R: radio::Radio> radio::RxClient for AwakeMac<'a, R> {
         }
 
         if addr_match {
+            debug!("match!!!!");
             self.rx_client.map(move |c| {
                 c.receive(buf, frame_len, crc_valid, result);
             });
         } else {
             debug!("[AwakeMAC] Received a packet, but not addressed to us");
+            debug!("radio addr is: {:?}", self.radio.get_address());
             self.radio.set_receive_buffer(buf);
         }
     }

--- a/capsules/src/net/ipv6/ip_utils.rs
+++ b/capsules/src/net/ipv6/ip_utils.rs
@@ -125,7 +125,7 @@ pub fn compute_udp_checksum(
         while i < ((udp_length - 8) as usize) {
             let msb_dat: u16 = ((payload[i]) as u16) << 8;
             let mut lsb_dat: u16 = 0;
-            if (i + 1 < udp_length as usize - 8) {
+            if i + 1 < udp_length as usize - 8 {
                 lsb_dat = payload[i + 1] as u16;
             }
             let temp_dat: u16 = msb_dat + lsb_dat;

--- a/capsules/src/net/ipv6/ip_utils.rs
+++ b/capsules/src/net/ipv6/ip_utils.rs
@@ -124,7 +124,10 @@ pub fn compute_udp_checksum(
         let mut i: usize = 0;
         while i < ((udp_length - 8) as usize) {
             let msb_dat: u16 = ((payload[i]) as u16) << 8;
-            let lsb_dat: u16 = payload[i + 1] as u16;
+            let mut lsb_dat: u16 = 0;
+            if (i + 1 < udp_length as usize - 8) {
+                lsb_dat = payload[i + 1] as u16;
+            }
             let temp_dat: u16 = msb_dat + lsb_dat;
             sum += temp_dat as u32;
 

--- a/capsules/src/net/ipv6/ip_utils.rs
+++ b/capsules/src/net/ipv6/ip_utils.rs
@@ -118,6 +118,7 @@ pub fn compute_udp_checksum(
     sum += src_port as u32;
     sum += dst_port as u32;
     sum += udp_header.get_len() as u32;
+    sum += udp_header.get_cksum() as u32;
     //Now just need to iterate thru data and add it to the sum
     {
         let mut i: usize = 0;

--- a/capsules/src/net/ipv6/ipv6_recv.rs
+++ b/capsules/src/net/ipv6/ipv6_recv.rs
@@ -2,6 +2,8 @@ use kernel::common::cells::OptionalCell;
 use kernel::ReturnCode;
 use net::ipv6::ipv6::IP6Header;
 use net::sixlowpan::sixlowpan_state::SixlowpanRxClient;
+use net::udp::udp::UDPHeader;
+use net::ipv6::ip_utils::compute_udp_checksum;
 
 // To provide some context for the entire rx chain:
 /*
@@ -60,16 +62,22 @@ impl<'a> IP6RecvStruct<'a> {
 
 impl<'a> SixlowpanRxClient for IP6RecvStruct<'a> {
     fn receive(&self, buf: &[u8], len: usize, result: ReturnCode) {
-        // TODO: Drop here?
+        // TODO: Drop here? Any additional sanity checking?
         if len > buf.len() || result != ReturnCode::SUCCESS {
             return;
         }
         match IP6Header::decode(buf).done() {
-            Some((offset, header)) => {
-                // TODO: Probably do some sanity checking, check for checksum
-                // correctness, length, etc.
+            Some((offset, ip6_header)) => {
+                let checksum_result = ip6_header.check_transport_checksum(&buf[offset..len]);
+                if checksum_result == ReturnCode::FAIL {
+                    debug!("dropped!: {:?}", checksum_result);
+                    return; //Dropped.
+                }
+                // Note: Protocols for which checksum verification is not implemented (TCP, etc.)
+                // are automatically assumed as fine, rather than dropped
+
                 self.client
-                    .map(|client| client.receive(header, &buf[offset..len]));
+                    .map(|client| client.receive(ip6_header, &buf[offset..len]));
             }
             None => {
                 // TODO: Report the error somewhere...

--- a/capsules/src/net/ipv6/ipv6_recv.rs
+++ b/capsules/src/net/ipv6/ipv6_recv.rs
@@ -2,8 +2,6 @@ use kernel::common::cells::OptionalCell;
 use kernel::ReturnCode;
 use net::ipv6::ipv6::IP6Header;
 use net::sixlowpan::sixlowpan_state::SixlowpanRxClient;
-use net::udp::udp::UDPHeader;
-use net::ipv6::ip_utils::compute_udp_checksum;
 
 // To provide some context for the entire rx chain:
 /*
@@ -62,7 +60,7 @@ impl<'a> IP6RecvStruct<'a> {
 
 impl<'a> SixlowpanRxClient for IP6RecvStruct<'a> {
     fn receive(&self, buf: &[u8], len: usize, result: ReturnCode) {
-        // TODO: Drop here? Any additional sanity checking?
+        // TODO: Drop here?
         if len > buf.len() || result != ReturnCode::SUCCESS {
             return;
         }

--- a/capsules/src/net/ipv6/ipv6_send.rs
+++ b/capsules/src/net/ipv6/ipv6_send.rs
@@ -180,7 +180,8 @@ impl IP6SendStruct<'a> {
         // being called again by another app before ip6_packet is replaced.
         // To fix this, we pass a bool out of the closure to indicate whether send_completed()
         // should be called once the closure exits
-        let (ret, call_send_complete) = self.ip6_packet
+        let (ret, call_send_complete) = self
+            .ip6_packet
             .map(move |ip6_packet| match self.tx_buf.take() {
                 Some(tx_buf) => {
                     let mut send = false;

--- a/capsules/src/net/ipv6/ipv6_send.rs
+++ b/capsules/src/net/ipv6/ipv6_send.rs
@@ -163,11 +163,19 @@ impl IP6SendStruct<'a> {
 
     // Returns EBUSY if the tx_buf is not there
     fn send_next_fragment(&self) -> ReturnCode {
+        // Below code adds delay between fragments. Despite some efforts
+        // to fix this bug, I find that without it the receiving imix cannot
+        // receive more than 2 fragments in a single packet without hanging
+        // waiting for the third fragments.
+        let mut x = 0;
+        for i in 0..100000 {
+            x = x + i;
+        }
+        debug!("{}", x);
         self.ip6_packet
             .map(move |ip6_packet| match self.tx_buf.take() {
                 Some(tx_buf) => {
                     let next_frame = self.sixlowpan.next_fragment(ip6_packet, tx_buf, self.radio);
-
                     match next_frame {
                         Ok((is_done, frame)) => {
                             if is_done {

--- a/capsules/src/net/ipv6/ipv6_send.rs
+++ b/capsules/src/net/ipv6/ipv6_send.rs
@@ -196,7 +196,7 @@ impl IP6SendStruct<'a> {
 impl TxClient for IP6SendStruct<'a> {
     fn send_done(&self, tx_buf: &'static mut [u8], acked: bool, result: ReturnCode) {
         self.tx_buf.replace(tx_buf);
-        debug!("sendDone return code is: {:?}, acked: {}", result, acked);
+        debug!("Send result: {:?}, acked: {}", result, acked);
         let result = self.send_next_fragment();
         if result != ReturnCode::SUCCESS {
             self.send_completed(result);

--- a/capsules/src/net/ipv6/ipv6_send.rs
+++ b/capsules/src/net/ipv6/ipv6_send.rs
@@ -126,7 +126,6 @@ impl IP6Sender<'a> for IP6SendStruct<'a> {
         );
         self.init_packet(dst, transport_header, payload);
         let ret = self.send_next_fragment();
-        debug!("Done sending the next fragment");
         ret
     }
 }
@@ -155,7 +154,6 @@ impl IP6SendStruct<'a> {
 
     fn init_packet(&self, dst_addr: IPAddr, transport_header: TransportHeader, payload: &[u8]) {
         self.ip6_packet.map(|ip6_packet| {
-            debug!("Mapping ip6_packet success");
             ip6_packet.header = IP6Header::default();
             ip6_packet.header.src_addr = self.src_addr.get();
             ip6_packet.header.dst_addr = dst_addr;
@@ -175,7 +173,6 @@ impl IP6SendStruct<'a> {
             x = x + i;
         }
         debug!("{}", x);
-        debug!("Before sending, ip6Packetisnone: {:?}", self.ip6_packet.is_none());
         // Originally send_complete() was called within the below closure.
         // However, this led to a race condition where when multiple apps transmitted
         // simultaneously, it was possible for send_complete to trigger another
@@ -212,11 +209,9 @@ impl IP6SendStruct<'a> {
                 None => (ReturnCode::EBUSY, false),
             }).unwrap_or((ReturnCode::ENOMEM, false));
         if call_send_complete {
-            debug!("Calling send_complete!");
             self.send_completed(ret);
             return ReturnCode::SUCCESS;
         }
-        debug!("After sending, ip6Packetisnone: {:?}", self.ip6_packet.is_none());
         ret
     }
 

--- a/capsules/src/net/ipv6/ipv6_send.rs
+++ b/capsules/src/net/ipv6/ipv6_send.rs
@@ -19,8 +19,8 @@
 use core::cell::Cell;
 use ieee802154::device::{MacDevice, TxClient};
 use kernel::common::cells::{OptionalCell, TakeCell};
-use kernel::ReturnCode;
 use kernel::hil::time::{self, Frequency};
+use kernel::ReturnCode;
 use net::ieee802154::MacAddress;
 use net::ipv6::ip_utils::IPAddr;
 use net::ipv6::ipv6::{IP6Header, IP6Packet, TransportHeader};
@@ -86,8 +86,8 @@ pub struct IP6SendStruct<'a, A: time::Alarm> {
     // We want the ip6_packet field to be a TakeCell so that it is easy to mutate
     ip6_packet: TakeCell<'static, IP6Packet<'static>>,
     alarm: &'a A, // Alarm so we can introduce a small delay between fragments to ensure
-                  // successful reception on receivers with slow copies out of the radio buffer
-                  // (imix)
+    // successful reception on receivers with slow copies out of the radio buffer
+    // (imix)
     src_addr: Cell<IPAddr>,
     gateway: Cell<MacAddress>,
     tx_buf: TakeCell<'static, [u8]>,

--- a/capsules/src/net/sixlowpan/sixlowpan_compression.rs
+++ b/capsules/src/net/sixlowpan/sixlowpan_compression.rs
@@ -3,7 +3,7 @@
 use core::mem;
 use core::result::Result;
 use net::ieee802154::MacAddress;
-use net::ipv6::ip_utils::{ip6_nh, IPAddr};
+use net::ipv6::ip_utils::{ip6_nh, IPAddr, compute_udp_checksum};
 use net::ipv6::ipv6::{IP6Header, IP6Packet, TransportHeader};
 use net::udp::udp::UDPHeader;
 use net::util;
@@ -80,6 +80,7 @@ mod nhc {
     pub const UDP_CHECKSUM_FLAG: u8 = 0b100;
     pub const UDP_SRC_PORT_FLAG: u8 = 0b010;
     pub const UDP_DST_PORT_FLAG: u8 = 0b001;
+    pub const UDP_PORTS_SIZE: u16 = 4;
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -155,87 +156,6 @@ pub fn is_lowpan(packet: &[u8]) -> bool {
     (packet[0] & iphc::DISPATCH[0]) == iphc::DISPATCH[0]
 }
 
-trait OnesComplement {
-    fn ones_complement_add(self, other: Self) -> Self;
-}
-
-/// Implements one's complement addition for use in calculating the UDP checksum
-impl OnesComplement for u16 {
-    fn ones_complement_add(self, other: u16) -> u16 {
-        let (sum, overflow) = self.overflowing_add(other);
-        if overflow {
-            sum + 1
-        } else {
-            sum
-        }
-    }
-}
-
-/// Computes the UDP checksum for a UDP packet sent over IPv6.
-/// Returns the checksum in host byte-order.
-//TODO: Replace use of this function with use of the function found in ip_utils
-// that operates on the new packet format rather than the received buffer
-// Alternatively, dont support checksum elision bc of security concerns
-fn compute_udp_checksum(
-    ip6_header: &IP6Header,
-    udp_header: &[u8],
-    udp_length: u16,
-    payload: &[u8],
-) -> u16 {
-    // The UDP checksum is computed on the IPv6 pseudo-header concatenated
-    // with the UDP header and payload, but with the UDP checksum field
-    // zeroed out. Hence, this function assumes that `udp_header` has already
-    // been filled with the UDP header, except for the ignored checksum.
-    let mut checksum: u16 = 0;
-
-    // IPv6 pseudo-header
-    // +--16 bits--+--16 bits--+--16 bits--+--16 bits--+
-    // |                                               |
-    // +              Source IPv6 Address              +
-    // |                                               |
-    // +-----------+-----------+-----------+-----------+
-    // |                                               |
-    // +           Destination IPv6 Address            +
-    // |                                               |
-    // +-----------+-----------+-----------+-----------+
-    // |      UDP Length       |     0     |  NH type  |
-    // +-----------+-----------+-----------+-----------+
-
-    // Source and destination addresses
-    for two_bytes in ip6_header.src_addr.0.chunks(2) {
-        checksum = checksum.ones_complement_add(slice_to_u16(two_bytes));
-    }
-    for two_bytes in ip6_header.dst_addr.0.chunks(2) {
-        checksum = checksum.ones_complement_add(slice_to_u16(two_bytes));
-    }
-
-    // UDP length and UDP next header type. Note that we can avoid adding zeros,
-    // but the pseudo header must be in network byte-order.
-    checksum = checksum.ones_complement_add(udp_length.to_be());
-    checksum = checksum.ones_complement_add((ip6_nh::UDP as u16).to_be());
-
-    // UDP header without the checksum (which is the last two bytes)
-    for two_bytes in udp_header[0..6].chunks(2) {
-        checksum = checksum.ones_complement_add(slice_to_u16(two_bytes));
-    }
-
-    // UDP payload
-    for bytes in payload.chunks(2) {
-        checksum = checksum.ones_complement_add(if bytes.len() == 2 {
-            slice_to_u16(bytes)
-        } else {
-            (bytes[0] as u16).to_be()
-        });
-    }
-
-    // Return the complement of the checksum, unless it is 0, in which case we
-    // the checksum is one's complement -0 for a non-zero binary representation
-    if !checksum != 0 {
-        !checksum
-    } else {
-        checksum
-    }
-}
 
 /// Maps a LoWPAN_NHC header the corresponding IPv6 next header type,
 /// or an error if the NHC header is invalid
@@ -775,14 +695,30 @@ pub fn decompress(
             ip6_nh::UDP => {
                 // UDP length includes UDP header and data in bytes
                 // Below line works bc udp nh must be last nh per 6282
-                let udp_length = if is_fragment {
+                let mut udp_length = if is_fragment {
                     dgram_size - written as u16
                 } else {
-                    buf.len() as u16 - written as u16
+                    buf.len() as u16 - consumed as u16
                 };
 
                 // Decompress UDP header fields
+                let consumed_before_port_decompress = consumed;
                 let (src_port, dst_port) = decompress_udp_ports(nhc_header, &buf, &mut consumed);
+
+                //need to add any growth from decompression to the udp length if we used the buf
+                //len to calculate the length
+                if !is_fragment {
+                    // Expansion from port compression
+                    udp_length += nhc::UDP_PORTS_SIZE - ((consumed - consumed_before_port_decompress) as u16);
+                    // Expansion from length elision (always applied per RFC 6282, length is 2
+                    // bytes)
+                    udp_length += 2;
+                    // UDP checksum elision
+                    if (nhc_header & nhc::UDP_CHECKSUM_FLAG) != 0 {
+                        udp_length += 2;
+                    }
+                }
+
                 // Fill in uncompressed UDP header
                 // TODO: The current implementation works, but I don't understand the calls to
                 // to_be(), because src_port.to_be() returns the src_port in little endian..
@@ -1226,10 +1162,17 @@ fn decompress_udp_checksum(
     consumed: &mut usize,
 ) -> u16 {
     // TODO: In keeping with Postel's Law, we accept UDP packets that elide the
-    // checksum. We are not sure if we should continue to support this feature
-    // however.
+    // checksum (per RFC 6282). We are not sure if we should continue to support
+    // this feature however.
     if (udp_nhc & nhc::UDP_CHECKSUM_FLAG) != 0 {
-        compute_udp_checksum(ip6_header, udp_header, udp_length, &buf[*consumed..])
+        let mut udp_header_copy: [u8; 8] = [0, 0, 0, 0, 0, 0, 0, 0];
+        udp_header_copy.copy_from_slice(udp_header);
+        match UDPHeader::decode(&udp_header_copy).done() {
+            Some((_offset, hdr)) => {
+                u16::from_be(compute_udp_checksum(ip6_header, &hdr, udp_length, &buf[*consumed..]))
+            }
+            None => 0 //Will be dropped  by IP layer
+        }
     } else {
         let checksum = u16::from_be(slice_to_u16(&buf[*consumed..*consumed + 2]));
         *consumed += 2;

--- a/capsules/src/net/udp/driver.rs
+++ b/capsules/src/net/udp/driver.rs
@@ -484,7 +484,7 @@ impl<'a> Driver for UDPDriver<'a> {
                     app.pending_tx = next_tx;
                     self.do_next_tx_immediate(appid)
                 })
-            },
+            }
             3 => {
                 self.do_with_app(appid, |app| {
                     // Move UDPEndpoint into udp.rs?
@@ -546,7 +546,7 @@ impl<'a> Driver for UDPDriver<'a> {
                         return ReturnCode::EINVAL;
                     }
                 })
-            },
+            }
             4 => ReturnCode::SuccessWithValue {
                 value: self.max_tx_pyld_len,
             },

--- a/capsules/src/net/udp/udp.rs
+++ b/capsules/src/net/udp/udp.rs
@@ -107,7 +107,6 @@ impl UDPHeader {
     /// # Return Value
     ///
     /// This function returns a `UDPHeader` struct wrapped in an SResult
-    // TODO: Decode has not been tested
     pub fn decode(buf: &[u8]) -> SResult<UDPHeader> {
         stream_len_cond!(buf, 8);
         let mut udp_header = Self::new();

--- a/doc/syscalls/30002_udp.md
+++ b/doc/syscalls/30002_udp.md
@@ -112,7 +112,7 @@ the driver.
 
     **Argument 3**: Unused
 
-    **Returns**: SUCCESS (TODO: return ENODEVICE if driver doesn't exist)
+    **Returns**: SUCCESS
 
   * ### Command Number: 1
 
@@ -146,3 +146,22 @@ the driver.
                  is returned with value 1, this means the the packet was successfully passed
                  the radio without any errors, which tells the userland application that it can
                  immediately queue another packet without having to wait for a callback.
+
+  * ### Command Number: 3
+
+    **Description**: Bind to the address and port in rx_cfg.
+                     This command should be called after allow() is called on the rx_cfg buffer, and
+                     after subscribe() is used to set up the recv callback. If this command is called
+                     and the address in rx_cfg is 0::0 : 0, this command will reset the option
+                     containing the bound port to None, and set the rx callback to None.
+
+    **Argument 1**: Unused
+
+    **Argument 2**: Unused
+
+    **Argument 3**: AppId
+
+    **Returns**: Returns SUCCESS if that addr/port combo is free,
+                 returns EINVAL if the address requested is not a local interface, or if the port
+                 requested is 0. Returns EBUSY if that port is already bound to by another app.
+

--- a/doc/syscalls/30002_udp.md
+++ b/doc/syscalls/30002_udp.md
@@ -79,13 +79,14 @@ the driver.
 
   * ### Subscribe Number: 0
 
-    **Description**: Setup callback for when frame is received.
+    **Description**: Setup callback for when frame is received. This callback cannot be set unless
+                     the app is bound to a local UDP endpoint.
 
     **Argument 1**: The callback
 
     **Argument 2**: AppId
 
-    **Returns**: SUCCESS
+    **Returns**: ERESERVE if the app is not currently bound to a port, SUCCESS otherwise.
 
   * ### Subscribe Number: 1
 
@@ -139,13 +140,25 @@ the driver.
     **Returns**: EBUSY is this process already has a pending tx.
                  Returns EINVAL if no valid buffer has been loaded into the write buffer,
                  or if the config buffer is the wrong length, or if the destination and source
-                 oirt/address pairs cannot be parsed.
-                 Otherwise, returns the result of do_next_tx_sync(). Notably, a successful
+                 port/address pairs cannot be parsed.
+                 Otherwise, returns the result of do_next_tx_immediate(). Notably, a successful
                  transmit can produce two different success values. If success is returned,
-                 this simply means that the packet was queued. However, if SuccessWithValue
+                 this simply means that the packet was queued. In this case, the app still
+                 still needs to wait for a callback to check if any errors occurred before
+                 the packet was passed to the radio. However, if SuccessWithValue
                  is returned with value 1, this means the the packet was successfully passed
-                 the radio without any errors, which tells the userland application that it can
-                 immediately queue another packet without having to wait for a callback.
+                 the radio without any errors, which tells the userland application that it does
+                 not need to wait for a callback to check if any errors occured while the packet
+                 was being passed down to the radio. Any successful return value indicates that
+                 the app should wait for a send_done() callback before attempting to queue another
+                 packet.
+                 Currently, only will transmit if the app has bound to the port passed in the tx_cfg
+                 buf as the source address. If no port is bound, returns ERESERVE, if it tries to
+                 send on a port other than the port which is bound, returns EINVALID.
+
+                 Notably, the currently transmit implementation allows for starvation - an
+                 an app with a lower app id can send constantly and starve an app with a
+                 later ID.
 
   * ### Command Number: 3
 
@@ -164,4 +177,18 @@ the driver.
     **Returns**: Returns SUCCESS if that addr/port combo is free,
                  returns EINVAL if the address requested is not a local interface, or if the port
                  requested is 0. Returns EBUSY if that port is already bound to by another app.
+
+  * ### Command Number: 4
+
+    **Description**: Returns the maximum payload that can be transmitted by apps using this driver.
+                     This represents the size of the payload buffer in the kernel. Apps can use
+                     this syscall to ensure they do not attempt to send too-large messages.
+
+    **Argument 1**: Unused
+
+    **Argument 2**: Unused
+
+    **Argument 3**: AppId
+
+    **Returns**: Returns SUCCESSWithValue, where the value is the maximum tx payload length
 

--- a/kernel/src/debug.rs
+++ b/kernel/src/debug.rs
@@ -222,7 +222,7 @@ pub struct DebugWriter {
 /// needed so the debug!() macros have a reference to the object to use.
 static mut DEBUG_WRITER: Option<&'static mut DebugWriterWrapper> = None;
 
-pub static mut OUTPUT_BUF: [u8; 1024] = [0; 1024];
+pub static mut OUTPUT_BUF: [u8; 64] = [0; 64];
 pub static mut INTERNAL_BUF: [u8; 1024] = [0; 1024];
 
 pub unsafe fn get_debug_writer() -> &'static mut DebugWriterWrapper {

--- a/kernel/src/debug.rs
+++ b/kernel/src/debug.rs
@@ -222,7 +222,7 @@ pub struct DebugWriter {
 /// needed so the debug!() macros have a reference to the object to use.
 static mut DEBUG_WRITER: Option<&'static mut DebugWriterWrapper> = None;
 
-pub static mut OUTPUT_BUF: [u8; 64] = [0; 64];
+pub static mut OUTPUT_BUF: [u8; 1024] = [0; 1024];
 pub static mut INTERNAL_BUF: [u8; 1024] = [0; 1024];
 
 pub unsafe fn get_debug_writer() -> &'static mut DebugWriterWrapper {


### PR DESCRIPTION
### Pull Request Overview

This pull request adds FCFS port binding to Tock. It allows for userland apps to bind to ports on which they are receiving, giving that app exclusive access to receive on that port. Notably, this port binding is for userland apps only -- kernel apps can still bind to any port, regardless of if a userland port has bound to that port. Currently, binding applies to bothe send and receive -- apps can only send or receive on a single port at a time, and they must be bound to a port to send from or receive on that port. The design of the systemcall interface is such that transmission without binding could be allowed if the underlying implementation were changed.

This PR also adds functionality to the driver to allow for apps to close bound ports, adds a driver call for apps to detect the longest message they can send for the current kernel config of the stack, and refactors some of the driver code. 

Finally, this PR adds back in the manual for i in 0..100000 delay between sending fragments, as despite this being "fixed" in the past I have found that it is still an issue for imixes receiving packets 3 fragments or longer.

In order to use or test this PR, the code must be run alongside the port binding PR in libtock-c that I am posting alongside this one.

### Testing Strategy

I tested this PR by flashing multiple UDP rcv apps onto an Imix and testing that when one app binds to a port, the other cannot. I also tested that two apps can still bind to two different ports. 

Additionally, I tested that the driver call for checking the max possible UDP packet works.

I also tested that the driver works fine for sending packets longer than a single frame. This works now, though it did not before this PR.

I flashed multiple IP send apps onto a single device and tested sending from multiple ports on one device to multiple ports on another device, this works even when the apps attempt to send near simultaneously.

I also tested most of the error handling code by simulating situations such as attempting to send or receive without binding, attempting asynchronous sends, attempting to bind to non-local addresses etc.

### Documentation Updated

- [x] Updated the syscalls documentation in docs/syscalls, and updated comments in driver.rs to better reflect how to use the driver.

### Formatting

- [x] Ran `make formatall`.
