### PR TITLE
Makefile: Fix the temp directory creation when cloning OT ROM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -510,7 +510,7 @@ define ci_setup_qemu_opentitan
 	# Download OpenTitan image
 	@printf "Downloading OpenTitan boot rom from: 1beb08b474790d4b6c67ae5b3423e2e8dfc9e368\n"
 	@pwd=$$(pwd) && \
-		temp=$$(mktemp -d)\
+		temp=$$(mktemp -d) && \
 		cd $$temp && \
 		curl $$(curl "https://dev.azure.com/lowrisc/opentitan/_apis/build/builds/14991/artifacts?artifactName=opentitan-dist&api-version=5.1" | cut -d \" -f 38) --output opentitan-dist.zip; \
 		unzip opentitan-dist.zip; \


### PR DESCRIPTION
### Pull Request Overview

Fix the temp directory creation when cloning OT ROM

### Testing Strategy

Running the CI

### TODO or Help Wanted

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
