### PR TITLE
arch/rv32i: Simplify mcause CSR parsing

### DIFF
--- a/arch/rv32i/src/csr/mcause.rs
+++ b/arch/rv32i/src/csr/mcause.rs
@@ -2,35 +2,39 @@ use kernel::common::registers::{register_bitfields, LocalRegisterCopy};
 
 register_bitfields![u32,
     pub mcause [
-        // only support 32 bit targets
-        isException OFFSET(31) NUMBITS(1) [],
+        is_interrupt OFFSET(31) NUMBITS(1) [],
         reason OFFSET(0) NUMBITS(31) []
+    ],
+    // Per the spec, implementations are allowed to use the higher bits of the
+    // interrupt/exception reason for their own purposes.  For regular parsing,
+    // we only concern ourselves with the "standard" values.
+    reason [
+        reserved OFFSET(4) NUMBITS(27) [],
+        std OFFSET(0) NUMBITS(4) []
     ]
 ];
-
-pub trait McauseHelpers {
-    fn is_interrupt(&self) -> bool;
-    fn cause(&self) -> Trap;
-}
-
-impl McauseHelpers for LocalRegisterCopy<u32, mcause::Register> {
-    fn is_interrupt(&self) -> bool {
-        self.read(mcause::isException).eq(&1)
-    }
-    fn cause(&self) -> Trap {
-        if self.is_interrupt() {
-            Trap::Interrupt(Interrupt::from(self.read(mcause::reason)))
-        } else {
-            Trap::Exception(Exception::from(self.read(mcause::reason)))
-        }
-    }
-}
 
 /// Trap Cause
 #[derive(Copy, Clone, Debug)]
 pub enum Trap {
     Interrupt(Interrupt),
     Exception(Exception),
+}
+
+impl From<LocalRegisterCopy<u32, mcause::Register>> for Trap {
+    fn from(val: LocalRegisterCopy<u32, mcause::Register>) -> Self {
+        if val.is_set(mcause::is_interrupt) {
+            Trap::Interrupt(Interrupt::from_reason(val.read(mcause::reason)))
+        } else {
+            Trap::Exception(Exception::from_reason(val.read(mcause::reason)))
+        }
+    }
+}
+
+impl From<u32> for Trap {
+    fn from(csr_val: u32) -> Self {
+        Self::from(LocalRegisterCopy::<u32, mcause::Register>::new(csr_val))
+    }
 }
 
 /// Interrupt
@@ -69,8 +73,9 @@ pub enum Exception {
 }
 
 impl Interrupt {
-    pub fn from(nr: u32) -> Self {
-        match nr {
+    fn from_reason(val: u32) -> Self {
+        let reason = LocalRegisterCopy::<u32, reason::Register>::new(val);
+        match reason.read(reason::std) {
             0 => Interrupt::UserSoft,
             1 => Interrupt::SupervisorSoft,
             3 => Interrupt::MachineSoft,
@@ -86,8 +91,9 @@ impl Interrupt {
 }
 
 impl Exception {
-    pub fn from(nr: u32) -> Self {
-        match nr {
+    fn from_reason(val: u32) -> Self {
+        let reason = LocalRegisterCopy::<u32, reason::Register>::new(val);
+        match reason.read(reason::std) {
             0 => Exception::InstructionMisaligned,
             1 => Exception::InstructionFault,
             2 => Exception::IllegalInstruction,

--- a/chips/e310x/src/chip.rs
+++ b/chips/e310x/src/chip.rs
@@ -86,7 +86,7 @@ pub unsafe fn handle_trap() {
     let cause = rv32i::csr::CSR.mcause.extract();
     // if most sig bit is set, is interrupt
     // strip off the msb
-    match rv32i::csr::mcause::McauseHelpers::cause(&cause) {
+    match rv32i::csr::mcause::Trap::from(cause) {
         rv32i::csr::mcause::Trap::Interrupt(interrupt) => {
             match interrupt {
                 rv32i::csr::mcause::Interrupt::MachineSoft => {
@@ -178,7 +178,7 @@ pub unsafe fn handle_trap() {
 pub fn disable_interrupt_cause() {
     let cause = rv32i::csr::CSR.mcause.extract();
 
-    match rv32i::csr::mcause::McauseHelpers::cause(&cause) {
+    match rv32i::csr::mcause::Trap::from(cause) {
         rv32i::csr::mcause::Trap::Interrupt(interrupt) => match interrupt {
             rv32i::csr::mcause::Interrupt::UserSoft => {
                 csr::CSR.mie.modify(csr::mie::mie::usoft::CLEAR);

--- a/chips/ibex/src/chip.rs
+++ b/chips/ibex/src/chip.rs
@@ -192,9 +192,7 @@ unsafe fn handle_interrupt(intr: mcause::Interrupt) {
 /// disable it.
 #[export_name = "_start_trap_rust"]
 pub unsafe extern "C" fn start_trap_rust() {
-    let cause = CSR.mcause.extract();
-
-    match mcause::McauseHelpers::cause(&cause) {
+    match mcause::Trap::from(CSR.mcause.extract()) {
         mcause::Trap::Interrupt(interrupt) => {
             handle_interrupt(interrupt);
         }
@@ -208,11 +206,8 @@ pub unsafe extern "C" fn start_trap_rust() {
 /// mcause is passed in, and this function should correctly handle disabling the
 /// interrupt that fired so that it does not trigger again.
 #[export_name = "_disable_interrupt_trap_handler"]
-pub unsafe extern "C" fn disable_interrupt_trap_handler(_mcause: u32) {
-    // TODO: reuse _mcause from above
-    let cause = CSR.mcause.extract();
-
-    match mcause::McauseHelpers::cause(&cause) {
+pub unsafe extern "C" fn disable_interrupt_trap_handler(mcause_val: u32) {
+    match mcause::Trap::from(mcause_val) {
         mcause::Trap::Interrupt(interrupt) => {
             handle_interrupt(interrupt);
         }


### PR DESCRIPTION
### Pull Request Overview

This PR switches the parsing of `mcause` to use the standard `From<>` trait interface, rather than the bespoke `McauseHelpers`.  In the case of `disable_interrupt_trap_handler` for Ibex, it means easier reuse of the already-collected `mcause` value, rather than re-querying the CSR.

### Testing Strategy

This PR was tested on OpenTitan (under verilator) and HiFive (under qemu via the `sifive_e` machine type) to see that the platforms were still functioning as expected.


### TODO or Help Wanted

n/a

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
