### PR TITLE
kernel: Initialize the process app_idx

### DIFF
--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -50,6 +50,7 @@ pub fn load_processes<S: UserspaceKernelBoundary, M: MPU>(
                 app_memory_ptr,
                 app_memory_size,
                 fault_response,
+                i,
             );
 
             if process.is_none() {
@@ -973,6 +974,7 @@ impl<S: 'static + UserspaceKernelBoundary, M: 'static + MPU> Process<'a, S, M> {
         remaining_app_memory: *mut u8,
         remaining_app_memory_size: usize,
         fault_response: FaultResponse,
+        index: usize,
     ) -> (Option<&'static ProcessType>, usize, usize) {
         if let Some(tbf_header) = tbfheader::parse_and_validate_tbf_header(app_flash_address) {
             let app_flash_size = tbf_header.get_total_size() as usize;
@@ -1097,6 +1099,7 @@ impl<S: 'static + UserspaceKernelBoundary, M: 'static + MPU> Process<'a, S, M> {
             let mut process: &mut Process<S, M> =
                 &mut *(process_struct_memory_location as *mut Process<'static, S, M>);
 
+            process.app_idx = index;
             process.kernel = kernel;
             process.syscall = syscall;
             process.memory = app_memory;


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes process.rs to initialize the app_idx for the process. Not doing this causes some weird errors.

It's likely that this was in #1144 at some point, but got accidentally dropped during a rebase as other PRs were merged.


### Testing Strategy

This pull request was tested by running multiple apps on Hail.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
