### PR TITLE
[RFC] Driver registry / driver lookup mechanism

### DIFF
--- a/boards/components/src/console.rs
+++ b/boards/components/src/console.rs
@@ -107,6 +107,7 @@ impl Component for ConsoleComponent {
         let console = static_init!(
             console::Console<'static>,
             console::Console::new(
+                console::PRIMARY_CONSOLE_ID,
                 console_uart,
                 &mut console::WRITE_BUF,
                 &mut console::READ_BUF,

--- a/boards/hifive1/src/main.rs
+++ b/boards/hifive1/src/main.rs
@@ -64,16 +64,16 @@ impl Platform for HiFive1 {
     where
         F: FnOnce(Option<&dyn kernel::Driver>) -> R,
     {
-        if let Some(driver) = self.driver_registry.from_syscall_id(driver_num) {
-            f(Some(driver))
-        } else {
-            // Compatability with legacy code
-            match driver_num {
-                capsules::led::DRIVER_NUM => f(Some(self.led)),
-                capsules::console::DRIVER_NUM => f(Some(self.console)),
-                capsules::alarm::DRIVER_NUM => f(Some(self.alarm)),
-                capsules::low_level_debug::DRIVER_NUM => f(Some(self.lldb)),
-                _ => f(None),
+        match driver_num {
+            // Drivers reachable at a fixed driver_num
+            capsules::led::DRIVER_NUM => f(Some(self.led)),
+            capsules::console::DRIVER_NUM => f(Some(self.console)),
+            capsules::alarm::DRIVER_NUM => f(Some(self.alarm)),
+            capsules::low_level_debug::DRIVER_NUM => f(Some(self.lldb)),
+            dynamic_num => {
+                // Check whether this driver num is registered by the
+                // registry
+                f(self.driver_registry.from_syscall_id(dynamic_num))
             }
         }
     }

--- a/capsules/src/alarm.rs
+++ b/capsules/src/alarm.rs
@@ -1,6 +1,7 @@
 //! Provides userspace applications with a alarm API.
 
 use core::cell::Cell;
+use kernel::driver_registry::DriverInfo;
 use kernel::hil::time::{self, Alarm, Frequency};
 use kernel::{AppId, Callback, Driver, Grant, ReturnCode};
 
@@ -236,5 +237,24 @@ mod test {
     #[test]
     pub fn alarm_after_systick_wrap_time_after_systick_wrap_not_expired() {
         assert_eq!(super::has_expired(1u32, 0u32, 3u32), false);
+    }
+}
+
+impl<'a, A: Alarm<'a>> DriverInfo<crate::driver::NUM> for AlarmDriver<'a, A> {
+    fn driver(&self) -> &dyn Driver {
+        self
+    }
+
+    fn driver_type(&self) -> crate::driver::NUM {
+        crate::driver::NUM::Alarm
+    }
+
+    fn driver_name(&self) -> &'static str {
+        "alarm"
+    }
+
+    fn instance_identifier<'b>(&'b self) -> &'b str {
+        // TODO: Change this to something more meaningful
+        "alarm0"
     }
 }

--- a/capsules/src/driver.rs
+++ b/capsules/src/driver.rs
@@ -16,6 +16,7 @@ pub enum NUM {
     Adc                   = 0x00005,
     Dac                   = 0x00006,
     AnalogComparator      = 0x00007,
+    LowLevelDebug         = 0x00008,
 
     // Kernel
     Ipc                   = 0x10000,
@@ -65,4 +66,10 @@ pub enum NUM {
     // Misc
     Buzzer                = 0x90000,
 }
+}
+
+impl From<NUM> for usize {
+    fn from(num: NUM) -> usize {
+        num as usize
+    }
 }

--- a/capsules/src/low_level_debug/mod.rs
+++ b/capsules/src/low_level_debug/mod.rs
@@ -10,7 +10,7 @@ use kernel::{AppId, Grant, ReturnCode};
 // LowLevelDebug requires a &mut [u8] buffer of length at least BUF_LEN.
 pub use fmt::BUF_LEN;
 
-pub const DRIVER_NUM: usize = 0x8;
+pub const DRIVER_NUM: usize = crate::driver::NUM::LowLevelDebug as usize;
 
 pub struct LowLevelDebug<'u, U: Transmit<'u>> {
     buffer: Cell<Option<&'static mut [u8]>>,
@@ -153,4 +153,25 @@ pub(crate) enum DebugEntry {
     AlertCode(usize),     // Display a predefined alert code
     Print1(usize),        // Print a single number
     Print2(usize, usize), // Print two numbers
+}
+
+impl<'u, U: Transmit<'u>> kernel::driver_registry::DriverInfo<crate::driver::NUM>
+    for LowLevelDebug<'u, U>
+{
+    fn driver(&self) -> &dyn kernel::Driver {
+        self
+    }
+
+    fn driver_type(&self) -> crate::driver::NUM {
+        crate::driver::NUM::LowLevelDebug
+    }
+
+    fn driver_name(&self) -> &'static str {
+        "low_level_debug"
+    }
+
+    fn instance_identifier<'b>(&'b self) -> &'b str {
+        // TODO: This should be changed to something more meaningful
+        "lld0"
+    }
 }

