### PR TITLE
Spi: Move SPI buffer size into SPI capsule

### DIFF
--- a/boards/components/src/spi.rs
+++ b/boards/components/src/spi.rs
@@ -27,7 +27,7 @@
 
 use core::mem::MaybeUninit;
 
-use capsules::spi::Spi;
+use capsules::spi::{Spi, SPI_WRITE_BUF, SPI_READ_BUF};
 use capsules::virtual_spi::{MuxSpiMaster, VirtualSpiMasterDevice};
 use kernel::component::Component;
 use kernel::hil::spi;
@@ -130,9 +130,6 @@ impl<S: 'static + spi::SpiMaster> Component for SpiSyscallComponent<S> {
             Spi<'static, VirtualSpiMasterDevice<'static, S>>,
             Spi::new(syscall_spi_device)
         );
-
-        static mut SPI_READ_BUF: [u8; 1024] = [0; 1024];
-        static mut SPI_WRITE_BUF: [u8; 1024] = [0; 1024];
 
         spi_syscalls.config_buffers(&mut SPI_READ_BUF, &mut SPI_WRITE_BUF);
         syscall_spi_device.set_client(spi_syscalls);

--- a/boards/components/src/spi.rs
+++ b/boards/components/src/spi.rs
@@ -27,11 +27,11 @@
 
 use core::mem::MaybeUninit;
 
-use capsules::spi::{Spi, SPI_READ_BUF, SPI_WRITE_BUF};
+use capsules::spi::{Spi, DEFAULT_READ_BUF_LENGTH, DEFAULT_WRITE_BUF_LENGTH};
 use capsules::virtual_spi::{MuxSpiMaster, VirtualSpiMasterDevice};
 use kernel::component::Component;
 use kernel::hil::spi;
-use kernel::static_init_half;
+use kernel::{static_init, static_init_half};
 
 // Setup static space for the objects.
 #[macro_export]
@@ -131,7 +131,15 @@ impl<S: 'static + spi::SpiMaster> Component for SpiSyscallComponent<S> {
             Spi::new(syscall_spi_device)
         );
 
-        spi_syscalls.config_buffers(&mut SPI_READ_BUF, &mut SPI_WRITE_BUF);
+        let spi_read_buf =
+            static_init!([u8; DEFAULT_READ_BUF_LENGTH], [0; DEFAULT_READ_BUF_LENGTH]);
+
+        let spi_write_buf = static_init!(
+            [u8; DEFAULT_WRITE_BUF_LENGTH],
+            [0; DEFAULT_WRITE_BUF_LENGTH]
+        );
+
+        spi_syscalls.config_buffers(spi_read_buf, spi_write_buf);
         syscall_spi_device.set_client(spi_syscalls);
 
         spi_syscalls

--- a/capsules/src/spi.rs
+++ b/capsules/src/spi.rs
@@ -13,6 +13,10 @@ use kernel::{AppId, AppSlice, Callback, Driver, ReturnCode, Shared};
 use crate::driver;
 pub const DRIVER_NUM: usize = driver::NUM::Spi as usize;
 
+/// Suggested length for the Spi read and write buffer
+pub const DEFAULT_READ_BUF_LENGTH: usize = 1024;
+pub const DEFAULT_WRITE_BUF_LENGTH: usize = 1024;
+
 // SPI operations are handled by coping into a kernel buffer for
 // writes and copying out of a kernel buffer for reads.
 //

--- a/capsules/src/spi.rs
+++ b/capsules/src/spi.rs
@@ -48,9 +48,6 @@ struct SlaveApp {
     index: usize,
 }
 
-pub static mut SPI_WRITE_BUF: [u8; 1024] = [0; 1024];
-pub static mut SPI_READ_BUF: [u8; 1024] = [0; 1024];
-
 pub struct Spi<'a, S: SpiMasterDevice> {
     spi_master: &'a S,
     busy: Cell<bool>,

--- a/capsules/src/spi.rs
+++ b/capsules/src/spi.rs
@@ -44,6 +44,9 @@ struct SlaveApp {
     index: usize,
 }
 
+pub static mut SPI_WRITE_BUF: [u8; 1024] = [0; 1024];
+pub static mut SPI_READ_BUF: [u8; 1024] = [0; 1024];
+
 pub struct Spi<'a, S: SpiMasterDevice> {
     spi_master: &'a S,
     busy: Cell<bool>,


### PR DESCRIPTION

### Pull Request Overview

This pull request moves the SPI buffer size into capsule from the component, thus addressing the solution for #1462 . 


### Testing Strategy

This pull request was tested by `make allcheck` and `make allboards`, no device testing.


### TODO or Help Wanted

Should be fine.


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
