### PR TITLE
Stm32f4 I2C HAL

### DIFF
--- a/chips/README.md
+++ b/chips/README.md
@@ -29,7 +29,7 @@ HIL Support
 | gpio::Output                            | ✓        | ✓        | ✓      | ✓     | ✓       | ✓        | ✓        | ✓     | ✓         | ✓         |
 | gpio::Pin                               | ✓        | ✓        | ✓      | ✓     | ✓       | ✓        | ✓        | ✓     | ✓         | ✓         |
 | digest::Hmac                            |          |          |        |       | ✓       |          |          |       |           |           |
-| i2c::I2CMaster                          |          |          | ✓      |       | ✓       | ✓        | ✓        | ✓     | ✓         |           |
+| i2c::I2CMaster                          |          |          | ✓      |       | ✓       | ✓        | ✓        | ✓     | ✓         | ✓         |
 | i2c::I2CMasterSlave                     |          |          |        |       |         |          |          | ✓     |           |           |
 | i2c::I2CSlave                           |          |          |        |       |         |          |          | ✓     |           |           |
 | mod::Controller                         |          |          |        |       |         | ✓        | ✓        | ✓     |           |           |

--- a/chips/stm32f4xx/src/chip.rs
+++ b/chips/stm32f4xx/src/chip.rs
@@ -6,6 +6,7 @@ use kernel::Chip;
 
 use crate::dma1;
 use crate::exti;
+use crate::i2c;
 use crate::nvic;
 use crate::spi;
 use crate::tim2;
@@ -58,6 +59,9 @@ impl Chip for Stm32f4xx {
 
                         nvic::USART2 => usart::USART2.handle_interrupt(),
                         nvic::USART3 => usart::USART3.handle_interrupt(),
+
+                        nvic::I2C1_EV => i2c::I2C1.handle_event(),
+                        nvic::I2C1_ER => i2c::I2C1.handle_error(),
 
                         nvic::SPI3 => spi::SPI3.handle_interrupt(),
 

--- a/chips/stm32f4xx/src/i2c.rs
+++ b/chips/stm32f4xx/src/i2c.rs
@@ -194,7 +194,6 @@ pub struct I2C<'a> {
     slave_address: Cell<u8>,
 
     status: Cell<I2CStatus>,
-    // transfers: Cell<u8>
 }
 
 #[derive(Copy, Clone, PartialEq)]

