### PR TITLE
libraries/tock-cells: Add `unwrap` function for `OptionalCell`

### DIFF
--- a/libraries/tock-cells/src/optional_cell.rs
+++ b/libraries/tock-cells/src/optional_cell.rs
@@ -67,8 +67,10 @@ impl<T: Copy> OptionalCell<T> {
         self.value.get().expect(msg)
     }
 
-    // Note: Explicitly do not support unwrap, as we do not to encourage
-    // panic'ing in the Tock kernel.
+    /// Returns the contained value or panics if contents is `None`.
+    pub unsafe fn unwrap(&self) -> T {
+        self.value.get().unwrap()
+    }
 
     /// Returns the contained value or a default.
     pub fn unwrap_or(&self, default: T) -> T {


### PR DESCRIPTION
Introduce `unwrap` function with the following signature.

```
pub unsafe fn unwrap(&self) -> T
```

By specifying the function as `unsafe`, indicate to the caller that there are
extra invariants that the caller needs to consider as this method will panic if
the content is `None`.

With `unwrap` we can write

```
// Safety:
//   `xxx` should not be `None`
unsafe fn fun1() {
   let mut p = xxx.unwrap();
}
```

Instead of

```
// Safety:
//   `xxx` should not be `None`
unsafe fn fun1() {
   let mut p = xxx.expect("ABC");
}
```

And save on storage space for "ABC".

