### PR TITLE
doc: clean up rustdoc warnings

### DIFF
--- a/arch/cortex-m3/src/mpu.rs
+++ b/arch/cortex-m3/src/mpu.rs
@@ -8,7 +8,7 @@ use kernel::common::registers::{FieldValue, ReadOnly, ReadWrite};
 use kernel::common::StaticRef;
 use kernel::mpu;
 
-/// MPU Registers for the Cortex-M[34] families
+/// MPU Registers for the Cortex-M3 and Cortex-M4 families
 /// Described in section 4.5 of
 /// <http://infocenter.arm.com/help/topic/com.arm.doc.dui0553a/DUI0553A_cortex_m4_dgug.pdf>
 #[repr(C)]

--- a/chips/nrf52/src/adc.rs
+++ b/chips/nrf52/src/adc.rs
@@ -29,7 +29,7 @@ struct AdcRegisters {
     events_calibratedone: ReadWrite<u32, EVENT::Register>,
     /// The ADC has stopped
     events_stopped: ReadWrite<u32, EVENT::Register>,
-    /// Last result is equal or above CH[X].LIMIT
+    /// Last result is equal or above `CH[X].LIMIT`
     events_ch: [AdcEventChRegisters; 8],
     _reserved1: [u8; 424],
     /// Enable or disable interrupt

--- a/libraries/tock-register-interface/src/registers.rs
+++ b/libraries/tock-register-interface/src/registers.rs
@@ -100,7 +100,7 @@ pub trait RegisterLongName {}
 impl RegisterLongName for () {}
 
 /// Conversion of raw register value into enumerated values member.
-/// Implemented inside register_bitfields![] macro for each bit field.
+/// Implemented inside register_bitfields! macro for each bit field.
 pub trait TryFromValue<V> {
     type EnumType;
 


### PR DESCRIPTION
### Pull Request Overview

Doc-only changes that clean up some warnings in the rustdoc runs.

### Testing Strategy

This pull request was tested by compiling.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.

-----------------

There's still one set of warnings generated for each board, but that appears to be a known bug rather than a real issue: https://github.com/rust-lang/rust/issues/43144