### PR TITLE
Add OSX to Travis-CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ cache:
 
 os:
   - linux
+  - osx
 
 # If you change this, you must also change Getting_Started.md, Makefile.common,
 # .vscode/settings.json, and tools/netlify-build.sh.


### PR DESCRIPTION
### Pull Request Overview

This pull request adds OSX to the Travis-CI config. This will help detect CI build failures on OSX machines without waiting for manual testing (see for example https://github.com/tock/tock/pull/1393#issuecomment-539723255).

### Testing Strategy

This pull request was tested by waiting for Travis-CI results.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.