### PR TITLE
use new components for nrf52 boards

### DIFF
--- a/boards/components/src/button.rs
+++ b/boards/components/src/button.rs
@@ -33,7 +33,7 @@ macro_rules! button_component_helper {
                     (static_init!(InterruptValueWrapper, InterruptValueWrapper::new($P))
                     .finalize(),
                     $M
-                    )
+                    ),
                 )*
             ]
         )

--- a/boards/nordic/nrf52840_dongle/Cargo.toml
+++ b/boards/nordic/nrf52840_dongle/Cargo.toml
@@ -18,6 +18,7 @@ opt-level = "z"
 debug = true
 
 [dependencies]
+components = { path = "../../components" }
 cortexm4 = { path = "../../../arch/cortex-m4" }
 capsules = { path = "../../../capsules" }
 kernel = { path = "../../../kernel" }

--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -64,6 +64,7 @@ pub unsafe fn reset_handler() {
     // GPIOs
     let gpio = components::gpio::GpioComponent::new(board_kernel).finalize(
         components::gpio_component_helper!(
+            // left side of the USB plug
             &nrf52840::gpio::PORT[Pin::P0_13],
             &nrf52840::gpio::PORT[Pin::P0_15],
             &nrf52840::gpio::PORT[Pin::P0_17],
@@ -73,6 +74,7 @@ pub unsafe fn reset_handler() {
             &nrf52840::gpio::PORT[Pin::P1_00],
             &nrf52840::gpio::PORT[Pin::P0_09],
             &nrf52840::gpio::PORT[Pin::P0_10],
+            // right side of the USB plug
             &nrf52840::gpio::PORT[Pin::P0_31],
             &nrf52840::gpio::PORT[Pin::P0_29],
             &nrf52840::gpio::PORT[Pin::P0_02],
@@ -92,12 +94,10 @@ pub unsafe fn reset_handler() {
         ),
     );
     let button = components::button::ButtonComponent::new(board_kernel).finalize(
-        components::button_component_helper!(
-            (
-                &nrf52840::gpio::PORT[BUTTON_PIN],
-                capsules::button::GpioMode::LowWhenPressed
-            ) //16
-        ),
+        components::button_component_helper!((
+            &nrf52840::gpio::PORT[BUTTON_PIN],
+            capsules::button::GpioMode::LowWhenPressed
+        )),
     );
 
     let led = components::led::LedsComponent::new().finalize(components::led_component_helper!(

--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -7,6 +7,7 @@
 #![no_main]
 #![deny(missing_docs)]
 
+use kernel::component::Component;
 #[allow(unused_imports)]
 use kernel::{debug, debug_gpio, debug_verbose, static_init};
 use nrf52840::gpio::Pin;
@@ -59,197 +60,79 @@ pub unsafe fn reset_handler() {
     // Loads relocations and clears BSS
     nrf52840::init();
 
-    // GPIOs
-    let gpio_pins = static_init!(
-        [&'static dyn kernel::hil::gpio::InterruptValuePin; 24],
-        [
-            // Left side of the USB plug
-            static_init!(
-                kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P0_13])
-            )
-            .finalize(),
-            static_init!(
-                kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P0_15])
-            )
-            .finalize(),
-            static_init!(
-                kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P0_17])
-            )
-            .finalize(),
-            static_init!(
-                kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P0_20])
-            )
-            .finalize(),
-            static_init!(
-                kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P0_22])
-            )
-            .finalize(),
-            static_init!(
-                kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P0_24])
-            )
-            .finalize(),
-            static_init!(
-                kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P1_00])
-            )
-            .finalize(),
-            static_init!(
-                kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P0_09])
-            )
-            .finalize(),
-            static_init!(
-                kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P0_10])
-            )
-            .finalize(),
-            // Right side of the USB plug
-            static_init!(
-                kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P0_31])
-            )
-            .finalize(),
-            static_init!(
-                kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P0_29])
-            )
-            .finalize(),
-            static_init!(
-                kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P0_02])
-            )
-            .finalize(),
-            static_init!(
-                kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P1_15])
-            )
-            .finalize(),
-            static_init!(
-                kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P1_13])
-            )
-            .finalize(),
-            static_init!(
-                kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P1_10])
-            )
-            .finalize(),
-            // Below the PCB
-            static_init!(
-                kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P0_26])
-            )
-            .finalize(),
-            static_init!(
-                kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P0_04])
-            )
-            .finalize(),
-            static_init!(
-                kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P0_11])
-            )
-            .finalize(),
-            static_init!(
-                kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P0_14])
-            )
-            .finalize(),
-            static_init!(
-                kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P1_11])
-            )
-            .finalize(),
-            static_init!(
-                kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P1_07])
-            )
-            .finalize(),
-            static_init!(
-                kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P1_01])
-            )
-            .finalize(),
-            static_init!(
-                kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P1_04])
-            )
-            .finalize(),
-            static_init!(
-                kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P1_02])
-            )
-            .finalize(),
-        ]
-    );
-
-    // LEDs
-    let led_pins = static_init!(
-        [(
-            &'static dyn kernel::hil::gpio::Pin,
-            capsules::led::ActivationMode
-        ); 4],
-        [
-            (
-                &nrf52840::gpio::PORT[LED1_PIN],
-                capsules::led::ActivationMode::ActiveLow
-            ),
-            (
-                &nrf52840::gpio::PORT[LED2_R_PIN],
-                capsules::led::ActivationMode::ActiveLow
-            ),
-            (
-                &nrf52840::gpio::PORT[LED2_G_PIN],
-                capsules::led::ActivationMode::ActiveLow
-            ),
-            (
-                &nrf52840::gpio::PORT[LED2_B_PIN],
-                capsules::led::ActivationMode::ActiveLow
-            ),
-        ]
-    );
-
-    let button_pins = static_init!(
-        [(
-            &'static dyn kernel::hil::gpio::InterruptValuePin,
-            capsules::button::GpioMode
-        ); 1],
-        [(
-            static_init!(
-                kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[BUTTON_PIN])
-            )
-            .finalize(),
-            capsules::button::GpioMode::LowWhenPressed
-        ),]
-    );
-
-    for &(btn, _) in button_pins.iter() {
-        btn.set_floating_state(kernel::hil::gpio::FloatingState::PullUp);
-    }
-
     let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
