### PR TITLE
Fix assembly ordering in context switching code

### DIFF
--- a/arch/cortex-m/src/syscall.rs
+++ b/arch/cortex-m/src/syscall.rs
@@ -200,14 +200,9 @@ impl kernel::syscall::UserspaceKernelBoundary for SysCall {
         } else if systick_expired == 1 {
             kernel::syscall::ContextSwitchReason::TimesliceExpired
         } else {
-            // Desired: If something else happened, which shouldn't, we fallback
-            // to this process having faulted.
-            //
-            // Currently: Defaulting to `Fault` is causing the first app to
-            // crash immediately. While that can be sorted, default to
-            // essentially a no-op so that Tock works again. Also this is (I
-            // think) the old behavior (before #1113).
-            kernel::syscall::ContextSwitchReason::TimesliceExpired
+            // If none of the above cases are true its because the process was interrupted by an
+            // ISR for a hardware event
+            kernel::syscall::ContextSwitchReason::Interrupted
         };
 
         (new_stack_pointer as *mut usize, switch_reason)

--- a/arch/cortex-m0/src/lib.rs
+++ b/arch/cortex-m0/src/lib.rs
@@ -82,7 +82,7 @@ MEXC_RETURN_MSP:
   .word 0xFFFFFFF9
 MEXC_RETURN_PSP:
   .word 0xFFFFFFFD"
-    );
+    : : : : "volatile");
 }
 
 #[naked]
@@ -108,7 +108,7 @@ EXC_RETURN_MSP:
 EXC_RETURN_PSP:
   .word 0xFFFFFFFD
   "
-    );
+  : : : : "volatile"  );
 }
 
 #[no_mangle]
@@ -156,6 +156,6 @@ pub unsafe extern "C" fn switch_to_user(
     "
     : "={r0}"(user_stack)
     : "{r0}"(user_stack), "{r1}"(process_regs)
-    : "r4","r5","r6","r7","r8","r9","r10","r11");
+    : "r4","r5","r6","r7","r8","r9","r10","r11" : "volatile" );
     user_stack as *mut u8
 }

--- a/arch/cortex-m3/src/lib.rs
+++ b/arch/cortex-m3/src/lib.rs
@@ -33,7 +33,7 @@ pub unsafe extern "C" fn systick_handler() {
         movw LR, #0xFFF9
         movt LR, #0xFFFF
          "
-    );
+    : : : : "volatile" );
 }
 
 #[no_mangle]
@@ -94,7 +94,7 @@ _ggeneric_isr_no_stacking:
      *
      *  */
 	str	r0, [r3, r2, lsl #2]"
-    );
+    : : : : "volatile" );
 }
 
 #[no_mangle]
@@ -157,6 +157,6 @@ pub unsafe extern "C" fn switch_to_user(
     mrs $0, PSP /* PSP into r0 */"
     : "={r0}"(user_stack)
     : "{r0}"(user_stack), "{r1}"(process_regs)
-    : "r4","r5","r6","r7","r8","r9","r10","r11");
+    : "r4","r5","r6","r7","r8","r9","r10","r11" : "volatile" );
     user_stack as *mut u8
 }

--- a/arch/cortex-m4/src/lib.rs
+++ b/arch/cortex-m4/src/lib.rs
@@ -53,7 +53,7 @@ pub unsafe extern "C" fn systick_handler() {
 
     movw LR, #0xFFF9
     movt LR, #0xFFFF"
-    );
+    : : : : "volatile" );
 }
 
 #[cfg(not(target_os = "none"))]
@@ -116,7 +116,7 @@ pub unsafe extern "C" fn generic_isr() {
      *
      *  */
     str r0, [r3, r2, lsl #2]"
-    );
+    : : : : "volatile" );
 }
 
 #[cfg(not(target_os = "none"))]
@@ -147,8 +147,9 @@ pub unsafe extern "C" fn svc_handler() {
     msr CONTROL, r0
 
     movw LR, #0xFFF9
-    movt LR, #0xFFFF"
-    );
+    movt LR, #0xFFFF
+    bx lr"
+    : : : : "volatile" );
 }
 
 #[cfg(not(target_os = "none"))]
