### PR TITLE
make: make local qemu opt-in

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,11 +86,11 @@ jobs:
       - name: ci-tools
         run: make ci-tools
 
-  emulation-check:
+  qemu-check:
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
       - name: qemu tests
-        run: make emulation-check
+        run: make qemu-check


### PR DESCRIPTION
### Pull Request Overview

Running `make ci` locally will now produce:

```
** Tock is experimenting with QEMU testing.
** This requires installing a QEMU fork to run locally.
** Would you like Tock to install QEMU for you? [y/N]
```

as the last step if QEMU is not already installed. If QEMU is already installed, it will simply run (i.e. opt-in once). And finally, if you never want to run QEMU locally, you can set an environment variable:

```
$ TOCK_NO_QEMU=1 make qemu-possibly-check
Skipping QEMU due to TOCK_NO_QEMU environment variable.
```

### Testing Strategy

Lots of local builds.

### TODO or Help Wanted

Is this an okay compromise for now?

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make format`.
- [ ] Fixed errors surfaced by `make clippy`.
