### PR TITLE
Rename all occurances of UartMux to MuxUart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,8 +51,8 @@ Since 1.2
 
     ```rust
     let uart_mux = static_init!(
-        UartMux<'static>,
-        UartMux::new(
+        MuxUart<'static>,
+        MuxUart::new(
             &sam4l::usart::USART0, // Choose the correct UART HW bus
             &mut capsules::virtual_uart::RX_BUF,
             115200

--- a/boards/acd52832/src/main.rs
+++ b/boards/acd52832/src/main.rs
@@ -5,7 +5,7 @@
 #![deny(missing_docs)]
 
 use capsules::virtual_alarm::VirtualMuxAlarm;
-use capsules::virtual_uart::{UartDevice, UartMux};
+use capsules::virtual_uart::{MuxUart, UartDevice};
 use kernel::capabilities;
 use kernel::hil;
 use kernel::hil::entropy::Entropy32;
@@ -307,8 +307,8 @@ pub unsafe fn reset_handler() {
 
     // Create a shared UART channel for the console and for kernel debug.
     let uart_mux = static_init!(
-        UartMux<'static>,
-        UartMux::new(rtt, &mut capsules::virtual_uart::RX_BUF, 115200)
+        MuxUart<'static>,
+        MuxUart::new(rtt, &mut capsules::virtual_uart::RX_BUF, 115200)
     );
     kernel::hil::uart::UART::set_client(rtt, uart_mux);
 

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -10,7 +10,7 @@
 use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use capsules::virtual_i2c::{I2CDevice, MuxI2C};
 use capsules::virtual_spi::{MuxSpiMaster, VirtualSpiMasterDevice};
-use capsules::virtual_uart::{UartDevice, UartMux};
+use capsules::virtual_uart::{MuxUart, UartDevice};
 use kernel::capabilities;
 use kernel::hil;
 use kernel::hil::entropy::Entropy32;
@@ -217,8 +217,8 @@ pub unsafe fn reset_handler() {
 
     // Create a shared UART channel for the console and for kernel debug.
     let uart_mux = static_init!(
-        UartMux<'static>,
-        UartMux::new(
+        MuxUart<'static>,
+        MuxUart::new(
             &sam4l::usart::USART0,
             &mut capsules::virtual_uart::RX_BUF,
             115200

--- a/boards/imix/src/components/console.rs
+++ b/boards/imix/src/components/console.rs
@@ -18,7 +18,7 @@
 #![allow(dead_code)] // Components are intended to be conditionally included
 
 use capsules::console;
-use capsules::virtual_uart::{UartDevice, UartMux};
+use capsules::virtual_uart::{MuxUart, UartDevice};
 use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
@@ -27,14 +27,14 @@ use kernel::static_init;
 
 pub struct ConsoleComponent {
     board_kernel: &'static kernel::Kernel,
-    uart_mux: &'static UartMux<'static>,
+    uart_mux: &'static MuxUart<'static>,
     baud_rate: u32,
 }
 
 impl ConsoleComponent {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
-        uart_mux: &'static UartMux,
+        uart_mux: &'static MuxUart,
         rate: u32,
     ) -> ConsoleComponent {
         ConsoleComponent {

--- a/boards/imix/src/components/process_console.rs
+++ b/boards/imix/src/components/process_console.rs
@@ -11,7 +11,7 @@
 #![allow(dead_code)] // Components are intended to be conditionally included
 
 use capsules::process_console;
-use capsules::virtual_uart::{UartDevice, UartMux};
+use capsules::virtual_uart::{MuxUart, UartDevice};
 use kernel::capabilities;
 use kernel::component::Component;
 use kernel::hil;
@@ -19,14 +19,14 @@ use kernel::static_init;
 
 pub struct ProcessConsoleComponent {
     board_kernel: &'static kernel::Kernel,
-    uart_mux: &'static UartMux<'static>,
+    uart_mux: &'static MuxUart<'static>,
     baud_rate: u32,
 }
 
 impl ProcessConsoleComponent {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
-        uart_mux: &'static UartMux,
+        uart_mux: &'static MuxUart,
         rate: u32,
     ) -> ProcessConsoleComponent {
         ProcessConsoleComponent {

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -15,7 +15,7 @@ use capsules::net::ipv6::ip_utils::IPAddr;
 use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use capsules::virtual_i2c::MuxI2C;
 use capsules::virtual_spi::{MuxSpiMaster, VirtualSpiMasterDevice};
-use capsules::virtual_uart::{UartDevice, UartMux};
+use capsules::virtual_uart::{MuxUart, UartDevice};
 use kernel::capabilities;
 use kernel::component::Component;
 use kernel::hil;
@@ -303,8 +303,8 @@ pub unsafe fn reset_handler() {
     // Create a shared UART channel for the consoles and for kernel debug.
     sam4l::usart::USART3.set_mode(sam4l::usart::UsartMode::Uart);
     let uart_mux = static_init!(
-        UartMux<'static>,
-        UartMux::new(
+        MuxUart<'static>,
+        MuxUart::new(
             &sam4l::usart::USART3,
             &mut capsules::virtual_uart::RX_BUF,
             115200

--- a/boards/imix/src/virtual_uart_rx_test.rs
+++ b/boards/imix/src/virtual_uart_rx_test.rs
@@ -4,7 +4,7 @@
 //!    virtual_uart_rx_test::run_virtual_uart_receive(uart_mux);
 //! ```
 //! to the imix boot sequence, where `uart_mux` is a
