### PR TITLE
doc: add readme for enum_primitive library

### DIFF
--- a/libraries/enum_primitive/README.md
+++ b/libraries/enum_primitive/README.md
@@ -1,0 +1,17 @@
+enum_primitive
+==============
+
+This library is a lightly modified clone of
+[enum_primitive-rs](https://github.com/andersk/enum_primitive-rs), adapted to
+support `no_std`.
+
+For complete documenation please visit
+https://andersk.github.io/enum_primitive-rs/enum_primitive/
+
+
+Status / Why a Copy?
+--------------------
+
+Due to auditability concerns, Tock currently has a policy against linking in
+external code. For a simpler library, the approach taken here was to audit a
+snapshot and include it directly.

--- a/libraries/enum_primitive/README.md
+++ b/libraries/enum_primitive/README.md
@@ -5,7 +5,7 @@ This library is a lightly modified clone of
 [enum_primitive-rs](https://github.com/andersk/enum_primitive-rs), adapted to
 support `no_std`.
 
-For complete documenation please visit
+For complete documentation please visit
 https://andersk.github.io/enum_primitive-rs/enum_primitive/
 
 


### PR DESCRIPTION
### Pull Request Overview

Adds a basic readme for the enum_primitive library. This is really just a pointer to the "real" readme.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
