### PR TITLE
rust: remove all uses of unstable pragma "in_band_lifetimes"

### DIFF
--- a/arch/rv32i/src/lib.rs
+++ b/arch/rv32i/src/lib.rs
@@ -2,14 +2,7 @@
 
 #![crate_name = "rv32i"]
 #![crate_type = "rlib"]
-#![feature(
-    asm,
-    const_fn,
-    lang_items,
-    global_asm,
-    naked_functions,
-    in_band_lifetimes
-)]
+#![feature(asm, const_fn, lang_items, global_asm, naked_functions)]
 #![no_std]
 
 use core::fmt::Write;

--- a/arch/rv32i/src/machine_timer.rs
+++ b/arch/rv32i/src/machine_timer.rs
@@ -28,8 +28,8 @@ pub struct MachineTimer<'a> {
     client: OptionalCell<&'a dyn hil::time::AlarmClient>,
 }
 
-impl MachineTimer<'a> {
-    pub const fn new(base: StaticRef<MachineTimerRegisters>) -> MachineTimer<'a> {
+impl MachineTimer<'_> {
+    pub const fn new(base: StaticRef<MachineTimerRegisters>) -> Self {
         MachineTimer {
             registers: base,
             client: OptionalCell::empty(),
@@ -53,7 +53,7 @@ impl MachineTimer<'a> {
     }
 }
 
-impl hil::time::Time for MachineTimer<'a> {
+impl hil::time::Time for MachineTimer<'_> {
     type Frequency = hil::time::Freq32KHz;
 
     fn now(&self) -> u32 {
@@ -65,7 +65,7 @@ impl hil::time::Time for MachineTimer<'a> {
     }
 }
 
