### PR TITLE
regs: Add Copy and Clone to InMemoryRegister

### DIFF
--- a/libraries/tock-register-interface/CHANGELOG.md
+++ b/libraries/tock-register-interface/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 ## master
 
+ - #1481
+   - Add `#[derive(Copy, Clone)]` to InMemoryRegister.
+
  - #1428
-   - Implement `mask()` for `FieldValue<u16>` which seems to have been 
+   - Implement `mask()` for `FieldValue<u16>` which seems to have been
      skipped at some point.
    - Implement `read()` for `FieldValue` so that individual fields
      can be extracted from a register `FieldValue` representation.

--- a/libraries/tock-register-interface/src/registers.rs
+++ b/libraries/tock-register-interface/src/registers.rs
@@ -344,6 +344,7 @@ impl<R: RegisterLongName> From<LocalRegisterCopy<u64, R>> for u64 {
 /// In memory volatile register.
 // To successfully alias this structure onto hardware registers in memory, this
 // struct must be exactly the size of the `T`.
+#[derive(Copy, Clone)]
 #[repr(transparent)]
 pub struct InMemoryRegister<T: IntLike, R: RegisterLongName = ()> {
     value: T,


### PR DESCRIPTION
### Pull Request Overview

Add `Copy` and `Clone` to `InMemoryRegister`. This might be useful in a couple of cases, for example when instantiating a static array with this type.
