### PR TITLE
doc: Add explicit Code of Conduct to top-level README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,20 @@ discussions on Tock development.
 
 [slack]: https://join.slack.com/t/tockos/shared_invite/enQtNDE5ODQyNDU4NTE1LWVjNTgzMTMwYzA1NDI1MjExZjljMjFmOTMxMGIwOGJlMjk0ZTI4YzY0NTYzNWM0ZmJmZGFjYmY5MTJiMDBlOTk
 
+
+Code of Conduct
+---------------
+
+The Tock project adheres to the Rust [Code of Conduct][coc].
+
+All contributors, community members, and visitors are expected to familiarize
+themselves with the Code of Conduct and to follow these standards in all
+Tock-affiliated environments, which includes but is not limited to
+repositories, chats, and meetup events. For moderation issues, please contact
+members of the @tock/core-wg.
+
+[coc]: https://www.rust-lang.org/conduct.html
+
 License
 -------
 


### PR DESCRIPTION
### Pull Request Overview

The only place we referenced the CoC before was in the CONTRIBUTING guide as a "reminder" (from where?) that folks were supposed to adhere to Rust CoC. This just makes the CoC a bit more visible and explicit.

This PR motivated by the Netlify OSS hosting form, which requires a link to your org's CoC, which is kind of a neat structural incentive.

### TODO or Help Wanted

I think this covers what we want, but feedback of course welcome.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
