### PR TITLE
remove clone/copy from StoredState

### DIFF
--- a/arch/cortex-m/src/syscall.rs
+++ b/arch/cortex-m/src/syscall.rs
@@ -42,7 +42,7 @@ extern "C" {
 
 /// This holds all of the state that the kernel must keep for the process when
 /// the process is not executing.
-#[derive(Copy, Clone, Default)]
+#[derive(Default)]
 pub struct CortexMStoredState {
     regs: [usize; 8],
     yield_pc: usize,

--- a/arch/rv32i/src/syscall.rs
+++ b/arch/rv32i/src/syscall.rs
@@ -8,7 +8,7 @@ use kernel::syscall::ContextSwitchReason;
 
 /// This holds all of the state that the kernel must keep for the process when
 /// the process is not executing.
-#[derive(Copy, Clone, Default)]
+#[derive(Default)]
 #[repr(C)]
 pub struct RiscvimacStoredState {
     /// Store all of the app registers.

--- a/kernel/src/syscall.rs
+++ b/kernel/src/syscall.rs
@@ -73,7 +73,7 @@ pub trait UserspaceKernelBoundary {
     /// Implementations should **not** rely on the `Default` constructor (custom
     /// or derived) for any initialization of a process's stored state. The
     /// initialization must happen in the `initialize_process()` function.
-    type StoredState: Default + Copy;
+    type StoredState: Default;
 
     /// Called by the kernel after it has memory allocated to it but before it
     /// is allowed to begin executing. Allows for architecture-specific process


### PR DESCRIPTION
### Pull Request Overview

This pull request removes the Copy trait requirement for the `StoredState` trait, possible thanks to #1826 . This should help prevent performance regressions from somewhat expensive copying (at least on risc-v) of this object now that it is stored in a MapCell.

Closes #1833 .


### Testing Strategy

This pull request was tested by compiling. I think this is fine as we no longer seem to be using copies of `StoredState` objects anywhere.


### TODO or Help Wanted

N/A

### Documentation Updated

- [x] No updates are required.

### Formatting

- [x] Ran `make formatall`.
