### PR TITLE
Print out syscall return value as a format instead of a number

### DIFF
--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -289,11 +289,12 @@ impl Kernel {
                                     let res = memop::memop(process, operand, arg0);
                                     if config::CONFIG.trace_syscalls {
                                         debug!(
-                                            "[{:?}] memop({}, {:#x}) = {:#x}",
+                                            "[{:?}] memop({}, {:#x}) = {:#x} = {:?}",
                                             appid,
                                             operand,
                                             arg0,
-                                            usize::from(res)
+                                            usize::from(res),
+                                            res
                                         );
                                     }
                                     process.set_syscall_return_value(res.into());
@@ -335,13 +336,14 @@ impl Kernel {
                                         );
                                     if config::CONFIG.trace_syscalls {
                                         debug!(
-                                            "[{:?}] subscribe({:#x}, {}, @{:#x}, {:#x}) = {:#x}",
+                                            "[{:?}] subscribe({:#x}, {}, @{:#x}, {:#x}) = {:#x} = {:?}",
                                             appid,
                                             driver_number,
                                             subdriver_number,
                                             callback_ptr as usize,
                                             appdata,
-                                            usize::from(res)
+                                            usize::from(res),
+                                            res
                                         );
                                     }
                                     process.set_syscall_return_value(res.into());
@@ -364,13 +366,14 @@ impl Kernel {
                                         );
                                     if config::CONFIG.trace_syscalls {
                                         debug!(
-                                            "[{:?}] cmd({:#x}, {}, {:#x}, {:#x}) = {:#x}",
+                                            "[{:?}] cmd({:#x}, {}, {:#x}, {:#x}) = {:#x} = {:?}",
                                             appid,
                                             driver_number,
                                             subdriver_number,
                                             arg0,
                                             arg1,
-                                            usize::from(res)
+                                            usize::from(res),
+                                            res
                                         );
                                     }
                                     process.set_syscall_return_value(res.into());
@@ -396,13 +399,14 @@ impl Kernel {
                                     });
                                     if config::CONFIG.trace_syscalls {
                                         debug!(
-                                            "[{:?}] allow({:#x}, {}, @{:#x}, {:#x}) = {:#x}",
+                                            "[{:?}] allow({:#x}, {}, @{:#x}, {:#x}) = {:#x} = {:?}",
                                             appid,
                                             driver_number,
                                             subdriver_number,
                                             allow_address as usize,
                                             allow_size,
-                                            usize::from(res)
+                                            usize::from(res),
+                                            res
                                         );
                                     }
                                     process.set_syscall_return_value(res.into());


### PR DESCRIPTION
### Pull Request Overview

The syscall tracing currently prints out the return values as hex codes. Those are hard to decode without looking up the numbers and then memorizing them. Just go ahead and print out the name of the symbol.

### Testing Strategy

Tested via other debugging that the messages showed up as expected:

```
[0] cmd(0x0, 2, 0x0, 0x0) = SuccessWithValue { value: 562167 }
[0] cmd(0x2, 1, 0x0, 0x0) = SUCCESS
[0] cmd(0x2, 2, 0x1, 0x0) = SUCCESS
[0] cmd(0x2, 2, 0x2, 0x0) = SUCCESS
[0] cmd(0x2, 2, 0x3, 0x0) = SUCCESS
[0] cmd(0x2, 2, 0x4, 0x0) = SUCCESS
[0] cmd(0x2, 2, 0x5, 0x0) = SUCCESS
```

### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make formatall`.

The existing code was already violating the format. I can clean that up as part of this request if needed.