### PR TITLE
Unify arithmetic implementation of field registers and add unit tests.

### DIFF
--- a/libraries/tock-register-interface/src/registers.rs
+++ b/libraries/tock-register-interface/src/registers.rs
@@ -61,12 +61,13 @@
 
 use core::fmt;
 use core::marker::PhantomData;
-use core::ops::{Add, AddAssign, BitAnd, BitOr, Not, Shl, Shr};
+use core::ops::{Add, AddAssign, BitAnd, BitOr, BitOrAssign, Not, Shl, Shr};
 
 /// IntLike properties needed to read/write/modify a register.
 pub trait IntLike:
     BitAnd<Output = Self>
     + BitOr<Output = Self>
+    + BitOrAssign
     + Not<Output = Self>
     + Eq
     + Shr<usize, Output = Self>
@@ -92,7 +93,6 @@ impl IntLike for u32 {
         0
     }
 }
-
 impl IntLike for u64 {
     fn zero() -> Self {
         0
@@ -168,15 +168,13 @@ impl<T: IntLike, R: RegisterLongName> ReadWrite<T, R> {
     #[inline]
     /// Read the value of the given field
     pub fn read(&self, field: Field<T, R>) -> T {
-        (self.get() & (field.mask << field.shift)) >> field.shift
+        field.read(self.get())
     }
 
     #[inline]
     /// Read value of the given field as an enum member
     pub fn read_as_enum<E: TryFromValue<T, EnumType = E>>(&self, field: Field<T, R>) -> Option<E> {
-        let val: T = self.read(field);
-
-        E::try_from(val)
+        field.read_as_enum(self.get())
     }
 
     #[inline]
@@ -194,33 +192,32 @@ impl<T: IntLike, R: RegisterLongName> ReadWrite<T, R> {
     #[inline]
     /// Write the value of one or more fields, leaving the other fields unchanged
     pub fn modify(&self, field: FieldValue<T, R>) {
-        let reg: T = self.get();
-        self.set((reg & !field.mask) | field.value);
+        self.set(field.modify(self.get()));
     }
 
     #[inline]
     /// Write the value of one or more fields, maintaining the value of unchanged fields via a
     /// provided original value, rather than a register read.
     pub fn modify_no_read(&self, original: LocalRegisterCopy<T, R>, field: FieldValue<T, R>) {
-        self.set((original.get() & !field.mask) | field.value);
+        self.set(field.modify(original.get()));
     }
 
     #[inline]
     /// Check if one or more bits in a field are set
     pub fn is_set(&self, field: Field<T, R>) -> bool {
-        self.read(field) != T::zero()
+        field.is_set(self.get())
     }
 
     #[inline]
     /// Check if any specified parts of a field match
     pub fn matches_any(&self, field: FieldValue<T, R>) -> bool {
-        self.get() & field.mask != T::zero()
+        field.matches_any(self.get())
     }
 
     #[inline]
     /// Check if all specified parts of a field match
     pub fn matches_all(&self, field: FieldValue<T, R>) -> bool {
-        self.get() & field.mask == field.value
+        field.matches_all(self.get())
     }
 }
 
@@ -234,15 +231,13 @@ impl<T: IntLike, R: RegisterLongName> ReadOnly<T, R> {
     #[inline]
     /// Read the value of the given field
     pub fn read(&self, field: Field<T, R>) -> T {
-        (self.get() & (field.mask << field.shift)) >> field.shift
+        field.read(self.get())
     }
 
     #[inline]
     /// Read value of the given field as an enum member
     pub fn read_as_enum<E: TryFromValue<T, EnumType = E>>(&self, field: Field<T, R>) -> Option<E> {
-        let val: T = self.read(field);
-
-        E::try_from(val)
+        field.read_as_enum(self.get())
     }
 
     #[inline]
@@ -254,19 +249,19 @@ impl<T: IntLike, R: RegisterLongName> ReadOnly<T, R> {
     #[inline]
     /// Check if one or more bits in a field are set
     pub fn is_set(&self, field: Field<T, R>) -> bool {
-        self.read(field) != T::zero()
+        field.is_set(self.get())
     }
 
     #[inline]
     /// Check if any specified parts of a field match
     pub fn matches_any(&self, field: FieldValue<T, R>) -> bool {
-        self.get() & field.mask != T::zero()
+        field.matches_any(self.get())
     }
 
     #[inline]
     /// Check if all specified parts of a field match
     pub fn matches_all(&self, field: FieldValue<T, R>) -> bool {
-        self.get() & field.mask == field.value
+        field.matches_all(self.get())
     }
 }
 
@@ -300,15 +295,13 @@ impl<T: IntLike, R: RegisterLongName, W: RegisterLongName> Aliased<T, R, W> {
     #[inline]
     /// Read the value of the given field
     pub fn read(&self, field: Field<T, R>) -> T {
-        (self.get() & (field.mask << field.shift)) >> field.shift
+        field.read(self.get())
     }
 
     #[inline]
     /// Read value of the given field as an enum member
     pub fn read_as_enum<E: TryFromValue<T, EnumType = E>>(&self, field: Field<T, R>) -> Option<E> {
-        let val: T = self.read(field);
-
-        E::try_from(val)
+        field.read_as_enum(self.get())
     }
 
     #[inline]
@@ -326,19 +319,19 @@ impl<T: IntLike, R: RegisterLongName, W: RegisterLongName> Aliased<T, R, W> {
     #[inline]
     /// Check if one or more bits in a field are set
     pub fn is_set(&self, field: Field<T, R>) -> bool {
-        self.read(field) != T::zero()
+        field.is_set(self.get())
     }
 
     #[inline]
     /// Check if any specified parts of a field match
     pub fn matches_any(&self, field: FieldValue<T, R>) -> bool {
-        self.get() & field.mask != T::zero()
+        field.matches_any(self.get())
     }
 
     #[inline]
     /// Check if all specified parts of a field match
     pub fn matches_all(&self, field: FieldValue<T, R>) -> bool {
-        self.get() & field.mask == field.value
+        field.matches_all(self.get())
     }
 }
 
@@ -372,29 +365,27 @@ impl<T: IntLike, R: RegisterLongName> LocalRegisterCopy<T, R> {
 
     #[inline]
     pub fn read(&self, field: Field<T, R>) -> T {
-        (self.value & (field.mask << field.shift)) >> field.shift
+        field.read(self.get())
     }
 
     #[inline]
     pub fn read_as_enum<E: TryFromValue<T, EnumType = E>>(&self, field: Field<T, R>) -> Option<E> {
-        let val: T = self.read(field);
-
-        E::try_from(val)
+        field.read_as_enum(self.get())
     }
 
     #[inline]
     pub fn is_set(&self, field: Field<T, R>) -> bool {
-        self.read(field) != T::zero()
+        field.is_set(self.get())
     }
 
     #[inline]
     pub fn matches_any(&self, field: FieldValue<T, R>) -> bool {
-        self.value & field.mask != T::zero()
+        field.matches_any(self.get())
     }
 
     #[inline]
     pub fn matches_all(&self, field: FieldValue<T, R>) -> bool {
-        self.value & field.mask == field.value
+        field.matches_all(self.get())
     }
 
     /// Do a bitwise AND operation of the stored value and the passed in value
@@ -465,14 +456,12 @@ impl<T: IntLike, R: RegisterLongName> InMemoryRegister<T, R> {
 
     #[inline]
     pub fn read(&self, field: Field<T, R>) -> T {
-        (self.get() & (field.mask << field.shift)) >> field.shift
+        field.read(self.get())
     }
 
     #[inline]
     pub fn read_as_enum<E: TryFromValue<T, EnumType = E>>(&self, field: Field<T, R>) -> Option<E> {
-        let val: T = self.read(field);
-
-        E::try_from(val)
+        field.read_as_enum(self.get())
     }
 
     #[inline]
@@ -487,28 +476,27 @@ impl<T: IntLike, R: RegisterLongName> InMemoryRegister<T, R> {
 
     #[inline]
     pub fn modify(&self, field: FieldValue<T, R>) {
-        let reg: T = self.get();
-        self.set((reg & !field.mask) | field.value);
+        self.set(field.modify(self.get()));
     }
 
     #[inline]
     pub fn modify_no_read(&self, original: LocalRegisterCopy<T, R>, field: FieldValue<T, R>) {
-        self.set((original.get() & !field.mask) | field.value);
+        self.set(field.modify(original.get()));
     }
 
     #[inline]
     pub fn is_set(&self, field: Field<T, R>) -> bool {
-        self.read(field) != T::zero()
+        field.is_set(self.get())
     }
 
     #[inline]
     pub fn matches_any(&self, field: FieldValue<T, R>) -> bool {
-        self.get() & field.mask != T::zero()
+        field.matches_any(self.get())
     }
 
     #[inline]
     pub fn matches_all(&self, field: FieldValue<T, R>) -> bool {
-        self.get() & field.mask == field.value
+        field.matches_all(self.get())
     }
 }
 
@@ -518,6 +506,25 @@ pub struct Field<T: IntLike, R: RegisterLongName> {
     pub mask: T,
     pub shift: usize,
     associated_register: PhantomData<R>,
+}
+
+impl<T: IntLike, R: RegisterLongName> Field<T, R> {
+    #[inline]
+    pub fn read(self, val: T) -> T {
+        (val & (self.mask << self.shift)) >> self.shift
+    }
+
+    #[inline]
+    /// Check if one or more bits in a field are set
+    pub fn is_set(self, val: T) -> bool {
+        val & (self.mask << self.shift) != T::zero()
+    }
+
+    #[inline]
+    /// Read value of the field as an enum member
+    pub fn read_as_enum<E: TryFromValue<T, EnumType = E>>(self, val: T) -> Option<E> {
+        E::try_from(self.read(val))
+    }
 }
 
 // For the Field, the mask is unshifted, ie. the LSB should always be set
@@ -587,25 +594,16 @@ pub struct FieldValue<T: IntLike, R: RegisterLongName> {
     associated_register: PhantomData<R>,
 }
 
-// Necessary to split the implementation of u8 and u32 out because the bitwise
+// Necessary to split the implementation of new() out because the bitwise
 // math isn't treated as const when the type is generic.
+// Tracking issue: https://github.com/rust-lang/rfcs/pull/2632
 impl<R: RegisterLongName> FieldValue<u8, R> {
     pub const fn new(mask: u8, shift: usize, value: u8) -> Self {
         FieldValue {
             mask: mask << shift,
-            value: (value << shift) & (mask << shift),
+            value: (value & mask) << shift,
             associated_register: PhantomData,
         }
-    }
-
-    /// Get the raw bitmask represented by this FieldValue.
-    pub fn mask(self) -> u8 {
-        self.mask as u8
-    }
-
-    #[inline]
-    pub fn read(&self, field: Field<u8, R>) -> u8 {
-        (self.value & (field.mask << field.shift)) >> field.shift
     }
 }
 
@@ -619,19 +617,9 @@ impl<R: RegisterLongName> FieldValue<u16, R> {
     pub const fn new(mask: u16, shift: usize, value: u16) -> Self {
         FieldValue {
             mask: mask << shift,
-            value: (value << shift) & (mask << shift),
+            value: (value & mask) << shift,
             associated_register: PhantomData,
         }
-    }
-
-    /// Get the raw bitmask represented by this FieldValue.
-    pub fn mask(self) -> u16 {
-        self.mask as u16
-    }
-
-    #[inline]
-    pub fn read(&self, field: Field<u16, R>) -> u16 {
-        (self.value & (field.mask << field.shift)) >> field.shift
     }
 }
 
@@ -645,19 +633,9 @@ impl<R: RegisterLongName> FieldValue<u32, R> {
     pub const fn new(mask: u32, shift: usize, value: u32) -> Self {
         FieldValue {
             mask: mask << shift,
-            value: (value << shift) & (mask << shift),
+            value: (value & mask) << shift,
             associated_register: PhantomData,
         }
-    }
-
-    /// Get the raw bitmask represented by this FieldValue.
-    pub fn mask(self) -> u32 {
-        self.mask as u32
-    }
-
-    #[inline]
-    pub fn read(&self, field: Field<u32, R>) -> u32 {
-        (self.value & (field.mask << field.shift)) >> field.shift
     }
 }
 
@@ -671,19 +649,9 @@ impl<R: RegisterLongName> FieldValue<u64, R> {
     pub const fn new(mask: u64, shift: usize, value: u64) -> Self {
         FieldValue {
             mask: mask << shift,
-            value: (value << shift) & (mask << shift),
+            value: (value & mask) << shift,
             associated_register: PhantomData,
         }
-    }
-
-    /// Get the raw bitmask represented by this FieldValue.
-    pub fn mask(self) -> u64 {
-        self.mask as u64
-    }
-
-    #[inline]
-    pub fn read(&self, field: Field<u64, R>) -> u64 {
-        (self.value & (field.mask << field.shift)) >> field.shift
     }
 }
 
@@ -694,9 +662,29 @@ impl<R: RegisterLongName> From<FieldValue<u64, R>> for u64 {
 }
 
 impl<T: IntLike, R: RegisterLongName> FieldValue<T, R> {
-    // Modify fields in a register value
+    /// Get the raw bitmask represented by this FieldValue.
+    pub fn mask(self) -> T {
+        self.mask as T
+    }
+
+    #[inline]
+    pub fn read(&self, field: Field<T, R>) -> T {
+        field.read(self.value)
+    }
+
+    /// Modify fields in a register value
     pub fn modify(self, val: T) -> T {
         (val & !self.mask) | self.value
+    }
+
+    /// Check if any specified parts of a field match
+    pub fn matches_any(self, val: T) -> bool {
+        val & self.mask != T::zero()
+    }
+
+    /// Check if all specified parts of a field match
+    pub fn matches_all(self, val: T) -> bool {
+        val & self.mask == self.value
     }
 }
 
@@ -715,10 +703,270 @@ impl<T: IntLike, R: RegisterLongName> Add for FieldValue<T, R> {
 // Combine two fields with the += operator
 impl<T: IntLike, R: RegisterLongName> AddAssign for FieldValue<T, R> {
     fn add_assign(&mut self, rhs: FieldValue<T, R>) {
-        *self = FieldValue {
-            mask: self.mask | rhs.mask,
-            value: self.value | rhs.value,
-            associated_register: PhantomData,
-        };
+        self.mask |= rhs.mask;
+        self.value |= rhs.value;
     }
+}
+
+#[cfg(not(feature = "no_std_unit_tests"))]
+#[cfg(test)]
+mod tests {
+    #[derive(Debug, PartialEq, Eq)]
+    enum Foo {
+        Foo0,
+        Foo1,
+        Foo2,
+        Foo3,
+        Foo4,
+        Foo5,
+        Foo6,
+        Foo7,
+    }
+
+    impl super::TryFromValue<u16> for Foo {
+        type EnumType = Foo;
+
+        fn try_from(v: u16) -> Option<Self::EnumType> {
+            Self::try_from(v as u32)
+        }
+    }
+    impl super::TryFromValue<u32> for Foo {
+        type EnumType = Foo;
+
+        fn try_from(v: u32) -> Option<Self::EnumType> {
+            match v {
+                0 => Some(Foo::Foo0),
+                1 => Some(Foo::Foo1),
+                2 => Some(Foo::Foo2),
+                3 => Some(Foo::Foo3),
+                4 => Some(Foo::Foo4),
+                5 => Some(Foo::Foo5),
+                6 => Some(Foo::Foo6),
+                7 => Some(Foo::Foo7),
+                _ => None,
+            }
+        }
+    }
+
+    mod field {
+        use super::super::{Field, TryFromValue};
+        use super::Foo;
+
+        #[test]
+        fn test_new() {
+            let field8 = Field::<u8, ()>::new(0x12, 3);
+            assert_eq!(field8.mask, 0x12_u8);
+            assert_eq!(field8.shift, 3);
+            let field16 = Field::<u16, ()>::new(0x1234, 5);
+            assert_eq!(field16.mask, 0x1234_u16);
+            assert_eq!(field16.shift, 5);
+            let field32 = Field::<u32, ()>::new(0x12345678, 9);
+            assert_eq!(field32.mask, 0x12345678_u32);
+            assert_eq!(field32.shift, 9);
+            let field64 = Field::<u64, ()>::new(0x12345678_9abcdef0, 1);
+            assert_eq!(field64.mask, 0x12345678_9abcdef0_u64);
+            assert_eq!(field64.shift, 1);
+        }
+
+        #[test]
+        fn test_read() {
+            let field = Field::<u32, ()>::new(0xFF, 4);
+            assert_eq!(field.read(0x123), 0x12);
+            let field = Field::<u32, ()>::new(0xF0F, 4);
+            assert_eq!(field.read(0x1234), 0x103);
+        }
+
+        #[test]
+        fn test_is_set() {
+            let field = Field::<u16, ()>::new(0xFF, 4);
+            assert_eq!(field.is_set(0), false);
+            assert_eq!(field.is_set(0xFFFF), true);
+            assert_eq!(field.is_set(0x0FF0), true);
+            assert_eq!(field.is_set(0x1000), false);
+            assert_eq!(field.is_set(0x0100), true);
+            assert_eq!(field.is_set(0x0010), true);
+            assert_eq!(field.is_set(0x0001), false);
+
+            for shift in 0..24 {
+                let field = Field::<u32, ()>::new(0xFF, shift);
+                for x in 1..=0xFF {
+                    assert_eq!(field.is_set(x << shift), true);
+                }
+                assert_eq!(field.is_set(!(0xFF << shift)), false);
+            }
+        }
+
+        #[test]
+        fn test_read_as_enum() {
+            let field = Field::<u16, ()>::new(0x7, 4);
+            assert_eq!(field.read_as_enum(0x1234), Some(Foo::Foo3));
+            assert_eq!(field.read_as_enum(0x5678), Some(Foo::Foo7));
+            assert_eq!(field.read_as_enum(0xFFFF), Some(Foo::Foo7));
+            assert_eq!(field.read_as_enum(0x0000), Some(Foo::Foo0));
+            assert_eq!(field.read_as_enum(0x0010), Some(Foo::Foo1));
+            assert_eq!(field.read_as_enum(0x1204), Some(Foo::Foo0));
+
+            for shift in 0..29 {
+                let field = Field::<u32, ()>::new(0x7, shift);
+                for x in 0..8 {
+                    assert_eq!(field.read_as_enum(x << shift), Foo::try_from(x));
+                }
+            }
+        }
+    }
+
+    mod field_value {
+        use super::super::Field;
+
+        #[test]
+        fn test_from() {
+            let field = Field::<u32, ()>::new(0xFF, 4);
+            assert_eq!(u32::from(field.val(0)), 0);
+            assert_eq!(u32::from(field.val(0xFFFFFFFF)), 0xFF0);
+            assert_eq!(u32::from(field.val(0x12)), 0x120);
+            assert_eq!(u32::from(field.val(0x123)), 0x230);
+
+            for shift in 0..32 {
+                let field = Field::<u32, ()>::new(0xFF, shift);
+                for x in 0..=0xFF {
+                    assert_eq!(u32::from(field.val(x)), x << shift);
+                }
+            }
+        }
+
+        #[test]
+        fn test_read_same_field() {
+            let field = Field::<u32, ()>::new(0xFF, 4);
+            assert_eq!(field.val(0).read(field), 0);
+            assert_eq!(field.val(0xFFFFFFFF).read(field), 0xFF);
+            assert_eq!(field.val(0x12).read(field), 0x12);
+            assert_eq!(field.val(0x123).read(field), 0x23);
+
+            for shift in 0..24 {
+                let field = Field::<u32, ()>::new(0xFF, shift);
+                for x in 0..=0xFF {
+                    assert_eq!(field.val(x).read(field), x);
+                }
+            }
+        }
+
+        #[test]
+        fn test_read_disjoint_fields() {
+            for shift in 0..24 {
+                let field1 = Field::<u32, ()>::new(0xF0, shift);
+                let field2 = Field::<u32, ()>::new(0x0F, shift);
+                for x in 0..=0xFF {
+                    assert_eq!(field1.val(x).read(field2), 0);
+                    assert_eq!(field2.val(x).read(field1), 0);
+                }
+            }
+            for shift in 0..24 {
+                let field1 = Field::<u32, ()>::new(0xF, shift);
+                let field2 = Field::<u32, ()>::new(0xF, shift + 4);
+                for x in 0..=0xFF {
+                    assert_eq!(field1.val(x).read(field2), 0);
+                    assert_eq!(field2.val(x).read(field1), 0);
+                }
+            }
+        }
+
+        #[test]
+        fn test_modify() {
+            let field = Field::<u32, ()>::new(0xFF, 4);
+            assert_eq!(field.val(0x23).modify(0x0000), 0x0230);
+            assert_eq!(field.val(0x23).modify(0xFFFF), 0xF23F);
+            assert_eq!(field.val(0x23).modify(0x1234), 0x1234);
+            assert_eq!(field.val(0x23).modify(0x5678), 0x5238);
+        }
+
+        #[test]
+        fn test_matches_any() {
+            let field = Field::<u32, ()>::new(0xFF, 4);
+            assert_eq!(field.val(0x23).matches_any(0x1234), true);
+            assert_eq!(field.val(0x23).matches_any(0x5678), true);
+            assert_eq!(field.val(0x23).matches_any(0x5008), false);
+
+            for shift in 0..24 {
+                let field = Field::<u32, ()>::new(0xFF, shift);
+                for x in 0..=0xFF {
+                    let field_value = field.val(x);
+                    for y in 1..=0xFF {
+                        assert_eq!(field_value.matches_any(y << shift), true);
+                    }
+                    assert_eq!(field_value.matches_any(0), false);
+                    assert_eq!(field_value.matches_any(!(0xFF << shift)), false);
+                }
+            }
+        }
+
+        #[test]
+        fn test_matches_all() {
+            let field = Field::<u32, ()>::new(0xFF, 4);
+            assert_eq!(field.val(0x23).matches_all(0x1234), true);
+            assert_eq!(field.val(0x23).matches_all(0x5678), false);
+
+            for shift in 0..24 {
+                let field = Field::<u32, ()>::new(0xFF, shift);
+                for x in 0..=0xFF {
+                    assert_eq!(field.val(x).matches_all(x << shift), true);
+                    assert_eq!(field.val(x + 1).matches_all(x << shift), false);
+                }
+            }
+        }
+
+        #[test]
+        fn test_add_disjoint_fields() {
+            let field1 = Field::<u32, ()>::new(0xFF, 24);
+            let field2 = Field::<u32, ()>::new(0xFF, 16);
+            let field3 = Field::<u32, ()>::new(0xFF, 8);
+            let field4 = Field::<u32, ()>::new(0xFF, 0);
+            assert_eq!(
+                u32::from(
+                    field1.val(0x12) + field2.val(0x34) + field3.val(0x56) + field4.val(0x78)
+                ),
+                0x12345678
+            );
+
+            for shift in 0..24 {
+                let field1 = Field::<u32, ()>::new(0xF, shift);
+                let field2 = Field::<u32, ()>::new(0xF, shift + 4);
+                for x in 0..=0xF {
+                    for y in 0..=0xF {
+                        assert_eq!(
+                            u32::from(field1.val(x) + field2.val(y)),
+                            (x | (y << 4)) << shift
+                        );
+                    }
+                }
+            }
+        }
+
+        #[test]
+        fn test_add_assign_disjoint_fields() {
+            let field1 = Field::<u32, ()>::new(0xFF, 24);
+            let field2 = Field::<u32, ()>::new(0xFF, 16);
+            let field3 = Field::<u32, ()>::new(0xFF, 8);
+            let field4 = Field::<u32, ()>::new(0xFF, 0);
+
+            let mut value = field1.val(0x12);
+            value += field2.val(0x34);
+            value += field3.val(0x56);
+            value += field4.val(0x78);
+            assert_eq!(u32::from(value), 0x12345678);
+
+            for shift in 0..24 {
+                let field1 = Field::<u32, ()>::new(0xF, shift);
+                let field2 = Field::<u32, ()>::new(0xF, shift + 4);
+                for x in 0..=0xF {
+                    for y in 0..=0xF {
+                        let mut value = field1.val(x);
+                        value += field2.val(y);
+                        assert_eq!(u32::from(value), (x | (y << 4)) << shift);
+                    }
+                }
+            }
+        }
+    }
+
+    // TODO: More unit tests here.
 }


### PR DESCRIPTION
### Pull Request Overview

While reviewing https://github.com/tock/tock/pull/1661#discussion_r388306189, it came up that there is some amount of code duplication in the arithmetic operations on various register types.

This pull request unifies the implementation, by adding new functions to the `Field` and `FieldValue` types, and making the other types use these. Unit tests are also added for these unified functions.

Some formulas are also simplified:
- `(value << shift) & (mask << shift)` => `(value & mask) << shift`
- `(val & (field.mask << field.shift)) >> field.shift != T::zero()` => `val & (field.mask << field.shift) != T::zero()`


### Testing Strategy

This pull request was tested by Travis-CI.


### TODO or Help Wanted

- `matches_any(&self, field: FieldValue<T, R>) -> bool` doesn't makes a lot of sense to me, because it doesn't use any "value" of the field. It could be `matches_any(&self, field: Field<T, R>) -> bool` instead. But then it's the same as the existing `is_set(&self, field: Field<T, R>) -> bool`. Should `matches_any` be removed? Tock doesn't use a lot of `matches_any`.
- `ReadWrite` and `InMemoryRegister` have the same implementation. Is that intended? I wonder why volatile read/write are needed for `InMemoryRegister` - given that such "register" is not MMIO. Tock doesn't use a lot of `InMemoryRegister`.
- This pull request could be extended by defining new traits to further remove code duplication. However, this would mean more refactoring to expose these traits, and a breaking change for the published crate (https://crates.io/crates/tock-registers).
  Here is a draft of that:

```rust
trait ReadAble<T: IntLike, R: RegisterLongName> {
    /// Get the raw register value
    fn get(&self) -> T;

    /// Read the value of the given field
    fn read(&self, field: Field<T, R>) -> T {
        field.read(self.get())
    }

    /// Read value of the given field as an enum member
    fn read_as_enum<E: TryFromValue<T, EnumType = E>>(&self, field: Field<T, R>) -> Option<E> {
        field.read_as_enum(self.get())
    }

    ...
}

trait WriteAble<T: IntLike, R: RegisterLongName> {
    /// Set the raw register value
    fn set(&self, value: T);

    /// Write the value of one or more fields, overwriting the other fields with zero
    fn write(&self, field: FieldValue<T, R>) {
        self.set(field.value);
    }
}

trait ReadWriteAble<T: IntLike, R: RegisterLongName>: ReadAble<T, R> + WriteAble<T, R> {
    /// Write the value of one or more fields, maintaining the value of unchanged fields via a
    /// provided original value, rather than a register read.
    fn modify_no_read(&self, original: LocalRegisterCopy<T, R>, field: FieldValue<T, R>) {
        self.set(field.modify(original.get()));
    }

    ...
}

// ==========
// ReadWrite

impl<T: IntLike, R: RegisterLongName> ReadAble<T, R> for ReadWrite<T, R> {
    fn get(&self) -> T {
        unsafe { ::core::ptr::read_volatile(&self.value) }
    }
}

impl<T: IntLike, R: RegisterLongName> WriteAble<T, R> for ReadWrite<T, R> {
    fn set(&self, value: T) {
        unsafe { ::core::ptr::write_volatile(&self.value as *const T as *mut T, value) }
    }
}

impl<T: IntLike, R: RegisterLongName> ReadWriteAble<T, R> for ReadWrite<T, R> {}

// ==========
// ReadOnly

impl<T: IntLike, R: RegisterLongName> ReadAble<T, T> for ReadOnly<T, R> {
    fn get(&self) -> T {
        unsafe { ::core::ptr::read_volatile(&self.value) }
    }
}

// ==========
// WriteOnly

impl<T: IntLike, R: RegisterLongName> WriteAble<T, R> for WriteOnly<T, R> {
    fn set(&self, value: T) {
        unsafe { ::core::ptr::write_volatile(&self.value as *const T as *mut T, value) }
    }
}
```


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.