### PR TITLE
tock-registers: release v0.5

### DIFF
--- a/libraries/tock-register-interface/CHANGELOG.md
+++ b/libraries/tock-register-interface/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## master
+## v0.5
+
+ - #1510
+   - Register visibility granularity: don't automatically make everything
+      `pub`, rather give creation macro callers visbility control.
 
  - #1489
    - Make `register_structs!` unit test generation opt-out, so that
@@ -14,6 +18,7 @@
      skipped at some point.
    - Implement `read()` for `FieldValue` so that individual fields
      can be extracted from a register `FieldValue` representation.
+
  - #1461: Update `register_structs` macro to support flexible visibility of each
    struct and each field. Also revert to private structs by default.
 

--- a/libraries/tock-register-interface/Cargo.toml
+++ b/libraries/tock-register-interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tock-registers"
-version = "0.4.1"
+version = "0.5.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
 description = "Memory-Mapped I/O and register interface developed for Tock."
 homepage = "https://www.tockos.org/"


### PR DESCRIPTION
### Pull Request Overview

Bump version to release v0.5 of the library.

Closes #1482.

### Testing Strategy

This pull request was tested by compiling.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
