### PR TITLE
move duplicated unhandled_interrupt code to cortex-m4 crate

### DIFF
--- a/arch/cortex-m4/src/lib.rs
+++ b/arch/cortex-m4/src/lib.rs
@@ -143,6 +143,30 @@ pub unsafe extern "C" fn generic_isr() {
 
 // Mock implementation for tests on Travis-CI.
 #[cfg(not(any(target_arch = "arm", target_os = "none")))]
+pub unsafe extern "C" fn unhandled_interrupt() {
+    unimplemented!()
+}
+
+#[cfg(all(target_arch = "arm", target_os = "none"))]
+pub unsafe extern "C" fn unhandled_interrupt() {
+    let mut interrupt_number: u32;
+
+    // IPSR[8:0] holds the currently active interrupt
+    asm!(
+    "mrs    r0, ipsr                    "
+    : "={r0}"(interrupt_number)
+    :
+    : "r0"
+    :
+    );
+
+    interrupt_number = interrupt_number & 0x1ff;
+
+    panic!("Unhandled Interrupt. ISR {} is active.", interrupt_number);
+}
+
+// Mock implementation for tests on Travis-CI.
+#[cfg(not(any(target_arch = "arm", target_os = "none")))]
 pub unsafe extern "C" fn svc_handler() {
     unimplemented!()
 }

--- a/chips/cc26x2/src/crt1.rs
+++ b/chips/cc26x2/src/crt1.rs
@@ -1,4 +1,6 @@
-use cortexm4::{generic_isr, hard_fault_handler, nvic, svc_handler, systick_handler};
+use cortexm4::{
+    generic_isr, hard_fault_handler, nvic, svc_handler, systick_handler, unhandled_interrupt,
+};
 use tock_rt0;
 
 extern "C" {
@@ -13,10 +15,6 @@ extern "C" {
     // _estack is not really a function, but it makes the types work
     // You should never actually invoke it!!
     fn _estack();
-}
-
-unsafe extern "C" fn unhandled_interrupt() {
-    loop {}
 }
 
 #[cfg_attr(

--- a/chips/nrf52/src/crt1.rs
+++ b/chips/nrf52/src/crt1.rs
@@ -1,4 +1,6 @@
-use cortexm4::{generic_isr, hard_fault_handler, nvic, scb, svc_handler, systick_handler};
+use cortexm4::{
+    generic_isr, hard_fault_handler, nvic, scb, svc_handler, systick_handler, unhandled_interrupt,
+};
 use tock_rt0;
 
 /*
@@ -22,28 +24,6 @@ extern "C" {
     // _estack is not really a function, but it makes the types work
     // You should never actually invoke it!!
     fn _estack();
-}
-
-#[cfg(not(any(target_arch = "arm", target_os = "none")))]
-unsafe extern "C" fn unhandled_interrupt() {
-    unimplemented!()
-}
-
-#[cfg(all(target_arch = "arm", target_os = "none"))]
-unsafe extern "C" fn unhandled_interrupt() {
-    let mut interrupt_number: u32;
-
-    // IPSR[8:0] holds the currently active interrupt
-    asm!(
-    "mrs    r0, ipsr                    "
-    : "={r0}"(interrupt_number)
-    :
-    : "r0"
-    :
-    );
-
-    interrupt_number = interrupt_number & 0x1ff;
-    panic!("Unhandled Interrupt. ISR {} is active.", interrupt_number);
 }
 
 #[cfg_attr(

--- a/chips/sam4l/src/lib.rs
+++ b/chips/sam4l/src/lib.rs
@@ -34,30 +34,9 @@ pub mod usart;
 pub mod usbc;
 pub mod wdt;
 
-use cortexm4::{generic_isr, hard_fault_handler, svc_handler, systick_handler};
-
-#[cfg(not(any(target_arch = "arm", target_os = "none")))]
-unsafe extern "C" fn unhandled_interrupt() {
-    unimplemented!()
-}
-
-#[cfg(all(target_arch = "arm", target_os = "none"))]
-unsafe extern "C" fn unhandled_interrupt() {
-    let mut interrupt_number: u32;
-
-    // IPSR[8:0] holds the currently active interrupt
-    asm!(
-    "mrs    r0, ipsr                    "
-    : "={r0}"(interrupt_number)
-    :
-    : "r0"
-    :
-    );
-
-    interrupt_number = interrupt_number & 0x1ff;
-
-    panic!("Unhandled Interrupt. ISR {} is active.", interrupt_number);
-}
+use cortexm4::{
+    generic_isr, hard_fault_handler, svc_handler, systick_handler, unhandled_interrupt,
+};
 
 extern "C" {
     // _estack is not really a function, but it makes the types work

--- a/chips/stm32f303xc/src/lib.rs
+++ b/chips/stm32f303xc/src/lib.rs
@@ -21,30 +21,9 @@ pub mod syscfg;
 pub mod tim2;
 pub mod usart;
 
-use cortexm4::{generic_isr, hard_fault_handler, svc_handler, systick_handler};
-
-#[cfg(not(any(target_arch = "arm", target_os = "none")))]
-unsafe extern "C" fn unhandled_interrupt() {
-    unimplemented!()
-}
-
-#[cfg(all(target_arch = "arm", target_os = "none"))]
-unsafe extern "C" fn unhandled_interrupt() {
-    let mut interrupt_number: u32;
-
-    // IPSR[8:0] holds the currently active interrupt
-    asm!(
-    "mrs    r0, ipsr                    "
-    : "={r0}"(interrupt_number)
-    :
-    : "r0"
-    :
-    );
-
-    interrupt_number = interrupt_number & 0x1ff;
-
-    panic!("Unhandled Interrupt. ISR {} is active.", interrupt_number);
-}
+use cortexm4::{
+    generic_isr, hard_fault_handler, svc_handler, systick_handler, unhandled_interrupt,
+};
 
 extern "C" {
     // _estack is not really a function, but it makes the types work

--- a/chips/stm32f446re/src/lib.rs
+++ b/chips/stm32f446re/src/lib.rs
@@ -4,8 +4,7 @@ pub use stm32f4xx::{chip, dbg, dma1, exti, gpio, nvic, rcc, spi, syscfg, tim2, u
 
 pub mod stm32f446re_nvic;
 
-use cortexm4::generic_isr;
-use stm32f4xx::unhandled_interrupt;
+use cortexm4::{generic_isr, unhandled_interrupt};
 
 // STM32F446xx has total of 97 interrupts
 // Extracted from `CMSIS/Device/ST/STM32F4xx/Include/stm32f446xx.h`

--- a/chips/stm32f4xx/src/lib.rs
+++ b/chips/stm32f4xx/src/lib.rs
@@ -22,30 +22,7 @@ pub mod syscfg;
 pub mod tim2;
 pub mod usart;
 
-use cortexm4::{hard_fault_handler, svc_handler, systick_handler};
-
-#[cfg(not(any(target_arch = "arm", target_os = "none")))]
-pub unsafe extern "C" fn unhandled_interrupt() {
-    unimplemented!()
-}
-
-#[cfg(all(target_arch = "arm", target_os = "none"))]
-pub unsafe extern "C" fn unhandled_interrupt() {
-    let mut interrupt_number: u32;
-
-    // IPSR[8:0] holds the currently active interrupt
-    asm!(
-    "mrs    r0, ipsr                    "
-    : "={r0}"(interrupt_number)
-    :
-    : "r0"
-    :
-    );
-
-    interrupt_number = interrupt_number & 0x1ff;
-
-    panic!("Unhandled Interrupt. ISR {} is active.", interrupt_number);
-}
+use cortexm4::{hard_fault_handler, svc_handler, systick_handler, unhandled_interrupt};
 
 extern "C" {
     // _estack is not really a function, but it makes the types work


### PR DESCRIPTION
### Pull Request Overview

While reviewing #1857, I noticed that apollo3 would be the fifth chip crate to introduce an identical `fn unhandled_interrupt()` definition. The assembly for checking the currently active interrupt is cortex-m4 specific, but not chip specific (https://developer.arm.com/docs/dui0553/a/the-cortex-m4-processor/programmers-model/core-registers), so I thought it would be good to cut down on duplicated code by moving this definition to the cortex-m4 crate.

Nothing stops chips from defining their own `unhandled_interrupt` if a different implementation is desired.

The cc26x2 chip previously used an `unhandled_interrupt()` that just looped forever, but I changed it to use this shared implementation as a panic seems strictly more useful than a hang.


### Testing Strategy

This pull request was tested by `make allboards`.


### TODO or Help Wanted

N/A

### Documentation Updated

- [x] No updates are required.

### Formatting

- [x] Ran `make format`.
- [x] Fixed errors surfaced by `make clippy`.
