### PR TITLE
Change types in main.rs to make it easier to remove components.

### DIFF
--- a/boards/components/src/console.rs
+++ b/boards/components/src/console.rs
@@ -19,6 +19,7 @@
 
 use capsules::console;
 use capsules::virtual_uart::{MuxUart, UartDevice};
+use kernel;
 use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
@@ -44,7 +45,7 @@ impl ConsoleComponent {
 
 impl Component for ConsoleComponent {
     type StaticInput = ();
-    type Output = &'static console::Console<'static>;
+    type Output = &'static dyn kernel::Driver;
 
     unsafe fn finalize(&mut self, _s: Self::StaticInput) -> Self::Output {
         let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -225,7 +225,7 @@ pub unsafe fn reset_handler() {
     hil::uart::Receive::set_receive_client(&sam4l::usart::USART0, uart_mux);
 
     // Setup the console and the process inspection console.
-    let console = components::console::ConsoleComponent::new(board_kernel, uart_mux).finalize(());
+    let console = Some(components::console::ConsoleComponent::new(board_kernel, uart_mux).finalize(()));
     let process_console =
         components::process_console::ProcessConsoleComponent::new(board_kernel, uart_mux)
             .finalize(());
@@ -496,7 +496,7 @@ pub unsafe fn reset_handler() {
     // sam4l::gpio::PA[16].set_client(debug_process_restart);
 
     let hail = Hail {
-        console: Some(console),
+        console: console,
         gpio: Some(gpio),
         alarm: Some(alarm),
         ambient_light: Some(ambient_light),


### PR DESCRIPTION
### Pull Request Overview

Ok so this is an experimental PR. Motivated by the discussion on #1420, this changes some types around so that a component can be removed by making

```rust
let console = components::console::ConsoleComponent::new(board_kernel, uart_mux).finalize(());
```

look like

```rust
let console = None;
```

When writing this it felt a little sketchy to lose the type information, but, is that type information actually useful? I've always found it to be annoying and something where I just let the compiler tell me what I should have written.


### Testing Strategy

TODO


### TODO or Help Wanted
What do you think?


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make formatall`.
