### PR TITLE
rust2018: do not need macro_use

### DIFF
--- a/boards/acd52832/src/main.rs
+++ b/boards/acd52832/src/main.rs
@@ -32,7 +32,6 @@ const BUTTON4_PIN: usize = 16;
 const BUTTON_RST_PIN: usize = 19;
 
 /// UART Writer
-#[macro_use]
 pub mod io;
 
 // State for loading and holding applications.

--- a/boards/components/src/lib.rs
+++ b/boards/components/src/lib.rs
@@ -1,16 +1,13 @@
 #![no_std]
 #![feature(in_band_lifetimes)]
 
-#[macro_use]
-pub mod isl29035;
-pub mod rng;
-#[macro_use]
-pub mod crc;
-#[macro_use]
 pub mod alarm;
 pub mod console;
+pub mod crc;
+pub mod isl29035;
 pub mod nrf51822;
 pub mod process_console;
+pub mod rng;
 
 /// Same as `static_init!()` but without actually creating the static buffer.
 /// The static buffer must be passed in.

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -24,7 +24,6 @@ use kernel::{create_capability, debug, debug_gpio, static_init};
 /// Support routines for debugging I/O.
 ///
 /// Note: Use of this module will trample any other USART0 configuration.
-#[macro_use]
 pub mod io;
 #[allow(dead_code)]
 mod test_take_map_cell;

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -51,7 +51,6 @@ use imix_components::usb::UsbComponent;
 /// Support routines for debugging I/O.
 ///
 /// Note: Use of this module will trample any other USART3 configuration.
-#[macro_use]
 pub mod io;
 
 // Unit Tests for drivers.

--- a/boards/launchxl/src/main.rs
+++ b/boards/launchxl/src/main.rs
@@ -21,7 +21,6 @@ use kernel::hil::gpio;
 use kernel::hil::i2c::I2CMaster;
 use kernel::hil::rng::Rng;
 
-#[macro_use]
 pub mod io;
 
 #[allow(dead_code)]

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -39,7 +39,6 @@ const SPI_MX25R6435F_WRITE_PROTECT_PIN: usize = 22;
 const SPI_MX25R6435F_HOLD_PIN: usize = 23;
 
 /// UART Writer
-#[macro_use]
 pub mod io;
 
 // State for loading and holding applications.

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -92,7 +92,6 @@ const SPI_MISO: usize = 23;
 const SPI_CLK: usize = 24;
 
 /// UART Writer
-#[macro_use]
 pub mod io;
 
 // FIXME: Ideally this should be replaced with Rust's builtin tests by conditional compilation

--- a/kernel/src/common/utils.rs
+++ b/kernel/src/common/utils.rs
@@ -65,7 +65,6 @@ macro_rules! storage_volume {
 ///
 /// ```ignore
 /// use kernel::capabilities::ProcessManagementCapability;
-/// #[macro_use(create_capability)]
 /// use kernel;
 ///
 /// let process_mgmt_cap = create_capability!(ProcessManagementCapability);

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -14,10 +14,8 @@
 #![no_std]
 
 pub mod capabilities;
-#[macro_use]
 pub mod common;
 pub mod component;
-#[macro_use]
 pub mod debug;
 pub mod hil;
 pub mod introspection;

--- a/libraries/tock-register-interface/src/lib.rs
+++ b/libraries/tock-register-interface/src/lib.rs
@@ -5,7 +5,5 @@
 #![feature(const_fn)]
 #![no_std]
 
-#[macro_use]
 pub mod macros;
-
 pub mod registers;

--- a/libraries/tock-register-interface/src/registers.rs
+++ b/libraries/tock-register-interface/src/registers.rs
@@ -4,11 +4,10 @@
 //! registers and bitfields.
 //!
 //! ```rust
-//! # #[macro_use]
-//! # extern crate tock_registers;
 //! # fn main() {}
 //!
 //! use tock_registers::registers::{ReadOnly, ReadWrite};
+//! use tock_registers::register_bitfields;
 //!
 //! // Register maps are specified like this:
 //! #[repr(C)]


### PR DESCRIPTION
### Pull Request Overview

Many instances of `#[macro_use]` have become unneeded. This just cleans them up.


### Testing Strategy

This pull request was tested by travis.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
