### PR TITLE
added riscv toolchain to shell.nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -35,7 +35,7 @@ let
   nixpkgs = import <nixpkgs> { overlays = [ moz_overlay ]; };
   rust_date = "2020-03-06";
   rust_channel = "nightly";
-  rust_targets = [ "thumbv7em-none-eabi" "thumbv7em-none-eabihf" "thumbv6m-none-eabi" ];
+  rust_targets = [ "thumbv7em-none-eabi" "thumbv7em-none-eabihf" "thumbv6m-none-eabi" "riscv32imac-unknown-none-elf" "riscv32imc-unknown-none-elf"];
   rust_build = nixpkgs.rustChannelOfTargets rust_channel rust_date rust_targets;
 in
   with pkgs;


### PR DESCRIPTION
### Pull Request Overview

The included `shell.nix` does not currently include the RISC-V toolchain. This PR adds the toolchain with both the `imc` and `imac` extensions. 
 
### Testing Strategy

While `make` produces some errors (namely an inability to find rustup which is to be expected since rustup is not actually installed in the mozilla overlay), the shell.nix allows for tock to be successfully built on NixOS. I tested by building the hifive1, arty_e21, and opentitan boards.

### Formatting

- [x] Ran `make formatall`.