### PR TITLE
capsules: gpio: support multiple apps

### DIFF
--- a/boards/acd52832/src/main.rs
+++ b/boards/acd52832/src/main.rs
@@ -209,7 +209,10 @@ pub unsafe fn reset_handler() {
     //
     let gpio = static_init!(
         capsules::gpio::GPIO<'static, nrf5x::gpio::GPIOPin>,
-        capsules::gpio::GPIO::new(gpio_pins)
+        capsules::gpio::GPIO::new(
+            gpio_pins,
+            board_kernel.create_grant(&memory_allocation_capability)
+        )
     );
     for pin in gpio_pins.iter() {
         pin.set_client(gpio);

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -511,7 +511,10 @@ pub unsafe fn reset_handler() {
     ); // D7
     let gpio = static_init!(
         capsules::gpio::GPIO<'static, sam4l::gpio::GPIOPin>,
-        capsules::gpio::GPIO::new(gpio_pins)
+        capsules::gpio::GPIO::new(
+            gpio_pins,
+            board_kernel.create_grant(&memory_allocation_capability)
+        )
     );
     for pin in gpio_pins.iter() {
         pin.set_client(gpio);

--- a/boards/imix/src/components/button.rs
+++ b/boards/imix/src/components/button.rs
@@ -7,7 +7,7 @@
 //! Usage
 //! -----
 //! ```rust
-//! let button = ButtonComponent::new().finalize();
+//! let button = ButtonComponent::new(board_kernel).finalize();
 //! ```
 
 // Author: Philip Levis <pal@cs.stanford.edu>

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -371,7 +371,7 @@ pub unsafe fn reset_handler() {
     .finalize();
 
     let adc = AdcComponent::new().finalize();
-    let gpio = GpioComponent::new().finalize();
+    let gpio = GpioComponent::new(board_kernel).finalize();
     let led = LedComponent::new().finalize();
     let button = ButtonComponent::new(board_kernel).finalize();
     let crc = CrcComponent::new(board_kernel).finalize();

--- a/boards/launchxl/src/main.rs
+++ b/boards/launchxl/src/main.rs
@@ -247,7 +247,10 @@ pub unsafe fn reset_handler() {
     );
     let gpio = static_init!(
         capsules::gpio::GPIO<'static, cc26x2::gpio::GPIOPin>,
-        capsules::gpio::GPIO::new(gpio_pins)
+        capsules::gpio::GPIO::new(
+            gpio_pins,
+            board_kernel.create_grant(&memory_allocation_capability)
+        )
     );
     for pin in gpio_pins.iter() {
         pin.set_client(gpio);

--- a/boards/nordic/nrf52dk_base/Cargo.lock
+++ b/boards/nordic/nrf52dk_base/Cargo.lock
@@ -2,6 +2,7 @@
 name = "capsules"
 version = "0.1.0"
 dependencies = [
+ "enum_primitive 0.1.0",
  "kernel 0.1.0",
 ]
 
@@ -21,6 +22,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum_primitive"
+version = "0.1.0"
+
+[[package]]
 name = "kernel"
 version = "0.1.0"
 dependencies = [
@@ -35,6 +40,7 @@ dependencies = [
  "cortexm4 0.1.0",
  "kernel 0.1.0",
  "nrf5x 0.1.0",
+ "tock_rt0 0.1.0",
 ]
 
 [[package]]
@@ -62,4 +68,8 @@ version = "0.1.0"
 [[package]]
 name = "tock-registers"
 version = "0.2.0"
+
+[[package]]
+name = "tock_rt0"
+version = "0.1.0"
 

--- a/boards/nordic/nrf52dk_base/src/lib.rs
+++ b/boards/nordic/nrf52dk_base/src/lib.rs
@@ -155,7 +155,10 @@ pub unsafe fn setup_board(
 
     let gpio = static_init!(
         capsules::gpio::GPIO<'static, nrf5x::gpio::GPIOPin>,
-        capsules::gpio::GPIO::new(gpio_pins)
+        capsules::gpio::GPIO::new(
+            gpio_pins,
+            board_kernel.create_grant(&memory_allocation_capability)
+        )
     );
     for pin in gpio_pins.iter() {
         pin.set_client(gpio);

--- a/capsules/src/gpio.rs
+++ b/capsules/src/gpio.rs
@@ -47,20 +47,19 @@
 use driver;
 pub const DRIVER_NUM: usize = driver::NUM::GPIO as usize;
 
-use kernel::common::cells::OptionalCell;
 use kernel::hil::gpio::{Client, InputMode, InterruptMode, Pin, PinCtl};
-use kernel::{AppId, Callback, Driver, ReturnCode};
+use kernel::{AppId, Callback, Driver, Grant, ReturnCode};
 
 pub struct GPIO<'a, G: Pin> {
     pins: &'a [&'a G],
-    callback: OptionalCell<Callback>,
+    apps: Grant<Option<Callback>>,
 }
 
 impl<G: Pin + PinCtl> GPIO<'a, G> {
-    pub fn new(pins: &'a [&'a G]) -> GPIO<'a, G> {
+    pub fn new(pins: &'a [&'a G], grant: Grant<Option<Callback>>) -> GPIO<'a, G> {
         GPIO {
             pins: pins,
-            callback: OptionalCell::empty(),
+            apps: grant,
         }
     }
 
@@ -114,8 +113,9 @@ impl<G: Pin> Client for GPIO<'a, G> {
         let pin_state = pins[pin_num].read();
 
         // schedule callback with the pin number and value
-        self.callback
-            .map(|cb| cb.schedule(pin_num, pin_state as usize, 0));
+        self.apps.each(|callback| {
+            callback.map(|mut cb| cb.schedule(pin_num, pin_state as usize, 0));
+        });
     }
 }
 
@@ -130,15 +130,18 @@ impl<G: Pin + PinCtl> Driver for GPIO<'a, G> {
         &self,
         subscribe_num: usize,
         callback: Option<Callback>,
-        _app_id: AppId,
+        app_id: AppId,
     ) -> ReturnCode {
         match subscribe_num {
             // subscribe to all pin interrupts (no affect or reliance on
             // individual pins being configured as interrupts)
-            0 => {
-                self.callback.insert(callback);
-                ReturnCode::SUCCESS
-            }
+            0 => self
+                .apps
+                .enter(app_id, |app, _| {
+                    **app = callback;
+                    ReturnCode::SUCCESS
+                })
+                .unwrap_or_else(|err| err.into()),
 
             // default
             _ => ReturnCode::ENOSUPPORT,


### PR DESCRIPTION
Each app can now register a callback with the capsule and get a callback when an interrupt happens.

For #1216




### Testing Strategy

Running two copies of `examples/tests/gpio` on hail and seeing two apps get the interrupt.


### TODO or Help Wanted

I think this is good enough for the GPIO capsule driver?


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
