### PR TITLE
fix(volatile_cell): derive `Default`

### DIFF
--- a/libraries/tock-cells/src/volatile_cell.rs
+++ b/libraries/tock-cells/src/volatile_cell.rs
@@ -6,7 +6,7 @@ use core::ptr;
 /// and writes. This is particularly useful for accessing microcontroller
 /// registers.
 // Source: https://github.com/hackndev/zinc/tree/master/volatile_cell
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Default)]
 #[repr(C)]
 pub struct VolatileCell<T> {
     value: T,
@@ -14,7 +14,7 @@ pub struct VolatileCell<T> {
 
 impl<T> VolatileCell<T> {
     pub const fn new(value: T) -> Self {
-        VolatileCell { value: value }
+        VolatileCell { value }
     }
 
     #[inline]
@@ -25,11 +25,5 @@ impl<T> VolatileCell<T> {
     #[inline]
     pub fn set(&self, value: T) {
         unsafe { ptr::write_volatile(&self.value as *const T as *mut T, value) }
-    }
-}
-
-impl<T: Default> Default for VolatileCell<T> {
-    fn default() -> Self {
-        VolatileCell::new(Default::default())
     }
 }


### PR DESCRIPTION
### Pull Request Overview

This pull request changes VolatileCell to derive `Default` instead of manually implement it!


### Testing Strategy

This pull request was tested by CI tests


### TODO or Help Wanted

This pull request still needs n/a


### Documentation Updated

~- [ ] Updated the relevant files in `/docs`, or no updates are required.~

### Formatting

- [x] Ran `make formatall`.
