### PR TITLE
Rewrite TBF parsing logic

### DIFF
--- a/boards/acd52832/src/main.rs
+++ b/boards/acd52832/src/main.rs
@@ -4,8 +4,6 @@
 #![no_main]
 #![deny(missing_docs)]
 
-use core::slice;
-
 use capsules::virtual_alarm::VirtualMuxAlarm;
 use kernel::capabilities;
 use kernel::common::dynamic_deferred_call::{DynamicDeferredCall, DynamicDeferredCallClientState};

--- a/boards/acd52832/src/main.rs
+++ b/boards/acd52832/src/main.rs
@@ -523,15 +523,18 @@ pub unsafe fn reset_handler() {
         /// Beginning of the ROM region containing app images.
         static _sapps: u8;
 
-        /// Length of the ROM region containing app images.
+        /// End of the ROM region containing app images.
         ///
         /// This symbol is defined in the linker script.
-        static _lapps: u8;
+        static _eapps: u8;
     }
     kernel::procs::load_processes(
         board_kernel,
         chip,
-        slice::from_raw_parts(&_sapps as *const u8, &_lapps as *const u8 as usize),
+        core::slice::from_raw_parts(
+            &_sapps as *const u8,
+            &_eapps as *const u8 as usize - &_sapps as *const u8 as usize,
+        ),
         &mut APP_MEMORY,
         &mut PROCESSES,
         FAULT_RESPONSE,

--- a/boards/arty-e21/src/main.rs
+++ b/boards/arty-e21/src/main.rs
@@ -235,17 +235,26 @@ pub unsafe fn reset_handler() {
         ///
         /// This symbol is defined in the linker script.
         static _sapps: u8;
+
+        /// Length of the ROM region containing app images.
+        ///
+        /// This symbol is defined in the linker script.
+        static _lapps: u8;
     }
 
     kernel::procs::load_processes(
         board_kernel,
         chip,
-        &_sapps as *const u8,
+        core::slice::from_raw_parts(&_sapps as *const u8, &_lapps as *const u8 as usize),
         &mut APP_MEMORY,
         &mut PROCESSES,
         FAULT_RESPONSE,
         &process_mgmt_cap,
-    );
+    )
+    .unwrap_or_else(|err| {
+        debug!("Error loading processes!");
+        debug!("{:?}", err);
+    });
 
     board_kernel.kernel_loop(&artye21, chip, None, &main_loop_cap);
 }