+    // GPIOs
+    let gpio = components::gpio::GpioComponent::new(board_kernel).finalize(
+        components::gpio_component_helper!(
+            &nrf52840::gpio::PORT[Pin::P0_13],
+            &nrf52840::gpio::PORT[Pin::P0_15],
+            &nrf52840::gpio::PORT[Pin::P0_17],
+            &nrf52840::gpio::PORT[Pin::P0_20],
+            &nrf52840::gpio::PORT[Pin::P0_22],
+            &nrf52840::gpio::PORT[Pin::P0_24],
+            &nrf52840::gpio::PORT[Pin::P1_00],
+            &nrf52840::gpio::PORT[Pin::P0_09],
+            &nrf52840::gpio::PORT[Pin::P0_10],
+            &nrf52840::gpio::PORT[Pin::P0_31],
+            &nrf52840::gpio::PORT[Pin::P0_29],
+            &nrf52840::gpio::PORT[Pin::P0_02],
+            &nrf52840::gpio::PORT[Pin::P1_15],
+            &nrf52840::gpio::PORT[Pin::P1_13],
+            &nrf52840::gpio::PORT[Pin::P1_10],
+            // Below the PCB
+            &nrf52840::gpio::PORT[Pin::P0_26],
+            &nrf52840::gpio::PORT[Pin::P0_04],
+            &nrf52840::gpio::PORT[Pin::P0_11],
+            &nrf52840::gpio::PORT[Pin::P0_14],
+            &nrf52840::gpio::PORT[Pin::P1_11],
+            &nrf52840::gpio::PORT[Pin::P1_07],
+            &nrf52840::gpio::PORT[Pin::P1_01],
+            &nrf52840::gpio::PORT[Pin::P1_04],
+            &nrf52840::gpio::PORT[Pin::P1_02]
+        ),
+    );
+    let button = components::button::ButtonComponent::new(board_kernel).finalize(
+        components::button_component_helper!(
+            (
+                &nrf52840::gpio::PORT[BUTTON_PIN],
+                capsules::button::GpioMode::LowWhenPressed
+            ) //16
+        ),
+    );
+
+    let led = components::led::LedsComponent::new().finalize(components::led_component_helper!(
+        (
+            &nrf52840::gpio::PORT[LED1_PIN],
+            capsules::led::ActivationMode::ActiveLow
+        ),
+        (
+            &nrf52840::gpio::PORT[LED2_R_PIN],
+            capsules::led::ActivationMode::ActiveLow
+        ),
+        (
+            &nrf52840::gpio::PORT[LED2_G_PIN],
+            capsules::led::ActivationMode::ActiveLow
+        ),
+        (
+            &nrf52840::gpio::PORT[LED2_B_PIN],
+            capsules::led::ActivationMode::ActiveLow
+        )
+    ));
     let chip = static_init!(nrf52840::chip::Chip, nrf52840::chip::new());
 
     nrf52dk_base::setup_board(
         board_kernel,
         BUTTON_RST_PIN,
         &nrf52840::gpio::PORT,
-        gpio_pins,
+        gpio,
         LED2_R_PIN,
         LED2_G_PIN,
         LED2_B_PIN,
-        led_pins,
+        led,
         &UartPins::new(UART_RTS, UART_TXD, UART_CTS, UART_RXD),
         &SpiPins::new(SPI_MOSI, SPI_MISO, SPI_CLK),
         &None,
-        button_pins,
+        button,
         true,
         &mut APP_MEMORY,
         &mut PROCESSES,

--- a/boards/nordic/nrf52840dk/Cargo.toml
+++ b/boards/nordic/nrf52840dk/Cargo.toml
@@ -18,6 +18,7 @@ opt-level = "z"
 debug = true
 
 [dependencies]
+components = { path = "../../components" }
 cortexm4 = { path = "../../../arch/cortex-m4" }
 capsules = { path = "../../../capsules" }
 kernel = { path = "../../../kernel" }

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -64,6 +64,7 @@
 #![no_main]
 #![deny(missing_docs)]
 
+use kernel::component::Component;
 #[allow(unused_imports)]
 use kernel::{debug, debug_gpio, debug_verbose, static_init};
 use nrf52840::gpio::Pin;
@@ -122,184 +123,77 @@ pub unsafe fn reset_handler() {
     // Loads relocations and clears BSS
     nrf52840::init();
 
-    // GPIOs
-    let gpio_pins = static_init!(
-        [&'static dyn kernel::hil::gpio::InterruptValuePin; 16],
-        [
-            static_init!(
-                kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P1_01])
-            )
-            .finalize(),
-            static_init!(
-                kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P1_02])
-            )
-            .finalize(),
-            static_init!(
-                kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P1_03])
-            )
-            .finalize(),
-            static_init!(
-                kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P1_04])
-            )
-            .finalize(),
-            static_init!(
-                kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P1_05])
-            )
-            .finalize(),
-            static_init!(
-                kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P1_06])
-            )
-            .finalize(),
-            static_init!(
-                kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P1_07])
-            )
-            .finalize(),
-            static_init!(
-                kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P1_08])
-            )
-            .finalize(),
-            static_init!(
-                kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P1_10])
-            )
-            .finalize(),
-            static_init!(
-                kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P1_11])
-            )
-            .finalize(),
-            static_init!(
-                kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P1_12])
-            )
-            .finalize(),
-            static_init!(
-                kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P1_13])
-            )
-            .finalize(),
-            static_init!(
-                kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P1_14])
-            )
-            .finalize(),
-            static_init!(
-                kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P1_15])
-            )
-            .finalize(),
-            static_init!(
-                kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P0_26])
-            )
-            .finalize(),
-            static_init!(
-                kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52840::gpio::PORT[Pin::P0_27])
-            )
-            .finalize(),
-        ]
-    );
-
-    // LEDs
-    let led_pins = static_init!(
-        [(
-            &'static dyn kernel::hil::gpio::Pin,
-            capsules::led::ActivationMode
-        ); 4],
-        [
-            (
-                &nrf52840::gpio::PORT[LED1_PIN],
-                capsules::led::ActivationMode::ActiveLow
-            ),
-            (
-                &nrf52840::gpio::PORT[LED2_PIN],
-                capsules::led::ActivationMode::ActiveLow
-            ),
-            (
-                &nrf52840::gpio::PORT[LED3_PIN],
-                capsules::led::ActivationMode::ActiveLow
-            ),
-            (
-                &nrf52840::gpio::PORT[LED4_PIN],
-                capsules::led::ActivationMode::ActiveLow
-            ),
-        ]
-    );
-
-    let button_pins = static_init!(
-        [(
-            &'static dyn kernel::hil::gpio::InterruptValuePin,
-            capsules::button::GpioMode
-        ); 4],
-        [
-            (
-                static_init!(
-                    kernel::hil::gpio::InterruptValueWrapper,
-                    kernel::hil::gpio::InterruptValueWrapper::new(
-                        &nrf52840::gpio::PORT[BUTTON1_PIN]
-                    )
-                )
-                .finalize(),
-                capsules::button::GpioMode::LowWhenPressed
-            ), // 13
-            (
-                static_init!(
-                    kernel::hil::gpio::InterruptValueWrapper,
-                    kernel::hil::gpio::InterruptValueWrapper::new(
-                        &nrf52840::gpio::PORT[BUTTON2_PIN]
-                    )
-                )
-                .finalize(),
-                capsules::button::GpioMode::LowWhenPressed
-            ), // 14
-            (
-                static_init!(
-                    kernel::hil::gpio::InterruptValueWrapper,
-                    kernel::hil::gpio::InterruptValueWrapper::new(
-                        &nrf52840::gpio::PORT[BUTTON3_PIN]
-                    )
-                )
-                .finalize(),
-                capsules::button::GpioMode::LowWhenPressed
-            ), // 15
-            (
-                static_init!(
-                    kernel::hil::gpio::InterruptValueWrapper,
-                    kernel::hil::gpio::InterruptValueWrapper::new(
-                        &nrf52840::gpio::PORT[BUTTON4_PIN]
-                    )
-                )
-                .finalize(),
-                capsules::button::GpioMode::LowWhenPressed
-            ), // 16
-        ]
-    );
-
-    for &(btn, _) in button_pins.iter() {
-        btn.set_floating_state(kernel::hil::gpio::FloatingState::PullUp);
-    }
-
     let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
