### PR TITLE
boards/Makefile.common: Minor cleanup

### DIFF
--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -153,9 +153,6 @@ doc: | target
 .PHONY: lst
 lst: target/$(TARGET)/release/$(PLATFORM).lst
 
-.PHONY: release
-release: target/$(TARGET)/release/$(PLATFORM).bin
-
 # Helper rule for showing the TARGET used by this board. Useful when building
 # the documentation for all boards.
 .PHONY: show-target


### PR DESCRIPTION
- Remove extra `:` from `clean:` target

- Remove extra `release:` target as it seems to be declared twice
