### PR TITLE
Use mainline QEMU

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,8 +53,5 @@ doc/rustdoc
 # are manually included for releases.
 Cargo.lock
 
-# Used to build QEMU for emulation testing
-tools/qemu
-
 # Python scripts
 __pycache__

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tools/qemu"]
+	path = tools/qemu
+	url = https://git.qemu.org/git/qemu.git

--- a/boards/README.md
+++ b/boards/README.md
@@ -4,20 +4,20 @@ Platforms Supported by Tock
 The `/boards` directory contains the physical hardware platforms
 that Tock supports.
 
-| Board                                                                | Architecture    | MCU            | Interface  | App deployment | QEMU Support? |
-|----------------------------------------------------------------------|-----------------|----------------|------------|----------------|---------------|
-| [Hail](hail/README.md)                                               | ARM Cortex-M4   | SAM4LC8BA      | Bootloader | tockloader     | No            |
-| [Imix](imix/README.md)                                               | ARM Cortex-M4   | SAM4LC8CA      | Bootloader | tockloader     | No            |
-| [Nordic nRF52-DK](nordic/nrf52dk/README.md)                          | ARM Cortex-M4   | nRF52832       | jLink      | tockloader     | No            |
-| [Nordic nRF52840-DK](nordic/nrf52840dk/README.md)                    | ARM Cortex-M4   | nRF52840       | jLink      | tockloader     | No            |
-| [Nordic nRF52840-Dongle](nordic/nrf52840_dongle/README.md)           | ARM Cortex-M4   | nRF52840       | jLink      | tockloader     | No            |
-| [ACD52832](acd52832/README.md)                                       | ARM Cortex-M4   | nRF52832       | jLink      | tockloader     | No            |
-| [Nano 33 BLE](nano33ble/README.md)                                   | ARM Cortex-M4   | nRF52840       | BOSSA      | bossac         | No            |
-| [ST Nucleo F446RE](nucleo_f446re/README.md)                          | ARM Cortex-M4   | STM32F446      | openocd    | custom         | #1827         |
-| [ST Nucleo F429ZI](nucleo_f429zi/README.md)                          | ARM Cortex-M4   | STM32F429      | openocd    | custom         | #1827         |
-| [STM32F3Discovery kit](stm32f3discovery/README.md)                   | ARM Cortex-M4   | STM32F303VCT6  | openocd    | custom         | #1827         |
-| [STM32F412G Discovery kit](stm32f412gdiscovery/README.md)            | ARM Cortex-M4   | STM32F412G     | openocd    | custom         | #1827         |
-| [SparkFun RedBoard Artemis Nano](redboard_artemis_nano/README.md)    | ARM Cortex-M4   | Apollo3        | custom     | custom         | No            |
-| [SiFive HiFive1](hifive1/README.md)                                  | RISC-V          | FE310-G000     | openocd    | tockloader     | Yes (5.1)     |
-| [Digilent Arty A-7 100T](arty_e21/README.md)                         | RISC-V RV32IMAC | SiFive E21     | openocd    | tockloader     | No            |
-| [Nexys Video OpenTitan](opentitan/README.md)                         | RISC-V RV32IMC  | EarlGrey       | custom     | custom         | Yes (5.1)     |
+| Board                                                                | Architecture    | MCU            | Interface  | App deployment | QEMU Support?     |
+|----------------------------------------------------------------------|-----------------|----------------|------------|----------------|-------------------|
+| [Hail](hail/README.md)                                               | ARM Cortex-M4   | SAM4LC8BA      | Bootloader | tockloader     | No                |
+| [Imix](imix/README.md)                                               | ARM Cortex-M4   | SAM4LC8CA      | Bootloader | tockloader     | No                |
+| [Nordic nRF52-DK](nordic/nrf52dk/README.md)                          | ARM Cortex-M4   | nRF52832       | jLink      | tockloader     | No                |
+| [Nordic nRF52840-DK](nordic/nrf52840dk/README.md)                    | ARM Cortex-M4   | nRF52840       | jLink      | tockloader     | No                |
+| [Nordic nRF52840-Dongle](nordic/nrf52840_dongle/README.md)           | ARM Cortex-M4   | nRF52840       | jLink      | tockloader     | No                |
+| [ACD52832](acd52832/README.md)                                       | ARM Cortex-M4   | nRF52832       | jLink      | tockloader     | No                |
+| [Nano 33 BLE](nano33ble/README.md)                                   | ARM Cortex-M4   | nRF52840       | BOSSA      | bossac         | No                |
+| [ST Nucleo F446RE](nucleo_f446re/README.md)                          | ARM Cortex-M4   | STM32F446      | openocd    | custom         | #1827             |
+| [ST Nucleo F429ZI](nucleo_f429zi/README.md)                          | ARM Cortex-M4   | STM32F429      | openocd    | custom         | #1827             |
+| [STM32F3Discovery kit](stm32f3discovery/README.md)                   | ARM Cortex-M4   | STM32F303VCT6  | openocd    | custom         | #1827             |
+| [STM32F412G Discovery kit](stm32f412gdiscovery/README.md)            | ARM Cortex-M4   | STM32F412G     | openocd    | custom         | #1827             |
+| [SparkFun RedBoard Artemis Nano](redboard_artemis_nano/README.md)    | ARM Cortex-M4   | Apollo3        | custom     | custom         | No                |
+| [SiFive HiFive1](hifive1/README.md)                                  | RISC-V          | FE310-G000     | openocd    | tockloader     | [Yes (5.1)][qemu] |
+| [Digilent Arty A-7 100T](arty_e21/README.md)                         | RISC-V RV32IMAC | SiFive E21     | openocd    | tockloader     | No                |
+| [Nexys Video OpenTitan](opentitan/README.md)                         | RISC-V RV32IMC  | EarlGrey       | custom     | custom         | [Yes (5.1)][qemu] |

