### PR TITLE
sam4l: fix interrupt setup ordering in usart `receive_automatic`

### DIFF
--- a/chips/sam4l/src/usart.rs
+++ b/chips/sam4l/src/usart.rs
@@ -713,11 +713,12 @@ impl USART {
             .rtor
             .write(RxTimeout::TO.val(timeout as u32));
 
+        // Start the timeout, and we must do this before enabling the interrupt.
+        // This ordering ensures that the interrupt does not fire prematurely.
+        usart.registers.cr.write(Control::STTTO::SET);
+
         // enable timeout interrupt
         usart.registers.ier.write(Interrupt::TIMEOUT::SET);
-
-        // start timeout
-        usart.registers.cr.write(Control::STTTO::SET);
     }
 
     fn disable_rx_timeout(&self, usart: &USARTRegManager) {


### PR DESCRIPTION
There was a bug in the ordering of how `receive_automatic` is implemented on the sam4l. Basically, the interrupt was being enabled before it was cleared, causing it to fire too early and essentially put the driver in a state it didn't expect.


~For some reason setting up `receive_automatic` disables the USART nvic interrupt. This doesn't make any sense, but it seems to be consistent. So, we re-enable it so that if there are no other interrupts in the system things keep working.~




### Testing Strategy

I found this by trying to get AT commands to work, and in particular getting AT command responses to work. I then double checked with the nrf serialization driver, and that exhibited the same behavior.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
