### PR TITLE
kernel: make AppId unique

### DIFF
--- a/kernel/src/callback.rs
+++ b/kernel/src/callback.rs
@@ -44,7 +44,7 @@ impl AppId {
     /// any padding at the end of the app. It does not include the TBF header,
     /// or any space that the kernel is using for any potential bookkeeping.
     pub fn get_editable_flash_range(&self) -> (usize, usize) {
-        self.kernel.process_map_or((0, 0), self.idx, |process| {
+        self.kernel.process_map_or((0, 0), *self, |process| {
             let start = process.flash_non_protected_start() as usize;
             let end = process.flash_end() as usize;
             (start, end)
@@ -98,7 +98,7 @@ impl Callback {
     pub fn schedule(&mut self, r0: usize, r1: usize, r2: usize) -> bool {
         self.app_id
             .kernel
-            .process_map_or(false, self.app_id.idx(), |process| {
+            .process_map_or(false, self.app_id, |process| {
                 process.enqueue_task(process::Task::FunctionCall(process::FunctionCall {
                     source: process::FunctionCallSource::Driver(self.callback_id),
                     argument0: r0,

--- a/kernel/src/introspection.rs
+++ b/kernel/src/introspection.rs
@@ -78,7 +78,7 @@ impl KernelInfo {
         _capability: &dyn ProcessManagementCapability,
     ) -> &'static str {
         self.kernel
-            .process_map_or("unknown", app.idx(), |process| process.get_process_name())
+            .process_map_or("unknown", app, |process| process.get_process_name())
     }
 
     /// Returns the number of syscalls the app has called.
@@ -88,7 +88,7 @@ impl KernelInfo {
         _capability: &dyn ProcessManagementCapability,
     ) -> usize {
         self.kernel
-            .process_map_or(0, app.idx(), |process| process.debug_syscall_count())
+            .process_map_or(0, app, |process| process.debug_syscall_count())
     }
 
     /// Returns the number of dropped callbacks the app has experience.
@@ -99,9 +99,8 @@ impl KernelInfo {
         app: AppId,
         _capability: &dyn ProcessManagementCapability,
     ) -> usize {
-        self.kernel.process_map_or(0, app.idx(), |process| {
-            process.debug_dropped_callback_count()
-        })
+        self.kernel
+            .process_map_or(0, app, |process| process.debug_dropped_callback_count())
     }
 
     /// Returns the number of time this app has been restarted.
@@ -111,7 +110,7 @@ impl KernelInfo {
         _capability: &dyn ProcessManagementCapability,
     ) -> usize {
         self.kernel
-            .process_map_or(0, app.idx(), |process| process.debug_restart_count())
+            .process_map_or(0, app, |process| process.debug_restart_count())
     }
 
     /// Returns the number of time this app has exceeded its timeslice.
@@ -120,9 +119,8 @@ impl KernelInfo {
         app: AppId,
         _capability: &dyn ProcessManagementCapability,
     ) -> usize {
-        self.kernel.process_map_or(0, app.idx(), |process| {
-            process.debug_timeslice_expiration_count()
-        })
+        self.kernel
+            .process_map_or(0, app, |process| process.debug_timeslice_expiration_count())
     }
 
     /// Returns the total number of times all processes have exceeded

--- a/kernel/src/ipc.rs
+++ b/kernel/src/ipc.rs
@@ -151,15 +151,17 @@ impl Driver for IPC {
             process::IPCType::Client
         };
 
-        self.data
-            .kernel
-            .process_map_or(ReturnCode::EINVAL, target_id - 1, |target| {
+        self.data.kernel.process_map_or(
+            ReturnCode::EINVAL,
+            AppId::new(self.data.kernel, target_id - 1),
+            |target| {
                 let ret = target.enqueue_task(process::Task::IPC((appid, cb_type)));
                 match ret {
                     true => ReturnCode::SUCCESS,
                     false => ReturnCode::FAIL,
                 }
-            })
+            },
+        )
     }
 
     /// allow enables processes to discover IPC services on the platform or

--- a/kernel/src/mem.rs
+++ b/kernel/src/mem.rs
@@ -51,7 +51,7 @@ impl<L, T> Drop for AppPtr<L, T> {
     fn drop(&mut self) {
         self.process
             .kernel
-            .process_map_or((), self.process.idx(), |process| unsafe {
+            .process_map_or((), self.process, |process| unsafe {
                 process.free(self.ptr.as_ptr() as *mut u8)
             })
     }
@@ -89,11 +89,11 @@ impl<L, T> AppSlice<L, T> {
     /// Provide access to one app's AppSlice to another app. This is used for
     /// IPC.
     crate unsafe fn expose_to(&self, appid: AppId) -> bool {
-        if appid.idx() != self.ptr.process.idx() {
+        if appid != self.ptr.process {
             self.ptr
                 .process
                 .kernel
-                .process_map_or(false, appid.idx(), |process| {
+                .process_map_or(false, appid, |process| {
                     process
                         .add_mpu_region(self.ptr() as *const u8, self.len(), self.len())
                         .is_some()

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -9,6 +9,7 @@ use crate::callback::{AppId, CallbackId};
 use crate::capabilities::ProcessManagementCapability;
 use crate::common::cells::MapCell;
 use crate::common::{Queue, RingBuffer};
+use crate::ipc;
 use crate::mem::{AppSlice, Shared};
 use crate::platform::mpu::{self, MPU};
 use crate::platform::Chip;
@@ -322,16 +323,10 @@ pub enum FaultResponse {
     Stop,
 }
 
-#[derive(Copy, Clone, Debug)]
-pub enum IPCType {
-    Service,
-    Client,
-}
-
 #[derive(Copy, Clone)]
 pub enum Task {
     FunctionCall(FunctionCall),
-    IPC((AppId, IPCType)),
+    IPC((AppId, ipc::IPCCallbackType)),
 }
 
 /// Enumeration to identify whether a function call comes directly from the

--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -80,15 +80,15 @@ impl Kernel {
     where
         F: FnOnce(&dyn process::ProcessType) -> R,
     {
-        // Find a process that matches the app id provided.
+        // Find a process that matches the app id provided, if one exists.
         let process = self
             .processes
             .iter()
-            .find(|&&p| p.map_or(false, |p2| appid == p2.appid()));
+            .find_map(|&p| p.map_or(None, |p2| if appid == p2.appid() { Some(p2) } else { None }));
 
-        // Run the closure on the process, dealing with the many options
-        // encountered along the way.
-        process.map_or(default, |p2| closure(p2.unwrap()))
+        // Return `default` if we couldn't find any matches, otherwise run the
+        // closure.
+        process.map_or(default, |p| closure(p))
     }
 
     /// Run a closure on every valid process. This will iterate the array of

--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -107,6 +107,20 @@ impl Kernel {
         }
     }
 
+    /// Return an iterator for all of the items in the processes array on this
+    /// board.
+    ///
+    /// NOTE: This would be better if it returned an iterator to only processes.
+    /// While with `filter_map()` it is straightforward to create an object that
+    /// implements `Iterator` and only iterates over `Some(process)` items in
+    /// the processes array, Rust doesn't seem to support the types necessary to
+    /// actually make that work and be usable. Perhaps as
+    /// https://github.com/rust-lang/rust/issues/63066 progresses this will be
+    /// possible in the future.
+    crate fn get_process_iter(&self) -> core::slice::Iter<Option<&dyn process::ProcessType>> {
+        self.processes.iter()
+    }
+
     /// Run a closure on every valid process. This will iterate the
     /// array of processes and call the closure on every process that
     /// exists. Ths method is available outside the kernel crate but
@@ -148,11 +162,6 @@ impl Kernel {
             }
         }
         ReturnCode::FAIL
-    }
-
-    /// Return how many processes this board supports.
-    crate fn number_of_process_slots(&self) -> usize {
-        self.processes.len()
     }
 
     /// Create a new unique identifier for a process and return the identifier.


### PR DESCRIPTION
`AppId.idx` used to refer to the index of the app in the process array. However, if an app restarts then an "old" AppId that was created for the process before it restarted will also work after an app is restarted, but the restarted version may use entirely different resources. This changes the AppId after an app is restarted so that to the rest of the OS it looks like an entirely different application.

Rather than passing around `idx` we now pass the entire `AppId` to make the interface more clear.

Requires #1533

### Testing Strategy

This pull request was tested by working on app restarting.


### TODO or Help Wanted

I think this is a reasonable change that improves this abstraction in the kernel. But, there may be a more Rusty method to accomplish the goal of disabling AppIds after the app crashes/is removed/restarts.

~~This breaks IPC currently since that relies on idx being an actual index in an array.~~

### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
