### PR TITLE
kernel: `Chip` does not need to be mut

### DIFF
--- a/boards/ek-tm4c1294xl/src/main.rs
+++ b/boards/ek-tm4c1294xl/src/main.rs
@@ -240,7 +240,7 @@ pub unsafe fn reset_handler() {
         button: button,
     };
 
-    let mut chip = tm4c129x::chip::Tm4c129x::new();
+    let chip = tm4c129x::chip::Tm4c129x::new();
 
     tm4c1294.console.initialize();
 
@@ -261,10 +261,5 @@ pub unsafe fn reset_handler() {
         FAULT_RESPONSE,
         &process_management_capability,
     );
-    board_kernel.kernel_loop(
-        &tm4c1294,
-        &mut chip,
-        Some(&tm4c1294.ipc),
-        &main_loop_capability,
-    );
+    board_kernel.kernel_loop(&tm4c1294, &chip, Some(&tm4c1294.ipc), &main_loop_capability);
 }

--- a/boards/hail/Cargo.lock
+++ b/boards/hail/Cargo.lock
@@ -35,7 +35,7 @@ name = "kernel"
 version = "0.1.0"
 dependencies = [
  "tock-cells 0.1.0",
- "tock-registers 0.1.0",
+ "tock-registers 0.2.0",
 ]
 
 [[package]]
@@ -52,5 +52,5 @@ version = "0.1.0"
 
 [[package]]
 name = "tock-registers"
-version = "0.1.0"
+version = "0.2.0"
 

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -217,7 +217,7 @@ pub unsafe fn reset_handler() {
         Some(&sam4l::gpio::PA[14]),
     );
 
-    let mut chip = sam4l::chip::Sam4l::new();
+    let chip = sam4l::chip::Sam4l::new();
 
     // Initialize USART0 for Uart
     sam4l::usart::USART0.set_mode(sam4l::usart::UsartMode::Uart);
@@ -597,5 +597,5 @@ pub unsafe fn reset_handler() {
         FAULT_RESPONSE,
         &process_management_capability,
     );
-    board_kernel.kernel_loop(&hail, &mut chip, Some(&hail.ipc), &main_loop_capability);
+    board_kernel.kernel_loop(&hail, &chip, Some(&hail.ipc), &main_loop_capability);
 }

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -410,7 +410,7 @@ pub unsafe fn reset_handler() {
         nonvolatile_storage: nonvolatile_storage,
     };
 
-    let mut chip = sam4l::chip::Sam4l::new();
+    let chip = sam4l::chip::Sam4l::new();
 
     // Need to reset the nRF on boot, toggle it's SWDIO
     imix.nrf51822.reset();
@@ -439,5 +439,5 @@ pub unsafe fn reset_handler() {
         &process_mgmt_cap,
     );
 
-    board_kernel.kernel_loop(&imix, &mut chip, Some(&imix.ipc), &main_cap);
+    board_kernel.kernel_loop(&imix, &chip, Some(&imix.ipc), &main_cap);
 }

--- a/boards/launchxl/Cargo.lock
+++ b/boards/launchxl/Cargo.lock
@@ -33,7 +33,7 @@ name = "kernel"
 version = "0.1.0"
 dependencies = [
  "tock-cells 0.1.0",
- "tock-registers 0.1.0",
+ "tock-registers 0.2.0",
 ]
 
 [[package]]
@@ -52,5 +52,5 @@ version = "0.1.0"
 
 [[package]]
 name = "tock-registers"
-version = "0.1.0"
+version = "0.2.0"
 

--- a/boards/launchxl/src/main.rs
+++ b/boards/launchxl/src/main.rs
@@ -352,7 +352,7 @@ pub unsafe fn reset_handler() {
         rng,
     };
 
