### PR TITLE
rv32i: pmp: Remove power of two allignment constraint

### DIFF
--- a/arch/rv32i/src/pmp.rs
+++ b/arch/rv32i/src/pmp.rs
@@ -5,7 +5,6 @@ use core::fmt;
 
 use crate::csr;
 use kernel;
-use kernel::common::math;
 use kernel::common::registers::register_bitfields;
 use kernel::mpu;
 
@@ -398,8 +397,6 @@ impl kernel::mpu::MPU for PMPConfig {
 
         // RISC-V PMP is not inclusive of the final address, while Tock is, increase the memory_size by 1
         let mut region_size = memory_size as usize + 1;
-
-        region_size = math::PowerOfTwo::ceiling(region_size as u32).as_num::<u32>() as usize;
 
         // Region size always has to align to 4 bytes
         if region_size % 4 != 0 {


### PR DESCRIPTION
### Pull Request Overview

The TOR PMP implementation (the one we are using) does not require a
power of two size allignment so let's remove it to save space.

### Testing Strategy

Running OpenTitan in QEMU with PMP enabled.

### TODO or Help Wanted

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make formatall`.
