### PR TITLE
HiFive1: Add support for Machine Mode Interrupts

### DIFF
--- a/arch/rv32i/src/machine_timer.rs
+++ b/arch/rv32i/src/machine_timer.rs
@@ -1,5 +1,6 @@
 //! Create a timer using the Machine Timer registers.
 
+use crate::csr;
 use kernel::common::cells::OptionalCell;
 use kernel::common::registers::{register_bitfields, ReadOnly, ReadWrite};
 use kernel::common::StaticRef;
@@ -78,6 +79,7 @@ impl hil::time::Alarm<'a> for MachineTimer<'a> {
         self.registers
             .mtimecmp
             .write(MTimeCmp::MTIMECMP.val(tics as u64));
+        csr::CSR.mie.modify(csr::mie::mie::mtimer::SET);
     }
 
     fn get_alarm(&self) -> u32 {

--- a/boards/README.md
+++ b/boards/README.md
@@ -14,5 +14,5 @@ that Tock supports.
 | [TI LAUNCHXL-CC26x2](launchxl/README.md)          | ARM Cortex-M4   | CC2652R    | openocd    | tockloader     |
 | [ST Nucleo F446RE](nucleo_f446re/README.md)       | ARM Cortex-M4   | STM32F446  | openocd    | custom         |
 | [ST Nucleo F429ZI](nucleo_f429zi/README.md)       | ARM Cortex-M4   | STM32F429  | openocd    | custom         |
-| [SiFive HiFive1](hifive1/README.md)               | RISC-V          | FE310-G000 | openocd    | not supported  |
+| [SiFive HiFive1](hifive1/README.md)               | RISC-V          | FE310-G000 | openocd    | tockloader     |
 | [Digilent Arty A-7 100T](arty-e21/README.md)      | RISC-V RV32IMAC | SiFive E21 | openocd    | tockloader     |

--- a/boards/hifive1/README.md
+++ b/boards/hifive1/README.md
@@ -6,11 +6,6 @@ SiFive HiFive1 RISC-V Board
 Arduino-compatible dev board for RISC-V. This is the first release of this
 board ("Rev A01").
 
-The RISC-V core on this board only supports Machine mode. That means that this
-board does not support running userland applications. It is useful for testing
-RISC-V kernel code, however.
-
-
 Programming
 -----------
 
@@ -25,7 +20,12 @@ Running in QEMU
 
 The HiFive1 application can be run in the QEMU emulation platform, allowing quick and easy testing.
 
-QEMU can be started with the following arguments:
+QEMU can be started with Tock using the following arguments:
 ```
 qemu-system-riscv32 -M sifive_e -kernel boards/hifive1/target/riscv32imac-unknown-none-elf/release/hifive1.elf  -nographic
+```
+
+QEMU can be started with Tock and a userspace app using the following arguments:
+```
+qemu-system-riscv32 -M sifive_e -kernel boards/hifive1/target/riscv32imac-unknown-none-elf/release/hifive1.elf -device loader,file=./examples/hello.tbf,addr=0x20430000 -nographic
 ```

--- a/boards/hifive1/src/main.rs
+++ b/boards/hifive1/src/main.rs
@@ -105,12 +105,9 @@ pub unsafe fn reset_handler() {
     // Need to enable all interrupts for Tock Kernel
     chip.enable_plic_interrupts();
     // enable interrupts globally
-    // we don't use timer interrupts anywhere; not needed
-    csr::CSR.mie.modify(
-        csr::mie::mie::msoft::SET + csr::mie::mie::mtimer::SET + csr::mie::mie::mtimer::SET,
-    );
-    // this should be uncommented and masked; unclear why board hangs
-    //riscvregs::mie::set_mext();
+    csr::CSR
+        .mie
+        .modify(csr::mie::mie::msoft::SET + csr::mie::mie::mtimer::SET);
     csr::CSR.mstatus.modify(csr::mstatus::mstatus::mie::SET);
 
     // Create a shared UART channel for the console and for kernel debug.

--- a/chips/e310x/src/chip.rs
+++ b/chips/e310x/src/chip.rs
@@ -3,6 +3,7 @@
 use kernel;
 use kernel::debug;
 use rv32i;
+use rv32i::csr;
 use rv32i::machine_timer;
 use rv32i::plic;
 
@@ -174,6 +175,49 @@ pub unsafe fn handle_trap() {
     }
 }
 
+pub fn disable_interrupt_cause() {
+    let cause = rv32i::csr::CSR.mcause.extract();
+
+    match rv32i::csr::mcause::McauseHelpers::cause(&cause) {
+        rv32i::csr::mcause::Trap::Interrupt(interrupt) => match interrupt {
+            rv32i::csr::mcause::Interrupt::UserSoft => {
+                csr::CSR.mie.modify(csr::mie::mie::usoft::CLEAR);
+            }
+            rv32i::csr::mcause::Interrupt::SupervisorSoft => {
+                csr::CSR.mie.modify(csr::mie::mie::ssoft::CLEAR);
+            }
+            rv32i::csr::mcause::Interrupt::MachineSoft => {
+                csr::CSR.mie.modify(csr::mie::mie::msoft::CLEAR);
+            }
+
+            rv32i::csr::mcause::Interrupt::UserTimer => {
+                csr::CSR.mie.modify(csr::mie::mie::utimer::CLEAR);
+            }
+            rv32i::csr::mcause::Interrupt::SupervisorTimer => {
+                csr::CSR.mie.modify(csr::mie::mie::stimer::CLEAR);
+            }
+            rv32i::csr::mcause::Interrupt::MachineTimer => {
+                csr::CSR.mie.modify(csr::mie::mie::mtimer::CLEAR);
+            }
+
+            rv32i::csr::mcause::Interrupt::UserExternal => {
+                csr::CSR.mie.modify(csr::mie::mie::uext::CLEAR);
+            }
+            rv32i::csr::mcause::Interrupt::SupervisorExternal => {
+                csr::CSR.mie.modify(csr::mie::mie::sext::CLEAR);
+            }
+            rv32i::csr::mcause::Interrupt::MachineExternal => {
+                csr::CSR.mie.modify(csr::mie::mie::mext::CLEAR);
+            }
+
+            rv32i::csr::mcause::Interrupt::Unknown => {
+                debug!("interrupt of unknown cause");
+            }
+        },
+        rv32i::csr::mcause::Trap::Exception(_exception) => (),
+    }
+}
+
 /// Trap handler for board/chip specific code.
 ///
 /// For the e310 this gets called when an interrupt occurs while the chip is
@@ -181,6 +225,7 @@ pub unsafe fn handle_trap() {
 /// disable it.
 #[export_name = "_start_trap_rust"]
 pub unsafe extern "C" fn start_trap_rust() {
+    disable_interrupt_cause();
     handle_trap();
 }
 
@@ -189,7 +234,5 @@ pub unsafe extern "C" fn start_trap_rust() {
 /// interrupt that fired so that it does not trigger again.
 #[export_name = "_disable_interrupt_trap_handler"]
 pub extern "C" fn disable_interrupt_trap_handler(_mcause: u32) {
-    unsafe {
-        handle_trap();
-    }
+    disable_interrupt_cause();
 }

--- a/chips/e310x/src/chip.rs
+++ b/chips/e310x/src/chip.rs
@@ -3,6 +3,7 @@
 use kernel;
 use kernel::debug;
 use rv32i;
+use rv32i::machine_timer;
 use rv32i::plic;
 
 use crate::gpio;
@@ -93,7 +94,9 @@ pub unsafe fn handle_trap() {
                 rv32i::csr::mcause::Interrupt::UserSoft => (),
                 rv32i::csr::mcause::Interrupt::SupervisorSoft => (),
 
-                rv32i::csr::mcause::Interrupt::MachineTimer => (),
+                rv32i::csr::mcause::Interrupt::MachineTimer => {
+                    machine_timer::MACHINETIMER.handle_interrupt();
+                }
 
                 // should never occur
                 rv32i::csr::mcause::Interrupt::UserTimer => (),


### PR DESCRIPTION
### Pull Request Overview

This PR adds support for Machine Mode Interrupts. This allows apps to request timers and then have Tock callback the app when the timer fires.

### Testing Strategy

This pull request was tested by running the hello example in libtock-rs.

There is still a bug in the trap handling, if an interrupt arrives while we are handling one we loose our state and end up executing somewhere strange. I'm guessing this is due to mepc somehow being lost. This only occurs on QEMU when the timer is set to fire extremely quickly.

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make formatall`.
