### PR TITLE
Travis memory reporting example, don't merge

### DIFF
--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -1,4 +1,4 @@
-//! Board file for Hail development platform
+//! Board file for Hail development platform.
 //!
 //! - <https://github.com/tock/tock/tree/master/boards/hail>
 //! - <https://github.com/lab11/hail>

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -1,4 +1,4 @@
-//! Board file for Hail development platform.
+//! Board file for Hail development platform
 //!
 //! - <https://github.com/tock/tock/tree/master/boards/hail>
 //! - <https://github.com/lab11/hail>

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -63,7 +63,6 @@ struct Hail {
     adc: &'static capsules::adc::Adc<'static, sam4l::adc::Adc>,
     led: &'static capsules::led::LED<'static>,
     button: &'static capsules::button::Button<'static>,
-    rng: &'static capsules::rng::RngDriver<'static>,
     ipc: kernel::ipc::IPC,
     crc: &'static capsules::crc::Crc<'static, sam4l::crccu::Crccu<'static>>,
     dac: &'static capsules::dac::Dac<'static>,
@@ -89,8 +88,6 @@ impl Platform for Hail {
             capsules::humidity::DRIVER_NUM => f(Some(self.humidity)),
             capsules::temperature::DRIVER_NUM => f(Some(self.temp)),
             capsules::ninedof::DRIVER_NUM => f(Some(self.ninedof)),
-
-            capsules::rng::DRIVER_NUM => f(Some(self.rng)),
 
             capsules::crc::DRIVER_NUM => f(Some(self.crc)),
 
@@ -347,9 +344,6 @@ pub unsafe fn reset_handler() {
     );
     sam4l::adc::ADC0.set_client(adc);
 
-    // Setup RNG
-    let rng = components::rng::RngComponent::new(board_kernel, &sam4l::trng::TRNG).finalize(());
-
     // set GPIO driver controlling remaining GPIO pins
     let gpio = components::gpio::GpioComponent::new(board_kernel).finalize(
         components::gpio_component_helper!(
@@ -410,7 +404,6 @@ pub unsafe fn reset_handler() {
         adc: adc,
         led: led,
         button: button,
-        rng: rng,
         ipc: kernel::ipc::IPC::new(board_kernel, &memory_allocation_capability),
         crc: crc,
         dac: dac,

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -35,7 +35,6 @@ use components::isl29035::AmbientLightComponent;
 use components::led::LedsComponent;
 use components::nrf51822::Nrf51822Component;
 use components::process_console::ProcessConsoleComponent;
-use components::rng::RngComponent;
 use components::si7021::{HumidityComponent, SI7021Component, TemperatureComponent};
 use components::spi::{SpiComponent, SpiSyscallComponent};
 use imix_components::adc::AdcComponent;
@@ -133,7 +132,6 @@ struct Imix {
     adc: &'static capsules::adc::Adc<'static, sam4l::adc::Adc>,
     led: &'static capsules::led::LED<'static>,
     button: &'static capsules::button::Button<'static>,
-    rng: &'static capsules::rng::RngDriver<'static>,
     analog_comparator: &'static capsules::analog_comparator::AnalogComparator<
         'static,
         sam4l::acifc::Acifc<'static>,
@@ -189,7 +187,6 @@ impl kernel::Platform for Imix {
             capsules::net::udp::DRIVER_NUM => f(Some(self.udp_driver)),
             capsules::nrf51822_serialization::DRIVER_NUM => f(Some(self.nrf51822)),
             capsules::nonvolatile_storage_driver::DRIVER_NUM => f(Some(self.nonvolatile_storage)),
-            capsules::rng::DRIVER_NUM => f(Some(self.rng)),
             kernel::ipc::DRIVER_NUM => f(Some(&self.ipc)),
             _ => f(None),
         }
@@ -389,7 +386,6 @@ pub unsafe fn reset_handler() {
     let crc = CrcComponent::new(board_kernel, &sam4l::crccu::CRCCU)
         .finalize(components::crc_component_helper!(sam4l::crccu::Crccu));
     let analog_comparator = AcComponent::new().finalize(());
-    let rng = RngComponent::new(board_kernel, &sam4l::trng::TRNG).finalize(());
 
     // For now, assign the 802.15.4 MAC address on the device as
     // simply a 16-bit short address which represents the last 16 bits
@@ -462,7 +458,6 @@ pub unsafe fn reset_handler() {
         adc,
         led,
         button,
-        rng,
         analog_comparator,
         crc,
         spi: spi_syscalls,
@@ -495,7 +490,6 @@ pub unsafe fn reset_handler() {
     // -pal, 11/20/18
     //
     // virtual_uart_rx_test::run_virtual_uart_receive(uart_mux);
-    // rng_test::run_entropy32();
     // aes_ccm_test::run();
     // aes_test::run_aes128_ctr();
     // aes_test::run_aes128_cbc();

--- a/boards/nucleo_f429zi/src/main.rs
+++ b/boards/nucleo_f429zi/src/main.rs
@@ -32,7 +32,7 @@ const FAULT_RESPONSE: kernel::procs::FaultResponse = kernel::procs::FaultRespons
 
 // RAM to be shared by all application processes.
 #[link_section = ".app_memory"]
-static mut APP_MEMORY: [u8; 65536] = [0; 65536];
+static mut APP_MEMORY: [u8; 85536] = [0; 85536];
 
 // Force the emission of the `.apps` segment in the kernel elf image
 // NOTE: This will cause the kernel to overwrite any existing apps when flashed!

--- a/boards/nucleo_f429zi/src/main.rs
+++ b/boards/nucleo_f429zi/src/main.rs
@@ -1,4 +1,4 @@
-//! Board file for Nucleo-F429ZI development board.
+//! Board file for Nucleo-F429ZI development board
 //!
 //! - <https://www.st.com/en/evaluation-tools/nucleo-f429zi.html>
 

--- a/boards/nucleo_f429zi/src/main.rs
+++ b/boards/nucleo_f429zi/src/main.rs
@@ -19,7 +19,7 @@ use kernel::{create_capability, debug, static_init};
 pub mod io;
 
 // Number of concurrent processes this platform supports.
-const NUM_PROCS: usize = 2000;
+const NUM_PROCS: usize = 20;
 
 // Actual memory for holding the active process structures.
 static mut PROCESSES: [Option<&'static dyn kernel::procs::ProcessType>; NUM_PROCS] =

--- a/boards/nucleo_f429zi/src/main.rs
+++ b/boards/nucleo_f429zi/src/main.rs
@@ -1,4 +1,4 @@
-//! Board file for Nucleo-F429ZI development board
+//! Board file for Nucleo-F429ZI development board.
 //!
 //! - <https://www.st.com/en/evaluation-tools/nucleo-f429zi.html>
 

--- a/boards/nucleo_f429zi/src/main.rs
+++ b/boards/nucleo_f429zi/src/main.rs
@@ -19,11 +19,11 @@ use kernel::{create_capability, debug, static_init};
 pub mod io;
 
 // Number of concurrent processes this platform supports.
-const NUM_PROCS: usize = 4;
+const NUM_PROCS: usize = 2000;
 
 // Actual memory for holding the active process structures.
 static mut PROCESSES: [Option<&'static dyn kernel::procs::ProcessType>; NUM_PROCS] =
-    [None, None, None, None];
+    [None; NUM_PROCS];
 
 static mut CHIP: Option<&'static stm32f4xx::chip::Stm32f4xx> = None;
 


### PR DESCRIPTION
This is an example PR to show how #1701 will work once merged into master.

The example PR here modifies 3 boards. It removes the RNG from Imix and Hail, and increases the APP_MEMORY size for a nucleo board by 20kB. Because APP_MEMORY is not counted as part of kernel memory, there is no diff shown for the nucleo board.

Click "see statuses" to see the reported diff of code size / memory for each board.