### PR TITLE
hil: ble_advertising: Pass the transmit buffer on callback

### DIFF
--- a/capsules/src/ble_advertising_driver.rs
+++ b/capsules/src/ble_advertising_driver.rs
@@ -260,10 +260,8 @@ impl App {
                     data[..adv_data_len].copy_from_slice(adv_data_corrected);
                 }
                 let total_len = cmp::min(PACKET_LENGTH, payload_len + 2);
-                let result = ble
-                    .radio
+                ble.radio
                     .transmit_advertisement(kernel_tx, total_len, channel);
-                ble.kernel_tx.replace(result);
                 ReturnCode::SUCCESS
             })
         })
@@ -502,7 +500,8 @@ where
 {
     // The ReturnCode indicates valid CRC or not, not used yet but could be used for
     // re-transmissions for invalid CRCs
-    fn transmit_event(&self, _crc_ok: ReturnCode) {
+    fn transmit_event(&self, buf: &'static mut [u8], _crc_ok: ReturnCode) {
+        self.kernel_tx.replace(buf);
         self.sending_app.map(|appid| {
             let _ = self.app.enter(*appid, |app, _| {
                 match app.process_status {

--- a/kernel/src/hil/ble_advertising.rs
+++ b/kernel/src/hil/ble_advertising.rs
@@ -50,12 +50,7 @@
 use crate::returncode::ReturnCode;
 
 pub trait BleAdvertisementDriver {
-    fn transmit_advertisement(
-        &self,
-        buf: &'static mut [u8],
-        len: usize,
-        channel: RadioChannel,
-    ) -> &'static mut [u8];
+    fn transmit_advertisement(&self, buf: &'static mut [u8], len: usize, channel: RadioChannel);
     fn receive_advertisement(&self, channel: RadioChannel);
     fn set_receive_client(&self, client: &'static dyn RxClient);
     fn set_transmit_client(&self, client: &'static dyn TxClient);
@@ -70,7 +65,7 @@ pub trait RxClient {
 }
 
 pub trait TxClient {
-    fn transmit_event(&self, result: ReturnCode);
+    fn transmit_event(&self, buf: &'static mut [u8], result: ReturnCode);
 }
 
 // Bluetooth Core Specification:Vol. 6. Part B, section 1.4.1 Advertising and Data Channel Indices


### PR DESCRIPTION
### Pull Request Overview

Pass the BLE transmit buffer back to the capsule.

### Testing Strategy

### TODO or Help Wanted

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
