### PR TITLE
schedulers: store references to slots in processes array instead of AppIds

### DIFF
--- a/boards/components/src/sched/mlfq.rs
+++ b/boards/components/src/sched/mlfq.rs
@@ -23,30 +23,24 @@ macro_rules! mlfq_component_helper {
         static mut BUF1: MaybeUninit<VirtualMuxAlarm<'static, $A>> = MaybeUninit::uninit();
         static mut BUF2: MaybeUninit<MLFQSched<'static, VirtualMuxAlarm<'static, $A>>> =
             MaybeUninit::uninit();
-        (
-            &mut BUF1,
-            &mut BUF2,
-            static_init!([Option<MLFQProcessNode<'static>>; $N], [None; $N]),
-        )
+        static mut BUF3: [MaybeUninit<MLFQProcessNode<'static>>; $N] = [MaybeUninit::uninit(); $N];
+        (&mut BUF1, &mut BUF2, &mut BUF3)
     };};
 }
 
 pub struct MLFQComponent<A: 'static + time::Alarm<'static>> {
-    board_kernel: &'static kernel::Kernel,
     alarm_mux: &'static MuxAlarm<'static, A>,
     processes: &'static [Option<&'static dyn ProcessType>],
 }
 
 impl<A: 'static + time::Alarm<'static>> MLFQComponent<A> {
     pub fn new(
-        board_kernel: &'static kernel::Kernel,
         alarm_mux: &'static MuxAlarm<'static, A>,
         processes: &'static [Option<&'static dyn ProcessType>],
     ) -> MLFQComponent<A> {
         MLFQComponent {
-            board_kernel: board_kernel,
-            alarm_mux: alarm_mux,
-            processes: processes,
+            alarm_mux,
+            processes,
         }
     }
 }
@@ -55,7 +49,7 @@ impl<A: 'static + time::Alarm<'static>> Component for MLFQComponent<A> {
     type StaticInput = (
         &'static mut MaybeUninit<VirtualMuxAlarm<'static, A>>,
         &'static mut MaybeUninit<MLFQSched<'static, VirtualMuxAlarm<'static, A>>>,
-        &'static mut [Option<MLFQProcessNode<'static>>],
+        &'static mut [MaybeUninit<MLFQProcessNode<'static>>],
     );
     type Output = &'static mut MLFQSched<'static, VirtualMuxAlarm<'static, A>>;
 
@@ -69,19 +63,15 @@ impl<A: 'static + time::Alarm<'static>> Component for MLFQComponent<A> {
         let scheduler = static_init_half!(
             sched_buf,
             MLFQSched<'static, VirtualMuxAlarm<'static, A>>,
-            MLFQSched::new(self.board_kernel, scheduler_alarm)
+            MLFQSched::new(scheduler_alarm)
         );
-        let num_procs = proc_nodes.len();
-
-        for i in 0..num_procs {
-            if self.processes[i].is_some() {
-                proc_nodes[i] = Some(MLFQProcessNode::new(self.processes[i].unwrap().appid()));
-            }
-        }
-        for i in 0..num_procs {
-            if self.processes[i].is_some() {
-                scheduler.processes[0].push_head(proc_nodes[i].as_ref().unwrap());
-            }
+        for (i, node) in proc_nodes.iter_mut().enumerate() {
+            let init_node = static_init_half!(
+                node,
+                MLFQProcessNode<'static>,
+                MLFQProcessNode::new(&self.processes[i])
+            );
+            scheduler.processes[0].push_head(init_node);
         }
         scheduler
     }

--- a/boards/components/src/sched/round_robin.rs
+++ b/boards/components/src/sched/round_robin.rs
@@ -48,14 +48,12 @@ impl Component for RoundRobinComponent {
         let scheduler = static_init!(RoundRobinSched<'static>, RoundRobinSched::new());
 
         for (i, node) in buf.iter_mut().enumerate() {
-            if self.processes[i].is_some() {
-                let init_node = static_init_half!(
-                    node,
-                    RoundRobinProcessNode<'static>,
-                    RoundRobinProcessNode::new(self.processes[i].unwrap().appid(),)
-                );
-                scheduler.processes.push_head(init_node);
-            }
+            let init_node = static_init_half!(
+                node,
+                RoundRobinProcessNode<'static>,
+                RoundRobinProcessNode::new(&self.processes[i])
+            );
+            scheduler.processes.push_head(init_node);
         }
         scheduler
     }


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes #2063 , by modifying each scheduler that stored a local copy of an AppId to instead store a pointer to a slot in the processes array. It also modifies initialization of these lists such that each scheduler has a list of all slots in the process array, and simply skips empty slots when scheduling. This makes restartable apps work again, and is also a first step towards supporting dynamically loaded apps (I imagine that will also involve replacing `Option<&'static dyn ProcessType>` with `OptionalCell<&'static dyn ProcessType>`).

This PR also changes the components for the mlfq and cooperative scheduler to include improvements I had made to the round robin component.

One downside of this approach is that if a process moves to a new slot in the app array, the scheduler state associated with that process is lost (i.e. position in the round robin queue is changed, and for mlfq the tracker of total CPU time used by the process during the current scheduling period will be inaccurate until the next resurrection). For the current schedulers I think this is fine, as it seems reasonable that moving processes around in the array might reset some state temporarily. If in the future schedulers are added that need to track state for all-time, we may want to reconsider this.

### Testing Strategy

This pull request was tested by running two apps with each scheduler on Imix, and verifying that process restarts work using the process console.


### TODO or Help Wanted

I ended up choosing this design over alternatives due to its simplicity. Eventually, we may want to move to the Kernel owning a generic `ProcessCollection` type, but doing this without adding additional trait-object indirection/overhead feels difficult.

### Documentation Updated

- [x] No updates are required

### Formatting

- [x] Ran `make prepush`.
