### PR TITLE
clippy::option_map_unwrap_or

### DIFF
--- a/capsules/src/ieee802154/driver.rs
+++ b/capsules/src/ieee802154/driver.rs
@@ -445,8 +445,9 @@ impl RadioDriver<'a> {
                     .app_write
                     .take()
                     .as_ref()
-                    .map(|payload| frame.append_payload(payload.as_ref()))
-                    .unwrap_or(ReturnCode::EINVAL);
+                    .map_or(ReturnCode::EINVAL, |payload| {
+                        frame.append_payload(payload.as_ref())
+                    });
                 if result != ReturnCode::SUCCESS {
                     return result;
                 }
@@ -481,7 +482,7 @@ impl RadioDriver<'a> {
     #[inline]
     fn do_next_tx_sync(&self, new_appid: AppId) -> ReturnCode {
         self.get_next_tx_if_idle()
-            .map(|appid| {
+            .map_or(ReturnCode::SUCCESS, |appid| {
                 if appid == new_appid {
                     self.perform_tx_sync(appid)
                 } else {
@@ -489,7 +490,6 @@ impl RadioDriver<'a> {
                     ReturnCode::SUCCESS
                 }
             })
-            .unwrap_or(ReturnCode::SUCCESS)
     }
 }
 
@@ -750,8 +750,9 @@ impl Driver for RadioDriver<'a> {
                 KeyDescriptor::decode(cfg)
                     .done()
                     .and_then(|(_, new_key)| self.add_key(new_key))
-                    .map(|index| ReturnCode::SuccessWithValue { value: index + 1 })
-                    .unwrap_or(ReturnCode::EINVAL)
+                    .map_or(ReturnCode::EINVAL, |index| ReturnCode::SuccessWithValue {
+                        value: index + 1,
+                    })
             }),
             25 => self.remove_key(arg1),
             26 => {

--- a/capsules/src/net/udp/driver.rs
+++ b/capsules/src/net/udp/driver.rs
@@ -273,7 +273,7 @@ impl<'a> UDPDriver<'a> {
     #[inline]
     fn do_next_tx_immediate(&self, new_appid: AppId) -> ReturnCode {
         self.get_next_tx_if_idle()
-            .map(|appid| {
+            .map_or(ReturnCode::SUCCESS, |appid| {
                 if appid == new_appid {
                     let sync_result = self.perform_tx_sync(appid);
                     if sync_result == ReturnCode::SUCCESS {
@@ -285,7 +285,6 @@ impl<'a> UDPDriver<'a> {
                     ReturnCode::SUCCESS
                 }
             })
-            .unwrap_or(ReturnCode::SUCCESS)
     }
 
     #[inline]


### PR DESCRIPTION
### Pull Request Overview

Not the best diff, but this replaces `.map(...).unwrap_or()` with `.map_or()`, which is more widely used in Tock.


### Testing Strategy

This pull request was tested by travis.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
