### PR TITLE
Event dispatcher

### DIFF
--- a/arch/cortex-m/src/support.rs
+++ b/arch/cortex-m/src/support.rs
@@ -48,5 +48,15 @@ where
 }
 
 #[cfg(target_os = "none")]
+pub unsafe fn atomic_write(location: &mut u64, value: u64) {
+    atomic(|| ::core::ptr::write_volatile(location, value));
+}
+
+#[cfg(target_os = "none")]
+pub unsafe fn atomic_read(location: &u64) -> u64 {
+    atomic(|| ::core::ptr::read_volatile(location))
+}
+
+#[cfg(target_os = "none")]
 #[lang = "eh_personality"]
 pub extern "C" fn eh_personality() {}

--- a/arch/cortex-m4/Cargo.lock
+++ b/arch/cortex-m4/Cargo.lock
@@ -18,7 +18,7 @@ name = "kernel"
 version = "0.1.0"
 dependencies = [
  "tock-cells 0.1.0",
- "tock-regs 0.1.0",
+ "tock-registers 0.2.0",
 ]
 
 [[package]]
@@ -26,6 +26,6 @@ name = "tock-cells"
 version = "0.1.0"
 
 [[package]]
-name = "tock-regs"
-version = "0.1.0"
+name = "tock-registers"
+version = "0.2.0"
 

