### PR TITLE
Event dispatcher

### DIFF
--- a/arch/cortex-m/Cargo.toml
+++ b/arch/cortex-m/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2018"
 
 [dependencies]
 kernel = { path = "../../kernel" }
+enum_primitive = { path = "../../libraries/enum_primitive" }

--- a/arch/cortex-m/src/events.rs
+++ b/arch/cortex-m/src/events.rs
@@ -1,0 +1,77 @@
+//
+//  These are generic event handling routines for any cortex-m architecture
+//
+use crate::support::atomic;
+use core::ptr;
+use enum_primitive::cast::{FromPrimitive, ToPrimitive};
+
+pub static mut FLAGS: usize = 0;
+
+pub fn has_event() -> bool {
+    let event_flags;
+    unsafe { event_flags = ptr::read_volatile(&FLAGS) }
+    event_flags != 0
+}
+
+pub fn next_pending<T: FromPrimitive>() -> Option<T> {
+    let mut event_flags;
+    unsafe { event_flags = ptr::read_volatile(&FLAGS) }
+
+    let mut count = 0;
+    // stay in loop until we found the flag
+    while event_flags != 0 {
+        // if flag is found, return the count
+        if (event_flags & 0b1) != 0 {
+            return Some(T::from_u8(count).expect("Unmapped EVENT_PRIORITY"));
+        }
+        // otherwise increment
+        count += 1;
+        event_flags >>= 1;
+    }
+    None
+}
+
+pub fn set_event_flag<T: ToPrimitive>(priority: T) {
+    unsafe {
+        let bm = 0b1
+            << priority
+                .to_usize()
+                .expect("Could not cast priority enum as usize");
+        atomic(|| {
+            let new_value = ptr::read_volatile(&FLAGS) | bm;
+            FLAGS = new_value;
+        })
+    };
+}
+
+#[naked]
+pub unsafe fn set_event_flag_from_isr(priority: usize) {
+    // Set PRIMASK
+    asm!("cpsid i" :::: "volatile");
+
+    asm!("
+        // Set event flag
+        orr $0, $2
+        isb
+        "
+        : "={r0}"(FLAGS)
+        : "{r0}"(FLAGS), "{r1}"(0b1<<(priority))
+        : : "volatile" "volatile"
+    );
+
+    // Unset PRIMASK
+    asm!("cpsie i" :::: "volatile");
+}
+
+pub fn clear_event_flag<T: ToPrimitive>(priority: T) {
+    unsafe {
+        let bm = !(0b1
+            << priority
+                .to_usize()
+                .expect("Could not cast priority enum as usize"));
+        atomic(|| {
+            let new_value = ptr::read_volatile(&FLAGS) & bm;
+            FLAGS = new_value;
+        })
+    };
+}

--- a/arch/cortex-m/src/lib.rs
+++ b/arch/cortex-m/src/lib.rs
@@ -2,11 +2,39 @@
 
 #![crate_name = "cortexm"]
 #![crate_type = "rlib"]
-#![feature(asm, const_fn, lang_items)]
+#![feature(asm, const_fn, lang_items, naked_functions)]
 #![no_std]
 
+pub mod events;
 pub mod nvic;
 pub mod scb;
 pub mod support;
 pub mod syscall;
 pub mod systick;
