### PR TITLE
Fixing GPIO component and missing FloatingState

### DIFF
--- a/boards/acd52832/src/main.rs
+++ b/boards/acd52832/src/main.rs
@@ -189,8 +189,6 @@ pub unsafe fn reset_handler() {
         ]
     );
 
-    // Setup GPIO pins that correspond to buttons
-
     // Make non-volatile memory writable and activate the reset button
     let uicr = nrf52832::uicr::Uicr::new();
     nrf52832::nvmc::NVMC.erase_uicr();

--- a/boards/acd52832/src/main.rs
+++ b/boards/acd52832/src/main.rs
@@ -190,58 +190,6 @@ pub unsafe fn reset_handler() {
     );
 
     // Setup GPIO pins that correspond to buttons
-    let button_pins = static_init!(
-        [(
-            &'static dyn hil::gpio::InterruptValuePin,
-            capsules::button::GpioMode
-        ); 4],
-        [
-            // 13
-            (
-                static_init!(
-                    kernel::hil::gpio::InterruptValueWrapper,
-                    kernel::hil::gpio::InterruptValueWrapper::new(
-                        &nrf52832::gpio::PORT[BUTTON1_PIN]
-                    )
-                )
-                .finalize(),
-                capsules::button::GpioMode::LowWhenPressed
-            ),
-            // 14
-            (
-                static_init!(
-                    kernel::hil::gpio::InterruptValueWrapper,
-                    kernel::hil::gpio::InterruptValueWrapper::new(
-                        &nrf52832::gpio::PORT[BUTTON2_PIN]
-                    )
-                )
-                .finalize(),
-                capsules::button::GpioMode::LowWhenPressed
-            ),
-            // 15
-            (
-                static_init!(
-                    kernel::hil::gpio::InterruptValueWrapper,
-                    kernel::hil::gpio::InterruptValueWrapper::new(
-                        &nrf52832::gpio::PORT[BUTTON3_PIN]
-                    )
-                )
-                .finalize(),
-                capsules::button::GpioMode::LowWhenPressed
-            ),
-            // 16
-            (
-                static_init!(
-                    kernel::hil::gpio::InterruptValueWrapper,
-                    kernel::hil::gpio::InterruptValueWrapper::new(
-                        &nrf52832::gpio::PORT[BUTTON4_PIN]
-                    )
-                )
-                .finalize(),
-                capsules::button::GpioMode::LowWhenPressed
-            ),
-        ]
-    );
 
     // Make non-volatile memory writable and activate the reset button
     let uicr = nrf52832::uicr::Uicr::new();
