### PR TITLE
Add panic_button component and update the GPIO HIL accordingly.

### DIFF
--- a/boards/acd52832/src/main.rs
+++ b/boards/acd52832/src/main.rs
@@ -168,23 +168,26 @@ pub unsafe fn reset_handler() {
 
     // LEDs
     let led_pins = static_init!(
-        [(&'static dyn hil::gpio::Pin, capsules::led::ActivationMode); 4],
+        [(
+            &'static dyn hil::gpio::Pin,
+            kernel::hil::gpio::ActivationMode
+        ); 4],
         [
             (
                 &nrf52832::gpio::PORT[LED1_PIN],
-                capsules::led::ActivationMode::ActiveLow
+                kernel::hil::gpio::ActivationMode::ActiveLow
             ),
             (
                 &nrf52832::gpio::PORT[LED2_PIN],
-                capsules::led::ActivationMode::ActiveLow
+                kernel::hil::gpio::ActivationMode::ActiveLow
             ),
             (
                 &nrf52832::gpio::PORT[LED3_PIN],
-                capsules::led::ActivationMode::ActiveLow
+                kernel::hil::gpio::ActivationMode::ActiveLow
             ),
             (
                 &nrf52832::gpio::PORT[LED4_PIN],
-                capsules::led::ActivationMode::ActiveLow
+                kernel::hil::gpio::ActivationMode::ActiveLow
             ),
         ]
     );
@@ -235,25 +238,25 @@ pub unsafe fn reset_handler() {
             // 13
             (
                 &nrf52832::gpio::PORT[BUTTON1_PIN],
-                hil::gpio::ButtonMode::LowWhenPressed,
+                hil::gpio::ActivationMode::ActiveLow,
                 hil::gpio::FloatingState::PullUp
             ),
             // 14
             (
                 &nrf52832::gpio::PORT[BUTTON2_PIN],
-                hil::gpio::ButtonMode::LowWhenPressed,
+                hil::gpio::ActivationMode::ActiveLow,
                 hil::gpio::FloatingState::PullUp
             ),
             // 15
             (
                 &nrf52832::gpio::PORT[BUTTON3_PIN],
-                hil::gpio::ButtonMode::LowWhenPressed,
+                hil::gpio::ActivationMode::ActiveLow,
                 hil::gpio::FloatingState::PullUp
             ),
             // 16
             (
                 &nrf52832::gpio::PORT[BUTTON4_PIN],
-                hil::gpio::ButtonMode::LowWhenPressed,
+                hil::gpio::ActivationMode::ActiveLow,
                 hil::gpio::FloatingState::PullUp
             )
         ),

--- a/boards/acd52832/src/main.rs
+++ b/boards/acd52832/src/main.rs
@@ -235,25 +235,25 @@ pub unsafe fn reset_handler() {
             // 13
             (
                 &nrf52832::gpio::PORT[BUTTON1_PIN],
-                capsules::button::GpioMode::LowWhenPressed,
+                hil::gpio::ButtonMode::LowWhenPressed,
                 hil::gpio::FloatingState::PullUp
             ),
             // 14
             (
                 &nrf52832::gpio::PORT[BUTTON2_PIN],
-                capsules::button::GpioMode::LowWhenPressed,
+                hil::gpio::ButtonMode::LowWhenPressed,
                 hil::gpio::FloatingState::PullUp
             ),
             // 15
             (
                 &nrf52832::gpio::PORT[BUTTON3_PIN],
-                capsules::button::GpioMode::LowWhenPressed,
+                hil::gpio::ButtonMode::LowWhenPressed,
                 hil::gpio::FloatingState::PullUp
             ),
             // 16
             (
                 &nrf52832::gpio::PORT[BUTTON4_PIN],
-                capsules::button::GpioMode::LowWhenPressed,
+                hil::gpio::ButtonMode::LowWhenPressed,
                 hil::gpio::FloatingState::PullUp
             )
         ),

--- a/boards/arty-e21/src/main.rs
+++ b/boards/arty-e21/src/main.rs
@@ -147,23 +147,23 @@ pub unsafe fn reset_handler() {
     let led_pins = static_init!(
         [(
             &'static dyn kernel::hil::gpio::Pin,
-            capsules::led::ActivationMode
+            kernel::hil::gpio::ActivationMode
         ); 3],
         [
             (
                 // Red
                 &arty_e21::gpio::PORT[0],
-                capsules::led::ActivationMode::ActiveHigh
+                kernel::hil::gpio::ActivationMode::ActiveHigh
             ),
             (
                 // Green
                 &arty_e21::gpio::PORT[1],
-                capsules::led::ActivationMode::ActiveHigh
+                kernel::hil::gpio::ActivationMode::ActiveHigh
             ),
             (
                 // Blue
                 &arty_e21::gpio::PORT[2],
-                capsules::led::ActivationMode::ActiveHigh
+                kernel::hil::gpio::ActivationMode::ActiveHigh
             ),
         ]
     );
@@ -176,7 +176,7 @@ pub unsafe fn reset_handler() {
     let button = components::button::ButtonComponent::new(board_kernel).finalize(
         components::button_component_helper!((
             &arty_e21::gpio::PORT[4],
-            kernel::hil::gpio::ButtonMode::HighWhenPressed,
+            kernel::hil::gpio::ActivationMode::ActiveHigh,
             kernel::hil::gpio::FloatingState::PullNone
         )),
     );

--- a/boards/arty-e21/src/main.rs
+++ b/boards/arty-e21/src/main.rs
@@ -176,7 +176,7 @@ pub unsafe fn reset_handler() {
     let button = components::button::ButtonComponent::new(board_kernel).finalize(
         components::button_component_helper!((
             &arty_e21::gpio::PORT[4],
-            capsules::button::GpioMode::HighWhenPressed,
+            kernel::hil::gpio::ButtonMode::HighWhenPressed,
             kernel::hil::gpio::FloatingState::PullNone
         )),
     );

--- a/boards/components/src/button.rs
+++ b/boards/components/src/button.rs
@@ -6,14 +6,14 @@
 //! let button = components::button::ButtonComponent::new(board_kernel).finalize(
 //!     components::button_component_helper!((
 //!         &sam4l::gpio::PC[24],
-//!         kernel::hil::gpio::ButtonMode::LowWhenPressed,
+//!         kernel::hil::gpio::ActivationMode::ActiveLow,
 //!         kernel::hil::gpio::FloatingState::PullUp
 //!     )),
 //! );
 //! ```
 //!
-//! Typically, `ButtonMode::LowWhenPressed` will be associated with `FloatingState::PullUp`
-//! whereas `ButtonMode::HighWhenPressed` will be paired with `FloatingState::PullDown`.
+//! Typically, `ActivationMode::ActiveLow` will be associated with `FloatingState::PullUp`
+//! whereas `ActivationMode::ActiveHigh` will be paired with `FloatingState::PullDown`.
 //! `FloatingState::None` will be used when the board provides external pull-up/pull-down
 //! resistors.
 
@@ -31,7 +31,7 @@ macro_rules! button_component_helper {
         const NUM_BUTTONS: usize = count_expressions!($($P),+);
 
         static_init!(
-            [(&'static dyn kernel::hil::gpio::InterruptValuePin, kernel::hil::gpio::ButtonMode, kernel::hil::gpio::FloatingState); NUM_BUTTONS],
+            [(&'static dyn kernel::hil::gpio::InterruptValuePin, kernel::hil::gpio::ActivationMode, kernel::hil::gpio::FloatingState); NUM_BUTTONS],
             [
                 $(
                     (static_init!(InterruptValueWrapper, InterruptValueWrapper::new($P))
@@ -60,7 +60,7 @@ impl ButtonComponent {
 impl Component for ButtonComponent {
     type StaticInput = &'static [(
         &'static dyn kernel::hil::gpio::InterruptValuePin,
-        kernel::hil::gpio::ButtonMode,
+        kernel::hil::gpio::ActivationMode,
         kernel::hil::gpio::FloatingState,
     )];
     type Output = &'static capsules::button::Button<'static>;

--- a/boards/components/src/button.rs
+++ b/boards/components/src/button.rs
@@ -6,14 +6,14 @@
 //! let button = components::button::ButtonComponent::new(board_kernel).finalize(
 //!     components::button_component_helper!((
 //!         &sam4l::gpio::PC[24],
-//!         capsules::button::GpioMode::LowWhenPressed,
+//!         kernel::hil::gpio::ButtonMode::LowWhenPressed,
 //!         kernel::hil::gpio::FloatingState::PullUp
 //!     )),
 //! );
 //! ```
 //!
-//! Typically, `GpioMode::LowWhenPressed` will be associated with `FloatingState::PullUp`
-//! whereas `GpioMode::HighWhenPressed` will be paired with `FloatingState::PullDown`.
+//! Typically, `ButtonMode::LowWhenPressed` will be associated with `FloatingState::PullUp`
+//! whereas `ButtonMode::HighWhenPressed` will be paired with `FloatingState::PullDown`.
 //! `FloatingState::None` will be used when the board provides external pull-up/pull-down
 //! resistors.
 
@@ -31,7 +31,7 @@ macro_rules! button_component_helper {
         const NUM_BUTTONS: usize = count_expressions!($($P),+);
 
         static_init!(
-            [(&'static dyn kernel::hil::gpio::InterruptValuePin, capsules::button::GpioMode, kernel::hil::gpio::FloatingState); NUM_BUTTONS],
+            [(&'static dyn kernel::hil::gpio::InterruptValuePin, kernel::hil::gpio::ButtonMode, kernel::hil::gpio::FloatingState); NUM_BUTTONS],
             [
                 $(
                     (static_init!(InterruptValueWrapper, InterruptValueWrapper::new($P))
@@ -60,7 +60,7 @@ impl ButtonComponent {
 impl Component for ButtonComponent {
     type StaticInput = &'static [(
         &'static dyn kernel::hil::gpio::InterruptValuePin,
-        capsules::button::GpioMode,
+        kernel::hil::gpio::ButtonMode,
         kernel::hil::gpio::FloatingState,
     )];
     type Output = &'static capsules::button::Button<'static>;

--- a/boards/components/src/led.rs
+++ b/boards/components/src/led.rs
@@ -4,9 +4,9 @@
 //! -----
 //! ```rust
 //! let led = components::led::LedsComponent::new().finalize(components::led_component_helper!(
-//!     (&nrf52840::gpio::PORT[LED_RED_PIN], capsules::led::ActivationMode::ActiveLow),
-//!     (&nrf52840::gpio::PORT[LED_GREEN_PIN], capsules::led::ActivationMode::ActiveLow),
-//!     (&nrf52840::gpio::PORT[LED_BLUE_PIN], capsules::led::ActivationMode::ActiveLow)
+//!     (&nrf52840::gpio::PORT[LED_RED_PIN], kernel::hil::gpio::ActivationMode::ActiveLow),
+//!     (&nrf52840::gpio::PORT[LED_GREEN_PIN], kernel::hil::gpio::ActivationMode::ActiveLow),
+//!     (&nrf52840::gpio::PORT[LED_BLUE_PIN], kernel::hil::gpio::ActivationMode::ActiveLow)
 //! ));
 //! ```
 
@@ -24,7 +24,7 @@ macro_rules! led_component_helper {
         static_init!(
             [(
                 &'static dyn kernel::hil::gpio::Pin,
-                capsules::led::ActivationMode
+                kernel::hil::gpio::ActivationMode
             ); NUM_LEDS],
             [
                 $($P,)*
@@ -44,7 +44,7 @@ impl LedsComponent {
 impl Component for LedsComponent {
     type StaticInput = &'static [(
         &'static dyn kernel::hil::gpio::Pin,
-        capsules::led::ActivationMode,
+        kernel::hil::gpio::ActivationMode,
     )];
     type Output = &'static capsules::led::LED<'static>;
 

--- a/boards/components/src/lib.rs
+++ b/boards/components/src/lib.rs
@@ -14,6 +14,7 @@ pub mod debug_writer;
 pub mod isl29035;
 pub mod lldb;
 pub mod nrf51822;
+pub mod panic_button;
 pub mod process_console;
 pub mod rng;
 pub mod segger_rtt;

--- a/boards/components/src/panic_button.rs
+++ b/boards/components/src/panic_button.rs
@@ -1,0 +1,79 @@
+//! Component to cause a button press to trigger a kernel panic.
+//!
+//! This can be useful especially when developping or debugging console
+//! capsules.
+//!
+//! Usage
+//! -----
+//!
+//! ```rust
+//! components::panic_button::PanicButtonComponent::new(
+//!     &sam4l::gpio::PC[24],
+//!     kernel::hil::gpio::ButtonMode::LowWhenPressed,
+//!     kernel::hil::gpio::FloatingState::PullUp
+//! ).finalize(());
+//! ```
+
+use kernel::component::Component;
+use kernel::hil::gpio;
+use kernel::static_init;
+
+pub struct PanicButtonComponent<'a> {
+    pin: &'a dyn gpio::InterruptPin,
+    mode: gpio::ButtonMode,
+    floating_state: gpio::FloatingState,
+}
+
+impl<'a> PanicButtonComponent<'a> {
+    pub fn new(
+        pin: &'a dyn gpio::InterruptPin,
+        mode: gpio::ButtonMode,
+        floating_state: gpio::FloatingState,
+    ) -> Self {
+        PanicButtonComponent {
+            pin,
+            mode,
+            floating_state,
+        }
+    }
+}
+
+impl Component for PanicButtonComponent<'static> {
+    type StaticInput = ();
+    type Output = ();
+
+    unsafe fn finalize(self, _: Self::StaticInput) -> Self::Output {
+        let panic_button = static_init!(
+            PanicButton,
+            PanicButton::new(self.pin, self.mode, self.floating_state)
+        );
+        self.pin.set_client(panic_button);
+    }
+}
+
+struct PanicButton<'a> {
+    pin: &'a dyn gpio::InterruptPin,
+    mode: gpio::ButtonMode,
+}
+
+impl<'a> PanicButton<'a> {
+    fn new(
+        pin: &'a dyn gpio::InterruptPin,
+        mode: gpio::ButtonMode,
+        floating_state: gpio::FloatingState,
+    ) -> Self {
+        pin.make_input();
+        pin.set_floating_state(floating_state);
+        pin.enable_interrupts(gpio::InterruptEdge::EitherEdge);
+
+        PanicButton { pin, mode }
+    }
+}
+
+impl gpio::Client for PanicButton<'_> {
+    fn fired(&self) {
+        if self.pin.read_button(self.mode) == gpio::ButtonState::Pressed {
+            panic!("Panic button pressed");
+        }
+    }
+}

--- a/boards/components/src/panic_button.rs
+++ b/boards/components/src/panic_button.rs
@@ -14,6 +14,7 @@
 //! ).finalize(());
 //! ```
 
+use capsules::panic_button::PanicButton;
 use kernel::component::Component;
 use kernel::hil::gpio;
 use kernel::static_init;
@@ -48,32 +49,5 @@ impl Component for PanicButtonComponent<'static> {
             PanicButton::new(self.pin, self.mode, self.floating_state)
         );
         self.pin.set_client(panic_button);
-    }
-}
-
-struct PanicButton<'a> {
-    pin: &'a dyn gpio::InterruptPin,
-    mode: gpio::ActivationMode,
-}
-
-impl<'a> PanicButton<'a> {
-    fn new(
-        pin: &'a dyn gpio::InterruptPin,
-        mode: gpio::ActivationMode,
-        floating_state: gpio::FloatingState,
-    ) -> Self {
-        pin.make_input();
-        pin.set_floating_state(floating_state);
-        pin.enable_interrupts(gpio::InterruptEdge::EitherEdge);
-
-        PanicButton { pin, mode }
-    }
-}
-
-impl gpio::Client for PanicButton<'_> {
-    fn fired(&self) {
-        if self.pin.read_activation(self.mode) == gpio::ActivationState::Active {
-            panic!("Panic button pressed");
-        }
     }
 }

--- a/boards/components/src/panic_button.rs
+++ b/boards/components/src/panic_button.rs
@@ -9,7 +9,7 @@
 //! ```rust
 //! components::panic_button::PanicButtonComponent::new(
 //!     &sam4l::gpio::PC[24],
-//!     kernel::hil::gpio::ButtonMode::LowWhenPressed,
+//!     kernel::hil::gpio::ActivationMode::ActiveLow,
 //!     kernel::hil::gpio::FloatingState::PullUp
 //! ).finalize(());
 //! ```
@@ -20,14 +20,14 @@ use kernel::static_init;
 
 pub struct PanicButtonComponent<'a> {
     pin: &'a dyn gpio::InterruptPin,
-    mode: gpio::ButtonMode,
+    mode: gpio::ActivationMode,
     floating_state: gpio::FloatingState,
 }
 
 impl<'a> PanicButtonComponent<'a> {
     pub fn new(
         pin: &'a dyn gpio::InterruptPin,
-        mode: gpio::ButtonMode,
+        mode: gpio::ActivationMode,
         floating_state: gpio::FloatingState,
     ) -> Self {
         PanicButtonComponent {
@@ -53,13 +53,13 @@ impl Component for PanicButtonComponent<'static> {
 
 struct PanicButton<'a> {
     pin: &'a dyn gpio::InterruptPin,
-    mode: gpio::ButtonMode,
+    mode: gpio::ActivationMode,
 }
 
 impl<'a> PanicButton<'a> {
     fn new(
         pin: &'a dyn gpio::InterruptPin,
-        mode: gpio::ButtonMode,
+        mode: gpio::ActivationMode,
         floating_state: gpio::FloatingState,
     ) -> Self {
         pin.make_input();
@@ -72,7 +72,7 @@ impl<'a> PanicButton<'a> {
 
 impl gpio::Client for PanicButton<'_> {
     fn fired(&self) {
-        if self.pin.read_button(self.mode) == gpio::ButtonState::Pressed {
+        if self.pin.read_activation(self.mode) == gpio::ActivationState::Active {
             panic!("Panic button pressed");
         }
     }

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -320,7 +320,7 @@ pub unsafe fn reset_handler() {
     let button = components::button::ButtonComponent::new(board_kernel).finalize(
         components::button_component_helper!((
             &sam4l::gpio::PA[16],
-            capsules::button::GpioMode::LowWhenPressed,
+            kernel::hil::gpio::ButtonMode::LowWhenPressed,
             kernel::hil::gpio::FloatingState::PullNone
         )),
     );

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -304,15 +304,15 @@ pub unsafe fn reset_handler() {
     let led = components::led::LedsComponent::new().finalize(components::led_component_helper!(
         (
             &sam4l::gpio::PA[13],
-            capsules::led::ActivationMode::ActiveLow
+            kernel::hil::gpio::ActivationMode::ActiveLow
         ), // Red
         (
             &sam4l::gpio::PA[15],
-            capsules::led::ActivationMode::ActiveLow
+            kernel::hil::gpio::ActivationMode::ActiveLow
         ), // Green
         (
             &sam4l::gpio::PA[14],
-            capsules::led::ActivationMode::ActiveLow
+            kernel::hil::gpio::ActivationMode::ActiveLow
         ) // Blue
     ));
 
@@ -320,7 +320,7 @@ pub unsafe fn reset_handler() {
     let button = components::button::ButtonComponent::new(board_kernel).finalize(
         components::button_component_helper!((
             &sam4l::gpio::PA[16],
-            kernel::hil::gpio::ButtonMode::LowWhenPressed,
+            kernel::hil::gpio::ActivationMode::ActiveLow,
             kernel::hil::gpio::FloatingState::PullNone
         )),
     );

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -371,12 +371,12 @@ pub unsafe fn reset_handler() {
 
     let led = LedsComponent::new().finalize(components::led_component_helper!((
         &sam4l::gpio::PC[10],
-        capsules::led::ActivationMode::ActiveHigh
+        kernel::hil::gpio::ActivationMode::ActiveHigh
     )));
     let button = components::button::ButtonComponent::new(board_kernel).finalize(
         components::button_component_helper!((
             &sam4l::gpio::PC[24],
-            kernel::hil::gpio::ButtonMode::LowWhenPressed,
+            kernel::hil::gpio::ActivationMode::ActiveLow,
             kernel::hil::gpio::FloatingState::PullNone
         )),
     );

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -376,7 +376,7 @@ pub unsafe fn reset_handler() {
     let button = components::button::ButtonComponent::new(board_kernel).finalize(
         components::button_component_helper!((
             &sam4l::gpio::PC[24],
-            capsules::button::GpioMode::LowWhenPressed,
+            kernel::hil::gpio::ButtonMode::LowWhenPressed,
             kernel::hil::gpio::FloatingState::PullNone
         )),
     );

--- a/boards/launchxl/src/main.rs
+++ b/boards/launchxl/src/main.rs
@@ -194,16 +194,16 @@ pub unsafe fn reset_handler() {
     let led_pins = static_init!(
         [(
             &'static dyn kernel::hil::gpio::Pin,
-            capsules::led::ActivationMode
+            kernel::hil::gpio::ActivationMode
         ); 2],
         [
             (
                 &cc26x2::gpio::PORT[pinmap.red_led],
-                capsules::led::ActivationMode::ActiveHigh
+                kernel::hil::gpio::ActivationMode::ActiveHigh
             ), // Red
             (
                 &cc26x2::gpio::PORT[pinmap.green_led],
-                capsules::led::ActivationMode::ActiveHigh
+                kernel::hil::gpio::ActivationMode::ActiveHigh
             ), // Green
         ]
     );
@@ -217,12 +217,12 @@ pub unsafe fn reset_handler() {
         components::button_component_helper!(
             (
                 &cc26x2::gpio::PORT[pinmap.button1],
-                hil::gpio::ButtonMode::LowWhenPressed,
+                hil::gpio::ActivationMode::ActiveLow,
                 hil::gpio::FloatingState::PullUp
             ),
             (
                 &cc26x2::gpio::PORT[pinmap.button2],
-                hil::gpio::ButtonMode::LowWhenPressed,
+                hil::gpio::ActivationMode::ActiveLow,
                 hil::gpio::FloatingState::PullUp
             )
         ),

--- a/boards/launchxl/src/main.rs
+++ b/boards/launchxl/src/main.rs
@@ -217,12 +217,12 @@ pub unsafe fn reset_handler() {
         components::button_component_helper!(
             (
                 &cc26x2::gpio::PORT[pinmap.button1],
-                capsules::button::GpioMode::LowWhenPressed,
+                hil::gpio::ButtonMode::LowWhenPressed,
                 hil::gpio::FloatingState::PullUp
             ),
             (
                 &cc26x2::gpio::PORT[pinmap.button2],
-                capsules::button::GpioMode::LowWhenPressed,
+                hil::gpio::ButtonMode::LowWhenPressed,
                 hil::gpio::FloatingState::PullUp
             )
         ),

--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -99,7 +99,7 @@ pub unsafe fn reset_handler() {
     let button = components::button::ButtonComponent::new(board_kernel).finalize(
         components::button_component_helper!((
             &nrf52840::gpio::PORT[BUTTON_PIN],
-            kernel::hil::gpio::ButtonMode::LowWhenPressed,
+            kernel::hil::gpio::ActivationMode::ActiveLow,
             kernel::hil::gpio::FloatingState::PullUp
         )),
     );
@@ -107,19 +107,19 @@ pub unsafe fn reset_handler() {
     let led = components::led::LedsComponent::new().finalize(components::led_component_helper!(
         (
             &nrf52840::gpio::PORT[LED1_PIN],
-            capsules::led::ActivationMode::ActiveLow
+            kernel::hil::gpio::ActivationMode::ActiveLow
         ),
         (
             &nrf52840::gpio::PORT[LED2_R_PIN],
-            capsules::led::ActivationMode::ActiveLow
+            kernel::hil::gpio::ActivationMode::ActiveLow
         ),
         (
             &nrf52840::gpio::PORT[LED2_G_PIN],
-            capsules::led::ActivationMode::ActiveLow
+            kernel::hil::gpio::ActivationMode::ActiveLow
         ),
         (
             &nrf52840::gpio::PORT[LED2_B_PIN],
-            capsules::led::ActivationMode::ActiveLow
+            kernel::hil::gpio::ActivationMode::ActiveLow
         )
     ));
     let chip = static_init!(nrf52840::chip::Chip, nrf52840::chip::new());

--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -99,7 +99,7 @@ pub unsafe fn reset_handler() {
     let button = components::button::ButtonComponent::new(board_kernel).finalize(
         components::button_component_helper!((
             &nrf52840::gpio::PORT[BUTTON_PIN],
-            capsules::button::GpioMode::LowWhenPressed,
+            kernel::hil::gpio::ButtonMode::LowWhenPressed,
             kernel::hil::gpio::FloatingState::PullUp
         )),
     );

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -171,22 +171,22 @@ pub unsafe fn reset_handler() {
         components::button_component_helper!(
             (
                 &nrf52840::gpio::PORT[BUTTON1_PIN],
-                capsules::button::GpioMode::LowWhenPressed,
+                kernel::hil::gpio::ButtonMode::LowWhenPressed,
                 kernel::hil::gpio::FloatingState::PullUp
             ), //13
             (
                 &nrf52840::gpio::PORT[BUTTON2_PIN],
-                capsules::button::GpioMode::LowWhenPressed,
+                kernel::hil::gpio::ButtonMode::LowWhenPressed,
                 kernel::hil::gpio::FloatingState::PullUp
             ), //14
             (
                 &nrf52840::gpio::PORT[BUTTON3_PIN],
-                capsules::button::GpioMode::LowWhenPressed,
+                kernel::hil::gpio::ButtonMode::LowWhenPressed,
                 kernel::hil::gpio::FloatingState::PullUp
             ), //15
             (
                 &nrf52840::gpio::PORT[BUTTON4_PIN],
-                capsules::button::GpioMode::LowWhenPressed,
+                kernel::hil::gpio::ButtonMode::LowWhenPressed,
                 kernel::hil::gpio::FloatingState::PullUp
             ) //16
         ),

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -171,22 +171,22 @@ pub unsafe fn reset_handler() {
         components::button_component_helper!(
             (
                 &nrf52840::gpio::PORT[BUTTON1_PIN],
-                kernel::hil::gpio::ButtonMode::LowWhenPressed,
+                kernel::hil::gpio::ActivationMode::ActiveLow,
                 kernel::hil::gpio::FloatingState::PullUp
             ), //13
             (
                 &nrf52840::gpio::PORT[BUTTON2_PIN],
-                kernel::hil::gpio::ButtonMode::LowWhenPressed,
+                kernel::hil::gpio::ActivationMode::ActiveLow,
                 kernel::hil::gpio::FloatingState::PullUp
             ), //14
             (
                 &nrf52840::gpio::PORT[BUTTON3_PIN],
-                kernel::hil::gpio::ButtonMode::LowWhenPressed,
+                kernel::hil::gpio::ActivationMode::ActiveLow,
                 kernel::hil::gpio::FloatingState::PullUp
             ), //15
             (
                 &nrf52840::gpio::PORT[BUTTON4_PIN],
-                kernel::hil::gpio::ButtonMode::LowWhenPressed,
+                kernel::hil::gpio::ActivationMode::ActiveLow,
                 kernel::hil::gpio::FloatingState::PullUp
             ) //16
         ),
@@ -195,19 +195,19 @@ pub unsafe fn reset_handler() {
     let led = components::led::LedsComponent::new().finalize(components::led_component_helper!(
         (
             &nrf52840::gpio::PORT[LED1_PIN],
-            capsules::led::ActivationMode::ActiveLow
+            kernel::hil::gpio::ActivationMode::ActiveLow
         ),
         (
             &nrf52840::gpio::PORT[LED2_PIN],
-            capsules::led::ActivationMode::ActiveLow
+            kernel::hil::gpio::ActivationMode::ActiveLow
         ),
         (
             &nrf52840::gpio::PORT[LED3_PIN],
-            capsules::led::ActivationMode::ActiveLow
+            kernel::hil::gpio::ActivationMode::ActiveLow
         ),
         (
             &nrf52840::gpio::PORT[LED4_PIN],
-            capsules::led::ActivationMode::ActiveLow
+            kernel::hil::gpio::ActivationMode::ActiveLow
         )
     ));
     let chip = static_init!(nrf52840::chip::Chip, nrf52840::chip::new());

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -152,22 +152,22 @@ pub unsafe fn reset_handler() {
         components::button_component_helper!(
             (
                 &nrf52832::gpio::PORT[BUTTON1_PIN],
-                capsules::button::GpioMode::LowWhenPressed,
+                kernel::hil::gpio::ButtonMode::LowWhenPressed,
                 kernel::hil::gpio::FloatingState::PullUp
             ), //13
             (
                 &nrf52832::gpio::PORT[BUTTON2_PIN],
-                capsules::button::GpioMode::LowWhenPressed,
+                kernel::hil::gpio::ButtonMode::LowWhenPressed,
                 kernel::hil::gpio::FloatingState::PullUp
             ), //14
             (
                 &nrf52832::gpio::PORT[BUTTON3_PIN],
-                capsules::button::GpioMode::LowWhenPressed,
+                kernel::hil::gpio::ButtonMode::LowWhenPressed,
                 kernel::hil::gpio::FloatingState::PullUp
             ), //15
             (
                 &nrf52832::gpio::PORT[BUTTON4_PIN],
-                capsules::button::GpioMode::LowWhenPressed,
+                kernel::hil::gpio::ButtonMode::LowWhenPressed,
                 kernel::hil::gpio::FloatingState::PullUp
             ) //16
         ),

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -152,22 +152,22 @@ pub unsafe fn reset_handler() {
         components::button_component_helper!(
             (
                 &nrf52832::gpio::PORT[BUTTON1_PIN],
-                kernel::hil::gpio::ButtonMode::LowWhenPressed,
+                kernel::hil::gpio::ActivationMode::ActiveLow,
                 kernel::hil::gpio::FloatingState::PullUp
             ), //13
             (
                 &nrf52832::gpio::PORT[BUTTON2_PIN],
-                kernel::hil::gpio::ButtonMode::LowWhenPressed,
+                kernel::hil::gpio::ActivationMode::ActiveLow,
                 kernel::hil::gpio::FloatingState::PullUp
             ), //14
             (
                 &nrf52832::gpio::PORT[BUTTON3_PIN],
-                kernel::hil::gpio::ButtonMode::LowWhenPressed,
+                kernel::hil::gpio::ActivationMode::ActiveLow,
                 kernel::hil::gpio::FloatingState::PullUp
             ), //15
             (
                 &nrf52832::gpio::PORT[BUTTON4_PIN],
-                kernel::hil::gpio::ButtonMode::LowWhenPressed,
+                kernel::hil::gpio::ActivationMode::ActiveLow,
                 kernel::hil::gpio::FloatingState::PullUp
             ) //16
         ),
@@ -176,19 +176,19 @@ pub unsafe fn reset_handler() {
     let led = components::led::LedsComponent::new().finalize(components::led_component_helper!(
         (
             &nrf52832::gpio::PORT[LED1_PIN],
-            capsules::led::ActivationMode::ActiveLow
+            kernel::hil::gpio::ActivationMode::ActiveLow
         ),
         (
             &nrf52832::gpio::PORT[LED2_PIN],
-            capsules::led::ActivationMode::ActiveLow
+            kernel::hil::gpio::ActivationMode::ActiveLow
         ),
         (
             &nrf52832::gpio::PORT[LED3_PIN],
-            capsules::led::ActivationMode::ActiveLow
+            kernel::hil::gpio::ActivationMode::ActiveLow
         ),
         (
             &nrf52832::gpio::PORT[LED4_PIN],
-            capsules::led::ActivationMode::ActiveLow
+            kernel::hil::gpio::ActivationMode::ActiveLow
         )
     ));
     let chip = static_init!(nrf52832::chip::Chip, nrf52832::chip::new());

--- a/boards/nucleo_f429zi/src/main.rs
+++ b/boards/nucleo_f429zi/src/main.rs
@@ -261,20 +261,20 @@ pub unsafe fn reset_handler() {
     let led_pins = static_init!(
         [(
             &'static dyn kernel::hil::gpio::Pin,
-            capsules::led::ActivationMode
+            kernel::hil::gpio::ActivationMode
         ); NUM_LEDS],
         [
             (
                 stm32f4xx::gpio::PinId::PB00.get_pin().as_ref().unwrap(),
-                capsules::led::ActivationMode::ActiveHigh
+                kernel::hil::gpio::ActivationMode::ActiveHigh
             ),
             (
                 stm32f4xx::gpio::PinId::PB07.get_pin().as_ref().unwrap(),
-                capsules::led::ActivationMode::ActiveHigh
+                kernel::hil::gpio::ActivationMode::ActiveHigh
             ),
             (
                 stm32f4xx::gpio::PinId::PB14.get_pin().as_ref().unwrap(),
-                capsules::led::ActivationMode::ActiveHigh
+                kernel::hil::gpio::ActivationMode::ActiveHigh
             )
         ]
     );
@@ -287,7 +287,7 @@ pub unsafe fn reset_handler() {
     let button = components::button::ButtonComponent::new(board_kernel).finalize(
         components::button_component_helper!((
             stm32f4xx::gpio::PinId::PC13.get_pin().as_ref().unwrap(),
-            kernel::hil::gpio::ButtonMode::LowWhenPressed,
+            kernel::hil::gpio::ActivationMode::ActiveLow,
             kernel::hil::gpio::FloatingState::PullNone
         )),
     );

--- a/boards/nucleo_f429zi/src/main.rs
+++ b/boards/nucleo_f429zi/src/main.rs
@@ -287,7 +287,7 @@ pub unsafe fn reset_handler() {
     let button = components::button::ButtonComponent::new(board_kernel).finalize(
         components::button_component_helper!((
             stm32f4xx::gpio::PinId::PC13.get_pin().as_ref().unwrap(),
-            capsules::button::GpioMode::LowWhenPressed,
+            kernel::hil::gpio::ButtonMode::LowWhenPressed,
             kernel::hil::gpio::FloatingState::PullNone
         )),
     );

--- a/boards/nucleo_f446re/src/main.rs
+++ b/boards/nucleo_f446re/src/main.rs
@@ -251,11 +251,11 @@ pub unsafe fn reset_handler() {
     let led_pins = static_init!(
         [(
             &'static dyn kernel::hil::gpio::Pin,
-            capsules::led::ActivationMode
+            kernel::hil::gpio::ActivationMode
         ); 1],
         [(
             stm32f4xx::gpio::PinId::PA05.get_pin().as_ref().unwrap(),
-            capsules::led::ActivationMode::ActiveHigh
+            kernel::hil::gpio::ActivationMode::ActiveHigh
         )]
     );
     let led = static_init!(
@@ -267,7 +267,7 @@ pub unsafe fn reset_handler() {
     let button = components::button::ButtonComponent::new(board_kernel).finalize(
         components::button_component_helper!((
             stm32f4xx::gpio::PinId::PC13.get_pin().as_ref().unwrap(),
-            kernel::hil::gpio::ButtonMode::LowWhenPressed,
+            kernel::hil::gpio::ActivationMode::ActiveLow,
             kernel::hil::gpio::FloatingState::PullNone
         )),
     );

--- a/boards/nucleo_f446re/src/main.rs
+++ b/boards/nucleo_f446re/src/main.rs
@@ -267,7 +267,7 @@ pub unsafe fn reset_handler() {
     let button = components::button::ButtonComponent::new(board_kernel).finalize(
         components::button_component_helper!((
             stm32f4xx::gpio::PinId::PC13.get_pin().as_ref().unwrap(),
-            capsules::button::GpioMode::LowWhenPressed,
+            kernel::hil::gpio::ButtonMode::LowWhenPressed,
             kernel::hil::gpio::FloatingState::PullNone
         )),
     );

--- a/boards/opentitan/src/main.rs
+++ b/boards/opentitan/src/main.rs
@@ -136,35 +136,35 @@ pub unsafe fn reset_handler() {
     let led = components::led::LedsComponent::new().finalize(components::led_component_helper!(
         (
             &ibex::gpio::PORT[7],
-            capsules::led::ActivationMode::ActiveLow
+            kernel::hil::gpio::ActivationMode::ActiveLow
         ),
         (
             &ibex::gpio::PORT[8],
-            capsules::led::ActivationMode::ActiveLow
+            kernel::hil::gpio::ActivationMode::ActiveLow
         ),
         (
             &ibex::gpio::PORT[9],
-            capsules::led::ActivationMode::ActiveLow
+            kernel::hil::gpio::ActivationMode::ActiveLow
         ),
         (
             &ibex::gpio::PORT[10],
-            capsules::led::ActivationMode::ActiveLow
+            kernel::hil::gpio::ActivationMode::ActiveLow
         ),
         (
             &ibex::gpio::PORT[11],
-            capsules::led::ActivationMode::ActiveHigh
+            kernel::hil::gpio::ActivationMode::ActiveHigh
         ),
         (
             &ibex::gpio::PORT[12],
-            capsules::led::ActivationMode::ActiveHigh
+            kernel::hil::gpio::ActivationMode::ActiveHigh
         ),
         (
             &ibex::gpio::PORT[13],
-            capsules::led::ActivationMode::ActiveHigh
+            kernel::hil::gpio::ActivationMode::ActiveHigh
         ),
         (
             &ibex::gpio::PORT[14],
-            capsules::led::ActivationMode::ActiveHigh
+            kernel::hil::gpio::ActivationMode::ActiveHigh
         )
     ));
 

--- a/capsules/src/button.rs
+++ b/capsules/src/button.rs
@@ -67,7 +67,7 @@ pub type SubscribeMap = u32;
 pub struct Button<'a> {
     pins: &'a [(
         &'a dyn gpio::InterruptValuePin,
-        gpio::ButtonMode,
+        gpio::ActivationMode,
         gpio::FloatingState,
     )],
     apps: Grant<(Option<Callback>, SubscribeMap)>,
@@ -77,7 +77,7 @@ impl<'a> Button<'a> {
     pub fn new(
         pins: &'a [(
             &'a dyn gpio::InterruptValuePin,
-            gpio::ButtonMode,
+            gpio::ActivationMode,
             gpio::FloatingState,
         )],
         grant: Grant<(Option<Callback>, SubscribeMap)>,
@@ -94,9 +94,9 @@ impl<'a> Button<'a> {
         }
     }
 
-    fn get_button_state(&self, pin_num: u32) -> gpio::ButtonState {
+    fn get_button_state(&self, pin_num: u32) -> gpio::ActivationState {
         let pin = &self.pins[pin_num as usize];
-        pin.0.read_button(pin.1)
+        pin.0.read_activation(pin.1)
     }
 }
 

--- a/capsules/src/button.rs
+++ b/capsules/src/button.rs
@@ -62,28 +62,12 @@ pub const DRIVER_NUM: usize = driver::NUM::Button as usize;
 /// that app has an interrupt registered for that button.
 pub type SubscribeMap = u32;
 
-/// Whether the GPIOs for the buttons on this platform are low when the button
-/// is pressed or high.
-#[derive(Clone, Copy)]
-pub enum GpioMode {
-    LowWhenPressed,
-    HighWhenPressed,
-}
-
-/// Values that are passed to userspace to identify if the button is pressed
-/// or not.
-#[derive(Clone, Copy)]
-pub enum ButtonState {
-    NotPressed = 0,
-    Pressed = 1,
-}
-
 /// Manages the list of GPIO pins that are connected to buttons and which apps
 /// are listening for interrupts from which buttons.
 pub struct Button<'a> {
     pins: &'a [(
         &'a dyn gpio::InterruptValuePin,
-        GpioMode,
+        gpio::ButtonMode,
         gpio::FloatingState,
     )],
     apps: Grant<(Option<Callback>, SubscribeMap)>,
@@ -93,7 +77,7 @@ impl<'a> Button<'a> {
     pub fn new(
         pins: &'a [(
             &'a dyn gpio::InterruptValuePin,
-            GpioMode,
+            gpio::ButtonMode,
             gpio::FloatingState,
         )],
         grant: Grant<(Option<Callback>, SubscribeMap)>,
@@ -110,19 +94,9 @@ impl<'a> Button<'a> {
         }
     }
 
-    fn get_button_state(&self, pin_num: u32) -> ButtonState {
-        let index = pin_num as usize;
-        let pin_value = self.pins[index].0.read();
-        match self.pins[index].1 {
-            GpioMode::LowWhenPressed => match pin_value {
-                false => ButtonState::Pressed,
-                true => ButtonState::NotPressed,
-            },
-            GpioMode::HighWhenPressed => match pin_value {
-                false => ButtonState::NotPressed,
-                true => ButtonState::Pressed,
-            },
-        }
+    fn get_button_state(&self, pin_num: u32) -> gpio::ButtonState {
+        let pin = &self.pins[pin_num as usize];
+        pin.0.read_button(pin.1)
     }
 }
 

--- a/capsules/src/debug_process_restart.rs
+++ b/capsules/src/debug_process_restart.rs
@@ -18,7 +18,7 @@
 //!         board_kernel,
 //!         ProcessMgmtCap
 //!         &sam4l::gpio::PA[16],
-//!         kernel::hil::gpio::ButtonMode::LowWhenPressed,
+//!         kernel::hil::gpio::ActivationMode::ActiveLow,
 //!         kernel::hil::gpio::FloatingState::PullUp
 //!     )
 //! );
@@ -33,7 +33,7 @@ pub struct DebugProcessRestart<'a, C: ProcessManagementCapability> {
     kernel: &'static Kernel,
     capability: C,
     pin: &'a dyn gpio::InterruptPin,
-    mode: gpio::ButtonMode,
+    mode: gpio::ActivationMode,
 }
 
 impl<'a, C: ProcessManagementCapability> DebugProcessRestart<'a, C> {
@@ -41,7 +41,7 @@ impl<'a, C: ProcessManagementCapability> DebugProcessRestart<'a, C> {
         kernel: &'static Kernel,
         cap: C,
         pin: &'a dyn gpio::InterruptPin,
-        mode: gpio::ButtonMode,
+        mode: gpio::ActivationMode,
         floating_state: gpio::FloatingState,
     ) -> Self {
         pin.make_input();
@@ -59,7 +59,7 @@ impl<'a, C: ProcessManagementCapability> DebugProcessRestart<'a, C> {
 
 impl<C: ProcessManagementCapability> gpio::Client for DebugProcessRestart<'_, C> {
     fn fired(&self) {
-        if self.pin.read_button(self.mode) == gpio::ButtonState::Pressed {
+        if self.pin.read_activation(self.mode) == gpio::ActivationState::Active {
             self.kernel.hardfault_all_apps(&self.capability);
         }
     }

--- a/capsules/src/lib.rs
+++ b/capsules/src/lib.rs
@@ -42,6 +42,7 @@ pub mod ninedof;
 pub mod nonvolatile_storage_driver;
 pub mod nonvolatile_to_pages;
 pub mod nrf51822_serialization;
+pub mod panic_button;
 pub mod pca9544a;
 pub mod process_console;
 pub mod rf233;

--- a/capsules/src/panic_button.rs
+++ b/capsules/src/panic_button.rs
@@ -1,0 +1,52 @@
+//! Debug capsule to cause a button press to trigger a kernel panic.
+//!
+//! This can be useful especially when developping or debugging console
+//! capsules.
+//!
+//! Usage
+//! -----
+//!
+//! The recommended way is to use the `PanicButtonComponent`.
+//!
+//! Alternatively, a low-level way of using the capsule is as follows.
+//!
+//! ```rust
+//! let panic_button = static_init!(
+//!     PanicButton,
+//!     PanicButton::new(
+//!         &sam4l::gpio::PA[16],
+//!         kernel::hil::gpio::ActivationMode::ActiveLow,
+//!         kernel::hil::gpio::FloatingState::PullUp
+//!     )
+//! );
+//! sam4l::gpio::PA[16].set_client(panic_button);
+//! ```
+
+use kernel::hil::gpio;
+
+pub struct PanicButton<'a> {
+    pin: &'a dyn gpio::InterruptPin,
+    mode: gpio::ActivationMode,
+}
+
+impl<'a> PanicButton<'a> {
+    pub fn new(
+        pin: &'a dyn gpio::InterruptPin,
+        mode: gpio::ActivationMode,
+        floating_state: gpio::FloatingState,
+    ) -> Self {
+        pin.make_input();
+        pin.set_floating_state(floating_state);
+        pin.enable_interrupts(gpio::InterruptEdge::EitherEdge);
+
+        PanicButton { pin, mode }
+    }
+}
+
+impl gpio::Client for PanicButton<'_> {
+    fn fired(&self) {
+        if self.pin.read_activation(self.mode) == gpio::ActivationState::Active {
+            panic!("Panic button pressed");
+        }
+    }
+}

--- a/kernel/src/hil/gpio.rs
+++ b/kernel/src/hil/gpio.rs
@@ -39,6 +39,22 @@ pub enum Configuration {
     Other,
 }
 
+/// Whether the GPIOs for the buttons on this platform are low when the button
+/// is pressed or high.
+#[derive(Clone, Copy)]
+pub enum ButtonMode {
+    LowWhenPressed,
+    HighWhenPressed,
+}
+
+/// Values that are passed to userspace to identify if a button GPIO is pressed
+/// or not.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum ButtonState {
+    NotPressed = 0,
+    Pressed = 1,
+}
+
 /// The Pin trait allows a pin to be used as either input
 /// or output and to be configured.
 pub trait Pin: Input + Output + Configure {}
@@ -137,6 +153,27 @@ pub trait Input {
     /// pin, return the output; for an input pin, return the input;
     /// for disabled or function pins the value is undefined.
     fn read(&self) -> bool;
+
+    /// Get the current state of a button GPIO pin, for a given button mode.
+    fn read_button(&self, mode: ButtonMode) -> ButtonState {
+        let value = self.read();
+        match mode {
+            ButtonMode::LowWhenPressed => {
+                if value {
+                    ButtonState::NotPressed
+                } else {
+                    ButtonState::Pressed
+                }
+            }
+            ButtonMode::HighWhenPressed => {
+                if value {
+                    ButtonState::Pressed
+                } else {
+                    ButtonState::NotPressed
+                }
+            }
+        }
+    }
 }
 
 pub trait Interrupt: Input {

--- a/kernel/src/hil/gpio.rs
+++ b/kernel/src/hil/gpio.rs
@@ -173,20 +173,12 @@ pub trait Input {
     /// Get the current state of a GPIO pin, for a given activation mode.
     fn read_activation(&self, mode: ActivationMode) -> ActivationState {
         let value = self.read();
-        match mode {
-            ActivationMode::ActiveLow => {
-                if value {
-                    ActivationState::Inactive
-                } else {
-                    ActivationState::Active
-                }
+        match (mode, value) {
+            (ActivationMode::ActiveHigh, true) | (ActivationMode::ActiveLow, false) => {
+                ActivationState::Active
             }
-            ActivationMode::ActiveHigh => {
-                if value {
-                    ActivationState::Active
-                } else {
-                    ActivationState::Inactive
-                }
+            (ActivationMode::ActiveLow, true) | (ActivationMode::ActiveHigh, false) => {
+                ActivationState::Inactive
             }
         }
     }


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes #1640.

The `(Low|High)WhenPressed` and `ButtonState` enums are also moved from the button capsule to the GPIO HIL. This is to make all capsules/components using buttons more consistent.

The `debug_process_restart` capsule is also refactored to take floating state and the button mode into account. Interrupts are now enabled on both edges.


### Testing Strategy

This pull request was tested on an nRF52840-DK board:
- Tested with `libtock-rs/button_leds` app, to check that changes to the HIL don't break it.
- Tested the `PanicButtonComponent` by pressing it and checking the panic message in the console.


### TODO or Help Wanted

- I implemented everything directly in a component. Is there a need for a capsule for such as simple component, given that no driver is made available to userspace?
- Corollary, Should `DebugProcessRestart` be moved to a component?
- Beyond this pull-request, should the kernel HIL include a more comprehensive `Button` (or `GpioInput`) HIL, to encapsulate the floating state and high/low-when-pressed mode? In particular, if `fired()` only accepts the "pressed" state, the interrupts could be enabled only on the corresponding edge (but not necessarily rising - it depends on the high/low-when-pressed mode).


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.