### PR TITLE
Console: Check for receive length just in case

### DIFF
--- a/kernel/src/hil/uart.rs
+++ b/kernel/src/hil/uart.rs
@@ -263,7 +263,7 @@ pub trait ReceiveClient {
     /// SHOULD NOT return EBUSY: when this callback is made the UART should
     /// be ready to receive another call.
     ///
-    /// The `rx_len` argument specifies how many words were transmitted.
+    /// The `rx_len` argument specifies how many words were received.
     /// An `rval` of SUCCESS indicates that every requested word was
     /// received: `rx_len` in the callback should be the same as
     /// `rx_len` in the initiating call.
@@ -273,7 +273,7 @@ pub trait ReceiveClient {
     ///     the buffer was not fully received. `rx_len` contains
     ///     how many words were received.
     ///   - ESIZE if the buffer could only be partially received. `rx_len`
-    ///     contains how many words were transmitted.
+    ///     contains how many words were received.
     ///   - FAIL if reception failed in some way: `error` may contain further
     ///     information.
     fn received_buffer(


### PR DESCRIPTION
### Pull Request Overview

This pull request adds a check in the console capsule to ensure that the console doesn't report that more bytes were received than were actually copied into the buffer. This shouldn't ever happen, but a buggy driver could lead to this behavior. This prevents that bug from propagating to userspace. However, userspace might want to know that the kernel is broken, so an error is reported since likely bytes were lost due to this bug.

Also fixes a comment in UART HIL.


### Testing Strategy

Hopefully simple enough to not be needed.


### TODO or Help Wanted

I could see closing this PR, since if we write UART HIL implementations according to the spec this case won't happen. But I wanted to open it to wrap up #1900.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

I'm not actually sure how the console syscall doc matches the console driver, but the return values weren't specified, so I didn't make any changes.

### Formatting

- [x] Ran `make prepush`.
