### PR TITLE
Remove OptionalCell's dependency on feature(const_fn) using `impl<T: Copy>`

### DIFF
--- a/libraries/tock-cells/src/optional_cell.rs
+++ b/libraries/tock-cells/src/optional_cell.rs
@@ -1,16 +1,15 @@
 //! `OptionalCell` convenience type
 
 use core::cell::Cell;
-use core::marker::Copy;
 
 /// `OptionalCell` is a `Cell` that wraps an `Option`. This is helper type
 /// that makes keeping types that can be `None` a little cleaner.
 #[derive(Default)]
-pub struct OptionalCell<T: Copy> {
+pub struct OptionalCell<T> {
     value: Cell<Option<T>>,
 }
 
-impl<T: Copy> OptionalCell<T> {
+impl<T> OptionalCell<T> {
     /// Create a new OptionalCell.
     pub const fn new(val: T) -> OptionalCell<T> {
         OptionalCell {
@@ -33,10 +32,7 @@ impl<T: Copy> OptionalCell<T> {
     /// Insert the value of the supplied `Option`, or `None` if the supplied
     /// `Option` is `None`.
     pub fn insert(&self, opt: Option<T>) {
-        match opt {
-            Some(v) => self.set(v),
-            None => self.clear(),
-        }
+        self.value.set(opt);
     }
 
     /// Replace the contents with the supplied value.
@@ -55,12 +51,18 @@ impl<T: Copy> OptionalCell<T> {
 
     /// Check if the cell contains something.
     pub fn is_some(&self) -> bool {
-        self.value.get().is_some()
+        let value = self.value.take();
+        let out = value.is_some();
+        self.value.set(value);
+        out
     }
 
     /// Check if the cell is None.
     pub fn is_none(&self) -> bool {
-        self.value.get().is_none()
+        let value = self.value.take();
+        let out = value.is_none();
+        self.value.set(value);
+        out
     }
 
     /// Returns true if the option is a Some value containing the given value.
@@ -68,9 +70,84 @@ impl<T: Copy> OptionalCell<T> {
     where
         T: PartialEq,
     {
-        self.value.get().contains(x)
+        let value = self.value.take();
+        let out = value.contains(x);
+        self.value.set(value);
+        out
     }
 
+    /// Transforms the contained `Option<T>` into a `Result<T, E>`, mapping
+    /// `Some(v)` to `Ok(v)` and `None` to `Err(err)`.
+    ///
+    /// Arguments passed to `ok_or` are eagerly evaluated; if you are passing
+    /// the result of a function call, it is recommended to use `ok_or_else`,
+    /// which is lazily evaluated.
+    pub fn ok_or<E>(self, err: E) -> Result<T, E> {
+        self.value.into_inner().ok_or(err)
+    }
+
+    /// Transforms the contained `Option<T>` into a `Result<T, E>`, mapping
+    /// `Some(v)` to `Ok(v)` and `None` to `Err(err)`.
+    pub fn ok_or_else<E, F>(self, err: F) -> Result<T, E>
+    where
+        F: FnOnce() -> E,
+    {
+        self.value.into_inner().ok_or_else(err)
+    }
+
+    /// Returns `None` if the option is `None`, otherwise returns `optb`.
+    pub fn and<U>(self, optb: Option<U>) -> Option<U> {
+        self.value.into_inner().and(optb)
+    }
+
+    /// Returns `None` if the option is `None`, otherwise calls `predicate` with
+    /// the wrapped value and returns:
+    ///
+    /// - `Some(t)` if `predicate` returns `true` (where `t` is the wrapped value), and
+    /// - `None` if `predicate` returns `false`.
+    pub fn filter<P>(self, predicate: P) -> Option<T>
+    where
+        P: FnOnce(&T) -> bool,
+    {
+        self.value.into_inner().filter(predicate)
+    }
+
+    /// Returns the option if it contains a value, otherwise returns `optb`.
+    ///
+    /// Arguments passed to or are eagerly evaluated; if you are passing the
+    /// result of a function call, it is recommended to use `or_else`, which
+    /// is lazily evaluated.
+    pub fn or(self, optb: Option<T>) -> Option<T> {
+        self.value.into_inner().or(optb)
+    }
+
+    /// Returns the option if it contains a value, otherwise calls `f` and
+    /// returns the result.
+    pub fn or_else<F>(self, f: F) -> Option<T>
+    where
+        F: FnOnce() -> Option<T>,
+    {
+        self.value.into_inner().or_else(f)
+    }
+
+    /// Return the contained value and replace it with None.
+    pub fn take(&self) -> Option<T> {
+        self.value.take()
+    }
+
+    /// Returns the contained value or a default
+    ///
+    /// Consumes the `self` argument then, if `Some`, returns the contained
+    /// value, otherwise if `None`, returns the default value for that type.
+    pub fn unwrap_or_default(self) -> T
+    where
+        T: Default,
+    {
+        self.value.into_inner().unwrap_or_default()
+    }
+}
+
+impl<T: Copy> OptionalCell<T> {
     /// Returns the contained value or panics if contents is `None`.
     pub fn expect(&self, msg: &str) -> T {
         self.value.get().expect(msg)
@@ -124,79 +201,9 @@ impl<T: Copy> OptionalCell<T> {
             .map_or_else(default, |mut val| closure(&mut val))
     }
 
-    /// Transforms the contained `Option<T>` into a `Result<T, E>`, mapping
-    /// `Some(v)` to `Ok(v)` and `None` to `Err(err)`.
-    ///
-    /// Arguments passed to `ok_or` are eagerly evaluated; if you are passing
-    /// the result of a function call, it is recommended to use `ok_or_else`,
-    /// which is lazily evaluated.
-    pub fn ok_or<E>(self, err: E) -> Result<T, E> {
-        self.value.get().ok_or(err)
-    }
-
-    /// Transforms the contained `Option<T>` into a `Result<T, E>`, mapping
-    /// `Some(v)` to `Ok(v)` and `None` to `Err(err)`.
-    pub fn ok_or_else<E, F>(self, err: F) -> Result<T, E>
-    where
-        F: FnOnce() -> E,
-    {
-        self.value.get().ok_or_else(err)
-    }
-
-    /// Returns `None` if the option is `None`, otherwise returns `optb`.
-    pub fn and<U>(self, optb: Option<U>) -> Option<U> {
-        self.value.get().and(optb)
-    }
-
     /// If the cell is empty, return `None`. Otherwise, call a closure
     /// with the value of the cell and return the result.
     pub fn and_then<U, F: FnOnce(T) -> Option<U>>(&self, f: F) -> Option<U> {
         self.value.get().and_then(f)
-    }
-
-    /// Returns `None` if the option is `None`, otherwise calls `predicate` with
-    /// the wrapped value and returns:
-    ///
-    /// - `Some(t)` if `predicate` returns `true` (where `t` is the wrapped value), and
-    /// - `None` if `predicate` returns `false`.
-    pub fn filter<P>(self, predicate: P) -> Option<T>
-    where
-        P: FnOnce(&T) -> bool,
-    {
-        self.value.get().filter(predicate)
-    }
-
-    /// Returns the option if it contains a value, otherwise returns `optb`.
-    ///
-    /// Arguments passed to or are eagerly evaluated; if you are passing the
-    /// result of a function call, it is recommended to use `or_else`, which
-    /// is lazily evaluated.
-    pub fn or(self, optb: Option<T>) -> Option<T> {
-        self.value.get().or(optb)
-    }
-
-    /// Returns the option if it contains a value, otherwise calls `f` and
-    /// returns the result.
-    pub fn or_else<F>(self, f: F) -> Option<T>
-    where
-        F: FnOnce() -> Option<T>,
-    {
-        self.value.get().or_else(f)
-    }
-
-    /// Return the contained value and replace it with None.
-    pub fn take(&self) -> Option<T> {
-        self.value.take()
-    }
-
-    /// Returns the contained value or a default
-    ///
-    /// Consumes the `self` argument then, if `Some`, returns the contained
-    /// value, otherwise if `None`, returns the default value for that type.
-    pub fn unwrap_or_default(self) -> T
-    where
-        T: Default,
-    {
-        self.value.get().unwrap_or_default()
     }
 }


### PR DESCRIPTION
### Pull Request Overview

This pull requests makes `OptionalCell` work with non-`Copy` types. This allows it to work without `#![feature(const_fn)]`. I rewrote a few methods that used `Cell::get` (which requires `T` to be `Copy`) that didn't need `T: Copy`.

`tock-cells` still needs `#![feature(const_fn)]` because `TakeCell` contains a mutable reference type, which cannot be initialized in `const` context without `const_fn`. Removing that dependency is possible but would require more `unsafe`, as we would need to replace `TockCell`'s reference with a raw pointer.

I have made the same semantic change using different syntax in #2009 ; I'd like input on which approach seems better.

This change helps migrate towards stable Rust (#1654).

### Testing Strategy

I commented out `#![feature(const_fn)]` and `pub mod take_cell;` in `libraries/tock-cells/src/lib.rs` then ran `cargo check` in `tock-cells` to verify I removed the dependency on `const_fn`. I reverted that change before committing.

I also ran `make allcheck` and `make fmt` in the root of this repository.

### TODO or Help Wanted

I also sent #2009, which makes the same improvement in an equivalent but syntactically-different manner (using an `impl<T: Copy>` block rather than `where` clauses). I'd like feedback on which approach you find more maintainable.


### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
