### PR TITLE
kernel: expose APIs for external `ProcessType`s

### DIFF
--- a/kernel/src/callback.rs
+++ b/kernel/src/callback.rs
@@ -95,7 +95,7 @@ impl AppId {
     ///
     /// This constructor is public but protected with a capability so that
     /// external implementations of `ProcessType` can use it.
-    pub fn new_public(
+    pub fn new_external(
         kernel: &'static Kernel,
         identifier: usize,
         index: usize,

--- a/kernel/src/callback.rs
+++ b/kernel/src/callback.rs
@@ -3,6 +3,7 @@
 use core::fmt;
 use core::ptr::NonNull;
 
+use crate::capabilities;
 use crate::config;
 use crate::debug;
 use crate::process;
@@ -79,7 +80,27 @@ impl fmt::Debug for AppId {
 }
 
 impl AppId {
+    /// Create a new `AppId` object based on the app identifier and its index
+    /// in the processes array.
     pub(crate) fn new(kernel: &'static Kernel, identifier: usize, index: usize) -> AppId {
+        AppId {
+            kernel: kernel,
+            identifier: identifier,
+            index: index,
+        }
+    }
+
+    /// Create a new `AppId` object based on the app identifier and its index
+    /// in the processes array.
+    ///
+    /// This constructor is public but protected with a capability so that
+    /// external implementations of `ProcessType` can use it.
+    pub fn new_public(
+        kernel: &'static Kernel,
+        identifier: usize,
+        index: usize,
+        _capability: &dyn capabilities::ExternalProcessCapability,
+    ) -> AppId {
         AppId {
             kernel: kernel,
             identifier: identifier,

--- a/kernel/src/capabilities.rs
+++ b/kernel/src/capabilities.rs
@@ -45,32 +45,44 @@
 //! Anything that calls `manage_process` must have a reference to some object
 //! that provides the `ProcessManagementCapability` trait, which proves that it
 //! has the correct capability.
+
 /// The `ProcessManagementCapability` allows the holder to control
 /// process execution, such as related to creating, restarting, and
 /// otherwise managing processes.
 pub unsafe trait ProcessManagementCapability {}
 
-/// The `MainLoopCapability` capability allows the holder to start executing
-/// the main scheduler loop in Tock.
+/// The `MainLoopCapability` capability allows the holder to start executing as
+/// well as manage the main scheduler loop in Tock. This is needed in a board's
+/// main.rs file to start the kernel. It also allows an external implementation
+/// of `ProcessType` to update state in the kernel struct used by the main loop.
 pub unsafe trait MainLoopCapability {}
 
 /// The `MemoryAllocationCapability` capability allows the holder to allocate
 /// memory, for example by creating grants.
 pub unsafe trait MemoryAllocationCapability {}
 
-/// The `UdpDriverCapability` capability allows the holder to use
-/// two functions only allowed by the UDP driver.
-/// The first `driver_send_to()` function in udp_send.rs, which does
-/// not require being bound to a single port, since the driver manages port
-/// bindings for apps on its own. The second is the `set_user_ports()` function
-/// in `udp_port_table.rs`, which gives the UDP port table a reference to
-/// the UDP driver so that it can check which ports have been bound by apps.
+/// The `ExternalProcessCapability` capability allows the holder to use the core
+/// kernel resources needed to successfully implement the `ProcessType` trait
+/// from outside of the core kernel crate. Many of these operations are very
+/// sensitive, that is they cannot just be made public. In particular, certain
+/// objects can be used outside of the core kernel, but the constructors must be
+/// restricted.
+pub unsafe trait ExternalProcessCapability {}
+
+/// The `UdpDriverCapability` capability allows the holder to use two functions
+/// only allowed by the UDP driver. The first is the `driver_send_to()` function
+/// in udp_send.rs, which does not require being bound to a single port, since
+/// the driver manages port bindings for apps on its own. The second is the
+/// `set_user_ports()` function in `udp_port_table.rs`, which gives the UDP port
+/// table a reference to the UDP driver so that it can check which ports have
+/// been bound by apps.
 pub unsafe trait UdpDriverCapability {}
 
-/// The `CreatePortTableCapability` capability allows the holder to instantiate a new
-/// copy of the UdpPortTable struct. There should only ever be one instance of this struct,
-/// so this capability should not be distributed to capsules at all, as the port table should only be
-/// instantiated once by the kernel
+/// The `CreatePortTableCapability` capability allows the holder to instantiate
+/// a new copy of the UdpPortTable struct. There should only ever be one
+/// instance of this struct, so this capability should not be distributed to
+/// capsules at all, as the port table should only be instantiated once by the
+/// kernel
 pub unsafe trait CreatePortTableCapability {}
 
 /// The `NetworkCapabilityCreationCapability` allows the holder to instantiate

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -81,7 +81,7 @@
 //!
 //!    One note is that there are currently very few extensions to the core
 //!    kernel that live outside of the kernel crate. That means we have not
-//!    necessarily crated `_extern` functions for all the interfaces needed for
+//!    necessarily created `_extern` functions for all the interfaces needed for
 //!    this use case. It is likely we will have to create new interfaces as new
 //!    use cases are discovered.
 

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -5,6 +5,85 @@
 //! Interface Layer (HIL) definitions.
 //!
 //! Most `unsafe` code is in this kernel crate.
+//!
+//!
+//! ## Core Kernel Visibility
+//!
+//! As the root crate in the Tock operating system, this crate serves multiple
+//! purposes:
+//!
+//! 1. It includes the logic for the core kernel, including process management,
+//!    grants, scheduling, etc.
+//!
+//! 2. It includes important interfaces for hardware and other device
+//!    abstractions. These are generally in the HIL and platform folders.
+//!
+//! 3. It includes utility functions used elsewhere in the kernel, generally by
+//!    multiple different crates such that it makes sense to have shared
+//!    implementations in the core kernel crate.
+//!
+//! Because of these different features of the core kernel, managing visibility
+//! of the various objects and functions is a bit tricky. In general, the kernel
+//! crate only exposes what it absolutely needs to. However, there are three
+//! cases where resources in this crate _must_ be exposed.
+//!
+//! 1. The shared utility functions and structs must be exposed. These are
+//!    marked `pub` and are used by many other kernel crates.
+//!
+//!    Some utility objects and abstractions, however, expose memory unsafe
+//!    behavior. These are marked as `unsafe`, and require an `unsafe` block to
+//!    use them. One example of this is `StaticRef` which is used for accessing
+//!    memory-mapped I/O registers. Since accessing the addresses through just a
+//!    memory address is potentially very unsafe, instantiating a `StaticRef`
+//!    requires an `unsafe` block.
+//!
+//! 2. The core kernel types generally have to be exposed as other layers of the
+//!    OS need to use them. However, generally only a very small interface is
+//!    exposed, and using that interface cannot compromise the overall system or
+//!    the core kernel. These functions are also marked `pub`. For example, the
+//!    `AppSlice` abstraction must be exposed to capsules to use shared memory
+//!    between a process and the kernel. However, the constructor is not public,
+//!    and the API exposed to capsules is very limited and confined by the Rust
+//!    type system. The constructor and other sensitive interfaces are
+//!    restricted to use only inside the kernel crate and are marked
+//!    `pub(crate)`.
+//!
+//!    In some cases, more sensitive core kernel interfaces must be exposed. For
+//!    example, the kernel exposes a function for starting the main scheduling
+//!    loop in the kernel. Since board crates must be able to start this loop
+//!    after all initialization is finished, the kernel loop function must be
+//!    exposed and marked `pub`. However, this interface is not generally safe
+//!    to use, since starting the loop a second time would compromise the
+//!    stability of the overall system. It's also not necessarily memory unsafe
+//!    to call the start loop function again, so we do not mark it as `unsafe`.
+//!    Instead, we require that the caller hold a `Capability` to call the
+//!    public but sensitive functions. More information is in `capabilities.rs`.
+//!    This allows the kernel crate to still expose functions as public while
+//!    restricting their use. Another example of this is the `Grant`
+//!    constructor, which must be called outside of the core kernel, but should
+//!    not be called except during the board setup.
+//!
+//! 3. Certain internal core kernel interfaces must also be exposed. These are
+//!    needed for extensions of the core kernel that happen to be implemented in
+//!    crates outside of the kernel crate. For example, additional
+//!    implementations of `ProcessType` may live outside of the kernel crate. To
+//!    successfully implement a new `ProcessType` requires access to certain
+//!    in-core-kernel APIs, and these must be marked `pub` so that outside
+//!    crates can access them.
+//!
+//!    These interfaces are highly sensitive, so again we require the caller
+//!    hold a Capability to call them. This helps restrict their use and makes
+//!    it very clear that calling them requires special permissions.
+//!    Additionally, to differentiate these interfaces, which are for external
+//!    extensions of core kernel functionality, from the other public but
+//!    sensitive interfaces (item 2 above), we append the name `_external` to
+//!    the function name.
+//!
+//!    One note is that there are currently very few extensions to the core
+//!    kernel that live outside of the kernel crate. That means we have not
+//!    necessarily crated `_extern` functions for all the interfaces needed for
+//!    this use case. It is likely we will have to create new interfaces as new
+//!    use cases are discovered.
 
 #![feature(core_intrinsics, const_fn, associated_type_defaults, try_trait)]
 #![warn(unreachable_pub)]

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -48,8 +48,8 @@ pub use crate::sched::Kernel;
 /// Publicly available process-related objects.
 pub mod procs {
     pub use crate::process::{
-        load_processes, AlwaysRestart, Error, FaultResponse, FunctionCall, Process,
-        ProcessLoadError, ProcessRestartPolicy, ProcessType, ThresholdRestart,
-        ThresholdRestartThenPanic,
+        load_processes, AlwaysRestart, Error, FaultResponse, FunctionCall, FunctionCallSource,
+        Process, ProcessLoadError, ProcessRestartPolicy, ProcessType, State, Task,
+        ThresholdRestart, ThresholdRestartThenPanic,
     };
 }

--- a/kernel/src/mem.rs
+++ b/kernel/src/mem.rs
@@ -66,7 +66,7 @@ impl<L, T> AppSlice<L, T> {
     ///
     /// This constructor is public but protected with a capability to enable
     /// external implementations of `ProcessType` to create `AppSlice`s.
-    pub unsafe fn new_public(
+    pub unsafe fn new_external(
         ptr: NonNull<T>,
         len: usize,
         appid: AppId,

--- a/kernel/src/mem.rs
+++ b/kernel/src/mem.rs
@@ -5,6 +5,7 @@ use core::ptr::NonNull;
 use core::slice;
 
 use crate::callback::AppId;
+use crate::capabilities;
 
 /// Type for specifying an AppSlice is hidden from the kernel.
 #[derive(Debug)]
@@ -52,9 +53,25 @@ pub struct AppSlice<L, T> {
 }
 
 impl<L, T> AppSlice<L, T> {
-    /// Safety: Trusts that `ptr` + `len` is a buffer in `appid` and that no
-    /// other references to that memory range exist.
+    /// Safety: Trusts that `ptr` + `len` is a buffer in the memory region owned
+    /// by `appid` and that no other references to that memory range exist.
     pub(crate) unsafe fn new(ptr: NonNull<T>, len: usize, appid: AppId) -> AppSlice<L, T> {
+        AppSlice {
+            ptr: AppPtr::new(ptr, appid),
+            len: len,
+        }
+    }
+    /// Safety: Trusts that `ptr` + `len` is a buffer in the memory region owned
+    /// by `appid` and that no other references to that memory range exist.
+    ///
+    /// This constructor is public but protected with a capability to enable
+    /// external implementations of `ProcessType` to create `AppSlice`s.
+    pub unsafe fn new_public(
+        ptr: NonNull<T>,
+        len: usize,
+        appid: AppId,
+        _capability: &dyn capabilities::ExternalProcessCapability,
+    ) -> AppSlice<L, T> {
         AppSlice {
             ptr: AppPtr::new(ptr, appid),
             len: len,

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -576,6 +576,9 @@ impl From<Error> for ReturnCode {
 }
 
 /// Various states a process can be in.
+///
+/// This is made public in case external implementations of `ProcessType` want
+/// to re-use these process states in the external implementation.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum State {
     /// Process expects to be running code. The process may not be currently
@@ -641,19 +644,28 @@ pub enum FaultResponse {
     Stop,
 }
 
+/// Tasks that can be enqueued for a process.
+///
+/// This is public for external implementations of `ProcessType`.
 #[derive(Copy, Clone)]
 pub enum Task {
+    /// Function pointer in the process to execute. Generally this is a callback
+    /// from a capsule.
     FunctionCall(FunctionCall),
+    /// An IPC operation that needs additional setup to configure memory access.
     IPC((AppId, ipc::IPCCallbackType)),
 }
 
-/// Enumeration to identify whether a function call comes directly from the
-/// kernel or from a callback subscribed through a driver.
+/// Enumeration to identify whether a function call for a process comes directly
+/// from the kernel or from a callback subscribed through a `Driver`
+/// implementation.
 ///
-/// An example of kernel function is the application entry point.
+/// An example of a kernel function is the application entry point.
 #[derive(Copy, Clone, Debug)]
 pub enum FunctionCallSource {
-    Kernel, // For functions coming directly from the kernel, such as `init_fn`.
+    /// For functions coming directly from the kernel, such as `init_fn`.
+    Kernel,
+    /// For functions coming from capsules or any implementation of `Driver`.
     Driver(CallbackId),
 }
 

--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -73,11 +73,13 @@ impl Kernel {
     /// is that external implementations of `ProcessType` need to be able to
     /// indicate there is more process work to do.
     pub fn increment_work_public(&self, _capability: &dyn capabilities::MainLoopCapability) {
-        self.work.increment();
+        self.increment_work();
     }
 
     /// Something finished for a process, so we decrement how much work there is
     /// to do.
+    ///
+    /// This is only exposed in the core kernel crate.
     pub(crate) fn decrement_work(&self) {
         self.work.decrement();
     }
@@ -89,7 +91,7 @@ impl Kernel {
     /// is that external implementations of `ProcessType` need to be able to
     /// indicate that some process work has finished.
     pub fn decrement_work_public(&self, _capability: &dyn capabilities::MainLoopCapability) {
-        self.work.decrement();
+        self.decrement_work();
     }
 
     /// Helper function for determining if we should service processes or go to
@@ -294,8 +296,7 @@ impl Kernel {
         &self,
         _capability: &dyn capabilities::ExternalProcessCapability,
     ) -> usize {
-        self.grants_finalized.set(true);
-        self.grant_counter.get()
+        self.get_grant_count_and_finalize()
     }
 
     /// Create a new unique identifier for a process and return the identifier.

--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -72,7 +72,10 @@ impl Kernel {
     /// This is exposed publicly, but restricted with a capability. The intent
     /// is that external implementations of `ProcessType` need to be able to
     /// indicate there is more process work to do.
-    pub fn increment_work_external(&self, _capability: &dyn capabilities::MainLoopCapability) {
+    pub fn increment_work_external(
+        &self,
+        _capability: &dyn capabilities::ExternalProcessCapability,
+    ) {
         self.increment_work();
     }
 
@@ -90,7 +93,10 @@ impl Kernel {
     /// This is exposed publicly, but restricted with a capability. The intent
     /// is that external implementations of `ProcessType` need to be able to
     /// indicate that some process work has finished.
-    pub fn decrement_work_external(&self, _capability: &dyn capabilities::MainLoopCapability) {
+    pub fn decrement_work_external(
+        &self,
+        _capability: &dyn capabilities::ExternalProcessCapability,
+    ) {
         self.decrement_work();
     }
 

--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -72,7 +72,7 @@ impl Kernel {
     /// This is exposed publicly, but restricted with a capability. The intent
     /// is that external implementations of `ProcessType` need to be able to
     /// indicate there is more process work to do.
-    pub fn increment_work_public(&self, _capability: &dyn capabilities::MainLoopCapability) {
+    pub fn increment_work_external(&self, _capability: &dyn capabilities::MainLoopCapability) {
         self.increment_work();
     }
 
@@ -90,7 +90,7 @@ impl Kernel {
     /// This is exposed publicly, but restricted with a capability. The intent
     /// is that external implementations of `ProcessType` need to be able to
     /// indicate that some process work has finished.
-    pub fn decrement_work_public(&self, _capability: &dyn capabilities::MainLoopCapability) {
+    pub fn decrement_work_external(&self, _capability: &dyn capabilities::MainLoopCapability) {
         self.decrement_work();
     }
 
@@ -292,7 +292,7 @@ impl Kernel {
     /// This is exposed publicly, but restricted with a capability. The intent
     /// is that external implementations of `ProcessType` need to be able to
     /// retrieve the final number of grants.
-    pub fn get_grant_count_and_finalize_public(
+    pub fn get_grant_count_and_finalize_external(
         &self,
         _capability: &dyn capabilities::ExternalProcessCapability,
     ) -> usize {

--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -61,13 +61,34 @@ impl Kernel {
     }
 
     /// Something was scheduled for a process, so there is more work to do.
+    ///
+    /// This is only exposed in the core kernel crate.
     pub(crate) fn increment_work(&self) {
+        self.work.increment();
+    }
+
+    /// Something was scheduled for a process, so there is more work to do.
+    ///
+    /// This is exposed publicly, but restricted with a capability. The intent
+    /// is that external implementations of `ProcessType` need to be able to
+    /// indicate there is more process work to do.
+    pub fn increment_work_public(&self, _capability: &dyn capabilities::MainLoopCapability) {
         self.work.increment();
     }
 
     /// Something finished for a process, so we decrement how much work there is
     /// to do.
     pub(crate) fn decrement_work(&self) {
+        self.work.decrement();
+    }
+
+    /// Something finished for a process, so we decrement how much work there is
+    /// to do.
+    ///
+    /// This is exposed publicly, but restricted with a capability. The intent
+    /// is that external implementations of `ProcessType` need to be able to
+    /// indicate that some process work has finished.
+    pub fn decrement_work_public(&self, _capability: &dyn capabilities::MainLoopCapability) {
         self.work.decrement();
     }
 
@@ -254,6 +275,25 @@ impl Kernel {
     /// In practice, this is called when processes are created, and the process
     /// memory is setup based on the number of current grants.
     pub(crate) fn get_grant_count_and_finalize(&self) -> usize {
+        self.grants_finalized.set(true);
+        self.grant_counter.get()
+    }
+
+    /// Returns the number of grants that have been setup in the system and
+    /// marks the grants as "finalized". This means that no more grants can
+    /// be created because data structures have been setup based on the number
+    /// of grants when this function is called.
+    ///
+    /// In practice, this is called when processes are created, and the process
+    /// memory is setup based on the number of current grants.
+    ///
+    /// This is exposed publicly, but restricted with a capability. The intent
+    /// is that external implementations of `ProcessType` need to be able to
+    /// retrieve the final number of grants.
+    pub fn get_grant_count_and_finalize_public(
+        &self,
+        _capability: &dyn capabilities::ExternalProcessCapability,
+    ) -> usize {
         self.grants_finalized.set(true);
         self.grant_counter.get()
     }


### PR DESCRIPTION
### Pull Request Overview

This pull request adds new functions with `pub` visibility modifiers to enable an implementation of `ProcessType` to exist outside of the kernel/ crate. These new functions are protected with capabilities since these are very sensitive operations that shouldn't be generally called.

I named the new functions `_public`. I don't think we have an existing convention for this, so I made one up.

I added a new capability `ExternalProcessCapability` to capture the use case for making these functions and constructors public. Increment/decrement work I re-used the `MainLoopCapability` since I think that accurately captures the permissions needed to increment or decrement work. For the others I wasn't sure what to do, so I added a new capability.

Replaces #1984.

### Testing Strategy

travis


### TODO or Help Wanted

@jon-flatley will this work?


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
