### PR TITLE
Fix counting the number of syscalls a process has called.

### DIFF
--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -234,7 +234,11 @@ pub trait ProcessType {
     /// Returns how many times this process has exceeded its timeslice.
     fn debug_timeslice_expiration_count(&self) -> usize;
 
+    /// Increment the number of times the process has exceeded its timeslice.
     fn debug_timeslice_expired(&self);
+
+    /// Increment the number of times the process called a syscall.
+    fn debug_syscall_called(&self);
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -956,6 +960,10 @@ impl<C: Chip> ProcessType for Process<'a, C> {
     fn debug_timeslice_expired(&self) {
         self.debug
             .map(|debug| debug.timeslice_expiration_count += 1);
+    }
+
+    fn debug_syscall_called(&self) {
+        self.debug.map(|debug| debug.syscall_count += 1);
     }
 
     unsafe fn fault_fmt(&self, writer: &mut dyn Write) {

--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -279,6 +279,8 @@ impl Kernel {
                             process.set_fault_state();
                         }
                         Some(ContextSwitchReason::SyscallFired { syscall }) => {
+                            process.debug_syscall_called();
+
                             // Handle each of the syscalls.
                             match syscall {
                                 Syscall::MEMOP { operand, arg0 } => {


### PR DESCRIPTION
This accidentally got removed when refactoring how context switches are handled.

Regression likely from #1318.

### Testing Strategy

I tested this by running the list command with the process console.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
