### PR TITLE
boards: hail: fix gpio pin assignments

### DIFF
--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -354,10 +354,10 @@ pub unsafe fn reset_handler() {
     // set GPIO driver controlling remaining GPIO pins
     let gpio = components::gpio::GpioComponent::new(board_kernel).finalize(
         components::gpio_component_helper!(
-            &sam4l::gpio::PC[14], // DO
-            &sam4l::gpio::PC[15], // D1
-            &sam4l::gpio::PC[11], // D6
-            &sam4l::gpio::PC[12]  // D7
+            &sam4l::gpio::PB[14], // D0
+            &sam4l::gpio::PB[15], // D1
+            &sam4l::gpio::PB[11], // D6
+            &sam4l::gpio::PB[12]  // D7
         ),
     );
 


### PR DESCRIPTION
### Pull Request Overview

This pull request puts the hail GPIO pins back to the correct pins.

This is for 1.5.

### Testing Strategy

I guess this is why we do releases!


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
