### PR TITLE
CRC: Add set_client to HIL

### DIFF
--- a/boards/components/src/crc.rs
+++ b/boards/components/src/crc.rs
@@ -60,6 +60,8 @@ impl<C: 'static + hil::crc::CRC> Component for CrcComponent<C> {
             crc::Crc::new(self.crc, self.board_kernel.create_grant(&grant_cap))
         );
 
+        self.crc.set_client(crc);
+
         crc
     }
 }

--- a/kernel/src/hil/crc.rs
+++ b/kernel/src/hil/crc.rs
@@ -25,6 +25,9 @@ pub enum CrcAlg {
 }
 
 pub trait CRC {
+    /// Set the client to be used for callbacks.
+    fn set_client(&self, client: &'static dyn Client);
+
     /// Initiate a CRC calculation
     fn compute(&self, data: &[u8], _: CrcAlg) -> ReturnCode;
 


### PR DESCRIPTION
### Pull Request Overview

I tried the crc test app on Hail and it didn't work. I tracked it back to the client of the sam4l crc driver not being set to the crc capsule in the component. However, the client cannot be set in the component since the set_client function is not in the HIL. This updates the HIL to include the set_client function, and then updates the sam4l driver and the component.


### Testing Strategy

Running the crc test app on hail.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
