### PR TITLE
nRF52: uart fixes for unknown bootloader configurations

### DIFF
--- a/chips/nrf52/src/uart.rs
+++ b/chips/nrf52/src/uart.rs
@@ -448,6 +448,14 @@ impl<'a> Uarte<'a> {
         self.set_tx_dma_pointer_to_buffer();
 
         let regs = &*self.registers;
+
+        // Make sure we clear the endtx interrupt since that is what we rely on
+        // to know when the DMA TX finishes. Normally, we clear this interrupt
+        // as we handle it, so this is not necessary. However, a bootloader (or
+        // some other startup code) may have setup TX interrupts, and there may
+        // be one pending. We clear it to be safe.
+        regs.event_endtx.write(Event::READY::CLEAR);
+
         regs.txd_maxcnt
             .write(Counter::COUNTER.val(min(tx_len as u32, UARTE_MAX_BUFFER_SIZE)));
         regs.task_starttx.write(Task::ENABLE::SET);

--- a/chips/nrf52/src/uart.rs
+++ b/chips/nrf52/src/uart.rs
@@ -300,15 +300,7 @@ impl<'a> Uarte<'a> {
             let tx_bytes = regs.txd_amount.get() as usize;
 
             let rem = match self.tx_remaining_bytes.get().checked_sub(tx_bytes) {
-                None => {
-                    debug!(
-                        "Error more bytes transmitted than requested\n \
-                         remaining: {} \t transmitted: {}",
-                        self.tx_remaining_bytes.get(),
-                        tx_bytes
-                    );
-                    return;
-                }
+                None => return,
                 Some(r) => r,
             };
 

--- a/chips/nrf52/src/uart.rs
+++ b/chips/nrf52/src/uart.rs
@@ -230,6 +230,13 @@ impl<'a> Uarte<'a> {
             },
         );
 
+        // Make sure we clear the endtx interrupt since that is what we rely on
+        // to know when the DMA TX finishes. Normally, we clear this interrupt
+        // as we handle it, so this is not necessary. However, a bootloader (or
+        // some other startup code) may have setup TX interrupts, and there may
+        // be one pending. We clear it to be safe.
+        regs.event_endtx.write(Event::READY::CLEAR);
+
         self.enable_uart();
     }
 
@@ -440,14 +447,6 @@ impl<'a> Uarte<'a> {
         self.set_tx_dma_pointer_to_buffer();
 
         let regs = &*self.registers;
-
-        // Make sure we clear the endtx interrupt since that is what we rely on
-        // to know when the DMA TX finishes. Normally, we clear this interrupt
-        // as we handle it, so this is not necessary. However, a bootloader (or
-        // some other startup code) may have setup TX interrupts, and there may
-        // be one pending. We clear it to be safe.
-        regs.event_endtx.write(Event::READY::CLEAR);
-
         regs.txd_maxcnt
             .write(Counter::COUNTER.val(min(tx_len as u32, UARTE_MAX_BUFFER_SIZE)));
         regs.task_starttx.write(Task::ENABLE::SET);

--- a/chips/nrf52/src/uart.rs
+++ b/chips/nrf52/src/uart.rs
@@ -12,7 +12,6 @@ use core::cmp::min;
 use kernel::common::cells::OptionalCell;
 use kernel::common::registers::{register_bitfields, ReadOnly, ReadWrite, WriteOnly};
 use kernel::common::StaticRef;
-use kernel::debug;
 use kernel::hil::uart;
 use kernel::ReturnCode;
 use nrf5x::pinmux;


### PR DESCRIPTION
### Pull Request Overview
Trying to setup the nano33ble, I ran into some issues with UART.

1. The bootloader seems to be enabling UART TX interrupt, which was causing an early interrupt, which caused Tock to re-send its TX buffer, which caused the number of TX'd bytes to be wrong, which caused UART to stop working.
2. There is a debug!() message that can never print (no callback is issued and interrupts are disabled), so it was very misleading since that case _was_ occurring, but yet there was no debug message. So I removed it.


### Testing Strategy

This pull request was tested by verifying UART now works on the nano33ble.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make format`.
- [ ] Fixed errors surfaced by `make clippy`.