@@ -182,13 +183,156 @@ pub unsafe extern "C" fn switch_to_user(
     mrs $0, PSP /* PSP into r0 */"
     : "={r0}"(user_stack)
     : "{r0}"(user_stack), "{r1}"(process_regs)
-    : "r4","r5","r6","r7","r8","r9","r10","r11");
+    : "r4","r5","r6","r7","r8","r9","r10","r11" : "volatile" );
     user_stack
 }
 
-pub unsafe extern "C" fn hard_fault_handler() {
+#[inline(never)]
+unsafe fn kernel_hardfault(faulting_stack: *mut u32) {
     use core::intrinsics::offset;
 
+    let stacked_r0: u32 = *offset(faulting_stack, 0);
+    let stacked_r1: u32 = *offset(faulting_stack, 1);
+    let stacked_r2: u32 = *offset(faulting_stack, 2);
+    let stacked_r3: u32 = *offset(faulting_stack, 3);
+    let stacked_r12: u32 = *offset(faulting_stack, 4);
+    let stacked_lr: u32 = *offset(faulting_stack, 5);
+    let stacked_pc: u32 = *offset(faulting_stack, 6);
+    let stacked_xpsr: u32 = *offset(faulting_stack, 7);
+
+    let mode_str = "Kernel";
+
+    let shcsr: u32 = core::ptr::read_volatile(0xE000ED24 as *const u32);
+    let cfsr: u32 = core::ptr::read_volatile(0xE000ED28 as *const u32);
+    let hfsr: u32 = core::ptr::read_volatile(0xE000ED2C as *const u32);
+    let mmfar: u32 = core::ptr::read_volatile(0xE000ED34 as *const u32);
+    let bfar: u32 = core::ptr::read_volatile(0xE000ED38 as *const u32);
+
+    let iaccviol = (cfsr & 0x01) == 0x01;
+    let daccviol = (cfsr & 0x02) == 0x02;
+    let munstkerr = (cfsr & 0x08) == 0x08;
+    let mstkerr = (cfsr & 0x10) == 0x10;
+    let mlsperr = (cfsr & 0x20) == 0x20;
+    let mmfarvalid = (cfsr & 0x80) == 0x80;
+
+    let ibuserr = ((cfsr >> 8) & 0x01) == 0x01;
+    let preciserr = ((cfsr >> 8) & 0x02) == 0x02;
+    let impreciserr = ((cfsr >> 8) & 0x04) == 0x04;
+    let unstkerr = ((cfsr >> 8) & 0x08) == 0x08;
+    let stkerr = ((cfsr >> 8) & 0x10) == 0x10;
+    let lsperr = ((cfsr >> 8) & 0x20) == 0x20;
+    let bfarvalid = ((cfsr >> 8) & 0x80) == 0x80;
+
+    let undefinstr = ((cfsr >> 16) & 0x01) == 0x01;
+    let invstate = ((cfsr >> 16) & 0x02) == 0x02;
+    let invpc = ((cfsr >> 16) & 0x04) == 0x04;
+    let nocp = ((cfsr >> 16) & 0x08) == 0x08;
+    let unaligned = ((cfsr >> 16) & 0x100) == 0x100;
+    let divbysero = ((cfsr >> 16) & 0x200) == 0x200;
+
+    let vecttbl = (hfsr & 0x02) == 0x02;
+    let forced = (hfsr & 0x40000000) == 0x40000000;
+
+    let ici_it = (((stacked_xpsr >> 25) & 0x3) << 6) | ((stacked_xpsr >> 10) & 0x3f);
+    let thumb_bit = ((stacked_xpsr >> 24) & 0x1) == 1;
+    let exception_number = (stacked_xpsr & 0x1ff) as usize;
+
+    panic!(
+        "{} HardFault.\r\n\
+         \tKernel version {}\r\n\
+         \tr0  0x{:x}\r\n\
+         \tr1  0x{:x}\r\n\
+         \tr2  0x{:x}\r\n\
+         \tr3  0x{:x}\r\n\
+         \tr12 0x{:x}\r\n\
+         \tlr  0x{:x}\r\n\
+         \tpc  0x{:x}\r\n\
+         \tprs 0x{:x} [ N {} Z {} C {} V {} Q {} GE {}{}{}{} ; ICI.IT {} T {} ; Exc {}-{} ]\r\n\
+         \tsp  0x{:x}\r\n\
+         \ttop of stack     0x{:x}\r\n\
+         \tbottom of stack  0x{:x}\r\n\
+         \tSHCSR 0x{:x}\r\n\
+         \tCFSR  0x{:x}\r\n\
+         \tHSFR  0x{:x}\r\n\
+         \tInstruction Access Violation:       {}\r\n\
+         \tData Access Violation:              {}\r\n\
+         \tMemory Management Unstacking Fault: {}\r\n\
+         \tMemory Management Stacking Fault:   {}\r\n\
+         \tMemory Management Lazy FP Fault:    {}\r\n\
+         \tInstruction Bus Error:              {}\r\n\
+         \tPrecise Data Bus Error:             {}\r\n\
+         \tImprecise Data Bus Error:           {}\r\n\
+         \tBus Unstacking Fault:               {}\r\n\
+         \tBus Stacking Fault:                 {}\r\n\
+         \tBus Lazy FP Fault:                  {}\r\n\
+         \tUndefined Instruction Usage Fault:  {}\r\n\
+         \tInvalid State Usage Fault:          {}\r\n\
+         \tInvalid PC Load Usage Fault:        {}\r\n\
+         \tNo Coprocessor Usage Fault:         {}\r\n\
+         \tUnaligned Access Usage Fault:       {}\r\n\
+         \tDivide By Zero:                     {}\r\n\
+         \tBus Fault on Vector Table Read:     {}\r\n\
+         \tForced Hard Fault:                  {}\r\n\
+         \tFaulting Memory Address: (valid: {}) {:#010X}\r\n\
+         \tBus Fault Address:       (valid: {}) {:#010X}\r\n\
+         ",
+        mode_str,
+        env!("TOCK_KERNEL_VERSION"),
+        stacked_r0,
+        stacked_r1,
+        stacked_r2,
+        stacked_r3,
+        stacked_r12,
+        stacked_lr,
+        stacked_pc,
+        stacked_xpsr,
+        (stacked_xpsr >> 31) & 0x1,
+        (stacked_xpsr >> 30) & 0x1,
+        (stacked_xpsr >> 29) & 0x1,
+        (stacked_xpsr >> 28) & 0x1,
+        (stacked_xpsr >> 27) & 0x1,
+        (stacked_xpsr >> 19) & 0x1,
+        (stacked_xpsr >> 18) & 0x1,
+        (stacked_xpsr >> 17) & 0x1,
+        (stacked_xpsr >> 16) & 0x1,
+        ici_it,
+        thumb_bit,
+        exception_number,
+        ipsr_isr_number_to_str(exception_number),
+        faulting_stack as u32,
+        (_estack as *const ()) as u32,
+        (&_ezero as *const u32) as u32,
+        shcsr,
+        cfsr,
+        hfsr,
+        iaccviol,
+        daccviol,
+        munstkerr,
+        mstkerr,
+        mlsperr,
+        ibuserr,
+        preciserr,
+        impreciserr,
+        unstkerr,
+        stkerr,
+        lsperr,
+        undefinstr,
+        invstate,
+        invpc,
+        nocp,
+        unaligned,
+        divbysero,
+        vecttbl,
+        forced,
+        mmfarvalid,
+        mmfar,
+        bfarvalid,
+        bfar
+    );
+}
+
+#[naked]
+pub unsafe extern "C" fn hard_fault_handler() {
     let faulting_stack: *mut u32;
     let kernel_stack: bool;
 
@@ -202,148 +346,11 @@ pub unsafe extern "C" fn hard_fault_handler() {
         : "={r0}"(faulting_stack), "={r1}"(kernel_stack)
         :
         : "r0", "r1"
-        :
+        : "volatile"
         );
 
     if kernel_stack {
-        let stacked_r0: u32 = *offset(faulting_stack, 0);
-        let stacked_r1: u32 = *offset(faulting_stack, 1);
-        let stacked_r2: u32 = *offset(faulting_stack, 2);
-        let stacked_r3: u32 = *offset(faulting_stack, 3);
-        let stacked_r12: u32 = *offset(faulting_stack, 4);
-        let stacked_lr: u32 = *offset(faulting_stack, 5);
-        let stacked_pc: u32 = *offset(faulting_stack, 6);
-        let stacked_xpsr: u32 = *offset(faulting_stack, 7);
-
-        let mode_str = "Kernel";
-
-        let shcsr: u32 = core::ptr::read_volatile(0xE000ED24 as *const u32);
-        let cfsr: u32 = core::ptr::read_volatile(0xE000ED28 as *const u32);
-        let hfsr: u32 = core::ptr::read_volatile(0xE000ED2C as *const u32);
-        let mmfar: u32 = core::ptr::read_volatile(0xE000ED34 as *const u32);
-        let bfar: u32 = core::ptr::read_volatile(0xE000ED38 as *const u32);
-
-        let iaccviol = (cfsr & 0x01) == 0x01;
-        let daccviol = (cfsr & 0x02) == 0x02;
-        let munstkerr = (cfsr & 0x08) == 0x08;
-        let mstkerr = (cfsr & 0x10) == 0x10;
-        let mlsperr = (cfsr & 0x20) == 0x20;
-        let mmfarvalid = (cfsr & 0x80) == 0x80;
-
-        let ibuserr = ((cfsr >> 8) & 0x01) == 0x01;
-        let preciserr = ((cfsr >> 8) & 0x02) == 0x02;
-        let impreciserr = ((cfsr >> 8) & 0x04) == 0x04;
-        let unstkerr = ((cfsr >> 8) & 0x08) == 0x08;
-        let stkerr = ((cfsr >> 8) & 0x10) == 0x10;
-        let lsperr = ((cfsr >> 8) & 0x20) == 0x20;
-        let bfarvalid = ((cfsr >> 8) & 0x80) == 0x80;
-
-        let undefinstr = ((cfsr >> 16) & 0x01) == 0x01;
-        let invstate = ((cfsr >> 16) & 0x02) == 0x02;
-        let invpc = ((cfsr >> 16) & 0x04) == 0x04;
-        let nocp = ((cfsr >> 16) & 0x08) == 0x08;
-        let unaligned = ((cfsr >> 16) & 0x100) == 0x100;
-        let divbysero = ((cfsr >> 16) & 0x200) == 0x200;
-
-        let vecttbl = (hfsr & 0x02) == 0x02;
-        let forced = (hfsr & 0x40000000) == 0x40000000;
-
-        let ici_it = (((stacked_xpsr >> 25) & 0x3) << 6) | ((stacked_xpsr >> 10) & 0x3f);
-        let thumb_bit = ((stacked_xpsr >> 24) & 0x1) == 1;
-        let exception_number = (stacked_xpsr & 0x1ff) as usize;
-
-        panic!(
-            "{} HardFault.\r\n\
-             \tKernel version {}\r\n\
-             \tr0  0x{:x}\r\n\
-             \tr1  0x{:x}\r\n\
-             \tr2  0x{:x}\r\n\
-             \tr3  0x{:x}\r\n\
-             \tr12 0x{:x}\r\n\
-             \tlr  0x{:x}\r\n\
-             \tpc  0x{:x}\r\n\
-             \tprs 0x{:x} [ N {} Z {} C {} V {} Q {} GE {}{}{}{} ; ICI.IT {} T {} ; Exc {}-{} ]\r\n\
-             \tsp  0x{:x}\r\n\
-             \ttop of stack     0x{:x}\r\n\
-             \tbottom of stack  0x{:x}\r\n\
-             \tSHCSR 0x{:x}\r\n\
-             \tCFSR  0x{:x}\r\n\
-             \tHSFR  0x{:x}\r\n\
-             \tInstruction Access Violation:       {}\r\n\
-             \tData Access Violation:              {}\r\n\
-             \tMemory Management Unstacking Fault: {}\r\n\
-             \tMemory Management Stacking Fault:   {}\r\n\
-             \tMemory Management Lazy FP Fault:    {}\r\n\
-             \tInstruction Bus Error:              {}\r\n\
-             \tPrecise Data Bus Error:             {}\r\n\
-             \tImprecise Data Bus Error:           {}\r\n\
-             \tBus Unstacking Fault:               {}\r\n\
-             \tBus Stacking Fault:                 {}\r\n\
-             \tBus Lazy FP Fault:                  {}\r\n\
-             \tUndefined Instruction Usage Fault:  {}\r\n\
-             \tInvalid State Usage Fault:          {}\r\n\
-             \tInvalid PC Load Usage Fault:        {}\r\n\
-             \tNo Coprocessor Usage Fault:         {}\r\n\
-             \tUnaligned Access Usage Fault:       {}\r\n\
-             \tDivide By Zero:                     {}\r\n\
-             \tBus Fault on Vector Table Read:     {}\r\n\
-             \tForced Hard Fault:                  {}\r\n\
-             \tFaulting Memory Address: (valid: {}) {:#010X}\r\n\
-             \tBus Fault Address:       (valid: {}) {:#010X}\r\n\
-             ",
-            mode_str,
-            env!("TOCK_KERNEL_VERSION"),
-            stacked_r0,
-            stacked_r1,
-            stacked_r2,
-            stacked_r3,
-            stacked_r12,
-            stacked_lr,
-            stacked_pc,
-            stacked_xpsr,
-            (stacked_xpsr >> 31) & 0x1,
-            (stacked_xpsr >> 30) & 0x1,
-            (stacked_xpsr >> 29) & 0x1,
-            (stacked_xpsr >> 28) & 0x1,
-            (stacked_xpsr >> 27) & 0x1,
-            (stacked_xpsr >> 19) & 0x1,
-            (stacked_xpsr >> 18) & 0x1,
-            (stacked_xpsr >> 17) & 0x1,
-            (stacked_xpsr >> 16) & 0x1,
-            ici_it,
-            thumb_bit,
-            exception_number,
-            ipsr_isr_number_to_str(exception_number),
-            faulting_stack as u32,
-            (_estack as *const ()) as u32,
-            (&_ezero as *const u32) as u32,
-            shcsr,
-            cfsr,
-            hfsr,
-            iaccviol,
-            daccviol,
-            munstkerr,
-            mstkerr,
-            mlsperr,
-            ibuserr,
-            preciserr,
-            impreciserr,
-            unstkerr,
-            stkerr,
-            lsperr,
-            undefinstr,
-            invstate,
-            invpc,
-            nocp,
-            unaligned,
-            divbysero,
-            vecttbl,
-            forced,
-            mmfarvalid,
-            mmfar,
-            bfarvalid,
-            bfar
-        );
+        kernel_hardfault(faulting_stack);
     } else {
         // hard fault occurred in an app, not the kernel. The app should be
         //  marked as in an error state and handled by the kernel
@@ -372,7 +379,7 @@ pub unsafe extern "C" fn hard_fault_handler() {
 
               movw LR, #0xFFF9
               movt LR, #0xFFFF"
-        );
+        : : : : "volatile" );
     }
 }
 

