### PR TITLE
chips/stm32f446re: Remove `get_transfer_counter` from `dma1.rs`

### DIFF
--- a/chips/stm32f446re/src/dma1.rs
+++ b/chips/stm32f446re/src/dma1.rs
@@ -912,19 +912,6 @@ impl Stream<'a> {
         self.buffer.take()
     }
 
-    pub fn get_transfer_counter(&self) -> usize {
-        match self.streamid {
-            StreamId::Stream0 => unsafe { DMA1.registers.s0ndtr.get() as usize },
-            StreamId::Stream1 => unsafe { DMA1.registers.s1ndtr.get() as usize },
-            StreamId::Stream2 => unsafe { DMA1.registers.s2ndtr.get() as usize },
-            StreamId::Stream3 => unsafe { DMA1.registers.s3ndtr.get() as usize },
-            StreamId::Stream4 => unsafe { DMA1.registers.s4ndtr.get() as usize },
-            StreamId::Stream5 => unsafe { DMA1.registers.s5ndtr.get() as usize },
-            StreamId::Stream6 => unsafe { DMA1.registers.s6ndtr.get() as usize },
-            StreamId::Stream7 => unsafe { DMA1.registers.s7ndtr.get() as usize },
-        }
-    }
-
     fn set_channel(&self) {
         self.peripheral.map(|pid| {
             match pid {


### PR DESCRIPTION
Commit `5c55cfb42` introduced the following API change.

```
-    pub fn abort_transfer(&self) -> Option<&'static mut [u8]> {
+    pub fn abort_transfer(&self) -> (Option<&'static mut [u8]>, u32) {
```

This removes the need for `get_transfer_counter` method as the same information
is now returned by the u32 element of the return tuple.
