### PR TITLE
Fix path for kernel_layout.ld in nordic boards' build.rs.

### DIFF
--- a/boards/nordic/nrf52840dk/build.rs
+++ b/boards/nordic/nrf52840dk/build.rs
@@ -1,4 +1,4 @@
 fn main() {
     println!("cargo:rerun-if-changed=layout.ld");
-    println!("cargo:rerun-if-changed=../kernel_layout.ld");
+    println!("cargo:rerun-if-changed=../../kernel_layout.ld");
 }

--- a/boards/nordic/nrf52dk/build.rs
+++ b/boards/nordic/nrf52dk/build.rs
@@ -1,5 +1,5 @@
 fn main() {
     println!("cargo:rerun-if-changed=layout.ld");
     println!("cargo:rerun-if-changed=chip_layout.ld");
-    println!("cargo:rerun-if-changed=../kernel_layout.ld");
+    println!("cargo:rerun-if-changed=../../kernel_layout.ld");
 }


### PR DESCRIPTION
### Pull Request Overview

The nordic boards are in a sub-directory, so the `kernel_layout.ld` file is one folder up.

### Testing Strategy

N/A

### TODO or Help Wanted

N/A

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.