### PR TITLE
travis: remove deprecated `sudo` key

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: rust
 
 addons:


### PR DESCRIPTION
### Pull Request Overview

Just noticed this on travis:
<img width="460" alt="image" src="https://user-images.githubusercontent.com/339422/80968404-e3f91300-8de5-11ea-81e9-837e651c5b35.png">

Figure we might as well remove it.

### Testing Strategy

You're looking at it :).

### TODO or Help Wanted

N/A

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make formatall`.
