### PR TITLE
capsules: virtual_uart: avoid double receive, check rx len, support custom buffer

### DIFF
--- a/capsules/src/virtual_uart.rs
+++ b/capsules/src/virtual_uart.rs
@@ -82,18 +82,23 @@ impl<'a> uart::ReceiveClient for MuxUart<'a> {
         rcode: ReturnCode,
         error: uart::Error,
     ) {
-        let mut next_read_len = RX_BUF_LEN;
+        // Likely we will issue another receive in response to the previous one
+        // finishing. `next_read_len` keeps track of the shortest outstanding
+        // receive requested by any client. We start with the longest it can be,
+        // i.e. the length of the buffer we pass to the UART.
+        let mut next_read_len = buffer.len();
         let mut read_pending = false;
+
+        // Set a flag that we are in this callback handler. This allows us to
+        // note that we can wait until all callbacks are finished before
+        // starting a new UART receive.
         self.completing_read.set(true);
-        // Because clients may issue another read in their callback we need to first
-        // copy out all the data, then make the callbacks.
+
+        // Because clients may issue another read in their callback we need to
+        // first copy out all the data, then make the callbacks.
         //
-        // Multiple client reads of different sizes can be pending. This code copies
-        // the underlying UART read into each of the client buffers; if the
-        // underlying read completes a client read, issue a callback to that
-        // client. In the meanwhile, compute the length of the next underlying
-        // UART read: if any client has more to read, issue another underlying
-        // read.
+        // Multiple client reads of different sizes can be pending. This code
+        // copies the underlying UART read into each of the client buffers.
         self.devices.iter().for_each(|device| {
             if device.receiver {
                 device.rx_buffer.take().map(|rxbuf| {
@@ -105,7 +110,7 @@ impl<'a> uart::ReceiveClient for MuxUart<'a> {
                     if state == UartDeviceReceiveState::Receiving
                         || state == UartDeviceReceiveState::Aborting
                     {
-                        //                        debug!("Have {} bytes, copying in bytes {}-{}, {} remain", rx_len, position, position + len, remaining);
+                        // debug!("Have {} bytes, copying in bytes {}-{}, {} remain", rx_len, position, position + len, remaining);
                         for i in 0..len {
                             rxbuf[position + i] = buffer[i];
                         }
@@ -115,7 +120,11 @@ impl<'a> uart::ReceiveClient for MuxUart<'a> {
                 });
             }
         });
-        self.buffer.replace(buffer);
+        // If the underlying read completes a client read, issue a callback to
+        // that client. In the meanwhile, compute the length of the next
+        // underlying UART read as the shortest outstanding read, including and
+        // new reads setup in the callback. If any client has more to read or
+        // has started a new read, issue another underlying UART receive.
         self.devices.iter().for_each(|device| {
             if device.receiver {
                 device.rx_buffer.take().map(|rxbuf| {
@@ -128,6 +137,11 @@ impl<'a> uart::ReceiveClient for MuxUart<'a> {
                     if remaining == 0 {
                         device.state.set(UartDeviceReceiveState::Idle);
                         device.received_buffer(rxbuf, position, rcode, error);
+                        // Need to check if receive was called in callback
+                        if device.state.get() == UartDeviceReceiveState::Receiving {
+                            read_pending = true;
+                            next_read_len = cmp::min(next_read_len, device.rx_len.get());
+                        }
                     } else if state == UartDeviceReceiveState::Aborting {
                         device.state.set(UartDeviceReceiveState::Idle);
                         device.received_buffer(
@@ -136,6 +150,11 @@ impl<'a> uart::ReceiveClient for MuxUart<'a> {
                             ReturnCode::ECANCEL,
                             uart::Error::Aborted,
                         );
+                        // Need to check if receive was called in callback
+                        if device.state.get() == UartDeviceReceiveState::Receiving {
+                            read_pending = true;
+                            next_read_len = cmp::min(next_read_len, device.rx_len.get());
+                        }
                     } else {
                         device.rx_buffer.replace(rxbuf);
                         next_read_len = cmp::min(next_read_len, remaining);
@@ -144,7 +163,19 @@ impl<'a> uart::ReceiveClient for MuxUart<'a> {
                 });
             }
         });
+
+        // After we have finished all callbacks we can replace this buffer. We
+        // have to wait to replace this to make sure that a client calling
+        // `receive_buffer()` in its callback does not start an underlying UART
+        // receive before all callbacks have finished.
+        self.buffer.replace(buffer);
+
+        // Clear the flag that we are in this handler.
         self.completing_read.set(false);
+
+        // If either our outstanding receive was longer than the number of bytes
+        // we just received, or if a new receive has been started, we start the
+        // underlying UART receive again.
         if read_pending {
             self.start_receive(next_read_len);
         }
@@ -220,25 +251,31 @@ impl<'a> MuxUart<'a> {
     /// the reception will issue a callback before the new read. A callback
     /// needs to be issued before the new read if a read was ongoing; the
     /// callback finishes the current read so the new one can start.
+    ///
     /// Three cases:
-    ///    1) We are in the midst of completing a read: let it restart the
-    ///       reads if needed (return false)
-    ///    2) We are in the midst of a read: abort so we can start a new
-    ///       read now (return true)
-    ///    3) We are idle: start reading (return false)
+    /// 1. We are in the midst of completing a read: let the `received_buffer()`
+    ///    handler restart the reads if needed (return false)
+    /// 2. We are in the midst of a read: abort so we can start a new read now
+    ///    (return true)
+    /// 3. We are idle: start reading (return false)
     fn start_receive(&self, rx_len: usize) -> bool {
         self.buffer.take().map_or_else(
             || {
                 // No rxbuf which means a read is ongoing
                 if self.completing_read.get() {
-                    // Do nothing, read completion will call start_receive when ready
+                    // Case (1). Do nothing here, `received_buffer()` handler
+                    // will call start_receive when ready.
                     false
                 } else {
+                    // Case (2). Stop the previous read so we can use the
+                    // `received_buffer()` handler to recalculate the minimum
+                    // length for a read.
                     self.uart.receive_abort();
                     true
                 }
             },
             |rxbuf| {
+                // Case (3). No ongoing receive calls, we can start one now.
                 let len = cmp::min(rx_len, rxbuf.len());
                 self.uart.receive_buffer(rxbuf, len);
                 false

--- a/capsules/src/virtual_uart.rs
+++ b/capsules/src/virtual_uart.rs
@@ -443,6 +443,8 @@ impl<'a> uart::Receive<'a> for UartDevice<'a> {
     ) -> (ReturnCode, Option<&'static mut [u8]>) {
         if self.rx_buffer.is_some() {
             (ReturnCode::EBUSY, Some(rx_buffer))
+        } else if rx_len > rx_buffer.len() {
+            (ReturnCode::ESIZE, Some(rx_buffer))
         } else {
             self.rx_buffer.replace(rx_buffer);
             self.rx_len.set(rx_len);

--- a/capsules/src/virtual_uart.rs
+++ b/capsules/src/virtual_uart.rs
@@ -128,10 +128,6 @@ impl<'a> uart::ReceiveClient for MuxUart<'a> {
                     if remaining == 0 {
                         device.state.set(UartDeviceReceiveState::Idle);
                         device.received_buffer(rxbuf, position, rcode, error);
-                        // Need to check if receive was called in callback
-                        if device.state.get() == UartDeviceReceiveState::Receiving {
-                            read_pending = true;
-                        }
                     } else if state == UartDeviceReceiveState::Aborting {
                         device.state.set(UartDeviceReceiveState::Idle);
                         device.received_buffer(
@@ -140,10 +136,6 @@ impl<'a> uart::ReceiveClient for MuxUart<'a> {
                             ReturnCode::ECANCEL,
                             uart::Error::Aborted,
                         );
-                        // Need to check if receive was called in callback
-                        if device.state.get() == UartDeviceReceiveState::Receiving {
-                            read_pending = true;
-                        }
                     } else {
                         device.rx_buffer.replace(rxbuf);
                         next_read_len = cmp::min(next_read_len, remaining);


### PR DESCRIPTION
### Pull Request Overview

Unexpected behavior: Running the process console causes uart.receive_abort to be called after every character.

Cause: start_receive gets called twice, once with a rx_buffer, and the second time without since it is being used after the first call. The first call happens because process console starts a new receive after handling its current read, and the second call happens because uart mux calls start_receive on its client's behalf after the callback.

Fix: Make sure that the buffer used by virtual_uart for underlying UART receives isn't replaced before client callbacks are completed. This causes all receives in callbacks to be queued until they have all completed and the virtual_uart receive handler can determine the shortest read to issue.

#### Other Changes

- Do not assume the buffer used for virtual_uart receive is the default one, and instead use the actual buffer length for the maximum receive length.
- Check for `ESIZE` when a client issues a read.






This pull request adds/changes/fixes...


### Testing Strategy

Running process console on hail and verifying it works.

Added a debug statement to sam4l::usart::abort and it no longer is printed.

Tried the imix/src/test/virtual_uart_rx_test on hail and it works as expected.

### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
