### PR TITLE
Separate the Makefile rules that require qemu, and stop silently installing qemu.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,5 +92,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
+      - name: qemu setup
+        run: make emulation-setup
       - name: qemu tests
         run: make emulation-check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,5 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
-      - name: qemu setup
-        run: make emulation-setup
       - name: qemu tests
         run: make emulation-check

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ before_script:
 
 script:
   - export PATH=$HOME/.cargo/bin:$PATH
+  - make emulation-setup
   - make ci-travis
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ before_script:
 script:
   - export PATH=$HOME/.cargo/bin:$PATH
   - make emulation-setup
-  - make ci-travis
+  - make ci-travis-with-qemu
 
 after_success:
   - export PATH=$HOME/.local/bin:$PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,6 @@ before_script:
 
 script:
   - export PATH=$HOME/.cargo/bin:$PATH
-  - make emulation-setup
   - make ci-travis-with-qemu
 
 after_success:

--- a/Makefile
+++ b/Makefile
@@ -60,18 +60,12 @@ alldoc:
 .PHONY: ci
 ci: ci-travis ci-netlify
 
+.PHONY: ci-no-qemu
+ci-no-qemu: ci-travis-no-qemu ci-netlify
+
 .PHONY: ci-travis
 ci-travis:\
-	ci-lints\
-	ci-tools\
-	ci-libraries\
-	ci-archs\
-	ci-kernel\
-	ci-chips\
-	ci-syntax\
-	ci-compilation\
-	ci-debug-support-targets\
-	ci-documentation \
+	ci-travis-no-qemu \
 	emulation-check
 	@printf "$$(tput bold)********************$$(tput sgr0)\n"
 	@printf "$$(tput bold)* CI-Travis: Done! *$$(tput sgr0)\n"
@@ -83,6 +77,19 @@ ci-netlify:\
 	@printf "$$(tput bold)*********************$$(tput sgr0)\n"
 	@printf "$$(tput bold)* CI-Netlify: Done! *$$(tput sgr0)\n"
 	@printf "$$(tput bold)*********************$$(tput sgr0)\n"
+
+.PHONY: ci-travis-no-qemu
+ci-travis-no-qemu:\
+	ci-lints\
+	ci-tools\
+	ci-libraries\
+	ci-archs\
+	ci-kernel\
+	ci-chips\
+	ci-syntax\
+	ci-compilation\
+	ci-debug-support-targets\
+	ci-documentation \
 
 .PHONY: ci-cargo-tests
 ci-cargo-tests:\

--- a/Makefile
+++ b/Makefile
@@ -57,14 +57,14 @@ alldoc:
 
 ## Meta-Targets
 
-.PHONY: ci
-ci: ci-travis ci-netlify
+.PHONY: ci-with-qemu
+ci: ci-travis-with-qemu ci-netlify
 
 .PHONY: ci-no-qemu
 ci-no-qemu: ci-travis-no-qemu ci-netlify
 
-.PHONY: ci-travis
-ci-travis:\
+.PHONY: ci-travis-with-qemu
+ci-travis-with-qemu:\
 	ci-travis-no-qemu \
 	emulation-check
 	@printf "$$(tput bold)********************$$(tput sgr0)\n"
@@ -240,7 +240,7 @@ emulation-setup:
 
 
 .PHONY: emulation-check
-emulation-check:
+emulation-check: emulation-setup
 	@$(MAKE) -C "boards/hifive1"
 	@$(MAKE) -C "boards/opentitan"
 	@cd tools/qemu-runner; PATH="$(shell pwd)/tools/qemu/riscv32-softmmu/:${PATH}" cargo run

--- a/Makefile
+++ b/Makefile
@@ -240,7 +240,7 @@ emulation-setup:
 
 
 .PHONY: emulation-check
-emulation-check: emulation-setup
+emulation-check:
 	@$(MAKE) -C "boards/hifive1"
 	@$(MAKE) -C "boards/opentitan"
 	@cd tools/qemu-runner; PATH="$(shell pwd)/tools/qemu/riscv32-softmmu/:${PATH}" cargo run


### PR DESCRIPTION
### Pull Request Overview

This pull request adds a new `ci-no-qemu` rule to the Makefile, which runs all CI rules except the ones that require qemu. This also removes the implicit dependency on `emulation-setup` for the `emulation-check` rule.

I find the `make ci` rule convenient for locally testing my commits before sending a pull request. But it now requires qemu, via `ci -> ci-travis -> emulation-check -> emulation-setup`. However, this automatic `emulation-setup` is problematic because:

1. I find it surprising that it automatically tries to install qemu "behind my back".
1. It anyway doesn't work out of the box without installing some other Debian packages.
1. As evidenced in [this workflow](https://github.com/tock/tock/pull/1861/checks?check_run_id=688603466) the qemu installation takes a bit of time (more than 5 minutes on the GitHub workflow runner).
1. The qemu tests are currently specific to some boards. Although this may change in the future, they may not be of high interest for developers of other boards.

I don't mind some rules silently installing Rust tools (Cargo, Clippy, Rustfmt, some compiler target), as these are anyway required to build Tock. But I don't think qemu should necessarily be in scope for **local** testing. Of course, developers who want to use it locally are free to do so, and the GitHub workflows check these tests, but I think there should be some freedom in what part of the CI a developer wants to run.

This pull request therefore adds a few rules to the Makefile that don't require qemu. It also removes the `emulation-setup` implicit dependency from `emulation-check` - one now has to explicitly choose to install qemu.

~~This allowed me to run the CI locally again, and identify some warning in the documentation, which is also fixed in this pull request.~~ Fixing the documentation is now in #1862.


### Testing Strategy

This pull request was tested by Travis, GitHub workflows, and `make ci-no-qemu` locally.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make format`.
- [x] Fixed errors surfaced by `make clippy`.
