### PR TITLE
Fix remove_pending_callbacks formatting.

### DIFF
--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -701,7 +701,7 @@ impl<C: Chip> ProcessType for Process<'a, C> {
                 let count_after = tasks.len();
                 debug!(
                     "[{:?}] remove_pending_callbacks[{:#x}:{}] = {} callback(s) removed",
-                    self.app_id,
+                    self.appid(),
                     callback_id.driver_num,
                     callback_id.subscribe_num,
                     count_before - count_after,


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes the formatting of `remove_pending_callbacks` when syscall tracing is enabled in the config.

The current display debugs the whole `Cell` structure:

```
[Cell { value: 0 }] remove_pending_callbacks[0x0:0] = 0 callback(s) removed
```

The other syscalls are not affected because they already get the contents of the cell.


### Testing Strategy

This pull request was tested on a nRF52840-DK with OpenSK.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.