### PR TITLE
fix capability check error

### DIFF
--- a/capsules/src/net/network_capabilities.rs
+++ b/capsules/src/net/network_capabilities.rs
@@ -47,8 +47,10 @@ impl AddrRange {
                 // initial bytes -- TODO: edge case
                 if &allowed_addr.0[0..full_bytes] != &addr.0[0..full_bytes] {
                     false
+                } else if remainder_bits == 0 {
+                    true //this case is necessary bc right shifting a u8 by 8 bits is UB
                 } else {
-                    allowed_addr.0[full_bytes] >> (8 - remainder_bits)
+                    addr.0[full_bytes] >> (8 - remainder_bits)
                         == allowed_addr.0[full_bytes] >> (8 - remainder_bits)
                 }
             }


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes a bug in the network capability code where the allowed subnet was compared to itself rather than the passed address. This was caught by clippy!

In the process of changing the code to what was probably originally intended I also caught the possibility of UB in a bit shift, so I corrected that as well.

### Testing Strategy

This pull request was tested by running the port table test.


### TODO or Help Wanted

N/A

### Documentation Updated

- [x] No updates are required.

### Formatting

- [x] Ran `make formatall`.
