### PR TITLE
Add new restart policy and configure hail to restart failed apps

### DIFF
--- a/boards/hail/README.md
+++ b/boards/hail/README.md
@@ -160,6 +160,29 @@ cd tock/boards/hail
 make program
 ```
 
+### Tock Kernel Application Restart Policy
+
+The Tock kernel decides what happens when an application faults (e.g. the app
+tries to access memory not allocated to it). By default, recent versions of the
+Hail kernel will try to restart a failed application. If the process continues
+to fail and restart, the kernel will stop trying to restart it and instead will
+panic and print diagnostic information.
+
+If you want to try restarting applications manually, you can use the process
+console to do that. After running `tockloader listen`, run the "list" command to
+see what apps are installed, and the "fault" command to cause an app to fail and
+then be restarted.
+
+```bash
+$ tockloader listen
+list
+PID    Name                Quanta  Syscalls  Dropped Callbacks  Restarts    State
+00     hail                     0       235                  0         0  Yielded
+
+fault hail
+Process hail now faulted
+```
+
 ### Debugging the Kernel
 
 You can use gdb to debug a running kernel. The `jlink/` folder has some scripts

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -57,6 +57,6 @@ pub use crate::sched::Kernel;
 pub mod procs {
     pub use crate::process::{
         load_processes, AlwaysRestart, Error, FaultResponse, FunctionCall, Process,
-        ProcessRestartPolicy, ProcessType, ThresholdRestart,
+        ProcessRestartPolicy, ProcessType, ThresholdRestart, ThresholdRestartThenPanic,
     };
 }

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -352,6 +352,29 @@ impl ProcessRestartPolicy for ThresholdRestart {
     }
 }
 
+/// Implementation of `ProcessRestartPolicy` that uses a threshold to decide
+/// whether to restart an app. If the app has been restarted more times than the
+/// threshold then the system will panic.
+pub struct ThresholdRestartThenPanic {
+    threshold: usize,
+}
+
+impl ThresholdRestartThenPanic {
+    pub const fn new(threshold: usize) -> ThresholdRestartThenPanic {
+        ThresholdRestartThenPanic { threshold }
+    }
+}
+
+impl ProcessRestartPolicy for ThresholdRestartThenPanic {
+    fn should_restart(&self, process: &dyn ProcessType) -> bool {
+        if process.get_restart_count() <= self.threshold {
+            true
+        } else {
+            panic!("Restart threshold surpassed!");
+        }
+    }
+}
+
 /// Implementation of `ProcessRestartPolicy` that unconditionally restarts the
 /// app.
 pub struct AlwaysRestart {}


### PR DESCRIPTION
### Pull Request Overview

This pull request changes the default behavior on Hail to restart apps a finite number of times before causing a panic and printing diagnostic information. This better demonstrates Tock's capabilities for isolating applications and the kernel, and shows that a faulty application does not necessarily crash the entire system. It also makes it easier to test that applications can be restarted.

This also adds a new restart policy `ThresholdRestartThenPanic` so that applications can be restarted a couple times, and then panic is called so that the debugging information is printed. I think this balances experimenting with the new functionality and debugging new applications.


### Testing Strategy

Using the process console to fault the hail app.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
