### PR TITLE
Enable AES hardware block for OpenTitan

### DIFF
--- a/boards/opentitan/src/aes_test.rs
+++ b/boards/opentitan/src/aes_test.rs
@@ -1,0 +1,36 @@
+//! Test that AES ECB mode is working properly.
+//!
+//! To test ECB mode, add the following line to the opentitan boot sequence:
+//! ```
+//!     aes_test::run_aes128_ecb();
+//! ```
+//! You should see the following output:
+//! ```
+//!     aes_test passed (ECB Enc Src/Dst)
+//!     aes_test passed (ECB Dec Src/Dst)
+//!     aes_test passed (ECB Enc In-place)
+//!     aes_test passed (ECB Dec In-place)
+//! ```
+
+use capsules::test::aes::TestAes128Ecb;
+use ibex::aes::{Aes, AES};
+use kernel::hil::symmetric_encryption::{AES128, AES128_BLOCK_SIZE, AES128_KEY_SIZE};
+use kernel::static_init;
+
+pub unsafe fn run_aes128_ecb() {
+    let t = static_init_test_ecb();
+    AES.set_client(t);
+
+    t.run();
+}
+
+unsafe fn static_init_test_ecb() -> &'static mut TestAes128Ecb<'static, Aes<'static>> {
+    let source = static_init!([u8; 4 * AES128_BLOCK_SIZE], [0; 4 * AES128_BLOCK_SIZE]);
+    let data = static_init!([u8; 6 * AES128_BLOCK_SIZE], [0; 6 * AES128_BLOCK_SIZE]);
+    let key = static_init!([u8; AES128_KEY_SIZE], [0; AES128_KEY_SIZE]);
+
+    static_init!(
+        TestAes128Ecb<'static, Aes>,
+        TestAes128Ecb::new(&AES, key, source, data)
+    )
+}

--- a/boards/opentitan/src/main.rs
+++ b/boards/opentitan/src/main.rs
@@ -15,6 +15,9 @@ use kernel::Platform;
 use kernel::{create_capability, debug, static_init};
 use rv32i::csr;
 
+#[allow(dead_code)]
+mod aes_test;
+
 pub mod io;
 //
 // Actual memory for holding the active process structures. Need an empty list
