### PR TITLE
Add in-kernel hash abstraction layer

### DIFF
--- a/capsules/src/hash.rs
+++ b/capsules/src/hash.rs
@@ -95,7 +95,7 @@ pub mod hash_functions {
     //! Definitions of common hash functions as HashTypes
     use crate::hash::HashType;
 
-    pub struct MD5;
+    pub enum MD5 {}
     impl HashType for MD5 {
         type Output = [u8; 16];
 
@@ -108,7 +108,7 @@ pub mod hash_functions {
         }
     }
 
-    pub struct SHA1;
+    pub enum SHA1 {}
     impl HashType for SHA1 {
         type Output = [u8; 20];
 
@@ -121,7 +121,7 @@ pub mod hash_functions {
         }
     }
 
-    pub struct SHA2_224;
+    pub enum SHA2_224 {}
     impl HashType for SHA2_224 {
         type Output = [u8; 28];
 
@@ -134,7 +134,7 @@ pub mod hash_functions {
         }
     }
 
-    pub struct SHA2_256;
+    pub enum SHA2_256 {}
     impl HashType for SHA2_256 {
         type Output = [u8; 32];
 
@@ -147,7 +147,7 @@ pub mod hash_functions {
         }
     }
 
-    pub struct SHA2_384;
+    pub enum SHA2_384 {}
     impl HashType for SHA2_384 {
         type Output = [u8; 48];
 
@@ -160,7 +160,7 @@ pub mod hash_functions {
         }
     }
 
-    pub struct SHA2_512;
+    pub enum SHA2_512 {}
     impl HashType for SHA2_512 {
         type Output = [u8; 64];
 
@@ -173,7 +173,7 @@ pub mod hash_functions {
         }
     }
 
-    pub struct SHA3_224;
+    pub enum SHA3_224 {}
     impl HashType for SHA3_224 {
         type Output = [u8; 28];
 
@@ -186,7 +186,7 @@ pub mod hash_functions {
         }
     }
 
-    pub struct SHA3_256;
+    pub enum SHA3_256 {}
     impl HashType for SHA3_256 {
         type Output = [u8; 32];
 
@@ -199,7 +199,7 @@ pub mod hash_functions {
         }
     }
 
-    pub struct SHA3_384;
+    pub enum SHA3_384 {}
     impl HashType for SHA3_384 {
         type Output = [u8; 48];
 
@@ -212,7 +212,7 @@ pub mod hash_functions {
         }
     }
 
-    pub struct SHA3_512;
+    pub enum SHA3_512 {}
     impl HashType for SHA3_512 {
         type Output = [u8; 64];
 

--- a/capsules/src/hash.rs
+++ b/capsules/src/hash.rs
@@ -1,0 +1,227 @@
+//! In kernel abstraction over hash functions
+//!
+//! This is an abstraction over hash functions and implementations of
+//! these hash functions. It supports exotic hash functions and
+//! checksums with non-byte outputs and inputs.
+//!
+//! The constraints over the Hasher are enforced by the HashType type
+//! parameter.
+//!
+//! Authors
+//! -------------------
+//! * Leon Schuermann <leon.git@is.currently.online>
+//! * Daniel Rutz <info@danielrutz.com>
+//! * April 01, 2020
+
+use kernel::ReturnCode;
+
+/// A trait to be implemented on zero-sized types indicating
+/// properties and types of hash functions
+///
+/// Implementors should be zero sized
+pub trait HashType {
+    /// The input type of the hash function
+    ///
+    /// Typically a byte
+    type Input = u8;
+
+    /// The output type of a hash function
+    ///
+    /// Typically a byte array with a fixed length
+    type Output;
+
+    /// Gives a unique identifier of this hash function, like
+    /// `sha2_384` or `md5`
+    fn identifier() -> &'static str;
+
+    /// Returns the hash output length in bits
+    fn output_bits() -> usize;
+}
+
+/// A hasher instance, taking an iterator over bytes and returning a type
+pub trait Hasher<'a, T: HashType> {
+    /// Set the client to receive callbacks
+    ///
+    /// Must be done prior to any operation
+    fn set_client(&'a self, client: &'a dyn HasherClient<T>);
+
+    /// Reset the state of the hasher. The next call to `input_data`
+    /// will start a new hash.
+    ///
+    /// A client must wait for the `reset_done` callback prior to
+    /// calling any other method.
+    fn reset(&self);
+
+    /// Input data into the hash function
+    ///
+    /// The function will return how many items have been consumed
+    /// from the Iterator. In addition to that, a boolean flag is
+    /// returned indicating whether the caller has to wait for a
+    /// `data_processed` callback, whereby `true` means a callback is
+    /// required.
+    ///
+    /// For synchronous or software implementations, this reduces
+    /// scheduler overhead and may improve throughput.
+    fn input_data(
+        &self,
+        iter: &mut dyn Iterator<Item = T::Input>,
+    ) -> Result<(usize, bool), ReturnCode>;
+
+    /// Request hash calculation
+    ///
+    /// The hash will be returned in the `hash_ready` callback on the
+    /// registered client
+    fn get_hash(&self) -> Result<(), ReturnCode>;
+}
+
+pub trait HasherClient<T: HashType> {
+    /// The Hasher state has been reset
+    ///
+    /// It is now safe to call `input_data` again to start a new hash.
+    fn reset_done(&self);
+
+    /// The data input using `input_data` was processed
+    ///
+    /// It is now safe to call `input_data` again or request the hash
+    /// using `hash_ready`
+    fn data_processed(&self, err: Option<ReturnCode>);
+
+    /// The requested hash has been calculated
+    fn hash_ready(&self, hash: Result<&T::Output, ReturnCode>);
+}
+
+// ----- HASH FUNCTION DEFINITIONS -----
+pub mod hash_functions {
+    //! Definitions of common hash functions as HashTypes
+    use crate::hash::HashType;
+
+    pub struct MD5;
+    impl HashType for MD5 {
+        type Output = [u8; 16];
+
+        fn identifier() -> &'static str {
+            "md5"
+        }
+
+        fn output_bits() -> usize {
+            128
+        }
+    }
+
+    pub struct SHA1;
+    impl HashType for SHA1 {
+        type Output = [u8; 20];
+
+        fn identifier() -> &'static str {
+            "sha1"
+        }
+
+        fn output_bits() -> usize {
+            160
+        }
+    }
+
+    pub struct SHA2_224;
+    impl HashType for SHA2_224 {
+        type Output = [u8; 28];
+
+        fn identifier() -> &'static str {
+            "sha2_224"
+        }
+
+        fn output_bits() -> usize {
+            224
+        }
+    }
+
+    pub struct SHA2_256;
+    impl HashType for SHA2_256 {
+        type Output = [u8; 32];
+
+        fn identifier() -> &'static str {
+            "sha2_256"
+        }
+
+        fn output_bits() -> usize {
+            256
+        }
+    }
+
+    pub struct SHA2_384;
+    impl HashType for SHA2_384 {
+        type Output = [u8; 48];
+
+        fn identifier() -> &'static str {
+            "sha2_384"
+        }
+
+        fn output_bits() -> usize {
+            384
+        }
+    }
+
+    pub struct SHA2_512;
+    impl HashType for SHA2_512 {
+        type Output = [u8; 64];
+
+        fn identifier() -> &'static str {
+            "sha2_512"
+        }
+
+        fn output_bits() -> usize {
+            512
+        }
+    }
+
+    pub struct SHA3_224;
+    impl HashType for SHA3_224 {
+        type Output = [u8; 28];
+
+        fn identifier() -> &'static str {
+            "sha3_224"
+        }
+
+        fn output_bits() -> usize {
+            224
+        }
+    }
+
+    pub struct SHA3_256;
+    impl HashType for SHA3_256 {
+        type Output = [u8; 32];
+
+        fn identifier() -> &'static str {
+            "sha3_256"
+        }
+
+        fn output_bits() -> usize {
+            256
+        }
+    }
+
+    pub struct SHA3_384;
+    impl HashType for SHA3_384 {
+        type Output = [u8; 48];
+
+        fn identifier() -> &'static str {
+            "sha3_384"
+        }
+
+        fn output_bits() -> usize {
+            384
+        }
+    }
+
+    pub struct SHA3_512;
+    impl HashType for SHA3_512 {
+        type Output = [u8; 64];
+
+        fn identifier() -> &'static str {
+            "sha3_512"
+        }
+
+        fn output_bits() -> usize {
+            512
+        }
+    }
+}

