### PR TITLE
fix TOCK_KERNEL_VERSION

### DIFF
--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -50,7 +50,7 @@ Q=@
 VERBOSE =
 endif
 
-export TOCK_KERNEL_VERSION := $(shell git describe --tags --always 2> /dev/null || echo "1.3+")
+export TOCK_KERNEL_VERSION := $(shell git describe --tags --always 2> /dev/null || echo "1.4+")
 
 
 # Validate that rustup is new enough

--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -50,7 +50,7 @@ Q=@
 VERBOSE =
 endif
 
-export TOCK_KERNEL_VERSION := $(shell git describe --always 2> /dev/null || echo "1.3+")
+export TOCK_KERNEL_VERSION := $(shell git describe --tags --always 2> /dev/null || echo "1.3+")
 
 
 # Validate that rustup is new enough


### PR DESCRIPTION
### Pull Request Overview

By default, `git describe` returns the last *annotated* tag, which for
TockOS is release-1.2-2018-06, leading to output like

    Kernel version release-1.2-2018-06-1281-g2cef0240

for something that is actually a build of a release-1.4 kernel. This
change uses the last tag of any kind.

### Testing Strategy

Run a broken app using a recompiled kernel:
```
Initialization complete. Entering main loop


Kernel panic at /home/hars/src/tock/kernel/src/process.rs:568:
        "Process blink had a fault"
        Kernel version release-1.4-10-g245e0014
```
### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make formatall`.
