### PR TITLE
nrf52: usb: do not print debug!() info on startup

### DIFF
--- a/chips/nrf52/src/usbd.rs
+++ b/chips/nrf52/src/usbd.rs
@@ -8,7 +8,6 @@ use kernel::common::registers::{
     ReadWrite, WriteOnly,
 };
 use kernel::common::StaticRef;
-use kernel::debug;
 use kernel::hil;
 use kernel::hil::usb::TransferType;
 
@@ -37,13 +36,13 @@ macro_rules! debug_packets {
 
 macro_rules! debug_info {
     [ $( $arg:expr ),+ ] => {
-        debug!($( $arg ),+);
+        {} // debug!($( $arg ),+);
     };
 }
 
 macro_rules! internal_warn {
     [ $( $arg:expr ),+ ] => {
-        debug!($( $arg ),+);
+        {} // debug!($( $arg ),+);
     };
 }
 


### PR DESCRIPTION
Debug statements at the beginning of the USB driver init process conflict with using the USB stack for UART/debug!(), since those debug outputs cause the USB driver to try to start sending before it is fully initialized. Eventually, an assertion fails and everything crashes.

They are also a little noisy for users not debugging the USB stack.



### Testing Strategy

This pull request was tested by getting CDC working on the nano33ble board.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
