### PR TITLE
Layered networking capabilities

### DIFF
--- a/boards/imix/src/icmp_lowpan_test.rs
+++ b/boards/imix/src/icmp_lowpan_test.rs
@@ -27,13 +27,12 @@ use capsules::net::ieee802154::MacAddress;
 use capsules::net::ipv6::ip_utils::IPAddr;
 use capsules::net::ipv6::ipv6::{IP6Packet, IPPayload, TransportHeader};
 use capsules::net::ipv6::ipv6_send::{IP6SendStruct, IP6Sender};
-use capsules::net::network_capabilities::NetworkCapability;
+use capsules::net::network_capabilities::{IpVisibilityCapability, NetworkCapability};
 use capsules::net::sixlowpan::sixlowpan_compression;
 use capsules::net::sixlowpan::sixlowpan_state::{Sixlowpan, SixlowpanState, TxState};
 
 use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use core::cell::Cell;
-use kernel::capabilities::IpVisibilityCapability;
 use kernel::debug;
 use kernel::hil::radio;
 use kernel::hil::time::Frequency;
@@ -75,7 +74,7 @@ pub unsafe fn initialize_all(
     mux_mac: &'static capsules::ieee802154::virtual_mac::MuxMac<'static>,
     mux_alarm: &'static MuxAlarm<'static, sam4l::ast::Ast>,
     net_cap: &'static NetworkCapability,
-    ip_vis: &'static dyn IpVisibilityCapability,
+    ip_vis: &'static IpVisibilityCapability,
 ) -> &'static LowpanICMPTest<
     'static,
     capsules::virtual_alarm::VirtualMuxAlarm<'static, sam4l::ast::Ast<'static>>,

--- a/boards/imix/src/icmp_lowpan_test.rs
+++ b/boards/imix/src/icmp_lowpan_test.rs
@@ -39,6 +39,8 @@ use kernel::hil::time::Frequency;
 use kernel::hil::time::{self, Alarm};
 use kernel::static_init;
 use kernel::ReturnCode;
+use kernel::capabilities::IpVisCap;
+
 
 pub const SRC_ADDR: IPAddr = IPAddr([
     0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
@@ -74,6 +76,7 @@ pub unsafe fn initialize_all(
     mux_mac: &'static capsules::ieee802154::virtual_mac::MuxMac<'static>,
     mux_alarm: &'static MuxAlarm<'static, sam4l::ast::Ast>,
     net_cap: &'static NetworkCapability,
+    ip_vis: &'static dyn IpVisCap,
 ) -> &'static LowpanICMPTest<
     'static,
     capsules::virtual_alarm::VirtualMuxAlarm<'static, sam4l::ast::Ast<'static>>,
@@ -122,7 +125,8 @@ pub unsafe fn initialize_all(
             sixlowpan_tx,
             radio_mac,
             DST_MAC_ADDR,
-            SRC_MAC_ADDR
+            SRC_MAC_ADDR,
+            ip_vis
         )
     );
     radio_mac.set_transmit_client(ip6_sender);
@@ -142,7 +146,7 @@ pub unsafe fn initialize_all(
             //radio_mac,
             VirtualMuxAlarm::new(mux_alarm),
             icmp_send_struct,
-            net_cap,
+            net_cap
         )
     );
 

--- a/boards/imix/src/icmp_lowpan_test.rs
+++ b/boards/imix/src/icmp_lowpan_test.rs
@@ -29,6 +29,8 @@ use capsules::net::ipv6::ipv6::{IP6Packet, IPPayload, TransportHeader};
 use capsules::net::ipv6::ipv6_send::{IP6SendStruct, IP6Sender};
 use capsules::net::sixlowpan::sixlowpan_compression;
 use capsules::net::sixlowpan::sixlowpan_state::{Sixlowpan, SixlowpanState, TxState};
+use capsules::net::network_capabilities::{NetworkCapability};
+
 use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use core::cell::Cell;
 use kernel::debug;
@@ -65,11 +67,13 @@ pub struct LowpanICMPTest<'a, A: time::Alarm<'a>> {
     alarm: A,
     test_counter: Cell<usize>,
     icmp_sender: &'a dyn ICMP6Sender<'a>,
+    net_cap: &'static NetworkCapability,
 }
 
 pub unsafe fn initialize_all(
     mux_mac: &'static capsules::ieee802154::virtual_mac::MuxMac<'static>,
     mux_alarm: &'static MuxAlarm<'static, sam4l::ast::Ast>,
+    net_cap: &'static NetworkCapability,
 ) -> &'static LowpanICMPTest<
     'static,
     capsules::virtual_alarm::VirtualMuxAlarm<'static, sam4l::ast::Ast<'static>>,
@@ -128,7 +132,7 @@ pub unsafe fn initialize_all(
             'static,
             IP6SendStruct<'static, VirtualMuxAlarm<'static, sam4l::ast::Ast<'static>>>,
         >,
-        ICMP6SendStruct::new(ip6_sender)
+        ICMP6SendStruct::new(ip6_sender, net_cap)
     );
 
     let icmp_lowpan_test = static_init!(
@@ -137,7 +141,8 @@ pub unsafe fn initialize_all(
             //sixlowpan_tx,
             //radio_mac,
             VirtualMuxAlarm::new(mux_alarm),
-            icmp_send_struct
+            icmp_send_struct,
+            net_cap,
         )
     );
 
