### PR TITLE
OpenTitan: USB support cleanup

### DIFF
--- a/chips/lowrisc/src/usbdev.rs
+++ b/chips/lowrisc/src/usbdev.rs
@@ -456,42 +456,70 @@ impl<'a> hil::usb::UsbController<'a> for Usb<'a> {
     }
 
     fn endpoint_in_enable(&self, transfer_type: TransferType, endpoint: usize) {
-        let regs = self.registers;
-
         match transfer_type {
             TransferType::Control => {
-                regs.rxenable_setup.set(1 << endpoint);
-                regs.rxenable_out.set(1 << endpoint);
+                self.registers
+                    .rxenable_setup
+                    .set(1 << endpoint | self.registers.rxenable_setup.get());
+                self.descriptors[endpoint]
+                    .state
+                    .set(EndpointState::Ctrl(CtrlState::Init));
             }
             TransferType::Bulk => {
                 // How is this different to control?
-                regs.rxenable_setup.set(1 << endpoint);
-                regs.rxenable_out.set(1 << endpoint);
+                self.registers
+                    .rxenable_setup
+                    .set(1 << endpoint | self.registers.rxenable_setup.get());
+                self.descriptors[endpoint]
+                    .state
+                    .set(EndpointState::BulkIn(BulkInState::Init));
             }
             TransferType::Interrupt => unimplemented!(),
             TransferType::Isochronous => {
-                regs.rxenable_setup.set(1 << endpoint);
-                regs.rxenable_out.set(1 << endpoint);
-                regs.iso.set(1 << endpoint);
+                self.registers
+                    .rxenable_setup
+                    .set(1 << endpoint | self.registers.rxenable_setup.get());
+                self.registers.iso.set(1 << endpoint);
+                self.descriptors[endpoint].state.set(EndpointState::Iso);
             }
         };
     }
 
     fn endpoint_out_enable(&self, transfer_type: TransferType, endpoint: usize) {
-        let regs = self.registers;
-
         match transfer_type {
             TransferType::Control => {
-                regs.rxenable_setup.set(1 << endpoint);
+                self.registers
+                    .rxenable_setup
+                    .set(1 << endpoint | self.registers.rxenable_setup.get());
+                self.registers
+                    .rxenable_out
+                    .set(1 << endpoint | self.registers.rxenable_out.get());
+                self.descriptors[endpoint]
+                    .state
+                    .set(EndpointState::Ctrl(CtrlState::Init));
             }
             TransferType::Bulk => {
                 // How is this different to control?
-                regs.rxenable_setup.set(1 << endpoint);
+                self.registers
+                    .rxenable_setup
+                    .set(1 << endpoint | self.registers.rxenable_setup.get());
+                self.registers
+                    .rxenable_out
+                    .set(1 << endpoint | self.registers.rxenable_out.get());
+                self.descriptors[endpoint]
+                    .state
+                    .set(EndpointState::BulkOut(BulkOutState::Init));
             }
             TransferType::Interrupt => unimplemented!(),
             TransferType::Isochronous => {
-                regs.rxenable_setup.set(1 << endpoint);
-                regs.iso.set(1 << endpoint);
+                self.registers
+                    .rxenable_setup
+                    .set(1 << endpoint | self.registers.rxenable_setup.get());
+                self.registers
+                    .rxenable_out
+                    .set(1 << endpoint | self.registers.rxenable_out.get());
+                self.registers.iso.set(1 << endpoint);
+                self.descriptors[endpoint].state.set(EndpointState::Iso);
             }
         };
     }

--- a/chips/lowrisc/src/usbdev.rs
+++ b/chips/lowrisc/src/usbdev.rs
@@ -16,6 +16,9 @@ macro_rules! client_warn {
     };
 }
 
