### PR TITLE
Use the gpio::Pin enum in nRF52-based boards instead of raw numbers.

### DIFF
--- a/boards/acd52832/src/io.rs
+++ b/boards/acd52832/src/io.rs
@@ -2,13 +2,14 @@ use core::panic::PanicInfo;
 
 use kernel::debug;
 use kernel::hil::led;
+use nrf52832::gpio::Pin;
 
 /// Panic.
 #[cfg(not(test))]
 #[no_mangle]
 #[panic_handler]
 pub unsafe extern "C" fn panic_fmt(_pi: &PanicInfo) -> ! {
-    const LED1_PIN: usize = 22;
+    const LED1_PIN: Pin = Pin::P0_22;
     let led = &mut led::LedLow::new(&mut nrf52832::gpio::PORT[LED1_PIN]);
     debug::panic_blink_forever(&mut [led])
 }

--- a/boards/acd52832/src/main.rs
+++ b/boards/acd52832/src/main.rs
@@ -118,16 +118,21 @@ pub unsafe fn reset_handler() {
 
     // GPIOs
     let gpio_pins = static_init!(
-        [&'static dyn kernel::hil::gpio::InterruptValuePin; 14],
+        [&'static dyn kernel::hil::gpio::InterruptValuePin; 7],
         [
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[Pin::P0_03])
+                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[Pin::P0_25])
             )
-            .finalize(), // Bottom right header on DK board
+            .finalize(),
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[Pin::P0_04])
+                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[Pin::P0_26])
+            )
+            .finalize(),
+            static_init!(
+                kernel::hil::gpio::InterruptValueWrapper,
+                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[Pin::P0_27])
             )
             .finalize(),
             static_init!(
@@ -147,47 +152,7 @@ pub unsafe fn reset_handler() {
             .finalize(),
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[Pin::P0_12])
-            )
-            .finalize(), // Top mid header on DK board
-            static_init!(
-                kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[Pin::P0_11])
-            )
-            .finalize(),
-            static_init!(
-                kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[Pin::P0_27])
-            )
-            .finalize(), // Top left header on DK board
-            static_init!(
-                kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[Pin::P0_26])
-            )
-            .finalize(),
-            static_init!(
-                kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[Pin::P0_02])
-            )
-            .finalize(),
-            static_init!(
-                kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[Pin::P0_25])
-            )
-            .finalize(),
-            static_init!(
-                kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[Pin::P0_24])
-            )
-            .finalize(),
-            static_init!(
-                kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[Pin::P0_23])
-            )
-            .finalize(),
-            static_init!(
-                kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[Pin::P0_22])
+                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[Pin::P0_31])
             )
             .finalize(),
         ]

--- a/boards/acd52832/src/main.rs
+++ b/boards/acd52832/src/main.rs
@@ -10,26 +10,25 @@ use kernel::capabilities;
 use kernel::component::Component;
 use kernel::hil;
 use kernel::hil::entropy::Entropy32;
-use kernel::hil::gpio::{
-    Configure, InterruptValuePin, InterruptValueWrapper, InterruptWithValue, Output, Pin,
-};
+use kernel::hil::gpio::{Configure, InterruptWithValue, Output};
 use kernel::hil::rng::Rng;
 #[allow(unused_imports)]
 use kernel::{create_capability, debug, debug_gpio, static_init};
+use nrf52832::gpio::Pin;
 use nrf52832::rtc::Rtc;
 
 use nrf52dk_base::nrf52_components::ble::BLEComponent;
 
-const LED1_PIN: usize = 26;
-const LED2_PIN: usize = 22;
-const LED3_PIN: usize = 23;
-const LED4_PIN: usize = 24;
+const LED1_PIN: Pin = Pin::P0_26;
+const LED2_PIN: Pin = Pin::P0_22;
+const LED3_PIN: Pin = Pin::P0_23;
+const LED4_PIN: Pin = Pin::P0_24;
 
-const BUTTON1_PIN: usize = 25;
-const BUTTON2_PIN: usize = 14;
-const BUTTON3_PIN: usize = 15;
-const BUTTON4_PIN: usize = 16;
-const BUTTON_RST_PIN: usize = 19;
+const BUTTON1_PIN: Pin = Pin::P0_25;
+const BUTTON2_PIN: Pin = Pin::P0_14;
+const BUTTON3_PIN: Pin = Pin::P0_15;
+const BUTTON4_PIN: Pin = Pin::P0_16;
+const BUTTON_RST_PIN: Pin = Pin::P0_19;
 
 /// UART Writer
 pub mod io;
@@ -123,72 +122,72 @@ pub unsafe fn reset_handler() {
         [
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[3])
+                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[Pin::P0_03])
             )
             .finalize(), // Bottom right header on DK board
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[4])
+                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[Pin::P0_04])
             )
             .finalize(),
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[28])
+                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[Pin::P0_28])
             )
             .finalize(),
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[29])
+                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[Pin::P0_29])
             )
             .finalize(),
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[30])
+                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[Pin::P0_30])
             )
             .finalize(),
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[12])
+                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[Pin::P0_12])
             )
             .finalize(), // Top mid header on DK board
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[11])
+                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[Pin::P0_11])
             )
             .finalize(),
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[27])
+                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[Pin::P0_27])
             )
             .finalize(), // Top left header on DK board
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[26])
+                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[Pin::P0_26])
             )
             .finalize(),
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[2])
+                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[Pin::P0_02])
             )
             .finalize(),
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[25])
+                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[Pin::P0_25])
             )
             .finalize(),
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[24])
+                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[Pin::P0_24])
             )
             .finalize(),
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[23])
+                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[Pin::P0_23])
             )
             .finalize(),
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[22])
+                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[Pin::P0_22])
             )
             .finalize(),
         ]
