### PR TITLE
ci: actually deny warnings in doc builds

### DIFF
--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -193,7 +193,9 @@ debug-lst: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/debug/$(PLATFORM).lst
 
 .PHONY: doc
 doc: | target
-	$(Q)RUSTDOCFLAGS='-Z unstable-options --document-hidden-items -D warnings' $(CARGO) doc $(VERBOSE) --release --package $(PLATFORM)
+	@# This mess is all to work around rustdoc giving no way to return an
+	@# error if there are warnings. This effectively simulates that.
+	$(Q)RUSTDOCFLAGS='-Z unstable-options --document-hidden-items -D warnings' $(CARGO) --color=always doc $(VERBOSE) --release --package $(PLATFORM) 2>&1 | tee /dev/tty | grep -q warning && (echo "Warnings detected during doc build" && if [[ $$CI == "true" ]]; then echo "Erroring due to CI context" && exit 33; fi) || if [ $$? -eq 33 ]; then exit 1; fi
 
 .PHONY: lst
 lst: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).lst

--- a/boards/nordic/nrf52dk_base/src/nrf52_components/startup.rs
+++ b/boards/nordic/nrf52dk_base/src/nrf52_components/startup.rs
@@ -1,10 +1,5 @@
 //! Component for starting up nrf52 platforms.
-//!
-//! Usage
-//! -----
-//! ```rust
-//!
-//! ```
+
 use kernel::component::Component;
 use nrf52::gpio::Pin;
 use nrf52::uicr::Regulator0Output;


### PR DESCRIPTION
### Pull Request Overview

Turns out, rustdoc provides no mechanism to have the cargo/rustdoc process
return an error if there are warnings (`-D warnings` and the like are ignored).

So, we hack around it with some shell magicry.

### Testing Strategy

Building with and without warning-raising code in the docs and the `CI` environment variable.

### TODO or Help Wanted

I mean, I want rustdoc to respect the warnings-as-errors flag, but that's been on their issue tracker since 2018, so it doesn't seem like that's happening.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make format`.
- [x] Fixed errors surfaced by `make clippy`.
