### PR TITLE
Run CI on Github Actions

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,35 @@
+# This workflow calculates size diffs for the compiled binary of each supported tock board
+
+name: Benchmarks
+
+# Controls when the action will run. Triggers the workflow on pull request
+# events but only for the master branch
+on:
+  pull_request:
+    branches: master
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+# If you add additional jobs, remember to add them to bors.toml
+jobs:
+  benchmarks:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1 # pulls version from rust-toolchain file
+        with:
+          components: rustfmt, clippy
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          pip install --user cxxfilt
+          sudo apt install llvm
+      - name: size report
+        run: |
+          ./tools/github_actions_size_changes.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ on:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 # If you add additional jobs, remember to add them to bors.toml
 jobs:
-  format:
+  ci-format:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
@@ -25,25 +25,25 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           components: rustfmt, clippy
-      - name: rustfmt
+      - name: ci-formatting
         run: make ci-formatting
-      - name: docs
+      - name: ci-documentation
         run: |
           npm install -g markdown-toc
           make ci-documentation
 
-  build:
+  ci-build:
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
 
-      - name: syntax
+      - name: ci-syntax
         run: make ci-syntax
-      - name: compilation
+      - name: ci-compilation
         run: make ci-compilation
-      - name: debug-support-targets
+      - name: ci-debug-support-targets
         run: make ci-debug-support-targets
 
       - name: collect-build-artifacts
@@ -54,15 +54,15 @@ jobs:
           name: build-artifacts
           path: ci-artifacts
 
-  tests:
+  ci-tests:
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
-      - name: cargo tests
+      - name: ci-cargo-tests
         run: make ci-cargo-tests
-      - name: tool tests
+      - name: ci-tools
         run: |
           sudo apt install libusb-1.0-0-dev
           make ci-tools

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,11 +61,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
       - name: cargo tests
-        run: |
-          make ci-libraries
-          make ci-archs
-          make ci-kernel
-          make ci-chips
+        run: make ci-cargo-tests
       - name: tool tests
         run: |
           sudo apt install libusb-1.0-0-dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,3 +66,12 @@ jobs:
         run: |
           sudo apt install libusb-1.0-0-dev
           make ci-tools
+
+  emulation-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+      - name: qemu tests
+        run: make emulation-check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,72 @@
+# This workflow contains all tock-ci, seperated into jobs
+
+name: tock-ci
+env:
+  TERM: xterm # Makes tput work in actions output
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+    branches-ignore: [ staging.tmp, trying.tmp ] # Run CI for all branches except bors tmp branches
+  pull_request: # Run CI for PRs on any branch
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+# If you add additional jobs, remember to add them to bors.toml
+jobs:
+  format:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1 # pulls version from rust-toolchain file
+      - uses: actions/setup-node@v1
+        with:
+          components: rustfmt, clippy
+      - name: rustfmt
+        run: make ci-formatting
+      - name: docs
+        run: |
+          npm install -g markdown-toc
+          make ci-documentation
+
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+
+      - name: syntax
+        run: make ci-syntax
+      - name: compilation
+        run: make ci-compilation
+      - name: debug-support-targets
+        run: make ci-debug-support-targets
+
+      - name: collect-build-artifacts
+        run: make ci-collect-artifacts
+      - name: upload-build-artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: build-artifacts
+          path: ci-artifacts
+
+  tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+      - name: cargo tests
+        run: |
+          make ci-libraries
+          make ci-archs
+          make ci-kernel
+          make ci-chips
+      - name: tool tests
+        run: |
+          sudo apt install libusb-1.0-0-dev
+          make ci-tools

--- a/Makefile
+++ b/Makefile
@@ -210,6 +210,7 @@ clean:
 	@echo "$$(tput bold)Clean top-level Cargo workspace" && cargo clean
 	@for f in `./tools/list_tools.sh`; do echo "$$(tput bold)Clean tools/$$f"; cargo clean --manifest-path "tools/$$f/Cargo.toml" || exit 1; done
 	@echo "$$(tput bold)Clean rustdoc" && rm -Rf doc/rustdoc
+	@echo "$$(tput bold)Clean ci-artifacts" && rm -Rf ./ci-artifacts
 
 .PHONY: fmt format formatall
 fmt format formatall:
@@ -226,3 +227,9 @@ list list-boards list-platforms:
 	@echo "    cd boards/hail"
 	@echo "    make"
 
+.PHONY: ci-collect-artifacts
+ci-collect-artifacts:
+	@test -d ./target || (echo "Target directory not found! Build some boards first to have their artifacts collected"; exit 1)
+	@mkdir -p ./ci-artifacts
+	@rm -rf "./ci-artifacts/*"
+	@for f in $$(find ./target -iname '*.bin' | grep -E "release/.*\.bin"); do mkdir -p "ci-artifacts/$$(dirname $$f)"; cp "$$f" "ci-artifacts/$$f"; done

