### PR TITLE
Fixes architectural decomposition of Cortex-M[34] MPU.

### DIFF
--- a/arch/cortex-m/src/lib.rs
+++ b/arch/cortex-m/src/lib.rs
@@ -8,7 +8,6 @@
 #[macro_use(register_bitfields, register_bitmasks)]
 extern crate kernel;
 
-pub mod mpu;
 pub mod nvic;
 pub mod scb;
 pub mod support;

--- a/arch/cortex-m3/src/lib.rs
+++ b/arch/cortex-m3/src/lib.rs
@@ -10,11 +10,12 @@
 extern crate kernel;
 extern crate cortexm;
 
+pub mod mpu;
+
 // Re-export the base generic cortex-m functions here as they are
 // valid on cortex-m3.
 pub use cortexm::support;
 
-pub use cortexm::mpu;
 pub use cortexm::nvic;
 pub use cortexm::scb;
 pub use cortexm::syscall;

--- a/arch/cortex-m3/src/mpu.rs
+++ b/arch/cortex-m3/src/mpu.rs
@@ -1,4 +1,5 @@
-//! Implementation of the ARM memory protection unit.
+//! Implementation of the memory protection unit for the Cortex-M3 and
+//! Cortex-M4..
 
 use core::cmp;
 use kernel;
@@ -7,8 +8,7 @@ use kernel::common::registers::{FieldValue, ReadOnly, ReadWrite};
 use kernel::common::StaticRef;
 use kernel::mpu;
 
-/// MPU Registers for the Cortex-M4 family
-///
+/// MPU Registers for the Cortex-M[34] families
 /// Described in section 4.5 of
 /// <http://infocenter.arm.com/help/topic/com.arm.doc.dui0553a/DUI0553A_cortex_m4_dgug.pdf>
 #[repr(C)]

--- a/arch/cortex-m4/src/lib.rs
+++ b/arch/cortex-m4/src/lib.rs
@@ -10,11 +10,12 @@
 extern crate kernel;
 extern crate cortexm;
 
+pub mod mpu;
+
 // Re-export the base generic cortex-m functions here as they are
 // valid on cortex-m4.
 pub use cortexm::support;
 
-pub use cortexm::mpu;
 pub use cortexm::nvic;
 pub use cortexm::scb;
 pub use cortexm::syscall;

--- a/arch/cortex-m4/src/mpu.rs
+++ b/arch/cortex-m4/src/mpu.rs
@@ -1,0 +1,1 @@
+../../cortex-m3/src/mpu.rs


### PR DESCRIPTION
This pull request moves the Cortex-M[34] MPU implementation out of arch/cortex-m, where it is incorrect. It moves the MPU implementation into arch/cortex-m3, and creates a symlink from the arch/cortex-m3/src/mpu.rs to arch/cortex-m4/src/mpu.rs. This means there is a single file for both architectures and so the file won't diverge. 

### Pull Request Overview

This pull request fixes the MPU implementation for Cortex-M[34], such that it is not incorrectly usable in other Cortex-M families (e.g., Cortex-M0).


### Testing Strategy

This pull request was tested by compiling, installing, and running applications on h1b and imix.


### TODO or Help Wanted

None.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
