### PR TITLE
Add @jrvanwhy to core team list

### DIFF
--- a/doc/CoreTeam.md
+++ b/doc/CoreTeam.md
@@ -11,6 +11,7 @@ The current members of the core team are:
  * Philip Levis - [phil-levis](https://github.com/phil-levis)
  * Amit Levy - [alevy](https://github.com/alevy)
  * Pat Pannuto - [ppannuto](https://github.com/ppannuto)
+ * Johnathan Van Why - [jrvanwhy](https://github.com/jrvanwhy)
 
 
 ## Updates to the Core Team


### PR DESCRIPTION
### Pull Request Overview

This pull request adds @jrvanwhy to the Core WG list in the documentation per a unanimous vote by the existing Core WG members in @tock/core-wg 


### Testing Strategy

N/A


### TODO or Help Wanted

N/A


### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

N/A
