### PR TITLE
Remove impossible if-condition in cortex-m3 MPU

### DIFF
--- a/arch/cortex-m3/src/mpu.rs
+++ b/arch/cortex-m3/src/mpu.rs
@@ -409,11 +409,6 @@ impl kernel::mpu::MPU for MPU {
             }
         }
 
-        // Cortex-M regions can't be greater than 4 GB.
-        if math::log_base_two(region_size as u32) >= 32 {
-            return None;
-        }
-
         // Check that our logical region fits in memory.
         if start + size > (unallocated_memory_start as usize) + unallocated_memory_size {
             return None;


### PR DESCRIPTION
### Pull Request Overview

This pull request removes the `math::log_base_two(region_size as u32) >= 32 ` test which is always false for 2 reasons:
1. A `u32` always fits in a `u32`.
2. cortex-m3 is 32-bits so `usize` is `u32`. If `usize` was larger, then the cast would be a bug.

### Testing Strategy

This pull request was tested by `make ci-travis`.

### TODO or Help Wanted

This pull request doesn't need anything.

### Documentation Updated

No updates are required.

### Formatting

- [x] Ran `make formatall`.