### PR TITLE
kernel: use NonNull, iterate on grant and appslice interfaces

### DIFF
--- a/kernel/src/grant.rs
+++ b/kernel/src/grant.rs
@@ -146,12 +146,10 @@ impl<T: Default> Grant<T> {
     pub fn grant(&self, appid: AppId) -> Option<AppliedGrant<T>> {
         appid.kernel.process_map_or(None, appid, |process| {
             if let Some(grant_ptr) = process.grant_ptr(self.grant_num) {
-                NonNull::new(grant_ptr).map_or(None, |grant| {
-                    Some(AppliedGrant {
-                        appid: appid,
-                        grant: grant.cast::<T>(),
-                        _phantom: PhantomData,
-                    })
+                NonNull::new(grant_ptr).map(|grant| AppliedGrant {
+                    appid: appid,
+                    grant: grant.cast::<T>(),
+                    _phantom: PhantomData,
                 })
             } else {
                 None

--- a/kernel/src/grant.rs
+++ b/kernel/src/grant.rs
@@ -3,7 +3,7 @@
 use core::marker::PhantomData;
 use core::mem::{align_of, size_of};
 use core::ops::{Deref, DerefMut};
-use core::ptr::{write, write_volatile, Unique};
+use core::ptr::{write, write_volatile, NonNull};
 
 use crate::callback::AppId;
 use crate::process::{Error, ProcessType};
@@ -39,14 +39,14 @@ pub struct Allocator {
 }
 
 pub struct Owned<T: ?Sized> {
-    data: Unique<T>,
+    data: NonNull<T>,
     appid: AppId,
 }
 
 impl<T: ?Sized> Owned<T> {
     unsafe fn new(data: *mut T, appid: AppId) -> Owned<T> {
         Owned {
-            data: Unique::new_unchecked(data),
+            data: NonNull::new_unchecked(data),
             appid: appid,
         }
     }

--- a/kernel/src/grant.rs
+++ b/kernel/src/grant.rs
@@ -98,7 +98,7 @@ impl Allocator {
                     Err(Error::OutOfMemory),
                     |buf| {
                         // Convert untyped `*mut u8` allocation to allocated type
-                        let ptr = NonNull::new_unchecked(buf.as_ptr() as *mut T);
+                        let ptr = NonNull::cast::<T>(buf);
 
                         // We use `ptr::write` to avoid `Drop`ping the uninitialized memory in
                         // case `T` implements the `Drop` trait.

--- a/kernel/src/introspection.rs
+++ b/kernel/src/introspection.rs
@@ -136,11 +136,11 @@ impl KernelInfo {
         let mut used = 0;
         self.kernel.process_map_or((), app, |process| {
             for i in 0..number_of_grants {
-                if let Some(grant_ptr) = process.grant_ptr(i) {
+                if let Some(grant_ptr) = process.get_grant_ptr(i) {
                     // If the pointer at that location is not NULL then the
                     // grant memory has been allocated and the grant is
                     // being used.
-                    if !(*grant_ptr).is_null() {
+                    if !(grant_ptr.is_null()) {
                         used += 1;
                     }
                 }

--- a/kernel/src/introspection.rs
+++ b/kernel/src/introspection.rs
@@ -136,14 +136,12 @@ impl KernelInfo {
         let mut used = 0;
         self.kernel.process_map_or((), app, |process| {
             for i in 0..number_of_grants {
-                unsafe {
-                    if let Some(ctr_ptr) = process.grant_ptr(i) {
-                        // If the pointer at that location is not NULL then the
-                        // grant memory has been allocated and the grant is
-                        // being used.
-                        if !(*ctr_ptr).is_null() {
-                            used += 1;
-                        }
+                if let Some(grant_ptr) = process.grant_ptr(i) {
+                    // If the pointer at that location is not NULL then the
+                    // grant memory has been allocated and the grant is
+                    // being used.
+                    if !(*grant_ptr).is_null() {
+                        used += 1;
                     }
                 }
             }

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -8,7 +8,6 @@
 
 #![feature(
     core_intrinsics,
-    ptr_internals,
     const_fn,
     panic_info_message,
     in_band_lifetimes,

--- a/kernel/src/mem.rs
+++ b/kernel/src/mem.rs
@@ -2,7 +2,7 @@
 
 use core::marker::PhantomData;
 use core::ops::{Deref, DerefMut};
-use core::ptr::Unique;
+use core::ptr::NonNull;
 use core::slice;
 
 use crate::callback::AppId;
@@ -18,7 +18,7 @@ pub struct Shared;
 /// Base type for an AppSlice that holds the raw pointer to the memory region
 /// the app shared with the kernel.
 pub struct AppPtr<L, T> {
-    ptr: Unique<T>,
+    ptr: NonNull<T>,
     process: AppId,
     _phantom: PhantomData<L>,
 }
@@ -26,7 +26,7 @@ pub struct AppPtr<L, T> {
 impl<L, T> AppPtr<L, T> {
     unsafe fn new(ptr: *mut T, appid: AppId) -> AppPtr<L, T> {
         AppPtr {
-            ptr: Unique::new_unchecked(ptr),
+            ptr: NonNull::new_unchecked(ptr),
             process: appid,
             _phantom: PhantomData,
         }

--- a/kernel/src/mem.rs
+++ b/kernel/src/mem.rs
@@ -24,7 +24,8 @@ pub struct AppPtr<L, T> {
 }
 
 impl<L, T> AppPtr<L, T> {
-    fn new(ptr: NonNull<T>, appid: AppId) -> AppPtr<L, T> {
+    /// Safety: Trusts that `ptr` points to userspace memory in `appid`
+    unsafe fn new(ptr: NonNull<T>, appid: AppId) -> AppPtr<L, T> {
         AppPtr {
             ptr: ptr,
             process: appid,
@@ -66,7 +67,9 @@ pub struct AppSlice<L, T> {
 }
 
 impl<L, T> AppSlice<L, T> {
-    crate fn new(ptr: NonNull<T>, len: usize, appid: AppId) -> AppSlice<L, T> {
+    /// Safety: Trusts that `ptr` + `len` is a buffer in `appid` and that no
+    /// other references to that memory range exist.
+    crate unsafe fn new(ptr: NonNull<T>, len: usize, appid: AppId) -> AppSlice<L, T> {
         AppSlice {
             ptr: AppPtr::new(ptr, appid),
             len: len,

--- a/kernel/src/mem.rs
+++ b/kernel/src/mem.rs
@@ -24,9 +24,9 @@ pub struct AppPtr<L, T> {
 }
 
 impl<L, T> AppPtr<L, T> {
-    unsafe fn new(ptr: *mut T, appid: AppId) -> AppPtr<L, T> {
+    fn new(ptr: NonNull<T>, appid: AppId) -> AppPtr<L, T> {
         AppPtr {
-            ptr: NonNull::new_unchecked(ptr),
+            ptr: ptr,
             process: appid,
             _phantom: PhantomData,
         }
@@ -66,12 +66,10 @@ pub struct AppSlice<L, T> {
 }
 
 impl<L, T> AppSlice<L, T> {
-    crate fn new(ptr: *mut T, len: usize, appid: AppId) -> AppSlice<L, T> {
-        unsafe {
-            AppSlice {
-                ptr: AppPtr::new(ptr, appid),
-                len: len,
-            }
+    crate fn new(ptr: NonNull<T>, len: usize, appid: AppId) -> AppSlice<L, T> {
+        AppSlice {
+            ptr: AppPtr::new(ptr, appid),
+            len: len,
         }
     }
 

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -351,7 +351,7 @@ pub trait ProcessType {
 
     unsafe fn free(&self, _: *mut u8);
 
-    /// Get the grant pointer for this grant number.
+    /// Get a reference to the grant pointer for this grant number.
     ///
     /// This will return `None` if the process is inactive and the grant region
     /// cannot be used.

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -1115,7 +1115,13 @@ impl<C: Chip> ProcessType for Process<'a, C> {
             let new_water_mark = max(self.allow_high_water_mark.get(), buf_end_addr);
             self.allow_high_water_mark.set(new_water_mark);
 
-            Ok(Some(AppSlice::new(buf_start, size, self.appid())))
+            // The `unsafe` promise we should be making here is that this
+            // buffer is inside of app memory and that it does not create any
+            // aliases (i.e. the same buffer has not been `allow`ed twice).
+            //
+            // TODO: We do not currently satisfy the second promise.
+            let slice = unsafe { AppSlice::new(buf_start, size, self.appid()) };
+            Ok(Some(slice))
         } else {
             Err(ReturnCode::EINVAL)
         }

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -1180,11 +1180,11 @@ impl<C: Chip> ProcessType for Process<'a, C> {
         }
 
         let grant_num = grant_num as isize;
-        unsafe {
+        let grant_pointer = unsafe {
             let grant_pointer_array = self.mem_end() as *const *mut u8;
-            let grant_pointer = *grant_pointer_array.offset(-(grant_num + 1));
-            Some(grant_pointer)
-        }
+            *grant_pointer_array.offset(-(grant_num + 1))
+        };
+        Some(grant_pointer)
     }
 
     unsafe fn set_grant_ptr(&self, grant_num: usize, grant_ptr: *mut u8) {

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -351,12 +351,13 @@ pub trait ProcessType {
 
     unsafe fn free(&self, _: *mut u8);
 
-    /// Get a pointer to the grant pointer for this grant number.
+    /// Get the grant pointer for this grant number.
     ///
     /// This will return `None` if the process is inactive and the grant region
     /// cannot be used.
     ///
-    /// Caution: Pointer may be null if the grant has not yet been allocated.
+    /// Caution: The grant may not have been allocated yet, so it is possible
+    /// for this grant pointer to be null.
     fn grant_ptr(&self, grant_num: usize) -> Option<&mut *mut u8>;
 
     // functions for processes that are architecture specific


### PR DESCRIPTION
### Pull Request Overview

This change is effectively `s/Unique/NonNull/g`, and is the supported upgrade path out of `ptr_internals`; it is effectively a no-op.

### Testing Strategy

`make allcheck` passes; presumably unit tests will catch any other silliness.

### TODO or Help Wanted

N/A

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
