### PR TITLE
Imix kernel test cleanup for 1.3 release

### DIFF
--- a/boards/imix/src/aes_ccm_test.rs
+++ b/boards/imix/src/aes_ccm_test.rs
@@ -1,9 +1,3 @@
-use capsules::aes_ccm;
-use capsules::test::aes_ccm::Test;
-use kernel::hil::symmetric_encryption::{AES128, AES128CCM, AES128_BLOCK_SIZE};
-use sam4l::aes::{Aes, AES};
-
-
 //! To run this test, include the code ```
 //!    aes_ccm_test::run();
 //! ```
@@ -16,6 +10,11 @@ use sam4l::aes::{Aes, AES};
 //! aes_ccm_test passed: (current_test=1, encrypting=false, tag_is_valid=true)
 //! aes_ccm_test passed: (current_test=2, encrypting=true, tag_is_valid=true)
 //! aes_ccm_test passed: (current_test=2, encrypting=false, tag_is_valid=true)
+
+use capsules::aes_ccm;
+use capsules::test::aes_ccm::Test;
+use kernel::hil::symmetric_encryption::{AES128, AES128CCM, AES128_BLOCK_SIZE};
+use sam4l::aes::{Aes, AES};
 
 pub unsafe fn run() {
     let ccm = static_init_ccm();

--- a/boards/imix/src/aes_ccm_test.rs
+++ b/boards/imix/src/aes_ccm_test.rs
@@ -1,4 +1,4 @@
-//! To run this test, include the code 
+//! To run this test, include the code
 //! ```
 //!    aes_ccm_test::run();
 //! ```

--- a/boards/imix/src/aes_ccm_test.rs
+++ b/boards/imix/src/aes_ccm_test.rs
@@ -1,4 +1,4 @@
-//! To run this test, include the code i
+//! To run this test, include the code 
 //! ```
 //!    aes_ccm_test::run();
 //! ```

--- a/boards/imix/src/aes_ccm_test.rs
+++ b/boards/imix/src/aes_ccm_test.rs
@@ -1,4 +1,5 @@
-//! To run this test, include the code ```
+//! To run this test, include the code i
+//! ```
 //!    aes_ccm_test::run();
 //! ```
 //! In the boot sequence. If it runs correctly, you should see the following

--- a/boards/imix/src/aes_ccm_test.rs
+++ b/boards/imix/src/aes_ccm_test.rs
@@ -3,6 +3,20 @@ use capsules::test::aes_ccm::Test;
 use kernel::hil::symmetric_encryption::{AES128, AES128CCM, AES128_BLOCK_SIZE};
 use sam4l::aes::{Aes, AES};
 
+
+//! To run this test, include the code ```
+//!    aes_ccm_test::run();
+//! ```
+//! In the boot sequence. If it runs correctly, you should see the following
+//! output:
+//!
+//! aes_ccm_test passed: (current_test=0, encrypting=true, tag_is_valid=true)
+//! aes_ccm_test passed: (current_test=0, encrypting=false, tag_is_valid=true)
+//! aes_ccm_test passed: (current_test=1, encrypting=true, tag_is_valid=true)
+//! aes_ccm_test passed: (current_test=1, encrypting=false, tag_is_valid=true)
+//! aes_ccm_test passed: (current_test=2, encrypting=true, tag_is_valid=true)
+//! aes_ccm_test passed: (current_test=2, encrypting=false, tag_is_valid=true)
+
 pub unsafe fn run() {
     let ccm = static_init_ccm();
     AES.set_client(ccm);

--- a/boards/imix/src/aes_test.rs
+++ b/boards/imix/src/aes_test.rs
@@ -1,3 +1,23 @@
+//! Test that AES (either CTR or CBC mode) is working properly.
+//!
+//! To test CBC mode, add the following line to the imix boot sequence: ```
+//!     aes_test::run_aes128_cbc();
+//! ```
+//! You should see the following output: ```
+//!     aes_test passed (CBC Enc Src/Dst)
+//!     aes_test passed (CBC Dec Src/Dst)
+//!     aes_test passed (CBC Enc In-place)
+//!     aes_test passed (CBC Dec In-place)
+//! ```
+//! To test CTR mode, add the following line to the imix boot sequence: ```
+//!     aes_test::run_aes128_ctr();
+//! ```
+//! You should see the following output: ```
+//!     aes_test CTR passed: (CTR Enc Ctr Src/Dst)
+//!     aes_test CTR passed: (CTR Dec Ctr Src/Dst)
+//! ```
+
+
 use capsules::test::aes::TestAes128Cbc;
 use capsules::test::aes::TestAes128Ctr;
 use kernel::hil::symmetric_encryption::{AES128, AES128_BLOCK_SIZE, AES128_KEY_SIZE};

--- a/boards/imix/src/aes_test.rs
+++ b/boards/imix/src/aes_test.rs
@@ -17,7 +17,6 @@
 //!     aes_test CTR passed: (CTR Dec Ctr Src/Dst)
 //! ```
 
-
 use capsules::test::aes::TestAes128Cbc;
 use capsules::test::aes::TestAes128Ctr;
 use kernel::hil::symmetric_encryption::{AES128, AES128_BLOCK_SIZE, AES128_KEY_SIZE};

--- a/boards/imix/src/aes_test.rs
+++ b/boards/imix/src/aes_test.rs
@@ -1,21 +1,21 @@
 //! Test that AES (either CTR or CBC mode) is working properly.
 //!
-//! To test CBC mode, add the following line to the imix boot sequence: 
+//! To test CBC mode, add the following line to the imix boot sequence:
 //! ```
 //!     aes_test::run_aes128_cbc();
 //! ```
-//! You should see the following output: 
+//! You should see the following output:
 //! ```
 //!     aes_test passed (CBC Enc Src/Dst)
 //!     aes_test passed (CBC Dec Src/Dst)
 //!     aes_test passed (CBC Enc In-place)
 //!     aes_test passed (CBC Dec In-place)
 //! ```
-//! To test CTR mode, add the following line to the imix boot sequence: 
+//! To test CTR mode, add the following line to the imix boot sequence:
 //! ```
 //!     aes_test::run_aes128_ctr();
 //! ```
-//! You should see the following output: 
+//! You should see the following output:
 //! ```
 //!     aes_test CTR passed: (CTR Enc Ctr Src/Dst)
 //!     aes_test CTR passed: (CTR Dec Ctr Src/Dst)

--- a/boards/imix/src/aes_test.rs
+++ b/boards/imix/src/aes_test.rs
@@ -1,18 +1,22 @@
 //! Test that AES (either CTR or CBC mode) is working properly.
 //!
-//! To test CBC mode, add the following line to the imix boot sequence: ```
+//! To test CBC mode, add the following line to the imix boot sequence: 
+//! ```
 //!     aes_test::run_aes128_cbc();
 //! ```
-//! You should see the following output: ```
+//! You should see the following output: 
+//! ```
 //!     aes_test passed (CBC Enc Src/Dst)
 //!     aes_test passed (CBC Dec Src/Dst)
 //!     aes_test passed (CBC Enc In-place)
 //!     aes_test passed (CBC Dec In-place)
 //! ```
-//! To test CTR mode, add the following line to the imix boot sequence: ```
+//! To test CTR mode, add the following line to the imix boot sequence: 
+//! ```
 //!     aes_test::run_aes128_ctr();
 //! ```
-//! You should see the following output: ```
+//! You should see the following output: 
+//! ```
 //!     aes_test CTR passed: (CTR Enc Ctr Src/Dst)
 //!     aes_test CTR passed: (CTR Dec Ctr Src/Dst)
 //! ```

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -475,7 +475,6 @@ pub unsafe fn reset_handler() {
 
     debug!("Initialization complete. Entering main loop");
 
-
     extern "C" {
         /// Beginning of the ROM region containing app images.
         static _sapps: u8;

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -117,7 +117,7 @@ const PAN_ID: u16 = 0xABCD;
 const FAULT_RESPONSE: kernel::procs::FaultResponse = kernel::procs::FaultResponse::Panic;
 
 #[link_section = ".app_memory"]
-static mut APP_MEMORY: [u8; 16384] = [0; 16384];
+static mut APP_MEMORY: [u8; 32768] = [0; 32768];
 
 static mut PROCESSES: [Option<&'static kernel::procs::ProcessType>; NUM_PROCS] = [None, None];
 
@@ -371,10 +371,6 @@ pub unsafe fn reset_handler() {
         RADIO_CHANNEL,
     ).finalize();
 
-    // Clear sensors enable pin to enable sensor rail
-    // sam4l::gpio::PC[16].enable_output();
-    // sam4l::gpio::PC[16].clear();
-
     let adc = AdcComponent::new().finalize();
     let gpio = GpioComponent::new().finalize();
     let led = LedComponent::new().finalize();
@@ -383,12 +379,13 @@ pub unsafe fn reset_handler() {
     let analog_comparator = AcComponent::new().finalize();
     let rng = RngComponent::new(board_kernel).finalize();
 
-    // For now, assign the MAC address on the device as simply a 16-bit short address which represents
-    // the last 16 bits of the serial number of the sam4l for this device.
-    // In the future, we could generate the MAC address by hashing the full 120-bit serial number
+    // For now, assign the 802.15.4 MAC address on the device as
+    // simply a 16-bit short address which represents the last 16 bits
+    // of the serial number of the sam4l for this device.  In the
+    // future, we could generate the MAC address by hashing the full
+    // 120-bit serial number
     let serial_num: sam4l::serial_num::SerialNum = sam4l::serial_num::SerialNum::new();
     let serial_num_bottom_16 = (serial_num.get_lower_64() & 0x0000_0000_0000_ffff) as u16;
-
     let src_mac_from_serial_num: MacAddress = MacAddress::Short(serial_num_bottom_16);
 
     // Can this initialize be pushed earlier, or into component? -pal
@@ -464,11 +461,21 @@ pub unsafe fn reset_handler() {
     imix.pconsole.initialize();
     imix.pconsole.start();
 
-    //    debug!("Starting virtual read test.");
-    //    virtual_uart_rx_test::run_virtual_uart_receive(uart_mux);
+    // Optional kernel tests. Note that these might conflict
+    // with normal operation (e.g., steal callbacks from drivers, etc.),
+    // so do not run these and expect all services/applications to work.
+    // Once everything is virtualized in the kernel this won't be a problem.
+    // -pal, 11/20/18
+    //
+    // virtual_uart_rx_test::run_virtual_uart_receive(uart_mux);
+    // rng_test::run_entropy32();
+    // aes_ccm_test::run();
+    // aes_test::run_aes128_ctr();
+    // aes_test::run_aes128_cbc();
+
     debug!("Initialization complete. Entering main loop");
 
-    //    rng_test::run_entropy32();
+
     extern "C" {
         /// Beginning of the ROM region containing app images.
         static _sapps: u8;

--- a/boards/imix/src/rng_test.rs
+++ b/boards/imix/src/rng_test.rs
@@ -4,10 +4,10 @@
 //! ```
 //!     rng_test::run_entropy32();
 //! ```
-//! This test takes a 32-bit entropy generator, puts its output into a 
-//! 32-8 conversion to be an 8-bit generator, puts that output into an 
+//! This test takes a 32-bit entropy generator, puts its output into a
+//! 32-8 conversion to be an 8-bit generator, puts that output into an
 //! 8-to-32 conversion to be a 32-bit generator again, and makes this final
-//! 32-bit entropy source be the tested RNG. This therefore tests not only 
+//! 32-bit entropy source be the tested RNG. This therefore tests not only
 //! the underlying entropy source but also the conversion library.
 //!
 //! The expected output is a series of random numbers that should be

--- a/boards/imix/src/rng_test.rs
+++ b/boards/imix/src/rng_test.rs
@@ -1,9 +1,14 @@
-//! This tests a platform with an underlying 32-bit entropy generator
-//! by taking that generator, putting into a 32-8 conversion to be an
-//! 8-bit generator, putting that into an 8-to-32 conversion to be a
-//! 32-bit generator again, and making that 32-bit entropy source be
-//! the tested RNG. This therefore tests not only the underlying entropy
-//! source but also the conversion library.
+//! This tests an underlying 32-bit entropy generator and the library
+//! transformations between 8-bit and 32-bit entropy. To run this test,
+//! add this line to the imix boot sequence:
+//! ```
+//!     rng_test::run_entropy32();
+//! ```
+//! This test takes a 32-bit entropy generator, puts its output into a 
+//! 32-8 conversion to be an 8-bit generator, puts that output into an 
+//! 8-to-32 conversion to be a 32-bit generator again, and makes this final
+//! 32-bit entropy source be the tested RNG. This therefore tests not only 
+//! the underlying entropy source but also the conversion library.
 //!
 //! The expected output is a series of random numbers that should be
 //! different on each invocation. Rigorous entropy tests are outside

--- a/boards/imix/src/rng_test.rs
+++ b/boards/imix/src/rng_test.rs
@@ -1,15 +1,20 @@
+//! This tests a platform with an underlying 32-bit entropy generator
+//! by taking that generator, putting into a 32-8 conversion to be an
+//! 8-bit generator, putting that into an 8-to-32 conversion to be a
+//! 32-bit generator again, and making that 32-bit entropy source be
+//! the tested RNG. This therefore tests not only the underlying entropy
+//! source but also the conversion library.
+//!
+//! The expected output is a series of random numbers that should be
+//! different on each invocation. Rigorous entropy tests are outside
+//! the scope of this test.
+
 use capsules::rng;
 use capsules::test::rng::TestRng;
 use kernel::hil::entropy::{Entropy32, Entropy8};
 use kernel::hil::rng::Rng;
 use sam4l::trng::TRNG;
 
-/// This tests a platform with an underlying 32-bit entropy generator
-/// by taking that generator, putting into a 32-8 conversion to be an
-/// 8-bit generator, putting that into an 8-to-32 conversion to be a
-/// 32-bit generator again, and making that 32-bit entropy source be
-/// the tested RNG. This therefore tests not only the underlying entropy
-/// source but also the conversion library.
 pub unsafe fn run_entropy32() {
     let t = static_init_test_entropy32();
     t.run();

--- a/boards/imix/src/virtual_uart_rx_test.rs
+++ b/boards/imix/src/virtual_uart_rx_test.rs
@@ -2,7 +2,8 @@
 //! 3-byte and a 7-byte read running in parallel. Test that they are
 //! both working by typing and seeing that they both get all
 //! characters. If you repeatedly type 'a', for example (0x61), you should see
-//! something like: ```
+//! something like: 
+//! ```
 //! Starting receive of length 3
 //! Virtual uart read complete: CommandComplete:
 //! 61
@@ -36,6 +37,7 @@
 //! 61
 //! 61
 //! 61
+//! ```
 
 use capsules::test::virtual_uart::TestVirtualUartReceive;
 use capsules::virtual_uart::{UartDevice, UartMux};

--- a/boards/imix/src/virtual_uart_rx_test.rs
+++ b/boards/imix/src/virtual_uart_rx_test.rs
@@ -1,3 +1,43 @@
+//! Test reception on the virtualized UART.  By default, there is a
+//! 3-byte and a 7-byte read running in parallel. Test that they are
+//! both working by typing and seeing that they both get all
+//! characters. If you repeatedly type 'a', for example (0x61), you should see
+//! something like: ```
+//! Starting receive of length 3
+//! Virtual uart read complete: CommandComplete:
+//! 61
+//! 61
+//! 61
+//! 61
+//! 61
+//! 61
+//! 61
+//! Starting receive of length 7
+//! Virtual uart read complete: CommandComplete:
+//! 61
+//! 61
+//! 61
+//! Starting receive of length 3
+//! Virtual uart read complete: CommandComplete:
+//! 61
+//! 61
+//! 61
+//! Starting receive of length 3
+//! Virtual uart read complete: CommandComplete:
+//! 61
+//! 61
+//! 61
+//! 61
+//! 61
+//! 61
+//! 61
+//! Starting receive of length 7
+//! Virtual uart read complete: CommandComplete:
+//! 61
+//! 61
+//! 61
+
+
 use capsules::test::virtual_uart::TestVirtualUartReceive;
 use capsules::virtual_uart::{UartDevice, UartMux};
 use kernel::hil::uart::UART;

--- a/boards/imix/src/virtual_uart_rx_test.rs
+++ b/boards/imix/src/virtual_uart_rx_test.rs
@@ -37,7 +37,6 @@
 //! 61
 //! 61
 
-
 use capsules::test::virtual_uart::TestVirtualUartReceive;
 use capsules::virtual_uart::{UartDevice, UartMux};
 use kernel::hil::uart::UART;

--- a/boards/imix/src/virtual_uart_rx_test.rs
+++ b/boards/imix/src/virtual_uart_rx_test.rs
@@ -3,11 +3,11 @@
 //! ```
 //!    virtual_uart_rx_test::run_virtual_uart_receive(uart_mux);
 //! ```
-//! to the imix boot sequence, where `uart_mux` is a 
-//! `capsules::virtual_uart::UartMux`.  There is a 3-byte and a 7-byte 
-//! read running in parallel. Test that they are both working by typing 
-//! and seeing that they both get all characters. If you repeatedly 
-//! type 'a', for example (0x61), you should see something like: 
+//! to the imix boot sequence, where `uart_mux` is a
+//! `capsules::virtual_uart::UartMux`.  There is a 3-byte and a 7-byte
+//! read running in parallel. Test that they are both working by typing
+//! and seeing that they both get all characters. If you repeatedly
+//! type 'a', for example (0x61), you should see something like:
 //! ```
 //! Starting receive of length 3
 //! Virtual uart read complete: CommandComplete:

--- a/boards/imix/src/virtual_uart_rx_test.rs
+++ b/boards/imix/src/virtual_uart_rx_test.rs
@@ -1,8 +1,13 @@
-//! Test reception on the virtualized UART.  By default, there is a
-//! 3-byte and a 7-byte read running in parallel. Test that they are
-//! both working by typing and seeing that they both get all
-//! characters. If you repeatedly type 'a', for example (0x61), you should see
-//! something like: 
+//! Test reception on the virtualized UART by creating two readers that
+//! read in parallel. To add this test, include the line
+//! ```
+//!    virtual_uart_rx_test::run_virtual_uart_receive(uart_mux);
+//! ```
+//! to the imix boot sequence, where `uart_mux` is a 
+//! `capsules::virtual_uart::UartMux`.  There is a 3-byte and a 7-byte 
+//! read running in parallel. Test that they are both working by typing 
+//! and seeing that they both get all characters. If you repeatedly 
+//! type 'a', for example (0x61), you should see something like: 
 //! ```
 //! Starting receive of length 3
 //! Virtual uart read complete: CommandComplete:

--- a/capsules/src/test/aes.rs
+++ b/capsules/src/test/aes.rs
@@ -175,7 +175,6 @@ impl<A: AES128<'a> + AES128Ctr> hil::symmetric_encryption::Client<'a> for TestAe
                     "In-place"
                 }
             );
-
         }
         self.aes.disable();
 

--- a/capsules/src/test/aes.rs
+++ b/capsules/src/test/aes.rs
@@ -1,4 +1,4 @@
-//! Test the AES hardware
+//! Test the AES hardware.
 
 use core::cell::Cell;
 use kernel::common::cells::TakeCell;
@@ -155,7 +155,7 @@ impl<A: AES128<'a> + AES128Ctr> hil::symmetric_encryption::Client<'a> for TestAe
             &data[DATA_OFFSET..DATA_OFFSET + DATA_LEN] == expected.as_ref()
         }) {
             debug!(
-                "OK! ({} {} {})",
+                "aes_test CTR passed: (CTR {} {} {})",
                 if self.encrypting.get() { "Enc" } else { "Dec" },
                 "Ctr",
                 if self.use_source.get() {
@@ -165,7 +165,17 @@ impl<A: AES128<'a> + AES128Ctr> hil::symmetric_encryption::Client<'a> for TestAe
                 }
             );
         } else {
-            panic!("FAIL");
+            debug!(
+                "aes_test failed: (CTR {} {} {})",
+                if self.encrypting.get() { "Enc" } else { "Dec" },
+                "Ctr",
+                if self.use_source.get() {
+                    "Src/Dst"
+                } else {
+                    "In-place"
+                }
+            );
+
         }
         self.aes.disable();
 
@@ -236,10 +246,10 @@ impl<A: AES128<'a> + AES128CBC> TestAes128Cbc<'a, A> {
         if !self.use_source.get() {
             // Copy source into dest for in-place encryption
             self.source.map_or_else(
-                || panic!("No source"),
+                || panic!("aes_test: no source"),
                 |source| {
                     self.data.map_or_else(
-                        || panic!("No data"),
+                        || panic!("aes_test: no data"),
                         |data| {
                             for (i, b) in source.iter().enumerate() {
                                 data[DATA_OFFSET + i] = *b;
@@ -295,11 +305,10 @@ impl<A: AES128<'a> + AES128CBC> hil::symmetric_encryption::Client<'a> for TestAe
         };
 
         if self.data.map_or(false, |data| {
-            // panic!("PASS: {:?}", &data[0..DATA_LEN] == expected.as_ref());
             &data[DATA_OFFSET..DATA_OFFSET + DATA_LEN] == expected.as_ref()
         }) {
             debug!(
-                "OK! ({} {})",
+                "aes_test passed (CBC {} {})",
                 if self.encrypting.get() { "Enc" } else { "Dec" },
                 if self.use_source.get() {
                     "Src/Dst"
@@ -308,7 +317,15 @@ impl<A: AES128<'a> + AES128CBC> hil::symmetric_encryption::Client<'a> for TestAe
                 }
             );
         } else {
-            panic!("FAIL");
+            debug!(
+                "aes_test failed: (CBC {} {})",
+                if self.encrypting.get() { "Enc" } else { "Dec" },
+                if self.use_source.get() {
+                    "Src/Dst"
+                } else {
+                    "In-place"
+                }
+            );
         }
         self.aes.disable();
 

--- a/capsules/src/test/aes_ccm.rs
+++ b/capsules/src/test/aes_ccm.rs
@@ -84,7 +84,7 @@ impl<A: AES128CCM<'a>> Test<'a, A> {
         let encrypting = self.encrypting.get();
 
         let buf = match self.buf.take() {
-            None => panic!("Test failed: buffer is not present."),
+            None => panic!("aes_ccm_test failed: buffer is not present."),
             Some(buf) => buf,
         };
 
@@ -99,7 +99,7 @@ impl<A: AES128CCM<'a>> Test<'a, A> {
         if self.aes_ccm.set_key(&KEY) != ReturnCode::SUCCESS
             || self.aes_ccm.set_nonce(&nonce) != ReturnCode::SUCCESS
         {
-            panic!("Test failed: cannot set key or nonce.");
+            panic!("aes_ccm_test failed: cannot set key or nonce.");
         }
 
         let (res, opt_buf) =
@@ -120,7 +120,7 @@ impl<A: AES128CCM<'a>> Test<'a, A> {
         let encrypting = self.encrypting.get();
 
         let buf = match self.buf.take() {
-            None => panic!("Test failed: buffer is not present."),
+            None => panic!("aes_ccm_test failed: buffer is not present."),
             Some(buf) => buf,
         };
 
@@ -135,13 +135,13 @@ impl<A: AES128CCM<'a>> Test<'a, A> {
                 .all(|(a, b)| *a == *b);
             if a_matches && c_matches && tag_is_valid {
                 debug!(
-                    "OK! (current_test={}, encrypting={}, tag_is_valid={})",
+                    "aes_ccm_test passed: (current_test={}, encrypting={}, tag_is_valid={})",
                     self.current_test.get(),
                     self.encrypting.get(),
                     tag_is_valid
                 );
             } else {
-                debug!("Failed: a_matches={}, c_matches={}, (current_test={}, encrypting={}, tag_is_valid={}",
+                debug!("aes_ccm_test failed: a_matches={}, c_matches={}, (current_test={}, encrypting={}, tag_is_valid={}",
                        a_matches,
                        c_matches,
                        self.current_test.get(),
@@ -165,13 +165,13 @@ impl<A: AES128CCM<'a>> Test<'a, A> {
                 .all(|(a, b)| *a == *b);
             if a_matches && m_matches && tag_is_valid {
                 debug!(
-                    "OK! (current_test={}, encrypting={}, tag_is_valid={})",
+                    "aes_ccm_test passed: (current_test={}, encrypting={}, tag_is_valid={})",
                     self.current_test.get(),
                     self.encrypting.get(),
                     tag_is_valid
                 );
             } else {
-                debug!("Failed: a_matches={}, m_matches={}, (current_test={}, encrypting={}, tag_is_valid={}",
+                debug!("aes_ccm_test failed: a_matches={}, m_matches={}, (current_test={}, encrypting={}, tag_is_valid={}",
                        a_matches,
                        m_matches,
                        self.current_test.get(),
@@ -188,7 +188,7 @@ impl<A: AES128CCM<'a>> CCMClient for Test<'a, A> {
     fn crypt_done(&self, buf: &'static mut [u8], res: ReturnCode, tag_is_valid: bool) {
         self.buf.replace(buf);
         if res != ReturnCode::SUCCESS {
-            debug!("Test failed: crypt_done returned {:?}", res);
+            debug!("aes_ccm_test failed: crypt_done returned {:?}", res);
         } else {
             self.check_test(tag_is_valid);
             if self.next_test() {

--- a/capsules/src/test/virtual_uart.rs
+++ b/capsules/src/test/virtual_uart.rs
@@ -1,6 +1,5 @@
 //! Test reception on the virtualized UART: best if multiple Tests are
 //! instantiated and tested in parallel.
-
 use kernel::common::cells::TakeCell;
 use kernel::hil;
 use kernel::hil::uart::Client;


### PR DESCRIPTION
### Pull Request Overview

This pull request cleans up the imix kernel tests; it includes all of them in the boot sequence (commented out) for easy inclusion and adds comments to each of them explaining how to run them and the expected output.


### Testing Strategy

This pull request was tested by running all of the tests successfully.


### TODO or Help Wanted

Nothing.


### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make formatall`.
