### PR TITLE
Add support for the MLX90614 IR Temperature Sensor

### DIFF
--- a/boards/components/src/lib.rs
+++ b/boards/components/src/lib.rs
@@ -17,6 +17,7 @@ pub mod l3gd20;
 pub mod led;
 pub mod lldb;
 pub mod lsm303dlhc;
+pub mod mlx90614;
 pub mod mx25r6435f;
 pub mod ninedof;
 pub mod nonvolatile_storage;

--- a/boards/components/src/mlx90614.rs
+++ b/boards/components/src/mlx90614.rs
@@ -1,0 +1,67 @@
+//! Components for the MLX90614 IR Temperature Sensor.
+//!
+//! Usage
+//! -----
+//! ```rust
+//!    let mlx90614 = components::mlx90614::Mlx90614I2CComponent::new()
+//!       .finalize(components::mlx90614_i2c_component_helper!(mux_i2c));
+//!
+//!    let temp = static_init!(
+//!           capsules::temperature::TemperatureSensor<'static>,
+//!           capsules::temperature::TemperatureSensor::new(mlx90614,
+//!                                                    grant_temperature));
+//!    kernel::hil::sensors::TemperatureDriver::set_client(mlx90614, temp);
+//! ```
+
+use capsules::mlx90614::Mlx90614SMBus;
+use capsules::virtual_i2c::{MuxI2C, SMBusDevice};
+use core::mem::MaybeUninit;
+use kernel::component::Component;
+use kernel::{static_init, static_init_half};
+
+// Setup static space for the objects.
+#[macro_export]
+macro_rules! mlx90614_component_helper {
+    () => {{
+        use capsules::mlx90614::Mlx90614SMBus;
+        use core::mem::MaybeUninit;
+        static mut BUF: MaybeUninit<Mlx90614SMBus<'static>> = MaybeUninit::uninit();
+        &mut BUF
+    };};
+}
+
+pub struct Mlx90614SMBusComponent {
+    i2c_mux: &'static MuxI2C<'static>,
+    i2c_address: u8,
+}
+
+impl Mlx90614SMBusComponent {
+    pub fn new(i2c: &'static MuxI2C<'static>, i2c_address: u8) -> Self {
+        Mlx90614SMBusComponent {
+            i2c_mux: i2c,
+            i2c_address: i2c_address,
+        }
+    }
+}
+
+static mut I2C_BUF: [u8; 14] = [0; 14];
+
+impl Component for Mlx90614SMBusComponent {
+    type StaticInput = &'static mut MaybeUninit<Mlx90614SMBus<'static>>;
+    type Output = &'static Mlx90614SMBus<'static>;
+
+    unsafe fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
+        let mlx90614_smbus = static_init!(
+            SMBusDevice,
+            SMBusDevice::new(self.i2c_mux, self.i2c_address)
+        );
+        let mlx90614 = static_init_half!(
+            static_buffer,
+            Mlx90614SMBus<'static>,
+            Mlx90614SMBus::new(mlx90614_smbus, &mut I2C_BUF)
+        );
+
+        mlx90614_smbus.set_client(mlx90614);
+        mlx90614
+    }
+}

--- a/capsules/README.md
+++ b/capsules/README.md
@@ -34,6 +34,7 @@ These implement a driver to setup and read various physical sensors.
 - **[L3GD20](src/l3gd20.rs)**: MEMS 3 axys digital gyroscope and temperature sensor.
 - **[LSM303DLHC](src/lsm303dlhc.rs)**: MEMS 3 axys digital accelerometer, magnetometer and temperature sensor.
 - **[LPS25HB](src/lps25hb.rs)**: Pressure sensor.
+- **[MLX90614](src/mlx90614.rs)**: Infrared temperature sensor.
 - **[SI7021](src/si7021.rs)**: Temperature and humidity sensor.
 - **[TMP006](src/tmp006.rs)**: Infrared temperature sensor.
 - **[TSL2561](src/tsl2561.rs)**: Light sensor.

