### PR TITLE
Implement a driver, HIL, and capsule to write to flash

### DIFF
--- a/capsules/src/driver.rs
+++ b/capsules/src/driver.rs
@@ -39,6 +39,7 @@ pub enum NUM {
     AppFlash              = 0x50000,
     NvmStorage            = 0x50001,
     SdCard                = 0x50002,
+    EmbeddedFlash         = 0x50003,
 
     // Sensors
     Temperature           = 0x60000,

--- a/capsules/src/embedded_flash.rs
+++ b/capsules/src/embedded_flash.rs
@@ -1,0 +1,116 @@
+//! Gives access to the writeable embedded flash regions of the application.
+//!
+//! The purpose of this capsule is to provide low-level control of the embedded flash to allow
+//! applications to implement flash-efficient data-structures using their writeable flash regions.
+//! The API is blocking since most flash either halt the CPU during write and erase operations or
+//! ask the application to wait until the operation is finished. A blocking API is also simpler to
+//! reason and less error-prone.
+//!
+//! # Syscalls
+//!
+//! - COMMAND(0): Check the driver.
+//! - COMMAND(1, 0): Get the word size.
+//! - COMMAND(1, 1): Get the page size.
+//! - COMMAND(1, 2): Get the maximum number of word writes between page erasures.
+//! - COMMAND(1, 3): Get the maximum number page erasures in the lifetime of the flash.
+//! - COMMAND(2, ptr): Write the allow slice to the flash region starting at `ptr`.
+//!   - `ptr` must be word-aligned.
+//!   - The allow slice length must be word aligned.
+//!   - The region starting at `ptr` of the same length as the allow slice must be in a writeable
+//!     flash region.
+//! - COMMAND(3, ptr): Erase a page.
+//!   - `ptr` must be page-aligned.
+//!   - The page starting at `ptr` must be in a writeable flash region.
+//! - ALLOW(0): The allow slice for COMMAND(2).
+
+use kernel::hil;
+use kernel::{AppId, AppSlice, Callback, Driver, Grant, ReturnCode, Shared};
+
+pub const DRIVER_NUM: usize = crate::driver::NUM::EmbeddedFlash as usize;
+
+#[derive(Default)]
+pub struct App {
+    /// The allow slice for COMMAND(2).
+    slice: Option<AppSlice<Shared, u8>>,
+}
+
+pub struct EmbeddedFlash {
+    driver: &'static dyn hil::embedded_flash::EmbeddedFlash,
+    apps: Grant<App>,
+}
+
+impl EmbeddedFlash {
+    pub fn new(
+        driver: &'static dyn hil::embedded_flash::EmbeddedFlash,
+        apps: Grant<App>,
+    ) -> EmbeddedFlash {
+        EmbeddedFlash { driver, apps }
+    }
+}
+
+impl Driver for EmbeddedFlash {
+    fn subscribe(&self, _: usize, _: Option<Callback>, _: AppId) -> ReturnCode {
+        ReturnCode::ENOSUPPORT
+    }
+
+    fn command(&self, cmd: usize, arg: usize, _: usize, appid: AppId) -> ReturnCode {
+        match (cmd, arg) {
+            (0, _) => ReturnCode::SUCCESS,
+
+            (1, 0) => ReturnCode::SuccessWithValue {
+                value: self.driver.word_size(),
+            },
+            (1, 1) => ReturnCode::SuccessWithValue {
+                value: self.driver.page_size(),
+            },
+            (1, 2) => ReturnCode::SuccessWithValue {
+                value: self.driver.max_word_writes(),
+            },
+            (1, 3) => ReturnCode::SuccessWithValue {
+                value: self.driver.max_page_erases(),
+            },
+            (1, _) => ReturnCode::EINVAL,
+
+            (2, ptr) => self
+                .apps
+                .enter(appid, |app, _| {
+                    let slice = match app.slice.take() {
+                        None => return ReturnCode::EINVAL,
+                        Some(slice) => slice,
+                    };
+                    if !appid.in_writeable_flash_region(ptr, slice.len()) {
+                        return ReturnCode::EINVAL;
+                    }
+                    self.driver.write_slice(ptr, slice.as_ref())
+                })
+                .unwrap_or_else(|err| err.into()),
+
+            (3, ptr) => {
+                if !appid.in_writeable_flash_region(ptr, self.driver.page_size()) {
+                    return ReturnCode::EINVAL;
+                }
+                self.driver.erase_page(ptr)
+            }
+
+            _ => ReturnCode::ENOSUPPORT,
+        }
+    }
+
+    fn allow(
+        &self,
+        appid: AppId,
+        allow_num: usize,
+        slice: Option<AppSlice<Shared, u8>>,
+    ) -> ReturnCode {
+        match allow_num {
+            0 => self
+                .apps
+                .enter(appid, |app, _| {
+                    app.slice = slice;
+                    ReturnCode::SUCCESS
+                })
+                .unwrap_or_else(|err| err.into()),
+            _ => ReturnCode::ENOSUPPORT,
+        }
+    }
+}

--- a/capsules/src/lib.rs
+++ b/capsules/src/lib.rs
@@ -22,6 +22,7 @@ pub mod crc;
 pub mod dac;
 pub mod debug_process_restart;
 pub mod driver;
+pub mod embedded_flash;
 pub mod fm25cl;
 pub mod fxos8700cq;
 pub mod gpio;

--- a/doc/syscalls/50003_embedded_flash.md
+++ b/doc/syscalls/50003_embedded_flash.md
@@ -1,0 +1,84 @@
+---
+driver number: 0x50003
+---
+
+# Embedded flash
+
+## Overview
+
+The embedded flash driver provides low-level control of the writeable flash
+regions of the application.
+
+## Command
+
+  * ### Command number: `0`
+
+    **Description**: Check if the driver is present on the board.
+
+    **Argument 1**: unused
+
+    **Argument 2**: unused
+
+    **Returns**: `SUCCESS` if the driver is present on the board, `ENODEVICE`
+    otherwise.
+
+  * ### Command number: `1`
+
+    **Description**: Get information about the driver.
+
+    **Argument 1**:
+      - 0: Get the word size.
+      - 1: Get the page size.
+      - 2: Get the maximum number of word writes between page erasures.
+      - 3: Get the maximum number page erasures in the lifetime of the flash.
+
+    **Argument 2**: unused
+
+    **Returns**: The corresponding value if the first argument is valid,
+    `EINVAL` otherwise.
+
+  * ### Command number: `2`
+
+    **Description**: Write a slice to a flash region. Before calling this
+    command, a slice to read from should be allowed (see allow number 0).
+
+    **Argument 1**: The start address of the flash region to write to. The
+    length is defined by the length of the allow slice. The address and length
+    must be word-aligned. The flash region must be in a writeable flash region.
+
+    **Argument 2**: unused
+
+    **Returns**: `SUCCESS` if the slice was successfully written, `EINVAL`
+    otherwise.
+
+  * ### Command number: `3`
+
+    **Description**: Erase a page.
+
+    **Argument 1**: The start address of the flash page to erase. The length is
+    implicitly the page size. The flash page must be in a writeable flash
+    region.
+
+    **Argument 2**: unused
+
+    **Returns**: `SUCCESS` if the page was successfully erased, `EINVAL`
+    otherwise.
+
+## Subscribe
+
+Unused for the embedded flash driver. Will always return `ENOSUPPORT`.
+
+## Allow
+
+  * ### Allow number: `0`
+
+    **Description**: The slice to read from when writing to a flash region.
+    Should be called before calling command number 2.
+
+    **Argument**: The slice whose content should be written to flash. The
+    slice should be in RAM (until [#1274] is fixed) and will not be modified.
+
+    **Returns**: `SUCCESS` if the slice was successfully allowed, an error
+    otherwise.
+
+[#1274]: https://github.com/tock/tock/issues/1274

--- a/kernel/src/callback.rs
+++ b/kernel/src/callback.rs
@@ -50,6 +50,31 @@ impl AppId {
             (start, end)
         })
     }
+
+    pub fn in_writeable_flash_region(&self, ptr: usize, len: usize) -> bool {
+        self.kernel.process_map_or(false, self.idx, |process| {
+            let ptr = match ptr.checked_sub(process.flash_start() as usize) {
+                None => return false,
+                Some(ptr) => ptr,
+            };
+            (0..process.number_writeable_flash_regions()).any(|i| {
+                let (region_ptr, region_len) = process.get_writeable_flash_region(i);
+                let region_ptr = region_ptr as usize;
+                let region_len = region_len as usize;
+                // We want to check the 2 following inequalities:
+                // (1) `region_ptr <= ptr`
+                // (2) `ptr + len <= region_ptr + region_len`
+                // However, the second one may overflow written as is. We introduce a third
+                // inequality to solve this issue:
+                // (3) `len <= region_len`
+                // Using this third inequality, we can rewrite the second one as:
+                // (4) `ptr - region_ptr <= region_len - len`
+                // This fourth inequality is equivalent to the second one but doesn't overflow when
+                // the first and third inequalities hold.
+                region_ptr <= ptr && len <= region_len && ptr - region_ptr <= region_len - len
+            })
+        })
+    }
 }
 
 /// Type to uniquely identify a callback subscription across all drivers.

--- a/kernel/src/hil/embedded_flash.rs
+++ b/kernel/src/hil/embedded_flash.rs
@@ -1,0 +1,51 @@
+use crate::returncode::ReturnCode;
+
+/// Embedded flash API.
+///
+/// The purpose of this HIL is to provide low-level control of the embedded flash to allow
+/// applications to implement flash-efficient data-structures. The API is blocking since most flash
+/// either halt the CPU during write and erase operations or ask the application to wait until the
+/// operation is finished. A blocking API is also simpler to reason and less error-prone.
+pub trait EmbeddedFlash {
+    /// Returns the size of a word in bytes.
+    fn word_size(&self) -> usize;
+
+    /// Returns the size of a page in bytes.
+    fn page_size(&self) -> usize;
+
+    /// Returns how many times a word can be written between page erasures.
+    fn max_word_writes(&self) -> usize;
+
+    /// Returns how many times a page can be erased in the lifetime of the flash.
+    fn max_page_erases(&self) -> usize;
+
+    /// Writes a word-aligned slice at a word-aligned address.
+    ///
+    /// Words are written only if necessary, i.e. if writing the new value would change the current
+    /// value. This can be used to simplify recovery operations (e.g. if power is lost during a
+    /// write operation). The application doesn't need to check which prefix has already been
+    /// written and may repeat the complete write that was interrupted.
+    ///
+    /// # Safety
+    ///
+    /// The slice starting at `ptr` of length `slice.len()` must be a valid flash range (this should
+    /// be checked by the capsule). The words in this range must have been written less than
+    /// `max_word_writes()` since the last erasure of their page.
+    ///
+    /// # Errors
+    ///
+    /// Fails with `EINVAL` if `ptr` or `slice.len()` are not word-aligned.
+    fn write_slice(&self, ptr: usize, slice: &[u8]) -> ReturnCode;
+
+    /// Erases a page at a page-aligned address.
+    ///
+    /// # Safety
+    ///
+    /// The slice starting at `ptr` of length `page_size()` must be a valid flash range (this should
+    /// be checked by the capsule).
+    ///
+    /// # Errors
+    ///
+    /// Fails with `EINVAL` if `ptr` is not page-aligned.
+    fn erase_page(&self, ptr: usize) -> ReturnCode;
+}

--- a/kernel/src/hil/mod.rs
+++ b/kernel/src/hil/mod.rs
@@ -6,6 +6,7 @@ pub mod ble_advertising;
 pub mod crc;
 pub mod dac;
 pub mod eic;
+pub mod embedded_flash;
 pub mod entropy;
 pub mod flash;
 pub mod gpio;


### PR DESCRIPTION
### Pull Request Overview

The purpose of the capsule is to provide low-level control of the embedded flash to allow applications to implement flash-efficient data-structures using their writeable flash regions. The API is blocking since most flash either halt the CPU during write and erase operations or ask the application to wait until the operation is finished. A blocking API is also simpler to reason and less error-prone.

### Testing Strategy

In addition to `make ci-travis`, this pull request was tested on the `nrf52840dk` board by implementing in `libtock-rs`:
- a syscall interface
- a multi-set data-structure
- an example application similar to `blink.rs` but with a persistent counter

And updating the linker script.

### TODO or Help Wanted

This pull request may use feedback for other boards if needed, although this may as well be done in followup pull-requests.

### Documentation Updated

- [x] Updated the relevant files in `/docs`.

### Formatting

- [x] Ran `make formatall`.
