### PR TITLE
arty e21: remove PMP driver

### DIFF
--- a/chips/arty_e21/Cargo.lock
+++ b/chips/arty_e21/Cargo.lock
@@ -18,10 +18,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "riscv-csr"
+version = "0.1.0"
+dependencies = [
+ "tock-registers 0.3.0",
+]
+
+[[package]]
 name = "rv32i"
 version = "0.1.0"
 dependencies = [
  "kernel 0.1.0",
+ "riscv-csr 0.1.0",
+ "tock-registers 0.3.0",
  "tock_rt0 0.1.0",
 ]
 

--- a/chips/arty_e21/src/chip.rs
+++ b/chips/arty_e21/src/chip.rs
@@ -121,6 +121,13 @@ impl ArtyExx {
 }
 
 impl kernel::Chip for ArtyExx {
+    // While there is initial support for a PMP driver (as of 2019-10-04), it is not
+    // complete, and while it should disable the PMP, it seems to cause some negative
+    // side effects (context switching does not work correctly) on the Arty-E21 platform.
+    //
+    // TODO: implement the PMP driver and add it here `type MPU = rv32i::pmp::PMPConfig;`.
+    //
+    // See https://github.com/tock/tock/pull/1382 for (a little) more information.
     type MPU = ();
     type UserspaceKernelBoundary = rv32i::syscall::SysCall;
     type SysTick = ();

--- a/chips/arty_e21/src/chip.rs
+++ b/chips/arty_e21/src/chip.rs
@@ -14,7 +14,6 @@ extern "C" {
 pub struct ArtyExx {
     userspace_kernel_boundary: rv32i::syscall::SysCall,
     clic: rv32i::clic::Clic,
-    pmp: rv32i::pmp::PMPConfig,
 }
 
 impl ArtyExx {
@@ -27,7 +26,6 @@ impl ArtyExx {
         ArtyExx {
             userspace_kernel_boundary: rv32i::syscall::SysCall::new(),
             clic: rv32i::clic::Clic::new(in_use_interrupts),
-            pmp: rv32i::pmp::PMPConfig::new(4),
         }
     }
 
@@ -123,12 +121,12 @@ impl ArtyExx {
 }
 
 impl kernel::Chip for ArtyExx {
-    type MPU = rv32i::pmp::PMPConfig;
+    type MPU = ();
     type UserspaceKernelBoundary = rv32i::syscall::SysCall;
     type SysTick = ();
 
     fn mpu(&self) -> &Self::MPU {
-        &self.pmp
+        &()
     }
 
     fn systick(&self) -> &Self::SysTick {


### PR DESCRIPTION
For some reason, adding the PMP driver causes userspace to fail on the
E21 core running on the Arty FPGA. I don't know why, but reverting this
change seems to allow userspace to run.

The driver should be added back when someone is able to test on the E21.

Symptoms:
- App is loaded, and the kernel switches to the app.
- The first memop syscall is triggered, and execution switches back to
the kernel.
- When the kernel goes to resume the application a fault occurs. I
believe the `mcause` is set to 1 ("Instruction access fault").
- The app goes into a fault state and the kernel panics.






### Testing Strategy

This pull request was tested by running blink on E21 core on FPGA.


### TODO or Help Wanted

Well the PMP driver should be implemented, but that is beyond this PR.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
