### PR TITLE
kernel: Add trait for process restart policies

### DIFF
--- a/capsules/src/process_console.rs
+++ b/capsules/src/process_console.rs
@@ -236,7 +236,7 @@ impl<'a, C: ProcessManagementCapability> ProcessConsole<'a, C> {
                                         proc.debug_timeslice_expiration_count(),
                                         proc.debug_syscall_count(),
                                         proc.debug_dropped_callback_count(),
-                                        proc.debug_restart_count(),
+                                        proc.get_restart_count(),
                                         proc.get_state()
                                     );
                                 });

--- a/kernel/src/introspection.rs
+++ b/kernel/src/introspection.rs
@@ -111,7 +111,7 @@ impl KernelInfo {
         _capability: &dyn ProcessManagementCapability,
     ) -> usize {
         self.kernel
-            .process_map_or(0, app.idx(), |process| process.debug_restart_count())
+            .process_map_or(0, app.idx(), |process| process.get_restart_count())
     }
 
     /// Returns the number of time this app has exceeded its timeslice.

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -51,7 +51,7 @@ pub use crate::sched::Kernel;
 /// Publicly available process-related objects.
 pub mod procs {
     pub use crate::process::{
-        load_processes, Error, FaultResponse, FunctionCall, Process, ProcessRestartPolicy,
-        ProcessType, PrpAlways, PrpThreshold,
+        load_processes, AlwaysRestart, Error, FaultResponse, FunctionCall, Process,
+        ProcessRestartPolicy, ProcessType, ThresholdRestart,
     };
 }

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -51,6 +51,7 @@ pub use crate::sched::Kernel;
 /// Publicly available process-related objects.
 pub mod procs {
     pub use crate::process::{
-        load_processes, Error, FaultResponse, FunctionCall, Process, ProcessType,
+        load_processes, Error, FaultResponse, FunctionCall, Process, ProcessRestartPolicy,
+        ProcessType, PrpAlways, PrpThreshold,
     };
 }


### PR DESCRIPTION
If a process's fault response is set to "Restart", then currently that process is unconditionally restarted if it crashes. This PR adds a trait so that boards can specify the policy the kernel should use when deciding whether to restart an app or not. There is an Always option to match what we have now, and I also implemented a very simple threshold approach where an app will only be restarted a certain number of times.

This is part of #1082.


### Testing Strategy

I tested this earlier, but need to test with the recent PR merges.


### TODO or Help Wanted

Thoughts?


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
