### PR TITLE
Add licensing information to CONTRIBUTING

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -212,7 +212,20 @@ invoke `make format`.
 The target `make formatall` in the root will automatically run all style checks
 and make any required changes. PRs must pass the formatting checks before landing.
 
-### Step 8: Landing
+### Step 8: Licensing
+
+Tock is dual-licensed under Apache2/MIT. Files in Tock require a short header
+indicating this. In 99% of cases, the following text should be at the top of every file:
+
+> This file is part of the Tock Project.
+>
+> Dual licensed under the Apache License, Version 2.0 or the MIT License, at your option.
+> See the License for the specific language governing permissions and limitations under the License.
+> This file may not be copied, modified, or distributed except according to those terms.
+
+This header should be automatically enforced by CI tooling.
+
+### Step 9: Landing
 
 In order to land, a Pull Request needs to be reviewed and
 [approved](#getting-approvals-for-your-pull-request) by at least one person with

--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,10 +1,18 @@
-Tock Operating System
-Copyright 2016 The Tock OS Developers
+Short version for non-lawyers:
 
-Licensed under the Apache License, Version 2.0
-<LICENSE-APACHE or
-http://www.apache.org/licenses/LICENSE-2.0> or the MIT
-license <LICENSE-MIT or http://opensource.org/licenses/MIT>,
-at your option. All files in this project may not be copied,
-modified, or distributed except according to those terms.
+The Tock Project is dual-licensed under Apache 2.0 and MIT terms.
+
+
+Longer version:
+
+Copyrights in the Tock project are retained by their contributors. No
+copyright assignment is required to contribute to the Tock project.
+
+Some files include explicit copyright notices and/or license notices.
+For full authorship information, see the version control history.
+
+Except as otherwise noted (below and/or in individual files), Tock is
+licensed under the Apache License, Version 2.0 <LICENSE-APACHE> or
+<http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+<LICENSE-MIT> or <http://opensource.org/licenses/MIT>, at your option.
 


### PR DESCRIPTION
### Pull Request Overview

This updates Tock policy to require license headers at the top of files.

This is conforming to a norm that we probably should have done all along (however much personal distaste I may have for the need).

### Testing Strategy

N/A.

### TODO or Help Wanted

(1) Agree on the text here.
--- [propose merging this PR at this step; then bulk change next two as a big PR] ---
(2) Update extant files to include header.
(3) Add CI to enforce this going forward.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make formatall`.
