### PR TITLE
Bring back Travis memory reporting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,4 +47,4 @@ script:
 after_success:
   - export PATH=$HOME/.local/bin:$PATH
   - pip3 install --user cxxfilt
-    #- ./tools/post_size_changes_to_github.sh
+  - ./tools/post_size_changes_to_github.sh

--- a/tools/post_size_changes_to_github.sh
+++ b/tools/post_size_changes_to_github.sh
@@ -61,7 +61,7 @@ if [ -n "$TRAVIS_PULL_REQUEST_BRANCH" ]; then
         ${TRAVIS_BUILD_DIR}/tools/diff_memory_usage.py previous-benchmark-${b} current-benchmark-${b} size-diffs-${b}.txt ${b}
         if [ -s "size-diffs-${b}.txt" ]; then
             RES="$( grep -hs ^ size-diffs-${b}.txt )" #grep instead of cat to prevent errors on no match
-            if [ -s "${TRAVIS_GITHUB_TOKEN}"]; then
+            if [ -n "${TRAVIS_GITHUB_TOKEN}" ]; then
                 # Only attempt to post statuses if the token is available (will not post for PRs from forks)
                 curl -X POST -H "Content-Type: application/json" --header "Authorization: token ${TRAVIS_GITHUB_TOKEN}" --data '{"state": "success", "context": "'"${b}"'", "description": "'"${RES}"'"}' https://api.github.com/repos/tock/tock/statuses/${TRAVIS_PULL_REQUEST_SHA}
             fi


### PR DESCRIPTION
### Pull Request Overview

This pull request brings back travis-ci running the memory reporting script. It is slightly modified now, so that Github status posts will only be made if the encrypted environment variable required for these posts is available (so status posts will not be made for PRs from forks). The size changes will always be printed in the final step of the build log, however (ctrl+f for CHANGE DETECTED to skip to any changes reported).


### Testing Strategy

This pull request was tested by creating two PRs against this branch, one from a branch on the upstream repository (#1751) and one from a branch on my fork of the repository (#1752 ). Travis-CI succeeded in both PRs, but a status was only posted on the PR from the upstream repo.


### TODO or Help Wanted

Figure out how to safely post statuses even for PRs from forks.


### Documentation Updated

- [x] No updates are required.

### Formatting

- [x] Ran `make formatall`.
