### PR TITLE
riscv: pmp: disable all entries

### DIFF
--- a/arch/rv32i/src/pmp.rs
+++ b/arch/rv32i/src/pmp.rs
@@ -193,9 +193,12 @@ impl kernel::mpu::MPU for PMPConfig {
     fn enable_mpu(&self) {}
 
     fn disable_mpu(&self) {
-        for x in 0..self.total_regions {
-            // If PMP is supported by the core then all 64 register sets must exist
-            // They don't all have to do anything, but let's zero them all just in case.
+        // `total_regions` here refers to the number of memory slices we can
+        // protect with the PMP. Each slice requires two PMP entries to protect,
+        // so `total_regions` is half of the number physical hardware PMP
+        // configuration entries. Therefore, we double `total_regions` to clear
+        // all the relevant `pmpcfg` entries.
+        for x in 0..(self.total_regions * 2) {
             match x % 4 {
                 0 => {
                     csr::CSR.pmpcfg[x / 4].modify(


### PR DESCRIPTION


### Pull Request Overview
With the PMP, the number of entries is double the number of regions. So for disable we want to clear all of the PMP entries.


### Testing Strategy

travis


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
