### PR TITLE
arty-e21: enable PMP

### DIFF
--- a/boards/arty-e21/src/main.rs
+++ b/boards/arty-e21/src/main.rs
@@ -26,7 +26,7 @@ const FAULT_RESPONSE: kernel::procs::FaultResponse = kernel::procs::FaultRespons
 
 // RAM to be shared by all application processes.
 #[link_section = ".app_memory"]
-static mut APP_MEMORY: [u8; 8192] = [0; 8192];
+static mut APP_MEMORY: [u8; 49152] = [0; 49152];
 
 // Actual memory for holding the active process structures.
 static mut PROCESSES: [Option<&'static dyn kernel::procs::ProcessType>; NUM_PROCS] =

--- a/chips/arty_e21/src/chip.rs
+++ b/chips/arty_e21/src/chip.rs
@@ -12,6 +12,7 @@ extern "C" {
 }
 
 pub struct ArtyExx {
+    pmp: rv32i::pmp::PMPConfig,
     userspace_kernel_boundary: rv32i::syscall::SysCall,
     clic: rv32i::clic::Clic,
 }
@@ -24,6 +25,7 @@ impl ArtyExx {
         let in_use_interrupts: u64 = 0x1FFFF0080;
 
         ArtyExx {
+            pmp: rv32i::pmp::PMPConfig::new(4),
             userspace_kernel_boundary: rv32i::syscall::SysCall::new(),
             clic: rv32i::clic::Clic::new(in_use_interrupts),
         }
@@ -31,45 +33,6 @@ impl ArtyExx {
 
     pub fn enable_all_interrupts(&self) {
         self.clic.enable_all();
-    }
-
-    /// Configure the PMP to allow all accesses in both machine mode (the
-    /// default) and in user mode.
-    ///
-    /// This needs to be replaced with a real PMP driver. See
-    /// https://github.com/tock/tock/issues/1135
-    #[cfg(all(target_arch = "riscv32", target_os = "none"))]
-    pub unsafe fn disable_pmp(&self) {
-        asm!("
-            // PMP PMP PMP
-            // PMP PMP PMP
-            // PMP PMP PMP
-            // PMP PMP PMP
-            // TODO: Add a real PMP driver!!
-            // Take some time to disable the PMP.
-
-            // Set the first region address to 0xFFFFFFFF. When using top-of-range mode
-            // this will include the entire address space.
-            lui  t0, %hi(0xFFFFFFFF)
-            addi t0, t0, %lo(0xFFFFFFFF)
-            csrw 0x3b0, t0    // CSR=pmpaddr0
-
-            // Set the first region to use top-of-range and allow everything.
-            // This is equivalent to:
-            // R=1, W=1, X=1, A=01, L=0
-            li   t0, 0x0F
-            csrw 0x3a0, t0    // CSR=pmpcfg0
-        "
-        :
-        :
-        :
-        : "volatile");
-    }
-
-    // Mock implementation for tests on Travis-CI.
-    #[cfg(not(any(target_arch = "riscv32", target_os = "none")))]
-    pub unsafe fn disable_pmp(&self) {
-        unimplemented!()
     }
 
     /// By default the machine timer is enabled and will trigger interrupts. To
@@ -135,26 +98,18 @@ impl ArtyExx {
     /// operations. Different boards can call the functions that `initialize()`
     /// calls directly if it needs to use a custom setup operation.
     pub unsafe fn initialize(&self) {
-        self.disable_pmp();
         self.disable_machine_timer();
         self.configure_trap_handler();
     }
 }
 
 impl kernel::Chip for ArtyExx {
-    // While there is initial support for a PMP driver (as of 2019-10-04), it is not
-    // complete, and while it should disable the PMP, it seems to cause some negative
-    // side effects (context switching does not work correctly) on the Arty-E21 platform.
-    //
-    // TODO: implement the PMP driver and add it here `type MPU = rv32i::pmp::PMPConfig;`.
-    //
-    // See https://github.com/tock/tock/pull/1382 for (a little) more information.
-    type MPU = ();
+    type MPU = rv32i::pmp::PMPConfig;
     type UserspaceKernelBoundary = rv32i::syscall::SysCall;
     type SysTick = ();
 
     fn mpu(&self) -> &Self::MPU {
-        &()
+        &self.pmp
     }
 
     fn systick(&self) -> &Self::SysTick {


### PR DESCRIPTION
This removes the assembly for disabling the PMP, uses the PMP driver when running apps, and maximizes the RAM available to processes.


### Testing Strategy

The blink app still runs on the arty-e21 with this change. I had to increase the app ram to make it work, however.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
