### PR TITLE
Fix bors by updating status names to include OS

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -2,7 +2,8 @@
 # pushed to master.
 status = [
   "continuous-integration/travis-ci/push",
-  "ci-format", "ci-build", "ci-tests", "emulation-check"
+  "ci-format (ubuntu-latest)", "ci-build (ubuntu-latest)", "ci-tests (ubuntu-latest)", "emulation-check",
+  "ci-format (macos-latest)", "ci-build (macos-latest)", "ci-tests (macos-latest)"
 ]
 
 # List of PR labels that may not be attached to a PR when it is r+-ed.


### PR DESCRIPTION
### Pull Request Overview

This pull request updates the status names that Bors blocks on before merging PRs. #1625  introduced jobs which run on multiple different OSes, so Github reports job names to Bors that include the OS of the runner for that job. Bors is expecting the old names, and so eventually times out.

This PR updates the names to match the names reported by Github.

### Testing Strategy

This pull request has not been tested. The easiest test would be for someone to approve this and tell bors to merge it and see if it works -- if it works its correct, if not it doesn't merge!


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] No updates are required.

### Formatting

- [x] Ran `make formatall`.
