### PR TITLE
added i2c component

### DIFF
--- a/boards/components/src/i2c.rs
+++ b/boards/components/src/i2c.rs
@@ -6,9 +6,6 @@
 //!
 //! 2. `I2CComponent` provides a virtualized client to the I2C bus.
 //!
-//! `SpiSyscallComponent` is used for processes, while `I2CComponent` is used
-//! for kernel capsules that need access to the SPI bus.
-//!
 //! Usage
 //! -----
 //! ```rust

--- a/boards/components/src/i2c.rs
+++ b/boards/components/src/i2c.rs
@@ -1,0 +1,130 @@
+//! Components for I2C.
+//!
+//! This provides three components.
+//!
+//! 1. `I2CMuxComponent` provides a virtualization layer for a I2C bus.
+//!
+//! 2. `I2CSyscallComponent` provides a system call interface to I2C.
+//!
+//! 3. `I2CComponent` provides a virtualized client to the I2C bus.
+//!
+//! `SpiSyscallComponent` is used for processes, while `I2CComponent` is used
+//! for kernel capsules that need access to the SPI bus.
+//!
+//! Usage
+//! -----
+//! ```rust
+//! let mux_i2c = components::i2c::I2CMuxComponent::new(&stm32f3xx::i2c::I2C1).finalize(());
+//! let i2c_syscalls = components::i2c::I2CyscallComponent::new(mux_i2c, address).finalize(());
+//! let client_i2c = components::i2c::I2CComponent::new(mux_i2c, address).finalize(());
+//! ```
+
+// Author: Alexandru Radovici <msg4alex@gmail.com>
+
+use core::mem::MaybeUninit;
+
+use capsules::i2c_master::I2CMasterDriver;
+use capsules::virtual_i2c::{I2CDevice, MuxI2C};
+use kernel::component::Component;
+use kernel::hil::i2c;
+use kernel::static_init;
+
+// Setup static space for the objects.
+// #[macro_export]
+// macro_rules! i2c_mux_component_helper {
+// 	($S:ty) => {{
+// 		use core::mem::MaybeUninit;
+// 		static mut BUF: MaybeUninit<MuxI2C<'static>> = MaybeUninit::uninit();
+// 		&mut BUF
+// 		};};
+// }
+
+pub struct I2CMuxComponent {
+    i2c: &'static dyn i2c::I2CMaster,
+}
+
+// pub struct I2CSyscallComponent {
+// 	i2c_mux: &'static MuxI2C<'static>,
+// 	address: u8,
+// }
+
+pub struct I2CComponent {
+    i2c_mux: &'static MuxI2C<'static>,
+    address: u8,
+}
+
+impl I2CMuxComponent {
+    pub fn new(i2c: &'static dyn i2c::I2CMaster) -> Self {
+        I2CMuxComponent { i2c: i2c }
+    }
+}
+
+impl Component for I2CMuxComponent {
+    type StaticInput = ();
+    type Output = &'static MuxI2C<'static>;
+
+    unsafe fn finalize(self, _static_buffer: Self::StaticInput) -> Self::Output {
+        let mux_i2c = static_init!(MuxI2C<'static>, MuxI2C::new(self.i2c));
+
+        self.i2c.set_master_client(mux_i2c);
+
+        mux_i2c
+    }
+}
+
+// impl I2CSyscallComponent {
+// 	pub fn new(mux: &'static MuxI2C<'static>, address: u8) -> Self {
+// 		I2CSyscallComponent {
+// 			i2c_mux: mux,
+// 			address: address,
+// 		}
+// 	}
+// }
+
+// impl Component for I2CSyscallComponent {
+// 	type StaticInput = ();
+// 	type Output = &'static I2CMasterDriver<I2CDevice<'static>>;
+
+// 	unsafe fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
+// 		let syscall_i2c_device = static_init!(
+// 			I2CDevice<'static>,
+// 			I2CDevice::new(self.i2c_mux, self.address)
+// 		);
+
+// 		let i2c_syscalls = static_init!(
+// 			I2CMasterDriver<I2CDevice<'static>>,
+// 			I2CMasterDriver::new(syscall_i2c_device)
+// 		);
+
+// 		static mut I2C_READ_BUF: [u8; 255] = [0; 255];
+// 		static mut I2C_WRITE_BUF: [u8; 255] = [0; 255];
+
+// 		i2c_syscalls.config_buffers(&mut I2C_READ_BUF, &mut I2C_WRITE_BUF);
+// 		syscall_i2c_device.set_client(i2c_syscalls);
+
+// 		i2c_syscalls
+// 	}
+// }
+
+impl I2CComponent {
+    pub fn new(mux: &'static MuxI2C<'static>, address: u8) -> Self {
+        I2CComponent {
+            i2c_mux: mux,
+            address: address,
+        }
+    }
+}
+
+impl Component for I2CComponent {
+    type StaticInput = ();
+    type Output = &'static I2CDevice<'static>;
+
+    unsafe fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
+        let i2c_device = static_init!(
+            I2CDevice<'static>,
+            I2CDevice::new(self.i2c_mux, self.address)
+        );
+
+        i2c_device
+    }
+}

