### PR TITLE
boards: nrf52840dk: add flash-openocd

### DIFF
--- a/boards/nordic/nrf52840dk/Makefile
+++ b/boards/nordic/nrf52840dk/Makefile
@@ -15,12 +15,15 @@ ifdef PORT
   TOCKLOADER_GENERAL_FLAGS += --port $(PORT)
 endif
 
-TOCKLOADER_JTAG_FLAGS = --jlink --board nrf52dk
-
 # Upload the kernel over JTAG
 .PHONY: flash
 flash: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin
-	$(TOCKLOADER) $(TOCKLOADER_GENERAL_FLAGS) flash --address $(KERNEL_ADDRESS) $(TOCKLOADER_JTAG_FLAGS) $<
+	$(TOCKLOADER) $(TOCKLOADER_GENERAL_FLAGS) flash --address $(KERNEL_ADDRESS) --board nrf52dk --jlink $<
+
+# Upload the kernel over JTAG using OpenOCD
+.PHONY: flash-openocd
+flash-openocd: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin
+	$(TOCKLOADER) $(TOCKLOADER_GENERAL_FLAGS) flash --address $(KERNEL_ADDRESS) --board nrf52dk --openocd $<
 
 # Upload the kernel over serial/bootloader
 .PHONY: program


### PR DESCRIPTION
### Pull Request Overview

This pull request adds a make target to the nrf52840dk makefile. Fixes #1626.


### Testing Strategy

Flashing a kernel on nrf52840dk.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
