### PR TITLE
Improve display of MPU layout in Cortex-M panic handler

### DIFF
--- a/arch/cortex-m3/src/mpu.rs
+++ b/arch/cortex-m3/src/mpu.rs
@@ -171,17 +171,35 @@ impl fmt::Display for CortexMConfig {
                     0b111 => "ReadOnlyAlias",
                     _ => "ERR",
                 };
+                let start = location.0 as usize;
                 write!(
                     f,
                     "\
-                     \r\n  Region {}: base:{:>width$x}, length: {} bytes; {} ({:#x})",
+                     \r\n  Region {}: [{:#010X}:{:#010X}], length: {} bytes; {} ({:#x})",
                     i,
-                    location.0 as usize,
+                    start,
+                    start + location.1,
                     location.1,
                     access_str,
                     access_bits,
-                    width = 10,
                 )?;
+                let subregion_bits = region.attributes().read(RegionAttributes::SRD);
+                let subregion_size = location.1 / 8;
+                for j in 0..8 {
+                    write!(
+                        f,
+                        "\
+                         \r\n    Sub-region {}: [{:#010X}:{:#010X}], {}",
+                        j,
+                        start + j * subregion_size,
+                        start + (j + 1) * subregion_size,
+                        if (subregion_bits >> j) & 1 == 0 {
+                            "Enabled"
+                        } else {
+                            "Disabled"
+                        },
+                    )?;
+                }
             } else {
                 write!(f, "\r\n  Region {}: Unused", i)?;
             }


### PR DESCRIPTION
### Pull Request Overview

This pull request improves the debugging output shown of the Cortex-M MPU in case of panic.
- Instead of a base address in hexadecimal + a length in decimal, a range of hexadecimal addresses is shown, for easier manual comparison of whether an address belongs to a given region. The decimal length is still shown in case it is useful.
- The sub-regions are also shown. Indeed, disabled sub-regions are actually not part of a given region.

Sample output:

```
 Cortex-M MPU
  Region 0: [0x20006000:0x20008000], length: 8192 bytes; ReadWrite (0x3)
    Sub-region 0: [0x20006000:0x20006400], Enabled
    Sub-region 1: [0x20006400:0x20006800], Enabled
    Sub-region 2: [0x20006800:0x20006C00], Enabled
    Sub-region 3: [0x20006C00:0x20007000], Enabled
    Sub-region 4: [0x20007000:0x20007400], Enabled
    Sub-region 5: [0x20007400:0x20007800], Disabled
    Sub-region 6: [0x20007800:0x20007C00], Disabled
    Sub-region 7: [0x20007C00:0x20008000], Disabled
  Region 1: [0x00030000:0x00032000], length: 8192 bytes; ReadOnly (0x6)
    Sub-region 0: [0x00030000:0x00030400], Enabled
    Sub-region 1: [0x00030400:0x00030800], Enabled
    Sub-region 2: [0x00030800:0x00030C00], Enabled
    Sub-region 3: [0x00030C00:0x00031000], Enabled
    Sub-region 4: [0x00031000:0x00031400], Enabled
    Sub-region 5: [0x00031400:0x00031800], Enabled
    Sub-region 6: [0x00031800:0x00031C00], Enabled
    Sub-region 7: [0x00031C00:0x00032000], Enabled
  Region 2: Unused
  Region 3: Unused
  Region 4: Unused
  Region 5: Unused
  Region 6: Unused
  Region 7: Unused
```


### Testing Strategy

This pull request was tested by triggering a panic and checking the debug output.


### TODO or Help Wanted

For now, the display of sub-region is a dumb loop over all sub-regions, even if the current implementation is just a contiguous range of enabled sub-regions followed by a contiguous range of disabled sub-regions. The dumb loop is to limit the size of added code, but the output could be simplified by merging enabled/disabled regions.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
