### PR TITLE
Fix NRF51 board

### DIFF
--- a/boards/nordic/nrf51dk/chip_layout.ld
+++ b/boards/nordic/nrf51dk/chip_layout.ld
@@ -2,7 +2,7 @@ MEMORY
 {
   rom (rx)  : ORIGIN = 0x00000000, LENGTH = 128K
   prog (rx) : ORIGIN = 0x00020000, LENGTH = 128K
-  ram (rwx) : ORIGIN = 0x20000000, LENGTH = 16K
+  ram (rwx) : ORIGIN = 0x20000000, LENGTH = 32K
 }
 
-MPU_MIN_ALIGN = 8;
+MPU_MIN_ALIGN = 8K;


### PR DESCRIPTION
### Pull Request Overview

Increases available RAM to 32kB---some variants only have 16kB, but
that's not enough to run most of the tests, and the development kits
generally have 32kB.

Fix the board configuration:

  - Have at 3 slots for processes
  - Use more RAM for processes
  - Initialize IPC before `load_processes` (since it needs a grant)
  - Invoke IPC driver

### Testing Strategy

Ran the 1.3 release tests

### Documentation Updated

- [x] ~~Updated the relevant files in `/docs`, or no updates are required.~~

### Formatting

- [x] Ran `make formatall`.
