### PR TITLE
Flash HIL: return buffers if errors

### DIFF
--- a/capsules/src/log.rs
+++ b/capsules/src/log.rs
@@ -476,7 +476,13 @@ impl<'a, F: Flash + 'static> Log<'a, F> {
         }
 
         // Sync page to flash.
-        self.driver.write_page(page_number, pagebuffer)
+        match self.driver.write_page(page_number, pagebuffer) {
+            Ok(()) => ReturnCode::SUCCESS,
+            Err((return_code, pagebuffer)) => {
+                self.pagebuffer.replace(pagebuffer);
+                return_code
+            }
+        }
     }
 
     /// Resets the pagebuffer so that new data can be written. Note that this also increments the

--- a/capsules/src/mx25r6435f.rs
+++ b/capsules/src/mx25r6435f.rs
@@ -255,7 +255,7 @@ impl<
         &self,
         sector_index: u32,
         sector: &'static mut Mx25r6435fSector,
-    ) -> (ReturnCode, Option<&'static mut Mx25r6435fSector>) {
+    ) -> Result<(), (ReturnCode, &'static mut Mx25r6435fSector)> {
         self.configure_spi();
         // Save the user buffer for later
         self.client_sector.replace(sector);
@@ -287,9 +287,9 @@ impl<
             });
 
         if retval == ReturnCode::SUCCESS {
-            (retval, None)
+            Ok(())
         } else {
-            (retval, Some(self.client_sector.take().unwrap()))
+            Err((retval, self.client_sector.take().unwrap()))
         }
     }
 
@@ -297,7 +297,7 @@ impl<
         &self,
         sector_index: u32,
         sector: &'static mut Mx25r6435fSector,
-    ) -> (ReturnCode, Option<&'static mut Mx25r6435fSector>) {
+    ) -> Result<(), (ReturnCode, &'static mut Mx25r6435fSector)> {
         self.client_sector.replace(sector);
         self.configure_spi();
         self.state.set(State::EraseSectorWriteEnable {
@@ -307,9 +307,9 @@ impl<
         let retval = self.enable_write();
 
         if retval == ReturnCode::SUCCESS {
-            (retval, None)
+            Ok(())
         } else {
-            (retval, Some(self.client_sector.take().unwrap()))
+            Err((retval, self.client_sector.take().unwrap()))
         }
     }
 }
@@ -572,7 +572,7 @@ impl<
         &self,
         page_number: usize,
         buf: &'static mut Self::Page,
-    ) -> (ReturnCode, Option<&'static mut Self::Page>) {
+    ) -> Result<(), (ReturnCode, &'static mut Self::Page)> {
         self.read_sector(page_number as u32, buf)
     }
 
@@ -580,7 +580,7 @@ impl<
         &self,
         page_number: usize,
         buf: &'static mut Self::Page,
-    ) -> (ReturnCode, Option<&'static mut Self::Page>) {
+    ) -> Result<(), (ReturnCode, &'static mut Self::Page)> {
         self.write_sector(page_number as u32, buf)
     }
 

--- a/capsules/src/mx25r6435f.rs
+++ b/capsules/src/mx25r6435f.rs
@@ -257,8 +257,6 @@ impl<
         sector: &'static mut Mx25r6435fSector,
     ) -> Result<(), (ReturnCode, &'static mut Mx25r6435fSector)> {
         self.configure_spi();
-        // Save the user buffer for later
-        self.client_sector.replace(sector);
 
         let retval = self
             .txbuffer
@@ -287,9 +285,10 @@ impl<
             });
 
         if retval == ReturnCode::SUCCESS {
+            self.client_sector.replace(sector);
             Ok(())
         } else {
-            Err((retval, self.client_sector.take().unwrap()))
+            Err((retval, sector))
         }
     }
 
