### PR TITLE
kernel: lib: make process::Error public

### DIFF
--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -49,5 +49,7 @@ pub use crate::sched::Kernel;
 // processes.
 /// Publicly available process-related objects.
 pub mod procs {
-    pub use crate::process::{load_processes, FaultResponse, FunctionCall, Process, ProcessType};
+    pub use crate::process::{
+        load_processes, Error, FaultResponse, FunctionCall, Process, ProcessType,
+    };
 }


### PR DESCRIPTION


### Pull Request Overview

Making `process::Error` public is necessary to check for errors with things like calling `grant.enter()`.


### Testing Strategy
Work on the ADC PR.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
