### PR TITLE
allow GPIOs to be switched on

### DIFF
--- a/kernel/src/hil/gpio.rs
+++ b/kernel/src/hil/gpio.rs
@@ -307,7 +307,7 @@ impl Configure for InterruptValueWrapper {
 
 impl Output for InterruptValueWrapper {
     fn set(&self) {
-        self.source.is_input();
+        self.source.set();
     }
 
     fn clear(&self) {


### PR DESCRIPTION
### Pull Request Overview

This pull request makes it possible to switch ouput GPIOs to the HIGH state.


### Testing Strategy

This pull request was tested by measuring the voltage on an output GPIO pin.


### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make formatall`.
