### PR TITLE
[RFC] Generic kernel lifetime?

### DIFF
--- a/boards/components/src/si7021.rs
+++ b/boards/components/src/si7021.rs
@@ -93,16 +93,16 @@ impl<A: 'static + time::Alarm<'static>> Component for SI7021Component<A> {
     }
 }
 
-pub struct TemperatureComponent<A: 'static + time::Alarm<'static>> {
-    board_kernel: &'static kernel::Kernel,
+pub struct TemperatureComponent<'ker, A: 'static + time::Alarm<'static>> {
+    board_kernel: &'ker kernel::Kernel<'ker>,
     si7021: &'static SI7021<'static, VirtualMuxAlarm<'static, A>>,
 }
 
-impl<A: 'static + time::Alarm<'static>> TemperatureComponent<A> {
+impl<A: 'static + time::Alarm<'static>> TemperatureComponent<'ker, A> {
     pub fn new(
-        board_kernel: &'static kernel::Kernel,
+        board_kernel: &'ker kernel::Kernel<'ker>,
         si: &'static SI7021<'static, VirtualMuxAlarm<'static, A>>,
-    ) -> TemperatureComponent<A> {
+    ) -> TemperatureComponent<'ker, A> {
         TemperatureComponent {
             board_kernel: board_kernel,
             si7021: si,
@@ -110,15 +110,18 @@ impl<A: 'static + time::Alarm<'static>> TemperatureComponent<A> {
     }
 }
 
-impl<A: 'static + time::Alarm<'static>> Component for TemperatureComponent<A> {
+impl<A: 'static + time::Alarm<'static>> Component for TemperatureComponent<'ker, A>
+where
+    'ker: 'static,
+{
     type StaticInput = ();
-    type Output = &'static TemperatureSensor<'static>;
+    type Output = &'static TemperatureSensor<'static, 'ker>;
 
     unsafe fn finalize(&mut self, _s: Self::StaticInput) -> Self::Output {
         let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
 
         let temp = static_init!(
-            TemperatureSensor<'static>,
+            TemperatureSensor<'static, '_>,
             TemperatureSensor::new(self.si7021, self.board_kernel.create_grant(&grant_cap))
         );
 
@@ -127,16 +130,16 @@ impl<A: 'static + time::Alarm<'static>> Component for TemperatureComponent<A> {
     }
 }
 
-pub struct HumidityComponent<A: 'static + time::Alarm<'static>> {
-    board_kernel: &'static kernel::Kernel,
+pub struct HumidityComponent<'ker, A: 'static + time::Alarm<'static>> {
+    board_kernel: &'ker kernel::Kernel<'ker>,
     si7021: &'static SI7021<'static, VirtualMuxAlarm<'static, A>>,
 }
 
-impl<A: 'static + time::Alarm<'static>> HumidityComponent<A> {
+impl<A: 'static + time::Alarm<'static>> HumidityComponent<'ker, A> {
     pub fn new(
-        board_kernel: &'static kernel::Kernel,
+        board_kernel: &'ker kernel::Kernel<'ker>,
         si: &'static SI7021<'static, VirtualMuxAlarm<'static, A>>,
-    ) -> HumidityComponent<A> {
+    ) -> HumidityComponent<'ker, A> {
         HumidityComponent {
             board_kernel: board_kernel,
             si7021: si,
@@ -144,15 +147,18 @@ impl<A: 'static + time::Alarm<'static>> HumidityComponent<A> {
     }
 }
 
-impl<A: 'static + time::Alarm<'static>> Component for HumidityComponent<A> {
+impl<A: 'static + time::Alarm<'static>> Component for HumidityComponent<'ker, A>
+where
+    'ker: 'static,
+{
     type StaticInput = ();
-    type Output = &'static HumiditySensor<'static>;
+    type Output = &'static HumiditySensor<'static, 'ker>;
 
     unsafe fn finalize(&mut self, _s: Self::StaticInput) -> Self::Output {
         let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
 
         let hum = static_init!(
-            HumiditySensor<'static>,
+            HumiditySensor<'static, '_>,
             HumiditySensor::new(self.si7021, self.board_kernel.create_grant(&grant_cap))
         );
 

--- a/boards/imix/src/imix_components/adc.rs
+++ b/boards/imix/src/imix_components/adc.rs
@@ -21,21 +21,24 @@ use kernel::component::Component;
 use kernel::create_capability;
 use kernel::static_init;
 
-pub struct AdcComponent {
-    board_kernel: &'static kernel::Kernel,
+pub struct AdcComponent<'ker> {
+    board_kernel: &'ker kernel::Kernel<'ker>,
 }
 
-impl AdcComponent {
-    pub fn new(board_kernel: &'static kernel::Kernel) -> AdcComponent {
+impl AdcComponent<'ker> {
+    pub fn new(board_kernel: &'ker kernel::Kernel<'ker>) -> AdcComponent<'ker> {
         AdcComponent {
             board_kernel: board_kernel,
         }
     }
 }
 
-impl Component for AdcComponent {
+impl Component for AdcComponent<'ker>
+where
+    'ker: 'static,
+{
     type StaticInput = ();
-    type Output = &'static adc::Adc<'static, sam4l::adc::Adc>;
+    type Output = &'static adc::Adc<'static, 'ker, sam4l::adc::Adc>;
 
     unsafe fn finalize(&mut self, _s: Self::StaticInput) -> Self::Output {
         let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
@@ -51,7 +54,7 @@ impl Component for AdcComponent {
             ]
         );
         let adc = static_init!(
-            adc::Adc<'static, sam4l::adc::Adc>,
+            adc::Adc<'static, '_, sam4l::adc::Adc>,
             adc::Adc::new(
                 &mut sam4l::adc::ADC0,
                 self.board_kernel.create_grant(&grant_cap),

--- a/boards/imix/src/imix_components/test/mock_udp.rs
+++ b/boards/imix/src/imix_components/test/mock_udp.rs
@@ -15,13 +15,16 @@ use kernel::component::Component;
 use kernel::hil::time::Alarm;
 use kernel::static_init;
 
-pub struct MockUDPComponent {
+pub struct MockUDPComponent<'ker>
+where
+    'ker: 'static,
+{
     // TODO: consider putting bound_port_table in a TakeCell
     udp_send_mux: &'static MuxUdpSender<
         'static,
         IP6SendStruct<'static, VirtualMuxAlarm<'static, sam4l::ast::Ast<'static>>>,
     >,
-    udp_recv_mux: &'static MuxUdpReceiver<'static>,
+    udp_recv_mux: &'static MuxUdpReceiver<'static, 'static, 'ker>,
     bound_port_table: &'static UdpPortManager,
     alarm_mux: &'static MuxAlarm<'static, sam4l::ast::Ast<'static>>,
     udp_payload: TakeCell<'static, [u8]>,
@@ -29,19 +32,19 @@ pub struct MockUDPComponent {
     dst_port: u16,
 }
 
-impl MockUDPComponent {
+impl MockUDPComponent<'ker> {
     pub fn new(
         udp_send_mux: &'static MuxUdpSender<
             'static,
             IP6SendStruct<'static, VirtualMuxAlarm<'static, sam4l::ast::Ast<'static>>>,
         >,
-        udp_recv_mux: &'static MuxUdpReceiver<'static>,
+        udp_recv_mux: &'static MuxUdpReceiver<'static, 'static, 'ker>,
         bound_port_table: &'static UdpPortManager,
         alarm: &'static MuxAlarm<'static, sam4l::ast::Ast<'static>>,
         udp_payload: &'static mut [u8],
         id: u16,
         dst_port: u16,
-    ) -> MockUDPComponent {
+    ) -> MockUDPComponent<'ker> {
         MockUDPComponent {
             udp_send_mux: udp_send_mux,
             udp_recv_mux: udp_recv_mux,
@@ -54,7 +57,7 @@ impl MockUDPComponent {
     }
 }
 
-impl Component for MockUDPComponent {
+impl Component for MockUDPComponent<'ker> {
     type StaticInput = ();
     type Output = &'static capsules::test::udp::MockUdp<
         'static,

--- a/boards/imix/src/imix_components/test/mock_udp2.rs
+++ b/boards/imix/src/imix_components/test/mock_udp2.rs
@@ -18,13 +18,16 @@ use kernel::component::Component;
 use kernel::hil::time::Alarm;
 use kernel::static_init;
 
-pub struct MockUDPComponent2 {
+pub struct MockUDPComponent2<'ker>
+where
+    'ker: 'static,
+{
     // TODO: consider putting bound_port_table in a TakeCell
     udp_send_mux: &'static MuxUdpSender<
         'static,
         IP6SendStruct<'static, VirtualMuxAlarm<'static, sam4l::ast::Ast<'static>>>,
     >,
-    udp_recv_mux: &'static MuxUdpReceiver<'static>,
+    udp_recv_mux: &'static MuxUdpReceiver<'static, 'static, 'ker>,
     bound_port_table: &'static UdpPortManager,
     alarm_mux: &'static MuxAlarm<'static, sam4l::ast::Ast<'static>>,
     udp_payload: TakeCell<'static, [u8]>,
@@ -32,19 +35,19 @@ pub struct MockUDPComponent2 {
     dst_port: u16,
 }
 
-impl MockUDPComponent2 {
+impl MockUDPComponent2<'ker> {
     pub fn new(
         udp_send_mux: &'static MuxUdpSender<
             'static,
             IP6SendStruct<'static, VirtualMuxAlarm<'static, sam4l::ast::Ast<'static>>>,
         >,
-        udp_recv_mux: &'static MuxUdpReceiver<'static>,
+        udp_recv_mux: &'static MuxUdpReceiver<'static, 'static, 'ker>,
         bound_port_table: &'static UdpPortManager,
         alarm: &'static MuxAlarm<'static, sam4l::ast::Ast<'static>>,
         udp_payload: &'static mut [u8],
         id: u16,
         dst_port: u16,
-    ) -> MockUDPComponent2 {
+    ) -> MockUDPComponent2<'ker> {
         MockUDPComponent2 {
             udp_send_mux: udp_send_mux,
             udp_recv_mux: udp_recv_mux,
@@ -57,7 +60,7 @@ impl MockUDPComponent2 {
     }
 }
 
-impl Component for MockUDPComponent2 {
+impl Component for MockUDPComponent2<'ker> {
     type StaticInput = ();
     type Output = &'static capsules::test::udp::MockUdp<
         'static,

--- a/boards/imix/src/udp_lowpan_test.rs
+++ b/boards/imix/src/udp_lowpan_test.rs
@@ -157,12 +157,12 @@ pub struct LowpanTest<'a, A: time::Alarm<'a>> {
     test_mode: Cell<TestMode>,
 }
 
-pub unsafe fn initialize_all(
+pub unsafe fn initialize_all<'ker>(
     udp_send_mux: &'static MuxUdpSender<
         'static,
         IP6SendStruct<'static, VirtualMuxAlarm<'static, sam4l::ast::Ast<'static>>>,
     >,
-    udp_recv_mux: &'static MuxUdpReceiver<'static>,
+    udp_recv_mux: &'static MuxUdpReceiver<'static, 'static, 'ker>,
     port_table: &'static UdpPortManager,
     mux_alarm: &'static MuxAlarm<'static, sam4l::ast::Ast>,
 ) -> &'static LowpanTest<

--- a/boards/nordic/nrf52dk_base/src/nrf52_components/ble.rs
+++ b/boards/nordic/nrf52dk_base/src/nrf52_components/ble.rs
@@ -18,18 +18,18 @@ use kernel::{create_capability, static_init};
 
 // Save some deep nesting
 
-pub struct BLEComponent {
-    board_kernel: &'static kernel::Kernel,
+pub struct BLEComponent<'ker> {
+    board_kernel: &'ker kernel::Kernel<'ker>,
     radio: &'static nrf52::ble_radio::Radio,
     mux_alarm: &'static capsules::virtual_alarm::MuxAlarm<'static, nrf52::rtc::Rtc<'static>>,
 }
 
-impl BLEComponent {
+impl<'ker> BLEComponent<'ker> {
     pub fn new(
-        board_kernel: &'static kernel::Kernel,
+        board_kernel: &'ker kernel::Kernel<'ker>,
         radio: &'static nrf52::ble_radio::Radio,
         mux_alarm: &'static capsules::virtual_alarm::MuxAlarm<'static, nrf52::rtc::Rtc>,
-    ) -> BLEComponent {
+    ) -> BLEComponent<'ker> {
         BLEComponent {
             board_kernel: board_kernel,
             radio: radio,
@@ -38,10 +38,14 @@ impl BLEComponent {
     }
 }
 
-impl Component for BLEComponent {
+impl<'ker> Component for BLEComponent<'ker>
+where
+    'ker: 'static,
+{
     type StaticInput = ();
     type Output = &'static capsules::ble_advertising_driver::BLE<
         'static,
+        'ker,
         nrf52::ble_radio::Radio,
         VirtualMuxAlarm<'static, Rtc<'static>>,
     >;
@@ -57,6 +61,7 @@ impl Component for BLEComponent {
         let ble_radio = static_init!(
             capsules::ble_advertising_driver::BLE<
                 'static,
+                '_,
                 nrf52::ble_radio::Radio,
                 VirtualMuxAlarm<'static, Rtc>,
             >,

--- a/capsules/src/dac.rs
+++ b/capsules/src/dac.rs
@@ -26,7 +26,7 @@ impl Dac<'a> {
     }
 }
 
-impl Driver for Dac<'a> {
+impl Driver<'ker> for Dac<'a> {
     /// Control the DAC.
     ///
     /// ### `command_num`
@@ -34,7 +34,7 @@ impl Driver for Dac<'a> {
     /// - `0`: Driver check.
     /// - `1`: Initialize and enable the DAC.
     /// - `2`: Set the output to `data1`, a scaled output value.
-    fn command(&self, command_num: usize, data: usize, _: usize, _: AppId) -> ReturnCode {
+    fn command(&self, command_num: usize, data: usize, _: usize, _: AppId<'ker>) -> ReturnCode {
         match command_num {
             0 /* check if present */ => ReturnCode::SUCCESS,
 

--- a/capsules/src/debug_process_restart.rs
+++ b/capsules/src/debug_process_restart.rs
@@ -28,17 +28,17 @@ use kernel::capabilities::ProcessManagementCapability;
 use kernel::hil::gpio;
 use kernel::Kernel;
 
-pub struct DebugProcessRestart<C: ProcessManagementCapability> {
-    kernel: &'static Kernel,
+pub struct DebugProcessRestart<'ker, C: ProcessManagementCapability> {
+    kernel: &'ker Kernel<'ker>,
     capability: C,
 }
 
-impl<'a, C: ProcessManagementCapability> DebugProcessRestart<C> {
+impl<'a, 'ker, C: ProcessManagementCapability> DebugProcessRestart<'ker, C> {
     pub fn new(
-        kernel: &'static Kernel,
+        kernel: &'ker Kernel<'ker>,
         pin: &'a dyn gpio::InterruptPin,
         cap: C,
-    ) -> DebugProcessRestart<C> {
+    ) -> DebugProcessRestart<'ker, C> {
         pin.make_input();
         pin.enable_interrupts(gpio::InterruptEdge::RisingEdge);
 
@@ -49,7 +49,7 @@ impl<'a, C: ProcessManagementCapability> DebugProcessRestart<C> {
     }
 }
 
-impl<'a, C: ProcessManagementCapability> gpio::Client for DebugProcessRestart<C> {
+impl<'a, 'ker, C: ProcessManagementCapability> gpio::Client for DebugProcessRestart<'ker, C> {
     fn fired(&self) {
         self.kernel.hardfault_all_apps(&self.capability);
     }

--- a/capsules/src/led.rs
+++ b/capsules/src/led.rs
@@ -85,7 +85,7 @@ impl<'a> LED<'a> {
     }
 }
 
-impl<'a> Driver for LED<'a> {
+impl<'a, 'ker> Driver<'ker> for LED<'a> {
     /// Control the LEDs.
     ///
     /// ### `command_num`
@@ -98,7 +98,7 @@ impl<'a> Driver for LED<'a> {
     ///        if the LED index is not valid.
     /// - `3`: Toggle the LED at index specified by `data` on or off. Returns
     ///        `EINVAL` if the LED index is not valid.
-    fn command(&self, command_num: usize, data: usize, _: usize, _: AppId) -> ReturnCode {
+    fn command(&self, command_num: usize, data: usize, _: usize, _: AppId<'ker>) -> ReturnCode {
         let pins_init = self.pins_init.as_ref();
         match command_num {
             // get number of LEDs

--- a/capsules/src/ltc294x.rs
+++ b/capsules/src/ltc294x.rs
@@ -403,13 +403,13 @@ impl gpio::Client for LTC294X<'a> {
 
 /// Default implementation of the LTC2941 driver that provides a Driver
 /// interface for providing access to applications.
-pub struct LTC294XDriver<'a> {
+pub struct LTC294XDriver<'a, 'ker> {
     ltc294x: &'a LTC294X<'a>,
-    callback: OptionalCell<Callback>,
+    callback: OptionalCell<Callback<'ker>>,
 }
 
-impl LTC294XDriver<'a> {
-    pub fn new(ltc: &'a LTC294X) -> LTC294XDriver<'a> {
+impl LTC294XDriver<'a, 'ker> {
+    pub fn new(ltc: &'a LTC294X) -> LTC294XDriver<'a, 'ker> {
         LTC294XDriver {
             ltc294x: ltc,
             callback: OptionalCell::empty(),
@@ -417,7 +417,7 @@ impl LTC294XDriver<'a> {
     }
 }
 
-impl LTC294XClient for LTC294XDriver<'a> {
+impl LTC294XClient for LTC294XDriver<'a, 'ker> {
     fn interrupt(&self) {
         self.callback.map(|cb| {
             cb.schedule(0, 0, 0);
@@ -467,7 +467,7 @@ impl LTC294XClient for LTC294XDriver<'a> {
     }
 }
 
-impl Driver for LTC294XDriver<'a> {
+impl Driver<'ker> for LTC294XDriver<'a, 'ker> {
     /// Setup callbacks.
     ///
     /// ### `subscribe_num`
@@ -484,8 +484,8 @@ impl Driver for LTC294XDriver<'a> {
     fn subscribe(
         &self,
         subscribe_num: usize,
-        callback: Option<Callback>,
-        _app_id: AppId,
+        callback: Option<Callback<'ker>>,
+        _app_id: AppId<'ker>,
     ) -> ReturnCode {
         match subscribe_num {
             0 => {
@@ -515,7 +515,7 @@ impl Driver for LTC294XDriver<'a> {
     /// - `9`: Get the current reading. Only supported on the LTC2943.
     /// - `10`: Set the model of the LTC294X actually being used. `data` is the
     ///   value of the X.
-    fn command(&self, command_num: usize, data: usize, _: usize, _: AppId) -> ReturnCode {
+    fn command(&self, command_num: usize, data: usize, _: usize, _: AppId<'ker>) -> ReturnCode {
         match command_num {
             // Check this driver exists.
             0 => ReturnCode::SUCCESS,

--- a/capsules/src/max17205.rs
+++ b/capsules/src/max17205.rs
@@ -357,13 +357,13 @@ impl i2c::I2CClient for MAX17205<'a> {
     }
 }
 
-pub struct MAX17205Driver<'a> {
+pub struct MAX17205Driver<'a, 'ker> {
     max17205: &'a MAX17205<'a>,
-    callback: OptionalCell<Callback>,
+    callback: OptionalCell<Callback<'ker>>,
 }
 
-impl MAX17205Driver<'a> {
-    pub fn new(max: &'a MAX17205) -> MAX17205Driver<'a> {
+impl MAX17205Driver<'a, 'ker> {
+    pub fn new(max: &'a MAX17205) -> MAX17205Driver<'a, 'ker> {
         MAX17205Driver {
             max17205: max,
             callback: OptionalCell::empty(),
@@ -371,7 +371,7 @@ impl MAX17205Driver<'a> {
     }
 }
 
-impl MAX17205Client for MAX17205Driver<'a> {
+impl MAX17205Client for MAX17205Driver<'a, 'ker> {
     fn status(&self, status: u16, error: ReturnCode) {
         self.callback
             .map(|cb| cb.schedule(From::from(error), status as usize, 0));
@@ -408,7 +408,7 @@ impl MAX17205Client for MAX17205Driver<'a> {
     }
 }
 
-impl Driver for MAX17205Driver<'a> {
+impl Driver<'ker> for MAX17205Driver<'a, 'ker> {
     /// Setup callback.
     ///
     /// ### `subscribe_num`
@@ -417,8 +417,8 @@ impl Driver for MAX17205Driver<'a> {
     fn subscribe(
         &self,
         subscribe_num: usize,
-        callback: Option<Callback>,
-        _app_id: AppId,
+        callback: Option<Callback<'ker>>,
+        _app_id: AppId<'ker>,
     ) -> ReturnCode {
         match subscribe_num {
             0 => {
@@ -441,7 +441,7 @@ impl Driver for MAX17205Driver<'a> {
     /// - `3`: Read the current voltage and current draw.
     /// - `4`: Read the raw coulomb count.
     /// - `5`: Read the unique 64 bit RomID.
-    fn command(&self, command_num: usize, _data: usize, _: usize, _: AppId) -> ReturnCode {
+    fn command(&self, command_num: usize, _data: usize, _: usize, _: AppId<'ker>) -> ReturnCode {
         match command_num {
             0 => ReturnCode::SUCCESS,
 

--- a/capsules/src/net/udp/udp_recv.rs
+++ b/capsules/src/net/udp/udp_recv.rs
@@ -15,13 +15,13 @@ use kernel::common::cells::{MapCell, OptionalCell};
 use kernel::common::{List, ListLink, ListNode};
 use kernel::debug;
 
-pub struct MuxUdpReceiver<'a> {
+pub struct MuxUdpReceiver<'a, 'b, 'ker> {
     rcvr_list: List<'a, UDPReceiver<'a>>,
-    driver: OptionalCell<&'static UDPDriver<'static>>,
+    driver: OptionalCell<&'b UDPDriver<'b, 'ker>>,
 }
 
-impl<'a> MuxUdpReceiver<'a> {
-    pub fn new() -> MuxUdpReceiver<'a> {
+impl MuxUdpReceiver<'a, 'b, 'ker> {
+    pub fn new() -> MuxUdpReceiver<'a, 'b, 'ker> {
         MuxUdpReceiver {
             rcvr_list: List::new(),
             driver: OptionalCell::empty(),
@@ -32,12 +32,12 @@ impl<'a> MuxUdpReceiver<'a> {
         self.rcvr_list.push_tail(rcvr);
     }
 
-    pub fn set_driver(&self, driver_ref: &'static UDPDriver) {
+    pub fn set_driver(&self, driver_ref: &'b UDPDriver<'b, 'ker>) {
         self.driver.replace(driver_ref);
     }
 }
 
-impl<'a> IP6RecvClient for MuxUdpReceiver<'a> {
+impl IP6RecvClient for MuxUdpReceiver<'a, 'b, 'ker> {
     fn receive(&self, ip_header: IP6Header, payload: &[u8]) {
         match UDPHeader::decode(payload).done() {
             Some((offset, udp_header)) => {

--- a/kernel/src/callback.rs
+++ b/kernel/src/callback.rs
@@ -10,27 +10,27 @@ use crate::sched::Kernel;
 
 /// Userspace app identifier.
 #[derive(Clone, Copy)]
-pub struct AppId {
-    crate kernel: &'static Kernel,
+pub struct AppId<'ker> {
+    crate kernel: &'ker Kernel<'ker>,
     idx: usize,
 }
 
-impl PartialEq for AppId {
+impl PartialEq for AppId<'_> {
     fn eq(&self, other: &AppId) -> bool {
         self.idx == other.idx
     }
 }
 
-impl Eq for AppId {}
+impl Eq for AppId<'_> {}
 
-impl fmt::Debug for AppId {
+impl fmt::Debug for AppId<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.idx)
     }
 }
 
-impl AppId {
-    crate fn new(kernel: &'static Kernel, idx: usize) -> AppId {
+impl<'ker> AppId<'ker> {
+    crate fn new(kernel: &'ker Kernel<'ker>, idx: usize) -> AppId {
         AppId {
             kernel: kernel,
             idx: idx,
@@ -67,16 +67,16 @@ pub struct CallbackId {
 ///
 /// This is essentially a wrapper around a function pointer.
 #[derive(Clone, Copy)]
-pub struct Callback {
-    app_id: AppId,
+pub struct Callback<'ker> {
+    app_id: AppId<'ker>,
     callback_id: CallbackId,
     appdata: usize,
     fn_ptr: NonNull<*mut ()>,
 }
 
-impl Callback {
+impl<'ker> Callback<'ker> {
     crate fn new(
-        app_id: AppId,
+        app_id: AppId<'ker>,
         callback_id: CallbackId,
         appdata: usize,
         fn_ptr: NonNull<*mut ()>,

--- a/kernel/src/driver.rs
+++ b/kernel/src/driver.rs
@@ -47,7 +47,7 @@ use crate::returncode::ReturnCode;
 ///
 /// See [the module level documentation](index.html) for an overview of how
 /// system calls are assigned to drivers.
-pub trait Driver {
+pub trait Driver<'ker> {
     /// `subscribe` lets an application pass a callback to the driver to be
     /// called later. This returns `ENOSUPPORT` if not used.
     ///
@@ -72,7 +72,12 @@ pub trait Driver {
     /// the magnitude of the return value of can signify extra information such
     /// as error type.
     #[allow(unused_variables)]
-    fn subscribe(&self, minor_num: usize, callback: Option<Callback>, app_id: AppId) -> ReturnCode {
+    fn subscribe(
+        &self,
+        minor_num: usize,
+        callback: Option<Callback<'ker>>,
+        app_id: AppId<'ker>,
+    ) -> ReturnCode {
         ReturnCode::ENOSUPPORT
     }
 
@@ -92,7 +97,13 @@ pub trait Driver {
     /// side effects. This convention ensures that applications can query the
     /// kernel for supported drivers on a given platform.
     #[allow(unused_variables)]
-    fn command(&self, minor_num: usize, r2: usize, r3: usize, caller_id: AppId) -> ReturnCode {
+    fn command(
+        &self,
+        minor_num: usize,
+        r2: usize,
+        r3: usize,
+        caller_id: AppId<'ker>,
+    ) -> ReturnCode {
         ReturnCode::ENOSUPPORT
     }
 
@@ -105,9 +116,9 @@ pub trait Driver {
     #[allow(unused_variables)]
     fn allow(
         &self,
-        app: AppId,
+        app: AppId<'ker>,
         minor_num: usize,
-        slice: Option<AppSlice<Shared, u8>>,
+        slice: Option<AppSlice<'ker, Shared, u8>>,
     ) -> ReturnCode {
         ReturnCode::ENOSUPPORT
     }

--- a/kernel/src/introspection.rs
+++ b/kernel/src/introspection.rs
@@ -19,12 +19,12 @@ use crate::process;
 use crate::sched::Kernel;
 
 /// This struct provides the inspection functions.
-pub struct KernelInfo {
-    kernel: &'static Kernel,
+pub struct KernelInfo<'ker> {
+    kernel: &'ker Kernel<'ker>,
 }
 
-impl KernelInfo {
-    pub fn new(kernel: &'static Kernel) -> KernelInfo {
+impl KernelInfo<'ker> {
+    pub fn new(kernel: &'ker Kernel<'ker>) -> KernelInfo {
         KernelInfo { kernel: kernel }
     }
 
@@ -74,7 +74,7 @@ impl KernelInfo {
     /// Get the name of the process.
     pub fn process_name(
         &self,
-        app: AppId,
+        app: AppId<'ker>,
         _capability: &dyn ProcessManagementCapability,
     ) -> &'static str {
         self.kernel
@@ -84,7 +84,7 @@ impl KernelInfo {
     /// Returns the number of syscalls the app has called.
     pub fn number_app_syscalls(
         &self,
-        app: AppId,
+        app: AppId<'ker>,
         _capability: &dyn ProcessManagementCapability,
     ) -> usize {
         self.kernel
@@ -96,7 +96,7 @@ impl KernelInfo {
     /// tries to schedule a callback.
     pub fn number_app_dropped_callbacks(
         &self,
-        app: AppId,
+        app: AppId<'ker>,
         _capability: &dyn ProcessManagementCapability,
     ) -> usize {
         self.kernel.process_map_or(0, app.idx(), |process| {
@@ -107,7 +107,7 @@ impl KernelInfo {
     /// Returns the number of time this app has been restarted.
     pub fn number_app_restarts(
         &self,
-        app: AppId,
+        app: AppId<'ker>,
         _capability: &dyn ProcessManagementCapability,
     ) -> usize {
         self.kernel
@@ -117,7 +117,7 @@ impl KernelInfo {
     /// Returns the number of time this app has exceeded its timeslice.
     pub fn number_app_timeslice_expirations(
         &self,
-        app: AppId,
+        app: AppId<'ker>,
         _capability: &dyn ProcessManagementCapability,
     ) -> usize {
         self.kernel.process_map_or(0, app.idx(), |process| {

--- a/kernel/src/platform/mod.rs
+++ b/kernel/src/platform/mod.rs
@@ -37,12 +37,12 @@ crate mod systick;
 ///     }
 /// }
 /// ```
-pub trait Platform {
+pub trait Platform<'ker> {
     /// Platform-specific mapping of syscall numbers to objects that implement
     /// the Driver methods for that syscall.
     fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
     where
-        F: FnOnce(Option<&dyn Driver>) -> R;
+        F: FnOnce(Option<&dyn Driver<'ker>>) -> R;
 }
 
 /// Interface for individual MCUs.


### PR DESCRIPTION
## Pull Request Overview

This pull request is a proof-of-concept of what it would mean to have a generic lifetime for the `Kernel` object, rather than it being `'static`. It is in the spirit of https://github.com/tock/tock/issues/1074 (generic lifetimes for kernel HILs).

I created this mostly to open the discussion. I made it a pull-request so that it's easier to compare the code, but it's essentially a draft and you can see it as an RFC, to see whether more generic lifetimes (beyond https://github.com/tock/tock/issues/1074) could be useful or on the contrary detrimental.

## Motivation

### When can `'static` be problematic?

There are multiple downsides with `'static` lifetimes.

- They sometimes lead to restrictions in the code, forcing many dependencies to also be `'static`, as highlighted in https://github.com/tock/tock/issues/1074.
- The Rust compiler has a hard time analyzing the memory safety of static data structures (especially mutable ones). It considers that mutable static data can be aliased and accessed concurrently - violating Rust's aliasing rules. This requires the `static_init` macro to be `unsafe` code (and rightfully so, given that calling `static_init` code twice, such as in a loop, would initialize it again without cleaning up old data).
- A corollary of the two previous points is that a lot of code using `'static` lifetimes must be marked as `unsafe`. Broadly speaking, all boards are initialized in large `unsafe` blocks. This means that the compiler cannot help us detect unintended memory safety issues in these large `unsafe` blocks.

### What are some pros and cons of generic lifetimes (non exhaustive list)?

Generic lifetimes can bring:

- More flexibility as seen in https://github.com/tock/tock/issues/1074.
- More fine-grained borrow checking. This can mean more efforts for developers to figure out how to spell the lifetimes constraints correctly. Aside that, the benefits in our case are not so clear - as borrow checking on `'static` lifetime works well.
- The ability to create board components directly on the stack, without `static_init`, i.e. without `unsafe` code.
- A downside of the previous point could be that the linker might not be able to check at compile time that all data structures will fit in memory (are static buffers on the contrary stored in the `.bss` section?). There could be a stack overflow at runtime instead.
- Generic lifetimes require many more annotations. Although Rust has done a great job at allowing elision of lifetimes in simple cases, all structures (recursively) containing a generic-lifetime reference must annotate it. It can become non-trivial to understand where to put these annotations in complex cases involving many objects and traits for example.


## This proof-of-concept

This proof-of-concept boils down to replacing `'static` lifetimes in the `Kernel` scheduler by a generic `'ker` lifetime. In practice, this lifetime will outlive anything useful because the `kernel_loop` function never terminates (unless one resets the board, in which case the board initialization starts from the beginning anyway). So it's "almost static", except that this generic lifetime could allow more flexibility, better borrow checking by the Rust compiler, and hopefully fewer `unsafe` code.

As you can see, this has a lot of consequences throughout the code-base:
- All kernel structures referencing the `Kernel` object are affected, in particular `Callback`, `Grant` and `AppId`. The `Driver` trait as well.
- In turn, all capsules, because they need to implement `Driver` and/or store `Callback`s. Those that don't have callbacks (`Led`) require much less refactoring.
- On top of that, lifetimes have to be added to the components.
- Last, the boards must include the new lifetime as well. I tried a few boards and managed to make them compile end-to-end.


### Beyond that?

1. I had a brief look at what would happen if one tried to instantiate the `board_kernel` as a non-static object. For now, the main limitation seems to be that kernel HILs (in particular `set_client` methods) require `'static` references. So further work in that direction would currently be blocked on https://github.com/tock/tock/issues/1074.
1. Generic lifetimes could also be applied to the `Chip` references throughout the kernel.


## Testing Strategy

This pull request was NOT tested at the moment.


## TODO or Help Wanted

This pull request still needs discussion.


## Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

## Formatting

- [ ] Ran `make formatall`.