### PR TITLE
Use list_boards.sh for building documentation

### DIFF
--- a/tools/build-all-docs.sh
+++ b/tools/build-all-docs.sh
@@ -47,22 +47,34 @@ function add_board {
 	done
 }
 
+function build_all_docs {
+    # Need to build one board to get things started.
+    BOARD=$1
+    shift
+    echo "Building docs for $BOARD"
+    pushd boards/$BOARD > /dev/null
+    make doc
+    popd > /dev/null
+    cp -r boards/$BOARD/target/thumbv7em-none-eabi/doc doc/rustdoc
+    ## Now can do all the rest.
+    for BOARD in $*
+    do
+        echo "Now building for $BOARD"
+        add_board imix
+        add_board nordic/nrf52dk
+        add_board nordic/nrf52840dk
+        add_board launchxl
+        add_board nucleo_f446re
+    done
+}
+
 # Delete any old docs
 rm -rf doc/rustdoc
 
-# Need to build one board to get things started.
-echo "Building docs for hail"
-pushd boards/hail > /dev/null
-make doc
-popd > /dev/null
-cp -r boards/hail/target/thumbv7em-none-eabi/doc doc/rustdoc
-
-# Now can do all the rest.
-add_board imix
-add_board nordic/nrf52dk
-add_board nordic/nrf52840dk
-add_board launchxl
-add_board nucleo_f446re
+# Get a list of all boards
+ALL_BOARDS=$(./tools/list_boards.sh)
+# Build documentation for all of them
+build_all_docs $ALL_BOARDS
 
 # Temporary redirect rule
 # https://www.netlify.com/docs/redirects/


### PR DESCRIPTION
### Pull Request Overview

This pull request modifies tools/build-all-docs.sh to use tools/list_boards.sh to get the list of boards for which documentation is to be built.  

### Testing Strategy

Running ./tools/build-all-docs.sh from the top-level directory successfully builds documentation for all boards.

### TODO or Help Wanted

This pull request still needs...


### Documentation Updated

No updates are required.

### Formatting

Shell scripts are not formatted