### PR TITLE
cortex-m: fix warning about volatile keyword in incorrect position

### DIFF
--- a/arch/cortex-m3/src/lib.rs
+++ b/arch/cortex-m3/src/lib.rs
@@ -170,7 +170,7 @@ pub unsafe extern "C" fn svc_handler() {
     movw LR, #0xFFF9
     movt LR, #0xFFFF
     bx lr"
-    : : : "r0", "r1", "cc" : "volatile" );
+    : : : "r0", "r1", "lr", "cc", "memory" : "volatile" );
 }
 
 // Mock implementation for tests on Travis-CI.
@@ -417,7 +417,8 @@ pub unsafe extern "C" fn hard_fault_handler() {
             mov sp, r0   /* Set the stack pointer to _estack */"
             :
             : "{r0}"((_estack as *const ()) as u32)
-            : : "volatile" );
+            :
+            : "volatile" );
 
             // Panic to show the correct error.
             panic!("kernel stack overflow");
@@ -457,7 +458,7 @@ pub unsafe extern "C" fn hard_fault_handler() {
 
         movw LR, #0xFFF9
         movt LR, #0xFFFF"
-        : : : "r1", "r0", "r2" : "volatile" );
+        : : : "r1", "r0", "r2", "memory" : "volatile" );
     }
 }
 

--- a/arch/cortex-m3/src/lib.rs
+++ b/arch/cortex-m3/src/lib.rs
@@ -417,7 +417,7 @@ pub unsafe extern "C" fn hard_fault_handler() {
             mov sp, r0   /* Set the stack pointer to _estack */"
             :
             : "{r0}"((_estack as *const ()) as u32)
-            : "volatile" );
+            : : "volatile" );
 
             // Panic to show the correct error.
             panic!("kernel stack overflow");

--- a/arch/cortex-m3/src/lib.rs
+++ b/arch/cortex-m3/src/lib.rs
@@ -49,7 +49,7 @@ pub unsafe extern "C" fn systick_handler() {
 
     movw LR, #0xFFF9
     movt LR, #0xFFFF"
-    : : : : "volatile" );
+    : : : "r0" : "volatile" );
 }
 
 // Mock implementation for tests on Travis-CI.
@@ -170,7 +170,7 @@ pub unsafe extern "C" fn svc_handler() {
     movw LR, #0xFFF9
     movt LR, #0xFFFF
     bx lr"
-    : : : : "volatile" );
+    : : : "r0", "r1", "cc" : "volatile" );
 }
 
 // Mock implementation for tests on Travis-CI.
@@ -378,7 +378,7 @@ pub unsafe extern "C" fn hard_fault_handler() {
     mrsne  r0, psp   /* r0 = userland stack pointer */"
     : "={r0}"(faulting_stack), "={r1}"(kernel_stack)
     :
-    : "r0", "r1"
+    : "cc"
     : "volatile" );
 
     if kernel_stack {
@@ -399,7 +399,7 @@ pub unsafe extern "C" fn hard_fault_handler() {
         moveq r3, #0           /* BFSR & 0b00110000 == 0; r3 = 0 */"
         : "={r3}"(stack_overflow)
         :
-        : "r3"
+        : "r2", "cc"
         : "volatile" );
 
         if stack_overflow {
@@ -457,7 +457,7 @@ pub unsafe extern "C" fn hard_fault_handler() {
 
         movw LR, #0xFFF9
         movt LR, #0xFFFF"
-        : : : : "volatile" );
+        : : : "r1", "r0", "r2" : "volatile" );
     }
 }
 

--- a/arch/cortex-m4/src/lib.rs
+++ b/arch/cortex-m4/src/lib.rs
@@ -228,7 +228,7 @@ pub unsafe extern "C" fn svc_handler() {
     movw LR, #0xFFF9
     movt LR, #0xFFFF
     bx lr"
-    : : : "r0", "r1", "cc" : "volatile" );
+    : : : "r0", "r1", "cc", "memory" : "volatile" );
 }
 
 // Mock implementation for tests on Travis-CI.
