### PR TITLE
nrf52[840]dk: correct the ordering of pins

### DIFF
--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -148,7 +148,7 @@ pub unsafe fn reset_handler() {
         LED2_PIN,
         LED3_PIN,
         led_pins,
-        &UartPins::new(UART_RTS, UART_TXD, UART_RXD, UART_CTS),
+        &UartPins::new(UART_RTS, UART_TXD, UART_CTS, UART_RXD),
         &SpiPins::new(SPI_MOSI, SPI_MISO, SPI_CLK),
         &Some(SpiMX25R6435FPins::new(
             SPI_MX25R6435F_CHIP_SELECT,

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -206,7 +206,7 @@ pub unsafe fn reset_handler() {
         LED2_PIN,
         LED3_PIN,
         led_pins,
-        &UartPins::new(UART_RTS, UART_TXD, UART_RXD, UART_CTS),
+        &UartPins::new(UART_RTS, UART_TXD, UART_CTS, UART_RXD),
         &SpiPins::new(SPI_MOSI, SPI_MISO, SPI_CLK),
         &None,
         button_pins,


### PR DESCRIPTION
The RX pin must be specified last for `UartPins::new()`.

https://github.com/tock/tock/blob/1d8cadd4e45698807c1a9d1a7e8f317fd7a197dc/boards/nordic/nrf52dk_base/src/lib.rs#L69-L73


### Testing Strategy

I tried running `console_timeout` on the nrf52840dk and it didn't do anything, and I tracked it down to this. It looks like the fix is also required on the nrf52dk board, but Amit marked the `console_timeout` test as working, so I'm not sure what to make of that.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
