### PR TITLE
Remove unused `asm` feature flags

### DIFF
--- a/boards/hifive1/src/main.rs
+++ b/boards/hifive1/src/main.rs
@@ -8,7 +8,6 @@
 // Disable this attribute when documenting, as a workaround for
 // https://github.com/rust-lang/rust/issues/62184.
 #![cfg_attr(not(doc), no_main)]
-#![feature(asm)]
 
 use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use kernel::capabilities;

--- a/boards/launchxl/src/main.rs
+++ b/boards/launchxl/src/main.rs
@@ -2,7 +2,7 @@
 // Disable this attribute when documenting, as a workaround for
 // https://github.com/rust-lang/rust/issues/62184.
 #![cfg_attr(not(doc), no_main)]
-#![feature(lang_items, asm)]
+#![feature(lang_items)]
 
 extern crate capsules;
 extern crate cc26x2;

--- a/boards/nucleo_f429zi/src/main.rs
+++ b/boards/nucleo_f429zi/src/main.rs
@@ -6,7 +6,6 @@
 // Disable this attribute when documenting, as a workaround for
 // https://github.com/rust-lang/rust/issues/62184.
 #![cfg_attr(not(doc), no_main)]
-#![feature(asm)]
 #![deny(missing_docs)]
 
 use capsules::virtual_alarm::VirtualMuxAlarm;

--- a/boards/nucleo_f446re/src/main.rs
+++ b/boards/nucleo_f446re/src/main.rs
@@ -6,7 +6,6 @@
 // Disable this attribute when documenting, as a workaround for
 // https://github.com/rust-lang/rust/issues/62184.
 #![cfg_attr(not(doc), no_main)]
-#![feature(asm)]
 #![deny(missing_docs)]
 
 use capsules::virtual_alarm::VirtualMuxAlarm;

--- a/boards/opentitan/src/main.rs
+++ b/boards/opentitan/src/main.rs
@@ -6,7 +6,6 @@
 // Disable this attribute when documenting, as a workaround for
 // https://github.com/rust-lang/rust/issues/62184.
 #![cfg_attr(not(doc), no_main)]
-#![feature(asm)]
 
 use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use capsules::virtual_hmac::VirtualMuxHmac;

--- a/boards/stm32f3discovery/src/main.rs
+++ b/boards/stm32f3discovery/src/main.rs
@@ -6,7 +6,7 @@
 // Disable this attribute when documenting, as a workaround for
 // https://github.com/rust-lang/rust/issues/62184.
 #![cfg_attr(not(doc), no_main)]
-#![feature(asm, core_intrinsics)]
+#![feature(core_intrinsics)]
 #![deny(missing_docs)]
 
 use capsules::lsm303dlhc;

--- a/chips/e310x/src/lib.rs
+++ b/chips/e310x/src/lib.rs
@@ -1,6 +1,5 @@
 //! Chip support for the E310 from SiFive.
 
-#![feature(asm)]
 #![no_std]
 #![crate_name = "e310x"]
 #![crate_type = "rlib"]

--- a/chips/lowrisc/src/lib.rs
+++ b/chips/lowrisc/src/lib.rs
@@ -1,6 +1,6 @@
 //! Implementations for generic LowRISC peripherals.
 
-#![feature(asm, const_fn, in_band_lifetimes)]
+#![feature(const_fn, in_band_lifetimes)]
 #![no_std]
 #![crate_name = "lowrisc"]
 #![crate_type = "rlib"]

--- a/chips/nrf52/src/lib.rs
+++ b/chips/nrf52/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(asm, const_fn)]
+#![feature(const_fn)]
 #![no_std]
 #![crate_name = "nrf52"]
 #![crate_type = "rlib"]

--- a/chips/sam4l/src/lib.rs
+++ b/chips/sam4l/src/lib.rs
@@ -4,7 +4,7 @@
 
 #![crate_name = "sam4l"]
 #![crate_type = "rlib"]
-#![feature(asm, const_fn, in_band_lifetimes)]
+#![feature(const_fn, in_band_lifetimes)]
 #![no_std]
 
 mod deferred_call_tasks;

--- a/chips/sifive/src/lib.rs
+++ b/chips/sifive/src/lib.rs
@@ -1,6 +1,6 @@
 //! Implementations for generic SiFive MCU peripherals.
 
-#![feature(asm, const_fn, in_band_lifetimes)]
+#![feature(const_fn, in_band_lifetimes)]
 #![no_std]
 #![crate_name = "sifive"]
 #![crate_type = "rlib"]

--- a/chips/stm32f303xc/src/lib.rs
+++ b/chips/stm32f303xc/src/lib.rs
@@ -4,7 +4,7 @@
 
 #![crate_name = "stm32f303xc"]
 #![crate_type = "rlib"]
-#![feature(asm, const_fn, in_band_lifetimes)]
+#![feature(const_fn, in_band_lifetimes)]
 #![no_std]
 #![allow(unused_doc_comments)]
 

--- a/chips/stm32f4xx/src/lib.rs
+++ b/chips/stm32f4xx/src/lib.rs
@@ -4,7 +4,7 @@
 
 #![crate_name = "stm32f4xx"]
 #![crate_type = "rlib"]
-#![feature(asm, const_fn, in_band_lifetimes)]
+#![feature(const_fn, in_band_lifetimes)]
 #![no_std]
 #![allow(unused_doc_comments)]
 


### PR DESCRIPTION
### Pull Request Overview

I noticed in #1776 that not all `asm` features are actually required. This removes many of the `asm` feature.

Part of #1654, technically.


### Testing Strategy

This pull request was tested by travis. (Can I still say that?)


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make format`.
- [x] Fixed errors surfaced by `make clippy`.
