### PR TITLE
Add kernel::debug::IoWrite trait and remove unsound str::from_utf8_unchecked (fix #1449)

### DIFF
--- a/boards/arty-e21/src/io.rs
+++ b/boards/arty-e21/src/io.rs
@@ -3,6 +3,7 @@ use core::fmt::Write;
 use core::panic::PanicInfo;
 use core::str;
 use kernel::debug;
+use kernel::debug::IoWrite;
 use kernel::hil::gpio;
 use kernel::hil::led;
 use rv32i;
@@ -17,6 +18,12 @@ impl Write for Writer {
     fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
         debug!("{}", s);
         Ok(())
+    }
+}
+
+impl IoWrite for Writer {
+    fn write(&mut self, buf: &[u8]) {
+        let _ = self.write_str(unsafe { str::from_utf8_unchecked(buf) });
     }
 }
 

--- a/boards/hail/src/io.rs
+++ b/boards/hail/src/io.rs
@@ -3,6 +3,7 @@ use core::panic::PanicInfo;
 use core::str;
 use cortexm4;
 use kernel::debug;
+use kernel::debug::IoWrite;
 use kernel::hil::led;
 use kernel::hil::uart::{self, Configure};
 
@@ -16,6 +17,13 @@ static mut WRITER: Writer = Writer { initialized: false };
 
 impl Write for Writer {
     fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
+        self.write(s.as_bytes());
+        Ok(())
+    }
+}
+
+impl IoWrite for Writer {
+    fn write(&mut self, buf: &[u8]) {
         let uart = unsafe { &mut sam4l::usart::USART0 };
         let regs_manager = &sam4l::usart::USARTRegManager::panic_new(&uart);
         if !self.initialized {
@@ -30,11 +38,10 @@ impl Write for Writer {
             uart.enable_tx(regs_manager);
         }
         // XXX: I'd like to get this working the "right" way, but I'm not sure how
-        for c in s.bytes() {
+        for &c in buf {
             uart.send_byte(regs_manager, c);
             while !uart.tx_ready(regs_manager) {}
         }
-        Ok(())
     }
 }
 

--- a/boards/hifive1/src/io.rs
+++ b/boards/hifive1/src/io.rs
@@ -3,6 +3,7 @@ use core::panic::PanicInfo;
 use core::str;
 use e310x;
 use kernel::debug;
+use kernel::debug::IoWrite;
 use kernel::hil::gpio;
 use kernel::hil::led;
 use rv32i;
@@ -15,10 +16,16 @@ static mut WRITER: Writer = Writer {};
 
 impl Write for Writer {
     fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
-        unsafe {
-            e310x::uart::UART0.transmit_sync(s.as_bytes());
-        }
+        self.write(s.as_bytes());
         Ok(())
+    }
+}
+
+impl IoWrite for Writer {
+    fn write(&mut self, buf: &[u8]) {
+        unsafe {
+            e310x::uart::UART0.transmit_sync(buf);
+        }
     }
 }
 

--- a/boards/imix/src/io.rs
+++ b/boards/imix/src/io.rs
@@ -2,6 +2,7 @@ use core::fmt::Write;
 use core::panic::PanicInfo;
 use cortexm4;
 use kernel::debug;
+use kernel::debug::IoWrite;
 use kernel::hil::led;
 use kernel::hil::uart::{self, Configure};
 use sam4l;
@@ -16,6 +17,13 @@ static mut WRITER: Writer = Writer { initialized: false };
 
 impl Write for Writer {
     fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
+        self.write(s.as_bytes());
+        Ok(())
+    }
+}
+
+impl IoWrite for Writer {
+    fn write(&mut self, buf: &[u8]) {
         let uart = unsafe { &mut sam4l::usart::USART3 };
         let regs_manager = &sam4l::usart::USARTRegManager::panic_new(&uart);
         if !self.initialized {
@@ -30,11 +38,10 @@ impl Write for Writer {
             uart.enable_tx(regs_manager);
         }
         // XXX: I'd like to get this working the "right" way, but I'm not sure how
-        for c in s.bytes() {
+        for &c in buf {
             uart.send_byte(regs_manager, c);
             while !uart.tx_ready(regs_manager) {}
         }
-        Ok(())
     }
 }
 

--- a/boards/nordic/nrf52dk/src/io.rs
+++ b/boards/nordic/nrf52dk/src/io.rs
@@ -2,6 +2,7 @@ use core::fmt::Write;
 use core::panic::PanicInfo;
 use cortexm4;
 use kernel::debug;
+use kernel::debug::IoWrite;
 use kernel::hil::led;
 use kernel::hil::uart::{self, Configure};
 use nrf52832::gpio::Pin;
@@ -16,6 +17,13 @@ static mut WRITER: Writer = Writer { initialized: false };
 
 impl Write for Writer {
     fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
+        self.write(s.as_bytes());
+        Ok(())
+    }
+}
+
+impl IoWrite for Writer {
+    fn write(&mut self, buf: &[u8]) {
         let uart = unsafe { &mut nrf52832::uart::UARTE0 };
         if !self.initialized {
             self.initialized = true;
@@ -27,13 +35,12 @@ impl Write for Writer {
                 width: uart::Width::Eight,
             });
         }
-        for c in s.bytes() {
+        for &c in buf {
             unsafe {
                 uart.send_byte(c);
             }
             while !uart.tx_ready() {}
         }
-        Ok(())
     }
 }
 

--- a/boards/nucleo_f429zi/src/io.rs
+++ b/boards/nucleo_f429zi/src/io.rs
@@ -4,6 +4,7 @@ use core::panic::PanicInfo;
 use cortexm4;
 
 use kernel::debug;
+use kernel::debug::IoWrite;
 use kernel::hil::led;
 use kernel::hil::uart;
 use kernel::hil::uart::Configure;
@@ -31,6 +32,13 @@ impl Writer {
 
 impl Write for Writer {
     fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
+        self.write(s.as_bytes());
+        Ok(())
+    }
+}
+
+impl IoWrite for Writer {
+    fn write(&mut self, buf: &[u8]) {
         let uart = unsafe { &mut stm32f4xx::usart::USART3 };
 
         if !self.initialized {
@@ -45,11 +53,9 @@ impl Write for Writer {
             });
         }
 
-        for c in s.bytes() {
+        for &c in buf {
             uart.send_byte(c);
         }
-
-        Ok(())
     }
 }
 

--- a/boards/nucleo_f446re/src/io.rs
+++ b/boards/nucleo_f446re/src/io.rs
@@ -4,6 +4,7 @@ use core::panic::PanicInfo;
 use cortexm4;
 
 use kernel::debug;
+use kernel::debug::IoWrite;
 use kernel::hil::led;
 use kernel::hil::uart;
 use kernel::hil::uart::Configure;
@@ -31,6 +32,13 @@ impl Writer {
 
 impl Write for Writer {
     fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
+        self.write(s.as_bytes());
+        Ok(())
+    }
+}
+
+impl IoWrite for Writer {
+    fn write(&mut self, buf: &[u8]) {
         let uart = unsafe { &mut stm32f4xx::usart::USART2 };
 
         if !self.initialized {
@@ -45,11 +53,9 @@ impl Write for Writer {
             });
         }
 
-        for c in s.bytes() {
+        for &c in buf {
             uart.send_byte(c);
         }
-
-        Ok(())
     }
 }
 


### PR DESCRIPTION
### Pull Request Overview

This pull request adds a new `IoWrite` trait in the kernel, to write arbitrary bytes instead of UTF-8 strings (fixes https://github.com/tock/tock/issues/1449). Until now, the `flush` function was using `str::from_utf8_unchecked`, even though the bytes are actually not UTF-8 (even with only UTF-8 input, the underlying ring buffer may wrap-around in the middle on a UTF-8 character).

In practice, the underlying implementations work byte-by-byte to send debug output, so a more general trait to write byte slices can be plugged in.

This `IoWrite` trait is similar to `std::io::Write`, except that the latter doesn't exist in `no_std` (because `std::io::Error` isn't compatible - see https://github.com/rust-lang/rust/issues/68315 and https://github.com/rust-lang/rfcs/issues/2262).


### Testing Strategy

This pull request was tested by Travis.


### TODO or Help Wanted

This pull request still needs support for byte-by-byte writing on the arty-e21 board. I'm not even sure the current `debug!` macro is what we want to do in a panic handler.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.