### PR TITLE
make RUSTFLAGS_FOR_CARGO_LINKING redefinable

### DIFF
--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -13,7 +13,7 @@ CARGO ?= cargo
 # lld uses the page size to align program sections. It defaults to 4096 and this
 # puts a gap between before the .relocate section. `zmax-page-size=512` tells
 # lld the actual page size so it doesn't have to be conservative.
-RUSTFLAGS_FOR_CARGO_LINKING := -C link-arg=-Tlayout.ld -C linker=rust-lld \
+RUSTFLAGS_FOR_CARGO_LINKING ?= -C link-arg=-Tlayout.ld -C linker=rust-lld \
 -Z linker-flavor=ld.lld -C relocation-model=dynamic-no-pic \
 -C link-arg=-zmax-page-size=512
 


### PR DESCRIPTION
### Pull Request Overview

This pull request makes a small change to the shared boards Makefile so that `RUSTFLAGS_FOR_CARGO_LINKING` can be customized for a board (like, say, a riscv board).


### Testing Strategy

n/a


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
