### PR TITLE
Updated the number of User LEDs for Nucleo_F429ZI

### DIFF
--- a/boards/nucleo_f429zi/src/main.rs
+++ b/boards/nucleo_f429zi/src/main.rs
@@ -8,13 +8,13 @@
 #![deny(missing_docs)]
 
 use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
+use components::gpio::GpioComponent;
 use kernel::capabilities;
 use kernel::common::dynamic_deferred_call::{DynamicDeferredCall, DynamicDeferredCallClientState};
 use kernel::component::Component;
 use kernel::hil::time::Alarm;
 use kernel::Platform;
 use kernel::{create_capability, debug, static_init};
-use components::gpio::GpioComponent;
 
 /// Support routines for debugging I/O.
 pub mod io;
@@ -304,13 +304,99 @@ pub unsafe fn reset_handler() {
     );
     virtual_alarm.set_client(alarm);
 
+    // GPIO
+
     let gpio = GpioComponent::new(board_kernel).finalize(components::gpio_component_helper!(
-        stm32f4xx::gpio::PIN[3][7].as_ref().unwrap ()
-        // stm32f4xx::gpio::PIN[0][1].as_ref().unwrap (),
-        // stm32f4xx::gpio::PIN[0][2].as_ref().unwrap (),
-        // stm32f4xx::gpio::PIN[0][3].as_ref().unwrap (),
-        // stm32f4xx::gpio::PIN[0][4].as_ref().unwrap (),
-        // stm32f4xx::gpio::PIN[0][5].as_ref().unwrap ()
+        // Arduino like RX/TX
+        stm32f4xx::gpio::PIN[6][9].as_ref().unwrap(), //D0
+        stm32f4xx::gpio::PIN[6][14].as_ref().unwrap(), //D1
+        stm32f4xx::gpio::PIN[5][15].as_ref().unwrap(), //D2
+        stm32f4xx::gpio::PIN[4][13].as_ref().unwrap(), //D3
+        stm32f4xx::gpio::PIN[5][14].as_ref().unwrap(), //D4
+        stm32f4xx::gpio::PIN[4][11].as_ref().unwrap(), //D5
+        stm32f4xx::gpio::PIN[4][9].as_ref().unwrap(), //D6
+        stm32f4xx::gpio::PIN[5][13].as_ref().unwrap(), //D7
+        stm32f4xx::gpio::PIN[5][12].as_ref().unwrap(), //D8
+        stm32f4xx::gpio::PIN[3][15].as_ref().unwrap(), //D9
+        // SPI Pins
+        stm32f4xx::gpio::PIN[3][14].as_ref().unwrap(), //D10
+        stm32f4xx::gpio::PIN[0][7].as_ref().unwrap(),  //D11
+        stm32f4xx::gpio::PIN[0][6].as_ref().unwrap(),  //D12
+        stm32f4xx::gpio::PIN[0][5].as_ref().unwrap(),  //D13
+        // I2C Pins
+        stm32f4xx::gpio::PIN[1][9].as_ref().unwrap(), //D14
+        stm32f4xx::gpio::PIN[1][8].as_ref().unwrap(), //D15
+        stm32f4xx::gpio::PIN[2][6].as_ref().unwrap(), //D16
+        stm32f4xx::gpio::PIN[1][15].as_ref().unwrap(), //D17
+        stm32f4xx::gpio::PIN[1][13].as_ref().unwrap(), //D18
+        stm32f4xx::gpio::PIN[1][12].as_ref().unwrap(), //D19
+        stm32f4xx::gpio::PIN[0][15].as_ref().unwrap(), //D20
+        stm32f4xx::gpio::PIN[2][7].as_ref().unwrap(), //D21
+        // SPI B Pins
+        stm32f4xx::gpio::PIN[1][5].as_ref().unwrap(), //D22
+        stm32f4xx::gpio::PIN[1][3].as_ref().unwrap(), //D23
+        stm32f4xx::gpio::PIN[0][4].as_ref().unwrap(), //D24
+        stm32f4xx::gpio::PIN[1][4].as_ref().unwrap(), //D25
+        // QSPI
+        stm32f4xx::gpio::PIN[1][6].as_ref().unwrap(), //D26
+        stm32f4xx::gpio::PIN[1][2].as_ref().unwrap(), //D27
+        stm32f4xx::gpio::PIN[3][13].as_ref().unwrap(), //D28
+        stm32f4xx::gpio::PIN[3][12].as_ref().unwrap(), //D29
+        stm32f4xx::gpio::PIN[3][11].as_ref().unwrap(), //D30
+        stm32f4xx::gpio::PIN[4][2].as_ref().unwrap(), //D31
+        // Timer Pins
+        stm32f4xx::gpio::PIN[0][0].as_ref().unwrap(), //D32
+        stm32f4xx::gpio::PIN[1][0].as_ref().unwrap(), //D33
+        stm32f4xx::gpio::PIN[4][0].as_ref().unwrap(), //D34
+        stm32f4xx::gpio::PIN[1][11].as_ref().unwrap(), //D35
+        stm32f4xx::gpio::PIN[1][10].as_ref().unwrap(), //D36
+        stm32f4xx::gpio::PIN[4][15].as_ref().unwrap(), //D37
+        stm32f4xx::gpio::PIN[4][14].as_ref().unwrap(), //D38
+        stm32f4xx::gpio::PIN[4][12].as_ref().unwrap(), //D39
+        stm32f4xx::gpio::PIN[4][10].as_ref().unwrap(), //D40
+        stm32f4xx::gpio::PIN[4][7].as_ref().unwrap(), //D41
+        stm32f4xx::gpio::PIN[4][8].as_ref().unwrap(), //D42
+        // SDMMC
+        stm32f4xx::gpio::PIN[2][8].as_ref().unwrap(), //D43
+        stm32f4xx::gpio::PIN[2][9].as_ref().unwrap(), //D44
+        stm32f4xx::gpio::PIN[2][10].as_ref().unwrap(), //D45
+        stm32f4xx::gpio::PIN[2][11].as_ref().unwrap(), //D46
+        stm32f4xx::gpio::PIN[2][12].as_ref().unwrap(), //D47
+        stm32f4xx::gpio::PIN[3][2].as_ref().unwrap(), //D48
+        stm32f4xx::gpio::PIN[6][2].as_ref().unwrap(), //D49
+        stm32f4xx::gpio::PIN[6][3].as_ref().unwrap(), //D50
+        // USART
+        stm32f4xx::gpio::PIN[3][7].as_ref().unwrap(), //D51
+        stm32f4xx::gpio::PIN[3][6].as_ref().unwrap(), //D52
+        stm32f4xx::gpio::PIN[3][5].as_ref().unwrap(), //D53
+        stm32f4xx::gpio::PIN[3][4].as_ref().unwrap(), //D54
+        stm32f4xx::gpio::PIN[3][3].as_ref().unwrap(), //D55
+        stm32f4xx::gpio::PIN[4][2].as_ref().unwrap(), //D56
+        stm32f4xx::gpio::PIN[4][4].as_ref().unwrap(), //D57
+        stm32f4xx::gpio::PIN[4][5].as_ref().unwrap(), //D58
+        stm32f4xx::gpio::PIN[4][6].as_ref().unwrap(), //D59
+        stm32f4xx::gpio::PIN[4][3].as_ref().unwrap(), //D60
+        stm32f4xx::gpio::PIN[5][8].as_ref().unwrap(), //D61
+        stm32f4xx::gpio::PIN[5][7].as_ref().unwrap(), //D62
+        stm32f4xx::gpio::PIN[5][9].as_ref().unwrap(), //D63
+        stm32f4xx::gpio::PIN[6][1].as_ref().unwrap(), //D64
+        stm32f4xx::gpio::PIN[6][0].as_ref().unwrap(), //D65
+        stm32f4xx::gpio::PIN[3][1].as_ref().unwrap(), //D66
+        stm32f4xx::gpio::PIN[3][0].as_ref().unwrap(), //D67
+        stm32f4xx::gpio::PIN[5][0].as_ref().unwrap(), //D68
+        stm32f4xx::gpio::PIN[5][1].as_ref().unwrap(), //D69
+        stm32f4xx::gpio::PIN[5][2].as_ref().unwrap(), //D70
+        stm32f4xx::gpio::PIN[0][7].as_ref().unwrap(), //D71
+        // ADC Pins
+        stm32f4xx::gpio::PIN[0][3].as_ref().unwrap(), //A0
+        stm32f4xx::gpio::PIN[2][0].as_ref().unwrap(), //A1
+        stm32f4xx::gpio::PIN[2][3].as_ref().unwrap(), //A2
+        stm32f4xx::gpio::PIN[5][3].as_ref().unwrap(), //A3
+        stm32f4xx::gpio::PIN[5][5].as_ref().unwrap(), //A4
+        stm32f4xx::gpio::PIN[5][10].as_ref().unwrap(), //A5
+        stm32f4xx::gpio::PIN[1][1].as_ref().unwrap(), //A6
+        stm32f4xx::gpio::PIN[2][2].as_ref().unwrap(), //A7
+        stm32f4xx::gpio::PIN[5][4].as_ref().unwrap()  //A8
     ));
 
     let nucleo_f429zi = NucleoF429ZI {
@@ -319,7 +405,7 @@ pub unsafe fn reset_handler() {
         led: led,
         button: button,
         alarm: alarm,
-        gpio:  gpio
+        gpio: gpio,
     };
 
     // // Optional kernel tests

--- a/boards/nucleo_f429zi/src/main.rs
+++ b/boards/nucleo_f429zi/src/main.rs
@@ -394,19 +394,19 @@ pub unsafe fn reset_handler() {
         stm32f4xx::gpio::PIN[5][0].as_ref().unwrap(), //D68
         stm32f4xx::gpio::PIN[5][1].as_ref().unwrap(), //D69
         stm32f4xx::gpio::PIN[5][2].as_ref().unwrap(), //D70
-        stm32f4xx::gpio::PIN[0][7].as_ref().unwrap() //D71
+        stm32f4xx::gpio::PIN[0][7].as_ref().unwrap()  //D71
 
-        // ADC Pins
-        // Enable the to use the ADC pins as GPIO
-        // stm32f4xx::gpio::PIN[0][3].as_ref().unwrap(), //A0
-        // stm32f4xx::gpio::PIN[2][0].as_ref().unwrap(), //A1
-        // stm32f4xx::gpio::PIN[2][3].as_ref().unwrap(), //A2
-        // stm32f4xx::gpio::PIN[5][3].as_ref().unwrap(), //A3
-        // stm32f4xx::gpio::PIN[5][5].as_ref().unwrap(), //A4
-        // stm32f4xx::gpio::PIN[5][10].as_ref().unwrap(), //A5
-        // stm32f4xx::gpio::PIN[1][1].as_ref().unwrap(), //A6
-        // stm32f4xx::gpio::PIN[2][2].as_ref().unwrap(), //A7
-        // stm32f4xx::gpio::PIN[5][4].as_ref().unwrap()  //A8
+                                                      // ADC Pins
+                                                      // Enable the to use the ADC pins as GPIO
+                                                      // stm32f4xx::gpio::PIN[0][3].as_ref().unwrap(), //A0
+                                                      // stm32f4xx::gpio::PIN[2][0].as_ref().unwrap(), //A1
+                                                      // stm32f4xx::gpio::PIN[2][3].as_ref().unwrap(), //A2
+                                                      // stm32f4xx::gpio::PIN[5][3].as_ref().unwrap(), //A3
+                                                      // stm32f4xx::gpio::PIN[5][5].as_ref().unwrap(), //A4
+                                                      // stm32f4xx::gpio::PIN[5][10].as_ref().unwrap(), //A5
+                                                      // stm32f4xx::gpio::PIN[1][1].as_ref().unwrap(), //A6
+                                                      // stm32f4xx::gpio::PIN[2][2].as_ref().unwrap(), //A7
+                                                      // stm32f4xx::gpio::PIN[5][4].as_ref().unwrap()  //A8
     ));
 
     let nucleo_f429zi = NucleoF429ZI {

--- a/boards/nucleo_f429zi/src/main.rs
+++ b/boards/nucleo_f429zi/src/main.rs
@@ -394,18 +394,19 @@ pub unsafe fn reset_handler() {
         stm32f4xx::gpio::PIN[5][0].as_ref().unwrap(), //D68
         stm32f4xx::gpio::PIN[5][1].as_ref().unwrap(), //D69
         stm32f4xx::gpio::PIN[5][2].as_ref().unwrap(), //D70
-        stm32f4xx::gpio::PIN[0][7].as_ref().unwrap(), //D71
+        stm32f4xx::gpio::PIN[0][7].as_ref().unwrap() //D71
+
         // ADC Pins
         // Enable the to use the ADC pins as GPIO
-        stm32f4xx::gpio::PIN[0][3].as_ref().unwrap(), //A0
-        stm32f4xx::gpio::PIN[2][0].as_ref().unwrap(), //A1
-        stm32f4xx::gpio::PIN[2][3].as_ref().unwrap(), //A2
-        stm32f4xx::gpio::PIN[5][3].as_ref().unwrap(), //A3
-        stm32f4xx::gpio::PIN[5][5].as_ref().unwrap(), //A4
-        stm32f4xx::gpio::PIN[5][10].as_ref().unwrap(), //A5
-        stm32f4xx::gpio::PIN[1][1].as_ref().unwrap(), //A6
-        stm32f4xx::gpio::PIN[2][2].as_ref().unwrap(), //A7
-        stm32f4xx::gpio::PIN[5][4].as_ref().unwrap()  //A8
+        // stm32f4xx::gpio::PIN[0][3].as_ref().unwrap(), //A0
+        // stm32f4xx::gpio::PIN[2][0].as_ref().unwrap(), //A1
+        // stm32f4xx::gpio::PIN[2][3].as_ref().unwrap(), //A2
+        // stm32f4xx::gpio::PIN[5][3].as_ref().unwrap(), //A3
+        // stm32f4xx::gpio::PIN[5][5].as_ref().unwrap(), //A4
+        // stm32f4xx::gpio::PIN[5][10].as_ref().unwrap(), //A5
+        // stm32f4xx::gpio::PIN[1][1].as_ref().unwrap(), //A6
+        // stm32f4xx::gpio::PIN[2][2].as_ref().unwrap(), //A7
+        // stm32f4xx::gpio::PIN[5][4].as_ref().unwrap()  //A8
     ));
 
     let nucleo_f429zi = NucleoF429ZI {

--- a/boards/nucleo_f429zi/src/main.rs
+++ b/boards/nucleo_f429zi/src/main.rs
@@ -152,6 +152,15 @@ unsafe fn set_pin_primary_functions() {
     });
     // EXTI13 interrupts is delivered at IRQn 40 (EXTI15_10)
     cortexm4::nvic::Nvic::new(stm32f4xx::nvic::EXTI15_10).enable();
