### PR TITLE
correcting layout so tock can run

### DIFF
--- a/boards/hifive1/layout.ld
+++ b/boards/hifive1/layout.ld
@@ -1,6 +1,6 @@
 MEMORY
 {
-  rom (rx)  : ORIGIN = 0x40400000, LENGTH = 512M
+  rom (rx)  : ORIGIN = 0x20400000, LENGTH = 512M
   prog (rx) : ORIGIN = 0x20500000, LENGTH = 507M
   ram (rwx) : ORIGIN = 0x80000000, LENGTH = 16K
 }


### PR DESCRIPTION
### Pull Request Overview

Tock currently fails on the third instruction in qemu because the rom doesn't start at 0x20400000. As a result it jumps to a unimpl instruction. This PR fixes that by moving the rom to 0x20400000.


### Testing Strategy

Tested in riscv32 qemu with the sifive_e machine flag.