### PR TITLE
Remove incorrect documentation about subscribe returning EINVAL for NULL.

### DIFF
--- a/doc/Syscalls.md
+++ b/doc/Syscalls.md
@@ -180,7 +180,6 @@ arguments.
 
 #### Return
 
- - `EINVAL` if the callback pointer is NULL.
  - `ENODEVICE` if `driver` does not refer to a valid kernel driver.
  - `ENOSUPPORT` if the driver exists but doesn't support the `subscribe_number`.
  - Other return codes based on the specific driver.


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes documentation about the `subscribe` syscall when given a NULL pointer as callback function. Passing NULL disables the callback, as documented in the previous paragraph.
However, no specific error code is returned in that case.

Verified with a quick `grep EINVAL` through the code ; I might have missed something, but that would fall under the "Other return codes based on the specific driver" category.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
