### PR TITLE
Remove tock-registers' dependence on feature(const_fn)

### DIFF
--- a/arch/rv32i/Cargo.toml
+++ b/arch/rv32i/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2018"
 [dependencies]
 kernel = { path = "../../kernel" }
 tock-rt0 = { path = "../../libraries/tock-rt0" }
-tock-registers = { path = "../../libraries/tock-register-interface" }
 riscv-csr = { path = "../../libraries/riscv-csr" }
 
+[dependencies.tock-registers]
+path = "../../libraries/tock-register-interface"
+features = ["unstable_const_fn"]

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -5,5 +5,8 @@ authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
 edition = "2018"
 
 [dependencies]
-tock-registers = { path = "../libraries/tock-register-interface" }
 tock-cells = { path = "../libraries/tock-cells" }
+
+[dependencies.tock-registers]
+path = "../libraries/tock-register-interface"
+features = ["unstable_const_fn"]

--- a/libraries/riscv-csr/Cargo.toml
+++ b/libraries/riscv-csr/Cargo.toml
@@ -14,5 +14,6 @@ edition = "2018"
 [badges]
 travis-ci = { repository = "tock/tock", branch = "master" }
 
-[dependencies]
-tock-registers = { path = "../tock-register-interface" }
+[dependencies.tock-registers]
+path = "../tock-register-interface"
+features = ["unstable_const_fn"]

--- a/libraries/tock-register-interface/Cargo.toml
+++ b/libraries/tock-register-interface/Cargo.toml
@@ -14,5 +14,9 @@ edition = "2018"
 [badges]
 travis-ci = { repository = "tock/tock", branch = "master" }
 
+[dependencies]
+const_fn = "^0.3"
+
 [features]
 no_std_unit_tests = []
+unstable_const_fn = []

--- a/libraries/tock-register-interface/src/lib.rs
+++ b/libraries/tock-register-interface/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //!
 
-#![feature(const_fn)]
+#![cfg_attr(feature = "unstable_const_fn", feature(const_fn))]
 #![no_std]
 
 pub mod macros;

--- a/libraries/tock-register-interface/src/registers.rs
+++ b/libraries/tock-register-interface/src/registers.rs
@@ -64,6 +64,8 @@ use core::fmt;
 use core::marker::PhantomData;
 use core::ops::{Add, AddAssign, BitAnd, BitOr, BitOrAssign, Not, Shl, Shr};
 
+use const_fn::const_fn;
+
 /// IntLike properties needed to read/write/modify a register.
 pub trait IntLike:
     BitAnd<Output = Self>
