### PR TITLE
CC26x2 fix UART

### DIFF
--- a/boards/launchxl/src/main.rs
+++ b/boards/launchxl/src/main.rs
@@ -232,6 +232,7 @@ pub unsafe fn reset_handler() {
     }
 
     // UART
+    cc26x2::uart::UART0.initialize();
 
     // Create a shared UART channel for the console and for kernel debug.
     let uart_mux = static_init!(
@@ -242,14 +243,13 @@ pub unsafe fn reset_handler() {
             115200
         )
     );
+    uart_mux.initialize();
     hil::uart::Receive::set_receive_client(&cc26x2::uart::UART0, uart_mux);
     hil::uart::Transmit::set_transmit_client(&cc26x2::uart::UART0, uart_mux);
 
     // Create a UartDevice for the console.
     let console_uart = static_init!(UartDevice, UartDevice::new(uart_mux, true));
     console_uart.setup();
-
-    cc26x2::uart::UART0.initialize();
 
     let console = static_init!(
         capsules::console::Console<'static>,

--- a/boards/launchxl/src/uart_echo.rs
+++ b/boards/launchxl/src/uart_echo.rs
@@ -4,75 +4,22 @@ use kernel::ReturnCode;
 
 /*
     #############################################
-    // Add the snippet below to main if you want to enable echo on UART1 and UART2
+    // Add the snippet below to main if you want to enable echo on UART0
     // Create a virtual device for echo test
-    let echo0_uart = static_init!(UartDevice, UartDevice::new(uart_mux, true));
-    echo0_uart.setup();
     let echo0 = static_init!(
-            uart_echo::UartEcho<UartDevice, UartDevice>,
-            uart_echo::UartEcho::new(
-                echo0_uart,
-                echo0_uart,
-                &mut uart_echo::OUT_BUF0,
-                &mut uart_echo::IN_BUF0,
-            )
-        );
-
-    hil::uart::UART::set_client(echo0_uart, echo0);
-    echo0.initialize();
-
-    // Directly hook up UART1 for echo test
-    let echo1 = static_init!(
             uart_echo::UartEcho<cc26x2::uart::UART, cc26x2::uart::UART>,
             uart_echo::UartEcho::new(
-                &cc26x2::uart::UART1,
-                &cc26x2::uart::UART1,
-                &mut uart_echo::OUT_BUF1,
-                &mut uart_echo::IN_BUF1,
-            )
-        );
-    hil::uart::UART::set_client(&cc26x2::uart::UART1, echo1);
-    cc26x2::uart::UART1.initialize();
-    cc26x2::uart::UART1.configure(uart_echo::UART_PARAMS);
-    echo1.initialize();
-
-    #############################################
-    // Add the snipper below to main if you want to criss-cross TX/RX of UART0/1
-    // Create a virtual device for echo test
-    let echo0_uart = static_init!(UartDevice, UartDevice::new(uart_mux, true));
-    echo0_uart.setup();
-    let echo0 = static_init!(
-            uart_echo::UartEcho<UartDevice, cc26x2::uart::UART>,
-            uart_echo::UartEcho::new(
-                echo0_uart,
-                &cc26x2::uart::UART1,
+                &cc26x2::uart::UART0,
+                &cc26x2::uart::UART0,
                 &mut uart_echo::OUT_BUF0,
                 &mut uart_echo::IN_BUF0,
             )
         );
-    hil::uart::UART::set_client(echo0_uart, echo0);
-    cc26x2::uart::UART1.set_rx_client(echo0);
+    hil::uart::Transmit::set_transmit_client(&cc26x2::uart::UART0, echo0);
+    hil::uart::Receive::set_receive_client(&cc26x2::uart::UART0, echo0);
+    // change initialize to false to test buffer mode
+    echo0.initialize(true);
 
-    echo0.initialize();
-
-    // Create a virtual device for echo test
-    let echo1_uart = static_init!(UartDevice, UartDevice::new(uart_mux, true));
-    echo1_uart.setup();
-    let echo1 = static_init!(
-            uart_echo::UartEcho<cc26x2::uart::UART, UartDevice>,
-            uart_echo::UartEcho::new(
-                &cc26x2::uart::UART1,
-                echo1_uart,
-                &mut uart_echo::OUT_BUF1,
-                &mut uart_echo::IN_BUF1,
-            )
-        );
-    cc26x2::uart::UART1.set_tx_client(echo1);
-    hil::uart::UART::set_client(echo1_uart, echo1);
-
-    cc26x2::uart::UART1.initialize();
-    cc26x2::uart::UART1.configure(uart_echo::UART_PARAMS);
-    echo1.initialize();
 */
 
 const DEFAULT_BAUD: u32 = 115200;
@@ -101,6 +48,8 @@ pub struct UartEcho<UTx: 'static + uart::Transmit<'static>, URx: 'static + uart:
     rx_buf: MapCell<&'static mut [u8]>,
 }
 
+use kernel::debug;
+
 impl<UTx: 'static + uart::Transmit<'static>, URx: 'static + uart::Receive<'static>>
     UartEcho<UTx, URx>
 {
@@ -123,10 +72,15 @@ impl<UTx: 'static + uart::Transmit<'static>, URx: 'static + uart::Receive<'stati
         }
     }
 
-    pub fn initialize(&self) {
-        self.rx_buf.take().map(|buf| {
-            self.uart_rx.receive_buffer(buf, MAX_PAYLOAD);
-        });
+    pub fn initialize(&self, word_mode: bool) {
+        if word_mode {
+            debug!("putting self as receive word");
+            self.uart_rx.receive_word();
+        } else {
+            self.rx_buf.take().map(|buf| {
+                self.uart_rx.receive_buffer(buf, MAX_PAYLOAD);
+            });
+        }
     }
 }
 
@@ -141,6 +95,21 @@ impl<UTx: 'static + uart::Transmit<'static>, URx: 'static + uart::Receive<'stati
 impl<UTx: 'static + uart::Transmit<'static>, URx: 'static + uart::Receive<'static>>
     uart::ReceiveClient for UartEcho<UTx, URx>
 {
+    fn received_word(&self, word: u32, _rval: ReturnCode, _error: uart::Error) {
+        if word == b'\r' as u32 {
+            self.tx_buf.take().map(|buf| {
+                buf[0] = b'\r';
+                buf[1] = b'\n';
+                // output on uart
+                self.uart_tx.transmit_buffer(buf, 2)
+            });
+        // if no buffer, these bytes will be dropped
+        } else {
+            self.uart_tx.transmit_word(word);
+        }
+        self.uart_rx.receive_word();
+    }
+
     fn received_buffer(
         &self,
         buffer: &'static mut [u8],


### PR DESCRIPTION
### Pull Request Overview

UART wasn't working anymore. The hardware UART needed initialization in board's `main.rs`.

Added support for word tx.

Added support for different word widths.

Simplified interrupt_handler routine.

Also updated the test file for UART. 

### Testing Strategy

Ran UART in echo mode. Ran UART stress app.

### TODO or Help Wanted

### Documentation Updated

### Formatting

-  Ran `make formatall`.
