### PR TITLE
riscv: pmp: only 16 regions, I guess?

### DIFF
--- a/arch/rv32i/src/pmp.rs
+++ b/arch/rv32i/src/pmp.rs
@@ -117,7 +117,7 @@ impl PMPRegion {
 
 /// Struct storing region configuration for RISCV PMP.
 pub struct PMPConfig {
-    regions: [Option<PMPRegion>; 32],
+    regions: [Option<PMPRegion>; 16],
     total_regions: usize,
     /// Indicates if the configuration has changed since the last time it was written to hardware.
     is_dirty: Cell<bool>,
@@ -132,7 +132,7 @@ impl Default for PMPConfig {
     /// number of regions on the arty chip
     fn default() -> PMPConfig {
         PMPConfig {
-            regions: [None; 32],
+            regions: [None; 16],
             total_regions: 8,
             is_dirty: Cell::new(true),
             last_configured_for: MapCell::empty(),
@@ -162,7 +162,7 @@ impl PMPConfig {
             panic!("Tock requires at least 4 PMP regions");
         }
         PMPConfig {
-            regions: [None; 32],
+            regions: [None; 16],
             // As we use the PMP TOR setup we only support half the number
             // of regions as hardware supports
             total_regions: pmp_regions / 2,


### PR DESCRIPTION
### Pull Request Overview

Following in my series of "I guess?" pull requests is issue number two: PMP edition. On the arty-e21 core, using 32 regions in the PMP causes the kernel stack to overflow. This shrinks it to 16 to make the arty-e21 platform work again.



### Testing Strategy

Running c_hello on arty-e21.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
