### PR TITLE
Minor `make` updates

### DIFF
--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -151,7 +151,7 @@ release: target/$(TARGET)/release/$(PLATFORM).bin
 # the documentation for all boards.
 .PHONY: show-target
 show-target:
-  $(info $(TARGET))
+	$(info $(TARGET))
 
 # Support rules
 

--- a/tools/run_cargo_fmt.sh
+++ b/tools/run_cargo_fmt.sh
@@ -10,8 +10,8 @@ if [ ! -x tools/run_cargo_fmt.sh ]; then
 fi
 
 # Add the rustfmt component if needed.
-if ! rustup component list | grep 'rustfmt-preview.*(installed)' -q; then
-	rustup component add rustfmt-preview
+if ! rustup component list | grep 'rustfmt.*(installed)' -q; then
+	rustup component add rustfmt
 fi
 
 # Format overwrites changes, which is probably good, but it's nice to see


### PR DESCRIPTION
### Pull Request Overview
Some extra stuff has been printing when running `make`, this fixes that.

- The name of rustfmt has changed, so we were always trying to install it, causing an informative message to be displayed.
- I accidentally used spaces instead of tabs in a makefile, causing an `$(info)` command to run unconditionally.


### Testing Strategy

This pull request was tested by running the relevant commands.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
