### PR TITLE
Format the list of driver numbers, and use driver::NUM in all capsules.

### DIFF
--- a/capsules/src/buzzer_driver.rs
+++ b/capsules/src/buzzer_driver.rs
@@ -44,7 +44,8 @@ use kernel::hil::time::Frequency;
 use kernel::{AppId, Callback, Driver, Grant, ReturnCode};
 
 /// Syscall driver number.
-pub const DRIVER_NUM: usize = 0x90000;
+use crate::driver;
+pub const DRIVER_NUM: usize = driver::NUM::Buzzer as usize;
 
 /// Standard max buzz time.
 pub const DEFAULT_MAX_BUZZ_TIME_MS: usize = 5000;

--- a/capsules/src/dac.rs
+++ b/capsules/src/dac.rs
@@ -10,7 +10,8 @@
 //! ```
 
 /// Syscall driver number.
-pub const DRIVER_NUM: usize = 0x00000006;
+use crate::driver;
+pub const DRIVER_NUM: usize = driver::NUM::Dac as usize;
 
 use kernel::hil;
 use kernel::{AppId, Driver, ReturnCode};

--- a/capsules/src/driver.rs
+++ b/capsules/src/driver.rs
@@ -5,35 +5,58 @@ enum_from_primitive! {
 #[derive(Debug, PartialEq)]
 // syscall driver numbers
 pub enum NUM {
-    Adc = 0x00000005,
-    Alarm = 0x00000000,
-    AmbientLight = 0x60002,
-    AnalogComparator = 0x00007,
-    AppFlash =  0x50000,
-    BleAdvertising = 0x030000,
-    Button = 0x00000003,
-    Console = 0x00000001,
-    Crc = 0x40002,
-    Dac = 0x00000006,
-    Gpio = 0x00000004,
-    GpioAsync = 0x80003,
-    Humidity= 0x60001,
-    I2cMaster = 0x40006,
-    I2cMasterSlave = 0x20006,
-    Led = 0x2,
-    Lps25hb = 0x70004,
-    Ltc294x = 0x80000,
-    Max17205 = 0x80001,
-    NINEDOF = 0x60004,
-    NvmStorage = 0x50001,
+    // Base
+    Alarm                 = 0x00000,
+    Console               = 0x00001,
+    Led                   = 0x00002,
+    Button                = 0x00003,
+    Gpio                  = 0x00004,
+    Adc                   = 0x00005,
+    Dac                   = 0x00006,
+    AnalogComparator      = 0x00007,
+
+    // Kernel
+    Ipc                   = 0x10000,
+
+    // HW Buses
+    Spi                   = 0x20001,
+    UsbUser               = 0x20005,
+    I2cMasterSlave        = 0x20006,
+
+    // Radio
+    BleAdvertising        = 0x30000,
+    Ieee802154            = 0x30001,
+    Udp                   = 0x30002,
+
+    // Cryptography
+    Rng                   = 0x40001,
+    Crc                   = 0x40002,
+    I2cMaster             = 0x40006,
+
+    // Storage
+    AppFlash              = 0x50000,
+    NvmStorage            = 0x50001,
+    SdCard                = 0x50002,
+
+    // Sensors
+    Temperature           = 0x60000,
+    Humidity              = 0x60001,
+    AmbientLight          = 0x60002,
+    NINEDOF               = 0x60004,
+
+    // Sensor ICs
+    Tsl2561               = 0x70000,
+    Tmp006                = 0x70001,
+    Lps25hb               = 0x70004,
+
+    // Other ICs
+    Ltc294x               = 0x80000,
+    Max17205              = 0x80001,
+    Pca9544a              = 0x80002,
+    GpioAsync             = 0x80003,
     Nrf51822Serialization = 0x80004,
-    Pca9544a = 0x80002,
-    Rng = 0x40001,
-    SdCard = 0x50002,
-    Spi = 0x20001,
-    Temperature = 0x60000,
-    Tmp006 = 0x70001,
-    Tsl2561 = 0x70000,
-    UsbUser = 0x20005,
+
+    // Misc
+    Buzzer                = 0x90000,
 }
 }

