### PR TITLE
LaunchXL Release Changes

### DIFF
--- a/boards/launchxl/src/main.rs
+++ b/boards/launchxl/src/main.rs
@@ -38,7 +38,7 @@ static mut PROCESSES: [Option<&'static kernel::procs::ProcessType>; NUM_PROCS] =
 
 #[link_section = ".app_memory"]
 // Give half of RAM to be dedicated APP memory
-static mut APP_MEMORY: [u8; 0xA000] = [0; 0xA000];
+static mut APP_MEMORY: [u8; 0x10000] = [0; 0x10000];
 
 /// Dummy buffer that causes the linker to reserve enough space for the stack.
 #[no_mangle]

--- a/boards/launchxl/src/main.rs
+++ b/boards/launchxl/src/main.rs
@@ -33,8 +33,8 @@ mod uart_echo;
 const FAULT_RESPONSE: kernel::procs::FaultResponse = kernel::procs::FaultResponse::Panic;
 
 // Number of concurrent processes this platform supports.
-const NUM_PROCS: usize = 2;
-static mut PROCESSES: [Option<&'static kernel::procs::ProcessType>; NUM_PROCS] = [None, None];
+const NUM_PROCS: usize = 3;
+static mut PROCESSES: [Option<&'static kernel::procs::ProcessType>; NUM_PROCS] = [None, None, None];
 
 #[link_section = ".app_memory"]
 // Give half of RAM to be dedicated APP memory
@@ -56,6 +56,7 @@ pub struct Platform {
     >,
     rng: &'static capsules::rng::RngDriver<'static>,
     i2c_master: &'static capsules::i2c_master::I2CMasterDriver<cc26x2::i2c::I2CMaster<'static>>,
+    ipc: kernel::ipc::IPC,
 }
 
 impl kernel::Platform for Platform {
@@ -71,13 +72,14 @@ impl kernel::Platform for Platform {
             capsules::alarm::DRIVER_NUM => f(Some(self.alarm)),
             capsules::rng::DRIVER_NUM => f(Some(self.rng)),
             capsules::i2c_master::DRIVER_NUM => f(Some(self.i2c_master)),
+            kernel::ipc::DRIVER_NUM => f(Some(&self.ipc)),
             _ => f(None),
         }
     }
 }
 
-mod pin_mapping_cc1352p;
-use pin_mapping_cc1352p::PIN_FN;
+mod pin_mapping_cc1312r;
+use pin_mapping_cc1312r::PIN_FN;
 ///
 unsafe fn configure_pins() {
     cc26x2::gpio::PORT[PIN_FN::UART0_RX as usize].enable_uart0_rx();
@@ -290,6 +292,8 @@ pub unsafe fn reset_handler() {
     cc26x2::trng::TRNG.set_client(entropy_to_random);
     entropy_to_random.set_client(rng);
 
+    let ipc = kernel::ipc::IPC::new(board_kernel, &memory_allocation_capability);
+
     let launchxl = Platform {
         console,
         gpio,
@@ -298,6 +302,7 @@ pub unsafe fn reset_handler() {
         alarm,
         rng,
         i2c_master,
+        ipc,
     };
 
     let chip = static_init!(cc26x2::chip::Cc26X2, cc26x2::chip::Cc26X2::new());
@@ -306,8 +311,6 @@ pub unsafe fn reset_handler() {
         /// Beginning of the ROM region containing app images.
         static _sapps: u8;
     }
-
-    let ipc = &kernel::ipc::IPC::new(board_kernel, &memory_allocation_capability);
 
     kernel::procs::load_processes(
         board_kernel,
@@ -319,5 +322,5 @@ pub unsafe fn reset_handler() {
         &process_management_capability,
     );
 
-    board_kernel.kernel_loop(&launchxl, chip, Some(&ipc), &main_loop_capability);
+    board_kernel.kernel_loop(&launchxl, chip, Some(&launchxl.ipc), &main_loop_capability);
 }

--- a/boards/launchxl/src/pin_mapping_cc1312r.rs
+++ b/boards/launchxl/src/pin_mapping_cc1312r.rs
@@ -16,48 +16,48 @@ pub enum PIN_FN {
 }
 }
 
-/// Booster pack standard pinout
-///
-/// 1  -> 3v3
-/// 2  -> DIO23 (analog)
-/// 3  -> DIO3  (UARTRX)
-/// 4  -> DIO2  (UARTTX)
-/// 5  -> DIO22 (GPIO)
-/// 6  -> DIO24 (analog)
-/// 7  -> DIO10 (SPI CLK)
-/// 8  -> DIO21 (GPIO)
-/// 9  -> DIO4  (I2CSCL)
-/// 10 -> DIO5  (I2CSDA)
-///
-/// 11 -> DIO15 (GPIO)
-/// 12 -> DIO14 (SPI CS - other)
-/// 13 -> DIO13 (SPI CS - display)
-/// 14 -> DIO8  (SPI MISO)
-/// 15 -> DIO9  (SPI MOSI)
-/// 16 -> LPRST
-/// 17 -> unused
-/// 18 -> DIO11 (SPI CS - RF)
-/// 19 -> DIO12 (PWM)
-/// 20 -> GND
-///
-/// 21 -> 5v
-/// 22 -> GND
-/// 23 -> DIO25 (analog)
-/// 24 -> DIO26 (analog)
-/// 25 -> DIO17 (analog)
-/// 26 -> DIO28 (analog)
-/// 27 -> DIO29 (analog)
-/// 28 -> DIO30 (analog)
-/// 29 -> DIO0  (GPIO)
-/// 30 -> DIO1  (GPIO)
-///
-/// 31 -> DIO17
-/// 32 -> DIO16
-/// 33 -> TMS
-/// 34 -> TCK
-/// 35 -> BPRST
-/// 36 -> DIO18 (PWM)
-/// 37 -> DIO19 (PWM)
-/// 38 -> DIO20 (PWM)
-/// 39 -> DIO6  (PWM)
-/// 40 -> DIO7  (PWM)
+// Booster pack standard pinout
+//
+// 1  -> 3v3
+// 2  -> DIO23 (analog)
+// 3  -> DIO3  (UARTRX)
+// 4  -> DIO2  (UARTTX)
+// 5  -> DIO22 (GPIO)
+// 6  -> DIO24 (analog)
+// 7  -> DIO10 (SPI CLK)
+// 8  -> DIO21 (GPIO)
+// 9  -> DIO4  (I2CSCL)
+// 10 -> DIO5  (I2CSDA)
+//
+// 11 -> DIO15 (GPIO)
+// 12 -> DIO14 (SPI CS - other)
+// 13 -> DIO13 (SPI CS - display)
+// 14 -> DIO8  (SPI MISO)
+// 15 -> DIO9  (SPI MOSI)
+// 16 -> LPRST
+// 17 -> unused
+// 18 -> DIO11 (SPI CS - RF)
+// 19 -> DIO12 (PWM)
+// 20 -> GND
+//
+// 21 -> 5v
+// 22 -> GND
+// 23 -> DIO25 (analog)
+// 24 -> DIO26 (analog)
+// 25 -> DIO17 (analog)
+// 26 -> DIO28 (analog)
+// 27 -> DIO29 (analog)
+// 28 -> DIO30 (analog)
+// 29 -> DIO0  (GPIO)
+// 30 -> DIO1  (GPIO)
+//
+// 31 -> DIO17
+// 32 -> DIO16
+// 33 -> TMS
+// 34 -> TCK
+// 35 -> BPRST
+// 36 -> DIO18 (PWM)
+// 37 -> DIO19 (PWM)
+// 38 -> DIO20 (PWM)
+// 39 -> DIO6  (PWM)
+// 40 -> DIO7  (PWM)


### PR DESCRIPTION
### Pull Request Overview

Small fixes in LaunchXL based on testing for 1.3.

Specifically:

  * Fix a compilation error in the pin mapping module for the cc26x2

  * Actually _use_ the IPC driver in the board configuration

  * Increase memory for processes. We just weren't allocating much, and it turned out not to be enough for the 32kB required by the Lua test.

### Testing Strategy

Ran the 1.3 tests

### Documentation Updated

- [X] ~~Updated the relevant files in `/docs`, or no updates are required.~~

### Formatting

- [X] Ran `make formatall`.
