### PR TITLE
arch/{cortex-m4,cortex-m3}: Update documentation for `switch_to_user`

### DIFF
--- a/arch/cortex-m3/src/lib.rs
+++ b/arch/cortex-m3/src/lib.rs
@@ -154,7 +154,7 @@ pub unsafe extern "C" fn switch_to_user(user_stack: *const u8, process_got: *con
 
 #[cfg(target_os = "none")]
 #[no_mangle]
-/// r0 is top of user stack, r1 Process GOT
+/// r0 is top of user stack, r1 is reference to `CortexMStoredState.regs`
 pub unsafe extern "C" fn switch_to_user(
     mut user_stack: *const usize,
     process_regs: &mut [usize; 8],

--- a/arch/cortex-m4/src/lib.rs
+++ b/arch/cortex-m4/src/lib.rs
@@ -154,7 +154,7 @@ pub unsafe extern "C" fn switch_to_user(user_stack: *const u8, process_got: *con
 
 #[cfg(target_os = "none")]
 #[no_mangle]
-/// r0 is top of user stack, r1 Process GOT
+/// r0 is top of user stack, r1 is reference to `CortexMStoredState.regs`
 pub unsafe extern "C" fn switch_to_user(
     mut user_stack: *const usize,
     process_regs: &mut [usize; 8],


### PR DESCRIPTION
In Tock, a `Process::create` creates a `Process` struct and stores it in the
App Grant region. Within the `Process` struct there is a field `stored_state`
defined as follows.

```
/// State saved on behalf of the process each time the app switches to the
/// kernel.
stored_state:
    Cell<<<C as Chip>::UserspaceKernelBoundary as UserspaceKernelBoundary>::StoredState>,
```

For Cortex-M based architecture, the `StoredState` is associated with type

```
/// This holds all of the state that the kernel must keep for the process when
/// the process is not executing.
#[derive(Copy, Clone)]
pub struct CortexMStoredState {
    regs: [usize; 8],
    yield_pc: usize,
    psr: usize,
}
```

The `regs` field refers to the non-hardware stacked registers (r4 thru' r11)
which must be saved and restored on every context switch.
