### PR TITLE
rust: remove all unused feature pragmas

### DIFF
--- a/arch/cortex-m/src/lib.rs
+++ b/arch/cortex-m/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![crate_name = "cortexm"]
 #![crate_type = "rlib"]
-#![feature(asm, const_fn, lang_items)]
+#![feature(asm, lang_items)]
 #![no_std]
 
 use core::fmt::Write;

--- a/arch/cortex-m0/src/lib.rs
+++ b/arch/cortex-m0/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![crate_name = "cortexm0"]
 #![crate_type = "rlib"]
-#![feature(asm, const_fn, core_intrinsics, naked_functions)]
+#![feature(asm, core_intrinsics, naked_functions)]
 #![no_std]
 
 // Re-export the base generic cortex-m functions here as they are

--- a/arch/cortex-m3/src/lib.rs
+++ b/arch/cortex-m3/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![crate_name = "cortexm3"]
 #![crate_type = "rlib"]
-#![feature(asm, const_fn, core_intrinsics, naked_functions)]
+#![feature(asm, core_intrinsics, naked_functions)]
 #![no_std]
 
 pub mod mpu;

--- a/arch/cortex-m4/src/lib.rs
+++ b/arch/cortex-m4/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![crate_name = "cortexm4"]
 #![crate_type = "rlib"]
-#![feature(asm, const_fn, core_intrinsics, naked_functions)]
+#![feature(asm, core_intrinsics, naked_functions)]
 #![no_std]
 
 pub mod mpu;

--- a/arch/rv32i/src/lib.rs
+++ b/arch/rv32i/src/lib.rs
@@ -7,7 +7,6 @@
     const_fn,
     lang_items,
     global_asm,
-    crate_visibility_modifier,
     naked_functions,
     in_band_lifetimes
 )]

--- a/boards/components/src/lib.rs
+++ b/boards/components/src/lib.rs
@@ -1,5 +1,4 @@
 #![no_std]
-#![feature(in_band_lifetimes)]
 
 #[macro_use]
 pub mod gpio;

--- a/boards/nucleo_f429zi/src/main.rs
+++ b/boards/nucleo_f429zi/src/main.rs
@@ -4,7 +4,7 @@
 
 #![no_std]
 #![no_main]
-#![feature(asm, core_intrinsics)]
+#![feature(asm)]
 #![deny(missing_docs)]
 
 use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};

--- a/boards/nucleo_f446re/src/main.rs
+++ b/boards/nucleo_f446re/src/main.rs
@@ -4,7 +4,7 @@
 
 #![no_std]
 #![no_main]
-#![feature(asm, core_intrinsics)]
+#![feature(asm)]
 #![deny(missing_docs)]
 
 use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};

--- a/chips/arty_e21/src/lib.rs
+++ b/chips/arty_e21/src/lib.rs
@@ -1,7 +1,6 @@
 //! Drivers and chip support for the E21 soft core.
 
-#![feature(asm, concat_idents, const_fn)]
-#![feature(exclusive_range_pattern)]
+#![feature(asm)]
 #![no_std]
 #![crate_name = "arty_e21"]
 #![crate_type = "rlib"]

--- a/chips/cc26x2/src/lib.rs
+++ b/chips/cc26x2/src/lib.rs
@@ -1,5 +1,4 @@
-#![feature(const_fn, untagged_unions)]
-#![feature(in_band_lifetimes)]
+#![feature(const_fn, untagged_unions, in_band_lifetimes)]
 #![no_std]
 #![crate_name = "cc26x2"]
 #![crate_type = "rlib"]

--- a/chips/e310x/src/lib.rs
+++ b/chips/e310x/src/lib.rs
@@ -1,7 +1,6 @@
 //! Chip support for the E310 from SiFive.
 
-#![feature(asm, concat_idents, const_fn)]
-#![feature(exclusive_range_pattern)]
+#![feature(asm, exclusive_range_pattern)]
 #![no_std]
 #![crate_name = "e310x"]
 #![crate_type = "rlib"]

