### PR TITLE
Make UART control flow pin optional on Nordic boards.

### DIFF
--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -23,9 +23,9 @@ const LED2_B_PIN: Pin = Pin::P0_12;
 const BUTTON_PIN: Pin = Pin::P1_06;
 const BUTTON_RST_PIN: Pin = Pin::P0_18;
 
-const UART_RTS: Pin = Pin::P0_13;
+const UART_RTS: Option<Pin> = Some(Pin::P0_13);
 const UART_TXD: Pin = Pin::P0_15;
-const UART_CTS: Pin = Pin::P0_17;
+const UART_CTS: Option<Pin> = Some(Pin::P0_17);
 const UART_RXD: Pin = Pin::P0_20;
 
 const SPI_MOSI: Pin = Pin::P1_01;

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -83,9 +83,9 @@ const BUTTON3_PIN: Pin = Pin::P0_24;
 const BUTTON4_PIN: Pin = Pin::P0_25;
 const BUTTON_RST_PIN: Pin = Pin::P0_18;
 
-const UART_RTS: Pin = Pin::P0_05;
+const UART_RTS: Option<Pin> = Some(Pin::P0_05);
 const UART_TXD: Pin = Pin::P0_06;
-const UART_CTS: Pin = Pin::P0_07;
+const UART_CTS: Option<Pin> = Some(Pin::P0_07);
 const UART_RXD: Pin = Pin::P0_08;
 
 const SPI_MOSI: Pin = Pin::P0_20;

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -83,9 +83,9 @@ const BUTTON3_PIN: Pin = Pin::P0_15;
 const BUTTON4_PIN: Pin = Pin::P0_16;
 const BUTTON_RST_PIN: Pin = Pin::P0_21;
 
-const UART_RTS: Pin = Pin::P0_05;
+const UART_RTS: Option<Pin> = Some(Pin::P0_05);
 const UART_TXD: Pin = Pin::P0_06;
-const UART_CTS: Pin = Pin::P0_07;
+const UART_CTS: Option<Pin> = Some(Pin::P0_07);
 const UART_RXD: Pin = Pin::P0_08;
 
 const SPI_MOSI: Pin = Pin::P0_22;

--- a/boards/nordic/nrf52dk_base/src/lib.rs
+++ b/boards/nordic/nrf52dk_base/src/lib.rs
@@ -59,14 +59,14 @@ impl SpiPins {
 /// Pins for the UART
 #[derive(Debug)]
 pub struct UartPins {
-    rts: Pin,
+    rts: Option<Pin>,
     txd: Pin,
-    cts: Pin,
+    cts: Option<Pin>,
     rxd: Pin,
 }
 
 impl UartPins {
-    pub fn new(rts: Pin, txd: Pin, cts: Pin, rxd: Pin) -> Self {
+    pub fn new(rts: Option<Pin>, txd: Pin, cts: Option<Pin>, rxd: Pin) -> Self {
         Self { rts, txd, cts, rxd }
     }
 }
@@ -246,8 +246,8 @@ pub unsafe fn setup_board<I: nrf52::interrupt_service::InterruptService>(
             nrf52::uart::UARTE0.initialize(
                 nrf52::pinmux::Pinmux::new(uart_pins.txd as u32),
                 nrf52::pinmux::Pinmux::new(uart_pins.rxd as u32),
-                Some(nrf52::pinmux::Pinmux::new(uart_pins.cts as u32)),
-                Some(nrf52::pinmux::Pinmux::new(uart_pins.rts as u32)),
+                uart_pins.cts.map(|x| nrf52::pinmux::Pinmux::new(x as u32)),
+                uart_pins.rts.map(|x| nrf52::pinmux::Pinmux::new(x as u32)),
             );
             &nrf52::uart::UARTE0
         }


### PR DESCRIPTION

### Pull Request Overview

Allow all Nordic boards to define a UART without control flow pins (i.e. just RX/TX signals).
This is supported by the underlying UART component but the code in `nrf52dk_base` wasn't allowing it.

### Testing Strategy

This pull request was tested by:
- [x] Running `make allboards`


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
