### PR TITLE
Added support for external clock source and systick user-defined clock value for ARM

### DIFF
--- a/arch/cortex-m/src/systick.rs
+++ b/arch/cortex-m/src/systick.rs
@@ -1,6 +1,6 @@
 //! ARM Cortex-M SysTick peripheral.
 
-use kernel::common::registers::{register_bitfields, ReadOnly, ReadWrite};
+use kernel::common::registers::{register_bitfields, ReadOnly, ReadWrite, FieldValue};
 use kernel::common::StaticRef;
 
 #[repr(C)]
@@ -53,6 +53,7 @@ register_bitfields![u32,
 /// Documented in the Cortex-MX Devices Generic User Guide, Chapter 4.4
 pub struct SysTick {
     hertz: u32,
+    external_clock: bool
 }
 
 const BASE_ADDR: *const SystickRegisters = 0xE000E010 as *const SystickRegisters;
@@ -65,7 +66,7 @@ impl SysTick {
     /// Use this constructor if the core implementation has a pre-calibration
     /// value in hardware.
     pub unsafe fn new() -> SysTick {
-        SysTick { hertz: 0 }
+        SysTick { hertz: 0, external_clock: false }
     }
 
     /// Initialize the `SysTick` with an explicit clock speed
@@ -81,12 +82,20 @@ impl SysTick {
         res
     }
 
+    pub unsafe fn new_with_calibration_and_external_clock(clock_speed: u32) -> SysTick {
+        let mut res = SysTick::new();
+        res.hertz = clock_speed;
+        res.external_clock = true;
+        res
+    }
+
     // Return the tic frequency in hertz. If the calibration value is set in
     // hardware, use `self.hertz`, which is set in the `new_with_calibration`
-    // constructor.
+    // constructor. However, if there is value configured by the user, choose
+    //`self.hertz` instead.
     fn hertz(&self) -> u32 {
         let tenms = SYSTICK_BASE.syst_calib.read(CalibrationValue::TENMS);
-        if tenms == 0 {
+        if tenms == 0 || self.hertz != 0 {
             self.hertz
         } else {
             // The `tenms` register is the reload value for 10ms, so
@@ -143,16 +152,22 @@ impl kernel::SysTick for SysTick {
     }
 
     fn enable(&self, with_interrupt: bool) {
+        let clock_source: FieldValue<u32, self::ControlAndStatus::Register> =  if self.external_clock {
+            ControlAndStatus::CLKSOURCE::CLEAR
+        } else {
+            ControlAndStatus::CLKSOURCE::SET
+        };
+        
         if with_interrupt {
             SYSTICK_BASE.syst_csr.write(
                 ControlAndStatus::ENABLE::SET
                     + ControlAndStatus::TICKINT::SET
-                    + ControlAndStatus::CLKSOURCE::SET,
+                    + clock_source,
             );
         } else {
             SYSTICK_BASE
                 .syst_csr
-                .write(ControlAndStatus::ENABLE::SET + ControlAndStatus::CLKSOURCE::SET);
+                .write(ControlAndStatus::ENABLE::SET + clock_source);
         }
     }
 }

--- a/arch/cortex-m/src/systick.rs
+++ b/arch/cortex-m/src/systick.rs
@@ -101,12 +101,12 @@ impl SysTick {
     }
 
     // Return the tic frequency in hertz. If the value is configured by the
-    // user using the `new_with_calibration` constructor return `self.hertz`. 
+    // user using the `new_with_calibration` constructor return `self.hertz`.
     // Otherwise, compute the frequncy using the calibration value that is set
-    // in hardware. 
+    // in hardware.
     fn hertz(&self) -> u32 {
         if self.hertz != 0 {
-             self.hertz
+            self.hertz
         } else {
             // The `tenms` register is the reload value for 10ms, so
             // Hertz = number of tics in 1 second = tenms * 100

--- a/arch/cortex-m/src/systick.rs
+++ b/arch/cortex-m/src/systick.rs
@@ -100,17 +100,17 @@ impl SysTick {
         res
     }
 
-    // Return the tic frequency in hertz. If the calibration value is set in
-    // hardware, use `self.hertz`, which is set in the `new_with_calibration`
-    // constructor. However, if there is value configured by the user, choose
-    //`self.hertz` instead.
+    // Return the tic frequency in hertz. If the value is configured by the
+    // user using the `new_with_calibration` constructor return `self.hertz`. 
+    // Otherwise, compute the frequncy using the calibration value that is set
+    // in hardware. 
     fn hertz(&self) -> u32 {
-        let tenms = SYSTICK_BASE.syst_calib.read(CalibrationValue::TENMS);
-        if tenms == 0 || self.hertz != 0 {
-            self.hertz
+        if self.hertz != 0 {
+             self.hertz
         } else {
             // The `tenms` register is the reload value for 10ms, so
             // Hertz = number of tics in 1 second = tenms * 100
+            let tenms = SYSTICK_BASE.syst_calib.read(CalibrationValue::TENMS);
             tenms * 100
         }
     }

--- a/arch/cortex-m/src/systick.rs
+++ b/arch/cortex-m/src/systick.rs
@@ -1,6 +1,6 @@
 //! ARM Cortex-M SysTick peripheral.
 
-use kernel::common::registers::{register_bitfields, ReadOnly, ReadWrite, FieldValue};
+use kernel::common::registers::{register_bitfields, FieldValue, ReadOnly, ReadWrite};
 use kernel::common::StaticRef;
 
 #[repr(C)]
@@ -53,7 +53,7 @@ register_bitfields![u32,
 /// Documented in the Cortex-MX Devices Generic User Guide, Chapter 4.4
 pub struct SysTick {
     hertz: u32,
-    external_clock: bool
+    external_clock: bool,
 }
 
 const BASE_ADDR: *const SystickRegisters = 0xE000E010 as *const SystickRegisters;
@@ -66,7 +66,10 @@ impl SysTick {
     /// Use this constructor if the core implementation has a pre-calibration
     /// value in hardware.
     pub unsafe fn new() -> SysTick {
-        SysTick { hertz: 0, external_clock: false }
+        SysTick {
+            hertz: 0,
+            external_clock: false,
+        }
     }
 
     /// Initialize the `SysTick` with an explicit clock speed
@@ -82,6 +85,14 @@ impl SysTick {
         res
     }
 
+    /// Initialize the `SysTick` with an explicit clock speed and external source
+    ///
+    /// Use this constructor if the core implementation does not have a
+    /// pre-calibration value and you need an external clock source for  
+    /// the Systick.
+    ///
+    ///   * `clock_speed` - the frequency of SysTick tics in Hertz. For example,
+    ///   if the SysTick is driven by the CPU clock, it is simply the CPU speed.
     pub unsafe fn new_with_calibration_and_external_clock(clock_speed: u32) -> SysTick {
         let mut res = SysTick::new();
         res.hertz = clock_speed;
@@ -152,17 +163,16 @@ impl kernel::SysTick for SysTick {
     }
 
     fn enable(&self, with_interrupt: bool) {
-        let clock_source: FieldValue<u32, self::ControlAndStatus::Register> =  if self.external_clock {
+        let clock_source: FieldValue<u32, self::ControlAndStatus::Register> = if self.external_clock
+        {
             ControlAndStatus::CLKSOURCE::CLEAR
         } else {
             ControlAndStatus::CLKSOURCE::SET
         };
-        
+
         if with_interrupt {
             SYSTICK_BASE.syst_csr.write(
-                ControlAndStatus::ENABLE::SET
-                    + ControlAndStatus::TICKINT::SET
-                    + clock_source,
+                ControlAndStatus::ENABLE::SET + ControlAndStatus::TICKINT::SET + clock_source,
             );
         } else {
             SYSTICK_BASE


### PR DESCRIPTION
### Pull Request Overview

This pull request adds support for setting external clock source for systick
and extends the support for setting a user-defined clock speed for the 
systick.

This pull request is needed for [#1918](https://github.com/tock/tock/pull/1918) to work because for the i.MX RT 1052 EVKB 
board, even though syst_calib.SKEW = 0 and syst.calib.NOREF = 0, the 
calibration value is not correct and causes thesystick to overflow too fast. 

Also, if I select external clock source in syst_csr, which causes an external 
24 MHz clock source to be prescaled to 100KHz and used as systick, the 
system will work.

### Testing Strategy

This pull request was tested using the i.MX RT 1052 EVKB Board.

### Documentation Updated

- [x] No updates are required.

### Formatting

- [x] Ran `make prepush`.
