### PR TITLE
boards: Add ACD52832

### DIFF
--- a/boards/acd52832/Cargo.lock
+++ b/boards/acd52832/Cargo.lock
@@ -1,0 +1,75 @@
+[[package]]
+name = "acd52832"
+version = "0.1.0"
+dependencies = [
+ "capsules 0.1.0",
+ "cortexm4 0.1.0",
+ "kernel 0.1.0",
+ "nrf52 0.1.0",
+ "nrf5x 0.1.0",
+]
+
+[[package]]
+name = "capsules"
+version = "0.1.0"
+dependencies = [
+ "enum_primitive 0.1.0",
+ "kernel 0.1.0",
+]
+
+[[package]]
+name = "cortexm"
+version = "0.1.0"
+dependencies = [
+ "kernel 0.1.0",
+]
+
+[[package]]
+name = "cortexm4"
+version = "0.1.0"
+dependencies = [
+ "cortexm 0.1.0",
+ "kernel 0.1.0",
+]
+
+[[package]]
+name = "enum_primitive"
+version = "0.1.0"
+
+[[package]]
+name = "kernel"
+version = "0.1.0"
+dependencies = [
+ "tock-cells 0.1.0",
+ "tock-registers 0.2.0",
+]
+
+[[package]]
+name = "nrf52"
+version = "0.1.0"
+dependencies = [
+ "cortexm4 0.1.0",
+ "kernel 0.1.0",
+ "nrf5x 0.1.0",
+ "tock_rt0 0.1.0",
+]
+
+[[package]]
+name = "nrf5x"
+version = "0.1.0"
+dependencies = [
+ "kernel 0.1.0",
+]
+
+[[package]]
+name = "tock-cells"
+version = "0.1.0"
+
+[[package]]
+name = "tock-registers"
+version = "0.2.0"
+
+[[package]]
+name = "tock_rt0"
+version = "0.1.0"
+

--- a/boards/acd52832/Cargo.toml
+++ b/boards/acd52832/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "acd52832"
+version = "0.1.0"
+authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+build = "build.rs"
+
+[profile.dev]
+panic = "abort"
+lto = false
+opt-level = "z"
+debug = true
+
+[profile.release]
+panic = "abort"
+lto = true
+opt-level = "z"
+debug = true
+
+[dependencies]
+cortexm4 = { path = "../../arch/cortex-m4" }
+capsules = { path = "../../capsules" }
+kernel = { path = "../../kernel" }
+nrf52 = { path = "../../chips/nrf52" }
+nrf5x = { path = "../../chips/nrf5x" }

--- a/boards/acd52832/Makefile
+++ b/boards/acd52832/Makefile
@@ -1,0 +1,24 @@
+# Makefile for building the tock kernel for the nRF development kit
+
+TOCK_ARCH=cortex-m4
+TARGET=thumbv7em-none-eabi
+PLATFORM=acd52832
+
+include ../Makefile.common
+
+TOCKLOADER=tockloader
+
+# Where in the SAM4L flash to load the kernel with `tockloader`
+KERNEL_ADDRESS=0x00000
+
+# Upload programs over uart with tockloader
+ifdef PORT
+  TOCKLOADER_GENERAL_FLAGS += --port $(PORT)
+endif
+
+TOCKLOADER_JTAG_FLAGS = --jlink --board nrf52dk
+
+# Upload the kernel over JTAG
+.PHONY: flash
+flash: target/$(TARGET)/release/$(PLATFORM).bin
+	$(TOCKLOADER) $(TOCKLOADER_GENERAL_FLAGS) flash --address $(KERNEL_ADDRESS) $(TOCKLOADER_JTAG_FLAGS) $<

