### PR TITLE
RISC-V: General PMP Improvements

### DIFF
--- a/arch/rv32i/src/pmp.rs
+++ b/arch/rv32i/src/pmp.rs
@@ -179,7 +179,7 @@ impl kernel::mpu::MPU for PMPConfig {
     fn enable_mpu(&self) {}
 
     fn disable_mpu(&self) {
-        for x in 0..16 {
+        for x in 0..self.total_regions {
             // If PMP is supported by the core then all 16 register sets must exist
             // They don't all have to do anything, but let's zero them all just in case.
             match x {

--- a/arch/rv32i/src/pmp.rs
+++ b/arch/rv32i/src/pmp.rs
@@ -184,131 +184,163 @@ impl kernel::mpu::MPU for PMPConfig {
             // They don't all have to do anything, but let's zero them all just in case.
             match x {
                 0 => {
-                    csr::CSR.pmpcfg0.modify(csr::pmpconfig::pmpcfg::r0::CLEAR);
-                    csr::CSR.pmpcfg0.modify(csr::pmpconfig::pmpcfg::w0::CLEAR);
-                    csr::CSR.pmpcfg0.modify(csr::pmpconfig::pmpcfg::x0::CLEAR);
-                    csr::CSR.pmpcfg0.modify(csr::pmpconfig::pmpcfg::a0::OFF);
-                    csr::CSR.pmpcfg0.modify(csr::pmpconfig::pmpcfg::l0::CLEAR);
+                    csr::CSR.pmpcfg0.modify(
+                        csr::pmpconfig::pmpcfg::r0::CLEAR
+                            + csr::pmpconfig::pmpcfg::w0::CLEAR
+                            + csr::pmpconfig::pmpcfg::x0::CLEAR
+                            + csr::pmpconfig::pmpcfg::a0::OFF
+                            + csr::pmpconfig::pmpcfg::l0::CLEAR,
+                    );
                     csr::CSR.pmpaddr0.set(0x0);
                 }
                 1 => {
-                    csr::CSR.pmpcfg0.modify(csr::pmpconfig::pmpcfg::r1::CLEAR);
-                    csr::CSR.pmpcfg0.modify(csr::pmpconfig::pmpcfg::w1::CLEAR);
-                    csr::CSR.pmpcfg0.modify(csr::pmpconfig::pmpcfg::x1::CLEAR);
-                    csr::CSR.pmpcfg0.modify(csr::pmpconfig::pmpcfg::a1::OFF);
-                    csr::CSR.pmpcfg0.modify(csr::pmpconfig::pmpcfg::l1::CLEAR);
+                    csr::CSR.pmpcfg0.modify(
+                        csr::pmpconfig::pmpcfg::r1::CLEAR
+                            + csr::pmpconfig::pmpcfg::w1::CLEAR
+                            + csr::pmpconfig::pmpcfg::x1::CLEAR
+                            + csr::pmpconfig::pmpcfg::a1::OFF
+                            + csr::pmpconfig::pmpcfg::l1::CLEAR,
+                    );
                     csr::CSR.pmpaddr1.set(0x0);
                 }
                 2 => {
-                    csr::CSR.pmpcfg0.modify(csr::pmpconfig::pmpcfg::r2::CLEAR);
-                    csr::CSR.pmpcfg0.modify(csr::pmpconfig::pmpcfg::w2::CLEAR);
-                    csr::CSR.pmpcfg0.modify(csr::pmpconfig::pmpcfg::x2::CLEAR);
-                    csr::CSR.pmpcfg0.modify(csr::pmpconfig::pmpcfg::a2::OFF);
-                    csr::CSR.pmpcfg0.modify(csr::pmpconfig::pmpcfg::l2::CLEAR);
+                    csr::CSR.pmpcfg0.modify(
+                        csr::pmpconfig::pmpcfg::r2::CLEAR
+                            + csr::pmpconfig::pmpcfg::w2::CLEAR
+                            + csr::pmpconfig::pmpcfg::x2::CLEAR
+                            + csr::pmpconfig::pmpcfg::a2::OFF
+                            + csr::pmpconfig::pmpcfg::l2::CLEAR,
+                    );
                     csr::CSR.pmpaddr2.set(0x0);
                 }
                 3 => {
-                    csr::CSR.pmpcfg0.modify(csr::pmpconfig::pmpcfg::r3::CLEAR);
-                    csr::CSR.pmpcfg0.modify(csr::pmpconfig::pmpcfg::w3::CLEAR);
-                    csr::CSR.pmpcfg0.modify(csr::pmpconfig::pmpcfg::x3::CLEAR);
-                    csr::CSR.pmpcfg0.modify(csr::pmpconfig::pmpcfg::a3::OFF);
-                    csr::CSR.pmpcfg0.modify(csr::pmpconfig::pmpcfg::l3::CLEAR);
+                    csr::CSR.pmpcfg0.modify(
+                        csr::pmpconfig::pmpcfg::r3::CLEAR
+                            + csr::pmpconfig::pmpcfg::w3::CLEAR
+                            + csr::pmpconfig::pmpcfg::x3::CLEAR
+                            + csr::pmpconfig::pmpcfg::a3::OFF
+                            + csr::pmpconfig::pmpcfg::l3::CLEAR,
+                    );
                     csr::CSR.pmpaddr3.set(0x0);
                 }
                 4 => {
-                    csr::CSR.pmpcfg1.modify(csr::pmpconfig::pmpcfg::r0::CLEAR);
-                    csr::CSR.pmpcfg1.modify(csr::pmpconfig::pmpcfg::w0::CLEAR);
-                    csr::CSR.pmpcfg1.modify(csr::pmpconfig::pmpcfg::x0::CLEAR);
-                    csr::CSR.pmpcfg1.modify(csr::pmpconfig::pmpcfg::a0::OFF);
-                    csr::CSR.pmpcfg1.modify(csr::pmpconfig::pmpcfg::l0::CLEAR);
+                    csr::CSR.pmpcfg1.modify(
+                        csr::pmpconfig::pmpcfg::r0::CLEAR
+                            + csr::pmpconfig::pmpcfg::w0::CLEAR
+                            + csr::pmpconfig::pmpcfg::x0::CLEAR
+                            + csr::pmpconfig::pmpcfg::a0::OFF
+                            + csr::pmpconfig::pmpcfg::l0::CLEAR,
+                    );
                     csr::CSR.pmpaddr4.set(0x0);
                 }
                 5 => {
-                    csr::CSR.pmpcfg1.modify(csr::pmpconfig::pmpcfg::r1::CLEAR);
-                    csr::CSR.pmpcfg1.modify(csr::pmpconfig::pmpcfg::w1::CLEAR);
-                    csr::CSR.pmpcfg1.modify(csr::pmpconfig::pmpcfg::x1::CLEAR);
-                    csr::CSR.pmpcfg1.modify(csr::pmpconfig::pmpcfg::a1::OFF);
-                    csr::CSR.pmpcfg1.modify(csr::pmpconfig::pmpcfg::l1::CLEAR);
+                    csr::CSR.pmpcfg1.modify(
+                        csr::pmpconfig::pmpcfg::r1::CLEAR
+                            + csr::pmpconfig::pmpcfg::w1::CLEAR
+                            + csr::pmpconfig::pmpcfg::x1::CLEAR
+                            + csr::pmpconfig::pmpcfg::a1::OFF
+                            + csr::pmpconfig::pmpcfg::l1::CLEAR,
+                    );
                     csr::CSR.pmpaddr5.set(0x0);
                 }
                 6 => {
-                    csr::CSR.pmpcfg1.modify(csr::pmpconfig::pmpcfg::r2::CLEAR);
-                    csr::CSR.pmpcfg1.modify(csr::pmpconfig::pmpcfg::w2::CLEAR);
-                    csr::CSR.pmpcfg1.modify(csr::pmpconfig::pmpcfg::x2::CLEAR);
-                    csr::CSR.pmpcfg1.modify(csr::pmpconfig::pmpcfg::a2::OFF);
-                    csr::CSR.pmpcfg1.modify(csr::pmpconfig::pmpcfg::l2::CLEAR);
+                    csr::CSR.pmpcfg1.modify(
+                        csr::pmpconfig::pmpcfg::r2::CLEAR
+                            + csr::pmpconfig::pmpcfg::w2::CLEAR
+                            + csr::pmpconfig::pmpcfg::x2::CLEAR
+                            + csr::pmpconfig::pmpcfg::a2::OFF
+                            + csr::pmpconfig::pmpcfg::l2::CLEAR,
+                    );
                     csr::CSR.pmpaddr6.set(0x0);
                 }
                 7 => {
-                    csr::CSR.pmpcfg1.modify(csr::pmpconfig::pmpcfg::r3::CLEAR);
-                    csr::CSR.pmpcfg1.modify(csr::pmpconfig::pmpcfg::w3::CLEAR);
-                    csr::CSR.pmpcfg1.modify(csr::pmpconfig::pmpcfg::x3::CLEAR);
-                    csr::CSR.pmpcfg1.modify(csr::pmpconfig::pmpcfg::a3::OFF);
-                    csr::CSR.pmpcfg1.modify(csr::pmpconfig::pmpcfg::l3::CLEAR);
+                    csr::CSR.pmpcfg1.modify(
+                        csr::pmpconfig::pmpcfg::r3::CLEAR
+                            + csr::pmpconfig::pmpcfg::w3::CLEAR
+                            + csr::pmpconfig::pmpcfg::x3::CLEAR
+                            + csr::pmpconfig::pmpcfg::a3::OFF
+                            + csr::pmpconfig::pmpcfg::l3::CLEAR,
+                    );
                     csr::CSR.pmpaddr7.set(0x0);
                 }
                 8 => {
-                    csr::CSR.pmpcfg2.modify(csr::pmpconfig::pmpcfg::r0::CLEAR);
-                    csr::CSR.pmpcfg2.modify(csr::pmpconfig::pmpcfg::w0::CLEAR);
-                    csr::CSR.pmpcfg2.modify(csr::pmpconfig::pmpcfg::x0::CLEAR);
-                    csr::CSR.pmpcfg2.modify(csr::pmpconfig::pmpcfg::a0::OFF);
-                    csr::CSR.pmpcfg2.modify(csr::pmpconfig::pmpcfg::l0::CLEAR);
+                    csr::CSR.pmpcfg2.modify(
+                        csr::pmpconfig::pmpcfg::r0::CLEAR
+                            + csr::pmpconfig::pmpcfg::w0::CLEAR
+                            + csr::pmpconfig::pmpcfg::x0::CLEAR
+                            + csr::pmpconfig::pmpcfg::a0::OFF
+                            + csr::pmpconfig::pmpcfg::l0::CLEAR,
+                    );
                     csr::CSR.pmpaddr8.set(0x0);
                 }
                 9 => {
-                    csr::CSR.pmpcfg2.modify(csr::pmpconfig::pmpcfg::r1::CLEAR);
-                    csr::CSR.pmpcfg2.modify(csr::pmpconfig::pmpcfg::w1::CLEAR);
-                    csr::CSR.pmpcfg2.modify(csr::pmpconfig::pmpcfg::x1::CLEAR);
-                    csr::CSR.pmpcfg2.modify(csr::pmpconfig::pmpcfg::a1::OFF);
-                    csr::CSR.pmpcfg2.modify(csr::pmpconfig::pmpcfg::l1::CLEAR);
+                    csr::CSR.pmpcfg2.modify(
+                        csr::pmpconfig::pmpcfg::r1::CLEAR
+                            + csr::pmpconfig::pmpcfg::w1::CLEAR
+                            + csr::pmpconfig::pmpcfg::x1::CLEAR
+                            + csr::pmpconfig::pmpcfg::a1::OFF
+                            + csr::pmpconfig::pmpcfg::l1::CLEAR,
+                    );
                     csr::CSR.pmpaddr9.set(0x0);
                 }
                 10 => {
-                    csr::CSR.pmpcfg2.modify(csr::pmpconfig::pmpcfg::r2::CLEAR);
-                    csr::CSR.pmpcfg2.modify(csr::pmpconfig::pmpcfg::w2::CLEAR);
-                    csr::CSR.pmpcfg2.modify(csr::pmpconfig::pmpcfg::x2::CLEAR);
-                    csr::CSR.pmpcfg2.modify(csr::pmpconfig::pmpcfg::a2::OFF);
-                    csr::CSR.pmpcfg2.modify(csr::pmpconfig::pmpcfg::l2::CLEAR);
+                    csr::CSR.pmpcfg2.modify(
+                        csr::pmpconfig::pmpcfg::r2::CLEAR
+                            + csr::pmpconfig::pmpcfg::w2::CLEAR
+                            + csr::pmpconfig::pmpcfg::x2::CLEAR
+                            + csr::pmpconfig::pmpcfg::a2::OFF
+                            + csr::pmpconfig::pmpcfg::l2::CLEAR,
+                    );
                     csr::CSR.pmpaddr10.set(0x0);
                 }
                 11 => {
-                    csr::CSR.pmpcfg2.modify(csr::pmpconfig::pmpcfg::r3::CLEAR);
-                    csr::CSR.pmpcfg2.modify(csr::pmpconfig::pmpcfg::w3::CLEAR);
-                    csr::CSR.pmpcfg2.modify(csr::pmpconfig::pmpcfg::x3::CLEAR);
-                    csr::CSR.pmpcfg2.modify(csr::pmpconfig::pmpcfg::a3::OFF);
-                    csr::CSR.pmpcfg2.modify(csr::pmpconfig::pmpcfg::l3::CLEAR);
+                    csr::CSR.pmpcfg2.modify(
+                        csr::pmpconfig::pmpcfg::r3::CLEAR
+                            + csr::pmpconfig::pmpcfg::w3::CLEAR
+                            + csr::pmpconfig::pmpcfg::x3::CLEAR
+                            + csr::pmpconfig::pmpcfg::a3::OFF
+                            + csr::pmpconfig::pmpcfg::l3::CLEAR,
+                    );
                     csr::CSR.pmpaddr11.set(0x0);
                 }
                 12 => {
-                    csr::CSR.pmpcfg3.modify(csr::pmpconfig::pmpcfg::r0::CLEAR);
-                    csr::CSR.pmpcfg3.modify(csr::pmpconfig::pmpcfg::w0::CLEAR);
-                    csr::CSR.pmpcfg3.modify(csr::pmpconfig::pmpcfg::x0::CLEAR);
-                    csr::CSR.pmpcfg3.modify(csr::pmpconfig::pmpcfg::a0::OFF);
-                    csr::CSR.pmpcfg3.modify(csr::pmpconfig::pmpcfg::l0::CLEAR);
+                    csr::CSR.pmpcfg3.modify(
+                        csr::pmpconfig::pmpcfg::r0::CLEAR
+                            + csr::pmpconfig::pmpcfg::w0::CLEAR
+                            + csr::pmpconfig::pmpcfg::x0::CLEAR
+                            + csr::pmpconfig::pmpcfg::a0::OFF
+                            + csr::pmpconfig::pmpcfg::l0::CLEAR,
+                    );
                     csr::CSR.pmpaddr12.set(0x0);
                 }
                 13 => {
-                    csr::CSR.pmpcfg3.modify(csr::pmpconfig::pmpcfg::r1::CLEAR);
-                    csr::CSR.pmpcfg3.modify(csr::pmpconfig::pmpcfg::w1::CLEAR);
-                    csr::CSR.pmpcfg3.modify(csr::pmpconfig::pmpcfg::x1::CLEAR);
-                    csr::CSR.pmpcfg3.modify(csr::pmpconfig::pmpcfg::a1::OFF);
-                    csr::CSR.pmpcfg3.modify(csr::pmpconfig::pmpcfg::l1::CLEAR);
+                    csr::CSR.pmpcfg3.modify(
+                        csr::pmpconfig::pmpcfg::r1::CLEAR
+                            + csr::pmpconfig::pmpcfg::w1::CLEAR
+                            + csr::pmpconfig::pmpcfg::x1::CLEAR
+                            + csr::pmpconfig::pmpcfg::a1::OFF
+                            + csr::pmpconfig::pmpcfg::l1::CLEAR,
+                    );
                     csr::CSR.pmpaddr13.set(0x0);
                 }
                 14 => {
-                    csr::CSR.pmpcfg3.modify(csr::pmpconfig::pmpcfg::r2::CLEAR);
-                    csr::CSR.pmpcfg3.modify(csr::pmpconfig::pmpcfg::w2::CLEAR);
-                    csr::CSR.pmpcfg3.modify(csr::pmpconfig::pmpcfg::x2::CLEAR);
-                    csr::CSR.pmpcfg3.modify(csr::pmpconfig::pmpcfg::a2::OFF);
-                    csr::CSR.pmpcfg3.modify(csr::pmpconfig::pmpcfg::l2::CLEAR);
+                    csr::CSR.pmpcfg3.modify(
+                        csr::pmpconfig::pmpcfg::r2::CLEAR
+                            + csr::pmpconfig::pmpcfg::w2::CLEAR
+                            + csr::pmpconfig::pmpcfg::x2::CLEAR
+                            + csr::pmpconfig::pmpcfg::a2::OFF
+                            + csr::pmpconfig::pmpcfg::l2::CLEAR,
+                    );
                     csr::CSR.pmpaddr14.set(0x0);
                 }
                 15 => {
-                    csr::CSR.pmpcfg3.modify(csr::pmpconfig::pmpcfg::r3::CLEAR);
-                    csr::CSR.pmpcfg3.modify(csr::pmpconfig::pmpcfg::w3::CLEAR);
-                    csr::CSR.pmpcfg3.modify(csr::pmpconfig::pmpcfg::x3::CLEAR);
-                    csr::CSR.pmpcfg3.modify(csr::pmpconfig::pmpcfg::a3::OFF);
-                    csr::CSR.pmpcfg3.modify(csr::pmpconfig::pmpcfg::l3::CLEAR);
+                    csr::CSR.pmpcfg3.modify(
+                        csr::pmpconfig::pmpcfg::r3::CLEAR
+                            + csr::pmpconfig::pmpcfg::w3::CLEAR
+                            + csr::pmpconfig::pmpcfg::x3::CLEAR
+                            + csr::pmpconfig::pmpcfg::a3::OFF
+                            + csr::pmpconfig::pmpcfg::l3::CLEAR,
+                    );
                     csr::CSR.pmpaddr15.set(0x0);
                 }
                 // spec 1.10 only goes to 15
@@ -476,10 +508,12 @@ impl kernel::mpu::MPU for PMPConfig {
                     match x {
                         0 => {
                             // Disable access up to the start address
-                            csr::CSR.pmpcfg0.modify(csr::pmpconfig::pmpcfg::r0::CLEAR);
-                            csr::CSR.pmpcfg0.modify(csr::pmpconfig::pmpcfg::w0::CLEAR);
-                            csr::CSR.pmpcfg0.modify(csr::pmpconfig::pmpcfg::x0::CLEAR);
-                            csr::CSR.pmpcfg0.modify(csr::pmpconfig::pmpcfg::a0::TOR);
+                            csr::CSR.pmpcfg0.modify(
+                                csr::pmpconfig::pmpcfg::r0::CLEAR
+                                    + csr::pmpconfig::pmpcfg::w0::CLEAR
+                                    + csr::pmpconfig::pmpcfg::x0::CLEAR
+                                    + csr::pmpconfig::pmpcfg::a0::TOR,
+                            );
                             csr::CSR.pmpaddr0.set((start as u32) >> 2);
 
                             // Set access to end address
@@ -488,10 +522,12 @@ impl kernel::mpu::MPU for PMPConfig {
                         }
                         1 => {
                             // Disable access up to the start address
-                            csr::CSR.pmpcfg0.modify(csr::pmpconfig::pmpcfg::r2::CLEAR);
-                            csr::CSR.pmpcfg0.modify(csr::pmpconfig::pmpcfg::w2::CLEAR);
-                            csr::CSR.pmpcfg0.modify(csr::pmpconfig::pmpcfg::x2::CLEAR);
-                            csr::CSR.pmpcfg0.modify(csr::pmpconfig::pmpcfg::a2::TOR);
+                            csr::CSR.pmpcfg0.modify(
+                                csr::pmpconfig::pmpcfg::r2::CLEAR
+                                    + csr::pmpconfig::pmpcfg::w2::CLEAR
+                                    + csr::pmpconfig::pmpcfg::x2::CLEAR
+                                    + csr::pmpconfig::pmpcfg::a2::TOR,
+                            );
                             csr::CSR.pmpaddr2.set((start as u32) >> 2);
 
                             // Set access to end address
@@ -500,10 +536,12 @@ impl kernel::mpu::MPU for PMPConfig {
                         }
                         2 => {
                             // Disable access up to the start address
-                            csr::CSR.pmpcfg1.modify(csr::pmpconfig::pmpcfg::r0::CLEAR);
-                            csr::CSR.pmpcfg1.modify(csr::pmpconfig::pmpcfg::w0::CLEAR);
-                            csr::CSR.pmpcfg1.modify(csr::pmpconfig::pmpcfg::x0::CLEAR);
-                            csr::CSR.pmpcfg1.modify(csr::pmpconfig::pmpcfg::a0::TOR);
+                            csr::CSR.pmpcfg1.modify(
+                                csr::pmpconfig::pmpcfg::r0::CLEAR
+                                    + csr::pmpconfig::pmpcfg::w0::CLEAR
+                                    + csr::pmpconfig::pmpcfg::x0::CLEAR
+                                    + csr::pmpconfig::pmpcfg::a0::TOR,
+                            );
                             csr::CSR.pmpaddr4.set((start as u32) >> 2);
 
                             // Set access to end address
@@ -512,10 +550,12 @@ impl kernel::mpu::MPU for PMPConfig {
                         }
                         3 => {
                             // Disable access up to the start address
-                            csr::CSR.pmpcfg1.modify(csr::pmpconfig::pmpcfg::r3::CLEAR);
-                            csr::CSR.pmpcfg1.modify(csr::pmpconfig::pmpcfg::w3::CLEAR);
-                            csr::CSR.pmpcfg1.modify(csr::pmpconfig::pmpcfg::x3::CLEAR);
-                            csr::CSR.pmpcfg1.modify(csr::pmpconfig::pmpcfg::a3::TOR);
+                            csr::CSR.pmpcfg1.modify(
+                                csr::pmpconfig::pmpcfg::r3::CLEAR
+                                    + csr::pmpconfig::pmpcfg::w3::CLEAR
+                                    + csr::pmpconfig::pmpcfg::x3::CLEAR
+                                    + csr::pmpconfig::pmpcfg::a3::TOR,
+                            );
                             csr::CSR.pmpaddr6.set((start as u32) >> 2);
 
                             // Set access to end address
@@ -524,10 +564,12 @@ impl kernel::mpu::MPU for PMPConfig {
                         }
                         4 => {
                             // Disable access up to the start address
-                            csr::CSR.pmpcfg2.modify(csr::pmpconfig::pmpcfg::r0::CLEAR);
-                            csr::CSR.pmpcfg2.modify(csr::pmpconfig::pmpcfg::w0::CLEAR);
-                            csr::CSR.pmpcfg2.modify(csr::pmpconfig::pmpcfg::x0::CLEAR);
-                            csr::CSR.pmpcfg2.modify(csr::pmpconfig::pmpcfg::a0::TOR);
+                            csr::CSR.pmpcfg2.modify(
+                                csr::pmpconfig::pmpcfg::r0::CLEAR
+                                    + csr::pmpconfig::pmpcfg::w0::CLEAR
+                                    + csr::pmpconfig::pmpcfg::x0::CLEAR
+                                    + csr::pmpconfig::pmpcfg::a0::TOR,
+                            );
                             csr::CSR.pmpaddr8.set((start as u32) >> 2);
 
                             // Set access to end address
@@ -536,10 +578,12 @@ impl kernel::mpu::MPU for PMPConfig {
                         }
                         5 => {
                             // Disable access up to the start address
-                            csr::CSR.pmpcfg2.modify(csr::pmpconfig::pmpcfg::r3::CLEAR);
-                            csr::CSR.pmpcfg2.modify(csr::pmpconfig::pmpcfg::w3::CLEAR);
-                            csr::CSR.pmpcfg2.modify(csr::pmpconfig::pmpcfg::x3::CLEAR);
-                            csr::CSR.pmpcfg2.modify(csr::pmpconfig::pmpcfg::a3::TOR);
+                            csr::CSR.pmpcfg2.modify(
+                                csr::pmpconfig::pmpcfg::r3::CLEAR
+                                    + csr::pmpconfig::pmpcfg::w3::CLEAR
+                                    + csr::pmpconfig::pmpcfg::x3::CLEAR
+                                    + csr::pmpconfig::pmpcfg::a3::TOR,
+                            );
                             csr::CSR.pmpaddr10.set((start as u32) >> 2);
 
                             // Set access to end address
@@ -548,10 +592,12 @@ impl kernel::mpu::MPU for PMPConfig {
                         }
                         6 => {
                             // Disable access up to the start address
-                            csr::CSR.pmpcfg3.modify(csr::pmpconfig::pmpcfg::r0::CLEAR);
-                            csr::CSR.pmpcfg3.modify(csr::pmpconfig::pmpcfg::w0::CLEAR);
-                            csr::CSR.pmpcfg3.modify(csr::pmpconfig::pmpcfg::x0::CLEAR);
-                            csr::CSR.pmpcfg3.modify(csr::pmpconfig::pmpcfg::a0::TOR);
+                            csr::CSR.pmpcfg3.modify(
+                                csr::pmpconfig::pmpcfg::r0::CLEAR
+                                    + csr::pmpconfig::pmpcfg::w0::CLEAR
+                                    + csr::pmpconfig::pmpcfg::x0::CLEAR
+                                    + csr::pmpconfig::pmpcfg::a0::TOR,
+                            );
                             csr::CSR.pmpaddr12.set((start as u32) >> 2);
 
                             // Set access to end address
@@ -560,10 +606,12 @@ impl kernel::mpu::MPU for PMPConfig {
                         }
                         7 => {
                             // Disable access up to the start address
-                            csr::CSR.pmpcfg3.modify(csr::pmpconfig::pmpcfg::r3::CLEAR);
-                            csr::CSR.pmpcfg3.modify(csr::pmpconfig::pmpcfg::w3::CLEAR);
-                            csr::CSR.pmpcfg3.modify(csr::pmpconfig::pmpcfg::x3::CLEAR);
-                            csr::CSR.pmpcfg3.modify(csr::pmpconfig::pmpcfg::a3::TOR);
+                            csr::CSR.pmpcfg3.modify(
+                                csr::pmpconfig::pmpcfg::r3::CLEAR
+                                    + csr::pmpconfig::pmpcfg::w3::CLEAR
+                                    + csr::pmpconfig::pmpcfg::x3::CLEAR
+                                    + csr::pmpconfig::pmpcfg::a3::TOR,
+                            );
                             csr::CSR.pmpaddr14.set((start as u32) >> 2);
 
                             // Set access to end address

--- a/boards/hifive1/README.md
+++ b/boards/hifive1/README.md
@@ -1,10 +1,10 @@
 SiFive HiFive1 RISC-V Board
 =================
 
-- https://www.sifive.com/boards/hifive1
+- https://www.sifive.com/boards/hifive1-rev-b
 
-Arduino-compatible dev board for RISC-V. This is the first release of this
-board ("Rev A01").
+Arduino-compatible dev board for RISC-V. This is the second release of this
+board ("Rev B").
 
 Programming
 -----------

--- a/chips/e310x/src/chip.rs
+++ b/chips/e310x/src/chip.rs
@@ -14,12 +14,14 @@ use crate::uart;
 
 pub struct E310x {
     userspace_kernel_boundary: rv32i::syscall::SysCall,
+    pmp: rv32i::pmp::PMPConfig,
 }
 
 impl E310x {
     pub unsafe fn new() -> E310x {
         E310x {
             userspace_kernel_boundary: rv32i::syscall::SysCall::new(),
+            pmp: rv32i::pmp::PMPConfig::new(8),
         }
     }
 
@@ -31,12 +33,12 @@ impl E310x {
 }
 
 impl kernel::Chip for E310x {
-    type MPU = ();
+    type MPU = rv32i::pmp::PMPConfig;
     type UserspaceKernelBoundary = rv32i::syscall::SysCall;
     type SysTick = ();
 
     fn mpu(&self) -> &Self::MPU {
-        &()
+        &self.pmp
     }
 
     fn systick(&self) -> &Self::SysTick {


### PR DESCRIPTION
### Pull Request Overview

This PR reduces the number of instructions to enable/disable the PMP. It does this by looping over less registers when disabling PMP and by consolidating the read/write instructions to a single operation.

This PR then converts the HiFive1 board to the rev B board and enables PMP on this board.

### Testing Strategy

Tested by running Tock on QEMU for OpenTitan and HiFive1.

### TODO or Help Wanted

It would be good to run this on a rev B HiFive1 board.

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make formatall`.
