### PR TITLE
make: do not assume thumb arch for lst

### DIFF
--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -84,7 +84,12 @@ endif
 SIZE      ?= $(TOOLCHAIN)-size
 OBJCOPY   ?= $(TOOLCHAIN)-objcopy
 OBJDUMP   ?= $(TOOLCHAIN)-objdump
-OBJDUMP_FLAGS += --disassemble-all --source --arch-name=thumb --section-headers
+OBJDUMP_FLAGS += --disassemble-all --source --section-headers
+
+# Need an extra flag for OBJDUMP if we are on a thumb platform.
+ifneq (,$(findstring thumb,$(TARGET)))
+  OBJDUMP += --arch-name=thumb
+endif
 
 # Dump configuration for verbose builds
 ifneq ($(V),)


### PR DESCRIPTION
The `OBJDUMP` args assumed that the assembly would be thumb, and with RISC-V coming that is no longer true. This checks the target and adds the argument only if "thumb" is in the target name.

I'm not sure if there is a better way to do this. It's incredibly frustrating that objdump either doesn't check for thumb in the elf or the elf doesn't contain enough information to tell objdump.


### Testing Strategy

This pull request was tested by running `make lst` for the hail board and verifying that the assembly in `hail.lst` looks reasonable.


### TODO or Help Wanted

If there is a better way to do this then we should do that.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
