### PR TITLE
libraries/riscv-csr: Fix warning under cargo test

### DIFF
--- a/libraries/riscv-csr/src/csr.rs
+++ b/libraries/riscv-csr/src/csr.rs
@@ -48,12 +48,12 @@ impl<T: IntLike, R: RegisterLongName> ReadWriteRiscvCsr<T, R> {
     // Mock implementations for tests on Travis-CI.
     #[cfg(not(any(target_arch = "riscv32", target_os = "none")))]
     pub fn get(&self) -> T {
-        unimplemented!()
+        unimplemented!("reading RISC-V CSR {}", self.value)
     }
 
     #[cfg(not(any(target_arch = "riscv32", target_os = "none")))]
     pub fn set(&self, _val_to_set: T) {
-        unimplemented!()
+        unimplemented!("writing RISC-V CSR {}", self.value)
     }
 
     #[inline]


### PR DESCRIPTION
### Pull Request Overview

When rv32i and its related chips are build under test mode (for Travis and others), this warning is emitted:
```
   Compiling riscv-csr v0.1.0 (/home/travis/build/tock/tock/libraries/riscv-csr)
warning: field is never read: `value`
  --> /home/travis/build/tock/tock/libraries/riscv-csr/src/csr.rs:11:5
   |
11 |     value: usize,
   |     ^^^^^^^^^^^^
   |
   = note: `#[warn(dead_code)]` on by default
```
This PR updates the `#[cfg(test)]` version of functions in the library to quiet that error.

### Testing Strategy

This pull request was tested by running `cargo test` in rv32i and the chips which consume `riscv-csr` to confirm that the warnings are gone.

### TODO or Help Wanted

n/a

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
