### PR TITLE
Updated nucleo to use components for led and alarm

### DIFF
--- a/boards/nucleo_f429zi/src/main.rs
+++ b/boards/nucleo_f429zi/src/main.rs
@@ -7,12 +7,11 @@
 #![feature(asm)]
 #![deny(missing_docs)]
 
-use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
+use capsules::virtual_alarm::VirtualMuxAlarm;
 use components::gpio::GpioComponent;
 use kernel::capabilities;
 use kernel::common::dynamic_deferred_call::{DynamicDeferredCall, DynamicDeferredCallClientState};
 use kernel::component::Component;
-use kernel::hil::time::Alarm;
 use kernel::Platform;
 use kernel::{create_capability, debug, static_init};
 
@@ -45,8 +44,6 @@ static APP_HACK: u8 = 0;
 #[no_mangle]
 #[link_section = ".stack_buffer"]
 pub static mut STACK_MEMORY: [u8; 0x1000] = [0; 0x1000];
-
-const NUM_LEDS: usize = 3;
 
 /// A structure representing this platform that holds references to all
 /// capsules for this platform.
@@ -258,30 +255,21 @@ pub unsafe fn reset_handler() {
     // LEDs
 
     // Clock to Port A is enabled in `set_pin_primary_functions()`
-    let led_pins = static_init!(
-        [(
-            &'static dyn kernel::hil::gpio::Pin,
-            kernel::hil::gpio::ActivationMode
-        ); NUM_LEDS],
-        [
-            (
-                stm32f4xx::gpio::PinId::PB00.get_pin().as_ref().unwrap(),
-                kernel::hil::gpio::ActivationMode::ActiveHigh
-            ),
-            (
-                stm32f4xx::gpio::PinId::PB07.get_pin().as_ref().unwrap(),
-                kernel::hil::gpio::ActivationMode::ActiveHigh
-            ),
-            (
-                stm32f4xx::gpio::PinId::PB14.get_pin().as_ref().unwrap(),
-                kernel::hil::gpio::ActivationMode::ActiveHigh
-            )
-        ]
-    );
-    let led = static_init!(
-        capsules::led::LED<'static>,
-        capsules::led::LED::new(&led_pins[..])
-    );
+
+    let led = components::led::LedsComponent::new().finalize(components::led_component_helper!(
+        (
+            stm32f4xx::gpio::PinId::PB00.get_pin().as_ref().unwrap(),
+            kernel::hil::gpio::ActivationMode::ActiveHigh
+        ),
+        (
+            stm32f4xx::gpio::PinId::PB07.get_pin().as_ref().unwrap(),
+            kernel::hil::gpio::ActivationMode::ActiveHigh
+        ),
+        (
+            stm32f4xx::gpio::PinId::PB14.get_pin().as_ref().unwrap(),
+            kernel::hil::gpio::ActivationMode::ActiveHigh
+        )
+    ));
 
     // BUTTONs
     let button = components::button::ButtonComponent::new(board_kernel).finalize(
@@ -294,24 +282,13 @@ pub unsafe fn reset_handler() {
 
     // ALARM
 
-    let mux_alarm = static_init!(
-        MuxAlarm<'static, stm32f4xx::tim2::Tim2>,
-        MuxAlarm::new(&stm32f4xx::tim2::TIM2)
+    let tim2 = &stm32f4xx::tim2::TIM2;
+    let mux_alarm = components::alarm::AlarmMuxComponent::new(tim2).finalize(
+        components::alarm_mux_component_helper!(stm32f4xx::tim2::Tim2),
     );
-    stm32f4xx::tim2::TIM2.set_client(mux_alarm);
 
-    let virtual_alarm = static_init!(
-        VirtualMuxAlarm<'static, stm32f4xx::tim2::Tim2>,
-        VirtualMuxAlarm::new(mux_alarm)
-    );
-    let alarm = static_init!(
-        capsules::alarm::AlarmDriver<'static, VirtualMuxAlarm<'static, stm32f4xx::tim2::Tim2>>,
-        capsules::alarm::AlarmDriver::new(
-            virtual_alarm,
-            board_kernel.create_grant(&memory_allocation_capability)
-        )
-    );
-    virtual_alarm.set_client(alarm);
+    let alarm = components::alarm::AlarmDriverComponent::new(board_kernel, mux_alarm)
+        .finalize(components::alarm_component_helper!(stm32f4xx::tim2::Tim2));
 
     // GPIO
     let gpio = GpioComponent::new(board_kernel).finalize(components::gpio_component_helper!(

--- a/boards/nucleo_f446re/src/main.rs
+++ b/boards/nucleo_f446re/src/main.rs
@@ -7,12 +7,11 @@
 #![feature(asm)]
 #![deny(missing_docs)]
 
-use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
+use capsules::virtual_alarm::VirtualMuxAlarm;
 use kernel::capabilities;
 use kernel::common::dynamic_deferred_call::{DynamicDeferredCall, DynamicDeferredCallClientState};
 use kernel::component::Component;
 use kernel::hil::gpio::Configure;
-use kernel::hil::time::Alarm;
 use kernel::Platform;
 use kernel::{create_capability, debug, static_init};
 
@@ -248,20 +247,10 @@ pub unsafe fn reset_handler() {
     // LEDs
 
     // Clock to Port A is enabled in `set_pin_primary_functions()`
-    let led_pins = static_init!(
-        [(
-            &'static dyn kernel::hil::gpio::Pin,
-            kernel::hil::gpio::ActivationMode
-        ); 1],
-        [(
-            stm32f4xx::gpio::PinId::PA05.get_pin().as_ref().unwrap(),
-            kernel::hil::gpio::ActivationMode::ActiveHigh
-        )]
-    );
-    let led = static_init!(
-        capsules::led::LED<'static>,
-        capsules::led::LED::new(&led_pins[..])
-    );
+    let led = components::led::LedsComponent::new().finalize(components::led_component_helper!((
+        stm32f4xx::gpio::PinId::PA05.get_pin().as_ref().unwrap(),
+        kernel::hil::gpio::ActivationMode::ActiveHigh
+    )));
 
     // BUTTONs
     let button = components::button::ButtonComponent::new(board_kernel).finalize(
@@ -273,24 +262,13 @@ pub unsafe fn reset_handler() {
     );
 
     // ALARM
-    let mux_alarm = static_init!(
-        MuxAlarm<'static, stm32f4xx::tim2::Tim2>,
-        MuxAlarm::new(&stm32f4xx::tim2::TIM2)
+    let tim2 = &stm32f4xx::tim2::TIM2;
+    let mux_alarm = components::alarm::AlarmMuxComponent::new(tim2).finalize(
+        components::alarm_mux_component_helper!(stm32f4xx::tim2::Tim2),
     );
-    stm32f4xx::tim2::TIM2.set_client(mux_alarm);
 
-    let virtual_alarm = static_init!(
-        VirtualMuxAlarm<'static, stm32f4xx::tim2::Tim2>,
-        VirtualMuxAlarm::new(mux_alarm)
-    );
-    let alarm = static_init!(
-        capsules::alarm::AlarmDriver<'static, VirtualMuxAlarm<'static, stm32f4xx::tim2::Tim2>>,
-        capsules::alarm::AlarmDriver::new(
-            virtual_alarm,
-            board_kernel.create_grant(&memory_allocation_capability)
-        )
-    );
-    virtual_alarm.set_client(alarm);
+    let alarm = components::alarm::AlarmDriverComponent::new(board_kernel, mux_alarm)
+        .finalize(components::alarm_component_helper!(stm32f4xx::tim2::Tim2));
 
     let nucleo_f446re = NucleoF446RE {
         console: console,


### PR DESCRIPTION
### Pull Request Overview

This pull request changes the initialization of capsules led and alarm for the nucelo boards
so that they use the component system.

### Testing Strategy

This pull request was using a nucleo 429zi board.

### TODO or Help Wanted

This pull request still needs testing on nucleo f446re, I do not have the board.

### Documentation Updated

- [x] no updates are required.

### Formatting

- [x] Ran `make formatall`.
