### PR TITLE
components: make si7021 generic, add to hail

### DIFF
--- a/boards/components/src/lib.rs
+++ b/boards/components/src/lib.rs
@@ -9,6 +9,7 @@ pub mod isl29035;
 pub mod nrf51822;
 pub mod process_console;
 pub mod rng;
+pub mod si7021;
 pub mod spi;
 
 /// Same as `static_init!()` but without actually creating the static buffer.

--- a/boards/components/src/si7021.rs
+++ b/boards/components/src/si7021.rs
@@ -1,17 +1,18 @@
-//! Components for the SI7021 on the imix board.
+//! Components for the SI7021 Temperature/Humidity Sensor.
 //!
 //! This provides three Components, SI7021Component, which provides
 //! access to the SI7021 over I2C, TemperatureComponent, which
 //! provides a temperature system call driver, and HumidityComponent,
 //! which provides a humidity system call driver. SI7021Component is
-//! a paremeter to both TemperatureComponent and HumidityComponent.
+//! a parameter to both TemperatureComponent and HumidityComponent.
 //!
 //! Usage
 //! -----
 //! ```rust
-//! let si7021 = SI7021Component::new(mux_i2c, mux_alarm).finalize(());
-//! let temp = TemperatureComponent::new(si7021).finalize(());
-//! let humidity = HumidityComponent::new(si7021).finalize(());
+//! let si7021 = SI7021Component::new(mux_i2c, mux_alarm, 0x40).finalize(
+//!     components::si7021_component_helper!(sam4l::ast::Ast));
+//! let temp = TemperatureComponent::new(board_kernel, si7021).finalize(());
+//! let humidity = HumidityComponent::new(board_kernel, si7021).finalize(());
 //! ```
 
 // Author: Philip Levis <pal@cs.stanford.edu>
@@ -28,40 +29,61 @@ use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
 use kernel::hil;
-use kernel::hil::time::Alarm;
+use kernel::hil::time::{self, Alarm};
 use kernel::static_init;
 