@@ -196,7 +195,7 @@ pub unsafe fn reset_handler() {
 
     // LEDs
     let led_pins = static_init!(
-        [(&'static dyn Pin, capsules::led::ActivationMode); 4],
+        [(&'static dyn hil::gpio::Pin, capsules::led::ActivationMode); 4],
         [
             (
                 &nrf52832::gpio::PORT[LED1_PIN],
@@ -219,7 +218,10 @@ pub unsafe fn reset_handler() {
 
     // Setup GPIO pins that correspond to buttons
     let button_pins = static_init!(
-        [(&'static dyn InterruptValuePin, capsules::button::GpioMode); 4],
+        [(
+            &'static dyn hil::gpio::InterruptValuePin,
+            capsules::button::GpioMode
+        ); 4],
         [
             // 13
             (
@@ -420,13 +422,13 @@ pub unsafe fn reset_handler() {
 
     // Configure the MCP23017. Device address 0x20.
     let mcp_pin0 = static_init!(
-        InterruptValueWrapper,
-        InterruptValueWrapper::new(&nrf52832::gpio::PORT[11])
+        hil::gpio::InterruptValueWrapper,
+        hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[Pin::P0_11])
     )
     .finalize();
     let mcp_pin1 = static_init!(
-        InterruptValueWrapper,
-        InterruptValueWrapper::new(&nrf52832::gpio::PORT[12])
+        hil::gpio::InterruptValueWrapper,
+        hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[Pin::P0_12])
     )
     .finalize();
     let mcp23017_i2c = static_init!(
@@ -599,8 +601,8 @@ pub unsafe fn reset_handler() {
         nrf52832::chip::NRF52::new(&nrf52832::gpio::PORT)
     );
 
-    nrf52832::gpio::PORT[31].make_output();
-    nrf52832::gpio::PORT[31].clear();
+    nrf52832::gpio::PORT[Pin::P0_31].make_output();
+    nrf52832::gpio::PORT[Pin::P0_31].clear();
 
     debug!("Initialization complete. Entering main loop\r");
     debug!("{}", &nrf52832::ficr::FICR_INSTANCE);

--- a/boards/nordic/nrf52840_dongle/src/io.rs
+++ b/boards/nordic/nrf52840_dongle/src/io.rs
@@ -4,6 +4,7 @@ use cortexm4;
 use kernel::debug;
 use kernel::hil::led;
 use kernel::hil::uart::{self, Configure};
+use nrf52840::gpio::Pin;
 
 use crate::PROCESSES;
 
@@ -42,7 +43,7 @@ impl Write for Writer {
 /// Panic handler
 pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
     // The nRF52840 Dongle LEDs (see back of board)
-    const LED1_PIN: usize = nrf52840::gpio::Pin::P0_06 as usize;
+    const LED1_PIN: Pin = Pin::P0_06;
     let led = &mut led::LedLow::new(&mut nrf52840::gpio::PORT[LED1_PIN]);
     let writer = &mut WRITER;
     debug::panic(&mut [led], writer, pi, &cortexm4::support::nop, &PROCESSES)

--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -14,23 +14,23 @@ use nrf52840::gpio::Pin;
 use nrf52dk_base::{SpiPins, UartPins};
 
 // The nRF52840 Dongle LEDs
-const LED1_PIN: usize = Pin::P0_06 as usize;
-const LED2_R_PIN: usize = Pin::P0_08 as usize;
-const LED2_G_PIN: usize = Pin::P1_09 as usize;
-const LED2_B_PIN: usize = Pin::P0_12 as usize;
+const LED1_PIN: Pin = Pin::P0_06;
+const LED2_R_PIN: Pin = Pin::P0_08;
+const LED2_G_PIN: Pin = Pin::P1_09;
+const LED2_B_PIN: Pin = Pin::P0_12;
 
 // The nRF52840 Dongle button
-const BUTTON_PIN: usize = Pin::P1_06 as usize;
-const BUTTON_RST_PIN: usize = Pin::P0_18 as usize;
+const BUTTON_PIN: Pin = Pin::P1_06;
+const BUTTON_RST_PIN: Pin = Pin::P0_18;
 
-const UART_RTS: usize = Pin::P0_13 as usize;
-const UART_TXD: usize = Pin::P0_15 as usize;
-const UART_CTS: usize = Pin::P0_17 as usize;
-const UART_RXD: usize = Pin::P0_20 as usize;
+const UART_RTS: Pin = Pin::P0_13;
+const UART_TXD: Pin = Pin::P0_15;
+const UART_CTS: Pin = Pin::P0_17;
+const UART_RXD: Pin = Pin::P0_20;
 
-const SPI_MOSI: usize = Pin::P1_01 as usize;
-const SPI_MISO: usize = Pin::P1_02 as usize;
-const SPI_CLK: usize = Pin::P1_04 as usize;
+const SPI_MOSI: Pin = Pin::P1_01;
+const SPI_MISO: Pin = Pin::P1_02;
+const SPI_CLK: Pin = Pin::P1_04;
 
 /// UART Writer
 pub mod io;
@@ -67,172 +67,124 @@ pub unsafe fn reset_handler() {
             // Left side of the USB plug
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(
-                    &nrf52840::gpio::PORT[Pin::P0_13 as usize]
-                )
+                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P0_13])
             )
             .finalize(),
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(
-                    &nrf52840::gpio::PORT[Pin::P0_15 as usize]
-                )
+                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P0_15])
             )
             .finalize(),
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(
-                    &nrf52840::gpio::PORT[Pin::P0_17 as usize]
-                )
+                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P0_17])
             )
             .finalize(),
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(
-                    &nrf52840::gpio::PORT[Pin::P0_20 as usize]
-                )
+                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P0_20])
             )
             .finalize(),
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(
-                    &nrf52840::gpio::PORT[Pin::P0_22 as usize]
-                )
+                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P0_22])
             )
             .finalize(),
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(
-                    &nrf52840::gpio::PORT[Pin::P0_24 as usize]
-                )
+                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P0_24])
             )
             .finalize(),
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(
-                    &nrf52840::gpio::PORT[Pin::P1_00 as usize]
-                )
+                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P1_00])
             )
             .finalize(),
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(
-                    &nrf52840::gpio::PORT[Pin::P0_09 as usize]
-                )
+                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P0_09])
             )
             .finalize(),
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(
-                    &nrf52840::gpio::PORT[Pin::P0_10 as usize]
-                )
+                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P0_10])
             )
             .finalize(),
             // Right side of the USB plug
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(
-                    &nrf52840::gpio::PORT[Pin::P0_31 as usize]
-                )
+                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P0_31])
             )
             .finalize(),
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(
-                    &nrf52840::gpio::PORT[Pin::P0_29 as usize]
-                )
+                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P0_29])
             )
             .finalize(),
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(
-                    &nrf52840::gpio::PORT[Pin::P0_02 as usize]
-                )
+                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P0_02])
             )
             .finalize(),
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(
-                    &nrf52840::gpio::PORT[Pin::P1_15 as usize]
-                )
+                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P1_15])
             )
             .finalize(),
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(
-                    &nrf52840::gpio::PORT[Pin::P1_13 as usize]
-                )
+                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P1_13])
             )
             .finalize(),
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(
-                    &nrf52840::gpio::PORT[Pin::P1_10 as usize]
-                )
+                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P1_10])
             )
             .finalize(),
             // Below the PCB
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(
-                    &nrf52840::gpio::PORT[Pin::P0_26 as usize]
-                )
+                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P0_26])
             )
             .finalize(),
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(
-                    &nrf52840::gpio::PORT[Pin::P0_04 as usize]
-                )
+                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P0_04])
             )
             .finalize(),
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(
-                    &nrf52840::gpio::PORT[Pin::P0_11 as usize]
-                )
+                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P0_11])
             )
             .finalize(),
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(
-                    &nrf52840::gpio::PORT[Pin::P0_14 as usize]
-                )
+                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P0_14])
             )
             .finalize(),
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(
-                    &nrf52840::gpio::PORT[Pin::P1_11 as usize]
-                )
+                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P1_11])
             )
             .finalize(),
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(
-                    &nrf52840::gpio::PORT[Pin::P1_07 as usize]
-                )
+                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P1_07])
             )
             .finalize(),
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(
-                    &nrf52840::gpio::PORT[Pin::P1_01 as usize]
-                )
+                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P1_01])
             )
             .finalize(),
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(
-                    &nrf52840::gpio::PORT[Pin::P1_04 as usize]
-                )
+                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P1_04])
             )
             .finalize(),
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(
-                    &nrf52840::gpio::PORT[Pin::P1_02 as usize]
-                )
+                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P1_02])
             )
             .finalize(),
         ]

