### PR TITLE
Remove option encapsulation in Kernel get_process_iter

### DIFF
--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -133,18 +133,19 @@ impl Kernel {
         }
     }
 
-    /// Return an iterator for all of the items in the processes array on this
-    /// board.
-    ///
-    /// NOTE: This would be better if it returned an iterator to only processes.
-    /// While with `filter_map()` it is straightforward to create an object that
-    /// implements `Iterator` and only iterates over `Some(process)` items in
-    /// the processes array, Rust doesn't seem to support the types necessary to
-    /// actually make that work and be usable. Perhaps as
-    /// https://github.com/rust-lang/rust/issues/63066 progresses this will be
-    /// possible in the future.
-    crate fn get_process_iter(&self) -> core::slice::Iter<Option<&dyn process::ProcessType>> {
-        self.processes.iter()
+    /// Returns an iterator over all processes loaded by the kernel
+    crate fn get_process_iter(
+        &self,
+    ) -> core::iter::FilterMap<
+        core::slice::Iter<Option<&dyn process::ProcessType>>,
+        fn(&Option<&'static dyn process::ProcessType>) -> Option<&'static dyn process::ProcessType>,
+    > {
+        fn keep_some(
+            &x: &Option<&'static dyn process::ProcessType>,
+        ) -> Option<&'static dyn process::ProcessType> {
+            x
+        }
+        self.processes.iter().filter_map(keep_some)
     }
 
     /// Run a closure on every valid process. This will iterate the array of


### PR DESCRIPTION
### Pull Request Overview

This pull request changes `kernel.get_process_iter()` to return a type implementing `Iterator<&dyn ProcessType>` instead of `Iterator<Option<&dyn ProcessType>>` by excluding elements in the `PROCESSES` array that are `None`. This was mostly inspired by the comment on the function indicating this functionality was desired, and a code posting I saw on stack overflow indicating that such a type could be achieved by using a named function in the call to `filter_map()` instead of a closure.


### Testing Strategy

This pull request was tested by flashing two copies of the RNG app, the blink app, and the hello_loop app (the RNG capsules calls `grant.iter()`) and observing the expected output.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] No updates are required.

### Formatting

- [x] Ran `make formatall`.
