### PR TITLE
IPC: Shrink grant size, I guess?

### DIFF
--- a/kernel/src/ipc.rs
+++ b/kernel/src/ipc.rs
@@ -31,10 +31,10 @@ pub enum IPCCallbackType {
 struct IPCData {
     /// An array of app slices that this application has shared with other
     /// applications.
-    shared_memory: [Option<AppSlice<Shared, u8>>; 8],
+    shared_memory: [Option<AppSlice<Shared, u8>>; 6],
     /// An array of callbacks this process has registered to receive callbacks
     /// from other services.
-    client_callbacks: [Option<Callback>; 8],
+    client_callbacks: [Option<Callback>; 6],
     /// The callback setup by a service. Each process can only be one service.
     callback: Option<Callback>,
 }


### PR DESCRIPTION


### Pull Request Overview

This pull request works around a bug found by @lschuermann in #1933. For some reason, since we updated the nightly last, calling subscribe on IPC causes very strange behavior. I tracked it back to the grant, and in particular trying to enter and allocate the grant the first time. Entering a grant for the first time causes the allocator to be called:

https://github.com/tock/tock/blob/957a890e97550db00ca38407d93d2896d2724ec5/kernel/src/grant.rs#L93-L111

and it seems as though if `alloc_unowned()` is called with a type `T` that is larger than 344 bytes, bad things happen. I'm not really sure _what_ happens, though. On hail, everything just stops. On nrf52840dk, the chip reboots.

I tried messing with the size of `IPCData` and found that I got weird behavior once its size hit 345 bytes. I added a `panic!()` between lines 96 and 97 above that printed the size of T to find where the limit is. The panic also shows the bad behavior, as when T is > 344 the panic message stops printing while displaying the last syscall, so I get the following:

```
Initialization complete. Entering main loop.

panicked at 'wat 345', kernel/src/grant.rs:103:17
	Kernel version release-1.5-579-g254b07a4d

---| No debug queue found. You can set it with the DebugQueue component.

---| Fault Status |---
No faults detected.

---| App Status |---
App: org.tockos.examples.rot13   -   [Running]
 Events Queued: 0   Syscall Count: 4   Dropped Callback Count: 0
 Restart Count: 0
 Last Syscall: Some(SUBSCRIBE { driver_number: 65536, subdriver_number: 0, callback_ptr:
```
That is how I could tell where things go from working to not working. With a smaller grant size the entire panic message prints.

I tried today's nightly and got the same behavior.

So..this PR just makes the IPC grant size smaller so that IPC apps work again.

I don't know if the root of this is an issue with llvm or rust or our kernel.


### Testing Strategy

Running the rot13_ apps on hail and nrf52840dk.


### TODO or Help Wanted

Ideally someone would track down why IPCData can't be too large.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
