### PR TITLE
added system call to set alarm to a relative tics

### DIFF
--- a/capsules/src/alarm.rs
+++ b/capsules/src/alarm.rs
@@ -160,7 +160,7 @@ impl<A: Alarm<'a>> Driver for AlarmDriver<'a, A> {
                         let mut time = now.wrapping_add (data as u32) as usize;
                         let min_tics = self.min_tics.unwrap_or_else(|| {
                             // scale the min tics from 16Khz to the actual frequency of the CPU
-                            let min_tics = (MIN_TICS_AT_16KHZ * 16000) / (<A::Frequency>::frequency() as usize);
+                            let min_tics = (MIN_TICS_AT_16KHZ * (<A::Frequency>::frequency() as usize)) / 16000;
                             self.min_tics.set(min_tics);
                             min_tics
                         });

--- a/doc/syscalls/00000_alarm.md
+++ b/doc/syscalls/00000_alarm.md
@@ -68,6 +68,18 @@ The alarm's frequency is platform-specific, but must be _at least_ 1kHz.
     **Returns**: EINVAL if the notification identifier is invalid, EALREADY if
     the notification is already disabled, or SUCCESS.
 
+  * ### Command number: `5`
+
+    **Description**: Set an alarm notification for a counter value relative to the current value.
+    Notification invokes the callback set with subscribe.
+
+    **Argument 1**: The relative counter tic value to notifity.
+
+    **Argument 2**: unused
+
+    **Returns**: EINVAL if the notification identifier is invalid, EALREADY if
+    the notification is already disabled, or SUCCESS.
+
 ## Subscribe
 
   * ### Subscribe number: `0`

--- a/doc/syscalls/00000_alarm.md
+++ b/doc/syscalls/00000_alarm.md
@@ -68,7 +68,7 @@ The alarm's frequency is platform-specific, but must be _at least_ 1kHz.
     **Returns**: EINVAL if the notification identifier is invalid, EALREADY if
     the notification is already disabled, or SUCCESS.
 
-  * ### Command number: `5`
+  * ### Command number: `5` (experimental)
 
     **Description**: Set an alarm notification for a counter value relative to the current value.
     Notification invokes the callback set with subscribe.

--- a/doc/syscalls/00000_alarm.md
+++ b/doc/syscalls/00000_alarm.md
@@ -61,7 +61,7 @@ The alarm's frequency is platform-specific, but must be _at least_ 1kHz.
     **Description**: Set an alarm notification for a counter value.
     Notification invokes the callback set with subscribe.
 
-    **Argument 1**: The counter tic value to notifity.
+    **Argument 1**: The counter tic value to notify.
 
     **Argument 2**: unused
 
@@ -73,7 +73,7 @@ The alarm's frequency is platform-specific, but must be _at least_ 1kHz.
     **Description**: Set an alarm notification for a counter value relative to the current value.
     Notification invokes the callback set with subscribe.
 
-    **Argument 1**: The relative counter tic value to notifity.
+    **Argument 1**: The relative counter tic value to notify.
 
     **Argument 2**: unused
 


### PR DESCRIPTION
### Pull Request Overview

This pull request adds a system call to alarm that allows setting the expiration time as a relative number of tics. It tries to fix #1691.

This needs a modification in the users, pace code I will submit a pull request.

### Testing Strategy

This pull request was with a nucleo f429zi board.

### TODO or Help Wanted

This should be tested on other devices as well.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
