### PR TITLE
stop running size reporting script in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,4 +47,4 @@ script:
 after_success:
   - export PATH=$HOME/.local/bin:$PATH
   - pip3 install --user cxxfilt
-  - ./tools/post_size_changes_to_github.sh
+    #- ./tools/post_size_changes_to_github.sh


### PR DESCRIPTION
### Pull Request Overview

This pull request removes the call to the size reporting script. I noticed today that Travis is not successfully reporting results on most PRs, and suspected my size reporting script is somehow responsible. After some further investigation, it seems that Travis environment variables are not made available to PR builds when the build is triggered by a PR from a branch *in a fork* of Tock, so I will need to reevaluate the mechanism I am using to expose credentials to post statuses.

I still think that the size change reporting script failing should not be causing the travis builds to fail to report, as it is in the after_success block, but either way I think we should stop using this script until I find a way for it to work on branches started in forks of the repo.


### Testing Strategy

This pull request has not been tested


### TODO or Help Wanted

The TODOs are to fix the script, but that belongs in followup PRs.


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make formatall`.