--- a/capsules/src/ieee802154/driver.rs
+++ b/capsules/src/ieee802154/driver.rs
@@ -16,7 +16,8 @@ const MAX_NEIGHBORS: usize = 4;
 const MAX_KEYS: usize = 4;
 
 /// Syscall number
-pub const DRIVER_NUM: usize = 0x30001;
+use crate::driver;
+pub const DRIVER_NUM: usize = driver::NUM::Ieee802154 as usize;
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 struct DeviceDescriptor {

--- a/capsules/src/net/udp/driver.rs
+++ b/capsules/src/net/udp/driver.rs
@@ -17,7 +17,8 @@ use core::{cmp, mem};
 use kernel::{debug, AppId, AppSlice, Callback, Driver, Grant, ReturnCode, Shared};
 
 /// Syscall number
-pub const DRIVER_NUM: usize = 0x30002;
+use crate::driver;
+pub const DRIVER_NUM: usize = driver::NUM::Udp as usize;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct UDPEndpoint {

--- a/capsules/src/pca9544a.rs
+++ b/capsules/src/pca9544a.rs
@@ -32,7 +32,8 @@ use kernel::hil::i2c;
 use kernel::{AppId, Callback, Driver, ReturnCode};
 
 /// Syscall driver number.
-pub const DRIVER_NUM: usize = 0x80002;
+use crate::driver;
+pub const DRIVER_NUM: usize = driver::NUM::Pca9544a as usize;
 
 pub static mut BUFFER: [u8; 5] = [0; 5];
 

--- a/capsules/src/tsl2561.rs
+++ b/capsules/src/tsl2561.rs
@@ -20,7 +20,8 @@ use kernel::hil::i2c;
 use kernel::{AppId, Callback, Driver, ReturnCode};
 
 /// Syscall driver number.
-pub const DRIVER_NUM: usize = 0x70000;
+use crate::driver;
+pub const DRIVER_NUM: usize = driver::NUM::Tsl2561 as usize;
 
 // Buffer to use for I2C messages
 pub static mut BUFFER: [u8; 4] = [0; 4];

--- a/capsules/src/usb_user.rs
+++ b/capsules/src/usb_user.rs
@@ -29,7 +29,8 @@ use kernel::hil;
 use kernel::{AppId, Callback, Driver, Grant, ReturnCode};
 
 /// Syscall number
-pub const DRIVER_NUM: usize = 0x20005;
+use crate::driver;
+pub const DRIVER_NUM: usize = driver::NUM::UsbUser as usize;
 
 #[derive(Default)]
 pub struct App {

--- a/kernel/src/ipc.rs
+++ b/kernel/src/ipc.rs
@@ -3,9 +3,6 @@
 //! This is a special syscall driver that allows userspace applications to
 //! share memory.
 
-/// Syscall number
-pub const DRIVER_NUM: usize = 0x00010000;
-
 use crate::callback::{AppId, Callback};
 use crate::capabilities::MemoryAllocationCapability;
 use crate::driver::Driver;
@@ -14,6 +11,9 @@ use crate::mem::{AppSlice, Shared};
 use crate::process;
 use crate::returncode::ReturnCode;
 use crate::sched::Kernel;
+
+/// Syscall number
+pub const DRIVER_NUM: usize = 0x10000;
 
 struct IPCData {
     shared_memory: [Option<AppSlice<Shared, u8>>; 8],


### PR DESCRIPTION
### Pull Request Overview

This pull request formats the `driver::NUM` enum to use a consistent number of digits, ordering drivers by numbers instead of by name. This follows the ordering in categories of `doc/syscalls` and makes it easier to find unallocated driver numbers.

All the capsules now refer to this enumeration as well, so that driver numbers are defined in only one place. (The IPC still redefines a number in the kernel, given that the capsules module depends on the kernel module.)


### Testing Strategy

This pull request was tested by running `make ci-travis` and manually checking that numbers stayed the same


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
