### PR TITLE
Revert "[USB] Split each endpoint's state into independent IN and OUT…

### DIFF
--- a/capsules/src/usb/usbc_client.rs
+++ b/capsules/src/usb/usbc_client.rs
@@ -115,11 +115,11 @@ impl<'a, C: hil::usb::UsbController<'a>> hil::usb::Client<'a> for Client<'a, C> 
         self.client_ctrl.enable();
 
         // Set up a bulk-in endpoint for debugging
-        self.controller().endpoint_set_in_buffer(1, self.buffer(1));
+        self.controller().endpoint_set_buffer(1, self.buffer(1));
         self.controller().endpoint_in_enable(TransferType::Bulk, 1);
 
         // Set up a bulk-out endpoint for debugging
-        self.controller().endpoint_set_out_buffer(2, self.buffer(2));
+        self.controller().endpoint_set_buffer(2, self.buffer(2));
         self.controller().endpoint_out_enable(TransferType::Bulk, 2);
     }
 

--- a/capsules/src/usb/usbc_client_ctrl.rs
+++ b/capsules/src/usb/usbc_client_ctrl.rs
@@ -201,7 +201,7 @@ impl<'a, 'b, C: hil::usb::UsbController<'a>> ClientCtrl<'a, 'b, C> {
     pub fn enable(&'a self) {
         // Set up the default control endpoint
         self.controller
-            .endpoint_set_ctrl_buffer(&self.ctrl_buffer.buf);
+            .endpoint_set_buffer(0, &self.ctrl_buffer.buf);
         self.controller
             .enable_as_device(hil::usb::DeviceSpeed::Full); // must be Full for Bulk transfers
         self.controller

--- a/chips/nrf52840/src/lib.rs
+++ b/chips/nrf52840/src/lib.rs
@@ -2,7 +2,7 @@
 
 pub use nrf52::{
     acomp, adc, aes, ble_radio, clock, constants, crt1, ficr, i2c, ieee802154_radio, init, nvmc,
-    pinmux, ppi, pwm, rtc, spi, temperature, timer, trng, uart, uicr, usbd,
+    pinmux, ppi, pwm, rtc, spi, temperature, timer, trng, uart, uicr,
 };
 pub mod chip;
 pub mod gpio;

--- a/chips/sam4l/src/usbc/mod.rs
+++ b/chips/sam4l/src/usbc/mod.rs
@@ -1438,28 +1438,11 @@ fn endpoint_enable_interrupts(endpoint: usize, mask: FieldValue<u32, EndpointCon
 }
 
 impl hil::usb::UsbController<'a> for Usbc<'a> {
-    fn endpoint_set_ctrl_buffer(&self, buf: &'a [VolatileCell<u8>]) {
+    fn endpoint_set_buffer(&self, endpoint: usize, buf: &'a [VolatileCell<u8>]) {
         if buf.len() != 8 {
             client_err!("Bad endpoint buffer size");
         }
 
-        self._endpoint_bank_set_buffer(EndpointIndex::new(0), BankIndex::Bank0, buf);
-    }
-
-    fn endpoint_set_in_buffer(&self, endpoint: usize, buf: &'a [VolatileCell<u8>]) {
-        if buf.len() != 8 {
-            client_err!("Bad endpoint buffer size");
-        }
-
-        self._endpoint_bank_set_buffer(EndpointIndex::new(endpoint), BankIndex::Bank0, buf);
-    }
-
-    fn endpoint_set_out_buffer(&self, endpoint: usize, buf: &'a [VolatileCell<u8>]) {
-        if buf.len() != 8 {
-            client_err!("Bad endpoint buffer size");
-        }
-
-        // XXX: when implementing in_out endpoints, this should probably set a different slice than endpoint_set_in_buffer.
         self._endpoint_bank_set_buffer(EndpointIndex::new(endpoint), BankIndex::Bank0, buf);
     }
 

--- a/kernel/src/hil/usb.rs
+++ b/kernel/src/hil/usb.rs
@@ -5,9 +5,7 @@ use crate::common::cells::VolatileCell;
 /// USB controller interface
 pub trait UsbController<'a> {
     // Should be called before `enable_as_device()`
-    fn endpoint_set_ctrl_buffer(&self, buf: &'a [VolatileCell<u8>]);
-    fn endpoint_set_in_buffer(&self, endpoint: usize, buf: &'a [VolatileCell<u8>]);
-    fn endpoint_set_out_buffer(&self, endpoint: usize, buf: &'a [VolatileCell<u8>]);
+    fn endpoint_set_buffer(&self, endpoint: usize, buf: &'a [VolatileCell<u8>]);
 
     // Must be called before `attach()`
     fn enable_as_device(&self, speed: DeviceSpeed);


### PR DESCRIPTION
… sides."

This reverts commit 119957277bd1ea209ff9c20a122b0216ad96b3af.

This causes compilation issues with USB debugging on nrf52840dk:

  = note: rust-lld: error: section '.sram' will not fit in region 'ram': overflowed by 8192 bytes

### Pull Request Overview

This breaks USB debugging completely on the nrf52840dk. I didn't look too closely at what is triggering the linking failure but I suspect the addition of buffers given the suspicious overflow size (bss too large?)

@gendx 

### Testing Strategy

Now compiles on nrf52840dk with USB_DEBUGGING: bool = true


### TODO or Help Wanted

Would take a fix over a revert but I figured I would propose a revert


### Documentation Updated

- [ X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ X] Ran `make formatall`.
