### PR TITLE
Add USB CDC Component, Move set_client() to USB HIL

### DIFF
--- a/boards/components/src/cdc.rs
+++ b/boards/components/src/cdc.rs
@@ -1,0 +1,57 @@
+//! Component for CDC-ACM over USB support.
+//!
+//! This provides a component for using the CDC-ACM driver. This allows for
+//! serial communication over USB.
+//!
+//! Usage
+//! -----
+//! ```rust
+//! let cdc_acm = components::cdc::CdcAcmComponent::new(&nrf52::usbd::USBD)
+//!     .finalize(components::usb_cdc_acm_component_helper!(nrf52::usbd::Usbd));
+//! ```
+
+use core::mem::MaybeUninit;
+
+use kernel::component::Component;
+use kernel::hil;
+use kernel::static_init_half;
+
+// Setup static space for the objects.
+#[macro_export]
+macro_rules! usb_cdc_acm_component_helper {
+    ($U:ty) => {{
+        use core::mem::MaybeUninit;
+        static mut BUF: MaybeUninit<capsules::usb::cdc::CdcAcm<'static, $U>> =
+            MaybeUninit::uninit();
+        &mut BUF
+    };};
+}
+
+pub struct CdcAcmComponent<U: 'static + hil::usb::UsbController<'static>> {
+    usb: &'static U,
+}
+
+impl<U: 'static + hil::usb::UsbController<'static>> CdcAcmComponent<U> {
+    pub fn new(usb: &'static U) -> CdcAcmComponent<U> {
+        CdcAcmComponent { usb }
+    }
+}
+
+impl<U: 'static + hil::usb::UsbController<'static>> Component for CdcAcmComponent<U> {
+    type StaticInput = &'static mut MaybeUninit<capsules::usb::cdc::CdcAcm<'static, U>>;
+    type Output = &'static capsules::usb::cdc::CdcAcm<'static, U>;
+
+    unsafe fn finalize(self, s: Self::StaticInput) -> Self::Output {
+        let cdc = static_init_half!(
+            s,
+            capsules::usb::cdc::CdcAcm<'static, U>,
+            capsules::usb::cdc::CdcAcm::new(
+                self.usb,
+                capsules::usb::usbc_client::MAX_CTRL_PACKET_SIZE_NRF52840
+            )
+        );
+        self.usb.set_client(cdc);
+
+        cdc
+    }
+}

--- a/boards/components/src/lib.rs
+++ b/boards/components/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod alarm;
 pub mod analog_comparator;
 pub mod button;
+pub mod cdc;
 pub mod console;
 pub mod crc;
 pub mod debug_queue;

--- a/boards/imix/src/imix_components/usb.rs
+++ b/boards/imix/src/imix_components/usb.rs
@@ -17,6 +17,7 @@
 use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
+use kernel::hil::usb::UsbController;
 use kernel::static_init;
 
 pub struct UsbComponent {

--- a/chips/lowrisc/src/usbdev.rs
+++ b/chips/lowrisc/src/usbdev.rs
@@ -293,7 +293,7 @@ impl Endpoint {
 pub struct Usb<'a> {
     registers: StaticRef<UsbRegisters>,
     descriptors: [Endpoint; N_ENDPOINTS],
-    client: Option<&'a dyn hil::usb::Client<'a>>,
+    client: OptionalCell<&'a dyn hil::usb::Client<'a>>,
     state: OptionalCell<State>,
 }
 
@@ -315,14 +315,9 @@ impl<'a> Usb<'a> {
                 Endpoint::new(),
                 Endpoint::new(),
             ],
-            client: None,
+            client: OptionalCell::empty(),
             state: OptionalCell::new(State::Reset),
         }
-    }
-
-    /// Set a client to receive data from the USBC
-    pub fn set_client(&mut self, client: &'a dyn hil::usb::Client<'a>) {
-        self.client = Some(client);
     }
 
     fn get_state(&self) -> State {
@@ -365,6 +360,10 @@ impl<'a> Usb<'a> {
 }
 
 impl<'a> hil::usb::UsbController<'a> for Usb<'a> {
+    fn set_client(&self, client: &'a dyn hil::usb::Client<'a>) {
+        self.client.set(client);
+    }
+
     fn endpoint_set_ctrl_buffer(&self, buf: &'a [VolatileCell<u8>]) {
         self._endpoint_bank_set_buffer(0, buf);
     }

--- a/chips/nrf52/src/usbd.rs
+++ b/chips/nrf52/src/usbd.rs
@@ -1114,10 +1114,6 @@ impl<'a> Usbd<'a> {
         internal_warn!("disable_lowpower() not implemented");
     }
 
-    pub fn set_client(&self, client: &'a dyn hil::usb::Client<'a>) {
-        self.client.set(client);
-    }
-
     pub fn handle_interrupt(&self) {
         let regs = &*self.registers;
 
@@ -1802,6 +1798,10 @@ impl<'a> power::PowerClient for Usbd<'a> {
 }
 
 impl<'a> hil::usb::UsbController<'a> for Usbd<'a> {
+    fn set_client(&self, client: &'a dyn hil::usb::Client<'a>) {
+        self.client.set(client);
+    }
+
     fn endpoint_set_ctrl_buffer(&self, buf: &'a [VolatileCell<u8>]) {
         if buf.len() < 8 {
             panic!("Endpoint buffer must be at least 8 bytes");

--- a/kernel/src/hil/usb.rs
+++ b/kernel/src/hil/usb.rs
@@ -4,6 +4,8 @@ use crate::common::cells::VolatileCell;
 
 /// USB controller interface
 pub trait UsbController<'a> {
+    fn set_client(&self, client: &'a dyn Client<'a>);
+
     // Should be called before `enable_as_device()`
     fn endpoint_set_ctrl_buffer(&self, buf: &'a [VolatileCell<u8>]);
     fn endpoint_set_in_buffer(&self, endpoint: usize, buf: &'a [VolatileCell<u8>]);


### PR DESCRIPTION
### Pull Request Overview

This pull request adds a CDC component, while also doing the standard update to the USB HIL to add `set_client()` to the interface.


### Testing Strategy

This pull request was tested by running the CDC component on nano33ble.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