@@ -195,6 +198,7 @@ pub unsafe fn reset_handler() {
 
     let lldb = components::lldb::LowLevelDebugComponent::new(board_kernel, uart_mux).finalize(());
 
+    aes_test::run_aes128_ecb();
     debug!("OpenTitan initialisation complete. Entering main loop");
 
     extern "C" {

--- a/capsules/src/test/aes.rs
+++ b/capsules/src/test/aes.rs
@@ -5,7 +5,7 @@ use kernel::common::cells::TakeCell;
 use kernel::debug;
 use kernel::hil;
 use kernel::hil::symmetric_encryption::{
-    AES128Ctr, AES128, AES128CBC, AES128_BLOCK_SIZE, AES128_KEY_SIZE,
+    AES128Ctr, AES128, AES128CBC, AES128ECB, AES128_BLOCK_SIZE, AES128_KEY_SIZE,
 };
 use kernel::ReturnCode;
 
@@ -33,8 +33,102 @@ pub struct TestAes128Cbc<'a, A: 'a> {
     use_source: Cell<bool>,
 }
 
+pub struct TestAes128Ecb<'a, A: 'a> {
+    aes: &'a A,
+
+    key: TakeCell<'a, [u8]>,
+    source: TakeCell<'a, [u8]>,
+    data: TakeCell<'a, [u8]>,
+
+    encrypting: Cell<bool>,
+    use_source: Cell<bool>,
+}
+
 const DATA_OFFSET: usize = AES128_BLOCK_SIZE;
 const DATA_LEN: usize = 4 * AES128_BLOCK_SIZE;
+
+impl<A: AES128<'a> + AES128ECB> TestAes128Ecb<'a, A> {
+    pub fn new(aes: &'a A, key: &'a mut [u8], source: &'a mut [u8], data: &'a mut [u8]) -> Self {
+        TestAes128Ecb {
+            aes: aes,
+
+            key: TakeCell::new(key),
+            source: TakeCell::new(source),
+            data: TakeCell::new(data),
+
+            encrypting: Cell::new(true),
+            use_source: Cell::new(true),
+        }
+    }
+
+    pub fn run(&self) {
+        self.aes.enable();
+
+        // Copy key into key buffer and configure it in the hardware
+        self.key.map(|key| {
+            for (i, b) in KEY.iter().enumerate() {
+                key[i] = *b;
+            }
+
+            assert!(self.aes.set_key(key) == ReturnCode::SUCCESS);
+        });
+
+        // Copy mode-appropriate source into source buffer
+        let source_mode = if self.encrypting.get() {
+            &PTXT
+        } else {
+            &CTXT_ECB
+        };
+        self.source.map(|source| {
+            for (i, b) in source_mode.iter().enumerate() {
+                source[i] = *b;
+            }
+        });
+
+        if !self.use_source.get() {
+            // Copy source into dest for in-place encryption
+            self.source.map_or_else(
+                || panic!("No source"),
+                |source| {
+                    self.data.map_or_else(
+                        || panic!("No data"),
+                        |data| {
+                            for (i, b) in source.iter().enumerate() {
+                                data[DATA_OFFSET + i] = *b;
+                            }
+                        },
+                    );
+                },
+            );
+        }
+
+        self.aes.set_mode_aes128ecb(self.encrypting.get());
+        self.aes.start_message();
+
+        let start = DATA_OFFSET;
+        let stop = DATA_OFFSET + DATA_LEN;
+
+        match self.aes.crypt(
+            if self.use_source.get() {
+                self.source.take()
+            } else {
+                None
+            },
+            self.data.take().unwrap(),
+            start,
+            stop,
+        ) {
+            None => {
+                // await crypt_done()
+            }
+            Some((result, source, dest)) => {
+                self.source.put(source);
+                self.data.put(Some(dest));
+                panic!("crypt() failed: {:?}", result);
+            }
+        }
+    }
+}
 
 impl<A: AES128<'a> + AES128Ctr> TestAes128Ctr<'a, A> {
     pub fn new(
@@ -343,6 +437,61 @@ impl<A: AES128<'a> + AES128CBC> hil::symmetric_encryption::Client<'a> for TestAe
     }
 }
 
+impl<A: AES128<'a> + AES128ECB> hil::symmetric_encryption::Client<'a> for TestAes128Ecb<'a, A> {
+    fn crypt_done(&'a self, source: Option<&'a mut [u8]>, dest: &'a mut [u8]) {
+        if self.use_source.get() {
+            // Take back the source buffer
+            self.source.put(source);
+        }
+
+        // Take back the destination buffer
+        self.data.replace(dest);
+
+        let expected = if self.encrypting.get() {
+            &CTXT_ECB
+        } else {
+            &PTXT
+        };
+
+        if self.data.map_or(false, |data| {
+            &data[DATA_OFFSET..DATA_OFFSET + DATA_LEN] == expected.as_ref()
+        }) {
+            debug!(
+                "aes_test passed (ECB {} {})",
+                if self.encrypting.get() { "Enc" } else { "Dec" },
+                if self.use_source.get() {
+                    "Src/Dst"
+                } else {
+                    "In-place"
+                }
+            );
+        } else {
+            debug!(
+                "aes_test failed: (ECB {} {})",
+                if self.encrypting.get() { "Enc" } else { "Dec" },
+                if self.use_source.get() {
+                    "Src/Dst"
+                } else {
+                    "In-place"
+                }
+            );
+        }
+        self.aes.disable();
+
+        // Continue testing with other configurations
+        if self.encrypting.get() {
+            self.encrypting.set(false);
+            self.run();
+        } else {
+            if self.use_source.get() {
+                self.use_source.set(false);
+                self.encrypting.set(true);
+                self.run();
+            }
+        }
+    }
+}
+
 #[rustfmt::skip]
 const KEY: [u8; AES128_KEY_SIZE] = [
     0x2b, 0x7e, 0x15, 0x16, 0x28, 0xae, 0xd2, 0xa6,
@@ -395,4 +544,16 @@ const CTXT_CBC: [u8; 4 * AES128_BLOCK_SIZE] = [
     0x71, 0x16, 0xe6, 0x9e, 0x22, 0x22, 0x95, 0x16,
     0x3f, 0xf1, 0xca, 0xa1, 0x68, 0x1f, 0xac, 0x09,
     0x12, 0x0e, 0xca, 0x30, 0x75, 0x86, 0xe1, 0xa7
+];
+
+#[rustfmt::skip]
+const CTXT_ECB: [u8; 4 * AES128_BLOCK_SIZE] = [
+    0x3a, 0xd7, 0x7b, 0xb4, 0x0d, 0x7a, 0x36, 0x60,
+    0xa8, 0x9e, 0xca, 0xf3, 0x24, 0x66, 0xef, 0x97,
+    0xf5, 0xd3, 0xd5, 0x85, 0x03, 0xb9, 0x69, 0x9d,
+    0xe7, 0x85, 0x89, 0x5a, 0x96, 0xfd, 0xba, 0xaf,
+    0x43, 0xb1, 0xcd, 0x7f, 0x59, 0x8e, 0xce, 0x23,
+    0x88, 0x1b, 0x00, 0xe3, 0xed, 0x03, 0x06, 0x88,
+    0x7b, 0x0c, 0x78, 0x5e, 0x27, 0xe8, 0xad, 0x3f,
+    0x82, 0x23, 0x20, 0x71, 0x04, 0x72, 0x5d, 0xd4
 ];

--- a/chips/ibex/src/aes.rs
+++ b/chips/ibex/src/aes.rs
@@ -1,0 +1,352 @@
+//! Support for the AES hardware block on OpenTitan
+//!
+//! https://docs.opentitan.org/hw/ip/aes/doc/
+
+use kernel::common::cells::{OptionalCell, TakeCell};
+use kernel::common::registers::{
+    register_bitfields, register_structs, ReadOnly, ReadWrite, WriteOnly,
+};
+use kernel::common::StaticRef;
+use kernel::debug;
+use kernel::hil;
+use kernel::hil::symmetric_encryption;
+use kernel::hil::symmetric_encryption::{AES128_BLOCK_SIZE, AES128_KEY_SIZE};
+use kernel::ReturnCode;
+
+const MAX_LENGTH: usize = 128;
+
+register_structs! {
+    pub AesRegisters {
+        (0x00 => key0: WriteOnly<u32>),
+        (0x04 => key1: WriteOnly<u32>),
+        (0x08 => key2: WriteOnly<u32>),
+        (0x0c => key3: WriteOnly<u32>),
+        (0x10 => key4: WriteOnly<u32>),
+        (0x14 => key5: WriteOnly<u32>),
+        (0x18 => key6: WriteOnly<u32>),
+        (0x1c => key7: WriteOnly<u32>),
+        (0x20 => data_in0: WriteOnly<u32>),
+        (0x24 => data_in1: WriteOnly<u32>),
+        (0x28 => data_in2: WriteOnly<u32>),
+        (0x2c => data_in3: WriteOnly<u32>),
+        (0x30 => data_out0: ReadOnly<u32>),
+        (0x34 => data_out1: ReadOnly<u32>),
+        (0x38 => data_out2: ReadOnly<u32>),
+        (0x3c => data_out3: ReadOnly<u32>),
+        (0x40 => ctrl: ReadWrite<u32, CTRL::Register>),
+        (0x44 => trigger: WriteOnly<u32, TRIGGER::Register>),
+        (0x48 => status: ReadOnly<u32, STATUS::Register>),
+        (0x4c => @END),
+    }
+}
+
+register_bitfields![u32,
+    CTRL [
+        OPERATION OFFSET(0) NUMBITS(1) [
+            Encrypting = 0,
+            Decrypting = 1
+        ],
+        KEY_LEN OFFSET(1) NUMBITS(3) [
+            Key128 = 1,
+            Key192 = 2,
+            Key256 = 4
+        ],
+        MANUAL_OPERATION OFFSET(4) NUMBITS(1) []
+    ],
+    TRIGGER [
+        START OFFSET(0) NUMBITS(1) [],
+        KEY_CLEAR OFFSET(1) NUMBITS(1) [],
+        DATA_IN_CLEAR OFFSET(2) NUMBITS(1) [],
+        DATA_OUT_CLEAR OFFSET(3) NUMBITS(1) []
+    ],
+    STATUS [
+        IDLE 0,
+        STALL 1,
+        OUTPUT_VALID 2,
+        INPUT_READY 3
+    ]
+];
+
+// https://docs.opentitan.org/hw/top_earlgrey/doc/
+const AES_BASE: StaticRef<AesRegisters> =
+    unsafe { StaticRef::new(0x40110000 as *const AesRegisters) };
+
+pub struct Aes<'a> {
+    registers: StaticRef<AesRegisters>,
+
+    client: OptionalCell<&'a dyn hil::symmetric_encryption::Client<'a>>,
+    source: TakeCell<'a, [u8]>,
+    dest: TakeCell<'a, [u8]>,
+}
+
+impl Aes<'a> {
+    const fn new() -> Aes<'a> {
+        Aes {
+            registers: AES_BASE,
+            client: OptionalCell::empty(),
+            source: TakeCell::empty(),
+            dest: TakeCell::empty(),
+        }
+    }
+
+    fn clear(&self) {
+        let regs = self.registers;
+        regs.trigger.write(
+            TRIGGER::KEY_CLEAR::SET + TRIGGER::DATA_IN_CLEAR::SET + TRIGGER::DATA_OUT_CLEAR::SET,
+        );
+    }
+
+    fn configure(&self, encrypting: bool) {
+        let regs = self.registers;
+        let e = if encrypting {
+            CTRL::OPERATION::Encrypting
+        } else {
+            CTRL::OPERATION::Decrypting
+        };
+        // Set this in manual mode for the moment since automatic block mode
+        // does not appear to be working
+
+        regs.ctrl
+            .write(e + CTRL::KEY_LEN::Key128 + CTRL::MANUAL_OPERATION::SET);
+    }
+
+    fn idle(&self) -> bool {
+        let regs = self.registers;
+        return regs.status.is_set(STATUS::IDLE);
+    }
+
+    fn input_ready(&self) -> bool {
+        let regs = self.registers;
+        return regs.status.is_set(STATUS::INPUT_READY);
+    }
+
+    fn output_valid(&self) -> bool {
+        let regs = self.registers;
+        return regs.status.is_set(STATUS::OUTPUT_VALID);
+    }
+
+    fn trigger(&self) {
+        let regs = self.registers;
+        regs.trigger.write(TRIGGER::START::SET);
+    }
+
+    fn read_block(&self, blocknum: usize) {
+        let regs = self.registers;
+        let blocknum = blocknum * AES128_BLOCK_SIZE;
+
+        loop {
+            if self.output_valid() {
+                break;
+            }
+        }
+
+        self.dest.map_or_else(
+            || {
+                debug!("Called read_block() with no data");
+            },
+            |dest| {
+                for i in 0..4 {
+                    // we work off an array of u8 so we need to assemble those
+                    // back into a u32
+                    let mut v = 0;
+                    match i {
+                        0 => v = regs.data_out0.get(),
+                        1 => v = regs.data_out1.get(),
+                        2 => v = regs.data_out2.get(),
+                        3 => v = regs.data_out3.get(),
+                        _ => {}
+                    }
+                    dest[blocknum + (i * 4) + 0] = (v >> 0) as u8;
+                    dest[blocknum + (i * 4) + 1] = (v >> 8) as u8;
+                    dest[blocknum + (i * 4) + 2] = (v >> 16) as u8;
+                    dest[blocknum + (i * 4) + 3] = (v >> 24) as u8;
+                }
+            },
+        );
+    }
+
+    fn write_block(&self, blocknum: usize) {
+        let regs = self.registers;
+        let blocknum = blocknum * AES128_BLOCK_SIZE;
+
+        loop {
+            if self.input_ready() {
+                break;
+            }
+        }
+
+        self.source.map_or_else(
+            || {
+                // This is the case that dest = source
+                self.dest.map_or_else(
+                    || {
+                        debug!("Called write_block() with no data");
+                    },
+                    |dest| {
+                        for i in 0..4 {
+                            // we work off an array of u8 so we need to
+                            // assemble those back into a u32
+                            let mut v = dest[blocknum + (i * 4) + 0] as usize;
+                            v |= (dest[blocknum + (i * 4) + 1] as usize) << 8;
+                            v |= (dest[blocknum + (i * 4) + 2] as usize) << 16;
+                            v |= (dest[blocknum + (i * 4) + 3] as usize) << 24;
+                            match i {
+                                0 => regs.data_in0.set(v as u32),
+                                1 => regs.data_in1.set(v as u32),
+                                2 => regs.data_in2.set(v as u32),
+                                3 => regs.data_in3.set(v as u32),
+                                _ => {}
+                            }
+                        }
+                    },
+                )
+            },
+            |source| {
+                for i in 0..4 {
+                    // we work off an array of u8 so we need to assemble
+                    // those back into a u32
+                    let mut v = source[blocknum + (i * 4) + 0] as usize;
+                    v |= (source[blocknum + (i * 4) + 1] as usize) << 8;
+                    v |= (source[blocknum + (i * 4) + 2] as usize) << 16;
+                    v |= (source[blocknum + (i * 4) + 3] as usize) << 24;
+                    match i {
+                        0 => regs.data_in0.set(v as u32),
+                        1 => regs.data_in1.set(v as u32),
+                        2 => regs.data_in2.set(v as u32),
+                        3 => regs.data_in3.set(v as u32),
+                        _ => {}
+                    }
+                }
+            },
+        );
+    }
+
+    fn set_key(&self, key: &[u8]) -> ReturnCode {
+        let regs = self.registers;
+
+        loop {
+            if self.idle() {
+                break;
+            }
+        }
+
+        if key.len() != AES128_KEY_SIZE {
+            return ReturnCode::EINVAL;
+        }
+
+        for i in 0..4 {
+            let mut k = key[i * 4 + 0] as usize;
+            k |= (key[i * 4 + 1] as usize) << 8;
+            k |= (key[i * 4 + 2] as usize) << 16;
+            k |= (key[i * 4 + 3] as usize) << 24;
+            match i {
+                0 => regs.key0.set(k as u32),
+                1 => regs.key1.set(k as u32),
+                2 => regs.key2.set(k as u32),
+                3 => regs.key3.set(k as u32),
+                _ => {}
+            }
+        }
+
+        // We must write the rest of the registers as well
+        regs.key4.set(0);
+        regs.key5.set(0);
+        regs.key6.set(0);
+        regs.key7.set(0);
+        ReturnCode::SUCCESS
+    }
+
+    fn do_crypt(&self, start_index: usize, stop_index: usize, wr_start_index: usize) {
+        // convert our indicies into the array into block numbers
+        // start and end are pointer for reading
+        // write is the pointer for writing
+        // Note that depending on whether or not we have separate source
+        // and dest buffers the write and read pointers may index into
+        // different arrays.
+        let start_block = start_index / AES128_BLOCK_SIZE;
+        let end_block = stop_index / AES128_BLOCK_SIZE;
+        let mut write_block = wr_start_index / AES128_BLOCK_SIZE;
+        for i in start_block..end_block {
+            self.write_block(write_block);
+            self.trigger();
+            self.read_block(i);
+            write_block = write_block + 1;
+        }
+    }
+}
+
+impl hil::symmetric_encryption::AES128<'a> for Aes<'a> {
+    fn enable(&self) {
+        self.configure(true);
+    }
+
+    fn disable(&self) {
+        self.clear();
+    }
+
+    fn set_client(&'a self, client: &'a dyn symmetric_encryption::Client<'a>) {
+        self.client.set(client);
+    }
+
+    fn set_iv(&self, _iv: &[u8]) -> ReturnCode {
+        // nothing because this is ECB
+        ReturnCode::SUCCESS
+    }
+
+    fn start_message(&self) {
+        return;
+    }
+
+    fn set_key(&self, key: &[u8]) -> ReturnCode {
+        return self.set_key(key);
+    }
+
+    fn crypt(
+        &'a self,
+        source: Option<&'a mut [u8]>,
+        dest: &'a mut [u8],
+        start_index: usize,
+        stop_index: usize,
+    ) -> Option<(ReturnCode, Option<&'a mut [u8]>, &'a mut [u8])> {
+        match stop_index.checked_sub(start_index) {
+            None => return Some((ReturnCode::EINVAL, source, dest)),
+            Some(s) => {
+                if s > MAX_LENGTH {
+                    return Some((ReturnCode::EINVAL, source, dest));
+                }
+                if s % AES128_BLOCK_SIZE != 0 {
+                    return Some((ReturnCode::EINVAL, source, dest));
+                }
+            }
+        }
+        self.dest.replace(dest);
+        // The crypt API has two cases: separate source and destination
+        // buffers and a single source buffer.
+        // If we don't have a separate source buffer, we overwrite the
+        // destination with the data. This means that read index and write
+        // index match
+        // If we do have a separate source buffer, we start writing from
+        // 0 and the read index is separate.
+        match source {
+            None => {
+                self.do_crypt(start_index, stop_index, start_index);
+            }
+            Some(src) => {
+                self.source.replace(src);
+                self.do_crypt(start_index, stop_index, 0);
+            }
+        }
+        self.client.map(|client| {
+            client.crypt_done(self.source.take(), self.dest.take().unwrap());
+        });
+        None
+    }
+}
+
+pub static mut AES: Aes<'static> = Aes::new();
+
+impl kernel::hil::symmetric_encryption::AES128ECB for Aes<'a> {
+    fn set_mode_aes128ecb(&self, encrypting: bool) {
+        self.configure(encrypting);
+    }
+}

