### PR TITLE
Add --remap-path-prefix to make builds more deterministic and smaller.

### DIFF
--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -15,6 +15,9 @@ RUSTUP    ?= rustup
 # lld uses the page size to align program sections. It defaults to 4096 and this
 # puts a gap between before the .relocate section. `zmax-page-size=512` tells
 # lld the actual page size so it doesn't have to be conservative.
+#
+# We use `remap-path-prefix` to remove user-specific filepath strings for error
+# reporting from appearing in the generated binary.
 RUSTFLAGS_FOR_CARGO ?= \
   -C link-arg=-Tlayout.ld \
   -C linker=rust-lld \

--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -4,6 +4,7 @@ MAKEFLAGS += -r
 MAKEFLAGS += -R
 
 MAKEFILE_COMMON_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+MAKEFILE_PARENT_PATH := $(dir $(abspath $(MAKEFILE_COMMON_PATH)/..))
 
 # Common defaults that specific boards can override, but likely do not need to.
 TOOLCHAIN ?= llvm
@@ -14,14 +15,18 @@ RUSTUP    ?= rustup
 # lld uses the page size to align program sections. It defaults to 4096 and this
 # puts a gap between before the .relocate section. `zmax-page-size=512` tells
 # lld the actual page size so it doesn't have to be conservative.
-RUSTFLAGS_FOR_CARGO_LINKING ?= -C link-arg=-Tlayout.ld -C linker=rust-lld \
--C linker-flavor=ld.lld -C relocation-model=dynamic-no-pic \
--C link-arg=-zmax-page-size=512
+RUSTFLAGS_FOR_CARGO ?= \
+  -C link-arg=-Tlayout.ld \
+  -C linker=rust-lld \
+  -C linker-flavor=ld.lld \
+  -C relocation-model=dynamic-no-pic \
+  -C link-arg=-zmax-page-size=512 \
+  --remap-path-prefix=$(MAKEFILE_PARENT_PATH)= \
 
 # Disallow warnings for continuous integration builds. Disallowing them here
 # ensures that warnings during testing won't prevent compilation from succeeding.
 ifeq ($(CI),true)
-  RUSTFLAGS_FOR_CARGO_LINKING += -D warnings
+  RUSTFLAGS_FOR_CARGO += -D warnings
 endif
 
 # http://stackoverflow.com/questions/10858261/abort-makefile-if-variable-not-set
@@ -102,7 +107,7 @@ ifneq ($(V),)
   $(info PLATFORM            = $(PLATFORM))
   $(info TARGET              = $(TARGET))
   $(info TOCK_KERNEL_VERSION = $(TOCK_KERNEL_VERSION))
-  $(info RUSTFLAGS_FOR_CARGO = $(RUSTFLAGS_FOR_CARGO_LINKING))
+  $(info RUSTFLAGS_FOR_CARGO = $(RUSTFLAGS_FOR_CARGO))
   $(info MAKEFLAGS           = $(MAKEFLAGS))
   $(info OBJDUMP_FLAGS       = $(OBJDUMP_FLAGS))
   $(info )
@@ -131,7 +136,7 @@ all: release
 # binary. This makes checking for Rust errors much faster.
 .PHONY: check
 check:
-	$(Q)RUSTFLAGS="$(RUSTFLAGS_FOR_CARGO_LINKING)" $(CARGO) check --target=$(TARGET) $(VERBOSE) --release
+	$(Q)RUSTFLAGS="$(RUSTFLAGS_FOR_CARGO)" $(CARGO) check --target=$(TARGET) $(VERBOSE) --release
 
 .PHONY: clean
 clean::
@@ -181,10 +186,10 @@ target:
 
 .PHONY: target/$(TARGET)/release/$(PLATFORM)
 target/$(TARGET)/release/$(PLATFORM):
-	$(Q)RUSTFLAGS="$(RUSTFLAGS_FOR_CARGO_LINKING)" $(CARGO) build --target=$(TARGET) $(VERBOSE) --release
+	$(Q)RUSTFLAGS="$(RUSTFLAGS_FOR_CARGO)" $(CARGO) build --target=$(TARGET) $(VERBOSE) --release
 	$(Q)$(SIZE) $@
 
 .PHONY: target/$(TARGET)/debug/$(PLATFORM)
 target/$(TARGET)/debug/$(PLATFORM):
