### PR TITLE
arch/rv32i: pmp: Make the PMP struct as long as required

### DIFF
--- a/arch/rv32i/src/pmp.rs
+++ b/arch/rv32i/src/pmp.rs
@@ -1,13 +1,16 @@
 //! Implementation of the physical memory protection unit (PMP).
 
+#[macro_export]
+macro_rules! PMPConfigMacro {
+    ( $x:expr ) => {
 use core::cell::Cell;
 use core::cmp;
 use core::fmt;
 use kernel::common::cells::OptionalCell;
 
-use crate::csr;
-use kernel;
+use rv32i::csr;
 use kernel::common::cells::MapCell;
+use kernel::common::registers;
 use kernel::common::registers::register_bitfields;
 use kernel::mpu;
 use kernel::AppId;
@@ -40,7 +43,7 @@ register_bitfields![u8,
 #[derive(Copy, Clone)]
 pub struct PMPRegion {
     location: (*const u8, usize),
-    cfg: tock_registers::registers::FieldValue<u8, pmpcfg::Register>,
+    cfg: registers::FieldValue<u8, pmpcfg::Register>,
 }
 
 impl fmt::Display for PMPRegion {
@@ -130,8 +133,6 @@ pub struct PMPConfig<N: PMPConfigType> {
     app_region: OptionalCell<usize>,
 }
 
-macro_rules! PMPConfigMacro {
-    ( $x:expr ) => {
 impl PMPConfigType for [Option<PMPRegion>; $x] {}
 
 impl Default for PMPConfig<[Option<PMPRegion>; $x]> {
@@ -503,6 +504,3 @@ impl kernel::mpu::MPU for PMPConfig<[Option<PMPRegion>; $x]> {
         }
     };
 }
-
-PMPConfigMacro!(4);
-PMPConfigMacro!(8);

--- a/chips/arty_e21_chip/src/chip.rs
+++ b/chips/arty_e21_chip/src/chip.rs
@@ -2,6 +2,7 @@ use core::fmt::Write;
 use kernel;
 use kernel::debug;
 use rv32i;
+use rv32i::pmp::PMPRegion;
 
 use crate::gpio;
 use crate::interrupts;
@@ -13,7 +14,7 @@ extern "C" {
 }
 
 pub struct ArtyExx {
-    pmp: rv32i::pmp::PMPConfig,
+    pmp: rv32i::pmp::PMPConfig<[Option<PMPRegion>; 4]>,
     userspace_kernel_boundary: rv32i::syscall::SysCall,
     clic: rv32i::clic::Clic,
 }
@@ -26,7 +27,7 @@ impl ArtyExx {
         let in_use_interrupts: u64 = 0x1FFFF0080;
 
         ArtyExx {
-            pmp: rv32i::pmp::PMPConfig::new(4),
+            pmp: rv32i::pmp::PMPConfig::default(),
             userspace_kernel_boundary: rv32i::syscall::SysCall::new(),
             clic: rv32i::clic::Clic::new(in_use_interrupts),
         }
@@ -105,7 +106,7 @@ impl ArtyExx {
 }
 
 impl kernel::Chip for ArtyExx {
-    type MPU = rv32i::pmp::PMPConfig;
+    type MPU = rv32i::pmp::PMPConfig<[Option<PMPRegion>; 4]>;
     type UserspaceKernelBoundary = rv32i::syscall::SysCall;
     type SchedulerTimer = ();
     type WatchDog = ();

--- a/chips/arty_e21_chip/src/chip.rs
+++ b/chips/arty_e21_chip/src/chip.rs
@@ -2,19 +2,21 @@ use core::fmt::Write;
 use kernel;
 use kernel::debug;
 use rv32i;
-use rv32i::pmp::PMPRegion;
+use rv32i::PMPConfigMacro;
 
 use crate::gpio;
 use crate::interrupts;
 use crate::timer;
 use crate::uart;
 
+PMPConfigMacro!(4);
+
 extern "C" {
     fn _start_trap();
 }
 
 pub struct ArtyExx {
-    pmp: rv32i::pmp::PMPConfig<[Option<PMPRegion>; 4]>,
+    pmp: PMPConfig<[Option<PMPRegion>; 4]>,
     userspace_kernel_boundary: rv32i::syscall::SysCall,
     clic: rv32i::clic::Clic,
 }
@@ -27,7 +29,7 @@ impl ArtyExx {
         let in_use_interrupts: u64 = 0x1FFFF0080;
 
         ArtyExx {
-            pmp: rv32i::pmp::PMPConfig::default(),
+            pmp: PMPConfig::default(),
             userspace_kernel_boundary: rv32i::syscall::SysCall::new(),
             clic: rv32i::clic::Clic::new(in_use_interrupts),
         }
@@ -106,7 +108,7 @@ impl ArtyExx {
 }
 
 impl kernel::Chip for ArtyExx {
-    type MPU = rv32i::pmp::PMPConfig<[Option<PMPRegion>; 4]>;
+    type MPU = PMPConfig<[Option<PMPRegion>; 4]>;
     type UserspaceKernelBoundary = rv32i::syscall::SysCall;
     type SchedulerTimer = ();
     type WatchDog = ();

--- a/chips/arty_e21_chip/src/chip.rs
+++ b/chips/arty_e21_chip/src/chip.rs
@@ -16,7 +16,7 @@ extern "C" {
 }
 
 pub struct ArtyExx {
-    pmp: PMPConfig<[Option<PMPRegion>; 4]>,
+    pmp: PMPConfig<[Option<PMPRegion>; 2]>,
     userspace_kernel_boundary: rv32i::syscall::SysCall,
     clic: rv32i::clic::Clic,
 }
@@ -108,7 +108,7 @@ impl ArtyExx {
 }
 
 impl kernel::Chip for ArtyExx {
-    type MPU = PMPConfig<[Option<PMPRegion>; 4]>;
+    type MPU = PMPConfig<[Option<PMPRegion>; 2]>;
     type UserspaceKernelBoundary = rv32i::syscall::SysCall;
     type SchedulerTimer = ();
     type WatchDog = ();

--- a/chips/arty_e21_chip/src/chip.rs
+++ b/chips/arty_e21_chip/src/chip.rs
@@ -2,21 +2,19 @@ use core::fmt::Write;
 use kernel;
 use kernel::debug;
 use rv32i;
-use rv32i::PMPConfigMacro;
 
 use crate::gpio;
 use crate::interrupts;
+use crate::pmp;
 use crate::timer;
 use crate::uart;
-
-PMPConfigMacro!(4);
 
 extern "C" {
     fn _start_trap();
 }
 
 pub struct ArtyExx {
-    pmp: PMPConfig<[Option<PMPRegion>; 2]>,
+    pmp: pmp::PMPConfig<[Option<pmp::PMPRegion>; 2]>,
     userspace_kernel_boundary: rv32i::syscall::SysCall,
     clic: rv32i::clic::Clic,
 }
@@ -29,7 +27,7 @@ impl ArtyExx {
         let in_use_interrupts: u64 = 0x1FFFF0080;
 
         ArtyExx {
-            pmp: PMPConfig::default(),
+            pmp: pmp::PMPConfig::default(),
             userspace_kernel_boundary: rv32i::syscall::SysCall::new(),
             clic: rv32i::clic::Clic::new(in_use_interrupts),
         }
@@ -108,7 +106,7 @@ impl ArtyExx {
 }
 
 impl kernel::Chip for ArtyExx {
-    type MPU = PMPConfig<[Option<PMPRegion>; 2]>;
+    type MPU = pmp::PMPConfig<[Option<pmp::PMPRegion>; 2]>;
     type UserspaceKernelBoundary = rv32i::syscall::SysCall;
     type SchedulerTimer = ();
     type WatchDog = ();

--- a/chips/arty_e21_chip/src/lib.rs
+++ b/chips/arty_e21_chip/src/lib.rs
@@ -6,6 +6,7 @@
 #![crate_type = "rlib"]
 
 mod interrupts;
+mod pmp;
 
 pub mod chip;
 pub mod gpio;

--- a/chips/arty_e21_chip/src/pmp.rs
+++ b/chips/arty_e21_chip/src/pmp.rs
@@ -1,0 +1,6 @@
+//! Instantiate the PMP for the e21 core.
+
+use rv32i::PMPConfigMacro;
+
+// The arty-e21 has four PMP entries.
+PMPConfigMacro!(4);

--- a/chips/e310x/src/chip.rs
+++ b/chips/e310x/src/chip.rs
@@ -19,7 +19,7 @@ PMPConfigMacro!(8);
 
 pub struct E310x<A: 'static + Alarm<'static>> {
     userspace_kernel_boundary: rv32i::syscall::SysCall,
-    pmp: PMPConfig<[Option<PMPRegion>; 8]>,
+    pmp: PMPConfig<[Option<PMPRegion>; 4]>,
     scheduler_timer: kernel::VirtualSchedulerTimer<A>,
 }
 
@@ -54,7 +54,7 @@ impl<A: 'static + Alarm<'static>> E310x<A> {
 }
 
 impl<A: 'static + Alarm<'static>> kernel::Chip for E310x<A> {
-    type MPU = PMPConfig<[Option<PMPRegion>; 8]>;
+    type MPU = PMPConfig<[Option<PMPRegion>; 4]>;
     type UserspaceKernelBoundary = rv32i::syscall::SysCall;
     type SchedulerTimer = kernel::VirtualSchedulerTimer<A>;
     type WatchDog = ();

--- a/chips/e310x/src/chip.rs
+++ b/chips/e310x/src/chip.rs
@@ -7,7 +7,7 @@ use kernel::debug;
 use kernel::hil::time::Alarm;
 use rv32i;
 use rv32i::csr::{mcause, mie::mie, mip::mip, CSR};
-use rv32i::pmp::PMPRegion;
+use rv32i::PMPConfigMacro;
 
 use crate::gpio;
 use crate::interrupts;
@@ -15,9 +15,11 @@ use crate::plic;
 use crate::timer;
 use crate::uart;
 
+PMPConfigMacro!(8);
+
 pub struct E310x<A: 'static + Alarm<'static>> {
     userspace_kernel_boundary: rv32i::syscall::SysCall,
-    pmp: rv32i::pmp::PMPConfig<[Option<PMPRegion>; 8]>,
+    pmp: PMPConfig<[Option<PMPRegion>; 8]>,
     scheduler_timer: kernel::VirtualSchedulerTimer<A>,
 }
 
@@ -25,7 +27,7 @@ impl<A: 'static + Alarm<'static>> E310x<A> {
     pub unsafe fn new(alarm: &'static A) -> Self {
         Self {
             userspace_kernel_boundary: rv32i::syscall::SysCall::new(),
-            pmp: rv32i::pmp::PMPConfig::default(),
+            pmp: PMPConfig::default(),
             scheduler_timer: kernel::VirtualSchedulerTimer::new(alarm),
         }
     }
@@ -52,7 +54,7 @@ impl<A: 'static + Alarm<'static>> E310x<A> {
 }
 
 impl<A: 'static + Alarm<'static>> kernel::Chip for E310x<A> {
-    type MPU = rv32i::pmp::PMPConfig<[Option<PMPRegion>; 8]>;
+    type MPU = PMPConfig<[Option<PMPRegion>; 8]>;
     type UserspaceKernelBoundary = rv32i::syscall::SysCall;
     type SchedulerTimer = kernel::VirtualSchedulerTimer<A>;
     type WatchDog = ();

--- a/chips/e310x/src/chip.rs
+++ b/chips/e310x/src/chip.rs
@@ -7,6 +7,7 @@ use kernel::debug;
 use kernel::hil::time::Alarm;
 use rv32i;
 use rv32i::csr::{mcause, mie::mie, mip::mip, CSR};
+use rv32i::pmp::PMPRegion;
 
 use crate::gpio;
 use crate::interrupts;
@@ -16,7 +17,7 @@ use crate::uart;
 
 pub struct E310x<A: 'static + Alarm<'static>> {
     userspace_kernel_boundary: rv32i::syscall::SysCall,
-    pmp: rv32i::pmp::PMPConfig,
+    pmp: rv32i::pmp::PMPConfig<[Option<PMPRegion>; 8]>,
     scheduler_timer: kernel::VirtualSchedulerTimer<A>,
 }
 
@@ -24,7 +25,7 @@ impl<A: 'static + Alarm<'static>> E310x<A> {
     pub unsafe fn new(alarm: &'static A) -> Self {
         Self {
             userspace_kernel_boundary: rv32i::syscall::SysCall::new(),
-            pmp: rv32i::pmp::PMPConfig::new(8),
+            pmp: rv32i::pmp::PMPConfig::default(),
             scheduler_timer: kernel::VirtualSchedulerTimer::new(alarm),
         }
     }
@@ -51,7 +52,7 @@ impl<A: 'static + Alarm<'static>> E310x<A> {
 }
 
 impl<A: 'static + Alarm<'static>> kernel::Chip for E310x<A> {
-    type MPU = rv32i::pmp::PMPConfig;
+    type MPU = rv32i::pmp::PMPConfig<[Option<PMPRegion>; 8]>;
     type UserspaceKernelBoundary = rv32i::syscall::SysCall;
     type SchedulerTimer = kernel::VirtualSchedulerTimer<A>;
     type WatchDog = ();

--- a/chips/earlgrey/src/chip.rs
+++ b/chips/earlgrey/src/chip.rs
@@ -27,7 +27,7 @@ pub const CHIP_FREQ: u32 = CONFIG.chip_freq;
 
 pub struct EarlGrey<A: 'static + Alarm<'static>> {
     userspace_kernel_boundary: SysCall,
-    pmp: PMPConfig<[Option<PMPRegion>; 4]>,
+    pmp: PMPConfig<[Option<PMPRegion>; 2]>,
     scheduler_timer: kernel::VirtualSchedulerTimer<A>,
 }
 
@@ -110,7 +110,7 @@ impl<A: 'static + Alarm<'static>> EarlGrey<A> {
 }
 
 impl<A: 'static + Alarm<'static>> kernel::Chip for EarlGrey<A> {
-    type MPU = PMPConfig<[Option<PMPRegion>; 4]>;
+    type MPU = PMPConfig<[Option<PMPRegion>; 2]>;
     type UserspaceKernelBoundary = SysCall;
     type SchedulerTimer = kernel::VirtualSchedulerTimer<A>;
     type WatchDog = ();

--- a/chips/earlgrey/src/chip.rs
+++ b/chips/earlgrey/src/chip.rs
@@ -8,8 +8,8 @@ use kernel::debug;
 use kernel::hil::time::Alarm;
 use kernel::Chip;
 use rv32i::csr::{mcause, mie::mie, mip::mip, mtvec::mtvec, CSR};
-use rv32i::pmp::PMPRegion;
 use rv32i::syscall::SysCall;
+use rv32i::PMPConfigMacro;
 
 use crate::chip_config::CONFIG;
 use crate::gpio;
@@ -21,11 +21,13 @@ use crate::timer;
 use crate::uart;
 use crate::usbdev;
 
+PMPConfigMacro!(4);
+
 pub const CHIP_FREQ: u32 = CONFIG.chip_freq;
 
 pub struct EarlGrey<A: 'static + Alarm<'static>> {
     userspace_kernel_boundary: SysCall,
-    pmp: rv32i::pmp::PMPConfig<[Option<PMPRegion>; 4]>,
+    pmp: PMPConfig<[Option<PMPRegion>; 4]>,
     scheduler_timer: kernel::VirtualSchedulerTimer<A>,
 }
 
@@ -33,7 +35,7 @@ impl<A: 'static + Alarm<'static>> EarlGrey<A> {
     pub unsafe fn new(alarm: &'static A) -> Self {
         Self {
             userspace_kernel_boundary: SysCall::new(),
-            pmp: rv32i::pmp::PMPConfig::default(),
+            pmp: PMPConfig::default(),
             scheduler_timer: kernel::VirtualSchedulerTimer::new(alarm),
         }
     }
@@ -108,7 +110,7 @@ impl<A: 'static + Alarm<'static>> EarlGrey<A> {
 }
 
 impl<A: 'static + Alarm<'static>> kernel::Chip for EarlGrey<A> {
-    type MPU = rv32i::pmp::PMPConfig<[Option<PMPRegion>; 4]>;
+    type MPU = PMPConfig<[Option<PMPRegion>; 4]>;
     type UserspaceKernelBoundary = SysCall;
     type SchedulerTimer = kernel::VirtualSchedulerTimer<A>;
     type WatchDog = ();

--- a/chips/earlgrey/src/chip.rs
+++ b/chips/earlgrey/src/chip.rs
@@ -2,13 +2,13 @@
 
 use core::fmt::Write;
 use core::hint::unreachable_unchecked;
-
 use kernel;
 use kernel::common::registers::FieldValue;
 use kernel::debug;
 use kernel::hil::time::Alarm;
 use kernel::Chip;
 use rv32i::csr::{mcause, mie::mie, mip::mip, mtvec::mtvec, CSR};
+use rv32i::pmp::PMPRegion;
 use rv32i::syscall::SysCall;
 
 use crate::chip_config::CONFIG;
@@ -25,7 +25,7 @@ pub const CHIP_FREQ: u32 = CONFIG.chip_freq;
 
 pub struct EarlGrey<A: 'static + Alarm<'static>> {
     userspace_kernel_boundary: SysCall,
-    pmp: rv32i::pmp::PMPConfig,
+    pmp: rv32i::pmp::PMPConfig<[Option<PMPRegion>; 4]>,
     scheduler_timer: kernel::VirtualSchedulerTimer<A>,
 }
 
@@ -33,7 +33,7 @@ impl<A: 'static + Alarm<'static>> EarlGrey<A> {
     pub unsafe fn new(alarm: &'static A) -> Self {
         Self {
             userspace_kernel_boundary: SysCall::new(),
-            pmp: rv32i::pmp::PMPConfig::new(4),
+            pmp: rv32i::pmp::PMPConfig::default(),
             scheduler_timer: kernel::VirtualSchedulerTimer::new(alarm),
         }
     }
@@ -108,7 +108,7 @@ impl<A: 'static + Alarm<'static>> EarlGrey<A> {
 }
 
 impl<A: 'static + Alarm<'static>> kernel::Chip for EarlGrey<A> {
-    type MPU = rv32i::pmp::PMPConfig;
+    type MPU = rv32i::pmp::PMPConfig<[Option<PMPRegion>; 4]>;
     type UserspaceKernelBoundary = SysCall;
     type SchedulerTimer = kernel::VirtualSchedulerTimer<A>;
     type WatchDog = ();


### PR DESCRIPTION
### Pull Request Overview

RISC-V allows up to 64 PMP regions, but most SoCs only support a smaller
number (currenlty 4 or 8). Allocating an array of all 64 regions for a
SoC that will only ever use 4 seems very wasteful. At the same time
restricting this amount will hinder devices that can support all 64.

Luckily Rust has a solution with generics. Unfortunately we can't have
generic arrays (there is an external crate that helps). I did manage to
get something almost working, but it was then impossible to iterate or
index into the array.

This patch converts the PMPConfig to be a generic type with specific
implementations created by macros. This allows us to easily support
a dynamic (compile time) number of regions.

### Testing Strategy

Testing with libtock-rs in QEMU on HiFive1 board.


### TODO or Help Wanted

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
