### PR TITLE
Add support for structs with a lifetime parameter in register_structs.

### DIFF
--- a/libraries/tock-register-interface/CHANGELOG.md
+++ b/libraries/tock-register-interface/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## master
+
+ - #1554: Allow lifetime parameters for `register_structs! { Foo<'a> { ..`
+
 ## v0.5
 
  - #1510

--- a/libraries/tock-register-interface/src/macros.rs
+++ b/libraries/tock-register-interface/src/macros.rs
@@ -145,12 +145,12 @@ macro_rules! register_bitfields {
 #[macro_export]
 macro_rules! register_fields {
     // Macro entry point.
-    (@root $(#[$attr_struct:meta])* $vis_struct:vis $name:ident { $($input:tt)* } ) => {
+    (@root $(#[$attr_struct:meta])* $vis_struct:vis $name:ident $(<$life:lifetime>)? { $($input:tt)* } ) => {
         $crate::register_fields!(
             @munch (
                 $($input)*
             ) -> {
-                $vis_struct struct $(#[$attr_struct])* $name
+                $vis_struct struct $(#[$attr_struct])* $name $(<$life>)?
             }
         );
     };
@@ -161,14 +161,14 @@ macro_rules! register_fields {
             $(#[$attr_end:meta])*
             ($offset:expr => @END),
         )
-        -> {$vis_struct:vis struct $(#[$attr_struct:meta])* $name:ident $(
+        -> {$vis_struct:vis struct $(#[$attr_struct:meta])* $name:ident $(<$life:lifetime>)? $(
                 $(#[$attr:meta])*
                 ($vis:vis $id:ident: $ty:ty)
             )*}
     ) => {
         $(#[$attr_struct])*
         #[repr(C)]
-        $vis_struct struct $name {
+        $vis_struct struct $name $(<$life>)? {
             $(
                 $(#[$attr])*
                 $vis $id: $ty
@@ -224,12 +224,14 @@ macro_rules! register_fields {
 #[macro_export]
 macro_rules! test_fields {
     // Macro entry point.
-    (@root $struct:ident $($input:tt)* ) => {
-        $crate::test_fields!(@munch $struct sum ($($input)*) -> {});
+    (@root $struct:ident $(<$life:lifetime>)? { $($input:tt)* } ) => {
+        $crate::test_fields!(@munch $struct $(<$life>)? sum ($($input)*) -> {});
     };
 
     // Print the tests once all fields have been munched.
-    (@munch $struct:ident $sum:ident
+    // We wrap the tests in a "detail" function that potentially takes a lifetime parameter, so that
+    // the lifetime is declared inside it - therefore all types using the lifetime are well-defined.
+    (@munch $struct:ident $(<$life:lifetime>)? $sum:ident
         (
             $(#[$attr_end:meta])*
             ($size:expr => @END),
@@ -237,21 +239,26 @@ macro_rules! test_fields {
         -> {$($stmts:block)*}
     ) => {
         {
-        let mut $sum: usize = 0;
-        $($stmts)*
-        let size = core::mem::size_of::<$struct>();
-        assert!(
-            size == $size,
-            "Invalid size for struct {} (expected {:#X} but was {:#X})",
-            stringify!($struct),
-            $size,
-            size
-        );
+        fn detail $(<$life>)? ()
+        {
+            let mut $sum: usize = 0;
+            $($stmts)*
+            let size = core::mem::size_of::<$struct $(<$life>)?>();
+            assert!(
+                size == $size,
+                "Invalid size for struct {} (expected {:#X} but was {:#X})",
+                stringify!($struct),
+                $size,
+                size
+            );
+        }
+
+        detail();
         }
     };
 
     // Munch field.
-    (@munch $struct:ident $sum:ident
+    (@munch $struct:ident $(<$life:lifetime>)? $sum:ident
         (
             $(#[$attr:meta])*
             ($offset_start:expr => $vis:vis $field:ident: $ty:ty),
@@ -262,7 +269,7 @@ macro_rules! test_fields {
         -> {$($output:block)*}
     ) => {
         $crate::test_fields!(
-            @munch $struct $sum (
+            @munch $struct $(<$life>)? $sum (
                 $(#[$attr_next])*
                 ($offset_end => $($next)*),
                 $($after)*
@@ -298,7 +305,7 @@ macro_rules! test_fields {
     };
 
     // Munch padding.
-    (@munch $struct:ident $sum:ident
+    (@munch $struct:ident $(<$life:lifetime>)? $sum:ident
         (
             $(#[$attr:meta])*
             ($offset_start:expr => $padding:ident),
@@ -309,7 +316,7 @@ macro_rules! test_fields {
         -> {$($output:block)*}
     ) => {
         $crate::test_fields!(
-            @munch $struct $sum (
+            @munch $struct $(<$life>)? $sum (
                 $(#[$attr_next])*
                 ($offset_end => $($next)*),
                 $($after)*
@@ -336,12 +343,12 @@ macro_rules! register_structs {
     {
         $(
             $(#[$attr:meta])*
-            $vis_struct:vis $name:ident {
+            $vis_struct:vis $name:ident $(<$life:lifetime>)? {
                 $( $fields:tt )*
             }
         ),*
     } => {
-        $( $crate::register_fields!(@root $(#[$attr])* $vis_struct $name { $($fields)* } ); )*
+        $( $crate::register_fields!(@root $(#[$attr])* $vis_struct $name $(<$life>)? { $($fields)* } ); )*
 
         #[cfg(test)]
         mod test_register_structs {
@@ -351,7 +358,7 @@ macro_rules! register_structs {
                 use super::super::*;
                 #[test]
                 fn test_offsets() {
-                    $crate::test_fields!(@root $name $($fields)* )
+                    $crate::test_fields!(@root $name $(<$life>)? { $($fields)* } )
                 }
             }
         )*
@@ -365,11 +372,11 @@ macro_rules! register_structs {
     {
         $(
             $(#[$attr:meta])*
-            $vis_struct:vis $name:ident {
+            $vis_struct:vis $name:ident $(<$life:lifetime>)? {
                 $( $fields:tt )*
             }
         ),*
     } => {
-        $( $crate::register_fields!(@root $(#[$attr])* $vis_struct $name { $($fields)* } ); )*
+        $( $crate::register_fields!(@root $(#[$attr])* $vis_struct $name $(<$life>)? { $($fields)* } ); )*
     };
 }


### PR DESCRIPTION
### Pull Request Overview

This pull request extends `register_structs` to allow defining structs with a lifetime parameter.

This will be useful to be able to migrate the definition of `UsbdRegisters` in `chips/nrf52/usbd` to use the `register_structs` macro.

https://github.com/tock/tock/blob/8bb3fc1fa3d1b3fe66f2ed0e85860d229df0af7c/chips/nrf52/src/usbd.rs#L46

I created this separate PR to avoid blocking https://github.com/tock/tock/pull/1543 (which is already large enough), while being able to iterate on `register_structs` in parallel.


### Testing Strategy

This pull request was tested by:
- Running `make ci-travis` with a migrated version of `UsbdRegisters` (not yet in review, to avoid blocking https://github.com/tock/tock/pull/1543 in the meantime).
- Running Travis-CI on the current code, checking that other uses of `register_structs` are unaffected.


### TODO or Help Wanted

- [x] For now, this change only allows a single lifetime parameter. I'm not sure we'll ever need more lifetimes (in the end these lifetimes are `'static` in Tock), but the syntax could be extended in the future if necessary.
- [x] Eventually, migrating `UsbdRegisters` to use `register_structs`, but this can be done after this PR, and after https://github.com/tock/tock/pull/1543 is merged.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

The additional lifetimes should be seamless in terms of user syntax, i.e. one will be able to write:

```rust
register_structs! {
    Foo<'a> {
        (0x000 => bar: Bar<'a>),
        ...
    }
}
```

Therefore I'm not sure whether any updates to the docs are required for this specific case.

### Formatting

- [x] Ran `make formatall`.