### PR TITLE
arty-e21 updates

### DIFF
--- a/boards/arty_e21/src/main.rs
+++ b/boards/arty_e21/src/main.rs
@@ -106,8 +106,8 @@ pub unsafe fn reset_handler() {
 
     // Configure kernel debug gpios as early as possible
     kernel::debug::assign_gpios(
-        Some(&arty_e21_chip::gpio::PORT[0]), // Red
-        Some(&arty_e21_chip::gpio::PORT[1]),
+        Some(&arty_e21_chip::gpio::PORT[0]), // Blue
+        Some(&arty_e21_chip::gpio::PORT[1]), // Green
         Some(&arty_e21_chip::gpio::PORT[8]),
     );
 
@@ -155,7 +155,7 @@ pub unsafe fn reset_handler() {
         [
             (
                 // Red
-                &arty_e21_chip::gpio::PORT[0],
+                &arty_e21_chip::gpio::PORT[2],
                 kernel::hil::gpio::ActivationMode::ActiveHigh
             ),
             (
@@ -165,7 +165,7 @@ pub unsafe fn reset_handler() {
             ),
             (
                 // Blue
-                &arty_e21_chip::gpio::PORT[2],
+                &arty_e21_chip::gpio::PORT[0],
                 kernel::hil::gpio::ActivationMode::ActiveHigh
             ),
         ]

--- a/chips/arty_e21_chip/src/chip.rs
+++ b/chips/arty_e21_chip/src/chip.rs
@@ -127,9 +127,9 @@ impl kernel::Chip for ArtyExx {
                 match interrupt {
                     interrupts::MTIP => timer::MACHINETIMER.handle_interrupt(),
 
-                    interrupts::GPIO0 => gpio::PORT[3].handle_interrupt(),
-                    interrupts::GPIO1 => gpio::PORT[3].handle_interrupt(),
-                    interrupts::GPIO2 => gpio::PORT[3].handle_interrupt(),
+                    interrupts::GPIO0 => gpio::PORT[0].handle_interrupt(),
+                    interrupts::GPIO1 => gpio::PORT[1].handle_interrupt(),
+                    interrupts::GPIO2 => gpio::PORT[2].handle_interrupt(),
                     interrupts::GPIO3 => gpio::PORT[3].handle_interrupt(),
                     interrupts::GPIO4 => gpio::PORT[4].handle_interrupt(),
                     interrupts::GPIO5 => gpio::PORT[5].handle_interrupt(),


### PR DESCRIPTION
### Pull Request Overview

Updates the arty-e21 board from 1.5 testing:

- Enable panic!() printing for the arty-e21
- Fix LED mappings
- Fix interrupt indices


### Testing Strategy

Calling panic!() and seeing the panic printout.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make formatall`.
