### PR TITLE
Fix race condition between DynamicDeferredCall and interrupts.

### DIFF
--- a/kernel/src/common/dynamic_deferred_call.rs
+++ b/kernel/src/common/dynamic_deferred_call.rs
@@ -226,23 +226,25 @@ impl DynamicDeferredCall {
     /// `call_global_instance_while`.
     pub(self) fn call_while<F: Fn() -> bool>(&self, f: F) {
         if self.call_pending.get() {
-            // Reset call_pending here, as it may be set again in the deferred calls
-            self.call_pending.set(false);
+            for (i, client_state) in self.client_states.iter().enumerate() {
+                if !f() {
+                    break;
+                }
+                if client_state.scheduled.get() {
+                    client_state.client.map(|client| {
+                        client_state.scheduled.set(false);
+                        client.call(DeferredCallHandle(i));
+                    });
+                }
+            }
 
-            self.client_states
-                .iter()
-                .enumerate()
-                .filter(|(_i, client_state)| client_state.scheduled.get())
-                .filter_map(|(i, client_state)| {
-                    client_state
-                        .client
-                        .map(|c| (i, &client_state.scheduled, *c))
-                })
-                .take_while(|_| f())
-                .for_each(|(i, call_reqd, client)| {
-                    call_reqd.set(false);
-                    client.call(DeferredCallHandle(i));
-                });
+            // Recompute call_pending here, as some deferred calls may have been skipped due to the
+            // `f` predicate becoming false.
+            self.call_pending.set(
+                self.client_states
+                    .iter()
+                    .any(|client_state| client_state.scheduled.get()),
+            );
         }
     }
 }


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes https://github.com/tock/tock/issues/1629.

The `call_pending` sentinel value was set to `false` in `call_while` even if some callbacks may be skipped due to the predicate becoming true (in practice, a race condition with an interrupt).

I also refactored the long chain of iterator methods into a loop, which ends up being more concise and makes it clearer what's going on in this function. Although iterators methods are in general nice, this chain of 10 combinators was over-engineered and bringing more confusion than readable code.


### Testing Strategy

This pull request was tested by on a nRF52840-DK with the [OpenSK](https://github.com/google/OpenSK) app, checking the debug output with Segger RTT and UART, and debugging the debug with `debug_gpio!` to make sure the problem was gone.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
