### PR TITLE
root makefile: improve listing boards

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,9 @@ usage:
 	@echo "First things first, if you haven't yet, check out doc/Getting_Started."
 	@echo "You'll need to install a few requirements before we get going."
 	@echo
-	@echo "The next step is to choose a board to build Tock for."
-	@echo "Mainline Tock currently includes support for:"
-	@ls -p boards/ | grep '/$$' | cut -d'/' -f1 | xargs echo "  "
+	@echo "The next step is to choose a board to build Tock for. Mainline"
+	@echo "Tock currently includes support for the following platforms:"
+	@for f in `./tools/list_boards.sh`; do printf " - $$f\n"; done
 	@echo
 	@echo "Run 'make' in a board directory to build Tock for that board,"
 	@echo "and usually 'make program' or 'make flash' to load Tock onto hardware."
@@ -27,15 +27,15 @@ usage:
 
 .PHONY: allboards
 allboards:
-	@for f in `./tools/list_boards.sh -1`; do echo "$$(tput bold)Build $$f"; $(MAKE) -C "boards/$$f" || exit 1; done
+	@for f in `./tools/list_boards.sh`; do echo "$$(tput bold)Build $$f"; $(MAKE) -C "boards/$$f" || exit 1; done
 
 .PHONY: allcheck
 allcheck:
-	@for f in `./tools/list_boards.sh -1`; do echo "$$(tput bold)Check $$f"; $(MAKE) -C "boards/$$f" check || exit 1; done
+	@for f in `./tools/list_boards.sh`; do echo "$$(tput bold)Check $$f"; $(MAKE) -C "boards/$$f" check || exit 1; done
 
 .PHONY: alldoc
 alldoc:
-	@for f in `./tools/list_boards.sh -1`; do echo "$$(tput bold)Documenting $$f"; $(MAKE) -C "boards/$$f" doc || exit 1; done
+	@for f in `./tools/list_boards.sh`; do echo "$$(tput bold)Documenting $$f"; $(MAKE) -C "boards/$$f" doc || exit 1; done
 
 .PHONY: ci-travis
 ci-travis:
@@ -89,5 +89,11 @@ fmt format formatall:
 
 .PHONY: list list-boards list-platforms
 list list-boards list-platforms:
-	@./tools/list_boards.sh
+	@echo "Supported Tock Boards:"
+	@for f in `./tools/list_boards.sh`; do printf " - $$f\n"; done
+	@echo
+	@echo "To build the kernel for a particular board, change to that directory"
+	@echo "and run make:"
+	@echo "    cd boards/hail"
+	@echo "    make"
 

--- a/tools/list_boards.sh
+++ b/tools/list_boards.sh
@@ -1,20 +1,5 @@
 #!/usr/bin/env bash
 
-# http://stackoverflow.com/questions/192249/how-do-i-parse-command-line-arguments-in-bash
-oneline=0
-while getopts "h?1" opt; do
-    case "$opt" in
-    h|\?)
-        echo Prints supported tock boards
-        echo ""
-        echo "    -1  One entry per line, for scripting"
-        exit 0
-        ;;
-    1)  oneline=1
-        ;;
-    esac
-done
-
 # Find boards based on folders with Makefiles
 boards=""
 for b in $(find boards | egrep 'Makefile$'); do
@@ -23,15 +8,6 @@ for b in $(find boards | egrep 'Makefile$'); do
     boards+="$b2 "
 done
 
-if [ $oneline -eq 1 ]; then
-    for board in $boards; do
-        echo $board
-    done
-    exit 0
-fi
-
-echo Supported Tock boards: $boards
-echo ""
-echo To build the kernel for a particular board, change to that direcotry
-echo "    cd boards/hail"
-echo "    make"
+for board in $boards; do
+    echo $board
+done


### PR DESCRIPTION
1. Our list of boards in the root makefile wasn't quite correct (didn't account for boards in subdirectories). This updates that.
2. Fix a spelling mistake in list_boards.sh.
3. Simplify list_boards.sh and move the display logic to the makefile with all of the other display text.




### Testing Strategy

I ran `make` and `make list` a few times.


### TODO or Help Wanted
n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
