### PR TITLE
Remove entropy32 test from standard imix boot sequence.

### DIFF
--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -428,7 +428,7 @@ pub unsafe fn reset_handler() {
     //    virtual_uart_rx_test::run_virtual_uart_receive(uart_mux);
     debug!("Initialization complete. Entering main loop");
 
-    rng_test::run_entropy32();
+    //    rng_test::run_entropy32();
 
     extern "C" {
         /// Beginning of the ROM region containing app images.


### PR DESCRIPTION
### Pull Request Overview

This removes the entropy test from the default imix boot sequence.


### Testing Strategy

This pull request was tested by compiling.


### TODO or Help Wanted

This pull request still needs nothing.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make formatall`.
