### PR TITLE
kernel: Add syscall filter to platform trait

### DIFF
--- a/kernel/src/platform/mod.rs
+++ b/kernel/src/platform/mod.rs
@@ -46,10 +46,12 @@ pub trait Platform {
     where
         F: FnOnce(Option<&dyn Driver>) -> R;
 
-    /// Check the platform-provided system call filter.  If the system call is allowed for the
-    /// provied process then return Ok(()).  Otherwise, return Err with a ReturnCode that will be
-    /// returned to the calling application.  The default implementation allows all system calls.
-    /// This API should be considered unstable, and is likely to change in the future.
+    /// Check the platform-provided system call filter for all non-yield system
+    /// calls.  If the system call is allowed for the provided process then
+    /// return Ok(()).  Otherwise, return Err with a ReturnCode that will be
+    /// returned to the calling application.  The default implementation allows
+    /// all system calls. This API should be considered unstable, and is likely
+    /// to change in the future.
     fn filter_syscall(
         &self,
         _process: &dyn process::ProcessType,

--- a/kernel/src/platform/mod.rs
+++ b/kernel/src/platform/mod.rs
@@ -1,6 +1,8 @@
 //! Interface for chips and boards.
 
 use crate::driver::Driver;
+use crate::process;
+use crate::returncode;
 use crate::syscall;
 use core::fmt::Write;
 
@@ -43,6 +45,18 @@ pub trait Platform {
     fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
     where
         F: FnOnce(Option<&dyn Driver>) -> R;
+
+    /// Check the platform-provided system call filter.  If the system call is allowed for the
+    /// provied process then return Ok(()).  Otherwise, return Err with a ReturnCode that will be
+    /// returned to the calling application.  The default implementation allows all system calls.
+    /// This API should be considered unstable, and is likely to change in the future.
+    fn filter_syscall(
+        &self,
+        _process: &dyn process::ProcessType,
+        _syscall: &syscall::Syscall,
+    ) -> Result<(), returncode::ReturnCode> {
+        Ok(())
+    }
 }
 
 /// Interface for individual MCUs.


### PR DESCRIPTION
### Pull Request Overview

This pull request adds a Platform trait fn for filtering syscalls, and an enum for representing the filtering decision.  This is the first part of a solution for #1350, which I think is a good incremental piece.  It will also flexibly allow trying new filtering ideas without mandating them across platforms.

### Testing Strategy

This pull request was tested by `make allcheck`, no device testing.

### TODO or Help Wanted

This pull request still needs eyes on the design.

### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make formatall`.
