### PR TITLE
register_structs!: Make output type public

### DIFF
--- a/boards/acd52832/Cargo.lock
+++ b/boards/acd52832/Cargo.lock
@@ -52,7 +52,7 @@ name = "kernel"
 version = "0.1.0"
 dependencies = [
  "tock-cells 0.1.0",
- "tock-registers 0.4.0",
+ "tock-registers 0.4.1",
 ]
 
 [[package]]
@@ -90,7 +90,7 @@ version = "0.1.0"
 
 [[package]]
 name = "tock-registers"
-version = "0.4.0"
+version = "0.4.1"
 
 [[package]]
 name = "tock_rt0"

--- a/boards/arty-e21/Cargo.lock
+++ b/boards/arty-e21/Cargo.lock
@@ -46,14 +46,14 @@ name = "kernel"
 version = "0.1.0"
 dependencies = [
  "tock-cells 0.1.0",
- "tock-registers 0.4.0",
+ "tock-registers 0.4.1",
 ]
 
 [[package]]
 name = "riscv-csr"
 version = "0.1.0"
 dependencies = [
- "tock-registers 0.4.0",
+ "tock-registers 0.4.1",
 ]
 
 [[package]]
@@ -62,7 +62,7 @@ version = "0.1.0"
 dependencies = [
  "kernel 0.1.0",
  "riscv-csr 0.1.0",
- "tock-registers 0.4.0",
+ "tock-registers 0.4.1",
  "tock_rt0 0.1.0",
 ]
 
@@ -80,7 +80,7 @@ version = "0.1.0"
 
 [[package]]
 name = "tock-registers"
-version = "0.4.0"
+version = "0.4.1"
 
 [[package]]
 name = "tock_rt0"

--- a/boards/hail/Cargo.lock
+++ b/boards/hail/Cargo.lock
@@ -51,7 +51,7 @@ name = "kernel"
 version = "0.1.0"
 dependencies = [
  "tock-cells 0.1.0",
- "tock-registers 0.4.0",
+ "tock-registers 0.4.1",
 ]
 
 [[package]]
@@ -69,7 +69,7 @@ version = "0.1.0"
 
 [[package]]
 name = "tock-registers"
-version = "0.4.0"
+version = "0.4.1"
 
 [[package]]
 name = "tock_rt0"

--- a/boards/hifive1/Cargo.lock
+++ b/boards/hifive1/Cargo.lock
@@ -37,14 +37,14 @@ name = "kernel"
 version = "0.1.0"
 dependencies = [
  "tock-cells 0.1.0",
- "tock-registers 0.4.0",
+ "tock-registers 0.4.1",
 ]
 
 [[package]]
 name = "riscv-csr"
 version = "0.1.0"
 dependencies = [
- "tock-registers 0.4.0",
+ "tock-registers 0.4.1",
 ]
 
 [[package]]
@@ -53,7 +53,7 @@ version = "0.1.0"
 dependencies = [
  "kernel 0.1.0",
  "riscv-csr 0.1.0",
- "tock-registers 0.4.0",
+ "tock-registers 0.4.1",
  "tock_rt0 0.1.0",
 ]
 
@@ -71,7 +71,7 @@ version = "0.1.0"
 
 [[package]]
 name = "tock-registers"
-version = "0.4.0"
+version = "0.4.1"
 
 [[package]]
 name = "tock_rt0"

--- a/boards/imix/Cargo.lock
+++ b/boards/imix/Cargo.lock
@@ -51,7 +51,7 @@ name = "kernel"
 version = "0.1.0"
 dependencies = [
  "tock-cells 0.1.0",
- "tock-registers 0.4.0",
+ "tock-registers 0.4.1",
 ]
 
 [[package]]
@@ -69,7 +69,7 @@ version = "0.1.0"
 
 [[package]]
 name = "tock-registers"
-version = "0.4.0"
+version = "0.4.1"
 
 [[package]]
 name = "tock_rt0"

--- a/boards/launchxl/Cargo.lock
+++ b/boards/launchxl/Cargo.lock
@@ -42,7 +42,7 @@ name = "kernel"
 version = "0.1.0"
 dependencies = [
  "tock-cells 0.1.0",
- "tock-registers 0.4.0",
+ "tock-registers 0.4.1",
 ]
 
 [[package]]
@@ -62,7 +62,7 @@ version = "0.1.0"
 
 [[package]]
 name = "tock-registers"
