### PR TITLE
Add debug statements to show how and where process are loaded from flash to sram.

### DIFF
--- a/boards/hifive1/src/main.rs
+++ b/boards/hifive1/src/main.rs
@@ -33,7 +33,7 @@ const FAULT_RESPONSE: kernel::procs::FaultResponse = kernel::procs::FaultRespons
 
 // RAM to be shared by all application processes.
 #[link_section = ".app_memory"]
-static mut APP_MEMORY: [u8; 5 * 1024] = [0; 5 * 1024];
+static mut APP_MEMORY: [u8; 4 * 1024] = [0; 4 * 1024];
 
 /// Dummy buffer that causes the linker to reserve enough space for the stack.
 #[no_mangle]

--- a/boards/hifive1/src/main.rs
+++ b/boards/hifive1/src/main.rs
@@ -33,7 +33,7 @@ const FAULT_RESPONSE: kernel::procs::FaultResponse = kernel::procs::FaultRespons
 
 // RAM to be shared by all application processes.
 #[link_section = ".app_memory"]
-static mut APP_MEMORY: [u8; 4 * 1024] = [0; 4 * 1024];
+static mut APP_MEMORY: [u8; 5 * 1024] = [0; 5 * 1024];
 
 /// Dummy buffer that causes the linker to reserve enough space for the stack.
 #[no_mangle]

