### PR TITLE
chips/stm32f446re: Remove `as usize`

### DIFF
--- a/chips/stm32f446re/src/usart.rs
+++ b/chips/stm32f446re/src/usart.rs
@@ -301,7 +301,7 @@ impl Usart<'a> {
         // alert client
         self.tx_client.map(|client| {
             buffer.take().map(|buf| {
-                client.transmitted_buffer(buf, count as usize, rcode);
+                client.transmitted_buffer(buf, count, rcode);
             });
         });
     }


### PR DESCRIPTION
`count` would be inferred as `usize` by rust, so adding `as usize` here is
redundant.
