### PR TITLE
cortex-m: Add missing ISB after CONTROL writes

### DIFF
--- a/arch/cortex-m0/src/lib.rs
+++ b/arch/cortex-m0/src/lib.rs
@@ -322,6 +322,8 @@ _hardfault_exit:
              /* Set thread mode to privileged */
              movs r0, #0
              msr CONTROL, r0
+             /* No ISB required on M0 */
+             /* http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dai0321a/BIHFJCAC.html */
 
              ldr r0, FEXC_RETURN_MSP
              bx r0

--- a/arch/cortex-m3/src/lib.rs
+++ b/arch/cortex-m3/src/lib.rs
@@ -49,6 +49,9 @@ pub unsafe extern "C" fn systick_handler() {
     /* Set thread mode to privileged */
     mov r0, #0
     msr CONTROL, r0
+    /* CONTROL writes must be followed by ISB */
+    /* http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dai0321a/BIHFJCAC.html */
+    isb
 
     movw LR, #0xFFF9
     movt LR, #0xFFFF"
@@ -81,6 +84,9 @@ pub unsafe extern "C" fn generic_isr() {
     /* Set thread mode to privileged */
     mov r0, #0
     msr CONTROL, r0
+    /* CONTROL writes must be followed by ISB */
+    /* http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dai0321a/BIHFJCAC.html */
+    isb
 
     movw LR, #0xFFF9
     movt LR, #0xFFFF
@@ -138,6 +144,9 @@ pub unsafe extern "C" fn svc_handler() {
     /* Set thread mode to unprivileged */
     mov r0, #1
     msr CONTROL, r0
+    /* CONTROL writes must be followed by ISB */
+    /* http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dai0321a/BIHFJCAC.html */
+    isb
 
     movw lr, #0xfffd
     movt lr, #0xffff
@@ -150,6 +159,9 @@ pub unsafe extern "C" fn svc_handler() {
     /* Set thread mode to privileged */
     mov r0, #0
     msr CONTROL, r0
+    /* CONTROL writes must be followed by ISB */
+    /* http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dai0321a/BIHFJCAC.html */
+    isb
 
     movw LR, #0xFFF9
     movt LR, #0xFFFF
@@ -393,6 +405,9 @@ pub unsafe extern "C" fn hard_fault_handler() {
               /* Set thread mode to privileged */
               mov r0, #0
               msr CONTROL, r0
+              /* CONTROL writes must be followed by ISB */
+              /* http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dai0321a/BIHFJCAC.html */
+              isb
 
               movw LR, #0xFFF9
               movt LR, #0xFFFF"

--- a/arch/cortex-m4/src/lib.rs
+++ b/arch/cortex-m4/src/lib.rs
@@ -54,6 +54,9 @@ pub unsafe extern "C" fn systick_handler() {
     // Set thread mode to privileged to switch back to kernel mode.
     mov r0, #0
     msr CONTROL, r0
+    /* CONTROL writes must be followed by ISB */
+    /* http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dai0321a/BIHFJCAC.html */
+    isb
 
     movw LR, #0xFFF9
     movt LR, #0xFFFF
@@ -88,6 +91,9 @@ pub unsafe extern "C" fn generic_isr() {
     // was executing.
     mov r0, #0
     msr CONTROL, r0
+    /* CONTROL writes must be followed by ISB */
+    /* http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dai0321a/BIHFJCAC.html */
+    isb
 
     // This is a special address to return Thread mode with Main stack
     movw LR, #0xFFF9
@@ -164,6 +170,9 @@ pub unsafe extern "C" fn svc_handler() {
     // application. Set thread mode to unprivileged to run the application.
     mov r0, #1
     msr CONTROL, r0
+    /* CONTROL writes must be followed by ISB */
+    /* http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dai0321a/BIHFJCAC.html */
+    isb
 
     // This is a special address to return Thread mode with Process stack
     movw lr, #0xfffd
@@ -183,6 +192,9 @@ pub unsafe extern "C" fn svc_handler() {
     // Set thread mode to privileged as we switch back to the kernel.
     mov r0, #0
     msr CONTROL, r0
+    /* CONTROL writes must be followed by ISB */
+    /* http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dai0321a/BIHFJCAC.html */
+    isb
 
     // This is a special address to return Thread mode with Main stack
     movw LR, #0xFFF9
@@ -440,6 +452,9 @@ pub unsafe extern "C" fn hard_fault_handler() {
               /* Set thread mode to privileged */
               mov r0, #0
               msr CONTROL, r0
+              /* CONTROL writes must be followed by ISB */
+              /* http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dai0321a/BIHFJCAC.html */
+              isb
 
               movw LR, #0xFFF9
               movt LR, #0xFFFF"


### PR DESCRIPTION
### Pull Request Overview

According to the ARM ARM, an instruction synchronization barrier is
requried after switching processor priviledge state:
http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dai0321a/BIHFJCAC.html

In practice, most Cortex-M's have tiny instruction caches, so this hasn't
bitten us yet, but we should still do the right thing in case this becomes
an issue in the future.

### Testing Strategy

Compiling.

### TODO or Help Wanted

Need to test on HW.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make format`.
- [x] Fixed errors surfaced by `make clippy`.
