### PR TITLE
Add a notice about QEMU support

### DIFF
--- a/doc/Getting_Started.md
+++ b/doc/Getting_Started.md
@@ -16,6 +16,9 @@ developing Tock.
    the options with `tockloader` support to load applications, as that
    is the configuration that most examples and tutorials assume.
 
+   * Info about testing Tock on QEMU
+     * 01/07/2020 : Boards supported by Tock OS are not yet supported on QEMU at the moment.
+
 ### Super Quick Setup
 
 Nix:

--- a/doc/Getting_Started.md
+++ b/doc/Getting_Started.md
@@ -17,7 +17,7 @@ developing Tock.
    is the configuration that most examples and tutorials assume.
 
    * Info about testing Tock on QEMU
-     * 01/07/2020 : Boards supported by Tock OS are not yet supported on QEMU at the moment.
+     * 01/08/2020 : Among the boards supported by Tock, [SiFive HiFive1 RISC-V Board](../boards/hifive1/#running-in-qemu) can be tested in QEMU.
 
 ### Super Quick Setup
 


### PR DESCRIPTION
### Pull Request Overview

After reading the 4th bullet of the `requirements` section, I assumed that I can try running Tock OS on QEMU (since it mentions a `QEMU configuration` as a requirement). However, I couldn't find any board in the `boards/` subdirectory that are supported in QEMU at the moment. 

I added a note to the documentation that boards that support Tock OS are currently not supported on QEMU. I thought adding a note about QEMU support would be helpful to prevent newcomers like me from getting confused. 

P.S. 
If I'm mistaken and there is a way to test running Tock OS on QEMU, please let me know! I would be glad to close this PR :smile:

### Documentation Updated

- [x] Updated the relevant file `/docs/Getting_Started.md`.

### Formatting

- [ ] Ran `make formatall`.
