### PR TITLE
Add utility for inspecting process state

### DIFF
--- a/boards/hail/Cargo.lock
+++ b/boards/hail/Cargo.lock
@@ -35,7 +35,7 @@ name = "kernel"
 version = "0.1.0"
 dependencies = [
  "tock-cells 0.1.0",
- "tock-registers 0.1.0",
+ "tock-registers 0.2.0",
 ]
 
 [[package]]
@@ -52,5 +52,5 @@ version = "0.1.0"
 
 [[package]]
 name = "tock-registers"
-version = "0.1.0"
+version = "0.2.0"
 

--- a/kernel/Cargo.lock
+++ b/kernel/Cargo.lock
@@ -3,7 +3,7 @@ name = "kernel"
 version = "0.1.0"
 dependencies = [
  "tock-cells 0.1.0",
- "tock-registers 0.1.0",
+ "tock-registers 0.2.0",
 ]
 
 [[package]]
@@ -12,5 +12,5 @@ version = "0.1.0"
 
 [[package]]
 name = "tock-registers"
-version = "0.1.0"
+version = "0.2.0"
 

--- a/kernel/src/introspection.rs
+++ b/kernel/src/introspection.rs
@@ -1,0 +1,124 @@
+//! Mechanism for inspecting the status of the kernel.
+//!
+//! In particular this provides functions for getting the status of processes
+//! on the board. It potentially could be expanded to other kernel state.
+//!
+//! To restrict access on what can use this module, even though it is public (in
+//! a Rust sense) so it is visible outside of this crate, the introspection
+//! functions require the caller have the correct capability to call the
+//! functions. This prevents arbitrary capsules from being able to use this
+//! module, and only capsules that the board author has explicitly passed the
+//! correct capabilities to can use it.
+
+use core::cell::Cell;
+
+use callback::AppId;
+use capabilities::ProcessManagementCapability;
+use common::cells::NumericCellExt;
+use process;
+use sched::Kernel;
+
+/// This struct provides the introspection functions.
+pub struct Introspection {
+    kernel: &'static Kernel,
+}
+
+impl Introspection {
+    pub fn new(kernel: &'static Kernel) -> Introspection {
+        Introspection { kernel: kernel }
+    }
+
+    /// Returns how many processes have been loaded on this platform. This is
+    /// functionally equivalent to how many of the process slots have been used
+    /// on the board. This does not consider what state the process is in, as
+    /// long as it has been loaded.
+    pub fn number_loaded_processes(&self, _capability: &ProcessManagementCapability) -> usize {
+        let count: Cell<usize> = Cell::new(0);
+        self.kernel.process_each_enumerate(|_, _| count.increment());
+        count.get()
+    }
+
+    /// Returns how many processes are considered to be active. This includes
+    /// processes in the `Running` and `Yield` states. This does not include
+    /// processes which have faulted, or processes which the kernel is no longer
+    /// scheduling because they have faulted too frequently or for some other
+    /// reason.
+    pub fn number_active_processes(&self, _capability: &ProcessManagementCapability) -> usize {
+        let count: Cell<usize> = Cell::new(0);
+        self.kernel
+            .process_each_enumerate(|_, process| match process.get_state() {
+                process::State::Running => count.increment(),
+                process::State::Yielded => count.increment(),
+                process::State::Fault => {}
+            });
+        count.get()
+    }
+
+    /// Returns how many processes are considered to be inactive. This includes
+    /// processes in the `Fault` state and processes which the kernel is not
+    /// scheduling for any reason.
+    pub fn number_inactive_processes(&self, _capability: &ProcessManagementCapability) -> usize {
+        let count: Cell<usize> = Cell::new(0);
+        self.kernel
+            .process_each_enumerate(|_, process| match process.get_state() {
+                process::State::Running => {}
+                process::State::Yielded => {}
+                process::State::Fault => count.increment(),
+            });
+        count.get()
+    }
+
+    /// Get the name of the process.
+    pub fn process_name(
+        &self,
+        app: AppId,
+        _capability: &ProcessManagementCapability,
+    ) -> &'static str {
+        self.kernel
+            .process_map_or("", app.idx(), |process| process.get_process_name())
+    }
+
+    /// Returns the number of syscalls the app has called.
+    pub fn number_app_syscalls(
+        &self,
+        app: AppId,
+        _capability: &ProcessManagementCapability,
+    ) -> usize {
+        self.kernel
+            .process_map_or(0, app.idx(), |process| process.debug_syscall_count())
+    }
+
+    /// Returns the number of dropped callbacks the app has experience.
+    /// Callbacks can be dropped if the queue for the app is full when a capsule
+    /// tries to schedule a callback.
+    pub fn number_app_dropped_callbacks(
+        &self,
+        app: AppId,
+        _capability: &ProcessManagementCapability,
+    ) -> usize {
+        self.kernel.process_map_or(0, app.idx(), |process| {
+            process.debug_dropped_callback_count()
+        })
+    }
+
+    /// Returns the number of time this app has been restarted.
+    pub fn number_app_restarts(
+        &self,
+        app: AppId,
+        _capability: &ProcessManagementCapability,
+    ) -> usize {
+        self.kernel
+            .process_map_or(0, app.idx(), |process| process.debug_restart_count())
+    }
+
+    /// Returns the number of time this app has exceeded its timeslice.
+    pub fn number_app_timeslice_expirations(
+        &self,
+        app: AppId,
+        _capability: &ProcessManagementCapability,
+    ) -> usize {
+        self.kernel.process_map_or(0, app.idx(), |process| {
+            process.debug_timeslice_expiration_count()
+        })
+    }
+}

--- a/kernel/src/ipc.rs
+++ b/kernel/src/ipc.rs
@@ -182,7 +182,7 @@ impl Driver for IPC {
             match slice {
                 Some(slice_data) => {
                     let ret = self.data.kernel.process_each_enumerate_stop(|i, p| {
-                        let s = p.get_process_name();
+                        let s = p.get_process_name().as_bytes();
                         // are slices equal?
                         if s.len() == slice_data.len()
                             && s.iter().zip(slice_data.iter()).all(|(c1, c2)| c1 == c2)

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -24,6 +24,7 @@ pub mod component;
 #[macro_use]
 pub mod debug;
 pub mod hil;
+pub mod introspection;
 pub mod ipc;
 pub mod syscall;
 

--- a/kernel/src/syscall.rs
+++ b/kernel/src/syscall.rs
@@ -50,6 +50,7 @@ pub enum Syscall {
 }
 
 /// Why the process stopped executing and execution returned to the kernel.
+#[derive(PartialEq)]
 pub enum ContextSwitchReason {
     /// Process called a syscall.
     SyscallFired,


### PR DESCRIPTION
### Pull Request Overview

This pull request adds a new introspection module in the kernel that provides functions that can allow a capsule to see key stats about the processes on the board.

This is likely still a work in progress, but we need it for the sensys demo so I at least wanted to get it in front of people.


### Testing Strategy

I have only compiled this code.


### TODO or Help Wanted

I think this is a start, but changes are likely necessary.


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
