### PR TITLE
libraries: release tock-register-interface v0.4

### DIFF
--- a/boards/acd52832/Cargo.lock
+++ b/boards/acd52832/Cargo.lock
@@ -52,7 +52,7 @@ name = "kernel"
 version = "0.1.0"
 dependencies = [
  "tock-cells 0.1.0",
- "tock-registers 0.3.0",
+ "tock-registers 0.4.0",
 ]
 
 [[package]]
@@ -90,7 +90,7 @@ version = "0.1.0"
 
 [[package]]
 name = "tock-registers"
-version = "0.3.0"
+version = "0.4.0"
 
 [[package]]
 name = "tock_rt0"

--- a/boards/arty-e21/Cargo.lock
+++ b/boards/arty-e21/Cargo.lock
@@ -37,14 +37,14 @@ name = "kernel"
 version = "0.1.0"
 dependencies = [
  "tock-cells 0.1.0",
- "tock-registers 0.3.0",
+ "tock-registers 0.4.0",
 ]
 
 [[package]]
 name = "riscv-csr"
 version = "0.1.0"
 dependencies = [
- "tock-registers 0.3.0",
+ "tock-registers 0.4.0",
 ]
 
 [[package]]
@@ -53,7 +53,7 @@ version = "0.1.0"
 dependencies = [
  "kernel 0.1.0",
  "riscv-csr 0.1.0",
- "tock-registers 0.3.0",
+ "tock-registers 0.4.0",
  "tock_rt0 0.1.0",
 ]
 
@@ -71,7 +71,7 @@ version = "0.1.0"
 
 [[package]]
 name = "tock-registers"
-version = "0.3.0"
+version = "0.4.0"
 
 [[package]]
 name = "tock_rt0"

--- a/boards/hail/Cargo.lock
+++ b/boards/hail/Cargo.lock
@@ -51,7 +51,7 @@ name = "kernel"
 version = "0.1.0"
 dependencies = [
  "tock-cells 0.1.0",
- "tock-registers 0.3.0",
+ "tock-registers 0.4.0",
 ]
 
 [[package]]
@@ -69,7 +69,7 @@ version = "0.1.0"
 
 [[package]]
 name = "tock-registers"
-version = "0.3.0"
+version = "0.4.0"
 
 [[package]]
 name = "tock_rt0"

--- a/boards/hifive1/Cargo.lock
+++ b/boards/hifive1/Cargo.lock
@@ -37,14 +37,14 @@ name = "kernel"
 version = "0.1.0"
 dependencies = [
  "tock-cells 0.1.0",
- "tock-registers 0.3.0",
+ "tock-registers 0.4.0",
 ]
 
 [[package]]
 name = "riscv-csr"
 version = "0.1.0"
 dependencies = [
- "tock-registers 0.3.0",
+ "tock-registers 0.4.0",
 ]
 
 [[package]]
@@ -53,7 +53,7 @@ version = "0.1.0"
 dependencies = [
  "kernel 0.1.0",
  "riscv-csr 0.1.0",
- "tock-registers 0.3.0",
+ "tock-registers 0.4.0",
  "tock_rt0 0.1.0",
 ]
 
@@ -71,7 +71,7 @@ version = "0.1.0"
 
 [[package]]
 name = "tock-registers"
-version = "0.3.0"
+version = "0.4.0"
 
 [[package]]
 name = "tock_rt0"

--- a/boards/imix/Cargo.lock
+++ b/boards/imix/Cargo.lock
@@ -51,7 +51,7 @@ name = "kernel"
 version = "0.1.0"
 dependencies = [
  "tock-cells 0.1.0",
- "tock-registers 0.3.0",
+ "tock-registers 0.4.0",
 ]
 
 [[package]]
@@ -69,7 +69,7 @@ version = "0.1.0"
 
 [[package]]
 name = "tock-registers"
-version = "0.3.0"
+version = "0.4.0"
 
 [[package]]
 name = "tock_rt0"

