### PR TITLE
sam4l: usb: handle return code, long buffers

### DIFF
--- a/chips/sam4l/src/usbc/mod.rs
+++ b/chips/sam4l/src/usbc/mod.rs
@@ -1440,7 +1440,7 @@ fn endpoint_enable_interrupts(endpoint: usize, mask: FieldValue<u32, EndpointCon
 
 impl hil::usb::UsbController<'a> for Usbc<'a> {
     fn endpoint_set_ctrl_buffer(&self, buf: &'a [VolatileCell<u8>]) {
-        if buf.len() != 8 {
+        if buf.len() < 8 {
             client_err!("Bad endpoint buffer size");
         }
 
@@ -1448,7 +1448,7 @@ impl hil::usb::UsbController<'a> for Usbc<'a> {
     }
 
     fn endpoint_set_in_buffer(&self, endpoint: usize, buf: &'a [VolatileCell<u8>]) {
-        if buf.len() != 8 {
+        if buf.len() < 8 {
             client_err!("Bad endpoint buffer size");
         }
 
@@ -1456,7 +1456,7 @@ impl hil::usb::UsbController<'a> for Usbc<'a> {
     }
 
     fn endpoint_set_out_buffer(&self, endpoint: usize, buf: &'a [VolatileCell<u8>]) {
-        if buf.len() != 8 {
+        if buf.len() < 8 {
             client_err!("Bad endpoint buffer size");
         }
 

--- a/chips/sam4l/src/usbc/mod.rs
+++ b/chips/sam4l/src/usbc/mod.rs
@@ -952,7 +952,8 @@ impl Usbc<'a> {
                         };
 
                         match result {
-                            Some(hil::usb::CtrlSetupResult::Ok) => {
+                            Some(hil::usb::CtrlSetupResult::Ok)
+                            | Some(hil::usb::CtrlSetupResult::OkSetAddress) => {
                                 // Unsubscribe from SETUP interrupts
                                 endpoint_disable_interrupts(endpoint, EndpointControl::RXSTPE::SET);
 

--- a/chips/sam4l/src/usbc/mod.rs
+++ b/chips/sam4l/src/usbc/mod.rs
@@ -1043,11 +1043,15 @@ impl Usbc<'a> {
                                 packet_bytes,
                                 transfer_complete,
                             )) => {
-                                let packet_size = if packet_bytes == 8 && transfer_complete {
+                                // Check if the entire buffer is full, and
+                                // handle that case slightly differently. Note,
+                                // this depends on the length of the buffer
+                                // used. Right now, that is 64 bytes.
+                                let packet_size = if packet_bytes == 64 && transfer_complete {
                                     // Send a complete final packet, and request
                                     // that the controller also send a zero-length
                                     // packet to signal the end of transfer
-                                    PacketSize::BYTE_COUNT.val(8) + PacketSize::AUTO_ZLP::Yes
+                                    PacketSize::BYTE_COUNT.val(64) + PacketSize::AUTO_ZLP::Yes
                                 } else {
                                     // Send either a complete but not-final
                                     // packet, or a short and final packet (which


### PR DESCRIPTION
1. The `OkSetAddress` return type was split off from `Ok`, but not added to the return code handler for the SAM4L. This puts it back.
2. The capsule uses 64 byte buffers, while the sam4l driver originally only used 8 byte buffers. Since we only seem to use the pointer address in the driver, and not the actual length of the buffer, I think it should be fine if the buffers are too long.


### Testing Strategy

This pull request was tested by running the usb test on imix and verifying that my laptop recognizes the USB device.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make format`.
- [x] Fixed errors surfaced by `make clippy`.
