### PR TITLE
Add support for the nrf52840_dongle board.

### DIFF
--- a/boards/nordic/nrf52840_dongle/Cargo.toml
+++ b/boards/nordic/nrf52840_dongle/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "nrf52840_dongle"
+version = "0.1.0"
+authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+build = "build.rs"
+edition = "2018"
+
+[profile.dev]
+panic = "abort"
+lto = false
+opt-level = "z"
+debug = true
+
+[profile.release]
+panic = "abort"
+lto = true
+opt-level = "z"
+debug = true
+
+[dependencies]
+cortexm4 = { path = "../../../arch/cortex-m4" }
+capsules = { path = "../../../capsules" }
+kernel = { path = "../../../kernel" }
+nrf52840 = { path = "../../../chips/nrf52840" }
+nrf52dk_base = { path = "../nrf52dk_base" }

--- a/boards/nordic/nrf52840_dongle/Makefile
+++ b/boards/nordic/nrf52840_dongle/Makefile
@@ -1,0 +1,29 @@
+# Makefile for building the tock kernel for the nRF development kit
+
+TOCK_ARCH=cortex-m4
+TARGET=thumbv7em-none-eabi
+PLATFORM=nrf52840_dongle
+
+include ../../Makefile.common
+
+TOCKLOADER=tockloader
+
+# Where in the nrf52 flash to load the kernel with `tockloader`
+KERNEL_ADDRESS=0x00000
+
+# Upload programs over uart with tockloader
+ifdef PORT
+  TOCKLOADER_GENERAL_FLAGS += --port $(PORT)
+endif
+
+TOCKLOADER_JTAG_FLAGS = --jlink --board nrf52dk
+
+# Upload the kernel over JTAG
+.PHONY: flash
+flash: target/$(TARGET)/release/$(PLATFORM).bin
+	$(TOCKLOADER) $(TOCKLOADER_GENERAL_FLAGS) flash --address $(KERNEL_ADDRESS) $(TOCKLOADER_JTAG_FLAGS) $<
+
+# Upload the kernel over serial/bootloader
+.PHONY: program
+program: target/$(TARGET)/release/$(PLATFORM).hex
+	$(error Cannot program nRF52 Dongle over USB. Use \`make flash\` and JTAG)

--- a/boards/nordic/nrf52840_dongle/README.md
+++ b/boards/nordic/nrf52840_dongle/README.md
@@ -1,0 +1,32 @@
+Platform-Specific Instructions: nRF52840-DK
+===================================
+
+The [nRF52840 Dongle](https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF52840-DK)
+is a platform based around the nRF52840, an SoC with an ARM Cortex-M4 and a BLE radio.
+The kit is uses a USB key form factor and includes 1 button, 1 red LED and 1 RGB LED.
+
+## Getting Started
+
+First, follow the [Tock Getting Started guide](../../../doc/Getting_Started.md)
+
+JTAG is the preferred method to program. The development kit has the JTAG pins exposed either
+through the half-moons pads or, below the PCB, on a Tag-Connect TC2050 connector footprint.
+You need to [install JTAG software](../../../doc/Getting_Started.md#optional-requirements).
+
+## Programming the kernel
+Once you have all software installed, you should be able to simply run
+make flash in this directory to install a fresh kernel.
+
+## Programming user-level applications
+You can program an application via JTAG using `tockloader`:
+
+    ```bash
+    $ cd libtock-c/examples/<app>
+    $ make
+    $ tockloader install --jlink --board nrf52dk
+    ```
+
+## Debugging
+
+See the [nrf52dk README](../nrf52dk/README.md) for information about debugging
+the nRF52840 Dongle.

--- a/boards/nordic/nrf52840_dongle/README.md
+++ b/boards/nordic/nrf52840_dongle/README.md
@@ -1,7 +1,7 @@
-Platform-Specific Instructions: nRF52840-DK
+Platform-Specific Instructions: nRF52840-Dongle
 ===================================
 
-The [nRF52840 Dongle](https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF52840-DK)
+The [nRF52840 Dongle](https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF52840-Dongle)
 is a platform based around the nRF52840, an SoC with an ARM Cortex-M4 and a BLE radio.
 The kit is uses a USB key form factor and includes 1 button, 1 red LED and 1 RGB LED.
 
@@ -20,7 +20,7 @@ make flash in this directory to install a fresh kernel.
 ## Programming user-level applications
 You can program an application via JTAG using `tockloader`:
 
-    ```bash
+    ```shell
     $ cd libtock-c/examples/<app>
     $ make
     $ tockloader install --jlink --board nrf52dk

--- a/boards/nordic/nrf52840_dongle/README.md
+++ b/boards/nordic/nrf52840_dongle/README.md
@@ -7,7 +7,14 @@ The kit is uses a USB key form factor and includes 1 button, 1 red LED and 1 RGB
 
 ## Getting Started
 
-First, follow the [Tock Getting Started guide](../../../doc/Getting_Started.md)
+To program the nRF52840 Dongle with Tock, you will need a JLink JTAG device and the
+appropriate cables. An example setup is:
+
+- [JLink JTAG Device](https://www.digikey.com/product-detail/en/segger-microcontroller-systems/8.08.90-J-LINK-EDU/899-1008-ND/2263130)
+- [ARM to TagConnect Adapter](https://www.digikey.com/product-detail/en/tag-connect-llc/TC2050-ARM2010/TC2050-ARM2010-ND/3528170)
+- [10pin TagConnect Cable](https://www.digikey.com/product-detail/en/tag-connect-llc/TC2050-IDC-NL/TC2050-IDC-NL-ND/2605367)
+
+Then, follow the [Tock Getting Started guide](../../../doc/Getting_Started.md)
 
 JTAG is the preferred method to program. The development kit has the JTAG pins exposed either
 through the half-moons pads or, below the PCB, on a Tag-Connect TC2050 connector footprint.

--- a/boards/nordic/nrf52840_dongle/README.md
+++ b/boards/nordic/nrf52840_dongle/README.md
@@ -20,11 +20,11 @@ make flash in this directory to install a fresh kernel.
 ## Programming user-level applications
 You can program an application via JTAG using `tockloader`:
 
-    ```shell
-    $ cd libtock-c/examples/<app>
-    $ make
-    $ tockloader install --jlink --board nrf52dk
-    ```
+```shell
+$ cd libtock-c/examples/<app>
+$ make
+$ tockloader install --jlink --board nrf52dk
+```
 
 ## Debugging
 

--- a/boards/nordic/nrf52840_dongle/build.rs
+++ b/boards/nordic/nrf52840_dongle/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    println!("cargo:rerun-if-changed=layout.ld");
+    println!("cargo:rerun-if-changed=../../kernel_layout.ld");
+}

--- a/boards/nordic/nrf52840_dongle/jtag/gdbinit_pca10040.jlink
+++ b/boards/nordic/nrf52840_dongle/jtag/gdbinit_pca10040.jlink
@@ -1,0 +1,25 @@
+#
+#
+#
+# J-LINK GDB SERVER initialization
+#
+# This connects to a GDB Server listening
+# for commands on localhost at tcp port 2331
+target remote localhost:2331
+monitor speed 30
+file ../target/thumbv7em-none-eabi/release/nrf52840_dongle
+monitor reset
+#
+# CPU core initialization (to be done by user)
+#
+# Set the processor mode
+# monitor reg cpsr = 0xd3
+# Set auto JTAG speed
+monitor speed auto
+# Setup GDB FOR FASTER DOWNLOADS
+set remote memory-write-packet-size 1024
+set remote memory-write-packet-size fixed
+# tui enable
+# layout split
+# layout service_pending_interrupts
+b reset_handler

--- a/boards/nordic/nrf52840_dongle/jtag/jdbserver_pca10040.sh
+++ b/boards/nordic/nrf52840_dongle/jtag/jdbserver_pca10040.sh
@@ -1,0 +1,1 @@
+JLinkGDBServer -device nRF52840_xxAA -speed 1200 -if swd -AutoConnect 1 -port 2331

--- a/boards/nordic/nrf52840_dongle/layout.ld
+++ b/boards/nordic/nrf52840_dongle/layout.ld
@@ -1,0 +1,10 @@
+MEMORY
+{
+  rom (rx)  : ORIGIN = 0x00000000, LENGTH = 128K
+  prog (rx) : ORIGIN = 0x00030000, LENGTH = 832K
+  ram (rwx) : ORIGIN = 0x20000000, LENGTH = 256K
+}
+
+MPU_MIN_ALIGN = 8K;
+
+INCLUDE ../../kernel_layout.ld

--- a/boards/nordic/nrf52840_dongle/src/io.rs
+++ b/boards/nordic/nrf52840_dongle/src/io.rs
@@ -1,0 +1,49 @@
+use core::fmt::Write;
+use core::panic::PanicInfo;
+use cortexm4;
+use kernel::debug;
+use kernel::hil::led;
+use kernel::hil::uart::{self, Configure};
+
+use crate::PROCESSES;
+
+struct Writer {
+    initialized: bool,
+}
+
+static mut WRITER: Writer = Writer { initialized: false };
+
+impl Write for Writer {
+    fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
+        let uart = unsafe { &mut nrf52840::uart::UARTE0 };
+        if !self.initialized {
+            self.initialized = true;
+            uart.configure(uart::Parameters {
+                baud_rate: 115200,
+                stop_bits: uart::StopBits::One,
+                parity: uart::Parity::None,
+                hw_flow_control: false,
+                width: uart::Width::Eight,
+            });
+        }
+        for c in s.bytes() {
+            unsafe {
+                uart.send_byte(c);
+            }
+            while !uart.tx_ready() {}
+        }
+        Ok(())
+    }
+}
+
+#[cfg(not(test))]
+#[no_mangle]
+#[panic_handler]
+/// Panic handler
+pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
+    // The nRF52840 Dongle LEDs (see back of board)
+    const LED1_PIN: usize = nrf52840::gpio::Pin::P0_06 as usize;
+    let led = &mut led::LedLow::new(&mut nrf52840::gpio::PORT[LED1_PIN]);
+    let writer = &mut WRITER;
+    debug::panic(&mut [led], writer, pi, &cortexm4::support::nop, &PROCESSES)
+}

--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -302,5 +302,7 @@ pub unsafe fn reset_handler() {
         &mut APP_MEMORY,
         &mut PROCESSES,
         FAULT_RESPONSE,
+        nrf52840::uicr::Regulator0Output::V3_0,
+        false,
     );
 }

--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -1,0 +1,306 @@
+//! Tock kernel for the Nordic Semiconductor nRF52840 dongle.
+//!
+//! It is based on nRF52840 SoC (Cortex M4 core with a BLE transceiver) with
+//! many exported I/O and peripherals.
+
+#![no_std]
+#![no_main]
+#![deny(missing_docs)]
+
+#[allow(unused_imports)]
+use kernel::{debug, debug_gpio, debug_verbose, static_init};
+
+use nrf52840::gpio::Pin;
+use nrf52dk_base::{SpiPins, UartPins};
+
+// The nRF52840 Dongle LEDs
+const LED1_PIN: usize = Pin::P0_06 as usize;
+const LED2_R_PIN: usize = Pin::P0_08 as usize;
+const LED2_G_PIN: usize = Pin::P1_09 as usize;
+const LED2_B_PIN: usize = Pin::P0_12 as usize;
+
+// The nRF52840 Dongle button
+const BUTTON_PIN: usize = Pin::P1_06 as usize;
+const BUTTON_RST_PIN: usize = Pin::P0_18 as usize;
+
+const UART_RTS: usize = Pin::P0_13 as usize;
+const UART_TXD: usize = Pin::P0_15 as usize;
+const UART_CTS: usize = Pin::P0_17 as usize;
+const UART_RXD: usize = Pin::P0_20 as usize;
+
+const SPI_MOSI: usize = Pin::P1_01 as usize;
+const SPI_MISO: usize = Pin::P1_02 as usize;
+const SPI_CLK: usize = Pin::P1_04 as usize;
+
+/// UART Writer
+pub mod io;
+
+// State for loading and holding applications.
+// How should the kernel respond when a process faults.
+const FAULT_RESPONSE: kernel::procs::FaultResponse = kernel::procs::FaultResponse::Panic;
+
+// Number of concurrent processes this platform supports.
+const NUM_PROCS: usize = 8;
+
+// RAM to be shared by all application processes.
+#[link_section = ".app_memory"]
+static mut APP_MEMORY: [u8; 0x3C000] = [0; 0x3C000];
+
+static mut PROCESSES: [Option<&'static dyn kernel::procs::ProcessType>; NUM_PROCS] =
+    [None, None, None, None, None, None, None, None];
+
+/// Dummy buffer that causes the linker to reserve enough space for the stack.
+#[no_mangle]
+#[link_section = ".stack_buffer"]
+pub static mut STACK_MEMORY: [u8; 0x1000] = [0; 0x1000];
+
+/// Entry point in the vector table called on hard reset.
+#[no_mangle]
+pub unsafe fn reset_handler() {
+    // Loads relocations and clears BSS
+    nrf52840::init();
+
+    // GPIOs
+    let gpio_pins = static_init!(
+        [&'static dyn kernel::hil::gpio::InterruptValuePin; 24],
+        [
+            // Left side of the USB plug
+            static_init!(
+                kernel::hil::gpio::InterruptValueWrapper,
+                kernel::hil::gpio::InterruptValueWrapper::new(
+                    &nrf52840::gpio::PORT[Pin::P0_13 as usize]
+                )
+            )
+            .finalize(),
+            static_init!(
+                kernel::hil::gpio::InterruptValueWrapper,
+                kernel::hil::gpio::InterruptValueWrapper::new(
+                    &nrf52840::gpio::PORT[Pin::P0_15 as usize]
+                )
+            )
+            .finalize(),
+            static_init!(
+                kernel::hil::gpio::InterruptValueWrapper,
+                kernel::hil::gpio::InterruptValueWrapper::new(
+                    &nrf52840::gpio::PORT[Pin::P0_17 as usize]
+                )
+            )
+            .finalize(),
+            static_init!(
+                kernel::hil::gpio::InterruptValueWrapper,
+                kernel::hil::gpio::InterruptValueWrapper::new(
+                    &nrf52840::gpio::PORT[Pin::P0_20 as usize]
+                )
+            )
+            .finalize(),
+            static_init!(
+                kernel::hil::gpio::InterruptValueWrapper,
+                kernel::hil::gpio::InterruptValueWrapper::new(
+                    &nrf52840::gpio::PORT[Pin::P0_22 as usize]
+                )
+            )
+            .finalize(),
+            static_init!(
+                kernel::hil::gpio::InterruptValueWrapper,
+                kernel::hil::gpio::InterruptValueWrapper::new(
+                    &nrf52840::gpio::PORT[Pin::P0_24 as usize]
+                )
+            )
+            .finalize(),
+            static_init!(
+                kernel::hil::gpio::InterruptValueWrapper,
+                kernel::hil::gpio::InterruptValueWrapper::new(
+                    &nrf52840::gpio::PORT[Pin::P1_00 as usize]
+                )
+            )
+            .finalize(),
+            static_init!(
+                kernel::hil::gpio::InterruptValueWrapper,
+                kernel::hil::gpio::InterruptValueWrapper::new(
+                    &nrf52840::gpio::PORT[Pin::P0_09 as usize]
+                )
+            )
+            .finalize(),
+            static_init!(
+                kernel::hil::gpio::InterruptValueWrapper,
+                kernel::hil::gpio::InterruptValueWrapper::new(
+                    &nrf52840::gpio::PORT[Pin::P0_10 as usize]
+                )
+            )
+            .finalize(),
+            // Right side of the USB plug
+            static_init!(
+                kernel::hil::gpio::InterruptValueWrapper,
+                kernel::hil::gpio::InterruptValueWrapper::new(
+                    &nrf52840::gpio::PORT[Pin::P0_31 as usize]
+                )
+            )
+            .finalize(),
+            static_init!(
+                kernel::hil::gpio::InterruptValueWrapper,
+                kernel::hil::gpio::InterruptValueWrapper::new(
+                    &nrf52840::gpio::PORT[Pin::P0_29 as usize]
+                )
+            )
+            .finalize(),
+            static_init!(
+                kernel::hil::gpio::InterruptValueWrapper,
+                kernel::hil::gpio::InterruptValueWrapper::new(
+                    &nrf52840::gpio::PORT[Pin::P0_02 as usize]
+                )
+            )
+            .finalize(),
+            static_init!(
+                kernel::hil::gpio::InterruptValueWrapper,
+                kernel::hil::gpio::InterruptValueWrapper::new(
+                    &nrf52840::gpio::PORT[Pin::P1_15 as usize]
+                )
+            )
+            .finalize(),
+            static_init!(
+                kernel::hil::gpio::InterruptValueWrapper,
+                kernel::hil::gpio::InterruptValueWrapper::new(
+                    &nrf52840::gpio::PORT[Pin::P1_13 as usize]
+                )
+            )
+            .finalize(),
+            static_init!(
+                kernel::hil::gpio::InterruptValueWrapper,
+                kernel::hil::gpio::InterruptValueWrapper::new(
+                    &nrf52840::gpio::PORT[Pin::P1_10 as usize]
+                )
+            )
+            .finalize(),
+            // Below the PCB
+            static_init!(
+                kernel::hil::gpio::InterruptValueWrapper,
+                kernel::hil::gpio::InterruptValueWrapper::new(
+                    &nrf52840::gpio::PORT[Pin::P0_26 as usize]
+                )
+            )
+            .finalize(),
+            static_init!(
+                kernel::hil::gpio::InterruptValueWrapper,
+                kernel::hil::gpio::InterruptValueWrapper::new(
+                    &nrf52840::gpio::PORT[Pin::P0_04 as usize]
+                )
+            )
+            .finalize(),
+            static_init!(
+                kernel::hil::gpio::InterruptValueWrapper,
+                kernel::hil::gpio::InterruptValueWrapper::new(
+                    &nrf52840::gpio::PORT[Pin::P0_11 as usize]
+                )
+            )
+            .finalize(),
+            static_init!(
+                kernel::hil::gpio::InterruptValueWrapper,
+                kernel::hil::gpio::InterruptValueWrapper::new(
+                    &nrf52840::gpio::PORT[Pin::P0_14 as usize]
+                )
+            )
+            .finalize(),
+            static_init!(
+                kernel::hil::gpio::InterruptValueWrapper,
+                kernel::hil::gpio::InterruptValueWrapper::new(
+                    &nrf52840::gpio::PORT[Pin::P1_11 as usize]
+                )
+            )
+            .finalize(),
+            static_init!(
+                kernel::hil::gpio::InterruptValueWrapper,
+                kernel::hil::gpio::InterruptValueWrapper::new(
+                    &nrf52840::gpio::PORT[Pin::P1_07 as usize]
+                )
+            )
+            .finalize(),
+            static_init!(
+                kernel::hil::gpio::InterruptValueWrapper,
+                kernel::hil::gpio::InterruptValueWrapper::new(
+                    &nrf52840::gpio::PORT[Pin::P1_01 as usize]
+                )
+            )
+            .finalize(),
+            static_init!(
+                kernel::hil::gpio::InterruptValueWrapper,
+                kernel::hil::gpio::InterruptValueWrapper::new(
+                    &nrf52840::gpio::PORT[Pin::P1_04 as usize]
+                )
+            )
+            .finalize(),
+            static_init!(
+                kernel::hil::gpio::InterruptValueWrapper,
+                kernel::hil::gpio::InterruptValueWrapper::new(
+                    &nrf52840::gpio::PORT[Pin::P1_02 as usize]
+                )
+            )
+            .finalize(),
+        ]
+    );
+
+    // LEDs
+    let led_pins = static_init!(
+        [(
+            &'static dyn kernel::hil::gpio::Pin,
+            capsules::led::ActivationMode
+        ); 4],
+        [
+            (
+                &nrf52840::gpio::PORT[LED1_PIN],
+                capsules::led::ActivationMode::ActiveLow
+            ),
+            (
+                &nrf52840::gpio::PORT[LED2_R_PIN],
+                capsules::led::ActivationMode::ActiveLow
+            ),
+            (
+                &nrf52840::gpio::PORT[LED2_G_PIN],
+                capsules::led::ActivationMode::ActiveLow
+            ),
+            (
+                &nrf52840::gpio::PORT[LED2_B_PIN],
+                capsules::led::ActivationMode::ActiveLow
+            ),
+        ]
+    );
+
+    let button_pins = static_init!(
+        [(
+            &'static dyn kernel::hil::gpio::InterruptValuePin,
+            capsules::button::GpioMode
+        ); 1],
+        [(
+            static_init!(
+                kernel::hil::gpio::InterruptValueWrapper,
+                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[BUTTON_PIN])
+            )
+            .finalize(),
+            capsules::button::GpioMode::LowWhenPressed
+        ),]
+    );
+
+    for &(btn, _) in button_pins.iter() {
+        btn.set_floating_state(kernel::hil::gpio::FloatingState::PullUp);
+    }
+
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
+
+    nrf52dk_base::setup_board(
+        board_kernel,
+        BUTTON_RST_PIN,
+        &nrf52840::gpio::PORT,
+        gpio_pins,
+        LED2_R_PIN,
+        LED2_G_PIN,
+        LED2_B_PIN,
+        led_pins,
+        &UartPins::new(UART_RTS, UART_TXD, UART_CTS, UART_RXD),
+        &SpiPins::new(SPI_MOSI, SPI_MISO, SPI_CLK),
+        &None,
+        button_pins,
+        true,
+        &mut APP_MEMORY,
+        &mut PROCESSES,
+        FAULT_RESPONSE,
+    );
+}


### PR DESCRIPTION
### Pull Request Overview

This pull request adds support for the [nRF52840-Dongle](https://www.nordicsemi.com/Software-and-tools/Development-Kits/nRF52840-Dongle) board. It is similar to the nRF52840-DK, but with a different layout of GPIOs, and available LEDs/buttons.


### Testing Strategy

This pull request was tested by flashing Tock on such a dongle and manually testing simple apps.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

I added the relevant README. Is there anything else to update?

### Formatting

- [x] Ran `make formatall`.