### PR TITLE
Run OpenTitan tests in the CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -221,6 +221,14 @@ emulation-setup:
 		cd qemu; ./configure --target-list=riscv32-softmmu; \
 	fi
 	@$(MAKE) -C "tools/qemu" > /dev/null
+	@printf "Downloading OpenTitan boot rom from: 2aedf641120665b91c3a5d5aa214175d09f71ee6\n"
+	$(eval CURRENT_DIR := $(shell pwd))
+	@pushd `mktemp -d -t`; \
+		curl `curl "https://dev.azure.com/lowrisc/opentitan/_apis/build/builds/13066/artifacts?artifactName=opentitan-dist&api-version=5.1" | cut -d \" -f 38` --output opentitan-dist.zip; \
+		unzip opentitan-dist.zip; \
+		tar  -xf opentitan-dist/opentitan-snapshot-20191101-*.tar.xz; \
+		mv opentitan-snapshot-20191101-*/sw/device/boot_rom/boot_rom_fpga_nexysvideo.elf $(CURRENT_DIR)/opentitan-boot-rom.elf
+
 
 .PHONY: emulation-check
 emulation-check: emulation-setup

--- a/Makefile
+++ b/Makefile
@@ -233,6 +233,7 @@ emulation-setup:
 .PHONY: emulation-check
 emulation-check: emulation-setup
 	@$(MAKE) -C "boards/hifive1"
+	@$(MAKE) -C "boards/opentitan"
 	@cd tools/qemu-runner; PATH="$(shell pwd)/tools/qemu/riscv32-softmmu/:${PATH}" cargo run
 
 .PHONY: clean

--- a/boards/opentitan/Makefile
+++ b/boards/opentitan/Makefile
@@ -5,5 +5,11 @@ PLATFORM=opentitan
 
 include ../Makefile.common
 
+qemu: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
+	qemu-system-riscv32 -M opentitan -kernel $^ -bios $(OPENTITAN_BOOT_ROM) -nographic -serial mon:stdio
+
+qemu-app: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
+	qemu-system-riscv32 -M opentitan -kernel $^ -bios $(OPENTITAN_BOOT_ROM) -device loader,file=$(APP),addr=0x20030000 -nographic -serial mon:stdio
+
 flash: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin
 	$(OPENTITAN_TREE)/sw/host/spiflash/spiflash --input=$(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin

--- a/boards/opentitan/README.md
+++ b/boards/opentitan/README.md
@@ -50,4 +50,33 @@ You can also just use the `spiflash` program manually to download the image to t
 
 NOTE: You will need to download the Tock binary after every power cycle.
 
-Tock applications currenlty don't work on OpenTitan.
+Running in QEMU
+---------------
+
+The OpenTitan application can be run in the QEMU emulation platform, allowing quick and easy testing.
+
+QEMU can be started with Tock using the `qemu` make target:
+
+```bash
+$ make OPENTITAN_BOOT_ROM=<path_to_opentitan>/sw/device/boot_rom/boot_rom_fpga_nexysvideo.elf qemu
+```
+
+Where OPENTITAN_BOOT_ROM is set to point to the OpenTitan ELF file. This is usually located at `sw/device/boot_rom/boot_rom_fpga_nexysvideo.elf` in the OpenTitan build output.
+
+QEMU can be started with Tock and a userspace app with the `qemu-app` make target:
+
+```bash
+$ make OPENTITAN_BOOT_ROM=<path_to_opentitan/sw/device/boot_rom/boot_rom_fpga_nexysvideo.elf> APP=/path/to/app.tbf qemu-app
+```
+
+The TBF must be compiled for the OpenTitan board which is, at the time of writing,
+supported for Rust userland apps using libtock-rs. For example, you can build
+the Hello World exmple app from the libtock-rs repository by running:
+
+```
+$ cd [LIBTOCK-RS-DIR]
+$ make flash-opentitan
+$ tar xf target/riscv32imac-unknown-none-elf/tab/opentitan/hello_world.tab
+$ cd [TOCK_ROOT]/boards/opentitan
+$ make APP=[LIBTOCK-RS-DIR]/rv32imac.tbf qemu-app
+```

--- a/tools/qemu-runner/src/main.rs
+++ b/tools/qemu-runner/src/main.rs
@@ -23,6 +23,23 @@ fn hifive1() -> Result<(), Error> {
     Ok(())
 }
 
+fn opentitan() -> Result<(), Error> {
+    let mut p = spawn(
+        "make OPENTITAN_BOOT_ROM=../../opentitan-boot-rom.elf qemu -C ../../boards/opentitan",
+        Some(10_000),
+    )?;
+
+    p.exp_string("Boot ROM initialisation has completed, jump into flash!")?;
+    p.exp_string("Entering main loop")?;
+
+    // Test completed, kill QEMU
+    kill_qemu(&mut p)?;
+
+    p.exp_eof()?;
+    Ok(())
+}
+
 fn main() {
     hifive1().unwrap_or_else(|e| panic!("hifive1 job failed with {}", e));
+    opentitan().unwrap_or_else(|e| panic!("opentitan job failed with {}", e));
 }


### PR DESCRIPTION
### Pull Request Overview

This pull request runs OpenTitan on QEMU as part of the `emulation-check` make target.

### Testing Strategy

Push the PR.

### TODO or Help Wanted

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make formatall`.
