### PR TITLE
sam4l: usb: don't just queue resume in

### DIFF
--- a/chips/sam4l/src/usbc/mod.rs
+++ b/chips/sam4l/src/usbc/mod.rs
@@ -1558,8 +1558,7 @@ impl<'a> hil::usb::UsbController<'a> for Usbc<'a> {
         requests.resume_in = true;
         self.requests[endpoint].set(requests);
 
-        // TODO: Not sure why this needs to be manually called. Not sure why
-        // it wasn't before.
+        // Immediately handle the request to resume the endpoint.
         self.handle_requests();
     }
 
@@ -1568,8 +1567,7 @@ impl<'a> hil::usb::UsbController<'a> for Usbc<'a> {
         requests.resume_out = true;
         self.requests[endpoint].set(requests);
 
-        // TODO: Not sure why this needs to be manually called. Not sure why
-        // it wasn't before.
+        // Immediately handle the request to resume the endpoint.
         self.handle_requests();
     }
 }

--- a/chips/sam4l/src/usbc/mod.rs
+++ b/chips/sam4l/src/usbc/mod.rs
@@ -1557,12 +1557,20 @@ impl<'a> hil::usb::UsbController<'a> for Usbc<'a> {
         let mut requests = self.requests[endpoint].get();
         requests.resume_in = true;
         self.requests[endpoint].set(requests);
+
+        // TODO: Not sure why this needs to be manually called. Not sure why
+        // it wasn't before.
+        self.handle_requests();
     }
 
     fn endpoint_resume_out(&self, endpoint: usize) {
         let mut requests = self.requests[endpoint].get();
         requests.resume_out = true;
         self.requests[endpoint].set(requests);
+
+        // TODO: Not sure why this needs to be manually called. Not sure why
+        // it wasn't before.
+        self.handle_requests();
     }
 }
 


### PR DESCRIPTION


### Pull Request Overview

While working on #1048 #1893, getting UART.tx to work (sending from device to host) I noticed that transmissions only worked when a character was received. I tracked it down to this change.

Basically, we want to ask the host to send by asking to resume the IN endpoint. The SAM4L driver handled our request, but then queued it until some later event (hence why it didn't work until some receive event). With this change the SAM4L driver now immediately handles our resume in request.

I'm not sure why it was queued in the first place.


### Testing Strategy

This pull request was tested by using hello_loop and console_recv apps on imix with the CDC driver.


### TODO or Help Wanted

What am I missing? What was the queue for? Maybe this change is good enough since I don't know how much interest there is in debugging the SAM4L USB stack.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make format`.
- [x] Fixed errors surfaced by `make clippy`.
