### PR TITLE
kernel: remove unstable `crate_visibility_modifier`, aka crate -> pub(crate)

### DIFF
--- a/kernel/src/callback.rs
+++ b/kernel/src/callback.rs
@@ -43,7 +43,7 @@ pub struct AppId {
     /// Reference to the main kernel struct. This is needed for checking on
     /// certain properties of the referred app (like its editable bounds), but
     /// also for checking that the index is valid.
-    crate kernel: &'static Kernel,
+    pub(crate) kernel: &'static Kernel,
 
     /// The index in the kernel.PROCESSES[] array where this app's state is
     /// stored. This makes for fast lookup of the process and helps with
@@ -51,7 +51,7 @@ pub struct AppId {
     ///
     /// This value is crate visible to enable optimizations in sched.rs. Other
     /// users should call `.index()` instead.
-    crate index: usize,
+    pub(crate) index: usize,
 
     /// The unique identifier for this process. This can be used to refer to the
     /// process in situations where a single number is required, for instance
@@ -79,7 +79,7 @@ impl fmt::Debug for AppId {
 }
 
 impl AppId {
-    crate fn new(kernel: &'static Kernel, identifier: usize, index: usize) -> AppId {
+    pub(crate) fn new(kernel: &'static Kernel, identifier: usize, index: usize) -> AppId {
         AppId {
             kernel: kernel,
             identifier: identifier,
@@ -92,7 +92,7 @@ impl AppId {
     /// This will return `Some(index)` if the identifier stored in this `AppId`
     /// matches the app saved at the known index. If the identifier does not
     /// match then `None` will be returned.
-    crate fn index(&self) -> Option<usize> {
+    pub(crate) fn index(&self) -> Option<usize> {
         // Do a lookup to make sure that the index we have is correct.
         if self.kernel.appid_is_valid(self) {
             Some(self.index)
@@ -153,7 +153,7 @@ pub struct Callback {
 }
 
 impl Callback {
-    crate fn new(
+    pub(crate) fn new(
         app_id: AppId,
         callback_id: CallbackId,
         appdata: usize,

--- a/kernel/src/common/deferred_call.rs
+++ b/kernel/src/common/deferred_call.rs
@@ -23,21 +23,21 @@ struct AtomicUsize {
 }
 
 impl AtomicUsize {
-    crate const fn new(v: usize) -> AtomicUsize {
+    pub(crate) const fn new(v: usize) -> AtomicUsize {
         AtomicUsize {
             v: UnsafeCell::new(v),
         }
     }
 
-    crate fn load_relaxed(&self) -> usize {
+    pub(crate) fn load_relaxed(&self) -> usize {
         unsafe { intrinsics::atomic_load_relaxed(self.v.get()) }
     }
 
-    crate fn store_relaxed(&self, val: usize) {
+    pub(crate) fn store_relaxed(&self, val: usize) {
         unsafe { intrinsics::atomic_store_relaxed(self.v.get(), val) }
     }
 
-    crate fn fetch_or_relaxed(&self, val: usize) {
+    pub(crate) fn fetch_or_relaxed(&self, val: usize) {
         unsafe { intrinsics::atomic_store_relaxed(self.v.get(), self.load_relaxed() | val) }
     }
 }

--- a/kernel/src/config.rs
+++ b/kernel/src/config.rs
@@ -27,24 +27,24 @@
 ///
 /// To change the configuration, modify the relevant values in the `CONFIG` constant object defined
 /// at the end of this file.
-crate struct Config {
+pub(crate) struct Config {
     /// Whether the kernel should trace syscalls to the debug output.
     ///
     /// If enabled, the kernel will print a message in the debug output for each system call and
     /// callback, with details including the application ID, and system call or callback parameters.
-    crate trace_syscalls: bool,
+    pub(crate) trace_syscalls: bool,
 
     /// Whether the kernel should show debugging output when loading processes.
     ///
     /// If enabled, the kernel will show from which addresses processes are loaded in flash and
     /// into which SRAM addresses. This can be useful to debug whether the kernel could
     /// successfully load processes, and whether the allocated SRAM is as expected.
-    crate debug_load_processes: bool,
+    pub(crate) debug_load_processes: bool,
 }
 
 /// A unique instance of `Config` where compile-time configuration options are defined. These
 /// options are available in the kernel crate to be used for relevant configuration.
-crate const CONFIG: Config = Config {
+pub(crate) const CONFIG: Config = Config {
     trace_syscalls: false,
     debug_load_processes: false,
 };

--- a/kernel/src/grant.rs
+++ b/kernel/src/grant.rs
@@ -11,7 +11,7 @@ use crate::sched::Kernel;
 
 /// Region of process memory reserved for the kernel.
 pub struct Grant<T: Default> {
-    crate kernel: &'static Kernel,
+    pub(crate) kernel: &'static Kernel,
     grant_num: usize,
     ptr: PhantomData<T>,
 }
@@ -143,7 +143,7 @@ impl<T: 'a + ?Sized> DerefMut for Borrowed<'a, T> {
 }
 
 impl<T: Default> Grant<T> {
-    crate fn new(kernel: &'static Kernel, grant_index: usize) -> Grant<T> {
+    pub(crate) fn new(kernel: &'static Kernel, grant_index: usize) -> Grant<T> {
         Grant {
             kernel: kernel,
             grant_num: grant_index,

--- a/kernel/src/ipc.rs
+++ b/kernel/src/ipc.rs
@@ -54,7 +54,7 @@ impl IPC {
 
     /// Schedule an IPC callback for a process. This is called by the main
     /// scheduler loop if an IPC task was queued for the process.
-    crate unsafe fn schedule_callback(
+    pub(crate) unsafe fn schedule_callback(
         &self,
         appid: AppId,
         otherapp: AppId,

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -11,7 +11,6 @@
     const_fn,
     panic_info_message,
     in_band_lifetimes,
-    crate_visibility_modifier,
     associated_type_defaults,
     try_trait
 )]

--- a/kernel/src/mem.rs
+++ b/kernel/src/mem.rs
@@ -69,7 +69,7 @@ pub struct AppSlice<L, T> {
 impl<L, T> AppSlice<L, T> {
     /// Safety: Trusts that `ptr` + `len` is a buffer in `appid` and that no
     /// other references to that memory range exist.
-    crate unsafe fn new(ptr: NonNull<T>, len: usize, appid: AppId) -> AppSlice<L, T> {
+    pub(crate) unsafe fn new(ptr: NonNull<T>, len: usize, appid: AppId) -> AppSlice<L, T> {
         AppSlice {
             ptr: AppPtr::new(ptr, appid),
             len: len,
@@ -89,7 +89,7 @@ impl<L, T> AppSlice<L, T> {
 
     /// Provide access to one app's AppSlice to another app. This is used for
     /// IPC.
-    crate unsafe fn expose_to(&self, appid: AppId) -> bool {
+    pub(crate) unsafe fn expose_to(&self, appid: AppId) -> bool {
         if appid != self.ptr.process {
             self.ptr
                 .process

--- a/kernel/src/memop.rs
+++ b/kernel/src/memop.rs
@@ -36,7 +36,7 @@ use crate::returncode::ReturnCode;
 ///   where the app has put the start of its heap. This is not strictly
 ///   necessary for correct operation, but allows for better debugging if the
 ///   app crashes.
-crate fn memop(process: &dyn ProcessType, op_type: usize, r1: usize) -> ReturnCode {
+pub(crate) fn memop(process: &dyn ProcessType, op_type: usize, r1: usize) -> ReturnCode {
     match op_type {
         // Op Type 0: BRK
         0 /* BRK */ => {

--- a/kernel/src/platform/mod.rs
+++ b/kernel/src/platform/mod.rs
@@ -7,7 +7,7 @@ use crate::syscall;
 use core::fmt::Write;
 
 pub mod mpu;
-crate mod systick;
+pub(crate) mod systick;
 
 /// Interface for individual boards.
 ///

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -1495,7 +1495,7 @@ fn exceeded_check(size: usize, allocated: usize) -> &'static str {
 }
 
 impl<C: 'static + Chip> Process<'a, C> {
-    crate unsafe fn create(
+    pub(crate) unsafe fn create(
         kernel: &'static Kernel,
         chip: &'static C,
         app_flash: &'static [u8],

--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -61,13 +61,13 @@ impl Kernel {
     }
 
     /// Something was scheduled for a process, so there is more work to do.
-    crate fn increment_work(&self) {
+    pub(crate) fn increment_work(&self) {
         self.work.increment();
     }
 
     /// Something finished for a process, so we decrement how much work there is
     /// to do.
-    crate fn decrement_work(&self) {
+    pub(crate) fn decrement_work(&self) {
         self.work.decrement();
     }
 
@@ -87,7 +87,7 @@ impl Kernel {
     /// different index in the processes array. Note that a match _will_ be
     /// found if the process still exists in the correct location in the array
     /// but is in any "stopped" state.
-    crate fn process_map_or<F, R>(&self, default: R, appid: AppId, closure: F) -> R
+    pub(crate) fn process_map_or<F, R>(&self, default: R, appid: AppId, closure: F) -> R
     where
         F: FnOnce(&dyn process::ProcessType) -> R,
     {
@@ -119,7 +119,7 @@ impl Kernel {
 
     /// Run a closure on every valid process. This will iterate the array of
     /// processes and call the closure on every process that exists.
-    crate fn process_each<F>(&self, closure: F)
+    pub(crate) fn process_each<F>(&self, closure: F)
     where
         F: Fn(&dyn process::ProcessType),
     {
@@ -134,7 +134,7 @@ impl Kernel {
     }
 
     /// Returns an iterator over all processes loaded by the kernel
-    crate fn get_process_iter(
+    pub(crate) fn get_process_iter(
         &self,
     ) -> core::iter::FilterMap<
         core::slice::Iter<Option<&dyn process::ProcessType>>,
@@ -175,7 +175,7 @@ impl Kernel {
     /// `FAIL`. That is, if the closure returns any other return code than
     /// `FAIL`, that value will be returned from this function and the iteration
     /// of the array of processes will stop.
-    crate fn process_until<F>(&self, closure: F) -> ReturnCode
+    pub(crate) fn process_until<F>(&self, closure: F) -> ReturnCode
     where
         F: Fn(&dyn process::ProcessType) -> ReturnCode,
     {
@@ -197,7 +197,7 @@ impl Kernel {
     /// useful if an app identifier is passed to the kernel from somewhere (such
     /// as from userspace) and needs to be expanded to a full `AppId` for use
     /// with other APIs.
-    crate fn lookup_app_by_identifier(&self, identifier: usize) -> Option<AppId> {
+    pub(crate) fn lookup_app_by_identifier(&self, identifier: usize) -> Option<AppId> {
         self.processes.iter().find_map(|&p| {
             p.map_or(None, |p2| {
                 if p2.appid().id() == identifier {
@@ -215,7 +215,7 @@ impl Kernel {
     ///
     /// This is needed for `AppId` itself to implement the `.index()` command to
     /// verify that the referenced app is still at the correct index.
-    crate fn appid_is_valid(&self, appid: &AppId) -> bool {
+    pub(crate) fn appid_is_valid(&self, appid: &AppId) -> bool {
         self.processes.get(appid.index).map_or(false, |p| {
             p.map_or(false, |process| process.appid().id() == appid.id())
         })
@@ -253,7 +253,7 @@ impl Kernel {
     ///
     /// In practice, this is called when processes are created, and the process
     /// memory is setup based on the number of current grants.
-    crate fn get_grant_count_and_finalize(&self) -> usize {
+    pub(crate) fn get_grant_count_and_finalize(&self) -> usize {
         self.grants_finalized.set(true);
         self.grant_counter.get()
     }
@@ -262,7 +262,7 @@ impl Kernel {
     ///
     /// Typically we just choose a larger number than we have used for any process
     /// before which ensures that the identifier is unique.
-    crate fn create_process_identifier(&self) -> usize {
+    pub(crate) fn create_process_identifier(&self) -> usize {
         self.process_identifier_max.get_and_increment()
     }
 


### PR DESCRIPTION
### Pull Request Overview

This commit removes the crate_visibility_modifier unstable pragma. The
upgrade path is a slightly nuanced variant of `s/crate/pub(crate)/g`, so
this change is a trivial noop.

### Testing Strategy

This change is a noop, so `make allcheck` is sufficient.

### TODO or Help Wanted

N/A

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