--- a/capsules/src/lib.rs
+++ b/capsules/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(const_fn, in_band_lifetimes)]
+#![feature(const_fn, in_band_lifetimes, associated_type_defaults)]
 #![forbid(unsafe_code)]
 #![no_std]
 
@@ -26,6 +26,7 @@ pub mod fm25cl;
 pub mod fxos8700cq;
 pub mod gpio;
 pub mod gpio_async;
+pub mod hash;
 pub mod hd44780;
 pub mod humidity;
 pub mod i2c_master;

--- a/capsules/src/lib.rs
+++ b/capsules/src/lib.rs
@@ -26,7 +26,6 @@ pub mod fm25cl;
 pub mod fxos8700cq;
 pub mod gpio;
 pub mod gpio_async;
-pub mod hash;
 pub mod hd44780;
 pub mod humidity;
 pub mod i2c_master;

--- a/kernel/src/hil/hash.rs
+++ b/kernel/src/hil/hash.rs
@@ -13,7 +13,7 @@
 //! * Daniel Rutz <info@danielrutz.com>
 //! * April 01, 2020
 
-use kernel::ReturnCode;
+use crate::ReturnCode;
 
 /// A trait to be implemented on zero-sized types indicating
 /// properties and types of hash functions
@@ -93,7 +93,7 @@ pub trait HasherClient<T: HashType> {
 // ----- HASH FUNCTION DEFINITIONS -----
 pub mod hash_functions {
     //! Definitions of common hash functions as HashTypes
-    use crate::hash::HashType;
+    use crate::hil::hash::HashType;
 
     pub enum MD5 {}
     impl HashType for MD5 {

--- a/kernel/src/hil/mod.rs
+++ b/kernel/src/hil/mod.rs
@@ -10,6 +10,7 @@ pub mod entropy;
 pub mod flash;
 pub mod gpio;
 pub mod gpio_async;
+pub mod hash;
 pub mod i2c;
 pub mod led;
 pub mod log;


### PR DESCRIPTION
### Pull Request Overview

This pull request adds an in-kernel hash abstraction layer. While currently contained in `capsules` as I wouldn't call it a _hardware interface layer_, in line with @bradjc comment on #1720 this should probably moved to `kernel/hil`.

It makes heavy use of the type system, deducing constraints of the hash-function for the hasher using a type argument. The type argument's `HashType` trait only uses static functions which should be inlined and incur no runtime cost at all. The `HashType` implementors are all zero sized, and can even be converted to enums without variants to avoid instantiation (but that doesn't hurt).

### Testing Strategy

In a joint effort with a colleague (@danielrutz) we've developed software implementations of the SHA1 and SHA-32-family (SHA2-224 + SHA2-256) of hash functions, which will be PR'ed shortly.
Combined with an appropriate userspace driver, this should be enough to validate the idea.

This should be checked for possible interop with #1702, especially regarding making the HMAC HIL generic over the `HashType` as done here.

I'm open to further suggestions regarding a testing strategy.

### TODO or Help Wanted

- [ ] Software implementation to validate implementer side (almost ready)
- [ ] Userspace driver (almost ready)
- [ ] I'm using `associated_type_defaults` here, but that can be removed if required.


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
