### PR TITLE
Fix Tock register interface to allow large unsigned values as bitmasks

### DIFF
--- a/chips/nrf52/src/ficr.rs
+++ b/chips/nrf52/src/ficr.rs
@@ -135,7 +135,6 @@ register_bitfields! [u32,
             /// nRF52840
             N52840 = 0x52840,
             /// Unspecified
-            #[allow(overflowing_literals)]
             Unspecified = 0xffffffff
         ]
     ],
@@ -174,7 +173,6 @@ register_bitfields! [u32,
             /// CAAA
             CAAA = 0x43414141,
             /// Unspecified
-            #[allow(overflowing_literals)]
             Unspecified = 0xffffffff
         ]
     ],
@@ -193,7 +191,6 @@ register_bitfields! [u32,
             /// CKxx - 7x8 WLCSP 56 balls with backside coating for light protection
             CK = 0x2005,
             /// Unspecified
-            #[allow(overflowing_literals)]
             Unspecified = 0xffffffff
         ]
     ],
@@ -210,7 +207,6 @@ register_bitfields! [u32,
             K128 = 0x80,
             /// 256 kByte RAM
             K256 = 0x100,
-            #[allow(overflowing_literals)]
             Unspecified = 0xffffffff
 
         ]
@@ -229,7 +225,6 @@ register_bitfields! [u32,
             /// 2048 kByte FLASH
             K2048 = 0x800,
             /// Unspecified
-            #[allow(overflowing_literals)]
             Unspecified = 0xffffffff
         ]
     ]

--- a/libraries/tock-register-interface/CHANGELOG.md
+++ b/libraries/tock-register-interface/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## master
+## v0.6
 
+ - #1823: Allow large unsigned values as bitmasks + add bitmask! helper macro
  - #1554: Allow lifetime parameters for `register_structs! { Foo<'a> { ..`
  - #1661: Add `Aliased` register type for MMIO with differing R/W behavior
 

--- a/libraries/tock-register-interface/CHANGELOG.md
+++ b/libraries/tock-register-interface/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.6
+## master
 
  - #1823: Allow large unsigned values as bitmasks + add bitmask! helper macro
  - #1554: Allow lifetime parameters for `register_structs! { Foo<'a> { ..`

--- a/libraries/tock-register-interface/Cargo.toml
+++ b/libraries/tock-register-interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tock-registers"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
 description = "Memory-Mapped I/O and register interface developed for Tock."
 homepage = "https://www.tockos.org/"

--- a/libraries/tock-register-interface/Cargo.toml
+++ b/libraries/tock-register-interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tock-registers"
-version = "0.6.0"
+version = "0.5.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
 description = "Memory-Mapped I/O and register interface developed for Tock."
 homepage = "https://www.tockos.org/"

