### PR TITLE
propagate additional process loading errors to main.rs

### DIFF
--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -31,6 +31,11 @@ pub enum ProcessLoadError {
     /// Not enough flash remaining to parse an app and its header.
     NotEnoughFlash,
 
+    /// Not enough memory to meet the amount requested by an app.
+    /// Modify your app to request less memory or flash fewer apps or
+    /// increase the size of the region your board reserves for app memory.
+    NotEnoughMemory,
+
     /// Process loading error due (likely) to a bug in the kernel. If you get
     /// this error please open a bug report.
     InternalError,
@@ -56,6 +61,10 @@ impl fmt::Debug for ProcessLoadError {
 
             ProcessLoadError::NotEnoughFlash => {
                 write!(f, "Not enough flash available for app linked list")
+            }
+
+            ProcessLoadError::NotEnoughMemory => {
+                write!(f, "Not able to meet memory requirements requested by apps")
             }
 
             ProcessLoadError::InternalError => write!(f, "Error in kernel. Likely a bug."),
@@ -1595,13 +1604,13 @@ impl<C: 'static + Chip> Process<'a, C> {
         {
             if config::CONFIG.debug_load_processes {
                 debug!(
-                    "[!] flash=[{:#010X}:{:#010X}] process={:?} - couldn't allocate flash region",
+                    "[!] flash=[{:#010X}:{:#010X}] process={:?} - couldn't allocate MPU region for flash",
                     app_flash.as_ptr() as usize,
                     app_flash.as_ptr() as usize + app_flash.len(),
                     process_name
                 );
             }
-            return Ok((None, 0));
+            return Err(ProcessLoadError::InternalError);
         }
 
         // Determine how much space we need in the application's
@@ -1656,7 +1665,7 @@ impl<C: 'static + Chip> Process<'a, C> {
                         min_total_memory_size
                     );
                 }
-                return Ok((None, 0));
+                return Err(ProcessLoadError::NotEnoughMemory);
             }
         };
 
@@ -1793,7 +1802,7 @@ impl<C: 'static + Chip> Process<'a, C> {
                         process_name
                     );
                 }
-                return Ok((None, 0));
+                return Err(ProcessLoadError::InternalError);
             }
         };
 

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -36,6 +36,11 @@ pub enum ProcessLoadError {
     /// increase the size of the region your board reserves for app memory.
     NotEnoughMemory,
 
+    /// An app was loaded with a length in flash that the MPU does not support.
+    /// The fix is probably to correct the app size, but this could also be caused
+    /// by a bad MPU implementation.
+    MpuInvalidFlashLength,
+
     /// Process loading error due (likely) to a bug in the kernel. If you get
     /// this error please open a bug report.
     InternalError,
@@ -65,6 +70,10 @@ impl fmt::Debug for ProcessLoadError {
 
             ProcessLoadError::NotEnoughMemory => {
                 write!(f, "Not able to meet memory requirements requested by apps")
+            }
+
+            ProcessLoadError::MpuInvalidFlashLength => {
+                write!(f, "App flash length not supported by MPU")
             }
 
             ProcessLoadError::InternalError => write!(f, "Error in kernel. Likely a bug."),
@@ -1610,7 +1619,7 @@ impl<C: 'static + Chip> Process<'a, C> {
                     process_name
                 );
             }
-            return Err(ProcessLoadError::InternalError);
+            return Err(ProcessLoadError::MpuInvalidFlashLength);
         }
 
         // Determine how much space we need in the application's


### PR DESCRIPTION
### Pull Request Overview

This pull request modifies `process::create()` to return an error in 3 cases where previously it just returned an empty process slot -- if there is an error initializing the process, if there is an error allocating the MPU region for that process's flash, or if there is not enough memory to meet the amount requested by that process (or the minimum amount currently required by the kernel).

It adds one new `ProcessLoadError` variant: `ProcessLoadError::NotEnoughMemory`. Failures with allocating an MPU region or initializing a process are treated as `InternalError`'s. 

This PR fixes #1764 by making it so that failing to load a valid process is no longer a silent failure if the board chooses to handle the error.


### Testing Strategy

This pull request was tested by flashing 4 apps, each requesting 8kB of RAM, and observing they work as expected, then flashing 5 apps, each requesting 8kB of RAM, and observing that `load_processes()` fails, causing a debug message to be printed to the screen.


### TODO or Help Wanted

This modifies the existing behavior of `load_processes()` so that it returns as soon as any process fails to load, whereas currently it will continue trying to load processes even if one fails for one of the above 3 reasons. I think this behavior is better, especially given that boards can redefine `load_processes` if they want to, but am open to pushback on this.


### Documentation Updated

- [x] No updates are required.

### Formatting

- [x] Ran `make formatall`.
