### PR TITLE
Fix in-kernel storage allocation macro and section.

### DIFF
--- a/boards/kernel_layout.ld
+++ b/boards/kernel_layout.ld
@@ -177,9 +177,9 @@ SECTIONS
      * Align on 512 bytes since that is the page size.
      * Volumes within this region are allocated with the
      * storage_volume! macro in utils.rs. */
-    . = ALIGN(512);
     .storage :
     {
+      . = ALIGN(512);
       _sstorage = .;
       *(.storage* storage*)
       _estorage = .;

--- a/kernel/src/common/utils.rs
+++ b/kernel/src/common/utils.rs
@@ -52,7 +52,7 @@ macro_rules! static_init_half {
 /// Non-volatile storage abstractions can then refer to the block of
 /// allocate flash in terms of the name of the volume. For example,
 ///
-/// `storage_volume(LOG, 32);`
+/// `storage_volume!(LOG, 32);`
 ///
 /// will allocate 32kB of space in the flash and define a symbol LOG
 /// at the start address of that flash region. The intention is that
@@ -65,6 +65,7 @@ macro_rules! storage_volume {
     ($N:ident, $kB:expr) => {
         #[link_section = ".storage"]
         #[used]
+	#[no_mangle]
         pub static $N: [u8; $kB * 1024] = [0x00; $kB * 1024];
     };
 }

--- a/kernel/src/common/utils.rs
+++ b/kernel/src/common/utils.rs
@@ -65,7 +65,7 @@ macro_rules! storage_volume {
     ($N:ident, $kB:expr) => {
         #[link_section = ".storage"]
         #[used]
-	#[no_mangle]
+        #[no_mangle]
         pub static $N: [u8; $kB * 1024] = [0x00; $kB * 1024];
     };
 }


### PR DESCRIPTION
### Pull Request Overview

Two fixes are needed for in-kernel storage allocation units to operate properly:
  1) kernel_layout.ld has to have the alignment for the start of the
     .storage section within the section.
  2. The macro needs to declare the variable no_mangle.

Without these changes, storage units are not aligned to start on a flash
page boundary and the storage unit itself may have an inacessible name.

### Testing Strategy

This pull request was tested by compiling and looking at the binary image. Its merge should wait on @TPackard testing.


### TODO or Help Wanted

This pull request needs @TPackard to test it.


### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

Fixed a comment in the storage_volume macro comment.

### Formatting

- [X] Ran `make formatall`.