--- a/libraries/tock-register-interface/src/macros.rs
+++ b/libraries/tock-register-interface/src/macros.rs
@@ -127,8 +127,8 @@ macro_rules! register_bitmasks {
     {
         $valtype:ident, $reg_desc:ident, $(#[$outer:meta])* $field:ident,
                     $offset:expr, $numbits:expr,
-                    [$( $(#[$inner:meta])* $valname:ident = $value:expr ),*]
-    } => { //same pattern as previous match arm, except allows for 0 elements in array. Required because [repr(usize)] cannot be used for zero-variant enums.
+                    []
+    } => { //same pattern as previous match arm, for 0 elements in array. Removes code associated with array.
         #[allow(non_upper_case_globals)]
         #[allow(unused)]
         pub const $field: Field<$valtype, $reg_desc> =
@@ -141,15 +141,6 @@ macro_rules! register_bitmasks {
             #[allow(unused_imports)]
             use $crate::registers::{FieldValue, TryFromValue};
             use super::$reg_desc;
-
-            $(
-            #[allow(non_upper_case_globals)]
-            #[allow(unused)]
-            $(#[$inner])*
-            pub const $valname: FieldValue<$valtype, $reg_desc> =
-                FieldValue::<$valtype, $reg_desc>::new($crate::bitmask!($numbits),
-                    $offset, $value);
-            )*
 
             #[allow(non_upper_case_globals)]
             #[allow(unused)]
@@ -166,25 +157,13 @@ macro_rules! register_bitmasks {
             #[allow(dead_code)]
             #[allow(non_camel_case_types)]
             $(#[$outer])*
-            pub enum Value {
-                $(
-                    $(#[$inner])*
-                    $valname = $value,
-                )*
-            }
+            pub enum Value {}
 
             impl TryFromValue<$valtype> for Value {
                 type EnumType = Value;
 
-                fn try_from(v: $valtype) -> Option<Self::EnumType> {
-                    match v {
-                        $(
-                            $(#[$inner])*
-                            x if x == Value::$valname as $valtype => Some(Value::$valname),
-                        )*
-
-                        _ => Option::None
-                    }
+                fn try_from(_v: $valtype) -> Option<Self::EnumType> {
+                    Option::None
                 }
             }
         }

--- a/libraries/tock-register-interface/src/macros.rs
+++ b/libraries/tock-register-interface/src/macros.rs
@@ -6,7 +6,7 @@ macro_rules! register_bitmasks {
     {
         // BITFIELD_NAME OFFSET(x)
         $(#[$outer:meta])*
-        $valtype:ty, $reg_desc:ident, [
+        $valtype:ident, $reg_desc:ident, [
             $( $(#[$inner:meta])* $field:ident OFFSET($offset:expr)),+
         ]
     } => {
@@ -17,7 +17,7 @@ macro_rules! register_bitmasks {
         // BITFIELD_NAME OFFSET
         // All fields are 1 bit
         $(#[$outer:meta])*
-        $valtype:ty, $reg_desc:ident, [
+        $valtype:ident, $reg_desc:ident, [
             $( $(#[$inner:meta])* $field:ident $offset:expr ),+
         ]
     } => {
@@ -28,7 +28,7 @@ macro_rules! register_bitmasks {
     {
         // BITFIELD_NAME OFFSET(x) NUMBITS(y)
         $(#[$outer:meta])*
-        $valtype:ty, $reg_desc:ident, [
+        $valtype:ident, $reg_desc:ident, [
             $( $(#[$inner:meta])* $field:ident OFFSET($offset:expr) NUMBITS($numbits:expr) ),+
         ]
     } => {
@@ -39,7 +39,7 @@ macro_rules! register_bitmasks {
     {
         // BITFIELD_NAME OFFSET(x) NUMBITS(y) []
         $(#[$outer:meta])*
-        $valtype:ty, $reg_desc:ident, [
+        $valtype:ident, $reg_desc:ident, [
             $( $(#[$inner:meta])* $field:ident OFFSET($offset:expr) NUMBITS($numbits:expr)
                $values:tt ),+
         ]
@@ -49,7 +49,7 @@ macro_rules! register_bitmasks {
                               $values); )*
     };
     {
-        $valtype:ty, $reg_desc:ident, $(#[$outer:meta])* $field:ident,
+        $valtype:ident, $reg_desc:ident, $(#[$outer:meta])* $field:ident,
                     $offset:expr, $numbits:expr,
                     [$( $(#[$inner:meta])* $valname:ident = $value:expr ),+]
     } => { // this match arm is duplicated below with an allowance for 0 elements in the valname -> value array,
@@ -91,7 +91,7 @@ macro_rules! register_bitmasks {
 
             #[allow(dead_code)]
             #[allow(non_camel_case_types)]
-            #[repr(u64)] // use repr(u64) so that any value supported by the interface can be stored
+            #[repr($valtype)] // so that values larger than isize::MAX can be stored
             $(#[$outer])*
             pub enum Value {
                 $(
@@ -117,7 +117,7 @@ macro_rules! register_bitmasks {
         }
     };
     {
-        $valtype:ty, $reg_desc:ident, $(#[$outer:meta])* $field:ident,
+        $valtype:ident, $reg_desc:ident, $(#[$outer:meta])* $field:ident,
                     $offset:expr, $numbits:expr,
                     [$( $(#[$inner:meta])* $valname:ident = $value:expr ),*]
     } => { //same pattern as previous match arm, except allows for 0 elements in array. Required because [repr(usize)] cannot be used for zero-variant enums.
@@ -187,7 +187,7 @@ macro_rules! register_bitmasks {
 #[macro_export]
 macro_rules! register_bitfields {
     {
-        $valtype:ty, $( $(#[$inner:meta])* $vis:vis $reg:ident $fields:tt ),*
+        $valtype:ident, $( $(#[$inner:meta])* $vis:vis $reg:ident $fields:tt ),*
     } => {
         $(
             #[allow(non_snake_case)]

--- a/libraries/tock-register-interface/src/macros.rs
+++ b/libraries/tock-register-interface/src/macros.rs
@@ -52,7 +52,9 @@ macro_rules! register_bitmasks {
         $valtype:ty, $reg_desc:ident, $(#[$outer:meta])* $field:ident,
                     $offset:expr, $numbits:expr,
                     [$( $(#[$inner:meta])* $valname:ident = $value:expr ),+]
-    } => {
+    } => { // this match arm is duplicated below with an allowance for 0 elements in the valname -> value array,
+        // to seperately support the case of zero-variant enums not supporting non-default
+        // representations.
         #[allow(non_upper_case_globals)]
         #[allow(unused)]
         pub const $field: Field<$valtype, $reg_desc> =
@@ -89,7 +91,7 @@ macro_rules! register_bitmasks {
 
             #[allow(dead_code)]
             #[allow(non_camel_case_types)]
-            #[repr(usize)] //use repr(usize) so that unsigned literals larger than max isize can be stored
+            #[repr(u64)] // use repr(u64) so that any value supported by the interface can be stored
             $(#[$outer])*
             pub enum Value {
                 $(

--- a/libraries/tock-register-interface/src/macros.rs
+++ b/libraries/tock-register-interface/src/macros.rs
@@ -1,5 +1,13 @@
 //! Macros for cleanly defining peripheral registers.
 
+/// Helper macro for computing bitmask of variable number of bits
+#[macro_export]
+macro_rules! bitmask {
+    ($numbits:expr) => {
+        (1 << ($numbits - 1)) + ((1 << ($numbits - 1)) - 1)
+    };
+}
+
 /// Helper macro for defining register fields.
 #[macro_export]
 macro_rules! register_bitmasks {
@@ -58,7 +66,7 @@ macro_rules! register_bitmasks {
         #[allow(non_upper_case_globals)]
         #[allow(unused)]
         pub const $field: Field<$valtype, $reg_desc> =
-            Field::<$valtype, $reg_desc>::new((1<<($numbits-1))+((1<<($numbits-1))-1), $offset);
+            Field::<$valtype, $reg_desc>::new($crate::bitmask!($numbits), $offset);
 
         #[allow(non_snake_case)]
         #[allow(unused)]
@@ -73,20 +81,20 @@ macro_rules! register_bitmasks {
             #[allow(unused)]
             $(#[$inner])*
             pub const $valname: FieldValue<$valtype, $reg_desc> =
-                FieldValue::<$valtype, $reg_desc>::new((1<<($numbits-1))+((1<<($numbits-1))-1),
+                FieldValue::<$valtype, $reg_desc>::new($crate::bitmask!($numbits),
                     $offset, $value);
             )*
 
             #[allow(non_upper_case_globals)]
             #[allow(unused)]
             pub const SET: FieldValue<$valtype, $reg_desc> =
-                FieldValue::<$valtype, $reg_desc>::new((1<<($numbits-1))+((1<<($numbits-1))-1),
-                    $offset, (1<<($numbits-1))+((1<<($numbits-1))-1));
+                FieldValue::<$valtype, $reg_desc>::new($crate::bitmask!($numbits),
+                    $offset, $crate::bitmask!($numbits));
 
             #[allow(non_upper_case_globals)]
             #[allow(unused)]
             pub const CLEAR: FieldValue<$valtype, $reg_desc> =
-                FieldValue::<$valtype, $reg_desc>::new((1<<($numbits-1))+((1<<($numbits-1))-1),
+                FieldValue::<$valtype, $reg_desc>::new($crate::bitmask!($numbits),
                     $offset, 0);
 
             #[allow(dead_code)]
@@ -124,7 +132,7 @@ macro_rules! register_bitmasks {
         #[allow(non_upper_case_globals)]
         #[allow(unused)]
         pub const $field: Field<$valtype, $reg_desc> =
-            Field::<$valtype, $reg_desc>::new((1<<($numbits-1))+((1<<($numbits-1))-1), $offset);
+            Field::<$valtype, $reg_desc>::new($crate::bitmask!($numbits), $offset);
 
         #[allow(non_snake_case)]
         #[allow(unused)]
@@ -139,20 +147,20 @@ macro_rules! register_bitmasks {
             #[allow(unused)]
             $(#[$inner])*
             pub const $valname: FieldValue<$valtype, $reg_desc> =
-                FieldValue::<$valtype, $reg_desc>::new((1<<($numbits-1))+((1<<($numbits-1))-1),
+                FieldValue::<$valtype, $reg_desc>::new($crate::bitmask!($numbits),
                     $offset, $value);
             )*
 
             #[allow(non_upper_case_globals)]
             #[allow(unused)]
             pub const SET: FieldValue<$valtype, $reg_desc> =
-                FieldValue::<$valtype, $reg_desc>::new((1<<($numbits-1))+((1<<($numbits-1))-1),
-                    $offset, (1<<($numbits-1))+((1<<($numbits-1))-1));
+                FieldValue::<$valtype, $reg_desc>::new($crate::bitmask!($numbits),
+                    $offset, $crate::bitmask!($numbits));
 
             #[allow(non_upper_case_globals)]
             #[allow(unused)]
             pub const CLEAR: FieldValue<$valtype, $reg_desc> =
-                FieldValue::<$valtype, $reg_desc>::new((1<<($numbits-1))+((1<<($numbits-1))-1),
+                FieldValue::<$valtype, $reg_desc>::new($crate::bitmask!($numbits),
                     $offset, 0);
 
             #[allow(dead_code)]


### PR DESCRIPTION
### Pull Request Overview

This pull request changes the representation of the `Value` enum in the `register_bitmasks!()` macro to be `#[repr(u64)]` instead of the default representation for Rust enums, `#[repr(isize)]`.

This change allows for values larger than `0x7FFFFFFF` to be stored in 32-bit bitmasks of type `u32`, without confusingly requiring the `#[allow(overflowing_literals)]` lint that suggests matching may not work, and fixes it being impossible to store 64-bit bitmasks with values larger than `0xffffffff`.

Because Rust does not allow for zero-variant enums to be given a non-default representation, this change required duplicating the entire final match arm of the `register_bitmasks!()` macro so that the representation is left unchanged in the case that no bitmasks are passed to an invocation of the macro (as happens often when `register_bitmasks!()` is called from within `register_bitfields!()`.

This change is part of a collection of recent PRs targeted at getting clippy to pass so that we can incorporate clippy into the CI pipeline.

### Testing Strategy

This pull request was tested by compiling on nrf52840dk after removing `#[allow(overflowing_literals)` and by running `run_clippy.sh` succesfully.


### TODO or Help Wanted

This pull request could probably incorporate other changes to clean up this macro -- the largely duplicated match arms could be separated out into smaller macros, for example -- but I was wary to change much more than this as this is the first time I have looked at the internals of this crate.

Also, is this change deserving of a version bump for the tock-register-interface crate?


### Documentation Updated

- [x] No updates are required.

### Formatting

- [x] Ran `make formatall`.
