### PR TITLE
refactor: use MaybeUninit in favor of mem::uninitialized

### DIFF
--- a/libraries/tock-cells/src/lib.rs
+++ b/libraries/tock-cells/src/lib.rs
@@ -1,5 +1,6 @@
 //! Tock Cell types.
 
+#![feature(maybe_uninit)]
 #![feature(const_fn, untagged_unions)]
 #![no_std]
 


### PR DESCRIPTION
### Pull Request Overview

Replace the inner union of the MapCell with `mem::MaybeUninit`


### Testing Strategy

Ran unit tests



### Documentation Updated

- No updates are required.


### Formatting

- [x] Ran `make formatall`.

