### PR TITLE
Revert "kernel: common: use built in AtomicUsize"

### DIFF
--- a/kernel/src/common/deferred_call.rs
+++ b/kernel/src/common/deferred_call.rs
@@ -4,18 +4,51 @@
 //! in the chip scheduler if the hardware doesn't support interrupts where
 //! they are needed.
 
+use core::cell::UnsafeCell;
 use core::convert::Into;
 use core::convert::TryFrom;
 use core::convert::TryInto;
+use core::intrinsics;
 use core::marker::Copy;
-use core::sync::atomic::AtomicUsize;
-use core::sync::atomic::Ordering;
+use core::marker::Sync;
+
+/// AtomicUsize with no CAS operations that works on targets that have "no atomic
+/// support" according to their specification. This makes it work on thumbv6
+/// platforms.
+///
+/// Borrowed from https://github.com/japaric/heapless/blob/master/src/ring_buffer/mod.rs
+/// See: https://github.com/japaric/heapless/commit/37c8b5b63780ed8811173dc1ec8859cd99efa9ad
+struct AtomicUsize {
+    v: UnsafeCell<usize>,
+}
+
+impl AtomicUsize {
+    crate const fn new(v: usize) -> AtomicUsize {
+        AtomicUsize {
+            v: UnsafeCell::new(v),
+        }
+    }
+
+    crate fn load_relaxed(&self) -> usize {
+        unsafe { intrinsics::atomic_load_relaxed(self.v.get()) }
+    }
+
+    crate fn store_relaxed(&self, val: usize) {
+        unsafe { intrinsics::atomic_store_relaxed(self.v.get(), val) }
+    }
+
+    crate fn fetch_or_relaxed(&self, val: usize) {
+        unsafe { intrinsics::atomic_store_relaxed(self.v.get(), self.load_relaxed() | val) }
+    }
+}
+
+unsafe impl Sync for AtomicUsize {}
 
 static DEFERRED_CALL: AtomicUsize = AtomicUsize::new(0);
 
 /// Are there any pending `DeferredCall`s?
 pub fn has_tasks() -> bool {
-    DEFERRED_CALL.load(Ordering::Relaxed) != 0
+    DEFERRED_CALL.load_relaxed() != 0
 }
 
 /// Represents a way to generate an asynchronous call without a hardware
@@ -33,21 +66,18 @@ impl<T: Into<usize> + TryFrom<usize> + Copy> DeferredCall<T> {
 
     /// Set the `DeferredCall` as pending
     pub fn set(&self) {
-        // DEFERRED_CALL.fetch_or(1 << self.0.into() as usize, Ordering::Relaxed);
-        let val = DEFERRED_CALL.load(Ordering::Relaxed);
-        let new_val = val | (1 << self.0.into());
-        DEFERRED_CALL.store(new_val, Ordering::Relaxed);
+        DEFERRED_CALL.fetch_or_relaxed(1 << self.0.into() as usize);
     }
 
     /// Gets and clears the next pending `DeferredCall`
     pub fn next_pending() -> Option<T> {
-        let val = DEFERRED_CALL.load(Ordering::Relaxed);
+        let val = DEFERRED_CALL.load_relaxed();
         if val == 0 {
             None
         } else {
             let bit = val.trailing_zeros() as usize;
             let new_val = val & !(1 << bit);
-            DEFERRED_CALL.store(new_val, Ordering::Relaxed);
+            DEFERRED_CALL.store_relaxed(new_val);
             bit.try_into().ok()
         }
     }


### PR DESCRIPTION
### Pull Request Overview

This reverts commit 7f20daa74edcc45c57139e0b4485bfb49c49b3c8.

There are RISC-V platforms that don't support atomics (such as
OpenTitan) so let's revert this commit until RV32 has atomic load and
store support when the Atomic (A) extension isn't supported. That is
wait until something like this for RISC-V is merged:
https://github.com/rust-lang/rust/pull/51953

### Testing Strategy

Building OpenTitan


### TODO or Help Wanted

N/A


### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make formatall`.
