### PR TITLE
boards: Make .app section default, do not include it in kernel binary

### DIFF
--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -140,9 +140,13 @@ SIZE      ?= $(TOOLCHAIN)-size
 OBJCOPY   ?= $(TOOLCHAIN)-objcopy
 OBJDUMP   ?= $(TOOLCHAIN)-objdump
 
-# Set additional flags to produce binary from .elf
-# --strip-sections prevents enormous binaries when SRAM is below flash
-OBJCOPY_FLAGS ?= --strip-sections -S
+# Set additional flags to produce binary from .elf.
+# * --strip-sections prevents enormous binaries when SRAM is below flash.
+# * --remove-section .apps prevents the .apps section from being included in the
+#   kernel binary file. This section is a placeholder for optionally including
+#   application binaries, and only needs to exist in the .elf. By removing it,
+#   we prevent the kernel binary from overwriting applications.
+OBJCOPY_FLAGS ?= --strip-sections -S --remove-section .apps
 # This make variable allows board-specific Makefiles to pass down options to
 # the Cargo build command. For example, in boards/<custom_board>/Makefile:
 # `CARGO_FLAGS += --features=foo` would pass feature `foo` to the top level

--- a/boards/kernel_layout.ld
+++ b/boards/kernel_layout.ld
@@ -185,9 +185,10 @@ SECTIONS
     PROVIDE_HIDDEN (__exidx_end = .);
 
     /* Region for on-chip kernel non-volatile storage.
-     * Align on 512 bytes since that is the page size.
-     * Volumes within this region are allocated with the
-     * storage_volume! macro in utils.rs. */
+     *
+     * Align on 512 bytes since that is the page size. Volumes within this
+     * region are allocated with the storage_volume! macro in utils.rs.
+     */
     .storage :
     {
       . = ALIGN(512);
@@ -204,25 +205,33 @@ SECTIONS
     _textend = .;   /* alias for _etext expected by some MS toolchains */
 
 
-    /* Customer configuration is most often located
-     * at the end of the rom. It is conditional, and won't
-     * be written if not specified in the board specific linker
-     * file. */
+    /* Customer configuration is most often located at the end of the rom. It is
+     * conditional, and won't be written if not specified in the board specific
+     * linker file.
+     */
     .ccfg : {
         KEEP(*(.ccfg))
     } > ccfg
 
 
-    /* STATIC ELEMENTS FOR TOCK APPLICATIONS */
+    /* Section for application binaries in flash.
+     *
+     * This section is put into the "prog" memory, which is reserved for
+     * applications. This section is not used for the kernel, but including it
+     * in the .elf file allows for concatenating application binaries with the
+     * kernel.
+     */
     .apps :
     {
-        /* _sapps symbol used by tock to look for first application */
+        /* _sapps symbol used by Tock to look for first application. */
         . = ALIGN(4);
         _sapps = .;
 
-        /* Optional .app sections a convenience mechanism to bundle tock
-           kernel and apps into a single image */
-        KEEP (*(.app.*))
+        /* Include a placeholder byte in this section so that the linker
+         * includes a segment for it. Otherwise the section will be empty and
+         * the linker will ignore it when defining the segments.
+         */
+        BYTE(0)
     } > prog
     /* _eapps symbol used by tock to calculate the length of app flash */
     _eapps = _sapps + LENGTH(prog);

--- a/boards/nucleo_f429zi/src/main.rs
+++ b/boards/nucleo_f429zi/src/main.rs
@@ -31,12 +31,6 @@ static mut CHIP: Option<&'static stm32f429zi::chip::Stm32f4xx> = None;
 // How should the kernel respond when a process faults.
 const FAULT_RESPONSE: kernel::procs::FaultResponse = kernel::procs::FaultResponse::Panic;
 
-// Force the emission of the `.apps` segment in the kernel elf image
-// NOTE: This will cause the kernel to overwrite any existing apps when flashed!
-#[used]
-#[link_section = ".app.hack"]
-static APP_HACK: u8 = 0;
-
 /// Dummy buffer that causes the linker to reserve enough space for the stack.
 #[no_mangle]
 #[link_section = ".stack_buffer"]

--- a/boards/nucleo_f446re/src/main.rs
+++ b/boards/nucleo_f446re/src/main.rs
@@ -36,12 +36,6 @@ static mut CHIP: Option<&'static stm32f446re::chip::Stm32f4xx> = None;
 // How should the kernel respond when a process faults.
 const FAULT_RESPONSE: kernel::procs::FaultResponse = kernel::procs::FaultResponse::Panic;
 
-// Force the emission of the `.apps` segment in the kernel elf image
-// NOTE: This will cause the kernel to overwrite any existing apps when flashed!
-#[used]
-#[link_section = ".app.hack"]
-static APP_HACK: u8 = 0;
-
 /// Dummy buffer that causes the linker to reserve enough space for the stack.
 #[no_mangle]
 #[link_section = ".stack_buffer"]

--- a/boards/opentitan/src/main.rs
+++ b/boards/opentitan/src/main.rs
@@ -34,12 +34,6 @@ static mut CHIP: Option<&'static ibex::chip::Ibex> = None;
 // How should the kernel respond when a process faults.
 const FAULT_RESPONSE: kernel::procs::FaultResponse = kernel::procs::FaultResponse::Panic;
 
-// Force the emission of the `.apps` segment in the kernel elf image
-// NOTE: This will cause the kernel to overwrite any existing apps when flashed!
-#[used]
-#[link_section = ".app.hack"]
-static APP_HACK: u8 = 0;
-
 /// Dummy buffer that causes the linker to reserve enough space for the stack.
 #[no_mangle]
 #[link_section = ".stack_buffer"]

--- a/boards/stm32f3discovery/src/main.rs
+++ b/boards/stm32f3discovery/src/main.rs
@@ -39,12 +39,6 @@ static mut CHIP: Option<&'static stm32f303xc::chip::Stm32f3xx> = None;
 // How should the kernel respond when a process faults.
 const FAULT_RESPONSE: kernel::procs::FaultResponse = kernel::procs::FaultResponse::Panic;
 
-// Force the emission of the `.apps` segment in the kernel elf image
-// NOTE: This will cause the kernel to overwrite any existing apps when flashed!
-#[used]
-#[link_section = ".app.hack"]
-static APP_HACK: u8 = 0;
-
 /// Dummy buffer that causes the linker to reserve enough space for the stack.
 #[no_mangle]
 #[link_section = ".stack_buffer"]

--- a/boards/stm32f412gdiscovery/src/main.rs
+++ b/boards/stm32f412gdiscovery/src/main.rs
@@ -31,12 +31,6 @@ static mut CHIP: Option<&'static stm32f412g::chip::Stm32f4xx> = None;
 // How should the kernel respond when a process faults.
 const FAULT_RESPONSE: kernel::procs::FaultResponse = kernel::procs::FaultResponse::Panic;
 
-// Force the emission of the `.apps` segment in the kernel elf image
-// NOTE: This will cause the kernel to overwrite any existing apps when flashed!
-#[used]
-#[link_section = ".app.hack"]
-static APP_HACK: u8 = 0;
-
 /// Dummy buffer that causes the linker to reserve enough space for the stack.
 #[no_mangle]
 #[link_section = ".stack_buffer"]

--- a/doc/Compilation.md
+++ b/doc/Compilation.md
@@ -13,6 +13,7 @@ of how platforms program each onto an actual board.
 - [Compiling the kernel](#compiling-the-kernel)
   * [Life of a Tock compilation](#life-of-a-tock-compilation)
   * [LLVM Binutils](#llvm-binutils)
+  * [Special `.apps` section](#special-apps-section)
 - [Compiling a process](#compiling-a-process)
   * [Position Independent Code](#position-independent-code)
   * [Tock Binary Format](#tock-binary-format)
@@ -102,6 +103,28 @@ has three main ramifications:
 3. Tock no longer relies on an external dependency to provide these tools. That
    should ensure that all Tock developers are using the same version of the
    tools.
+
+### Special `.apps` section
+
+Tock kernels include a `.apps` section in the kernel .elf file that is at the
+same physical address where applications will be loaded. When compiling the
+kernel, this is just a placeholder and is not populated with any meaningful
+data. It exists to make it easy to update the kernel .elf file with an
+application binary to make a monolithic .elf file so that the kernel and apps
+can be flashed together.
+
+When the Tock build system creates the kernel binary, it explicitly removes this
+section so that the placeholder is not included in the kernel binary.
+
+To use the special `.apps` section, `objcopy` can replace the placeholder with an actual app binary. The general command looks like:
+
+```bash
+$ arm-none-eabi-objcopy --update-section .apps=libtock-c/examples/c_hello/build/cortex-m4/cortex-m4.tbf target/thumbv7em-none-eabi/release/stm32f412gdiscovery.elf target/thumbv7em-none-eabi/release/stm32f4discovery-app.elf
+```
+
+This replaces the placeholder section `.apps` with the "c_hello" application TBF
+in the stm32f412gdiscovery.elf kernel ELF, and creates a new .elf called
+`stm32f4discovery-app.elf`.
 
 ## Compiling a process
 


### PR DESCRIPTION
### Pull Request Overview

Having a .apps section makes it straightforward to concatenate application binaries into the kernel elf to create a monolithic 
image that flashes the kernel and applications together. However, this has had the side effect that flashing only the kernel erases applications. And, it is only supported on some boards. This PR makes creating a .apps section default, and also removes it from the kernel binary so that the kernel alone will not erase apps.

#### More detail:

The .apps section in flash is a placeholder section that satisfies two properties:

1. Its physical address is the same address as the start of apps in flash.
2. The linker places it into a segment, so that when the .elf file is used, the .apps section will be loaded at the correct address.

In the kernel build system, we have no application binaries, so the
.apps section only includes a placeholder byte so that the linker keeps
it around and creates a segment for it. Later, the .elf file can be
updated with an actual application binary in the .apps section, and the
application binary will be loaded with the kernel binary.

Due to the requirements above, that single placeholder byte means the
kernel .elf file creates a binary with one byte at the address where
applications start. This, when flashed, overwrites the first application
header, effectively erasing all apps.

However, when we are creating just the kernel binary file in the build
system, we do not need to include the .apps section (it is just a
placeholder after all). So, we explicitly ignore it in the .elf file
when creating the kernel binary.

### Testing Strategy

Verifying the hail kernel does not overwrite apps.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
