### PR TITLE
Increase delay in Segger RTT debugging (fix #1697).

### DIFF
--- a/capsules/src/segger_rtt.rs
+++ b/capsules/src/segger_rtt.rs
@@ -238,7 +238,7 @@ impl<'a, A: hil::time::Alarm<'a>> uart::Transmit<'a> for SeggerRtt<'a, A> {
                     //
                     // This heuristic interval was tested with the console capsule on a nRF52840-DK
                     // board, passing buffers up to 1500 bytes from userspace. 100 micro-seconds
-                    // was to short, even for buffers as small as 128 bytes. 1 milli-second seems to
+                    // was too short, even for buffers as small as 128 bytes. 1 milli-second seems to
                     // be reliable.
                     let interval = (1000 as u32) * <A::Frequency>::frequency() / 1000000;
                     let tics = self.alarm.now().wrapping_add(interval);

--- a/capsules/src/segger_rtt.rs
+++ b/capsules/src/segger_rtt.rs
@@ -233,9 +233,14 @@ impl<'a, A: hil::time::Alarm<'a>> uart::Transmit<'a> for SeggerRtt<'a, A> {
                     // Save the client buffer so we can pass it back with the callback.
                     self.client_buffer.replace(tx_data);
 
-                    // Start a short timer so that we get a callback and
-                    // can issue the callback to the client.
-                    let interval = (100 as u32) * <A::Frequency>::frequency() / 1000000;
+                    // Start a short timer so that we get a callback and can issue the callback to
+                    // the client.
+                    //
+                    // This heuristic interval was tested with the console capsule on a nRF52840-DK
+                    // board, passing buffers up to 1500 bytes from userspace. 100 micro-seconds
+                    // was to short, even for buffers as small as 128 bytes. 1 milli-second seems to
+                    // be reliable.
+                    let interval = (1000 as u32) * <A::Frequency>::frequency() / 1000000;
                     let tics = self.alarm.now().wrapping_add(interval);
                     self.alarm.set_alarm(tics);
                 })


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes #1697 by increasing the delay in Segger RTT debugging.

I tried various parameters, and 1ms of delay seems reliable enough, even for large buffers (tested up to 1500 bytes).

Somehow, when I originally filed #1697, I don't recall that increasing this delay would work, but it seems to fix it in the current kernel.


### Testing Strategy

This pull request was tested on a nRF52840-DK board with the "console triangle" test mentioned in #1697 and located on https://github.com/gendx/libtock-rs/blob/console-check/examples/console_triangle.rs. I also tested increasing the "width" of the triangle up to 1500 bytes, and the output works properly.

I had a look at https://www.segger.com/downloads/jlink but couldn't find a reliable source of ground truth on the acceptable frequency to refresh the RTT buffers...


### TODO or Help Wanted

This change makes the console slower, especially if one only uses very small buffers. However, reliability is likely preferable over premature optimization. Better start from a working code and optimize from there than the opposite.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
