### PR TITLE
Fix PMP use for RISC-V

### DIFF
--- a/arch/rv32i/src/csr/mod.rs
+++ b/arch/rv32i/src/csr/mod.rs
@@ -53,8 +53,30 @@ pub const CSR: &CSR = &CSR {
     mcause: ReadWriteRiscvCsr::new(riscv_csr::csr::MCAUSE),
     mtval: ReadWriteRiscvCsr::new(riscv_csr::csr::MTVAL),
     mip: ReadWriteRiscvCsr::new(riscv_csr::csr::MIP),
-    pmpcfg: [ReadWriteRiscvCsr::new(riscv_csr::csr::PMPCFG0); 4],
-    pmpaddr: [ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR0); 16],
+    pmpcfg: [
+        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPCFG0),
+        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPCFG1),
+        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPCFG2),
+        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPCFG3),
+    ],
+    pmpaddr: [
+        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR0),
+        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR1),
+        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR2),
+        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR3),
+        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR4),
+        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR5),
+        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR6),
+        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR7),
+        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR8),
+        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR9),
+        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR10),
+        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR11),
+        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR12),
+        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR13),
+        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR14),
+        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR15),
+    ],
 };
 
 impl CSR {

--- a/arch/rv32i/src/pmp.rs
+++ b/arch/rv32i/src/pmp.rs
@@ -445,21 +445,21 @@ impl kernel::mpu::MPU for PMPConfig {
                                 csr::CSR.pmpaddr[4].set((start as u32) >> 2);
 
                                 // Set access to end address
-                                csr::CSR.pmpcfg[1].set(cfg_val << 8 | csr::CSR.pmpcfg[0].get());
+                                csr::CSR.pmpcfg[1].set(cfg_val << 8 | csr::CSR.pmpcfg[1].get());
                                 csr::CSR.pmpaddr[5].set((start as u32 + size as u32) >> 2);
                             }
                             3 => {
                                 // Disable access up to the start address
                                 csr::CSR.pmpcfg[1].modify(
-                                    csr::pmpconfig::pmpcfg::r3::CLEAR
-                                        + csr::pmpconfig::pmpcfg::w3::CLEAR
-                                        + csr::pmpconfig::pmpcfg::x3::CLEAR
-                                        + csr::pmpconfig::pmpcfg::a3::TOR,
+                                    csr::pmpconfig::pmpcfg::r2::CLEAR
+                                        + csr::pmpconfig::pmpcfg::w2::CLEAR
+                                        + csr::pmpconfig::pmpcfg::x2::CLEAR
+                                        + csr::pmpconfig::pmpcfg::a2::TOR,
                                 );
                                 csr::CSR.pmpaddr[6].set((start as u32) >> 2);
 
                                 // Set access to end address
-                                csr::CSR.pmpcfg[1].set(cfg_val << 24 | csr::CSR.pmpcfg[0].get());
+                                csr::CSR.pmpcfg[1].set(cfg_val << 24 | csr::CSR.pmpcfg[1].get());
                                 csr::CSR.pmpaddr[7].set((start as u32 + size as u32) >> 2);
                             }
                             4 => {
@@ -473,21 +473,21 @@ impl kernel::mpu::MPU for PMPConfig {
                                 csr::CSR.pmpaddr[8].set((start as u32) >> 2);
 
                                 // Set access to end address
-                                csr::CSR.pmpcfg[2].set(cfg_val << 8 | csr::CSR.pmpcfg[0].get());
+                                csr::CSR.pmpcfg[2].set(cfg_val << 8 | csr::CSR.pmpcfg[2].get());
                                 csr::CSR.pmpaddr[9].set((start as u32 + size as u32) >> 2);
                             }
                             5 => {
                                 // Disable access up to the start address
                                 csr::CSR.pmpcfg[2].modify(
-                                    csr::pmpconfig::pmpcfg::r3::CLEAR
-                                        + csr::pmpconfig::pmpcfg::w3::CLEAR
-                                        + csr::pmpconfig::pmpcfg::x3::CLEAR
-                                        + csr::pmpconfig::pmpcfg::a3::TOR,
+                                    csr::pmpconfig::pmpcfg::r2::CLEAR
+                                        + csr::pmpconfig::pmpcfg::w2::CLEAR
+                                        + csr::pmpconfig::pmpcfg::x2::CLEAR
+                                        + csr::pmpconfig::pmpcfg::a2::TOR,
                                 );
                                 csr::CSR.pmpaddr[10].set((start as u32) >> 2);
 
                                 // Set access to end address
-                                csr::CSR.pmpcfg[2].set(cfg_val << 24 | csr::CSR.pmpcfg[0].get());
+                                csr::CSR.pmpcfg[2].set(cfg_val << 24 | csr::CSR.pmpcfg[2].get());
                                 csr::CSR.pmpaddr[11].set((start as u32 + size as u32) >> 2);
                             }
                             6 => {
@@ -501,21 +501,21 @@ impl kernel::mpu::MPU for PMPConfig {
                                 csr::CSR.pmpaddr[12].set((start as u32) >> 2);
 
                                 // Set access to end address
-                                csr::CSR.pmpcfg[3].set(cfg_val << 8 | csr::CSR.pmpcfg[0].get());
+                                csr::CSR.pmpcfg[3].set(cfg_val << 8 | csr::CSR.pmpcfg[3].get());
                                 csr::CSR.pmpaddr[13].set((start as u32 + size as u32) >> 2);
                             }
                             7 => {
                                 // Disable access up to the start address
                                 csr::CSR.pmpcfg[3].modify(
-                                    csr::pmpconfig::pmpcfg::r3::CLEAR
-                                        + csr::pmpconfig::pmpcfg::w3::CLEAR
-                                        + csr::pmpconfig::pmpcfg::x3::CLEAR
-                                        + csr::pmpconfig::pmpcfg::a3::TOR,
+                                    csr::pmpconfig::pmpcfg::r2::CLEAR
+                                        + csr::pmpconfig::pmpcfg::w2::CLEAR
+                                        + csr::pmpconfig::pmpcfg::x2::CLEAR
+                                        + csr::pmpconfig::pmpcfg::a2::TOR,
                                 );
                                 csr::CSR.pmpaddr[14].set((start as u32) >> 2);
 
                                 // Set access to end address
-                                csr::CSR.pmpcfg[3].set(cfg_val << 24 | csr::CSR.pmpcfg[0].get());
+                                csr::CSR.pmpcfg[3].set(cfg_val << 24 | csr::CSR.pmpcfg[3].get());
                                 csr::CSR.pmpaddr[15].set((start as u32 + size as u32) >> 2);
                             }
                             _ => break,

--- a/libraries/riscv-csr/src/csr.rs
+++ b/libraries/riscv-csr/src/csr.rs
@@ -21,25 +21,25 @@ pub const MCAUSE: usize = 0x342;
 pub const MTVAL: usize = 0x343;
 pub const MIP: usize = 0x344;
 pub const PMPCFG0: usize = 0x3A0;
-pub const PMPCFG1: usize = 0x3A4;
-pub const PMPCFG2: usize = 0x3A8;
-pub const PMPCFG3: usize = 0x3AC;
+pub const PMPCFG1: usize = 0x3A1;
+pub const PMPCFG2: usize = 0x3A2;
+pub const PMPCFG3: usize = 0x3A3;
 pub const PMPADDR0: usize = 0x3B0;
-pub const PMPADDR1: usize = 0x3B4;
-pub const PMPADDR2: usize = 0x3B8;
-pub const PMPADDR3: usize = 0x3BC;
-pub const PMPADDR4: usize = 0x3C0;
-pub const PMPADDR5: usize = 0x3C4;
-pub const PMPADDR6: usize = 0x3C8;
-pub const PMPADDR7: usize = 0x3CC;
-pub const PMPADDR8: usize = 0x3D0;
-pub const PMPADDR9: usize = 0x3D4;
-pub const PMPADDR10: usize = 0x3D8;
-pub const PMPADDR11: usize = 0x3DC;
-pub const PMPADDR12: usize = 0x3E0;
-pub const PMPADDR13: usize = 0x3E4;
-pub const PMPADDR14: usize = 0x3E8;
-pub const PMPADDR15: usize = 0x3EC;
+pub const PMPADDR1: usize = 0x3B1;
+pub const PMPADDR2: usize = 0x3B2;
+pub const PMPADDR3: usize = 0x3B3;
+pub const PMPADDR4: usize = 0x3B4;
+pub const PMPADDR5: usize = 0x3B5;
+pub const PMPADDR6: usize = 0x3B6;
+pub const PMPADDR7: usize = 0x3B7;
+pub const PMPADDR8: usize = 0x3B8;
+pub const PMPADDR9: usize = 0x3B9;
+pub const PMPADDR10: usize = 0x3BA;
+pub const PMPADDR11: usize = 0x3BB;
+pub const PMPADDR12: usize = 0x3BC;
+pub const PMPADDR13: usize = 0x3BD;
+pub const PMPADDR14: usize = 0x3BE;
+pub const PMPADDR15: usize = 0x3BF;
 
 /// Read/Write registers.
 #[derive(Copy, Clone)]
@@ -167,6 +167,46 @@ impl<R: RegisterLongName> ReadWriteRiscvCsr<u32, R> {
             unsafe {
                 asm!("csrr {rd}, {csr}", rd = out(reg) r, csr = const PMPADDR5);
             }
+        } else if self.value == PMPADDR6 {
+            unsafe {
+                asm!("csrr {rd}, {csr}", rd = out(reg) r, csr = const PMPADDR6);
+            }
+        } else if self.value == PMPADDR7 {
+            unsafe {
+                asm!("csrr {rd}, {csr}", rd = out(reg) r, csr = const PMPADDR7);
+            }
+        } else if self.value == PMPADDR8 {
+            unsafe {
+                asm!("csrr {rd}, {csr}", rd = out(reg) r, csr = const PMPADDR8);
+            }
+        } else if self.value == PMPADDR9 {
+            unsafe {
+                asm!("csrr {rd}, {csr}", rd = out(reg) r, csr = const PMPADDR9);
+            }
+        } else if self.value == PMPADDR10 {
+            unsafe {
+                asm!("csrr {rd}, {csr}", rd = out(reg) r, csr = const PMPADDR10);
+            }
+        } else if self.value == PMPADDR11 {
+            unsafe {
+                asm!("csrr {rd}, {csr}", rd = out(reg) r, csr = const PMPADDR11);
+            }
+        } else if self.value == PMPADDR12 {
+            unsafe {
+                asm!("csrr {rd}, {csr}", rd = out(reg) r, csr = const PMPADDR12);
+            }
+        } else if self.value == PMPADDR13 {
+            unsafe {
+                asm!("csrr {rd}, {csr}", rd = out(reg) r, csr = const PMPADDR13);
+            }
+        } else if self.value == PMPADDR14 {
+            unsafe {
+                asm!("csrr {rd}, {csr}", rd = out(reg) r, csr = const PMPADDR14);
+            }
+        } else if self.value == PMPADDR15 {
+            unsafe {
+                asm!("csrr {rd}, {csr}", rd = out(reg) r, csr = const PMPADDR15);
+            }
         } else {
             panic!("Unsupported CSR read");
         }
@@ -271,6 +311,46 @@ impl<R: RegisterLongName> ReadWriteRiscvCsr<u32, R> {
         } else if self.value == PMPADDR5 {
             unsafe {
                 asm!("csrw {csr}, {rs}", rs = in(reg) val_to_set, csr = const PMPADDR5);
+            }
+        } else if self.value == PMPADDR6 {
+            unsafe {
+                asm!("csrw {csr}, {rs}", rs = in(reg) val_to_set, csr = const PMPADDR6);
+            }
+        } else if self.value == PMPADDR7 {
+            unsafe {
+                asm!("csrw {csr}, {rs}", rs = in(reg) val_to_set, csr = const PMPADDR7);
+            }
+        } else if self.value == PMPADDR8 {
+            unsafe {
+                asm!("csrw {csr}, {rs}", rs = in(reg) val_to_set, csr = const PMPADDR8);
+            }
+        } else if self.value == PMPADDR9 {
+            unsafe {
+                asm!("csrw {csr}, {rs}", rs = in(reg) val_to_set, csr = const PMPADDR9);
+            }
+        } else if self.value == PMPADDR10 {
+            unsafe {
+                asm!("csrw {csr}, {rs}", rs = in(reg) val_to_set, csr = const PMPADDR10);
+            }
+        } else if self.value == PMPADDR11 {
+            unsafe {
+                asm!("csrw {csr}, {rs}", rs = in(reg) val_to_set, csr = const PMPADDR11);
+            }
+        } else if self.value == PMPADDR12 {
+            unsafe {
+                asm!("csrw {csr}, {rs}", rs = in(reg) val_to_set, csr = const PMPADDR12);
+            }
+        } else if self.value == PMPADDR13 {
+            unsafe {
+                asm!("csrw {csr}, {rs}", rs = in(reg) val_to_set, csr = const PMPADDR13);
+            }
+        } else if self.value == PMPADDR14 {
+            unsafe {
+                asm!("csrw {csr}, {rs}", rs = in(reg) val_to_set, csr = const PMPADDR14);
+            }
+        } else if self.value == PMPADDR15 {
+            unsafe {
+                asm!("csrw {csr}, {rs}", rs = in(reg) val_to_set, csr = const PMPADDR15);
             }
         } else {
             panic!("Unsupported CSR write");


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes use of PMP registers are configured beyond the first two PMP regions (which occupy 4 blocks in pmpcfg0 - each unaligned region taking two blocks):
1) The offsets & values used for pmpcfg1..3 were incorrect.
2) Pmpaddr and pmpcfg CSR numbers didn't match RISC-V spec (pmpcfg1 is 0x3A1, not 0x3A4, etc).
3) CSR structure contained N identical register structs, all pointing to pmpcfg0/pmpaddr0 instead of [pmpcfg0, pmpcfg1, ...], [pmpaddr0, pmpadd1, ...]

### Testing Strategy

This pull request was tested by running on RISC-V board with an applicaton requiring 3 PMP regions.