--- a/kernel/src/config.rs
+++ b/kernel/src/config.rs
@@ -33,10 +33,18 @@ crate struct Config {
     /// If enabled, the kernel will print a message in the debug output for each system call and
     /// callback, with details including the application ID, and system call or callback parameters.
     crate trace_syscalls: bool,
+
+    /// Whether the kernel should show debugging output when loading processes.
+    ///
+    /// If enabled, the kernel will show from which addresses processes are loaded in flash and
+    /// into which SRAM addresses. This can be useful to debug whether the kernel could
+    /// successfully load processes, and whether the allocated SRAM is as expected.
+    crate debug_load_processes: bool,
 }
 
 /// A unique instance of `Config` where compile-time configuration options are defined. These
 /// options are available in the kernel crate to be used for relevant configuration.
 crate const CONFIG: Config = Config {
     trace_syscalls: false,
+    debug_load_processes: false,
 };

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -1204,16 +1204,30 @@ impl<C: 'static + Chip> Process<'a, C> {
     ) -> (Option<&'static dyn ProcessType>, usize, usize) {
         if let Some(tbf_header) = tbfheader::parse_and_validate_tbf_header(app_flash_address) {
             let app_flash_size = tbf_header.get_total_size() as usize;
+            let process_name = tbf_header.get_package_name();
 
             // If this isn't an app (i.e. it is padding) or it is an app but it
             // isn't enabled, then we can skip it but increment past its flash.
             if !tbf_header.is_app() || !tbf_header.enabled() {
+                if config::CONFIG.debug_load_processes {
+                    if !tbf_header.is_app() {
+                        debug!(
+                            "[!] flash={:#010X} process={:?} - process isn't an app",
+                            app_flash_address as usize, process_name
+                        );
+                    }
+                    if !tbf_header.enabled() {
+                        debug!(
+                            "[!] flash={:#010X} process={:?} - process isn't enabled",
+                            app_flash_address as usize, process_name
+                        );
+                    }
+                }
                 return (None, app_flash_size, 0);
             }
 
             // Otherwise, actually load the app.
             let mut min_app_ram_size = tbf_header.get_minimum_app_ram_size() as usize;
-            let process_name = tbf_header.get_package_name();
             let init_fn =
                 app_flash_address.offset(tbf_header.get_init_function_offset() as isize) as usize;
 
@@ -1228,6 +1242,12 @@ impl<C: 'static + Chip> Process<'a, C> {
                 mpu::Permissions::ReadExecuteOnly,
                 &mut mpu_config,
             ) {
+                if config::CONFIG.debug_load_processes {
+                    debug!(
+                        "[!] flash={:#010X} process={:?} - couldn't allocate flash region",
+                        app_flash_address as usize, process_name
+                    );
+                }
                 return (None, app_flash_size, 0);
             }
 
@@ -1274,6 +1294,12 @@ impl<C: 'static + Chip> Process<'a, C> {
                 Some((memory_start, memory_size)) => (memory_start, memory_size),
                 None => {
                     // Failed to load process. Insufficient memory.
+                    if config::CONFIG.debug_load_processes {
+                        debug!(
+                            "[!] flash={:#010X} process={:?} - couldn't allocate memory region",
+                            app_flash_address as usize, process_name
+                        );
+                    }
                     return (None, app_flash_size, 0);
                 }
             };
@@ -1354,7 +1380,7 @@ impl<C: 'static + Chip> Process<'a, C> {
                 Cell::new(None),
             ];
             process.tasks = MapCell::new(tasks);
-            process.process_name = process_name;
+            process.process_name = process_name.unwrap_or("");
 
             process.debug = MapCell::new(ProcessDebug {
                 app_heap_start_pointer: app_heap_start_pointer,
@@ -1396,6 +1422,12 @@ impl<C: 'static + Chip> Process<'a, C> {
                     process.stored_state.set(stored_state);
                 }
                 Err(_) => {
+                    if config::CONFIG.debug_load_processes {
+                        debug!(
+                            "[!] flash={:#010X} process={:?} - couldn't initialize process",
+                            app_flash_address as usize, process_name
+                        );
+                    }
                     return (None, app_flash_size, 0);
                 }
             };
@@ -1407,6 +1439,12 @@ impl<C: 'static + Chip> Process<'a, C> {
                 Some(process),
                 app_flash_size,
                 memory_padding_size + memory_size,
+            );
+        }
+        if config::CONFIG.debug_load_processes {
+            debug!(
+                "[!] flash={:#010X} - not a valid TBF header",
+                app_flash_address as usize
             );
         }
         (None, 0, 0)

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -43,12 +43,14 @@ pub fn load_processes<C: Chip>(
     let mut app_memory_ptr = app_memory.as_mut_ptr();
     let mut app_memory_size = app_memory.len();
 
-    debug!(
-        "Loading processes from flash={:#010X} into sram=[{:#010X}:{:#010X}]",
-        start_of_flash as usize,
-        app_memory_ptr as usize,
-        app_memory_ptr as usize + app_memory_size
-    );
+    if config::CONFIG.debug_load_processes {
+        debug!(
+            "Loading processes from flash={:#010X} into sram=[{:#010X}:{:#010X}]",
+            start_of_flash as usize,
+            app_memory_ptr as usize,
+            app_memory_ptr as usize + app_memory_size
+        );
+    }
 
     for i in 0..procs.len() {
         unsafe {
@@ -62,14 +64,16 @@ pub fn load_processes<C: Chip>(
                 i,
             );
 
-            debug!(
-                "Loaded process[{}] from flash={:#010X} into sram=[{:#010X}:{:#010X}] = {:?}",
-                i,
-                apps_in_flash_ptr as usize,
-                app_memory_ptr as usize,
-                app_memory_ptr as usize + memory_offset,
-                process.map(|p| p.get_process_name())
-            );
+            if config::CONFIG.debug_load_processes {
+                debug!(
+                    "Loaded process[{}] from flash={:#010X} into sram=[{:#010X}:{:#010X}] = {:?}",
+                    i,
+                    apps_in_flash_ptr as usize,
+                    app_memory_ptr as usize,
+                    app_memory_ptr as usize + memory_offset,
+                    process.map(|p| p.get_process_name())
+                );
+            }
 
             if process.is_none() {
                 // We did not get a valid process, but we may have gotten a disabled

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -42,6 +42,14 @@ pub fn load_processes<C: Chip>(
     let mut apps_in_flash_ptr = start_of_flash;
     let mut app_memory_ptr = app_memory.as_mut_ptr();
     let mut app_memory_size = app_memory.len();
+
+    debug!(
+        "Loading processes from flash={:#010X} into sram=[{:#010X}:{:#010X}]",
+        start_of_flash as usize,
+        app_memory_ptr as usize,
+        app_memory_ptr as usize + app_memory_size
+    );
+
     for i in 0..procs.len() {
         unsafe {
             let (process, flash_offset, memory_offset) = Process::create(
@@ -52,6 +60,15 @@ pub fn load_processes<C: Chip>(
                 app_memory_size,
                 fault_response,
                 i,
+            );
+
+            debug!(
+                "Loaded process[{}] from flash={:#010X} into sram=[{:#010X}:{:#010X}] = {:?}",
+                i,
+                apps_in_flash_ptr as usize,
+                app_memory_ptr as usize,
+                app_memory_ptr as usize + memory_offset,
+                process.map(|p| p.get_process_name())
             );
 
             if process.is_none() {

--- a/kernel/src/tbfheader.rs
+++ b/kernel/src/tbfheader.rs
@@ -145,10 +145,10 @@ impl TbfHeader {
     }
 
     /// Get the name of the app.
-    crate fn get_package_name(&self) -> &'static str {
+    crate fn get_package_name(&self) -> Option<&'static str> {
         match *self {
-            TbfHeader::TbfHeaderV2(hd) => hd.package_name.unwrap_or(""),
-            _ => "",
+            TbfHeader::TbfHeaderV2(hd) => hd.package_name,
+            _ => None,
         }
     }
 


### PR DESCRIPTION
### Pull Request Overview

This pull request adds debug statements in the `load_processes` function, to visualize better which apps are loaded, from where in flash and into where in sram. This can provide useful feedback when one has to manually adjust the addresses in tockloader and linker scripts.


### Testing Strategy

This pull request was tested on an nRF52840-DK board, checking the debug output for loaded apps.

Sample output:

```
Loading processes from flash=0x00030000 into sram=[0x2000C000:0x20040000]
Loaded process[0] from flash=0x00030000 into sram=[0x2000C000:0x2000E000] = Some("blink_random")
Loaded process[1] from flash=0x00032000 into sram=[0x2000E000:0x2000E000] = None
```


### TODO or Help Wanted

**Update:** increasing memory on `hifive1` is not needed anymore when the `const` configuration is disabled (which is the default).

~~Apparently, this requires reducing the `APP_MEMORY` size on `hifive1`.~~

~~I'm not sure what to do with it. This doesn't seem to leave much memory: 4KB for all the apps, but keep in mind that each process is given at least 3KB by the kernel:~~

https://github.com/tock/tock/blob/553654012946e2a703cd527aebd95c2d8cee41a2/kernel/src/process.rs#L1209-L1213

~~This should still be enough to run one simple app, although I haven't tested on hardware. But given the limited amount of available memory, is it worth continuing to officially support this platform for Tock?~~


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.