### PR TITLE
tools: list_boards: limit depth of search

### DIFF
--- a/tools/list_boards.sh
+++ b/tools/list_boards.sh
@@ -2,7 +2,7 @@
 
 # Find boards based on folders with Makefiles
 boards=""
-for b in $(find boards | egrep 'Makefile$'); do
+for b in $(find boards -maxdepth 4 | egrep 'Makefile$'); do
     b1=${b#boards/}
     b2=${b1%/*}
     boards+="$b2 "


### PR DESCRIPTION
Speeds up considerably with a lot of built boards.

Before:

```
time ./tools/list_boards.sh
nordic/nrf52dk
nordic/nrf52840dk
launchxl
hifive1
hail
nucleo_f429zi
acd52832
imix
nucleo_f446re

real	0m0.948s
user	0m0.139s
sys	0m0.861s
```

After:

```
time ./tools/list_boards.sh
nordic/nrf52dk
nordic/nrf52840dk
launchxl
hifive1
hail
nucleo_f429zi
acd52832
imix
nucleo_f446re

real	0m0.016s
user	0m0.006s
sys	0m0.012s
```


### Testing Strategy

This pull request was tested by running the script on my mac.


### TODO or Help Wanted

Would be good to run this on linux.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
