### PR TITLE
add method for measuring elapsed time using systick

### DIFF
--- a/arch/cortex-m/src/systick.rs
+++ b/arch/cortex-m/src/systick.rs
@@ -132,6 +132,12 @@ impl kernel::SysTick for SysTick {
         value > tics
     }
 
+    fn get_value(&self) -> u32 {
+        let tics = SYSTICK_BASE.syst_cvr.read(CurrentValue::CURRENT) as u64;
+        let hertz = self.hertz() as u64;
+        (tics * 1_000_000 / hertz) as u32
+    }
+
     fn overflowed(&self) -> bool {
         SYSTICK_BASE.syst_csr.is_set(ControlAndStatus::COUNTFLAG)
     }

--- a/kernel/src/platform/systick.rs
+++ b/kernel/src/platform/systick.rs
@@ -21,6 +21,9 @@ pub trait SysTick {
     /// Returns if there is at least `us` microseconds left
     fn greater_than(&self, us: u32) -> bool;
 
+    /// Get number of us remaining on timer
+    fn get_value(&self) -> u32;
+
     /// Returns true if the timer has expired
     fn overflowed(&self) -> bool;
 
@@ -51,6 +54,10 @@ impl SysTick for () {
 
     fn overflowed(&self) -> bool {
         false
+    }
+
+    fn get_value(&self) -> u32 {
+        0 // without a real systick, cannot measure time elapsed
     }
 
     fn greater_than(&self, _: u32) -> bool {

--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -270,6 +270,7 @@ impl Kernel {
                     chip.mpu().enable_mpu();
                     systick.enable(true);
                     let context_switch_reason = process.switch_to();
+                    let _elapsed = KERNEL_TICK_DURATION_US - systick.get_value();
                     systick.enable(false);
                     chip.mpu().disable_mpu();
 


### PR DESCRIPTION
### Pull Request Overview

This pull request modifies the `SysTick` trait to add a `get_value()` method that returns the number of microseconds remaining on the systick timer (which counts down). This method allows the scheduler to quickly measure how much of its time slice an app has used, which I would like to use in my upcoming PR showcasing several new scheduler designs for Tock. It also implements this method for the cortex-m architecture. 

I am planning to break up my upcoming Scheduling-related PRs into minimal pieces to ease review.

Part of #1441.

### Testing Strategy

This pull request was tested by calling the get_value() method in the scheduler after an app returns to the kernel and printing the elapsed time.

I also used the sam4l DWT to measure the number of cycles required to execute this function (I was slightly concerned about floating point math), and found that executing the 3-line body consistently requires 20 cycles, which I believe to be a sufficiently small cost.


### TODO or Help Wanted

While implementing this I realized that we currently only have a real SysTick implementation for Cortex-M boards (RISC-V boards use the mock systick implementation that allows apps to run indefinitely). Is it fair to anticipate that the whatever we ultimately use as a SysTick on RISC-V will support getting the amount of time remaining?

Also, do I have to disable interrupts before calling `get_value()` in `sched.rs`, or is after fine?

### Documentation Updated

- [x] No updates are required.

### Formatting

- [x] Ran `make formatall`.