--- a/boards/acd52832/README.md
+++ b/boards/acd52832/README.md
@@ -1,0 +1,44 @@
+Platform-Specific Instructions: ACD52832
+========================================
+
+![acd52832](http://aconno.de/wp-content/uploads/2016/03/img_modul-08.png)
+
+The [ACD52832](http://aconno.de/acd52832/) is a development board based on the
+nRF52832. It includes:
+
+- E-ink display
+- LEDs
+- Buttons
+- Buzzer
+- Temperature sensor
+- IR LED
+- Joystick
+- Potentiometer
+- 2x 60V DC Relays
+- 9DOF sensor
+- Light sensor
+
+## Getting Started
+
+First, follow the [Tock Getting Started guide](../../doc/Getting_Started.md)
+
+JTAG is the preferred method to program. The development kit has an
+integrated JTAG debugger, you simply need to [install JTAG
+software](../../doc/Getting_Started.md#optional-requirements).
+
+## Programming the kernel
+Once you have all software installed, you should be able to simply run
+make flash in this directory to install a fresh kernel.
+
+## Programming user-level applications
+You can program an application via JTAG using Tockloader:
+
+```bash
+$ tockloader install --jlink --board nrf52dk
+```
+
+## TODO
+
+- Implement panic! print in io.rs.
+
+

--- a/boards/acd52832/build.rs
+++ b/boards/acd52832/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    println!("cargo:rerun-if-changed=layout.ld");
+    println!("cargo:rerun-if-changed=../kernel_layout.ld");
+}

--- a/boards/acd52832/layout.ld
+++ b/boards/acd52832/layout.ld
@@ -1,0 +1,11 @@
+/* Memory Space Definitions, 512K flash, 64K ram */
+MEMORY
+{
+  rom (rx)  : ORIGIN = 0x00000000, LENGTH = 128K
+  prog (rx) : ORIGIN = 0x00030000, LENGTH = 384K
+  ram (rwx) : ORIGIN = 0x20000000, LENGTH = 64K
+}
+
+MPU_MIN_ALIGN = 8K;
+
+INCLUDE ../kernel_layout.ld

--- a/boards/acd52832/src/io.rs
+++ b/boards/acd52832/src/io.rs
@@ -1,0 +1,15 @@
+use core::panic::PanicInfo;
+
+use kernel::debug;
+use kernel::hil::led;
+use nrf5x;
+
+/// Panic.
+#[cfg(not(test))]
+#[no_mangle]
+#[panic_handler]
+pub unsafe extern "C" fn panic_fmt(_pi: &PanicInfo) -> ! {
+    const LED1_PIN: usize = 22;
+    let led = &mut led::LedLow::new(&mut nrf5x::gpio::PORT[LED1_PIN]);
+    debug::panic_blink_forever(&mut [led])
+}

--- a/boards/acd52832/src/main.rs
+++ b/boards/acd52832/src/main.rs
@@ -1,0 +1,588 @@
+//! Tock kernel for the Aconno ACD52832 board based on the Nordic nRF52832 MCU.
+
+#![no_std]
+#![no_main]
+#![deny(missing_docs)]
+
+extern crate capsules;
+extern crate cortexm4;
+#[allow(unused_imports)]
+#[macro_use(create_capability, debug, debug_verbose, debug_gpio, static_init)]
+extern crate kernel;
+extern crate nrf52;
+extern crate nrf5x;
+
+use capsules::virtual_alarm::VirtualMuxAlarm;
+use capsules::virtual_uart::{UartDevice, UartMux};
+use kernel::capabilities;
+use kernel::hil;
+use kernel::hil::entropy::Entropy32;
+use kernel::hil::gpio::Pin;
+use kernel::hil::rng::Rng;
+use nrf5x::rtc::Rtc;
+
+const LED1_PIN: usize = 26;
+const LED2_PIN: usize = 22;
+const LED3_PIN: usize = 23;
+const LED4_PIN: usize = 24;
+
+const BUTTON1_PIN: usize = 25;
+const BUTTON2_PIN: usize = 14;
+const BUTTON3_PIN: usize = 15;
+const BUTTON4_PIN: usize = 16;
+const BUTTON_RST_PIN: usize = 19;
+
+/// UART Writer
+#[macro_use]
+pub mod io;
+
+// State for loading and holding applications.
+// How should the kernel respond when a process faults.
+const FAULT_RESPONSE: kernel::procs::FaultResponse = kernel::procs::FaultResponse::Panic;
+
+// Number of concurrent processes this platform supports.
+const NUM_PROCS: usize = 4;
+
+#[link_section = ".app_memory"]
+static mut APP_MEMORY: [u8; 32768] = [0; 32768];
+
+static mut PROCESSES: [Option<&'static kernel::procs::ProcessType>; NUM_PROCS] = [None; NUM_PROCS];
+
+/// Dummy buffer that causes the linker to reserve enough space for the stack.
+#[no_mangle]
+#[link_section = ".stack_buffer"]
+pub static mut STACK_MEMORY: [u8; 0x1000] = [0; 0x1000];
+
+/// Supported drivers by the platform
+pub struct Platform {
+    ble_radio: &'static capsules::ble_advertising_driver::BLE<
+        'static,
+        nrf52::radio::Radio,
+        VirtualMuxAlarm<'static, Rtc>,
+    >,
+    button: &'static capsules::button::Button<'static, nrf5x::gpio::GPIOPin>,
+    console: &'static capsules::console::Console<'static, UartDevice<'static>>,
+    gpio: &'static capsules::gpio::GPIO<'static, nrf5x::gpio::GPIOPin>,
+    led: &'static capsules::led::LED<'static, nrf5x::gpio::GPIOPin>,
+    rng: &'static capsules::rng::RngDriver<'static>,
+    temp: &'static capsules::temperature::TemperatureSensor<'static>,
+    ipc: kernel::ipc::IPC,
+    alarm:
+        &'static capsules::alarm::AlarmDriver<'static, VirtualMuxAlarm<'static, nrf5x::rtc::Rtc>>,
+    gpio_async:
+        &'static capsules::gpio_async::GPIOAsync<'static, capsules::mcp230xx::MCP230xx<'static>>,
+    light: &'static capsules::ambient_light::AmbientLight<'static>,
+    buzzer: &'static capsules::buzzer_driver::Buzzer<
+        'static,
+        capsules::virtual_alarm::VirtualMuxAlarm<'static, nrf5x::rtc::Rtc>,
+    >,
+}
+
+impl kernel::Platform for Platform {
+    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    where
+        F: FnOnce(Option<&kernel::Driver>) -> R,
+    {
+        match driver_num {
+            capsules::console::DRIVER_NUM => f(Some(self.console)),
+            capsules::gpio::DRIVER_NUM => f(Some(self.gpio)),
+            capsules::alarm::DRIVER_NUM => f(Some(self.alarm)),
+            capsules::led::DRIVER_NUM => f(Some(self.led)),
+            capsules::button::DRIVER_NUM => f(Some(self.button)),
+            capsules::rng::DRIVER_NUM => f(Some(self.rng)),
+            capsules::ble_advertising_driver::DRIVER_NUM => f(Some(self.ble_radio)),
+            capsules::temperature::DRIVER_NUM => f(Some(self.temp)),
+            capsules::gpio_async::DRIVER_NUM => f(Some(self.gpio_async)),
+            capsules::ambient_light::DRIVER_NUM => f(Some(self.light)),
+            capsules::buzzer_driver::DRIVER_NUM => f(Some(self.buzzer)),
+            kernel::ipc::DRIVER_NUM => f(Some(&self.ipc)),
+            _ => f(None),
+        }
+    }
+}
+
+/// Entry point in the vector table called on hard reset.
+#[no_mangle]
+pub unsafe fn reset_handler() {
+    // Loads relocations and clears BSS
+    nrf52::init();
+
+    // Create capabilities that the board needs to call certain protected kernel
+    // functions.
+    let process_management_capability =
+        create_capability!(capabilities::ProcessManagementCapability);
+    let main_loop_capability = create_capability!(capabilities::MainLoopCapability);
+    let memory_allocation_capability = create_capability!(capabilities::MemoryAllocationCapability);
+
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
+
+    // GPIOs
+    let gpio_pins = static_init!(
+        [&'static nrf5x::gpio::GPIOPin; 14],
+        [
+            &nrf5x::gpio::PORT[3], // Bottom right header on DK board
+            &nrf5x::gpio::PORT[4],
+            &nrf5x::gpio::PORT[28],
+            &nrf5x::gpio::PORT[29],
+            &nrf5x::gpio::PORT[30],
+            // &nrf5x::gpio::PORT[31], // -----
+            &nrf5x::gpio::PORT[12], // Top mid header on DK board
+            &nrf5x::gpio::PORT[11], // -----
+            &nrf5x::gpio::PORT[27], // Top left header on DK board
+            &nrf5x::gpio::PORT[26],
+            &nrf5x::gpio::PORT[2],
+            &nrf5x::gpio::PORT[25],
+            &nrf5x::gpio::PORT[24],
+            &nrf5x::gpio::PORT[23],
+            &nrf5x::gpio::PORT[22], // -----
+        ]
+    );
+
+    // LEDs
+    let led_pins = static_init!(
+        [(&'static nrf5x::gpio::GPIOPin, capsules::led::ActivationMode); 4],
+        [
+            (
+                &nrf5x::gpio::PORT[LED1_PIN],
+                capsules::led::ActivationMode::ActiveLow
+            ),
+            (
+                &nrf5x::gpio::PORT[LED2_PIN],
+                capsules::led::ActivationMode::ActiveLow
+            ),
+            (
+                &nrf5x::gpio::PORT[LED3_PIN],
+                capsules::led::ActivationMode::ActiveLow
+            ),
+            (
+                &nrf5x::gpio::PORT[LED4_PIN],
+                capsules::led::ActivationMode::ActiveLow
+            ),
+        ]
+    );
+
+    // Setup GPIO pins that correspond to buttons
+    let button_pins = static_init!(
+        [(&'static nrf5x::gpio::GPIOPin, capsules::button::GpioMode); 4],
+        [
+            // 13
+            (
+                &nrf5x::gpio::PORT[BUTTON1_PIN],
+                capsules::button::GpioMode::LowWhenPressed
+            ),
+            // 14
+            (
+                &nrf5x::gpio::PORT[BUTTON2_PIN],
+                capsules::button::GpioMode::LowWhenPressed
+            ),
+            // 15
+            (
+                &nrf5x::gpio::PORT[BUTTON3_PIN],
+                capsules::button::GpioMode::LowWhenPressed
+            ),
+            // 16
+            (
+                &nrf5x::gpio::PORT[BUTTON4_PIN],
+                capsules::button::GpioMode::LowWhenPressed
+            ),
+        ]
+    );
+
+    // Make non-volatile memory writable and activate the reset button
+    let uicr = nrf52::uicr::Uicr::new();
+    nrf52::nvmc::NVMC.erase_uicr();
+    nrf52::nvmc::NVMC.configure_writeable();
+    while !nrf52::nvmc::NVMC.is_ready() {}
+    uicr.set_psel0_reset_pin(BUTTON_RST_PIN);
+    while !nrf52::nvmc::NVMC.is_ready() {}
+    uicr.set_psel1_reset_pin(BUTTON_RST_PIN);
+
+    // Configure kernel debug gpios as early as possible
+    kernel::debug::assign_gpios(
+        Some(&nrf5x::gpio::PORT[LED2_PIN]),
+        Some(&nrf5x::gpio::PORT[LED3_PIN]),
+        Some(&nrf5x::gpio::PORT[LED4_PIN]),
+    );
+
+    //
+    // GPIO Pins
+    //
+    let gpio = static_init!(
+        capsules::gpio::GPIO<'static, nrf5x::gpio::GPIOPin>,
+        capsules::gpio::GPIO::new(gpio_pins)
+    );
+    for pin in gpio_pins.iter() {
+        pin.set_client(gpio);
+    }
+
+    //
+    // LEDs
+    //
+    let led = static_init!(
+        capsules::led::LED<'static, nrf5x::gpio::GPIOPin>,
+        capsules::led::LED::new(led_pins)
+    );
+
+    //
+    // Buttons
+    //
+    let button = static_init!(
+        capsules::button::Button<'static, nrf5x::gpio::GPIOPin>,
+        capsules::button::Button::new(
+            button_pins,
+            board_kernel.create_grant(&memory_allocation_capability)
+        )
+    );
+    for &(btn, _) in button_pins.iter() {
+        use kernel::hil::gpio::PinCtl;
+        btn.set_input_mode(kernel::hil::gpio::InputMode::PullUp);
+        btn.set_client(button);
+    }
+
+    //
+    // RTC for Timers
+    //
+    let rtc = &nrf5x::rtc::RTC;
+    rtc.start();
+    let mux_alarm = static_init!(
+        capsules::virtual_alarm::MuxAlarm<'static, nrf5x::rtc::Rtc>,
+        capsules::virtual_alarm::MuxAlarm::new(&nrf5x::rtc::RTC)
+    );
+    rtc.set_client(mux_alarm);
+
+    //
+    // Timer/Alarm
+    //
+
+    // Virtual alarm for the userspace timers
+    let alarm_driver_virtual_alarm = static_init!(
+        capsules::virtual_alarm::VirtualMuxAlarm<'static, nrf5x::rtc::Rtc>,
+        capsules::virtual_alarm::VirtualMuxAlarm::new(mux_alarm)
+    );
+
+    // Userspace timer driver
+    let alarm = static_init!(
+        capsules::alarm::AlarmDriver<
+            'static,
+            capsules::virtual_alarm::VirtualMuxAlarm<'static, nrf5x::rtc::Rtc>,
+        >,
+        capsules::alarm::AlarmDriver::new(
+            alarm_driver_virtual_alarm,
+            board_kernel.create_grant(&memory_allocation_capability)
+        )
+    );
+    alarm_driver_virtual_alarm.set_client(alarm);
+
+    //
+    // RTT and Console and `debug!()`
+    //
+
+    // Virtual alarm for the Segger RTT communication channel
+    let virtual_alarm_rtt = static_init!(
+        capsules::virtual_alarm::VirtualMuxAlarm<'static, nrf5x::rtc::Rtc>,
+        capsules::virtual_alarm::VirtualMuxAlarm::new(mux_alarm)
+    );
+
+    // RTT communication channel
+    let rtt_memory = static_init!(
+        capsules::segger_rtt::SeggerRttMemory,
+        capsules::segger_rtt::SeggerRttMemory::new(
+            b"Terminal\0",
+            &mut capsules::segger_rtt::UP_BUFFER,
+            b"Terminal\0",
+            &mut capsules::segger_rtt::DOWN_BUFFER
+        )
+    );
+    let rtt = static_init!(
+        capsules::segger_rtt::SeggerRtt<VirtualMuxAlarm<'static, nrf5x::rtc::Rtc>>,
+        capsules::segger_rtt::SeggerRtt::new(
+            virtual_alarm_rtt,
+            rtt_memory,
+            &mut capsules::segger_rtt::UP_BUFFER,
+            &mut capsules::segger_rtt::DOWN_BUFFER
+        )
+    );
+    virtual_alarm_rtt.set_client(rtt);
+
+    //
+    // Virtual UART
+    //
+
+    // Create a shared UART channel for the console and for kernel debug.
+    let uart_mux = static_init!(
+        UartMux<'static>,
+        UartMux::new(rtt, &mut capsules::virtual_uart::RX_BUF, 115200)
+    );
+    kernel::hil::uart::UART::set_client(rtt, uart_mux);
+
+    // Create a UartDevice for the console.
+    let console_uart = static_init!(UartDevice, UartDevice::new(uart_mux, true));
+    console_uart.setup();
+
+    // Create the console object for apps to printf()
+    let console = static_init!(
+        capsules::console::Console<UartDevice>,
+        capsules::console::Console::new(
+            console_uart,
+            115200,
+            &mut capsules::console::WRITE_BUF,
+            &mut capsules::console::READ_BUF,
+            board_kernel.create_grant(&memory_allocation_capability)
+        )
+    );
+    kernel::hil::uart::UART::set_client(console_uart, console);
+
+    // Create virtual device for kernel debug.
+    let debugger_uart = static_init!(UartDevice, UartDevice::new(uart_mux, false));
+    debugger_uart.setup();
+
+    // Create the debugger object that handles calls to `debug!()`
+    let debugger = static_init!(
+        kernel::debug::DebugWriter,
+        kernel::debug::DebugWriter::new(
+            debugger_uart,
+            &mut kernel::debug::OUTPUT_BUF,
+            &mut kernel::debug::INTERNAL_BUF,
+        )
+    );
+    hil::uart::UART::set_client(debugger_uart, debugger);
+
+    // Create the wrapper which helps with rust ownership rules.
+    let debug_wrapper = static_init!(
+        kernel::debug::DebugWriterWrapper,
+        kernel::debug::DebugWriterWrapper::new(debugger)
+    );
+    kernel::debug::set_debug_writer_wrapper(debug_wrapper);
+
+    //
+    // I2C Devices
+    //
+
+    // Create shared mux for the I2C bus
+    let i2c_mux = static_init!(
+        capsules::virtual_i2c::MuxI2C<'static>,
+        capsules::virtual_i2c::MuxI2C::new(&nrf52::i2c::TWIM0)
+    );
+    nrf52::i2c::TWIM0.configure(
+        nrf5x::pinmux::Pinmux::new(21),
+        nrf5x::pinmux::Pinmux::new(20),
+    );
+    nrf52::i2c::TWIM0.set_client(i2c_mux);
+
+    // Configure the MCP23017. Device address 0x20.
+    let mcp23017_i2c = static_init!(
+        capsules::virtual_i2c::I2CDevice,
+        capsules::virtual_i2c::I2CDevice::new(i2c_mux, 0x40)
+    );
+    let mcp23017 = static_init!(
+        capsules::mcp230xx::MCP230xx<'static>,
+        capsules::mcp230xx::MCP230xx::new(
+            mcp23017_i2c,
+            Some(&nrf5x::gpio::PORT[11]),
+            Some(&nrf5x::gpio::PORT[12]),
+            &mut capsules::mcp230xx::BUFFER,
+            8,
+            2
+        )
+    );
+    mcp23017_i2c.set_client(mcp23017);
+    nrf5x::gpio::PORT[11].set_client(mcp23017);
+    nrf5x::gpio::PORT[12].set_client(mcp23017);
+
+    //
+    // GPIO Extenders
+    //
+
+    // Create an array of the GPIO extenders so we can pass them to an
+    // administrative layer that provides a single interface to them all.
+    let async_gpio_ports = static_init!([&'static capsules::mcp230xx::MCP230xx; 1], [mcp23017]);
+
+    // `gpio_async` is the object that manages all of the extenders.
+    let gpio_async = static_init!(
+        capsules::gpio_async::GPIOAsync<'static, capsules::mcp230xx::MCP230xx<'static>>,
+        capsules::gpio_async::GPIOAsync::new(async_gpio_ports)
+    );
+    // Setup the clients correctly.
+    for port in async_gpio_ports.iter() {
+        port.set_client(gpio_async);
+    }
+
+    //
+    // BLE
+    //
+
+    // Virtual alarm for the BLE stack
+    let ble_radio_virtual_alarm = static_init!(
+        capsules::virtual_alarm::VirtualMuxAlarm<'static, nrf5x::rtc::Rtc>,
+        capsules::virtual_alarm::VirtualMuxAlarm::new(mux_alarm)
+    );
+
+    // Setup the BLE radio object that implements the BLE stack
+    let ble_radio = static_init!(
+        capsules::ble_advertising_driver::BLE<
+            'static,
+            nrf52::radio::Radio,
+            VirtualMuxAlarm<'static, Rtc>,
+        >,
+        capsules::ble_advertising_driver::BLE::new(
+            &mut nrf52::radio::RADIO,
+            board_kernel.create_grant(&memory_allocation_capability),
+            &mut capsules::ble_advertising_driver::BUF,
+            ble_radio_virtual_alarm
+        )
+    );
+    kernel::hil::ble_advertising::BleAdvertisementDriver::set_receive_client(
+        &nrf52::radio::RADIO,
+        ble_radio,
+    );
+    kernel::hil::ble_advertising::BleAdvertisementDriver::set_transmit_client(
+        &nrf52::radio::RADIO,
+        ble_radio,
+    );
+    ble_radio_virtual_alarm.set_client(ble_radio);
+
+    //
+    // Temperature
+    //
+
+    // Setup internal temperature sensor
+    let temp = static_init!(
+        capsules::temperature::TemperatureSensor<'static>,
+        capsules::temperature::TemperatureSensor::new(
+            &mut nrf5x::temperature::TEMP,
+            board_kernel.create_grant(&memory_allocation_capability)
+        )
+    );
+    kernel::hil::sensors::TemperatureDriver::set_client(&nrf5x::temperature::TEMP, temp);
+
+    //
+    // RNG
+    //
+
+    // Convert hardware RNG to the Random interface.
+    let entropy_to_random = static_init!(
+        capsules::rng::Entropy32ToRandom<'static>,
+        capsules::rng::Entropy32ToRandom::new(&nrf5x::trng::TRNG)
+    );
+    nrf5x::trng::TRNG.set_client(entropy_to_random);
+
+    // Setup RNG for userspace
+    let rng = static_init!(
+        capsules::rng::RngDriver<'static>,
+        capsules::rng::RngDriver::new(
+            entropy_to_random,
+            board_kernel.create_grant(&memory_allocation_capability)
+        )
+    );
+    entropy_to_random.set_client(rng);
+
+    //
+    // Light Sensor
+    //
+
+    // Setup Analog Light Sensor
+    let analog_light_sensor = static_init!(
+        capsules::analog_sensor::AnalogLightSensor<'static, nrf52::adc::Adc>,
+        capsules::analog_sensor::AnalogLightSensor::new(
+            &nrf52::adc::ADC,
+            &nrf52::adc::AdcChannel::AnalogInput5,
+            capsules::analog_sensor::AnalogLightSensorType::LightDependentResistor,
+        )
+    );
+    nrf52::adc::ADC.set_client(analog_light_sensor);
+
+    // Create userland driver for ambient light sensor
+    let light = static_init!(
+        capsules::ambient_light::AmbientLight<'static>,
+        capsules::ambient_light::AmbientLight::new(
+            analog_light_sensor,
+            board_kernel.create_grant(&memory_allocation_capability)
+        )
+    );
+    hil::sensors::AmbientLight::set_client(analog_light_sensor, light);
+
+    //
+    // PWM
+    //
+    let mux_pwm = static_init!(
+        capsules::virtual_pwm::MuxPwm<'static, nrf52::pwm::Pwm>,
+        capsules::virtual_pwm::MuxPwm::new(&nrf52::pwm::PWM0)
+    );
+    let virtual_pwm_buzzer = static_init!(
+        capsules::virtual_pwm::PwmPinUser<'static, nrf52::pwm::Pwm>,
+        capsules::virtual_pwm::PwmPinUser::new(mux_pwm, nrf5x::pinmux::Pinmux::new(31))
+    );
+    virtual_pwm_buzzer.add_to_mux();
+
+    //
+    // Buzzer
+    //
+    let virtual_alarm_buzzer = static_init!(
+        capsules::virtual_alarm::VirtualMuxAlarm<'static, nrf5x::rtc::Rtc>,
+        capsules::virtual_alarm::VirtualMuxAlarm::new(mux_alarm)
+    );
+    let buzzer = static_init!(
+        capsules::buzzer_driver::Buzzer<
+            'static,
+            capsules::virtual_alarm::VirtualMuxAlarm<'static, nrf5x::rtc::Rtc>,
+        >,
+        capsules::buzzer_driver::Buzzer::new(
+            virtual_pwm_buzzer,
+            virtual_alarm_buzzer,
+            capsules::buzzer_driver::DEFAULT_MAX_BUZZ_TIME_MS,
+            board_kernel.create_grant(&memory_allocation_capability)
+        )
+    );
+    virtual_alarm_buzzer.set_client(buzzer);
+
+    // Start all of the clocks. Low power operation will require a better
+    // approach than this.
+    nrf52::clock::CLOCK.low_stop();
+    nrf52::clock::CLOCK.high_stop();
+
+    nrf52::clock::CLOCK.low_set_source(nrf52::clock::LowClockSource::XTAL);
+    nrf52::clock::CLOCK.low_start();
+    nrf52::clock::CLOCK.high_set_source(nrf52::clock::HighClockSource::XTAL);
+    nrf52::clock::CLOCK.high_start();
+    while !nrf52::clock::CLOCK.low_started() {}
+    while !nrf52::clock::CLOCK.high_started() {}
+
+    let platform = Platform {
+        button: button,
+        ble_radio: ble_radio,
+        console: console,
+        led: led,
+        gpio: gpio,
+        rng: rng,
+        temp: temp,
+        alarm: alarm,
+        gpio_async: gpio_async,
+        light: light,
+        buzzer: buzzer,
+        ipc: kernel::ipc::IPC::new(board_kernel, &memory_allocation_capability),
+    };
+
+    let chip = static_init!(nrf52::chip::NRF52, nrf52::chip::NRF52::new());
+
+    nrf5x::gpio::PORT[31].make_output();
+    nrf5x::gpio::PORT[31].clear();
+
+    debug!("Initialization complete. Entering main loop\r");
+    debug!("{}", &nrf52::ficr::FICR_INSTANCE);
+
+    extern "C" {
+        /// Beginning of the ROM region containing app images.
+        static _sapps: u8;
+    }
+    kernel::procs::load_processes(
+        board_kernel,
+        chip,
+        &_sapps as *const u8,
+        &mut APP_MEMORY,
+        &mut PROCESSES,
+        FAULT_RESPONSE,
+        &process_management_capability,
+    );
+
+    board_kernel.kernel_loop(&platform, chip, Some(&platform.ipc), &main_loop_capability);
+}

--- a/capsules/README.md
+++ b/capsules/README.md
@@ -28,6 +28,7 @@ The list of Tock capsules and a brief description.
 
 These implement a driver to setup and read various physical sensors.
 
+- **[Analog Sensors](src/analog_sensor.rs)**: Single ADC pin sensors.
 - **[FXOS8700CQ](src/fxos8700cq.rs)**: Accelerometer and magnetometer.
 - **[ISL29035](src/isl29035.rs)**: Light sensor.
 - **[LPS25HB](src/lps25hb.rs)**: Pressure sensor.

--- a/capsules/README.md
+++ b/capsules/README.md
@@ -114,6 +114,7 @@ These allow for multiple users of shared hardware resources in the kernel.
 - **[Virtual Alarm](src/virtual_alarm.rs)**: Shared alarm resource.
 - **[Virtual Flash](src/virtual_flash.rs)**: Shared flash resource.
 - **[Virtual I2C](src/virtual_i2c.rs)**: Shared I2C and fixed addresses.
+- **[Virtual PWM](src/virtual_pwm.rs)**: Shared PWM hardware.
 - **[Virtual SPI](src/virtual_spi.rs)**: Shared SPI and fixed chip select pins.
 - **[Virtual UART](src/virtual_uart.rs)**: Shared UART bus.
 

--- a/capsules/README.md
+++ b/capsules/README.md
@@ -89,6 +89,7 @@ These provide common and better abstractions for userspace.
 - **[App Flash](src/app_flash_driver.rs)**: Allow applications to write their
   own flash.
 - **[Button](src/button.rs)**: Detect button presses.
+- **[Buzzer](src/buzzer_driver.rs)**: Simple buzzer.
 - **[Console](src/console.rs)**: UART console support.
 - **[Humidity](src/humidity.rs)**: Query humidity sensors.
 - **[LED](src/led.rs)**: Turn on and off LEDs.

--- a/capsules/src/analog_sensor.rs
+++ b/capsules/src/analog_sensor.rs
@@ -1,0 +1,118 @@
+//! Capsule for analog sensors.
+//!
+//! This capsule provides the sensor HIL interfaces for sensors which only need
+//! an ADC.
+//!
+//! It includes support for analog light sensors and analog temperature sensors.
+
+use kernel::common::cells::OptionalCell;
+use kernel::hil;
+use kernel::ReturnCode;
+
+/// The type of the sensor implies how the raw ADC reading should be converted
+/// to a light value.
+pub enum AnalogLightSensorType {
+    LightDependentResistor,
+}
+
+pub struct AnalogLightSensor<'a, A: hil::adc::Adc> {
+    adc: &'a A,
+    channel: &'a <A as hil::adc::Adc>::Channel,
+    sensor_type: AnalogLightSensorType,
+    client: OptionalCell<&'a hil::sensors::AmbientLightClient>,
+}
+
+impl<A: hil::adc::Adc> AnalogLightSensor<'a, A> {
+    pub fn new(
+        adc: &'a A,
+        channel: &'a <A as hil::adc::Adc>::Channel,
+        sensor_type: AnalogLightSensorType,
+    ) -> AnalogLightSensor<'a, A> {
+        AnalogLightSensor {
+            adc: adc,
+            channel: channel,
+            sensor_type: sensor_type,
+            client: OptionalCell::empty(),
+        }
+    }
+}
+
+/// Callbacks from the ADC driver
+impl<A: hil::adc::Adc> hil::adc::Client for AnalogLightSensor<'a, A> {
+    fn sample_ready(&self, sample: u16) {
+        // TODO: calculate the actual light reading.
+        let measurement: usize = match self.sensor_type {
+            AnalogLightSensorType::LightDependentResistor => {
+                // TODO: need to determine the actual value that the 5000 should be
+                (sample as usize * 5000) / 65535
+            }
+        };
+        self.client.map(|client| client.callback(measurement));
+    }
+}
+
+impl<A: hil::adc::Adc> hil::sensors::AmbientLight for AnalogLightSensor<'a, A> {
+    fn set_client(&self, client: &'static hil::sensors::AmbientLightClient) {
+        self.client.set(client);
+    }
+
+    fn read_light_intensity(&self) -> ReturnCode {
+        self.adc.sample(self.channel)
+    }
+}
+
+/// The type of the sensor implies how the raw ADC reading should be converted
+/// to a temperature value.
+pub enum AnalogTemperatureSensorType {
+    MicrochipMcp9700,
+}
+
+pub struct AnalogTemperatureSensor<'a, A: hil::adc::Adc> {
+    adc: &'a A,
+    channel: &'a <A as hil::adc::Adc>::Channel,
+    sensor_type: AnalogTemperatureSensorType,
+    client: OptionalCell<&'a hil::sensors::TemperatureClient>,
+}
+
+impl<A: hil::adc::Adc> AnalogTemperatureSensor<'a, A> {
+    pub fn new(
+        adc: &'a A,
+        channel: &'a <A as hil::adc::Adc>::Channel,
+        sensor_type: AnalogLightSensorType,
+    ) -> AnalogLightSensor<'a, A> {
+        AnalogLightSensor {
+            adc: adc,
+            channel: channel,
+            sensor_type: sensor_type,
+            client: OptionalCell::empty(),
+        }
+    }
+}
+
+/// Callbacks from the ADC driver
+impl<A: hil::adc::Adc> hil::adc::Client for AnalogTemperatureSensor<'a, A> {
+    fn sample_ready(&self, sample: u16) {
+        // TODO: calculate the actual temperature reading.
+        let measurement: usize = match self.sensor_type {
+            // 𝑉out = 500𝑚𝑉 + 10𝑚𝑉/C ∗ 𝑇A
+            AnalogTemperatureSensorType::MicrochipMcp9700 => {
+                let ref_mv = self.adc.get_voltage_reference_mv().unwrap_or(3300);
+                // reading_mv = (ADC / (2^16-1)) * ref_voltage
+                let reading_mv = (sample as usize * ref_mv) / 65535;
+                // need 0.01°C
+                (reading_mv - 500) * 10
+            }
+        };
+        self.client.map(|client| client.callback(measurement));
+    }
+}
+
+impl<A: hil::adc::Adc> hil::sensors::TemperatureDriver for AnalogTemperatureSensor<'a, A> {
+    fn set_client(&self, client: &'static hil::sensors::TemperatureClient) {
+        self.client.set(client);
+    }
+
+    fn read_temperature(&self) -> ReturnCode {
+        self.adc.sample(self.channel)
+    }
+}

