### PR TITLE
debugging: add status print capsule

### DIFF
--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -539,6 +539,30 @@ pub unsafe fn reset_handler() {
     // );
     // sam4l::gpio::PA[16].set_client(debug_process_restart);
 
+    // // DEBUG Display Status of All Apps
+    // struct ProcessMgmtCap;
+    // unsafe impl capabilities::ProcessManagementCapability for ProcessMgmtCap {}
+    // let debug_process_status_virtual_alarm = static_init!(
+    //     VirtualMuxAlarm<'static, sam4l::ast::Ast>,
+    //     VirtualMuxAlarm::new(mux_alarm)
+    // );
+    // let introspection = static_init!(
+    //     kernel::introspection::Introspection,
+    //     kernel::introspection::Introspection::new(board_kernel)
+    // );
+    // let debug_process_status = static_init!(
+    //     capsules::debug_process_status::DebugProcessStatus<
+    //         'static,
+    //         VirtualMuxAlarm<'static, sam4l::ast::Ast>,
+    //     >,
+    //     capsules::debug_process_status::DebugProcessStatus::new(
+    //         debug_process_status_virtual_alarm,
+    //         introspection,
+    //         &ProcessMgmtCap
+    //     )
+    // );
+    // debug_process_status_virtual_alarm.set_client(debug_process_status);
+
     let hail = Hail {
         console: console,
         gpio: gpio,
@@ -582,6 +606,8 @@ pub unsafe fn reset_handler() {
     // Reset the nRF and setup the UART bus.
     hail.nrf51822.reset();
     hail.nrf51822.initialize();
+
+    // debug_process_status.start(2000);
 
     // Uncomment to measure overheads for TakeCell and MapCell:
     // test_take_map_cell::test_take_map_cell();

--- a/capsules/README.md
+++ b/capsules/README.md
@@ -133,3 +133,5 @@ various elements of Tock.
 
 - **[Debug Process Restart](src/debug_process_restart.rs)**: Force all processes
   to enter a fault state when a button is pressed.
+- **[Debug Process Status](src/debug_process_status.rs)**: Print status information
+  about each app to the console periodically.

--- a/capsules/src/debug_process_status.rs
+++ b/capsules/src/debug_process_status.rs
@@ -1,0 +1,113 @@
+//! Periodic process status display.
+//!
+//! This capsule periodically prints the status of all of the apps on the board.
+//!
+//! Usage
+//! -----
+//!
+//! ```
+//! struct ProcessMgmtCap;
+//! unsafe impl capabilities::ProcessManagementCapability for ProcessMgmtCap {}
+//! let debug_process_status_virtual_alarm = static_init!(
+//!     VirtualMuxAlarm<'static, sam4l::ast::Ast>,
+//!     VirtualMuxAlarm::new(mux_alarm)
+//! );
+//! let introspection = static_init!(
+//!     kernel::introspection::Introspection,
+//!     kernel::introspection::Introspection::new(board_kernel)
+//! );
+//! let debug_process_status = static_init!(
+//!     capsules::debug_process_status::DebugProcessStatus<
+//!         'static,
+//!         VirtualMuxAlarm<'static, sam4l::ast::Ast>,
+//!     >,
+//!     capsules::debug_process_status::DebugProcessStatus::new(
+//!         debug_process_status_virtual_alarm,
+//!         introspection,
+//!         &ProcessMgmtCap
+//!     )
+//! );
+//! debug_process_status_virtual_alarm.set_client(debug_process_status);
+//! ```
+
+use kernel::capabilities::ProcessManagementCapability;
+use kernel::common::cells::OptionalCell;
+use kernel::hil;
+use kernel::hil::time::Frequency;
+use kernel::introspection::Introspection;
+
+pub struct DebugProcessStatus<'a, A: hil::time::Alarm + 'a> {
+    alarm: &'a A,
+    inspector: &'a Introspection,
+    interval: OptionalCell<u32>,
+    capability: &'a ProcessManagementCapability,
+}
+
+impl<'a, A: hil::time::Alarm + 'a> DebugProcessStatus<'a, A> {
+    pub fn new(
+        alarm: &'a A,
+        inspector: &'a Introspection,
+        cap: &'a ProcessManagementCapability,
+    ) -> DebugProcessStatus<'a, A> {
+        DebugProcessStatus {
+            alarm: alarm,
+            inspector: inspector,
+            interval: OptionalCell::empty(),
+            capability: cap,
+        }
+    }
+
+    /// Enable the debugging display and have it start printing the status of
+    /// each process.
+    pub fn start(&self, interval_ms: usize) {
+        let interval = (interval_ms as u32) * <A::Frequency>::frequency() / 1000;
+        self.interval.set(interval);
+        let tics = self.alarm.now().wrapping_add(interval);
+        self.alarm.set_alarm(tics);
+    }
+
+    /// Stop the periodic debugging display.
+    pub fn stop(&self) {
+        self.interval.clear();
+    }
+}
+
+impl<'a, A: hil::time::Alarm + 'a> hil::time::Client for DebugProcessStatus<'a, A> {
+    fn fired(&self) {
+        debug!("##### APP INFORMATION #####");
+
+        let process_count = self.inspector.number_loaded_processes(self.capability);
+        debug!("  Number of processes: {}\n", process_count);
+
+        self.inspector.each_app(|appid| {
+            debug!(
+                "  app: {}",
+                self.inspector.process_name(appid, self.capability)
+            );
+            debug!(
+                "    # syscalls:              {}",
+                self.inspector.number_app_syscalls(appid, self.capability)
+            );
+            debug!(
+                "    # dropped callbacks:     {}",
+                self.inspector
+                    .number_app_dropped_callbacks(appid, self.capability)
+            );
+            debug!(
+                "    # restarts:              {}",
+                self.inspector.number_app_restarts(appid, self.capability)
+            );
+            debug!(
+                "    # timeslice expirations: {}\n",
+                self.inspector
+                    .number_app_timeslice_expirations(appid, self.capability)
+            );
+        });
+
+        // Restart the timer unless `stop()` was called.
+        self.interval.map(|interval| {
+            let tics = self.alarm.now().wrapping_add(*interval);
+            self.alarm.set_alarm(tics);
+        });
+    }
+}

--- a/capsules/src/lib.rs
+++ b/capsules/src/lib.rs
@@ -25,6 +25,7 @@ pub mod console;
 pub mod crc;
 pub mod dac;
 pub mod debug_process_restart;
+pub mod debug_process_status;
 pub mod fm25cl;
 pub mod fxos8700cq;
 pub mod gpio;

--- a/kernel/src/introspection.rs
+++ b/kernel/src/introspection.rs
@@ -28,6 +28,17 @@ impl Introspection {
         Introspection { kernel: kernel }
     }
 
+    /// Call a callback with the `AppId` of each app on the board.
+    pub fn each_app<F>(&self, fun: F)
+    where
+        F: Fn(AppId),
+    {
+        self.kernel.process_each_enumerate(|app_id, _| {
+            let appid = AppId::new(self.kernel, app_id);
+            fun(appid);
+        });
+    }
+
     /// Returns how many processes have been loaded on this platform. This is
     /// functionally equivalent to how many of the process slots have been used
     /// on the board. This does not consider what state the process is in, as


### PR DESCRIPTION
### Pull Request Overview

This pull request adds a capsule that uses the introspection tool to print the status of each application on the board periodically. It is only for debugging/testing, but provides a simple test use of the introspection tool.

Needs #1168.


### Testing Strategy

This pull request was tested by running with several apps on Hail.


### TODO or Help Wanted

Feel free to add commits if inspiration strikes.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
