### PR TITLE
Add make audit command based on Cargo audit.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,10 @@ ci-netlify:
 .PHONY: ci
 ci: ci-travis ci-netlify
 
+.PHONY: audit
+audit:
+	@for f in `./tools/list_lock.sh`; do echo "$$(tput bold)Auditing $$f"; (cd "$$f" && cargo audit || exit 1); done
+
 .PHONY: clean
 clean:
 	@for f in `./tools/list_archs.sh`; do echo "$$(tput bold)Clean arch/$$f"; cd "arch/$$f" && cargo clean || exit 1; cd ../..; done

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ usage:
 	@echo "  allboards: Compiles Tock for all supported boards"
 	@echo "   allcheck: Checks, but does not compile, Tock for all supported boards"
 	@echo "     alldoc: Builds Tock documentation for all boards"
+	@echo "      audit: Audit Cargo dependencies for all kernel sources"
 	@echo "         ci: Run all continuous integration tests"
 	@echo "      clean: Clean all builds"
 	@echo "     format: Runs the rustfmt tool on all kernel sources"

--- a/tools/list_lock.sh
+++ b/tools/list_lock.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# Find crates based on folders with Cargo.lock files
+for b in $(find . -maxdepth 4 | egrep 'Cargo.lock$'); do
+    b2=${b%/*}
+    echo $b2
+done


### PR DESCRIPTION
### Pull Request Overview

This pull request adds an `audit` command to the Makefile, using [Cargo audit](https://github.com/RustSec/cargo-audit).

The goal is to look for known vulnerabilities (according to [RustSec Advisory Database](https://github.com/RustSec/advisory-db/)) in dependencies.

Because Tock has a policy of limiting the number of external dependencies, this didn't find any such vulnerability, but making it easy to do from time to time would be nice. However, `cargo audit` itself has many dependencies, so I don't think we need to integrate it on CI or force developers to install it at this point.


### Testing Strategy

This pull request was tested by running `make audit` and checking that no known vulnerability was reported.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.