### PR TITLE
Fix restarting apps

### DIFF
--- a/arch/rv32i/src/syscall.rs
+++ b/arch/rv32i/src/syscall.rs
@@ -34,12 +34,17 @@ impl SysCall {
 impl kernel::syscall::UserspaceKernelBoundary for SysCall {
     type StoredState = RiscvimacStoredState;
 
-    unsafe fn initialize_new_process(
+    unsafe fn initialize_process(
         &self,
         stack_pointer: *const usize,
         _stack_size: usize,
         state: &mut Self::StoredState,
     ) -> Result<*const usize, ()> {
+        // Need to clear the stored state when initializing.
+        state.regs.iter_mut().for_each(|x| *x = 0);
+        state.pc = 0;
+        state.mcause = 0;
+
         // The first time the process runs we need to set the initial stack
         // pointer in the sp register.
         state.regs[1] = stack_pointer as usize;
@@ -318,13 +323,13 @@ impl kernel::syscall::UserspaceKernelBoundary for SysCall {
           li   t1, 8          // 8 is the index of ECALL from U mode.
           beq  t0, t1, _ecall // Check if we did an ECALL and handle it
                               // correctly.
-            
+
         _check_ecall_m_mode:
           li   t1, 11          // 11 is the index of ECALL from M mode.
           beq  t0, t1, _ecall  // analagous to _check_ecall_umode but included to support hifive1 board
-                               // only applicable to the hifive1 rev a board/FE310-G0000 chip, 
+                               // only applicable to the hifive1 rev a board/FE310-G0000 chip,
                                // which only has machine mode.
-                              
+
 
 
         _check_exception:

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -432,8 +432,6 @@ pub unsafe fn reset_handler() {
     // unsafe impl capabilities::ProcessManagementCapability for ProcessMgmtCap {}
     // let debug_process_restart = static_init!(
     //     capsules::debug_process_restart::DebugProcessRestart<
-    //         'static,
-    //         sam4l::gpio::GPIOPin,
     //         ProcessMgmtCap,
     //     >,
     //     capsules::debug_process_restart::DebugProcessRestart::new(

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -451,6 +451,7 @@ pub struct Process<'a, C: 'static + Chip> {
 
     /// Pointer to high water mark for process buffers shared through `allow`
     allow_high_water_mark: Cell<*const u8>,
+    original_allow_high_water_mark: *const u8,
 
     /// Saved when the app switches to the kernel.
     current_stack_pointer: Cell<*const u8>,
@@ -610,6 +611,8 @@ impl<C: Chip> ProcessType for Process<'a, C> {
                 // Reset other memory pointers.
                 self.app_break.set(self.original_app_break);
                 self.current_stack_pointer.set(self.original_stack_pointer);
+                self.allow_high_water_mark
+                    .set(self.original_allow_high_water_mark);
 
                 // Handle any architecture-specific requirements for a process
                 // when it first starts (as it would when it is new).
@@ -1321,6 +1324,7 @@ impl<C: 'static + Chip> Process<'a, C> {
             process.app_break = Cell::new(initial_sbrk_pointer);
             process.original_app_break = initial_sbrk_pointer;
             process.allow_high_water_mark = Cell::new(remaining_app_memory);
+            process.original_allow_high_water_mark = remaining_app_memory;
             process.current_stack_pointer = Cell::new(initial_stack_pointer);
             process.original_stack_pointer = initial_stack_pointer;
 

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -1341,7 +1341,7 @@ impl<C: 'static + Chip> Process<'a, C> {
 
             // Handle any architecture-specific requirements for a new process
             let mut stored_state = process.stored_state.get();
-            match chip.userspace_kernel_boundary().initialize_new_process(
+            match chip.userspace_kernel_boundary().initialize_process(
                 process.sp(),
                 process.sp() as usize - process.memory.as_ptr() as usize,
                 &mut stored_state,

--- a/kernel/src/syscall.rs
+++ b/kernel/src/syscall.rs
@@ -69,12 +69,22 @@ pub trait UserspaceKernelBoundary {
     /// Some architecture-specific struct containing per-process state that must
     /// be kept while the process is not running. For example, for keeping CPU
     /// registers that aren't stored on the stack.
+    ///
+    /// Implementations should **not** rely on the `Default` constructor (custom
+    /// or derived) for any initialization of a process's stored state. The
+    /// initialization must happen in the `initialize_process()` function.
     type StoredState: Default + Copy;
 
-    /// Called by the kernel after a new process has been created by before it
+    /// Called by the kernel after it has memory allocated to it but before it
     /// is allowed to begin executing. Allows for architecture-specific process
     /// setup, e.g. allocating a syscall stack frame.
-    unsafe fn initialize_new_process(
+    ///
+    /// This function must also initialize the stored state (if needed).
+    ///
+    /// This function may be called multiple times on the same process. For
+    /// example, if a process crashes and is to be restarted, this must be
+    /// called. Or if the process is moved this may need to be called.
+    unsafe fn initialize_process(
         &self,
         stack_pointer: *const usize,
         stack_size: usize,


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes how app restarting is handled by re-initializing the context switching state when the process is being restarted.

This change does this by calling the initialize function in the `UserlandKernelBoundary` trait. However, the process is no longer "new" so I renamed the function. Also, we can't rely on the constructor for the stored state to initialize values, and the `initialize_process()` function must do that.

This also updates the example code in hail to enable restarting all apps.


### Testing Strategy
Using the restart all apps capsule to restart blink, c_hello, and hello_loop on hail.


### TODO or Help Wanted

- I can revert the function name change if that is too big of a change.
- ~~`hello_loop` doesn't restart correctly, but I'm not sure why.~~ fixed now


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
