### PR TITLE
Add chunked buffer processing mechanism

### DIFF
--- a/boards/nordic/nrf52dk_base/src/lib.rs
+++ b/boards/nordic/nrf52dk_base/src/lib.rs
@@ -239,6 +239,7 @@ pub unsafe fn setup_board(
             board_kernel.create_grant(&memory_allocation_capability)
         )
     );
+    console.set_self_reference(console);
     kernel::hil::uart::Transmit::set_transmit_client(console_uart, console);
     kernel::hil::uart::Receive::set_receive_client(console_uart, console);
 

--- a/kernel/src/common/chunked_process.rs
+++ b/kernel/src/common/chunked_process.rs
@@ -1,0 +1,255 @@
+use crate::common::cells::{MapCell, OptionalCell, TakeCell};
+use core::cell::Cell;
+
+#[derive(Debug, Clone, Copy)]
+pub enum ChunkedProcessError {
+    LengthInvalid,
+    Busy,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum ChunkedProcessMode {
+    Read,
+    Write,
+    ReadWrite,
+}
+impl Default for ChunkedProcessMode {
+    fn default() -> Self {
+        ChunkedProcessMode::Read
+    }
+}
+
+/// Client of a [ChunkedProcess] instance
+///
+/// The called function depends on the [ChunkedProcessMode] used.
+///
+/// - `read` means, that the data in the chunk-buffer represents the chunk
+///   from the source, but new (written) data is ignored.
+/// - `write` means, that the data in the chunk-buffer may not be relied on.
+///   However, the new state of the buffer will be written back to the source.
+/// - `read_write` combines the two options. The buffer contents are copyied from
+///   the source, and then later copied back. This is the slowest option.
+///
+/// After the operation is complete, `chunk_done` on [ChunkedProcess] needs
+/// to be called with the buffer.
+pub trait ChunkedProcessClient<'a, T, R, E> {
+    fn read_chunk(
+        &self,
+        current_pos: usize,
+        acc: R,
+        chunk: &'a mut [T],
+        length: usize,
+    ) -> Result<R, E>;
+    fn write_chunk(
+        &self,
+        current_pos: usize,
+        acc: R,
+        chunk: &'a mut [T],
+        length: usize,
+    ) -> Result<R, E>;
+    fn read_write_chunk(
+        &self,
+        current_pos: usize,
+        acc: R,
+        chunk: &'a mut [T],
+        length: usize,
+    ) -> Result<R, E>;
+}
+
+/// Process a large amount of data (e.g. [AppSlice](crate::AppSlice)) in chunks
+/// supporting asynchronous and callback-style programming
+///
+/// This struct takes something that can be mutably borrowed and
+/// for every n-bytes, calls a function.
+/// Depending on the mode, the buffer passed to this function may
+/// contain the data of the current chunk, and/or can can be overwritten
+/// with new data.
+/// The chunk size is determined by the temporary buffer size.
+///
+/// For keeping track of custom arguments, this also implements a
+/// `fold`-style accumulator for callbacks.
+pub struct ChunkedProcess<'buf, 'client, S, T, R, E>
+where
+    S: AsMut<[T]>,
+    T: Clone,
+{
+    src: MapCell<S>,
+    buffer: TakeCell<'buf, [T]>,
+    client: OptionalCell<&'client ChunkedProcessClient<'buf, T, R, E>>,
+
+    mode: Cell<ChunkedProcessMode>,
+    start: Cell<usize>,
+    length: Cell<usize>,
+    current_progress: OptionalCell<usize>,
+}
+
+impl<'buf, 'client, S, T, R, E> ChunkedProcess<'buf, 'client, S, T, R, E>
+where
+    S: AsMut<[T]>,
+    T: Clone,
+{
+    /// Construct a new [ChunkedProcress] instance
+    ///
+    /// The source needs to be mutably borrowable to a slice of type T.
+    pub fn new(src: S, buffer: &'buf mut [T]) -> ChunkedProcess<'buf, 'client, S, T, R, E> {
+        ChunkedProcess {
+            src: MapCell::new(src),
+            buffer: TakeCell::new(buffer),
+            client: OptionalCell::empty(),
+
+            mode: Default::default(),
+            start: Cell::new(0),
+            length: Cell::new(0),
+            current_progress: OptionalCell::empty(),
+        }
+    }
+
+    /// Return the source and temporary buffers
+    ///
+    /// If no operation is currently in progress, this method will consume the
+    /// [ChunkedProcess] instance and return the internal buffers.
+    pub fn destroy(self) -> Result<(S, &'buf mut [T]), ChunkedProcessError> {
+        if self.current_progress.is_some() {
+            Err(ChunkedProcessError::Busy)
+        } else {
+            Ok((self.src.take().unwrap(), self.buffer.take().unwrap()))
+        }
+    }
+
+    pub fn set_client(&self, client: &'client ChunkedProcessClient<'buf, T, R, E>) {
+        self.client.set(client);
+    }
+
+    /// Start a [ChunkedProcess] operation
+    ///
+    /// `start` and `length` can be used to specify a range of the input source.
+    /// `init` is the initial accumulator value.
+    ///
+    /// The [ChunkedProcressMode] determines whether data will be read from, written
+    /// to the source, or both. See [ChunkedProcessClient] for further information.
+    pub fn run(
+        &self,
+        mode: ChunkedProcessMode,
+        start: usize,
+        length: usize,
+        init: R,
+    ) -> Result<(), ChunkedProcessError> {
+        if self.current_progress.is_some() {
+            return Err(ChunkedProcessError::Busy);
+        }
+
+        self.src
+            .map(|src| {
+                if src.as_mut().len() < start + length {
+                    Err(ChunkedProcessError::LengthInvalid)
+                } else {
+                    Ok(())
+                }
+            })
+            .expect("can't map chunked progress source")?;
+
+        self.mode.set(mode);
+        self.start.set(start);
+        self.length.set(length);
+        self.current_progress.set(start);
+
+        self.next_chunk(init)
+            .map_or_else(|| Ok(()), |_| Err(ChunkedProcessError::LengthInvalid))?;
+
+        Ok(())
+    }
+
+    /// Try to call the client with the next chunk
+    ///
+    /// If all chunks have been processed already, return a `Some(_)` with types
+    /// compatible to [chunk_done].
+    fn next_chunk(&self, acc: R) -> Option<(ChunkedProcessMode, Result<R, E>)> {
+        let current = self
+            .current_progress
+            .expect("next_chunk called without progress");
+
+        if current >= self.start.get() + self.length.get() {
+            Some((self.mode.get(), Ok(acc)))
+        } else {
+            let buffer = self.buffer.take().expect("buffer not available");
+            let mode = self.mode.get();
+
+            // If we read or read-write, copy the src contents into the buffer
+            match mode {
+                ChunkedProcessMode::Read | ChunkedProcessMode::ReadWrite => {
+                    self.src
+                        .map(|src| {
+                            buffer
+                                .iter_mut()
+                                .zip((src.as_mut())[current..].iter())
+                                .for_each(|(d, s)| *d = s.clone());
+                        })
+                        .expect("chunked_progress: src couldn't be mapped");
+                }
+                ChunkedProcessMode::Write => (),
+            };
+
+            let mut remaining = self.start.get() + self.length.get() - current;
+            if remaining >= buffer.len() {
+                remaining = buffer.len();
+            }
+
+            self.client.map(move |c| match mode {
+                ChunkedProcessMode::Read => c.read_chunk(current, acc, buffer, remaining),
+                ChunkedProcessMode::Write => c.write_chunk(current, acc, buffer, remaining),
+                ChunkedProcessMode::ReadWrite => {
+                    c.read_write_chunk(current, acc, buffer, remaining)
+                }
+            });
+
+            None
+        }
+    }
+
+    /// A chunk from a callback has been processed
+    ///
+    /// This method needs be called when a chunk (provided by a callback) has been processed.
+    ///
+    /// In case of an error, or when all chunks have been processed, this function will return
+    /// the accumulator / error and mode used.
+    pub fn chunk_done(
+        &self,
+        buffer: &'buf mut [T],
+        res: Result<R, E>,
+    ) -> Option<(ChunkedProcessMode, Result<R, E>)> {
+        let prev_progress = self
+            .current_progress
+            .expect("chunk_done called without progress");
+
+        // If we write or read-write, copy the buffer contents into the src slice
+        match self.mode.get() {
+            ChunkedProcessMode::Write | ChunkedProcessMode::ReadWrite => {
+                self.src
+                    .map(|src| {
+                        src.as_mut()[prev_progress..]
+                            .iter_mut()
+                            .zip(buffer.iter())
+                            .for_each(|(d, s)| *d = s.clone());
+                    })
+                    .expect("chunked_progress: src couldn't be mapped");
+            }
+            ChunkedProcessMode::Read => (),
+        }
+
+        // No matter how much we've actually processed, add a whole buffer length here
+        // The only time this will be smaller is at the end - where we stop anyways
+        self.current_progress.set(prev_progress + buffer.len());
+        self.buffer.replace(buffer);
+
+        match res {
+            Err(e) => {
+                // There was an error, immediately return it to the client
+                Some((self.mode.get(), Err(e)))
+            }
+            Ok(acc) => {
+                // There has been no error, try to call the next chunk
+                self.next_chunk(acc)
+            }
+        }
+    }
+}

