### PR TITLE
rv32i: add Display trait for PMPRegion/Config

### DIFF
--- a/arch/rv32i/src/pmp.rs
+++ b/arch/rv32i/src/pmp.rs
@@ -47,21 +47,22 @@ impl fmt::Display for PMPRegion {
         fn bit_str<'a>(reg: &PMPRegion, bit: u32, on_str: &'a str, off_str: &'a str) -> &'a str {
             match reg.cfg.value & bit {
                 0 => off_str,
-                _ => on_str
+                _ => on_str,
             }
         }
 
         match self.location {
             None => write!(f, "<unset>"),
-            Some((addr, size)) => {
-                write!(f,
-                    "addr={:p}, size={:#X}, cfg={:#X} ({}{}{})",
-                    addr, size, u32::from(self.cfg),
-                    bit_str(self, pmpcfg::r::SET.value, "r", "-"),
-                    bit_str(self, pmpcfg::w::SET.value, "w", "-"),
-                    bit_str(self, pmpcfg::x::SET.value, "x", "-"),
-                )
-            }
+            Some((addr, size)) => write!(
+                f,
+                "addr={:p}, size={:#X}, cfg={:#X} ({}{}{})",
+                addr,
+                size,
+                u32::from(self.cfg),
+                bit_str(self, pmpcfg::r::SET.value, "r", "-"),
+                bit_str(self, pmpcfg::w::SET.value, "w", "-"),
+                bit_str(self, pmpcfg::x::SET.value, "x", "-"),
+            ),
         }
     }
 }
@@ -161,9 +162,9 @@ impl Default for PMPConfig {
 
 impl fmt::Display for PMPConfig {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        writeln!(f, "PMP regions:");
+        writeln!(f, "PMP regions:")?;
         for n in 0..self.total_regions {
-            writeln!(f, " [{}]: {}", n, self.regions[n]);
+            writeln!(f, " [{}]: {}", n, self.regions[n])?;
         }
         Ok(())
     }

--- a/arch/rv32i/src/pmp.rs
+++ b/arch/rv32i/src/pmp.rs
@@ -42,6 +42,30 @@ pub struct PMPRegion {
     cfg: tock_registers::registers::FieldValue<u32, pmpcfg::Register>,
 }
 
+impl fmt::Display for PMPRegion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fn bit_str<'a>(reg: &PMPRegion, bit: u32, on_str: &'a str, off_str: &'a str) -> &'a str {
+            match reg.cfg.value & bit {
+                0 => off_str,
+                _ => on_str
+            }
+        }
+
+        match self.location {
+            None => write!(f, "<unset>"),
+            Some((addr, size)) => {
+                write!(f,
+                    "addr={:p}, size={:#X}, cfg={:#X} ({}{}{})",
+                    addr, size, u32::from(self.cfg),
+                    bit_str(self, pmpcfg::r::SET.value, "r", "-"),
+                    bit_str(self, pmpcfg::w::SET.value, "w", "-"),
+                    bit_str(self, pmpcfg::x::SET.value, "x", "-"),
+                )
+            }
+        }
+    }
+}
+
 impl PMPRegion {
     fn new(start: *const u8, size: usize, permissions: mpu::Permissions) -> PMPRegion {
         // Determine access and execute permissions
@@ -136,7 +160,11 @@ impl Default for PMPConfig {
 }
 
 impl fmt::Display for PMPConfig {
-    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "PMP regions:");
+        for n in 0..self.total_regions {
+            writeln!(f, " [{}]: {}", n, self.regions[n]);
+        }
         Ok(())
     }
 }


### PR DESCRIPTION
### Pull Request Overview

This patch implements Display trait for PMPregion and PMPconfig, and that adds PMP regions information for a process to the standard panic printout.

### Testing Strategy

This pull request was tested by triggering a panic on a RISC-V board and monitoring output.
