### PR TITLE
nrf: fixup Platform struct

### DIFF
--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -292,18 +292,18 @@ pub unsafe fn reset_handler() {
     nrf52_components::NrfClockComponent::new().finalize(());
 
     let platform = Platform {
-        button,
         ble_radio,
         ieee802154_radio,
+        button,
         pconsole,
         console,
-        led,
         gpio,
+        led,
         rng,
         temp,
-        alarm,
-        analog_comparator,
         ipc: kernel::ipc::IPC::new(board_kernel, &memory_allocation_capability),
+        analog_comparator,
+        alarm,
     };
 
     platform.pconsole.start();

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -416,19 +416,19 @@ pub unsafe fn reset_handler() {
     nrf52_components::NrfClockComponent::new().finalize(());
 
     let platform = Platform {
-        button,
         ble_radio,
         ieee802154_radio,
+        button,
         pconsole,
         console,
-        led,
         gpio,
+        led,
         rng,
         temp,
-        alarm,
-        analog_comparator,
-        nonvolatile_storage,
         ipc: kernel::ipc::IPC::new(board_kernel, &memory_allocation_capability),
+        analog_comparator,
+        alarm,
+        nonvolatile_storage,
     };
 
     platform.pconsole.start();

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -340,17 +340,17 @@ pub unsafe fn reset_handler() {
     nrf52_components::NrfClockComponent::new().finalize(());
 
     let platform = Platform {
-        button,
         ble_radio,
+        button,
         pconsole,
         console,
-        led,
         gpio,
+        led,
         rng,
         temp,
-        alarm,
-        analog_comparator,
         ipc: kernel::ipc::IPC::new(board_kernel, &memory_allocation_capability),
+        analog_comparator,
+        alarm,
     };
 
     platform.pconsole.start();


### PR DESCRIPTION
### Pull Request Overview

In the process of pulling #1760 up to master, I noticed that the big Nordic refactor mis-ordered several of the `Platform` elements.

I am extremely confused right now. Are capsule types somehow so weak that any capsule can slot in for any other? Or is Rust just matching up the types for the struct elements auto-magically independent of their order?

### Testing Strategy

Compiling... though I'm losing confidence in that.

### TODO or Help Wanted

Why did the existing code compile?

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
