### PR TITLE
Make the Field::mask and FieldValue::mask fields private.

### DIFF
--- a/libraries/riscv-csr/src/csr.rs
+++ b/libraries/riscv-csr/src/csr.rs
@@ -58,14 +58,12 @@ impl<T: IntLike, R: RegisterLongName> ReadWriteRiscvCsr<T, R> {
 
     #[inline]
     pub fn read(&self, field: Field<T, R>) -> T {
-        (self.get() & (field.mask << field.shift)) >> field.shift
+        field.read(self.get())
     }
 
     #[inline]
     pub fn read_as_enum<E: TryFromValue<T, EnumType = E>>(&self, field: Field<T, R>) -> Option<E> {
-        let val: T = self.read(field);
-
-        E::try_from(val)
+        field.read_as_enum(self.get())
     }
 
     #[inline]
@@ -80,26 +78,25 @@ impl<T: IntLike, R: RegisterLongName> ReadWriteRiscvCsr<T, R> {
 
     #[inline]
     pub fn modify(&self, field: FieldValue<T, R>) {
-        let reg: T = self.get();
-        self.set((reg & !field.mask) | field.value);
+        self.set(field.modify(self.get()));
     }
 
     #[inline]
     pub fn modify_no_read(&self, original: LocalRegisterCopy<T, R>, field: FieldValue<T, R>) {
-        self.set((original.get() & !field.mask) | field.value);
+        self.set(field.modify(original.get()));
     }
     #[inline]
     pub fn is_set(&self, field: Field<T, R>) -> bool {
-        self.read(field) != T::zero()
+        field.is_set(self.get())
     }
 
     #[inline]
     pub fn matches_any(&self, field: FieldValue<T, R>) -> bool {
-        self.get() & field.mask != T::zero()
+        field.matches_any(self.get())
     }
 
     #[inline]
     pub fn matches_all(&self, field: FieldValue<T, R>) -> bool {
-        self.get() & field.mask == field.value
+        field.matches_all(self.get())
     }
 }

--- a/libraries/tock-register-interface/src/registers.rs
+++ b/libraries/tock-register-interface/src/registers.rs
@@ -503,7 +503,7 @@ impl<T: IntLike, R: RegisterLongName> InMemoryRegister<T, R> {
 /// Specific section of a register.
 #[derive(Copy, Clone)]
 pub struct Field<T: IntLike, R: RegisterLongName> {
-    pub mask: T,
+    mask: T,
     pub shift: usize,
     associated_register: PhantomData<R>,
 }
@@ -589,7 +589,7 @@ impl<R: RegisterLongName> Field<u64, R> {
 // location in the register.
 #[derive(Copy, Clone)]
 pub struct FieldValue<T: IntLike, R: RegisterLongName> {
-    pub mask: T,
+    mask: T,
     pub value: T,
     associated_register: PhantomData<R>,
 }


### PR DESCRIPTION
### Pull Request Overview

The `mask` fields don't need to be exposed publicly, as their use cases overlap with the existing functions to manipulate fields.

- This pull request makes them private.
- As a side effect, the `libraries/riscv-csr/src/csr.rs` is refactored to use the unified arithmetic methods introduced in #1766.


### Testing Strategy

This pull request was tested by CI.


### TODO or Help Wanted

- These changes currently overlap with #1926, although are compatible with that PR, as discussed in https://github.com/tock/tock/pull/1926#discussion_r440143726.
- The `Field::shift` field should also be made private, but is currently used in `chips/lowrisc/src/gpio.rs`. That code should probably be refactored so that the shift is not exposed as-is. https://github.com/tock/tock/blob/555b3a0441697d111a0330c01d392c15b36712f6/chips/lowrisc/src/gpio.rs#L94-L104
- Likewise, the `FieldValue::value` field should be made private, but is currently used in https://github.com/tock/tock/blob/555b3a0441697d111a0330c01d392c15b36712f6/libraries/riscv-csr/src/csr.rs#L76-L79


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.