### PR TITLE
nrf52: remove duplicate radio reference

### DIFF
--- a/boards/nordic/nrf52dk_base/src/nrf52_components/ble.rs
+++ b/boards/nordic/nrf52dk_base/src/nrf52_components/ble.rs
@@ -6,8 +6,6 @@
 //! let ble_radio = BLEComponent::new(board_kernel, &nrf52::ble_radio::RADIO, mux_alarm).finalize();
 //! ```
 
-#![allow(dead_code)] // Components are intended to be conditionally included
-
 use capsules;
 use capsules::virtual_alarm::VirtualMuxAlarm;
 
@@ -63,19 +61,17 @@ impl Component for BLEComponent {
                 VirtualMuxAlarm<'static, Rtc>,
             >,
             capsules::ble_advertising_driver::BLE::new(
-                &nrf52::ble_radio::RADIO,
+                self.radio,
                 self.board_kernel.create_grant(&grant_cap),
                 &mut capsules::ble_advertising_driver::BUF,
                 ble_radio_virtual_alarm
             )
         );
         kernel::hil::ble_advertising::BleAdvertisementDriver::set_receive_client(
-            &nrf52::ble_radio::RADIO,
-            ble_radio,
+            self.radio, ble_radio,
         );
         kernel::hil::ble_advertising::BleAdvertisementDriver::set_transmit_client(
-            &nrf52::ble_radio::RADIO,
-            ble_radio,
+            self.radio, ble_radio,
         );
         hil::time::Alarm::set_client(ble_radio_virtual_alarm, ble_radio);
 

--- a/boards/nordic/nrf52dk_base/src/nrf52_components/ieee802154.rs
+++ b/boards/nordic/nrf52dk_base/src/nrf52_components/ieee802154.rs
@@ -10,8 +10,6 @@
 //! let (ieee802154_radio, _) = Ieee802154Component::new(board_kernel, &nrf52::ieee802154_radio::RADIO, PAN_ID, SRC_MAC).finalize();
 //! ```
 
-#![allow(dead_code)] // Components are intended to be conditionally included
-
 use capsules;
 use capsules::ieee802154::device::MacDevice;
 use capsules::ieee802154::mac::{AwakeMac, Mac};


### PR DESCRIPTION
### Pull Request Overview

The advertising driver holds an internal reference to the radio,
so the BLEComponent itself doesn't need to hold an explicit reference.

Inspired/found by #1593 and removing more unneeded dead code annotations.

---

@hudson-ayers you were right about this one though! :)

### Testing Strategy

This pull request was tested by compiling.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
