### PR TITLE
capsule: process console: fix printout ordering

### DIFF
--- a/capsules/src/process_console.rs
+++ b/capsules/src/process_console.rs
@@ -135,7 +135,14 @@ pub struct ProcessConsole<'a, C: ProcessManagementCapability> {
     rx_buffer: TakeCell<'static, [u8]>,
     command_buffer: TakeCell<'static, [u8]>,
     command_index: Cell<usize>,
+
+    /// Flag to mark that the process console is active and has called receive
+    /// from the underlying UART.
     running: Cell<bool>,
+
+    /// Internal flag that the process console should parse the command it just
+    /// received after finishing echoing the last newline character.
+    execute: Cell<bool>,
     kernel: &'static Kernel,
     capability: C,
 }
@@ -158,6 +165,7 @@ impl<'a, C: ProcessManagementCapability> ProcessConsole<'a, C> {
             command_buffer: TakeCell::new(cmd_buffer),
             command_index: Cell::new(0),
             running: Cell::new(false),
+            execute: Cell::new(false),
             kernel: kernel,
             capability: capability,
         }
@@ -323,10 +331,15 @@ impl<'a, C: ProcessManagementCapability> ProcessConsole<'a, C> {
 
 impl<'a, C: ProcessManagementCapability> uart::TransmitClient for ProcessConsole<'a, C> {
     fn transmitted_buffer(&self, buffer: &'static mut [u8], _tx_len: usize, _rcode: ReturnCode) {
-        // Either print more from the AppSlice or send a callback to the
-        // application.
         self.tx_buffer.replace(buffer);
         self.tx_in_progress.set(false);
+
+        // Check if we just received and echoed a newline character, and
+        // therefore need to process the received message.
+        if self.execute.get() {
+            self.execute.set(false);
+            self.read_command();
+        }
     }
 }
 impl<'a, C: ProcessManagementCapability> uart::ReceiveClient for ProcessConsole<'a, C> {
@@ -337,7 +350,6 @@ impl<'a, C: ProcessManagementCapability> uart::ReceiveClient for ProcessConsole<
         _rcode: ReturnCode,
         error: uart::Error,
     ) {
-        let mut execute = false;
         if error == uart::Error::None {
             match rx_len {
                 0 => debug!("ProcessConsole had read of 0 bytes"),
@@ -345,7 +357,7 @@ impl<'a, C: ProcessManagementCapability> uart::ReceiveClient for ProcessConsole<
                     self.command_buffer.map(|command| {
                         let index = self.command_index.get() as usize;
                         if read_buf[0] == ('\n' as u8) || read_buf[0] == ('\r' as u8) {
-                            execute = true;
+                            self.execute.set(true);
                             self.write_bytes(&['\r' as u8, '\n' as u8]);
                         } else if read_buf[0] == ('\x08' as u8) && index > 0 {
                             // Backspace, echo and remove last byte
@@ -373,8 +385,5 @@ impl<'a, C: ProcessManagementCapability> uart::ReceiveClient for ProcessConsole<
         }
         self.rx_in_progress.set(true);
         self.uart.receive_buffer(read_buf, 1);
-        if execute {
-            self.read_command();
-        }
     }
 }


### PR DESCRIPTION
This avoids a potential issue with a virtual uart for the process console. Since the console echos characters to the console itself, but uses `debug!()` for a majority of its printouts, the last echoed newline can get stuck in the virtual uart queue behind the debug!() output, causing slightly malformed output in the terminal. This makes sure that the newline has been echoed before calling any debug!() commands.

This fixes #1569.




### Testing Strategy

This pull request was tested by running the process console on hail and verifying the output looks right.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
