### PR TITLE
nrf52: dont write to read only register

### DIFF
--- a/boards/acd52832/src/main.rs
+++ b/boards/acd52832/src/main.rs
@@ -446,7 +446,6 @@ pub unsafe fn reset_handler() {
 
     nrf52832::clock::CLOCK.low_set_source(nrf52832::clock::LowClockSource::XTAL);
     nrf52832::clock::CLOCK.low_start();
-    nrf52832::clock::CLOCK.high_set_source(nrf52832::clock::HighClockSource::XTAL);
     nrf52832::clock::CLOCK.high_start();
     while !nrf52832::clock::CLOCK.low_started() {}
     while !nrf52832::clock::CLOCK.high_started() {}

--- a/boards/nordic/nrf52dk_base/src/nrf52_components/startup.rs
+++ b/boards/nordic/nrf52dk_base/src/nrf52_components/startup.rs
@@ -113,7 +113,6 @@ impl Component for NrfClockComponent {
 
         nrf52::clock::CLOCK.low_set_source(nrf52::clock::LowClockSource::XTAL);
         nrf52::clock::CLOCK.low_start();
-        nrf52::clock::CLOCK.high_set_source(nrf52::clock::HighClockSource::XTAL);
         nrf52::clock::CLOCK.high_start();
         while !nrf52::clock::CLOCK.low_started() {}
         while !nrf52::clock::CLOCK.high_started() {}

--- a/chips/nrf52/src/clock.rs
+++ b/chips/nrf52/src/clock.rs
@@ -42,7 +42,7 @@ register_structs! {
         (0x308 => intenclr: ReadWrite<u32, Interrupt::Register>),
         (0x30C => _reserved4),
         (0x408 => hfclkrun: ReadOnly<u32, Status::Register>),
-        (0x40C => hfclkstat: ReadWrite<u32, HfClkStat::Register>),
+        (0x40C => hfclkstat: ReadOnly<u32, HfClkStat::Register>),
         (0x410 => _reserved5),
         (0x414 => lfclkrun: ReadOnly<u32, Control::Register>),
         (0x418 => lfclkstat: ReadWrite<u32, LfClkStat::Register>),
@@ -200,7 +200,8 @@ impl Clock {
         }
     }
 
-    /// Start the high frequency clock
+    /// Start the high frequency clock - specifically HFXO, and sets the high frequency
+    /// clock source to HFXO
     pub fn high_start(&self) {
         let regs = &*self.registers;
         regs.tasks_hfclkstart.write(Control::ENABLE::SET);
@@ -271,12 +272,5 @@ impl Clock {
     pub fn low_set_source(&self, clock_source: LowClockSource) {
         let regs = &*self.registers;
         regs.lfclksrc.write(LfClkSrc::SRC.val(clock_source as u32));
-    }
-
-    /// Set high frequency clock source
-    pub fn high_set_source(&self, clock_source: HighClockSource) {
-        let regs = &*self.registers;
-        regs.hfclkstat
-            .write(HfClkStat::SRC.val(clock_source as u32));
     }
 }


### PR DESCRIPTION
### Pull Request Overview

While trying to debug what is wrong with the nrf52 15.4 driver, I realized that the nrf52 clock code attempts to write to a register that both the nrf52840 and nrf52832 datasheets define as a read only register (page 107: https://infocenter.nordicsemi.com/pdf/nRF52832_PS_v1.4.pdf , https://infocenter.nordicsemi.com/index.jsp?topic=%2Fps_nrf52840%2Fclock.html&cp=4_0_0_4_3_2_16&anchor=register.HFCLKSTAT) .

This PR removes this incorrect code. Despite this function call not working, the code was actually functionally correct, because the subsequent line that starts the high speed clock has a side effect of setting the HighClockSource to XTAL anyway (per https://infocenter.nordicsemi.com/topic/ps_nrf52840/clock.html?cp=4_0_0_4_3_2_0#register.TASKS_HFCLKSTART).

### Testing Strategy

Flashing the 15.4 radio_tx app on an nrf52840. It works the same as before this change.


### TODO or Help Wanted

N/A.


### Documentation Updated

- [x] No updates are required.

### Formatting

- [x] Ran `make format`.
- [x] Fixed errors surfaced by `make clippy`.