--- a/boards/README.md
+++ b/boards/README.md
@@ -4,20 +4,20 @@ Platforms Supported by Tock
 The `/boards` directory contains the physical hardware platforms
 that Tock supports.
 
-| Board                                                                | Architecture    | MCU            | Interface  | App deployment |
-|----------------------------------------------------------------------|-----------------|----------------|------------|----------------|
-| [Hail](hail/README.md)                                               | ARM Cortex-M4   | SAM4LC8BA      | Bootloader | tockloader     |
-| [Imix](imix/README.md)                                               | ARM Cortex-M4   | SAM4LC8CA      | Bootloader | tockloader     |
-| [Nordic nRF52-DK](nordic/nrf52dk/README.md)                          | ARM Cortex-M4   | nRF52832       | jLink      | tockloader     |
-| [Nordic nRF52840-DK](nordic/nrf52840dk/README.md)                    | ARM Cortex-M4   | nRF52840       | jLink      | tockloader     |
-| [Nordic nRF52840-Dongle](nordic/nrf52840_dongle/README.md)           | ARM Cortex-M4   | nRF52840       | jLink      | tockloader     |
-| [ACD52832](acd52832/README.md)                                       | ARM Cortex-M4   | nRF52832       | jLink      | tockloader     |
-| [Nano 33 BLE](nano33ble/README.md)                                   | ARM Cortex-M4   | nRF52840       | BOSSA      | bossac         |
-| [ST Nucleo F446RE](nucleo_f446re/README.md)                          | ARM Cortex-M4   | STM32F446      | openocd    | custom         |
-| [ST Nucleo F429ZI](nucleo_f429zi/README.md)                          | ARM Cortex-M4   | STM32F429      | openocd    | custom         |
-| [STM32F3Discovery kit](stm32f3discovery/README.md)                   | ARM Cortex-M4   | STM32F303VCT6  | openocd    | custom         |
-| [STM32F412G Discovery kit](stm32f412gdiscovery/README.md)            | ARM Cortex-M4   | STM32F412G     | openocd    | custom         |
-| [SparkFun RedBoard Artemis Nano](redboard_artemis_nano/README.md)    | ARM Cortex-M4   | Apollo3        | custom     | custom         |
-| [SiFive HiFive1](hifive1/README.md)                                  | RISC-V          | FE310-G000     | openocd    | tockloader     |
-| [Digilent Arty A-7 100T](arty_e21/README.md)                         | RISC-V RV32IMAC | SiFive E21     | openocd    | tockloader     |
-| [Nexys Video OpenTitan](opentitan/README.md)                         | RISC-V RV32IMC  | EarlGrey       | custom     | custom         |
+| Board                                                                | Architecture    | MCU            | Interface  | App deployment | QEMU Support? |
+|----------------------------------------------------------------------|-----------------|----------------|------------|----------------|---------------|
+| [Hail](hail/README.md)                                               | ARM Cortex-M4   | SAM4LC8BA      | Bootloader | tockloader     | No            |
+| [Imix](imix/README.md)                                               | ARM Cortex-M4   | SAM4LC8CA      | Bootloader | tockloader     | No            |
+| [Nordic nRF52-DK](nordic/nrf52dk/README.md)                          | ARM Cortex-M4   | nRF52832       | jLink      | tockloader     | No            |
+| [Nordic nRF52840-DK](nordic/nrf52840dk/README.md)                    | ARM Cortex-M4   | nRF52840       | jLink      | tockloader     | No            |
+| [Nordic nRF52840-Dongle](nordic/nrf52840_dongle/README.md)           | ARM Cortex-M4   | nRF52840       | jLink      | tockloader     | No            |
+| [ACD52832](acd52832/README.md)                                       | ARM Cortex-M4   | nRF52832       | jLink      | tockloader     | No            |
+| [Nano 33 BLE](nano33ble/README.md)                                   | ARM Cortex-M4   | nRF52840       | BOSSA      | bossac         | No            |
+| [ST Nucleo F446RE](nucleo_f446re/README.md)                          | ARM Cortex-M4   | STM32F446      | openocd    | custom         | #1827         |
+| [ST Nucleo F429ZI](nucleo_f429zi/README.md)                          | ARM Cortex-M4   | STM32F429      | openocd    | custom         | #1827         |
+| [STM32F3Discovery kit](stm32f3discovery/README.md)                   | ARM Cortex-M4   | STM32F303VCT6  | openocd    | custom         | #1827         |
+| [STM32F412G Discovery kit](stm32f412gdiscovery/README.md)            | ARM Cortex-M4   | STM32F412G     | openocd    | custom         | #1827         |
+| [SparkFun RedBoard Artemis Nano](redboard_artemis_nano/README.md)    | ARM Cortex-M4   | Apollo3        | custom     | custom         | No            |
+| [SiFive HiFive1](hifive1/README.md)                                  | RISC-V          | FE310-G000     | openocd    | tockloader     | Yes (5.1)     |
+| [Digilent Arty A-7 100T](arty_e21/README.md)                         | RISC-V RV32IMAC | SiFive E21     | openocd    | tockloader     | No            |
+| [Nexys Video OpenTitan](opentitan/README.md)                         | RISC-V RV32IMC  | EarlGrey       | custom     | custom         | Yes (5.1)     |

