### PR TITLE
Use Rust 2018

### DIFF
--- a/arch/cortex-m/Cargo.toml
+++ b/arch/cortex-m/Cargo.toml
@@ -2,6 +2,7 @@
 name = "cortexm"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+edition = "2018"
 
 [dependencies]
 kernel = { path = "../../kernel" }

--- a/arch/cortex-m/src/lib.rs
+++ b/arch/cortex-m/src/lib.rs
@@ -5,9 +5,6 @@
 #![feature(asm, const_fn, lang_items)]
 #![no_std]
 
-#[macro_use(register_bitfields, register_bitmasks)]
-extern crate kernel;
-
 pub mod nvic;
 pub mod scb;
 pub mod support;

--- a/arch/cortex-m/src/systick.rs
+++ b/arch/cortex-m/src/systick.rs
@@ -1,6 +1,6 @@
 //! ARM Cortex-M SysTick peripheral.
 
-use kernel::common::registers::{ReadOnly, ReadWrite};
+use kernel::common::registers::{register_bitfields, ReadOnly, ReadWrite};
 use kernel::common::StaticRef;
 
 #[repr(C)]

--- a/arch/cortex-m0/Cargo.toml
+++ b/arch/cortex-m0/Cargo.toml
@@ -2,6 +2,7 @@
 name = "cortexm0"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+edition = "2018"
 
 [dependencies]
 kernel = { path = "../../kernel" }

--- a/arch/cortex-m0/src/lib.rs
+++ b/arch/cortex-m0/src/lib.rs
@@ -1,9 +1,6 @@
 #![feature(asm, const_fn, naked_functions)]
 #![no_std]
 
-extern crate cortexm;
-extern crate kernel;
-
 // Re-export the base generic cortex-m functions here as they are
 // valid on cortex-m0.
 pub use cortexm::support;

--- a/arch/cortex-m3/Cargo.lock
+++ b/arch/cortex-m3/Cargo.lock
@@ -18,7 +18,7 @@ name = "kernel"
 version = "0.1.0"
 dependencies = [
  "tock-cells 0.1.0",
- "tock-regs 0.1.0",
+ "tock-registers 0.2.0",
 ]
 
 [[package]]
@@ -26,6 +26,6 @@ name = "tock-cells"
 version = "0.1.0"
 
 [[package]]
-name = "tock-regs"
-version = "0.1.0"
+name = "tock-registers"
+version = "0.2.0"
 

--- a/arch/cortex-m3/Cargo.toml
+++ b/arch/cortex-m3/Cargo.toml
@@ -2,6 +2,7 @@
 name = "cortexm3"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+edition = "2018"
 
 [dependencies]
 kernel = { path = "../../kernel" }

--- a/arch/cortex-m3/src/lib.rs
+++ b/arch/cortex-m3/src/lib.rs
@@ -5,11 +5,6 @@
 #![feature(asm, const_fn, core_intrinsics, naked_functions)]
 #![no_std]
 
-#[allow(unused_imports)]
-#[macro_use(debug, debug_gpio, register_bitfields, register_bitmasks)]
-extern crate kernel;
-extern crate cortexm;
-
 pub mod mpu;
 
 // Re-export the base generic cortex-m functions here as they are

--- a/arch/cortex-m3/src/mpu.rs
+++ b/arch/cortex-m3/src/mpu.rs
@@ -4,7 +4,7 @@
 use core::cmp;
 use kernel;
 use kernel::common::math;
-use kernel::common::registers::{FieldValue, ReadOnly, ReadWrite};
+use kernel::common::registers::{register_bitfields, FieldValue, ReadOnly, ReadWrite};
 use kernel::common::StaticRef;
 use kernel::mpu;
 

--- a/arch/cortex-m4/Cargo.toml
+++ b/arch/cortex-m4/Cargo.toml
@@ -2,6 +2,7 @@
 name = "cortexm4"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+edition = "2018"
 
 [dependencies]
 kernel = { path = "../../kernel" }

--- a/arch/cortex-m4/src/lib.rs
+++ b/arch/cortex-m4/src/lib.rs
@@ -5,11 +5,6 @@
 #![feature(asm, const_fn, core_intrinsics, naked_functions)]
 #![no_std]
 
-#[allow(unused_imports)]
-#[macro_use(debug, debug_gpio, register_bitfields, register_bitmasks)]
-extern crate kernel;
-extern crate cortexm;
-
 pub mod mpu;
 
 // Re-export the base generic cortex-m functions here as they are

--- a/boards/acd52832/Cargo.toml
+++ b/boards/acd52832/Cargo.toml
@@ -3,6 +3,7 @@ name = "acd52832"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
 build = "build.rs"
+edition = "2018"
 
 [profile.dev]
 panic = "abort"

--- a/boards/acd52832/src/main.rs
+++ b/boards/acd52832/src/main.rs
@@ -4,14 +4,6 @@
 #![no_main]
 #![deny(missing_docs)]
 
-extern crate capsules;
-extern crate cortexm4;
-#[allow(unused_imports)]
-#[macro_use(create_capability, debug, debug_verbose, debug_gpio, static_init)]
-extern crate kernel;
-extern crate nrf52;
-extern crate nrf5x;
-
 use capsules::virtual_alarm::VirtualMuxAlarm;
 use capsules::virtual_uart::{UartDevice, UartMux};
 use kernel::capabilities;
@@ -19,6 +11,8 @@ use kernel::hil;
 use kernel::hil::entropy::Entropy32;
 use kernel::hil::gpio::Pin;
 use kernel::hil::rng::Rng;
+#[allow(unused_imports)]
+use kernel::{create_capability, debug, debug_gpio, static_init};
 use nrf5x::rtc::Rtc;
 
 const LED1_PIN: usize = 26;

--- a/boards/hail/Cargo.toml
+++ b/boards/hail/Cargo.toml
@@ -3,6 +3,7 @@ name = "hail"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
 build = "build.rs"
+edition = "2018"
 
 [profile.dev]
 panic = "abort"

--- a/boards/hail/src/io.rs
+++ b/boards/hail/src/io.rs
@@ -6,7 +6,7 @@ use kernel::debug;
 use kernel::hil::led;
 use kernel::hil::uart::{self, UART};
 
