### PR TITLE
arch/cortex-m0: Rename `SVC_Handler` to `svc_handler`

### DIFF
--- a/arch/cortex-m0/src/lib.rs
+++ b/arch/cortex-m0/src/lib.rs
@@ -83,8 +83,7 @@ MEXC_RETURN_PSP:
 }
 
 #[naked]
-#[allow(non_snake_case)]
-pub unsafe extern "C" fn SVC_Handler() {
+pub unsafe extern "C" fn svc_handler() {
     asm!(
         "
   ldr r0, EXC_RETURN_MSP


### PR DESCRIPTION
Make name consistent with `cortex-{m3,m4}`.
