### PR TITLE
When subscribing to a callback, remove all pending function calls for this callback ID

### DIFF
--- a/doc/Syscalls.md
+++ b/doc/Syscalls.md
@@ -84,7 +84,7 @@ In Tock, a process can be in one of three states:
 
 ## Startup
 
-Upon process initialization, a single function call task is added to it's
+Upon process initialization, a single function call task is added to its
 callback queue. The function is determined by the ENTRY point in the process
 TBF header (typically the `_start` symbol) and is passed the following
 arguments in registers `r0` - `r3`:
@@ -150,7 +150,15 @@ None.
 ### 1: Subscribe
 
 Subscribe assigns callback functions to be executed in response to various
-events. A null pointer to a callback disables a previously set callback.
+events.
+
+A callback function is uniquely identified by the pair (`driver`,
+`subscribe_number`), a.k.a. *callback ID*. When calling `subscribe`, if there
+are any pending callbacks for this callback ID, they are removed from the queue
+before the new callback function is bound to the callback ID.
+
+Passing a null pointer callback function disables a previously set callback
+(besides flushing pending callbacks for this callback ID).
 
 ```rust
 subscribe(driver: u32, subscribe_number: u32, callback: u32, userdata: u32) -> ReturnCode as u32

--- a/kernel/src/callback.rs
+++ b/kernel/src/callback.rs
@@ -52,7 +52,7 @@ impl AppId {
     }
 }
 
-/// Type to uniquely identify a callback subscription accross all drivers.
+/// Type to uniquely identify a callback subscription across all drivers.
 ///
 /// This contains the driver number and the subscribe number within the driver.
 #[derive(Copy, Clone, PartialEq, Debug)]

--- a/kernel/src/callback.rs
+++ b/kernel/src/callback.rs
@@ -52,22 +52,35 @@ impl AppId {
     }
 }
 
+#[derive(Copy, Clone, PartialEq, Debug)]
+pub struct CallbackId {
+    pub driver_num: usize,
+    pub subscribe_num: usize,
+}
+
 /// Type for calling a callback in a process.
 ///
 /// This is essentially a wrapper around a function pointer.
 #[derive(Clone, Copy)]
 pub struct Callback {
     app_id: AppId,
+    callback_id: CallbackId,
     appdata: usize,
     fn_ptr: NonNull<*mut ()>,
 }
 
 impl Callback {
-    crate fn new(appid: AppId, appdata: usize, fn_ptr: NonNull<*mut ()>) -> Callback {
+    crate fn new(
+        app_id: AppId,
+        callback_id: CallbackId,
+        appdata: usize,
+        fn_ptr: NonNull<*mut ()>,
+    ) -> Callback {
         Callback {
-            app_id: appid,
-            appdata: appdata,
-            fn_ptr: fn_ptr,
+            app_id,
+            callback_id,
+            appdata,
+            fn_ptr,
         }
     }
 
@@ -84,6 +97,7 @@ impl Callback {
             .kernel
             .process_map_or(false, self.app_id.idx(), |process| {
                 process.enqueue_task(process::Task::FunctionCall(process::FunctionCall {
+                    callback_id: Some(self.callback_id),
                     argument0: r0,
                     argument1: r1,
                     argument2: r2,

--- a/kernel/src/callback.rs
+++ b/kernel/src/callback.rs
@@ -52,6 +52,9 @@ impl AppId {
     }
 }
 
+/// Type to uniquely identify a callback subscription accross all drivers.
+///
+/// This contains the driver number and the subscribe number within the driver.
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub struct CallbackId {
     pub driver_num: usize,
@@ -97,7 +100,7 @@ impl Callback {
             .kernel
             .process_map_or(false, self.app_id.idx(), |process| {
                 process.enqueue_task(process::Task::FunctionCall(process::FunctionCall {
-                    callback_id: Some(self.callback_id),
+                    source: process::FunctionCallSource::Driver(self.callback_id),
                     argument0: r0,
                     argument1: r1,
                     argument2: r2,

--- a/kernel/src/common/queue.rs
+++ b/kernel/src/common/queue.rs
@@ -18,4 +18,9 @@ pub trait Queue<T> {
 
     /// Remove all elements from the ring buffer.
     fn empty(&mut self);
+
+    /// Retains only the elements that satisfy the predicate.
+    fn retain<F>(&mut self, f: F)
+    where
+        F: FnMut(&T) -> bool;
 }

--- a/kernel/src/common/ring_buffer.rs
+++ b/kernel/src/common/ring_buffer.rs
@@ -63,4 +63,29 @@ impl<T: Copy> queue::Queue<T> for RingBuffer<'a, T> {
         self.head = 0;
         self.tail = 0;
     }
+
+    fn retain<F>(&mut self, mut f: F)
+    where
+        F: FnMut(&T) -> bool,
+    {
+        let len = self.ring.len();
+        // Index over the elements before the retain operation.
+        let mut src = self.head;
+        // Index over the retained elements.
+        let mut dst = self.head;
+
+        while src != self.tail {
+            if f(&self.ring[src]) {
+                // When the predicate is true, move the current element to the
+                // destination if needed, and increment the destination index.
+                if src != dst {
+                    self.ring[dst] = self.ring[src];
+                }
+                dst = (dst + 1) % len;
+            }
+            src = (src + 1) % len;
+        }
+
+        self.tail = dst;
+    }
 }

--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -3,7 +3,7 @@
 use core::cell::Cell;
 use core::ptr::NonNull;
 
-use crate::callback::Callback;
+use crate::callback::{Callback, CallbackId};
 use crate::capabilities;
 use crate::common::cells::NumericCellExt;
 use crate::common::dynamic_deferred_call::DynamicDeferredCall;
@@ -297,9 +297,16 @@ impl Kernel {
                                     callback_ptr,
                                     appdata,
                                 } => {
+                                    let callback_id = CallbackId {
+                                        driver_num: driver_number,
+                                        subscribe_num: subdriver_number,
+                                    };
+                                    process.remove_pending_callbacks(callback_id);
+
                                     let callback_ptr = NonNull::new(callback_ptr);
-                                    let callback = callback_ptr
-                                        .map(|ptr| Callback::new(appid, appdata, ptr.cast()));
+                                    let callback = callback_ptr.map(|ptr| {
+                                        Callback::new(appid, callback_id, appdata, ptr.cast())
+                                    });
 
                                     let res =
                                         platform.with_driver(


### PR DESCRIPTION
# Pull Request Overview

This pull request removes all pending callbacks for a given driver_id:subscribe_id from an application's task queue whenever a subscribe syscall is triggered for by this application for driver_id:subscribe_id.
This prevents pending callbacks from being called after the application has unsubscribed or subscribed to a different callback function.


### Testing Strategy

This pull request was tested by running (on a nRF52840-dk board) an example libtock-rs application where the pending callbacks where sometimes called too late on the previous kernel. With the patches, this problem doesn't occur anymore.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
