### PR TITLE
Fix memory overuse in HiFive1 board

### DIFF
--- a/boards/components/src/lib.rs
+++ b/boards/components/src/lib.rs
@@ -6,6 +6,7 @@ pub mod console;
 pub mod crc;
 pub mod debug_writer;
 pub mod isl29035;
+pub mod lldb;
 pub mod nrf51822;
 pub mod process_console;
 pub mod rng;

--- a/boards/components/src/lldb.rs
+++ b/boards/components/src/lldb.rs
@@ -1,0 +1,69 @@
+//! Component for LowLevelDebug
+//!
+//! This provides one Component, LowLevelDebugComponent, which provides the LowLevelDebug
+//! driver---a driver that can prints messages to the serial port relying on only `command`s from
+//! userspace. It is particularly useful for board or runtime bringup when more complex operations
+//! (allow and subscribe) may still not be working.
+//!
+//! Usage
+//! -----
+//! ```rust
+//! let lldb = LowLevelDebugComponent::new(board_kernel, uart_mux).finalize(());
+//! ```
+
+// Author: Amit Levy <amit@amitlevy.com>
+// Last modified: 12/04/2019
+
+#![allow(dead_code)] // Components are intended to be conditionally included
+
+use capsules::low_level_debug;
+use capsules::virtual_uart::{MuxUart, UartDevice};
+use kernel::capabilities;
+use kernel::component::Component;
+use kernel::create_capability;
+use kernel::hil;
+use kernel::static_init;
+
+pub struct LowLevelDebugComponent {
+    board_kernel: &'static kernel::Kernel,
+    uart_mux: &'static MuxUart<'static>,
+}
+
+impl LowLevelDebugComponent {
+    pub fn new(
+        board_kernel: &'static kernel::Kernel,
+        uart_mux: &'static MuxUart,
+    ) -> LowLevelDebugComponent {
+        LowLevelDebugComponent {
+            board_kernel: board_kernel,
+            uart_mux: uart_mux,
+        }
+    }
+}
+
+impl Component for LowLevelDebugComponent {
+    type StaticInput = ();
+    type Output = &'static low_level_debug::LowLevelDebug<'static, UartDevice<'static>>;
+
+    unsafe fn finalize(&mut self, _s: Self::StaticInput) -> Self::Output {
+        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
+
+        // Create virtual device for console.
+        let lldb_uart = static_init!(UartDevice, UartDevice::new(self.uart_mux, true));
+        lldb_uart.setup();
+
+        static mut MYBUF: [u8; low_level_debug::BUF_LEN] = [0; low_level_debug::BUF_LEN];
+
+        let lldb = static_init!(
+            low_level_debug::LowLevelDebug<'static, UartDevice<'static>>,
+            low_level_debug::LowLevelDebug::new(
+                &mut MYBUF,
+                lldb_uart,
+                self.board_kernel.create_grant(&grant_cap)
+            )
+        );
+        hil::uart::Transmit::set_transmit_client(lldb_uart, lldb);
+
+        lldb
+    }
+}

--- a/boards/hifive1/layout.ld
+++ b/boards/hifive1/layout.ld
@@ -8,7 +8,7 @@ MEMORY
 {
   rom (rx)  : ORIGIN = 0x20400000, LENGTH = 0x30000
   prog (rx) : ORIGIN = 0x20430000, LENGTH = 512M-0x430000
-  ram (rwx) : ORIGIN = 0x80000000, LENGTH = 1M
+  ram (rwx) : ORIGIN = 0x80000000, LENGTH = 16K
 }
 
 MPU_MIN_ALIGN = 1K;

--- a/boards/hifive1/src/main.rs
+++ b/boards/hifive1/src/main.rs
@@ -33,7 +33,7 @@ const FAULT_RESPONSE: kernel::procs::FaultResponse = kernel::procs::FaultRespons
 
 // RAM to be shared by all application processes.
 #[link_section = ".app_memory"]
-static mut APP_MEMORY: [u8; 8192] = [0; 8192];
+static mut APP_MEMORY: [u8; 5 * 1024] = [0; 5 * 1024];
 
 /// Dummy buffer that causes the linker to reserve enough space for the stack.
 #[no_mangle]