-    let mut chip = cc26x2::chip::Cc26X2::new();
+    let chip = cc26x2::chip::Cc26X2::new();
 
     extern "C" {
         /// Beginning of the ROM region containing app images.
@@ -371,5 +371,5 @@ pub unsafe fn reset_handler() {
         &process_management_capability,
     );
 
-    board_kernel.kernel_loop(&launchxl, &mut chip, Some(&ipc), &main_loop_capability);
+    board_kernel.kernel_loop(&launchxl, &chip, Some(&ipc), &main_loop_capability);
 }

--- a/boards/nordic/nrf51dk/Cargo.lock
+++ b/boards/nordic/nrf51dk/Cargo.lock
@@ -25,7 +25,7 @@ name = "kernel"
 version = "0.1.0"
 dependencies = [
  "tock-cells 0.1.0",
- "tock-registers 0.1.0",
+ "tock-registers 0.2.0",
 ]
 
 [[package]]
@@ -61,5 +61,5 @@ version = "0.1.0"
 
 [[package]]
 name = "tock-registers"
-version = "0.1.0"
+version = "0.2.0"
 

--- a/boards/nordic/nrf51dk/src/main.rs
+++ b/boards/nordic/nrf51dk/src/main.rs
@@ -393,7 +393,7 @@ pub unsafe fn reset_handler() {
 
     rtc.start();
 
-    let mut chip = nrf51::chip::NRF51::new();
+    let chip = nrf51::chip::NRF51::new();
     chip.systick().reset();
     chip.systick().enable(true);
 
@@ -415,7 +415,7 @@ pub unsafe fn reset_handler() {
 
     board_kernel.kernel_loop(
         &platform,
-        &mut chip,
+        &chip,
         Some(&kernel::ipc::IPC::new(
             board_kernel,
             &memory_allocation_capability,

--- a/boards/nordic/nrf52840dk/Cargo.lock
+++ b/boards/nordic/nrf52840dk/Cargo.lock
@@ -25,7 +25,7 @@ name = "kernel"
 version = "0.1.0"
 dependencies = [
  "tock-cells 0.1.0",
- "tock-registers 0.1.0",
+ "tock-registers 0.2.0",
 ]
 
 [[package]]
@@ -73,5 +73,5 @@ version = "0.1.0"
 
 [[package]]
 name = "tock-registers"
-version = "0.1.0"
+version = "0.2.0"
 

--- a/boards/nordic/nrf52dk/Cargo.lock
+++ b/boards/nordic/nrf52dk/Cargo.lock
@@ -25,7 +25,7 @@ name = "kernel"
 version = "0.1.0"
 dependencies = [
  "tock-cells 0.1.0",
- "tock-registers 0.1.0",
+ "tock-registers 0.2.0",
 ]
 
 [[package]]
@@ -73,5 +73,5 @@ version = "0.1.0"
 
 [[package]]
 name = "tock-registers"
-version = "0.1.0"
+version = "0.2.0"
 

--- a/boards/nordic/nrf52dk_base/Cargo.lock
+++ b/boards/nordic/nrf52dk_base/Cargo.lock
@@ -25,7 +25,7 @@ name = "kernel"
 version = "0.1.0"
 dependencies = [
  "tock-cells 0.1.0",
- "tock-registers 0.1.0",
+ "tock-registers 0.2.0",
 ]
 
 [[package]]
@@ -61,5 +61,5 @@ version = "0.1.0"
 
 [[package]]
 name = "tock-registers"
-version = "0.1.0"
+version = "0.2.0"
 

--- a/boards/nordic/nrf52dk_base/src/lib.rs
+++ b/boards/nordic/nrf52dk_base/src/lib.rs
@@ -418,7 +418,7 @@ pub unsafe fn setup_board(
         ipc: kernel::ipc::IPC::new(board_kernel, &memory_allocation_capability),
     };
 
-    let mut chip = nrf52::chip::NRF52::new();
+    let chip = nrf52::chip::NRF52::new();
 
     debug!("Initialization complete. Entering main loop\r");
     debug!("{}", &nrf52::ficr::FICR_INSTANCE);
@@ -437,10 +437,5 @@ pub unsafe fn setup_board(
         &process_management_capability,
     );
 
-    board_kernel.kernel_loop(
-        &platform,
-        &mut chip,
-        Some(&platform.ipc),
-        &main_loop_capability,
-    );
+    board_kernel.kernel_loop(&platform, &chip, Some(&platform.ipc), &main_loop_capability);
 }

--- a/chips/cc26x2/Cargo.lock
+++ b/chips/cc26x2/Cargo.lock
@@ -1,7 +1,8 @@
 [[package]]
-name = "capsules"
+name = "cc26x2"
 version = "0.1.0"
 dependencies = [
+ "cortexm4 0.1.0",
  "kernel 0.1.0",
 ]
 
@@ -21,29 +22,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "ek-tm4c1294xl"
-version = "0.1.0"
-dependencies = [
- "capsules 0.1.0",
- "cortexm4 0.1.0",
- "kernel 0.1.0",
- "tm4c129x 0.1.0",
-]
-
-[[package]]
 name = "kernel"
 version = "0.1.0"
 dependencies = [
  "tock-cells 0.1.0",
  "tock-registers 0.2.0",
-]
-
-[[package]]
-name = "tm4c129x"
-version = "0.1.0"
-dependencies = [
- "cortexm4 0.1.0",
- "kernel 0.1.0",
 ]
 
 [[package]]

--- a/chips/cc26x2/src/chip.rs
+++ b/chips/cc26x2/src/chip.rs
@@ -32,7 +32,7 @@ impl kernel::Chip for Cc26X2 {
     fn systick(&self) -> &Self::SysTick {
         &self.systick
     }
-    fn service_pending_interrupts(&mut self) {
+    fn service_pending_interrupts(&self) {
         unsafe {
             while let Some(interrupt) = nvic::next_pending() {
                 match interrupt {

--- a/chips/nrf51/Cargo.lock
+++ b/chips/nrf51/Cargo.lock
@@ -16,6 +16,10 @@ dependencies = [
 [[package]]
 name = "kernel"
 version = "0.1.0"
+dependencies = [
+ "tock-cells 0.1.0",
+ "tock-registers 0.2.0",
+]
 
 [[package]]
 name = "nrf51"
@@ -32,4 +36,12 @@ version = "0.1.0"
 dependencies = [
  "kernel 0.1.0",
 ]
+
+[[package]]
+name = "tock-cells"
+version = "0.1.0"
+
+[[package]]
+name = "tock-registers"
+version = "0.2.0"
 

--- a/chips/nrf51/src/chip.rs
+++ b/chips/nrf51/src/chip.rs
@@ -27,7 +27,7 @@ impl kernel::Chip for NRF51 {
         &self.0
     }
 
-    fn service_pending_interrupts(&mut self) {
+    fn service_pending_interrupts(&self) {
         unsafe {
             while let Some(interrupt) = nvic::next_pending() {
                 match interrupt {

--- a/chips/nrf52/Cargo.lock
+++ b/chips/nrf52/Cargo.lock
@@ -18,7 +18,7 @@ name = "kernel"
 version = "0.1.0"
 dependencies = [
  "tock-cells 0.1.0",
- "tock-regs 0.1.0",
+ "tock-registers 0.2.0",
 ]
 
 [[package]]
@@ -42,6 +42,6 @@ name = "tock-cells"
 version = "0.1.0"
 
 [[package]]
-name = "tock-regs"
-version = "0.1.0"
+name = "tock-registers"
+version = "0.2.0"
 

--- a/chips/nrf52/src/chip.rs
+++ b/chips/nrf52/src/chip.rs
@@ -39,7 +39,7 @@ impl kernel::Chip for NRF52 {
         &self.systick
     }
 
-    fn service_pending_interrupts(&mut self) {
+    fn service_pending_interrupts(&self) {
         unsafe {
             loop {
                 if let Some(task) = deferred_call::DeferredCall::next_pending() {

--- a/chips/sam4l/Cargo.lock
+++ b/chips/sam4l/Cargo.lock
@@ -18,7 +18,7 @@ name = "kernel"
 version = "0.1.0"
 dependencies = [
  "tock-cells 0.1.0",
- "tock-regs 0.1.0",
+ "tock-registers 0.2.0",
 ]
 
 [[package]]
@@ -34,6 +34,6 @@ name = "tock-cells"
 version = "0.1.0"
 
 [[package]]
-name = "tock-regs"
-version = "0.1.0"
+name = "tock-registers"
+version = "0.2.0"
 

--- a/chips/sam4l/src/chip.rs
+++ b/chips/sam4l/src/chip.rs
@@ -71,7 +71,7 @@ impl Chip for Sam4l {
     type MPU = cortexm4::mpu::MPU;
     type SysTick = cortexm4::systick::SysTick;
 
-    fn service_pending_interrupts(&mut self) {
+    fn service_pending_interrupts(&self) {
         unsafe {
             loop {
                 if let Some(task) = deferred_call::DeferredCall::next_pending() {

--- a/chips/tm4c129x/Cargo.lock
+++ b/chips/tm4c129x/Cargo.lock
@@ -18,7 +18,7 @@ name = "kernel"
 version = "0.1.0"
 dependencies = [
  "tock-cells 0.1.0",
- "tock-regs 0.1.0",
+ "tock-registers 0.2.0",
 ]
 
 [[package]]
@@ -34,6 +34,6 @@ name = "tock-cells"
 version = "0.1.0"
 
 [[package]]
-name = "tock-regs"
-version = "0.1.0"
+name = "tock-registers"
+version = "0.2.0"
 

--- a/chips/tm4c129x/src/chip.rs
+++ b/chips/tm4c129x/src/chip.rs
@@ -23,7 +23,7 @@ impl Chip for Tm4c129x {
     type MPU = cortexm4::mpu::MPU;
     type SysTick = cortexm4::systick::SysTick;
 
-    fn service_pending_interrupts(&mut self) {
+    fn service_pending_interrupts(&self) {
         use nvic;
 
         unsafe {

--- a/kernel/Cargo.lock
+++ b/kernel/Cargo.lock
@@ -3,7 +3,7 @@ name = "kernel"
 version = "0.1.0"
 dependencies = [
  "tock-cells 0.1.0",
- "tock-registers 0.1.0",
+ "tock-registers 0.2.0",
 ]
 
 [[package]]
@@ -12,5 +12,5 @@ version = "0.1.0"
 
 [[package]]
 name = "tock-registers"
-version = "0.1.0"
+version = "0.2.0"
 

--- a/kernel/src/platform/mod.rs
+++ b/kernel/src/platform/mod.rs
@@ -19,7 +19,7 @@ pub trait Chip {
     type MPU: mpu::MPU;
     type SysTick: systick::SysTick;
 
-    fn service_pending_interrupts(&mut self);
+    fn service_pending_interrupts(&self);
     fn has_pending_interrupts(&self) -> bool;
     fn mpu(&self) -> &Self::MPU;
     fn systick(&self) -> &Self::SysTick;

--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -185,7 +185,7 @@ impl Kernel {
     pub fn kernel_loop<P: Platform, C: Chip>(
         &'static self,
         platform: &P,
-        chip: &mut C,
+        chip: &C,
         ipc: Option<&ipc::IPC>,
         _capability: &capabilities::MainLoopCapability,
     ) {
@@ -220,7 +220,7 @@ impl Kernel {
     unsafe fn do_process<P: Platform, C: Chip>(
         &self,
         platform: &P,
-        chip: &mut C,
+        chip: &C,
         process: &process::ProcessType,
         appid: AppId,
         ipc: Option<&::ipc::IPC>,


### PR DESCRIPTION
I'm not sure when this changed, but we do not need a mutable reference to `Chip`.

Shouldn't be any actual logic change.

This should help with #1159.


### Testing Strategy

This pull request was tested by running on hail.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