--- a/capsules/src/buzzer_driver.rs
+++ b/capsules/src/buzzer_driver.rs
@@ -1,0 +1,236 @@
+//! This provides virtualized userspace access to a buzzer.
+//!
+//! Each app can have one outstanding buzz request, and buzz requests will queue
+//! with each app getting exclusive access to the buzzer during its turn. Apps
+//! can specify the frequency and duration of the square wave buzz, but the
+//! duration is capped to prevent this from being annoying.
+//!
+//! Apps can subscribe to an optional callback if they care about getting
+//! buzz done events.
+//!
+//! Usage
+//! -----
+//!
+//! ```
+//! let virtual_pwm_buzzer = static_init!(
+//!     capsules::virtual_pwm::PwmPinUser<'static, nrf52::pwm::Pwm>,
+//!     capsules::virtual_pwm::PwmPinUser::new(mux_pwm, nrf5x::pinmux::Pinmux::new(31))
+//! );
+//! virtual_pwm_buzzer.add_to_mux();
+//!
+//! let virtual_alarm_buzzer = static_init!(
+//!     capsules::virtual_alarm::VirtualMuxAlarm<'static, nrf5x::rtc::Rtc>,
+//!     capsules::virtual_alarm::VirtualMuxAlarm::new(mux_alarm)
+//! );
+//!
+//! let buzzer = static_init!(
+//!     capsules::buzzer_driver::Buzzer<
+//!         'static,
+//!         capsules::virtual_alarm::VirtualMuxAlarm<'static, nrf5x::rtc::Rtc>>,
+//!     capsules::buzzer_driver::Buzzer::new(
+//!         virtual_pwm_buzzer,
+//!         virtual_alarm_buzzer,
+//!         capsules::buzzer_driver::DEFAULT_MAX_BUZZ_TIME_MS,
+//!         kernel::Grant::create())
+//! );
+//! virtual_alarm_buzzer.set_client(buzzer);
+//! ```
+
+use core::cmp;
+
+use kernel::common::cells::OptionalCell;
+use kernel::hil;
+use kernel::hil::time::Frequency;
+use kernel::{AppId, Callback, Driver, Grant, ReturnCode};
+
+/// Syscall driver number.
+pub const DRIVER_NUM: usize = 0x90000;
+
+/// Standard max buzz time.
+pub const DEFAULT_MAX_BUZZ_TIME_MS: usize = 5000;
+
+#[derive(Clone, Copy, PartialEq)]
+pub enum BuzzerCommand {
+    Buzz {
+        frequency_hz: usize,
+        duration_ms: usize,
+    },
+}
+
+#[derive(Default)]
+pub struct App {
+    callback: Option<Callback>, // Optional callback to signal when the buzzer event is over.
+    pending_command: Option<BuzzerCommand>, // What command to run when the buzzer is free.
+}
+
+pub struct Buzzer<'a, A: hil::time::Alarm> {
+    // The underlying PWM generator to make the buzzer buzz.
+    pwm_pin: &'a hil::pwm::PwmPin,
+    // Alarm to stop the buzzer after some time.
+    alarm: &'a A,
+    // Per-app state.
+    apps: Grant<App>,
+    // Which app is currently using the buzzer.
+    active_app: OptionalCell<AppId>,
+    // Max buzz time.
+    max_duration_ms: usize,
+}
+
+impl<A: hil::time::Alarm> Buzzer<'a, A> {
+    pub fn new(
+        pwm_pin: &'a hil::pwm::PwmPin,
+        alarm: &'a A,
+        max_duration_ms: usize,
+        grant: Grant<App>,
+    ) -> Buzzer<'a, A> {
+        Buzzer {
+            pwm_pin: pwm_pin,
+            alarm: alarm,
+            apps: grant,
+            active_app: OptionalCell::empty(),
+            max_duration_ms: max_duration_ms,
+        }
+    }
+
+    // Check so see if we are doing something. If not, go ahead and do this
+    // command. If so, this is queued and will be run when the pending
+    // command completes.
+    fn enqueue_command(&self, command: BuzzerCommand, app_id: AppId) -> ReturnCode {
+        if self.active_app.is_none() {
+            // No app is currently using the buzzer, so we just use this app.
+            self.active_app.set(app_id);
+            self.buzz(command)
+        } else {
+            // There is an active app, so queue this request (if possible).
+            self.apps
+                .enter(app_id, |app, _| {
+                    // Some app is using the storage, we must wait.
+                    if app.pending_command.is_some() {
+                        // No more room in the queue, nowhere to store this
+                        // request.
+                        ReturnCode::ENOMEM
+                    } else {
+                        // We can store this, so lets do it.
+                        app.pending_command = Some(command);
+                        ReturnCode::SUCCESS
+                    }
+                })
+                .unwrap_or_else(|err| err.into())
+        }
+    }
+
+    fn buzz(&self, command: BuzzerCommand) -> ReturnCode {
+        match command {
+            BuzzerCommand::Buzz {
+                frequency_hz,
+                duration_ms,
+            } => {
+                // Start the PWM output at the specified frequency with a 50%
+                // duty cycle.
+                let ret = self
+                    .pwm_pin
+                    .start(frequency_hz, self.pwm_pin.get_maximum_duty_cycle() / 2);
+                if ret != ReturnCode::SUCCESS {
+                    return ret;
+                }
+
+                // Now start a timer so we know when to stop the PWM.
+                let interval = (duration_ms as u32) * <A::Frequency>::frequency() / 1000;
+                let tics = self.alarm.now().wrapping_add(interval);
+                self.alarm.set_alarm(tics);
+                ReturnCode::SUCCESS
+            }
+        }
+    }
+
+    fn check_queue(&self) {
+        for appiter in self.apps.iter() {
+            let started_command = appiter.enter(|app, _| {
+                // If this app has a pending command let's use it.
+                app.pending_command.take().map_or(false, |command| {
+                    // Mark this driver as being in use.
+                    self.active_app.set(app.appid());
+                    // Actually make the buzz happen.
+                    self.buzz(command) == ReturnCode::SUCCESS
+                })
+            });
+            if started_command {
+                break;
+            }
+        }
+    }
+}
+
+impl<A: hil::time::Alarm> hil::time::Client for Buzzer<'a, A> {
+    fn fired(&self) {
+        // All we have to do is stop the PWM and check if there are any pending
+        // uses of the buzzer.
+        self.pwm_pin.stop();
+        // Mark the active app as None and see if there is a callback.
+        self.active_app.take().map(|app_id| {
+            let _ = self.apps.enter(app_id, |app, _| {
+                app.callback.map(|mut cb| cb.schedule(0, 0, 0));
+            });
+        });
+
+        // Check if there is anything else to do.
+        self.check_queue();
+    }
+}
+
+/// Provide an interface for userland.
+impl<A: hil::time::Alarm> Driver for Buzzer<'a, A> {
+    /// Setup callbacks.
+    ///
+    /// ### `subscribe_num`
+    ///
+    /// - `0`: Setup a buzz done callback.
+    fn subscribe(
+        &self,
+        subscribe_num: usize,
+        callback: Option<Callback>,
+        app_id: AppId,
+    ) -> ReturnCode {
+        self.apps
+            .enter(app_id, |app, _| {
+                match subscribe_num {
+                    0 => app.callback = callback,
+                    _ => return ReturnCode::ENOSUPPORT,
+                }
+                ReturnCode::SUCCESS
+            })
+            .unwrap_or_else(|err| err.into())
+    }
+
+    /// Command interface.
+    ///
+    /// ### `command_num`
+    ///
+    /// - `0`: Return SUCCESS if this driver is included on the platform.
+    /// - `1`: Buzz the buzzer. `arg1` is used for the frequency in hertz, and
+    ///   `arg2` is the duration in ms. Note the duration is capped at 5000
+    ///   milliseconds.
+    fn command(&self, command_num: usize, arg1: usize, arg2: usize, appid: AppId) -> ReturnCode {
+        match command_num {
+            0 =>
+            /* This driver exists. */
+            {
+                ReturnCode::SUCCESS
+            }
+
+            1 => {
+                let frequency_hz = arg1;
+                let duration_ms = cmp::min(arg2, self.max_duration_ms);
+                self.enqueue_command(
+                    BuzzerCommand::Buzz {
+                        frequency_hz,
+                        duration_ms,
+                    },
+                    appid,
+                )
+            }
+
+            _ => ReturnCode::ENOSUPPORT,
+        }
+    }
+}

