### PR TITLE
chips/ibex: Normalize timer interrupt handler

### DIFF
--- a/boards/opentitan/README.md
+++ b/boards/opentitan/README.md
@@ -12,7 +12,7 @@ You can get started with OpenTitan using either the Nexys Video FPGA board or si
 Programming
 -----------
 
-OpenTitan requires commit 12d48111539c765567467c12c6f5486ce6d1140c "[rv_plic] Work around sim/synth mismatch in Vivado" or newer.
+Tock on OpenTitan requires lowRISC/opentitan@3c5b86f1ad4077caa080b7cc19a8e1aecd23edee or newer.
 
 For more information you can follow the [OpenTitan development flow](https://docs.opentitan.org/doc/ug/getting_started_fpga/index.html#testing-the-demo-design) to flash the image.
 


### PR DESCRIPTION
### Pull Request Overview

With the merge of lowRISC/opentitan@3c5b86f1ad4077caa080b7cc19a8e1aecd23edee (or lowRISC/ibex@2a42c23eafb43943da35684ced2b94e5c40aa213 for anything using the Ibex core by itself), the behavior of the `mip` CSR is now conforming to the RISC-V specification.  This eliminates the need for the rv_timer driver to track pending events in the top half of the interrupt handling.

### Testing Strategy

This was tested using a Verilator model to confirm proper behavior from both the timer and PLIC-attached (UART) peripherals.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
