### PR TITLE
Removed loop from io.rs panic_fmt for nucleo

### DIFF
--- a/boards/nucleo_f429zi/src/io.rs
+++ b/boards/nucleo_f429zi/src/io.rs
@@ -65,19 +65,15 @@ impl IoWrite for Writer {
 #[panic_handler]
 pub unsafe extern "C" fn panic_fmt(info: &PanicInfo) -> ! {
     // User LD2 is connected to PB07
-    PinId::PB07.get_pin_mut().as_mut().map(|pb7| {
-        let led = &mut led::LedHigh::new(pb7);
-        let writer = &mut WRITER;
+    let led = &mut led::LedHigh::new(PinId::PB07.get_pin_mut().as_mut().unwrap());
+    let writer = &mut WRITER;
 
-        debug::panic(
-            &mut [led],
-            writer,
-            info,
-            &cortexm4::support::nop,
-            &PROCESSES,
-            &CHIP,
-        )
-    });
-
-    loop {}
+    debug::panic(
+        &mut [led],
+        writer,
+        info,
+        &cortexm4::support::nop,
+        &PROCESSES,
+        &CHIP,
+    )
 }

--- a/boards/nucleo_f446re/src/io.rs
+++ b/boards/nucleo_f446re/src/io.rs
@@ -65,19 +65,15 @@ impl IoWrite for Writer {
 #[panic_handler]
 pub unsafe extern "C" fn panic_fmt(info: &PanicInfo) -> ! {
     // User LD2 is connected to PA05
-    PinId::PA05.get_pin_mut().as_mut().map(|pa5| {
-        let led = &mut led::LedHigh::new(pa5);
-        let writer = &mut WRITER;
+    let led = &mut led::LedHigh::new(PinId::PA05.get_pin_mut().as_mut().unwrap());
+    let writer = &mut WRITER;
 
-        debug::panic(
-            &mut [led],
-            writer,
-            info,
-            &cortexm4::support::nop,
-            &PROCESSES,
-            &CHIP,
-        )
-    });
-
-    loop {}
+    debug::panic(
+        &mut [led],
+        writer,
+        info,
+        &cortexm4::support::nop,
+        &PROCESSES,
+        &CHIP,
+    )
 }


### PR DESCRIPTION
### Pull Request Overview

This pull request changes the loop {} from the panic_fmt for the nucelo boards.


### Testing Strategy

This pull request was tested with nucleo f429zi.


### TODO or Help Wanted

This pull request still needs to be tested on nucleo f446re.


### Documentation Updated

- [x] no updates are required.

### Formatting

- [x] Ran `make formatall`.
