### PR TITLE
rust: Disable frame pointers on RISC-V targets only

### DIFF
--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -26,6 +26,14 @@ RUSTFLAGS_FOR_CARGO ?= \
   -C link-arg=-zmax-page-size=512 \
   --remap-path-prefix=$(MAKEFILE_PARENT_PATH)= \
 
+# RISC-V-specific flags.
+ifneq ($(findstring riscv32i, $(TARGET)),)
+  # NOTE: This flag causes kernel panics on some ARM cores. Since the
+  # size benefit is almost exclusively for RISC-V, we only apply it for
+  # those targets.
+  RUSTFLAGS_FOR_CARGO += -C force-frame-pointers=no
+endif
+
 # Disallow warnings for continuous integration builds. Disallowing them here
 # ensures that warnings during testing won't prevent compilation from succeeding.
 ifeq ($(CI),true)


### PR DESCRIPTION
### Pull Request Overview

The last time we tried to turn frame pointers off, we discovered that
not having them resulted in kernel panics on some ARM boards. This
change re-disables frame pointers, but only for RISC-V borads.

### Testing Strategy

This pull request was tested by... (see below).

### TODO or Help Wanted

I'd like to avoid breaking someone again. I'm not familiar with any of the ARM boards, and I'd appreciate some thoughts on how to approach checking that nothing broke.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
