### PR TITLE
Add hifive1 support for user application

### DIFF
--- a/arch/rv32i/src/syscall.rs
+++ b/arch/rv32i/src/syscall.rs
@@ -318,6 +318,12 @@ impl kernel::syscall::UserspaceKernelBoundary for SysCall {
           li   t1, 8          // 8 is the index of ECALL from U mode.
           beq  t0, t1, _ecall // Check if we did an ECALL and handle it
                               // correctly.
+            
+        _check_ecall_m_mode:
+          li   t1, 11          // 11 is the index of ECALL from M mode.
+          beq  t0, t1, _ecall  // analagous to _check_ecall_umode but included to support hifive1 board
+                              
+
 
         _check_exception:
           li   $0, 2          // If we get here, the only other option is an

--- a/arch/rv32i/src/syscall.rs
+++ b/arch/rv32i/src/syscall.rs
@@ -322,6 +322,8 @@ impl kernel::syscall::UserspaceKernelBoundary for SysCall {
         _check_ecall_m_mode:
           li   t1, 11          // 11 is the index of ECALL from M mode.
           beq  t0, t1, _ecall  // analagous to _check_ecall_umode but included to support hifive1 board
+                               // only applicable to the hifive1 rev a board/FE310-G0000 chip, 
+                               // which only has machine mode.
                               
 
 


### PR DESCRIPTION
This allows for syscalls on the hifive1 board to not panic, and the hello_world program to run successfully.

I tested this with the hello_world program on the hifive1 rev a board.