-	$(Q)RUSTFLAGS="$(RUSTFLAGS_FOR_CARGO_LINKING)" $(CARGO) build $(VERBOSE) --target=$(TARGET)
+	$(Q)RUSTFLAGS="$(RUSTFLAGS_FOR_CARGO)" $(CARGO) build $(VERBOSE) --target=$(TARGET)
 	$(Q)$(SIZE) $@


### PR DESCRIPTION
### Pull Request Overview

This pull request adds `--remap-path-prefix` as discussed in https://github.com/tock/tock/issues/1666#issuecomment-595415338.

Note that there is currently no impact on the `acd52832` board, which completely ignores the message in its panic handler (so the Rust compiler is indeed eliminating dead code).

https://github.com/tock/tock/blob/cf505cf00c3230d95d0ba4ad0aa5a77bc8f0727d/boards/acd52832/src/io.rs#L9-L15


### Testing Strategy

This pull request was tested by:
- running the `strings` command and manually checking the output for paths,
- checking the size of built targets before/after the change.

```shell
strings boards/imix/target/thumbv7em-none-eabi/release/imix.bin
```

Size before:

```
$ make allboards
   text	   data	    bss	    dec	    hex	filename
 165376	   3228	  54112	 222716	  365fc	target/thumbv7em-none-eabi/release/imix
 101376	   3196	  62336	 166908	  28bfc	target/thumbv7em-none-eabi/release/hail
  66561	   1952	  79968	 148481	  24401	target/thumbv7em-none-eabi/release/nucleo_f429zi
  53760	   4452	   9884	  68096	  10a00	target/riscv32imac-unknown-none-elf/release/hifive1
  64512	    900	  72824	 138236	  21bfc	target/thumbv7em-none-eabi/release/launchxl
  60417	   1952	  71776	 134145	  20c01	target/thumbv7em-none-eabi/release/nucleo_f446re
  57856	   3764	  61768	 123388	  1e1fc	target/riscv32imac-unknown-none-elf/release/arty-e21
  63989	   4416	  23232	  91637	  165f5	target/riscv32imc-unknown-none-elf/release/opentitan
  63488	   1248	  47904	 112640	  1b800	target/thumbv7em-none-eabi/release/acd52832
 116224	   1708	 260436	 378368	  5c600	target/thumbv7em-none-eabi/release/nrf52840dk
 111104	   1708	 260436	 373248	  5b200	target/thumbv7em-none-eabi/release/nrf52840_dongle
  91136	   1244	  47908	 140288	  22400	target/thumbv7em-none-eabi/release/nrf52dk
```

Size after:

```
$ make allboards
   text	   data	    bss	    dec	    hex	filename
 162304	   3228	  54112	 219644	  359fc	target/thumbv7em-none-eabi/release/imix
  99840	   3196	  62336	 165372	  285fc	target/thumbv7em-none-eabi/release/hail
  65025	   1952	  79968	 146945	  23e01	target/thumbv7em-none-eabi/release/nucleo_f429zi
  53248	   4452	   9884	  67584	  10800	target/riscv32imac-unknown-none-elf/release/hifive1
  63488	    900	  72824	 137212	  217fc	target/thumbv7em-none-eabi/release/launchxl
  59393	   1952	  71776	 133121	  20801	target/thumbv7em-none-eabi/release/nucleo_f446re
  57344	   3764	  61768	 122876	  1dffc	target/riscv32imac-unknown-none-elf/release/arty-e21
  63477	   4416	  23232	  91125	  163f5	target/riscv32imc-unknown-none-elf/release/opentitan
  63488	   1248	  47904	 112640	  1b800	target/thumbv7em-none-eabi/release/acd52832
 114688	   1708	 260436	 376832	  5c000	target/thumbv7em-none-eabi/release/nrf52840dk
 109568	   1708	 260436	 371712	  5ac00	target/thumbv7em-none-eabi/release/nrf52840_dongle
  90112	   1244	  47908	 139264	  22000	target/thumbv7em-none-eabi/release/nrf52dk
```


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