-impl hil::time::Alarm<'a> for MachineTimer<'a> {
+impl<'a> hil::time::Alarm<'a> for MachineTimer<'a> {
     fn set_client(&self, client: &'a dyn hil::time::AlarmClient) {
         self.client.set(client);
     }

--- a/boards/arty_e21/src/main.rs
+++ b/boards/arty_e21/src/main.rs
@@ -4,7 +4,7 @@
 // Disable this attribute when documenting, as a workaround for
 // https://github.com/rust-lang/rust/issues/62184.
 #![cfg_attr(not(doc), no_main)]
-#![feature(const_fn, in_band_lifetimes)]
+#![feature(const_fn)]
 
 use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use kernel::capabilities;

--- a/boards/arty_e21/src/timer_test.rs
+++ b/boards/arty_e21/src/timer_test.rs
@@ -7,7 +7,7 @@ pub struct TimerTest<'a, A: Alarm<'a>> {
     alarm: &'a A,
 }
 
-impl<A: Alarm<'a>> TimerTest<'a, A> {
+impl<'a, A: Alarm<'a>> TimerTest<'a, A> {
     pub const fn new(alarm: &'a A) -> TimerTest<'a, A> {
         TimerTest { alarm: alarm }
     }
@@ -20,7 +20,7 @@ impl<A: Alarm<'a>> TimerTest<'a, A> {
     }
 }
 
-impl<A: Alarm<'a>> time::AlarmClient for TimerTest<'a, A> {
+impl<'a, A: Alarm<'a>> time::AlarmClient for TimerTest<'a, A> {
     fn fired(&self) {
         debug!("timer!!");
     }

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -7,7 +7,6 @@
 // Disable this attribute when documenting, as a workaround for
 // https://github.com/rust-lang/rust/issues/62184.
 #![cfg_attr(not(doc), no_main)]
-#![feature(in_band_lifetimes)]
 #![deny(missing_docs)]
 
 mod imix_components;

--- a/boards/imix/src/test/icmp_lowpan_test.rs
+++ b/boards/imix/src/test/icmp_lowpan_test.rs
@@ -170,7 +170,7 @@ impl<'a, A: time::Alarm<'a>> capsules::net::icmpv6::icmpv6_send::ICMP6SendClient
     }
 }
 
-impl<A: time::Alarm<'a>> LowpanICMPTest<'a, A> {
+impl<'a, A: time::Alarm<'a>> LowpanICMPTest<'a, A> {
     pub fn new(
         alarm: A,
         icmp_sender: &'a dyn ICMP6Sender<'a>,

--- a/capsules/src/adc.rs
+++ b/capsules/src/adc.rs
@@ -108,7 +108,7 @@ pub static mut ADC_BUFFER2: [u16; 128] = [0; 128];
 pub static mut ADC_BUFFER3: [u16; 128] = [0; 128];
 
 /// Functions to create, initialize, and interact with the ADC
-impl<A: hil::adc::Adc + hil::adc::AdcHighSpeed> Adc<'a, A> {
+impl<'a, A: hil::adc::Adc + hil::adc::AdcHighSpeed> Adc<'a, A> {
     /// Create a new `Adc` application interface.
     ///
     /// - `adc` - ADC driver to provide application access to
@@ -570,7 +570,7 @@ impl<A: hil::adc::Adc + hil::adc::AdcHighSpeed> Adc<'a, A> {
 }
 
 /// Callbacks from the ADC driver
-impl<A: hil::adc::Adc + hil::adc::AdcHighSpeed> hil::adc::Client for Adc<'a, A> {
+impl<A: hil::adc::Adc + hil::adc::AdcHighSpeed> hil::adc::Client for Adc<'_, A> {
     /// Single sample operation complete.
     ///
     /// Collects the sample and provides a callback to the application.
@@ -644,7 +644,7 @@ impl<A: hil::adc::Adc + hil::adc::AdcHighSpeed> hil::adc::Client for Adc<'a, A> 
 }
 
 /// Callbacks from the High Speed ADC driver
-impl<A: hil::adc::Adc + hil::adc::AdcHighSpeed> hil::adc::HighSpeedClient for Adc<'a, A> {
+impl<A: hil::adc::Adc + hil::adc::AdcHighSpeed> hil::adc::HighSpeedClient for Adc<'_, A> {
     /// Internal buffer has filled from a buffered sampling operation.
     /// Copies data over to application buffer, determines if more data is
     /// needed, and performs a callback to the application if ready. If
@@ -968,7 +968,7 @@ impl<A: hil::adc::Adc + hil::adc::AdcHighSpeed> hil::adc::HighSpeedClient for Ad
 }
 
 /// Implementations of application syscalls
-impl<A: hil::adc::Adc + hil::adc::AdcHighSpeed> Driver for Adc<'a, A> {
+impl<A: hil::adc::Adc + hil::adc::AdcHighSpeed> Driver for Adc<'_, A> {
     /// Provides access to a buffer from the application to store data in or
     /// read data from.
     ///

--- a/capsules/src/aes_ccm.rs
+++ b/capsules/src/aes_ccm.rs
@@ -86,7 +86,7 @@ pub struct AES128CCM<'a, A: AES128<'a> + AES128Ctr + AES128CBC> {
     saved_tag: Cell<[u8; AES128_BLOCK_SIZE]>,
 }
 
-impl<A: AES128<'a> + AES128Ctr + AES128CBC> AES128CCM<'a, A> {
+impl<'a, A: AES128<'a> + AES128Ctr + AES128CBC> AES128CCM<'a, A> {
     pub fn new(aes: &'a A, crypt_buf: &'static mut [u8]) -> AES128CCM<'a, A> {
         AES128CCM {
             aes: aes,
@@ -414,7 +414,7 @@ impl<A: AES128<'a> + AES128Ctr + AES128CBC> AES128CCM<'a, A> {
     }
 }
 
-impl<A: AES128<'a> + AES128Ctr + AES128CBC> symmetric_encryption::AES128CCM<'a>
+impl<'a, A: AES128<'a> + AES128Ctr + AES128CBC> symmetric_encryption::AES128CCM<'a>
     for AES128CCM<'a, A>
 {
     fn set_client(&self, client: &'a dyn symmetric_encryption::CCMClient) {
@@ -492,7 +492,9 @@ impl<A: AES128<'a> + AES128Ctr + AES128CBC> symmetric_encryption::AES128CCM<'a>
     }
 }
 
-impl<A: AES128<'a> + AES128Ctr + AES128CBC> symmetric_encryption::Client<'a> for AES128CCM<'a, A> {
+impl<'a, A: AES128<'a> + AES128Ctr + AES128CBC> symmetric_encryption::Client<'a>
+    for AES128CCM<'a, A>
+{
     fn crypt_done(&self, _: Option<&'a mut [u8]>, crypt_buf: &'a mut [u8]) {
         self.crypt_buf.replace(crypt_buf);
         match self.state.get() {

--- a/capsules/src/alarm.rs
+++ b/capsules/src/alarm.rs
@@ -41,7 +41,7 @@ pub struct AlarmDriver<'a, A: Alarm<'a>> {
     prev: Cell<u32>,
 }
 
-impl<A: Alarm<'a>> AlarmDriver<'a, A> {
+impl<'a, A: Alarm<'a>> AlarmDriver<'a, A> {
     pub const fn new(alarm: &'a A, grant: Grant<AlarmData>) -> AlarmDriver<'a, A> {
         AlarmDriver {
             alarm: alarm,
@@ -76,7 +76,7 @@ impl<A: Alarm<'a>> AlarmDriver<'a, A> {
     }
 }
 
-impl<A: Alarm<'a>> Driver for AlarmDriver<'a, A> {
+impl<'a, A: Alarm<'a>> Driver for AlarmDriver<'a, A> {
     /// Subscribe to alarm expiration
     ///
     /// ### `_subscribe_num`
@@ -180,7 +180,7 @@ fn has_expired(alarm: u32, now: u32, prev: u32) -> bool {
     now.wrapping_sub(prev) >= alarm.wrapping_sub(prev)
 }
 
-impl<A: Alarm<'a>> time::AlarmClient for AlarmDriver<'a, A> {
+impl<'a, A: Alarm<'a>> time::AlarmClient for AlarmDriver<'a, A> {
     fn fired(&self) {
         let now = self.alarm.now();
         self.app_alarm.each(|alarm| {

--- a/capsules/src/ambient_light.rs
+++ b/capsules/src/ambient_light.rs
@@ -31,7 +31,7 @@ pub struct AmbientLight<'a> {
     apps: Grant<App>,
 }
 
-impl AmbientLight<'a> {
+impl<'a> AmbientLight<'a> {
     pub fn new(sensor: &'a dyn hil::sensors::AmbientLight, grant: Grant<App>) -> AmbientLight {
         AmbientLight {
             sensor: sensor,
@@ -58,7 +58,7 @@ impl AmbientLight<'a> {
     }
 }
 
-impl Driver for AmbientLight<'a> {
+impl Driver for AmbientLight<'_> {
     /// Subscribe to light intensity readings
     ///
     /// ### `subscribe`
@@ -94,7 +94,7 @@ impl Driver for AmbientLight<'a> {
     ///
     /// - `0`: Check driver presence
     /// - `1`: Start a light sensor reading
-    fn command(&self, command_num: usize, _arg1: usize, _: usize, appid: AppId) -> ReturnCode {
+    fn command(&self, command_num: usize, _: usize, _: usize, appid: AppId) -> ReturnCode {
         match command_num {
             0 /* check if present */ => ReturnCode::SUCCESS,
             1 => {
@@ -106,7 +106,7 @@ impl Driver for AmbientLight<'a> {
     }
 }
 
-impl hil::sensors::AmbientLightClient for AmbientLight<'a> {
+impl hil::sensors::AmbientLightClient for AmbientLight<'_> {
     fn callback(&self, lux: usize) {
         self.command_pending.set(false);
         self.apps.each(|app| {

--- a/capsules/src/analog_sensor.rs
+++ b/capsules/src/analog_sensor.rs
@@ -22,7 +22,7 @@ pub struct AnalogLightSensor<'a, A: hil::adc::Adc> {
     client: OptionalCell<&'a dyn hil::sensors::AmbientLightClient>,
 }
 
-impl<A: hil::adc::Adc> AnalogLightSensor<'a, A> {
+impl<'a, A: hil::adc::Adc> AnalogLightSensor<'a, A> {
     pub fn new(
         adc: &'a A,
         channel: &'a <A as hil::adc::Adc>::Channel,
@@ -38,7 +38,7 @@ impl<A: hil::adc::Adc> AnalogLightSensor<'a, A> {
 }
 
 /// Callbacks from the ADC driver
-impl<A: hil::adc::Adc> hil::adc::Client for AnalogLightSensor<'a, A> {
+impl<A: hil::adc::Adc> hil::adc::Client for AnalogLightSensor<'_, A> {
     fn sample_ready(&self, sample: u16) {
         // TODO: calculate the actual light reading.
         let measurement: usize = match self.sensor_type {
@@ -51,7 +51,7 @@ impl<A: hil::adc::Adc> hil::adc::Client for AnalogLightSensor<'a, A> {
     }
 }
 
-impl<A: hil::adc::Adc> hil::sensors::AmbientLight for AnalogLightSensor<'a, A> {
+impl<A: hil::adc::Adc> hil::sensors::AmbientLight for AnalogLightSensor<'_, A> {
     fn set_client(&self, client: &'static dyn hil::sensors::AmbientLightClient) {
         self.client.set(client);
     }
@@ -74,7 +74,7 @@ pub struct AnalogTemperatureSensor<'a, A: hil::adc::Adc> {
     client: OptionalCell<&'a dyn hil::sensors::TemperatureClient>,
 }
 
-impl<A: hil::adc::Adc> AnalogTemperatureSensor<'a, A> {
+impl<'a, A: hil::adc::Adc> AnalogTemperatureSensor<'a, A> {
     pub fn new(
         adc: &'a A,
         channel: &'a <A as hil::adc::Adc>::Channel,
@@ -90,7 +90,7 @@ impl<A: hil::adc::Adc> AnalogTemperatureSensor<'a, A> {
 }
 
 /// Callbacks from the ADC driver
-impl<A: hil::adc::Adc> hil::adc::Client for AnalogTemperatureSensor<'a, A> {
+impl<A: hil::adc::Adc> hil::adc::Client for AnalogTemperatureSensor<'_, A> {
     fn sample_ready(&self, sample: u16) {
         // TODO: calculate the actual temperature reading.
         let measurement: usize = match self.sensor_type {
@@ -107,7 +107,7 @@ impl<A: hil::adc::Adc> hil::adc::Client for AnalogTemperatureSensor<'a, A> {
     }
 }
 
-impl<A: hil::adc::Adc> hil::sensors::TemperatureDriver for AnalogTemperatureSensor<'a, A> {
+impl<A: hil::adc::Adc> hil::sensors::TemperatureDriver for AnalogTemperatureSensor<'_, A> {
     fn set_client(&self, client: &'static dyn hil::sensors::TemperatureClient) {
         self.client.set(client);
     }

--- a/capsules/src/app_flash_driver.rs
+++ b/capsules/src/app_flash_driver.rs
@@ -44,7 +44,7 @@ pub struct AppFlash<'a> {
     buffer: TakeCell<'static, [u8]>,
 }
 
-impl AppFlash<'a> {
+impl<'a> AppFlash<'a> {
     pub fn new(
         driver: &'a dyn hil::nonvolatile_storage::NonvolatileStorage<'static>,
         grant: Grant<App>,
@@ -106,7 +106,7 @@ impl AppFlash<'a> {
     }
 }
 
-impl hil::nonvolatile_storage::NonvolatileStorageClient<'static> for AppFlash<'a> {
+impl hil::nonvolatile_storage::NonvolatileStorageClient<'static> for AppFlash<'_> {
     fn read_done(&self, _buffer: &'static mut [u8], _length: usize) {}
 
     fn write_done(&self, buffer: &'static mut [u8], _length: usize) {
@@ -158,7 +158,7 @@ impl hil::nonvolatile_storage::NonvolatileStorageClient<'static> for AppFlash<'a
     }
 }
 
-impl Driver for AppFlash<'a> {
+impl Driver for AppFlash<'_> {
     /// Setup buffer to write from.
     ///
     /// ### `allow_num`

--- a/capsules/src/ble_advertising_driver.rs
+++ b/capsules/src/ble_advertising_driver.rs
@@ -307,7 +307,7 @@ where
     receiving_app: OptionalCell<kernel::AppId>,
 }
 
-impl<B, A> BLE<'a, B, A>
+impl<'a, B, A> BLE<'a, B, A>
 where
     B: ble_advertising::BleAdvertisementDriver + ble_advertising::BleConfig,
     A: kernel::hil::time::Alarm<'a>,
@@ -359,7 +359,7 @@ where
 }
 
 // Timer alarm
-impl<B, A> kernel::hil::time::AlarmClient for BLE<'a, B, A>
+impl<'a, B, A> kernel::hil::time::AlarmClient for BLE<'a, B, A>
 where
     B: ble_advertising::BleAdvertisementDriver + ble_advertising::BleConfig,
     A: kernel::hil::time::Alarm<'a>,
@@ -428,7 +428,7 @@ where
 }
 
 // Callback from the radio once a RX event occur
-impl<B, A> ble_advertising::RxClient for BLE<'a, B, A>
+impl<'a, B, A> ble_advertising::RxClient for BLE<'a, B, A>
 where
     B: ble_advertising::BleAdvertisementDriver + ble_advertising::BleConfig,
     A: kernel::hil::time::Alarm<'a>,
@@ -495,7 +495,7 @@ where
 }
 
 // Callback from the radio once a TX event occur
-impl<B, A> ble_advertising::TxClient for BLE<'a, B, A>
+impl<'a, B, A> ble_advertising::TxClient for BLE<'a, B, A>
 where
     B: ble_advertising::BleAdvertisementDriver + ble_advertising::BleConfig,
     A: kernel::hil::time::Alarm<'a>,
@@ -536,7 +536,7 @@ where
 }
 
 // System Call implementation
-impl<B, A> kernel::Driver for BLE<'a, B, A>
+impl<'a, B, A> kernel::Driver for BLE<'a, B, A>
 where
     B: ble_advertising::BleAdvertisementDriver + ble_advertising::BleConfig,
     A: kernel::hil::time::Alarm<'a>,

--- a/capsules/src/buzzer_driver.rs
+++ b/capsules/src/buzzer_driver.rs
@@ -77,7 +77,7 @@ pub struct Buzzer<'a, A: hil::time::Alarm<'a>> {
     max_duration_ms: usize,
 }
 
-impl<A: hil::time::Alarm<'a>> Buzzer<'a, A> {
+impl<'a, A: hil::time::Alarm<'a>> Buzzer<'a, A> {
     pub fn new(
         pwm_pin: &'a dyn hil::pwm::PwmPin,
         alarm: &'a A,
@@ -162,7 +162,7 @@ impl<A: hil::time::Alarm<'a>> Buzzer<'a, A> {
     }
 }
 
-impl<A: hil::time::Alarm<'a>> hil::time::AlarmClient for Buzzer<'a, A> {
+impl<'a, A: hil::time::Alarm<'a>> hil::time::AlarmClient for Buzzer<'a, A> {
     fn fired(&self) {
         // All we have to do is stop the PWM and check if there are any pending
         // uses of the buzzer.
@@ -180,7 +180,7 @@ impl<A: hil::time::Alarm<'a>> hil::time::AlarmClient for Buzzer<'a, A> {
 }
 
 /// Provide an interface for userland.
-impl<A: hil::time::Alarm<'a>> Driver for Buzzer<'a, A> {
+impl<'a, A: hil::time::Alarm<'a>> Driver for Buzzer<'a, A> {
     /// Setup callbacks.
     ///
     /// ### `subscribe_num`

--- a/capsules/src/console.rs
+++ b/capsules/src/console.rs
@@ -68,7 +68,7 @@ pub struct Console<'a> {
     rx_buffer: TakeCell<'static, [u8]>,
 }
 
-impl Console<'a> {
+impl<'a> Console<'a> {
     pub fn new(
         uart: &'a dyn uart::UartData<'a>,
         tx_buffer: &'static mut [u8],
@@ -181,7 +181,7 @@ impl Console<'a> {
     }
 }
 
-impl Driver for Console<'a> {
+impl Driver for Console<'_> {
     /// Setup shared buffers.
     ///
     /// ### `allow_num`
@@ -276,7 +276,7 @@ impl Driver for Console<'a> {
     }
 }
 
-impl uart::TransmitClient for Console<'a> {
+impl uart::TransmitClient for Console<'_> {
     fn transmitted_buffer(&self, buffer: &'static mut [u8], _tx_len: usize, _rcode: ReturnCode) {
         // Either print more from the AppSlice or send a callback to the
         // application.
@@ -341,7 +341,7 @@ impl uart::TransmitClient for Console<'a> {
     }
 }
 
-impl uart::ReceiveClient for Console<'a> {
+impl uart::ReceiveClient for Console<'_> {
     fn received_buffer(
         &self,
         buffer: &'static mut [u8],

--- a/capsules/src/crc.rs
+++ b/capsules/src/crc.rs
@@ -93,7 +93,7 @@ pub struct Crc<'a, C: hil::crc::CRC> {
     serving_app: OptionalCell<AppId>,
 }
 
-impl<C: hil::crc::CRC> Crc<'a, C> {
+impl<'a, C: hil::crc::CRC> Crc<'a, C> {
     /// Create a `Crc` driver
     ///
     /// The argument `crc_unit` must implement the abstract `CRC`
@@ -165,7 +165,7 @@ impl<C: hil::crc::CRC> Crc<'a, C> {
 /// the `subscribe` system call and `allow`s the driver access to the buffer over-which to compute.
 /// Then, it initiates a CRC computation using the `command` system call. See function-specific
 /// comments for details.
-impl<C: hil::crc::CRC> Driver for Crc<'a, C> {
+impl<C: hil::crc::CRC> Driver for Crc<'_, C> {
     /// The `allow` syscall for this driver supports the single
     /// `allow_num` zero, which is used to provide a buffer over which
     /// to compute a CRC computation.
@@ -322,7 +322,7 @@ impl<C: hil::crc::CRC> Driver for Crc<'a, C> {
     }
 }
 
-impl<C: hil::crc::CRC> hil::crc::Client for Crc<'a, C> {
+impl<C: hil::crc::CRC> hil::crc::Client for Crc<'_, C> {
     fn receive_result(&self, result: u32) {
         self.serving_app.take().map(|appid| {
             self.apps

--- a/capsules/src/dac.rs
+++ b/capsules/src/dac.rs
@@ -20,13 +20,13 @@ pub struct Dac<'a> {
     dac: &'a dyn hil::dac::DacChannel,
 }
 
-impl Dac<'a> {
+impl<'a> Dac<'a> {
     pub fn new(dac: &'a dyn hil::dac::DacChannel) -> Dac<'a> {
         Dac { dac: dac }
     }
 }
 
-impl Driver for Dac<'a> {
+impl Driver for Dac<'_> {
     /// Control the DAC.
     ///
     /// ### `command_num`

--- a/capsules/src/fm25cl.rs
+++ b/capsules/src/fm25cl.rs
@@ -99,7 +99,7 @@ pub struct FM25CL<'a, S: hil::spi::SpiMasterDevice> {
     client_write_len: Cell<u16>,
 }
 
-impl<S: hil::spi::SpiMasterDevice> FM25CL<'a, S> {
+impl<'a, S: hil::spi::SpiMasterDevice> FM25CL<'a, S> {
     pub fn new(
         spi: &'a S,
         txbuffer: &'static mut [u8],
@@ -179,7 +179,7 @@ impl<S: hil::spi::SpiMasterDevice> FM25CL<'a, S> {
     }
 }
 
-impl<S: hil::spi::SpiMasterDevice> hil::spi::SpiMasterClient for FM25CL<'a, S> {
+impl<S: hil::spi::SpiMasterDevice> hil::spi::SpiMasterClient for FM25CL<'_, S> {
     fn read_write_done(
         &self,
         write_buffer: &'static mut [u8],
@@ -265,7 +265,7 @@ impl<S: hil::spi::SpiMasterDevice> hil::spi::SpiMasterClient for FM25CL<'a, S> {
 }
 
 // Implement the custom interface that exposes chip-specific commands.
-impl<S: hil::spi::SpiMasterDevice> FM25CLCustom for FM25CL<'a, S> {
+impl<S: hil::spi::SpiMasterDevice> FM25CLCustom for FM25CL<'_, S> {
     fn read_status(&self) -> ReturnCode {
         self.configure_spi();
 
@@ -290,7 +290,7 @@ impl<S: hil::spi::SpiMasterDevice> FM25CLCustom for FM25CL<'a, S> {
 /// Implement the generic `NonvolatileStorage` interface common to chips that
 /// provide nonvolatile memory.
 impl<S: hil::spi::SpiMasterDevice> hil::nonvolatile_storage::NonvolatileStorage<'static>
-    for FM25CL<'a, S>
+    for FM25CL<'_, S>
 {
     fn set_client(&self, client: &'static dyn hil::nonvolatile_storage::NonvolatileStorageClient) {
         self.client.set(client);

--- a/capsules/src/fxos8700cq.rs
+++ b/capsules/src/fxos8700cq.rs
@@ -182,7 +182,7 @@ pub struct Fxos8700cq<'a> {
     callback: OptionalCell<&'static dyn hil::sensors::NineDofClient>,
 }
 
-impl Fxos8700cq<'a> {
+impl<'a> Fxos8700cq<'a> {
     pub fn new(
         i2c: &'a dyn I2CDevice,
         interrupt_pin1: &'a dyn gpio::InterruptPin,
@@ -224,7 +224,7 @@ impl Fxos8700cq<'a> {
     }
 }
 
-impl gpio::Client for Fxos8700cq<'a> {
+impl gpio::Client for Fxos8700cq<'_> {
     fn fired(&self) {
         self.buffer.take().map(|buffer| {
             self.interrupt_pin1.disable_interrupts();
@@ -238,7 +238,7 @@ impl gpio::Client for Fxos8700cq<'a> {
     }
 }
 
-impl I2CClient for Fxos8700cq<'a> {
+impl I2CClient for Fxos8700cq<'_> {
     fn command_complete(&self, buffer: &'static mut [u8], _error: Error) {
         match self.state.get() {
             State::ReadAccelSetup => {
@@ -315,7 +315,7 @@ impl I2CClient for Fxos8700cq<'a> {
     }
 }
 
-impl hil::sensors::NineDof for Fxos8700cq<'a> {
+impl hil::sensors::NineDof for Fxos8700cq<'_> {
     fn set_client(&self, client: &'static dyn hil::sensors::NineDofClient) {
         self.callback.set(client);
     }

--- a/capsules/src/gpio_async.rs
+++ b/capsules/src/gpio_async.rs
@@ -38,7 +38,7 @@ pub struct GPIOAsync<'a, Port: hil::gpio_async::Port> {
     interrupt_callback: OptionalCell<Callback>,
 }
 
-impl<Port: hil::gpio_async::Port> GPIOAsync<'a, Port> {
+impl<'a, Port: hil::gpio_async::Port> GPIOAsync<'a, Port> {
     pub fn new(ports: &'a [&'a Port]) -> GPIOAsync<'a, Port> {
         GPIOAsync {
             ports: ports,
@@ -70,7 +70,7 @@ impl<Port: hil::gpio_async::Port> GPIOAsync<'a, Port> {
     }
 }
 
-impl<Port: hil::gpio_async::Port> hil::gpio_async::Client for GPIOAsync<'a, Port> {
+impl<Port: hil::gpio_async::Port> hil::gpio_async::Client for GPIOAsync<'_, Port> {
     fn fired(&self, pin: usize, identifier: usize) {
         self.interrupt_callback
             .map(|cb| cb.schedule(identifier, pin, 0));
@@ -81,7 +81,7 @@ impl<Port: hil::gpio_async::Port> hil::gpio_async::Client for GPIOAsync<'a, Port
     }
 }
 
-impl<Port: hil::gpio_async::Port> Driver for GPIOAsync<'a, Port> {
+impl<Port: hil::gpio_async::Port> Driver for GPIOAsync<'_, Port> {
     /// Setup callbacks for gpio_async events.
     ///
     /// ### `subscribe_num`

--- a/capsules/src/hmac.rs
+++ b/capsules/src/hmac.rs
@@ -50,7 +50,7 @@ pub struct HmacDriver<'a, H: digest::Digest<'a, T>, T: 'static + DigestType> {
     dest_buffer: TakeCell<'static, T>,
 }
 
-impl<H: digest::Digest<'a, T> + digest::HMACSha256, T: DigestType> HmacDriver<'a, H, T>
+impl<'a, H: digest::Digest<'a, T> + digest::HMACSha256, T: DigestType> HmacDriver<'a, H, T>
 where
     T: AsMut<[u8]>,
 {
@@ -147,7 +147,7 @@ where
     }
 }
 
-impl<H: digest::Digest<'a, T> + digest::HMACSha256, T: DigestType> digest::Client<'a, T>
+impl<'a, H: digest::Digest<'a, T> + digest::HMACSha256, T: DigestType> digest::Client<'a, T>
     for HmacDriver<'a, H, T>
 {
     fn add_data_done(&'a self, _result: Result<(), ReturnCode>, data: &'static mut [u8]) {
@@ -297,7 +297,9 @@ impl<H: digest::Digest<'a, T> + digest::HMACSha256, T: DigestType> digest::Clien
 /// - `2`: Allow a buffer for storing the digest.
 ///        The kernel will fill this with the HMAC digest before calling
 ///        the `hash_done` callback.
-impl<H: digest::Digest<'a, T> + digest::HMACSha256, T: DigestType> Driver for HmacDriver<'a, H, T> {
+impl<'a, H: digest::Digest<'a, T> + digest::HMACSha256, T: DigestType> Driver
+    for HmacDriver<'a, H, T>
+{
     fn allow(
         &self,
         appid: AppId,

--- a/capsules/src/humidity.rs
+++ b/capsules/src/humidity.rs
@@ -73,7 +73,7 @@ pub struct HumiditySensor<'a> {
     busy: Cell<bool>,
 }
 
-impl HumiditySensor<'a> {
+impl<'a> HumiditySensor<'a> {
     pub fn new(
         driver: &'a dyn hil::sensors::HumidityDriver,
         grant: Grant<App>,
@@ -116,7 +116,7 @@ impl HumiditySensor<'a> {
     }
 }
 
-impl hil::sensors::HumidityClient for HumiditySensor<'a> {
+impl hil::sensors::HumidityClient for HumiditySensor<'_> {
     fn callback(&self, tmp_val: usize) {
         for cntr in self.apps.iter() {
             cntr.enter(|app, _| {
@@ -130,7 +130,7 @@ impl hil::sensors::HumidityClient for HumiditySensor<'a> {
     }
 }
 
-impl Driver for HumiditySensor<'a> {
+impl Driver for HumiditySensor<'_> {
     fn subscribe(
         &self,
         subscribe_num: usize,

--- a/capsules/src/i2c_master_slave_driver.rs
+++ b/capsules/src/i2c_master_slave_driver.rs
@@ -52,7 +52,7 @@ pub struct I2CMasterSlaveDriver<'a> {
     app: MapCell<App>,
 }
 
-impl I2CMasterSlaveDriver<'a> {
+impl<'a> I2CMasterSlaveDriver<'a> {
     pub fn new(
         i2c: &'a dyn hil::i2c::I2CMasterSlave,
         master_buffer: &'static mut [u8],
@@ -71,7 +71,7 @@ impl I2CMasterSlaveDriver<'a> {
     }
 }
 
-impl hil::i2c::I2CHwMasterClient for I2CMasterSlaveDriver<'a> {
+impl hil::i2c::I2CHwMasterClient for I2CMasterSlaveDriver<'_> {
     fn command_complete(&self, buffer: &'static mut [u8], error: hil::i2c::Error) {
         // Map I2C error to a number we can pass back to the application
         let err: isize = match error {
@@ -137,7 +137,7 @@ impl hil::i2c::I2CHwMasterClient for I2CMasterSlaveDriver<'a> {
     }
 }
 
-impl hil::i2c::I2CHwSlaveClient for I2CMasterSlaveDriver<'a> {
+impl hil::i2c::I2CHwSlaveClient for I2CMasterSlaveDriver<'_> {
     fn command_complete(
         &self,
         buffer: &'static mut [u8],
@@ -209,7 +209,7 @@ impl hil::i2c::I2CHwSlaveClient for I2CMasterSlaveDriver<'a> {
     }
 }
 
-impl Driver for I2CMasterSlaveDriver<'a> {
+impl Driver for I2CMasterSlaveDriver<'_> {
     fn allow(
         &self,
         _appid: AppId,

--- a/capsules/src/ieee802154/driver.rs
+++ b/capsules/src/ieee802154/driver.rs
@@ -98,8 +98,8 @@ fn decode_key_id(buf: &[u8]) -> SResult<KeyId> {
     }
 }
 
-impl From<&'a KeyId> for KeyIdModeUserland {
-    fn from(key_id: &'a KeyId) -> Self {
+impl From<&KeyId> for KeyIdModeUserland {
+    fn from(key_id: &KeyId) -> Self {
         match *key_id {
             KeyId::Implicit => KeyIdModeUserland::Implicit,
             KeyId::Index(_) => KeyIdModeUserland::Index,
@@ -191,7 +191,7 @@ pub struct RadioDriver<'a> {
     kernel_tx: TakeCell<'static, [u8]>,
 }
 
-impl RadioDriver<'a> {
+impl<'a> RadioDriver<'a> {
     pub fn new(
         mac: &'a dyn device::MacDevice<'a>,
         grant: Grant<App>,
@@ -493,7 +493,7 @@ impl RadioDriver<'a> {
     }
 }
 
-impl framer::DeviceProcedure for RadioDriver<'a> {
+impl framer::DeviceProcedure for RadioDriver<'_> {
     /// Gets the long address corresponding to the neighbor that matches the given
     /// MAC address. If no such neighbor exists, returns `None`.
     fn lookup_addr_long(&self, addr: MacAddress) -> Option<[u8; 8]> {
@@ -509,7 +509,7 @@ impl framer::DeviceProcedure for RadioDriver<'a> {
     }
 }
 
-impl framer::KeyProcedure for RadioDriver<'a> {
+impl framer::KeyProcedure for RadioDriver<'_> {
     /// Gets the key corresponding to the key that matches the given security
     /// level `level` and key ID `key_id`. If no such key matches, returns
     /// `None`.
@@ -523,7 +523,7 @@ impl framer::KeyProcedure for RadioDriver<'a> {
     }
 }
 
-impl Driver for RadioDriver<'a> {
+impl Driver for RadioDriver<'_> {
     /// Setup buffers to read/write from.
     ///
     /// ### `allow_num`
@@ -797,7 +797,7 @@ impl Driver for RadioDriver<'a> {
     }
 }
 
-impl device::TxClient for RadioDriver<'a> {
+impl device::TxClient for RadioDriver<'_> {
     fn send_done(&self, spi_buf: &'static mut [u8], acked: bool, result: ReturnCode) {
         self.kernel_tx.replace(spi_buf);
         self.current_app.take().map(|appid| {
@@ -827,7 +827,7 @@ fn encode_address(addr: &Option<MacAddress>) -> usize {
     ((AddressMode::from(addr) as usize) << 16) | short_addr_only
 }
 
-impl device::RxClient for RadioDriver<'a> {
+impl device::RxClient for RadioDriver<'_> {
     fn receive<'b>(&self, buf: &'b [u8], header: Header<'b>, data_offset: usize, data_len: usize) {
         self.apps.each(|app| {
             app.app_read.take().as_mut().map(|rbuf| {

--- a/capsules/src/ieee802154/framer.rs
+++ b/capsules/src/ieee802154/framer.rs
@@ -314,7 +314,7 @@ pub struct Framer<'a, M: Mac, A: AES128CCM<'a>> {
     rx_client: OptionalCell<&'a dyn RxClient>,
 }
 
-impl<M: Mac, A: AES128CCM<'a>> Framer<'a, M, A> {
+impl<'a, M: Mac, A: AES128CCM<'a>> Framer<'a, M, A> {
     pub fn new(mac: &'a M, aes_ccm: &'a A) -> Framer<'a, M, A> {
         Framer {
             mac: mac,
@@ -645,7 +645,7 @@ impl<M: Mac, A: AES128CCM<'a>> Framer<'a, M, A> {
     }
 }
 
-impl<M: Mac, A: AES128CCM<'a>> MacDevice<'a> for Framer<'a, M, A> {
+impl<'a, M: Mac, A: AES128CCM<'a>> MacDevice<'a> for Framer<'a, M, A> {
     fn set_transmit_client(&self, client: &'a dyn TxClient) {
         self.tx_client.set(client);
     }
@@ -785,7 +785,7 @@ impl<M: Mac, A: AES128CCM<'a>> MacDevice<'a> for Framer<'a, M, A> {
     }
 }
 
-impl<M: Mac, A: AES128CCM<'a>> radio::TxClient for Framer<'a, M, A> {
+impl<'a, M: Mac, A: AES128CCM<'a>> radio::TxClient for Framer<'a, M, A> {
     fn send_done(&self, buf: &'static mut [u8], acked: bool, result: ReturnCode) {
         self.data_sequence.set(self.data_sequence.get() + 1);
         self.tx_client.map(move |client| {
@@ -794,7 +794,7 @@ impl<M: Mac, A: AES128CCM<'a>> radio::TxClient for Framer<'a, M, A> {
     }
 }
 
-impl<M: Mac, A: AES128CCM<'a>> radio::RxClient for Framer<'a, M, A> {
+impl<'a, M: Mac, A: AES128CCM<'a>> radio::RxClient for Framer<'a, M, A> {
     fn receive(&self, buf: &'static mut [u8], frame_len: usize, crc_valid: bool, _: ReturnCode) {
         // Drop all frames with invalid CRC
         if !crc_valid {
@@ -824,7 +824,7 @@ impl<M: Mac, A: AES128CCM<'a>> radio::RxClient for Framer<'a, M, A> {
     }
 }
 
-impl<M: Mac, A: AES128CCM<'a>> radio::ConfigClient for Framer<'a, M, A> {
+impl<'a, M: Mac, A: AES128CCM<'a>> radio::ConfigClient for Framer<'a, M, A> {
     fn config_done(&self, _: ReturnCode) {
         // The transmission pipeline is the only state machine that
         // waits for the configuration procedure to complete before
@@ -839,7 +839,7 @@ impl<M: Mac, A: AES128CCM<'a>> radio::ConfigClient for Framer<'a, M, A> {
     }
 }
 
-impl<M: Mac, A: AES128CCM<'a>> CCMClient for Framer<'a, M, A> {
+impl<'a, M: Mac, A: AES128CCM<'a>> CCMClient for Framer<'a, M, A> {
     fn crypt_done(&self, buf: &'static mut [u8], res: ReturnCode, tag_is_valid: bool) {
         let mut tx_waiting = false;
         let mut rx_waiting = false;

--- a/capsules/src/ieee802154/mac.rs
+++ b/capsules/src/ieee802154/mac.rs
@@ -74,7 +74,7 @@ pub struct AwakeMac<'a, R: radio::Radio> {
     rx_client: OptionalCell<&'static dyn radio::RxClient>,
 }
 
-impl<R: radio::Radio> AwakeMac<'a, R> {
+impl<'a, R: radio::Radio> AwakeMac<'a, R> {
     pub fn new(radio: &'a R) -> AwakeMac<'a, R> {
         AwakeMac {
             radio: radio,
@@ -84,7 +84,7 @@ impl<R: radio::Radio> AwakeMac<'a, R> {
     }
 }
 
-impl<R: radio::Radio> Mac for AwakeMac<'a, R> {
+impl<R: radio::Radio> Mac for AwakeMac<'_, R> {
     fn initialize(&self, _mac_buf: &'static mut [u8]) -> ReturnCode {
         // do nothing, extra buffer unnecessary
         ReturnCode::SUCCESS
@@ -147,7 +147,7 @@ impl<R: radio::Radio> Mac for AwakeMac<'a, R> {
     }
 }
 
-impl<R: radio::Radio> radio::TxClient for AwakeMac<'a, R> {
+impl<R: radio::Radio> radio::TxClient for AwakeMac<'_, R> {
     fn send_done(&self, buf: &'static mut [u8], acked: bool, result: ReturnCode) {
         self.tx_client.map(move |c| {
             c.send_done(buf, acked, result);
@@ -155,7 +155,7 @@ impl<R: radio::Radio> radio::TxClient for AwakeMac<'a, R> {
     }
 }
 
-impl<R: radio::Radio> radio::RxClient for AwakeMac<'a, R> {
+impl<R: radio::Radio> radio::RxClient for AwakeMac<'_, R> {
     fn receive(
         &self,
         buf: &'static mut [u8],

--- a/capsules/src/ieee802154/virtual_mac.rs
+++ b/capsules/src/ieee802154/virtual_mac.rs
@@ -42,7 +42,7 @@ pub struct MuxMac<'a> {
     inflight: OptionalCell<&'a MacUser<'a>>,
 }
 
-impl device::TxClient for MuxMac<'a> {
+impl device::TxClient for MuxMac<'_> {
     fn send_done(&self, spi_buf: &'static mut [u8], acked: bool, result: ReturnCode) {
         self.inflight.take().map(move |user| {
             user.send_done(spi_buf, acked, result);
@@ -51,7 +51,7 @@ impl device::TxClient for MuxMac<'a> {
     }
 }
 
-impl device::RxClient for MuxMac<'a> {
+impl device::RxClient for MuxMac<'_> {
     fn receive<'b>(&self, buf: &'b [u8], header: Header<'b>, data_offset: usize, data_len: usize) {
         for user in self.users.iter() {
             user.receive(buf, header, data_offset, data_len);
@@ -59,7 +59,7 @@ impl device::RxClient for MuxMac<'a> {
     }
 }
 
-impl MuxMac<'a> {
+impl<'a> MuxMac<'a> {
     pub const fn new(mac: &'a dyn device::MacDevice<'a>) -> MuxMac<'a> {
         MuxMac {
             mac: mac,
@@ -193,7 +193,7 @@ pub struct MacUser<'a> {
     rx_client: Cell<Option<&'a dyn device::RxClient>>,
 }
 
-impl MacUser<'a> {
+impl<'a> MacUser<'a> {
     pub const fn new(mux: &'a MuxMac<'a>) -> MacUser<'a> {
         MacUser {
             mux: mux,
@@ -205,7 +205,7 @@ impl MacUser<'a> {
     }
 }
 
-impl MacUser<'a> {
+impl MacUser<'_> {
     fn send_done(&self, spi_buf: &'static mut [u8], acked: bool, result: ReturnCode) {
         self.tx_client
             .get()
@@ -219,13 +219,13 @@ impl MacUser<'a> {
     }
 }
 
-impl ListNode<'a, MacUser<'a>> for MacUser<'a> {
+impl<'a> ListNode<'a, MacUser<'a>> for MacUser<'a> {
     fn next(&'a self) -> &'a ListLink<'a, MacUser<'a>> {
         &self.next
     }
 }
 
-impl device::MacDevice<'a> for MacUser<'a> {
+impl<'a> device::MacDevice<'a> for MacUser<'a> {
     fn set_transmit_client(&self, client: &'a dyn device::TxClient) {
         self.tx_client.set(Some(client));
     }

--- a/capsules/src/ieee802154/xmac.rs
+++ b/capsules/src/ieee802154/xmac.rs
@@ -162,7 +162,7 @@ pub struct XMac<'a, R: radio::Radio, A: Alarm<'a>> {
     rx_pending: Cell<bool>,
 }
 
-impl<R: radio::Radio, A: Alarm<'a>> XMac<'a, R, A> {
+impl<'a, R: radio::Radio, A: Alarm<'a>> XMac<'a, R, A> {
     pub fn new(radio: &'a R, alarm: &'a A, rng: &'a dyn Rng<'a>) -> XMac<'a, R, A> {
         XMac {
             radio: radio,
@@ -308,7 +308,7 @@ impl<R: radio::Radio, A: Alarm<'a>> XMac<'a, R, A> {
     }
 }
 
-impl<R: radio::Radio, A: Alarm<'a>> rng::Client for XMac<'a, R, A> {
+impl<'a, R: radio::Radio, A: Alarm<'a>> rng::Client for XMac<'a, R, A> {
     fn randomness_available(
         &self,
         randomness: &mut dyn Iterator<Item = u32>,
@@ -339,7 +339,7 @@ impl<R: radio::Radio, A: Alarm<'a>> rng::Client for XMac<'a, R, A> {
 }
 
 // The vast majority of these calls pass through to the underlying radio driver.
-impl<R: radio::Radio, A: Alarm<'a>> Mac for XMac<'a, R, A> {
+impl<'a, R: radio::Radio, A: Alarm<'a>> Mac for XMac<'a, R, A> {
     fn initialize(&self, mac_buf: &'static mut [u8]) -> ReturnCode {
         self.tx_preamble_buf.replace(mac_buf);
         self.state.set(XMacState::STARTUP);
@@ -460,7 +460,7 @@ impl<R: radio::Radio, A: Alarm<'a>> Mac for XMac<'a, R, A> {
 
 // Core of the XMAC protocol - when the timer fires, the protocol state
 // indicates the next state/action to take.
-impl<R: radio::Radio, A: Alarm<'a>> time::AlarmClient for XMac<'a, R, A> {
+impl<'a, R: radio::Radio, A: Alarm<'a>> time::AlarmClient for XMac<'a, R, A> {
     fn fired(&self) {
         match self.state.get() {
             XMacState::SLEEP => {
@@ -500,7 +500,7 @@ impl<R: radio::Radio, A: Alarm<'a>> time::AlarmClient for XMac<'a, R, A> {
     }
 }
 
-impl<R: radio::Radio, A: Alarm<'a>> radio::PowerClient for XMac<'a, R, A> {
+impl<'a, R: radio::Radio, A: Alarm<'a>> radio::PowerClient for XMac<'a, R, A> {
     fn changed(&self, on: bool) {
         // If the radio turns on and we're in STARTUP, then either transition to
         // listening for incoming preambles or start transmitting preambles if
@@ -521,7 +521,7 @@ impl<R: radio::Radio, A: Alarm<'a>> radio::PowerClient for XMac<'a, R, A> {
     }
 }
 
-impl<R: radio::Radio, A: Alarm<'a>> radio::TxClient for XMac<'a, R, A> {
+impl<'a, R: radio::Radio, A: Alarm<'a>> radio::TxClient for XMac<'a, R, A> {
     fn send_done(&self, buf: &'static mut [u8], acked: bool, result: ReturnCode) {
         match self.state.get() {
             // Completed a data transmission to the destination node
@@ -555,7 +555,7 @@ impl<R: radio::Radio, A: Alarm<'a>> radio::TxClient for XMac<'a, R, A> {
 // destination node is receiving packets/awake while we are attempting a
 // transmission, we put the radio in promiscuous mode. Not a huge issue, but
 // we need to be wary of incoming packets not actually addressed to our node.
-impl<R: radio::Radio, A: Alarm<'a>> radio::RxClient for XMac<'a, R, A> {
+impl<'a, R: radio::Radio, A: Alarm<'a>> radio::RxClient for XMac<'a, R, A> {
     fn receive(
         &self,
         buf: &'static mut [u8],

--- a/capsules/src/isl29035.rs
+++ b/capsules/src/isl29035.rs
@@ -51,7 +51,7 @@ pub struct Isl29035<'a, A: time::Alarm<'a>> {
     client: OptionalCell<&'a dyn AmbientLightClient>,
 }
 
-impl<A: time::Alarm<'a>> Isl29035<'a, A> {
+impl<'a, A: time::Alarm<'a>> Isl29035<'a, A> {
     pub fn new(i2c: &'a dyn I2CDevice, alarm: &'a A, buffer: &'static mut [u8]) -> Isl29035<'a, A> {
         Isl29035 {
             i2c: i2c,
@@ -86,7 +86,7 @@ impl<A: time::Alarm<'a>> Isl29035<'a, A> {
     }
 }
 
-impl<A: time::Alarm<'a>> AmbientLight for Isl29035<'a, A> {
+impl<'a, A: time::Alarm<'a>> AmbientLight for Isl29035<'a, A> {
     fn set_client(&self, client: &'static dyn AmbientLightClient) {
         self.client.set(client);
     }
@@ -97,7 +97,7 @@ impl<A: time::Alarm<'a>> AmbientLight for Isl29035<'a, A> {
     }
 }
 
-impl<A: time::Alarm<'a>> time::AlarmClient for Isl29035<'a, A> {
+impl<'a, A: time::Alarm<'a>> time::AlarmClient for Isl29035<'a, A> {
     fn fired(&self) {
         self.buffer.take().map(|buffer| {
             // Turn on i2c to send commands.
@@ -110,7 +110,7 @@ impl<A: time::Alarm<'a>> time::AlarmClient for Isl29035<'a, A> {
     }
 }
 
-impl<A: time::Alarm<'a>> I2CClient for Isl29035<'a, A> {
+impl<'a, A: time::Alarm<'a>> I2CClient for Isl29035<'a, A> {
     fn command_complete(&self, buffer: &'static mut [u8], _error: Error) {
         // TODO(alevy): handle I2C errors
         match self.state.get() {

--- a/capsules/src/l3gd20.rs
+++ b/capsules/src/l3gd20.rs
@@ -189,7 +189,7 @@ pub struct L3gd20Spi<'a> {
     temperature_client: OptionalCell<&'a dyn sensors::TemperatureClient>,
 }
 
-impl L3gd20Spi<'a> {
+impl<'a> L3gd20Spi<'a> {
     pub fn new(
         spi: &'a dyn spi::SpiMasterDevice,
         txbuffer: &'static mut [u8; L3GD20_TX_SIZE],
@@ -293,7 +293,7 @@ impl L3gd20Spi<'a> {
     }
 }
 
-impl Driver for L3gd20Spi<'a> {
+impl Driver for L3gd20Spi<'_> {
     fn command(&self, command_num: usize, data1: usize, data2: usize, _: AppId) -> ReturnCode {
         match command_num {
             0 => ReturnCode::SUCCESS,
@@ -386,7 +386,7 @@ impl Driver for L3gd20Spi<'a> {
     }
 }
 
-impl spi::SpiMasterClient for L3gd20Spi<'a> {
+impl spi::SpiMasterClient for L3gd20Spi<'_> {
     fn read_write_done(
         &self,
         write_buffer: &'static mut [u8],
@@ -505,7 +505,7 @@ impl spi::SpiMasterClient for L3gd20Spi<'a> {
     }
 }
 
-impl sensors::NineDof for L3gd20Spi<'a> {
+impl<'a> sensors::NineDof for L3gd20Spi<'a> {
     fn set_client(&self, nine_dof_client: &'a dyn sensors::NineDofClient) {
         self.nine_dof_client.replace(nine_dof_client);
     }
@@ -520,7 +520,7 @@ impl sensors::NineDof for L3gd20Spi<'a> {
     }
 }
 
-impl sensors::TemperatureDriver for L3gd20Spi<'a> {
+impl<'a> sensors::TemperatureDriver for L3gd20Spi<'a> {
     fn set_client(&self, temperature_client: &'a dyn sensors::TemperatureClient) {
         self.temperature_client.replace(temperature_client);
     }

--- a/capsules/src/lib.rs
+++ b/capsules/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(const_fn, in_band_lifetimes)]
+#![feature(const_fn)]
 #![forbid(unsafe_code)]
 #![no_std]
 

--- a/capsules/src/lps25hb.rs
+++ b/capsules/src/lps25hb.rs
@@ -99,7 +99,7 @@ pub struct LPS25HB<'a> {
     buffer: TakeCell<'static, [u8]>,
 }
 
-impl LPS25HB<'a> {
+impl<'a> LPS25HB<'a> {
     pub fn new(
         i2c: &'a dyn i2c::I2CDevice,
         interrupt_pin: &'a dyn gpio::InterruptPin,
@@ -146,7 +146,7 @@ impl LPS25HB<'a> {
     }
 }
 
-impl i2c::I2CClient for LPS25HB<'a> {
+impl i2c::I2CClient for LPS25HB<'_> {
     fn command_complete(&self, buffer: &'static mut [u8], _error: i2c::Error) {
         match self.state.get() {
             State::SelectWhoAmI => {
@@ -205,7 +205,7 @@ impl i2c::I2CClient for LPS25HB<'a> {
     }
 }
 
-impl gpio::Client for LPS25HB<'a> {
+impl gpio::Client for LPS25HB<'_> {
     fn fired(&self) {
         self.buffer.take().map(|buf| {
             // turn on i2c to send commands
@@ -219,7 +219,7 @@ impl gpio::Client for LPS25HB<'a> {
     }
 }
 
-impl Driver for LPS25HB<'a> {
+impl Driver for LPS25HB<'_> {
     fn subscribe(
         &self,
         subscribe_num: usize,

--- a/capsules/src/lsm303dlhc.rs
+++ b/capsules/src/lsm303dlhc.rs
@@ -259,7 +259,7 @@ pub struct Lsm303dlhcI2C<'a> {
     temperature_client: OptionalCell<&'a dyn sensors::TemperatureClient>,
 }
 
-impl Lsm303dlhcI2C<'a> {
+impl<'a> Lsm303dlhcI2C<'a> {
     pub fn new(
         i2c_accelerometer: &'a dyn i2c::I2CDevice,
         i2c_magnetometer: &'a dyn i2c::I2CDevice,
@@ -411,7 +411,7 @@ impl Lsm303dlhcI2C<'a> {
     }
 }
 
-impl i2c::I2CClient for Lsm303dlhcI2C<'a> {
+impl i2c::I2CClient for Lsm303dlhcI2C<'_> {
     fn command_complete(&self, buffer: &'static mut [u8], error: Error) {
         match self.state.get() {
             State::IsPresent => {
@@ -606,7 +606,7 @@ impl i2c::I2CClient for Lsm303dlhcI2C<'a> {
     }
 }
 
-impl Driver for Lsm303dlhcI2C<'a> {
+impl Driver for Lsm303dlhcI2C<'_> {
     fn command(&self, command_num: usize, data1: usize, data2: usize, _: AppId) -> ReturnCode {
         match command_num {
             0 => ReturnCode::SUCCESS,
@@ -723,7 +723,7 @@ impl Driver for Lsm303dlhcI2C<'a> {
     }
 }
 
-impl sensors::NineDof for Lsm303dlhcI2C<'a> {
+impl<'a> sensors::NineDof for Lsm303dlhcI2C<'a> {
     fn set_client(&self, nine_dof_client: &'a dyn sensors::NineDofClient) {
         self.nine_dof_client.replace(nine_dof_client);
     }
@@ -747,7 +747,7 @@ impl sensors::NineDof for Lsm303dlhcI2C<'a> {
     }
 }
 
-impl sensors::TemperatureDriver for Lsm303dlhcI2C<'a> {
+impl<'a> sensors::TemperatureDriver for Lsm303dlhcI2C<'a> {
     fn set_client(&self, temperature_client: &'a dyn sensors::TemperatureClient) {
         self.temperature_client.replace(temperature_client);
     }

--- a/capsules/src/ltc294x.rs
+++ b/capsules/src/ltc294x.rs
@@ -136,7 +136,7 @@ pub struct LTC294X<'a> {
     client: OptionalCell<&'static dyn LTC294XClient>,
 }
 
-impl LTC294X<'a> {
+impl<'a> LTC294X<'a> {
     pub fn new(
         i2c: &'a dyn i2c::I2CDevice,
         interrupt_pin: Option<&'a dyn gpio::InterruptPin>,
@@ -320,7 +320,7 @@ impl LTC294X<'a> {
     }
 }
 
-impl i2c::I2CClient for LTC294X<'a> {
+impl i2c::I2CClient for LTC294X<'_> {
     fn command_complete(&self, buffer: &'static mut [u8], _error: i2c::Error) {
         match self.state.get() {
             State::ReadStatus => {
@@ -393,7 +393,7 @@ impl i2c::I2CClient for LTC294X<'a> {
     }
 }
 
-impl gpio::Client for LTC294X<'a> {
+impl gpio::Client for LTC294X<'_> {
     fn fired(&self) {
         self.client.map(|client| {
             client.interrupt();
@@ -408,7 +408,7 @@ pub struct LTC294XDriver<'a> {
     callback: OptionalCell<Callback>,
 }
 
-impl LTC294XDriver<'a> {
+impl<'a> LTC294XDriver<'a> {
     pub fn new(ltc: &'a LTC294X) -> LTC294XDriver<'a> {
         LTC294XDriver {
             ltc294x: ltc,
@@ -417,7 +417,7 @@ impl LTC294XDriver<'a> {
     }
 }
 
-impl LTC294XClient for LTC294XDriver<'a> {
+impl LTC294XClient for LTC294XDriver<'_> {
     fn interrupt(&self) {
         self.callback.map(|cb| {
             cb.schedule(0, 0, 0);
@@ -467,7 +467,7 @@ impl LTC294XClient for LTC294XDriver<'a> {
     }
 }
 
-impl Driver for LTC294XDriver<'a> {
+impl Driver for LTC294XDriver<'_> {
     /// Setup callbacks.
     ///
     /// ### `subscribe_num`

--- a/capsules/src/max17205.rs
+++ b/capsules/src/max17205.rs
@@ -104,7 +104,7 @@ pub struct MAX17205<'a> {
     client: OptionalCell<&'static dyn MAX17205Client>,
 }
 
-impl MAX17205<'a> {
+impl<'a> MAX17205<'a> {
     pub fn new(
         i2c_lower: &'a dyn i2c::I2CDevice,
         i2c_upper: &'a dyn i2c::I2CDevice,
@@ -194,7 +194,7 @@ impl MAX17205<'a> {
     }
 }
 
-impl i2c::I2CClient for MAX17205<'a> {
+impl i2c::I2CClient for MAX17205<'_> {
     fn command_complete(&self, buffer: &'static mut [u8], _error: i2c::Error) {
         match self.state.get() {
             State::SetupReadStatus => {
@@ -362,7 +362,7 @@ pub struct MAX17205Driver<'a> {
     callback: OptionalCell<Callback>,
 }
 
-impl MAX17205Driver<'a> {
+impl<'a> MAX17205Driver<'a> {
     pub fn new(max: &'a MAX17205) -> MAX17205Driver<'a> {
         MAX17205Driver {
             max17205: max,
@@ -371,7 +371,7 @@ impl MAX17205Driver<'a> {
     }
 }
 
-impl MAX17205Client for MAX17205Driver<'a> {
+impl MAX17205Client for MAX17205Driver<'_> {
     fn status(&self, status: u16, error: ReturnCode) {
         self.callback
             .map(|cb| cb.schedule(From::from(error), status as usize, 0));
@@ -408,7 +408,7 @@ impl MAX17205Client for MAX17205Driver<'a> {
     }
 }
 
-impl Driver for MAX17205Driver<'a> {
+impl Driver for MAX17205Driver<'_> {
     /// Setup callback.
     ///
     /// ### `subscribe_num`

--- a/capsules/src/mcp230xx.rs
+++ b/capsules/src/mcp230xx.rs
@@ -138,7 +138,7 @@ pub struct MCP230xx<'a> {
     client: OptionalCell<&'static dyn gpio_async::Client>,
 }
 
-impl MCP230xx<'a> {
+impl<'a> MCP230xx<'a> {
     pub fn new(
         i2c: &'a dyn hil::i2c::I2CDevice,
         interrupt_pin_a: Option<&'static dyn gpio::InterruptValuePin>,
@@ -375,7 +375,7 @@ impl MCP230xx<'a> {
     }
 }
 
-impl hil::i2c::I2CClient for MCP230xx<'a> {
+impl hil::i2c::I2CClient for MCP230xx<'_> {
     fn command_complete(&self, buffer: &'static mut [u8], _error: hil::i2c::Error) {
         match self.state.get() {
             State::SelectIoDir(pin_number, direction) => {
@@ -524,7 +524,7 @@ impl hil::i2c::I2CClient for MCP230xx<'a> {
     }
 }
 
-impl gpio::ClientWithValue for MCP230xx<'a> {
+impl gpio::ClientWithValue for MCP230xx<'_> {
     fn fired(&self, value: u32) {
         if value < 2 {
             return; // Error, value specifies which pin A=0, B=1
@@ -543,7 +543,7 @@ impl gpio::ClientWithValue for MCP230xx<'a> {
     }
 }
 
-impl gpio_async::Port for MCP230xx<'a> {
+impl gpio_async::Port for MCP230xx<'_> {
     fn disable(&self, pin: usize) -> ReturnCode {
         // Best we can do is make this an input.
         self.set_direction(pin as u8, Direction::Input)

--- a/capsules/src/net/icmpv6/icmpv6_send.rs
+++ b/capsules/src/net/icmpv6/icmpv6_send.rs
@@ -62,7 +62,7 @@ pub struct ICMP6SendStruct<'a, T: IP6Sender<'a>> {
     client: OptionalCell<&'a dyn ICMP6SendClient>,
 }
 
-impl<T: IP6Sender<'a>> ICMP6SendStruct<'a, T> {
+impl<'a, T: IP6Sender<'a>> ICMP6SendStruct<'a, T> {
     pub fn new(ip_send_struct: &'a T) -> ICMP6SendStruct<'a, T> {
         ICMP6SendStruct {
             ip_send_struct: ip_send_struct,
@@ -71,7 +71,7 @@ impl<T: IP6Sender<'a>> ICMP6SendStruct<'a, T> {
     }
 }
 
-impl<T: IP6Sender<'a>> ICMP6Sender<'a> for ICMP6SendStruct<'a, T> {
+impl<'a, T: IP6Sender<'a>> ICMP6Sender<'a> for ICMP6SendStruct<'a, T> {
     fn set_client(&self, client: &'a dyn ICMP6SendClient) {
         self.client.set(client);
     }
@@ -91,7 +91,7 @@ impl<T: IP6Sender<'a>> ICMP6Sender<'a> for ICMP6SendStruct<'a, T> {
     }
 }
 
-impl<T: IP6Sender<'a>> IP6SendClient for ICMP6SendStruct<'a, T> {
+impl<'a, T: IP6Sender<'a>> IP6SendClient for ICMP6SendStruct<'a, T> {
     /// Forwards callback received from the `IP6Sender` to the
     /// `ICMP6SendClient`.
     fn send_done(&self, result: ReturnCode) {

--- a/capsules/src/net/ieee802154.rs
+++ b/capsules/src/net/ieee802154.rs
@@ -109,7 +109,7 @@ pub enum AddressMode {
     Long = 0b11,
 }
 
-impl From<&'a Option<MacAddress>> for AddressMode {
+impl<'a> From<&'a Option<MacAddress>> for AddressMode {
     fn from(opt_addr: &'a Option<MacAddress>) -> Self {
         match *opt_addr {
             None => AddressMode::NotPresent,
@@ -252,7 +252,7 @@ impl KeyId {
     }
 }
 
-impl From<&'a KeyId> for KeyIdMode {
+impl<'a> From<&'a KeyId> for KeyIdMode {
     fn from(key_id: &'a KeyId) -> Self {
         match *key_id {
             KeyId::Implicit => KeyIdMode::Implicit,
@@ -353,13 +353,13 @@ pub enum HeaderIE<'a> {
     Termination2,
 }
 
-impl Default for HeaderIE<'a> {
+impl Default for HeaderIE<'_> {
     fn default() -> Self {
         HeaderIE::Termination1
     }
 }
 
-impl HeaderIE<'a> {
+impl HeaderIE<'_> {
     pub fn is_termination(&self) -> bool {
         match *self {
             HeaderIE::Termination1 | HeaderIE::Termination2 => true,
@@ -423,13 +423,13 @@ pub enum PayloadIE<'a> {
     Termination,
 }
 
-impl Default for PayloadIE<'a> {
+impl Default for PayloadIE<'_> {
     fn default() -> Self {
         PayloadIE::Termination
     }
 }
 
-impl PayloadIE<'a> {
+impl PayloadIE<'_> {
     pub fn is_termination(&self) -> bool {
         match *self {
             PayloadIE::Termination => true,
@@ -504,7 +504,7 @@ pub struct Header<'a> {
     pub payload_ies_len: usize,
 }
 
-impl Header<'a> {
+impl Header<'_> {
     pub fn encode(&self, buf: &mut [u8], has_payload: bool) -> SResult<usize> {
         // The frame control field is collected in the course of encoding the
         // various other fields of the header and then written only at the end

--- a/capsules/src/net/ipv6/ipv6.rs
+++ b/capsules/src/net/ipv6/ipv6.rs
@@ -319,7 +319,7 @@ pub struct IPPayload<'a> {
     pub payload: &'a mut [u8],
 }
 
-impl IPPayload<'a> {
+impl<'a> IPPayload<'a> {
     /// This function constructs a new `IPPayload` struct
     ///
     /// # Arguments
@@ -420,7 +420,7 @@ pub struct IP6Packet<'a> {
 // Note: We want to have the IP6Header struct implement these methods,
 // as there are cases where we want to allocate/modify the IP6Header without
 // allocating/modifying the entire IP6Packet
-impl IP6Packet<'a> {
+impl<'a> IP6Packet<'a> {
     // Sets fields to appropriate defaults
 
     /// This function returns a new `IP6Packet` struct. Note that the

--- a/capsules/src/net/ipv6/ipv6_send.rs
+++ b/capsules/src/net/ipv6/ipv6_send.rs
@@ -107,7 +107,7 @@ pub struct IP6SendStruct<'a, A: time::Alarm<'a>> {
     ip_vis: &'static IpVisibilityCapability,
 }
 
-impl<A: time::Alarm<'a>> IP6Sender<'a> for IP6SendStruct<'a, A> {
+impl<'a, A: time::Alarm<'a>> IP6Sender<'a> for IP6SendStruct<'a, A> {
     fn set_client(&self, client: &'a dyn IP6SendClient) {
         self.client.set(client);
     }
@@ -147,7 +147,7 @@ impl<A: time::Alarm<'a>> IP6Sender<'a> for IP6SendStruct<'a, A> {
     }
 }
 
-impl<A: time::Alarm<'a>> IP6SendStruct<'a, A> {
+impl<'a, A: time::Alarm<'a>> IP6SendStruct<'a, A> {
     pub fn new(
         ip6_packet: &'static mut IP6Packet<'static>,
         alarm: &'a A,
@@ -245,7 +245,7 @@ impl<A: time::Alarm<'a>> IP6SendStruct<'a, A> {
     }
 }
 
-impl<A: time::Alarm<'a>> time::AlarmClient for IP6SendStruct<'a, A> {
+impl<'a, A: time::Alarm<'a>> time::AlarmClient for IP6SendStruct<'a, A> {
     fn fired(&self) {
         let result = self.send_next_fragment();
         if result != ReturnCode::SUCCESS {
@@ -254,7 +254,7 @@ impl<A: time::Alarm<'a>> time::AlarmClient for IP6SendStruct<'a, A> {
     }
 }
 
-impl<A: time::Alarm<'a>> TxClient for IP6SendStruct<'a, A> {
+impl<'a, A: time::Alarm<'a>> TxClient for IP6SendStruct<'a, A> {
     fn send_done(&self, tx_buf: &'static mut [u8], acked: bool, result: ReturnCode) {
         self.tx_buf.replace(tx_buf);
         if result != ReturnCode::SUCCESS {

--- a/capsules/src/net/sixlowpan/sixlowpan_state.rs
+++ b/capsules/src/net/sixlowpan/sixlowpan_state.rs
@@ -327,7 +327,7 @@ pub struct TxState<'a> {
     sixlowpan: &'a dyn SixlowpanState<'a>,
 }
 
-impl TxState<'a> {
+impl<'a> TxState<'a> {
     /// Creates a new `TxState`
     ///
     /// # Arguments
@@ -639,13 +639,13 @@ pub struct RxState<'a> {
     next: ListLink<'a, RxState<'a>>,
 }
 
-impl ListNode<'a, RxState<'a>> for RxState<'a> {
+impl<'a> ListNode<'a, RxState<'a>> for RxState<'a> {
     fn next(&'a self) -> &'a ListLink<RxState<'a>> {
         &self.next
     }
 }
 
-impl RxState<'a> {
+impl<'a> RxState<'a> {
     /// Creates a new `RxState`
     ///
     /// # Arguments
@@ -794,7 +794,7 @@ pub struct Sixlowpan<'a, A: time::Alarm<'a>, C: ContextStore> {
 }
 
 // This function is called after receiving a frame
-impl<A: time::Alarm<'a>, C: ContextStore> RxClient for Sixlowpan<'a, A, C> {
+impl<'a, A: time::Alarm<'a>, C: ContextStore> RxClient for Sixlowpan<'a, A, C> {
     fn receive<'b>(&self, buf: &'b [u8], header: Header<'b>, data_offset: usize, data_len: usize) {
         // We return if retcode is not valid, as it does not make sense to issue
         // a callback for an invalid frame reception
@@ -815,7 +815,7 @@ impl<A: time::Alarm<'a>, C: ContextStore> RxClient for Sixlowpan<'a, A, C> {
     }
 }
 
-impl<A: time::Alarm<'a>, C: ContextStore> SixlowpanState<'a> for Sixlowpan<'a, A, C> {
+impl<'a, A: time::Alarm<'a>, C: ContextStore> SixlowpanState<'a> for Sixlowpan<'a, A, C> {
     fn next_dgram_tag(&self) -> u16 {
         // Increment dgram_tag
         let dgram_tag = if (self.tx_dgram_tag.get() + 1) == 0 {
@@ -846,7 +846,7 @@ impl<A: time::Alarm<'a>, C: ContextStore> SixlowpanState<'a> for Sixlowpan<'a, A
     }
 }
 
-impl<A: time::Alarm<'a>, C: ContextStore> Sixlowpan<'a, A, C> {
+impl<'a, A: time::Alarm<'a>, C: ContextStore> Sixlowpan<'a, A, C> {
     /// Creates a new `Sixlowpan`
     ///
     /// # Arguments

--- a/capsules/src/net/thread/tlv.rs
+++ b/capsules/src/net/thread/tlv.rs
@@ -119,7 +119,7 @@ pub enum Tlv<'a> {
     PendingOperationalDataset(&'a [u8]),
 }
 
-impl Tlv<'a> {
+impl Tlv<'_> {
     /// Serializes TLV data in `buf` into the format specific to the TLV
     /// type.
     pub fn encode(&self, buf: &mut [u8]) -> SResult {
@@ -495,8 +495,8 @@ impl From<u8> for TlvType {
     }
 }
 
-impl<'a, 'b> From<&'a Tlv<'b>> for TlvType {
-    fn from(tlv: &'a Tlv<'b>) -> Self {
+impl From<&Tlv<'_>> for TlvType {
+    fn from(tlv: &Tlv<'_>) -> Self {
         match *tlv {
             Tlv::SourceAddress(_) => TlvType::SourceAddress,
             Tlv::Mode(_) => TlvType::Mode,
@@ -568,7 +568,7 @@ pub enum NetworkDataTlv<'a> {
     },
 }
 
-impl NetworkDataTlv<'a> {
+impl NetworkDataTlv<'_> {
     /// Serializes TLV data in `buf` into the format specific to the
     /// Network Data TLV type.
     pub fn encode(&self, buf: &mut [u8], stable: bool) -> SResult {
@@ -730,8 +730,8 @@ impl From<u8> for NetworkDataTlvType {
     }
 }
 
-impl<'a, 'b> From<&'a NetworkDataTlv<'b>> for NetworkDataTlvType {
-    fn from(network_data_tlv: &'a NetworkDataTlv<'b>) -> Self {
+impl From<&NetworkDataTlv<'_>> for NetworkDataTlvType {
+    fn from(network_data_tlv: &NetworkDataTlv<'_>) -> Self {
         match *network_data_tlv {
             NetworkDataTlv::Prefix { .. } => NetworkDataTlvType::Prefix,
             NetworkDataTlv::CommissioningData { .. } => NetworkDataTlvType::CommissioningData,
@@ -751,7 +751,7 @@ pub enum PrefixSubTlv<'a> {
     },
 }
 
-impl PrefixSubTlv<'a> {
+impl PrefixSubTlv<'_> {
     /// Serializes TLV data in `buf` into the format specific to the
     /// Prefix sub-TLV type.
     pub fn encode(&self, buf: &mut [u8], stable: bool) -> SResult {
@@ -862,8 +862,8 @@ impl From<u8> for PrefixSubTlvType {
     }
 }
 
-impl<'a, 'b> From<&'a PrefixSubTlv<'b>> for PrefixSubTlvType {
-    fn from(prefix_sub_tlv: &'a PrefixSubTlv<'b>) -> Self {
+impl From<&PrefixSubTlv<'_>> for PrefixSubTlvType {
+    fn from(prefix_sub_tlv: &PrefixSubTlv<'_>) -> Self {
         match *prefix_sub_tlv {
             PrefixSubTlv::HasRoute(_) => PrefixSubTlvType::HasRoute,
             PrefixSubTlv::BorderRouter(_) => PrefixSubTlvType::BorderRouter,
@@ -1034,8 +1034,8 @@ impl From<u8> for ServiceSubTlvType {
     }
 }
 
-impl From<&'a ServiceSubTlv> for ServiceSubTlvType {
-    fn from(service_sub_tlv: &'a ServiceSubTlv) -> Self {
+impl From<&ServiceSubTlv> for ServiceSubTlvType {
+    fn from(service_sub_tlv: &ServiceSubTlv) -> Self {
         match *service_sub_tlv {
             ServiceSubTlv::Server { .. } => ServiceSubTlvType::Server,
         }
@@ -1080,7 +1080,7 @@ pub enum NetworkManagementTlv<'a> {
     ChannelMask(&'a [u8]),
 }
 
-impl NetworkManagementTlv<'a> {
+impl NetworkManagementTlv<'_> {
     /// Serializes TLV data in `buf` into the format specific to the
     /// Network Management TLV type.
     pub fn encode(&self, buf: &mut [u8]) -> SResult {
@@ -1418,8 +1418,8 @@ impl From<u8> for NetworkManagementTlvType {
     }
 }
 
-impl<'a, 'b> From<&'a NetworkManagementTlv<'b>> for NetworkManagementTlvType {
-    fn from(network_mgmt_tlv: &'a NetworkManagementTlv<'b>) -> Self {
+impl From<&NetworkManagementTlv<'_>> for NetworkManagementTlvType {
+    fn from(network_mgmt_tlv: &NetworkManagementTlv<'_>) -> Self {
         match *network_mgmt_tlv {
             NetworkManagementTlv::Channel { .. } => NetworkManagementTlvType::Channel,
             NetworkManagementTlv::PanId(_) => NetworkManagementTlvType::PanId,

--- a/capsules/src/net/udp/udp_send.rs
+++ b/capsules/src/net/udp/udp_send.rs
@@ -34,7 +34,7 @@ pub struct MuxUdpSender<'a, T: IP6Sender<'a>> {
     ip_sender: &'a dyn IP6Sender<'a>,
 }
 
-impl<T: IP6Sender<'a>> MuxUdpSender<'a, T> {
+impl<'a, T: IP6Sender<'a>> MuxUdpSender<'a, T> {
     pub fn new(ip6_sender: &'a dyn IP6Sender<'a>) -> MuxUdpSender<'a, T> {
         // similar to UdpSendStruct new()
         MuxUdpSender {
@@ -84,7 +84,7 @@ impl<T: IP6Sender<'a>> MuxUdpSender<'a, T> {
 /// This function implements the `IP6SendClient` trait for the `UDPSendStruct`,
 /// and is necessary to receive callbacks from the lower (IP) layer. When
 /// the UDP layer receives this callback, it forwards it to the `UDPSendClient`.
-impl<T: IP6Sender<'a>> IP6SendClient for MuxUdpSender<'a, T> {
+impl<'a, T: IP6Sender<'a>> IP6SendClient for MuxUdpSender<'a, T> {
     fn send_done(&self, result: ReturnCode) {
         let last_sender = self.sender_list.pop_head();
         let next_sender_option = self.sender_list.head(); // must check here, because udp driver
@@ -257,7 +257,7 @@ impl<'a, T: IP6Sender<'a>> ListNode<'a, UDPSendStruct<'a, T>> for UDPSendStruct<
 
 /// Below is the implementation of the `UDPSender` traits for the
 /// `UDPSendStruct`.
-impl<T: IP6Sender<'a>> UDPSender<'a> for UDPSendStruct<'a, T> {
+impl<'a, T: IP6Sender<'a>> UDPSender<'a> for UDPSendStruct<'a, T> {
     fn set_client(&self, client: &'a dyn UDPSendClient) {
         self.client.set(client);
     }
@@ -341,7 +341,7 @@ impl<T: IP6Sender<'a>> UDPSender<'a> for UDPSendStruct<'a, T> {
     }
 }
 
-impl<T: IP6Sender<'a>> UDPSendStruct<'a, T> {
+impl<'a, T: IP6Sender<'a>> UDPSendStruct<'a, T> {
     pub fn new(
         udp_mux_sender: &'a MuxUdpSender<'a, T>, /*binding: UdpPortBindingTx*/
         udp_vis: &'static UdpVisibilityCapability,

--- a/capsules/src/ninedof.rs
+++ b/capsules/src/ninedof.rs
@@ -58,7 +58,7 @@ pub struct NineDof<'a> {
     current_app: OptionalCell<AppId>,
 }
 
-impl NineDof<'a> {
+impl<'a> NineDof<'a> {
     pub fn new(drivers: &'a [&'a dyn hil::sensors::NineDof], grant: Grant<App>) -> NineDof<'a> {
         NineDof {
             drivers: drivers,
@@ -131,7 +131,7 @@ impl NineDof<'a> {
     }
 }
 
-impl hil::sensors::NineDofClient for NineDof<'a> {
+impl hil::sensors::NineDofClient for NineDof<'_> {
     fn callback(&self, arg1: usize, arg2: usize, arg3: usize) {
         // Notify the current application that the command finished.
         // Also keep track of what just finished to see if we can re-use
@@ -178,7 +178,7 @@ impl hil::sensors::NineDofClient for NineDof<'a> {
     }
 }
 
-impl Driver for NineDof<'a> {
+impl Driver for NineDof<'_> {
     fn subscribe(
         &self,
         subscribe_num: usize,

--- a/capsules/src/nonvolatile_storage_driver.rs
+++ b/capsules/src/nonvolatile_storage_driver.rs
@@ -140,7 +140,7 @@ pub struct NonvolatileStorage<'a> {
     kernel_readwrite_address: Cell<usize>,
 }
 
-impl NonvolatileStorage<'a> {
+impl<'a> NonvolatileStorage<'a> {
     pub fn new(
         driver: &'a dyn hil::nonvolatile_storage::NonvolatileStorage<'static>,
         grant: Grant<App>,
@@ -387,7 +387,7 @@ impl NonvolatileStorage<'a> {
 }
 
 /// This is the callback client for the underlying physical storage driver.
-impl hil::nonvolatile_storage::NonvolatileStorageClient<'static> for NonvolatileStorage<'a> {
+impl hil::nonvolatile_storage::NonvolatileStorageClient<'static> for NonvolatileStorage<'_> {
     fn read_done(&self, buffer: &'static mut [u8], length: usize) {
         // Switch on which user of this capsule generated this callback.
         self.current_user.take().map(|user| {
@@ -448,7 +448,7 @@ impl hil::nonvolatile_storage::NonvolatileStorageClient<'static> for Nonvolatile
 }
 
 /// Provide an interface for the kernel.
-impl hil::nonvolatile_storage::NonvolatileStorage<'static> for NonvolatileStorage<'a> {
+impl hil::nonvolatile_storage::NonvolatileStorage<'static> for NonvolatileStorage<'_> {
     fn set_client(&self, client: &'static dyn hil::nonvolatile_storage::NonvolatileStorageClient) {
         self.kernel_client.set(client);
     }
@@ -465,7 +465,7 @@ impl hil::nonvolatile_storage::NonvolatileStorage<'static> for NonvolatileStorag
 }
 
 /// Provide an interface for userland.
-impl Driver for NonvolatileStorage<'a> {
+impl Driver for NonvolatileStorage<'_> {
     /// Setup shared buffers.
     ///
     /// ### `allow_num`

--- a/capsules/src/nonvolatile_to_pages.rs
+++ b/capsules/src/nonvolatile_to_pages.rs
@@ -69,7 +69,7 @@ pub struct NonvolatileToPages<'a, F: hil::flash::Flash + 'static> {
     buffer_index: Cell<usize>,
 }
 
-impl<F: hil::flash::Flash> NonvolatileToPages<'a, F> {
+impl<'a, F: hil::flash::Flash> NonvolatileToPages<'a, F> {
     pub fn new(driver: &'a F, buffer: &'static mut F::Page) -> NonvolatileToPages<'a, F> {
         NonvolatileToPages {
             driver: driver,
@@ -85,7 +85,7 @@ impl<F: hil::flash::Flash> NonvolatileToPages<'a, F> {
     }
 }
 
-impl<F: hil::flash::Flash> hil::nonvolatile_storage::NonvolatileStorage<'static>
+impl<'a, F: hil::flash::Flash> hil::nonvolatile_storage::NonvolatileStorage<'static>
     for NonvolatileToPages<'a, F>
 {
     fn set_client(&self, client: &'static dyn hil::nonvolatile_storage::NonvolatileStorageClient) {
@@ -174,7 +174,7 @@ impl<F: hil::flash::Flash> hil::nonvolatile_storage::NonvolatileStorage<'static>
     }
 }
 
-impl<F: hil::flash::Flash> hil::flash::Client<F> for NonvolatileToPages<'a, F> {
+impl<F: hil::flash::Flash> hil::flash::Client<F> for NonvolatileToPages<'_, F> {
     fn read_complete(&self, pagebuffer: &'static mut F::Page, _error: hil::flash::Error) {
         match self.state.get() {
             State::Read => {

--- a/capsules/src/nrf51822_serialization.rs
+++ b/capsules/src/nrf51822_serialization.rs
@@ -52,7 +52,7 @@ pub struct Nrf51822Serialization<'a> {
     rx_buffer: TakeCell<'static, [u8]>,
 }
 
-impl Nrf51822Serialization<'a> {
+impl<'a> Nrf51822Serialization<'a> {
     pub fn new(
         uart: &'a dyn uart::UartAdvanced<'a>,
         grant: Grant<App>,
@@ -91,7 +91,7 @@ impl Nrf51822Serialization<'a> {
     }
 }
 
-impl Driver for Nrf51822Serialization<'a> {
+impl Driver for Nrf51822Serialization<'_> {
     /// Pass application space memory to this driver.
     ///
     /// This also sets which app is currently using this driver. Only one app
@@ -209,7 +209,7 @@ impl Driver for Nrf51822Serialization<'a> {
 }
 
 // Callbacks from the underlying UART driver.
-impl uart::TransmitClient for Nrf51822Serialization<'a> {
+impl uart::TransmitClient for Nrf51822Serialization<'_> {
     // Called when the UART TX has finished.
     fn transmitted_buffer(&self, buffer: &'static mut [u8], _tx_len: usize, _rcode: ReturnCode) {
         self.tx_buffer.replace(buffer);
@@ -227,7 +227,7 @@ impl uart::TransmitClient for Nrf51822Serialization<'a> {
     fn transmitted_word(&self, _rcode: ReturnCode) {}
 }
 
-impl uart::ReceiveClient for Nrf51822Serialization<'a> {
+impl uart::ReceiveClient for Nrf51822Serialization<'_> {
     // Called when a buffer is received on the UART.
     fn received_buffer(
         &self,

--- a/capsules/src/pca9544a.rs
+++ b/capsules/src/pca9544a.rs
@@ -60,7 +60,7 @@ pub struct PCA9544A<'a> {
     callback: OptionalCell<Callback>,
 }
 
-impl PCA9544A<'a> {
+impl<'a> PCA9544A<'a> {
     pub fn new(i2c: &'a dyn i2c::I2CDevice, buffer: &'static mut [u8]) -> PCA9544A<'a> {
         PCA9544A {
             i2c: i2c,
@@ -118,7 +118,7 @@ impl PCA9544A<'a> {
     }
 }
 
-impl i2c::I2CClient for PCA9544A<'a> {
+impl i2c::I2CClient for PCA9544A<'_> {
     fn command_complete(&self, buffer: &'static mut [u8], _error: i2c::Error) {
         match self.state.get() {
             State::ReadControl(field) => {
@@ -146,7 +146,7 @@ impl i2c::I2CClient for PCA9544A<'a> {
     }
 }
 
-impl Driver for PCA9544A<'a> {
+impl Driver for PCA9544A<'_> {
     /// Setup callback for event done.
     ///
     /// ### `subscribe_num`

--- a/capsules/src/rf233.rs
+++ b/capsules/src/rf233.rs
@@ -276,7 +276,7 @@ fn interrupt_included(mask: u8, interrupt: InteruptFlags) -> bool {
     (mask & int) == int
 }
 
-impl<S: spi::SpiMasterDevice> spi::SpiMasterClient for RF233<'a, S> {
+impl<'a, S: spi::SpiMasterDevice> spi::SpiMasterClient for RF233<'a, S> {
     // This function is a bit confusing because the order of the logic in the
     // function is different than the order of operations during transmission
     // and reception.
@@ -1017,13 +1017,13 @@ impl<S: spi::SpiMasterDevice> spi::SpiMasterClient for RF233<'a, S> {
     }
 }
 
-impl<S: spi::SpiMasterDevice> gpio::Client for RF233<'a, S> {
+impl<S: spi::SpiMasterDevice> gpio::Client for RF233<'_, S> {
     fn fired(&self) {
         self.handle_interrupt();
     }
 }
 
-impl<S: spi::SpiMasterDevice> RF233<'a, S> {
+impl<'a, S: spi::SpiMasterDevice> RF233<'a, S> {
     pub fn new(
         spi: &'a S,
         reset: &'a dyn gpio::Pin,
@@ -1162,9 +1162,9 @@ impl<S: spi::SpiMasterDevice> RF233<'a, S> {
     }
 }
 
-impl<S: spi::SpiMasterDevice> radio::Radio for RF233<'a, S> {}
+impl<S: spi::SpiMasterDevice> radio::Radio for RF233<'_, S> {}
 
-impl<S: spi::SpiMasterDevice> radio::RadioConfig for RF233<'a, S> {
+impl<S: spi::SpiMasterDevice> radio::RadioConfig for RF233<'_, S> {
     fn initialize(
         &self,
         buf: &'static mut [u8],
@@ -1329,7 +1329,7 @@ impl<S: spi::SpiMasterDevice> radio::RadioConfig for RF233<'a, S> {
     }
 }
 
-impl<S: spi::SpiMasterDevice> radio::RadioData for RF233<'a, S> {
+impl<S: spi::SpiMasterDevice> radio::RadioData for RF233<'_, S> {
     fn set_transmit_client(&self, client: &'static dyn radio::TxClient) {
         self.tx_client.set(client);
     }

--- a/capsules/src/rng.rs
+++ b/capsules/src/rng.rs
@@ -43,7 +43,7 @@ pub struct RngDriver<'a> {
     getting_randomness: Cell<bool>,
 }
 
-impl RngDriver<'a> {
+impl<'a> RngDriver<'a> {
     pub fn new(rng: &'a dyn Rng<'a>, grant: Grant<App>) -> RngDriver<'a> {
         RngDriver {
             rng: rng,
@@ -53,7 +53,7 @@ impl RngDriver<'a> {
     }
 }
 
-impl<'a> rng::Client for RngDriver<'a> {
+impl rng::Client for RngDriver<'_> {
     fn randomness_available(
         &self,
         randomness: &mut dyn Iterator<Item = u32>,
@@ -207,7 +207,7 @@ pub struct Entropy32ToRandom<'a> {
     client: OptionalCell<&'a dyn rng::Client>,
 }
 
-impl Entropy32ToRandom<'a> {
+impl<'a> Entropy32ToRandom<'a> {
     pub fn new(egen: &'a dyn Entropy32<'a>) -> Entropy32ToRandom<'a> {
         Entropy32ToRandom {
             egen: egen,
@@ -216,7 +216,7 @@ impl Entropy32ToRandom<'a> {
     }
 }
 
-impl Rng<'a> for Entropy32ToRandom<'a> {
+impl<'a> Rng<'a> for Entropy32ToRandom<'a> {
     fn get(&self) -> ReturnCode {
         self.egen.get()
     }
@@ -231,7 +231,7 @@ impl Rng<'a> for Entropy32ToRandom<'a> {
     }
 }
 
-impl entropy::Client32 for Entropy32ToRandom<'a> {
+impl entropy::Client32 for Entropy32ToRandom<'_> {
     fn entropy_available(
         &self,
         entropy: &mut dyn Iterator<Item = u32>,
@@ -257,7 +257,7 @@ impl entropy::Client32 for Entropy32ToRandom<'a> {
 
 struct Entropy32ToRandomIter<'a>(&'a mut dyn Iterator<Item = u32>);
 
-impl Iterator for Entropy32ToRandomIter<'a> {
+impl Iterator for Entropy32ToRandomIter<'_> {
     type Item = u32;
 
     fn next(&mut self) -> Option<u32> {
@@ -272,7 +272,7 @@ pub struct Entropy8To32<'a> {
     bytes: Cell<u32>,
 }
 
-impl Entropy8To32<'a> {
+impl<'a> Entropy8To32<'a> {
     pub fn new(egen: &'a dyn Entropy8<'a>) -> Entropy8To32<'a> {
         Entropy8To32 {
             egen: egen,
@@ -283,7 +283,7 @@ impl Entropy8To32<'a> {
     }
 }
 
-impl Entropy32<'a> for Entropy8To32<'a> {
+impl<'a> Entropy32<'a> for Entropy8To32<'a> {
     fn get(&self) -> ReturnCode {
         self.egen.get()
     }
@@ -306,7 +306,7 @@ impl Entropy32<'a> for Entropy8To32<'a> {
     }
 }
 
-impl entropy::Client8 for Entropy8To32<'a> {
+impl entropy::Client8 for Entropy8To32<'_> {
     fn entropy_available(
         &self,
         entropy: &mut dyn Iterator<Item = u8>,
@@ -348,7 +348,7 @@ impl entropy::Client8 for Entropy8To32<'a> {
 
 struct Entropy8To32Iter<'a, 'b: 'a>(&'a Entropy8To32<'b>);
 
-impl Iterator for Entropy8To32Iter<'a, 'b> {
+impl Iterator for Entropy8To32Iter<'_, '_> {
     type Item = u32;
 
     fn next(&mut self) -> Option<u32> {
@@ -369,7 +369,7 @@ pub struct Entropy32To8<'a> {
     bytes_consumed: Cell<usize>,
 }
 
-impl Entropy32To8<'a> {
+impl<'a> Entropy32To8<'a> {
     pub fn new(egen: &'a dyn Entropy32<'a>) -> Entropy32To8<'a> {
         Entropy32To8 {
             egen: egen,
@@ -380,7 +380,7 @@ impl Entropy32To8<'a> {
     }
 }
 
-impl Entropy8<'a> for Entropy32To8<'a> {
+impl<'a> Entropy8<'a> for Entropy32To8<'a> {
     fn get(&self) -> ReturnCode {
         self.egen.get()
     }
@@ -403,7 +403,7 @@ impl Entropy8<'a> for Entropy32To8<'a> {
     }
 }
 
-impl entropy::Client32 for Entropy32To8<'a> {
+impl entropy::Client32 for Entropy32To8<'_> {
     fn entropy_available(
         &self,
         entropy: &mut dyn Iterator<Item = u32>,
@@ -429,7 +429,7 @@ impl entropy::Client32 for Entropy32To8<'a> {
 
 struct Entropy32To8Iter<'a, 'b: 'a>(&'a Entropy32To8<'b>);
 
-impl Iterator for Entropy32To8Iter<'a, 'b> {
+impl Iterator for Entropy32To8Iter<'_, '_> {
     type Item = u8;
 
     fn next(&mut self) -> Option<u8> {
@@ -454,7 +454,7 @@ pub struct SynchronousRandom<'a> {
 }
 
 #[allow(dead_code)]
-impl SynchronousRandom<'a> {
+impl<'a> SynchronousRandom<'a> {
     fn new(rgen: &'a dyn Rng<'a>) -> SynchronousRandom {
         SynchronousRandom {
             rgen: rgen,
@@ -463,7 +463,7 @@ impl SynchronousRandom<'a> {
     }
 }
 
-impl Random<'a> for SynchronousRandom<'a> {
+impl<'a> Random<'a> for SynchronousRandom<'a> {
     fn initialize(&'a self) {
         self.rgen.set_client(self);
         self.rgen.get();
@@ -489,7 +489,7 @@ impl Random<'a> for SynchronousRandom<'a> {
     }
 }
 
-impl Client for SynchronousRandom<'a> {
+impl Client for SynchronousRandom<'_> {
     fn randomness_available(
         &self,
         randomness: &mut dyn Iterator<Item = u32>,

--- a/capsules/src/sdcard.rs
+++ b/capsules/src/sdcard.rs
@@ -190,7 +190,7 @@ pub trait SDCardClient {
 }
 
 /// Functions for initializing and accessing an SD card
-impl<A: hil::time::Alarm<'a>> SDCard<'a, A> {
+impl<'a, A: hil::time::Alarm<'a>> SDCard<'a, A> {
     /// Create a new SD card interface
     ///
     /// spi - virtualized SPI to use for communication with SD card
@@ -1330,7 +1330,7 @@ impl<A: hil::time::Alarm<'a>> SDCard<'a, A> {
 }
 
 /// Handle callbacks from the SPI peripheral
-impl<A: hil::time::Alarm<'a>> hil::spi::SpiMasterClient for SDCard<'a, A> {
+impl<'a, A: hil::time::Alarm<'a>> hil::spi::SpiMasterClient for SDCard<'a, A> {
     fn read_write_done(
         &self,
         write_buffer: &'static mut [u8],
@@ -1345,14 +1345,14 @@ impl<A: hil::time::Alarm<'a>> hil::spi::SpiMasterClient for SDCard<'a, A> {
 }
 
 /// Handle callbacks from the timer
-impl<A: hil::time::Alarm<'a>> hil::time::AlarmClient for SDCard<'a, A> {
+impl<'a, A: hil::time::Alarm<'a>> hil::time::AlarmClient for SDCard<'a, A> {
     fn fired(&self) {
         self.process_alarm_states();
     }
 }
 
 /// Handle callbacks from the card detection pin
-impl<A: hil::time::Alarm<'a>> hil::gpio::Client for SDCard<'a, A> {
+impl<'a, A: hil::time::Alarm<'a>> hil::gpio::Client for SDCard<'a, A> {
     fn fired(&self) {
         // check if there was an open transaction with the sd card
         if self.alarm_state.get() != AlarmState::Idle || self.state.get() != SpiState::Idle {
@@ -1403,7 +1403,7 @@ struct App {
 pub static mut KERNEL_BUFFER: [u8; 512] = [0; 512];
 
 /// Functions for SDCardDriver
-impl<A: hil::time::Alarm<'a>> SDCardDriver<'a, A> {
+impl<'a, A: hil::time::Alarm<'a>> SDCardDriver<'a, A> {
     /// Create new SD card userland interface
     ///
     /// sdcard - SDCard interface to provide application access to
@@ -1423,7 +1423,7 @@ impl<A: hil::time::Alarm<'a>> SDCardDriver<'a, A> {
 }
 
 /// Handle callbacks from SDCard
-impl<A: hil::time::Alarm<'a>> SDCardClient for SDCardDriver<'a, A> {
+impl<'a, A: hil::time::Alarm<'a>> SDCardClient for SDCardDriver<'a, A> {
     fn card_detection_changed(&self, installed: bool) {
         self.app.map(|app| {
             app.callback.map(|mut cb| {
@@ -1488,7 +1488,7 @@ impl<A: hil::time::Alarm<'a>> SDCardClient for SDCardDriver<'a, A> {
 }
 
 /// Connections to userspace syscalls
-impl<A: hil::time::Alarm<'a>> Driver for SDCardDriver<'a, A> {
+impl<'a, A: hil::time::Alarm<'a>> Driver for SDCardDriver<'a, A> {
     fn allow(
         &self,
         _appid: AppId,

--- a/capsules/src/segger_rtt.rs
+++ b/capsules/src/segger_rtt.rs
@@ -128,7 +128,7 @@ pub struct SeggerRttBuffer<'a> {
     _lifetime: PhantomData<&'a [u8]>,
 }
 
-impl SeggerRttMemory<'a> {
+impl<'a> SeggerRttMemory<'a> {
     pub fn new_raw(
         up_buffer_name: &'a [u8],
         up_buffer_ptr: *const u8,
@@ -260,7 +260,7 @@ impl<'a, A: hil::time::Alarm<'a>> uart::Transmit<'a> for SeggerRtt<'a, A> {
     }
 }
 
-impl<A: hil::time::Alarm<'a>> hil::time::AlarmClient for SeggerRtt<'a, A> {
+impl<'a, A: hil::time::Alarm<'a>> hil::time::AlarmClient for SeggerRtt<'a, A> {
     fn fired(&self) {
         self.client.map(|client| {
             self.client_buffer.take().map(|buffer| {

--- a/capsules/src/si7021.rs
+++ b/capsules/src/si7021.rs
@@ -102,7 +102,7 @@ pub struct SI7021<'a, A: time::Alarm<'a>> {
     buffer: TakeCell<'static, [u8]>,
 }
 
-impl<A: time::Alarm<'a>> SI7021<'a, A> {
+impl<'a, A: time::Alarm<'a>> SI7021<'a, A> {
     pub fn new(
         i2c: &'a dyn i2c::I2CDevice,
         alarm: &'a A,
@@ -150,7 +150,7 @@ impl<A: time::Alarm<'a>> SI7021<'a, A> {
     }
 }
 
-impl<A: time::Alarm<'a>> i2c::I2CClient for SI7021<'a, A> {
+impl<'a, A: time::Alarm<'a>> i2c::I2CClient for SI7021<'a, A> {
     fn command_complete(&self, buffer: &'static mut [u8], _error: i2c::Error) {
         match self.state.get() {
             State::SelectElectronicId1 => {
@@ -237,7 +237,7 @@ impl<A: time::Alarm<'a>> i2c::I2CClient for SI7021<'a, A> {
     }
 }
 
-impl<A: time::Alarm<'a>> kernel::hil::sensors::TemperatureDriver for SI7021<'a, A> {
+impl<'a, A: time::Alarm<'a>> kernel::hil::sensors::TemperatureDriver for SI7021<'a, A> {
     fn read_temperature(&self) -> kernel::ReturnCode {
         self.buffer.take().map_or_else(
             || {
@@ -265,7 +265,7 @@ impl<A: time::Alarm<'a>> kernel::hil::sensors::TemperatureDriver for SI7021<'a, 
     }
 }
 
-impl<A: time::Alarm<'a>> kernel::hil::sensors::HumidityDriver for SI7021<'a, A> {
+impl<'a, A: time::Alarm<'a>> kernel::hil::sensors::HumidityDriver for SI7021<'a, A> {
     fn read_humidity(&self) -> kernel::ReturnCode {
         self.buffer.take().map_or_else(
             || {
@@ -293,7 +293,7 @@ impl<A: time::Alarm<'a>> kernel::hil::sensors::HumidityDriver for SI7021<'a, A> 
     }
 }
 
-impl<A: time::Alarm<'a>> time::AlarmClient for SI7021<'a, A> {
+impl<'a, A: time::Alarm<'a>> time::AlarmClient for SI7021<'a, A> {
     fn fired(&self) {
         self.buffer.take().map(|buffer| {
             // turn on i2c to send commands

--- a/capsules/src/spi.rs
+++ b/capsules/src/spi.rs
@@ -66,7 +66,7 @@ pub struct SpiSlave<'a, S: SpiSlaveDevice> {
     kernel_len: Cell<usize>,
 }
 
-impl<S: SpiMasterDevice> Spi<'a, S> {
+impl<'a, S: SpiMasterDevice> Spi<'a, S> {
     pub fn new(spi_master: &'a S) -> Spi<'a, S> {
         Spi {
             spi_master: spi_master,
@@ -108,7 +108,7 @@ impl<S: SpiMasterDevice> Spi<'a, S> {
     }
 }
 
-impl<S: SpiMasterDevice> Driver for Spi<'a, S> {
+impl<'a, S: SpiMasterDevice> Driver for Spi<'a, S> {
     fn allow(
         &self,
         _appid: AppId,
@@ -258,7 +258,7 @@ impl<S: SpiMasterDevice> Driver for Spi<'a, S> {
     }
 }
 
-impl<S: SpiMasterDevice> SpiMasterClient for Spi<'a, S> {
+impl<S: SpiMasterDevice> SpiMasterClient for Spi<'_, S> {
     fn read_write_done(
         &self,
         writebuf: &'static mut [u8],
@@ -295,7 +295,7 @@ impl<S: SpiMasterDevice> SpiMasterClient for Spi<'a, S> {
     }
 }
 
-impl<S: SpiSlaveDevice> SpiSlave<'a, S> {
+impl<'a, S: SpiSlaveDevice> SpiSlave<'a, S> {
     pub fn new(spi_slave: &'a S) -> SpiSlave<'a, S> {
         SpiSlave {
             spi_slave: spi_slave,
@@ -334,7 +334,7 @@ impl<S: SpiSlaveDevice> SpiSlave<'a, S> {
     }
 }
 
-impl<S: SpiSlaveDevice> Driver for SpiSlave<'a, S> {
+impl<S: SpiSlaveDevice> Driver for SpiSlave<'_, S> {
     /// Provide read/write buffers to SpiSlave
     ///
     /// - allow_num 0: Provides an app_read buffer to receive transfers into.
@@ -475,7 +475,7 @@ impl<S: SpiSlaveDevice> Driver for SpiSlave<'a, S> {
     }
 }
 
-impl<S: SpiSlaveDevice> SpiSlaveClient for SpiSlave<'a, S> {
+impl<S: SpiSlaveDevice> SpiSlaveClient for SpiSlave<'_, S> {
     fn read_write_done(
         &self,
         writebuf: Option<&'static mut [u8]>,

--- a/capsules/src/temperature.rs
+++ b/capsules/src/temperature.rs
@@ -71,7 +71,7 @@ pub struct TemperatureSensor<'a> {
     busy: Cell<bool>,
 }
 
-impl TemperatureSensor<'a> {
+impl<'a> TemperatureSensor<'a> {
     pub fn new(
         driver: &'a dyn hil::sensors::TemperatureDriver,
         grant: Grant<App>,
@@ -107,7 +107,7 @@ impl TemperatureSensor<'a> {
     }
 }
 
-impl hil::sensors::TemperatureClient for TemperatureSensor<'a> {
+impl hil::sensors::TemperatureClient for TemperatureSensor<'_> {
     fn callback(&self, temp_val: usize) {
         for cntr in self.apps.iter() {
             cntr.enter(|app, _| {
@@ -121,7 +121,7 @@ impl hil::sensors::TemperatureClient for TemperatureSensor<'a> {
     }
 }
 
-impl Driver for TemperatureSensor<'a> {
+impl Driver for TemperatureSensor<'_> {
     fn subscribe(
         &self,
         subscribe_num: usize,

--- a/capsules/src/test/aes.rs
+++ b/capsules/src/test/aes.rs
@@ -47,7 +47,7 @@ pub struct TestAes128Ecb<'a, A: 'a> {
 const DATA_OFFSET: usize = AES128_BLOCK_SIZE;
 const DATA_LEN: usize = 4 * AES128_BLOCK_SIZE;
 
-impl<A: AES128<'a> + AES128ECB> TestAes128Ecb<'a, A> {
+impl<'a, A: AES128<'a> + AES128ECB> TestAes128Ecb<'a, A> {
     pub fn new(aes: &'a A, key: &'a mut [u8], source: &'a mut [u8], data: &'a mut [u8]) -> Self {
         TestAes128Ecb {
             aes: aes,
@@ -130,7 +130,7 @@ impl<A: AES128<'a> + AES128ECB> TestAes128Ecb<'a, A> {
     }
 }
 
-impl<A: AES128<'a> + AES128Ctr> TestAes128Ctr<'a, A> {
+impl<'a, A: AES128<'a> + AES128Ctr> TestAes128Ctr<'a, A> {
     pub fn new(
         aes: &'a A,
         key: &'a mut [u8],
@@ -230,7 +230,7 @@ impl<A: AES128<'a> + AES128Ctr> TestAes128Ctr<'a, A> {
     }
 }
 
-impl<A: AES128<'a> + AES128Ctr> hil::symmetric_encryption::Client<'a> for TestAes128Ctr<'a, A> {
+impl<'a, A: AES128<'a> + AES128Ctr> hil::symmetric_encryption::Client<'a> for TestAes128Ctr<'a, A> {
     fn crypt_done(&'a self, source: Option<&'a mut [u8]>, dest: &'a mut [u8]) {
         if self.use_source.get() {
             // Take back the source buffer
@@ -281,7 +281,7 @@ impl<A: AES128<'a> + AES128Ctr> hil::symmetric_encryption::Client<'a> for TestAe
     }
 }
 
-impl<A: AES128<'a> + AES128CBC> TestAes128Cbc<'a, A> {
+impl<'a, A: AES128<'a> + AES128CBC> TestAes128Cbc<'a, A> {
     pub fn new(
         aes: &'a A,
         key: &'a mut [u8],
@@ -382,7 +382,7 @@ impl<A: AES128<'a> + AES128CBC> TestAes128Cbc<'a, A> {
     }
 }
 
-impl<A: AES128<'a> + AES128CBC> hil::symmetric_encryption::Client<'a> for TestAes128Cbc<'a, A> {
+impl<'a, A: AES128<'a> + AES128CBC> hil::symmetric_encryption::Client<'a> for TestAes128Cbc<'a, A> {
     fn crypt_done(&'a self, source: Option<&'a mut [u8]>, dest: &'a mut [u8]) {
         if self.use_source.get() {
             // Take back the source buffer
@@ -437,7 +437,7 @@ impl<A: AES128<'a> + AES128CBC> hil::symmetric_encryption::Client<'a> for TestAe
     }
 }
 
-impl<A: AES128<'a> + AES128ECB> hil::symmetric_encryption::Client<'a> for TestAes128Ecb<'a, A> {
+impl<'a, A: AES128<'a> + AES128ECB> hil::symmetric_encryption::Client<'a> for TestAes128Ecb<'a, A> {
     fn crypt_done(&'a self, source: Option<&'a mut [u8]>, dest: &'a mut [u8]) {
         if self.use_source.get() {
             // Take back the source buffer

--- a/capsules/src/test/aes_ccm.rs
+++ b/capsules/src/test/aes_ccm.rs
@@ -24,7 +24,7 @@ pub struct Test<'a, A: AES128CCM<'a>> {
     ); 3],
 }
 
-impl<A: AES128CCM<'a>> Test<'a, A> {
+impl<'a, A: AES128CCM<'a>> Test<'a, A> {
     pub fn new(aes_ccm: &'a A, buf: &'static mut [u8]) -> Test<'a, A> {
         Test {
             aes_ccm: aes_ccm,
@@ -185,7 +185,7 @@ impl<A: AES128CCM<'a>> Test<'a, A> {
     }
 }
 
-impl<A: AES128CCM<'a>> CCMClient for Test<'a, A> {
+impl<'a, A: AES128CCM<'a>> CCMClient for Test<'a, A> {
     fn crypt_done(&self, buf: &'static mut [u8], res: ReturnCode, tag_is_valid: bool) {
         self.buf.replace(buf);
         if res != ReturnCode::SUCCESS {

--- a/capsules/src/test/alarm.rs
+++ b/capsules/src/test/alarm.rs
@@ -12,7 +12,7 @@ pub struct TestAlarm<'a, A: Alarm<'a>> {
     ms: Cell<u32>,
 }
 
-impl<A: Alarm<'a>> TestAlarm<'a, A> {
+impl<'a, A: Alarm<'a>> TestAlarm<'a, A> {
     pub fn new(alarm: &'a A) -> TestAlarm<'a, A> {
         TestAlarm {
             alarm: alarm,
@@ -38,7 +38,7 @@ impl<A: Alarm<'a>> TestAlarm<'a, A> {
     }
 }
 
-impl<A: Alarm<'a>> AlarmClient for TestAlarm<'a, A> {
+impl<'a, A: Alarm<'a>> AlarmClient for TestAlarm<'a, A> {
     fn fired(&self) {
         // Generate a new interval that's irregular
         let new_ms: u32 = 10 + ((self.ms.get() + 137) % 757);

--- a/capsules/src/tmp006.rs
+++ b/capsules/src/tmp006.rs
@@ -106,7 +106,7 @@ pub struct TMP006<'a> {
     buffer: TakeCell<'static, [u8]>,
 }
 
-impl TMP006<'a> {
+impl<'a> TMP006<'a> {
     /// The `interrupt_pin` must be pulled-up since the TMP006 is open-drain.
     pub fn new(
         i2c: &'a dyn i2c::I2CDevice,
@@ -190,7 +190,7 @@ fn calculate_temperature(sensor_voltage: i16, die_temperature: i16) -> f32 {
     t_celsius
 }
 
-impl i2c::I2CClient for TMP006<'a> {
+impl i2c::I2CClient for TMP006<'_> {
     fn command_complete(&self, buffer: &'static mut [u8], _error: i2c::Error) {
         // TODO(alevy): handle protocol errors
         match self.protocol_state.get() {
@@ -256,7 +256,7 @@ impl i2c::I2CClient for TMP006<'a> {
     }
 }
 
-impl gpio::Client for TMP006<'a> {
+impl gpio::Client for TMP006<'_> {
     fn fired(&self) {
         self.buffer.take().map(|buf| {
             // turn on i2c to send commands
@@ -270,7 +270,7 @@ impl gpio::Client for TMP006<'a> {
     }
 }
 
-impl Driver for TMP006<'a> {
+impl Driver for TMP006<'_> {
     fn subscribe(
         &self,
         subscribe_num: usize,

--- a/capsules/src/tsl2561.rs
+++ b/capsules/src/tsl2561.rs
@@ -209,7 +209,7 @@ pub struct TSL2561<'a> {
     buffer: TakeCell<'static, [u8]>,
 }
 
-impl TSL2561<'a> {
+impl<'a> TSL2561<'a> {
     pub fn new(
         i2c: &'a dyn i2c::I2CDevice,
         interrupt_pin: &'a dyn gpio::InterruptPin,
@@ -345,7 +345,7 @@ impl TSL2561<'a> {
     }
 }
 
-impl i2c::I2CClient for TSL2561<'a> {
+impl i2c::I2CClient for TSL2561<'_> {
     fn command_complete(&self, buffer: &'static mut [u8], _error: i2c::Error) {
         match self.state.get() {
             State::SelectId => {
@@ -422,7 +422,7 @@ impl i2c::I2CClient for TSL2561<'a> {
     }
 }
 
-impl gpio::Client for TSL2561<'a> {
+impl gpio::Client for TSL2561<'_> {
     fn fired(&self) {
         self.buffer.take().map(|buffer| {
             // turn on i2c to send commands
@@ -436,7 +436,7 @@ impl gpio::Client for TSL2561<'a> {
     }
 }
 
-impl Driver for TSL2561<'a> {
+impl Driver for TSL2561<'_> {
     fn subscribe(
         &self,
         subscribe_num: usize,

--- a/capsules/src/usb/descriptors.rs
+++ b/capsules/src/usb/descriptors.rs
@@ -571,7 +571,7 @@ pub struct HIDSubordinateDescriptor {
     pub len: u16,
 }
 
-impl Descriptor for HIDDescriptor<'a> {
+impl Descriptor for HIDDescriptor<'_> {
     fn size(&self) -> usize {
         6 + (3 * self.sub_descriptors.len())
     }
@@ -595,7 +595,7 @@ pub struct ReportDescriptor<'a> {
     pub desc: &'a [u8],
 }
 
-impl Descriptor for ReportDescriptor<'a> {
+impl Descriptor for ReportDescriptor<'_> {
     fn size(&self) -> usize {
         self.desc.len()
     }
@@ -612,7 +612,7 @@ pub struct LanguagesDescriptor<'a> {
     pub langs: &'a [u16],
 }
 
-impl Descriptor for LanguagesDescriptor<'a> {
+impl Descriptor for LanguagesDescriptor<'_> {
     fn size(&self) -> usize {
         2 + (2 * self.langs.len())
     }
@@ -632,7 +632,7 @@ pub struct StringDescriptor<'a> {
     pub string: &'a str,
 }
 
-impl Descriptor for StringDescriptor<'a> {
+impl Descriptor for StringDescriptor<'_> {
     fn size(&self) -> usize {
         let mut len = 2;
         for ch in self.string.chars() {

--- a/capsules/src/usb/usb_user.rs
+++ b/capsules/src/usb/usb_user.rs
@@ -43,7 +43,7 @@ pub struct UsbSyscallDriver<'a, C: hil::usb::Client<'a>> {
     serving_app: OptionalCell<AppId>,
 }
 
-impl<C> UsbSyscallDriver<'a, C>
+impl<'a, C> UsbSyscallDriver<'a, C>
 where
     C: hil::usb::Client<'a>,
 {

--- a/capsules/src/virtual_alarm.rs
+++ b/capsules/src/virtual_alarm.rs
@@ -14,13 +14,13 @@ pub struct VirtualMuxAlarm<'a, A: Alarm<'a>> {
     client: OptionalCell<&'a dyn time::AlarmClient>,
 }
 
-impl<A: Alarm<'a>> ListNode<'a, VirtualMuxAlarm<'a, A>> for VirtualMuxAlarm<'a, A> {
+impl<'a, A: Alarm<'a>> ListNode<'a, VirtualMuxAlarm<'a, A>> for VirtualMuxAlarm<'a, A> {
     fn next(&self) -> &'a ListLink<VirtualMuxAlarm<'a, A>> {
         &self.next
     }
 }
 
-impl<A: Alarm<'a>> VirtualMuxAlarm<'a, A> {
+impl<'a, A: Alarm<'a>> VirtualMuxAlarm<'a, A> {
     pub fn new(mux_alarm: &'a MuxAlarm<'a, A>) -> VirtualMuxAlarm<'a, A> {
         VirtualMuxAlarm {
             mux: mux_alarm,
@@ -32,7 +32,7 @@ impl<A: Alarm<'a>> VirtualMuxAlarm<'a, A> {
     }
 }
 
-impl<A: Alarm<'a>> Time for VirtualMuxAlarm<'a, A> {
+impl<'a, A: Alarm<'a>> Time for VirtualMuxAlarm<'a, A> {
     type Frequency = A::Frequency;
 
     fn max_tics(&self) -> u32 {
@@ -44,7 +44,7 @@ impl<A: Alarm<'a>> Time for VirtualMuxAlarm<'a, A> {
     }
 }
 
-impl<A: Alarm<'a>> Alarm<'a> for VirtualMuxAlarm<'a, A> {
+impl<'a, A: Alarm<'a>> Alarm<'a> for VirtualMuxAlarm<'a, A> {
     fn set_client(&'a self, client: &'a dyn time::AlarmClient) {
         self.mux.virtual_alarms.push_head(self);
         self.when.set(0);
@@ -102,7 +102,7 @@ impl<A: Alarm<'a>> Alarm<'a> for VirtualMuxAlarm<'a, A> {
     }
 }
 
-impl<A: Alarm<'a>> time::AlarmClient for VirtualMuxAlarm<'a, A> {
+impl<'a, A: Alarm<'a>> time::AlarmClient for VirtualMuxAlarm<'a, A> {
     fn fired(&self) {
         self.client.map(|client| client.fired());
     }
@@ -117,7 +117,7 @@ pub struct MuxAlarm<'a, A: Alarm<'a>> {
     alarm: &'a A,
 }
 
-impl<A: Alarm<'a>> MuxAlarm<'a, A> {
+impl<'a, A: Alarm<'a>> MuxAlarm<'a, A> {
     pub const fn new(alarm: &'a A) -> MuxAlarm<'a, A> {
         MuxAlarm {
             virtual_alarms: List::new(),
@@ -132,7 +132,7 @@ fn has_expired(alarm: u32, now: u32, prev: u32) -> bool {
     now.wrapping_sub(prev) >= alarm.wrapping_sub(prev)
 }
 
-impl<A: Alarm<'a>> time::AlarmClient for MuxAlarm<'a, A> {
+impl<'a, A: Alarm<'a>> time::AlarmClient for MuxAlarm<'a, A> {
     fn fired(&self) {
         let now = self.alarm.now();
 

--- a/capsules/src/virtual_digest.rs
+++ b/capsules/src/virtual_digest.rs
@@ -17,7 +17,7 @@ pub struct VirtualMuxDigest<'a, A: digest::Digest<'a, T>, T: DigestType> {
     id: u32,
 }
 
-impl<A: digest::Digest<'a, T>, T: DigestType> ListNode<'a, VirtualMuxDigest<'a, A, T>>
+impl<'a, A: digest::Digest<'a, T>, T: DigestType> ListNode<'a, VirtualMuxDigest<'a, A, T>>
     for VirtualMuxDigest<'a, A, T>
 {
     fn next(&self) -> &'a ListLink<VirtualMuxDigest<'a, A, T>> {
@@ -25,7 +25,7 @@ impl<A: digest::Digest<'a, T>, T: DigestType> ListNode<'a, VirtualMuxDigest<'a, 
     }
 }
 
-impl<A: digest::Digest<'a, T>, T: DigestType> VirtualMuxDigest<'a, A, T> {
+impl<'a, A: digest::Digest<'a, T>, T: DigestType> VirtualMuxDigest<'a, A, T> {
     pub fn new(mux_digest: &'a MuxDigest<'a, A, T>) -> VirtualMuxDigest<'a, A, T> {
         let id = mux_digest.next_id.get();
         mux_digest.next_id.set(id + 1);
@@ -39,7 +39,9 @@ impl<A: digest::Digest<'a, T>, T: DigestType> VirtualMuxDigest<'a, A, T> {
     }
 }
 
-impl<A: digest::Digest<'a, T>, T: DigestType> digest::Digest<'a, T> for VirtualMuxDigest<'a, A, T> {
+impl<'a, A: digest::Digest<'a, T>, T: DigestType> digest::Digest<'a, T>
+    for VirtualMuxDigest<'a, A, T>
+{
     /// Set the client instance which will receive `add_data_done()` and
     /// `hash_done()` callbacks
     fn set_client(&'a self, client: &'a dyn digest::Client<'a, T>) {
@@ -91,7 +93,9 @@ impl<A: digest::Digest<'a, T>, T: DigestType> digest::Digest<'a, T> for VirtualM
     }
 }
 
-impl<A: digest::Digest<'a, T>, T: DigestType> digest::Client<'a, T> for VirtualMuxDigest<'a, A, T> {
+impl<'a, A: digest::Digest<'a, T>, T: DigestType> digest::Client<'a, T>
+    for VirtualMuxDigest<'a, A, T>
+{
     fn add_data_done(&'a self, result: Result<(), ReturnCode>, data: &'static mut [u8]) {
         self.client
             .map(move |client| client.add_data_done(result, data));
@@ -103,7 +107,7 @@ impl<A: digest::Digest<'a, T>, T: DigestType> digest::Client<'a, T> for VirtualM
     }
 }
 
-impl<A: digest::Digest<'a, T> + digest::HMACSha256, T: DigestType> digest::HMACSha256
+impl<'a, A: digest::Digest<'a, T> + digest::HMACSha256, T: DigestType> digest::HMACSha256
     for VirtualMuxDigest<'a, A, T>
 {
     fn set_mode_hmacsha256(&self, key: &[u8; 32]) -> Result<(), ReturnCode> {
@@ -132,7 +136,7 @@ pub struct MuxDigest<'a, A: digest::Digest<'a, T>, T: DigestType> {
     phantom: PhantomData<&'a T>,
 }
 
-impl<A: digest::Digest<'a, T>, T: DigestType> MuxDigest<'a, A, T> {
+impl<'a, A: digest::Digest<'a, T>, T: DigestType> MuxDigest<'a, A, T> {
     pub const fn new(digest: &'a A) -> MuxDigest<'a, A, T> {
         MuxDigest {
             digest: digest,

--- a/capsules/src/virtual_hmac.rs
+++ b/capsules/src/virtual_hmac.rs
@@ -17,7 +17,7 @@ pub struct VirtualMuxHmac<'a, A: digest::Digest<'a, T>, T: DigestType> {
     id: u32,
 }
 
-impl<A: digest::Digest<'a, T>, T: DigestType> ListNode<'a, VirtualMuxHmac<'a, A, T>>
+impl<'a, A: digest::Digest<'a, T>, T: DigestType> ListNode<'a, VirtualMuxHmac<'a, A, T>>
     for VirtualMuxHmac<'a, A, T>
 {
     fn next(&self) -> &'a ListLink<VirtualMuxHmac<'a, A, T>> {
@@ -25,7 +25,7 @@ impl<A: digest::Digest<'a, T>, T: DigestType> ListNode<'a, VirtualMuxHmac<'a, A,
     }
 }
 
-impl<A: digest::Digest<'a, T>, T: DigestType> VirtualMuxHmac<'a, A, T> {
+impl<'a, A: digest::Digest<'a, T>, T: DigestType> VirtualMuxHmac<'a, A, T> {
     pub fn new(mux_hmac: &'a MuxHmac<'a, A, T>) -> VirtualMuxHmac<'a, A, T> {
         let id = mux_hmac.next_id.get();
         mux_hmac.next_id.set(id + 1);
@@ -39,7 +39,9 @@ impl<A: digest::Digest<'a, T>, T: DigestType> VirtualMuxHmac<'a, A, T> {
     }
 }
 
-impl<A: digest::Digest<'a, T>, T: DigestType> digest::Digest<'a, T> for VirtualMuxHmac<'a, A, T> {
+impl<'a, A: digest::Digest<'a, T>, T: DigestType> digest::Digest<'a, T>
+    for VirtualMuxHmac<'a, A, T>
+{
     /// Set the client instance which will receive `add_data_done()` and
     /// `hash_done()` callbacks
     fn set_client(&'a self, client: &'a dyn digest::Client<'a, T>) {
@@ -91,7 +93,9 @@ impl<A: digest::Digest<'a, T>, T: DigestType> digest::Digest<'a, T> for VirtualM
     }
 }
 
-impl<A: digest::Digest<'a, T>, T: DigestType> digest::Client<'a, T> for VirtualMuxHmac<'a, A, T> {
+impl<'a, A: digest::Digest<'a, T>, T: DigestType> digest::Client<'a, T>
+    for VirtualMuxHmac<'a, A, T>
+{
     fn add_data_done(&'a self, result: Result<(), ReturnCode>, data: &'static mut [u8]) {
         self.client
             .map(move |client| client.add_data_done(result, data));
@@ -103,7 +107,7 @@ impl<A: digest::Digest<'a, T>, T: DigestType> digest::Client<'a, T> for VirtualM
     }
 }
 
-impl<A: digest::Digest<'a, T> + digest::HMACSha256, T: DigestType> digest::HMACSha256
+impl<'a, A: digest::Digest<'a, T> + digest::HMACSha256, T: DigestType> digest::HMACSha256
     for VirtualMuxHmac<'a, A, T>
 {
     fn set_mode_hmacsha256(&self, key: &[u8; 32]) -> Result<(), ReturnCode> {
@@ -128,7 +132,7 @@ pub struct MuxHmac<'a, A: digest::Digest<'a, T>, T: DigestType> {
     phantom: PhantomData<&'a T>,
 }
 
-impl<A: digest::Digest<'a, T>, T: DigestType> MuxHmac<'a, A, T> {
+impl<'a, A: digest::Digest<'a, T>, T: DigestType> MuxHmac<'a, A, T> {
     pub const fn new(hmac: &'a A) -> MuxHmac<'a, A, T> {
         MuxHmac {
             hmac,

--- a/capsules/src/virtual_i2c.rs
+++ b/capsules/src/virtual_i2c.rs
@@ -15,7 +15,7 @@ pub struct MuxI2C<'a> {
     inflight: OptionalCell<&'a I2CDevice<'a>>,
 }
 
-impl I2CHwMasterClient for MuxI2C<'a> {
+impl I2CHwMasterClient for MuxI2C<'_> {
     fn command_complete(&self, buffer: &'static mut [u8], error: Error) {
         self.inflight.take().map(move |device| {
             device.command_complete(buffer, error);
@@ -24,7 +24,7 @@ impl I2CHwMasterClient for MuxI2C<'a> {
     }
 }
 
-impl MuxI2C<'a> {
+impl<'a> MuxI2C<'a> {
     pub const fn new(i2c: &'a dyn i2c::I2CMaster) -> MuxI2C<'a> {
         MuxI2C {
             i2c: i2c,
@@ -92,7 +92,7 @@ pub struct I2CDevice<'a> {
     client: OptionalCell<&'a dyn I2CClient>,
 }
 
-impl I2CDevice<'a> {
+impl<'a> I2CDevice<'a> {
     pub const fn new(mux: &'a MuxI2C<'a>, addr: u8) -> I2CDevice<'a> {
         I2CDevice {
             mux: mux,
@@ -111,7 +111,7 @@ impl I2CDevice<'a> {
     }
 }
 
-impl I2CClient for I2CDevice<'a> {
+impl I2CClient for I2CDevice<'_> {
     fn command_complete(&self, buffer: &'static mut [u8], error: Error) {
         self.client.map(move |client| {
             client.command_complete(buffer, error);
@@ -119,13 +119,13 @@ impl I2CClient for I2CDevice<'a> {
     }
 }
 
-impl ListNode<'a, I2CDevice<'a>> for I2CDevice<'a> {
+impl<'a> ListNode<'a, I2CDevice<'a>> for I2CDevice<'a> {
     fn next(&'a self) -> &'a ListLink<'a, I2CDevice<'a>> {
         &self.next
     }
 }
 
-impl i2c::I2CDevice for I2CDevice<'a> {
+impl i2c::I2CDevice for I2CDevice<'_> {
     fn enable(&self) {
         if !self.enabled.get() {
             self.enabled.set(true);

--- a/capsules/src/virtual_pwm.rs
+++ b/capsules/src/virtual_pwm.rs
@@ -29,7 +29,7 @@ pub struct MuxPwm<'a, P: hil::pwm::Pwm> {
     inflight: OptionalCell<&'a PwmPinUser<'a, P>>,
 }
 
-impl<P: hil::pwm::Pwm> MuxPwm<'a, P> {
+impl<'a, P: hil::pwm::Pwm> MuxPwm<'a, P> {
     pub const fn new(pwm: &'a P) -> MuxPwm<'a, P> {
         MuxPwm {
             pwm: pwm,
@@ -109,7 +109,7 @@ pub struct PwmPinUser<'a, P: hil::pwm::Pwm> {
     next: ListLink<'a, PwmPinUser<'a, P>>,
 }
 
-impl<P: hil::pwm::Pwm> PwmPinUser<'a, P> {
+impl<'a, P: hil::pwm::Pwm> PwmPinUser<'a, P> {
     pub const fn new(mux: &'a MuxPwm<'a, P>, pin: P::Pin) -> PwmPinUser<'a, P> {
         PwmPinUser {
             mux: mux,
@@ -124,13 +124,13 @@ impl<P: hil::pwm::Pwm> PwmPinUser<'a, P> {
     }
 }
 
-impl<P: hil::pwm::Pwm> ListNode<'a, PwmPinUser<'a, P>> for PwmPinUser<'a, P> {
+impl<'a, P: hil::pwm::Pwm> ListNode<'a, PwmPinUser<'a, P>> for PwmPinUser<'a, P> {
     fn next(&'a self) -> &'a ListLink<'a, PwmPinUser<'a, P>> {
         &self.next
     }
 }
 
-impl<P: hil::pwm::Pwm> hil::pwm::PwmPin for PwmPinUser<'a, P> {
+impl<P: hil::pwm::Pwm> hil::pwm::PwmPin for PwmPinUser<'_, P> {
     fn start(&self, frequency_hz: usize, duty_cycle: usize) -> ReturnCode {
         self.operation.set(Operation::Simple {
             frequency_hz,

--- a/capsules/src/virtual_spi.rs
+++ b/capsules/src/virtual_spi.rs
@@ -14,7 +14,7 @@ pub struct MuxSpiMaster<'a, Spi: hil::spi::SpiMaster> {
     inflight: OptionalCell<&'a VirtualSpiMasterDevice<'a, Spi>>,
 }
 
-impl<Spi: hil::spi::SpiMaster> hil::spi::SpiMasterClient for MuxSpiMaster<'a, Spi> {
+impl<Spi: hil::spi::SpiMaster> hil::spi::SpiMasterClient for MuxSpiMaster<'_, Spi> {
     fn read_write_done(
         &self,
         write_buffer: &'static mut [u8],
@@ -28,7 +28,7 @@ impl<Spi: hil::spi::SpiMaster> hil::spi::SpiMasterClient for MuxSpiMaster<'a, Sp
     }
 }
 
-impl<Spi: hil::spi::SpiMaster> MuxSpiMaster<'a, Spi> {
+impl<'a, Spi: hil::spi::SpiMaster> MuxSpiMaster<'a, Spi> {
     pub const fn new(spi: &'a Spi) -> MuxSpiMaster<'a, Spi> {
         MuxSpiMaster {
             spi: spi,
@@ -101,7 +101,7 @@ pub struct VirtualSpiMasterDevice<'a, Spi: hil::spi::SpiMaster> {
     client: OptionalCell<&'a dyn hil::spi::SpiMasterClient>,
 }
 
-impl<Spi: hil::spi::SpiMaster> VirtualSpiMasterDevice<'a, Spi> {
+impl<'a, Spi: hil::spi::SpiMaster> VirtualSpiMasterDevice<'a, Spi> {
     pub const fn new(
         mux: &'a MuxSpiMaster<'a, Spi>,
         chip_select: Spi::ChipSelect,
@@ -123,7 +123,7 @@ impl<Spi: hil::spi::SpiMaster> VirtualSpiMasterDevice<'a, Spi> {
     }
 }
 
-impl<Spi: hil::spi::SpiMaster> hil::spi::SpiMasterClient for VirtualSpiMasterDevice<'a, Spi> {
+impl<Spi: hil::spi::SpiMaster> hil::spi::SpiMasterClient for VirtualSpiMasterDevice<'_, Spi> {
     fn read_write_done(
         &self,
         write_buffer: &'static mut [u8],
@@ -136,7 +136,7 @@ impl<Spi: hil::spi::SpiMaster> hil::spi::SpiMasterClient for VirtualSpiMasterDev
     }
 }
 
-impl<Spi: hil::spi::SpiMaster> ListNode<'a, VirtualSpiMasterDevice<'a, Spi>>
+impl<'a, Spi: hil::spi::SpiMaster> ListNode<'a, VirtualSpiMasterDevice<'a, Spi>>
     for VirtualSpiMasterDevice<'a, Spi>
 {
     fn next(&'a self) -> &'a ListLink<'a, VirtualSpiMasterDevice<'a, Spi>> {
@@ -144,7 +144,7 @@ impl<Spi: hil::spi::SpiMaster> ListNode<'a, VirtualSpiMasterDevice<'a, Spi>>
     }
 }
 
-impl<Spi: hil::spi::SpiMaster> hil::spi::SpiMasterDevice for VirtualSpiMasterDevice<'a, Spi> {
+impl<Spi: hil::spi::SpiMaster> hil::spi::SpiMasterDevice for VirtualSpiMasterDevice<'_, Spi> {
     fn configure(&self, cpol: hil::spi::ClockPolarity, cpal: hil::spi::ClockPhase, rate: u32) {
         self.operation.set(Op::Configure(cpol, cpal, rate));
         self.mux.do_next_op();
@@ -196,7 +196,7 @@ pub struct VirtualSpiSlaveDevice<'a, Spi: hil::spi::SpiSlave> {
     client: OptionalCell<&'a dyn hil::spi::SpiSlaveClient>,
 }
 
-impl<Spi: hil::spi::SpiSlave> VirtualSpiSlaveDevice<'a, Spi> {
+impl<'a, Spi: hil::spi::SpiSlave> VirtualSpiSlaveDevice<'a, Spi> {
     pub const fn new(spi: &'a Spi) -> VirtualSpiSlaveDevice<'a, Spi> {
         VirtualSpiSlaveDevice {
             spi: spi,
@@ -209,7 +209,7 @@ impl<Spi: hil::spi::SpiSlave> VirtualSpiSlaveDevice<'a, Spi> {
     }
 }
 
-impl<Spi: hil::spi::SpiSlave> hil::spi::SpiSlaveClient for VirtualSpiSlaveDevice<'a, Spi> {
+impl<Spi: hil::spi::SpiSlave> hil::spi::SpiSlaveClient for VirtualSpiSlaveDevice<'_, Spi> {
     fn read_write_done(
         &self,
         write_buffer: Option<&'static mut [u8]>,
@@ -228,7 +228,7 @@ impl<Spi: hil::spi::SpiSlave> hil::spi::SpiSlaveClient for VirtualSpiSlaveDevice
     }
 }
 
-impl<Spi: hil::spi::SpiSlave> hil::spi::SpiSlaveDevice for VirtualSpiSlaveDevice<'a, Spi> {
+impl<Spi: hil::spi::SpiSlave> hil::spi::SpiSlaveDevice for VirtualSpiSlaveDevice<'_, Spi> {
     fn configure(&self, cpol: hil::spi::ClockPolarity, cpal: hil::spi::ClockPhase) {
         self.spi.set_clock(cpol);
         self.spi.set_phase(cpal);

--- a/capsules/src/virtual_uart.rs
+++ b/capsules/src/virtual_uart.rs
@@ -330,7 +330,7 @@ pub struct UartDevice<'a> {
     tx_client: OptionalCell<&'a dyn uart::TransmitClient>,
 }
 
-impl uart::UartData<'a> for UartDevice<'a> {}
+impl<'a> uart::UartData<'a> for UartDevice<'a> {}
 
 impl<'a> UartDevice<'a> {
     pub const fn new(mux: &'a MuxUart<'a>, receiver: bool) -> UartDevice<'a> {

--- a/chips/apollo3/src/lib.rs
+++ b/chips/apollo3/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![crate_name = "apollo3"]
 #![crate_type = "rlib"]
-#![feature(asm, const_fn, in_band_lifetimes, naked_functions)]
+#![feature(asm, const_fn, naked_functions)]
 #![no_std]
 #![allow(unused_doc_comments)]
 

--- a/chips/apollo3/src/uart.rs
+++ b/chips/apollo3/src/uart.rs
@@ -178,9 +178,9 @@ pub struct UartParams {
     pub baud_rate: u32,
 }
 
-impl Uart<'a> {
-    pub const fn new(base: StaticRef<UartRegisters>) -> Uart<'a> {
-        Uart {
+impl Uart<'_> {
+    pub const fn new(base: StaticRef<UartRegisters>) -> Self {
+        Self {
             registers: base,
             clock_frequency: 24_000_000,
             tx_client: OptionalCell::empty(),
@@ -281,10 +281,10 @@ impl Uart<'a> {
     }
 }
 
-impl hil::uart::UartData<'a> for Uart<'a> {}
-impl hil::uart::Uart<'a> for Uart<'a> {}
+impl<'a> hil::uart::UartData<'a> for Uart<'a> {}
+impl<'a> hil::uart::Uart<'a> for Uart<'a> {}
 
-impl hil::uart::Configure for Uart<'a> {
+impl hil::uart::Configure for Uart<'_> {
     fn configure(&self, params: hil::uart::Parameters) -> ReturnCode {
         let regs = self.registers;
 
@@ -313,7 +313,7 @@ impl hil::uart::Configure for Uart<'a> {
     }
 }
 
-impl hil::uart::Transmit<'a> for Uart<'a> {
+impl<'a> hil::uart::Transmit<'a> for Uart<'a> {
     fn set_transmit_client(&self, client: &'a dyn hil::uart::TransmitClient) {
         self.tx_client.set(client);
     }
@@ -347,7 +347,7 @@ impl hil::uart::Transmit<'a> for Uart<'a> {
     }
 }
 
-impl hil::uart::Receive<'a> for Uart<'a> {
+impl<'a> hil::uart::Receive<'a> for Uart<'a> {
     fn set_receive_client(&self, client: &'a dyn hil::uart::ReceiveClient) {
         self.rx_client.set(client);
     }

--- a/chips/cc26x2/src/lib.rs
+++ b/chips/cc26x2/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(const_fn, in_band_lifetimes)]
+#![feature(const_fn)]
 #![no_std]
 #![crate_name = "cc26x2"]
 #![crate_type = "rlib"]

--- a/chips/cc26x2/src/rtc.rs
+++ b/chips/cc26x2/src/rtc.rs
@@ -67,8 +67,8 @@ pub struct Rtc<'a> {
 
 pub static mut RTC: Rtc<'static> = Rtc::new();
 
-impl Rtc<'a> {
-    const fn new() -> Rtc<'static> {
+impl<'a> Rtc<'a> {
+    const fn new() -> Rtc<'a> {
         Rtc {
             registers: RTC_BASE,
             callback: OptionalCell::empty(),
@@ -153,7 +153,7 @@ impl Frequency for RtcFreq {
     }
 }
 
-impl Time for Rtc<'a> {
+impl Time for Rtc<'_> {
     type Frequency = RtcFreq;
 
     fn now(&self) -> u32 {
@@ -165,7 +165,7 @@ impl Time for Rtc<'a> {
     }
 }
 
-impl Alarm<'a> for Rtc<'a> {
+impl<'a> Alarm<'a> for Rtc<'a> {
     fn set_client(&self, client: &'a dyn time::AlarmClient) {
         self.callback.set(client);
     }

--- a/chips/ibex/src/aes.rs
+++ b/chips/ibex/src/aes.rs
@@ -79,7 +79,7 @@ pub struct Aes<'a> {
     dest: TakeCell<'a, [u8]>,
 }
 
-impl Aes<'a> {
+impl<'a> Aes<'a> {
     const fn new() -> Aes<'a> {
         Aes {
             registers: AES_BASE,
@@ -275,7 +275,7 @@ impl Aes<'a> {
     }
 }
 
-impl hil::symmetric_encryption::AES128<'a> for Aes<'a> {
+impl<'a> hil::symmetric_encryption::AES128<'a> for Aes<'a> {
     fn enable(&self) {
         self.configure(true);
     }
@@ -343,7 +343,7 @@ impl hil::symmetric_encryption::AES128<'a> for Aes<'a> {
 
 pub static mut AES: Aes<'static> = Aes::new();
 
-impl kernel::hil::symmetric_encryption::AES128ECB for Aes<'a> {
+impl kernel::hil::symmetric_encryption::AES128ECB for Aes<'_> {
     fn set_mode_aes128ecb(&self, encrypting: bool) {
         self.configure(encrypting);
     }

--- a/chips/ibex/src/lib.rs
+++ b/chips/ibex/src/lib.rs
@@ -1,6 +1,6 @@
 //! Drivers and chip support for the Ibex soft core.
 
-#![feature(asm, const_fn, naked_functions, in_band_lifetimes)]
+#![feature(asm, const_fn, naked_functions)]
 #![no_std]
 #![crate_name = "ibex"]
 #![crate_type = "rlib"]

--- a/chips/ibex/src/timer.rs
+++ b/chips/ibex/src/timer.rs
@@ -57,7 +57,7 @@ pub struct RvTimer<'a> {
     client: OptionalCell<&'a dyn time::AlarmClient>,
 }
 
-impl RvTimer<'a> {
+impl<'a> RvTimer<'a> {
     const fn new(base: StaticRef<TimerRegisters>) -> RvTimer<'a> {
         RvTimer {
             registers: base,
@@ -86,7 +86,7 @@ impl RvTimer<'a> {
     }
 }
 
-impl time::Time for RvTimer<'a> {
+impl time::Time for RvTimer<'_> {
     type Frequency = Freq10KHz;
 
     fn now(&self) -> u32 {
@@ -97,7 +97,7 @@ impl time::Time for RvTimer<'a> {
     }
 }
 
-impl time::Alarm<'a> for RvTimer<'a> {
+impl<'a> time::Alarm<'a> for RvTimer<'a> {
     fn set_client(&self, client: &'a dyn time::AlarmClient) {
         self.client.set(client);
     }

--- a/chips/lowrisc/src/hmac.rs
+++ b/chips/lowrisc/src/hmac.rs
@@ -76,8 +76,8 @@ pub struct Hmac<'a> {
     digest: Cell<Option<&'static mut [u8; 32]>>,
 }
 
-impl Hmac<'a> {
-    pub const fn new(base: StaticRef<HmacRegisters>) -> Hmac<'a> {
+impl Hmac<'_> {
+    pub const fn new(base: StaticRef<HmacRegisters>) -> Self {
         Hmac {
             registers: base,
             client: OptionalCell::empty(),
@@ -187,7 +187,7 @@ impl Hmac<'a> {
     }
 }
 
-impl hil::digest::Digest<'a, [u8; 32]> for Hmac<'a> {
+impl<'a> hil::digest::Digest<'a, [u8; 32]> for Hmac<'a> {
     fn set_client(&'a self, client: &'a dyn digest::Client<'a, [u8; 32]>) {
         self.client.set(client);
     }
@@ -244,7 +244,7 @@ impl hil::digest::Digest<'a, [u8; 32]> for Hmac<'a> {
     }
 }
 
-impl hil::digest::HMACSha256 for Hmac<'a> {
+impl hil::digest::HMACSha256 for Hmac<'_> {
     fn set_mode_hmacsha256(&self, key: &[u8; 32]) -> Result<(), ReturnCode> {
         let regs = self.registers;
 

--- a/chips/lowrisc/src/lib.rs
+++ b/chips/lowrisc/src/lib.rs
@@ -1,6 +1,6 @@
 //! Implementations for generic LowRISC peripherals.
 
-#![feature(const_fn, in_band_lifetimes)]
+#![feature(const_fn)]
 #![no_std]
 #![crate_name = "lowrisc"]
 #![crate_type = "rlib"]

--- a/chips/lowrisc/src/uart.rs
+++ b/chips/lowrisc/src/uart.rs
@@ -117,7 +117,7 @@ pub struct UartParams {
     pub baud_rate: u32,
 }
 
-impl Uart<'a> {
+impl<'a> Uart<'a> {
     pub const fn new(base: StaticRef<UartRegisters>, clock_frequency: u32) -> Uart<'a> {
         Uart {
             registers: base,
@@ -258,10 +258,10 @@ impl Uart<'a> {
     }
 }
 
-impl hil::uart::UartData<'a> for Uart<'a> {}
-impl hil::uart::Uart<'a> for Uart<'a> {}
+impl<'a> hil::uart::UartData<'a> for Uart<'a> {}
+impl<'a> hil::uart::Uart<'a> for Uart<'a> {}
 
-impl hil::uart::Configure for Uart<'a> {
+impl hil::uart::Configure for Uart<'_> {
     fn configure(&self, params: hil::uart::Parameters) -> ReturnCode {
         let regs = self.registers;
         // We can set the baud rate.
@@ -277,7 +277,7 @@ impl hil::uart::Configure for Uart<'a> {
     }
 }
 
-impl hil::uart::Transmit<'a> for Uart<'a> {
+impl<'a> hil::uart::Transmit<'a> for Uart<'a> {
     fn set_transmit_client(&self, client: &'a dyn hil::uart::TransmitClient) {
         self.tx_client.set(client);
     }
@@ -312,7 +312,7 @@ impl hil::uart::Transmit<'a> for Uart<'a> {
 }
 
 /* UART receive is not implemented yet, mostly due to a lack of tests avaliable */
-impl hil::uart::Receive<'a> for Uart<'a> {
+impl<'a> hil::uart::Receive<'a> for Uart<'a> {
     fn set_receive_client(&self, client: &'a dyn hil::uart::ReceiveClient) {
         self.rx_client.set(client);
     }

--- a/chips/lowrisc/src/usbdev.rs
+++ b/chips/lowrisc/src/usbdev.rs
@@ -297,7 +297,7 @@ pub struct Usb<'a> {
     state: OptionalCell<State>,
 }
 
-impl Usb<'a> {
+impl<'a> Usb<'a> {
     pub const fn new(base: StaticRef<UsbRegisters>) -> Self {
         Usb {
             registers: base,
@@ -364,7 +364,7 @@ impl Usb<'a> {
     }
 }
 
-impl hil::usb::UsbController<'a> for Usb<'a> {
+impl<'a> hil::usb::UsbController<'a> for Usb<'a> {
     fn endpoint_set_ctrl_buffer(&self, buf: &'a [VolatileCell<u8>]) {
         self._endpoint_bank_set_buffer(0, buf);
     }

--- a/chips/nrf5x/src/aes.rs
+++ b/chips/nrf5x/src/aes.rs
@@ -134,7 +134,7 @@ pub struct AesECB<'a> {
 
 pub static mut AESECB: AesECB = AesECB::new();
 
-impl AesECB<'a> {
+impl<'a> AesECB<'a> {
     const fn new() -> AesECB<'a> {
         AesECB {
             registers: AESECB_BASE,
@@ -252,7 +252,7 @@ impl AesECB<'a> {
     }
 }
 
-impl kernel::hil::symmetric_encryption::AES128<'a> for AesECB<'a> {
+impl<'a> kernel::hil::symmetric_encryption::AES128<'a> for AesECB<'a> {
     fn enable(&self) {
         self.set_dma();
     }
@@ -331,20 +331,20 @@ impl kernel::hil::symmetric_encryption::AES128<'a> for AesECB<'a> {
     }
 }
 
-impl kernel::hil::symmetric_encryption::AES128Ctr for AesECB<'a> {
+impl kernel::hil::symmetric_encryption::AES128Ctr for AesECB<'_> {
     // not needed by NRF5x (the configuration is the same for encryption and decryption)
     fn set_mode_aes128ctr(&self, _encrypting: bool) {
         ()
     }
 }
 
-impl kernel::hil::symmetric_encryption::AES128CBC for AesECB<'a> {
+impl kernel::hil::symmetric_encryption::AES128CBC for AesECB<'_> {
     fn set_mode_aes128cbc(&self, _encrypting: bool) {
         ()
     }
 }
 //TODO: replace this placeholder with a proper implementation of the AES system
-impl kernel::hil::symmetric_encryption::AES128CCM<'a> for AesECB<'a> {
+impl<'a> kernel::hil::symmetric_encryption::AES128CCM<'a> for AesECB<'a> {
     /// Set the client instance which will receive `crypt_done()` callbacks
     fn set_client(&'a self, _client: &'a dyn kernel::hil::symmetric_encryption::CCMClient) {}
 

--- a/chips/nrf5x/src/lib.rs
+++ b/chips/nrf5x/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(const_fn, in_band_lifetimes)]
+#![feature(const_fn)]
 #![no_std]
 #![allow(unused_doc_comments)]
 

--- a/chips/nrf5x/src/rtc.rs
+++ b/chips/nrf5x/src/rtc.rs
@@ -92,7 +92,7 @@ pub static mut RTC: Rtc = Rtc {
     callback: OptionalCell::empty(),
 };
 
-impl Controller for Rtc<'a> {
+impl<'a> Controller for Rtc<'a> {
     type Config = &'a dyn time::AlarmClient;
 
     fn configure(&self, client: &'a dyn time::AlarmClient) {
@@ -105,7 +105,7 @@ impl Controller for Rtc<'a> {
     }
 }
 
-impl Rtc<'a> {
+impl<'a> Rtc<'a> {
     pub fn start(&self) {
         // This function takes a nontrivial amount of time
         // So it should only be called during initialization, not each tick
@@ -131,7 +131,7 @@ impl Rtc<'a> {
     }
 }
 
-impl Time for Rtc<'a> {
+impl Time for Rtc<'_> {
     type Frequency = Freq32KHz;
 
     fn now(&self) -> u32 {
@@ -143,7 +143,7 @@ impl Time for Rtc<'a> {
     }
 }
 
-impl Alarm<'a> for Rtc<'a> {
+impl<'a> Alarm<'a> for Rtc<'a> {
     fn set_client(&self, client: &'a dyn time::AlarmClient) {
         self.callback.set(client);
     }

--- a/chips/nrf5x/src/timer.rs
+++ b/chips/nrf5x/src/timer.rs
@@ -270,7 +270,7 @@ const ALARM_COMPARE: usize = 1;
 const ALARM_INTERRUPT_BIT: registers::Field<u32, Inte::Register> = Inte::COMPARE1;
 const ALARM_INTERRUPT_BIT_SET: registers::FieldValue<u32, Inte::Register> = Inte::COMPARE1::SET;
 
-impl TimerAlarm<'a> {
+impl<'a> TimerAlarm<'a> {
     const fn new(instance: usize) -> TimerAlarm<'a> {
         TimerAlarm {
             registers: INSTANCES[instance],
@@ -313,7 +313,7 @@ impl TimerAlarm<'a> {
     }
 }
 
-impl hil::time::Time for TimerAlarm<'a> {
+impl hil::time::Time for TimerAlarm<'_> {
     type Frequency = hil::time::Freq16KHz;
 
     fn now(&self) -> u32 {
@@ -325,7 +325,7 @@ impl hil::time::Time for TimerAlarm<'a> {
     }
 }
 
-impl hil::time::Alarm<'a> for TimerAlarm<'a> {
+impl<'a> hil::time::Alarm<'a> for TimerAlarm<'a> {
     fn set_client(&self, client: &'a dyn hil::time::AlarmClient) {
         self.client.set(client);
     }

--- a/chips/nrf5x/src/trng.rs
+++ b/chips/nrf5x/src/trng.rs
@@ -113,7 +113,7 @@ pub struct Trng<'a> {
 
 pub static mut TRNG: Trng<'static> = Trng::new();
 
-impl Trng<'a> {
+impl<'a> Trng<'a> {
     const fn new() -> Trng<'a> {
         Trng {
             registers: RNG_BASE,
@@ -191,7 +191,7 @@ impl Trng<'a> {
 
 struct TrngIter<'a, 'b: 'a>(&'a Trng<'b>);
 
-impl Iterator for TrngIter<'a, 'b> {
+impl Iterator for TrngIter<'_, '_> {
     type Item = u32;
 
     fn next(&mut self) -> Option<u32> {

--- a/chips/sam4l/src/aes.rs
+++ b/chips/sam4l/src/aes.rs
@@ -160,7 +160,7 @@ pub struct Aes<'a> {
     stop_index: Cell<usize>,
 }
 
-impl Aes<'a> {
+impl<'a> Aes<'a> {
     const fn new() -> Aes<'a> {
         Aes {
             registers: AES_BASE,
@@ -403,7 +403,7 @@ impl Aes<'a> {
     }
 }
 
-impl hil::symmetric_encryption::AES128<'a> for Aes<'a> {
+impl<'a> hil::symmetric_encryption::AES128<'a> for Aes<'a> {
     fn enable(&self) {
         let regs: &AesRegisters = &*self.registers;
         self.enable_clock();
@@ -502,13 +502,13 @@ impl hil::symmetric_encryption::AES128<'a> for Aes<'a> {
     }
 }
 
-impl hil::symmetric_encryption::AES128Ctr for Aes<'a> {
+impl hil::symmetric_encryption::AES128Ctr for Aes<'_> {
     fn set_mode_aes128ctr(&self, encrypting: bool) {
         self.set_mode(encrypting, ConfidentialityMode::CTR);
     }
 }
 
-impl hil::symmetric_encryption::AES128CBC for Aes<'a> {
+impl hil::symmetric_encryption::AES128CBC for Aes<'_> {
     fn set_mode_aes128cbc(&self, encrypting: bool) {
         self.set_mode(encrypting, ConfidentialityMode::CBC);
     }

--- a/chips/sam4l/src/ast.rs
+++ b/chips/sam4l/src/ast.rs
@@ -174,10 +174,10 @@ pub static mut AST: Ast<'static> = Ast {
     callback: OptionalCell::empty(),
 };
 
-impl Controller for Ast<'a> {
+impl Controller for Ast<'_> {
     type Config = &'static dyn time::AlarmClient;
 
-    fn configure(&self, client: &'a dyn time::AlarmClient) {
+    fn configure(&self, client: Self::Config) {
         self.callback.set(client);
 
         pm::enable_clock(pm::Clock::PBD(PBDClock::AST));
@@ -200,7 +200,7 @@ enum Clock {
     Clock1K = 4,
 }
 
-impl Ast<'a> {
+impl<'a> Ast<'a> {
     fn clock_busy(&self) -> bool {
         let regs: &AstRegisters = &*self.registers;
         regs.sr.is_set(Status::CLKBUSY)
@@ -298,7 +298,7 @@ impl Ast<'a> {
     }
 }
 
-impl Time for Ast<'a> {
+impl Time for Ast<'_> {
     type Frequency = Freq16KHz;
 
     fn now(&self) -> u32 {
@@ -310,7 +310,7 @@ impl Time for Ast<'a> {
     }
 }
 
-impl Alarm<'a> for Ast<'a> {
+impl<'a> Alarm<'a> for Ast<'a> {
     fn set_client(&self, client: &'a dyn time::AlarmClient) {
         self.callback.set(client);
     }

--- a/chips/sam4l/src/crccu.rs
+++ b/chips/sam4l/src/crccu.rs
@@ -237,7 +237,7 @@ pub struct Crccu<'a> {
 
 const DSCR_RESERVE: usize = 512 + 5 * 4;
 
-impl Crccu<'a> {
+impl Crccu<'_> {
     const fn new(base_address: StaticRef<CrccuRegisters>) -> Self {
         Crccu {
             registers: base_address,
@@ -330,7 +330,7 @@ impl Crccu<'a> {
 }
 
 // Implement the generic CRC interface with the CRCCU
-impl crc::CRC for Crccu<'a> {
+impl<'a> crc::CRC for Crccu<'a> {
     /// Set a client to receive results from the CRCCU
     fn set_client(&self, client: &'a dyn crc::Client) {
         self.client.set(client);

--- a/chips/sam4l/src/eic.rs
+++ b/chips/sam4l/src/eic.rs
@@ -129,7 +129,7 @@ register_bitfields![
 const EIC_BASE: StaticRef<EicRegisters> =
     unsafe { StaticRef::new(0x400F1000 as *const EicRegisters) };
 
-impl PeripheralManagement<pm::Clock> for Eic<'a> {
+impl PeripheralManagement<pm::Clock> for Eic<'_> {
     type RegisterType = EicRegisters;
 
     fn get_registers(&self) -> &EicRegisters {
@@ -155,7 +155,7 @@ pub struct Eic<'a> {
     callbacks: [OptionalCell<&'a dyn hil::eic::Client>; 9],
 }
 
-impl<'a> hil::eic::ExternalInterruptController for Eic<'a> {
+impl hil::eic::ExternalInterruptController for Eic<'_> {
     type Line = Line;
 
     fn line_enable(&self, line: &Self::Line, interrupt_mode: hil::eic::InterruptMode) {

--- a/chips/sam4l/src/lib.rs
+++ b/chips/sam4l/src/lib.rs
@@ -4,7 +4,7 @@
 
 #![crate_name = "sam4l"]
 #![crate_type = "rlib"]
-#![feature(const_fn, in_band_lifetimes)]
+#![feature(const_fn)]
 #![no_std]
 
 mod deferred_call_tasks;

--- a/chips/sam4l/src/trng.rs
+++ b/chips/sam4l/src/trng.rs
@@ -53,7 +53,7 @@ pub struct Trng<'a> {
 pub static mut TRNG: Trng<'static> = Trng::new();
 const KEY: u32 = 0x524e47;
 
-impl Trng<'a> {
+impl<'a> Trng<'a> {
     const fn new() -> Trng<'a> {
         Trng {
             regs: BASE_ADDRESS,
@@ -82,7 +82,7 @@ impl Trng<'a> {
 
 struct TrngIter<'a, 'b: 'a>(&'a Trng<'b>);
 
-impl Iterator for TrngIter<'a, 'b> {
+impl Iterator for TrngIter<'_, '_> {
     type Item = u32;
 
     fn next(&mut self) -> Option<u32> {
@@ -95,7 +95,7 @@ impl Iterator for TrngIter<'a, 'b> {
     }
 }
 
-impl entropy::Entropy32<'a> for Trng<'a> {
+impl<'a> entropy::Entropy32<'a> for Trng<'a> {
     fn get(&self) -> ReturnCode {
         let regs = &*self.regs;
         pm::enable_clock(pm::Clock::PBA(pm::PBAClock::TRNG));

--- a/chips/sam4l/src/usbc/debug.rs
+++ b/chips/sam4l/src/usbc/debug.rs
@@ -2,7 +2,7 @@ use core::fmt;
 
 pub struct HexBuf<'a>(pub &'a [u8]);
 
-impl fmt::Debug for HexBuf<'a> {
+impl fmt::Debug for HexBuf<'_> {
     #[allow(unused_must_use)]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "[");

--- a/chips/sam4l/src/usbc/mod.rs
+++ b/chips/sam4l/src/usbc/mod.rs
@@ -423,7 +423,7 @@ register_bitfields![u32,
     ]
 ];
 
-impl Usbc<'a> {
+impl<'a> Usbc<'a> {
     const fn new() -> Self {
         Usbc {
             client: None,
@@ -1437,7 +1437,7 @@ fn endpoint_enable_interrupts(endpoint: usize, mask: FieldValue<u32, EndpointCon
     usbc_regs().ueconset[endpoint].write(mask);
 }
 
-impl hil::usb::UsbController<'a> for Usbc<'a> {
+impl<'a> hil::usb::UsbController<'a> for Usbc<'a> {
     fn endpoint_set_ctrl_buffer(&self, buf: &'a [VolatileCell<u8>]) {
         if buf.len() != 8 {
             client_err!("Bad endpoint buffer size");

--- a/chips/sifive/src/lib.rs
+++ b/chips/sifive/src/lib.rs
@@ -1,6 +1,6 @@
 //! Implementations for generic SiFive MCU peripherals.
 
-#![feature(const_fn, in_band_lifetimes)]
+#![feature(const_fn)]
 #![no_std]
 #![crate_name = "sifive"]
 #![crate_type = "rlib"]

--- a/chips/sifive/src/uart.rs
+++ b/chips/sifive/src/uart.rs
@@ -74,7 +74,7 @@ pub struct UartParams {
     pub baud_rate: u32,
 }
 
-impl Uart<'a> {
+impl<'a> Uart<'a> {
     pub const fn new(base: StaticRef<UartRegisters>, clock_frequency: u32) -> Uart<'a> {
         Uart {
             registers: base,
@@ -164,10 +164,10 @@ impl Uart<'a> {
     }
 }
 
-impl hil::uart::UartData<'a> for Uart<'a> {}
-impl hil::uart::Uart<'a> for Uart<'a> {}
+impl<'a> hil::uart::UartData<'a> for Uart<'a> {}
+impl<'a> hil::uart::Uart<'a> for Uart<'a> {}
 
-impl hil::uart::Configure for Uart<'a> {
+impl hil::uart::Configure for Uart<'_> {
     fn configure(&self, params: hil::uart::Parameters) -> ReturnCode {
         // This chip does not support these features.
         if params.parity != hil::uart::Parity::None {
@@ -187,7 +187,7 @@ impl hil::uart::Configure for Uart<'a> {
     }
 }
 
-impl hil::uart::Transmit<'a> for Uart<'a> {
+impl<'a> hil::uart::Transmit<'a> for Uart<'a> {
     fn set_transmit_client(&self, client: &'a dyn hil::uart::TransmitClient) {
         self.tx_client.set(client);
     }
@@ -243,7 +243,7 @@ impl hil::uart::Transmit<'a> for Uart<'a> {
     }
 }
 
-impl hil::uart::Receive<'a> for Uart<'a> {
+impl<'a> hil::uart::Receive<'a> for Uart<'a> {
     fn set_receive_client(&self, client: &'a dyn hil::uart::ReceiveClient) {
         self.rx_client.set(client);
     }

--- a/chips/stm32f303xc/src/exti.rs
+++ b/chips/stm32f303xc/src/exti.rs
@@ -508,7 +508,7 @@ pub struct Exti<'a> {
 
 pub static mut EXTI: Exti<'static> = Exti::new();
 
-impl Exti<'a> {
+impl<'a> Exti<'a> {
     const fn new() -> Exti<'a> {
         Exti {
             registers: EXTI_BASE,

--- a/chips/stm32f303xc/src/gpio.rs
+++ b/chips/stm32f303xc/src/gpio.rs
@@ -695,7 +695,7 @@ pub static mut PIN: [[Option<Pin<'static>>; 16]; 6] = [
     ],
 ];
 
-impl Pin<'a> {
+impl<'a> Pin<'a> {
     const fn new(pinid: PinId) -> Pin<'a> {
         Pin {
             pinid: pinid,
@@ -975,10 +975,10 @@ impl Pin<'a> {
     }
 }
 
-impl hil::gpio::Pin for Pin<'a> {}
-impl hil::gpio::InterruptPin for Pin<'a> {}
+impl hil::gpio::Pin for Pin<'_> {}
+impl hil::gpio::InterruptPin for Pin<'_> {}
 
-impl hil::gpio::Configure for Pin<'a> {
+impl hil::gpio::Configure for Pin<'_> {
     /// Output mode default is push-pull
     fn make_output(&self) -> hil::gpio::Configuration {
         self.set_mode(Mode::GeneralPurposeOutputMode);
@@ -1050,7 +1050,7 @@ impl hil::gpio::Configure for Pin<'a> {
     }
 }
 
-impl hil::gpio::Output for Pin<'a> {
+impl hil::gpio::Output for Pin<'_> {
     fn set(&self) {
         self.set_output_high();
     }
@@ -1064,13 +1064,13 @@ impl hil::gpio::Output for Pin<'a> {
     }
 }
 
-impl hil::gpio::Input for Pin<'a> {
+impl hil::gpio::Input for Pin<'_> {
     fn read(&self) -> bool {
         self.read_input()
     }
 }
 
-impl hil::gpio::Interrupt for Pin<'a> {
+impl hil::gpio::Interrupt for Pin<'_> {
     fn enable_interrupts(&self, mode: hil::gpio::InterruptEdge) {
         unsafe {
             atomic(|| {

--- a/chips/stm32f303xc/src/i2c.rs
+++ b/chips/stm32f303xc/src/i2c.rs
@@ -261,9 +261,9 @@ pub static mut I2C1: I2C = I2C::new(
     I2CClock(rcc::PeripheralClock::APB1(rcc::PCLK1::I2C1)),
 );
 
-impl I2C<'a> {
-    const fn new(base_addr: StaticRef<I2CRegisters>, clock: I2CClock) -> I2C<'a> {
-        I2C {
+impl I2C<'_> {
+    const fn new(base_addr: StaticRef<I2CRegisters>, clock: I2CClock) -> Self {
+        Self {
             registers: base_addr,
             clock,
 
@@ -465,7 +465,7 @@ impl I2C<'a> {
     }
 }
 
-impl i2c::I2CMaster for I2C<'a> {
+impl i2c::I2CMaster for I2C<'_> {
     fn set_master_client(&self, master_client: &'static dyn I2CHwMasterClient) {
         self.master_client.replace(master_client);
     }

--- a/chips/stm32f303xc/src/lib.rs
+++ b/chips/stm32f303xc/src/lib.rs
@@ -4,7 +4,7 @@
 
 #![crate_name = "stm32f303xc"]
 #![crate_type = "rlib"]
-#![feature(const_fn, in_band_lifetimes)]
+#![feature(const_fn)]
 #![no_std]
 #![allow(unused_doc_comments)]
 

--- a/chips/stm32f303xc/src/spi.rs
+++ b/chips/stm32f303xc/src/spi.rs
@@ -206,9 +206,9 @@ pub static mut SPI1: Spi = Spi::new(
     SpiClock(rcc::PeripheralClock::APB2(rcc::PCLK2::SPI1)),
 );
 
-impl Spi<'a> {
-    const fn new(base_addr: StaticRef<SpiRegisters>, clock: SpiClock) -> Spi<'a> {
-        Spi {
+impl Spi<'_> {
+    const fn new(base_addr: StaticRef<SpiRegisters>, clock: SpiClock) -> Self {
+        Self {
             registers: base_addr,
             clock,
 
@@ -402,7 +402,7 @@ impl Spi<'a> {
     }
 }
 
-impl spi::SpiMaster for Spi<'a> {
+impl spi::SpiMaster for Spi<'_> {
     type ChipSelect = PinId;
 
     fn set_client(&self, client: &'static dyn SpiMasterClient) {

--- a/chips/stm32f303xc/src/tim2.rs
+++ b/chips/stm32f303xc/src/tim2.rs
@@ -315,9 +315,9 @@ pub struct Tim2<'a> {
 
 pub static mut TIM2: Tim2<'static> = Tim2::new();
 
-impl Tim2<'a> {
-    const fn new() -> Tim2<'a> {
-        Tim2 {
+impl Tim2<'_> {
+    const fn new() -> Self {
+        Self {
             registers: TIM2_BASE,
             clock: Tim2Clock(rcc::PeripheralClock::APB1(rcc::PCLK1::TIM2)),
             client: OptionalCell::empty(),
@@ -358,7 +358,7 @@ impl Tim2<'a> {
     }
 }
 
-impl hil::time::Alarm<'a> for Tim2<'a> {
+impl<'a> hil::time::Alarm<'a> for Tim2<'a> {
     fn set_client(&self, client: &'a dyn hil::time::AlarmClient) {
         self.client.set(client);
     }
@@ -388,7 +388,7 @@ impl hil::time::Alarm<'a> for Tim2<'a> {
     }
 }
 
-impl hil::time::Time for Tim2<'a> {
+impl hil::time::Time for Tim2<'_> {
     type Frequency = hil::time::Freq16KHz;
 
     fn now(&self) -> u32 {

--- a/chips/stm32f303xc/src/usart.rs
+++ b/chips/stm32f303xc/src/usart.rs
@@ -321,9 +321,9 @@ pub static mut USART3: Usart = Usart::new(
     UsartClock(rcc::PeripheralClock::APB1(rcc::PCLK1::USART3)),
 );
 
-impl Usart<'a> {
-    const fn new(base_addr: StaticRef<UsartRegisters>, clock: UsartClock) -> Usart<'a> {
-        Usart {
+impl Usart<'_> {
+    const fn new(base_addr: StaticRef<UsartRegisters>, clock: UsartClock) -> Self {
+        Self {
             registers: base_addr,
             clock: clock,
 
@@ -480,7 +480,7 @@ impl Usart<'a> {
     }
 }
 
-impl hil::uart::Transmit<'a> for Usart<'a> {
+impl<'a> hil::uart::Transmit<'a> for Usart<'a> {
     fn set_transmit_client(&self, client: &'a dyn hil::uart::TransmitClient) {
         self.tx_client.set(client);
     }
@@ -520,7 +520,7 @@ impl hil::uart::Transmit<'a> for Usart<'a> {
     }
 }
 
-impl hil::uart::Configure for Usart<'a> {
+impl hil::uart::Configure for Usart<'_> {
     fn configure(&self, params: hil::uart::Parameters) -> ReturnCode {
         if params.baud_rate != 115200
             || params.stop_bits != hil::uart::StopBits::One
@@ -564,7 +564,7 @@ impl hil::uart::Configure for Usart<'a> {
     }
 }
 
-impl hil::uart::Receive<'a> for Usart<'a> {
+impl<'a> hil::uart::Receive<'a> for Usart<'a> {
     fn set_receive_client(&self, client: &'a dyn hil::uart::ReceiveClient) {
         self.rx_client.set(client);
     }
@@ -604,8 +604,8 @@ impl hil::uart::Receive<'a> for Usart<'a> {
     }
 }
 
-impl hil::uart::UartData<'a> for Usart<'a> {}
-impl hil::uart::Uart<'a> for Usart<'a> {}
+impl<'a> hil::uart::UartData<'a> for Usart<'a> {}
+impl<'a> hil::uart::Uart<'a> for Usart<'a> {}
 
 struct UsartClock(rcc::PeripheralClock);
 

--- a/chips/stm32f4xx/src/dma1.rs
+++ b/chips/stm32f4xx/src/dma1.rs
@@ -841,7 +841,7 @@ pub trait StreamClient {
     fn transfer_done(&self, pid: Dma1Peripheral);
 }
 
-impl Stream<'a> {
+impl<'a> Stream<'a> {
     const fn new(streamid: StreamId) -> Stream<'a> {
         Stream {
             streamid: streamid,

--- a/chips/stm32f4xx/src/exti.rs
+++ b/chips/stm32f4xx/src/exti.rs
@@ -390,7 +390,7 @@ pub struct Exti<'a> {
 
 pub static mut EXTI: Exti<'static> = Exti::new();
 
-impl Exti<'a> {
+impl<'a> Exti<'a> {
     const fn new() -> Exti<'a> {
         Exti {
             registers: EXTI_BASE,

--- a/chips/stm32f4xx/src/gpio.rs
+++ b/chips/stm32f4xx/src/gpio.rs
@@ -726,7 +726,7 @@ pub static mut PIN: [[Option<Pin<'static>>; 16]; 8] = [
     ],
 ];
 
-impl Pin<'a> {
+impl<'a> Pin<'a> {
     const fn new(pinid: PinId) -> Pin<'a> {
         Pin {
             pinid: pinid,
@@ -1006,10 +1006,10 @@ impl Pin<'a> {
     }
 }
 
-impl hil::gpio::Pin for Pin<'a> {}
-impl hil::gpio::InterruptPin for Pin<'a> {}
+impl hil::gpio::Pin for Pin<'_> {}
+impl hil::gpio::InterruptPin for Pin<'_> {}
 
-impl hil::gpio::Configure for Pin<'a> {
+impl hil::gpio::Configure for Pin<'_> {
     /// Output mode default is push-pull
     fn make_output(&self) -> hil::gpio::Configuration {
         self.set_mode(Mode::GeneralPurposeOutputMode);
@@ -1081,7 +1081,7 @@ impl hil::gpio::Configure for Pin<'a> {
     }
 }
 
-impl hil::gpio::Output for Pin<'a> {
+impl hil::gpio::Output for Pin<'_> {
     fn set(&self) {
         self.set_output_high();
     }
@@ -1095,13 +1095,13 @@ impl hil::gpio::Output for Pin<'a> {
     }
 }
 
-impl hil::gpio::Input for Pin<'a> {
+impl hil::gpio::Input for Pin<'_> {
     fn read(&self) -> bool {
         self.read_input()
     }
 }
 
-impl hil::gpio::Interrupt for Pin<'a> {
+impl hil::gpio::Interrupt for Pin<'_> {
     fn enable_interrupts(&self, mode: hil::gpio::InterruptEdge) {
         unsafe {
             atomic(|| {

--- a/chips/stm32f4xx/src/lib.rs
+++ b/chips/stm32f4xx/src/lib.rs
@@ -4,7 +4,7 @@
 
 #![crate_name = "stm32f4xx"]
 #![crate_type = "rlib"]
-#![feature(const_fn, in_band_lifetimes)]
+#![feature(const_fn)]
 #![no_std]
 #![allow(unused_doc_comments)]
 

--- a/chips/stm32f4xx/src/spi.rs
+++ b/chips/stm32f4xx/src/spi.rs
@@ -170,7 +170,7 @@ pub static mut SPI3: Spi = Spi::new(
     Dma1Peripheral::SPI3_RX,
 );
 
-impl Spi<'a> {
+impl<'a> Spi<'a> {
     const fn new(
         base_addr: StaticRef<SpiRegisters>,
         clock: SpiClock,
@@ -337,7 +337,7 @@ impl Spi<'a> {
     }
 }
 
-impl spi::SpiMaster for Spi<'a> {
+impl spi::SpiMaster for Spi<'_> {
     type ChipSelect = PinId;
 
     fn set_client(&self, client: &'static dyn SpiMasterClient) {
@@ -455,7 +455,7 @@ impl spi::SpiMaster for Spi<'a> {
     }
 }
 
-impl dma1::StreamClient for Spi<'a> {
+impl dma1::StreamClient for Spi<'_> {
     fn transfer_done(&self, pid: dma1::Dma1Peripheral) {
         if pid == self.tx_dma_pid {
             self.disable_tx();

--- a/chips/stm32f4xx/src/tim2.rs
+++ b/chips/stm32f4xx/src/tim2.rs
@@ -313,7 +313,7 @@ pub struct Tim2<'a> {
 
 pub static mut TIM2: Tim2<'static> = Tim2::new();
 
-impl Tim2<'a> {
+impl<'a> Tim2<'a> {
     const fn new() -> Tim2<'a> {
         Tim2 {
             registers: TIM2_BASE,
@@ -356,7 +356,7 @@ impl Tim2<'a> {
     }
 }
 
-impl hil::time::Alarm<'a> for Tim2<'a> {
+impl<'a> hil::time::Alarm<'a> for Tim2<'a> {
     fn set_client(&self, client: &'a dyn hil::time::AlarmClient) {
         self.client.set(client);
     }
@@ -386,7 +386,7 @@ impl hil::time::Alarm<'a> for Tim2<'a> {
     }
 }
 
-impl hil::time::Time for Tim2<'a> {
+impl hil::time::Time for Tim2<'_> {
     type Frequency = hil::time::Freq16KHz;
 
     fn now(&self) -> u32 {

--- a/chips/stm32f4xx/src/usart.rs
+++ b/chips/stm32f4xx/src/usart.rs
@@ -201,7 +201,7 @@ pub static mut USART3: Usart = Usart::new(
     Dma1Peripheral::USART3_RX,
 );
 
-impl Usart<'a> {
+impl<'a> Usart<'a> {
     const fn new(
         base_addr: StaticRef<UsartRegisters>,
         clock: UsartClock,
@@ -363,7 +363,7 @@ impl Usart<'a> {
     }
 }
 
-impl hil::uart::Transmit<'a> for Usart<'a> {
+impl<'a> hil::uart::Transmit<'a> for Usart<'a> {
     fn set_transmit_client(&self, client: &'a dyn hil::uart::TransmitClient) {
         self.tx_client.set(client);
     }
@@ -409,7 +409,7 @@ impl hil::uart::Transmit<'a> for Usart<'a> {
     }
 }
 
-impl hil::uart::Configure for Usart<'a> {
+impl<'a> hil::uart::Configure for Usart<'a> {
     fn configure(&self, params: hil::uart::Parameters) -> ReturnCode {
         if params.baud_rate != 115200
             || params.stop_bits != hil::uart::StopBits::One
@@ -452,7 +452,7 @@ impl hil::uart::Configure for Usart<'a> {
     }
 }
 
-impl hil::uart::Receive<'a> for Usart<'a> {
+impl<'a> hil::uart::Receive<'a> for Usart<'a> {
     fn set_receive_client(&self, client: &'a dyn hil::uart::ReceiveClient) {
         self.rx_client.set(client);
     }
@@ -493,10 +493,10 @@ impl hil::uart::Receive<'a> for Usart<'a> {
     }
 }
 
-impl hil::uart::UartData<'a> for Usart<'a> {}
-impl hil::uart::Uart<'a> for Usart<'a> {}
+impl<'a> hil::uart::UartData<'a> for Usart<'a> {}
+impl<'a> hil::uart::Uart<'a> for Usart<'a> {}
 
-impl dma1::StreamClient for Usart<'a> {
+impl dma1::StreamClient for Usart<'_> {
     fn transfer_done(&self, pid: dma1::Dma1Peripheral) {
         if pid == self.tx_dma_pid {
             self.usart_tx_state.set(USARTStateTX::Transfer_Completing);

--- a/kernel/src/common/list.rs
+++ b/kernel/src/common/list.rs
@@ -4,7 +4,7 @@ use core::cell::Cell;
 
 pub struct ListLink<'a, T: 'a + ?Sized>(Cell<Option<&'a T>>);
 
-impl<T: ?Sized> ListLink<'a, T> {
+impl<'a, T: ?Sized> ListLink<'a, T> {
     pub const fn empty() -> ListLink<'a, T> {
         ListLink(Cell::new(None))
     }
@@ -22,7 +22,7 @@ pub struct ListIterator<'a, T: 'a + ?Sized + ListNode<'a, T>> {
     cur: Option<&'a T>,
 }
 
-impl<T: ?Sized + ListNode<'a, T>> Iterator for ListIterator<'a, T> {
+impl<'a, T: ?Sized + ListNode<'a, T>> Iterator for ListIterator<'a, T> {
     type Item = &'a T;
 
     fn next(&mut self) -> Option<&'a T> {
@@ -36,7 +36,7 @@ impl<T: ?Sized + ListNode<'a, T>> Iterator for ListIterator<'a, T> {
     }
 }
 
-impl<T: ?Sized + ListNode<'a, T>> List<'a, T> {
+impl<'a, T: ?Sized + ListNode<'a, T>> List<'a, T> {
     pub const fn new() -> List<'a, T> {
         List {
             head: ListLink(Cell::new(None)),

--- a/kernel/src/common/peripherals.rs
+++ b/kernel/src/common/peripherals.rs
@@ -210,7 +210,7 @@ where
     clock: &'a C,
 }
 
-impl<H, C> PeripheralManager<'a, H, C>
+impl<'a, H, C> PeripheralManager<'a, H, C>
 where
     H: 'a + PeripheralManagement<C>,
     C: 'a + ClockInterface,
@@ -227,7 +227,7 @@ where
     }
 }
 
-impl<H, C> Drop for PeripheralManager<'a, H, C>
+impl<'a, H, C> Drop for PeripheralManager<'a, H, C>
 where
     H: 'a + PeripheralManagement<C>,
     C: 'a + ClockInterface,

--- a/kernel/src/common/ring_buffer.rs
+++ b/kernel/src/common/ring_buffer.rs
@@ -8,7 +8,7 @@ pub struct RingBuffer<'a, T: 'a> {
     tail: usize,
 }
 
-impl<T: Copy> RingBuffer<'a, T> {
+impl<'a, T: Copy> RingBuffer<'a, T> {
     pub fn new(ring: &'a mut [T]) -> RingBuffer<'a, T> {
         RingBuffer {
             head: 0,
@@ -52,7 +52,7 @@ impl<T: Copy> RingBuffer<'a, T> {
     }
 }
 
-impl<T: Copy> queue::Queue<T> for RingBuffer<'a, T> {
+impl<T: Copy> queue::Queue<T> for RingBuffer<'_, T> {
     fn has_elements(&self) -> bool {
         self.head != self.tail
     }

--- a/kernel/src/grant.rs
+++ b/kernel/src/grant.rs
@@ -116,7 +116,7 @@ pub struct Borrowed<'a, T: 'a + ?Sized> {
     appid: AppId,
 }
 
-impl<T: 'a + ?Sized> Borrowed<'a, T> {
+impl<'a, T: 'a + ?Sized> Borrowed<'a, T> {
     pub fn new(data: &'a mut T, appid: AppId) -> Borrowed<'a, T> {
         Borrowed {
             data: data,
@@ -129,14 +129,14 @@ impl<T: 'a + ?Sized> Borrowed<'a, T> {
     }
 }
 
-impl<T: 'a + ?Sized> Deref for Borrowed<'a, T> {
+impl<'a, T: 'a + ?Sized> Deref for Borrowed<'a, T> {
     type Target = T;
     fn deref(&self) -> &T {
         self.data
     }
 }
 
-impl<T: 'a + ?Sized> DerefMut for Borrowed<'a, T> {
+impl<'a, T: 'a + ?Sized> DerefMut for Borrowed<'a, T> {
     fn deref_mut(&mut self) -> &mut T {
         self.data
     }
@@ -289,7 +289,7 @@ pub struct Iter<'a, T: 'a + Default> {
     >,
 }
 
-impl<T: Default> Iterator for Iter<'a, T> {
+impl<T: Default> Iterator for Iter<'_, T> {
     type Item = AppliedGrant<T>;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -10,7 +10,6 @@
     core_intrinsics,
     const_fn,
     panic_info_message,
-    in_band_lifetimes,
     associated_type_defaults,
     try_trait
 )]

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -807,7 +807,7 @@ pub struct Process<'a, C: 'static + Chip> {
     debug: MapCell<ProcessDebug>,
 }
 
-impl<C: Chip> ProcessType for Process<'a, C> {
+impl<C: Chip> ProcessType for Process<'_, C> {
     fn appid(&self) -> AppId {
         self.app_id.get()
     }
@@ -1494,7 +1494,7 @@ fn exceeded_check(size: usize, allocated: usize) -> &'static str {
     }
 }
 
-impl<C: 'static + Chip> Process<'a, C> {
+impl<C: 'static + Chip> Process<'_, C> {
     pub(crate) unsafe fn create(
         kernel: &'static Kernel,
         chip: &'static C,


### PR DESCRIPTION
### Pull Request Overview

This commit removes the use of the unstable pragma "in_band_lifetimes" everywhere. The main culprit turned out to be the `capsules` crate.

### Testing Strategy

This change is a noop, since it consits of either adding required lifetime annotations, or changing exlicit lifetimes `'a` to placeholder liftimes `'_`. `make allcheck` should be sufficient to show this change is correct. In general, I tried to make the change that required minimal changes to the AST.

### TODO or Help Wanted

N/A

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
