### PR TITLE
Drop messages instead of panicking when the debug buffer is full (Fix #1442).

### DIFF
--- a/boards/acd52832/src/main.rs
+++ b/boards/acd52832/src/main.rs
@@ -7,6 +7,7 @@
 use capsules::virtual_alarm::VirtualMuxAlarm;
 use capsules::virtual_uart::{MuxUart, UartDevice};
 use kernel::capabilities;
+use kernel::common::ring_buffer::RingBuffer;
 use kernel::component::Component;
 use kernel::hil;
 use kernel::hil::entropy::Entropy32;
@@ -413,13 +414,13 @@ pub unsafe fn reset_handler() {
     debugger_uart.setup();
 
     // Create the debugger object that handles calls to `debug!()`
+    let ring_buffer = static_init!(
+        RingBuffer<'static, u8>,
+        RingBuffer::new(&mut kernel::debug::INTERNAL_BUF)
+    );
     let debugger = static_init!(
         kernel::debug::DebugWriter,
-        kernel::debug::DebugWriter::new(
-            debugger_uart,
-            &mut kernel::debug::OUTPUT_BUF,
-            &mut kernel::debug::INTERNAL_BUF,
-        )
+        kernel::debug::DebugWriter::new(debugger_uart, &mut kernel::debug::OUTPUT_BUF, ring_buffer)
     );
     hil::uart::Transmit::set_transmit_client(debugger_uart, debugger);
 

--- a/boards/arty-e21/src/main.rs
+++ b/boards/arty-e21/src/main.rs
@@ -7,6 +7,7 @@
 use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use capsules::virtual_uart::{MuxUart, UartDevice};
 use kernel::capabilities;
+use kernel::common::ring_buffer::RingBuffer;
 use kernel::hil;
 use kernel::Platform;
 use kernel::{create_capability, debug, static_init};
@@ -259,13 +260,13 @@ pub unsafe fn reset_handler() {
     // Create virtual device for kernel debug.
     let debugger_uart = static_init!(UartDevice, UartDevice::new(uart_mux, false));
     debugger_uart.setup();
+    let ring_buffer = static_init!(
+        RingBuffer<'static, u8>,
+        RingBuffer::new(&mut kernel::debug::INTERNAL_BUF)
+    );
     let debugger = static_init!(
         kernel::debug::DebugWriter,
-        kernel::debug::DebugWriter::new(
-            debugger_uart,
-            &mut kernel::debug::OUTPUT_BUF,
-            &mut kernel::debug::INTERNAL_BUF,
-        )
+        kernel::debug::DebugWriter::new(debugger_uart, &mut kernel::debug::OUTPUT_BUF, ring_buffer)
     );
     hil::uart::Transmit::set_transmit_client(debugger_uart, debugger);
 

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -12,6 +12,7 @@ use capsules::virtual_i2c::{I2CDevice, MuxI2C};
 use capsules::virtual_spi::{MuxSpiMaster, VirtualSpiMasterDevice};
 use capsules::virtual_uart::{MuxUart, UartDevice};
 use kernel::capabilities;
+use kernel::common::ring_buffer::RingBuffer;
 use kernel::component::Component;
 use kernel::hil;
 use kernel::hil::gpio;
@@ -520,13 +521,13 @@ pub unsafe fn reset_handler() {
     // Create virtual device for kernel debug.
     let debugger_uart = static_init!(UartDevice, UartDevice::new(uart_mux, false));
     debugger_uart.setup();
+    let ring_buffer = static_init!(
+        RingBuffer<'static, u8>,
+        RingBuffer::new(&mut kernel::debug::INTERNAL_BUF)
+    );
     let debugger = static_init!(
         kernel::debug::DebugWriter,
-        kernel::debug::DebugWriter::new(
-            debugger_uart,
-            &mut kernel::debug::OUTPUT_BUF,
-            &mut kernel::debug::INTERNAL_BUF,
-        )
+        kernel::debug::DebugWriter::new(debugger_uart, &mut kernel::debug::OUTPUT_BUF, ring_buffer)
     );
     hil::uart::Transmit::set_transmit_client(debugger_uart, debugger);
 

--- a/boards/hifive1/src/main.rs
+++ b/boards/hifive1/src/main.rs
@@ -15,6 +15,7 @@
 use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use capsules::virtual_uart::{MuxUart, UartDevice};
 use kernel::capabilities;
+use kernel::common::ring_buffer::RingBuffer;
 use kernel::hil;
 use kernel::Platform;
 use kernel::{create_capability, debug, static_init};
@@ -138,13 +139,13 @@ pub unsafe fn reset_handler() {
     // Create virtual device for kernel debug.
     let debugger_uart = static_init!(UartDevice, UartDevice::new(uart_mux, false));
     debugger_uart.setup();
+    let ring_buffer = static_init!(
+        RingBuffer<'static, u8>,
+        RingBuffer::new(&mut kernel::debug::INTERNAL_BUF)
+    );
     let debugger = static_init!(
         kernel::debug::DebugWriter,
-        kernel::debug::DebugWriter::new(
-            debugger_uart,
-            &mut kernel::debug::OUTPUT_BUF,
-            &mut kernel::debug::INTERNAL_BUF,
-        )
+        kernel::debug::DebugWriter::new(debugger_uart, &mut kernel::debug::OUTPUT_BUF, ring_buffer)
     );
     hil::uart::Transmit::set_transmit_client(debugger_uart, debugger);
 

--- a/boards/launchxl/src/main.rs
+++ b/boards/launchxl/src/main.rs
@@ -15,6 +15,7 @@ use cc26x2::aon;
 use cc26x2::prcm;
 use cc26x2::pwm;
 use kernel::capabilities;
+use kernel::common::ring_buffer::RingBuffer;
 use kernel::hil;
 use kernel::hil::entropy::Entropy32;
 use kernel::hil::gpio;
@@ -272,13 +273,13 @@ pub unsafe fn reset_handler() {
     // Create virtual device for kernel debug.
     let debugger_uart = static_init!(UartDevice, UartDevice::new(uart_mux, false));
     debugger_uart.setup();
+    let ring_buffer = static_init!(
+        RingBuffer<'static, u8>,
+        RingBuffer::new(&mut kernel::debug::INTERNAL_BUF)
+    );
     let debugger = static_init!(
         kernel::debug::DebugWriter,
-        kernel::debug::DebugWriter::new(
-            debugger_uart,
-            &mut kernel::debug::OUTPUT_BUF,
-            &mut kernel::debug::INTERNAL_BUF,
-        )
+        kernel::debug::DebugWriter::new(debugger_uart, &mut kernel::debug::OUTPUT_BUF, ring_buffer)
     );
     hil::uart::Transmit::set_transmit_client(debugger_uart, debugger);
 

--- a/boards/nucleo_f429zi/src/main.rs
+++ b/boards/nucleo_f429zi/src/main.rs
@@ -10,6 +10,7 @@
 use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use capsules::virtual_uart::{MuxUart, UartDevice};
 use kernel::capabilities;
+use kernel::common::ring_buffer::RingBuffer;
 use kernel::hil::{self, time::Alarm};
 use kernel::Platform;
 use kernel::{create_capability, debug, static_init};
@@ -210,13 +211,13 @@ pub unsafe fn reset_handler() {
     // Create a virtual device for kernel debug.
     let debugger_uart = static_init!(UartDevice, UartDevice::new(mux_uart, false));
     debugger_uart.setup();
+    let ring_buffer = static_init!(
+        RingBuffer<'static, u8>,
+        RingBuffer::new(&mut kernel::debug::INTERNAL_BUF)
+    );
     let debugger = static_init!(
         kernel::debug::DebugWriter,
-        kernel::debug::DebugWriter::new(
-            debugger_uart,
-            &mut kernel::debug::OUTPUT_BUF,
-            &mut kernel::debug::INTERNAL_BUF,
-        )
+        kernel::debug::DebugWriter::new(debugger_uart, &mut kernel::debug::OUTPUT_BUF, ring_buffer)
     );
     hil::uart::Transmit::set_transmit_client(debugger_uart, debugger);
 

--- a/kernel/src/common/mod.rs
+++ b/kernel/src/common/mod.rs
@@ -20,10 +20,10 @@ pub mod dynamic_deferred_call;
 pub mod list;
 pub mod math;
 pub mod peripherals;
+pub mod queue;
+pub mod ring_buffer;
 pub mod utils;
 
-mod queue;
-mod ring_buffer;
 mod static_ref;
 
 pub use self::list::{List, ListLink, ListNode};

--- a/kernel/src/common/ring_buffer.rs
+++ b/kernel/src/common/ring_buffer.rs
@@ -17,13 +17,22 @@ impl<T: Copy> RingBuffer<'a, T> {
         }
     }
 
-    // Returns the number of elements that can be enqueued until the ring buffer is full.
+    /// Returns the number of elements that can be enqueued until the ring buffer is full.
     pub fn available_len(&self) -> usize {
         // The maximum capacity of the queue is ring.len - 1, because head == tail for the empty
         // queue.
         self.ring.len().saturating_sub(1 + queue::Queue::len(self))
     }
 
+    /// Returns up to 2 slices that together form the contents of the ring buffer.
+    ///
+    /// Returns:
+    /// - `(None, None)` if the buffer is empty.
+    /// - `(Some(slice), None)` if the head is before the tail (therefore all the contents is
+    /// contiguous).
+    /// - `(Some(left), Some(right))` if the head is after the tail. In that case, the logical
+    /// contents of the buffer is `[left, right].concat()` (although physically the "left" slice is
+    /// stored after the "right" slice).
     pub fn as_slices(&'a self) -> (Option<&'a [T]>, Option<&'a [T]>) {
         if self.head < self.tail {
             (Some(&self.ring[self.head..self.tail]), None)

--- a/kernel/src/common/ring_buffer.rs
+++ b/kernel/src/common/ring_buffer.rs
@@ -16,6 +16,31 @@ impl<T: Copy> RingBuffer<'a, T> {
             ring: ring,
         }
     }
+
+    // Returns the number of elements that can be enqueued until the ring buffer is full.
+    pub fn available_len(&self) -> usize {
+        // The maximum capacity of the queue is ring.len - 1, because head == tail for the empty
+        // queue.
+        self.ring.len().saturating_sub(1 + queue::Queue::len(self))
+    }
+
+    pub fn as_slices(&'a self) -> (Option<&'a [T]>, Option<&'a [T]>) {
+        if self.head < self.tail {
+            (Some(&self.ring[self.head..self.tail]), None)
+        } else if self.head > self.tail {
+            let (left, right) = self.ring.split_at(self.head);
+            (
+                Some(right),
+                if self.tail == 0 {
+                    None
+                } else {
+                    Some(&left[..self.tail])
+                },
+            )
+        } else {
+            (None, None)
+        }
+    }
 }
 
 impl<T: Copy> queue::Queue<T> for RingBuffer<'a, T> {

--- a/kernel/src/debug.rs
+++ b/kernel/src/debug.rs
@@ -38,15 +38,15 @@
 //! ```
 
 use core::cell::Cell;
-use core::cmp::{self, min};
 use core::fmt::{write, Arguments, Result, Write};
 use core::panic::PanicInfo;
 use core::ptr;
-use core::slice;
 use core::str;
 
 use crate::common::cells::NumericCellExt;
 use crate::common::cells::{MapCell, TakeCell};
+use crate::common::queue::Queue;
+use crate::common::ring_buffer::RingBuffer;
 use crate::hil;
 use crate::process::ProcessType;
 use crate::ReturnCode;
@@ -210,11 +210,7 @@ pub struct DebugWriter {
     // The buffer that is passed to the writing mechanism.
     output_buffer: TakeCell<'static, [u8]>,
     // An internal buffer that is used to hold debug!() calls as they come in.
-    internal_buffer: TakeCell<'static, [u8]>,
-    head: Cell<usize>,
-    tail: Cell<usize>,
-    // How many bytes are being written on the current publish_str call.
-    active_len: Cell<usize>,
+    internal_buffer: TakeCell<'static, RingBuffer<'static, u8>>,
     // Number of debug!() calls.
     count: Cell<usize>,
 }
@@ -250,16 +246,13 @@ impl DebugWriter {
     pub fn new(
         uart: &'static dyn hil::uart::Transmit,
         out_buffer: &'static mut [u8],
-        internal_buffer: &'static mut [u8],
+        internal_buffer: &'static mut RingBuffer<'static, u8>,
     ) -> DebugWriter {
         DebugWriter {
             uart: uart,
             output_buffer: TakeCell::new(out_buffer),
             internal_buffer: TakeCell::new(internal_buffer),
-            head: Cell::new(0),       // first valid index in output_buffer
-            tail: Cell::new(0),       // one past last valid index (wraps to 0)
-            active_len: Cell::new(0), // how big is the current transaction?
-            count: Cell::new(0),      // how many debug! calls
+            count: Cell::new(0), // how many debug! calls
         }
     }
 
@@ -271,118 +264,50 @@ impl DebugWriter {
         self.count.get()
     }
 
-    /// Convenience method that writes (end-start) bytes from bytes into the
-    /// internal debug buffer.
-    fn write_buffer(&self, start: usize, end: usize, bytes: &[u8]) {
-        if end < start {
-            panic!("wb bounds: start {} end {} bytes {:?}", start, end, bytes);
-        }
-        self.internal_buffer.map(|in_buffer| {
-            for (dst, src) in in_buffer[start..end].iter_mut().zip(bytes.iter()) {
-                *dst = *src;
-            }
-        });
-    }
-
     /// Write as many of the bytes from the internal_buffer to the output
     /// mechanism as possible.
     fn publish_str(&self) {
         // Can only publish if we have the output_buffer. If we don't that is
         // fine, we will do it when the transmit done callback happens.
         self.output_buffer.take().map(|out_buffer| {
-            let head = self.head.get();
-            let tail = self.tail.get();
-            let len = self
-                .internal_buffer
-                .map_or(0, |internal_buffer| internal_buffer.len());
+            let mut count = 0;
 
-            // Want to write everything from tail inclusive to head
-            // exclusive
-            let (start, end) = if tail > head {
-                // Need to pass subscribe a contiguous buffer, so first
-                // write from tail to end of buffer. The completion
-                // callback will see that the buffer's not empty and
-                // call again to write the rest (tail will be 0)
-                let start = tail;
-                let end = len;
-                (start, end)
-            } else if tail < head {
-                let start = tail;
-                let end = head;
-                (start, end)
-            } else {
-                panic!("Consistency error: publish empty buffer?")
-            };
-
-            // Check that we aren't writing a segment larger than the output
-            // buffer.
-            let real_end = start + cmp::min(end - start, out_buffer.len());
-
-            self.internal_buffer.map(|internal_buffer| {
-                for (dst, src) in out_buffer
-                    .iter_mut()
-                    .zip(internal_buffer[start..real_end].iter())
-                {
-                    *dst = *src;
-                }
-            });
-
-            // Transmit the data in the output buffer.
-            let out_len = real_end - start;
-            let (rval, opt) = self.uart.transmit_buffer(out_buffer, out_len);
-            match rval {
-                ReturnCode::SUCCESS => {
-                    // Set the outgoing length
-                    self.active_len.set(out_len);
-                }
-                _ => {
-                    self.output_buffer.replace(opt.unwrap());
+            let ring_buffer = self.internal_buffer.take().unwrap();
+            for dst in out_buffer.iter_mut() {
+                match ring_buffer.dequeue() {
+                    Some(src) => {
+                        *dst = src;
+                        count += 1;
+                    }
+                    None => {
+                        break;
+                    }
                 }
             }
+            self.internal_buffer.put(Some(ring_buffer));
+
+            if count == 0 {
+                panic!("Consistency error: publish empty buffer?");
+            }
+
+            // Transmit the data in the output buffer.
+            let (_rval, opt) = self.uart.transmit_buffer(out_buffer, count);
+            self.output_buffer.put(opt);
         });
     }
 
-    fn extract(&self) -> Option<(usize, usize, &mut [u8])> {
-        self.internal_buffer
-            .take()
-            .map(|buf| (self.head.get(), self.tail.get(), buf))
+    fn extract(&self) -> Option<&mut RingBuffer<'static, u8>> {
+        self.internal_buffer.take()
     }
 }
 
 impl hil::uart::TransmitClient for DebugWriter {
-    fn transmitted_buffer(&self, buffer: &'static mut [u8], tx_len: usize, _rcode: ReturnCode) {
+    fn transmitted_buffer(&self, buffer: &'static mut [u8], _tx_len: usize, _rcode: ReturnCode) {
         // Replace this buffer since we are done with it.
         self.output_buffer.replace(buffer);
 
-        // Mark how many bytes outstanding so we don't overwrite buffer
-        // in transmit calls.
-        let goal_length = self.active_len.get();
-        let remainder = goal_length - tx_len;
-        self.active_len.set(remainder);
-
-        let len = self
-            .internal_buffer
-            .map_or(0, |internal_buffer| internal_buffer.len());
-        let head = self.head.get();
-        let mut tail = self.tail.get();
-
-        //panic!("Tail: {}, head: {}, tx_len: {}, rcode: {:?}", tail, head, tx_len, _rcode);
-
-        // Increment the tail with how many bytes were written to the output
-        // mechanism, and wrap if needed.
-        tail += tx_len;
-        if tail > len {
-            tail = tail - len;
-        }
-
-        if head == tail {
-            // Empty. As an optimization, reset the head and tail pointers to 0
-            // to maximize the buffer length available before fragmentation
-            self.head.set(0);
-            self.tail.set(0);
-        } else {
+        if self.internal_buffer.map_or(false, |buf| buf.has_elements()) {
             // Buffer not empty, go around again
-            self.tail.set(tail);
             self.publish_str();
         }
     }
@@ -407,100 +332,35 @@ impl DebugWriterWrapper {
         });
     }
 
-    fn extract(&self) -> Option<(usize, usize, &mut [u8])> {
+    fn extract(&self) -> Option<&mut RingBuffer<'static, u8>> {
         self.dw.map_or(None, |dw| dw.extract())
     }
 }
 
 impl Write for DebugWriterWrapper {
     fn write_str(&mut self, s: &str) -> Result {
-        // Circular buffer.
-        //
-        // Note, we don't use the kernel's RingBuffer here because we want
-        // slightly different semantics. Specifically, we need to be able
-        // to take *contiguous* slices of the buffer and pass them around,
-        // we're also okay with fragmenting if we're inserting a slice over
-        // the internal wraparound, but we need to handle that case manually
-        //
-        //  - head points to the index of the first valid place to write
-        //  - tail points one past the index of the last open place to write
-        //  -> head == tail implies buffer is empty
-        //  -> there's no "full/empty" bit, so the effective buffer size is -1
-
+        const FULL_MSG: &[u8] = b"\n*** DEBUG BUFFER FULL ***\n";
         self.dw.map(|dw| {
-            let mut head = dw.head.get();
-            let tail = dw.tail.get();
-            let len = dw.internal_buffer.map_or(0, |buffer| buffer.len());
+            let bytes = s.as_bytes();
 
-            let remaining_bytes = if head >= tail {
-                let bytes = s.as_bytes();
+            let ring_buffer = dw.internal_buffer.take().unwrap();
+            let available_len_for_msg = ring_buffer.available_len().saturating_sub(FULL_MSG.len());
 
-                // First write from current head to end of buffer in memory
-                let mut backside_len = len - head;
-                if tail == 0 {
-                    // Handle special case where tail has just wrapped to 0,
-                    // so we can't let the head point to 0 as well
-                    backside_len -= 1;
+            if available_len_for_msg >= bytes.len() {
+                for &b in bytes {
+                    ring_buffer.enqueue(b);
                 }
-
-                let written = if backside_len != 0 {
-                    let start = head;
-                    let end = head + backside_len;
-                    dw.write_buffer(start, end, bytes);
-                    min(end - start, bytes.len())
-                } else {
-                    0
-                };
-
-                // Advance and possibly wrap the head
-                head += written;
-                if head == len {
-                    head = 0;
-                }
-                &bytes[written..]
             } else {
-                s.as_bytes()
-            };
-
-            // At this point, either
-            //  o head < tail
-            //  o head = len-1, tail = 0 (buffer full edge case)
-            //  o there are no more bytes to write
-
-            if remaining_bytes.len() != 0 {
-                // Now write from the head up to tail
-                let start = head;
-                let end = tail;
-                if (tail == 0) && (head == len - 1) {
-                    let active = dw.active_len.get();
-                    panic!(
-                        "Debug buffer full. Head {} tail {} len {} active {} remaining {}",
-                        head,
-                        tail,
-                        len,
-                        active,
-                        remaining_bytes.len()
-                    );
+                for &b in &bytes[..available_len_for_msg] {
+                    ring_buffer.enqueue(b);
                 }
-                if remaining_bytes.len() > end - start {
-                    let active = dw.active_len.get();
-                    panic!(
-                        "Debug buffer out of room. Head {} tail {} len {} active {} remaining {}",
-                        head,
-                        tail,
-                        len,
-                        active,
-                        remaining_bytes.len()
-                    );
+                // When the buffer is close to full, print a warning and drop the current
+                // string.
+                for &b in FULL_MSG {
+                    ring_buffer.enqueue(b);
                 }
-                dw.write_buffer(start, end, remaining_bytes);
-                let written = min(end - start, remaining_bytes.len());
-
-                // head cannot wrap here
-                head += written;
             }
-
-            dw.head.set(head);
+            dw.internal_buffer.put(Some(ring_buffer));
         });
 
         Ok(())
@@ -586,24 +446,18 @@ impl Default for Debug {
 pub unsafe fn flush<W: Write>(writer: &mut W) {
     let debug_writer = get_debug_writer();
 
-    if let Some((head, mut tail, buffer)) = debug_writer.extract() {
-        if head != tail {
+    if let Some(ring_buffer) = debug_writer.extract() {
+        if ring_buffer.has_elements() {
             let _ = writer.write_str(
                 "\r\n---| Debug buffer not empty. Flushing. May repeat some of last message(s):\r\n",
             );
 
-            if tail > head {
-                let start = buffer.as_mut_ptr().add(tail);
-                let len = buffer.len();
-                let slice = slice::from_raw_parts(start, len);
+            let (left, right) = ring_buffer.as_slices();
+            if let Some(slice) = left {
                 let s = str::from_utf8_unchecked(slice);
                 let _ = writer.write_str(s);
-                tail = 0;
             }
-            if tail != head {
-                let start = buffer.as_mut_ptr().add(tail);
-                let len = head - tail;
-                let slice = slice::from_raw_parts(start, len);
+            if let Some(slice) = right {
                 let s = str::from_utf8_unchecked(slice);
                 let _ = writer.write_str(s);
             }


### PR DESCRIPTION
### Pull Request Overview

This pull request simplifies the implementation of kernel debugging, and avoids panicking when the debug buffer is full.
Instead, messages are dropped and a marker message is written to the debug output.

The implementation now relies on the kernel's `RingBuffer` type, which makes it much simpler.

### Testing Strategy

This pull request was tested by flashing Tock on a nRF52840dk board and writing large messages to the debug output. Also tested with a smaller `INTERNAL_BUF` array in order to trigger a full buffer more often.

### TODO or Help Wanted

1. For now, the implementation copies bytes one at a time. This may be slower than the previous implementation, but I think that correctness is more important. However, the `RingBuffer` type could be extended to enqueue/dequeue many elements at a time (i.e. via slices), to potentially allow faster copying.
1. Should a _component_ (https://github.com/tock/tock/pull/1338) be defined to initialize UART on boards?

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.