### PR TITLE
kernel: give processes unique identifiers

### DIFF
--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -529,7 +529,7 @@ struct ProcessDebug {
 pub struct Process<'a, C: 'static + Chip> {
     /// Identifier of this process and the index of the process in the process
     /// table.
-    app_id: AppId,
+    app_id: Cell<AppId>,
 
     /// Pointer to the main Kernel struct.
     kernel: &'static Kernel,
@@ -637,7 +637,7 @@ pub struct Process<'a, C: 'static + Chip> {
 
 impl<C: Chip> ProcessType for Process<'a, C> {
     fn appid(&self) -> AppId {
-        self.app_id
+        self.app_id.get()
     }
 
     fn enqueue_task(&self, task: Task) -> bool {
@@ -738,6 +738,17 @@ impl<C: Chip> ProcessType for Process<'a, C> {
                 if !restart_policy.should_restart(self) {
                     return;
                 }
+
+                // We need a new process identifier for this app since the
+                // restarted version is in effect a new process. This is also
+                // necessary to invalidate any stored `AppId`s that point to the
+                // old version of the app. However, the app has not moved
+                // locations in the processes array, so we copy the existing
+                // index.
+                let old_index = self.app_id.get().index;
+                let new_identifier = self.kernel.create_process_identifier();
+                self.app_id
+                    .set(AppId::new(self.kernel, new_identifier, old_index));
 
                 // Update debug information
                 self.debug.map(|debug| {
@@ -1528,7 +1539,13 @@ impl<C: 'static + Chip> Process<'a, C> {
             let mut process: &mut Process<C> =
                 &mut *(process_struct_memory_location as *mut Process<'static, C>);
 
-            process.app_id = AppId::new(kernel, index, index);
+            // Ask the kernel for a unique identifier for this process that is
+            // being created.
+            let unique_identifier = kernel.create_process_identifier();
+
+            process
+                .app_id
+                .set(AppId::new(kernel, unique_identifier, index));
             process.kernel = kernel;
             process.chip = chip;
             process.memory = app_memory;


### PR DESCRIPTION
### Pull Request Overview

This builds on top of PR #1566 and makes app identifiers for processes unique by incrementing a counter every time a new process needs an identifier.

Since this requires #1566 there are many commits here, but the relevant one (and where you should look) is here: https://github.com/tock/tock/commit/a2020b67fee37496f032a2dde04f549745e727a5

This is part of #1082.

### Testing Strategy

todo


### TODO or Help Wanted

This is a redo of a prior PR, and one question that came up is should the counter be 64 bit in case a process restarts continuously. Changing from a `usize` to `u64` was not as straightforward as I thought, so I did not include that change here. Should we do something about the counter wrapping around? Or should boards use one of the restart policies to avoid restarting an app that many times?


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
