### PR TITLE
nRF51 Serialization: Support restarting apps

### DIFF
--- a/boards/components/src/nrf51822.rs
+++ b/boards/components/src/nrf51822.rs
@@ -14,7 +14,9 @@
 // Last modified: 6/20/2018
 
 use capsules::nrf51822_serialization;
+use kernel::capabilities;
 use kernel::component::Component;
+use kernel::create_capability;
 use kernel::hil;
 use kernel::static_init;
 
@@ -24,15 +26,21 @@ pub struct Nrf51822Component<
 > {
     uart: &'static U,
     reset_pin: &'static G,
+    board_kernel: &'static kernel::Kernel,
 }
 
 impl<U: 'static + hil::uart::UartAdvanced<'static>, G: 'static + hil::gpio::Pin>
     Nrf51822Component<U, G>
 {
-    pub fn new(uart: &'static U, reset_pin: &'static G) -> Nrf51822Component<U, G> {
+    pub fn new(
+        uart: &'static U,
+        reset_pin: &'static G,
+        board_kernel: &'static kernel::Kernel,
+    ) -> Nrf51822Component<U, G> {
         Nrf51822Component {
             uart: uart,
             reset_pin: reset_pin,
+            board_kernel: board_kernel,
         }
     }
 }
@@ -44,10 +52,13 @@ impl<U: 'static + hil::uart::UartAdvanced<'static>, G: 'static + hil::gpio::Pin>
     type Output = &'static nrf51822_serialization::Nrf51822Serialization<'static>;
 
     unsafe fn finalize(&mut self, _s: Self::StaticInput) -> Self::Output {
+        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
+
         let nrf_serialization = static_init!(
             nrf51822_serialization::Nrf51822Serialization<'static>,
             nrf51822_serialization::Nrf51822Serialization::new(
                 self.uart,
+                self.board_kernel.create_grant(&grant_cap),
                 self.reset_pin,
                 &mut nrf51822_serialization::WRITE_BUF,
                 &mut nrf51822_serialization::READ_BUF

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -240,9 +240,12 @@ pub unsafe fn reset_handler() {
     sam4l::usart::USART3.set_mode(sam4l::usart::UsartMode::Uart);
     // Create the Nrf51822Serialization driver for passing BLE commands
     // over UART to the nRF51822 radio.
-    let nrf_serialization =
-        components::nrf51822::Nrf51822Component::new(&sam4l::usart::USART3, &sam4l::gpio::PA[17])
-            .finalize(());
+    let nrf_serialization = components::nrf51822::Nrf51822Component::new(
+        &sam4l::usart::USART3,
+        &sam4l::gpio::PA[17],
+        board_kernel,
+    )
+    .finalize(());
 
     let ast = &sam4l::ast::AST;
     let mux_alarm = components::alarm::AlarmMuxComponent::new(ast)
@@ -409,8 +412,7 @@ pub unsafe fn reset_handler() {
         dac: dac,
     };
 
-    // Reset the nRF and setup the UART bus.
-    hail.nrf51822.reset();
+    // Setup the UART bus for nRF51 serialization..
     hail.nrf51822.initialize();
 
     process_console.start();

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -317,7 +317,8 @@ pub unsafe fn reset_handler() {
     // Allow processes to communicate over BLE through the nRF51822
     sam4l::usart::USART2.set_mode(sam4l::usart::UsartMode::Uart);
     let nrf_serialization =
-        Nrf51822Component::new(&sam4l::usart::USART2, &sam4l::gpio::PB[07]).finalize(());
+        Nrf51822Component::new(&sam4l::usart::USART2, &sam4l::gpio::PB[07], board_kernel)
+            .finalize(());
 
     // # TIMER
     let ast = &sam4l::ast::AST;
@@ -475,8 +476,7 @@ pub unsafe fn reset_handler() {
     let chip = static_init!(sam4l::chip::Sam4l, sam4l::chip::Sam4l::new());
     CHIP = Some(&chip);
 
-    // Need to reset the nRF on boot, toggle it's SWDIO
-    imix.nrf51822.reset();
+    // Need to initialize the UART for the nRF51 serialization.
     imix.nrf51822.initialize();
 
     // These two lines need to be below the creation of the chip for


### PR DESCRIPTION
This updates the nrf serialization capsule to allow apps that use it to restart successfully.

Part of #1082


### Testing Strategy

This pull request was tested by restarting the hail app on hail using the process console.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
