### PR TITLE
Allow/subscribe null pointer doc clarifications

### DIFF
--- a/doc/Syscalls.md
+++ b/doc/Syscalls.md
@@ -157,8 +157,9 @@ A callback function is uniquely identified by the pair (`driver`,
 are any pending callbacks for this callback ID, they are removed from the queue
 before the new callback function is bound to the callback ID.
 
-Passing a null pointer callback function disables a previously set callback
-(besides flushing pending callbacks for this callback ID).
+A process can pass a null pointer as the callback argument to request the driver
+disable a previously set callback (besides flushing pending callbacks for this
+callback ID).
 
 ```rust
 subscribe(driver: u32, subscribe_number: u32, callback: u32, userdata: u32) -> ReturnCode as u32
@@ -224,7 +225,8 @@ additional meaning such as the number of devices present, as is the case in the
 ### 3: Allow
 
 Allow marks a region of memory as shared between the kernel and application.
-A null pointer revokes sharing a region.
+Passing a null pointer requests the corresponding driver to stop accessing the
+shared memory region.
 
 ```rust
 allow(driver: u32, allow_number: u32, pointer: usize, size: u32) -> ReturnCode as u32


### PR DESCRIPTION
Correct the documentation of the allow() system call to indicate that passing a null pointer only asks a driver to stop accessing a region; it does not revoke that driver's access.

I also clarified the subscribe documentation to indicate that passing a null callback asks the driver to stop calling it rather than revokes its access to the callback.

### Pull Request Overview

This pull request changes the system call documentation for `allow` and `subscribe`.


### Testing Strategy

This pull request was tested by looking [the rendered documentation](https://www.github.com/jrvanwhy/tock/blob/allow-subscribe-null/doc/Syscalls.md).



### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make formatall`.
