### PR TITLE
Add functional unit tests for the kernel ring buffer.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,9 +53,9 @@ ci-travis:
 	@printf "$$(tput bold)* CI: Syntax *$$(tput sgr0)\n"
 	@printf "$$(tput bold)**************$$(tput sgr0)\n"
 	@CI=true $(MAKE) allcheck
-	@printf "$$(tput bold)****************$$(tput sgr0)\n"
-	@printf "$$(tput bold)* CI: DocTests *$$(tput sgr0)\n"
-	@printf "$$(tput bold)****************$$(tput sgr0)\n"
+	@printf "$$(tput bold)**************$$(tput sgr0)\n"
+	@printf "$$(tput bold)* CI: Kernel *$$(tput sgr0)\n"
+	@printf "$$(tput bold)**************$$(tput sgr0)\n"
 	@cd kernel && CI=true TOCK_KERNEL_VERSION=ci_test cargo test
 	@printf "$$(tput bold)*******************$$(tput sgr0)\n"
 	@printf "$$(tput bold)* CI: Compilation *$$(tput sgr0)\n"

--- a/kernel/src/common/ring_buffer.rs
+++ b/kernel/src/common/ring_buffer.rs
@@ -89,3 +89,118 @@ impl<T: Copy> queue::Queue<T> for RingBuffer<'a, T> {
         self.tail = dst;
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::super::queue::Queue;
+    use super::RingBuffer;
+
+    #[test]
+    fn test_enqueue_dequeue() {
+        const LEN: usize = 10;
+        let mut ring = [0; LEN];
+        let mut buf = RingBuffer::new(&mut ring);
+
+        for _ in 0..2 * LEN {
+            assert!(buf.enqueue(42));
+            assert_eq!(buf.len(), 1);
+            assert!(buf.has_elements());
+
+            assert_eq!(buf.dequeue(), Some(42));
+            assert_eq!(buf.len(), 0);
+            assert!(!buf.has_elements());
+        }
+    }
+
+    // Enqueue integers 1 <= n < len, checking that it succeeds and that the
+    // queue is full at the end.
+    // See std::iota in C++.
+    fn enqueue_iota(buf: &mut RingBuffer<usize>, len: usize) {
+        for i in 1..len {
+            assert!(!buf.is_full());
+            assert!(buf.enqueue(i));
+            assert!(buf.has_elements());
+            assert_eq!(buf.len(), i);
+        }
+
+        assert!(buf.is_full());
+        assert!(!buf.enqueue(0));
+        assert!(buf.has_elements());
+    }
+
+    // Dequeue all elements, expecting integers 1 <= n < len, checking that the
+    // queue is empty at the end.
+    // See std::iota in C++.
+    fn dequeue_iota(buf: &mut RingBuffer<usize>, len: usize) {
+        for i in 1..len {
+            assert!(buf.has_elements());
+            assert_eq!(buf.len(), len - i);
+            assert_eq!(buf.dequeue(), Some(i));
+            assert!(!buf.is_full());
+        }
+
+        assert!(!buf.has_elements());
+        assert_eq!(buf.len(), 0);
+    }
+
+    // Move the head by `count` elements, by enqueueing/dequeueing `count`
+    // times an element.
+    // This assumes an empty queue at the beginning, and yields an empty queue.
+    fn move_head(buf: &mut RingBuffer<usize>, count: usize) {
+        assert!(!buf.has_elements());
+        assert_eq!(buf.len(), 0);
+
+        for _ in 0..count {
+            assert!(buf.enqueue(0));
+            assert_eq!(buf.dequeue(), Some(0));
+        }
+
+        assert!(!buf.has_elements());
+        assert_eq!(buf.len(), 0);
+    }
+
+    #[test]
+    fn test_fill_once() {
+        const LEN: usize = 10;
+        let mut ring = [0; LEN];
+        let mut buf = RingBuffer::new(&mut ring);
+
+        assert!(!buf.has_elements());
+        assert_eq!(buf.len(), 0);
+
+        enqueue_iota(&mut buf, LEN);
+        dequeue_iota(&mut buf, LEN);
+    }
+
+    #[test]
+    fn test_refill() {
+        const LEN: usize = 10;
+        let mut ring = [0; LEN];
+        let mut buf = RingBuffer::new(&mut ring);
+
+        for _ in 0..10 {
+            enqueue_iota(&mut buf, LEN);
+            dequeue_iota(&mut buf, LEN);
+        }
+    }
+
+    #[test]
+    fn test_retain() {
+        const LEN: usize = 10;
+        let mut ring = [0; LEN];
+        let mut buf = RingBuffer::new(&mut ring);
+
+        move_head(&mut buf, LEN - 2);
+        enqueue_iota(&mut buf, LEN);
+
+        buf.retain(|x| x % 2 == 1);
+        assert_eq!(buf.len(), LEN / 2);
+
+        assert_eq!(buf.dequeue(), Some(1));
+        assert_eq!(buf.dequeue(), Some(3));
+        assert_eq!(buf.dequeue(), Some(5));
+        assert_eq!(buf.dequeue(), Some(7));
+        assert_eq!(buf.dequeue(), Some(9));
+        assert_eq!(buf.dequeue(), None);
+    }
+}


### PR DESCRIPTION
### Pull Request Overview

The `make ci-travis` command can already run unit tests, and the ring_buffer module can be compiled on desktop, so let's add functional unit tests.

### Testing Strategy

This pull request was tested by running `make ci-travis` and making sure that the unit tests appear in the output - and pass.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
