### PR TITLE
chips: plic: Disable only specific interrupts in the top half

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,7 +54,7 @@ doc/rustdoc
 Cargo.lock
 
 # The QEMU build directory
-tools/qemu-build
+tools/qemu/build
 
 # Python scripts
 __pycache__

--- a/Makefile
+++ b/Makefile
@@ -499,9 +499,9 @@ define ci_setup_qemu_riscv
 	@# Use the latest QEMU as it has OpenTitan support
 	@printf "Building QEMU, this could take a few minutes\n\n"
 	@git submodule sync; git submodule update --init
-	@mkdir -p tools/qemu-build && cd tools/qemu-build; ../qemu/configure --target-list=riscv32-softmmu;
+	@cd tools/qemu; ../qemu/configure --target-list=riscv32-softmmu --disable-linux-io-uring --disable-libdaxctl;
 	@# Build qemu
-	@$(MAKE) -C "tools/qemu-build" || (echo "You might need to install some missing packages" || exit 127)
+	@$(MAKE) -C "tools/qemu/build" || (echo "You might need to install some missing packages" || exit 127)
 endef
 
 define ci_setup_qemu_opentitan
@@ -525,7 +525,7 @@ ci-setup-qemu:
 	$(call ci_setup_helper,\
 		status=$$(git submodule status -- tools/qemu); \
 		[[ "$${status:0:1}" != "" ]] && \
-			cd tools/qemu-build && make -q riscv32-softmmu && echo yes,\
+			cd tools/qemu/build && make -q riscv32-softmmu && echo yes,\
 		Clone QEMU and run its build scripts,\
 		ci_setup_qemu_riscv,\
 		CI_JOB_QEMU_RISCV)
@@ -541,7 +541,7 @@ ci-setup-qemu:
 define ci_job_qemu
 	$(call banner,CI-Job: QEMU)
 	@cd tools/qemu-runner;\
-		PATH="$(shell pwd)/tools/qemu-build/riscv32-softmmu/:${PATH}"\
+		PATH="$(shell pwd)/tools/qemu/build/riscv32-softmmu/:${PATH}"\
 		CI=true cargo run
 endef
 

