### PR TITLE
chips/stm32f4xx: Remove unused import

### DIFF
--- a/chips/stm32f4xx/src/dma1.rs
+++ b/chips/stm32f4xx/src/dma1.rs
@@ -1,4 +1,3 @@
-use cortexm4;
 use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::common::registers::{register_bitfields, ReadOnly, ReadWrite};
 use kernel::common::StaticRef;


### PR DESCRIPTION
Removes unused import from `chips/stm32f4xx/src/dma1.rs`