### PR TITLE
Remove duplicate app register saving on context switch

### DIFF
--- a/arch/cortex-m4/src/lib.rs
+++ b/arch/cortex-m4/src/lib.rs
@@ -64,13 +64,6 @@ pub unsafe extern "C" fn generic_isr() {
     cmp lr, #0xfffffffd
     bne _ggeneric_isr_no_stacking
 
-    /* We need the most recent kernel's version of r1, which points */
-    /* to the Process struct's stored registers field. The kernel's r1 */
-    /* lives in the second word of the hardware stacked registers on MSP */
-    mov r1, sp
-    ldr r1, [r1, #4]
-    stmia r1, {r4-r11}
-
     /* Set thread mode to privileged */
     mov r0, #0
     msr CONTROL, r0

--- a/arch/cortex-m4/src/lib.rs
+++ b/arch/cortex-m4/src/lib.rs
@@ -61,7 +61,6 @@ pub unsafe extern "C" fn generic_isr() {
     asm!(
         "
     /* Skip saving process state if not coming from user-space */
-    cmp lr, #0xfffffffd
     bne _ggeneric_isr_no_stacking
 
     /* Set thread mode to privileged */

--- a/arch/cortex-m4/src/lib.rs
+++ b/arch/cortex-m4/src/lib.rs
@@ -31,104 +31,144 @@ extern "C" {
 #[cfg(not(target_os = "none"))]
 pub unsafe extern "C" fn systick_handler() {}
 
+/// The `systick_handler` is called when the systick interrupt occurs, signaling
+/// that an application executed for longer than its timeslice. If this is
+/// called we want to return to the scheduler.
 #[cfg(target_os = "none")]
 #[naked]
 pub unsafe extern "C" fn systick_handler() {
     asm!(
         "
-    /* Mark that the systick handler was called meaning that the process */
-    /* stopped executing because it has exceeded its timeslice. */
+    // Mark that the systick handler was called meaning that the process stopped
+    // executing because it has exceeded its timeslice. This is a global
+    // variable that the `UserspaceKernelBoundary` code uses to determine why
+    // the application stopped executing.
     ldr r0, =SYSTICK_EXPIRED
     mov r1, #1
     str r1, [r0, #0]
 
-    /* Set thread mode to privileged */
+    // Set thread mode to privileged to switch back to kernel mode.
     mov r0, #0
     msr CONTROL, r0
 
     movw LR, #0xFFF9
-    movt LR, #0xFFFF"
+    movt LR, #0xFFFF
+
+    // This will resume in the switch to user function where application state
+    // is saved and the scheduler can choose what to do next.
+    "
     : : : : "volatile" );
 }
 
 #[cfg(not(target_os = "none"))]
 pub unsafe extern "C" fn generic_isr() {}
 
+/// All ISRs are caught by this handler. This must ensure the interrupt is
+/// disabled (per Tock's interrupt model) and then as quickly as possible resume
+/// the main thread (i.e. leave the interrupt context). The interrupt will be
+/// marked as pending and handled when the scheduler checks if there are any
+/// pending interrupts.
+///
+/// If the ISR is called while an app is running, this will switch control to
+/// the kernel.
 #[cfg(target_os = "none")]
 #[naked]
-/// All ISRs are caught by this handler which disables the NVIC and switches to the kernel.
 pub unsafe extern "C" fn generic_isr() {
     asm!(
         "
-    /* Skip saving process state if not coming from user-space */
-
-    /* Set thread mode to privileged */
+    // Set thread mode to privileged to ensure we are executing as the kernel.
+    // This may be redundant if the interrupt happened while the kernel code
+    // was executing.
     mov r0, #0
     msr CONTROL, r0
 
     movw LR, #0xFFF9
     movt LR, #0xFFFF
-  _ggeneric_isr_no_stacking:
-    /* Find the ISR number by looking at the low byte of the IPSR registers */
-    mrs r0, IPSR
-    and r0, #0xff
-    /* ISRs start at 16, so substract 16 to get zero-indexed */
-    sub r0, #16
 
-    /*
-     * High level:
-     *    NVIC.ICER[r0 / 32] = 1 << (r0 & 31)
-     * */
-    lsrs r2, r0, #5 /* r2 = r0 / 32 */
+    // Now need to disable the interrupt that fired in the NVIC to ensure it
+    // does not trigger again before the scheduler has a chance to handle it. We
+    // do this here in assembly for performance.
+    //
+    // The general idea is:
+    // 1. Get the index of the interrupt that occurred.
+    // 2. Set the disable bit for that interrupt in the NVIC.
 
-    /* r0 = 1 << (r0 & 31) */
-    movs r3, #1        /* r3 = 1 */
-    and r0, r0, #31    /* r0 = r0 & 31 */
-    lsl r0, r3, r0     /* r0 = r3 << r0 */
+    // Find the ISR number (`index`) by looking at the low byte of the IPSR
+    // registers.
+    mrs r0, IPSR       // r0 = Interrupt Program Status Register (IPSR)
+    and r0, #0xff      // r0 = r0 & 0xFF
+    sub r0, #16        // ISRs start at 16, so subtract 16 to get zero-indexed.
 
-    /* r3 = &NVIC.ICER */
-    mov r3, #0xe180
+    // Now disable that interrupt in the NVIC.
+    // High level:
+    //    r0 = index
+    //    NVIC.ICER[r0 / 32] = 1 << (r0 & 31)
+    //
+    lsrs r2, r0, #5    // r2 = r0 / 32
+
+    // r0 = 1 << (r0 & 31)
+    movs r3, #1        // r3 = 1
+    and r0, r0, #31    // r0 = r0 & 31
+    lsl r0, r3, r0     // r0 = r3 << r0
+
+    // Load the ICER register address.
+    mov r3, #0xe180    // r3 = &NVIC.ICER
     movt r3, #0xe000
 
-    /* here:
-     *
-     *  `r2` is r0 / 32
-     *  `r3` is &NVIC.ICER
-     *  `r0` is 1 << (r0 & 31)
-     *
-     * So we just do:
-     *
-     *  `*(r3 + r2 * 4) = r0`
-     *
-     *  */
-    str r0, [r3, r2, lsl #2]"
+    // Here:
+    // - `r2` is index / 32
+    // - `r3` is &NVIC.ICER
+    // - `r0` is 1 << (index & 31)
+    //
+    // So we just do:
+    //
+    //  `*(r3 + r2 * 4) = r0`
+    //
+    str r0, [r3, r2, lsl #2]
+
+    // Now we can return from the interrupt context and resume what we were
+    // doing. If an app was executing we will switch to the kernel so it can
+    // choose whether to service the interrupt.
+    "
     : : : : "volatile" );
 }
 
 #[cfg(not(target_os = "none"))]
 pub unsafe extern "C" fn svc_handler() {}
 
+/// This is called after a `svc` instruction, both when switching to userspace
+/// and when userspace makes a system call.
 #[cfg(target_os = "none")]
 #[naked]
 pub unsafe extern "C" fn svc_handler() {
     asm!(
         "
+    // First check to see which direction we are going in. If the link register
+    // is something other than 0xfffffff9, then we are coming from an app which
+    // has called a syscall.
     cmp lr, #0xfffffff9
     bne to_kernel
 
-    /* Set thread mode to unprivileged */
+    // If we get here, then this is a context switch from the kernel to the
+    // application. Set thread mode to unprivileged to run the application.
     mov r0, #1
     msr CONTROL, r0
 
     movw lr, #0xfffd
     movt lr, #0xffff
+    // Switch to the app.
     bx lr
+
   to_kernel:
+    // An application called a syscall. We mark this in the global variable
+    // `SYSCALL_FIRED` which is stored in the syscall file.
+    // `UserspaceKernelBoundary` will use this variable to decide why the app
+    // stopped executing.
     ldr r0, =SYSCALL_FIRED
     mov r1, #1
     str r1, [r0, #0]
 
-    /* Set thread mode to privileged */
+    // Set thread mode to privileged as we switch back to the kernel.
     mov r0, #0
     msr CONTROL, r0
 
@@ -143,30 +183,43 @@ pub unsafe extern "C" fn switch_to_user(user_stack: *const u8, _process_got: *co
     user_stack as *mut u8
 }
 
+/// Assembly function called from `UserspaceKernelBoundary` to switch to an
+/// an application. This handles storing and restoring application state before
+/// and after the switch.
 #[cfg(target_os = "none")]
 #[no_mangle]
-/// r0 is top of user stack, r1 is reference to `CortexMStoredState.regs`
 pub unsafe extern "C" fn switch_to_user(
     mut user_stack: *const usize,
     process_regs: &mut [usize; 8],
 ) -> *const usize {
-    asm!("
-    /* Load bottom of stack into Process Stack Pointer */
+    asm!(
+        "
+    // The arguments passed in are:
+    // - `r0` is the top of the user stack
+    // - `r1` is a reference to `CortexMStoredState.regs`
+
+    // Load bottom of stack into Process Stack Pointer.
     msr psp, $0
 
-    /* Load non-hardware-stacked registers from Process stack */
-    /* Ensure that $2 is stored in a callee saved register */
+    // Load non-hardware-stacked registers from the process stored state. Ensure
+    // that $2 is stored in a callee saved register.
     ldmia $2, {r4-r11}
 
-    /* SWITCH */
-    svc 0xff /* It doesn't matter which SVC number we use here */
+    // SWITCH
+    svc 0xff   // It doesn't matter which SVC number we use here as it has no
+               // defined meaning for the Cortex-M syscall interface. Data being
+               // returned from a syscall is transfered on the app's stack.
 
-    /* Push non-hardware-stacked registers into Process struct's */
-    /* regs field */
+    // When execution returns here we have switched back to the kernel from the
+    // application.
+
+    // Push non-hardware-stacked registers into the saved state for the
+    // application.
     stmia $2, {r4-r11}
 
-
-    mrs $0, PSP /* PSP into r0 */"
+    // Update the user stack pointer with the current value after the
+    // application has executed.
+    mrs $0, PSP   // r0 = PSP"
     : "={r0}"(user_stack)
     : "{r0}"(user_stack), "{r1}"(process_regs)
     : "r4","r5","r6","r7","r8","r9","r10","r11" : "volatile" );

--- a/arch/cortex-m4/src/lib.rs
+++ b/arch/cortex-m4/src/lib.rs
@@ -61,7 +61,6 @@ pub unsafe extern "C" fn generic_isr() {
     asm!(
         "
     /* Skip saving process state if not coming from user-space */
-    bne _ggeneric_isr_no_stacking
 
     /* Set thread mode to privileged */
     mov r0, #0

--- a/arch/cortex-m4/src/lib.rs
+++ b/arch/cortex-m4/src/lib.rs
@@ -82,6 +82,7 @@ pub unsafe extern "C" fn generic_isr() {
     mov r0, #0
     msr CONTROL, r0
 
+    // This is a special address to return Thread mode with Main stack
     movw LR, #0xFFF9
     movt LR, #0xFFFF
 
@@ -154,6 +155,7 @@ pub unsafe extern "C" fn svc_handler() {
     mov r0, #1
     msr CONTROL, r0
 
+    // This is a special address to return Thread mode with Process stack
     movw lr, #0xfffd
     movt lr, #0xffff
     // Switch to the app.
@@ -172,6 +174,7 @@ pub unsafe extern "C" fn svc_handler() {
     mov r0, #0
     msr CONTROL, r0
 
+    // This is a special address to return Thread mode with Main stack
     movw LR, #0xFFF9
     movt LR, #0xFFFF
     bx lr"


### PR DESCRIPTION
Remove unnecessary register saving

### Pull Request Overview

Please correct me if I'm wrong.
The ISR handler saves registers when the interrupt comes from user mode (unprivileged thread mode). However, this storing is done in  switch_to_user function. So, as long as switch_to_user function is the only path to enter user mode, this register storing seems unnecessary. And other handler don't have this storing logic as well (e.g. systick handler).

### Testing Strategy
Tested in my Nucleo-F429ZI board with my sample app


### TODO or Help Wanted

This pull request still needs...


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make formatall`.
