### PR TITLE
RFC: Simplified capabilities

### DIFF
--- a/boards/arty-e21/src/main.rs
+++ b/boards/arty-e21/src/main.rs
@@ -11,7 +11,7 @@ use kernel::common::ring_buffer::RingBuffer;
 use kernel::component::Component;
 use kernel::hil;
 use kernel::Platform;
-use kernel::{create_capability, debug, static_init};
+use kernel::{debug, static_init};
 
 mod timer_test;
 
@@ -84,9 +84,9 @@ pub unsafe fn reset_handler() {
     let chip = static_init!(arty_e21::chip::ArtyExx, arty_e21::chip::ArtyExx::new());
     chip.initialize();
 
-    let process_mgmt_cap = create_capability!(capabilities::ProcessManagementCapability);
-    let main_loop_cap = create_capability!(capabilities::MainLoopCapability);
-    let memory_allocation_cap = create_capability!(capabilities::MemoryAllocationCapability);
+    let process_mgmt_cap = capabilities::ProcessManagementCapability::new();
+    let main_loop_cap = capabilities::MainLoopCapability::new();
+    let memory_allocation_cap = capabilities::MemoryAllocationCapability::new();
 
     let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
 

--- a/boards/components/src/alarm.rs
+++ b/boards/components/src/alarm.rs
@@ -21,7 +21,6 @@ use capsules::alarm::AlarmDriver;
 use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use kernel::capabilities;
 use kernel::component::Component;
-use kernel::create_capability;
 use kernel::hil::time;
 use kernel::static_init_half;
 
@@ -63,7 +62,7 @@ impl<A: 'static + time::Alarm<'static>> Component for AlarmDriverComponent<A> {
     type Output = &'static AlarmDriver<'static, VirtualMuxAlarm<'static, A>>;
 
     unsafe fn finalize(&mut self, static_buffer: Self::StaticInput) -> Self::Output {
-        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
+        let grant_cap = capabilities::MemoryAllocationCapability::new();
 
         let virtual_alarm1 = static_init_half!(
             static_buffer.0,

--- a/boards/components/src/console.rs
+++ b/boards/components/src/console.rs
@@ -19,7 +19,6 @@ use capsules::console;
 use capsules::virtual_uart::{MuxUart, UartDevice};
 use kernel::capabilities;
 use kernel::component::Component;
-use kernel::create_capability;
 use kernel::hil;
 use kernel::static_init;
 
@@ -45,7 +44,7 @@ impl Component for ConsoleComponent {
     type Output = &'static console::Console<'static>;
 
     unsafe fn finalize(&mut self, _s: Self::StaticInput) -> Self::Output {
-        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
+        let grant_cap = capabilities::MemoryAllocationCapability::new();
 
         // Create virtual device for console.
         let console_uart = static_init!(UartDevice, UartDevice::new(self.uart_mux, true));

--- a/boards/components/src/crc.rs
+++ b/boards/components/src/crc.rs
@@ -20,7 +20,6 @@ use core::mem::MaybeUninit;
 use capsules::crc;
 use kernel::capabilities;
 use kernel::component::Component;
-use kernel::create_capability;
 use kernel::hil;
 use kernel::static_init_half;
 
@@ -54,7 +53,7 @@ impl<C: 'static + hil::crc::CRC> Component for CrcComponent<C> {
     type Output = &'static crc::Crc<'static, C>;
 
     unsafe fn finalize(&mut self, static_buffer: Self::StaticInput) -> Self::Output {
-        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
+        let grant_cap = capabilities::MemoryAllocationCapability::new();
 
         let crc = static_init_half!(
             static_buffer,

--- a/boards/components/src/debug_writer.rs
+++ b/boards/components/src/debug_writer.rs
@@ -15,7 +15,6 @@
 #![allow(dead_code)] // Components are intended to be conditionally included
 
 use capsules::virtual_uart::{MuxUart, UartDevice};
-use kernel::capabilities;
 use kernel::common::ring_buffer::RingBuffer;
 use kernel::component::Component;
 use kernel::hil;
@@ -30,9 +29,6 @@ impl DebugWriterComponent {
         DebugWriterComponent { uart_mux: uart_mux }
     }
 }
-
-pub struct Capability;
-unsafe impl capabilities::ProcessManagementCapability for Capability {}
 
 impl Component for DebugWriterComponent {
     type StaticInput = ();

--- a/boards/components/src/isl29035.rs
+++ b/boards/components/src/isl29035.rs
@@ -31,7 +31,6 @@ use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use capsules::virtual_i2c::{I2CDevice, MuxI2C};
 use kernel::capabilities;
 use kernel::component::Component;
-use kernel::create_capability;
 use kernel::hil;
 use kernel::hil::time;
 use kernel::hil::time::Alarm;
@@ -126,7 +125,7 @@ impl<A: 'static + time::Alarm<'static>> Component for AmbientLightComponent<A> {
     type Output = &'static AmbientLight<'static>;
 
     unsafe fn finalize(&mut self, static_buffer: Self::StaticInput) -> Self::Output {
-        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
+        let grant_cap = capabilities::MemoryAllocationCapability::new();
 
         let isl29035_i2c = static_init!(I2CDevice, I2CDevice::new(self.i2c_mux, 0x44));
         let isl29035_virtual_alarm = static_init_half!(

--- a/boards/components/src/process_console.rs
+++ b/boards/components/src/process_console.rs
@@ -39,12 +39,9 @@ impl ProcessConsoleComponent {
     }
 }
 
-pub struct Capability;
-unsafe impl capabilities::ProcessManagementCapability for Capability {}
-
 impl Component for ProcessConsoleComponent {
     type StaticInput = ();
-    type Output = &'static process_console::ProcessConsole<'static, Capability>;
+    type Output = &'static process_console::ProcessConsole<'static>;
 
     unsafe fn finalize(&mut self, _s: Self::StaticInput) -> Self::Output {
         // Create virtual device for console.
@@ -52,14 +49,14 @@ impl Component for ProcessConsoleComponent {
         console_uart.setup();
 
         let console = static_init!(
-            process_console::ProcessConsole<'static, Capability>,
+            process_console::ProcessConsole<'static>,
             process_console::ProcessConsole::new(
                 console_uart,
                 &mut process_console::WRITE_BUF,
                 &mut process_console::READ_BUF,
                 &mut process_console::COMMAND_BUF,
                 self.board_kernel,
-                Capability,
+                capabilities::ProcessManagementCapability::new(),
             )
         );
         hil::uart::Transmit::set_transmit_client(console_uart, console);

--- a/boards/components/src/rng.rs
+++ b/boards/components/src/rng.rs
@@ -17,7 +17,6 @@
 use capsules::rng;
 use kernel::capabilities;
 use kernel::component::Component;
-use kernel::create_capability;
 use kernel::hil::entropy::Entropy32;
 use kernel::hil::rng::Rng;
 use kernel::static_init;
@@ -44,7 +43,7 @@ impl Component for RngComponent {
     type Output = &'static rng::RngDriver<'static>;
 
     unsafe fn finalize(&mut self, _static_buffer: Self::StaticInput) -> Self::Output {
-        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
+        let grant_cap = capabilities::MemoryAllocationCapability::new();
 
         let entropy_to_random = static_init!(
             rng::Entropy32ToRandom<'static>,

--- a/boards/components/src/si7021.rs
+++ b/boards/components/src/si7021.rs
@@ -29,7 +29,6 @@ use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use capsules::virtual_i2c::{I2CDevice, MuxI2C};
 use kernel::capabilities;
 use kernel::component::Component;
-use kernel::create_capability;
 use kernel::hil;
 use kernel::hil::time::{self, Alarm};
 use kernel::{static_init, static_init_half};
@@ -117,7 +116,7 @@ impl<A: 'static + time::Alarm<'static>> Component for TemperatureComponent<A> {
     type Output = &'static TemperatureSensor<'static>;
 
     unsafe fn finalize(&mut self, _s: Self::StaticInput) -> Self::Output {
-        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
+        let grant_cap = capabilities::MemoryAllocationCapability::new();
 
         let temp = static_init!(
             TemperatureSensor<'static>,
@@ -151,7 +150,7 @@ impl<A: 'static + time::Alarm<'static>> Component for HumidityComponent<A> {
     type Output = &'static HumiditySensor<'static>;
 
     unsafe fn finalize(&mut self, _s: Self::StaticInput) -> Self::Output {
-        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
+        let grant_cap = capabilities::MemoryAllocationCapability::new();
 
         let hum = static_init!(
             HumiditySensor<'static>,

--- a/capsules/src/debug_process_restart.rs
+++ b/capsules/src/debug_process_restart.rs
@@ -28,28 +28,28 @@ use kernel::capabilities::ProcessManagementCapability;
 use kernel::hil::gpio;
 use kernel::Kernel;
 
-pub struct DebugProcessRestart<C: ProcessManagementCapability> {
+pub struct DebugProcessRestart {
     kernel: &'static Kernel,
-    capability: C,
+    capability: ProcessManagementCapability,
 }
 
-impl<'a, C: ProcessManagementCapability> DebugProcessRestart<C> {
+impl DebugProcessRestart {
     pub fn new(
         kernel: &'static Kernel,
-        pin: &'a dyn gpio::InterruptPin,
-        cap: C,
-    ) -> DebugProcessRestart<C> {
+        pin: &dyn gpio::InterruptPin,
+        cap: ProcessManagementCapability,
+    ) -> Self {
         pin.make_input();
         pin.enable_interrupts(gpio::InterruptEdge::RisingEdge);
 
-        DebugProcessRestart {
+        Self {
             kernel: kernel,
             capability: cap,
         }
     }
 }
 
-impl<'a, C: ProcessManagementCapability> gpio::Client for DebugProcessRestart<C> {
+impl gpio::Client for DebugProcessRestart {
     fn fired(&self) {
         self.kernel.hardfault_all_apps(&self.capability);
     }

--- a/kernel/src/capabilities.rs
+++ b/kernel/src/capabilities.rs
@@ -48,12 +48,30 @@
 /// The `ProcessManagementCapability` allows the holder to control
 /// process execution, such as related to creating, restarting, and
 /// otherwise managing processes.
-pub unsafe trait ProcessManagementCapability {}
+pub struct ProcessManagementCapability(());
+
+impl ProcessManagementCapability {
+    pub unsafe fn new() -> Self {
+        Self(())
+    }
+}
 
 /// The `MainLoopCapability` capability allows the holder to start executing
 /// the main scheduler loop in Tock.
-pub unsafe trait MainLoopCapability {}
+pub struct MainLoopCapability(());
+
+impl MainLoopCapability {
+    pub unsafe fn new() -> Self {
+        Self(())
+    }
+}
 
 /// The `MemoryAllocationCapability` capability allows the holder to allocate
 /// memory, for example by creating grants.
-pub unsafe trait MemoryAllocationCapability {}
+pub struct MemoryAllocationCapability(());
+
+impl MemoryAllocationCapability {
+    pub unsafe fn new() -> Self {
+        Self(())
+    }
+}

--- a/kernel/src/common/utils.rs
+++ b/kernel/src/common/utils.rs
@@ -68,25 +68,3 @@ macro_rules! storage_volume {
         pub static $N: [u8; $kB * 1024] = [0x00; $kB * 1024];
     };
 }
-
-/// Create an object with the given capability.
-///
-/// ```ignore
-/// use kernel::capabilities::ProcessManagementCapability;
-/// use kernel;
-///
-/// let process_mgmt_cap = create_capability!(ProcessManagementCapability);
-/// ```
-///
-/// This helper macro cannot be called from `#![forbid(unsafe_code)]` crates,
-/// and is used by trusted code to generate a capability that it can either use
-/// or pass to another module.
-#[macro_export]
-macro_rules! create_capability {
-    ($T:ty) => {{
-        struct Cap;
-        #[allow(unsafe_code)]
-        unsafe impl $T for Cap {}
-        Cap
-    };};
-}

--- a/kernel/src/introspection.rs
+++ b/kernel/src/introspection.rs
@@ -32,7 +32,7 @@ impl KernelInfo {
     /// functionally equivalent to how many of the process slots have been used
     /// on the board. This does not consider what state the process is in, as
     /// long as it has been loaded.
-    pub fn number_loaded_processes(&self, _capability: &dyn ProcessManagementCapability) -> usize {
+    pub fn number_loaded_processes(&self, _capability: &ProcessManagementCapability) -> usize {
         let count: Cell<usize> = Cell::new(0);
         self.kernel.process_each(|_| count.increment());
         count.get()
@@ -43,7 +43,7 @@ impl KernelInfo {
     /// processes which have faulted, or processes which the kernel is no longer
     /// scheduling because they have faulted too frequently or for some other
     /// reason.
-    pub fn number_active_processes(&self, _capability: &dyn ProcessManagementCapability) -> usize {
+    pub fn number_active_processes(&self, _capability: &ProcessManagementCapability) -> usize {
         let count: Cell<usize> = Cell::new(0);
         self.kernel
             .process_each(|process| match process.get_state() {
@@ -57,10 +57,7 @@ impl KernelInfo {
     /// Returns how many processes are considered to be inactive. This includes
     /// processes in the `Fault` state and processes which the kernel is not
     /// scheduling for any reason.
-    pub fn number_inactive_processes(
-        &self,
-        _capability: &dyn ProcessManagementCapability,
-    ) -> usize {
+    pub fn number_inactive_processes(&self, _capability: &ProcessManagementCapability) -> usize {
         let count: Cell<usize> = Cell::new(0);
         self.kernel
             .process_each(|process| match process.get_state() {
@@ -75,7 +72,7 @@ impl KernelInfo {
     pub fn process_name(
         &self,
         app: AppId,
-        _capability: &dyn ProcessManagementCapability,
+        _capability: &ProcessManagementCapability,
     ) -> &'static str {
         self.kernel
             .process_map_or("unknown", app.idx(), |process| process.get_process_name())
@@ -85,7 +82,7 @@ impl KernelInfo {
     pub fn number_app_syscalls(
         &self,
         app: AppId,
-        _capability: &dyn ProcessManagementCapability,
+        _capability: &ProcessManagementCapability,
     ) -> usize {
         self.kernel
             .process_map_or(0, app.idx(), |process| process.debug_syscall_count())
@@ -97,7 +94,7 @@ impl KernelInfo {
     pub fn number_app_dropped_callbacks(
         &self,
         app: AppId,
-        _capability: &dyn ProcessManagementCapability,
+        _capability: &ProcessManagementCapability,
     ) -> usize {
         self.kernel.process_map_or(0, app.idx(), |process| {
             process.debug_dropped_callback_count()
@@ -108,7 +105,7 @@ impl KernelInfo {
     pub fn number_app_restarts(
         &self,
         app: AppId,
-        _capability: &dyn ProcessManagementCapability,
+        _capability: &ProcessManagementCapability,
     ) -> usize {
         self.kernel
             .process_map_or(0, app.idx(), |process| process.debug_restart_count())
@@ -118,7 +115,7 @@ impl KernelInfo {
     pub fn number_app_timeslice_expirations(
         &self,
         app: AppId,
-        _capability: &dyn ProcessManagementCapability,
+        _capability: &ProcessManagementCapability,
     ) -> usize {
         self.kernel.process_map_or(0, app.idx(), |process| {
             process.debug_timeslice_expiration_count()
@@ -127,7 +124,7 @@ impl KernelInfo {
 
     /// Returns the total number of times all processes have exceeded
     /// their timeslices.
-    pub fn timeslice_expirations(&self, _capability: &dyn ProcessManagementCapability) -> usize {
+    pub fn timeslice_expirations(&self, _capability: &ProcessManagementCapability) -> usize {
         let count: Cell<usize> = Cell::new(0);
         self.kernel.process_each(|proc| {
             count.add(proc.debug_timeslice_expiration_count());

--- a/kernel/src/ipc.rs
+++ b/kernel/src/ipc.rs
@@ -36,7 +36,7 @@ pub struct IPC {
 }
 
 impl IPC {
-    pub fn new(kernel: &'static Kernel, capability: &dyn MemoryAllocationCapability) -> IPC {
+    pub fn new(kernel: &'static Kernel, capability: &MemoryAllocationCapability) -> IPC {
         IPC {
             data: kernel.create_grant(capability),
         }

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -35,7 +35,7 @@ pub fn load_processes<C: Chip>(
     app_memory: &mut [u8],
     procs: &'static mut [Option<&'static dyn ProcessType>],
     fault_response: FaultResponse,
-    _capability: &dyn ProcessManagementCapability,
+    _capability: &ProcessManagementCapability,
 ) {
     let mut apps_in_flash_ptr = start_of_flash;
     let mut app_memory_ptr = app_memory.as_mut_ptr();

--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -103,7 +103,7 @@ impl Kernel {
     /// requires a `ProcessManagementCapability` to use.
     pub fn process_each_capability<F>(
         &'static self,
-        _capability: &dyn capabilities::ProcessManagementCapability,
+        _capability: &capabilities::ProcessManagementCapability,
         closure: F,
     ) where
         F: Fn(usize, &dyn process::ProcessType),
@@ -158,7 +158,7 @@ impl Kernel {
     /// `MemoryAllocationCapability` capability.
     pub fn create_grant<T: Default>(
         &'static self,
-        _capability: &dyn capabilities::MemoryAllocationCapability,
+        _capability: &capabilities::MemoryAllocationCapability,
     ) -> Grant<T> {
         if self.grants_finalized.get() {
             panic!("Grants finalized. Cannot create a new grant.");
@@ -192,7 +192,7 @@ impl Kernel {
     /// function. This restricts general capsules from being able to call this
     /// function, since capsules should not be able to arbitrarily restart all
     /// apps.
-    pub fn hardfault_all_apps<C: capabilities::ProcessManagementCapability>(&self, _c: &C) {
+    pub fn hardfault_all_apps(&self, _c: &capabilities::ProcessManagementCapability) {
         for p in self.processes.iter() {
             p.map(|process| {
                 process.set_fault_state();
@@ -206,7 +206,7 @@ impl Kernel {
         platform: &P,
         chip: &C,
         ipc: Option<&ipc::IPC>,
-        _capability: &dyn capabilities::MainLoopCapability,
+        _capability: &capabilities::MainLoopCapability,
     ) {
         loop {
             unsafe {


### PR DESCRIPTION
### Pull Request Overview

This pull request changes the capabilities to use simple unforgeable types that only the `kernel` crate can construct safely but that do provide unsafe public constructors to be used by trusted code.

This seems to be a reasonable simplification compared to unsafe traits as a single object possessing multiple capabilities seems to be unused. It also removes the issue of the `create_capabilities!` macro being callable from `#![forbid(unsafe_code)]` crates as this constellation does not prevent `unsafe` blocks inside the macros. 

### TODO

This pull request is very much work in progress as it is meant to solicit feedback on the chosen design and I currently only adjusted the code for the `arty-e21` board and did not yet update any code comments or design documents.

### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
