### PR TITLE
Make nrf52* based boards compatible with bootloader.

### DIFF
--- a/chips/nrf52/src/crt1.rs
+++ b/chips/nrf52/src/crt1.rs
@@ -1,4 +1,4 @@
-use cortexm4::{generic_isr, hard_fault_handler, nvic, svc_handler, systick_handler};
+use cortexm4::{generic_isr, hard_fault_handler, nvic, scb, svc_handler, systick_handler};
 use tock_rt0;
 
 /*
@@ -167,6 +167,10 @@ pub unsafe extern "C" fn init() {
 
     tock_rt0::init_data(&mut _etext, &mut _srelocate, &mut _erelocate);
     tock_rt0::zero_bss(&mut _szero, &mut _ezero);
+
+    // Ensure that we are compatible with a bootloader.
+    // For this we need to offset our vector table
+    scb::set_vector_table_offset(BASE_VECTORS.as_ptr() as *const ());
 
     nvic::enable_all();
 }

--- a/chips/nrf52/src/crt1.rs
+++ b/chips/nrf52/src/crt1.rs
@@ -168,8 +168,12 @@ pub unsafe extern "C" fn init() {
     tock_rt0::init_data(&mut _etext, &mut _srelocate, &mut _erelocate);
     tock_rt0::zero_bss(&mut _szero, &mut _ezero);
 
-    // Ensure that we are compatible with a bootloader.
-    // For this we need to offset our vector table
+    // Explicitly tell the core where Tock's vector table is located. If Tock is the
+    // only thing on the chip then this is effectively a no-op. If, however, there is
+    // a bootloader present then we want to ensure that the vector table is set
+    // correctly for Tock. The bootloader _may_ set this for us, but it may not
+    // so that any errors early in the Tock boot process trap back to the bootloader.
+    // To be safe we unconditionally set the vector table.
     scb::set_vector_table_offset(BASE_VECTORS.as_ptr() as *const ());
 
     nvic::enable_all();


### PR DESCRIPTION
### Pull Request Overview

This pull request makes Tock OS compatible with a bootloader on all boards that are based on nrf52 chip family.
The offset is determined by the linker. This way the board layout defines the offset.

### Testing Strategy

This pull request was tested by flashing OpenSK on a nRF52840DK board using JLink, flashing it on a nRF52840 USB dongle using `nordicdfu` tool as well as flashing OpenSK firmware on a nRF52840-MDK USB dongle over DFU.

### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
