### PR TITLE
`tock-rt0` related cosmetic changes.

### DIFF
--- a/arch/rv32i/Cargo.toml
+++ b/arch/rv32i/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 kernel = { path = "../../kernel" }
-tock_rt0 = { path = "../../libraries/tock-rt0" }
+tock-rt0 = { path = "../../libraries/tock-rt0" }
 tock-registers = { path = "../../libraries/tock-register-interface" }
 riscv-csr = { path = "../../libraries/riscv-csr" }
 

--- a/chips/cc26x2/Cargo.toml
+++ b/chips/cc26x2/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2018"
 
 [dependencies]
 cortexm4 = { path = "../../arch/cortex-m4" }
-tock_rt0 = { path = "../../libraries/tock-rt0" }
+tock-rt0 = { path = "../../libraries/tock-rt0" }
 kernel = { path = "../../kernel" }
 enum_primitive = { path = "../../libraries/enum_primitive" }

--- a/chips/lowrisc/Cargo.toml
+++ b/chips/lowrisc/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2018"
 [dependencies]
 rv32i = { path = "../../arch/rv32i" }
 kernel = { path = "../../kernel" }
-tock_rt0 = { path = "../../libraries/tock-rt0" }
+tock-rt0 = { path = "../../libraries/tock-rt0" }

--- a/chips/nrf52/Cargo.toml
+++ b/chips/nrf52/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 cortexm4 = { path = "../../arch/cortex-m4" }
 kernel = { path = "../../kernel" }
-tock_rt0 = { path = "../../libraries/tock-rt0" }
+tock-rt0 = { path = "../../libraries/tock-rt0" }
 enum_primitive = { path = "../../libraries/enum_primitive" }
 
 [dependencies.nrf5x]

--- a/chips/nrf52832/Cargo.toml
+++ b/chips/nrf52832/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2018"
 cortexm4 = { path = "../../arch/cortex-m4" }
 kernel = { path = "../../kernel" }
 nrf52 = { path = "../nrf52" }
-tock_rt0 = { path = "../../libraries/tock-rt0" }
+tock-rt0 = { path = "../../libraries/tock-rt0" }

--- a/chips/nrf52840/Cargo.toml
+++ b/chips/nrf52840/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2018"
 cortexm4 = { path = "../../arch/cortex-m4" }
 kernel = { path = "../../kernel" }
 nrf52 = { path = "../nrf52" }
-tock_rt0 = { path = "../../libraries/tock-rt0" }
+tock-rt0 = { path = "../../libraries/tock-rt0" }

--- a/chips/sam4l/Cargo.toml
+++ b/chips/sam4l/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2018"
 
 [dependencies]
 cortexm4 = { path = "../../arch/cortex-m4" }
-tock_rt0 = { path = "../../libraries/tock-rt0" }
+tock-rt0 = { path = "../../libraries/tock-rt0" }
 kernel = { path = "../../kernel" }

--- a/chips/stm32f303xc/Cargo.toml
+++ b/chips/stm32f303xc/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2018"
 cortexm4 = { path = "../../arch/cortex-m4" }
 enum_primitive = { path = "../../libraries/enum_primitive" }
 kernel = { path = "../../kernel" }
-tock_rt0 = { path = "../../libraries/tock-rt0" }
+tock-rt0 = { path = "../../libraries/tock-rt0" }

--- a/chips/stm32f429zi/Cargo.toml
+++ b/chips/stm32f429zi/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2018"
 cortexm4 = { path = "../../arch/cortex-m4" }
 kernel = { path = "../../kernel" }
 stm32f4xx = { path = "../stm32f4xx" }
-tock_rt0 = { path = "../../libraries/tock-rt0" }
+tock-rt0 = { path = "../../libraries/tock-rt0" }
 enum_primitive = { path = "../../libraries/enum_primitive" }

--- a/chips/stm32f446re/Cargo.toml
+++ b/chips/stm32f446re/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2018"
 cortexm4 = { path = "../../arch/cortex-m4" }
 kernel = { path = "../../kernel" }
 stm32f4xx = { path = "../stm32f4xx" }
-tock_rt0 = { path = "../../libraries/tock-rt0" }
+tock-rt0 = { path = "../../libraries/tock-rt0" }
 enum_primitive = { path = "../../libraries/enum_primitive" }

--- a/chips/stm32f4xx/Cargo.toml
+++ b/chips/stm32f4xx/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2018"
 cortexm4 = { path = "../../arch/cortex-m4" }
 enum_primitive = { path = "../../libraries/enum_primitive" }
 kernel = { path = "../../kernel" }
-tock_rt0 = { path = "../../libraries/tock-rt0" }
+tock-rt0 = { path = "../../libraries/tock-rt0" }

--- a/libraries/tock-rt0/Cargo.toml
+++ b/libraries/tock-rt0/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "tock_rt0"
+name = "tock-rt0"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
 

--- a/libraries/tock-rt0/src/lib.rs
+++ b/libraries/tock-rt0/src/lib.rs
@@ -25,10 +25,10 @@ pub unsafe fn init_data(
 
 /// Sets non-initialized data in RAM to 0.
 /// This is used to clear the BSS section on initial bootup.
-pub unsafe fn zero_bss(mut bss: *mut u32, bss_end: *mut u32) {
-    while bss < bss_end {
+pub unsafe fn zero_bss(mut start_bss: *mut u32, end_bss: *mut u32) {
+    while start_bss < end_bss {
         // `volatile` to make sure it doesn't get optimized out
-        bss.write_volatile(0);
-        bss = bss.offset(1);
+        start_bss.write_volatile(0);
+        start_bss = start_bss.offset(1);
     }
 }


### PR DESCRIPTION
There are two changes in this PR.

1. Tree-wide rename of `tock_rt0` to `tock-rt0`. This makes it consistent with other `tock-*` crate names.

2. Rename parameters to `zero_bss` to make it consistent with `init_data`.