### PR TITLE
tools: rustfmt: use --all with workspace

### DIFF
--- a/tools/run_cargo_fmt.sh
+++ b/tools/run_cargo_fmt.sh
@@ -45,19 +45,15 @@ if git status --porcelain | grep '^.M.*\.rs' -q; then
 fi
 
 set +e
-let FAIL=0
-set -e
 
-# Find folders with Cargo.toml files in them and run `cargo fmt`.
 if [ "$1" == "diff" ]; then
-	# Just print out diffs and count errors, used by Travis
+	# Just print out diffs, used by Travis.
 	CARGO_FMT_ARGS="-- --check"
 fi
-for f in $(find . | grep Cargo.toml); do
-	pushd $(dirname $f) > /dev/null
-	cargo-fmt $CARGO_FMT_ARGS || let FAIL=FAIL+1
-	popd > /dev/null
-done
+
+# Format all crates in the workspace.
+cargo fmt --all $CARGO_FMT_ARGS
+FAIL=$?
 
 if [[ $FAIL -ne 0 ]]; then
 	echo

--- a/tools/run_cargo_fmt.sh
+++ b/tools/run_cargo_fmt.sh
@@ -44,20 +44,19 @@ if git status --porcelain | grep '^.M.*\.rs' -q; then
 	fi
 fi
 
-set +e
-
 if [ "$1" == "diff" ]; then
 	# Just print out diffs, used by Travis.
 	CARGO_FMT_ARGS="-- --check"
 fi
 
-# Format all crates in the workspace.
-cargo fmt --all $CARGO_FMT_ARGS
-FAIL=$?
-
-if [[ $FAIL -ne 0 ]]; then
+function on_error() {
 	echo
 	echo "$(tput bold)Formatting errors.$(tput sgr0)"
 	echo "See above for details"
-fi
-exit $FAIL
+}
+
+# Print a helpful message if there are formatting errors:
+trap on_error ERR
+
+# Format all crates in the workspace.
+cargo fmt --all $CARGO_FMT_ARGS


### PR DESCRIPTION
Since Tock is now in a workspace, we can run `cargo fmt --all` instead of needing to do the loop ourselves.

I don't know if it matters if we use `cargo-fmt` versus `cargo fmt`, but the latter makes more sense to me.

### Testing Strategy

This pull request was tested by running it several times.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
