### PR TITLE
rv32i: pmp: Fix the app allocation calculator

### DIFF
--- a/arch/rv32i/src/pmp.rs
+++ b/arch/rv32i/src/pmp.rs
@@ -396,11 +396,10 @@ impl kernel::mpu::MPU for PMPConfig {
             initial_app_memory_size + initial_kernel_memory_size,
         );
 
-        let mut region_size =
-            math::PowerOfTwo::ceiling(memory_size as u32).as_num::<u32>() as usize;
-
         // RISC-V PMP is not inclusive of the final address, while Tock is, increase the memory_size by 1
-        region_size += 1;
+        let mut region_size = memory_size as usize + 1;
+
+        region_size = math::PowerOfTwo::ceiling(region_size as u32).as_num::<u32>() as usize;
 
         // Region size always has to align to 4 bytes
         if region_size % 4 != 0 {


### PR DESCRIPTION
### Pull Request Overview

When calculating a size for apps we need to make sure we increment the
size by 1 as RISC-V PMP addresses aren't inclusive, while Tock's are.

The problem is we were doing this after the PowerOfTwo::ceiling call,
which meant if we were below a power of two allignment to start with we
would waste space. Change the order so we increment the size first, then
ceiling it to a power of 2.

### Testing Strategy

Run large apps on OpenTitan.

### TODO or Help Wanted

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
