### PR TITLE
tools: Add `setuptools` to `svd2regs.nix` generated environment

### DIFF
--- a/tools/svd2regs.nix
+++ b/tools/svd2regs.nix
@@ -49,7 +49,8 @@ let
 
   svd2regsPythonEnv = python37.withPackages (_: [ cmsis-svd
                                                   pydentifier
-                                                  python37.pkgs.six ]);
+                                                  python37.pkgs.six
+                                                  python37.pkgs.setuptools ]);
 in
 myEnvFun {
   name = "svd2regs";


### PR DESCRIPTION
Due to a change in Nix, `setuptools` is no longer available by default. 

Upstream issue [#68314](https://github.com/NixOS/nixpkgs/pull/68314)
