### PR TITLE
tock-registers: Turn off certain clippy lints

### DIFF
--- a/libraries/tock-register-interface/src/registers.rs
+++ b/libraries/tock-register-interface/src/registers.rs
@@ -54,6 +54,12 @@
 //! ------
 //! - Shane Leonard <shanel@stanford.edu>
 
+// The register interface uses `+` in a way that is fine for bitfields, but
+// looks unusual (and perhaps problematic) to a linter. We just ignore those
+// lints for this file.
+#![allow(clippy::suspicious_op_assign_impl)]
+#![allow(clippy::suspicious_arithmetic_impl)]
+
 use core::fmt;
 use core::marker::PhantomData;
 use core::ops::{Add, AddAssign, BitAnd, BitOr, Not, Shl, Shr};


### PR DESCRIPTION
### Pull Request Overview

We use `+` for our register interface in a way that clippy finds suspicious. This turns that off so that clippy can proceed to inspect other crates.


### Testing Strategy

This pull request was tested by running `cargo clippy`.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
