### PR TITLE
kernel: no asm feature

### DIFF
--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -6,7 +6,7 @@
 //!
 //! Most `unsafe` code is in this kernel crate.
 
-#![feature(asm, core_intrinsics, ptr_internals, const_fn)]
+#![feature(core_intrinsics, ptr_internals, const_fn)]
 #![feature(try_from, panic_info_message)]
 #![feature(in_band_lifetimes, crate_visibility_modifier)]
 #![feature(associated_type_defaults)]


### PR DESCRIPTION
The kernel has no assembly, and it shouldn't because that is not cross-platform.




### Testing Strategy

n/a


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
