### PR TITLE
Enable writing the PMP configuration to hardware 

### DIFF
--- a/arch/rv32i/src/csr/pmpconfig.rs
+++ b/arch/rv32i/src/csr/pmpconfig.rs
@@ -13,17 +13,19 @@ register_bitfields![u32,
             NA4 = 2,
             NAPOT = 3
         ],
-        l0 OFFSET(5) NUMBITS(1) [],
-        r1 OFFSET(6) NUMBITS(1) [],
-        w1 OFFSET(7) NUMBITS(1) [],
-        x1 OFFSET(8) NUMBITS(1) [],
-        a1 OFFSET(9) NUMBITS(2) [
+        l0 OFFSET(7) NUMBITS(1) [],
+
+        r1 OFFSET(8) NUMBITS(1) [],
+        w1 OFFSET(9) NUMBITS(1) [],
+        x1 OFFSET(10) NUMBITS(1) [],
+        a1 OFFSET(11) NUMBITS(2) [
             OFF = 0,
             TOR = 1,
             NA4 = 2,
             NAPOT = 3
         ],
         l1 OFFSET(15) NUMBITS(1) [],
+
         r2 OFFSET(16) NUMBITS(1) [],
         w2 OFFSET(17) NUMBITS(1) [],
         x2 OFFSET(18) NUMBITS(1) [],
@@ -34,6 +36,7 @@ register_bitfields![u32,
             NAPOT = 3
         ],
         l2 OFFSET(23) NUMBITS(1) [],
+
         r3 OFFSET(24) NUMBITS(1) [],
         w3 OFFSET(25) NUMBITS(1) [],
         x3 OFFSET(26) NUMBITS(1) [],

--- a/arch/rv32i/src/pmp.rs
+++ b/arch/rv32i/src/pmp.rs
@@ -4,22 +4,124 @@ use core::fmt;
 
 use crate::csr;
 use kernel;
+use kernel::common::registers::register_bitfields;
 use kernel::mpu;
 
-/// Struct storing configuration for a RISCV PMP region.
-/// In accordance with the priviliged ISA 1.10
-/// https://content.riscv.org/wp-content/uploads/2017/05/riscv-privileged-v1.10.pdf
+// This is the RISC-V PMP support for Tock
+// We use the PMP TOR alignment as there are alignment issues with NAPOT
+// NAPOT would allow us to use more regions (each PMP region can be a
+//     memory region) but the problem with NAPOT is the address must be
+//     alignment to the size, which results in wasted memory.
+// To avoid this wasted memory we use TOR and each memory region uses two
+//     physical PMP regions.
+
+// Generic PMP config
+register_bitfields![u32,
+    pub pmpcfg [
+        r OFFSET(0) NUMBITS(1) [],
+        w OFFSET(1) NUMBITS(1) [],
+        x OFFSET(2) NUMBITS(1) [],
+        a OFFSET(3) NUMBITS(2) [
+            OFF = 0,
+            TOR = 1,
+            NA4 = 2,
+            NAPOT = 3
+        ],
+        l OFFSET(7) NUMBITS(1) []
+    ]
+];
+
+/// Struct storing configuration for a RISC-V PMP region.
+#[derive(Copy, Clone)]
+pub struct PMPRegion {
+    location: Option<(*const u8, usize)>,
+    _cfg: tock_registers::registers::FieldValue<u32, pmpcfg::Register>,
+}
+
+impl PMPRegion {
+    fn new(start: *const u8, size: usize, permissions: mpu::Permissions) -> PMPRegion {
+        // Determine access and execute permissions
+        let pmpcfg = match permissions {
+            mpu::Permissions::ReadWriteExecute => {
+                pmpcfg::r::SET + pmpcfg::w::SET + pmpcfg::x::SET + pmpcfg::a::TOR
+            }
+            mpu::Permissions::ReadWriteOnly => {
+                pmpcfg::r::SET + pmpcfg::w::SET + pmpcfg::x::CLEAR + pmpcfg::a::TOR
+            }
+            mpu::Permissions::ReadExecuteOnly => {
+                pmpcfg::r::SET + pmpcfg::w::CLEAR + pmpcfg::x::SET + pmpcfg::a::TOR
+            }
+            mpu::Permissions::ReadOnly => {
+                pmpcfg::r::SET + pmpcfg::w::CLEAR + pmpcfg::x::CLEAR + pmpcfg::a::TOR
+            }
+            mpu::Permissions::ExecuteOnly => {
+                pmpcfg::r::CLEAR + pmpcfg::w::CLEAR + pmpcfg::x::SET + pmpcfg::a::TOR
+            }
+        };
+
+        PMPRegion {
+            location: Some((start, size)),
+            _cfg: pmpcfg,
+        }
+    }
+
+    fn empty(_region_num: usize) -> PMPRegion {
+        PMPRegion {
+            location: None,
+            _cfg: pmpcfg::r::CLEAR + pmpcfg::w::CLEAR + pmpcfg::x::CLEAR + pmpcfg::a::OFF,
+        }
+    }
+
+    fn location(&self) -> Option<(*const u8, usize)> {
+        self.location
+    }
+
+    fn overlaps(&self, other_start: *const u8, other_size: usize) -> bool {
+        let other_start = other_start as usize;
+        let other_end = other_start + other_size;
+
+        let (region_start, region_end) = match self.location {
+            Some((region_start, region_size)) => {
+                let region_start = region_start as usize;
+                let region_end = region_start + region_size;
+                (region_start, region_end)
+            }
+            None => return false,
+        };
+
+        if region_start < other_end && other_start < region_end {
+            true
+        } else {
+            false
+        }
+    }
+}
 
 /// Struct storing region configuration for RISCV PMP.
 #[derive(Copy, Clone)]
 pub struct PMPConfig {
-    regions: usize,
+    regions: [PMPRegion; 8],
+    total_regions: usize,
 }
+
+const APP_MEMORY_REGION_NUM: usize = 0;
 
 impl Default for PMPConfig {
     /// number of regions on the arty chip
     fn default() -> PMPConfig {
-        PMPConfig { regions: 4 }
+        PMPConfig {
+            regions: [
+                PMPRegion::empty(0),
+                PMPRegion::empty(1),
+                PMPRegion::empty(2),
+                PMPRegion::empty(3),
+                PMPRegion::empty(4),
+                PMPRegion::empty(5),
+                PMPRegion::empty(6),
+                PMPRegion::empty(7),
+            ],
+            total_regions: 8,
+        }
     }
 }
 
@@ -30,19 +132,54 @@ impl fmt::Display for PMPConfig {
 }
 
 impl PMPConfig {
-    pub const fn new(num_regions: usize) -> PMPConfig {
-        PMPConfig {
-            regions: num_regions,
+    pub fn new(pmp_regions: usize) -> PMPConfig {
+        if pmp_regions > 16 {
+            panic!("There is an ISA maximum of 16 PMP regions");
         }
+        if pmp_regions < 4 {
+            panic!("Tock requires at least 4 PMP regions");
+        }
+        PMPConfig {
+            regions: [
+                PMPRegion::empty(0),
+                PMPRegion::empty(1),
+                PMPRegion::empty(2),
+                PMPRegion::empty(3),
+                PMPRegion::empty(4),
+                PMPRegion::empty(5),
+                PMPRegion::empty(6),
+                PMPRegion::empty(7),
+            ],
+            // As we use the PMP TOR setup we only support half the number
+            // of regions as hardware supports
+            total_regions: pmp_regions / 2,
+        }
+    }
+
+    fn unused_region_number(&self) -> Option<usize> {
+        for (number, region) in self.regions.iter().enumerate() {
+            if number == APP_MEMORY_REGION_NUM {
+                continue;
+            }
+            if let None = region.location() {
+                if number < self.total_regions {
+                    return Some(number);
+                }
+            }
+        }
+        None
     }
 }
 
 impl kernel::mpu::MPU for PMPConfig {
+    type MpuConfig = PMPConfig;
+
     fn enable_mpu(&self) {}
 
     fn disable_mpu(&self) {
-        for x in 0..self.regions {
-            // disable everything
+        for x in 0..16 {
+            // If PMP is supported by the core then all 16 register sets must exist
+            // They don't all have to do anything, but let's zero them all just in case.
             match x {
                 0 => {
                     csr::CSR.pmpcfg0.modify(csr::pmpconfig::pmpcfg::r0::CLEAR);
@@ -186,7 +323,7 @@ impl kernel::mpu::MPU for PMPConfig {
     }
 
     fn number_total_regions(&self) -> usize {
-        self.regions
+        self.total_regions
     }
 
     fn allocate_region(

--- a/arch/rv32i/src/pmp.rs
+++ b/arch/rv32i/src/pmp.rs
@@ -175,14 +175,14 @@ impl kernel::mpu::MPU for PMPConfig {
                 // spec 1.10 only goes to 15
                 _ => break,
             }
-            //set first PMP to have permissions to entire space
-            csr::CSR.pmpaddr0.set(0xFFFF_FFFF);
-            //enable R W X fields
-            csr::CSR.pmpcfg0.modify(csr::pmpconfig::pmpcfg::r0::SET);
-            csr::CSR.pmpcfg0.modify(csr::pmpconfig::pmpcfg::w0::SET);
-            csr::CSR.pmpcfg0.modify(csr::pmpconfig::pmpcfg::x0::SET);
-            csr::CSR.pmpcfg0.modify(csr::pmpconfig::pmpcfg::a0::OFF);
         }
+        //set first PMP to have permissions to entire space
+        csr::CSR.pmpaddr0.set(0xFFFF_FFFF);
+        //enable R W X fields
+        csr::CSR.pmpcfg0.modify(csr::pmpconfig::pmpcfg::r0::SET);
+        csr::CSR.pmpcfg0.modify(csr::pmpconfig::pmpcfg::w0::SET);
+        csr::CSR.pmpcfg0.modify(csr::pmpconfig::pmpcfg::x0::SET);
+        csr::CSR.pmpcfg0.modify(csr::pmpconfig::pmpcfg::a0::OFF)
     }
 
     fn number_total_regions(&self) -> usize {

--- a/chips/ibex/src/chip.rs
+++ b/chips/ibex/src/chip.rs
@@ -17,12 +17,14 @@ pub const CHIP_FREQ: u32 = 50_000_000;
 
 pub struct Ibex {
     userspace_kernel_boundary: SysCall,
+    pmp: rv32i::pmp::PMPConfig,
 }
 
 impl Ibex {
     pub unsafe fn new() -> Ibex {
         Ibex {
             userspace_kernel_boundary: SysCall::new(),
+            pmp: rv32i::pmp::PMPConfig::new(4),
         }
     }
 
@@ -34,12 +36,12 @@ impl Ibex {
 }
 
 impl kernel::Chip for Ibex {
-    type MPU = ();
+    type MPU = rv32i::pmp::PMPConfig;
     type UserspaceKernelBoundary = SysCall;
     type SysTick = ();
 
     fn mpu(&self) -> &Self::MPU {
-        &()
+        &self.pmp
     }
 
     fn systick(&self) -> &Self::SysTick {


### PR DESCRIPTION
### Pull Request Overview

This PR builds on top of https://github.com/tock/tock/pull/1589

This patch let's us write the PMP configuration to hardware.

Currently we only support NAPOT mode for the address matching.

This is completely untested due to a lack of PMP enabled hardware.
Once OpenTitan enables PMP I can test this: lowRISC/opentitan#1445

### Testing Strategy

Not doing anything


### TODO or Help Wanted

Testing...


### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make formatall`.