+pub const N_ENDPOINTS: usize = 12;
+pub const N_BUFFERS: usize = 32;
+
 register_structs! {
     pub UsbRegisters {
         (0x000 => intr_state: ReadWrite<u32, INTR::Register>),
@@ -29,11 +32,13 @@ register_structs! {
         (0x020 => rxenable_out: ReadWrite<u32, RXENABLE_OUT::Register>),
         (0x024 => in_sent: ReadWrite<u32, IN_SENT::Register>),
         (0x028 => stall: ReadWrite<u32, STALL::Register>),
-        (0x02c => configin: [ReadWrite<u32, CONFIGIN::Register>; 12]),
+        (0x02c => configin: [ReadWrite<u32, CONFIGIN::Register>; N_ENDPOINTS]),
         (0x05c => iso: ReadWrite<u32, ISO::Register>),
         (0x060 => data_toggle_clear: WriteOnly<u32, DATA_TOGGLE_CLEAR::Register>),
         (0x064 => phy_config: ReadWrite<u32, PHY_CONFIG::Register>),
-        (0x068 => @END),
+        (0x068 => _reserved0),
+        (0x800 => buffer: [ReadWrite<u64, BUFFER::Register>; N_BUFFERS]),
+        (0x900 => @END),
     }
 }
 
@@ -174,11 +179,21 @@ register_bitfields![u32,
         TX_DIFFERENTIAL_MODE OFFSET(1) NUMBITS(1) [],
         EOP_SINGLE_BIT OFFSET(2) NUMBITS(1) [],
         OVERRIDE_PWR_SENSE_EN OFFSET(3) NUMBITS(1) [],
-        OVERRIDE_PWR_SENSE_VAL OFFSET(4) NUMBITS(1) []
+        OVERRIDE_PWR_SENSE_VAL OFFSET(4) NUMBITS(1) [],
+        PINFLIP OFFSET(5) NUMBITS(1) [],
+        USB_REF_DISABLE OFFSET(6) NUMBITS(1) []
     ]
 ];
 
-pub const N_ENDPOINTS: usize = 12;
+register_bitfields![u64,
+    BUFFER [
+        REQUEST_TYPE OFFSET(0) NUMBITS(8) [],
+        REQUEST OFFSET(8) NUMBITS(8) [],
+        VALUE OFFSET(16) NUMBITS(16) [],
+        INDEX OFFSET(32) NUMBITS(16) [],
+        LENGTH OFFSET(48) NUMBITS(16) []
+    ]
+];
 
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub enum CtrlState {

--- a/chips/lowrisc/src/usbdev.rs
+++ b/chips/lowrisc/src/usbdev.rs
@@ -413,6 +413,17 @@ impl<'a> Usb<'a> {
         );
     }
 
+    fn free_buffer(&self, buf_id: usize) {
+        let mut bufs = self.bufs.get();
+
+        for buf in bufs.iter_mut() {
+            if buf.id == buf_id {
+                buf.free = true;
+                break;
+            }
+        }
+    }
+
     pub fn handle_interrupt(&self) {
         // Disable interrupts
         self.disable_interrupts();

--- a/chips/lowrisc/src/usbdev.rs
+++ b/chips/lowrisc/src/usbdev.rs
@@ -10,12 +10,6 @@ use kernel::debug;
 use kernel::hil;
 use kernel::hil::usb::TransferType;
 
-macro_rules! client_warn {
-    [ $( $arg:expr ),+ ] => {
-        debug!($( $arg ),+);
-    };
-}
-
 pub const N_ENDPOINTS: usize = 12;
 pub const N_BUFFERS: usize = 32;
 
@@ -406,8 +400,8 @@ impl<'a> hil::usb::UsbController<'a> for Usb<'a> {
         let regs = self.registers;
 
         match self.get_state() {
-            State::Reset => client_warn!("Not enabled"),
-            State::Active(_) => client_warn!("Already attached"),
+            State::Reset => unreachable!("Not enabled"),
+            State::Active(_) => unreachable!("Already attached"),
             State::Idle(mode) => {
                 regs.rxenable_setup.write(RXENABLE_SETUP::SETUP10::SET);
                 regs.rxenable_out.write(RXENABLE_OUT::OUT0::SET);


### PR DESCRIPTION
### Pull Request Overview

This PR includes various commits to start cleaning up the OpenTItan USB support. This is in preperation of supporting a CDC console in Tock.

With this PR the OpenTitan USB device will receive interrupts when attached to a USB host. I have more changes locally working on handling interrupt, but haven't made enough progress to send a PR yet.

### Testing Strategy

Connecting the OT FPGA dev kit to a Linux USB host.

### TODO or Help Wanted

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