--- a/chips/stm32f4xx/src/i2c.rs
+++ b/chips/stm32f4xx/src/i2c.rs
@@ -1,0 +1,482 @@
+use core::cell::Cell;
+
+use kernel::common::cells::{OptionalCell, TakeCell};
+use kernel::common::registers::{register_bitfields, ReadWrite};
+use kernel::common::StaticRef;
+use kernel::hil::i2c::{self, Error, I2CHwMasterClient, I2CMaster};
+use kernel::ClockInterface;
+use kernel::{debug, hil};
+
+use crate::rcc;
+
+pub enum I2CSpeed {
+    Speed100k,
+    Speed400k,
+}
+
+/// Inter-Integrated Circuit
+#[repr(C)]
+struct I2CRegisters {
+    /// control register 1
+    cr1: ReadWrite<u32, CR1::Register>,
+    /// control register 2
+    cr2: ReadWrite<u32, CR2::Register>,
+    /// own address register 1
+    oar1: ReadWrite<u32, OAR1::Register>,
+    /// own address register 2
+    oar2: ReadWrite<u32, OAR2::Register>,
+    /// data register
+    dr: ReadWrite<u32, DR::Register>,
+    /// status register 1
+    sr1: ReadWrite<u32, SR1::Register>,
+    /// status register 2
+    sr2: ReadWrite<u32, SR2::Register>,
+    /// clock control register
+    ccr: ReadWrite<u32, CCR::Register>,
+    /// tRise register
+    trise: ReadWrite<u32, TRISE::Register>,
+    /// filter register
+    fltr: ReadWrite<u32, FLTR::Register>,
+}
+
+register_bitfields![u32,
+    CR1 [
+        /// Software reset
+        SWRST OFFSET(15) NUMBITS(1) [],
+        /// SMBus alert
+        ALERT OFFSET(13) NUMBITS(1) [],
+        /// Packet error checking
+        PEC OFFSET(12) NUMBITS(1) [],
+        /// Acknowledge/PEC Position (for data reception)
+        POS OFFSET(11) NUMBITS(1) [],
+        /// Acknowledge enable
+        ACK OFFSET(10) NUMBITS(1) [],
+        /// Stop generation
+        STOP OFFSET(9) NUMBITS(1) [],
+        /// Start generation
+        START OFFSET(8) NUMBITS(1) [],
+        /// Clock stretching disable (Slave mode)
+        NOSTRETCH OFFSET(7) NUMBITS(1) [],
+        /// General call enable
+        ENGC OFFSET(6) NUMBITS(1) [],
+        /// PEC enable
+        ENPEC OFFSET(5) NUMBITS(1) [],
+        /// ARP enable
+        ENARP OFFSET(4) NUMBITS(1) [],
+        /// SMBus type
+        SMBTYPE OFFSET(3) NUMBITS(1) [],
+        /// SMBus mode
+        SMBUS OFFSET(1) NUMBITS(1) [],
+        /// Peripheral enable
+        PE OFFSET(0) NUMBITS(1) []
+    ],
+    CR2 [
+        /// DMA last transfer
+        LAST OFFSET(12) NUMBITS(1) [],
+        /// DMA requests enable
+        DMAEN OFFSET(11) NUMBITS(1) [],
+        /// Buffer interrupt enable
+        ITBUFEN OFFSET(10) NUMBITS(1) [],
+        /// Event interrupt enable
+        ITEVTEN OFFSET(9) NUMBITS(1) [],
+        // Error interrupt enable
+        ITERREN OFFSET(8) NUMBITS(1) [],
+        /// Peripheral clock frequency
+        FREQ OFFSET(0) NUMBITS(6) []
+    ],
+    OAR1 [
+        /// Addressing mode (slave mode)
+        ADDMODE OFFSET(15) NUMBITS(1) [],
+        /// Interface address
+        ADD OFFSET(0) NUMBITS(10) []
+    ],
+    OAR2 [
+        /// Interface address
+        ADD2 OFFSET(1) NUMBITS(7) [],
+        /// Dual addressing mode enable
+        ENDUAL OFFSET(1) NUMBITS(1) []
+    ],
+    DR [
+        /// 8-bit receive data
+        DR OFFSET(0) NUMBITS(8) []
+    ],
+    SR1 [
+        /// SMBus alert
+        SMBALERT OFFSET(15) NUMBITS(1) [],
+        /// Timeout or tLOW detection flag
+        TIMEOUT OFFSET(14) NUMBITS(1) [],
+        /// PEC Error in reception
+        PECERR OFFSET(12) NUMBITS(1) [],
+        /// Overrun/Underrun
+        OVR OFFSET(11) NUMBITS(1) [],
+        /// Acknowledge failure
+        AF OFFSET(10) NUMBITS(1) [],
+        /// Arbitration lost
+        ARLO OFFSET(9) NUMBITS(1) [],
+        /// Bus error
+        BERR OFFSET(8) NUMBITS(1) [],
+        /// Data register empty (transmitters)
+        TXE OFFSET(7) NUMBITS(1) [],
+        /// Data register not empty (receivers)
+        RXNE OFFSET(6) NUMBITS(1) [],
+        /// Stop detection (slave mode)
+        STOPF OFFSET(4) NUMBITS(1) [],
+        /// 10-bit header sent (Master mode)
+        ADD10 OFFSET(3) NUMBITS(1) [],
+        /// Byte transfer finished
+        BTF OFFSET(2) NUMBITS(1) [],
+        /// Address sent (master mode)/matched (slave mode)
+        ADDR OFFSET(1) NUMBITS(1) [],
+        /// Start bit (Master mode)
+        SB OFFSET(0) NUMBITS(1) []
+    ],
+    SR2 [
+        /// Packet error checking register
+        PEC OFFSET(8) NUMBITS(8) [],
+        /// Dual flag (Slave mode)
+        DUALF OFFSET(7) NUMBITS(1) [],
+        /// SMBus host header (Slave mode)
+        SMBHOST OFFSET(6) NUMBITS(1) [],
+        /// SMBus device default address (Slave mode)
+        SMBDEFAULT OFFSET(5) NUMBITS(1) [],
+        /// General call address (Slave mode)
+        GENCALL OFFSET(4) NUMBITS(1) [],
+        /// Transmitter/receiver
+        TRA OFFSET(2) NUMBITS(1) [],
+        /// Bus busy
+        BUSY OFFSET(1) NUMBITS(1) [],
+        /// Master/slave
+        MSL OFFSET(0) NUMBITS(1) []
+    ],
+    CCR [
+        /// I2C master mode selection
+        FS OFFSET(15) NUMBITS(1) [
+            SM_MODE = 0,
+            FM_MODE = 1
+        ],
+        /// Fm mode duty cycle
+        DUTY OFFSET(14) NUMBITS(1) [],
+        /// Clock control register in Fm/Sm mode (Master mode)
+        CCR OFFSET(0) NUMBITS(12) []
+    ],
+    TRISE [
+        /// Maximum rise time in Fm/Sm mode (Master mode)
+        TRISE OFFSET(0) NUMBITS(6) []
+    ],
+    FLTR [
+        /// Analog noise filter OFF
+        ANOFF OFFSET(4) NUMBITS(1) [],
+        /// Digital noise filter
+        DNF OFFSET(0) NUMBITS(4) []
+    ]
+];
+
+const I2C1_BASE: StaticRef<I2CRegisters> =
+    unsafe { StaticRef::new(0x4000_5400 as *const I2CRegisters) };
+const I2C2_BASE: StaticRef<I2CRegisters> =
+    unsafe { StaticRef::new(0x4000_5800 as *const I2CRegisters) };
+const I2C3_BASE: StaticRef<I2CRegisters> =
+    unsafe { StaticRef::new(0x4000_5C00 as *const I2CRegisters) };
+
+pub struct I2C<'a> {
+    registers: StaticRef<I2CRegisters>,
+    clock: I2CClock,
+
+    // I2C slave support not yet implemented
+    master_client: OptionalCell<&'a dyn hil::i2c::I2CHwMasterClient>,
+
+    buffer: TakeCell<'static, [u8]>,
+    tx_position: Cell<u8>,
+    rx_position: Cell<u8>,
+    tx_len: Cell<u8>,
+    rx_len: Cell<u8>,
+
+    slave_address: Cell<u8>,
+
+    status: Cell<I2CStatus>,
+    // transfers: Cell<u8>
+}
+
+#[derive(Copy, Clone, PartialEq)]
+enum I2CStatus {
+    Idle,
+    Writing,
+    WritingReading,
+    Reading,
+}
+
+pub static mut I2C1: I2C = I2C::new(
+    I2C1_BASE,
+    I2CClock(rcc::PeripheralClock::APB1(rcc::PCLK1::I2C1)),
+);
+
+impl I2C<'_> {
+    const fn new(base_addr: StaticRef<I2CRegisters>, clock: I2CClock) -> Self {
+        Self {
+            registers: base_addr,
+            clock,
+
+            master_client: OptionalCell::empty(),
+
+            slave_address: Cell::new(0),
+
+            buffer: TakeCell::empty(),
+            tx_position: Cell::new(0),
+            rx_position: Cell::new(0),
+
+            tx_len: Cell::new(0),
+            rx_len: Cell::new(0),
+
+            status: Cell::new(I2CStatus::Idle),
+        }
+    }
+
+    pub fn set_speed(&self, speed: I2CSpeed, system_clock_in_mhz: usize) {
+        self.disable();
+        self.registers
+            .cr2
+            .modify(CR2::FREQ.val(system_clock_in_mhz as u32));
+        match speed {
+            I2CSpeed::Speed100k => {
+                self.registers
+                    .ccr
+                    .modify(CCR::CCR.val(system_clock_in_mhz as u32 * 5) + CCR::FS::SM_MODE);
+                self.registers
+                    .trise
+                    .modify(TRISE::TRISE.val(system_clock_in_mhz as u32 + 1));
+            }
+            I2CSpeed::Speed400k => {
+                self.registers
+                    .ccr
+                    .modify(CCR::CCR.val(system_clock_in_mhz as u32 * 5 / 6) + CCR::FS::FM_MODE);
+                self.registers
+                    .trise
+                    .modify(TRISE::TRISE.val(system_clock_in_mhz as u32 + 1));
+            }
+        }
+        self.enable();
+    }
+
+    pub fn is_enabled_clock(&self) -> bool {
+        self.clock.is_enabled()
+    }
+
+    pub fn enable_clock(&self) {
+        self.clock.enable();
+    }
+
+    pub fn disable_clock(&self) {
+        self.clock.disable();
+    }
+
+    pub fn handle_event(&self) {
+        if self.registers.sr1.is_set(SR1::SB) {
+            let dir = match self.status.get() {
+                I2CStatus::Writing | I2CStatus::WritingReading => 0,
+                I2CStatus::Reading => 1,
+                _ => panic!("invalid i2c state when setting address"),
+            };
+            debug!("i2c write address {}", self.slave_address.get());
+            self.registers
+                .dr
+                .write(DR::DR.val(((self.slave_address.get() << 1) as u32) | dir));
+        }
+        if self.registers.sr1.is_set(SR1::ADDR) {
+            // i2c requires a sr2 read
+            self.registers.sr2.get();
+        }
+        if self.registers.sr1.is_set(SR1::TXE) {
+            // send the next byte
+            if self.buffer.is_some() && self.tx_position.get() < self.tx_len.get() {
+                self.buffer.map(|buf| {
+                    let byte = buf[self.tx_position.get() as usize];
+                    debug!("write byte {}", byte);
+                    self.registers.dr.write(DR::DR.val(byte as u32));
+                    self.tx_position.set(self.tx_position.get() + 1);
+                });
+            }
+        }
+
+        while self.registers.sr1.is_set(SR1::RXNE) {
+            // send the next byte
+            let byte = self.registers.dr.read(DR::DR);
+            // debug!("read byte {}", byte);
+            if self.buffer.is_some() && self.rx_position.get() < self.rx_len.get() {
+                self.buffer.map(|buf| {
+                    buf[self.rx_position.get() as usize] = byte as u8;
+                    self.rx_position.set(self.rx_position.get() + 1);
+                });
+            }
+
+            if self.buffer.is_some() && self.rx_position.get() == self.rx_len.get() {
+                self.registers.cr1.modify(CR1::STOP::SET);
+                self.stop();
+                self.master_client.map(|client| {
+                    self.buffer
+                        .take()
+                        .map(|buf| client.command_complete(buf, Error::CommandComplete))
+                });
+            }
+        }
+
+        if self.registers.sr1.is_set(SR1::BTF) {
+            match self.status.get() {
+                I2CStatus::Writing | I2CStatus::WritingReading => {
+                    if self.tx_position.get() < self.tx_len.get() {
+                        self.registers.cr1.modify(CR1::STOP::SET);
+                        self.stop();
+                        self.master_client.map(|client| {
+                            self.buffer
+                                .take()
+                                .map(|buf| client.command_complete(buf, Error::DataNak))
+                        });
+                    } else {
+                        if self.status.get() == I2CStatus::Writing {
+                            self.registers.cr1.modify(CR1::STOP::SET);
+                            self.stop();
+                            self.master_client.map(|client| {
+                                self.buffer
+                                    .take()
+                                    .map(|buf| client.command_complete(buf, Error::CommandComplete))
+                            });
+                        } else {
+                            self.status.set(I2CStatus::Reading);
+                            self.start_read();
+                        }
+                    }
+                }
+                I2CStatus::Reading => {
+                    let error = if self.rx_position.get() == self.rx_len.get() {
+                        Error::CommandComplete
+                    } else {
+                        Error::DataNak
+                    };
+                    self.registers.cr1.modify(CR1::STOP::SET);
+                    self.stop();
+                    self.master_client.map(|client| {
+                        self.buffer
+                            .take()
+                            .map(|buf| client.command_complete(buf, error))
+                    });
+                }
+                _ => panic!("i2c status error"),
+            }
+        }
+    }
+
+    pub fn handle_error(&self) {
+        panic!("i2c error");
+        // not sure that this is the best error to send
+        // if self.registers.sr1.is_set(ISR::NACKF) {
+        //     // abort transfer due to NACK
+        //     self.registers.cr2.modify(CR2::STOP::SET);
+        //     self.stop();
+        //     self.registers.icr.modify(ICR::NACKCF::SET);
+        //     self.master_client.map(|client| {
+        //         self.buffer
+        //             .take()
+        //             .map(|buf| client.command_complete(buf, Error::AddressNak))
+        //     });
+        // }
+        self.master_client.map(|client| {
+            self.buffer
+                .take()
+                .map(|buf| client.command_complete(buf, Error::DataNak))
+        });
+        self.stop();
+    }
+
+    fn reset(&self) {
+        self.disable();
+        self.enable();
+    }
+
+    fn start_write(&self) {
+        self.tx_position.set(0);
+        self.registers
+            .cr2
+            .modify(CR2::ITEVTEN::SET + CR2::ITERREN::SET + CR2::ITBUFEN::SET);
+        self.registers.cr1.modify(CR1::POS::CLEAR);
+        self.registers.cr1.modify(CR1::ACK::SET);
+        self.registers.cr1.modify(CR1::START::SET);
+    }
+
+    fn stop(&self) {
+        self.registers
+            .cr2
+            .modify(CR2::ITEVTEN::CLEAR + CR2::ITERREN::CLEAR + CR2::ITBUFEN::CLEAR);
+        self.registers.cr1.modify(CR1::POS::CLEAR);
+        self.registers.cr1.modify(CR1::ACK::CLEAR);
+        self.status.set(I2CStatus::Idle);
+    }
+
+    fn start_read(&self) {
+        self.rx_position.set(0);
+        self.registers
+            .cr2
+            .modify(CR2::ITEVTEN::SET + CR2::ITERREN::SET + CR2::ITBUFEN::SET);
+        self.registers.cr1.modify(CR1::POS::CLEAR);
+        self.registers.cr1.modify(CR1::ACK::SET);
+        self.registers.cr1.modify(CR1::START::SET);
+    }
+}
+
+impl i2c::I2CMaster for I2C<'_> {
+    fn set_master_client(&self, master_client: &'static dyn I2CHwMasterClient) {
+        self.master_client.replace(master_client);
+    }
+    fn enable(&self) {
+        self.registers.cr1.modify(CR1::PE::SET);
+    }
+    fn disable(&self) {
+        self.registers.cr1.modify(CR1::PE::CLEAR);
+    }
+    fn write_read(&self, addr: u8, data: &'static mut [u8], write_len: u8, read_len: u8) {
+        debug!("sr1 {:b}", self.registers.sr1.get(),);
+        if self.status.get() == I2CStatus::Idle {
+            self.reset();
+            self.status.set(I2CStatus::WritingReading);
+            self.slave_address.set(addr);
+            self.buffer.replace(data);
+            self.tx_len.set(write_len);
+            self.rx_len.set(read_len);
+            self.start_write();
+        }
+    }
+    fn write(&self, addr: u8, data: &'static mut [u8], len: u8) {
+        if self.status.get() == I2CStatus::Idle {
+            self.reset();
+            self.status.set(I2CStatus::Writing);
+            self.slave_address.set(addr);
+            self.buffer.replace(data);
+            self.tx_len.set(len);
+            self.start_write();
+        }
+    }
+    fn read(&self, addr: u8, buffer: &'static mut [u8], len: u8) {
+        if self.status.get() == I2CStatus::Idle {
+            self.reset();
+            self.status.set(I2CStatus::Reading);
+            self.slave_address.set(addr);
+            self.buffer.replace(buffer);
+            self.rx_len.set(len);
+            self.start_read();
+        }
+    }
+}
+
+struct I2CClock(rcc::PeripheralClock);
+
+impl ClockInterface for I2CClock {
+    fn is_enabled(&self) -> bool {
+        self.0.is_enabled()
+    }
+
+    fn enable(&self) {
+        self.0.enable();
+    }
+
+    fn disable(&self) {
+        self.0.disable();
+    }
+}