--- a/boards/nordic/nrf52840dk/src/io.rs
+++ b/boards/nordic/nrf52840dk/src/io.rs
@@ -4,6 +4,7 @@ use cortexm4;
 use kernel::debug;
 use kernel::hil::led;
 use kernel::hil::uart::{self, Configure};
+use nrf52840::gpio::Pin;
 
 use crate::PROCESSES;
 
@@ -42,7 +43,7 @@ impl Write for Writer {
 /// Panic handler
 pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
     // The nRF52840DK LEDs (see back of board)
-    const LED1_PIN: usize = 13;
+    const LED1_PIN: Pin = Pin::P0_13;
     let led = &mut led::LedLow::new(&mut nrf52840::gpio::PORT[LED1_PIN]);
     let writer = &mut WRITER;
     debug::panic(&mut [led], writer, pi, &cortexm4::support::nop, &PROCESSES)

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -9,34 +9,35 @@
 
 #[allow(unused_imports)]
 use kernel::{debug, debug_gpio, debug_verbose, static_init};
+use nrf52840::gpio::Pin;
 
 use nrf52dk_base::{SpiMX25R6435FPins, SpiPins, UartPins};
 
 // The nRF52840DK LEDs (see back of board)
-const LED1_PIN: usize = 13;
-const LED2_PIN: usize = 14;
-const LED3_PIN: usize = 15;
-const LED4_PIN: usize = 16;
+const LED1_PIN: Pin = Pin::P0_13;
+const LED2_PIN: Pin = Pin::P0_14;
+const LED3_PIN: Pin = Pin::P0_15;
+const LED4_PIN: Pin = Pin::P0_16;
 
 // The nRF52840DK buttons (see back of board)
-const BUTTON1_PIN: usize = 11;
-const BUTTON2_PIN: usize = 12;
-const BUTTON3_PIN: usize = 24;
-const BUTTON4_PIN: usize = 25;
-const BUTTON_RST_PIN: usize = 18;
+const BUTTON1_PIN: Pin = Pin::P0_11;
+const BUTTON2_PIN: Pin = Pin::P0_12;
+const BUTTON3_PIN: Pin = Pin::P0_24;
+const BUTTON4_PIN: Pin = Pin::P0_25;
+const BUTTON_RST_PIN: Pin = Pin::P0_18;
 
-const UART_RTS: usize = 5;
-const UART_TXD: usize = 6;
-const UART_CTS: usize = 7;
-const UART_RXD: usize = 8;
+const UART_RTS: Pin = Pin::P0_05;
+const UART_TXD: Pin = Pin::P0_06;
+const UART_CTS: Pin = Pin::P0_07;
+const UART_RXD: Pin = Pin::P0_08;
 
-const SPI_MOSI: usize = 20;
-const SPI_MISO: usize = 21;
-const SPI_CLK: usize = 19;
+const SPI_MOSI: Pin = Pin::P0_20;
+const SPI_MISO: Pin = Pin::P0_21;
+const SPI_CLK: Pin = Pin::P0_19;
 
-const SPI_MX25R6435F_CHIP_SELECT: usize = 17;
-const SPI_MX25R6435F_WRITE_PROTECT_PIN: usize = 22;
-const SPI_MX25R6435F_HOLD_PIN: usize = 23;
+const SPI_MX25R6435F_CHIP_SELECT: Pin = Pin::P0_17;
+const SPI_MX25R6435F_WRITE_PROTECT_PIN: Pin = Pin::P0_22;
+const SPI_MX25R6435F_HOLD_PIN: Pin = Pin::P0_23;
 
 /// UART Writer
 pub mod io;
@@ -71,67 +72,67 @@ pub unsafe fn reset_handler() {
         [
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[3])
+                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P0_03])
             )
             .finalize(), // Bottom right header on DK board
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[4])
+                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P0_04])
             )
             .finalize(),
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[28])
+                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P0_28])
             )
             .finalize(),
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[29])
+                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P0_29])
             )
             .finalize(),
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[30])
+                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P0_30])
             )
             .finalize(),
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[10])
+                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P0_10])
             )
             .finalize(),
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[9])
+                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P0_09])
             )
             .finalize(),
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[8])
+                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P0_08])
             )
             .finalize(),
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[7])
+                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P0_07])
             )
             .finalize(),
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[6])
+                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P0_06])
             )
             .finalize(),
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[5])
+                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P0_05])
             )
             .finalize(),
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[1])
+                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P0_01])
             )
             .finalize(),
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[0])
+                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P0_00])
             )
             .finalize(),
         ]