--- a/capsules/src/driver.rs
+++ b/capsules/src/driver.rs
@@ -53,6 +53,7 @@ pub enum NUM {
     Lps25hb               = 0x70004,
     L3gd20                = 0x70005,
     Lsm303dlch            = 0x70006,
+    Mlx90614              = 0x70007,
 
     // Other ICs
     Ltc294x               = 0x80000,

--- a/capsules/src/lib.rs
+++ b/capsules/src/lib.rs
@@ -42,6 +42,7 @@ pub mod lsm303dlhc;
 pub mod ltc294x;
 pub mod max17205;
 pub mod mcp230xx;
+pub mod mlx90614;
 pub mod mx25r6435f;
 pub mod ninedof;
 pub mod nonvolatile_storage_driver;

--- a/capsules/src/mlx90614.rs
+++ b/capsules/src/mlx90614.rs
@@ -1,0 +1,220 @@
+//! Driver for the MLX90614 Infrared Thermometer.
+//!
+//! SMBus Interface
+//!
+//! Usage
+//! -----
+//!
+//! ```rust
+//! let mux_i2c = components::i2c::I2CMuxComponent::new(&ibex::i2c::I2C)
+//!     .finalize(components::i2c_mux_component_helper!());
+//!
+//! let mlx90614 = components::mlx90614::Mlx90614I2CComponent::new()
+//!    .finalize(components::mlx90614_i2c_component_helper!(mux_i2c));
+//! ```
+//!
+
+use crate::driver;
+use core::cell::Cell;
+use enum_primitive::cast::FromPrimitive;
+use enum_primitive::enum_from_primitive;
+use kernel::common::cells::{OptionalCell, TakeCell};
+use kernel::common::registers::register_bitfields;
+use kernel::hil::i2c::{self, Error};
+use kernel::hil::sensors;
+use kernel::{AppId, Callback, Driver, ReturnCode};
+
+/// Syscall driver number.
+pub const DRIVER_NUM: usize = driver::NUM::Mlx90614 as usize;
+
+register_bitfields![u16,
+    CONFIG [
+        IIR OFFSET(0) NUMBITS(3) [],
+        DUAL OFFSET(6) NUMBITS(1) [],
+        FIR OFFSET(8) NUMBITS(3) [],
+        GAIN OFFSET(11) NUMBITS(3) []
+    ]
+];
+
+#[derive(Clone, Copy, PartialEq, Debug)]
+enum State {
+    Idle,
+    IsPresent,
+    ReadAmbientTemp,
+    ReadObjTemp,
+}
+
+enum_from_primitive! {
+    enum Mlx90614Registers {
+        RAW1 = 0x04,
+        RAW2 = 0x05,
+        TA = 0x06,
+        TOBJ1 = 0x07,
+        TOBJ2 = 0x08,
+        EMISSIVITY = 0x24,
+        CONFIG = 0x25,
+    }
+}
+
+pub struct Mlx90614SMBus<'a> {
+    smbus_temp: &'a dyn i2c::SMBusDevice,
+    callback: OptionalCell<Callback>,
+    temperature_client: OptionalCell<&'a dyn sensors::TemperatureClient>,
+    buffer: TakeCell<'static, [u8]>,
+    state: Cell<State>,
+}
+
+impl<'a> Mlx90614SMBus<'_> {
+    pub fn new(
+        smbus_temp: &'a dyn i2c::SMBusDevice,
+        buffer: &'static mut [u8],
+    ) -> Mlx90614SMBus<'a> {
+        Mlx90614SMBus {
+            smbus_temp,
+            callback: OptionalCell::empty(),
+            temperature_client: OptionalCell::empty(),
+            buffer: TakeCell::new(buffer),
+            state: Cell::new(State::Idle),
+        }
+    }
+
+    fn is_present(&self) {
+        self.state.set(State::IsPresent);
+        self.buffer.take().map(|buf| {
+            // turn on i2c to send commands
+            buf[0] = Mlx90614Registers::RAW1 as u8;
+            self.smbus_temp.smbus_write_read(buf, 1, 1).unwrap();
+        });
+    }
+
+    fn read_ambient_temperature(&self) {
+        self.state.set(State::ReadAmbientTemp);
+        self.buffer.take().map(|buf| {
+            buf[0] = Mlx90614Registers::TA as u8;
+            self.smbus_temp.smbus_write_read(buf, 1, 1).unwrap();
+        });
+    }
+
+    fn read_object_temperature(&self) {
+        self.state.set(State::ReadObjTemp);
+        self.buffer.take().map(|buf| {
+            buf[0] = Mlx90614Registers::TOBJ1 as u8;
+            self.smbus_temp.smbus_write_read(buf, 1, 2).unwrap();
+        });
+    }
+}
+
+impl<'a> i2c::I2CClient for Mlx90614SMBus<'a> {
+    fn command_complete(&self, buffer: &'static mut [u8], error: Error) {
+        match self.state.get() {
+            State::Idle => {
+                self.buffer.replace(buffer);
+            }
+            State::IsPresent => {
+                let present = if error == Error::CommandComplete && buffer[0] == 60 {
+                    true
+                } else {
+                    false
+                };
+
+                self.callback.map(|callback| {
+                    callback.schedule(if present { 1 } else { 0 }, 0, 0);
+                });
+                self.buffer.replace(buffer);
+                self.state.set(State::Idle);
+            }
+            State::ReadAmbientTemp | State::ReadObjTemp => {
+                let mut temp: usize = 0;
+
+                let values = if error == Error::CommandComplete {
+                    // Convert to centi celsius
+                    temp = ((buffer[0] as usize | (buffer[1] as usize) << 8) * 2) - 27300;
+                    self.temperature_client.map(|client| {
+                        client.callback(temp as usize);
+                    });
+                    true
+                } else {
+                    self.temperature_client.map(|client| {
+                        client.callback(0);
+                    });
+                    false
+                };
+                if values {
+                    self.callback.map(|callback| {
+                        callback.schedule(temp, 0, 0);
+                    });
+                } else {
+                    self.callback.map(|callback| {
+                        callback.schedule(0, 0, 0);
+                    });
+                }
+                self.buffer.replace(buffer);
+                self.state.set(State::Idle);
+            }
+        }
+    }
+}
+
+impl<'a> Driver for Mlx90614SMBus<'a> {
+    fn command(&self, command_num: usize, _data1: usize, _data2: usize, _: AppId) -> ReturnCode {
+        match command_num {
+            0 => ReturnCode::SUCCESS,
+            // Check is sensor is correctly connected
+            1 => {
+                if self.state.get() == State::Idle {
+                    self.is_present();
+                    ReturnCode::SUCCESS
+                } else {
+                    ReturnCode::EBUSY
+                }
+            }
+            // Read Ambient Temperature
+            2 => {
+                if self.state.get() == State::Idle {
+                    self.read_ambient_temperature();
+                    ReturnCode::SUCCESS
+                } else {
+                    ReturnCode::EBUSY
+                }
+            }
+            // Read Object Temperature
+            3 => {
+                if self.state.get() == State::Idle {
+                    self.read_object_temperature();
+                    ReturnCode::SUCCESS
+                } else {
+                    ReturnCode::EBUSY
+                }
+            }
+            // default
+            _ => ReturnCode::ENOSUPPORT,
+        }
+    }
+
+    fn subscribe(
+        &self,
+        subscribe_num: usize,
+        callback: Option<Callback>,
+        _app_id: AppId,
+    ) -> ReturnCode {
+        match subscribe_num {
+            0 /* set the one shot callback */ => {
+				self.callback.insert(callback);
+				ReturnCode::SUCCESS
+			},
+            // default
+            _ => ReturnCode::ENOSUPPORT,
+        }
+    }
+}
+
+impl<'a> sensors::TemperatureDriver for Mlx90614SMBus<'a> {
+    fn set_client(&self, temperature_client: &'a dyn sensors::TemperatureClient) {
+        self.temperature_client.replace(temperature_client);
+    }
+
+    fn read_temperature(&self) -> ReturnCode {
+        self.read_object_temperature();
+        ReturnCode::SUCCESS
+    }
+}

--- a/capsules/src/virtual_i2c.rs
+++ b/capsules/src/virtual_i2c.rs
@@ -274,7 +274,11 @@ pub struct SMBusDevice<'a> {
 }
 
 impl<'a> SMBusDevice<'a> {
-    pub const fn new(mux: &'a MuxI2C<'a>, addr: u8) -> SMBusDevice<'a> {
+    pub fn new(mux: &'a MuxI2C<'a>, addr: u8) -> SMBusDevice<'a> {
+        if mux.smbus.is_none() {
+            panic!("There is no SMBus to attach to");
+        }
+
         SMBusDevice {
             mux: mux,
             addr: addr,


### PR DESCRIPTION
### Pull Request Overview

This PR adds support for the MLX90614 IR Temperature sensor which uses SMBus.

### Testing Strategy

Communicating with the sensor.

### TODO or Help Wanted

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
