### PR TITLE
chore(bump tock_registers): v0.3.0

### DIFF
--- a/boards/acd52832/Cargo.lock
+++ b/boards/acd52832/Cargo.lock
@@ -41,7 +41,7 @@ name = "kernel"
 version = "0.1.0"
 dependencies = [
  "tock-cells 0.1.0",
- "tock-registers 0.2.0",
+ "tock-registers 0.3.0",
 ]
 
 [[package]]
@@ -67,7 +67,7 @@ version = "0.1.0"
 
 [[package]]
 name = "tock-registers"
-version = "0.2.0"
+version = "0.3.0"
 
 [[package]]
 name = "tock_rt0"

--- a/boards/hail/Cargo.lock
+++ b/boards/hail/Cargo.lock
@@ -40,7 +40,7 @@ name = "kernel"
 version = "0.1.0"
 dependencies = [
  "tock-cells 0.1.0",
- "tock-registers 0.2.0",
+ "tock-registers 0.3.0",
 ]
 
 [[package]]
@@ -58,7 +58,7 @@ version = "0.1.0"
 
 [[package]]
 name = "tock-registers"
-version = "0.2.0"
+version = "0.3.0"
 
 [[package]]
 name = "tock_rt0"

--- a/boards/imix/Cargo.lock
+++ b/boards/imix/Cargo.lock
@@ -40,7 +40,7 @@ name = "kernel"
 version = "0.1.0"
 dependencies = [
  "tock-cells 0.1.0",
- "tock-registers 0.2.0",
+ "tock-registers 0.3.0",
 ]
 
 [[package]]
@@ -58,7 +58,7 @@ version = "0.1.0"
 
 [[package]]
 name = "tock-registers"
-version = "0.2.0"
+version = "0.3.0"
 
 [[package]]
 name = "tock_rt0"

--- a/boards/nordic/nrf52840dk/Cargo.lock
+++ b/boards/nordic/nrf52840dk/Cargo.lock
@@ -30,7 +30,7 @@ name = "kernel"
 version = "0.1.0"
 dependencies = [
  "tock-cells 0.1.0",
- "tock-registers 0.2.0",
+ "tock-registers 0.3.0",
 ]
 
 [[package]]
@@ -79,7 +79,7 @@ version = "0.1.0"
 
 [[package]]
 name = "tock-registers"
-version = "0.2.0"
+version = "0.3.0"
 
 [[package]]
 name = "tock_rt0"

--- a/boards/nordic/nrf52dk/Cargo.lock
+++ b/boards/nordic/nrf52dk/Cargo.lock
@@ -30,7 +30,7 @@ name = "kernel"
 version = "0.1.0"
 dependencies = [
  "tock-cells 0.1.0",
- "tock-registers 0.2.0",
+ "tock-registers 0.3.0",
 ]
 
 [[package]]
@@ -79,7 +79,7 @@ version = "0.1.0"
 
 [[package]]
 name = "tock-registers"
-version = "0.2.0"
+version = "0.3.0"
 
 [[package]]
 name = "tock_rt0"


### PR DESCRIPTION
### Pull Request Overview

This pull request bumps `Cargo.lock` to use tock_registers v0.3.0


### Testing Strategy

This pull request was tested by CI


### TODO or Help Wanted

N/A


### Documentation Updated

- ~~[ ] Updated the relevant files in `/docs`, or no updates are required.~~

### Formatting

- ~~[ ] Ran `make formatall`.~~
