### PR TITLE
kernel: process/hdr: no clippy::cast_ptr_alignment

### DIFF
--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -796,6 +796,7 @@ impl<C: Chip> ProcessType for Process<'a, C> {
 
     unsafe fn free(&self, _: *mut u8) {}
 
+    #[allow(clippy::cast_ptr_alignment)]
     unsafe fn grant_ptr(&self, grant_num: usize) -> *mut *mut u8 {
         let grant_num = grant_num as isize;
         (self.mem_end() as *mut *mut u8).offset(-(grant_num + 1))
@@ -1062,6 +1063,7 @@ impl<C: Chip> ProcessType for Process<'a, C> {
 }
 
 impl<C: 'static + Chip> Process<'a, C> {
+    #[allow(clippy::cast_ptr_alignment)]
     crate unsafe fn create(
         kernel: &'static Kernel,
         chip: &'static C,
@@ -1280,6 +1282,7 @@ impl<C: 'static + Chip> Process<'a, C> {
         (None, 0, 0)
     }
 
+    #[allow(clippy::cast_ptr_alignment)]
     fn sp(&self) -> *const usize {
         self.current_stack_pointer.get() as *const usize
     }
@@ -1298,6 +1301,7 @@ impl<C: 'static + Chip> Process<'a, C> {
     }
 
     /// Reset all `grant_ptr`s to NULL.
+    #[allow(clippy::cast_ptr_alignment)]
     unsafe fn grant_ptrs_reset(&self) {
         let grant_ptrs_num = self.kernel.get_grant_count_and_finalize();
         for grant_num in 0..grant_ptrs_num {

--- a/kernel/src/tbfheader.rs
+++ b/kernel/src/tbfheader.rs
@@ -183,6 +183,7 @@ impl TbfHeader {
 /// This function takes a pointer to arbitrary memory and optionally returns a
 /// TBF header struct. This function will validate the header checksum, but does
 /// not perform sanity or security checking on the structure.
+#[allow(clippy::cast_ptr_alignment)]
 crate unsafe fn parse_and_validate_tbf_header(address: *const u8) -> Option<TbfHeader> {
     let version = *(address as *const u16);
 


### PR DESCRIPTION
### Pull Request Overview

This pull request adds some clippy flags in the kernel to turn off errors for potentially misaligned pointers. This lint is by default an error, so we have to either change the pointers (not sure that is possible) or disable the lint for these two files.

https://rust-lang.github.io/rust-clippy/master/index.html#cast_ptr_alignment


### Testing Strategy

This pull request was tested by travis.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
