### PR TITLE
Travis: Report Code Size and Memory diffs for each PR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ language: rust
 
 addons:
   apt:
-    packages: libusb-1.0-0-dev
+    packages:
+      - libusb-1.0-0-dev
+      - llvm # Used by memory reporting script
 
 
 # bors default configuration:
@@ -36,8 +38,16 @@ rust:
 
 before_script:
   - npm install -g markdown-toc
+#TODO: Move below lines to after_success once actual script moves there
+#- sudo apt install python3
+  - python3 -m venv env --without-pip
+  - source env/bin/activate
+  - curl https://bootstrap.pypa.io/get-pip.py | python3
+  - pip3 install cxxfilt
 
 script:
   - export PATH=$HOME/.cargo/bin:$PATH
   - make ci-travis
 
+after_success:
+  - ./tools/print_binary_sizes.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,16 +38,14 @@ rust:
 
 before_script:
   - npm install -g markdown-toc
-#TODO: Move below lines to after_success once actual script moves there
-#- sudo apt install python3
-  - python3 -m venv env --without-pip
-  - source env/bin/activate
-  - curl https://bootstrap.pypa.io/get-pip.py | python3
-  - pip3 install cxxfilt
 
 script:
   - export PATH=$HOME/.cargo/bin:$PATH
   - make ci-travis
 
 after_success:
-  - ./tools/print_binary_sizes.sh
+  - python3 -m venv env --without-pip
+  - source env/bin/activate
+  - curl https://bootstrap.pypa.io/get-pip.py | python3
+  - pip3 install cxxfilt
+  - ./tools/post_size_changes_to_github.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ addons:
     packages:
       - libusb-1.0-0-dev
       - llvm # Used by memory reporting script
+      - python3-pip
 
 
 # bors default configuration:
@@ -44,8 +45,6 @@ script:
   - make ci-travis
 
 after_success:
-  - python3 -m venv env --without-pip
-  - source env/bin/activate
-  - curl https://bootstrap.pypa.io/get-pip.py | python3
-  - pip3 install cxxfilt
+  - export PATH=$HOME/.local/bin:$PATH
+  - pip3 install --user cxxfilt
   - ./tools/post_size_changes_to_github.sh

