### PR TITLE
doc: add more details about QEMU support

### DIFF
--- a/boards/README.md
+++ b/boards/README.md
@@ -4,19 +4,21 @@ Platforms Supported by Tock
 The `/boards` directory contains the physical hardware platforms
 that Tock supports.
 
-| Board                                                                | Architecture    | MCU            | Interface  | App deployment | QEMU Support? |
-|----------------------------------------------------------------------|-----------------|----------------|------------|----------------|---------------|
-| [Hail](hail/README.md)                                               | ARM Cortex-M4   | SAM4LC8BA      | Bootloader | tockloader     | No            |
-| [Imix](imix/README.md)                                               | ARM Cortex-M4   | SAM4LC8CA      | Bootloader | tockloader     | No            |
-| [Nordic nRF52-DK](nordic/nrf52dk/README.md)                          | ARM Cortex-M4   | nRF52832       | jLink      | tockloader     | No            |
-| [Nordic nRF52840-DK](nordic/nrf52840dk/README.md)                    | ARM Cortex-M4   | nRF52840       | jLink      | tockloader     | No            |
-| [Nordic nRF52840-Dongle](nordic/nrf52840_dongle/README.md)           | ARM Cortex-M4   | nRF52840       | jLink      | tockloader     | No            |
-| [ACD52832](acd52832/README.md)                                       | ARM Cortex-M4   | nRF52832       | jLink      | tockloader     | No            |
-| [TI LAUNCHXL-CC26x2](launchxl/README.md)                             | ARM Cortex-M4   | CC2652R        | openocd    | tockloader     | No            |
-| [ST Nucleo F446RE](nucleo_f446re/README.md)                          | ARM Cortex-M4   | STM32F446      | openocd    | custom         | #1827         |
-| [ST Nucleo F429ZI](nucleo_f429zi/README.md)                          | ARM Cortex-M4   | STM32F429      | openocd    | custom         | #1827         |
-| [STM32F3Discovery kit](stm32f3discovery/README.md)                   | ARM Cortex-M4   | STM32F303VCT6  | openocd    | custom         | #1827         |
-| [SparkFun RedBoard Artemis Nano](redboard_artemis_nano/README.md)    | ARM Cortex-M4   | Apollo3        | custom     | custom         | No            |
-| [SiFive HiFive1](hifive1/README.md)                                  | RISC-V          | FE310-G000     | openocd    | tockloader     | Tock fork     |
-| [Digilent Arty A-7 100T](arty_e21/README.md)                         | RISC-V RV32IMAC | SiFive E21     | openocd    | tockloader     | No            |
-| [Nexys Video OpenTitan](opentitan/README.md)                         | RISC-V RV32IMC  | Ibex           | custom     | custom         | Tock fork     |
+| Board                                                                | Architecture    | MCU            | Interface  | App deployment | QEMU Support?     |
+|----------------------------------------------------------------------|-----------------|----------------|------------|----------------|-------------------|
+| [Hail](hail/README.md)                                               | ARM Cortex-M4   | SAM4LC8BA      | Bootloader | tockloader     | No                |
+| [Imix](imix/README.md)                                               | ARM Cortex-M4   | SAM4LC8CA      | Bootloader | tockloader     | No                |
+| [Nordic nRF52-DK](nordic/nrf52dk/README.md)                          | ARM Cortex-M4   | nRF52832       | jLink      | tockloader     | No                |
+| [Nordic nRF52840-DK](nordic/nrf52840dk/README.md)                    | ARM Cortex-M4   | nRF52840       | jLink      | tockloader     | No                |
+| [Nordic nRF52840-Dongle](nordic/nrf52840_dongle/README.md)           | ARM Cortex-M4   | nRF52840       | jLink      | tockloader     | No                |
+| [ACD52832](acd52832/README.md)                                       | ARM Cortex-M4   | nRF52832       | jLink      | tockloader     | No                |
+| [TI LAUNCHXL-CC26x2](launchxl/README.md)                             | ARM Cortex-M4   | CC2652R        | openocd    | tockloader     | No                |
+| [ST Nucleo F446RE](nucleo_f446re/README.md)                          | ARM Cortex-M4   | STM32F446      | openocd    | custom         | #1827             |
+| [ST Nucleo F429ZI](nucleo_f429zi/README.md)                          | ARM Cortex-M4   | STM32F429      | openocd    | custom         | #1827             |
+| [STM32F3Discovery kit](stm32f3discovery/README.md)                   | ARM Cortex-M4   | STM32F303VCT6  | openocd    | custom         | #1827             |
+| [SparkFun RedBoard Artemis Nano](redboard_artemis_nano/README.md)    | ARM Cortex-M4   | Apollo3        | custom     | custom         | No                |
+| [SiFive HiFive1](hifive1/README.md)                                  | RISC-V          | FE310-G000     | openocd    | tockloader     | [Tock fork][qemu] |
+| [Digilent Arty A-7 100T](arty_e21/README.md)                         | RISC-V RV32IMAC | SiFive E21     | openocd    | tockloader     | No                |
+| [Nexys Video OpenTitan](opentitan/README.md)                         | RISC-V RV32IMC  | Ibex           | custom     | custom         | [Tock fork][qemu] |
+
+[qemu]: ../doc/Qemu.md#tock-qemu-fork