--- a/boards/nordic/nrf52dk/src/io.rs
+++ b/boards/nordic/nrf52dk/src/io.rs
@@ -43,7 +43,7 @@ impl Write for Writer {
 /// Panic handler
 pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
     // The nRF52 DK LEDs (see back of board)
-    const LED1_PIN: Pin = nrf52832::gpio::Pin::P0_17;
+    const LED1_PIN: Pin = Pin::P0_17;
     let led = &mut led::LedLow::new(&mut nrf52832::gpio::PORT[LED1_PIN]);
     let writer = &mut WRITER;
     debug::panic(&mut [led], writer, pi, &cortexm4::support::nop, &PROCESSES)

--- a/boards/nordic/nrf52dk/src/io.rs
+++ b/boards/nordic/nrf52dk/src/io.rs
@@ -4,6 +4,7 @@ use cortexm4;
 use kernel::debug;
 use kernel::hil::led;
 use kernel::hil::uart::{self, Configure};
+use nrf52832::gpio::Pin;
 
 use crate::PROCESSES;
 
@@ -42,7 +43,7 @@ impl Write for Writer {
 /// Panic handler
 pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
     // The nRF52 DK LEDs (see back of board)
-    const LED1_PIN: usize = nrf52832::gpio::Pin::P0_17 as usize;
+    const LED1_PIN: Pin = nrf52832::gpio::Pin::P0_17;
     let led = &mut led::LedLow::new(&mut nrf52832::gpio::PORT[LED1_PIN]);
     let writer = &mut WRITER;
     debug::panic(&mut [led], writer, pi, &cortexm4::support::nop, &PROCESSES)

--- a/boards/nordic/nrf52dk/src/io.rs
+++ b/boards/nordic/nrf52dk/src/io.rs
@@ -42,7 +42,7 @@ impl Write for Writer {
 /// Panic handler
 pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
     // The nRF52 DK LEDs (see back of board)
-    const LED1_PIN: usize = 17;
+    const LED1_PIN: usize = nrf52832::gpio::Pin::P0_17 as usize;
     let led = &mut led::LedLow::new(&mut nrf52832::gpio::PORT[LED1_PIN]);
     let writer = &mut WRITER;
     debug::panic(&mut [led], writer, pi, &cortexm4::support::nop, &PROCESSES)

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -67,29 +67,30 @@
 #[allow(unused_imports)]
 use kernel::{debug, debug_gpio, debug_verbose, static_init};
 
+use nrf52832::gpio::Pin;
 use nrf52dk_base::{SpiPins, UartPins};
 
 // The nRF52 DK LEDs (see back of board)
-const LED1_PIN: usize = 17;
-const LED2_PIN: usize = 18;
-const LED3_PIN: usize = 19;
-const LED4_PIN: usize = 20;
+const LED1_PIN: usize = Pin::P0_17 as usize;
+const LED2_PIN: usize = Pin::P0_18 as usize;
+const LED3_PIN: usize = Pin::P0_19 as usize;
+const LED4_PIN: usize = Pin::P0_20 as usize;
 
 // The nRF52 DK buttons (see back of board)
-const BUTTON1_PIN: usize = 13;
-const BUTTON2_PIN: usize = 14;
-const BUTTON3_PIN: usize = 15;
-const BUTTON4_PIN: usize = 16;
-const BUTTON_RST_PIN: usize = 21;
+const BUTTON1_PIN: usize = Pin::P0_13 as usize;
+const BUTTON2_PIN: usize = Pin::P0_14 as usize;
+const BUTTON3_PIN: usize = Pin::P0_15 as usize;
+const BUTTON4_PIN: usize = Pin::P0_16 as usize;
+const BUTTON_RST_PIN: usize = Pin::P0_21 as usize;
 
-const UART_RTS: usize = 5;
-const UART_TXD: usize = 6;
-const UART_CTS: usize = 7;
-const UART_RXD: usize = 8;
+const UART_RTS: usize = Pin::P0_05 as usize;
+const UART_TXD: usize = Pin::P0_06 as usize;
+const UART_CTS: usize = Pin::P0_07 as usize;
+const UART_RXD: usize = Pin::P0_08 as usize;
 
-const SPI_MOSI: usize = 22;
-const SPI_MISO: usize = 23;
-const SPI_CLK: usize = 24;
+const SPI_MOSI: usize = Pin::P0_22 as usize;
+const SPI_MISO: usize = Pin::P0_23 as usize;
+const SPI_CLK: usize = Pin::P0_24 as usize;
 
 /// UART Writer
 pub mod io;
@@ -127,64 +128,91 @@ pub unsafe fn reset_handler() {
     let gpio_pins = static_init!(
         [&'static dyn kernel::hil::gpio::InterruptValuePin; 12],
         [
+            // Bottom right header on DK board
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[3])
-            )
-            .finalize(), // Bottom right header on DK board
-            static_init!(
-                kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[4])
+                kernel::hil::gpio::InterruptValueWrapper::new(
+                    &nrf52832::gpio::PORT[Pin::P0_03 as usize]
+                )
             )
             .finalize(),
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[28])
+                kernel::hil::gpio::InterruptValueWrapper::new(
+                    &nrf52832::gpio::PORT[Pin::P0_04 as usize]
+                )
             )
             .finalize(),
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[29])
+                kernel::hil::gpio::InterruptValueWrapper::new(
+                    &nrf52832::gpio::PORT[Pin::P0_28 as usize]
+                )
             )
             .finalize(),
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[30])
+                kernel::hil::gpio::InterruptValueWrapper::new(
+                    &nrf52832::gpio::PORT[Pin::P0_29 as usize]
+                )
             )
             .finalize(),
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[31])
+                kernel::hil::gpio::InterruptValueWrapper::new(
+                    &nrf52832::gpio::PORT[Pin::P0_30 as usize]
+                )
             )
             .finalize(),
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[12])
+                kernel::hil::gpio::InterruptValueWrapper::new(
+                    &nrf52832::gpio::PORT[Pin::P0_31 as usize]
+                )
             )