--- a/boards/components/src/i2c.rs
+++ b/boards/components/src/i2c.rs
@@ -4,9 +4,7 @@
 //!
 //! 1. `I2CMuxComponent` provides a virtualization layer for a I2C bus.
 //!
-//! 2. `I2CSyscallComponent` provides a system call interface to I2C.
-//!
-//! 3. `I2CComponent` provides a virtualized client to the I2C bus.
+//! 2. `I2CComponent` provides a virtualized client to the I2C bus.
 //!
 //! `SpiSyscallComponent` is used for processes, while `I2CComponent` is used
 //! for kernel capsules that need access to the SPI bus.
@@ -15,7 +13,6 @@
 //! -----
 //! ```rust
 //! let mux_i2c = components::i2c::I2CMuxComponent::new(&stm32f3xx::i2c::I2C1).finalize(());
-//! let i2c_syscalls = components::i2c::I2CyscallComponent::new(mux_i2c, address).finalize(());
 //! let client_i2c = components::i2c::I2CComponent::new(mux_i2c, address).finalize(());
 //! ```
 
@@ -29,11 +26,6 @@ use kernel::static_init;
 pub struct I2CMuxComponent {
     i2c: &'static dyn i2c::I2CMaster,
 }
-
-// pub struct I2CSyscallComponent {
-// 	i2c_mux: &'static MuxI2C<'static>,
-// 	address: u8,
-// }
 
 pub struct I2CComponent {
     i2c_mux: &'static MuxI2C<'static>,
@@ -58,40 +50,6 @@ impl Component for I2CMuxComponent {
         mux_i2c
     }
 }
