### PR TITLE
CC26x2 read hard_fault_handler

### DIFF
--- a/chips/cc26x2/src/crt1.rs
+++ b/chips/cc26x2/src/crt1.rs
@@ -1,4 +1,4 @@
-use cortexm4::{generic_isr, nvic, svc_handler, systick_handler};
+use cortexm4::{generic_isr, hard_fault_handler, nvic, svc_handler, systick_handler};
 
 extern "C" {
     // Symbols defined in the linker file
@@ -15,10 +15,6 @@ extern "C" {
 }
 
 unsafe extern "C" fn unhandled_interrupt() {
-    'loop0: loop {}
-}
-
-unsafe extern "C" fn hard_fault_handler() {
     'loop0: loop {}
 }
 


### PR DESCRIPTION
### Pull Request Overview

Use the `cortexm4` crate's hard_fault_handler in CC26x2 instead of the dummy custom one.


### Testing Strategy

Generating a hard fault on the cc26x2, which is, unfortunately, very easy.


### TODO or Help Wanted

N/A


### Documentation Updated

- [X] ~~Updated the relevant files in `/docs`, or no updates are required.~~

### Formatting

- [X] Ran `make formatall`.
