### PR TITLE
chips/e310x: Fix spelling of suppress_all

### DIFF
--- a/chips/e310x/src/chip.rs
+++ b/chips/e310x/src/chip.rs
@@ -117,7 +117,7 @@ pub unsafe fn handle_trap() {
                         Some(ext_interrupt_id) => {
                             debug!("interrupt triggered {}\n", ext_interrupt_id);
                             plic::complete(ext_interrupt_id);
-                            plic::surpress_all();
+                            plic::suppress_all();
                         }
                     }
                 }

--- a/chips/e310x/src/plic.rs
+++ b/chips/e310x/src/plic.rs
@@ -94,7 +94,7 @@ pub unsafe fn has_pending() -> bool {
 
 /// This is a generic implementation. There may be board specific versions as
 /// some platforms have added more bits to the `mtvec` register.
-pub unsafe fn surpress_all() {
+pub unsafe fn suppress_all() {
     let plic: &PlicRegisters = &*PLIC_BASE;
     // Accept all interrupts.
     plic.threshold.write(priority::Priority.val(0));


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes the spelling of `suppress_all`.

### Testing Strategy

This pull request was tested by running `make allcheck`.

### TODO or Help Wanted

None.

### Documentation Updated

No updates are required.

### Formatting

- [X] Ran `make formatall`.