-            .finalize(), // Top mid header on DK board
+            .finalize(),
+            // Top mid header on DK board
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[11])
+                kernel::hil::gpio::InterruptValueWrapper::new(
+                    &nrf52832::gpio::PORT[Pin::P0_12 as usize]
+                )
             )
             .finalize(),
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[27])
+                kernel::hil::gpio::InterruptValueWrapper::new(
+                    &nrf52832::gpio::PORT[Pin::P0_11 as usize]
+                )
             )
-            .finalize(), // Top left header on DK board
+            .finalize(),
+            // Top left header on DK board
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[26])
+                kernel::hil::gpio::InterruptValueWrapper::new(
+                    &nrf52832::gpio::PORT[Pin::P0_27 as usize]
+                )
             )
             .finalize(),
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[2])
+                kernel::hil::gpio::InterruptValueWrapper::new(
+                    &nrf52832::gpio::PORT[Pin::P0_26 as usize]
+                )
             )
             .finalize(),
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[25])
+                kernel::hil::gpio::InterruptValueWrapper::new(
+                    &nrf52832::gpio::PORT[Pin::P0_02 as usize]
+                )
+            )
+            .finalize(),
+            static_init!(
+                kernel::hil::gpio::InterruptValueWrapper,
+                kernel::hil::gpio::InterruptValueWrapper::new(
+                    &nrf52832::gpio::PORT[Pin::P0_25 as usize]
+                )
             )
             .finalize(),
         ]

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -71,26 +71,26 @@ use nrf52832::gpio::Pin;
 use nrf52dk_base::{SpiPins, UartPins};
 
 // The nRF52 DK LEDs (see back of board)
