### PR TITLE
nRF52 UART updates - CTS/RTS optional, support PORT1 pins

### DIFF
--- a/boards/nordic/nrf52dk_base/src/lib.rs
+++ b/boards/nordic/nrf52dk_base/src/lib.rs
@@ -276,8 +276,8 @@ pub unsafe fn setup_board(
     nrf52::uart::UARTE0.initialize(
         nrf52::pinmux::Pinmux::new(uart_pins.txd as u32),
         nrf52::pinmux::Pinmux::new(uart_pins.rxd as u32),
-        nrf52::pinmux::Pinmux::new(uart_pins.cts as u32),
-        nrf52::pinmux::Pinmux::new(uart_pins.rts as u32),
+        Some(nrf52::pinmux::Pinmux::new(uart_pins.cts as u32)),
+        Some(nrf52::pinmux::Pinmux::new(uart_pins.rts as u32)),
     );
 
     // Setup the console.

--- a/chips/nrf52/src/uart.rs
+++ b/chips/nrf52/src/uart.rs
@@ -125,8 +125,11 @@ register_bitfields! [u32,
 
     /// Pin select
     Psel [
-        // Pin number
-        PIN OFFSET(0) NUMBITS(5),
+        // Pin number. MSB is actually the port indicator, but since we number
+        // pins sequentially the binary representation of the pin number has
+        // the port bit set correctly. So, for simplicity we just treat the
+        // pin number as a 6 bit field.
+        PIN OFFSET(0) NUMBITS(6),
         // Connect/Disconnect
         CONNECT OFFSET(31) NUMBITS(1)
     ],


### PR DESCRIPTION
### Pull Request Overview

This pull request makes two changes to the nRF UART driver:
1. Not all boards have pins specified for the CTS/RTS lines. This makes passing in those pins optional.
2. The nRF52840dk has more pins, and this changes the register format to allow pins in the second PORT to be used as UART pins.


### Testing Strategy

This pull request was tested by getting UART working on the Arduino Nano 33 BLE board which uses:

```rust
const UART_TX_PIN: Pin = Pin::P1_03;
const UART_RX_PIN: Pin = Pin::P1_10;
```


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