-pub struct SI7021Component {
-    i2c_mux: &'static MuxI2C<'static>,
-    alarm_mux: &'static MuxAlarm<'static, sam4l::ast::Ast<'static>>,
+use crate::static_init_half;
+
+// Setup static space for the objects.
+#[macro_export]
+macro_rules! si7021_component_helper {
+    ($A:ty) => {{
+        use capsules::si7021::SI7021;
+        static mut BUF1: Option<VirtualMuxAlarm<'static, $A>> = None;
+        static mut BUF2: Option<SI7021<'static, VirtualMuxAlarm<'static, $A>>> = None;
+        (&mut BUF1, &mut BUF2)
+    };};
 }
 
-impl SI7021Component {
+pub struct SI7021Component<A: 'static + time::Alarm<'static>> {
+    i2c_mux: &'static MuxI2C<'static>,
+    alarm_mux: &'static MuxAlarm<'static, A>,
+    i2c_address: u8,
+}
+
+impl<A: 'static + time::Alarm<'static>> SI7021Component<A> {
     pub fn new(
         i2c: &'static MuxI2C<'static>,
-        alarm: &'static MuxAlarm<'static, sam4l::ast::Ast<'static>>,
+        alarm: &'static MuxAlarm<'static, A>,
+        i2c_address: u8,
     ) -> Self {
         SI7021Component {
             i2c_mux: i2c,
             alarm_mux: alarm,
+            i2c_address: i2c_address,
         }
     }
 }
 
 static mut I2C_BUF: [u8; 14] = [0; 14];
 
-impl Component for SI7021Component {
-    type StaticInput = ();
-    type Output = &'static SI7021<'static, VirtualMuxAlarm<'static, sam4l::ast::Ast<'static>>>;
+impl<A: 'static + time::Alarm<'static>> Component for SI7021Component<A> {
+    type StaticInput = (
+        &'static mut Option<VirtualMuxAlarm<'static, A>>,
+        &'static mut Option<SI7021<'static, VirtualMuxAlarm<'static, A>>>,
+    );
+    type Output = &'static SI7021<'static, VirtualMuxAlarm<'static, A>>;
 
-    unsafe fn finalize(&mut self, _s: Self::StaticInput) -> Self::Output {
-        let si7021_i2c = static_init!(I2CDevice, I2CDevice::new(self.i2c_mux, 0x40));
-        let si7021_alarm = static_init!(
-            VirtualMuxAlarm<'static, sam4l::ast::Ast>,
+    unsafe fn finalize(&mut self, static_buffer: Self::StaticInput) -> Self::Output {
+        let si7021_i2c = static_init!(I2CDevice, I2CDevice::new(self.i2c_mux, self.i2c_address));
+        let si7021_alarm = static_init_half!(
+            static_buffer.0,
+            VirtualMuxAlarm<'static, A>,
             VirtualMuxAlarm::new(self.alarm_mux)
         );
-        let si7021 = static_init!(
-            SI7021<'static, VirtualMuxAlarm<'static, sam4l::ast::Ast<'static>>>,
+        let si7021 = static_init_half!(
+            static_buffer.1,
+            SI7021<'static, VirtualMuxAlarm<'static, A>>,
             SI7021::new(si7021_i2c, si7021_alarm, &mut I2C_BUF)
         );
 
@@ -71,16 +93,16 @@ impl Component for SI7021Component {
     }
 }
 
-pub struct TemperatureComponent {
+pub struct TemperatureComponent<A: 'static + time::Alarm<'static>> {
     board_kernel: &'static kernel::Kernel,
-    si7021: &'static SI7021<'static, VirtualMuxAlarm<'static, sam4l::ast::Ast<'static>>>,
+    si7021: &'static SI7021<'static, VirtualMuxAlarm<'static, A>>,
 }
 
-impl TemperatureComponent {
+impl<A: 'static + time::Alarm<'static>> TemperatureComponent<A> {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
-        si: &'static SI7021<'static, VirtualMuxAlarm<'static, sam4l::ast::Ast<'static>>>,
-    ) -> TemperatureComponent {
+        si: &'static SI7021<'static, VirtualMuxAlarm<'static, A>>,
+    ) -> TemperatureComponent<A> {
         TemperatureComponent {
             board_kernel: board_kernel,
             si7021: si,
@@ -88,7 +110,7 @@ impl TemperatureComponent {
     }
 }
 
-impl Component for TemperatureComponent {
+impl<A: 'static + time::Alarm<'static>> Component for TemperatureComponent<A> {
     type StaticInput = ();
     type Output = &'static TemperatureSensor<'static>;
 
@@ -105,16 +127,16 @@ impl Component for TemperatureComponent {
     }
 }
 
-pub struct HumidityComponent {
+pub struct HumidityComponent<A: 'static + time::Alarm<'static>> {
     board_kernel: &'static kernel::Kernel,
-    si7021: &'static SI7021<'static, VirtualMuxAlarm<'static, sam4l::ast::Ast<'static>>>,
+    si7021: &'static SI7021<'static, VirtualMuxAlarm<'static, A>>,
 }
 
-impl HumidityComponent {
+impl<A: 'static + time::Alarm<'static>> HumidityComponent<A> {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
-        si: &'static SI7021<'static, VirtualMuxAlarm<'static, sam4l::ast::Ast<'static>>>,
-    ) -> HumidityComponent {
+        si: &'static SI7021<'static, VirtualMuxAlarm<'static, A>>,
+    ) -> HumidityComponent<A> {
         HumidityComponent {
             board_kernel: board_kernel,
             si7021: si,
@@ -122,7 +144,7 @@ impl HumidityComponent {
     }
 }
 
-impl Component for HumidityComponent {
+impl<A: 'static + time::Alarm<'static>> Component for HumidityComponent<A> {
     type StaticInput = ();
     type Output = &'static HumiditySensor<'static>;
 

--- a/boards/imix/src/imix_components/mod.rs
+++ b/boards/imix/src/imix_components/mod.rs
@@ -7,7 +7,6 @@ pub mod led;
 pub mod nonvolatile_storage;
 pub mod radio;
 pub mod rf233;
-pub mod si7021;
 pub mod udp_6lowpan;
 pub mod usb;
 
@@ -20,6 +19,5 @@ pub use self::led::LedComponent;
 pub use self::nonvolatile_storage::NonvolatileStorageComponent;
 pub use self::radio::RadioComponent;
 pub use self::rf233::RF233Component;
-pub use self::si7021::{HumidityComponent, SI7021Component, TemperatureComponent};
 pub use self::udp_6lowpan::UDPComponent;
 pub use self::usb::UsbComponent;

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -34,6 +34,7 @@ use components::isl29035::AmbientLightComponent;
 use components::nrf51822::Nrf51822Component;
 use components::process_console::ProcessConsoleComponent;
 use components::rng::RngComponent;
+use components::si7021::{HumidityComponent, SI7021Component, TemperatureComponent};
 use components::spi::{SpiComponent, SpiSyscallComponent};
 use imix_components::adc::AdcComponent;
 use imix_components::analog_comparator::AcComponent;
@@ -44,7 +45,6 @@ use imix_components::led::LedComponent;
 use imix_components::nonvolatile_storage::NonvolatileStorageComponent;
 use imix_components::radio::RadioComponent;
 use imix_components::rf233::RF233Component;
-use imix_components::si7021::{HumidityComponent, SI7021Component, TemperatureComponent};
 use imix_components::udp_6lowpan::UDPComponent;
 use imix_components::usb::UsbComponent;
 
@@ -337,7 +337,8 @@ pub unsafe fn reset_handler() {
 
     let ambient_light = AmbientLightComponent::new(board_kernel, mux_i2c, mux_alarm)
         .finalize(components::isl29035_component_helper!(sam4l::ast::Ast));
-    let si7021 = SI7021Component::new(mux_i2c, mux_alarm).finalize(());
+    let si7021 = SI7021Component::new(mux_i2c, mux_alarm, 0x40)
+        .finalize(components::si7021_component_helper!(sam4l::ast::Ast));
     let temp = TemperatureComponent::new(board_kernel, si7021).finalize(());
     let humidity = HumidityComponent::new(board_kernel, si7021).finalize(());
     let ninedof = NineDofComponent::new(board_kernel, mux_i2c, &sam4l::gpio::PC[13]).finalize(());


### PR DESCRIPTION
### Pull Request Overview

This pull request updates the SI7021 temp/humidity component to be generic.


### Testing Strategy

This pull request was tested by travis.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
