### PR TITLE
Implement round-robin scheduling for Tock

### DIFF
--- a/boards/imix/src/io.rs
+++ b/boards/imix/src/io.rs
@@ -45,5 +45,11 @@ impl Write for Writer {
 pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
     let led = &mut led::LedLow::new(&mut sam4l::gpio::PC[22]);
     let writer = &mut WRITER;
-    debug::panic(&mut [led], writer, pi, &cortexm4::support::nop, &PROCESSES)
+    debug::panic(
+        &mut [led],
+        writer,
+        pi,
+        &cortexm4::support::nop,
+        &PROCESSES.process_array,
+    )
 }

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -8,6 +8,8 @@
 #![feature(in_band_lifetimes)]
 #![deny(missing_docs)]
 
+use core::cell::Cell;
+
 mod components;
 use capsules::alarm::AlarmDriver;
 use capsules::net::ieee802154::MacAddress;
@@ -105,7 +107,10 @@ const FAULT_RESPONSE: kernel::procs::FaultResponse = kernel::procs::FaultRespons
 #[link_section = ".app_memory"]
 static mut APP_MEMORY: [u8; 32768] = [0; 32768];
 
-static mut PROCESSES: [Option<&'static kernel::procs::ProcessType>; NUM_PROCS] = [None; NUM_PROCS];
+static mut PROCESSES: kernel::sched::Processes = kernel::sched::Processes {
+    process_array: &mut [None; NUM_PROCS],
+    current: Cell::new(0),
+};
 
 /// Dummy buffer that causes the linker to reserve enough space for the stack.
 #[no_mangle]

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -32,7 +32,7 @@ mod memop;
 mod platform;
 mod process;
 mod returncode;
-mod sched;
+pub mod sched;
 mod tbfheader;
 
 pub use crate::callback::{AppId, Callback};

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -33,14 +33,14 @@ pub fn load_processes<C: Chip>(
     chip: &'static C,
     start_of_flash: *const u8,
     app_memory: &mut [u8],
-    procs: &'static mut [Option<&'static ProcessType>],
+    procs: &mut crate::sched::Processes,
     fault_response: FaultResponse,
     _capability: &ProcessManagementCapability,
 ) {
     let mut apps_in_flash_ptr = start_of_flash;
     let mut app_memory_ptr = app_memory.as_mut_ptr();
     let mut app_memory_size = app_memory.len();
-    for i in 0..procs.len() {
+    for i in 0..procs.process_array.len() {
         unsafe {
             let (process, flash_offset, memory_offset) = Process::create(
                 kernel,
@@ -61,7 +61,7 @@ pub fn load_processes<C: Chip>(
                     break;
                 }
             } else {
-                procs[i] = process;
+                procs.process_array[i] = process;
             }
 
             apps_in_flash_ptr = apps_in_flash_ptr.offset(flash_offset as isize);


### PR DESCRIPTION
### Pull Request Overview

This pull request implements round robin scheduling for Tock. The current scheduler starts at the beginning of process list after a hardware interrupt. This means that processes other than the first one may be starved in case of some particular timing of hardware interrupts.


### Testing Strategy
I used 2 example processes to test the scheduling. If 2 different processes run the following code and print different results, the current scheduler only runs the first one. After applying the changes in this PR both processes get to run (although the first process runs a lot more).
```C
char hello[] = "A";//char hello[] = "B"
...
int main(void) {
  // Blink the LEDs in a binary count pattern and scale
  // to the number of LEDs on the board.
  for (int count = 0; ; count++) {
     putnstr_async(hello, sizeof(hello), nop, NULL);     
     // This delay uses an underlying timer in the kernel.
     for(int i=0; i < 100000; i++);
  }

  return 0;
}
```
Additional testing is definitely necessary for this but I am not sure what are some good ways go about testing it. Please comment below if you have testing ideas.

### TODO or Help Wanted
- Additional test cases
- Should the process iterator ever terminate?
the process iterator `for` loop will never terminate as the iterator will never return None.
I can change the implementation so the for loop terminates after each process has been executed once but am not sure it is the best approach.
As a result of the infinite iterator, I check 
```Rust
 chip.atomic(|| {
     if !chip.has_pending_interrupts()
         && !DynamicDeferredCall::global_instance_calls_pending()
             .unwrap_or(false)
         && self.processes_blocked()
     {
         chip.sleep();
     }
 });
```
condition for each process in the list instead of checking it once per round of iteration. This can easily be changed but I am not sure what the right approach is.
### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.
The current scheduler is mostly round-robin already and this is reflected in the 
[docs]( https://github.com/tock/tock/blob/4a73ac726cff8a109f1bd6acfa7765e06d0de122/doc/Overview.md) so I think no change should be necessary.
### Formatting

- [x] Ran `make formatall`.
