### PR TITLE
Added search pin index by id for gpio capsule

### DIFF
--- a/capsules/src/gpio.rs
+++ b/capsules/src/gpio.rs
@@ -289,6 +289,22 @@ impl<'a> Driver for GPIO<'a> {
                 }
             }
 
+            // get pin by id
+            10 => {
+                let mut res = ReturnCode::EINVAL;
+                let mut index: usize = 0;
+                for &pin in pins {
+                    if let ReturnCode::SuccessWithValue { value } = pin.pin_id() {
+                        if value == data1 {
+                            res = ReturnCode::SuccessWithValue { value: index };
+                            break;
+                        }
+                    }
+                    index = index + 1;
+                }
+                res
+            }
+
             // default
             _ => ReturnCode::ENOSUPPORT,
         }

--- a/chips/stm32f4xx/src/gpio.rs
+++ b/chips/stm32f4xx/src/gpio.rs
@@ -7,6 +7,7 @@ use kernel::common::registers::{register_bitfields, ReadOnly, ReadWrite, WriteOn
 use kernel::common::StaticRef;
 use kernel::hil;
 use kernel::ClockInterface;
+use kernel::ReturnCode;
 
 use crate::exti;
 use crate::rcc;
@@ -1074,6 +1075,13 @@ impl hil::gpio::Configure for Pin<'a> {
 
     fn is_output(&self) -> bool {
         self.get_mode() == Mode::GeneralPurposeOutputMode
+    }
+
+    fn pin_id(&self) -> ReturnCode {
+        ReturnCode::SuccessWithValue {
+            value: (self.pinid.get_port_number() as usize) << 4
+                | (self.pinid.get_pin_number() as usize),
+        }
     }
 }
 

--- a/doc/reference/trd103-gpio.md
+++ b/doc/reference/trd103-gpio.md
@@ -43,8 +43,8 @@ The rest of this document discusses each in turn.
 2 `Pin` trait
 ========================================
 
-The `Pin` trait is for requesting a single ADC conversion. It has
-three functions:
+The `Pin` trait is for a GPIO Pin. It has
+the following functions:
 
 ```rust
 pub trait Pin {
@@ -78,6 +78,10 @@ pub trait Pin {
 
     /// Disable the interrupt for the GPIO pin.
     fn disable_interrupt(&self);
+
+    /// Return PinID as ReturnCode::SuccessWithValue
+    /// return ENOSUPORT if not implmented
+    fn pin_id(&self) -> ReturnCode;
 }
 ```
 

--- a/kernel/src/hil/gpio.rs
+++ b/kernel/src/hil/gpio.rs
@@ -104,6 +104,18 @@ pub trait Configure {
             _ => false,
         }
     }
+
+    /// Return PinID as ReturnCode::SuccessWithValue
+    /// or ReturnCode::ENOSUPORT if the chip does not
+    /// implement this function
+    /// This is useful for accessing a certain GPIO as
+    /// most boards do not number GPIOs in the continous way
+    /// Usespace libraries may use a command syscall to get the
+    /// index of a certain pin by supplying the board
+    /// dependant pinid
+    fn pin_id(&self) -> ReturnCode {
+        ReturnCode::ENOSUPPORT
+    }
 }
 
 /// Configuration trait for pins that can be simultaneously
@@ -302,6 +314,10 @@ impl Configure for InterruptValueWrapper {
 
     fn is_output(&self) -> bool {
         self.source.is_input()
+    }
+
+    fn pin_id(&self) -> ReturnCode {
+        self.source.pin_id()
     }
 }
 


### PR DESCRIPTION
### Pull Request Overview

This pull request adds to the gpio capsule the api necessary to search a
pin index based on the pin id supplied by the board (usually PORT << 4 | PIN_NUMBER).

Some boards (like the STM Discovery kit) do not have gpio pins numbered in a
continuous order on the PCB print. Most of the boards print something similar
P_PORT_XX. If a user writes an app without knowing the exact order in which pins were
set up by the board file, it is difficult to implement portable apps. Any change in the board
file must be reflected by a change in the app's source code.

With this patch, users that write apps are able to use _command_ syscall with function 10,
supply a pin id (the same as provided in the board support) and get the index on which the
pin was registered. Then they can than safely use the pin index. If there is any change in the way
pins are registered by the board, the search function will just return a different 
index (or EINVAL).

I have also submitted a patch with the new corresponding API to libtock-c: https://github.com/tock/libtock-c/pull/73

### Testing Strategy

This pull request was tested with a nucleo f429zi board

### TODO or Help Wanted

Any feedback is very much appreciated.

### Documentation Updated

- [x] Updated the relevant files in `/docs`

### Formatting

- [x] Ran `make formatall`.
