### PR TITLE
Added eic driver for sam4l

### DIFF
--- a/chips/sam4l/src/chip.rs
+++ b/chips/sam4l/src/chip.rs
@@ -8,6 +8,7 @@ use crate::crccu;
 use crate::dac;
 use crate::deferred_call_tasks::Task;
 use crate::dma;
+use crate::eic;
 use crate::flashcalw;
 use crate::gpio;
 use crate::i2c;
@@ -17,7 +18,6 @@ use crate::spi;
 use crate::trng;
 use crate::usart;
 use crate::usbc;
-use crate::eic;
 
 use cortexm4;
 use kernel::common::deferred_call;
@@ -151,7 +151,7 @@ impl Chip for Sam4l {
                         nvic::EIC6 => eic::EIC.handle_interrupt(6),
                         nvic::EIC7 => eic::EIC.handle_interrupt(7),
                         nvic::EIC8 => eic::EIC.handle_interrupt(8),
-                        
+
                         _ => {
                             panic!("unhandled interrupt {}", interrupt);
                         }

--- a/chips/sam4l/src/chip.rs
+++ b/chips/sam4l/src/chip.rs
@@ -17,6 +17,8 @@ use crate::spi;
 use crate::trng;
 use crate::usart;
 use crate::usbc;
+use crate::eic;
+
 use cortexm4;
 use kernel::common::deferred_call;
 use kernel::Chip;
@@ -140,6 +142,16 @@ impl Chip for Sam4l {
 
                         nvic::TRNG => trng::TRNG.handle_interrupt(),
                         nvic::AESA => aes::AES.handle_interrupt(),
+
+                        nvic::EIC1 => eic::EIC.handle_interrupt(1),
+                        nvic::EIC2 => eic::EIC.handle_interrupt(2),
+                        nvic::EIC3 => eic::EIC.handle_interrupt(3),
+                        nvic::EIC4 => eic::EIC.handle_interrupt(4),
+                        nvic::EIC5 => eic::EIC.handle_interrupt(5),
+                        nvic::EIC6 => eic::EIC.handle_interrupt(6),
+                        nvic::EIC7 => eic::EIC.handle_interrupt(7),
+                        nvic::EIC8 => eic::EIC.handle_interrupt(8),
+                        
                         _ => {
                             panic!("unhandled interrupt {}", interrupt);
                         }

--- a/chips/sam4l/src/chip.rs
+++ b/chips/sam4l/src/chip.rs
@@ -143,14 +143,14 @@ impl Chip for Sam4l {
                         nvic::TRNG => trng::TRNG.handle_interrupt(),
                         nvic::AESA => aes::AES.handle_interrupt(),
 
-                        nvic::EIC1 => eic::EIC.handle_interrupt(1),
-                        nvic::EIC2 => eic::EIC.handle_interrupt(2),
-                        nvic::EIC3 => eic::EIC.handle_interrupt(3),
-                        nvic::EIC4 => eic::EIC.handle_interrupt(4),
-                        nvic::EIC5 => eic::EIC.handle_interrupt(5),
-                        nvic::EIC6 => eic::EIC.handle_interrupt(6),
-                        nvic::EIC7 => eic::EIC.handle_interrupt(7),
-                        nvic::EIC8 => eic::EIC.handle_interrupt(8),
+                        nvic::EIC1 => eic::EIC.handle_interrupt(&eic::Line::Ext1),
+                        nvic::EIC2 => eic::EIC.handle_interrupt(&eic::Line::Ext2),
+                        nvic::EIC3 => eic::EIC.handle_interrupt(&eic::Line::Ext3),
+                        nvic::EIC4 => eic::EIC.handle_interrupt(&eic::Line::Ext4),
+                        nvic::EIC5 => eic::EIC.handle_interrupt(&eic::Line::Ext5),
+                        nvic::EIC6 => eic::EIC.handle_interrupt(&eic::Line::Ext6),
+                        nvic::EIC7 => eic::EIC.handle_interrupt(&eic::Line::Ext7),
+                        nvic::EIC8 => eic::EIC.handle_interrupt(&eic::Line::Ext8),
 
                         _ => {
                             panic!("unhandled interrupt {}", interrupt);

--- a/chips/sam4l/src/eic.rs
+++ b/chips/sam4l/src/eic.rs
@@ -171,7 +171,7 @@ impl<'a> hil::eic::ExternalInterruptController for Eic<'a> {
             self.enable();
         }
 
-        let interrupt_line: u32 = 1 << line.line_number;
+        let interrupt_line = *line as u32;
         let regs: &EicRegisters = &*self.registers;
 
         regs.en.write(Interrupt::INT.val(interrupt_line));

--- a/chips/sam4l/src/eic.rs
+++ b/chips/sam4l/src/eic.rs
@@ -22,14 +22,14 @@ use kernel::hil;
 #[derive(Copy, Clone, Debug)]
 #[repr(u8)]
 pub enum Line {
-    Nmi = 0, // NMI
-    Ext1 = 1, // EXT1
-    Ext2 = 2, // EXT2
-    Ext3 = 4, // EXT3
-    Ext4 = 8, // EXT4
-    Ext5 = 16, // EXT5
-    Ext6 = 32, // EXT6
-    Ext7 = 64, // EXT7
+    Nmi = 0,    // NMI
+    Ext1 = 1,   // EXT1
+    Ext2 = 2,   // EXT2
+    Ext3 = 4,   // EXT3
+    Ext4 = 8,   // EXT4
+    Ext5 = 16,  // EXT5
+    Ext6 = 32,  // EXT6
+    Ext7 = 64,  // EXT7
     Ext8 = 128, // EXT8
 }
 
@@ -79,6 +79,7 @@ register_bitfields![
     Interrupt [
         INT OFFSET(0) NUMBITS(32) []
     ],
+    // Test is not being used for now
     Test [
         //0: This bit disables external interrupt test mode.
         //1: This bit enables external interrupt test mode.
@@ -86,37 +87,7 @@ register_bitfields![
 
         // Writing a zero to this bit will set the input value to INTn to zero, if test mode is enabled. 
         // Writing a one to this bit will set the input value to INTn to one, if test mode is enabled.
-        INT30 30,
-        INT29 29,
-        INT28 28,
-        INT27 27,
-        INT26 26,
-        INT25 25,
-        INT24 24,
-        INT23 23,
-        INT22 22,
-        INT21 21,
-        INT20 20,
-        INT19 19,
-        INT18 18,
-        INT17 17,
-        INT16 16,
-        INT15 15,
-        INT14 14,
-        INT13 13,
-        INT12 12,
-        INT11 11,
-        INT10 10,
-        INT9 9,
-        INT8 8,
-        INT7 7,
-        INT6 6,
-        INT5 5,
-        INT4 4,
-        INT3 3,
-        INT2 2,
-        INT1 1,
-        NMI 0   // Non-interrupt_lineable Interrupt
+        INT OFFSET(0) NUMBITS(31) []
     ]
 ];
 

--- a/chips/sam4l/src/eic.rs
+++ b/chips/sam4l/src/eic.rs
@@ -278,7 +278,7 @@ impl<'a> Eic<'a> {
     pub fn line_is_enabled(&self, line_num: usize) -> bool {
         let regs: &EicRegisters = &*self.registers;
         let mask: u32 = 1 << line_num;
-        return (mask & regs.ctrl.get()) != 0;
+        (mask & regs.ctrl.get()) != 0
     }
 
     // Enables the propagation from the EIC to the interrupt controller of the external interrupt on a specified

--- a/chips/sam4l/src/eic.rs
+++ b/chips/sam4l/src/eic.rs
@@ -121,11 +121,7 @@ pub struct Eic<'a> {
 impl<'a> hil::eic::ExternalInterruptController for Eic<'a> {
     type Line = Line;
 
-    fn line_enable(
-        &self,
-        line: &Self::Line,
-        interrupt_mode: hil::eic::InterruptMode,
-    ) {
+    fn line_enable(&self, line: &Self::Line, interrupt_mode: hil::eic::InterruptMode) {
         if !self.is_enabled() {
             self.enable();
         }
@@ -134,7 +130,12 @@ impl<'a> hil::eic::ExternalInterruptController for Eic<'a> {
 
         regs.en.write(Interrupt::INT.val(*line as u32));
 
-        self.line_configure(line, interrupt_mode, FilterMode::FilterEnable, SynchronizationMode::Synchronous);
+        self.line_configure(
+            line,
+            interrupt_mode,
+            FilterMode::FilterEnable,
+            SynchronizationMode::Synchronous,
+        );
 
         self.line_enable_interrupt(line);
     }

--- a/chips/sam4l/src/eic.rs
+++ b/chips/sam4l/src/eic.rs
@@ -154,7 +154,7 @@ const EIC_BASE: StaticRef<EicRegisters> =
 pub struct Eic<'a> {
     registers: StaticRef<EicRegisters>,
     enabled: Cell<bool>,
-    callbacks: [OptionalCell<&'a hil::eic::Client>; 9],
+    callbacks: [OptionalCell<&'a dyn hil::eic::Client>; 9],
 }
 
 impl<'a> hil::eic::ExternalInterruptController for Eic<'a> {

--- a/chips/sam4l/src/eic.rs
+++ b/chips/sam4l/src/eic.rs
@@ -16,7 +16,7 @@
 
 use crate::pm::{self, Clock, PBDClock};
 use kernel::common::cells::OptionalCell;
-use kernel::common::peripherals::{PeripheralManagement, PeripheralManager};
+use kernel::common::peripherals::PeripheralManagement;
 use kernel::common::registers::{register_bitfields, ReadOnly, ReadWrite, WriteOnly};
 use kernel::common::StaticRef;
 use kernel::hil;
@@ -150,8 +150,6 @@ impl PeripheralManagement<pm::Clock> for Eic<'a> {
         }
     }
 }
-
-type EicRegisterManager<'a, 'b> = PeripheralManager<'a, Eic<'b>, pm::Clock>;
 
 pub struct Eic<'a> {
     callbacks: [OptionalCell<&'a dyn hil::eic::Client>; 9],

--- a/chips/sam4l/src/eic.rs
+++ b/chips/sam4l/src/eic.rs
@@ -245,7 +245,7 @@ impl<'a> Eic<'a> {
     }
 
     pub fn set_client(&self, client: &'a hil::eic::Client, line_num: usize) {
-        self.callbacks[line_num].set(client);
+        self.callbacks.get(line_num).map(|c| c.set(client));
     }
 
     pub fn handle_interrupt(&self, line_num: usize) {

--- a/chips/sam4l/src/eic.rs
+++ b/chips/sam4l/src/eic.rs
@@ -12,7 +12,6 @@
 // Author: Josh Zhang <jiashuoz@cs.princeton.edu>
 // Last modified July 9, 2019
 
-
 use crate::pm::{self, Clock, PBDClock};
 use core::cell::Cell;
 use kernel::common::cells::OptionalCell;
@@ -20,15 +19,15 @@ use kernel::common::registers::{register_bitfields, ReadOnly, ReadWrite, WriteOn
 use kernel::common::StaticRef;
 use kernel::hil;
 
-/// The sam4l chip supports 9 external interrupt lines: Ext1 - Ext8 and an additional 
-/// Non-Maskable Interrupt (NMI) pin. NMI has the same properties as the other external 
-/// interrupts, but is connected to the NMI request of the CPU, enabling it to interrupt 
+/// The sam4l chip supports 9 external interrupt lines: Ext1 - Ext8 and an additional
+/// Non-Maskable Interrupt (NMI) pin. NMI has the same properties as the other external
+/// interrupts, but is connected to the NMI request of the CPU, enabling it to interrupt
 /// any other interrupt mode.
 #[derive(Copy, Clone, Debug)]
 #[repr(u32)]
 pub enum Line {
     Nmi = 1,
-    Ext1 = 2,   
+    Ext1 = 2,
     Ext2 = 4,
     Ext3 = 8,
     Ext4 = 16,
@@ -138,7 +137,7 @@ impl<'a> hil::eic::ExternalInterruptController for Eic<'a> {
         regs.dis.write(Interrupt::INT.val(*line as u32));
 
         self.line_disable_interrupt(line);
-        
+
         self.disable();
     }
 }

--- a/chips/sam4l/src/eic.rs
+++ b/chips/sam4l/src/eic.rs
@@ -52,21 +52,35 @@ pub enum Line {
 
 #[repr(C)]
 struct EicRegisters {
-    ier: WriteOnly<u32, Interrupt::Register>,          // 0x00
-    idr: WriteOnly<u32, Interrupt::Register>,          // 0x04
-    imr: ReadOnly<u32, Interrupt::Register>,           // 0x08
-    isr: ReadOnly<u32, Interrupt::Register>,           // 0x0c
-    icr: WriteOnly<u32, Interrupt::Register>,          // 0x10
-    mode: ReadWrite<u32, Interrupt::Register>,         // 0x14
-    edge: ReadWrite<u32, Interrupt::Register>,         // 0x18
-    level: ReadWrite<u32, Interrupt::Register>,        // 0x1c
-    filter: ReadWrite<u32, Interrupt::Register>,       // 0x20
-    test: ReadWrite<u32, Test::Register>,              // 0x24
-    asynchronous: ReadWrite<u32, Interrupt::Register>, // 0x28
-    _reserved0: ReadOnly<u32>,                         // 0x02c, skip
-    en: WriteOnly<u32, Interrupt::Register>,           // 0x30
-    dis: WriteOnly<u32, Interrupt::Register>,          // 0x34
-    ctrl: ReadOnly<u32, Interrupt::Register>,          // 0x38
+    /// Enables propagation from eic to nvic
+    ier: WriteOnly<u32, Interrupt::Register>,
+    /// Disables propagation from eic to nvic
+    idr: WriteOnly<u32, Interrupt::Register>,
+    /// Indicates if the propagation is on
+    imr: ReadOnly<u32, Interrupt::Register>,
+    /// A bit is set when an interrupt triggers
+    isr: ReadOnly<u32, Interrupt::Register>,
+    /// Clears ISR  
+    icr: WriteOnly<u32, Interrupt::Register>,
+    /// Sets interrupt mode
+    mode: ReadWrite<u32, Interrupt::Register>,
+    /// Configures falling or rising edge
+    edge: ReadWrite<u32, Interrupt::Register>,
+    /// Configures low or high level
+    level: ReadWrite<u32, Interrupt::Register>,
+    /// Configures filter
+    filter: ReadWrite<u32, Interrupt::Register>,
+    /// For testing
+    test: ReadWrite<u32, Test::Register>,
+    /// Configures synchronization
+    asynchronous: ReadWrite<u32, Interrupt::Register>,
+    _reserved0: ReadOnly<u32>,
+    /// Enables an interrupt line
+    en: WriteOnly<u32, Interrupt::Register>,
+    /// Disables an interrupt line
+    dis: WriteOnly<u32, Interrupt::Register>,
+    /// Indicates if an interrupt line is enabled or not
+    ctrl: ReadOnly<u32, Interrupt::Register>,
 }
 
 // IER: Writing a one to this bit will set the corresponding bit in IMR.
@@ -94,16 +108,17 @@ struct EicRegisters {
 register_bitfields![
     u32,
     Interrupt [
+        /// Each bit represents the setup for each line, for sam4l, only bit 0-8 makes sense
         INT OFFSET(0) NUMBITS(32) []
     ],
-    // Test is not being used right now
+    /// Test is not being used right now
     Test [
-        //0: This bit disables external interrupt test mode.
-        //1: This bit enables external interrupt test mode.
+        /// 0: This bit disables external interrupt test mode.
+        /// 1: This bit enables external interrupt test mode.
         TESTEN OFFSET(31) NUMBITS(1) [],
 
-        // Writing a zero to this bit will set the input value to INTn to zero, if test mode is enabled. 
-        // Writing a one to this bit will set the input value to INTn to one, if test mode is enabled.
+        /// Writing a zero to this bit will set the input value to INTn to zero, if test mode is enabled. 
+        /// Writing a one to this bit will set the input value to INTn to one, if test mode is enabled.
         INT OFFSET(0) NUMBITS(31) []
     ]
 ];
@@ -134,7 +149,7 @@ impl<'a> hil::eic::ExternalInterruptController for Eic<'a> {
             line,
             interrupt_mode,
             FilterMode::FilterEnable,
-            SynchronizationMode::Synchronous,
+            SynchronizationMode::Asynchronous,
         );
 
         self.line_enable_interrupt(line);

--- a/chips/sam4l/src/eic.rs
+++ b/chips/sam4l/src/eic.rs
@@ -182,7 +182,9 @@ impl<'a> hil::eic::ExternalInterruptController for Eic<'a> {
     }
 
     fn line_disable(&self, line: &Self::Line) {
-        if !self.is_enabled() { return; }
+        if !self.is_enabled() {
+            return;
+        }
 
         let interrupt_line: u32 = 1 << line.line_number;
         let regs: &EicRegisters = &*self.registers;
@@ -198,8 +200,7 @@ impl<'a> Eic<'a> {
         int_mode: hil::eic::InterruptMode,
         filter_mode: hil::eic::FilterMode,
         syn_mode: hil::eic::SynchronizationMode,
-    ) { 
-
+    ) {
         let mode_bits = match int_mode {
             hil::eic::InterruptMode::RisingEdge => 0b00,
             hil::eic::InterruptMode::FallingEdge => 0b01,
@@ -237,7 +238,7 @@ impl<'a> Eic<'a> {
         let original_edge: u32 = regs.edge.get();
 
         if mode_bits & 0b10 != 0 {
-            regs.mode.set(original_mode | interrupt_line); // 0b10 or 0b11 -> level 
+            regs.mode.set(original_mode | interrupt_line); // 0b10 or 0b11 -> level
         } else {
             regs.mode.set(original_mode & !interrupt_line); // 0b00 or 0b01 -> edge
         }
@@ -274,7 +275,9 @@ impl<'a> Eic<'a> {
     }
 
     pub fn set_client(&self, client: &'a hil::eic::Client, line_number: usize) {
-        if line_number > 8 { return; }
+        if line_number > 8 {
+            return;
+        }
         self.callbacks.get(line_number).map(|c| c.set(client));
     }
 
@@ -289,10 +292,10 @@ impl<'a> Eic<'a> {
     /// Sets interrupt clear register
     pub fn line_clear_interrupt(&self, line_number: usize) {
         let regs: &EicRegisters = &*self.registers;
-        
+
         // line_number always sits in the range 1-8, no need to check shift overflow
         let interrupt_line: u32 = 1 << line_number;
-        
+
         regs.icr.write(Interrupt::INT.val(interrupt_line));
     }
 

--- a/chips/sam4l/src/eic.rs
+++ b/chips/sam4l/src/eic.rs
@@ -158,7 +158,7 @@ pub struct Eic<'a> {
 }
 
 impl<'a> hil::eic::ExternalInterruptController for Eic<'a> {
-    type Line = EicLine;
+    type Line = Line;
 
     fn line_enable(
         &self,

--- a/chips/sam4l/src/eic.rs
+++ b/chips/sam4l/src/eic.rs
@@ -17,7 +17,6 @@ use core::cell::Cell;
 use kernel::common::cells::OptionalCell;
 use kernel::common::registers::{register_bitfields, ReadOnly, ReadWrite, WriteOnly};
 use kernel::common::StaticRef;
-use kernel::debug;
 use kernel::hil;
 
 /// Representation of an EIC line on the SAM4L.

--- a/chips/sam4l/src/eic.rs
+++ b/chips/sam4l/src/eic.rs
@@ -19,46 +19,19 @@ use kernel::common::registers::{register_bitfields, ReadOnly, ReadWrite, WriteOn
 use kernel::common::StaticRef;
 use kernel::hil;
 
-/// Representation of an EIC line on the SAM4L.
-pub struct EicLine {
-    line_number: u32,
-}
-
 #[derive(Copy, Clone, Debug)]
 #[repr(u8)]
-enum Line {
-    LINE0 = 0x00, // NMI
-    LINE1 = 0x01, // EXT1
-    LINE2 = 0x02, // EXT2
-    LINE3 = 0x03, // EXT3
-    LINE4 = 0x04, // EXT4
-    LINE5 = 0x05, // EXT5
-    LINE6 = 0x06, // EXT6
-    LINE7 = 0x07, // EXT7
-    LINE8 = 0x08, // EXT8
+pub enum Line {
+    Nmi = 0, // NMI
+    Ext1 = 1, // EXT1
+    Ext2 = 2, // EXT2
+    Ext3 = 4, // EXT3
+    Ext4 = 8, // EXT4
+    Ext5 = 16, // EXT5
+    Ext6 = 32, // EXT6
+    Ext7 = 64, // EXT7
+    Ext8 = 128, // EXT8
 }
-
-/// Initialization of an EIC line.
-impl EicLine {
-    /// Create a new EIC line.
-    ///
-    /// - `line`: Line enum representing the line number
-    const fn new(line: Line) -> EicLine {
-        EicLine {
-            line_number: ((line as u8) & 0x0F) as u32,
-        }
-    }
-}
-
-pub static mut LINE_EIC0: EicLine = EicLine::new(Line::LINE0);
-pub static mut LINE_EIC1: EicLine = EicLine::new(Line::LINE1);
-pub static mut LINE_EIC2: EicLine = EicLine::new(Line::LINE2);
-pub static mut LINE_EIC3: EicLine = EicLine::new(Line::LINE3);
-pub static mut LINE_EIC4: EicLine = EicLine::new(Line::LINE4);
-pub static mut LINE_EIC5: EicLine = EicLine::new(Line::LINE5);
-pub static mut LINE_EIC6: EicLine = EicLine::new(Line::LINE6);
-pub static mut LINE_EIC7: EicLine = EicLine::new(Line::LINE7);
-pub static mut LINE_EIC8: EicLine = EicLine::new(Line::LINE8);
 
 #[repr(C)]
 struct EicRegisters {
@@ -185,7 +158,7 @@ impl<'a> hil::eic::ExternalInterruptController for Eic<'a> {
             return;
         }
 
-        let interrupt_line: u32 = 1 << line.line_number;
+        let interrupt_line: u32 = 1 << *line as u32;
         let regs: &EicRegisters = &*self.registers;
         regs.dis.write(Interrupt::INT.val(interrupt_line));
         self.line_disable_interrupt(interrupt_line);

--- a/chips/sam4l/src/eic.rs
+++ b/chips/sam4l/src/eic.rs
@@ -79,11 +79,11 @@ register_bitfields![
     Interrupt [
         INT OFFSET(0) NUMBITS(32) []
     ],
-    // Test is not being used for now
+    // Test is not being used right now
     Test [
         //0: This bit disables external interrupt test mode.
         //1: This bit enables external interrupt test mode.
-        TESTEN 31,
+        TESTEN OFFSET(31) NUMBITS(1) [],
 
         // Writing a zero to this bit will set the input value to INTn to zero, if test mode is enabled. 
         // Writing a one to this bit will set the input value to INTn to one, if test mode is enabled.

--- a/chips/sam4l/src/eic.rs
+++ b/chips/sam4l/src/eic.rs
@@ -1,0 +1,367 @@
+//! Implementation of the SAM4L External Interrupt Controller (EIC).
+//!
+//! Datasheet section "21. External Interrupt Controller (EIC)".
+//!
+//! The External Interrupt Controller (EIC) allows pins to be configured as external 
+//! interrupts. Each external interrupt has its own interrupt request and can be individually 
+//! masked. Each external interrupt can generate an interrupt on rising or falling edge, or 
+//! high or low level. Every interrupt input has a configurable filter to remove spikes from 
+//! the interrupt source. Every interrupt pin can also be configured to be asynchronous in order 
+//! to wake up the part from sleep modes where the CLK_SYNC clock has been disabled.
+//!
+//! - Author: Josh Zhang  <jiashuoz@princeton.edu>
+//! - Updated: June 25, 2019
+
+use kernel::common::registers::{register_bitfields, ReadOnly, ReadWrite, WriteOnly};
+use kernel::common::StaticRef;
+use kernel::hil;
+use kernel::debug;
+use core::cell::Cell;
+use kernel::common::cells::{OptionalCell};
+use crate::pm::{self, Clock, PBDClock};
+
+#[repr(C)]
+struct EicRegisters {
+    ier: WriteOnly<u32, Interrupt::Register>,       // 0x00
+    idr: WriteOnly<u32, Interrupt::Register>,       // 0x04
+    imr: ReadOnly<u32, Interrupt::Register>,        // 0x08
+    isr: ReadOnly<u32, Interrupt::Register>,        // 0x0c
+    icr: WriteOnly<u32, Interrupt::Register>,       // 0x10
+    mode: ReadWrite<u32, Interrupt::Register>,      // 0x14
+    edge: ReadWrite<u32, Interrupt::Register>,      // 0x18
+    level: ReadWrite<u32, Interrupt::Register>,     // 0x1c
+    filter: ReadWrite<u32, Interrupt::Register>,    // 0x20
+    test: ReadWrite<u32, Test::Register>,      // 0x24
+    asynchronous: ReadWrite<u32, Interrupt::Register>,     // 0x28
+    _reserved0: ReadOnly<u32>, // 0x02c, skip
+    en: WriteOnly<u32, Interrupt::Register>,        // 0x30
+    dis: WriteOnly<u32, Interrupt::Register>,       // 0x34
+    ctrl: ReadOnly<u32, Interrupt::Register>,       // 0x38
+}
+
+// IER: Writing a one to this bit will set the corresponding bit in IMR.
+// IDR: Writing a one to this bit will clear the corresponding bit in IMR.
+// IMR: 0: The corresponding interrupt is disabled.
+//      1: The corresponding interrupt is enabled.
+// ISR: 0: An interrupt event has not occurred.
+//      1: An interrupt event has occurred.
+// ICR: Writing a one to this bit will clear the corresponding bit in ISR.
+// MODE:    0: The external interrupt is edge triggered.
+//          1: The external interrupt is level triggered.'
+// EDGE:    0: The external interrupt triggers on falling edge.
+//          1: The external interrupt triggers on rising edge.
+// LEVEL:   0: The external interrupt triggers on low level.
+//          1: The external interrupt triggers on high level.
+// FILTER:  0: The external interrupt is not filtered.
+//          1: The external interrupt is filtered.
+// ASYNC:   0: The external interrupt is synchronized to CLK_SYNC.
+//          1: The external interrupt is asynchronous.
+// EN: Writing a one to this bit will enable the corresponding external interrupt.
+// DIS: Writing a one to this bit will disable the corresponding external interrupt.
+// CTRL:    0: The corresponding external interrupt is disabled.
+//          1: The corresponding external interrupt is enabled.
+
+register_bitfields![
+    u32,
+    Interrupt [
+        INT OFFSET(0) NUMBITS(32) []
+    ],
+    Test [
+        //0: This bit disables external interrupt test mode.
+        //1: This bit enables external interrupt test mode.
+        TESTEN 31,
+
+        // Writing a zero to this bit will set the input value to INTn to zero, if test mode is enabled. 
+        // Writing a one to this bit will set the input value to INTn to one, if test mode is enabled.
+        INT30 30,
+        INT29 29,
+        INT28 28,
+        INT27 27,
+        INT26 26,
+        INT25 25,
+        INT24 24,
+        INT23 23,
+        INT22 22,
+        INT21 21,
+        INT20 20,
+        INT19 19,
+        INT18 18,
+        INT17 17,
+        INT16 16,
+        INT15 15,
+        INT14 14,
+        INT13 13,
+        INT12 12,
+        INT11 11,
+        INT10 10,
+        INT9 9,
+        INT8 8,
+        INT7 7,
+        INT6 6,
+        INT5 5,
+        INT4 4,
+        INT3 3,
+        INT2 2,
+        INT1 1,
+        NMI 0   // Non-Maskable Interrupt
+    ]
+];
+
+// Page 59 of SAM4L data sheet
+const EIC_BASE: StaticRef<EicRegisters> =
+    unsafe { StaticRef::new(0x400F1000 as *const EicRegisters) };
+
+pub struct Eic<'a> {
+    registers: StaticRef<EicRegisters>,
+    enabled: Cell<bool>,
+    callbacks: [OptionalCell<&'a hil::eic::Client>; 9],
+}
+
+impl<'a> hil::eic::ExternalInterruptController for Eic<'a> {
+    fn enable(&self) {
+        pm::enable_clock(Clock::PBD(PBDClock::EIC));
+        self.enabled.set(true);
+        debug!("{}", pm::is_clock_enabled(Clock::PBD(PBDClock::EIC)));
+    }
+
+    fn disable(&self) {
+        pm::disable_clock(Clock::PBD(PBDClock::EIC));
+        self.enabled.set(false);
+    }
+
+    fn line_enable(&self, line_num: usize) {
+        let regs : &EicRegisters = &*self.registers;
+        let mask : u32 = 1 << line_num;
+        // en == WriteOnly
+        match line_num {
+            0 => regs.en.write(Interrupt::INT.val(mask)),
+            1 => regs.en.write(Interrupt::INT.val(mask)),
+            2 => regs.en.write(Interrupt::INT.val(mask)),
+            3 => regs.en.write(Interrupt::INT.val(mask)),
+            4 => regs.en.write(Interrupt::INT.val(mask)),
+            5 => regs.en.write(Interrupt::INT.val(mask)),
+            6 => regs.en.write(Interrupt::INT.val(mask)),
+            7 => regs.en.write(Interrupt::INT.val(mask)),
+            8 => regs.en.write(Interrupt::INT.val(mask)),
+            _ => debug!("not supported!"),
+        }
+
+        self.line_enable_interrupt(line_num);
+    }
+
+    fn line_disable(&self, line_num: usize) {
+        let regs : &EicRegisters = &*self.registers;
+        let mask : u32 = 1 << line_num;
+        match line_num {
+            0 => regs.dis.write(Interrupt::INT.val(mask)),
+            1 => regs.dis.write(Interrupt::INT.val(mask)),
+            2 => regs.dis.write(Interrupt::INT.val(mask)),
+            3 => regs.dis.write(Interrupt::INT.val(mask)),
+            4 => regs.dis.write(Interrupt::INT.val(mask)),
+            5 => regs.dis.write(Interrupt::INT.val(mask)),
+            6 => regs.dis.write(Interrupt::INT.val(mask)),
+            7 => regs.dis.write(Interrupt::INT.val(mask)),
+            8 => regs.dis.write(Interrupt::INT.val(mask)),
+            _ => debug!("not supported!"),
+        }
+
+        self.line_disable_interrupt(line_num);
+    }
+
+    fn line_configure(&self, line_num: usize, int_mode: hil::eic::InterruptMode, filter: hil::eic::FilterMode, syn_mode: hil::eic::SynchronizationMode) {
+        let mask : u32 = 1 << line_num;
+
+        // regs.mode.set(original_mode & !mask);
+
+        let mode_bits = match int_mode {
+            hil::eic::InterruptMode::RisingEdge => 0b00,
+            hil::eic::InterruptMode::FallingEdge => 0b01,
+            hil::eic::InterruptMode::HighLevel => 0b10,
+            hil::eic::InterruptMode::LowLevel => 0b11,
+        };
+
+        self.set_interrupt_mode(mode_bits, mask);
+
+        match filter {
+            hil::eic::FilterMode::FilterEnable => self.line_enable_filter(mask),
+            hil::eic::FilterMode::FilterDisable => self.line_disable_filter(mask),
+        }
+
+        match syn_mode {
+            hil::eic::SynchronizationMode::Synchronous => self.line_disable_asyn(mask),
+            hil::eic::SynchronizationMode::Asynchronous => self.line_enable_asyn(mask),
+        }
+    }
+}
+
+impl<'a> Eic<'a> {
+
+    pub fn set_interrupt_mode(&self, mode_bits: u8, mask: u32) {
+        let regs : &EicRegisters = &*self.registers;
+        let original_mode : u32 = regs.mode.get();
+        let original_level : u32 = regs.level.get();
+        let original_edge : u32 = regs.edge.get();
+
+        if mode_bits & 0b10 != 0 {
+            regs.mode.set(original_mode & !mask);
+        } else {
+            regs.mode.set(original_mode | mask);
+        }
+
+        if mode_bits & 0b01 != 0 {
+            regs.edge.set(original_edge & !mask); // falling edge
+            regs.level.set(original_level & !mask); // low level
+        } else {
+            regs.edge.set(original_edge | mask); // rising edge
+            regs.level.set(original_level | mask); // high level
+        }
+    }
+
+    const fn new() -> Eic<'a> {
+        Eic {
+            registers: EIC_BASE,
+            enabled: Cell::new(false),
+            callbacks: [OptionalCell::empty(),
+                        OptionalCell::empty(),
+                        OptionalCell::empty(),
+                        OptionalCell::empty(),
+                        OptionalCell::empty(),
+                        OptionalCell::empty(),
+                        OptionalCell::empty(),
+                        OptionalCell::empty(),
+                        OptionalCell::empty(),],
+        }
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        self.enabled.get()
+    }
+
+    pub fn set_client(&self, client: &'a hil::eic::Client, line_num: usize) {
+        self.callbacks[line_num].set(client);
+    }
+
+    pub fn handle_interrupt(&self, line_num: usize) {
+        self.line_clear_interrupt(line_num); 
+        self.callbacks[line_num].map(|cb| {
+            cb.fired();
+        });
+    }
+
+    /// Clears the interrupt flag of line. Should be called after handling interrupt
+    /// Sets interrupt clear register
+    pub fn line_clear_interrupt(&self, line_num: usize) {
+        let regs : &EicRegisters = &*self.registers;
+        let mask : u32 = 1 << line_num;
+        // icr WriteOnly
+        match line_num {
+            0 => regs.icr.write(Interrupt::INT.val(mask)),
+            1 => regs.icr.write(Interrupt::INT.val(mask)),
+            2 => regs.icr.write(Interrupt::INT.val(mask)),
+            3 => regs.icr.write(Interrupt::INT.val(mask)),
+            4 => regs.icr.write(Interrupt::INT.val(mask)),
+            5 => regs.icr.write(Interrupt::INT.val(mask)),
+            6 => regs.icr.write(Interrupt::INT.val(mask)),
+            7 => regs.icr.write(Interrupt::INT.val(mask)),
+            8 => regs.icr.write(Interrupt::INT.val(mask)),
+            _ => debug!("not supported!"),
+        }
+    }
+
+    pub fn line_is_enabled(&self, line_num: usize) -> bool {
+        let regs : &EicRegisters = &*self.registers;
+        let mask : u32 = 1 << line_num;
+        return (mask & regs.ctrl.get()) != 0
+    }
+
+    // Enables the propagation from the EIC to the interrupt controller of the external interrupt on a specified
+    // line.
+    pub fn line_enable_interrupt(&self, line_num: usize) {
+        let regs : &EicRegisters = &*self.registers;
+        let mask : u32 = 1 << line_num;
+        // ier WriteOnly
+        match line_num {
+            0 => regs.ier.write(Interrupt::INT.val(mask)),
+            1 => regs.ier.write(Interrupt::INT.val(mask)),
+            2 => regs.ier.write(Interrupt::INT.val(mask)),
+            3 => regs.ier.write(Interrupt::INT.val(mask)),
+            4 => regs.ier.write(Interrupt::INT.val(mask)),
+            5 => regs.ier.write(Interrupt::INT.val(mask)),
+            6 => regs.ier.write(Interrupt::INT.val(mask)),
+            7 => regs.ier.write(Interrupt::INT.val(mask)),
+            8 => regs.ier.write(Interrupt::INT.val(mask)),
+            _ => debug!("not supported!"),
+        }
+    }
+
+    pub fn line_disable_interrupt(&self, line_num: usize) {
+        let regs : &EicRegisters = &*self.registers;
+        let mask : u32 = 1 << line_num;
+        match line_num {
+            0 => regs.idr.write(Interrupt::INT.val(mask)),
+            1 => regs.idr.write(Interrupt::INT.val(mask)),
+            2 => regs.idr.write(Interrupt::INT.val(mask)),
+            3 => regs.idr.write(Interrupt::INT.val(mask)),
+            4 => regs.idr.write(Interrupt::INT.val(mask)),
+            5 => regs.idr.write(Interrupt::INT.val(mask)),
+            6 => regs.idr.write(Interrupt::INT.val(mask)),
+            7 => regs.idr.write(Interrupt::INT.val(mask)),
+            8 => regs.idr.write(Interrupt::INT.val(mask)),
+            _ => debug!("not supported!"),
+        }
+    }
+
+    /// Reads IMR register
+    pub fn line_interrupt_is_enabled(&self, line_num: usize) -> bool {
+        let regs : &EicRegisters = &*self.registers;
+        let mask : u32 = 1 << line_num;
+        return (mask & regs.imr.get()) != 0
+    }
+
+
+    /// Tells whether an EIC interrupt line is pending.
+    pub fn line_interrupt_pending(&self, line_num: usize) -> bool {
+        let regs : &EicRegisters = &*self.registers;
+        let mask : u32 = 1 << line_num;
+        return (mask & regs.isr.get()) != 0
+    }
+
+    pub fn line_enable_filter(&self, mask: u32) {
+        let regs : &EicRegisters = &*self.registers;
+        let original_filter : u32 = regs.filter.get();
+        regs.filter.set(original_filter | mask);
+    }
+
+    pub fn line_disable_filter(&self, mask: u32) {
+        let regs : &EicRegisters = &*self.registers;
+        let original_filter : u32 = regs.filter.get();
+        regs.filter.set(original_filter & (!mask));
+    }
+
+    pub fn line_enable_filter_is_enabled(&self, line_num: usize) -> bool {
+        let regs : &EicRegisters = &*self.registers;
+        let mask : u32 = 1 << line_num;
+        return (mask & regs.filter.get()) != 0
+    }
+
+    pub fn line_enable_asyn(&self, mask: u32) {
+        let regs : &EicRegisters = &*self.registers;
+        let original_asyn : u32 = regs.asynchronous.get();
+        regs.asynchronous.modify(Interrupt::INT.val(original_asyn | mask));
+    }
+
+    pub fn line_disable_asyn(&self, mask: u32) {
+        let regs : &EicRegisters = &*self.registers;
+        let original_asyn : u32 = regs.asynchronous.get();
+        regs.asynchronous.modify(Interrupt::INT.val(original_asyn & (!mask)));
+    }
+
+    pub fn line_asyn_is_enabled(&self, line_num: usize) -> bool {
+        let regs : &EicRegisters = &*self.registers;
+        let mask : u32 = 1 << line_num;
+        return (mask & regs.asynchronous.get()) != 0
+    }
+}
+
+/// Static state to manage the EIC
+pub static mut EIC: Eic = Eic::new();

--- a/chips/sam4l/src/lib.rs
+++ b/chips/sam4l/src/lib.rs
@@ -32,6 +32,7 @@ pub mod trng;
 pub mod usart;
 pub mod usbc;
 pub mod wdt;
+pub mod eic;
 
 use cortexm4::{generic_isr, hard_fault_handler, svc_handler, systick_handler};
 

--- a/chips/sam4l/src/lib.rs
+++ b/chips/sam4l/src/lib.rs
@@ -20,6 +20,7 @@ pub mod chip;
 pub mod crccu;
 pub mod dac;
 pub mod dma;
+pub mod eic;
 pub mod flashcalw;
 pub mod gpio;
 pub mod i2c;
@@ -32,7 +33,6 @@ pub mod trng;
 pub mod usart;
 pub mod usbc;
 pub mod wdt;
-pub mod eic;
 
 use cortexm4::{generic_isr, hard_fault_handler, svc_handler, systick_handler};
 

--- a/kernel/src/hil/eic.rs
+++ b/kernel/src/hil/eic.rs
@@ -35,7 +35,7 @@ pub trait ExternalInterruptController {
     type Line;
 
     /// Enables external interrupt on line_num
-    /// In asychronous mode, all edge interrupts will be 
+    /// In asychronous mode, all edge interrupts will be
     /// interpreted as level interrupts and the filter is disabled.
     fn line_enable(
         &self,

--- a/kernel/src/hil/eic.rs
+++ b/kernel/src/hil/eic.rs
@@ -27,11 +27,7 @@ pub trait ExternalInterruptController {
     /// Enables external interrupt on the given 'line'
     /// In asychronous mode, all edge interrupts will be
     /// interpreted as level interrupts and the filter is disabled.
-    fn line_enable(
-        &self,
-        line: &Self::Line,
-        interrupt_mode: InterruptMode,
-    );
+    fn line_enable(&self, line: &Self::Line, interrupt_mode: InterruptMode);
 
     /// Disables external interrupt on the given 'line'
     fn line_disable(&self, line: &Self::Line);

--- a/kernel/src/hil/eic.rs
+++ b/kernel/src/hil/eic.rs
@@ -37,7 +37,13 @@ pub trait ExternalInterruptController {
     fn line_disable(&self, line_num: usize);
 
     /// Configure external interrupt on line_num
-    fn line_configure(&self, line_num: usize, int_mode: InterruptMode, filter: FilterMode, syn_mode: SynchronizationMode);
+    fn line_configure(
+        &self,
+        line_num: usize,
+        int_mode: InterruptMode,
+        filter: FilterMode,
+        syn_mode: SynchronizationMode,
+    );
 }
 
 /// Interface for users of EIC. In order

--- a/kernel/src/hil/eic.rs
+++ b/kernel/src/hil/eic.rs
@@ -19,19 +19,6 @@ pub enum InterruptMode {
     LowLevel,
 }
 
-/// Enum for enabling or disabling spurious event filtering (i.e. de-bouncing control).
-pub enum FilterMode {
-    FilterEnable,
-    FilterDisable,
-}
-
-/// Enum for selecting synchronous or asynchronous mode. Interrupts in asynchronous mode
-/// can wake up the system from deep sleep mode.
-pub enum SynchronizationMode {
-    Synchronous,
-    Asynchronous,
-}
-
 /// Interface for EIC.
 pub trait ExternalInterruptController {
     /// The chip-dependent type of an EIC line. Number of lines available depends on the chip.
@@ -44,8 +31,6 @@ pub trait ExternalInterruptController {
         &self,
         line: &Self::Line,
         interrupt_mode: InterruptMode,
-        filter_mode: FilterMode,
-        synchronization_mode: SynchronizationMode,
     );
 
     /// Disables external interrupt on the given 'line'

--- a/kernel/src/hil/eic.rs
+++ b/kernel/src/hil/eic.rs
@@ -18,13 +18,13 @@ pub enum InterruptMode {
     LowLevel,
 }
 
-/// Enum for enabling/disabling filter
+/// Enum for enabling or disabling spurious event filtering (i.e. de-bouncing control).
 pub enum FilterMode {
     FilterEnable,
     FilterDisable,
 }
 
-/// Enum for selecting syn/asyn mode
+/// Enum for selecting synchronous or asynchronous mode.
 pub enum SynchronizationMode {
     Synchronous,
     Asynchronous,
@@ -34,18 +34,18 @@ pub enum SynchronizationMode {
 pub trait ExternalInterruptController {
     type Line;
 
-    /// Enables external interrupt on line_num
+    /// Enables external interrupt on the given 'line'
     /// In asychronous mode, all edge interrupts will be
     /// interpreted as level interrupts and the filter is disabled.
     fn line_enable(
         &self,
         line: &Self::Line,
-        int_mode: InterruptMode,
-        filter: FilterMode,
-        syn_mode: SynchronizationMode,
+        interrupt_mode: InterruptMode,
+        filter_mode: FilterMode,
+        synchronization_mode: SynchronizationMode,
     );
 
-    /// Disables external interrupt on line_num
+    /// Disables external interrupt on the given 'line'
     fn line_disable(&self, line: &Self::Line);
 }
 

--- a/kernel/src/hil/eic.rs
+++ b/kernel/src/hil/eic.rs
@@ -1,10 +1,10 @@
 //! Interface for external interrupt controller.
 //!
-//! The External Interrupt Controller (EIC) allows pins to be configured as 
-//! external interrupts. Each external interrupt has its own interrupt request 
-//! and can be individually masked. Each external interrupt can generate an 
-//! interrupt on rising or falling edge, or high or low level.  
-//! Every interrupt pin can also be configured to be asynchronous, in order to 
+//! The External Interrupt Controller (EIC) allows pins to be configured as
+//! external interrupts. Each external interrupt has its own interrupt request
+//! and can be individually masked. Each external interrupt can generate an
+//! interrupt on rising or falling edge, or high or low level.
+//! Every interrupt pin can also be configured to be asynchronous, in order to
 //! wake-up the part from sleep modes where the CLK_SYNC clock has been disabled.
 //!
 //! A basic use case:

--- a/kernel/src/hil/eic.rs
+++ b/kernel/src/hil/eic.rs
@@ -1,4 +1,13 @@
 //! Interface for external interrupt controller.
+//! Interrupt can be configured as asynchronous to operate
+//! during deep sleep mode where the EIC clock is disabled.
+//!
+//! A basic use case:
+//! A user button is configured for falling edge trigger and async mode
+//!
+
+// Author: Josh Zhang <jiashuoz@cs.princeton.edu>
+// Last modified June 26, 2019
 
 /// Enum for selecting which edge to trigger interrupts on.
 #[derive(Debug)]
@@ -23,27 +32,21 @@ pub enum SynchronizationMode {
 
 /// Interface for EIC.
 pub trait ExternalInterruptController {
-    /// Enables EIC module
-    fn enable(&self);
-
-    /// Disables EIC module
-    fn disable(&self);
+    type Line;
 
     /// Enables external interrupt on line_num
-    /// In asychronous mode, all edge interrupts will be interpreted as level interrupts and the filter is disabled.
-    fn line_enable(&self, line_num: usize);
-
-    /// Disables external interrupt on line_num
-    fn line_disable(&self, line_num: usize);
-
-    /// Configure external interrupt on line_num
-    fn line_configure(
+    /// In asychronous mode, all edge interrupts will be 
+    /// interpreted as level interrupts and the filter is disabled.
+    fn line_enable(
         &self,
-        line_num: usize,
+        line: &Self::Line,
         int_mode: InterruptMode,
         filter: FilterMode,
         syn_mode: SynchronizationMode,
     );
+
+    /// Disables external interrupt on line_num
+    fn line_disable(&self, line: &Self::Line);
 }
 
 /// Interface for users of EIC. In order

--- a/kernel/src/hil/eic.rs
+++ b/kernel/src/hil/eic.rs
@@ -1,13 +1,14 @@
 //! Interface for external interrupt controller.
-//! Interrupt can be configured as asynchronous to operate
-//! during deep sleep mode where the EIC clock is disabled.
+//!
+//! The External Interrupt Controller (EIC) allows pins to be configured as 
+//! external interrupts. Each external interrupt has its own interrupt request 
+//! and can be individually masked. Each external interrupt can generate an 
+//! interrupt on rising or falling edge, or high or low level.  
+//! Every interrupt pin can also be configured to be asynchronous, in order to 
+//! wake-up the part from sleep modes where the CLK_SYNC clock has been disabled.
 //!
 //! A basic use case:
-//! A user button is configured for falling edge trigger and async mode
-//!
-
-// Author: Josh Zhang <jiashuoz@cs.princeton.edu>
-// Last modified June 26, 2019
+//! A user button is configured for falling edge trigger and async mode.
 
 /// Enum for selecting which edge to trigger interrupts on.
 #[derive(Debug)]
@@ -24,7 +25,8 @@ pub enum FilterMode {
     FilterDisable,
 }
 
-/// Enum for selecting synchronous or asynchronous mode.
+/// Enum for selecting synchronous or asynchronous mode. Interrupts in asynchronous mode
+/// can wake up the system from deep sleep mode.
 pub enum SynchronizationMode {
     Synchronous,
     Asynchronous,
@@ -32,6 +34,7 @@ pub enum SynchronizationMode {
 
 /// Interface for EIC.
 pub trait ExternalInterruptController {
+    /// The chip-dependent type of an EIC line. Number of lines available depends on the chip.
     type Line;
 
     /// Enables external interrupt on the given 'line'

--- a/kernel/src/hil/eic.rs
+++ b/kernel/src/hil/eic.rs
@@ -1,0 +1,49 @@
+//! Interface for external interrupt controller.
+
+/// Enum for selecting which edge to trigger interrupts on.
+#[derive(Debug)]
+pub enum InterruptMode {
+    RisingEdge,
+    FallingEdge,
+    HighLevel,
+    LowLevel,
+}
+
+/// Enum for enabling/disabling filter
+pub enum FilterMode {
+    FilterEnable,
+    FilterDisable,
+}
+
+/// Enum for selecting syn/asyn mode
+pub enum SynchronizationMode {
+    Synchronous,
+    Asynchronous,
+}
+
+/// Interface for EIC.
+pub trait ExternalInterruptController {
+    /// Enables EIC module
+    fn enable(&self);
+
+    /// Disables EIC module
+    fn disable(&self);
+
+    /// Enables external interrupt on line_num
+    /// In asychronous mode, all edge interrupts will be interpreted as level interrupts and the filter is disabled.
+    fn line_enable(&self, line_num: usize);
+
+    /// Disables external interrupt on line_num
+    fn line_disable(&self, line_num: usize);
+
+    /// Configure external interrupt on line_num
+    fn line_configure(&self, line_num: usize, int_mode: InterruptMode, filter: FilterMode, syn_mode: SynchronizationMode);
+}
+
+/// Interface for users of EIC. In order
+/// to execute interrupts, the user must implement
+/// this `Client` interface.
+pub trait Client {
+    /// Called when an interrupt occurs.
+    fn fired(&self);
+}

--- a/kernel/src/hil/mod.rs
+++ b/kernel/src/hil/mod.rs
@@ -22,6 +22,7 @@ pub mod time;
 pub mod uart;
 pub mod usb;
 pub mod watchdog;
+pub mod eic;
 
 /// Shared interface for configuring components.
 pub trait Controller {

--- a/kernel/src/hil/mod.rs
+++ b/kernel/src/hil/mod.rs
@@ -5,6 +5,7 @@ pub mod analog_comparator;
 pub mod ble_advertising;
 pub mod crc;
 pub mod dac;
+pub mod eic;
 pub mod entropy;
 pub mod flash;
 pub mod gpio;
@@ -22,7 +23,6 @@ pub mod time;
 pub mod uart;
 pub mod usb;
 pub mod watchdog;
-pub mod eic;
 
 /// Shared interface for configuring components.
 pub trait Controller {


### PR DESCRIPTION
### Pull Request Overview

This pull request adds the hardware driver for the external interrupt controller module in sam4l.
Mainly, two files were created and added: chips/sam4l/src/eic.rs and kernel/src/hil/eic.rs.


### Testing Strategy

This pull request was tested by enabling an external interrupt on the user push button (pin PC[24]). Each button press will print a message using debug!().


### TODO or Help Wanted

This pull request still needs further testing on the difference between asynchronous mode and synchronous operations. This pull request still needs further testing on the difference between the level-triggered interrupts and the edge-triggered interrupts. 

We still need to figure out how NMI works with EIC.


### Documentation Updated

- [x] No update is needed at this stage.

### Formatting

- [x] Ran `make formatall`.
