### PR TITLE
Remove unneeded pass by reference

### DIFF
--- a/capsules/src/ieee802154/driver.rs
+++ b/capsules/src/ieee802154/driver.rs
@@ -812,7 +812,7 @@ impl device::TxClient for RadioDriver<'a> {
 
 /// Encode two PAN IDs into a single usize.
 #[inline]
-fn encode_pans(dst_pan: &Option<PanID>, src_pan: &Option<PanID>) -> usize {
+fn encode_pans(dst_pan: Option<PanID>, src_pan: Option<PanID>) -> usize {
     ((dst_pan.unwrap_or(0) as usize) << 16) | (src_pan.unwrap_or(0) as usize)
 }
 
@@ -839,7 +839,7 @@ impl device::RxClient for RadioDriver<'a> {
                 rbuf[1] = data_len as u8;
 
                 // Encode useful parts of the header in 3 usizes
-                let pans = encode_pans(&header.dst_pan, &header.src_pan);
+                let pans = encode_pans(header.dst_pan, header.src_pan);
                 let dst_addr = encode_address(&header.dst_addr);
                 let src_addr = encode_address(&header.src_addr);
                 app.rx_callback

--- a/capsules/src/ieee802154/framer.rs
+++ b/capsules/src/ieee802154/framer.rs
@@ -195,7 +195,7 @@ impl FrameInfo {
     }
 }
 
