### PR TITLE
boards/opentitan: Build OpenTitan with target device specific parameters

### DIFF
--- a/boards/opentitan/Cargo.toml
+++ b/boards/opentitan/Cargo.toml
@@ -12,3 +12,19 @@ capsules = { path = "../../capsules" }
 kernel = { path = "../../kernel" }
 earlgrey = { path = "../../chips/earlgrey" }
 lowrisc = { path = "../../chips/lowrisc" }
+
+[features]
+# OpenTitan SoC design can be synthesized or compiled for different targets. A
+# target can be a specific FPGA board, an ASIC technology, or a simulation tool.
+# Please see: https://docs.opentitan.org/doc/ug/getting_started/ for further
+# information.
+#
+# OpenTitan CPU and possibly other components must be configured appropriately
+# for a specific target:
+#    - fpga_nexysvideo:
+#      OpenTitan SoC design running on Nexys Video Artix-7 FPGA.
+#
+#    - sim_verilator:
+#      OpenTitan SoC design simulated in Verilator.
+fpga_nexysvideo = ["earlgrey/config_fpga_nexysvideo"]
+sim_verilator = ["earlgrey/config_sim_verilator"]

--- a/boards/opentitan/Makefile
+++ b/boards/opentitan/Makefile
@@ -5,6 +5,11 @@ PLATFORM=opentitan
 
 include ../Makefile.common
 
+# Passing a feature to cargo through `FEATURES` environment variable.
+ifneq ($(FEATURES),)
+	CARGO_FLAGS += --features=$(FEATURES)
+endif
+
 qemu: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
 	$(call check_defined, OPENTITAN_BOOT_ROM)
 	qemu-system-riscv32 -M opentitan -kernel $^ -bios $(OPENTITAN_BOOT_ROM) -nographic -serial mon:stdio

--- a/boards/opentitan/Makefile
+++ b/boards/opentitan/Makefile
@@ -1,13 +1,17 @@
 # Makefile for building the tock kernel for the OpenTitan platform
 
+DEFAULT_BOARD_CONFIGURATION=fpga_nexysvideo
 TARGET=riscv32imc-unknown-none-elf
 PLATFORM=opentitan
 
 include ../Makefile.common
 
-# Passing a feature to cargo through `FEATURES` environment variable.
-ifneq ($(FEATURES),)
-	CARGO_FLAGS += --features=$(FEATURES)
+# Pass OpenTitan board configuration option in `BOARD_CONFIGURATION` through
+# Cargo `--features`. Please see `Cargo.toml` for available options.
+ifneq ($(BOARD_CONFIGURATION),)
+	CARGO_FLAGS += --features=$(BOARD_CONFIGURATION)
+else
+	CARGO_FLAGS += --features=$(DEFAULT_BOARD_CONFIGURATION)
 endif
 
 qemu: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf

--- a/boards/opentitan/README.md
+++ b/boards/opentitan/README.md
@@ -50,6 +50,23 @@ You can also just use the `spiflash` program manually to download the image to t
 
 NOTE: You will need to download the Tock binary after every power cycle.
 
+### Compiling the Kernel for FPGA or Verilator
+
+Opentitan is supported on both an FPGA and in Verilator. Slightly different
+versions of the EarlGrey chip implementation are required for the different
+platforms. By default the kernel is compiled for the FPGA. To compile for
+Verilator, run:
+
+```shell
+make BOARD_CONFIGURATION=sim_verilator
+```
+
+To explicitly specify the FPGA, run:
+
+```shell
+make BOARD_CONFIGURATION=fpga_nexysvideo
+```
+
 Programming Apps
 ----------------
 

