### PR TITLE
fix slack invite link

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -15,7 +15,7 @@ join us on [Slack][slack].
 As a reminder, all contributors are expected to follow the Rust [Code of
 Conduct][coc].
 
-[slack]: https://join.slack.com/t/tockos/shared_invite/enQtNDE5ODQyNDU4NTE1LTg4YzE1MTkwYzI0YjhjNjA0YWExOGY2ZGYwNjQ2YmFiZjdhOTdlMzY0YTBiYTA2YTRlYzMyZTI1MDdmMTgwMzc
+[slack]: https://join.slack.com/t/tockos/shared_invite/enQtNDE5ODQyNDU4NTE1LWVjNTgzMTMwYzA1NDI1MjExZjljMjFmOTMxMGIwOGJlMjk0ZTI4YzY0NTYzNWM0ZmJmZGFjYmY5MTJiMDBlOTk
 [listserv]: https://groups.google.com/forum/#!forum/tock-dev
 [coc]: https://www.rust-lang.org/conduct.html
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ post series highlights what's new in Tock. Also, follow
 
 You can also browse our
 [email group](https://groups.google.com/forum/#!forum/tock-dev)
-and our [Slack](https://join.slack.com/t/tockos/shared_invite/enQtNDE5ODQyNDU4NTE1LTg4YzE1MTkwYzI0YjhjNjA0YWExOGY2ZGYwNjQ2YmFiZjdhOTdlMzY0YTBiYTA2YTRlYzMyZTI1MDdmMTgwMzc) to see
+and our [Slack](https://join.slack.com/t/tockos/shared_invite/enQtNDE5ODQyNDU4NTE1LWVjNTgzMTMwYzA1NDI1MjExZjljMjFmOTMxMGIwOGJlMjk0ZTI4YzY0NTYzNWM0ZmJmZGFjYmY5MTJiMDBlOTk) to see
 discussions on Tock development.
 
 


### PR DESCRIPTION
### Pull Request Overview

The old link apparently expired -- slack promises me this one won't
in the dialog box that popped up, but we should probably check this
periodically I guess

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make formatall`.
