### PR TITLE
kernel: stdize process_each and process_each_cap

### DIFF
--- a/capsules/src/process_console.rs
+++ b/capsules/src/process_console.rs
@@ -187,7 +187,7 @@ impl<'a, C: ProcessManagementCapability> ProcessConsole<'a, C> {
                             argument.map(|name| {
                                 self.kernel.process_each_capability(
                                     &self.capability,
-                                    |_i, proc| {
+                                    |proc| {
                                         let proc_name = proc.get_process_name();
                                         if proc_name == name {
                                             proc.resume();
@@ -201,7 +201,7 @@ impl<'a, C: ProcessManagementCapability> ProcessConsole<'a, C> {
                             argument.map(|name| {
                                 self.kernel.process_each_capability(
                                     &self.capability,
-                                    |_i, proc| {
+                                    |proc| {
                                         let proc_name = proc.get_process_name();
                                         if proc_name == name {
                                             proc.stop();
@@ -215,7 +215,7 @@ impl<'a, C: ProcessManagementCapability> ProcessConsole<'a, C> {
                             argument.map(|name| {
                                 self.kernel.process_each_capability(
                                     &self.capability,
-                                    |_i, proc| {
+                                    |proc| {
                                         let proc_name = proc.get_process_name();
                                         if proc_name == name {
                                             proc.set_fault_state();
@@ -227,11 +227,11 @@ impl<'a, C: ProcessManagementCapability> ProcessConsole<'a, C> {
                         } else if clean_str.starts_with("list") {
                             debug!(" PID    Name                Quanta  Syscalls  Dropped Callbacks  Restarts    State");
                             self.kernel
-                                .process_each_capability(&self.capability, |i, proc| {
+                                .process_each_capability(&self.capability, |proc| {
                                     let pname = proc.get_process_name();
                                     debug!(
-                                        "  {:02}\t{:<20}{:6}{:10}{:19}{:10}  {:?}",
-                                        i,
+                                        "  {:?}\t{:<20}{:6}{:10}{:19}{:10}  {:?}",
+                                        proc.appid(),
                                         pname,
                                         proc.debug_timeslice_expiration_count(),
                                         proc.debug_syscall_count(),

--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -147,21 +147,23 @@ impl Kernel {
         self.processes.iter()
     }
 
-    /// Run a closure on every valid process. This will iterate the
-    /// array of processes and call the closure on every process that
-    /// exists. Ths method is available outside the kernel crate but
-    /// requires a `ProcessManagementCapability` to use.
+    /// Run a closure on every valid process. This will iterate the array of
+    /// processes and call the closure on every process that exists.
+    ///
+    /// This is functionally the same as `process_each()`, but this method is
+    /// available outside the kernel crate and requires a
+    /// `ProcessManagementCapability` to use.
     pub fn process_each_capability<F>(
         &'static self,
         _capability: &dyn capabilities::ProcessManagementCapability,
         closure: F,
     ) where
-        F: Fn(usize, &dyn process::ProcessType),
+        F: Fn(&dyn process::ProcessType),
     {
-        for (i, process) in self.processes.iter().enumerate() {
+        for process in self.processes.iter() {
             match process {
                 Some(p) => {
-                    closure(i, *p);
+                    closure(*p);
                 }
                 None => {}
             }


### PR DESCRIPTION
With the updates to AppId, we no longer need to manually expose the index of a process in the processes array to get its ID. This makes it possible to make both versions of process_each in the kernel the same.

Also, this prohibits users of this interface from using the processes array index as an identifier (which it no longer is).

Thanks to @hudson-ayers for pointing this out.




### Testing Strategy

I ran the process console on hail and ensured that the process id changed after faulting the app and having it restart.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
