### PR TITLE
rv32i,ibex: use ',' as sections specifier

### DIFF
--- a/arch/rv32i/src/lib.rs
+++ b/arch/rv32i/src/lib.rs
@@ -150,7 +150,7 @@ pub extern "C" fn _start_trap() {
 /// save the application state and then resume the `switch_to()` function to
 /// correctly return back to the kernel.
 #[cfg(all(target_arch = "riscv32", target_os = "none"))]
-#[link_section = ".riscv.trap"]
+#[link_section = ".riscv,trap"]
 #[export_name = "_start_trap"]
 #[naked]
 pub extern "C" fn _start_trap() {

--- a/boards/kernel_layout.ld
+++ b/boards/kernel_layout.ld
@@ -88,15 +88,15 @@ SECTIONS
          */
         KEEP(*(.riscv.start));
         /* For RISC-V we need the `_start_trap` function to be 256 byte aligned,
-         * and that function is at the start of the .riscv.trap section. If that
+         * and that function is at the start of the .riscv,trap section. If that
          * function does not exist (as for non-RISC-V platforms) then we do not
          * need any unusual alignment.
          * The allignment is implementation specific, so we currently use 256 to
          * work with the lowRISC CPUs.
          */
         . = DEFINED(_start_trap) ? ALIGN(256) : ALIGN(1);
-        KEEP(*(.riscv.trap_vectored));
-        KEEP(*(.riscv.trap));
+        KEEP(*(.riscv,trap_vectored));
+        KEEP(*(.riscv,trap));
 
         /* .text and .rodata hold most program code and immutable constants */
         /* .gnu.linkonce hold C++ elements with vague linkage

--- a/chips/ibex/src/chip.rs
+++ b/chips/ibex/src/chip.rs
@@ -210,7 +210,7 @@ pub unsafe fn configure_trap_handler() {
         .write(mtvec::trap_addr.val(_start_trap_vectored as u32 >> 2) + mtvec::mode::Vectored)
 }
 
-#[link_section = ".riscv.trap_vectored"]
+#[link_section = ".riscv,trap_vectored"]
 #[export_name = "_start_trap_vectored"]
 #[naked]
 pub extern "C" fn _start_trap_vectored() -> ! {


### PR DESCRIPTION
In order to build tests, we have to specify sections that are permissible
to both ELF and Mach-o. ELF doesn't really care what you call things, but
Mach-O is pickier, so we'll just follow the Mach-o convention everywhere.

### Pull Request Overview

This cherry-picks the second commit from #1625, deferring the travis question, but fixing the test infrastructure for 1.5.

### Testing Strategy

Running `make ci` on a mac.

### TODO or Help Wanted

Validation from RiscV folk

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
