### PR TITLE
Makefile: Run OpenTitan userspace tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,5 +53,10 @@ doc/rustdoc
 # are manually included for releases.
 Cargo.lock
 
+# Copied binaries from libtock-rs
+tools/qemu-runner/riscv32imac-unknown-none-elf
+tools/qemu-runner/riscv32imc-unknown-none-elf
+tools/qemu-runner/thumbv7em-none-eabi
+
 # Python scripts
 __pycache__

--- a/tools/qemu-runner/src/main.rs
+++ b/tools/qemu-runner/src/main.rs
@@ -72,6 +72,59 @@ fn opentitan() -> Result<(), Error> {
     Ok(())
 }
 
+fn opentitan_userspace() -> Result<(), Error> {
+    // First, build the board if needed
+    // n.b. rexpect's `exp_eof` does not actually block main thread, so use
+    // the standard Rust process library mechanism instead.
+    let mut build = Command::new("make")
+        .arg("-C")
+        .arg("../../boards/opentitan")
+        .spawn()
+        .expect("failed to spawn build");
+    assert!(build.wait().unwrap().success());
+
+    // Get canonicalized path to opentitan rom
+    let mut rom_path = std::env::current_exe().unwrap();
+    rom_path.pop(); // strip exe file
+    rom_path.pop(); // strip /debug
+    rom_path.pop(); // strip /target
+    rom_path.push("opentitan-boot-rom.elf");
+
+    // Get canonicalized path to opentitan test app
+    let mut app_path = std::env::current_exe().unwrap();
+    app_path.pop(); // strip exe file
+    app_path.pop(); // strip /debug
+    app_path.pop(); // strip /target
+    app_path.push("riscv32imc-unknown-none-elf/tab/opentitan/libtock_test/rv32imc.tbf");
+
+    let mut p = spawn(
+        &format!(
+            "make OPENTITAN_BOOT_ROM={} APP={} qemu-app -C ../../boards/opentitan",
+            rom_path.to_str().unwrap(),
+            app_path.to_str().unwrap(),
+        ),
+        Some(10_000),
+    )?;
+
+    p.exp_string("Boot ROM initialisation has completed, jump into flash")?;
+    p.exp_string("OpenTitan initialisation complete.")?;
+    p.exp_string("Entering main loop")?;
+    p.exp_string("[      OK ] Console")?;
+    p.exp_string("[      OK ] static mut")?;
+    p.exp_string("[      OK ] Dynamic dispatch")?;
+    p.exp_string("[      OK ] Formatting")?;
+    p.exp_string("[      OK ] Heap")?;
+    p.exp_string("[      OK ] Drivers only instantiable once")?;
+    // This test currently fails
+    // p.exp_string("[      OK ] Callbacks")?;
+
+    // Test completed, kill QEMU
+    kill_qemu(&mut p)?;
+
+    p.exp_eof()?;
+    Ok(())
+}
+
 fn main() {
     println!("Tock qemu-runner starting...");
     println!("");
@@ -81,5 +134,6 @@ fn main() {
     println!("");
     println!("Running opentitan tests...");
     opentitan().unwrap_or_else(|e| panic!("opentitan job failed with {}", e));
+    opentitan_userspace().unwrap_or_else(|e| panic!("opentitan user space job failed with {}", e));
     println!("opentitan SUCCESS.");
 }


### PR DESCRIPTION
### Pull Request Overview

This PR runs the libtock-rs binaries as part of the build test.

Recently apps on OpenTitan was completely broken (fixed with: https://github.com/tock/tock/pull/1970) due to a lack of testing. One of my PMP changes broke userspace apps, but wasn't caught on the board as PMP was disabled on the FPGA bitsrteam. Having a CI that runs even a basic app in userspace would have caught this issue, hence this PR.

The idea of this PR is to move the CI towards what a user will run. That should hopefully increase the coverage of the CI while also catching bugs before users do. This should hopefully help improve sync issues between libtock-* and tock as well.

### Testing Strategy

Running the CI.

### TODO or Help Wanted

Unfortunately the GitHub artifact action is completely broken and requires a user to have a GitHub account to download artifacts.

Due to this we need the CI to have a user and a token to run the test. For example I can run the test like this (not a real token):

```
USER_PAT="alistair23:cjqka6fkhhodne7945fioynd3hs6m6yig88oft7x" make ci-job-qemu
```

For the CI we could probably save a token securely in the CI (I know Travis can do this at least) but that won't help for people running it locally.

Otherwise we have to wait for GitHub to fix their artifact builder, have libtock-rs use something other then GitHub actions (a third party service) or possibly check in the binaries or build libtock-rs binaries ourselves.

Thoughts?

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
