### PR TITLE
turn the "getting started" guide into more of a tutorial

### DIFF
--- a/doc/Getting_Started.md
+++ b/doc/Getting_Started.md
@@ -180,14 +180,16 @@ SUBSYSTEMS=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="374b", \
 ## Installing your first application
 
 A kernel alone isn't much use, as an embedded developer you want to
-see some LEDs blink.  Fortunatety, there is an example `blink` app
+see some LEDs blink.  Fortunately, there is an example `blink` app
 available from the TockOS app repository which `tockloader` can
-download and install (if you are using a Cortex M4 board that is
-supported by `tockloader`).
+download and install (if you are using a board that is supported
+by `tockloader`).
 
-Unlike the makefile in the board directory, `tockloader` cannot know
+For certain boards (e.g. Hail and imix), `tockloader` can read
+attributes from the board to configure how it communicates with the
+board. For many boards, however, `tockloader` cannot know
 which board and communication method you want to use, so you have to
-tell it explicitly, for example:
+tell it explicitly. For example:
 
 ```bash
 $ tockloader install --board nrf52dk --jlink blink
@@ -203,28 +205,33 @@ Finished in 2.567 seconds
 ```
 
 Boards that use `openocd` will of course require the parameter
-`--openocd` instead of `--jlink`.  And if your board has a serial
-bootloader, it is sufficient to tell `tockloader` the board type, it
-will look for the default serial interface (named `tock`) or else ask
-you which interface to use:
+`--openocd` instead of `--jlink`.  If your board has a serial
+bootloader, `tockloader` should work without any additional arguments:
+
+    $ tockloader install blink
+
+However, you can specify the board type manually as well:
 
     $ tockloader install --board imix blink
 
-You can also tell it which serial port to use by passing it a
-parameter like `--port ttyACM0` to use `/dev/ttyACM0`.
+You can also tell it which serial port to use (which is useful if you
+have multiple boards plugged in) by passing it the `--port` parameter
+like `--port /dev/ttyACM0` to use `/dev/ttyACM0`:
 
-If you have another board, try
+    $ tockloader --port /dev/ttyACM0 install blink
+
+To see the list of boards `tockloader` knows about you can run:
 
     $ tockloader list-known-boards
 
 If everything has worked until here, the LEDs on your board should now
 display a binary counter. Congratulations, you have a working TockOS
-installation on your board.
+installation on your board!
 
 ## Compiling applications
 
 The last remaining step is to compile applications locally.
-All user-level code lives in two  separate repositories:
+All user-level code lives in two separate repositories:
 
 - [libtock-c](https://github.com/tock/libtock-c): C and C++ apps.
 - [libtock-rs](https://github.com/tock/libtock-rs): Rust apps.

--- a/doc/Getting_Started.md
+++ b/doc/Getting_Started.md
@@ -9,7 +9,7 @@ developing Tock.
 1. [Rust](http://www.rust-lang.org/)
 2. [rustup](https://rustup.rs/) to install Rust (version >= 1.11.0)
 3. Command line utilities: make
-4. A supported board.
+4. A supported board or QEMU configuration.
 
    If you are just starting to work with TockOS, you should look in
    the [`boards/` subdirectory](../boards/README.md) and choose one of
@@ -145,7 +145,7 @@ most purposes, available distribution packages are sufficient and it can
 be installed with:
 
 ```bash
-(Linux): sudo apt-get install openocd
+(Linux/Debian): sudo apt-get install openocd
 (MacOS): brew install open-ocd
 ```
 


### PR DESCRIPTION
### Pull Request Overview

This pull request rewrites part of the "Getting Started" document to be more of a step-by-step tutorial and fixes some steps that did not (no longer?) work (while the memory from #1402 is still fresh).

### Testing Strategy

I tested all steps that were possible with just an nRF52840-DK. 
I checked that the new links in the document point to the correct targets.

### TODO or Help Wanted

Somebody should check that all steps work for other boards, too, and that the necessary changes are described correctly.

It would be good if a native speaker could proofread the text.

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make formatall`.
