### PR TITLE
ADC Capsule: More work on supporting restarts.

### DIFF
--- a/capsules/src/adc.rs
+++ b/capsules/src/adc.rs
@@ -276,7 +276,9 @@ impl<A: hil::adc::Adc + hil::adc::AdcHighSpeed> Adc<'a, A> {
                     state.app_buf1.is_some()
                 })
                 .map_err(|err| {
-                    if err == kernel::procs::Error::NoSuchApp {
+                    if err == kernel::procs::Error::NoSuchApp
+                        || err == kernel::procs::Error::InactiveApp
+                    {
                         self.appid.clear();
                     }
                 })
@@ -334,7 +336,9 @@ impl<A: hil::adc::Adc + hil::adc::AdcHighSpeed> Adc<'a, A> {
                     res
                 })
                 .map_err(|err| {
-                    if err == kernel::procs::Error::NoSuchApp {
+                    if err == kernel::procs::Error::NoSuchApp
+                        || err == kernel::procs::Error::InactiveApp
+                    {
                         self.appid.clear();
                     }
                 })
@@ -351,7 +355,9 @@ impl<A: hil::adc::Adc + hil::adc::AdcHighSpeed> Adc<'a, A> {
                         app.samples_outstanding.set(0);
                     })
                     .map_err(|err| {
-                        if err == kernel::procs::Error::NoSuchApp {
+                        if err == kernel::procs::Error::NoSuchApp
+                            || err == kernel::procs::Error::InactiveApp
+                        {
                             self.appid.clear();
                         }
                     })
@@ -391,7 +397,9 @@ impl<A: hil::adc::Adc + hil::adc::AdcHighSpeed> Adc<'a, A> {
                     state.app_buf1.is_some() && state.app_buf2.is_some()
                 })
                 .map_err(|err| {
-                    if err == kernel::procs::Error::NoSuchApp {
+                    if err == kernel::procs::Error::NoSuchApp
+                        || err == kernel::procs::Error::InactiveApp
+                    {
                         self.appid.clear();
                     }
                 })
@@ -463,7 +471,9 @@ impl<A: hil::adc::Adc + hil::adc::AdcHighSpeed> Adc<'a, A> {
                     })
                 })
                 .map_err(|err| {
-                    if err == kernel::procs::Error::NoSuchApp {
+                    if err == kernel::procs::Error::NoSuchApp
+                        || err == kernel::procs::Error::InactiveApp
+                    {
                         self.appid.clear();
                     }
                 })
@@ -480,7 +490,9 @@ impl<A: hil::adc::Adc + hil::adc::AdcHighSpeed> Adc<'a, A> {
                         app.samples_outstanding.set(0);
                     })
                     .map_err(|err| {
-                        if err == kernel::procs::Error::NoSuchApp {
+                        if err == kernel::procs::Error::NoSuchApp
+                            || err == kernel::procs::Error::InactiveApp
+                        {
                             self.appid.clear();
                         }
                     })
@@ -528,7 +540,9 @@ impl<A: hil::adc::Adc + hil::adc::AdcHighSpeed> Adc<'a, A> {
                     rc
                 })
                 .map_err(|err| {
-                    if err == kernel::procs::Error::NoSuchApp {
+                    if err == kernel::procs::Error::NoSuchApp
+                        || err == kernel::procs::Error::InactiveApp
+                    {
                         self.appid.clear();
                     }
                 })
@@ -566,7 +580,9 @@ impl<A: hil::adc::Adc + hil::adc::AdcHighSpeed> hil::adc::Client for Adc<'a, A> 
                         });
                     })
                     .map_err(|err| {
-                        if err == kernel::procs::Error::NoSuchApp {
+                        if err == kernel::procs::Error::NoSuchApp
+                            || err == kernel::procs::Error::InactiveApp
+                        {
                             self.appid.clear();
                         }
                     })
@@ -588,7 +604,9 @@ impl<A: hil::adc::Adc + hil::adc::AdcHighSpeed> hil::adc::Client for Adc<'a, A> 
                         });
                     })
                     .map_err(|err| {
-                        if err == kernel::procs::Error::NoSuchApp {
+                        if err == kernel::procs::Error::NoSuchApp
+                            || err == kernel::procs::Error::InactiveApp
+                        {
                             self.appid.clear();
                         }
                     })
@@ -599,6 +617,10 @@ impl<A: hil::adc::Adc + hil::adc::AdcHighSpeed> hil::adc::Client for Adc<'a, A> 
             // callback
             self.active.set(false);
             self.mode.set(AdcMode::NoMode);
+
+            // Also make sure that no more samples are taken if we were in
+            // continuous mode.
+            self.adc.stop_sampling();
         }
     }
 }
