### PR TITLE
Include instructions to erase existing apps in tutorial

### DIFF
--- a/doc/tutorials/01_running_blink.md
+++ b/doc/tutorials/01_running_blink.md
@@ -52,9 +52,16 @@ kernel is installed on your board two options are supported: `program` and
     not alter the kernel, and applications can be re-programed without
     re-programming the kernel.
 
-3. **Load an Application**. For this introduction, we will program the blink
-app. Tockloader supports installing apps from a repository, so installing the
-blink app is simple:
+3. **Load an Application**. First, we need to remove any applications already
+on the board. Note that Tockloader by default will install any application in
+addition to whatever is already installed on the board.
+
+    ```bash
+    tockloader erase-apps
+    ```
+
+    For this introduction, we will program the blink app. Tockloader supports
+    installing apps from a repository, so installing the blink app is simple:
 
     ```bash
     tockloader install blink


### PR DESCRIPTION
### Pull Request Overview

This PR adds a brief instruction to the Blink tutorial informing users that they should erase existing apps before installing Blink. Specifically, the documentation for Hail points at this tutorial and blindly following it leaves you with a non-blinking device (because Hails by default have an old kernel and an old app, updating the kernel leaves the app broken, and then blink doesn't work because the original app still fails).

### Testing Strategy

Reading it and checking that the Markdown was good.


### TODO or Help Wanted

None


### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [N/A] Ran `make formatall`.
