### PR TITLE
nrf52: usb: handle control OUT transfer

### DIFF
--- a/chips/nrf52/src/usbd.rs
+++ b/chips/nrf52/src/usbd.rs
@@ -1409,6 +1409,9 @@ impl<'a> Usbd<'a> {
                 self.client.map(|client| {
                     match client.ctrl_out(endpoint, regs.epout[endpoint].amount()) {
                         hil::usb::CtrlOutResult::Ok => {
+                            // TODO: Check if the CTRL WRITE is longer
+                            // than the amount of data we have received,
+                            // and receive more data before completing.
                             self.complete_ctrl_status();
                         }
                         hil::usb::CtrlOutResult::Delay => {}

--- a/chips/nrf52/src/usbd.rs
+++ b/chips/nrf52/src/usbd.rs
@@ -324,10 +324,6 @@ mod detail {
             self.ptr.set(slice.as_ptr() as *const u8);
             self.maxcnt.write(Count::MAXCNT.val(slice.len() as u32));
         }
-
-        pub fn amount(&self) -> u32 {
-            self.amount.get()
-        }
     }
 }
 
@@ -1407,7 +1403,7 @@ impl<'a> Usbd<'a> {
                 // Now we can handle it and pass it to the client to see
                 // what the client returns.
                 self.client.map(|client| {
-                    match client.ctrl_out(endpoint, regs.epout[endpoint].amount()) {
+                    match client.ctrl_out(endpoint, regs.size_epout[endpoint].get()) {
                         hil::usb::CtrlOutResult::Ok => {
                             // TODO: Check if the CTRL WRITE is longer
                             // than the amount of data we have received,


### PR DESCRIPTION
### Pull Request Overview

This pull request is part of #1048, #1893.

This adds support for control write (OUT) transfers in the nRF52 USB stack. This is needed for CDC since the host client sends control messages (which we ignore, but still need to respond to).

### Testing Strategy

This pull request was tested by running the CDC capsule and verifying that console tx and rx works using it on the nrf52840dk.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make format`.
- [x] Fixed errors surfaced by `make clippy`.
