### PR TITLE
tools: update makefile to partition CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,64 +39,140 @@ allcheck:
 alldoc:
 	@for f in `./tools/list_boards.sh`; do echo "$$(tput bold)Documenting $$f"; $(MAKE) -C "boards/$$f" doc || exit 1; done
 
+
+
+###################################################################
+##
+## Continuous Integration Targets
+##
+## To run all CI locally, use the meta-target `make ci`.
+##
+## Each of the phases of CI is broken into its own target to enable
+## quick local iteration without re-running all phases of CI.
+##
+
+
+## Meta-Targets
+
+.PHONY: ci
+ci: ci-travis ci-netlify
+
 .PHONY: ci-travis
-ci-travis:
+ci-travis:\
+	ci-formatting\
+	ci-tools\
+	ci-libraries\
+	ci-archs\
+	ci-kernel\
+	ci-chips\
+	ci-syntax\
+	ci-compilation\
+	ci-special-targets\
+	ci-documentation
+	@printf "$$(tput bold)********************$$(tput sgr0)\n"
+	@printf "$$(tput bold)* CI-Travis: Done! *$$(tput sgr0)\n"
+	@printf "$$(tput bold)********************$$(tput sgr0)\n"
+
+.PHONY: ci-netlify
+ci-netlify:\
+	ci-rustdoc
+	@printf "$$(tput bold)*********************$$(tput sgr0)\n"
+	@printf "$$(tput bold)* CI-Netlify: Done! *$$(tput sgr0)\n"
+	@printf "$$(tput bold)*********************$$(tput sgr0)\n"
+
+
+## Actual Rules (Travis)
+
+.PHONY: ci-formatting
+ci-formatting:
 	@printf "$$(tput bold)******************$$(tput sgr0)\n"
 	@printf "$$(tput bold)* CI: Formatting *$$(tput sgr0)\n"
 	@printf "$$(tput bold)******************$$(tput sgr0)\n"
 	@CI=true ./tools/run_cargo_fmt.sh diff
 	@./tools/check_wildcard_imports.sh
+
+.PHONY: ci-tools
+ci-tools:
 	@printf "$$(tput bold)*************$$(tput sgr0)\n"
 	@printf "$$(tput bold)* CI: Tools *$$(tput sgr0)\n"
 	@printf "$$(tput bold)*************$$(tput sgr0)\n"
 	@for f in `./tools/list_tools.sh`; do echo "$$(tput bold)Build & Test $$f"; cd tools/$$f && CI=true RUSTFLAGS="-D warnings" cargo build --all-targets || exit 1; cd - > /dev/null; done
+
+.PHONY: ci-libraries
+ci-libraries:
 	@printf "$$(tput bold)*****************$$(tput sgr0)\n"
 	@printf "$$(tput bold)* CI: Libraries *$$(tput sgr0)\n"
 	@printf "$$(tput bold)*****************$$(tput sgr0)\n"
 	@cd libraries/tock-cells && CI=true cargo test
 	@cd libraries/tock-register-interface && CI=true cargo test
+
+.PHONY: ci-archs
+ci-archs:
 	@printf "$$(tput bold)*************$$(tput sgr0)\n"
 	@printf "$$(tput bold)* CI: Archs *$$(tput sgr0)\n"
 	@printf "$$(tput bold)*************$$(tput sgr0)\n"
 	@for f in `./tools/list_archs.sh`; do echo "$$(tput bold)Test $$f"; cd arch/$$f; CI=true TOCK_KERNEL_VERSION=ci_test cargo test || exit 1; cd ../..; done
+
+.PHONY: ci-chips
+ci-chips:
 	@printf "$$(tput bold)*************$$(tput sgr0)\n"
 	@printf "$$(tput bold)* CI: Chips *$$(tput sgr0)\n"
 	@printf "$$(tput bold)*************$$(tput sgr0)\n"
 	@for f in `./tools/list_chips.sh`; do echo "$$(tput bold)Test $$f"; cd chips/$$f; CI=true TOCK_KERNEL_VERSION=ci_test cargo test || exit 1; cd ../..; done
-	@printf "$$(tput bold)**************$$(tput sgr0)\n"
-	@printf "$$(tput bold)* CI: Syntax *$$(tput sgr0)\n"
-	@printf "$$(tput bold)**************$$(tput sgr0)\n"
-	@CI=true $(MAKE) allcheck
+
+.PHONY: ci-kernel
+ci-kernel:
 	@printf "$$(tput bold)**************$$(tput sgr0)\n"
 	@printf "$$(tput bold)* CI: Kernel *$$(tput sgr0)\n"
 	@printf "$$(tput bold)**************$$(tput sgr0)\n"
 	@cd kernel && CI=true TOCK_KERNEL_VERSION=ci_test cargo test