--- a/doc/Getting_Started.md
+++ b/doc/Getting_Started.md
@@ -38,6 +38,11 @@ developing Tock.
    the options with `tockloader` support to load applications, as that
    is the configuration that most examples and tutorials assume.
 
+   **Note:** QEMU support in Tock is in the early stages. Please be
+   sure to check whether and how QEMU is supported for a board based on
+   the table in the [`boards/` subdirectory](../boards/README.md).
+   The `make ci-job-qemu` target is the authority on QEMU support.
+
    * Info about testing Tock on QEMU
      * 01/08/2020 : Among the boards supported by Tock, [SiFive HiFive1 RISC-V Board](../boards/hifive1/#running-in-qemu) can be tested in QEMU.
 

--- a/doc/Qemu.md
+++ b/doc/Qemu.md
@@ -1,0 +1,34 @@
+Qemu and Tock
+=============
+
+Tock is experimenting with QEMU.
+
+**All things QEMU are in early stages and rough edges are to be expected.**
+
+That said, please do file PRs or issues if you run into trouble or find things
+confusing. The long-term goal is to integrate QEMU as a core part of CI for Tock.
+
+<!-- npm i -g markdown-toc; markdown-toc -i Qemu.md -->
+
+<!-- toc -->
+
+- [Supported Boards](#supported-boards)
+- [Building QEMU](#building-qemu)
+
+<!-- tocstop -->
+
+## Supported Boards
+
+QEMU support for embedded platforms is limited. Please check the the table in
+the [`boards/` subdirectory](../boards/README.md) for an up-to-date list of
+supported boards.
+
+## Building QEMU
+
+Tock requires the master branch of QEMU. The `make ci-setup-qemu` Make target
+will build this for you. If you would prefer to build it yourself or you need
+more help look at the QEMU wiki: https://wiki.qemu.org/Hosts
+
+Although both Tock and QEMU have automated testing it's possible that the version
+of QEMU and Tock will become out of sync and will no longer work. If you are having
+problems try older versions of QEMU and/or Tock.


### PR DESCRIPTION
### Pull Request Overview

Instead of cloning a fork QEMU let's instead clone mainline.

This also applies two patches from https://github.com/tock/tock/pull/1938 but updates them to refer to mainline QEMU instead of the old fork.

### Testing Strategy

Running the CI.

### TODO or Help Wanted

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
