### PR TITLE
doc: note upgrade for pip commands

### DIFF
--- a/boards/hail/README.md
+++ b/boards/hail/README.md
@@ -33,8 +33,8 @@ any standard serial program (set to 115200 baud), Tock ships with the
 install tockloader, use pip:
 
 ```bash
-(Linux): sudo pip3 install tockloader==0.7.1
-(MacOS): pip3 install tockloader==0.7.1
+(Linux): sudo pip3 install --upgrade
+(MacOS): pip3 install --upgrade
 ```
 
 Tockloader can read attributes from connected serial devices, and will

--- a/doc/Getting_Started.md
+++ b/doc/Getting_Started.md
@@ -20,13 +20,13 @@ $ nix-shell
 MacOS:
 ```
 $ curl https://sh.rustup.rs -sSf | sh
-$ pip3 install tockloader
+$ pip3 install --upgrade tockloader
 ```
 
 Ubuntu:
 ```
 $ curl https://sh.rustup.rs -sSf | sh
-$ pip3 install tockloader --user
+$ pip3 install --upgrade tockloader --user
 $ grep -q dialout <(groups $(whoami)) || sudo usermod -a -G dialout $(whoami) # Note, will need to reboot if prompted for password
 ```
 
@@ -70,8 +70,8 @@ Tockloader is a Python application and can be installed with the Python
 package manager (pip).
 
 ```bash
-(Linux): sudo pip3 install tockloader
-(MacOS): pip3 install tockloader
+(Linux): sudo pip3 install --upgrade tockloader
+(MacOS): pip3 install --upgrade tockloader
 ```
 
 ## Compiling the Kernel


### PR DESCRIPTION
### Pull Request Overview

This pull request mirrors what we do in the courses for the rest of the tree, namely to put the `--upgrade` flag on all pip commands to make sure folks are on the latest.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