--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,12 @@ ci-netlify:\
 	@printf "$$(tput bold)* CI-Netlify: Done! *$$(tput sgr0)\n"
 	@printf "$$(tput bold)*********************$$(tput sgr0)\n"
 
+.PHONY: ci-cargo-tests
+ci-cargo-tests:\
+	ci-libraries\
+	ci-archs\
+	ci-kernel\
+	ci-chips\
 
 ## Actual Rules (Travis)
 

--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,22 @@ ci-cargo-tests:\
 	ci-kernel\
 	ci-chips\
 
+.PHONY: ci-format
+ci-format:\
+	ci-formatting\
+	ci-documentation\
+
+.PHONY: ci-build
+ci-build:\
+	ci-syntax\
+	ci-compilation\
+	ci-debug-support-targets\
+
+.PHONY: ci-tests
+ci-tests:\
+	ci-cargo-tests\
+	ci-tools\
+
 ## Actual Rules (Travis)
 
 .PHONY: ci-formatting

--- a/bors.toml
+++ b/bors.toml
@@ -2,7 +2,7 @@
 # pushed to master.
 status = [
   "continuous-integration/travis-ci/push",
-  "ci-format", "ci-build", "ci-test", "emulation-check"
+  "ci-format", "ci-build", "ci-tests", "emulation-check"
 ]
 
 # List of PR labels that may not be attached to a PR when it is r+-ed.

--- a/bors.toml
+++ b/bors.toml
@@ -2,6 +2,7 @@
 # pushed to master.
 status = [
   "continuous-integration/travis-ci/push",
+  "format", "build", "test"
 ]
 
 # List of PR labels that may not be attached to a PR when it is r+-ed.

--- a/bors.toml
+++ b/bors.toml
@@ -2,7 +2,7 @@
 # pushed to master.
 status = [
   "continuous-integration/travis-ci/push",
-  "ci-format", "ci-build", "ci-test"
+  "ci-format", "ci-build", "ci-test", "emulation-check"
 ]
 
 # List of PR labels that may not be attached to a PR when it is r+-ed.

--- a/bors.toml
+++ b/bors.toml
@@ -2,7 +2,7 @@
 # pushed to master.
 status = [
   "continuous-integration/travis-ci/push",
-  "format", "build", "test"
+  "ci-format", "ci-build", "ci-test"
 ]
 
 # List of PR labels that may not be attached to a PR when it is r+-ed.