-const LED1_PIN: usize = Pin::P0_17 as usize;
-const LED2_PIN: usize = Pin::P0_18 as usize;
-const LED3_PIN: usize = Pin::P0_19 as usize;
-const LED4_PIN: usize = Pin::P0_20 as usize;
+const LED1_PIN: Pin = Pin::P0_17;
+const LED2_PIN: Pin = Pin::P0_18;
+const LED3_PIN: Pin = Pin::P0_19;
+const LED4_PIN: Pin = Pin::P0_20;
 
 // The nRF52 DK buttons (see back of board)
-const BUTTON1_PIN: usize = Pin::P0_13 as usize;
-const BUTTON2_PIN: usize = Pin::P0_14 as usize;
-const BUTTON3_PIN: usize = Pin::P0_15 as usize;
-const BUTTON4_PIN: usize = Pin::P0_16 as usize;
-const BUTTON_RST_PIN: usize = Pin::P0_21 as usize;
+const BUTTON1_PIN: Pin = Pin::P0_13;
+const BUTTON2_PIN: Pin = Pin::P0_14;
+const BUTTON3_PIN: Pin = Pin::P0_15;
+const BUTTON4_PIN: Pin = Pin::P0_16;
+const BUTTON_RST_PIN: Pin = Pin::P0_21;
 
-const UART_RTS: usize = Pin::P0_05 as usize;
-const UART_TXD: usize = Pin::P0_06 as usize;
-const UART_CTS: usize = Pin::P0_07 as usize;
-const UART_RXD: usize = Pin::P0_08 as usize;
+const UART_RTS: Pin = Pin::P0_05;
+const UART_TXD: Pin = Pin::P0_06;
+const UART_CTS: Pin = Pin::P0_07;
+const UART_RXD: Pin = Pin::P0_08;
 
-const SPI_MOSI: usize = Pin::P0_22 as usize;
-const SPI_MISO: usize = Pin::P0_23 as usize;
-const SPI_CLK: usize = Pin::P0_24 as usize;
+const SPI_MOSI: Pin = Pin::P0_22;
+const SPI_MISO: Pin = Pin::P0_23;
+const SPI_CLK: Pin = Pin::P0_24;
 
 /// UART Writer
 pub mod io;
@@ -131,88 +131,64 @@ pub unsafe fn reset_handler() {
             // Bottom right header on DK board
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(
-                    &nrf52832::gpio::PORT[Pin::P0_03 as usize]
-                )
+                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[Pin::P0_03])
             )
             .finalize(),
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(
-                    &nrf52832::gpio::PORT[Pin::P0_04 as usize]
-                )
+                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[Pin::P0_04])
             )
             .finalize(),
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(
-                    &nrf52832::gpio::PORT[Pin::P0_28 as usize]
-                )
+                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[Pin::P0_28])
             )
             .finalize(),
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(
-                    &nrf52832::gpio::PORT[Pin::P0_29 as usize]
-                )
+                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[Pin::P0_29])
             )
             .finalize(),
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(
-                    &nrf52832::gpio::PORT[Pin::P0_30 as usize]
-                )
+                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[Pin::P0_30])
             )
             .finalize(),
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(
-                    &nrf52832::gpio::PORT[Pin::P0_31 as usize]
-                )
+                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[Pin::P0_31])
             )
             .finalize(),
             // Top mid header on DK board
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(
-                    &nrf52832::gpio::PORT[Pin::P0_12 as usize]
-                )
+                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[Pin::P0_12])
             )
             .finalize(),
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(
-                    &nrf52832::gpio::PORT[Pin::P0_11 as usize]
-                )
+                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[Pin::P0_11])
             )
             .finalize(),
             // Top left header on DK board
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(
-                    &nrf52832::gpio::PORT[Pin::P0_27 as usize]
-                )
+                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[Pin::P0_27])
             )
             .finalize(),
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(
-                    &nrf52832::gpio::PORT[Pin::P0_26 as usize]
-                )
+                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[Pin::P0_26])
             )
             .finalize(),
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(
-                    &nrf52832::gpio::PORT[Pin::P0_02 as usize]
-                )
+                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[Pin::P0_02])
             )
             .finalize(),
             static_init!(
                 kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(
-                    &nrf52832::gpio::PORT[Pin::P0_25 as usize]
-                )
+                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[Pin::P0_25])
             )
             .finalize(),
         ]

--- a/boards/nordic/nrf52dk_base/src/lib.rs
+++ b/boards/nordic/nrf52dk_base/src/lib.rs
@@ -11,6 +11,7 @@ use capsules::virtual_uart::MuxUart;
 use kernel::capabilities;
 use kernel::component::Component;
 use kernel::hil;
+use nrf52::gpio::Pin;
 use nrf52::rtc::Rtc;
 use nrf52::uicr::Regulator0Output;
 
