### PR TITLE
fix imix in-kernel networking tests

### DIFF
--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -476,12 +476,18 @@ pub unsafe fn reset_handler() {
     //test::aes_test::run_aes128_cbc();
     //test::log_test::run(mux_alarm, dynamic_deferred_caller);
     //test::linear_log_test::run(mux_alarm, dynamic_deferred_caller);
+    //test::icmp_lowpan_test::run(mux_mac, mux_alarm);
+    //let lowpan_frag_test = test::ipv6_lowpan_test::initialize_all(mux_mac, mux_alarm);
+    //lowpan_frag_test.start(); // If flashing the transmitting Imix
+    /*let udp_lowpan_test = test::udp_lowpan_test::initialize_all(
+       udp_send_mux,
+        udp_recv_mux,
+        udp_port_table,
+        mux_alarm,
+    );*/
+    //udp_lowpan_test.start();
 
     debug!("Initialization complete. Entering main loop");
-
-    // Only include to run kernel tests, do not include during normal operation
-    // let udp_lowpan_test =
-    //     test::udp_lowpan_test::initialize_all(udp_send_mux, udp_recv_mux, udp_port_table, mux_alarm);
 
     extern "C" {
         /// Beginning of the ROM region containing app images.

--- a/boards/imix/src/test/icmp_lowpan_test.rs
+++ b/boards/imix/src/test/icmp_lowpan_test.rs
@@ -3,22 +3,12 @@
 //!
 //! Currently this file only tests sending messages.
 //!
-//! To use this test suite, allocate space for a new LowpanICMPTest structure, and
-//! call the `initialize_all` function, which performs
-//! the initialization routines for the 6LoWPAN, TxState, RxState, and Sixlowpan
-//! structs. Insert the code into `boards/imix/src/main.rs` as follows:
+//! To use this test suite, simply call the `run` function.
+//! Insert the code into `boards/imix/src/main.rs` as follows:
 //!
-//! ...
-//! // Radio initialization code
-//! ...
-//!    let icmp_lowpan_test = test::icmp_lowpan_test::initialize_all(
-//!        mux_mac,
-//!        mux_alarm as &'static MuxAlarm<'static, sam4l::ast::Ast>,
-//!    );
-//! ...
-//! // Imix initialization
-//! ...
-//! icmp_lowpan_test.start();
+//!```rust
+//! test::icmp_lowpan_test::run(mux_mac, mux_alarm);
+//! ```
 
 use capsules::ieee802154::device::MacDevice;
 use capsules::net::icmpv6::icmpv6::{ICMP6Header, ICMP6Type};
@@ -27,12 +17,16 @@ use capsules::net::ieee802154::MacAddress;
 use capsules::net::ipv6::ip_utils::IPAddr;
 use capsules::net::ipv6::ipv6::{IP6Packet, IPPayload, TransportHeader};
 use capsules::net::ipv6::ipv6_send::{IP6SendStruct, IP6Sender};
-use capsules::net::network_capabilities::{IpVisibilityCapability, NetworkCapability};
+use capsules::net::network_capabilities::{
+    AddrRange, IpVisibilityCapability, NetworkCapability, PortRange,
+};
 use capsules::net::sixlowpan::sixlowpan_compression;
 use capsules::net::sixlowpan::sixlowpan_state::{Sixlowpan, SixlowpanState, TxState};
 
 use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use core::cell::Cell;
+use kernel::capabilities::NetworkCapabilityCreationCapability;
+use kernel::create_capability;
 use kernel::debug;
 use kernel::hil::radio;
 use kernel::hil::time::Frequency;
@@ -70,15 +64,19 @@ pub struct LowpanICMPTest<'a, A: time::Alarm<'a>> {
     net_cap: &'static NetworkCapability,
 }
 
-pub unsafe fn initialize_all(
+pub unsafe fn run(
     mux_mac: &'static capsules::ieee802154::virtual_mac::MuxMac<'static>,
     mux_alarm: &'static MuxAlarm<'static, sam4l::ast::Ast>,
-    net_cap: &'static NetworkCapability,
-    ip_vis: &'static IpVisibilityCapability,
-) -> &'static LowpanICMPTest<
-    'static,
-    capsules::virtual_alarm::VirtualMuxAlarm<'static, sam4l::ast::Ast<'static>>,
-> {
+) {
+    let create_cap = create_capability!(NetworkCapabilityCreationCapability);
+    let net_cap = static_init!(
+        NetworkCapability,
+        NetworkCapability::new(AddrRange::Any, PortRange::Any, PortRange::Any, &create_cap)
+    );
+    let ip_vis = static_init!(
+        IpVisibilityCapability,
+        IpVisibilityCapability::new(&create_cap)
+    );
     let radio_mac = static_init!(
         capsules::ieee802154::virtual_mac::MacUser<'static>,
         capsules::ieee802154::virtual_mac::MacUser::new(mux_mac)
@@ -152,8 +150,7 @@ pub unsafe fn initialize_all(
     icmp_send_struct.set_client(icmp_lowpan_test);
     icmp_lowpan_test.alarm.set_client(icmp_lowpan_test);
     ipsender_virtual_alarm.set_client(ip6_sender);
-
-    icmp_lowpan_test
+    icmp_lowpan_test.start();
 }
 
 impl<'a, A: time::Alarm<'a>> capsules::net::icmpv6::icmpv6_send::ICMP6SendClient

--- a/boards/imix/src/test/ipv6_lowpan_test.rs
+++ b/boards/imix/src/test/ipv6_lowpan_test.rs
@@ -16,27 +16,17 @@
 //! to remain in sync, they must both be started at the same time. Any dropped
 //! frames will prevent the test from completing successfully.
 //!
-//! To use this test suite, allocate space for a new LowpanTest structure, and
-//! set it as the client for the Sixlowpan struct and for the respective TxState
-//! struct. For the transmit side, call the LowpanTest::start method. The
-//! `initialize_all` function performs this initialization; simply call this
-//! function in `boards/imix/src/main.rs` as follows:
+//! To use this test, the `initialize_all` is called on both boards; and `start()`
+//! is called on the transmitting board. Simply call these
+//! functions in `boards/imix/src/main.rs` as follows:
 //!
-//! Alternatively, you can call the `initialize_all` function, which performs
-//! the initialization routines for the 6LoWPAN, TxState, RxState, and Sixlowpan
-//! structs. Insert the code into `boards/imix/src/main.rs` as follows:
-//!
-//! ...
-//! // Radio initialization code
-//! ...
+//! ```rust
 //! let lowpan_frag_test = test::ipv6_lowpan_test::initialize_all(
 //!    mux_mac,
-//!    mux_alarm as &'static MuxAlarm<'static, sam4l::ast::Ast>,
+//!    mux_alarm,
 //! );
-//! ...
-//! // Imix initialization
-//! ...
 //! lowpan_frag_test.start(); // If flashing the transmitting Imix
+//! ```
 
 use capsules::ieee802154::device::{MacDevice, TxClient};
 use capsules::net::ieee802154::MacAddress;
@@ -59,12 +49,6 @@ use kernel::ReturnCode;
 
 pub const MLP: [u8; 8] = [0xc0, 0xc1, 0xc2, 0xc3, 0xc4, 0xc5, 0xc6, 0xc7];
 
-/* pub const SRC_ADDR: IPAddr = IPAddr([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-                                     0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
-
-pub const DST_ADDR: IPAddr = IPAddr([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-                                     0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);*/
-
 pub const SRC_ADDR: IPAddr = IPAddr([
     0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
 ]);
@@ -73,8 +57,6 @@ pub const DST_ADDR: IPAddr = IPAddr([
 ]);
 pub const SRC_MAC_ADDR: MacAddress =
     MacAddress::Long([0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17]);
-//pub const DST_MAC_ADDR: MacAddress =
-//    MacAddress::Long([0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f]);
 pub const DST_MAC_ADDR: MacAddress = MacAddress::Short(57326);
 //TODO: No longer pass MAC addresses to 6lowpan code, so these values arent used rn
 pub const IP6_HDR_SIZE: usize = 40;
@@ -780,7 +762,7 @@ fn ipv6_prepare_packet(tf: TF, hop_limit: u8, sac: SAC, dac: DAC) {
                 } //This bracket ends mutable borrow of ip6_packet for header
                   //Now that packet is fully prepared, set checksum
                 ip6_packet.set_transport_checksum(); //calculates and sets UDP cksum
-            } //End of Some{}
+            }
             None => debug!("Error! tried to prepare uninitialized IP6Packet"),
         }
     }

--- a/boards/imix/src/test/udp_lowpan_test.rs
+++ b/boards/imix/src/test/udp_lowpan_test.rs
@@ -7,17 +7,13 @@
 //!
 //! To use this test suite, insert the below code into `boards/imix/src/main.rs` as follows:
 //!
-//!```
-//! ...
-//! // Radio initialization code
-//! ...
-//!    let udp_lowpan_test = test::udp_lowpan_test::initialize_all(
-//!        udp_mux,
-//!        mux_alarm as &'static MuxAlarm<'static, sam4l::ast::Ast>,
-//!    );
-//! ...
-//! // Imix initialization
-//! ...
+//!```rust
+//! let udp_lowpan_test = test::udp_lowpan_test::initialize_all(
+//!    udp_send_mux,
+//!     udp_recv_mux,
+//!     udp_port_table,
+//!     mux_alarm,
+//! );
 //! udp_lowpan_test.start();
 //!```
 //!


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes several in-kernel networking tests for Imix that I discovered were broken while testing for 1.5. This is partially just updating the usage of each test to match how they can actually be invoked, and also includes a fix for some capsule code introduced in #1581 that broke one test. In the process of addressing this error I realized the logic for storing network capabilities in the UDP Mux was incorrect, so I fixed that as well.

Notably, the ipv6_lowpan_test is still broken after this PR, due to an issue with how that test sets the UDP checksum. I believe that test has actually been broken for awhile, but it wasn't caught because it was not a part of previous release testing. The error may be specific to the test itself, rather than the actual networking code.


### Testing Strategy

This pull request was tested by running the in kernel network stack tests for Imix.


### TODO or Help Wanted

Eventually the ipv6_lowpan_test will need to be fixed.


### Documentation Updated

- [x] No updates are required.

### Formatting

- [x] Ran `make formatall`.
