### PR TITLE
rust: Turn on aggressive identical code folding

### DIFF
--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -24,6 +24,7 @@ RUSTFLAGS_FOR_CARGO ?= \
   -C linker-flavor=ld.lld \
   -C relocation-model=dynamic-no-pic \
   -C link-arg=-zmax-page-size=512 \
+  -C link-arg=-icf=all \
   --remap-path-prefix=$(MAKEFILE_PARENT_PATH)= \
 
 # Disallow warnings for continuous integration builds. Disallowing them here


### PR DESCRIPTION
### Pull Request Overview

This change passes -icf=all to the linker, which ups the aggressiveness
of identical code folding (rustc passes -icf=safe by default). This cuts
down binary size slightly, at the cost of breaking function pointer
equality (i.e., it is now possible for distinct functions to have the
same observeable address).

For OT, we see a 1K code size decrease from turning on this flag.

### Testing Strategy

Currently untested beyond "it builds". I think we should make some attempt to figure out if we depend on function pointer equality in this particular way anywhere (I think this is unlikely, since rustc... tends to get function pointer comparisons wrong, anyway).

### TODO or Help Wanted

Still need to figure out whether this change is safe. I have no obvious reason to believe it isn't, but maybe Tock is doing function pointer shenanigans I was not yet aware of.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
