### PR TITLE
Remove reborrows?

### DIFF
--- a/arch/cortex-m3/src/mpu.rs
+++ b/arch/cortex-m3/src/mpu.rs
@@ -364,27 +364,25 @@ impl kernel::mpu::MPU for MPU {
     type MpuConfig = CortexMConfig;
 
     fn clear_mpu(&self) {
-        let regs = &*self.registers;
-        regs.ctrl.write(Control::ENABLE::CLEAR);
+        self.registers.ctrl.write(Control::ENABLE::CLEAR);
     }
 
     fn enable_app_mpu(&self) {
-        let regs = &*self.registers;
-
         // Enable the MPU, disable it during HardFault/NMI handlers, and allow
         // privileged code access to all unprotected memory.
-        regs.ctrl
+        self.registers
+            .ctrl
             .write(Control::ENABLE::SET + Control::HFNMIENA::CLEAR + Control::PRIVDEFENA::SET);
     }
 
     fn disable_app_mpu(&self) {
         // The MPU is not enabled for privileged mode, so we don't have to do
         // anything
+        self.registers.ctrl.write(Control::ENABLE::CLEAR);
     }
 
     fn number_total_regions(&self) -> usize {
-        let regs = &*self.registers;
-        regs.mpu_type.read(Type::DREGION) as usize
+        self.registers.mpu_type.read(Type::DREGION) as usize
     }
 
     fn allocate_region(
@@ -685,12 +683,10 @@ impl kernel::mpu::MPU for MPU {
         // If the hardware is already configured for this app and the app's MPU
         // configuration has not changed, then skip the hardware update.
         if !self.hardware_is_configured_for.contains(app_id) || config.is_dirty.get() {
-            let regs = &*self.registers;
-
             // Set MPU regions
             for region in config.regions.iter() {
-                regs.rbar.write(region.base_address());
-                regs.rasr.write(region.attributes());
+                self.registers.rbar.write(region.base_address());
+                self.registers.rasr.write(region.attributes());
             }
             self.hardware_is_configured_for.set(*app_id);
             config.is_dirty.set(false);

--- a/chips/nrf52/src/clock.rs
+++ b/chips/nrf52/src/clock.rs
@@ -178,51 +178,55 @@ impl Clock {
 
     /// Enable interrupt
     pub fn interrupt_enable(&self, interrupt: InterruptField) {
-        let regs = &*self.registers;
         // this is a little too verbose
         match interrupt {
-            InterruptField::CTTO => regs.intenset.write(Interrupt::CTTO::SET),
-            InterruptField::DONE => regs.intenset.write(Interrupt::DONE::SET),
-            InterruptField::HFCLKSTARTED => regs.intenset.write(Interrupt::HFCLKSTARTED::SET),
-            InterruptField::LFCLKSTARTED => regs.intenset.write(Interrupt::LFCLKSTARTED::SET),
+            InterruptField::CTTO => self.registers.intenset.write(Interrupt::CTTO::SET),
+            InterruptField::DONE => self.registers.intenset.write(Interrupt::DONE::SET),
+            InterruptField::HFCLKSTARTED => {
+                self.registers.intenset.write(Interrupt::HFCLKSTARTED::SET)
+            }
+            InterruptField::LFCLKSTARTED => {
+                self.registers.intenset.write(Interrupt::LFCLKSTARTED::SET)
+            }
         }
     }
 
     /// Disable interrupt
     pub fn interrupt_disable(&self, interrupt: InterruptField) {
-        let regs = &*self.registers;
         // this is a little too verbose
         match interrupt {
-            InterruptField::CTTO => regs.intenset.write(Interrupt::CTTO::SET),
-            InterruptField::DONE => regs.intenset.write(Interrupt::DONE::SET),
-            InterruptField::HFCLKSTARTED => regs.intenset.write(Interrupt::HFCLKSTARTED::SET),
-            InterruptField::LFCLKSTARTED => regs.intenset.write(Interrupt::LFCLKSTARTED::SET),
+            InterruptField::CTTO => self.registers.intenset.write(Interrupt::CTTO::SET),
+            InterruptField::DONE => self.registers.intenset.write(Interrupt::DONE::SET),
+            InterruptField::HFCLKSTARTED => {
+                self.registers.intenset.write(Interrupt::HFCLKSTARTED::SET)
+            }
+            InterruptField::LFCLKSTARTED => {
+                self.registers.intenset.write(Interrupt::LFCLKSTARTED::SET)
+            }
         }
     }
 
     /// Start the high frequency clock - specifically HFXO, and sets the high frequency
     /// clock source to HFXO
     pub fn high_start(&self) {
-        let regs = &*self.registers;
-        regs.tasks_hfclkstart.write(Control::ENABLE::SET);
+        self.registers.tasks_hfclkstart.write(Control::ENABLE::SET);
     }
 
     /// Stop the high frequency clock
     pub fn high_stop(&self) {
-        let regs = &*self.registers;
-        regs.tasks_hfclkstop.write(Control::ENABLE::SET);
+        self.registers.tasks_hfclkstop.write(Control::ENABLE::SET);
     }
 
     /// Check if the high frequency clock has started
     pub fn high_started(&self) -> bool {
-        let regs = &*self.registers;
-        regs.events_hfclkstarted.matches_all(Status::READY.val(1))
+        self.registers
+            .events_hfclkstarted
+            .matches_all(Status::READY.val(1))
     }
 
     /// Read clock source from the high frequency clock
     pub fn high_source(&self) -> HighClockSource {
-        let regs = &*self.registers;
-        match regs.hfclkstat.read(HfClkStat::SRC) {
+        match self.registers.hfclkstat.read(HfClkStat::SRC) {
             0 => HighClockSource::RC,
             _ => HighClockSource::XTAL,
         }
@@ -230,32 +234,31 @@ impl Clock {
 
     /// Check if the high frequency clock is running
     pub fn high_running(&self) -> bool {
-        let regs = &*self.registers;
-        regs.hfclkstat.matches_all(HfClkStat::STATE::RUNNING)
+        self.registers
+            .hfclkstat
+            .matches_all(HfClkStat::STATE::RUNNING)
     }
 
     /// Start the low frequency clock
     pub fn low_start(&self) {
-        let regs = &*self.registers;
-        regs.tasks_lfclkstart.write(Control::ENABLE::SET);
+        self.registers.tasks_lfclkstart.write(Control::ENABLE::SET);
     }
 
     /// Stop the low frequency clock
     pub fn low_stop(&self) {
-        let regs = &*self.registers;
-        regs.tasks_lfclkstop.write(Control::ENABLE::SET);
+        self.registers.tasks_lfclkstop.write(Control::ENABLE::SET);
     }
 
     /// Check if the low frequency clock has started
     pub fn low_started(&self) -> bool {
-        let regs = &*self.registers;
-        regs.events_lfclkstarted.matches_all(Status::READY::SET)
+        self.registers
+            .events_lfclkstarted
+            .matches_all(Status::READY::SET)
     }
 
     /// Read clock source from the low frequency clock
     pub fn low_source(&self) -> LowClockSource {
-        let regs = &*self.registers;
-        match regs.lfclkstat.read(LfClkStat::SRC) {
+        match self.registers.lfclkstat.read(LfClkStat::SRC) {
             0b1 => LowClockSource::XTAL,
             0b10 => LowClockSource::SYNTH,
             _ => LowClockSource::RC,
@@ -264,13 +267,15 @@ impl Clock {
 
     /// Check if the low frequency clock is running
     pub fn low_running(&self) -> bool {
-        let regs = &*self.registers;
-        regs.lfclkstat.matches_all(LfClkStat::STATE::RUNNING)
+        self.registers
+            .lfclkstat
+            .matches_all(LfClkStat::STATE::RUNNING)
     }
 
     /// Set low frequency clock source
     pub fn low_set_source(&self, clock_source: LowClockSource) {
-        let regs = &*self.registers;
-        regs.lfclksrc.write(LfClkSrc::SRC.val(clock_source as u32));
+        self.registers
+            .lfclksrc
+            .write(LfClkSrc::SRC.val(clock_source as u32));
     }
 }

--- a/chips/nrf52/src/ficr.rs
+++ b/chips/nrf52/src/ficr.rs
@@ -312,8 +312,7 @@ impl Ficr {
     }
 
     fn part(&self) -> Part {
-        let regs = &*self.registers;
-        match regs.info_part.get() {
+        match self.registers.info_part.get() {
             0x52832 => Part::N52832,
             0x52833 => Part::N52833,
             0x52840 => Part::N52840,
@@ -322,8 +321,7 @@ impl Ficr {
     }
 
     fn variant(&self) -> Variant {
-        let regs = &*self.registers;
-        match regs.info_variant.get() {
+        match self.registers.info_variant.get() {
             0x41414130 => Variant::AAA0,
             0x41414141 => Variant::AAAA,
             0x41414142 => Variant::AAAB,
@@ -343,8 +341,7 @@ impl Ficr {
     }
 
     fn package(&self) -> Package {
-        let regs = &*self.registers;
-        match regs.info_package.get() {
+        match self.registers.info_package.get() {
             0x2000 => Package::QF,
             0x2001 => Package::CH,
             0x2002 => Package::CI,
@@ -355,8 +352,7 @@ impl Ficr {
     }
 
     fn ram(&self) -> Ram {
-        let regs = &*self.registers;
-        match regs.info_ram.get() {
+        match self.registers.info_ram.get() {
             0x10 => Ram::K16,
             0x20 => Ram::K32,
             0x40 => Ram::K64,
@@ -367,8 +363,7 @@ impl Ficr {
     }
 
     fn flash(&self) -> Flash {
-        let regs = &*self.registers;
-        match regs.info_flash.get() {
+        match self.registers.info_flash.get() {
             0x80 => Flash::K128,
             0x100 => Flash::K256,
             0x200 => Flash::K512,
@@ -379,10 +374,14 @@ impl Ficr {
     }
 
     pub fn address(&self) -> [u8; 6] {
-        let regs = self.registers;
-
-        let lo = regs.deviceaddr0.read(DeviceAddress0::DEVICEADDRESS);
-        let hi = regs.deviceaddr1.read(DeviceAddress1::DEVICEADDRESS) as u16;
+        let lo = self
+            .registers
+            .deviceaddr0
+            .read(DeviceAddress0::DEVICEADDRESS);
+        let hi = self
+            .registers
+            .deviceaddr1
+            .read(DeviceAddress1::DEVICEADDRESS) as u16;
         let mut addr = [0; 6];
         addr[..4].copy_from_slice(&lo.to_le_bytes());
         addr[4..].copy_from_slice(&hi.to_le_bytes());
@@ -390,8 +389,8 @@ impl Ficr {
     }
 
     pub fn address_type(&self) -> AddressType {
-        let regs = self.registers;
-        match regs
+        match self
+            .registers
             .deviceaddrtype
             .read(DeviceAddressType::DEVICEADDRESSTYPE)
         {
@@ -403,9 +402,14 @@ impl Ficr {
     /// Return a MAC address string that has been hardcoded on this chip in the
     /// format `46:db:52:cd:93:9e`.
     pub fn address_str(&self, buf: &'static mut [u8; 17]) -> &'static str {
-        let regs = self.registers;
-        let lo = regs.deviceaddr0.read(DeviceAddress0::DEVICEADDRESS);
-        let hi = regs.deviceaddr1.read(DeviceAddress1::DEVICEADDRESS);
+        let lo = self
+            .registers
+            .deviceaddr0
+            .read(DeviceAddress0::DEVICEADDRESS);
+        let hi = self
+            .registers
+            .deviceaddr1
+            .read(DeviceAddress1::DEVICEADDRESS);
 
         let h: [u8; 16] = [
             '0' as u8, '1' as u8, '2' as u8, '3' as u8, '4' as u8, '5' as u8, '6' as u8, '7' as u8,

--- a/chips/nrf52/src/ieee802154_radio.rs
+++ b/chips/nrf52/src/ieee802154_radio.rs
@@ -704,8 +704,7 @@ impl Radio {
     }
 
     fn rx(&self) {
-        let regs = &*self.registers;
-        regs.event_ready.write(Event::READY::CLEAR);
+        self.registers.event_ready.write(Event::READY::CLEAR);
 
         if self.transmitting.get() {
             let tbuf = self
@@ -722,41 +721,40 @@ impl Radio {
             self.rx_buf.replace(self.set_dma_ptr(rbuf));
         }
 
-        regs.task_rxen.write(Task::ENABLE::SET);
+        self.registers.task_rxen.write(Task::ENABLE::SET);
 
         self.enable_interrupts();
     }
 
     fn set_rx_address(&self) {
-        let regs = &*self.registers;
-        regs.rxaddresses.write(ReceiveAddresses::ADDRESS.val(1));
+        self.registers
+            .rxaddresses
+            .write(ReceiveAddresses::ADDRESS.val(1));
     }
 
     fn set_tx_address(&self) {
-        let regs = &*self.registers;
-        regs.txaddress.write(TransmitAddress::ADDRESS.val(0));
+        self.registers
+            .txaddress
+            .write(TransmitAddress::ADDRESS.val(0));
     }
 
     fn radio_on(&self) {
-        let regs = &*self.registers;
         // reset and enable power
-        regs.power.write(Task::ENABLE::CLEAR);
-        regs.power.write(Task::ENABLE::SET);
+        self.registers.power.write(Task::ENABLE::CLEAR);
+        self.registers.power.write(Task::ENABLE::SET);
     }
 
     fn radio_off(&self) {
-        let regs = &*self.registers;
-        regs.power.write(Task::ENABLE::CLEAR);
+        self.registers.power.write(Task::ENABLE::CLEAR);
     }
 
     fn set_tx_power(&self) {
-        let regs = &*self.registers;
-        regs.txpower.set(self.tx_power.get() as u32);
+        self.registers.txpower.set(self.tx_power.get() as u32);
     }
 
     fn set_dma_ptr(&self, buffer: &'static mut [u8]) -> &'static mut [u8] {
-        let regs = &*self.registers;
-        regs.packetptr
+        self.registers
+            .packetptr
             .set(buffer.as_ptr() as u32 + MIMIC_PSDU_OFFSET);
         buffer
     }
@@ -764,37 +762,38 @@ impl Radio {
     // TODO: Theres an additional step for 802154 rx/tx handling
     #[inline(never)]
     pub fn handle_interrupt(&self) {
-        let regs = &*self.registers;
         self.disable_all_interrupts();
 
-        if regs.event_ready.is_set(Event::READY) {
-            regs.event_ready.write(Event::READY::CLEAR);
-            regs.event_end.write(Event::READY::CLEAR);
-            if self.transmitting.get() && regs.state.get() == nrf5x::constants::RADIO_STATE_RXIDLE {
+        if self.registers.event_ready.is_set(Event::READY) {
+            self.registers.event_ready.write(Event::READY::CLEAR);
+            self.registers.event_end.write(Event::READY::CLEAR);
+            if self.transmitting.get()
+                && self.registers.state.get() == nrf5x::constants::RADIO_STATE_RXIDLE
+            {
                 if self.cca_count.get() > 0 {
                     unsafe {
                         ppi::PPI.disable(ppi::Channel::CH21::SET);
                     }
                 }
-                regs.task_ccastart.write(Task::ENABLE::SET);
+                self.registers.task_ccastart.write(Task::ENABLE::SET);
             } else {
-                regs.task_start.write(Task::ENABLE::SET);
+                self.registers.task_start.write(Task::ENABLE::SET);
             }
         }
 
-        if regs.event_framestart.is_set(Event::READY) {
-            regs.event_framestart.write(Event::READY::CLEAR);
+        if self.registers.event_framestart.is_set(Event::READY) {
+            self.registers.event_framestart.write(Event::READY::CLEAR);
         }
 
         //   IF we receive the go ahead (channel is clear)
         // THEN start the transmit part of the radio
-        if regs.event_ccaidle.is_set(Event::READY) {
-            regs.event_ccaidle.write(Event::READY::CLEAR);
-            regs.task_txen.write(Task::ENABLE::SET)
+        if self.registers.event_ccaidle.is_set(Event::READY) {
+            self.registers.event_ccaidle.write(Event::READY::CLEAR);
+            self.registers.task_txen.write(Task::ENABLE::SET)
         }
 
-        if regs.event_ccabusy.is_set(Event::READY) {
-            regs.event_ccabusy.write(Event::READY::CLEAR);
+        if self.registers.event_ccabusy.is_set(Event::READY) {
+            self.registers.event_ccabusy.write(Event::READY::CLEAR);
             //need to back off for a period of time outlined
             //in the IEEE 802.15.4 standard (see Figure 69 in
             //section 7.5.1.4 The CSMA-CA algorithm of the
@@ -820,22 +819,22 @@ impl Radio {
                     });
             }
 
-            regs.event_ready.write(Event::READY::CLEAR);
-            regs.task_disable.write(Task::ENABLE::SET);
+            self.registers.event_ready.write(Event::READY::CLEAR);
+            self.registers.task_disable.write(Task::ENABLE::SET);
             self.enable_interrupts();
         }
 
         // tx or rx finished!
-        if regs.event_end.is_set(Event::READY) {
-            regs.event_end.write(Event::READY::CLEAR);
+        if self.registers.event_end.is_set(Event::READY) {
+            self.registers.event_end.write(Event::READY::CLEAR);
 
-            let result = if regs.crcstatus.is_set(Event::READY) {
+            let result = if self.registers.crcstatus.is_set(Event::READY) {
                 ReturnCode::SUCCESS
             } else {
                 ReturnCode::FAIL
             };
 
-            match regs.state.get() {
+            match self.registers.state.get() {
                 nrf5x::constants::RADIO_STATE_TXRU
                 | nrf5x::constants::RADIO_STATE_TXIDLE
                 | nrf5x::constants::RADIO_STATE_TXDISABLE
@@ -865,7 +864,7 @@ impl Radio {
                         // And because the length field is directly read from the packet
                         // We need to add 2 to length to get the total length
 
-                        client.receive(rbuf, frame_len, regs.crcstatus.get() == 1, result)
+                        client.receive(rbuf, frame_len, self.registers.crcstatus.get() == 1, result)
                     });
                 }
                 // Radio state - Disabled
@@ -879,8 +878,7 @@ impl Radio {
     }
 
     pub fn enable_interrupts(&self) {
-        let regs = &*self.registers;
-        regs.intenset.write(
+        self.registers.intenset.write(
             Interrupt::READY::SET
                 + Interrupt::CCAIDLE::SET
                 + Interrupt::CCABUSY::SET
@@ -890,29 +888,25 @@ impl Radio {
     }
 
     pub fn enable_interrupt(&self, intr: u32) {
-        let regs = &*self.registers;
-        regs.intenset.set(intr);
+        self.registers.intenset.set(intr);
     }
 
     pub fn clear_interrupt(&self, intr: u32) {
-        let regs = &*self.registers;
-        regs.intenclr.set(intr);
+        self.registers.intenclr.set(intr);
     }
 
     pub fn disable_all_interrupts(&self) {
-        let regs = &*self.registers;
         // disable all possible interrupts
-        regs.intenclr.set(0xffffffff);
+        self.registers.intenclr.set(0xffffffff);
     }
 
     fn radio_initialize(&self) {
-        let regs = &*self.registers;
         self.radio_on();
 
         // Radio disable
-        regs.event_disabled.set(0);
-        regs.task_disable.write(Task::ENABLE::SET);
-        while regs.event_disabled.get() == 0 {}
+        self.registers.event_disabled.set(0);
+        self.registers.task_disable.write(Task::ENABLE::SET);
+        while self.registers.event_disabled.get() == 0 {}
         // end radio disable
 
         self.ieee802154_set_channel_rate();
@@ -938,22 +932,25 @@ impl Radio {
 
     // IEEE802.15.4 SPECIFICATION Section 6.20.12.5 of the NRF52840 Datasheet
     fn ieee802154_set_crc_config(&self) {
-        let regs = &*self.registers;
-        regs.crccnf
+        self.registers
+            .crccnf
             .write(CrcConfiguration::LEN::TWO + CrcConfiguration::SKIPADDR::IEEE802154);
-        regs.crcinit.set(nrf5x::constants::RADIO_CRCINIT_IEEE802154);
-        regs.crcpoly.set(nrf5x::constants::RADIO_CRCPOLY_IEEE802154);
+        self.registers
+            .crcinit
+            .set(nrf5x::constants::RADIO_CRCINIT_IEEE802154);
+        self.registers
+            .crcpoly
+            .set(nrf5x::constants::RADIO_CRCPOLY_IEEE802154);
     }
 
     fn ieee802154_set_rampup_mode(&self) {
-        let regs = &*self.registers;
-        regs.modecnf0
+        self.registers
+            .modecnf0
             .write(RadioModeConfig::RU::FAST + RadioModeConfig::DTX::CENTER);
     }
 
     fn ieee802154_set_cca_config(&self) {
-        let regs = &*self.registers;
-        regs.ccactrl.write(
+        self.registers.ccactrl.write(
             CCAControl::CCAMODE.val(nrf5x::constants::IEEE802154_CCA_MODE)
                 + CCAControl::CCAEDTHRESH.val(nrf5x::constants::IEEE802154_CCA_ED_THRESH)
                 + CCAControl::CCACORRTHRESH.val(nrf5x::constants::IEEE802154_CCA_CORR_THRESH)
@@ -964,26 +961,24 @@ impl Radio {
     // Packet configuration
     // Settings taken from RiotOS nrf52840 15.4 driver
     fn ieee802154_set_packet_config(&self) {
-        let regs = &*self.registers;
-
-        regs.pcnf0.write(
+        self.registers.pcnf0.write(
             PacketConfiguration0::LFLEN.val(8)
                 + PacketConfiguration0::PLEN::THIRTYTWOZEROS
                 + PacketConfiguration0::CRCINC::INCLUDE,
         );
 
-        regs.pcnf1
+        self.registers
+            .pcnf1
             .write(PacketConfiguration1::MAXLEN.val(nrf5x::constants::RADIO_PAYLOAD_LENGTH as u32));
     }
 
     fn ieee802154_set_channel_rate(&self) {
-        let regs = &*self.registers;
-        regs.mode.write(Mode::MODE::IEEE802154_250KBIT);
+        self.registers.mode.write(Mode::MODE::IEEE802154_250KBIT);
     }
 
     fn ieee802154_set_channel_freq(&self, channel: RadioChannel) {
-        let regs = &*self.registers;
-        regs.frequency
+        self.registers
+            .frequency
             .write(Frequency::FREQUENCY.val(channel as u32));
     }
 

--- a/chips/nrf52/src/power.rs
+++ b/chips/nrf52/src/power.rs
@@ -275,56 +275,51 @@ impl<'a> Power<'a> {
     }
 
     pub fn handle_interrupt(&self) {
-        let regs = &*self.registers;
         self.disable_all_interrupts();
 
-        if regs.event_usbdetected.is_set(Event::READY) {
-            regs.event_usbdetected.write(Event::READY::CLEAR);
+        if self.registers.event_usbdetected.is_set(Event::READY) {
+            self.registers.event_usbdetected.write(Event::READY::CLEAR);
             self.usb_client
                 .map(|client| client.handle_power_event(PowerEvent::UsbPluggedIn));
         }
 
-        if regs.event_usbremoved.is_set(Event::READY) {
-            regs.event_usbremoved.write(Event::READY::CLEAR);
+        if self.registers.event_usbremoved.is_set(Event::READY) {
+            self.registers.event_usbremoved.write(Event::READY::CLEAR);
             self.usb_client
                 .map(|client| client.handle_power_event(PowerEvent::UsbPluggedOut));
         }
 
-        if regs.event_usbpwrrdy.is_set(Event::READY) {
-            regs.event_usbpwrrdy.write(Event::READY::CLEAR);
+        if self.registers.event_usbpwrrdy.is_set(Event::READY) {
+            self.registers.event_usbpwrrdy.write(Event::READY::CLEAR);
             self.usb_client
                 .map(|client| client.handle_power_event(PowerEvent::UsbPowerReady));
         }
 
         // Clearing unused events
-        regs.event_pofwarn.write(Event::READY::CLEAR);
-        regs.event_sleepenter.write(Event::READY::CLEAR);
-        regs.event_sleepexit.write(Event::READY::CLEAR);
+        self.registers.event_pofwarn.write(Event::READY::CLEAR);
+        self.registers.event_sleepenter.write(Event::READY::CLEAR);
+        self.registers.event_sleepexit.write(Event::READY::CLEAR);
 
         self.enable_interrupts();
     }
 
     pub fn enable_interrupts(&self) {
-        let regs = &*self.registers;
-        regs.intenset.write(
+        self.registers.intenset.write(
             Interrupt::USBDETECTED::SET + Interrupt::USBREMOVED::SET + Interrupt::USBPWRRDY::SET,
         );
     }
 
     pub fn enable_interrupt(&self, intr: u32) {
-        let regs = &*self.registers;
-        regs.intenset.set(intr);
+        self.registers.intenset.set(intr);
     }
 
     pub fn clear_interrupt(&self, intr: u32) {
-        let regs = &*self.registers;
-        regs.intenclr.set(intr);
+        self.registers.intenclr.set(intr);
     }
 
     pub fn disable_all_interrupts(&self) {
-        let regs = &*self.registers;
         // disable all possible interrupts
-        regs.intenclr.set(0xffffffff);
+        self.registers.intenclr.set(0xffffffff);
     }
 
     pub fn get_main_supply_status(&self) -> MainVoltage {

--- a/chips/nrf52/src/ppi.rs
+++ b/chips/nrf52/src/ppi.rs
@@ -163,12 +163,10 @@ impl Ppi {
     }
 
     pub fn enable(&self, channels: FieldValue<u32, Channel::Register>) {
-        let regs = &*self.registers;
-        regs.chenset.write(channels);
+        self.registers.chenset.write(channels);
     }
 
     pub fn disable(&self, channels: FieldValue<u32, Channel::Register>) {
-        let regs = &*self.registers;
-        regs.chenclr.write(channels);
+        self.registers.chenclr.write(channels);
     }
 }

--- a/chips/nrf52/src/uart.rs
+++ b/chips/nrf52/src/uart.rs
@@ -205,27 +205,26 @@ impl<'a> Uarte<'a> {
         cts: Option<pinmux::Pinmux>,
         rts: Option<pinmux::Pinmux>,
     ) {
-        let regs = &*self.registers;
-        regs.pseltxd.write(Psel::PIN.val(txd.into()));
-        regs.pselrxd.write(Psel::PIN.val(rxd.into()));
+        self.registers.pseltxd.write(Psel::PIN.val(txd.into()));
+        self.registers.pselrxd.write(Psel::PIN.val(rxd.into()));
         cts.map_or_else(
             || {
                 // If no CTS pin is provided, then we need to mark it as
                 // disconnected in the register.
-                regs.pselcts.write(Psel::CONNECT::SET);
+                self.registers.pselcts.write(Psel::CONNECT::SET);
             },
             |c| {
-                regs.pselcts.write(Psel::PIN.val(c.into()));
+                self.registers.pselcts.write(Psel::PIN.val(c.into()));
             },
         );
         rts.map_or_else(
             || {
                 // If no RTS pin is provided, then we need to mark it as
                 // disconnected in the register.
-                regs.pselrts.write(Psel::CONNECT::SET);
+                self.registers.pselrts.write(Psel::CONNECT::SET);
             },
             |r| {
-                regs.pselrts.write(Psel::PIN.val(r.into()));
+                self.registers.pselrts.write(Psel::PIN.val(r.into()));
             },
         );
 
@@ -234,76 +233,66 @@ impl<'a> Uarte<'a> {
         // as we handle it, so this is not necessary. However, a bootloader (or
         // some other startup code) may have setup TX interrupts, and there may
         // be one pending. We clear it to be safe.
-        regs.event_endtx.write(Event::READY::CLEAR);
+        self.registers.event_endtx.write(Event::READY::CLEAR);
 
         self.enable_uart();
     }
 
     fn set_baud_rate(&self, baud_rate: u32) {
-        let regs = &*self.registers;
         match baud_rate {
-            1200 => regs.baudrate.set(0x0004F000),
-            2400 => regs.baudrate.set(0x0009D000),
-            4800 => regs.baudrate.set(0x0013B000),
-            9600 => regs.baudrate.set(0x00275000),
-            14400 => regs.baudrate.set(0x003AF000),
-            19200 => regs.baudrate.set(0x004EA000),
-            28800 => regs.baudrate.set(0x0075C000),
-            38400 => regs.baudrate.set(0x009D0000),
-            57600 => regs.baudrate.set(0x00EB0000),
-            76800 => regs.baudrate.set(0x013A9000),
-            115200 => regs.baudrate.set(0x01D60000),
-            230400 => regs.baudrate.set(0x03B00000),
-            250000 => regs.baudrate.set(0x04000000),
-            460800 => regs.baudrate.set(0x07400000),
-            921600 => regs.baudrate.set(0x0F000000),
-            1000000 => regs.baudrate.set(0x10000000),
-            _ => regs.baudrate.set(0x01D60000), //setting default to 115200
+            1200 => self.registers.baudrate.set(0x0004F000),
+            2400 => self.registers.baudrate.set(0x0009D000),
+            4800 => self.registers.baudrate.set(0x0013B000),
+            9600 => self.registers.baudrate.set(0x00275000),
+            14400 => self.registers.baudrate.set(0x003AF000),
+            19200 => self.registers.baudrate.set(0x004EA000),
+            28800 => self.registers.baudrate.set(0x0075C000),
+            38400 => self.registers.baudrate.set(0x009D0000),
+            57600 => self.registers.baudrate.set(0x00EB0000),
+            76800 => self.registers.baudrate.set(0x013A9000),
+            115200 => self.registers.baudrate.set(0x01D60000),
+            230400 => self.registers.baudrate.set(0x03B00000),
+            250000 => self.registers.baudrate.set(0x04000000),
+            460800 => self.registers.baudrate.set(0x07400000),
+            921600 => self.registers.baudrate.set(0x0F000000),
+            1000000 => self.registers.baudrate.set(0x10000000),
+            _ => self.registers.baudrate.set(0x01D60000), //setting default to 115200
         }
     }
 
     // Enable UART peripheral, this need to disabled for low power applications
     fn enable_uart(&self) {
-        let regs = &*self.registers;
-        regs.enable.write(Uart::ENABLE::ON);
+        self.registers.enable.write(Uart::ENABLE::ON);
     }
 
     #[allow(dead_code)]
     fn disable_uart(&self) {
-        let regs = &*self.registers;
-        regs.enable.write(Uart::ENABLE::OFF);
+        self.registers.enable.write(Uart::ENABLE::OFF);
     }
 
     fn enable_rx_interrupts(&self) {
-        let regs = &*self.registers;
-        regs.intenset.write(Interrupt::ENDRX::SET);
+        self.registers.intenset.write(Interrupt::ENDRX::SET);
     }
 
     fn enable_tx_interrupts(&self) {
-        let regs = &*self.registers;
-        regs.intenset.write(Interrupt::ENDTX::SET);
+        self.registers.intenset.write(Interrupt::ENDTX::SET);
     }
 
     fn disable_rx_interrupts(&self) {
-        let regs = &*self.registers;
-        regs.intenclr.write(Interrupt::ENDRX::SET);
+        self.registers.intenclr.write(Interrupt::ENDRX::SET);
     }
 
     fn disable_tx_interrupts(&self) {
-        let regs = &*self.registers;
-        regs.intenclr.write(Interrupt::ENDTX::SET);
+        self.registers.intenclr.write(Interrupt::ENDTX::SET);
     }
 
     /// UART interrupt handler that listens for both tx_end and rx_end events
     #[inline(never)]
     pub fn handle_interrupt(&mut self) {
-        let regs = &*self.registers;
-
         if self.tx_ready() {
             self.disable_tx_interrupts();
-            let regs = &*self.registers;
-            regs.event_endtx.write(Event::READY::CLEAR);
-            let tx_bytes = regs.txd_amount.get() as usize;
+            self.registers.event_endtx.write(Event::READY::CLEAR);
+            let tx_bytes = self.registers.txd_amount.get() as usize;
 
             let rem = match self.tx_remaining_bytes.get().checked_sub(tx_bytes) {
                 None => return,
@@ -327,9 +316,10 @@ impl<'a> Uarte<'a> {
                 self.offset.set(self.offset.get() + tx_bytes);
                 self.tx_remaining_bytes.set(rem);
                 self.set_tx_dma_pointer_to_buffer();
-                regs.txd_maxcnt
+                self.registers
+                    .txd_maxcnt
                     .write(Counter::COUNTER.val(min(rem as u32, UARTE_MAX_BUFFER_SIZE)));
-                regs.task_starttx.write(Task::ENABLE::SET);
+                self.registers.task_starttx.write(Task::ENABLE::SET);
                 self.enable_tx_interrupts();
             }
         }
@@ -338,10 +328,10 @@ impl<'a> Uarte<'a> {
             self.disable_rx_interrupts();
 
             // Clear the ENDRX event
-            regs.event_endrx.write(Event::READY::CLEAR);
+            self.registers.event_endrx.write(Event::READY::CLEAR);
 
             // Get the number of bytes in the buffer that was received this time
-            let rx_bytes = regs.rxd_amount.get() as usize;
+            let rx_bytes = self.registers.rxd_amount.get() as usize;
 
             // Check if this ENDRX is due to an abort. If so, we want to
             // do the receive callback immediately.
@@ -384,11 +374,13 @@ impl<'a> Uarte<'a> {
                     // Setup how much we can read. We already made sure that
                     // this will fit in the buffer.
                     let to_read = core::cmp::min(rem, 255);
-                    regs.rxd_maxcnt.write(Counter::COUNTER.val(to_read as u32));
+                    self.registers
+                        .rxd_maxcnt
+                        .write(Counter::COUNTER.val(to_read as u32));
 
                     // Actually do the receive.
                     self.set_rx_dma_pointer_to_buffer();
-                    regs.task_startrx.write(Task::ENABLE::SET);
+                    self.registers.task_startrx.write(Task::ENABLE::SET);
                     self.enable_rx_interrupts();
                 }
             }
@@ -398,41 +390,37 @@ impl<'a> Uarte<'a> {
     /// Transmit one byte at the time and the client is responsible for polling
     /// This is used by the panic handler
     pub unsafe fn send_byte(&self, byte: u8) {
-        let regs = &*self.registers;
-
         self.tx_remaining_bytes.set(1);
-        regs.event_endtx.write(Event::READY::CLEAR);
+        self.registers.event_endtx.write(Event::READY::CLEAR);
         // precaution: copy value into variable with static lifetime
         BYTE = byte;
-        regs.txd_ptr.set((&BYTE as *const u8) as u32);
-        regs.txd_maxcnt.write(Counter::COUNTER.val(1));
-        regs.task_starttx.write(Task::ENABLE::SET);
+        self.registers.txd_ptr.set((&BYTE as *const u8) as u32);
+        self.registers.txd_maxcnt.write(Counter::COUNTER.val(1));
+        self.registers.task_starttx.write(Task::ENABLE::SET);
     }
 
     /// Check if the UART transmission is done
     pub fn tx_ready(&self) -> bool {
-        let regs = &*self.registers;
-        regs.event_endtx.is_set(Event::READY)
+        self.registers.event_endtx.is_set(Event::READY)
     }
 
     /// Check if either the rx_buffer is full or the UART has timed out
     pub fn rx_ready(&self) -> bool {
-        let regs = &*self.registers;
-        regs.event_endrx.is_set(Event::READY)
+        self.registers.event_endrx.is_set(Event::READY)
     }
 
     fn set_tx_dma_pointer_to_buffer(&self) {
-        let regs = &*self.registers;
         self.tx_buffer.map(|tx_buffer| {
-            regs.txd_ptr
+            self.registers
+                .txd_ptr
                 .set(tx_buffer[self.offset.get()..].as_ptr() as u32);
         });
     }
 
     fn set_rx_dma_pointer_to_buffer(&self) {
-        let regs = &*self.registers;
         self.rx_buffer.map(|rx_buffer| {
-            regs.rxd_ptr
+            self.registers
+                .rxd_ptr
                 .set(rx_buffer[self.offset.get()..].as_ptr() as u32);
         });
     }
@@ -445,10 +433,10 @@ impl<'a> Uarte<'a> {
         self.tx_buffer.replace(buf);
         self.set_tx_dma_pointer_to_buffer();
 
-        let regs = &*self.registers;
-        regs.txd_maxcnt
+        self.registers
+            .txd_maxcnt
             .write(Counter::COUNTER.val(min(tx_len as u32, UARTE_MAX_BUFFER_SIZE)));
-        regs.task_starttx.write(Task::ENABLE::SET);
+        self.registers.task_starttx.write(Task::ENABLE::SET);
 
         self.enable_tx_interrupts();
     }
@@ -516,7 +504,6 @@ impl<'a> uart::Receive<'a> for Uarte<'a> {
         rx_buf: &'static mut [u8],
         rx_len: usize,
     ) -> (ReturnCode, Option<&'static mut [u8]>) {
-        let regs = &*self.registers;
         if self.rx_buffer.is_some() {
             return (ReturnCode::EBUSY, Some(rx_buf));
         }
@@ -530,10 +517,11 @@ impl<'a> uart::Receive<'a> for Uarte<'a> {
 
         let truncated_uart_max_length = core::cmp::min(truncated_length, 255);
 
-        regs.rxd_maxcnt
+        self.registers
+            .rxd_maxcnt
             .write(Counter::COUNTER.val(truncated_uart_max_length as u32));
-        regs.task_stoprx.write(Task::ENABLE::SET);
-        regs.task_startrx.write(Task::ENABLE::SET);
+        self.registers.task_stoprx.write(Task::ENABLE::SET);
+        self.registers.task_startrx.write(Task::ENABLE::SET);
 
         self.enable_rx_interrupts();
         (ReturnCode::SUCCESS, None)
@@ -548,9 +536,8 @@ impl<'a> uart::Receive<'a> for Uarte<'a> {
         if self.rx_buffer.is_none() {
             ReturnCode::SUCCESS
         } else {
-            let regs = &*self.registers;
             self.rx_abort_in_progress.set(true);
-            regs.task_stoprx.write(Task::ENABLE::SET);
+            self.registers.task_stoprx.write(Task::ENABLE::SET);
             ReturnCode::EBUSY
         }
     }

--- a/chips/nrf52/src/uicr.rs
+++ b/chips/nrf52/src/uicr.rs
@@ -137,8 +137,7 @@ impl Uicr {
     }
 
     pub fn set_psel0_reset_pin(&self, pin: Pin) {
-        let regs = &*self.registers;
-        regs.pselreset0.set(pin as u32);
+        self.registers.pselreset0.set(pin as u32);
     }
 
     pub fn get_psel0_reset_pin(&self) -> Option<Pin> {
@@ -146,8 +145,7 @@ impl Uicr {
     }
 
     pub fn set_psel1_reset_pin(&self, pin: Pin) {
-        let regs = &*self.registers;
-        regs.pselreset1.set(pin as u32);
+        self.registers.pselreset1.set(pin as u32);
     }
 
     pub fn get_psel1_reset_pin(&self) -> Option<Pin> {
@@ -155,8 +153,7 @@ impl Uicr {
     }
 
     pub fn set_vout(&self, vout: Regulator0Output) {
-        let regs = &*self.registers;
-        regs.regout0.modify(RegOut::VOUT.val(vout as u32));
+        self.registers.regout0.modify(RegOut::VOUT.val(vout as u32));
     }
 
     pub fn get_vout(&self) -> Regulator0Output {
@@ -164,11 +161,10 @@ impl Uicr {
     }
 
     pub fn set_nfc_pins_protection(&self, protected: bool) {
-        let regs = &*self.registers;
         if protected {
-            regs.nfcpins.write(NfcPins::PROTECT::NFC);
+            self.registers.nfcpins.write(NfcPins::PROTECT::NFC);
         } else {
-            regs.nfcpins.write(NfcPins::PROTECT::DISABLED);
+            self.registers.nfcpins.write(NfcPins::PROTECT::DISABLED);
         }
     }
 

--- a/chips/nrf5x/src/aes.rs
+++ b/chips/nrf5x/src/aes.rs
@@ -149,9 +149,8 @@ impl<'a> AesECB<'a> {
     }
 
     fn set_dma(&self) {
-        let regs = &*self.registers;
         unsafe {
-            regs.ecbdataptr.set(ECB_DATA.as_ptr() as u32);
+            self.registers.ecbdataptr.set(ECB_DATA.as_ptr() as u32);
         }
     }
 
@@ -169,22 +168,18 @@ impl<'a> AesECB<'a> {
     }
 
     fn crypt(&self) {
-        let regs = &*self.registers;
-
-        regs.event_endecb.write(Event::READY::CLEAR);
-        regs.task_startecb.set(1);
+        self.registers.event_endecb.write(Event::READY::CLEAR);
+        self.registers.task_startecb.set(1);
 
         self.enable_interrupts();
     }
 
     /// AesEcb Interrupt handler
     pub fn handle_interrupt(&self) {
-        let regs = &*self.registers;
-
         // disable interrupts
         self.disable_interrupts();
 
-        if regs.event_endecb.get() == 1 {
+        if self.registers.event_endecb.get() == 1 {
             let current_idx = self.current_idx.get();
             let end_idx = self.end_idx.get();
 
@@ -240,14 +235,14 @@ impl<'a> AesECB<'a> {
     }
 
     fn enable_interrupts(&self) {
-        let regs = &*self.registers;
-        regs.intenset
+        self.registers
+            .intenset
             .write(Intenset::ENDECB::SET + Intenset::ERRORECB::SET);
     }
 
     fn disable_interrupts(&self) {
-        let regs = &*self.registers;
-        regs.intenclr
+        self.registers
+            .intenclr
             .write(Intenclr::ENDECB::SET + Intenclr::ERRORECB::SET);
     }
 }
@@ -258,8 +253,7 @@ impl<'a> kernel::hil::symmetric_encryption::AES128<'a> for AesECB<'a> {
     }
 
     fn disable(&self) {
-        let regs = &*self.registers;
-        regs.task_stopecb.write(Task::ENABLE::CLEAR);
+        self.registers.task_stopecb.write(Task::ENABLE::CLEAR);
         self.disable_interrupts();
     }
 

--- a/chips/nrf5x/src/temperature.rs
+++ b/chips/nrf5x/src/temperature.rs
@@ -122,14 +122,13 @@ impl<'a> Temp<'a> {
     pub fn handle_interrupt(&self) {
         // disable interrupts
         self.disable_interrupts();
-        let regs = &*self.registers;
 
         // get temperature
         // Result of temperature measurement in °C, 2's complement format, 0.25 °C
-        let temp = (regs.temp.get() / 4) * 100;
+        let temp = (self.registers.temp.get() / 4) * 100;
 
         // stop measurement
-        regs.task_stop.write(Task::ENABLE::SET);
+        self.registers.task_stop.write(Task::ENABLE::SET);
 
         // disable interrupts
         self.disable_interrupts();
@@ -139,22 +138,19 @@ impl<'a> Temp<'a> {
     }
 
     fn enable_interrupts(&self) {
-        let regs = &*self.registers;
-        regs.intenset.write(Intenset::DATARDY::SET);
+        self.registers.intenset.write(Intenset::DATARDY::SET);
     }
 
     fn disable_interrupts(&self) {
-        let regs = &*self.registers;
-        regs.intenclr.write(Intenclr::DATARDY::SET);
+        self.registers.intenclr.write(Intenclr::DATARDY::SET);
     }
 }
 
 impl<'a> kernel::hil::sensors::TemperatureDriver<'a> for Temp<'a> {
     fn read_temperature(&self) -> kernel::ReturnCode {
-        let regs = &*self.registers;
         self.enable_interrupts();
-        regs.event_datardy.write(Event::READY::CLEAR);
-        regs.task_start.write(Task::ENABLE::SET);
+        self.registers.event_datardy.write(Event::READY::CLEAR);
+        self.registers.task_start.write(Task::ENABLE::SET);
         kernel::ReturnCode::SUCCESS
     }
 

--- a/chips/nrf5x/src/trng.rs
+++ b/chips/nrf5x/src/trng.rs
@@ -125,8 +125,6 @@ impl<'a> Trng<'a> {
 
     /// RNG Interrupt handler
     pub fn handle_interrupt(&self) {
-        let regs = &*self.registers;
-
         self.disable_interrupts();
 
         match self.index.get() {
@@ -135,7 +133,7 @@ impl<'a> Trng<'a> {
                 // 3 lines below to change data in Cell, perhaps it can be done more nicely
                 let mut rn = self.randomness.get();
                 // 1 byte randomness
-                let r = regs.value.get();
+                let r = self.registers.value.get();
                 //  e = 0 -> byte 1 LSB
                 //  e = 1 -> byte 2
                 //  e = 2 -> byte 3
@@ -166,26 +164,22 @@ impl<'a> Trng<'a> {
     }
 
     fn enable_interrupts(&self) {
-        let regs = &*self.registers;
-        regs.intenset.write(Intenset::VALRDY::SET);
+        self.registers.intenset.write(Intenset::VALRDY::SET);
     }
 
     fn disable_interrupts(&self) {
-        let regs = &*self.registers;
-        regs.intenclr.write(Intenclr::VALRDY::SET);
+        self.registers.intenclr.write(Intenclr::VALRDY::SET);
     }
 
     fn start_rng(&self) {
-        let regs = &*self.registers;
-
         // Reset `valrdy`
-        regs.event_valrdy.write(Event::READY::CLEAR);
+        self.registers.event_valrdy.write(Event::READY::CLEAR);
 
         // Enable interrupts
         self.enable_interrupts();
 
         // Start rng
-        regs.task_start.write(Task::ENABLE::SET);
+        self.registers.task_start.write(Task::ENABLE::SET);
     }
 }
 

--- a/chips/sam4l/src/adc.rs
+++ b/chips/sam4l/src/adc.rs
@@ -400,8 +400,7 @@ impl Adc {
 
     /// Interrupt handler for the ADC.
     pub fn handle_interrupt(&mut self) {
-        let regs: &AdcRegisters = &*self.registers;
-        let status = regs.sr.is_set(Status::SEOC);
+        let status = self.registers.sr.is_set(Status::SEOC);
 
         if self.enabled.get() && self.active.get() {
             if status {
@@ -413,7 +412,7 @@ impl Adc {
                     // we actually care about this sample
 
                     // single sample complete. Send value to client
-                    let val = regs.lcv.read(SequencerLastConvertedValue::LCV) as u16;
+                    let val = self.registers.lcv.read(SequencerLastConvertedValue::LCV) as u16;
                     self.client.map(|client| {
                         client.sample_ready(val);
                     });
@@ -425,7 +424,7 @@ impl Adc {
                     } else {
                         // single sampling, disable interrupt and set inactive
                         self.active.set(false);
-                        regs.idr.write(Interrupt::SEOC::SET);
+                        self.registers.idr.write(Interrupt::SEOC::SET);
                     }
                 } else {
                     // increment count and wait for next sample
@@ -433,12 +432,12 @@ impl Adc {
                 }
 
                 // clear status
-                regs.scr.write(Interrupt::SEOC::SET);
+                self.registers.scr.write(Interrupt::SEOC::SET);
             }
         } else {
             // we are inactive, why did we get an interrupt?
             // disable all interrupts, clear status, and just ignore it
-            regs.idr.write(
+            self.registers.idr.write(
                 Interrupt::TTO::SET
                     + Interrupt::SMTRG::SET
                     + Interrupt::WM::SET
@@ -451,8 +450,7 @@ impl Adc {
 
     /// Clear all status bits using the status clear register.
     fn clear_status(&self) {
-        let regs: &AdcRegisters = &*self.registers;
-        regs.scr.write(
+        self.registers.scr.write(
             Interrupt::TTO::SET
                 + Interrupt::SMTRG::SET
                 + Interrupt::WM::SET
@@ -473,15 +471,13 @@ impl Adc {
             // already configured to work on this frequency
             ReturnCode::SUCCESS
         } else {
-            let regs: &AdcRegisters = &*self.registers;
-
             // disabling the ADC before switching clocks is necessary to avoid
             // leaving it in undefined state
-            regs.cr.write(Control::DIS::SET);
+            self.registers.cr.write(Control::DIS::SET);
 
             // wait until status is disabled
             let mut timeout = 10000;
-            while regs.sr.is_set(Status::EN) {
+            while self.registers.sr.is_set(Status::EN) {
                 timeout -= 1;
                 if timeout == 0 {
                     // ADC never disabled
@@ -559,22 +555,22 @@ impl Adc {
                 cfg_val += Configuration::CLKSEL::GenericClock
             }
 
-            regs.cfg.write(cfg_val);
+            self.registers.cfg.write(cfg_val);
 
             // set startup to wait 24 cycles
-            regs.tim.write(
+            self.registers.tim.write(
                 TimingConfiguration::ENSTUP::Enable + TimingConfiguration::STARTUP.val(0x17),
             );
 
             // software reset (does not clear registers)
-            regs.cr.write(Control::SWRST::SET);
+            self.registers.cr.write(Control::SWRST::SET);
 
             // enable ADC
-            regs.cr.write(Control::EN::SET);
+            self.registers.cr.write(Control::EN::SET);
 
             // wait until status is enabled
             let mut timeout = 10000;
-            while !regs.sr.is_set(Status::EN) {
+            while !self.registers.sr.is_set(Status::EN) {
                 timeout -= 1;
                 if timeout == 0 {
                     // ADC never enabled
@@ -584,12 +580,14 @@ impl Adc {
 
             // enable Bandgap buffer and Reference buffer. I don't actually
             // know what these do, but you need to turn them on
-            regs.cr
+            self.registers
+                .cr
                 .write(Control::BGREQEN::SET + Control::REFBUFEN::SET);
 
             // wait until buffers are enabled
             timeout = 100000;
-            while !regs
+            while !self
+                .registers
                 .sr
                 .matches_all(Status::BGREQ::SET + Status::REFBUF::SET + Status::EN::SET)
             {
@@ -606,14 +604,12 @@ impl Adc {
 
     /// Disables the ADC so that the chip can return to deep sleep
     fn disable(&self) {
-        let regs: &AdcRegisters = &*self.registers;
-
         // disable ADC
-        regs.cr.write(Control::DIS::SET);
+        self.registers.cr.write(Control::DIS::SET);
 
         // wait until status is disabled
         let mut timeout = 10000;
-        while regs.sr.is_set(Status::EN) {
+        while self.registers.sr.is_set(Status::EN) {
             timeout -= 1;
             if timeout == 0 {
                 // ADC never disabled
@@ -622,7 +618,8 @@ impl Adc {
         }
 
         // disable bandgap and reference buffers
-        regs.cr
+        self.registers
+            .cr
             .write(Control::BGREQDIS::SET + Control::REFBUFDIS::SET);
 
         self.enabled.set(false);
@@ -640,8 +637,6 @@ impl hil::adc::Adc for Adc {
     ///
     /// - `channel`: the ADC channel to sample
     fn sample(&self, channel: &Self::Channel) -> ReturnCode {
-        let regs: &AdcRegisters = &*self.registers;
-
         // always configure to 1KHz to get the slowest clock with single sampling
         let res = self.config_and_enable(1000);
 
@@ -667,16 +662,16 @@ impl hil::adc::Adc for Adc {
                 + SequencerConfig::GAIN::Gain0p5x
                 + SequencerConfig::BIPOLAR::Disable
                 + SequencerConfig::HWLA::Enable;
-            regs.seqcfg.write(cfg);
+            self.registers.seqcfg.write(cfg);
 
             // clear any current status
             self.clear_status();
 
             // enable end of conversion interrupt
-            regs.ier.write(Interrupt::SEOC::SET);
+            self.registers.ier.write(Interrupt::SEOC::SET);
 
             // initiate conversion
-            regs.cr.write(Control::STRIG::SET);
+            self.registers.cr.write(Control::STRIG::SET);
 
             ReturnCode::SUCCESS
         }
@@ -691,8 +686,6 @@ impl hil::adc::Adc for Adc {
     /// - `channel`: the ADC channel to sample
     /// - `frequency`: the number of samples per second to collect
     fn sample_continuous(&self, channel: &Self::Channel, frequency: u32) -> ReturnCode {
-        let regs: &AdcRegisters = &*self.registers;
-
         let res = self.config_and_enable(frequency);
 
         if res != ReturnCode::SUCCESS {
@@ -724,10 +717,10 @@ impl hil::adc::Adc for Adc {
             } else {
                 cfg += SequencerConfig::TRGSEL::ContinuousMode;
             }
-            regs.seqcfg.write(cfg);
+            self.registers.seqcfg.write(cfg);
 
             // stop timer if running
-            regs.cr.write(Control::TSTOP::SET);
+            self.registers.cr.write(Control::TSTOP::SET);
 
             if self.cpu_clock.get() {
                 // This logic only applies for sampling off the CPU
@@ -760,7 +753,9 @@ impl hil::adc::Adc for Adc {
                 // f(timer) = f(adc) / (counter + 1)
                 let mut counter = (self.adc_clk_freq.get() / timer_frequency) - 1;
                 counter = cmp::max(cmp::min(counter, 0xFFFF), 0);
-                regs.itimer.write(InternalTimer::ITMC.val(counter));
+                self.registers
+                    .itimer
+                    .write(InternalTimer::ITMC.val(counter));
             } else {
                 // we can sample at this frequency directly with the timer
                 self.timer_repeats.set(0);
@@ -771,10 +766,10 @@ impl hil::adc::Adc for Adc {
             self.clear_status();
 
             // enable end of conversion interrupt
-            regs.ier.write(Interrupt::SEOC::SET);
+            self.registers.ier.write(Interrupt::SEOC::SET);
 
             // start timer
-            regs.cr.write(Control::TSTART::SET);
+            self.registers.cr.write(Control::TSTART::SET);
 
             ReturnCode::SUCCESS
         }
@@ -785,8 +780,6 @@ impl hil::adc::Adc for Adc {
     /// but can be called to abort any currently running operation. The buffer,
     /// if any, will be returned via the `samples_ready` callback.
     fn stop_sampling(&self) -> ReturnCode {
-        let regs: &AdcRegisters = &*self.registers;
-
         if !self.enabled.get() {
             ReturnCode::EOFF
         } else if !self.active.get() {
@@ -799,13 +792,13 @@ impl hil::adc::Adc for Adc {
             self.dma_running.set(false);
 
             // stop internal timer
-            regs.cr.write(Control::TSTOP::SET);
+            self.registers.cr.write(Control::TSTOP::SET);
 
             // disable sample interrupts
-            regs.idr.write(Interrupt::SEOC::SET);
+            self.registers.idr.write(Interrupt::SEOC::SET);
 
             // reset the ADC peripheral
-            regs.cr.write(Control::SWRST::SET);
+            self.registers.cr.write(Control::SWRST::SET);
 
             // disable the ADC
             self.disable();
@@ -875,8 +868,6 @@ impl hil::adc::AdcHighSpeed for Adc {
         Option<&'static mut [u16]>,
         Option<&'static mut [u16]>,
     ) {
-        let regs: &AdcRegisters = &*self.registers;
-
         let res = self.config_and_enable(frequency);
 
         if res != ReturnCode::SUCCESS {
@@ -917,17 +908,19 @@ impl hil::adc::AdcHighSpeed for Adc {
             } else {
                 cfg += SequencerConfig::TRGSEL::ContinuousMode;
             }
-            regs.seqcfg.write(cfg);
+            self.registers.seqcfg.write(cfg);
 
             // stop timer if running
-            regs.cr.write(Control::TSTOP::SET);
+            self.registers.cr.write(Control::TSTOP::SET);
 
             if self.cpu_clock.get() {
                 // set timer, limit to bounds
                 // f(timer) = f(adc) / (counter + 1)
                 let mut counter = (self.adc_clk_freq.get() / frequency) - 1;
                 counter = cmp::max(cmp::min(counter, 0xFFFF), 0);
-                regs.itimer.write(InternalTimer::ITMC.val(counter));
+                self.registers
+                    .itimer
+                    .write(InternalTimer::ITMC.val(counter));
             }
 
             // clear any current status
@@ -956,7 +949,7 @@ impl hil::adc::AdcHighSpeed for Adc {
             });
 
             // start timer
-            regs.cr.write(Control::TSTART::SET);
+            self.registers.cr.write(Control::TSTART::SET);
 
             (ReturnCode::SUCCESS, None, None)
         }

--- a/chips/sam4l/src/ast.rs
+++ b/chips/sam4l/src/ast.rs
@@ -202,92 +202,82 @@ enum Clock {
 
 impl<'a> Ast<'a> {
     fn clock_busy(&self) -> bool {
-        let regs: &AstRegisters = &*self.registers;
-        regs.sr.is_set(Status::CLKBUSY)
+        self.registers.sr.is_set(Status::CLKBUSY)
     }
 
     fn busy(&self) -> bool {
-        let regs: &AstRegisters = &*self.registers;
-        regs.sr.is_set(Status::BUSY)
+        self.registers.sr.is_set(Status::BUSY)
     }
 
     /// Clears the alarm bit in the status register (indicating the alarm value
     /// has been reached).
     fn clear_alarm(&self) {
-        let regs: &AstRegisters = &*self.registers;
         while self.busy() {}
-        regs.scr.write(Interrupt::ALARM0::SET);
+        self.registers.scr.write(Interrupt::ALARM0::SET);
         while self.busy() {}
     }
 
     // Configure the clock to use to drive the AST
     fn select_clock(&self, clock: Clock) {
-        let regs: &AstRegisters = &*self.registers;
         // Disable clock by setting first bit to zero
         while self.clock_busy() {}
-        regs.clock.modify(ClockControl::CEN::CLEAR);
+        self.registers.clock.modify(ClockControl::CEN::CLEAR);
         while self.clock_busy() {}
 
         // Select clock
-        regs.clock.write(ClockControl::CSSEL.val(clock as u32));
+        self.registers
+            .clock
+            .write(ClockControl::CSSEL.val(clock as u32));
         while self.clock_busy() {}
 
         // Re-enable clock
-        regs.clock.modify(ClockControl::CEN::SET);
+        self.registers.clock.modify(ClockControl::CEN::SET);
         while self.clock_busy() {}
     }
 
     /// Enables the AST registers
     fn enable(&self) {
-        let regs: &AstRegisters = &*self.registers;
         while self.busy() {}
-        regs.cr.modify(Control::EN::SET);
+        self.registers.cr.modify(Control::EN::SET);
         while self.busy() {}
     }
 
     /// Disable the AST registers
     fn disable(&self) {
-        let regs: &AstRegisters = &*self.registers;
         while self.busy() {}
-        regs.cr.modify(Control::EN::CLEAR);
+        self.registers.cr.modify(Control::EN::CLEAR);
         while self.busy() {}
     }
 
     /// Returns if an alarm is currently set
     fn is_alarm_enabled(&self) -> bool {
-        let regs: &AstRegisters = &*self.registers;
         while self.busy() {}
-        regs.sr.is_set(Status::ALARM0)
+        self.registers.sr.is_set(Status::ALARM0)
     }
 
     fn set_prescalar(&self, val: u8) {
-        let regs: &AstRegisters = &*self.registers;
         while self.busy() {}
-        regs.cr.modify(Control::PSEL.val(val as u32));
+        self.registers.cr.modify(Control::PSEL.val(val as u32));
         while self.busy() {}
     }
 
     fn enable_alarm_irq(&self) {
-        let regs: &AstRegisters = &*self.registers;
-        regs.ier.write(Interrupt::ALARM0::SET);
+        self.registers.ier.write(Interrupt::ALARM0::SET);
     }
 
     fn disable_alarm_irq(&self) {
-        let regs: &AstRegisters = &*self.registers;
-        regs.idr.write(Interrupt::ALARM0::SET);
+        self.registers.idr.write(Interrupt::ALARM0::SET);
     }
 
     fn enable_alarm_wake(&self) {
-        let regs: &AstRegisters = &*self.registers;
         while self.busy() {}
-        regs.wer.modify(Event::ALARM0::SET);
+        self.registers.wer.modify(Event::ALARM0::SET);
         while self.busy() {}
     }
 
     fn get_counter(&self) -> u32 {
-        let regs: &AstRegisters = &*self.registers;
         while self.busy() {}
-        regs.cv.read(Value::VALUE)
+        self.registers.cv.read(Value::VALUE)
     }
 
     pub fn handle_interrupt(&mut self) {
@@ -316,7 +306,6 @@ impl<'a> Alarm<'a> for Ast<'a> {
     }
 
     fn set_alarm(&self, mut tics: u32) {
-        let regs: &AstRegisters = &*self.registers;
         let now = self.get_counter();
         if tics.wrapping_sub(now) <= ALARM0_SYNC_TICS {
             tics = now.wrapping_add(ALARM0_SYNC_TICS);
@@ -326,16 +315,15 @@ impl<'a> Alarm<'a> for Ast<'a> {
         self.clear_alarm();
 
         while self.busy() {}
-        regs.ar0.write(Value::VALUE.val(tics));
+        self.registers.ar0.write(Value::VALUE.val(tics));
         while self.busy() {}
         self.enable_alarm_irq();
         self.enable();
     }
 
     fn get_alarm(&self) -> u32 {
-        let regs: &AstRegisters = &*self.registers;
         while self.busy() {}
-        regs.ar0.read(Value::VALUE)
+        self.registers.ar0.read(Value::VALUE)
     }
 
     fn disable(&self) {

--- a/chips/sifive/src/watchdog.rs
+++ b/chips/sifive/src/watchdog.rs
@@ -49,22 +49,17 @@ impl Watchdog {
     }
 
     fn unlock(&self) {
-        let regs = &*self.registers;
-        regs.wdogkey.write(key::key.val(0x51F15E));
+        self.registers.wdogkey.write(key::key.val(0x51F15E));
     }
 
     fn feed(&self) {
-        let regs = &*self.registers;
-
         self.unlock();
-        regs.wdogfeed.write(feed::feed.val(0xD09F00D));
+        self.registers.wdogfeed.write(feed::feed.val(0xD09F00D));
     }
 
     pub fn disable(&self) {
-        let regs = &*self.registers;
-
         self.unlock();
-        regs.wdogcfg.write(
+        self.registers.wdogcfg.write(
             cfg::scale.val(0)
                 + cfg::rsten::CLEAR
                 + cfg::zerocmp::CLEAR

--- a/doc/Mutable_References.md
+++ b/doc/Mutable_References.md
@@ -180,10 +180,13 @@ call to `take`:
 
 ```rust
 pub fn abort_transfer(&self) -> Option<&'static mut [u8]> {
-    let registers: &DMARegisters = unsafe { &*self.registers };
-    registers.interrupt_disable.set(!0);
+    self.registers
+        .idr
+        .write(Interrupt::TERR::SET + Interrupt::TRC::SET + Interrupt::RCZ::SET);
+
     // Reset counter
-    registers.transfer_counter.set(0);
+    self.registers.tcr.write(TransferCounter::TCV.val(0));
+
     self.buffer.take()
 }
 ```


### PR DESCRIPTION
### Pull Request Overview

We use a re-borrow idiom everywhere we access registers. Once upon a lifetime, when MMIO looked very different, I think this was necessary as we changed types to something that let us access the hardware. After the introduction of `StaticRef`, however, I don't think we actually need this anymore and we can simplify all of the register accesses.

There ~300 more instances of this `&*` register pattern in the kernel, so I wanted to take a temperature check on this before doing more of them.

### Testing Strategy

Compiling.

### TODO or Help Wanted

Is there are a reason to keep all of these `&*` around?

### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
