### PR TITLE
kernel: remove panic_info_message feature

### DIFF
--- a/kernel/src/debug.rs
+++ b/kernel/src/debug.rs
@@ -124,19 +124,7 @@ pub unsafe fn panic_begin(nop: &dyn Fn()) {
 ///
 /// **NOTE:** The supplied `writer` must be synchronous.
 pub unsafe fn panic_banner<W: Write>(writer: &mut W, panic_info: &PanicInfo) {
-    if let Some(location) = panic_info.location() {
-        let _ = writer.write_fmt(format_args!(
-            "\r\n\nKernel panic at {}:{}:\r\n\t\"",
-            location.file(),
-            location.line()
-        ));
-    } else {
-        let _ = writer.write_fmt(format_args!("\r\n\nKernel panic:\r\n\t\""));
-    }
-    if let Some(args) = panic_info.message() {
-        let _ = write(writer, *args);
-    }
-    let _ = writer.write_str("\"\r\n");
+    let _ = writer.write_fmt(format_args!("\r\n{}\r\n", panic_info));
 
     // Print version of the kernel
     let _ = writer.write_fmt(format_args!(

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -6,13 +6,7 @@
 //!
 //! Most `unsafe` code is in this kernel crate.
 
-#![feature(
-    core_intrinsics,
-    const_fn,
-    panic_info_message,
-    associated_type_defaults,
-    try_trait
-)]
+#![feature(core_intrinsics, const_fn, associated_type_defaults, try_trait)]
 #![warn(unreachable_pub)]
 #![no_std]
 


### PR DESCRIPTION
### Pull Request Overview

Part of #1654 .

Before:

```
[INFO   ] Using "/dev/cu.usbserial-c098e5130152 - Hail IoT Module - TockOS".
[INFO   ] Listening for serial output.
Initialization complete. Entering main loop.

Kernel panic at kernel/src/process.rs:517:
	"Restart threshold surpassed!"
	Kernel version release-1.5-549-g313a5e122

---| No debug queue found. You can set it with the DebugQueue component.

---| Fault Status |---
Data Access Violation:              true
Forced Hard Fault:                  true
Faulting Memory Address:            0x00000000
Fault Status Register (CFSR):       0x00000082
```

After:

```
[INFO   ] Waiting for other tockloader to finish before listening
[INFO   ] Resuming listening...
[INFO   ] Listening for serial output.
Initialization complete. Entering main loop.

panicked at 'Restart threshold surpassed!', kernel/src/process.rs:517:13
	Kernel version release-1.5-550-g6ad2749fe

---| No debug queue found. You can set it with the DebugQueue component.

---| Fault Status |---
Data Access Violation:              true
Forced Hard Fault:                  true
Faulting Memory Address:            0x00000000
Fault Status Register (CFSR):       0x00000082
Hard Fault Status Register (HFSR):  0x40000000
```


### Testing Strategy

This pull request was tested with crash dummy app on hail.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