@@ -616,6 +638,13 @@ impl<A: hil::adc::Adc + hil::adc::AdcHighSpeed> hil::adc::HighSpeedClient for Ad
     /// - `length` - number of valid samples in the buffer, guaranteed to be
     ///   less than or equal to buffer length
     fn samples_ready(&self, buf: &'static mut [u16], length: usize) {
+        let mut unexpected_state = false;
+
+        // Make sure in all cases we regain ownership of the buffer. However,
+        // we also get a reference back to it so we can copy the sampled values
+        // out and to an application.
+        let buffer_with_samples = self.replace_buffer(buf);
+
         // do we expect a buffer?
         if self.active.get()
             && (self.mode.get() == AdcMode::SingleBuffer
@@ -792,10 +821,9 @@ impl<A: hil::adc::Adc + hil::adc::AdcHighSpeed> hil::adc::HighSpeedClient for Ad
                         }
                         // next we should copy bytes to the app buffer
                         app_buf.map(move |app_buf| {
-                            // copy bytes to app buffer
-                            // first, regain ownership of the buffer and then iterate
-                            // over the data
-                            self.replace_buffer(buf).map(|adc_buf| {
+                            // Copy bytes to app buffer by iterating over the
+                            // data.
+                            buffer_with_samples.map(|adc_buf| {
                                 // The `for` commands:
                                 //  * `chunks_mut`: get sets of two bytes from the app
                                 //                  buffer
@@ -874,14 +902,21 @@ impl<A: hil::adc::Adc + hil::adc::AdcHighSpeed> hil::adc::HighSpeedClient for Ad
                         });
                     })
                     .map_err(|err| {
-                        if err == kernel::procs::Error::NoSuchApp {
+                        if err == kernel::procs::Error::NoSuchApp
+                            || err == kernel::procs::Error::InactiveApp
+                        {
                             self.appid.clear();
+                            unexpected_state = true;
                         }
                     })
             });
         } else {
-            // operation was likely canceled. Make sure state is consistent. No
-            // callback
+            unexpected_state = true;
+        }
+
+        if unexpected_state {
+            // Operation was likely canceled, or the app crashed. Make sure
+            // state is consistent. No callback.
             self.active.set(false);
             self.mode.set(AdcMode::NoMode);
             self.appid.map(|id| {
@@ -890,14 +925,26 @@ impl<A: hil::adc::Adc + hil::adc::AdcHighSpeed> hil::adc::HighSpeedClient for Ad
                         app.app_buf_offset.set(0);
                     })
                     .map_err(|err| {
-                        if err == kernel::procs::Error::NoSuchApp {
+                        if err == kernel::procs::Error::NoSuchApp
+                            || err == kernel::procs::Error::InactiveApp
+                        {
                             self.appid.clear();
                         }
                     })
             });
 
-            // still need to replace the buffer
-            self.replace_buffer(buf);
+            // Make sure we do not take more samples since we know no app
+            // is currently waiting on samples.
+            self.adc.stop_sampling();
+
+            // Also retrieve any buffers we passed to the underlying ADC driver.
+            let (_, buf1, buf2) = self.adc.retrieve_buffers();
+            buf1.map(|buf| {
+                self.replace_buffer(buf);
+            });
+            buf2.map(|buf| {
+                self.replace_buffer(buf);
+            });
         }
     }
 }
