### PR TITLE
nrf52: add nRF52840 support to ficr.rs

### DIFF
--- a/chips/nrf52/src/ficr.rs
+++ b/chips/nrf52/src/ficr.rs
@@ -16,7 +16,10 @@ const FICR_BASE: StaticRef<FicrRegisters> =
 
 /// Struct of the FICR registers
 ///
-/// Section 13.1 of <http://infocenter.nordicsemi.com/pdf/nRF52832_PS_v1.0.pdf>
+/// Section 13.1 of <https://infocenter.nordicsemi.com/pdf/nRF52832_PS_v1.0.pdf>
+/// Section  4.4 of <https://infocenter.nordicsemi.com/pdf/nRF52840_PS_v1.1.pdf>
+/// The structure is identical for the data mapped here, differences start
+/// at address 0x350.
 #[repr(C)]
 struct FicrRegisters {
     /// Reserved
@@ -125,8 +128,10 @@ register_bitfields! [u32,
     /// Part code
     InfoPart [
         PART OFFSET(0) NUMBITS(32) [
-            /// nRF52838
+            /// nRF52832
             N52832 = 0x52832,
+            /// nRF52840
+            N52840 = 0x52840,
             /// Unspecified
             #[allow(overflowing_literals)]
             Unspecified = 0xffffffff
@@ -135,7 +140,8 @@ register_bitfields! [u32,
     /// Part Variant, Hardware version and Production configuration
     InfoVariant [
         /// Part Variant, Hardware version and Production configuration, encoded as ASCII
-        // Note, some of these are not present in datasheet but is in nrf52.svd
+        // Note, some of these are not present in datasheets
+        // but are in nrf52.svd or are observed in the wild
         VARIANT OFFSET(0) NUMBITS(32) [
             /// AAAA
             AAAA = 0x41414141,
@@ -147,8 +153,16 @@ register_bitfields! [u32,
             AABB = 0x41414242,
             /// AAB0
             AAB0 = 0x41414230,
+            /// AACA
+            AACA = 0x41414341,
+            /// AAC0
+            AAC0 = 0x41414330,
             /// AAE0
             AAE0 = 0x41414530,
+            /// BAAA
+            BAAA = 0x42414141,
+            /// CAAA
+            CAAA = 0x43414141,
             /// Unspecified
             #[allow(overflowing_literals)]
             Unspecified = 0xffffffff
@@ -164,6 +178,8 @@ register_bitfields! [u32,
             CH = 0x2001,
             /// CIxx - 7x8 WLCSP 56 balls<
             CI = 0x2002,
+            /// QIxx - 73-pin aQFN
+            QI = 0x2004,
             /// CKxx - 7x8 WLCSP 56 balls with backside coating for light protection
             CK = 0x2005,
             /// Unspecified
@@ -180,6 +196,10 @@ register_bitfields! [u32,
             K32 = 0x20,
             /// 64 kByte RAM
             K64 = 0x40,
+            /// 128 kByte RAM
+            K128 = 0x80,
+            /// 256 kByte RAM
+            K256 = 0x100,
             #[allow(overflowing_literals)]
             Unspecified = 0xffffffff
 
@@ -194,6 +214,10 @@ register_bitfields! [u32,
             K256 = 0x100,
             /// 512 kByte FLASH
             K512 = 0x200,
+            /// 1024 kByte FLASH
+            K1024 = 0x400,
+            /// 2048 kByte FLASH
+            K2048 = 0x800,
             /// Unspecified
             #[allow(overflowing_literals)]
             Unspecified = 0xffffffff
@@ -210,7 +234,11 @@ enum Variant {
     AABA = 0x41414241,
     AABB = 0x41414242,
     AAB0 = 0x41414230,
+    AACA = 0x41414341,
+    AAC0 = 0x41414330,
     AAE0 = 0x41414530,
+    BAAA = 0x42414141,
+    CAAA = 0x43414141,
     Unspecified = 0xffffffff,
 }
 
@@ -218,6 +246,7 @@ enum Variant {
 #[repr(u32)]
 enum Part {
     N52832 = 0x52832,
+    N52840 = 0x52840,
     Unspecified = 0xffffffff,
 }
 
@@ -227,6 +256,7 @@ enum Package {
     QF = 0x2000,
     CH = 0x2001,
     CI = 0x2002,
+    QI = 0x2004,
     CK = 0x2005,
     Unspecified = 0xffffffff,
 }
@@ -237,6 +267,8 @@ enum Ram {
     K16 = 0x10,
     K32 = 0x20,
     K64 = 0x40,
+    K128 = 0x80,
+    K256 = 0x100,
     Unspecified = 0xffffffff,
 }
 
@@ -246,6 +278,8 @@ enum Flash {
     K128 = 0x80,
     K256 = 0x100,
     K512 = 0x200,
+    K1024 = 0x400,
+    K2048 = 0x800,
     Unspecified = 0xffffffff,
 }
 
@@ -264,6 +298,7 @@ impl Ficr {
         let regs = &*self.registers;
         match regs.info_part.get() {
             0x52832 => Part::N52832,
+            0x52840 => Part::N52840,
             _ => Part::Unspecified,
         }
     }
@@ -274,9 +309,13 @@ impl Ficr {
             0x41414141 => Variant::AAAA,
             0x41414142 => Variant::AAAB,
             0x41414241 => Variant::AABA,
+            0x41414341 => Variant::AACA,
             0x41414242 => Variant::AABB,
             0x41414230 => Variant::AAB0,
+            0x41414330 => Variant::AAC0,
             0x41414530 => Variant::AAE0,
+            0x42414141 => Variant::BAAA,
+            0x43414141 => Variant::CAAA,
             _ => Variant::Unspecified,
         }
     }
@@ -287,6 +326,7 @@ impl Ficr {
             0x2000 => Package::QF,
             0x2001 => Package::CH,
             0x2002 => Package::CI,
+            0x2004 => Package::QI,
             0x2005 => Package::CK,
             _ => Package::Unspecified,
         }
@@ -298,6 +338,8 @@ impl Ficr {
             0x10 => Ram::K16,
             0x20 => Ram::K32,
             0x40 => Ram::K64,
+            0x80 => Ram::K128,
+            0x100 => Ram::K256,
             _ => Ram::Unspecified,
         }
     }
@@ -308,6 +350,8 @@ impl Ficr {
             0x80 => Flash::K128,
             0x100 => Flash::K256,
             0x200 => Flash::K512,
+            0x400 => Flash::K1024,
+            0x800 => Flash::K2048,
             _ => Flash::Unspecified,
         }
     }
@@ -317,7 +361,7 @@ impl fmt::Display for Ficr {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "NRF52-DK HW INFO: Variant: {:?}, Part: {:?}, Package: {:?}, Ram: {:?}, Flash: {:?}",
+            "NRF52 HW INFO: Variant: {:?}, Part: {:?}, Package: {:?}, Ram: {:?}, Flash: {:?}",
             self.variant(),
             self.part(),
             self.package(),


### PR DESCRIPTION
### Pull Request Overview

This pull request adds the necessary things to get more than

    NRF52-DK HW INFO: Variant: Unspecified, Part: Unspecified, Package: Unspecified, Ram: Unspecified, Flash: Unspecified

from the FICR logic when running on a nRF52840-DK

### Testing Strategy

This pull request was tested by running it on a nRF52840-DK and observing:

    NRF52 HW INFO: Variant: AAC0, Part: N52840, Package: QI, Ram: K256, Flash: K1024

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make formatall`.
