### PR TITLE
Avoid encoding register offsets as fields in a repr(C) struct

### DIFF
--- a/kernel/src/common/mod.rs
+++ b/kernel/src/common/mod.rs
@@ -8,11 +8,13 @@
 
 /// Re-export the tock-register-interface library.
 pub mod registers {
+    pub use tock_registers::define_registers;
     pub use tock_registers::register_bitfields;
     pub use tock_registers::registers::InMemoryRegister;
     pub use tock_registers::registers::RegisterLongName;
     pub use tock_registers::registers::{Field, FieldValue, LocalRegisterCopy};
     pub use tock_registers::registers::{ReadOnly, ReadWrite, WriteOnly};
+    pub use tock_registers::BaseAddress;
 }
 
 pub mod deferred_call;

--- a/libraries/tock-register-interface/src/lib.rs
+++ b/libraries/tock-register-interface/src/lib.rs
@@ -9,3 +9,18 @@
 pub mod macros;
 
 pub mod registers;
+
+#[derive(Clone, Copy)]
+pub struct BaseAddress {
+    base_address: usize,
+}
+
+impl BaseAddress {
+    pub const unsafe fn new(base_address: usize) -> BaseAddress {
+        BaseAddress { base_address }
+    }
+
+    pub const fn offset(&self, offset: usize) -> usize {
+        self.base_address + offset
+    }
+}


### PR DESCRIPTION
This is an implementation of my proposal in #1410 so that it is simpler to compare.

### Pull Request Overview

This pull request adds a macro to define a mapping from register names to types and offsets from a parametric base address. The macro also generates a compile-time check that offsets are increasing and registers are not overlapping. The main motivation is to avoid encoding the mapping from register name to offset as fields in a `repr(C)` struct, which doesn't represent any actual semantics. This struct is not part of any ABI as far as I'm aware of. As a consequence, there is no need to specify the non-existing gaps between the non-existing fields. And there is no need to specify unused or deprecated registers.

### Testing Strategy

This pull request was tested by `make ci-travis`.

### TODO or Help Wanted

This pull request is not meant to be merged and mostly for discussion.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