@@ -284,17 +232,34 @@ pub unsafe fn reset_handler() {
     //
     // Buttons
     //
-    let button = static_init!(
-        capsules::button::Button<'static>,
-        capsules::button::Button::new(
-            button_pins,
-            board_kernel.create_grant(&memory_allocation_capability)
-        )
+    let button = components::button::ButtonComponent::new(board_kernel).finalize(
+        components::button_component_helper!(
+            // 13
+            (
+                &nrf52832::gpio::PORT[BUTTON1_PIN],
+                capsules::button::GpioMode::LowWhenPressed,
+                hil::gpio::FloatingState::PullUp
+            ),
+            // 14
+            (
+                &nrf52832::gpio::PORT[BUTTON2_PIN],
+                capsules::button::GpioMode::LowWhenPressed,
+                hil::gpio::FloatingState::PullUp
+            ),
+            // 15
+            (
+                &nrf52832::gpio::PORT[BUTTON3_PIN],
+                capsules::button::GpioMode::LowWhenPressed,
+                hil::gpio::FloatingState::PullUp
+            ),
+            // 16
+            (
+                &nrf52832::gpio::PORT[BUTTON4_PIN],
+                capsules::button::GpioMode::LowWhenPressed,
+                hil::gpio::FloatingState::PullUp
+            )
+        ),
     );
-    for &(btn, _) in button_pins.iter() {
-        btn.set_floating_state(kernel::hil::gpio::FloatingState::PullUp);
-        btn.set_client(button);
-    }
 
     //
     // RTC for Timers

--- a/boards/arty-e21/src/main.rs
+++ b/boards/arty-e21/src/main.rs
@@ -170,12 +170,10 @@ pub unsafe fn reset_handler() {
 
     // BUTTONs
     let button = components::button::ButtonComponent::new(board_kernel).finalize(
-        components::button_component_helper!(
-            (
-                &arty_e21::gpio::PORT[4],
-                capsules::button::GpioMode::HighWhenPressed
-            )
-        ),
+        components::button_component_helper!((
+            &arty_e21::gpio::PORT[4],
+            capsules::button::GpioMode::HighWhenPressed
+        )),
     );
 
     // set GPIO driver controlling remaining GPIO pins

--- a/boards/arty-e21/src/main.rs
+++ b/boards/arty-e21/src/main.rs
@@ -169,30 +169,14 @@ pub unsafe fn reset_handler() {
     );
 
     // BUTTONs
-    let button_pins = static_init!(
-        [(
-            &'static dyn kernel::hil::gpio::InterruptValuePin,
-            capsules::button::GpioMode
-        ); 1],
-        [(
-            static_init!(
-                kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(&arty_e21::gpio::PORT[4])
+    let button = components::button::ButtonComponent::new(board_kernel).finalize(
+        components::button_component_helper!(
+            (
+                &arty_e21::gpio::PORT[4],
+                capsules::button::GpioMode::HighWhenPressed
             )
-            .finalize(),
-            capsules::button::GpioMode::HighWhenPressed
-        )]
+        ),
     );
-    let button = static_init!(
-        capsules::button::Button<'static>,
-        capsules::button::Button::new(
-            button_pins,
-            board_kernel.create_grant(&memory_allocation_cap)
-        )
-    );
-    for &(btn, _) in button_pins.iter() {
-        btn.set_client(button);
-    }
 
     // set GPIO driver controlling remaining GPIO pins
     let gpio_pins = static_init!(

--- a/boards/arty-e21/src/main.rs
+++ b/boards/arty-e21/src/main.rs
@@ -172,7 +172,8 @@ pub unsafe fn reset_handler() {
     let button = components::button::ButtonComponent::new(board_kernel).finalize(
         components::button_component_helper!((
             &arty_e21::gpio::PORT[4],
-            capsules::button::GpioMode::HighWhenPressed
+            capsules::button::GpioMode::HighWhenPressed,
+            kernel::hil::gpio::FloatingState::PullNone
         )),
     );
 

--- a/boards/components/src/button.rs
+++ b/boards/components/src/button.rs
@@ -11,6 +11,11 @@
 //!     )),
 //! );
 //! ```
+//!
+//! Typically, `GpioMode::LowWhenPressed` will be associated with `FloatingState::PullUp`
+//! whereas `GpioMode::HighWhenPressed` will be paired with `FloatingState::PullDown`.
+//! `FloatingState::None` will be used when the board provides external pull-up/pull-down
+//! resistors.
 
 #![allow(dead_code)] // Components are intended to be conditionally included
 

--- a/boards/components/src/button.rs
+++ b/boards/components/src/button.rs
@@ -7,7 +7,7 @@
 //!     components::button_component_helper!((
 //!         &sam4l::gpio::PC[24],
 //!         capsules::button::GpioMode::LowWhenPressed,
-//!         kernel::hil::gpio::FloatingState::PullDown,
+//!         kernel::hil::gpio::FloatingState::PullUp
 //!     )),
 //! );
 //! ```
@@ -28,33 +28,13 @@ macro_rules! button_component_helper {
         const NUM_BUTTONS: usize = count_expressions!($($P),+);
 
         static_init!(
-            [(&'static dyn kernel::hil::gpio::InterruptValuePin, capsules::button::GpioMode, Option<kernel::hil::gpio::FloatingState>); NUM_BUTTONS],
+            [(&'static dyn kernel::hil::gpio::InterruptValuePin, capsules::button::GpioMode, kernel::hil::gpio::FloatingState); NUM_BUTTONS],
             [
                 $(
                     (static_init!(InterruptValueWrapper, InterruptValueWrapper::new($P))
                     .finalize(),
                     $M,
-                    Some($F)
-                    ),
-                )*
-            ]
-        )
-    };};
-
-    ($(($P:expr, $M:expr)),+ ) => {{
-        use kernel::static_init;
-        use kernel::count_expressions;
-        use kernel::hil::gpio::InterruptValueWrapper;
-        const NUM_BUTTONS: usize = count_expressions!($($P),+);
-
-        static_init!(
-            [(&'static dyn kernel::hil::gpio::InterruptValuePin, capsules::button::GpioMode, Option<kernel::hil::gpio::FloatingState>); NUM_BUTTONS],
-            [
-                $(
-                    (static_init!(InterruptValueWrapper, InterruptValueWrapper::new($P))
-                    .finalize(),
-                    $M,
-                    None
+                    $F
                     ),
                 )*
             ]
@@ -78,7 +58,7 @@ impl Component for ButtonComponent {
     type StaticInput = &'static [(
         &'static dyn kernel::hil::gpio::InterruptValuePin,
         capsules::button::GpioMode,
-        Option<kernel::hil::gpio::FloatingState>,
+        kernel::hil::gpio::FloatingState,
     )];
     type Output = &'static capsules::button::Button<'static>;
 

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -315,7 +315,8 @@ pub unsafe fn reset_handler() {
     let button = components::button::ButtonComponent::new(board_kernel).finalize(
         components::button_component_helper!((
             &sam4l::gpio::PA[16],
-            capsules::button::GpioMode::LowWhenPressed
+            capsules::button::GpioMode::LowWhenPressed,
+            kernel::hil::gpio::FloatingState::PullUp
         )),
     );
 

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -316,7 +316,7 @@ pub unsafe fn reset_handler() {
         components::button_component_helper!((
             &sam4l::gpio::PA[16],
             capsules::button::GpioMode::LowWhenPressed,
-            kernel::hil::gpio::FloatingState::PullUp
+            kernel::hil::gpio::FloatingState::PullNone
         )),
     );
 

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -374,7 +374,8 @@ pub unsafe fn reset_handler() {
     let button = components::button::ButtonComponent::new(board_kernel).finalize(
         components::button_component_helper!((
             &sam4l::gpio::PC[24],
-            capsules::button::GpioMode::LowWhenPressed
+            capsules::button::GpioMode::LowWhenPressed,
+            kernel::hil::gpio::FloatingState::PullUp
         )),
     );
     let crc = CrcComponent::new(board_kernel, &sam4l::crccu::CRCCU)

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -375,7 +375,7 @@ pub unsafe fn reset_handler() {
         components::button_component_helper!((
             &sam4l::gpio::PC[24],
             capsules::button::GpioMode::LowWhenPressed,
-            kernel::hil::gpio::FloatingState::PullUp
+            kernel::hil::gpio::FloatingState::PullNone
         )),
     );
     let crc = CrcComponent::new(board_kernel, &sam4l::crccu::CRCCU)

--- a/boards/launchxl/src/main.rs
+++ b/boards/launchxl/src/main.rs
@@ -207,43 +207,20 @@ pub unsafe fn reset_handler() {
     );
 
     // BUTTONS
-    let button_pins = static_init!(
-        [(
-            &'static dyn gpio::InterruptValuePin,
-            capsules::button::GpioMode
-        ); 2],
-        [
+    let button = components::button::ButtonComponent::new(board_kernel).finalize(
+        components::button_component_helper!(
             (
-                static_init!(
-                    gpio::InterruptValueWrapper,
-                    gpio::InterruptValueWrapper::new(&cc26x2::gpio::PORT[pinmap.button1])
-                )
-                .finalize(),
-                capsules::button::GpioMode::LowWhenPressed
+                &cc26x2::gpio::PORT[pinmap.button1],
+                capsules::button::GpioMode::LowWhenPressed,
+                hil::gpio::FloatingState::PullUp
             ),
             (
-                static_init!(
-                    gpio::InterruptValueWrapper,
-                    gpio::InterruptValueWrapper::new(&cc26x2::gpio::PORT[pinmap.button2])
-                )
-                .finalize(),
-                capsules::button::GpioMode::LowWhenPressed
+                &cc26x2::gpio::PORT[pinmap.button2],
+                capsules::button::GpioMode::LowWhenPressed,
+                hil::gpio::FloatingState::PullUp
             )
-        ]
+        ),
     );
-
-    let button = static_init!(
-        capsules::button::Button<'static>,
-        capsules::button::Button::new(
-            button_pins,
-            board_kernel.create_grant(&memory_allocation_capability)
-        )
-    );
-
-    for (pin, _) in button_pins.iter() {
-        pin.set_client(button);
-        pin.set_floating_state(hil::gpio::FloatingState::PullUp);
-    }
 
     // UART
     cc26x2::uart::UART0.initialize();

--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -96,7 +96,8 @@ pub unsafe fn reset_handler() {
     let button = components::button::ButtonComponent::new(board_kernel).finalize(
         components::button_component_helper!((
             &nrf52840::gpio::PORT[BUTTON_PIN],
-            capsules::button::GpioMode::LowWhenPressed
+            capsules::button::GpioMode::LowWhenPressed,
+            kernel::hil::gpio::FloatingState::PullUp
         )),
     );
 

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -148,19 +148,23 @@ pub unsafe fn reset_handler() {
         components::button_component_helper!(
             (
                 &nrf52840::gpio::PORT[BUTTON1_PIN],
-                capsules::button::GpioMode::LowWhenPressed
+                capsules::button::GpioMode::LowWhenPressed,
+                kernel::hil::gpio::FloatingState::PullUp
             ), //13
             (
                 &nrf52840::gpio::PORT[BUTTON2_PIN],
-                capsules::button::GpioMode::LowWhenPressed
+                capsules::button::GpioMode::LowWhenPressed,
+                kernel::hil::gpio::FloatingState::PullUp
             ), //14
             (
                 &nrf52840::gpio::PORT[BUTTON3_PIN],
-                capsules::button::GpioMode::LowWhenPressed
+                capsules::button::GpioMode::LowWhenPressed,
+                kernel::hil::gpio::FloatingState::PullUp
             ), //15
             (
                 &nrf52840::gpio::PORT[BUTTON4_PIN],
-                capsules::button::GpioMode::LowWhenPressed
+                capsules::button::GpioMode::LowWhenPressed,
+                kernel::hil::gpio::FloatingState::PullUp
             ) //16
         ),
     );

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -149,19 +149,23 @@ pub unsafe fn reset_handler() {
         components::button_component_helper!(
             (
                 &nrf52832::gpio::PORT[BUTTON1_PIN],
-                capsules::button::GpioMode::LowWhenPressed
+                capsules::button::GpioMode::LowWhenPressed,
+                kernel::hil::gpio::FloatingState::PullUp
             ), //13
             (
                 &nrf52832::gpio::PORT[BUTTON2_PIN],
-                capsules::button::GpioMode::LowWhenPressed
+                capsules::button::GpioMode::LowWhenPressed,
+                kernel::hil::gpio::FloatingState::PullUp
             ), //14
             (
                 &nrf52832::gpio::PORT[BUTTON3_PIN],
-                capsules::button::GpioMode::LowWhenPressed
+                capsules::button::GpioMode::LowWhenPressed,
+                kernel::hil::gpio::FloatingState::PullUp
             ), //15
             (
                 &nrf52832::gpio::PORT[BUTTON4_PIN],
-                capsules::button::GpioMode::LowWhenPressed
+                capsules::button::GpioMode::LowWhenPressed,
+                kernel::hil::gpio::FloatingState::PullUp
             ) //16
         ),
     );

--- a/boards/nucleo_f429zi/src/main.rs
+++ b/boards/nucleo_f429zi/src/main.rs
@@ -262,7 +262,8 @@ pub unsafe fn reset_handler() {
     let button = components::button::ButtonComponent::new(board_kernel).finalize(
         components::button_component_helper!((
             stm32f4xx::gpio::PinId::PC13.get_pin().as_ref().unwrap(),
-            capsules::button::GpioMode::LowWhenPressed
+            capsules::button::GpioMode::LowWhenPressed,
+            kernel::hil::gpio::FloatingState::PullNone
         )),
     );
 

--- a/boards/nucleo_f429zi/src/main.rs
+++ b/boards/nucleo_f429zi/src/main.rs
@@ -260,12 +260,10 @@ pub unsafe fn reset_handler() {
 
     // BUTTONs
     let button = components::button::ButtonComponent::new(board_kernel).finalize(
-        components::button_component_helper!(
-            (
-                stm32f4xx::gpio::PinId::PC13.get_pin().as_ref().unwrap(),
-                capsules::button::GpioMode::LowWhenPressed
-            )
-        ),
+        components::button_component_helper!((
+            stm32f4xx::gpio::PinId::PC13.get_pin().as_ref().unwrap(),
+            capsules::button::GpioMode::LowWhenPressed
+        )),
     );
 
     // ALARM

--- a/boards/nucleo_f429zi/src/main.rs
+++ b/boards/nucleo_f429zi/src/main.rs
@@ -43,7 +43,6 @@ static APP_HACK: u8 = 0;
 #[link_section = ".stack_buffer"]
 pub static mut STACK_MEMORY: [u8; 0x1000] = [0; 0x1000];
 
-const NUM_BUTTONS: usize = 1;
 const NUM_LEDS: usize = 1;
 
 /// A structure representing this platform that holds references to all
@@ -260,34 +259,14 @@ pub unsafe fn reset_handler() {
     );
 
     // BUTTONs
-    let button_pins = static_init!(
-        [(
-            &'static dyn kernel::hil::gpio::InterruptValuePin,
-            capsules::button::GpioMode
-        ); NUM_BUTTONS],
-        [(
-            static_init!(
-                kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(
-                    stm32f4xx::gpio::PinId::PC13.get_pin().as_ref().unwrap()
-                )
+    let button = components::button::ButtonComponent::new(board_kernel).finalize(
+        components::button_component_helper!(
+            (
+                stm32f4xx::gpio::PinId::PC13.get_pin().as_ref().unwrap(),
+                capsules::button::GpioMode::LowWhenPressed
             )
-            .finalize(),
-            capsules::button::GpioMode::LowWhenPressed
-        ),]
+        ),
     );
-
-    let button = static_init!(
-        capsules::button::Button<'static>,
-        capsules::button::Button::new(
-            button_pins,
-            board_kernel.create_grant(&memory_allocation_capability)
-        )
-    );
-
-    for (pin, _) in button_pins.iter() {
-        pin.set_client(button);
-    }
 
     // ALARM
 

--- a/boards/nucleo_f446re/src/main.rs
+++ b/boards/nucleo_f446re/src/main.rs
@@ -48,8 +48,6 @@ static APP_HACK: u8 = 0;
 #[link_section = ".stack_buffer"]
 pub static mut STACK_MEMORY: [u8; 0x1000] = [0; 0x1000];
 
-const NUM_BUTTONS: usize = 1;
-
 /// A structure representing this platform that holds references to all
 /// capsules for this platform.
 struct NucleoF446RE {
@@ -262,34 +260,14 @@ pub unsafe fn reset_handler() {
     );
 
     // BUTTONs
-    let button_pins = static_init!(
-        [(
-            &'static dyn kernel::hil::gpio::InterruptValuePin,
-            capsules::button::GpioMode
-        ); NUM_BUTTONS],
-        [(
-            static_init!(
-                kernel::hil::gpio::InterruptValueWrapper,
-                kernel::hil::gpio::InterruptValueWrapper::new(
-                    stm32f4xx::gpio::PinId::PC13.get_pin().as_ref().unwrap()
-                )
+    let button = components::button::ButtonComponent::new(board_kernel).finalize(
+        components::button_component_helper!(
+            (
+                stm32f4xx::gpio::PinId::PC13.get_pin().as_ref().unwrap(),
+                capsules::button::GpioMode::LowWhenPressed
             )
-            .finalize(),
-            capsules::button::GpioMode::LowWhenPressed
-        ),]
+        ),
     );
-
-    let button = static_init!(
-        capsules::button::Button<'static>,
-        capsules::button::Button::new(
-            button_pins,
-            board_kernel.create_grant(&memory_allocation_capability)
-        )
-    );
-
-    for (pin, _) in button_pins.iter() {
-        pin.set_client(button);
-    }
 
     // ALARM
     let mux_alarm = static_init!(

--- a/boards/nucleo_f446re/src/main.rs
+++ b/boards/nucleo_f446re/src/main.rs
@@ -263,7 +263,8 @@ pub unsafe fn reset_handler() {
     let button = components::button::ButtonComponent::new(board_kernel).finalize(
         components::button_component_helper!((
             stm32f4xx::gpio::PinId::PC13.get_pin().as_ref().unwrap(),
-            capsules::button::GpioMode::LowWhenPressed
+            capsules::button::GpioMode::LowWhenPressed,
+            kernel::hil::gpio::FloatingState::PullNone
         )),
     );
 

--- a/boards/nucleo_f446re/src/main.rs
+++ b/boards/nucleo_f446re/src/main.rs
@@ -261,12 +261,10 @@ pub unsafe fn reset_handler() {
 
     // BUTTONs
     let button = components::button::ButtonComponent::new(board_kernel).finalize(
-        components::button_component_helper!(
-            (
-                stm32f4xx::gpio::PinId::PC13.get_pin().as_ref().unwrap(),
-                capsules::button::GpioMode::LowWhenPressed
-            )
-        ),
+        components::button_component_helper!((
+            stm32f4xx::gpio::PinId::PC13.get_pin().as_ref().unwrap(),
+            capsules::button::GpioMode::LowWhenPressed
+        )),
     );
 
     // ALARM

--- a/capsules/src/button.rs
+++ b/capsules/src/button.rs
@@ -84,7 +84,7 @@ pub struct Button<'a> {
     pins: &'a [(
         &'a dyn gpio::InterruptValuePin,
         GpioMode,
-        Option<gpio::FloatingState>,
+        gpio::FloatingState,
     )],
     apps: Grant<(Option<Callback>, SubscribeMap)>,
 }
@@ -94,16 +94,14 @@ impl<'a> Button<'a> {
         pins: &'a [(
             &'a dyn gpio::InterruptValuePin,
             GpioMode,
-            Option<gpio::FloatingState>,
+            gpio::FloatingState,
         )],
         grant: Grant<(Option<Callback>, SubscribeMap)>,
     ) -> Button<'a> {
         for (i, &(pin, _, floating_state)) in pins.iter().enumerate() {
             pin.make_input();
             pin.set_value(i as u32);
-            if let Some(state) = floating_state {
-                pin.set_floating_state(state);
-            }
+            pin.set_floating_state(floating_state);
         }
 
         Button {

--- a/kernel/src/hil/gpio.rs
+++ b/kernel/src/hil/gpio.rs
@@ -4,7 +4,7 @@ use crate::ReturnCode;
 use core::cell::Cell;
 
 /// Enum for configuring any pull-up or pull-down resistors on the GPIO pin.
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub enum FloatingState {
     PullUp,
     PullDown,


### PR DESCRIPTION
### Pull Request Overview

By not setting the FloatingState on the underlying GPIOs for a button, GPIOs become sensitive to static charges, causing instability on their state.
Also the way the GPIO HIL was implemented on the Nordic chips was overwriting the direction of the GPIO, it's driving mode, etc.
Finally the `deactivate_to_low_power` method on the HIL was implemented for Nordic chip.

This fixes issue #1557 and at the same time all the supported boards now
are using the component for Buttons.


### Testing Strategy

Tested on the nRF52840 dongle using the example `button_leds`


### TODO or Help Wanted

Test other boards.


### Documentation Updated

- no updates are required.

### Formatting

- [x] Ran `make formatall`.
