### PR TITLE
Mechanically align static_init_half with updated static_init macro.

### DIFF
--- a/boards/components/src/crc.rs
+++ b/boards/components/src/crc.rs
@@ -15,20 +15,22 @@
 
 #![allow(dead_code)] // Components are intended to be conditionally included
 
+use core::mem::MaybeUninit;
+
 use capsules::crc;
 use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
 use kernel::hil;
-
-use crate::static_init_half;
+use kernel::static_init_half;
 
 // Setup static space for the objects.
 #[macro_export]
 macro_rules! crc_component_helper {
     ($C:ty) => {{
         use capsules::crc;
-        static mut BUF: Option<crc::Crc<'static, $C>> = None;
+        use core::mem::MaybeUninit;
+        static mut BUF: MaybeUninit<crc::Crc<'static, $C>> = MaybeUninit::uninit();
         &mut BUF
     };};
 }
@@ -48,7 +50,7 @@ impl<C: 'static + hil::crc::CRC> CrcComponent<C> {
 }
 
 impl<C: 'static + hil::crc::CRC> Component for CrcComponent<C> {
-    type StaticInput = &'static mut Option<crc::Crc<'static, C>>;
+    type StaticInput = &'static mut MaybeUninit<crc::Crc<'static, C>>;
     type Output = &'static crc::Crc<'static, C>;
 
     unsafe fn finalize(&mut self, static_buffer: Self::StaticInput) -> Self::Output {

--- a/boards/components/src/isl29035.rs
+++ b/boards/components/src/isl29035.rs
@@ -23,6 +23,8 @@
 
 #![allow(dead_code)] // Components are intended to be conditionally included
 
+use core::mem::MaybeUninit;
+
 use capsules::ambient_light::AmbientLight;
 use capsules::isl29035::Isl29035;
 use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
@@ -33,17 +35,17 @@ use kernel::create_capability;
 use kernel::hil;
 use kernel::hil::time;
 use kernel::hil::time::Alarm;
-use kernel::static_init;
-
-use crate::static_init_half;
+use kernel::{static_init, static_init_half};
 
 // Setup static space for the objects.
 #[macro_export]
 macro_rules! isl29035_component_helper {
     ($A:ty) => {{
         use capsules::isl29035::Isl29035;
-        static mut BUF1: Option<VirtualMuxAlarm<'static, $A>> = None;
-        static mut BUF2: Option<Isl29035<'static, VirtualMuxAlarm<'static, $A>>> = None;
+        use core::mem::MaybeUninit;
+        static mut BUF1: MaybeUninit<VirtualMuxAlarm<'static, $A>> = MaybeUninit::uninit();
+        static mut BUF2: MaybeUninit<Isl29035<'static, VirtualMuxAlarm<'static, $A>>> =
+            MaybeUninit::uninit();
         (&mut BUF1, &mut BUF2)
     };};
 }
@@ -72,8 +74,8 @@ static mut I2C_BUF: [u8; 3] = [0; 3];
 
 impl<A: 'static + time::Alarm<'static>> Component for Isl29035Component<A> {
     type StaticInput = (
-        &'static mut Option<VirtualMuxAlarm<'static, A>>,
-        &'static mut Option<Isl29035<'static, VirtualMuxAlarm<'static, A>>>,
+        &'static mut MaybeUninit<VirtualMuxAlarm<'static, A>>,
+        &'static mut MaybeUninit<Isl29035<'static, VirtualMuxAlarm<'static, A>>>,
     );
 
     type Output = &'static Isl29035<'static, VirtualMuxAlarm<'static, A>>;
@@ -118,8 +120,8 @@ impl<A: 'static + time::Alarm<'static>> AmbientLightComponent<A> {
 
 impl<A: 'static + time::Alarm<'static>> Component for AmbientLightComponent<A> {
     type StaticInput = (
-        &'static mut Option<VirtualMuxAlarm<'static, A>>,
-        &'static mut Option<Isl29035<'static, VirtualMuxAlarm<'static, A>>>,
+        &'static mut MaybeUninit<VirtualMuxAlarm<'static, A>>,
+        &'static mut MaybeUninit<Isl29035<'static, VirtualMuxAlarm<'static, A>>>,
     );
     type Output = &'static AmbientLight<'static>;
 

--- a/boards/components/src/lib.rs
+++ b/boards/components/src/lib.rs
@@ -11,15 +11,3 @@ pub mod process_console;
 pub mod rng;
 pub mod si7021;
 pub mod spi;
-
-/// Same as `static_init!()` but without actually creating the static buffer.
-/// The static buffer must be passed in.
-#[macro_export]
-macro_rules! static_init_half {
-    ($B:expr, $T:ty, $e:expr) => {{
-        use core::{mem, ptr};
-        let tmp: &'static mut $T = mem::transmute($B);
-        ptr::write(tmp as *mut $T, $e);
-        tmp
-    };};
-}

--- a/boards/components/src/si7021.rs
+++ b/boards/components/src/si7021.rs
@@ -20,6 +20,8 @@
 
 #![allow(dead_code)] // Components are intended to be conditionally included
 
+use core::mem::MaybeUninit;
+
 use capsules::humidity::HumiditySensor;
 use capsules::si7021::SI7021;
 use capsules::temperature::TemperatureSensor;
@@ -30,17 +32,17 @@ use kernel::component::Component;
 use kernel::create_capability;
 use kernel::hil;
 use kernel::hil::time::{self, Alarm};
-use kernel::static_init;
-
-use crate::static_init_half;
+use kernel::{static_init, static_init_half};
 
 // Setup static space for the objects.
 #[macro_export]
 macro_rules! si7021_component_helper {
     ($A:ty) => {{
         use capsules::si7021::SI7021;
-        static mut BUF1: Option<VirtualMuxAlarm<'static, $A>> = None;
-        static mut BUF2: Option<SI7021<'static, VirtualMuxAlarm<'static, $A>>> = None;
+        use core::mem::MaybeUninit;
+        static mut BUF1: MaybeUninit<VirtualMuxAlarm<'static, $A>> = MaybeUninit::uninit();
+        static mut BUF2: MaybeUninit<SI7021<'static, VirtualMuxAlarm<'static, $A>>> =
+            MaybeUninit::uninit();
         (&mut BUF1, &mut BUF2)
     };};
 }
@@ -69,8 +71,8 @@ static mut I2C_BUF: [u8; 14] = [0; 14];
 
 impl<A: 'static + time::Alarm<'static>> Component for SI7021Component<A> {
     type StaticInput = (
-        &'static mut Option<VirtualMuxAlarm<'static, A>>,
-        &'static mut Option<SI7021<'static, VirtualMuxAlarm<'static, A>>>,
+        &'static mut MaybeUninit<VirtualMuxAlarm<'static, A>>,
+        &'static mut MaybeUninit<SI7021<'static, VirtualMuxAlarm<'static, A>>>,
     );
     type Output = &'static SI7021<'static, VirtualMuxAlarm<'static, A>>;
 


### PR DESCRIPTION
### Pull Request Overview

This pull request completes the work started in #1446 and mechanically aligns `static_init_half!` with the updated implementation of `static_init!`.


### Testing Strategy

This pull request was tested by building.

### Documentation Updated

- [x] No updates are required.

### Formatting

- [x] Ran `make formatall`.
