### PR TITLE
doc: restore documentation for hidden items

### DIFF
--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -148,7 +148,7 @@ debug-lst: target/$(TARGET)/debug/$(PLATFORM).lst
 
 .PHONY: doc
 doc: | target
-	$(Q)$(CARGO) doc $(VERBOSE) --release --target=$(TARGET)
+	$(Q)RUSTDOCFLAGS='-Z unstable-options --document-hidden-items' $(CARGO) doc $(VERBOSE) --release --target=$(TARGET)
 
 .PHONY: lst
 lst: target/$(TARGET)/release/$(PLATFORM).lst


### PR DESCRIPTION
### Pull Request Overview

This fixes a bug in documentation building introduced in #1546.

As discussed in https://github.com/rust-lang/rust/pull/67875, there is a
difference between 'private' and 'hidden' items. Documenting private is
now the default for **bin** crates, but we also want documentation for
all of private library crates to be generated as well. Compare:

 - Before #1546: https://5e23ab06b4899600087c8c17--docs-tockosorg.netlify.com/nrf52/ficr/
 -  After #1546: https://deploy-preview-1546--docs-tockosorg.netlify.com/nrf52/ficr/

This restores our previous documentation

### Testing Strategy

Building, a lot, and being confused for a while until I found the right rust issue :).

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