--- a/boards/README.md
+++ b/boards/README.md
@@ -4,19 +4,19 @@ Platforms Supported by Tock
 The `/boards` directory contains the physical hardware platforms
 that Tock supports.
 
-| Board                                                                | Architecture    | MCU            | Interface  | App deployment |
-|----------------------------------------------------------------------|-----------------|----------------|------------|----------------|
-| [Hail](hail/README.md)                                               | ARM Cortex-M4   | SAM4LC8BA      | Bootloader | tockloader     |
-| [Imix](imix/README.md)                                               | ARM Cortex-M4   | SAM4LC8CA      | Bootloader | tockloader     |
-| [Nordic nRF52-DK](nordic/nrf52dk/README.md)                          | ARM Cortex-M4   | nRF52832       | jLink      | tockloader     |
-| [Nordic nRF52840-DK](nordic/nrf52840dk/README.md)                    | ARM Cortex-M4   | nRF52840       | jLink      | tockloader     |
-| [Nordic nRF52840-Dongle](nordic/nrf52840_dongle/README.md)           | ARM Cortex-M4   | nRF52840       | jLink      | tockloader     |
-| [ACD52832](acd52832/README.md)                                       | ARM Cortex-M4   | nRF52832       | jLink      | tockloader     |
-| [TI LAUNCHXL-CC26x2](launchxl/README.md)                             | ARM Cortex-M4   | CC2652R        | openocd    | tockloader     |
-| [ST Nucleo F446RE](nucleo_f446re/README.md)                          | ARM Cortex-M4   | STM32F446      | openocd    | custom         |
-| [ST Nucleo F429ZI](nucleo_f429zi/README.md)                          | ARM Cortex-M4   | STM32F429      | openocd    | custom         |
-| [STM32F3Discovery kit](stm32f3discovery/README.md)                   | ARM Cortex-M4   | STM32F303VCT6  | openocd    | custom         |
-| [SparkFun RedBoard Artemis Nano](redboard_artemis_nano/README.md)    | ARM Cortex-M4   | Apollo3        | custom     | custom         |
-| [SiFive HiFive1](hifive1/README.md)                                  | RISC-V          | FE310-G000     | openocd    | tockloader     |
-| [Digilent Arty A-7 100T](arty_e21/README.md)                         | RISC-V RV32IMAC | SiFive E21     | openocd    | tockloader     |
-| [Nexys Video OpenTitan](opentitan/README.md)                         | RISC-V RV32IMC  | Ibex           | custom     | custom         |
+| Board                                                                | Architecture    | MCU            | Interface  | App deployment | QEMU Support? |
+|----------------------------------------------------------------------|-----------------|----------------|------------|----------------|---------------|
+| [Hail](hail/README.md)                                               | ARM Cortex-M4   | SAM4LC8BA      | Bootloader | tockloader     | No            |
+| [Imix](imix/README.md)                                               | ARM Cortex-M4   | SAM4LC8CA      | Bootloader | tockloader     | No            |
+| [Nordic nRF52-DK](nordic/nrf52dk/README.md)                          | ARM Cortex-M4   | nRF52832       | jLink      | tockloader     | No            |
+| [Nordic nRF52840-DK](nordic/nrf52840dk/README.md)                    | ARM Cortex-M4   | nRF52840       | jLink      | tockloader     | No            |
+| [Nordic nRF52840-Dongle](nordic/nrf52840_dongle/README.md)           | ARM Cortex-M4   | nRF52840       | jLink      | tockloader     | No            |
+| [ACD52832](acd52832/README.md)                                       | ARM Cortex-M4   | nRF52832       | jLink      | tockloader     | No            |
+| [TI LAUNCHXL-CC26x2](launchxl/README.md)                             | ARM Cortex-M4   | CC2652R        | openocd    | tockloader     | No            |
+| [ST Nucleo F446RE](nucleo_f446re/README.md)                          | ARM Cortex-M4   | STM32F446      | openocd    | custom         | #1827         |
+| [ST Nucleo F429ZI](nucleo_f429zi/README.md)                          | ARM Cortex-M4   | STM32F429      | openocd    | custom         | #1827         |
+| [STM32F3Discovery kit](stm32f3discovery/README.md)                   | ARM Cortex-M4   | STM32F303VCT6  | openocd    | custom         | #1827         |
+| [SparkFun RedBoard Artemis Nano](redboard_artemis_nano/README.md)    | ARM Cortex-M4   | Apollo3        | custom     | custom         | No            |
+| [SiFive HiFive1](hifive1/README.md)                                  | RISC-V          | FE310-G000     | openocd    | tockloader     | Tock fork     |
+| [Digilent Arty A-7 100T](arty_e21/README.md)                         | RISC-V RV32IMAC | SiFive E21     | openocd    | tockloader     | No            |
+| [Nexys Video OpenTitan](opentitan/README.md)                         | RISC-V RV32IMC  | Ibex           | custom     | custom         | Tock fork     |

