### PR TITLE
Enforce doc warnings.

### DIFF
--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -193,7 +193,7 @@ debug-lst: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/debug/$(PLATFORM).lst
 
 .PHONY: doc
 doc: | target
-	$(Q)RUSTDOCFLAGS='-Z unstable-options --document-hidden-items' $(CARGO) doc $(VERBOSE) --release --package $(PLATFORM)
+	$(Q)RUSTDOCFLAGS='-Z unstable-options --document-hidden-items -D warnings' $(CARGO) doc $(VERBOSE) --release --package $(PLATFORM)
 
 .PHONY: lst
 lst: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).lst

--- a/boards/acd52832/src/main.rs
+++ b/boards/acd52832/src/main.rs
@@ -1,7 +1,9 @@
 //! Tock kernel for the Aconno ACD52832 board based on the Nordic nRF52832 MCU.
 
 #![no_std]
-#![no_main]
+// Disable this attribute when documenting, as a workaround for
+// https://github.com/rust-lang/rust/issues/62184.
+#![cfg_attr(not(doc), no_main)]
 #![deny(missing_docs)]
 
 use capsules::virtual_alarm::VirtualMuxAlarm;

--- a/boards/arty_e21/src/main.rs
+++ b/boards/arty_e21/src/main.rs
@@ -1,7 +1,9 @@
 //! Board file for the SiFive E21 Bitstream running on the Arty FPGA
 
 #![no_std]
-#![no_main]
+// Disable this attribute when documenting, as a workaround for
+// https://github.com/rust-lang/rust/issues/62184.
+#![cfg_attr(not(doc), no_main)]
 #![feature(const_fn, in_band_lifetimes)]
 
 use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -4,7 +4,9 @@
 //! - <https://github.com/lab11/hail>
 
 #![no_std]
-#![no_main]
+// Disable this attribute when documenting, as a workaround for
+// https://github.com/rust-lang/rust/issues/62184.
+#![cfg_attr(not(doc), no_main)]
 #![deny(missing_docs)]
 
 use capsules::virtual_alarm::VirtualMuxAlarm;

--- a/boards/hifive1/src/main.rs
+++ b/boards/hifive1/src/main.rs
@@ -5,7 +5,9 @@
 //! This board file is only compatible with revision B of the HiFive1.
 
 #![no_std]
-#![no_main]
+// Disable this attribute when documenting, as a workaround for
+// https://github.com/rust-lang/rust/issues/62184.
+#![cfg_attr(not(doc), no_main)]
 #![feature(asm)]
 
 use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -4,7 +4,9 @@
 //! - <https://github.com/tock/imix>
 
 #![no_std]
-#![no_main]
+// Disable this attribute when documenting, as a workaround for
+// https://github.com/rust-lang/rust/issues/62184.
+#![cfg_attr(not(doc), no_main)]
 #![feature(in_band_lifetimes)]
 #![deny(missing_docs)]
 

--- a/boards/launchxl/src/ccfg.rs
+++ b/boards/launchxl/src/ccfg.rs
@@ -1,5 +1,7 @@
 #![no_std]
-#![no_main]
+// Disable this attribute when documenting, as a workaround for
+// https://github.com/rust-lang/rust/issues/62184.
+#![cfg_attr(not(doc), no_main)]
 //! CCFG - Customer Configuration
 //!
 //! For details see p. 710 in the cc2650 technical reference manual.

--- a/boards/launchxl/src/main.rs
+++ b/boards/launchxl/src/main.rs
@@ -1,5 +1,7 @@
 #![no_std]
-#![no_main]
+// Disable this attribute when documenting, as a workaround for
+// https://github.com/rust-lang/rust/issues/62184.
+#![cfg_attr(not(doc), no_main)]
 #![feature(lang_items, asm)]
 
 extern crate capsules;

--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -4,7 +4,9 @@
 //! many exported I/O and peripherals.
 
 #![no_std]
-#![no_main]
+// Disable this attribute when documenting, as a workaround for
+// https://github.com/rust-lang/rust/issues/62184.
+#![cfg_attr(not(doc), no_main)]
 #![deny(missing_docs)]
 
 use kernel::component::Component;

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -61,7 +61,9 @@
 //! | P0.25 | P24 15 | Button 4 |
 
 #![no_std]
