### PR TITLE
Ft6x06 touch status fix and impoved report efficency

### DIFF
--- a/capsules/src/touch.rs
+++ b/capsules/src/touch.rs
@@ -12,7 +12,6 @@
 //! ```
 
 use core::mem;
-// use kernel::debug;
 use kernel::hil;
 use kernel::hil::screen::ScreenRotation;
 use kernel::hil::touch::{GestureEvent, TouchEvent, TouchStatus};
@@ -30,6 +29,9 @@ pub struct App {
     events_buffer: Option<AppSlice<Shared, u8>>,
     ack: bool,
     dropped_events: usize,
+    x: u16,
+    y: u16,
+    status: usize,
 }
 
 impl Default for App {
@@ -41,6 +43,9 @@ impl Default for App {
             events_buffer: None,
             ack: true,
             dropped_events: 0,
+            x: 0,
+            y: 0,
+            status: 3,
         }
     }
 }
@@ -157,24 +162,30 @@ impl<'a> hil::touch::TouchClient for Touch<'a> {
         // );
         for app in self.apps.iter() {
             app.enter(|app, _| {
-                app.touch_callback.map(|mut callback| {
-                    let event_id = match event.status {
-                        TouchStatus::Released => 0,
-                        TouchStatus::Pressed => 1,
-                    };
-                    let pressure_size = match event.pressure {
-                        Some(pressure) => (pressure as usize) << 16,
-                        None => 0,
-                    } | match event.size {
-                        Some(size) => size as usize,
-                        None => 0,
-                    };
-                    callback.schedule(
-                        event_id,
-                        (event.x as usize) << 16 | event.y as usize,
-                        pressure_size,
-                    );
-                })
+                let event_status = match event.status {
+                    TouchStatus::Released => 0,
+                    TouchStatus::Pressed => 1,
+                    TouchStatus::Moved => 2,
+                };
+                if app.x != event.x || app.y != event.y || app.status != event_status {
+                    app.x = event.x;
+                    app.y = event.y;
+                    app.status = event_status;
+                    app.touch_callback.map(|mut callback| {
+                        let pressure_size = match event.pressure {
+                            Some(pressure) => (pressure as usize) << 16,
+                            None => 0,
+                        } | match event.size {
+                            Some(size) => size as usize,
+                            None => 0,
+                        };
+                        callback.schedule(
+                            event_status,
+                            (event.x as usize) << 16 | event.y as usize,
+                            pressure_size,
+                        );
+                    });
+                }
             });
         }
     }
@@ -205,6 +216,7 @@ impl<'a> hil::touch::MultiTouchClient for Touch<'a> {
                                 let event_status = match event.status {
                                     TouchStatus::Released => 0,
                                     TouchStatus::Pressed => 1,
+                                    TouchStatus::Moved => 2,
                                 };
                                 // debug!(
                                 //     " multitouch {:?} x {} y {} size {:?} pressure {:?}",
@@ -282,10 +294,10 @@ impl<'a> Driver for Touch<'a> {
             // allow a buffer for the multi touch
             // buffer data format
             //  0         1           2                  4                  6           7             8         ...
-            // +---------+-----------+------------------+------------------+-----------+-------------+--------- ...
+            // +---------+-----------+------------------+------------------+-----------+---------------+--------- ...
             // | id (u8) | type (u8) | x (u16)          | y (u16)          | size (u8) | pressure (u8) |          ...
-            // +---------+-----------+------------------+------------------+-----------+-------------+--------- ...
-            // | Touch 0                                                                             | Touch 1  ...
+            // +---------+-----------+------------------+------------------+-----------+---------------+--------- ...
+            // | Touch 0                                                                               | Touch 1  ...
             2 => {
                 if self.multi_touch.is_some() {
                     self.apps
@@ -356,6 +368,20 @@ impl<'a> Driver for Touch<'a> {
             // This driver exists.
             {
                 ReturnCode::SUCCESS
+            }
+
+            // number of touches
+            100 => {
+                let num_touches = if let Some(multi_touch) = self.multi_touch {
+                    multi_touch.get_num_touches()
+                } else {
+                    if self.touch.is_some() {
+                        1
+                    } else {
+                        0
+                    }
+                };
+                ReturnCode::SuccessWithValue { value: num_touches }
             }
 
             _ => ReturnCode::ENOSUPPORT,

--- a/capsules/src/touch.rs
+++ b/capsules/src/touch.rs
@@ -22,6 +22,15 @@ use kernel::{AppId, AppSlice, Callback, Driver, Grant, Shared};
 use crate::driver;
 pub const DRIVER_NUM: usize = driver::NUM::Touch as usize;
 
+fn touch_status_to_number(status: &TouchStatus) -> usize {
+    match status {
+        TouchStatus::Released => 0,
+        TouchStatus::Pressed => 1,
+        TouchStatus::Moved => 2,
+        TouchStatus::Unstarted => 3,
+    }
+}
+
 pub struct App {
     touch_callback: Option<Callback>,
     gesture_callback: Option<Callback>,
@@ -162,11 +171,7 @@ impl<'a> hil::touch::TouchClient for Touch<'a> {
         // );
         for app in self.apps.iter() {
             app.enter(|app, _| {
-                let event_status = match event.status {
-                    TouchStatus::Released => 0,
-                    TouchStatus::Pressed => 1,
-                    TouchStatus::Moved => 2,
-                };
+                let event_status = touch_status_to_number(&event.status);
                 if app.x != event.x || app.y != event.y || app.status != event_status {
                     app.x = event.x;
                     app.y = event.y;
@@ -213,11 +218,7 @@ impl<'a> hil::touch::MultiTouchClient for Touch<'a> {
                             for event_index in 0..num {
                                 let mut event = touch_events[event_index].clone();
                                 self.update_rotation(&mut event);
-                                let event_status = match event.status {
-                                    TouchStatus::Released => 0,
-                                    TouchStatus::Pressed => 1,
-                                    TouchStatus::Moved => 2,
-                                };
+                                let event_status = touch_status_to_number(&event.status);
                                 // debug!(
                                 //     " multitouch {:?} x {} y {} size {:?} pressure {:?}",
                                 //     event.status, event.x, event.y, event.size, event.pressure

--- a/capsules/src/touch.rs
+++ b/capsules/src/touch.rs
@@ -54,7 +54,7 @@ impl Default for App {
             dropped_events: 0,
             x: 0,
             y: 0,
-            status: 3,
+            status: touch_status_to_number(&TouchStatus::Unstarted),
         }
     }
 }

--- a/kernel/src/hil/touch.rs
+++ b/kernel/src/hil/touch.rs
@@ -5,6 +5,7 @@ use crate::ReturnCode;
 /// Touch Event Status
 #[derive(Debug, Copy, Clone)]
 pub enum TouchStatus {
+    Unstarted,
     Pressed,
     Released,
     Moved,

--- a/kernel/src/hil/touch.rs
+++ b/kernel/src/hil/touch.rs
@@ -7,6 +7,7 @@ use crate::ReturnCode;
 pub enum TouchStatus {
     Pressed,
     Released,
+    Moved,
 }
 
 /// Gesture event


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes a bug in ft6x06 when reporting the touch status. It also reports touches more efficiently to the user land, scheduling a callback only when the position or status changes.

### Testing Strategy

This pull request was tested using an stm32f412g discovery.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
