### PR TITLE
sam4l: remove legacy TRNG interrupt check

### DIFF
--- a/chips/sam4l/src/trng.rs
+++ b/chips/sam4l/src/trng.rs
@@ -64,9 +64,6 @@ impl Trng<'a> {
     pub fn handle_interrupt(&self) {
         let regs = &*self.regs;
 
-        if !regs.imr.is_set(Interrupt::DATRDY) {
-            return;
-        }
         regs.idr.write(Interrupt::DATRDY::SET);
 
         self.client.map(|client| {


### PR DESCRIPTION
### Pull Request Overview

Remove a legacy check from early Tock design for the TRNG driver.

### Testing Strategy

This pull request was tested by running the `rng` app and the `crc` app, that seeds itself with the RNG.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
