### PR TITLE
kernel: Fix recording last syscall

### DIFF
--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -266,8 +266,9 @@ pub trait ProcessType {
     /// Increment the number of times the process has exceeded its timeslice.
     fn debug_timeslice_expired(&self);
 
-    /// Increment the number of times the process called a syscall.
-    fn debug_syscall_called(&self);
+    /// Increment the number of times the process called a syscall and record
+    /// the last syscall that was called.
+    fn debug_syscall_called(&self, last_syscall: Syscall);
 }
 
 /// Generic trait for implementing process restart policies.
@@ -1067,8 +1068,11 @@ impl<C: Chip> ProcessType for Process<'a, C> {
             .map(|debug| debug.timeslice_expiration_count += 1);
     }
 
-    fn debug_syscall_called(&self) {
-        self.debug.map(|debug| debug.syscall_count += 1);
+    fn debug_syscall_called(&self, last_syscall: Syscall) {
+        self.debug.map(|debug| {
+            debug.syscall_count += 1;
+            debug.last_syscall = Some(last_syscall);
+        });
     }
 
     unsafe fn print_memory_map(&self, writer: &mut dyn Write) {

--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -280,7 +280,7 @@ impl Kernel {
                             process.set_fault_state();
                         }
                         Some(ContextSwitchReason::SyscallFired { syscall }) => {
-                            process.debug_syscall_called();
+                            process.debug_syscall_called(syscall);
 
                             // Handle each of the syscalls.
                             match syscall {


### PR DESCRIPTION
Saving the last syscall a process called was accidentally dropped in 351c22cf0e4bfabdd4aff77217afa2611ae2f703 during a refactor of the interface between processes and the kernel loop. This restores recording the last syscall.

Relevant to #1641 




### Testing Strategy

This pull request was tested by travis.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
