### PR TITLE
Disable adc for deep sleep

### DIFF
--- a/chips/sam4l/src/adc.rs
+++ b/chips/sam4l/src/adc.rs
@@ -603,6 +603,31 @@ impl Adc {
             ReturnCode::SUCCESS
         }
     }
+
+    /// Disables the ADC so that the chip can return to deep sleep
+    fn disable(&self) {
+        let regs: &AdcRegisters = &*self.registers;
+
+        // disable ADC
+        regs.cr.write(Control::DIS::SET);
+
+        // wait until status is disabled
+        let mut timeout = 10000;
+        while regs.sr.is_set(Status::EN) {
+            timeout -= 1;
+            if timeout == 0 {
+                // ADC never disabled 
+                return;
+            }
+        }
+
+        // disable bandgap and reference buffers
+        regs.cr.write(Control::BGREQDIS::SET + Control::REFBUFDIS::SET);
+
+        self.enabled.set(false);
+        scif::generic_clock_disable(scif::GenericClock::GCLK10);
+        pm::disable_clock(Clock::PBA(PBAClock::ADCIFE));
+    }
 }
 
 /// Implements an ADC capable reading ADC samples on any channel.
@@ -780,6 +805,9 @@ impl hil::adc::Adc for Adc {
 
             // reset the ADC peripheral
             regs.cr.write(Control::SWRST::SET);
+
+            // disable the ADC
+            self.disable();
 
             // stop DMA transfer if going. This should safely return a None if
             // the DMA was not being used

--- a/chips/sam4l/src/adc.rs
+++ b/chips/sam4l/src/adc.rs
@@ -616,13 +616,14 @@ impl Adc {
         while regs.sr.is_set(Status::EN) {
             timeout -= 1;
             if timeout == 0 {
-                // ADC never disabled 
+                // ADC never disabled
                 return;
             }
         }
 
         // disable bandgap and reference buffers
-        regs.cr.write(Control::BGREQDIS::SET + Control::REFBUFDIS::SET);
+        regs.cr
+            .write(Control::BGREQDIS::SET + Control::REFBUFDIS::SET);
 
         self.enabled.set(false);
         scif::generic_clock_disable(scif::GenericClock::GCLK10);


### PR DESCRIPTION
### Pull Request Overview

This pull request makes sure that for the SAM4L, when stop_sampling() is called on the ADC, the ADC is disabled and the chip can go to deep sleep.


### Testing Strategy

This pull request was tested by running an application that uses the ADC and seeing on an oscilloscope that the added changes cause the power draw to drop to the expected deep sleep level. The radio and pconsole were disabled during testing since they prevent the chip from going into deep sleep while active.


### TODO or Help Wanted


### Documentation Updated

- [x] no updates are required.

### Formatting

- [x] Ran `make formatall`.
