### PR TITLE
platform: mpu: Add function to set kernel permissions

### DIFF
--- a/kernel/src/platform/mpu.rs
+++ b/kernel/src/platform/mpu.rs
@@ -112,6 +112,43 @@ pub trait MPU {
         0
     }
 
+    /// Mark a region of memory that the Tock kernel owns
+    ///
+    /// This function will optionally set the MPU to enforce the specified
+    /// constraints for all accessess (even from the kernel).
+    /// This should be used to mark read/write/execute only areas of the Tock
+    /// kernel to have the hardware enforce those permissions.
+    ///
+    /// If using this function, all kernel executable code must be marked as
+    /// executable prior to enabling the MPU (by calling `enable_mpu()).
+    /// Also all kernel read/write regions must be marked. That is any
+    /// unmarked kernel regions will cause a fault if accesses.
+    ///
+    /// Not all architectures support this, so don't assume this will be
+    /// implemented.
+    ///
+    /// # Arguments
+    ///
+    /// - `memory_start`:             start of memory region
+    /// - `memory_size`:              size of unallocated memory
+    /// - `permissions`:              permissions for the region
+    /// - `config`:                   MPU region configuration
+    ///
+    /// # Return Value
+    ///
+    /// Returns the start and size of the requested memory region. If it is
+    /// infeasible to allocate the MPU region, returns None.
+    #[allow(unused_variables)]
+    fn allocate_kernel_region(
+        &self,
+        memory_start: *const u8,
+        memory_size: usize,
+        permissions: Permissions,
+        config: &mut Self::MpuConfig,
+    ) -> Option<Region> {
+        None
+    }
+
     /// Allocates a new MPU region.
     ///
     /// An implementation must allocate an MPU region at least `min_region_size`


### PR DESCRIPTION
### Pull Request Overview

The RISC-V enhanced PMP spec is making progress and it seems like it is unlikely to have any major changes before ratification.

In anticipation of this let's start to prepare adding support to Tock.

This PR updates the MPU trait to allow marking regions of kernel memory with permissions.

The idea here is that before the MPU is enabled Tock will set read/write/execute permissions for itself. This will limit what Tock itself can access, for example by removing write permissions from code.

We can also add a check to see if it is already enabled. If the previous stage has enabled lock down mode we won't set it ourselves. We will have to trust the previous stage (that would have loaded us) to have done it correctly. If no one else has set it, we can set it for enhanced security.

Once enabled we can't change the execute permission (read/write can change) so let's enforce that all regions are added before enabling.

### Testing Strategy

Untested.

### TODO or Help Wanted

I need feedback on the generic API before I go too far in enabling it and test with QEMU.

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make format`.
- [X] Fixed errors surfaced by `make clippy`.
