### PR TITLE
kernel: return correct time used

### DIFF
--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -834,7 +834,7 @@ impl Kernel {
                 // so we protect against that by checking for the expiration here. Checking
                 // the return reason is insufficient because it is possible for the timer to expire
                 // after the process has returned to the kernel but before these lines are reached.
-                Some(0)
+                Some(timeslice)
             } else {
                 Some(timeslice - remaining)
             }


### PR DESCRIPTION
If the timeslice is used up, return the total timeslice length not the amount of time remaining.




### Testing Strategy

This pull request was tested by running imix+whileone on imix.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
