### PR TITLE
arch/rv32i: Fix up the PMP CFG offsets

### DIFF
--- a/arch/rv32i/src/csr/pmpconfig.rs
+++ b/arch/rv32i/src/csr/pmpconfig.rs
@@ -13,17 +13,19 @@ register_bitfields![u32,
             NA4 = 2,
             NAPOT = 3
         ],
-        l0 OFFSET(5) NUMBITS(1) [],
-        r1 OFFSET(6) NUMBITS(1) [],
-        w1 OFFSET(7) NUMBITS(1) [],
-        x1 OFFSET(8) NUMBITS(1) [],
-        a1 OFFSET(9) NUMBITS(2) [
+        l0 OFFSET(7) NUMBITS(1) [],
+
+        r1 OFFSET(8) NUMBITS(1) [],
+        w1 OFFSET(9) NUMBITS(1) [],
+        x1 OFFSET(10) NUMBITS(1) [],
+        a1 OFFSET(11) NUMBITS(2) [
             OFF = 0,
             TOR = 1,
             NA4 = 2,
             NAPOT = 3
         ],
         l1 OFFSET(15) NUMBITS(1) [],
+
         r2 OFFSET(16) NUMBITS(1) [],
         w2 OFFSET(17) NUMBITS(1) [],
         x2 OFFSET(18) NUMBITS(1) [],
@@ -34,6 +36,7 @@ register_bitfields![u32,
             NAPOT = 3
         ],
         l2 OFFSET(23) NUMBITS(1) [],
+
         r3 OFFSET(24) NUMBITS(1) [],
         w3 OFFSET(25) NUMBITS(1) [],
         x3 OFFSET(26) NUMBITS(1) [],


### PR DESCRIPTION
### Pull Request Overview

This PR fixes up the RV32 PMP config offsets.


### Testing Strategy

Running Tock on QEMU with PMP enabled.


### TODO or Help Wanted


### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make formatall`.
