### PR TITLE
Update nrf52840dk README

### DIFF
--- a/boards/nordic/nrf52840dk/README.md
+++ b/boards/nordic/nrf52840dk/README.md
@@ -13,20 +13,31 @@ First, follow the [Tock Getting Started guide](../../../doc/Getting_Started.md)
 
 JTAG is the preferred method to program. The development kit has an
 integrated JTAG debugger, you simply need to [install JTAG
-software](../../../doc/Getting_Started.md#optional-requirements).
+software](../../../doc/Getting_Started.md#loading-the-kernel-onto-a-board).
 
 ## Programming the kernel
 Once you have all software installed, you should be able to simply run
 make flash in this directory to install a fresh kernel.
 
 ## Programming user-level applications
-You can program an application via JTAG using `tockloader`:
+You can program an application over USB using the integrated JTAG and `tockloader`:
 
 ```bash
 $ cd libtock-c/examples/<app>
 $ make
 $ tockloader install --jlink --board nrf52dk
 ```
+
+The same options (`--jlink --board nrf52dk`) must be passed for other tockloader commands
+such as `erase-apps` or `list`.
+
+Viewing console output on the nrf52840dk is slightly different from other boards. You must use
+```bash
+$ tockloader listen
+```
+**followed by a press of the reset button** in order to view console output starting from the boot
+sequence. Notably, you should not
+pass the `--jlink` option to `tockloader listen`.
 
 ## Debugging
 


### PR DESCRIPTION
# Pull Request Overview

Currently the README does not explain several challenges regarding using tockloader with this board. This PR fixes it. It also fixes a broken link in the README.


### TODO or Help Wanted

Is there another mechanism for getting `tockloader listen` to work on this board that also enables the process console to work? If so we should document that instead.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make formatall`.
