### PR TITLE
arch/rv32i: Implement proper atomic helper

### DIFF
--- a/arch/rv32i/src/support.rs
+++ b/arch/rv32i/src/support.rs
@@ -1,5 +1,6 @@
 //! Core low-level operations.
 
+use crate::csr::{mstatus::mstatus, CSR};
 use core::ops::FnOnce;
 
 #[cfg(all(target_arch = "riscv32", target_os = "none"))]
@@ -18,12 +19,21 @@ pub unsafe fn wfi() {
     asm!("wfi" :::: "volatile");
 }
 
-/// TODO: implement
 pub unsafe fn atomic<F, R>(f: F) -> R
 where
     F: FnOnce() -> R,
 {
-    f()
+    let original_mstatus = CSR.mstatus.extract();
+    if original_mstatus.is_set(mstatus::mie) {
+        CSR.mstatus
+            .modify_no_read(original_mstatus, mstatus::mie::CLEAR);
+    }
+    let res = f();
+    if original_mstatus.is_set(mstatus::mie) {
+        CSR.mstatus
+            .modify_no_read(original_mstatus, mstatus::mie::SET);
+    }
+    res
 }
 
 #[cfg(all(target_arch = "riscv32", target_os = "none"))]


### PR DESCRIPTION
### Pull Request Overview

This PR provides a working `atomic` helper mechanism for the rv32i architecture.  By toggling `mie` in the `mstatus` CSR, it fulfills the contract stated in the `Chip` trait "... that an interrupt will not fire during the passed in function's execution"

### Testing Strategy

All of our recent testing on the OpenTitan device has been with a branch including this change.

### TODO or Help Wanted

n/a

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