--- a/capsules/src/lib.rs
+++ b/capsules/src/lib.rs
@@ -21,6 +21,7 @@ pub mod analog_comparator;
 pub mod app_flash_driver;
 pub mod ble_advertising_driver;
 pub mod button;
+pub mod buzzer_driver;
 pub mod console;
 pub mod crc;
 pub mod dac;

--- a/capsules/src/lib.rs
+++ b/capsules/src/lib.rs
@@ -63,5 +63,6 @@ pub mod usbc_client;
 pub mod virtual_alarm;
 pub mod virtual_flash;
 pub mod virtual_i2c;
+pub mod virtual_pwm;
 pub mod virtual_spi;
 pub mod virtual_uart;

--- a/capsules/src/lib.rs
+++ b/capsules/src/lib.rs
@@ -18,6 +18,7 @@ pub mod aes_ccm;
 pub mod alarm;
 pub mod ambient_light;
 pub mod analog_comparator;
+pub mod analog_sensor;
 pub mod app_flash_driver;
 pub mod ble_advertising_driver;
 pub mod button;

--- a/capsules/src/virtual_pwm.rs
+++ b/capsules/src/virtual_pwm.rs
@@ -1,0 +1,156 @@
+//! Virtualize a PWM interface.
+//!
+//! `MuxPwm` provides shared access to a single PWM interface for multiple
+//! users. `PwmPinUser` provides access to a specific PWM pin.
+//!
+//! Usage
+//! -----
+//!
+//! ```
+//! let mux_pwm = static_init!(
+//!     capsules::virtual_pwm::MuxPwm<'static, nrf52::pwm::Pwm>,
+//!     capsules::virtual_pwm::MuxPwm::new(&nrf52::pwm::PWM0)
+//! );
+//! let virtual_pwm_buzzer = static_init!(
+//!     capsules::virtual_pwm::PwmPinUser<'static, nrf52::pwm::Pwm>,
+//!     capsules::virtual_pwm::PwmPinUser::new(mux_pwm, nrf5x::pinmux::Pinmux::new(31))
+//! );
+//! virtual_pwm_buzzer.add_to_mux();
+//! ```
+
+use kernel::common::cells::OptionalCell;
+use kernel::common::{List, ListLink, ListNode};
+use kernel::hil;
+use kernel::ReturnCode;
+
+pub struct MuxPwm<'a, P: hil::pwm::Pwm> {
+    pwm: &'a P,
+    devices: List<'a, PwmPinUser<'a, P>>,
+    inflight: OptionalCell<&'a PwmPinUser<'a, P>>,
+}
+
+impl<P: hil::pwm::Pwm> MuxPwm<'a, P> {
+    pub const fn new(pwm: &'a P) -> MuxPwm<'a, P> {
+        MuxPwm {
+            pwm: pwm,
+            devices: List::new(),
+            inflight: OptionalCell::empty(),
+        }
+    }
+
+    /// If we are not currently doing anything, scan the list of devices for
+    /// one with an outstanding operation and run that.
+    fn do_next_op(&self) {
+        if self.inflight.is_none() {
+            let mnode = self.devices.iter().find(|node| node.operation.is_some());
+            mnode.map(|node| {
+                let started = node.operation.take().map_or(false, |operation| {
+                    match operation {
+                        Operation::Simple {
+                            frequency_hz,
+                            duty_cycle,
+                        } => {
+                            self.pwm.start(&node.pin, frequency_hz, duty_cycle);
+                            true
+                        }
+                        Operation::Stop => {
+                            // Can't stop if nothing is running
+                            false
+                        }
+                    }
+                });
+                if started {
+                    self.inflight.set(node);
+                } else {
+                    // Keep looking for something to do.
+                    self.do_next_op();
+                }
+            });
+        } else {
+            // We are running so we do whatever the inflight user wants, if
+            // there is some command there.
+            self.inflight.map(|node| {
+                node.operation.take().map(|operation| {
+                    match operation {
+                        Operation::Simple {
+                            frequency_hz,
+                            duty_cycle,
+                        } => {
+                            // Changed some parameter.
+                            self.pwm.start(&node.pin, frequency_hz, duty_cycle);
+                        }
+                        Operation::Stop => {
+                            // Ok we got a stop.
+                            self.pwm.stop(&node.pin);
+                            self.inflight.clear();
+                        }
+                    }
+                    // Recurse in case there is more to do.
+                    self.do_next_op();
+                });
+            });
+        }
+    }
+}
+
+#[derive(Copy, Clone, PartialEq)]
+enum Operation {
+    Simple {
+        frequency_hz: usize,
+        duty_cycle: usize,
+    },
+    Stop,
+}
+
+pub struct PwmPinUser<'a, P: hil::pwm::Pwm> {
+    mux: &'a MuxPwm<'a, P>,
+    pin: P::Pin,
+    operation: OptionalCell<Operation>,
+    next: ListLink<'a, PwmPinUser<'a, P>>,
+}
+
+impl<P: hil::pwm::Pwm> PwmPinUser<'a, P> {
+    pub const fn new(mux: &'a MuxPwm<'a, P>, pin: P::Pin) -> PwmPinUser<'a, P> {
+        PwmPinUser {
+            mux: mux,
+            pin: pin,
+            operation: OptionalCell::empty(),
+            next: ListLink::empty(),
+        }
+    }
+
+    pub fn add_to_mux(&'a self) {
+        self.mux.devices.push_head(self);
+    }
+}
+
+impl<P: hil::pwm::Pwm> ListNode<'a, PwmPinUser<'a, P>> for PwmPinUser<'a, P> {
+    fn next(&'a self) -> &'a ListLink<'a, PwmPinUser<'a, P>> {
+        &self.next
+    }
+}
+
+impl<P: hil::pwm::Pwm> hil::pwm::PwmPin for PwmPinUser<'a, P> {
+    fn start(&self, frequency_hz: usize, duty_cycle: usize) -> ReturnCode {
+        self.operation.set(Operation::Simple {
+            frequency_hz,
+            duty_cycle,
+        });
+        self.mux.do_next_op();
+        ReturnCode::SUCCESS
+    }
+
+    fn stop(&self) -> ReturnCode {
+        self.operation.set(Operation::Stop);
+        self.mux.do_next_op();
+        ReturnCode::SUCCESS
+    }
+
+    fn get_maximum_frequency_hz(&self) -> usize {
+        self.mux.pwm.get_maximum_frequency_hz()
+    }
+
+    fn get_maximum_duty_cycle(&self) -> usize {
+        self.mux.pwm.get_maximum_duty_cycle()
+    }
+}

