### PR TITLE
Makefile: Don't run the setup commands inside bash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@
 # First, need to fill out some variables that the Makefile will use
 $(eval ALL_BOARDS := $(shell ./tools/list_boards.sh))
 
+# Force the Shell to be bash as some systems have strange default shells
+SHELL := bash
+
 ##
 ## End: internal support.
 ##
@@ -76,7 +79,7 @@ define ci_setup_helper
 	$(eval build_function := $(strip $(3)))
 	$(eval guard_variable := $(strip $(4)))
 	@# First, if the dependency is installed, we can bail early
-	$(if $(shell bash -c '$(1)'),$(eval $(guard_variable) := true),
+	$(if $(shell '$(1)'),$(eval $(guard_variable) := true),
 	@# If running in CI context always yes
 	$(if $(CI),$(eval do_install := yes_CI),
 	@# If running nosetup always no


### PR DESCRIPTION
### Pull Request Overview

Instead of running the setup commands as part of bash -c * just have
Make call them from the shell.

This fixes a build failure seen at: https://github.com/tock/libtock-rs/pull/210


### Testing Strategy

Running the CI

### TODO or Help Wanted

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
