### PR TITLE
Makefile.common: use system sha256sum if available

### DIFF
--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -247,9 +247,17 @@ target:
 %.elf: %
 	$(Q)cp $< $@
 
-%.bin: %.elf $(TOCK_ROOT_DIRECTORY)tools/sha256sum/target/debug/sha256sum
+# Check whether the system already has a sha256sum application
+# present, if not use the custom shipped one
+ifeq (, $(shell which sha256sum))
+  %.bin: %.elf $(TOCK_ROOT_DIRECTORY)tools/sha256sum/target/debug/sha256sum
 	$(Q)$(OBJCOPY) --output-target=binary $(OBJCOPY_FLAGS) $< $@
 	$(Q)$(TOCK_ROOT_DIRECTORY)tools/sha256sum/target/debug/sha256sum $@
+else
+  %.bin: %.elf
+	$(Q)$(OBJCOPY) --output-target=binary $(OBJCOPY_FLAGS) $< $@
+	$(Q)sha256sum $@
+endif
 
 %.lst: %.elf
 	$(Q)$(OBJDUMP) $(OBJDUMP_FLAGS) $< > $@

--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -161,7 +161,7 @@ endif
 
 # Check whether the system already has a sha256sum application
 # present, if not use the custom shipped one
-ifeq (, $(shell which sha256sum))
+ifeq (, $(shell sha256sum --version 2>/dev/null))
   # No system sha256sum available
   SHA256SUM := $(TOCK_ROOT_DIRECTORY)tools/sha256sum/target/debug/sha256sum
 else

--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -163,7 +163,7 @@ endif
 # present, if not use the custom shipped one
 ifeq (, $(shell sha256sum --version 2>/dev/null))
   # No system sha256sum available
-  SHA256SUM := $(TOCK_ROOT_DIRECTORY)tools/sha256sum/target/debug/sha256sum
+  SHA256SUM := $(CARGO) run --manifest-path $(TOCK_ROOT_DIRECTORY)tools/sha256sum/Cargo.toml --
 else
   # Use system sha256sum
   SHA256SUM := sha256sum
@@ -258,7 +258,7 @@ target:
 	$(Q)cp $< $@
 
 
-%.bin: %.elf $(TOCK_ROOT_DIRECTORY)tools/sha256sum/target/debug/sha256sum
+%.bin: %.elf
 	$(Q)$(OBJCOPY) --output-target=binary $(OBJCOPY_FLAGS) $< $@
 	$(Q)$(SHA256SUM) $@
 

--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -159,6 +159,16 @@ ifneq (,$(findstring thumb,$(TARGET)))
   OBJDUMP_FLAGS += --arch-name=thumb
 endif
 
+# Check whether the system already has a sha256sum application
+# present, if not use the custom shipped one
+ifeq (, $(shell which sha256sum))
+  # No system sha256sum available
+  SHA256SUM := $(TOCK_ROOT_DIRECTORY)tools/sha256sum/target/debug/sha256sum
+else
+  # Use system sha256sum
+  SHA256SUM := sha256sum
+endif
+
 # Dump configuration for verbose builds
 ifneq ($(V),)
   $(info )
@@ -247,17 +257,10 @@ target:
 %.elf: %
 	$(Q)cp $< $@
 
-# Check whether the system already has a sha256sum application
-# present, if not use the custom shipped one
-ifeq (, $(shell which sha256sum))
-  %.bin: %.elf $(TOCK_ROOT_DIRECTORY)tools/sha256sum/target/debug/sha256sum
+
+%.bin: %.elf $(TOCK_ROOT_DIRECTORY)tools/sha256sum/target/debug/sha256sum
 	$(Q)$(OBJCOPY) --output-target=binary $(OBJCOPY_FLAGS) $< $@
-	$(Q)$(TOCK_ROOT_DIRECTORY)tools/sha256sum/target/debug/sha256sum $@
-else
-  %.bin: %.elf
-	$(Q)$(OBJCOPY) --output-target=binary $(OBJCOPY_FLAGS) $< $@
-	$(Q)sha256sum $@
-endif
+	$(Q)$(SHA256SUM) $@
 
 %.lst: %.elf
 	$(Q)$(OBJDUMP) $(OBJDUMP_FLAGS) $< > $@


### PR DESCRIPTION
### Pull Request Overview
Use the `sha256sum` binary from coreutils/busybox/... if installed.

Somehow the compilation of the custom shipped `sha256sum` binary often fails for me, chooses the wrong interpreter or does other weird stuff. Often deleting the respective `target/` directory helps, sometimes "uninstalling" rustup (I'm on Nix, so I just leave the nix-shell) helps. In any case this is annoying and since a lot of systems have this preinstalled (almost Linux distributions I'm aware of), we can avoid building our custom application.

#### Going further

There's no _technical_ reason to not do what we currently do, but building our own replacement for something available on virtually every OS's package manager - which could instead be specified as an (optional) build dependency - feels over-engineered. It makes it _our_ responsibility that the produced `sha256sum` binary is bug-free and secure and we must ensure the build process works.

Even #1669 mentioned that this [isn't mandatory for the build](https://github.com/tock/tock/pull/1669#issuecomment-596427676). For the reasons outlined above, I would propose to use the binary if present, specify it as an optional build-time dependency and only run it when it's present.

Tagging @gendx @bradjc, since they were involved #1669.

### Testing Strategy

Building a board with `sha256sum` in $PATH and excluded from $PATH.


### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
