### PR TITLE
refactor buffer copy logic to reduce flash memory usage

### DIFF
--- a/capsules/src/process_console.rs
+++ b/capsules/src/process_console.rs
@@ -311,9 +311,8 @@ impl<'a, C: ProcessManagementCapability> ProcessConsole<'a, C> {
             self.tx_in_progress.set(true);
             self.tx_buffer.take().map(|buffer| {
                 let len = cmp::min(bytes.len(), buffer.len());
-                for i in 0..len {
-                    buffer[i] = bytes[i];
-                }
+                // Copy elements of `bytes` into `buffer`
+                (&mut buffer[..len]).copy_from_slice(&bytes[..len]);
                 self.uart.transmit_buffer(buffer, len);
             });
             ReturnCode::SUCCESS


### PR DESCRIPTION
### Pull Request Overview

Refactored buffer copy logic in `capsules/src/process_console.rs` to reduce flash memory usage.


### Testing Strategy

Used `tools/print_tock_memory_usage.py` to compare memory usage before/after the change.

1. Summary of changes in memory usage
Changes made in this PR results in memory usage reduction of..
    * Kernel (flash) : 80 bytes of memory usage
    * Function groups (flash): 48 bytes of memory usage

2. Memory usage before change
```
lonelyjoe@lonelyjoe-desktop:~/workspace/tock/boards/hail$ ../../tools/print_tock_memory_usage.py ../../target/thumbv7em-none-eabi/release/hail.elf
Tock memory usage report for ../../target/thumbv7em-none-eabi/release/hail.elf
Kernel occupies 105368 bytes of flash
  102172        code and constant strings
    3196        variable initializers
Kernel occupies 65532 bytes of RAM
    4096        stack
   58240        uninitialized variables
    3196        initialized variables
   61436        variables total
Applications allocated 49152 bytes of RAM

Variable groups (RAM): 56009 bytes
  capsules::*   2206 bytes
  components::* 17 bytes
  hail::*       50161 bytes
  kernel::*     12 bytes
  sam4l::*      3613 bytes

Embedded data (flash): 15981 bytes

Function groups (flash): 74898 bytes
  capsules::*   29296 bytes
  core::*       14602 bytes
  cortexm4::*   1972 bytes
  cortexm::*    1488 bytes
  hail::*       128 bytes
  kernel::*     18894 bytes
  sam4l::*      8468 bytes
  tock_cells::* 50 bytes
```

3. Memory usage after change
```
AFTER

lonelyjoe@lonelyjoe-desktop:~/workspace/tock/boards/hail$ ../../tools/print_tock_memory_usage.py ../../target/thumbv7em-none-eabi/release/hail.elf
Tock memory usage report for ../../target/thumbv7em-none-eabi/release/hail.elf
Kernel occupies 105288 bytes of flash
  102092        code and constant strings
    3196        variable initializers
Kernel occupies 65532 bytes of RAM
    4096        stack
   58240        uninitialized variables
    3196        initialized variables
   61436        variables total
Applications allocated 49152 bytes of RAM

Variable groups (RAM): 56009 bytes
  capsules::*   2206 bytes
  components::* 17 bytes
  hail::*       50161 bytes
  kernel::*     12 bytes
  sam4l::*      3613 bytes

Embedded data (flash): 15981 bytes

Function groups (flash): 74850 bytes
  capsules::*   29248 bytes
  core::*       14602 bytes
  cortexm4::*   1972 bytes
  cortexm::*    1488 bytes
  hail::*       128 bytes
  kernel::*     18894 bytes
  sam4l::*      8468 bytes
  tock_cells::* 50 bytes
```

### TODO or Help Wanted

I haven't performed performance comparisons before/after the change. 
Is there a canonical way to do this in Tock?

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