--- a/kernel/src/common/mod.rs
+++ b/kernel/src/common/mod.rs
@@ -13,6 +13,7 @@ pub mod registers {
     pub use tock_registers::registers::{ReadOnly, ReadWrite, WriteOnly};
 }
 
+pub mod chunked_process;
 pub mod deferred_call;
 pub mod list;
 pub mod math;

--- a/kernel/src/grant.rs
+++ b/kernel/src/grant.rs
@@ -31,6 +31,10 @@ impl<T> AppliedGrant<T> {
         let mut root = unsafe { Owned::new(self.grant, self.appid) };
         fun(&mut root, &mut allocator)
     }
+
+    pub fn appid(&self) -> AppId {
+        self.appid
+    }
 }
 
 pub struct Allocator {


### PR DESCRIPTION
### Pull Request Overview

Because in drivers, borrows of `AppSlice`s can not be passed to `HIL`s directly, a small temporary buffer has to be used. This implies an *`AppSlice` to buffer* copying logic.

This pull request draft tries to implement such a copying logic for all kinds of drivers. By taking care of slice indexing and keeping track of the current progress, mistakes should be avoided.
While using the `ChunkedProcess` may not result in having less overall code, it's probably more glue-code and less buffer handling & indexing logic.

I've talked to Amit about the possibility of introducing reference counted `AppSlice`s, but I'm not sure if that is a good idea. While I am concerned with the performance-aspect of copying data from userspace to kernel memory, and then again to the peripheral (take TCP/IP packets), this is probably the only viable solution. This PR is an attempt to improve the developer ergonomics over the existing solution.

### Testing Strategy

This pull request needs more testing.


### TODO or Help Wanted

- First of all, I really dislike the name, but have a hard time coming up with something better.
- Is this really safe? I'm passing around ownership of the AppSlice in the kernel. Therefore, it may leave the app's grant region. Am I at risk of accessing unallocated/invalid memory?
- [ ] Documentation needs improvements.
- [ ] Code quality is quite bad right now and could probably be cleaned up a lot.
- [ ] Some capsule (e.g. `Console`) should be re-written using this. In the mean time, I'm using my [partitioned storage driver implementation](https://github.com/lschuermann/hsm-tock/blob/partitioned-storage-dev/capsules/src/partitioned_storage_driver.rs) (very WIP) as a proof of concept.


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
