### PR TITLE
hifive1: Increase stack size to 0x1000

### DIFF
--- a/boards/hifive1/src/main.rs
+++ b/boards/hifive1/src/main.rs
@@ -37,7 +37,7 @@ static mut APP_MEMORY: [u8; 8192] = [0; 8192];
 /// Dummy buffer that causes the linker to reserve enough space for the stack.
 #[no_mangle]
 #[link_section = ".stack_buffer"]
-pub static mut STACK_MEMORY: [u8; 1000] = [0; 1000];
+pub static mut STACK_MEMORY: [u8; 0x1000] = [0; 0x1000];
 
 /// A structure representing this platform that holds references to all
 /// capsules for this platform. We've included an alarm and console.


### PR DESCRIPTION
### Pull Request Overview
The original stack size of 1000 is too small to run basic libtock-rs
apps and handle a panic. Let's increase the stack size to 1K to give
us at least some breathing space.

### Testing Strategy

This pull request was tested by running libtock-rs apps on tock with the QEMU sifive_e machine.

Signed-off-by: Alistair Francis <alistair.francis@wdc.com>

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make formatall`.