--- a/arch/rv32i/src/lib.rs
+++ b/arch/rv32i/src/lib.rs
@@ -227,7 +227,7 @@ pub extern "C" fn _start_trap() {
             // Jump to board-specific trap handler code. Likely this was an
             // interrupt and we want to disable a particular interrupt, but each
             // board/chip can customize this as needed.
-            jal ra, _start_trap_rust
+            jal ra, _start_trap_rust_from_kernel
 
             // Restore the registers from the stack.
             lw   ra, 0*4(sp)
@@ -337,7 +337,7 @@ pub extern "C" fn _start_trap() {
             bge  t0, zero, _from_app_continue
             // Copy mcause into a0 and then call the interrupt disable function.
             mv   a0, t0
-            jal  ra, _disable_interrupt_trap_handler
+            jal  ra, _disable_interrupt_trap_rust_from_app
 
         _from_app_continue:
             // Now determine the address of _return_to_kernel and resume the

--- a/chips/arty_e21_chip/src/chip.rs
+++ b/chips/arty_e21_chip/src/chip.rs
@@ -220,7 +220,7 @@ impl<'a, I: InterruptService<()> + 'a> kernel::Chip for ArtyExx<'a, I> {
 /// in kernel mode. All we need to do is check which interrupt occurred and
 /// disable it.
 #[cfg(all(target_arch = "riscv32", target_os = "none"))]
-#[export_name = "_start_trap_rust"]
+#[export_name = "_start_trap_rust_from_kernel"]
 pub extern "C" fn start_trap_rust() {
     let mut mcause: i32;
 
@@ -255,7 +255,7 @@ pub extern "C" fn start_trap_rust() {
 /// Function that gets called if an interrupt occurs while an app was running.
 /// mcause is passed in, and this function should correctly handle disabling the
 /// interrupt that fired so that it does not trigger again.
-#[export_name = "_disable_interrupt_trap_handler"]
+#[export_name = "_disable_interrupt_trap_rust_from_app"]
 pub extern "C" fn disable_interrupt_trap_handler(mcause: u32) {
     // The interrupt number is then the lowest 8
     // bits.

--- a/chips/e310x/src/chip.rs
+++ b/chips/e310x/src/chip.rs
@@ -223,7 +223,7 @@ unsafe fn handle_interrupt(intr: mcause::Interrupt) {
 /// For the e310 this gets called when an interrupt occurs while the chip is
 /// in kernel mode. All we need to do is check which interrupt occurred and
 /// disable it.
-#[export_name = "_start_trap_rust"]
+#[export_name = "_start_trap_rust_from_kernel"]
 pub unsafe extern "C" fn start_trap_rust() {
     match mcause::Trap::from(CSR.mcause.extract()) {
         mcause::Trap::Interrupt(interrupt) => {
@@ -238,7 +238,7 @@ pub unsafe extern "C" fn start_trap_rust() {
 /// Function that gets called if an interrupt occurs while an app was running.
 /// mcause is passed in, and this function should correctly handle disabling the
 /// interrupt that fired so that it does not trigger again.
-#[export_name = "_disable_interrupt_trap_handler"]
+#[export_name = "_disable_interrupt_trap_rust_from_app"]
 pub unsafe extern "C" fn disable_interrupt_trap_handler(mcause_val: u32) {
     match mcause::Trap::from(mcause_val) {
         mcause::Trap::Interrupt(interrupt) => {

--- a/chips/e310x/src/chip.rs
+++ b/chips/e310x/src/chip.rs
@@ -10,7 +10,7 @@ use rv32i::PMPConfigMacro;
 
 use crate::interrupts;
 use crate::plic::Plic;
-use crate::plic::PLIC_BASE;
+use crate::plic::PLIC;
 use kernel::InterruptService;
 
 PMPConfigMacro!(8);
@@ -18,7 +18,7 @@ PMPConfigMacro!(8);
 pub struct E310x<'a, A: 'static + Alarm<'static>, I: InterruptService<()> + 'a> {
     userspace_kernel_boundary: rv32i::syscall::SysCall,
     pmp: PMP,
-    plic: Plic,
+    plic: &'a Plic,
     scheduler_timer: kernel::VirtualSchedulerTimer<A>,
     timer: &'a rv32i::machine_timer::MachineTimer<'a>,
     plic_interrupt_service: &'a I,
@@ -78,7 +78,7 @@ impl<'a, A: 'static + Alarm<'static>, I: InterruptService<()> + 'a> E310x<'a, A,
         Self {
             userspace_kernel_boundary: rv32i::syscall::SysCall::new(),
             pmp: PMP::new(),
-            plic: Plic::new(PLIC_BASE),
+            plic: &PLIC,
             scheduler_timer: kernel::VirtualSchedulerTimer::new(alarm),
             timer,
             plic_interrupt_service,

--- a/chips/e310x/src/plic.rs
+++ b/chips/e310x/src/plic.rs
@@ -8,6 +8,8 @@ use kernel::common::StaticRef;
 pub const PLIC_BASE: StaticRef<PlicRegisters> =
     unsafe { StaticRef::new(0x0c00_0000 as *const PlicRegisters) };
 
+pub static mut PLIC: Plic = Plic::new(PLIC_BASE);
+
 #[repr(C)]
 pub struct PlicRegisters {
     /// Interrupt Priority Register

--- a/chips/e310x/src/plic.rs
+++ b/chips/e310x/src/plic.rs
@@ -1,5 +1,7 @@
 //! Platform Level Interrupt Control peripheral driver.
 
+use kernel::common::cells::VolatileCell;
+use kernel::common::registers::LocalRegisterCopy;
 use kernel::common::registers::{register_bitfields, ReadWrite};
 use kernel::common::StaticRef;
 
@@ -32,11 +34,18 @@ register_bitfields![u32,
 
 pub struct Plic {
     registers: StaticRef<PlicRegisters>,
+    saved: [VolatileCell<LocalRegisterCopy<u32>>; 2],
 }
 
 impl Plic {
     pub const fn new(base: StaticRef<PlicRegisters>) -> Self {
-        Plic { registers: base }
+        Plic {
+            registers: base,
+            saved: [
+                VolatileCell::new(LocalRegisterCopy::new(0)),
+                VolatileCell::new(LocalRegisterCopy::new(0)),
+            ],
+        }
     }
 
     /// Clear all pending interrupts.
@@ -79,6 +88,20 @@ impl Plic {
         } else {
             Some(claim)
         }
+    }
+
+    /// Save the current interrupt to be handled later
+    /// This will save the interrupt at index internally to be handled later.
+    /// Interrupts must be disabled before this is called.
+    pub unsafe fn save_interrupt(&self, index: u32) {
+        let offset = if index < 32 { 0 } else { 1 };
+        let irq = index % 32;
+
+        // OR the current saved state with the new value
+        let new_saved = self.saved[offset].get().get() | 1 << irq;
+
+        // Set the new state
+        self.saved[offset].set(LocalRegisterCopy::new(new_saved));
     }
 
     /// Signal that an interrupt is finished being handled. In Tock, this should be

--- a/chips/e310x/src/plic.rs
+++ b/chips/e310x/src/plic.rs
@@ -96,6 +96,7 @@ impl Plic {
     /// This will save the interrupt at index internally to be handled later.
     /// Interrupts must be disabled before this is called.
     /// Saved interrupts can be retrieved by calling `get_saved_interrupts()`.
+    /// Saved interrupts are cleared when `'complete()` is called.
     pub unsafe fn save_interrupt(&self, index: u32) {
         let offset = if index < 32 { 0 } else { 1 };
         let irq = index % 32;
@@ -123,18 +124,18 @@ impl Plic {
 
     /// Signal that an interrupt is finished being handled. In Tock, this should be
     /// called from the normal main loop (not the interrupt handler).
-    pub fn complete(&self, index: u32) {
+    /// Interrupts must be disabled before this is called.
+    pub unsafe fn complete(&self, index: u32) {
         self.registers.claim.set(index);
-    }
 
-    /// Return `true` if there are any pending interrupts in the PLIC, `false`
-    /// otherwise.
-    pub fn has_pending(&self) -> bool {
-        self.registers
-            .pending
-            .iter()
-            .fold(0, |i, pending| pending.get() | i)
-            != 0
+        let offset = if index < 32 { 0 } else { 1 };
+        let irq = index % 32;
+
+        // OR the current saved state with the new value
+        let new_saved = self.saved[offset].get().get() & !(1 << irq);
+
+        // Set the new state
+        self.saved[offset].set(LocalRegisterCopy::new(new_saved));
     }
 
     /// This is a generic implementation. There may be board specific versions as

--- a/chips/earlgrey/src/chip.rs
+++ b/chips/earlgrey/src/chip.rs
@@ -13,14 +13,14 @@ use rv32i::PMPConfigMacro;
 use crate::chip_config::CONFIG;
 use crate::interrupts;
 use crate::plic::Plic;
-use crate::plic::PLIC_BASE;
+use crate::plic::PLIC;
 
 PMPConfigMacro!(4);
 
 pub struct EarlGrey<'a, A: 'static + Alarm<'static>, I: InterruptService<()> + 'a> {
     userspace_kernel_boundary: SysCall,
     pmp: PMP,
-    plic: Plic,
+    plic: &'a Plic,
     scheduler_timer: kernel::VirtualSchedulerTimer<A>,
     timer: &'static crate::timer::RvTimer<'static>,
     pwrmgr: lowrisc::pwrmgr::PwrMgr,
@@ -92,7 +92,7 @@ impl<'a, A: 'static + Alarm<'static>, I: InterruptService<()> + 'a> EarlGrey<'a,
         Self {
             userspace_kernel_boundary: SysCall::new(),
             pmp: PMP::new(),
-            plic: Plic::new(PLIC_BASE),
+            plic: &PLIC,
             scheduler_timer: kernel::VirtualSchedulerTimer::new(virtual_alarm),
             pwrmgr: lowrisc::pwrmgr::PwrMgr::new(crate::pwrmgr::PWRMGR_BASE),
             timer,

--- a/chips/earlgrey/src/chip.rs
+++ b/chips/earlgrey/src/chip.rs
@@ -113,7 +113,10 @@ impl<'a, A: 'static + Alarm<'static>, I: InterruptService<()> + 'a> EarlGrey<'a,
             } else if !self.plic_interrupt_service.service_interrupt(interrupt) {
                 debug!("Pidx {}", interrupt);
             }
-            self.plic.complete(interrupt);
+            self.atomic(|| {
+                // Safe as interrupts are disabled
+                self.plic.complete(interrupt);
+            });
         }
     }
 

--- a/chips/earlgrey/src/chip.rs
+++ b/chips/earlgrey/src/chip.rs
@@ -99,7 +99,6 @@ impl<'a, A: 'static + Alarm<'static>, I: InterruptService<()> + 'a> EarlGrey<'a,
 
     pub unsafe fn enable_plic_interrupts(&self) {
         plic::disable_all();
-        plic::clear_all_pending();
         plic::enable_all();
     }
 

--- a/chips/earlgrey/src/chip.rs
+++ b/chips/earlgrey/src/chip.rs
@@ -281,7 +281,7 @@ unsafe fn handle_interrupt(intr: mcause::Interrupt) {
 /// For the Ibex this gets called when an interrupt occurs while the chip is
 /// in kernel mode. All we need to do is check which interrupt occurred and
 /// disable it.
-#[export_name = "_start_trap_rust"]
+#[export_name = "_start_trap_rust_from_kernel"]
 pub unsafe extern "C" fn start_trap_rust() {
     match mcause::Trap::from(CSR.mcause.extract()) {
         mcause::Trap::Interrupt(interrupt) => {
@@ -296,7 +296,7 @@ pub unsafe extern "C" fn start_trap_rust() {
 /// Function that gets called if an interrupt occurs while an app was running.
 /// mcause is passed in, and this function should correctly handle disabling the
 /// interrupt that fired so that it does not trigger again.
-#[export_name = "_disable_interrupt_trap_handler"]
+#[export_name = "_disable_interrupt_trap_rust_from_app"]
 pub unsafe extern "C" fn disable_interrupt_trap_handler(mcause_val: u32) {
     match mcause::Trap::from(mcause_val) {
         mcause::Trap::Interrupt(interrupt) => {

--- a/chips/earlgrey/src/plic.rs
+++ b/chips/earlgrey/src/plic.rs
@@ -104,6 +104,7 @@ impl Plic {
     /// Save the current interrupt to be handled later
     /// This will save the interrupt at index internally to be handled later.
     /// Interrupts must be disabled before this is called.
+    /// Saved interrupts can be retrieved by calling `get_saved_interrupts()`.
     pub unsafe fn save_interrupt(&self, index: u32) {
         let offset = if index < 32 {
             0
@@ -119,6 +120,20 @@ impl Plic {
 
         // Set the new state
         self.saved[offset].set(LocalRegisterCopy::new(new_saved));
+    }
+
+    /// The `next_pending()` function will only return enabled interrupts.
+    /// This function will return a pending interrupt that has been disabled by
+    /// `save_interrupt()`.
+    pub fn get_saved_interrupts(&self) -> Option<u32> {
+        for (i, pending) in self.saved.iter().enumerate() {
+            let saved = pending.get().get();
+            if saved != 0 {
+                return Some(saved.trailing_zeros() + (i as u32 * 32));
+            }
+        }
+
+        None
     }
 
     /// Signal that an interrupt is finished being handled. In Tock, this should be

--- a/chips/earlgrey/src/plic.rs
+++ b/chips/earlgrey/src/plic.rs
@@ -4,6 +4,9 @@ use kernel::common::registers::{register_bitfields, register_structs, ReadOnly, 
 use kernel::common::StaticRef;
 //use kernel::debug;
 
+pub const PLIC_BASE: StaticRef<PlicRegisters> =
+    unsafe { StaticRef::new(0x4009_0000 as *const PlicRegisters) };
+
 register_structs! {
     pub PlicRegisters {
         /// Interrupt Pending Register
@@ -31,73 +34,76 @@ register_bitfields![u32,
     ]
 ];
 
-const PLIC_BASE: StaticRef<PlicRegisters> =
-    unsafe { StaticRef::new(0x4009_0000 as *const PlicRegisters) };
-
-/// Clear all pending interrupts.
-pub unsafe fn clear_all_pending() {
-    unimplemented!()
+pub struct Plic {
+    registers: StaticRef<PlicRegisters>,
 }
 
-/// Enable all interrupts.
-pub unsafe fn enable_all() {
-    let plic: &PlicRegisters = &*PLIC_BASE;
-
-    // USB hardware on current OT master branch seems to have
-    // interrupt bugs: running Alarms causes persistent USB
-    // CONNECTED interrupts that can't be masked from USBDEV and
-    // cause the system to hang. So enable all interrupts except
-    // for the USB ones. Some open PRs on OT fix this, we'll re-enable
-    // USB interrurupts.
-    //
-    // https://github.com/lowRISC/opentitan/issues/3388
-    plic.enable[0].set(0xFFFF_FFFF);
-    plic.enable[1].set(0xFFFF_FFFF);
-    plic.enable[2].set(0xFFFF_0000); // USB are 64-79
-
-    // Set the max priority for each interrupt. This is not really used
-    // at this point.
-    for priority in plic.priority.iter() {
-        priority.write(priority::Priority.val(3));
+impl Plic {
+    pub const fn new(base: StaticRef<PlicRegisters>) -> Self {
+        Plic { registers: base }
     }
 
-    // Accept all interrupts.
-    plic.threshold.write(priority::Priority.val(1));
-}
-
-/// Disable all interrupts.
-pub unsafe fn disable_all() {
-    let plic: &PlicRegisters = &*PLIC_BASE;
-    for enable in plic.enable.iter() {
-        enable.set(0);
+    /// Clear all pending interrupts.
+    pub fn clear_all_pending(&self) {
+        unimplemented!()
     }
-}
 
-/// Get the index (0-256) of the lowest number pending interrupt, or `None` if
-/// none is pending. RISC-V PLIC has a "claim" register which makes it easy
-/// to grab the highest priority pending interrupt.
-pub unsafe fn next_pending() -> Option<u32> {
-    let plic: &PlicRegisters = &*PLIC_BASE;
+    /// Enable all interrupts.
+    pub fn enable_all(&self) {
+        // USB hardware on current OT master branch seems to have
+        // interrupt bugs: running Alarms causes persistent USB
+        // CONNECTED interrupts that can't be masked from USBDEV and
+        // cause the system to hang. So enable all interrupts except
+        // for the USB ones. Some open PRs on OT fix this, we'll re-enable
+        // USB interrurupts.
+        //
+        // https://github.com/lowRISC/opentitan/issues/3388
+        self.registers.enable[0].set(0xFFFF_FFFF);
+        self.registers.enable[1].set(0xFFFF_FFFF);
+        self.registers.enable[2].set(0xFFFF_0000); // USB are 64-79
 
-    let claim = plic.claim.get();
-    if claim == 0 {
-        None
-    } else {
-        Some(claim)
+        // Set the max priority for each interrupt. This is not really used
+        // at this point.
+        for priority in self.registers.priority.iter() {
+            priority.write(priority::Priority.val(3));
+        }
+
+        // Accept all interrupts.
+        self.registers.threshold.write(priority::Priority.val(1));
     }
-}
 
-/// Signal that an interrupt is finished being handled. In Tock, this should be
-/// called from the normal main loop (not the interrupt handler).
-pub unsafe fn complete(index: u32) {
-    let plic: &PlicRegisters = &*PLIC_BASE;
-    plic.claim.set(index);
-}
+    /// Disable all interrupts.
+    pub fn disable_all(&self) {
+        for enable in self.registers.enable.iter() {
+            enable.set(0);
+        }
+    }
 
-/// Return `true` if there are any pending interrupts in the PLIC, `false`
-/// otherwise.
-pub unsafe fn has_pending() -> bool {
-    let plic: &PlicRegisters = &*PLIC_BASE;
+    /// Get the index (0-256) of the lowest number pending interrupt, or `None` if
+    /// none is pending. RISC-V PLIC has a "claim" register which makes it easy
+    /// to grab the highest priority pending interrupt.
+    pub fn next_pending(&self) -> Option<u32> {
+        let claim = self.registers.claim.get();
+        if claim == 0 {
+            None
+        } else {
+            Some(claim)
+        }
+    }
 
-    plic.pending.iter().fold(0, |i, pending| pending.get() | i) != 0
+    /// Signal that an interrupt is finished being handled. In Tock, this should be
+    /// called from the normal main loop (not the interrupt handler).
+    pub fn complete(&self, index: u32) {
+        self.registers.claim.set(index);
+    }
+
+    /// Return `true` if there are any pending interrupts in the PLIC, `false`
+    /// otherwise.
+    pub fn has_pending(&self) -> bool {
+        self.registers
+            .pending
+            .iter()
+            .fold(0, |i, pending| pending.get() | i)
+            != 0
+    }
 }

--- a/chips/earlgrey/src/plic.rs
+++ b/chips/earlgrey/src/plic.rs
@@ -36,7 +36,7 @@ const PLIC_BASE: StaticRef<PlicRegisters> =
 
 /// Clear all pending interrupts.
 pub unsafe fn clear_all_pending() {
-    let _plic: &PlicRegisters = &*PLIC_BASE;
+    unimplemented!()
 }
 
 /// Enable all interrupts.

--- a/chips/earlgrey/src/plic.rs
+++ b/chips/earlgrey/src/plic.rs
@@ -9,6 +9,8 @@ use kernel::common::StaticRef;
 pub const PLIC_BASE: StaticRef<PlicRegisters> =
     unsafe { StaticRef::new(0x4009_0000 as *const PlicRegisters) };
 
+pub static mut PLIC: Plic = Plic::new(PLIC_BASE);
+
 register_structs! {
     pub PlicRegisters {
         /// Interrupt Pending Register

--- a/tools/qemu-runner/Cargo.toml
+++ b/tools/qemu-runner/Cargo.toml
@@ -5,4 +5,4 @@ authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
 edition = "2018"
 
 [dependencies]
-rexpect = "0.3.0"
+rexpect = "0.4.0"

--- a/tools/qemu-runner/src/main.rs
+++ b/tools/qemu-runner/src/main.rs
@@ -61,9 +61,8 @@ fn opentitan() -> Result<(), Error> {
         Some(10_000),
     )?;
 
-    p.exp_string("Boot ROM initialisation has completed, jump into flash")?;
-    p.exp_string("OpenTitan initialisation complete.")?;
-    p.exp_string("Entering main loop")?;
+    p.exp_string("Boot ROM initialisation has completed, jump into flash!")?;
+    p.exp_string("OpenTitan initialisation complete. Entering main loop")?;
 
     // Test completed, kill QEMU
     kill_qemu(&mut p)?;


### PR DESCRIPTION
### Pull Request Overview

When handling an interrupt only disable the specific interrupt instead
of all external interrupts.

See individual commits for more information.

### Testing Strategy

Run Tock on QEMU and OpenTitan hardware.

### TODO or Help Wanted

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
