### PR TITLE
tools: remove fixed bash interpreter path

### DIFF
--- a/tools/list_archs.sh
+++ b/tools/list_archs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Find archs based on folders with Cargo.toml
 for b in $(find arch -maxdepth 4 -name 'Cargo.toml'); do

--- a/tools/list_chips.sh
+++ b/tools/list_chips.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Find chips based on folders with Cargo.toml
 for b in $(find chips -maxdepth 4 -name 'Cargo.toml'); do

--- a/tools/list_tools.sh
+++ b/tools/list_tools.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Find tools built in rust based on folders with Cargo.toml
 for b in $(find tools -maxdepth 4 -name 'Cargo.toml'); do


### PR DESCRIPTION
### Pull Request Overview
Increase the portability of `tools/` bash scripts and the `ci` make target by avoiding a hardcoded bash interpreter path. This unbreaks `make ci` on NixOS.

### Testing Strategy

This pull request was tested by running the affected scripts standalone and through `make ci`.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
