### PR TITLE
interrupts were not re-enabled

### DIFF
--- a/chips/cc26x2/src/uart.rs
+++ b/chips/cc26x2/src/uart.rs
@@ -145,6 +145,8 @@ impl UART {
 
         self.fifo_enable();
 
+        self.enable_interrupts();
+
         // Enable UART, RX and TX
         self.registers
             .ctl


### PR DESCRIPTION
### Pull Request Overview

`enable_interrupts` was removed as a public function, removing the burden from the client, but was not called internally from configure. Since `disable` disables interrupts, they were not enabled after configuration.


### Testing Strategy

Tested on CC1312 with UART0