### PR TITLE
Refactor Segger RTT and add a usb_debugging mode on the nRF52840-DK board

### DIFF
--- a/boards/acd52832/src/main.rs
+++ b/boards/acd52832/src/main.rs
@@ -334,21 +334,10 @@ pub unsafe fn reset_handler() {
     // RTT and Console and `debug!()`
     //
 
-    // Virtual alarm for the Segger RTT communication channel
-    let virtual_alarm_rtt = static_init!(
-        capsules::virtual_alarm::VirtualMuxAlarm<'static, nrf52832::rtc::Rtc>,
-        capsules::virtual_alarm::VirtualMuxAlarm::new(mux_alarm)
-    );
-
     // RTT communication channel
-    let (rtt_memory, up_buffer, down_buffer) =
-        components::segger_rtt::SeggerRttMemoryComponent::new().finalize(());
-
-    let rtt = static_init!(
-        capsules::segger_rtt::SeggerRtt<VirtualMuxAlarm<'static, nrf52832::rtc::Rtc>>,
-        capsules::segger_rtt::SeggerRtt::new(virtual_alarm_rtt, rtt_memory, up_buffer, down_buffer)
-    );
-    hil::time::Alarm::set_client(virtual_alarm_rtt, rtt);
+    let rtt_memory = components::segger_rtt::SeggerRttMemoryComponent::new().finalize(());
+    let rtt = components::segger_rtt::SeggerRttComponent::new(mux_alarm, rtt_memory)
+        .finalize(components::segger_rtt_component_helper!(nrf52832::rtc::Rtc));
 
     //
     // Virtual UART

--- a/boards/acd52832/src/main.rs
+++ b/boards/acd52832/src/main.rs
@@ -341,23 +341,26 @@ pub unsafe fn reset_handler() {
     );
 
     // RTT communication channel
+    let name = b"Terminal\0";
+    let up_buffer_name = name;
+    let down_buffer_name = name;
+    let up_buffer = static_init!([u8; 1024], [0; 1024]);
+    let down_buffer = static_init!([u8; 32], [0; 32]);
+
     let rtt_memory = static_init!(
         capsules::segger_rtt::SeggerRttMemory,
-        capsules::segger_rtt::SeggerRttMemory::new(
-            b"Terminal\0",
-            &mut capsules::segger_rtt::UP_BUFFER,
-            b"Terminal\0",
-            &mut capsules::segger_rtt::DOWN_BUFFER
+        capsules::segger_rtt::SeggerRttMemory::new_raw(
+            up_buffer_name,
+            up_buffer.as_ptr(),
+            up_buffer.len(),
+            down_buffer_name,
+            down_buffer.as_ptr(),
+            down_buffer.len()
         )
     );
     let rtt = static_init!(
         capsules::segger_rtt::SeggerRtt<VirtualMuxAlarm<'static, nrf52832::rtc::Rtc>>,
-        capsules::segger_rtt::SeggerRtt::new(
-            virtual_alarm_rtt,
-            rtt_memory,
-            &mut capsules::segger_rtt::UP_BUFFER,
-            &mut capsules::segger_rtt::DOWN_BUFFER
-        )
+        capsules::segger_rtt::SeggerRtt::new(virtual_alarm_rtt, rtt_memory, up_buffer, down_buffer)
     );
     hil::time::Alarm::set_client(virtual_alarm_rtt, rtt);
 

--- a/boards/acd52832/src/main.rs
+++ b/boards/acd52832/src/main.rs
@@ -341,23 +341,9 @@ pub unsafe fn reset_handler() {
     );
 
     // RTT communication channel
-    let name = b"Terminal\0";
-    let up_buffer_name = name;
-    let down_buffer_name = name;
-    let up_buffer = static_init!([u8; 1024], [0; 1024]);
-    let down_buffer = static_init!([u8; 32], [0; 32]);
+    let (rtt_memory, up_buffer, down_buffer) =
+        components::segger_rtt::SeggerRttMemoryComponent::new().finalize(());
 
-    let rtt_memory = static_init!(
-        capsules::segger_rtt::SeggerRttMemory,
-        capsules::segger_rtt::SeggerRttMemory::new_raw(
-            up_buffer_name,
-            up_buffer.as_ptr(),
-            up_buffer.len(),
-            down_buffer_name,
-            down_buffer.as_ptr(),
-            down_buffer.len()
-        )
-    );
     let rtt = static_init!(
         capsules::segger_rtt::SeggerRtt<VirtualMuxAlarm<'static, nrf52832::rtc::Rtc>>,
         capsules::segger_rtt::SeggerRtt::new(virtual_alarm_rtt, rtt_memory, up_buffer, down_buffer)

--- a/boards/components/src/alarm.rs
+++ b/boards/components/src/alarm.rs
@@ -69,7 +69,7 @@ impl<A: 'static + time::Alarm<'static>> Component for AlarmMuxComponent<A> {
     type StaticInput = &'static mut MaybeUninit<MuxAlarm<'static, A>>;
     type Output = &'static MuxAlarm<'static, A>;
 
-    unsafe fn finalize(&mut self, static_buffer: Self::StaticInput) -> Self::Output {
+    unsafe fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
         let mux_alarm = static_init_half!(
             static_buffer,
             MuxAlarm<'static, A>,
@@ -105,7 +105,7 @@ impl<A: 'static + time::Alarm<'static>> Component for AlarmDriverComponent<A> {
     );
     type Output = &'static AlarmDriver<'static, VirtualMuxAlarm<'static, A>>;
 
-    unsafe fn finalize(&mut self, static_buffer: Self::StaticInput) -> Self::Output {
+    unsafe fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
         let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
 
         let virtual_alarm1 = static_init_half!(

--- a/boards/components/src/button.rs
+++ b/boards/components/src/button.rs
@@ -59,7 +59,7 @@ impl Component for ButtonComponent {
     )];
     type Output = &'static capsules::button::Button<'static>;
 
-    unsafe fn finalize(&mut self, button_pins: Self::StaticInput) -> Self::Output {
+    unsafe fn finalize(self, button_pins: Self::StaticInput) -> Self::Output {
         let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
         let button = static_init!(
             capsules::button::Button<'static>,

--- a/boards/components/src/console.rs
+++ b/boards/components/src/console.rs
@@ -54,7 +54,7 @@ impl Component for UartMuxComponent {
     type StaticInput = ();
     type Output = &'static MuxUart<'static>;
 
-    unsafe fn finalize(&mut self, _s: Self::StaticInput) -> Self::Output {
+    unsafe fn finalize(self, _s: Self::StaticInput) -> Self::Output {
         let uart_mux = static_init!(
             MuxUart<'static>,
             MuxUart::new(
@@ -99,7 +99,7 @@ impl Component for ConsoleComponent {
     type StaticInput = ();
     type Output = &'static console::Console<'static>;
 
-    unsafe fn finalize(&mut self, _s: Self::StaticInput) -> Self::Output {
+    unsafe fn finalize(self, _s: Self::StaticInput) -> Self::Output {
         let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
 
         // Create virtual device for console.

--- a/boards/components/src/crc.rs
+++ b/boards/components/src/crc.rs
@@ -53,7 +53,7 @@ impl<C: 'static + hil::crc::CRC> Component for CrcComponent<C> {
     type StaticInput = &'static mut MaybeUninit<crc::Crc<'static, C>>;
     type Output = &'static crc::Crc<'static, C>;
 
-    unsafe fn finalize(&mut self, static_buffer: Self::StaticInput) -> Self::Output {
+    unsafe fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
         let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
 
         let crc = static_init_half!(

--- a/boards/components/src/debug_writer.rs
+++ b/boards/components/src/debug_writer.rs
@@ -38,7 +38,7 @@ impl Component for DebugWriterComponent {
     type StaticInput = ();
     type Output = ();
 
-    unsafe fn finalize(&mut self, _s: Self::StaticInput) -> Self::Output {
+    unsafe fn finalize(self, _s: Self::StaticInput) -> Self::Output {
         // The sum of the output_buf and internal_buf is set to 1024 bytes in order to avoid excessive
         // padding between kernel memory and application memory (which often needs to be aligned to at
         // least a 1kB boundary). This is not _semantically_ critical, but helps keep buffers on 1kB

--- a/boards/components/src/gpio.rs
+++ b/boards/components/src/gpio.rs
@@ -60,7 +60,7 @@ impl Component for GpioComponent {
     type StaticInput = &'static [&'static dyn kernel::hil::gpio::InterruptValuePin];
     type Output = &'static capsules::gpio::GPIO<'static>;
 
-    unsafe fn finalize(&mut self, gpio_pins: Self::StaticInput) -> Self::Output {
+    unsafe fn finalize(self, gpio_pins: Self::StaticInput) -> Self::Output {
         let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
         let gpio = static_init!(
             capsules::gpio::GPIO<'static>,

--- a/boards/components/src/isl29035.rs
+++ b/boards/components/src/isl29035.rs
@@ -80,7 +80,7 @@ impl<A: 'static + time::Alarm<'static>> Component for Isl29035Component<A> {
 
     type Output = &'static Isl29035<'static, VirtualMuxAlarm<'static, A>>;
 
-    unsafe fn finalize(&mut self, static_buffer: Self::StaticInput) -> Self::Output {
+    unsafe fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
         let isl29035_i2c = static_init!(I2CDevice, I2CDevice::new(self.i2c_mux, 0x44));
         let isl29035_virtual_alarm = static_init_half!(
             static_buffer.0,
@@ -125,7 +125,7 @@ impl<A: 'static + time::Alarm<'static>> Component for AmbientLightComponent<A> {
     );
     type Output = &'static AmbientLight<'static>;
 
-    unsafe fn finalize(&mut self, static_buffer: Self::StaticInput) -> Self::Output {
+    unsafe fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
         let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
 
         let isl29035_i2c = static_init!(I2CDevice, I2CDevice::new(self.i2c_mux, 0x44));

--- a/boards/components/src/led.rs
+++ b/boards/components/src/led.rs
@@ -50,7 +50,7 @@ impl Component for LedsComponent {
     )];
     type Output = &'static capsules::led::LED<'static>;
 
-    unsafe fn finalize(&mut self, pins: Self::StaticInput) -> Self::Output {
+    unsafe fn finalize(self, pins: Self::StaticInput) -> Self::Output {
         static_init!(capsules::led::LED<'static>, capsules::led::LED::new(pins))
     }
 }

--- a/boards/components/src/lib.rs
+++ b/boards/components/src/lib.rs
@@ -17,5 +17,6 @@ pub mod lldb;
 pub mod nrf51822;
 pub mod process_console;
 pub mod rng;
+pub mod segger_rtt;
 pub mod si7021;
 pub mod spi;

--- a/boards/components/src/lldb.rs
+++ b/boards/components/src/lldb.rs
@@ -45,7 +45,7 @@ impl Component for LowLevelDebugComponent {
     type StaticInput = ();
     type Output = &'static low_level_debug::LowLevelDebug<'static, UartDevice<'static>>;
 
-    unsafe fn finalize(&mut self, _s: Self::StaticInput) -> Self::Output {
+    unsafe fn finalize(self, _s: Self::StaticInput) -> Self::Output {
         let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
 
         // Create virtual device for console.

--- a/boards/components/src/nrf51822.rs
+++ b/boards/components/src/nrf51822.rs
@@ -45,7 +45,7 @@ impl<U: 'static + hil::uart::UartAdvanced<'static>, G: 'static + hil::gpio::Pin>
     type StaticInput = ();
     type Output = &'static nrf51822_serialization::Nrf51822Serialization<'static>;
 
-    unsafe fn finalize(&mut self, _s: Self::StaticInput) -> Self::Output {
+    unsafe fn finalize(self, _s: Self::StaticInput) -> Self::Output {
         let nrf_serialization = static_init!(
             nrf51822_serialization::Nrf51822Serialization<'static>,
             nrf51822_serialization::Nrf51822Serialization::new(

--- a/boards/components/src/process_console.rs
+++ b/boards/components/src/process_console.rs
@@ -46,7 +46,7 @@ impl Component for ProcessConsoleComponent {
     type StaticInput = ();
     type Output = &'static process_console::ProcessConsole<'static, Capability>;
 
-    unsafe fn finalize(&mut self, _s: Self::StaticInput) -> Self::Output {
+    unsafe fn finalize(self, _s: Self::StaticInput) -> Self::Output {
         // Create virtual device for console.
         let console_uart = static_init!(UartDevice, UartDevice::new(self.uart_mux, true));
         console_uart.setup();

--- a/boards/components/src/rng.rs
+++ b/boards/components/src/rng.rs
@@ -43,7 +43,7 @@ impl Component for RngComponent {
     type StaticInput = ();
     type Output = &'static rng::RngDriver<'static>;
 
-    unsafe fn finalize(&mut self, _static_buffer: Self::StaticInput) -> Self::Output {
+    unsafe fn finalize(self, _static_buffer: Self::StaticInput) -> Self::Output {
         let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
 
         let entropy_to_random = static_init!(

--- a/boards/components/src/segger_rtt.rs
+++ b/boards/components/src/segger_rtt.rs
@@ -1,0 +1,61 @@
+//! Component for SeggerRttMemory.
+//!
+//! This provides one `Component`, `SeggerRttMemoryComponent`, which creates suitable memory for
+//! the Segger RTT capsule.
+//!
+//! Usage
+//! -----
+//! ```rust
+//! let (rtt_memory, up_buffer, down_buffer) = SeggerRttMemoryComponent::new().finalize(());
+//! ```
+
+// Author: Guillaume Endignoux <guillaumee@google.com>
+// Last modified: 07/02/2020
+
+use capsules::segger_rtt::{SeggerRttMemory, DEFAULT_DOWN_BUFFER_LENGTH, DEFAULT_UP_BUFFER_LENGTH};
+use kernel::component::Component;
+use kernel::static_init;
+
+pub struct SeggerRttMemoryComponent {}
+
+impl SeggerRttMemoryComponent {
+    pub fn new() -> SeggerRttMemoryComponent {
+        SeggerRttMemoryComponent {}
+    }
+}
+
+impl Component for SeggerRttMemoryComponent {
+    type StaticInput = ();
+    type Output = (
+        &'static mut SeggerRttMemory<'static>,
+        &'static mut [u8],
+        &'static mut [u8],
+    );
+
+    unsafe fn finalize(&mut self, _s: Self::StaticInput) -> Self::Output {
+        let name = b"Terminal\0";
+        let up_buffer_name = name;
+        let down_buffer_name = name;
+        let up_buffer = static_init!(
+            [u8; DEFAULT_UP_BUFFER_LENGTH],
+            [0; DEFAULT_UP_BUFFER_LENGTH]
+        );
+        let down_buffer = static_init!(
+            [u8; DEFAULT_DOWN_BUFFER_LENGTH],
+            [0; DEFAULT_DOWN_BUFFER_LENGTH]
+        );
+
+        let rtt_memory = static_init!(
+            SeggerRttMemory,
+            SeggerRttMemory::new_raw(
+                up_buffer_name,
+                up_buffer.as_ptr(),
+                up_buffer.len(),
+                down_buffer_name,
+                down_buffer.as_ptr(),
+                down_buffer.len()
+            )
+        );
+        (rtt_memory, up_buffer, down_buffer)
+    }
+}

--- a/boards/components/src/segger_rtt.rs
+++ b/boards/components/src/segger_rtt.rs
@@ -3,7 +3,7 @@
 //! This provides two `Component`s:
 //! - `SeggerRttMemoryComponent`, which creates suitable memory for the Segger
 //!   RTT capsule.
-//! - `SeggerRttComponent`, which instanciates the Segger RTT capsule.
+//! - `SeggerRttComponent`, which instantiates the Segger RTT capsule.
 //!
 //! Usage
 //! -----

--- a/boards/components/src/segger_rtt.rs
+++ b/boards/components/src/segger_rtt.rs
@@ -1,20 +1,56 @@
 //! Component for SeggerRttMemory.
 //!
-//! This provides one `Component`, `SeggerRttMemoryComponent`, which creates suitable memory for
-//! the Segger RTT capsule.
+//! This provides two `Component`s:
+//! - `SeggerRttMemoryComponent`, which creates suitable memory for the Segger
+//!   RTT capsule.
+//! - `SeggerRttComponent`, which instanciates the Segger RTT capsule.
 //!
 //! Usage
 //! -----
 //! ```rust
-//! let (rtt_memory, up_buffer, down_buffer) = SeggerRttMemoryComponent::new().finalize(());
+//! let rtt_memory = components::segger_rtt::SeggerRttMemoryComponent::new().finalize(());
+//! let rtt = components::segger_rtt::SeggerRttComponent::new(mux_alarm, rtt_memory)
+//!     .finalize(components::segger_rtt_component_helper!(nrf52832::rtc::Rtc));
 //! ```
 
 // Author: Guillaume Endignoux <guillaumee@google.com>
 // Last modified: 07/02/2020
 
-use capsules::segger_rtt::{SeggerRttMemory, DEFAULT_DOWN_BUFFER_LENGTH, DEFAULT_UP_BUFFER_LENGTH};
+use capsules::segger_rtt::{
+    SeggerRtt, SeggerRttMemory, DEFAULT_DOWN_BUFFER_LENGTH, DEFAULT_UP_BUFFER_LENGTH,
+};
+use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
+use core::mem::MaybeUninit;
 use kernel::component::Component;
-use kernel::static_init;
+use kernel::hil::time;
+use kernel::hil::time::Alarm;
+use kernel::{static_init, static_init_half};
+
+// Setup static space for the objects.
+#[macro_export]
+macro_rules! segger_rtt_component_helper {
+    ($A:ty) => {{
+        use capsules::segger_rtt::SeggerRtt;
+        use capsules::virtual_alarm::VirtualMuxAlarm;
+        use core::mem::MaybeUninit;
+        static mut BUF1: MaybeUninit<VirtualMuxAlarm<'static, $A>> = MaybeUninit::uninit();
+        static mut BUF2: MaybeUninit<SeggerRtt<'static, VirtualMuxAlarm<'static, $A>>> =
+            MaybeUninit::uninit();
+        (&mut BUF1, &mut BUF2)
+    };};
+}
+
+pub struct SeggerRttMemoryRefs<'a> {
+    rtt_memory: &'a mut SeggerRttMemory<'a>,
+    up_buffer: &'a mut [u8],
+    down_buffer: &'a mut [u8],
+}
+
+impl<'a> SeggerRttMemoryRefs<'a> {
+    pub unsafe fn get_rtt_memory_ptr(&mut self) -> *mut SeggerRttMemory<'a> {
+        self.rtt_memory as *mut _
+    }
+}
 
 pub struct SeggerRttMemoryComponent {}
 
@@ -26,13 +62,9 @@ impl SeggerRttMemoryComponent {
 
 impl Component for SeggerRttMemoryComponent {
     type StaticInput = ();
-    type Output = (
-        &'static mut SeggerRttMemory<'static>,
-        &'static mut [u8],
-        &'static mut [u8],
-    );
+    type Output = SeggerRttMemoryRefs<'static>;
 
-    unsafe fn finalize(&mut self, _s: Self::StaticInput) -> Self::Output {
+    unsafe fn finalize(self, _s: Self::StaticInput) -> Self::Output {
         let name = b"Terminal\0";
         let up_buffer_name = name;
         let down_buffer_name = name;
@@ -56,6 +88,59 @@ impl Component for SeggerRttMemoryComponent {
                 down_buffer.len()
             )
         );
-        (rtt_memory, up_buffer, down_buffer)
+        SeggerRttMemoryRefs {
+            rtt_memory,
+            up_buffer,
+            down_buffer,
+        }
+    }
+}
+
+pub struct SeggerRttComponent<A: 'static + time::Alarm<'static>> {
+    mux_alarm: &'static MuxAlarm<'static, A>,
+    rtt_memory_refs: SeggerRttMemoryRefs<'static>,
+}
+
+impl<A: 'static + time::Alarm<'static>> SeggerRttComponent<A> {
+    pub fn new(
+        mux_alarm: &'static MuxAlarm<'static, A>,
+        rtt_memory_refs: SeggerRttMemoryRefs<'static>,
+    ) -> SeggerRttComponent<A> {
+        SeggerRttComponent {
+            mux_alarm,
+            rtt_memory_refs,
+        }
+    }
+}
+
+impl<A: 'static + time::Alarm<'static>> Component for SeggerRttComponent<A> {
+    type StaticInput = (
+        &'static mut MaybeUninit<VirtualMuxAlarm<'static, A>>,
+        &'static mut MaybeUninit<SeggerRtt<'static, VirtualMuxAlarm<'static, A>>>,
+    );
+    type Output = &'static capsules::segger_rtt::SeggerRtt<'static, VirtualMuxAlarm<'static, A>>;
+
+    unsafe fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
+        let virtual_alarm_rtt = static_init_half!(
+            static_buffer.0,
+            VirtualMuxAlarm<'static, A>,
+            VirtualMuxAlarm::new(self.mux_alarm)
+        );
+
+        // RTT communication channel
+        let rtt = static_init_half!(
+            static_buffer.1,
+            SeggerRtt<'static, VirtualMuxAlarm<'static, A>>,
+            SeggerRtt::new(
+                virtual_alarm_rtt,
+                self.rtt_memory_refs.rtt_memory,
+                self.rtt_memory_refs.up_buffer,
+                self.rtt_memory_refs.down_buffer
+            )
+        );
+
+        virtual_alarm_rtt.set_client(rtt);
+
+        rtt
     }
 }

--- a/boards/components/src/si7021.rs
+++ b/boards/components/src/si7021.rs
@@ -76,7 +76,7 @@ impl<A: 'static + time::Alarm<'static>> Component for SI7021Component<A> {
     );
     type Output = &'static SI7021<'static, VirtualMuxAlarm<'static, A>>;
 
-    unsafe fn finalize(&mut self, static_buffer: Self::StaticInput) -> Self::Output {
+    unsafe fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
         let si7021_i2c = static_init!(I2CDevice, I2CDevice::new(self.i2c_mux, self.i2c_address));
         let si7021_alarm = static_init_half!(
             static_buffer.0,
@@ -116,7 +116,7 @@ impl<A: 'static + time::Alarm<'static>> Component for TemperatureComponent<A> {
     type StaticInput = ();
     type Output = &'static TemperatureSensor<'static>;
 
-    unsafe fn finalize(&mut self, _s: Self::StaticInput) -> Self::Output {
+    unsafe fn finalize(self, _s: Self::StaticInput) -> Self::Output {
         let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
 
         let temp = static_init!(
@@ -150,7 +150,7 @@ impl<A: 'static + time::Alarm<'static>> Component for HumidityComponent<A> {
     type StaticInput = ();
     type Output = &'static HumiditySensor<'static>;
 
-    unsafe fn finalize(&mut self, _s: Self::StaticInput) -> Self::Output {
+    unsafe fn finalize(self, _s: Self::StaticInput) -> Self::Output {
         let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
 
         let hum = static_init!(

--- a/boards/components/src/spi.rs
+++ b/boards/components/src/spi.rs
@@ -90,7 +90,7 @@ impl<S: 'static + spi::SpiMaster> Component for SpiMuxComponent<S> {
     type StaticInput = &'static mut MaybeUninit<MuxSpiMaster<'static, S>>;
     type Output = &'static MuxSpiMaster<'static, S>;
 
-    unsafe fn finalize(&mut self, static_buffer: Self::StaticInput) -> Self::Output {
+    unsafe fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
         let mux_spi = static_init_half!(
             static_buffer,
             MuxSpiMaster<'static, S>,
@@ -120,7 +120,7 @@ impl<S: 'static + spi::SpiMaster> Component for SpiSyscallComponent<S> {
     );
     type Output = &'static Spi<'static, VirtualSpiMasterDevice<'static, S>>;
 
-    unsafe fn finalize(&mut self, static_buffer: Self::StaticInput) -> Self::Output {
+    unsafe fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
         let syscall_spi_device = static_init_half!(
             static_buffer.0,
             VirtualSpiMasterDevice<'static, S>,
@@ -156,7 +156,7 @@ impl<S: 'static + spi::SpiMaster> Component for SpiComponent<S> {
     type StaticInput = &'static mut MaybeUninit<VirtualSpiMasterDevice<'static, S>>;
     type Output = &'static VirtualSpiMasterDevice<'static, S>;
 
-    unsafe fn finalize(&mut self, static_buffer: Self::StaticInput) -> Self::Output {
+    unsafe fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
         let spi_device = static_init_half!(
             static_buffer,
             VirtualSpiMasterDevice<'static, S>,

--- a/boards/imix/src/imix_components/adc.rs
+++ b/boards/imix/src/imix_components/adc.rs
@@ -37,7 +37,7 @@ impl Component for AdcComponent {
     type StaticInput = ();
     type Output = &'static adc::Adc<'static, sam4l::adc::Adc>;
 
-    unsafe fn finalize(&mut self, _s: Self::StaticInput) -> Self::Output {
+    unsafe fn finalize(self, _s: Self::StaticInput) -> Self::Output {
         let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
         let adc_channels = static_init!(
             [&'static sam4l::adc::AdcChannel; 6],

--- a/boards/imix/src/imix_components/analog_comparator.rs
+++ b/boards/imix/src/imix_components/analog_comparator.rs
@@ -32,7 +32,7 @@ impl Component for AcComponent {
     type Output =
         &'static analog_comparator::AnalogComparator<'static, sam4l::acifc::Acifc<'static>>;
 
-    unsafe fn finalize(&mut self, _s: Self::StaticInput) -> Self::Output {
+    unsafe fn finalize(self, _s: Self::StaticInput) -> Self::Output {
         let ac_channels = static_init!(
             [&'static sam4l::acifc::AcChannel; 4],
             [

--- a/boards/imix/src/imix_components/fxos8700.rs
+++ b/boards/imix/src/imix_components/fxos8700.rs
@@ -53,7 +53,7 @@ impl Component for Fxos8700Component {
     type StaticInput = ();
     type Output = &'static fxos8700cq::Fxos8700cq<'static>;
 
-    unsafe fn finalize(&mut self, _s: Self::StaticInput) -> Self::Output {
+    unsafe fn finalize(self, _s: Self::StaticInput) -> Self::Output {
         let fxos8700_i2c = static_init!(I2CDevice, I2CDevice::new(self.i2c_mux, 0x1e));
         let fxos8700 = static_init!(
             fxos8700cq::Fxos8700cq<'static>,
@@ -89,7 +89,7 @@ impl Component for NineDofComponent {
     type StaticInput = ();
     type Output = &'static NineDof<'static>;
 
-    unsafe fn finalize(&mut self, _s: Self::StaticInput) -> Self::Output {
+    unsafe fn finalize(self, _s: Self::StaticInput) -> Self::Output {
         let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
 
         let fxos8700_i2c = static_init!(I2CDevice, I2CDevice::new(self.i2c_mux, 0x1e));

--- a/boards/imix/src/imix_components/nonvolatile_storage.rs
+++ b/boards/imix/src/imix_components/nonvolatile_storage.rs
@@ -39,7 +39,7 @@ impl Component for NonvolatileStorageComponent {
     type StaticInput = ();
     type Output = &'static NonvolatileStorage<'static>;
 
-    unsafe fn finalize(&mut self, _s: Self::StaticInput) -> Self::Output {
+    unsafe fn finalize(self, _s: Self::StaticInput) -> Self::Output {
         let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
 
         sam4l::flashcalw::FLASH_CONTROLLER.configure();

--- a/boards/imix/src/imix_components/radio.rs
+++ b/boards/imix/src/imix_components/radio.rs
@@ -74,7 +74,7 @@ impl Component for RadioComponent {
         &'static capsules::ieee802154::virtual_mac::MuxMac<'static>,
     );
 
-    unsafe fn finalize(&mut self, _s: Self::StaticInput) -> Self::Output {
+    unsafe fn finalize(self, _s: Self::StaticInput) -> Self::Output {
         let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
 
         let aes_ccm = static_init!(

--- a/boards/imix/src/imix_components/rf233.rs
+++ b/boards/imix/src/imix_components/rf233.rs
@@ -54,7 +54,7 @@ impl Component for RF233Component {
     type StaticInput = ();
     type Output = &'static RF233<'static, VirtualSpiMasterDevice<'static, sam4l::spi::SpiHw>>;
 
-    unsafe fn finalize(&mut self, _s: Self::StaticInput) -> Self::Output {
+    unsafe fn finalize(self, _s: Self::StaticInput) -> Self::Output {
         let rf233: &RF233<'static, VirtualSpiMasterDevice<'static, sam4l::spi::SpiHw>> = static_init!(
             RF233<'static, VirtualSpiMasterDevice<'static, sam4l::spi::SpiHw>>,
             RF233::new(self.spi, self.reset, self.sleep, self.irq, self.channel)

--- a/boards/imix/src/imix_components/test/mock_udp.rs
+++ b/boards/imix/src/imix_components/test/mock_udp.rs
@@ -61,7 +61,7 @@ impl Component for MockUDPComponent {
         VirtualMuxAlarm<'static, sam4l::ast::Ast<'static>>,
     >;
 
-    unsafe fn finalize(&mut self, _s: Self::StaticInput) -> Self::Output {
+    unsafe fn finalize(self, _s: Self::StaticInput) -> Self::Output {
         let udp_send = static_init!(
             UDPSendStruct<
                 'static,

--- a/boards/imix/src/imix_components/test/mock_udp2.rs
+++ b/boards/imix/src/imix_components/test/mock_udp2.rs
@@ -64,7 +64,7 @@ impl Component for MockUDPComponent2 {
         VirtualMuxAlarm<'static, sam4l::ast::Ast<'static>>,
     >;
 
-    unsafe fn finalize(&mut self, _s: Self::StaticInput) -> Self::Output {
+    unsafe fn finalize(self, _s: Self::StaticInput) -> Self::Output {
         let udp_send = static_init!(
             UDPSendStruct<
                 'static,

--- a/boards/imix/src/imix_components/udp_driver.rs
+++ b/boards/imix/src/imix_components/udp_driver.rs
@@ -79,7 +79,7 @@ impl Component for UDPDriverComponent {
     type StaticInput = ();
     type Output = &'static capsules::net::udp::UDPDriver<'static>;
 
-    unsafe fn finalize(&mut self, _s: Self::StaticInput) -> Self::Output {
+    unsafe fn finalize(self, _s: Self::StaticInput) -> Self::Output {
         let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
         let udp_send = static_init!(
             UDPSendStruct<

--- a/boards/imix/src/imix_components/udp_mux.rs
+++ b/boards/imix/src/imix_components/udp_mux.rs
@@ -119,7 +119,7 @@ impl Component for UDPMuxComponent {
         &'static UdpPortManager,
     );
 
-    unsafe fn finalize(&mut self, _s: Self::StaticInput) -> Self::Output {
+    unsafe fn finalize(self, _s: Self::StaticInput) -> Self::Output {
         let ipsender_virtual_alarm = static_init!(
             VirtualMuxAlarm<'static, sam4l::ast::Ast>,
             VirtualMuxAlarm::new(self.alarm_mux)

--- a/boards/imix/src/imix_components/usb.rs
+++ b/boards/imix/src/imix_components/usb.rs
@@ -40,7 +40,7 @@ impl Component for UsbComponent {
     type StaticInput = ();
     type Output = &'static UsbDevice;
 
-    unsafe fn finalize(&mut self, _s: Self::StaticInput) -> Self::Output {
+    unsafe fn finalize(self, _s: Self::StaticInput) -> Self::Output {
         let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
 
         // Configure the USB controller

--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -11,7 +11,7 @@ use kernel::component::Component;
 #[allow(unused_imports)]
 use kernel::{debug, debug_gpio, debug_verbose, static_init};
 use nrf52840::gpio::Pin;
-use nrf52dk_base::{SpiPins, UartPins};
+use nrf52dk_base::{SpiPins, UartChannel, UartPins};
 
 // The nRF52840 Dongle LEDs
 const LED1_PIN: Pin = Pin::P0_06;
@@ -129,7 +129,7 @@ pub unsafe fn reset_handler() {
         LED2_G_PIN,
         LED2_B_PIN,
         led,
-        &UartPins::new(UART_RTS, UART_TXD, UART_CTS, UART_RXD),
+        UartChannel::Pins(UartPins::new(UART_RTS, UART_TXD, UART_CTS, UART_RXD)),
         &SpiPins::new(SPI_MOSI, SPI_MISO, SPI_CLK),
         &None,
         button,

--- a/boards/nordic/nrf52840dk/Cargo.toml
+++ b/boards/nordic/nrf52840dk/Cargo.toml
@@ -17,9 +17,6 @@ lto = true
 opt-level = "z"
 debug = true
 
-[features]
-usb_debugging = []
-
 [dependencies]
 components = { path = "../../components" }
 cortexm4 = { path = "../../../arch/cortex-m4" }

--- a/boards/nordic/nrf52840dk/Cargo.toml
+++ b/boards/nordic/nrf52840dk/Cargo.toml
@@ -17,6 +17,9 @@ lto = true
 opt-level = "z"
 debug = true
 
+[features]
+usb_debugging = []
+
 [dependencies]
 components = { path = "../../components" }
 cortexm4 = { path = "../../../arch/cortex-m4" }

--- a/boards/nordic/nrf52840dk/README.md
+++ b/boards/nordic/nrf52840dk/README.md
@@ -54,6 +54,9 @@ is enabled by setting the `USB_DEBUGGING` constant to `true` in the
 [main.rs](src/main.rs) file.
 This disables the UART interface.
 
+For instructions about how to receive RTT messages on the host, see the
+[corresponding capsule](../../capsules/src/segger_rtt.rs).
+
 ## Debugging
 
 See the [nrf52dk README](../nrf52dk/README.md) for information about debugging

--- a/boards/nordic/nrf52840dk/README.md
+++ b/boards/nordic/nrf52840dk/README.md
@@ -39,6 +39,21 @@ $ tockloader listen
 sequence. Notably, you should not
 pass the `--jlink` option to `tockloader listen`.
 
+## Console output
+
+This board supports two methods for writing messages to a console interface
+(console driver for applications as well as debug statements in the kernel).
+
+By default, messages are written to a UART interface over the GPIO pins `P0.05`
+to `P0.08` (see the [main.rs](src/main.rs) file).
+
+If you don't have any UART cables or want to use a different interface, there is
+also a console over the Segger RTT protocol. This only requires a micro-USB
+cable on the USB debugging port (the same used to flash Tock on the board), and
+is enabled by setting the `USB_DEBUGGING` constant to `true` in the
+[main.rs](src/main.rs) file.
+This disables the UART interface.
+
 ## Debugging
 
 See the [nrf52dk README](../nrf52dk/README.md) for information about debugging

--- a/boards/nordic/nrf52840dk/README.md
+++ b/boards/nordic/nrf52840dk/README.md
@@ -55,7 +55,7 @@ is enabled by setting the `USB_DEBUGGING` constant to `true` in the
 This disables the UART interface.
 
 For instructions about how to receive RTT messages on the host, see the
-[corresponding capsule](../../capsules/src/segger_rtt.rs).
+[corresponding capsule](../../../capsules/src/segger_rtt.rs).
 
 ## Debugging
 

--- a/boards/nordic/nrf52840dk/src/io.rs
+++ b/boards/nordic/nrf52840dk/src/io.rs
@@ -1,19 +1,46 @@
 use core::fmt::Write;
 use core::panic::PanicInfo;
 use cortexm4;
+#[cfg(feature = "usb_debugging")]
+use kernel::common::cells::TakeCell;
 use kernel::debug;
 use kernel::debug::IoWrite;
 use kernel::hil::led;
+#[cfg(not(feature = "usb_debugging"))]
 use kernel::hil::uart::{self, Configure};
 use nrf52840::gpio::Pin;
 
 use crate::PROCESSES;
 
 struct Writer {
+    #[cfg(not(feature = "usb_debugging"))]
     initialized: bool,
+    #[cfg(feature = "usb_debugging")]
+    rtt_memory: TakeCell<'static, capsules::segger_rtt::SeggerRttMemory<'static>>,
 }
 
+#[cfg(not(feature = "usb_debugging"))]
 static mut WRITER: Writer = Writer { initialized: false };
+#[cfg(feature = "usb_debugging")]
+static mut WRITER: Writer = Writer {
+    rtt_memory: TakeCell::empty(),
+};
+
+#[cfg(feature = "usb_debugging")]
+fn wait() {
+    let mut x = 0;
+    for i in 0..5000 {
+        unsafe { core::ptr::write_volatile(&mut x as *mut _, i) };
+    }
+}
+
+/// Set the RTT memory buffer used to output panic messages.
+#[cfg(feature = "usb_debugging")]
+pub unsafe fn set_rtt_memory(
+    rtt_memory: &'static mut capsules::segger_rtt::SeggerRttMemory<'static>,
+) {
+    WRITER.rtt_memory.replace(rtt_memory);
+}
 
 impl Write for Writer {
     fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
@@ -23,6 +50,7 @@ impl Write for Writer {
 }
 
 impl IoWrite for Writer {
+    #[cfg(not(feature = "usb_debugging"))]
     fn write(&mut self, buf: &[u8]) {
         let uart = unsafe { &mut nrf52840::uart::UARTE0 };
         if !self.initialized {
@@ -41,6 +69,30 @@ impl IoWrite for Writer {
             }
             while !uart.tx_ready() {}
         }
+    }
+
+    #[cfg(feature = "usb_debugging")]
+    fn write(&mut self, buf: &[u8]) {
+        // TODO: initialize if needed.
+        self.rtt_memory.map(|rtt_memory| {
+            let up_buffer = &mut rtt_memory.up_buffer;
+            let buffer_len = up_buffer.length.get();
+            let buffer = unsafe {
+                core::slice::from_raw_parts_mut(
+                    up_buffer.buffer.get() as *mut u8,
+                    buffer_len as usize,
+                )
+            };
+
+            let mut write_position = up_buffer.write_position.get();
+
+            for &c in buf {
+                buffer[write_position as usize] = c;
+                write_position = (write_position + 1) % buffer_len;
+                up_buffer.write_position.set(write_position);
+                wait();
+            }
+        });
     }
 }
 

--- a/boards/nordic/nrf52840dk/src/io.rs
+++ b/boards/nordic/nrf52840dk/src/io.rs
@@ -19,7 +19,7 @@ static mut WRITER: Writer = Writer::WriterUart(false);
 fn wait() {
     let mut x = 0;
     for i in 0..5000 {
-        unsafe { core::ptr::write_volatile(&mut x as *mut _, i) };
+        cortexm4::support::nop();
     }
 }
 

--- a/boards/nordic/nrf52840dk/src/io.rs
+++ b/boards/nordic/nrf52840dk/src/io.rs
@@ -18,8 +18,7 @@ enum Writer {
 static mut WRITER: Writer = Writer::WriterUart(false);
 
 fn wait() {
-    let mut x = 0;
-    for i in 0..5000 {
+    for _ in 0..100 {
         cortexm4::support::nop();
     }
 }

--- a/boards/nordic/nrf52840dk/src/io.rs
+++ b/boards/nordic/nrf52840dk/src/io.rs
@@ -12,7 +12,7 @@ use crate::PROCESSES;
 
 enum Writer {
     WriterUart(/* initialized */ bool),
-    WriterRtt(&'static mut capsules::segger_rtt::SeggerRttMemory<'static>),
+    WriterRtt(&'static capsules::segger_rtt::SeggerRttMemory<'static>),
 }
 
 static mut WRITER: Writer = Writer::WriterUart(false);
@@ -60,7 +60,7 @@ impl IoWrite for Writer {
                 }
             }
             Writer::WriterRtt(rtt_memory) => {
-                let up_buffer = &mut rtt_memory.up_buffer;
+                let up_buffer = unsafe { &*rtt_memory.get_up_buffer_ptr() };
                 let buffer_len = up_buffer.length.get();
                 let buffer = unsafe {
                     core::slice::from_raw_parts_mut(

--- a/boards/nordic/nrf52840dk/src/io.rs
+++ b/boards/nordic/nrf52840dk/src/io.rs
@@ -1,32 +1,21 @@
 use core::fmt::Write;
 use core::panic::PanicInfo;
 use cortexm4;
-#[cfg(feature = "usb_debugging")]
-use kernel::common::cells::TakeCell;
 use kernel::debug;
 use kernel::debug::IoWrite;
 use kernel::hil::led;
-#[cfg(not(feature = "usb_debugging"))]
 use kernel::hil::uart::{self, Configure};
 use nrf52840::gpio::Pin;
 
 use crate::PROCESSES;
 
-struct Writer {
-    #[cfg(not(feature = "usb_debugging"))]
-    initialized: bool,
-    #[cfg(feature = "usb_debugging")]
-    rtt_memory: TakeCell<'static, capsules::segger_rtt::SeggerRttMemory<'static>>,
+enum Writer {
+    WriterUart(/* initialized */ bool),
+    WriterRtt(&'static mut capsules::segger_rtt::SeggerRttMemory<'static>),
 }
 
-#[cfg(not(feature = "usb_debugging"))]
-static mut WRITER: Writer = Writer { initialized: false };
-#[cfg(feature = "usb_debugging")]
-static mut WRITER: Writer = Writer {
-    rtt_memory: TakeCell::empty(),
-};
+static mut WRITER: Writer = Writer::WriterUart(false);
 
-#[cfg(feature = "usb_debugging")]
 fn wait() {
     let mut x = 0;
     for i in 0..5000 {
@@ -35,11 +24,10 @@ fn wait() {
 }
 
 /// Set the RTT memory buffer used to output panic messages.
-#[cfg(feature = "usb_debugging")]
 pub unsafe fn set_rtt_memory(
     rtt_memory: &'static mut capsules::segger_rtt::SeggerRttMemory<'static>,
 ) {
-    WRITER.rtt_memory.replace(rtt_memory);
+    WRITER = Writer::WriterRtt(rtt_memory);
 }
 
 impl Write for Writer {
@@ -50,49 +38,47 @@ impl Write for Writer {
 }
 
 impl IoWrite for Writer {
-    #[cfg(not(feature = "usb_debugging"))]
     fn write(&mut self, buf: &[u8]) {
-        let uart = unsafe { &mut nrf52840::uart::UARTE0 };
-        if !self.initialized {
-            self.initialized = true;
-            uart.configure(uart::Parameters {
-                baud_rate: 115200,
-                stop_bits: uart::StopBits::One,
-                parity: uart::Parity::None,
-                hw_flow_control: false,
-                width: uart::Width::Eight,
-            });
-        }
-        for &c in buf {
-            unsafe {
-                uart.send_byte(c);
+        match self {
+            Writer::WriterUart(ref mut initialized) => {
+                let uart = unsafe { &mut nrf52840::uart::UARTE0 };
+                if !*initialized {
+                    *initialized = true;
+                    uart.configure(uart::Parameters {
+                        baud_rate: 115200,
+                        stop_bits: uart::StopBits::One,
+                        parity: uart::Parity::None,
+                        hw_flow_control: false,
+                        width: uart::Width::Eight,
+                    });
+                }
+                for &c in buf {
+                    unsafe {
+                        uart.send_byte(c);
+                    }
+                    while !uart.tx_ready() {}
+                }
             }
-            while !uart.tx_ready() {}
-        }
-    }
+            Writer::WriterRtt(rtt_memory) => {
+                let up_buffer = &mut rtt_memory.up_buffer;
+                let buffer_len = up_buffer.length.get();
+                let buffer = unsafe {
+                    core::slice::from_raw_parts_mut(
+                        up_buffer.buffer.get() as *mut u8,
+                        buffer_len as usize,
+                    )
+                };
 
-    #[cfg(feature = "usb_debugging")]
-    fn write(&mut self, buf: &[u8]) {
-        // TODO: initialize if needed.
-        self.rtt_memory.map(|rtt_memory| {
-            let up_buffer = &mut rtt_memory.up_buffer;
-            let buffer_len = up_buffer.length.get();
-            let buffer = unsafe {
-                core::slice::from_raw_parts_mut(
-                    up_buffer.buffer.get() as *mut u8,
-                    buffer_len as usize,
-                )
-            };
+                let mut write_position = up_buffer.write_position.get();
 
-            let mut write_position = up_buffer.write_position.get();
-
-            for &c in buf {
-                buffer[write_position as usize] = c;
-                write_position = (write_position + 1) % buffer_len;
-                up_buffer.write_position.set(write_position);
-                wait();
+                for &c in buf {
+                    buffer[write_position as usize] = c;
+                    write_position = (write_position + 1) % buffer_len;
+                    up_buffer.write_position.set(write_position);
+                    wait();
+                }
             }
-        });
+        };
     }
 }
 

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -132,27 +132,8 @@ pub unsafe fn reset_handler() {
     // Initialize Segger RTT as early as possible so that any panic beyond this point can use the
     // RTT memory object.
     #[cfg(feature = "usb_debugging")]
-    let (up_buffer, down_buffer, rtt_memory) = {
-        let name = b"Terminal\0";
-        let up_buffer_name = name;
-        let down_buffer_name = name;
-        let up_buffer = static_init!([u8; 1024], [0; 1024]);
-        let down_buffer = static_init!([u8; 32], [0; 32]);
-
-        let rtt_memory = static_init!(
-            capsules::segger_rtt::SeggerRttMemory,
-            capsules::segger_rtt::SeggerRttMemory::new_raw(
-                up_buffer_name,
-                up_buffer.as_ptr(),
-                up_buffer.len(),
-                down_buffer_name,
-                down_buffer.as_ptr(),
-                down_buffer.len()
-            )
-        );
-
-        (up_buffer, down_buffer, rtt_memory)
-    };
+    let (rtt_memory, up_buffer, down_buffer) =
+        components::segger_rtt::SeggerRttMemoryComponent::new().finalize(());
 
     // XXX: This is inherently unsafe as it aliases the mutable reference to rtt_memory. This
     // aliases reference is only used inside a panic handler, which should be OK, but maybe we

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -132,14 +132,13 @@ pub unsafe fn reset_handler() {
     // Initialize Segger RTT as early as possible so that any panic beyond this point can use the
     // RTT memory object.
     #[cfg(feature = "usb_debugging")]
-    let (rtt_memory, up_buffer, down_buffer) =
-        components::segger_rtt::SeggerRttMemoryComponent::new().finalize(());
+    let rtt_memory_refs = components::segger_rtt::SeggerRttMemoryComponent::new().finalize(());
 
     // XXX: This is inherently unsafe as it aliases the mutable reference to rtt_memory. This
     // aliases reference is only used inside a panic handler, which should be OK, but maybe we
     // should use a const reference to rtt_memory and leverage interior mutability instead.
     #[cfg(feature = "usb_debugging")]
-    self::io::set_rtt_memory(&mut *(rtt_memory as *mut _));
+    self::io::set_rtt_memory(&mut *rtt_memory_refs.get_rtt_memory_ptr());
 
     let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
     let gpio = components::gpio::GpioComponent::new(board_kernel).finalize(

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -112,7 +112,7 @@ const FAULT_RESPONSE: kernel::procs::FaultResponse = kernel::procs::FaultRespons
 const NUM_PROCS: usize = 8;
 
 #[link_section = ".app_memory"]
-static mut APP_MEMORY: [u8; 0x3A000] = [0; 0x3A000];
+static mut APP_MEMORY: [u8; 0x3C000] = [0; 0x3C000];
 
 static mut PROCESSES: [Option<&'static dyn kernel::procs::ProcessType>; NUM_PROCS] =
     [None, None, None, None, None, None, None, None];

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -68,7 +68,7 @@ use kernel::component::Component;
 #[allow(unused_imports)]
 use kernel::{debug, debug_gpio, debug_verbose, static_init};
 use nrf52832::gpio::Pin;
-use nrf52dk_base::{SpiPins, UartPins};
+use nrf52dk_base::{SpiPins, UartChannel, UartPins};
 
 // The nRF52 DK LEDs (see back of board)
 const LED1_PIN: Pin = Pin::P0_17;
@@ -195,7 +195,7 @@ pub unsafe fn reset_handler() {
         LED2_PIN,
         LED3_PIN,
         led,
-        &UartPins::new(UART_RTS, UART_TXD, UART_CTS, UART_RXD),
+        UartChannel::Pins(UartPins::new(UART_RTS, UART_TXD, UART_CTS, UART_RXD)),
         &SpiPins::new(SPI_MOSI, SPI_MISO, SPI_CLK),
         &None,
         button,

--- a/boards/nordic/nrf52dk_base/src/nrf52_components/ble.rs
+++ b/boards/nordic/nrf52dk_base/src/nrf52_components/ble.rs
@@ -48,7 +48,7 @@ impl Component for BLEComponent {
         VirtualMuxAlarm<'static, Rtc<'static>>,
     >;
 
-    unsafe fn finalize(&mut self, _s: Self::StaticInput) -> Self::Output {
+    unsafe fn finalize(self, _s: Self::StaticInput) -> Self::Output {
         let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
 
         let ble_radio_virtual_alarm = static_init!(

--- a/boards/nordic/nrf52dk_base/src/nrf52_components/ieee802154.rs
+++ b/boards/nordic/nrf52dk_base/src/nrf52_components/ieee802154.rs
@@ -65,7 +65,7 @@ impl Component for Ieee802154Component {
         &'static capsules::ieee802154::virtual_mac::MuxMac<'static>,
     );
 
-    unsafe fn finalize(&mut self, _s: Self::StaticInput) -> Self::Output {
+    unsafe fn finalize(self, _s: Self::StaticInput) -> Self::Output {
         let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
 
         let aes_ccm = static_init!(

--- a/capsules/src/segger_rtt.rs
+++ b/capsules/src/segger_rtt.rs
@@ -112,14 +112,14 @@ pub struct SeggerRttMemory<'a> {
     id: VolatileCell<[u8; 16]>,
     number_up_buffers: VolatileCell<u32>,
     number_down_buffers: VolatileCell<u32>,
-    // marked `pub` to allow access in panic handler
-    pub up_buffer: SeggerRttBuffer<'a>,
+    up_buffer: SeggerRttBuffer<'a>,
     down_buffer: SeggerRttBuffer<'a>,
 }
 
 #[repr(C)]
 pub struct SeggerRttBuffer<'a> {
     name: VolatileCell<*const u8>, // Pointer to the name of this channel. Must be a 4 byte thin pointer.
+    // These fields are marked as `pub` to allow access in the panic handler.
     pub buffer: VolatileCell<*const u8>, // Pointer to the buffer for this channel.
     pub length: VolatileCell<u32>,
     pub write_position: VolatileCell<u32>,
@@ -163,6 +163,13 @@ impl SeggerRttMemory<'a> {
                 _lifetime: PhantomData,
             },
         }
+    }
+
+    /// This getter allows access to the underlying buffer in the panic handler.
+    /// The result is a pointer so that only `unsafe` code can actually dereference it - this is to
+    /// restrict this priviledged access to the panic handler.
+    pub fn get_up_buffer_ptr(&self) -> *const SeggerRttBuffer<'a> {
+        &self.up_buffer
     }
 }
 

--- a/capsules/src/segger_rtt.rs
+++ b/capsules/src/segger_rtt.rs
@@ -138,9 +138,13 @@ impl SeggerRttMemory<'a> {
         down_buffer_len: usize,
     ) -> SeggerRttMemory<'a> {
         SeggerRttMemory {
-            // TODO: only write this ID when the object is fully initialized, to avoid having
-            // these bytes elsewhere in (flash) memory.
-            // Must be "SEGGER RTT".
+            // This field is a magic value that must be set to "SEGGER RTT" for the debugger to
+            // recognize it when scanning the memory.
+            //
+            // In principle, there could be a risk that the value is duplicated elsewhere in
+            // memory, therefore confusing the debugger. However in practice this hasn't caused any
+            // known problem so far. If needed, this ID could be scrambled here, with the real magic
+            // value being written only when this object is fully initialized.
             id: VolatileCell::new(*b"SEGGER RTT\0\0\0\0\0\0"),
             number_up_buffers: VolatileCell::new(1),
             number_down_buffers: VolatileCell::new(1),

--- a/capsules/src/segger_rtt.rs
+++ b/capsules/src/segger_rtt.rs
@@ -98,6 +98,12 @@ use kernel::hil::time::Frequency;
 use kernel::hil::uart;
 use kernel::ReturnCode;
 
+/// Suggested length for the up buffer to pass to the Segger RTT capsule.
+pub const DEFAULT_UP_BUFFER_LENGTH: usize = 1024;
+
+/// Suggested length for the down buffer to pass to the Segger RTT capsule.
+pub const DEFAULT_DOWN_BUFFER_LENGTH: usize = 32;
+
 /// This structure is defined by the segger RTT protocol. It must exist in
 /// memory in exactly this form so that the segger JTAG tool can find it in the
 /// chip's memory and read and write messages to the appropriate buffers.

--- a/capsules/src/segger_rtt.rs
+++ b/capsules/src/segger_rtt.rs
@@ -112,6 +112,7 @@ pub struct SeggerRttMemory<'a> {
     id: VolatileCell<[u8; 16]>,
     number_up_buffers: VolatileCell<u32>,
     number_down_buffers: VolatileCell<u32>,
+    // marked `pub` to allow access in panic handler
     pub up_buffer: SeggerRttBuffer<'a>,
     down_buffer: SeggerRttBuffer<'a>,
 }

--- a/kernel/src/component.rs
+++ b/kernel/src/component.rs
@@ -34,5 +34,5 @@ pub trait Component {
     /// `static_memory` argument to allow the board initialization code to pass
     /// in references to static memory that the component will use to setup the
     /// Output type object.
-    unsafe fn finalize(&mut self, static_memory: Self::StaticInput) -> Self::Output;
+    unsafe fn finalize(self, static_memory: Self::StaticInput) -> Self::Output;
 }


### PR DESCRIPTION
### Pull Request Overview

This pull request:
- Refactors the Segger RTT capsule, to make sure all writes are done via a `VolatileCell`, so that the memory scanner can see them and pull whatever is written there.
- Move the `static mut` buffers out of the capsule. They should be created by the boards instead - which also allows to use them in panic handlers (the fact that `unsafe` is forbidden outside of capsules would otherwise make it quite difficult to share the RTT buffers with the panic handler).
- Adds a `usb_debugging` mode to the `nrf52840dk` board. This is now implemented via a feature, but doesn't affect any other crate. This could potentially be refactored without the feature if needed.


### Testing Strategy

This pull request was tested by flashing a nRF52840-DK board (with and without an additional `default = ["usb_debugging"]` feature in the `Cargo.toml`), running `JLinkExe -device nrf52 -if swd -speed 1000 -autoconnect 1` and `JLinkRTTClient` to observe the debugging output.

In particular, I tested normal writing to the console, as well as kernel panic.


### TODO or Help Wanted

This pull request still needs:
- Moving Segger RTT initialization to a new component?
- Testing on `acd52832`. Note that `acd52832` could also use the new RTT-based panic handler of the `nrf52840dk` - currently it only blinks LEDs and doesn't print the panic message to any sort of console.
- Deciding whether a feature is acceptable in this case (or even necessary).
- Updates to the documentation. For now it's still mostly a proof-of-concept with a few things to cleanup.


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.