--- a/boards/launchxl/Cargo.lock
+++ b/boards/launchxl/Cargo.lock
@@ -42,7 +42,7 @@ name = "kernel"
 version = "0.1.0"
 dependencies = [
  "tock-cells 0.1.0",
- "tock-registers 0.3.0",
+ "tock-registers 0.4.0",
 ]
 
 [[package]]
@@ -62,7 +62,7 @@ version = "0.1.0"
 
 [[package]]
 name = "tock-registers"
-version = "0.3.0"
+version = "0.4.0"
 
 [[package]]
 name = "tock_rt0"

--- a/boards/nordic/nrf52840dk/Cargo.lock
+++ b/boards/nordic/nrf52840dk/Cargo.lock
@@ -40,7 +40,7 @@ name = "kernel"
 version = "0.1.0"
 dependencies = [
  "tock-cells 0.1.0",
- "tock-registers 0.3.0",
+ "tock-registers 0.4.0",
 ]
 
 [[package]]
@@ -90,7 +90,7 @@ version = "0.1.0"
 
 [[package]]
 name = "tock-registers"
-version = "0.3.0"
+version = "0.4.0"
 
 [[package]]
 name = "tock_rt0"

--- a/boards/nordic/nrf52dk/Cargo.lock
+++ b/boards/nordic/nrf52dk/Cargo.lock
@@ -40,7 +40,7 @@ name = "kernel"
 version = "0.1.0"
 dependencies = [
  "tock-cells 0.1.0",
- "tock-registers 0.3.0",
+ "tock-registers 0.4.0",
 ]
 
 [[package]]
@@ -90,7 +90,7 @@ version = "0.1.0"
 
 [[package]]
 name = "tock-registers"
-version = "0.3.0"
+version = "0.4.0"
 
 [[package]]
 name = "tock_rt0"

--- a/boards/nucleo_f429zi/Cargo.lock
+++ b/boards/nucleo_f429zi/Cargo.lock
@@ -32,7 +32,7 @@ name = "kernel"
 version = "0.1.0"
 dependencies = [
  "tock-cells 0.1.0",
- "tock-registers 0.3.0",
+ "tock-registers 0.4.0",
 ]
 
 [[package]]
@@ -61,7 +61,7 @@ version = "0.1.0"
 
 [[package]]
 name = "tock-registers"
-version = "0.3.0"
+version = "0.4.0"
 
 [[package]]
 name = "tock_rt0"

--- a/boards/nucleo_f446re/Cargo.lock
+++ b/boards/nucleo_f446re/Cargo.lock
@@ -32,7 +32,7 @@ name = "kernel"
 version = "0.1.0"
 dependencies = [
  "tock-cells 0.1.0",
- "tock-registers 0.3.0",
+ "tock-registers 0.4.0",
 ]
 
 [[package]]
@@ -61,7 +61,7 @@ version = "0.1.0"
 
 [[package]]
 name = "tock-registers"
-version = "0.3.0"
+version = "0.4.0"
 
 [[package]]
 name = "tock_rt0"

--- a/libraries/tock-register-interface/CHANGELOG.md
+++ b/libraries/tock-register-interface/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## master
 
+
+## v0.4
+
  - #1368: Remove `new()` and add `InMemoryRegister`
  - #1410: Add new macro for generating structs
 

--- a/libraries/tock-register-interface/Cargo.lock
+++ b/libraries/tock-register-interface/Cargo.lock
@@ -2,5 +2,5 @@
 # It is not intended for manual editing.
 [[package]]
 name = "tock-registers"
-version = "0.3.0"
+version = "0.4.0"
 

--- a/libraries/tock-register-interface/Cargo.toml
+++ b/libraries/tock-register-interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tock-registers"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
 description = "Memory-Mapped I/O and register interface developed for Tock."
 homepage = "https://www.tockos.org/"


### PR DESCRIPTION
### Pull Request Overview

Release v0.4 of register interface.

New in v0.4:

 - #1368: Remove `new()` and add `InMemoryRegister`
 - #1410: Add new macro for generating structs

Closes #1444.

### Testing Strategy

Compiling.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make formatall`.
