### PR TITLE
[draft] proposal for new alarm hil

### DIFF
--- a/capsules/src/alarm.rs
+++ b/capsules/src/alarm.rs
@@ -149,7 +149,7 @@ impl<A: Alarm<'a>> Driver for AlarmDriver<'a, A> {
                         // debug!("set relative tics {}", time);
                         // if previously unarmed, but now will become armed
                         if let Expiration::Disabled = td.expiration {
-                            self.num_armed.set(self.num_armed.get());
+                            self.num_armed.set(self.num_armed.get() + 1);
                         }
                         td.expiration = Expiration::Abs(time as u32);
                         (ReturnCode::SuccessWithValue { value: time }, true)
@@ -159,9 +159,9 @@ impl<A: Alarm<'a>> Driver for AlarmDriver<'a, A> {
                         // debug!("set relative tics {}", time);
                         // if previously unarmed, but now will become armed
                         if let Expiration::Disabled = td.expiration {
-                            self.num_armed.set(now as usize + self.num_armed.get());
+                            self.num_armed.set(self.num_armed.get() + 1);
                         }
-                        td.expiration = Expiration::Abs(time as u32);
+                        td.expiration = Expiration::Abs(now + time as u32);
                         (ReturnCode::SuccessWithValue { value: time }, true)
                     },
                     _ => (ReturnCode::ENOSUPPORT, false)

--- a/capsules/src/alarm.rs
+++ b/capsules/src/alarm.rs
@@ -104,6 +104,7 @@ impl<A: Alarm<'a>> Driver for AlarmDriver<'a, A> {
     /// - `2`: Read the the current clock value
     /// - `3`: Stop the alarm if it is outstanding
     /// - `4`: Set an alarm to fire at a given clock value `time`.
+    /// - `5`: Set an alarm to fire at a given clock value `time` from `now`.
     fn command(&self, cmd_type: usize, data: usize, _: usize, caller_id: AppId) -> ReturnCode {
         // Returns the error code to return to the user and whether we need to
         // reset which is the next active alarm. We only _don't_ reset if we're

--- a/capsules/src/virtual_alarm.rs
+++ b/capsules/src/virtual_alarm.rs
@@ -62,6 +62,9 @@ impl<A: Alarm<'a>> Alarm<'a> for VirtualMuxAlarm<'a, A> {
         self.armed.set(false);
 
         self.mux.alarm.disable();
+        // checks whether the mux has been notified of the new alarm
+        // if yes, than the mux is alreafy in a reschedule function
+        // is not, it notifies it
         if !self.mux.notified.get() {
             self.mux.reschedule();
         }
@@ -78,6 +81,9 @@ impl<A: Alarm<'a>> Alarm<'a> for VirtualMuxAlarm<'a, A> {
 
         self.when.set(tics);
         self.mux.alarm.disable();
+        // checks whether the mux has been notified of the new alarm
+        // if yes, than the mux is alreafy in a reschedule function
+        // is not, it notifies it
         if !self.mux.notified.get() {
             self.mux.reschedule();
         }
@@ -120,6 +126,7 @@ impl<A: Alarm<'a>> MuxAlarm<'a, A> {
     }
 
     pub fn reschedule(&self) {
+        // the mux has been notified
         self.notified.set(true);
         // if we are in the fired handler, reschedule will be called
         // from update

--- a/chips/stm32f4xx/src/tim2.rs
+++ b/chips/stm32f4xx/src/tim2.rs
@@ -3,6 +3,7 @@ use cortexm4::support::atomic;
 use kernel::common::cells::OptionalCell;
 use kernel::common::registers::{register_bitfields, ReadWrite, WriteOnly};
 use kernel::common::StaticRef;
+use kernel::debug;
 use kernel::hil;
 use kernel::ClockInterface;
 
@@ -336,6 +337,7 @@ impl Tim2<'a> {
     }
 
     pub fn handle_interrupt(&self) {
+        // debug!("fired");
         self.registers.sr.modify(SR::CC1IF::CLEAR);
 
         self.client.map(|client| client.fired());
@@ -364,6 +366,8 @@ impl hil::time::Alarm<'a> for Tim2<'a> {
     fn set_alarm(&self, tics: u32) {
         self.registers.ccr1.set(tics);
         self.registers.dier.modify(DIER::CC1IE::SET);
+        // reset alarm counter, alarm will be oneshot
+        self.registers.egr.write(EGR::UG::SET);
     }
 
     fn get_alarm(&self) -> u32 {

--- a/kernel/src/hil/time.rs
+++ b/kernel/src/hil/time.rs
@@ -119,6 +119,10 @@ pub trait AlarmClient {
     /// Callback signaled when the alarm's clock reaches the value set in
     /// [`Alarm#set_alarm`](trait.Alarm.html#tymethod.set_alarm).
     fn fired(&self);
+
+    /// Inform the alarm that a number of tics have elapsed
+    /// empty function if it is ignored
+    fn update(&self, _tics: usize) {}
 }
 
 /// The `Timer` trait models a timer that can notify when a particular interval


### PR DESCRIPTION
### Pull Request Overview

This pull request adds a small rewrite proposal of the alarm capsule, virtual alarm mux and timer to try to fix issues like #1513, #1651, #1691.

The problem is that the alarm system sometimes deadlocks and/or generates alarms in a wrong order and uses a timer that can overflow. The changes proposed are based on the following assumptions:

1. alarms guarantee that they don't fire earlier than the number of tics, but might fire a little later (they are not real time)
2. the alarm does not keep a monotonic timer
3. the mcu timer should not be set to a value in the past, so that is has to overflow

The algorithm that I started from is the following:
1. the alarm is set to fire after n tics (usually 1)
2. every time the alarm fires, the mux informs all the client alarms that a number of tics have elapsed (using the update function)
````rust
pub trait AlarmClient {
    // ...
    /// Inform the alarm that a number of tics have elapsed
    /// empty function if it is ignored
    fn update(&self, _tics: usize) {}
}
````
3. every alarm subtracts from its expiration times the number of tics
  - if it finds an expiration time that should be negative or is 0, it schedules the callback
4. the mux resets the timer and repeats steps 1 to 4

This algorithm has no race as no one interacts with the actual times setup, it just fires after a certain period.

This is not very efficient, as the alarm fires continuously just for subtracting some tics. The following optimization is applied:
1. the mux schedules the alarm to fire after the minimum number of tics of its alarm clients
 steps 2 and 4 are the same

Here we have two race conditions:
  1. when an alarm requires a new timeout (might be smaller than the current alarm)
  2. when an alarm requires a stop

To solve these ones, the timer is disabled temporarily while taking these actions. This will push the fired event a little later, but it is within the assumptions.

This tries to be somehow backward compatible for the user space, preserving alarm syscall number 4, but there might be some issues, as `now` always resets.

### Testing Strategy

This pull request was tested with a nucleo f429zi.

### TODO or Help Wanted

This pull request still needs code review and feedback, testing and adapting other chips to use it.

### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
