### PR TITLE
rv32i: try a different section identifier

### DIFF
--- a/arch/rv32i/src/lib.rs
+++ b/arch/rv32i/src/lib.rs
@@ -150,7 +150,7 @@ pub extern "C" fn _start_trap() {
 /// save the application state and then resume the `switch_to()` function to
 /// correctly return back to the kernel.
 #[cfg(all(target_arch = "riscv32", target_os = "none"))]
-#[link_section = ".riscv,trap"]
+#[link_section = ".riscv.trap"]
 #[export_name = "_start_trap"]
 #[naked]
 pub extern "C" fn _start_trap() {

--- a/boards/kernel_layout.ld
+++ b/boards/kernel_layout.ld
@@ -88,15 +88,15 @@ SECTIONS
          */
         KEEP(*(.riscv.start));
         /* For RISC-V we need the `_start_trap` function to be 256 byte aligned,
-         * and that function is at the start of the .riscv,trap section. If that
+         * and that function is at the start of the .riscv.trap section. If that
          * function does not exist (as for non-RISC-V platforms) then we do not
          * need any unusual alignment.
          * The allignment is implementation specific, so we currently use 256 to
          * work with the lowRISC CPUs.
          */
         . = DEFINED(_start_trap) ? ALIGN(256) : ALIGN(1);
-        KEEP(*(.riscv,trap_vectored));
-        KEEP(*(.riscv,trap));
+        KEEP(*(.riscv.trap_vectored));
+        KEEP(*(.riscv.trap));
 
         /* .text and .rodata hold most program code and immutable constants */
         /* .gnu.linkonce hold C++ elements with vague linkage

--- a/chips/ibex/src/chip.rs
+++ b/chips/ibex/src/chip.rs
@@ -210,6 +210,17 @@ pub unsafe fn configure_trap_handler() {
         .write(mtvec::trap_addr.val(_start_trap_vectored as u32 >> 2) + mtvec::mode::Vectored)
 }
 
+// Mock implementation for crate tests that does not include the section
+// specifier, as the test will not use our linker script, and the host
+// compilation environment may not allow the section name.
+#[cfg(not(any(target_arch = "riscv32", target_os = "none")))]
+pub extern "C" fn _start_trap_vectored() {
+    unsafe {
+        unreachable_unchecked();
+    }
+}
+
+#[cfg(all(target_arch = "riscv32", target_os = "none"))]
 #[link_section = ".riscv.trap_vectored"]
 #[export_name = "_start_trap_vectored"]
 #[naked]

--- a/chips/ibex/src/chip.rs
+++ b/chips/ibex/src/chip.rs
@@ -210,7 +210,7 @@ pub unsafe fn configure_trap_handler() {
         .write(mtvec::trap_addr.val(_start_trap_vectored as u32 >> 2) + mtvec::mode::Vectored)
 }
 
-#[link_section = ".riscv,trap_vectored"]
+#[link_section = ".riscv.trap_vectored"]
 #[export_name = "_start_trap_vectored"]
 #[naked]
 pub extern "C" fn _start_trap_vectored() -> ! {


### PR DESCRIPTION
Also shorten the name becuase of Mach-O's 16 character limit

### Pull Request Overview

This hopefully fixes the issue introduced in #1778 by using a different identifier. With an underscore instead of a comma, it appears to get linked into the `.text` section again:

```
$ readelf.py -S target/riscv32imac-unknown-none-elf/release/hifive1.elf
There are 22 section headers, starting at offset 0x18a568

Section Headers:
  [Nr] Name              Type            Addr     Off    Size   ES Flg Lk Inf Al
  [ 0]                   NULL            00000000 000000 000000 00      0   0  0
  [ 1] .stack            NOBITS          80000000 0000f4 000800 00  WA  0   0  1
  [ 2] .text             PROGBITS        20400000 000200 00c61c 00 AXM  0   0 16
  [ 3] .storage          PROGBITS        2040c61c 00c81c 0001e4 00  AX  0   0  1
  [ 4] .apps             PROGBITS        20430000 00ca00 000000 00  AX  0   0  1
  [ 5] .relocate         PROGBITS        80000800 00ca00 0011f0 00  WA  0   0  4
  [ 6] .sram             NOBITS          800019f0 00dbf0 001e10 00  WA  0   0  4
  [ 7] .debug_str        PROGBITS        00000000 00dbf0 049434 01  MS  0   0  1
  [ 8] .debug_loc        PROGBITS        00000000 057024 01ddad 00      0   0  1
  [ 9] .debug_abbrev     PROGBITS        00000000 074dd1 000be7 00      0   0  1
  [10] .debug_info       PROGBITS        00000000 0759b8 06e411 00      0   0  1
  [11] .debug_aranges    PROGBITS        00000000 0e3dc9 001468 00      0   0  1
  [12] .debug_ranges     PROGBITS        00000000 0e5231 009170 00      0   0  1
  [13] .debug_macinfo    PROGBITS        00000000 0ee3a1 000002 00      0   0  1
  [14] .debug_pubnames   PROGBITS        00000000 0ee3a3 01c65e 00      0   0  1
  [15] .debug_pubtypes   PROGBITS        00000000 10aa01 02b984 00      0   0  1
  [16] .debug_frame      PROGBITS        00000000 136388 003f48 00      0   0  4
  [17] .debug_line       PROGBITS        00000000 13a2d0 0169b7 00      0   0  1
  [18] .comment          PROGBITS        00000000 150c87 000012 01  MS  0   0  1
  [19] .symtab           SYMTAB          00000000 150c9c 02f0f0 10     21 12018  4
  [20] .shstrtab         STRTAB          00000000 17fd8c 0000e5 00      0   0  1
  [21] .strtab           STRTAB          00000000 17fe71 00a6f4 00      0   0  1
```


### Testing Strategy

Compiling.


### TODO or Help Wanted

@alistair23 does this fix?


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
