### PR TITLE
arch/cortex-m0: Add `hard_fault_handler`

### DIFF
--- a/arch/cortex-m0/src/lib.rs
+++ b/arch/cortex-m0/src/lib.rs
@@ -1,4 +1,8 @@
-#![feature(asm, const_fn, naked_functions)]
+//! Shared implementations for ARM Cortex-M0 MCUs.
+
+#![crate_name = "cortexm0"]
+#![crate_type = "rlib"]
+#![feature(asm, const_fn, core_intrinsics, naked_functions)]
 #![no_std]
 
 // Re-export the base generic cortex-m functions here as they are
@@ -7,6 +11,18 @@ pub use cortexm::support;
 
 pub use cortexm::nvic;
 pub use cortexm::syscall;
+
+extern "C" {
+    // _estack is not really a function, but it makes the types work
+    // You should never actually invoke it!!
+    fn _estack();
+    static mut _sstack: u32;
+    static mut _szero: u32;
+    static mut _ezero: u32;
+    static mut _etext: u32;
+    static mut _srelocate: u32;
+    static mut _erelocate: u32;
+}
 
 #[cfg(not(target_os = "none"))]
 pub unsafe extern "C" fn generic_isr() {}
@@ -154,4 +170,137 @@ pub unsafe extern "C" fn switch_to_user(
     : "{r0}"(user_stack), "{r1}"(process_regs)
     : "r4","r5","r6","r7","r8","r9","r10","r11" : "volatile" );
     user_stack as *mut u8
+}
+
+struct HardFaultStackedRegisters {
+    r0: u32,
+    r1: u32,
+    r2: u32,
+    r3: u32,
+    r12: u32,
+    lr: u32,
+    pc: u32,
+    xpsr: u32,
+}
+
+#[inline(never)]
+unsafe fn kernel_hardfault(faulting_stack: *mut u32) {
+    use core::intrinsics::offset;
+
+    let hardfault_stacked_registers = HardFaultStackedRegisters {
+        r0: *offset(faulting_stack, 0),
+        r1: *offset(faulting_stack, 1),
+        r2: *offset(faulting_stack, 2),
+        r3: *offset(faulting_stack, 3),
+        r12: *offset(faulting_stack, 4),
+        lr: *offset(faulting_stack, 5),
+        pc: *offset(faulting_stack, 6),
+        xpsr: *offset(faulting_stack, 7),
+    };
+
+    // NOTE: Unlike Cortex-M3, `panic!` does not seem to work
+    //       here. `panic!` seems to be producing wrong `PanicInfo`
+    //       value. Therefore as a workaround, capture the stacked
+    //       registers and invoke a breakpoint.
+    //
+    asm!("
+         bkpt
+1:
+         b 1b
+         "
+         :
+         : "r"(&hardfault_stacked_registers)
+         :
+         : "volatile");
+}
+
+#[naked]
+pub unsafe extern "C" fn hard_fault_handler() {
+    let faulting_stack: *mut u32;
+    let kernel_stack: bool;
+
+    // If `kernel_stack` is non-zero, then hard-fault occurred in
+    // kernel, otherwise the hard-fault occurrend in user.
+    asm!("
+    /*
+     * Will be incremented to 1 when we determine that it was a fault
+     * in the kernel
+     */
+    movs r1, #0
+    /*
+     * r2 is used for testing and r3 is used to store lr
+     */
+    mov r3, lr
+
+    movs r2, #4
+    tst r3, r2
+    beq _hardfault_msp
+
+_hardfault_psp:
+    mrs r0, psp
+    b _hardfault_exit
+
+_hardfault_msp:
+    mrs r0, msp
+    adds r1, #1
+
+_hardfault_exit:
+    "
+    : "={r0}"(faulting_stack), "={r1}"(kernel_stack)
+    :
+    : "r0", "r1", "r2", "r3"
+    : "volatile"
+    );
+
+    if kernel_stack {
+        kernel_hardfault(faulting_stack);
+    } else {
+        // hard fault occurred in an app, not the kernel. The app should be
+        // marked as in an error state and handled by the kernel
+        asm!("
+             ldr r0, =APP_HARD_FAULT
+             movs r1, #1 /* Fault */
+             str r1, [r0, #0]
+
+             /*
+              * NOTE:
+              * -----
+              *
+              * Even though ARMv6-M SCB and Control registers
+              * are different from ARMv7-M, they are still compatible
+              * with each other. So, we can keep the same code as
+              * ARMv7-M.
+              *
+              * ARMv6-M however has no _privileged_ mode.
+              */
+
+             /* Read the SCB registers. */
+             ldr r0, =SCB_REGISTERS
+             ldr r1, =0xE000ED14
+             ldr r2, [r1, #0] /* CCR */
+             str r2, [r0, #0]
+             ldr r2, [r1, #20] /* CFSR */
+             str r2, [r0, #4]
+             ldr r2, [r1, #24] /* HFSR */
+             str r2, [r0, #8]
+             ldr r2, [r1, #32] /* MMFAR */
+             str r2, [r0, #12]
+             ldr r2, [r1, #36] /* BFAR */
+             str r2, [r0, #16]
+
+             /* Set thread mode to privileged */
+             movs r0, #0
+             msr CONTROL, r0
+
+             ldr r0, FEXC_RETURN_MSP
+             bx r0
+.align 2
+FEXC_RETURN_MSP:
+  .word 0xFFFFFFF9
+             "
+             :
+             :
+             :
+             : "volatile");
+    }
 }


### PR DESCRIPTION
### Pull Request Overview

Add `hard_fault_hander` for Cortex M0

### Testing Strategy

Tested using the following code to manually trigger hardfault in the kernel.

```
    // Generate a hard fault
    asm!(
        "ldr r0, HF_VAL
         ldr r1, [r0, #0]
         nop

.align 2
HF_VAL:
  .word 0xFFFFFFFF
        "
        :
        :
        : "r0", "r1"
        : "volatile");
```