### PR TITLE
Add an InterruptService for chips of the nRF5x family.

### DIFF
--- a/boards/acd52832/src/main.rs
+++ b/boards/acd52832/src/main.rs
@@ -15,7 +15,6 @@ use kernel::hil::rng::Rng;
 #[allow(unused_imports)]
 use kernel::{create_capability, debug, debug_gpio, static_init};
 use nrf52832::gpio::Pin;
-use nrf52832::interrupt_service::Nrf52832InterruptService;
 use nrf52832::rtc::Rtc;
 
 use nrf52dk_base::nrf52_components::ble::BLEComponent;
@@ -562,14 +561,7 @@ pub unsafe fn reset_handler() {
         ipc: kernel::ipc::IPC::new(board_kernel, &memory_allocation_capability),
     };
 
-    let interrupt_service = static_init!(
-        Nrf52832InterruptService,
-        Nrf52832InterruptService::new(&nrf52832::gpio::PORT)
-    );
-    let chip = static_init!(
-        nrf52832::chip::NRF52<Nrf52832InterruptService>,
-        nrf52832::chip::NRF52::new(interrupt_service)
-    );
+    let chip = nrf52832::chip::new();
 
     nrf52832::gpio::PORT[Pin::P0_31].make_output();
     nrf52832::gpio::PORT[Pin::P0_31].clear();

