### PR TITLE
Print a SHA-256 sum of built binaries, to check for reproducibility.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,9 +104,10 @@ audit:
 
 .PHONY: clean
 clean:
-	@for f in `./tools/list_archs.sh`; do echo "$$(tput bold)Clean arch/$$f"; cd "arch/$$f" && cargo clean || exit 1; cd ../..; done
-	@for f in `./tools/list_chips.sh`; do echo "$$(tput bold)Clean chips/$$f"; cd "chips/$$f" && cargo clean || exit 1; cd ../..; done
+	@for f in `./tools/list_archs.sh`; do echo "$$(tput bold)Clean arch/$$f"; cargo clean --manifest-path "arch/$$f/Cargo.toml" || exit 1; done
+	@for f in `./tools/list_chips.sh`; do echo "$$(tput bold)Clean chips/$$f"; cargo clean --manifest-path "chips/$$f/Cargo.toml" || exit 1; done
 	@for f in `./tools/list_boards.sh`; do echo "$$(tput bold)Clean boards/$$f"; $(MAKE) -C "boards/$$f" clean || exit 1; done
+	@for f in `./tools/list_tools.sh`; do echo "$$(tput bold)Clean tools/$$f"; cargo clean --manifest-path "tools/$$f/Cargo.toml" || exit 1; done
 	@cd kernel && echo "$$(tput bold)Clean kernel" && cargo clean
 	@cd libraries/tock-cells && echo "$$(tput bold)Clean libraries/tock-cells" && cargo clean
 	@cd libraries/tock-register-interface && echo "$$(tput bold)Clean libraries/tock-register-interface" && cargo clean

--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -168,16 +168,16 @@ target:
 %.elf: %
 	$(Q)cp $< $@
 
-%.bin: %.elf $(MAKEFILE_COMMON_PATH)/../tools/sha256sum/target/debug/sha256sum
+%.bin: %.elf $(MAKEFILE_COMMON_PATH)../tools/sha256sum/target/debug/sha256sum
 	$(Q)$(OBJCOPY) --output-target=binary $< $@
-	$(Q)$(MAKEFILE_COMMON_PATH)/../tools/sha256sum/target/debug/sha256sum $@
+	$(Q)$(MAKEFILE_COMMON_PATH)../tools/sha256sum/target/debug/sha256sum $@
 
 %.lst: %.elf
 	$(Q)$(OBJDUMP) $(OBJDUMP_FLAGS) $< > $@
 
 
-$(MAKEFILE_COMMON_PATH)/../tools/sha256sum/target/debug/sha256sum:
-	$(Q)$(CARGO) build $(VERBOSE) --manifest-path $(MAKEFILE_COMMON_PATH)/../tools/sha256sum/Cargo.toml
+$(MAKEFILE_COMMON_PATH)../tools/sha256sum/target/debug/sha256sum:
+	$(Q)$(CARGO) build $(VERBOSE) --manifest-path $(MAKEFILE_COMMON_PATH)../tools/sha256sum/Cargo.toml
 
 
 # Cargo-drivers

--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -9,6 +9,7 @@ MAKEFILE_COMMON_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 TOOLCHAIN ?= llvm
 CARGO     ?= cargo
 RUSTUP    ?= rustup
+SHA256SUM ?= sha256sum
 
 # This will hopefully move into Cargo.toml (or Cargo.toml.local) eventually.
 # lld uses the page size to align program sections. It defaults to 4096 and this
@@ -108,6 +109,7 @@ ifneq ($(V),)
   $(info )
   $(info TOOLCHAIN           = $(TOOLCHAIN))
   $(info SIZE                = $(SIZE))
+  $(info SHA256SUM           = $(SHA256SUM))
   $(info OBJCOPY             = $(OBJCOPY))
   $(info OBJDUMP             = $(OBJDUMP))
   $(info CARGO               = $(CARGO))
@@ -170,6 +172,7 @@ target:
 
 %.bin: %.elf
 	$(Q)$(OBJCOPY) --output-target=binary $^ $@
+	$(Q)$(SHA256SUM) $@
 
 %.lst: %.elf
 	$(Q)$(OBJDUMP) $(OBJDUMP_FLAGS) $< > $@

--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -9,7 +9,6 @@ MAKEFILE_COMMON_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 TOOLCHAIN ?= llvm
 CARGO     ?= cargo
 RUSTUP    ?= rustup
