### PR TITLE
Add support for SMBus

### DIFF
--- a/boards/acd52832/src/main.rs
+++ b/boards/acd52832/src/main.rs
@@ -282,7 +282,7 @@ pub unsafe fn reset_handler() {
     // Create shared mux for the I2C bus
     let i2c_mux = static_init!(
         capsules::virtual_i2c::MuxI2C<'static>,
-        capsules::virtual_i2c::MuxI2C::new(&nrf52832::i2c::TWIM0)
+        capsules::virtual_i2c::MuxI2C::new(&nrf52832::i2c::TWIM0, None)
     );
     nrf52832::i2c::TWIM0.configure(
         nrf52832::pinmux::Pinmux::new(21),

--- a/boards/acd52832/src/main.rs
+++ b/boards/acd52832/src/main.rs
@@ -282,7 +282,7 @@ pub unsafe fn reset_handler() {
     // Create shared mux for the I2C bus
     let i2c_mux = static_init!(
         capsules::virtual_i2c::MuxI2C<'static>,
-        capsules::virtual_i2c::MuxI2C::new(&nrf52832::i2c::TWIM0, None)
+        capsules::virtual_i2c::MuxI2C::new(&nrf52832::i2c::TWIM0, None, dynamic_deferred_caller)
     );
     nrf52832::i2c::TWIM0.configure(
         nrf52832::pinmux::Pinmux::new(21),

--- a/boards/components/src/i2c.rs
+++ b/boards/components/src/i2c.rs
@@ -17,6 +17,7 @@
 
 use capsules::virtual_i2c::{I2CDevice, MuxI2C};
 use core::mem::MaybeUninit;
+use kernel::common::dynamic_deferred_call::DynamicDeferredCall;
 use kernel::component::Component;
 use kernel::hil::i2c;
 use kernel::static_init_half;
@@ -45,6 +46,7 @@ macro_rules! i2c_component_helper {
 pub struct I2CMuxComponent {
     i2c: &'static dyn i2c::I2CMaster,
     smbus: Option<&'static dyn i2c::SMBusMaster>,
+    deferred_caller: &'static DynamicDeferredCall,
 }
 
 pub struct I2CComponent {
@@ -56,8 +58,13 @@ impl I2CMuxComponent {
     pub fn new(
         i2c: &'static dyn i2c::I2CMaster,
         smbus: Option<&'static dyn i2c::SMBusMaster>,
+        deferred_caller: &'static DynamicDeferredCall,
     ) -> Self {
-        I2CMuxComponent { i2c, smbus }
+        I2CMuxComponent {
+            i2c,
+            smbus,
+            deferred_caller,
+        }
     }
 }
 
@@ -69,7 +76,13 @@ impl Component for I2CMuxComponent {
         let mux_i2c = static_init_half!(
             static_buffer,
             MuxI2C<'static>,
-            MuxI2C::new(self.i2c, self.smbus)
+            MuxI2C::new(self.i2c, self.smbus, self.deferred_caller)
+        );
+
+        mux_i2c.initialize_callback_handle(
+            self.deferred_caller
+                .register(mux_i2c)
+                .expect("no deferred call slot available for I2C mux"),
         );
 
         self.i2c.set_master_client(mux_i2c);

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -252,7 +252,10 @@ pub unsafe fn reset_handler() {
         .finalize(components::alarm_mux_component_helper!(sam4l::ast::Ast));
     ast.configure(mux_alarm);
 
-    let sensors_i2c = static_init!(MuxI2C<'static>, MuxI2C::new(&sam4l::i2c::I2C1, None));
+    let sensors_i2c = static_init!(
+        MuxI2C<'static>,
+        MuxI2C::new(&sam4l::i2c::I2C1, None, dynamic_deferred_caller)
+    );
     sam4l::i2c::I2C1.set_master_client(sensors_i2c);
 
     // SI7021 Temperature / Humidity Sensor, address: 0x40

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -252,7 +252,7 @@ pub unsafe fn reset_handler() {
         .finalize(components::alarm_mux_component_helper!(sam4l::ast::Ast));
     ast.configure(mux_alarm);
 
-    let sensors_i2c = static_init!(MuxI2C<'static>, MuxI2C::new(&sam4l::i2c::I2C1));
+    let sensors_i2c = static_init!(MuxI2C<'static>, MuxI2C::new(&sam4l::i2c::I2C1, None));
     sam4l::i2c::I2C1.set_master_client(sensors_i2c);
 
     // SI7021 Temperature / Humidity Sensor, address: 0x40

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -308,7 +308,10 @@ pub unsafe fn reset_handler() {
         .finalize(components::alarm_component_helper!(sam4l::ast::Ast));
 
     // # I2C and I2C Sensors
-    let mux_i2c = static_init!(MuxI2C<'static>, MuxI2C::new(&sam4l::i2c::I2C2, None));
+    let mux_i2c = static_init!(
+        MuxI2C<'static>,
+        MuxI2C::new(&sam4l::i2c::I2C2, None, dynamic_deferred_caller)
+    );
     sam4l::i2c::I2C2.set_master_client(mux_i2c);
 
     let ambient_light = AmbientLightComponent::new(board_kernel, mux_i2c, mux_alarm)

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -308,7 +308,7 @@ pub unsafe fn reset_handler() {
         .finalize(components::alarm_component_helper!(sam4l::ast::Ast));
 
     // # I2C and I2C Sensors
-    let mux_i2c = static_init!(MuxI2C<'static>, MuxI2C::new(&sam4l::i2c::I2C2));
+    let mux_i2c = static_init!(MuxI2C<'static>, MuxI2C::new(&sam4l::i2c::I2C2, None));
     sam4l::i2c::I2C2.set_master_client(mux_i2c);
 
     let ambient_light = AmbientLightComponent::new(board_kernel, mux_i2c, mux_alarm)

--- a/boards/stm32f3discovery/src/main.rs
+++ b/boards/stm32f3discovery/src/main.rs
@@ -479,7 +479,7 @@ pub unsafe fn reset_handler() {
 
     // LSM303DLHC
 
-    let mux_i2c = components::i2c::I2CMuxComponent::new(&stm32f303xc::i2c::I2C1)
+    let mux_i2c = components::i2c::I2CMuxComponent::new(&stm32f303xc::i2c::I2C1, None)
         .finalize(components::i2c_mux_component_helper!());
 
     let lsm303dlhc = components::lsm303dlhc::Lsm303dlhcI2CComponent::new()

--- a/boards/stm32f3discovery/src/main.rs
+++ b/boards/stm32f3discovery/src/main.rs
@@ -479,8 +479,12 @@ pub unsafe fn reset_handler() {
 
     // LSM303DLHC
 
-    let mux_i2c = components::i2c::I2CMuxComponent::new(&stm32f303xc::i2c::I2C1, None)
-        .finalize(components::i2c_mux_component_helper!());
+    let mux_i2c = components::i2c::I2CMuxComponent::new(
+        &stm32f303xc::i2c::I2C1,
+        None,
+        dynamic_deferred_caller,
+    )
+    .finalize(components::i2c_mux_component_helper!());
 
     let lsm303dlhc = components::lsm303dlhc::Lsm303dlhcI2CComponent::new()
         .finalize(components::lsm303dlhc_i2c_component_helper!(mux_i2c));

--- a/capsules/src/i2c_master_slave_driver.rs
+++ b/capsules/src/i2c_master_slave_driver.rs
@@ -79,6 +79,7 @@ impl hil::i2c::I2CHwMasterClient for I2CMasterSlaveDriver<'_> {
             hil::i2c::Error::DataNak => -2,
             hil::i2c::Error::ArbitrationLost => -3,
             hil::i2c::Error::Overrun => -4,
+            hil::i2c::Error::NotSupported => -5,
             hil::i2c::Error::CommandComplete => 0,
         };
 


### PR DESCRIPTION
### Pull Request Overview

Add some functions to support SMBus read/write operations. Although SMBus is similar to I2C it has a few differences, mostly in regards to frequency, ACK/NACK, timings and ARP.

Some I2C hardware exposes timing options that can be tweaked to better match the SMBus timing requirements. This is why we are adding two new functions. It tells the driver to tweak the timing to match the SMBus spec.

This PR adds new functions to the I2C HIL and also extends the `virtual_i2c.rs` to Mux SMBus devices with I2C devices.

### Testing Strategy

With some patches on top of this I can communicate with an SMBus IR temperature sensor. Once this is merged I'll send a PR to add the sensor.

### TODO or Help Wanted

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make format`.
- [X] Fixed errors surfaced by `make clippy`.