@@ -27,13 +28,13 @@ const PAN_ID: u16 = 0xABCD;
 /// Pins for SPI for the flash chip MX25R6435F
 #[derive(Debug)]
 pub struct SpiMX25R6435FPins {
-    chip_select: usize,
-    write_protect_pin: usize,
-    hold_pin: usize,
+    chip_select: Pin,
+    write_protect_pin: Pin,
+    hold_pin: Pin,
 }
 
 impl SpiMX25R6435FPins {
-    pub fn new(chip_select: usize, write_protect_pin: usize, hold_pin: usize) -> Self {
+    pub fn new(chip_select: Pin, write_protect_pin: Pin, hold_pin: Pin) -> Self {
         Self {
             chip_select,
             write_protect_pin,
@@ -45,13 +46,13 @@ impl SpiMX25R6435FPins {
 /// Pins for the SPI driver
 #[derive(Debug)]
 pub struct SpiPins {
-    mosi: usize,
-    miso: usize,
-    clk: usize,
+    mosi: Pin,
+    miso: Pin,
+    clk: Pin,
 }
 
 impl SpiPins {
-    pub fn new(mosi: usize, miso: usize, clk: usize) -> Self {
+    pub fn new(mosi: Pin, miso: Pin, clk: Pin) -> Self {
         Self { mosi, miso, clk }
     }
 }
@@ -59,14 +60,14 @@ impl SpiPins {
 /// Pins for the UART
 #[derive(Debug)]
 pub struct UartPins {
-    rts: usize,
-    txd: usize,
-    cts: usize,
-    rxd: usize,
+    rts: Pin,
+    txd: Pin,
+    cts: Pin,
+    rxd: Pin,
 }
 
 impl UartPins {
-    pub fn new(rts: usize, txd: usize, cts: usize, rxd: usize) -> Self {
+    pub fn new(rts: Pin, txd: Pin, cts: Pin, rxd: Pin) -> Self {
         Self { rts, txd, cts, rxd }
     }
 }
@@ -126,12 +127,12 @@ impl kernel::Platform for Platform {
 #[inline]
 pub unsafe fn setup_board(
     board_kernel: &'static kernel::Kernel,
-    button_rst_pin: usize,
+    button_rst_pin: Pin,
     gpio_port: &'static nrf52::gpio::Port,
     gpio_pins: &'static mut [&'static dyn kernel::hil::gpio::InterruptValuePin],
-    debug_pin1_index: usize,
-    debug_pin2_index: usize,
-    debug_pin3_index: usize,
+    debug_pin1_index: Pin,
+    debug_pin2_index: Pin,
+    debug_pin3_index: Pin,
     led_pins: &'static mut [(
         &'static dyn kernel::hil::gpio::Pin,
         capsules::led::ActivationMode,
@@ -155,8 +156,8 @@ pub unsafe fn setup_board(
 
     // Check if we need to erase UICR memory to re-program it
     // This only needs to be done when a bit needs to be flipped from 0 to 1.
-    let mut erase_uicr = (!uicr.get_psel0_reset_pin() & button_rst_pin != 0)
-        | (!uicr.get_psel1_reset_pin() & button_rst_pin != 0)
+    let mut erase_uicr = (!(uicr.get_psel0_reset_pin() as usize) & (button_rst_pin as usize) != 0)
+        | (!(uicr.get_psel1_reset_pin() as usize) & (button_rst_pin as usize) != 0)
         | (!(uicr.get_vout() as u32) & (reg_vout as u32) != 0);
 
     // Only enabling the NFC pin protection requires an erase.

--- a/chips/nrf52/Cargo.toml
+++ b/chips/nrf52/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 cortexm4 = { path = "../../arch/cortex-m4" }
 kernel = { path = "../../kernel" }
 tock_rt0 = { path = "../../libraries/tock-rt0" }
+enum_primitive = { path = "../../libraries/enum_primitive" }
 
 [dependencies.nrf5x]
 path = "../nrf5x"

--- a/chips/nrf52/src/uicr.rs
+++ b/chips/nrf52/src/uicr.rs
@@ -141,8 +141,8 @@ impl Uicr {
         regs.pselreset0.set(pin as u32);
     }
 
-    pub fn get_psel0_reset_pin(&self) -> Pin {
-        Pin::from_u32(self.registers.pselreset0.get()).unwrap_or(Pin::P0_00)
+    pub fn get_psel0_reset_pin(&self) -> Option<Pin> {
+        Pin::from_u32(self.registers.pselreset0.get())
     }
 
     pub fn set_psel1_reset_pin(&self, pin: Pin) {
@@ -150,8 +150,8 @@ impl Uicr {
         regs.pselreset1.set(pin as u32);
     }
 
-    pub fn get_psel1_reset_pin(&self) -> Pin {
-        Pin::from_u32(self.registers.pselreset1.get()).unwrap_or(Pin::P0_00)
+    pub fn get_psel1_reset_pin(&self) -> Option<Pin> {
+        Pin::from_u32(self.registers.pselreset1.get())
     }
 
     pub fn set_vout(&self, vout: Regulator0Output) {

--- a/chips/nrf52/src/uicr.rs
+++ b/chips/nrf52/src/uicr.rs
@@ -3,8 +3,11 @@
 //! Minimal implementation to support activation of the reset button on
 //! nRF52-DK.
 
+use enum_primitive::cast::FromPrimitive;
 use kernel::common::registers::{register_bitfields, ReadWrite};
 use kernel::common::StaticRef;
+
+use crate::gpio::Pin;
 
 const UICR_BASE: StaticRef<UicrRegisters> =
     unsafe { StaticRef::new(0x10001200 as *const UicrRegisters) };
@@ -133,22 +136,22 @@ impl Uicr {
         }
     }
 
-    pub fn set_psel0_reset_pin(&self, pin: usize) {
+    pub fn set_psel0_reset_pin(&self, pin: Pin) {
         let regs = &*self.registers;
         regs.pselreset0.set(pin as u32);
     }
 
-    pub fn get_psel0_reset_pin(&self) -> usize {
-        self.registers.pselreset0.get() as usize
+    pub fn get_psel0_reset_pin(&self) -> Pin {
+        Pin::from_u32(self.registers.pselreset0.get()).unwrap_or(Pin::P0_00)
     }
 
-    pub fn set_psel1_reset_pin(&self, pin: usize) {
+    pub fn set_psel1_reset_pin(&self, pin: Pin) {
         let regs = &*self.registers;
         regs.pselreset1.set(pin as u32);
     }
 
-    pub fn get_psel1_reset_pin(&self) -> usize {
-        self.registers.pselreset1.get() as usize
+    pub fn get_psel1_reset_pin(&self) -> Pin {
+        Pin::from_u32(self.registers.pselreset1.get()).unwrap_or(Pin::P0_00)
     }
 
     pub fn set_vout(&self, vout: Regulator0Output) {

--- a/chips/nrf5x/Cargo.toml
+++ b/chips/nrf5x/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 kernel = { path = "../../kernel" }
+enum_primitive = { path = "../../libraries/enum_primitive" }
 
 [features]
 default = []

--- a/chips/nrf5x/src/gpio.rs
+++ b/chips/nrf5x/src/gpio.rs
@@ -5,6 +5,8 @@
 //! * Date: August 18, 2016
 
 use core::ops::{Index, IndexMut};
+use enum_primitive::cast::FromPrimitive;
+use enum_primitive::enum_from_primitive;
 use kernel::common::cells::OptionalCell;
 use kernel::common::registers::{register_bitfields, FieldValue, ReadWrite};
 use kernel::common::StaticRef;
@@ -330,16 +332,18 @@ register_bitfields! [u32,
     ]
 ];
 
-#[derive(Copy, Clone)]
-#[rustfmt::skip]
-pub enum Pin {
-    P0_00, P0_01, P0_02, P0_03, P0_04, P0_05, P0_06, P0_07,
-    P0_08, P0_09, P0_10, P0_11, P0_12, P0_13, P0_14, P0_15,
-    P0_16, P0_17, P0_18, P0_19, P0_20, P0_21, P0_22, P0_23,
-    P0_24, P0_25, P0_26, P0_27, P0_28, P0_29, P0_30, P0_31,
-    // Pins only on nrf52840.
-    P1_00, P1_01, P1_02, P1_03, P1_04, P1_05, P1_06, P1_07,
-    P1_08, P1_09, P1_10, P1_11, P1_12, P1_13, P1_14, P1_15,
+enum_from_primitive! {
+    #[derive(Copy, Clone, Debug, PartialEq)]
+    #[rustfmt::skip]
+    pub enum Pin {
+        P0_00, P0_01, P0_02, P0_03, P0_04, P0_05, P0_06, P0_07,
+        P0_08, P0_09, P0_10, P0_11, P0_12, P0_13, P0_14, P0_15,
+        P0_16, P0_17, P0_18, P0_19, P0_20, P0_21, P0_22, P0_23,
+        P0_24, P0_25, P0_26, P0_27, P0_28, P0_29, P0_30, P0_31,
+        // Pins only on nrf52840.
+        P1_00, P1_01, P1_02, P1_03, P1_04, P1_05, P1_06, P1_07,
+        P1_08, P1_09, P1_10, P1_11, P1_12, P1_13, P1_14, P1_15,
+    }
 }
 
 pub struct GPIOPin {
@@ -541,17 +545,17 @@ pub struct Port {
     pub pins: &'static mut [GPIOPin],
 }
 
-impl Index<usize> for Port {
+impl Index<Pin> for Port {
     type Output = GPIOPin;
 
-    fn index(&self, index: usize) -> &GPIOPin {
-        &self.pins[index]
+    fn index(&self, index: Pin) -> &GPIOPin {
+        &self.pins[index as usize]
     }
 }
 
-impl IndexMut<usize> for Port {
-    fn index_mut(&mut self, index: usize) -> &mut GPIOPin {
-        &mut self.pins[index]
+impl IndexMut<Pin> for Port {
+    fn index_mut(&mut self, index: Pin) -> &mut GPIOPin {
+        &mut self.pins[index as usize]
     }
 }
 


### PR DESCRIPTION
### Pull Request Overview

This pull request leverages the `gpio::Pin` enum for the nRF52-based boards. This enum allows to use more meaningful names like `P1_04` instead of `36`.


### Testing Strategy

This pull request was tested with Travis-CI.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.