### PR TITLE
Remove emulation-check from travis-ci.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,6 @@ branches:
 
 cache:
   cargo: true
-  directories:
-    - tools/qemu
 
 os:
   - linux

--- a/Makefile
+++ b/Makefile
@@ -71,8 +71,7 @@ ci-travis:\
 	ci-syntax\
 	ci-compilation\
 	ci-debug-support-targets\
-	ci-documentation \
-	emulation-check
+	ci-documentation
 	@printf "$$(tput bold)********************$$(tput sgr0)\n"
 	@printf "$$(tput bold)* CI-Travis: Done! *$$(tput sgr0)\n"
 	@printf "$$(tput bold)********************$$(tput sgr0)\n"


### PR DESCRIPTION
### Pull Request Overview

As an hopefully simpler to review alternative to #1861, this pull request removes `emulation-check` from the `travis-ci` rules, for the following reasons.

- The `emulation-check` rule in its current form raises concerns (https://github.com/tock/tock/pull/1861#issuecomment-631298388) regarding security of its integration and unpolished installation steps. Therefore, until these concerns are resolved, I think it should only be available as an explicit `make emulation-check` invocation, but there should be no other rule _implicitly_ invoking it.
- Travis-CI is already slow enough. The `emulation-check` steps adds to the latency.
- There is already a `make emulation-check` in the GitHub workflow (https://github.com/tock/tock/blob/master/.github/workflows/ci.yml#L89-L96).

I apologize for starting 2 pull requests on this topic, but I really don't want to see this problem lingering around, and given the latency of discussions and reviews across time zones I think it's the best way to solve this in a reasonable time.


### Testing Strategy

This pull request was tested by Travis.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make format`.
- [x] Fixed errors surfaced by `make clippy`.
