### PR TITLE
Updated instructions on running HiFive under qemu

### DIFF
--- a/boards/hifive1/Makefile
+++ b/boards/hifive1/Makefile
@@ -8,3 +8,9 @@ include ../Makefile.common
 flash: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
 	openocd \
 		-c "source [find board/sifive-hifive1.cfg]; flash protect 0 64 last off; program $<; resume 0x20400000; exit"
+
+qemu: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
+	qemu-system-riscv32 -M sifive_e -kernel $^  -nographic
+
+qemu-app: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
+	qemu-system-riscv32 -M sifive_e -kernel $^ -device loader,file=$(APP),addr=0x20430000 -nographic

--- a/boards/hifive1/README.md
+++ b/boards/hifive1/README.md
@@ -21,11 +21,37 @@ Running in QEMU
 The HiFive1 application can be run in the QEMU emulation platform, allowing quick and easy testing.
 
 QEMU can be started with Tock using the following arguments (in Tock's top-level directory):
+
+```bash
+$ qemu-system-riscv32 -M sifive_e -kernel $TOCK_ROOT/target/riscv32imac-unknown-none-elf/release/hifive1.elf  -nographic
 ```
-qemu-system-riscv32 -M sifive_e -kernel target/riscv32imac-unknown-none-elf/release/hifive1.elf  -nographic
+
+Or with the `qemu` make target:
+
+```bash
+$ make qemu
 ```
 
 QEMU can be started with Tock and a userspace app using the following arguments (in Tock's top-level directory):
+
 ```
-qemu-system-riscv32 -M sifive_e -kernel target/riscv32imac-unknown-none-elf/release/hifive1.elf -device loader,file=./examples/hello.tbf,addr=0x20430000 -nographic
+qemu-system-riscv32 -M sifive_e -kernel $TOCK_ROOT/target/riscv32imac-unknown-none-elf/release/hifive1.elf -device loader,file=./examples/hello.tbf,addr=0x20430000 -nographic
 ```
+Or with the `qemu-app` make target:
+
+```bash
+$ make APP=/path/to/app.tbf qemu-app
+```
+
+The TBF must be compiled for the HiFive board which is, at the time of writing,
+supported for Rust userland apps using libtock-rs. For example, you can build
+the Hello World exmple app from the libtock-rs repository by running:
+
+```
+$ cd [LIBTOCK-RS-DIR]
+$ make flash-hifive1
+$ tar xf target/riscv32imac-unknown-none-elf/tab/hifive1/hello_world.tab
+$ cd [TOCK_ROOT]/boards/hifive
+$ make APP=[LIBTOCK-RS-DIR]/rv32imac.tbf qemu-app
+```
+

--- a/shell.nix
+++ b/shell.nix
@@ -50,6 +50,7 @@ in
       pythonPackages.tockloader
       rust_build
       llvm
+      qemu
     ];
 
     LD_LIBRARY_PATH="${stdenv.cc.cc.lib}/lib64:$LD_LIBRARY_PATH";


### PR DESCRIPTION
### Pull Request Overview

Updates the Makefile and README for the HiFive board to provide more complete instructions for running Tock on the HiFive board under qemu with an application.

It also adds `qemu` to the Nix shell

### Testing Strategy

Repeating the steps in the README and getting a nice "Hello World" on the console

### TODO or Help Wanted

N/A

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make formatall`.
