### PR TITLE
kernel: Add an "identifier" to AppId

### DIFF
--- a/capsules/src/ble_advertising_driver.rs
+++ b/capsules/src/ble_advertising_driver.rs
@@ -222,10 +222,10 @@ impl App {
     fn generate_random_address(&mut self, appid: kernel::AppId) -> ReturnCode {
         self.address = [
             0xf0,
-            (appid.idx() & 0xff) as u8,
-            ((appid.idx() << 8) & 0xff) as u8,
-            ((appid.idx() << 16) & 0xff) as u8,
-            ((appid.idx() << 24) & 0xff) as u8,
+            (appid.id() & 0xff) as u8,
+            ((appid.id() << 8) & 0xff) as u8,
+            ((appid.id() << 16) & 0xff) as u8,
+            ((appid.id() << 24) & 0xff) as u8,
             0xf0,
         ];
         ReturnCode::SUCCESS

--- a/capsules/src/low_level_debug/mod.rs
+++ b/capsules/src/low_level_debug/mod.rs
@@ -72,7 +72,7 @@ impl<'u, U: Transmit<'u>> TransmitClient for LowLevelDebug<'u, U> {
             let (app_num, first_entry) = applied_grant.enter(|owned_app_data, _| {
                 owned_app_data.queue.rotate_left(1);
                 (
-                    owned_app_data.appid().idx(),
+                    owned_app_data.appid().id(),
                     owned_app_data.queue[QUEUE_SIZE - 1].take(),
                 )
             });
@@ -98,7 +98,7 @@ impl<'u, U: Transmit<'u>> LowLevelDebug<'u, U> {
         use DebugEntry::Dropped;
 
         if let Some(buffer) = self.buffer.take() {
-            self.transmit_entry(buffer, appid.idx(), entry);
+            self.transmit_entry(buffer, appid.id(), entry);
             return;
         }
 

--- a/kernel/src/callback.rs
+++ b/kernel/src/callback.rs
@@ -46,7 +46,7 @@ impl AppId {
     /// any padding at the end of the app. It does not include the TBF header,
     /// or any space that the kernel is using for any potential bookkeeping.
     pub fn get_editable_flash_range(&self) -> (usize, usize) {
-        self.kernel.process_map_or((0, 0), self.idx, |process| {
+        self.kernel.process_map_or((0, 0), *self, |process| {
             let start = process.flash_non_protected_start() as usize;
             let end = process.flash_end() as usize;
             (start, end)
@@ -101,7 +101,7 @@ impl Callback {
         let res = self
             .app_id
             .kernel
-            .process_map_or(false, self.app_id.idx(), |process| {
+            .process_map_or(false, self.app_id, |process| {
                 process.enqueue_task(process::Task::FunctionCall(process::FunctionCall {
                     source: process::FunctionCallSource::Driver(self.callback_id),
                     argument0: r0,

--- a/kernel/src/callback.rs
+++ b/kernel/src/callback.rs
@@ -94,7 +94,7 @@ impl AppId {
     /// match then `None` will be returned.
     crate fn index(&self) -> Option<usize> {
         // Do a lookup to make sure that the index we have is correct.
-        if self.kernel.appid_is_valid(*self) {
+        if self.kernel.appid_is_valid(self) {
             Some(self.index)
         } else {
             None

--- a/kernel/src/callback.rs
+++ b/kernel/src/callback.rs
@@ -37,8 +37,8 @@ impl AppId {
         }
     }
 
-    pub fn idx(&self) -> usize {
-        self.idx
+    pub fn idx(&self) -> Option<usize> {
+        Some(self.idx)
     }
 
     /// Returns the full address of the start and end of the flash region that

--- a/kernel/src/callback.rs
+++ b/kernel/src/callback.rs
@@ -94,15 +94,11 @@ impl AppId {
     /// match then `None` will be returned.
     crate fn index(&self) -> Option<usize> {
         // Do a lookup to make sure that the index we have is correct.
-        self.kernel
-            .lookup_app_by_index(self.index)
-            .map_or(None, |appid| {
-                if appid.identifier == self.identifier {
-                    Some(self.index)
-                } else {
-                    None
-                }
-            })
+        if self.kernel.appid_is_valid(*self) {
+            Some(self.index)
+        } else {
+            None
+        }
     }
 
     /// Get a `usize` unique identifier for the app this `AppId` refers to.

--- a/kernel/src/callback.rs
+++ b/kernel/src/callback.rs
@@ -59,7 +59,16 @@ impl AppId {
     /// matches the app saved at the known index. If the identifier does not
     /// match then `None` will be returned.
     crate fn index(&self) -> Option<usize> {
-        Some(self.index)
+        // Do a lookup to make sure that the index we have is correct.
+        self.kernel
+            .lookup_app_identifier(self.index)
+            .map_or(None, |id| {
+                if id == self.identifier {
+                    Some(self.index)
+                } else {
+                    None
+                }
+            })
     }
 
     /// Get a `usize` unique identifier for the app this `AppId` refers to.

--- a/kernel/src/callback.rs
+++ b/kernel/src/callback.rs
@@ -66,7 +66,7 @@ pub struct AppId {
 
 impl PartialEq for AppId {
     fn eq(&self, other: &AppId) -> bool {
-        self.index == other.index && self.identifier == other.identifier
+        self.identifier == other.identifier
     }
 }
 

--- a/kernel/src/introspection.rs
+++ b/kernel/src/introspection.rs
@@ -78,7 +78,7 @@ impl KernelInfo {
         _capability: &dyn ProcessManagementCapability,
     ) -> &'static str {
         self.kernel
-            .process_map_or("unknown", app.idx(), |process| process.get_process_name())
+            .process_map_or("unknown", app, |process| process.get_process_name())
     }
 
     /// Returns the number of syscalls the app has called.
@@ -88,7 +88,7 @@ impl KernelInfo {
         _capability: &dyn ProcessManagementCapability,
     ) -> usize {
         self.kernel
-            .process_map_or(0, app.idx(), |process| process.debug_syscall_count())
+            .process_map_or(0, app, |process| process.debug_syscall_count())
     }
 
     /// Returns the number of dropped callbacks the app has experience.
@@ -99,9 +99,8 @@ impl KernelInfo {
         app: AppId,
         _capability: &dyn ProcessManagementCapability,
     ) -> usize {
-        self.kernel.process_map_or(0, app.idx(), |process| {
-            process.debug_dropped_callback_count()
-        })
+        self.kernel
+            .process_map_or(0, app, |process| process.debug_dropped_callback_count())
     }
 
     /// Returns the number of time this app has been restarted.
@@ -111,7 +110,7 @@ impl KernelInfo {
         _capability: &dyn ProcessManagementCapability,
     ) -> usize {
         self.kernel
-            .process_map_or(0, app.idx(), |process| process.get_restart_count())
+            .process_map_or(0, app, |process| process.get_restart_count())
     }
 
     /// Returns the number of time this app has exceeded its timeslice.
@@ -120,9 +119,8 @@ impl KernelInfo {
         app: AppId,
         _capability: &dyn ProcessManagementCapability,
     ) -> usize {
-        self.kernel.process_map_or(0, app.idx(), |process| {
-            process.debug_timeslice_expiration_count()
-        })
+        self.kernel
+            .process_map_or(0, app, |process| process.debug_timeslice_expiration_count())
     }
 
     /// Returns the total number of times all processes have exceeded

--- a/kernel/src/ipc.rs
+++ b/kernel/src/ipc.rs
@@ -151,15 +151,17 @@ impl Driver for IPC {
             process::IPCType::Client
         };
 
-        self.data
-            .kernel
-            .process_map_or(ReturnCode::EINVAL, target_id - 1, |target| {
+        self.data.kernel.process_map_or(
+            ReturnCode::EINVAL,
+            AppId::new(self.data.kernel, target_id - 1),
+            |target| {
                 let ret = target.enqueue_task(process::Task::IPC((appid, cb_type)));
                 match ret {
                     true => ReturnCode::SUCCESS,
                     false => ReturnCode::FAIL,
                 }
-            })
+            },
+        )
     }
 
     /// allow enables processes to discover IPC services on the platform or

--- a/kernel/src/mem.rs
+++ b/kernel/src/mem.rs
@@ -51,7 +51,7 @@ impl<L, T> Drop for AppPtr<L, T> {
     fn drop(&mut self) {
         self.process
             .kernel
-            .process_map_or((), self.process.idx(), |process| unsafe {
+            .process_map_or((), self.process, |process| unsafe {
                 process.free(self.ptr.as_ptr() as *mut u8)
             })
     }
@@ -89,11 +89,11 @@ impl<L, T> AppSlice<L, T> {
     /// Provide access to one app's AppSlice to another app. This is used for
     /// IPC.
     crate unsafe fn expose_to(&self, appid: AppId) -> bool {
-        if appid.idx() != self.ptr.process.idx() {
+        if appid != self.ptr.process {
             self.ptr
                 .process
                 .kernel
-                .process_map_or(false, appid.idx(), |process| {
+                .process_map_or(false, appid, |process| {
                     process
                         .add_mpu_region(self.ptr() as *const u8, self.len(), self.len())
                         .is_some()

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -470,10 +470,9 @@ struct ProcessDebug {
 }
 
 pub struct Process<'a, C: 'static + Chip> {
-    /// Index of the process in the process table.
-    ///
-    /// Corresponds to AppId
-    app_idx: usize,
+    /// Identifier of this process and the index of the process in the process
+    /// table.
+    app_id: AppId,
 
     /// Pointer to the main Kernel struct.
     kernel: &'static Kernel,
@@ -573,7 +572,7 @@ pub struct Process<'a, C: 'static + Chip> {
 
 impl<C: Chip> ProcessType for Process<'a, C> {
     fn appid(&self) -> AppId {
-        AppId::new(self.kernel, self.app_idx)
+        self.app_id
     }
 
     fn enqueue_task(&self, task: Task) -> bool {
@@ -613,8 +612,8 @@ impl<C: Chip> ProcessType for Process<'a, C> {
             if config::CONFIG.trace_syscalls {
                 let count_after = tasks.len();
                 debug!(
-                    "[{}] remove_pending_callbacks[{:#x}:{}] = {} callback(s) removed",
-                    self.app_idx,
+                    "[{:?}] remove_pending_callbacks[{:#x}:{}] = {} callback(s) removed",
+                    self.app_id,
                     callback_id.driver_num,
                     callback_id.subscribe_num,
                     count_before - count_after,
@@ -1433,7 +1432,7 @@ impl<C: 'static + Chip> Process<'a, C> {
             let mut process: &mut Process<C> =
                 &mut *(process_struct_memory_location as *mut Process<'static, C>);
 
-            process.app_idx = index;
+            process.app_id = AppId::new(kernel, index, index);
             process.kernel = kernel;
             process.chip = chip;
             process.memory = app_memory;

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -11,6 +11,7 @@ use crate::common::cells::{MapCell, NumericCellExt};
 use crate::common::{Queue, RingBuffer};
 use crate::config;
 use crate::debug;
+use crate::ipc;
 use crate::mem::{AppSlice, Shared};
 use crate::platform::mpu::{self, MPU};
 use crate::platform::Chip;
@@ -402,16 +403,10 @@ pub enum FaultResponse {
     Stop,
 }
 
-#[derive(Copy, Clone, Debug)]
-pub enum IPCType {
-    Service,
-    Client,
-}
-
 #[derive(Copy, Clone)]
 pub enum Task {
     FunctionCall(FunctionCall),
-    IPC((AppId, IPCType)),
+    IPC((AppId, ipc::IPCCallbackType)),
 }
 
 /// Enumeration to identify whether a function call comes directly from the

--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -198,6 +198,16 @@ impl Kernel {
         })
     }
 
+    /// Retrieve the app identifier for the process at the given index in the
+    /// processes array.
+    ///
+    /// If the process at that index does not exist return `None`.
+    crate fn lookup_app_identifier(&self, index: usize) -> Option<usize> {
+        self.processes.get(index).map_or(None, |p| {
+            p.map_or(None, |process| Some(process.appid().id()))
+        })
+    }
+
     /// Create a new grant. This is used in board initialization to setup grants
     /// that capsules use to interact with processes.
     ///

--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -198,7 +198,7 @@ impl Kernel {
     ///
     /// This is needed for `AppId` itself to implement the `.index()` command to
     /// verify that the referenced app is still at the correct index.
-    crate fn appid_is_valid(&self, appid: AppId) -> bool {
+    crate fn appid_is_valid(&self, appid: &AppId) -> bool {
         self.processes.get(appid.index).map_or(false, |p| {
             p.map_or(false, |process| process.appid().id() == appid.id())
         })

--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -3,7 +3,7 @@
 use core::cell::Cell;
 use core::ptr::NonNull;
 
-use crate::callback::{Callback, CallbackId};
+use crate::callback::{AppId, Callback, CallbackId};
 use crate::capabilities;
 use crate::common::cells::NumericCellExt;
 use crate::common::dynamic_deferred_call::DynamicDeferredCall;
@@ -73,14 +73,14 @@ impl Kernel {
     /// not exist (i.e. it is `None` in the `processes` array) then `default`
     /// will be returned. Otherwise the closure will executed and passed a
     /// reference to the process.
-    crate fn process_map_or<F, R>(&self, default: R, process_index: usize, closure: F) -> R
+    crate fn process_map_or<F, R>(&self, default: R, appid: AppId, closure: F) -> R
     where
         F: FnOnce(&dyn process::ProcessType) -> R,
     {
-        if process_index > self.processes.len() {
+        if appid.idx() > self.processes.len() {
             return default;
         }
-        self.processes[process_index].map_or(default, |process| closure(process))
+        self.processes[appid.idx()].map_or(default, |process| closure(process))
     }
 
     /// Run a closure on every valid process. This will iterate the array of

--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -69,10 +69,16 @@ impl Kernel {
         self.work.get() == 0
     }
 
-    /// Run a closure on a specific process if it exists. If the process does
-    /// not exist (i.e. it is `None` in the `processes` array, or has stopped,
-    /// restarted, or been removed) then `default` will be returned. Otherwise
-    /// the closure will executed and passed a reference to the process.
+    /// Run a closure on a specific process if it exists. If the process with a
+    /// matching `AppId` does not exist at the index specified within the
+    /// `AppId`, then `default` will be returned.
+    ///
+    /// A match will not be found if the process was removed (and there is a
+    /// `None` in the process array), if the process changed its identifier
+    /// (likely after being restarted), or if the process was moved to a
+    /// different index in the processes array. Note that a match _will_ be
+    /// found if the process still exists in the correct location in the array
+    /// but is in any "stopped" state.
     crate fn process_map_or<F, R>(&self, default: R, appid: AppId, closure: F) -> R
     where
         F: FnOnce(&dyn process::ProcessType) -> R,

--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -192,16 +192,15 @@ impl Kernel {
         })
     }
 
-    /// Retrieve the `AppId` for the process at the given index in the
-    /// processes array.
+    /// Checks if the provided `AppId` is still valid given the processes stored
+    /// in the processes array. Returns `true` if the AppId still refers to
+    /// a valid process, and `false` if not.
     ///
-    /// If the process at that index does not exist return `None`.
-    ///
-    /// This is needed for `AppId` itself to implement the `.index()` command
-    /// to verify that the referenced app is still at the correct index.
-    crate fn lookup_app_by_index(&self, index: usize) -> Option<AppId> {
-        self.processes.get(index).map_or(None, |p| {
-            p.map_or(None, |process| Some(process.appid()))
+    /// This is needed for `AppId` itself to implement the `.index()` command to
+    /// verify that the referenced app is still at the correct index.
+    crate fn appid_is_valid(&self, appid: AppId) -> bool {
+        self.processes.get(appid.index).map_or(false, |p| {
+            p.map_or(false, |process| process.appid().id() == appid.id())
         })
     }
 

--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -77,10 +77,12 @@ impl Kernel {
     where
         F: FnOnce(&dyn process::ProcessType) -> R,
     {
-        if appid.idx() > self.processes.len() {
-            return default;
+        match appid.idx() {
+            Some(i) => {
+                self.processes[i].map_or(default, |process| closure(process))
+            }
+            None => default,
         }
-        self.processes[appid.idx()].map_or(default, |process| closure(process))
     }
 
     /// Run a closure on every valid process. This will iterate the array of

--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -99,6 +99,20 @@ impl Kernel {
         }
     }
 
+    /// Return an iterator for all of the items in the processes array on this
+    /// board.
+    ///
+    /// NOTE: This would be better if it returned an iterator to only processes.
+    /// While with `filter_map()` it is straightforward to create an object that
+    /// implements `Iterator` and only iterates over `Some(process)` items in
+    /// the processes array, Rust doesn't seem to support the types necessary to
+    /// actually make that work and be usable. Perhaps as
+    /// https://github.com/rust-lang/rust/issues/63066 progresses this will be
+    /// possible in the future.
+    crate fn get_process_iter(&self) -> core::slice::Iter<Option<&dyn process::ProcessType>> {
+        self.processes.iter()
+    }
+
     /// Run a closure on every valid process. This will iterate the
     /// array of processes and call the closure on every process that
     /// exists. Ths method is available outside the kernel crate but
@@ -140,11 +154,6 @@ impl Kernel {
             }
         }
         ReturnCode::FAIL
-    }
-
-    /// Return how many processes this board supports.
-    crate fn number_of_process_slots(&self) -> usize {
-        self.processes.len()
     }
 
     /// Create a new grant. This is used in board initialization to setup grants


### PR DESCRIPTION
### Pull Request Overview

Currently a capsule can store an `AppId` to refer to a process, and there is not really a mechanism for ensuring that that `AppId` is still valid. Currently in Tock we are OK with this since we only create processes once, they don't restart, and we don't move them around in the processes array. However, as process management becomes more sophisticated, the idea that an AppId is always valid will no longer be true. Since `AppId` only stores the index of the relevant process in that array, if a process restarts, or if a process is removed and then a new one is added in the same slot, then the stored `AppId` will appear valid, even though it actually refers to a different process.

To enable verifying that `AppId`s are still valid, this PR adds a new field (`identifier`) to the `AppId` object. This allows `AppId`s to be used as before (i.e. they are still copyable), but now operations using `AppId` can verify that the identifier in the AppId matches the identifier assigned to the process at a particular index.

AppId retains the `index` field which does correspond to the index in the processes array (at least while the AppId is valid). This allows us to retain direct lookups, as well as simplifies the IPC implementation.

#### Changes to AppId API

The existing `.idx()` function has been removed, and `.index()` and `.id()` have been added. `.index()` checks that the AppId is still valid before returning the index in the array of the corresponding app. `.id()` just returns the identifier, which can be passed to userspace or over a UART channel, for example.

These changes resulted in a couple changes to capsules which need `usize` identifiers for apps, and now must call `.id()`.

#### Changes to kernel APIs

The major change in the kernel (beyond AppId) is that functions which used to take an index now just take an `AppId`. Mostly this is a minor change, except for `kernel.process_map_or()`. This function runs a closure on a specific app if it is exists, and uses the index and identifier to verify the app is still valid.

Otherwise, IPC had to be updated quite a bit to handle the changes. I also took the opportunity to update how grant iters are implemented since this PR reduces the reliance on an app's identifier being its index in the process array.

#### How does this fix the capsule problem?

A capsule can still store an AppId, and that AppId can still become invalid. However, the main use of an AppId between a capsule and the kernel is to call `grant.enter(appid)`. Without this PR, if appid refers to an old process, and a new process has started in the same array index, `grant.enter(appid)` would succeed (after initializing a new grant region for the new process). Now, when `grant.enter()` calls `.kernel.process_map_or(appid)`, an error will be returned which will bubble back to the capsule.

#### What does this PR not do?

This PR just improves the mechanism for detecting app changes, but does not change the policy on how app identifiers are assigned. Identifiers remain equivalent to their index in the array.

I iterated on the design in this PR several times, and the changes became substantial without also changing how app identifiers are assigned.

This is part of #1082.

### Testing Strategy

This pull request was tested by running the IPC apps. More testing is needed.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
