### PR TITLE
fix unsigned int rollover bug in sam4l adc with slow clock

### DIFF
--- a/chips/sam4l/src/adc.rs
+++ b/chips/sam4l/src/adc.rs
@@ -491,14 +491,19 @@ impl Adc {
 
             self.enabled.set(true);
 
+            // configure the ADC max speed and reference select
+            let mut cfg_val = Configuration::SPEED::ksps300 + Configuration::REFSEL::VccX0p5;
+
             // First, enable the clocks
-            // Both the ADCIFE clock and GCLK10 are needed
-            let mut clock_divisor: i32;
+            // Both the ADCIFE clock and GCLK10 are needed,
+            // but the GCLK10 source depends on the requested sampling frequency
 
             // turn on ADCIFE bus clock. Already set to the same frequency
             // as the CPU clock
             pm::enable_clock(Clock::PBA(PBAClock::ADCIFE));
-            // the maximum sampling frequency with the RC clocks is 1/32th of their clock
+
+            // Now, determine the prescalar.
+            // The maximum sampling frequency with the RC clocks is 1/32th of their clock
             // frequency. This is because of the minimum PRESCAL by a factor of 4 and the
             // 7+1 cycles needed for conversion in continuous mode. Hence, 4*(7+1)=32.
             if frequency <= 113600 / 32 {
@@ -521,9 +526,10 @@ impl Adc {
                     max_freq = 113600 / 32;
                 }
                 let divisor = (frequency + max_freq - 1) / frequency; // ceiling of division
-                clock_divisor = math::log_base_two(math::closest_power_of_two(divisor)) as i32;
-                clock_divisor = cmp::min(cmp::max(clock_divisor, 0), 7); // keep in bounds
+                let divisor_pow2 = math::closest_power_of_two(divisor);
+                let clock_divisor = cmp::min(math::log_base_two(divisor_pow2), 7);
                 self.adc_clk_freq.set(max_freq / (1 << (clock_divisor)));
+                cfg_val += Configuration::PRESCAL.val(clock_divisor);
             } else {
                 // CPU clock
                 self.cpu_clock.set(true);
@@ -537,17 +543,15 @@ impl Adc {
                 // becomes: N <= ceil(log_2(f(CLK_CPU)/1500000)) - 2
                 let cpu_frequency = pm::get_system_frequency();
                 let divisor = (cpu_frequency + (1500000 - 1)) / 1500000; // ceiling of division
-                clock_divisor = math::log_base_two(math::closest_power_of_two(divisor)) as i32;
-                clock_divisor -= 2;
-                clock_divisor = cmp::min(cmp::max(clock_divisor, 0), 7); // keep in bounds
+                let divisor_pow2 = math::closest_power_of_two(divisor);
+                let clock_divisor = cmp::min(
+                    math::log_base_two(divisor_pow2).checked_sub(2).unwrap_or(0),
+                    7,
+                );
                 self.adc_clk_freq
                     .set(cpu_frequency / (1 << (clock_divisor + 2)));
+                cfg_val += Configuration::PRESCAL.val(clock_divisor);
             }
-
-            // configure the ADC
-            let mut cfg_val = Configuration::PRESCAL.val(clock_divisor as u32)
-                + Configuration::SPEED::ksps300
-                + Configuration::REFSEL::VccX0p5;
 
             if self.cpu_clock.get() {
                 cfg_val += Configuration::CLKSEL::ApbClock

--- a/chips/sam4l/src/adc.rs
+++ b/chips/sam4l/src/adc.rs
@@ -537,7 +537,12 @@ impl Adc {
                 // becomes: N <= ceil(log_2(f(CLK_CPU)/1500000)) - 2
                 let cpu_frequency = pm::get_system_frequency();
                 let divisor = (cpu_frequency + (1500000 - 1)) / 1500000; // ceiling of division
-                clock_divisor = math::log_base_two(math::closest_power_of_two(divisor)) - 2;
+                clock_divisor = math::log_base_two(math::closest_power_of_two(divisor));
+                if clock_divisor > 2 {
+                    clock_divisor -= 2;
+                } else {
+                    clock_divisor = 0;
+                }
                 clock_divisor = cmp::min(cmp::max(clock_divisor, 0), 7); // keep in bounds
                 self.adc_clk_freq
                     .set(cpu_frequency / (1 << (clock_divisor + 2)));

--- a/chips/sam4l/src/adc.rs
+++ b/chips/sam4l/src/adc.rs
@@ -493,7 +493,7 @@ impl Adc {
 
             // First, enable the clocks
             // Both the ADCIFE clock and GCLK10 are needed
-            let mut clock_divisor;
+            let mut clock_divisor: i32;
 
             // turn on ADCIFE bus clock. Already set to the same frequency
             // as the CPU clock
@@ -521,7 +521,7 @@ impl Adc {
                     max_freq = 113600 / 32;
                 }
                 let divisor = (frequency + max_freq - 1) / frequency; // ceiling of division
-                clock_divisor = math::log_base_two(math::closest_power_of_two(divisor));
+                clock_divisor = math::log_base_two(math::closest_power_of_two(divisor)) as i32;
                 clock_divisor = cmp::min(cmp::max(clock_divisor, 0), 7); // keep in bounds
                 self.adc_clk_freq.set(max_freq / (1 << (clock_divisor)));
             } else {
@@ -537,19 +537,15 @@ impl Adc {
                 // becomes: N <= ceil(log_2(f(CLK_CPU)/1500000)) - 2
                 let cpu_frequency = pm::get_system_frequency();
                 let divisor = (cpu_frequency + (1500000 - 1)) / 1500000; // ceiling of division
-                clock_divisor = math::log_base_two(math::closest_power_of_two(divisor));
-                if clock_divisor > 2 {
-                    clock_divisor -= 2;
-                } else {
-                    clock_divisor = 0;
-                }
+                clock_divisor = math::log_base_two(math::closest_power_of_two(divisor)) as i32;
+                clock_divisor -= 2;
                 clock_divisor = cmp::min(cmp::max(clock_divisor, 0), 7); // keep in bounds
                 self.adc_clk_freq
                     .set(cpu_frequency / (1 << (clock_divisor + 2)));
             }
 
             // configure the ADC
-            let mut cfg_val = Configuration::PRESCAL.val(clock_divisor)
+            let mut cfg_val = Configuration::PRESCAL.val(clock_divisor as u32)
                 + Configuration::SPEED::ksps300
                 + Configuration::REFSEL::VccX0p5;
 


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes a bug in the sam4l adc driver which causes the incorrect clock driver to be selected when a clock slower than 1.5 MHz is used to drive the ADC. The bug is that `clock_divisor` is instantiated as unsigned, and when the `cpu_frequency` is lower than 1.5 MHz, subtracting 2 from the `clock_divisor` causes a rollover to the max unsigned value, so the `\\ keep in bounds` line sets the divisor to the maximum value instead of correctly setting it to the minimum (0).

Note: The precise source of this bug was discovered by @phil-levis , not me, I am just pushing a fix.


### Testing Strategy

This pull request was tested by sampling the ADC with the 1 MHz clock and observing the correct divider is chosen. Notably, there still appear to be some bug where at certain sampling frequencies / numbers of samples the sampling time does not match the expected sampling rate. 

### Formatting

- [x] Ran `make formatall`.
