### PR TITLE
Add a simple alarm test. It fires the first alarm in about 10 seconds.

### DIFF
--- a/capsules/src/test/alarm.rs
+++ b/capsules/src/test/alarm.rs
@@ -9,10 +9,10 @@ use kernel::hil::time::{Alarm, AlarmClient, Frequency};
 
 pub struct TestAlarm<'a, A: Alarm<'a>> {
     alarm: &'a A,
-    ms: Cell<u32>
+    ms: Cell<u32>,
 }
 
-impl<A: Alarm<'a>>  TestAlarm<'a, A> {
+impl<A: Alarm<'a>> TestAlarm<'a, A> {
     pub fn new(alarm: &'a A) -> TestAlarm<'a, A> {
         TestAlarm {
             alarm: alarm,
@@ -24,7 +24,6 @@ impl<A: Alarm<'a>>  TestAlarm<'a, A> {
         debug!("Starting alarms.");
         self.ms.set(10000);
         self.set_next_alarm(10000);
-
     }
 
     fn set_next_alarm(&self, ms: u32) {
@@ -42,7 +41,7 @@ impl<A: Alarm<'a>>  TestAlarm<'a, A> {
 impl<A: Alarm<'a>> AlarmClient for TestAlarm<'a, A> {
     fn fired(&self) {
         // Generate a new interval that's irregular
-        let new_ms:u32 = 10 + ((self.ms.get() + 137) % 757);
+        let new_ms: u32 = 10 + ((self.ms.get() + 137) % 757);
         self.set_next_alarm(new_ms);
     }
 }

--- a/capsules/src/test/alarm.rs
+++ b/capsules/src/test/alarm.rs
@@ -1,0 +1,48 @@
+//! Test that an Alarm implementation is working. Depends on a working
+//! UART and debug! macro.
+//!
+//! Author: Philip Levis <plevis@google.com>
+//! Last Modified: 1/10/2020
+use core::cell::Cell;
+use kernel::debug;
+use kernel::hil::time::{Alarm, AlarmClient, Frequency};
+
+pub struct TestAlarm<'a, A: Alarm<'a>> {
+    alarm: &'a A,
+    ms: Cell<u32>
+}
+
+impl<A: Alarm<'a>>  TestAlarm<'a, A> {
+    pub fn new(alarm: &'a A) -> TestAlarm<'a, A> {
+        TestAlarm {
+            alarm: alarm,
+            ms: Cell::new(0),
+        }
+    }
+
+    pub fn run(&self) {
+        debug!("Starting alarms.");
+        self.ms.set(10000);
+        self.set_next_alarm(10000);
+
+    }
+
+    fn set_next_alarm(&self, ms: u32) {
+        self.ms.set(ms);
+        let now = self.alarm.now();
+        let freq: u64 = <A::Frequency>::frequency() as u64;
+        let lticks: u64 = ms as u64 * freq;
+        let ticks: u32 = (lticks / 1000) as u32;
+        let t = now.wrapping_add(ticks);
+        debug!("Setting alarm to {}", t);
+        self.alarm.set_alarm(t);
+    }
+}
+
+impl<A: Alarm<'a>> AlarmClient for TestAlarm<'a, A> {
+    fn fired(&self) {
+        // Generate a new interval that's irregular
+        let new_ms:u32 = 10 + ((self.ms.get() + 137) % 757);
+        self.set_next_alarm(new_ms);
+    }
+}

--- a/capsules/src/test/mod.rs
+++ b/capsules/src/test/mod.rs
@@ -1,5 +1,6 @@
 pub mod aes;
 pub mod aes_ccm;
+pub mod alarm;
 pub mod rng;
 pub mod udp;
 pub mod virtual_uart;


### PR DESCRIPTION
It fires the first alarm in about 10 seconds, then after that a few times a second, somewhat erratically (to fuzz on edge conditions).

### Pull Request Overview

This pull request adds an alarm test in components/test.


### Testing Strategy

This pull request was tested by instantiating and executing the test on h1b (tock-on-titan).


### TODO or Help Wanted

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make formatall`.