--- a/doc/Getting_Started.md
+++ b/doc/Getting_Started.md
@@ -38,6 +38,11 @@ developing Tock.
    the options with `tockloader` support to load applications, as that
    is the configuration that most examples and tutorials assume.
 
+   **Note:** QEMU support in Tock is in the very early stages. Please be
+   sure to check whether and how QEMU is supported for a board based on
+   the table in the [`boards/` subdirectory](../boards/README.md).
+   The `make ci-job-qemu` target is the authority on QEMU support.
+
    * Info about testing Tock on QEMU
      * 01/08/2020 : Among the boards supported by Tock, [SiFive HiFive1 RISC-V Board](../boards/hifive1/#running-in-qemu) can be tested in QEMU.
 

--- a/doc/Qemu.md
+++ b/doc/Qemu.md
@@ -1,0 +1,35 @@
+Qemu and Tock
+=============
+
+Tock is experimenting with QEMU.
+
+**All things QEMU are in very early stages and rough edges are to be expected.**
+
+That said, please do file PRs or issues if you run into trouble or find things
+confusing. The long-term goal is to integrate QEMU as a core part of CI for Tock.
+
+<!-- npm i -g markdown-toc; markdown-toc -i Qemu.md -->
+
+<!-- toc -->
+
+- [Supported Boards](#supported-boards)
+- [Tock QEMU Fork](#tock-qemu-fork)
+
+<!-- tocstop -->
+
+## Supported Boards
+
+QEMU support for embedded platforms is limited. Please check the the table in
+the [`boards/` subdirectory](../boards/README.md) for an up-to-date list of
+supported boards.
+
+## Tock QEMU Fork
+
+Some of the Tock developers are working to improve board support, but one
+consequences is that not everything is yet upstreamed.
+
+In the short term, we abstract all of this away in the build system.
+To experiement with the Tock fork, the easiest path is the run
+`make ci-job-qemu`, which will fetch and build everything for you.
+While things are in flux, those wanting more details are encouraged to look at
+the make recipe.


### PR DESCRIPTION
### Pull Request Overview

This pull request adds some documentation and caveats to QEMU support.

### Testing Strategy

N/A

### TODO or Help Wanted

Probably still more documentation, but this is at least a step in the right direction and hopefully tempers expectations a bit.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
