### PR TITLE
kernel: add a config switch for process debug info

### DIFF
--- a/capsules/src/process_console.rs
+++ b/capsules/src/process_console.rs
@@ -111,6 +111,7 @@ use core::cmp;
 use core::str;
 use kernel::capabilities::ProcessManagementCapability;
 use kernel::common::cells::TakeCell;
+use kernel::config;
 use kernel::debug;
 use kernel::hil::uart;
 use kernel::introspection::KernelInfo;
@@ -249,6 +250,10 @@ impl<'a, C: ProcessManagementCapability> ProcessConsole<'a, C> {
                                 );
                             });
                         } else if clean_str.starts_with("list") {
+                            if config::CONFIG.debug_processes == false {
+                                debug!("WARNING: Values reported below are inaccurate because process debugging is currently disabled.");
+                                debug!("This setting can be enabled in `kernel/src/config.rs`.");
+                            }
                             debug!(" PID    Name                Quanta  Syscalls  Dropped Callbacks  Restarts    State  Grants");
                             self.kernel
                                 .process_each_capability(&self.capability, |proc| {

--- a/kernel/src/config.rs
+++ b/kernel/src/config.rs
@@ -27,24 +27,32 @@
 ///
 /// To change the configuration, modify the relevant values in the `CONFIG` constant object defined
 /// at the end of this file.
-crate struct Config {
+pub struct Config {
     /// Whether the kernel should trace syscalls to the debug output.
     ///
     /// If enabled, the kernel will print a message in the debug output for each system call and
     /// callback, with details including the application ID, and system call or callback parameters.
-    crate trace_syscalls: bool,
+    pub(crate) trace_syscalls: bool,
 
     /// Whether the kernel should show debugging output when loading processes.
     ///
     /// If enabled, the kernel will show from which addresses processes are loaded in flash and
     /// into which SRAM addresses. This can be useful to debug whether the kernel could
     /// successfully load processes, and whether the allocated SRAM is as expected.
-    crate debug_load_processes: bool,
+    pub(crate) debug_load_processes: bool,
+
+    /// Whether the kernel should collect debugging information for processes.
+    ///
+    /// If enabled, the kernel will collect debugging information such as stack and heap pointers,
+    /// syscall count, and timeslice expiration count. This can be useful to debug app crashes or
+    /// performance issues.
+    pub debug_processes: bool,
 }
 
 /// A unique instance of `Config` where compile-time configuration options are defined. These
 /// options are available in the kernel crate to be used for relevant configuration.
-crate const CONFIG: Config = Config {
+pub const CONFIG: Config = Config {
     trace_syscalls: false,
     debug_load_processes: false,
+    debug_processes: true,
 };

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -21,6 +21,7 @@
 pub mod capabilities;
 pub mod common;
 pub mod component;
+pub mod config;
 pub mod debug;
 pub mod hil;
 pub mod introspection;
@@ -28,7 +29,6 @@ pub mod ipc;
 pub mod syscall;
 
 mod callback;
-mod config;
 mod driver;
 mod grant;
 mod mem;

--- a/kernel/src/memop.rs
+++ b/kernel/src/memop.rs
@@ -1,5 +1,6 @@
 //! Implementation of the MEMOP family of syscalls.
 
+use crate::config;
 use crate::process::ProcessType;
 use crate::returncode::ReturnCode;
 
@@ -98,13 +99,17 @@ crate fn memop(process: &dyn ProcessType, op_type: usize, r1: usize) -> ReturnCo
 
         // Op Type 10: Specify where the start of the app stack is.
         10 => {
-            process.update_stack_start_pointer(r1 as *const u8);
+            if config::CONFIG.debug_processes {
+                process.debug_update_stack_start_pointer(r1 as *const u8);
+            }
             ReturnCode::SUCCESS
         }
 
         // Op Type 11: Specify where the start of the app heap is.
         11 => {
-            process.update_heap_start_pointer(r1 as *const u8);
+            if config::CONFIG.debug_processes {
+                process.debug_update_heap_start_pointer(r1 as *const u8);
+            }
             ReturnCode::SUCCESS
         }
 

--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -340,7 +340,9 @@ impl Kernel {
             }
 
             if systick.overflowed() || !systick.greater_than(MIN_QUANTA_THRESHOLD_US) {
-                process.debug_timeslice_expired();
+                if config::CONFIG.debug_processes {
+                    process.debug_timeslice_expired();
+                }
                 break;
             }
 
@@ -364,7 +366,9 @@ impl Kernel {
                             process.set_fault_state();
                         }
                         Some(ContextSwitchReason::SyscallFired { syscall }) => {
-                            process.debug_syscall_called(syscall);
+                            if config::CONFIG.debug_processes {
+                                process.debug_syscall_called(syscall);
+                            }
 
                             // Enforce platform-specific syscall filtering here.
                             //


### PR DESCRIPTION
### Pull Request Overview

This change adds a config switch to control the collection of debugging information for processes and improve syscall latency.

I also added the `debug_` prefix to two functions and refactored some code to new `debug_*` functions.

See also: #1730, #1443.

### Testing Strategy

I ran the app used to test #1826 with `debug_processes` both `true` and `false`. Setting `debug_processes = false` saves ~60 cycles when `opt-level=3`, `lto=true`, `debug=false` and ~200 cycles when `codegen-units=1` in addition to the previous settings.

### TODO or Help Wanted

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make formatall`.
