### PR TITLE
fix: Avoid "broken pipe" build warnings

### DIFF
--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -63,7 +63,7 @@ ifeq ($(shell $(MAKEFILE_COMMON_PATH)../tools/semver.sh $(RUSTUP_VERSION) \< $(M
   DUMMY := $(shell rustup update)
 endif
 
-LLVM_TOOLS_INSTALLED := $(shell rustup component list | grep 'llvm-tools-preview.*(installed)' -q; echo $$?)
+LLVM_TOOLS_INSTALLED := $(shell rustup component list | grep 'llvm-tools-preview.*(installed)' > /dev/null; echo $$?)
 ifeq ($(LLVM_TOOLS_INSTALLED),1)
   $(shell rustup component add llvm-tools-preview)
 endif


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes the "broken pipe" error that Grep emits with the -q flag (quiet). For all intents and purposes, it functionally identical.

### Testing Strategy

The project was built using the standard build commands (`make buildall`) and compared using manual visual comparison of the terminal output to verify the error was no longer emitted.

This pull request was tested by...

- Chris Kay <chris@cjkay.com>

### TODO or Help Wanted

N/A

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
