### PR TITLE
boards/opentitan: Connect the GPIO capsule

### DIFF
--- a/boards/opentitan/src/main.rs
+++ b/boards/opentitan/src/main.rs
@@ -46,6 +46,7 @@ pub static mut STACK_MEMORY: [u8; 0x1000] = [0; 0x1000];
 /// capsules for this platform. We've included an alarm and console.
 struct OpenTitan {
     led: &'static capsules::led::LED<'static>,
+    gpio: &'static capsules::gpio::GPIO<'static>,
     console: &'static capsules::console::Console<'static>,
     alarm: &'static capsules::alarm::AlarmDriver<
         'static,
@@ -65,6 +66,7 @@ impl Platform for OpenTitan {
     {
         match driver_num {
             capsules::led::DRIVER_NUM => f(Some(self.led)),
+            capsules::gpio::DRIVER_NUM => f(Some(self.gpio)),
             capsules::console::DRIVER_NUM => f(Some(self.console)),
             capsules::alarm::DRIVER_NUM => f(Some(self.alarm)),
             capsules::low_level_debug::DRIVER_NUM => f(Some(self.lldb)),
@@ -163,6 +165,19 @@ pub unsafe fn reset_handler() {
         )
     ));
 
+    let gpio = components::gpio::GpioComponent::new(board_kernel).finalize(
+        components::gpio_component_helper!(
+            &ibex::gpio::PORT[0],
+            &ibex::gpio::PORT[1],
+            &ibex::gpio::PORT[2],
+            &ibex::gpio::PORT[3],
+            &ibex::gpio::PORT[4],
+            &ibex::gpio::PORT[5],
+            &ibex::gpio::PORT[6],
+            &ibex::gpio::PORT[15]
+        ),
+    );
+
     let alarm = &ibex::timer::TIMER;
     alarm.setup();
 
@@ -205,6 +220,7 @@ pub unsafe fn reset_handler() {
     }
 
     let opentitan = OpenTitan {
+        gpio: gpio,
         led: led,
         console: console,
         alarm: alarm,


### PR DESCRIPTION
### Pull Request Overview

Add the GPIO capsule to the OpenTitan board.

### Testing Strategy

Use the GPIOs on OpenTitan.

### TODO or Help Wanted

N/A

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make formatall`.
