### PR TITLE
.elf outputs and line returns

### DIFF
--- a/arch/cortex-m4/src/lib.rs
+++ b/arch/cortex-m4/src/lib.rs
@@ -253,43 +253,43 @@ pub unsafe extern "C" fn hard_fault_handler() {
         let exception_number = (stacked_xpsr & 0x1ff) as usize;
 
         panic!(
-            "{} HardFault.\n\
-             \tKernel version {}\n\
-             \tr0  0x{:x}\n\
-             \tr1  0x{:x}\n\
-             \tr2  0x{:x}\n\
-             \tr3  0x{:x}\n\
-             \tr12 0x{:x}\n\
-             \tlr  0x{:x}\n\
-             \tpc  0x{:x}\n\
-             \tprs 0x{:x} [ N {} Z {} C {} V {} Q {} GE {}{}{}{} ; ICI.IT {} T {} ; Exc {}-{} ]\n\
-             \tsp  0x{:x}\n\
-             \ttop of stack     0x{:x}\n\
-             \tbottom of stack  0x{:x}\n\
-             \tSHCSR 0x{:x}\n\
-             \tCFSR  0x{:x}\n\
-             \tHSFR  0x{:x}\n\
-             \tInstruction Access Violation:       {}\n\
-             \tData Access Violation:              {}\n\
-             \tMemory Management Unstacking Fault: {}\n\
-             \tMemory Management Stacking Fault:   {}\n\
-             \tMemory Management Lazy FP Fault:    {}\n\
-             \tInstruction Bus Error:              {}\n\
-             \tPrecise Data Bus Error:             {}\n\
-             \tImprecise Data Bus Error:           {}\n\
-             \tBus Unstacking Fault:               {}\n\
-             \tBus Stacking Fault:                 {}\n\
-             \tBus Lazy FP Fault:                  {}\n\
-             \tUndefined Instruction Usage Fault:  {}\n\
-             \tInvalid State Usage Fault:          {}\n\
-             \tInvalid PC Load Usage Fault:        {}\n\
-             \tNo Coprocessor Usage Fault:         {}\n\
-             \tUnaligned Access Usage Fault:       {}\n\
-             \tDivide By Zero:                     {}\n\
-             \tBus Fault on Vector Table Read:     {}\n\
-             \tForced Hard Fault:                  {}\n\
-             \tFaulting Memory Address: (valid: {}) {:#010X}\n\
-             \tBus Fault Address:       (valid: {}) {:#010X}\n\
+            "{} HardFault.\r\n\
+             \tKernel version {}\r\n\
+             \tr0  0x{:x}\r\n\
+             \tr1  0x{:x}\r\n\
+             \tr2  0x{:x}\r\n\
+             \tr3  0x{:x}\r\n\
+             \tr12 0x{:x}\r\n\
+             \tlr  0x{:x}\r\n\
+             \tpc  0x{:x}\r\n\
+             \tprs 0x{:x} [ N {} Z {} C {} V {} Q {} GE {}{}{}{} ; ICI.IT {} T {} ; Exc {}-{} ]\r\n\
+             \tsp  0x{:x}\r\n\
+             \ttop of stack     0x{:x}\r\n\
+             \tbottom of stack  0x{:x}\r\n\
+             \tSHCSR 0x{:x}\r\n\
+             \tCFSR  0x{:x}\r\n\
+             \tHSFR  0x{:x}\r\n\
+             \tInstruction Access Violation:       {}\r\n\
+             \tData Access Violation:              {}\r\n\
+             \tMemory Management Unstacking Fault: {}\r\n\
+             \tMemory Management Stacking Fault:   {}\r\n\
+             \tMemory Management Lazy FP Fault:    {}\r\n\
+             \tInstruction Bus Error:              {}\r\n\
+             \tPrecise Data Bus Error:             {}\r\n\
+             \tImprecise Data Bus Error:           {}\r\n\
+             \tBus Unstacking Fault:               {}\r\n\
+             \tBus Stacking Fault:                 {}\r\n\
+             \tBus Lazy FP Fault:                  {}\r\n\
+             \tUndefined Instruction Usage Fault:  {}\r\n\
+             \tInvalid State Usage Fault:          {}\r\n\
+             \tInvalid PC Load Usage Fault:        {}\r\n\
+             \tNo Coprocessor Usage Fault:         {}\r\n\
+             \tUnaligned Access Usage Fault:       {}\r\n\
+             \tDivide By Zero:                     {}\r\n\
+             \tBus Fault on Vector Table Read:     {}\r\n\
+             \tForced Hard Fault:                  {}\r\n\
+             \tFaulting Memory Address: (valid: {}) {:#010X}\r\n\
+             \tBus Fault Address:       (valid: {}) {:#010X}\r\n\
              ",
             mode_str,
             env!("TOCK_KERNEL_VERSION"),

--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -106,6 +106,8 @@ ifneq ($(V),)
   $(info )
 endif
 
+.PRECIOUS: %.elf
+# Support rules
 
 # User-facing targets
 .PHONY: all

--- a/kernel/src/debug.rs
+++ b/kernel/src/debug.rs
@@ -505,7 +505,7 @@ pub fn begin_debug_fmt(args: Arguments) {
     unsafe {
         let writer = get_debug_writer();
         let _ = write(writer, args);
-        let _ = writer.write_str("\n");
+        let _ = writer.write_str("\r\n");
         writer.publish_str();
     }
 }
@@ -520,7 +520,7 @@ pub fn begin_debug_verbose_fmt(args: Arguments, file_line: &(&'static str, u32))
         let (file, line) = *file_line;
         let _ = writer.write_fmt(format_args!("TOCK_DEBUG({}): {}:{}: ", count, file, line));
         let _ = write(writer, args);
-        let _ = writer.write_str("\n");
+        let _ = writer.write_str("\r\n");
         writer.publish_str();
     }
 }


### PR DESCRIPTION
### Pull Request Overview

.elf is a good format for debuggers and if .bin was the build output, it would be removed.

Serial output was not coming out cleanly on minicom or screen without carraige return.