--- a/boards/opentitan/src/main.rs
+++ b/boards/opentitan/src/main.rs
@@ -132,7 +132,7 @@ pub unsafe fn reset_handler() {
     // Create a shared UART channel for the console and for kernel debug.
     let uart_mux = components::console::UartMuxComponent::new(
         &earlgrey::uart::UART0,
-        230400,
+        earlgrey::uart::UART0_BAUDRATE,
         dynamic_deferred_caller,
     )
     .finalize(());

--- a/chips/earlgrey/Cargo.toml
+++ b/chips/earlgrey/Cargo.toml
@@ -4,6 +4,11 @@ version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
 edition = "2018"
 
+[features]
+config_fpga_nexysvideo = ["config_disable_default"]
+config_sim_verilator = ["config_disable_default"]
+config_disable_default = []
+
 [dependencies]
 lowrisc = { path = "../lowrisc" }
 rv32i = { path = "../../arch/rv32i" }

--- a/chips/earlgrey/Cargo.toml
+++ b/chips/earlgrey/Cargo.toml
@@ -5,6 +5,8 @@ authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
 edition = "2018"
 
 [features]
+# Compiling this crate requires enabling one of these features, otherwise
+# the default will be chosen.
 config_fpga_nexysvideo = ["config_disable_default"]
 config_sim_verilator = ["config_disable_default"]
 config_disable_default = []

--- a/chips/earlgrey/README.md
+++ b/chips/earlgrey/README.md
@@ -4,3 +4,12 @@ EarlGrey is the first OpenTitan system. At the center of the Earl Grey is the
 Ibex RISC-V compliant processor.
 
 [General information](https://docs.opentitan.org/hw/top_earlgrey/doc/)
+
+
+EarlGrey Configurations
+-----------------------
+
+Since the EarlGrey chip has not yet been fabricated in silicon, using it
+requires running it on an FPGA or in a simulator. These environments have slight
+differences, and require slightly different configurations of the EarlGrey chip.
+These configurations can be found in `chip_config.rs`.

--- a/chips/earlgrey/src/chip.rs
+++ b/chips/earlgrey/src/chip.rs
@@ -173,6 +173,10 @@ impl<A: 'static + Alarm<'static>> kernel::Chip for EarlGrey<A> {
     }
 
     unsafe fn print_state(&self, writer: &mut dyn Write) {
+        let _ = writer.write_fmt(format_args!(
+            "\r\n---| EarlGrey configuration for {} |---",
+            CONFIG.name
+        ));
         rv32i::print_riscv_state(writer);
     }
 }

--- a/chips/earlgrey/src/chip.rs
+++ b/chips/earlgrey/src/chip.rs
@@ -11,6 +11,7 @@ use kernel::Chip;
 use rv32i::csr::{mcause, mie::mie, mip::mip, mtvec::mtvec, CSR};
 use rv32i::syscall::SysCall;
 
+use crate::chip_config::CONFIG;
 use crate::gpio;
 use crate::hmac;
 use crate::interrupts;
@@ -20,7 +21,7 @@ use crate::timer;
 use crate::uart;
 use crate::usbdev;
 
-pub const CHIP_FREQ: u32 = 50_000_000;
+pub const CHIP_FREQ: u32 = CONFIG.chip_freq;
 
 pub struct EarlGrey<A: 'static + Alarm<'static>> {
     userspace_kernel_boundary: SysCall,

--- a/chips/earlgrey/src/chip_config.rs
+++ b/chips/earlgrey/src/chip_config.rs
@@ -1,0 +1,29 @@
+//! Chip specific configuration.
+
+// Chip configuration based on the target device.
+pub struct Config<'a> {
+    pub name: &'a str,
+    pub chip_freq: u32,
+    pub uart_baudrate: u32,
+}
+
+#[cfg(not(feature = "config_disable_default"))]
+pub const CONFIG: Config = Config {
+    name: &"default",
+    chip_freq: 50_000_000,
+    uart_baudrate: 230400,
+};
+
+#[cfg(feature = "config_fpga_nexysvideo")]
+pub const CONFIG: Config = Config {
+    name: &"fpga_nexysvideo",
+    chip_freq: 50_000_000,
+    uart_baudrate: 230400,
+};
+
+#[cfg(feature = "config_sim_verilator")]
+pub const CONFIG: Config = Config {
+    name: &"sim_verilator",
+    chip_freq: 500_000,
+    uart_baudrate: 9600,
+};

--- a/chips/earlgrey/src/chip_config.rs
+++ b/chips/earlgrey/src/chip_config.rs
@@ -1,29 +1,42 @@
 //! Chip specific configuration.
+//!
+//! This file includes configuration values for different implementations and
+//! uses of the same earlgrey chip. For example, running the chip on an FPGA
+//! requires different parameters from running it in a verilog simulator.
+//! Additionally, chips on different platforms can be used differently, so this
+//! also permits changing values like the UART baud rate to enable better
+//! debugging on platforms that can support it.
+//!
+//! The configuration used is selected via Cargo features specified when the
+//! board is compiled.
 
-// Chip configuration based on the target device.
+/// Earlgrey configuration based on the target device.
 pub struct Config<'a> {
+    /// Identifier for the platform. This is useful for debugging to confirm the
+    /// correct configuration of the chip is being used.
     pub name: &'a str,
+    /// The clock speed of the core in Hz.
     pub chip_freq: u32,
+    /// The baud rate for UART. This allows for a version of the chip that can
+    /// support a faster baud rate to use it to help with debugging.
     pub uart_baudrate: u32,
 }
 
