### PR TITLE
capsules: process console: add fault to help msg

### DIFF
--- a/capsules/src/process_console.rs
+++ b/capsules/src/process_console.rs
@@ -197,7 +197,7 @@ impl<'a, C: ProcessManagementCapability> ProcessConsole<'a, C> {
                         let clean_str = s.trim();
                         if clean_str.starts_with("help") {
                             debug!("Welcome to the process console.");
-                            debug!("Valid commands are: help status list stop start");
+                            debug!("Valid commands are: help status list stop start fault");
                         } else if clean_str.starts_with("start") {
                             let argument = clean_str.split_whitespace().nth(1);
                             argument.map(|name| {


### PR DESCRIPTION
### Pull Request Overview

This adds "fault" to the process console help string. I missed this when I added the fault command.

For 1.5.


### Testing Strategy

This pull request was tested by using the process console on hail.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
