### PR TITLE
CRC HIL: make lifetime 'a, not 'static

### DIFF
--- a/boards/components/src/crc.rs
+++ b/boards/components/src/crc.rs
@@ -33,12 +33,12 @@ macro_rules! crc_component_helper {
     };};
 }
 
-pub struct CrcComponent<C: 'static + hil::crc::CRC> {
+pub struct CrcComponent<C: 'static + hil::crc::CRC<'static>> {
     board_kernel: &'static kernel::Kernel,
     crc: &'static C,
 }
 
-impl<C: 'static + hil::crc::CRC> CrcComponent<C> {
+impl<C: 'static + hil::crc::CRC<'static>> CrcComponent<C> {
     pub fn new(board_kernel: &'static kernel::Kernel, crc: &'static C) -> CrcComponent<C> {
         CrcComponent {
             board_kernel: board_kernel,
@@ -47,7 +47,7 @@ impl<C: 'static + hil::crc::CRC> CrcComponent<C> {
     }
 }
 
-impl<C: 'static + hil::crc::CRC> Component for CrcComponent<C> {
+impl<C: 'static + hil::crc::CRC<'static>> Component for CrcComponent<C> {
     type StaticInput = &'static mut MaybeUninit<crc::Crc<'static, C>>;
     type Output = &'static crc::Crc<'static, C>;
 

--- a/capsules/src/crc.rs
+++ b/capsules/src/crc.rs
@@ -89,13 +89,13 @@ pub struct App {
 
 /// Struct that holds the state of the CRC driver and implements the `Driver` trait for use by
 /// processes through the system call interface.
-pub struct Crc<'a, C: hil::crc::CRC> {
+pub struct Crc<'a, C: hil::crc::CRC<'a>> {
     crc_unit: &'a C,
     apps: Grant<App>,
     serving_app: OptionalCell<AppId>,
 }
 
-impl<'a, C: hil::crc::CRC> Crc<'a, C> {
+impl<'a, C: hil::crc::CRC<'a>> Crc<'a, C> {
     /// Create a `Crc` driver
     ///
     /// The argument `crc_unit` must implement the abstract `CRC`
@@ -166,7 +166,7 @@ impl<'a, C: hil::crc::CRC> Crc<'a, C> {
 /// the `subscribe` system call and `allow`s the driver access to the buffer over-which to compute.
 /// Then, it initiates a CRC computation using the `command` system call. See function-specific
 /// comments for details.
-impl<C: hil::crc::CRC> Driver for Crc<'_, C> {
+impl<'a, C: hil::crc::CRC<'a>> Driver for Crc<'a, C> {
     /// The `allow` syscall for this driver supports the single
     /// `allow_num` zero, which is used to provide a buffer over which
     /// to compute a CRC computation.
@@ -325,7 +325,7 @@ impl<C: hil::crc::CRC> Driver for Crc<'_, C> {
     }
 }
 
-impl<C: hil::crc::CRC> hil::crc::Client for Crc<'_, C> {
+impl<'a, C: hil::crc::CRC<'a>> hil::crc::Client for Crc<'a, C> {
     fn receive_result(&self, result: u32) {
         self.serving_app.take().map(|appid| {
             self.apps

--- a/chips/sam4l/src/crccu.rs
+++ b/chips/sam4l/src/crccu.rs
@@ -330,7 +330,7 @@ impl Crccu<'_> {
 }
 
 // Implement the generic CRC interface with the CRCCU
-impl<'a> crc::CRC for Crccu<'a> {
+impl<'a> crc::CRC<'a> for Crccu<'a> {
     /// Set a client to receive results from the CRCCU
     fn set_client(&self, client: &'a dyn crc::Client) {
         self.client.set(client);

--- a/kernel/src/hil/crc.rs
+++ b/kernel/src/hil/crc.rs
@@ -24,9 +24,9 @@ pub enum CrcAlg {
     Sam4L32C,
 }
 
-pub trait CRC {
+pub trait CRC<'a> {
     /// Set the client to be used for callbacks.
-    fn set_client(&self, client: &'static dyn Client);
+    fn set_client(&self, client: &'a dyn Client);
 
     /// Initiate a CRC calculation
     fn compute(&self, data: &[u8], _: CrcAlg) -> ReturnCode;


### PR DESCRIPTION
### Pull Request Overview

Part of #1074. Convert CRC HIL to use `<'a>` not `<'static>` for client references.


### Testing Strategy

I didn't.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
