### PR TITLE
Bind AppSlice to app instance (AppId), fixes #1914

### DIFF
--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -40,7 +40,7 @@ mod tbfheader;
 pub use crate::callback::{AppId, Callback};
 pub use crate::driver::Driver;
 pub use crate::grant::Grant;
-pub use crate::mem::{AppPtr, AppSlice, Private, Shared};
+pub use crate::mem::{AppSlice, Private, Shared};
 pub use crate::platform::systick::SysTick;
 pub use crate::platform::{mpu, Chip, Platform};
 pub use crate::platform::{ClockInterface, NoClockControl, NO_CLOCK_CONTROL};

--- a/kernel/src/mem.rs
+++ b/kernel/src/mem.rs
@@ -108,16 +108,22 @@ impl<L, T> AppSlice<L, T> {
 
 impl<L, T> AsRef<[T]> for AppSlice<L, T> {
     fn as_ref(&self) -> &[T] {
-        self.ptr.process.kernel.process_map_or(&[], self.ptr.process, |_| {
-            unsafe { slice::from_raw_parts(self.ptr.ptr.as_ref(), self.len) }
-        })
+        self.ptr
+            .process
+            .kernel
+            .process_map_or(&[], self.ptr.process, |_| unsafe {
+                slice::from_raw_parts(self.ptr.ptr.as_ref(), self.len)
+            })
     }
 }
 
 impl<L, T> AsMut<[T]> for AppSlice<L, T> {
     fn as_mut(&mut self) -> &mut [T] {
-        self.ptr.process.kernel.process_map_or(&mut [], self.ptr.process, |_| {
-            unsafe { slice::from_raw_parts_mut(self.ptr.ptr.as_mut(), self.len) }
-        })
+        self.ptr
+            .process
+            .kernel
+            .process_map_or(&mut [], self.ptr.process, |_| unsafe {
+                slice::from_raw_parts_mut(self.ptr.ptr.as_mut(), self.len)
+            })
     }
 }

--- a/kernel/src/mem.rs
+++ b/kernel/src/mem.rs
@@ -97,24 +97,77 @@ impl<L, T> AppSlice<L, T> {
         }
     }
 
+    /// Returns an iterator over the slice
+    ///
+    /// See
+    /// [`std::slice::iter()`](https://doc.rust-lang.org/std/primitive.slice.html#method.iter).
+    ///
+    /// Internally this uses
+    /// [`AsRef`](struct.AppSlice.html#impl-AsRef<[T]>), hence when
+    /// the app dies, restarts or the
+    /// [`AppId`](crate::callback::AppId) changes for any other
+    /// reason, the iterator will be of zero length.
     pub fn iter(&self) -> slice::Iter<T> {
         self.as_ref().iter()
     }
 
+    /// Returns an iterator that allows modifying each value
+    ///
+    /// See
+    /// [`std::slice::iter_mut()`](https://doc.rust-lang.org/std/primitive.slice.html#method.iter_mut).
+    ///
+    /// Internally this uses
+    /// [`AsMut`](struct.AppSlice.html#impl-AsMut<[T]>), hence when
+    /// the app dies, restarts or the
+    /// [`AppId`](crate::callback::AppId) changes for any other
+    /// reason, the iterator will be of zero length.
     pub fn iter_mut(&mut self) -> slice::IterMut<T> {
         self.as_mut().iter_mut()
     }
 
+    /// Iterate over `chunk_size` elements at a time, starting at the
+    /// beginning of the AppSlice.
+    ///
+    /// See
+    /// [`std::slice::chunks()`](https://doc.rust-lang.org/std/primitive.slice.html#method.chunks).
+    ///
+    /// Internally this uses
+    /// [`AsRef`](struct.AppSlice.html#impl-AsRef<[T]>), hence when
+    /// the app dies, restarts or the
+    /// [`AppId`](crate::callback::AppId) changes for any other
+    /// reason, a [`Chunks`](core::slice::Chunks) iterator of zero length will
+    /// be returned.
     pub fn chunks(&self, size: usize) -> slice::Chunks<T> {
         self.as_ref().chunks(size)
     }
 
