### PR TITLE
kernel: TBF parsing: match the threat model

### DIFF
--- a/kernel/src/tbfheader.rs
+++ b/kernel/src/tbfheader.rs
@@ -473,30 +473,18 @@ pub(crate) fn parse_tbf_header_lengths(
     // We trust that the version number has been checked prior to running this
     // parsing code. That is, whatever loaded this application has verified that
     // the version is valid and therefore we can trust it.
-    let version = u16::from_le_bytes(
-        app.get(0..2)
-            .ok_or(InitialTbfParseError::UnableToParse)?
-            .try_into()?,
-    );
+    let version = u16::from_le_bytes([app[0], app[1]]);
 
     match version {
         2 => {
             // In version 2, the next 16 bits after the version represent
             // the size of the TBF header in bytes.
-            let tbf_header_size = u16::from_le_bytes(
-                app.get(2..4)
-                    .ok_or(InitialTbfParseError::UnableToParse)?
-                    .try_into()?,
-            );
+            let tbf_header_size = u16::from_le_bytes([app[2], app[3]]);
 
             // The next 4 bytes are the size of the entire app's TBF space
             // including the header. This also must be checked before parsing
             // this header and we trust the value in flash.
-            let tbf_size = u32::from_le_bytes(
-                app.get(4..8)
-                    .ok_or(InitialTbfParseError::UnableToParse)?
-                    .try_into()?,
-            );
+            let tbf_size = u32::from_le_bytes([app[4], app[5], app[6], app[7]]);
 
             // Check that the header length isn't greater than the entire app,
             // and is at least as large as the v2 required header (which is 16

--- a/kernel/src/tbfheader.rs
+++ b/kernel/src/tbfheader.rs
@@ -15,14 +15,35 @@ macro_rules! align4 {
     };
 }
 
+/// Error when parsing just the beginning of the TBF header. This is only used
+/// when establishing the linked list structure of apps installed in flash.
+pub(crate) enum InitialTbfParseError {
+    /// We were unable to parse the beginning of the header. This either means
+    /// we ran out of flash, or the trusted values are invalid meaning this is
+    /// just empty flash after the end of the last app. This error is fine, as
+    /// it just means we must have hit the end of the linked list of apps.
+    UnableToParse,
+
+    /// Some length or value in the header is invalid. The header parsing has
+    /// failed at this point. However, the total app length value is a trusted
+    /// field, so we return that value with this error so that we can skip over
+    /// this invalid app and continue to check for additional apps.
+    InvalidHeader(u32),
+}
+
+impl From<core::array::TryFromSliceError> for InitialTbfParseError {
+    // Convert a slice to a parsed type. Since we control how long we make our
+    // slices, this conversion should never fail. If it does, then this is a bug
+    // in this library that must be fixed.
+    fn from(_error: core::array::TryFromSliceError) -> Self {
+        InitialTbfParseError::UnableToParse
+    }
+}
+
 /// Error when parsing an app's TBF header.
 pub enum TbfParseError {
     /// Not enough bytes in the buffer to parse the expected field.
     NotEnoughFlash,
-
-    /// The length fields of the header and app do not make sense. Likely the
-    /// TBF header length is set to be longer than the entire app.
-    BadSize,
 
     /// Unknown version of the TBF header.
     UnsupportedVersion(u16),
@@ -62,7 +83,6 @@ impl fmt::Debug for TbfParseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             TbfParseError::NotEnoughFlash => write!(f, "Buffer too short to parse TBF header"),
-            TbfParseError::BadSize => write!(f, "Invalid TBF header and app lengths"),
             TbfParseError::UnsupportedVersion(version) => {
                 write!(f, "TBF version {} unsupported", version)
             }
@@ -432,10 +452,20 @@ impl TbfHeader {
 ///
 /// ## Return
 ///
-/// Ok((Version, TBF header length, entire TBF length))
+/// If all parsing is successful:
+/// - Ok((Version, TBF header length, entire TBF length))
+///
+/// If we cannot parse the header because we have run out of flash, or the
+/// values are entirely wrong we return `UnableToParse`. This means we have hit
+/// the end of apps in flash.
+/// - Err(InitialTbfParseError::UnableToParse)
+///
+/// Any other error we return an error and the length of the entire app so that
+/// we can skip over it and check for the next app.
+/// - Err(InitialTbfParseError::InvalidHeader(app_length))
 pub(crate) fn parse_tbf_header_lengths(
     app: &'static [u8; 8],
-) -> Result<(u16, u16, u32), TbfParseError> {
+) -> Result<(u16, u16, u32), InitialTbfParseError> {
     // Version is the first 16 bits of the app TBF contents. We need this to
     // correctly parse the other lengths.
     //
@@ -445,7 +475,7 @@ pub(crate) fn parse_tbf_header_lengths(
     // the version is valid and therefore we can trust it.
     let version = u16::from_le_bytes(
         app.get(0..2)
-            .ok_or(TbfParseError::NotEnoughFlash)?
+            .ok_or(InitialTbfParseError::UnableToParse)?
             .try_into()?,
     );
 
@@ -455,7 +485,7 @@ pub(crate) fn parse_tbf_header_lengths(
             // the size of the TBF header in bytes.
             let tbf_header_size = u16::from_le_bytes(
                 app.get(2..4)
-                    .ok_or(TbfParseError::NotEnoughFlash)?
+                    .ok_or(InitialTbfParseError::UnableToParse)?
                     .try_into()?,
             );
 
@@ -464,20 +494,24 @@ pub(crate) fn parse_tbf_header_lengths(
             // this header and we trust the value in flash.
             let tbf_size = u32::from_le_bytes(
                 app.get(4..8)
-                    .ok_or(TbfParseError::NotEnoughFlash)?
+                    .ok_or(InitialTbfParseError::UnableToParse)?
                     .try_into()?,
             );
 
-            // Check that the header length isn't greater than the entire
-            // app. If that at least looks good then return the sizes.
-            if u32::from(tbf_header_size) > tbf_size {
-                Err(TbfParseError::BadSize)
+            // Check that the header length isn't greater than the entire app,
+            // and is at least as large as the v2 required header (which is 16
+            // bytes). If that at least looks good then return the sizes.
+            if u32::from(tbf_header_size) > tbf_size || tbf_header_size < 16 {
+                Err(InitialTbfParseError::InvalidHeader(tbf_size))
             } else {
                 Ok((version, tbf_header_size, tbf_size))
             }
         }
 
-        _ => Err(TbfParseError::UnsupportedVersion(version)),
+        // Since we have to trust the total size, and by extension the version
+        // number, if we don't know how to handle the version this must not be
+        // an actual app. Likely this is just the end of the app linked list.
+        _ => Err(InitialTbfParseError::UnableToParse),
     }
 }
 


### PR DESCRIPTION
I was testing Tockloader, and a bug I introduced caused the header_len field to be 14 (when it should have been 16). This caused the kernel to give me an internal kernel error, which is against the threat model. This change fixes that issue, and gets the TBF parsing logic inline with the threat model.

The main change is being much more clear about what errors can be returned with doing the initial parsing of the tbf header in flash. Now there are only two options: we are at the end of apps, or we return the length of the entire app (which is a trusted field). This allows us to more confidently stop parsing for apps, as well as skip over invalid apps.



### Testing Strategy

I tested this with tockloader to corrupt the header length field of an app, and it no longer causes an internal error. Additionally, I flashed two apps, and corrupted the first header length, and the second app was successfully parsed and executed.


### TODO or Help Wanted

I have one question for @jrvanwhy: is it OK that I am assuming that the version is trusted as part of the total length being trusted? If not, then we have to assume that the total length is _always_ 4 bytes into the tbf header, which we might not want to do. Right now, if the version doesn't match I assume the "app" is just erased flash at the end of the app linked list. 


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
