### PR TITLE
Question: do we want to use shorter operation style?

### DIFF
--- a/capsules/src/adc.rs
+++ b/capsules/src/adc.rs
@@ -694,7 +694,7 @@ impl<A: hil::adc::Adc + hil::adc::AdcHighSpeed> hil::adc::HighSpeedClient for Ad
                             let mut val = sample;
                             for byte in chunk.iter_mut() {
                                 *byte = (val & 0xFF) as u8;
-                                val = val >> 8;
+                                val >>= 8;
                             }
                         }
 

--- a/capsules/src/net/ipv6/ip_utils.rs
+++ b/capsules/src/net/ipv6/ip_utils.rs
@@ -176,7 +176,7 @@ pub fn compute_udp_checksum(
 
     //Finally, flip all bits
     sum = !sum;
-    sum = sum & 65535; //Remove upper 16 bits (which should be FFFF after flip)
+    sum &= 65535; //Remove upper 16 bits (which should be FFFF after flip)
     (sum as u16) //Return result as u16 in host byte order */
 }
 
@@ -219,7 +219,7 @@ pub fn compute_icmp_checksum(
     }
 
     sum = !sum;
-    sum = sum & 0xffff;
+    sum &= 0xffff;
 
     sum as u16
 }

--- a/capsules/src/rng.rs
+++ b/capsules/src/rng.rs
@@ -331,7 +331,7 @@ impl entropy::Client8 for Entropy8To32<'a> {
                             let current = self.bytes.get();
                             let bits = val as u32;
                             let result = current | (bits << (8 * count));
-                            count = count + 1;
+                            count += 1;
                             self.count.set(count);
                             self.bytes.set(result)
                         }

--- a/capsules/src/test/rng.rs
+++ b/capsules/src/test/rng.rs
@@ -75,7 +75,7 @@ impl<'a> rng::Client for TestRng<'a> {
             let mut pool = self.pool.get();
             let mut count = self.count.get();
             pool[count] = data;
-            count = count + 1;
+            count += 1;
             self.pool.set(pool);
             self.count.set(count);
 
@@ -138,7 +138,7 @@ impl<'a> entropy::Client32 for TestEntropy32<'a> {
             let mut pool = self.pool.get();
             let mut count = self.count.get();
             pool[count] = data;
-            count = count + 1;
+            count += 1;
             self.pool.set(pool);
             self.count.set(count);
 
@@ -201,7 +201,7 @@ impl<'a> entropy::Client8 for TestEntropy8<'a> {
             let mut pool = self.pool.get();
             let mut count = self.count.get();
             pool[count] = data;
-            count = count + 1;
+            count += 1;
             self.pool.set(pool);
             self.count.set(count);
 

--- a/capsules/src/tsl2561.rs
+++ b/capsules/src/tsl2561.rs
@@ -261,7 +261,7 @@ impl TSL2561<'a> {
                                                    // let mut ch_scale: usize = 1 << CH_SCALE; // Default
 
         // Scale if gain is NOT 16X
-        ch_scale = ch_scale << 4; // scale 1X to 16X
+        ch_scale <<= 4; // scale 1X to 16X
 
         // scale the channel values
         let channel0 = (chan0 as usize * ch_scale) >> CH_SCALE;

--- a/chips/sam4l/src/lib.rs
+++ b/chips/sam4l/src/lib.rs
@@ -48,7 +48,7 @@ unsafe extern "C" fn unhandled_interrupt() {
     :
     );
 
-    interrupt_number = interrupt_number & 0x1ff;
+    interrupt_number &= 0x1ff;
 
     panic!("Unhandled Interrupt. ISR {} is active.", interrupt_number);
 }


### PR DESCRIPTION
### Pull Request Overview

This pull request changes instances of `a = a + 1` to `a += 1`. I think it is reasonable to use a constant style here, but I wanted to see what people think.

https://rust-lang.github.io/rust-clippy/master/index.html#assign_op_pattern

### Testing Strategy

This pull request was tested by travis.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
