### PR TITLE
nrf52: gpio: make disable_input a no-op

### DIFF
--- a/chips/nrf5x/src/gpio.rs
+++ b/chips/nrf5x/src/gpio.rs
@@ -420,7 +420,10 @@ impl hil::gpio::Configure for GPIOPin {
     }
 
     fn disable_input(&self) -> hil::gpio::Configuration {
-        self.make_output()
+        // GPIOs are either inputs or outputs on this chip. To "disable" input
+        // would cause this pin to start driving, which is likely undesired, so
+        // this function is a no-op.
+        self.configuration()
     }
 
     fn configuration(&self) -> hil::gpio::Configuration {


### PR DESCRIPTION
### Pull Request Overview

This pull request removes the potentially problematic implementation of `disable_input` and copies the CC26xx chip and just does nothing.



Fixes #1416


### Testing Strategy

I didn't do anything.


### TODO or Help Wanted

Perhaps if there is a better implementation someone can add it here?


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
