### PR TITLE
Add DWT timer helpers in Cortex-M4

### DIFF
--- a/arch/cortex-m4/src/dwt.rs
+++ b/arch/cortex-m4/src/dwt.rs
@@ -1,0 +1,40 @@
+use kernel::common::registers::{ReadWrite};
+use kernel::common::StaticRef;
+
+struct DWTRegisters {
+    ctrl: ReadWrite<u32>,
+    cycnt: ReadWrite<u32>,
+}
+
+struct DBGRegisters {
+    demcr: ReadWrite<u32>,
+}
+
+const DWT: StaticRef<DWTRegisters> = unsafe { StaticRef::new(0xE0001000 as *const _) };
+const DEMCR: StaticRef<ReadWrite<u32>> = unsafe { StaticRef::new(0xE000EDFC as *const _) };
+
+pub unsafe fn reset_timer() {
+    DEMCR.set(DEMCR.get() | 0x01000000);
+    DWT.cycnt.set(0); // reset the counter
+    DWT.ctrl.set(0); // disable counter;
+}
+
+pub unsafe fn start_timer() {
+    DWT.ctrl.set(1); // enable counter;
+}
+
+pub unsafe fn stop_timer() {
+    DWT.ctrl.set(0); // disable counter;
+}
+
+pub unsafe fn get_time() -> u32 {
+    DWT.cycnt.get()
+}
+
+pub unsafe fn bench<F: FnOnce()>(f: F) -> u32 {
+    reset_timer();
+    start_timer();
+    f();
+    stop_timer();
+    get_time()
+}

--- a/arch/cortex-m4/src/lib.rs
+++ b/arch/cortex-m4/src/lib.rs
@@ -6,6 +6,7 @@
 #![no_std]
 
 pub mod mpu;
+pub mod dwt;
 
 // Re-export the base generic cortex-m functions here as they are
 // valid on cortex-m4.


### PR DESCRIPTION
### Pull Request Overview

Cortex-M4 has an optional system peripheral called the Data Watchpoint
and Trace Unit which, among other things, allows software to measure CPU
cycles. This adds some utilities to help access these registers.

The easiest way to use this code is to use the `bench` utility, which takes a closure to measure the CPU cycles for and returns the number of cycles elapsed as a `u32`:

```rust
pub unsafe fn bench<F: FnOnce()>(f: F) -> u32;

...

let elapsed = cortexm4::dwt::bench(|| {
   mycomponent.expensive_computation();
});

debug!("Elapsed cycles: {}", elapsed);
```
For reference, measuring with a null value resulted in 3 cycles.

### Testing Strategy

TODO


### TODO or Help Wanted

Should we include this for all Cortex-M's? Should it be marked `unsafe` or is it safe? (I think it's safe)


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make formatall`.