--- a/boards/arty-e21/src/main.rs
+++ b/boards/arty-e21/src/main.rs
@@ -236,16 +236,19 @@ pub unsafe fn reset_handler() {
         /// This symbol is defined in the linker script.
         static _sapps: u8;
 
-        /// Length of the ROM region containing app images.
+        /// End of the ROM region containing app images.
         ///
         /// This symbol is defined in the linker script.
-        static _lapps: u8;
+        static _eapps: u8;
     }
 
     kernel::procs::load_processes(
         board_kernel,
         chip,
-        core::slice::from_raw_parts(&_sapps as *const u8, &_lapps as *const u8 as usize),
+        core::slice::from_raw_parts(
+            &_sapps as *const u8,
+            &_eapps as *const u8 as usize - &_sapps as *const u8 as usize,
+        ),
         &mut APP_MEMORY,
         &mut PROCESSES,
         FAULT_RESPONSE,

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -432,16 +432,19 @@ pub unsafe fn reset_handler() {
         /// This symbol is defined in the linker script.
         static _sapps: u8;
 
-        /// Length of the ROM region containing app images.
+        /// End of the ROM region containing app images.
         ///
         /// This symbol is defined in the linker script.
-        static _lapps: u8;
+        static _eapps: u8;
     }
 
     kernel::procs::load_processes(
         board_kernel,
         chip,
-        core::slice::from_raw_parts(&_sapps as *const u8, &_lapps as *const u8 as usize),
+        core::slice::from_raw_parts(
+            &_sapps as *const u8,
+            &_eapps as *const u8 as usize - &_sapps as *const u8 as usize,
+        ),
         &mut APP_MEMORY,
         &mut PROCESSES,
         fault_response,

--- a/boards/hifive1/src/main.rs
+++ b/boards/hifive1/src/main.rs
@@ -185,6 +185,11 @@ pub unsafe fn reset_handler() {
         ///
         /// This symbol is defined in the linker script.
         static _sapps: u8;
+
+        /// Length of the ROM region containing app images.
+        ///
+        /// This symbol is defined in the linker script.
+        static _lapps: u8;
     }
 
     let hifive1 = HiFive1 {
@@ -196,12 +201,16 @@ pub unsafe fn reset_handler() {
     kernel::procs::load_processes(
         board_kernel,
         chip,
-        &_sapps as *const u8,
+        core::slice::from_raw_parts(&_sapps as *const u8, &_lapps as *const u8 as usize),
         &mut APP_MEMORY,
         &mut PROCESSES,
         FAULT_RESPONSE,
         &process_mgmt_cap,
-    );
+    )
+    .unwrap_or_else(|err| {
+        debug!("Error loading processes!");
+        debug!("{:?}", err);
+    });
 
     board_kernel.kernel_loop(&hifive1, chip, None, &main_loop_cap);
 }

--- a/boards/hifive1/src/main.rs
+++ b/boards/hifive1/src/main.rs
@@ -186,10 +186,10 @@ pub unsafe fn reset_handler() {
         /// This symbol is defined in the linker script.
         static _sapps: u8;
 
-        /// Length of the ROM region containing app images.
+        /// End of the ROM region containing app images.
         ///
         /// This symbol is defined in the linker script.
-        static _lapps: u8;
+        static _eapps: u8;
     }
 
     let hifive1 = HiFive1 {
@@ -201,7 +201,10 @@ pub unsafe fn reset_handler() {
     kernel::procs::load_processes(
         board_kernel,
         chip,
-        core::slice::from_raw_parts(&_sapps as *const u8, &_lapps as *const u8 as usize),
+        core::slice::from_raw_parts(
+            &_sapps as *const u8,
+            &_eapps as *const u8 as usize - &_sapps as *const u8 as usize,
+        ),
         &mut APP_MEMORY,
         &mut PROCESSES,
         FAULT_RESPONSE,

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -512,15 +512,18 @@ pub unsafe fn reset_handler() {
         /// Beginning of the ROM region containing app images.
         static _sapps: u8;
 
-        /// Length of the ROM region containing app images.
+        /// End of the ROM region containing app images.
         ///
         /// This symbol is defined in the linker script.
-        static _lapps: u8;
+        static _eapps: u8;
     }
     kernel::procs::load_processes(
         board_kernel,
         chip,
-        core::slice::from_raw_parts(&_sapps as *const u8, &_lapps as *const u8 as usize),
+        core::slice::from_raw_parts(
+            &_sapps as *const u8,
+            &_eapps as *const u8 as usize - &_sapps as *const u8 as usize,
+        ),
         &mut APP_MEMORY,
         &mut PROCESSES,
         FAULT_RESPONSE,

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -511,16 +511,25 @@ pub unsafe fn reset_handler() {
     extern "C" {
         /// Beginning of the ROM region containing app images.
         static _sapps: u8;
+
+        /// Length of the ROM region containing app images.
+        ///
+        /// This symbol is defined in the linker script.
+        static _lapps: u8;
     }
     kernel::procs::load_processes(
         board_kernel,
         chip,
-        &_sapps as *const u8,
+        core::slice::from_raw_parts(&_sapps as *const u8, &_lapps as *const u8 as usize),
         &mut APP_MEMORY,
         &mut PROCESSES,
         FAULT_RESPONSE,
         &process_mgmt_cap,
-    );
+    )
+    .unwrap_or_else(|err| {
+        debug!("Error loading processes!");
+        debug!("{:?}", err);
+    });
 
     board_kernel.kernel_loop(&imix, chip, Some(&imix.ipc), &main_cap);
 }

--- a/boards/kernel_layout.ld
+++ b/boards/kernel_layout.ld
@@ -216,6 +216,8 @@ SECTIONS
            kernel and apps into a single image */
         KEEP (*(.app.*))
     } > prog
+    /* _lapps symbol used by tock to calculate the length of app flash */
+    _lapps = LENGTH(prog);
 
 
 

--- a/boards/kernel_layout.ld
+++ b/boards/kernel_layout.ld
@@ -25,7 +25,8 @@
  * `_sapps`, `_lapps`
  *
  *    The `_sapps` symbol marks the beginning of application memory in flash.
- *    The `_lapps` symbol is how long the application flash region is.
+ *    The `_eapps` symbol marks the end of application memory in flash by
+ *    pointing to next address after application flash.
  */
 
 
@@ -217,8 +218,8 @@ SECTIONS
            kernel and apps into a single image */
         KEEP (*(.app.*))
     } > prog
-    /* _lapps symbol used by tock to calculate the length of app flash */
-    _lapps = LENGTH(prog);
+    /* _eapps symbol used by tock to calculate the length of app flash */
+    _eapps = _sapps + LENGTH(prog);
 
 
 

--- a/boards/kernel_layout.ld
+++ b/boards/kernel_layout.ld
@@ -22,7 +22,7 @@
  *    The `_szero` and `_ezero` symbols define the range of the BSS, SRAM that
  *    Tock will zero on boot.
  *
- * `_sapps`, `_lapps`
+ * `_sapps`, `_eapps`
  *
  *    The `_sapps` symbol marks the beginning of application memory in flash.
  *    The `_eapps` symbol marks the end of application memory in flash by

--- a/boards/kernel_layout.ld
+++ b/boards/kernel_layout.ld
@@ -22,9 +22,10 @@
  *    The `_szero` and `_ezero` symbols define the range of the BSS, SRAM that
  *    Tock will zero on boot.
  *
- * `_sapps`
+ * `_sapps`, `_lapps`
  *
  *    The `_sapps` symbol marks the beginning of application memory in flash.
+ *    The `_lapps` symbol is how long the application flash region is.
  */
 
 

--- a/boards/launchxl/src/main.rs
+++ b/boards/launchxl/src/main.rs
@@ -352,17 +352,26 @@ pub unsafe fn reset_handler() {
     extern "C" {
         /// Beginning of the ROM region containing app images.
         static _sapps: u8;
+
+        /// Length of the ROM region containing app images.
+        ///
+        /// This symbol is defined in the linker script.
+        static _lapps: u8;
     }
 
     kernel::procs::load_processes(
         board_kernel,
         chip,
-        &_sapps as *const u8,
+        core::slice::from_raw_parts(&_sapps as *const u8, &_lapps as *const u8 as usize),
         &mut APP_MEMORY,
         &mut PROCESSES,
         FAULT_RESPONSE,
         &process_management_capability,
-    );
+    )
+    .unwrap_or_else(|err| {
+        debug!("Error loading processes!");
+        debug!("{:?}", err);
+    });
 
     board_kernel.kernel_loop(&launchxl, chip, Some(&launchxl.ipc), &main_loop_capability);
 }

--- a/boards/launchxl/src/main.rs
+++ b/boards/launchxl/src/main.rs
@@ -353,16 +353,19 @@ pub unsafe fn reset_handler() {
         /// Beginning of the ROM region containing app images.
         static _sapps: u8;
 
-        /// Length of the ROM region containing app images.
+        /// End of the ROM region containing app images.
         ///
         /// This symbol is defined in the linker script.
-        static _lapps: u8;
+        static _eapps: u8;
     }
 
     kernel::procs::load_processes(
         board_kernel,
         chip,
-        core::slice::from_raw_parts(&_sapps as *const u8, &_lapps as *const u8 as usize),
+        core::slice::from_raw_parts(
+            &_sapps as *const u8,
+            &_eapps as *const u8 as usize - &_sapps as *const u8 as usize,
+        ),
         &mut APP_MEMORY,
         &mut PROCESSES,
         FAULT_RESPONSE,

--- a/boards/nordic/nrf52dk_base/src/lib.rs
+++ b/boards/nordic/nrf52dk_base/src/lib.rs
@@ -448,16 +448,25 @@ pub unsafe fn setup_board<I: nrf52::interrupt_service::InterruptService>(
     extern "C" {
         /// Beginning of the ROM region containing app images.
         static _sapps: u8;
+
+        /// Length of the ROM region containing app images.
+        ///
+        /// This symbol is defined in the linker script.
+        static _lapps: u8;
     }
     kernel::procs::load_processes(
         board_kernel,
         chip,
-        &_sapps as *const u8,
+        core::slice::from_raw_parts(&_sapps as *const u8, &_lapps as *const u8 as usize),
         app_memory,
         process_pointers,
         app_fault_response,
         &process_management_capability,
-    );
+    )
+    .unwrap_or_else(|err| {
+        debug!("Error loading processes!");
+        debug!("{:?}", err);
+    });
 
     board_kernel.kernel_loop(&platform, chip, Some(&platform.ipc), &main_loop_capability);
 }

--- a/boards/nordic/nrf52dk_base/src/lib.rs
+++ b/boards/nordic/nrf52dk_base/src/lib.rs
@@ -449,15 +449,18 @@ pub unsafe fn setup_board<I: nrf52::interrupt_service::InterruptService>(
         /// Beginning of the ROM region containing app images.
         static _sapps: u8;
 
-        /// Length of the ROM region containing app images.
+        /// End of the ROM region containing app images.
         ///
         /// This symbol is defined in the linker script.
-        static _lapps: u8;
+        static _eapps: u8;
     }
     kernel::procs::load_processes(
         board_kernel,
         chip,
-        core::slice::from_raw_parts(&_sapps as *const u8, &_lapps as *const u8 as usize),
+        core::slice::from_raw_parts(
+            &_sapps as *const u8,
+            &_eapps as *const u8 as usize - &_sapps as *const u8 as usize,
+        ),
         app_memory,
         process_pointers,
         app_fault_response,

--- a/boards/nucleo_f429zi/src/main.rs
+++ b/boards/nucleo_f429zi/src/main.rs
@@ -407,17 +407,26 @@ pub unsafe fn reset_handler() {
         ///
         /// This symbol is defined in the linker script.
         static _sapps: u8;
+
+        /// Length of the ROM region containing app images.
+        ///
+        /// This symbol is defined in the linker script.
+        static _lapps: u8;
     }
 
     kernel::procs::load_processes(
         board_kernel,
         chip,
-        &_sapps as *const u8,
+        core::slice::from_raw_parts(&_sapps as *const u8, &_lapps as *const u8 as usize),
         &mut APP_MEMORY,
         &mut PROCESSES,
         FAULT_RESPONSE,
         &process_management_capability,
-    );
+    )
+    .unwrap_or_else(|err| {
+        debug!("Error loading processes!");
+        debug!("{:?}", err);
+    });
 
     board_kernel.kernel_loop(
         &nucleo_f429zi,

--- a/boards/nucleo_f429zi/src/main.rs
+++ b/boards/nucleo_f429zi/src/main.rs
@@ -408,16 +408,19 @@ pub unsafe fn reset_handler() {
         /// This symbol is defined in the linker script.
         static _sapps: u8;
 
-        /// Length of the ROM region containing app images.
+        /// End of the ROM region containing app images.
         ///
         /// This symbol is defined in the linker script.
-        static _lapps: u8;
+        static _eapps: u8;
     }
 
     kernel::procs::load_processes(
         board_kernel,
         chip,
-        core::slice::from_raw_parts(&_sapps as *const u8, &_lapps as *const u8 as usize),
+        core::slice::from_raw_parts(
+            &_sapps as *const u8,
+            &_eapps as *const u8 as usize - &_sapps as *const u8 as usize,
+        ),
         &mut APP_MEMORY,
         &mut PROCESSES,
         FAULT_RESPONSE,

--- a/boards/nucleo_f446re/src/main.rs
+++ b/boards/nucleo_f446re/src/main.rs
@@ -291,16 +291,19 @@ pub unsafe fn reset_handler() {
         /// This symbol is defined in the linker script.
         static _sapps: u8;
 
-        /// Length of the ROM region containing app images.
+        /// End of the ROM region containing app images.
         ///
         /// This symbol is defined in the linker script.
-        static _lapps: u8;
+        static _eapps: u8;
     }
 
     kernel::procs::load_processes(
         board_kernel,
         chip,
-        core::slice::from_raw_parts(&_sapps as *const u8, &_lapps as *const u8 as usize),
+        core::slice::from_raw_parts(
+            &_sapps as *const u8,
+            &_eapps as *const u8 as usize - &_sapps as *const u8 as usize,
+        ),
         &mut APP_MEMORY,
         &mut PROCESSES,
         FAULT_RESPONSE,

--- a/boards/nucleo_f446re/src/main.rs
+++ b/boards/nucleo_f446re/src/main.rs
@@ -290,17 +290,26 @@ pub unsafe fn reset_handler() {
         ///
         /// This symbol is defined in the linker script.
         static _sapps: u8;
+
+        /// Length of the ROM region containing app images.
+        ///
+        /// This symbol is defined in the linker script.
+        static _lapps: u8;
     }
 
     kernel::procs::load_processes(
         board_kernel,
         chip,
-        &_sapps as *const u8,
+        core::slice::from_raw_parts(&_sapps as *const u8, &_lapps as *const u8 as usize),
         &mut APP_MEMORY,
         &mut PROCESSES,
         FAULT_RESPONSE,
         &process_management_capability,
-    );
+    )
+    .unwrap_or_else(|err| {
+        debug!("Error loading processes!");
+        debug!("{:?}", err);
+    });
 
     board_kernel.kernel_loop(
         &nucleo_f446re,

--- a/boards/opentitan/src/main.rs
+++ b/boards/opentitan/src/main.rs
@@ -222,10 +222,10 @@ pub unsafe fn reset_handler() {
         /// This symbol is defined in the linker script.
         static _sapps: u8;
 
-        /// Length of the ROM region containing app images.
+        /// End of the ROM region containing app images.
         ///
         /// This symbol is defined in the linker script.
-        static _lapps: u8;
+        static _eapps: u8;
     }
 
     let opentitan = OpenTitan {
@@ -239,7 +239,10 @@ pub unsafe fn reset_handler() {
     kernel::procs::load_processes(
         board_kernel,
         chip,
-        core::slice::from_raw_parts(&_sapps as *const u8, &_lapps as *const u8 as usize),
+        core::slice::from_raw_parts(
+            &_sapps as *const u8,
+            &_eapps as *const u8 as usize - &_sapps as *const u8 as usize,
+        ),
         &mut APP_MEMORY,
         &mut PROCESSES,
         FAULT_RESPONSE,

--- a/doc/TockBinaryFormat.md
+++ b/doc/TockBinaryFormat.md
@@ -129,6 +129,10 @@ struct TbfHeaderWriteableFlashRegions {
 }
 ```
 
+Since all headers are a multiple of four bytes, and all TLV structures must be a
+multiple of four bytes, the entire TBF header will always be a multiple of four
+bytes.
+
 
 ### TBF Header Base
 

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -13,7 +13,8 @@
     panic_info_message,
     in_band_lifetimes,
     crate_visibility_modifier,
-    associated_type_defaults
+    associated_type_defaults,
+    try_trait
 )]
 #![warn(unreachable_pub)]
 #![no_std]
@@ -57,6 +58,7 @@ pub use crate::sched::Kernel;
 pub mod procs {
     pub use crate::process::{
         load_processes, AlwaysRestart, Error, FaultResponse, FunctionCall, Process,
-        ProcessRestartPolicy, ProcessType, ThresholdRestart, ThresholdRestartThenPanic,
+        ProcessLoadError, ProcessRestartPolicy, ProcessType, ThresholdRestart,
+        ThresholdRestartThenPanic,
     };
 }

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -31,10 +31,9 @@ pub enum ProcessLoadError {
     /// Not enough flash remaining to parse an app and its header.
     NotEnoughFlash,
 
+    /// Process loading error due (likely) to a bug in the kernel. If you get
+    /// this error please open a bug report.
     InternalError,
-
-    /// Other error.
-    Error,
 }
 
 impl From<tbfheader::TbfParseError> for ProcessLoadError {
@@ -60,8 +59,6 @@ impl fmt::Debug for ProcessLoadError {
             }
 
             ProcessLoadError::InternalError => write!(f, "Error in kernel. Likely a bug."),
-
-            ProcessLoadError::Error => write!(f, "Other error occurred"),
         }
     }
 }

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -1,6 +1,8 @@
 //! Support for creating and running userspace applications.
 
 use core::cell::Cell;
+use core::convert::TryInto;
+use core::fmt;
 use core::fmt::Write;
 use core::ptr::write_volatile;
 use core::{mem, ptr, slice, str};
@@ -21,6 +23,49 @@ use crate::syscall::{self, Syscall, UserspaceKernelBoundary};
 use crate::tbfheader;
 use core::cmp::max;
 
+/// Errors that can occur when trying to load and create processes.
+pub enum ProcessLoadError {
+    /// The TBF header for the app could not be successfully parsed.
+    TbfHeaderParseFailure(tbfheader::TbfParseError),
+
+    /// Not enough flash remaining to parse an app and its header.
+    NotEnoughFlash,
+
+    InternalError,
+
+    /// Other error.
+    Error,
+}
+
+impl From<tbfheader::TbfParseError> for ProcessLoadError {
+    /// Convert between a TBF Header parse error and a process load error.
+    ///
+    /// We note that the process load error is because a TBF header failed to
+    /// parse, and just pass through the parse error.
+    fn from(error: tbfheader::TbfParseError) -> Self {
+        ProcessLoadError::TbfHeaderParseFailure(error)
+    }
+}
+
+impl fmt::Debug for ProcessLoadError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            ProcessLoadError::TbfHeaderParseFailure(tbf_parse_error) => {
+                write!(f, "Error parsing TBF header\n")?;
+                write!(f, "{:?}", tbf_parse_error)
+            }
+
+            ProcessLoadError::NotEnoughFlash => {
+                write!(f, "Not enough flash available for app linked list")
+            }
+
+            ProcessLoadError::InternalError => write!(f, "Error in kernel. Likely a bug."),
+
+            ProcessLoadError::Error => write!(f, "Other error occurred"),
+        }
+    }
+}
+
 /// Helper function to load processes from flash into an array of active
 /// processes. This is the default template for loading processes, but a board
 /// is able to create its own `load_processes()` function and use that instead.
@@ -34,20 +79,20 @@ use core::cmp::max;
 pub fn load_processes<C: Chip>(
     kernel: &'static Kernel,
     chip: &'static C,
-    start_of_flash: *const u8,
+    app_flash: &'static [u8],
     app_memory: &mut [u8],
     procs: &'static mut [Option<&'static dyn ProcessType>],
     fault_response: FaultResponse,
     _capability: &dyn ProcessManagementCapability,
-) {
-    let mut apps_in_flash_ptr = start_of_flash;
+) -> Result<(), ProcessLoadError> {
+    let mut remaining_flash = app_flash;
     let mut app_memory_ptr = app_memory.as_mut_ptr();
     let mut app_memory_size = app_memory.len();
 
     if config::CONFIG.debug_load_processes {
         debug!(
             "Loading processes from flash={:#010X} into sram=[{:#010X}:{:#010X}]",
-            start_of_flash as usize,
+            app_flash.as_ptr() as usize,
             app_memory_ptr as usize,
             app_memory_ptr as usize + app_memory_size
         );
@@ -55,45 +100,86 @@ pub fn load_processes<C: Chip>(
 
     for i in 0..procs.len() {
         unsafe {
-            let (process, flash_offset, memory_offset) = Process::create(
+            // Get the first eight bytes of flash to check if there is another
+            // app.
+            let test_header_slice = match remaining_flash.get(0..8) {
+                Some(s) => s,
+                None => {
+                    // Not enough flash to test for another app. This just means
+                    // we are at the end of flash, and there are no more apps to
+                    // load.
+                    return Ok(());
+                }
+            };
+
+            // Pass the first eight bytes to tbfheader to parse out the length
+            // of the tbf header and app. We then use those values to see if we
+            // have enough flash remaining to parse the remainder of the header.
+            let (version, header_length, app_length) = match tbfheader::parse_tbf_header_lengths(
+                test_header_slice
+                    .try_into()
+                    .or(Err(ProcessLoadError::InternalError))?,
+            ) {
+                Ok((v, hl, al)) => (v, hl, al),
+                Err(_tbferr) => {
+                    // Since Tock apps use a linked list, it is very possible
+                    // the header we started to parse is intentionally invalid
+                    // to signal the end of apps. This is ok and just means we
+                    // have finished loading apps.
+                    return Ok(());
+                }
+            };
+
+            // Now we can get a slice which only encompasses the app. At this
+            // point, since the version number in the beginning of the header is
+            // valid, we consider further parsing errors to be actual errors and
+            // report them to the caller.
+            let app_flash = remaining_flash
+                .get(0..app_length as usize)
+                .ok_or(ProcessLoadError::NotEnoughFlash)?;
+
+            // Try to create a process object from that app slice.
+            let (process, memory_offset) = Process::create(
                 kernel,
                 chip,
-                apps_in_flash_ptr,
+                app_flash,
+                header_length as usize,
+                version,
                 app_memory_ptr,
                 app_memory_size,
                 fault_response,
                 i,
-            );
+            )?;
 
-            if config::CONFIG.debug_load_processes {
-                debug!(
-                    "Loaded process[{}] from flash=[{:#010X}:{:#010X}] into sram=[{:#010X}:{:#010X}] = {:?}",
-                    i,
-                    apps_in_flash_ptr as usize,
-                    apps_in_flash_ptr as usize + flash_offset,
-                    app_memory_ptr as usize,
-                    app_memory_ptr as usize + memory_offset,
-                    process.map(|p| p.get_process_name())
-                );
-            }
-
-            if process.is_none() {
-                // We did not get a valid process, but we may have gotten a disabled
-                // process or padding. Therefore we want to skip this chunk of flash
-                // and see if there is a valid app there. However, if we cannot
-                // advance the flash pointer, then we are done.
-                if flash_offset == 0 && memory_offset == 0 {
-                    break;
+            // Check to see if actually got a valid process to execute. If we
+            // didn't and we didn't get a loading error (aka we got to this
+            // point), then the app is a disabled process or just padding.
+            if process.is_some() {
+                if config::CONFIG.debug_load_processes {
+                    debug!(
+                        "Loaded process[{}] from flash=[{:#010X}:{:#010X}] into sram=[{:#010X}:{:#010X}] = {:?}",
+                        i,
+                        app_flash.as_ptr() as usize,
+                        app_flash.as_ptr() as usize + app_flash.len(),
+                        app_memory_ptr as usize,
+                        app_memory_ptr as usize + memory_offset,
+                        process.map(|p| p.get_process_name())
+                    );
                 }
-            } else {
                 procs[i] = process;
             }
 
-            apps_in_flash_ptr = apps_in_flash_ptr.add(flash_offset);
+            // Advance in our buffers before seeing if there is an additional
+            // process to load.
+            remaining_flash = remaining_flash
+                .get(app_flash.len()..)
+                .ok_or(ProcessLoadError::NotEnoughFlash)?;
             app_memory_ptr = app_memory_ptr.add(memory_offset);
             app_memory_size -= memory_offset;
         }
     }
+
+    Ok(())
 }
 
 /// This trait is implemented by process structs.
@@ -1394,280 +1480,279 @@ impl<C: 'static + Chip> Process<'a, C> {
     crate unsafe fn create(
         kernel: &'static Kernel,
         chip: &'static C,
-        app_flash_address: *const u8,
+        app_flash: &'static [u8],
+        header_length: usize,
+        app_version: u16,
         remaining_app_memory: *mut u8,
         remaining_app_memory_size: usize,
         fault_response: FaultResponse,
         index: usize,
-    ) -> (Option<&'static dyn ProcessType>, usize, usize) {
-        if let Some(tbf_header) = tbfheader::parse_and_validate_tbf_header(app_flash_address) {
-            let app_flash_size = tbf_header.get_total_size() as usize;
-            let process_name = tbf_header.get_package_name();
+    ) -> Result<(Option<&'static dyn ProcessType>, usize), ProcessLoadError> {
+        // Get a slice for just the app header.
+        let header_flash = app_flash
+            .get(0..header_length as usize)
+            .ok_or(ProcessLoadError::NotEnoughFlash)?;
 
-            // If this isn't an app (i.e. it is padding) or it is an app but it
-            // isn't enabled, then we can skip it but increment past its flash.
-            if !tbf_header.is_app() || !tbf_header.enabled() {
-                if config::CONFIG.debug_load_processes {
-                    if !tbf_header.is_app() {
-                        debug!(
-                            "[!] flash=[{:#010X}:{:#010X}] process={:?} - process isn't an app",
-                            app_flash_address as usize,
-                            app_flash_address as usize + app_flash_size,
-                            process_name
-                        );
-                    }
-                    if !tbf_header.enabled() {
-                        debug!(
-                            "[!] flash=[{:#010X}:{:#010X}] process={:?} - process isn't enabled",
-                            app_flash_address as usize,
-                            app_flash_address as usize + app_flash_size,
-                            process_name
-                        );
-                    }
-                }
-                return (None, app_flash_size, 0);
-            }
+        // Parse the full TBF header to see if this is a valid app. If the
+        // header can't parse, we will error right here.
+        let tbf_header = tbfheader::parse_tbf_header(header_flash, app_version)?;
 
-            // Otherwise, actually load the app.
-            let mut min_app_ram_size = tbf_header.get_minimum_app_ram_size() as usize;
-            let init_fn =
-                app_flash_address.offset(tbf_header.get_init_function_offset() as isize) as usize;
+        let process_name = tbf_header.get_package_name();
 
-            // Initialize MPU region configuration.
-            let mut mpu_config: <<C as Chip>::MPU as MPU>::MpuConfig = Default::default();
-
-            // Allocate MPU region for flash.
-            if chip
-                .mpu()
-                .allocate_region(
-                    app_flash_address,
-                    app_flash_size,
-                    app_flash_size,
-                    mpu::Permissions::ReadExecuteOnly,
-                    &mut mpu_config,
-                )
-                .is_none()
-            {
-                if config::CONFIG.debug_load_processes {
+        // If this isn't an app (i.e. it is padding) or it is an app but it
+        // isn't enabled, then we can skip it but increment past its flash.
+        if !tbf_header.is_app() || !tbf_header.enabled() {
+            if config::CONFIG.debug_load_processes {
+                if !tbf_header.is_app() {
                     debug!(
-                        "[!] flash=[{:#010X}:{:#010X}] process={:?} - couldn't allocate flash region",
-                            app_flash_address as usize,
-                            app_flash_address as usize + app_flash_size,
-                            process_name
+                        "[!] flash=[{:#010X}:{:#010X}] process={:?} - process isn't an app",
+                        app_flash.as_ptr() as usize,
+                        app_flash.as_ptr() as usize + app_flash.len(),
+                        process_name
                     );
                 }
-                return (None, app_flash_size, 0);
+                if !tbf_header.enabled() {
+                    debug!(
+                        "[!] flash=[{:#010X}:{:#010X}] process={:?} - process isn't enabled",
+                        app_flash.as_ptr() as usize,
+                        app_flash.as_ptr() as usize + app_flash.len(),
+                        process_name
+                    );
+                }
             }
+            return Ok((None, 0));
+        }
 
-            // Determine how much space we need in the application's
-            // memory space just for kernel and grant state. We need to make
-            // sure we allocate enough memory just for that.
+        // Otherwise, actually load the app.
+        let mut min_app_ram_size = tbf_header.get_minimum_app_ram_size() as usize;
+        let init_fn = app_flash
+            .as_ptr()
+            .offset(tbf_header.get_init_function_offset() as isize) as usize;
 
-            // Make room for grant pointers.
-            let grant_ptr_size = mem::size_of::<*const usize>();
-            let grant_ptrs_num = kernel.get_grant_count_and_finalize();
-            let grant_ptrs_offset = grant_ptrs_num * grant_ptr_size;
+        // Initialize MPU region configuration.
+        let mut mpu_config: <<C as Chip>::MPU as MPU>::MpuConfig = Default::default();
 
-            // Allocate memory for callback ring buffer.
-            let callback_size = mem::size_of::<Task>();
-            let callback_len = 10;
-            let callbacks_offset = callback_len * callback_size;
-
-            // Make room to store this process's metadata.
-            let process_struct_offset = mem::size_of::<Process<C>>();
-
-            // Initial sizes of the app-owned and kernel-owned parts of process memory.
-            // Provide the app with plenty of initial process accessible memory.
-            let initial_kernel_memory_size =
-                grant_ptrs_offset + callbacks_offset + process_struct_offset;
-            let initial_app_memory_size = 3 * 1024;
-
-            if min_app_ram_size < initial_app_memory_size {
-                min_app_ram_size = initial_app_memory_size;
-            }
-
-            // Minimum memory size for the process.
-            let min_total_memory_size = min_app_ram_size + initial_kernel_memory_size;
-
-            // Determine where process memory will go and allocate MPU region for app-owned memory.
-            let (memory_start, memory_size) = match chip.mpu().allocate_app_memory_region(
-                remaining_app_memory as *const u8,
-                remaining_app_memory_size,
-                min_total_memory_size,
-                initial_app_memory_size,
-                initial_kernel_memory_size,
-                mpu::Permissions::ReadWriteOnly,
+        // Allocate MPU region for flash.
+        if chip
+            .mpu()
+            .allocate_region(
+                app_flash.as_ptr(),
+                app_flash.len(),
+                app_flash.len(),
+                mpu::Permissions::ReadExecuteOnly,
                 &mut mpu_config,
-            ) {
-                Some((memory_start, memory_size)) => (memory_start, memory_size),
-                None => {
-                    // Failed to load process. Insufficient memory.
-                    if config::CONFIG.debug_load_processes {
-                        debug!(
-                            "[!] flash=[{:#010X}:{:#010X}] process={:?} - couldn't allocate memory region of size >= {:#X}",
-                            app_flash_address as usize,
-                            app_flash_address as usize + app_flash_size,
-                            process_name,
-                            min_total_memory_size
-                        );
-                    }
-                    return (None, app_flash_size, 0);
-                }
-            };
-
-            // Compute how much padding before start of process memory.
-            let memory_padding_size = (memory_start as usize) - (remaining_app_memory as usize);
-
-            // Set up process memory.
-            let app_memory = slice::from_raw_parts_mut(memory_start as *mut u8, memory_size);
-
-            // Set the initial process stack and memory to 3072 bytes.
-            let initial_stack_pointer = memory_start.add(initial_app_memory_size);
-            let initial_sbrk_pointer = memory_start.add(initial_app_memory_size);
-
-            // Set up initial grant region.
-            let mut kernel_memory_break = app_memory.as_mut_ptr().add(app_memory.len());
-
-            // Now that we know we have the space we can setup the grant
-            // pointers.
-            kernel_memory_break = kernel_memory_break.offset(-(grant_ptrs_offset as isize));
-
-            // Set all pointers to null.
-            let opts =
-                slice::from_raw_parts_mut(kernel_memory_break as *mut *const usize, grant_ptrs_num);
-            for opt in opts.iter_mut() {
-                *opt = ptr::null()
+            )
+            .is_none()
+        {
+            if config::CONFIG.debug_load_processes {
+                debug!(
+                    "[!] flash=[{:#010X}:{:#010X}] process={:?} - couldn't allocate flash region",
+                    app_flash.as_ptr() as usize,
+                    app_flash.as_ptr() as usize + app_flash.len(),
+                    process_name
+                );
             }
-
-            // Now that we know we have the space we can setup the memory
-            // for the callbacks.
-            kernel_memory_break = kernel_memory_break.offset(-(callbacks_offset as isize));
-
-            // Set up ring buffer.
-            let callback_buf =
-                slice::from_raw_parts_mut(kernel_memory_break as *mut Task, callback_len);
-            let tasks = RingBuffer::new(callback_buf);
-
-            // Last thing is the process struct.
-            kernel_memory_break = kernel_memory_break.offset(-(process_struct_offset as isize));
-            let process_struct_memory_location = kernel_memory_break;
-
-            // Determine the debug information to the best of our
-            // understanding. If the app is doing all of the PIC fixup and
-            // memory management we don't know much.
-            let app_heap_start_pointer = None;
-            let app_stack_start_pointer = None;
-
-            // Create the Process struct in the app grant region.
-            let mut process: &mut Process<C> =
-                &mut *(process_struct_memory_location as *mut Process<'static, C>);
-
-            // Ask the kernel for a unique identifier for this process that is
-            // being created.
-            let unique_identifier = kernel.create_process_identifier();
-
-            process
-                .app_id
-                .set(AppId::new(kernel, unique_identifier, index));
-            process.kernel = kernel;
-            process.chip = chip;
-            process.memory = app_memory;
-            process.header = tbf_header;
-            process.kernel_memory_break = Cell::new(kernel_memory_break);
-            process.original_kernel_memory_break = kernel_memory_break;
-            process.app_break = Cell::new(initial_sbrk_pointer);
-            process.original_app_break = initial_sbrk_pointer;
-            process.allow_high_water_mark = Cell::new(remaining_app_memory);
-            process.original_allow_high_water_mark = remaining_app_memory;
-            process.current_stack_pointer = Cell::new(initial_stack_pointer);
-            process.original_stack_pointer = initial_stack_pointer;
-
-            process.flash = slice::from_raw_parts(app_flash_address, app_flash_size);
-
-            process.stored_state = Cell::new(Default::default());
-            process.state = Cell::new(State::Unstarted);
-            process.fault_response = fault_response;
-            process.restart_count = Cell::new(0);
-
-            process.mpu_config = MapCell::new(mpu_config);
-            process.mpu_regions = [
-                Cell::new(None),
-                Cell::new(None),
-                Cell::new(None),
-                Cell::new(None),
-                Cell::new(None),
-                Cell::new(None),
-            ];
-            process.tasks = MapCell::new(tasks);
-            process.process_name = process_name.unwrap_or("");
-
-            process.debug = MapCell::new(ProcessDebug {
-                app_heap_start_pointer: app_heap_start_pointer,
-                app_stack_start_pointer: app_stack_start_pointer,
-                min_stack_pointer: initial_stack_pointer,
-                syscall_count: 0,
-                last_syscall: None,
-                dropped_callback_count: 0,
-                timeslice_expiration_count: 0,
-            });
-
-            let flash_protected_size = process.header.get_protected_size() as usize;
-            let flash_app_start = app_flash_address as usize + flash_protected_size;
-
-            process.tasks.map(|tasks| {
-                tasks.enqueue(Task::FunctionCall(FunctionCall {
-                    source: FunctionCallSource::Kernel,
-                    pc: init_fn,
-                    argument0: flash_app_start,
-                    argument1: process.memory.as_ptr() as usize,
-                    argument2: process.memory.len() as usize,
-                    argument3: process.app_break.get() as usize,
-                }));
-            });
-
-            // Handle any architecture-specific requirements for a new process
-            let mut stored_state = process.stored_state.get();
-            match chip.userspace_kernel_boundary().initialize_process(
-                process.sp(),
-                process.sp() as usize - process.memory.as_ptr() as usize,
-                &mut stored_state,
-            ) {
-                Ok(new_stack_pointer) => {
-                    process
-                        .current_stack_pointer
-                        .set(new_stack_pointer as *mut u8);
-                    process.debug_set_max_stack_depth();
-                    process.stored_state.set(stored_state);
-                }
-                Err(_) => {
-                    if config::CONFIG.debug_load_processes {
-                        debug!(
-                            "[!] flash=[{:#010X}:{:#010X}] process={:?} - couldn't initialize process",
-                            app_flash_address as usize,
-                            app_flash_address as usize + app_flash_size,
-                            process_name
-                        );
-                    }
-                    return (None, app_flash_size, 0);
-                }
-            };
-
-            // Mark this process as having something to do (it has to start!)
-            kernel.increment_work();
-
-            return (
-                Some(process),
-                app_flash_size,
-                memory_padding_size + memory_size,
-            );
+            return Ok((None, 0));
         }
-        if config::CONFIG.debug_load_processes {
-            debug!(
-                "[!] flash={:#010X} - not a valid TBF header",
-                app_flash_address as usize
-            );
+
+        // Determine how much space we need in the application's
+        // memory space just for kernel and grant state. We need to make
+        // sure we allocate enough memory just for that.
+
+        // Make room for grant pointers.
+        let grant_ptr_size = mem::size_of::<*const usize>();
+        let grant_ptrs_num = kernel.get_grant_count_and_finalize();
+        let grant_ptrs_offset = grant_ptrs_num * grant_ptr_size;
+
+        // Allocate memory for callback ring buffer.
+        let callback_size = mem::size_of::<Task>();
+        let callback_len = 10;
+        let callbacks_offset = callback_len * callback_size;
+
+        // Make room to store this process's metadata.
+        let process_struct_offset = mem::size_of::<Process<C>>();
+
+        // Initial sizes of the app-owned and kernel-owned parts of process memory.
+        // Provide the app with plenty of initial process accessible memory.
+        let initial_kernel_memory_size =
+            grant_ptrs_offset + callbacks_offset + process_struct_offset;
+        let initial_app_memory_size = 3 * 1024;
+
+        if min_app_ram_size < initial_app_memory_size {
+            min_app_ram_size = initial_app_memory_size;
         }
-        (None, 0, 0)
+
+        // Minimum memory size for the process.
+        let min_total_memory_size = min_app_ram_size + initial_kernel_memory_size;
+
+        // Determine where process memory will go and allocate MPU region for app-owned memory.
+        let (memory_start, memory_size) = match chip.mpu().allocate_app_memory_region(
+            remaining_app_memory as *const u8,
+            remaining_app_memory_size,
+            min_total_memory_size,
+            initial_app_memory_size,
+            initial_kernel_memory_size,
+            mpu::Permissions::ReadWriteOnly,
+            &mut mpu_config,
+        ) {
+            Some((memory_start, memory_size)) => (memory_start, memory_size),
+            None => {
+                // Failed to load process. Insufficient memory.
+                if config::CONFIG.debug_load_processes {
+                    debug!(
+                        "[!] flash=[{:#010X}:{:#010X}] process={:?} - couldn't allocate memory region of size >= {:#X}",
+                        app_flash.as_ptr() as usize,
+                        app_flash.as_ptr() as usize + app_flash.len(),
+                        process_name,
+                        min_total_memory_size
+                    );
+                }
+                return Ok((None, 0));
+            }
+        };
+
+        // Compute how much padding before start of process memory.
+        let memory_padding_size = (memory_start as usize) - (remaining_app_memory as usize);
+
+        // Set up process memory.
+        let app_memory = slice::from_raw_parts_mut(memory_start as *mut u8, memory_size);
+
+        // Set the initial process stack and memory to 3072 bytes.
+        let initial_stack_pointer = memory_start.add(initial_app_memory_size);
+        let initial_sbrk_pointer = memory_start.add(initial_app_memory_size);
+
+        // Set up initial grant region.
+        let mut kernel_memory_break = app_memory.as_mut_ptr().add(app_memory.len());
+
+        // Now that we know we have the space we can setup the grant
+        // pointers.
+        kernel_memory_break = kernel_memory_break.offset(-(grant_ptrs_offset as isize));
+
+        // Set all pointers to null.
+        let opts =
+            slice::from_raw_parts_mut(kernel_memory_break as *mut *const usize, grant_ptrs_num);
+        for opt in opts.iter_mut() {
+            *opt = ptr::null()
+        }
+
+        // Now that we know we have the space we can setup the memory
+        // for the callbacks.
+        kernel_memory_break = kernel_memory_break.offset(-(callbacks_offset as isize));
+
+        // Set up ring buffer.
+        let callback_buf =
+            slice::from_raw_parts_mut(kernel_memory_break as *mut Task, callback_len);
+        let tasks = RingBuffer::new(callback_buf);
+
+        // Last thing is the process struct.
+        kernel_memory_break = kernel_memory_break.offset(-(process_struct_offset as isize));
+        let process_struct_memory_location = kernel_memory_break;
+
+        // Determine the debug information to the best of our
+        // understanding. If the app is doing all of the PIC fixup and
+        // memory management we don't know much.
+        let app_heap_start_pointer = None;
+        let app_stack_start_pointer = None;
+
+        // Create the Process struct in the app grant region.
+        let mut process: &mut Process<C> =
+            &mut *(process_struct_memory_location as *mut Process<'static, C>);
+
+        // Ask the kernel for a unique identifier for this process that is
+        // being created.
+        let unique_identifier = kernel.create_process_identifier();
+
+        process
+            .app_id
+            .set(AppId::new(kernel, unique_identifier, index));
+        process.kernel = kernel;
+        process.chip = chip;
+        process.memory = app_memory;
+        process.header = tbf_header;
+        process.kernel_memory_break = Cell::new(kernel_memory_break);
+        process.original_kernel_memory_break = kernel_memory_break;
+        process.app_break = Cell::new(initial_sbrk_pointer);
+        process.original_app_break = initial_sbrk_pointer;
+        process.allow_high_water_mark = Cell::new(remaining_app_memory);
+        process.original_allow_high_water_mark = remaining_app_memory;
+        process.current_stack_pointer = Cell::new(initial_stack_pointer);
+        process.original_stack_pointer = initial_stack_pointer;
+
+        process.flash = app_flash;
+
+        process.stored_state = Cell::new(Default::default());
+        process.state = Cell::new(State::Unstarted);
+        process.fault_response = fault_response;
+        process.restart_count = Cell::new(0);
+
+        process.mpu_config = MapCell::new(mpu_config);
+        process.mpu_regions = [
+            Cell::new(None),
+            Cell::new(None),
+            Cell::new(None),
+            Cell::new(None),
+            Cell::new(None),
+            Cell::new(None),
+        ];
+        process.tasks = MapCell::new(tasks);
+        process.process_name = process_name.unwrap_or("");
+
+        process.debug = MapCell::new(ProcessDebug {
+            app_heap_start_pointer: app_heap_start_pointer,
+            app_stack_start_pointer: app_stack_start_pointer,
+            min_stack_pointer: initial_stack_pointer,
+            syscall_count: 0,
+            last_syscall: None,
+            dropped_callback_count: 0,
+            timeslice_expiration_count: 0,
+        });
+
+        let flash_protected_size = process.header.get_protected_size() as usize;
+        let flash_app_start_addr = app_flash.as_ptr() as usize + flash_protected_size;
+
+        process.tasks.map(|tasks| {
+            tasks.enqueue(Task::FunctionCall(FunctionCall {
+                source: FunctionCallSource::Kernel,
+                pc: init_fn,
+                argument0: flash_app_start_addr,
+                argument1: process.memory.as_ptr() as usize,
+                argument2: process.memory.len() as usize,
+                argument3: process.app_break.get() as usize,
+            }));
+        });
+
+        // Handle any architecture-specific requirements for a new process
+        let mut stored_state = process.stored_state.get();
+        match chip.userspace_kernel_boundary().initialize_process(
+            process.sp(),
+            process.sp() as usize - process.memory.as_ptr() as usize,
+            &mut stored_state,
+        ) {
+            Ok(new_stack_pointer) => {
+                process
+                    .current_stack_pointer
+                    .set(new_stack_pointer as *mut u8);
+                process.debug_set_max_stack_depth();
+                process.stored_state.set(stored_state);
+            }
+            Err(_) => {
+                if config::CONFIG.debug_load_processes {
+                    debug!(
+                        "[!] flash=[{:#010X}:{:#010X}] process={:?} - couldn't initialize process",
+                        app_flash.as_ptr() as usize,
+                        app_flash.as_ptr() as usize + app_flash.len(),
+                        process_name
+                    );
+                }
+                return Ok((None, 0));
+            }
+        };
+
+        // Mark this process as having something to do (it has to start!)
+        kernel.increment_work();
+
+        // return
+        Ok((Some(process), memory_padding_size + memory_size))
     }
 
     /// Stop and clear a process's state.

--- a/kernel/src/tbfheader.rs
+++ b/kernel/src/tbfheader.rs
@@ -433,10 +433,6 @@ crate fn parse_tbf_header(header: &'static [u8], version: u16) -> Result<TbfHead
                 }
             }
 
-            // DO WE NEED TO PARSE THE REMAINDER (AKA DO APPS HAVE HEADERS
-            // NOT MULTIPLE OF 4)??
-            // let extra = header_iter.remainder();
-
             // Verify the header matches.
             if checksum != tbf_header_base.checksum {
                 return Err(TbfParseError::ChecksumMismatch(

--- a/kernel/src/tbfheader.rs
+++ b/kernel/src/tbfheader.rs
@@ -1,6 +1,9 @@
 //! Tock Binary Format Header definitions and parsing code.
 
-use core::{mem, slice, str};
+use core::convert::TryInto;
+use core::fmt;
+use core::iter::Iterator;
+use core::{mem, str};
 
 /// Takes a value and rounds it up to be aligned % 4
 macro_rules! align4 {
@@ -9,8 +12,72 @@ macro_rules! align4 {
     };
 }
 
+/// Error when parsing an app's TBF header.
+pub enum TbfParseError {
+    /// Not enough bytes in the buffer to parse the expected field.
+    NotEnoughFlash,
+
+    /// The length fields of the header and app do not make sense. Likely the
+    /// TBF header length is set to be longer than the entire app.
+    BadSize,
+
+    /// Unknown version of the TBF header.
+    UnsupportedVersion(u16),
+
+    /// Checksum calculation did not match what is stored in the TBF header.
+    /// First value is the checksum provided, second value is the checksum we
+    /// calculated.
+    ChecksumMismatch(u32, u32),
+
+    /// One of the TLV entries did not parse correctly. This could happen if the
+    /// TLV.length does not match the size of a fixed-length entry. The `usize`
+    /// is the value of the "tipe" field.
+    BadTlvEntry(usize),
+
+    /// The app name in the TBF header could not be successfully parsed as a
+    /// UTF-8 string.
+    BadProcessName,
+
+    /// Internal kernel error. This is a bug inside of this library. Likely this
+    /// means that for some reason a slice was not sized properly for parsing a
+    /// certain type, which is something completely controlled by this library.
+    /// If the slice passed in is not long enough, then a `get()` call will
+    /// fail and that will trigger a different error.
+    InternalError,
+}
+
+impl From<core::array::TryFromSliceError> for TbfParseError {
+    // Convert a slice to a parsed type. Since we control how long we make our
+    // slices, this conversion should never fail. If it does, then this is a bug
+    // in this library that must be fixed.
+    fn from(_error: core::array::TryFromSliceError) -> Self {
+        TbfParseError::InternalError
+    }
+}
+
+impl fmt::Debug for TbfParseError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            TbfParseError::NotEnoughFlash => write!(f, "Buffer too short to parse TBF header"),
+            TbfParseError::BadSize => write!(f, "Invalid TBF header and app lengths"),
+            TbfParseError::UnsupportedVersion(version) => {
+                write!(f, "TBF version {} unsupported", version)
+            }
+            TbfParseError::ChecksumMismatch(app, calc) => write!(
+                f,
+                "Checksum verification failed: app:{:#x}, calc:{:#x}",
+                app, calc
+            ),
+            TbfParseError::BadTlvEntry(tipe) => write!(f, "TLV entry type {} is invalid", tipe),
+            TbfParseError::BadProcessName => write!(f, "Process name not UTF-8"),
+            TbfParseError::InternalError => write!(f, "Internal kernel error. This is a bug."),
+        }
+    }
+}
+
+// TBF structure
+
 /// TBF fields that must be present in all v2 headers.
-#[repr(C)]
 #[derive(Clone, Copy, Debug)]
 crate struct TbfHeaderV2Base {
     version: u16,
@@ -21,18 +88,19 @@ crate struct TbfHeaderV2Base {
 }
 
 /// Types in TLV structures for each optional block of the header.
-#[repr(u16)]
 #[derive(Clone, Copy, Debug)]
-#[allow(dead_code)]
 crate enum TbfHeaderTypes {
     TbfHeaderMain = 1,
     TbfHeaderWriteableFlashRegions = 2,
     TbfHeaderPackageName = 3,
-    Unused = 5,
+
+    /// Some field in the header that we do not understand. Since the TLV format
+    /// specifies the length of each section, if we get a field we do not
+    /// understand we just skip it, rather than throwing an error.
+    Unknown = 5,
 }
 
 /// The TLV header (T and L).
-#[repr(C)]
 #[derive(Clone, Copy, Debug)]
 crate struct TbfHeaderTlv {
     tipe: TbfHeaderTypes,
@@ -43,7 +111,6 @@ crate struct TbfHeaderTlv {
 ///
 /// All apps must have a main section. Without it, the header is considered as
 /// only padding.
-#[repr(C)]
 #[derive(Clone, Copy, Debug)]
 crate struct TbfHeaderV2Main {
     init_fn_offset: u32,
@@ -55,20 +122,132 @@ crate struct TbfHeaderV2Main {
 ///
 /// There can be multiple (or zero) flash regions defined, so this is its own
 /// struct.
-#[repr(C)]
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Default)]
 crate struct TbfHeaderV2WriteableFlashRegion {
     writeable_flash_region_offset: u32,
     writeable_flash_region_size: u32,
 }
 
+// Conversion functions from slices to the various TBF fields.
+
+impl core::convert::TryFrom<&[u8]> for TbfHeaderV2Base {
+    type Error = TbfParseError;
+
+    fn try_from(b: &[u8]) -> Result<TbfHeaderV2Base, Self::Error> {
+        Ok(TbfHeaderV2Base {
+            version: u16::from_le_bytes(
+                b.get(0..2)
+                    .ok_or(TbfParseError::InternalError)?
+                    .try_into()?,
+            ),
+            header_size: u16::from_le_bytes(
+                b.get(2..4)
+                    .ok_or(TbfParseError::InternalError)?
+                    .try_into()?,
+            ),
+            total_size: u32::from_le_bytes(
+                b.get(4..8)
+                    .ok_or(TbfParseError::InternalError)?
+                    .try_into()?,
+            ),
+            flags: u32::from_le_bytes(
+                b.get(8..12)
+                    .ok_or(TbfParseError::InternalError)?
+                    .try_into()?,
+            ),
+            checksum: u32::from_le_bytes(
+                b.get(12..16)
+                    .ok_or(TbfParseError::InternalError)?
+                    .try_into()?,
+            ),
+        })
+    }
+}
+
+impl core::convert::TryFrom<u16> for TbfHeaderTypes {
+    type Error = TbfParseError;
+
+    fn try_from(h: u16) -> Result<TbfHeaderTypes, Self::Error> {
+        match h {
+            1 => Ok(TbfHeaderTypes::TbfHeaderMain),
+            2 => Ok(TbfHeaderTypes::TbfHeaderWriteableFlashRegions),
+            3 => Ok(TbfHeaderTypes::TbfHeaderPackageName),
+            _ => Ok(TbfHeaderTypes::Unknown),
+        }
+    }
+}
+
+impl core::convert::TryFrom<&[u8]> for TbfHeaderTlv {
+    type Error = TbfParseError;
+
+    fn try_from(b: &[u8]) -> Result<TbfHeaderTlv, Self::Error> {
+        Ok(TbfHeaderTlv {
+            tipe: u16::from_le_bytes(
+                b.get(0..2)
+                    .ok_or(TbfParseError::InternalError)?
+                    .try_into()?,
+            )
+            .try_into()?,
+            length: u16::from_le_bytes(
+                b.get(2..4)
+                    .ok_or(TbfParseError::InternalError)?
+                    .try_into()?,
+            ),
+        })
+    }
+}
+
+impl core::convert::TryFrom<&[u8]> for TbfHeaderV2Main {
+    type Error = TbfParseError;
+
+    fn try_from(b: &[u8]) -> Result<TbfHeaderV2Main, Self::Error> {
+        Ok(TbfHeaderV2Main {
+            init_fn_offset: u32::from_le_bytes(
+                b.get(0..4)
+                    .ok_or(TbfParseError::InternalError)?
+                    .try_into()?,
+            ),
+            protected_size: u32::from_le_bytes(
+                b.get(4..8)
+                    .ok_or(TbfParseError::InternalError)?
+                    .try_into()?,
+            ),
+            minimum_ram_size: u32::from_le_bytes(
+                b.get(8..12)
+                    .ok_or(TbfParseError::InternalError)?
+                    .try_into()?,
+            ),
+        })
+    }
+}
+
+impl core::convert::TryFrom<&[u8]> for TbfHeaderV2WriteableFlashRegion {
+    type Error = TbfParseError;
+
+    fn try_from(b: &[u8]) -> Result<TbfHeaderV2WriteableFlashRegion, Self::Error> {
+        Ok(TbfHeaderV2WriteableFlashRegion {
+            writeable_flash_region_offset: u32::from_le_bytes(
+                b.get(0..4)
+                    .ok_or(TbfParseError::InternalError)?
+                    .try_into()?,
+            ),
+            writeable_flash_region_size: u32::from_le_bytes(
+                b.get(4..8)
+                    .ok_or(TbfParseError::InternalError)?
+                    .try_into()?,
+            ),
+        })
+    }
+}
+
 /// Single header that can contain all parts of a v2 header.
 #[derive(Clone, Copy, Debug)]
 crate struct TbfHeaderV2 {
-    base: &'static TbfHeaderV2Base,
-    main: Option<&'static TbfHeaderV2Main>,
+    base: TbfHeaderV2Base,
+    // main: Option<&'static TbfHeaderV2Main>,
+    main: Option<TbfHeaderV2Main>,
     package_name: Option<&'static str>,
-    writeable_regions: Option<&'static [TbfHeaderV2WriteableFlashRegion]>,
+    writeable_regions: Option<[TbfHeaderV2WriteableFlashRegion; 4]>,
 }
 
 /// Type that represents the fields of the Tock Binary Format header.
@@ -80,7 +259,7 @@ crate struct TbfHeaderV2 {
 #[derive(Debug)]
 crate enum TbfHeader {
     TbfHeaderV2(TbfHeaderV2),
-    Padding(&'static TbfHeaderV2Base),
+    Padding(TbfHeaderV2Base),
 }
 
 impl TbfHeader {
@@ -101,14 +280,6 @@ impl TbfHeader {
                 hd.base.flags & 0x00000001 == 1
             }
             TbfHeader::Padding(_) => false,
-        }
-    }
-
-    /// Get the total size in flash of this app or padding.
-    crate fn get_total_size(&self) -> u32 {
-        match *self {
-            TbfHeader::TbfHeaderV2(hd) => hd.base.total_size,
-            TbfHeader::Padding(hd) => hd.total_size,
         }
     }
 
@@ -155,7 +326,16 @@ impl TbfHeader {
     /// Get the number of flash regions this app has specified in its header.
     crate fn number_writeable_flash_regions(&self) -> usize {
         match *self {
-            TbfHeader::TbfHeaderV2(hd) => hd.writeable_regions.map_or(0, |wr| wr.len()),
+            TbfHeader::TbfHeaderV2(hd) => hd.writeable_regions.map_or(0, |wrs| {
+                wrs.iter().fold(0, |acc, wr| {
+                    if wr.writeable_flash_region_offset != 0 && wr.writeable_flash_region_size != 0
+                    {
+                        acc + 1
+                    } else {
+                        acc
+                    }
+                })
+            }),
             _ => 0,
         }
     }
@@ -178,150 +358,206 @@ impl TbfHeader {
     }
 }
 
-/// Converts a pointer to memory to a TbfHeader struct
+/// Parse the TBF header length and the entire length of the TBF binary.
 ///
-/// This function takes a pointer to arbitrary memory and optionally returns a
-/// TBF header struct. This function will validate the header checksum, but does
-/// not perform sanity or security checking on the structure.
-#[allow(clippy::cast_ptr_alignment)]
-crate unsafe fn parse_and_validate_tbf_header(address: *const u8) -> Option<TbfHeader> {
-    let version = *(address as *const u16);
+/// ## Return
+///
+/// Ok((Version, TBF header length, entire TBF length))
+crate fn parse_tbf_header_lengths(app: &'static [u8; 8]) -> Result<(u16, u16, u32), TbfParseError> {
+    // Version is the first 16 bits of the app TBF contents. We need this to
+    // correctly parse the other lengths.
+    //
+    // ## Safety
+    // We trust that the version number has been checked prior to running this
+    // parsing code. That is, whatever loaded this application has verified that
+    // the version is valid and therefore we can trust it.
+    let version = u16::from_le_bytes(
+        app.get(0..2)
+            .ok_or(TbfParseError::NotEnoughFlash)?
+            .try_into()?,
+    );
 
     match version {
         2 => {
-            let tbf_header_base = &*(address as *const TbfHeaderV2Base);
+            // In version 2, the next 16 bits after the version represent
+            // the size of the TBF header in bytes.
+            let tbf_header_size = u16::from_le_bytes(
+                app.get(2..4)
+                    .ok_or(TbfParseError::NotEnoughFlash)?
+                    .try_into()?,
+            );
 
-            // Some sanity checking. Make sure the header isn't longer than the
-            // total app. Make sure the total app fits inside a reasonable size
-            // of flash.
-            if tbf_header_base.header_size as u32 >= tbf_header_base.total_size
-                || tbf_header_base.total_size > 0x010000000
-            {
-                return None;
+            // The next 4 bytes are the size of the entire app's TBF space
+            // including the header. This also must be checked before parsing
+            // this header and we trust the value in flash.
+            let tbf_size = u32::from_le_bytes(
+                app.get(4..8)
+                    .ok_or(TbfParseError::NotEnoughFlash)?
+                    .try_into()?,
+            );
+
+            // Check that the header length isn't greater than the entire
+            // app. If that at least looks good then return the sizes.
+            if u32::from(tbf_header_size) > tbf_size {
+                Err(TbfParseError::BadSize)
+            } else {
+                Ok((version, tbf_header_size, tbf_size))
             }
+        }
+
+        _ => Err(TbfParseError::UnsupportedVersion(version)),
+    }
+}
+
+/// Parse a TBF header stored in flash.
+///
+/// The `header` must be a slice that only contains the TBF header. The caller
+/// should use the `parse_tbf_header_lengths()` function to determine this
+/// length to create the correct sized slice.
+crate fn parse_tbf_header(header: &'static [u8], version: u16) -> Result<TbfHeader, TbfParseError> {
+    match version {
+        2 => {
+            // Get the required base. This will succeed because we parsed the
+            // first bit of the header already in `parse_tbf_header_lengths()`.
+            let tbf_header_base: TbfHeaderV2Base = header.try_into()?;
 
             // Calculate checksum. The checksum is the XOR of each 4 byte word
             // in the header.
-            let mut chunks = tbf_header_base.header_size as usize / 4;
-            let leftover_bytes = tbf_header_base.header_size as usize % 4;
-            if leftover_bytes != 0 {
-                chunks += 1;
-            }
             let mut checksum: u32 = 0;
-            let header = slice::from_raw_parts(address as *const u32, chunks);
-            for (i, chunk) in header.iter().enumerate() {
+
+            // Get an iterator across 4 byte fields in the header.
+            let header_iter = header.chunks_exact(4);
+
+            // Iterate all chunks and XOR the chunks to compute the checksum.
+            for (i, chunk) in header_iter.enumerate() {
+                let word = u32::from_le_bytes(chunk.try_into()?);
                 if i == 3 {
                     // Skip the checksum field.
-                } else if i == chunks - 1 && leftover_bytes != 0 {
-                    // In this case, we don't want to use the entire word.
-                    checksum ^= *chunk & (0xFFFFFFFF >> (4 - leftover_bytes));
                 } else {
-                    checksum ^= *chunk;
+                    checksum ^= word;
                 }
             }
 
+            // DO WE NEED TO PARSE THE REMAINDER (AKA DO APPS HAVE HEADERS
+            // NOT MULTIPLE OF 4)??
+            // let extra = header_iter.remainder();
+
+            // Verify the header matches.
             if checksum != tbf_header_base.checksum {
-                return None;
+                return Err(TbfParseError::ChecksumMismatch(
+                    tbf_header_base.checksum,
+                    checksum,
+                ));
             }
 
-            // Skip the base of the header.
-            let mut offset = mem::size_of::<TbfHeaderV2Base>() as isize;
-            let mut remaining_length = tbf_header_base.header_size as usize - offset as usize;
+            // Get the rest of the header. The `remaining` variable will
+            // continue to hold the remainder of the header we have not
+            // processed.
+            let mut remaining = header.get(16..).ok_or(TbfParseError::NotEnoughFlash)?;
 
-            // Check if this is a real app or just padding. Padding apps are
-            // identified by not having any options.
-            if remaining_length == 0 {
+            // If there is nothing left in the header then this is just a
+            // padding "app" between two other apps.
+            if remaining.len() == 0 {
                 // Just padding.
-                Some(TbfHeader::Padding(tbf_header_base))
+                Ok(TbfHeader::Padding(tbf_header_base))
             } else {
                 // This is an actual app.
 
                 // Places to save fields that we parse out of the header
                 // options.
-                let mut main_pointer: Option<&TbfHeaderV2Main> = None;
-                let mut wfr_pointer: Option<&'static [TbfHeaderV2WriteableFlashRegion]> = None;
+                let mut main_pointer: Option<TbfHeaderV2Main> = None;
+                let mut wfr_pointer: [TbfHeaderV2WriteableFlashRegion; 4] = Default::default();
                 let mut app_name_str = "";
 
-                // Loop through the header looking for known options.
-                while remaining_length > mem::size_of::<TbfHeaderTlv>() {
-                    let tbf_tlv_header = &*(address.offset(offset) as *const TbfHeaderTlv);
+                // Iterate the remainder of the header looking for TLV entries.
+                while remaining.len() > 0 {
+                    // Get the T and L portions of the next header (if it is
+                    // there).
+                    let tlv_header: TbfHeaderTlv = remaining.try_into()?;
+                    remaining = remaining.get(4..).ok_or(TbfParseError::NotEnoughFlash)?;
 
-                    remaining_length -= mem::size_of::<TbfHeaderTlv>();
-                    offset += mem::size_of::<TbfHeaderTlv>() as isize;
+                    match tlv_header.tipe {
+                        TbfHeaderTypes::TbfHeaderMain => {
+                            let entry_len = mem::size_of::<TbfHeaderV2Main>();
 
-                    // Only parse known TLV blocks. There is no type 0.
-                    if (tbf_tlv_header.tipe as u16) < TbfHeaderTypes::Unused as u16
-                        && (tbf_tlv_header.tipe as u16) > 0
-                    {
-                        // This lets us skip unknown header types.
-
-                        match tbf_tlv_header.tipe {
-                            TbfHeaderTypes::TbfHeaderMain =>
-                            /* Main */
-                            {
-                                if remaining_length >= mem::size_of::<TbfHeaderV2Main>()
-                                    && tbf_tlv_header.length as usize
-                                        == mem::size_of::<TbfHeaderV2Main>()
-                                {
-                                    let tbf_main =
-                                        &*(address.offset(offset) as *const TbfHeaderV2Main);
-                                    main_pointer = Some(tbf_main);
-                                }
+                            // Check that the size of the TLV entry matches the
+                            // size of the Main TLV. If so we can store it.
+                            // Otherwise, we fail to parse this TBF header and
+                            // throw an error.
+                            if tlv_header.length as usize == entry_len {
+                                main_pointer = Some(remaining.try_into()?);
+                            } else {
+                                return Err(TbfParseError::BadTlvEntry(tlv_header.tipe as usize));
                             }
-                            TbfHeaderTypes::TbfHeaderWriteableFlashRegions =>
-                            /* Writeable Flash Regions */
-                            {
-                                // Length must be a multiple of the size of a region definition.
-                                if tbf_tlv_header.length as usize
-                                    % mem::size_of::<TbfHeaderV2WriteableFlashRegion>()
-                                    == 0
-                                {
-                                    let number_regions = tbf_tlv_header.length as usize
-                                        / mem::size_of::<TbfHeaderV2WriteableFlashRegion>();
-                                    let region_start = &*(address.offset(offset)
-                                        as *const TbfHeaderV2WriteableFlashRegion);
-                                    let regions =
-                                        slice::from_raw_parts(region_start, number_regions);
-                                    wfr_pointer = Some(regions);
-                                }
-                            }
-                            TbfHeaderTypes::TbfHeaderPackageName =>
-                            /* Package Name */
-                            {
-                                if remaining_length >= tbf_tlv_header.length as usize {
-                                    let package_name_byte_array = slice::from_raw_parts(
-                                        address.offset(offset),
-                                        tbf_tlv_header.length as usize,
-                                    );
-                                    let _ =
-                                        str::from_utf8(package_name_byte_array).map(|name_str| {
-                                            app_name_str = name_str;
-                                        });
-                                }
-                            }
-                            TbfHeaderTypes::Unused => {}
                         }
+
+                        TbfHeaderTypes::TbfHeaderWriteableFlashRegions => {
+                            // Length must be a multiple of the size of a region definition.
+                            if tlv_header.length as usize
+                                % mem::size_of::<TbfHeaderV2WriteableFlashRegion>()
+                                == 0
+                            {
+                                // Calculate how many writeable flash regions
+                                // there are specified in this header.
+                                let wfr_len = mem::size_of::<TbfHeaderV2WriteableFlashRegion>();
+                                let mut number_regions = tlv_header.length as usize / wfr_len;
+
+                                // Capture a slice with just the wfr information.
+                                let wfr_slice = remaining
+                                    .get(0..tlv_header.length as usize)
+                                    .ok_or(TbfParseError::NotEnoughFlash)?;
+
+                                // To enable a static buffer, we only support up
+                                // to four writeable flash regions.
+                                if number_regions > 4 {
+                                    number_regions = 4;
+                                }
+
+                                // Convert and store each wfr.
+                                for i in 0..number_regions {
+                                    wfr_pointer[i] = wfr_slice
+                                        .get(i * wfr_len..(i + 1) * wfr_len)
+                                        .ok_or(TbfParseError::NotEnoughFlash)?
+                                        .try_into()?;
+                                }
+                            } else {
+                                return Err(TbfParseError::BadTlvEntry(tlv_header.tipe as usize));
+                            }
+                        }
+
+                        TbfHeaderTypes::TbfHeaderPackageName => {
+                            let name_buf = remaining
+                                .get(0..tlv_header.length as usize)
+                                .ok_or(TbfParseError::NotEnoughFlash)?;
+
+                            str::from_utf8(name_buf)
+                                .map(|name_str| {
+                                    app_name_str = name_str;
+                                })
+                                .or(Err(TbfParseError::BadProcessName))?;
+                        }
+
+                        _ => {}
                     }
 
                     // All TLV blocks are padded to 4 bytes, so we need to skip
                     // more if the length is not a multiple of 4.
-                    remaining_length -= align4!(tbf_tlv_header.length) as usize;
-                    offset += align4!(tbf_tlv_header.length) as isize;
+                    let skip_len: usize = align4!(tlv_header.length as usize);
+                    remaining = remaining
+                        .get(skip_len..)
+                        .ok_or(TbfParseError::NotEnoughFlash)?;
                 }
 
                 let tbf_header = TbfHeaderV2 {
                     base: tbf_header_base,
                     main: main_pointer,
                     package_name: Some(app_name_str),
-                    writeable_regions: wfr_pointer,
+                    writeable_regions: Some(wfr_pointer),
                 };
 
-                Some(TbfHeader::TbfHeaderV2(tbf_header))
+                Ok(TbfHeader::TbfHeaderV2(tbf_header))
             }
         }
-
-        // If we don't recognize the version number, we assume this is not a
-        // valid app.
-        _ => None,
+        _ => Err(TbfParseError::UnsupportedVersion(version)),
     }
 }

--- a/kernel/src/tbfheader.rs
+++ b/kernel/src/tbfheader.rs
@@ -97,7 +97,7 @@ crate enum TbfHeaderTypes {
     /// Some field in the header that we do not understand. Since the TLV format
     /// specifies the length of each section, if we get a field we do not
     /// understand we just skip it, rather than throwing an error.
-    Unknown = 5,
+    Unknown,
 }
 
 /// The TLV header (T and L).


### PR DESCRIPTION
### Pull Request Overview

This completely re-writes how TBF headers are parsed. The major results:

1. kernel/src/tbfheader.rs no longer uses `unsafe`.
2. To make 1 work I couldn't figure out how to support a variable number of writeable flash regions in the header. Right now I set the max number of WFRs to 4.
3. The TBF header parsing code uses `Result`, and therefore load_processes also returns a Result now.

I tried to reduce/eliminate the ability for the tbf parsing to panic.


### Testing Strategy

Blink on Hail works, but more testing is needed.


### TODO or Help Wanted

There might be ways to do this better.

I also need to update all of the boards.

### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make formatall`.
