### PR TITLE
Fixed USART number for panic of stm32f3 boards

### DIFF
--- a/boards/stm32f3discovery/src/io.rs
+++ b/boards/stm32f3discovery/src/io.rs
@@ -38,7 +38,7 @@ impl Write for Writer {
 
 impl IoWrite for Writer {
     fn write(&mut self, buf: &[u8]) {
-        let uart = unsafe { &mut stm32f3xx::usart::USART2 };
+        let uart = unsafe { &mut stm32f3xx::usart::USART1 };
 
         if !self.initialized {
             self.initialized = true;


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes the USART number for displaying a panic.


### Testing Strategy

This pull request was tested using an stm32f3discovery board.

### TODO or Help Wanted

N/A

### Documentation Updated

- [x] no updates are required.

### Formatting

- [x] Ran `make formatall`.
