### PR TITLE
Update nucleo documentation and deleted sudo for make program

### DIFF
--- a/boards/nucleo_f429zi/README.md
+++ b/boards/nucleo_f429zi/README.md
@@ -45,7 +45,7 @@ KERNEL_WITH_APP=$(TOCK_ROOT_DIRECTORY)/target/$(TARGET)/debug/$(PLATFORM)-app.el
 .PHONY: program
 program: target/$(TARGET)/debug/$(PLATFORM).elf
         arm-none-eabi-objcopy --update-section .apps=$(APP) $(KERNEL) $(KERNEL_WITH_APP)
-        sudo $(OPENOCD) $(OPENOCD_OPTIONS) -c "init; reset halt; flash write_image erase $(KERNEL_WITH_APP); verify_image $(KERNEL_WITH_APP); reset; shutdown"
+        $(OPENOCD) $(OPENOCD_OPTIONS) -c "init; reset halt; flash write_image erase $(KERNEL_WITH_APP); verify_image $(KERNEL_WITH_APP); reset; shutdown"
 ```
 
 After setting `APP`, `KERNEL`, `KERNEL_WITH_APP`, and `program` target

--- a/boards/nucleo_f446re/README.md
+++ b/boards/nucleo_f446re/README.md
@@ -45,7 +45,7 @@ KERNEL_WITH_APP=$(TOCK_ROOT_DIRECTORY)/target/$(TARGET)/debug/$(PLATFORM)-app.el
 .PHONY: program
 program: target/$(TARGET)/debug/$(PLATFORM).elf
         arm-none-eabi-objcopy --update-section .apps=$(APP) $(KERNEL) $(KERNEL_WITH_APP)
-        sudo $(OPENOCD) $(OPENOCD_OPTIONS) -c "init; reset halt; flash write_image erase $(KERNEL_WITH_APP); verify_image $(KERNEL_WITH_APP); reset; shutdown"
+        $(OPENOCD) $(OPENOCD_OPTIONS) -c "init; reset halt; flash write_image erase $(KERNEL_WITH_APP); verify_image $(KERNEL_WITH_APP); reset; shutdown"
 ```
 
 After setting `APP`, `KERNEL`, `KERNEL_WITH_APP`, and `program` target


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes the documentation for nucleo boards, it deletes the sudo from make program.

### Testing Strategy

### TODO or Help Wanted

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
