### PR TITLE
Add support for explicit visibility in register_structs.

### DIFF
--- a/libraries/tock-register-interface/CHANGELOG.md
+++ b/libraries/tock-register-interface/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## master
 
+ - #1461: Update `register_structs` macro to support flexible visibility of each
+   struct and each field. Also revert to private structs by default.
+
 ## v0.4.1
 
  - #1458: Update struct macro to create `pub` structs

--- a/libraries/tock-register-interface/README.md
+++ b/libraries/tock-register-interface/README.md
@@ -120,6 +120,33 @@ struct Registers {
     bar: ReadOnly<u32>,
 }
 ```
+
+By default, the visibility of the generated structs and fields is private. You
+can make them public using the `pub` keyword, just before the struct name or the
+field identifier.
+
+For example, the following call to the macro:
+
+```rust
+register_structs! {
+    pub Registers {
+        (0x000 => foo: ReadOnly<u32>),
+        (0x004 => pub bar: ReadOnly<u32>),
+        (0x008 => @END),
+    }
+}
+```
+
+will generate the following struct.
+
+```rust
+#[repr(C)]
+pub struct Registers {
+    foo: ReadOnly<u32>,
+    pub bar: ReadOnly<u32>,
+}
+```
+
 ## Defining bitfields
 
 Bitfields are defined through the `register_bitfields!` macro:

--- a/libraries/tock-register-interface/src/macros.rs
+++ b/libraries/tock-register-interface/src/macros.rs
@@ -140,12 +140,12 @@ macro_rules! register_bitfields {
 #[macro_export]
 macro_rules! register_fields {
     // Macro entry point.
-    (@root $(#[$attr_struct:meta])* $name:ident { $($input:tt)* } ) => {
+    (@root $(#[$attr_struct:meta])* $vis_struct:vis $name:ident { $($input:tt)* } ) => {
         $crate::register_fields!(
             @munch (
                 $($input)*
             ) -> {
-                struct $(#[$attr_struct])* $name
+                $vis_struct struct $(#[$attr_struct])* $name
             }
         );
     };
@@ -156,17 +156,17 @@ macro_rules! register_fields {
             $(#[$attr_end:meta])*
             ($offset:expr => @END),
         )
-        -> {struct $(#[$attr_struct:meta])* $name:ident $(
+        -> {$vis_struct:vis struct $(#[$attr_struct:meta])* $name:ident $(
                 $(#[$attr:meta])*
-                ($id:ident: $ty:ty)
+                ($vis:vis $id:ident: $ty:ty)
             )*}
     ) => {
         $(#[$attr_struct])*
         #[repr(C)]
-        pub struct $name {
+        $vis_struct struct $name {
             $(
                 $(#[$attr])*
-                $id: $ty
+                $vis $id: $ty
             ),*
         }
     };
@@ -175,7 +175,7 @@ macro_rules! register_fields {
     (@munch
         (
             $(#[$attr:meta])*
-            ($offset_start:expr => $field:ident: $ty:ty),
+            ($offset_start:expr => $vis:vis $field:ident: $ty:ty),
             $($after:tt)*
         )
         -> {$($output:tt)*}
@@ -186,7 +186,7 @@ macro_rules! register_fields {
             ) -> {
                 $($output)*
                 $(#[$attr])*
-                ($field: $ty)
+                ($vis $field: $ty)
             }
         );
     };
@@ -249,7 +249,7 @@ macro_rules! test_fields {
     (@munch $struct:ident $sum:ident
         (
             $(#[$attr:meta])*
-            ($offset_start:expr => $field:ident: $ty:ty),
+            ($offset_start:expr => $vis:vis $field:ident: $ty:ty),
             $(#[$attr_next:meta])*
             ($offset_end:expr => $($next:tt)*),
             $($after:tt)*
@@ -330,12 +330,12 @@ macro_rules! register_structs {
     {
         $(
             $(#[$attr:meta])*
-            $name:ident {
+            $vis_struct:vis $name:ident {
                 $( $fields:tt )*
             }
         ),*
     } => {
-        $( $crate::register_fields!(@root $(#[$attr])* $name { $($fields)* } ); )*
+        $( $crate::register_fields!(@root $(#[$attr])* $vis_struct $name { $($fields)* } ); )*
 
         #[cfg(test)]
         mod test_register_structs {


### PR DESCRIPTION
### Pull Request Overview

In https://github.com/tock/tock/pull/1458, the visibility of structs generated by `register_structs` was made public for all structs. Without any explicit mention of the `pub` keyword, this goes against Rust's principle of private visibility by default. Also, the documentation was not updated accordingly.

This pull request makes the visibility more flexible, using the suitable visibility [macro metavariable](https://doc.rust-lang.org/reference/macros-by-example.html#metavariables). Now, the visibility is back to private by default, but can be changed at the granularity of each struct, and of each field within the structs.

### Testing Strategy

This pull request was tested with `make ci-travis`.

### TODO or Help Wanted

- @andre-richter, could you please take a look?
- I bumped again the version to 0.4.2, but given that the previous version was already pushed to crates.io and that this is technically a breaking change, should we use version 0.5.0 instead?

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.