### PR TITLE
RFC: use const generics for ipc arrays

### DIFF
--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -132,7 +132,7 @@ struct Imix {
         sam4l::acifc::Acifc<'static>,
     >,
     spi: &'static capsules::spi::Spi<'static, VirtualSpiMasterDevice<'static, sam4l::spi::SpiHw>>,
-    ipc: kernel::ipc::IPC,
+    ipc: kernel::ipc::IPC<NUM_PROCS>,
     ninedof: &'static capsules::ninedof::NineDof<'static>,
     radio_driver: &'static capsules::ieee802154::RadioDriver<'static>,
     udp_driver: &'static capsules::net::udp::UDPDriver<'static>,

--- a/kernel/src/ipc.rs
+++ b/kernel/src/ipc.rs
@@ -12,6 +12,7 @@ use crate::process;
 use crate::returncode::ReturnCode;
 use crate::sched::Kernel;
 use core::mem::MaybeUninit;
+use core::ptr;
 
 /// Syscall number
 pub const DRIVER_NUM: usize = 0x10000;
@@ -29,11 +30,11 @@ impl<const NUM_PROCS: usize> Default for IPCData<NUM_PROCS> {
             client_callbacks: unsafe { MaybeUninit::zeroed().assume_init() },
             callback: None,
         };
-        for opt in ipc_data.shared_memory.iter_mut() {
-            *opt = None;
+        for i in 0..NUM_PROCS {
+            unsafe { ptr::write(&mut ipc_data.shared_memory[i], None) };
         }
-        for opt in ipc_data.client_callbacks.iter_mut() {
-            *opt = None;
+        for i in 0..NUM_PROCS {
+            unsafe { ptr::write(&mut ipc_data.client_callbacks[i], None) };
         }
         ipc_data
     }

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -10,6 +10,7 @@
 #![feature(panic_info_message)]
 #![feature(in_band_lifetimes, crate_visibility_modifier)]
 #![feature(associated_type_defaults)]
+#![feature(const_generics)]
 #![warn(unreachable_pub)]
 #![no_std]
 

--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -203,11 +203,11 @@ impl Kernel {
     }
 
     /// Main loop.
-    pub fn kernel_loop<P: Platform, C: Chip>(
+    pub fn kernel_loop<P: Platform, C: Chip, const NUM_PROCS: usize>(
         &'static self,
         platform: &P,
         chip: &C,
-        ipc: Option<&ipc::IPC>,
+        ipc: Option<&ipc::IPC<NUM_PROCS>>,
         _capability: &dyn capabilities::MainLoopCapability,
     ) {
         loop {
@@ -238,12 +238,12 @@ impl Kernel {
         }
     }
 
-    unsafe fn do_process<P: Platform, C: Chip>(
+    unsafe fn do_process<P: Platform, C: Chip, const NUM_PROCS: usize>(
         &self,
         platform: &P,
         chip: &C,
         process: &dyn process::ProcessType,
-        ipc: Option<&crate::ipc::IPC>,
+        ipc: Option<&crate::ipc::IPC<NUM_PROCS>>,
     ) {
         let appid = process.appid();
         let systick = chip.systick();


### PR DESCRIPTION
### Pull Request Overview

This pull request modifies the IPCData struct to use const generics such that the number of elements in the `client_callbacks` and `shared_memory` arrays are set to the number of processes on the board. This fixes issue #1583 , and prevents wasteful use of the grant region for boards with fewer process slots than 8. It also makes it more clear that the current IPC implementation uses the location of apps in the PROCESSES array to lookup callbacks or shared memory regions corresponding to those apps.

It also raises the question: are `const_generics` stable enough for us to use yet? This code does currently generate the warning: 

"warning: the feature `const_generics` is incomplete and may cause the compiler to crash"

but the rust std library has started to use `const_generics` internally, and for simple cases like this I think they are really nice. I know that we already use a number of unstable features in the kernel. 

**That being said, I totally understand if others think we should wait before using `const_generics`.**

Either way I just thought this was a nice little fix and people might be interested.


### Testing Strategy

Tested by flashing a single rot13 server and client app on Imix and observing console output.


### TODO or Help Wanted

All boards main.rs files need one line modifications to IPC initialization to support this change, assuming people like it. Travis will fail until this has been done.

Also, the new `Default` implementation is unsafe and requires `MaybeUninit`, though that can change once https://github.com/rust-lang/rust/issues/61415 is addressed and arrays of all sizes satisfy the trait bounds for `Default`.


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