+
+    // Enable clocks for GPIO Ports
+    // Disable some of them if you don't need some of the GPIOs
+    PORT[PortId::A as usize].enable_clock();
+    // Ports B, C and D are already enabled
+    PORT[PortId::E as usize].enable_clock();
+    PORT[PortId::F as usize].enable_clock();
+    PORT[PortId::G as usize].enable_clock();
+    PORT[PortId::H as usize].enable_clock();
 }
 
 /// Helper function for miscellaneous peripheral functions
@@ -305,7 +314,6 @@ pub unsafe fn reset_handler() {
     virtual_alarm.set_client(alarm);
 
     // GPIO
-
     let gpio = GpioComponent::new(board_kernel).finalize(components::gpio_component_helper!(
         // Arduino like RX/TX
         stm32f4xx::gpio::PIN[6][9].as_ref().unwrap(), //D0
@@ -388,6 +396,7 @@ pub unsafe fn reset_handler() {
         stm32f4xx::gpio::PIN[5][2].as_ref().unwrap(), //D70
         stm32f4xx::gpio::PIN[0][7].as_ref().unwrap(), //D71
         // ADC Pins
+        // Enable the to use the ADC pins as GPIO
         stm32f4xx::gpio::PIN[0][3].as_ref().unwrap(), //A0
         stm32f4xx::gpio::PIN[2][0].as_ref().unwrap(), //A1
         stm32f4xx::gpio::PIN[2][3].as_ref().unwrap(), //A2

--- a/boards/nucleo_f429zi/src/main.rs
+++ b/boards/nucleo_f429zi/src/main.rs
@@ -45,7 +45,7 @@ static APP_HACK: u8 = 0;
 #[link_section = ".stack_buffer"]
 pub static mut STACK_MEMORY: [u8; 0x1000] = [0; 0x1000];
 
-const NUM_LEDS: usize = 1;
+const NUM_LEDS: usize = 3;
 
 /// A structure representing this platform that holds references to all
 /// capsules for this platform.
@@ -252,7 +252,15 @@ pub unsafe fn reset_handler() {
             capsules::led::ActivationMode
         ); NUM_LEDS],
         [(
+            stm32f4xx::gpio::PinId::PB00.get_pin().as_ref().unwrap(),
+            capsules::led::ActivationMode::ActiveHigh
+        ),
+        (
             stm32f4xx::gpio::PinId::PB07.get_pin().as_ref().unwrap(),
+            capsules::led::ActivationMode::ActiveHigh
+        ),
+        (
+            stm32f4xx::gpio::PinId::PB14.get_pin().as_ref().unwrap(),
             capsules::led::ActivationMode::ActiveHigh
         )]
     );

--- a/boards/nucleo_f429zi/src/main.rs
+++ b/boards/nucleo_f429zi/src/main.rs
@@ -251,18 +251,20 @@ pub unsafe fn reset_handler() {
             &'static dyn kernel::hil::gpio::Pin,
             capsules::led::ActivationMode
         ); NUM_LEDS],
-        [(
-            stm32f4xx::gpio::PinId::PB00.get_pin().as_ref().unwrap(),
-            capsules::led::ActivationMode::ActiveHigh
-        ),
-        (
-            stm32f4xx::gpio::PinId::PB07.get_pin().as_ref().unwrap(),
-            capsules::led::ActivationMode::ActiveHigh
-        ),
-        (
-            stm32f4xx::gpio::PinId::PB14.get_pin().as_ref().unwrap(),
-            capsules::led::ActivationMode::ActiveHigh
-        )]
+        [
+            (
+                stm32f4xx::gpio::PinId::PB00.get_pin().as_ref().unwrap(),
+                capsules::led::ActivationMode::ActiveHigh
+            ),
+            (
+                stm32f4xx::gpio::PinId::PB07.get_pin().as_ref().unwrap(),
+                capsules::led::ActivationMode::ActiveHigh
+            ),
+            (
+                stm32f4xx::gpio::PinId::PB14.get_pin().as_ref().unwrap(),
+                capsules::led::ActivationMode::ActiveHigh
+            )
+        ]
     );
     let led = static_init!(
         capsules::led::LED<'static>,


### PR DESCRIPTION
### Pull Request Overview

This pull request changes the number of LEDs exposed by Nucleo_F429ZI.
The actual number of User LEDs is 3, not 1 as it was specified before.

### Testing Strategy

This pull request was tested using a Nucelo board and the libtock-c. 

### Documentation Updated

- [X] no updates are required.

### Formatting

- [X] Ran `make formatall`.
