### PR TITLE
libraries: bump tock-register-interface version

### DIFF
--- a/libraries/tock-register-interface/CHANGELOG.md
+++ b/libraries/tock-register-interface/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.3
+
+ - #1243: Update to Rust 2018 (nightly)
+ - #1250: Doc-only: Fix some rustdoc warnings
+
 ## v0.2
 
  - #1161: Add `read_as_enum` to `LocalRegisterCopy`; thanks @andre-richter

--- a/libraries/tock-register-interface/Cargo.lock
+++ b/libraries/tock-register-interface/Cargo.lock
@@ -1,4 +1,4 @@
 [[package]]
 name = "tock-registers"
-version = "0.2.0"
+version = "0.3.0"
 

--- a/libraries/tock-register-interface/Cargo.toml
+++ b/libraries/tock-register-interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tock-registers"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
 description = "Memory-Mapped I/O and register interface developed for Tock."
 homepage = "https://www.tockos.org/"


### PR DESCRIPTION
### Pull Request Overview

Publishes the update to Rust 2018 (nightly)

Fixes #1253.

### Testing Strategy

This pull request was tested by compiling.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
