### PR TITLE
chips/e310x: Remove unstable pragma

### DIFF
--- a/chips/e310x/src/chip.rs
+++ b/chips/e310x/src/chip.rs
@@ -52,7 +52,7 @@ impl kernel::Chip for E310x {
             while let Some(interrupt) = plic::next_pending() {
                 match interrupt {
                     interrupts::UART0 => uart::UART0.handle_interrupt(),
-                    index @ interrupts::GPIO0..interrupts::GPIO31 => {
+                    index @ interrupts::GPIO0..=interrupts::GPIO31 => {
                         gpio::PORT[index as usize].handle_interrupt()
                     }
                     _ => debug!("Pidx {}", interrupt),

--- a/chips/e310x/src/chip.rs
+++ b/chips/e310x/src/chip.rs
@@ -55,7 +55,7 @@ impl kernel::Chip for E310x {
                     int_pin @ interrupts::GPIO0..=interrupts::GPIO31 => {
                         let pin = &gpio::PORT[(int_pin - interrupts::GPIO0) as usize];
                         pin.handle_interrupt();
-                    },
+                    }
                     _ => debug!("Pidx {}", interrupt),
                 }
 

--- a/chips/e310x/src/chip.rs
+++ b/chips/e310x/src/chip.rs
@@ -52,9 +52,10 @@ impl kernel::Chip for E310x {
             while let Some(interrupt) = plic::next_pending() {
                 match interrupt {
                     interrupts::UART0 => uart::UART0.handle_interrupt(),
-                    index @ interrupts::GPIO0..=interrupts::GPIO31 => {
-                        gpio::PORT[index as usize].handle_interrupt()
-                    }
+                    int_pin @ interrupts::GPIO0..=interrupts::GPIO31 => {
+                        let pin = &gpio::PORT[(int_pin - interrupts::GPIO0) as usize];
+                        pin.handle_interrupt();
+                    },
                     _ => debug!("Pidx {}", interrupt),
                 }
 

--- a/chips/e310x/src/lib.rs
+++ b/chips/e310x/src/lib.rs
@@ -1,6 +1,6 @@
 //! Chip support for the E310 from SiFive.
 
-#![feature(asm, exclusive_range_pattern)]
+#![feature(asm)]
 #![no_std]
 #![crate_name = "e310x"]
 #![crate_type = "rlib"]


### PR DESCRIPTION
### Pull Request Overview

For some reason, e310x uses the exclusive_range_pattern pragma to use a `a..b` pattern, though given context this appears to be a mistake, and should be an inclusive range (`a...b`) instead.

### Testing Strategy

See TODO.

### TODO or Help Wanted

This PR needs some kind of testing strategy, since it is not a no-op. I strongly believe that the missing period is a typo, since current implementation seems to just ignore the 31st GPIO pin.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
