### PR TITLE
Add transmit_sync for sifive UART for use in panic

### DIFF
--- a/boards/hifive1/src/io.rs
+++ b/boards/hifive1/src/io.rs
@@ -15,7 +15,9 @@ static mut WRITER: Writer = Writer {};
 
 impl Write for Writer {
     fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
-        debug!("{}", s);
+        unsafe {
+            e310x::uart::UART0.transmit_sync(s.as_bytes());
+        }
         Ok(())
     }
 }
@@ -36,5 +38,6 @@ pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
 
     let led_red = &mut led::LedLow::new(&mut e310x::gpio::PORT[22]);
     let writer = &mut WRITER;
+
     debug::panic(&mut [led_red], writer, pi, &rv32i::support::nop, &PROCESSES)
 }

--- a/chips/sifive/src/uart.rs
+++ b/chips/sifive/src/uart.rs
@@ -154,6 +154,14 @@ impl Uart<'a> {
             }
         }
     }
+
+    pub fn transmit_sync(&self, bytes: &[u8]) {
+        let regs = self.registers;
+        for b in bytes.iter() {
+            while regs.txdata.is_set(txdata::full) {}
+            regs.txdata.write(txdata::data.val(*b as u32));
+        }
+    }
 }
 
 impl hil::uart::UartData<'a> for Uart<'a> {}


### PR DESCRIPTION
### Pull Request Overview

This pull request does two related things:

- Adds a synchronous transmit to the sifive UART driver

- Uses it in the HiFive board's `panic` implementation

Because panic happens outside the main kernel loop (i.e. it cuts everything else off and just spins, or restarts or whatever), using the UART normally (e.g. through `debug!`) doesn't work inside panic---it'll only output a buffer's worth of the panic message.

This changes writes to the UART synchronously so we get a glorious, full panic message.

### Testing Strategy

HiFive board under qemu by injecting an process fault, though testing any panic inside the kernel should yield similar results.

Before the change we got something like:

```
Kernel panic at /home/alevy/hack/tock/kernel/src/process.rs:568:

```

with the rest cut off.

Now we get

```
Kernel panic at /home/alevy/hack/tock/kernel/src/process.rs:568:
	"Process  had a fault"
	Kernel version release-1.4-193-g9b2a1d50e

---| App Status |---
App:    -   [Running]
 Events Queued: 0   Syscall Count: 0   Dropped Callback Count: 0
 Restart Count: 0
 Last Syscall: None

 ╔═══════════╤══════════════════════════════════════════╗
 ║  Address  │ Region Name    Used | Allocated (bytes)  ║
 ╚0x00000000═╪══════════════════════════════════════════╝
...
```

etc...

### Documentation Updated

- [X] ~~Updated the relevant files in `/docs`, or no updates are required.~~

### Formatting

- [x] Ran `make formatall`.
