### PR TITLE
kernel: configure MPU only if switching to a different process

### DIFF
--- a/arch/cortex-m3/src/mpu.rs
+++ b/arch/cortex-m3/src/mpu.rs
@@ -8,6 +8,7 @@ use kernel::common::math;
 use kernel::common::registers::{register_bitfields, FieldValue, ReadOnly, ReadWrite};
 use kernel::common::StaticRef;
 use kernel::mpu;
+use kernel::AppId;
 
 /// MPU Registers for the Cortex-M3 and Cortex-M4 families
 /// Described in section 4.5 of
@@ -649,7 +650,7 @@ impl kernel::mpu::MPU for MPU {
         Ok(())
     }
 
-    fn configure_mpu(&self, config: &Self::MpuConfig) {
+    fn configure_mpu(&self, config: &Self::MpuConfig, _app_id: &AppId) {
         let regs = &*self.0;
 
         // Set MPU regions

--- a/kernel/src/platform/mpu.rs
+++ b/kernel/src/platform/mpu.rs
@@ -1,5 +1,6 @@
 //! Interface for configuring the Memory Protection Unit.
 
+use crate::callback::AppId;
 use core::cmp;
 use core::fmt::{self, Display};
 
@@ -248,9 +249,10 @@ pub trait MPU {
     ///
     /// # Arguments
     ///
-    /// - `config: MPU region configuration
+    /// - `config`: MPU region configuration
+    /// - `app_id`: AppId of the process that the MPU is configured for
     #[allow(unused_variables)]
-    fn configure_mpu(&self, config: &Self::MpuConfig) {}
+    fn configure_mpu(&self, config: &Self::MpuConfig, app_id: &AppId) {}
 }
 
 /// Implement default MPU trait for unit.

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -942,7 +942,7 @@ impl<C: Chip> ProcessType for Process<'a, C> {
 
     fn setup_mpu(&self) {
         self.mpu_config.map(|config| {
-            self.chip.mpu().configure_mpu(&config);
+            self.chip.mpu().configure_mpu(&config, &self.appid());
         });
     }
 
@@ -1009,7 +1009,7 @@ impl<C: Chip> ProcessType for Process<'a, C> {
                 } else {
                     let old_break = self.app_break.get();
                     self.app_break.set(new_break);
-                    self.chip.mpu().configure_mpu(&config);
+                    self.chip.mpu().configure_mpu(&config, &self.appid());
                     Ok(old_break)
                 }
             })

--- a/libraries/tock-cells/src/lib.rs
+++ b/libraries/tock-cells/src/lib.rs
@@ -1,6 +1,13 @@
 //! Tock Cell types.
 
 #![feature(const_fn)]
+// Feature used to opt-in the new `core::Option::contains()` API.
+//
+// This feature can be removed if needed by manually reimplementing the
+// `contains` logic for `Option`.
+//
+// Tock expects this feature to stabilize in the near future.
+// Tracking: https://github.com/rust-lang/rust/issues/62358
 #![feature(option_result_contains)]
 #![no_std]
 

--- a/libraries/tock-cells/src/lib.rs
+++ b/libraries/tock-cells/src/lib.rs
@@ -1,6 +1,7 @@
 //! Tock Cell types.
 
 #![feature(const_fn)]
+#![feature(option_result_contains)]
 #![no_std]
 
 pub mod map_cell;

--- a/libraries/tock-cells/src/optional_cell.rs
+++ b/libraries/tock-cells/src/optional_cell.rs
@@ -63,6 +63,14 @@ impl<T: Copy> OptionalCell<T> {
         self.value.get().is_none()
     }
 
+    /// Returns true if the option is a Some value containing the given value.
+    pub fn contains(&self, x: &T) -> bool
+    where
+        T: PartialEq,
+    {
+        self.value.get().contains(x)
+    }
+
     /// Returns the contained value or panics if contents is `None`.
     pub fn expect(&self, msg: &str) -> T {
         self.value.get().expect(msg)


### PR DESCRIPTION
### Pull Request Overview

Currently, the scheduler configures the MPU every time when it switches
to a process. This change aims to improve syscall latency by caching the
last running process and configuring the MPU only when switching to a
different process.

See also: #1730.

### Testing Strategy

I ran a simple `libtock-rs` application for measuring syscall latency with
and without this change on opentitan on verilator. This change reduces the
latency of a command syscall by ~~2751~~ 1711 cycles (the exact number of cycles
saved obviously depends on the actual implementation, e.g. would probably
be less after #1821).

Also ran `make allcheck`.

### TODO or Help Wanted

I couldn't find any doc files or tests that should be updated. Since
this is my first real Tock PR, it would be great if you could point me
in the right direction if I missed anything.

### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make formatall`.