### PR TITLE
tools: add cargo fix script

### DIFF
--- a/tools/run_cargo_fix.sh
+++ b/tools/run_cargo_fix.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+FAIL=0
+
+set -e
+
+# Verify that we're running in the base directory
+if [ ! -x tools/run_cargo_fix.sh ]; then
+	echo ERROR: $0 must be run from the tock repository root.
+	echo ""
+	exit 1
+fi
+
+for f in $(find . | grep Cargo.toml); do
+	pushd $(dirname $f) > /dev/null
+	cargo fix --allow-dirty || let FAIL=FAIL+1
+	popd > /dev/null
+done
+


### PR DESCRIPTION
Runs `cargo fix` on all crates. Useful for updating as rust changes.




### Testing Strategy

I used this when trying to update to a more recent Rust nightly.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