-#![no_main]
+// Disable this attribute when documenting, as a workaround for
+// https://github.com/rust-lang/rust/issues/62184.
+#![cfg_attr(not(doc), no_main)]
 #![deny(missing_docs)]
 
 use kernel::component::Component;

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -61,7 +61,9 @@
 //! * July 16, 2017
 
 #![no_std]
-#![no_main]
+// Disable this attribute when documenting, as a workaround for
+// https://github.com/rust-lang/rust/issues/62184.
+#![cfg_attr(not(doc), no_main)]
 #![deny(missing_docs)]
 
 use kernel::component::Component;

--- a/boards/nucleo_f429zi/src/main.rs
+++ b/boards/nucleo_f429zi/src/main.rs
@@ -3,7 +3,9 @@
 //! - <https://www.st.com/en/evaluation-tools/nucleo-f429zi.html>
 
 #![no_std]
-#![no_main]
+// Disable this attribute when documenting, as a workaround for
+// https://github.com/rust-lang/rust/issues/62184.
+#![cfg_attr(not(doc), no_main)]
 #![feature(asm)]
 #![deny(missing_docs)]
 

--- a/boards/nucleo_f446re/src/main.rs
+++ b/boards/nucleo_f446re/src/main.rs
@@ -3,7 +3,9 @@
 //! - <https://www.st.com/en/evaluation-tools/nucleo-f446re.html>
 
 #![no_std]
-#![no_main]
+// Disable this attribute when documenting, as a workaround for
+// https://github.com/rust-lang/rust/issues/62184.
+#![cfg_attr(not(doc), no_main)]
 #![feature(asm)]
 #![deny(missing_docs)]
 

--- a/boards/opentitan/src/main.rs
+++ b/boards/opentitan/src/main.rs
@@ -3,7 +3,9 @@
 //! - <https://opentitan.org/>
 
 #![no_std]
-#![no_main]
+// Disable this attribute when documenting, as a workaround for
+// https://github.com/rust-lang/rust/issues/62184.
+#![cfg_attr(not(doc), no_main)]
 #![feature(asm)]
 
 use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};

--- a/boards/stm32f3discovery/src/main.rs
+++ b/boards/stm32f3discovery/src/main.rs
@@ -3,7 +3,9 @@
 //! - <https://www.st.com/en/evaluation-tools/stm32f3discovery.html>
 
 #![no_std]
-#![no_main]
+// Disable this attribute when documenting, as a workaround for
+// https://github.com/rust-lang/rust/issues/62184.
+#![cfg_attr(not(doc), no_main)]
 #![feature(asm, core_intrinsics)]
 #![deny(missing_docs)]
 

--- a/capsules/src/lsm303dlhc.rs
+++ b/capsules/src/lsm303dlhc.rs
@@ -31,6 +31,7 @@
 //!
 //! NideDof Example
 //!
+//! ```rust
 //! let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
 //! let grant_ninedof = board_kernel.create_grant(&grant_cap);
 //!
@@ -49,7 +50,6 @@
 //! );
 //! ninedof.add_secondary_driver(lsm303dlhc_secondary);
 //! hil::sensors::NineDof::set_client(lsm303dlhc, ninedof);
-//!
 //! ```
 //!
 //! Temperature Example
@@ -71,7 +71,6 @@
 //! capsules::temperature::TemperatureSensor<'static>,
 //!     capsules::temperature::TemperatureSensor::new(lsm303dlhc, grant_temperature));
 //! kernel::hil::sensors::TemperatureDriver::set_client(lsm303dlhc, temp);
-//!
 //! ```
 //!
 //! Author: Alexandru Radovici <msg4alex@gmail.com>


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes #1334.

To work around rust-lang/rust#62184, a `cfg_attr` attribute is added to disable `no_main` when `cfg(doc)` is active.


### Testing Strategy

This pull request was tested by running `make ci-netlify` locally, and observing that warnings are indeed denied, for example when putting back the original `#![no_main]` in one of the boards.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make format`.
- [x] Fixed errors surfaced by `make clippy`.