--- a/chips/stm32f4xx/src/lib.rs
+++ b/chips/stm32f4xx/src/lib.rs
@@ -16,6 +16,7 @@ pub mod dbg;
 pub mod dma1;
 pub mod exti;
 pub mod gpio;
+pub mod i2c;
 pub mod rcc;
 pub mod spi;
 pub mod syscfg;

--- a/chips/stm32f4xx/src/rcc.rs
+++ b/chips/stm32f4xx/src/rcc.rs
@@ -735,6 +735,22 @@ impl Rcc {
         }
     }
 
+    // I2C1 clock
+
+    fn is_enabled_i2c1_clock(&self) -> bool {
+        self.registers.apb1enr.is_set(APB1ENR::I2C1EN)
+    }
+
+    fn enable_i2c1_clock(&self) {
+        self.registers.apb1enr.modify(APB1ENR::I2C1EN::SET);
+        self.registers.apb1rstr.modify(APB1RSTR::I2C1RST::SET);
+        self.registers.apb1rstr.modify(APB1RSTR::I2C1RST::CLEAR);
+    }
+
+    fn disable_i2c1_clock(&self) {
+        self.registers.apb1enr.modify(APB1ENR::I2C1EN::CLEAR)
+    }
+
     // SPI3 clock
 
     fn is_enabled_spi3_clock(&self) -> bool {
@@ -971,6 +987,7 @@ pub enum PCLK1 {
     USART2,
     USART3,
     SPI3,
+    I2C1,
 }
 
 /// Peripherals clocked by PCLK2
@@ -996,6 +1013,7 @@ impl ClockInterface for PeripheralClock {
                 PCLK1::TIM2 => unsafe { RCC.is_enabled_tim2_clock() },
                 PCLK1::USART2 => unsafe { RCC.is_enabled_usart2_clock() },
                 PCLK1::USART3 => unsafe { RCC.is_enabled_usart3_clock() },
+                PCLK1::I2C1 => unsafe { RCC.is_enabled_i2c1_clock() },
                 PCLK1::SPI3 => unsafe { RCC.is_enabled_spi3_clock() },
             },
             &PeripheralClock::APB2(ref v) => match v {
@@ -1044,6 +1062,9 @@ impl ClockInterface for PeripheralClock {
                 },
                 PCLK1::USART3 => unsafe {
                     RCC.enable_usart3_clock();
+                },
+                PCLK1::I2C1 => unsafe {
+                    RCC.enable_i2c1_clock();
                 },
                 PCLK1::SPI3 => unsafe {
                     RCC.enable_spi3_clock();
@@ -1097,6 +1118,9 @@ impl ClockInterface for PeripheralClock {
                 },
                 PCLK1::USART3 => unsafe {
                     RCC.disable_usart3_clock();
+                },
+                PCLK1::I2C1 => unsafe {
+                    RCC.disable_i2c1_clock();
                 },
                 PCLK1::SPI3 => unsafe {
                     RCC.disable_spi3_clock();


### PR DESCRIPTION
### Pull Request Overview

This pull request adds the I2C HAL for the stm32f4xx chip.

The implementation is without DMA as the I2C overlaps with SPI and USART. The DMA HAL should be rewritten to allocate the streams on a need basis.

### Testing Strategy

This pull request was tested using an stm32f412g discovery kit.

### TODO or Help Wanted

Testing on other devices would be useful.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
