### PR TITLE
tock-registers: use UnsafeCell in writeable registers

### DIFF
--- a/libraries/tock-register-interface/src/registers.rs
+++ b/libraries/tock-register-interface/src/registers.rs
@@ -59,6 +59,7 @@
 #![allow(clippy::suspicious_op_assign_impl)]
 #![allow(clippy::suspicious_arithmetic_impl)]
 
+use core::cell::UnsafeCell;
 use core::fmt;
 use core::marker::PhantomData;
 use core::ops::{Add, AddAssign, BitAnd, BitOr, BitOrAssign, Not, Shl, Shr};
@@ -117,7 +118,7 @@ pub trait TryFromValue<V> {
 // struct must be exactly the size of the `T`.
 #[repr(transparent)]
 pub struct ReadWrite<T: IntLike, R: RegisterLongName = ()> {
-    value: T,
+    value: UnsafeCell<T>,
     associated_register: PhantomData<R>,
 }
 
@@ -135,7 +136,7 @@ pub struct ReadOnly<T: IntLike, R: RegisterLongName = ()> {
 // struct must be exactly the size of the `T`.
 #[repr(transparent)]
 pub struct WriteOnly<T: IntLike, R: RegisterLongName = ()> {
-    value: T,
+    value: UnsafeCell<T>,
     associated_register: PhantomData<R>,
 }
 
@@ -148,7 +149,7 @@ pub struct WriteOnly<T: IntLike, R: RegisterLongName = ()> {
 // struct must be exactly the size of the `T`.
 #[repr(transparent)]
 pub struct Aliased<T: IntLike, R: RegisterLongName = (), W: RegisterLongName = ()> {
-    value: T,
+    value: UnsafeCell<T>,
     associated_register: PhantomData<(R, W)>,
 }
 
@@ -156,13 +157,13 @@ impl<T: IntLike, R: RegisterLongName> ReadWrite<T, R> {
     #[inline]
     /// Get the raw register value
     pub fn get(&self) -> T {
-        unsafe { ::core::ptr::read_volatile(&self.value) }
+        unsafe { ::core::ptr::read_volatile(self.value.get()) }
     }
 
     #[inline]
     /// Set the raw register value
     pub fn set(&self, value: T) {
-        unsafe { ::core::ptr::write_volatile(&self.value as *const T as *mut T, value) }
+        unsafe { ::core::ptr::write_volatile(self.value.get(), value) }
     }
 
     #[inline]
@@ -269,7 +270,7 @@ impl<T: IntLike, R: RegisterLongName> WriteOnly<T, R> {
     #[inline]
     /// Set the raw register value
     pub fn set(&self, value: T) {
-        unsafe { ::core::ptr::write_volatile(&self.value as *const T as *mut T, value) }
+        unsafe { ::core::ptr::write_volatile(self.value.get(), value) }
     }
 
     #[inline]
@@ -283,13 +284,13 @@ impl<T: IntLike, R: RegisterLongName, W: RegisterLongName> Aliased<T, R, W> {
     #[inline]
     /// Get the raw register value
     pub fn get(&self) -> T {
-        unsafe { ::core::ptr::read_volatile(&self.value) }
+        unsafe { ::core::ptr::read_volatile(self.value.get()) }
     }
 
     #[inline]
     /// Set the raw register value
     pub fn set(&self, value: T) {
-        unsafe { ::core::ptr::write_volatile(&self.value as *const T as *mut T, value) }
+        unsafe { ::core::ptr::write_volatile(self.value.get(), value) }
     }
 
     #[inline]
@@ -429,29 +430,28 @@ impl<R: RegisterLongName> From<LocalRegisterCopy<u64, R>> for u64 {
 /// In memory volatile register.
 // To successfully alias this structure onto hardware registers in memory, this
 // struct must be exactly the size of the `T`.
-#[derive(Copy, Clone)]
 #[repr(transparent)]
 pub struct InMemoryRegister<T: IntLike, R: RegisterLongName = ()> {
-    value: T,
+    value: UnsafeCell<T>,
     associated_register: PhantomData<R>,
 }
 
 impl<T: IntLike, R: RegisterLongName> InMemoryRegister<T, R> {
     pub const fn new(value: T) -> Self {
         InMemoryRegister {
-            value: value,
+            value: UnsafeCell::new(value),
             associated_register: PhantomData,
         }
     }
 
     #[inline]
     pub fn get(&self) -> T {
-        unsafe { ::core::ptr::read_volatile(&self.value) }
+        unsafe { ::core::ptr::read_volatile(self.value.get()) }
     }
 
     #[inline]
     pub fn set(&self, value: T) {
-        unsafe { ::core::ptr::write_volatile(&self.value as *const T as *mut T, value) }
+        unsafe { ::core::ptr::write_volatile(self.value.get(), value) }
     }
 
     #[inline]

--- a/tools/run_clippy.sh
+++ b/tools/run_clippy.sh
@@ -18,6 +18,11 @@ fi
 #
 # - `clippy::if_same_then_else`: There are often good reasons to enumerate
 #   different states that have the same effect.
+# - `clippy::borrow_interior_mutable_const`: There's a common pattern of using
+#   a const `StaticRef` to reference mutable memory-mapped registers, and that
+#   triggers a false positive of this lint.
+#
+#   See https://github.com/rust-lang/rust-clippy/issues/5796.
 
 CLIPPY_ARGS="
 -A clippy::complexity
@@ -29,6 +34,7 @@ CLIPPY_ARGS="
 -A clippy::restriction
 
 -A clippy::if_same_then_else
+-A clippy::borrow_interior_mutable_const
 
 -D clippy::needless_return
 -D clippy::unnecessary_mut_passed


### PR DESCRIPTION
### Pull Request Overview

This pull request changes all writeable registers in `tock-register-interface` to use `UnsafeCell`-wrapped values, rather than just storing `T`.

In particular, `ReadWrite`, `WriteOnly`, `Aliased` and `InMemoryRegister` now wrap `UnsafeCell<T>`, and use `UnsafeCell::get` to retrieve mutable pointers rather than casting immutable references into mutable pointers. The intent is to avoid the undefined behavior of mutating through an immutable reference.

As a consequence, I had to remove `Copy` and `Clone` implementations for `InMemoryRegister`, and all changed registers are no longer `Sync`.

Fixes #2005.

### Testing Strategy

This pull request was tested by running the existing test suite. I ran `make ci-nosetup`, `make prepush`, and flashed a freshly built tock with these changes onto my `nrf52840dk` board.

### TODO or Help Wanted

This pull request still needs verification that removing `Sync` impls, and the `Copy` / `Clone` impls on `InMemoryRegisters` is OK.

There was some discussion of `Sync` in #2005, but none of the `Copy`/`Clone` changes. I'm not sure if this changes respects the purpose of `InMemoryRegister`, although it seems all code continues to compile without these impls?

In addition, this appears to introduce a number of clippy lint errors about not copying const values with inner mutability, despite that inner mutability being behind a pointer in `StaticRef`. I believe this is a false positive, and `clippy` is ignore the fact that the interior mutability is behind a pointer. But this doesn't resolve the errors.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