+    let gpio = components::gpio::GpioComponent::new(board_kernel).finalize(
+        components::gpio_component_helper!(
+            &nrf52840::gpio::PORT[Pin::P1_01],
+            &nrf52840::gpio::PORT[Pin::P1_02],
+            &nrf52840::gpio::PORT[Pin::P1_03],
+            &nrf52840::gpio::PORT[Pin::P1_04],
+            &nrf52840::gpio::PORT[Pin::P1_05],
+            &nrf52840::gpio::PORT[Pin::P1_06],
+            &nrf52840::gpio::PORT[Pin::P1_07],
+            &nrf52840::gpio::PORT[Pin::P1_08],
+            &nrf52840::gpio::PORT[Pin::P1_10],
+            &nrf52840::gpio::PORT[Pin::P1_11],
+            &nrf52840::gpio::PORT[Pin::P1_12],
+            &nrf52840::gpio::PORT[Pin::P1_13],
+            &nrf52840::gpio::PORT[Pin::P1_14],
+            &nrf52840::gpio::PORT[Pin::P1_15],
+            &nrf52840::gpio::PORT[Pin::P0_26],
+            &nrf52840::gpio::PORT[Pin::P0_27]
+        ),
+    );
+    let button = components::button::ButtonComponent::new(board_kernel).finalize(
+        components::button_component_helper!(
+            (
+                &nrf52840::gpio::PORT[BUTTON1_PIN],
+                capsules::button::GpioMode::LowWhenPressed
+            ), //13
+            (
+                &nrf52840::gpio::PORT[BUTTON2_PIN],
+                capsules::button::GpioMode::LowWhenPressed
+            ), //14
+            (
+                &nrf52840::gpio::PORT[BUTTON3_PIN],
+                capsules::button::GpioMode::LowWhenPressed
+            ), //15
+            (
+                &nrf52840::gpio::PORT[BUTTON4_PIN],
+                capsules::button::GpioMode::LowWhenPressed
+            ) //16
+        ),
+    );
+
+    let led = components::led::LedsComponent::new().finalize(components::led_component_helper!(
+        (
+            &nrf52840::gpio::PORT[LED1_PIN],
+            capsules::led::ActivationMode::ActiveLow
+        ),
+        (
+            &nrf52840::gpio::PORT[LED2_PIN],
+            capsules::led::ActivationMode::ActiveLow
+        ),
+        (
+            &nrf52840::gpio::PORT[LED3_PIN],
+            capsules::led::ActivationMode::ActiveLow
+        ),
+        (
+            &nrf52840::gpio::PORT[LED4_PIN],
+            capsules::led::ActivationMode::ActiveLow
+        )
+    ));
     let chip = static_init!(nrf52840::chip::Chip, nrf52840::chip::new());
 
     nrf52dk_base::setup_board(
         board_kernel,
         BUTTON_RST_PIN,
         &nrf52840::gpio::PORT,
-        gpio_pins,
+        gpio,
         LED1_PIN,
         LED2_PIN,
         LED3_PIN,
-        led_pins,
+        led,
         &UartPins::new(UART_RTS, UART_TXD, UART_CTS, UART_RXD),
         &SpiPins::new(SPI_MOSI, SPI_MISO, SPI_CLK),
         &Some(SpiMX25R6435FPins::new(
@@ -307,7 +201,7 @@ pub unsafe fn reset_handler() {
             SPI_MX25R6435F_WRITE_PROTECT_PIN,
             SPI_MX25R6435F_HOLD_PIN,
         )),
-        button_pins,
+        button,
         true,
         &mut APP_MEMORY,
         &mut PROCESSES,

--- a/boards/nordic/nrf52dk/Cargo.toml
+++ b/boards/nordic/nrf52dk/Cargo.toml
@@ -18,6 +18,7 @@ opt-level = "z"
 debug = true
 
 [dependencies]
+components = { path = "../../components" }
 cortexm4 = { path = "../../../arch/cortex-m4" }
 capsules = { path = "../../../capsules" }
 kernel = { path = "../../../kernel" }

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -128,14 +128,17 @@ pub unsafe fn reset_handler() {
     let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
     let gpio = components::gpio::GpioComponent::new(board_kernel).finalize(
         components::gpio_component_helper!(
+            // Bottom right header on DK board
             &nrf52832::gpio::PORT[Pin::P0_03],
             &nrf52832::gpio::PORT[Pin::P0_04],
             &nrf52832::gpio::PORT[Pin::P0_28],
             &nrf52832::gpio::PORT[Pin::P0_29],
             &nrf52832::gpio::PORT[Pin::P0_30],
             &nrf52832::gpio::PORT[Pin::P0_31],
+            // Top mid header on DK board
             &nrf52832::gpio::PORT[Pin::P0_12],
             &nrf52832::gpio::PORT[Pin::P0_11],
+            // Top left header on DK board
             &nrf52832::gpio::PORT[Pin::P0_27],
             &nrf52832::gpio::PORT[Pin::P0_26],
             &nrf52832::gpio::PORT[Pin::P0_02],

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -64,6 +64,7 @@
 #![no_main]
 #![deny(missing_docs)]
 
+use kernel::component::Component;
 #[allow(unused_imports)]
 use kernel::{debug, debug_gpio, debug_verbose, static_init};
 use nrf52832::gpio::Pin;
@@ -124,170 +125,77 @@ pub unsafe fn reset_handler() {
     // Loads relocations and clears BSS
     nrf52832::init();
 
-    let gpio_pins = static_init!(
-        [&'static dyn kernel::hil::gpio::InterruptValuePin; 12],
-        [
-            // Bottom right header on DK board
-            static_init!(
-                kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[Pin::P0_03])
-            )
-            .finalize(),
-            static_init!(
-                kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[Pin::P0_04])
-            )
-            .finalize(),
-            static_init!(
-                kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[Pin::P0_28])
-            )
-            .finalize(),
-            static_init!(
-                kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[Pin::P0_29])
-            )
-            .finalize(),
-            static_init!(
-                kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[Pin::P0_30])
-            )
-            .finalize(),
-            static_init!(
-                kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[Pin::P0_31])
-            )
-            .finalize(),
-            // Top mid header on DK board
-            static_init!(
-                kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[Pin::P0_12])
-            )
-            .finalize(),
-            static_init!(
-                kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[Pin::P0_11])
-            )
-            .finalize(),
-            // Top left header on DK board
-            static_init!(
-                kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[Pin::P0_27])
-            )
-            .finalize(),
-            static_init!(
-                kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[Pin::P0_26])
-            )
-            .finalize(),
-            static_init!(
-                kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[Pin::P0_02])
-            )
-            .finalize(),
-            static_init!(
-                kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&nrf52832::gpio::PORT[Pin::P0_25])
-            )
-            .finalize(),
-        ]
-    );
-
-    // LEDs
-    let led_pins = static_init!(
-        [(
-            &'static dyn kernel::hil::gpio::Pin,
-            capsules::led::ActivationMode
-        ); 4],
-        [
-            (
-                &nrf52832::gpio::PORT[LED1_PIN],
-                capsules::led::ActivationMode::ActiveLow
-            ),
-            (
-                &nrf52832::gpio::PORT[LED2_PIN],
-                capsules::led::ActivationMode::ActiveLow
-            ),
-            (
-                &nrf52832::gpio::PORT[LED3_PIN],
-                capsules::led::ActivationMode::ActiveLow
-            ),
-            (
-                &nrf52832::gpio::PORT[LED4_PIN],
-                capsules::led::ActivationMode::ActiveLow
-            ),
-        ]
-    );
-
-    let button_pins = static_init!(
-        [(
-            &'static dyn kernel::hil::gpio::InterruptValuePin,
-            capsules::button::GpioMode
-        ); 4],
-        [
-            (
-                static_init!(
-                    kernel::hil::gpio::InterruptValueWrapper,
-                    kernel::hil::gpio::InterruptValueWrapper::new(
-                        &nrf52832::gpio::PORT[BUTTON1_PIN]
-                    )
-                )
-                .finalize(),
-                capsules::button::GpioMode::LowWhenPressed
-            ), // 13
-            (
-                static_init!(
-                    kernel::hil::gpio::InterruptValueWrapper,
-                    kernel::hil::gpio::InterruptValueWrapper::new(
-                        &nrf52832::gpio::PORT[BUTTON2_PIN]
-                    )
-                )
-                .finalize(),
-                capsules::button::GpioMode::LowWhenPressed
-            ), // 14
-            (
-                static_init!(
-                    kernel::hil::gpio::InterruptValueWrapper,
-                    kernel::hil::gpio::InterruptValueWrapper::new(
-                        &nrf52832::gpio::PORT[BUTTON3_PIN]
-                    )
-                )
-                .finalize(),
-                capsules::button::GpioMode::LowWhenPressed
-            ), // 15
-            (
-                static_init!(
-                    kernel::hil::gpio::InterruptValueWrapper,
-                    kernel::hil::gpio::InterruptValueWrapper::new(
-                        &nrf52832::gpio::PORT[BUTTON4_PIN]
-                    )
-                )
-                .finalize(),
-                capsules::button::GpioMode::LowWhenPressed
-            ), // 16
-        ]
-    );
-
-    for &(btn, _) in button_pins.iter() {
-        btn.set_floating_state(kernel::hil::gpio::FloatingState::PullUp);
-    }
-
     let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
