### PR TITLE
remove all uses of lang_items unstable feature

### DIFF
--- a/arch/cortex-m/src/lib.rs
+++ b/arch/cortex-m/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![crate_name = "cortexm"]
 #![crate_type = "rlib"]
-#![feature(llvm_asm, lang_items)]
+#![feature(llvm_asm)]
 #![no_std]
 
 use core::fmt::Write;

--- a/arch/cortex-m/src/support.rs
+++ b/arch/cortex-m/src/support.rs
@@ -31,10 +31,6 @@ where
     return res;
 }
 
-#[cfg(all(target_arch = "arm", target_os = "none"))]
-#[lang = "eh_personality"]
-pub extern "C" fn eh_personality() {}
-
 // Mock implementations for tests on Travis-CI.
 #[cfg(not(any(target_arch = "arm", target_os = "none")))]
 /// NOP instruction (mock)

--- a/arch/rv32i/src/lib.rs
+++ b/arch/rv32i/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![crate_name = "rv32i"]
 #![crate_type = "rlib"]
-#![feature(llvm_asm, const_fn, lang_items, global_asm, naked_functions)]
+#![feature(llvm_asm, const_fn, global_asm, naked_functions)]
 #![no_std]
 
 use core::fmt::Write;

--- a/arch/rv32i/src/support.rs
+++ b/arch/rv32i/src/support.rs
@@ -36,10 +36,6 @@ where
     res
 }
 
-#[cfg(all(target_arch = "riscv32", target_os = "none"))]
-#[lang = "eh_personality"]
-pub extern "C" fn eh_personality() {}
-
 // Mock implementations for tests on Travis-CI.
 #[cfg(not(any(target_arch = "riscv32", target_os = "none")))]
 /// NOP instruction (mock)

--- a/boards/launchxl/src/main.rs
+++ b/boards/launchxl/src/main.rs
@@ -2,7 +2,6 @@
 // Disable this attribute when documenting, as a workaround for
 // https://github.com/rust-lang/rust/issues/62184.
 #![cfg_attr(not(doc), no_main)]
-#![feature(lang_items)]
 
 extern crate capsules;
 extern crate cc26x2;


### PR DESCRIPTION
### Pull Request Overview

This pull request removes all uses of the lang_items unstable feature, to get us closer to building Tock on stable rust.

Originally, lang_items was required to declare the global panic handler, but that was changed by https://github.com/rust-lang/rust/pull/51366/ . After that, we seem to have just kept it around for declaring a dummy `eh_personality()` implementation, which I understand is not needed if you build with panic=abort (which we do for both release and debug builds). see: https://os.phil-opp.com/freestanding-rust-binary/


### Testing Strategy

This pull request was tested by compiling, running a normal app on Imix, and by panicing intentionally and observing the output looks normal.


### TODO or Help Wanted

Confirmation that I am correct in my understanding that we do not need eh_personality because we always use panic=abort.


### Documentation Updated

- [x] No updates are required.

### Formatting

- [x] Ran `make prepush`.
