### PR TITLE
doc: remove allow(unused_doc_comments)

### DIFF
--- a/chips/apollo3/src/lib.rs
+++ b/chips/apollo3/src/lib.rs
@@ -4,7 +4,6 @@
 #![crate_type = "rlib"]
 #![feature(llvm_asm, const_fn, naked_functions)]
 #![no_std]
-#![allow(unused_doc_comments)]
 
 // Peripherals
 pub mod ble;

--- a/chips/nrf5x/src/gpio.rs
+++ b/chips/nrf5x/src/gpio.rs
@@ -122,7 +122,7 @@ struct GpioRegisters {
     pin_cnf: [ReadWrite<u32, PinConfig::Register>; 32],
 }
 
-/// Gpio
+// Gpio
 register_bitfields! [u32,
     /// Write GPIO port
     Out [
@@ -247,7 +247,7 @@ register_bitfields! [u32,
     ]
 ];
 
-/// GpioTe
+// GpioTe
 register_bitfields! [u32,
     /// Task for writing to pin specified in CONFIG\[n\].PSEL.
     /// Action on pin is configured in CONFIG\[n\].POLARITY

--- a/chips/nrf5x/src/lib.rs
+++ b/chips/nrf5x/src/lib.rs
@@ -1,6 +1,5 @@
 #![feature(const_fn)]
 #![no_std]
-#![allow(unused_doc_comments)]
 
 pub mod aes;
 pub mod constants;

--- a/chips/stm32f303xc/src/gpio.rs
+++ b/chips/stm32f303xc/src/gpio.rs
@@ -516,12 +516,12 @@ impl PinId {
     }
 }
 
-/// GPIO pin mode [^1]
-///
-/// [^1]: Section 7.1.4, page 187 of reference manual
 enum_from_primitive! {
     #[repr(u32)]
     #[derive(PartialEq)]
+    /// GPIO pin mode [^1]
+    ///
+    /// [^1]: Section 7.1.4, page 187 of reference manual
     pub enum Mode {
         Input = 0b00,
         GeneralPurposeOutputMode = 0b01,
@@ -563,11 +563,11 @@ pub enum AlternateFunction {
     AF15 = 0b1111,
 }
 
-/// GPIO pin internal pull-up and pull-down [^1]
-///
-/// [^1]: Section 11.4.4, page 238 of reference manual
 enum_from_primitive! {
     #[repr(u32)]
+    /// GPIO pin internal pull-up and pull-down [^1]
+    ///
+    /// [^1]: Section 11.4.4, page 238 of reference manual
     enum PullUpPullDown {
         NoPullUpPullDown = 0b00,
         PullUp = 0b01,

--- a/chips/stm32f303xc/src/lib.rs
+++ b/chips/stm32f303xc/src/lib.rs
@@ -6,7 +6,6 @@
 #![crate_type = "rlib"]
 #![feature(const_fn)]
 #![no_std]
-#![allow(unused_doc_comments)]
 
 pub mod chip;
 pub mod nvic;

--- a/chips/stm32f303xc/src/syscfg.rs
+++ b/chips/stm32f303xc/src/syscfg.rs
@@ -97,11 +97,11 @@ register_bitfields![u32,
 const SYSCFG_BASE: StaticRef<SyscfgRegisters> =
     unsafe { StaticRef::new(0x40010000 as *const SyscfgRegisters) };
 
-/// SYSCFG EXTI configuration [^1]
-///
-/// [^1]: Section 8.2.2, page 197 of reference manual
 enum_from_primitive! {
     #[repr(u32)]
+    /// SYSCFG EXTI configuration [^1]
+    ///
+    /// [^1]: Section 8.2.2, page 197 of reference manual
     enum ExtiCrId {
         PA = 0b0000,
         PB = 0b0001,

--- a/chips/stm32f4xx/src/gpio.rs
+++ b/chips/stm32f4xx/src/gpio.rs
@@ -531,12 +531,12 @@ impl PinId {
     }
 }
 
-/// GPIO pin mode [^1]
-///
-/// [^1]: Section 7.1.4, page 187 of reference manual
 enum_from_primitive! {
     #[repr(u32)]
     #[derive(PartialEq)]
+    /// GPIO pin mode [^1]
+    ///
+    /// [^1]: Section 7.1.4, page 187 of reference manual
     pub enum Mode {
         Input = 0b00,
         GeneralPurposeOutputMode = 0b01,
@@ -578,11 +578,11 @@ pub enum AlternateFunction {
     AF15 = 0b1111,
 }
 
-/// GPIO pin internal pull-up and pull-down [^1]
-///
-/// [^1]: Section 7.4.4, page 189 of reference manual
 enum_from_primitive! {
     #[repr(u32)]
+    /// GPIO pin internal pull-up and pull-down [^1]
+    ///
+    /// [^1]: Section 7.4.4, page 189 of reference manual
     enum PullUpPullDown {
         NoPullUpPullDown = 0b00,
         PullUp = 0b01,

--- a/chips/stm32f4xx/src/lib.rs
+++ b/chips/stm32f4xx/src/lib.rs
@@ -6,7 +6,6 @@
 #![crate_type = "rlib"]
 #![feature(const_fn)]
 #![no_std]
-#![allow(unused_doc_comments)]
 
 pub mod chip;
 pub mod nvic;

--- a/chips/stm32f4xx/src/syscfg.rs
+++ b/chips/stm32f4xx/src/syscfg.rs
@@ -97,11 +97,11 @@ register_bitfields![u32,
 const SYSCFG_BASE: StaticRef<SyscfgRegisters> =
     unsafe { StaticRef::new(0x40013800 as *const SyscfgRegisters) };
 
-/// SYSCFG EXTI configuration [^1]
-///
-/// [^1]: Section 8.2.2, page 197 of reference manual
 enum_from_primitive! {
     #[repr(u32)]
+    /// SYSCFG EXTI configuration [^1]
+    ///
+    /// [^1]: Section 8.2.2, page 197 of reference manual
     enum ExtiCrId {
         PA = 0b0000,
         PB = 0b0001,


### PR DESCRIPTION
### Pull Request Overview

Remove an unneeded `allow` directive. This was hiding misplaced comments

### Testing Strategy

Compiling.

### TODO or Help Wanted

N/A

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
