### PR TITLE
Add Nano 33 BLE Board

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
     "boards/opentitan",
     "boards/redboard_artemis_nano",
     "boards/stm32f3discovery",
+    "boards/nano33ble",
     "capsules",
     "chips/apollo3",
     "chips/arty_e21_chip",

--- a/boards/README.md
+++ b/boards/README.md
@@ -12,6 +12,7 @@ that Tock supports.
 | [Nordic nRF52840-DK](nordic/nrf52840dk/README.md)                    | ARM Cortex-M4   | nRF52840       | jLink      | tockloader     |
 | [Nordic nRF52840-Dongle](nordic/nrf52840_dongle/README.md)           | ARM Cortex-M4   | nRF52840       | jLink      | tockloader     |
 | [ACD52832](acd52832/README.md)                                       | ARM Cortex-M4   | nRF52832       | jLink      | tockloader     |
+| [Nano 33 BLE](nano33ble/README.md)                                   | ARM Cortex-M4   | nRF52840       | BOSSA      | bossac         |
 | [TI LAUNCHXL-CC26x2](launchxl/README.md)                             | ARM Cortex-M4   | CC2652R        | openocd    | tockloader     |
 | [ST Nucleo F446RE](nucleo_f446re/README.md)                          | ARM Cortex-M4   | STM32F446      | openocd    | custom         |
 | [ST Nucleo F429ZI](nucleo_f429zi/README.md)                          | ARM Cortex-M4   | STM32F429      | openocd    | custom         |

--- a/boards/nano33ble/Cargo.toml
+++ b/boards/nano33ble/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "nano33ble"
+version = "0.1.0"
+authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+build = "build.rs"
+edition = "2018"
+
+[dependencies]
+cortexm4 = { path = "../../arch/cortex-m4" }
+capsules = { path = "../../capsules" }
+kernel = { path = "../../kernel" }
+nrf52 = { path = "../../chips/nrf52" }
+nrf52840 = { path = "../../chips/nrf52840" }
+components = { path = "../components" }
+nrf52dk_base = { path = "../nordic/nrf52dk_base" }

--- a/boards/nano33ble/Cargo.toml
+++ b/boards/nano33ble/Cargo.toml
@@ -12,4 +12,4 @@ kernel = { path = "../../kernel" }
 nrf52 = { path = "../../chips/nrf52" }
 nrf52840 = { path = "../../chips/nrf52840" }
 components = { path = "../components" }
-nrf52dk_base = { path = "../nordic/nrf52dk_base" }
+nrf52_components = { path = "../nordic/nrf52_components" }

--- a/boards/nano33ble/Makefile
+++ b/boards/nano33ble/Makefile
@@ -10,7 +10,7 @@ ifdef PORT
   FLAGS += --port $(PORT)
 endif
 
-# Upload the kernel over using bossac
+# Upload the kernel using bossac
 .PHONY: program
 program: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin
 	bossac $(FLAGS) -U -i -e -w $< -R

--- a/boards/nano33ble/Makefile
+++ b/boards/nano33ble/Makefile
@@ -1,0 +1,16 @@
+# Makefile for building the tock kernel for the Arduino Nano 33 BLE board.
+
+TOCK_ARCH=cortex-m4
+TARGET=thumbv7em-none-eabi
+PLATFORM=nano33ble
+
+include ../Makefile.common
+
+ifdef PORT
+  FLAGS += --port $(PORT)
+endif
+
+# Upload the kernel over using bossac
+.PHONY: program
+program: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin
+	bossac $(FLAGS) -U -i -e -w $< -R

