### PR TITLE
components: Add debug writer that doesn't use a UART mux

### DIFF
--- a/boards/components/src/debug_writer.rs
+++ b/boards/components/src/debug_writer.rs
@@ -1,12 +1,19 @@
 //! Component for DebugWriter, the implementation for `debug!()`.
 //!
-//! This provides one `Component`, `DebugWriter`, which attaches kernel debug
-//! output (for panic!, print!, debug!, etc.) to the provided UART mux.
+//! This provides components for attaching the kernel debug output (for panic!,
+//! print!, debug!, etc.) to the output. `DebugWriterComponent` uses a UART mux,
+//! and `DebugWriterNoMuxComponent` just uses a UART interface directly.
 //!
 //! Usage
 //! -----
 //! ```rust
 //! DebugWriterComponent::new(uart_mux).finalize(());
+//!
+//! components::debug_writer::DebugWriterNoMuxComponent::new(
+//!     &nrf52::uart::UARTE0,
+//!     &nrf52::uart::UARTE0,
+//! )
+//! .finalize(());
 //! ```
 
 // Author: Brad Campbell <bradjc@virginia.edu>
@@ -17,6 +24,7 @@ use kernel::capabilities;
 use kernel::common::ring_buffer::RingBuffer;
 use kernel::component::Component;
 use kernel::hil;
+use kernel::hil::uart;
 use kernel::static_init;
 
 pub struct DebugWriterComponent {
@@ -60,5 +68,56 @@ impl Component for DebugWriterComponent {
             kernel::debug::DebugWriterWrapper::new(debugger)
         );
         kernel::debug::set_debug_writer_wrapper(debug_wrapper);
+    }
+}
+
+pub struct DebugWriterNoMuxComponent {
+    uart: &'static dyn uart::Uart<'static>,
+    uart_tx: &'static dyn uart::Transmit<'static>,
+}
+
+impl DebugWriterNoMuxComponent {
+    pub fn new(
+        uart: &'static dyn uart::Uart<'static>,
+        uart_tx: &'static dyn uart::Transmit<'static>,
+    ) -> DebugWriterNoMuxComponent {
+        DebugWriterNoMuxComponent { uart, uart_tx }
+    }
+}
+
+impl Component for DebugWriterNoMuxComponent {
+    type StaticInput = ();
+    type Output = ();
+
+    unsafe fn finalize(self, _s: Self::StaticInput) -> Self::Output {
+        // The sum of the output_buf and internal_buf is set to 1024 bytes in order to avoid excessive
+        // padding between kernel memory and application memory (which often needs to be aligned to at
+        // least a 1kB boundary). This is not _semantically_ critical, but helps keep buffers on 1kB
+        // boundaries in some cases. Of course, these definitions are only advisory, and individual boards
+        // can choose to pass in their own buffers with different lengths.
+        let buf = static_init!([u8; 1024], [0; 1024]);
+        let (output_buf, internal_buf) = buf.split_at_mut(64);
+
+        // Create virtual device for kernel debug.
+        let ring_buffer = static_init!(RingBuffer<'static, u8>, RingBuffer::new(internal_buf));
+        let debugger = static_init!(
+            kernel::debug::DebugWriter,
+            kernel::debug::DebugWriter::new(self.uart_tx, output_buf, ring_buffer)
+        );
+        hil::uart::Transmit::set_transmit_client(self.uart_tx, debugger);
+
+        let debug_wrapper = static_init!(
+            kernel::debug::DebugWriterWrapper,
+            kernel::debug::DebugWriterWrapper::new(debugger)
+        );
+        kernel::debug::set_debug_writer_wrapper(debug_wrapper);
+
+        self.uart.configure(uart::Parameters {
+            baud_rate: 115200,
+            width: uart::Width::Eight,
+            stop_bits: uart::StopBits::One,
+            parity: uart::Parity::None,
+            hw_flow_control: false,
+        });
     }
 }


### PR DESCRIPTION
### Pull Request Overview

This is useful if you want to use `debug!()` directly on top of a UART.


### Testing Strategy

While working on CDC on nano33ble: the debug stream went over uart, while console went over USB.


### TODO or Help Wanted

If someone wants to fix this issue with needing to pass two UART references to make the traits work out, that might be good.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
