### PR TITLE
Use static_init in the DebugWriter component to create debug buffers.

### DIFF
--- a/boards/components/src/debug_writer.rs
+++ b/boards/components/src/debug_writer.rs
@@ -39,20 +39,21 @@ impl Component for DebugWriterComponent {
     type Output = ();
 
     unsafe fn finalize(&mut self, _s: Self::StaticInput) -> Self::Output {
+        // The sum of the output_buf and internal_buf is set to 1024 bytes in order to avoid excessive
+        // padding between kernel memory and application memory (which often needs to be aligned to at
+        // least a 1kB boundary). This is not _semantically_ critical, but helps keep buffers on 1kB
+        // boundaries in some cases. Of course, these definitions are only advisory, and individual boards
+        // can choose to pass in their own buffers with different lengths.
+        let buf = static_init!([u8; 1024], [0; 1024]);
+        let (output_buf, internal_buf) = buf.split_at_mut(64);
+
         // Create virtual device for kernel debug.
         let debugger_uart = static_init!(UartDevice, UartDevice::new(self.uart_mux, false));
         debugger_uart.setup();
-        let ring_buffer = static_init!(
-            RingBuffer<'static, u8>,
-            RingBuffer::new(&mut kernel::debug::INTERNAL_BUF)
-        );
+        let ring_buffer = static_init!(RingBuffer<'static, u8>, RingBuffer::new(internal_buf));
         let debugger = static_init!(
             kernel::debug::DebugWriter,
-            kernel::debug::DebugWriter::new(
-                debugger_uart,
-                &mut kernel::debug::OUTPUT_BUF,
-                ring_buffer,
-            )
+            kernel::debug::DebugWriter::new(debugger_uart, output_buf, ring_buffer)
         );
         hil::uart::Transmit::set_transmit_client(debugger_uart, debugger);
 

--- a/kernel/src/debug.rs
+++ b/kernel/src/debug.rs
@@ -219,14 +219,6 @@ pub struct DebugWriter {
 /// needed so the debug!() macros have a reference to the object to use.
 static mut DEBUG_WRITER: Option<&'static mut DebugWriterWrapper> = None;
 
-// The sum of the OUTPUT_BUF and INTERNAL_BUF is set to 1024 bytes in order to avoid excessive
-// padding between kernel memory and application memory (which often needs to be aligned to at
-// least a 1kB boundary). This is not _semantically_ critical, but helps keep buffers on 1kB
-// boundaries in some cases. Of course, these definitions are only advisory, and individual boards
-// can choose to pass in their own buffers with different lengths.
-pub static mut OUTPUT_BUF: [u8; 64] = [0; 64];
-pub static mut INTERNAL_BUF: [u8; 1024 - 64] = [0; 1024 - 64];
-
 pub unsafe fn get_debug_writer() -> &'static mut DebugWriterWrapper {
     match ptr::read(&DEBUG_WRITER) {
         Some(x) => x,


### PR DESCRIPTION
### Pull Request Overview

This pull request:
- Updates the arty board to use the `DebugWriterComponent`.
- Removes the `pub static mut` buffers from the `kernel/src/debug.rs` and uses `static_init` to create them in the component instead. This is less error-prone as discussed in https://github.com/tock/tock/issues/1545, and can be more flexible as it allows to more easily increase the buffer size in a specific board.


### Testing Strategy

This pull request was tested by Travis. I don't have an arty board to test on.

I also checked that the code size is the same on all boards before/after this change.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.