### PR TITLE
Deleted thumb check

### DIFF
--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -1255,14 +1255,6 @@ impl<C: 'static + Chip> Process<'a, C> {
                 timeslice_expiration_count: 0,
             });
 
-            if (init_fn & 0x1) != 1 {
-                panic!(
-                    "{:?} process image invalid. \
-                     init_fn address must end in 1 to be Thumb, got {:#X}",
-                    process_name, init_fn
-                );
-            }
-
             let flash_protected_size = process.header.get_protected_size() as usize;
             let flash_app_start = app_flash_address as usize + flash_protected_size;
 


### PR DESCRIPTION
### Pull Request Overview

This pull request deletes the thumb check in the kernel to keep it platform agnostic. I'm working on getting Tock running on risc-v and this check caused a problem when trying to run an application.

### Testing Strategy

I ran it on the Hail board using the blink app and everything seems to be in working order. Also allows load processes to complete on the Arty-e21 (risc-v board). 

### TODO or Help Wanted

Not sure if this check needs to be put somewhere else in the platform specific code. 

### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