--- a/chips/ibex/src/lib.rs
+++ b/chips/ibex/src/lib.rs
@@ -8,6 +8,7 @@
 
 mod interrupts;
 
+pub mod aes;
 pub mod chip;
 pub mod gpio;
 pub mod plic;

--- a/kernel/src/hil/symmetric_encryption.rs
+++ b/kernel/src/hil/symmetric_encryption.rs
@@ -96,6 +96,11 @@ pub trait AES128CBC {
     fn set_mode_aes128cbc(&self, encrypting: bool);
 }
 
+pub trait AES128ECB {
+    /// Call before `AES128::crypt()` to perform AES128ECB
+    fn set_mode_aes128ecb(&self, encrypting: bool);
+}
+
 pub trait CCMClient {
     /// `res` is SUCCESS if the encryption/decryption process succeeded. This
     /// does not mean that the message has been verified in the case of


### PR DESCRIPTION
### Pull Request Overview

This pull request enables the AES hardware block as specified in https://docs.opentitan.org/hw/ip/aes/doc/ . Note that the automatic operation currently has a bug (https://github.com/lowRISC/opentitan/issues/1560) so this implementation uses the manual trigger mode.
I had to extend a few traits to add ECB mode for AES (yes it's not particularly secure but it's good to support it)

### Testing Strategy

I extended the existing AES tests with the NIST test vectors (see https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38a.pdf) and added a self-test:

INFO: Boot ROM initialisation has completed, jump into flash!
aes_test passed (ECB Enc Src/Dst)
aes_test passed (ECB Dec Src/Dst)
aes_test passed (ECB Enc In-place)
aes_test passed (ECB Dec In-place)
OpenTitan initialisation complete. Entering main loop


### TODO or Help Wanted

Should be complete. One question is if we merge with the test enabled or not (I suspect the answer is no)

### Documentation Updated

- [ X] Updated the relevant files in `/docs`, or **no updates are required.**

(I don't think there was anything to update in docs)

### Formatting

- [ X] Ran `make formatall`.
