### PR TITLE
kernel: add option to stop app on fault

### DIFF
--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -401,6 +401,10 @@ impl Kernel {
                     break;
                     // Do nothing
                 }
+                process::State::StoppedFaulted => {
+                    break;
+                    // Do nothing
+                }
             }
         }
         systick.reset();


### PR DESCRIPTION
### Pull Request Overview

As a part of #1082 this adds the ability to stop faulty processes. That is, when a process faults, the kernel can put it in a stopped state and it will no longer be scheduled.


### Testing Strategy

This pull request was tested by running crash_dummy on hail, pressing the button to cause it to crash and then using the process console to verify it is in fact in the StoppedFault state.

### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
