### PR TITLE
Sensys Changes to Networking Code

### DIFF
--- a/boards/imix/src/components/udp_6lowpan.rs
+++ b/boards/imix/src/components/udp_6lowpan.rs
@@ -151,9 +151,9 @@ impl Component for UDPComponent {
         );
         ipsender_virtual_alarm.set_client(ip_send);
 
-        // Initially, set src IP of the sender to be the first IP in the Interface
-        // list. Userland apps can change this if they so choose.
-        ip_send.set_addr(self.interface_list[0]);
+        // Set src IP of the sender to be the address configured via the sam4l.
+        // Userland apps can change this if they so choose.
+        ip_send.set_addr(self.interface_list[2]);
         udp_mac.set_transmit_client(ip_send);
 
         let udp_send = static_init!(

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -108,7 +108,7 @@ const NUM_PROCS: usize = 2;
 // onto each device. This makes MAC address configuration a good target for capabilities -
 // only allow one app per board to have control of MAC address configuration?
 const RADIO_CHANNEL: u8 = 26;
-const DST_MAC_ADDR: MacAddress = MacAddress::Short(57330);
+const DST_MAC_ADDR: MacAddress = MacAddress::Short(49138);
 const DEFAULT_CTX_PREFIX_LEN: u8 = 8; //Length of context for 6LoWPAN compression
 const DEFAULT_CTX_PREFIX: [u8; 16] = [0x0 as u8; 16]; //Context for 6LoWPAN Compression
 const PAN_ID: u16 = 0xABCD;

--- a/capsules/src/ieee802154/mac.rs
+++ b/capsules/src/ieee802154/mac.rs
@@ -174,7 +174,7 @@ impl<R: radio::Radio> radio::RxClient for AwakeMac<'a, R> {
         }
 
         if addr_match {
-            debug!("[AwakeMAC] Rcvd a 15.4 frame addressed to this device");
+            //debug!("[AwakeMAC] Rcvd a 15.4 frame addressed to this device");
             self.rx_client.map(move |c| {
                 c.receive(buf, frame_len, crc_valid, result);
             });

--- a/capsules/src/net/ipv6/ipv6_send.rs
+++ b/capsules/src/net/ipv6/ipv6_send.rs
@@ -231,7 +231,9 @@ impl<A: time::Alarm> time::Client for IP6SendStruct<'a, A> {
 impl<A: time::Alarm> TxClient for IP6SendStruct<'a, A> {
     fn send_done(&self, tx_buf: &'static mut [u8], acked: bool, result: ReturnCode) {
         self.tx_buf.replace(tx_buf);
-        debug!("Send result: {:?}, acked: {}", result, acked);
+        if result != ReturnCode::SUCCESS {
+            debug!("Send Failed: {:?}, acked: {}", result, acked);
+        }
         // Below code adds delay between fragments. Despite some efforts
         // to fix this bug, I find that without it the receiving imix cannot
         // receive more than 2 fragments in a single packet without hanging

--- a/capsules/src/net/udp/driver.rs
+++ b/capsules/src/net/udp/driver.rs
@@ -124,15 +124,12 @@ impl<'a> UDPDriver<'a> {
     {
         self.apps
             .enter(appid, |app, _| {
-                app.app_cfg
-                    .take()
-                    .as_ref()
-                    .map_or(ReturnCode::EINVAL, |cfg| {
-                        if cfg.len() != len {
-                            return ReturnCode::EINVAL;
-                        }
-                        closure(cfg.as_ref())
-                    })
+                app.app_cfg.as_ref().map_or(ReturnCode::EINVAL, |cfg| {
+                    if cfg.len() != len {
+                        return ReturnCode::EINVAL;
+                    }
+                    closure(cfg.as_ref())
+                })
             }).unwrap_or_else(|err| err.into())
     }
 
@@ -144,15 +141,12 @@ impl<'a> UDPDriver<'a> {
     {
         self.apps
             .enter(appid, |app, _| {
-                app.app_cfg
-                    .take()
-                    .as_mut()
-                    .map_or(ReturnCode::EINVAL, |cfg| {
-                        if cfg.len() != len {
-                            return ReturnCode::EINVAL;
-                        }
-                        closure(cfg.as_mut())
-                    })
+                app.app_cfg.as_mut().map_or(ReturnCode::EINVAL, |cfg| {
+                    if cfg.len() != len {
+                        return ReturnCode::EINVAL;
+                    }
+                    closure(cfg.as_mut())
+                })
             }).unwrap_or_else(|err| err.into())
     }
 
@@ -167,7 +161,6 @@ impl<'a> UDPDriver<'a> {
         self.apps
             .enter(appid, |app, _| {
                 app.app_rx_cfg
-                    .take()
                     .as_ref()
                     .map_or(ReturnCode::EINVAL, |cfg| closure(cfg.as_ref()))
             }).unwrap_or_else(|err| err.into())
@@ -183,15 +176,12 @@ impl<'a> UDPDriver<'a> {
     {
         self.apps
             .enter(appid, |app, _| {
-                app.app_rx_cfg
-                    .take()
-                    .as_mut()
-                    .map_or(ReturnCode::EINVAL, |cfg| {
-                        if cfg.len() != len {
-                            return ReturnCode::EINVAL;
-                        }
-                        closure(cfg.as_mut())
-                    })
+                app.app_rx_cfg.as_mut().map_or(ReturnCode::EINVAL, |cfg| {
+                    if cfg.len() != len {
+                        return ReturnCode::EINVAL;
+                    }
+                    closure(cfg.as_mut())
+                })
             }).unwrap_or_else(|err| err.into())
     }
 


### PR DESCRIPTION
### Pull Request Overview

This pull request contains the changes from the Sensys tutorial which were necessary to get it to work. The most important change is removing the take() of the config buffers in the UDP driver, which prevented the receiver from ever updating the source IP address of each received packet. It also removes some debug statements from the kernel.


### Testing Strategy

Tested using the Sensys UDP send/receive apps on Imix.


### Documentation Updated

- [x] No updates are required.

### Formatting

- [x] Ran `make formatall`.