--- a/kernel/src/driver_registry.rs
+++ b/kernel/src/driver_registry.rs
@@ -1,0 +1,133 @@
+use crate::mem::AppSlice;
+use crate::mem::Shared;
+use crate::AppId;
+use crate::Callback;
+use crate::Driver;
+use crate::Grant;
+use crate::ReturnCode;
+use core::cell::Cell;
+use core::marker::PhantomData;
+
+pub trait DriverInfo<T: Into<usize>>: Driver {
+    fn driver(&self) -> &dyn Driver;
+    fn driver_type(&self) -> T;
+    fn driver_name(&self) -> &'static str;
+    fn instance_identifier(&'a self) -> &'a str;
+}
+
+#[derive(Default)]
+pub struct App {
+    identifier_buffer: Option<AppSlice<Shared, u8>>,
+}
+
+pub struct DriverRegistry<'a, T: Into<usize>> {
+    drivers: Cell<&'a [&'a dyn DriverInfo<T>]>,
+    syscall_offset: usize,
+    apps: Grant<App>,
+    _driver_types: PhantomData<T>,
+}
+
+impl<'a, T: Into<usize>> DriverRegistry<'a, T> {
+    pub fn new(
+        syscall_offset: usize,
+        drivers: &'a [&'a dyn DriverInfo<T>],
+        grant: Grant<App>,
+    ) -> DriverRegistry<'a, T> {
+        DriverRegistry {
+            drivers: Cell::new(drivers),
+            syscall_offset,
+            apps: grant,
+            _driver_types: PhantomData,
+        }
+    }
+
+    pub fn update_drivers(&self, drivers: &'a [&'a dyn DriverInfo<T>]) {
+        self.drivers.set(drivers)
+    }
+
+    pub fn find_instance(
+        &'b self,
+        driver_type: usize,
+        instance_id: &'b [u8],
+    ) -> Option<(usize, &'a dyn Driver)> {
+        let dtype: usize = driver_type.into();
+
+        self.drivers
+            .get()
+            .iter()
+            .enumerate()
+            .find(|(_, driver)| {
+                driver.driver_type().into() == dtype
+                    && driver.instance_identifier().as_bytes() == instance_id
+            })
+            .and_then(|(index, driver)| {
+                index
+                    .checked_add(self.syscall_offset + 1)
+                    .map(move |syscall_id| (syscall_id, driver.driver()))
+            })
+    }
+
+    pub fn from_syscall_id(&self, syscall_id: usize) -> Option<&dyn Driver> {
+        if syscall_id == self.syscall_offset {
+            Some(self)
+        } else {
+            syscall_id
+                .checked_sub(self.syscall_offset + 1)
+                .and_then(|index| self.drivers.get().get(index).map(|driver| driver.driver()))
+        }
+    }
+}
+
+impl<'a, T: Into<usize>> Driver for DriverRegistry<'a, T> {
+    fn subscribe(
+        &self,
+        _minor_num: usize,
+        _callback: Option<Callback>,
+        _app_id: AppId,
+    ) -> ReturnCode {
+        ReturnCode::ENOSUPPORT
+    }
+
+    fn command(&self, command_num: usize, r2: usize, _r3: usize, app_id: AppId) -> ReturnCode {
+        match command_num {
+            0 /* Check if the driver is available */ => {
+                ReturnCode::SUCCESS
+	    },
+            1 /* Find syscall number for driver identifier */ => {
+                self.apps
+                    .enter(app_id, |app, _| {
+                        if let Some(id_buf) = &app.identifier_buffer {
+                            self.find_instance(r2, id_buf.as_ref())
+                                .map(|(syscall_id, _)| ReturnCode::SuccessWithValue {
+                                    value: syscall_id,
+                                })
+                                .unwrap_or(ReturnCode::ENODEVICE)
+                        } else {
+                            ReturnCode::ERESERVE
+                        }
+                    })
+                    .unwrap_or_else(|err| err.into())
+            },
+            _ => ReturnCode::ENOSUPPORT,
+        }
+    }
+
+    fn allow(
+        &self,
+        app_id: AppId,
+        minor_num: usize,
+        slice: Option<AppSlice<Shared, u8>>,
+    ) -> ReturnCode {
+        match minor_num {
+            0 /* the instance identifier to search for */ => {
+                self.apps
+                    .enter(app_id, |app, _| {
+                        app.identifier_buffer = slice;
+                        ReturnCode::SUCCESS
+                    })
+                    .unwrap_or_else(|err| err.into())
+            },
+            _ => ReturnCode::ENOSUPPORT,
+        }
+    }
+}

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -22,6 +22,7 @@ pub mod capabilities;
 pub mod common;
 pub mod component;
 pub mod debug;
