### PR TITLE
[RFC] Generalize ticks in the time HIL, and add support for 24- and 32-bit ticks

### DIFF
--- a/boards/arty-e21/src/timer_test.rs
+++ b/boards/arty-e21/src/timer_test.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 
 use kernel::debug;
-use kernel::hil::time::{self, Alarm};
+use kernel::hil::time::{Alarm, AlarmClient};
 
 pub struct TimerTest<'a, A: Alarm<'a>> {
     alarm: &'a A,
@@ -14,13 +14,11 @@ impl<A: Alarm<'a>> TimerTest<'a, A> {
 
     pub fn start(&self) {
         debug!("starting");
-        let start = self.alarm.now();
-        let exp = start + 99999;
-        self.alarm.set_alarm(exp);
+        self.alarm.set_alarm_from_now(A::Ticks::from(99999));
     }
 }
 
-impl<A: Alarm<'a>> time::AlarmClient for TimerTest<'a, A> {
+impl<A: Alarm<'a>> AlarmClient for TimerTest<'a, A> {
     fn fired(&self) {
         debug!("timer!!");
     }

--- a/boards/imix/src/imix_components/udp_mux.rs
+++ b/boards/imix/src/imix_components/udp_mux.rs
@@ -44,7 +44,7 @@ use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
 use kernel::hil::radio;
-use kernel::hil::time::Alarm;
+use kernel::hil::time::{Alarm, Ticks32Bits};
 use kernel::static_init;
 use sam4l;
 
@@ -148,10 +148,10 @@ impl Component for UDPMuxComponent {
             )
         );
 
-        let sixlowpan_state = sixlowpan as &dyn sixlowpan_state::SixlowpanState;
+        let sixlowpan_state = sixlowpan as &dyn sixlowpan_state::SixlowpanState<Ticks32Bits>;
         let sixlowpan_tx = sixlowpan_state::TxState::new(sixlowpan_state);
         let default_rx_state = static_init!(
-            sixlowpan_state::RxState<'static>,
+            sixlowpan_state::RxState<'static, Ticks32Bits>,
             sixlowpan_state::RxState::new(&mut SIXLOWPAN_RX_BUF)
         );
         sixlowpan_state.add_rx_state(default_rx_state);

--- a/capsules/src/ieee802154/xmac.rs
+++ b/capsules/src/ieee802154/xmac.rs
@@ -205,10 +205,14 @@ impl<R: radio::Radio, A: Alarm<'a>> XMac<'a, R, A> {
         }
     }
 
-    // Sets the timer to fire a set number of milliseconds in the future based
-    // on the current tick value.
+    // Sets the timer to fire a set number of milliseconds in the future.
     fn set_timer_ms(&self, ms: u32) {
-        self.alarm.set_alarm_from_now(A::ticks_from_ms(ms));
+        self.set_timer_ticks(A::ticks_from_ms(ms));
+    }
+
+    // Sets the timer to fire a set number of ticks in the future.
+    fn set_timer_ticks(&self, ticks: A::Ticks) {
+        self.alarm.set_alarm_from_now(ticks);
     }
 
     fn transmit_preamble(&self) {
@@ -321,9 +325,9 @@ impl<R: radio::Radio, A: Alarm<'a>> rng::Client for XMac<'a, R, A> {
                     // asynchronous, we account for the time spent waiting for
                     // the callback and randomly determine the remaining time
                     // spent backing off.
-                    let time_remaining_ms =
-                        A::ticks_to_ms(self.alarm.get_alarm().wrapping_sub(self.alarm.now()));
-                    self.set_timer_ms(random % time_remaining_ms);
+                    let time_remaining_ticks =
+                        self.alarm.get_alarm().wrapping_sub(self.alarm.now());
+                    self.set_timer_ticks(A::Ticks::from(random % time_remaining_ticks.into_u32()));
                 }
                 rng::Continue::Done
             }

--- a/capsules/src/mx25r6435f.rs
+++ b/capsules/src/mx25r6435f.rs
@@ -51,7 +51,6 @@ use kernel::common::cells::OptionalCell;
 use kernel::common::cells::TakeCell;
 use kernel::debug;
 use kernel::hil;
-use kernel::hil::time::Frequency;
 use kernel::ReturnCode;
 
 pub static mut TXBUFFER: [u8; PAGE_SIZE as usize + 4] = [0; PAGE_SIZE as usize + 4];
@@ -377,9 +376,7 @@ impl<
                 self.txbuffer.replace(write_buffer);
                 // Datasheet says erase takes 58 ms on average. So we wait that
                 // long.
-                let interval = (58 as u32) * <A::Frequency>::frequency() / 1000;
-                let tics = self.alarm.now().wrapping_add(interval);
-                self.alarm.set_alarm(tics);
+                self.alarm.set_alarm_from_now(A::ticks_from_ms(58));
             }
             State::EraseSectorCheckDone { operation } => {
                 read_buffer.map(move |read_buffer| {
@@ -473,9 +470,7 @@ impl<
                 self.txbuffer.replace(write_buffer);
                 // Datasheet says write page takes 3.2 ms on average. So we wait
                 // that long.
-                let interval = (3200 as u32) * <A::Frequency>::frequency() / 1000000;
-                let tics = self.alarm.now().wrapping_add(interval);
-                self.alarm.set_alarm(tics);
+                self.alarm.set_alarm_from_now(A::ticks_from_us(3200));
             }
             State::WriteSectorWaitDone {
                 sector_index,

--- a/capsules/src/sdcard.rs
+++ b/capsules/src/sdcard.rs
@@ -41,7 +41,6 @@ use core::cell::Cell;
 use core::cmp;
 use kernel::common::cells::{MapCell, OptionalCell, TakeCell};
 use kernel::hil;
-use kernel::hil::time::Frequency;
 use kernel::{AppId, AppSlice, Callback, Driver, ReturnCode, Shared};
 
 /// Syscall driver number.
@@ -506,9 +505,7 @@ impl<A: hil::time::Alarm<'a>> SDCard<'a, A> {
 
                     // try again after 10 ms
                     self.alarm_state.set(AlarmState::RepeatHCSInit);
-                    let interval = (10 as u32) * <A::Frequency>::frequency() / 1000;
-                    let tics = self.alarm.now().wrapping_add(interval);
-                    self.alarm.set_alarm(tics);
+                    self.alarm.set_alarm_from_now(A::ticks_from_ms(10));
                 } else {
                     // error, send callback and quit
                     self.txbuffer.replace(write_buffer);
@@ -603,9 +600,7 @@ impl<A: hil::time::Alarm<'a>> SDCard<'a, A> {
 
                     // try again after 10 ms
                     self.alarm_state.set(AlarmState::RepeatAppSpecificInit);
-                    let interval = (10 as u32) * <A::Frequency>::frequency() / 1000;
-                    let tics = self.alarm.now().wrapping_add(interval);
-                    self.alarm.set_alarm(tics);
+                    self.alarm.set_alarm_from_now(A::ticks_from_ms(10));
                 } else {
                     // error, send callback and quit
                     self.txbuffer.replace(write_buffer);
@@ -642,9 +637,7 @@ impl<A: hil::time::Alarm<'a>> SDCard<'a, A> {
 
                     // try again after 10 ms
                     self.alarm_state.set(AlarmState::RepeatGenericInit);
-                    let interval = (10 as u32) * <A::Frequency>::frequency() / 1000;
-                    let tics = self.alarm.now().wrapping_add(interval);
-                    self.alarm.set_alarm(tics);
+                    self.alarm.set_alarm_from_now(A::ticks_from_ms(10));
                 } else {
                     // error, send callback and quit
                     self.txbuffer.replace(write_buffer);
@@ -785,9 +778,7 @@ impl<A: hil::time::Alarm<'a>> SDCard<'a, A> {
 
                     // try again after 1 ms
                     self.alarm_state.set(AlarmState::WaitForDataBlock);
-                    let interval = (1 as u32) * <A::Frequency>::frequency() / 1000;
-                    let tics = self.alarm.now().wrapping_add(interval);
-                    self.alarm.set_alarm(tics);
+                    self.alarm.set_alarm_from_now(A::ticks_from_ms(1));
                 } else {
                     // error, send callback and quit
                     self.txbuffer.replace(write_buffer);
@@ -844,9 +835,7 @@ impl<A: hil::time::Alarm<'a>> SDCard<'a, A> {
                     // try again after 1 ms
                     self.alarm_state
                         .set(AlarmState::WaitForDataBlocks { count: count });
-                    let interval = (1 as u32) * <A::Frequency>::frequency() / 1000;
-                    let tics = self.alarm.now().wrapping_add(interval);
-                    self.alarm.set_alarm(tics);
+                    self.alarm.set_alarm_from_now(A::ticks_from_ms(1));
                 } else {
                     // error, send callback and quit
                     self.txbuffer.replace(write_buffer);
@@ -1032,9 +1021,7 @@ impl<A: hil::time::Alarm<'a>> SDCard<'a, A> {
 
                     // try again after 1 ms
                     self.alarm_state.set(AlarmState::WaitForWriteBusy);
-                    let interval = (1 as u32) * <A::Frequency>::frequency() / 1000;
-                    let tics = self.alarm.now().wrapping_add(interval);
-                    self.alarm.set_alarm(tics);
+                    self.alarm.set_alarm_from_now(A::ticks_from_ms(1));
                 }
             }
 
@@ -1375,9 +1362,7 @@ impl<A: hil::time::Alarm<'a>> hil::gpio::Client for SDCard<'a, A> {
 
         // run a timer for 500 ms in order to let the sd card settle
         self.alarm_state.set(AlarmState::DetectionChange);
-        let interval = (500 as u32) * <A::Frequency>::frequency() / 1000;
-        let tics = self.alarm.now().wrapping_add(interval);
-        self.alarm.set_alarm(tics);
+        self.alarm.set_alarm_from_now(A::ticks_from_ms(500));
     }
 }
 

--- a/capsules/src/segger_rtt.rs
+++ b/capsules/src/segger_rtt.rs
@@ -93,7 +93,6 @@
 use core::cell::Cell;
 use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::hil;
-use kernel::hil::time::Frequency;
 use kernel::hil::uart;
 use kernel::ReturnCode;
 
@@ -220,9 +219,7 @@ impl<'a, A: hil::time::Alarm<'a>> uart::Transmit<'a> for SeggerRtt<'a, A> {
 
                     // Start a short timer so that we get a callback and
                     // can issue the callback to the client.
-                    let interval = (100 as u32) * <A::Frequency>::frequency() / 1000000;
-                    let tics = self.alarm.now().wrapping_add(interval);
-                    self.alarm.set_alarm(tics);
+                    self.alarm.set_alarm_from_now(A::ticks_from_us(100));
                 })
             });
             (ReturnCode::SUCCESS, None)

--- a/chips/nrf52/src/ieee802154_radio.rs
+++ b/chips/nrf52/src/ieee802154_radio.rs
@@ -7,7 +7,7 @@ use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::common::registers::{register_bitfields, ReadOnly, ReadWrite, WriteOnly};
 use kernel::common::StaticRef;
 use kernel::hil::radio::{self, PowerClient};
-use kernel::hil::time::Alarm;
+use kernel::hil::time::{Alarm, Ticks32Bits};
 use kernel::ReturnCode;
 
 use crate::ppi;
@@ -796,8 +796,9 @@ impl Radio {
                 let backoff_periods = self.random_nonce() & ((1 << self.cca_be.get()) - 1);
                 unsafe {
                     ppi::PPI.enable(ppi::Channel::CH21::SET);
-                    nrf5x::timer::TIMER0
-                        .set_alarm(backoff_periods * (IEEE802154_BACKOFF_PERIOD as u32));
+                    nrf5x::timer::TIMER0.set_alarm(Ticks32Bits::from(
+                        backoff_periods * (IEEE802154_BACKOFF_PERIOD as u32),
+                    ));
                 }
             } else {
                 self.transmitting.set(false);

--- a/kernel/src/hil/entropy.rs
+++ b/kernel/src/hil/entropy.rs
@@ -51,7 +51,7 @@
 //!
 //! impl<'a, A: Alarm<'a>> EntropyTest<'a, A> {
 //!     pub fn initialize(&self) {
-//!         self.alarm.set_alarm_from_now(A::ticks_from_ms(1000));
+//!         self.alarm.set_alarm_from_now(A::ticks_from_seconds(1));
 //!     }
 //! }
 //!
@@ -68,7 +68,7 @@
 //!         match entropy.next() {
 //!             Some(val) => {
 //!                 println!("Entropy {}", val);
-//!                 self.alarm.set_alarm_from_now(A::ticks_from_ms(1000));
+//!                 self.alarm.set_alarm_from_now(A::ticks_from_seconds(1));
 //!                 hil::entropy::Continue::Done
 //!             },
 //!             None => hil::entropy::Continue::More

--- a/kernel/src/hil/entropy.rs
+++ b/kernel/src/hil/entropy.rs
@@ -41,21 +41,17 @@
 //! use kernel::hil;
 //! use kernel::hil::entropy::Entropy32;
 //! use kernel::hil::entropy::Client32;
-//! use kernel::hil::time::Alarm;
-//! use kernel::hil::time::Frequency;
-//! use kernel::hil::time::AlarmClient;
+//! use kernel::hil::time::{Alarm, AlarmClient};
 //! use kernel::ReturnCode;
 //!
 //! struct EntropyTest<'a, A: 'a + Alarm<'a>> {
-//!     entropy: &'a Entropy32 <'a>,
+//!     entropy: &'a Entropy32<'a>,
 //!     alarm: &'a A
 //! }
 //!
 //! impl<'a, A: Alarm<'a>> EntropyTest<'a, A> {
 //!     pub fn initialize(&self) {
-//!         let interval = 1 * <A::Frequency>::frequency();
-//!         let tics = self.alarm.now().wrapping_add(interval);
-//!         self.alarm.set_alarm(tics);
+//!         self.alarm.set_alarm_from_now(A::ticks_from_ms(1000));
 //!     }
 //! }
 //!
@@ -72,9 +68,7 @@
 //!         match entropy.next() {
 //!             Some(val) => {
 //!                 println!("Entropy {}", val);
-//!                 let interval = 1 * <A::Frequency>::frequency();
-//!                 let tics = self.alarm.now().wrapping_add(interval);
-//!                 self.alarm.set_alarm(tics);
+//!                 self.alarm.set_alarm_from_now(A::ticks_from_ms(1000));
 //!                 hil::entropy::Continue::Done
 //!             },
 //!             None => hil::entropy::Continue::More

--- a/kernel/src/hil/rng.rs
+++ b/kernel/src/hil/rng.rs
@@ -49,38 +49,34 @@
 //!
 //! ```
 //! use kernel::hil;
-//! use kernel::hil::time::Frequency;
+//! use kernel::hil::time::{Alarm, AlarmClient, Frequency};
 //! use kernel::ReturnCode;
 //!
-//! struct RngTest<'a, A: 'a + hil::time::Alarm<'a>> {
+//! struct RngTest<'a, A: 'a + Alarm<'a>> {
 //!     rng: &'a hil::rng::Rng<'a>,
 //!     alarm: &'a A
 //! }
 //!
-//! impl<'a, A: hil::time::Alarm<'a>> RngTest<'a, A> {
+//! impl<'a, A: Alarm<'a>> RngTest<'a, A> {
 //!     pub fn initialize(&self) {
-//!         let interval = 1 * <A::Frequency>::frequency();
-//!         let tics = self.alarm.now().wrapping_add(interval);
-//!         self.alarm.set_alarm(tics);
+//!         self.alarm.set_alarm_from_now(A::ticks_from_ms(1000));
 //!     }
 //! }
 //!
-//! impl<'a, A: hil::time::Alarm<'a>> hil::time::AlarmClient for RngTest<'a, A> {
+//! impl<'a, A: Alarm<'a>> AlarmClient for RngTest<'a, A> {
 //!     fn fired(&self) {
 //!         self.rng.get();
 //!     }
 //! }
 //!
-//! impl<'a, A: hil::time::Alarm<'a>> hil::rng::Client for RngTest<'a, A> {
+//! impl<'a, A: Alarm<'a>> hil::rng::Client for RngTest<'a, A> {
 //!     fn randomness_available(&self,
 //!                             randomness: &mut Iterator<Item = u32>,
 //!                             error: ReturnCode) -> hil::rng::Continue {
 //!         match randomness.next() {
 //!             Some(random) => {
 //!                 println!("Rand {}", random);
-//!                 let interval = 1 * <A::Frequency>::frequency();
-//!                 let tics = self.alarm.now().wrapping_add(interval);
-//!                 self.alarm.set_alarm(tics);
+//!                 self.alarm.set_alarm_from_now(A::ticks_from_ms(1000));
 //!                 hil::rng::Continue::Done
 //!             },
 //!             None => hil::rng::Continue::More

--- a/kernel/src/hil/rng.rs
+++ b/kernel/src/hil/rng.rs
@@ -59,7 +59,7 @@
 //!
 //! impl<'a, A: Alarm<'a>> RngTest<'a, A> {
 //!     pub fn initialize(&self) {
-//!         self.alarm.set_alarm_from_now(A::ticks_from_ms(1000));
+//!         self.alarm.set_alarm_from_now(A::ticks_from_seconds(1));
 //!     }
 //! }
 //!
@@ -76,7 +76,7 @@
 //!         match randomness.next() {
 //!             Some(random) => {
 //!                 println!("Rand {}", random);
-//!                 self.alarm.set_alarm_from_now(A::ticks_from_ms(1000));
+//!                 self.alarm.set_alarm_from_now(A::ticks_from_seconds(1));
 //!                 hil::rng::Continue::Done
 //!             },
 //!             None => hil::rng::Continue::More

--- a/kernel/src/hil/time.rs
+++ b/kernel/src/hil/time.rs
@@ -2,20 +2,31 @@
 
 use crate::ReturnCode;
 
-pub trait Time<W = u32> {
+pub trait Time {
+    type Ticks: Ticks;
     type Frequency: Frequency;
 
     /// Returns the current time in hardware clock units.
-    fn now(&self) -> W;
+    fn now(&self) -> Self::Ticks;
 
-    /// Returns the wrap-around value of the clock.
-    ///
-    /// The maximum value of the clock, at which `now` will wrap around. I.e., this should return
-    /// `core::u32::MAX` on a 32-bit-clock, or `(1 << 24) - 1` for a 24-bit clock.
-    fn max_tics(&self) -> W;
+    fn ticks_from_seconds(s: u32) -> Self::Ticks {
+        Self::Ticks::from(s * Self::Frequency::frequency())
+    }
+
+    fn ticks_from_ms(ms: u32) -> Self::Ticks {
+        Self::Ticks::from(((ms as f32 / 1000.0) * Self::Frequency::frequency() as f32) as u32)
+    }
+
+    fn ticks_from_us(us: u32) -> Self::Ticks {
+        Self::Ticks::from(((us as f32 / 1000000.0) * Self::Frequency::frequency() as f32) as u32)
+    }
+
+    fn ticks_to_ms(ticks: Self::Ticks) -> u32 {
+        ((ticks.into_u32() as f32 / Self::Frequency::frequency() as f32) * 1000.0) as u32
+    }
 }
 
-pub trait Counter<W = u32>: Time<W> {
+pub trait Counter: Time {
     fn start(&self) -> ReturnCode;
     fn stop(&self) -> ReturnCode;
     fn is_running(&self) -> bool;
@@ -73,7 +84,7 @@ impl Frequency for Freq1KHz {
 /// (usually clock tics). Implementers should use the
 /// [`Client`](trait.Client.html) trait to signal when the counter has
 /// reached a pre-specified value set in [`set_alarm`](#tymethod.set_alarm).
-pub trait Alarm<'a, W = u32>: Time<W> {
+pub trait Alarm<'a>: Time {
     /// Sets a one-shot alarm to fire when the clock reaches `tics`.
     ///
     /// [`Client#fired`](trait.Client.html#tymethod.fired) is signaled
@@ -86,10 +97,26 @@ pub trait Alarm<'a, W = u32>: Time<W> {
     /// let tics = alarm.now().wrapping_add(delta);
     /// alarm.set_alarm(tics);
     /// ```
-    fn set_alarm(&self, tics: W);
+    fn set_alarm(&self, tics: Self::Ticks);
+
+    /// Sets a one-shot alarm to fire when the clock reaches `duration` ticks
+    /// from now.
+    ///
+    /// [`Client#fired`](trait.Client.html#tymethod.fired) is signaled when the
+    /// alarm is elapsed.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let delta = 1337;
+    /// alarm.set_duration(delta);
+    /// ```
+    fn set_alarm_from_now(&self, duration: Self::Ticks) {
+        self.set_alarm(self.now().wrapping_add(duration));
+    }
 
     /// Returns the value set in [`set_alarm`](#tymethod.set_alarm)
-    fn get_alarm(&self) -> W;
+    fn get_alarm(&self) -> Self::Ticks;
 
     /// Set the client for interrupt events.
     fn set_client(&'a self, client: &'a dyn AlarmClient);
@@ -123,25 +150,25 @@ pub trait AlarmClient {
 
 /// The `Timer` trait models a timer that can notify when a particular interval
 /// has elapsed.
-pub trait Timer<'a, W = u32>: Time<W> {
+pub trait Timer<'a>: Time {
     /// Set the client for interrupt events.
     fn set_client(&'a self, client: &'a dyn TimerClient);
 
     /// Sets a one-shot timer to fire in `interval` clock-tics.
     ///
     /// Calling this method will override any existing oneshot or repeating timer.
-    fn oneshot(&self, interval: W);
+    fn oneshot(&self, interval: Self::Ticks);
 
     /// Sets repeating timer to fire every `interval` clock-tics.
     ///
     /// Calling this method will override any existing oneshot or repeating timer.
-    fn repeat(&self, interval: W);
+    fn repeat(&self, interval: Self::Ticks);
 
     /// Returns the interval for a repeating timer.
     ///
     /// Returns `None` if the timer is disabled or in oneshot mode and `Some(interval)` if it is
     /// repeating.
-    fn interval(&self) -> Option<W>;
+    fn interval(&self) -> Option<Self::Ticks>;
 
     /// Returns whether this is a oneshot (rather than repeating) timer.
     fn is_oneshot(&self) -> bool {
@@ -156,7 +183,7 @@ pub trait Timer<'a, W = u32>: Time<W> {
     /// Returns the remaining time in clock tics for a oneshot or repeating timer.
     ///
     /// Returns `None` if the timer is disabled.
-    fn time_remaining(&self) -> Option<W>;
+    fn time_remaining(&self) -> Option<Self::Ticks>;
 
     /// Returns whether this timer is currently active (has time remaining).
     fn is_enabled(&self) -> bool {
@@ -174,4 +201,99 @@ pub trait Timer<'a, W = u32>: Time<W> {
 pub trait TimerClient {
     /// Callback signaled when the timer's clock reaches the specified interval.
     fn fired(&self);
+}
+
+pub trait Ticks: Clone + Copy + From<u32> {
+    fn into_usize(self) -> usize;
+    fn into_u32(self) -> u32;
+
+    fn wrapping_add(self, other: Self) -> Self;
+    fn wrapping_sub(self, other: Self) -> Self;
+
+    /// Check whether `now` is after or equal to `when`, w.r.t. a `reference` time point.
+    fn expired(reference: Self, now: Self, when: Self) -> bool;
+
+    /// Returns the wrap-around value of the clock.
+    ///
+    /// The maximum value of the clock, at which `now` will wrap around. I.e., this should return
+    /// `core::u32::MAX` on a 32-bit-clock, or `(1 << 24) - 1` for a 24-bit clock.
+    fn max_value() -> Self;
+}
+
+#[derive(Clone, Copy)]
+pub struct Ticks32Bits(u32);
+
+impl Ticks32Bits {
+    pub const MAX_VALUE: u32 = 0xFFFFFFFF;
+}
+
+impl From<u32> for Ticks32Bits {
+    fn from(x: u32) -> Self {
+        Ticks32Bits(x)
+    }
+}
+
+impl Ticks for Ticks32Bits {
+    fn into_usize(self) -> usize {
+        self.0 as usize
+    }
+
+    fn into_u32(self) -> u32 {
+        self.0
+    }
+
+    fn wrapping_add(self, other: Self) -> Self {
+        Ticks32Bits(self.0.wrapping_add(other.0))
+    }
+
+    fn wrapping_sub(self, other: Self) -> Self {
+        Ticks32Bits(self.0.wrapping_sub(other.0))
+    }
+
+    fn expired(reference: Self, now: Self, when: Self) -> bool {
+        now.wrapping_sub(reference).0 >= when.wrapping_sub(reference).0
+    }
+
+    fn max_value() -> Self {
+        Self(Self::MAX_VALUE)
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct Ticks24Bits(u32);
+
+impl Ticks24Bits {
+    pub const MAX_VALUE: u32 = 0x00FFFFFF;
+}
+
+impl From<u32> for Ticks24Bits {
+    fn from(x: u32) -> Self {
+        Ticks24Bits(x & Self::MAX_VALUE)
+    }
+}
+
+impl Ticks for Ticks24Bits {
+    fn into_usize(self) -> usize {
+        self.0 as usize
+    }
+
+    fn into_u32(self) -> u32 {
+        self.0
+    }
+
+    fn wrapping_add(self, other: Self) -> Self {
+        Ticks24Bits((self.0.wrapping_add(other.0)) & Self::MAX_VALUE)
+    }
+
+    fn wrapping_sub(self, other: Self) -> Self {
+        Ticks24Bits((self.0.wrapping_sub(other.0)) & Self::MAX_VALUE)
+    }
+
+    fn expired(reference: Self, now: Self, when: Self) -> bool {
+        now.wrapping_sub(reference).0 >= when.wrapping_sub(reference).0
+    }
+
+    fn max_value() -> Self {
+        Self(Self::MAX_VALUE)
+    }
 }

--- a/kernel/src/hil/time.rs
+++ b/kernel/src/hil/time.rs
@@ -397,6 +397,15 @@ mod test {
     }
 
     #[test]
+    fn test_24bit_from() {
+        assert_eq!(Ticks24Bits::from(1).into_u32(), 1);
+        assert_eq!(Ticks24Bits::from(0x00FFFFFF).into_u32(), 0xFFFFFF);
+        assert_eq!(Ticks24Bits::from(0x01000000).into_u32(), 0);
+        assert_eq!(Ticks24Bits::from(0x12345678).into_u32(), 0x345678);
+        assert_eq!(Ticks24Bits::from(0xFFFFFFFF).into_u32(), 0xFFFFFF);
+    }
+
+    #[test]
     fn test_24bit_add() {
         assert_eq!(
             Ticks24Bits::from(1)

--- a/kernel/src/hil/time.rs
+++ b/kernel/src/hil/time.rs
@@ -14,15 +14,11 @@ pub trait Time {
     }
 
     fn ticks_from_ms(ms: u32) -> Self::Ticks {
-        Self::Ticks::from(((ms as f32 / 1000.0) * Self::Frequency::frequency() as f32) as u32)
+        Self::Ticks::from(((ms as u64 * Self::Frequency::frequency() as u64) / 1000) as u32)
     }
 
     fn ticks_from_us(us: u32) -> Self::Ticks {
-        Self::Ticks::from(((us as f32 / 1000000.0) * Self::Frequency::frequency() as f32) as u32)
-    }
-
-    fn ticks_to_ms(ticks: Self::Ticks) -> u32 {
-        ((ticks.into_u32() as f32 / Self::Frequency::frequency() as f32) * 1000.0) as u32
+        Self::Ticks::from(((us as u64 * Self::Frequency::frequency() as u64) / 1_000_000) as u32)
     }
 }
 
@@ -354,31 +350,6 @@ mod test {
         assert_eq!(Time32Bits32KHz::ticks_from_us(1).into_u32(), 0);
         assert_eq!(Time32Bits32KHz::ticks_from_us(10).into_u32(), 0);
         assert_eq!(Time32Bits32KHz::ticks_from_us(100).into_u32(), 3);
-    }
-
-    #[test]
-    fn test_ticks_to_ms() {
-        assert_eq!(Time32Bits16MHz::ticks_to_ms(Ticks32Bits::from(16_000)), 1);
-        assert_eq!(Time32Bits16MHz::ticks_to_ms(Ticks32Bits::from(160_000)), 10);
-        assert_eq!(
-            Time32Bits16MHz::ticks_to_ms(Ticks32Bits::from(1_600_000)),
-            100
-        );
-        assert_eq!(
-            Time32Bits16MHz::ticks_to_ms(Ticks32Bits::from(16_000_000)),
-            1000
-        );
-        assert_eq!(Time32Bits32KHz::ticks_to_ms(Ticks32Bits::from(32)), 0);
-        assert_eq!(Time32Bits32KHz::ticks_to_ms(Ticks32Bits::from(33)), 1);
-        assert_eq!(Time32Bits32KHz::ticks_to_ms(Ticks32Bits::from(327)), 9);
-        assert_eq!(Time32Bits32KHz::ticks_to_ms(Ticks32Bits::from(328)), 10);
-        assert_eq!(Time32Bits32KHz::ticks_to_ms(Ticks32Bits::from(3_276)), 99);
-        assert_eq!(Time32Bits32KHz::ticks_to_ms(Ticks32Bits::from(3_277)), 100);
-        assert_eq!(Time32Bits32KHz::ticks_to_ms(Ticks32Bits::from(32_767)), 999);
-        assert_eq!(
-            Time32Bits32KHz::ticks_to_ms(Ticks32Bits::from(32_768)),
-            1000
-        );
     }
 
     #[test]

--- a/kernel/src/hil/time.rs
+++ b/kernel/src/hil/time.rs
@@ -109,7 +109,7 @@ pub trait Alarm<'a>: Time {
     ///
     /// ```ignore
     /// let delta = 1337;
-    /// alarm.set_duration(delta);
+    /// alarm.set_alarm_from_now(delta);
     /// ```
     fn set_alarm_from_now(&self, duration: Self::Ticks) {
         self.set_alarm(self.now().wrapping_add(duration));


### PR DESCRIPTION
### Pull Request Overview

This pull request modifies the time HIL to support various width of clock ticks, as an alternative proposal to https://github.com/tock/tock/pull/1413. In particular, support for 24-bit and 32-bit ticks are added, but it could easily be extended to other widths in the future as needed.

- Added a `Ticks` associated type for the `Time` trait, in lieu of the currently unused `W` parameter. This is more consistent with the `Frequency` associated type and is more convenient to work it through dependencies.
- The `Ticks` trait represent a type encapsulating a ticks value (i.e. a 24-bit or 32-bit integer), with support for wrapping arithmetic and conversion to/from `u32`/`usize`.
- Removed the `Time::max_tics(&self)` function. This was unused. Instead, `Ticks::max_value` is now available (and doesn't take any parameter, as it is a constant of the type).
- Added the `Ticks::expired` primitive, to unify an implementation that was duplicated in various capsules.
- Added `Time::ticks_from_ms` and similar utility functions, to avoid the need for dealing with frequencies in all the capsules. This centralizes the arithmetic logic in one place, to reduce code duplication.
- Added a new `Alarm::set_alarm_from_now` function, to support the common `self.set_alarm(self.now().wrapping_add(duration))` pattern and reduce code duplication.


### Testing Strategy

This pull request was tested with:
- `ci-travis`
- new unit tests added in `kernel::hil::timer`.

I haven't done much more tests for now, to first gather feedback on the implementation.


### TODO or Help Wanted

This pull request still needs:
- [ ] Checking that the widths are correct for all clocks.
- [ ] Double-checking that the affected capsules are still correct.


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.