### PR TITLE
boards: make: quiet sha256sum from cargo

### DIFF
--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -164,7 +164,7 @@ endif
 # present, if not use the custom shipped one
 ifeq (, $(shell sha256sum --version 2>/dev/null))
   # No system sha256sum available
-  SHA256SUM := $(CARGO) run --manifest-path $(TOCK_ROOT_DIRECTORY)tools/sha256sum/Cargo.toml --
+  SHA256SUM := $(CARGO) run --manifest-path $(TOCK_ROOT_DIRECTORY)tools/sha256sum/Cargo.toml -- 2>/dev/null
 else
   # Use system sha256sum
   SHA256SUM := sha256sum
@@ -198,6 +198,7 @@ ifneq ($(V),)
   $(info OBJDUMP              = $(OBJDUMP))
   $(info CARGO                = $(CARGO))
   $(info RUSTUP               = $(RUSTUP))
+  $(info SHA256SUM            = $(SHA256SUM))
   $(info )
   $(info cargo --version      = $(shell $(CARGO) --version))
   $(info rustc --version      = $(shell rustc --version))


### PR DESCRIPTION
### Pull Request Overview

Return the sha256sum output to how it was without all of the cargo extra text.

Without this PR:
```bash
make
   Compiling kernel v0.1.0 (/Users/bradjc/git/tock/kernel)
   Compiling cortexm v0.1.0 (/Users/bradjc/git/tock/arch/cortex-m)
   Compiling capsules v0.1.0 (/Users/bradjc/git/tock/capsules)
   Compiling cortexm4 v0.1.0 (/Users/bradjc/git/tock/arch/cortex-m4)
   Compiling sam4l v0.1.0 (/Users/bradjc/git/tock/chips/sam4l)
   Compiling components v0.1.0 (/Users/bradjc/git/tock/boards/components)
   Compiling hail v0.1.0 (/Users/bradjc/git/tock/boards/hail)
    Finished release [optimized + debuginfo] target(s) in 22.37s
   text	   data	    bss	    dec	    hex	filename
 103936	   3196	  13184	 120316	  1d5fc	/Users/bradjc/git/tock/target/thumbv7em-none-eabi/release/hail
    Finished dev [unoptimized + debuginfo] target(s) in 0.02s
     Running `/Users/bradjc/git/tock/tools/sha256sum/target/debug/sha256sum /Users/bradjc/git/tock/target/thumbv7em-none-eabi/release/hail.bin`
83e84b8c50cbd7e97cef162133ad149c62d05fb7ac294df20914cba28fbaa834	/Users/bradjc/git/tock/target/thumbv7em-none-eabi/release/hail.bin
```

With this PR:

```bash
make
   Compiling hail v0.1.0 (/Users/bradjc/git/tock/boards/hail)
    Finished release [optimized + debuginfo] target(s) in 8.05s
   text	   data	    bss	    dec	    hex	filename
 103936	   3196	  13184	 120316	  1d5fc	/Users/bradjc/git/tock/target/thumbv7em-none-eabi/release/hail
83e84b8c50cbd7e97cef162133ad149c62d05fb7ac294df20914cba28fbaa834	/Users/bradjc/git/tock/target/thumbv7em-none-eabi/release/hail.bin
```

Also add the command to the V=1 printout.

### Testing Strategy

Compiling the hail kernel.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