+    let gpio = components::gpio::GpioComponent::new(board_kernel).finalize(
+        components::gpio_component_helper!(
+            &nrf52832::gpio::PORT[Pin::P0_03],
+            &nrf52832::gpio::PORT[Pin::P0_04],
+            &nrf52832::gpio::PORT[Pin::P0_28],
+            &nrf52832::gpio::PORT[Pin::P0_29],
+            &nrf52832::gpio::PORT[Pin::P0_30],
+            &nrf52832::gpio::PORT[Pin::P0_31],
+            &nrf52832::gpio::PORT[Pin::P0_12],
+            &nrf52832::gpio::PORT[Pin::P0_11],
+            &nrf52832::gpio::PORT[Pin::P0_27],
+            &nrf52832::gpio::PORT[Pin::P0_26],
+            &nrf52832::gpio::PORT[Pin::P0_02],
+            &nrf52832::gpio::PORT[Pin::P0_25]
+        ),
+    );
+    let button = components::button::ButtonComponent::new(board_kernel).finalize(
+        components::button_component_helper!(
+            (
+                &nrf52832::gpio::PORT[BUTTON1_PIN],
+                capsules::button::GpioMode::LowWhenPressed
+            ), //13
+            (
+                &nrf52832::gpio::PORT[BUTTON2_PIN],
+                capsules::button::GpioMode::LowWhenPressed
+            ), //14
+            (
+                &nrf52832::gpio::PORT[BUTTON3_PIN],
+                capsules::button::GpioMode::LowWhenPressed
+            ), //15
+            (
+                &nrf52832::gpio::PORT[BUTTON4_PIN],
+                capsules::button::GpioMode::LowWhenPressed
+            ) //16
+        ),
+    );
+
+    let led = components::led::LedsComponent::new().finalize(components::led_component_helper!(
+        (
+            &nrf52832::gpio::PORT[LED1_PIN],
+            capsules::led::ActivationMode::ActiveLow
+        ),
+        (
+            &nrf52832::gpio::PORT[LED2_PIN],
+            capsules::led::ActivationMode::ActiveLow
+        ),
+        (
+            &nrf52832::gpio::PORT[LED3_PIN],
+            capsules::led::ActivationMode::ActiveLow
+        ),
+        (
+            &nrf52832::gpio::PORT[LED4_PIN],
+            capsules::led::ActivationMode::ActiveLow
+        )
+    ));
     let chip = static_init!(nrf52832::chip::Chip, nrf52832::chip::new());
 
     nrf52dk_base::setup_board(
         board_kernel,
         BUTTON_RST_PIN,
         &nrf52832::gpio::PORT,
-        gpio_pins,
+        gpio,
         LED1_PIN,
         LED2_PIN,
         LED3_PIN,
-        led_pins,
+        led,
         &UartPins::new(UART_RTS, UART_TXD, UART_CTS, UART_RXD),
         &SpiPins::new(SPI_MOSI, SPI_MISO, SPI_CLK),
         &None,
-        button_pins,
+        button,
         false,
         &mut APP_MEMORY,
         &mut PROCESSES,

--- a/boards/nordic/nrf52dk_base/src/lib.rs
+++ b/boards/nordic/nrf52dk_base/src/lib.rs
@@ -131,21 +131,15 @@ pub unsafe fn setup_board<I: nrf52::interrupt_service::InterruptService>(
     board_kernel: &'static kernel::Kernel,
     button_rst_pin: Pin,
     gpio_port: &'static nrf52::gpio::Port,
-    gpio_pins: &'static mut [&'static dyn kernel::hil::gpio::InterruptValuePin],
+    gpio: &'static capsules::gpio::GPIO<'static>,
     debug_pin1_index: Pin,
     debug_pin2_index: Pin,
     debug_pin3_index: Pin,
-    led_pins: &'static mut [(
-        &'static dyn kernel::hil::gpio::Pin,
-        capsules::led::ActivationMode,
-    )],
+    led: &'static capsules::led::LED<'static>,
     uart_pins: &UartPins,
     spi_pins: &SpiPins,
     mx25r6435f: &Option<SpiMX25R6435FPins>,
