### PR TITLE
Makefile: Split QEMU build to a seperate directory 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,5 +53,8 @@ doc/rustdoc
 # are manually included for releases.
 Cargo.lock
 
+# The QEMU build directory
+tools/qemu-build
+
 # Python scripts
 __pycache__

--- a/Makefile
+++ b/Makefile
@@ -496,9 +496,9 @@ define ci_setup_qemu_riscv
 	@# Use the latest QEMU as it has OpenTitan support
 	@printf "Building QEMU, this could take a few minutes\n\n"
 	@git submodule sync; git submodule update --init
-	@cd tools/qemu; ./configure --target-list=riscv32-softmmu;
+	@mkdir -p tools/qemu-build && cd tools/qemu-build; ../qemu/configure --target-list=riscv32-softmmu;
 	@# Build qemu
-	@$(MAKE) -C "tools/qemu" || (echo "You might need to install some missing packages" || exit 127)
+	@$(MAKE) -C "tools/qemu-build" || (echo "You might need to install some missing packages" || exit 127)
 endef
 
 define ci_setup_qemu_opentitan
@@ -519,7 +519,7 @@ ci-setup-qemu:
 	$(call ci_setup_helper,\
 		status=$$(git submodule status -- tools/qemu); \
 		[[ "$${status:0:1}" != "" ]] && \
-			cd tools/qemu && make -q riscv32-softmmu && echo yes,\
+			cd tools/qemu-build && make -q riscv32-softmmu && echo yes,\
 		Clone QEMU and run its build scripts,\
 		ci_setup_qemu_riscv,\
 		CI_JOB_QEMU_RISCV)
@@ -535,7 +535,7 @@ ci-setup-qemu:
 define ci_job_qemu
 	$(call banner,CI-Job: QEMU)
 	@cd tools/qemu-runner;\
-		PATH="$(shell pwd)/tools/qemu/riscv32-softmmu/:${PATH}"\
+		PATH="$(shell pwd)/tools/qemu-build/riscv32-softmmu/:${PATH}"\
 		CI=true cargo run
 endef
 


### PR DESCRIPTION
### Pull Request Overview

Split the QEMU build to a seperate directory, this avoids users seeing
the qemu submodule in status.

@bradjc 

### Testing Strategy

Running the CI

### TODO or Help Wanted

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