@@ -298,7 +297,6 @@ impl<
         sector_index: u32,
         sector: &'static mut Mx25r6435fSector,
     ) -> Result<(), (ReturnCode, &'static mut Mx25r6435fSector)> {
-        self.client_sector.replace(sector);
         self.configure_spi();
         self.state.set(State::EraseSectorWriteEnable {
             sector_index,
@@ -307,9 +305,10 @@ impl<
         let retval = self.enable_write();
 
         if retval == ReturnCode::SUCCESS {
+            self.client_sector.replace(sector);
             Ok(())
         } else {
-            Err((retval, self.client_sector.take().unwrap()))
+            Err((retval, sector))
         }
     }
 }

--- a/capsules/src/virtual_flash.rs
+++ b/capsules/src/virtual_flash.rs
@@ -93,10 +93,14 @@ impl<F: hil::flash::Flash> MuxFlash<'a, F> {
                     |buf| {
                         match node.operation.get() {
                             Op::Write(page_number) => {
-                                self.flash.write_page(page_number, buf);
+                                if let Err((_, buf)) = self.flash.write_page(page_number, buf) {
+                                    node.buffer.replace(buf);
+                                }
                             }
                             Op::Read(page_number) => {
-                                self.flash.read_page(page_number, buf);
+                                if let Err((_, buf)) = self.flash.read_page(page_number, buf) {
+                                    node.buffer.replace(buf);
+                                }
                             }
                             Op::Erase(page_number) => {
                                 self.flash.erase_page(page_number);
@@ -186,22 +190,22 @@ impl<F: hil::flash::Flash> hil::flash::Flash for FlashUser<'a, F> {
         &self,
         page_number: usize,
         buf: &'static mut Self::Page,
-    ) -> (ReturnCode, Option<&'static mut Self::Page>) {
+    ) -> Result<(), (ReturnCode, &'static mut Self::Page)> {
         self.buffer.replace(buf);
         self.operation.set(Op::Read(page_number));
         self.mux.do_next_op();
-        (ReturnCode::SUCCESS, None)
+        Ok(())
     }
 
     fn write_page(
         &self,
         page_number: usize,
         buf: &'static mut Self::Page,
-    ) -> (ReturnCode, Option<&'static mut Self::Page>) {
+    ) -> Result<(), (ReturnCode, &'static mut Self::Page)> {
         self.buffer.replace(buf);
         self.operation.set(Op::Write(page_number));
         self.mux.do_next_op();
-        (ReturnCode::SUCCESS, None)
+        Ok(())
     }
 
     fn erase_page(&self, page_number: usize) -> ReturnCode {

--- a/capsules/src/virtual_flash.rs
+++ b/capsules/src/virtual_flash.rs
@@ -182,18 +182,26 @@ impl<F: hil::flash::Flash> ListNode<'a, FlashUser<'a, F>> for FlashUser<'a, F> {
 impl<F: hil::flash::Flash> hil::flash::Flash for FlashUser<'a, F> {
     type Page = F::Page;
 
-    fn read_page(&self, page_number: usize, buf: &'static mut Self::Page) -> ReturnCode {
+    fn read_page(
+        &self,
+        page_number: usize,
+        buf: &'static mut Self::Page,
+    ) -> (ReturnCode, Option<&'static mut Self::Page>) {
         self.buffer.replace(buf);
         self.operation.set(Op::Read(page_number));
         self.mux.do_next_op();
-        ReturnCode::SUCCESS
+        (ReturnCode::SUCCESS, None)
     }
 
-    fn write_page(&self, page_number: usize, buf: &'static mut Self::Page) -> ReturnCode {
+    fn write_page(
+        &self,
+        page_number: usize,
+        buf: &'static mut Self::Page,
+    ) -> (ReturnCode, Option<&'static mut Self::Page>) {
         self.buffer.replace(buf);
         self.operation.set(Op::Write(page_number));
         self.mux.do_next_op();
-        ReturnCode::SUCCESS
+        (ReturnCode::SUCCESS, None)
     }
 
     fn erase_page(&self, page_number: usize) -> ReturnCode {

--- a/chips/nrf52/src/nvmc.rs
+++ b/chips/nrf52/src/nvmc.rs
@@ -284,7 +284,11 @@ impl Nvmc {
         while !regs.ready.is_set(Ready::READY) {}
     }
 
-    fn read_range(&self, page_number: usize, buffer: &'static mut NrfPage) -> ReturnCode {
+    fn read_range(
+        &self,
+        page_number: usize,
+        buffer: &'static mut NrfPage,
+    ) -> (ReturnCode, Option<&'static mut NrfPage>) {
         // Actually do a copy from flash into the buffer.
         let mut byte: *const u8 = (page_number * PAGE_SIZE) as *const u8;
         unsafe {
@@ -302,10 +306,14 @@ impl Nvmc {
         self.state.set(FlashState::Read);
         DEFERRED_CALL.set();
 
-        ReturnCode::SUCCESS
+        (ReturnCode::SUCCESS, None)
     }
 
-    fn write_page(&self, page_number: usize, data: &'static mut NrfPage) -> ReturnCode {
+    fn write_page(
+        &self,
+        page_number: usize,
+        data: &'static mut NrfPage,
+    ) -> (ReturnCode, Option<&'static mut NrfPage>) {
         let regs = &*self.registers;
 
         // Need to erase the page first.
@@ -337,7 +345,7 @@ impl Nvmc {
         self.state.set(FlashState::Write);
         DEFERRED_CALL.set();
 
-        ReturnCode::SUCCESS
+        (ReturnCode::SUCCESS, None)
     }
 
     fn erase_page(&self, page_number: usize) -> ReturnCode {
@@ -362,11 +370,19 @@ impl<C: hil::flash::Client<Self>> hil::flash::HasClient<'static, C> for Nvmc {
 impl hil::flash::Flash for Nvmc {
     type Page = NrfPage;
 
-    fn read_page(&self, page_number: usize, buf: &'static mut Self::Page) -> ReturnCode {
+    fn read_page(
+        &self,
+        page_number: usize,
+        buf: &'static mut Self::Page,
+    ) -> (ReturnCode, Option<&'static mut Self::Page>) {
         self.read_range(page_number, buf)
     }
 
-    fn write_page(&self, page_number: usize, buf: &'static mut Self::Page) -> ReturnCode {
+    fn write_page(
+        &self,
+        page_number: usize,
+        buf: &'static mut Self::Page,
+    ) -> (ReturnCode, Option<&'static mut Self::Page>) {
         self.write_page(page_number, buf)
     }
 

--- a/chips/nrf52/src/nvmc.rs
+++ b/chips/nrf52/src/nvmc.rs
@@ -288,7 +288,7 @@ impl Nvmc {
         &self,
         page_number: usize,
         buffer: &'static mut NrfPage,
-    ) -> (ReturnCode, Option<&'static mut NrfPage>) {
+    ) -> Result<(), (ReturnCode, &'static mut NrfPage)> {
         // Actually do a copy from flash into the buffer.
         let mut byte: *const u8 = (page_number * PAGE_SIZE) as *const u8;
         unsafe {
@@ -306,14 +306,14 @@ impl Nvmc {
         self.state.set(FlashState::Read);
         DEFERRED_CALL.set();
 
-        (ReturnCode::SUCCESS, None)
+        Ok(())
     }
 
     fn write_page(
         &self,
         page_number: usize,
         data: &'static mut NrfPage,
-    ) -> (ReturnCode, Option<&'static mut NrfPage>) {
+    ) -> Result<(), (ReturnCode, &'static mut NrfPage)> {
         let regs = &*self.registers;
 
         // Need to erase the page first.
@@ -345,7 +345,7 @@ impl Nvmc {
         self.state.set(FlashState::Write);
         DEFERRED_CALL.set();
 
-        (ReturnCode::SUCCESS, None)
+        Ok(())
     }
 
     fn erase_page(&self, page_number: usize) -> ReturnCode {
@@ -374,7 +374,7 @@ impl hil::flash::Flash for Nvmc {
         &self,
         page_number: usize,
         buf: &'static mut Self::Page,
-    ) -> (ReturnCode, Option<&'static mut Self::Page>) {
+    ) -> Result<(), (ReturnCode, &'static mut Self::Page)> {
         self.read_range(page_number, buf)
     }
 
@@ -382,7 +382,7 @@ impl hil::flash::Flash for Nvmc {
         &self,
         page_number: usize,
         buf: &'static mut Self::Page,
-    ) -> (ReturnCode, Option<&'static mut Self::Page>) {
+    ) -> Result<(), (ReturnCode, &'static mut Self::Page)> {
         self.write_page(page_number, buf)
     }
 

--- a/chips/sam4l/src/flashcalw.rs
+++ b/chips/sam4l/src/flashcalw.rs
@@ -839,9 +839,9 @@ impl FLASHCALW {
         address: usize,
         size: usize,
         buffer: &'static mut Sam4lPage,
-    ) -> ReturnCode {
+    ) -> (ReturnCode, Option<&'static mut Sam4lPage>) {
         if self.current_state.get() == FlashState::Unconfigured {
-            return ReturnCode::FAIL;
+            return (ReturnCode::FAIL, Some(buffer));
         }
 
         // Enable clock in case it's off.
@@ -854,7 +854,7 @@ impl FLASHCALW {
             || buffer.len() < size
         {
             // invalid flash address
-            return ReturnCode::EINVAL;
+            return (ReturnCode::EINVAL, Some(buffer));
         }
 
         // Actually do a copy from flash into the buffer.
@@ -875,18 +875,22 @@ impl FLASHCALW {
         // we can allow this function to return and then call the callback.
         DEFERRED_CALL.set();
 
-        ReturnCode::SUCCESS
+        (ReturnCode::SUCCESS, None)
     }
 
-    fn write_page(&self, page_num: i32, data: &'static mut Sam4lPage) -> ReturnCode {
+    fn write_page(
+        &self,
+        page_num: i32,
+        data: &'static mut Sam4lPage,
+    ) -> (ReturnCode, Option<&'static mut Sam4lPage>) {
         // Enable clock in case it's off.
         pm::enable_clock(self.ahb_clock);
 
         match self.current_state.get() {
-            FlashState::Unconfigured => return ReturnCode::FAIL,
+            FlashState::Unconfigured => return (ReturnCode::FAIL, Some(data)),
             FlashState::Ready => {}
             // If we're not ready don't take the command
-            _ => return ReturnCode::EBUSY,
+            _ => return (ReturnCode::EBUSY, Some(data)),
         }
 
         // Save the buffer for the future write.
@@ -895,7 +899,7 @@ impl FLASHCALW {
         self.current_state
             .set(FlashState::WriteUnlocking { page: page_num });
         self.lock_page_region(page_num, false);
-        ReturnCode::SUCCESS
+        (ReturnCode::SUCCESS, None)
     }
 
     fn erase_page(&self, page_num: i32) -> ReturnCode {
@@ -921,11 +925,19 @@ impl<C: hil::flash::Client<Self>> hil::flash::HasClient<'static, C> for FLASHCAL
 impl hil::flash::Flash for FLASHCALW {
     type Page = Sam4lPage;
 
-    fn read_page(&self, page_number: usize, buf: &'static mut Self::Page) -> ReturnCode {
+    fn read_page(
+        &self,
+        page_number: usize,
+        buf: &'static mut Self::Page,
+    ) -> (ReturnCode, Option<&'static mut Self::Page>) {
         self.read_range(page_number * (PAGE_SIZE as usize), buf.len(), buf)
     }
 
-    fn write_page(&self, page_number: usize, buf: &'static mut Self::Page) -> ReturnCode {
+    fn write_page(
+        &self,
+        page_number: usize,
+        buf: &'static mut Self::Page,
+    ) -> (ReturnCode, Option<&'static mut Self::Page>) {
         self.write_page(page_number as i32, buf)
     }
 

--- a/kernel/src/hil/flash.rs
+++ b/kernel/src/hil/flash.rs
@@ -53,8 +53,8 @@
 //! impl hil::flash::Flash for NewChipStruct {
 //!     type Page = NewChipPage;
 //!
-//!     fn read_page(&self, page_number: usize, buf: &'static mut Self::Page) -> ReturnCode { ReturnCode::FAIL }
-//!     fn write_page(&self, page_number: usize, buf: &'static mut Self::Page) -> ReturnCode { ReturnCode::FAIL }
+//!     fn read_page(&self, page_number: usize, buf: &'static mut Self::Page) -> (ReturnCode, Option<&'static mut Self::Page>) { (ReturnCode::FAIL, Some(buf)) }
+//!     fn write_page(&self, page_number: usize, buf: &'static mut Self::Page) -> (ReturnCode, Option<&'static mut Self::Page>) { (ReturnCode::FAIL, Some(buf)) }
 //!     fn erase_page(&self, page_number: usize) -> ReturnCode { ReturnCode::FAIL }
 //! }
 //! ```
@@ -110,10 +110,18 @@ pub trait Flash {
     type Page: AsMut<[u8]>;
 
     /// Read a page of flash into the buffer.
-    fn read_page(&self, page_number: usize, buf: &'static mut Self::Page) -> ReturnCode;
+    fn read_page(
+        &self,
+        page_number: usize,
+        buf: &'static mut Self::Page,
+    ) -> (ReturnCode, Option<&'static mut Self::Page>);
 
     /// Write a page of flash from the buffer.
-    fn write_page(&self, page_number: usize, buf: &'static mut Self::Page) -> ReturnCode;
+    fn write_page(
+        &self,
+        page_number: usize,
+        buf: &'static mut Self::Page,
+    ) -> (ReturnCode, Option<&'static mut Self::Page>);
 
     /// Erase a page of flash.
     fn erase_page(&self, page_number: usize) -> ReturnCode;

--- a/kernel/src/hil/flash.rs
+++ b/kernel/src/hil/flash.rs
@@ -53,8 +53,8 @@
 //! impl hil::flash::Flash for NewChipStruct {
 //!     type Page = NewChipPage;
 //!
-//!     fn read_page(&self, page_number: usize, buf: &'static mut Self::Page) -> (ReturnCode, Option<&'static mut Self::Page>) { (ReturnCode::FAIL, Some(buf)) }
-//!     fn write_page(&self, page_number: usize, buf: &'static mut Self::Page) -> (ReturnCode, Option<&'static mut Self::Page>) { (ReturnCode::FAIL, Some(buf)) }
+//!     fn read_page(&self, page_number: usize, buf: &'static mut Self::Page) -> Result<(), (ReturnCode, &'static mut Self::Page)> { Err((ReturnCode::FAIL, buf)) }
+//!     fn write_page(&self, page_number: usize, buf: &'static mut Self::Page) -> Result<(), (ReturnCode, &'static mut Self::Page)> { Err((ReturnCode::FAIL, buf)) }
 //!     fn erase_page(&self, page_number: usize) -> ReturnCode { ReturnCode::FAIL }
 //! }
 //! ```
@@ -114,14 +114,14 @@ pub trait Flash {
         &self,
         page_number: usize,
         buf: &'static mut Self::Page,
-    ) -> (ReturnCode, Option<&'static mut Self::Page>);
+    ) -> Result<(), (ReturnCode, &'static mut Self::Page)>;
 
     /// Write a page of flash from the buffer.
     fn write_page(
         &self,
         page_number: usize,
         buf: &'static mut Self::Page,
-    ) -> (ReturnCode, Option<&'static mut Self::Page>);
+    ) -> Result<(), (ReturnCode, &'static mut Self::Page)>;
 
     /// Erase a page of flash.
     fn erase_page(&self, page_number: usize) -> ReturnCode;


### PR DESCRIPTION
### Pull Request Overview

This pull request modifies the flash hil to return client buffers in the event of flash read/write errors. This prevents these statically-allocated buffers from being lost if an error occurs, enabling recovery from these errors.


### Testing Strategy

This modified flash hil was tested on an imix running the [log storage](https://github.com/tock/tock/pull/1580) test suite (which uses flash on the sam4l).


### TODO or Help Wanted

This PR does modify some code for the NRF52, which I don't have a board to test for. Ideally somebody else would verify that these changes work on the NRF52, although it seems to compile fine for me.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.
I don't think any docs need to be updated, but let me know if I missed something.

### Formatting

- [x] Ran `make formatall`.
