### PR TITLE
[RFC] Add ConstPtr32 type to wrap a pointer type expected to be 32-bit wide.

### DIFF
--- a/libraries/tock-cells/src/lib.rs
+++ b/libraries/tock-cells/src/lib.rs
@@ -6,5 +6,6 @@
 pub mod map_cell;
 pub mod numeric_cell_ext;
 pub mod optional_cell;
+pub mod ptr_wrappers;
 pub mod take_cell;
 pub mod volatile_cell;

--- a/libraries/tock-cells/src/ptr_wrappers.rs
+++ b/libraries/tock-cells/src/ptr_wrappers.rs
@@ -1,0 +1,49 @@
+#[cfg(target_pointer_width = "32")]
+use crate::volatile_cell::VolatileCell;
+
+#[cfg(target_pointer_width = "32")]
+#[repr(C)]
+pub struct ConstPtr32<T> {
+    ptr: VolatileCell<*const T>,
+}
+
+#[cfg(not(target_pointer_width = "32"))]
+#[repr(C)]
+pub struct ConstPtr32<T> {
+    _dummy: u32,
+    _phantom: core::marker::PhantomData<T>,
+}
+
+#[cfg(target_pointer_width = "32")]
+impl<T> ConstPtr32<T> {
+    pub fn new(ptr: *const T) -> Self {
+        ConstPtr32 {
+            ptr: VolatileCell::new(ptr),
+        }
+    }
+
+    #[inline]
+    pub fn get(&self) -> *const T {
+        self.ptr.get()
+    }
+
+    #[inline]
+    pub fn set(&mut self, ptr: *const T) {
+        self.ptr.set(ptr);
+    }
+}
+
+#[cfg(not(target_pointer_width = "32"))]
+impl<T> ConstPtr32<T> {
+    pub fn new(_ptr: *const T) -> Self {
+        unimplemented!()
+    }
+
+    pub fn get(&self) -> *const T {
+        unimplemented!()
+    }
+
+    pub fn set(&mut self, _ptr: *const T) {
+        unimplemented!()
+    }
+}


### PR DESCRIPTION
### Pull Request Overview

This pull request adds a new `ConstPtr32<T>` wrapper type (name subject to bikeshedding). As the name goes, this type wraps as `*const T` on architectures where a pointer is 32-bit wide.

With `register_structs` (https://github.com/tock/tock/pull/1410) and `cargo test` on chips (https://github.com/tock/tock/pull/1393) now merged, we can migrate more structs to `register_structs`, with automated tests that addresses and sizes are what they claim to be.

However, some register structs use a raw pointer, such as `EndpointRegisters` in `chips/nrf52/usb`.

https://github.com/tock/tock/blob/8bb3fc1fa3d1b3fe66f2ed0e85860d229df0af7c/chips/nrf52/src/usbd.rs#L265-L267

The unit tests generated by `register_structs` will output some code checking the size of the pointer (i.e. `core::mem::size_of::<VolatileCell<*const u8>>()`). The problem is that the pointer size of the target architecture of Tock (usually 32-bit) may be different than the size on the desktop it runs on (usually 64-bit nowadays).

This new `ConstPtr32` wrapper is guaranteed to have a size of 4 bytes on all architectures, so that the unit tests behave as expected in all cases. Further, it wraps a real pointer on archs with 32-bit pointers, and a dummy value in other cases (with `unimplemented` methods to prevent mistakes).

When defining registers on a specific chip, the pointer width is fixed an known, so one can use `ConstPtr32<T>` as a replacement for `*const T` in that case. If the wrong pointer width is assumed, accesses to it will `panic` at runtime (in the meantime the layout of the struct is as declared by the `register_structs` macro as long as the unit tests pass - so potential accesses to other fields of the same struct shouldn't trigger unexpected behavior).

**Note**: In principle, not all `*const T` have the target pointer width, for example if `T = dyn U`, then `*const dyn U` will be a "fat pointer" containing a regular pointer + a vtable pointer. In that case the size would be wrong, however `ConstPtr32` would only accept such dynamic types if there was a `T: ?Sized` bound in the definition.
So in the current form it shouldn't be possible to have `size_of::<ConstPtr32<T>>()` be anything else than 4 bytes. Besides, I don't see any use case for dynamic types in register structs.


### Testing Strategy

This pull request was tested by:
- Checking that it compiles.
- Running `make ci-travis` with a ported version of `EndpointRegisters` on `chips/nrf52/usb`.

The migration of `chips/nrf52/usb` is not done here to avoid blocking https://github.com/tock/tock/pull/1543 in the meantime.


### TODO or Help Wanted

This pull request still needs:
- [ ] To decide whether the wrapper type should be backed by `VolatileCell`, or if it's up to the caller to wrap the pointer in a volatile cell if they want to.
- [ ] To agree on the name of the module, and of the pointer wrapper type.
- [ ] Is `ConstPtr64` needed at this point?


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
