### PR TITLE
Make process RAM Read-Write, not Read-Write-Execute

### DIFF
--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -704,7 +704,7 @@ impl<C: Chip> ProcessType for Process<'a, C> {
                 unallocated_memory_start,
                 unallocated_memory_size,
                 min_region_size,
-                mpu::Permissions::ReadWriteExecute,
+                mpu::Permissions::ReadWriteOnly,
                 &mut config,
             );
 
@@ -739,7 +739,7 @@ impl<C: Chip> ProcessType for Process<'a, C> {
                 } else if let Err(_) = self.chip.mpu().update_app_memory_region(
                     new_break,
                     self.kernel_memory_break.get(),
-                    mpu::Permissions::ReadWriteExecute,
+                    mpu::Permissions::ReadWriteOnly,
                     &mut config,
                 ) {
                     Err(Error::OutOfMemory)
@@ -784,7 +784,7 @@ impl<C: Chip> ProcessType for Process<'a, C> {
             } else if let Err(_) = self.chip.mpu().update_app_memory_region(
                 self.app_break.get(),
                 new_break,
-                mpu::Permissions::ReadWriteExecute,
+                mpu::Permissions::ReadWriteOnly,
                 &mut config,
             ) {
                 None
@@ -1147,7 +1147,7 @@ impl<C: 'static + Chip> Process<'a, C> {
                 min_total_memory_size,
                 initial_app_memory_size,
                 initial_kernel_memory_size,
-                mpu::Permissions::ReadWriteExecute,
+                mpu::Permissions::ReadWriteOnly,
                 &mut mpu_config,
             ) {
                 Some((memory_start, memory_size)) => (memory_start, memory_size),

--- a/libraries/tock-cells/src/optional_cell.rs
+++ b/libraries/tock-cells/src/optional_cell.rs
@@ -1,10 +1,11 @@
-//! OptionalCell convenience type
+//! `OptionalCell` convenience type
 
 use core::cell::Cell;
 use core::marker::Copy;
 
 /// `OptionalCell` is a `Cell` that wraps an `Option`. This is helper type
 /// that makes keeping types that can be `None` a little cleaner.
+#[derive(Default)]
 pub struct OptionalCell<T: Copy> {
     value: Cell<Option<T>>,
 }


### PR DESCRIPTION
### Pull Request Overview

Fixes #1287 

Removes execute permission for process RAM to help defend against code execution attacks on applications.

### Testing Strategy

First, I ran a number of apps (`ip_sense`, `c_hello`, `blink`), to verify sure this doesn't break anything in unexpected ways (the changes should have no impact on existing apps, since nothing runs from RAM in practice).

Next, I wrote a simple test app that includes a RAM allocated variable containing _just_ an ARM `bx lr` instruction (`0x4770`):

```
#include <stdio.h>

#include <console.h>
#include <timer.h>

uint16_t space = 0x4770;

typedef void dummy(void);

int main(void) {
  int j = (int)(&space) | 1;
  asm ("blx %0;" : : "r"(j));
  while (1) {
    printf("Hello\n");
    delay_ms(1000);
  }
}
```

Running this on `master` works: the app doesn't crash, and it prints `Hello` periodically following a brief prelude in the RAM-allocated "dummy" function.

Running on this branch, with write permissions turned off for RAM, the app crashes with an access violation fault, as expected:

```
Kernel panic at /home/alevy/hack/tock/kernel/src/process.rs:537:
        "Process rwx had a fault"
        Kernel version release-1.2-2018-06-926-g9637f419

---| Debug buffer not empty. Flushing. May repeat some of last message(s):
Initialization complete. Entering main loop

---| Fault Status |---
Instruction Access Violation:       true
Forced Hard Fault:                  true
Fault Status Register (CFSR):       0x00000001
Hard Fault Status Register (HFSR):  0x40000000

...
```

### TODO or Help Wanted

Where should we document this?

### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