--- a/chips/ibex/src/lib.rs
+++ b/chips/ibex/src/lib.rs
@@ -1,7 +1,6 @@
 //! Drivers and chip support for the Ibex soft core.
 
-#![feature(asm, concat_idents, const_fn, naked_functions)]
-#![feature(in_band_lifetimes)]
+#![feature(asm, const_fn, naked_functions, in_band_lifetimes)]
 #![no_std]
 #![crate_name = "ibex"]
 #![crate_type = "rlib"]

--- a/chips/lowrisc/src/lib.rs
+++ b/chips/lowrisc/src/lib.rs
@@ -1,8 +1,6 @@
 //! Implementations for generic LowRISC peripherals.
 
-#![feature(asm, concat_idents, const_fn, core_intrinsics)]
-#![feature(in_band_lifetimes)]
-#![feature(exclusive_range_pattern)]
+#![feature(asm, const_fn, in_band_lifetimes)]
 #![no_std]
 #![crate_name = "lowrisc"]
 #![crate_type = "rlib"]

--- a/chips/nrf52/src/lib.rs
+++ b/chips/nrf52/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(asm, const_fn, core_intrinsics)]
+#![feature(asm, const_fn)]
 #![no_std]
 #![crate_name = "nrf52"]
 #![crate_type = "rlib"]

--- a/chips/sam4l/src/lib.rs
+++ b/chips/sam4l/src/lib.rs
@@ -4,8 +4,7 @@
 
 #![crate_name = "sam4l"]
 #![crate_type = "rlib"]
-#![feature(asm, concat_idents, const_fn, core_intrinsics)]
-#![feature(in_band_lifetimes)]
+#![feature(asm, concat_idents, const_fn, core_intrinsics, in_band_lifetimes)]
 #![no_std]
 
 mod deferred_call_tasks;

--- a/chips/sifive/src/lib.rs
+++ b/chips/sifive/src/lib.rs
@@ -1,8 +1,6 @@
 //! Implementations for generic SiFive MCU peripherals.
 
-#![feature(asm, concat_idents, const_fn, core_intrinsics)]
-#![feature(in_band_lifetimes)]
-#![feature(exclusive_range_pattern)]
+#![feature(asm, const_fn, in_band_lifetimes)]
 #![no_std]
 #![crate_name = "sifive"]
 #![crate_type = "rlib"]

--- a/kernel/src/hil/flash.rs
+++ b/kernel/src/hil/flash.rs
@@ -4,7 +4,6 @@
 //! `page`. Here is an example of a page type and implementation of this trait:
 //!
 //! ```rust
-//! # #![feature(const_fn)]
 //! use core::ops::{Index, IndexMut};
 //!
 //! use kernel::hil;

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -6,10 +6,15 @@
 //!
 //! Most `unsafe` code is in this kernel crate.
 
-#![feature(core_intrinsics, ptr_internals, const_fn)]
-#![feature(panic_info_message)]
-#![feature(in_band_lifetimes, crate_visibility_modifier)]
-#![feature(associated_type_defaults)]
+#![feature(
+    core_intrinsics,
+    ptr_internals,
+    const_fn,
+    panic_info_message,
+    in_band_lifetimes,
+    crate_visibility_modifier,
+    associated_type_defaults
+)]
 #![warn(unreachable_pub)]
 #![no_std]
 

--- a/libraries/tock-cells/src/lib.rs
+++ b/libraries/tock-cells/src/lib.rs
@@ -1,6 +1,6 @@
 //! Tock Cell types.
 
-#![feature(const_fn, untagged_unions)]
+#![feature(const_fn)]
 #![no_std]
 
 pub mod map_cell;


### PR DESCRIPTION
### Pull Request Overview

This is the first PR towards making Tock (mostly) buildable with a stable Rust toolchain. This change is the low hanging fruit: all pragmas that can be removed without the build breaking and without any code changes. By my count, 24 pragmas were removed.

### Testing Strategy

`make allcheck` succeeds. Since all changes are removal of feature pragmas and no other code changes, this should be sufficient.

### TODO or Help Wanted

N/A

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
