### PR TITLE
OpenTitan: HMAC: Convert to being interrupt driven

### DIFF
--- a/boards/opentitan/README.md
+++ b/boards/opentitan/README.md
@@ -12,7 +12,7 @@ You can get started with OpenTitan using either the Nexys Video FPGA board or si
 Programming
 -----------
 
-Tock on OpenTitan requires lowRISC/opentitan@f743b4450a057a352540cf3b154ec47b43e14c17 or newer.
+Tock on OpenTitan requires lowRISC/opentitan@0e5d819d61b5bf56f8453ad877eb10e3c52fc542 or newer.
 
 For more information you can follow the [OpenTitan development flow](https://docs.opentitan.org/doc/ug/getting_started_fpga/index.html#testing-the-demo-design) to flash the image.
 

--- a/chips/lowrisc/src/hmac.rs
+++ b/chips/lowrisc/src/hmac.rs
@@ -115,7 +115,7 @@ impl Hmac<'a> {
                 d |= (slice[data_idx + 3] as u32) << 24;
 
                 regs.msg_fifo.set(d);
-                self.data_index.set(data_idx + 4)
+                self.data_index.set(data_idx + 4);
             }
 
             let idx = self.data_index.get();


### PR DESCRIPTION
### Pull Request Overview

Convert the OpenTitan HMAC to being interrupt driven. When the `MSF_FIFO` buffer is not empty or full we stop writing to it and wait for it to become empty.

### Testing Strategy

Running OpenTitan HMAC example on the FPGA.


### TODO or Help Wanted

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make formatall`.
