### PR TITLE
board: arty: use components

### DIFF
--- a/boards/arty-e21/Cargo.lock
+++ b/boards/arty-e21/Cargo.lock
@@ -6,6 +6,7 @@ version = "0.1.0"
 dependencies = [
  "arty_e21 0.1.0",
  "capsules 0.1.0",
+ "components 0.1.0",
  "kernel 0.1.0",
  "rv32i 0.1.0",
  "sifive 0.1.0",
@@ -25,6 +26,14 @@ name = "capsules"
 version = "0.1.0"
 dependencies = [
  "enum_primitive 0.1.0",
+ "kernel 0.1.0",
+]
+
+[[package]]
+name = "components"
+version = "0.1.0"
+dependencies = [
+ "capsules 0.1.0",
  "kernel 0.1.0",
 ]
 

--- a/boards/arty-e21/Cargo.toml
+++ b/boards/arty-e21/Cargo.toml
@@ -18,6 +18,7 @@ opt-level = "z"
 debug = true
 
 [dependencies]
+components = { path = "../components" }
 rv32i = { path = "../../arch/rv32i" }
 capsules = { path = "../../capsules" }
 kernel = { path = "../../kernel" }


### PR DESCRIPTION
### Pull Request Overview

This pull request updates the arty-e21 board to use a couple components.


### Testing Strategy

This pull request was tested by running the kernel on the board and verifying it prints the init message.


### TODO or Help Wanted

I mean if someone wants to port more things to generic components...but it makes sense to just have a series of PRs for that.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
