### PR TITLE
Remove unneeded `return`s

### DIFF
--- a/capsules/src/analog_comparator.rs
+++ b/capsules/src/analog_comparator.rs
@@ -72,9 +72,9 @@ impl<'a, A: hil::analog_comparator::AnalogComparator> AnalogComparator<'a, A> {
         let chan = self.channels[channel];
         let result = self.analog_comparator.comparison(chan);
 
-        return ReturnCode::SuccessWithValue {
+        ReturnCode::SuccessWithValue {
             value: result as usize,
-        };
+        }
     }
 
     // Start comparing on a channel
@@ -86,7 +86,7 @@ impl<'a, A: hil::analog_comparator::AnalogComparator> AnalogComparator<'a, A> {
         let chan = self.channels[channel];
         let result = self.analog_comparator.start_comparing(chan);
 
-        return result;
+        result
     }
 
     // Stop comparing on a channel
@@ -98,7 +98,7 @@ impl<'a, A: hil::analog_comparator::AnalogComparator> AnalogComparator<'a, A> {
         let chan = self.channels[channel];
         let result = self.analog_comparator.stop_comparing(chan);
 
-        return result;
+        result
     }
 }
 
@@ -129,7 +129,7 @@ impl<'a, A: hil::analog_comparator::AnalogComparator> Driver for AnalogComparato
 
             3 => self.stop_comparing(channel),
 
-            _ => return ReturnCode::ENOSUPPORT,
+            _ => ReturnCode::ENOSUPPORT,
         }
     }
 

--- a/capsules/src/dac.rs
+++ b/capsules/src/dac.rs
@@ -35,7 +35,7 @@ impl Driver for Dac<'a> {
     /// - `2`: Set the output to `data1`, a scaled output value.
     fn command(&self, command_num: usize, data: usize, _: usize, _: AppId) -> ReturnCode {
         match command_num {
-            0 /* check if present */ => return ReturnCode::SUCCESS,
+            0 /* check if present */ => ReturnCode::SUCCESS,
 
             // enable the dac
             1 => self.dac.initialize(),
@@ -43,7 +43,7 @@ impl Driver for Dac<'a> {
             // set the dac output
             2 => self.dac.set_value(data),
 
-            _ => return ReturnCode::ENOSUPPORT,
+            _ => ReturnCode::ENOSUPPORT,
         }
     }
 }

--- a/capsules/src/i2c_master.rs
+++ b/capsules/src/i2c_master.rs
@@ -72,7 +72,7 @@ impl<I: 'static + i2c::I2CMaster> I2CMasterDriver<I> {
                             Cmd::Read => self.i2c.read(addr, buffer, rlen),
                             Cmd::WriteRead => self.i2c.write_read(addr, buffer, wlen, rlen),
                         }
-                        return ReturnCode::SUCCESS;
+                        ReturnCode::SUCCESS
                     });
                     // buffer has not been returned by I2C
                     // i2c_master.rs should not allow us to get here

--- a/capsules/src/net/icmpv6/icmpv6.rs
+++ b/capsules/src/net/icmpv6/icmpv6.rs
@@ -106,11 +106,11 @@ impl ICMP6Header {
     }
 
     pub fn get_len(&self) -> u16 {
-        return self.len;
+        self.len
     }
 
     pub fn get_hdr_size(&self) -> usize {
-        return 8;
+        8
     }
 
     /// Serializes an `ICMP6Header` into a buffer.

--- a/capsules/src/net/sixlowpan/sixlowpan_compression.rs
+++ b/capsules/src/net/sixlowpan/sixlowpan_compression.rs
@@ -544,7 +544,7 @@ fn compress_udp_ports(udp_header: &UDPHeader, buf: &mut [u8], written: &mut usiz
         //buf[*written..*written + 4].copy_from_slice(&udp_header[0..4]);
         *written += 4;
     }
-    return udp_port_nhc;
+    udp_port_nhc
 }
 
 // NOTE: We currently only support (or intend to support) carrying the UDP
@@ -878,7 +878,7 @@ fn decompress_nh(iphc_header: u8, buf: &[u8], consumed: &mut usize) -> (bool, u8
         next_header = buf[*consumed];
         *consumed += 1;
     }