-version = "0.4.0"
+version = "0.4.1"
 
 [[package]]
 name = "tock_rt0"

--- a/boards/nordic/nrf52840dk/Cargo.lock
+++ b/boards/nordic/nrf52840dk/Cargo.lock
@@ -40,7 +40,7 @@ name = "kernel"
 version = "0.1.0"
 dependencies = [
  "tock-cells 0.1.0",
- "tock-registers 0.4.0",
+ "tock-registers 0.4.1",
 ]
 
 [[package]]
@@ -90,7 +90,7 @@ version = "0.1.0"
 
 [[package]]
 name = "tock-registers"
-version = "0.4.0"
+version = "0.4.1"
 
 [[package]]
 name = "tock_rt0"

--- a/boards/nordic/nrf52dk/Cargo.lock
+++ b/boards/nordic/nrf52dk/Cargo.lock
@@ -40,7 +40,7 @@ name = "kernel"
 version = "0.1.0"
 dependencies = [
  "tock-cells 0.1.0",
- "tock-registers 0.4.0",
+ "tock-registers 0.4.1",
 ]
 
 [[package]]
@@ -90,7 +90,7 @@ version = "0.1.0"
 
 [[package]]
 name = "tock-registers"
-version = "0.4.0"
+version = "0.4.1"
 
 [[package]]
 name = "tock_rt0"

--- a/boards/nucleo_f429zi/Cargo.lock
+++ b/boards/nucleo_f429zi/Cargo.lock
@@ -32,7 +32,7 @@ name = "kernel"
 version = "0.1.0"
 dependencies = [
  "tock-cells 0.1.0",
- "tock-registers 0.4.0",
+ "tock-registers 0.4.1",
 ]
 
 [[package]]
@@ -61,7 +61,7 @@ version = "0.1.0"
 
 [[package]]
 name = "tock-registers"
-version = "0.4.0"
+version = "0.4.1"
 
 [[package]]
 name = "tock_rt0"

--- a/boards/nucleo_f446re/Cargo.lock
+++ b/boards/nucleo_f446re/Cargo.lock
@@ -32,7 +32,7 @@ name = "kernel"
 version = "0.1.0"
 dependencies = [
  "tock-cells 0.1.0",
- "tock-registers 0.4.0",
+ "tock-registers 0.4.1",
 ]
 
 [[package]]
@@ -61,7 +61,7 @@ version = "0.1.0"
 
 [[package]]
 name = "tock-registers"
-version = "0.4.0"
+version = "0.4.1"
 
 [[package]]
 name = "tock_rt0"

--- a/libraries/tock-register-interface/CHANGELOG.md
+++ b/libraries/tock-register-interface/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## master
 
+## v0.4.1
+
+ - #1458: Update struct macro to create `pub` structs
 
 ## v0.4
 

--- a/libraries/tock-register-interface/Cargo.toml
+++ b/libraries/tock-register-interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tock-registers"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
 description = "Memory-Mapped I/O and register interface developed for Tock."
 homepage = "https://www.tockos.org/"

--- a/libraries/tock-register-interface/README.md
+++ b/libraries/tock-register-interface/README.md
@@ -104,6 +104,7 @@ register_structs! {
     Registers {
         (0x000 => foo: ReadOnly<u8>),
         (0x008 => bar: ReadOnly<u8>),
+        (0x009 => @END),
     }
 }
 ```

--- a/libraries/tock-register-interface/src/macros.rs
+++ b/libraries/tock-register-interface/src/macros.rs
@@ -163,7 +163,7 @@ macro_rules! register_fields {
     ) => {
         $(#[$attr_struct])*
         #[repr(C)]
-        struct $name {
+        pub struct $name {
             $(
                 $(#[$attr])*
                 $id: $ty


### PR DESCRIPTION
### Pull Request Overview

The recently introduced `register_structs!` macro differs from previous macros in that it's produced output type is not `pub`. This has some downsides for users of the library outside tockos.

For example, implementing the [deref pattern](https://github.com/rust-embedded/register-rs#the-deref-pattern-for-drivers) using the Rust corelib deref traits is not possible. It also limits reuse of the produced type because a non-pub struct can't be exported and shared between different consumers in different files.

This PR fixes this by adding the `pub` keyword to the generated type. It should have no repercussions on existing tock code using the macro.

Also: Tiny fix in the README.