--- a/tools/diff_memory_usage.py
+++ b/tools/diff_memory_usage.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+
+import argparse
+import sys
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("prev_bench", help="Memory benchmark of base branch of PR")
+    parser.add_argument("cur_bench", help="Memory benchmark of PR post-merge")
+    parser.add_argument("outfile", help="Filename to output diffs into")
+    parser.add_argument("board", help="Board these measurements are derived from")
+    args = parser.parse_args()
+
+    board = args.board
+    prev_flash = -1
+    prev_RAM = -1
+    cur_flash = -1
+    cur_RAM = -1
+    with open(args.prev_bench, "r") as f:
+        for line in f:
+            if "Kernel occupies" in line:
+                if "flash" in line:
+                    prev_flash = int(line.split()[2])
+                elif "RAM" in line:
+                    prev_RAM = int(line.split()[2])
+                    break
+    if prev_flash == -1 or prev_RAM == -1:
+        sys.exit("Failed to parse prev_bench for board: {}".format(board))
+
+    with open(args.cur_bench, "r") as f:
+        for line in f:
+            if "Kernel occupies" in line:
+                if "flash" in line:
+                    cur_flash = int(line.split()[2])
+                elif "RAM" in line:
+                    cur_RAM = int(line.split()[2])
+                    break
+    if cur_flash == -1 or cur_RAM == -1:
+        sys.exit("Failed to parse cur_bench for board: {}".format(board))
+
+    diff_flash = cur_flash - prev_flash
+    diff_RAM = cur_RAM - prev_RAM
+
+    if diff_flash == 0 and diff_RAM == 0:
+        return
+        # Don't write to file for boards with no change in size
+
+    flash_percent = diff_flash / prev_flash * 100
+    RAM_percent = diff_RAM / prev_RAM * 100
+
+    flash_change_string = "+"
+    if diff_flash < 0:
+        flash_change_string = ""
+    RAM_change_string = "+"
+    if diff_RAM < 0:
+        RAM_change_string = ""
+
+    f = open(args.outfile, "a+")
+
+    f.write(
+        "flash use {}{} bytes ({:+.2f}%), RAM use {}{} bytes({:+.2f}%)\n".format(
+            flash_change_string,
+            diff_flash,
+            flash_percent,
+            RAM_change_string,
+            diff_RAM,
+            RAM_percent,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/diff_memory_usage.py
+++ b/tools/diff_memory_usage.py
@@ -24,7 +24,11 @@ def main():
                     prev_flash = int(line.split()[2])
                 elif "RAM" in line:
                     prev_RAM = int(line.split()[2])
+            elif "Applications allocated" in line:
+                if "RAM" in line and prev_RAM > 0:
+                    prev_RAM -= int(line.split()[2])
                     break
+
     if prev_flash == -1 or prev_RAM == -1:
         sys.exit("Failed to parse prev_bench for board: {}".format(board))
 
@@ -35,6 +39,9 @@ def main():
                     cur_flash = int(line.split()[2])
                 elif "RAM" in line:
                     cur_RAM = int(line.split()[2])
+            elif "Applications allocated" in line:
+                if "RAM" in line and cur_RAM > 0:
+                    cur_RAM -= int(line.split()[2])
                     break
     if cur_flash == -1 or cur_RAM == -1:
         sys.exit("Failed to parse cur_bench for board: {}".format(board))

--- a/tools/diff_memory_usage.py
+++ b/tools/diff_memory_usage.py
@@ -27,7 +27,10 @@ def main():
             elif "Applications allocated" in line:
                 if "RAM" in line and prev_RAM > 0:
                     prev_RAM -= int(line.split()[2])
-                    break
+            elif "Total of" in line and "wasted" in line and "RAM" in line:
+                # Don't count wasted RAM as contributing to the count
+                prev_RAM -= int(line.split()[2])
+                break
 
     if prev_flash == -1 or prev_RAM == -1:
         sys.exit("Failed to parse prev_bench for board: {}".format(board))
@@ -42,7 +45,10 @@ def main():
             elif "Applications allocated" in line:
                 if "RAM" in line and cur_RAM > 0:
                     cur_RAM -= int(line.split()[2])
-                    break
+            elif "Total of" in line and "wasted" in line and "RAM" in line:
+                # Don't count wasted RAM as contributing to the count
+                cur_RAM -= int(line.split()[2])
+                break
     if cur_flash == -1 or cur_RAM == -1:
         sys.exit("Failed to parse cur_bench for board: {}".format(board))
 

--- a/tools/post_size_changes_to_github.sh
+++ b/tools/post_size_changes_to_github.sh
@@ -1,5 +1,14 @@
 #!/usr/bin/env bash
 
+# Post commit statuses to github indicating how a PR affects flash and RAM use for different boards.
+# This script is run by Travis after successful PR builds. It reports resource differences between
+# the target branch before and after merging in the PR.
+# This script also prints more detailed size analysis to the Travis build log.
+# This script only reports updates for boards whose size have changed as a result of the PR being
+# tested, and does not currently support analyzing size differences in RISC-V boards.
+# This file relies on a travis enviroment variable to post to github, which is the value of a
+# Github OAuth personal token associated with @hudson-ayers Github identity.
+
 set -e
 set -x
 
@@ -30,7 +39,7 @@ if [ -n "$TRAVIS_PULL_REQUEST_BRANCH" ]; then
     #     TRAVIS_BRANCH=master
     #     TRAVIS_PULL_REQUEST_BRANCH=foo
 
-    #Travis-ci uses a shallow clone, so to checkout target branch you must fetch it
+    # Travis-ci uses a shallow clone, so to checkout target branch you must fetch it
     git remote set-branches origin "${TRAVIS_BRANCH}"
     git fetch --depth 1 origin "${TRAVIS_BRANCH}"
     git checkout -f "${TRAVIS_BRANCH}"

--- a/tools/post_size_changes_to_github.sh
+++ b/tools/post_size_changes_to_github.sh
@@ -22,7 +22,7 @@ if [ -n "$TRAVIS_PULL_REQUEST_BRANCH" ]; then
     for elf in $(find boards -maxdepth 8 | grep 'release' | egrep '\.elf$' | grep -v 'riscv'); do
         tmp=${elf#*release/}
         b=${tmp%.elf}
-        ${TRAVIS_BUILD_DIR}/tools/print_tock_memory_usage.py ${elf} | tee ${TRAVIS_BUILD_DIR}/current-benchmark-${b}
+        ${TRAVIS_BUILD_DIR}/tools/print_tock_memory_usage.py -s ${elf} | tee ${TRAVIS_BUILD_DIR}/current-benchmark-${b}
     done
 
     # The Travis environment variables behave like so:
@@ -50,7 +50,7 @@ if [ -n "$TRAVIS_PULL_REQUEST_BRANCH" ]; then
     for elf in $(find boards -maxdepth 8 | grep 'release' | egrep '\.elf$' | grep -v 'riscv'); do
         tmp=${elf#*release/}
         b=${tmp%.elf}
-        ${TRAVIS_BUILD_DIR}/tools/print_tock_memory_usage.py ${elf} | tee ${TRAVIS_BUILD_DIR}/previous-benchmark-${b}
+        ${TRAVIS_BUILD_DIR}/tools/print_tock_memory_usage.py -s ${elf} | tee ${TRAVIS_BUILD_DIR}/previous-benchmark-${b}
     done
 
     # now calculate diff for each board, and post status to github for each non-0 diff
@@ -58,7 +58,7 @@ if [ -n "$TRAVIS_PULL_REQUEST_BRANCH" ]; then
     for elf in $(find boards -maxdepth 8 | grep 'release' | egrep '\.elf$' | grep -v 'riscv'); do
         tmp=${elf#*release/}
         b=${tmp%.elf}
-        ${TRAVIS_BUILD_DIR}/tools/diff_memory_usage.py -s previous-benchmark-${b} current-benchmark-${b} size-diffs-${b}.txt ${b}
+        ${TRAVIS_BUILD_DIR}/tools/diff_memory_usage.py previous-benchmark-${b} current-benchmark-${b} size-diffs-${b}.txt ${b}
         if [ -s "size-diffs-${b}.txt" ]; then
             RES="$( grep -hs ^ size-diffs-${b}.txt )" #grep instead of cat to prevent errors on no match
             curl -X POST -H "Content-Type: application/json" --header "Authorization: token ${TRAVIS_GITHUB_TOKEN}" --data '{"state": "success", "context": "'"${b}"'", "description": "'"${RES}"'"}' https://api.github.com/repos/tock/tock/statuses/${TRAVIS_PULL_REQUEST_SHA}

--- a/tools/post_size_changes_to_github.sh
+++ b/tools/post_size_changes_to_github.sh
@@ -58,7 +58,7 @@ if [ -n "$TRAVIS_PULL_REQUEST_BRANCH" ]; then
     for elf in $(find boards -maxdepth 8 | grep 'release' | egrep '\.elf$' | grep -v 'riscv'); do
         tmp=${elf#*release/}
         b=${tmp%.elf}
-        ${TRAVIS_BUILD_DIR}/tools/diff_memory_usage.py previous-benchmark-${b} current-benchmark-${b} size-diffs-${b}.txt ${b}
+        ${TRAVIS_BUILD_DIR}/tools/diff_memory_usage.py -s previous-benchmark-${b} current-benchmark-${b} size-diffs-${b}.txt ${b}
         if [ -s "size-diffs-${b}.txt" ]; then
             RES="$( grep -hs ^ size-diffs-${b}.txt )" #grep instead of cat to prevent errors on no match
             curl -X POST -H "Content-Type: application/json" --header "Authorization: token ${TRAVIS_GITHUB_TOKEN}" --data '{"state": "success", "context": "'"${b}"'", "description": "'"${RES}"'"}' https://api.github.com/repos/tock/tock/statuses/${TRAVIS_PULL_REQUEST_SHA}

--- a/tools/print_binary_sizes.sh
+++ b/tools/print_binary_sizes.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+set -e
+set -x
+
+# Only run for PR builds, not push builds
+if [ -n "$TRAVIS_PULL_REQUEST_BRANCH" ]; then
+    REMOTE_URL="$(git config --get remote.origin.url)"
+
+    # Bench the current commit that was pushed. Requires navigating back to build directory
+    cd ${TRAVIS_BUILD_DIR}
+    make allboards #TODO: Can remove?
+    for elf in $(find boards -maxdepth 8 | grep 'release' | egrep '\.elf$' | grep -v 'riscv'); do
+        tmp=${elf#*release/}
+        b=${tmp%.elf}
+        ${TRAVIS_BUILD_DIR}/tools/print_tock_memory_usage.py ${elf} | tee ${TRAVIS_BUILD_DIR}/current-benchmark-${b}
+    done
+
+    # The Travis environment variables behave like so:
+    # TRAVIS_BRANCH
+    #   - if PR build, this is the pr base branch
+    #   - if push build, this is the branch that was pushed
+    # TRAVIS_PULL_REQUEST_BRANCH
+    #   - if PR build, this is the "target" of the pr, i.e. not the base branch
+    #   - if push build, this is blank
+    #
+    # Example:
+    # You open a PR with target `master`, and PR branch `foo`
+    # During a PR build:
+    #     TRAVIS_BRANCH=master
+    #     TRAVIS_PULL_REQUEST_BRANCH=foo
+
+    #Travis-ci uses a shallow clone, so to checkout target branch you must fetch it
+    git remote set-branches origin "${TRAVIS_BRANCH}"
+    git fetch --depth 1 origin "${TRAVIS_BRANCH}"
+    git checkout -f "${TRAVIS_BRANCH}"
+    make allboards
+
+    # Find elfs compiled for release (for use in analyzing binaries in CI),
+    # ignore riscv binaries for now because Phil's tool does not support RISC-V
+    for elf in $(find boards -maxdepth 8 | grep 'release' | egrep '\.elf$' | grep -v 'riscv'); do
+        tmp=${elf#*release/}
+        b=${tmp%.elf}
+        ${TRAVIS_BUILD_DIR}/tools/print_tock_memory_usage.py ${elf} | tee ${TRAVIS_BUILD_DIR}/previous-benchmark-${b}
+    done
+
+    # now calculate diff for each board, and post status to github for each non-0 diff
+    cd ${TRAVIS_BUILD_DIR}
+    for elf in $(find boards -maxdepth 8 | grep 'release' | egrep '\.elf$' | grep -v 'riscv'); do
+        tmp=${elf#*release/}
+        b=${tmp%.elf}
+        ${TRAVIS_BUILD_DIR}/tools/diff_memory_usage.py previous-benchmark-${b} current-benchmark-${b} size-diffs-${b}.txt ${b}
+        if [ -s "size-diffs-${b}.txt" ]; then
+            RES="$( grep -hs ^ size-diffs-${b}.txt )" #grep instead of cat to prevent errors on no match
+            curl -X POST -H "Content-Type: application/json" --header "Authorization: token ${TRAVIS_GITHUB_TOKEN}" --data '{"state": "success", "context": "'"${b}"'", "description": "'"${RES}"'"}' https://api.github.com/repos/tock/tock/statuses/${TRAVIS_PULL_REQUEST_SHA}
+        fi
+    done
+fi


### PR DESCRIPTION
### Pull Request Overview

This pull request adds two scripts and modifies Travis so that PRs are automatically updated with "statuses" (shown at the bottom of the PR) on how they affect flash/memory use by the Kernel (as reported by @phil-levis script (#1673) .

Currently, this is configured to only run on PR builds (not push builds), and so will only run on PRs that are currently mergeable (don't need rebase). It reports the difference in size between the target branch before and after merging in the PR. This information is reported in the `after_success` block `.travis.yml`, and so is only reported after travis has successfully completed. A side-effect of this is that any failure in this script will not result in a failure of travis reporting the status of the build (instead, the only result of a failure is that these diffs will not be reported).

Notably, the script only reports size changes for boards where this value has changed! So if a PR only affects Nordic boards, the size changes will only be reported for those boards.

This PR does not report size differences for RISC-V boards, as the size reporting script does not support analyzing RISC-V binaries.

To observe the results of this script, please see #1695 , (click "show all checks") which has an example PR that modifies 3 boards.


### Testing Strategy

This pull request was tested mostly using #1695 . For PRs with small modifications, it only seems to increase Travis build times by about 30 seconds.


### TODO or Help Wanted

This pull request currently includes a copy of Phil's `print_tock_memory_size.py` script, which will need to be removed once #1673 is merged.

Currently, status posting is enabled by using an OAuth Personal Token that I generated which is set as a hidden environment variable available in Travis CI (when printed to the Travis CI log it is redacted). This token only grants the ability to post commit statuses. As a result, my Github profile image shows up next to every status. I tried for awhile and could not figure out how to get it to work using the Travis-CI identity -- as far as I can tell Travis does not expose its token in the shell environment. It might make sense to change this token to be one generated by @alevy or @bradjc , and I am happy to change it if that is preferred.

Also, my shell scripting abilities leave plenty to be desired, so any comments there are welcome..

### Documentation Updated

- [ ] Should I document this somewhere?.

### Formatting

- [x] Ran `make formatall`.
