### PR TITLE
Add DebugWriter component, use console component

### DIFF
--- a/boards/acd52832/Cargo.lock
+++ b/boards/acd52832/Cargo.lock
@@ -5,6 +5,7 @@ name = "acd52832"
 version = "0.1.0"
 dependencies = [
  "capsules 0.1.0",
+ "components 0.1.0",
  "cortexm4 0.1.0",
  "kernel 0.1.0",
  "nrf52 0.1.0",

--- a/boards/acd52832/Cargo.toml
+++ b/boards/acd52832/Cargo.toml
@@ -18,6 +18,7 @@ opt-level = "z"
 debug = true
 
 [dependencies]
+components = { path = "../components" }
 cortexm4 = { path = "../../arch/cortex-m4" }
 capsules = { path = "../../capsules" }
 kernel = { path = "../../kernel" }

--- a/boards/components/Cargo.lock
+++ b/boards/components/Cargo.lock
@@ -25,7 +25,7 @@ name = "kernel"
 version = "0.1.0"
 dependencies = [
  "tock-cells 0.1.0",
- "tock-registers 0.3.0",
+ "tock-registers 0.4.0",
 ]
 
 [[package]]
@@ -34,5 +34,5 @@ version = "0.1.0"
 
 [[package]]
 name = "tock-registers"
-version = "0.3.0"
+version = "0.4.0"
 

--- a/boards/components/src/debug_writer.rs
+++ b/boards/components/src/debug_writer.rs
@@ -1,0 +1,65 @@
+//! Component for DebugWriter, the implementation for `debug!()`.
+//!
+//! This provides one `Component`, `DebugWriter`, which attaches kernel debug
+//! output (for panic!, print!, debug!, etc.) to the provided UART mux.
+//!
+//! Usage
+//! -----
+//! ```rust
+//! DebugWriterComponent::new(uart_mux).finalize(());
+//! ```
+
+// Author: Brad Campbell <bradjc@virginia.edu>
+// Last modified: 11/07/2019
+
+#![allow(dead_code)] // Components are intended to be conditionally included
+
+use capsules::virtual_uart::{MuxUart, UartDevice};
+use kernel::capabilities;
+use kernel::common::ring_buffer::RingBuffer;
+use kernel::component::Component;
+use kernel::hil;
+use kernel::static_init;
+
+pub struct DebugWriterComponent {
+    uart_mux: &'static MuxUart<'static>,
+}
+
+impl DebugWriterComponent {
+    pub fn new(uart_mux: &'static MuxUart) -> DebugWriterComponent {
+        DebugWriterComponent { uart_mux: uart_mux }
+    }
+}
+
+pub struct Capability;
+unsafe impl capabilities::ProcessManagementCapability for Capability {}
+
+impl Component for DebugWriterComponent {
+    type StaticInput = ();
+    type Output = ();
+
+    unsafe fn finalize(&mut self, _s: Self::StaticInput) -> Self::Output {
+        // Create virtual device for kernel debug.
+        let debugger_uart = static_init!(UartDevice, UartDevice::new(self.uart_mux, false));
+        debugger_uart.setup();
+        let ring_buffer = static_init!(
+            RingBuffer<'static, u8>,
+            RingBuffer::new(&mut kernel::debug::INTERNAL_BUF)
+        );
+        let debugger = static_init!(
+            kernel::debug::DebugWriter,
+            kernel::debug::DebugWriter::new(
+                debugger_uart,
+                &mut kernel::debug::OUTPUT_BUF,
+                ring_buffer,
+            )
+        );
+        hil::uart::Transmit::set_transmit_client(debugger_uart, debugger);
+
+        let debug_wrapper = static_init!(
+            kernel::debug::DebugWriterWrapper,
+            kernel::debug::DebugWriterWrapper::new(debugger)
+        );
+        kernel::debug::set_debug_writer_wrapper(debug_wrapper);
+    }
+}

--- a/boards/components/src/lib.rs
+++ b/boards/components/src/lib.rs
@@ -4,6 +4,7 @@
 pub mod alarm;
 pub mod console;
 pub mod crc;
+pub mod debug_writer;
 pub mod isl29035;
 pub mod nrf51822;
 pub mod process_console;

--- a/boards/hifive1/Cargo.lock
+++ b/boards/hifive1/Cargo.lock
@@ -9,6 +9,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "components"
+version = "0.1.0"
+dependencies = [
+ "capsules 0.1.0",
+ "kernel 0.1.0",
+]
+
+[[package]]
 name = "e310x"
 version = "0.1.0"
 dependencies = [
@@ -26,6 +34,7 @@ name = "hifive1"
 version = "0.1.0"
 dependencies = [
  "capsules 0.1.0",
+ "components 0.1.0",
  "e310x 0.1.0",
  "kernel 0.1.0",
  "rv32i 0.1.0",

--- a/boards/hifive1/Cargo.toml
+++ b/boards/hifive1/Cargo.toml
@@ -18,6 +18,7 @@ opt-level = "z"
 debug = true
 
 [dependencies]
+components = { path = "../components" }
 rv32i = { path = "../../arch/rv32i" }
 capsules = { path = "../../capsules" }
 kernel = { path = "../../kernel" }

--- a/boards/hifive1/src/main.rs
+++ b/boards/hifive1/src/main.rs
@@ -13,9 +13,9 @@
 #![feature(asm)]
 
 use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
-use capsules::virtual_uart::{MuxUart, UartDevice};
+use capsules::virtual_uart::MuxUart;
 use kernel::capabilities;
-use kernel::common::ring_buffer::RingBuffer;
+use kernel::component::Component;
 use kernel::hil;
 use kernel::Platform;
 use kernel::{create_capability, debug, static_init};
@@ -136,25 +136,6 @@ pub unsafe fn reset_handler() {
     hil::gpio::Pin::make_output(&e310x::gpio::PORT[21]);
     hil::gpio::Pin::clear(&e310x::gpio::PORT[21]);
 
-    // Create virtual device for kernel debug.
-    let debugger_uart = static_init!(UartDevice, UartDevice::new(uart_mux, false));
-    debugger_uart.setup();
-    let ring_buffer = static_init!(
-        RingBuffer<'static, u8>,
-        RingBuffer::new(&mut kernel::debug::INTERNAL_BUF)
-    );
-    let debugger = static_init!(
-        kernel::debug::DebugWriter,
-        kernel::debug::DebugWriter::new(debugger_uart, &mut kernel::debug::OUTPUT_BUF, ring_buffer)
-    );
-    hil::uart::Transmit::set_transmit_client(debugger_uart, debugger);
-
-    let debug_wrapper = static_init!(
-        kernel::debug::DebugWriterWrapper,
-        kernel::debug::DebugWriterWrapper::new(debugger)
-    );
-    kernel::debug::set_debug_writer_wrapper(debug_wrapper);
-
     e310x::uart::UART0.initialize_gpio_pins(&e310x::gpio::PORT[17], &e310x::gpio::PORT[16]);
 
     // Create a shared virtualization mux layer on top of a single hardware
@@ -182,20 +163,10 @@ pub unsafe fn reset_handler() {
     );
     hil::time::Alarm::set_client(virtual_alarm_user, alarm);
 
-    // Create a UartDevice for the console.
-    let console_uart = static_init!(UartDevice, UartDevice::new(uart_mux, true));
-    console_uart.setup();
-    let console = static_init!(
-        capsules::console::Console<'static>,
-        capsules::console::Console::new(
-            console_uart,
-            &mut capsules::console::WRITE_BUF,
-            &mut capsules::console::READ_BUF,
-            board_kernel.create_grant(&memory_allocation_cap)
-        )
-    );
-    hil::uart::Transmit::set_transmit_client(console_uart, console);
-    hil::uart::Receive::set_receive_client(console_uart, console);
+    // Setup the console.
+    let console = components::console::ConsoleComponent::new(board_kernel, uart_mux).finalize(());
+    // Create the debugger object that handles calls to `debug!()`.
+    components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
 
     debug!("HiFive1 initialization complete. Entering main loop");
 

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -314,6 +314,7 @@ pub unsafe fn reset_handler() {
 
     let pconsole = ProcessConsoleComponent::new(board_kernel, uart_mux).finalize(());
     let console = ConsoleComponent::new(board_kernel, uart_mux).finalize(());
+    DebugWriterComponent::new(uart_mux).finalize(());
 
     // Allow processes to communicate over BLE through the nRF51822
     sam4l::usart::USART2.set_mode(sam4l::usart::UsartMode::Uart);

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -30,6 +30,7 @@ use kernel::{create_capability, debug, debug_gpio, static_init};
 use components::alarm::AlarmDriverComponent;
 use components::console::ConsoleComponent;
 use components::crc::CrcComponent;
+use components::debug_writer::DebugWriterComponent;
 use components::isl29035::AmbientLightComponent;
 use components::nrf51822::Nrf51822Component;
 use components::process_console::ProcessConsoleComponent;

--- a/boards/launchxl/Cargo.lock
+++ b/boards/launchxl/Cargo.lock
@@ -19,6 +19,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "components"
+version = "0.1.0"
+dependencies = [
+ "capsules 0.1.0",
+ "kernel 0.1.0",
+]
+
+[[package]]
 name = "cortexm"
 version = "0.1.0"
 dependencies = [
@@ -51,6 +59,7 @@ version = "0.1.0"
 dependencies = [
  "capsules 0.1.0",
  "cc26x2 0.1.0",
+ "components 0.1.0",
  "cortexm4 0.1.0",
  "enum_primitive 0.1.0",
  "kernel 0.1.0",

--- a/boards/launchxl/Cargo.toml
+++ b/boards/launchxl/Cargo.toml
@@ -26,6 +26,7 @@ name = "launchxlccfg"
 path = "src/ccfg.rs"
 
 [dependencies]
+components = { path = "../components" }
 cortexm4 = { path = "../../arch/cortex-m4" }
 capsules = { path = "../../capsules" }
 kernel = { path = "../../kernel" }

--- a/boards/nordic/nrf52dk_base/Cargo.lock
+++ b/boards/nordic/nrf52dk_base/Cargo.lock
@@ -40,7 +40,7 @@ name = "kernel"
 version = "0.1.0"
 dependencies = [
  "tock-cells 0.1.0",
- "tock-registers 0.3.0",
+ "tock-registers 0.4.0",
 ]
 
 [[package]]
@@ -78,7 +78,7 @@ version = "0.1.0"
 
 [[package]]
 name = "tock-registers"
-version = "0.3.0"
+version = "0.4.0"
 
 [[package]]
 name = "tock_rt0"

--- a/boards/nucleo_f429zi/Cargo.lock
+++ b/boards/nucleo_f429zi/Cargo.lock
@@ -9,6 +9,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "components"
+version = "0.1.0"
+dependencies = [
+ "capsules 0.1.0",
+ "kernel 0.1.0",
+]
+
+[[package]]
 name = "cortexm"
 version = "0.1.0"
 dependencies = [
@@ -40,6 +48,7 @@ name = "nucleo_f429zi"
 version = "0.1.0"
 dependencies = [
  "capsules 0.1.0",
+ "components 0.1.0",
  "cortexm4 0.1.0",
  "kernel 0.1.0",
  "stm32f4xx 0.1.0",

--- a/boards/nucleo_f429zi/Cargo.toml
+++ b/boards/nucleo_f429zi/Cargo.toml
@@ -18,6 +18,7 @@ opt-level = "z"
 debug = true
 
 [dependencies]
+components = { path = "../components" }
 cortexm4 = { path = "../../arch/cortex-m4" }
 capsules = { path = "../../capsules" }
 kernel = { path = "../../kernel" }

--- a/boards/nucleo_f446re/Cargo.lock
+++ b/boards/nucleo_f446re/Cargo.lock
@@ -9,6 +9,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "components"
+version = "0.1.0"
+dependencies = [
+ "capsules 0.1.0",
+ "kernel 0.1.0",
+]
+
+[[package]]
 name = "cortexm"
 version = "0.1.0"
 dependencies = [
@@ -40,6 +48,7 @@ name = "nucleo_f446re"
 version = "0.1.0"
 dependencies = [
  "capsules 0.1.0",
+ "components 0.1.0",
  "cortexm4 0.1.0",
  "kernel 0.1.0",
  "stm32f4xx 0.1.0",

--- a/boards/nucleo_f446re/Cargo.toml
+++ b/boards/nucleo_f446re/Cargo.toml
@@ -18,6 +18,7 @@ opt-level = "z"
 debug = true
 
 [dependencies]
+components = { path = "../components" }
 cortexm4 = { path = "../../arch/cortex-m4" }
 capsules = { path = "../../capsules" }
 kernel = { path = "../../kernel" }

--- a/boards/nucleo_f446re/src/main.rs
+++ b/boards/nucleo_f446re/src/main.rs
@@ -8,9 +8,9 @@
 #![deny(missing_docs)]
 
 use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
-use capsules::virtual_uart::{MuxUart, UartDevice};
+use capsules::virtual_uart::MuxUart;
 use kernel::capabilities;
-use kernel::common::ring_buffer::RingBuffer;
+use kernel::component::Component;
 use kernel::hil::gpio::Configure;
 use kernel::hil::{self, time::Alarm};
 use kernel::Platform;
@@ -209,25 +209,6 @@ pub unsafe fn reset_handler() {
     hil::uart::Transmit::set_transmit_client(&stm32f4xx::usart::USART2, mux_uart);
     hil::uart::Receive::set_receive_client(&stm32f4xx::usart::USART2, mux_uart);
 
-    // Create a virtual device for kernel debug.
-    let debugger_uart = static_init!(UartDevice, UartDevice::new(mux_uart, false));
-    debugger_uart.setup();
-    let ring_buffer = static_init!(
-        RingBuffer<'static, u8>,
-        RingBuffer::new(&mut kernel::debug::INTERNAL_BUF)
-    );
-    let debugger = static_init!(
-        kernel::debug::DebugWriter,
-        kernel::debug::DebugWriter::new(debugger_uart, &mut kernel::debug::OUTPUT_BUF, ring_buffer)
-    );
-    hil::uart::Transmit::set_transmit_client(debugger_uart, debugger);
-
-    let debug_wrapper = static_init!(
-        kernel::debug::DebugWriterWrapper,
-        kernel::debug::DebugWriterWrapper::new(debugger)
-    );
-    kernel::debug::set_debug_writer_wrapper(debug_wrapper);
-
     // Create capabilities that the board needs to call certain protected kernel
     // functions.
     let memory_allocation_capability = create_capability!(capabilities::MemoryAllocationCapability);
@@ -235,20 +216,10 @@ pub unsafe fn reset_handler() {
     let process_management_capability =
         create_capability!(capabilities::ProcessManagementCapability);
 
-    // Create a UartDevice for console
-    let console_uart = static_init!(UartDevice, UartDevice::new(mux_uart, true));
-    console_uart.setup();
-    let console = static_init!(
-        capsules::console::Console,
-        capsules::console::Console::new(
-            console_uart,
-            &mut capsules::console::WRITE_BUF,
-            &mut capsules::console::READ_BUF,
-            board_kernel.create_grant(&memory_allocation_capability)
-        )
-    );
-    hil::uart::Transmit::set_transmit_client(console_uart, console);
-    hil::uart::Receive::set_receive_client(console_uart, console);
+    // Setup the console.
+    let console = components::console::ConsoleComponent::new(board_kernel, mux_uart).finalize(());
+    // Create the debugger object that handles calls to `debug!()`.
+    components::debug_writer::DebugWriterComponent::new(mux_uart).finalize(());
 
     // // Setup the process inspection console
     // let process_console_uart = static_init!(UartDevice, UartDevice::new(mux_uart, true));


### PR DESCRIPTION
### Pull Request Overview

Both the process console and console components used to setup the debug console so that `debug!()` works. This is unnecessary repetition. This PR moves the `debug!()` setup to its own component so that both console and process_console can be included with debug getting configured only once.

This also then applies the capsule component and debug component to more boards on the chip.


### Testing Strategy

I tested this with hail, and travis compiled all of the boards.



### TODO or Help Wanted

Should be good.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