-//! `capsules::virtual_uart::UartMux`.  There is a 3-byte and a 7-byte
+//! `capsules::virtual_uart::MuxUart`.  There is a 3-byte and a 7-byte
 //! read running in parallel. Test that they are both working by typing
 //! and seeing that they both get all characters. If you repeatedly
 //! type 'a', for example (0x61), you should see something like:
@@ -45,12 +45,12 @@
 //! ```
 
 use capsules::test::virtual_uart::TestVirtualUartReceive;
-use capsules::virtual_uart::{UartDevice, UartMux};
+use capsules::virtual_uart::{MuxUart, UartDevice};
 use kernel::debug;
 use kernel::hil::uart::UART;
 use kernel::static_init;
 
-pub unsafe fn run_virtual_uart_receive(mux: &'static UartMux<'static>) {
+pub unsafe fn run_virtual_uart_receive(mux: &'static MuxUart<'static>) {
     debug!("Starting virtual reads.");
     let small = static_init_test_receive_small(mux);
     let large = static_init_test_receive_large(mux);
@@ -59,7 +59,7 @@ pub unsafe fn run_virtual_uart_receive(mux: &'static UartMux<'static>) {
 }
 
 unsafe fn static_init_test_receive_small(
-    mux: &'static UartMux<'static>,
+    mux: &'static MuxUart<'static>,
 ) -> &'static TestVirtualUartReceive {
     static mut SMALL: [u8; 3] = [0; 3];
     let device = static_init!(UartDevice<'static>, UartDevice::new(mux, true));
@@ -73,7 +73,7 @@ unsafe fn static_init_test_receive_small(
 }
 
 unsafe fn static_init_test_receive_large(
-    mux: &'static UartMux<'static>,
+    mux: &'static MuxUart<'static>,
 ) -> &'static TestVirtualUartReceive {
     static mut BUFFER: [u8; 7] = [0; 7];
     let device = static_init!(UartDevice<'static>, UartDevice::new(mux, true));

--- a/boards/launchxl/src/main.rs
+++ b/boards/launchxl/src/main.rs
@@ -5,7 +5,7 @@
 #[allow(unused_imports)]
 use kernel::{create_capability, debug, debug_gpio, static_init};
 
-use capsules::virtual_uart::{UartDevice, UartMux};
+use capsules::virtual_uart::{MuxUart, UartDevice};
 use cc26x2::aon;
 use cc26x2::prcm;
 use kernel::capabilities;
@@ -168,8 +168,8 @@ pub unsafe fn reset_handler() {
 
     // Create a shared UART channel for the console and for kernel debug.
     let uart_mux = static_init!(
-        UartMux<'static>,
-        UartMux::new(
+        MuxUart<'static>,
+        MuxUart::new(
             &cc26x2::uart::UART0,
             &mut capsules::virtual_uart::RX_BUF,
             115200

--- a/boards/nordic/nrf52dk_base/src/lib.rs
+++ b/boards/nordic/nrf52dk_base/src/lib.rs
@@ -7,7 +7,7 @@ use kernel::{create_capability, debug, debug_gpio, debug_verbose, static_init};
 
 use capsules::virtual_alarm::VirtualMuxAlarm;
 use capsules::virtual_spi::MuxSpiMaster;
-use capsules::virtual_uart::{UartDevice, UartMux};
+use capsules::virtual_uart::{MuxUart, UartDevice};
 use kernel::capabilities;
 use kernel::hil;
 use kernel::hil::entropy::Entropy32;
@@ -209,8 +209,8 @@ pub unsafe fn setup_board(
 
     // Create a shared UART channel for the console and for kernel debug.
     let uart_mux = static_init!(
-        UartMux<'static>,
-        UartMux::new(
+        MuxUart<'static>,
+        MuxUart::new(
             &nrf52::uart::UARTE0,
             &mut capsules::virtual_uart::RX_BUF,
             115200

--- a/capsules/src/virtual_uart.rs
+++ b/capsules/src/virtual_uart.rs
@@ -7,7 +7,7 @@
 //! Clients can choose if they want to receive. Incoming messages will be sent
 //! to all clients that have enabled receiving.
 //!
-//! `UartMux` provides shared access to a single UART bus for multiple users.
+//! `MuxUart` provides shared access to a single UART bus for multiple users.
 //! `UartDevice` provides access for a single client.
 //!
 //! Usage
@@ -16,8 +16,8 @@
 //! ```
 //! // Create a shared UART channel for the console and for kernel debug.
 //! let uart_mux = static_init!(
-//!     UartMux<'static>,
-//!     UartMux::new(&sam4l::usart::USART0, &mut capsules::virtual_uart::RX_BUF)
+//!     MuxUart<'static>,
+//!     MuxUart::new(&sam4l::usart::USART0, &mut capsules::virtual_uart::RX_BUF)
 //! );
 //! hil::uart::UART::set_client(&sam4l::usart::USART0, uart_mux);
 
@@ -49,7 +49,7 @@ use kernel::ReturnCode;
 const RX_BUF_LEN: usize = 64;
 pub static mut RX_BUF: [u8; RX_BUF_LEN] = [0; RX_BUF_LEN];
 
-pub struct UartMux<'a> {
+pub struct MuxUart<'a> {
     uart: &'a hil::uart::UART,
     speed: u32,
     devices: List<'a, UartDevice<'a>>,
@@ -58,7 +58,7 @@ pub struct UartMux<'a> {
     completing_read: Cell<bool>,
 }
 
-impl<'a> hil::uart::Client for UartMux<'a> {
+impl<'a> hil::uart::Client for MuxUart<'a> {
     fn transmit_complete(&self, tx_buffer: &'static mut [u8], error: hil::uart::Error) {
         self.inflight.map(move |device| {
             self.inflight.clear();
@@ -140,9 +140,9 @@ impl<'a> hil::uart::Client for UartMux<'a> {
     }
 }
 
-impl<'a> UartMux<'a> {
-    pub fn new(uart: &'a hil::uart::UART, buffer: &'static mut [u8], speed: u32) -> UartMux<'a> {
-        UartMux {
+impl<'a> MuxUart<'a> {
+    pub fn new(uart: &'a hil::uart::UART, buffer: &'static mut [u8], speed: u32) -> MuxUart<'a> {
+        MuxUart {
             uart: uart,
             speed: speed,
             devices: List::new(),
@@ -221,7 +221,7 @@ enum UartDeviceReceiveState {
 
 pub struct UartDevice<'a> {
     state: Cell<UartDeviceReceiveState>,
-    mux: &'a UartMux<'a>,
+    mux: &'a MuxUart<'a>,
     receiver: bool, // Whether or not to pass this UartDevice incoming messages.
     tx_buffer: TakeCell<'static, [u8]>,
     rx_buffer: TakeCell<'static, [u8]>,
@@ -233,7 +233,7 @@ pub struct UartDevice<'a> {
 }
 
 impl<'a> UartDevice<'a> {
-    pub const fn new(mux: &'a UartMux<'a>, receiver: bool) -> UartDevice<'a> {
+    pub const fn new(mux: &'a MuxUart<'a>, receiver: bool) -> UartDevice<'a> {
         UartDevice {
             state: Cell::new(UartDeviceReceiveState::Idle),
             mux: mux,


### PR DESCRIPTION
### Pull Request Overview

Per issue #1247, rename all occurrences of UartMux to MuxUart

### Testing Strategy

Grep plus clean build for all board types

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

No updates are required, but I did change an example in CHANGELOG.md.  That felt a little weird but seemed to make sense.

### Formatting

- [X] Ran `make formatall`.