--- a/tools/github_actions_size_changes.sh
+++ b/tools/github_actions_size_changes.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+# Post github check indicating how a PR affects flash and RAM use for different boards.
+# This script is run by Github actions after successful PR builds. It reports resource differences between
+# the target branch before and after merging in the PR.
+# This script only reports updates for boards whose size have changed as a result of the PR being
+# tested, and does not currently support analyzing size differences in RISC-V boards.
+
+set -e
+
+# Bench the current commit that was pushed. Requires navigating back to build directory
+make allboards > /dev/null 2>&1
+for elf in $(find . -maxdepth 8 | grep 'release' | egrep '\.elf$' | grep -v 'riscv'); do
+    tmp=${elf#*release/}
+    b=${tmp%.elf}
+    ./tools/print_tock_memory_usage.py -s ${elf} > current-benchmark-${b}
+done
+
+git remote set-branches origin ${GITHUB_BASE_REF}  > /dev/null 2>&1
+git fetch --depth 1 origin ${GITHUB_BASE_REF} > /dev/null 2>&1
+git checkout ${GITHUB_BASE_REF} > /dev/null 2>&1
+make allboards > /dev/null 2>&1
+
+# Find elfs compiled for release (for use in analyzing binaries in CI),
+# ignore riscv binaries for now because size tool does not support RISC-V
+for elf in $(find . -maxdepth 8 | grep 'release' | egrep '\.elf$' | grep -v 'riscv'); do
+    tmp=${elf#*release/}
+    b=${tmp%.elf}
+    ./tools/print_tock_memory_usage.py -s ${elf} > previous-benchmark-${b}
+done
+
+# now calculate diff for each board, and post status to github for each non-0 diff
+for elf in $(find . -maxdepth 8 | grep 'release' | egrep '\.elf$' | grep -v 'riscv'); do
+    tmp=${elf#*release/}
+    b=${tmp%.elf}
+    # Compute a summary suitable for GitHub.
+    ./tools/diff_memory_usage.py previous-benchmark-${b} current-benchmark-${b} size-diffs-${b}.txt ${b}
+    if [ -s "size-diffs-${b}.txt" ]; then
+        RES="$( grep -hs ^ size-diffs-${b}.txt )" #grep instead of cat to prevent errors on no match
+        echo "${b}: ${RES}"
+    fi
+    # Print a detailed by raw line-by-line diff. Can be useful to
+    # understand where the size differences come from.
+    git diff --no-index previous-benchmark-${b} current-benchmark-${b} || true #Supress exit code
+done

--- a/tools/github_actions_size_changes.sh
+++ b/tools/github_actions_size_changes.sh
@@ -6,6 +6,9 @@
 # This script only reports updates for boards whose size have changed as a result of the PR being
 # tested, and does not currently support analyzing size differences in RISC-V boards.
 
+UPSTREAM_REMOTE_NAME="${UPSTREAM_REMOTE_NAME:-origin}"
+GITHUB_BASE_REF="${GITHUB_BASE_REF:-master}"
+
 set -e
 
 # Bench the current commit that was pushed. Requires navigating back to build directory
@@ -16,9 +19,9 @@ for elf in $(find . -maxdepth 8 | grep 'release' | egrep '\.elf$' | grep -v 'ris
     ./tools/print_tock_memory_usage.py -s ${elf} > current-benchmark-${b}
 done
 
-git remote set-branches origin ${GITHUB_BASE_REF}  > /dev/null 2>&1
-git fetch --depth 1 origin ${GITHUB_BASE_REF} > /dev/null 2>&1
-git checkout ${GITHUB_BASE_REF} > /dev/null 2>&1
+git remote set-branches "$UPSTREAM_REMOTE_NAME" "$GITHUB_BASE_REF"  > /dev/null 2>&1
+git fetch --depth 1 "$UPSTREAM_REMOTE_NAME" "$GITHUB_BASE_REF" > /dev/null 2>&1
+git checkout "$UPSTREAM_REMOTE_NAME"/"$GITHUB_BASE_REF" > /dev/null 2>&1
 make allboards > /dev/null 2>&1
 
 # Find elfs compiled for release (for use in analyzing binaries in CI),
@@ -29,6 +32,8 @@ for elf in $(find . -maxdepth 8 | grep 'release' | egrep '\.elf$' | grep -v 'ris
     ./tools/print_tock_memory_usage.py -s ${elf} > previous-benchmark-${b}
 done
 
+DIFF_DETECTED=0
+
 # now calculate diff for each board, and post status to github for each non-0 diff
 for elf in $(find . -maxdepth 8 | grep 'release' | egrep '\.elf$' | grep -v 'riscv'); do
     tmp=${elf#*release/}
@@ -36,6 +41,7 @@ for elf in $(find . -maxdepth 8 | grep 'release' | egrep '\.elf$' | grep -v 'ris
     # Compute a summary suitable for GitHub.
     ./tools/diff_memory_usage.py previous-benchmark-${b} current-benchmark-${b} size-diffs-${b}.txt ${b}
     if [ -s "size-diffs-${b}.txt" ]; then
+	DIFF_DETECTED=1
         RES="$( grep -hs ^ size-diffs-${b}.txt )" #grep instead of cat to prevent errors on no match
         echo "${b}: ${RES}"
     fi
@@ -43,3 +49,7 @@ for elf in $(find . -maxdepth 8 | grep 'release' | egrep '\.elf$' | grep -v 'ris
     # understand where the size differences come from.
     git diff --no-index previous-benchmark-${b} current-benchmark-${b} || true #Supress exit code
 done
+
+if [ $DIFF_DETECTED -eq 0 ]; then
+    echo "-> No size difference on any board detected"
+fi


### PR DESCRIPTION
### Pull Request Overview

This pull request adds Github Actions based CI to Tock. For now, Github Actions would run in parallel with Travis until we are comfortable that actions is not missing anything that Travis catches.
It also replicates the size reporting script by adding a github check that contains the size diffs. It also saves artifacts on every build that store successfully built .bin files for each board, so that the exact kernel executable produced for each build can be easily obtained and flashed without requiring one to fetch the branch and recompile.

Notably, we split the CI into several logically separate jobs so that they can run in parallel. This does mean that more checks show up at the bottom of each PR.

The total time to run the github actions based CI is about 4 minutes!

### Testing Strategy

This pull request was tested by forking into another organization and running CI on various branches.

We tested integration with bors on this fork as well, but for now this PR does not configure Bors to block on Github actions checks.

### TODO or Help Wanted

N/A

### Documentation Updated

- [x] Probably no need to update docs until we move to an exclusively github actions based workflow.

### Formatting

- [x] Ran `make formatall`.