--- a/chips/nrf52/src/lib.rs
+++ b/chips/nrf52/src/lib.rs
@@ -27,6 +27,7 @@ pub mod ficr;
 pub mod i2c;
 pub mod nvmc;
 pub mod ppi;
+pub mod pwm;
 pub mod radio;
 pub mod spi;
 pub mod uart;

--- a/chips/nrf52/src/pwm.rs
+++ b/chips/nrf52/src/pwm.rs
@@ -1,0 +1,270 @@
+//! PWM driver for nRF52.
+
+use kernel::common::cells::VolatileCell;
+use kernel::common::registers::{ReadWrite, WriteOnly};
+use kernel::common::StaticRef;
+use kernel::hil;
+use kernel::ReturnCode;
+use nrf5x;
+
+#[repr(C)]
+struct PwmRegisters {
+    _reserved0: [u8; 4],
+    /// Stops PWM pulse generation on all channels at the end of current PWM period
+    tasks_stop: WriteOnly<u32, TASK::Register>,
+    /// Loads the first PWM value on all enabled channels
+    tasks_seqstart: [WriteOnly<u32, TASK::Register>; 2],
+    /// Steps by one value in the current sequence on all enabled channels if DECODER.MO
+    tasks_nextstep: WriteOnly<u32, TASK::Register>,
+    _reserved1: [u8; 240],
+    /// Response to STOP task, emitted when PWM pulses are no longer generated
+    events_stopped: ReadWrite<u32, EVENT::Register>,
+    /// First PWM period started on sequence 0
+    events_seqstarted: [ReadWrite<u32, EVENT::Register>; 2],
+    /// Emitted at end of every sequence 0, when last value from RAM has been
+    /// applied to the wave counter
+    events_seqend: [ReadWrite<u32, EVENT::Register>; 2],
+    /// Emitted at the end of each PWM period
+    events_pwmperiodend: ReadWrite<u32, EVENT::Register>,
+    /// Concatenated sequences have been played the amount of times defined in LOOP.CNT
+    events_loopsdone: ReadWrite<u32, EVENT::Register>,
+    _reserved2: [u8; 224],
+    /// Shortcut register
+    shorts: ReadWrite<u32, SHORTS::Register>,
+    _reserved3: [u8; 252],
+    /// Enable or disable interrupt
+    inten: ReadWrite<u32, INTEN::Register>,
+    /// Enable interrupt
+    intenset: ReadWrite<u32, INTEN::Register>,
+    /// Disable interrupt
+    intenclr: ReadWrite<u32, INTEN::Register>,
+    _reserved4: [u8; 500],
+    /// PWM module enable register
+    enable: ReadWrite<u32, ENABLE::Register>,
+    /// Selects operating mode of the wave counter
+    mode: ReadWrite<u32, MODE::Register>,
+    /// Value up to which the pulse generator counter counts
+    countertop: ReadWrite<u32, COUNTERTOP::Register>,
+    /// Configuration for PWM_CLK
+    prescaler: ReadWrite<u32, PRESCALER::Register>,
+    /// Configuration of the decoder
+    decoder: ReadWrite<u32, DECODER::Register>,
+    /// Amount of playback of a loop
+    loopreg: ReadWrite<u32, LOOP::Register>,
+    _reserved5: [u8; 8],
+    seq0: PwmSeqRegisters,
+    _reserved6: [u8; 16],
+    seq1: PwmSeqRegisters,
+    _reserved7: [u8; 16],
+    psel_out: [VolatileCell<nrf5x::pinmux::Pinmux>; 4],
+}
+
+#[repr(C)]
+struct PwmSeqRegisters {
+    seq_ptr: VolatileCell<*const u16>,
+    seq_cnt: ReadWrite<u32, SEQ_CNT::Register>,
+    seq_refresh: ReadWrite<u32, SEQ_REFRESH::Register>,
+    seq_enddelay: ReadWrite<u32, SEQ_ENDDELAY::Register>,
+}
+
+register_bitfields![u32,
+    SHORTS [
+        /// Shortcut between EVENTS_SEQEND[0] event and TASKS_STOP task
+        SEQEND0_STOP 0,
+        /// Shortcut between EVENTS_SEQEND[1] event and TASKS_STOP task
+        SEQEND1_STOP 1,
+        /// Shortcut between EVENTS_LOOPSDONE event and TASKS_SEQSTART[0] task
+        LOOPSDONE_SEQSTART0 2,
+        /// Shortcut between EVENTS_LOOPSDONE event and TASKS_SEQSTART[1] task
+        LOOPSDONE_SEQSTART1 3,
+        /// Shortcut between EVENTS_LOOPSDONE event and TASKS_STOP task
+        LOOPSDONE_STOP 4
+    ],
+    INTEN [
+        /// Enable or disable interrupt on EVENTS_STOPPED event
+        STOPPED 1,
+        /// Enable or disable interrupt on EVENTS_SEQSTARTED[0] event
+        SEQSTARTED0 2,
+        /// Enable or disable interrupt on EVENTS_SEQSTARTED[1] event
+        SEQSTARTED1 3,
+        /// Enable or disable interrupt on EVENTS_SEQEND[0] event
+        SEQEND0 4,
+        /// Enable or disable interrupt on EVENTS_SEQEND[1] event
+        SEQEND1 5,
+        /// Enable or disable interrupt on EVENTS_PWMPERIODEND event
+        PWMPERIODEND 6,
+        /// Enable or disable interrupt on EVENTS_LOOPSDONE event
+        LOOPSDONE 7
+    ],
+    ENABLE [
+        ENABLE 0
+    ],
+    MODE [
+        UPDOWN OFFSET(0) NUMBITS(1) [
+            Up = 0,
+            UpAndDown = 1
+        ]
+    ],
+    COUNTERTOP [
+        COUNTERTOP OFFSET(0) NUMBITS(15) []
+    ],
+    PRESCALER [
+        PRESCALER OFFSET(0) NUMBITS(3) [
+            DIV_1 = 0,
+            DIV_2 = 1,
+            DIV_4 = 2,
+            DIV_8 = 3,
+            DIV_16 = 4,
+            DIV_32 = 5,
+            DIV_64 = 6,
+            DIV_128 = 7
+        ]
+    ],
+    DECODER [
+        /// How a sequence is read from RAM and spread to the compare register
+        LOAD OFFSET(0) NUMBITS(2) [
+            /// 1st half word (16-bit) used in all PWM channels 0..3
+            Common = 0,
+            /// 1st half word (16-bit) used in channel 0..1; 2nd word in channel 2..3
+            Grouped = 1,
+            /// 1st half word (16-bit) in ch.0; 2nd in ch.1; ...; 4th in ch.3
+            Individual = 2,
+            /// 1st half word (16-bit) in ch.0; 2nd in ch.1; ...; 4th in COUNTERTOP
+            Waveform = 3
+        ],
+        /// Selects source for advancing the active sequence
+        MODE OFFSET(8) NUMBITS(1) [
+            /// SEQ[n].REFRESH is used to determine loading internal compare registers
+            RefreshCount = 0,
+            /// NEXTSTEP task causes a new value to be loaded to internal compare registers
+            NextStep = 1
+        ]
+    ],
+    LOOP [
+        /// Number of playbacks of pattern cycles. 0 to disable.
+        CNT OFFSET(0) NUMBITS(16) []
+    ],
+    EVENT [
+        EVENT 0
+    ],
+    TASK [
+        TASK 0
+    ],
+    SEQ_CNT [
+        CNT OFFSET(0) NUMBITS(15) []
+    ],
+    SEQ_REFRESH [
+        CNT OFFSET(0) NUMBITS(24) []
+    ],
+    SEQ_ENDDELAY [
+        CNT OFFSET(0) NUMBITS(24) []
+    ]
+];
+
+const PWM0_BASE: StaticRef<PwmRegisters> =
+    unsafe { StaticRef::new(0x4001C000 as *const PwmRegisters) };
+
+pub static mut PWM0: Pwm = Pwm::new(PWM0_BASE);
+
+/// `DUTY_CYCLES` is a static array that must be passed to the PWM hardware.
+/// The nRF52 hardware uses this static array in memory to enable switching
+/// between multiple duty cycles automatically while generating the PWM output.
+/// This isn't ideal from a Rust perspective, but the peripheral hardware must
+/// be passed a pointer.
+static mut DUTY_CYCLES: [u16; 4] = [0; 4];
+
+pub struct Pwm {
+    registers: StaticRef<PwmRegisters>,
+}
+
+impl Pwm {
+    const fn new(registers: StaticRef<PwmRegisters>) -> Pwm {
+        Pwm {
+            registers: registers,
+        }
+    }
+
+    fn start_pwm(
+        &self,
+        pin: &nrf5x::pinmux::Pinmux,
+        frequency_hz: usize,
+        duty_cycle: usize,
+    ) -> ReturnCode {
+        let regs = &*self.registers;
+
+        let prescaler = 0;
+        let counter_top = (16000000 / frequency_hz) >> prescaler;
+
+        // Use the passed in duty cycle to calculate the value we pass to the
+        // hardware. A 50% duty cycle is half of counter_top, a 10% duty cycle
+        // would be 90% of counter_top.
+        //
+        //                               duty_cycle
+        //  dc_out = counter_top * (1 -  ---------- )
+        //                                5333333
+        let dc_out = counter_top - ((3 * duty_cycle) / frequency_hz);
+
+        // Configure the pin
+        regs.psel_out[0].set(*pin);
+
+        // Start by enabling the peripheral.
+        regs.enable.write(ENABLE::ENABLE::SET);
+        // Want count up mode.
+        regs.mode.write(MODE::UPDOWN::Up);
+        // Disable loop (repeat) mode.
+        regs.loopreg.write(LOOP::CNT.val(0));
+        // Set the decoder settings.
+        regs.decoder
+            .write(DECODER::LOAD::Common + DECODER::MODE::RefreshCount);
+        // Set the prescaler.
+        regs.prescaler.write(PRESCALER::PRESCALER::DIV_1);
+        // Set the value to count to.
+        regs.countertop
+            .write(COUNTERTOP::COUNTERTOP.val(counter_top as u32));
+
+        // Setup the duty cycles
+        unsafe {
+            DUTY_CYCLES[0] = dc_out as u16;
+            regs.seq0.seq_ptr.set(&DUTY_CYCLES as *const u16);
+        }
+        regs.seq0.seq_cnt.write(SEQ_CNT::CNT.val(1));
+        regs.seq0.seq_refresh.write(SEQ_REFRESH::CNT.val(0));
+        regs.seq0.seq_enddelay.write(SEQ_ENDDELAY::CNT.val(0));
+
+        // Start
+        regs.tasks_seqstart[0].write(TASK::TASK::SET);
+
+        ReturnCode::SUCCESS
+    }
+
+    fn stop_pwm(&self, _pin: &nrf5x::pinmux::Pinmux) -> ReturnCode {
+        let regs = &*self.registers;
+        regs.tasks_stop.write(TASK::TASK::SET);
+        regs.enable.write(ENABLE::ENABLE::CLEAR);
+        ReturnCode::SUCCESS
+    }
+}
+
+impl hil::pwm::Pwm for Pwm {
+    type Pin = nrf5x::pinmux::Pinmux;
+
+    fn start(&self, pin: &Self::Pin, frequency: usize, duty_cycle: usize) -> ReturnCode {
+        self.start_pwm(pin, frequency, duty_cycle)
+    }
+
+    fn stop(&self, pin: &Self::Pin) -> ReturnCode {
+        self.stop_pwm(pin)
+    }
+
+    fn get_maximum_frequency_hz(&self) -> usize {
+        // Counter runs at 16 MHz, and the minimum value for the COUNTERTOP
+        // register is 3. 16000000 / 3 = 5333333
+        5333333
+    }
+
+    fn get_maximum_duty_cycle(&self) -> usize {
+        // We use the max frequency as the max duty cycle as well. This makes
+        // calculating `dc_out` straightforward.
+        5333333
+    }
+}

