### PR TITLE
Add cargo test for capsules on ci-travis.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,13 +64,17 @@ ci-travis:
 	@printf "$$(tput bold)*************$$(tput sgr0)\n"
 	@for f in `./tools/list_chips.sh`; do echo "$$(tput bold)Test $$f"; cd chips/$$f; CI=true TOCK_KERNEL_VERSION=ci_test cargo test || exit 1; cd ../..; done
 	@printf "$$(tput bold)**************$$(tput sgr0)\n"
-	@printf "$$(tput bold)* CI: Syntax *$$(tput sgr0)\n"
-	@printf "$$(tput bold)**************$$(tput sgr0)\n"
-	@CI=true $(MAKE) allcheck
-	@printf "$$(tput bold)**************$$(tput sgr0)\n"
 	@printf "$$(tput bold)* CI: Kernel *$$(tput sgr0)\n"
 	@printf "$$(tput bold)**************$$(tput sgr0)\n"
 	@cd kernel && CI=true TOCK_KERNEL_VERSION=ci_test cargo test
+	@printf "$$(tput bold)**************$$(tput sgr0)\n"
+	@printf "$$(tput bold)* CI: Capsules *$$(tput sgr0)\n"
+	@printf "$$(tput bold)**************$$(tput sgr0)\n"
+	@cd capsules && CI=true TOCK_KERNEL_VERSION=ci_test cargo test
+	@printf "$$(tput bold)**************$$(tput sgr0)\n"
+	@printf "$$(tput bold)* CI: Syntax *$$(tput sgr0)\n"
+	@printf "$$(tput bold)**************$$(tput sgr0)\n"
+	@CI=true $(MAKE) allcheck
 	@printf "$$(tput bold)*******************$$(tput sgr0)\n"
 	@printf "$$(tput bold)* CI: Compilation *$$(tput sgr0)\n"
 	@printf "$$(tput bold)*******************$$(tput sgr0)\n"

--- a/capsules/examples/traitobj_list.rs
+++ b/capsules/examples/traitobj_list.rs
@@ -16,22 +16,26 @@
 //! manager.report();
 //! ```
 
-use kernel::common::list::{List, ListLink, ListNode};
+// Dummy main function for this example to compile with `cargo test`.
+fn main() {}
 