--- a/boards/nano33ble/README.md
+++ b/boards/nano33ble/README.md
@@ -27,6 +27,9 @@ $ cd BOSSA
 $ make bossac
 ```
 
+Then you will need to add `BOSSA/bin` to your `$PATH` variable so that your
+system can find the `bossac` program.
+
 ## Programming the Kernel
 
 To program the kernel we use the BOSSA tool to communicate with the bootloader

--- a/boards/nano33ble/README.md
+++ b/boards/nano33ble/README.md
@@ -1,0 +1,83 @@
+Arduino Nano 33 BLE
+===================
+
+<img src="https://store-cdn.arduino.cc/usa/catalog/product/cache/1/image/1040x660/604a3538c15e081937dbfbd20aa60aad/a/b/abx00031_featured.jpg" width="35%">
+
+The [Arduino Nano 33 BLE](https://store.arduino.cc/usa/nano-33-ble) and [Arduino
+Nano 33 BLE Sense](https://store.arduino.cc/usa/nano-33-ble-sense) are compact
+boards based on the Nordic nRF52840 SoC. The "Sense" version includes the
+following sensors:
+
+- 9 axis inertial sensor
+- humidity and temperature sensor
+- barometric sensor
+- microphone
+- gesture, proximity, light color and light intensity sensor
+
+
+## Getting Started
+
+First, follow the [Tock Getting Started guide](../../../doc/Getting_Started.md)
+
+You will need the bossac bootloader tool:
+
+```shell
+$ git clone https://github.com/arduino/BOSSA
+$ cd BOSSA
+$ make bossac
+```
+
+## Programming the Kernel
+
+To program the kernel we use the BOSSA tool to communicate with the bootloader
+on the board which then flashes the kernel. This requires that the bootloader be
+active. To force the board into bootloader mode, press the button on the board
+twice in rapid succession. You should see the yellow LED pulse on and off.
+
+At this point you should be able to simply run `make program` in this directory
+to install a fresh kernel.
+
+```
+$ make program
+```
+
+You may need to specify the port like so:
+
+```
+$ make program PORT=<serial port path>
+```
+
+## Programming Applications
+
+This is currently a weakness of the Nano 33 board as flashing applications is
+not as ergonomic as Tock expects. Right now, you should be able to flash a
+single application. For example, to flash the "blink" app, first compile it:
+
+```
+$ git clone https://github.com/tock/libtock-c
+$ cd libtock-c/examples/blink
+$ make
+```
+
+This previous step will create a TAB (`.tab` file) that normally tockloader
+would use to program on the board. However, tockloader is currently not
+supported. As a workaround, we can directly program a single app. To load the
+blink app, first press the button on the board twice in rapid succession to
+enter the bootloader, and then:
+
+```
+$ bossac -i -e -o 0x20000 -w build/cortex-m4/cortex-m4.tbf -R
+```
+
+That tells the BOSSA tool to flash the application in the Tock Binary Format to
+the correct offset (the app will end up at address 0x30000). You may also need
+to pass the `--port` flag.
+
+## UART Debugging
+
+Currently the Nano 33 board file uses the UART peripheral for all UART
+debugging. However, that UART is not connected to the USB header on the board.
+So, all `debug!()` messages or application `printf()` calls will not be
+displayed. If you want to see the debug output, you need to connect to the two
+UART pins on the Nano 33 headers. You should be able to connect a serial <-> USB
+converter, like an FTDI board, to retrieve the UART output.

--- a/boards/nano33ble/README.md
+++ b/boards/nano33ble/README.md
@@ -96,11 +96,9 @@ and the physical elements on the Nano 33 BLE board.
 | LED[1]            | Tri-color LED Green |
 | LED[2]            | Tri-color LED Blue  |
 
-## UART Debugging
+## Debugging
 
-Currently the Nano 33 board file uses the UART peripheral for all UART
-debugging. However, that UART is not connected to the USB header on the board.
-So, all `debug!()` messages or application `printf()` calls will not be
-displayed. If you want to see the debug output, you need to connect to the two
-UART pins on the Nano 33 headers. You should be able to connect a serial <-> USB
-converter, like an FTDI board, to retrieve the UART output.
+The Nano 33 board uses a virtual serial console over USB to send debugging info
+from the kernel and print messages from applications. You can use whatever your
+favorite serial terminal program is to view the output. Tockloader also
+supports reading and writing to a serial console with `tockloader listen`.

--- a/boards/nano33ble/README.md
+++ b/boards/nano33ble/README.md
@@ -102,3 +102,13 @@ The Nano 33 board uses a virtual serial console over USB to send debugging info
 from the kernel and print messages from applications. You can use whatever your
 favorite serial terminal program is to view the output. Tockloader also
 supports reading and writing to a serial console with `tockloader listen`.
+
+### Kernel Panics
+
+If the kernel or an app encounter a `panic!()`, the panic handler specified in
+`io.rs` is called. This causes the kernel to stop. You will notice the yellow
+LED starts blinking in a repeating but slightly irregular pattern. There is also
+a panic print out that provides a fair bit of debugging information. However,
+currently that panic print info is transmitted over `UARTE0`, not the USB port.
+So, to view the panic info, you will need to connect to the two pins on the
+board labeled `TX1` and `RX0` and view the UART information there.

--- a/boards/nano33ble/README.md
+++ b/boards/nano33ble/README.md
@@ -73,6 +73,26 @@ That tells the BOSSA tool to flash the application in the Tock Binary Format to
 the correct offset (the app will end up at address 0x30000). You may also need
 to pass the `--port` flag.
 
+### Userspace Resource Mapping
+
+This table shows the mappings between resources available in userspace
+and the physical elements on the Nano 33 BLE board.
+
+| Software Resource | Physical Element    |
+|-------------------|---------------------|
+| GPIO[2]           | Pin D2              |
+| GPIO[3]           | Pin D3              |
+| GPIO[4]           | Pin D4              |
+| GPIO[5]           | Pin D5              |
+| GPIO[6]           | Pin D6              |
+| GPIO[7]           | Pin D7              |
+| GPIO[8]           | Pin D8              |
+| GPIO[9]           | Pin D9              |
+| GPIO[10]          | Pin D10             |
+| LED[0]            | Tri-color LED Red   |
+| LED[1]            | Tri-color LED Green |
+| LED[2]            | Tri-color LED Blue  |
+
 ## UART Debugging
 
 Currently the Nano 33 board file uses the UART peripheral for all UART

--- a/boards/nano33ble/build.rs
+++ b/boards/nano33ble/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    println!("cargo:rerun-if-changed=layout.ld");
+    println!("cargo:rerun-if-changed=../kernel_layout.ld");
+}

--- a/boards/nano33ble/layout.ld
+++ b/boards/nano33ble/layout.ld
@@ -1,0 +1,10 @@
+MEMORY
+{
+  rom (rx)  : ORIGIN = 0x00010000, LENGTH = 128K
+  prog (rx) : ORIGIN = 0x00030000, LENGTH = 832K
+  ram (rwx) : ORIGIN = 0x20000000, LENGTH = 256K
+}
+
+MPU_MIN_ALIGN = 8K;
+
+INCLUDE ../kernel_layout.ld

--- a/boards/nano33ble/src/io.rs
+++ b/boards/nano33ble/src/io.rs
@@ -1,0 +1,67 @@
+use core::fmt::Write;
+use core::panic::PanicInfo;
+
+use cortexm4;
+use kernel::debug;
+use kernel::debug::IoWrite;
+use kernel::hil::led;
+use kernel::hil::uart::{self, Configure};
+use nrf52840::gpio::Pin;
+
+use crate::CHIP;
+use crate::PROCESSES;
+
+struct Writer {
+    initialized: bool,
+}
+
+static mut WRITER: Writer = Writer { initialized: false };
+
+impl Write for Writer {
+    fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
+        self.write(s.as_bytes());
+        Ok(())
+    }
+}
+
+impl IoWrite for Writer {
+    fn write(&mut self, buf: &[u8]) {
+        let uart = unsafe { &mut nrf52840::uart::UARTE0 };
+        if !self.initialized {
+            self.initialized = true;
+            uart.configure(uart::Parameters {
+                baud_rate: 115200,
+                stop_bits: uart::StopBits::One,
+                parity: uart::Parity::None,
+                hw_flow_control: false,
+                width: uart::Width::Eight,
+            });
+        }
+        for &c in buf {
+            unsafe {
+                uart.send_byte(c);
+            }
+            while !uart.tx_ready() {}
+        }
+    }
+}
+
+/// Default panic handler for the Nano 33 Board.
+///
+/// We just use the standard default provided by the debug module in the kernel.
+#[cfg(not(test))]
+#[no_mangle]
+#[panic_handler]
+pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
+    const LED_KERNEL_PIN: Pin = Pin::P0_13;
+    let led = &mut led::LedLow::new(&mut nrf52840::gpio::PORT[LED_KERNEL_PIN]);
+    let writer = &mut WRITER;
+    debug::panic(
+        &mut [led],
+        writer,
+        pi,
+        &cortexm4::support::nop,
+        &PROCESSES,
+        &CHIP,
+    )
+}

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -133,15 +133,15 @@ pub unsafe fn reset_handler() {
         board_kernel,
         components::gpio_component_helper!(
             nrf52840::gpio::GPIOPin,
-            0 => &nrf52840::gpio::PORT[GPIO_D2],
-            1 => &nrf52840::gpio::PORT[GPIO_D3],
-            2 => &nrf52840::gpio::PORT[GPIO_D4],
-            3 => &nrf52840::gpio::PORT[GPIO_D5],
-            4 => &nrf52840::gpio::PORT[GPIO_D6],
-            5 => &nrf52840::gpio::PORT[GPIO_D7],
-            6 => &nrf52840::gpio::PORT[GPIO_D8],
-            7 => &nrf52840::gpio::PORT[GPIO_D9],
-            8 => &nrf52840::gpio::PORT[GPIO_D10]
+            2 => &nrf52840::gpio::PORT[GPIO_D2],
+            3 => &nrf52840::gpio::PORT[GPIO_D3],
+            4 => &nrf52840::gpio::PORT[GPIO_D4],
+            5 => &nrf52840::gpio::PORT[GPIO_D5],
+            6 => &nrf52840::gpio::PORT[GPIO_D6],
+            7 => &nrf52840::gpio::PORT[GPIO_D7],
+            8 => &nrf52840::gpio::PORT[GPIO_D8],
+            9 => &nrf52840::gpio::PORT[GPIO_D9],
+            10 => &nrf52840::gpio::PORT[GPIO_D10]
         ),
     )
     .finalize(components::gpio_component_buf!(nrf52840::gpio::GPIOPin));

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -1,6 +1,6 @@
 //! Tock kernel for the Arduino Nano 33 BLE.
 //!
-//! It is based on nRF52840 SoC (Cortex M4 core with a BLE transceiver).
+//! It is based on nRF52840 SoC (Cortex M4 core with a BLE + IEEE 802.15.4 transceiver).
 
 #![no_std]
 #![no_main]
@@ -66,7 +66,7 @@ pub struct Platform {
     //     nrf52::ble_radio::Radio,
     //     VirtualMuxAlarm<'static, Rtc<'static>>,
     // >,
-    // ieee802154_radio: Option<&'static capsules::ieee802154::RadioDriver<'static>>,
+    // ieee802154_radio: &'static capsules::ieee802154::RadioDriver<'static>,
     console: &'static capsules::console::Console<'static>,
     gpio: &'static capsules::gpio::GPIO<'static, nrf52::gpio::GPIOPin>,
     led: &'static capsules::led::LED<'static, nrf52::gpio::GPIOPin>,
@@ -90,10 +90,7 @@ impl kernel::Platform for Platform {
             capsules::led::DRIVER_NUM => f(Some(self.led)),
             capsules::rng::DRIVER_NUM => f(Some(self.rng)),
             // capsules::ble_advertising_driver::DRIVER_NUM => f(Some(self.ble_radio)),
-            // capsules::ieee802154::DRIVER_NUM => match self.ieee802154_radio {
-            //     Some(radio) => f(Some(radio)),
-            //     None => f(None),
-            // },
+            // capsules::ieee802154::DRIVER_NUM => f(Some(radio)),
             kernel::ipc::DRIVER_NUM => f(Some(&self.ipc)),
             _ => f(None),
         }
@@ -218,16 +215,20 @@ pub unsafe fn reset_handler() {
 
     let rng = components::rng::RngComponent::new(board_kernel, &nrf52::trng::TRNG).finalize(());
 
+    //--------------------------------------------------------------------------
+    // WIRELESS
+    //--------------------------------------------------------------------------
+
     // let ble_radio =
     //     BLEComponent::new(board_kernel, &nrf52::ble_radio::RADIO, mux_alarm).finalize(());
 
-    //     let (ieee802154_radio, _) = Ieee802154Component::new(
-    //         board_kernel,
-    //         &nrf52::ieee802154_radio::RADIO,
-    //         PAN_ID,
-    //         SRC_MAC,
-    //     )
-    //     .finalize(());
+    // let (ieee802154_radio, _) = Ieee802154Component::new(
+    //     board_kernel,
+    //     &nrf52::ieee802154_radio::RADIO,
+    //     PAN_ID,
+    //     SRC_MAC,
+    // )
+    // .finalize(());
 
     // Start all of the clocks. Low power operation will require a better
     // approach than this.

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -232,7 +232,7 @@ pub unsafe fn reset_handler() {
 
     // Start all of the clocks. Low power operation will require a better
     // approach than this.
-    nrf52dk_base::nrf52_components::NrfClockComponent::new().finalize(());
+    nrf52_components::NrfClockComponent::new().finalize(());
 
     let platform = Platform {
         // ble_radio: ble_radio,

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -190,8 +190,11 @@ pub unsafe fn reset_handler() {
     //--------------------------------------------------------------------------
 
     // Setup the CDC-ACM over USB driver that we will use for UART.
-    let cdc = components::cdc::CdcAcmComponent::new(&nrf52::usbd::USBD)
-        .finalize(components::usb_cdc_acm_component_helper!(nrf52::usbd::Usbd));
+    let cdc = components::cdc::CdcAcmComponent::new(
+        &nrf52::usbd::USBD,
+        capsules::usb::cdc::MAX_CTRL_PACKET_SIZE_NRF52840,
+    )
+    .finalize(components::usb_cdc_acm_component_helper!(nrf52::usbd::Usbd));
 
     // Create a shared UART channel for the console and for kernel debug.
     let uart_mux = components::console::UartMuxComponent::new(cdc, 115200, dynamic_deferred_caller)

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -1,0 +1,283 @@
+//! Tock kernel for the Arduino Nano 33 BLE.
+//!
+//! It is based on nRF52840 SoC (Cortex M4 core with a BLE transceiver).
+
+#![no_std]
+#![no_main]
+#![deny(missing_docs)]
+
+use kernel::capabilities;
+use kernel::common::dynamic_deferred_call::{DynamicDeferredCall, DynamicDeferredCallClientState};
+use kernel::component::Component;
+use kernel::hil::gpio::ActivationMode::ActiveLow;
+#[allow(unused_imports)]
+use kernel::{create_capability, debug, debug_gpio, debug_verbose, static_init};
+
+use nrf52840::gpio::Pin;
+
+// Three-color LED.
+const LED_RED_PIN: Pin = Pin::P0_24;
+const LED_GREEN_PIN: Pin = Pin::P0_16;
+const LED_BLUE_PIN: Pin = Pin::P0_06;
+
+const LED_KERNEL_PIN: Pin = Pin::P0_13;
+
+// const BUTTON_RST_PIN: Pin = Pin::P0_18;
+
+const GPIO_D2: Pin = Pin::P1_11;
+const GPIO_D3: Pin = Pin::P1_12;
+const GPIO_D4: Pin = Pin::P1_15;
+const GPIO_D5: Pin = Pin::P1_13;
+const GPIO_D6: Pin = Pin::P1_14;
+const GPIO_D7: Pin = Pin::P0_23;
+const GPIO_D8: Pin = Pin::P0_21;
+const GPIO_D9: Pin = Pin::P0_27;
+const GPIO_D10: Pin = Pin::P1_02;
+
+const UART_TX_PIN: Pin = Pin::P1_03;
+const UART_RX_PIN: Pin = Pin::P1_10;
+
+/// UART Writer for panic!()s.
+pub mod io;
+
+// State for loading and holding applications.
+// How should the kernel respond when a process faults.
+const FAULT_RESPONSE: kernel::procs::FaultResponse = kernel::procs::FaultResponse::Panic;
+
+// Number of concurrent processes this platform supports.
+const NUM_PROCS: usize = 8;
+
+#[link_section = ".app_memory"]
+static mut APP_MEMORY: [u8; 245760] = [0; 245760];
+
+static mut PROCESSES: [Option<&'static dyn kernel::procs::ProcessType>; NUM_PROCS] = [None; 8];
+
+static mut CHIP: Option<&'static nrf52840::chip::Chip> = None;
+
+/// Dummy buffer that causes the linker to reserve enough space for the stack.
+#[no_mangle]
+#[link_section = ".stack_buffer"]
+pub static mut STACK_MEMORY: [u8; 0x1000] = [0; 0x1000];
+
+/// Supported drivers by the platform
+pub struct Platform {
+    // ble_radio: &'static capsules::ble_advertising_driver::BLE<
+    //     'static,
+    //     nrf52::ble_radio::Radio,
+    //     VirtualMuxAlarm<'static, Rtc<'static>>,
+    // >,
+    // ieee802154_radio: Option<&'static capsules::ieee802154::RadioDriver<'static>>,
+    console: &'static capsules::console::Console<'static>,
+    gpio: &'static capsules::gpio::GPIO<'static, nrf52::gpio::GPIOPin>,
+    led: &'static capsules::led::LED<'static, nrf52::gpio::GPIOPin>,
+    rng: &'static capsules::rng::RngDriver<'static>,
+    ipc: kernel::ipc::IPC,
+    alarm: &'static capsules::alarm::AlarmDriver<
+        'static,
+        capsules::virtual_alarm::VirtualMuxAlarm<'static, nrf52::rtc::Rtc<'static>>,
+    >,
+}
+
+impl kernel::Platform for Platform {
+    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    where
+        F: FnOnce(Option<&dyn kernel::Driver>) -> R,
+    {
+        match driver_num {
+            capsules::console::DRIVER_NUM => f(Some(self.console)),
+            capsules::gpio::DRIVER_NUM => f(Some(self.gpio)),
+            capsules::alarm::DRIVER_NUM => f(Some(self.alarm)),
+            capsules::led::DRIVER_NUM => f(Some(self.led)),
+            capsules::rng::DRIVER_NUM => f(Some(self.rng)),
+            // capsules::ble_advertising_driver::DRIVER_NUM => f(Some(self.ble_radio)),
+            // capsules::ieee802154::DRIVER_NUM => match self.ieee802154_radio {
+            //     Some(radio) => f(Some(radio)),
+            //     None => f(None),
+            // },
+            kernel::ipc::DRIVER_NUM => f(Some(&self.ipc)),
+            _ => f(None),
+        }
+    }
+}
+
+/// Entry point in the vector table called on hard reset.
+#[no_mangle]
+pub unsafe fn reset_handler() {
+    // Loads relocations and clears BSS
+    nrf52840::init();
+
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
+
+    //--------------------------------------------------------------------------
+    // CAPABILITIES
+    //--------------------------------------------------------------------------
+
+    // Create capabilities that the board needs to call certain protected kernel
+    // functions.
+    let process_management_capability =
+        create_capability!(capabilities::ProcessManagementCapability);
+    let main_loop_capability = create_capability!(capabilities::MainLoopCapability);
+    let memory_allocation_capability = create_capability!(capabilities::MemoryAllocationCapability);
+
+    //--------------------------------------------------------------------------
+    // DEBUG GPIO
+    //--------------------------------------------------------------------------
+
+    // Configure kernel debug GPIOs as early as possible. These are used by the
+    // `debug_gpio!(0, toggle)` macro. We configure these early so that the
+    // macro is available during most of the setup code and kernel execution.
+    kernel::debug::assign_gpios(Some(&nrf52840::gpio::PORT[LED_KERNEL_PIN]), None, None);
+
+    //--------------------------------------------------------------------------
+    // GPIO
+    //--------------------------------------------------------------------------
+
+    let gpio = components::gpio::GpioComponent::new(
+        board_kernel,
+        components::gpio_component_helper!(
+            nrf52840::gpio::GPIOPin,
+            0 => &nrf52840::gpio::PORT[GPIO_D2],
+            1 => &nrf52840::gpio::PORT[GPIO_D3],
+            2 => &nrf52840::gpio::PORT[GPIO_D4],
+            3 => &nrf52840::gpio::PORT[GPIO_D5],
+            4 => &nrf52840::gpio::PORT[GPIO_D6],
+            5 => &nrf52840::gpio::PORT[GPIO_D7],
+            6 => &nrf52840::gpio::PORT[GPIO_D8],
+            7 => &nrf52840::gpio::PORT[GPIO_D9],
+            8 => &nrf52840::gpio::PORT[GPIO_D10]
+        ),
+    )
+    .finalize(components::gpio_component_buf!(nrf52840::gpio::GPIOPin));
+
+    //--------------------------------------------------------------------------
+    // LEDs
+    //--------------------------------------------------------------------------
+
+    let led = components::led::LedsComponent::new(components::led_component_helper!(
+        nrf52840::gpio::GPIOPin,
+        (&nrf52840::gpio::PORT[LED_RED_PIN], ActiveLow),
+        (&nrf52840::gpio::PORT[LED_GREEN_PIN], ActiveLow),
+        (&nrf52840::gpio::PORT[LED_BLUE_PIN], ActiveLow)
+    ))
+    .finalize(components::led_component_buf!(nrf52840::gpio::GPIOPin));
+
+    //--------------------------------------------------------------------------
+    // Deferred Call (Dynamic) Setup
+    //--------------------------------------------------------------------------
+
+    let dynamic_deferred_call_clients =
+        static_init!([DynamicDeferredCallClientState; 2], Default::default());
+    let dynamic_deferred_caller = static_init!(
+        DynamicDeferredCall,
+        DynamicDeferredCall::new(dynamic_deferred_call_clients)
+    );
+    DynamicDeferredCall::set_global_instance(dynamic_deferred_caller);
+
+    //--------------------------------------------------------------------------
+    // ALARM & TIMER
+    //--------------------------------------------------------------------------
+
+    let rtc = &nrf52::rtc::RTC;
+    rtc.start();
+
+    let mux_alarm = components::alarm::AlarmMuxComponent::new(rtc)
+        .finalize(components::alarm_mux_component_helper!(nrf52::rtc::Rtc));
+    let alarm = components::alarm::AlarmDriverComponent::new(board_kernel, mux_alarm)
+        .finalize(components::alarm_component_helper!(nrf52::rtc::Rtc));
+
+    //--------------------------------------------------------------------------
+    // UART & CONSOLE & DEBUG
+    //--------------------------------------------------------------------------
+
+    // Create a shared UART channel for the console and for kernel debug.
+    // `nrf52::uart::UARTE0` uses the UART pinned out on the castellated header,
+    // _not_ the micro USB.
+    let uart_mux = components::console::UartMuxComponent::new(
+        &nrf52::uart::UARTE0,
+        115200,
+        dynamic_deferred_caller,
+    )
+    .finalize(());
+
+    // Configure the UART pins on this specific board.
+    nrf52::uart::UARTE0.initialize(
+        nrf52::pinmux::Pinmux::new(UART_TX_PIN as u32),
+        nrf52::pinmux::Pinmux::new(UART_RX_PIN as u32),
+        None,
+        None,
+    );
+
+    // Setup the console.
+    let console = components::console::ConsoleComponent::new(board_kernel, uart_mux).finalize(());
+    // Create the debugger object that handles calls to `debug!()`.
+    components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
+
+    //--------------------------------------------------------------------------
+    // RANDOM NUMBERS
+    //--------------------------------------------------------------------------
+
+    let rng = components::rng::RngComponent::new(board_kernel, &nrf52::trng::TRNG).finalize(());
+
+    // let ble_radio =
+    //     BLEComponent::new(board_kernel, &nrf52::ble_radio::RADIO, mux_alarm).finalize(());
+
+    //     let (ieee802154_radio, _) = Ieee802154Component::new(
+    //         board_kernel,
+    //         &nrf52::ieee802154_radio::RADIO,
+    //         PAN_ID,
+    //         SRC_MAC,
+    //     )
+    //     .finalize(());
+
+    // Start all of the clocks. Low power operation will require a better
+    // approach than this.
+    nrf52dk_base::nrf52_components::NrfClockComponent::new().finalize(());
+
+    let platform = Platform {
+        // ble_radio: ble_radio,
+        // ieee802154_radio: ieee802154_radio,
+        console: console,
+        led: led,
+        gpio: gpio,
+        rng: rng,
+        alarm: alarm,
+        ipc: kernel::ipc::IPC::new(board_kernel, &memory_allocation_capability),
+    };
+
+    let chip = static_init!(nrf52840::chip::Chip, nrf52840::chip::new());
+    CHIP = Some(chip);
+
+    debug!("Initialization complete. Entering main loop.");
+
+    //--------------------------------------------------------------------------
+    // PROCESSES AND MAIN LOOP
+    //--------------------------------------------------------------------------
+
+    extern "C" {
+        /// Beginning of the ROM region containing app images.
+        static _sapps: u8;
+
+        /// End of the ROM region containing app images.
+        ///
+        /// This symbol is defined in the linker script.
+        static _eapps: u8;
+    }
+    kernel::procs::load_processes(
+        board_kernel,
+        chip,
+        core::slice::from_raw_parts(
+            &_sapps as *const u8,
+            &_eapps as *const u8 as usize - &_sapps as *const u8 as usize,
+        ),
+        &mut APP_MEMORY,
+        &mut PROCESSES,
+        FAULT_RESPONSE,
+        &process_management_capability,
+    )
+    .unwrap_or_else(|err| {
+        debug!("Error loading processes!");
+        debug!("{:?}", err);
+    });
+
+    board_kernel.kernel_loop(&platform, chip, Some(&platform.ipc), &main_loop_capability);
+}


### PR DESCRIPTION
### Pull Request Overview

This pull request adds a board main.rs for the long-discussed (see #994) Nano 33 BLE board. Since it is based on the nrf52840, this is pretty straightforward.

The bootloader situation is not the best at the moment, but that is a work in progress. Also right now the UART requires attaching an FTDI chip to the UART pins. However, when the CDC USB stack is merged we can switch to using the USB header.


### Testing Strategy

This pull request was tested by running the hello loop and blink apps on the board.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
