### PR TITLE
kernel/sched: Change `systick.enable` to `false`

### DIFF
--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -240,7 +240,7 @@ impl Kernel {
         let systick = chip.systick();
         systick.reset();
         systick.set_timer(KERNEL_TICK_DURATION_US);
-        systick.enable(true);
+        systick.enable(false);
 
         loop {
             if chip.has_pending_interrupts() {


### PR DESCRIPTION
### Pull Request Overview

`systick.enable` take a parameter of type `bool` to indicate if the SysTick
interrupt handler needs to be called or not.

While we need SysTick timer to be running before we enter the `do_process`
loop, from what I understand we do not require SysTick interrupt handler to be
enabled intially.

SysTick interrupt handler is enabled (using `systick.enable(true)`) prior to
switching to user space.

### Testing Strategy

Tested on Nucleo-446RE
