### PR TITLE
 kernel::hil: time: fixed wrong implementation of is_oneshot()

### DIFF
--- a/kernel/src/hil/time.rs
+++ b/kernel/src/hil/time.rs
@@ -145,7 +145,7 @@ pub trait Timer<'a, W = u32>: Time<W> {
 
     /// Returns whether this is a oneshot (rather than repeating) timer.
     fn is_oneshot(&self) -> bool {
-        self.interval().is_none()
+        self.interval().is_none() && self.is_enabled()
     }
 
     /// Returns whether this is a repeating (rather than oneshot) timer.


### PR DESCRIPTION
### Pull Request Overview

This PR fixes the implementation of the function `is_oneshot()` in the Timer trait. By the definition the function `interval()` can return `None` if the timer is disabled OR in oneshot, thus it's not sufficient to only check if `interval()` returns `None`, its also necessary to check if the timer is enabled.

### Testing Strategy

First an issue was opened, and the solution was confirmed there.

### TODO or Help Wanted

x

### Documentation Updated

x

### Formatting

- [x] Ran `ci-nosetup`.
