### PR TITLE
doc: Update GPIO syscall for pseudo-stabilization

### DIFF
--- a/doc/syscalls/00004_gpio.md
+++ b/doc/syscalls/00004_gpio.md
@@ -1,5 +1,5 @@
 ---
-driver number: 0x00004
+driver number: `0x00004`
 ---
 
 # GPIO
@@ -9,22 +9,29 @@ driver number: 0x00004
 The GPIO driver allows userspace to synchronously control the output and
 receive callbacks on changes in the input for a set of GPIO pins.
 
-GPIO pins are indexed in the array starting at 0. The order of the pins and the
-mapping between indexes and actual pins is set by the kernel in the board's
-main file.
+This is a low-level GPIO driver designed to export "hardware-like" control
+of GPIO pins to userspace. Not all platforms will expose all or even any
+pins using this interface to userspace.
+
+_Unstable:_ As this is a low-level interface, the mapping of GPIO pins
+is currently unstable and unspecified. Users of this driver must consult
+their board for a mapping from pin identifiers used in this driver to
+actual hardware pins. This mapping is currently subject to change.
 
 ## Command
 
   * ### Command number: `0`
 
-    **Description**: How many GPIO pins are supported on this board.
+    **Description**: Whether GPIO pins are exported by this board.
 
     **Argument 1**: unused
 
     **Argument 2**: unused
 
-    **Returns**: The number of pins on the board, or `ENODEVICE` if this driver
-    is not present on the board.
+    **Returns**: _Unstable:_ Most boards return the number of GPIO pins
+    available, however users should consult their board for details of
+    this return value.
+    `ENODEVICE` if this driver is not present on the board.
 
 
   * ### Command number: `1`
@@ -33,8 +40,7 @@ main file.
     output-related operations on the pin (`set`, `clear`, `toggle`) are
     available. Using input operations on a pin in this state is undefined.
 
-    **Argument 1**: The index of the GPIO pin to enable output for, starting at
-    0.
+    **Argument 1**: The identifier of the GPIO pin to enable output for.
 
     **Argument 2**: unused
 
@@ -46,22 +52,22 @@ main file.
     **Description**: Set the output of a GPIO pin (high). Using this command
     without first enabling output is undefined.
 
-    **Argument 1**: The index of the GPIO pin to set, starting at 0.
+    **Argument 1**: The identifier of the GPIO pin to set.
 
     **Argument 2**: unused
 
-    **Returns**: `SUCCESS` if the pin index is valid, `EINVAL` otherwise.
+    **Returns**: `SUCCESS` if the pin identifier is valid, `EINVAL` otherwise.
 
   * ### Command number: `3`
 
     **Description**: Clear the output of a GPIO pin (low). Using this command
     without first enabling output is undefined.
 
-    **Argument 1**: The index of the GPIO pin to clear, starting at 0.
+    **Argument 1**: The identifier of the GPIO pin to clear.
 
     **Argument 2**: unused
 
-    **Returns**: `SUCCESS` if the pin index is valid, `EINVAL` otherwise.
+    **Returns**: `SUCCESS` if the pin identifier is valid, `EINVAL` otherwise.
 
   * ### Command number: `4`
 
@@ -69,11 +75,11 @@ main file.
     previously high, this operation clears it. If it was previously low, sets
     it. Using this command without first enabling output is undefined.
 
-    **Argument 1**: The index of the GPIO pin to toggle, starting at 0.
+    **Argument 1**: The identifier of the GPIO pin to toggle.
 
     **Argument 2**: unused
 
-    **Returns**: `SUCCESS` if the pin index is valid, `EINVAL` otherwise.
+    **Returns**: `SUCCESS` if the pin identifier is valid, `EINVAL` otherwise.
 
   * ### Command number: `5`
 
@@ -81,41 +87,43 @@ main file.
     input, input-related operations on the pin (e.g. `read`) are available.
     Using output operations on a pin in this state is undefined.
 
-    **Argument 1**: The index of the GPIO pin to toggle, starting at 0.
+    **Argument 1**: The identifier of the GPIO pin to toggle.
 
     **Argument 2**: requested resistor to attach to the pin: `0` for pull-none,
-    `1` for pull-up, or `2` for pull-down.
+    `1` for pull-up, or `2` for pull-down. Other values are undefined.
 
-    **Returns**: `SUCCESS` if the pin index is valid, `EINVAL` if it is
+    **Returns**: `SUCCESS` if the pin identifier is valid, `EINVAL` if it is
     invalid, and `ENOSUPPORT` if the resistor configuration is not supported by
-    the hardware.
+    the hardware. If any error is returned, no state will be changed.
 
   * ### Command number: `6`
 
     **Description**: Read the current value of a GPIO pin.
 
-    **Argument 1**: The index of the GPIO pin to read, starting at 0.
+    **Argument 1**: The identifier of the GPIO pin to read.
 
     **Argument 2**: unused
 