--- a/arch/cortex-m4/src/lib.rs
+++ b/arch/cortex-m4/src/lib.rs
@@ -46,11 +46,9 @@ pub unsafe extern "C" fn systick_handler() {
     ldr r0, =SYSTICK_EXPIRED
     mov r1, #1
     str r1, [r0, #0]
-
     /* Set thread mode to privileged */
     mov r0, #0
     msr CONTROL, r0
-
     movw LR, #0xFFF9
     movt LR, #0xFFFF"
     : : : : "volatile" );
@@ -59,51 +57,64 @@ pub unsafe extern "C" fn systick_handler() {
 #[cfg(not(target_os = "none"))]
 pub unsafe extern "C" fn generic_isr() {}
 
-#[cfg(target_os = "none")]
-#[naked]
 /// All ISRs are caught by this handler which disables the NVIC and switches to the kernel.
+#[naked]
 pub unsafe extern "C" fn generic_isr() {
+    stash_process_state();
+    set_privileged_thread();
+    disable_specific_nvic();
+}
+
+#[naked]
+pub unsafe extern "C" fn stash_process_state() {
     asm!(
         "
     /* Skip saving process state if not coming from user-space */
     cmp lr, #0xfffffffd
-    bne _ggeneric_isr_no_stacking
-
+    bne 1f
     /* We need the most recent kernel's version of r1, which points */
     /* to the Process struct's stored registers field. The kernel's r1 */
     /* lives in the second word of the hardware stacked registers on MSP */
     mov r1, sp
     ldr r1, [r1, #4]
     stmia r1, {r4-r11}
+  1:
+    "
+    : : : : "volatile" );
+}
 
-    /* Set thread mode to privileged */
+#[naked]
+pub unsafe extern "C" fn set_privileged_thread() {
+    asm!("
+      /* Set thread mode to privileged */
     mov r0, #0
     msr CONTROL, r0
-
     movw LR, #0xFFF9
-    movt LR, #0xFFFF
-  _ggeneric_isr_no_stacking:
+    movt LR, #0xFFFF"
+    : : : : "volatile");
+}
+
+#[naked]
+pub unsafe extern "C" fn disable_specific_nvic() {
+    asm!(
+        "
     /* Find the ISR number by looking at the low byte of the IPSR registers */
     mrs r0, IPSR
     and r0, #0xff
     /* ISRs start at 16, so substract 16 to get zero-indexed */
     sub r0, #16
-
     /*
      * High level:
      *    NVIC.ICER[r0 / 32] = 1 << (r0 & 31)
      * */
     lsrs r2, r0, #5 /* r2 = r0 / 32 */
-
     /* r0 = 1 << (r0 & 31) */
     movs r3, #1        /* r3 = 1 */
     and r0, r0, #31    /* r0 = r0 & 31 */
     lsl r0, r3, r0     /* r0 = r3 << r0 */
-
     /* r3 = &NVIC.ICER */
     mov r3, #0xe180
     movt r3, #0xe000
-
     /* here:
      *
      *  `r2` is r0 / 32
@@ -129,11 +140,9 @@ pub unsafe extern "C" fn svc_handler() {
         "
     cmp lr, #0xfffffff9
     bne to_kernel
-
     /* Set thread mode to unprivileged */
     mov r0, #1
     msr CONTROL, r0
-
     movw lr, #0xfffd
     movt lr, #0xffff
     bx lr
@@ -141,11 +150,9 @@ pub unsafe extern "C" fn svc_handler() {
     ldr r0, =SYSCALL_FIRED
     mov r1, #1
     str r1, [r0, #0]
-
     /* Set thread mode to privileged */
     mov r0, #0
     msr CONTROL, r0
-
     movw LR, #0xFFF9
     movt LR, #0xFFFF
     bx lr"
@@ -167,19 +174,14 @@ pub unsafe extern "C" fn switch_to_user(
     asm!("
     /* Load bottom of stack into Process Stack Pointer */
     msr psp, $0
-
     /* Load non-hardware-stacked registers from Process stack */
     /* Ensure that $2 is stored in a callee saved register */
     ldmia $2, {r4-r11}
-
     /* SWITCH */
     svc 0xff /* It doesn't matter which SVC number we use here */
-
     /* Push non-hardware-stacked registers into Process struct's */
     /* regs field */
     stmia $2, {r4-r11}
-
-
     mrs $0, PSP /* PSP into r0 */"
     : "={r0}"(user_stack)
     : "{r0}"(user_stack), "{r1}"(process_regs)
@@ -358,7 +360,6 @@ pub unsafe extern "C" fn hard_fault_handler() {
             "ldr r0, =APP_HARD_FAULT
               mov r1, #1 /* Fault */
               str r1, [r0, #0]
-
               /* Read the SCB registers. */
               ldr r0, =SCB_REGISTERS
               ldr r1, =0xE000ED14
@@ -372,11 +373,9 @@ pub unsafe extern "C" fn hard_fault_handler() {
               str r2, [r0, #12]
               ldr r2, [r1, #36] /* BFAR */
               str r2, [r0, #16]
-
               /* Set thread mode to privileged */
               mov r0, #0
               msr CONTROL, r0
-
               movw LR, #0xFFF9
               movt LR, #0xFFFF"
         : : : : "volatile" );

--- a/boards/imix/src/icmp_lowpan_test.rs
+++ b/boards/imix/src/icmp_lowpan_test.rs
@@ -70,8 +70,6 @@ pub static mut RF233_BUF: [u8; radio::MAX_BUF_SIZE] = [0 as u8; radio::MAX_BUF_S
 
 pub struct LowpanICMPTest<'a, A: time::Alarm> {
     alarm: A,
-    //sixlowpan_tx: TxState<'a>,
-    //radio: &'a Mac<'a>,
     test_counter: Cell<usize>,
     icmp_sender: &'a ICMP6Sender<'a>,
 }
@@ -108,10 +106,16 @@ pub unsafe fn initialize_all(
 
     let ip6_dg = static_init!(IP6Packet<'static>, IP6Packet::new(ip_pyld));
 
+    let ipsender_virtual_alarm = static_init!(
+        VirtualMuxAlarm<'static, sam4l::ast::Ast>,
+        VirtualMuxAlarm::new(mux_alarm)
+    );
+
     let ip6_sender = static_init!(
-        IP6SendStruct<'static>,
+        IP6SendStruct<'static, VirtualMuxAlarm<'static, sam4l::ast::Ast<'static>>>,
         IP6SendStruct::new(
             ip6_dg,
+            ipsender_virtual_alarm,
             &mut RF233_BUF,
             sixlowpan_tx,
             radio_mac,
@@ -122,7 +126,10 @@ pub unsafe fn initialize_all(
     radio_mac.set_transmit_client(ip6_sender);
 
     let icmp_send_struct = static_init!(
-        ICMP6SendStruct<'static, IP6SendStruct<'static>>,
+        ICMP6SendStruct<
+            'static,
+            IP6SendStruct<'static, VirtualMuxAlarm<'static, sam4l::ast::Ast<'static>>>,
+        >,
         ICMP6SendStruct::new(ip6_sender)
     );
 

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -121,7 +121,7 @@ static mut PROCESSES: [Option<&'static kernel::procs::ProcessType>; NUM_PROCS] =
 /// Dummy buffer that causes the linker to reserve enough space for the stack.
 #[no_mangle]
 #[link_section = ".stack_buffer"]
-pub static mut STACK_MEMORY: [u8; 0x1000] = [0; 0x1000];
+pub static mut STACK_MEMORY: [u8; 0x2000] = [0; 0x2000];
 
 struct Imix {
     console: &'static capsules::console::Console<'static, UartDevice<'static>>,
@@ -379,8 +379,6 @@ pub unsafe fn reset_handler() {
     let usb_driver = UsbComponent::new(board_kernel).finalize();
     let nonvolatile_storage = NonvolatileStorageComponent::new(board_kernel).finalize();
 
-    // ** UDP **
-
     let udp_driver = UDPComponent::new(
         board_kernel,
         mux_mac,
@@ -389,6 +387,7 @@ pub unsafe fn reset_handler() {
         DST_MAC_ADDR,
         SRC_MAC_ADDR,
         &LOCAL_IP_IFACES,
+        mux_alarm,
     ).finalize();
 
     let imix = Imix {

--- a/boards/imix/src/udp_lowpan_test.rs
+++ b/boards/imix/src/udp_lowpan_test.rs
@@ -124,10 +124,16 @@ pub unsafe fn initialize_all(
 
     let ip6_dg = static_init!(IP6Packet<'static>, IP6Packet::new(ip_pyld));
 
+    let ipsender_virtual_alarm = static_init!(
+        VirtualMuxAlarm<'static, sam4l::ast::Ast>,
+        VirtualMuxAlarm::new(mux_alarm)
+    );
+
     let ip6_sender = static_init!(
-        IP6SendStruct<'static>,
+        IP6SendStruct<'static, VirtualMuxAlarm<'static, sam4l::ast::Ast<'static>>>,
         IP6SendStruct::new(
             ip6_dg,
+            ipsender_virtual_alarm,
             &mut RF233_BUF,
             sixlowpan_tx,
             radio_mac,
@@ -138,7 +144,10 @@ pub unsafe fn initialize_all(
     radio_mac.set_transmit_client(ip6_sender);
 
     let udp_send_struct = static_init!(
-        UDPSendStruct<'static, IP6SendStruct<'static>>,
+        UDPSendStruct<
+            'static,
+            IP6SendStruct<'static, VirtualMuxAlarm<'static, sam4l::ast::Ast<'static>>>,
+        >,
         UDPSendStruct::new(ip6_sender)
     );
 

--- a/boards/launchxl/Cargo.lock
+++ b/boards/launchxl/Cargo.lock
@@ -9,6 +9,7 @@ dependencies = [
 name = "cc26x2"
 version = "0.1.0"
 dependencies = [
+ "cortexm 0.1.0",
  "cortexm4 0.1.0",
  "enum_primitive 0.1.0",
  "kernel 0.1.0",

--- a/capsules/src/ieee802154/mac.rs
+++ b/capsules/src/ieee802154/mac.rs
@@ -174,11 +174,13 @@ impl<R: radio::Radio> radio::RxClient for AwakeMac<'a, R> {
         }
 
         if addr_match {
+            debug!("[AwakeMAC] Rcvd a 15.4 frame addressed to this device");
             self.rx_client.map(move |c| {
                 c.receive(buf, frame_len, crc_valid, result);
             });
         } else {
             debug!("[AwakeMAC] Received a packet, but not addressed to us");
+            debug!("radio addr is: {:?}", self.radio.get_address());
             self.radio.set_receive_buffer(buf);
         }
     }

--- a/capsules/src/net/ipv6/ip_utils.rs
+++ b/capsules/src/net/ipv6/ip_utils.rs
@@ -118,12 +118,16 @@ pub fn compute_udp_checksum(
     sum += src_port as u32;
     sum += dst_port as u32;
     sum += udp_header.get_len() as u32;
+    sum += udp_header.get_cksum() as u32;
     //Now just need to iterate thru data and add it to the sum
     {
         let mut i: usize = 0;
         while i < ((udp_length - 8) as usize) {
             let msb_dat: u16 = ((payload[i]) as u16) << 8;
-            let lsb_dat: u16 = payload[i + 1] as u16;
+            let mut lsb_dat: u16 = 0;
+            if i + 1 < udp_length as usize - 8 {
+                lsb_dat = payload[i + 1] as u16;
+            }
             let temp_dat: u16 = msb_dat + lsb_dat;
             sum += temp_dat as u32;
 

--- a/capsules/src/net/ipv6/ipv6.rs
+++ b/capsules/src/net/ipv6/ipv6.rs
@@ -64,6 +64,7 @@
 // a major problem in general, it makes handling encapsulated IPv6 packets
 // (as required by 6LoWPAN) difficult.
 
+use kernel::ReturnCode;
 use net::icmpv6::icmpv6::ICMP6Header;
 use net::ipv6::ip_utils::{compute_icmp_checksum, compute_udp_checksum, ip6_nh, IPAddr};
 use net::stream::SResult;
@@ -71,6 +72,9 @@ use net::stream::{decode_bytes, decode_u16, decode_u8};
 use net::stream::{encode_bytes, encode_u16, encode_u8};
 use net::tcp::TCPHeader;
 use net::udp::udp::UDPHeader;
+
+pub const UDP_HDR_LEN: usize = 8;
+pub const ICMP_HDR_LEN: usize = 8;
 
 /// This is the struct definition for an IPv6 header. It contains (in order)
 /// the same fields as a normal IPv6 header.
@@ -249,6 +253,48 @@ impl IP6Header {
 
     pub fn set_hop_limit(&mut self, new_hl: u8) {
         self.hop_limit = new_hl;
+    }
+
+    /// Utility function for verifying whether a transport layer checksum of a received
+    /// packet is correct. Is called on the assocaite IPv6 Header, and passed the buffer
+    /// containing the remainder of the packet.
+    pub fn check_transport_checksum(&self, buf: &[u8]) -> ReturnCode {
+        match self.next_header {
+            ip6_nh::UDP => {
+                let mut udp_header: [u8; UDP_HDR_LEN] = [0; UDP_HDR_LEN];
+                udp_header.copy_from_slice(&buf[..UDP_HDR_LEN]);
+                let checksum = match UDPHeader::decode(&udp_header).done() {
+                    Some((_offset, hdr)) => u16::from_be(compute_udp_checksum(
+                        &self,
+                        &hdr,
+                        buf.len() as u16,
+                        &buf[UDP_HDR_LEN..],
+                    )),
+                    None => 0xffff, //Will be dropped, as ones comp -0 checksum is invalid
+                };
+                if checksum != 0 {
+                    return ReturnCode::FAIL; //Incorrect cksum
+                }
+                ReturnCode::SUCCESS
+            }
+            ip6_nh::ICMP => {
+                // Untested (10/5/18)
+                let mut icmp_header: [u8; ICMP_HDR_LEN] = [0; ICMP_HDR_LEN];
+                icmp_header.copy_from_slice(&buf[..ICMP_HDR_LEN]);
+                let checksum = match ICMP6Header::decode(&icmp_header).done() {
+                    Some((_offset, mut hdr)) => {
+                        hdr.set_len(buf.len() as u16);
+                        u16::from_be(compute_icmp_checksum(&self, &hdr, &buf[ICMP_HDR_LEN..]))
+                    }
+                    None => 0xffff, //Will be dropped, as ones comp -0 checksum is invalid
+                };
+                if checksum != 0 {
+                    return ReturnCode::FAIL; //Incorrect cksum
+                }
+                ReturnCode::SUCCESS
+            }
+            _ => ReturnCode::ENOSUPPORT,
+        }
     }
 }
 

--- a/capsules/src/net/ipv6/ipv6_recv.rs
+++ b/capsules/src/net/ipv6/ipv6_recv.rs
@@ -65,11 +65,17 @@ impl<'a> SixlowpanRxClient for IP6RecvStruct<'a> {
             return;
         }
         match IP6Header::decode(buf).done() {
-            Some((offset, header)) => {
-                // TODO: Probably do some sanity checking, check for checksum
-                // correctness, length, etc.
+            Some((offset, ip6_header)) => {
+                let checksum_result = ip6_header.check_transport_checksum(&buf[offset..len]);
+                if checksum_result == ReturnCode::FAIL {
+                    debug!("dropped!: {:?}", checksum_result);
+                    return; //Dropped.
+                }
+                // Note: Protocols for which checksum verification is not implemented (TCP, etc.)
+                // are automatically assumed as fine, rather than dropped
+
                 self.client
-                    .map(|client| client.receive(header, &buf[offset..len]));
+                    .map(|client| client.receive(ip6_header, &buf[offset..len]));
             }
             None => {
                 // TODO: Report the error somewhere...

--- a/capsules/src/net/ipv6/ipv6_send.rs
+++ b/capsules/src/net/ipv6/ipv6_send.rs
@@ -19,6 +19,7 @@
 use core::cell::Cell;
 use ieee802154::device::{MacDevice, TxClient};
 use kernel::common::cells::{OptionalCell, TakeCell};
+use kernel::hil::time::{self, Frequency};
 use kernel::ReturnCode;
 use net::ieee802154::MacAddress;
 use net::ipv6::ip_utils::IPAddr;
@@ -81,9 +82,12 @@ pub trait IP6Sender<'a> {
 
 /// This struct is a specific implementation of the `IP6Sender` trait. This
 /// struct sends the packet using 6LoWPAN over a generic `MacDevice` object.
-pub struct IP6SendStruct<'a> {
+pub struct IP6SendStruct<'a, A: time::Alarm> {
     // We want the ip6_packet field to be a TakeCell so that it is easy to mutate
     ip6_packet: TakeCell<'static, IP6Packet<'static>>,
+    alarm: &'a A, // Alarm so we can introduce a small delay between fragments to ensure
+    // successful reception on receivers with slow copies out of the radio buffer
+    // (imix)
     src_addr: Cell<IPAddr>,
     gateway: Cell<MacAddress>,
     tx_buf: TakeCell<'static, [u8]>,
@@ -94,7 +98,7 @@ pub struct IP6SendStruct<'a> {
     client: OptionalCell<&'a IP6SendClient>,
 }
 
-impl IP6Sender<'a> for IP6SendStruct<'a> {
+impl<A: time::Alarm> IP6Sender<'a> for IP6SendStruct<'a, A> {
     fn set_client(&self, client: &'a IP6SendClient) {
         self.client.set(client);
     }
@@ -125,21 +129,24 @@ impl IP6Sender<'a> for IP6SendStruct<'a> {
             None,
         );
         self.init_packet(dst, transport_header, payload);
-        self.send_next_fragment()
+        let ret = self.send_next_fragment();
+        ret
     }
 }
 
-impl IP6SendStruct<'a> {
+impl<A: time::Alarm> IP6SendStruct<'a, A> {
     pub fn new(
         ip6_packet: &'static mut IP6Packet<'static>,
+        alarm: &'a A,
         tx_buf: &'static mut [u8],
         sixlowpan: TxState<'a>,
         radio: &'a MacDevice<'a>,
         dst_mac_addr: MacAddress,
         src_mac_addr: MacAddress,
-    ) -> IP6SendStruct<'a> {
+    ) -> IP6SendStruct<'a, A> {
         IP6SendStruct {
             ip6_packet: TakeCell::new(ip6_packet),
+            alarm: alarm,
             src_addr: Cell::new(IPAddr::new()),
             gateway: Cell::new(dst_mac_addr),
             tx_buf: TakeCell::new(tx_buf),
@@ -163,29 +170,47 @@ impl IP6SendStruct<'a> {
 
     // Returns EBUSY if the tx_buf is not there
     fn send_next_fragment(&self) -> ReturnCode {
-        self.ip6_packet
+        // Originally send_complete() was called within the below closure.
+        // However, this led to a race condition where when multiple apps transmitted
+        // simultaneously, it was possible for send_complete to trigger another
+        // transmission before the below closure would exit, leading to this function
+        // being called again by another app before ip6_packet is replaced.
+        // To fix this, we pass a bool out of the closure to indicate whether send_completed()
+        // should be called once the closure exits
+        let (ret, call_send_complete) = self
+            .ip6_packet
             .map(move |ip6_packet| match self.tx_buf.take() {
                 Some(tx_buf) => {
+                    let mut send = false;
+                    let mut send_complete_return = ReturnCode::SUCCESS;
                     let next_frame = self.sixlowpan.next_fragment(ip6_packet, tx_buf, self.radio);
-
                     match next_frame {
                         Ok((is_done, frame)) => {
                             if is_done {
                                 self.tx_buf.replace(frame.into_buf());
-                                self.send_completed(ReturnCode::SUCCESS);
+                                //self.send_completed(ReturnCode::SUCCESS);
+                                send = true;
+                                return (send_complete_return, send);
                             } else {
                                 self.radio.transmit(frame);
                             }
                         }
                         Err((retcode, buf)) => {
                             self.tx_buf.replace(buf);
-                            self.send_completed(retcode);
+                            //self.send_completed(retcode);
+                            send = true;
+                            send_complete_return = retcode;
                         }
                     }
-                    ReturnCode::SUCCESS
+                    (send_complete_return, send)
                 }
-                None => ReturnCode::EBUSY,
-            }).unwrap_or(ReturnCode::ENOMEM)
+                None => (ReturnCode::EBUSY, false),
+            }).unwrap_or((ReturnCode::ENOMEM, false));
+        if call_send_complete {
+            self.send_completed(ret);
+            return ReturnCode::SUCCESS;
+        }
+        ret
     }
 
     fn send_completed(&self, result: ReturnCode) {
@@ -193,13 +218,29 @@ impl IP6SendStruct<'a> {
     }
 }
 
-impl TxClient for IP6SendStruct<'a> {
-    fn send_done(&self, tx_buf: &'static mut [u8], acked: bool, result: ReturnCode) {
-        self.tx_buf.replace(tx_buf);
-        debug!("sendDone return code is: {:?}, acked: {}", result, acked);
+impl<A: time::Alarm> time::Client for IP6SendStruct<'a, A> {
+    fn fired(&self) {
         let result = self.send_next_fragment();
         if result != ReturnCode::SUCCESS {
             self.send_completed(result);
         }
+    }
+}
+
+impl<A: time::Alarm> TxClient for IP6SendStruct<'a, A> {
+    fn send_done(&self, tx_buf: &'static mut [u8], acked: bool, result: ReturnCode) {
+        self.tx_buf.replace(tx_buf);
+        debug!("Send result: {:?}, acked: {}", result, acked);
+        // Below code adds delay between fragments. Despite some efforts
+        // to fix this bug, I find that without it the receiving imix cannot
+        // receive more than 2 fragments in a single packet without hanging
+        // waiting for the third fragments.
+        // Specifically, here we set a timer, which fires and sends the next fragment
+        // One flaw with this is that we also introduce a delay after sending the last
+        // fragment, before passing the send_done callback back to the client. This
+        // could be optimized by checking if it is the last fragment before setting the timer.
+        let interval = (100000 as u32) * <A::Frequency>::frequency() / 1000000;
+        let tics = self.alarm.now().wrapping_add(interval);
+        self.alarm.set_alarm(tics);
     }
 }

--- a/capsules/src/net/udp/driver.rs
+++ b/capsules/src/net/udp/driver.rs
@@ -10,16 +10,48 @@ use core::cell::Cell;
 use core::{cmp, mem};
 use kernel::{AppId, AppSlice, Callback, Driver, Grant, ReturnCode, Shared};
 use net::ipv6::ip_utils::IPAddr;
+use net::stream::encode_u16;
+use net::stream::encode_u8;
+use net::stream::SResult;
 use net::udp::udp_recv::{UDPReceiver, UDPRecvClient};
 use net::udp::udp_send::{UDPSendClient, UDPSender};
 
 /// Syscall number
 pub const DRIVER_NUM: usize = 0x30002;
 
-#[derive(Debug)]
-struct UDPEndpoint {
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct UDPEndpoint {
     addr: IPAddr,
     port: u16,
+}
+
+impl UDPEndpoint {
+    /// This function serializes the `UDPEndpoint` into the provided buffer.
+    ///
+    /// # Arguments
+    ///
+    /// `buf` - A mutable buffer to serialize the `UDPEndpoint` into
+    /// `offset` - The current offset into the provided buffer
+    ///
+    /// # Return Value
+    ///
+    /// This function returns the new offset into the buffer wrapped in an
+    /// SResult.
+    pub fn encode(&self, buf: &mut [u8], offset: usize) -> SResult<usize> {
+        stream_len_cond!(buf, mem::size_of::<UDPEndpoint>() + offset);
+
+        let mut off = offset;
+        for i in 0..16 {
+            off = enc_consume!(buf, off; encode_u8, self.addr.0[i]);
+        }
+        off = enc_consume!(buf, off; encode_u16, self.port);
+        stream_done!(off, off);
+    }
+
+    /// This function checks if the UDPEndpoint specified is the 0 address + 0 port.
+    pub fn is_zero(&self) -> bool {
+        self.addr.is_unspecified() && self.port == 0
+    }
 }
 
 #[derive(Default)]
@@ -31,6 +63,7 @@ pub struct App {
     app_cfg: Option<AppSlice<Shared, u8>>,
     app_rx_cfg: Option<AppSlice<Shared, u8>>,
     pending_tx: Option<[UDPEndpoint; 2]>,
+    bound_port: Option<UDPEndpoint>,
 }
 
 #[allow(dead_code)]
@@ -48,6 +81,9 @@ pub struct UDPDriver<'a> {
 
     /// List of IP Addresses of the interfaces on the device
     interface_list: &'static [IPAddr],
+
+    /// Maximum length payload that an app can transmit via this driver
+    max_tx_pyld_len: usize,
 }
 
 impl<'a> UDPDriver<'a> {
@@ -56,6 +92,7 @@ impl<'a> UDPDriver<'a> {
         receiver: &'a UDPReceiver<'a>,
         grant: Grant<App>,
         interface_list: &'static [IPAddr],
+        max_tx_pyld_len: usize,
     ) -> UDPDriver<'a> {
         UDPDriver {
             sender: sender,
@@ -63,6 +100,7 @@ impl<'a> UDPDriver<'a> {
             apps: grant,
             current_app: Cell::new(None),
             interface_list: interface_list,
+            max_tx_pyld_len: max_tx_pyld_len,
         }
     }
 
@@ -315,8 +353,13 @@ impl<'a> Driver for UDPDriver<'a> {
     ///
     /// ### `subscribe_num`
     ///
-    /// - `0`: Setup callback for when frame is received.
-    /// - `1`: Setup callback for when frame is transmitted.
+    /// - `0`: Setup callback for when packet is received. If no port has
+    ///        been bound, return ERESERVE to indicate that port binding is
+    ///        is a prerequisite to reception.
+    /// - `1`: Setup callback for when packet is transmitted. Notably,
+    ///        this callback receives the result of the send_done callback
+    ///        from udp_send.rs, which does not currently pass information
+    ///        regarding whether packets were acked at the link layer.
     fn subscribe(
         &self,
         subscribe_num: usize,
@@ -325,8 +368,12 @@ impl<'a> Driver for UDPDriver<'a> {
     ) -> ReturnCode {
         match subscribe_num {
             0 => self.do_with_app(app_id, |app| {
-                app.rx_callback = callback;
-                ReturnCode::SUCCESS
+                if app.bound_port.is_some() {
+                    app.rx_callback = callback;
+                    ReturnCode::SUCCESS
+                } else {
+                    ReturnCode::ERESERVE
+                }
             }),
             1 => self.do_with_app(app_id, |app| {
                 app.tx_callback = callback;
@@ -359,10 +406,29 @@ impl<'a> Driver for UDPDriver<'a> {
     ///        was being passed down to the radio. Any successful return value indicates that
     ///        the app should wait for a send_done() callback before attempting to queue another
     ///        packet.
+    ///        Currently, only will transmit if the app has bound to the port passed in the tx_cfg
+    ///        buf as the source address. If no port is bound, returns ERESERVE, if it tries to
+    ///        send on a port other than the port which is bound, returns EINVALID.
     ///
     ///        Notably, the currently transmit implementation allows for starvation - an
     ///        an app with a lower app id can send constantly and starve an app with a
     ///        later ID.
+    /// - `3`: Bind to the address in rx_cfg. Returns SUCCESS if that addr/port combo is free,
+    ///        returns EINVAL if the address requested is not a local interface, or if the port
+    ///        requested is 0. Returns EBUSY if that port is already bound to by another app.
+    ///        This command should be called after allow() is called on the rx_cfg buffer, and
+    ///        before subscribe() is used to set up the recv callback. Additionally, apps can only
+    ///        send on ports after they have bound to said port. If this command is called
+    ///        and the address in rx_cfg is 0::0 : 0, this command will reset the option
+    ///        containing the bound port to None and set the rx callback to None. Notably,
+    ///        the current implementation of this only allows for each app to bind to a single
+    ///        port at a time, as such an implementation conserves memory (and is similar
+    ///        to the approach applied by TinyOS and Riot). Further, there is
+    ///        currently no mechanism for anything in the kernel to bind to ports, and there
+    ///        is no distinction between ephemeral ports and reserved ports.
+    /// - `4`: Returns the maximum payload that can be transmitted by apps using this driver.
+    ///        This represents the size of the payload buffer in the kernel. Apps can use this
+    ///        syscall to ensure they do not attempt to send too-large messages.
 
     fn command(&self, command_num: usize, arg1: usize, _: usize, appid: AppId) -> ReturnCode {
         match command_num {
@@ -383,29 +449,31 @@ impl<'a> Driver for UDPDriver<'a> {
                 }
             }),
 
-            // Transmits UDP packet stored in
+            // Transmits UDP packet stored in tx_buf
             2 => {
                 self.do_with_app(appid, |app| {
                     if app.pending_tx.is_some() {
                         // Cannot support more than one pending tx per process.
                         return ReturnCode::EBUSY;
                     }
+                    if app.bound_port.is_none() {
+                        // Currently, apps need to bind to a port before they can send from said port
+                        return ReturnCode::ERESERVE;
+                    }
                     let next_tx = app.app_cfg.as_ref().and_then(|cfg| {
                         if cfg.len() != 2 * mem::size_of::<UDPEndpoint>() {
-                            // debug!("cfg len is {:?}, needed at least {:?}", cfg.len(), 2 * mem::size_of::<UDPEndpoint>());
                             return None;
                         }
-
-                        debug!(
-                            "{:?}",
-                            self.parse_ip_port_pair(&cfg.as_ref()[mem::size_of::<UDPEndpoint>()..])
-                        );
 
                         if let (Some(dst), Some(src)) = (
                             self.parse_ip_port_pair(&cfg.as_ref()[mem::size_of::<UDPEndpoint>()..]),
                             self.parse_ip_port_pair(&cfg.as_ref()[..mem::size_of::<UDPEndpoint>()]),
                         ) {
-                            Some([src, dst])
+                            if Some(src.clone()) == app.bound_port {
+                                Some([src, dst])
+                            } else {
+                                None
+                            }
                         } else {
                             None
                         }
@@ -414,10 +482,74 @@ impl<'a> Driver for UDPDriver<'a> {
                         return ReturnCode::EINVAL;
                     }
                     app.pending_tx = next_tx;
-
                     self.do_next_tx_immediate(appid)
                 })
             }
+            3 => {
+                self.do_with_app(appid, |app| {
+                    // Move UDPEndpoint into udp.rs?
+                    let mut requested_addr_opt = app.app_rx_cfg.as_ref().and_then(|cfg| {
+                        if cfg.len() != 2 * mem::size_of::<UDPEndpoint>() {
+                            None
+                        } else if let Some(local_iface) =
+                            self.parse_ip_port_pair(&cfg.as_ref()[mem::size_of::<UDPEndpoint>()..])
+                        {
+                            Some(local_iface)
+                        } else {
+                            None
+                        }
+                    });
+                    if requested_addr_opt.is_none() {
+                        return ReturnCode::EINVAL;
+                    }
+                    if requested_addr_opt.is_some() {
+                        let requested_addr = requested_addr_opt.unwrap();
+                        // If zero address, close any already bound socket
+                        if requested_addr.is_zero() {
+                            app.rx_callback = None;
+                            app.bound_port = None;
+                            return ReturnCode::SUCCESS;
+                        }
+                        // Check that requested addr is a local interface
+                        let mut requested_is_local = false;
+                        for i in 0..self.interface_list.len() {
+                            if requested_addr.addr == self.interface_list[i] {
+                                requested_is_local = true;
+                            }
+                        }
+                        if !requested_is_local {
+                            return ReturnCode::EINVAL;
+                        }
+                        let mut addr_already_bound = false;
+                        for app in self.apps.iter() {
+                            app.enter(|other_app, _| {
+                                if other_app.bound_port.is_some() {
+                                    let other_addr_opt = other_app.bound_port.clone();
+                                    let other_addr = other_addr_opt.unwrap();
+                                    if other_addr.port == requested_addr.port {
+                                        if other_addr.addr == requested_addr.addr {
+                                            addr_already_bound = true;
+                                        }
+                                    }
+                                }
+                            });
+                        }
+                        if addr_already_bound {
+                            return ReturnCode::EBUSY;
+                        } else {
+                            requested_addr_opt = Some(requested_addr);
+                            // If this point is reached, the requested addr is free and valid
+                            app.bound_port = requested_addr_opt;
+                            return ReturnCode::SUCCESS;
+                        }
+                    } else {
+                        return ReturnCode::EINVAL;
+                    }
+                })
+            }
+            4 => ReturnCode::SuccessWithValue {
+                value: self.max_tx_pyld_len,
+            },
             _ => ReturnCode::ENOSUPPORT,
         }
     }
@@ -432,10 +564,10 @@ impl<'a> UDPSendClient for UDPDriver<'a> {
             });
         });
         self.current_app.set(None);
+        self.do_next_tx_queued();
     }
 }
 
-// how many levels of indentation before this starts to make no sense
 impl<'a> UDPRecvClient for UDPDriver<'a> {
     fn receive(
         &self,
@@ -446,38 +578,42 @@ impl<'a> UDPRecvClient for UDPDriver<'a> {
         payload: &[u8],
     ) {
         self.apps.each(|app| {
-            self.do_with_rx_cfg(app.appid(), |cfg| {
-                if cfg.len() != 2 * mem::size_of::<UDPEndpoint>() {
-                    return ReturnCode::EINVAL;
-                }
-                self.parse_ip_port_pair(&cfg.as_ref()[..mem::size_of::<UDPEndpoint>()])
-                    .map(|socket_addr| {
-                        self.parse_ip_port_pair(&cfg.as_ref()[mem::size_of::<UDPEndpoint>()..])
-                            .map(|requested_addr| {
-                                if (socket_addr.addr == dst_addr
-                                    && requested_addr.addr == src_addr
-                                    && socket_addr.port == dst_port
-                                    && requested_addr.port == src_port)
-                                    || true
-                                {
-                                    let mut app_read = app.app_read.take();
-                                    app_read.as_mut().map(|rbuf| {
-                                        //app.app_read.take().as_mut().map(|rbuf| {
-                                        let rbuf = rbuf.as_mut();
-                                        let len = payload.len();
-                                        if rbuf.len() >= len {
-                                            // silently ignore packets that don't fit?
-                                            rbuf[..len].copy_from_slice(&payload[..len]);
-                                            app.rx_callback.map(|mut cb| cb.schedule(len, 0, 0));
-                                        }
-                                    });
-                                    app.app_read = app_read;
-                                }
-                                ReturnCode::SUCCESS
-                            });
+            if app.bound_port.is_some() {
+                let appid = app.appid();
+                self.do_with_app(app.appid(), |app| {
+                    let mut for_me = false;
+                    app.bound_port.as_ref().map(|requested_addr| {
+                        if requested_addr.addr == dst_addr && requested_addr.port == dst_port {
+                            for_me = true;
+                        }
                     });
-                ReturnCode::EINVAL
-            });
+                    if for_me {
+                        let mut app_read = app.app_read.take();
+                        app_read.as_mut().map(|rbuf| {
+                            let rbuf = rbuf.as_mut();
+                            let len = payload.len();
+                            if rbuf.len() >= len {
+                                // silently ignore packets that don't fit?
+                                rbuf[..len].copy_from_slice(&payload[..len]);
+
+                                // Write address of sender into rx_cfg so it can be read by client
+                                let sender_addr = UDPEndpoint {
+                                    addr: src_addr,
+                                    port: src_port,
+                                };
+                                let cfg_len = 2 * mem::size_of::<UDPEndpoint>();
+                                self.do_with_rx_cfg_mut(appid, cfg_len, |cfg| {
+                                    sender_addr.encode(cfg, 0);
+                                    ReturnCode::SUCCESS
+                                });
+                                app.rx_callback.map(|mut cb| cb.schedule(len, 0, 0));
+                            }
+                        });
+                        app.app_read = app_read;
+                    }
+                    ReturnCode::SUCCESS
+                });
+            }
         });
     }
 }

--- a/capsules/src/net/udp/udp.rs
+++ b/capsules/src/net/udp/udp.rs
@@ -107,7 +107,6 @@ impl UDPHeader {
     /// # Return Value
     ///
     /// This function returns a `UDPHeader` struct wrapped in an SResult
-    // TODO: Decode has not been tested
     pub fn decode(buf: &[u8]) -> SResult<UDPHeader> {
         stream_len_cond!(buf, 8);
         let mut udp_header = Self::new();

--- a/chips/cc26x2/Cargo.lock
+++ b/chips/cc26x2/Cargo.lock
@@ -2,6 +2,7 @@
 name = "cc26x2"
 version = "0.1.0"
 dependencies = [
+ "cortexm 0.1.0",
  "cortexm4 0.1.0",
  "enum_primitive 0.1.0",
  "kernel 0.1.0",
@@ -25,6 +26,8 @@ dependencies = [
 [[package]]
 name = "enum_primitive"
 version = "0.1.0"
+
+[[package]]
 name = "kernel"
 version = "0.1.0"
 dependencies = [

--- a/chips/cc26x2/Cargo.toml
+++ b/chips/cc26x2/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
 
 [dependencies]
+cortexm = { path = "../../arch/cortex-m" }
 cortexm4 = { path = "../../arch/cortex-m4" }
 kernel = { path = "../../kernel" }
 enum_primitive = { path = "../../libraries/enum_primitive" }

--- a/chips/cc26x2/src/chip.rs
+++ b/chips/cc26x2/src/chip.rs
@@ -1,9 +1,9 @@
-use cortexm4::{self, nvic};
-use enum_primitive::cast::FromPrimitive;
+use cortexm4;
+use event_priority::EVENT_PRIORITY;
+use events;
 use gpio;
 use i2c;
 use kernel;
-use peripheral_interrupts::NVIC_IRQ;
 use rtc;
 use uart;
 
@@ -33,29 +33,26 @@ impl kernel::Chip for Cc26X2 {
     fn systick(&self) -> &Self::SysTick {
         &self.systick
     }
+
     fn service_pending_interrupts(&self) {
         unsafe {
-            while let Some(interrupt) = nvic::next_pending() {
-                let irq = NVIC_IRQ::from_u32(interrupt)
-                    .expect("Pending IRQ flag not enumerated in NVIQ_IRQ");
-                match irq {
-                    NVIC_IRQ::GPIO => gpio::PORT.handle_interrupt(),
-                    NVIC_IRQ::AON_RTC => rtc::RTC.handle_interrupt(),
-                    NVIC_IRQ::UART0 => uart::UART0.handle_interrupt(),
-                    NVIC_IRQ::I2C0 => i2c::I2C0.handle_interrupt(),
-                    // We need to ignore JTAG events since some debuggers emit these
-                    NVIC_IRQ::AON_PROG => (),
-                    _ => panic!("Unhandled interrupt {:?}", irq),
+            while let Some(event) = events::next_pending() {
+                events::clear_event_flag(event);
+                match event {
+                    EVENT_PRIORITY::GPIO => gpio::PORT.handle_events(),
+                    EVENT_PRIORITY::AON_RTC => rtc::RTC.handle_events(),
+                    EVENT_PRIORITY::I2C0 => i2c::I2C0.handle_events(),
+                    EVENT_PRIORITY::UART0 => uart::UART0.handle_events(),
+                    EVENT_PRIORITY::UART1 => uart::UART1.handle_events(),
+                    EVENT_PRIORITY::AON_PROG => (),
+                    _ => panic!("unhandled event {:?} ", event),
                 }
-                let n = nvic::Nvic::new(interrupt);
-                n.clear_pending();
-                n.enable();
             }
         }
     }
 
     fn has_pending_interrupts(&self) -> bool {
-        unsafe { nvic::has_pending() }
+        events::has_event()
     }
 
     fn sleep(&self) {

--- a/chips/cc26x2/src/crt1.rs
+++ b/chips/cc26x2/src/crt1.rs
@@ -1,4 +1,9 @@
-use cortexm4::{generic_isr, hard_fault_handler, nvic, svc_handler, systick_handler};
+use cortexm4::{
+    disable_specific_nvic, generic_isr, hard_fault_handler, nvic, set_privileged_thread,
+    stash_process_state, svc_handler, systick_handler,
+};
+
+use events::set_event_flag_from_isr;
 
 extern "C" {
     // Symbols defined in the linker file
@@ -13,6 +18,41 @@ extern "C" {
     // You should never actually invoke it!!
     fn _estack();
 }
+
+use event_priority;
+macro_rules! generic_isr {
+    ($label:tt, $priority:expr) => {
+        #[cfg(target_os = "none")]
+        #[naked]
+        unsafe extern "C" fn $label() {
+            stash_process_state();
+            set_event_flag_from_isr($priority);
+            disable_specific_nvic();
+            set_privileged_thread();
+        }
+    };
+}
+
+macro_rules! custom_isr {
+    ($label:tt, $priority:expr, $isr:ident) => {
+        #[cfg(target_os = "none")]
+        #[naked]
+        unsafe extern "C" fn $label() {
+            stash_process_state();
+            set_event_flag_from_isr($priority);
+            $isr();
+            set_privileged_thread();
+        }
+    };
+}
+
+generic_isr!(gpio_nvic, event_priority::EVENT_PRIORITY::GPIO);
+generic_isr!(i2c0_nvic, event_priority::EVENT_PRIORITY::I2C0);
+generic_isr!(aon_rtc_nvic, event_priority::EVENT_PRIORITY::AON_RTC);
+
+use uart::{uart0_isr, uart1_isr};
+custom_isr!(uart0_nvic, event_priority::EVENT_PRIORITY::UART0, uart0_isr);
+custom_isr!(uart1_nvic, event_priority::EVENT_PRIORITY::UART1, uart1_isr);
 
 unsafe extern "C" fn unhandled_interrupt() {
     'loop0: loop {}
@@ -38,12 +78,12 @@ pub static BASE_VECTORS: [unsafe extern "C" fn(); 54] = [
     unhandled_interrupt, // Reserved
     unhandled_interrupt, // PendSV
     systick_handler,     // Systick
-    generic_isr,         // GPIO Int handler
-    generic_isr,         // I2C
+    gpio_nvic,           // GPIO Int handler
+    i2c0_nvic,           // I2C0
     generic_isr,         // RF Core Command & Packet Engine 1
     generic_isr,         // AON SpiSplave Rx, Tx and CS
-    generic_isr,         // AON RTC
-    generic_isr,         // UART0 Rx and Tx
+    aon_rtc_nvic,        // AON RTC
+    uart0_nvic,          // UART0 Rx and Tx
     generic_isr,         // AUX software event 0
     generic_isr,         // SSI0 Rx and Tx
     generic_isr,         // SSI1 Rx and Tx
@@ -73,10 +113,10 @@ pub static BASE_VECTORS: [unsafe extern "C" fn(); 54] = [
     generic_isr, // AUX Comparator A
     generic_isr, // AUX ADC new sample or ADC DMA
     // done, ADC underflow, ADC overflow
-    generic_isr, // TRNG event
+    generic_isr, // TRNG event (hw_ints.h 49)
     generic_isr,
     generic_isr,
-    generic_isr,
+    uart1_nvic, //uart1_generic_isr,//uart::uart1_isr, // 52 allegedly UART1 (http://e2e.ti.com/support/wireless_connectivity/proprietary_sub_1_ghz_simpliciti/f/156/t/662981?CC1312R-UART1-can-t-work-correctly-in-sensor-oad-cc1312lp-example-on-both-cc1312-launchpad-and-cc1352-launchpad)
     generic_isr,
 ];
 

--- a/chips/cc26x2/src/event_priority.rs
+++ b/chips/cc26x2/src/event_priority.rs
@@ -1,0 +1,20 @@
+//
+//  These are configurable priorities that can be used by ISRs or yields from within kernel space
+//
+
+use enum_primitive::cast::FromPrimitive;
+
+pub static mut FLAGS: u32 = 0;
+
+enum_from_primitive!{
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub enum EVENT_PRIORITY {
+    GPIO = 0,
+    UART0 = 2,
+    UART1 = 1,
+    AON_RTC = 3,
+    RTC = 4,
+    I2C0 = 6,
+    AON_PROG = 7,
+}
+}

--- a/chips/cc26x2/src/events.rs
+++ b/chips/cc26x2/src/events.rs
@@ -1,0 +1,72 @@
+//
+//  These are generic event handling routines which could be defined in cortexm
+//
+
+use core::ptr;
+use cortexm::support::atomic;
+use enum_primitive::cast::FromPrimitive;
+use event_priority::{EVENT_PRIORITY, FLAGS};
+
+pub fn has_event() -> bool {
+    let event_flags;
+    unsafe { event_flags = ptr::read_volatile(&FLAGS) }
+    event_flags != 0
+}
+
+pub fn next_pending() -> Option<EVENT_PRIORITY> {
+    let mut event_flags;
+    unsafe { event_flags = ptr::read_volatile(&FLAGS) }
+
+    let mut count = 0;
+    // stay in loop until we found the flag
+    while event_flags != 0 {
+        // if flag is found, return the count
+        if (event_flags & 0b1) != 0 {
+            return Some(EVENT_PRIORITY::from_u8(count).expect("Unmapped EVENT_PRIORITY"));
+        }
+        // otherwise increment
+        count += 1;
+        event_flags >>= 1;
+    }
+    None
+}
+
+#[inline(never)]
+pub fn set_event_flag(priority: EVENT_PRIORITY) {
+    unsafe {
+        let bm = 0b1 << (priority as u8) as u32;
+        atomic(|| {
+            let new_value = ptr::read_volatile(&FLAGS) | bm;
+            FLAGS = new_value;
+        })
+    };
+}
+
+#[naked]
+pub unsafe fn set_event_flag_from_isr(priority: EVENT_PRIORITY) {
+    // Set PRIMASK
+    asm!("cpsid i" :::: "volatile");
+
+    asm!("
+        // Set event flag
+        orr $0, $2
+        isb
+        "
+        : "={r0}"(FLAGS)
+        : "{r0}"(FLAGS), "{r1}"(0b1<<(priority as u8))
+        : : "volatile" "volatile"
+    );
+
+    // Unset PRIMASK
+    asm!("cpsie i" :::: "volatile");
+}
+
+pub fn clear_event_flag(priority: EVENT_PRIORITY) {
+    unsafe {
+        let bm = !0b1 << (priority as u8) as u32;
+        atomic(|| {
+            let new_value = ptr::read_volatile(&FLAGS) & bm;
+            FLAGS = new_value;
+        })
+    };
+}

--- a/chips/cc26x2/src/gpio.rs
+++ b/chips/cc26x2/src/gpio.rs
@@ -12,6 +12,9 @@ use kernel::common::StaticRef;
 use kernel::hil;
 use kernel::hil::gpio::PinCtl;
 
+use cortexm4::nvic;
+use peripheral_interrupts;
+
 const NUM_PINS: usize = 32;
 
 const GPIO_BASE: StaticRef<GpioRegisters> =
@@ -303,6 +306,7 @@ impl hil::gpio::Pin for GPIOPin {
 }
 
 pub struct Port {
+    nvic: &'static nvic::Nvic,
     pins: [GPIOPin; NUM_PINS],
 }
 
@@ -321,7 +325,7 @@ impl IndexMut<usize> for Port {
 }
 
 impl Port {
-    pub fn handle_interrupt(&self) {
+    pub fn handle_events(&self) {
         let regs = GPIO_BASE;
         let evflags = regs.evflags.get();
         // Clear all interrupts by setting their bits to 1 in evflags
@@ -338,10 +342,16 @@ impl Port {
 
             self.pins[pin].handle_interrupt();
         }
+        self.nvic.clear_pending();
+        self.nvic.enable();
     }
 }
 
+const GPIO_NVIC: nvic::Nvic =
+    unsafe { nvic::Nvic::new(peripheral_interrupts::NVIC_IRQ::GPIO as u32) };
+
 pub static mut PORT: Port = Port {
+    nvic: &GPIO_NVIC,
     pins: [
         GPIOPin::new(0),
         GPIOPin::new(1),

--- a/chips/cc26x2/src/i2c.rs
+++ b/chips/cc26x2/src/i2c.rs
@@ -6,6 +6,8 @@ use kernel::common::registers::{ReadOnly, ReadWrite, WriteOnly};
 use kernel::common::StaticRef;
 use kernel::hil::i2c;
 
+use cortexm4::nvic;
+use peripheral_interrupts;
 use prcm;
 
 /// A wrapper module for interal register types.
@@ -124,18 +126,23 @@ enum TransferMode {
 const I2C0REGISTERS: StaticRef<I2CMasterRegisters> =
     unsafe { StaticRef::new(0x4000_2800 as *const _) };
 
-pub static mut I2C0: I2CMaster = I2CMaster::new(I2C0REGISTERS);
+const I2C0_NVIC: nvic::Nvic =
+    unsafe { nvic::Nvic::new(peripheral_interrupts::NVIC_IRQ::I2C0 as u32) };
+
+pub static mut I2C0: I2CMaster = I2CMaster::new(I2C0REGISTERS, &I2C0_NVIC);
 
 pub struct I2CMaster<'a> {
     registers: StaticRef<I2CMasterRegisters>,
+    nvic: &'a nvic::Nvic,
     client: OptionalCell<&'a i2c::I2CHwMasterClient>,
     transfer: MapCell<Transfer>,
 }
 
 impl<'a> I2CMaster<'a> {
-    const fn new(registers: StaticRef<I2CMasterRegisters>) -> I2CMaster<'a> {
+    const fn new(registers: StaticRef<I2CMasterRegisters>, nvic: &'a nvic::Nvic) -> I2CMaster<'a> {
         I2CMaster {
-            registers: registers,
+            registers,
+            nvic,
             client: OptionalCell::empty(),
             transfer: MapCell::empty(),
         }
@@ -175,7 +182,7 @@ impl<'a> I2CMaster<'a> {
         );
     }
 
-    pub fn handle_interrupt(&self) {
+    pub fn handle_events(&self) {
         self.registers.micr.write(Interrupt::IM::SET);
         if let Some(mut transfer) = self.transfer.take() {
             let status = self.registers.mstat_ctrl.stat();
@@ -246,6 +253,8 @@ impl<'a> I2CMaster<'a> {
                 }
             }
         }
+        self.nvic.clear_pending();
+        self.nvic.enable();
     }
 
     // TODO(alevy): I think we should change this method of setting up power and pins, but I'm

--- a/chips/cc26x2/src/lib.rs
+++ b/chips/cc26x2/src/lib.rs
@@ -1,7 +1,8 @@
-#![feature(const_fn, untagged_unions, used)]
+#![feature(const_fn, untagged_unions, used, asm, naked_functions)]
 #![no_std]
 #![crate_name = "cc26x2"]
 #![crate_type = "rlib"]
+extern crate cortexm;
 extern crate cortexm4;
 #[allow(unused_imports)]
 #[macro_use]
@@ -12,6 +13,8 @@ extern crate enum_primitive;
 pub mod aon;
 pub mod chip;
 pub mod crt1;
+pub mod event_priority;
+pub mod events;
 pub mod gpio;
 pub mod i2c;
 pub mod peripheral_interrupts;

--- a/chips/cc26x2/src/rtc.rs
+++ b/chips/cc26x2/src/rtc.rs
@@ -5,6 +5,9 @@ use kernel::common::registers::{ReadOnly, ReadWrite};
 use kernel::common::StaticRef;
 use kernel::hil::time::{self, Alarm, Frequency, Time};
 
+use cortexm4::nvic;
+use peripheral_interrupts;
+
 #[repr(C)]
 struct RtcRegisters {
     ctl: ReadWrite<u32, Control::Register>,
@@ -60,8 +63,12 @@ register_bitfields![
 const RTC_BASE: StaticRef<RtcRegisters> =
     unsafe { StaticRef::new(0x40092000 as *const RtcRegisters) };
 
+const RTC_NVIC: nvic::Nvic =
+    unsafe { nvic::Nvic::new(peripheral_interrupts::NVIC_IRQ::AON_RTC as u32) };
+
 pub struct Rtc {
     registers: StaticRef<RtcRegisters>,
+    nvic: &'static nvic::Nvic,
     callback: OptionalCell<&'static time::Client>,
 }
 
@@ -71,6 +78,7 @@ impl Rtc {
     const fn new() -> Rtc {
         Rtc {
             registers: RTC_BASE,
+            nvic: &RTC_NVIC,
             callback: OptionalCell::empty(),
         }
     }
@@ -119,7 +127,7 @@ impl Rtc {
         regs.channel_ctl.read(ChannelControl::CH1_EN) != 0
     }
 
-    pub fn handle_interrupt(&self) {
+    pub fn handle_events(&self) {
         let regs = &*self.registers;
 
         // Event flag is cleared when you set it
@@ -130,6 +138,8 @@ impl Rtc {
         regs.sync.get();
 
         self.callback.map(|cb| cb.fired());
+        self.nvic.clear_pending();
+        self.nvic.enable();
     }
 
     pub fn set_client(&self, client: &'static time::Client) {

--- a/doc/syscalls/30002_udp.md
+++ b/doc/syscalls/30002_udp.md
@@ -79,13 +79,14 @@ the driver.
 
   * ### Subscribe Number: 0
 
-    **Description**: Setup callback for when frame is received.
+    **Description**: Setup callback for when frame is received. This callback cannot be set unless
+                     the app is bound to a local UDP endpoint.
 
     **Argument 1**: The callback
 
     **Argument 2**: AppId
 
-    **Returns**: SUCCESS
+    **Returns**: ERESERVE if the app is not currently bound to a port, SUCCESS otherwise.
 
   * ### Subscribe Number: 1
 
@@ -112,7 +113,7 @@ the driver.
 
     **Argument 3**: Unused
 
-    **Returns**: SUCCESS (TODO: return ENODEVICE if driver doesn't exist)
+    **Returns**: SUCCESS
 
   * ### Command Number: 1
 
@@ -139,10 +140,55 @@ the driver.
     **Returns**: EBUSY is this process already has a pending tx.
                  Returns EINVAL if no valid buffer has been loaded into the write buffer,
                  or if the config buffer is the wrong length, or if the destination and source
-                 oirt/address pairs cannot be parsed.
-                 Otherwise, returns the result of do_next_tx_sync(). Notably, a successful
+                 port/address pairs cannot be parsed.
+                 Otherwise, returns the result of do_next_tx_immediate(). Notably, a successful
                  transmit can produce two different success values. If success is returned,
-                 this simply means that the packet was queued. However, if SuccessWithValue
+                 this simply means that the packet was queued. In this case, the app still
+                 still needs to wait for a callback to check if any errors occurred before
+                 the packet was passed to the radio. However, if SuccessWithValue
                  is returned with value 1, this means the the packet was successfully passed
-                 the radio without any errors, which tells the userland application that it can
-                 immediately queue another packet without having to wait for a callback.
+                 the radio without any errors, which tells the userland application that it does
+                 not need to wait for a callback to check if any errors occured while the packet
+                 was being passed down to the radio. Any successful return value indicates that
+                 the app should wait for a send_done() callback before attempting to queue another
+                 packet.
+                 Currently, only will transmit if the app has bound to the port passed in the tx_cfg
+                 buf as the source address. If no port is bound, returns ERESERVE, if it tries to
+                 send on a port other than the port which is bound, returns EINVALID.
+
+                 Notably, the currently transmit implementation allows for starvation - an
+                 an app with a lower app id can send constantly and starve an app with a
+                 later ID.
+
+  * ### Command Number: 3
+
+    **Description**: Bind to the address and port in rx_cfg.
+                     This command should be called after allow() is called on the rx_cfg buffer, and
+                     after subscribe() is used to set up the recv callback. If this command is called
+                     and the address in rx_cfg is 0::0 : 0, this command will reset the option
+                     containing the bound port to None, and set the rx callback to None.
+
+    **Argument 1**: Unused
+
+    **Argument 2**: Unused
+
+    **Argument 3**: AppId
+
+    **Returns**: Returns SUCCESS if that addr/port combo is free,
+                 returns EINVAL if the address requested is not a local interface, or if the port
+                 requested is 0. Returns EBUSY if that port is already bound to by another app.
+
+  * ### Command Number: 4
+
+    **Description**: Returns the maximum payload that can be transmitted by apps using this driver.
+                     This represents the size of the payload buffer in the kernel. Apps can use
+                     this syscall to ensure they do not attempt to send too-large messages.
+
+    **Argument 1**: Unused
+
+    **Argument 2**: Unused
+
+    **Argument 3**: AppId
+
+    **Returns**: Returns SUCCESSWithValue, where the value is the maximum tx payload length
+


### PR DESCRIPTION
### Pull Request Overview

Motivation: I initially started this PR in hopes of creating a more flexible kernel-context "event dispatcher" rather then the current kernel-context "interrupt handler". 

The ideas was to provide the following:

- allow for higher performance drivers to leverage interrupt context, ie: create a canonical way to service interrupts in interrupt context but then dispatch the event to capsules
- allow for kernel-space yielding to a centralized event dispatcher, eg: a long-running computation or busy/read write can be segmented into smaller chunks, allowing periodic yields
- allow for re-prioritization of the kernel-context interrupt handlers beyond their hardware-based NVIC number; currently peripheral interrupts are serviced from lowest IRQn to highest IRQn

However, a recent post on [tock-dev](https://groups.google.com/d/msgid/tock-dev/CACW1YzsUHhBD4GLXSXD4PFSLPZto1NFFQRozR0vhfkUgt5a61g%40mail.gmail.com) highlights another motivation to this PR, which allows us to not miss interrupts. Previously, a hardware interrupt condition that requires no software servicing to "resolve" itself, could be missed.

The root of the charge is in cc26x2::service_pending_interrupts, where we have switched to a notion of events rather than "interrupts". The file events.rs provide some event definitions and functions.

The way things work is that the "generic_isr" is now a macro that sets an event flag as well as disabling the NVIC; this keeps backwards porting with all handle_interrupts handlers pretty easy.

The big difference now though is that handle_interrupt functions now have to clear and re-enable their own NVIC, where as the service_pending_interrupts function did this for them before. The implications are that every single driver now needs to know about it's own interrupt. I adapted all the drivers that were previously being serviced to fit the new model. Also worth noting, the "event flag" is handled by the service_pending_interrupts loop but it does it before entering the handler, allowing the handler to reset the flag in special-cases (thus, the handler can yield, but indicate that it has more to do if nothing more pressing has occured).

So while these changes have inserted a whole new concept and put some NVIC handling burden onto drivers, here's where the good stuff comes in:

- very trivially, you can change the priority of the interrupt by changing the number it has on the EVENT_PRIORITY (similar to NVIC priority, smaller number => greater urgency)
- it is easy be more precise with interrupt handling. I have a UART implementation, that I will push soon where I handle the hardware registers in interrupt context, thus keeping the NVIC enabled, while pushing data through to other capsules in kernel context (custom_isr! is already defined in crt1.rs for setting these up)
- it is possible to start adding arbitrary "events": a busy read/write operation can set it's event flag and yield, allowing the kernel to service higher priority events; a long computation in kernel-space can break itself into arbitrarily small chunks allowing the kernel to preserve a good response time to critical events

I tried to make the design as incremental as possible, while accomplishing the important features that I was after, most critically, better flexibility and control of how time gets allocated between interrupts and kernel-context. That being said, there are two things I don't like:

- I don't think the priorities should be set in chips, I think it should be on a per-board basis. I had trouble implementing this in a clean way. Either I find out how to do a global static Box (my "event priority array" attempt [here](https://github.com/refugeesus/tock/tree/static-box-games)) or perhaps the more trivial solution is to push service_pending_interrupts routine down to the board context and to make the event type a generic to the event library (which should perhaps be in kernel directory)
- I don't love that drivers have to do their own NVIC handling in "generic" case; I wish using inheritance, this could be made more automatic for generic cases, but my rust-fu isn't good enough to rig that up. I think some generic Impl definition would be the way
- I don't like the event_flag to handler mapping is human-maintained, but this is no better or worse than the old way of doing things
- Finally, I made a design decision with "generic" interrupts that I think could be contested. I made it so that each NVIC handler must set it's own event flag. ~~Another approach would've been to have the event_handler loop constantly check NVICs and convert them into event flags. I couldn't find a clean way to maps NVICs to event flags without making another human-maintained table, so I decided to use the existing NVIC table to do that.~~ Now that I know that NVIC flags are auto-cleared, I think the current solution is fine.

### Testing Strategy
I have tested this with the LaunchXL board based on the CC26x2 chip. I converted all interrupt_handlers into event_handlers but only tested UART.

### TODO or Help Wanted
Please poke holes and let me know what you think.

### Documentation

- [ ] Kernel docs in `/doc` updated with the new interrupt handling strategy.