--- a/kernel/src/hil/mod.rs
+++ b/kernel/src/hil/mod.rs
@@ -12,6 +12,7 @@ pub mod gpio_async;
 pub mod i2c;
 pub mod led;
 pub mod nonvolatile_storage;
+pub mod pwm;
 pub mod radio;
 pub mod rng;
 pub mod sensors;

--- a/kernel/src/hil/pwm.rs
+++ b/kernel/src/hil/pwm.rs
@@ -1,0 +1,61 @@
+//! Interfaces for Pulse Width Modulation output.
+
+use returncode::ReturnCode;
+
+/// PWM control for a single pin.
+pub trait Pwm {
+    /// The chip-dependent type of a PWM pin.
+    type Pin;
+
+    /// Generate a PWM single on the given pin at the given frequency and duty
+    /// cycle.
+    ///
+    /// - `frequency_hz` is specified in Hertz.
+    /// - `duty_cycle` is specified as a portion of the max duty cycle supported
+    ///   by the chip. Clients should call `get_maximum_duty_cycle()` to get the
+    ///   value that corresponds to 100% duty cycle, and divide that
+    ///   appropriately to get the desired duty cycle value. For example, a 25%
+    ///   duty cycle would be `PWM0.get_maximum_duty_cycle() / 4`.
+    fn start(&self, pin: &Self::Pin, frequency_hz: usize, duty_cycle: usize) -> ReturnCode;
+
+    /// Stop a PWM pin output.
+    fn stop(&self, pin: &Self::Pin) -> ReturnCode;
+
+    /// Return the maximum PWM frequency supported by the PWM implementation.
+    /// The frequency will be specified in Hertz.
+    fn get_maximum_frequency_hz(&self) -> usize;
+
+    /// Return an opaque number that represents a 100% duty cycle. This value
+    /// will be hardware specific, and essentially represents the precision
+    /// of the underlying PWM hardware.
+    ///
+    /// Users of this HIL should divide this number to calculate a duty cycle
+    /// value suitable for calling `start()`. For example, to generate a 50%
+    /// duty cycle:
+    ///
+    /// ```ignore
+    /// let max = PWM0.get_maximum_duty_cycle();
+    /// let dc  = max / 2;
+    /// PWM0.start(pin, freq, dc);
+    /// ```
+    fn get_maximum_duty_cycle(&self) -> usize;
+}
+
+/// Higher-level PWM interface that restricts the user to a specific PWM pin.
+/// This is particularly useful for passing to capsules that need to control
+/// only a specific pin.
+pub trait PwmPin {
+    /// Start a PWM output. Same as the `start` function in the `Pwm` trait.
+    fn start(&self, frequency_hz: usize, duty_cycle: usize) -> ReturnCode;
+
+    /// Stop a PWM output. Same as the `stop` function in the `Pwm` trait.
+    fn stop(&self) -> ReturnCode;
+
+    /// Return the maximum PWM frequency supported by the PWM implementation.
+    /// Same as the `get_maximum_frequency_hz` function in the `Pwm` trait.
+    fn get_maximum_frequency_hz(&self) -> usize;
+
+    /// Return an opaque number that represents a 100% duty cycle. This value
+    /// Same as the `get_maximum_duty_cycle` function in the `Pwm` trait.
+    fn get_maximum_duty_cycle(&self) -> usize;
+}


### PR DESCRIPTION
### Pull Request Overview

This pull request adds a new board: https://www.mouser.com/ProductDetail/aconno/ACD52832?qs=EU6FO9ffTwcfj3wToVD24w%3D%3D

This board is nice because it is based on the nRF52 but also has a nice array of sensors, plus an e-ink display, buzzer, and relay outputs.


### Testing Strategy

This pull request was tested by running the peripherals on the ACD52832 board.


### TODO or Help Wanted

Blocking on several dependent pull requests.

Also needs to be checked that things are still working as expected.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
