### PR TITLE
add set_vector_table_offset()

### DIFF
--- a/arch/cortex-m/src/scb.rs
+++ b/arch/cortex-m/src/scb.rs
@@ -9,7 +9,7 @@ use kernel::common::StaticRef;
 struct ScbRegisters {
     cpuid: VolatileCell<u32>,
     icsr: VolatileCell<u32>,
-    vtor: VolatileCell<u32>,
+    vtor: VolatileCell<*const ()>,
     aircr: VolatileCell<u32>,
     scr: VolatileCell<u32>,
     ccr: VolatileCell<u32>,
@@ -53,4 +53,9 @@ pub unsafe fn reset() {
     let aircr = SCB.aircr.get();
     let reset = (0x5FA << 16) | (aircr & (0x7 << 8)) | (1 << 2);
     SCB.aircr.set(reset);
+}
+
+/// relocate interrupt vector table
+pub unsafe fn set_vector_table_offset(offset: *const ()) {
+    SCB.vtor.set(offset);
 }


### PR DESCRIPTION
when using a bootloader, tock os may need to relocate interrupt
vector table, then use this function to do that.

See the discussion at https://github.com/google/OpenSK/issues/3

### Pull Request Overview

This pull request adds `add set_vector_table_offset` function to relocate interrupt vector table.


### Testing Strategy

TODO

### TODO or Help Wanted

N/A

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
