### PR TITLE
boards/opentitan: Fix bad pointer dereference

### DIFF
--- a/boards/opentitan/src/main.rs
+++ b/boards/opentitan/src/main.rs
@@ -220,10 +220,6 @@ pub unsafe fn reset_handler() {
         FAULT_RESPONSE,
         &process_mgmt_cap,
     );
-    let bad_ptr = 0x81200000 as *mut u8;
-    let val = *bad_ptr;
-    if val == 0 {
-        debug!("Dereferenced bad pointer.");
-    }
+
     board_kernel.kernel_loop(&opentitan, chip, None, &main_loop_cap);
 }


### PR DESCRIPTION
### Pull Request Overview

Commit b73429fc0b714545ba83773f81dc68da4792d05e introduced a bad pointer
dereference, let's remove it.


### Testing Strategy

N/A


### TODO or Help Wanted

N/A


### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make formatall`.
