### PR TITLE
opentitan: Reduce RAM usage in linker script

### DIFF
--- a/boards/opentitan/layout.ld
+++ b/boards/opentitan/layout.ld
@@ -2,7 +2,7 @@ MEMORY
 {
   rom   (rx)  : ORIGIN = 0x20000000, LENGTH = 0x30000
   prog  (rx)  : ORIGIN = 0x20030000, LENGTH = 0x100000-0x30000
-  ram   (!rx) : ORIGIN = 0x10000000, LENGTH = 0x10000
+  ram   (!rx) : ORIGIN = 0x10000000, LENGTH = 0x8000
 }
 
 MPU_MIN_ALIGN = 1K;


### PR DESCRIPTION
### Pull Request Overview

Reduce the RAM allocated to Tock so that we have more left over for the
apps.

### Testing Strategy

Run libtock-c apps on top of Tock on OpenTitan.


### TODO or Help Wanted



### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make formatall`.
