### PR TITLE
let mcu sleep when radio is off

### DIFF
--- a/capsules/src/rf233.rs
+++ b/capsules/src/rf233.rs
@@ -682,6 +682,7 @@ impl<S: spi::SpiMasterDevice> spi::SpiMasterClient for RF233<'a, S> {
                     self.power_client.map(|p| {
                         p.changed(self.radio_on.get());
                     });
+                    self.irq_pin.disable_interrupt(); // Lets MCU sleep
                 }
             }
             // Do nothing; a call to start() is required to restart radio
@@ -691,6 +692,8 @@ impl<S: spi::SpiMasterDevice> spi::SpiMasterClient for RF233<'a, S> {
                 // Toggle the sleep pin to take the radio out of sleep mode into
                 // InternalState::TRX_OFF, then transition directly to RX_AACK_ON.
                 self.sleep_pin.clear();
+                self.irq_pin
+                    .enable_interrupt(INTERRUPT_ID, gpio::InterruptMode::RisingEdge);
                 self.state_transition_write(
                     RF233Register::TRX_STATE,
                     RF233TrxCmd::RX_AACK_ON as u8,


### PR DESCRIPTION
### Pull Request Overview

This pull request modifies the rf233 driver so that the sam4l can sleep when the radio is off by disabling the gpio interrupt used by the rf233 to indicate received packets / completed transmissions.

### Testing Strategy

This pull request was tested on Imix when working on power clocks by disabling a number of other peripherals which currently prevent the MCU from sleeping. Notably, the radio is only turned off when XMAC is employed, so this only makes a difference if XMAC is used. This change was also tested on the current master branch using the libtock-c udp tests.

### Documentation Updated

- [x] no updates are required

### Formatting

- [x] Ran `make formatall`.
