### PR TITLE
Allow apps to handle interrupts at any time*

### DIFF
--- a/arch/cortex-m/src/syscall.rs
+++ b/arch/cortex-m/src/syscall.rs
@@ -137,6 +137,19 @@ impl kernel::syscall::UserspaceKernelBoundary for SysCall {
         Ok(stack_bottom)
     }
 
+    unsafe fn get_current_register_state(
+        &self,
+        state: &Self::StoredState,
+    ) -> (usize, usize, usize, usize, usize) {
+        (
+            state.yield_pc,
+            state.regs[0],
+            state.regs[1],
+            state.regs[2],
+            state.regs[3],
+        )
+    }
+
     unsafe fn switch_to_process(
         &self,
         stack_pointer: *const usize,

--- a/arch/rv32i/src/syscall.rs
+++ b/arch/rv32i/src/syscall.rs
@@ -97,6 +97,19 @@ impl kernel::syscall::UserspaceKernelBoundary for SysCall {
         Ok(stack_pointer as *mut usize)
     }
 
+    unsafe fn get_current_register_state(
+        &self,
+        state: &Self::StoredState,
+    ) -> (usize, usize, usize, usize, usize) {
+        (
+            state.pc,
+            state.regs[R_A0],
+            state.regs[R_A1],
+            state.regs[R_A2],
+            state.regs[R_A3],
+        )
+    }
+
     // Mock implementation for tests on Travis-CI.
     #[cfg(not(any(target_arch = "riscv32", target_os = "none")))]
     unsafe fn switch_to_process(

--- a/arch/rv32i/src/syscall.rs
+++ b/arch/rv32i/src/syscall.rs
@@ -27,7 +27,6 @@ pub struct RiscvimacStoredState {
 // Named offsets into the stored state registers.  These needs to be kept in
 // sync with the register save logic in _start_trap() as well as the register
 // restore logic in switch_to_process() below.
-const R_RA: usize = 0;
 const R_SP: usize = 1;
 const R_A0: usize = 9;
 const R_A1: usize = 10;
@@ -91,14 +90,6 @@ impl kernel::syscall::UserspaceKernelBoundary for SysCall {
         state.regs[R_A1] = callback.argument1;
         state.regs[R_A2] = callback.argument2;
         state.regs[R_A3] = callback.argument3;
-
-        // We also need to set the return address (ra) register so that the new
-        // function that the process is running returns to the correct location.
-        // Note, however, that if this function happens to be the first time the
-        // process is executing then `state.pc` is invalid/useless, but the
-        // application must ignore it anyway since there is nothing logically
-        // for it to return to. So this doesn't hurt anything.
-        state.regs[R_RA] = state.pc;
 
         // Save the PC we expect to execute.
         state.pc = callback.pc;
@@ -373,25 +364,25 @@ impl kernel::syscall::UserspaceKernelBoundary for SysCall {
     ) {
         let _ = writer.write_fmt(format_args!(
             "\
-            \r\n R0 : {:#010X}    R16: {:#010X}\
-            \r\n R1 : {:#010X}    R17: {:#010X}\
-            \r\n R2 : {:#010X}    R18: {:#010X}\
-            \r\n R3 : {:#010X}    R19: {:#010X}\
-            \r\n R4 : {:#010X}    R20: {:#010X}\
-            \r\n R5 : {:#010X}    R21: {:#010X}\
-            \r\n R6 : {:#010X}    R22: {:#010X}\
-            \r\n R7 : {:#010X}    R23: {:#010X}\
-            \r\n R8 : {:#010X}    R24: {:#010X}\
-            \r\n R9 : {:#010X}    R25: {:#010X}\
-            \r\n R10: {:#010X}    R26: {:#010X}\
-            \r\n R11: {:#010X}    R27: {:#010X}\
-            \r\n R12: {:#010X}    R28: {:#010X}\
-            \r\n R13: {:#010X}    R29: {:#010X}\
-            \r\n R14: {:#010X}    R30: {:#010X}\
-            \r\n R15: {:#010X}    R31: {:#010X}\
-            \r\n PC : {:#010X}\
-            \r\n SP:  {:#010X}\
-            \r\n",
+             \r\n R0 : {:#010X}    R16: {:#010X}\
+             \r\n R1 : {:#010X}    R17: {:#010X}\
+             \r\n R2 : {:#010X}    R18: {:#010X}\
+             \r\n R3 : {:#010X}    R19: {:#010X}\
+             \r\n R4 : {:#010X}    R20: {:#010X}\
+             \r\n R5 : {:#010X}    R21: {:#010X}\
+             \r\n R6 : {:#010X}    R22: {:#010X}\
+             \r\n R7 : {:#010X}    R23: {:#010X}\
+             \r\n R8 : {:#010X}    R24: {:#010X}\
+             \r\n R9 : {:#010X}    R25: {:#010X}\
+             \r\n R10: {:#010X}    R26: {:#010X}\
+             \r\n R11: {:#010X}    R27: {:#010X}\
+             \r\n R12: {:#010X}    R28: {:#010X}\
+             \r\n R13: {:#010X}    R29: {:#010X}\
+             \r\n R14: {:#010X}    R30: {:#010X}\
+             \r\n R15: {:#010X}    R31: {:#010X}\
+             \r\n PC : {:#010X}\
+             \r\n SP:  {:#010X}\
+             \r\n",
             0,
             state.regs[15],
             state.regs[0],

--- a/boards/opentitan/src/main.rs
+++ b/boards/opentitan/src/main.rs
@@ -46,6 +46,7 @@ pub static mut STACK_MEMORY: [u8; 0x1000] = [0; 0x1000];
 /// capsules for this platform. We've included an alarm and console.
 struct OpenTitan {
     led: &'static capsules::led::LED<'static>,
+    gpio: &'static capsules::gpio::GPIO<'static>,
     console: &'static capsules::console::Console<'static>,
     alarm: &'static capsules::alarm::AlarmDriver<
         'static,
@@ -65,6 +66,7 @@ impl Platform for OpenTitan {
     {
         match driver_num {
             capsules::led::DRIVER_NUM => f(Some(self.led)),
+            capsules::gpio::DRIVER_NUM => f(Some(self.gpio)),
             capsules::console::DRIVER_NUM => f(Some(self.console)),
             capsules::alarm::DRIVER_NUM => f(Some(self.alarm)),
             capsules::low_level_debug::DRIVER_NUM => f(Some(self.lldb)),
@@ -163,6 +165,19 @@ pub unsafe fn reset_handler() {
         )
     ));
 
+    let gpio = components::gpio::GpioComponent::new(board_kernel).finalize(
+        components::gpio_component_helper!(
+            &ibex::gpio::PORT[0],
+            &ibex::gpio::PORT[1],
+            &ibex::gpio::PORT[2],
+            &ibex::gpio::PORT[3],
+            &ibex::gpio::PORT[4],
+            &ibex::gpio::PORT[5],
+            &ibex::gpio::PORT[6],
+            &ibex::gpio::PORT[15]
+        ),
+    );
+
     let alarm = &ibex::timer::TIMER;
     alarm.setup();
 
@@ -205,6 +220,7 @@ pub unsafe fn reset_handler() {
     }
 
     let opentitan = OpenTitan {
+        gpio: gpio,
         led: led,
         console: console,
         alarm: alarm,

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -102,6 +102,8 @@ pub trait ProcessType {
     /// or "yielded".
     fn get_state(&self) -> State;
 
+    fn get_current_register_state(&self) -> (usize, usize, usize, usize, usize);
+
     /// Move this process from the running state to the yielded state.
     fn set_yielded_state(&self);
 
@@ -557,6 +559,15 @@ impl<C: Chip> ProcessType for Process<'a, C> {
 
     fn get_state(&self) -> State {
         self.state.get()
+    }
+
+    fn get_current_register_state(&self) -> (usize, usize, usize, usize, usize) {
+        let stored_state = self.stored_state.get();
+        unsafe {
+            self.chip
+                .userspace_kernel_boundary()
+                .get_current_register_state(&stored_state)
+        }
     }
 
     fn set_yielded_state(&self) {

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -107,6 +107,10 @@ pub trait ProcessType {
     /// Move this process from the running state to the yielded state.
     fn set_yielded_state(&self);
 
+    fn backup_stored_state(&self);
+
+    fn restore_stored_state(&self);
+
     /// Move this process from running or yielded state into the stopped state
     fn stop(&self);
 
@@ -482,6 +486,9 @@ pub struct Process<'a, C: 'static + Chip> {
     stored_state:
         Cell<<<C as Chip>::UserspaceKernelBoundary as UserspaceKernelBoundary>::StoredState>,
 
+    backup_stored_state:
+        Cell<<<C as Chip>::UserspaceKernelBoundary as UserspaceKernelBoundary>::StoredState>,
+
     /// Whether the scheduler can schedule this app.
     state: Cell<State>,
 
@@ -575,6 +582,14 @@ impl<C: Chip> ProcessType for Process<'a, C> {
             self.state.set(State::Yielded);
             self.kernel.decrement_work();
         }
+    }
+
+    fn backup_stored_state(&self) {
+        self.backup_stored_state.set(self.stored_state.get())
+    }
+
+    fn restore_stored_state(&self) {
+        self.stored_state.set(self.backup_stored_state.get())
     }
 
     fn stop(&self) {

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -348,7 +348,7 @@ pub enum Task {
 /// kernel or from a callback subscribed through a driver.
 ///
 /// An example of kernel function is the application entry point.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub enum FunctionCallSource {
     Kernel, // For functions coming directly from the kernel, such as `init_fn`.
     Driver(CallbackId),

--- a/kernel/src/syscall.rs
+++ b/kernel/src/syscall.rs
@@ -141,6 +141,11 @@ pub trait UserspaceKernelBoundary {
         callback: process::FunctionCall,
     ) -> Result<*mut usize, *mut usize>;
 
+    unsafe fn get_current_register_state(
+        &self,
+        state: &Self::StoredState,
+    ) -> (usize, usize, usize, usize, usize);
+
     /// Context switch to a specific process.
     ///
     /// This returns a tuple:


### PR DESCRIPTION
### Pull Request Overview

As [documented ](https://github.com/tock/tock/blob/master/doc/Userland.md#callbacks) currently apps must register a callback then `yield` before the kernel will call the callback. This means that if an app registers a callback for an interrupt (such as a GPIO input) but then performs a long running task the app won't get the interrupt. Even though the kernel has received the interrupt and added it to the processes queue.

This current method works well for anything that is event driven, such as an app that registers callbacks then `yields`.
Apps that do need to force an event to happen (like printing) can use `yield_for` but it doesn't work too well for nondeterministic interrupts on long running processes (like waiting for a GPIO to stop a long calculation).

This PR changes the current implementation to allow apps to run the callbacks without yielding. NOTE: This will still not interrupt a running application. When we call `do_process()` in the Tock kernel to schedule a process we will run the first item in the queue, saving the current state (if we weren't running a callback) onto the queue.

### Testing Strategy

Not tested. This works somewhat on RISC-V but will eventually crash, completely untested on ARM. It probably breaks ARM.

### TODO or Help Wanted

Review and comments please.

### Documentation Updated

The documentation has not been updated. That will have to be done as well as inline comments.

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make formatall`.