@@ -167,11 +172,13 @@ impl<'a, A: time::Alarm<'a>> capsules::net::icmpv6::icmpv6_send::ICMP6SendClient
 }
 
 impl<A: time::Alarm<'a>> LowpanICMPTest<'a, A> {
-    pub fn new(alarm: A, icmp_sender: &'a dyn ICMP6Sender<'a>) -> LowpanICMPTest<'a, A> {
+    pub fn new(alarm: A, icmp_sender: &'a dyn ICMP6Sender<'a>,
+        net_cap: &'static NetworkCapability) -> LowpanICMPTest<'a, A> {
         LowpanICMPTest {
             alarm: alarm,
             test_counter: Cell::new(0),
             icmp_sender: icmp_sender,
+            net_cap: net_cap,
         }
     }
 
@@ -219,7 +226,8 @@ impl<A: time::Alarm<'a>> LowpanICMPTest<'a, A> {
 
     fn send_next(&self) {
         let icmp_hdr = ICMP6Header::new(ICMP6Type::Type128); // Echo Request
-        unsafe { self.icmp_sender.send(DST_ADDR, icmp_hdr, &mut ICMP_PAYLOAD) };
+        unsafe { self.icmp_sender.send(DST_ADDR, icmp_hdr, &mut ICMP_PAYLOAD,
+            self.net_cap) };
     }
 }
 

--- a/boards/imix/src/icmp_lowpan_test.rs
+++ b/boards/imix/src/icmp_lowpan_test.rs
@@ -136,7 +136,7 @@ pub unsafe fn initialize_all(
             'static,
             IP6SendStruct<'static, VirtualMuxAlarm<'static, sam4l::ast::Ast<'static>>>,
         >,
-        ICMP6SendStruct::new(ip6_sender, net_cap)
+        ICMP6SendStruct::new(ip6_sender)
     );
 
     let icmp_lowpan_test = static_init!(

--- a/boards/imix/src/icmp_lowpan_test.rs
+++ b/boards/imix/src/icmp_lowpan_test.rs
@@ -27,20 +27,19 @@ use capsules::net::ieee802154::MacAddress;
 use capsules::net::ipv6::ip_utils::IPAddr;
 use capsules::net::ipv6::ipv6::{IP6Packet, IPPayload, TransportHeader};
 use capsules::net::ipv6::ipv6_send::{IP6SendStruct, IP6Sender};
+use capsules::net::network_capabilities::NetworkCapability;
 use capsules::net::sixlowpan::sixlowpan_compression;
 use capsules::net::sixlowpan::sixlowpan_state::{Sixlowpan, SixlowpanState, TxState};
-use capsules::net::network_capabilities::{NetworkCapability};
 
 use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use core::cell::Cell;
+use kernel::capabilities::IpVisCap;
 use kernel::debug;
 use kernel::hil::radio;
 use kernel::hil::time::Frequency;
 use kernel::hil::time::{self, Alarm};
 use kernel::static_init;
 use kernel::ReturnCode;
-use kernel::capabilities::IpVisCap;
-
 
 pub const SRC_ADDR: IPAddr = IPAddr([
     0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
@@ -176,8 +175,11 @@ impl<'a, A: time::Alarm<'a>> capsules::net::icmpv6::icmpv6_send::ICMP6SendClient
 }
 
 impl<A: time::Alarm<'a>> LowpanICMPTest<'a, A> {
-    pub fn new(alarm: A, icmp_sender: &'a dyn ICMP6Sender<'a>,
-        net_cap: &'static NetworkCapability) -> LowpanICMPTest<'a, A> {
+    pub fn new(
+        alarm: A,
+        icmp_sender: &'a dyn ICMP6Sender<'a>,
+        net_cap: &'static NetworkCapability,
+    ) -> LowpanICMPTest<'a, A> {
         LowpanICMPTest {
             alarm: alarm,
             test_counter: Cell::new(0),
@@ -230,8 +232,10 @@ impl<A: time::Alarm<'a>> LowpanICMPTest<'a, A> {
 
     fn send_next(&self) {
         let icmp_hdr = ICMP6Header::new(ICMP6Type::Type128); // Echo Request
-        unsafe { self.icmp_sender.send(DST_ADDR, icmp_hdr, &mut ICMP_PAYLOAD,
-            self.net_cap) };
+        unsafe {
+            self.icmp_sender
+                .send(DST_ADDR, icmp_hdr, &mut ICMP_PAYLOAD, self.net_cap)
+        };
     }
 }
 

--- a/boards/imix/src/icmp_lowpan_test.rs
+++ b/boards/imix/src/icmp_lowpan_test.rs
@@ -33,7 +33,7 @@ use capsules::net::sixlowpan::sixlowpan_state::{Sixlowpan, SixlowpanState, TxSta
 
 use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use core::cell::Cell;
-use kernel::capabilities::IpVisCap;
+use kernel::capabilities::IpVisibilityCapability;
 use kernel::debug;
 use kernel::hil::radio;
 use kernel::hil::time::Frequency;
@@ -75,7 +75,7 @@ pub unsafe fn initialize_all(
     mux_mac: &'static capsules::ieee802154::virtual_mac::MuxMac<'static>,
     mux_alarm: &'static MuxAlarm<'static, sam4l::ast::Ast>,
     net_cap: &'static NetworkCapability,
-    ip_vis: &'static dyn IpVisCap,
+    ip_vis: &'static dyn IpVisibilityCapability,
 ) -> &'static LowpanICMPTest<
     'static,
     capsules::virtual_alarm::VirtualMuxAlarm<'static, sam4l::ast::Ast<'static>>,

--- a/boards/imix/src/imix_components/test/mock_udp.rs
+++ b/boards/imix/src/imix_components/test/mock_udp.rs
@@ -5,14 +5,13 @@
 #![allow(dead_code)] // Components are intended to be conditionally included
 
 use capsules::net::ipv6::ipv6_send::IP6SendStruct;
-use capsules::net::network_capabilities::NetworkCapability;
+use capsules::net::network_capabilities::{NetworkCapability, UdpVisibilityCapability};
 use capsules::net::udp::udp_recv::{MuxUdpReceiver, UDPReceiver};
 use capsules::net::udp::udp_send::{MuxUdpSender, UDPSendStruct, UDPSender};
 
 use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 
 use capsules::net::udp::udp_port_table::UdpPortManager;
-use kernel::capabilities::UdpVisibilityCapability;
 use kernel::common::cells::TakeCell;
 use kernel::component::Component;
 use kernel::hil::time::Alarm;
@@ -31,7 +30,7 @@ pub struct MockUDPComponent {
     id: u16,
     dst_port: u16,
     net_cap: &'static NetworkCapability,
-    udp_vis: &'static dyn UdpVisibilityCapability,
+    udp_vis: &'static UdpVisibilityCapability,
 }
 
 impl MockUDPComponent {
@@ -47,7 +46,7 @@ impl MockUDPComponent {
         id: u16,
         dst_port: u16,
         net_cap: &'static NetworkCapability,
-        udp_vis: &'static dyn UdpVisibilityCapability,
+        udp_vis: &'static UdpVisibilityCapability,
     ) -> MockUDPComponent {
         MockUDPComponent {
             udp_send_mux: udp_send_mux,

--- a/boards/imix/src/imix_components/test/mock_udp.rs
+++ b/boards/imix/src/imix_components/test/mock_udp.rs
@@ -12,7 +12,7 @@ use capsules::net::udp::udp_send::{MuxUdpSender, UDPSendStruct, UDPSender};
 use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 
 use capsules::net::udp::udp_port_table::UdpPortManager;
-use kernel::capabilities::UdpVisCap;
+use kernel::capabilities::UdpVisibilityCapability;
 use kernel::common::cells::TakeCell;
 use kernel::component::Component;
 use kernel::hil::time::Alarm;
@@ -31,7 +31,7 @@ pub struct MockUDPComponent {
     id: u16,
     dst_port: u16,
     net_cap: &'static NetworkCapability,
-    udp_vis: &'static dyn UdpVisCap,
+    udp_vis: &'static dyn UdpVisibilityCapability,
 }
 
 impl MockUDPComponent {
@@ -47,7 +47,7 @@ impl MockUDPComponent {
         id: u16,
         dst_port: u16,
         net_cap: &'static NetworkCapability,
-        udp_vis: &'static dyn UdpVisCap,
+        udp_vis: &'static dyn UdpVisibilityCapability,
     ) -> MockUDPComponent {
         MockUDPComponent {
             udp_send_mux: udp_send_mux,

--- a/boards/imix/src/imix_components/test/mock_udp.rs
+++ b/boards/imix/src/imix_components/test/mock_udp.rs
@@ -7,6 +7,8 @@
 use capsules::net::ipv6::ipv6_send::IP6SendStruct;
 use capsules::net::udp::udp_recv::{MuxUdpReceiver, UDPReceiver};
 use capsules::net::udp::udp_send::{MuxUdpSender, UDPSendStruct, UDPSender};
+use capsules::net::network_capabilities::{NetworkCapability};
+
 use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 
 use capsules::net::udp::udp_port_table::UdpPortManager;
@@ -27,6 +29,7 @@ pub struct MockUDPComponent {
     udp_payload: TakeCell<'static, [u8]>,
     id: u16,
     dst_port: u16,
+    net_cap: &'static NetworkCapability,
 }
 
 impl MockUDPComponent {
@@ -41,6 +44,7 @@ impl MockUDPComponent {
         udp_payload: &'static mut [u8],
         id: u16,
         dst_port: u16,
+        net_cap: &'static NetworkCapability,
     ) -> MockUDPComponent {
         MockUDPComponent {
             udp_send_mux: udp_send_mux,
@@ -50,6 +54,7 @@ impl MockUDPComponent {
             udp_payload: TakeCell::new(udp_payload),
             id: id,
             dst_port: dst_port,
+            net_cap: net_cap,
         }
     }
 }
@@ -92,6 +97,7 @@ impl Component for MockUDPComponent {
                     self.udp_payload.take().expect("missing payload")
                 ),
                 self.dst_port,
+                self.net_cap,
             )
         );
         udp_send.set_client(mock_udp);

--- a/boards/imix/src/imix_components/test/mock_udp.rs
+++ b/boards/imix/src/imix_components/test/mock_udp.rs
@@ -5,18 +5,18 @@
 #![allow(dead_code)] // Components are intended to be conditionally included
 
 use capsules::net::ipv6::ipv6_send::IP6SendStruct;
+use capsules::net::network_capabilities::NetworkCapability;
 use capsules::net::udp::udp_recv::{MuxUdpReceiver, UDPReceiver};
 use capsules::net::udp::udp_send::{MuxUdpSender, UDPSendStruct, UDPSender};
-use capsules::net::network_capabilities::{NetworkCapability};
 
 use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 
 use capsules::net::udp::udp_port_table::UdpPortManager;
+use kernel::capabilities::UdpVisCap;
 use kernel::common::cells::TakeCell;
 use kernel::component::Component;
 use kernel::hil::time::Alarm;
 use kernel::static_init;
-use kernel::capabilities::UdpVisCap;
 
 pub struct MockUDPComponent {
     // TODO: consider putting bound_port_table in a TakeCell

--- a/boards/imix/src/imix_components/test/mock_udp.rs
+++ b/boards/imix/src/imix_components/test/mock_udp.rs
@@ -16,6 +16,7 @@ use kernel::common::cells::TakeCell;
 use kernel::component::Component;
 use kernel::hil::time::Alarm;
 use kernel::static_init;
+use kernel::capabilities::UdpVisCap;
 
 pub struct MockUDPComponent {
     // TODO: consider putting bound_port_table in a TakeCell
@@ -30,6 +31,7 @@ pub struct MockUDPComponent {
     id: u16,
     dst_port: u16,
     net_cap: &'static NetworkCapability,
+    udp_vis: &'static dyn UdpVisCap,
 }
 
 impl MockUDPComponent {
@@ -45,6 +47,7 @@ impl MockUDPComponent {
         id: u16,
         dst_port: u16,
         net_cap: &'static NetworkCapability,
+        udp_vis: &'static dyn UdpVisCap,
     ) -> MockUDPComponent {
         MockUDPComponent {
             udp_send_mux: udp_send_mux,
@@ -55,6 +58,7 @@ impl MockUDPComponent {
             id: id,
             dst_port: dst_port,
             net_cap: net_cap,
+            udp_vis: udp_vis,
         }
     }
 }
@@ -75,7 +79,7 @@ impl Component for MockUDPComponent {
                     VirtualMuxAlarm<'static, sam4l::ast::Ast<'static>>,
                 >,
             >,
-            UDPSendStruct::new(self.udp_send_mux)
+            UDPSendStruct::new(self.udp_send_mux, self.udp_vis)
         );
 
         let udp_recv = static_init!(UDPReceiver<'static>, UDPReceiver::new());

--- a/boards/imix/src/imix_components/test/mock_udp2.rs
+++ b/boards/imix/src/imix_components/test/mock_udp2.rs
@@ -11,6 +11,8 @@ use capsules::net::ipv6::ipv6_send::IP6SendStruct;
 use capsules::net::udp::udp_recv::{MuxUdpReceiver, UDPReceiver};
 use capsules::net::udp::udp_send::{MuxUdpSender, UDPSendStruct, UDPSender};
 use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
+use capsules::net::network_capabilities::{NetworkCapability};
+
 
 use capsules::net::udp::udp_port_table::UdpPortManager;
 use kernel::common::cells::TakeCell;
@@ -30,6 +32,7 @@ pub struct MockUDPComponent2 {
     udp_payload: TakeCell<'static, [u8]>,
     id: u16,
     dst_port: u16,
+    net_cap: &'static NetworkCapability,
 }
 
 impl MockUDPComponent2 {
@@ -44,6 +47,7 @@ impl MockUDPComponent2 {
         udp_payload: &'static mut [u8],
         id: u16,
         dst_port: u16,
+        net_cap: &'static NetworkCapability,
     ) -> MockUDPComponent2 {
         MockUDPComponent2 {
             udp_send_mux: udp_send_mux,
@@ -53,6 +57,7 @@ impl MockUDPComponent2 {
             udp_payload: TakeCell::new(udp_payload),
             id: id,
             dst_port: dst_port,
+            net_cap: net_cap,
         }
     }
 }
@@ -95,6 +100,7 @@ impl Component for MockUDPComponent2 {
                     self.udp_payload.take().expect("missing payload")
                 ),
                 self.dst_port,
+                self.net_cap,
             )
         );
         udp_send.set_client(mock_udp);

--- a/boards/imix/src/imix_components/test/mock_udp2.rs
+++ b/boards/imix/src/imix_components/test/mock_udp2.rs
@@ -8,13 +8,12 @@
 #![allow(dead_code)] // Components are intended to be conditionally included
 
 use capsules::net::ipv6::ipv6_send::IP6SendStruct;
-use capsules::net::network_capabilities::NetworkCapability;
+use capsules::net::network_capabilities::{NetworkCapability, UdpVisibilityCapability};
 use capsules::net::udp::udp_recv::{MuxUdpReceiver, UDPReceiver};
 use capsules::net::udp::udp_send::{MuxUdpSender, UDPSendStruct, UDPSender};
 use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 
 use capsules::net::udp::udp_port_table::UdpPortManager;
-use kernel::capabilities::UdpVisibilityCapability;
 use kernel::common::cells::TakeCell;
 use kernel::component::Component;
 use kernel::hil::time::Alarm;
@@ -33,7 +32,7 @@ pub struct MockUDPComponent2 {
     id: u16,
     dst_port: u16,
     net_cap: &'static NetworkCapability,
-    udp_vis: &'static dyn UdpVisibilityCapability,
+    udp_vis: &'static UdpVisibilityCapability,
 }
 
 impl MockUDPComponent2 {
@@ -49,7 +48,7 @@ impl MockUDPComponent2 {
         id: u16,
         dst_port: u16,
         net_cap: &'static NetworkCapability,
-        udp_vis: &'static dyn UdpVisibilityCapability,
+        udp_vis: &'static UdpVisibilityCapability,
     ) -> MockUDPComponent2 {
         MockUDPComponent2 {
             udp_send_mux: udp_send_mux,

--- a/boards/imix/src/imix_components/test/mock_udp2.rs
+++ b/boards/imix/src/imix_components/test/mock_udp2.rs
@@ -19,6 +19,8 @@ use kernel::common::cells::TakeCell;
 use kernel::component::Component;
 use kernel::hil::time::Alarm;
 use kernel::static_init;
+use kernel::capabilities::UdpVisCap;
+
 
 pub struct MockUDPComponent2 {
     // TODO: consider putting bound_port_table in a TakeCell
@@ -33,6 +35,7 @@ pub struct MockUDPComponent2 {
     id: u16,
     dst_port: u16,
     net_cap: &'static NetworkCapability,
+    udp_vis: &'static dyn UdpVisCap,
 }
 
 impl MockUDPComponent2 {
@@ -48,6 +51,7 @@ impl MockUDPComponent2 {
         id: u16,
         dst_port: u16,
         net_cap: &'static NetworkCapability,
+        udp_vis: &'static dyn UdpVisCap,
     ) -> MockUDPComponent2 {
         MockUDPComponent2 {
             udp_send_mux: udp_send_mux,
@@ -58,6 +62,7 @@ impl MockUDPComponent2 {
             id: id,
             dst_port: dst_port,
             net_cap: net_cap,
+            udp_vis: udp_vis,
         }
     }
 }
@@ -78,7 +83,7 @@ impl Component for MockUDPComponent2 {
                     VirtualMuxAlarm<'static, sam4l::ast::Ast<'static>>,
                 >,
             >,
-            UDPSendStruct::new(self.udp_send_mux)
+            UDPSendStruct::new(self.udp_send_mux, self.udp_vis)
         );
 
         let udp_recv = static_init!(UDPReceiver<'static>, UDPReceiver::new());

--- a/boards/imix/src/imix_components/test/mock_udp2.rs
+++ b/boards/imix/src/imix_components/test/mock_udp2.rs
@@ -8,19 +8,17 @@
 #![allow(dead_code)] // Components are intended to be conditionally included
 
 use capsules::net::ipv6::ipv6_send::IP6SendStruct;
+use capsules::net::network_capabilities::NetworkCapability;
 use capsules::net::udp::udp_recv::{MuxUdpReceiver, UDPReceiver};
 use capsules::net::udp::udp_send::{MuxUdpSender, UDPSendStruct, UDPSender};
 use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
-use capsules::net::network_capabilities::{NetworkCapability};
-
 
 use capsules::net::udp::udp_port_table::UdpPortManager;
+use kernel::capabilities::UdpVisCap;
 use kernel::common::cells::TakeCell;
 use kernel::component::Component;
 use kernel::hil::time::Alarm;
 use kernel::static_init;
-use kernel::capabilities::UdpVisCap;
-
 
 pub struct MockUDPComponent2 {
     // TODO: consider putting bound_port_table in a TakeCell

--- a/boards/imix/src/imix_components/test/mock_udp2.rs
+++ b/boards/imix/src/imix_components/test/mock_udp2.rs
@@ -14,7 +14,7 @@ use capsules::net::udp::udp_send::{MuxUdpSender, UDPSendStruct, UDPSender};
 use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 
 use capsules::net::udp::udp_port_table::UdpPortManager;
-use kernel::capabilities::UdpVisCap;
+use kernel::capabilities::UdpVisibilityCapability;
 use kernel::common::cells::TakeCell;
 use kernel::component::Component;
 use kernel::hil::time::Alarm;
@@ -33,7 +33,7 @@ pub struct MockUDPComponent2 {
     id: u16,
     dst_port: u16,
     net_cap: &'static NetworkCapability,
-    udp_vis: &'static dyn UdpVisCap,
+    udp_vis: &'static dyn UdpVisibilityCapability,
 }
 
 impl MockUDPComponent2 {
@@ -49,7 +49,7 @@ impl MockUDPComponent2 {
         id: u16,
         dst_port: u16,
         net_cap: &'static NetworkCapability,
-        udp_vis: &'static dyn UdpVisCap,
+        udp_vis: &'static dyn UdpVisibilityCapability,
     ) -> MockUDPComponent2 {
         MockUDPComponent2 {
             udp_send_mux: udp_send_mux,

--- a/boards/imix/src/imix_components/udp_driver.rs
+++ b/boards/imix/src/imix_components/udp_driver.rs
@@ -38,6 +38,7 @@ use kernel::{create_capability, static_init};
 use kernel;
 use kernel::capabilities;
 use kernel::component::Component;
+use kernel::capabilities::UdpVisCap;
 use sam4l;
 
 const UDP_HDR_SIZE: usize = 8;
@@ -55,6 +56,7 @@ pub struct UDPDriverComponent {
     port_table: &'static UdpPortManager,
     interface_list: &'static [IPAddr],
     net_cap: &'static NetworkCapability,
+    udp_vis: &'static dyn UdpVisCap,
 }
 
 impl UDPDriverComponent {
@@ -68,6 +70,7 @@ impl UDPDriverComponent {
         port_table: &'static UdpPortManager,
         interface_list: &'static [IPAddr],
         net_cap: &'static NetworkCapability,
+        udp_vis: &'static dyn UdpVisCap,
     ) -> UDPDriverComponent {
         UDPDriverComponent {
             board_kernel: board_kernel,
@@ -76,6 +79,7 @@ impl UDPDriverComponent {
             port_table: port_table,
             interface_list: interface_list,
             net_cap: net_cap,
+            udp_vis: udp_vis,
         }
     }
 }
@@ -94,7 +98,7 @@ impl Component for UDPDriverComponent {
                     VirtualMuxAlarm<'static, sam4l::ast::Ast<'static>>,
                 >,
             >,
-            UDPSendStruct::new(self.udp_send_mux)
+            UDPSendStruct::new(self.udp_send_mux, self.udp_vis)
         );
         // Can't use create_capability bc need capability to have a static lifetime
         // so that UDP driver can use it as needed

--- a/boards/imix/src/imix_components/udp_driver.rs
+++ b/boards/imix/src/imix_components/udp_driver.rs
@@ -31,6 +31,8 @@ use capsules::net::udp::udp_recv::MuxUdpReceiver;
 use capsules::net::udp::udp_recv::UDPReceiver;
 use capsules::net::udp::udp_send::{MuxUdpSender, UDPSendStruct, UDPSender};
 use capsules::virtual_alarm::VirtualMuxAlarm;
+use capsules::net::network_capabilities::{NetworkCapability};
+
 use kernel::{create_capability, static_init};
 
 use kernel;
@@ -52,6 +54,7 @@ pub struct UDPDriverComponent {
     udp_recv_mux: &'static MuxUdpReceiver<'static>,
     port_table: &'static UdpPortManager,
     interface_list: &'static [IPAddr],
+    net_cap: &'static NetworkCapability,
 }
 
 impl UDPDriverComponent {
@@ -64,6 +67,7 @@ impl UDPDriverComponent {
         udp_recv_mux: &'static MuxUdpReceiver<'static>,
         port_table: &'static UdpPortManager,
         interface_list: &'static [IPAddr],
+        net_cap: &'static NetworkCapability,
     ) -> UDPDriverComponent {
         UDPDriverComponent {
             board_kernel: board_kernel,
@@ -71,6 +75,7 @@ impl UDPDriverComponent {
             udp_recv_mux: udp_recv_mux,
             port_table: port_table,
             interface_list: interface_list,
+            net_cap: net_cap,
         }
     }
 }
@@ -107,6 +112,7 @@ impl Component for UDPDriverComponent {
                 self.port_table,
                 kernel::common::leasable_buffer::LeasableBuffer::new(&mut DRIVER_BUF),
                 &DRIVER_CAP,
+                self.net_cap,
             )
         );
         udp_send.set_client(udp_driver);

--- a/boards/imix/src/imix_components/udp_driver.rs
+++ b/boards/imix/src/imix_components/udp_driver.rs
@@ -37,7 +37,7 @@ use kernel::{create_capability, create_static_capability, static_init};
 
 use kernel;
 use kernel::capabilities;
-use kernel::capabilities::{UdpVisCap, NetCapCreateCap};
+use kernel::capabilities::{UdpVisibilityCapability, NetworkCapabilityCreationCapability};
 use kernel::component::Component;
 use sam4l;
 
@@ -84,7 +84,7 @@ impl Component for UDPDriverComponent {
 
     unsafe fn finalize(&mut self, _s: Self::StaticInput) -> Self::Output {
         let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
-        let udp_vis = create_static_capability!(UdpVisCap);
+        let udp_vis = create_static_capability!(UdpVisibilityCapability);
         let udp_send = static_init!(
             UDPSendStruct<
                 'static,
@@ -102,10 +102,10 @@ impl Component for UDPDriverComponent {
         // static DRIVER_CAP: DriverCap = DriverCap;
         let driver_cap = create_static_capability!(capabilities::UdpDriverCapability);
 
-        // struct NetCapCreateCapStruct;
-        // unsafe impl NetCapCreateCap for NetCapCreateCapStruct {}
-        // static mut CREATE_CAP: NetCapCreateCapStruct = NetCapCreateCapStruct;
-        let create_cap = create_static_capability!(NetCapCreateCap);
+        // struct NetworkCapabilityCreationCapabilityStruct;
+        // unsafe impl NetworkCapabilityCreationCapability for NetworkCapabilityCreationCapabilityStruct {}
+        // static mut CREATE_CAP: NetworkCapabilityCreationCapabilityStruct = NetworkCapabilityCreationCapabilityStruct;
+        let create_cap = create_static_capability!(NetworkCapabilityCreationCapability);
 
 
 

--- a/boards/imix/src/imix_components/udp_driver.rs
+++ b/boards/imix/src/imix_components/udp_driver.rs
@@ -26,19 +26,19 @@
 use capsules;
 use capsules::net::ipv6::ip_utils::IPAddr;
 use capsules::net::ipv6::ipv6_send::IP6SendStruct;
+use capsules::net::network_capabilities::NetworkCapability;
 use capsules::net::udp::udp_port_table::UdpPortManager;
 use capsules::net::udp::udp_recv::MuxUdpReceiver;
 use capsules::net::udp::udp_recv::UDPReceiver;
 use capsules::net::udp::udp_send::{MuxUdpSender, UDPSendStruct, UDPSender};
 use capsules::virtual_alarm::VirtualMuxAlarm;
-use capsules::net::network_capabilities::{NetworkCapability};
 
 use kernel::{create_capability, static_init};
 
 use kernel;
 use kernel::capabilities;
-use kernel::component::Component;
 use kernel::capabilities::UdpVisCap;
+use kernel::component::Component;
 use sam4l;
 
 const UDP_HDR_SIZE: usize = 8;

--- a/boards/imix/src/imix_components/udp_driver.rs
+++ b/boards/imix/src/imix_components/udp_driver.rs
@@ -26,8 +26,9 @@
 use capsules;
 use capsules::net::ipv6::ip_utils::IPAddr;
 use capsules::net::ipv6::ipv6_send::IP6SendStruct;
-use capsules::net::network_capabilities::{NetworkCapability, PortRange,
-    AddrRange, UdpVisibilityCapability};
+use capsules::net::network_capabilities::{
+    AddrRange, NetworkCapability, PortRange, UdpVisibilityCapability,
+};
 use capsules::net::udp::udp_port_table::UdpPortManager;
 use capsules::net::udp::udp_recv::MuxUdpReceiver;
 use capsules::net::udp::udp_recv::UDPReceiver;
@@ -87,8 +88,10 @@ impl Component for UDPDriverComponent {
         let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
         // TODO: change initialization below
         let create_cap = create_capability!(NetworkCapabilityCreationCapability);
-        let udp_vis = static_init!(UdpVisibilityCapability,
-            UdpVisibilityCapability::new(&create_cap));
+        let udp_vis = static_init!(
+            UdpVisibilityCapability,
+            UdpVisibilityCapability::new(&create_cap)
+        );
         let udp_send = static_init!(
             UDPSendStruct<
                 'static,
@@ -108,8 +111,8 @@ impl Component for UDPDriverComponent {
 
         let net_cap = static_init!(
             NetworkCapability,
-            NetworkCapability::new(AddrRange::Any, PortRange::Any, PortRange::Any,
-                &create_cap));
+            NetworkCapability::new(AddrRange::Any, PortRange::Any, PortRange::Any, &create_cap)
+        );
 
         let udp_driver = static_init!(
             capsules::net::udp::UDPDriver<'static>,

--- a/boards/imix/src/imix_components/udp_mux.rs
+++ b/boards/imix/src/imix_components/udp_mux.rs
@@ -33,6 +33,7 @@ use capsules::net::ipv6::ipv6::{IP6Packet, IPPayload, TransportHeader};
 use capsules::net::ipv6::ipv6_recv::IP6Receiver;
 use capsules::net::ipv6::ipv6_send::IP6SendStruct;
 use capsules::net::ipv6::ipv6_send::IP6Sender;
+use capsules::net::network_capabilities::{IpVisibilityCapability, UdpVisibilityCapability};
 use capsules::net::sixlowpan::{sixlowpan_compression, sixlowpan_state};
 use capsules::net::udp::udp::UDPHeader;
 use capsules::net::udp::udp_port_table::{SocketBindingEntry, UdpPortManager, MAX_NUM_BOUND_PORTS};
@@ -41,9 +42,8 @@ use capsules::net::udp::udp_send::MuxUdpSender;
 use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use kernel;
 use kernel::capabilities;
-use kernel::capabilities::{IpVisibilityCapability, UdpVisibilityCapability};
 use kernel::component::Component;
-use kernel::{create_capability, create_static_capability};
+use kernel::create_capability;
 use kernel::hil::radio;
 use kernel::hil::time::Alarm;
 use kernel::static_init;
@@ -132,10 +132,11 @@ impl Component for UDPMuxComponent {
             capsules::ieee802154::virtual_mac::MacUser::new(self.mux_mac)
         );
         self.mux_mac.add_user(udp_mac);
-        let udp_vis = create_static_capability!(UdpVisibilityCapability);
-        let ip_vis = create_static_capability!(IpVisibilityCapability);
-
-
+        let create_cap = create_capability!(capabilities::NetworkCapabilityCreationCapability);
+        let udp_vis = static_init!(UdpVisibilityCapability,
+            UdpVisibilityCapability::new(&create_cap));
+        let ip_vis = static_init!(IpVisibilityCapability,
+            IpVisibilityCapability::new(&create_cap));
 
         let sixlowpan = static_init!(
             sixlowpan_state::Sixlowpan<

--- a/boards/imix/src/imix_components/udp_mux.rs
+++ b/boards/imix/src/imix_components/udp_mux.rs
@@ -41,12 +41,12 @@ use capsules::net::udp::udp_send::MuxUdpSender;
 use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use kernel;
 use kernel::capabilities;
+use kernel::capabilities::{IpVisCap, UdpVisCap};
 use kernel::component::Component;
 use kernel::create_capability;
 use kernel::hil::radio;
 use kernel::hil::time::Alarm;
 use kernel::static_init;
-use kernel::capabilities::{IpVisCap, UdpVisCap};
 
 use sam4l;
 

--- a/boards/imix/src/imix_components/udp_mux.rs
+++ b/boards/imix/src/imix_components/udp_mux.rs
@@ -48,6 +48,8 @@ use kernel::create_capability;
 use kernel::hil::radio;
 use kernel::hil::time::Alarm;
 use kernel::static_init;
+use kernel::capabilities::IpVisCap;
+
 use sam4l;
 
 // The UDP stack requires exactly one of several packet buffers:
@@ -87,6 +89,7 @@ pub struct UDPMuxComponent {
     interface_list: &'static [IPAddr],
     alarm_mux: &'static MuxAlarm<'static, sam4l::ast::Ast<'static>>,
     net_cap: &'static NetworkCapability,
+    ip_vis: &'static dyn IpVisCap,
 }
 
 impl UDPMuxComponent {
@@ -99,6 +102,7 @@ impl UDPMuxComponent {
         interface_list: &'static [IPAddr],
         alarm: &'static MuxAlarm<'static, sam4l::ast::Ast<'static>>,
         net_cap: &'static NetworkCapability,
+        ip_vis: &'static dyn IpVisCap,
     ) -> UDPMuxComponent {
         UDPMuxComponent {
             mux_mac: mux_mac,
@@ -109,6 +113,7 @@ impl UDPMuxComponent {
             interface_list: interface_list,
             alarm_mux: alarm,
             net_cap: net_cap,
+            ip_vis: ip_vis,
         }
     }
 }
@@ -188,6 +193,7 @@ impl Component for UDPMuxComponent {
                 udp_mac,
                 self.dst_mac_addr,
                 self.src_mac_addr,
+                self.ip_vis,
             )
         );
         ipsender_virtual_alarm.set_client(ip_send);

--- a/boards/imix/src/imix_components/udp_mux.rs
+++ b/boards/imix/src/imix_components/udp_mux.rs
@@ -38,6 +38,8 @@ use capsules::net::udp::udp::UDPHeader;
 use capsules::net::udp::udp_port_table::{SocketBindingEntry, UdpPortManager, MAX_NUM_BOUND_PORTS};
 use capsules::net::udp::udp_recv::MuxUdpReceiver;
 use capsules::net::udp::udp_send::MuxUdpSender;
+use capsules::net::network_capabilities::{NetworkCapability};
+
 use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use kernel;
 use kernel::capabilities;
@@ -84,6 +86,7 @@ pub struct UDPMuxComponent {
     src_mac_addr: MacAddress,
     interface_list: &'static [IPAddr],
     alarm_mux: &'static MuxAlarm<'static, sam4l::ast::Ast<'static>>,
+    net_cap: &'static NetworkCapability,
 }
 
 impl UDPMuxComponent {
@@ -95,6 +98,7 @@ impl UDPMuxComponent {
         src_mac_addr: MacAddress,
         interface_list: &'static [IPAddr],
         alarm: &'static MuxAlarm<'static, sam4l::ast::Ast<'static>>,
+        net_cap: &'static NetworkCapability,
     ) -> UDPMuxComponent {
         UDPMuxComponent {
             mux_mac: mux_mac,
@@ -104,6 +108,7 @@ impl UDPMuxComponent {
             src_mac_addr: src_mac_addr,
             interface_list: interface_list,
             alarm_mux: alarm,
+            net_cap: net_cap,
         }
     }
 }
@@ -210,7 +215,7 @@ impl Component for UDPMuxComponent {
                     VirtualMuxAlarm<'static, sam4l::ast::Ast<'static>>,
                 >,
             >,
-            MuxUdpSender::new(ip_send)
+            MuxUdpSender::new(ip_send, self.net_cap)
         );
         ip_send.set_client(udp_send_mux);
 

--- a/boards/imix/src/imix_components/udp_mux.rs
+++ b/boards/imix/src/imix_components/udp_mux.rs
@@ -133,10 +133,14 @@ impl Component for UDPMuxComponent {
         );
         self.mux_mac.add_user(udp_mac);
         let create_cap = create_capability!(capabilities::NetworkCapabilityCreationCapability);
-        let udp_vis = static_init!(UdpVisibilityCapability,
-            UdpVisibilityCapability::new(&create_cap));
-        let ip_vis = static_init!(IpVisibilityCapability,
-            IpVisibilityCapability::new(&create_cap));
+        let udp_vis = static_init!(
+            UdpVisibilityCapability,
+            UdpVisibilityCapability::new(&create_cap)
+        );
+        let ip_vis = static_init!(
+            IpVisibilityCapability,
+            IpVisibilityCapability::new(&create_cap)
+        );
 
         let sixlowpan = static_init!(
             sixlowpan_state::Sixlowpan<

--- a/boards/imix/src/imix_components/udp_mux.rs
+++ b/boards/imix/src/imix_components/udp_mux.rs
@@ -41,7 +41,7 @@ use capsules::net::udp::udp_send::MuxUdpSender;
 use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use kernel;
 use kernel::capabilities;
-use kernel::capabilities::{IpVisCap, UdpVisCap};
+use kernel::capabilities::{IpVisibilityCapability, UdpVisibilityCapability};
 use kernel::component::Component;
 use kernel::{create_capability, create_static_capability};
 use kernel::hil::radio;
@@ -132,8 +132,8 @@ impl Component for UDPMuxComponent {
             capsules::ieee802154::virtual_mac::MacUser::new(self.mux_mac)
         );
         self.mux_mac.add_user(udp_mac);
-        let udp_vis = create_static_capability!(UdpVisCap);
-        let ip_vis = create_static_capability!(IpVisCap);
+        let udp_vis = create_static_capability!(UdpVisibilityCapability);
+        let ip_vis = create_static_capability!(IpVisibilityCapability);
 
 
 

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -441,6 +441,7 @@ pub unsafe fn reset_handler() {
         local_ip_ifaces,
         mux_alarm,
         net_cap,
+        &IP_VIS,
     )
     .finalize(());
 
@@ -452,12 +453,13 @@ pub unsafe fn reset_handler() {
         udp_port_table,
         local_ip_ifaces,
         net_cap,
+        &UDP_VIS,
     )
     .finalize(());
 
     // Only include to run kernel tests, do not include during normal operation
-    //let udp_lowpan_test =
-    //    udp_lowpan_test::initialize_all(udp_send_mux, udp_recv_mux, udp_port_table, mux_alarm);
+    let udp_lowpan_test = udp_lowpan_test::initialize_all(udp_send_mux, udp_recv_mux,
+        udp_port_table, mux_alarm, net_cap, &UDP_VIS);
 
     let imix = Imix {
         pconsole,
@@ -511,7 +513,7 @@ pub unsafe fn reset_handler() {
     debug!("Initialization complete. Entering main loop");
 
     // Include below to run udp tests
-    //udp_lowpan_test.start();
+    udp_lowpan_test.start();
 
     extern "C" {
         /// Beginning of the ROM region containing app images.

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -440,8 +440,8 @@ pub unsafe fn reset_handler() {
         //MacAddress::Short(49138), //comment in for dual rx test only
         local_ip_ifaces,
         mux_alarm,
-        net_cap,
         &IP_VIS,
+        &UDP_VIS,
     )
     .finalize(());
 

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -439,9 +439,9 @@ pub unsafe fn reset_handler() {
     .finalize(());
 
     // Only include to run kernel tests, do not include during normal operation
-    let udp_lowpan_test =
-        udp_lowpan_test::initialize_all(udp_send_mux, udp_recv_mux, udp_port_table, mux_alarm);
-    udp_lowpan_test.start();
+    // let udp_lowpan_test =
+    //     udp_lowpan_test::initialize_all(udp_send_mux, udp_recv_mux, udp_port_table, mux_alarm);
+    // udp_lowpan_test.start();
 
     let imix = Imix {
         pconsole,

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -438,11 +438,6 @@ pub unsafe fn reset_handler() {
     )
     .finalize(());
 
-    // Only include to run kernel tests, do not include during normal operation
-    // let udp_lowpan_test =
-    //     udp_lowpan_test::initialize_all(udp_send_mux, udp_recv_mux, udp_port_table, mux_alarm);
-    // udp_lowpan_test.start();
-
     let imix = Imix {
         pconsole,
         console,
@@ -494,6 +489,9 @@ pub unsafe fn reset_handler() {
 
     debug!("Initialization complete. Entering main loop");
 
+    // Only include to run kernel tests, do not include during normal operation
+    // let udp_lowpan_test =
+    //     udp_lowpan_test::initialize_all(udp_send_mux, udp_recv_mux, udp_port_table, mux_alarm);
     // Include below to run udp tests
     // udp_lowpan_test.start();
 

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -439,12 +439,9 @@ pub unsafe fn reset_handler() {
     .finalize(());
 
     // Only include to run kernel tests, do not include during normal operation
-    // let udp_lowpan_test = udp_lowpan_test::initialize_all(
-    //     udp_send_mux,
-    //     udp_recv_mux,
-    //     udp_port_table,
-    //     mux_alarm,
-    // );
+    let udp_lowpan_test =
+        udp_lowpan_test::initialize_all(udp_send_mux, udp_recv_mux, udp_port_table, mux_alarm);
+    udp_lowpan_test.start();
 
     let imix = Imix {
         pconsole,

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -410,12 +410,6 @@ pub unsafe fn reset_handler() {
         ]
     );
 
-    // TODO: remove commented code below
-    // let net_cap = static_init!(
-    //     NetworkCapability,
-    //     NetworkCapability::new(AddrRange::Any, PortRange::Any, PortRange::Any, &CREATE_CAP)
-    // );
-
     let (udp_send_mux, udp_recv_mux, udp_port_table) = UDPMuxComponent::new(
         mux_mac,
         DEFAULT_CTX_PREFIX_LEN,
@@ -492,8 +486,6 @@ pub unsafe fn reset_handler() {
     // Only include to run kernel tests, do not include during normal operation
     // let udp_lowpan_test =
     //     udp_lowpan_test::initialize_all(udp_send_mux, udp_recv_mux, udp_port_table, mux_alarm);
-    // Include below to run udp tests
-    // udp_lowpan_test.start();
 
     extern "C" {
         /// Beginning of the ROM region containing app images.

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -12,7 +12,7 @@ mod imix_components;
 use capsules::alarm::AlarmDriver;
 use capsules::net::ieee802154::MacAddress;
 use capsules::net::ipv6::ip_utils::IPAddr;
-use capsules::net::network_capabilities::{NetworkCapability, AddrRange, PortRange};
+use capsules::net::network_capabilities::{AddrRange, NetworkCapability, PortRange};
 use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use capsules::virtual_i2c::MuxI2C;
 use capsules::virtual_spi::{MuxSpiMaster, VirtualSpiMasterDevice};

--- a/boards/imix/src/udp_lowpan_test.rs
+++ b/boards/imix/src/udp_lowpan_test.rs
@@ -123,6 +123,7 @@ use capsules::net::udp::udp_recv::MuxUdpReceiver;
 use capsules::net::udp::udp_send::MuxUdpSender;
 use capsules::test::udp::MockUdp;
 use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
+use capsules::net::network_capabilities::{NetworkCapability};
 use core::cell::Cell;
 use kernel::component::Component;
 use kernel::debug;
@@ -165,6 +166,7 @@ pub unsafe fn initialize_all(
     udp_recv_mux: &'static MuxUdpReceiver<'static>,
     port_table: &'static UdpPortManager,
     mux_alarm: &'static MuxAlarm<'static, sam4l::ast::Ast>,
+    net_cap: &'static NetworkCapability,
 ) -> &'static LowpanTest<
     'static,
     capsules::virtual_alarm::VirtualMuxAlarm<'static, sam4l::ast::Ast<'static>>,
@@ -177,6 +179,7 @@ pub unsafe fn initialize_all(
         &mut UDP_PAYLOAD1,
         1, //id
         3, //dst_port
+        net_cap,
     )
     .finalize(());
 
@@ -188,6 +191,7 @@ pub unsafe fn initialize_all(
         &mut UDP_PAYLOAD2,
         2, //id
         4, //dst_port
+        net_cap,
     )
     .finalize(());
 

--- a/boards/imix/src/udp_lowpan_test.rs
+++ b/boards/imix/src/udp_lowpan_test.rs
@@ -293,8 +293,8 @@ impl<'a, A: time::Alarm<'a>> LowpanTest<'a, A> {
                 }
                 match test_id {
                     0 => self.capsule_send_fail(),
-                    1 => self.port_table_test(), // TODO: fix test below!
-                    2 => self.port_table_test2(), //self.port_table_test2(),
+                    1 => self.port_table_test(),
+                    2 => self.port_table_test2(),
                     3 => self.capsule_send_test(),
                     4 => self.addr_range_valid_test(),
                     5 => self.port_range_valid_test(),
@@ -542,24 +542,22 @@ impl<'a, A: time::Alarm<'a>> LowpanTest<'a, A> {
         debug!("PortRange tests passed");
     }
 
-    // TODO: check return codes from send_with_cap
-    // Valid network capability (valid addr, valid port)
-
     fn capsule_send_net_cap_test(
         &self,
         net_cap1: &'static NetworkCapability,
         net_cap2: &'static NetworkCapability,
     ) -> (ReturnCode, ReturnCode) {
         // from capsule send_test
+        self.mock_udp1.update_capability(net_cap1);
         self.mock_udp1.bind(14000);
         self.mock_udp1.set_dst(15000);
+        self.mock_udp2.update_capability(net_cap2);
         self.mock_udp2.bind(14001);
         self.mock_udp2.set_dst(15001);
         // Send from 2 different capsules in quick succession - second send should execute once
-        // first completes!
-        // TODO: construct capabilities.
-        let ret1 = self.mock_udp1.send_with_cap(22, net_cap1);
-        let ret2 = self.mock_udp2.send_with_cap(23, net_cap2);
+        // first completes, assuming valid capabilities for each.
+        let ret1 = self.mock_udp1.send(22);
+        let ret2 = self.mock_udp2.send(23);
         debug!("send_test executed, look at printed results once callbacks arrive");
         (ret1, ret2)
     }
@@ -623,7 +621,7 @@ impl<'a, A: time::Alarm<'a>> LowpanTest<'a, A> {
         let (ret1, ret2) = self.capsule_send_net_cap_test(net_cap1, net_cap2);
         assert_eq!(ret1, ReturnCode::SUCCESS);
         assert_eq!(ret2, ReturnCode::ERESERVE);
-        debug!("send_invalid_net_cap_port test executed, send will fail");
+        debug!("send_invalid_net_cap_port test executed, expect one send with Result: SUCCESS");
     }
 
     // Invalid network capability (invalid addr, valid port)
@@ -651,7 +649,7 @@ impl<'a, A: time::Alarm<'a>> LowpanTest<'a, A> {
         let (ret1, ret2) = self.capsule_send_net_cap_test(net_cap1, net_cap2);
         assert_eq!(ret1, ReturnCode::SUCCESS);
         assert_eq!(ret2, ReturnCode::ERESERVE);
-        debug!("send_invalid_net_cap_addr executed, send will fail");
+        debug!("send_invalid_net_cap_addr executed, expect one send with Result: SUCCESS");
     }
 
     // Invalid network capability (invalid addr, invalid port)
@@ -684,7 +682,9 @@ impl<'a, A: time::Alarm<'a>> LowpanTest<'a, A> {
         let (ret1, ret2) = self.capsule_send_net_cap_test(net_cap1, net_cap2);
         assert_eq!(ret1, ReturnCode::SUCCESS);
         assert_eq!(ret2, ReturnCode::ERESERVE);
-        debug!("send_invalid_net_cap_addr_port test executed, send will fail");
+        debug!(
+            "send_invalid_net_cap_addr_port test executed, expect one send with Result: SUCCESS"
+        );
     }
 }
 

--- a/boards/imix/src/udp_lowpan_test.rs
+++ b/boards/imix/src/udp_lowpan_test.rs
@@ -126,7 +126,7 @@ use capsules::net::udp::udp_send::MuxUdpSender;
 use capsules::test::udp::MockUdp;
 use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use core::cell::Cell;
-use kernel::capabilities::{NetCapCreateCap, UdpVisCap};
+use kernel::capabilities::{NetworkCapabilityCreationCapability, UdpVisibilityCapability};
 use kernel::{create_static_capability};
 use kernel::component::Component;
 use kernel::debug;
@@ -159,7 +159,7 @@ pub struct LowpanTest<'a, A: time::Alarm<'a>> {
     mock_udp1: &'a MockUdp<'a, A>,
     mock_udp2: &'a MockUdp<'a, A>,
     test_mode: Cell<TestMode>,
-    create_cap: &'static dyn NetCapCreateCap,
+    create_cap: &'static dyn NetworkCapabilityCreationCapability,
 }
 
 pub unsafe fn initialize_all(
@@ -174,12 +174,12 @@ pub unsafe fn initialize_all(
     'static,
     capsules::virtual_alarm::VirtualMuxAlarm<'static, sam4l::ast::Ast<'static>>,
 > {
-    let create_cap = create_static_capability!(NetCapCreateCap);
+    let create_cap = create_static_capability!(NetworkCapabilityCreationCapability);
     let net_cap = static_init!(
         NetworkCapability,
         NetworkCapability::new(AddrRange::Any, PortRange::Any, PortRange::Any, create_cap)
     );
-    let udp_vis = create_static_capability!(UdpVisCap);
+    let udp_vis = create_static_capability!(UdpVisibilityCapability);
     let mock_udp1 = MockUDPComponent::new(
         udp_send_mux,
         udp_recv_mux,
@@ -231,7 +231,7 @@ impl<'a, A: time::Alarm<'a>> LowpanTest<'a, A> {
         port_table: &'static UdpPortManager,
         mock_udp1: &'static MockUdp<'a, A>,
         mock_udp2: &'static MockUdp<'a, A>,
-        create_cap: &'static dyn NetCapCreateCap,
+        create_cap: &'static dyn NetworkCapabilityCreationCapability,
     ) -> LowpanTest<'a, A> {
         LowpanTest {
             alarm: alarm,

--- a/boards/imix/src/udp_lowpan_test.rs
+++ b/boards/imix/src/udp_lowpan_test.rs
@@ -299,7 +299,7 @@ impl<'a, A: time::Alarm<'a>> LowpanTest<'a, A> {
                     4 => self.addr_range_valid_test(),
                     5 => self.port_range_valid_test(),
                     6 => self.capsule_send_valid_net_cap_test(),
-                    7 => self.capsule_send_invalid_net_cap_port_test(), // TODO: fix last three
+                    7 => self.capsule_send_invalid_net_cap_port_test(),
                     8 => self.capsule_send_invalid_net_cap_addr_test(),
                     9 => self.capsule_send_invalid_net_cap_addr_port_test(),
                     _ => return,
@@ -465,7 +465,6 @@ impl<'a, A: time::Alarm<'a>> LowpanTest<'a, A> {
     }
 
     // Test network capability enforcement for addrs
-    // TODO: include a positive and negative test for each (as apporpriate)
     fn addr_range_valid_test(&self) {
         let ip_addr1 = IPAddr([
             0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d,

--- a/boards/imix/src/udp_lowpan_test.rs
+++ b/boards/imix/src/udp_lowpan_test.rs
@@ -131,6 +131,8 @@ use kernel::hil::time::Frequency;
 use kernel::hil::time::{self, Alarm};
 use kernel::static_init;
 use kernel::ReturnCode;
+use kernel::capabilities::UdpVisCap;
+
 
 pub const TEST_DELAY_MS: u32 = 2000;
 pub const TEST_LOOP: bool = false;
@@ -167,6 +169,7 @@ pub unsafe fn initialize_all(
     port_table: &'static UdpPortManager,
     mux_alarm: &'static MuxAlarm<'static, sam4l::ast::Ast>,
     net_cap: &'static NetworkCapability,
+    udp_vis: &'static dyn UdpVisCap,
 ) -> &'static LowpanTest<
     'static,
     capsules::virtual_alarm::VirtualMuxAlarm<'static, sam4l::ast::Ast<'static>>,
@@ -180,6 +183,7 @@ pub unsafe fn initialize_all(
         1, //id
         3, //dst_port
         net_cap,
+        udp_vis,
     )
     .finalize(());
 
@@ -192,6 +196,7 @@ pub unsafe fn initialize_all(
         2, //id
         4, //dst_port
         net_cap,
+        udp_vis,
     )
     .finalize(());
 
@@ -279,7 +284,7 @@ impl<'a, A: time::Alarm<'a>> LowpanTest<'a, A> {
                 match test_id {
                     0 => self.capsule_send_fail(),
                     1 => self.port_table_test(),
-                    2 => self.port_table_test2(),
+                    2 => self.port_table_test(),//self.port_table_test2(),
                     3 => self.capsule_send_test(),
                     _ => return,
                 }

--- a/boards/imix/src/udp_lowpan_test.rs
+++ b/boards/imix/src/udp_lowpan_test.rs
@@ -285,7 +285,7 @@ impl<'a, A: time::Alarm<'a>> LowpanTest<'a, A> {
     }
 
     fn num_tests(&self) -> usize {
-        4
+        10
     }
 
     fn run_test(&self, test_id: usize) {
@@ -301,6 +301,12 @@ impl<'a, A: time::Alarm<'a>> LowpanTest<'a, A> {
                     1 => self.port_table_test(),
                     2 => self.port_table_test(),//self.port_table_test2(),
                     3 => self.capsule_send_test(),
+                    4 => self.addr_range_valid_test(),
+                    5 => self.port_range_valid_test(),
+                    6 => self.capsule_send_valid_net_cap_test(),
+                    7 => self.capsule_send_invalid_net_cap_port_test(),
+                    8 => self.capsule_send_invalid_net_cap_addr_test(),
+                    9 => self.capsule_send_invalid_net_cap_addr_port_test(),
                     _ => return,
                 }
             }
@@ -483,8 +489,7 @@ impl<'a, A: time::Alarm<'a>> LowpanTest<'a, A> {
         assert!(subnet.is_addr_valid(ip_addr1));
         assert!(!subnet.is_addr_valid(ip_addr2));
         assert!(subnet.is_addr_valid(ip_addr3));
-
-
+        debug!("AddrRange tests passed");
     }
 
     // Test enforcement for ports
@@ -512,6 +517,7 @@ impl<'a, A: time::Alarm<'a>> LowpanTest<'a, A> {
         let single_port = PortRange::Port(8888);
         assert!(single_port.is_port_valid(8888));
         assert!(!single_port.is_port_valid(8000));
+        debug!("PortRange tests passed");
     }
 
     // TODO: check return codes from send_with_cap
@@ -532,48 +538,56 @@ impl<'a, A: time::Alarm<'a>> LowpanTest<'a, A> {
         debug!("send_test executed, look at printed results once callbacks arrive");
     }
 
-    unsafe fn capsule_send_valid_net_cap_test(&self) {
-        let net_cap1 = static_init!(NetworkCapability,
-            NetworkCapability::new(AddrRange::Any, PortRange::Port(14000),
-            PortRange::Port(15000), &CREATE_CAP));
-        let net_cap2 = static_init!(NetworkCapability,
-            NetworkCapability::new(AddrRange::Any, PortRange::Port(14001),
-            PortRange::Port(15001), &CREATE_CAP));
+    fn capsule_send_valid_net_cap_test(&self) {
+        let net_cap1 = unsafe{static_init!(NetworkCapability,
+            NetworkCapability::new(AddrRange::Any, PortRange::Port(15000),
+            PortRange::Any, &CREATE_CAP))};
+        let net_cap2 = unsafe{static_init!(NetworkCapability,
+            NetworkCapability::new(AddrRange::Any, PortRange::Port(15001),
+            PortRange::Any, &CREATE_CAP))};
         self.capsule_send_net_cap_test(net_cap1, net_cap2);
+        debug!("send_valid_net_cap test executed, look at printed results once callbacks arrive");
+
     }
 
     // Invalid network capability (valid addr, invalid port)
-    unsafe fn capsule_send_invalid_net_cap_port_test(&self) {
-        let net_cap1 = static_init!(NetworkCapability,
-            NetworkCapability::new(AddrRange::Any, PortRange::Port(14000),
-            PortRange::Port(15000), &CREATE_CAP));
+    fn capsule_send_invalid_net_cap_port_test(&self) {
+        let net_cap1 = unsafe{static_init!(NetworkCapability,
+            NetworkCapability::new(AddrRange::Any, PortRange::Port(15001),
+            PortRange::Any, &CREATE_CAP))};
         // net_cap2 has an invalid dst port
-        let net_cap2 = static_init!(NetworkCapability,
-            NetworkCapability::new(AddrRange::Any, PortRange::Port(14001),
-            PortRange::Port(15002), &CREATE_CAP));
+        let net_cap2 = unsafe{static_init!(NetworkCapability,
+            NetworkCapability::new(AddrRange::Any, PortRange::Port(15002),
+            PortRange::Any, &CREATE_CAP))};
         self.capsule_send_net_cap_test(net_cap1, net_cap2);
+                debug!("send_invalid_net_cap_port test executed, look at printed results once callbacks arrive");
+
     }
 
     // Invalid network capability (invalid addr, valid port)
-    unsafe fn capsule_send_invalid_net_cap_addr_test(&self) {
-        let net_cap1 = static_init!(NetworkCapability,
-            NetworkCapability::new(AddrRange::NoAddrs, PortRange::Port(14000),
-            PortRange::Port(15000), &CREATE_CAP));
-        let net_cap2 = static_init!(NetworkCapability,
-            NetworkCapability::new(AddrRange::Any, PortRange::Port(14001),
-            PortRange::Port(15001), &CREATE_CAP));
+    fn capsule_send_invalid_net_cap_addr_test(&self) {
+        let net_cap1 = unsafe{static_init!(NetworkCapability,
+            NetworkCapability::new(AddrRange::NoAddrs, PortRange::Port(15000),
+            PortRange::Any, &CREATE_CAP))};
+        let net_cap2 = unsafe{static_init!(NetworkCapability,
+            NetworkCapability::new(AddrRange::Any, PortRange::Port(15001),
+            PortRange::Any, &CREATE_CAP))};
         self.capsule_send_net_cap_test(net_cap1, net_cap2);
+                debug!("send_invalid_net_cap_addr executed, look at printed results once callbacks arrive");
+
     }
 
     // Invalid network capability (invalid addr, invalid port)
-    unsafe fn capsule_send_invalid_net_cap_addr_port(&self) {
-        let net_cap1 = static_init!(NetworkCapability,
-            NetworkCapability::new(AddrRange::NoAddrs, PortRange::Port(14000),
-            PortRange::Port(15000), &CREATE_CAP));
-        let net_cap2 = static_init!(NetworkCapability,
-            NetworkCapability::new(AddrRange::Any, PortRange::Port(14001),
-            PortRange::Port(15002), &CREATE_CAP));
+    fn capsule_send_invalid_net_cap_addr_port_test(&self) {
+        let net_cap1 = unsafe{static_init!(NetworkCapability,
+            NetworkCapability::new(AddrRange::NoAddrs, PortRange::Port(15000),
+            PortRange::Any, &CREATE_CAP))};
+        let net_cap2 = unsafe{static_init!(NetworkCapability,
+            NetworkCapability::new(AddrRange::Any, PortRange::Port(15002),
+            PortRange::Any, &CREATE_CAP))};
         self.capsule_send_net_cap_test(net_cap1, net_cap2);
+                debug!("send_invalid_net_cap_addr_port test executed, look at printed results once callbacks arrive");
+
     }
 }
 

--- a/capsules/src/net/icmpv6/icmpv6_send.rs
+++ b/capsules/src/net/icmpv6/icmpv6_send.rs
@@ -55,16 +55,13 @@ pub trait ICMP6Sender<'a> {
 pub struct ICMP6SendStruct<'a, T: IP6Sender<'a>> {
     ip_send_struct: &'a T,
     client: OptionalCell<&'a dyn ICMP6SendClient>,
-    net_cap: &'static NetworkCapability,
 }
 
 impl<T: IP6Sender<'a>> ICMP6SendStruct<'a, T> {
-    pub fn new(ip_send_struct: &'a T,
-        net_cap: &'static NetworkCapability) -> ICMP6SendStruct<'a, T> {
+    pub fn new(ip_send_struct: &'a T) -> ICMP6SendStruct<'a, T> {
         ICMP6SendStruct {
             ip_send_struct: ip_send_struct,
             client: OptionalCell::empty(),
-            net_cap: net_cap,
         }
     }
 }

--- a/capsules/src/net/icmpv6/icmpv6_send.rs
+++ b/capsules/src/net/icmpv6/icmpv6_send.rs
@@ -11,7 +11,7 @@ use crate::net::icmpv6::icmpv6::ICMP6Header;
 use crate::net::ipv6::ip_utils::IPAddr;
 use crate::net::ipv6::ipv6::TransportHeader;
 use crate::net::ipv6::ipv6_send::{IP6SendClient, IP6Sender};
-use crate::net::network_capabilities::{NetworkCapability};
+use crate::net::network_capabilities::NetworkCapability;
 use kernel::common::cells::OptionalCell;
 use kernel::common::leasable_buffer::LeasableBuffer;
 use kernel::ReturnCode;
@@ -47,8 +47,13 @@ pub trait ICMP6Sender<'a> {
     /// This function returns a code reporting either success or any
     /// synchronous errors. Note that any asynchronous errors are returned
     /// via the callback.
-    fn send(&self, dest: IPAddr, icmp_header: ICMP6Header, buf: &'static mut [u8],
-        net_cap: &'static NetworkCapability) -> ReturnCode;
+    fn send(
+        &self,
+        dest: IPAddr,
+        icmp_header: ICMP6Header,
+        buf: &'static mut [u8],
+        net_cap: &'static NetworkCapability,
+    ) -> ReturnCode;
 }
 
 /// A struct that implements the `ICMP6Sender` trait.

--- a/capsules/src/net/icmpv6/icmpv6_send.rs
+++ b/capsules/src/net/icmpv6/icmpv6_send.rs
@@ -11,6 +11,7 @@ use crate::net::icmpv6::icmpv6::ICMP6Header;
 use crate::net::ipv6::ip_utils::IPAddr;
 use crate::net::ipv6::ipv6::TransportHeader;
 use crate::net::ipv6::ipv6_send::{IP6SendClient, IP6Sender};
+use crate::net::network_capabilities::{NetworkCapability};
 use kernel::common::cells::OptionalCell;
 use kernel::common::leasable_buffer::LeasableBuffer;
 use kernel::ReturnCode;
@@ -46,20 +47,24 @@ pub trait ICMP6Sender<'a> {
     /// This function returns a code reporting either success or any
     /// synchronous errors. Note that any asynchronous errors are returned
     /// via the callback.
-    fn send(&self, dest: IPAddr, icmp_header: ICMP6Header, buf: &'static mut [u8]) -> ReturnCode;
+    fn send(&self, dest: IPAddr, icmp_header: ICMP6Header, buf: &'static mut [u8],
+        net_cap: &'static NetworkCapability) -> ReturnCode;
 }
 
 /// A struct that implements the `ICMP6Sender` trait.
 pub struct ICMP6SendStruct<'a, T: IP6Sender<'a>> {
     ip_send_struct: &'a T,
     client: OptionalCell<&'a dyn ICMP6SendClient>,
+    net_cap: &'static NetworkCapability,
 }
 
 impl<T: IP6Sender<'a>> ICMP6SendStruct<'a, T> {
-    pub fn new(ip_send_struct: &'a T) -> ICMP6SendStruct<'a, T> {
+    pub fn new(ip_send_struct: &'a T,
+        net_cap: &'static NetworkCapability) -> ICMP6SendStruct<'a, T> {
         ICMP6SendStruct {
             ip_send_struct: ip_send_struct,
             client: OptionalCell::empty(),
+            net_cap: net_cap,
         }
     }
 }
@@ -74,12 +79,13 @@ impl<T: IP6Sender<'a>> ICMP6Sender<'a> for ICMP6SendStruct<'a, T> {
         dest: IPAddr,
         mut icmp_header: ICMP6Header,
         buf: &'static mut [u8],
+        net_cap: &'static NetworkCapability,
     ) -> ReturnCode {
         let total_len = buf.len() + icmp_header.get_hdr_size();
         icmp_header.set_len(total_len as u16);
         let transport_header = TransportHeader::ICMP(icmp_header);
         self.ip_send_struct
-            .send_to(dest, transport_header, &LeasableBuffer::new(buf))
+            .send_to(dest, transport_header, &LeasableBuffer::new(buf), net_cap)
     }
 }
 

--- a/capsules/src/net/ipv6/ipv6_send.rs
+++ b/capsules/src/net/ipv6/ipv6_send.rs
@@ -20,16 +20,15 @@ use crate::ieee802154::device::{MacDevice, TxClient};
 use crate::net::ieee802154::MacAddress;
 use crate::net::ipv6::ip_utils::IPAddr;
 use crate::net::ipv6::ipv6::{IP6Header, IP6Packet, TransportHeader};
-use crate::net::sixlowpan::sixlowpan_state::TxState;
 use crate::net::network_capabilities::NetworkCapability;
+use crate::net::sixlowpan::sixlowpan_state::TxState;
 use core::cell::Cell;
+use kernel::capabilities::IpVisCap;
 use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::common::leasable_buffer::LeasableBuffer;
 use kernel::debug;
 use kernel::hil::time::{self, Frequency};
 use kernel::ReturnCode;
-use kernel::capabilities::IpVisCap;
-
 
 /// This trait must be implemented by upper layers in order to receive
 /// the `send_done` callback when a transmission has completed. The upper

--- a/capsules/src/net/ipv6/ipv6_send.rs
+++ b/capsules/src/net/ipv6/ipv6_send.rs
@@ -23,7 +23,7 @@ use crate::net::ipv6::ipv6::{IP6Header, IP6Packet, TransportHeader};
 use crate::net::network_capabilities::NetworkCapability;
 use crate::net::sixlowpan::sixlowpan_state::TxState;
 use core::cell::Cell;
-use kernel::capabilities::IpVisCap;
+use kernel::capabilities::IpVisibilityCapability;
 use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::common::leasable_buffer::LeasableBuffer;
 use kernel::debug;
@@ -105,7 +105,7 @@ pub struct IP6SendStruct<'a, A: time::Alarm<'a>> {
     dst_mac_addr: MacAddress,
     src_mac_addr: MacAddress,
     client: OptionalCell<&'a dyn IP6SendClient>,
-    ip_vis: &'static dyn IpVisCap,
+    ip_vis: &'static dyn IpVisibilityCapability,
 }
 
 impl<A: time::Alarm<'a>> IP6Sender<'a> for IP6SendStruct<'a, A> {
@@ -157,7 +157,7 @@ impl<A: time::Alarm<'a>> IP6SendStruct<'a, A> {
         radio: &'a dyn MacDevice<'a>,
         dst_mac_addr: MacAddress,
         src_mac_addr: MacAddress,
-        ip_vis: &'static dyn IpVisCap,
+        ip_vis: &'static dyn IpVisibilityCapability,
     ) -> IP6SendStruct<'a, A> {
         IP6SendStruct {
             ip6_packet: TakeCell::new(ip6_packet),

--- a/capsules/src/net/ipv6/ipv6_send.rs
+++ b/capsules/src/net/ipv6/ipv6_send.rs
@@ -21,6 +21,7 @@ use crate::net::ieee802154::MacAddress;
 use crate::net::ipv6::ip_utils::IPAddr;
 use crate::net::ipv6::ipv6::{IP6Header, IP6Packet, TransportHeader};
 use crate::net::sixlowpan::sixlowpan_state::TxState;
+use crate::net::network_capabilities::{NetworkCapability};
 use core::cell::Cell;
 use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::common::leasable_buffer::LeasableBuffer;
@@ -83,6 +84,7 @@ pub trait IP6Sender<'a> {
         dst: IPAddr,
         transport_header: TransportHeader,
         payload: &LeasableBuffer<'static, u8>,
+        net_cap: &'static NetworkCapability,
     ) -> ReturnCode;
 }
 
@@ -127,6 +129,7 @@ impl<A: time::Alarm<'a>> IP6Sender<'a> for IP6SendStruct<'a, A> {
         dst: IPAddr,
         transport_header: TransportHeader,
         payload: &LeasableBuffer<'static, u8>,
+        net_cap: &'static NetworkCapability,
     ) -> ReturnCode {
         self.sixlowpan.init(
             self.src_mac_addr,

--- a/capsules/src/net/ipv6/ipv6_send.rs
+++ b/capsules/src/net/ipv6/ipv6_send.rs
@@ -20,10 +20,9 @@ use crate::ieee802154::device::{MacDevice, TxClient};
 use crate::net::ieee802154::MacAddress;
 use crate::net::ipv6::ip_utils::IPAddr;
 use crate::net::ipv6::ipv6::{IP6Header, IP6Packet, TransportHeader};
-use crate::net::network_capabilities::NetworkCapability;
+use crate::net::network_capabilities::{NetworkCapability, IpVisibilityCapability};
 use crate::net::sixlowpan::sixlowpan_state::TxState;
 use core::cell::Cell;
-use kernel::capabilities::IpVisibilityCapability;
 use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::common::leasable_buffer::LeasableBuffer;
 use kernel::debug;
@@ -105,7 +104,7 @@ pub struct IP6SendStruct<'a, A: time::Alarm<'a>> {
     dst_mac_addr: MacAddress,
     src_mac_addr: MacAddress,
     client: OptionalCell<&'a dyn IP6SendClient>,
-    ip_vis: &'static dyn IpVisibilityCapability,
+    ip_vis: &'static IpVisibilityCapability,
 }
 
 impl<A: time::Alarm<'a>> IP6Sender<'a> for IP6SendStruct<'a, A> {
@@ -157,7 +156,7 @@ impl<A: time::Alarm<'a>> IP6SendStruct<'a, A> {
         radio: &'a dyn MacDevice<'a>,
         dst_mac_addr: MacAddress,
         src_mac_addr: MacAddress,
-        ip_vis: &'static dyn IpVisibilityCapability,
+        ip_vis: &'static IpVisibilityCapability,
     ) -> IP6SendStruct<'a, A> {
         IP6SendStruct {
             ip6_packet: TakeCell::new(ip6_packet),

--- a/capsules/src/net/ipv6/ipv6_send.rs
+++ b/capsules/src/net/ipv6/ipv6_send.rs
@@ -20,7 +20,7 @@ use crate::ieee802154::device::{MacDevice, TxClient};
 use crate::net::ieee802154::MacAddress;
 use crate::net::ipv6::ip_utils::IPAddr;
 use crate::net::ipv6::ipv6::{IP6Header, IP6Packet, TransportHeader};
-use crate::net::network_capabilities::{NetworkCapability, IpVisibilityCapability};
+use crate::net::network_capabilities::{IpVisibilityCapability, NetworkCapability};
 use crate::net::sixlowpan::sixlowpan_state::TxState;
 use core::cell::Cell;
 use kernel::common::cells::{OptionalCell, TakeCell};

--- a/capsules/src/net/mod.rs
+++ b/capsules/src/net/mod.rs
@@ -8,7 +8,7 @@ pub mod stream;
 pub mod icmpv6;
 pub mod ieee802154;
 pub mod ipv6;
+pub mod network_capabilities;
 pub mod tcp;
 pub mod thread;
 pub mod udp;
-pub mod network_capabilities;

--- a/capsules/src/net/mod.rs
+++ b/capsules/src/net/mod.rs
@@ -11,3 +11,4 @@ pub mod ipv6;
 pub mod tcp;
 pub mod thread;
 pub mod udp;
+pub mod network_capabilities;

--- a/capsules/src/net/network_capabilities.rs
+++ b/capsules/src/net/network_capabilities.rs
@@ -6,7 +6,6 @@ const MAX_PORT_SET_SIZE: usize = 8;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum AddrRange {
-    // TODO: change u32 to IPAddr type (inclusion weirdness?)
     Any, // Any address
     NoAddrs,
     AddrSet([IPAddr; MAX_ADDR_SET_SIZE]),
@@ -59,9 +58,6 @@ impl PortRange {
 
 // Make the structs below implement an unsafe trait to make them only
 // constructable in trusted code.
-
-// TODO: remove copy eventually!!!!
-//#[derive(Clone, Copy, PartialEq)]
 pub struct NetworkCapability {
     // can potentially add more
     remote_addrs: AddrRange,

--- a/capsules/src/net/network_capabilities.rs
+++ b/capsules/src/net/network_capabilities.rs
@@ -1,3 +1,23 @@
+//! Capabilities for specifying capsule access to network resources
+//!
+//! A network capability specifies (1) with what IP addresses the holder of the
+//! capability may communicate, (2) from which UDP ports the holder may send,
+//! and (3) to which UDP ports the holder may send. In order to express various
+//! ranges of IP addresses, one uses the AddrRange enum. One specifies ranges of
+//! ports using the PortRange enum.
+//!
+//! Capsules must obtain static references to network capabilities from trusted
+//! code (i.e. code that must use the unsafe keyword) since the constructor of
+//! a network capability requires the NetCapCreateCap capability. Code that
+//! checks these capabilities must possess the appropriate visibilty privileges.
+//! UDP visibility privileges are given through the UdpVisCap capability and IP
+//! visibility privileges are given through the IpVisCap capability.
+//!
+//! An example of the visibility capabilities can be found in udp_port_table.rs.
+//! When attempting to bind to a port, we must first verify that the caller of
+//! bind has a capability to send from that port. Therefore, we check the
+//! network capability of the caller. In order to check the UDP-specific aspect
+//! of the network capability, the port table must posses a UdpVisCap reference.
 use crate::net::ipv6::ip_utils::IPAddr;
 use kernel::capabilities::{IpVisCap, NetCapCreateCap, UdpVisCap};
 
@@ -56,8 +76,9 @@ impl PortRange {
     }
 }
 
-// Make the structs below implement an unsafe trait to make them only
-// constructable in trusted code.
+/// The NetworkCapability struct specifies remote IP addresses with which the
+/// holder may communicate (remote_addrs), ports from which the holder may send
+/// (local_ports), and ports to which the holder may send (remote_ports).
 pub struct NetworkCapability {
     // can potentially add more
     remote_addrs: AddrRange,

--- a/capsules/src/net/network_capabilities.rs
+++ b/capsules/src/net/network_capabilities.rs
@@ -1,5 +1,6 @@
 use core::cell::Cell;
 use kernel::capabilities::{UdpVisCap, IpVisCap, NetCapCreateCap};
+use crate::net::ipv6::ip_utils::IPAddr;
 
 const MAX_ADDR_SET_SIZE: usize = 16;
 const MAX_PORT_SET_SIZE: usize = 16;
@@ -10,20 +11,19 @@ const MAX_NUM_CAPSULES: usize = 32;
 pub enum AddrRange { // TODO: change u32 to IPAddr type (inclusion weirdness?)
     Any, // Any address
     NoAddrs,
-    AddrSet([u32; MAX_ADDR_SET_SIZE]),
-    Range(u32, u32),
-    Addr(u32),
+    AddrSet([IPAddr; MAX_ADDR_SET_SIZE]),
+    Addr(IPAddr),
+    // TODO: add range for IP addrs.
 }
 
 impl AddrRange {
-    pub fn is_addr_valid(&self, addr: u32) -> bool {
+    pub fn is_addr_valid(&self, addr: IPAddr) -> bool {
         match self {
             AddrRange::Any => true,
             AddrRange::NoAddrs => false,
             AddrRange::AddrSet(allowed_addrs) =>
                 allowed_addrs.iter().any(|&a| a == addr),
-            AddrRange::Range(low, high) => (*low <= addr && addr <= *high),
-            AddrRange::Addr(allowed_addr) => addr == *allowed_addr,
+            AddrRange::Addr(allowed_addr) => addr == *allowed_addr, //TODO: refs?
         }
     }
 }
@@ -80,7 +80,8 @@ impl NetworkCapability {
         self.remote_addrs
     }
 
-    pub fn remote_addr_valid(&self, remote_addr: u32, ip_cap: & dyn IpVisCap) -> bool {
+    pub fn remote_addr_valid(&self, remote_addr: IPAddr, ip_cap: & dyn IpVisCap)
+        -> bool {
         self.remote_addrs.is_addr_valid(remote_addr)
     }
 

--- a/capsules/src/net/network_capabilities.rs
+++ b/capsules/src/net/network_capabilities.rs
@@ -1,5 +1,5 @@
 use core::cell::Cell;
-use core::marker::PhantomData;
+use kernel::capabilities::{UdpVisCap, IpVisCap, NetCapCreateCap};
 
 const MAX_ADDR_SET_SIZE: usize = 16;
 const MAX_PORT_SET_SIZE: usize = 16;
@@ -54,11 +54,6 @@ impl PortRange {
 
 // Make the structs below implement an unsafe trait to make them only
 // constructable in trusted code.
-pub struct UdpVisCap {}
-
-pub struct IpVisCap {}
-
-pub struct NetCapCreateCap {}
 
 // TODO: remove copy eventually!!!!
 #[derive(Clone, Copy, PartialEq)]
@@ -72,7 +67,7 @@ pub struct NetworkCapability {
 
 impl NetworkCapability {
     pub fn new(remote_addrs: AddrRange, remote_ports: PortRange,
-        local_ports: PortRange, create_net_cap: &NetCapCreateCap)
+        local_ports: PortRange, create_net_cap: & dyn NetCapCreateCap)
         -> NetworkCapability {
             NetworkCapability {
                 remote_addrs: remote_addrs,
@@ -81,27 +76,27 @@ impl NetworkCapability {
             }
     }
 
-    pub fn get_range(&self, ip_cap: &IpVisCap) -> AddrRange {
+    pub fn get_range(&self, ip_cap: & dyn IpVisCap) -> AddrRange {
         self.remote_addrs
     }
 
-    pub fn remote_addr_valid(&self, remote_addr: u32, ip_cap: &IpVisCap) -> bool {
+    pub fn remote_addr_valid(&self, remote_addr: u32, ip_cap: & dyn IpVisCap) -> bool {
         self.remote_addrs.is_addr_valid(remote_addr)
     }
 
-    pub fn get_remote_ports(&self, udp_cap: &UdpVisCap) -> PortRange {
+    pub fn get_remote_ports(&self, udp_cap: & dyn UdpVisCap) -> PortRange {
         self.remote_ports
     }
 
-    pub fn get_local_ports(&self, udp_cap: &UdpVisCap) -> PortRange {
+    pub fn get_local_ports(&self, udp_cap: & dyn UdpVisCap) -> PortRange {
         self.local_ports
     }
 
-    pub fn remote_port_valid(&self, remote_port: u16, udp_cap: &UdpVisCap) -> bool {
+    pub fn remote_port_valid(&self, remote_port: u16, udp_cap: & dyn UdpVisCap) -> bool {
         self.remote_ports.is_port_valid(remote_port)
     }
 
-    pub fn local_port_valid(&self, local_port: u16, udp_cap: &UdpVisCap) -> bool {
+    pub fn local_port_valid(&self, local_port: u16, udp_cap: & dyn UdpVisCap) -> bool {
         self.local_ports.is_port_valid(local_port)
     }
     

--- a/capsules/src/net/network_capabilities.rs
+++ b/capsules/src/net/network_capabilities.rs
@@ -1,11 +1,12 @@
-use kernel::capabilities::{UdpVisCap, IpVisCap, NetCapCreateCap};
 use crate::net::ipv6::ip_utils::IPAddr;
+use kernel::capabilities::{IpVisCap, NetCapCreateCap, UdpVisCap};
 
 const MAX_ADDR_SET_SIZE: usize = 8;
 const MAX_PORT_SET_SIZE: usize = 8;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub enum AddrRange { // TODO: change u32 to IPAddr type (inclusion weirdness?)
+pub enum AddrRange {
+    // TODO: change u32 to IPAddr type (inclusion weirdness?)
     Any, // Any address
     NoAddrs,
     AddrSet([IPAddr; MAX_ADDR_SET_SIZE]),
@@ -18,24 +19,22 @@ impl AddrRange {
         match self {
             AddrRange::Any => true,
             AddrRange::NoAddrs => false,
-            AddrRange::AddrSet(allowed_addrs) =>
-                allowed_addrs.iter().any(|&a| a == addr),
+            AddrRange::AddrSet(allowed_addrs) => allowed_addrs.iter().any(|&a| a == addr),
             AddrRange::Addr(allowed_addr) => addr == *allowed_addr, //TODO: refs?
             AddrRange::Subnet(allowed_addr, prefix_len) => {
-                let full_bytes: usize = prefix_len/8;
-                let remainder_bits: usize = prefix_len%8;
+                let full_bytes: usize = prefix_len / 8;
+                let remainder_bits: usize = prefix_len % 8;
                 // initial bytes -- TODO: edge case
                 if &allowed_addr.0[0..full_bytes] != &addr.0[0..full_bytes] {
                     false
                 } else {
-                    allowed_addr.0[full_bytes] >> (8 - remainder_bits) == 
                     allowed_addr.0[full_bytes] >> (8 - remainder_bits)
+                        == allowed_addr.0[full_bytes] >> (8 - remainder_bits)
                 }
             }
         }
     }
 }
-
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum PortRange {
@@ -51,14 +50,12 @@ impl PortRange {
         match self {
             PortRange::Any => true,
             PortRange::NoPorts => false,
-            PortRange::PortSet(allowed_ports) =>
-                allowed_ports.iter().any(|&p| p == port), // TODO: check refs
+            PortRange::PortSet(allowed_ports) => allowed_ports.iter().any(|&p| p == port), // TODO: check refs
             PortRange::Range(low, high) => (*low <= port && port <= *high),
             PortRange::Port(allowed_port) => port == *allowed_port,
         }
     }
 }
-
 
 // Make the structs below implement an unsafe trait to make them only
 // constructable in trusted code.
@@ -69,44 +66,44 @@ pub struct NetworkCapability {
     // can potentially add more
     remote_addrs: AddrRange,
     remote_ports: PortRange, // dst
-    local_ports: PortRange, // src
-
+    local_ports: PortRange,  // src
 }
 
 impl NetworkCapability {
-    pub fn new(remote_addrs: AddrRange, remote_ports: PortRange,
-        local_ports: PortRange, _create_net_cap: & dyn NetCapCreateCap)
-        -> NetworkCapability {
-            NetworkCapability {
-                remote_addrs: remote_addrs,
-                remote_ports: remote_ports,
-                local_ports: local_ports,
-            }
+    pub fn new(
+        remote_addrs: AddrRange,
+        remote_ports: PortRange,
+        local_ports: PortRange,
+        _create_net_cap: &dyn NetCapCreateCap,
+    ) -> NetworkCapability {
+        NetworkCapability {
+            remote_addrs: remote_addrs,
+            remote_ports: remote_ports,
+            local_ports: local_ports,
+        }
     }
 
-    pub fn get_range(&self, _ip_cap: & dyn IpVisCap) -> AddrRange {
+    pub fn get_range(&self, _ip_cap: &dyn IpVisCap) -> AddrRange {
         self.remote_addrs
     }
 
-    pub fn remote_addr_valid(&self, remote_addr: IPAddr, _ip_cap: & dyn IpVisCap)
-        -> bool {
+    pub fn remote_addr_valid(&self, remote_addr: IPAddr, _ip_cap: &dyn IpVisCap) -> bool {
         self.remote_addrs.is_addr_valid(remote_addr)
     }
 
-    pub fn get_remote_ports(&self, _udp_cap: & dyn UdpVisCap) -> PortRange {
+    pub fn get_remote_ports(&self, _udp_cap: &dyn UdpVisCap) -> PortRange {
         self.remote_ports
     }
 
-    pub fn get_local_ports(&self, _udp_cap: & dyn UdpVisCap) -> PortRange {
+    pub fn get_local_ports(&self, _udp_cap: &dyn UdpVisCap) -> PortRange {
         self.local_ports
     }
 
-    pub fn remote_port_valid(&self, remote_port: u16, _udp_cap: & dyn UdpVisCap) -> bool {
+    pub fn remote_port_valid(&self, remote_port: u16, _udp_cap: &dyn UdpVisCap) -> bool {
         self.remote_ports.is_port_valid(remote_port)
     }
 
-    pub fn local_port_valid(&self, local_port: u16, _udp_cap: & dyn UdpVisCap) -> bool {
+    pub fn local_port_valid(&self, local_port: u16, _udp_cap: &dyn UdpVisCap) -> bool {
         self.local_ports.is_port_valid(local_port)
     }
-    
 }

--- a/capsules/src/net/network_capabilities.rs
+++ b/capsules/src/net/network_capabilities.rs
@@ -23,7 +23,7 @@ use crate::net::ipv6::ip_utils::IPAddr;
 const MAX_ADDR_SET_SIZE: usize = 8;
 const MAX_PORT_SET_SIZE: usize = 8;
 
-use kernel::capabilities::{UdpVisibilityCapability, IpVisibilityCapability, NetworkCapabilityCreationCapability};
+use kernel::capabilities::{NetworkCapabilityCreationCapability};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum AddrRange {
@@ -77,6 +77,31 @@ impl PortRange {
     }
 }
 
+/// The UdpVisibilityCapability and IpVisibilityCapability has an empty private
+/// field to make it so the only way to create these structs is via a call to
+/// `new` which requires a NetworkCapabilityCreationCapability. 
+pub struct UdpVisibilityCapability {
+    _priv: (), // an empty private field
+}
+
+pub struct IpVisibilityCapability {
+    _priv: (), // an empty private field
+}
+
+impl UdpVisibilityCapability {
+    pub fn new(_create_net_cap: &dyn NetworkCapabilityCreationCapability)
+        -> UdpVisibilityCapability {
+        UdpVisibilityCapability {_priv: ()}
+    }
+}
+
+impl IpVisibilityCapability {
+    pub fn new(_create_net_cap: &dyn NetworkCapabilityCreationCapability)
+        -> IpVisibilityCapability {
+        IpVisibilityCapability {_priv: ()}
+    }
+}
+
 /// The NetworkCapability specifies access to network resourcess across the UDP
 /// and IP layers. Access to layer-specific information is mediated by the
 /// UdpVsibilityCapability and the IpVisibilityCapability. 
@@ -101,27 +126,27 @@ impl NetworkCapability {
         }
     }
 
-    pub fn get_range(&self, _ip_cap: &dyn IpVisibilityCapability) -> AddrRange {
+    pub fn get_range(&self, _ip_cap: &'static IpVisibilityCapability) -> AddrRange {
         self.remote_addrs
     }
 
-    pub fn remote_addr_valid(&self, remote_addr: IPAddr, _ip_cap: &dyn IpVisibilityCapability) -> bool {
+    pub fn remote_addr_valid(&self, remote_addr: IPAddr, _ip_cap: &'static IpVisibilityCapability) -> bool {
         self.remote_addrs.is_addr_valid(remote_addr)
     }
 
-    pub fn get_remote_ports(&self, _udp_cap: &dyn UdpVisibilityCapability) -> PortRange {
+    pub fn get_remote_ports(&self, _udp_cap: &'static UdpVisibilityCapability) -> PortRange {
         self.remote_ports
     }
 
-    pub fn get_local_ports(&self, _udp_cap: &dyn UdpVisibilityCapability) -> PortRange {
+    pub fn get_local_ports(&self, _udp_cap: &'static UdpVisibilityCapability) -> PortRange {
         self.local_ports
     }
 
-    pub fn remote_port_valid(&self, remote_port: u16, _udp_cap: &dyn UdpVisibilityCapability) -> bool {
+    pub fn remote_port_valid(&self, remote_port: u16, _udp_cap: &'static UdpVisibilityCapability) -> bool {
         self.remote_ports.is_port_valid(remote_port)
     }
 
-    pub fn local_port_valid(&self, local_port: u16, _udp_cap: &dyn UdpVisibilityCapability) -> bool {
+    pub fn local_port_valid(&self, local_port: u16, _udp_cap: &'static UdpVisibilityCapability) -> bool {
         self.local_ports.is_port_valid(local_port)
     }
 }

--- a/capsules/src/net/network_capabilities.rs
+++ b/capsules/src/net/network_capabilities.rs
@@ -23,7 +23,7 @@ use crate::net::ipv6::ip_utils::IPAddr;
 const MAX_ADDR_SET_SIZE: usize = 8;
 const MAX_PORT_SET_SIZE: usize = 8;
 
-use kernel::capabilities::{NetworkCapabilityCreationCapability};
+use kernel::capabilities::NetworkCapabilityCreationCapability;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum AddrRange {
@@ -79,7 +79,7 @@ impl PortRange {
 
 /// The UdpVisibilityCapability and IpVisibilityCapability has an empty private
 /// field to make it so the only way to create these structs is via a call to
-/// `new` which requires a NetworkCapabilityCreationCapability. 
+/// `new` which requires a NetworkCapabilityCreationCapability.
 pub struct UdpVisibilityCapability {
     _priv: (), // an empty private field
 }
@@ -89,22 +89,24 @@ pub struct IpVisibilityCapability {
 }
 
 impl UdpVisibilityCapability {
-    pub fn new(_create_net_cap: &dyn NetworkCapabilityCreationCapability)
-        -> UdpVisibilityCapability {
-        UdpVisibilityCapability {_priv: ()}
+    pub fn new(
+        _create_net_cap: &dyn NetworkCapabilityCreationCapability,
+    ) -> UdpVisibilityCapability {
+        UdpVisibilityCapability { _priv: () }
     }
 }
 
 impl IpVisibilityCapability {
-    pub fn new(_create_net_cap: &dyn NetworkCapabilityCreationCapability)
-        -> IpVisibilityCapability {
-        IpVisibilityCapability {_priv: ()}
+    pub fn new(
+        _create_net_cap: &dyn NetworkCapabilityCreationCapability,
+    ) -> IpVisibilityCapability {
+        IpVisibilityCapability { _priv: () }
     }
 }
 
 /// The NetworkCapability specifies access to network resourcess across the UDP
 /// and IP layers. Access to layer-specific information is mediated by the
-/// UdpVsibilityCapability and the IpVisibilityCapability. 
+/// UdpVsibilityCapability and the IpVisibilityCapability.
 pub struct NetworkCapability {
     // can potentially add more
     remote_addrs: AddrRange, // IP addresses with which the holder may communicate
@@ -130,7 +132,11 @@ impl NetworkCapability {
         self.remote_addrs
     }
 
-    pub fn remote_addr_valid(&self, remote_addr: IPAddr, _ip_cap: &'static IpVisibilityCapability) -> bool {
+    pub fn remote_addr_valid(
+        &self,
+        remote_addr: IPAddr,
+        _ip_cap: &'static IpVisibilityCapability,
+    ) -> bool {
         self.remote_addrs.is_addr_valid(remote_addr)
     }
 
@@ -142,11 +148,19 @@ impl NetworkCapability {
         self.local_ports
     }
 
-    pub fn remote_port_valid(&self, remote_port: u16, _udp_cap: &'static UdpVisibilityCapability) -> bool {
+    pub fn remote_port_valid(
+        &self,
+        remote_port: u16,
+        _udp_cap: &'static UdpVisibilityCapability,
+    ) -> bool {
         self.remote_ports.is_port_valid(remote_port)
     }
 
-    pub fn local_port_valid(&self, local_port: u16, _udp_cap: &'static UdpVisibilityCapability) -> bool {
+    pub fn local_port_valid(
+        &self,
+        local_port: u16,
+        _udp_cap: &'static UdpVisibilityCapability,
+    ) -> bool {
         self.local_ports.is_port_valid(local_port)
     }
 }

--- a/capsules/src/net/network_capabilities.rs
+++ b/capsules/src/net/network_capabilities.rs
@@ -1,0 +1,108 @@
+use core::cell::Cell;
+use core::marker::PhantomData;
+
+const MAX_ADDR_SET_SIZE: usize = 16;
+const MAX_PORT_SET_SIZE: usize = 16;
+const MAX_NUM_CAPAB: usize = 16;
+const MAX_NUM_CAPSULES: usize = 32;
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum AddrRange { // TODO: change u32 to IPAddr type (inclusion weirdness?)
+    Any, // Any address
+    NoAddrs,
+    AddrSet([u32; MAX_ADDR_SET_SIZE]),
+    Range(u32, u32),
+    Addr(u32),
+}
+
+impl AddrRange {
+    pub fn is_addr_valid(&self, addr: u32) -> bool {
+        match self {
+            AddrRange::Any => true,
+            AddrRange::NoAddrs => false,
+            AddrRange::AddrSet(allowed_addrs) =>
+                allowed_addrs.iter().any(|&a| a == addr),
+            AddrRange::Range(low, high) => (*low <= addr && addr <= *high),
+            AddrRange::Addr(allowed_addr) => addr == *allowed_addr,
+        }
+    }
+}
+
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum PortRange {
+    Any,
+    NoPorts,
+    PortSet([u16; MAX_PORT_SET_SIZE]),
+    Range(u16, u16),
+    Port(u16),
+}
+
+impl PortRange {
+    pub fn is_port_valid(&self, port: u16) -> bool {
+        match self {
+            PortRange::Any => true,
+            PortRange::NoPorts => false,
+            PortRange::PortSet(allowed_ports) =>
+                allowed_ports.iter().any(|&p| p == port), // TODO: check refs
+            PortRange::Range(low, high) => (*low <= port && port <= *high),
+            PortRange::Port(allowed_port) => port == *allowed_port,
+        }
+    }
+}
+
+
+// Make the structs below implement an unsafe trait to make them only
+// constructable in trusted code.
+pub struct UdpVisCap {}
+
+pub struct IpVisCap {}
+
+pub struct NetCapCreateCap {}
+
+// TODO: remove copy eventually!!!!
+#[derive(Clone, Copy, PartialEq)]
+pub struct NetworkCapability {
+    // can potentially add more
+    remote_addrs: AddrRange,
+    remote_ports: PortRange, // dst
+    local_ports: PortRange, // src
+
+}
+
+impl NetworkCapability {
+    pub fn new(remote_addrs: AddrRange, remote_ports: PortRange,
+        local_ports: PortRange, create_net_cap: &NetCapCreateCap)
+        -> NetworkCapability {
+            NetworkCapability {
+                remote_addrs: remote_addrs,
+                remote_ports: remote_ports,
+                local_ports: local_ports,
+            }
+    }
+
+    pub fn get_range(&self, ip_cap: &IpVisCap) -> AddrRange {
+        self.remote_addrs
+    }
+
+    pub fn remote_addr_valid(&self, remote_addr: u32, ip_cap: &IpVisCap) -> bool {
+        self.remote_addrs.is_addr_valid(remote_addr)
+    }
+
+    pub fn get_remote_ports(&self, udp_cap: &UdpVisCap) -> PortRange {
+        self.remote_ports
+    }
+
+    pub fn get_local_ports(&self, udp_cap: &UdpVisCap) -> PortRange {
+        self.local_ports
+    }
+
+    pub fn remote_port_valid(&self, remote_port: u16, udp_cap: &UdpVisCap) -> bool {
+        self.remote_ports.is_port_valid(remote_port)
+    }
+
+    pub fn local_port_valid(&self, local_port: u16, udp_cap: &UdpVisCap) -> bool {
+        self.local_ports.is_port_valid(local_port)
+    }
+    
+}

--- a/capsules/src/net/network_capabilities.rs
+++ b/capsules/src/net/network_capabilities.rs
@@ -8,21 +8,22 @@
 //!
 //! Capsules must obtain static references to network capabilities from trusted
 //! code (i.e. code that must use the unsafe keyword) since the constructor of
-//! a network capability requires the NetCapCreateCap capability. Code that
+//! a network capability requires the NetworkCapabilityCreationCapability capability. Code that
 //! checks these capabilities must possess the appropriate visibilty privileges.
-//! UDP visibility privileges are given through the UdpVisCap capability and IP
-//! visibility privileges are given through the IpVisCap capability.
+//! UDP visibility privileges are given through the UdpVisibilityCapability capability and IP
+//! visibility privileges are given through the IpVisibilityCapability capability.
 //!
 //! An example of the visibility capabilities can be found in udp_port_table.rs.
 //! When attempting to bind to a port, we must first verify that the caller of
 //! bind has a capability to send from that port. Therefore, we check the
 //! network capability of the caller. In order to check the UDP-specific aspect
-//! of the network capability, the port table must posses a UdpVisCap reference.
+//! of the network capability, the port table must posses a UdpVisibilityCapability reference.
 use crate::net::ipv6::ip_utils::IPAddr;
-use kernel::capabilities::{IpVisCap, NetCapCreateCap, UdpVisCap};
 
 const MAX_ADDR_SET_SIZE: usize = 8;
 const MAX_PORT_SET_SIZE: usize = 8;
+
+use kernel::capabilities::{UdpVisibilityCapability, IpVisibilityCapability, NetworkCapabilityCreationCapability};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum AddrRange {
@@ -76,14 +77,14 @@ impl PortRange {
     }
 }
 
-/// The NetworkCapability struct specifies remote IP addresses with which the
-/// holder may communicate (remote_addrs), ports from which the holder may send
-/// (local_ports), and ports to which the holder may send (remote_ports).
+/// The NetworkCapability specifies access to network resourcess across the UDP
+/// and IP layers. Access to layer-specific information is mediated by the
+/// UdpVsibilityCapability and the IpVisibilityCapability. 
 pub struct NetworkCapability {
     // can potentially add more
-    remote_addrs: AddrRange,
-    remote_ports: PortRange, // dst
-    local_ports: PortRange,  // src
+    remote_addrs: AddrRange, // IP addresses with which the holder may communicate
+    remote_ports: PortRange, // ports to which the holder may send
+    local_ports: PortRange,  // ports from which the holder may send
 }
 
 impl NetworkCapability {
@@ -91,7 +92,7 @@ impl NetworkCapability {
         remote_addrs: AddrRange,
         remote_ports: PortRange,
         local_ports: PortRange,
-        _create_net_cap: &dyn NetCapCreateCap,
+        _create_net_cap: &dyn NetworkCapabilityCreationCapability,
     ) -> NetworkCapability {
         NetworkCapability {
             remote_addrs: remote_addrs,
@@ -100,27 +101,27 @@ impl NetworkCapability {
         }
     }
 
-    pub fn get_range(&self, _ip_cap: &dyn IpVisCap) -> AddrRange {
+    pub fn get_range(&self, _ip_cap: &dyn IpVisibilityCapability) -> AddrRange {
         self.remote_addrs
     }
 
-    pub fn remote_addr_valid(&self, remote_addr: IPAddr, _ip_cap: &dyn IpVisCap) -> bool {
+    pub fn remote_addr_valid(&self, remote_addr: IPAddr, _ip_cap: &dyn IpVisibilityCapability) -> bool {
         self.remote_addrs.is_addr_valid(remote_addr)
     }
 
-    pub fn get_remote_ports(&self, _udp_cap: &dyn UdpVisCap) -> PortRange {
+    pub fn get_remote_ports(&self, _udp_cap: &dyn UdpVisibilityCapability) -> PortRange {
         self.remote_ports
     }
 
-    pub fn get_local_ports(&self, _udp_cap: &dyn UdpVisCap) -> PortRange {
+    pub fn get_local_ports(&self, _udp_cap: &dyn UdpVisibilityCapability) -> PortRange {
         self.local_ports
     }
 
-    pub fn remote_port_valid(&self, remote_port: u16, _udp_cap: &dyn UdpVisCap) -> bool {
+    pub fn remote_port_valid(&self, remote_port: u16, _udp_cap: &dyn UdpVisibilityCapability) -> bool {
         self.remote_ports.is_port_valid(remote_port)
     }
 
-    pub fn local_port_valid(&self, local_port: u16, _udp_cap: &dyn UdpVisCap) -> bool {
+    pub fn local_port_valid(&self, local_port: u16, _udp_cap: &dyn UdpVisibilityCapability) -> bool {
         self.local_ports.is_port_valid(local_port)
     }
 }

--- a/capsules/src/net/udp/driver.rs
+++ b/capsules/src/net/udp/driver.rs
@@ -9,6 +9,7 @@
 /// Syscall number
 use crate::driver;
 use crate::net::ipv6::ip_utils::IPAddr;
+use crate::net::network_capabilities::NetworkCapability;
 use crate::net::stream::encode_u16;
 use crate::net::stream::encode_u8;
 use crate::net::stream::SResult;
@@ -22,7 +23,6 @@ use kernel::capabilities::UdpDriverCapability;
 use kernel::common::cells::MapCell;
 use kernel::common::leasable_buffer::LeasableBuffer;
 use kernel::{debug, AppId, AppSlice, Callback, Driver, Grant, ReturnCode, Shared};
-use crate::net::network_capabilities::{NetworkCapability};
 pub const DRIVER_NUM: usize = driver::NUM::Udp as usize;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -107,7 +107,7 @@ impl<'a> UDPDriver<'a> {
         port_table: &'static UdpPortManager,
         kernel_buffer: LeasableBuffer<'static, u8>,
         driver_send_cap: &'static dyn UdpDriverCapability,
-        net_cap: &'static NetworkCapability
+        net_cap: &'static NetworkCapability,
     ) -> UDPDriver<'a> {
         UDPDriver {
             sender: sender,

--- a/capsules/src/net/udp/driver.rs
+++ b/capsules/src/net/udp/driver.rs
@@ -22,6 +22,7 @@ use kernel::capabilities::UdpDriverCapability;
 use kernel::common::cells::MapCell;
 use kernel::common::leasable_buffer::LeasableBuffer;
 use kernel::{debug, AppId, AppSlice, Callback, Driver, Grant, ReturnCode, Shared};
+use crate::net::network_capabilities::{NetworkCapability};
 pub const DRIVER_NUM: usize = driver::NUM::Udp as usize;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -93,6 +94,8 @@ pub struct UDPDriver<'a> {
     kernel_buffer: MapCell<LeasableBuffer<'static, u8>>,
 
     driver_send_cap: &'static dyn UdpDriverCapability,
+
+    net_cap: &'static NetworkCapability,
 }
 
 impl<'a> UDPDriver<'a> {
@@ -104,6 +107,7 @@ impl<'a> UDPDriver<'a> {
         port_table: &'static UdpPortManager,
         kernel_buffer: LeasableBuffer<'static, u8>,
         driver_send_cap: &'static dyn UdpDriverCapability,
+        net_cap: &'static NetworkCapability
     ) -> UDPDriver<'a> {
         UDPDriver {
             sender: sender,
@@ -114,6 +118,7 @@ impl<'a> UDPDriver<'a> {
             port_table: port_table,
             kernel_buffer: MapCell::new(kernel_buffer),
             driver_send_cap: driver_send_cap,
+            net_cap: net_cap,
         }
     }
 
@@ -271,6 +276,7 @@ impl<'a> UDPDriver<'a> {
                                 src_port,
                                 kernel_buffer,
                                 self.driver_send_cap,
+                                self.net_cap,
                             ) {
                                 Ok(_) => ReturnCode::SUCCESS,
                                 Err(mut buf) => {

--- a/capsules/src/net/udp/udp_port_table.rs
+++ b/capsules/src/net/udp/udp_port_table.rs
@@ -32,9 +32,9 @@
 //! userspace UDP driver to check which ports are bound, and vice-versa, such that
 //! exclusive access to ports between userspace apps and capsules is still enforced.
 
-use crate::net::network_capabilities::NetworkCapability;
+use crate::net::network_capabilities::{NetworkCapability, UdpVisibilityCapability};
 use core::fmt;
-use kernel::capabilities::{CreatePortTableCapability, UdpDriverCapability, UdpVisibilityCapability};
+use kernel::capabilities::{CreatePortTableCapability, UdpDriverCapability};
 use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::ReturnCode;
 
@@ -73,7 +73,7 @@ pub struct UdpSocket {
 pub struct UdpPortManager {
     port_array: TakeCell<'static, [Option<SocketBindingEntry>]>,
     user_ports: OptionalCell<&'static dyn PortQuery>,
-    udp_vis: &'static dyn UdpVisibilityCapability,
+    udp_vis: &'static UdpVisibilityCapability,
 }
 
 impl fmt::Debug for UdpPortManager {
@@ -146,7 +146,7 @@ impl UdpPortManager {
     pub fn new(
         _cap: &dyn CreatePortTableCapability,
         used_kernel_ports: &'static mut [Option<SocketBindingEntry>],
-        udp_vis: &'static dyn UdpVisibilityCapability,
+        udp_vis: &'static UdpVisibilityCapability,
     ) -> UdpPortManager {
         UdpPortManager {
             port_array: TakeCell::new(used_kernel_ports),

--- a/capsules/src/net/udp/udp_port_table.rs
+++ b/capsules/src/net/udp/udp_port_table.rs
@@ -36,11 +36,14 @@ use crate::net::network_capabilities::{NetworkCapability, UdpVisibilityCapabilit
 use core::fmt;
 use kernel::capabilities::{CreatePortTableCapability, UdpDriverCapability};
 use kernel::common::cells::{OptionalCell, TakeCell};
-use kernel::ReturnCode; // TODO: remove debug
+use kernel::ReturnCode;
 
 // Sets the maximum number of UDP ports that can be bound by capsules. Reducing this number
 // can save a small amount of memory, and slightly reduces the overhead of iterating through the
-// table to check whether a port is already bound.
+// table to check whether a port is already bound. Note: if this numberis changed,
+// port_table_test2 in udp_lowpan_test.rs will fail since it tests the capacity of
+// the port table -- therefore that test should be modified when MAX_NUM_BOUND_PORTS
+// is.
 pub const MAX_NUM_BOUND_PORTS: usize = 16;
 
 /// The SocketBindingEntry struct is stored in the PORT_TABLE and conveys what port is bound

--- a/capsules/src/net/udp/udp_port_table.rs
+++ b/capsules/src/net/udp/udp_port_table.rs
@@ -36,12 +36,12 @@ use crate::net::network_capabilities::{NetworkCapability, UdpVisibilityCapabilit
 use core::fmt;
 use kernel::capabilities::{CreatePortTableCapability, UdpDriverCapability};
 use kernel::common::cells::{OptionalCell, TakeCell};
-use kernel::ReturnCode;
+use kernel::ReturnCode; // TODO: remove debug
 
 // Sets the maximum number of UDP ports that can be bound by capsules. Reducing this number
 // can save a small amount of memory, and slightly reduces the overhead of iterating through the
 // table to check whether a port is already bound.
-pub const MAX_NUM_BOUND_PORTS: usize = 5;
+pub const MAX_NUM_BOUND_PORTS: usize = 16;
 
 /// The SocketBindingEntry struct is stored in the PORT_TABLE and conveys what port is bound
 /// at the given index if one is bound. If no port is bound, the value stored

--- a/capsules/src/net/udp/udp_port_table.rs
+++ b/capsules/src/net/udp/udp_port_table.rs
@@ -36,8 +36,7 @@ use crate::net::network_capabilities::NetworkCapability;
 use core::fmt;
 use kernel::capabilities::{CreatePortTableCapability, UdpDriverCapability, UdpVisCap};
 use kernel::common::cells::{OptionalCell, TakeCell};
-use kernel::debug;
-use kernel::ReturnCode; // TODO: remove
+use kernel::ReturnCode;
 
 // Sets the maximum number of UDP ports that can be bound by capsules. Reducing this number
 // can save a small amount of memory, and slightly reduces the overhead of iterating through the
@@ -268,7 +267,6 @@ impl UdpPortManager {
                 Err(_) => Err(socket),
             }
         } else {
-            debug!("oh no error binding!!!");
             Err(socket)
         }
     }

--- a/capsules/src/net/udp/udp_port_table.rs
+++ b/capsules/src/net/udp/udp_port_table.rs
@@ -34,7 +34,7 @@
 
 use crate::net::network_capabilities::NetworkCapability;
 use core::fmt;
-use kernel::capabilities::{CreatePortTableCapability, UdpDriverCapability, UdpVisCap};
+use kernel::capabilities::{CreatePortTableCapability, UdpDriverCapability, UdpVisibilityCapability};
 use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::ReturnCode;
 
@@ -73,7 +73,7 @@ pub struct UdpSocket {
 pub struct UdpPortManager {
     port_array: TakeCell<'static, [Option<SocketBindingEntry>]>,
     user_ports: OptionalCell<&'static dyn PortQuery>,
-    udp_vis: &'static dyn UdpVisCap,
+    udp_vis: &'static dyn UdpVisibilityCapability,
 }
 
 impl fmt::Debug for UdpPortManager {
@@ -146,7 +146,7 @@ impl UdpPortManager {
     pub fn new(
         _cap: &dyn CreatePortTableCapability,
         used_kernel_ports: &'static mut [Option<SocketBindingEntry>],
-        udp_vis: &'static dyn UdpVisCap,
+        udp_vis: &'static dyn UdpVisibilityCapability,
     ) -> UdpPortManager {
         UdpPortManager {
             port_array: TakeCell::new(used_kernel_ports),

--- a/capsules/src/net/udp/udp_port_table.rs
+++ b/capsules/src/net/udp/udp_port_table.rs
@@ -32,13 +32,12 @@
 //! userspace UDP driver to check which ports are bound, and vice-versa, such that
 //! exclusive access to ports between userspace apps and capsules is still enforced.
 
+use crate::net::network_capabilities::NetworkCapability;
 use core::fmt;
 use kernel::capabilities::{CreatePortTableCapability, UdpDriverCapability, UdpVisCap};
-use crate::net::network_capabilities::{NetworkCapability};
 use kernel::common::cells::{OptionalCell, TakeCell};
-use kernel::ReturnCode;
-use kernel::debug; // TODO: remove
-
+use kernel::debug;
+use kernel::ReturnCode; // TODO: remove
 
 // Sets the maximum number of UDP ports that can be bound by capsules. Reducing this number
 // can save a small amount of memory, and slightly reduces the overhead of iterating through the

--- a/capsules/src/net/udp/udp_port_table.rs
+++ b/capsules/src/net/udp/udp_port_table.rs
@@ -37,6 +37,8 @@ use kernel::capabilities::{CreatePortTableCapability, UdpDriverCapability, UdpVi
 use crate::net::network_capabilities::{NetworkCapability};
 use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::ReturnCode;
+use kernel::debug; // TODO: remove
+
 
 // Sets the maximum number of UDP ports that can be bound by capsules. Reducing this number
 // can save a small amount of memory, and slightly reduces the overhead of iterating through the
@@ -267,6 +269,7 @@ impl UdpPortManager {
                 Err(_) => Err(socket),
             }
         } else {
+            debug!("oh no error binding!!!");
             Err(socket)
         }
     }

--- a/capsules/src/net/udp/udp_send.rs
+++ b/capsules/src/net/udp/udp_send.rs
@@ -18,12 +18,11 @@
 use crate::net::ipv6::ip_utils::IPAddr;
 use crate::net::ipv6::ipv6::TransportHeader;
 use crate::net::ipv6::ipv6_send::{IP6SendClient, IP6Sender};
-use crate::net::network_capabilities::NetworkCapability;
+use crate::net::network_capabilities::{NetworkCapability, UdpVisibilityCapability};
 use crate::net::udp::udp::UDPHeader;
 use crate::net::udp::udp_port_table::UdpPortBindingTx;
 use core::cell::Cell;
 use kernel::capabilities::UdpDriverCapability;
-use kernel::capabilities::UdpVisibilityCapability;
 use kernel::common::cells::{MapCell, OptionalCell};
 use kernel::common::leasable_buffer::LeasableBuffer;
 use kernel::common::{List, ListLink, ListNode};
@@ -247,7 +246,7 @@ pub struct UDPSendStruct<'a, T: IP6Sender<'a>> {
     next_dest: Cell<IPAddr>,
     next_th: OptionalCell<TransportHeader>,
     binding: MapCell<UdpPortBindingTx>,
-    udp_vis: &'static dyn UdpVisibilityCapability,
+    udp_vis: &'static UdpVisibilityCapability,
 }
 
 impl<'a, T: IP6Sender<'a>> ListNode<'a, UDPSendStruct<'a, T>> for UDPSendStruct<'a, T> {
@@ -343,7 +342,7 @@ impl<T: IP6Sender<'a>> UDPSender<'a> for UDPSendStruct<'a, T> {
 impl<T: IP6Sender<'a>> UDPSendStruct<'a, T> {
     pub fn new(
         udp_mux_sender: &'a MuxUdpSender<'a, T>, /*binding: UdpPortBindingTx*/
-        udp_vis: &'static dyn UdpVisibilityCapability,
+        udp_vis: &'static UdpVisibilityCapability,
     ) -> UDPSendStruct<'a, T> {
         UDPSendStruct {
             udp_mux_sender: udp_mux_sender,

--- a/capsules/src/net/udp/udp_send.rs
+++ b/capsules/src/net/udp/udp_send.rs
@@ -23,7 +23,7 @@ use crate::net::udp::udp::UDPHeader;
 use crate::net::udp::udp_port_table::UdpPortBindingTx;
 use core::cell::Cell;
 use kernel::capabilities::UdpDriverCapability;
-use kernel::capabilities::UdpVisCap;
+use kernel::capabilities::UdpVisibilityCapability;
 use kernel::common::cells::{MapCell, OptionalCell};
 use kernel::common::leasable_buffer::LeasableBuffer;
 use kernel::common::{List, ListLink, ListNode};
@@ -247,7 +247,7 @@ pub struct UDPSendStruct<'a, T: IP6Sender<'a>> {
     next_dest: Cell<IPAddr>,
     next_th: OptionalCell<TransportHeader>,
     binding: MapCell<UdpPortBindingTx>,
-    udp_vis: &'static dyn UdpVisCap,
+    udp_vis: &'static dyn UdpVisibilityCapability,
 }
 
 impl<'a, T: IP6Sender<'a>> ListNode<'a, UDPSendStruct<'a, T>> for UDPSendStruct<'a, T> {
@@ -343,7 +343,7 @@ impl<T: IP6Sender<'a>> UDPSender<'a> for UDPSendStruct<'a, T> {
 impl<T: IP6Sender<'a>> UDPSendStruct<'a, T> {
     pub fn new(
         udp_mux_sender: &'a MuxUdpSender<'a, T>, /*binding: UdpPortBindingTx*/
-        udp_vis: &'static dyn UdpVisCap,
+        udp_vis: &'static dyn UdpVisibilityCapability,
     ) -> UDPSendStruct<'a, T> {
         UDPSendStruct {
             udp_mux_sender: udp_mux_sender,

--- a/capsules/src/net/udp/udp_send.rs
+++ b/capsules/src/net/udp/udp_send.rs
@@ -33,6 +33,7 @@ use kernel::ReturnCode;
 pub struct MuxUdpSender<'a, T: IP6Sender<'a>> {
     sender_list: List<'a, UDPSendStruct<'a, T>>,
     ip_sender: &'a dyn IP6Sender<'a>,
+    // OptionalCell needed to store net_cap for send_done
     net_cap: OptionalCell<&'static NetworkCapability>,
 }
 

--- a/capsules/src/net/udp/udp_send.rs
+++ b/capsules/src/net/udp/udp_send.rs
@@ -276,8 +276,10 @@ impl<T: IP6Sender<'a>> UDPSender<'a> for UDPSendStruct<'a, T> {
                 if !net_cap.remote_port_valid(dst_port, self.udp_vis)
                     || !net_cap.local_port_valid(binding.get_port(), self.udp_vis)
                 {
+                    self.binding.replace(binding);
                     Err(buf)
                 } else if binding.get_port() == 0 {
+                    self.binding.replace(binding);
                     Err(buf)
                 } else {
                     udp_header.set_src_port(binding.get_port());

--- a/capsules/src/test/udp.rs
+++ b/capsules/src/test/udp.rs
@@ -91,7 +91,7 @@ impl<'a, A: Alarm<'a>> MockUdp<'a, A> {
                     self.udp_sender.get_binding().expect("missing1"),
                     self.udp_receiver.get_binding().expect("missing2"),
                 ) {
-                    Ok(sock) => match self.port_table.bind(sock, self.src_port.get()) {
+                    Ok(sock) => match self.port_table.bind(sock, self.src_port.get(), self.net_cap) {
                         Ok((send_bind, rcv_bind)) => {
                             self.udp_sender.set_binding(send_bind);
                             self.udp_receiver.set_binding(rcv_bind);
@@ -111,7 +111,7 @@ impl<'a, A: Alarm<'a>> MockUdp<'a, A> {
                 let socket = self.port_table.create_socket();
                 match socket {
                     Ok(sock) => {
-                        match self.port_table.bind(sock, self.src_port.get()) {
+                        match self.port_table.bind(sock, self.src_port.get(), self.net_cap) {
                             Ok((send_bind, rcv_bind)) => {
                                 self.udp_sender.set_binding(send_bind);
                                 self.udp_receiver.set_binding(rcv_bind);

--- a/capsules/src/test/udp.rs
+++ b/capsules/src/test/udp.rs
@@ -136,7 +136,7 @@ impl<'a, A: Alarm<'a>> MockUdp<'a, A> {
     }
 
     // Sends a packet containing a single 2 byte number.
-    pub fn send(&self, value: u16) -> ReturnCode {
+    pub fn send_with_cap(&self, value: u16, net_cap: &'static NetworkCapability) -> ReturnCode {
         match self.udp_dgram.take() {
             Some(mut dgram) => {
                 dgram[0] = (value >> 8) as u8;
@@ -144,7 +144,7 @@ impl<'a, A: Alarm<'a>> MockUdp<'a, A> {
                 dgram.slice(0..2);
                 match self
                     .udp_sender
-                    .send_to(DST_ADDR, self.dst_port.get(), dgram, self.net_cap)
+                    .send_to(DST_ADDR, self.dst_port.get(), dgram, net_cap)
                 {
                     Ok(_) => ReturnCode::SUCCESS,
                     Err(mut buf) => {
@@ -160,6 +160,13 @@ impl<'a, A: Alarm<'a>> MockUdp<'a, A> {
             }
         }
     }
+
+    pub fn send(&self, value: u16) -> ReturnCode {
+        self.send_with_cap(value, self.net_cap)
+    }
+
+
+
 }
 
 impl<'a, A: Alarm<'a>> time::AlarmClient for MockUdp<'a, A> {

--- a/capsules/src/test/udp.rs
+++ b/capsules/src/test/udp.rs
@@ -6,10 +6,10 @@
 //! Example use of this capsule can be found in `udp_lowpan_test.rs` in the Imix board directory.
 
 use crate::net::ipv6::ip_utils::IPAddr;
+use crate::net::network_capabilities::NetworkCapability;
 use crate::net::udp::udp_port_table::UdpPortManager;
 use crate::net::udp::udp_recv::{UDPReceiver, UDPRecvClient};
 use crate::net::udp::udp_send::{UDPSendClient, UDPSender};
-use crate::net::network_capabilities::{NetworkCapability};
 use core::cell::Cell;
 use kernel::common::cells::MapCell;
 use kernel::common::leasable_buffer::LeasableBuffer;
@@ -91,7 +91,10 @@ impl<'a, A: Alarm<'a>> MockUdp<'a, A> {
                     self.udp_sender.get_binding().expect("missing1"),
                     self.udp_receiver.get_binding().expect("missing2"),
                 ) {
-                    Ok(sock) => match self.port_table.bind(sock, self.src_port.get(), self.net_cap) {
+                    Ok(sock) => match self
+                        .port_table
+                        .bind(sock, self.src_port.get(), self.net_cap)
+                    {
                         Ok((send_bind, rcv_bind)) => {
                             self.udp_sender.set_binding(send_bind);
                             self.udp_receiver.set_binding(rcv_bind);
@@ -111,7 +114,10 @@ impl<'a, A: Alarm<'a>> MockUdp<'a, A> {
                 let socket = self.port_table.create_socket();
                 match socket {
                     Ok(sock) => {
-                        match self.port_table.bind(sock, self.src_port.get(), self.net_cap) {
+                        match self
+                            .port_table
+                            .bind(sock, self.src_port.get(), self.net_cap)
+                        {
                             Ok((send_bind, rcv_bind)) => {
                                 self.udp_sender.set_binding(send_bind);
                                 self.udp_receiver.set_binding(rcv_bind);
@@ -164,9 +170,6 @@ impl<'a, A: Alarm<'a>> MockUdp<'a, A> {
     pub fn send(&self, value: u16) -> ReturnCode {
         self.send_with_cap(value, self.net_cap)
     }
-
-
-
 }
 
 impl<'a, A: Alarm<'a>> time::AlarmClient for MockUdp<'a, A> {

--- a/kernel/src/capabilities.rs
+++ b/kernel/src/capabilities.rs
@@ -72,3 +72,9 @@ pub unsafe trait UdpDriverCapability {}
 /// so this capability should not be distributed to capsules at all, as the port table should only be
 /// instantiated once by the kernel
 pub unsafe trait CreatePortTableCapability {}
+
+pub unsafe trait UdpVisCap {}
+
+pub unsafe trait IpVisCap {}
+
+pub unsafe trait NetCapCreateCap {}

--- a/kernel/src/capabilities.rs
+++ b/kernel/src/capabilities.rs
@@ -73,4 +73,8 @@ pub unsafe trait UdpDriverCapability {}
 /// instantiated once by the kernel
 pub unsafe trait CreatePortTableCapability {}
 
+/// The `NetworkCapabilityCreationCapability` allows the holder to instantiate
+/// `NetworkCapability`S and visibility capabilities for the IP and UDP layers
+/// of the networking stack. A capsule would never hold this capability although
+/// it may hold capabilities created via this capability.
 pub unsafe trait NetworkCapabilityCreationCapability {}

--- a/kernel/src/capabilities.rs
+++ b/kernel/src/capabilities.rs
@@ -73,8 +73,8 @@ pub unsafe trait UdpDriverCapability {}
 /// instantiated once by the kernel
 pub unsafe trait CreatePortTableCapability {}
 
-pub unsafe trait UdpVisCap {}
+pub unsafe trait UdpVisibilityCapability {}
 
-pub unsafe trait IpVisCap {}
+pub unsafe trait IpVisibilityCapability {}
 
-pub unsafe trait NetCapCreateCap {}
+pub unsafe trait NetworkCapabilityCreationCapability {}

--- a/kernel/src/capabilities.rs
+++ b/kernel/src/capabilities.rs
@@ -73,8 +73,4 @@ pub unsafe trait UdpDriverCapability {}
 /// instantiated once by the kernel
 pub unsafe trait CreatePortTableCapability {}
 
-pub unsafe trait UdpVisibilityCapability {}
-
-pub unsafe trait IpVisibilityCapability {}
-
 pub unsafe trait NetworkCapabilityCreationCapability {}

--- a/kernel/src/common/utils.rs
+++ b/kernel/src/common/utils.rs
@@ -81,10 +81,3 @@ macro_rules! create_capability {
         Cap
     };};
 }
-
-
-
-
-
-
-

--- a/kernel/src/common/utils.rs
+++ b/kernel/src/common/utils.rs
@@ -81,3 +81,23 @@ macro_rules! create_capability {
         Cap
     };};
 }
+
+
+/// Creates a static object with the given capability.
+/// Works as create_capability above, but the given capability has a static
+/// lifetime.
+#[macro_export]
+macro_rules! create_static_capability {
+    ($T:ty) => {{
+        struct Cap;
+        unsafe impl $T for Cap {}
+        static CapStruct: Cap = Cap;
+        &CapStruct
+    };};
+}
+
+
+
+
+
+

--- a/kernel/src/common/utils.rs
+++ b/kernel/src/common/utils.rs
@@ -83,19 +83,6 @@ macro_rules! create_capability {
 }
 
 
-/// Creates a static object with the given capability.
-/// Works as create_capability above, but the given capability has a static
-/// lifetime.
-#[macro_export]
-macro_rules! create_static_capability {
-    ($T:ty) => {{
-        struct Cap;
-        unsafe impl $T for Cap {}
-        static CapStruct: Cap = Cap;
-        &CapStruct
-    };};
-}
-
 
 
 


### PR DESCRIPTION
### Pull Request Overview

This pull request introduces layered network capabilities into the networking stack. Network capabilities (defined in net/network_capabilities.rs) provide an abstraction by which capsules can be granted permission to communicate with certain ranges of IP addresses, send to certain remote UDP ports, and send from certain local UDP ports. This abstraction also enforces that only layer-specific code can query the relevant part of the capability i.e. only IP code can test if an address is valid for the given capability and only UDP code can test if certain remote/local ports are valid for the given capability -- this layer specific access is facilitated by a UDP visibility capability (UdpVisCap) and an IP visibility capability (IpVisCap).

The network capability is checked when we send IP packets (to see if the destination address is valid relative to the allowed remote addresses), when we send UDP packets (to see if the destination port is allowed), and when we bind to UDP ports (to see if sending from the local port is allowed). These network capabilities are created and given to capsules within main.rs. Capabilities provide us a powerful way to manage access to network resources across different capsules.

Please let me know if I can elaborate at all on the description above, or if you have any questions. Thanks!

### Testing Strategy

I added additional tests specific to capabilities in udp_lowpan_test.rs -- I ran the kernel tests on an imix board.


### TODO or Help Wanted

This pull request still needs feedback on the layered network capability and suggestions for possible improvement. Perhaps there are additional ways in which we'd want to specify address/port ranges. There may be additional fields that we should add to the capability as well.

### Documentation Updated

- I haven't updated documentation yet since I don't know where in particular I should make this update and the network capability abstraction may change as a result of feedback on this PR.

### Formatting

- [x] Ran `make formatall`.