-pub trait Funky<'a> {
+use kernel::common::list::{List, ListLink, ListNode};
+use kernel::debug;
+
+pub trait Funky<'a>: 'a {
     fn name(&self) -> &'static str;
-    fn next_funky_thing(&'a self) -> &'a ListLink<'a, Funky<'a>>;
+    fn next_funky_thing(&'a self) -> &'a ListLink<'a, dyn Funky<'a>>;
 }
 
-impl<'a> ListNode<'a, Funky<'a>> for Funky<'a> {
-    fn next(&'a self) -> &'a ListLink<'a, Funky<'a>> {
+impl<'a> ListNode<'a, dyn Funky<'a>> for dyn Funky<'a> {
+    fn next(&'a self) -> &'a ListLink<'a, dyn Funky<'a>> {
         &self.next_funky_thing()
     }
 }
 
 // A manager holds a list of funky things
 pub struct Manager<'a> {
-    funky_things: List<'a, Funky<'a>>,
+    funky_things: List<'a, dyn Funky<'a>>,
 }
 
 impl<'a> Manager<'a> {
@@ -41,7 +45,7 @@ impl<'a> Manager<'a> {
         }
     }
 
-    pub fn manage(&mut self, thing: &'a (Funky<'a>)) {
+    pub fn manage(&mut self, thing: &'a (dyn Funky<'a>)) {
         self.funky_things.push_head(thing);
     }
 
@@ -54,7 +58,7 @@ impl<'a> Manager<'a> {
 
 // Jazz is a funky thing
 pub struct Jazz<'a> {
-    next: ListLink<'a, Funky<'a>>,
+    next: ListLink<'a, dyn Funky<'a>>,
 }
 
 impl<'a> Jazz<'a> {
@@ -70,14 +74,14 @@ impl<'a> Funky<'a> for Jazz<'a> {
         "Jazz"
     }
 
-    fn next_funky_thing(&'a self) -> &'a ListLink<'a, Funky<'a>> {
+    fn next_funky_thing(&'a self) -> &'a ListLink<'a, dyn Funky<'a>> {
         &self.next
     }
 }
 
 // Cheese is a funky thing
 pub struct Cheese<'a> {
-    next: ListLink<'a, Funky<'a>>,
+    next: ListLink<'a, dyn Funky<'a>>,
 }
 
 impl<'a> Cheese<'a> {
@@ -92,7 +96,7 @@ impl<'a> Funky<'a> for Cheese<'a> {
     fn name(&self) -> &'static str {
         "Cheese"
     }
-    fn next_funky_thing(&'a self) -> &'a ListLink<'a, Funky<'a>> {
+    fn next_funky_thing(&'a self) -> &'a ListLink<'a, dyn Funky<'a>> {
         &self.next
     }
 }

--- a/capsules/src/adc.rs
+++ b/capsules/src/adc.rs
@@ -4,7 +4,9 @@
 //! Usage
 //! -----
 //!
-//! ```
+//! ```rust
+//! # use kernel::static_init;
+//!
 //! let adc_channels = static_init!(
 //!     [&'static sam4l::adc::AdcChannel; 6],
 //!     [

--- a/capsules/src/aes_ccm.rs
+++ b/capsules/src/aes_ccm.rs
@@ -39,7 +39,10 @@
 //! Usage
 //! -----
 //!
-//! ```
+//! ```rust
+//! # use kernel::static_init;
+//! # use kernel::hil::symmetric_encryption;
+//!
 //! const CRYPT_SIZE: usize = 3 * symmetric_encryption::AES128_BLOCK_SIZE + radio::MAX_BUF_SIZE;
 //! static mut CRYPT_BUF: [u8; CRYPT_SIZE] = [0x00; CRYPT_SIZE];
 //!

--- a/capsules/src/ambient_light.rs
+++ b/capsules/src/ambient_light.rs
@@ -3,10 +3,12 @@
 //! You need a device that provides the `hil::sensors::AmbientLight` trait.
 //!
 //! ```rust
+//! # use kernel::{hil, static_init};
+//!
 //! let light = static_init!(
-//!     capsules::sensors::AmbientLight<'static>,
-//!     capsules::sensors::AmbientLight::new(isl29035,
-//!         kernel::Grant::create()));
+//!     capsules::ambient_light::AmbientLight<'static>,
+//!     capsules::ambient_light::AmbientLight::new(isl29035,
+//!         board_kernel.create_grant(&grant_cap)));
 //! hil::sensors::AmbientLight::set_client(isl29035, ambient_light);
 //! ```
 

--- a/capsules/src/analog_comparator.rs
+++ b/capsules/src/analog_comparator.rs
@@ -3,7 +3,9 @@
 //! Usage
 //! -----
 //!
-//! ```
+//! ```rust
+//! # use kernel::static_init;
+//!
 //! let ac_channels = static_init!(
 //!     [&'static sam4l::acifc::AcChannel; 2],
 //!     [

--- a/capsules/src/app_flash_driver.rs
+++ b/capsules/src/app_flash_driver.rs
@@ -13,11 +13,13 @@
 //! -----
 //!
 //! ```
+//! # use kernel::static_init;
+//!
 //! pub static mut APP_FLASH_BUFFER: [u8; 512] = [0; 512];
 //! let app_flash = static_init!(
 //!     capsules::app_flash_driver::AppFlash<'static>,
 //!     capsules::app_flash_driver::AppFlash::new(nv_to_page,
-//!         kernel::Grant::create(), &mut APP_FLASH_BUFFER));
+//!         board_kernel.create_grant(&grant_cap), &mut APP_FLASH_BUFFER));
 //! ```
 
 use core::cmp;

--- a/capsules/src/ble_advertising_driver.rs
+++ b/capsules/src/ble_advertising_driver.rs
@@ -63,19 +63,24 @@
 //! timer to perform events and not block the entire kernel
 //!
 //! ```rust
-//!     let ble_radio = static_init!(
-//!     nrf5x::ble_advertising_driver::BLE
-//!     <'static, nrf52::radio::Radio, VirtualMuxAlarm<'static, Rtc>>,
-//!     nrf5x::ble_advertising_driver::BLE::new(
-//!         &mut nrf52::radio::RADIO,
-//!     kernel::Grant::create(),
-//!         &mut nrf5x::ble_advertising_driver::BUF,
-//!         ble_radio_virtual_alarm));
-//!    nrf5x::ble_advertising_hil::BleAdvertisementDriver::set_rx_client(&nrf52::radio::RADIO,
-//!                                                                      ble_radio);
-//!    nrf5x::ble_advertising_hil::BleAdvertisementDriver::set_tx_client(&nrf52::radio::RADIO,
-//!                                                                      ble_radio);
-//!    ble_radio_virtual_alarm.set_client(ble_radio);
+//! # use kernel::static_init;
+//! # use capsules::virtual_alarm::VirtualMuxAlarm;
+//!
+//! let ble_radio = static_init!(
+//! nrf5x::ble_advertising_driver::BLE<
+//!     'static,
+//!     nrf52::radio::Radio, VirtualMuxAlarm<'static, Rtc>
+//! >,
+//! nrf5x::ble_advertising_driver::BLE::new(
+//!     &mut nrf52::radio::RADIO,
+//!     board_kernel.create_grant(&grant_cap),
+//!     &mut nrf5x::ble_advertising_driver::BUF,
+//!     ble_radio_virtual_alarm));
+//! nrf5x::ble_advertising_hil::BleAdvertisementDriver::set_rx_client(&nrf52::radio::RADIO,
+//!                                                                   ble_radio);
+//! nrf5x::ble_advertising_hil::BleAdvertisementDriver::set_tx_client(&nrf52::radio::RADIO,
+//!                                                                   ble_radio);
+//! ble_radio_virtual_alarm.set_client(ble_radio);
 //! ```
 //!
 //! ### Authors

--- a/capsules/src/button.rs
+++ b/capsules/src/button.rs
@@ -8,12 +8,14 @@
 //! -----
 //!
 //! ```rust
+//! # use kernel::static_init;
+//!
 //! let button_pins = static_init!(
 //!     [&'static sam4l::gpio::GPIOPin; 1],
 //!     [&sam4l::gpio::PA[16]]);
 //! let button = static_init!(
-//!     capsules::button::Button<'static, sam4l::gpio::GPIOPin>,
-//!     capsules::button::Button::new(button_pins, kernel::Grant::create()));
+//!     capsules::button::Button<'static>,
+//!     capsules::button::Button::new(button_pins, board_kernel.create_grant(&grant_cap)));
 //! for btn in button_pins.iter() {
 //!     btn.set_client(button);
 //! }

--- a/capsules/src/buzzer_driver.rs
+++ b/capsules/src/buzzer_driver.rs
@@ -11,7 +11,9 @@
 //! Usage
 //! -----
 //!
-//! ```
+//! ```rust
+//! # use kernel::static_init;
+//!
 //! let virtual_pwm_buzzer = static_init!(
 //!     capsules::virtual_pwm::PwmPinUser<'static, nrf52::pwm::Pwm>,
 //!     capsules::virtual_pwm::PwmPinUser::new(mux_pwm, nrf5x::pinmux::Pinmux::new(31))
@@ -31,7 +33,7 @@
 //!         virtual_pwm_buzzer,
 //!         virtual_alarm_buzzer,
 //!         capsules::buzzer_driver::DEFAULT_MAX_BUZZ_TIME_MS,
-//!         kernel::Grant::create())
+//!         board_kernel.create_grant(&grant_cap))
 //! );
 //! virtual_alarm_buzzer.set_client(buzzer);
 //! ```

--- a/capsules/src/console.rs
+++ b/capsules/src/console.rs
@@ -6,13 +6,16 @@
 //! You need a device that provides the `hil::uart::UART` trait.
 //!
 //! ```rust
+//! # use kernel::static_init;
+//! # use capsules::console::Console;
+//!
 //! let console = static_init!(
 //!     Console<usart::USART>,
 //!     Console::new(&usart::USART0,
 //!                  115200,
 //!                  &mut console::WRITE_BUF,
 //!                  &mut console::READ_BUF,
-//!                  kernel::Grant::create()));
+//!                  board_kernel.create_grant(&grant_cap)));
 //! hil::uart::UART::set_client(&usart::USART0, console);
 //! ```
 //!

--- a/capsules/src/crc.rs
+++ b/capsules/src/crc.rs
@@ -8,9 +8,11 @@
 //! driver:
 //!
 //! ```rust
+//! # use kernel::static_init;
+//!
 //! let crc = static_init!(
 //!     capsules::crc::Crc<'static, sam4l::crccu::Crccu<'static>>,
-//!     capsules::crc::Crc::new(&mut sam4l::crccu::CRCCU, kernel::Grant::create()));
+//!     capsules::crc::Crc::new(&mut sam4l::crccu::CRCCU, board_kernel.create_grant(&grant_cap)));
 //! sam4l::crccu::CRCCU.set_client(crc);
 //!
 //! ```
@@ -103,9 +105,8 @@ impl<C: hil::crc::CRC> Crc<'a, C> {
     ///
     /// ## Example
     ///
-    /// ```
-    /// capsules::crc::Crc::new(&sam4l::crccu::CRCCU, kernel::Grant::create()),
-    ///
+    /// ```rust
+    /// capsules::crc::Crc::new(&sam4l::crccu::CRCCU, board_kernel.create_grant(&grant_cap));
     /// ```
     ///
     pub fn new(crc_unit: &'a C, apps: Grant<App>) -> Crc<'a, C> {
@@ -194,7 +195,9 @@ impl<C: hil::crc::CRC> Driver for Crc<'a, C> {
     /// result of a CRC computation.  The signature of the callback is
     ///
     /// ```
-    /// fn callback(status, result);
+    /// # use kernel::ReturnCode;
+    ///
+    /// fn callback(status: ReturnCode, result: usize) {}
     /// ```
     ///
     /// where

--- a/capsules/src/dac.rs
+++ b/capsules/src/dac.rs
@@ -4,6 +4,8 @@
 //! -----
 //!
 //! ```rust
+//! # use kernel::static_init;
+//!
 //! let dac = static_init!(
 //!     capsules::dac::Dac<'static>,
 //!     capsules::dac::Dac::new(&mut sam4l::dac::DAC));

--- a/capsules/src/debug_process_restart.rs
+++ b/capsules/src/debug_process_restart.rs
@@ -7,6 +7,8 @@
 //! -----
 //!
 //! ```rust
+//! # use kernel::{capabilities, static_init};
+//!
 //! struct ProcessMgmtCap;
 //! unsafe impl capabilities::ProcessManagementCapability for ProcessMgmtCap {}
 //! let debug_process_restart = static_init!(

--- a/capsules/src/fm25cl.rs
+++ b/capsules/src/fm25cl.rs
@@ -15,6 +15,8 @@
 //! -----
 //!
 //! ```rust
+//! # use kernel::static_init;
+//!
 //! // Create a SPI device for this chip.
 //! let fm25cl_spi = static_init!(
 //!     capsules::virtual_spi::VirtualSpiMasterDevice<'static, usart::USART>,

--- a/capsules/src/fxos8700cq.rs
+++ b/capsules/src/fxos8700cq.rs
@@ -9,6 +9,8 @@
 //! -----
 //!
 //! ```rust
+//! # use kernel::static_init;
+//!
 //! let fxos8700_i2c = static_init!(I2CDevice, I2CDevice::new(i2c_bus, 0x1e));
 //! let fxos8700 = static_init!(
 //!     capsules::fxos8700cq::Fxos8700cq<'static>,

--- a/capsules/src/gpio.rs
+++ b/capsules/src/gpio.rs
@@ -12,6 +12,8 @@
 //! -----
 //!
 //! ```rust
+//! # use kernel::static_init;
+//!
 //! let gpio_pins = static_init!(
 //!     [&'static sam4l::gpio::GPIOPin; 4],
 //!     [&sam4l::gpio::PB[14],

--- a/capsules/src/gpio_async.rs
+++ b/capsules/src/gpio_async.rs
@@ -8,13 +8,15 @@
 //! -----
 //!
 //! ```rust
-//! Generate a list of ports to group into one userspace driver.
+//! # use kernel::static_init;
+//!
+//! // Generate a list of ports to group into one userspace driver.
 //! let async_gpio_ports = static_init!(
-//!     [&'static capsules::mcp23008::MCP23008; 1],
+//!     [&'static capsules::mcp230xx::MCP230xx; 1],
 //!     [mcp23008]);
 //!
 //! let gpio_async = static_init!(
-//!     capsules::gpio_async::GPIOAsync<'static, capsules::mcp23008::MCP23008<'static>>,
+//!     capsules::gpio_async::GPIOAsync<'static, capsules::mcp230xx::MCP230xx<'static>>,
 //!     capsules::gpio_async::GPIOAsync::new(async_gpio_ports));
 //!
 //! // Setup the clients correctly.

--- a/capsules/src/humidity.rs
+++ b/capsules/src/humidity.rs
@@ -39,10 +39,12 @@
 //! You need a device that provides the `hil::sensors::HumidityDriver` trait.
 //!
 //! ```rust
+//! # use kernel::static_init;
+//!
 //! let humidity = static_init!(
 //!        capsules::humidity::HumiditySensor<'static>,
 //!        capsules::humidity::HumiditySensor::new(si7021,
-//!                                                kernel::Grant::create()));
+//!                                                board_kernel.create_grant(&grant_cap)));
 //! kernel::hil::sensors::HumidityDriver::set_client(si7021, humidity);
 //! ```
 

--- a/capsules/src/ieee802154/framer.rs
+++ b/capsules/src/ieee802154/framer.rs
@@ -54,9 +54,11 @@
 //! 802.15.4 frames:
 //!
 //! ```rust
+//! # use kernel::static_init;
+//!
 //! let radio_capsule = static_init!(
 //!     capsules::ieee802154::RadioDriver<'static>,
-//!     capsules::ieee802154::RadioDriver::new(mac_device, kernel::Grant::create(), &mut RADIO_BUF));
+//!     capsules::ieee802154::RadioDriver::new(mac_device, board_kernel.create_grant(&grant_cap), &mut RADIO_BUF));
 //! mac_device.set_key_procedure(radio_capsule);
 //! mac_device.set_device_procedure(radio_capsule);
 //! mac_device.set_transmit_client(radio_capsule);

--- a/capsules/src/ieee802154/virtual_mac.rs
+++ b/capsules/src/ieee802154/virtual_mac.rs
@@ -12,6 +12,8 @@
 //! -----
 //!
 //! ```
+//! # use kernel::static_init;
+//!
 //! // Create the mux.
 //! let mux_mac = static_init!(
 //!     capsules::ieee802154::virtual_mac::MuxMac<'static>,

--- a/capsules/src/ieee802154/xmac.rs
+++ b/capsules/src/ieee802154/xmac.rs
@@ -33,6 +33,8 @@
 //! necessary modifications to the board configuration are shown below for `imix`s:
 //!
 //! ```rust
+//! # use kernel::static_init;
+//!
 //! // main.rs
 //!
 //! use capsules::ieee802154::mac::Mac;

--- a/capsules/src/isl29035.rs
+++ b/capsules/src/isl29035.rs
@@ -13,6 +13,9 @@
 //! -----
 //!
 //! ```rust
+//! # use kernel::static_init;
+//! # use capsules::virtual_alarm::VirtualMuxAlarm;
+//!
 //! let isl29035_i2c = static_init!(I2CDevice, I2CDevice::new(i2c_bus, 0x44));
 //! let isl29035_virtual_alarm = static_init!(
 //!     VirtualMuxAlarm<'static, sam4l::ast::Ast>,

--- a/capsules/src/led.rs
+++ b/capsules/src/led.rs
@@ -13,6 +13,8 @@
 //! -----
 //!
 //! ```rust
+//! # use kernel::static_init;
+//!
 //! let led_pins = static_init!(
 //!     [(&'static sam4l::gpio::GPIOPin, kernel::hil::gpio::ActivationMode); 3],
 //!     [(&sam4l::gpio::PA[13], kernel::hil::gpio::ActivationMode::ActiveLow),   // Red

--- a/capsules/src/lps25hb.rs
+++ b/capsules/src/lps25hb.rs
@@ -6,6 +6,8 @@
 //! -----
 //!
 //! ```rust
+//! # use kernel::static_init;
+//!
 //! let lps25hb_i2c = static_init!(I2CDevice, I2CDevice::new(i2c_bus, 0x5C));
 //! let lps25hb = static_init!(
 //!     capsules::lps25hb::LPS25HB<'static>,

--- a/capsules/src/ltc294x.rs
+++ b/capsules/src/ltc294x.rs
@@ -27,6 +27,8 @@
 //! Here is a sample usage of this capsule in a board's main.rs file:
 //!
 //! ```rust
+//! # use kernel::static_init;
+//!
 //! let ltc294x_i2c = static_init!(
 //!     capsules::virtual_i2c::I2CDevice,
 //!     capsules::virtual_i2c::I2CDevice::new(i2c_mux, 0x64));

--- a/capsules/src/max17205.rs
+++ b/capsules/src/max17205.rs
@@ -13,6 +13,8 @@
 //! -----
 //!
 //! ```rust
+//! # use kernel::static_init;
+//!
 //! // Two i2c addresses are necessary.
 //! // Registers 0x000-0x0FF are accessed by address 0x36.
 //! // Registers 0x100-0x1FF are accessed by address 0x0B.

--- a/capsules/src/mcp230xx.rs
+++ b/capsules/src/mcp230xx.rs
@@ -26,27 +26,29 @@
 //! Example usage:
 //!
 //! ```rust
+//! # use kernel::static_init;
+//!
 //! // Configure the MCP230xx. Device address 0x20.
-//! let mcp23008_i2c = static_init!(
+//! let mcp230xx_i2c = static_init!(
 //!     capsules::virtual_i2c::I2CDevice,
 //!     capsules::virtual_i2c::I2CDevice::new(i2c_mux, 0x20));
-//! let mcp23008 = static_init!(
+//! let mcp230xx = static_init!(
 //!     capsules::mcp230xx::MCP230xx<'static>,
-//!     capsules::mcp230xx::MCP230xx::new(mcp23008_i2c,
+//!     capsules::mcp230xx::MCP230xx::new(mcp230xx_i2c,
 //!                                       Some(&sam4l::gpio::PA[04]),
 //!                                       None,
-//!                                       &mut capsules::mcp23008::BUFFER,
+//!                                       &mut capsules::mcp230xx::BUFFER,
 //!                                       8, // How many pins in a bank
 //!                                       1, // How many pin banks on the chip
 //!                                       ));
-//! mcp23008_i2c.set_client(mcp23008);
-//! sam4l::gpio::PA[04].set_client(mcp23008);
+//! mcp230xx_i2c.set_client(mcp230xx);
+//! sam4l::gpio::PA[04].set_client(mcp230xx);
 //!
 //! // Create an array of the GPIO extenders so we can pass them to an
 //! // administrative layer that provides a single interface to them all.
 //! let async_gpio_ports = static_init!(
 //!     [&'static capsules::mcp230xx::MCP230xx; 1],
-//!     [mcp23008]);
+//!     [mcp230xx]);
 //!
 //! // `gpio_async` is the object that manages all of the extenders.
 //! let gpio_async = static_init!(

--- a/capsules/src/mx25r6435f.rs
+++ b/capsules/src/mx25r6435f.rs
@@ -16,6 +16,9 @@
 //! -----
 //!
 //! ```rust
+//! # use kernel::static_init;
+//! # use capsules::virtual_alarm::VirtualMuxAlarm;
+//!
 //! // Create a SPI device for this chip.
 //! let mx25r6435f_spi = static_init!(
 //!     capsules::virtual_spi::VirtualSpiMasterDevice<'static, nrf52::spi::SPIM>,
@@ -68,6 +71,8 @@ const PAGE_SIZE: u32 = 256;
 /// An example looks like:
 ///
 /// ```
+/// # use capsules::mx25r6435f::Mx25r6435fSector;
+///
 /// static mut PAGEBUFFER: Mx25r6435fSector = Mx25r6435fSector::new();
 /// ```
 pub struct Mx25r6435fSector(pub [u8; SECTOR_SIZE as usize]);

--- a/capsules/src/net/ipv6/ipv6.rs
+++ b/capsules/src/net/ipv6/ipv6.rs
@@ -8,6 +8,7 @@
 //! An implementation for the structure of an IPv6 packet is provided by this
 //! file, and a rough outline is given below:
 //!
+//! ```txt
 //!            ----------------------------------------------
 //!            |                 IP6Packet                  |
 //!            |--------------------------------------------|
@@ -15,6 +16,7 @@
 //!            |    IP6Header    |--------------------------|
 //!            |                 |TransportHeader | Payload |
 //!            ----------------------------------------------
+//! ```
 //!
 //! The [IP6Packet](struct.IP6Packet.html) struct contains an
 //! [IP6Header](struct.IP6Header.html) struct and an

--- a/capsules/src/net/sixlowpan/sixlowpan_state.rs
+++ b/capsules/src/net/sixlowpan/sixlowpan_state.rs
@@ -40,7 +40,7 @@
 //! At a high level, clients interact with this module as shown in the diagrams
 //! below:
 //!
-//! ```
+//! ```txt
 //! Transmit:
 //!
 //!           +-----------+
@@ -67,7 +67,7 @@
 //!            +---------+
 //! ```
 //!
-//! ```
+//! ```txt
 //! Receive:
 //!
 //!         +---------------+
@@ -82,7 +82,7 @@
 //!           +---------+
 //! ```
 //!
-//! ```
+//! ```txt
 //! Initialization:
 //!
 //!           +-----------+

--- a/capsules/src/net/stream.rs
+++ b/capsules/src/net/stream.rs
@@ -130,7 +130,10 @@ macro_rules! stream_from_option {
 /// would result in it defaulting to 0. Idiomatically, the way to combine
 /// encoders is to define another encoder as follows:
 ///
-/// ```
+/// ```rust
+/// # use capsules::{enc_try, stream_done};
+/// # use capsules::net::stream::SResult;
+///
 /// // call a simple encoder
 /// let (bytes, out1) = enc_try!(buf; encoder1);
 /// /* Do something with out1 */
@@ -150,6 +153,8 @@ macro_rules! stream_from_option {
 /// Then, using an encoder can be done simply by:
 ///
 /// ```
+/// # use capsules::net::stream::SResult;
+///
 /// match encoder(&mut buf) {
 ///     SResult::Done(off, out) => { /* celebrate */ }
 ///     SResult::Needed(off) => { /* get more memory? */ }

--- a/capsules/src/net/thread/tlv.rs
+++ b/capsules/src/net/thread/tlv.rs
@@ -12,20 +12,20 @@
 //! MLE for network attaching comprises a four-step handshake that works
 //! as follows:
 //!
-//!     1. A child device multicasts a Parent Request MLE command.
-//!     2. Each potential parent device on the network unicasts a Parent
-//!        Response MLE command.
-//!     3. The child device selects a parent based on a hierarchy of
-//!        connectivity metrics and unicasts a Child ID Request MLE
-//!        command.
-//!     4. The selected parent unicasts a Child ID Response MLE command.
+//! 1. A child device multicasts a Parent Request MLE command.
+//! 2. Each potential parent device on the network unicasts a Parent
+//!    Response MLE command.
+//! 3. The child device selects a parent based on a hierarchy of
+//!    connectivity metrics and unicasts a Child ID Request MLE
+//!    command.
+//! 4. The selected parent unicasts a Child ID Response MLE command.
 //!
 //! A TLV is comprised of three parts:
 //!
-//!     1. Type   - A one-byte TLV type number.
-//!     2. Length - A one-byte number representing the length of the TLV
-//!                 value in bytes.
-//!     3. Value  - The TLV value.
+//! 1. Type   - A one-byte TLV type number.
+//! 2. Length - A one-byte number representing the length of the TLV
+//!             value in bytes.
+//! 3. Value  - The TLV value.
 //!
 //! For some TLVs, the TLV type number is shifted left by one to leave the
 //! least significant bit to denote whether information in the TLV value

--- a/capsules/src/net/udp/driver.rs
+++ b/capsules/src/net/udp/driver.rs
@@ -456,7 +456,6 @@ impl<'a> Driver for UDPDriver<'a> {
     ///        Currently, only will transmit if the app has bound to the port passed in the tx_cfg
     ///        buf as the source address. If no port is bound, returns ERESERVE, if it tries to
     ///        send on a port other than the port which is bound, returns EINVALID.
-    ///
     ///        Notably, the currently transmit implementation allows for starvation - an
     ///        an app with a lower app id can send constantly and starve an app with a
     ///        later ID.

--- a/capsules/src/ninedof.rs
+++ b/capsules/src/ninedof.rs
@@ -6,13 +6,15 @@
 //! You need a device that provides the `hil::sensors::NineDof` trait.
 //!
 //! ```rust
+//! # use kernel::{hil, static_init};
 //!
 //! let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
 //! let grant_ninedof = board_kernel.create_grant(&grant_cap);
 //!
 //! let ninedof = static_init!(
 //!     capsules::ninedof::NineDof<'static>,
-//!     capsules::ninedof::NineDof::new(fxos8700, grant_ninedof));
+//!     capsules::ninedof::NineDof::new(fxos8700, board_kernel.create_grant(&grant_ninedof));
+//!
 //! hil::sensors::NineDof::set_client(fxos8700, ninedof);
 //! ```
 

--- a/capsules/src/nonvolatile_storage_driver.rs
+++ b/capsules/src/nonvolatile_storage_driver.rs
@@ -37,11 +37,13 @@
 //! Example instantiation:
 //!
 //! ```rust
+//! # use kernel::static_init;
+//!
 //! let nonvolatile_storage = static_init!(
 //!     capsules::nonvolatile_storage_driver::NonvolatileStorage<'static>,
 //!     capsules::nonvolatile_storage_driver::NonvolatileStorage::new(
 //!         fm25cl,                      // The underlying storage driver.
-//!         kernel::Grant::create(),     // Storage for app-specific state.
+//!         board_kernel.create_grant(&grant_cap),     // Storage for app-specific state.
 //!         3000,                        // The byte start address for the userspace
 //!                                      // accessible memory region.
 //!         2000,                        // The length of the userspace region.

--- a/capsules/src/nonvolatile_to_pages.rs
+++ b/capsules/src/nonvolatile_to_pages.rs
@@ -20,7 +20,9 @@
 //! Usage
 //! -----
 //!
-//! ```
+//! ```rust
+//! # use kernel::{hil, static_init};
+//!
 //! sam4l::flashcalw::FLASH_CONTROLLER.configure();
 //! pub static mut PAGEBUFFER: sam4l::flashcalw::Sam4lPage = sam4l::flashcalw::Sam4lPage::new();
 //! let nv_to_page = static_init!(

--- a/capsules/src/nrf51822_serialization.rs
+++ b/capsules/src/nrf51822_serialization.rs
@@ -8,6 +8,10 @@
 //! -----
 //!
 //! ```rust
+//! # use kernel::{hil, static_init};
+//! # use capsules::nrf51822_serialization;
+//! # use capsules::nrf51822_serialization::Nrf51822Serialization;
+//!
 //! let nrf_serialization = static_init!(
 //!     Nrf51822Serialization<usart::USART>,
 //!     Nrf51822Serialization::new(&usart::USART3,

--- a/capsules/src/pca9544a.rs
+++ b/capsules/src/pca9544a.rs
@@ -17,6 +17,8 @@
 //! -----
 //!
 //! ```rust
+//! # use kernel::static_init;
+//!
 //! let pca9544a_i2c = static_init!(
 //!     capsules::virtual_i2c::I2CDevice,
 //!     capsules::virtual_i2c::I2CDevice::new(i2c_bus, 0x70));

--- a/capsules/src/process_console.rs
+++ b/capsules/src/process_console.rs
@@ -36,6 +36,9 @@
 //! connects a `ProcessConsole` directly up to USART0:
 //!
 //! ```rust
+//! # use kernel::{capabilities, hil, static_init};
+//! # use capsules::process_console::ProcessConsole;
+//!
 //! pub struct Capability;
 //! unsafe impl capabilities::ProcessManagementCapability for Capability {}
 //!
@@ -47,7 +50,7 @@
 //!                  &mut console::READ_BUF,
 //!                  &mut console::COMMAND_BUF,
 //!                  kernel,
-//!                  Capability);
+//!                  Capability));
 //! hil::uart::UART::set_client(&usart::USART0, pconsole);
 //!
 //! pconsole.initialize();
@@ -70,7 +73,9 @@
 //! Next, establish a serial console connection to the board. An easy way to do
 //! this is to run:
 //!
-//!     $ tockloader listen
+//! ```shell
+//! $ tockloader listen
+//! ```
 //!
 //! With that console open, you can issue commands. For example, to see all of
 //! the processes on the board, use `list`:

--- a/capsules/src/rng.rs
+++ b/capsules/src/rng.rs
@@ -11,9 +11,11 @@
 //! -----
 //!
 //! ```rust
+//! # use kernel::static_init;
+//!
 //! let rng = static_init!(
 //!         capsules::rng::RngDriver<'static, sam4l::trng::Trng>,
-//!         capsules::rng::RngDriver::new(&sam4l::trng::TRNG, kernel::Grant::create()));
+//!         capsules::rng::RngDriver::new(&sam4l::trng::TRNG, board_kernel.create_grant(&grant_cap)));
 //! sam4l::trng::TRNG.set_client(rng);
 //! ```
 

--- a/capsules/src/sdcard.rs
+++ b/capsules/src/sdcard.rs
@@ -6,6 +6,9 @@
 //! -----
 //!
 //! ```rust
+//! # use kernel::static_init;
+//! # use capsules::virtual_alarm::VirtualMuxAlarm;
+//!
 //! let sdcard_spi = static_init!(
 //!     capsules::virtual_spi::VirtualSpiMasterDevice<'static, usart::USART>,
 //!     capsules::virtual_spi::VirtualSpiMasterDevice::new(mux_spi,

--- a/capsules/src/segger_rtt.rs
+++ b/capsules/src/segger_rtt.rs
@@ -5,18 +5,22 @@
 //! the host uses a JTAG connection to read the messages out of the chip's
 //! memory.
 //!
-//!	Receiving RTT Messages
-//!	----------------------
+//! Receiving RTT Messages
+//! ----------------------
 //!
-//!	With the jlink tools, reciving RTT messages is a two step process. First,
-//!	open a JTAG connection with a command like:
+//! With the jlink tools, reciving RTT messages is a two step process. First,
+//! open a JTAG connection with a command like:
 //!
-//!         $ JLinkExe -device nrf52 -if swd -speed 1000 -autoconnect 1
+//! ```shell
+//! $ JLinkExe -device nrf52 -if swd -speed 1000 -autoconnect 1
+//! ```
 //!
-//!	Then, use the `JLinkRTTClient` tool in a different terminal to print the
-//!	messages:
+//! Then, use the `JLinkRTTClient` tool in a different terminal to print the
+//! messages:
 //!
-//!         $ JLinkRTTClient
+//! ```shell
+//! $ JLinkRTTClient
+//! ```
 //!
 //! Notes
 //! -----
@@ -34,25 +38,22 @@
 //! Usage
 //! -----
 //!
-//! ```
+//! ```rust
 //! pub struct Platform {
 //!     // Other fields omitted for clarity
-//!     console: &'static capsules::console::Console<
-//!         'static,
-//!         capsules::segger_rtt::SeggerRtt<
-//!             'static,
-//!             capsules::virtual_alarm::VirtualMuxAlarm<'static, nrf5x::rtc::Rtc>,
-//!         >,
-//!     >,
+//!     console: &'static capsules::console::Console<'static>,
 //! }
 //! ```
 //!
 //! In `reset_handler()`:
 //!
-//! ```
+//! ```rust
+//! # use kernel::static_init;
+//! # use capsules::virtual_alarm::VirtualMuxAlarm;
+//!
 //! let virtual_alarm_rtt = static_init!(
-//!     capsules::virtual_alarm::VirtualMuxAlarm<'static, nrf5x::rtc::Rtc>,
-//!     capsules::virtual_alarm::VirtualMuxAlarm::new(mux_alarm)
+//!     VirtualMuxAlarm<'static, nrf5x::rtc::Rtc>,
+//!     VirtualMuxAlarm::new(mux_alarm)
 //! );
 //!
 //! let rtt_memory = static_init!(
@@ -72,18 +73,12 @@
 //! virtual_alarm_rtt.set_client(rtt);
 //!
 //! let console = static_init!(
-//!     capsules::console::Console<
-//!         'static,
-//!         capsules::segger_rtt::SeggerRtt<
-//!             capsules::virtual_alarm::VirtualMuxAlarm<'static, nrf5x::rtc::Rtc>,
-//!         >,
-//!     >,
+//!     capsules::console::Console<'static>,
 //!     capsules::console::Console::new(
 //!         rtt,
-//!         0, // Baud rate is meaningless with RTT
 //!         &mut capsules::console::WRITE_BUF,
 //!         &mut capsules::console::READ_BUF,
-//!         kernel::Grant::create()
+//!         board_kernel.create_grant(&grant_cap)
 //!     )
 //! );
 //! kernel::hil::uart::UART::set_client(rtt, console);

--- a/capsules/src/si7021.rs
+++ b/capsules/src/si7021.rs
@@ -18,6 +18,9 @@
 //! -----
 //!
 //! ```rust
+//! # use kernel::static_init;
+//! # use capsules::virtual_alarm::VirtualMuxAlarm;
+//!
 //! let si7021_i2c = static_init!(
 //!     capsules::virtual_i2c::I2CDevice,
 //!     capsules::virtual_i2c::I2CDevice::new(i2c_bus, 0x40));

--- a/capsules/src/temperature.rs
+++ b/capsules/src/temperature.rs
@@ -39,6 +39,7 @@
 //! You need a device that provides the `hil::sensors::TemperatureDriver` trait.
 //!
 //! ```rust
+//! # use kernel::static_init;
 //!
 //! let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
 //! let grant_temperature = board_kernel.create_grant(&grant_cap);
@@ -46,7 +47,8 @@
 //! let temp = static_init!(
 //!        capsules::temperature::TemperatureSensor<'static>,
 //!        capsules::temperature::TemperatureSensor::new(si7021,
-//!                                                 grant_temperature));
+//!                                                 board_kernel.create_grant(&grant_cap)));
+//!
 //! kernel::hil::sensors::TemperatureDriver::set_client(si7021, temp);
 //! ```
 

--- a/capsules/src/usb/usb_user.rs
+++ b/capsules/src/usb/usb_user.rs
@@ -10,18 +10,20 @@
 //! example:
 //!
 //! ```rust
+//! # use kernel::static_init;
+//!
 //! // Configure the USB controller
 //! let usb_client = static_init!(
-//!     capsules::usbc_client::Client<'static, sam4l::usbc::Usbc<'static>>,
-//!     capsules::usbc_client::Client::new(&sam4l::usbc::USBC));
+//!     capsules::usb::usbc_client::Client<'static, sam4l::usbc::Usbc<'static>>,
+//!     capsules::usb::usbc_client::Client::new(&sam4l::usbc::USBC));
 //! sam4l::usbc::USBC.set_client(usb_client);
 //!
 //! // Configure the USB userspace driver
 //! let usb_driver = static_init!(
-//!     capsules::usb_user::UsbSyscallDriver<'static,
-//!         capsules::usbc_client::Client<'static, sam4l::usbc::Usbc<'static>>>,
-//!     capsules::usb_user::UsbSyscallDriver::new(
-//!         usb_client, kernel::Grant::create()));
+//!     capsules::usb::usb_user::UsbSyscallDriver<'static,
+//!         capsules::usb::usbc_client::Client<'static, sam4l::usbc::Usbc<'static>>>,
+//!     capsules::usb::usb_user::UsbSyscallDriver::new(
+//!         usb_client, board_kernel.create_grant(&grant_cap)));
 //! ```
 
 use kernel::common::cells::OptionalCell;

--- a/capsules/src/virtual_alarm.rs
+++ b/capsules/src/virtual_alarm.rs
@@ -174,3 +174,15 @@ impl<A: Alarm<'a>> time::AlarmClient for MuxAlarm<'a, A> {
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::has_expired;
+
+    #[test]
+    fn has_expired_with_zero_reference() {
+        assert_eq!(has_expired(1, 1, 0), true);
+        assert_eq!(has_expired(1, 0, 0), false);
+        assert_eq!(has_expired(0, 1, 0), true);
+    }
+}

--- a/capsules/src/virtual_flash.rs
+++ b/capsules/src/virtual_flash.rs
@@ -12,6 +12,8 @@
 //! -----
 //!
 //! ```
+//! # use kernel::{hil, static_init};
+//!
 //! // Create the mux.
 //! let mux_flash = static_init!(
 //!     capsules::virtual_flash::MuxFlash<'static, sam4l::flashcalw::FLASHCALW>,

--- a/capsules/src/virtual_pwm.rs
+++ b/capsules/src/virtual_pwm.rs
@@ -7,6 +7,8 @@
 //! -----
 //!
 //! ```
+//! # use kernel::static_init;
+//!
 //! let mux_pwm = static_init!(
 //!     capsules::virtual_pwm::MuxPwm<'static, nrf52::pwm::Pwm>,
 //!     capsules::virtual_pwm::MuxPwm::new(&nrf52::pwm::PWM0)

--- a/capsules/src/virtual_uart.rs
+++ b/capsules/src/virtual_uart.rs
@@ -13,12 +13,15 @@
 //! Usage
 //! -----
 //!
-//! ```
+//! ```rust
+//! # use kernel::{hil, static_init};
+//! # use capsules::virtual_uart::{MuxUart, UartDevice};
+//!
 //! // Create a shared UART channel for the console and for kernel debug.
 //! let uart_mux = static_init!(
 //!     MuxUart<'static>,
 //!     MuxUart::new(&sam4l::usart::USART0, &mut capsules::virtual_uart::RX_BUF)
-//! )
+//! );
 //! hil::uart::UART::set_receive_client(&sam4l::usart::USART0, uart_mux);
 //! hil::uart::UART::set_transmit_client(&sam4l::usart::USART0, uart_mux);
 //!
@@ -26,13 +29,12 @@
 //! let console_uart = static_init!(UartDevice, UartDevice::new(uart_mux, true));
 //! console_uart.setup(); // This is important!
 //! let console = static_init!(
-//!     capsules::console::Console<UartDevice>,
+//!     capsules::console::Console<'static>,
 //!     capsules::console::Console::new(
 //!         console_uart,
-//!         115200,
 //!         &mut capsules::console::WRITE_BUF,
 //!         &mut capsules::console::READ_BUF,
-//!         kernel::Grant::create()
+//!         board_kernel.create_grant(&grant_cap)
 //!     )
 //! );
 //! hil::uart::UART::set_transmit_client(console_uart, console);


### PR DESCRIPTION
### Pull Request Overview

This pull request adds `cargo test` for the `capsules` crate to the Makefile.

I added a simple test in the virtual alarm capsule, but in general I think that capsules should be of great interest for functional unit tests, due to the non-trivial logic and the abstraction provided by HILs. In particular, one can write mock implementations of HILs to simulate various behaviors and test that the capsules react as expected.


### Testing Strategy

This pull request was tested by running `make ci-travis` and checking that unit tests indeed appear in the log.


### TODO or Help Wanted

- This pull request still needs fixing a bunch of doc tests in capsules.
- I hope that we can agree on the usefulness of such tests now that a lot of discussion happened on https://github.com/tock/tock/pull/1393. 


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