@@ -935,7 +982,9 @@ impl<A: hil::adc::Adc + hil::adc::AdcHighSpeed> Driver for Adc<'a, A> {
                             ReturnCode::SUCCESS
                         })
                         .map_err(|err| {
-                            if err == kernel::procs::Error::NoSuchApp {
+                            if err == kernel::procs::Error::NoSuchApp
+                                || err == kernel::procs::Error::InactiveApp
+                            {
                                 self.appid.clear();
                             }
                         })
@@ -953,7 +1002,9 @@ impl<A: hil::adc::Adc + hil::adc::AdcHighSpeed> Driver for Adc<'a, A> {
                             ReturnCode::SUCCESS
                         })
                         .map_err(|err| {
-                            if err == kernel::procs::Error::NoSuchApp {
+                            if err == kernel::procs::Error::NoSuchApp
+                                || err == kernel::procs::Error::InactiveApp
+                            {
                                 self.appid.clear();
                             }
                         })
@@ -996,7 +1047,9 @@ impl<A: hil::adc::Adc + hil::adc::AdcHighSpeed> Driver for Adc<'a, A> {
                             ReturnCode::SUCCESS
                         })
                         .map_err(|err| {
-                            if err == kernel::procs::Error::NoSuchApp {
+                            if err == kernel::procs::Error::NoSuchApp
+                                || err == kernel::procs::Error::InactiveApp
+                            {
                                 self.appid.clear();
                             }
                         })
@@ -1021,8 +1074,33 @@ impl<A: hil::adc::Adc + hil::adc::AdcHighSpeed> Driver for Adc<'a, A> {
         frequency: usize,
         appid: AppId,
     ) -> ReturnCode {
-        let match_or_empty = self.appid.map(|id| id == &appid).unwrap_or(true);
-        if match_or_empty {
+        // Return true if this app already owns the ADC capsule, if no app owns
+        // the ADC capsule, or if the app that is marked as owning the ADC
+        // capsule no longer exists.
+        let match_or_empty_or_nonexistant = self.appid.map_or(true, |owning_app| {
+            // We have recorded that an app has ownership of the ADC.
+
+            // If the ADC is still active, then we need to wait for the operation
+            // to finish and the app, whether it exists or not (it may have crashed),
+            // still owns this capsule. If the ADC is not active, then
+            // we need to verify that that application still exists, and remove
+            // it as owner if not.
+            if self.active.get() {
+                owning_app == &appid
+            } else {
+                // Check the app still exists.
+                //
+                // If the `.enter()` succeeds, then the app is still valid, and
+                // we can check if the owning app matches the one that called
+                // the command. If the `.enter()` fails, then the owning app no
+                // longer exists and we return `true` to signify the
+                // "or_nonexistant" case.
+                self.apps
+                    .enter(*owning_app, |_, _| owning_app == &appid)
+                    .unwrap_or(true)
+            }
+        });
+        if match_or_empty_or_nonexistant {
             self.appid.set(appid);
         } else {
             return ReturnCode::ENOMEM;


### PR DESCRIPTION
### Pull Request Overview

This pull request continues to update the ADC capsule to allow applications to restart while using the ADC driver and for the system to continue working afterwards.

Highlights of changes:

- Handle `InactiveApp` error when checking if a grant region is valid.
- Check on `sample_ready()` and `samples_ready()` if the app is still valid, and properly handle it if not.
- Check on every command syscall if the app that has exclusive control of the adc driver still exists.
- Call stop sampling if a callback from the adc peripheral driver occurs and the app is no longer valid.

Note, if/when the ADC capsule is virtualized then this will no longer be an issue.


### Testing Strategy

I ran the adc and adc_continuous apps numerous times and used the process console to cause them to fault in various stages of their operation. I can now no longer get the ADC capsule into a state where apps only error.


### TODO or Help Wanted

I tested this with a combination of my other PRs #1565 #1566 #1588. Until those are merged this PR/commit alone will not work.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