@@ -488,7 +488,8 @@ pub unsafe extern "C" fn hard_fault_handler() {
             mov sp, r0   /* Set the stack pointer to _estack */"
             :
             : "{r0}"((_estack as *const ()) as u32)
-            : : "volatile" );
+            :
+            : "volatile" );
 
             // Panic to show the correct error.
             panic!("kernel stack overflow");
@@ -528,7 +529,7 @@ pub unsafe extern "C" fn hard_fault_handler() {
 
         movw LR, #0xFFF9
         movt LR, #0xFFFF"
-        : : : "r1", "r0", "r2" : "volatile" );
+        : : : "r1", "r0", "r2", "memory" : "volatile" );
     }
 }
 

--- a/arch/cortex-m4/src/lib.rs
+++ b/arch/cortex-m4/src/lib.rs
@@ -58,7 +58,7 @@ pub unsafe extern "C" fn systick_handler() {
     // This will resume in the switch to user function where application state
     // is saved and the scheduler can choose what to do next.
     "
-    : : : : "volatile" );
+    : : : "r0" : "volatile" );
 }
 
 // Mock implementation for tests on Travis-CI.
@@ -228,7 +228,7 @@ pub unsafe extern "C" fn svc_handler() {
     movw LR, #0xFFF9
     movt LR, #0xFFFF
     bx lr"
-    : : : : "volatile" );
+    : : : "r0", "r1", "cc" : "volatile" );
 }
 
 // Mock implementation for tests on Travis-CI.
@@ -449,7 +449,7 @@ pub unsafe extern "C" fn hard_fault_handler() {
     mrsne  r0, psp   /* r0 = userland stack pointer */"
     : "={r0}"(faulting_stack), "={r1}"(kernel_stack)
     :
-    : "r0", "r1"
+    : "cc"
     : "volatile" );
 
     if kernel_stack {
@@ -470,7 +470,7 @@ pub unsafe extern "C" fn hard_fault_handler() {
         moveq r3, #0           /* BFSR & 0b00110000 == 0; r3 = 0 */"
         : "={r3}"(stack_overflow)
         :
-        : "r3"
+        : "r2", "cc"
         : "volatile" );
 
         if stack_overflow {
@@ -528,7 +528,7 @@ pub unsafe extern "C" fn hard_fault_handler() {
 
         movw LR, #0xFFF9
         movt LR, #0xFFFF"
-        : : : : "volatile" );
+        : : : "r1", "r0", "r2" : "volatile" );
     }
 }
 

--- a/arch/cortex-m4/src/lib.rs
+++ b/arch/cortex-m4/src/lib.rs
@@ -488,7 +488,7 @@ pub unsafe extern "C" fn hard_fault_handler() {
             mov sp, r0   /* Set the stack pointer to _estack */"
             :
             : "{r0}"((_estack as *const ()) as u32)
-            : "volatile" );
+            : : "volatile" );
 
             // Panic to show the correct error.
             panic!("kernel stack overflow");


### PR DESCRIPTION
### Pull Request Overview

#2002 added a volatile keyword in the position intended for clobbers in the assembly responsible for resetting the stack pointer.
This surfaced a warning whenever compiling a cortex-m4 architecture, but this warning did not cause CI to fail because `cd arch/ && RUSTFLAGS="-D warnings" cargo test` ignores code that can't be compiled on the host platform, and we do not deny warnings when compiling all boards.

### Testing Strategy

This pull request was tested by compiling Imix and seeing that the warning is gone.


### TODO or Help Wanted

Ideally we would deny warnings in `ci-job-compilation` so mistakes like this couldn't slip past CI, but passing `RUSTFLAGS="-D warnings"` to the call to `make allboards` within `ci-job-compilation` did not seem to work, and I did not try anything further.

### Documentation Updated

- [x] No updates are required.

### Formatting

- [x] Ran `make prepush`.