-#[cfg(not(feature = "config_disable_default"))]
+/// Config for running EarlGrey on an FPGA. Also the default configuration.
+#[cfg(any(
+    feature = "config_fpga_nexysvideo",
+    not(feature = "config_disable_default")
+))]
 pub const CONFIG: Config = Config {
-    name: &"default",
+    name: "fpga_nexysvideo",
     chip_freq: 50_000_000,
     uart_baudrate: 230400,
 };
 
-#[cfg(feature = "config_fpga_nexysvideo")]
-pub const CONFIG: Config = Config {
-    name: &"fpga_nexysvideo",
-    chip_freq: 50_000_000,
-    uart_baudrate: 230400,
-};
-
+/// Config for running EarlGrey in a verilog simulator.
 #[cfg(feature = "config_sim_verilator")]
 pub const CONFIG: Config = Config {
-    name: &"sim_verilator",
+    name: "sim_verilator",
     chip_freq: 500_000,
     uart_baudrate: 9600,
 };

--- a/chips/earlgrey/src/lib.rs
+++ b/chips/earlgrey/src/lib.rs
@@ -5,6 +5,7 @@
 #![crate_name = "earlgrey"]
 #![crate_type = "rlib"]
 
+mod chip_config;
 mod interrupts;
 
 pub mod aes;

--- a/chips/earlgrey/src/uart.rs
+++ b/chips/earlgrey/src/uart.rs
@@ -2,6 +2,9 @@ use kernel::common::StaticRef;
 use lowrisc::uart::{Uart, UartRegisters};
 
 use crate::chip;
+use crate::chip_config::CONFIG;
+
+pub const UART0_BAUDRATE: u32 = CONFIG.uart_baudrate;
 
 pub static mut UART0: Uart = Uart::new(UART0_BASE, chip::CHIP_FREQ);
 


### PR DESCRIPTION
### Pull Request Overview

I think it is useful to be able to pass options to cargo from the board specific makefiles. This PR does it in a controlled way, by not getting the `CARGO_FLAGS` from the environment, but modified from within the board makefiles.

Rust features add some flexibility. In this case they serve as simple `#[cfg(feature = "sim_verilator")]`, but could be used to pull in optional dependencies.

This pull request consists of three changes:
- Opentitan `makefile` change to pass features to Cargo.
- Creates an infrastructure in the opentitan chain (`boards/opentitan`, `chips/earlgrey)` to pass requested features. It also adds a configuration file, which based on the requested feature initialises a structure with the device specific information.
- Uses the device specific data instead of the hardcoded values.

### Testing Strategy

This pull request was tested by running on the verilator with environment variable `BOARD_CONFIGURATION=sim_verilator`, and observing the expected UART output. When built for the fpga, and ran on verilator, no output was observed (expected).

### TODO or Help Wanted

- [x] Test on the FPGA or verilator.

### Documentation Updated

No updates are required?

### Formatting

- [x] Ran `make formatall`.
