### PR TITLE
Fix typo in kernel linker script

### DIFF
--- a/boards/kernel_layout.ld
+++ b/boards/kernel_layout.ld
@@ -79,7 +79,7 @@ SECTIONS
         /* .gnu.linkonce hold C++ elements with vague linkage
                 https://gcc.gnu.org/onlinedocs/gcc/Vague-Linkage.html */
         *(.text .text.* .gnu.linkonce.t.*)
-        *(.rodata .rodata* .gnu.linkonce.r.*)
+        *(.rodata .rodata.* .gnu.linkonce.r.*)
 
         /* C++ exception unwinding information */
         *(.ARM.extab* .gnu.linkonce.armextab.*)


### PR DESCRIPTION
### Pull Request Overview

Corrects a typo in the linker script:

`rodata*` should be `rodata.*`

Fixes #1278

