### PR TITLE
Remove comment from RF233 

### DIFF
--- a/capsules/src/rf233.rs
+++ b/capsules/src/rf233.rs
@@ -20,9 +20,7 @@ use kernel::hil::gpio;
 use kernel::hil::radio;
 use kernel::hil::spi;
 use kernel::ReturnCode;
-// n.b. This is a fairly "C"-like interface presently. Ideally it should move
-// over to the Tock register interface eventually, but this code does work as
-// written. Do not follow this as an example when implementing new code.
+
 use crate::rf233_const::CSMA_SEED_1;
 use crate::rf233_const::IRQ_MASK;
 use crate::rf233_const::PHY_CC_CCA_MODE_CS_OR_ED;


### PR DESCRIPTION
Asked Pat what this comment meant (since the registers are on the RF233 and accessed via SPI operations, you can't use the Register interface), he replied:

"Honestly, I'm not sure what I was thinking there. Looking at the history, that looks like it was part of a bigger, somewhat mechanical, refactor. That was shortly after the new register interface was merged.. if I had to guess I suspect I had some notion that there would be some magical, "more elegant" means of handling constants coming, but I'll confess I'm not sure what that would be.

I think it should be fine to simply delete that comment. Sorry for the noise :/"

### Pull Request Overview

Removes a comment from RF233.


### Testing Strategy

No testing.


### TODO or Help Wanted

Nothing.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
