### PR TITLE
imix: remap LEDs

### DIFF
--- a/boards/imix/src/components/led.rs
+++ b/boards/imix/src/components/led.rs
@@ -31,11 +31,8 @@ impl Component for LedComponent {
 
     unsafe fn finalize(&mut self) -> Self::Output {
         let led_pins = static_init!(
-            [(&'static sam4l::gpio::GPIOPin, led::ActivationMode); 2],
-            [
-                (&sam4l::gpio::PC[22], led::ActivationMode::ActiveHigh),
-                (&sam4l::gpio::PC[10], led::ActivationMode::ActiveHigh),
-            ]
+            [(&'static sam4l::gpio::GPIOPin, led::ActivationMode); 1],
+            [(&sam4l::gpio::PC[10], led::ActivationMode::ActiveHigh),]
         );
         let led = static_init!(
             led::LED<'static, sam4l::gpio::GPIOPin>,

--- a/boards/imix/src/io.rs
+++ b/boards/imix/src/io.rs
@@ -42,7 +42,7 @@ impl Write for Writer {
 #[no_mangle]
 #[panic_implementation]
 pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
-    let led = &mut led::LedLow::new(&mut sam4l::gpio::PC[10]);
+    let led = &mut led::LedLow::new(&mut sam4l::gpio::PC[22]);
     let writer = &mut WRITER;
     debug::panic(&mut [led], writer, pi, &cortexm4::support::nop, &PROCESSES)
 }


### PR DESCRIPTION


### Pull Request Overview

This makes the "kernel" LED only accessible in the kernel, and makes `panic!()` blink the kernel LED (instead of the "user" one).

This change is noted in issue #1205, and likely a change we will want to make anyway, so it's probably better to have it in 1.3 to reduce any potential future confusion.

@phil-levis @hudson-ayers 

### Testing Strategy

This pull request was tested by running blink and mpu_walk_region on imix.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
