### PR TITLE
Fix potential unsoundness in dynamic grant allocation

### DIFF
--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -112,7 +112,7 @@ mod tbfheader;
 
 pub use crate::callback::{AppId, Callback};
 pub use crate::driver::Driver;
-pub use crate::grant::Grant;
+pub use crate::grant::{DynamicGrant, Grant};
 pub use crate::mem::{AppSlice, Private, Shared};
 pub use crate::platform::scheduler_timer::{SchedulerTimer, VirtualSchedulerTimer};
 pub use crate::platform::watchdog;


### PR DESCRIPTION
### Pull Request Overview

In the original code, `Allocator::alloc` returned `Owned`, a type which asserts that the memory it is pointing to is accessible.

If a capsule stores the returned `Owned` outside of an app-specific `Grant`, and then tries to access it after the app has crashed/restarted, it will access deallocated memory.

To fix this, I've changed `Allocator::alloc` to return a new type, `DynamicGrant`, which requires an `enter` call, and then exposes `Borrowed`.

This API exposes `Borrowed` rather than `Owned` as I believe it matches the nature of this `enter` function better. In particular, the value will be accessible multiple times, and the closure doesn't actually get ownership of it - only temporary access.

CC @alevy 

### Testing Strategy

I applied changes from #2053 on top of these changes, and then ran the tests from PR. Mainly, creating a temporary test capsule and app which allocate, check the results, and then re-allocate every other tick until running out of grant memory.

### TODO or Help Wanted

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
