### PR TITLE
Fix typo in net::ipv6::ip_utils documentation.

### DIFF
--- a/capsules/src/net/ipv6/ip_utils.rs
+++ b/capsules/src/net/ipv6/ip_utils.rs
@@ -1,6 +1,6 @@
 //! This file implements various utilities used by the different components
 //! of the IP stack. Note that this file also contains the definition for the
-//! [IPAddr](struct.IPAddr.html] struct and associated helper functions.
+//! [IPAddr](struct.IPAddr.html) struct and associated helper functions.
 
 use crate::net::icmpv6::icmpv6::{ICMP6Header, ICMP6HeaderOptions};
 use crate::net::ieee802154::MacAddress;


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes a typo in net::ipv6::ip_utils documentation. I noticed it in the netlify logs.

### Testing Strategy

This pull request was tested by checking the netlify logs.

### TODO or Help Wanted

Is there a way to convert such logging into CI errors?

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.