### PR TITLE
hail: fix typo in board config

### DIFF
--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -450,7 +450,7 @@ pub unsafe fn reset_handler() {
         [(
             static_init!(
                 gpio::InterruptValueWrapper,
-                gpio::InterruptValueWrapper::new(&sam4l::gpio::PC[16])
+                gpio::InterruptValueWrapper::new(&sam4l::gpio::PA[16])
             )
             .finalize(),
             capsules::button::GpioMode::LowWhenPressed


### PR DESCRIPTION
### Pull Request Overview

Fixes a typo in button configuration for hail.


### Testing Strategy

Running `buttons` app

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make formatall`.