+
+.PHONY: ci-syntax
+ci-syntax:
+	@printf "$$(tput bold)**************$$(tput sgr0)\n"
+	@printf "$$(tput bold)* CI: Syntax *$$(tput sgr0)\n"
+	@printf "$$(tput bold)**************$$(tput sgr0)\n"
+	@CI=true $(MAKE) allcheck
+
+.PHONY: ci-compilation
+ci-compilation:
 	@printf "$$(tput bold)*******************$$(tput sgr0)\n"
 	@printf "$$(tput bold)* CI: Compilation *$$(tput sgr0)\n"
 	@printf "$$(tput bold)*******************$$(tput sgr0)\n"
 	@CI=true $(MAKE) allboards
+
+.PHONY: ci-special-targets
+ci-special-targets:
 	@printf "$$(tput bold)***********************$$(tput sgr0)\n"
 	@printf "$$(tput bold)* CI: Special Targets *$$(tput sgr0)\n"
 	@printf "$$(tput bold)***********************$$(tput sgr0)\n"
 	@CI=true $(MAKE) -C boards/nordic/nrf52dk lst
 	@CI=true $(MAKE) -C boards/nordic/nrf52dk debug
 	@CI=true $(MAKE) -C boards/nordic/nrf52dk debug-lst
+
+.PHONY: ci-documentation
+ci-documentation:
 	@printf "$$(tput bold)*********************$$(tput sgr0)\n"
 	@printf "$$(tput bold)* CI: Documentation *$$(tput sgr0)\n"
 	@printf "$$(tput bold)*********************$$(tput sgr0)\n"
 	@CI=true tools/toc.sh
-	@printf "$$(tput bold)*************$$(tput sgr0)\n"
-	@printf "$$(tput bold)* CI: Done! *$$(tput sgr0)\n"
-	@printf "$$(tput bold)*************$$(tput sgr0)\n"
 
-.PHONY: ci-netlify
-ci-netlify:
+
+## Actual Rules (Netlify)
+
+.PHONY: ci-rustdoc
+ci-rustdoc:
+	@printf "$$(tput bold)*****************************$$(tput sgr0)\n"
+	@printf "$$(tput bold)* CI: Rustdoc Documentation *$$(tput sgr0)\n"
+	@printf "$$(tput bold)*****************************$$(tput sgr0)\n"
 	@#n.b. netlify calls tools/netlify-build.sh, which is a wrapper
 	@#     that first installs toolchains, then calls this.
 	@tools/build-all-docs.sh
 
-.PHONY: ci
-ci: ci-travis ci-netlify
+## End CI rules
+##
+###################################################################
+
 
 .PHONY: audit
 audit:

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ ci-travis:\
 	ci-chips\
 	ci-syntax\
 	ci-compilation\
-	ci-special-targets\
+	ci-debug-support-targets\
 	ci-documentation
 	@printf "$$(tput bold)********************$$(tput sgr0)\n"
 	@printf "$$(tput bold)* CI-Travis: Done! *$$(tput sgr0)\n"
@@ -141,11 +141,16 @@ ci-compilation:
 	@printf "$$(tput bold)*******************$$(tput sgr0)\n"
 	@CI=true $(MAKE) allboards
 
-.PHONY: ci-special-targets
-ci-special-targets:
-	@printf "$$(tput bold)***********************$$(tput sgr0)\n"
-	@printf "$$(tput bold)* CI: Special Targets *$$(tput sgr0)\n"
-	@printf "$$(tput bold)***********************$$(tput sgr0)\n"
+.PHONY: ci-debug-support-targets
+ci-debug-support-targets:
+	# These are rules that build additional debugging information, but are
+	# also quite time consuming. So we want to verify that the rules still
+	# work, but don't build them for every board.
+	#
+	# The choice of building for the nrf52dk was chosen by random die roll.
+	@printf "$$(tput bold)*****************************$$(tput sgr0)\n"
+	@printf "$$(tput bold)* CI: Debug Support Targets *$$(tput sgr0)\n"
+	@printf "$$(tput bold)*****************************$$(tput sgr0)\n"
 	@CI=true $(MAKE) -C boards/nordic/nrf52dk lst
 	@CI=true $(MAKE) -C boards/nordic/nrf52dk debug
 	@CI=true $(MAKE) -C boards/nordic/nrf52dk debug-lst


### PR DESCRIPTION
This eases running the failing portions of CI locally

### Pull Request Overview

Inspired by moving rules around while working on #1512, this partitions each phase of CI into its own rule. It should effectively be a no-op.

### Testing Strategy

This pull request was tested by making my poor laptop very warm by running lots of `make ci-X`

### TODO or Help Wanted

N/A

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
