### PR TITLE
Handle device register aliases explicitly

### DIFF
--- a/chips/cc26x2/src/lib.rs
+++ b/chips/cc26x2/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(const_fn, untagged_unions, in_band_lifetimes)]
+#![feature(const_fn, in_band_lifetimes)]
 #![no_std]
 #![crate_name = "cc26x2"]
 #![crate_type = "rlib"]

--- a/kernel/src/common/mod.rs
+++ b/kernel/src/common/mod.rs
@@ -10,8 +10,8 @@
 pub mod registers {
     pub use tock_registers::registers::InMemoryRegister;
     pub use tock_registers::registers::RegisterLongName;
+    pub use tock_registers::registers::{Aliased, ReadOnly, ReadWrite, WriteOnly};
     pub use tock_registers::registers::{Field, FieldValue, LocalRegisterCopy};
-    pub use tock_registers::registers::{ReadOnly, ReadWrite, WriteOnly};
     pub use tock_registers::{register_bitfields, register_structs};
 }
 

--- a/libraries/tock-register-interface/CHANGELOG.md
+++ b/libraries/tock-register-interface/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master
 
  - #1554: Allow lifetime parameters for `register_structs! { Foo<'a> { ..`
+ - #1661: Add `Aliased` register type for MMIO with differing R/W behavior
 
 ## v0.5
 

--- a/libraries/tock-register-interface/README.md
+++ b/libraries/tock-register-interface/README.md
@@ -226,8 +226,8 @@ register_bitfields! [
 
 ## Register Interface Summary
 
-There are three types provided by the register interface: `ReadOnly`,
-`WriteOnly`, and `ReadWrite`. They provide the following functions:
+There are four types provided by the register interface: `ReadOnly`,
+`WriteOnly`, `ReadWrite`, and `Aliased`. They provide the following functions:
 
 ```rust
 ReadOnly<T: IntLike, R: RegisterLongName = ()>
@@ -243,8 +243,6 @@ WriteOnly<T: IntLike, R: RegisterLongName = ()>
 .set(value: T)                                 // Set the raw register value
 .write(value: FieldValue<T, R>)                // Write the value of one or more fields,
                                                //  overwriting other fields to zero
-
-
 ReadWrite<T: IntLike, R: RegisterLongName = ()>
 .get() -> T                                    // Get the raw register value
 .set(value: T)                                 // Set the raw register value
@@ -262,7 +260,21 @@ ReadWrite<T: IntLike, R: RegisterLongName = ()>
 .matches_all(value: FieldValue<T, R>) -> bool  // Check if all specified parts of a field match
 .extract() -> LocalRegisterCopy<T, R>          // Make local copy of register
 
+Aliased<T: IntLike, R: RegisterLongName = (), W: RegisterLongName = ()>
+.get() -> T                                    // Get the raw register value
+.set(value: T)                                 // Set the raw register value
+.read(field: Field<T, R>) -> T                 // Read the value of the given field
+.read_as_enum<E>(field: Field<T, R>) -> Option<E> // Read value of the given field as a enum member
+.write(value: FieldValue<T, W>)                // Write the value of one or more fields,
+                                               //  overwriting other fields to zero
+.is_set(field: Field<T, R>) -> bool            // Check if one or more bits in a field are set
+.matches_any(value: FieldValue<T, R>) -> bool  // Check if any specified parts of a field match
+.matches_all(value: FieldValue<T, R>) -> bool  // Check if all specified parts of a field match
+.extract() -> LocalRegisterCopy<T, R>          // Make local copy of register
 ```
+
+The `Aliased` type represents cases where read-only and write-only registers,
+with different meanings, are aliased to the same memory location.
 
 The first type parameter (the `IntLike` type) is `u8`, `u16`, `u32`, or `u64`.
 


### PR DESCRIPTION
### Pull Request Overview

This addresses the `untagged_unions` portion of #1654.  By providing an explicit interface for registers which feature different functions and formats based on if they are written or read, we can avoid using a `union` type while still enjoying type safety for values traversing `reg.write()` or the register read functions.

### Testing Strategy

I lack the hardware to confirm that the one effected chip/board still functions as expected.

### TODO or Help Wanted

Testing on the board in question would be very helpful.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
