### PR TITLE
Remove direct dependency on nrf5x from nrf52dk_base.

### DIFF
--- a/boards/nordic/nrf52dk_base/Cargo.toml
+++ b/boards/nordic/nrf52dk_base/Cargo.toml
@@ -10,4 +10,3 @@ cortexm4 = { path = "../../../arch/cortex-m4" }
 capsules = { path = "../../../capsules" }
 kernel = { path = "../../../kernel" }
 nrf52 = { path = "../../../chips/nrf52" }
-nrf5x = { path = "../../../chips/nrf5x" }

--- a/boards/nordic/nrf52dk_base/src/nrf52_components/ble.rs
+++ b/boards/nordic/nrf52dk_base/src/nrf52_components/ble.rs
@@ -11,7 +11,7 @@
 use capsules;
 use capsules::virtual_alarm::VirtualMuxAlarm;
 
-use nrf5x::rtc::Rtc;
+use nrf52::rtc::Rtc;
 
 use kernel::capabilities;
 use kernel::component::Component;
@@ -23,14 +23,14 @@ use kernel::{create_capability, static_init};
 pub struct BLEComponent {
     board_kernel: &'static kernel::Kernel,
     radio: &'static nrf52::ble_radio::Radio,
-    mux_alarm: &'static capsules::virtual_alarm::MuxAlarm<'static, nrf5x::rtc::Rtc<'static>>,
+    mux_alarm: &'static capsules::virtual_alarm::MuxAlarm<'static, nrf52::rtc::Rtc<'static>>,
 }
 
 impl BLEComponent {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
         radio: &'static nrf52::ble_radio::Radio,
-        mux_alarm: &'static capsules::virtual_alarm::MuxAlarm<'static, nrf5x::rtc::Rtc>,
+        mux_alarm: &'static capsules::virtual_alarm::MuxAlarm<'static, nrf52::rtc::Rtc>,
     ) -> BLEComponent {
         BLEComponent {
             board_kernel: board_kernel,
@@ -52,7 +52,7 @@ impl Component for BLEComponent {
         let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
 
         let ble_radio_virtual_alarm = static_init!(
-            capsules::virtual_alarm::VirtualMuxAlarm<'static, nrf5x::rtc::Rtc>,
+            capsules::virtual_alarm::VirtualMuxAlarm<'static, nrf52::rtc::Rtc>,
             capsules::virtual_alarm::VirtualMuxAlarm::new(self.mux_alarm)
         );
 

--- a/boards/nordic/nrf52dk_base/src/nrf52_components/ieee802154.rs
+++ b/boards/nordic/nrf52dk_base/src/nrf52_components/ieee802154.rs
@@ -69,8 +69,8 @@ impl Component for Ieee802154Component {
         let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
 
         let aes_ccm = static_init!(
-            capsules::aes_ccm::AES128CCM<'static, nrf5x::aes::AesECB<'static>>,
-            capsules::aes_ccm::AES128CCM::new(&nrf5x::aes::AESECB, &mut CRYPT_BUF)
+            capsules::aes_ccm::AES128CCM<'static, nrf52::aes::AesECB<'static>>,
+            capsules::aes_ccm::AES128CCM::new(&nrf52::aes::AESECB, &mut CRYPT_BUF)
         );
 
         // Keeps the radio on permanently; pass-through layer
@@ -85,7 +85,7 @@ impl Component for Ieee802154Component {
             capsules::ieee802154::framer::Framer<
                 'static,
                 AwakeMac<'static, nrf52::ieee802154_radio::Radio>,
-                capsules::aes_ccm::AES128CCM<'static, nrf5x::aes::AesECB<'static>>,
+                capsules::aes_ccm::AES128CCM<'static, nrf52::aes::AesECB<'static>>,
             >,
             capsules::ieee802154::framer::Framer::new(awake_mac, aes_ccm)
         );


### PR DESCRIPTION
### Pull Request Overview

This pull request removes the direct dependency on the nrf5x chip from nrf52dk_base. It now depends on nrf52 only.

This was forgotten in the dependency refactoring of https://github.com/tock/tock/pull/1422


### Testing Strategy

This pull request was tested by flashing Tock on a nRF52840-DK board.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.