### PR TITLE
kernel: process: use slice for app memory

### DIFF
--- a/boards/acd52832/src/main.rs
+++ b/boards/acd52832/src/main.rs
@@ -490,7 +490,7 @@ pub unsafe fn reset_handler() {
             &_sapps as *const u8,
             &_eapps as *const u8 as usize - &_sapps as *const u8 as usize,
         ),
-        &mut core::slice::from_raw_parts_mut(
+        core::slice::from_raw_parts_mut(
             &mut _sappmem as *mut u8,
             &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
         ),

--- a/boards/arty_e21/src/main.rs
+++ b/boards/arty_e21/src/main.rs
@@ -233,7 +233,7 @@ pub unsafe fn reset_handler() {
             &_sapps as *const u8,
             &_eapps as *const u8 as usize - &_sapps as *const u8 as usize,
         ),
-        &mut core::slice::from_raw_parts_mut(
+        core::slice::from_raw_parts_mut(
             &mut _sappmem as *mut u8,
             &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
         ),

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -9,7 +9,6 @@
 #![cfg_attr(not(doc), no_main)]
 #![feature(const_in_array_repeat_expressions)]
 #![deny(missing_docs)]
-#![feature(const_raw_ptr_to_usize_cast)]
 
 use capsules::virtual_alarm::VirtualMuxAlarm;
 use capsules::virtual_i2c::{I2CDevice, MuxI2C};

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -9,6 +9,7 @@
 #![cfg_attr(not(doc), no_main)]
 #![feature(const_in_array_repeat_expressions)]
 #![deny(missing_docs)]
+#![feature(const_raw_ptr_to_usize_cast)]
 
 use capsules::virtual_alarm::VirtualMuxAlarm;
 use capsules::virtual_i2c::{I2CDevice, MuxI2C};
@@ -453,7 +454,7 @@ pub unsafe fn reset_handler() {
             &_sapps as *const u8,
             &_eapps as *const u8 as usize - &_sapps as *const u8 as usize,
         ),
-        &mut core::slice::from_raw_parts_mut(
+        core::slice::from_raw_parts_mut(
             &mut _sappmem as *mut u8,
             &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
         ),

--- a/boards/hifive1/src/main.rs
+++ b/boards/hifive1/src/main.rs
@@ -227,7 +227,7 @@ pub unsafe fn reset_handler() {
             &_sapps as *const u8,
             &_eapps as *const u8 as usize - &_sapps as *const u8 as usize,
         ),
-        &mut core::slice::from_raw_parts_mut(
+        core::slice::from_raw_parts_mut(
             &mut _sappmem as *mut u8,
             &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
         ),

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -554,7 +554,7 @@ pub unsafe fn reset_handler() {
             &_sapps as *const u8,
             &_eapps as *const u8 as usize - &_sapps as *const u8 as usize,
         ),
-        &mut core::slice::from_raw_parts_mut(
+        core::slice::from_raw_parts_mut(
             &mut _sappmem as *mut u8,
             &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
         ),

--- a/boards/msp_exp432p401r/src/main.rs
+++ b/boards/msp_exp432p401r/src/main.rs
@@ -218,7 +218,7 @@ pub unsafe fn reset_handler() {
             &_sapps as *const u8,
             &_eapps as *const u8 as usize - &_sapps as *const u8 as usize,
         ),
-        &mut core::slice::from_raw_parts_mut(
+        core::slice::from_raw_parts_mut(
             &mut _sappmem as *mut u8,
             &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
         ),

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -297,7 +297,7 @@ pub unsafe fn reset_handler() {
             &_sapps as *const u8,
             &_eapps as *const u8 as usize - &_sapps as *const u8 as usize,
         ),
-        &mut core::slice::from_raw_parts_mut(
+        core::slice::from_raw_parts_mut(
             &mut _sappmem as *mut u8,
             &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
         ),

--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -326,7 +326,7 @@ pub unsafe fn reset_handler() {
             &_sapps as *const u8,
             &_eapps as *const u8 as usize - &_sapps as *const u8 as usize,
         ),
-        &mut core::slice::from_raw_parts_mut(
+        core::slice::from_raw_parts_mut(
             &mut _sappmem as *mut u8,
             &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
         ),

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -452,7 +452,7 @@ pub unsafe fn reset_handler() {
             &_sapps as *const u8,
             &_eapps as *const u8 as usize - &_sapps as *const u8 as usize,
         ),
-        &mut core::slice::from_raw_parts_mut(
+        core::slice::from_raw_parts_mut(
             &mut _sappmem as *mut u8,
             &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
         ),

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -374,7 +374,7 @@ pub unsafe fn reset_handler() {
             &_sapps as *const u8,
             &_eapps as *const u8 as usize - &_sapps as *const u8 as usize,
         ),
-        &mut core::slice::from_raw_parts_mut(
+        core::slice::from_raw_parts_mut(
             &mut _sappmem as *mut u8,
             &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
         ),

--- a/boards/nucleo_f429zi/src/main.rs
+++ b/boards/nucleo_f429zi/src/main.rs
@@ -425,7 +425,7 @@ pub unsafe fn reset_handler() {
             &_sapps as *const u8,
             &_eapps as *const u8 as usize - &_sapps as *const u8 as usize,
         ),
-        &mut core::slice::from_raw_parts_mut(
+        core::slice::from_raw_parts_mut(
             &mut _sappmem as *mut u8,
             &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
         ),

--- a/boards/nucleo_f446re/src/main.rs
+++ b/boards/nucleo_f446re/src/main.rs
@@ -305,7 +305,7 @@ pub unsafe fn reset_handler() {
             &_sapps as *const u8,
             &_eapps as *const u8 as usize - &_sapps as *const u8 as usize,
         ),
-        &mut core::slice::from_raw_parts_mut(
+        core::slice::from_raw_parts_mut(
             &mut _sappmem as *mut u8,
             &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
         ),

--- a/boards/opentitan/src/main.rs
+++ b/boards/opentitan/src/main.rs
@@ -301,7 +301,7 @@ pub unsafe fn reset_handler() {
             &_sapps as *const u8,
             &_eapps as *const u8 as usize - &_sapps as *const u8 as usize,
         ),
-        &mut core::slice::from_raw_parts_mut(
+        core::slice::from_raw_parts_mut(
             &mut _sappmem as *mut u8,
             &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
         ),

--- a/boards/redboard_artemis_nano/src/main.rs
+++ b/boards/redboard_artemis_nano/src/main.rs
@@ -225,7 +225,7 @@ pub unsafe fn reset_handler() {
             &_sapps as *const u8,
             &_eapps as *const u8 as usize - &_sapps as *const u8 as usize,
         ),
-        &mut core::slice::from_raw_parts_mut(
+        core::slice::from_raw_parts_mut(
             &mut _sappmem as *mut u8,
             &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
         ),

--- a/boards/stm32f3discovery/src/main.rs
+++ b/boards/stm32f3discovery/src/main.rs
@@ -647,7 +647,7 @@ pub unsafe fn reset_handler() {
             &_sapps as *const u8,
             &_eapps as *const u8 as usize - &_sapps as *const u8 as usize,
         ),
-        &mut core::slice::from_raw_parts_mut(
+        core::slice::from_raw_parts_mut(
             &mut _sappmem as *mut u8,
             &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
         ),

--- a/boards/stm32f412gdiscovery/src/main.rs
+++ b/boards/stm32f412gdiscovery/src/main.rs
@@ -569,7 +569,7 @@ pub unsafe fn reset_handler() {
             &_sapps as *const u8,
             &_eapps as *const u8 as usize - &_sapps as *const u8 as usize,
         ),
-        &mut core::slice::from_raw_parts_mut(
+        core::slice::from_raw_parts_mut(
             &mut _sappmem as *mut u8,
             &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
         ),

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -143,7 +143,7 @@ pub fn load_processes<C: Chip>(
 ) -> Result<(), ProcessLoadError> {
     if config::CONFIG.debug_load_processes {
         debug!(
-            "Loading processes from flash=[{:#010X}:{:#010X}] into sram=[{:#010X}:{:#010X}]",
+            "Loading processes from flash={:#010X}-{:#010X} into sram={:#010X}-{:#010X}",
             app_flash.as_ptr() as usize,
             app_flash.as_ptr() as usize + app_flash.len() - 1,
             app_memory.as_ptr() as usize,
@@ -224,7 +224,7 @@ pub fn load_processes<C: Chip>(
             process_option.map(|process| {
                 if config::CONFIG.debug_load_processes {
                     debug!(
-                        "Loaded process[{}] from flash=[{:#010X}:{:#010X}] into sram=[{:#010X}:{:#010X}] = {:?}",
+                        "Loaded process[{}] from flash={:#010X}-{:#010X} into sram={:#010X}-{:#010X} = {:?}",
                         i,
                         entry_flash.as_ptr() as usize,
                         entry_flash.as_ptr() as usize + entry_flash.len() - 1,
@@ -1607,16 +1607,16 @@ impl<C: 'static + Chip> Process<'_, C> {
             if config::CONFIG.debug_load_processes {
                 if !tbf_header.is_app() {
                     debug!(
-                        "Padding in flash=[{:#010X}:{:#010X}]",
+                        "Padding in flash={:#010X}-{:#010X}",
                         app_flash.as_ptr() as usize,
-                        app_flash.as_ptr() as usize + app_flash.len()
+                        app_flash.as_ptr() as usize + app_flash.len() - 1
                     );
                 }
                 if !tbf_header.enabled() {
                     debug!(
-                        "Process not enabled flash=[{:#010X}:{:#010X}] process={:?}",
+                        "Process not enabled flash={:#010X}-{:#010X} process={:?}",
                         app_flash.as_ptr() as usize,
-                        app_flash.as_ptr() as usize + app_flash.len(),
+                        app_flash.as_ptr() as usize + app_flash.len() - 1,
                         process_name
                     );
                 }
@@ -1648,9 +1648,9 @@ impl<C: 'static + Chip> Process<'_, C> {
         {
             if config::CONFIG.debug_load_processes {
                 debug!(
-                    "[!] flash=[{:#010X}:{:#010X}] process={:?} - couldn't allocate MPU region for flash",
+                    "[!] flash={:#010X}-{:#010X} process={:?} - couldn't allocate MPU region for flash",
                     app_flash.as_ptr() as usize,
-                    app_flash.as_ptr() as usize + app_flash.len(),
+                    app_flash.as_ptr() as usize + app_flash.len() - 1,
                     process_name
                 );
             }
@@ -1704,7 +1704,7 @@ impl<C: 'static + Chip> Process<'_, C> {
                 // Failed to load process. Insufficient memory.
                 if config::CONFIG.debug_load_processes {
                     debug!(
-                        "[!] flash=[{:#010X}:{:#010X}] process={:?} - couldn't allocate memory region of size >= {:#X}",
+                        "[!] flash={:#010X}-{:#010X} process={:?} - couldn't allocate memory region of size >= {:#X}",
                         app_flash.as_ptr() as usize,
                         app_flash.as_ptr() as usize + app_flash.len(),
                         process_name,
@@ -1894,7 +1894,7 @@ impl<C: 'static + Chip> Process<'_, C> {
             _ => {
                 if config::CONFIG.debug_load_processes {
                     debug!(
-                        "[!] flash=[{:#010X}:{:#010X}] process={:?} - couldn't initialize process",
+                        "[!] flash={:#010X}-{:#010X} process={:?} - couldn't initialize process",
                         app_flash.as_ptr() as usize,
                         app_flash.as_ptr() as usize + app_flash.len(),
                         process_name

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -1706,7 +1706,7 @@ impl<C: 'static + Chip> Process<'_, C> {
                     debug!(
                         "[!] flash={:#010X}-{:#010X} process={:?} - couldn't allocate memory region of size >= {:#X}",
                         app_flash.as_ptr() as usize,
-                        app_flash.as_ptr() as usize + app_flash.len(),
+                        app_flash.as_ptr() as usize + app_flash.len() - 1,
                         process_name,
                         min_total_memory_size
                     );
@@ -1896,7 +1896,7 @@ impl<C: 'static + Chip> Process<'_, C> {
                     debug!(
                         "[!] flash={:#010X}-{:#010X} process={:?} - couldn't initialize process",
                         app_flash.as_ptr() as usize,
-                        app_flash.as_ptr() as usize + app_flash.len(),
+                        app_flash.as_ptr() as usize + app_flash.len() - 1,
                         process_name
                     );
                 }

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -1563,7 +1563,6 @@ fn exceeded_check(size: usize, allocated: usize) -> &'static str {
 }
 
 impl<C: 'static + Chip> Process<'_, C> {
-    #[inline(always)]
     pub(crate) unsafe fn create(
         kernel: &'static Kernel,
         chip: &'static C,

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -198,6 +198,13 @@ pub fn load_processes<C: Chip>(
             .get(0..entry_length as usize)
             .ok_or(ProcessLoadError::NotEnoughFlash)?;
 
+        // Advance the flash slice for process discovery beyond this last entry.
+        // This will be the start of where we look for a new process since Tock
+        // processes are allocated back-to-back in flash.
+        remaining_flash = remaining_flash
+            .get(entry_flash.len()..)
+            .ok_or(ProcessLoadError::NotEnoughFlash)?;
+
         // Need to reassign remaining_memory in every iteration so the compiler
         // knows it will not be re-borrowed.
         remaining_memory = if header_length > 0 {
@@ -243,13 +250,6 @@ pub fn load_processes<C: Chip>(
             // same amount of process memory to allocate from.
             remaining_memory
         };
-
-        // Advance the flash slice for process discovery beyond this last entry.
-        // This will be the start of where we look for a new process since Tock processes
-        // are allocated back-to-back in flash.
-        remaining_flash = remaining_flash
-            .get(entry_flash.len()..)
-            .ok_or(ProcessLoadError::NotEnoughFlash)?;
     }
 
     Ok(())

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -1614,7 +1614,7 @@ impl<C: 'static + Chip> Process<'_, C> {
                 }
                 if !tbf_header.enabled() {
                     debug!(
-                        "Note flash=[{:#010X}:{:#010X}] process={:?} not enabled",
+                        "Process not enabled flash=[{:#010X}:{:#010X}] process={:?}",
                         app_flash.as_ptr() as usize,
                         app_flash.as_ptr() as usize + app_flash.len(),
                         process_name


### PR DESCRIPTION

### Pull Request Overview

Convert `load_processes` and `process::create()` to use a slice for process memory rather than a pointer and length. This ultimately ends up being safer as we can rely on more rust functions to manage the slice, and it reduces the portion of the code that has to be marked `unsafe`.

~~A while ago I changed load_processes and process::create to use a slice for flash rather than a raw pointer and length. I have always intended to do the same for memory. In general, using a slice seems to be less error prone than using a raw pointer and length. This would also address a small bug currently in load_processes, where the debug print assumes the app's memory region starts at the beginning of the remaining app memory, which isn't necessarily true.~~

~~This is my attempt. I've tried this a couple times now, and I think I'm close, but I can't get Rust to fully compile it. The issue seems to stem from memory being `mut`, and the process struct keeping a reference to its memory slice. To make rust happy with that I had to mark the memory slice as `'static`. That _almost_ works, but there are some ownership issues, so my thought was to pass the entire memory slice to process:create(), and then have process::create() return what it doesn't use. There is conveniently a `split_as_mut()` function, but it seems to lose the `'static` lifetime, causing an error again. That is where it stands now.~~

Compiling hail:

```
make
   Compiling tock-cells v0.1.0 (/Users/bradjc/git/tock/libraries/tock-cells)
   Compiling tock-registers v0.5.0 (/Users/bradjc/git/tock/libraries/tock-register-interface)
   Compiling hail v0.1.0 (/Users/bradjc/git/tock/boards/hail)
   Compiling kernel v0.1.0 (/Users/bradjc/git/tock/kernel)
error[E0499]: cannot borrow `*remaining_memory` as mutable more than once at a time
   --> kernel/src/process.rs:207:21
    |
201 |                   if let Some((process, unused_memory)) = Process::create(
    |  _________________________________________________________-
202 | |                     kernel,
203 | |                     chip,
204 | |                     entry_flash,
...   |
207 | |                     remaining_memory,
    | |                     ^^^^^^^^^^^^^^^^ mutable borrow starts here in previous iteration of loop
208 | |                     fault_response,
209 | |                     i,
210 | |                 )? {
    | |_________________- argument requires that `*remaining_memory` is borrowed for `'static`

error[E0502]: cannot borrow `*app_memory` as immutable because it is also borrowed as mutable
    --> kernel/src/process.rs:1772:51
     |
1766 |         process.memory = app_memory;
     |         ---------------------------
     |         |                |
     |         |                mutable borrow occurs here
     |         assignment requires that `*app_memory` is borrowed for `'static`
...
1772 |         process.allow_high_water_mark = Cell::new(app_memory.as_ptr());
     |                                                   ^^^^^^^^^^ immutable borrow occurs here

error[E0502]: cannot borrow `*app_memory` as immutable because it is also borrowed as mutable
    --> kernel/src/process.rs:1773:50
     |
1766 |         process.memory = app_memory;
     |         ---------------------------
     |         |                |
     |         |                mutable borrow occurs here
     |         assignment requires that `*app_memory` is borrowed for `'static`
...
1773 |         process.original_allow_high_water_mark = app_memory.as_ptr();
     |                                                  ^^^^^^^^^^ immutable borrow occurs here

error: aborting due to 3 previous errors

Some errors have detailed explanations: E0499, E0502.
For more information about an error, try `rustc --explain E0499`.
error: could not compile `kernel`.
```


### Testing Strategy

todo


### TODO or Help Wanted

Anyone have any ideas?

Also there are a few old comments from past attempts that need I will clean up if we can find a working solution.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