-use PROCESSES;
+use crate::PROCESSES;
 
 struct Writer {
     initialized: bool,

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -7,13 +7,6 @@
 #![no_main]
 #![deny(missing_docs)]
 
-extern crate capsules;
-#[allow(unused_imports)]
-#[macro_use(create_capability, debug, debug_gpio, static_init)]
-extern crate kernel;
-extern crate cortexm4;
-extern crate sam4l;
-
 use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use capsules::virtual_i2c::{I2CDevice, MuxI2C};
 use capsules::virtual_spi::{MuxSpiMaster, VirtualSpiMasterDevice};
@@ -25,6 +18,8 @@ use kernel::hil::rng::Rng;
 use kernel::hil::spi::SpiMaster;
 use kernel::hil::Controller;
 use kernel::Platform;
+#[allow(unused_imports)]
+use kernel::{create_capability, debug, debug_gpio, static_init};
 
 /// Support routines for debugging I/O.
 ///

--- a/boards/hail/src/test_take_map_cell.rs
+++ b/boards/hail/src/test_take_map_cell.rs
@@ -1,4 +1,5 @@
 use kernel::common::cells::MapCell;
+use kernel::debug;
 
 pub unsafe fn test_take_map_cell() {
     static FOO: u32 = 1234;

--- a/boards/imix/Cargo.toml
+++ b/boards/imix/Cargo.toml
@@ -3,6 +3,7 @@ name = "imix"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
 build = "build.rs"
+edition = "2018"
 
 [profile.dev]
 panic = "abort"

--- a/boards/imix/src/aes_ccm_test.rs
+++ b/boards/imix/src/aes_ccm_test.rs
@@ -15,6 +15,7 @@
 use capsules::aes_ccm;
 use capsules::test::aes_ccm::Test;
 use kernel::hil::symmetric_encryption::{AES128, AES128CCM, AES128_BLOCK_SIZE};
+use kernel::static_init;
 use sam4l::aes::{Aes, AES};
 
 pub unsafe fn run() {

--- a/boards/imix/src/aes_test.rs
+++ b/boards/imix/src/aes_test.rs
@@ -24,6 +24,7 @@
 use capsules::test::aes::TestAes128Cbc;
 use capsules::test::aes::TestAes128Ctr;
 use kernel::hil::symmetric_encryption::{AES128, AES128_BLOCK_SIZE, AES128_KEY_SIZE};
+use kernel::static_init;
 use sam4l::aes::{Aes, AES};
 
 pub unsafe fn run_aes128_ctr() {

--- a/boards/imix/src/components/adc.rs
+++ b/boards/imix/src/components/adc.rs
@@ -17,6 +17,7 @@
 
 use capsules::adc;
 use kernel::component::Component;
+use kernel::static_init;
 
 pub struct AdcComponent {}
 

--- a/boards/imix/src/components/alarm.rs
+++ b/boards/imix/src/components/alarm.rs
@@ -18,6 +18,8 @@ use capsules::alarm::AlarmDriver;
 use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use kernel::capabilities;
 use kernel::component::Component;
+use kernel::create_capability;
+use kernel::static_init;
 
 pub struct AlarmDriverComponent {
     board_kernel: &'static kernel::Kernel,

--- a/boards/imix/src/components/analog_comparator.rs
+++ b/boards/imix/src/components/analog_comparator.rs
@@ -17,6 +17,7 @@
 
 use capsules::analog_comparator;
 use kernel::component::Component;
+use kernel::static_init;
 
 pub struct AcComponent {}
 

--- a/boards/imix/src/components/button.rs
+++ b/boards/imix/src/components/button.rs
@@ -18,6 +18,8 @@
 use capsules::button;
 use kernel::capabilities;
 use kernel::component::Component;
+use kernel::create_capability;
+use kernel::static_init;
 
 pub struct ButtonComponent {
     board_kernel: &'static kernel::Kernel,

--- a/boards/imix/src/components/console.rs
+++ b/boards/imix/src/components/console.rs
@@ -19,9 +19,11 @@
 
 use capsules::console;
 use capsules::virtual_uart::{UartDevice, UartMux};
-use hil;
 use kernel::capabilities;
 use kernel::component::Component;
+use kernel::create_capability;
+use kernel::hil;
+use kernel::static_init;
 
 pub struct ConsoleComponent {
     board_kernel: &'static kernel::Kernel,

--- a/boards/imix/src/components/crc.rs
+++ b/boards/imix/src/components/crc.rs
@@ -18,6 +18,8 @@
 use capsules::crc;
 use kernel::capabilities;
 use kernel::component::Component;
+use kernel::create_capability;
+use kernel::static_init;
 
 pub struct CrcComponent {
     board_kernel: &'static kernel::Kernel,

--- a/boards/imix/src/components/fxos8700.rs
+++ b/boards/imix/src/components/fxos8700.rs
@@ -25,9 +25,11 @@
 use capsules::fxos8700cq;
 use capsules::ninedof::NineDof;
 use capsules::virtual_i2c::{I2CDevice, MuxI2C};
-use hil;
 use kernel::capabilities;
 use kernel::component::Component;
+use kernel::create_capability;
+use kernel::hil;
+use kernel::static_init;
 use kernel::Grant;
 
 pub struct Fxos8700Component {

--- a/boards/imix/src/components/gpio.rs
+++ b/boards/imix/src/components/gpio.rs
@@ -20,6 +20,8 @@
 use capsules::gpio;
 use kernel::capabilities;
 use kernel::component::Component;
+use kernel::create_capability;
+use kernel::static_init;
 
 pub struct GpioComponent {
     board_kernel: &'static kernel::Kernel,

--- a/boards/imix/src/components/isl29035.rs
+++ b/boards/imix/src/components/isl29035.rs
@@ -25,9 +25,11 @@ use capsules::ambient_light::AmbientLight;
 use capsules::isl29035::Isl29035;
 use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use capsules::virtual_i2c::{I2CDevice, MuxI2C};
-use hil;
 use kernel::capabilities;
 use kernel::component::Component;
+use kernel::create_capability;
+use kernel::hil;
+use kernel::static_init;
 
 pub struct Isl29035Component {
     i2c_mux: &'static MuxI2C<'static>,

--- a/boards/imix/src/components/led.rs
+++ b/boards/imix/src/components/led.rs
@@ -16,6 +16,7 @@
 
 use capsules::led;
 use kernel::component::Component;
+use kernel::static_init;
 
 pub struct LedComponent {}
 

--- a/boards/imix/src/components/nonvolatile_storage.rs
+++ b/boards/imix/src/components/nonvolatile_storage.rs
@@ -19,7 +19,9 @@ use capsules::nonvolatile_storage_driver::NonvolatileStorage;
 use capsules::nonvolatile_to_pages::NonvolatileToPages;
 use kernel::capabilities;
 use kernel::component::Component;
+use kernel::create_capability;
 use kernel::hil;
+use kernel::static_init;
 
 pub struct NonvolatileStorageComponent {
     board_kernel: &'static kernel::Kernel,

--- a/boards/imix/src/components/nrf51822.rs
+++ b/boards/imix/src/components/nrf51822.rs
@@ -15,8 +15,9 @@
 #![allow(dead_code)] // Components are intended to be conditionally included
 
 use capsules::nrf51822_serialization;
-use hil;
 use kernel::component::Component;
+use kernel::hil;
+use kernel::static_init;
 
 pub struct Nrf51822Component {
     uart: &'static sam4l::usart::USART,

--- a/boards/imix/src/components/process_console.rs
+++ b/boards/imix/src/components/process_console.rs
@@ -12,9 +12,10 @@
 
 use capsules::process_console;
 use capsules::virtual_uart::{UartDevice, UartMux};
-use hil;
 use kernel::capabilities;
 use kernel::component::Component;
+use kernel::hil;
+use kernel::static_init;
 
 pub struct ProcessConsoleComponent {
     board_kernel: &'static kernel::Kernel,

--- a/boards/imix/src/components/radio.rs
+++ b/boards/imix/src/components/radio.rs
@@ -21,10 +21,12 @@ use capsules::virtual_spi::VirtualSpiMasterDevice;
 
 use kernel::capabilities;
 use kernel::component::Component;
+use kernel::create_capability;
 use kernel::hil::radio;
 use kernel::hil::radio::RadioData;
 use kernel::hil::symmetric_encryption;
 use kernel::hil::symmetric_encryption::{AES128, AES128CCM};
+use kernel::static_init;
 
 // Save some deep nesting
 type RF233Device =

--- a/boards/imix/src/components/rf233.rs
+++ b/boards/imix/src/components/rf233.rs
@@ -17,8 +17,9 @@
 
 use capsules::rf233::RF233;
 use capsules::virtual_spi::VirtualSpiMasterDevice;
-use hil;
 use kernel::component::Component;
+use kernel::hil;
+use kernel::static_init;
 
 pub struct RF233Component {
     spi: &'static VirtualSpiMasterDevice<'static, sam4l::spi::SpiHw>,

--- a/boards/imix/src/components/rng.rs
+++ b/boards/imix/src/components/rng.rs
@@ -18,8 +18,10 @@
 use capsules::rng;
 use kernel::capabilities;
 use kernel::component::Component;
+use kernel::create_capability;
 use kernel::hil::entropy::Entropy32;
 use kernel::hil::rng::Rng;
+use kernel::static_init;
 
 pub struct RngComponent {
     board_kernel: &'static kernel::Kernel,

--- a/boards/imix/src/components/si7021.rs
+++ b/boards/imix/src/components/si7021.rs
@@ -24,9 +24,11 @@ use capsules::si7021::SI7021;
 use capsules::temperature::TemperatureSensor;
 use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use capsules::virtual_i2c::{I2CDevice, MuxI2C};
-use hil;
 use kernel::capabilities;
 use kernel::component::Component;
+use kernel::create_capability;
+use kernel::hil;
+use kernel::static_init;
 
 pub struct SI7021Component {
     i2c_mux: &'static MuxI2C<'static>,

--- a/boards/imix/src/components/spi.rs
+++ b/boards/imix/src/components/spi.rs
@@ -21,6 +21,7 @@
 use capsules::spi::Spi;
 use capsules::virtual_spi::{MuxSpiMaster, VirtualSpiMasterDevice};
 use kernel::component::Component;
+use kernel::static_init;
 
 pub struct SpiSyscallComponent {
     spi_mux: &'static MuxSpiMaster<'static, sam4l::spi::SpiHw>,

--- a/boards/imix/src/components/udp_6lowpan.rs
+++ b/boards/imix/src/components/udp_6lowpan.rs
@@ -32,7 +32,9 @@ use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 
 use kernel::capabilities;
 use kernel::component::Component;
+use kernel::create_capability;
 use kernel::hil::radio;
+use kernel::static_init;
 
 const PAYLOAD_LEN: usize = 200; //The max size UDP message that can be sent by userland apps
 

--- a/boards/imix/src/components/usb.rs
+++ b/boards/imix/src/components/usb.rs
@@ -16,6 +16,8 @@
 
 use kernel::capabilities;
 use kernel::component::Component;
+use kernel::create_capability;
+use kernel::static_init;
 
 pub struct UsbComponent {
     board_kernel: &'static kernel::Kernel,

--- a/boards/imix/src/i2c_dummy.rs
+++ b/boards/imix/src/i2c_dummy.rs
@@ -1,6 +1,7 @@
 //! A dummy I2C client
 
 use core::cell::Cell;
+use kernel::debug;
 use kernel::hil;
 use kernel::hil::i2c::I2CMaster;
 use sam4l::i2c;

--- a/boards/imix/src/icmp_lowpan_test.rs
+++ b/boards/imix/src/icmp_lowpan_test.rs
@@ -20,7 +20,6 @@
 //! ...
 //! icmp_lowpan_test.start();
 
-extern crate sam4l;
 use capsules::ieee802154::device::MacDevice;
 use capsules::net::icmpv6::icmpv6::{ICMP6Header, ICMP6Type};
 use capsules::net::icmpv6::icmpv6_send::{ICMP6SendStruct, ICMP6Sender};
@@ -32,9 +31,11 @@ use capsules::net::sixlowpan::sixlowpan_compression;
 use capsules::net::sixlowpan::sixlowpan_state::{Sixlowpan, SixlowpanState, TxState};
 use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use core::cell::Cell;
+use kernel::debug;
 use kernel::hil::radio;
 use kernel::hil::time;
 use kernel::hil::time::Frequency;
+use kernel::static_init;
 use kernel::ReturnCode;
 
 pub const SRC_ADDR: IPAddr = IPAddr([

--- a/boards/imix/src/io.rs
+++ b/boards/imix/src/io.rs
@@ -5,7 +5,7 @@ use kernel::debug;
 use kernel::hil::led;
 use kernel::hil::uart::{self, UART};
 
-use PROCESSES;
+use crate::PROCESSES;
 
 struct Writer {
     initialized: bool,

--- a/boards/imix/src/ipv6_lowpan_test.rs
+++ b/boards/imix/src/ipv6_lowpan_test.rs
@@ -38,7 +38,6 @@
 //! ...
 //! lowpan_frag_test.start(); // If flashing the transmitting Imix
 
-extern crate sam4l;
 use capsules::ieee802154::device::{MacDevice, TxClient};
 use capsules::net::ieee802154::MacAddress;
 use capsules::net::ipv6::ip_utils::{ip6_nh, IPAddr};
@@ -51,9 +50,11 @@ use capsules::net::udp::udp::UDPHeader;
 use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use core::cell::Cell;
 use core::ptr;
+use kernel::debug;
 use kernel::hil::radio;
 use kernel::hil::time;
 use kernel::hil::time::Frequency;
+use kernel::static_init;
 use kernel::ReturnCode;
 
 pub const MLP: [u8; 8] = [0xc0, 0xc1, 0xc2, 0xc3, 0xc4, 0xc5, 0xc6, 0xc7];

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -5,22 +5,8 @@
 
 #![no_std]
 #![no_main]
-#![feature(in_band_lifetimes)]
+#![feature(in_band_lifetimes, uniform_paths)]
 #![deny(missing_docs)]
-
-extern crate capsules;
-#[allow(unused_imports)]
-#[macro_use(
-    debug,
-    debug_gpio,
-    static_init,
-    create_capability,
-    register_bitfields,
-    register_bitmasks
-)]
-extern crate kernel;
-extern crate cortexm4;
-extern crate sam4l;
 
 mod components;
 use capsules::alarm::AlarmDriver;
@@ -38,6 +24,8 @@ use kernel::hil::radio;
 use kernel::hil::radio::{RadioConfig, RadioData};
 use kernel::hil::spi::SpiMaster;
 use kernel::hil::Controller;
+#[allow(unused_imports)]
+use kernel::{create_capability, debug, debug_gpio, static_init};
 
 use components::adc::AdcComponent;
 use components::alarm::AlarmDriverComponent;

--- a/boards/imix/src/rng_test.rs
+++ b/boards/imix/src/rng_test.rs
@@ -18,6 +18,7 @@ use capsules::rng;
 use capsules::test::rng::TestRng;
 use kernel::hil::entropy::{Entropy32, Entropy8};
 use kernel::hil::rng::Rng;
+use kernel::static_init;
 use sam4l::trng::TRNG;
 
 pub unsafe fn run_entropy32() {

--- a/boards/imix/src/spi_slave_dummy.rs
+++ b/boards/imix/src/spi_slave_dummy.rs
@@ -1,6 +1,5 @@
 //! A dummy SPI client to test the SPI implementation
 
-extern crate kernel;
 use kernel::hil::gpio;
 use kernel::hil::gpio::Pin;
 use kernel::hil::spi::{self, SpiSlave};

--- a/boards/imix/src/udp_lowpan_test.rs
+++ b/boards/imix/src/udp_lowpan_test.rs
@@ -23,7 +23,6 @@
 //! ...
 //! udp_lowpan_test.start();
 
-extern crate sam4l;
 use capsules::ieee802154::device::MacDevice;
 use capsules::net::ieee802154::MacAddress;
 use capsules::net::ipv6::ip_utils::{ip6_nh, IPAddr};
@@ -35,9 +34,11 @@ use capsules::net::udp::udp::UDPHeader;
 use capsules::net::udp::udp_send::{UDPSendStruct, UDPSender};
 use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use core::cell::Cell;
+use kernel::debug;
 use kernel::hil::radio;
 use kernel::hil::time;
 use kernel::hil::time::Frequency;
+use kernel::static_init;
 use kernel::ReturnCode;
 
 pub const SRC_ADDR: IPAddr = IPAddr([

--- a/boards/imix/src/virtual_uart_rx_test.rs
+++ b/boards/imix/src/virtual_uart_rx_test.rs
@@ -46,7 +46,9 @@
 
 use capsules::test::virtual_uart::TestVirtualUartReceive;
 use capsules::virtual_uart::{UartDevice, UartMux};
+use kernel::debug;
 use kernel::hil::uart::UART;
+use kernel::static_init;
 
 pub unsafe fn run_virtual_uart_receive(mux: &'static UartMux<'static>) {
     debug!("Starting virtual reads.");

--- a/boards/launchxl/Cargo.toml
+++ b/boards/launchxl/Cargo.toml
@@ -3,6 +3,7 @@ name = "launchxl"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
 build = "build.rs"
+edition = "2018"
 
 [profile.dev]
 panic = "abort"

--- a/boards/launchxl/src/i2c_tests.rs
+++ b/boards/launchxl/src/i2c_tests.rs
@@ -2,6 +2,7 @@
 
 use cc26x2::i2c;
 use core::cell::Cell;
+use kernel::debug;
 use kernel::hil;
 use kernel::hil::i2c::I2CMaster;
 

--- a/boards/launchxl/src/io.rs
+++ b/boards/launchxl/src/io.rs
@@ -5,7 +5,7 @@ use kernel::debug;
 use kernel::hil::led;
 use kernel::hil::uart::{self, UART};
 
-use PROCESSES;
+use crate::PROCESSES;
 
 struct Writer {
     initialized: bool,

--- a/boards/launchxl/src/main.rs
+++ b/boards/launchxl/src/main.rs
@@ -2,15 +2,8 @@
 #![no_main]
 #![feature(lang_items, asm)]
 
-extern crate capsules;
-extern crate cortexm4;
-#[macro_use]
-extern crate enum_primitive;
-extern crate cc26x2;
-
 #[allow(unused_imports)]
-#[macro_use(create_capability, debug, debug_gpio, static_init)]
-extern crate kernel;
+use kernel::{create_capability, debug, debug_gpio, static_init};
 
 use capsules::virtual_uart::{UartDevice, UartMux};
 use cc26x2::aon;
@@ -79,7 +72,7 @@ impl kernel::Platform for Platform {
 }
 
 mod pin_mapping_cc1312r;
-use pin_mapping_cc1312r::PIN_FN;
+use crate::pin_mapping_cc1312r::PIN_FN;
 ///
 unsafe fn configure_pins() {
     cc26x2::gpio::PORT[PIN_FN::UART0_RX as usize].enable_uart0_rx();

--- a/boards/launchxl/src/pin_mapping_cc1312r.rs
+++ b/boards/launchxl/src/pin_mapping_cc1312r.rs
@@ -1,4 +1,5 @@
 use enum_primitive::cast::FromPrimitive;
+use enum_primitive::enum_from_primitive;
 
 enum_from_primitive! {
 pub enum PIN_FN {

--- a/boards/nordic/nrf52840dk/Cargo.toml
+++ b/boards/nordic/nrf52840dk/Cargo.toml
@@ -3,6 +3,7 @@ name = "nrf52840dk"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
 build = "build.rs"
+edition = "2018"
 
 [profile.dev]
 panic = "abort"

--- a/boards/nordic/nrf52840dk/src/io.rs
+++ b/boards/nordic/nrf52840dk/src/io.rs
@@ -5,7 +5,7 @@ use kernel::debug;
 use kernel::hil::led;
 use kernel::hil::uart::{self, UART};
 
-use PROCESSES;
+use crate::PROCESSES;
 
 struct Writer {
     initialized: bool,

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -7,14 +7,8 @@
 #![no_main]
 #![deny(missing_docs)]
 
-extern crate capsules;
 #[allow(unused_imports)]
-#[macro_use(debug, debug_verbose, debug_gpio, static_init)]
-extern crate kernel;
-extern crate cortexm4;
-extern crate nrf52;
-extern crate nrf52dk_base;
-extern crate nrf5x;
+use kernel::{debug, debug_gpio, debug_verbose, static_init};
 
 use nrf52dk_base::{SpiMX25R6435FPins, SpiPins, UartPins};
 

--- a/boards/nordic/nrf52dk/Cargo.toml
+++ b/boards/nordic/nrf52dk/Cargo.toml
@@ -3,6 +3,7 @@ name = "nrf52dk"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
 build = "build.rs"
+edition = "2018"
 
 [profile.dev]
 panic = "abort"

--- a/boards/nordic/nrf52dk/src/io.rs
+++ b/boards/nordic/nrf52dk/src/io.rs
@@ -5,7 +5,7 @@ use kernel::debug;
 use kernel::hil::led;
 use kernel::hil::uart::{self, UART};
 
-use PROCESSES;
+use crate::PROCESSES;
 
 struct Writer {
     initialized: bool,

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -64,14 +64,8 @@
 #![no_main]
 #![deny(missing_docs)]
 
-extern crate capsules;
 #[allow(unused_imports)]
-#[macro_use(debug, debug_verbose, debug_gpio, static_init)]
-extern crate kernel;
-extern crate cortexm4;
-extern crate nrf52;
-extern crate nrf52dk_base;
-extern crate nrf5x;
+use kernel::{debug, debug_gpio, debug_verbose, static_init};
 
 use nrf52dk_base::{SpiPins, UartPins};
 

--- a/boards/nordic/nrf52dk/src/tests/aes.rs
+++ b/boards/nordic/nrf52dk/src/tests/aes.rs
@@ -1,5 +1,6 @@
 use capsules::test::aes::TestAes128Ctr;
 use kernel::hil::symmetric_encryption::{AES128, AES128_BLOCK_SIZE, AES128_KEY_SIZE};
+use kernel::static_init;
 use nrf5x::aes::{AesECB, AESECB};
 
 /// To run the tests add the following `main.rs::reset_handler` somewhere after that the AES

--- a/boards/nordic/nrf52dk/src/tests/uart.rs
+++ b/boards/nordic/nrf52dk/src/tests/uart.rs
@@ -1,4 +1,5 @@
 use kernel::hil::uart::UART;
+use kernel::static_init;
 use nrf52::uart::UARTE0;
 
 const BUFFER_SIZE_2048: usize = 2048;

--- a/boards/nordic/nrf52dk_base/Cargo.toml
+++ b/boards/nordic/nrf52dk_base/Cargo.toml
@@ -2,7 +2,7 @@
 name = "nrf52dk_base"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-
+edition = "2018"
 
 [dependencies]
 cortexm4 = { path = "../../../arch/cortex-m4" }

--- a/boards/nordic/nrf52dk_base/src/lib.rs
+++ b/boards/nordic/nrf52dk_base/src/lib.rs
@@ -2,13 +2,8 @@
 
 #![no_std]
 
-extern crate capsules;
-extern crate cortexm4;
 #[allow(unused_imports)]
-#[macro_use(create_capability, debug, debug_verbose, debug_gpio, static_init)]
-extern crate kernel;
-extern crate nrf52;
-extern crate nrf5x;
+use kernel::{create_capability, debug, debug_gpio, debug_verbose, static_init};
 
 use capsules::virtual_alarm::VirtualMuxAlarm;
 use capsules::virtual_spi::MuxSpiMaster;

--- a/capsules/Cargo.toml
+++ b/capsules/Cargo.toml
@@ -2,6 +2,7 @@
 name = "capsules"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+edition = "2018"
 
 [dependencies]
 kernel = { path = "../kernel" }

--- a/capsules/src/adc.rs
+++ b/capsules/src/adc.rs
@@ -36,7 +36,7 @@ use kernel::hil;
 use kernel::{AppId, AppSlice, Callback, Driver, ReturnCode, Shared};
 
 /// Syscall driver number.
-use driver;
+use crate::driver;
 pub const DRIVER_NUM: usize = driver::NUM::ADC as usize;
 
 /// ADC application driver, used by applications to interact with ADC.

--- a/capsules/src/aes_ccm.rs
+++ b/capsules/src/aes_ccm.rs
@@ -51,6 +51,8 @@
 //! sam4l::aes::AES.enable();
 //! ```
 
+use crate::net::stream::SResult;
+use crate::net::stream::{encode_bytes, encode_u16};
 use core::cell::Cell;
 use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::hil::symmetric_encryption;
@@ -58,8 +60,6 @@ use kernel::hil::symmetric_encryption::{
     AES128Ctr, AES128, AES128CBC, AES128_BLOCK_SIZE, AES128_KEY_SIZE, CCM_NONCE_LENGTH,
 };
 use kernel::ReturnCode;
-use net::stream::SResult;
-use net::stream::{encode_bytes, encode_u16};
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 enum CCMState {

--- a/capsules/src/alarm.rs
+++ b/capsules/src/alarm.rs
@@ -5,7 +5,7 @@ use kernel::hil::time::{self, Alarm, Frequency};
 use kernel::{AppId, Callback, Driver, Grant, ReturnCode};
 
 /// Syscall driver number.
-use driver;
+use crate::driver;
 pub const DRIVER_NUM: usize = driver::NUM::ALARM as usize;
 
 #[derive(Copy, Clone, Debug)]

--- a/capsules/src/ambient_light.rs
+++ b/capsules/src/ambient_light.rs
@@ -15,7 +15,7 @@ use kernel::hil;
 use kernel::{AppId, Callback, Driver, Grant, ReturnCode};
 
 /// Syscall driver number.
-use driver;
+use crate::driver;
 pub const DRIVER_NUM: usize = driver::NUM::AMBIENT_LIGHT as usize;
 
 /// Per-process metadata

--- a/capsules/src/analog_comparator.rs
+++ b/capsules/src/analog_comparator.rs
@@ -32,7 +32,7 @@
 // Last modified August 9th, 2018
 
 /// Syscall driver number.
-use driver;
+use crate::driver;
 pub const DRIVER_NUM: usize = driver::NUM::ANALOG_COMPARATOR as usize;
 
 use core::cell::Cell;

--- a/capsules/src/app_flash_driver.rs
+++ b/capsules/src/app_flash_driver.rs
@@ -26,7 +26,7 @@ use kernel::hil;
 use kernel::{AppId, AppSlice, Callback, Driver, Grant, ReturnCode, Shared};
 
 /// Syscall driver number.
-use driver;
+use crate::driver;
 pub const DRIVER_NUM: usize = driver::NUM::APP_FLASH as usize;
 
 #[derive(Default)]

--- a/capsules/src/ble_advertising_driver.rs
+++ b/capsules/src/ble_advertising_driver.rs
@@ -98,13 +98,14 @@
 use core::cell::Cell;
 use core::cmp;
 use kernel::common::cells::OptionalCell;
+use kernel::debug;
 use kernel::hil::ble_advertising;
 use kernel::hil::ble_advertising::RadioChannel;
 use kernel::hil::time::Frequency;
 use kernel::ReturnCode;
 
 /// Syscall driver number.
-use driver;
+use crate::driver;
 pub const DRIVER_NUM: usize = driver::NUM::BLE_ADVERTISING as usize;
 
 /// Advertisement Buffer

--- a/capsules/src/button.rs
+++ b/capsules/src/button.rs
@@ -55,7 +55,7 @@ use kernel::hil::gpio::{Client, InterruptMode};
 use kernel::{AppId, Callback, Driver, Grant, ReturnCode};
 
 /// Syscall driver number.
-use driver;
+use crate::driver;
 pub const DRIVER_NUM: usize = driver::NUM::BUTTON as usize;
 
 /// This capsule keeps track for each app of which buttons it has a registered

--- a/capsules/src/console.rs
+++ b/capsules/src/console.rs
@@ -40,7 +40,7 @@ use kernel::hil::uart::{self, Client, UART};
 use kernel::{AppId, AppSlice, Callback, Driver, Grant, ReturnCode, Shared};
 
 /// Syscall driver number.
-use driver;
+use crate::driver;
 pub const DRIVER_NUM: usize = driver::NUM::CONSOLE as usize;
 
 #[derive(Default)]

--- a/capsules/src/crc.rs
+++ b/capsules/src/crc.rs
@@ -71,7 +71,7 @@ use kernel::hil::crc::CrcAlg;
 use kernel::{AppId, AppSlice, Callback, Driver, Grant, ReturnCode, Shared};
 
 /// Syscall driver number.
-use driver;
+use crate::driver;
 pub const DRIVER_NUM: usize = driver::NUM::CRC as usize;
 
 /// An opaque value maintaining state for one application's request

--- a/capsules/src/driver.rs
+++ b/capsules/src/driver.rs
@@ -1,4 +1,5 @@
 use enum_primitive::cast::FromPrimitive;
+use enum_primitive::enum_from_primitive;
 
 enum_from_primitive! {
 #[derive(Debug, PartialEq)]

--- a/capsules/src/gpio.rs
+++ b/capsules/src/gpio.rs
@@ -44,7 +44,7 @@
 //! have had interrupts enabled.
 
 /// Syscall driver number.
-use driver;
+use crate::driver;
 pub const DRIVER_NUM: usize = driver::NUM::GPIO as usize;
 
 use kernel::hil::gpio::{Client, InputMode, InterruptMode, Pin, PinCtl};

--- a/capsules/src/gpio_async.rs
+++ b/capsules/src/gpio_async.rs
@@ -29,7 +29,7 @@ use kernel::ReturnCode;
 use kernel::{AppId, Callback, Driver};
 
 /// Syscall driver number.
-use driver;
+use crate::driver;
 pub const DRIVER_NUM: usize = driver::NUM::GPIO_ASYNC as usize;
 
 pub struct GPIOAsync<'a, Port: hil::gpio_async::Port> {

--- a/capsules/src/humidity.rs
+++ b/capsules/src/humidity.rs
@@ -52,7 +52,7 @@ use kernel::ReturnCode;
 use kernel::{AppId, Callback, Driver, Grant};
 
 /// Syscall driver number.
-use driver;
+use crate::driver;
 pub const DRIVER_NUM: usize = driver::NUM::HUMIDITY as usize;
 
 #[derive(Clone, Copy, PartialEq)]

--- a/capsules/src/i2c_master.rs
+++ b/capsules/src/i2c_master.rs
@@ -1,9 +1,10 @@
+use enum_primitive::enum_from_primitive;
 use kernel::common::cells::{MapCell, OptionalCell, TakeCell};
 use kernel::hil::i2c;
 use kernel::{AppId, AppSlice, Callback, Driver, Grant, ReturnCode, Shared};
 
 /// Syscall driver number.
-use driver;
+use crate::driver;
 pub const DRIVER_NUM: usize = driver::NUM::I2C_MASTER as usize;
 
 #[derive(Default)]

--- a/capsules/src/i2c_master_slave_driver.rs
+++ b/capsules/src/i2c_master_slave_driver.rs
@@ -23,7 +23,7 @@ pub static mut BUFFER2: [u8; 256] = [0; 256];
 pub static mut BUFFER3: [u8; 256] = [0; 256];
 
 /// Syscall driver number.
-use driver;
+use crate::driver;
 pub const DRIVER_NUM: usize = driver::NUM::I2C_MASTER_SLAVE as usize;
 
 #[derive(Default)]

--- a/capsules/src/ieee802154/device.rs
+++ b/capsules/src/ieee802154/device.rs
@@ -11,9 +11,9 @@
 //! example, a radio chip might be able to completely inline the frame security
 //! procedure in hardware, as opposed to requiring a software implementation.
 
-use ieee802154::framer::Frame;
+use crate::ieee802154::framer::Frame;
+use crate::net::ieee802154::{Header, KeyId, MacAddress, PanID, SecurityLevel};
 use kernel::ReturnCode;
-use net::ieee802154::{Header, KeyId, MacAddress, PanID, SecurityLevel};
 
 pub trait MacDevice<'a> {
     /// Sets the transmission client of this MAC device

--- a/capsules/src/ieee802154/driver.rs
+++ b/capsules/src/ieee802154/driver.rs
@@ -4,13 +4,13 @@
 //! frames. Also provides a minimal list-based interface for managing keys and
 //! known link neighbors, which is needed for 802.15.4 security.
 
+use crate::ieee802154::{device, framer};
+use crate::net::ieee802154::{AddressMode, Header, KeyId, MacAddress, PanID, SecurityLevel};
+use crate::net::stream::{decode_bytes, decode_u8, encode_bytes, encode_u8, SResult};
 use core::cell::Cell;
 use core::cmp::min;
-use ieee802154::{device, framer};
 use kernel::common::cells::{MapCell, OptionalCell, TakeCell};
 use kernel::{AppId, AppSlice, Callback, Driver, Grant, ReturnCode, Shared};
-use net::ieee802154::{AddressMode, Header, KeyId, MacAddress, PanID, SecurityLevel};
-use net::stream::{decode_bytes, decode_u8, encode_bytes, encode_u8, SResult};
 
 const MAX_NEIGHBORS: usize = 4;
 const MAX_KEYS: usize = 4;

--- a/capsules/src/ieee802154/framer.rs
+++ b/capsules/src/ieee802154/framer.rs
@@ -69,18 +69,18 @@
 // TODO: Channel scanning
 //
 
+use crate::ieee802154::device::{MacDevice, RxClient, TxClient};
+use crate::ieee802154::mac::Mac;
+use crate::net::ieee802154::{
+    FrameType, FrameVersion, Header, KeyId, MacAddress, PanID, Security, SecurityLevel,
+};
+use crate::net::stream::SResult;
+use crate::net::stream::{encode_bytes, encode_u32, encode_u8};
 use core::cell::Cell;
-use ieee802154::device::{MacDevice, RxClient, TxClient};
-use ieee802154::mac::Mac;
 use kernel::common::cells::{MapCell, OptionalCell};
 use kernel::hil::radio;
 use kernel::hil::symmetric_encryption::{CCMClient, AES128CCM};
 use kernel::ReturnCode;
-use net::ieee802154::{
-    FrameType, FrameVersion, Header, KeyId, MacAddress, PanID, Security, SecurityLevel,
-};
-use net::stream::SResult;
-use net::stream::{encode_bytes, encode_u32, encode_u8};
 
 /// A `Frame` wraps a static mutable byte slice and keeps just enough
 /// information about its header contents to expose a restricted interface for

--- a/capsules/src/ieee802154/mac.rs
+++ b/capsules/src/ieee802154/mac.rs
@@ -9,10 +9,11 @@
 //! the underlying kernel::hil::radio::Radio powered at all times and passing
 //! through each frame for transmission.
 
+use crate::net::ieee802154::{Header, MacAddress};
 use kernel::common::cells::OptionalCell;
+use kernel::debug;
 use kernel::hil::radio;
 use kernel::ReturnCode;
-use net::ieee802154::{Header, MacAddress};
 
 pub trait Mac {
     /// Initializes the layer; may require a buffer to temporarily retaining frames to be

--- a/capsules/src/ieee802154/virtual_mac.rs
+++ b/capsules/src/ieee802154/virtual_mac.rs
@@ -26,12 +26,12 @@
 //! mux_mac.add_user(virtual_mac);
 //! ```
 
+use crate::ieee802154::{device, framer};
+use crate::net::ieee802154::{Header, KeyId, MacAddress, PanID, SecurityLevel};
 use core::cell::Cell;
-use ieee802154::{device, framer};
 use kernel::common::cells::{MapCell, OptionalCell};
 use kernel::common::{List, ListLink, ListNode};
 use kernel::ReturnCode;
-use net::ieee802154::{Header, KeyId, MacAddress, PanID, SecurityLevel};
 
 /// IEE 802.15.4 MAC device muxer that keeps a list of MAC users and sequences
 /// any pending transmission requests. Any received frames from the underlying

--- a/capsules/src/ieee802154/xmac.rs
+++ b/capsules/src/ieee802154/xmac.rs
@@ -76,14 +76,14 @@
 // Date: Nov 21 2017
 //
 
+use crate::ieee802154::mac::Mac;
+use crate::net::ieee802154::{FrameType, FrameVersion, Header, MacAddress, PanID};
 use core::cell::Cell;
-use ieee802154::mac::Mac;
 use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::hil::radio;
 use kernel::hil::rng::{self, Rng};
 use kernel::hil::time::{self, Alarm, Frequency, Time};
 use kernel::ReturnCode;
-use net::ieee802154::{FrameType, FrameVersion, Header, MacAddress, PanID};
 
 // Time the radio will remain awake listening for packets before sleeping.
 // Observing the RF233, receive callbacks for preambles are generated only after

--- a/capsules/src/led.rs
+++ b/capsules/src/led.rs
@@ -52,7 +52,7 @@ use kernel::hil;
 use kernel::{AppId, Driver, ReturnCode};
 
 /// Syscall driver number.
-use driver;
+use crate::driver;
 pub const DRIVER_NUM: usize = driver::NUM::LED as usize;
 
 /// Whether the LEDs are active high or active low on this platform.

--- a/capsules/src/lib.rs
+++ b/capsules/src/lib.rs
@@ -2,12 +2,6 @@
 #![forbid(unsafe_code)]
 #![no_std]
 
-#[allow(unused_imports)]
-#[macro_use(debug)]
-extern crate kernel;
-#[macro_use]
-extern crate enum_primitive;
-
 pub mod test;
 
 #[macro_use]

--- a/capsules/src/lps25hb.rs
+++ b/capsules/src/lps25hb.rs
@@ -23,7 +23,7 @@ use kernel::hil::i2c;
 use kernel::{AppId, Callback, Driver, ReturnCode};
 
 /// Syscall driver number.
-use driver;
+use crate::driver;
 pub const DRIVER_NUM: usize = driver::NUM::LPS25HB as usize;
 
 // Buffer to use for I2C messages

--- a/capsules/src/ltc294x.rs
+++ b/capsules/src/ltc294x.rs
@@ -51,7 +51,7 @@ use kernel::ReturnCode;
 use kernel::{AppId, Callback, Driver};
 
 /// Syscall driver number.
-use driver;
+use crate::driver;
 pub const DRIVER_NUM: usize = driver::NUM::LTC294X as usize;
 
 pub static mut BUFFER: [u8; 20] = [0; 20];

--- a/capsules/src/max17205.rs
+++ b/capsules/src/max17205.rs
@@ -41,7 +41,7 @@ use kernel::hil::i2c;
 use kernel::{AppId, Callback, Driver, ReturnCode};
 
 /// Syscall driver number.
-use driver;
+use crate::driver;
 pub const DRIVER_NUM: usize = driver::NUM::MAX17205 as usize;
 
 pub static mut BUFFER: [u8; 8] = [0; 8];

--- a/capsules/src/mx25r6435f.rs
+++ b/capsules/src/mx25r6435f.rs
@@ -49,6 +49,7 @@ use core::cell::Cell;
 use core::ops::{Index, IndexMut};
 use kernel::common::cells::OptionalCell;
 use kernel::common::cells::TakeCell;
+use kernel::debug;
 use kernel::hil;
 use kernel::hil::time::Frequency;
 use kernel::ReturnCode;

--- a/capsules/src/net/icmpv6/icmpv6.rs
+++ b/capsules/src/net/icmpv6/icmpv6.rs
@@ -4,9 +4,9 @@
 //!
 //! - Author: Conor McAvity <cmcavity@stanford.edu>
 
-use net::stream::SResult;
-use net::stream::{decode_u16, decode_u32, decode_u8};
-use net::stream::{encode_u16, encode_u32, encode_u8};
+use crate::net::stream::SResult;
+use crate::net::stream::{decode_u16, decode_u32, decode_u8};
+use crate::net::stream::{encode_u16, encode_u32, encode_u8};
 
 /// A struct representing an ICMPv6 header.
 #[derive(Copy, Clone)]

--- a/capsules/src/net/icmpv6/icmpv6_send.rs
+++ b/capsules/src/net/icmpv6/icmpv6_send.rs
@@ -7,12 +7,12 @@
 //!
 //! - Author: Conor McAvity <cmcavity@stanford.edu>
 
+use crate::net::icmpv6::icmpv6::ICMP6Header;
+use crate::net::ipv6::ip_utils::IPAddr;
+use crate::net::ipv6::ipv6::TransportHeader;
+use crate::net::ipv6::ipv6_send::{IP6SendClient, IP6Sender};
 use kernel::common::cells::OptionalCell;
 use kernel::ReturnCode;
-use net::icmpv6::icmpv6::ICMP6Header;
-use net::ipv6::ip_utils::IPAddr;
-use net::ipv6::ipv6::TransportHeader;
-use net::ipv6::ipv6_send::{IP6SendClient, IP6Sender};
 
 /// A trait for a client of an `ICMP6Sender`.
 pub trait ICMP6SendClient {

--- a/capsules/src/net/ieee802154.rs
+++ b/capsules/src/net/ieee802154.rs
@@ -2,9 +2,9 @@
 //! Supports the general MAC frame format, which encompasses data frames, beacon
 //! frames, MAC command frames, and the like.
 
-use net::stream::SResult;
-use net::stream::{decode_bytes_be, decode_u16, decode_u32, decode_u8};
-use net::stream::{encode_bytes, encode_bytes_be, encode_u16, encode_u32, encode_u8};
+use crate::net::stream::SResult;
+use crate::net::stream::{decode_bytes_be, decode_u16, decode_u32, decode_u8};
+use crate::net::stream::{encode_bytes, encode_bytes_be, encode_u16, encode_u32, encode_u8};
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub enum MacAddress {

--- a/capsules/src/net/ipv6/ip_utils.rs
+++ b/capsules/src/net/ipv6/ip_utils.rs
@@ -2,10 +2,10 @@
 //! of the IP stack. Note that this file also contains the definition for the
 //! [IPAddr](struct.IPAddr.html] struct and associated helper functions.
 
-use net::icmpv6::icmpv6::{ICMP6Header, ICMP6HeaderOptions};
-use net::ieee802154::MacAddress;
-use net::ipv6::ipv6::IP6Header;
-use net::udp::udp::UDPHeader;
+use crate::net::icmpv6::icmpv6::{ICMP6Header, ICMP6HeaderOptions};
+use crate::net::ieee802154::MacAddress;
+use crate::net::ipv6::ipv6::IP6Header;
+use crate::net::udp::udp::UDPHeader;
 
 #[derive(Copy, Clone, PartialEq)]
 pub enum MacAddr {

--- a/capsules/src/net/ipv6/ipv6.rs
+++ b/capsules/src/net/ipv6/ipv6.rs
@@ -64,14 +64,14 @@
 // a major problem in general, it makes handling encapsulated IPv6 packets
 // (as required by 6LoWPAN) difficult.
 
+use crate::net::icmpv6::icmpv6::ICMP6Header;
+use crate::net::ipv6::ip_utils::{compute_icmp_checksum, compute_udp_checksum, ip6_nh, IPAddr};
+use crate::net::stream::SResult;
+use crate::net::stream::{decode_bytes, decode_u16, decode_u8};
+use crate::net::stream::{encode_bytes, encode_u16, encode_u8};
+use crate::net::tcp::TCPHeader;
+use crate::net::udp::udp::UDPHeader;
 use kernel::ReturnCode;
-use net::icmpv6::icmpv6::ICMP6Header;
-use net::ipv6::ip_utils::{compute_icmp_checksum, compute_udp_checksum, ip6_nh, IPAddr};
-use net::stream::SResult;
-use net::stream::{decode_bytes, decode_u16, decode_u8};
-use net::stream::{encode_bytes, encode_u16, encode_u8};
-use net::tcp::TCPHeader;
-use net::udp::udp::UDPHeader;
 
 pub const UDP_HDR_LEN: usize = 8;
 pub const ICMP_HDR_LEN: usize = 8;

--- a/capsules/src/net/ipv6/ipv6_recv.rs
+++ b/capsules/src/net/ipv6/ipv6_recv.rs
@@ -1,7 +1,8 @@
+use crate::net::ipv6::ipv6::IP6Header;
+use crate::net::sixlowpan::sixlowpan_state::SixlowpanRxClient;
 use kernel::common::cells::OptionalCell;
+use kernel::debug;
 use kernel::ReturnCode;
-use net::ipv6::ipv6::IP6Header;
-use net::sixlowpan::sixlowpan_state::SixlowpanRxClient;
 
 // To provide some context for the entire rx chain:
 /*

--- a/capsules/src/net/ipv6/ipv6_send.rs
+++ b/capsules/src/net/ipv6/ipv6_send.rs
@@ -16,15 +16,16 @@
 // over 6LoWPAN, and should be separated from the generic IPv6 sending
 // interface.
 
+use crate::ieee802154::device::{MacDevice, TxClient};
+use crate::net::ieee802154::MacAddress;
+use crate::net::ipv6::ip_utils::IPAddr;
+use crate::net::ipv6::ipv6::{IP6Header, IP6Packet, TransportHeader};
+use crate::net::sixlowpan::sixlowpan_state::TxState;
 use core::cell::Cell;
-use ieee802154::device::{MacDevice, TxClient};
 use kernel::common::cells::{OptionalCell, TakeCell};
+use kernel::debug;
 use kernel::hil::time::{self, Frequency};
 use kernel::ReturnCode;
-use net::ieee802154::MacAddress;
-use net::ipv6::ip_utils::IPAddr;
-use net::ipv6::ipv6::{IP6Header, IP6Packet, TransportHeader};
-use net::sixlowpan::sixlowpan_state::TxState;
 
 /// This trait must be implemented by upper layers in order to receive
 /// the `send_done` callback when a transmission has completed. The upper

--- a/capsules/src/net/sixlowpan/sixlowpan_compression.rs
+++ b/capsules/src/net/sixlowpan/sixlowpan_compression.rs
@@ -1,13 +1,13 @@
+use crate::net::ieee802154::MacAddress;
+use crate::net::ipv6::ip_utils::{compute_udp_checksum, ip6_nh, IPAddr};
+use crate::net::ipv6::ipv6::{IP6Header, IP6Packet, TransportHeader};
+use crate::net::udp::udp::UDPHeader;
+use crate::net::util;
+use crate::net::util::{slice_to_u16, u16_to_slice};
 /// Implements the 6LoWPAN specification for sending IPv6 datagrams over
 /// 802.15.4 packets efficiently, as detailed in RFC 6282.
 use core::mem;
 use core::result::Result;
-use net::ieee802154::MacAddress;
-use net::ipv6::ip_utils::{compute_udp_checksum, ip6_nh, IPAddr};
-use net::ipv6::ipv6::{IP6Header, IP6Packet, TransportHeader};
-use net::udp::udp::UDPHeader;
-use net::util;
-use net::util::{slice_to_u16, u16_to_slice};
 
 /// Contains bit masks and constants related to the two-byte header of the
 /// LoWPAN_IPHC encoding format.

--- a/capsules/src/net/sixlowpan/sixlowpan_state.rs
+++ b/capsules/src/net/sixlowpan/sixlowpan_state.rs
@@ -224,22 +224,22 @@
 //     reassembled.
 //
 
+use crate::ieee802154::device::{MacDevice, RxClient};
+use crate::ieee802154::framer::Frame;
+use crate::net::frag_utils::Bitmap;
+use crate::net::ieee802154::{Header, KeyId, MacAddress, PanID, SecurityLevel};
+use crate::net::ipv6::ipv6::IP6Packet;
+use crate::net::sixlowpan::sixlowpan_compression;
+use crate::net::sixlowpan::sixlowpan_compression::{is_lowpan, ContextStore};
+use crate::net::util::{slice_to_u16, u16_to_slice};
 use core::cell::Cell;
 use core::cmp::min;
-use ieee802154::device::{MacDevice, RxClient};
-use ieee802154::framer::Frame;
 use kernel::common::cells::{MapCell, TakeCell};
 use kernel::common::list::{List, ListLink, ListNode};
 use kernel::hil::radio;
 use kernel::hil::time;
 use kernel::hil::time::Frequency;
 use kernel::ReturnCode;
-use net::frag_utils::Bitmap;
-use net::ieee802154::{Header, KeyId, MacAddress, PanID, SecurityLevel};
-use net::ipv6::ipv6::IP6Packet;
-use net::sixlowpan::sixlowpan_compression;
-use net::sixlowpan::sixlowpan_compression::{is_lowpan, ContextStore};
-use net::util::{slice_to_u16, u16_to_slice};
 
 // Reassembly timeout in seconds
 const FRAG_TIMEOUT: u32 = 60;

--- a/capsules/src/net/thread/tlv.rs
+++ b/capsules/src/net/thread/tlv.rs
@@ -57,10 +57,10 @@
 //    - Are Active and Pending Timestamp TLVs, respectively, required to be sent as well
 //      if either of the dataset tlvs are sent?
 
+use crate::net::stream::SResult;
+use crate::net::stream::{decode_bytes_be, decode_u16, decode_u32, decode_u8};
+use crate::net::stream::{encode_bytes, encode_bytes_be, encode_u16, encode_u32, encode_u8};
 use core::mem;
-use net::stream::SResult;
-use net::stream::{decode_bytes_be, decode_u16, decode_u32, decode_u8};
-use net::stream::{encode_bytes, encode_bytes_be, encode_u16, encode_u32, encode_u8};
 
 const TL_WIDTH: usize = 2; // Type and length fields of TLV are each one byte.
 const MAX_VALUE_FIELD_LENGTH: usize = 128; // Assume a TLV value will be no longer than 128 bytes.

--- a/capsules/src/net/udp/driver.rs
+++ b/capsules/src/net/udp/driver.rs
@@ -6,15 +6,15 @@
 //! Also exposes a list of interface addresses to the application (currently
 //! hard-coded).
 
+use crate::net::ipv6::ip_utils::IPAddr;
+use crate::net::stream::encode_u16;
+use crate::net::stream::encode_u8;
+use crate::net::stream::SResult;
+use crate::net::udp::udp_recv::{UDPReceiver, UDPRecvClient};
+use crate::net::udp::udp_send::{UDPSendClient, UDPSender};
 use core::cell::Cell;
 use core::{cmp, mem};
-use kernel::{AppId, AppSlice, Callback, Driver, Grant, ReturnCode, Shared};
-use net::ipv6::ip_utils::IPAddr;
-use net::stream::encode_u16;
-use net::stream::encode_u8;
-use net::stream::SResult;
-use net::udp::udp_recv::{UDPReceiver, UDPRecvClient};
-use net::udp::udp_send::{UDPSendClient, UDPSender};
+use kernel::{debug, AppId, AppSlice, Callback, Driver, Grant, ReturnCode, Shared};
 
 /// Syscall number
 pub const DRIVER_NUM: usize = 0x30002;

--- a/capsules/src/net/udp/udp.rs
+++ b/capsules/src/net/udp/udp.rs
@@ -3,9 +3,9 @@
 //! as the standard encode/decode functionality required for serializing
 //! the struct for transmission.
 
-use net::stream::decode_u16;
-use net::stream::encode_u16;
-use net::stream::SResult;
+use crate::net::stream::decode_u16;
+use crate::net::stream::encode_u16;
+use crate::net::stream::SResult;
 
 // Note: All UDP Header fields are stored in network byte order
 

--- a/capsules/src/net/udp/udp_recv.rs
+++ b/capsules/src/net/udp/udp_recv.rs
@@ -1,8 +1,9 @@
+use crate::net::ipv6::ip_utils::IPAddr;
+use crate::net::ipv6::ipv6::IP6Header;
+use crate::net::ipv6::ipv6_recv::IP6RecvClient;
+use crate::net::udp::udp::UDPHeader;
 use kernel::common::cells::OptionalCell;
-use net::ipv6::ip_utils::IPAddr;
-use net::ipv6::ipv6::IP6Header;
-use net::ipv6::ipv6_recv::IP6RecvClient;
-use net::udp::udp::UDPHeader;
+use kernel::debug;
 
 /// The UDP driver implements this client interface trait to receive
 /// packets passed up the network stack to the UDPReceiver, and then

--- a/capsules/src/net/udp/udp_send.rs
+++ b/capsules/src/net/udp/udp_send.rs
@@ -5,12 +5,12 @@
 //! upper layer to allow them to receive the `send_done` callback once
 //! transmission has completed.
 
+use crate::net::ipv6::ip_utils::IPAddr;
+use crate::net::ipv6::ipv6::TransportHeader;
+use crate::net::ipv6::ipv6_send::{IP6SendClient, IP6Sender};
+use crate::net::udp::udp::UDPHeader;
 use kernel::common::cells::OptionalCell;
 use kernel::ReturnCode;
-use net::ipv6::ip_utils::IPAddr;
-use net::ipv6::ipv6::TransportHeader;
-use net::ipv6::ipv6_send::{IP6SendClient, IP6Sender};
-use net::udp::udp::UDPHeader;
 
 /// The `send_done` function in this trait is invoked after the UDPSender
 /// has completed sending the requested packet. Note that the

--- a/capsules/src/ninedof.rs
+++ b/capsules/src/ninedof.rs
@@ -18,7 +18,7 @@ use kernel::ReturnCode;
 use kernel::{AppId, Callback, Driver, Grant};
 
 /// Syscall driver number.
-use driver;
+use crate::driver;
 pub const DRIVER_NUM: usize = driver::NUM::NINEDOF as usize;
 
 #[derive(Clone, Copy, PartialEq)]

--- a/capsules/src/nonvolatile_storage_driver.rs
+++ b/capsules/src/nonvolatile_storage_driver.rs
@@ -59,7 +59,7 @@ use kernel::hil;
 use kernel::{AppId, AppSlice, Callback, Driver, Grant, ReturnCode, Shared};
 
 /// Syscall driver number.
-use driver;
+use crate::driver;
 pub const DRIVER_NUM: usize = driver::NUM::NVM_STORAGE as usize;
 
 pub static mut BUFFER: [u8; 512] = [0; 512];

--- a/capsules/src/nrf51822_serialization.rs
+++ b/capsules/src/nrf51822_serialization.rs
@@ -24,7 +24,7 @@ use kernel::hil::uart::{self, Client, UARTReceiveAdvanced};
 use kernel::{AppId, AppSlice, Callback, Driver, ReturnCode, Shared};
 
 /// Syscall driver number.
-use driver;
+use crate::driver;
 pub const DRIVER_NUM: usize = driver::NUM::NRF51822_SERIALIZATION as usize;
 
 #[derive(Default)]

--- a/capsules/src/process_console.rs
+++ b/capsules/src/process_console.rs
@@ -95,6 +95,7 @@ use core::cmp;
 use core::str;
 use kernel::capabilities::ProcessManagementCapability;
 use kernel::common::cells::TakeCell;
+use kernel::debug;
 use kernel::hil::uart::{self, Client, UART};
 use kernel::introspection::KernelInfo;
 use kernel::Kernel;

--- a/capsules/src/rf233.rs
+++ b/capsules/src/rf233.rs
@@ -11,30 +11,32 @@
 
 #![allow(unused_parens)]
 
+use crate::rf233_const::{
+    ExternalState, InteruptFlags, RF233BusCommand, RF233Register, RF233TrxCmd,
+};
 use core::cell::Cell;
 use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::hil::gpio;
 use kernel::hil::radio;
 use kernel::hil::spi;
 use kernel::ReturnCode;
-use rf233_const::{ExternalState, InteruptFlags, RF233BusCommand, RF233Register, RF233TrxCmd};
 // n.b. This is a fairly "C"-like interface presently. Ideally it should move
 // over to the Tock register interface eventually, but this code does work as
 // written. Do not follow this as an example when implementing new code.
-use rf233_const::CSMA_SEED_1;
-use rf233_const::IRQ_MASK;
-use rf233_const::PHY_CC_CCA_MODE_CS_OR_ED;
-use rf233_const::PHY_RSSI_RX_CRC_VALID;
-use rf233_const::PHY_TX_PWR;
-use rf233_const::SHORT_ADDR_0;
-use rf233_const::SHORT_ADDR_1;
-use rf233_const::TRX_CTRL_1;
-use rf233_const::TRX_CTRL_2;
-use rf233_const::TRX_RPC;
-use rf233_const::TRX_TRAC_CHANNEL_ACCESS_FAILURE;
-use rf233_const::TRX_TRAC_MASK;
-use rf233_const::XAH_CTRL_0;
-use rf233_const::XAH_CTRL_1;
+use crate::rf233_const::CSMA_SEED_1;
+use crate::rf233_const::IRQ_MASK;
+use crate::rf233_const::PHY_CC_CCA_MODE_CS_OR_ED;
+use crate::rf233_const::PHY_RSSI_RX_CRC_VALID;
+use crate::rf233_const::PHY_TX_PWR;
+use crate::rf233_const::SHORT_ADDR_0;
+use crate::rf233_const::SHORT_ADDR_1;
+use crate::rf233_const::TRX_CTRL_1;
+use crate::rf233_const::TRX_CTRL_2;
+use crate::rf233_const::TRX_RPC;
+use crate::rf233_const::TRX_TRAC_CHANNEL_ACCESS_FAILURE;
+use crate::rf233_const::TRX_TRAC_MASK;
+use crate::rf233_const::XAH_CTRL_0;
+use crate::rf233_const::XAH_CTRL_1;
 
 const INTERRUPT_ID: usize = 0x2154;
 

--- a/capsules/src/rng.rs
+++ b/capsules/src/rng.rs
@@ -26,7 +26,7 @@ use kernel::hil::rng::{Client, Continue, Random, Rng};
 use kernel::{AppId, AppSlice, Callback, Driver, Grant, ReturnCode, Shared};
 
 /// Syscall driver number.
-use driver;
+use crate::driver;
 pub const DRIVER_NUM: usize = driver::NUM::RNG as usize;
 
 #[derive(Default)]

--- a/capsules/src/sdcard.rs
+++ b/capsules/src/sdcard.rs
@@ -45,7 +45,7 @@ use kernel::hil::time::Frequency;
 use kernel::{AppId, AppSlice, Callback, Driver, ReturnCode, Shared};
 
 /// Syscall driver number.
-use driver;
+use crate::driver;
 pub const DRIVER_NUM: usize = driver::NUM::SD_CARD as usize;
 
 /// Buffers used for SD card transactions, assigned in board `main.rs` files
@@ -1333,7 +1333,7 @@ impl<A: hil::time::Alarm> SDCard<'a, A> {
 impl<A: hil::time::Alarm> hil::spi::SpiMasterClient for SDCard<'a, A> {
     fn read_write_done(
         &self,
-        mut write_buffer: &'static mut [u8],
+        write_buffer: &'static mut [u8],
         read_buffer: Option<&'static mut [u8]>,
         len: usize,
     ) {
@@ -1444,6 +1444,7 @@ impl<A: hil::time::Alarm> SDCardClient for SDCardDriver<'a, A> {
     fn read_done(&self, data: &'static mut [u8], len: usize) {
         self.kernel_buf.replace(data);
         self.app.map(|app| {
+            #[allow(unused_mut)]
             let mut read_len: usize = 0;
             self.kernel_buf.map(|data| {
                 app.read_buffer.as_mut().map(move |read_buffer| {

--- a/capsules/src/spi.rs
+++ b/capsules/src/spi.rs
@@ -10,7 +10,7 @@ use kernel::hil::spi::{SpiMasterClient, SpiMasterDevice, SpiSlaveClient, SpiSlav
 use kernel::{AppId, AppSlice, Callback, Driver, ReturnCode, Shared};
 
 /// Syscall driver number.
-use driver;
+use crate::driver;
 pub const DRIVER_NUM: usize = driver::NUM::SPI as usize;
 
 // SPI operations are handled by coping into a kernel buffer for

--- a/capsules/src/temperature.rs
+++ b/capsules/src/temperature.rs
@@ -52,7 +52,7 @@ use kernel::ReturnCode;
 use kernel::{AppId, Callback, Driver, Grant};
 
 /// Syscall driver number.
-use driver;
+use crate::driver;
 pub const DRIVER_NUM: usize = driver::NUM::TEMPERATURE as usize;
 
 #[derive(Default)]

--- a/capsules/src/test/aes.rs
+++ b/capsules/src/test/aes.rs
@@ -2,6 +2,7 @@
 
 use core::cell::Cell;
 use kernel::common::cells::TakeCell;
+use kernel::debug;
 use kernel::hil;
 use kernel::hil::symmetric_encryption::{
     AES128Ctr, AES128, AES128CBC, AES128_BLOCK_SIZE, AES128_KEY_SIZE,

--- a/capsules/src/test/aes_ccm.rs
+++ b/capsules/src/test/aes_ccm.rs
@@ -2,6 +2,7 @@
 
 use core::cell::Cell;
 use kernel::common::cells::TakeCell;
+use kernel::debug;
 use kernel::hil::symmetric_encryption::{CCMClient, AES128CCM, AES128_KEY_SIZE, CCM_NONCE_LENGTH};
 use kernel::ReturnCode;
 

--- a/capsules/src/test/rng.rs
+++ b/capsules/src/test/rng.rs
@@ -6,6 +6,7 @@
 //! for ELEMENTS random numbers and print them in hex to console.
 
 use core::cell::Cell;
+use kernel::debug;
 use kernel::hil::entropy;
 use kernel::hil::rng;
 use kernel::ReturnCode;

--- a/capsules/src/test/virtual_uart.rs
+++ b/capsules/src/test/virtual_uart.rs
@@ -1,10 +1,11 @@
 //! Test reception on the virtualized UART: best if multiple Tests are
 //! instantiated and tested in parallel.
+use crate::virtual_uart::UartDevice;
 use kernel::common::cells::TakeCell;
+use kernel::debug;
 use kernel::hil;
 use kernel::hil::uart::Client;
 use kernel::hil::uart::UART;
-use virtual_uart::UartDevice;
 
 pub struct TestVirtualUartReceive {
     device: &'static UartDevice<'static>,

--- a/capsules/src/tmp006.rs
+++ b/capsules/src/tmp006.rs
@@ -16,7 +16,7 @@ use kernel::hil::i2c;
 use kernel::{AppId, Callback, Driver, ReturnCode};
 
 /// Syscall driver number.
-use driver;
+use crate::driver;
 pub const DRIVER_NUM: usize = driver::NUM::TMP006 as usize;
 
 pub static mut BUFFER: [u8; 3] = [0; 3];

--- a/capsules/src/usbc_client.rs
+++ b/capsules/src/usbc_client.rs
@@ -2,23 +2,24 @@
 //!
 //! It responds to standard device requests and can be enumerated.
 
+use crate::usb::ConfigurationDescriptor;
+use crate::usb::Descriptor;
+use crate::usb::DescriptorType;
+use crate::usb::DeviceDescriptor;
+use crate::usb::EndpointAddress;
+use crate::usb::EndpointDescriptor;
+use crate::usb::InterfaceDescriptor;
+use crate::usb::LanguagesDescriptor;
+use crate::usb::SetupData;
+use crate::usb::StandardDeviceRequest;
+use crate::usb::StringDescriptor;
+use crate::usb::TransferDirection;
+use crate::usb::TransferType;
 use core::cell::Cell;
 use core::cmp::min;
 use kernel::common::cells::VolatileCell;
+use kernel::debug;
 use kernel::hil;
-use usb::ConfigurationDescriptor;
-use usb::Descriptor;
-use usb::DescriptorType;
-use usb::DeviceDescriptor;
-use usb::EndpointAddress;
-use usb::EndpointDescriptor;
-use usb::InterfaceDescriptor;
-use usb::LanguagesDescriptor;
-use usb::SetupData;
-use usb::StandardDeviceRequest;
-use usb::StringDescriptor;
-use usb::TransferDirection;
-use usb::TransferType;
 
 const VENDOR_ID: u16 = 0x6667;
 const PRODUCT_ID: u16 = 0xabcd;

--- a/chips/cc26x2/Cargo.lock
+++ b/chips/cc26x2/Cargo.lock
@@ -4,8 +4,8 @@ version = "0.1.0"
 dependencies = [
  "cortexm4 0.1.0",
  "enum_primitive 0.1.0",
- "crt0s 0.1.0",
  "kernel 0.1.0",
+ "tock_rt0 0.1.0",
 ]
 
 [[package]]
@@ -26,8 +26,6 @@ dependencies = [
 [[package]]
 name = "enum_primitive"
 version = "0.1.0"
-name = "crt0s"
-version = "0.1.0"
 
 [[package]]
 name = "kernel"
@@ -44,4 +42,8 @@ version = "0.1.0"
 [[package]]
 name = "tock-registers"
 version = "0.2.0"
+
+[[package]]
+name = "tock_rt0"
+version = "0.1.0"
 

--- a/chips/cc26x2/Cargo.toml
+++ b/chips/cc26x2/Cargo.toml
@@ -2,6 +2,7 @@
 name = "cc26x2"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+edition = "2018"
 
 [dependencies]
 cortexm4 = { path = "../../arch/cortex-m4" }

--- a/chips/cc26x2/src/aon.rs
+++ b/chips/cc26x2/src/aon.rs
@@ -4,9 +4,9 @@
 //!
 //! The current configuration disables all wake-up selectors, since the
 //! MCU never go to sleep and is always active.
-use kernel::common::registers::{ReadOnly, ReadWrite};
+use crate::rtc;
+use kernel::common::registers::{register_bitfields, ReadOnly, ReadWrite};
 use kernel::common::StaticRef;
-use rtc;
 
 #[repr(C)]
 pub struct AonIocRegisters {

--- a/chips/cc26x2/src/chip.rs
+++ b/chips/cc26x2/src/chip.rs
@@ -1,10 +1,10 @@
+use crate::gpio;
+use crate::i2c;
+use crate::peripheral_interrupts::NVIC_IRQ;
+use crate::rtc;
+use crate::uart;
 use cortexm4::{self, nvic};
 use enum_primitive::cast::FromPrimitive;
-use gpio;
-use i2c;
-use peripheral_interrupts::NVIC_IRQ;
-use rtc;
-use uart;
 
 pub struct Cc26X2 {
     mpu: cortexm4::mpu::MPU,

--- a/chips/cc26x2/src/gpio.rs
+++ b/chips/cc26x2/src/gpio.rs
@@ -7,7 +7,7 @@
 use core::cell::Cell;
 use core::ops::{Index, IndexMut};
 use kernel::common::cells::OptionalCell;
-use kernel::common::registers::{ReadWrite, WriteOnly};
+use kernel::common::registers::{register_bitfields, ReadWrite, WriteOnly};
 use kernel::common::StaticRef;
 use kernel::hil;
 use kernel::hil::gpio::PinCtl;

--- a/chips/cc26x2/src/i2c.rs
+++ b/chips/cc26x2/src/i2c.rs
@@ -2,11 +2,11 @@
 
 use core::cmp;
 use kernel::common::cells::{MapCell, OptionalCell};
-use kernel::common::registers::{ReadOnly, ReadWrite, WriteOnly};
+use kernel::common::registers::{register_bitfields, ReadOnly, ReadWrite, WriteOnly};
 use kernel::common::StaticRef;
 use kernel::hil::i2c;
 
-use prcm;
+use crate::prcm;
 
 /// A wrapper module for interal register types.
 ///

--- a/chips/cc26x2/src/lib.rs
+++ b/chips/cc26x2/src/lib.rs
@@ -2,13 +2,6 @@
 #![no_std]
 #![crate_name = "cc26x2"]
 #![crate_type = "rlib"]
-extern crate cortexm4;
-extern crate tock_rt0;
-#[allow(unused_imports)]
-#[macro_use]
-extern crate kernel;
-#[macro_use]
-extern crate enum_primitive;
 
 pub mod aon;
 pub mod chip;
@@ -21,4 +14,4 @@ pub mod rtc;
 pub mod trng;
 pub mod uart;
 
-pub use crt1::init;
+pub use crate::crt1::init;

--- a/chips/cc26x2/src/peripheral_interrupts.rs
+++ b/chips/cc26x2/src/peripheral_interrupts.rs
@@ -1,4 +1,5 @@
 use enum_primitive::cast::FromPrimitive;
+use enum_primitive::enum_from_primitive;
 
 enum_from_primitive! {
 #[derive(Debug, PartialEq)]

--- a/chips/cc26x2/src/prcm.rs
+++ b/chips/cc26x2/src/prcm.rs
@@ -11,7 +11,7 @@
 //! It also manages the clocks attached to almost every peripheral, which needs to
 //! be enabled before usage.
 //!
-use kernel::common::registers::{ReadOnly, ReadWrite, WriteOnly};
+use kernel::common::registers::{register_bitfields, ReadOnly, ReadWrite, WriteOnly};
 use kernel::common::StaticRef;
 
 // The AON Power Management Control registers are required here to select the clock source for

--- a/chips/cc26x2/src/rtc.rs
+++ b/chips/cc26x2/src/rtc.rs
@@ -1,7 +1,7 @@
 //! RTC driver
 
 use kernel::common::cells::OptionalCell;
-use kernel::common::registers::{ReadOnly, ReadWrite};
+use kernel::common::registers::{register_bitfields, ReadOnly, ReadWrite};
 use kernel::common::StaticRef;
 use kernel::hil::time::{self, Alarm, Frequency, Time};
 

--- a/chips/cc26x2/src/trng.rs
+++ b/chips/cc26x2/src/trng.rs
@@ -3,12 +3,12 @@
 //! Generates a random number using hardware entropy.
 //!
 
+use crate::prcm;
 use kernel::common::cells::OptionalCell;
-use kernel::common::registers::{ReadOnly, ReadWrite, WriteOnly};
+use kernel::common::registers::{register_bitfields, ReadOnly, ReadWrite, WriteOnly};
 use kernel::common::StaticRef;
 use kernel::hil::entropy;
 use kernel::ReturnCode;
-use prcm;
 
 #[repr(C)]
 struct RngRegisters {

--- a/chips/cc26x2/src/uart.rs
+++ b/chips/cc26x2/src/uart.rs
@@ -1,10 +1,10 @@
 //! UART driver, cc26x2 family
+use crate::prcm;
 use kernel::common::cells::{MapCell, OptionalCell};
-use kernel::common::registers::{ReadOnly, ReadWrite, WriteOnly};
+use kernel::common::registers::{register_bitfields, ReadOnly, ReadWrite, WriteOnly};
 use kernel::common::StaticRef;
 use kernel::hil::uart;
 use kernel::ReturnCode;
-use prcm;
 
 use core::cmp;
 

--- a/chips/nrf52/Cargo.lock
+++ b/chips/nrf52/Cargo.lock
@@ -14,10 +14,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crt0s"
-version = "0.1.0"
-
-[[package]]
 name = "kernel"
 version = "0.1.0"
 dependencies = [
@@ -30,9 +26,9 @@ name = "nrf52"
 version = "0.1.0"
 dependencies = [
  "cortexm4 0.1.0",
- "crt0s 0.1.0",
  "kernel 0.1.0",
  "nrf5x 0.1.0",
+ "tock_rt0 0.1.0",
 ]
 
 [[package]]
@@ -49,4 +45,8 @@ version = "0.1.0"
 [[package]]
 name = "tock-registers"
 version = "0.2.0"
+
+[[package]]
+name = "tock_rt0"
+version = "0.1.0"
 

--- a/chips/nrf52/Cargo.toml
+++ b/chips/nrf52/Cargo.toml
@@ -2,6 +2,7 @@
 name = "nrf52"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+edition = "2018"
 
 [dependencies]
 cortexm4 = { path = "../../arch/cortex-m4" }

--- a/chips/nrf52/src/adc.rs
+++ b/chips/nrf52/src/adc.rs
@@ -1,7 +1,7 @@
 //! ADC driver for the nRF52. Uses the SAADC peripheral.
 
 use kernel::common::cells::{OptionalCell, VolatileCell};
-use kernel::common::registers::{ReadOnly, ReadWrite, WriteOnly};
+use kernel::common::registers::{register_bitfields, ReadOnly, ReadWrite, WriteOnly};
 use kernel::common::StaticRef;
 use kernel::hil;
 use kernel::ReturnCode;

--- a/chips/nrf52/src/chip.rs
+++ b/chips/nrf52/src/chip.rs
@@ -1,13 +1,14 @@
-use adc;
+use crate::adc;
+use crate::deferred_call_tasks::DeferredCallTask;
+use crate::i2c;
+use crate::nvmc;
+use crate::radio;
+use crate::spi;
+use crate::uart;
 use cortexm4::{self, nvic};
-use deferred_call_tasks::DeferredCallTask;
-use i2c;
 use kernel::common::deferred_call;
+use kernel::debug;
 use nrf5x::peripheral_interrupts;
-use nvmc;
-use radio;
-use spi;
-use uart;
 
 pub struct NRF52 {
     mpu: cortexm4::mpu::MPU,

--- a/chips/nrf52/src/clock.rs
+++ b/chips/nrf52/src/clock.rs
@@ -17,7 +17,7 @@
 //!
 
 use kernel::common::cells::OptionalCell;
-use kernel::common::registers::{ReadOnly, ReadWrite, WriteOnly};
+use kernel::common::registers::{register_bitfields, ReadOnly, ReadWrite, WriteOnly};
 use kernel::common::StaticRef;
 
 #[repr(C)]

--- a/chips/nrf52/src/ficr.rs
+++ b/chips/nrf52/src/ficr.rs
@@ -8,7 +8,7 @@
 //! - Date: November 27, 2017
 
 use core::fmt;
-use kernel::common::registers::ReadOnly;
+use kernel::common::registers::{register_bitfields, ReadOnly};
 use kernel::common::StaticRef;
 
 const FICR_BASE: StaticRef<FicrRegisters> =

--- a/chips/nrf52/src/i2c.rs
+++ b/chips/nrf52/src/i2c.rs
@@ -10,7 +10,7 @@
 use kernel::common::cells::OptionalCell;
 use kernel::common::cells::TakeCell;
 use kernel::common::cells::VolatileCell;
-use kernel::common::registers::{ReadWrite, WriteOnly};
+use kernel::common::registers::{register_bitfields, ReadWrite, WriteOnly};
 use kernel::common::StaticRef;
 use kernel::hil;
 use nrf5x::pinmux::Pinmux;

--- a/chips/nrf52/src/lib.rs
+++ b/chips/nrf52/src/lib.rs
@@ -3,21 +3,6 @@
 #![crate_name = "nrf52"]
 #![crate_type = "rlib"]
 
-#[allow(unused_imports)]
-extern crate cortexm4;
-extern crate nrf5x;
-extern crate tock_rt0;
-
-#[allow(unused)]
-#[macro_use(
-    debug,
-    debug_verbose,
-    debug_gpio,
-    register_bitfields,
-    register_bitmasks
-)]
-extern crate kernel;
-
 pub mod adc;
 pub mod chip;
 pub mod clock;
@@ -33,4 +18,4 @@ pub mod spi;
 pub mod uart;
 pub mod uicr;
 
-pub use crt1::init;
+pub use crate::crt1::init;

--- a/chips/nrf52/src/nvmc.rs
+++ b/chips/nrf52/src/nvmc.rs
@@ -8,12 +8,12 @@ use kernel::common::cells::OptionalCell;
 use kernel::common::cells::TakeCell;
 use kernel::common::cells::VolatileCell;
 use kernel::common::deferred_call::DeferredCall;
-use kernel::common::registers::{ReadOnly, ReadWrite};
+use kernel::common::registers::{register_bitfields, ReadOnly, ReadWrite};
 use kernel::common::StaticRef;
 use kernel::hil;
 use kernel::ReturnCode;
 
-use deferred_call_tasks::DeferredCallTask;
+use crate::deferred_call_tasks::DeferredCallTask;
 
 const NVMC_BASE: StaticRef<NvmcRegisters> =
     unsafe { StaticRef::new(0x4001E400 as *const NvmcRegisters) };

--- a/chips/nrf52/src/ppi.rs
+++ b/chips/nrf52/src/ppi.rs
@@ -33,7 +33,7 @@
 //! * Francine Mäkelä
 //! * Date: May 04, 2018
 
-use kernel::common::registers::{FieldValue, ReadWrite};
+use kernel::common::registers::{register_bitfields, FieldValue, ReadWrite};
 use kernel::common::StaticRef;
 
 const PPI_BASE: StaticRef<PpiRegisters> =

--- a/chips/nrf52/src/pwm.rs
+++ b/chips/nrf52/src/pwm.rs
@@ -1,7 +1,7 @@
 //! PWM driver for nRF52.
 
 use kernel::common::cells::VolatileCell;
-use kernel::common::registers::{ReadWrite, WriteOnly};
+use kernel::common::registers::{register_bitfields, ReadWrite, WriteOnly};
 use kernel::common::StaticRef;
 use kernel::hil;
 use kernel::ReturnCode;

--- a/chips/nrf52/src/radio.rs
+++ b/chips/nrf52/src/radio.rs
@@ -36,7 +36,7 @@
 use core::cell::Cell;
 use core::convert::TryFrom;
 use kernel::common::cells::OptionalCell;
-use kernel::common::registers::{ReadOnly, ReadWrite, WriteOnly};
+use kernel::common::registers::{register_bitfields, ReadOnly, ReadWrite, WriteOnly};
 use kernel::common::StaticRef;
 use kernel::hil::ble_advertising;
 use kernel::hil::ble_advertising::RadioChannel;

--- a/chips/nrf52/src/spi.rs
+++ b/chips/nrf52/src/spi.rs
@@ -32,7 +32,7 @@
 use core::cell::Cell;
 use core::{cmp, ptr};
 use kernel::common::cells::{OptionalCell, TakeCell, VolatileCell};
-use kernel::common::registers::{ReadWrite, WriteOnly};
+use kernel::common::registers::{register_bitfields, ReadWrite, WriteOnly};
 use kernel::common::StaticRef;
 use kernel::hil;
 use kernel::ReturnCode;

--- a/chips/nrf52/src/uart.rs
+++ b/chips/nrf52/src/uart.rs
@@ -10,8 +10,9 @@ use core;
 use core::cell::Cell;
 use core::cmp::min;
 use kernel::common::cells::OptionalCell;
-use kernel::common::registers::{ReadOnly, ReadWrite, WriteOnly};
+use kernel::common::registers::{register_bitfields, ReadOnly, ReadWrite, WriteOnly};
 use kernel::common::StaticRef;
+use kernel::debug;
 use kernel::ReturnCode;
 use nrf5x::pinmux;
 

--- a/chips/nrf52/src/uicr.rs
+++ b/chips/nrf52/src/uicr.rs
@@ -3,7 +3,7 @@
 //! Minimal implementation to support activation of the reset button on
 //! nRF52-DK.
 
-use kernel::common::registers::ReadWrite;
+use kernel::common::registers::{register_bitfields, ReadWrite};
 use kernel::common::StaticRef;
 
 const UICR_BASE: StaticRef<UicrRegisters> =

--- a/chips/nrf5x/Cargo.lock
+++ b/chips/nrf5x/Cargo.lock
@@ -2,7 +2,8 @@
 name = "kernel"
 version = "0.1.0"
 dependencies = [
- "tock-regs 0.1.0",
+ "tock-cells 0.1.0",
+ "tock-registers 0.2.0",
 ]
 
 [[package]]
@@ -13,6 +14,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "tock-regs"
+name = "tock-cells"
 version = "0.1.0"
+
+[[package]]
+name = "tock-registers"
+version = "0.2.0"
 

--- a/chips/nrf5x/Cargo.toml
+++ b/chips/nrf5x/Cargo.toml
@@ -2,6 +2,7 @@
 name = "nrf5x"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+edition = "2018"
 
 [dependencies]
 kernel = { path = "../../kernel" }

--- a/chips/nrf5x/src/aes.rs
+++ b/chips/nrf5x/src/aes.rs
@@ -33,7 +33,7 @@
 use core::cell::Cell;
 use kernel::common::cells::OptionalCell;
 use kernel::common::cells::TakeCell;
-use kernel::common::registers::{ReadWrite, WriteOnly};
+use kernel::common::registers::{register_bitfields, ReadWrite, WriteOnly};
 use kernel::common::StaticRef;
 use kernel::hil::symmetric_encryption;
 use kernel::ReturnCode;

--- a/chips/nrf5x/src/gpio.rs
+++ b/chips/nrf5x/src/gpio.rs
@@ -7,8 +7,9 @@
 use core::cell::Cell;
 use core::ops::{Index, IndexMut};
 use kernel::common::cells::OptionalCell;
-use kernel::common::registers::{FieldValue, ReadWrite};
+use kernel::common::registers::{register_bitfields, FieldValue, ReadWrite};
 use kernel::common::StaticRef;
+use kernel::debug;
 use kernel::hil;
 
 #[cfg(feature = "nrf51")]

--- a/chips/nrf5x/src/lib.rs
+++ b/chips/nrf5x/src/lib.rs
@@ -2,16 +2,6 @@
 #![feature(in_band_lifetimes)]
 #![no_std]
 
-#[allow(unused_imports)]
-#[macro_use(
-    debug,
-    debug_verbose,
-    debug_gpio,
-    register_bitfields,
-    register_bitmasks
-)]
-extern crate kernel;
-
 pub mod aes;
 pub mod constants;
 pub mod gpio;

--- a/chips/nrf5x/src/rtc.rs
+++ b/chips/nrf5x/src/rtc.rs
@@ -1,7 +1,7 @@
 //! RTC driver, nRF5X-family
 
 use kernel::common::cells::OptionalCell;
-use kernel::common::registers::{ReadOnly, ReadWrite, WriteOnly};
+use kernel::common::registers::{register_bitfields, ReadOnly, ReadWrite, WriteOnly};
 use kernel::common::StaticRef;
 use kernel::hil::time::{self, Alarm, Freq32KHz, Time};
 use kernel::hil::Controller;

--- a/chips/nrf5x/src/temperature.rs
+++ b/chips/nrf5x/src/temperature.rs
@@ -9,7 +9,7 @@
 //! * Date: March 03, 2017
 
 use kernel::common::cells::OptionalCell;
-use kernel::common::registers::{ReadOnly, ReadWrite, WriteOnly};
+use kernel::common::registers::{register_bitfields, ReadOnly, ReadWrite, WriteOnly};
 use kernel::common::StaticRef;
 
 const TEMP_BASE: StaticRef<TempRegisters> =

--- a/chips/nrf5x/src/timer.rs
+++ b/chips/nrf5x/src/timer.rs
@@ -23,7 +23,7 @@
 //! * Date: August 18, 2016
 
 use kernel::common::cells::OptionalCell;
-use kernel::common::registers::{self, ReadWrite, WriteOnly};
+use kernel::common::registers::{self, register_bitfields, ReadWrite, WriteOnly};
 use kernel::common::StaticRef;
 use kernel::hil;
 

--- a/chips/nrf5x/src/trng.rs
+++ b/chips/nrf5x/src/trng.rs
@@ -22,7 +22,7 @@
 
 use core::cell::Cell;
 use kernel::common::cells::OptionalCell;
-use kernel::common::registers::{ReadOnly, ReadWrite, WriteOnly};
+use kernel::common::registers::{register_bitfields, ReadOnly, ReadWrite, WriteOnly};
 use kernel::common::StaticRef;
 use kernel::hil::entropy::{self, Continue};
 use kernel::ReturnCode;

--- a/chips/sam4l/Cargo.lock
+++ b/chips/sam4l/Cargo.lock
@@ -14,10 +14,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crt0s"
-version = "0.1.0"
-
-[[package]]
 name = "kernel"
 version = "0.1.0"
 dependencies = [
@@ -30,8 +26,8 @@ name = "sam4l"
 version = "0.1.0"
 dependencies = [
  "cortexm4 0.1.0",
- "crt0s 0.1.0",
  "kernel 0.1.0",
+ "tock_rt0 0.1.0",
 ]
 
 [[package]]
@@ -41,4 +37,8 @@ version = "0.1.0"
 [[package]]
 name = "tock-registers"
 version = "0.2.0"
+
+[[package]]
+name = "tock_rt0"
+version = "0.1.0"
 

--- a/chips/sam4l/Cargo.toml
+++ b/chips/sam4l/Cargo.toml
@@ -2,6 +2,7 @@
 name = "sam4l"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+edition = "2018"
 
 [dependencies]
 cortexm4 = { path = "../../arch/cortex-m4" }

--- a/chips/sam4l/src/acifc.rs
+++ b/chips/sam4l/src/acifc.rs
@@ -26,12 +26,13 @@
 // Author: Danilo Verhaert <verhaert@cs.stanford.edu>
 // Last modified August 8th, 2018
 
+use crate::pm;
 use core::cell::Cell;
-use kernel::common::registers::{ReadOnly, ReadWrite, WriteOnly};
+use kernel::common::registers::{register_bitfields, ReadOnly, ReadWrite, WriteOnly};
 use kernel::common::StaticRef;
+use kernel::debug;
 use kernel::hil::analog_comparator;
 use kernel::ReturnCode;
-use pm;
 
 /// Representation of an AC channel on the SAM4L.
 pub struct AcChannel {

--- a/chips/sam4l/src/adc.rs
+++ b/chips/sam4l/src/adc.rs
@@ -16,17 +16,17 @@
 //! - Author: Philip Levis <pal@cs.stanford.edu>, Branden Ghena <brghena@umich.edu>
 //! - Updated: May 1, 2017
 
+use crate::dma;
+use crate::pm::{self, Clock, PBAClock};
+use crate::scif;
 use core::cell::Cell;
 use core::{cmp, mem, slice};
-use dma;
 use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::common::math;
-use kernel::common::registers::{ReadOnly, ReadWrite, WriteOnly};
+use kernel::common::registers::{register_bitfields, ReadOnly, ReadWrite, WriteOnly};
 use kernel::common::StaticRef;
 use kernel::hil;
 use kernel::ReturnCode;
-use pm::{self, Clock, PBAClock};
-use scif;
 
 /// Representation of an ADC channel on the SAM4L.
 pub struct AdcChannel {

--- a/chips/sam4l/src/aes.rs
+++ b/chips/sam4l/src/aes.rs
@@ -8,15 +8,16 @@
 //!
 //! Converted to new register abstraction by Philip Levis <pal@cs.stanford.edu>
 
+use crate::pm;
+use crate::scif;
 use core::cell::Cell;
 use kernel::common::cells::{OptionalCell, TakeCell};
-use kernel::common::registers::{ReadOnly, ReadWrite, WriteOnly};
+use kernel::common::registers::{register_bitfields, ReadOnly, ReadWrite, WriteOnly};
 use kernel::common::StaticRef;
+use kernel::debug;
 use kernel::hil;
 use kernel::hil::symmetric_encryption::{AES128_BLOCK_SIZE, AES128_KEY_SIZE};
 use kernel::ReturnCode;
-use pm;
-use scif;
 
 #[allow(dead_code)]
 #[derive(Copy, Clone)]

--- a/chips/sam4l/src/ast.rs
+++ b/chips/sam4l/src/ast.rs
@@ -4,12 +4,12 @@
 //! - Author: Philip Levis <pal@cs.stanford.edu>
 //! - Date: July 16, 2015
 
+use crate::pm::{self, PBDClock};
 use kernel::common::cells::OptionalCell;
-use kernel::common::registers::{ReadOnly, ReadWrite, WriteOnly};
+use kernel::common::registers::{register_bitfields, ReadOnly, ReadWrite, WriteOnly};
 use kernel::common::StaticRef;
 use kernel::hil::time::{self, Alarm, Freq16KHz, Time};
 use kernel::hil::Controller;
-use pm::{self, PBDClock};
 
 /// Minimum number of clock tics to make sure ALARM0 register is synchronized
 ///

--- a/chips/sam4l/src/bpm.rs
+++ b/chips/sam4l/src/bpm.rs
@@ -1,6 +1,6 @@
 //! Implementation of the BPM peripheral.
 
-use kernel::common::registers::{ReadOnly, ReadWrite, WriteOnly};
+use kernel::common::registers::{register_bitfields, ReadOnly, ReadWrite, WriteOnly};
 use kernel::common::StaticRef;
 
 #[repr(C)]

--- a/chips/sam4l/src/bscif.rs
+++ b/chips/sam4l/src/bscif.rs
@@ -1,6 +1,6 @@
 //! Implementation of the Backup System Control Interface (BSCIF) peripheral.
 
-use kernel::common::registers::{ReadOnly, ReadWrite, WriteOnly};
+use kernel::common::registers::{register_bitfields, ReadOnly, ReadWrite, WriteOnly};
 use kernel::common::StaticRef;
 
 #[repr(C)]

--- a/chips/sam4l/src/chip.rs
+++ b/chips/sam4l/src/chip.rs
@@ -1,25 +1,25 @@
 //! Interrupt mapping and DMA channel setup.
 
-use acifc;
-use adc;
-use aes;
-use ast;
+use crate::acifc;
+use crate::adc;
+use crate::aes;
+use crate::ast;
+use crate::crccu;
+use crate::dac;
+use crate::deferred_call_tasks::Task;
+use crate::dma;
+use crate::flashcalw;
+use crate::gpio;
+use crate::i2c;
+use crate::nvic;
+use crate::pm;
+use crate::spi;
+use crate::trng;
+use crate::usart;
+use crate::usbc;
 use cortexm4;
-use crccu;
-use dac;
-use deferred_call_tasks::Task;
-use dma;
-use flashcalw;
-use gpio;
-use i2c;
 use kernel::common::deferred_call;
 use kernel::Chip;
-use nvic;
-use pm;
-use spi;
-use trng;
-use usart;
-use usbc;
 
 pub struct Sam4l {
     mpu: cortexm4::mpu::MPU,

--- a/chips/sam4l/src/crccu.rs
+++ b/chips/sam4l/src/crccu.rs
@@ -48,12 +48,12 @@
 //
 // - Support continuous-mode CRC
 
+use crate::pm::{disable_clock, enable_clock, Clock, HSBClock, PBBClock};
 use core::cell::Cell;
-use kernel::common::registers::{FieldValue, ReadOnly, ReadWrite, WriteOnly};
+use kernel::common::registers::{register_bitfields, FieldValue, ReadOnly, ReadWrite, WriteOnly};
 use kernel::common::StaticRef;
 use kernel::hil::crc::{self, CrcAlg};
 use kernel::ReturnCode;
-use pm::{disable_clock, enable_clock, Clock, HSBClock, PBBClock};
 
 // Base address of CRCCU registers.  See "7.1 Product Mapping"
 const BASE_ADDRESS: StaticRef<CrccuRegisters> =

--- a/chips/sam4l/src/dac.rs
+++ b/chips/sam4l/src/dac.rs
@@ -5,12 +5,12 @@
 //! - Author: Justin Hsieh <hsiehju@umich.edu>
 //! - Date: May 26th, 2017
 
+use crate::pm::{self, Clock, PBAClock};
 use core::cell::Cell;
-use kernel::common::registers::{ReadOnly, ReadWrite, WriteOnly};
+use kernel::common::registers::{register_bitfields, ReadOnly, ReadWrite, WriteOnly};
 use kernel::common::StaticRef;
 use kernel::hil;
 use kernel::ReturnCode;
-use pm::{self, Clock, PBAClock};
 
 #[repr(C)]
 pub struct DacRegisters {

--- a/chips/sam4l/src/dma.rs
+++ b/chips/sam4l/src/dma.rs
@@ -1,12 +1,12 @@
 //! Implementation of the PDCA DMA peripheral.
 
+use crate::pm;
 use core::cell::Cell;
 use core::{cmp, intrinsics};
 use kernel::common::cells::VolatileCell;
 use kernel::common::cells::{OptionalCell, TakeCell};
-use kernel::common::registers::{ReadOnly, ReadWrite, WriteOnly};
+use kernel::common::registers::{register_bitfields, ReadOnly, ReadWrite, WriteOnly};
 use kernel::common::StaticRef;
-use pm;
 
 /// Memory registers for a DMA channel. Section 16.6.1 of the datasheet.
 #[repr(C)]

--- a/chips/sam4l/src/flashcalw.rs
+++ b/chips/sam4l/src/flashcalw.rs
@@ -21,16 +21,16 @@
 //! - Author:  Kevin Baichoo <kbaichoo@cs.stanford.edu>
 //! - Date: July 27, 2016
 
+use crate::deferred_call_tasks::Task;
+use crate::pm;
 use core::cell::Cell;
 use core::ops::{Index, IndexMut};
-use deferred_call_tasks::Task;
 use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::common::deferred_call::DeferredCall;
-use kernel::common::registers::{ReadOnly, ReadWrite, WriteOnly};
+use kernel::common::registers::{register_bitfields, ReadOnly, ReadWrite, WriteOnly};
 use kernel::common::StaticRef;
 use kernel::hil;
 use kernel::ReturnCode;
-use pm;
 
 /// Struct of the FLASHCALW registers. Section 14.10 of the datasheet.
 #[repr(C)]

--- a/chips/sam4l/src/i2c.rs
+++ b/chips/sam4l/src/i2c.rs
@@ -9,15 +9,15 @@
 //! The point is that until this changes, and this notice is taken away: IF YOU
 //! CHANGE THIS DRIVER, TEST RIGOROUSLY!!!
 
+use crate::dma::{DMAChannel, DMAClient, DMAPeripheral};
+use crate::pm;
 use core::cell::Cell;
-use dma::{DMAChannel, DMAClient, DMAPeripheral};
 use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::common::peripherals::{PeripheralManagement, PeripheralManager};
-use kernel::common::registers::{FieldValue, ReadOnly, ReadWrite, WriteOnly};
+use kernel::common::registers::{register_bitfields, FieldValue, ReadOnly, ReadWrite, WriteOnly};
 use kernel::common::StaticRef;
 use kernel::hil;
 use kernel::ClockInterface;
-use pm;
 
 // Listing of all registers related to the TWIM peripheral.
 // Section 27.9 of the datasheet

--- a/chips/sam4l/src/lib.rs
+++ b/chips/sam4l/src/lib.rs
@@ -8,12 +8,6 @@
 #![feature(in_band_lifetimes)]
 #![no_std]
 
-extern crate cortexm4;
-extern crate tock_rt0;
-#[allow(unused_imports)]
-#[macro_use(debug, debug_gpio, static_init, register_bitfields, register_bitmasks)]
-extern crate kernel;
-
 mod deferred_call_tasks;
 
 pub mod acifc;

--- a/chips/sam4l/src/pm.rs
+++ b/chips/sam4l/src/pm.rs
@@ -1,15 +1,15 @@
 //! Implementation of the power manager (PM) peripheral.
 
-use bpm;
-use bscif;
+use crate::bpm;
+use crate::bscif;
+use crate::flashcalw;
+use crate::gpio;
+use crate::scif;
 use core::cell::Cell;
 use core::sync::atomic::Ordering;
-use flashcalw;
-use gpio;
-use kernel::common::registers::{FieldValue, ReadOnly, ReadWrite, WriteOnly};
+use kernel::common::registers::{register_bitfields, FieldValue, ReadOnly, ReadWrite, WriteOnly};
 use kernel::common::StaticRef;
 use kernel::ClockInterface;
-use scif;
 
 /// §10.7 PM::UserInterface from SAM4L Datasheet.
 #[repr(C)]

--- a/chips/sam4l/src/scif.rs
+++ b/chips/sam4l/src/scif.rs
@@ -7,8 +7,8 @@
 //! - Author: Philip Levis
 //! - Date: Aug 2, 2015
 
-use bscif;
-use kernel::common::registers::{FieldValue, ReadOnly, ReadWrite, WriteOnly};
+use crate::bscif;
+use kernel::common::registers::{register_bitfields, FieldValue, ReadOnly, ReadWrite, WriteOnly};
 use kernel::common::StaticRef;
 
 pub enum Register {

--- a/chips/sam4l/src/spi.rs
+++ b/chips/sam4l/src/spi.rs
@@ -6,14 +6,15 @@
 //!
 //! - Authors: Sam Crow <samcrow@uw.edu>, Philip Levis <pal@cs.stanford.edu>
 
+use crate::dma::DMAChannel;
+use crate::dma::DMAClient;
+use crate::dma::DMAPeripheral;
+use crate::pm;
 use core::cell::Cell;
 use core::cmp;
-use dma::DMAChannel;
-use dma::DMAClient;
-use dma::DMAPeripheral;
 use kernel::common::cells::OptionalCell;
 use kernel::common::peripherals::{PeripheralManagement, PeripheralManager};
-use kernel::common::registers::{self, ReadOnly, ReadWrite, WriteOnly};
+use kernel::common::registers::{self, register_bitfields, ReadOnly, ReadWrite, WriteOnly};
 use kernel::common::StaticRef;
 use kernel::hil::spi;
 use kernel::hil::spi::ClockPhase;
@@ -21,7 +22,6 @@ use kernel::hil::spi::ClockPolarity;
 use kernel::hil::spi::SpiMasterClient;
 use kernel::hil::spi::SpiSlaveClient;
 use kernel::{ClockInterface, ReturnCode};
-use pm;
 
 #[repr(C)]
 pub struct SpiRegisters {

--- a/chips/sam4l/src/trng.rs
+++ b/chips/sam4l/src/trng.rs
@@ -1,12 +1,12 @@
 //! Implementation of the SAM4L TRNG. It provides an implementation of
 //! the Entropy32 trait.
 
+use crate::pm;
 use kernel::common::cells::OptionalCell;
-use kernel::common::registers::{ReadOnly, WriteOnly};
+use kernel::common::registers::{register_bitfields, ReadOnly, WriteOnly};
 use kernel::common::StaticRef;
 use kernel::hil::entropy::{self, Continue};
 use kernel::ReturnCode;
-use pm;
 
 #[repr(C)]
 struct TrngRegisters {

--- a/chips/sam4l/src/usart.rs
+++ b/chips/sam4l/src/usart.rs
@@ -6,13 +6,13 @@ use core::cell::Cell;
 use core::cmp;
 use core::sync::atomic::{AtomicBool, Ordering};
 use kernel::common::cells::OptionalCell;
-use kernel::common::registers::{ReadOnly, ReadWrite, WriteOnly};
+use kernel::common::registers::{register_bitfields, ReadOnly, ReadWrite, WriteOnly};
 use kernel::common::StaticRef;
 use kernel::hil;
 use kernel::ReturnCode;
 
-use dma;
-use pm;
+use crate::dma;
+use crate::pm;
 
 // Register map for SAM4L USART
 #[repr(C)]
@@ -970,7 +970,7 @@ impl hil::spi::SpiMaster for USART {
 
     fn read_write_bytes(
         &self,
-        mut write_buffer: &'static mut [u8],
+        write_buffer: &'static mut [u8],
         read_buffer: Option<&'static mut [u8]>,
         len: usize,
     ) -> ReturnCode {

--- a/chips/sam4l/src/usbc/mod.rs
+++ b/chips/sam4l/src/usbc/mod.rs
@@ -4,16 +4,19 @@ pub mod debug;
 
 #[allow(unused_imports)]
 use self::debug::{HexBuf, UdintFlags, UeconFlags, UestaFlags};
+use crate::pm;
+use crate::pm::{disable_clock, enable_clock, Clock, HSBClock, PBBClock};
+use crate::scif;
 use core::cell::Cell;
 use core::ptr;
 use core::slice;
 use kernel::common::cells::{OptionalCell, VolatileCell};
-use kernel::common::registers::{FieldValue, LocalRegisterCopy, ReadOnly, ReadWrite, WriteOnly};
+use kernel::common::registers::{
+    register_bitfields, FieldValue, LocalRegisterCopy, ReadOnly, ReadWrite, WriteOnly,
+};
 use kernel::common::StaticRef;
+use kernel::debug as debugln;
 use kernel::hil;
-use pm;
-use pm::{disable_clock, enable_clock, Clock, HSBClock, PBBClock};
-use scif;
 
 // The following macros provide some diagnostics and panics(!)
 // while this module is experimental and should eventually be removed or
@@ -21,7 +24,7 @@ use scif;
 
 macro_rules! client_warn {
     [ $( $arg:expr ),+ ] => {
-        debug!($( $arg ),+);
+        debugln!($( $arg ),+);
     };
 }
 
@@ -33,7 +36,7 @@ macro_rules! client_err {
 
 macro_rules! debug1 {
     [ $( $arg:expr ),+ ] => {
-        {} // debug!($( $arg ),+)
+        {} // debugln!($( $arg ),+)
     };
 }
 
@@ -705,10 +708,10 @@ impl Usbc<'a> {
                         endpoint_enable_interrupts(endpoint, EndpointControl::RXOUTE::SET);
                         *endpoint_state = EndpointState::BulkOut(BulkOutState::Init);
                     }
-                    _ => debug!("Ignoring superfluous resume"),
+                    _ => debugln!("Ignoring superfluous resume"),
                 }
             }
-            _ => debug!("Ignoring inappropriate resume"),
+            _ => debugln!("Ignoring inappropriate resume"),
         });
     }
 
@@ -1220,7 +1223,7 @@ impl Usbc<'a> {
                     debug1!("\tep{}: RXOUT", endpoint);
 
                     if !usbc_regs().uecon[endpoint].is_set(EndpointControl::FIFOCON) {
-                        debug!("Got RXOUT but not FIFOCON");
+                        debugln!("Got RXOUT but not FIFOCON");
                         return;
                     }
                     // A bank is full of an OUT packet
@@ -1288,7 +1291,7 @@ impl Usbc<'a> {
                     debug1!("\tep{}: TXIN", endpoint);
 
                     if !usbc_regs().uecon[endpoint].is_set(EndpointControl::FIFOCON) {
-                        debug!("Got TXIN but not FIFOCON");
+                        debugln!("Got TXIN but not FIFOCON");
                         return;
                     }
                     // A bank is free to write an IN packet

--- a/chips/sam4l/src/wdt.rs
+++ b/chips/sam4l/src/wdt.rs
@@ -1,12 +1,12 @@
 //! Implementation of the SAM4L hardware watchdog timer.
 
+use crate::pm::{self, Clock, PBDClock};
 use core::cell::Cell;
 use cortexm4::support;
 use kernel::common::math::log_base_two_u64;
-use kernel::common::registers::{FieldValue, ReadOnly, ReadWrite, WriteOnly};
+use kernel::common::registers::{register_bitfields, FieldValue, ReadOnly, ReadWrite, WriteOnly};
 use kernel::common::StaticRef;
 use kernel::hil;
-use pm::{self, Clock, PBDClock};
 
 #[repr(C)]
 pub struct WdtRegisters {

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -2,6 +2,7 @@
 name = "kernel"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+edition = "2018"
 
 [dependencies]
 tock-registers = { path = "../libraries/tock-register-interface" }

--- a/kernel/src/callback.rs
+++ b/kernel/src/callback.rs
@@ -3,8 +3,8 @@
 use core::fmt;
 use core::ptr::NonNull;
 
-use process;
-use sched::Kernel;
+use crate::process;
+use crate::sched::Kernel;
 
 /// Userspace app identifier.
 #[derive(Clone, Copy)]

--- a/kernel/src/common/mod.rs
+++ b/kernel/src/common/mod.rs
@@ -7,7 +7,11 @@
 //! crates do not need to use unsafe code.
 
 /// Re-export the tock-register-interface library.
-pub use tock_registers::{macros, registers};
+pub mod registers {
+    pub use tock_registers::register_bitfields;
+    pub use tock_registers::registers::{Field, FieldValue, LocalRegisterCopy};
+    pub use tock_registers::registers::{ReadOnly, ReadWrite, WriteOnly};
+}
 
 pub mod deferred_call;
 pub mod list;

--- a/kernel/src/common/peripherals.rs
+++ b/kernel/src/common/peripherals.rs
@@ -145,7 +145,7 @@
 //! }
 //! ```
 
-use ClockInterface;
+use crate::ClockInterface;
 
 /// A structure encapsulating a peripheral should implement this trait.
 pub trait PeripheralManagement<C>
@@ -166,13 +166,13 @@ where
     ///
     /// Responsible for ensure the periphal can be safely accessed, e.g. that
     /// its clock is powered on.
-    fn before_peripheral_access(&self, &C, &Self::RegisterType);
+    fn before_peripheral_access(&self, _: &C, _: &Self::RegisterType);
 
     /// Called after periphal access.
     ///
     /// Currently used primarily for power management to check whether the
     /// peripheral can be powered off.
-    fn after_peripheral_access(&self, &C, &Self::RegisterType);
+    fn after_peripheral_access(&self, _: &C, _: &Self::RegisterType);
 }
 
 /// Structures encapsulating periphal hardware (those implementing the

--- a/kernel/src/common/ring_buffer.rs
+++ b/kernel/src/common/ring_buffer.rs
@@ -1,6 +1,6 @@
 //! Implementation of a ring buffer.
 
-use common::queue;
+use crate::common::queue;
 
 pub struct RingBuffer<'a, T: 'a> {
     ring: &'a mut [T],

--- a/kernel/src/debug.rs
+++ b/kernel/src/debug.rs
@@ -23,7 +23,7 @@
 //! -------
 //!
 //! ```no_run
-//! # #[macro_use] extern crate kernel;
+//! # use kernel::{debug, debug_gpio, debug_verbose};
 //! # fn main() {
 //! # let i = 42;
 //! debug!("Yes the code gets here with value {}", i);
@@ -45,10 +45,10 @@ use core::ptr;
 use core::slice;
 use core::str;
 
-use common::cells::NumericCellExt;
-use common::cells::{MapCell, TakeCell};
-use hil;
-use process::ProcessType;
+use crate::common::cells::NumericCellExt;
+use crate::common::cells::{MapCell, TakeCell};
+use crate::hil;
+use crate::process::ProcessType;
 
 ///////////////////////////////////////////////////////////////////
 // panic! support routines

--- a/kernel/src/driver.rs
+++ b/kernel/src/driver.rs
@@ -38,9 +38,9 @@
 //! While drivers do not handle the `yield` system call, it is important to
 //! understand its function and how it interacts with `subscribe`.
 
-use callback::{AppId, Callback};
-use mem::{AppSlice, Shared};
-use returncode::ReturnCode;
+use crate::callback::{AppId, Callback};
+use crate::mem::{AppSlice, Shared};
+use crate::returncode::ReturnCode;
 
 /// `Driver`s implement the three driver-specific system calls: `subscribe`,
 /// `command` and `allow`.

--- a/kernel/src/grant.rs
+++ b/kernel/src/grant.rs
@@ -5,9 +5,9 @@ use core::mem::size_of;
 use core::ops::{Deref, DerefMut};
 use core::ptr::{write, write_volatile, Unique};
 
-use callback::AppId;
-use process::Error;
-use sched::Kernel;
+use crate::callback::AppId;
+use crate::process::Error;
+use crate::sched::Kernel;
 
 pub struct Grant<T: Default> {
     crate kernel: &'static Kernel,

--- a/kernel/src/hil/adc.rs
+++ b/kernel/src/hil/adc.rs
@@ -1,6 +1,6 @@
 //! Interfaces for analog to digital converter peripherals.
 
-use returncode::ReturnCode;
+use crate::returncode::ReturnCode;
 
 // *** Interfaces for low-speed, single-sample ADCs ***
 

--- a/kernel/src/hil/analog_comparator.rs
+++ b/kernel/src/hil/analog_comparator.rs
@@ -3,7 +3,7 @@
 // Author: Danilo Verhaert <verhaert@cs.stanford.edu>
 // Last modified August 9th, 2018
 
-use returncode::ReturnCode;
+use crate::returncode::ReturnCode;
 
 pub trait AnalogComparator {
     /// The chip-dependent type of an analog comparator channel.
@@ -27,5 +27,5 @@ pub trait AnalogComparator {
 pub trait Client {
     /// Fires when handle_interrupt is called, returning the channel on which
     /// the interrupt occurred.
-    fn fired(&self, usize);
+    fn fired(&self, _: usize);
 }

--- a/kernel/src/hil/ble_advertising.rs
+++ b/kernel/src/hil/ble_advertising.rs
@@ -47,7 +47,7 @@
 //!
 //! ```
 
-use returncode::ReturnCode;
+use crate::returncode::ReturnCode;
 
 pub trait BleAdvertisementDriver {
     fn transmit_advertisement(

--- a/kernel/src/hil/crc.rs
+++ b/kernel/src/hil/crc.rs
@@ -1,6 +1,6 @@
 //! Interface for CRC computation.
 
-use returncode::ReturnCode;
+use crate::returncode::ReturnCode;
 
 /// CRC algorithms
 ///
@@ -26,7 +26,7 @@ pub enum CrcAlg {
 
 pub trait CRC {
     /// Initiate a CRC calculation
-    fn compute(&self, data: &[u8], CrcAlg) -> ReturnCode;
+    fn compute(&self, data: &[u8], _: CrcAlg) -> ReturnCode;
 
     /// Disable the CRC unit until compute() is next called
     fn disable(&self);
@@ -34,5 +34,5 @@ pub trait CRC {
 
 pub trait Client {
     /// Receive the successful result of a CRC calculation
-    fn receive_result(&self, u32);
+    fn receive_result(&self, _: u32);
 }

--- a/kernel/src/hil/dac.rs
+++ b/kernel/src/hil/dac.rs
@@ -1,6 +1,6 @@
 //! Interface for digital to analog converters.
 
-use returncode::ReturnCode;
+use crate::returncode::ReturnCode;
 
 /// Simple interface for using the DAC.
 pub trait DacChannel {

--- a/kernel/src/hil/entropy.rs
+++ b/kernel/src/hil/entropy.rs
@@ -83,7 +83,7 @@
 //! }
 //! ```
 
-use returncode::ReturnCode;
+use crate::returncode::ReturnCode;
 /// Denotes whether the [Client](trait.Client.html) wants to be notified when
 /// `More` randomness is available or if they are `Done`
 #[derive(Debug, Eq, PartialEq)]
@@ -123,7 +123,7 @@ pub trait Entropy32<'a> {
     fn cancel(&self) -> ReturnCode;
 
     /// Set the client to receive `entropy_available` callbacks.
-    fn set_client(&'a self, &'a Client32);
+    fn set_client(&'a self, _: &'a Client32);
 }
 
 /// An [Entropy32](trait.Entropy32.html) client
@@ -180,7 +180,7 @@ pub trait Entropy8<'a> {
     fn cancel(&self) -> ReturnCode;
 
     /// Set the client to receive `entropy_available` callbacks.
-    fn set_client(&'a self, &'a Client8);
+    fn set_client(&'a self, _: &'a Client8);
 }
 
 /// An [Entropy8](trait.Entropy8.html) client

--- a/kernel/src/hil/flash.rs
+++ b/kernel/src/hil/flash.rs
@@ -5,8 +5,6 @@
 //!
 //! ```rust
 //! # #![feature(const_fn)]
-//! # extern crate core;
-//! # extern crate kernel;
 //! use core::ops::{Index, IndexMut};
 //!
 //! use kernel::hil;
@@ -89,7 +87,7 @@
 //! }
 //! ```
 
-use returncode::ReturnCode;
+use crate::returncode::ReturnCode;
 
 /// Flash errors returned in the callbacks.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]

--- a/kernel/src/hil/gpio.rs
+++ b/kernel/src/hil/gpio.rs
@@ -19,7 +19,7 @@ pub enum InterruptMode {
 pub trait PinCtl {
     /// Configure whether the pin should have a pull-up or pull-down resistor or
     /// neither.
-    fn set_input_mode(&self, InputMode);
+    fn set_input_mode(&self, _: InputMode);
 }
 
 /// Interface for synchronous GPIO pins.

--- a/kernel/src/hil/gpio_async.rs
+++ b/kernel/src/hil/gpio_async.rs
@@ -1,7 +1,7 @@
 //! Interface for GPIO pins that require split-phase operation to control.
 
-use hil;
-use returncode::ReturnCode;
+use crate::hil;
+use crate::returncode::ReturnCode;
 
 /// Interface for banks of asynchronous GPIO pins. GPIO pins are asynchronous
 /// when there is an asynchronous interface used to control them. The most

--- a/kernel/src/hil/led.rs
+++ b/kernel/src/hil/led.rs
@@ -4,7 +4,7 @@
 //!  Date: July 31, 2015
 //!
 
-use hil::gpio;
+use crate::hil::gpio;
 
 pub trait Led {
     fn init(&mut self);

--- a/kernel/src/hil/mod.rs
+++ b/kernel/src/hil/mod.rs
@@ -27,5 +27,5 @@ pub mod watchdog;
 pub trait Controller {
     type Config;
 
-    fn configure(&self, Self::Config);
+    fn configure(&self, _: Self::Config);
 }

--- a/kernel/src/hil/nonvolatile_storage.rs
+++ b/kernel/src/hil/nonvolatile_storage.rs
@@ -1,6 +1,6 @@
 //! Generic interface for nonvolatile memory.
 
-use returncode::ReturnCode;
+use crate::returncode::ReturnCode;
 
 /// Simple interface for reading and writing nonvolatile memory. It is expected
 /// that drivers for nonvolatile memory would implement this trait.

--- a/kernel/src/hil/pwm.rs
+++ b/kernel/src/hil/pwm.rs
@@ -1,6 +1,6 @@
 //! Interfaces for Pulse Width Modulation output.
 
-use returncode::ReturnCode;
+use crate::returncode::ReturnCode;
 
 /// PWM control for a single pin.
 pub trait Pwm {

--- a/kernel/src/hil/radio.rs
+++ b/kernel/src/hil/radio.rs
@@ -7,7 +7,7 @@
 //! for address recognition. This must be committed to hardware with a call to
 //! config_commit. Please see the relevant TRD for more details.
 
-use returncode::ReturnCode;
+use crate::returncode::ReturnCode;
 pub trait TxClient {
     fn send_done(&self, buf: &'static mut [u8], acked: bool, result: ReturnCode);
 }

--- a/kernel/src/hil/rng.rs
+++ b/kernel/src/hil/rng.rs
@@ -89,7 +89,7 @@
 //! }
 //! ```
 
-use returncode::ReturnCode;
+use crate::returncode::ReturnCode;
 /// Denotes whether the [Client](trait.Client.html) wants to be notified when
 /// `More` randomness is available or if they are `Done`
 #[derive(Debug, Eq, PartialEq)]
@@ -127,7 +127,7 @@ pub trait Rng<'a> {
     ///   - FAIL: There will be a randomness_available callback, which
     ///     may or may not return an error code.
     fn cancel(&self) -> ReturnCode;
-    fn set_client(&'a self, &'a Client);
+    fn set_client(&'a self, _: &'a Client);
 }
 
 /// An [Rng](trait.Rng.html) client

--- a/kernel/src/hil/sensors.rs
+++ b/kernel/src/hil/sensors.rs
@@ -1,6 +1,6 @@
 //! Interfaces for environment sensors
 
-use returncode::ReturnCode;
+use crate::returncode::ReturnCode;
 
 /// A basic interface for a temperature sensor
 pub trait TemperatureDriver {

--- a/kernel/src/hil/spi.rs
+++ b/kernel/src/hil/spi.rs
@@ -1,7 +1,7 @@
 //! Interfaces for SPI master and slave communication.
 
+use crate::returncode::ReturnCode;
 use core::option::Option;
-use returncode::ReturnCode;
 
 /// Values for the ordering of bits
 #[derive(Copy, Clone, Debug)]

--- a/kernel/src/hil/symmetric_encryption.rs
+++ b/kernel/src/hil/symmetric_encryption.rs
@@ -2,7 +2,7 @@
 //!
 //! see boards/imix/src/aes_test.rs for example usage
 
-use returncode::ReturnCode;
+use crate::returncode::ReturnCode;
 
 /// Implement this trait and use `set_client()` in order to receive callbacks from an `AES128`
 /// instance.

--- a/kernel/src/hil/uart.rs
+++ b/kernel/src/hil/uart.rs
@@ -1,6 +1,6 @@
 //! Interfaces for UART communications.
 
-use returncode::ReturnCode;
+use crate::returncode::ReturnCode;
 
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum StopBits {

--- a/kernel/src/hil/usb.rs
+++ b/kernel/src/hil/usb.rs
@@ -1,6 +1,6 @@
 //! Interface to USB controller hardware
 
-use common::cells::VolatileCell;
+use crate::common::cells::VolatileCell;
 
 /// USB controller interface
 pub trait UsbController {

--- a/kernel/src/introspection.rs
+++ b/kernel/src/introspection.rs
@@ -12,11 +12,11 @@
 
 use core::cell::Cell;
 
-use callback::AppId;
-use capabilities::ProcessManagementCapability;
-use common::cells::NumericCellExt;
-use process;
-use sched::Kernel;
+use crate::callback::AppId;
+use crate::capabilities::ProcessManagementCapability;
+use crate::common::cells::NumericCellExt;
+use crate::process;
+use crate::sched::Kernel;
 
 /// This struct provides the inspection functions.
 pub struct KernelInfo {

--- a/kernel/src/ipc.rs
+++ b/kernel/src/ipc.rs
@@ -6,14 +6,14 @@
 /// Syscall number
 pub const DRIVER_NUM: usize = 0x00010000;
 
-use callback::{AppId, Callback};
-use capabilities::MemoryAllocationCapability;
-use driver::Driver;
-use grant::Grant;
-use mem::{AppSlice, Shared};
-use process;
-use returncode::ReturnCode;
-use sched::Kernel;
+use crate::callback::{AppId, Callback};
+use crate::capabilities::MemoryAllocationCapability;
+use crate::driver::Driver;
+use crate::grant::Grant;
+use crate::mem::{AppSlice, Shared};
+use crate::process;
+use crate::returncode::ReturnCode;
+use crate::sched::Kernel;
 
 struct IPCData {
     shared_memory: [Option<AppSlice<Shared, u8>>; 8],

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -13,11 +13,6 @@
 #![warn(unreachable_pub)]
 #![no_std]
 
-extern crate tock_cells;
-extern crate tock_registers;
-
-pub use tock_registers::{register_bitfields, register_bitmasks};
-
 pub mod capabilities;
 #[macro_use]
 pub mod common;
@@ -40,20 +35,20 @@ mod returncode;
 mod sched;
 mod tbfheader;
 
-pub use callback::{AppId, Callback};
-pub use driver::Driver;
-pub use grant::Grant;
-pub use mem::{AppPtr, AppSlice, Private, Shared};
-pub use platform::systick::SysTick;
-pub use platform::{mpu, Chip, Platform};
-pub use platform::{ClockInterface, NoClockControl, NO_CLOCK_CONTROL};
-pub use returncode::ReturnCode;
-pub use sched::Kernel;
+pub use crate::callback::{AppId, Callback};
+pub use crate::driver::Driver;
+pub use crate::grant::Grant;
+pub use crate::mem::{AppPtr, AppSlice, Private, Shared};
+pub use crate::platform::systick::SysTick;
+pub use crate::platform::{mpu, Chip, Platform};
+pub use crate::platform::{ClockInterface, NoClockControl, NO_CLOCK_CONTROL};
+pub use crate::returncode::ReturnCode;
+pub use crate::sched::Kernel;
 
 // Export only select items from the process module. To remove the name conflict
 // this cannot be called `process`, so we use a shortened version. These
 // functions and types are used by board files to setup the platform and setup
 // processes.
 pub mod procs {
-    pub use process::{load_processes, FaultResponse, FunctionCall, Process, ProcessType};
+    pub use crate::process::{load_processes, FaultResponse, FunctionCall, Process, ProcessType};
 }

--- a/kernel/src/mem.rs
+++ b/kernel/src/mem.rs
@@ -5,7 +5,7 @@ use core::ops::{Deref, DerefMut};
 use core::ptr::Unique;
 use core::slice;
 
-use callback::AppId;
+use crate::callback::AppId;
 
 #[derive(Debug)]
 pub struct Private;

--- a/kernel/src/memop.rs
+++ b/kernel/src/memop.rs
@@ -1,7 +1,7 @@
 //! Implementation of the MEMOP family of syscalls.
 
-use process::ProcessType;
-use returncode::ReturnCode;
+use crate::process::ProcessType;
+use crate::returncode::ReturnCode;
 
 /// Handle the `memop` syscall.
 ///

--- a/kernel/src/platform/mod.rs
+++ b/kernel/src/platform/mod.rs
@@ -1,7 +1,7 @@
 //! Interface for chips and boards.
 
-use driver::Driver;
-use syscall;
+use crate::driver::Driver;
+use crate::syscall;
 
 pub mod mpu;
 crate mod systick;

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -5,18 +5,18 @@ use core::fmt::Write;
 use core::ptr::write_volatile;
 use core::{mem, ptr, slice, str};
 
-use callback::AppId;
-use capabilities::ProcessManagementCapability;
-use common::cells::MapCell;
-use common::{Queue, RingBuffer};
+use crate::callback::AppId;
+use crate::capabilities::ProcessManagementCapability;
+use crate::common::cells::MapCell;
+use crate::common::{Queue, RingBuffer};
+use crate::mem::{AppSlice, Shared};
+use crate::platform::mpu::{self, MPU};
+use crate::platform::Chip;
+use crate::returncode::ReturnCode;
+use crate::sched::Kernel;
+use crate::syscall::{self, Syscall, UserspaceKernelBoundary};
+use crate::tbfheader;
 use core::cmp::max;
-use mem::{AppSlice, Shared};
-use platform::mpu::{self, MPU};
-use platform::Chip;
-use returncode::ReturnCode;
-use sched::Kernel;
-use syscall::{self, Syscall, UserspaceKernelBoundary};
-use tbfheader;
 
 /// Helper function to load processes from flash into an array of active
 /// processes. This is the default template for loading processes, but a board
@@ -1197,8 +1197,8 @@ impl<C: 'static + Chip> Process<'a, C> {
             // Determine the debug information to the best of our
             // understanding. If the app is doing all of the PIC fixup and
             // memory management we don't know much.
-            let mut app_heap_start_pointer = None;
-            let mut app_stack_start_pointer = None;
+            let app_heap_start_pointer = None;
+            let app_stack_start_pointer = None;
 
             // Create the Process struct in the app grant region.
             let mut process: &mut Process<C> =

--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -3,18 +3,18 @@
 use core::cell::Cell;
 use core::ptr::NonNull;
 
-use callback::Callback;
-use capabilities;
-use common::cells::NumericCellExt;
-use grant::Grant;
-use ipc;
-use memop;
-use platform::mpu::MPU;
-use platform::systick::SysTick;
-use platform::{Chip, Platform};
-use process::{self, Task};
-use returncode::ReturnCode;
-use syscall::{ContextSwitchReason, Syscall};
+use crate::callback::Callback;
+use crate::capabilities;
+use crate::common::cells::NumericCellExt;
+use crate::grant::Grant;
+use crate::ipc;
+use crate::memop;
+use crate::platform::mpu::MPU;
+use crate::platform::systick::SysTick;
+use crate::platform::{Chip, Platform};
+use crate::process::{self, Task};
+use crate::returncode::ReturnCode;
+use crate::syscall::{ContextSwitchReason, Syscall};
 
 /// The time a process is permitted to run before being pre-empted
 const KERNEL_TICK_DURATION_US: u32 = 10000;
@@ -234,7 +234,7 @@ impl Kernel {
         platform: &P,
         chip: &C,
         process: &process::ProcessType,
-        ipc: Option<&::ipc::IPC>,
+        ipc: Option<&crate::ipc::IPC>,
     ) {
         let appid = process.appid();
         let systick = chip.systick();

--- a/kernel/src/syscall.rs
+++ b/kernel/src/syscall.rs
@@ -2,7 +2,7 @@
 
 use core::fmt::Write;
 
-use process;
+use crate::process;
 
 /// The syscall number assignments.
 #[derive(Copy, Clone, Debug)]

--- a/libraries/enum_primitive/src/lib.rs
+++ b/libraries/enum_primitive/src/lib.rs
@@ -22,8 +22,8 @@ macro_rules! enum_from_primitive_impl_ty {
 macro_rules! enum_from_primitive_impl {
     ($name:ident, $( $variant:ident )*) => {
         impl FromPrimitive for $name {
-            enum_from_primitive_impl_ty! { from_i64, i64, $name, $( $variant )* }
-            enum_from_primitive_impl_ty! { from_u64, u64, $name, $( $variant )* }
+            $crate::enum_from_primitive_impl_ty! { from_i64, i64, $name, $( $variant )* }
+            $crate::enum_from_primitive_impl_ty! { from_u64, u64, $name, $( $variant )* }
 
         }
     };
@@ -43,7 +43,7 @@ macro_rules! enum_from_primitive {
         enum $name {
             $( $( #[$variant_attr] )* $variant ),+ $( = $discriminator, $( $( #[$variant_two_attr] )* $variant_two ),+ )*
         }
-        enum_from_primitive_impl! { $name, $( $variant )+ $( $( $variant_two )+ )* }
+        $crate::enum_from_primitive_impl! { $name, $( $variant )+ $( $( $variant_two )+ )* }
     };
 
     (
@@ -56,7 +56,7 @@ macro_rules! enum_from_primitive {
         enum $name {
             $( $( $( #[$variant_attr] )* $variant ),+ = $discriminator ),*
         }
-        enum_from_primitive_impl! { $name, $( $( $variant )+ )* }
+        $crate::enum_from_primitive_impl! { $name, $( $( $variant )+ )* }
     };
 
     (
@@ -69,7 +69,7 @@ macro_rules! enum_from_primitive {
         enum $name {
             $( $( #[$variant_attr] )* $variant ),+ $( = $discriminator, $( $( #[$variant_two_attr] )* $variant_two ),+ )*,
         }
-        enum_from_primitive_impl! { $name, $( $variant )+ $( $( $variant_two )+ )* }
+        $crate::enum_from_primitive_impl! { $name, $( $variant )+ $( $( $variant_two )+ )* }
     };
 
     (
@@ -82,7 +82,7 @@ macro_rules! enum_from_primitive {
         enum $name {
             $( $( $( #[$variant_attr] )* $variant ),+ = $discriminator ),+,
         }
-        enum_from_primitive_impl! { $name, $( $( $variant )+ )+ }
+        $crate::enum_from_primitive_impl! { $name, $( $( $variant )+ )+ }
     };
 
     (
@@ -95,7 +95,7 @@ macro_rules! enum_from_primitive {
         pub enum $name {
             $( $( #[$variant_attr] )* $variant ),+ $( = $discriminator, $( $( #[$variant_two_attr] )* $variant_two ),+ )*
         }
-        enum_from_primitive_impl! { $name, $( $variant )+ $( $( $variant_two )+ )* }
+        $crate::enum_from_primitive_impl! { $name, $( $variant )+ $( $( $variant_two )+ )* }
     };
 
     (
@@ -108,7 +108,7 @@ macro_rules! enum_from_primitive {
         pub enum $name {
             $( $( $( #[$variant_attr] )* $variant ),+ = $discriminator ),*
         }
-        enum_from_primitive_impl! { $name, $( $( $variant )+ )* }
+        $crate::enum_from_primitive_impl! { $name, $( $( $variant )+ )* }
     };
 
     (
@@ -121,7 +121,7 @@ macro_rules! enum_from_primitive {
         pub enum $name {
             $( $( #[$variant_attr] )* $variant ),+ $( = $discriminator, $( $( #[$variant_two_attr] )* $variant_two ),+ )*,
         }
-        enum_from_primitive_impl! { $name, $( $variant )+ $( $( $variant_two )+ )* }
+        $crate::enum_from_primitive_impl! { $name, $( $variant )+ $( $( $variant_two )+ )* }
     };
 
     (
@@ -134,6 +134,6 @@ macro_rules! enum_from_primitive {
         pub enum $name {
             $( $( $( #[$variant_attr] )* $variant ),+ = $discriminator ),+,
         }
-        enum_from_primitive_impl! { $name, $( $( $variant )+ )+ }
+        $crate::enum_from_primitive_impl! { $name, $( $( $variant )+ )+ }
     };
 }

--- a/libraries/tock-register-interface/Cargo.toml
+++ b/libraries/tock-register-interface/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 keywords = ["tock", "embedded", "registers", "mmio", "bare-metal"]
 categories = ["data-structures", "embedded", "no-std"]
 license = "MIT/Apache-2.0"
+edition = "2018"
 
 [badges]
 travis-ci = { repository = "tock/tock", branch = "master" }

--- a/libraries/tock-register-interface/src/macros.rs
+++ b/libraries/tock-register-interface/src/macros.rs
@@ -11,7 +11,7 @@ macro_rules! register_bitmasks {
         ]
     } => {
         $(#[$outer])*
-        $( register_bitmasks!($valtype, $reg_desc, $(#[$inner])* $field, $offset, 1, []); )*
+        $( $crate::register_bitmasks!($valtype, $reg_desc, $(#[$inner])* $field, $offset, 1, []); )*
     };
     {
         // BITFIELD_NAME OFFSET
@@ -22,7 +22,7 @@ macro_rules! register_bitmasks {
         ]
     } => {
         $(#[$outer])*
-        $( register_bitmasks!($valtype, $reg_desc, $(#[$inner])* $field, $offset, 1, []); )*
+        $( $crate::register_bitmasks!($valtype, $reg_desc, $(#[$inner])* $field, $offset, 1, []); )*
     };
 
     {
@@ -33,7 +33,7 @@ macro_rules! register_bitmasks {
         ]
     } => {
         $(#[$outer])*
-        $( register_bitmasks!($valtype, $reg_desc, $(#[$inner])* $field, $offset, $numbits, []); )*
+        $( $crate::register_bitmasks!($valtype, $reg_desc, $(#[$inner])* $field, $offset, $numbits, []); )*
     };
 
     {
@@ -45,7 +45,7 @@ macro_rules! register_bitmasks {
         ]
     } => {
         $(#[$outer])*
-        $( register_bitmasks!($valtype, $reg_desc, $(#[$inner])* $field, $offset, $numbits,
+        $( $crate::register_bitmasks!($valtype, $reg_desc, $(#[$inner])* $field, $offset, $numbits,
                               $values); )*
     };
     {
@@ -131,7 +131,7 @@ macro_rules! register_bitfields {
 
                 use $crate::registers::Field;
 
-                register_bitmasks!( $valtype, Register, $fields );
+                $crate::register_bitmasks!( $valtype, Register, $fields );
             }
         )*
     }


### PR DESCRIPTION
Rust now has four active versions:
- Stable, Rust 2015
- Stable, Rust 2018
- Nightly, Rust 2015
- Nightly, Rust 2018

Since we are already on nightly, we might as well also use the new version of Rust too.

The two main changes:
- Macros are now imported like everything else and not some weird global imports.
- No more `extern crate`.



### Testing Strategy

This pull request was tested by compiling.


### TODO or Help Wanted

Need to remove the old boards so I don't have to update those as well.


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