--- a/boards/hifive1/src/main.rs
+++ b/boards/hifive1/src/main.rs
@@ -44,6 +44,10 @@ pub static mut STACK_MEMORY: [u8; 0x1000] = [0; 0x1000];
 /// capsules for this platform. We've included an alarm and console.
 struct HiFive1 {
     console: &'static capsules::console::Console<'static>,
+    lldb: &'static capsules::low_level_debug::LowLevelDebug<
+        'static,
+        capsules::virtual_uart::UartDevice<'static>,
+    >,
     alarm: &'static capsules::alarm::AlarmDriver<
         'static,
         VirtualMuxAlarm<'static, rv32i::machine_timer::MachineTimer<'static>>,
@@ -59,6 +63,7 @@ impl Platform for HiFive1 {
         match driver_num {
             capsules::console::DRIVER_NUM => f(Some(self.console)),
             capsules::alarm::DRIVER_NUM => f(Some(self.alarm)),
+            capsules::low_level_debug::DRIVER_NUM => f(Some(self.lldb)),
             _ => f(None),
         }
     }
@@ -166,6 +171,8 @@ pub unsafe fn reset_handler() {
     // Create the debugger object that handles calls to `debug!()`.
     components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
 
+    let lldb = components::lldb::LowLevelDebugComponent::new(board_kernel, uart_mux).finalize(());
+
     debug!("HiFive1 initialization complete. Entering main loop");
 
     extern "C" {
@@ -178,6 +185,7 @@ pub unsafe fn reset_handler() {
     let hifive1 = HiFive1 {
         console: console,
         alarm: alarm,
+        lldb: lldb,
     };
 
     kernel::procs::load_processes(

--- a/kernel/src/debug.rs
+++ b/kernel/src/debug.rs
@@ -219,6 +219,11 @@ pub struct DebugWriter {
 /// needed so the debug!() macros have a reference to the object to use.
 static mut DEBUG_WRITER: Option<&'static mut DebugWriterWrapper> = None;
 
+// The sum of the OUTPUT_BUF and INTERNAL_BUF is set to 1024 bytes in order to avoid excessive
+// padding between kernel memory and application memory (which often needs to be aligned to at
+// least a 1kB boundary). This is not _semantically_ critical, but helps keep buffers on 1kB
+// boundaries in some cases. Of course, these definitions are only advisory, and individual boards
+// can choose to pass in their own buffers with different lengths.
 pub static mut OUTPUT_BUF: [u8; 64] = [0; 64];
 pub static mut INTERNAL_BUF: [u8; 1024 - 64] = [0; 1024 - 64];
 

--- a/kernel/src/debug.rs
+++ b/kernel/src/debug.rs
@@ -220,7 +220,7 @@ pub struct DebugWriter {
 static mut DEBUG_WRITER: Option<&'static mut DebugWriterWrapper> = None;
 
 pub static mut OUTPUT_BUF: [u8; 64] = [0; 64];
-pub static mut INTERNAL_BUF: [u8; 1024] = [0; 1024];
+pub static mut INTERNAL_BUF: [u8; 1024 - 64] = [0; 1024 - 64];
 
 pub unsafe fn get_debug_writer() -> &'static mut DebugWriterWrapper {
     match ptr::read(&DEBUG_WRITER) {


### PR DESCRIPTION
### Pull Request Overview

This is the first of two PRs (the second will be in `libtock-rs`) to fix issues that have resulting in running user apps on HiFive1 being precarious.

The fixes in this PR are actually relatively minor:

  * The sifive_e chip only has 16kB of RAM, change the linker script to reflect that so we get proper memory over use errors when linking with too much memory
  * Reduce the amount of memory allocated to APP_MEMORY on the HiFive1 board to 5kB so it actually fits within the 16kB total
  * Reduce the `debug!` buffer by 64 bytes to avoid extraneous padding before APP_MEMORY (this results in a _total_ use of 1kB in the debug driver between the transmission buffer and the holding buffer).
  * Add the LowLevelDebug driver to the HiFive1 board---this was just useful when debugging and it's a small change so I'm piggy-backing.

### Testing Strategy

Testing this isn't that meaningful without changes to libtock-rs or libtock-c. I've run it a bunch, and it helps fix actual issues, but I don't have a regression that's fixed with only this PR (since fixes toto libtock-rs are also required).

If anyone has suggestions for things to test or if any of the changes raise alarm bells, please suggest!

### Documentation Updated

- [X] ~~Updated the relevant files in `/docs`, or no updates are required.~~

### Formatting

- [X] Ran `make formatall`.