-    button_pins: &'static mut [(
-        &'static dyn kernel::hil::gpio::InterruptValuePin,
-        capsules::button::GpioMode,
-    )],
+    button: &'static capsules::button::Button<'static>,
     ieee802154: bool,
     app_memory: &mut [u8],
     process_pointers: &'static mut [Option<&'static dyn kernel::procs::ProcessType>],
@@ -230,37 +224,6 @@ pub unsafe fn setup_board<I: nrf52::interrupt_service::InterruptService>(
         Some(&gpio_port[debug_pin2_index]),
         Some(&gpio_port[debug_pin3_index]),
     );
-
-    let gpio = static_init!(
-        capsules::gpio::GPIO<'static>,
-        capsules::gpio::GPIO::new(
-            gpio_pins,
-            board_kernel.create_grant(&memory_allocation_capability)
-        )
-    );
-
-    for pin in gpio_pins.iter() {
-        pin.set_client(gpio);
-    }
-
-    // LEDs
-    let led = static_init!(
-        capsules::led::LED<'static>,
-        capsules::led::LED::new(led_pins)
-    );
-
-    // Buttons
-    let button = static_init!(
-        capsules::button::Button<'static>,
-        capsules::button::Button::new(
-            button_pins,
-            board_kernel.create_grant(&memory_allocation_capability)
-        )
-    );
-
-    for (pin, _) in button_pins.iter() {
-        pin.set_client(button);
-    }
 
     let rtc = &nrf52::rtc::RTC;
     rtc.start();


### PR DESCRIPTION
### Pull Request Overview

This pull request changes the nrf52 initialization code to use the general components for UartMux, AlarmMux, Led, Button, and GPIO, and adds the process console. This required some refactoring to move the entirety of the capsule instantiation for Led/Button/Gpio into the respective main for each board rather than just defining the pins in each specific board and instantiating the capsule in nrf52dk_base.

It also fixes a missing comma in the button_component_helper!() macro that made it only work for a single button.

### Testing Strategy

Flashing several apps and testing the process console on the nrf52840dk.

### Documentation Updated

- [x] no updates are required.

### Formatting

- [x] Ran `make formatall`.
