### PR TITLE
Removed useless allow(dead_code) in components.

### DIFF
--- a/boards/components/src/alarm.rs
+++ b/boards/components/src/alarm.rs
@@ -18,8 +18,6 @@
 // Author: Philip Levis <pal@cs.stanford.edu>
 // Last modified: 12/21/2019
 
-#![allow(dead_code)] // Components are intended to be conditionally included
-
 use core::mem::MaybeUninit;
 
 use capsules::alarm::AlarmDriver;

--- a/boards/components/src/button.rs
+++ b/boards/components/src/button.rs
@@ -17,8 +17,6 @@
 //! `FloatingState::None` will be used when the board provides external pull-up/pull-down
 //! resistors.
 
-#![allow(dead_code)] // Components are intended to be conditionally included
-
 use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;

--- a/boards/components/src/console.rs
+++ b/boards/components/src/console.rs
@@ -18,8 +18,6 @@
 // Author: Philip Levis <pal@cs.stanford.edu>
 // Last modified: 1/08/2020
 
-#![allow(dead_code)] // Components are intended to be conditionally included
-
 use capsules::console;
 use capsules::virtual_uart::{MuxUart, UartDevice};
 use kernel::capabilities;

--- a/boards/components/src/crc.rs
+++ b/boards/components/src/crc.rs
@@ -13,8 +13,6 @@
 // Author: Philip Levis <pal@cs.stanford.edu>
 // Last modified: 6/20/2018
 
-#![allow(dead_code)] // Components are intended to be conditionally included
-
 use core::mem::MaybeUninit;
 
 use capsules::crc;

--- a/boards/components/src/debug_writer.rs
+++ b/boards/components/src/debug_writer.rs
@@ -12,8 +12,6 @@
 // Author: Brad Campbell <bradjc@virginia.edu>
 // Last modified: 11/07/2019
 
-#![allow(dead_code)] // Components are intended to be conditionally included
-
 use capsules::virtual_uart::{MuxUart, UartDevice};
 use kernel::capabilities;
 use kernel::common::ring_buffer::RingBuffer;

--- a/boards/components/src/gpio.rs
+++ b/boards/components/src/gpio.rs
@@ -17,8 +17,6 @@
 //! ));
 //! ```
 
-#![allow(dead_code)] // Components are intended to be conditionally included
-
 use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;

--- a/boards/components/src/isl29035.rs
+++ b/boards/components/src/isl29035.rs
@@ -21,8 +21,6 @@
 // Author: Philip Levis <pal@cs.stanford.edu>
 // Last modified: 6/20/2018
 
-#![allow(dead_code)] // Components are intended to be conditionally included
-
 use core::mem::MaybeUninit;
 
 use capsules::ambient_light::AmbientLight;

--- a/boards/components/src/led.rs
+++ b/boards/components/src/led.rs
@@ -10,8 +10,6 @@
 //! ));
 //! ```
 
-#![allow(dead_code)] // Components are intended to be conditionally included
-
 use capsules;
 use kernel::component::Component;
 use kernel::static_init;

--- a/boards/components/src/lldb.rs
+++ b/boards/components/src/lldb.rs
@@ -14,8 +14,6 @@
 // Author: Amit Levy <amit@amitlevy.com>
 // Last modified: 12/04/2019
 
-#![allow(dead_code)] // Components are intended to be conditionally included
-
 use capsules::low_level_debug;
 use capsules::virtual_uart::{MuxUart, UartDevice};
 use kernel::capabilities;

--- a/boards/components/src/nrf51822.rs
+++ b/boards/components/src/nrf51822.rs
@@ -13,8 +13,6 @@
 // Author: Philip Levis <pal@cs.stanford.edu>
 // Last modified: 6/20/2018
 
-#![allow(dead_code)] // Components are intended to be conditionally included
-
 use capsules::nrf51822_serialization;
 use kernel::component::Component;
 use kernel::hil;

--- a/boards/components/src/process_console.rs
+++ b/boards/components/src/process_console.rs
@@ -13,8 +13,6 @@
 // Author: Philip Levis <pal@cs.stanford.edu>
 // Last modified: 6/20/2018
 
-#![allow(dead_code)] // Components are intended to be conditionally included
-
 use capsules::process_console;
 use capsules::virtual_uart::{MuxUart, UartDevice};
 use kernel::capabilities;

--- a/boards/components/src/rng.rs
+++ b/boards/components/src/rng.rs
@@ -12,8 +12,6 @@
 // Author: Hudson Ayers <hayers@cs.stanford.edu>
 // Last modified: 07/12/2019
 
-#![allow(dead_code)] // Components are intended to be conditionally included
-
 use capsules::rng;
 use kernel::capabilities;
 use kernel::component::Component;

--- a/boards/components/src/si7021.rs
+++ b/boards/components/src/si7021.rs
@@ -18,8 +18,6 @@
 // Author: Philip Levis <pal@cs.stanford.edu>
 // Last modified: 6/20/2018
 
-#![allow(dead_code)] // Components are intended to be conditionally included
-
 use core::mem::MaybeUninit;
 
 use capsules::humidity::HumiditySensor;

--- a/boards/components/src/spi.rs
+++ b/boards/components/src/spi.rs
@@ -25,8 +25,6 @@
 // Author: Philip Levis <pal@cs.stanford.edu>
 // Last modified: 6/20/2018
 
-#![allow(dead_code)] // Components are intended to be conditionally included
-
 use core::mem::MaybeUninit;
 
 use capsules::spi::Spi;


### PR DESCRIPTION
### Pull Request Overview

This pull request removes unneeded `allow(dead_code)` statements in components.

These are not needed, because the relevant code is exported in the public interface of the components library, so the compiler never warns against dead code. Removing these allowances will however enable the compiler to warn against truly unused code.


### Testing Strategy

This pull request was tested by Travis.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.