### PR TITLE
debug: add flag for kernel_loop begin

### DIFF
--- a/kernel/src/debug.rs
+++ b/kernel/src/debug.rs
@@ -355,7 +355,15 @@ pub struct DebugWriter {
 /// needed so the debug!() macros have a reference to the object to use.
 static mut DEBUG_WRITER: Option<&'static mut DebugWriterWrapper> = None;
 
+/// The `debug!` macro only works correctly once the kernel loop is running.
+/// This is a guard to help prevent folks working on board bringup from
+/// accidentally trying to use `debug!` too early in boot.
+pub(crate) static mut DEBUG_KERNEL_LOOP_STARTED: bool = false;
+
 pub unsafe fn get_debug_writer() -> &'static mut DebugWriterWrapper {
+    if !DEBUG_KERNEL_LOOP_STARTED {
+        panic!("Cannot use `debug!` before kernel_loop");
+    }
     DEBUG_WRITER
         .as_deref_mut()
         .expect("Must call `set_debug_writer_wrapper` in board initialization.")

--- a/kernel/src/hil/emergency_serial.rs
+++ b/kernel/src/hil/emergency_serial.rs
@@ -1,0 +1,28 @@
+//! Hardware interface layer (HIL) for Emergency Serial
+//!
+
+use crate::returncode::ReturnCode;
+
+/// This is a serial-like interface designated for use only in exceptional
+/// situations. In contrast to other kernel interfaces, all methods here are
+/// synchronous. Implementations of this HIL should be as conservative as
+/// possible, use as few chip/board features as possible, and rely on as
+/// little as possible from the rest of the kernel.
+///
+/// The primary use case for this interface is to support panic! messages.
+/// Certain debug primitives may also leverage this interface, however such
+/// debuggging is intended exclusively for active development work. Only
+/// panic! may use this interface in mainline code.
+pub trait EmergencySerial {
+    /// Called once before any other methods. This is responsible for ensuring
+    /// that subsequent writes will succeed. If appropriate, other users of the
+    /// underlying serial interface should be shut down (e.g. cancelling DMA).
+    /// This shutdown **does not** need to be graceful, nor should it trigger
+    /// other kernel code to run if possible (e.g. disable DMA interrupts
+    /// before cancelling transactions so the DMA handler will not run).
+    fn initialize(&self);
+
+    /// Send a byte over the serial interface. This method must block until the
+    /// byte has been sent.
+    fn write_byte(&self, byte: u8);
+}

--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -292,6 +292,10 @@ impl Kernel {
         ipc: Option<&ipc::IPC>,
         _capability: &dyn capabilities::MainLoopCapability,
     ) {
+        unsafe {
+            debug::DEBUG_KERNEL_LOOP_STARTED = true;
+        }
+
         loop {
             unsafe {
                 chip.service_pending_interrupts();


### PR DESCRIPTION
### Pull Request Overview

As noted in #1931, it's a bit non-obvious to folks working on board bringup that `debug!` can't be used before the kernel loop has begun.

This is a bit brute force-y of an implementation, but it's in line with the `DEBUG_WRITER` and kind of the ugly necessity of the lower-level debug stuff.

### Testing Strategy

Compiling.

### TODO or Help Wanted

N/A; feedback if folks have it.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
