### PR TITLE
kernel/common: Export `RegisterLongName` for use in chip crate

### DIFF
--- a/kernel/src/common/mod.rs
+++ b/kernel/src/common/mod.rs
@@ -9,6 +9,7 @@
 /// Re-export the tock-register-interface library.
 pub mod registers {
     pub use tock_registers::register_bitfields;
+    pub use tock_registers::registers::RegisterLongName;
     pub use tock_registers::registers::{Field, FieldValue, LocalRegisterCopy};
     pub use tock_registers::registers::{ReadOnly, ReadWrite, WriteOnly};
 }


### PR DESCRIPTION
Having `RegisterLongName` trait in chip crates allows us to build generic
`structs` and other types such as

```
struct PeripheralSetClear<T>
where
    T: RegisterLongName,
{
    set: FieldValue<u32, T>,
    clear: FieldValue<u32, T>,
}
```

where `T` can refer to `FieldValues` spread across different registers.

This allows us to capture registers associated with a specific function and
build other data structures on top of it.
