### PR TITLE
Account for timeslice expiration during syscalls

### DIFF
--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -236,6 +236,8 @@ pub trait ProcessType {
 
     /// Returns how many times this process has exceeded its timeslice.
     fn debug_timeslice_expiration_count(&self) -> usize;
+
+    fn debug_timeslice_expired(&self);
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -861,6 +863,11 @@ impl<C: Chip> ProcessType for Process<'a, C> {
     fn debug_timeslice_expiration_count(&self) -> usize {
         self.debug
             .map_or(0, |debug| debug.timeslice_expiration_count)
+    }
+
+    fn debug_timeslice_expired(&self) {
+        self.debug
+            .map(|debug| debug.timeslice_expiration_count += 1);
     }
 
     unsafe fn fault_fmt(&self, writer: &mut Write) {

--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -243,10 +243,12 @@ impl Kernel {
         systick.enable(true);
 
         loop {
-            if chip.has_pending_interrupts()
-                || systick.overflowed()
-                || !systick.greater_than(MIN_QUANTA_THRESHOLD_US)
-            {
+            if chip.has_pending_interrupts() {
+                break;
+            }
+
+            if systick.overflowed() || !systick.greater_than(MIN_QUANTA_THRESHOLD_US) {
+                process.debug_timeslice_expired();
                 break;
             }
 


### PR DESCRIPTION
This is quick change to the scheduler to count timeslice expirations in the `debug` structure when they happen during a `command` system call.




### Testing Strategy

This pull request was tested by running the `app1` from the sensys 2018 tutorial.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make formatall`.
