### PR TITLE
capsules: usb: change config descriptor to 1

### DIFF
--- a/capsules/src/usb/descriptors.rs
+++ b/capsules/src/usb/descriptors.rs
@@ -383,7 +383,7 @@ impl Default for ConfigurationDescriptor {
     fn default() -> Self {
         ConfigurationDescriptor {
             num_interfaces: 1,
-            configuration_value: 0,
+            configuration_value: 1,
             string_index: 0,
             attributes: ConfigurationAttributes::new(true, false),
             max_power: 0, // in 2mA units


### PR DESCRIPTION
This allows the USB tests to work for me on mac with imix.

I found this by trying to get the tools/usb tests to work. Without this, they fail with something like:

```
thread 'main' panicked at 'Claiming interface: NotFound', src/main.rs:70:5
```

because this line fails:

```
dh.claim_interface(0).expect("Claiming interface");
```

I then tried the same test but using an FTDI chip...which didn't work either but got past the claim interface step. I then compared the output of `lsusb` and changed the imix setup to match until it worked. This was the necessary change.

My guess is that maybe linux is more forgiving with this value than mac?


### Testing Strategy

This pull request was tested by running the tools/usb tests with imix.


### TODO or Help Wanted

It would be great to verify this still works on linux. Try the sam4l-usb branch on imix, and run the tools/usb/control-test.

Also, would be good to verify this doesn't break anything on the nRF.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make format`.
- [x] Fixed errors surfaced by `make clippy`.