@@ -352,6 +354,7 @@ pub struct LocalRegisterCopy<T: IntLike, R: RegisterLongName = ()> {
 }
 
 impl<T: IntLike, R: RegisterLongName> LocalRegisterCopy<T, R> {
+    #[const_fn(feature = "unstable_const_fn")]
     pub const fn new(value: T) -> Self {
         LocalRegisterCopy {
             value: value,
@@ -437,6 +440,7 @@ pub struct InMemoryRegister<T: IntLike, R: RegisterLongName = ()> {
 }
 
 impl<T: IntLike, R: RegisterLongName> InMemoryRegister<T, R> {
+    #[const_fn(feature = "unstable_const_fn")]
     pub const fn new(value: T) -> Self {
         InMemoryRegister {
             value: UnsafeCell::new(value),
@@ -529,6 +533,7 @@ impl<T: IntLike, R: RegisterLongName> Field<T, R> {
 
 // For the Field, the mask is unshifted, ie. the LSB should always be set
 impl<R: RegisterLongName> Field<u8, R> {
+    #[const_fn(feature = "unstable_const_fn")]
     pub const fn new(mask: u8, shift: usize) -> Field<u8, R> {
         Field {
             mask: mask,
@@ -543,6 +548,7 @@ impl<R: RegisterLongName> Field<u8, R> {
 }
 
 impl<R: RegisterLongName> Field<u16, R> {
+    #[const_fn(feature = "unstable_const_fn")]
     pub const fn new(mask: u16, shift: usize) -> Field<u16, R> {
         Field {
             mask: mask,
@@ -557,6 +563,7 @@ impl<R: RegisterLongName> Field<u16, R> {
 }
 
 impl<R: RegisterLongName> Field<u32, R> {
+    #[const_fn(feature = "unstable_const_fn")]
     pub const fn new(mask: u32, shift: usize) -> Field<u32, R> {
         Field {
             mask: mask,
@@ -571,6 +578,7 @@ impl<R: RegisterLongName> Field<u32, R> {
 }
 
 impl<R: RegisterLongName> Field<u64, R> {
+    #[const_fn(feature = "unstable_const_fn")]
     pub const fn new(mask: u64, shift: usize) -> Field<u64, R> {
         Field {
             mask: mask,
@@ -598,6 +606,7 @@ pub struct FieldValue<T: IntLike, R: RegisterLongName> {
 // math isn't treated as const when the type is generic.
 // Tracking issue: https://github.com/rust-lang/rfcs/pull/2632
 impl<R: RegisterLongName> FieldValue<u8, R> {
+    #[const_fn(feature = "unstable_const_fn")]
     pub const fn new(mask: u8, shift: usize, value: u8) -> Self {
         FieldValue {
             mask: mask << shift,
@@ -614,6 +623,7 @@ impl<R: RegisterLongName> From<FieldValue<u8, R>> for u8 {
 }
 
 impl<R: RegisterLongName> FieldValue<u16, R> {
+    #[const_fn(feature = "unstable_const_fn")]
     pub const fn new(mask: u16, shift: usize, value: u16) -> Self {
         FieldValue {
             mask: mask << shift,
@@ -630,6 +640,7 @@ impl<R: RegisterLongName> From<FieldValue<u16, R>> for u16 {
 }
 
 impl<R: RegisterLongName> FieldValue<u32, R> {
+    #[const_fn(feature = "unstable_const_fn")]
     pub const fn new(mask: u32, shift: usize, value: u32) -> Self {
         FieldValue {
             mask: mask << shift,
@@ -646,6 +657,7 @@ impl<R: RegisterLongName> From<FieldValue<u32, R>> for u32 {
 }
 
 impl<R: RegisterLongName> FieldValue<u64, R> {
+    #[const_fn(feature = "unstable_const_fn")]
     pub const fn new(mask: u64, shift: usize, value: u64) -> Self {
         FieldValue {
             mask: mask << shift,


### PR DESCRIPTION
### Pull Request Overview

This pull request aims to remove **tock-registers**' dependence on `feature(const_fn)` by conditionally switching between `fn` and `const fn` based on a new `unstable_const_fn` crate feature, instead of enforcing the latter (and thus `feature(const_fn)`).

Since **tock-registers** is available as a stand-alone library crate this change is desirable, even if the effect on **tock** as a whole is negligible, as it removes the nightly-enforcing use of `feature(const_fn)`, allowing the use of **tocks-registers** (or the related [**rust-embedded/register-rs**](https://crates.io/crates/register) crate) in projects using stable Rust.

To achieve this I added a dependency for the [`const_fn`](https://crates.io/crates/const_fn) crate, which then allows for conveniently decorating `const fn`s with `#[const_fn(feature = "unstable_const_fn")]`, instead of the more involved alternative of providing two copies of the same function, each with corresponding  `#[cfg(feature = "unstable_const_fn")]` &  `#[cfg(not(feature = "unstable_const_fn"))]` conditional compilation guards.

This causes the `const fn` in the **tock-registers** crate to compile to `const fn` if the `unstable_const_fn` feature is enabled, otherwise just `fn`.

### Testing Strategy

This pull request was tested by...

Building `tock-registers` with the following configurations has the expected results:

| Command                                               | Compiles? |
| ----------------------------------------------------- | --------- |
| `cargo +stable check --features "unstable_const_fn"`  | NO        |
| `cargo +stable check`                                 | YES       |
| `cargo +nightly check --features "unstable_const_fn"` | YES       |
| `cargo +nightly check --features "unstable_const_fn"` | YES       |

While building `tock` with `cargo check` does not break.

### TODO or Help Wanted

This pull request still needs to resolve the following open questions:

#### Open Questions

1. **Use proc-macro dependency or write and use own macro by example?**

   The pull request currently introduces a dependency for a crate that has so far only had 12 versions published and 1,820 downloads (94 commits; last from 2 months ago).

   If you think this is too much a risk, then alternatively one could use a [macro by example](https://stackoverflow.com/questions/49479854/how-do-i-change-a-functions-qualifiers-via-conditional-compilation) instead, which would change things from this:

   ```rust
   #[const_fn(feature = "unstable_const_fn")]`
   const fn foo(...) {
       ...
   }
   ```

   … to this:

   ```rust
   maybe_const_fn! {
       const fn foo(...) {
           ...
       }
   }
   ```

   … effectively trading convenience for reliability & trust.

   

   It is worth noting however that either way the use of such "hacks" would become obsolete (and thus could be removed without breaking, since `fn` -> `const fn` is a non-breaking change) as soon as the required subset of `const_fn` is stable.

2. **Make `unstable_const_fn` a default feature?**

   It is my understanding that while **tock-registers** is published as a stand-alone library crate it is considered mostly an internal dependency.

   As such (and in order to conform to the idiomatic "opt-in to experimental stuff" pattern of Rust) I decided to _not_ make `unstable_const_fn` a default feature, and instead chose to update the *internal* dependencies of **tock** like so:

   ```toml
   [dependencies.tock-registers]
   ...
   features = ["unstable_const_fn"]
   ```

   This however may lead to breakage for depending crates, in case they are actually making use of the existing `const fn`s in a `const` context.

   However:

   - according to [crates.io](https://crates.io/) the [only crate dependent on tocks-registers](https://crates.io/crates/tock-registers/reverse_dependencies) is [**rust-embedded/register-rs**](https://crates.io/crates/register), which is merely a thin name-erasing shim around **tocks-registers** anyway, and could thus easily be updated accordingly.
   - **tocks-registers** is currently at `0.5.0`. As such we actually could just release it as `0.6.0`, taking the breaking change as `0.x`-releases are considered breaking anyway.

#### TODO:

- [ ] Bump version to `0.6.0` & update internal dependencies

****

### Documentation Updated

- [x] ~~Updated the relevant files in `/docs`~~, or <u>no updates are required</u>.

### Formatting

- [x] Ran `make prepush`.