### PR TITLE
kernel: use .add(), not .offset(x as isize)

### DIFF
--- a/kernel/src/debug.rs
+++ b/kernel/src/debug.rs
@@ -593,7 +593,7 @@ pub unsafe fn flush<W: Write>(writer: &mut W) {
             );
 
             if tail > head {
-                let start = buffer.as_mut_ptr().offset(tail as isize);
+                let start = buffer.as_mut_ptr().add(tail);
                 let len = buffer.len();
                 let slice = slice::from_raw_parts(start, len);
                 let s = str::from_utf8_unchecked(slice);
@@ -601,7 +601,7 @@ pub unsafe fn flush<W: Write>(writer: &mut W) {
                 tail = 0;
             }
             if tail != head {
-                let start = buffer.as_mut_ptr().offset(tail as isize);
+                let start = buffer.as_mut_ptr().add(tail);
                 let len = head - tail;
                 let slice = slice::from_raw_parts(start, len);
                 let s = str::from_utf8_unchecked(slice);


### PR DESCRIPTION
### Pull Request Overview

This pull request updates the kernel crate to use `.add()` instead of `.offset()` since we have positive values. This is a little cleaner.


### Testing Strategy

This pull request was tested by travis.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