-
-// impl I2CSyscallComponent {
-// 	pub fn new(mux: &'static MuxI2C<'static>, address: u8) -> Self {
-// 		I2CSyscallComponent {
-// 			i2c_mux: mux,
-// 			address: address,
-// 		}
-// 	}
-// }
-
-// impl Component for I2CSyscallComponent {
-// 	type StaticInput = ();
-// 	type Output = &'static I2CMasterDriver<I2CDevice<'static>>;
-
-// 	unsafe fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
-// 		let syscall_i2c_device = static_init!(
-// 			I2CDevice<'static>,
-// 			I2CDevice::new(self.i2c_mux, self.address)
-// 		);
-
-// 		let i2c_syscalls = static_init!(
-// 			I2CMasterDriver<I2CDevice<'static>>,
-// 			I2CMasterDriver::new(syscall_i2c_device)
-// 		);
-
-// 		static mut I2C_READ_BUF: [u8; 255] = [0; 255];
-// 		static mut I2C_WRITE_BUF: [u8; 255] = [0; 255];
-
-// 		i2c_syscalls.config_buffers(&mut I2C_READ_BUF, &mut I2C_WRITE_BUF);
-// 		syscall_i2c_device.set_client(i2c_syscalls);
-
-// 		i2c_syscalls
-// 	}
-// }
 
 impl I2CComponent {
     pub fn new(mux: &'static MuxI2C<'static>, address: u8) -> Self {

--- a/boards/components/src/i2c.rs
+++ b/boards/components/src/i2c.rs
@@ -9,16 +9,38 @@
 //! Usage
 //! -----
 //! ```rust
-//! let mux_i2c = components::i2c::I2CMuxComponent::new(&stm32f3xx::i2c::I2C1).finalize(());
-//! let client_i2c = components::i2c::I2CComponent::new(mux_i2c, address).finalize(());
+//! llet mux_i2c = components::i2c::I2CMuxComponent::new(&stm32f3xx::i2c::I2C1).finalize(components::i2c_mux_component_helper!());
+//! let client_i2c = components::i2c::I2CComponent::new(mux_i2c, 0x19).finalize(components::i2c_component_helper!());
 //! ```
 
 // Author: Alexandru Radovici <msg4alex@gmail.com>
 
 use capsules::virtual_i2c::{I2CDevice, MuxI2C};
+use core::mem::MaybeUninit;
 use kernel::component::Component;
 use kernel::hil::i2c;
-use kernel::static_init;
+use kernel::{static_init, static_init_half};
+
+// Setup static space for the objects.
+#[macro_export]
+macro_rules! i2c_mux_component_helper {
+    () => {{
+        use capsules::virtual_i2c::MuxI2C;
+        use core::mem::MaybeUninit;
+        static mut BUF: MaybeUninit<MuxI2C<'static>> = MaybeUninit::uninit();
+        &mut BUF
+    };};
+}
+
+#[macro_export]
+macro_rules! i2c_component_helper {
+    () => {{
+        use capsules::virtual_i2c::I2CDevice;
+        use core::mem::MaybeUninit;
+        static mut BUF: MaybeUninit<I2CDevice<'static>> = MaybeUninit::uninit();
+        &mut BUF
+    };};
+}
 
 pub struct I2CMuxComponent {
     i2c: &'static dyn i2c::I2CMaster,
@@ -36,11 +58,11 @@ impl I2CMuxComponent {
 }
 
 impl Component for I2CMuxComponent {
-    type StaticInput = ();
+    type StaticInput = &'static mut MaybeUninit<MuxI2C<'static>>;
     type Output = &'static MuxI2C<'static>;
 
-    unsafe fn finalize(self, _static_buffer: Self::StaticInput) -> Self::Output {
-        let mux_i2c = static_init!(MuxI2C<'static>, MuxI2C::new(self.i2c));
+    unsafe fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
+        let mux_i2c = static_init_half!(static_buffer, MuxI2C<'static>, MuxI2C::new(self.i2c));
 
         self.i2c.set_master_client(mux_i2c);
 
@@ -58,11 +80,12 @@ impl I2CComponent {
 }
 
 impl Component for I2CComponent {
-    type StaticInput = ();
+    type StaticInput = &'static mut MaybeUninit<I2CDevice<'static>>;
     type Output = &'static I2CDevice<'static>;
 
-    unsafe fn finalize(self, _static_buffer: Self::StaticInput) -> Self::Output {
-        let i2c_device = static_init!(
+    unsafe fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
+        let i2c_device = static_init_half!(
+            static_buffer,
             I2CDevice<'static>,
             I2CDevice::new(self.i2c_mux, self.address)
         );

--- a/boards/components/src/i2c.rs
+++ b/boards/components/src/i2c.rs
@@ -9,7 +9,7 @@
 //! Usage
 //! -----
 //! ```rust
-//! llet mux_i2c = components::i2c::I2CMuxComponent::new(&stm32f3xx::i2c::I2C1).finalize(components::i2c_mux_component_helper!());
+//! let mux_i2c = components::i2c::I2CMuxComponent::new(&stm32f3xx::i2c::I2C1).finalize(components::i2c_mux_component_helper!());
 //! let client_i2c = components::i2c::I2CComponent::new(mux_i2c, 0x19).finalize(components::i2c_component_helper!());
 //! ```
 
@@ -19,7 +19,7 @@ use capsules::virtual_i2c::{I2CDevice, MuxI2C};
 use core::mem::MaybeUninit;
 use kernel::component::Component;
 use kernel::hil::i2c;
-use kernel::{static_init, static_init_half};
+use kernel::static_init_half;
 
 // Setup static space for the objects.
 #[macro_export]

--- a/boards/components/src/i2c.rs
+++ b/boards/components/src/i2c.rs
@@ -21,23 +21,10 @@
 
 // Author: Alexandru Radovici <msg4alex@gmail.com>
 
-use core::mem::MaybeUninit;
-
-use capsules::i2c_master::I2CMasterDriver;
 use capsules::virtual_i2c::{I2CDevice, MuxI2C};
 use kernel::component::Component;
 use kernel::hil::i2c;
 use kernel::static_init;
-
-// Setup static space for the objects.
-// #[macro_export]
-// macro_rules! i2c_mux_component_helper {
-// 	($S:ty) => {{
-// 		use core::mem::MaybeUninit;
-// 		static mut BUF: MaybeUninit<MuxI2C<'static>> = MaybeUninit::uninit();
-// 		&mut BUF
-// 		};};
-// }
 
 pub struct I2CMuxComponent {
     i2c: &'static dyn i2c::I2CMaster,
@@ -119,7 +106,7 @@ impl Component for I2CComponent {
     type StaticInput = ();
     type Output = &'static I2CDevice<'static>;
 
-    unsafe fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
+    unsafe fn finalize(self, _static_buffer: Self::StaticInput) -> Self::Output {
         let i2c_device = static_init!(
             I2CDevice<'static>,
             I2CDevice::new(self.i2c_mux, self.address)

--- a/boards/components/src/i2c.rs
+++ b/boards/components/src/i2c.rs
@@ -1,6 +1,6 @@
 //! Components for I2C.
 //!
-//! This provides three components.
+//! This provides two components.
 //!
 //! 1. `I2CMuxComponent` provides a virtualization layer for a I2C bus.
 //!

--- a/boards/components/src/lib.rs
+++ b/boards/components/src/lib.rs
@@ -13,6 +13,7 @@ pub mod crc;
 pub mod debug_queue;
 pub mod debug_writer;
 pub mod hd44780;
+pub mod i2c;
 pub mod isl29035;
 pub mod lldb;
 pub mod nrf51822;

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -14,6 +14,7 @@ use kernel::capabilities;
 use kernel::common::dynamic_deferred_call::{DynamicDeferredCall, DynamicDeferredCallClientState};
 use kernel::component::Component;
 use kernel::hil;
+use kernel::hil::i2c::I2CMaster;
 use kernel::hil::Controller;
 use kernel::Platform;
 #[allow(unused_imports)]

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -18,6 +18,7 @@ use capsules::virtual_spi::{MuxSpiMaster, VirtualSpiMasterDevice};
 use kernel::capabilities;
 use kernel::common::dynamic_deferred_call::{DynamicDeferredCall, DynamicDeferredCallClientState};
 use kernel::component::Component;
+use kernel::hil::i2c::I2CMaster;
 use kernel::hil::radio;
 #[allow(unused_imports)]
 use kernel::hil::radio::{RadioConfig, RadioData};

--- a/chips/cc26x2/src/i2c.rs
+++ b/chips/cc26x2/src/i2c.rs
@@ -100,7 +100,7 @@ impl<'a> I2CMaster<'a> {
         }
     }
 
-    pub fn set_client(&'a self, client: &'a dyn i2c::I2CHwMasterClient) {
+    pub fn set_client(&self, client: &'a dyn i2c::I2CHwMasterClient) {
         self.client.set(client)
     }
 
@@ -237,6 +237,9 @@ impl<'a> I2CMaster<'a> {
 }
 
 impl<'a> i2c::I2CMaster for I2CMaster<'a> {
+    fn set_master_client(&self, master_client: &'static dyn i2c::I2CHwMasterClient) {
+        self.set_client(master_client);
+    }
     fn enable(&self) {
         self.registers.mcr.write(Configuration::MFE::SET);
         self.registers.mimr.write(Interrupt::IM::SET);

--- a/chips/nrf52/src/i2c.rs
+++ b/chips/nrf52/src/i2c.rs
@@ -122,6 +122,9 @@ impl TWIM {
 }
 
 impl hil::i2c::I2CMaster for TWIM {
+    fn set_master_client(&self, client: &'static dyn hil::i2c::I2CHwMasterClient) {
+        self.set_client(client);
+    }
     fn enable(&self) {
         self.enable();
     }

--- a/chips/sam4l/src/i2c.rs
+++ b/chips/sam4l/src/i2c.rs
@@ -728,14 +728,6 @@ impl I2CHw {
         self.dma.set(dma);
     }
 
-    pub fn set_master_client(&self, client: &'static dyn hil::i2c::I2CHwMasterClient) {
-        self.master_client.set(Some(client));
-    }
-
-    pub fn set_slave_client(&self, client: &'static dyn hil::i2c::I2CHwSlaveClient) {
-        self.slave_client.set(Some(client));
-    }
-
     pub fn handle_interrupt(&self) {
         use kernel::hil::i2c::Error;
 
@@ -1302,6 +1294,9 @@ impl DMAClient for I2CHw {
 }
 
 impl hil::i2c::I2CMaster for I2CHw {
+    fn set_master_client(&self, client: &'static dyn hil::i2c::I2CHwMasterClient) {
+        self.master_client.set(Some(client));
+    }
     /// This enables the entire I2C peripheral
     fn enable(&self) {
         //disable the i2c slave peripheral
@@ -1361,6 +1356,9 @@ impl hil::i2c::I2CMaster for I2CHw {
 }
 
 impl hil::i2c::I2CSlave for I2CHw {
+    fn set_slave_client(&self, client: &'static dyn hil::i2c::I2CHwSlaveClient) {
+        self.slave_client.set(Some(client));
+    }
     fn enable(&self) {
         if self.slave_mmio_address.is_some() {
             let twis = &TWISRegisterManager::new(&self);

--- a/kernel/src/hil/i2c.rs
+++ b/kernel/src/hil/i2c.rs
@@ -47,6 +47,9 @@ pub enum SlaveTransmissionType {
 
 /// Interface for an I2C Master hardware driver.
 pub trait I2CMaster {
+    fn set_master_client(&self, _master_client: &'static dyn I2CHwMasterClient) {
+        panic!("not implemented");
+    }
     fn enable(&self);
     fn disable(&self);
     fn write_read(&self, addr: u8, data: &'static mut [u8], write_len: u8, read_len: u8);
@@ -56,6 +59,9 @@ pub trait I2CMaster {
 
 /// Interface for an I2C Slave hardware driver.
 pub trait I2CSlave {
+    fn set_slave_client(&self, _slave_client: Option<&'static dyn I2CHwSlaveClient>) {
+        panic!("not implemented");
+    }
     fn enable(&self);
     fn disable(&self);
     fn set_address(&self, addr: u8);

--- a/kernel/src/hil/i2c.rs
+++ b/kernel/src/hil/i2c.rs
@@ -47,9 +47,7 @@ pub enum SlaveTransmissionType {
 
 /// Interface for an I2C Master hardware driver.
 pub trait I2CMaster {
-    fn set_master_client(&self, _master_client: &'static dyn I2CHwMasterClient) {
-        panic!("not implemented");
-    }
+    fn set_master_client(&self, master_client: &'static dyn I2CHwMasterClient);
     fn enable(&self);
     fn disable(&self);
     fn write_read(&self, addr: u8, data: &'static mut [u8], write_len: u8, read_len: u8);
@@ -59,9 +57,7 @@ pub trait I2CMaster {
 
 /// Interface for an I2C Slave hardware driver.
 pub trait I2CSlave {
-    fn set_slave_client(&self, _slave_client: Option<&'static dyn I2CHwSlaveClient>) {
-        panic!("not implemented");
-    }
+    fn set_slave_client(&self, slave_client: &'static dyn I2CHwSlaveClient);
     fn enable(&self);
     fn disable(&self);
     fn set_address(&self, addr: u8);


### PR DESCRIPTION
### Pull Request Overview

This pull request adds an i2c component.

the `set_master_client` and `set_slave_client` methods where missing from the I2CMaster and I2CSlave traits. As writing the component is much easier if they are present, I added them and wrote a default implementation that panics if used (otherwise some chips and boards do not build). Is there any reason why these where not placed here?

### Testing Strategy

This pull request was tested while writing I2C for stm32f3discovery.

### TODO or Help Wanted

I am not able to implement the I2CSycallComponent, as I2CDevice from virtual_i2c.rs does not implement I2CMaster required by the i2c _master.rs capsule. Is this intentionally done like this?

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