+    /// Mutably iterate over `chunk_size` elements at a time, starting at the
+    /// beginning of the AppSlice.
+    ///
+    /// See
+    /// [`std::slice::chunks_mut()`](https://doc.rust-lang.org/std/primitive.slice.html#method.chunks_mut).
+    ///
+    /// Internally this uses
+    /// [`AsMut`](struct.AppSlice.html#impl-AsMut<[T]>), hence when
+    /// the app dies, restarts or the
+    /// [`AppId`](crate::callback::AppId) changes for any other
+    /// reason, a [`ChunksMut`](core::slice::ChunksMut) iterator of zero length will
+    /// be returned.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `chunk_size` is 0.
     pub fn chunks_mut(&mut self, size: usize) -> slice::ChunksMut<T> {
         self.as_mut().chunks_mut(size)
     }
 }
 
 impl<L, T> AsRef<[T]> for AppSlice<L, T> {
+    /// Get a slice reference over the userspace buffer
+    ///
+    /// This first checks whether the app died, restarted, or its
+    /// AppId identifier changed for any other reason. In this case, a
+    /// slice of length zero is returned.
     fn as_ref(&self) -> &[T] {
         self.ptr
             .process
@@ -126,6 +179,11 @@ impl<L, T> AsRef<[T]> for AppSlice<L, T> {
 }
 
 impl<L, T> AsMut<[T]> for AppSlice<L, T> {
+    /// Get a mutable slice reference over the userspace buffer
+    ///
+    /// This first checks whether the app died, restarted, or its
+    /// AppId identifier changed for any other reason. In this case, a
+    /// slice of length zero is returned.
     fn as_mut(&mut self) -> &mut [T] {
         self.ptr
             .process

--- a/kernel/src/mem.rs
+++ b/kernel/src/mem.rs
@@ -16,7 +16,7 @@ pub struct Shared;
 
 /// Base type for an AppSlice that holds the raw pointer to the memory region
 /// the app shared with the kernel.
-pub struct AppPtr<L, T> {
+pub(crate) struct AppPtr<L, T> {
     ptr: NonNull<T>,
     process: AppId,
     _phantom: PhantomData<L>,

--- a/kernel/src/mem.rs
+++ b/kernel/src/mem.rs
@@ -62,8 +62,16 @@ impl<L, T> AppSlice<L, T> {
     }
 
     /// Number of bytes in the `AppSlice`.
+    ///
+    /// If the app died, has restarted, or its AppId identifier
+    /// changed for any other reason, return an accessible length of
+    /// zero, consistent with the [`AsRef`](struct.AppSlice.html#impl-AsRef<[T]>)
+    /// and [`AsMut`](struct.AppSlice.html#impl-AsMut<[T]>) implementations.
     pub fn len(&self) -> usize {
-        self.len
+        self.ptr
+            .process
+            .kernel
+            .process_map_or(0, self.ptr.process, |_| self.len)
     }
 
     /// Get the raw pointer to the buffer. This will be a pointer inside of the


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes #1914 by checking whether the memory an AppSlice points to still belongs to the same app instance (more precisely, the `instance` field in `AppSlice`).

Thanks to @alevy for implementing the main part of this which turned out to be working perfectly. The commits on top make sure that the returned `AppSlice` length is consistent with the `AsRef` and `AsMut` implementations and document this new behavior.


### Testing Strategy

This pull request was tested by developing a crude capsule which deliberately keeps an `AppSlice` out of a grant and does not accept a second `allow`. This ensures that the AppSlice is shared from the first app instance, but is used in the second app instance.

The test capsule (integrated with the nRF52840) along the userspace `libtock_c` app can be found [here](https://github.com/lschuermann/tock/commit/6403b2e4305177dccf968f4f5f65dfd62c84069f).

The output validates that indeed the `AppSlice` returns a length of 0 and hands out a immutable / mutable slice of length `0`.
```
Initialization complete. Entering main loop
NRF52 HW INFO: Variant: AAC0, Part: N52840, Package: QI, Ram: K256, Flash: K1024

--> AppSlice safety test app!
Allow buffer of length 64
AppSlice shared by app!
Tell capsule to print AppSlice info
Shared slice reports length 64
Shared slice as_ref length 64
Shared slice as_mut length 64

<fault app by button press>

--> AppSlice safety test app!
Allow buffer of length 64
AppSlice already shared, refusing to replace
Tell capsule to print AppSlice info
Shared slice reports length 0
Shared slice as_ref length 0
Shared slice as_mut length 0
```

### TODO

We should probably run the release test suite along with the `DebugProcessRestart` capsule to make sure this doesn't break any existing capsules. I can verify this once this gets "yes, we indeed want this" feedback. :smile: 

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

  I believe there not to be a section in `/docs` which needs to elaborate on this behavior. I hope the generated rustdoc is sufficient. If indeed an update in `/docs` is required, please provide pointers to the respective section.

### Formatting

- [x] Ran `make prepush`.
