### PR TITLE
Convert QEMU testing to use rexpect

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ members = [
 ]
 exclude = [
     "tools/alert_codes",
+    "tools/qemu-runner",
     "tools/sha256sum",
     "tools/usb/bulk-echo",
     "tools/usb/bulk-echo-fast",

--- a/Makefile
+++ b/Makefile
@@ -222,10 +222,7 @@ emulation-setup:
 .PHONY: emulation-check
 emulation-check: emulation-setup
 	@$(MAKE) -C "boards/hifive1"
-	$(eval TMPFILE := $(shell mktemp))
-	@PATH="${PATH}:../../tools/qemu/riscv32-softmmu/" timeout --foreground 10s $(MAKE) qemu -C "boards/hifive1" | tee $(TMPFILE) > /dev/null
-	grep "Entering main loop" $(TMPFILE) > /dev/null;
-	rm "$(TMPFILE)"
+	@cd tools/qemu-runner; PATH="$(shell pwd)/tools/qemu/riscv32-softmmu/:${PATH}" cargo run
 
 .PHONY: clean
 clean:

--- a/tools/qemu-runner/Cargo.toml
+++ b/tools/qemu-runner/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "qemu-runner"
+version = "0.1.0"
+authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+edition = "2018"
+
+[dependencies]
+rexpect = "0.3.0"

--- a/tools/qemu-runner/src/main.rs
+++ b/tools/qemu-runner/src/main.rs
@@ -1,0 +1,28 @@
+use rexpect::errors::Error;
+use rexpect::session::PtySession;
+use rexpect::spawn;
+
+fn kill_qemu(p: &mut PtySession) -> Result<(), Error> {
+    p.send_control('a')?;
+    p.send("x")?;
+    p.flush()?;
+
+    Ok(())
+}
+
+fn hifive1() -> Result<(), Error> {
+    let mut p = spawn("make qemu -C ../../boards/hifive1", Some(3_000))?;
+
+    p.exp_string("HiFive1 initialization complete.")?;
+    p.exp_string("Entering main loop.")?;
+
+    // Test completed, kill QEMU
+    kill_qemu(&mut p)?;
+
+    p.exp_eof()?;
+    Ok(())
+}
+
+fn main() {
+    hifive1().unwrap_or_else(|e| panic!("hifive1 job failed with {}", e));
+}


### PR DESCRIPTION
### Pull Request Overview

Convert the QEMU CI testing from `grep`ing  logs to using the Rust port of pexpect ([rexpect](https://crates.io/crates/rexpect)).

This gives us much more control for interfacing with Tock and QEMU during testing.

This is part of the overall push for QEMU tests, see: https://github.com/tock/tock/issues/1827

### Testing Strategy

Use the Makefile to run the tests.

### TODO or Help Wanted

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make formatall`.
