### PR TITLE
rv32i: pmp: use TOR in disable_mpu

### DIFF
--- a/arch/rv32i/src/pmp.rs
+++ b/arch/rv32i/src/pmp.rs
@@ -321,7 +321,7 @@ impl kernel::mpu::MPU for PMPConfig {
         csr::CSR.pmpcfg0.modify(csr::pmpconfig::pmpcfg::r0::SET);
         csr::CSR.pmpcfg0.modify(csr::pmpconfig::pmpcfg::w0::SET);
         csr::CSR.pmpcfg0.modify(csr::pmpconfig::pmpcfg::x0::SET);
-        csr::CSR.pmpcfg0.modify(csr::pmpconfig::pmpcfg::a0::OFF)
+        csr::CSR.pmpcfg0.modify(csr::pmpconfig::pmpcfg::a0::TOR)
     }
 
     fn number_total_regions(&self) -> usize {


### PR DESCRIPTION

### Pull Request Overview

After trying to add PMP support to the arty-e21 board, I noticed the disable_mpu function did not work. The difference between my code in asm and the PMP function was the PMP setup one region and then disabled it, instead of set it to top-of-region (TOR). This changes the disabled region to instead by TOR.


### Testing Strategy

This pull request was tested by using it on arty-e21 and verifying an app still runs.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
