### PR TITLE
register_structs!: Fix breakage of custom_test_frameworks

### DIFF
--- a/libraries/tock-register-interface/CHANGELOG.md
+++ b/libraries/tock-register-interface/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master
 
+ - #1489
+   - Make `register_structs!` unit test generation opt-out, so that
+     `custom-test-frameworks` environments can disable them.
+
  - #1481
    - Add `#[derive(Copy, Clone)]` to InMemoryRegister.
 

--- a/libraries/tock-register-interface/Cargo.toml
+++ b/libraries/tock-register-interface/Cargo.toml
@@ -13,3 +13,6 @@ edition = "2018"
 
 [badges]
 travis-ci = { repository = "tock/tock", branch = "master" }
+
+[features]
+no_std_unit_tests = []

--- a/libraries/tock-register-interface/README.md
+++ b/libraries/tock-register-interface/README.md
@@ -58,9 +58,7 @@ register_structs! {
 }
 ```
 
-This generates a C-style struct of the following form. Unit tests are also
-generated to make sure that the offsets and padding are consistent with the
-actual fields in the struct, and that alignment is correct.
+This generates a C-style struct of the following form.
 
 ```rust
 #[repr(C)]
@@ -89,6 +87,21 @@ struct Registers {
 
     // Etc.
 }
+```
+
+By default, `std` unit tests for the struct are generated as well (that is,
+tests attributed with `#[test]`). The unit tests make sure that the offsets and
+padding are consistent with the actual fields in the struct, and that alignment
+is correct.
+
+Since those tests would break compilation in `custom-test-frameworks`
+environments, it is possible to opt out of the test generation. To do so, add
+the following cargo feature:
+
+```toml
+[dependencies.tock-registers]
+version = "0.4.x"
+features = ["no_std_unit_tests"]
 ```
 
 WARNING: For now, the **unit tests checking offsets and alignments are not yet

--- a/libraries/tock-register-interface/src/macros.rs
+++ b/libraries/tock-register-interface/src/macros.rs
@@ -325,6 +325,7 @@ macro_rules! test_fields {
     };
 }
 
+#[cfg(not(feature = "no_std_unit_tests"))]
 #[macro_export]
 macro_rules! register_structs {
     {
@@ -350,5 +351,20 @@ macro_rules! register_structs {
             }
         )*
         }
+    };
+}
+
+#[cfg(feature = "no_std_unit_tests")]
+#[macro_export]
+macro_rules! register_structs {
+    {
+        $(
+            $(#[$attr:meta])*
+            $vis_struct:vis $name:ident {
+                $( $fields:tt )*
+            }
+        ),*
+    } => {
+        $( $crate::register_fields!(@root $(#[$attr])* $vis_struct $name { $($fields)* } ); )*
     };
 }


### PR DESCRIPTION
The current version of the `register_structs!` macro is not usable in `no_std`
libraries or binaries that implement `#![feature(custom_test_frameworks)]`.

Current `register_structs!` definitions will break the test execution because
they emit unit tests with the `#[test]` attribute macro, which depends on the
`std` test crate which isn't there and can't be used in `no_std`:

```
error[E0463]: can't find crate for `test`
   | 
  ::: <::core::macros::builtin::test macros>:1:1
   |
1  |    ($ item : item) => { }
   |    ---------------------- in this expansion of `#[test]`
  --> <::tock_registers::macros::register_structs macros>:11:49
   |
1  |  / { $ ($ (# [$ attr : meta]) * $ name : ident { $ ($ fields : tt) * }), * } =>
2  |  | {
3  |  |     $
4  |  |     ($ crate :: register_fields !
...   |
11 |  |              use super :: super :: * ; # [test] fn test_offsets ()
   |  |________________________________________--------_^
   | ||                                        |
   | ||                                        in this macro invocation
12 | ||              { $ crate :: test_fields ! (@ root $ name $ ($ fields) *) }
   | ||________________________________________________________________________^ can't find crate
13 |  |          }) *
14 |  |     }
15 |  | } ;
   |  |___- in this expansion of `register_structs!`
```

More literature at: https://os.phil-opp.com/testing

Fix this by making the `std` unit tests opt-in through a feature. I went for opt-in because tock-registers is `no_std` by nature.

CC @ppannuto @gendx 