-    **Returns**: `EINVAL` if the index of the pin is invalid, `1` if the value
-    of the pin is high or `0` if it is low.
+    **Returns**: `EINVAL` if the identifier of the pin is invalid, `1` if the
+    value of the pin is high or `0` if it is low.
 
   * ### Command number: `7`
 
     **Description**: Configure interrupts on a GPIO pin.
     After enabling interrupts, the callback set in subscribe will be called
-    when a the pin level changes.
+    when the pin level changes.
     Using this command without first enabling input is undefined.
 
-    **Argument 1**: The index of the GPIO pin to read, starting at 0.
+    **Argument 1**: The identifier of the GPIO pin to read.
 
     **Argument 2**: Indicates which events trigger callbacks: `0` for either
-    edge, `1` for rising edge, or `2` for falling edge.
+    edge, `1` for rising edge, or `2` for falling edge. Other values are
+    undefined.
 
-    **Returns**: `SUCCESS` if the pin index is valid, `EINVAL` if it is
+    **Returns**: `SUCCESS` if the pin identifier is valid, `EINVAL` if it is
     invalid, and `ENOSUPPORT` if an invalid interrupt mode is passed in the
-    configuration field of the argument.
+    configuration field of the argument. If any error is returned, no state
+    will be changed.
 
 ## Subscribe
 
@@ -126,10 +134,10 @@ main file.
     not have an effect on whether any GPIO pin interrupts are enabled.
 
     **Callback signature**: The callback receives two arguments. The first is
-    the index of the GPIO pin whose level has changed, and the second is value
-    of the pin when the interrupt occurred. The second argument has the same
-    semantics as the return value for the `read` command: `0` for low, `1` for
-    high.
+    the identifier of the GPIO pin whose level has changed, and the second is
+    the value of the pin when the interrupt occurred. The second argument has
+    the same semantics as the return value for the `read` command: `0` for low,
+    `1` for high.
 
     **Returns**: SUCCESS if the subscribe was successful, ENOMEM if the driver
     cannot support another app, and `EINVAL` if the app is somehow invalid.

--- a/doc/syscalls/README.md
+++ b/doc/syscalls/README.md
@@ -14,7 +14,7 @@ provided syscalls, and the driver specific interfaces (using `allow`,
 - [Capsule Provided Drivers](#capsule-provided-drivers)
   * [Base](#base)
   * [Kernel](#kernel)
-  * [HW Buses](#hw-buses)
+  * [Hardware Access](#hardware-access)
   * [Radio](#radio)
   * [Cryptography](#cryptography)
   * [Storage](#storage)
@@ -46,7 +46,6 @@ stabilized or not (a "✓" indicates stability) in the Tock 1.0 release.
 | ✓ | 0x00001       | [Console](00001_console.md) | UART console                               |
 | ✓ | 0x00002       | [LED](00002_leds.md)        | Control LEDs on board                      |
 | ✓ | 0x00003       | [Button](00003_buttons.md)  | Get interrupts from buttons on the board   |
-|   | 0x00004       | [GPIO](00004_gpio.md)       | Set and read GPIO pins                     |
 | ✓ | 0x00005       | [ADC](00005_adc.md)         | Sample analog-to-digital converter pins    |
 |   | 0x00006       | DAC                         | Digital to analog converter                |
 |   | 0x00007       | [AnalogComparator](00007_analog_comparator.md) | Analog Comparator       |
@@ -58,16 +57,19 @@ stabilized or not (a "✓" indicates stability) in the Tock 1.0 release.
 |---|---------------|------------------|--------------------------------------------|
 |   | 0x10000       | IPC              | Inter-process communication                |
 
-### HW Buses
+### Hardware Access
 
 |1.0| Driver Number | Driver           | Description                                |
 |---|---------------|------------------|--------------------------------------------|
+|   | 0x00004       | [GPIO](00004_gpio.md) | Set and read GPIO pins                |
 |   | 0x20000       | UART             | UART                                       |
 |   | 0x20001       | SPI              | Raw SPI Master interface                   |
 |   | 0x20002       | SPI Slave        | Raw SPI slave interface                    |
 |   | 0x20003       | I2C Master       | Raw I2C Master interface                   |
 |   | 0x20004       | I2C Slave        | Raw I2C Slave interface                    |
 |   | 0x20005       | USB              | Universal Serial Bus interface             |
+
+_Note:_ GPIO is slated for re-numbering in Tock 2.0.
 
 ### Radio
 


### PR DESCRIPTION
### Pull Request Overview

Following the discussion from the #core channel on slack and the goal of resolving #630 for Tock 1.5, this is a draft of the semantics we aim to guarantee for GPIOs.

The GPIO interface provides low-level hardware access, and as such isn't something we necessarily intend to ever stabalize as a general OS interface (ideally the OS will export more semantically meaningful interfaces -- switch, LED, etc -- a GPIO is not really meaningful to a cross platform app [what does the pin do across platforms?]). This moves GPIO to join the rest of the low-level hardware interfaces and updates its documentation to align with this intent. It also relaxes the description of the mapping to allow for experimentation like #1690 without breaking any interface promises.

### Testing Strategy

None yet.

### TODO or Help Wanted

We should come to consensus on the intent and the semi-arbitrary renumbering, then I'll update the actual drivers as well.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make formatall`.
