### PR TITLE
Use MaybeUninit in static_init instead of transmuting an option.

### DIFF
--- a/kernel/src/common/utils.rs
+++ b/kernel/src/common/utils.rs
@@ -26,7 +26,8 @@ macro_rules! static_init {
             // return a reference to it.
             static mut BUF: MaybeUninit<$T> = MaybeUninit::<$T>::uninit();
             BUF.as_mut_ptr().write($e);
-            // TODO: use BUF.get_mut() once that is stabilized.
+            // TODO: use MaybeUninit::get_mut() once that is stabilized (see
+            // https://github.com/rust-lang/rust/issues/63568).
             let result: &'static mut $T = &mut *BUF.as_mut_ptr();
             result
         };

--- a/kernel/src/common/utils.rs
+++ b/kernel/src/common/utils.rs
@@ -6,9 +6,6 @@
 /// initialize the array to the value given and return a `&'static mut`
 /// reference to it.
 ///
-/// If `std::mem::size_of<T>` ever becomes a `const` function then `static_init`
-/// will be optimized to save up to a word of memory for every use.
-///
 /// # Safety
 ///
 /// As this macro will write directly to a global area without acquiring a lock
@@ -24,12 +21,11 @@ macro_rules! static_init {
             // Statically allocate a read-write buffer for the value, write our
             // initial value into it (without dropping the initial zeros) and
             // return a reference to it.
-            static mut BUF: MaybeUninit<$T> = MaybeUninit::<$T>::uninit();
+            static mut BUF: MaybeUninit<$T> = MaybeUninit::uninit();
             BUF.as_mut_ptr().write($e);
             // TODO: use MaybeUninit::get_mut() once that is stabilized (see
             // https://github.com/rust-lang/rust/issues/63568).
-            let result: &'static mut $T = &mut *BUF.as_mut_ptr();
-            result
+            &mut *BUF.as_mut_ptr() as &'static mut $T
         };
     }
 }


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes the `static_init` macro to use [MaybeUninit](https://doc.rust-lang.org/beta/core/mem/union.MaybeUninit.html) now that it's available in Rust. It should be safer and more memory efficient than transmuting an Option.

### Testing Strategy

This pull request was tested by running `make ci-travis`.

### TODO or Help Wanted

N/A

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.