-fn get_ccm_nonce(device_addr: &[u8; 8], frame_counter: u32, level: SecurityLevel) -> [u8; 13] {
+fn get_ccm_nonce(device_addr: [u8; 8], frame_counter: u32, level: SecurityLevel) -> [u8; 13] {
     let mut nonce = [0u8; 13];
     let encode_ccm_nonce = |buf: &mut [u8]| {
         let off = enc_consume!(buf; encode_bytes, device_addr.as_ref());
@@ -442,7 +442,7 @@ impl<M: Mac, A: AES128CCM<'a>> Framer<'a, M, A> {
                         };
 
                         // Compute ccm nonce
-                        let nonce = get_ccm_nonce(&device_addr, frame_counter, security.level);
+                        let nonce = get_ccm_nonce(device_addr, frame_counter, security.level);
 
                         Some(FrameInfo {
                             frame_type: header.frame_type,
@@ -706,7 +706,7 @@ impl<M: Mac, A: AES128CCM<'a>> MacDevice<'a> for Framer<'a, M, A> {
             self.lookup_key(level, key_id).map(|key| {
                 // TODO: lookup frame counter for device
                 let frame_counter = 0;
-                let nonce = get_ccm_nonce(&src_addr_long, frame_counter, level);
+                let nonce = get_ccm_nonce(src_addr_long, frame_counter, level);
                 (
                     Security {
                         level: level,

--- a/capsules/src/net/ieee802154.rs
+++ b/capsules/src/net/ieee802154.rs
@@ -166,15 +166,15 @@ impl SecurityLevel {
         }
     }
 
-    pub fn encryption_needed(&self) -> bool {
-        match *self {
+    pub fn encryption_needed(self) -> bool {
+        match self {
             SecurityLevel::EncMic32 | SecurityLevel::EncMic64 | SecurityLevel::EncMic128 => true,
             _ => false,
         }
     }
 
-    pub fn mic_len(&self) -> usize {
-        match *self {
+    pub fn mic_len(self) -> usize {
+        match self {
             SecurityLevel::Mic32 | SecurityLevel::EncMic32 => 4,
             SecurityLevel::Mic64 | SecurityLevel::EncMic64 => 8,
             SecurityLevel::Mic128 | SecurityLevel::EncMic128 => 16,

--- a/capsules/src/net/ipv6/ip_utils.rs
+++ b/capsules/src/net/ipv6/ip_utils.rs
@@ -115,7 +115,7 @@ impl IPAddr {
 
 pub fn compute_udp_checksum(
     ip6_header: &IP6Header,
-    udp_header: &UDPHeader,
+    udp_header: UDPHeader,
     udp_length: u16,
     payload: &[u8],
 ) -> u16 {

--- a/capsules/src/net/ipv6/ipv6.rs
+++ b/capsules/src/net/ipv6/ipv6.rs
@@ -266,7 +266,7 @@ impl IP6Header {
                 let checksum = match UDPHeader::decode(&udp_header).done() {
                     Some((_offset, hdr)) => u16::from_be(compute_udp_checksum(
                         &self,
-                        &hdr,
+                        hdr,
                         buf.len() as u16,
                         &buf[UDP_HDR_LEN..],
                     )),
@@ -459,10 +459,10 @@ impl IP6Packet<'a> {
         // using this pseudoheader cksum to set the transport packet cksum
 
         match self.payload.header {
-            TransportHeader::UDP(ref mut udp_header) => {
+            TransportHeader::UDP(mut udp_header) => {
                 let cksum = compute_udp_checksum(
                     &self.header,
-                    &udp_header,
+                    udp_header,
                     udp_header.get_len(),
                     self.payload.payload,
                 );

--- a/capsules/src/net/sixlowpan/sixlowpan_compression.rs
+++ b/capsules/src/net/sixlowpan/sixlowpan_compression.rs
@@ -272,8 +272,8 @@ pub fn compress<'a>(
                 written += 1;
 
                 // Compress ports and checksum
-                nhc_header |= compress_udp_ports(&udp_header, &mut buf, &mut written);
-                nhc_header |= compress_udp_checksum(&udp_header, &mut buf, &mut written);
+                nhc_header |= compress_udp_ports(udp_header, &mut buf, &mut written);
+                nhc_header |= compress_udp_checksum(udp_header, &mut buf, &mut written);
 
                 // Write the UDP LoWPAN_NHC byte
                 buf[udp_nh_offset] = nhc_header;
@@ -509,7 +509,7 @@ fn compress_multicast(
     }
 }
 
-fn compress_udp_ports(udp_header: &UDPHeader, buf: &mut [u8], written: &mut usize) -> u8 {
+fn compress_udp_ports(udp_header: UDPHeader, buf: &mut [u8], written: &mut usize) -> u8 {
     // Need to deal with fields in network byte order when writing directly to buf
     let src_port = udp_header.get_src_port().to_be();
     let dst_port = udp_header.get_dst_port().to_be();
@@ -549,7 +549,7 @@ fn compress_udp_ports(udp_header: &UDPHeader, buf: &mut [u8], written: &mut usiz
 
 // NOTE: We currently only support (or intend to support) carrying the UDP
 // checksum inline.
-fn compress_udp_checksum(udp_header: &UDPHeader, buf: &mut [u8], written: &mut usize) -> u8 {
+fn compress_udp_checksum(udp_header: UDPHeader, buf: &mut [u8], written: &mut usize) -> u8 {
     // get_cksum returns cksum in host byte order
     let cksum = udp_header.get_cksum().to_be();
     buf[*written] = cksum as u8;
@@ -1174,7 +1174,7 @@ fn decompress_udp_checksum(
         match UDPHeader::decode(&udp_header_copy).done() {
             Some((_offset, hdr)) => u16::from_be(compute_udp_checksum(
                 ip6_header,
-                &hdr,
+                hdr,
                 udp_length,
                 &buf[*consumed..],
             )),

--- a/capsules/src/net/udp/udp.rs
+++ b/capsules/src/net/udp/udp.rs
@@ -36,7 +36,7 @@ impl UDPHeader {
         UDPHeader::default()
     }
     // TODO: Always returns size of UDP header
-    pub fn get_offset(&self) -> usize {
+    pub fn get_offset(self) -> usize {
         8
     }
 
@@ -55,23 +55,23 @@ impl UDPHeader {
         self.cksum = cksum.to_be();
     }
 
-    pub fn get_src_port(&self) -> u16 {
+    pub fn get_src_port(self) -> u16 {
         u16::from_be(self.src_port)
     }
 
-    pub fn get_dst_port(&self) -> u16 {
+    pub fn get_dst_port(self) -> u16 {
         u16::from_be(self.dst_port)
     }
 
-    pub fn get_len(&self) -> u16 {
+    pub fn get_len(self) -> u16 {
         u16::from_be(self.len)
     }
 
-    pub fn get_cksum(&self) -> u16 {
+    pub fn get_cksum(self) -> u16 {
         u16::from_be(self.cksum)
     }
 
-    pub fn get_hdr_size(&self) -> usize {
+    pub fn get_hdr_size(self) -> usize {
         // TODO
         8
     }
@@ -87,7 +87,7 @@ impl UDPHeader {
     ///
     /// This function returns the new offset into the buffer wrapped in an
     /// SResult.
-    pub fn encode(&self, buf: &mut [u8], offset: usize) -> SResult<usize> {
+    pub fn encode(self, buf: &mut [u8], offset: usize) -> SResult<usize> {
         stream_len_cond!(buf, self.get_hdr_size() + offset);
 
         let mut off = offset;

--- a/capsules/src/usb.rs
+++ b/capsules/src/usb.rs
@@ -31,7 +31,7 @@ impl SetupData {
     }
 
     /// If the `SetupData` represents a standard device request, return it
-    pub fn get_standard_request(&self) -> Option<StandardDeviceRequest> {
+    pub fn get_standard_request(self) -> Option<StandardDeviceRequest> {
         match self.request_type.request_type() {
             RequestType::Standard => match self.request_code {
                 0 => Some(StandardDeviceRequest::GetStatus {

--- a/chips/sam4l/src/chip.rs
+++ b/chips/sam4l/src/chip.rs
@@ -143,14 +143,14 @@ impl Chip for Sam4l {
                         nvic::TRNG => trng::TRNG.handle_interrupt(),
                         nvic::AESA => aes::AES.handle_interrupt(),
 
-                        nvic::EIC1 => eic::EIC.handle_interrupt(&eic::Line::Ext1),
-                        nvic::EIC2 => eic::EIC.handle_interrupt(&eic::Line::Ext2),
-                        nvic::EIC3 => eic::EIC.handle_interrupt(&eic::Line::Ext3),
-                        nvic::EIC4 => eic::EIC.handle_interrupt(&eic::Line::Ext4),
-                        nvic::EIC5 => eic::EIC.handle_interrupt(&eic::Line::Ext5),
-                        nvic::EIC6 => eic::EIC.handle_interrupt(&eic::Line::Ext6),
-                        nvic::EIC7 => eic::EIC.handle_interrupt(&eic::Line::Ext7),
-                        nvic::EIC8 => eic::EIC.handle_interrupt(&eic::Line::Ext8),
+                        nvic::EIC1 => eic::EIC.handle_interrupt(eic::Line::Ext1),
+                        nvic::EIC2 => eic::EIC.handle_interrupt(eic::Line::Ext2),
+                        nvic::EIC3 => eic::EIC.handle_interrupt(eic::Line::Ext3),
+                        nvic::EIC4 => eic::EIC.handle_interrupt(eic::Line::Ext4),
+                        nvic::EIC5 => eic::EIC.handle_interrupt(eic::Line::Ext5),
+                        nvic::EIC6 => eic::EIC.handle_interrupt(eic::Line::Ext6),
+                        nvic::EIC7 => eic::EIC.handle_interrupt(eic::Line::Ext7),
+                        nvic::EIC8 => eic::EIC.handle_interrupt(eic::Line::Ext8),
 
                         _ => {
                             panic!("unhandled interrupt {}", interrupt);

--- a/kernel/src/hil/eic.rs
+++ b/kernel/src/hil/eic.rs
@@ -27,10 +27,10 @@ pub trait ExternalInterruptController {
     /// Enables external interrupt on the given 'line'
     /// In asychronous mode, all edge interrupts will be
     /// interpreted as level interrupts and the filter is disabled.
-    fn line_enable(&self, line: &Self::Line, interrupt_mode: InterruptMode);
+    fn line_enable(&self, line: Self::Line, interrupt_mode: InterruptMode);
 
     /// Disables external interrupt on the given 'line'
-    fn line_disable(&self, line: &Self::Line);
+    fn line_disable(&self, line: Self::Line);
 }
 
 /// Interface for users of EIC. In order


### PR DESCRIPTION
### Pull Request Overview

There are certain cases where passing by value is better than copy by reference, according to `clippy::trivially_copy_pass_by_ref`. This adds those changes.


https://rust-lang.github.io/rust-clippy/master/index.html#trivially_copy_pass_by_ref

### Testing Strategy

This pull request was tested by travis.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
