### PR TITLE
opentitan: Disable aes_test

### DIFF
--- a/boards/opentitan/src/main.rs
+++ b/boards/opentitan/src/main.rs
@@ -213,7 +213,6 @@ pub unsafe fn reset_handler() {
 
     let lldb = components::lldb::LowLevelDebugComponent::new(board_kernel, uart_mux).finalize(());
 
-    aes_test::run_aes128_ecb();
     debug!("OpenTitan initialisation complete. Entering main loop");
 
     extern "C" {


### PR DESCRIPTION
This test takes a long time to run in the verilator environment. Just
disable it for now.

### Pull Request Overview

Just comment out the AES test on OpenTitan

### Testing Strategy

Verified that we can run on verilator in a reasonable time frame

### TODO or Help Wanted

None


### Documentation Updated

- [ X Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ X] Ran `make formatall`.
