### PR TITLE
nrf5x: timer: make TIMER0 a TimerAlarm

### DIFF
--- a/chips/nrf5x/src/timer.rs
+++ b/chips/nrf5x/src/timer.rs
@@ -265,10 +265,10 @@ pub struct TimerAlarm {
 
 // CC0 is used for capture
 // CC1 is used for compare/interrupts
-const ALARM_CAPTURE: usize = 1;
-const ALARM_COMPARE: usize = 0;
-const ALARM_INTERRUPT_BIT: registers::Field<u32, Inte::Register> = Inte::COMPARE0;
-const ALARM_INTERRUPT_BIT_SET: registers::FieldValue<u32, Inte::Register> = Inte::COMPARE0::SET;
+const ALARM_CAPTURE: usize = 0;
+const ALARM_COMPARE: usize = 1;
+const ALARM_INTERRUPT_BIT: registers::Field<u32, Inte::Register> = Inte::COMPARE1;
+const ALARM_INTERRUPT_BIT_SET: registers::FieldValue<u32, Inte::Register> = Inte::COMPARE1::SET;
 
 impl TimerAlarm {
     const fn new(instance: usize) -> TimerAlarm {


### PR DESCRIPTION
Co-authored-by: dcellucc <daniel.w.cellucci@nasa.gov>

### Pull Request Overview

This pull request is part of #1237. It reconfigures how the timers for the nRF5x chips. Best I can tell this shouldn't have any affect on existing code, but I couldn't tell you why these changes are all necessary to support 802.15.4.


### Testing Strategy
Copied from #1237 


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
