### PR TITLE
chips: Only report a PLIC interrupt as pending if enabled

### DIFF
--- a/chips/e310x/src/plic.rs
+++ b/chips/e310x/src/plic.rs
@@ -89,7 +89,13 @@ pub unsafe fn complete(index: u32) {
 pub unsafe fn has_pending() -> bool {
     let plic: &PlicRegisters = &*PLIC_BASE;
 
-    plic.pending.iter().fold(0, |i, pending| pending.get() | i) != 0
+    for (i, pending) in plic.pending.iter().enumerate() {
+        if pending.get() & plic.enable[i].get() != 0 {
+            return true;
+        }
+    }
+
+    false
 }
 
 /// This is a generic implementation. There may be board specific versions as

--- a/chips/earlgrey/src/plic.rs
+++ b/chips/earlgrey/src/plic.rs
@@ -89,5 +89,11 @@ pub unsafe fn complete(index: u32) {
 pub unsafe fn has_pending() -> bool {
     let plic: &PlicRegisters = &*PLIC_BASE;
 
-    plic.pending.iter().fold(0, |i, pending| pending.get() | i) != 0
+    for (i, pending) in plic.pending.iter().enumerate() {
+        if pending.get() & plic.enable[i].get() != 0 {
+            return true;
+        }
+    }
+
+    false
 }


### PR DESCRIPTION
### Pull Request Overview

There is currently no change to functionality as all PLIC interrupts are
enabled in Tock.

As discussed today this fixes the problem where we will service disabled interrupts before enabled interrupts. This only fixes the problem for RISC-V PLIC systems.

### Testing Strategy

Run Tock on QEMU and OpenTitan hardware.

### TODO or Help Wanted

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
