### PR TITLE
RFC: kernel: Add mechanism to filter driver access

### DIFF
--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -394,6 +394,12 @@ impl Kernel {
                                     callback_ptr,
                                     appdata,
                                 } => {
+                                    if !process.can_access_driver(driver_number) {
+                                        process
+                                            .set_syscall_return_value(ReturnCode::ENODEVICE.into());
+                                        break;
+                                    }
+
                                     let callback_id = CallbackId {
                                         driver_num: driver_number,
                                         subscribe_num: subdriver_number,
@@ -441,6 +447,12 @@ impl Kernel {
                                     arg0,
                                     arg1,
                                 } => {
+                                    if !process.can_access_driver(driver_number) {
+                                        process
+                                            .set_syscall_return_value(ReturnCode::ENODEVICE.into());
+                                        break;
+                                    }
+
                                     let res =
                                         platform.with_driver(
                                             driver_number,
@@ -474,6 +486,12 @@ impl Kernel {
                                     allow_address,
                                     allow_size,
                                 } => {
+                                    if !process.can_access_driver(driver_number) {
+                                        process
+                                            .set_syscall_return_value(ReturnCode::ENODEVICE.into());
+                                        break;
+                                    }
+
                                     let res = platform.with_driver(driver_number, |driver| {
                                         match driver {
                                             Some(d) => {


### PR DESCRIPTION
## Pull Request Overview

This pull request adds the ability for the kernel to filter access to drivers on a per-process level.  This is a sketch, and not a complete implementation.  I'm interested in feedback on the approach.  Specifically, I think a filter fn is flexible but doesn't really dictate how this is stored or installed.  If this were a slice of usizes then the check could be a quick scan instead of a fn dispatch.

### Testing Strategy

This pull request was not tested beyond `make allcheck`.

### TODO or Help Wanted

This pull request still needs others to look at it and comment on the approach.  Documentation will be updated later if this approach is acceptable.

### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make formatall`.