-    return (is_nhc, next_header);
+    (is_nhc, next_header)
 }
 
 fn decompress_hl(

--- a/capsules/src/net/udp/driver.rs
+++ b/capsules/src/net/udp/driver.rs
@@ -530,15 +530,15 @@ impl<'a> Driver for UDPDriver<'a> {
                             });
                         }
                         if addr_already_bound {
-                            return ReturnCode::EBUSY;
+                            ReturnCode::EBUSY
                         } else {
                             requested_addr_opt = Some(requested_addr);
                             // If this point is reached, the requested addr is free and valid
                             app.bound_port = requested_addr_opt;
-                            return ReturnCode::SUCCESS;
+                            ReturnCode::SUCCESS
                         }
                     } else {
-                        return ReturnCode::EINVAL;
+                        ReturnCode::EINVAL
                     }
                 })
             }

--- a/capsules/src/rf233.rs
+++ b/capsules/src/rf233.rs
@@ -246,31 +246,31 @@ fn setting_to_power(setting: u8) -> i8 {
 
 fn power_to_setting(power: i8) -> u8 {
     if (power >= 4) {
-        return 0x00;
+        0x00
     } else if (power >= 3) {
-        return 0x03;
+        0x03
     } else if (power >= 2) {
-        return 0x05;
+        0x05
     } else if (power >= 1) {
-        return 0x06;
+        0x06
     } else if (power >= 0) {
-        return 0x07;
+        0x07
     } else if (power >= -1) {
-        return 0x08;
+        0x08
     } else if (power >= -2) {
-        return 0x09;
+        0x09
     } else if (power >= -3) {
-        return 0x0A;
+        0x0A
     } else if (power >= -4) {
-        return 0x0B;
+        0x0B
     } else if (power >= -6) {
-        return 0x0C;
+        0x0C
     } else if (power >= -8) {
-        return 0x0D;
+        0x0D
     } else if (power >= -12) {
-        return 0x0E;
+        0x0E
     } else {
-        return 0x0F;
+        0x0F
     }
 }
 

--- a/capsules/src/test/aes_ccm.rs
+++ b/capsules/src/test/aes_ccm.rs
@@ -75,7 +75,7 @@ impl<A: AES128CCM<'a>> Test<'a, A> {
                 return false;
             }
         }
-        return true;
+        true
     }
 
     fn trigger_test(&self) {

--- a/chips/sam4l/src/acifc.rs
+++ b/chips/sam4l/src/acifc.rs
@@ -478,7 +478,7 @@ impl<'a> analog_comparator::AnalogComparator for Acifc<'a> {
             self.disable();
             panic!("PANIC! Please choose a comparator (value of ac) that this chip supports");
         }
-        return result;
+        result
     }
 
     /// Start interrupt-based comparisons
@@ -489,24 +489,24 @@ impl<'a> analog_comparator::AnalogComparator for Acifc<'a> {
         if channel.chan_num == 0 {
             // Enable interrupts.
             regs.ier.write(Interrupt::ACINT0::SET);
-            return ReturnCode::SUCCESS;
+            ReturnCode::SUCCESS
         } else if channel.chan_num == 1 {
             // Repeat the same for ac == 1
             regs.ier.write(Interrupt::ACINT1::SET);
-            return ReturnCode::SUCCESS;
+            ReturnCode::SUCCESS
         } else if channel.chan_num == 2 {
             // Repeat the same for ac == 2
             regs.ier.write(Interrupt::ACINT2::SET);
-            return ReturnCode::SUCCESS;
+            ReturnCode::SUCCESS
         } else if channel.chan_num == 3 {
             // Repeat the same for ac == 3
             regs.ier.write(Interrupt::ACINT3::SET);
-            return ReturnCode::SUCCESS;
+            ReturnCode::SUCCESS
         } else {
             // Should never get here, just making sure
             self.disable();
             debug!("Please choose a comparator (value of ac) that this chip supports");
-            return ReturnCode::EINVAL;
+            ReturnCode::EINVAL
         }
     }
 
@@ -517,24 +517,24 @@ impl<'a> analog_comparator::AnalogComparator for Acifc<'a> {
         if channel.chan_num == 0 {
             // Disable interrupts.
             regs.ier.write(Interrupt::ACINT0::CLEAR);
-            return ReturnCode::SUCCESS;
+            ReturnCode::SUCCESS
         } else if channel.chan_num == 1 {
             // Repeat the same for ac == 1
             regs.ier.write(Interrupt::ACINT1::CLEAR);
-            return ReturnCode::SUCCESS;
+            ReturnCode::SUCCESS
         } else if channel.chan_num == 2 {
             // Repeat the same for ac == 2
             regs.ier.write(Interrupt::ACINT2::CLEAR);
-            return ReturnCode::SUCCESS;
+            ReturnCode::SUCCESS
         } else if channel.chan_num == 3 {
             // Repeat the same for ac == 3
             regs.ier.write(Interrupt::ACINT3::CLEAR);
-            return ReturnCode::SUCCESS;
+            ReturnCode::SUCCESS
         } else {
             // Should never get here, just making sure
             self.disable();
             debug!("Please choose a comparator (value of ac) that this chip supports");
-            return ReturnCode::EINVAL;
+            ReturnCode::EINVAL
         }
     }
 }

