### PR TITLE
Fix formatting bug in markdown

### DIFF
--- a/boards/nordic/nrf52840dk/README.md
+++ b/boards/nordic/nrf52840dk/README.md
@@ -22,11 +22,11 @@ make flash in this directory to install a fresh kernel.
 ## Programming user-level applications
 You can program an application via JTAG using `tockloader`:
 
-    ```bash
-    $ cd libtock-c/examples/<app>
-    $ make
-    $ tockloader install --jlink --board nrf52dk
-    ```
+```bash
+$ cd libtock-c/examples/<app>
+$ make
+$ tockloader install --jlink --board nrf52dk
+```
 
 ## Debugging
 


### PR DESCRIPTION
Can't do 4-space and syntax identifier

### Pull Request Overview

noticed & fixed during a meeting

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
