### PR TITLE
mark get_pin_mut() as unsafe

### DIFF
--- a/chips/stm32f3xx/src/gpio.rs
+++ b/chips/stm32f3xx/src/gpio.rs
@@ -472,7 +472,11 @@ impl PinId {
         unsafe { &PIN[usize::from(port_num)][usize::from(pin_num)] }
     }
 
-    pub fn get_pin_mut(&self) -> &mut Option<Pin<'static>> {
+    #[allow(clippy::mut_from_ref)]
+    // This function is inherently unsafe, but no more unsafe than multiple accesses
+    // to `pub static mut PIN` made directly, so okay to ignore this clippy lint
+    // so long as the function is marked unsafe.
+    pub unsafe fn get_pin_mut(&self) -> &mut Option<Pin<'static>> {
         let mut port_num: u8 = *self as u8;
 
         // Right shift p by 4 bits, so we can get rid of pin bits
@@ -482,7 +486,7 @@ impl PinId {
         // Mask top 3 bits, so can get only the suffix
         pin_num &= 0b0001111;
 
-        unsafe { &mut PIN[usize::from(port_num)][usize::from(pin_num)] }
+        &mut PIN[usize::from(port_num)][usize::from(pin_num)]
     }
 
     pub fn get_port(&self) -> &Port {

--- a/chips/stm32f4xx/src/gpio.rs
+++ b/chips/stm32f4xx/src/gpio.rs
@@ -487,7 +487,11 @@ impl PinId {
         unsafe { &PIN[usize::from(port_num)][usize::from(pin_num)] }
     }
 
-    pub fn get_pin_mut(&self) -> &mut Option<Pin<'static>> {
+    #[allow(clippy::mut_from_ref)]
+    // This function is inherently unsafe, but no more unsafe than multiple accesses
+    // to `pub static mut PIN` made directly, so okay to ignore this clippy lint
+    // so long as the function is marked unsafe.
+    pub unsafe fn get_pin_mut(&self) -> &mut Option<Pin<'static>> {
         let mut port_num: u8 = *self as u8;
 
         // Right shift p by 4 bits, so we can get rid of pin bits
@@ -497,7 +501,7 @@ impl PinId {
         // Mask top 3 bits, so can get only the suffix
         pin_num &= 0b0001111;
 
-        unsafe { &mut PIN[usize::from(port_num)][usize::from(pin_num)] }
+        &mut PIN[usize::from(port_num)][usize::from(pin_num)]
     }
 
     pub fn get_port(&self) -> &Port {


### PR DESCRIPTION
### Pull Request Overview

This pull request adds unsafe to `get_pin_mut()` to indicate that calling this function could allow for multiple mutable references to a single pin. Currently this function was only called in `panic_fmt()` for various boards, so none of the calling instances had to be modified. 

I also added a clippy allow associated with this behavior to indicate what we are allowing is (I think) effectively no different than if the calling instances directly accessed the global `PINS` variable.

I am in favor of this fix being included in 1.5.

### Testing Strategy

This pull request was tested by running `run_clippy.sh` on a branch with a number of other clippy fixes included, and by travis-ci.


### TODO or Help Wanted

N/A

### Documentation Updated

- [x] No updates are required.

### Formatting

- [x] Ran `make formatall`.
