### PR TITLE
PMP and MPU Improvements

### DIFF
--- a/arch/cortex-m3/src/mpu.rs
+++ b/arch/cortex-m3/src/mpu.rs
@@ -363,7 +363,12 @@ impl CortexMRegion {
 impl kernel::mpu::MPU for MPU {
     type MpuConfig = CortexMConfig;
 
-    fn enable_mpu(&self) {
+    fn clear_mpu(&self) {
+        let regs = &*self.registers;
+        regs.ctrl.write(Control::ENABLE::CLEAR);
+    }
+
+    fn enable_app_mpu(&self) {
         let regs = &*self.registers;
 
         // Enable the MPU, disable it during HardFault/NMI handlers, and allow
@@ -372,9 +377,9 @@ impl kernel::mpu::MPU for MPU {
             .write(Control::ENABLE::SET + Control::HFNMIENA::CLEAR + Control::PRIVDEFENA::SET);
     }
 
-    fn disable_mpu(&self) {
-        let regs = &*self.registers;
-        regs.ctrl.write(Control::ENABLE::CLEAR);
+    fn disable_app_mpu(&self) {
+        // The MPU is not enabled for privileged mode, so we don't have to do
+        // anything
     }
 
     fn number_total_regions(&self) -> usize {

--- a/arch/rv32i/src/pmp.rs
+++ b/arch/rv32i/src/pmp.rs
@@ -244,9 +244,7 @@ impl PMPConfig {
 impl kernel::mpu::MPU for PMP {
     type MpuConfig = PMPConfig;
 
-    fn enable_mpu(&self) {}
-
-    fn disable_mpu(&self) {
+    fn clear_mpu(&self) {
         // We want to disable all of the hardware entries, so we use `$x` here,
         // and not `$x / 2`.
         for x in 0..$x {
@@ -299,8 +297,15 @@ impl kernel::mpu::MPU for PMP {
         csr::CSR.pmpcfg[0].modify(csr::pmpconfig::pmpcfg::w0::SET);
         csr::CSR.pmpcfg[0].modify(csr::pmpconfig::pmpcfg::x0::SET);
         csr::CSR.pmpcfg[0].modify(csr::pmpconfig::pmpcfg::a0::TOR);
-        // MPU is not configured for any process now
+        // PMP is not configured for any process now
         self.last_configured_for.take();
+    }
+
+    fn enable_app_mpu(&self) {}
+
+    fn disable_app_mpu(&self) {
+        // PMP is not enabled for machine mode, so we don't have to do
+        // anything
     }
 
     fn number_total_regions(&self) -> usize {

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -266,7 +266,7 @@ pub unsafe fn reset_handler() {
     CHIP = Some(chip);
 
     // Need to disable the MPU because the bootloader seems to set it up.
-    chip.mpu().disable_mpu();
+    chip.mpu().clear_mpu();
 
     // Configure the USB stack to enable a serial port over CDC-ACM.
     cdc.enable();

--- a/kernel/src/platform/mpu.rs
+++ b/kernel/src/platform/mpu.rs
@@ -93,20 +93,29 @@ pub trait MPU {
     /// current state to help with debugging.
     type MpuConfig: Default + Display = MpuConfigDefault;
 
-    /// Enables the MPU.
+    /// Clears the MPU.
+    ///
+    /// This function will clear any access control enforced by the
+    /// MPU where possible.
+    /// On some hardware it is impossible to reset the MPU after it has
+    /// been locked, in this case this function wont change those regions.
+    fn clear_mpu(&self) {}
+
+    /// Enables the MPU for userspace apps.
     ///
     /// This function must enable the permission restrictions on the various
     /// regions protected by the MPU.
-    fn enable_mpu(&self) {}
+    fn enable_app_mpu(&self) {}
 
-    /// Disables the MPU.
+    /// Disables the MPU for userspace apps.
     ///
-    /// This function must completely disable any access control enforced by the
-    /// MPU. This will be called before the kernel starts to execute as on some
+    /// This function must disable any access control that was previously setup
+    /// for an app if it will interfere with the kernel.
+    /// This will be called before the kernel starts to execute as on some
     /// platforms the MPU rules apply to privileged code as well, and therefore
-    /// the MPU must be completely disabled for the kernel to effectively manage
-    /// processes.
-    fn disable_mpu(&self) {}
+    /// some of the MPU configuration must be disabled for the kernel to effectively
+    /// manage processes.
+    fn disable_app_mpu(&self) {}
 
     /// Returns the maximum number of regions supported by the MPU.
     fn number_total_regions(&self) -> usize {

--- a/kernel/src/platform/mpu.rs
+++ b/kernel/src/platform/mpu.rs
@@ -266,3 +266,76 @@ pub trait MPU {
 
 /// Implement default MPU trait for unit.
 impl MPU for () {}
+
+/// The generic trait that particular kernel level memory protection unit
+/// implementations need to implement.
+///
+/// This trait provides generic functionality to extend the MPU trait above
+/// to also allow the kernel to protect itself. It is expected that only a
+/// limited number of SoCs can support this, which is why it is a seperate
+/// implementation.
+pub trait KernelMPU {
+    /// MPU-specific state that defines a particular configuration for the kernel
+    /// MPU.
+    /// That is, this should contain all of the required state such that the
+    /// implementation can be passed an object of this type and it should be
+    /// able to correctly and entirely configure the MPU.
+    ///
+    /// It is `Default` so we can create empty state when the kernel is
+    /// created, and `Display` so that the `panic!()` output can display the
+    /// current state to help with debugging.
+    type KernelMpuConfig: Default + Display = MpuConfigDefault;
+
+    /// Mark a region of memory that the Tock kernel owns.
+    ///
+    /// This function will optionally set the MPU to enforce the specified
+    /// constraints for all accessess (even from the kernel).
+    /// This should be used to mark read/write/execute areas of the Tock
+    /// kernel to have the hardware enforce those permissions.
+    ///
+    /// If the KernelMPU trait is supported a board should use this function
+    /// to set permissions for all areas of memory the kernel will use.
+    /// Once all regions of memory have been allocated, the board must call
+    /// enable_kernel_mpu(). After enable_kernel_mpu() is called no changes
+    /// to kernel level code permissions can be made.
+    ///
+    /// Note that kernel level permissions also apply to apps, although apps
+    /// will have more constraints applied on top of the kernel ones as
+    /// specified by the `MPU` trait.
+    ///
+    /// Not all architectures support this, so don't assume this will be
+    /// implemented.
+    ///
+    /// # Arguments
+    ///
+    /// - `memory_start`:             start of memory region
+    /// - `memory_size`:              size of unallocated memory
+    /// - `permissions`:              permissions for the region
+    /// - `config`:                   MPU region configuration
+    ///
+    /// # Return Value
+    ///
+    /// Returns the start and size of the requested memory region. If it is
+    /// infeasible to allocate the MPU region, returns None.
+    #[allow(unused_variables)]
+    fn allocate_kernel_region(
+        &self,
+        memory_start: *const u8,
+        memory_size: usize,
+        permissions: Permissions,
+        config: &mut Self::KernelMpuConfig,
+    ) -> Option<Region>;
+
+    /// Enables the MPU for the kernel.
+    ///
+    /// This function must enable the permission restrictions on the various
+    /// kernel regions specified by `allocate_kernel_region()` protected by
+    /// the MPU.
+    ///
+    /// It is expected that this function is called in `reset_handler()`.
+    ///
+    /// Once enabled this cannot be disabled. It is expected there won't be any
+    /// changes to the kernel regions after this is enabled.
+    #[allow(unused_variables)]
+    fn enable_kernel_mpu(&self, config: &mut Self::KernelMpuConfig);
+}

--- a/kernel/src/platform/mpu.rs
+++ b/kernel/src/platform/mpu.rs
@@ -195,7 +195,7 @@ pub trait MPU {
     /// This function returns the start address and the size of the memory block
     /// chosen for the process. If it is infeasible to find a memory block or
     /// allocate the MPU region, or if the function has already been called,
-    /// returns None.
+    /// returns None. If None is returned no changes are made.
     #[allow(unused_variables)]
     fn allocate_app_memory_region(
         &self,
@@ -234,7 +234,8 @@ pub trait MPU {
     /// # Return Value
     ///
     /// Returns an error if it is infeasible to update the MPU region, or if it
-    /// was never created.
+    /// was never created. If an error is returned no changes are made to the
+    /// configuration.
     #[allow(unused_variables)]
     fn update_app_memory_region(
         &self,
@@ -316,7 +317,8 @@ pub trait KernelMPU {
     /// # Return Value
     ///
     /// Returns the start and size of the requested memory region. If it is
-    /// infeasible to allocate the MPU region, returns None.
+    /// infeasible to allocate the MPU region, returns None. If None is
+    /// returned no changes are made.
     #[allow(unused_variables)]
     fn allocate_kernel_region(
         &self,

--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -610,11 +610,11 @@ impl Kernel {
                     // generate an interrupt when the timeslice has expired. The
                     // underlying timer is not affected.
                     process.setup_mpu();
-                    chip.mpu().enable_mpu();
+                    chip.mpu().enable_app_mpu();
                     scheduler_timer.arm();
                     let context_switch_reason = process.switch_to();
                     scheduler_timer.disarm();
-                    chip.mpu().disable_mpu();
+                    chip.mpu().disable_app_mpu();
 
                     // Now the process has returned back to the kernel. Check
                     // why and handle the process as appropriate.


### PR DESCRIPTION
### Pull Request Overview

This PR replaces:
 - https://github.com/tock/tock/pull/1867
 - https://github.com/tock/tock/pull/1871

And combines a few different MPU/PMP improvements

 1. Rename the `enable/disable_mpu()` functions to be `enable/disable_app_mpu()` functions. This is because these functions only enable and disable the MPU for apps.
 2. Conver the current `disable_mpu()` function to be `clear_mpu()` and run it at boot. Instead of clearing the MPU/PMP after returning to the kernel from an app let's instead do nothing as we don't need to. We still leave the function around though, encase a future architectures wants to use it. This should improve syscall performance, especially for RISC-V. We also clear the MPU/PMP at boot encase a previous stage has set anything up.
 3. We also add new functions in preperation for RISC-V ePMP (see below)

#### RISC-V ePMP

The RISC-V enhanced PMP spec is making progress and it seems like it is unlikely to have any major changes before ratification.

In anticipation of this let's start to prepare adding support to Tock.

This PR updates the MPU trait to allow marking regions of kernel memory with permissions.

The idea here is that before the MPU is enabled Tock will set read/write/execute permissions for itself. This will limit what Tock itself can access, for example by removing write permissions from code.

We can also add a check to see if it is already enabled. If the previous stage has enabled lock down mode we won't set it ourselves. We will have to trust the previous stage (that would have loaded us) to have done it correctly. If no one else has set it, we can set it for enhanced security.

Once enabled we can't change the execute permission (read/write can change) so let's enforce that all regions are added before enabling.


### Testing Strategy

Running on QEMU, I'll test the Unleashed and Apollo3 as well.

### TODO or Help Wanted

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make format`.
- [X] Fixed errors surfaced by `make clippy`.