--- a/chips/sam4l/src/adc.rs
+++ b/chips/sam4l/src/adc.rs
@@ -620,7 +620,7 @@ impl hil::adc::Adc for Adc {
         let res = self.config_and_enable(1000);
 
         if res != ReturnCode::SUCCESS {
-            return res;
+            res
         } else if !self.enabled.get() {
             ReturnCode::EOFF
         } else if self.active.get() {
@@ -670,7 +670,7 @@ impl hil::adc::Adc for Adc {
         let res = self.config_and_enable(frequency);
 
         if res != ReturnCode::SUCCESS {
-            return res;
+            res
         } else if !self.enabled.get() {
             ReturnCode::EOFF
         } else if self.active.get() {
@@ -851,7 +851,7 @@ impl hil::adc::AdcHighSpeed for Adc {
         let res = self.config_and_enable(frequency);
 
         if res != ReturnCode::SUCCESS {
-            return (res, Some(buffer1), Some(buffer2));
+            (res, Some(buffer1), Some(buffer2))
         } else if !self.enabled.get() {
             (ReturnCode::EOFF, Some(buffer1), Some(buffer2))
         } else if self.active.get() {

--- a/chips/sam4l/src/bscif.rs
+++ b/chips/sam4l/src/bscif.rs
@@ -350,7 +350,7 @@ pub fn enable_rc32k() {
 }
 
 pub fn rc32k_enabled() -> bool {
-    return BSCIF.rc32kcr.is_set(RC32Control::EN);
+    BSCIF.rc32kcr.is_set(RC32Control::EN)
 }
 
 pub fn setup_rc_1mhz() {

--- a/chips/sam4l/src/crccu.rs
+++ b/chips/sam4l/src/crccu.rs
@@ -302,7 +302,7 @@ impl Crccu<'a> {
         let t = s % 512;
         let u = 512 - t;
         let d = s + u;
-        return d as *mut Descriptor;
+        d as *mut Descriptor
     }
 
     /// Handle an interrupt from the CRCCU
@@ -393,7 +393,7 @@ impl crc::CRC for Crccu<'a> {
         // Enable DMA channel
         regs.dmaen.write(DmaEnable::DMAEN::SET);
 
-        return ReturnCode::SUCCESS;
+        ReturnCode::SUCCESS
     }
 
     fn disable(&self) {

--- a/chips/sam4l/src/usart.rs
+++ b/chips/sam4l/src/usart.rs
@@ -1031,7 +1031,7 @@ impl spi::SpiMaster for USART<'a> {
     }
 
     fn is_busy(&self) -> bool {
-        return false;
+        false
     }
 
     fn read_write_bytes(

--- a/kernel/src/common/ring_buffer.rs
+++ b/kernel/src/common/ring_buffer.rs
@@ -41,11 +41,11 @@ impl<T: Copy> queue::Queue<T> for RingBuffer<'a, T> {
     fn enqueue(&mut self, val: T) -> bool {
         if ((self.tail + 1) % self.ring.len()) == self.head {
             // Incrementing tail will overwrite head
-            return false;
+            false
         } else {
             self.ring[self.tail] = val;
             self.tail = (self.tail + 1) % self.ring.len();
-            return true;
+            true
         }
     }
 

--- a/kernel/src/ipc.rs
+++ b/kernel/src/ipc.rs
@@ -208,8 +208,7 @@ impl Driver for IPC {
 
             return ReturnCode::EINVAL; /* AppSlice must have non-zero length */
         }
-        return self
-            .data
+        self.data
             .enter(appid, |data, _| {
                 data.shared_memory
                     .get_mut(target_id - 1)
@@ -219,6 +218,6 @@ impl Driver for IPC {
                     })
                     .unwrap_or(ReturnCode::EINVAL) /* Target process does not exist */
             })
-            .unwrap_or(ReturnCode::EBUSY);
+            .unwrap_or(ReturnCode::EBUSY)
     }
 }


### PR DESCRIPTION
This is basically the changes recommended by using the `clippy::needless_return` lint.

I think this is a pretty clear code consistency improvement, since we mostly omit the `return` when it is not needed.



### Testing Strategy

This pull request was tested by ensuring travis passes.


### TODO or Help Wanted

n/a

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
