### PR TITLE
Spi disable optimization

### DIFF
--- a/chips/sam4l/src/spi.rs
+++ b/chips/sam4l/src/spi.rs
@@ -692,7 +692,6 @@ impl DMAClient for SpiHw {
             .set(self.transfers_in_progress.get() - 1);
 
         if self.transfers_in_progress.get() == 0 {
-            self.disable();
             let txbuf = self.dma_write.map_or(None, |dma| {
                 let buf = dma.abort_transfer();
                 dma.disable();
@@ -721,6 +720,9 @@ impl DMAClient for SpiHw {
                         cb.read_write_done(txbuf, rxbuf, len);
                     });
                 }
+            }
+            if self.transfers_in_progress.get() == 0 {
+                self.disable();
             }
         }
     }


### PR DESCRIPTION
### Pull Request Overview
SPI's transfer_done() function calls self.disable() before its callback functions. Those callback functions can trigger new SPI operations, so to avoid disabling and reenabling the SPI between consecutive SPI operations, we can check that there are no more transfers after the callback functions have completed, and only then disable SPI. Optimization was proposed by @phil-levis 

### Testing Strategy

This pull request was tested by running an application that sent radio packets which were divided into multiple consecutive spi read_write_bytes() operations and observing correct behavior with this change.

### Formatting

- [x] Ran `make formatall`.