+pub mod driver_registry;
 pub mod hil;
 pub mod introspection;
 pub mod ipc;


### PR DESCRIPTION
### Pull Request Overview
This PR adds a _driver registry_, which assigns each driver a possibly non-deterministic driver id to use in syscalls. In addition to that, it provides a lookup mechanism to determine the driver id for a given instance of a particular driver. For looking up the driver itself, the existing driver ids are used.

This is very much work in progress and a simple proof of concept. The code is primarily a demonstration for my solution approach to the problem outlined in _Motivation_.

Looking up the driver id (syscall argument) once may have a high cost, but I tried to keep the overhead during runtime as low as possible. This is using array indices to directly map from a driver id to a driver. I have not looked at the generated assembly yet.

As this approach does not make sense for drivers without the need for multiple instances, those can still be addressed the usual way. The pseudorandom ids can be generated after an offset specified in the constructor, dividing the driver ids into two regions: Static, and generated during runtime. Per driver, one mechanism must be decided.

As such an approach incurs significant changes to driver addressing from userspace, it'd be something to work towards for Tock 2.0 #1607.

Feedback is of course welcome, in the likely case that we don't want to have this this PR can be closed. :)

### Motivation
_I'd like to apologize for the confusing terminology, this is something I still have to work on. Specifically, this introduces a separation of what's traditionally known as the driver id, and the id used in syscalls._

Not all drivers offer the possibility to manage multiple devices. While that does make sense for something like LEDs, this is impractical for more complex drivers as the overhead for implementing multi-device support would quickly outrun the benefits. In such cases, when a person new to Tock asks "and how can I have multiple of those?" the standard answer has been to add another driver instance to the board.

That's fine, but suddenly the new driver is reachable under a different syscall number as [originally intended / assigned](https://github.com/tock/tock/blob/master/doc/syscalls/README.md). As this may be hardcoded in userspace, it requires substantial changes and the userspace library will be incompatible.

A possible solution for this issue is to reserve for each driver a few driver ids, taking the offset to the base driver id as an argument in the userspace library. That only postpones the issue until someone reaches the `n` instances limit, and feels more like a hack than a solution.

This pull request takes another approach. The driver numbers are assigned once at boot in a possibly non-deterministic way through a `DriverRegistry` component. That component itself provides a driver to userspace, exposing functionality to lookup the id to use for the syscall. Multiple instances of a single driver can be registered with the `DriverRegistry`, providing an individual _instance identifer_.

As a side effect, this can make Tock apps much more board agnostic. Take the console: an app may want to communicate different information through two consoles. By assigning each one an appropriate instance identifier (`console0` for debug / default, `user_console` for user output), this application will automatically resolve the correct peripheral to use on each board. (If this is a bad example, replace _console_ for any other driver) 


### Testing Strategy

This pull request was tested by compiling (untested, proof of concept code).


### TODO or Help Wanted

This pull request still needs
- [ ] feedback indicating whether we want this at all
- [ ] further development
- [ ] performance impact analysis
- [ ] testing
- [ ] documentation



### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
