### PR TITLE
kernel: process: Return a slice if memory is already allocated

### DIFF
--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -813,7 +813,7 @@ impl<C: Chip> ProcessType for Process<'a, C> {
         self.mpu_config.and_then(|mut config| {
             let new_break = self.kernel_memory_break.get().offset(-(size as isize));
             if new_break < self.app_break.get() {
-                None
+                Some(slice::from_raw_parts_mut(new_break as *mut u8, size))
             } else if let Err(_) = self.chip.mpu().update_app_memory_region(
                 self.app_break.get(),
                 new_break,


### PR DESCRIPTION
### Pull Request Overview

When calling the process alloc() function let's return a valid slice if
the new size is less then the current size. This means that even is we
don't need to allocate more memory (as we have enough) we still return
a usable slice.

This fixes running libtock-rs on the HiFive 1.

### Testing Strategy

This pull request was tested by running libtock-rs hello example on HiFive 1.

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make formatall`.