+
+#[macro_export]
+macro_rules! generic_isr {
+    ($label:tt, $priority:expr) => {
+        #[cfg(target_os = "none")]
+        #[naked]
+        unsafe extern "C" fn $label() {
+            stash_process_state();
+            events::set_event_flag_from_isr($priority as usize);
+            set_privileged_thread();
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! custom_isr {
+    ($label:tt, $priority:expr, $isr:ident) => {
+        #[cfg(target_os = "none")]
+        #[naked]
+        unsafe extern "C" fn $label() {
+            stash_process_state();
+            events::set_event_flag_from_isr($priority);
+            $isr();
+            set_privileged_thread();
+        }
+    };
+}

--- a/boards/launchxl/Cargo.lock
+++ b/boards/launchxl/Cargo.lock
@@ -20,6 +20,7 @@ dependencies = [
 name = "cortexm"
 version = "0.1.0"
 dependencies = [
+ "enum_primitive 0.1.0",
  "kernel 0.1.0",
 ]
 
@@ -49,6 +50,7 @@ version = "0.1.0"
 dependencies = [
  "capsules 0.1.0",
  "cc26x2 0.1.0",
+ "cortexm 0.1.0",
  "cortexm4 0.1.0",
  "enum_primitive 0.1.0",
  "kernel 0.1.0",

--- a/boards/launchxl/Cargo.toml
+++ b/boards/launchxl/Cargo.toml
@@ -26,6 +26,7 @@ name = "launchxlccfg"
 path = "src/ccfg.rs"
 
 [dependencies]
+cortexm = { path = "../../arch/cortex-m" }
 cortexm4 = { path = "../../arch/cortex-m4" }
 capsules = { path = "../../capsules" }
 kernel = { path = "../../kernel" }

--- a/boards/launchxl/src/cc1312r.rs
+++ b/boards/launchxl/src/cc1312r.rs
@@ -1,5 +1,5 @@
 use super::Pinmap;
-use enum_primitive::cast::FromPrimitive;
+use enum_primitive::cast::{FromPrimitive, ToPrimitive};
 use enum_primitive::enum_from_primitive;
 
 #[allow(dead_code)]

--- a/boards/launchxl/src/cc1352p.rs
+++ b/boards/launchxl/src/cc1352p.rs
@@ -1,5 +1,5 @@
 use super::Pinmap;
-use enum_primitive::cast::FromPrimitive;
+use enum_primitive::cast::{FromPrimitive, ToPrimitive};
 use enum_primitive::enum_from_primitive;
 
 pub const CHIP_ID: u32 = 0x2282f000;

--- a/boards/launchxl/src/event_priority.rs
+++ b/boards/launchxl/src/event_priority.rs
@@ -1,0 +1,23 @@
+//
+//  This allows for boards to set custom interrupt priorities
+//
+use enum_primitive::cast::{FromPrimitive, ToPrimitive};
+use enum_primitive::enum_from_primitive;
+
+enum_from_primitive! {
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub enum EVENT_PRIORITY {
+    GPIO = 0,
+    UART0 = 1,
+    UART1 = 2,
+    AON_RTC = 3,
+    RTC = 4,
+    I2C0 = 6,
+    AON_PROG = 7,
+    OSC = 8,
+}
+}
+
+// a default interrupt table can be used that generates the interrupt handlers
+// with appropriate event flags based on EVENT_PRIORITY defined in this file
+cc26x2::default_interrupt_table!();

--- a/capsules/src/driver.rs
+++ b/capsules/src/driver.rs
@@ -1,4 +1,4 @@
-use enum_primitive::cast::FromPrimitive;
+use enum_primitive::cast::{FromPrimitive, ToPrimitive};
 use enum_primitive::enum_from_primitive;
 
 enum_from_primitive! {

--- a/capsules/src/i2c_master.rs
+++ b/capsules/src/i2c_master.rs
@@ -88,7 +88,7 @@ impl<I: 'static + i2c::I2CMaster> I2CMasterDriver<I> {
     }
 }
 
-use enum_primitive::cast::FromPrimitive;
+use enum_primitive::cast::{FromPrimitive, ToPrimitive};
 
 enum_from_primitive! {
 #[derive(Debug, PartialEq, Clone, Copy)]

--- a/chips/cc26x2/src/chip.rs
+++ b/chips/cc26x2/src/chip.rs
@@ -1,11 +1,3 @@
-use crate::gpio;
-use crate::i2c;
-use crate::peripheral_interrupts::NVIC_IRQ;
-use crate::rtc;
-use crate::uart;
-use cortexm4::{self, nvic};
-use enum_primitive::cast::FromPrimitive;
-
 pub struct Cc26X2 {
     mpu: cortexm4::mpu::MPU,
     userspace_kernel_boundary: cortexm4::syscall::SysCall,
@@ -40,31 +32,6 @@ impl kernel::Chip for Cc26X2 {
 
     fn userspace_kernel_boundary(&self) -> &Self::UserspaceKernelBoundary {
         &self.userspace_kernel_boundary
-    }
-
-    fn service_pending_interrupts(&self) {
-        unsafe {
-            while let Some(interrupt) = nvic::next_pending() {
-                let irq = NVIC_IRQ::from_u32(interrupt)
-                    .expect("Pending IRQ flag not enumerated in NVIQ_IRQ");
-                match irq {
-                    NVIC_IRQ::GPIO => gpio::PORT.handle_interrupt(),
-                    NVIC_IRQ::AON_RTC => rtc::RTC.handle_interrupt(),
-                    NVIC_IRQ::UART0 => uart::UART0.handle_interrupt(),
-                    NVIC_IRQ::I2C0 => i2c::I2C0.handle_interrupt(),
-                    // We need to ignore JTAG events since some debuggers emit these
-                    NVIC_IRQ::AON_PROG => (),
-                    _ => panic!("Unhandled interrupt {:?}", irq),
-                }
-                let n = nvic::Nvic::new(interrupt);
-                n.clear_pending();
-                n.enable();
-            }
-        }
-    }
-
-    fn has_pending_interrupts(&self) -> bool {
-        unsafe { nvic::has_pending() }
     }
 
     fn sleep(&self) {

--- a/chips/cc26x2/src/crt1.rs
+++ b/chips/cc26x2/src/crt1.rs
@@ -1,4 +1,4 @@
-use cortexm4::{generic_isr, hard_fault_handler, nvic, svc_handler, systick_handler};
+use cortexm4::nvic;
 use tock_rt0;
 
 extern "C" {
@@ -8,78 +8,12 @@ extern "C" {
     static mut _ezero: u32;
     static mut _srelocate: u32;
     static mut _szero: u32;
-    fn reset_handler();
+    pub fn reset_handler();
 
     // _estack is not really a function, but it makes the types work
     // You should never actually invoke it!!
-    fn _estack();
+    pub fn _estack();
 }
-
-unsafe extern "C" fn unhandled_interrupt() {
-    'loop0: loop {}
-}
-
-#[link_section = ".vectors"]
-// used Ensures that the symbol is kept until the final binary
-#[used]
-pub static BASE_VECTORS: [unsafe extern "C" fn(); 54] = [
-    _estack,
-    reset_handler,
-    unhandled_interrupt, // NMI
-    hard_fault_handler,  // Hard Fault
-    unhandled_interrupt, // MPU fault
-    unhandled_interrupt, // Bus fault
-    unhandled_interrupt, // Usage fault
-    unhandled_interrupt, // Reserved
-    unhandled_interrupt, // Reserved
-    unhandled_interrupt, // Reserved
-    unhandled_interrupt, // Reserved
-    svc_handler,         // SVC
-    unhandled_interrupt, // Debug monitor,
-    unhandled_interrupt, // Reserved
-    unhandled_interrupt, // PendSV
-    systick_handler,     // Systick
-    generic_isr,         // GPIO Int handler
-    generic_isr,         // I2C
-    generic_isr,         // RF Core Command & Packet Engine 1
-    generic_isr,         // AON SpiSplave Rx, Tx and CS
-    generic_isr,         // AON RTC
-    generic_isr,         // UART0 Rx and Tx
-    generic_isr,         // AUX software event 0
-    generic_isr,         // SSI0 Rx and Tx
-    generic_isr,         // SSI1 Rx and Tx
-    generic_isr,         // RF Core Command & Packet Engine 0
-    generic_isr,         // RF Core Hardware
-    generic_isr,         // RF Core Command Acknowledge
-    generic_isr,         // I2S
-    generic_isr,         // AUX software event 1
-    generic_isr,         // Watchdog timer
-    generic_isr,         // Timer 0 subtimer A
-    generic_isr,         // Timer 0 subtimer B
-    generic_isr,         // Timer 1 subtimer A
-    generic_isr,         // Timer 1 subtimer B
-    generic_isr,         // Timer 2 subtimer A
-    generic_isr,         // Timer 2 subtimer B
-    generic_isr,         // Timer 3 subtimer A
-    generic_isr,         // Timer 3 subtimer B
-    generic_isr,         // Crypto Core Result available
-    generic_isr,         // uDMA Software
-    generic_isr,         // uDMA Error
-    generic_isr,         // Flash controller
-    generic_isr,         // Software Event 0
-    generic_isr,         // AUX combined event
-    generic_isr,         // AON programmable 0
-    generic_isr,         // Dynamic Programmable interrupt
-    // source (Default: PRCM)
-    generic_isr, // AUX Comparator A
-    generic_isr, // AUX ADC new sample or ADC DMA
-    // done, ADC underflow, ADC overflow
-    generic_isr, // TRNG event
-    generic_isr,
-    generic_isr,
-    generic_isr,
-    generic_isr,
-];
 
 #[no_mangle]
 pub unsafe extern "C" fn init() {

--- a/chips/cc26x2/src/gpio.rs
+++ b/chips/cc26x2/src/gpio.rs
@@ -346,7 +346,7 @@ impl IndexMut<usize> for Port {
 }
 
 impl Port {
-    pub fn handle_interrupt(&self) {
+    pub fn handle_events(&self) {
         let regs = GPIO_BASE;
         let mut evflags = regs.evflags.get();
         // Clear all interrupts by setting their bits to 1 in evflags

--- a/chips/cc26x2/src/lib.rs
+++ b/chips/cc26x2/src/lib.rs
@@ -22,3 +22,84 @@ pub mod trng;
 pub mod uart;
 
 pub use crate::crt1::init;
+
+#[macro_export]
+macro_rules! default_interrupt_table {
+    () => {
+        use cortexm::{events, generic_isr};
+        use cortexm4::{
+            generic_isr, hard_fault_handler, set_privileged_thread, stash_process_state,
+            svc_handler, systick_handler,
+        };
+
+        unsafe extern "C" fn unhandled_interrupt() {
+            'loop0: loop {}
+        }
+
+        generic_isr!(uart0_nvic, EVENT_PRIORITY::UART0);
+        generic_isr!(uart1_nvic, EVENT_PRIORITY::UART1);
+        generic_isr!(osc_isr, EVENT_PRIORITY::OSC);
+
+        #[link_section = ".vectors"]
+        // used Ensures that the symbol is kept until the final binary
+        #[used]
+        pub static BASE_VECTORS: [unsafe extern "C" fn(); 54] = [
+            cc26x2::crt1::_estack,
+            cc26x2::crt1::reset_handler,
+            unhandled_interrupt, // NMI
+            hard_fault_handler,  // Hard Fault
+            unhandled_interrupt, // MPU fault
+            unhandled_interrupt, // Bus fault
+            unhandled_interrupt, // Usage fault
+            unhandled_interrupt, // Reserved
+            unhandled_interrupt, // Reserved
+            unhandled_interrupt, // Reserved
+            unhandled_interrupt, // Reserved
+            svc_handler,         // SVC
+            unhandled_interrupt, // Debug monitor,
+            unhandled_interrupt, // Reserved
+            unhandled_interrupt, // PendSV
+            systick_handler,     // Systick
+            generic_isr,         // GPIO Int handler
+            generic_isr,         // I2C
+            generic_isr,         // RF Core Command & Packet Engine 1
+            generic_isr,         // AON SpiSplave Rx, Tx and CS
+            generic_isr,         // AON RTC
+            uart0_nvic,          // UART0 Rx and Tx
+            generic_isr,         // AUX software event 0
+            generic_isr,         // SSI0 Rx and Tx
+            generic_isr,         // SSI1 Rx and Tx
+            generic_isr,         // RF Core Command & Packet Engine 0
+            generic_isr,         // RF Core Hardware
+            generic_isr,         // RF Core Command Acknowledge
+            generic_isr,         // I2S
+            generic_isr,         // AUX software event 1
+            generic_isr,         // Watchdog timer
+            generic_isr,         // Timer 0 subtimer A
+            generic_isr,         // Timer 0 subtimer B
+            generic_isr,         // Timer 1 subtimer A
+            generic_isr,         // Timer 1 subtimer B
+            generic_isr,         // Timer 2 subtimer A
+            generic_isr,         // Timer 2 subtimer B
+            generic_isr,         // Timer 3 subtimer A
+            generic_isr,         // Timer 3 subtimer B
+            generic_isr,         // Crypto Core Result available
+            generic_isr,         // uDMA Software
+            generic_isr,         // uDMA Error
+            generic_isr,         // Flash controller
+            generic_isr,         // Software Event 0
+            generic_isr,         // AUX combined event
+            generic_isr,         // AON programmable 0
+            generic_isr,         // Dynamic Programmable interrupt
+            // source (Default: PRCM)
+            generic_isr, // AUX Comparator A
+            generic_isr, // AUX ADC new sample or ADC DMA
+            // done, ADC underflow, ADC overflow
+            generic_isr, // TRNG event
+            osc_isr,
+            generic_isr,
+            uart1_nvic, //uart1
+            generic_isr,
+        ];
+    };
+}

--- a/chips/cc26x2/src/peripheral_interrupts.rs
+++ b/chips/cc26x2/src/peripheral_interrupts.rs
@@ -1,4 +1,4 @@
-use enum_primitive::cast::FromPrimitive;
+use enum_primitive::cast::{FromPrimitive, ToPrimitive};
 use enum_primitive::enum_from_primitive;
 
 enum_from_primitive! {

--- a/chips/cc26x2/src/pwm.rs
+++ b/chips/cc26x2/src/pwm.rs
@@ -1,4 +1,4 @@
-use enum_primitive::cast::FromPrimitive;
+use enum_primitive::cast::{FromPrimitive, ToPrimitive};
 use enum_primitive::enum_from_primitive;
 
 use crate::gpt;

--- a/chips/cc26x2/src/rom.rs
+++ b/chips/cc26x2/src/rom.rs
@@ -1,4 +1,4 @@
-use enum_primitive::cast::FromPrimitive;
+use enum_primitive::cast::{FromPrimitive, ToPrimitive};
 use enum_primitive::enum_from_primitive;
 use kernel::common::StaticRef;
 

--- a/chips/cc26x2/src/rtc.rs
+++ b/chips/cc26x2/src/rtc.rs
@@ -5,6 +5,9 @@ use kernel::common::registers::{register_bitfields, ReadOnly, ReadWrite};
 use kernel::common::StaticRef;
 use kernel::hil::time::{self, Alarm, Frequency, Time};
 
+use crate::peripheral_interrupts;
+use cortexm4::nvic;
+
 #[repr(C)]
 struct RtcRegisters {
     ctl: ReadWrite<u32, Control::Register>,
@@ -60,8 +63,12 @@ register_bitfields![
 const RTC_BASE: StaticRef<RtcRegisters> =
     unsafe { StaticRef::new(0x40092000 as *const RtcRegisters) };
 
+const RTC_NVIC: nvic::Nvic =
+    unsafe { nvic::Nvic::new(peripheral_interrupts::NVIC_IRQ::AON_RTC as u32) };
+
 pub struct Rtc {
     registers: StaticRef<RtcRegisters>,
+    nvic: &'static nvic::Nvic,
     callback: OptionalCell<&'static time::Client>,
 }
 
@@ -71,6 +78,7 @@ impl Rtc {
     const fn new() -> Rtc {
         Rtc {
             registers: RTC_BASE,
+            nvic: &RTC_NVIC,
             callback: OptionalCell::empty(),
         }
     }
@@ -119,7 +127,7 @@ impl Rtc {
         regs.channel_ctl.read(ChannelControl::CH1_EN) != 0
     }
 
-    pub fn handle_interrupt(&self) {
+    pub fn handle_events(&self) {
         let regs = &*self.registers;
 
         // Event flag is cleared when you set it
@@ -130,6 +138,8 @@ impl Rtc {
         regs.sync.get();
 
         self.callback.map(|cb| cb.fired());
+        self.nvic.clear_pending();
+        self.nvic.enable();
     }
 
     pub fn set_client(&self, client: &'static time::Client) {

--- a/kernel/src/platform/mod.rs
+++ b/kernel/src/platform/mod.rs
@@ -13,6 +13,10 @@ pub trait Platform {
     fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
     where
         F: FnOnce(Option<&Driver>) -> R;
+
+    fn has_pending_events(&mut self) -> bool;
+
+    fn service_pending_events(&mut self);
 }
 
 /// Interface for individual MCUs.
@@ -20,9 +24,6 @@ pub trait Chip {
     type MPU: mpu::MPU;
     type UserspaceKernelBoundary: syscall::UserspaceKernelBoundary;
     type SysTick: systick::SysTick;
-
-    fn service_pending_interrupts(&self);
-    fn has_pending_interrupts(&self) -> bool;
     fn mpu(&self) -> &Self::MPU;
     fn systick(&self) -> &Self::SysTick;
     fn userspace_kernel_boundary(&self) -> &Self::UserspaceKernelBoundary;

--- a/libraries/enum_primitive/src/lib.rs
+++ b/libraries/enum_primitive/src/lib.rs
@@ -24,7 +24,21 @@ macro_rules! enum_from_primitive_impl {
         impl FromPrimitive for $name {
             $crate::enum_from_primitive_impl_ty! { from_i64, i64, $name, $( $variant )* }
             $crate::enum_from_primitive_impl_ty! { from_u64, u64, $name, $( $variant )* }
+        }
+        impl ToPrimitive for $name {
+            $crate::enum_to_primitive_impl_ty! { to_i64, i64, $name }
+            $crate::enum_to_primitive_impl_ty! { to_u64, u64, $name }
+        }
+    };
+}
 
+#[macro_export]
+macro_rules! enum_to_primitive_impl_ty {
+    ($meth:ident, $ty:ty, $name:ident) => {
+        #[allow(non_upper_case_globals, unused)]
+        fn $meth(&self) -> Option<$ty> {
+            let copy: $name = unsafe { ::core::mem::transmute_copy(self) };
+            Some(copy as $ty)
         }
     };
 }


### PR DESCRIPTION
This is a more generalized version of [a previous PR](https://github.com/tock/tock/pull/1181).

### Pull Request Overview

This pull request changes how interrupt handlers are defined. Basically, a software-based event flag is put in place of the hardware NVIQ register. 

This allows for a few things:
- since the top-half ISR sets the software event flag, [even short pulsed ISRs](https://github.com/tock/tock/issues/1252) will trigger the corresponding bottom-half; previously a second firing of the NVIQ after it had been disabled was required leading to potentially missed IRQs
- priority of ISRs in the bottom half can be reordered depending on the board
- a canonical way of extending what code gets executed in the top-half ISR is proposed via cortex-m::custom_isr! - this allows for a board maintainer to create True Real Time features

One big architectural aspect is that the ISR table definition is moved to the board. This was necessary because it seemed that event priorities should be board specific and the ISR function generation macros (`generic_isr!` and `custom_isr!`) require events to be defined before their invocation. Nonetheless, chip maintainers can provide `chip::default_interrupt_table!()` to avoid needless code repetition; this is demonstrated for the `cc26x2` and invoked from `launchxl::event_priority`.

### Testing Strategy

We have been using these interrupt vector definitions since about October at Helium and have not had any issues.

### TODO or Help Wanted

Do we like this general approach? I believe that it introduces quite a bit of flexibility and features without incurring much overhead, if any.

If the general approach is agreed upon, I'm happy to bring up the model on all other chips and boards. Help from other chip/board maintainers would of course be appreciated :)

One thing to note is that with these macros and with specific ISRs being generated for every ISR, we could hard-code the NVIQ flag such `disable_specific_nvic` would not need to figure out which NVIQ number it is; this would lead to faster top-half ISRs, I imagine.

Also TODO: when platform was made mutable, the compiler didn't like a second ipc pointer existing. We should probably try to reduce it to just one anyway.

### Documentation Updated 

### Formatting

- Ran `make formatall`.
