### PR TITLE
Add a git-diff line to tools/post_size_changes_to_github.sh

### DIFF
--- a/tools/post_size_changes_to_github.sh
+++ b/tools/post_size_changes_to_github.sh
@@ -58,6 +58,10 @@ if [ -n "$TRAVIS_PULL_REQUEST_BRANCH" ]; then
     for elf in $(find . -maxdepth 8 | grep 'release' | egrep '\.elf$' | grep -v 'riscv'); do
         tmp=${elf#*release/}
         b=${tmp%.elf}
+        # Print a detailed by raw line-by-line diff. Can be useful to
+        # understand where the size differences come from.
+        git diff --no-index previous-benchmark-${b} current-benchmark-${b}
+        # Compute a summary suitable for GitHub.
         ${TRAVIS_BUILD_DIR}/tools/diff_memory_usage.py previous-benchmark-${b} current-benchmark-${b} size-diffs-${b}.txt ${b}
         if [ -s "size-diffs-${b}.txt" ]; then
             RES="$( grep -hs ^ size-diffs-${b}.txt )" #grep instead of cat to prevent errors on no match


### PR DESCRIPTION
### Pull Request Overview

I noticed that the size diffing tool has been added back in #1753. However, I find it hard to pinpoint which sections of the code have the most impact in the size difference, because the diff only summarizes global flash and RAM differences.
However, the size reports are more detailed than that.

This pull request adds a simple `git diff` command over the raw size reports. Although it doesn't compute the difference as a number or percentage, it's a low-hanging fruit which can help understanding where the difference comes from.


### Testing Strategy

This pull request was tested by Travis.


### TODO or Help Wanted

- [ ] Should this line be part of `tools/diff_memory_usage.py` instead?


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
