### PR TITLE
add --strip-sections to objcopy flags

### DIFF
--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -141,7 +141,8 @@ OBJCOPY   ?= $(TOOLCHAIN)-objcopy
 OBJDUMP   ?= $(TOOLCHAIN)-objdump
 
 # Set additional flags to produce binary from .elf
-OBJCOPY_FLAGS ?= -S
+# --strip-sections prevents enormous binaries when SRAM is below flash
+OBJCOPY_FLAGS ?= --strip-sections -S
 # This make variable allows board-specific Makefiles to pass down options to
 # the Cargo build command. For example, in boards/<custom_board>/Makefile:
 # `CARGO_FLAGS += --features=foo` would pass feature `foo` to the top level


### PR DESCRIPTION
### Pull Request Overview

This pull request adds `--strip-sections` to OBJCOPY_FLAGS. This fixes an issue where boards with SRAM located below flash would have huge binaries (250 MB+) after we updated to the latest nightly, which included an update to LLVM objcopy. This was first noticed by Emilio Moretti on an out of tree board he maintains, but it also affects OpenTitan.

The help description for the flag follows:
`--strip-sections        Remove all section headers and all sections not in segments`


### Testing Strategy

This pull request was tested by compiling opentitan and observing the binary size has returned to normal, and running the hello_world app in QEMU for opentitan.


### TODO or Help Wanted

N/A

### Documentation Updated

- [x] no updates are required.

### Formatting

- [x] Ran `make prepush`.
