### PR TITLE
Make ieee802154 driver optional in nrf52_base

### DIFF
--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -227,6 +227,7 @@ pub unsafe fn reset_handler() {
             SPI_MX25R6435F_HOLD_PIN,
         )),
         button_pins,
+        true,
         &mut APP_MEMORY,
         &mut PROCESSES,
         FAULT_RESPONSE,

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -276,6 +276,7 @@ pub unsafe fn reset_handler() {
         &SpiPins::new(SPI_MOSI, SPI_MISO, SPI_CLK),
         &None,
         button_pins,
+        false,
         &mut APP_MEMORY,
         &mut PROCESSES,
         FAULT_RESPONSE,


### PR DESCRIPTION
### Pull Request Overview

This pull request makes the ieee802154 driver optional in the NRF52 base board and fixes up the NRF52dk board to _not_ include it, since it doesn't have an 802154 radio.

### Testing Strategy

Ran all the tests for release-1.4, including making sure the 802154 tests "work" (in the sense that they don't crash)

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
