### PR TITLE
kernel+process console: add grant usage

### DIFF
--- a/capsules/src/process_console.rs
+++ b/capsules/src/process_console.rs
@@ -13,6 +13,18 @@
 //!  - 'start n' starts the stopped process with name n
 //!  - 'fault n' forces the process with name n into a fault state
 //!
+//! ### `list` Command Fields:
+//!
+//! - `Quanta`: How many times this process has exceeded its alloted time
+//!   quanta.
+//! - `Dropped Callbacks`: How many callbacks were dropped for this process
+//!   because the queue was full.
+//! - `Restarts`: How many times this process has crashed and been restarted by
+//!   the kernel.
+//! - `State`: The state the process is in.
+//! - `Grants`: The number of grants that have been initialized for the process
+//!   out of the total number of grants defined by the kernel.
+//!
 //! Setup
 //! -----
 //!
@@ -69,9 +81,9 @@
 //! Initialization complete. Entering main loop
 //! Hello World!
 //! list
-//! PID    Name    Quanta  Syscalls  Dropped Callbacks  Restarts    State
-//! 00     blink        0       113                  0         0  Yielded
-//! 01     c_hello      0         8                  0         0  Yielded
+//! PID    Name    Quanta  Syscalls  Dropped Callbacks  Restarts    State  Grants
+//! 00     blink        0       113                  0         0  Yielded    1/12
+//! 01     c_hello      0         8                  0         0  Yielded    3/12
 //! ```
 //!
 //! To get a general view of the system, use the status command:
@@ -225,19 +237,26 @@ impl<'a, C: ProcessManagementCapability> ProcessConsole<'a, C> {
                                 );
                             });
                         } else if clean_str.starts_with("list") {
-                            debug!(" PID    Name                Quanta  Syscalls  Dropped Callbacks  Restarts    State");
+                            debug!(" PID    Name                Quanta  Syscalls  Dropped Callbacks  Restarts    State  Grants");
                             self.kernel
                                 .process_each_capability(&self.capability, |proc| {
+                                    let info: KernelInfo = KernelInfo::new(self.kernel);
+
                                     let pname = proc.get_process_name();
+                                    let appid = proc.appid();
+                                    let (grants_used, grants_total) = info.number_app_grant_uses(appid, &self.capability);
+
                                     debug!(
-                                        "  {:?}\t{:<20}{:6}{:10}{:19}{:10}  {:?}",
-                                        proc.appid(),
+                                        "  {:?}\t{:<20}{:6}{:10}{:19}{:10}  {:?}{:5}/{}",
+                                        appid,
                                         pname,
                                         proc.debug_timeslice_expiration_count(),
                                         proc.debug_syscall_count(),
                                         proc.debug_dropped_callback_count(),
                                         proc.get_restart_count(),
-                                        proc.get_state()
+                                        proc.get_state(),
+                                        grants_used,
+                                        grants_total
                                     );
                                 });
                         } else if clean_str.starts_with("status") {

--- a/capsules/src/process_console.rs
+++ b/capsules/src/process_console.rs
@@ -15,8 +15,12 @@
 //!
 //! ### `list` Command Fields:
 //!
+//! - `PID`: The identifier for the process. This can change if the process
+//!   restarts.
+//! - `Name`: The process name.
 //! - `Quanta`: How many times this process has exceeded its alloted time
 //!   quanta.
+//! - `Syscalls`: The number of system calls the process has made to the kernel.
 //! - `Dropped Callbacks`: How many callbacks were dropped for this process
 //!   because the queue was full.
 //! - `Restarts`: How many times this process has crashed and been restarted by

--- a/kernel/src/introspection.rs
+++ b/kernel/src/introspection.rs
@@ -123,6 +123,35 @@ impl KernelInfo {
             .process_map_or(0, app, |process| process.debug_timeslice_expiration_count())
     }
 
+    /// Returns a tuple of the (the number of grants in the grant region this
+    /// app has allocated, total number of grants that exist in the system).
+    pub fn number_app_grant_uses(
+        &self,
+        app: AppId,
+        _capability: &dyn ProcessManagementCapability,
+    ) -> (usize, usize) {
+        // Just need to get the number, this has already been finalized, but it
+        // doesn't hurt to call this again.
+        let number_of_grants = self.kernel.get_grant_count_and_finalize();
+        let mut used = 0;
+        self.kernel.process_map_or((), app, |process| {
+            for i in 0..number_of_grants {
+                unsafe {
+                    if let Some(ctr_ptr) = process.grant_ptr(i) {
+                        // If the pointer at that location is not NULL then the
+                        // grant memory has been allocated and the grant is
+                        // being used.
+                        if !(*ctr_ptr).is_null() {
+                            used += 1;
+                        }
+                    }
+                }
+            }
+        });
+
+        (used, number_of_grants)
+    }
+
     /// Returns the total number of times all processes have exceeded
     /// their timeslices.
     pub fn timeslice_expirations(&self, _capability: &dyn ProcessManagementCapability) -> usize {


### PR DESCRIPTION
Add a mechanism for the process console to show a rough idea of how many system resources a process is using by showing how many grants have been setup for it.

The "list" command in the process console now outputs:

```
PID     Name                Quanta  Syscalls  Dropped Callbacks  Restarts    State  Grants
0	hail                     0      3078                  0         0  Yielded    9/13
1	hello_loop               0       348                  0         0  Yielded    2/13
```




### Testing Strategy

This pull request was tested by running "list" on hail with the two apps you see above installed.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
