### PR TITLE
tools: add link checking script

### DIFF
--- a/tools/check-all-links.sh
+++ b/tools/check-all-links.sh
@@ -8,6 +8,11 @@
 ###
 ###     Then patch /usr/local/lib/ruby/gems/2.4.0/gems/awesome_bot-1.17.2/lib/awesome_bot/check.rb
 ###     to set `head = true`.
+###
+### There are some limitations to this tool, so it tends to find many false positives.
+### Using this script requires skipping through the output and manually checking and
+### fixing links. Therefore, we do not include it in any CI build right now, and instead
+### simply run it periodically to try to keep links up-to-date.
 
 red=`tput setaf 1`
 green=`tput setaf 2`

--- a/tools/check-all-links.sh
+++ b/tools/check-all-links.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+### Scan all markdown files and check for broken links.
+###
+### Requirements:
+###
+###     gem install awesome_bot
+###
+###     Then patch /usr/local/lib/ruby/gems/2.4.0/gems/awesome_bot-1.17.2/lib/awesome_bot/check.rb
+###     to set `head = true`.
+
+red=`tput setaf 1`
+green=`tput setaf 2`
+reset=`tput sgr0`
+
+# Keep track of how many READMEs have broken links in them.
+let FAIL=0
+
+# Iterate every directory in the repo.
+for D in $(find . -mindepth 1 -type d); do
+	pushd $D > /dev/null
+
+	# Iterate every markdown file in the folder
+	for MD in $(find . -maxdepth 1 -type f -name "*.md"); do
+		# Check that this .md file is actually in the repo. Ignore files
+		# that may have come from submodules or npm packages or other sources.
+		git ls-files --error-unmatch $MD > /dev/null 2>&1
+		if [[ $? -eq 0 ]]; then
+
+			printf "CHECKING ${D:2}/${MD:2}"
+
+			let LAST_FAIL=$FAIL
+
+			# Run the actual check on
+			OUT=`awesome_bot --allow-dupe --allow-redirect --skip-save-results --allow 405 --base-url https://github.com/tock/tock/blob/master/${D:2}/ $MD`
+			let FAIL=FAIL+$?
+
+			# If non-zero return code print the awesome_bot output and failed links.
+			if [[ $FAIL-$LAST_FAIL -ne 0 ]]; then
+				printf " ${red}FAIL${reset}\n"
+				echo "$OUT"
+				echo
+			else
+				printf " ${green}SUCCESS${reset}\n"
+			fi
+		fi
+
+	done
+
+	popd > /dev/null
+done
+
+exit $FAIL


### PR DESCRIPTION
This script scans all markdown files to find broken links. It works OK, but awesome_bot does not handle code blocks properly so there are many false negatives.

I've had this in a branch for a while, not sure there isn't a good reason to just have it in the tools folder.


### Testing Strategy

This pull request was tested by running it at various times and having the pull requests created from its output merged.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
