### PR TITLE
replace env! with option_env!

### DIFF
--- a/arch/cortex-m3/src/lib.rs
+++ b/arch/cortex-m3/src/lib.rs
@@ -272,7 +272,7 @@ unsafe fn kernel_hardfault(faulting_stack: *mut u32) {
          \tBus Fault Address:       (valid: {}) {:#010X}\r\n\
          ",
         mode_str,
-        env!("TOCK_KERNEL_VERSION"),
+        option_env!("TOCK_KERNEL_VERSION").unwrap_or("unknown"),
         stacked_r0,
         stacked_r1,
         stacked_r2,

--- a/arch/cortex-m4/src/lib.rs
+++ b/arch/cortex-m4/src/lib.rs
@@ -272,7 +272,7 @@ unsafe fn kernel_hardfault(faulting_stack: *mut u32) {
          \tBus Fault Address:       (valid: {}) {:#010X}\r\n\
          ",
         mode_str,
-        env!("TOCK_KERNEL_VERSION"),
+        option_env!("TOCK_KERNEL_VERSION").unwrap_or("unknown"),
         stacked_r0,
         stacked_r1,
         stacked_r2,

--- a/kernel/src/debug.rs
+++ b/kernel/src/debug.rs
@@ -105,7 +105,7 @@ pub unsafe fn panic_banner<W: Write>(writer: &mut W, panic_info: &PanicInfo) {
     // Print version of the kernel
     let _ = writer.write_fmt(format_args!(
         "\tKernel version {}\r\n",
-        env!("TOCK_KERNEL_VERSION")
+        option_env!("TOCK_KERNEL_VERSION").unwrap_or("unknown")
     ));
 }
 


### PR DESCRIPTION
Since `TOCK_KERNEL_VERSION` only gets set in the board makefile, running cargo commands manually often times ends with an error that `TOCK_KERNEL_VERSION` is not set. Now we choose a reasonable default so that things like running `cargo clippy` don't result in errors.


### Testing Strategy

This pull request was tested by travis.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
