### PR TITLE
Revert PR #1660

### DIFF
--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -24,7 +24,6 @@ RUSTFLAGS_FOR_CARGO ?= \
   -C linker-flavor=ld.lld \
   -C relocation-model=dynamic-no-pic \
   -C link-arg=-zmax-page-size=512 \
-  -C force-frame-pointers=no \
   --remap-path-prefix=$(MAKEFILE_PARENT_PATH)= \
 
 # Disallow warnings for continuous integration builds. Disallowing them here


### PR DESCRIPTION
#1660 causes the kernel to panic on Hail.

I don't know why, but I git bisected back to this change.




### Testing Strategy

This pull request was tested by running Blink on Hail.


### TODO or Help Wanted

We should merge this and then re-evaluate #1660.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
