### PR TITLE
Set interrupt pending bit manually

### DIFF
--- a/arch/cortex-m0/src/lib.rs
+++ b/arch/cortex-m0/src/lib.rs
@@ -90,6 +90,18 @@ _ggeneric_isr_no_stacking:
 
     /* *r3 = r2 */
     str r2, [r3]
+
+    /* The pending bit in ISPR might be reset by hardware for pulse interrupts
+     * at this point. So set it here again so the interrupt does not get lost
+     * in service_pending_interrupts()
+     *
+     * The NVIC.ISPR base is 0xE000E200, which is 0x20 (aka #32) above the
+     * NVIC.ICER base.  Calculate the ISPR address by offsetting from the ICER
+     * address so as to avoid re-doing the [r0 / 32] index math.
+     */
+    adds r3, #32
+    str r2, [r3]
+
     bx lr /* return here since we have extra words in the assembly */
 
 .align 4

--- a/arch/cortex-m3/src/lib.rs
+++ b/arch/cortex-m3/src/lib.rs
@@ -119,10 +119,14 @@ pub unsafe extern "C" fn generic_isr() {
      *  */
     str r0, [r3, r2, lsl #2]
 
+    /* The pending bit in ISPR might be reset by hardware for pulse interrupts
+     * at this point. So set it here again so the interrupt does not get lost
+     * in service_pending_interrupts()
+     * */
     /* r3 = &NVIC.ISPR */
     mov r3, #0xe200
     movt r3, #0xe000
-    /* set pending bit */
+    /* Set pending bit */
     str r0, [r3, r2, lsl #2]"
     : : : : "volatile" );
 }

--- a/arch/cortex-m3/src/lib.rs
+++ b/arch/cortex-m3/src/lib.rs
@@ -117,6 +117,12 @@ pub unsafe extern "C" fn generic_isr() {
      *  `*(r3 + r2 * 4) = r0`
      *
      *  */
+    str r0, [r3, r2, lsl #2]
+
+    /* r3 = &NVIC.ISPR */
+    mov r3, #0xe200
+    movt r3, #0xe000
+    /* set pending bit */
     str r0, [r3, r2, lsl #2]"
     : : : : "volatile" );
 }

--- a/arch/cortex-m4/src/lib.rs
+++ b/arch/cortex-m4/src/lib.rs
@@ -134,6 +134,16 @@ pub unsafe extern "C" fn generic_isr() {
     //
     str r0, [r3, r2, lsl #2]
 
+    /* The pending bit in ISPR might be reset by hardware for pulse interrupts
+     * at this point. So set it here again so the interrupt does not get lost
+     * in service_pending_interrupts()
+     * */
+    /* r3 = &NVIC.ISPR */
+    mov r3, #0xe200
+    movt r3, #0xe000
+    /* Set pending bit */
+    str r0, [r3, r2, lsl #2]
+
     // Now we can return from the interrupt context and resume what we were
     // doing. If an app was executing we will switch to the kernel so it can
     // choose whether to service the interrupt.


### PR DESCRIPTION
### Pull Request Overview
This pull request fixes the bug mentioned here:
https://github.com/tock/tock/issues/1252

generic_isr() is called but the interrupt is not handled in service_pending_interrupts() as the pending bit is not set.
While this bug does not seem to be triggered on tock supported boards, I encountered the problem on an automotive board.

### Testing Strategy
This was tested on a hardware security module. After this fix the interrupt is handled properly in service_pending_interrupts().

### TODO or Help Wanted
This should be tested on tock boards as I do not have one.

### Documentation Updated
No documentation was updated.
