### PR TITLE
Add support for USB bulk/interrupt on the nrf52 chip.

### DIFF
--- a/capsules/src/usb/descriptors.rs
+++ b/capsules/src/usb/descriptors.rs
@@ -4,6 +4,7 @@ use core::cell::Cell;
 use core::convert::From;
 use core::fmt;
 use kernel::common::cells::VolatileCell;
+use kernel::hil::usb::TransferType;
 
 // On Nordic, USB buffers must be 32-bit aligned, with a power-of-2 size. For now we apply these
 // constraints on all platforms.
@@ -490,14 +491,6 @@ impl EndpointAddress {
     pub const fn new_const(endpoint: usize, direction: TransferDirection) -> Self {
         EndpointAddress(endpoint as u8 & 0xf | (direction as u8) << 7)
     }
-}
-
-#[derive(Copy, Clone)]
-pub enum TransferType {
-    Control = 0,
-    Isochronous,
-    Bulk,
-    Interrupt,
 }
 
 pub struct EndpointDescriptor {

--- a/capsules/src/usb/usb_user.rs
+++ b/capsules/src/usb/usb_user.rs
@@ -37,7 +37,7 @@ pub struct App {
     awaiting: Option<Request>,
 }
 
-pub struct UsbSyscallDriver<'a, C: hil::usb::Client> {
+pub struct UsbSyscallDriver<'a, C: hil::usb::Client<'a>> {
     usbc_client: &'a C,
     apps: Grant<App>,
     serving_app: OptionalCell<AppId>,
@@ -45,7 +45,7 @@ pub struct UsbSyscallDriver<'a, C: hil::usb::Client> {
 
 impl<C> UsbSyscallDriver<'a, C>
 where
-    C: hil::usb::Client,
+    C: hil::usb::Client<'a>,
 {
     pub fn new(usbc_client: &'a C, apps: Grant<App>) -> Self {
         UsbSyscallDriver {
@@ -98,9 +98,9 @@ enum Request {
     EnableAndAttach,
 }
 
-impl<C> Driver for UsbSyscallDriver<'a, C>
+impl<'a, C> Driver for UsbSyscallDriver<'a, C>
 where
-    C: hil::usb::Client,
+    C: hil::usb::Client<'a>,
 {
     fn subscribe(
         &self,

--- a/capsules/src/usb/usbc_client.rs
+++ b/capsules/src/usb/usbc_client.rs
@@ -7,12 +7,12 @@ use super::descriptors::DeviceDescriptor;
 use super::descriptors::EndpointAddress;
 use super::descriptors::EndpointDescriptor;
 use super::descriptors::TransferDirection;
-use super::descriptors::TransferType;
 use super::usbc_client_ctrl::ClientCtrl;
 use core::cell::Cell;
 use kernel::common::cells::VolatileCell;
 use kernel::debug;
 use kernel::hil;
+use kernel::hil::usb::TransferType;
 
 const VENDOR_ID: u16 = 0x6667;
 const PRODUCT_ID: u16 = 0xabcd;
@@ -54,11 +54,10 @@ pub struct Client<'a, C: 'a> {
     // from an OUT endpoint back to an IN endpoint
     echo_buf: [Cell<u8>; 8], // Must be no larger than endpoint packet buffer
     echo_len: Cell<usize>,
-    delayed_in: Cell<bool>,
     delayed_out: Cell<bool>,
 }
 
-impl<C: hil::usb::UsbController> Client<'a, C> {
+impl<'a, C: hil::usb::UsbController<'a>> Client<'a, C> {
     pub fn new(controller: &'a C) -> Self {
         Client {
             client_ctrl: ClientCtrl::new(
@@ -82,29 +81,25 @@ impl<C: hil::usb::UsbController> Client<'a, C> {
             buffers: Default::default(),
             echo_buf: Default::default(),
             echo_len: Cell::new(0),
-            delayed_in: Cell::new(false),
             delayed_out: Cell::new(false),
         }
     }
 
-    fn alert_full(&self) {
-        // In case we reported Delay before, alert the controller
-        // that we now have data to send on the Bulk IN endpoint 1
-        if self.delayed_in.take() {
-            self.controller().endpoint_bulk_resume(1);
-        }
+    fn alert_full(&'a self) {
+        // Alert the controller that we now have data to send on the Bulk IN endpoint 1
+        self.controller().endpoint_resume_in(1);
     }
 
-    fn alert_empty(&self) {
+    fn alert_empty(&'a self) {
         // In case we reported Delay before, alert the controller
         // that we can now receive data on the Bulk OUT endpoint 2
         if self.delayed_out.take() {
-            self.controller().endpoint_bulk_resume(2);
+            self.controller().endpoint_resume_out(2);
         }
     }
 
     #[inline]
-    fn controller(&self) -> &'a C {
+    fn controller(&'a self) -> &'a C {
         self.client_ctrl.controller()
     }
 
@@ -114,25 +109,25 @@ impl<C: hil::usb::UsbController> Client<'a, C> {
     }
 }
 
-impl<C: hil::usb::UsbController> hil::usb::Client for Client<'a, C> {
-    fn enable(&self) {
+impl<'a, C: hil::usb::UsbController<'a>> hil::usb::Client<'a> for Client<'a, C> {
+    fn enable(&'a self) {
         // Set up the default control endpoint
         self.client_ctrl.enable();
 
         // Set up a bulk-in endpoint for debugging
         self.controller().endpoint_set_buffer(1, self.buffer(1));
-        self.controller().endpoint_bulk_in_enable(1);
+        self.controller().endpoint_in_enable(TransferType::Bulk, 1);
 
         // Set up a bulk-out endpoint for debugging
         self.controller().endpoint_set_buffer(2, self.buffer(2));
-        self.controller().endpoint_bulk_out_enable(2);
+        self.controller().endpoint_out_enable(TransferType::Bulk, 2);
     }
 
-    fn attach(&self) {
+    fn attach(&'a self) {
         self.client_ctrl.attach();
     }
 
-    fn bus_reset(&self) {
+    fn bus_reset(&'a self) {
         // Should the client initiate reconfiguration here?
         // For now, the hardware layer does it.
 
@@ -140,86 +135,108 @@ impl<C: hil::usb::UsbController> hil::usb::Client for Client<'a, C> {
 
         // Reset the state for our pair of debugging endpoints
         self.echo_len.set(0);
-        self.delayed_in.set(false);
         self.delayed_out.set(false);
     }
 
     /// Handle a Control Setup transaction
-    fn ctrl_setup(&self, endpoint: usize) -> hil::usb::CtrlSetupResult {
+    fn ctrl_setup(&'a self, endpoint: usize) -> hil::usb::CtrlSetupResult {
         self.client_ctrl.ctrl_setup(endpoint)
     }
 
     /// Handle a Control In transaction
-    fn ctrl_in(&self, endpoint: usize) -> hil::usb::CtrlInResult {
+    fn ctrl_in(&'a self, endpoint: usize) -> hil::usb::CtrlInResult {
         self.client_ctrl.ctrl_in(endpoint)
     }
 
     /// Handle a Control Out transaction
-    fn ctrl_out(&self, endpoint: usize, packet_bytes: u32) -> hil::usb::CtrlOutResult {
+    fn ctrl_out(&'a self, endpoint: usize, packet_bytes: u32) -> hil::usb::CtrlOutResult {
         self.client_ctrl.ctrl_out(endpoint, packet_bytes)
     }
 
-    fn ctrl_status(&self, endpoint: usize) {
+    fn ctrl_status(&'a self, endpoint: usize) {
         self.client_ctrl.ctrl_status(endpoint)
     }
 
     /// Handle the completion of a Control transfer
-    fn ctrl_status_complete(&self, endpoint: usize) {
+    fn ctrl_status_complete(&'a self, endpoint: usize) {
         self.client_ctrl.ctrl_status_complete(endpoint)
     }
 
-    /// Handle a Bulk IN transaction
-    fn bulk_in(&self, endpoint: usize) -> hil::usb::BulkInResult {
-        // Write a packet into the endpoint buffer
-
-        let packet_bytes = self.echo_len.get();
-        if packet_bytes > 0 {
-            // Copy the entire echo buffer into the packet
-            let packet = self.buffer(endpoint);
-            for i in 0..packet_bytes {
-                packet[i].set(self.echo_buf[i].get());
+    /// Handle a Bulk/Interrupt IN transaction
+    fn packet_in(&'a self, transfer_type: TransferType, endpoint: usize) -> hil::usb::InResult {
+        match transfer_type {
+            TransferType::Interrupt => {
+                debug!("interrupt_in({}) not implemented", endpoint);
+                hil::usb::InResult::Error
             }
-            self.echo_len.set(0);
+            TransferType::Bulk => {
+                // Write a packet into the endpoint buffer
+                let packet_bytes = self.echo_len.get();
+                if packet_bytes > 0 {
+                    // Copy the entire echo buffer into the packet
+                    let packet = self.buffer(endpoint);
+                    for i in 0..packet_bytes {
+                        packet[i].set(self.echo_buf[i].get());
+                    }
+                    self.echo_len.set(0);
 
-            // We can receive more now
-            self.alert_empty();
+                    // We can receive more now
+                    self.alert_empty();
 
-            hil::usb::BulkInResult::Packet(packet_bytes)
-        } else {
-            // Nothing to send
-            self.delayed_in.set(true);
-            hil::usb::BulkInResult::Delay
+                    hil::usb::InResult::Packet(packet_bytes)
+                } else {
+                    // Nothing to send
+                    hil::usb::InResult::Delay
+                }
+            }
+            TransferType::Control | TransferType::Isochronous => unreachable!(),
         }
     }
 
-    /// Handle a Bulk OUT transaction
-    fn bulk_out(&self, endpoint: usize, packet_bytes: u32) -> hil::usb::BulkOutResult {
-        // Consume a packet from the endpoint buffer
-
-        let new_len = packet_bytes as usize;
-        let current_len = self.echo_len.get();
-        let total_len = current_len + new_len as usize;
-
-        if total_len > self.echo_buf.len() {
-            // The packet won't fit in our little buffer.  We'll have
-            // to wait until it is drained
-            self.delayed_out.set(true);
-            hil::usb::BulkOutResult::Delay
-        } else if new_len > 0 {
-            // Copy the packet into our echo buffer
-            let packet = self.buffer(endpoint);
-            for i in 0..new_len {
-                self.echo_buf[current_len + i].set(packet[i].get());
+    /// Handle a Bulk/Interrupt OUT transaction
+    fn packet_out(
+        &'a self,
+        transfer_type: TransferType,
+        endpoint: usize,
+        packet_bytes: u32,
+    ) -> hil::usb::OutResult {
+        match transfer_type {
+            TransferType::Interrupt => {
+                debug!("interrupt_out({}) not implemented", endpoint);
+                hil::usb::OutResult::Error
             }
-            self.echo_len.set(total_len);
+            TransferType::Bulk => {
+                // Consume a packet from the endpoint buffer
+                let new_len = packet_bytes as usize;
+                let current_len = self.echo_len.get();
+                let total_len = current_len + new_len as usize;
 
-            // We can start sending again
-            self.alert_full();
+                if total_len > self.echo_buf.len() {
+                    // The packet won't fit in our little buffer.  We'll have
+                    // to wait until it is drained
+                    self.delayed_out.set(true);
+                    hil::usb::OutResult::Delay
+                } else if new_len > 0 {
+                    // Copy the packet into our echo buffer
+                    let packet = self.buffer(endpoint);
+                    for i in 0..new_len {
+                        self.echo_buf[current_len + i].set(packet[i].get());
+                    }
+                    self.echo_len.set(total_len);
 
-            hil::usb::BulkOutResult::Ok
-        } else {
-            debug!("Ignoring zero-length OUT packet");
-            hil::usb::BulkOutResult::Ok
+                    // We can start sending again
+                    self.alert_full();
+                    hil::usb::OutResult::Ok
+                } else {
+                    debug!("Ignoring zero-length OUT packet");
+                    hil::usb::OutResult::Ok
+                }
+            }
+            TransferType::Control | TransferType::Isochronous => unreachable!(),
         }
+    }
+
+    fn packet_transmitted(&'a self, _endpoint: usize) {
+        // Nothing to do.
     }
 }

--- a/capsules/src/usb/usbc_client_ctrl.rs
+++ b/capsules/src/usb/usbc_client_ctrl.rs
@@ -20,6 +20,7 @@ use super::descriptors::TransferDirection;
 use core::cell::Cell;
 use core::cmp::min;
 use kernel::hil;
+use kernel::hil::usb::TransferType;
 
 const DESCRIPTOR_BUFLEN: usize = 64;
 
@@ -84,7 +85,7 @@ impl Default for State {
     }
 }
 
-impl<C: hil::usb::UsbController> ClientCtrl<'a, 'b, C> {
+impl<'a, 'b, C: hil::usb::UsbController<'a>> ClientCtrl<'a, 'b, C> {
     pub fn new(
         controller: &'a C,
         device_descriptor: DeviceDescriptor,
@@ -188,7 +189,7 @@ impl<C: hil::usb::UsbController> ClientCtrl<'a, 'b, C> {
     }
 
     #[inline]
-    pub fn controller(&self) -> &'a C {
+    pub fn controller(&'a self) -> &'a C {
         self.controller
     }
 
@@ -197,21 +198,22 @@ impl<C: hil::usb::UsbController> ClientCtrl<'a, 'b, C> {
         &self.descriptor_storage
     }
 
-    pub fn enable(&self) {
+    pub fn enable(&'a self) {
         // Set up the default control endpoint
         self.controller
             .endpoint_set_buffer(0, &self.ctrl_buffer.buf);
         self.controller
             .enable_as_device(hil::usb::DeviceSpeed::Full); // must be Full for Bulk transfers
-        self.controller.endpoint_ctrl_out_enable(0);
+        self.controller
+            .endpoint_out_enable(TransferType::Control, 0);
     }
 
-    pub fn attach(&self) {
+    pub fn attach(&'a self) {
         self.controller.attach();
     }
 
     /// Handle a Control Setup transaction
-    pub fn ctrl_setup(&self, endpoint: usize) -> hil::usb::CtrlSetupResult {
+    pub fn ctrl_setup(&'a self, endpoint: usize) -> hil::usb::CtrlSetupResult {
         if endpoint != 0 {
             // For now we only support the default Control endpoint
             return hil::usb::CtrlSetupResult::ErrInvalidDeviceIndex;
@@ -257,7 +259,7 @@ impl<C: hil::usb::UsbController> ClientCtrl<'a, 'b, C> {
     }
 
     fn handle_standard_device_request(
-        &self,
+        &'a self,
         endpoint: usize,
         request: StandardRequest,
     ) -> hil::usb::CtrlSetupResult {
@@ -379,7 +381,7 @@ impl<C: hil::usb::UsbController> ClientCtrl<'a, 'b, C> {
     }
 
     fn handle_standard_interface_request(
-        &self,
+        &'a self,
         endpoint: usize,
         request: StandardRequest,
     ) -> hil::usb::CtrlSetupResult {
@@ -421,7 +423,7 @@ impl<C: hil::usb::UsbController> ClientCtrl<'a, 'b, C> {
     }
 
     /// Handle a Control In transaction
-    pub fn ctrl_in(&self, endpoint: usize) -> hil::usb::CtrlInResult {
+    pub fn ctrl_in(&'a self, endpoint: usize) -> hil::usb::CtrlInResult {
         match self.state[endpoint].get() {
             State::CtrlIn(start, end) => {
                 let len = end.saturating_sub(start);
@@ -451,7 +453,7 @@ impl<C: hil::usb::UsbController> ClientCtrl<'a, 'b, C> {
     }
 
     /// Handle a Control Out transaction
-    pub fn ctrl_out(&self, endpoint: usize, _packet_bytes: u32) -> hil::usb::CtrlOutResult {
+    pub fn ctrl_out(&'a self, endpoint: usize, _packet_bytes: u32) -> hil::usb::CtrlOutResult {
         match self.state[endpoint].get() {
             State::CtrlOut => {
                 // Gamely accept the data
@@ -464,12 +466,12 @@ impl<C: hil::usb::UsbController> ClientCtrl<'a, 'b, C> {
         }
     }
 
-    pub fn ctrl_status(&self, _endpoint: usize) {
+    pub fn ctrl_status(&'a self, _endpoint: usize) {
         // Entered Status stage
     }
 
     /// Handle the completion of a Control transfer
-    pub fn ctrl_status_complete(&self, endpoint: usize) {
+    pub fn ctrl_status_complete(&'a self, endpoint: usize) {
         // Control Read: IN request acknowledged
         // Control Write: status sent
 

--- a/chips/nrf52/src/usbd.rs
+++ b/chips/nrf52/src/usbd.rs
@@ -60,7 +60,7 @@ const USBD_BASE: StaticRef<UsbdRegisters<'static>> =
     unsafe { StaticRef::new(0x40027000 as *const UsbdRegisters<'static>) };
 
 const USBERRATA_BASE: StaticRef<UsbErrataRegisters> =
-    unsafe { StaticRef::new(0x4006EC00 as *const UsbErrataRegisters) };
+    unsafe { StaticRef::new(0x4006E000 as *const UsbErrataRegisters) };
 
 const NUM_ENDPOINTS: usize = 8;
 
@@ -75,15 +75,16 @@ register_structs! {
     },
 
     UsbErrataRegisters {
+        (0x000 => _reserved0),
         /// Undocumented register - Errata 171
-        (0x000 => reg0: ReadWrite<u32>),
-        (0x004 => _reserved1),
+        (0xC00 => reg_c00: ReadWrite<u32>),
+        (0xC04 => _reserved1),
         /// Undocumented register - Errata 171
-        (0x014 => reg14: WriteOnly<u32>),
-        (0x018 => _reserved2),
+        (0xC14 => reg_c14: WriteOnly<u32>),
+        (0xC18 => _reserved2),
         /// Undocumented register - Errata 187
-        (0x114 => reg114: WriteOnly<u32>),
-        (0x118 => @END),
+        (0xD14 => reg_d14: WriteOnly<u32>),
+        (0xD18 => @END),
     }
 }
 
@@ -777,12 +778,12 @@ impl<'a> Usbd<'a> {
         if self.has_errata_171() {
             unsafe {
                 atomic(|| {
-                    if USBERRATA_BASE.reg0.get() == 0 {
-                        USBERRATA_BASE.reg0.set(0x9375);
-                        USBERRATA_BASE.reg14.set(val);
-                        USBERRATA_BASE.reg0.set(0x9375);
+                    if USBERRATA_BASE.reg_c00.get() == 0 {
+                        USBERRATA_BASE.reg_c00.set(0x9375);
+                        USBERRATA_BASE.reg_c14.set(val);
+                        USBERRATA_BASE.reg_c00.set(0x9375);
                     } else {
-                        USBERRATA_BASE.reg14.set(val);
+                        USBERRATA_BASE.reg_c14.set(val);
                     }
                 });
             }
@@ -794,12 +795,12 @@ impl<'a> Usbd<'a> {
         if self.has_errata_187() {
             unsafe {
                 atomic(|| {
-                    if USBERRATA_BASE.reg0.get() == 0 {
-                        USBERRATA_BASE.reg0.set(0x9375);
-                        USBERRATA_BASE.reg114.set(val);
-                        USBERRATA_BASE.reg0.set(0x9375);
+                    if USBERRATA_BASE.reg_c00.get() == 0 {
+                        USBERRATA_BASE.reg_c00.set(0x9375);
+                        USBERRATA_BASE.reg_d14.set(val);
+                        USBERRATA_BASE.reg_c00.set(0x9375);
                     } else {
-                        USBERRATA_BASE.reg114.set(val);
+                        USBERRATA_BASE.reg_d14.set(val);
                     }
                 });
             }

--- a/chips/nrf52/src/usbd.rs
+++ b/chips/nrf52/src/usbd.rs
@@ -1,10 +1,56 @@
 //! Universal Serial Bus Device with EasyDMA (USBD)
 
-// TODO: implement the USB HIL and remove this unused warning.
-#![allow(dead_code)]
-
-use kernel::common::registers::{register_bitfields, ReadOnly, ReadWrite, WriteOnly};
+use core::cell::Cell;
+use cortexm4::support::atomic;
+use kernel::common::cells::{OptionalCell, VolatileCell};
+use kernel::common::registers::{
+    register_bitfields, Field, InMemoryRegister, LocalRegisterCopy, ReadOnly, ReadWrite, WriteOnly,
+};
 use kernel::common::StaticRef;
+use kernel::debug;
+use kernel::hil;
+use kernel::hil::usb::TransferType;
+
+use crate::power;
+
+// The following macros provide some diagnostics and panics(!)
+// while this module is experimental and should eventually be removed or
+// replaced with better error handling.
+macro_rules! debug_events {
+    [ $( $arg:expr ),+ ] => {
+        {} // debug!($( $arg ),+);
+    };
+}
+
+macro_rules! debug_tasks {
+    [ $( $arg:expr ),+ ] => {
+        {} // debug!($( $arg ),+);
+    };
+}
+
+macro_rules! debug_packets {
+    [ $( $arg:expr ),+ ] => {
+        {} // debug!($( $arg ),+);
+    };
+}
+
+macro_rules! debug_info {
+    [ $( $arg:expr ),+ ] => {
+        debug!($( $arg ),+);
+    };
+}
+
+macro_rules! internal_warn {
+    [ $( $arg:expr ),+ ] => {
+        debug!($( $arg ),+);
+    };
+}
+
+macro_rules! internal_err {
+    [ $( $arg:expr ),+ ] => {
+        panic!($( $arg ),+);
+    };
+}
 
 const USBD_BASE: StaticRef<UsbdRegisters<'static>> =
     unsafe { StaticRef::new(0x40027000 as *const UsbdRegisters<'static>) };
@@ -561,17 +607,1385 @@ register_bitfields! [u32,
     ]
 ];
 
+pub static mut USBD: Usbd<'static> = Usbd::new();
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum UsbState {
+    Disabled,
+    Started,
+    Initialized,
+    PoweredOn,
+    Attached,
+    Configured,
+}
+
+#[derive(Copy, Clone, Debug)]
+pub enum EndpointState {
+    Disabled,
+    Ctrl(CtrlState),
+    Bulk(TransferType, EndpointDirection, BulkState),
+}
+
+impl EndpointState {
+    fn ctrl_state(self) -> CtrlState {
+        match self {
+            EndpointState::Ctrl(state) => state,
+            _ => panic!("Expected EndpointState::Ctrl"),
+        }
+    }
+
+    fn bulk_state(self) -> (TransferType, EndpointDirection, BulkState) {
+        match self {
+            EndpointState::Bulk(transfer_type, direction, state) => {
+                (transfer_type, direction, state)
+            }
+            _ => panic!("Expected EndpointState::Bulk"),
+        }
+    }
+}
+
+#[derive(Copy, Clone, PartialEq, Debug)]
+pub enum CtrlState {
+    Init,
+    ReadIn,
+    ReadStatus,
+}
+
+#[derive(Copy, Clone, Debug)]
+pub enum EndpointDirection {
+    In,
+    Out,
+    InOut,
+}
+
+impl EndpointDirection {
+    fn has_in(&self) -> bool {
+        match self {
+            EndpointDirection::In | EndpointDirection::InOut => true,
+            EndpointDirection::Out => false,
+        }
+    }
+
+    fn has_out(&self) -> bool {
+        match self {
+            EndpointDirection::Out | EndpointDirection::InOut => true,
+            EndpointDirection::In => false,
+        }
+    }
+}
+
+#[derive(Copy, Clone, PartialEq, Debug)]
+pub enum BulkState {
+    // The endpoint is ready to perform transactions.
+    Init,
+    // There is a pending OUT packet in this endpoint's buffer, to be read by
+    // the client application.
+    OutDelay,
+    // There is a pending EPDATA to reply to.
+    OutData,
+    // There is a pending DMA transfer on this OUT endpoint.
+    OutDma,
+    // There is a pending DMA transfer on this IN endpoint.
+    InDma,
+    // There is a pending IN packet transfer on this endpoint.
+    InData,
+}
+
+pub struct Endpoint<'a> {
+    slice: OptionalCell<&'a [VolatileCell<u8>]>,
+    state: Cell<EndpointState>,
+    // The USB controller can only process one DMA transfer at a time (over all endpoints). The
+    // request_transmit_* bits allow to queue transfers until the DMA becomes available again.
+    // Whether a DMA transfer is requested on this IN endpoint.
+    request_transmit_in: Cell<bool>,
+    // Whether a DMA transfer is requested on this OUT endpoint.
+    request_transmit_out: Cell<bool>,
+}
+
+impl Endpoint<'_> {
+    const fn new() -> Self {
+        Endpoint {
+            slice: OptionalCell::empty(),
+            state: Cell::new(EndpointState::Disabled),
+            request_transmit_in: Cell::new(false),
+            request_transmit_out: Cell::new(false),
+        }
+    }
+}
+
 pub struct Usbd<'a> {
     registers: StaticRef<UsbdRegisters<'a>>,
-    // Stub for the USB device controller state.
+    state: OptionalCell<UsbState>,
+    dma_pending: Cell<bool>,
+    client: OptionalCell<&'a dyn hil::usb::Client<'a>>,
+    descriptors: [Endpoint<'a>; NUM_ENDPOINTS],
 }
 
 impl<'a> Usbd<'a> {
     const fn new() -> Self {
         Usbd {
             registers: USBD_BASE,
+            client: OptionalCell::empty(),
+            state: OptionalCell::new(UsbState::Disabled),
+            dma_pending: Cell::new(false),
+            descriptors: [
+                Endpoint::new(),
+                Endpoint::new(),
+                Endpoint::new(),
+                Endpoint::new(),
+                Endpoint::new(),
+                Endpoint::new(),
+                Endpoint::new(),
+                Endpoint::new(),
+            ],
+        }
+    }
+
+    /// ISO double buffering not functional
+    fn apply_errata_166(&self) {
+        self.registers.errata166_1.set(0x7e3);
+        self.registers.errata166_2.set(0x40);
+    }
+
+    /// USBD might not reach its active state.
+    fn apply_errata_171(&self, val: u32) {
+        unsafe {
+            atomic(|| {
+                if USBERRATA_BASE.reg0.get() == 0 {
+                    USBERRATA_BASE.reg0.set(0x9375);
+                    USBERRATA_BASE.reg14.set(val);
+                    USBERRATA_BASE.reg0.set(0x9375);
+                } else {
+                    USBERRATA_BASE.reg14.set(val);
+                }
+            });
+        }
+    }
+
+    /// USB cannot be enabled
+    fn apply_errata_187(&self, val: u32) {
+        if !CHIPINFO_BASE
+            .chip_model
+            .matches_all(ChipModel::MODEL::NRF52840)
+        {
+            return;
+        }
+        match CHIPINFO_BASE.chip_revision.read_as_enum(ChipRevision::REV) {
+            Some(ChipRevision::REV::Value::REVB)
+            | Some(ChipRevision::REV::Value::REVC)
+            | Some(ChipRevision::REV::Value::REVD) => unsafe {
+                atomic(|| {
+                    if USBERRATA_BASE.reg0.get() == 0 {
+                        USBERRATA_BASE.reg0.set(0x9375);
+                        USBERRATA_BASE.reg114.set(val);
+                        USBERRATA_BASE.reg0.set(0x9375);
+                    } else {
+                        USBERRATA_BASE.reg114.set(val);
+                    }
+                });
+            },
+            _ => (),
+        };
+    }
+
+    pub fn get_state(&self) -> UsbState {
+        self.state.expect("get_state: state value is in use")
+    }
+
+    // Powers the USB PHY on
+    fn enable(&self) {
+        if self.get_state() != UsbState::Disabled {
+            internal_warn!("USBC is already enabled");
+            return;
+        }
+        self.registers.eventcause.modify(EventCause::READY::CLEAR);
+        self.apply_errata_187(3);
+        self.apply_errata_171(0xc0);
+        self.registers.enable.write(Usb::ENABLE::ON);
+        while !self.registers.eventcause.is_set(EventCause::READY) {}
+        self.registers.eventcause.modify(EventCause::READY::CLEAR);
+        self.apply_errata_171(0);
+        self.apply_errata_166();
+        self.clear_pending_dma();
+        self.state.set(UsbState::Initialized);
+    }
+
+    // TODO: unused function
+    fn _suspend(&self) {
+        debug_info!("usbc::suspend()");
+        self.ep_abort_all();
+        if self.registers.eventcause.is_set(EventCause::RESUME) {
+            return;
+        }
+        self.enable_lowpower();
+        if self.registers.eventcause.is_set(EventCause::RESUME) {
+            self.disable_lowpower();
+        } else {
+            self.apply_errata_171(0);
+        }
+        internal_warn!("suspend() not fully implemented");
+    }
+
+    fn disable_all_interrupts(&self) {
+        self.registers.intenclr.set(0xffffffff);
+    }
+
+    fn enable_interrupts(&self, inter: u32) {
+        self.registers.inten.set(inter);
+    }
+
+    fn power_ready(&self) {
+        match self.get_state() {
+            UsbState::Disabled => {
+                self.enable();
+                self.state.set(UsbState::PoweredOn);
+            }
+            UsbState::Initialized => self.state.set(UsbState::PoweredOn),
+            _ => (),
+        }
+    }
+
+    fn enable_pullup(&self) {
+        debug_info!("enable_pullup() - State={:?}", self.get_state());
+        if self.get_state() == UsbState::Started {
+            debug_info!("Enabling USB pullups");
+            self.registers.usbpullup.write(UsbPullup::CONNECT::Enabled);
+        }
+        self.state.set(UsbState::Attached);
+        debug_info!("New state is {:?}", self.get_state());
+    }
+
+    fn disable_pullup(&self) {
+        debug_info!("Disabling USB pullup - State={:?}", self.get_state());
+        self.registers.usbpullup.write(UsbPullup::CONNECT::Disabled);
+        self.state.set(UsbState::Started);
+        debug_info!("New state is {:?}", self.get_state());
+    }
+
+    // Allows the peripheral to be enumerated by the USB master
+    fn start(&self) {
+        debug_info!("usbc::start() - State={:?}", self.get_state());
+
+        // Depending on the chip model, there are more or less errata to add to the code. To
+        // simplify things, this implementation only includes errata relevant to nRF52840 chips
+        // revisions >= C.
+        //
+        // If your chip isn't one of these, you will be alerted by these panics. You can disable
+        // them but will likely need to add the relevant errata to this implementation.
+        let chip_model = CHIPINFO_BASE.chip_model.get();
+        if chip_model != u32::from(ChipModel::MODEL::NRF52840) {
+            panic!(
+                "USB was only tested on NRF52840. Your chip model is {}.",
+                chip_model
+            );
+        }
+        let chip_revision = CHIPINFO_BASE.chip_revision.extract();
+        match chip_revision.read_as_enum(ChipRevision::REV) {
+            Some(ChipRevision::REV::Value::REVA) | Some(ChipRevision::REV::Value::REVB) => {
+                panic!(
+                    "Errata for USB on NRF52840 chips revisions A and B are not implemented. Your chip revision is {}.",
+                    chip_revision.get()
+                );
+            }
+            Some(ChipRevision::REV::Value::REVC) => {
+                debug_info!(
+                    "Your chip is NRF52840 revision {}. The USB stack was tested on your chip :)",
+                    chip_revision.get()
+                );
+            }
+            Some(ChipRevision::REV::Value::REVD) => {
+                internal_warn!(
+                    "Your chip is NRF52840 revision {}. Although this USB implementation should be compatible, your chip hasn't been tested.",
+                    chip_revision.get()
+                );
+            }
+            None => {
+                internal_warn!(
+                    "Your chip is NRF52840 revision {} (unknown revision). Although this USB implementation should be compatible, your chip hasn't been tested.",
+                    chip_revision.get()
+                );
+            }
+        }
+        unsafe {
+            if !power::POWER.is_vbus_present() {
+                debug_info!("[!] VBUS power is not detected.");
+                return;
+            }
+        }
+        if self.get_state() == UsbState::Disabled {
+            self.enable();
+        }
+        if self.get_state() != UsbState::PoweredOn {
+            debug_info!("Waiting for power regulators...");
+            unsafe { while power::POWER.is_vbus_present() && !power::POWER.is_usb_power_ready() {} }
+        }
+        debug_info!("usbc::start() - subscribing to interrupts.");
+        self.registers.intenset.write(
+            Interrupt::USBRESET::SET
+                + Interrupt::STARTED::SET
+                + Interrupt::ENDEPIN0::SET
+                + Interrupt::EP0DATADONE::SET
+                + Interrupt::ENDEPOUT0::SET
+                + Interrupt::USBEVENT::SET
+                + Interrupt::EP0SETUP::SET
+                + Interrupt::EPDATA::SET,
+        );
+        self.state.set(UsbState::Started);
+    }
+
+    fn stop(&self) {
+        debug_info!("usbc::stop() - State={:?}", self.get_state());
+        if self.get_state() != UsbState::Started {
+            return;
+        }
+        self.ep_abort_all();
+        self.disable_all_interrupts();
+        self.registers.usbpullup.write(UsbPullup::CONNECT::Disabled);
+        self.state.set(UsbState::PoweredOn);
+    }
+
+    fn disable(&self) {
+        debug_info!("usbc::disable() - State={:?}", self.get_state());
+        self.stop();
+        self.registers.enable.write(Usb::ENABLE::OFF);
+        self.state.set(UsbState::Initialized);
+        self.clear_pending_dma();
+        self.apply_errata_187(0);
+    }
+
+    fn clear_pending_dma(&self) {
+        debug_packets!("clear_pending_dma()");
+        self.registers.errata199.set(0);
+        self.dma_pending.set(false);
+    }
+
+    fn set_pending_dma(&self) {
+        debug_packets!("set_pending_dma()");
+        if self.dma_pending.get() {
+            internal_err!("Pending DMA already in flight");
+        }
+        self.registers.errata199.set(0x82);
+        self.dma_pending.set(true);
+    }
+
+    fn enable_in_endpoint_(&self, transfer_type: TransferType, endpoint: usize) {
+        debug_info!(
+            "enable_in_endpoint_({}), State={:?}",
+            endpoint,
+            self.get_state()
+        );
+        self.registers.intenset.write(match endpoint {
+            0 => Interrupt::ENDEPIN0::SET,
+            1 => Interrupt::ENDEPIN1::SET,
+            2 => Interrupt::ENDEPIN2::SET,
+            3 => Interrupt::ENDEPIN3::SET,
+            4 => Interrupt::ENDEPIN4::SET,
+            5 => Interrupt::ENDEPIN5::SET,
+            6 => Interrupt::ENDEPIN6::SET,
+            7 => Interrupt::ENDEPIN7::SET,
+            8 => Interrupt::ENDISOIN::SET,
+            _ => unreachable!("unexisting endpoint"),
+        });
+        self.registers.epinen.modify(match endpoint {
+            0 => EndpointEnable::EP0::Enable,
+            1 => EndpointEnable::EP1::Enable,
+            2 => EndpointEnable::EP2::Enable,
+            3 => EndpointEnable::EP2::Enable,
+            4 => EndpointEnable::EP2::Enable,
+            5 => EndpointEnable::EP2::Enable,
+            6 => EndpointEnable::EP2::Enable,
+            7 => EndpointEnable::EP2::Enable,
+            8 => EndpointEnable::ISO::Enable,
+            _ => unreachable!("unexisting endpoint"),
+        });
+        self.descriptors[endpoint].state.set(match endpoint {
+            0 => EndpointState::Ctrl(CtrlState::Init),
+            1..=7 => EndpointState::Bulk(transfer_type, EndpointDirection::In, BulkState::Init),
+            8 => unimplemented!("isochronous endpoint"),
+            _ => unreachable!("unexisting endpoint"),
+        });
+    }
+
+    fn enable_out_endpoint_(&self, transfer_type: TransferType, endpoint: usize) {
+        debug_info!(
+            "enable_out_endpoint_({}) - State={:?}",
+            endpoint,
+            self.get_state()
+        );
+        self.registers.intenset.write(match endpoint {
+            0 => Interrupt::ENDEPOUT0::SET,
+            1 => Interrupt::ENDEPOUT1::SET,
+            2 => Interrupt::ENDEPOUT2::SET,
+            3 => Interrupt::ENDEPOUT3::SET,
+            4 => Interrupt::ENDEPOUT4::SET,
+            5 => Interrupt::ENDEPOUT5::SET,
+            6 => Interrupt::ENDEPOUT6::SET,
+            7 => Interrupt::ENDEPOUT7::SET,
+            8 => Interrupt::ENDISOOUT::SET,
+            _ => unreachable!("unexisting endpoint"),
+        });
+        self.registers.epouten.modify(match endpoint {
+            0 => EndpointEnable::EP0::Enable,
+            1 => EndpointEnable::EP1::Enable,
+            2 => EndpointEnable::EP2::Enable,
+            3 => EndpointEnable::EP2::Enable,
+            4 => EndpointEnable::EP2::Enable,
+            5 => EndpointEnable::EP2::Enable,
+            6 => EndpointEnable::EP2::Enable,
+            7 => EndpointEnable::EP2::Enable,
+            8 => EndpointEnable::ISO::Enable,
+            _ => unreachable!("unexisting endpoint"),
+        });
+        self.descriptors[endpoint].state.set(match endpoint {
+            0 => EndpointState::Ctrl(CtrlState::Init),
+            1..=7 => EndpointState::Bulk(transfer_type, EndpointDirection::Out, BulkState::Init),
+            8 => unimplemented!("isochronous endpoint"),
+            _ => unreachable!("unexisting endpoint"),
+        });
+    }
+
+    fn enable_in_out_endpoint_(&self, transfer_type: TransferType, endpoint: usize) {
+        debug_info!(
+            "enable_in_out_endpoint_({}) - State={:?}",
+            endpoint,
+            self.get_state()
+        );
+        self.registers.intenset.write(match endpoint {
+            0 => Interrupt::ENDEPIN0::SET + Interrupt::ENDEPOUT0::SET,
+            1 => Interrupt::ENDEPIN1::SET + Interrupt::ENDEPOUT1::SET,
+            2 => Interrupt::ENDEPIN2::SET + Interrupt::ENDEPOUT2::SET,
+            3 => Interrupt::ENDEPIN3::SET + Interrupt::ENDEPOUT3::SET,
+            4 => Interrupt::ENDEPIN4::SET + Interrupt::ENDEPOUT4::SET,
+            5 => Interrupt::ENDEPIN5::SET + Interrupt::ENDEPOUT5::SET,
+            6 => Interrupt::ENDEPIN6::SET + Interrupt::ENDEPOUT6::SET,
+            7 => Interrupt::ENDEPIN7::SET + Interrupt::ENDEPOUT7::SET,
+            8 => Interrupt::ENDISOIN::SET + Interrupt::ENDISOOUT::SET,
+            _ => unreachable!("unexisting endpoint"),
+        });
+        self.registers.epinen.modify(match endpoint {
+            0 => EndpointEnable::EP0::Enable,
+            1 => EndpointEnable::EP1::Enable,
+            2 => EndpointEnable::EP2::Enable,
+            3 => EndpointEnable::EP2::Enable,
+            4 => EndpointEnable::EP2::Enable,
+            5 => EndpointEnable::EP2::Enable,
+            6 => EndpointEnable::EP2::Enable,
+            7 => EndpointEnable::EP2::Enable,
+            8 => EndpointEnable::ISO::Enable,
+            _ => unreachable!("unexisting endpoint"),
+        });
+        self.registers.epouten.modify(match endpoint {
+            0 => EndpointEnable::EP0::Enable,
+            1 => EndpointEnable::EP1::Enable,
+            2 => EndpointEnable::EP2::Enable,
+            3 => EndpointEnable::EP2::Enable,
+            4 => EndpointEnable::EP2::Enable,
+            5 => EndpointEnable::EP2::Enable,
+            6 => EndpointEnable::EP2::Enable,
+            7 => EndpointEnable::EP2::Enable,
+            8 => EndpointEnable::ISO::Enable,
+            _ => unreachable!("unexisting endpoint"),
+        });
+        self.descriptors[endpoint].state.set(match endpoint {
+            0 => EndpointState::Ctrl(CtrlState::Init),
+            1..=7 => EndpointState::Bulk(transfer_type, EndpointDirection::InOut, BulkState::Init),
+            8 => unimplemented!("isochronous endpoint"),
+            _ => unreachable!("unexisting endpoint"),
+        });
+    }
+
+    fn ep_abort_all(&self) {
+        internal_warn!("ep_abort_all() not implemented");
+    }
+
+    pub fn enable_lowpower(&self) {
+        internal_warn!("enable_lowpower() not implemented");
+    }
+
+    pub fn disable_lowpower(&self) {
+        internal_warn!("disable_lowpower() not implemented");
+    }
+
+    pub fn set_client(&self, client: &'a dyn hil::usb::Client<'a>) {
+        self.client.set(client);
+    }
+
+    pub fn handle_interrupt(&self) {
+        let regs = &*self.registers;
+
+        // Save then disable all interrupts.
+        let saved_inter = regs.intenset.extract();
+        self.disable_all_interrupts();
+
+        let active_events = self.active_events(&saved_inter);
+        let events_to_process = saved_inter.bitand(active_events.get());
+
+        // The following order in which we test events is important.
+        // Interrupts should be processed from bit 0 to bit 31 but EP0SETUP must be last.
+        if events_to_process.is_set(Interrupt::USBRESET) {
+            self.handle_usbreset();
+        }
+        if events_to_process.is_set(Interrupt::STARTED) {
+            self.handle_started();
+        }
+        // Note: isochronous endpoint receives a dedicated ENDISOIN interrupt instead.
+        for ep in 0..NUM_ENDPOINTS {
+            if events_to_process.is_set(inter_endepin(ep)) {
+                self.handle_endepin(ep);
+            }
+        }
+        if events_to_process.is_set(Interrupt::EP0DATADONE) {
+            self.handle_ep0datadone();
+        }
+        if events_to_process.is_set(Interrupt::ENDISOIN) {
+            self.handle_endisoin();
+        }
+        // Note: isochronous endpoint receives a dedicated ENDISOOUT interrupt instead.
+        for ep in 0..NUM_ENDPOINTS {
+            if events_to_process.is_set(inter_endepout(ep)) {
+                self.handle_endepout(ep);
+            }
+        }
+        if events_to_process.is_set(Interrupt::ENDISOOUT) {
+            self.handle_endisoout();
+        }
+        if events_to_process.is_set(Interrupt::SOF) {
+            self.handle_sof();
+        }
+        if events_to_process.is_set(Interrupt::USBEVENT) {
+            self.handle_usbevent();
+        }
+        if events_to_process.is_set(Interrupt::EPDATA) {
+            self.handle_epdata();
+        }
+
+        self.process_dma_requests();
+
+        // Setup packet received.
+        // This event must be handled last, even though EPDATA is after.
+        if events_to_process.is_set(Interrupt::EP0SETUP) {
+            self.handle_ep0setup();
+        }
+
+        // Restore interrupts
+        self.enable_interrupts(saved_inter.get());
+    }
+
+    fn active_events(
+        &self,
+        _saved_inter: &LocalRegisterCopy<u32, Interrupt::Register>,
+    ) -> InMemoryRegister<u32, Interrupt::Register> {
+        let regs = &*self.registers;
+
+        let result = InMemoryRegister::new(0);
+        if Usbd::take_event(&regs.event_usbreset) {
+            debug_events!(
+                "- event: usbreset{}",
+                ignored_str(_saved_inter, Interrupt::USBRESET)
+            );
+            result.modify(Interrupt::USBRESET::SET);
+        }
+        if Usbd::take_event(&regs.event_started) {
+            debug_events!(
+                "- event: started{}",
+                ignored_str(_saved_inter, Interrupt::STARTED)
+            );
+            result.modify(Interrupt::STARTED::SET);
+        }
+        for ep in 0..8 {
+            if Usbd::take_event(&regs.event_endepin[ep]) {
+                debug_events!(
+                    "- event: endepin[{}]{}",
+                    ep,
+                    ignored_str(_saved_inter, inter_endepin(ep))
+                );
+                result.modify(inter_endepin(ep).val(1));
+            }
+        }
+        if Usbd::take_event(&regs.event_ep0datadone) {
+            debug_events!(
+                "- event: ep0datadone{}",
+                ignored_str(_saved_inter, Interrupt::EP0DATADONE)
+            );
+            result.modify(Interrupt::EP0DATADONE::SET);
+        }
+        if Usbd::take_event(&regs.event_endisoin) {
+            debug_events!(
+                "- event: endisoin{}",
+                ignored_str(_saved_inter, Interrupt::ENDISOIN)
+            );
+            result.modify(Interrupt::ENDISOIN::SET);
+        }
+        for ep in 0..8 {
+            if Usbd::take_event(&regs.event_endepout[ep]) {
+                debug_events!(
+                    "- event: endepout[{}]{}",
+                    ep,
+                    ignored_str(_saved_inter, inter_endepout(ep))
+                );
+                result.modify(inter_endepout(ep).val(1));
+            }
+        }
+        if Usbd::take_event(&regs.event_endisoout) {
+            debug_events!(
+                "- event: endisoout{}",
+                ignored_str(_saved_inter, Interrupt::ENDISOOUT)
+            );
+            result.modify(Interrupt::ENDISOOUT::SET);
+        }
+        if Usbd::take_event(&regs.event_sof) {
+            debug_events!("- event: sof{}", ignored_str(_saved_inter, Interrupt::SOF));
+            result.modify(Interrupt::SOF::SET);
+        }
+        if Usbd::take_event(&regs.event_usbevent) {
+            debug_events!(
+                "- event: usbevent{}",
+                ignored_str(_saved_inter, Interrupt::USBEVENT)
+            );
+            result.modify(Interrupt::USBEVENT::SET);
+        }
+        if Usbd::take_event(&regs.event_ep0setup) {
+            debug_events!(
+                "- event: ep0setup{}",
+                ignored_str(_saved_inter, Interrupt::EP0SETUP)
+            );
+            result.modify(Interrupt::EP0SETUP::SET);
+        }
+        if Usbd::take_event(&regs.event_epdata) {
+            debug_events!(
+                "- event: epdata{}",
+                ignored_str(_saved_inter, Interrupt::EPDATA)
+            );
+            result.modify(Interrupt::EPDATA::SET);
+        }
+        result
+    }
+
+    // Reads the status of an Event register and clears the register.
+    // Returns the READY status.
+    fn take_event(event: &ReadWrite<u32, Event::Register>) -> bool {
+        let result = event.is_set(Event::READY);
+        if result {
+            event.write(Event::READY::CLEAR);
+        }
+        result
+    }
+
+    fn handle_usbreset(&self) {
+        let regs = &*self.registers;
+
+        for (ep, desc) in self.descriptors.iter().enumerate() {
+            match desc.state.get() {
+                EndpointState::Disabled => {}
+                EndpointState::Ctrl(_) => desc.state.set(EndpointState::Ctrl(CtrlState::Init)),
+                EndpointState::Bulk(transfer_type, direction, _) => {
+                    desc.state.set(EndpointState::Bulk(
+                        transfer_type,
+                        direction,
+                        BulkState::Init,
+                    ));
+                    if direction.has_out() {
+                        // Accept incoming OUT packets.
+                        regs.size_epout[ep].set(0);
+                    }
+                }
+            }
+            // Clear the DMA status.
+            desc.request_transmit_in.set(false);
+            desc.request_transmit_out.set(false);
+        }
+
+        self.dma_pending.set(false);
+
+        // TODO: reset controller stack
+        self.client.map(|client| {
+            client.bus_reset();
+        });
+    }
+
+    fn handle_started(&self) {
+        let regs = &*self.registers;
+
+        let epstatus = regs.epstatus.extract();
+        // Acknowledge the status by writing ones to the acknowledged bits.
+        regs.epstatus.set(epstatus.get());
+        debug_events!("epstatus: {:08X}", epstatus.get());
+
+        // Nothing to do here, we just wait for the corresponding ENDEP* event.
+    }
+
+    fn handle_endepin(&self, endpoint: usize) {
+        // Make DMA available again for other endpoints.
+        self.clear_pending_dma();
+
+        match endpoint {
+            0 => {}
+            1..=7 => {
+                let (transfer_type, direction, state) =
+                    self.descriptors[endpoint].state.get().bulk_state();
+                assert_eq!(state, BulkState::InDma);
+                self.descriptors[endpoint].state.set(EndpointState::Bulk(
+                    transfer_type,
+                    direction,
+                    BulkState::InData,
+                ));
+            }
+            8 => unimplemented!("isochronous endpoint"),
+            _ => unreachable!("unexisting endpoint"),
+        }
+
+        // Nothing else to do. Wait for the EPDATA event.
+    }
+
+    fn handle_ep0datadone(&self) {
+        let regs = &*self.registers;
+
+        let endpoint = 0;
+        let state = self.descriptors[endpoint].state.get().ctrl_state();
+        match state {
+            CtrlState::ReadIn => {
+                self.transmit_in_ep0();
+            }
+
+            CtrlState::ReadStatus => {
+                self.complete_ctrl_status();
+            }
+
+            CtrlState::Init => {
+                // We shouldn't be there. Let's STALL the endpoint.
+                debug_tasks!("- task: ep0stall");
+                regs.task_ep0stall.write(Task::ENABLE::SET);
+            }
+        }
+    }
+
+    fn handle_endisoin(&self) {
+        unimplemented!("handle_endisoin");
+    }
+
+    fn handle_endepout(&self, endpoint: usize) {
+        // Make DMA available again for other endpoints.
+        self.clear_pending_dma();
+
+        let regs = &*self.registers;
+
+        match endpoint {
+            0 => {
+                // TODO: the ENDEPOUT0_EP0RCVOUT shortcut could be established instead of manually
+                // triggering the task here.
+                debug_tasks!("- task: ep0rcvout");
+                regs.task_ep0rcvout.write(Task::ENABLE::SET);
+            }
+            1..=7 => {
+                // Notify the client about the new packet.
+                let packet_bytes = regs.size_epout[endpoint].get();
+                let (transfer_type, direction, state) =
+                    self.descriptors[endpoint].state.get().bulk_state();
+                assert_eq!(state, BulkState::OutDma);
+
+                self.debug_packet("out", packet_bytes as usize, endpoint);
+
+                self.client.map(|client| {
+                    let result = client.packet_out(transfer_type, endpoint, packet_bytes);
+                    debug_packets!("packet_out => {:?}", result);
+                    let newstate = match result {
+                        hil::usb::OutResult::Ok => {
+                            // Indicate that the endpoint is ready to receive data again.
+                            regs.size_epout[endpoint].set(0);
+                            BulkState::Init
+                        }
+
+                        hil::usb::OutResult::Delay => {
+                            // We can't send the packet now. Wait for a resume_out call from the client.
+                            BulkState::OutDelay
+                        }
+
+                        hil::usb::OutResult::Error => {
+                            regs.epstall.write(
+                                EndpointStall::EP.val(endpoint as u32)
+                                    + EndpointStall::IO::Out
+                                    + EndpointStall::STALL::Stall,
+                            );
+                            BulkState::Init
+                        }
+                    };
+                    self.descriptors[endpoint].state.set(EndpointState::Bulk(
+                        transfer_type,
+                        direction,
+                        newstate,
+                    ));
+                });
+            }
+            8 => unimplemented!("isochronous endpoint"),
+            _ => unreachable!("unexisting endpoint"),
+        }
+    }
+
+    fn handle_endisoout(&self) {
+        unimplemented!("handle_endisoout");
+    }
+
+    fn handle_sof(&self) {
+        unimplemented!("handle_sof");
+    }
+
+    fn handle_usbevent(&self) {
+        let regs = &*self.registers;
+
+        let eventcause = regs.eventcause.extract();
+        // Acknowledge the cause by writing ones to the acknowledged bits.
+        regs.eventcause.set(eventcause.get());
+
+        debug_events!("eventcause: {:08x}", eventcause.get());
+        if eventcause.is_set(EventCause::ISOOUTCRC) {
+            debug_events!("- usbevent: isooutcrc");
+            internal_warn!("usbc::isooutcrc not implemented");
+        }
+        if eventcause.is_set(EventCause::SUSPEND) {
+            debug_events!("- usbevent: suspend");
+            internal_warn!("usbc::suspend not implemented");
+        }
+        if eventcause.is_set(EventCause::RESUME) {
+            debug_events!("- usbevent: resume");
+            internal_warn!("usbc::resume not implemented");
+        }
+        if eventcause.is_set(EventCause::USBWUALLOWED) {
+            debug_events!("- usbevent: usbwuallowed");
+            internal_warn!("usbc::usbwuallowed not implemented");
+        }
+        if eventcause.is_set(EventCause::READY) {
+            debug_events!("- usbevent: ready");
+            internal_warn!("usbc::ready not implemented");
+        }
+    }
+
+    fn handle_epdata(&self) {
+        let regs = &*self.registers;
+
+        let epdatastatus = regs.epdatastatus.extract();
+        // Acknowledge the status by writing ones to the acknowledged bits.
+        regs.epdatastatus.set(epdatastatus.get());
+        debug_events!("epdatastatus: {:08X}", epdatastatus.get());
+
+        // Endpoint 0 (control) receives an EP0DATADONE event instead.
+        // Endpoint 8 (isochronous) doesn't receive any EPDATA event.
+        for endpoint in 1..NUM_ENDPOINTS {
+            if epdatastatus.is_set(status_epin(endpoint)) {
+                let (transfer_type, direction, state) =
+                    self.descriptors[endpoint].state.get().bulk_state();
+                assert_eq!(state, BulkState::InData);
+                self.descriptors[endpoint].state.set(EndpointState::Bulk(
+                    transfer_type,
+                    direction,
+                    BulkState::Init,
+                ));
+                self.client
+                    .map(|client| client.packet_transmitted(endpoint));
+            }
+        }
+
+        // Endpoint 0 (control) receives an EP0DATADONE event instead.
+        // Endpoint 8 (isochronous) doesn't receive any EPDATA event.
+        for ep in 1..NUM_ENDPOINTS {
+            if epdatastatus.is_set(status_epout(ep)) {
+                let (transfer_type, direction, state) =
+                    self.descriptors[ep].state.get().bulk_state();
+                match state {
+                    BulkState::Init => {
+                        // The endpoint is ready to receive data. Request a transmit_out.
+                        self.descriptors[ep].request_transmit_out.set(true);
+                    }
+                    BulkState::OutDelay => {
+                        // The endpoint will be resumed later by the client application with transmit_out().
+                    }
+                    BulkState::OutData
+                    | BulkState::OutDma
+                    | BulkState::InDma
+                    | BulkState::InData => {
+                        internal_err!("Unexpected state: {:?}", state);
+                    }
+                }
+                // Indicate that the endpoint now has data available.
+                self.descriptors[ep].state.set(EndpointState::Bulk(
+                    transfer_type,
+                    direction,
+                    BulkState::OutData,
+                ));
+            }
+        }
+    }
+
+    fn handle_ep0setup(&self) {
+        let regs = &*self.registers;
+
+        let endpoint = 0;
+        let state = self.descriptors[endpoint].state.get().ctrl_state();
+        match state {
+            CtrlState::Init => {
+                let ep_buf = &self.descriptors[endpoint].slice;
+                let ep_buf = ep_buf.expect("No slice set for this descriptor");
+                if ep_buf.len() < 8 {
+                    panic!("EP0 DMA buffer length < 8");
+                }
+
+                // Re-construct the SETUP packet from various registers. The
+                // client's ctrl_setup() will parse it as a SetupData
+                // descriptor.
+                ep_buf[0].set((regs.bmrequesttype.get() & 0xff) as u8);
+                ep_buf[1].set((regs.brequest.get() & 0xff) as u8);
+                ep_buf[2].set(regs.wvaluel.read(Byte::VALUE) as u8);
+                ep_buf[3].set(regs.wvalueh.read(Byte::VALUE) as u8);
+                ep_buf[4].set(regs.windexl.read(Byte::VALUE) as u8);
+                ep_buf[5].set(regs.windexh.read(Byte::VALUE) as u8);
+                ep_buf[6].set(regs.wlengthl.read(Byte::VALUE) as u8);
+                ep_buf[7].set(regs.wlengthh.read(Byte::VALUE) as u8);
+                let size = regs.wlengthl.read(Byte::VALUE) + (regs.wlengthh.read(Byte::VALUE) << 8);
+
+                self.client.map(|client| {
+                    match client.ctrl_setup(endpoint) {
+                        hil::usb::CtrlSetupResult::OkSetAddress => {}
+                        hil::usb::CtrlSetupResult::Ok => {
+                            // Setup request is successful.
+                            if size == 0 {
+                                self.complete_ctrl_status();
+                            } else {
+                                match regs.bmrequesttype.read_as_enum(RequestType::DIRECTION) {
+                                    Some(RequestType::DIRECTION::Value::HostToDevice) => {
+                                        unimplemented!("CTRL write transaction");
+                                    }
+                                    Some(RequestType::DIRECTION::Value::DeviceToHost) => {
+                                        self.descriptors[endpoint]
+                                            .state
+                                            .set(EndpointState::Ctrl(CtrlState::ReadIn));
+                                        // Transmit first packet
+                                        self.transmit_in_ep0();
+                                    }
+                                    None => unreachable!(),
+                                }
+                            }
+                        }
+                        _err => {
+                            // An error occurred, we STALL
+                            debug_tasks!("- task: ep0stall");
+                            regs.task_ep0stall.write(Task::ENABLE::SET);
+                        }
+                    }
+                });
+            }
+
+            CtrlState::ReadIn | CtrlState::ReadStatus => {
+                // Unexpected state to receive a SETUP packet. Let's STALL the endpoint.
+                internal_warn!("handle_ep0setup - unexpected state = {:?}", state);
+                debug_tasks!("- task: ep0stall");
+                regs.task_ep0stall.write(Task::ENABLE::SET);
+            }
+        }
+    }
+
+    fn complete_ctrl_status(&self) {
+        let regs = &*self.registers;
+        let endpoint = 0;
+
+        self.client.map(|client| {
+            client.ctrl_status(endpoint);
+            debug_tasks!("- task: ep0status");
+            regs.task_ep0status.write(Task::ENABLE::SET);
+            client.ctrl_status_complete(endpoint);
+            self.descriptors[endpoint]
+                .state
+                .set(EndpointState::Ctrl(CtrlState::Init));
+        });
+    }
+
+    fn process_dma_requests(&self) {
+        if self.dma_pending.get() {
+            return;
+        }
+
+        for (endpoint, desc) in self.descriptors.iter().enumerate() {
+            if desc.request_transmit_in.take() {
+                self.transmit_in(endpoint);
+                if self.dma_pending.get() {
+                    break;
+                }
+            }
+            if desc.request_transmit_out.take() {
+                self.transmit_out(endpoint);
+                if self.dma_pending.get() {
+                    break;
+                }
+            }
+        }
+    }
+
+    fn transmit_in_ep0(&self) {
+        let regs = &*self.registers;
+        let endpoint = 0;
+
+        self.client.map(|client| {
+            match client.ctrl_in(endpoint) {
+                hil::usb::CtrlInResult::Packet(size, last) => {
+                    if size == 0 {
+                        internal_err!("Empty ctrl packet?");
+                    }
+                    self.start_dma_in(endpoint, size);
+                    if last {
+                        self.descriptors[endpoint]
+                            .state
+                            .set(EndpointState::Ctrl(CtrlState::ReadStatus));
+                    }
+                }
+
+                hil::usb::CtrlInResult::Delay => {
+                    internal_err!("Unexpected CtrlInResult::Delay");
+                    // NAK is automatically sent by the modem.
+                }
+
+                hil::usb::CtrlInResult::Error => {
+                    // An error occurred, we STALL
+                    debug_tasks!("- task: ep0stall");
+                    regs.task_ep0stall.write(Task::ENABLE::SET);
+                }
+            };
+        });
+    }
+
+    fn transmit_in(&self, endpoint: usize) {
+        debug_info!("transmit_in({})", endpoint);
+        let regs = &*self.registers;
+
+        self.client.map(|client| {
+            let (transfer_type, direction, state) =
+                self.descriptors[endpoint].state.get().bulk_state();
+            assert_eq!(state, BulkState::Init);
+
+            let result = client.packet_in(transfer_type, endpoint);
+            debug_packets!("packet_in => {:?}", result);
+            let newstate = match result {
+                hil::usb::InResult::Packet(size) => {
+                    self.start_dma_in(endpoint, size);
+                    BulkState::InDma
+                }
+
+                hil::usb::InResult::Delay => {
+                    // No packet to send now. Wait for a resume call from the client.
+                    BulkState::Init
+                }
+
+                hil::usb::InResult::Error => {
+                    regs.epstall.write(
+                        EndpointStall::EP.val(endpoint as u32)
+                            + EndpointStall::IO::In
+                            + EndpointStall::STALL::Stall,
+                    );
+                    BulkState::Init
+                }
+            };
+
+            self.descriptors[endpoint].state.set(EndpointState::Bulk(
+                transfer_type,
+                direction,
+                newstate,
+            ));
+        });
+    }
+
+    fn transmit_out(&self, endpoint: usize) {
+        debug_info!("transmit_out({})", endpoint);
+
+        let (transfer_type, direction, state) = self.descriptors[endpoint].state.get().bulk_state();
+        // Starting the DMA can only happen in the OutData state, i.e. after an EPDATA event.
+        assert_eq!(state, BulkState::OutData);
+        self.start_dma_out(endpoint);
+
+        self.descriptors[endpoint].state.set(EndpointState::Bulk(
+            transfer_type,
+            direction,
+            BulkState::OutDma,
+        ));
+    }
+
+    fn start_dma_in(&self, endpoint: usize, size: usize) {
+        let regs = &*self.registers;
+
+        let slice = self.descriptors[endpoint]
+            .slice
+            .expect("No slice set for this descriptor");
+        self.debug_packet("in", size, endpoint);
+
+        // Start DMA transfer
+        self.set_pending_dma();
+        regs.epin[endpoint].set_buffer(&slice[..size]);
+        debug_tasks!("- task: startepin[{}]", endpoint);
+        regs.task_startepin[endpoint].write(Task::ENABLE::SET);
+    }
+
+    fn start_dma_out(&self, endpoint: usize) {
+        let regs = &*self.registers;
+
+        let slice = self.descriptors[endpoint]
+            .slice
+            .expect("No slice set for this descriptor");
+
+        // Start DMA transfer
+        self.set_pending_dma();
+        regs.epout[endpoint].set_buffer(slice);
+        debug_tasks!("- task: startepout[{}]", endpoint);
+        regs.task_startepout[endpoint].write(Task::ENABLE::SET);
+    }
+
+    // Debug-only function
+    fn debug_packet(&self, _title: &str, size: usize, endpoint: usize) {
+        let slice = self.descriptors[endpoint]
+            .slice
+            .expect("No slice set for this descriptor");
+        if size > slice.len() {
+            panic!("Packet is too large: {}", size);
+        }
+
+        let mut packet_hex = [0; 128];
+        packet_to_hex(slice, &mut packet_hex);
+        debug_packets!(
+            "{}={}",
+            _title,
+            core::str::from_utf8(&packet_hex[..(2 * size)]).unwrap()
+        );
+    }
+}
+
+impl<'a> power::PowerClient for Usbd<'a> {
+    fn handle_power_event(&self, event: power::PowerEvent) {
+        match event {
+            power::PowerEvent::UsbPluggedIn => self.enable(),
+            power::PowerEvent::UsbPluggedOut => self.disable(),
+            power::PowerEvent::UsbPowerReady => self.power_ready(),
+            _ => internal_warn!("usbc::handle_power_event: unknown power event"),
         }
     }
 }
 
-pub static mut USBD: Usbd<'static> = Usbd::new();
+impl<'a> hil::usb::UsbController<'a> for Usbd<'a> {
+    fn endpoint_set_buffer(&self, endpoint: usize, buf: &'a [VolatileCell<u8>]) {
+        if buf.len() < 8 {
+            panic!("Endpoint buffer must be at least 8 bytes");
+        }
+        if !buf.len().is_power_of_two() {
+            panic!("Buffer size must be a power of 2");
+        }
+        if endpoint >= NUM_ENDPOINTS {
+            panic!("Endpoint number is too high");
+        }
+        self.descriptors[endpoint].slice.set(buf);
+    }
+
+    fn enable_as_device(&self, speed: hil::usb::DeviceSpeed) {
+        match speed {
+            hil::usb::DeviceSpeed::Low => internal_err!("Low speed is not supported"),
+            hil::usb::DeviceSpeed::Full => {}
+        }
+        self.start();
+    }
+
+    fn attach(&self) {
+        debug_info!("attach() - State={:?}", self.get_state());
+        self.enable_pullup();
+    }
+
+    fn detach(&self) {
+        debug_info!("detach() - Disabling pull-ups");
+        self.disable_pullup();
+    }
+
+    fn set_address(&self, _addr: u16) {
+        // Nothing to do, it's handled by PHY of nrf52 chip.
+        debug_info!("Set Address = {}", _addr);
+    }
+
+    fn enable_address(&self) {
+        let _regs = &*self.registers;
+        debug_info!("Enable Address = {}", _regs.usbaddr.read(UsbAddress::ADDR));
+        // Nothing to do, it's handled by PHY of nrf52 chip.
+    }
+
+    fn endpoint_in_enable(&self, transfer_type: TransferType, endpoint: usize) {
+        match transfer_type {
+            TransferType::Control => {
+                panic!("There is no IN control endpoint");
+            }
+            TransferType::Bulk | TransferType::Interrupt => {
+                if endpoint == 0 || endpoint >= NUM_ENDPOINTS {
+                    panic!("Bulk/Interrupt endpoints are endpoints 1 to 7");
+                }
+                self.enable_in_endpoint_(transfer_type, endpoint);
+            }
+            TransferType::Isochronous => unimplemented!("isochronous endpoint"),
+        }
+    }
+
+    fn endpoint_out_enable(&self, transfer_type: TransferType, endpoint: usize) {
+        match transfer_type {
+            TransferType::Control => {
+                if endpoint != 0 {
+                    panic!("Only endpoint 0 can be a control endpoint");
+                }
+                self.enable_out_endpoint_(transfer_type, endpoint);
+            }
+            TransferType::Bulk | TransferType::Interrupt => {
+                if endpoint == 0 || endpoint >= NUM_ENDPOINTS {
+                    panic!("Bulk/Interrupt endpoints are endpoints 1 to 7");
+                }
+                self.enable_out_endpoint_(transfer_type, endpoint);
+            }
+            TransferType::Isochronous => unimplemented!("isochronous endpoint"),
+        }
+    }
+
+    fn endpoint_in_out_enable(&self, transfer_type: TransferType, endpoint: usize) {
+        match transfer_type {
+            TransferType::Control => {
+                panic!("There is no IN control endpoint");
+            }
+            TransferType::Bulk | TransferType::Interrupt => {
+                if endpoint == 0 || endpoint >= NUM_ENDPOINTS {
+                    panic!("Bulk/Interrupt endpoints are endpoints 1 to 7");
+                }
+                self.enable_in_out_endpoint_(transfer_type, endpoint);
+            }
+            TransferType::Isochronous => unimplemented!("isochronous endpoint"),
+        }
+    }
+
+    fn endpoint_resume_in(&self, endpoint: usize) {
+        let (_, direction, _) = self.descriptors[endpoint].state.get().bulk_state();
+        assert!(direction.has_in());
+
+        if self.dma_pending.get() {
+            debug_info!("requesting resume_in[{}]", endpoint);
+            // A DMA is already pending. Schedule the resume for later.
+            self.descriptors[endpoint].request_transmit_in.set(true);
+        } else {
+            // Trigger the transaction now.
+            self.transmit_in(endpoint);
+        }
+    }
+
+    fn endpoint_resume_out(&self, endpoint: usize) {
+        let (transfer_type, direction, state) = self.descriptors[endpoint].state.get().bulk_state();
+        assert!(direction.has_out());
+
+        match state {
+            BulkState::OutDelay => {
+                // The endpoint has now finished processing the last ENDEPOUT. No EPDATA event
+                // happened in the meantime, so the state is now back to Init.
+                self.descriptors[endpoint].state.set(EndpointState::Bulk(
+                    transfer_type,
+                    direction,
+                    BulkState::Init,
+                ));
+            }
+            BulkState::OutData => {
+                // Although the client reported a delay before, an EPDATA event has
+                // happened in the meantime. This pending transaction will now
+                // continue in transmit_out().
+                if self.dma_pending.get() {
+                    debug_info!("requesting resume_out[{}]", endpoint);
+                    // A DMA is already pending. Schedule the resume for later.
+                    self.descriptors[endpoint].request_transmit_out.set(true);
+                } else {
+                    // Trigger the transaction now.
+                    self.transmit_out(endpoint);
+                }
+            }
+            BulkState::Init | BulkState::OutDma | BulkState::InDma | BulkState::InData => {
+                internal_err!("Unexpected state: {:?}", state);
+            }
+        }
+    }
+}
+
+fn status_epin(ep: usize) -> Field<u32, EndpointStatus::Register> {
+    match ep {
+        0 => EndpointStatus::EPIN0,
+        1 => EndpointStatus::EPIN1,
+        2 => EndpointStatus::EPIN2,
+        3 => EndpointStatus::EPIN3,
+        4 => EndpointStatus::EPIN4,
+        5 => EndpointStatus::EPIN5,
+        6 => EndpointStatus::EPIN6,
+        7 => EndpointStatus::EPIN7,
+        8 => EndpointStatus::EPIN8,
+        _ => unreachable!(),
+    }
+}
+
+fn status_epout(ep: usize) -> Field<u32, EndpointStatus::Register> {
+    match ep {
+        0 => EndpointStatus::EPOUT0,
+        1 => EndpointStatus::EPOUT1,
+        2 => EndpointStatus::EPOUT2,
+        3 => EndpointStatus::EPOUT3,
+        4 => EndpointStatus::EPOUT4,
+        5 => EndpointStatus::EPOUT5,
+        6 => EndpointStatus::EPOUT6,
+        7 => EndpointStatus::EPOUT7,
+        8 => EndpointStatus::EPOUT8,
+        _ => unreachable!(),
+    }
+}
+
+fn inter_endepin(ep: usize) -> Field<u32, Interrupt::Register> {
+    match ep {
+        0 => Interrupt::ENDEPIN0,
+        1 => Interrupt::ENDEPIN1,
+        2 => Interrupt::ENDEPIN2,
+        3 => Interrupt::ENDEPIN3,
+        4 => Interrupt::ENDEPIN4,
+        5 => Interrupt::ENDEPIN5,
+        6 => Interrupt::ENDEPIN6,
+        7 => Interrupt::ENDEPIN7,
+        _ => unreachable!(),
+    }
+}
+
+fn inter_endepout(ep: usize) -> Field<u32, Interrupt::Register> {
+    match ep {
+        0 => Interrupt::ENDEPOUT0,
+        1 => Interrupt::ENDEPOUT1,
+        2 => Interrupt::ENDEPOUT2,
+        3 => Interrupt::ENDEPOUT3,
+        4 => Interrupt::ENDEPOUT4,
+        5 => Interrupt::ENDEPOUT5,
+        6 => Interrupt::ENDEPOUT6,
+        7 => Interrupt::ENDEPOUT7,
+        _ => unreachable!(),
+    }
+}
+
+// Debugging functions.
+fn packet_to_hex(packet: &[VolatileCell<u8>], packet_hex: &mut [u8]) {
+    let hex_char = |x: u8| {
+        if x < 10 {
+            b'0' + x
+        } else {
+            b'a' + x - 10
+        }
+    };
+
+    for (i, x) in packet.iter().enumerate() {
+        let x = x.get();
+        packet_hex[2 * i] = hex_char(x >> 4);
+        packet_hex[2 * i + 1] = hex_char(x & 0x0f);
+    }
+}
+
+#[allow(dead_code)]
+fn ignored_str(
+    saved_inter: &LocalRegisterCopy<u32, Interrupt::Register>,
+    field: Field<u32, Interrupt::Register>,
+) -> &'static str {
+    if saved_inter.is_set(field) {
+        ""
+    } else {
+        " (ignored)"
+    }
+}


### PR DESCRIPTION
### Pull Request Overview

This pull request updates the USB HIL and implements it on the nrf52 chip. There are still unimplemented parts (isochronous endpoints, handling of "USB events"), but I tested it on the USB [echo app](https://github.com/tock/libtock-c/tree/master/examples/tests/usb) for bulk endpoints, and some interrupt endpoints (example not public yet, though the logic in the chip is pretty much the same for interrupt and bulk).

Notable changes to the HIL in order to support this chip as well as interrupt endpoints:
- The `UsbController` and `Client` traits now take a lifetime parameter. This is ultimately to use lifetime-bound buffers, as previously discussed in https://github.com/tock/tock/pull/1427.
- Unified the `endpoint_*_enable` methods to take the transfer type as parameter. This avoids code duplication down the road, as interrupt and bulk endpoints are handled very similarly by the nrf52 chip. Similarly, `bulk_*` methods in the USB client are replaced by `packet_*` methods. And `Bulk(In|Out)Result` enums are generalized to interrupts as well.
- Added a possibility to enable an endpoint both for IN and OUT directions. Some protocols such as USB-HID have such bi-directional endpoints.
- Split `endpoint_bulk_resume` into `endpoint_resume_in` and `endpoint_resume_out` functions, to specify which direction should be resumed, given that an endpoint can now be both IN and OUT directions.
- Due to the way nrf52 triggers USB events, I had to remove the `delayed_in` check in `capsules/src/usb/usbc_client.rs`, otherwise the driver never initiates IN transactions (from the device to the host). I had a look at the sam4l code and this doesn't seem problematic ("superfluous" resumes are ignored).

I propagated these changes on the sam4l, but not implementing the new combinations there as I don't have a board to test on. Code compiles though.

Isochronous endpoints are left un-implemented.

Another thing to note: some revisions of the nrf52840 chip need many more errata to function properly. As I don't have the hardware to test, and to keep things simple, these extra errata are not implemented. If one enables the USB stack on such chip, it will panic, given that the rest of the code will be unstable on these chips.

### Testing Strategy

This pull request was tested by:
- Running the USB bulk-echo test [app](https://github.com/tock/libtock-c/tree/master/examples/tests/usb) with the [host test program](https://github.com/tock/tock/tree/master/tools/usb/bulk-echo).
- Testing a USB-interrupt-based (HID) protocol.


### TODO or Help Wanted

This pull request still needs:
- ~~The interrupt service to listen to USB (https://github.com/tock/tock/pull/1505).~~
- Adding the `usb_user` driver to the board. It's what I added on top of this pull-request to test bulk-echo, and I can integrate it to this pull-request if needed.
- There are still a few things to implement, but given how big USB is, I don't think a single pull-request should implement it all (similarly to sam4l). The goal is to give a basis to experiment and iterate on.


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.