### PR TITLE
Undo making the .apps section have content

### DIFF
--- a/boards/kernel_layout.ld
+++ b/boards/kernel_layout.ld
@@ -196,6 +196,17 @@ SECTIONS
     } > ccfg
 
 
+    /* STATIC ELEMENTS FOR TOCK APPLICATIONS */
+    .apps :
+    {
+        /* _sapps symbol used by tock to look for first application */
+        . = ALIGN(4);
+        _sapps = .;
+
+        /* Optional .app sections a convenience mechanism to bundle tock
+           kernel and apps into a single image */
+        KEEP (*(.app.*))
+    } > prog
 
 
 

--- a/boards/kernel_layout.ld
+++ b/boards/kernel_layout.ld
@@ -196,21 +196,6 @@ SECTIONS
     } > ccfg
 
 
-    /* STATIC ELEMENTS FOR TOCK APPLICATIONS */
-    .apps :
-    {
-        /* _sapps symbol used by tock to look for first application */
-        . = ALIGN(4);
-        _sapps = .;
-
-        /* Optional .app sections a convenience mechanism to bundle tock
-           kernel and apps into a single image */
-        KEEP (*(.app.*))
-
-        /* Required for objcopy mechanism to bundle tock kernel and apps
-           into a single image to work */
-        LONG(0)
-    } > prog
 
 
 

--- a/boards/nucleo_f429zi/README.md
+++ b/boards/nucleo_f429zi/README.md
@@ -17,6 +17,11 @@ $ make flash
 $ make flash-debug
 ```
 
+> **Note:** Unlike other Tock platforms, the default kernel image for this
+> board will clear flashed apps when the kernel is loaded. This is to support
+> the non-tockloader based app flash procedure below. To preserve loaded apps,
+> comment out the `APP_HACK` variable in `src/main.rs`.
+
 ## Flashing app
 
 Apps are built out-of-tree. Once an app is built, you can use

--- a/boards/nucleo_f429zi/src/main.rs
+++ b/boards/nucleo_f429zi/src/main.rs
@@ -31,6 +31,12 @@ const FAULT_RESPONSE: kernel::procs::FaultResponse = kernel::procs::FaultRespons
 #[link_section = ".app_memory"]
 static mut APP_MEMORY: [u8; 65536] = [0; 65536];
 
+// Force the emission of the `.apps` segment in the kernel elf image
+// NOTE: This will cause the kernel to overwrite any existing apps when flashed!
+#[used]
+#[link_section = ".app.hack"]
+static APP_HACK: u8 = 0;
+
 /// Dummy buffer that causes the linker to reserve enough space for the stack.
 #[no_mangle]
 #[link_section = ".stack_buffer"]

--- a/boards/nucleo_f446re/README.md
+++ b/boards/nucleo_f446re/README.md
@@ -17,6 +17,11 @@ $ make flash
 $ make flash-debug
 ```
 
+> **Note:** Unlike other Tock platforms, the default kernel image for this
+> board will clear flashed apps when the kernel is loaded. This is to support
+> the non-tockloader based app flash procedure below. To preserve loaded apps,
+> comment out the `APP_HACK` variable in `src/main.rs`.
+
 ## Flashing app
 
 Apps are built out-of-tree. Once an app is built, you can use

--- a/boards/nucleo_f446re/src/main.rs
+++ b/boards/nucleo_f446re/src/main.rs
@@ -35,6 +35,12 @@ const FAULT_RESPONSE: kernel::procs::FaultResponse = kernel::procs::FaultRespons
 #[link_section = ".app_memory"]
 static mut APP_MEMORY: [u8; 65536] = [0; 65536];
 
+// Force the emission of the `.apps` segment in the kernel elf image
+// NOTE: This will cause the kernel to overwrite any existing apps when flashed!
+#[used]
+#[link_section = ".app.hack"]
+static APP_HACK: u8 = 0;
+
 /// Dummy buffer that causes the linker to reserve enough space for the stack.
 #[no_mangle]
 #[link_section = ".stack_buffer"]


### PR DESCRIPTION
### Pull Request Overview

I noticed that using `make program` to load a kernel on to Hail caused my applications to be "erased". I tracked it back to these commits, which cause the `.apps` section from the ELF to be included in the `.bin` file, and that causes the .bin file to be long enough to overwrite the first four bytes of the first app installed, effectively uninstalling all apps.

These commits were added in #1220.

Adding `--remove-section=.apps` to the call to objcopy in Makefile.common also "fixes" this issue, but that feels like a hack. However, I'm not sure what the best route to take is. I don't really understand why the kernel needs to be compiled with four bytes of 0 for apps.


Before:

```
ls target/thumbv7em-none-eabi/release/
total 95624
drwxr-xr-x   4 bradjc  staff   128B May 15 19:46 build
drwxr-xr-x  98 bradjc  staff   3.1K Jun  4 16:17 deps
drwxr-xr-x   2 bradjc  staff    64B Dec  5 15:00 examples
-rwxr-xr-x   2 bradjc  staff   2.5M Jun  4 16:17 hail
-rwxr-xr-x   1 bradjc  staff   128K Jun  4 16:17 hail.bin
-rw-r--r--   1 bradjc  staff   9.7K May 15 19:47 hail.d
-rwxr-xr-x   1 bradjc  staff   2.5M Jun  4 16:17 hail.elf
-rw-r--r--   1 bradjc  staff    41M May 15 19:56 hail.lst
drwxr-xr-x   2 bradjc  staff    64B Dec  5 15:00 incremental
drwxr-xr-x   2 bradjc  staff    64B Dec  5 15:00 native
```

After:

```
ls target/thumbv7em-none-eabi/release/
total 95536
drwxr-xr-x   4 bradjc  staff   128B May 15 19:46 build
drwxr-xr-x  98 bradjc  staff   3.1K Jun  4 16:37 deps
drwxr-xr-x   2 bradjc  staff    64B Dec  5 15:00 examples
-rwxr-xr-x   2 bradjc  staff   2.5M Jun  4 16:37 hail
-rwxr-xr-x   1 bradjc  staff    90K Jun  4 16:37 hail.bin
-rw-r--r--   1 bradjc  staff   9.7K May 15 19:47 hail.d
-rwxr-xr-x   1 bradjc  staff   2.5M Jun  4 16:37 hail.elf
-rw-r--r--   1 bradjc  staff    41M May 15 19:56 hail.lst
drwxr-xr-x   2 bradjc  staff    64B Dec  5 15:00 incremental
drwxr-xr-x   2 bradjc  staff    64B Dec  5 15:00 native
```

### Testing Strategy

This pull request was tested by verifying that `make program` on Hail continues to run pre-existing applications.


### TODO or Help Wanted

Is this the way we want to fix this issue?


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
