### PR TITLE
Imix pin mapping documentation

### DIFF
--- a/boards/imix/README.md
+++ b/boards/imix/README.md
@@ -4,6 +4,29 @@ imix: Platform-Specific Instructions
 This board file is for imix version 2.
 
 
+## Userspace Resource Mapping
+
+This table shows the mappings between resources available in userspace
+and the physical elements on the imix board.
+
+| Software Resource | Physical Element |
+|-------------------|------------------|
+| GPIO[0]           | Pin D2           |
+| GPIO[1]           | Pin D3           |
+| GPIO[2]           | Pin D4           |
+| GPIO[3]           | Pin D5           |
+| GPIO[4]           | Pin D6           |
+| GPIO[5]           | Pin D7           |
+| GPIO[6]           | Pin D8           |
+| ADC[0]            | Pin A0           |
+| ADC[1]            | Pin A1           |
+| ADC[2]            | Pin A2           |
+| ADC[3]            | Pin A3           |
+| ADC[4]            | Pin A4           |
+| ADC[5]            | Pin A5           |
+| Button[0]         | "USER" button    |
+| LED[0]            | "USER" LED       |
+
 ## Flashing the kernel
 
 To program the Tock kernel onto the imix, `cd` into the `boards/imix` directory

--- a/boards/imix/src/components/gpio.rs
+++ b/boards/imix/src/components/gpio.rs
@@ -77,7 +77,7 @@ impl Component for GpioComponent {
                 .finalize(),
                 static_init!(
                     InterruptValueWrapper,
-                    InterruptValueWrapper::new(&sam4l::gpio::PC[20])
+                    InterruptValueWrapper::new(&sam4l::gpio::PA[20])
                 )
                 .finalize(),
             ]


### PR DESCRIPTION
### Pull Request Overview

This pull request adds documentation on how physical pins map to userspace items.

Also, it seems like there was a pin incorrectly mapped in the imix component.


### Testing Strategy

This pull request was tested by...


### TODO or Help Wanted

This pull request still needs...


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
