### PR TITLE
Deleted extract() for WriteOnly in documentation

### DIFF
--- a/libraries/tock-register-interface/README.md
+++ b/libraries/tock-register-interface/README.md
@@ -120,7 +120,6 @@ WriteOnly<T: IntLike, R: RegisterLongName = ()>
 .set(value: T)                                 // Set the raw register value
 .write(value: FieldValue<T, R>)                // Write the value of one or more fields,
                                                //  overwriting other fields to zero
-.extract() -> LocalRegisterCopy<T, R>          // Make local copy of register
 
 
 ReadWrite<T: IntLike, R: RegisterLongName = ()>


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes a mistaken typo in tock/libraries/tock-register-interface/README.md. The WriteOnly registers don't support extract() function. The documentation is mistaken.


### Testing Strategy

This pull request was tested by...


### TODO or Help Wanted

This pull request still needs...


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make formatall`.