--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -354,6 +354,10 @@ impl Kernel {
                             // break to handle other processes.
                             break;
                         }
+                        Some(ContextSwitchReason::Interrupted) => {
+                            // break to handle other processes.
+                            break;
+                        }
                         None => {
                             // Something went wrong when switching to this
                             // process. Indicate this by putting it in a fault

--- a/kernel/src/syscall.rs
+++ b/kernel/src/syscall.rs
@@ -58,6 +58,8 @@ pub enum ContextSwitchReason {
     Fault,
     /// Process exceeded its timeslice.
     TimesliceExpired,
+    /// Process interrupted (e.g. by a hardware event)
+    Interrupted,
 }
 
 /// This trait must be implemented by the architecture of the chip Tock is


### PR DESCRIPTION
### Pull Request Overview

Closes #1160 

This pull request fixes a bug in the context switching code that appears under certain circumstances where the compiler reorders volatile writes before inline assembly (which was _not_ marked volatile). The fix is to mark them volatile as well as move the non-assembly code in hardfault_handler to a separate function so we can make `hardfault_handler` `naked` like the other ISRs.

This can lead to defer execution of system calls or handling of faults which _seems_ to interact in such a way that sometimes app code faults.

At a high level, the code to determine why a process was interrupted (e.g. for a system call, timeslice, or fault) were moved to _before_ context switching to the app, so the kernel always thought the switch was due to whatever the _previous_ reason was.

This change also adds a new context switch condition, `Interrupted`, to distinguish cases where the context switch was due to an ISR (and it is used as the default case). I believe this is unrelated to the fix, but is meaningful and was helpful when I was debugging.

### Testing Strategy

@hudson-ayers, @lthiery, and @hchiang tested that this fixes the bugs we were seeing. I also looked carefully at the resulting assembly.

### TODO or Help Wanted

- [x] Replicate fixes for other architectures (Cortex-M0 & Cortex-M3)

### Documentation Updated

- [x] ~~Updated the relevant files in `/docs`, or no updates are required.~~

### Formatting

- [x] Ran `make formatall`.
