### PR TITLE
kernel: sched: add and update comments

### DIFF
--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -1,7 +1,7 @@
 //! Tock's central kernel logic and scheduler trait.
 //!
-//! Also defines several utility functions to reduce repeated
-//! code between different scheduler implementations.
+//! Also defines several utility functions to reduce duplicated code between
+//! different scheduler implementations.
 
 pub(crate) mod cooperative;
 pub(crate) mod mlfq;
@@ -28,21 +28,24 @@ use crate::process::{self, Task};
 use crate::returncode::ReturnCode;
 use crate::syscall::{ContextSwitchReason, Syscall};
 
-/// Skip re-scheduling a process if its quanta is nearly exhausted
+/// Threshold in microseconds to consider a process's timeslice to be exhausted.
+/// That is, Tock will skip re-scheduling a process if its remaining timeslice
+/// is less than this threshold.
 pub(crate) const MIN_QUANTA_THRESHOLD_US: u32 = 500;
 
 /// Trait which any scheduler must implement.
 pub trait Scheduler<C: Chip> {
     /// Decide which process to run next.
     ///
-    /// The scheduler must decide whether to run a process, and if so, which one.
-    /// If the scheduler chooses not to run a process, it can request that the chip
-    /// enter sleep mode.
+    /// The scheduler must decide whether to run a process, and if so, which
+    /// one. If the scheduler chooses not to run a process, it can request that
+    /// the chip enter sleep mode.
     ///
-    /// If the scheduler selects a process to run it must provide its `AppId` and an optional
-    /// timeslice length in microseconds to provide to that process. If the timeslice is `None`,
-    /// the process will be run cooperatively (i.e. without preemption). Otherwise the process
-    /// will run with a timeslice set to the specified length.
+    /// If the scheduler selects a process to run it must provide its `AppId`
+    /// and an optional timeslice length in microseconds to provide to that
+    /// process. If the timeslice is `None`, the process will be run
+    /// cooperatively (i.e. without preemption). Otherwise the process will run
+    /// with a timeslice set to the specified length.
     fn next(&self, kernel: &Kernel) -> SchedulingDecision;
 
     /// Inform the scheduler of why the last process stopped executing, and how
@@ -50,17 +53,17 @@ pub trait Scheduler<C: Chip> {
     /// if the the scheduler requested this process be run cooperatively.
     fn result(&self, result: StoppedExecutingReason, execution_time_us: Option<u32>);
 
-    /// Tell the scheduler to execute kernel work such as interrupt bottom halves
-    /// and dynamic deferred calls. Most schedulers will use this default
+    /// Tell the scheduler to execute kernel work such as interrupt bottom
+    /// halves and dynamic deferred calls. Most schedulers will use this default
     /// implementation, but schedulers which at times wish to defer interrupt
     /// handling will reimplement it.
     ///
-    /// Providing this interface allows schedulers to fully manage how
-    /// the main kernel loop executes. For example, a more advanced
-    /// scheduler that attempts to help processes meet their deadlines may
-    /// need to defer bottom half interrupt handling or to selectively service
-    /// certain interrupts. Or, a power aware scheduler may want to selectively
-    /// choose what work to complete at any time to meet power requirements.
+    /// Providing this interface allows schedulers to fully manage how the main
+    /// kernel loop executes. For example, a more advanced scheduler that
+    /// attempts to help processes meet their deadlines may need to defer bottom
+    /// half interrupt handling or to selectively service certain interrupts.
+    /// Or, a power aware scheduler may want to selectively choose what work to
+    /// complete at any time to meet power requirements.
     ///
     /// Custom implementations of this function must be very careful, however,
     /// as this function is called in the core kernel loop.
@@ -70,9 +73,9 @@ pub trait Scheduler<C: Chip> {
     }
 
     /// Ask the scheduler whether to take a break from executing userspace
-    /// processes to handle kernel tasks. Most schedulers will use this
-    /// default implementation, which always prioritizes kernel work, but
-    /// schedulers that wish to defer interrupt handling may reimplement it.
+    /// processes to handle kernel tasks. Most schedulers will use this default
+    /// implementation, which always prioritizes kernel work, but schedulers
+    /// that wish to defer interrupt handling may reimplement it.
     unsafe fn do_kernel_work_now(&self, chip: &C) -> bool {
         chip.has_pending_interrupts()
             || DynamicDeferredCall::global_instance_calls_pending().unwrap_or(false)
@@ -80,18 +83,18 @@ pub trait Scheduler<C: Chip> {
 
     /// Ask the scheduler whether to continue trying to execute a process.
     ///
-    /// Once a process is scheduled the kernel will try to execute it until it has no more
-    /// work to do or exhausts its timeslice. The kernel will call this function before
-    /// every loop to check with the scheduler if it wants to continue trying to execute
-    /// this process.
+    /// Once a process is scheduled the kernel will try to execute it until it
+    /// has no more work to do or exhausts its timeslice. The kernel will call
+    /// this function before every loop to check with the scheduler if it wants
+    /// to continue trying to execute this process.
     ///
-    /// Most
-    /// schedulers will use this default implementation, which causes the `do_process()`
-    /// loop to return if there are interrupts or deferred calls that need to be serviced.
-    /// However, schedulers which wish to defer interrupt handling may change this, or
-    /// priority schedulers which wish to check if the execution of the current process
-    /// has caused a higher priority process to become ready (such as in the case of IPC).
-    /// If this returns `false`, then `do_process` will exit with a `KernelPreemption`.
+    /// Most schedulers will use this default implementation, which causes the
+    /// `do_process()` loop to return if there are interrupts or deferred calls
+    /// that need to be serviced. However, schedulers which wish to defer
+    /// interrupt handling may change this, or priority schedulers which wish to
+    /// check if the execution of the current process has caused a higher
+    /// priority process to become ready (such as in the case of IPC). If this
+    /// returns `false`, then `do_process` will exit with a `KernelPreemption`.
     ///
     /// `id` is the identifier of the currently active process.
     unsafe fn continue_process(&self, _id: AppId, chip: &C) -> bool {
@@ -100,16 +103,18 @@ pub trait Scheduler<C: Chip> {
     }
 }
 
-/// Enum representing the actions the scheduler can request in each call to `scheduler.next()`.
+/// Enum representing the actions the scheduler can request in each call to
+/// `scheduler.next()`.
 #[derive(Copy, Clone)]
 pub enum SchedulingDecision {
     /// Tell the kernel to run the specified process with the passed timeslice.
-    /// If `None` is passed as a timeslice, the process will be run cooperatively.
+    /// If `None` is passed as a timeslice, the process will be run
+    /// cooperatively.
     RunProcess((AppId, Option<u32>)),
 
-    /// Tell the kernel to go to sleep. Notably, if the scheduler asks the kernel
-    /// to sleep when kernel tasks are ready, the kernel will not sleep, and will
-    /// instead restart the main loop and call `next()` again.
+    /// Tell the kernel to go to sleep. Notably, if the scheduler asks the
+    /// kernel to sleep when kernel tasks are ready, the kernel will not sleep,
+    /// and will instead restart the main loop and call `next()` again.
     TrySleep,
 }
 
@@ -138,15 +143,15 @@ pub struct Kernel {
     grants_finalized: Cell<bool>,
 }
 
-/// Enum used to inform scheduler why a process stopped
-/// executing (aka why `do_process()` returned).
+/// Enum used to inform scheduler why a process stopped executing (aka why
+/// `do_process()` returned).
 #[derive(PartialEq, Eq)]
 pub enum StoppedExecutingReason {
     /// The process returned because it is no longer ready to run.
     NoWorkLeft,
 
-    /// The process faulted, and the board restart policy was configured such that
-    /// it was not restarted and there was not a kernel panic.
+    /// The process faulted, and the board restart policy was configured such
+    /// that it was not restarted and there was not a kernel panic.
     StoppedFaulted,
 
     /// The kernel stopped the process.
@@ -155,9 +160,9 @@ pub enum StoppedExecutingReason {
     /// The process was preempted because its timeslice expired.
     TimesliceExpired,
 
-    /// The process returned because it was preempted by the kernel.
-    /// This can mean that kernel work became ready (most likely because an interrupt fired
-    /// and the kernel thread needs to execute the bottom half of the
+    /// The process returned because it was preempted by the kernel. This can
+    /// mean that kernel work became ready (most likely because an interrupt
+    /// fired and the kernel thread needs to execute the bottom half of the
     /// interrupt), or because the scheduler no longer wants to execute that
     /// process.
     KernelPreemption,
@@ -447,7 +452,8 @@ impl Kernel {
 
     /// Main loop of the OS.
     ///
-    /// Most of the behavior of this loop is controlled by the `Scheduler` implementation in use.
+    /// Most of the behavior of this loop is controlled by the `Scheduler`
+    /// implementation in use.
     pub fn kernel_loop<P: Platform, C: Chip, SC: Scheduler<C>>(
         &self,
         platform: &P,
@@ -460,9 +466,14 @@ impl Kernel {
         loop {
             chip.watchdog().tickle();
             unsafe {
+                // Ask the scheduler if we should do tasks inside of the kernel,
+                // such as handle interrupts. A scheduler may want to prioritize
+                // processes instead, or there may be no kernel work to do.
                 match scheduler.do_kernel_work_now(chip) {
                     true => {
-                        // Execute kernel work
+                        // Execute kernel work. This includes handling
+                        // interrupts and is how code in the chips/ and capsules
+                        // crates is able to execute.
                         scheduler.execute_kernel_work(chip);
                     }
                     false => {
@@ -483,11 +494,15 @@ impl Kernel {
                             }
                             SchedulingDecision::TrySleep => {
                                 chip.atomic(|| {
-                                    // Cannot sleep if interrupts are pending, as on most platforms
-                                    // unhandled interrupts will wake the device. Also, if the only pending
-                                    // interrupt occurred after the scheduler decided to put the chip
-                                    // to sleep, but before this atomic section starts, the interrupt will
-                                    // not be serviced and the chip will never wake from sleep.
+                                    // Cannot sleep if interrupts are pending,
+                                    // as on most platforms unhandled interrupts
+                                    // will wake the device. Also, if the only
+                                    // pending interrupt occurred after the
+                                    // scheduler decided to put the chip to
+                                    // sleep, but before this atomic section
+                                    // starts, the interrupt will not be
+                                    // serviced and the chip will never wake
+                                    // from sleep.
                                     if !chip.has_pending_interrupts()
                                         && !DynamicDeferredCall::global_instance_calls_pending()
                                             .unwrap_or(false)
@@ -505,33 +520,37 @@ impl Kernel {
         }
     }
 
-    /// Transfer control from the scheduler to a userspace process.
-    /// This function should be called by the scheduler to run userspace
-    /// code. Notably, when processes make system calls, the system calls
-    /// are handled in the kernel, *by the kernel thread*, but that is done
-    /// by looping within this function. This function will only return
-    /// control to the scheduler if a process yields with no callbacks pending,
-    /// exceeds its timeslice, or is interrupted.
+    /// Transfer control from the kernel to a userspace process.
     ///
-    /// Depending on the particular scheduler in use, this function may act
-    /// in a few different ways. `scheduler.continue_process()` allows the
-    /// scheduler to tell the Kernel whether to continue executing the process, or
-    /// to return control to the scheduler as soon
-    /// as a kernel task becomes ready (either a bottom half interrupt handler or
-    /// dynamic deferred call), or to continue executing the userspace process
-    /// until it reaches one of the aforementioned stopping conditions.
-    /// Some schedulers may not require a systick, passing `None` for the timeslice
-    /// will use a dummy systick rather than systick of the chip in use. Schedulers can
-    /// pass a timeslice (in us) of their choice, though if the passed timeslice
-    /// is smalled than MIN_QUANTA_THRESHOLD_US the process will not execute, and
-    /// this function will return immediately.
+    /// This function is called by the main kernel loop to run userspace code.
+    /// Notably, system calls from processes are handled in the kernel, *by the
+    /// kernel thread* in this function, and the syscall return value is set for
+    /// the process immediately. Normally, a process is allowed to continue
+    /// running after calling a syscall. However, the scheduler is given an out,
+    /// as `do_process()` will check with the scheduler before re-executing the
+    /// process to allow it to return from the syscall. If a process yields with
+    /// no callbacks pending, exits, exceeds its timeslice, or is interrupted,
+    /// then `do_process()` will return.
     ///
-    /// This function returns a tuple indicating the reason the reason this function
-    /// has returned to the scheduler, and the amount of time the process spent
-    /// executing (or None if the process was run cooperatively).
-    /// Notably, time spent in this function by the kernel, executing system
-    /// calls or merely setting up the switch to/from userspace, is charged to the
-    /// process.
+    /// Depending on the particular scheduler in use, this function may act in a
+    /// few different ways. `scheduler.continue_process()` allows the scheduler
+    /// to tell the Kernel whether to continue executing the process, or to
+    /// return control to the scheduler as soon as a kernel task becomes ready
+    /// (either a bottom half interrupt handler or dynamic deferred call), or to
+    /// continue executing the userspace process until it reaches one of the
+    /// aforementioned stopping conditions. Some schedulers may not require a
+    /// scheduler timer; passing `None` for the timeslice will use a null
+    /// scheduler timer even if the chip provides a real scheduler timer.
+    /// Schedulers can pass a timeslice (in us) of their choice, though if the
+    /// passed timeslice is smalled than `MIN_QUANTA_THRESHOLD_US` the process
+    /// will not execute, and this function will return immediately.
+    ///
+    /// This function returns a tuple indicating the reason the reason this
+    /// function has returned to the scheduler, and the amount of time the
+    /// process spent executing (or `None` if the process was run
+    /// cooperatively). Notably, time spent in this function by the kernel,
+    /// executing system calls or merely setting up the switch to/from
+    /// userspace, is charged to the process.
     unsafe fn do_process<P: Platform, C: Chip, S: Scheduler<C>>(
         &self,
         platform: &P,
@@ -541,24 +560,43 @@ impl Kernel {
         ipc: Option<&crate::ipc::IPC>,
         timeslice_us: Option<u32>,
     ) -> (StoppedExecutingReason, Option<u32>) {
+        // We must use a dummy scheduler timer if the process should be executed
+        // without any timeslice restrictions. Note, a chip may not provide a
+        // real scheduler timer implementation even if a timeslice is requested.
         let scheduler_timer: &dyn SchedulerTimer = if timeslice_us.is_none() {
-            &() //dummy timer, no preemption
+            &() // dummy timer, no preemption
         } else {
             chip.scheduler_timer()
         };
+
+        // Clear the scheduler timer and then start the counter. This starts the
+        // process's timeslice. Since the kernel is still executing at this
+        // point, the scheduler timer need not have an interrupt enabled after
+        // `start()`.
         scheduler_timer.reset();
         timeslice_us.map(|timeslice| scheduler_timer.start(timeslice));
+
+        // Need to track why the process is no longer executing so that we can
+        // inform the scheduler.
         let mut return_reason = StoppedExecutingReason::NoWorkLeft;
 
+        // Since the timeslice counts both the process's execution time and the
+        // time spent in the kernel on behalf of the process (setting it up and
+        // handling its syscalls), we intend to keep running the process until
+        // it has no more work to do. We break out of this loop if the scheduler
+        // no longer wants to execute this process or if it exceeds its
+        // timeslice.
         loop {
             if scheduler_timer.has_expired()
                 || scheduler_timer.get_remaining_us() <= MIN_QUANTA_THRESHOLD_US
             {
+                // Process ran out of time while the kernel was executing.
                 process.debug_timeslice_expired();
                 return_reason = StoppedExecutingReason::TimesliceExpired;
                 break;
             }
 
+            // Check if the scheduler wishes to continue running this process.
             if !scheduler.continue_process(process.appid(), chip) {
                 return_reason = StoppedExecutingReason::KernelPreemption;
                 break;
@@ -566,9 +604,11 @@ impl Kernel {
 
             match process.get_state() {
                 process::State::Running => {
-                    // Running means that this process expects to be running,
-                    // so go ahead and set things up and switch to executing
-                    // the process.
+                    // Running means that this process expects to be running, so
+                    // go ahead and set things up and switch to executing the
+                    // process. Arming the scheduler timer instructs it to
+                    // generate an interrupt when the timeslice has expired. The
+                    // underlying timer is not affected.
                     process.setup_mpu();
                     chip.mpu().enable_mpu();
                     scheduler_timer.arm();
@@ -638,10 +678,18 @@ impl Kernel {
                                     callback_ptr,
                                     appdata,
                                 } => {
+                                    // A callback is identified as a tuple of
+                                    // the driver number and the subdriver
+                                    // number.
                                     let callback_id = CallbackId {
                                         driver_num: driver_number,
                                         subscribe_num: subdriver_number,
                                     };
+                                    // Only one callback should exist per tuple.
+                                    // To ensure that there are no pending
+                                    // callbacks with the same identifier but
+                                    // with the old function pointer, we clear
+                                    // them now.
                                     process.remove_pending_callbacks(callback_id);
 
                                     let callback = NonNull::new(callback_ptr).map(|ptr| {
@@ -751,13 +799,15 @@ impl Kernel {
                         }
                         Some(ContextSwitchReason::Interrupted) => {
                             if scheduler_timer.has_expired() {
-                                // this interrupt was a timeslice expiration,
+                                // This interrupt was a timeslice expiration.
                                 process.debug_timeslice_expired();
                                 return_reason = StoppedExecutingReason::TimesliceExpired;
                                 break;
                             }
-                            // beginning of loop determines wheter to
-                            // break to handle other processes, or continue executing
+                            // Go to the beginning of loop to determine whether
+                            // to break to handle the interrupt, continue
+                            // executing this process, or switch to another
+                            // process.
                             continue;
                         }
                         None => {
@@ -768,42 +818,43 @@ impl Kernel {
                         }
                     }
                 }
-                process::State::Yielded | process::State::Unstarted => match process.dequeue_task()
-                {
-                    // If the process is yielded it might be waiting for a
-                    // callback. If there is a task scheduled for this process
-                    // go ahead and set the process to execute it.
-                    None => break,
-                    Some(cb) => match cb {
-                        Task::FunctionCall(ccb) => {
-                            if config::CONFIG.trace_syscalls {
-                                debug!(
-                                    "[{:?}] function_call @{:#x}({:#x}, {:#x}, {:#x}, {:#x})",
-                                    process.appid(),
-                                    ccb.pc,
-                                    ccb.argument0,
-                                    ccb.argument1,
-                                    ccb.argument2,
-                                    ccb.argument3,
+                process::State::Yielded | process::State::Unstarted => {
+                    // If the process is yielded or hasn't been started it is
+                    // waiting for a callback. If there is a task scheduled for
+                    // this process go ahead and set the process to execute it.
+                    match process.dequeue_task() {
+                        None => break,
+                        Some(cb) => match cb {
+                            Task::FunctionCall(ccb) => {
+                                if config::CONFIG.trace_syscalls {
+                                    debug!(
+                                        "[{:?}] function_call @{:#x}({:#x}, {:#x}, {:#x}, {:#x})",
+                                        process.appid(),
+                                        ccb.pc,
+                                        ccb.argument0,
+                                        ccb.argument1,
+                                        ccb.argument2,
+                                        ccb.argument3,
+                                    );
+                                }
+                                process.set_process_function(ccb);
+                            }
+                            Task::IPC((otherapp, ipc_type)) => {
+                                ipc.map_or_else(
+                                    || {
+                                        assert!(
+                                            false,
+                                            "Kernel consistency error: IPC Task with no IPC"
+                                        );
+                                    },
+                                    |ipc| {
+                                        ipc.schedule_callback(process.appid(), otherapp, ipc_type);
+                                    },
                                 );
                             }
-                            process.set_process_function(ccb);
-                        }
-                        Task::IPC((otherapp, ipc_type)) => {
-                            ipc.map_or_else(
-                                || {
-                                    assert!(
-                                        false,
-                                        "Kernel consistency error: IPC Task with no IPC"
-                                    );
-                                },
-                                |ipc| {
-                                    ipc.schedule_callback(process.appid(), otherapp, ipc_type);
-                                },
-                            );
-                        }
-                    },
-                },
+                        },
+                    }
+                }
                 process::State::Fault => {
                     // We should never be scheduling a process in fault.
                     panic!("Attempted to schedule a faulty process");
@@ -811,35 +862,41 @@ impl Kernel {
                 process::State::StoppedRunning => {
                     return_reason = StoppedExecutingReason::Stopped;
                     break;
-                    // Do nothing
                 }
                 process::State::StoppedYielded => {
                     return_reason = StoppedExecutingReason::Stopped;
                     break;
-                    // Do nothing
                 }
                 process::State::StoppedFaulted => {
                     return_reason = StoppedExecutingReason::StoppedFaulted;
                     break;
-                    // Do nothing
                 }
             }
         }
+
+        // Check how much time the process used while it was executing, and
+        // return the value so we can provide it to the scheduler.
         let time_executed_us = timeslice_us.map_or(None, |timeslice| {
-            let remaining = scheduler_timer.get_remaining_us();
+            // Note, we cannot call `.has_expired()` again if it has previously
+            // returned `true`, so we _must_ check the return reason first.
             if return_reason == StoppedExecutingReason::TimesliceExpired
                 || scheduler_timer.has_expired()
             {
-                // get_remaining_us() will return an invalid value after a timeslice expiration,
-                // so we protect against that by checking for the expiration here. Checking
-                // the return reason is insufficient because it is possible for the timer to expire
-                // after the process has returned to the kernel but before these lines are reached.
+                // Note we cannot call `.get_remaining_us()` as it will return
+                // an invalid value after a timeslice expiration. Instead, we
+                // just return the original length of the timeslice.
                 Some(timeslice)
             } else {
+                let remaining = scheduler_timer.get_remaining_us();
                 Some(timeslice - remaining)
             }
         });
+
+        // Reset the scheduler timer in case it unconditionally triggers
+        // interrupts upon expiration. We do not want it to expire while the
+        // chip is sleeping, for example.
         scheduler_timer.reset();
+
         (return_reason, time_executed_us)
     }
 }

--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -542,7 +542,7 @@ impl Kernel {
     /// scheduler timer; passing `None` for the timeslice will use a null
     /// scheduler timer even if the chip provides a real scheduler timer.
     /// Schedulers can pass a timeslice (in us) of their choice, though if the
-    /// passed timeslice is smalled than `MIN_QUANTA_THRESHOLD_US` the process
+    /// passed timeslice is smaller than `MIN_QUANTA_THRESHOLD_US` the process
     /// will not execute, and this function will return immediately.
     ///
     /// This function returns a tuple indicating the reason the reason this

--- a/kernel/src/sched/cooperative.rs
+++ b/kernel/src/sched/cooperative.rs
@@ -1,10 +1,15 @@
 //! Cooperative Scheduler for Tock
 //!
-//! When hardware interrupts occur while a userspace process is executing,
-//! this scheduler executes the top half of the interrupt,
-//! and then stops executing the userspace process immediately and handles the bottom
-//! half of the interrupt. However it then continues executing the same userspace process
-//! that was executing. This scheduler overwrites the systick
+//! This scheduler runs all processes in a round-robin fashion, but does not use
+//! a scheduler timer to enforce process timeslices. That is, all processes are
+//! run cooperatively. Processes are run until they yield or stop executing
+//! (i.e. they crash or exit).
+//!
+//! When hardware interrupts occur while a userspace process is executing, this
+//! scheduler executes the top half of the interrupt, and then stops executing
+//! the userspace process immediately and handles the bottom half of the
+//! interrupt. However it then continues executing the same userspace process
+//! that was executing.
 
 use crate::callback::AppId;
 use crate::common::list::{List, ListLink, ListNode};

--- a/kernel/src/sched/mlfq.rs
+++ b/kernel/src/sched/mlfq.rs
@@ -1,18 +1,21 @@
 //! Multilevel feedback queue scheduler for Tock
 //!
 //! Based on the MLFQ rules described in "Operating Systems: Three Easy Pieces"
-//! By Remzi H. Arpaci-Dusseau and Andrea C. Arpaci-Dusseau
+//! by Remzi H. Arpaci-Dusseau and Andrea C. Arpaci-Dusseau.
 //!
 //! This scheduler can be summarized by the following rules:
 //!
-//! Rule 1: If Priority(A) > Priority(B), and both are ready, A runs (B doesn’t).
-//! Rule 2: If Priority(A) = Priority(B), A & B run in round-robin fashion using the
-//!         time slice (quantum length) of the given queue.
-//! Rule 3: When a job enters the system, it is placed at the highest priority (the topmost queue).
-//! Rule 4: Once a job uses up its time allotment at a given level (regardless of how
-//!         many times it has given up the CPU), its priority is reduced
-//!         (i.e., it moves down one queue).
-//! Rule 5: After some time period S, move all the jobs in the system to the topmost queue.
+//! - Rule 1: If Priority(A) > Priority(B), and both are ready, A runs (B
+//!           doesn't).
+//! - Rule 2: If Priority(A) = Priority(B), A & B run in round-robin fashion
+//!           using the time slice (quantum length) of the given queue.
+//! - Rule 3: When a job enters the system, it is placed at the highest priority
+//!           (the topmost queue).
+//! - Rule 4: Once a job uses up its time allotment at a given level (regardless
+//!           of how many times it has given up the CPU), its priority is
+//!           reduced (i.e., it moves down one queue).
+//! - Rule 5: After some time period S, move all the jobs in the system to the
+//!           topmost queue.
 
 use crate::callback::AppId;
 use crate::common::list::{List, ListLink, ListNode};

--- a/kernel/src/sched/priority.rs
+++ b/kernel/src/sched/priority.rs
@@ -1,13 +1,14 @@
-//! Preemptive Priority Scheduler for Tock
+//! Fixed Priority Scheduler for Tock
 //!
-//! This scheduler allows for boards to set the priority of processes at boot,
-//! and runs the highest priority process available at any point in time.
-//! Kernel tasks (bottom half interrupt handling / deferred call handling)
-//! always take priority over userspace processes.
-//! Process priority is defined by the order the process appears in the PROCESSES
-//! array. Notably, there is no need to enforce timeslices, as it is impossible
-//! for a process running to not be the highest priority process at any point
-//! without the process being descheduled (thanks to the check in leave_do_process()).
+//! This scheduler assigns priority to processes based on their order in the
+//! `PROCESSES` array, and runs the highest priority process available at any
+//! point in time. Kernel tasks (bottom half interrupt handling / deferred call
+//! handling) always take priority over userspace processes.
+//!
+//! Notably, there is no need to enforce timeslices, as it is impossible for a
+//! process running to not be the highest priority process at any point while it
+//! is running. The only way for a process to longer be the highest priority is
+//! for an interrupt to occur, which will cause the process to stop running.
 
 use crate::callback::AppId;
 use crate::common::cells::OptionalCell;
@@ -15,14 +16,13 @@ use crate::common::dynamic_deferred_call::DynamicDeferredCall;
 use crate::platform::Chip;
 use crate::sched::{Kernel, Scheduler, SchedulingDecision, StoppedExecutingReason};
 
-/// Preemptive Priority Scheduler
+/// Priority scheduler based on the order of processes in the `PROCESSES` array.
 pub struct PrioritySched {
     kernel: &'static Kernel,
-    running: OptionalCell<AppId>, // tracks currently executing process
+    running: OptionalCell<AppId>,
 }
 
 impl PrioritySched {
-    /// How long a process can run before being pre-empted
     pub const fn new(kernel: &'static Kernel) -> Self {
         Self {
             kernel,
@@ -37,9 +37,9 @@ impl<C: Chip> Scheduler<C> for PrioritySched {
             // No processes ready
             SchedulingDecision::TrySleep
         } else {
-            // Iterates in-order through the process array, always running
-            // the first process it finds that is ready to run. This means
-            // that processes with higher
+            // Iterates in-order through the process array, always running the
+            // first process it finds that is ready to run. This enforces the
+            // priorities of all processes.
             let next = self
                 .kernel
                 .get_process_iter()

--- a/kernel/src/sched/round_robin.rs
+++ b/kernel/src/sched/round_robin.rs
@@ -1,15 +1,18 @@
 //! Round Robin Scheduler for Tock
+//!
 //! This scheduler is specifically a Round Robin Scheduler with Interrupts.
 //!
 //! See: https://www.eecs.umich.edu/courses/eecs461/lecture/SWArchitecture.pdf
 //! for details.
-//! When hardware interrupts occur while a userspace process is executing,
-//! this scheduler executes the top half of the interrupt,
-//! and then stops executing the userspace process immediately and handles the bottom
-//! half of the interrupt. This design decision was made to mimic the behavior of the
+//!
+//! When hardware interrupts occur while a userspace process is executing, this
+//! scheduler executes the top half of the interrupt, and then stops executing
+//! the userspace process immediately and handles the bottom half of the
+//! interrupt. This design decision was made to mimic the behavior of the
 //! original Tock scheduler. In order to ensure fair use of timeslices, when
-//! userspace processes are interrupted the systick is paused, and the same process
-//! is resumed with the same systick value from when it was interrupted.
+//! userspace processes are interrupted the scheduler timer is paused, and the
+//! same process is resumed with the same scheduler timer value from when it was
+//! interrupted.
 
 use crate::callback::AppId;
 use crate::common::list::{List, ListLink, ListNode};


### PR DESCRIPTION
Slight tweak to how process time used is calculated.

### Pull Request Overview

This pull request mostly just adds comments to sched. I think this code is has been looked at a fair bit recently, and its worth clearly explaining what is going on for anyone interested in reading through the main kernel loop.

I did change how time used is calculated, as the comments didn't quite seem to match the code.


### Testing Strategy

travis? Mostly just comments.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
