### PR TITLE
boards: linker: add sbss sections

### DIFF
--- a/boards/kernel_layout.ld
+++ b/boards/kernel_layout.ld
@@ -274,7 +274,7 @@ SECTIONS
         . = ALIGN(4);
         _szero = .;
 
-        *(.bss .bss.*)
+        *(.sbss .sbss.* .bss .bss.*);
         *(COMMON)
 
         . = ALIGN(4);

--- a/boards/kernel_layout.ld
+++ b/boards/kernel_layout.ld
@@ -274,6 +274,9 @@ SECTIONS
         . = ALIGN(4);
         _szero = .;
 
+        /* In addition to the traditional .bss section, RISC-V splits out a "small data" section
+         * see: https://github.com/riscv/riscv-pk/blob/a3e4ac61d2b1ff37a22b9193b85d3b94273e80cb/pk/pk.lds#L84
+         */
         *(.sbss .sbss.* .bss .bss.*);
         *(COMMON)
 


### PR DESCRIPTION
The RISC-V linker now creates a .sbss section which if not specified in
the linker file ends up as its own section, which gets placed in the
program binary (even though it should be in RAM). objdump places it at
the start of RAM, resulting in a very large .bin file.

Following the riscv-embedded Rust linker file, this commit adds the
sections in the same location as the .bss sections.

https://github.com/rust-embedded/riscv-rt/blob/2d0a00e6398ce82c528fef371d676c01429961c1/link.x#L69

I also recompiled Hail before and after and the resulting binary is the
same.

### Pull Request Overview

This pull request adds/changes/fixes...


### Testing Strategy

This pull request was tested by...


### TODO or Help Wanted

This pull request still needs...


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make formatall`.
