### PR TITLE
doc: Add syscall filter to syscall documentation

### DIFF
--- a/doc/Syscalls.md
+++ b/doc/Syscalls.md
@@ -380,14 +380,16 @@ After a system call is made, the call is handled and routed by the Tock kernel
 in [`sched.rs`](../kernel/src/sched.rs) through a series of steps.
 
 1. The kernel calls a platform-provided syscall filter function to determine if
-   it should process the syscall or not. This does not apply to `yield()`. The
-   filter function uses the syscall and which process called it and returns a
-   `Result((), ReturnCode)` to signal if the syscall should be handled or if an
-   error should be returned to the process.
+   it should process the syscall or not. This does not apply to `yield`. The
+   filter function takes the syscall and which process issued the syscall to
+   return a `Result((), ReturnCode)` to signal if the syscall should be handled
+   or if an error should be returned to the process.
 
-    If the filter function disallows the syscall it returns `Err(ReturnCode)` and
-    the `ReturnCode` is provided to the app as the return code for the syscall.
-    Otherwise, the syscall proceeds.
+   If the filter function disallows the syscall it returns `Err(ReturnCode)` and
+   the `ReturnCode` is provided to the app as the return code for the syscall.
+   Otherwise, the syscall proceeds.
+
+   _The filter interface is currently considered unstable and subject to change._
 
 2. The number of the syscall is matched against the valid syscall types. `yield`
    and `memop` have special functionality that is handled by the kernel.
@@ -400,31 +402,31 @@ in [`sched.rs`](../kernel/src/sched.rs) through a series of steps.
    supported or `None` otherwise. The kernel then calls the appropriate syscall
    function on that driver with the remaining syscall arguments.
 
-    An example board that implements the `Platform` trait looks something like
-    this:
+   An example board that implements the `Platform` trait looks something like
+   this:
 
-    ```rust
-    struct TestBoard {
-        console: &'static Console<'static, usart::USART>,
-    }
+   ```rust
+   struct TestBoard {
+       console: &'static Console<'static, usart::USART>,
+   }
 
-    impl Platform for TestBoard {
-        fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
-            where F: FnOnce(Option<&kernel::Driver>) -> R
-        {
+   impl Platform for TestBoard {
+       fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+           where F: FnOnce(Option<&kernel::Driver>) -> R
+       {
 
-            match driver_num {
-                0 => f(Some(self.console)),
-                _ => f(None),
-            }
-        }
-    }
-    ```
+           match driver_num {
+               0 => f(Some(self.console)), // use capsules::console::DRIVER_NUM rather than 0 in real code
+               _ => f(None),
+           }
+       }
+   }
+   ```
 
-    `TestBoard` then supports one driver, the UART console, and maps it to driver
-    number 0. Any `command`, `subscribe`, and `allow` sycalls to driver number 0
-    will get routed to the console, and all other driver numbers will return
-    `ReturnCode::ENODEVICE`.
+   `TestBoard` then supports one driver, the UART console, and maps it to driver
+   number 0. Any `command`, `subscribe`, and `allow` sycalls to driver number 0
+   will get routed to the console, and all other driver numbers will return
+   `ReturnCode::ENODEVICE`.
 
 
 


### PR DESCRIPTION
### Pull Request Overview

This pull request updates the syscall documentation slightly.

I did a quick pass over the docs in /doc and everything seemed to be reasonably up to date. I made this change but didn't see anything else to update.


### Testing Strategy

This pull request was tested by...


### TODO or Help Wanted

This pull request still needs...


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.

---

Rendered: https://github.com/tock/tock/blob/doc-update-2020-04/doc/Syscalls.md
