### PR TITLE
kernel: make user-kernel boundary in Chip

### DIFF
--- a/boards/ek-tm4c1294xl/src/main.rs
+++ b/boards/ek-tm4c1294xl/src/main.rs
@@ -16,7 +16,6 @@ use capsules::virtual_uart::{UartDevice, UartMux};
 use kernel::capabilities;
 use kernel::hil;
 use kernel::hil::Controller;
-use kernel::Chip;
 use kernel::Platform;
 
 #[macro_use]
@@ -255,8 +254,7 @@ pub unsafe fn reset_handler() {
     }
     kernel::procs::load_processes(
         board_kernel,
-        &cortexm4::syscall::SysCall::new(),
-        chip.mpu(),
+        chip,
         &_sapps as *const u8,
         &mut APP_MEMORY,
         &mut PROCESSES,

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -25,7 +25,6 @@ use kernel::hil::entropy::Entropy32;
 use kernel::hil::rng::Rng;
 use kernel::hil::spi::SpiMaster;
 use kernel::hil::Controller;
-use kernel::Chip;
 use kernel::Platform;
 
 /// Support routines for debugging I/O.
@@ -598,8 +597,7 @@ pub unsafe fn reset_handler() {
 
     kernel::procs::load_processes(
         board_kernel,
-        &cortexm4::syscall::SysCall::new(),
-        chip.mpu(),
+        chip,
         &_sapps as *const u8,
         &mut APP_MEMORY,
         &mut PROCESSES,

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -33,7 +33,6 @@ use kernel::hil::radio;
 use kernel::hil::radio::{RadioConfig, RadioData};
 use kernel::hil::spi::SpiMaster;
 use kernel::hil::Controller;
-use kernel::Chip;
 
 use components::adc::AdcComponent;
 use components::alarm::AlarmDriverComponent;
@@ -441,8 +440,7 @@ pub unsafe fn reset_handler() {
     }
     kernel::procs::load_processes(
         board_kernel,
-        &cortexm4::syscall::SysCall::new(),
-        chip.mpu(),
+        chip,
         &_sapps as *const u8,
         &mut APP_MEMORY,
         &mut PROCESSES,

--- a/boards/launchxl/src/main.rs
+++ b/boards/launchxl/src/main.rs
@@ -20,7 +20,6 @@ use kernel::hil;
 use kernel::hil::entropy::Entropy32;
 use kernel::hil::i2c::I2CMaster;
 use kernel::hil::rng::Rng;
-use kernel::Chip;
 
 #[macro_use]
 pub mod io;
@@ -312,8 +311,7 @@ pub unsafe fn reset_handler() {
 
     kernel::procs::load_processes(
         board_kernel,
-        &cortexm4::syscall::SysCall::new(),
-        chip.mpu(),
+        chip,
         &_sapps as *const u8,
         &mut APP_MEMORY,
         &mut PROCESSES,

--- a/boards/nordic/nrf51dk/src/main.rs
+++ b/boards/nordic/nrf51dk/src/main.rs
@@ -412,8 +412,7 @@ pub unsafe fn reset_handler() {
     }
     kernel::procs::load_processes(
         board_kernel,
-        &cortexm0::syscall::SysCall::new(),
-        chip.mpu(),
+        chip,
         &_sapps as *const u8,
         &mut APP_MEMORY,
         &mut PROCESSES,

--- a/boards/nordic/nrf52dk_base/src/lib.rs
+++ b/boards/nordic/nrf52dk_base/src/lib.rs
@@ -23,7 +23,6 @@ use kernel::capabilities;
 use kernel::hil;
 use kernel::hil::entropy::Entropy32;
 use kernel::hil::rng::Rng;
-use kernel::Chip;
 use nrf5x::rtc::Rtc;
 
 /// Pins for SPI for the flash chip MX25R6435F
@@ -438,8 +437,7 @@ pub unsafe fn setup_board(
     }
     kernel::procs::load_processes(
         board_kernel,
-        &cortexm4::syscall::SysCall::new(),
-        chip.mpu(),
+        chip,
         &_sapps as *const u8,
         app_memory,
         process_pointers,

--- a/chips/cc26x2/src/chip.rs
+++ b/chips/cc26x2/src/chip.rs
@@ -9,6 +9,7 @@ use uart;
 
 pub struct Cc26X2 {
     mpu: cortexm4::mpu::MPU,
+    userspace_kernel_boundary: cortexm4::syscall::SysCall,
     systick: cortexm4::systick::SysTick,
 }
 
@@ -16,6 +17,7 @@ impl Cc26X2 {
     pub unsafe fn new() -> Cc26X2 {
         Cc26X2 {
             mpu: cortexm4::mpu::MPU::new(),
+            userspace_kernel_boundary: cortexm4::syscall::SysCall::new(),
             // The systick clocks with 48MHz by default
             systick: cortexm4::systick::SysTick::new_with_calibration(48 * 1000000),
         }
@@ -24,6 +26,7 @@ impl Cc26X2 {
 
 impl kernel::Chip for Cc26X2 {
     type MPU = cortexm4::mpu::MPU;
+    type UserspaceKernelBoundary = cortexm4::syscall::SysCall;
     type SysTick = cortexm4::systick::SysTick;
 
     fn mpu(&self) -> &Self::MPU {
@@ -33,6 +36,11 @@ impl kernel::Chip for Cc26X2 {
     fn systick(&self) -> &Self::SysTick {
         &self.systick
     }
+
+    fn userspace_kernel_boundary(&self) -> &Self::UserspaceKernelBoundary {
+        &self.userspace_kernel_boundary
+    }
+
     fn service_pending_interrupts(&self) {
         unsafe {
             while let Some(interrupt) = nvic::next_pending() {

--- a/chips/nrf51/src/chip.rs
+++ b/chips/nrf51/src/chip.rs
@@ -7,24 +7,33 @@ use nrf5x::peripheral_interrupts;
 use radio;
 use uart;
 
-pub struct NRF51(());
+pub struct NRF51 {
+    userspace_kernel_boundary: cortexm0::syscall::SysCall,
+}
 
 impl NRF51 {
     pub unsafe fn new() -> NRF51 {
-        NRF51(())
+        NRF51 {
+            userspace_kernel_boundary: cortexm0::syscall::SysCall::new(),
+        }
     }
 }
 
 impl kernel::Chip for NRF51 {
     type MPU = ();
+    type UserspaceKernelBoundary = cortexm0::syscall::SysCall;
     type SysTick = ();
 
     fn mpu(&self) -> &Self::MPU {
-        &self.0
+        &()
     }
 
     fn systick(&self) -> &Self::SysTick {
-        &self.0
+        &()
+    }
+
+    fn userspace_kernel_boundary(&self) -> &cortexm0::syscall::SysCall {
+        &self.userspace_kernel_boundary
     }
 
     fn service_pending_interrupts(&self) {

--- a/chips/nrf52/src/chip.rs
+++ b/chips/nrf52/src/chip.rs
@@ -13,6 +13,7 @@ use uart;
 
 pub struct NRF52 {
     mpu: cortexm4::mpu::MPU,
+    userspace_kernel_boundary: cortexm4::syscall::SysCall,
     systick: cortexm4::systick::SysTick,
 }
 
@@ -20,6 +21,7 @@ impl NRF52 {
     pub unsafe fn new() -> NRF52 {
         NRF52 {
             mpu: cortexm4::mpu::MPU::new(),
+            userspace_kernel_boundary: cortexm4::syscall::SysCall::new(),
             // The NRF52's systick is uncalibrated, but is clocked from the
             // 64Mhz CPU clock.
             systick: cortexm4::systick::SysTick::new_with_calibration(64000000),
@@ -29,6 +31,7 @@ impl NRF52 {
 
 impl kernel::Chip for NRF52 {
     type MPU = cortexm4::mpu::MPU;
+    type UserspaceKernelBoundary = cortexm4::syscall::SysCall;
     type SysTick = cortexm4::systick::SysTick;
 
     fn mpu(&self) -> &Self::MPU {
@@ -37,6 +40,10 @@ impl kernel::Chip for NRF52 {
 
     fn systick(&self) -> &Self::SysTick {
         &self.systick
+    }
+
+    fn userspace_kernel_boundary(&self) -> &Self::UserspaceKernelBoundary {
+        &self.userspace_kernel_boundary
     }
 
     fn service_pending_interrupts(&self) {

--- a/chips/sam4l/src/chip.rs
+++ b/chips/sam4l/src/chip.rs
@@ -22,8 +22,9 @@ use usart;
 use usbc;
 
 pub struct Sam4l {
-    pub mpu: cortexm4::mpu::MPU,
-    pub systick: cortexm4::systick::SysTick,
+    mpu: cortexm4::mpu::MPU,
+    userspace_kernel_boundary: cortexm4::syscall::SysCall,
+    systick: cortexm4::systick::SysTick,
 }
 
 impl Sam4l {
@@ -62,6 +63,7 @@ impl Sam4l {
 
         Sam4l {
             mpu: cortexm4::mpu::MPU::new(),
+            userspace_kernel_boundary: cortexm4::syscall::SysCall::new(),
             systick: cortexm4::systick::SysTick::new(),
         }
     }
@@ -69,6 +71,7 @@ impl Sam4l {
 
 impl Chip for Sam4l {
     type MPU = cortexm4::mpu::MPU;
+    type UserspaceKernelBoundary = cortexm4::syscall::SysCall;
     type SysTick = cortexm4::systick::SysTick;
 
     fn service_pending_interrupts(&self) {
@@ -161,6 +164,10 @@ impl Chip for Sam4l {
 
     fn systick(&self) -> &cortexm4::systick::SysTick {
         &self.systick
+    }
+
+    fn userspace_kernel_boundary(&self) -> &cortexm4::syscall::SysCall {
+        &self.userspace_kernel_boundary
     }
 
     fn sleep(&self) {

--- a/chips/tm4c129x/src/chip.rs
+++ b/chips/tm4c129x/src/chip.rs
@@ -6,14 +6,16 @@ use kernel::Chip;
 use uart;
 
 pub struct Tm4c129x {
-    pub mpu: cortexm4::mpu::MPU,
-    pub systick: cortexm4::systick::SysTick,
+    mpu: cortexm4::mpu::MPU,
+    userspace_kernel_boundary: cortexm4::syscall::SysCall,
+    systick: cortexm4::systick::SysTick,
 }
 
 impl Tm4c129x {
     pub unsafe fn new() -> Tm4c129x {
         Tm4c129x {
             mpu: cortexm4::mpu::MPU::new(),
+            userspace_kernel_boundary: cortexm4::syscall::SysCall::new(),
             systick: cortexm4::systick::SysTick::new(),
         }
     }
@@ -21,6 +23,7 @@ impl Tm4c129x {
 
 impl Chip for Tm4c129x {
     type MPU = cortexm4::mpu::MPU;
+    type UserspaceKernelBoundary = cortexm4::syscall::SysCall;
     type SysTick = cortexm4::systick::SysTick;
 
     fn service_pending_interrupts(&self) {
@@ -56,6 +59,10 @@ impl Chip for Tm4c129x {
 
     fn systick(&self) -> &cortexm4::systick::SysTick {
         &self.systick
+    }
+
+    fn userspace_kernel_boundary(&self) -> &cortexm4::syscall::SysCall {
+        &self.userspace_kernel_boundary
     }
 
     fn sleep(&self) {

--- a/kernel/src/platform/mod.rs
+++ b/kernel/src/platform/mod.rs
@@ -1,6 +1,7 @@
 //! Interface for chips and boards.
 
 use driver::Driver;
+use syscall;
 
 pub mod mpu;
 crate mod systick;
@@ -17,12 +18,14 @@ pub trait Platform {
 /// Interface for individual MCUs.
 pub trait Chip {
     type MPU: mpu::MPU;
+    type UserspaceKernelBoundary: syscall::UserspaceKernelBoundary;
     type SysTick: systick::SysTick;
 
     fn service_pending_interrupts(&self);
     fn has_pending_interrupts(&self) -> bool;
     fn mpu(&self) -> &Self::MPU;
     fn systick(&self) -> &Self::SysTick;
+    fn userspace_kernel_boundary(&self) -> &Self::UserspaceKernelBoundary;
     fn sleep(&self);
     unsafe fn atomic<F, R>(&self, f: F) -> R
     where

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -12,6 +12,7 @@ use common::{Queue, RingBuffer};
 use core::cmp::max;
 use mem::{AppSlice, Shared};
 use platform::mpu::{self, MPU};
+use platform::Chip;
 use returncode::ReturnCode;
 use sched::Kernel;
 use syscall::{self, Syscall, UserspaceKernelBoundary};
@@ -27,10 +28,9 @@ use tbfheader;
 /// number of processes are created, with process structures placed in the
 /// provided array. How process faults are handled by the kernel is also
 /// selected.
-pub fn load_processes<S: UserspaceKernelBoundary, M: MPU>(
+pub fn load_processes<C: Chip>(
     kernel: &'static Kernel,
-    syscall: &'static S,
-    mpu: &'static M,
+    chip: &'static C,
     start_of_flash: *const u8,
     app_memory: &mut [u8],
     procs: &'static mut [Option<&'static ProcessType>],
@@ -44,8 +44,7 @@ pub fn load_processes<S: UserspaceKernelBoundary, M: MPU>(
         unsafe {
             let (process, flash_offset, memory_offset) = Process::create(
                 kernel,
-                syscall,
-                mpu,
+                chip,
                 apps_in_flash_ptr,
                 app_memory_ptr,
                 app_memory_size,
@@ -328,7 +327,7 @@ struct ProcessDebug {
     timeslice_expiration_count: usize,
 }
 
-pub struct Process<'a, S: 'static + UserspaceKernelBoundary, M: 'static + MPU> {
+pub struct Process<'a, C: 'static + Chip> {
     /// Index of the process in the process table.
     ///
     /// Corresponds to AppId
@@ -337,9 +336,12 @@ pub struct Process<'a, S: 'static + UserspaceKernelBoundary, M: 'static + MPU> {
     /// Pointer to the main Kernel struct.
     kernel: &'static Kernel,
 
-    /// Pointer to the struct that handles the architecture-specific syscall
-    /// functions.
-    syscall: &'static S,
+    /// Pointer to the struct that defines the actual chip the kernel is running
+    /// on. This is used because processes have subtle hardware-based
+    /// differences. Specifically, the actual syscall interface and how
+    /// processes are switched to is architecture-specific, and how memory must
+    /// be allocated for memory protection units is also hardware-specific.
+    chip: &'static C,
 
     /// Application memory layout:
     ///
@@ -395,7 +397,8 @@ pub struct Process<'a, S: 'static + UserspaceKernelBoundary, M: 'static + MPU> {
 
     /// State saved on behalf of the process each time the app switches to the
     /// kernel.
-    stored_state: Cell<S::StoredState>,
+    stored_state:
+        Cell<<<C as Chip>::UserspaceKernelBoundary as UserspaceKernelBoundary>::StoredState>,
 
     /// Whether the scheduler can schedule this app.
     state: Cell<State>,
@@ -403,11 +406,8 @@ pub struct Process<'a, S: 'static + UserspaceKernelBoundary, M: 'static + MPU> {
     /// How to deal with Faults occurring in the process
     fault_response: FaultResponse,
 
-    /// Pointer to the MPU
-    mpu: &'static M,
-
     /// Configuration data for the MPU
-    mpu_config: MapCell<M::MpuConfig>,
+    mpu_config: MapCell<<<C as Chip>::MPU as MPU>::MpuConfig>,
 
     /// MPU regions are saved as a pointer-size pair.
     mpu_regions: [Cell<Option<mpu::Region>>; 6],
@@ -423,7 +423,7 @@ pub struct Process<'a, S: 'static + UserspaceKernelBoundary, M: 'static + MPU> {
     debug: MapCell<ProcessDebug>,
 }
 
-impl<S: UserspaceKernelBoundary, M: MPU> ProcessType for Process<'a, S, M> {
+impl<C: Chip> ProcessType for Process<'a, C> {
     fn appid(&self) -> AppId {
         AppId::new(self.kernel, self.app_idx)
     }
@@ -595,7 +595,7 @@ impl<S: UserspaceKernelBoundary, M: MPU> ProcessType for Process<'a, S, M> {
 
     fn setup_mpu(&self) {
         self.mpu_config.map(|config| {
-            self.mpu.configure_mpu(&config);
+            self.chip.mpu().configure_mpu(&config);
         });
     }
 
@@ -606,7 +606,7 @@ impl<S: UserspaceKernelBoundary, M: MPU> ProcessType for Process<'a, S, M> {
         min_region_size: usize,
     ) -> Option<mpu::Region> {
         self.mpu_config.and_then(|mut config| {
-            let new_region = self.mpu.allocate_region(
+            let new_region = self.chip.mpu().allocate_region(
                 unallocated_memory_start,
                 unallocated_memory_size,
                 min_region_size,
@@ -642,7 +642,7 @@ impl<S: UserspaceKernelBoundary, M: MPU> ProcessType for Process<'a, S, M> {
                     Err(Error::AddressOutOfBounds)
                 } else if new_break > self.kernel_memory_break.get() {
                     Err(Error::OutOfMemory)
-                } else if let Err(_) = self.mpu.update_app_memory_region(
+                } else if let Err(_) = self.chip.mpu().update_app_memory_region(
                     new_break,
                     self.kernel_memory_break.get(),
                     mpu::Permissions::ReadWriteExecute,
@@ -652,7 +652,7 @@ impl<S: UserspaceKernelBoundary, M: MPU> ProcessType for Process<'a, S, M> {
                 } else {
                     let old_break = self.app_break.get();
                     self.app_break.set(new_break);
-                    self.mpu.configure_mpu(&mut config);
+                    self.chip.mpu().configure_mpu(&mut config);
                     Ok(old_break)
                 }
             })
@@ -687,7 +687,7 @@ impl<S: UserspaceKernelBoundary, M: MPU> ProcessType for Process<'a, S, M> {
             let new_break = self.kernel_memory_break.get().offset(-(size as isize));
             if new_break < self.app_break.get() {
                 None
-            } else if let Err(_) = self.mpu.update_app_memory_region(
+            } else if let Err(_) = self.chip.mpu().update_app_memory_region(
                 self.app_break.get(),
                 new_break,
                 mpu::Permissions::ReadWriteExecute,
@@ -713,7 +713,7 @@ impl<S: UserspaceKernelBoundary, M: MPU> ProcessType for Process<'a, S, M> {
     }
 
     unsafe fn get_syscall(&self) -> Option<Syscall> {
-        let last_syscall = self.syscall.get_syscall(self.sp());
+        let last_syscall = self.chip.userspace_kernel_boundary().get_syscall(self.sp());
 
         // Record this for debugging purposes.
         self.debug.map(|debug| {
@@ -725,14 +725,16 @@ impl<S: UserspaceKernelBoundary, M: MPU> ProcessType for Process<'a, S, M> {
     }
 
     unsafe fn set_syscall_return_value(&self, return_value: isize) {
-        self.syscall
+        self.chip
+            .userspace_kernel_boundary()
             .set_syscall_return_value(self.sp(), return_value);
     }
 
     unsafe fn pop_syscall_stack_frame(&self) {
         let mut stored_state = self.stored_state.get();
         let new_stack_pointer = self
-            .syscall
+            .chip
+            .userspace_kernel_boundary()
             .pop_syscall_stack_frame(self.sp(), &mut stored_state);
         self.current_stack_pointer
             .set(new_stack_pointer as *const u8);
@@ -750,7 +752,7 @@ impl<S: UserspaceKernelBoundary, M: MPU> ProcessType for Process<'a, S, M> {
         // since we don't know the details of exactly what the stack frames look
         // like.
         let stored_state = self.stored_state.get();
-        match self.syscall.push_function_call(
+        match self.chip.userspace_kernel_boundary().push_function_call(
             self.sp(),
             remaining_stack_bytes,
             callback,
@@ -795,8 +797,10 @@ impl<S: UserspaceKernelBoundary, M: MPU> ProcessType for Process<'a, S, M> {
 
     unsafe fn switch_to(&self) -> Option<syscall::ContextSwitchReason> {
         let mut stored_state = self.stored_state.get();
-        let (stack_pointer, switch_reason) =
-            self.syscall.switch_to_process(self.sp(), &mut stored_state);
+        let (stack_pointer, switch_reason) = self
+            .chip
+            .userspace_kernel_boundary()
+            .switch_to_process(self.sp(), &mut stored_state);
         self.current_stack_pointer.set(stack_pointer as *const u8);
         self.stored_state.set(stored_state);
 
@@ -836,7 +840,7 @@ impl<S: UserspaceKernelBoundary, M: MPU> ProcessType for Process<'a, S, M> {
     }
 
     unsafe fn fault_fmt(&self, writer: &mut Write) {
-        self.syscall.fault_fmt(writer);
+        self.chip.userspace_kernel_boundary().fault_fmt(writer);
     }
 
     unsafe fn process_detail_fmt(&self, writer: &mut Write) {
@@ -953,8 +957,11 @@ impl<S: UserspaceKernelBoundary, M: MPU> ProcessType for Process<'a, S, M> {
   flash_protected_size,
   flash_start));
 
-        self.syscall
-            .process_detail_fmt(self.sp(), &self.stored_state.get(), writer);
+        self.chip.userspace_kernel_boundary().process_detail_fmt(
+            self.sp(),
+            &self.stored_state.get(),
+            writer,
+        );
 
         let _ = writer.write_fmt(format_args!(
             "\
@@ -965,11 +972,10 @@ impl<S: UserspaceKernelBoundary, M: MPU> ProcessType for Process<'a, S, M> {
     }
 }
 
-impl<S: 'static + UserspaceKernelBoundary, M: 'static + MPU> Process<'a, S, M> {
+impl<C: 'static + Chip> Process<'a, C> {
     crate unsafe fn create(
         kernel: &'static Kernel,
-        syscall: &'static S,
-        mpu: &'static M,
+        chip: &'static C,
         app_flash_address: *const u8,
         remaining_app_memory: *mut u8,
         remaining_app_memory_size: usize,
@@ -992,10 +998,10 @@ impl<S: 'static + UserspaceKernelBoundary, M: 'static + MPU> Process<'a, S, M> {
                 app_flash_address.offset(tbf_header.get_init_function_offset() as isize) as usize;
 
             // Initialize MPU region configuration.
-            let mut mpu_config: M::MpuConfig = Default::default();
+            let mut mpu_config: <<C as Chip>::MPU as MPU>::MpuConfig = Default::default();
 
             // Allocate MPU region for flash.
-            if let None = mpu.allocate_region(
+            if let None = chip.mpu().allocate_region(
                 app_flash_address,
                 app_flash_size,
                 app_flash_size,
@@ -1020,7 +1026,7 @@ impl<S: 'static + UserspaceKernelBoundary, M: 'static + MPU> Process<'a, S, M> {
             let callbacks_offset = callback_len * callback_size;
 
             // Make room to store this process's metadata.
-            let process_struct_offset = mem::size_of::<Process<S, M>>();
+            let process_struct_offset = mem::size_of::<Process<C>>();
 
             // Initial sizes of the app-owned and kernel-owned parts of process memory.
             // Provide the app with plenty of initial process accessible memory.
@@ -1036,7 +1042,7 @@ impl<S: 'static + UserspaceKernelBoundary, M: 'static + MPU> Process<'a, S, M> {
             let min_total_memory_size = min_app_ram_size + initial_kernel_memory_size;
 
             // Determine where process memory will go and allocate MPU region for app-owned memory.
-            let (memory_start, memory_size) = match mpu.allocate_app_memory_region(
+            let (memory_start, memory_size) = match chip.mpu().allocate_app_memory_region(
                 remaining_app_memory as *const u8,
                 remaining_app_memory_size,
                 min_total_memory_size,
@@ -1096,12 +1102,12 @@ impl<S: 'static + UserspaceKernelBoundary, M: 'static + MPU> Process<'a, S, M> {
             let mut app_stack_start_pointer = None;
 
             // Create the Process struct in the app grant region.
-            let mut process: &mut Process<S, M> =
-                &mut *(process_struct_memory_location as *mut Process<'static, S, M>);
+            let mut process: &mut Process<C> =
+                &mut *(process_struct_memory_location as *mut Process<'static, C>);
 
             process.app_idx = index;
             process.kernel = kernel;
-            process.syscall = syscall;
+            process.chip = chip;
             process.memory = app_memory;
             process.header = tbf_header;
             process.kernel_memory_break = Cell::new(kernel_memory_break);
@@ -1118,7 +1124,6 @@ impl<S: 'static + UserspaceKernelBoundary, M: 'static + MPU> Process<'a, S, M> {
             process.state = Cell::new(State::Yielded);
             process.fault_response = fault_response;
 
-            process.mpu = mpu;
             process.mpu_config = MapCell::new(mpu_config);
             process.mpu_regions = [
                 Cell::new(None),


### PR DESCRIPTION


### Pull Request Overview

This pull request adds a new trait type to the `Chip` trait that represents the code that handles switching between kernelspace and userspace. Because this is a hardware feature, it makes sense to include it with the chip so that a user doesn't accidentally choose the wrong arch for a given MCU.

```rust
pub trait Chip {
    type MPU: mpu::MPU;
    type UserspaceKernelBoundary: syscall::UserspaceKernelBoundary;
    type SysTick: systick::SysTick;
    ...
```

This also simplifies main.rs as now setting up processes and the kernel only requires passing in the chip.

### Testing Strategy

This pull request was tested by running a hail kernel.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
