### PR TITLE
SiFive: PWM: Slight MMIO address correction

### DIFF
--- a/chips/sifive/src/pwm.rs
+++ b/chips/sifive/src/pwm.rs
@@ -7,12 +7,13 @@ use kernel::common::StaticRef;
 pub struct PwmRegisters {
     /// PWM Configuration Register
     cfg: ReadWrite<u32, cfg::Register>,
+    _reserved0: [u8; 4],
     /// Counter Register
     count: ReadWrite<u32>,
-    _reserved0: [u8; 8],
+    _reserved1: [u8; 4],
     /// Scaled Halfword Counter Register
     pwms: ReadWrite<u32>,
-    _reserved1: [u8; 12],
+    _reserved2: [u8; 12],
     /// Compare Register
     cmp0: ReadWrite<u32>,
     /// Compare Register


### PR DESCRIPTION
The mmio [here](https://sifive.cdn.prismic.io/sifive%2F500a69f8-af3a-4fd9-927f-10ca77077532_fe310-g000.pdf) on page 90 states that the first and third words are reserved. This simply changes the mapping to observe this.
