### PR TITLE
nRF52: Fix dynamic deferred calls

### DIFF
--- a/boards/nordic/nrf52dk_base/src/lib.rs
+++ b/boards/nordic/nrf52dk_base/src/lib.rs
@@ -417,14 +417,6 @@ pub unsafe fn setup_board<I: nrf52::interrupt_service::InterruptService>(
     while !nrf52::clock::CLOCK.low_started() {}
     while !nrf52::clock::CLOCK.high_started() {}
 
-    let dynamic_deferred_call_clients =
-        static_init!([DynamicDeferredCallClientState; 1], Default::default());
-    let dynamic_deferred_call = static_init!(
-        DynamicDeferredCall,
-        DynamicDeferredCall::new(dynamic_deferred_call_clients)
-    );
-    DynamicDeferredCall::set_global_instance(dynamic_deferred_call);
-
     let platform = Platform {
         button: button,
         ble_radio: ble_radio,


### PR DESCRIPTION
### Pull Request Overview

This removes a duplicate instantiation of the dynamic deffered calls component on nRF52 boards. Because it was overwriting the global instance after the previous one has already been used for the MuxUart, this would have caused deferred calls to not be routed to the MuxUart instance.

The remains of my development effort (thought of as an initial demonstration and usage) have been so far down the long board file, presumably @phil-levis just didn't notice them in #1522. It did gave me quite a laugh to see this though. :smiley: 

### Testing Strategy

This pull request was tested by booting the kernel on the nRF52840DK. The `MuxUart` (only thing using the deferred calls on this board) did work before, now it's still working. Still as far as I know this fix is required to make the deferred calls to `MuxUart` effective.

### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
