### PR TITLE
kernel: Update comments to mention Process Control Block

### DIFF
--- a/kernel/src/grant.rs
+++ b/kernel/src/grant.rs
@@ -182,6 +182,8 @@ impl<T: Default> Grant<T> {
                 //            │   GrantPointer1 [0x003FFC0]
                 //            │   ...
                 //            │   GrantPointerN [0x0000000 (NULL)]
+                //            ├────────────────────
+                //            │   Process Control Block
                 // 0x003FFE0  ├────────────────────
                 //            │   GrantRegion0
                 // 0x003FFC8  ├────────────────────

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -661,14 +661,19 @@ pub struct Process<'a, C: 'static + Chip> {
     ///
     /// ```text
     ///     ╒════════ ← memory[memory.len()]
-    ///  ╔═ │ Grant
-    ///     │   ↓
-    ///  D  │ ──────  ← kernel_memory_break
-    ///  Y  │
-    ///  N  │ ──────  ← app_break               ═╗
-    ///  A  │                                    ║
-    ///  M  │   ↑                                  A
-    ///     │  Heap                              P C
+    ///  ╔═ │ Grant Pointers
+    ///  ║  │ ──────
+    ///     │ Process Control Block
+    ///  D  │ ──────
+    ///  Y  │ Grant Regions
+    ///  N  │
+    ///  A  │   ↓
+    ///  M  │ ──────  ← kernel_memory_break
+    ///  I  │
+    ///  C  │ ──────  ← app_break               ═╗
+    ///     │                                    ║
+    ///  ║  │   ↑                                  A
+    ///  ║  │  Heap                              P C
     ///  ╠═ │ ──────  ← app_heap_start           R C
     ///     │  Data                              O E
     ///  F  │ ──────  ← data_start_pointer       C S


### PR DESCRIPTION
The presence of Process Control Block in grant memory region was implicit. This commit updates the comments to reflect that.
