### PR TITLE
Remove unneeded `&mut`

### DIFF
--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -470,7 +470,7 @@ pub unsafe fn reset_handler() {
     let adc = static_init!(
         capsules::adc::Adc<'static, sam4l::adc::Adc>,
         capsules::adc::Adc::new(
-            &mut sam4l::adc::ADC0,
+            &sam4l::adc::ADC0,
             adc_channels,
             &mut capsules::adc::ADC_BUFFER1,
             &mut capsules::adc::ADC_BUFFER2,
@@ -519,7 +519,7 @@ pub unsafe fn reset_handler() {
     let crc = static_init!(
         capsules::crc::Crc<'static, sam4l::crccu::Crccu<'static>>,
         capsules::crc::Crc::new(
-            &mut sam4l::crccu::CRCCU,
+            &sam4l::crccu::CRCCU,
             board_kernel.create_grant(&memory_allocation_capability)
         )
     );
@@ -528,7 +528,7 @@ pub unsafe fn reset_handler() {
     // DAC
     let dac = static_init!(
         capsules::dac::Dac<'static>,
-        capsules::dac::Dac::new(&mut sam4l::dac::DAC)
+        capsules::dac::Dac::new(&sam4l::dac::DAC)
     );
 
     // // DEBUG Restart All Apps

--- a/capsules/src/net/sixlowpan/sixlowpan_state.rs
+++ b/capsules/src/net/sixlowpan/sixlowpan_state.rs
@@ -576,7 +576,7 @@ impl TxState<'a> {
             // functionality should be fixed in the future.
             let mut headers = [0 as u8; 60];
             ip6_packet.encode(&mut headers);
-            frame.append_payload(&mut headers[dgram_offset..dgram_offset + headers_to_write]);
+            frame.append_payload(&headers[dgram_offset..dgram_offset + headers_to_write]);
             payload_len -= headers_to_write;
             dgram_offset += headers_to_write;
         }

--- a/chips/sam4l/src/chip.rs
+++ b/chips/sam4l/src/chip.rs
@@ -31,23 +31,23 @@ pub struct Sam4l {
 
 impl Sam4l {
     pub unsafe fn new() -> Sam4l {
-        usart::USART0.set_dma(&mut dma::DMA_CHANNELS[0], &mut dma::DMA_CHANNELS[1]);
+        usart::USART0.set_dma(&dma::DMA_CHANNELS[0], &dma::DMA_CHANNELS[1]);
         dma::DMA_CHANNELS[0].initialize(&mut usart::USART0, dma::DMAWidth::Width8Bit);
         dma::DMA_CHANNELS[1].initialize(&mut usart::USART0, dma::DMAWidth::Width8Bit);
 
-        usart::USART1.set_dma(&mut dma::DMA_CHANNELS[2], &mut dma::DMA_CHANNELS[3]);
+        usart::USART1.set_dma(&dma::DMA_CHANNELS[2], &dma::DMA_CHANNELS[3]);
         dma::DMA_CHANNELS[2].initialize(&mut usart::USART1, dma::DMAWidth::Width8Bit);
         dma::DMA_CHANNELS[3].initialize(&mut usart::USART1, dma::DMAWidth::Width8Bit);
 
-        usart::USART2.set_dma(&mut dma::DMA_CHANNELS[4], &mut dma::DMA_CHANNELS[5]);
+        usart::USART2.set_dma(&dma::DMA_CHANNELS[4], &dma::DMA_CHANNELS[5]);
         dma::DMA_CHANNELS[4].initialize(&mut usart::USART2, dma::DMAWidth::Width8Bit);
         dma::DMA_CHANNELS[5].initialize(&mut usart::USART2, dma::DMAWidth::Width8Bit);
 
-        usart::USART3.set_dma(&mut dma::DMA_CHANNELS[6], &mut dma::DMA_CHANNELS[7]);
+        usart::USART3.set_dma(&dma::DMA_CHANNELS[6], &dma::DMA_CHANNELS[7]);
         dma::DMA_CHANNELS[6].initialize(&mut usart::USART3, dma::DMAWidth::Width8Bit);
         dma::DMA_CHANNELS[7].initialize(&mut usart::USART3, dma::DMAWidth::Width8Bit);
 
-        spi::SPI.set_dma(&mut dma::DMA_CHANNELS[8], &mut dma::DMA_CHANNELS[9]);
+        spi::SPI.set_dma(&dma::DMA_CHANNELS[8], &dma::DMA_CHANNELS[9]);
         dma::DMA_CHANNELS[8].initialize(&mut spi::SPI, dma::DMAWidth::Width8Bit);
         dma::DMA_CHANNELS[9].initialize(&mut spi::SPI, dma::DMAWidth::Width8Bit);
 


### PR DESCRIPTION
### Pull Request Overview

The `clippy::unnecessary_mut_passed` lint finds cases where `&mut` isn't needed. Seems better to not unnecessarily mark something mutable that doesn't need to be.


### Testing Strategy

This pull request was tested by travis.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
