### PR TITLE
board make: fix version env. variable

### DIFF
--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -50,7 +50,7 @@ Q=@
 VERBOSE =
 endif
 
-export TOCK_KERNEL_VERSION := $(shell git describe --always || echo notgit)
+export TOCK_KERNEL_VERSION := $(shell git describe --always 2> /dev/null || echo "1.3")
 
 
 # Validate that rustup is new enough


### PR DESCRIPTION
### Pull Request Overview

This pull request makes it so that on a downloaded version of tock `fatal: not a git repository (or any of the parent directories): .git` is no longer printed and the correct (at least for this release) version will be included in kernel panics.


### Testing Strategy

Using `$(warning)` to view `TOCK_KERNEL_VERSION`.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
