### PR TITLE
sifive: uart: make sure tx enabled

### DIFF
--- a/chips/sifive/src/uart.rs
+++ b/chips/sifive/src/uart.rs
@@ -157,6 +157,9 @@ impl<'a> Uart<'a> {
 
     pub fn transmit_sync(&self, bytes: &[u8]) {
         let regs = self.registers;
+        // Make sure the UART is enabled.
+        regs.txctrl
+            .write(txctrl::txen::SET + txctrl::nstop::OneStopBit + txctrl::txcnt.val(1));
         for b in bytes.iter() {
             while regs.txdata.is_set(txdata::full) {}
             regs.txdata.write(txdata::data.val(*b as u32));


### PR DESCRIPTION
### Pull Request Overview

This pull request makes sure that the UART is enabled during panic printing on sifive platforms.


### Testing Strategy

Causing the arty-e21 board to panic.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
