### PR TITLE
Remove dead code that double-checks the checksum

### DIFF
--- a/kernel/src/tbfheader.rs
+++ b/kernel/src/tbfheader.rs
@@ -232,11 +232,7 @@ crate unsafe fn parse_and_validate_tbf_header(address: *const u8) -> Option<TbfH
             // identified by not having any options.
             if remaining_length == 0 {
                 // Just padding.
-                if checksum == tbf_header_base.checksum {
-                    Some(TbfHeader::Padding(tbf_header_base))
-                } else {
-                    None
-                }
+                Some(TbfHeader::Padding(tbf_header_base))
             } else {
                 // This is an actual app.
 


### PR DESCRIPTION
# Pull Request Overview

This pull request removes dead code. To reach the statement line 235, the control flow always goes first through line 223 which does the same check and exits the function if the checksum is incorrect.

### Testing Strategy

This pull request was tested by `make ci-travis`.

### TODO or Help Wanted

None.

### Documentation Updated

- [x] No updates are required.

### Formatting

- [x] Ran `make formatall`.