### PR TITLE
[RFC] arch/cortex-{m3,m4}: Disable SysTick in trap handler

### DIFF
--- a/arch/cortex-m3/src/lib.rs
+++ b/arch/cortex-m3/src/lib.rs
@@ -40,6 +40,14 @@ pub unsafe extern "C" fn systick_handler() {
 pub unsafe extern "C" fn systick_handler() {
     llvm_asm!(
         "
+    // Clear SYSTICK_CTRL.ENABLE[0]. This will stop the SysTick
+    // counter, so we can accurately know how much time was used by the
+    // user process.
+    ldr r0, =0xE000E010
+    ldr r1, [r0]
+    bic r1, #1
+    str r1, [r0]
+
     /* Mark that the systick handler was called meaning that the process */
     /* stopped executing because it has exceeded its timeslice. */
     ldr r0, =SYSTICK_EXPIRED
@@ -70,6 +78,14 @@ pub unsafe extern "C" fn generic_isr() {
 pub unsafe extern "C" fn generic_isr() {
     llvm_asm!(
         "
+    // Clear SYSTICK_CTRL.ENABLE[0]. This will stop the SysTick
+    // counter, so we can accurately know how much time was used by the
+    // user process.
+    ldr r0, =0xE000E010
+    ldr r1, [r0]
+    bic r1, #1
+    str r1, [r0]
+
     /* Skip saving process state if not coming from user-space */
     cmp lr, #0xfffffffd
     bne _ggeneric_isr_no_stacking
@@ -162,6 +178,14 @@ pub unsafe extern "C" fn svc_handler() {
     movt lr, #0xffff
     bx lr
   to_kernel:
+    // Clear SYSTICK_CTRL.ENABLE[0]. This will stop the SysTick
+    // counter, so we can accurately know how much time was used by the
+    // user process.
+    ldr r0, =0xE000E010
+    ldr r1, [r0]
+    bic r1, #1
+    str r1, [r0]
+
     ldr r0, =SYSCALL_FIRED
     mov r1, #1
     str r1, [r0, #0]

--- a/arch/cortex-m4/src/lib.rs
+++ b/arch/cortex-m4/src/lib.rs
@@ -43,6 +43,14 @@ pub unsafe extern "C" fn systick_handler() {
 pub unsafe extern "C" fn systick_handler() {
     llvm_asm!(
         "
+    // Clear SYSTICK_CTRL.ENABLE[0]. This will stop the SysTick
+    // counter, so we can accurately know how much time was used by the
+    // user process.
+    ldr r0, =0xE000E010
+    ldr r1, [r0]
+    bic r1, #1
+    str r1, [r0]
+
     // Mark that the systick handler was called meaning that the process stopped
     // executing because it has exceeded its timeslice. This is a global
     // variable that the `UserspaceKernelBoundary` code uses to determine why
@@ -86,6 +94,14 @@ pub unsafe extern "C" fn generic_isr() {
 pub unsafe extern "C" fn generic_isr() {
     llvm_asm!(
         "
+    // Clear SYSTICK_CTRL.ENABLE[0]. This will stop the SysTick
+    // counter, so we can accurately know how much time was used by the
+    // user process.
+    ldr r0, =0xE000E010
+    ldr r1, [r0]
+    bic r1, #1
+    str r1, [r0]
+
     // Set thread mode to privileged to ensure we are executing as the kernel.
     // This may be redundant if the interrupt happened while the kernel code
     // was executing.
@@ -215,6 +231,14 @@ pub unsafe extern "C" fn svc_handler() {
     bx lr
 
   to_kernel:
+    // Clear SYSTICK_CTRL.ENABLE[0]. This will stop the SysTick
+    // counter, so we can accurately know how much time was used by the
+    // user process.
+    ldr r0, =0xE000E010
+    ldr r1, [r0]
+    bic r1, #1
+    str r1, [r0]
+
     // An application called a syscall. We mark this in the global variable
     // `SYSCALL_FIRED` which is stored in the syscall file.
     // `UserspaceKernelBoundary` will use this variable to decide why the app


### PR DESCRIPTION
As I mentioned [here](https://github.com/tock/tock/pull/1767#discussion_r442563432) there is a possibility that we might not accurately capture the time spent in the user-space.

Here is a bit of assembly to disable SysTick in `systick_handler`, `generic_isr` and `svc_handler`. This allows us to accurately know how much time was used by the user process.