--- a/boards/acd52832/src/main.rs
+++ b/boards/acd52832/src/main.rs
@@ -562,8 +562,8 @@ pub unsafe fn reset_handler() {
     };
 
     let interrupt_service = static_init!(
-        nrf52832::chip::InterruptService,
-        nrf52832::chip::InterruptService::new(&nrf52832::gpio::PORT)
+        nrf52832::chip::Nrf52832InterruptService,
+        nrf52832::chip::Nrf52832InterruptService::new(&nrf52832::gpio::PORT)
     );
     let chip = static_init!(
         nrf52832::chip::NRF52,

--- a/boards/acd52832/src/main.rs
+++ b/boards/acd52832/src/main.rs
@@ -561,7 +561,7 @@ pub unsafe fn reset_handler() {
         ipc: kernel::ipc::IPC::new(board_kernel, &memory_allocation_capability),
     };
 
-    let chip = nrf52832::chip::new();
+    let chip = static_init!(nrf52832::chip::Chip, nrf52832::chip::new());
 
     nrf52832::gpio::PORT[Pin::P0_31].make_output();
     nrf52832::gpio::PORT[Pin::P0_31].clear();

--- a/boards/acd52832/src/main.rs
+++ b/boards/acd52832/src/main.rs
@@ -15,6 +15,7 @@ use kernel::hil::rng::Rng;
 #[allow(unused_imports)]
 use kernel::{create_capability, debug, debug_gpio, static_init};
 use nrf52832::gpio::Pin;
+use nrf52832::interrupt_service::Nrf52832InterruptService;
 use nrf52832::rtc::Rtc;
 
 use nrf52dk_base::nrf52_components::ble::BLEComponent;
@@ -562,11 +563,11 @@ pub unsafe fn reset_handler() {
     };
 
     let interrupt_service = static_init!(
-        nrf52832::chip::Nrf52832InterruptService,
-        nrf52832::chip::Nrf52832InterruptService::new(&nrf52832::gpio::PORT)
+        Nrf52832InterruptService,
+        Nrf52832InterruptService::new(&nrf52832::gpio::PORT)
     );
     let chip = static_init!(
-        nrf52832::chip::NRF52,
+        nrf52832::chip::NRF52<Nrf52832InterruptService>,
         nrf52832::chip::NRF52::new(interrupt_service)
     );
 

--- a/boards/acd52832/src/main.rs
+++ b/boards/acd52832/src/main.rs
@@ -561,9 +561,13 @@ pub unsafe fn reset_handler() {
         ipc: kernel::ipc::IPC::new(board_kernel, &memory_allocation_capability),
     };
 
+    let interrupt_service = static_init!(
+        nrf52832::chip::InterruptService,
+        nrf52832::chip::InterruptService::new(&nrf52832::gpio::PORT)
+    );
     let chip = static_init!(
         nrf52832::chip::NRF52,
-        nrf52832::chip::NRF52::new(&nrf52832::gpio::PORT)
+        nrf52832::chip::NRF52::new(interrupt_service)
     );
 
     nrf52832::gpio::PORT[Pin::P0_31].make_output();

--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -10,7 +10,6 @@
 #[allow(unused_imports)]
 use kernel::{debug, debug_gpio, debug_verbose, static_init};
 use nrf52840::gpio::Pin;
-use nrf52840::interrupt_service::Nrf52840InterruptService;
 use nrf52dk_base::{SpiPins, UartPins};
 
 // The nRF52840 Dongle LEDs
@@ -236,15 +235,7 @@ pub unsafe fn reset_handler() {
     }
 
     let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
-
-    let interrupt_service = static_init!(
-        Nrf52840InterruptService,
-        Nrf52840InterruptService::new(&nrf52840::gpio::PORT)
-    );
-    let chip = static_init!(
-        nrf52840::chip::NRF52<Nrf52840InterruptService>,
-        nrf52840::chip::NRF52::new(interrupt_service)
-    );
+    let chip = nrf52840::chip::new();
 
     nrf52dk_base::setup_board(
         board_kernel,

--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -235,7 +235,7 @@ pub unsafe fn reset_handler() {
     }
 
     let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
-    let chip = nrf52840::chip::new();
+    let chip = static_init!(nrf52840::chip::Chip, nrf52840::chip::new());
 
     nrf52dk_base::setup_board(
         board_kernel,

--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -237,6 +237,10 @@ pub unsafe fn reset_handler() {
 
     let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
 
+    let interrupt_service = static_init!(
+        nrf52840::chip::InterruptService,
+        nrf52840::chip::InterruptService::new(&nrf52840::gpio::PORT)
+    );
     nrf52dk_base::setup_board(
         board_kernel,
         BUTTON_RST_PIN,
@@ -256,5 +260,6 @@ pub unsafe fn reset_handler() {
         FAULT_RESPONSE,
         nrf52840::uicr::Regulator0Output::V3_0,
         false,
+        interrupt_service,
     );
 }

--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -238,8 +238,8 @@ pub unsafe fn reset_handler() {
     let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
 
     let interrupt_service = static_init!(
-        nrf52840::chip::InterruptService,
-        nrf52840::chip::InterruptService::new(&nrf52840::gpio::PORT)
+        nrf52840::chip::Nrf52840InterruptService,
+        nrf52840::chip::Nrf52840InterruptService::new(&nrf52840::gpio::PORT)
     );
     nrf52dk_base::setup_board(
         board_kernel,

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -219,6 +219,10 @@ pub unsafe fn reset_handler() {
 
     let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
 
+    let interrupt_service = static_init!(
+        nrf52840::chip::InterruptService,
+        nrf52840::chip::InterruptService::new(&nrf52840::gpio::PORT)
+    );
     nrf52dk_base::setup_board(
         board_kernel,
         BUTTON_RST_PIN,
@@ -242,5 +246,6 @@ pub unsafe fn reset_handler() {
         FAULT_RESPONSE,
         nrf52840::uicr::Regulator0Output::DEFAULT,
         false,
+        interrupt_service,
     );
 }

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -220,8 +220,8 @@ pub unsafe fn reset_handler() {
     let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
 
     let interrupt_service = static_init!(
-        nrf52840::chip::InterruptService,
-        nrf52840::chip::InterruptService::new(&nrf52840::gpio::PORT)
+        nrf52840::chip::Nrf52840InterruptService,
+        nrf52840::chip::Nrf52840InterruptService::new(&nrf52840::gpio::PORT)
     );
     nrf52dk_base::setup_board(
         board_kernel,

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -217,7 +217,7 @@ pub unsafe fn reset_handler() {
     }
 
     let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
-    let chip = nrf52840::chip::new();
+    let chip = static_init!(nrf52840::chip::Chip, nrf52840::chip::new());
 
     nrf52dk_base::setup_board(
         board_kernel,

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -10,7 +10,7 @@
 #[allow(unused_imports)]
 use kernel::{debug, debug_gpio, debug_verbose, static_init};
 use nrf52840::gpio::Pin;
-
+use nrf52840::interrupt_service::Nrf52840InterruptService;
 use nrf52dk_base::{SpiMX25R6435FPins, SpiPins, UartPins};
 
 // The nRF52840DK LEDs (see back of board)
@@ -220,9 +220,14 @@ pub unsafe fn reset_handler() {
     let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
 
     let interrupt_service = static_init!(
-        nrf52840::chip::Nrf52840InterruptService,
-        nrf52840::chip::Nrf52840InterruptService::new(&nrf52840::gpio::PORT)
+        Nrf52840InterruptService,
+        Nrf52840InterruptService::new(&nrf52840::gpio::PORT)
     );
+    let chip = static_init!(
+        nrf52840::chip::NRF52<Nrf52840InterruptService>,
+        nrf52840::chip::NRF52::new(interrupt_service)
+    );
+
     nrf52dk_base::setup_board(
         board_kernel,
         BUTTON_RST_PIN,
@@ -246,6 +251,6 @@ pub unsafe fn reset_handler() {
         FAULT_RESPONSE,
         nrf52840::uicr::Regulator0Output::DEFAULT,
         false,
-        interrupt_service,
+        chip,
     );
 }

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -10,7 +10,6 @@
 #[allow(unused_imports)]
 use kernel::{debug, debug_gpio, debug_verbose, static_init};
 use nrf52840::gpio::Pin;
-use nrf52840::interrupt_service::Nrf52840InterruptService;
 use nrf52dk_base::{SpiMX25R6435FPins, SpiPins, UartPins};
 
 // The nRF52840DK LEDs (see back of board)
@@ -218,15 +217,7 @@ pub unsafe fn reset_handler() {
     }
 
     let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
-
-    let interrupt_service = static_init!(
-        Nrf52840InterruptService,
-        Nrf52840InterruptService::new(&nrf52840::gpio::PORT)
-    );
-    let chip = static_init!(
-        nrf52840::chip::NRF52<Nrf52840InterruptService>,
-        nrf52840::chip::NRF52::new(interrupt_service)
-    );
+    let chip = nrf52840::chip::new();
 
     nrf52dk_base::setup_board(
         board_kernel,

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -275,6 +275,10 @@ pub unsafe fn reset_handler() {
 
     let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
 
+    let interrupt_service = static_init!(
+        nrf52832::chip::InterruptService,
+        nrf52832::chip::InterruptService::new(&nrf52832::gpio::PORT)
+    );
     nrf52dk_base::setup_board(
         board_kernel,
         BUTTON_RST_PIN,
@@ -294,5 +298,6 @@ pub unsafe fn reset_handler() {
         FAULT_RESPONSE,
         nrf52832::uicr::Regulator0Output::DEFAULT,
         false,
+        interrupt_service,
     );
 }

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -276,8 +276,8 @@ pub unsafe fn reset_handler() {
     let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
 
     let interrupt_service = static_init!(
-        nrf52832::chip::InterruptService,
-        nrf52832::chip::InterruptService::new(&nrf52832::gpio::PORT)
+        nrf52832::chip::Nrf52832InterruptService,
+        nrf52832::chip::Nrf52832InterruptService::new(&nrf52832::gpio::PORT)
     );
     nrf52dk_base::setup_board(
         board_kernel,

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -67,7 +67,6 @@
 #[allow(unused_imports)]
 use kernel::{debug, debug_gpio, debug_verbose, static_init};
 use nrf52832::gpio::Pin;
-use nrf52832::interrupt_service::Nrf52832InterruptService;
 use nrf52dk_base::{SpiPins, UartPins};
 
 // The nRF52 DK LEDs (see back of board)
@@ -274,15 +273,7 @@ pub unsafe fn reset_handler() {
     }
 
     let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
-
-    let interrupt_service = static_init!(
-        Nrf52832InterruptService,
-        Nrf52832InterruptService::new(&nrf52832::gpio::PORT)
-    );
-    let chip = static_init!(
-        nrf52832::chip::NRF52<Nrf52832InterruptService>,
-        nrf52832::chip::NRF52::new(interrupt_service)
-    );
+    let chip = nrf52832::chip::new();
 
     nrf52dk_base::setup_board(
         board_kernel,

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -273,7 +273,7 @@ pub unsafe fn reset_handler() {
     }
 
     let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
-    let chip = nrf52832::chip::new();
+    let chip = static_init!(nrf52832::chip::Chip, nrf52832::chip::new());
 
     nrf52dk_base::setup_board(
         board_kernel,

--- a/boards/nordic/nrf52dk_base/src/lib.rs
+++ b/boards/nordic/nrf52dk_base/src/lib.rs
@@ -443,13 +443,6 @@ pub unsafe fn setup_board<I: 'static + nrf52::interrupt_service::InterruptServic
         ipc: kernel::ipc::IPC::new(board_kernel, &memory_allocation_capability),
     };
 
-    /*
-    let chip = static_init!(
-        nrf52::chip::NRF52<I>,
-        nrf52::chip::NRF52::<I>::new(interrupt_service)
-    );
-    */
-
     debug!("Initialization complete. Entering main loop\r");
     debug!("{}", &nrf52::ficr::FICR_INSTANCE);
 

--- a/boards/nordic/nrf52dk_base/src/lib.rs
+++ b/boards/nordic/nrf52dk_base/src/lib.rs
@@ -125,7 +125,7 @@ impl kernel::Platform for Platform {
 
 /// Generic function for starting an nrf52dk board.
 #[inline]
-pub unsafe fn setup_board<I: 'static + nrf52::interrupt_service::InterruptService>(
+pub unsafe fn setup_board<I: nrf52::interrupt_service::InterruptService>(
     board_kernel: &'static kernel::Kernel,
     button_rst_pin: Pin,
     gpio_port: &'static nrf52::gpio::Port,

--- a/boards/nordic/nrf52dk_base/src/lib.rs
+++ b/boards/nordic/nrf52dk_base/src/lib.rs
@@ -150,7 +150,7 @@ pub unsafe fn setup_board(
     app_fault_response: kernel::procs::FaultResponse,
     reg_vout: Regulator0Output,
     nfc_as_gpios: bool,
-    interrupt_service: &'static dyn nrf52::chip::InterruptServiceTrait,
+    interrupt_service: &'static dyn nrf52::chip::InterruptService,
 ) {
     // Make non-volatile memory writable and activate the reset button
     let uicr = nrf52::uicr::Uicr::new();

--- a/boards/nordic/nrf52dk_base/src/lib.rs
+++ b/boards/nordic/nrf52dk_base/src/lib.rs
@@ -125,7 +125,7 @@ impl kernel::Platform for Platform {
 
 /// Generic function for starting an nrf52dk board.
 #[inline]
-pub unsafe fn setup_board(
+pub unsafe fn setup_board<I: 'static + nrf52::interrupt_service::InterruptService>(
     board_kernel: &'static kernel::Kernel,
     button_rst_pin: Pin,
     gpio_port: &'static nrf52::gpio::Port,
@@ -150,7 +150,7 @@ pub unsafe fn setup_board(
     app_fault_response: kernel::procs::FaultResponse,
     reg_vout: Regulator0Output,
     nfc_as_gpios: bool,
-    interrupt_service: &'static dyn nrf52::chip::InterruptService,
+    chip: &'static nrf52::chip::NRF52<I>,
 ) {
     // Make non-volatile memory writable and activate the reset button
     let uicr = nrf52::uicr::Uicr::new();
@@ -443,10 +443,12 @@ pub unsafe fn setup_board(
         ipc: kernel::ipc::IPC::new(board_kernel, &memory_allocation_capability),
     };
 
+    /*
     let chip = static_init!(
-        nrf52::chip::NRF52,
-        nrf52::chip::NRF52::new(interrupt_service)
+        nrf52::chip::NRF52<I>,
+        nrf52::chip::NRF52::<I>::new(interrupt_service)
     );
+    */
 
     debug!("Initialization complete. Entering main loop\r");
     debug!("{}", &nrf52::ficr::FICR_INSTANCE);

--- a/boards/nordic/nrf52dk_base/src/lib.rs
+++ b/boards/nordic/nrf52dk_base/src/lib.rs
@@ -150,6 +150,7 @@ pub unsafe fn setup_board(
     app_fault_response: kernel::procs::FaultResponse,
     reg_vout: Regulator0Output,
     nfc_as_gpios: bool,
+    interrupt_service: &'static dyn nrf52::chip::InterruptServiceTrait,
 ) {
     // Make non-volatile memory writable and activate the reset button
     let uicr = nrf52::uicr::Uicr::new();
@@ -442,7 +443,10 @@ pub unsafe fn setup_board(
         ipc: kernel::ipc::IPC::new(board_kernel, &memory_allocation_capability),
     };
 
-    let chip = static_init!(nrf52::chip::NRF52, nrf52::chip::NRF52::new(gpio_port));
+    let chip = static_init!(
+        nrf52::chip::NRF52,
+        nrf52::chip::NRF52::new(interrupt_service)
+    );
 
     debug!("Initialization complete. Entering main loop\r");
     debug!("{}", &nrf52::ficr::FICR_INSTANCE);

--- a/chips/nrf52/src/chip.rs
+++ b/chips/nrf52/src/chip.rs
@@ -12,7 +12,7 @@ use kernel::common::deferred_call;
 use kernel::debug;
 use nrf5x::peripheral_interrupts;
 
-pub trait InterruptServiceTrait {
+pub trait InterruptService {
     /// Service an interrupt, if supported by this chip. If this interrupt number is not supported,
     /// return false.
     unsafe fn service_interrupt(&self, interrupt: u32) -> bool;
@@ -22,11 +22,11 @@ pub struct NRF52 {
     mpu: cortexm4::mpu::MPU,
     userspace_kernel_boundary: cortexm4::syscall::SysCall,
     systick: cortexm4::systick::SysTick,
-    interrupt_service: &'static dyn InterruptServiceTrait,
+    interrupt_service: &'static dyn InterruptService,
 }
 
 impl NRF52 {
-    pub unsafe fn new(interrupt_service: &'static dyn InterruptServiceTrait) -> NRF52 {
+    pub unsafe fn new(interrupt_service: &'static dyn InterruptService) -> NRF52 {
         NRF52 {
             mpu: cortexm4::mpu::MPU::new(),
             userspace_kernel_boundary: cortexm4::syscall::SysCall::new(),
@@ -38,17 +38,17 @@ impl NRF52 {
     }
 }
 
-pub struct InterruptService {
+pub struct Nrf52InterruptService {
     gpio_port: &'static nrf5x::gpio::Port,
 }
 
-impl InterruptService {
-    pub unsafe fn new(gpio_port: &'static nrf5x::gpio::Port) -> InterruptService {
-        InterruptService { gpio_port }
+impl Nrf52InterruptService {
+    pub unsafe fn new(gpio_port: &'static nrf5x::gpio::Port) -> Nrf52InterruptService {
+        Nrf52InterruptService { gpio_port }
     }
 }
 
-impl InterruptServiceTrait for InterruptService {
+impl InterruptService for Nrf52InterruptService {
     unsafe fn service_interrupt(&self, interrupt: u32) -> bool {
         match interrupt {
             peripheral_interrupts::ECB => nrf5x::aes::AESECB.handle_interrupt(),

--- a/chips/nrf52/src/chip.rs
+++ b/chips/nrf52/src/chip.rs
@@ -5,15 +5,15 @@ use cortexm4::{self, nvic};
 use kernel::common::deferred_call;
 use kernel::debug;
 
-pub struct NRF52<I: 'static + InterruptService> {
+pub struct NRF52<I: InterruptService> {
     mpu: cortexm4::mpu::MPU,
     userspace_kernel_boundary: cortexm4::syscall::SysCall,
     systick: cortexm4::systick::SysTick,
-    interrupt_service: &'static I,
+    interrupt_service: I,
 }
 
-impl<I: 'static + InterruptService> NRF52<I> {
-    pub unsafe fn new(interrupt_service: &'static I) -> NRF52<I> {
+impl<I: InterruptService> NRF52<I> {
+    pub unsafe fn new(interrupt_service: I) -> NRF52<I> {
         NRF52 {
             mpu: cortexm4::mpu::MPU::new(),
             userspace_kernel_boundary: cortexm4::syscall::SysCall::new(),
@@ -25,7 +25,7 @@ impl<I: 'static + InterruptService> NRF52<I> {
     }
 }
 
-impl<I: 'static + InterruptService> kernel::Chip for NRF52<I> {
+impl<I: InterruptService> kernel::Chip for NRF52<I> {
     type MPU = cortexm4::mpu::MPU;
     type UserspaceKernelBoundary = cortexm4::syscall::SysCall;
     type SysTick = cortexm4::systick::SysTick;

--- a/chips/nrf52/src/chip.rs
+++ b/chips/nrf52/src/chip.rs
@@ -1,32 +1,19 @@
-use crate::adc;
-use crate::ble_radio;
 use crate::deferred_call_tasks::DeferredCallTask;
-use crate::i2c;
-use crate::ieee802154_radio;
+use crate::interrupt_service::InterruptService;
 use crate::nvmc;
-use crate::power;
-use crate::spi;
-use crate::uart;
 use cortexm4::{self, nvic};
 use kernel::common::deferred_call;
 use kernel::debug;
-use nrf5x::peripheral_interrupts;
 
-pub trait InterruptService {
-    /// Service an interrupt, if supported by this chip. If this interrupt number is not supported,
-    /// return false.
-    unsafe fn service_interrupt(&self, interrupt: u32) -> bool;
-}
-
-pub struct NRF52 {
+pub struct NRF52<I: 'static + InterruptService> {
     mpu: cortexm4::mpu::MPU,
     userspace_kernel_boundary: cortexm4::syscall::SysCall,
     systick: cortexm4::systick::SysTick,
-    interrupt_service: &'static dyn InterruptService,
+    interrupt_service: &'static I,
 }
 
-impl NRF52 {
-    pub unsafe fn new(interrupt_service: &'static dyn InterruptService) -> NRF52 {
+impl<I: 'static + InterruptService> NRF52<I> {
+    pub unsafe fn new(interrupt_service: &'static I) -> NRF52<I> {
         NRF52 {
             mpu: cortexm4::mpu::MPU::new(),
             userspace_kernel_boundary: cortexm4::syscall::SysCall::new(),
@@ -38,79 +25,7 @@ impl NRF52 {
     }
 }
 
-pub struct Nrf52InterruptService {
-    gpio_port: &'static nrf5x::gpio::Port,
-}
-
-impl Nrf52InterruptService {
-    pub unsafe fn new(gpio_port: &'static nrf5x::gpio::Port) -> Nrf52InterruptService {
-        Nrf52InterruptService { gpio_port }
-    }
-}
-
-impl InterruptService for Nrf52InterruptService {
-    unsafe fn service_interrupt(&self, interrupt: u32) -> bool {
-        match interrupt {
-            peripheral_interrupts::ECB => nrf5x::aes::AESECB.handle_interrupt(),
-            peripheral_interrupts::GPIOTE => self.gpio_port.handle_interrupt(),
-            peripheral_interrupts::POWER_CLOCK => power::POWER.handle_interrupt(),
-            peripheral_interrupts::RADIO => {
-                match (
-                    ieee802154_radio::RADIO.is_enabled(),
-                    ble_radio::RADIO.is_enabled(),
-                ) {
-                    (false, false) => (),
-                    (true, false) => ieee802154_radio::RADIO.handle_interrupt(),
-                    (false, true) => ble_radio::RADIO.handle_interrupt(),
-                    (true, true) => {
-                        debug!("nRF 802.15.4 and BLE radios cannot be simultaneously enabled!")
-                    }
-                }
-            }
-            peripheral_interrupts::RNG => nrf5x::trng::TRNG.handle_interrupt(),
-            peripheral_interrupts::RTC1 => nrf5x::rtc::RTC.handle_interrupt(),
-            peripheral_interrupts::TEMP => nrf5x::temperature::TEMP.handle_interrupt(),
-            peripheral_interrupts::TIMER0 => nrf5x::timer::TIMER0.handle_interrupt(),
-            peripheral_interrupts::TIMER1 => nrf5x::timer::ALARM1.handle_interrupt(),
-            peripheral_interrupts::TIMER2 => nrf5x::timer::TIMER2.handle_interrupt(),
-            peripheral_interrupts::UART0 => uart::UARTE0.handle_interrupt(),
-            peripheral_interrupts::SPI0_TWI0 => {
-                // SPI0 and TWI0 share interrupts.
-                // Dispatch the correct handler.
-                match (spi::SPIM0.is_enabled(), i2c::TWIM0.is_enabled()) {
-                    (false, false) => (),
-                    (true, false) => spi::SPIM0.handle_interrupt(),
-                    (false, true) => i2c::TWIM0.handle_interrupt(),
-                    (true, true) => debug_assert!(
-                        false,
-                        "SPIM0 and TWIM0 cannot be \
-                         enabled at the same time."
-                    ),
-                }
-            }
-            peripheral_interrupts::SPI1_TWI1 => {
-                // SPI1 and TWI1 share interrupts.
-                // Dispatch the correct handler.
-                match (spi::SPIM1.is_enabled(), i2c::TWIM1.is_enabled()) {
-                    (false, false) => (),
-                    (true, false) => spi::SPIM1.handle_interrupt(),
-                    (false, true) => i2c::TWIM1.handle_interrupt(),
-                    (true, true) => debug_assert!(
-                        false,
-                        "SPIM1 and TWIM1 cannot be \
-                         enabled at the same time."
-                    ),
-                }
-            }
-            peripheral_interrupts::SPIM2_SPIS2_SPI2 => spi::SPIM2.handle_interrupt(),
-            peripheral_interrupts::ADC => adc::ADC.handle_interrupt(),
-            _ => return false,
-        }
-        true
-    }
-}
-
-impl kernel::Chip for NRF52 {
+impl<I: 'static + InterruptService> kernel::Chip for NRF52<I> {
     type MPU = cortexm4::mpu::MPU;
     type UserspaceKernelBoundary = cortexm4::syscall::SysCall;
     type SysTick = cortexm4::systick::SysTick;

--- a/chips/nrf52/src/chip.rs
+++ b/chips/nrf52/src/chip.rs
@@ -12,23 +12,101 @@ use kernel::common::deferred_call;
 use kernel::debug;
 use nrf5x::peripheral_interrupts;
 
+pub trait InterruptServiceTrait {
+    // Service an interrupt, if supported by this chip. If this interrupt number is not supported,
+    // return false.
+    unsafe fn service_interrupt(&self, interrupt: u32) -> bool;
+}
+
 pub struct NRF52 {
     mpu: cortexm4::mpu::MPU,
     userspace_kernel_boundary: cortexm4::syscall::SysCall,
     systick: cortexm4::systick::SysTick,
-    gpio_port: &'static nrf5x::gpio::Port,
+    interrupt_service: &'static dyn InterruptServiceTrait,
 }
 
 impl NRF52 {
-    pub unsafe fn new(gpio_port: &'static nrf5x::gpio::Port) -> NRF52 {
+    pub unsafe fn new(interrupt_service: &'static dyn InterruptServiceTrait) -> NRF52 {
         NRF52 {
             mpu: cortexm4::mpu::MPU::new(),
             userspace_kernel_boundary: cortexm4::syscall::SysCall::new(),
             // The NRF52's systick is uncalibrated, but is clocked from the
             // 64Mhz CPU clock.
             systick: cortexm4::systick::SysTick::new_with_calibration(64000000),
-            gpio_port,
+            interrupt_service,
         }
+    }
+}
+
+pub struct InterruptService {
+    gpio_port: &'static nrf5x::gpio::Port,
+}
+
+impl InterruptService {
+    pub unsafe fn new(gpio_port: &'static nrf5x::gpio::Port) -> InterruptService {
+        InterruptService { gpio_port }
+    }
+}
+
+impl InterruptServiceTrait for InterruptService {
+    unsafe fn service_interrupt(&self, interrupt: u32) -> bool {
+        match interrupt {
+            peripheral_interrupts::ECB => nrf5x::aes::AESECB.handle_interrupt(),
+            peripheral_interrupts::GPIOTE => self.gpio_port.handle_interrupt(),
+            peripheral_interrupts::POWER_CLOCK => power::POWER.handle_interrupt(),
+            peripheral_interrupts::RADIO => {
+                match (
+                    ieee802154_radio::RADIO.is_enabled(),
+                    ble_radio::RADIO.is_enabled(),
+                ) {
+                    (false, false) => (),
+                    (true, false) => ieee802154_radio::RADIO.handle_interrupt(),
+                    (false, true) => ble_radio::RADIO.handle_interrupt(),
+                    (true, true) => {
+                        debug!("nRF 802.15.4 and BLE radios cannot be simultaneously enabled!")
+                    }
+                }
+            }
+            peripheral_interrupts::RNG => nrf5x::trng::TRNG.handle_interrupt(),
+            peripheral_interrupts::RTC1 => nrf5x::rtc::RTC.handle_interrupt(),
+            peripheral_interrupts::TEMP => nrf5x::temperature::TEMP.handle_interrupt(),
+            peripheral_interrupts::TIMER0 => nrf5x::timer::TIMER0.handle_interrupt(),
+            peripheral_interrupts::TIMER1 => nrf5x::timer::ALARM1.handle_interrupt(),
+            peripheral_interrupts::TIMER2 => nrf5x::timer::TIMER2.handle_interrupt(),
+            peripheral_interrupts::UART0 => uart::UARTE0.handle_interrupt(),
+            peripheral_interrupts::SPI0_TWI0 => {
+                // SPI0 and TWI0 share interrupts.
+                // Dispatch the correct handler.
+                match (spi::SPIM0.is_enabled(), i2c::TWIM0.is_enabled()) {
+                    (false, false) => (),
+                    (true, false) => spi::SPIM0.handle_interrupt(),
+                    (false, true) => i2c::TWIM0.handle_interrupt(),
+                    (true, true) => debug_assert!(
+                        false,
+                        "SPIM0 and TWIM0 cannot be \
+                         enabled at the same time."
+                    ),
+                }
+            }
+            peripheral_interrupts::SPI1_TWI1 => {
+                // SPI1 and TWI1 share interrupts.
+                // Dispatch the correct handler.
+                match (spi::SPIM1.is_enabled(), i2c::TWIM1.is_enabled()) {
+                    (false, false) => (),
+                    (true, false) => spi::SPIM1.handle_interrupt(),
+                    (false, true) => i2c::TWIM1.handle_interrupt(),
+                    (true, true) => debug_assert!(
+                        false,
+                        "SPIM1 and TWIM1 cannot be \
+                         enabled at the same time."
+                    ),
+                }
+            }
+            peripheral_interrupts::SPIM2_SPIS2_SPI2 => spi::SPIM2.handle_interrupt(),
+            peripheral_interrupts::ADC => adc::ADC.handle_interrupt(),
+            _ => return false,
+        }
+        true
     }
 }
 
@@ -57,61 +135,8 @@ impl kernel::Chip for NRF52 {
                         DeferredCallTask::Nvmc => nvmc::NVMC.handle_interrupt(),
                     }
                 } else if let Some(interrupt) = nvic::next_pending() {
-                    match interrupt {
-                        peripheral_interrupts::ECB => nrf5x::aes::AESECB.handle_interrupt(),
-                        peripheral_interrupts::GPIOTE => self.gpio_port.handle_interrupt(),
-                        peripheral_interrupts::POWER_CLOCK => power::POWER.handle_interrupt(),
-                        peripheral_interrupts::RADIO => {
-                            match (
-                                ieee802154_radio::RADIO.is_enabled(),
-                                ble_radio::RADIO.is_enabled(),
-                            ) {
-                                (false, false) => (),
-                                (true, false) => ieee802154_radio::RADIO.handle_interrupt(),
-                                (false, true) => ble_radio::RADIO.handle_interrupt(),
-                                (true, true) => debug!(
-                                    "nRF 802.15.4 and BLE radios cannot be simultaneously enabled!"
-                                ),
-                            }
-                        }
-                        peripheral_interrupts::RNG => nrf5x::trng::TRNG.handle_interrupt(),
-                        peripheral_interrupts::RTC1 => nrf5x::rtc::RTC.handle_interrupt(),
-                        peripheral_interrupts::TEMP => nrf5x::temperature::TEMP.handle_interrupt(),
-                        peripheral_interrupts::TIMER0 => nrf5x::timer::TIMER0.handle_interrupt(),
-                        peripheral_interrupts::TIMER1 => nrf5x::timer::ALARM1.handle_interrupt(),
-                        peripheral_interrupts::TIMER2 => nrf5x::timer::TIMER2.handle_interrupt(),
-                        peripheral_interrupts::UART0 => uart::UARTE0.handle_interrupt(),
-                        peripheral_interrupts::SPI0_TWI0 => {
-                            // SPI0 and TWI0 share interrupts.
-                            // Dispatch the correct handler.
-                            match (spi::SPIM0.is_enabled(), i2c::TWIM0.is_enabled()) {
-                                (false, false) => (),
-                                (true, false) => spi::SPIM0.handle_interrupt(),
-                                (false, true) => i2c::TWIM0.handle_interrupt(),
-                                (true, true) => debug_assert!(
-                                    false,
-                                    "SPIM0 and TWIM0 cannot be \
-                                     enabled at the same time."
-                                ),
-                            }
-                        }
-                        peripheral_interrupts::SPI1_TWI1 => {
-                            // SPI1 and TWI1 share interrupts.
-                            // Dispatch the correct handler.
-                            match (spi::SPIM1.is_enabled(), i2c::TWIM1.is_enabled()) {
-                                (false, false) => (),
-                                (true, false) => spi::SPIM1.handle_interrupt(),
-                                (false, true) => i2c::TWIM1.handle_interrupt(),
-                                (true, true) => debug_assert!(
-                                    false,
-                                    "SPIM1 and TWIM1 cannot be \
-                                     enabled at the same time."
-                                ),
-                            }
-                        }
-                        peripheral_interrupts::SPIM2_SPIS2_SPI2 => spi::SPIM2.handle_interrupt(),
-                        peripheral_interrupts::ADC => adc::ADC.handle_interrupt(),
-                        _ => debug!("NvicIdx not supported by Tock"),
+                    if !self.interrupt_service.service_interrupt(interrupt) {
+                        debug!("NvicIdx not supported by Tock: {}", interrupt);
                     }
                     let n = nvic::Nvic::new(interrupt);
                     n.clear_pending();

--- a/chips/nrf52/src/chip.rs
+++ b/chips/nrf52/src/chip.rs
@@ -13,8 +13,8 @@ use kernel::debug;
 use nrf5x::peripheral_interrupts;
 
 pub trait InterruptServiceTrait {
-    // Service an interrupt, if supported by this chip. If this interrupt number is not supported,
-    // return false.
+    /// Service an interrupt, if supported by this chip. If this interrupt number is not supported,
+    /// return false.
     unsafe fn service_interrupt(&self, interrupt: u32) -> bool;
 }
 

--- a/chips/nrf52/src/interrupt_service.rs
+++ b/chips/nrf52/src/interrupt_service.rs
@@ -8,6 +8,47 @@ use crate::uart;
 use kernel::debug;
 use nrf5x::peripheral_interrupts;
 
+/// Interface for handling interrupts on a hardware chip.
+///
+/// Each chip (or chip version) must implement this trait to handle specific
+/// interrupts. When an interrupt (identified by number) has triggered and
+/// should be handled, the implementation of this trait will be called with the
+/// interrupt number. The implementation can then handle the interrupt, or
+/// return `false` to signify that it does not know how to handle the interrupt.
+///
+/// This functionality is given this `InterruptService` interface so that
+/// multiple objects can be chained together to handle interrupts for a chip.
+/// This is useful for code organization and removing the need for duplication
+/// when multiple variations of a specific microcontroller exist. Then a shared,
+/// base object can handle most interrupts, and variation-specific objects can
+/// handle the variation-specific interrupts.
+///
+/// To simplify structuring the Rust code when using `InterruptService`, the
+/// interrupt number should be passed "top-down". That is, an interrupt to be
+/// handled will first be passed to the `InterruptService` object that is most
+/// specific. If that object cannot handle the interrupt, then it should
+/// maintain a reference to the second most specific object, and return by
+/// calling to that object to handle the interrupt. This continues until the
+/// base object handles the interrupt or decides that the chip does not know how
+/// to handle the interrupt. For example, consider a `nRF52840` chip that
+/// depends on the `nRF52` crate which in turn depends on the `nRF5` crate. If
+/// all three have specific interrupts they know how to handle, the flow would
+/// look like:
+///
+/// ```
+///           +---->nrf52840
+///           |        |
+///           |        |
+///           |        v
+///           |      nrf52
+///           |        |
+///           |        |
+///           |        v
+/// kernel-->nrf5     nrf5
+/// ```
+/// where the kernel instructs the `nrf5` crate to handle interrupts, and if
+/// there is an interrupt ready then that interrupt is passed through the crates
+/// until something can service it.
 pub trait InterruptService {
     /// Service an interrupt, if supported by this chip. If this interrupt number is not supported,
     /// return false.

--- a/chips/nrf52/src/interrupt_service.rs
+++ b/chips/nrf52/src/interrupt_service.rs
@@ -35,7 +35,7 @@ use nrf5x::peripheral_interrupts;
 /// all three have specific interrupts they know how to handle, the flow would
 /// look like:
 ///
-/// ```
+/// ```ignore
 ///           +---->nrf52840
 ///           |        |
 ///           |        |

--- a/chips/nrf52/src/interrupt_service.rs
+++ b/chips/nrf52/src/interrupt_service.rs
@@ -1,0 +1,87 @@
+use crate::adc;
+use crate::ble_radio;
+use crate::i2c;
+use crate::ieee802154_radio;
+use crate::power;
+use crate::spi;
+use crate::uart;
+use kernel::debug;
+use nrf5x::peripheral_interrupts;
+
+pub trait InterruptService {
+    /// Service an interrupt, if supported by this chip. If this interrupt number is not supported,
+    /// return false.
+    unsafe fn service_interrupt(&self, interrupt: u32) -> bool;
+}
+
+pub struct Nrf52InterruptService {
+    gpio_port: &'static nrf5x::gpio::Port,
+}
+
+impl Nrf52InterruptService {
+    pub unsafe fn new(gpio_port: &'static nrf5x::gpio::Port) -> Nrf52InterruptService {
+        Nrf52InterruptService { gpio_port }
+    }
+}
+
+impl InterruptService for Nrf52InterruptService {
+    unsafe fn service_interrupt(&self, interrupt: u32) -> bool {
+        match interrupt {
+            peripheral_interrupts::ECB => nrf5x::aes::AESECB.handle_interrupt(),
+            peripheral_interrupts::GPIOTE => self.gpio_port.handle_interrupt(),
+            peripheral_interrupts::POWER_CLOCK => power::POWER.handle_interrupt(),
+            peripheral_interrupts::RADIO => {
+                match (
+                    ieee802154_radio::RADIO.is_enabled(),
+                    ble_radio::RADIO.is_enabled(),
+                ) {
+                    (false, false) => (),
+                    (true, false) => ieee802154_radio::RADIO.handle_interrupt(),
+                    (false, true) => ble_radio::RADIO.handle_interrupt(),
+                    (true, true) => {
+                        debug!("nRF 802.15.4 and BLE radios cannot be simultaneously enabled!")
+                    }
+                }
+            }
+            peripheral_interrupts::RNG => nrf5x::trng::TRNG.handle_interrupt(),
+            peripheral_interrupts::RTC1 => nrf5x::rtc::RTC.handle_interrupt(),
+            peripheral_interrupts::TEMP => nrf5x::temperature::TEMP.handle_interrupt(),
+            peripheral_interrupts::TIMER0 => nrf5x::timer::TIMER0.handle_interrupt(),
+            peripheral_interrupts::TIMER1 => nrf5x::timer::ALARM1.handle_interrupt(),
+            peripheral_interrupts::TIMER2 => nrf5x::timer::TIMER2.handle_interrupt(),
+            peripheral_interrupts::UART0 => uart::UARTE0.handle_interrupt(),
+            peripheral_interrupts::SPI0_TWI0 => {
+                // SPI0 and TWI0 share interrupts.
+                // Dispatch the correct handler.
+                match (spi::SPIM0.is_enabled(), i2c::TWIM0.is_enabled()) {
+                    (false, false) => (),
+                    (true, false) => spi::SPIM0.handle_interrupt(),
+                    (false, true) => i2c::TWIM0.handle_interrupt(),
+                    (true, true) => debug_assert!(
+                        false,
+                        "SPIM0 and TWIM0 cannot be \
+                         enabled at the same time."
+                    ),
+                }
+            }
+            peripheral_interrupts::SPI1_TWI1 => {
+                // SPI1 and TWI1 share interrupts.
+                // Dispatch the correct handler.
+                match (spi::SPIM1.is_enabled(), i2c::TWIM1.is_enabled()) {
+                    (false, false) => (),
+                    (true, false) => spi::SPIM1.handle_interrupt(),
+                    (false, true) => i2c::TWIM1.handle_interrupt(),
+                    (true, true) => debug_assert!(
+                        false,
+                        "SPIM1 and TWIM1 cannot be \
+                         enabled at the same time."
+                    ),
+                }
+            }
+            peripheral_interrupts::SPIM2_SPIS2_SPI2 => spi::SPIM2.handle_interrupt(),
+            peripheral_interrupts::ADC => adc::ADC.handle_interrupt(),
+            _ => return false,
+        }
+        true
+    }
+}

--- a/chips/nrf52/src/lib.rs
+++ b/chips/nrf52/src/lib.rs
@@ -12,6 +12,7 @@ mod deferred_call_tasks;
 pub mod ficr;
 pub mod i2c;
 pub mod ieee802154_radio;
+pub mod interrupt_service;
 pub mod nvmc;
 pub mod power;
 pub mod ppi;

--- a/chips/nrf52/src/usbd.rs
+++ b/chips/nrf52/src/usbd.rs
@@ -572,6 +572,10 @@ impl<'a> Usbd<'a> {
             registers: USBD_BASE,
         }
     }
+
+    pub fn handle_interrupt(&self) {
+        // TODO
+    }
 }
 
 pub static mut USBD: Usbd<'static> = Usbd::new();

--- a/chips/nrf52832/src/chip.rs
+++ b/chips/nrf52832/src/chip.rs
@@ -1,0 +1,3 @@
+pub use nrf52::chip::NRF52;
+
+pub type Nrf52832InterruptService = nrf52::chip::Nrf52InterruptService;

--- a/chips/nrf52832/src/chip.rs
+++ b/chips/nrf52832/src/chip.rs
@@ -1,12 +1,8 @@
 use crate::interrupt_service::Nrf52832InterruptService;
-use kernel::static_init;
 use nrf52::chip::NRF52;
 
-pub unsafe fn new() -> &'static NRF52<Nrf52832InterruptService> {
-    let interrupt_service = static_init!(Nrf52832InterruptService, Nrf52832InterruptService::new());
-    let chip = static_init!(
-        NRF52<Nrf52832InterruptService>,
-        NRF52::new(interrupt_service)
-    );
-    chip
+pub type Chip = NRF52<Nrf52832InterruptService>;
+
+pub unsafe fn new() -> Chip {
+    NRF52::new(Nrf52832InterruptService::new())
 }

--- a/chips/nrf52832/src/chip.rs
+++ b/chips/nrf52832/src/chip.rs
@@ -3,13 +3,14 @@ use crate::interrupt_service::Nrf52832InterruptService;
 use kernel::static_init;
 use nrf52::chip::NRF52;
 
-pub type Chip = NRF52<Nrf52832InterruptService>;
-
-pub unsafe fn new() -> &'static Chip {
+pub unsafe fn new() -> &'static NRF52<Nrf52832InterruptService> {
     let interrupt_service = static_init!(
         Nrf52832InterruptService,
         Nrf52832InterruptService::new(&gpio::PORT)
     );
-    let chip = static_init!(Chip, NRF52::new(interrupt_service));
+    let chip = static_init!(
+        NRF52<Nrf52832InterruptService>,
+        NRF52::new(interrupt_service)
+    );
     chip
 }

--- a/chips/nrf52832/src/chip.rs
+++ b/chips/nrf52832/src/chip.rs
@@ -1,3 +1,1 @@
 pub use nrf52::chip::NRF52;
-
-pub type Nrf52832InterruptService = nrf52::chip::Nrf52InterruptService;

--- a/chips/nrf52832/src/chip.rs
+++ b/chips/nrf52832/src/chip.rs
@@ -1,13 +1,9 @@
-use crate::gpio;
 use crate::interrupt_service::Nrf52832InterruptService;
 use kernel::static_init;
 use nrf52::chip::NRF52;
 
 pub unsafe fn new() -> &'static NRF52<Nrf52832InterruptService> {
-    let interrupt_service = static_init!(
-        Nrf52832InterruptService,
-        Nrf52832InterruptService::new(&gpio::PORT)
-    );
+    let interrupt_service = static_init!(Nrf52832InterruptService, Nrf52832InterruptService::new());
     let chip = static_init!(
         NRF52<Nrf52832InterruptService>,
         NRF52::new(interrupt_service)

--- a/chips/nrf52832/src/interrupt_service.rs
+++ b/chips/nrf52832/src/interrupt_service.rs
@@ -1,1 +1,21 @@
-pub type Nrf52832InterruptService = nrf52::interrupt_service::Nrf52InterruptService;
+use crate::gpio;
+use nrf52::interrupt_service::InterruptService;
+
+pub struct Nrf52832InterruptService {
+    nrf52: nrf52::interrupt_service::Nrf52InterruptService,
+}
+
+impl Nrf52832InterruptService {
+    pub unsafe fn new() -> Nrf52832InterruptService {
+        Nrf52832InterruptService {
+            nrf52: nrf52::interrupt_service::Nrf52InterruptService::new(&gpio::PORT),
+        }
+    }
+}
+
+impl InterruptService for Nrf52832InterruptService {
+    unsafe fn service_interrupt(&self, interrupt: u32) -> bool {
+        // Add 52832-specific interrupts here.
+        self.nrf52.service_interrupt(interrupt)
+    }
+}

--- a/chips/nrf52832/src/interrupt_service.rs
+++ b/chips/nrf52832/src/interrupt_service.rs
@@ -1,0 +1,1 @@
+pub type Nrf52832InterruptService = nrf52::interrupt_service::Nrf52InterruptService;

--- a/chips/nrf52832/src/lib.rs
+++ b/chips/nrf52832/src/lib.rs
@@ -1,7 +1,8 @@
 #![no_std]
 
 pub use nrf52::{
-    adc, aes, ble_radio, chip, clock, constants, crt1, ficr, i2c, ieee802154_radio, init, nvmc,
+    adc, aes, ble_radio, clock, constants, crt1, ficr, i2c, ieee802154_radio, init, nvmc,
     peripheral_interrupts, pinmux, ppi, pwm, rtc, spi, temperature, timer, trng, uart, uicr,
 };
+pub mod chip;
 pub mod gpio;

--- a/chips/nrf52832/src/lib.rs
+++ b/chips/nrf52832/src/lib.rs
@@ -6,3 +6,4 @@ pub use nrf52::{
 };
 pub mod chip;
 pub mod gpio;
+pub mod interrupt_service;

--- a/chips/nrf52840/src/chip.rs
+++ b/chips/nrf52840/src/chip.rs
@@ -1,0 +1,24 @@
+use crate::peripheral_interrupts;
+use nrf52::chip::InterruptServiceTrait;
+
+pub struct InterruptService {
+    nrf52: nrf52::chip::InterruptService,
+}
+
+impl InterruptService {
+    pub unsafe fn new(gpio_port: &'static nrf52::gpio::Port) -> InterruptService {
+        InterruptService {
+            nrf52: nrf52::chip::InterruptService::new(gpio_port),
+        }
+    }
+}
+
+impl InterruptServiceTrait for InterruptService {
+    unsafe fn service_interrupt(&self, interrupt: u32) -> bool {
+        match interrupt {
+            peripheral_interrupts::USBD => nrf52::usbd::USBD.handle_interrupt(),
+            _ => return self.nrf52.service_interrupt(interrupt),
+        }
+        true
+    }
+}

--- a/chips/nrf52840/src/chip.rs
+++ b/chips/nrf52840/src/chip.rs
@@ -3,13 +3,14 @@ use crate::interrupt_service::Nrf52840InterruptService;
 use kernel::static_init;
 use nrf52::chip::NRF52;
 
-pub type Chip = NRF52<Nrf52840InterruptService>;
-
-pub unsafe fn new() -> &'static Chip {
+pub unsafe fn new() -> &'static NRF52<Nrf52840InterruptService> {
     let interrupt_service = static_init!(
         Nrf52840InterruptService,
         Nrf52840InterruptService::new(&gpio::PORT)
     );
-    let chip = static_init!(Chip, NRF52::new(interrupt_service));
+    let chip = static_init!(
+        NRF52<Nrf52840InterruptService>,
+        NRF52::new(interrupt_service)
+    );
     chip
 }

--- a/chips/nrf52840/src/chip.rs
+++ b/chips/nrf52840/src/chip.rs
@@ -1,12 +1,8 @@
 use crate::interrupt_service::Nrf52840InterruptService;
-use kernel::static_init;
 use nrf52::chip::NRF52;
 
-pub unsafe fn new() -> &'static NRF52<Nrf52840InterruptService> {
-    let interrupt_service = static_init!(Nrf52840InterruptService, Nrf52840InterruptService::new());
-    let chip = static_init!(
-        NRF52<Nrf52840InterruptService>,
-        NRF52::new(interrupt_service)
-    );
-    chip
+pub type Chip = NRF52<Nrf52840InterruptService>;
+
+pub unsafe fn new() -> Chip {
+    NRF52::new(Nrf52840InterruptService::new())
 }

--- a/chips/nrf52840/src/chip.rs
+++ b/chips/nrf52840/src/chip.rs
@@ -1,13 +1,9 @@
-use crate::gpio;
 use crate::interrupt_service::Nrf52840InterruptService;
 use kernel::static_init;
 use nrf52::chip::NRF52;
 
 pub unsafe fn new() -> &'static NRF52<Nrf52840InterruptService> {
-    let interrupt_service = static_init!(
-        Nrf52840InterruptService,
-        Nrf52840InterruptService::new(&gpio::PORT)
-    );
+    let interrupt_service = static_init!(Nrf52840InterruptService, Nrf52840InterruptService::new());
     let chip = static_init!(
         NRF52<Nrf52840InterruptService>,
         NRF52::new(interrupt_service)

--- a/chips/nrf52840/src/chip.rs
+++ b/chips/nrf52840/src/chip.rs
@@ -1,19 +1,19 @@
 use crate::peripheral_interrupts;
-use nrf52::chip::InterruptServiceTrait;
+use nrf52::chip::InterruptService;
 
-pub struct InterruptService {
-    nrf52: nrf52::chip::InterruptService,
+pub struct Nrf52840InterruptService {
+    nrf52: nrf52::chip::Nrf52InterruptService,
 }
 
-impl InterruptService {
-    pub unsafe fn new(gpio_port: &'static nrf52::gpio::Port) -> InterruptService {
-        InterruptService {
-            nrf52: nrf52::chip::InterruptService::new(gpio_port),
+impl Nrf52840InterruptService {
+    pub unsafe fn new(gpio_port: &'static nrf52::gpio::Port) -> Nrf52840InterruptService {
+        Nrf52840InterruptService {
+            nrf52: nrf52::chip::Nrf52InterruptService::new(gpio_port),
         }
     }
 }
 
-impl InterruptServiceTrait for InterruptService {
+impl InterruptService for Nrf52840InterruptService {
     unsafe fn service_interrupt(&self, interrupt: u32) -> bool {
         match interrupt {
             peripheral_interrupts::USBD => nrf52::usbd::USBD.handle_interrupt(),

--- a/chips/nrf52840/src/chip.rs
+++ b/chips/nrf52840/src/chip.rs
@@ -1,14 +1,14 @@
 use crate::gpio;
-use crate::interrupt_service::Nrf52832InterruptService;
+use crate::interrupt_service::Nrf52840InterruptService;
 use kernel::static_init;
 use nrf52::chip::NRF52;
 
-pub type Chip = NRF52<Nrf52832InterruptService>;
+pub type Chip = NRF52<Nrf52840InterruptService>;
 
 pub unsafe fn new() -> &'static Chip {
     let interrupt_service = static_init!(
-        Nrf52832InterruptService,
-        Nrf52832InterruptService::new(&gpio::PORT)
+        Nrf52840InterruptService,
+        Nrf52840InterruptService::new(&gpio::PORT)
     );
     let chip = static_init!(Chip, NRF52::new(interrupt_service));
     chip

--- a/chips/nrf52840/src/interrupt_service.rs
+++ b/chips/nrf52840/src/interrupt_service.rs
@@ -1,3 +1,4 @@
+use crate::gpio;
 use crate::peripheral_interrupts;
 use nrf52::interrupt_service::InterruptService;
 
@@ -6,9 +7,9 @@ pub struct Nrf52840InterruptService {
 }
 
 impl Nrf52840InterruptService {
-    pub unsafe fn new(gpio_port: &'static nrf52::gpio::Port) -> Nrf52840InterruptService {
+    pub unsafe fn new() -> Nrf52840InterruptService {
         Nrf52840InterruptService {
-            nrf52: nrf52::interrupt_service::Nrf52InterruptService::new(gpio_port),
+            nrf52: nrf52::interrupt_service::Nrf52InterruptService::new(&gpio::PORT),
         }
     }
 }

--- a/chips/nrf52840/src/interrupt_service.rs
+++ b/chips/nrf52840/src/interrupt_service.rs
@@ -1,14 +1,14 @@
 use crate::peripheral_interrupts;
-use nrf52::chip::InterruptService;
+use nrf52::interrupt_service::InterruptService;
 
 pub struct Nrf52840InterruptService {
-    nrf52: nrf52::chip::Nrf52InterruptService,
+    nrf52: nrf52::interrupt_service::Nrf52InterruptService,
 }
 
 impl Nrf52840InterruptService {
     pub unsafe fn new(gpio_port: &'static nrf52::gpio::Port) -> Nrf52840InterruptService {
         Nrf52840InterruptService {
-            nrf52: nrf52::chip::Nrf52InterruptService::new(gpio_port),
+            nrf52: nrf52::interrupt_service::Nrf52InterruptService::new(gpio_port),
         }
     }
 }

--- a/chips/nrf52840/src/lib.rs
+++ b/chips/nrf52840/src/lib.rs
@@ -1,7 +1,10 @@
 #![no_std]
 
 pub use nrf52::{
-    adc, aes, ble_radio, chip, clock, constants, crt1, ficr, i2c, ieee802154_radio, init, nvmc,
-    peripheral_interrupts, pinmux, ppi, pwm, rtc, spi, temperature, timer, trng, uart, uicr,
+    adc, aes, ble_radio, clock, constants, crt1, ficr, i2c, ieee802154_radio, init, nvmc, pinmux,
+    ppi, pwm, rtc, spi, temperature, timer, trng, uart, uicr,
 };
+pub mod chip;
 pub mod gpio;
+
+mod peripheral_interrupts;

--- a/chips/nrf52840/src/lib.rs
+++ b/chips/nrf52840/src/lib.rs
@@ -1,10 +1,10 @@
 #![no_std]
 
 pub use nrf52::{
-    adc, aes, ble_radio, clock, constants, crt1, ficr, i2c, ieee802154_radio, init, nvmc, pinmux,
-    ppi, pwm, rtc, spi, temperature, timer, trng, uart, uicr,
+    adc, aes, ble_radio, chip, clock, constants, crt1, ficr, i2c, ieee802154_radio, init, nvmc,
+    pinmux, ppi, pwm, rtc, spi, temperature, timer, trng, uart, uicr,
 };
-pub mod chip;
 pub mod gpio;
+pub mod interrupt_service;
 
 mod peripheral_interrupts;

--- a/chips/nrf52840/src/lib.rs
+++ b/chips/nrf52840/src/lib.rs
@@ -1,9 +1,10 @@
 #![no_std]
 
 pub use nrf52::{
-    adc, aes, ble_radio, chip, clock, constants, crt1, ficr, i2c, ieee802154_radio, init, nvmc,
-    pinmux, ppi, pwm, rtc, spi, temperature, timer, trng, uart, uicr,
+    adc, aes, ble_radio, clock, constants, crt1, ficr, i2c, ieee802154_radio, init, nvmc, pinmux,
+    ppi, pwm, rtc, spi, temperature, timer, trng, uart, uicr,
 };
+pub mod chip;
 pub mod gpio;
 pub mod interrupt_service;
 

--- a/chips/nrf52840/src/peripheral_interrupts.rs
+++ b/chips/nrf52840/src/peripheral_interrupts.rs
@@ -1,0 +1,11 @@
+pub const USBD: u32 = 39;
+#[allow(dead_code)]
+pub const UART1: u32 = 40;
+#[allow(dead_code)]
+pub const QSPI: u32 = 41;
+#[allow(dead_code)]
+pub const CRYPTOCELL: u32 = 42;
+#[allow(dead_code)]
+pub const PWM3: u32 = 45;
+#[allow(dead_code)]
+pub const SPIM3: u32 = 47;

--- a/chips/nrf5x/src/peripheral_interrupts.rs
+++ b/chips/nrf5x/src/peripheral_interrupts.rs
@@ -47,11 +47,3 @@ pub const RTC2: u32 = 36;
 pub const I2S: u32 = 37;
 #[cfg(feature = "nrf52")]
 pub const FPU: u32 = 38;
-
-// Interrupts specific to nrf52840.
-pub const USBD: u32 = 39;
-pub const UART1: u32 = 40;
-pub const QSPI: u32 = 41;
-pub const CRYPTOCELL: u32 = 42;
-pub const PWM3: u32 = 45;
-pub const SPIM3: u32 = 47;


### PR DESCRIPTION
### Pull Request Overview

This pull request implements https://github.com/tock/tock/issues/1501 for the Nordic chips.

For now, this also adds the USB interrupt handler to the `nrf52840` chip, but more nrf52840-specific interrupt handlers (as listed in `chips/nrf52840/src/peripheral_interrupts.rs`) can be added afterwards.


### Testing Strategy

This pull request was tested with the nRF52840-DK and nRF52840-Dongle boards.


### TODO or Help Wanted

This implementation works, but any feedback on the design is welcome.


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.