### PR TITLE
CDC: Wait for CDC messages, add delay to nRF USB RESET

### DIFF
--- a/capsules/src/usb/cdc.rs
+++ b/capsules/src/usb/cdc.rs
@@ -60,6 +60,9 @@ pub struct CdcAcm<'a, U: 'a> {
     /// 64 byte buffers for each endpoint.
     buffers: [Buffer64; N_ENDPOINTS],
 
+    /// Flag to track if the underlying USB stack is initialized and ready.
+    initialized: Cell<bool>,
+
     /// A holder reference for the TX buffer we are transmitting from.
     tx_buffer: TakeCell<'static, [u8]>,
     /// The number of bytes the client has asked us to send. We track this so we
@@ -188,6 +191,7 @@ impl<'a, U: hil::usb::UsbController<'a>> CdcAcm<'a, U> {
                 Buffer64::default(),
                 Buffer64::default(),
             ],
+            initialized: Cell::new(false),
             tx_buffer: TakeCell::empty(),
             tx_len: Cell::new(0),
             tx_offset: Cell::new(0),
@@ -232,7 +236,13 @@ impl<'a, U: hil::usb::UsbController<'a>> hil::usb::Client<'a> for CdcAcm<'a, U> 
     }
 
     fn bus_reset(&'a self) {
-        // No need to handle this at this layer.
+        // This signals enumeration has finished, and at this point we can ask
+        // for IN transfers if needed.
+        self.initialized.set(true);
+
+        if self.tx_buffer.is_some() {
+            self.controller().endpoint_resume_in(ENDPOINT_IN_NUM);
+        }
     }
 
     /// Handle a Control Setup transaction
@@ -247,13 +257,6 @@ impl<'a, U: hil::usb::UsbController<'a>> hil::usb::Client<'a> for CdcAcm<'a, U> 
 
     /// Handle a Control Out transaction
     fn ctrl_out(&'a self, endpoint: usize, packet_bytes: u32) -> hil::usb::CtrlOutResult {
-        // Hack to make sure we ask to send data if we have a buffer queued. We
-        // expect control out messages when the host actually connects via CDC,
-        // so we use this to generate the data IN request.
-        if self.tx_buffer.is_some() {
-            self.controller().endpoint_resume_in(ENDPOINT_IN_NUM);
-        }
-
         self.client_ctrl.ctrl_out(endpoint, packet_bytes)
     }
 
@@ -443,10 +446,12 @@ impl<'a, U: hil::usb::UsbController<'a>> uart::Transmit<'a> for CdcAcm<'a, U> {
             self.tx_offset.set(0);
             self.tx_buffer.replace(tx_buffer);
 
-            // Then signal to the lower layer that we are ready to do a TX by
-            // putting data in the IN endpoint.
-            self.controller().endpoint_resume_in(ENDPOINT_IN_NUM);
-
+            // Don't try to send if the USB stack isn't initialized yet.
+            if self.initialized.get() {
+                // Then signal to the lower layer that we are ready to do a TX by
+                // putting data in the IN endpoint.
+                self.controller().endpoint_resume_in(ENDPOINT_IN_NUM);
+            }
             (ReturnCode::SUCCESS, None)
         }
     }

--- a/capsules/src/usb/usbc_client_ctrl.rs
+++ b/capsules/src/usb/usbc_client_ctrl.rs
@@ -48,7 +48,7 @@ pub struct ClientCtrl<'a, 'b, U: 'a> {
 
     /// A 64-byte buffer for the control endpoint to be passed to the USB
     /// driver.
-    ctrl_buffer: Buffer64,
+    pub ctrl_buffer: Buffer64,
 
     /// Storage for composing responses to device descriptor requests.
     descriptor_storage: [Cell<u8>; DESCRIPTOR_BUFLEN],

--- a/chips/nrf52/src/usbd.rs
+++ b/chips/nrf52/src/usbd.rs
@@ -1305,6 +1305,16 @@ impl<'a> Usbd<'a> {
 
         self.dma_pending.set(false);
 
+        // Wait for at least T_RSTRCY for the hardware to be ready after the USB
+        // RESET (§6.35.6). I measured the loop using GPIO pins from `0..800000`
+        // as a 62.5 ms delay, and that was enough to allow the CDC layer to
+        // work. I tried shorter time than that (`0..700000`, measured at 54.7
+        // ms), but then the EPDATA event on the very first IN transfer
+        // immediately after the `client.bus_reset()` call below never occurs.
+        for _ in 0..800000 {
+            cortexm4::support::nop();
+        }
+
         // TODO: reset controller stack
         self.client.map(|client| {
             client.bus_reset();


### PR DESCRIPTION
### Pull Request Overview

This pull request allows the CDC layer to work on nRF even if it transmits a message immediately. We now wait for CDC messages that correlate with a CDC client being connected before requesting an endpoint IN transfer.

This also includes a delay for the nRF chip after a USB RESET event. Without this, the nRF chip could setup an IN transfer, but not ever get the interrupt that the transfer finished. According to the datasheet, we are supposed to wait after a USB reset event:

<img width="844" alt="image" src="https://user-images.githubusercontent.com/1467890/84934505-68a5a500-b0a5-11ea-9698-636dbc8a1dc9.png">

I experimentally determined a long enough wait such that the IN transfers would work.


### Testing Strategy

This pull request was tested by running a hello loop app on nano33ble.


### TODO or Help Wanted

This allows CDC to work as expect on my mac: all messages sent are displayed in the terminal after running `tockloader listen`. On linux, however, I'm still seeing the very first message be lost.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
