### PR TITLE
Add tests to capsules/alarm.rs

### DIFF
--- a/capsules/src/alarm.rs
+++ b/capsules/src/alarm.rs
@@ -192,3 +192,31 @@ impl<A: Alarm<'a>> time::AlarmClient for AlarmDriver<'a, A> {
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+    #[test]
+    pub fn alarm_before_systick_wrap_expired() {
+        assert_eq!(super::has_expired(2u32, 3u32, 1u32), true);
+    }
+
+    #[test]
+    pub fn alarm_before_systick_wrap_not_expired() {
+        assert_eq!(super::has_expired(3u32, 2u32, 1u32), false);
+    }
+
+    #[test]
+    pub fn alarm_after_systick_wrap_expired() {
+        assert_eq!(super::has_expired(1u32, 2u32, 3u32), true);
+    }
+
+    #[test]
+    pub fn alarm_after_systick_wrap_time_before_systick_wrap_not_expired() {
+        assert_eq!(super::has_expired(1u32, 4u32, 3u32), false);
+    }
+
+    #[test]
+    pub fn alarm_after_systick_wrap_time_after_systick_wrap_not_expired() {
+        assert_eq!(super::has_expired(1u32, 0u32, 3u32), false);
+    }
+}


### PR DESCRIPTION
### Pull Request Overview

This pull requests adds support to schedule timers where the systick count provided actually lies in the past. This is useful for setting timers for short periods of time. This can happens if simultaneously scheduling timers in one application, imagine two leds blinking in 500 and 250ms intervals simultaneously. One delay will have to start after the second has stopped and will be arbitrarily short. 
This easily leads to the (not-avoidable) situation that a systick count set as alarm is already over. 

This PR fixes this by firing the alarm if it is already over.

### Testing Strategy

I the parallel blink example from the `feature/async-timer` branch for a whole night without the blinking getting stuck (which happens for the current master).

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
