### PR TITLE
Update I2cMaster driver number according to doc/syscalls/README.md

### DIFF
--- a/capsules/src/driver.rs
+++ b/capsules/src/driver.rs
@@ -22,6 +22,7 @@ pub enum NUM {
 
     // HW Buses
     Spi                   = 0x20001,
+    I2cMaster             = 0x20003,
     UsbUser               = 0x20005,
     I2cMasterSlave        = 0x20006,
 
@@ -33,7 +34,6 @@ pub enum NUM {
     // Cryptography
     Rng                   = 0x40001,
     Crc                   = 0x40002,
-    I2cMaster             = 0x40006,
 
     // Storage
     AppFlash              = 0x50000,


### PR DESCRIPTION
### Pull Request Overview

This pull request changes the `I2cMaster` driver number to match what is in the [documentation](https://github.com/tock/tock/tree/master/doc/syscalls/README.md#hw-buses). The number was erroneously in the cryptography section (while `I2cMasterSlave` was in the HW bus section).


### Testing Strategy

This pull request was tested by checking the documentation.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
