### PR TITLE
[DO NOT MERGE] kernel: Export types for external process management

### DIFF
--- a/kernel/src/callback.rs
+++ b/kernel/src/callback.rs
@@ -79,7 +79,7 @@ impl fmt::Debug for AppId {
 }
 
 impl AppId {
-    crate fn new(kernel: &'static Kernel, identifier: usize, index: usize) -> AppId {
+    pub fn new(kernel: &'static Kernel, identifier: usize, index: usize) -> AppId {
         AppId {
             kernel: kernel,
             identifier: identifier,

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -39,7 +39,7 @@ mod returncode;
 mod sched;
 mod tbfheader;
 
-pub use crate::callback::{AppId, Callback};
+pub use crate::callback::{AppId, Callback, CallbackId};
 pub use crate::driver::Driver;
 pub use crate::grant::Grant;
 pub use crate::mem::{AppPtr, AppSlice, Private, Shared};
@@ -56,8 +56,8 @@ pub use crate::sched::Kernel;
 /// Publicly available process-related objects.
 pub mod procs {
     pub use crate::process::{
-        load_processes, AlwaysRestart, Error, FaultResponse, FunctionCall, Process,
-        ProcessLoadError, ProcessRestartPolicy, ProcessType, ThresholdRestart,
-        ThresholdRestartThenPanic,
+        load_processes, AlwaysRestart, Error, FaultResponse, FunctionCall,
+        FunctionCallSource, Process, ProcessLoadError, ProcessRestartPolicy,
+        ProcessType, State, Task, ThresholdRestart, ThresholdRestartThenPanic,
     };
 }

--- a/kernel/src/mem.rs
+++ b/kernel/src/mem.rs
@@ -69,7 +69,7 @@ pub struct AppSlice<L, T> {
 impl<L, T> AppSlice<L, T> {
     /// Safety: Trusts that `ptr` + `len` is a buffer in `appid` and that no
     /// other references to that memory range exist.
-    crate unsafe fn new(ptr: NonNull<T>, len: usize, appid: AppId) -> AppSlice<L, T> {
+    pub unsafe fn new(ptr: NonNull<T>, len: usize, appid: AppId) -> AppSlice<L, T> {
         AppSlice {
             ptr: AppPtr::new(ptr, appid),
             len: len,

--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -61,13 +61,13 @@ impl Kernel {
     }
 
     /// Something was scheduled for a process, so there is more work to do.
-    crate fn increment_work(&self) {
+    pub fn increment_work(&self) {
         self.work.increment();
     }
 
     /// Something finished for a process, so we decrement how much work there is
     /// to do.
-    crate fn decrement_work(&self) {
+    pub fn decrement_work(&self) {
         self.work.decrement();
     }
 
@@ -253,7 +253,7 @@ impl Kernel {
     ///
     /// In practice, this is called when processes are created, and the process
     /// memory is setup based on the number of current grants.
-    crate fn get_grant_count_and_finalize(&self) -> usize {
+    pub fn get_grant_count_and_finalize(&self) -> usize {
         self.grants_finalized.set(true);
         self.grant_counter.get()
     }


### PR DESCRIPTION
This is a reference commit to outline what functions and types are
needed to externally implement the `ProcessType` trait.

For some of these it may not make sense to just expose publicly, but
should be guarded behind a capability.

The following are justifications for exposing each type and function as
why they are necessary to support the host-side testing work found
here: https://github.com/jon-flatley/tock/tree/tock_testing

Functions changed from `crate` visibility to `pub`:

`callback::AppId::new()` - Used in process creating, needed to satisfy
    `process::ProcessType::appid()`.

`mem::AppSlice::new()` - Needed for the host-side testing implementation
    of the ALLOW syscall, and is returned from
    `Process::ProcessType::allow()`.

`sched::Kernel::increment_work()` - Needed when creating a new process,
    calling `enqueue_task()`, and calling `set_process_function()`.

`sched::Kernel::decrement_work()` - Needed when calling `dequeue_task()`
    and calling `set_yielded_state()`.

`sched::Kernel::get_grant_count_and_finalize()` - Needed to manage the
    creation of grants and for parameter sanity checking in
    `get_grant_ptr()`.

Types changed from `crate` visibility to `pub`:
`callback::CallbackId` - In the signature of
    `process::ProcessType::remove_pending_callbacks()`

`process::FunctionCallSouce` - Needed to manage tasks.

`process::State` - Needed to satisfy numerous signatures and manage
    process state.

`process::Task` - Needed to manage tasks.

### Pull Request Overview

This pull request adds/changes/fixes...


### Testing Strategy

This pull request was tested by...


### TODO or Help Wanted

This pull request still needs...


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
