### PR TITLE
doc: use copy-on-write for docs

### DIFF
--- a/tools/build-all-docs.sh
+++ b/tools/build-all-docs.sh
@@ -7,9 +7,23 @@ set -e
 # Delete any old docs
 rm -rf doc/rustdoc
 
+# Use copy-on-write cp if available
+touch _COW
+if `cp -c _COW _COW2 2> /dev/null`; then
+    # BSD (OS X) default
+    CP_COW="cp -c"
+elif `cp --reflink=auto _COW _COW2 2> /dev/null`; then
+    # Coreutils (unix) default
+    CP_COW="cp --reflink=auto"
+else
+    echo "$(tput bold)Warn: No copy-on-write cp available. Doc build will be slower.$(tput sgr0)"
+    CP_COW="cp"
+fi
+rm -f _COW _COW2
+
 # Make the documentation for all the boards and move it to doc/rustdoc.
 make alldoc
-cp -r target/doc doc/rustdoc
+$CP_COW -r target/doc doc/rustdoc
 
 # Temporary redirect rule
 # https://www.netlify.com/docs/redirects/


### PR DESCRIPTION
### Pull Request Overview

This resurrects the changes from #1726.

On my laptop it saves all of ~6s from the build and de-duplicates ~70MB of files, but hey, that's all free time and space at this point.

### Testing Strategy

Building documentation.

### TODO or Help Wanted

N/A

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
