### PR TITLE
boards/hifive1: Remove duplicate PLIC enable

### DIFF
--- a/boards/hifive1/src/main.rs
+++ b/boards/hifive1/src/main.rs
@@ -103,8 +103,6 @@ pub unsafe fn reset_handler() {
     // Need to enable all interrupts for Tock Kernel
     chip.enable_plic_interrupts();
 
-    // Need to enable all interrupts for Tock Kernel
-    chip.enable_plic_interrupts();
     // enable interrupts globally
     csr::CSR
         .mie


### PR DESCRIPTION
Signed-off-by: Garret Kelly <gdk@google.com>

### Pull Request Overview

This pull request removes a duplicate call to `chip.enable_plic_interrupts()` from the hifive1 `reset_handler`.  The PLIC is already enabled by the line above and enabling it twice is unnecessary. 

### Testing Strategy

This pull request was **not** tested.

### TODO or Help Wanted

This pull request still needs someone with a hifive1 board to flash and test it, if anyone thinks that there will be behavioral changes here.

### Documentation Updated

No updates are required.

### Formatting

- [x] Ran `make formatall`.