-SHA256SUM ?= sha256sum
 
 # This will hopefully move into Cargo.toml (or Cargo.toml.local) eventually.
 # lld uses the page size to align program sections. It defaults to 4096 and this
@@ -109,7 +108,6 @@ ifneq ($(V),)
   $(info )
   $(info TOOLCHAIN           = $(TOOLCHAIN))
   $(info SIZE                = $(SIZE))
-  $(info SHA256SUM           = $(SHA256SUM))
   $(info OBJCOPY             = $(OBJCOPY))
   $(info OBJDUMP             = $(OBJDUMP))
   $(info CARGO               = $(CARGO))
@@ -170,12 +168,16 @@ target:
 %.elf: %
 	$(Q)cp $< $@
 
-%.bin: %.elf
-	$(Q)$(OBJCOPY) --output-target=binary $^ $@
-	$(Q)$(SHA256SUM) $@
+%.bin: %.elf $(MAKEFILE_COMMON_PATH)/../tools/sha256sum/target/debug/sha256sum
+	$(Q)$(OBJCOPY) --output-target=binary $< $@
+	$(Q)$(MAKEFILE_COMMON_PATH)/../tools/sha256sum/target/debug/sha256sum $@
 
 %.lst: %.elf
 	$(Q)$(OBJDUMP) $(OBJDUMP_FLAGS) $< > $@
+
+
+$(MAKEFILE_COMMON_PATH)/../tools/sha256sum/target/debug/sha256sum:
+	$(Q)$(CARGO) build $(VERBOSE) --manifest-path $(MAKEFILE_COMMON_PATH)/../tools/sha256sum/Cargo.toml
 
 
 # Cargo-drivers

--- a/tools/sha256sum/Cargo.toml
+++ b/tools/sha256sum/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "sha256sum"
+version = "0.1.0"
+authors = ["RustCrypto Developers"]
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/RustCrypto/hashes"
+edition = "2018"
+
+[dependencies]
+sha2 = "0.8.1"

--- a/tools/sha256sum/src/main.rs
+++ b/tools/sha256sum/src/main.rs
@@ -1,0 +1,57 @@
+//! Example copied from https://github.com/RustCrypto/hashes/blob/master/sha2/examples/sha256sum.rs
+//!
+//! Please refer to the license at: https://github.com/RustCrypto/hashes#license
+//!
+//! > Licensed under either of
+//! > - Apache License, Version 2.0
+//! > - MIT license
+//! > at your option.
+extern crate sha2;
+
+use sha2::{Digest, Sha256};
+use std::env;
+use std::fs;
+use std::io::{self, Read};
+
+const BUFFER_SIZE: usize = 1024;
+
+/// Print digest result as hex string and name pair
+fn print_result(sum: &[u8], name: &str) {
+    for byte in sum {
+        print!("{:02x}", byte);
+    }
+    println!("\t{}", name);
+}
+
+/// Compute digest value for given `Reader` and print it
+/// On any error simply return without doing anything
+fn process<D: Digest + Default, R: Read>(reader: &mut R, name: &str) {
+    let mut sh = D::default();
+    let mut buffer = [0u8; BUFFER_SIZE];
+    loop {
+        let n = match reader.read(&mut buffer) {
+            Ok(n) => n,
+            Err(_) => return,
+        };
+        sh.input(&buffer[..n]);
+        if n == 0 || n < BUFFER_SIZE {
+            break;
+        }
+    }
+    print_result(&sh.result(), name);
+}
+
+fn main() {
+    let args = env::args();
+    // Process files listed in command line arguments one by one
+    // If no files provided process input from stdin
+    if args.len() > 1 {
+        for path in args.skip(1) {
+            if let Ok(mut file) = fs::File::open(&path) {
+                process::<Sha256, _>(&mut file, &path);
+            }
+        }
+    } else {
+        process::<Sha256, _>(&mut io::stdin(), "-");
+    }
+}


### PR DESCRIPTION
### Pull Request Overview

This pull request adds a SHA-256 sum of the produced binary when making boards.


### Testing Strategy

This pull request was tested by running `make` on boards.


### TODO or Help Wanted

I'm not sure what to do in the Makefile when `sha256sum` is not present.

I don't think it's a requirement to build Tock, more a nice-to-have to check whether multiple developers reproduce the same binaries. So if there's no such `sha256sum` binary, computing the sum should simply be skipped.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.