### PR TITLE
Board-based instantiation of chip drivers and interrupt --> driver mapping for Apollo3 + SAM4L

### DIFF
--- a/boards/hail/src/io.rs
+++ b/boards/hail/src/io.rs
@@ -25,7 +25,10 @@ impl Write for Writer {
 
 impl IoWrite for Writer {
     fn write(&mut self, buf: &[u8]) {
-        let uart = unsafe { &mut sam4l::usart::USART0 };
+        // Here, we create a second instance of the USART0 struct.
+        // This is okay because we only call this during a panic, and
+        // we will never actually process the interrupts
+        let uart = unsafe { sam4l::usart::USART::new_usart0(CHIP.unwrap().pm) };
         let regs_manager = &sam4l::usart::USARTRegManager::panic_new(&uart);
         if !self.initialized {
             self.initialized = true;
@@ -52,14 +55,15 @@ impl IoWrite for Writer {
 #[panic_handler]
 pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
     // turn off the non panic leds, just in case
-    let led_green = &sam4l::gpio::PA[14];
+    let led_green = sam4l::gpio::GPIOPin::new(sam4l::gpio::Pin::PA14);
     led_green.enable_output();
     led_green.set();
-    let led_blue = &sam4l::gpio::PA[15];
+    let led_blue = sam4l::gpio::GPIOPin::new(sam4l::gpio::Pin::PA15);
     led_blue.enable_output();
     led_blue.set();
 
-    let led_red = &mut led::LedLow::new(&mut sam4l::gpio::PA[13]);
+    let mut red_pin = sam4l::gpio::GPIOPin::new(sam4l::gpio::Pin::PA13);
+    let led_red = &mut led::LedLow::new(&mut red_pin);
     let writer = &mut WRITER;
     debug::panic(
         &mut [led_red],

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -22,6 +22,8 @@ use kernel::hil::Controller;
 use kernel::Platform;
 #[allow(unused_imports)]
 use kernel::{create_capability, debug, debug_gpio, static_init};
+use sam4l::adc::Channel;
+use sam4l::chip::Sam4lDefaultPeripherals;
 
 /// Support routines for debugging I/O.
 ///
@@ -38,7 +40,8 @@ const NUM_PROCS: usize = 20;
 // Actual memory for holding the active process structures.
 static mut PROCESSES: [Option<&'static dyn kernel::procs::ProcessType>; NUM_PROCS] =
     [None; NUM_PROCS];
-static mut CHIP: Option<&'static sam4l::chip::Sam4l> = None;
+
+static mut CHIP: Option<&'static sam4l::chip::Sam4l<Sam4lDefaultPeripherals>> = None;
 
 /// Dummy buffer that causes the linker to reserve enough space for the stack.
 #[no_mangle]
@@ -106,65 +109,64 @@ impl Platform for Hail {
 }
 
 /// Helper function called during bring-up that configures multiplexed I/O.
-unsafe fn set_pin_primary_functions() {
+unsafe fn set_pin_primary_functions(peripherals: &Sam4lDefaultPeripherals) {
     use sam4l::gpio::PeripheralFunction::{A, B};
-    use sam4l::gpio::{PA, PB};
 
-    PA[04].configure(Some(A)); // A0 - ADC0
-    PA[05].configure(Some(A)); // A1 - ADC1
-                               // DAC/WKP mode
-    PA[06].configure(Some(A)); // DAC
-    PA[07].configure(None); //... WKP - Wakeup
-                            // // Analog Comparator Mode
-                            // PA[06].configure(Some(E)); // ACAN0 - ACIFC
-                            // PA[07].configure(Some(E)); // ACAP0 - ACIFC
-    PA[08].configure(Some(A)); // FTDI_RTS - USART0 RTS
-    PA[09].configure(None); //... ACC_INT1 - FXOS8700CQ Interrupt 1
-    PA[10].configure(None); //... unused
-    PA[11].configure(Some(A)); // FTDI_OUT - USART0 RX FTDI->SAM4L
-    PA[12].configure(Some(A)); // FTDI_IN - USART0 TX SAM4L->FTDI
-    PA[13].configure(None); //... RED_LED
-    PA[14].configure(None); //... BLUE_LED
-    PA[15].configure(None); //... GREEN_LED
-    PA[16].configure(None); //... BUTTON - User Button
-    PA[17].configure(None); //... !NRF_RESET - Reset line for nRF51822
-    PA[18].configure(None); //... ACC_INT2 - FXOS8700CQ Interrupt 2
-    PA[19].configure(None); //... unused
-    PA[20].configure(None); //... !LIGHT_INT - ISL29035 Light Sensor Interrupt
-                            // SPI Mode
-    PA[21].configure(Some(A)); // D3 - SPI MISO
-    PA[22].configure(Some(A)); // D2 - SPI MOSI
-    PA[23].configure(Some(A)); // D4 - SPI SCK
-    PA[24].configure(Some(A)); // D5 - SPI CS0
-                               // // I2C Mode
-                               // PA[21].configure(None); // D3
-                               // PA[22].configure(None); // D2
-                               // PA[23].configure(Some(B)); // D4 - TWIMS0 SDA
-                               // PA[24].configure(Some(B)); // D5 - TWIMS0 SCL
-                               // UART Mode
-    PA[25].configure(Some(B)); // RX - USART2 RXD
-    PA[26].configure(Some(B)); // TX - USART2 TXD
+    peripherals.pa[04].configure(Some(A)); // A0 - ADC0
+    peripherals.pa[05].configure(Some(A)); // A1 - ADC1
+                                           // DAC/WKP mode
+    peripherals.pa[06].configure(Some(A)); // DAC
+    peripherals.pa[07].configure(None); //... WKP - Wakeup
+                                        // // Analog Comparator Mode
+                                        // peripherals.pa[06].configure(Some(E)); // ACAN0 - ACIFC
+                                        // peripherals.pa[07].configure(Some(E)); // ACAP0 - ACIFC
+    peripherals.pa[08].configure(Some(A)); // FTDI_RTS - USART0 RTS
+    peripherals.pa[09].configure(None); //... ACC_INT1 - FXOS8700CQ Interrupt 1
+    peripherals.pa[10].configure(None); //... unused
+    peripherals.pa[11].configure(Some(A)); // FTDI_OUT - USART0 RX FTDI->SAM4L
+    peripherals.pa[12].configure(Some(A)); // FTDI_IN - USART0 TX SAM4L->FTDI
+    peripherals.pa[13].configure(None); //... RED_LED
+    peripherals.pa[14].configure(None); //... BLUE_LED
+    peripherals.pa[15].configure(None); //... GREEN_LED
+    peripherals.pa[16].configure(None); //... BUTTON - User Button
+    peripherals.pa[17].configure(None); //... !NRF_RESET - Reset line for nRF51822
+    peripherals.pa[18].configure(None); //... ACC_INT2 - FXOS8700CQ Interrupt 2
+    peripherals.pa[19].configure(None); //... unused
+    peripherals.pa[20].configure(None); //... !LIGHT_INT - ISL29035 Light Sensor Interrupt
+                                        // SPI Mode
+    peripherals.pa[21].configure(Some(A)); // D3 - SPI MISO
+    peripherals.pa[22].configure(Some(A)); // D2 - SPI MOSI
+    peripherals.pa[23].configure(Some(A)); // D4 - SPI SCK
+    peripherals.pa[24].configure(Some(A)); // D5 - SPI CS0
+                                           // // I2C Mode
+                                           // peripherals.pa[21].configure(None); // D3
+                                           // peripherals.pa[22].configure(None); // D2
+                                           // peripherals.pa[23].configure(Some(B)); // D4 - TWIMS0 SDA
+                                           // peripherals.pa[24].configure(Some(B)); // D5 - TWIMS0 SCL
+                                           // UART Mode
+    peripherals.pa[25].configure(Some(B)); // RX - USART2 RXD
+    peripherals.pa[26].configure(Some(B)); // TX - USART2 TXD
 
-    PB[00].configure(Some(A)); // SENSORS_SDA - TWIMS1 SDA
-    PB[01].configure(Some(A)); // SENSORS_SCL - TWIMS1 SCL
-                               // ADC Mode
-    PB[02].configure(Some(A)); // A2 - ADC3
-    PB[03].configure(Some(A)); // A3 - ADC4
-                               // // Analog Comparator Mode
-                               // PB[02].configure(Some(E)); // ACBN0 - ACIFC
-                               // PB[03].configure(Some(E)); // ACBP0 - ACIFC
-    PB[04].configure(Some(A)); // A4 - ADC5
-    PB[05].configure(Some(A)); // A5 - ADC6
-    PB[06].configure(Some(A)); // NRF_CTS - USART3 RTS
-    PB[07].configure(Some(A)); // NRF_RTS - USART3 CTS
-    PB[08].configure(None); //... NRF_INT - Interrupt line nRF->SAM4L
-    PB[09].configure(Some(A)); // NRF_OUT - USART3 RXD
-    PB[10].configure(Some(A)); // NRF_IN - USART3 TXD
-    PB[11].configure(None); //... D6
-    PB[12].configure(None); //... D7
-    PB[13].configure(None); //... unused
-    PB[14].configure(None); //... D0
-    PB[15].configure(None); //... D1
+    peripherals.pb[00].configure(Some(A)); // SENSORS_SDA - TWIMS1 SDA
+    peripherals.pb[01].configure(Some(A)); // SENSORS_SCL - TWIMS1 SCL
+                                           // ADC Mode
+    peripherals.pb[02].configure(Some(A)); // A2 - ADC3
+    peripherals.pb[03].configure(Some(A)); // A3 - ADC4
+                                           // // Analog Comparator Mode
+                                           // peripherals.pb[02].configure(Some(E)); // ACBN0 - ACIFC
+                                           // peripherals.pb[03].configure(Some(E)); // ACBP0 - ACIFC
+    peripherals.pb[04].configure(Some(A)); // A4 - ADC5
+    peripherals.pb[05].configure(Some(A)); // A5 - ADC6
+    peripherals.pb[06].configure(Some(A)); // NRF_CTS - USART3 RTS
+    peripherals.pb[07].configure(Some(A)); // NRF_RTS - USART3 CTS
+    peripherals.pb[08].configure(None); //... NRF_INT - Interrupt line nRF->SAM4L
+    peripherals.pb[09].configure(Some(A)); // NRF_OUT - USART3 RXD
+    peripherals.pb[10].configure(Some(A)); // NRF_IN - USART3 TXD
+    peripherals.pb[11].configure(None); //... D6
+    peripherals.pb[12].configure(None); //... D7
+    peripherals.pb[13].configure(None); //... unused
+    peripherals.pb[14].configure(None); //... D0
+    peripherals.pb[15].configure(None); //... D1
 }
 
 /// Reset Handler.
@@ -176,16 +178,27 @@ unsafe fn set_pin_primary_functions() {
 #[no_mangle]
 pub unsafe fn reset_handler() {
     sam4l::init();
+    let pm = static_init!(sam4l::pm::PowerManager, sam4l::pm::PowerManager::new());
+    let peripherals = static_init!(Sam4lDefaultPeripherals, Sam4lDefaultPeripherals::new(pm));
 
-    sam4l::pm::PM.setup_system_clock(sam4l::pm::SystemClockSource::PllExternalOscillatorAt48MHz {
-        frequency: sam4l::pm::OscillatorFrequency::Frequency16MHz,
-        startup_mode: sam4l::pm::OscillatorStartup::SlowStart,
-    });
+    pm.setup_system_clock(
+        sam4l::pm::SystemClockSource::PllExternalOscillatorAt48MHz {
+            frequency: sam4l::pm::OscillatorFrequency::Frequency16MHz,
+            startup_mode: sam4l::pm::OscillatorStartup::SlowStart,
+        },
+        &peripherals.flash_controller,
+    );
 
     // Source 32Khz and 1Khz clocks from RC23K (SAM4L Datasheet 11.6.8)
     sam4l::bpm::set_ck32source(sam4l::bpm::CK32Source::RC32K);
 
-    set_pin_primary_functions();
+    set_pin_primary_functions(peripherals);
+    peripherals.setup_dma();
+    let chip = static_init!(
+        sam4l::chip::Sam4l<Sam4lDefaultPeripherals>,
+        sam4l::chip::Sam4l::new(pm, peripherals)
+    );
+    CHIP = Some(chip);
 
     let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
 
@@ -198,13 +211,10 @@ pub unsafe fn reset_handler() {
 
     // Configure kernel debug gpios as early as possible
     kernel::debug::assign_gpios(
-        Some(&sam4l::gpio::PA[13]),
-        Some(&sam4l::gpio::PA[15]),
-        Some(&sam4l::gpio::PA[14]),
+        Some(&peripherals.pa[13]),
+        Some(&peripherals.pa[15]),
+        Some(&peripherals.pa[14]),
     );
-
-    let chip = static_init!(sam4l::chip::Sam4l, sam4l::chip::Sam4l::new());
-    CHIP = Some(chip);
 
     let dynamic_deferred_call_clients =
         static_init!([DynamicDeferredCallClientState; 2], Default::default());
@@ -215,19 +225,19 @@ pub unsafe fn reset_handler() {
     DynamicDeferredCall::set_global_instance(dynamic_deferred_caller);
 
     // Initialize USART0 for Uart
-    sam4l::usart::USART0.set_mode(sam4l::usart::UsartMode::Uart);
+    peripherals.usart0.set_mode(sam4l::usart::UsartMode::Uart);
 
     // Create a shared UART channel for the console and for kernel debug.
     let uart_mux = components::console::UartMuxComponent::new(
-        &sam4l::usart::USART0,
+        &peripherals.usart0,
         115200,
         dynamic_deferred_caller,
     )
     .finalize(());
     uart_mux.initialize();
 
-    hil::uart::Transmit::set_transmit_client(&sam4l::usart::USART0, uart_mux);
-    hil::uart::Receive::set_receive_client(&sam4l::usart::USART0, uart_mux);
+    hil::uart::Transmit::set_transmit_client(&peripherals.usart0, uart_mux);
+    hil::uart::Receive::set_receive_client(&peripherals.usart0, uart_mux);
 
     // Setup the console and the process inspection console.
     let console = components::console::ConsoleComponent::new(board_kernel, uart_mux).finalize(());
@@ -237,26 +247,25 @@ pub unsafe fn reset_handler() {
     components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
 
     // Initialize USART3 for UART for the nRF serialization link.
-    sam4l::usart::USART3.set_mode(sam4l::usart::UsartMode::Uart);
+    peripherals.usart3.set_mode(sam4l::usart::UsartMode::Uart);
     // Create the Nrf51822Serialization driver for passing BLE commands
     // over UART to the nRF51822 radio.
     let nrf_serialization = components::nrf51822::Nrf51822Component::new(
-        &sam4l::usart::USART3,
-        &sam4l::gpio::PA[17],
+        &peripherals.usart3,
+        &peripherals.pa[17],
         board_kernel,
     )
     .finalize(());
 
-    let ast = &sam4l::ast::AST;
-    let mux_alarm = components::alarm::AlarmMuxComponent::new(ast)
+    let mux_alarm = components::alarm::AlarmMuxComponent::new(&peripherals.ast)
         .finalize(components::alarm_mux_component_helper!(sam4l::ast::Ast));
-    ast.configure(mux_alarm);
+    peripherals.ast.configure(mux_alarm);
 
     let sensors_i2c = static_init!(
         MuxI2C<'static>,
-        MuxI2C::new(&sam4l::i2c::I2C1, None, dynamic_deferred_caller)
+        MuxI2C::new(&peripherals.i2c1, None, dynamic_deferred_caller)
     );
-    sam4l::i2c::I2C1.set_master_client(sensors_i2c);
+    peripherals.i2c1.set_master_client(sensors_i2c);
 
     // SI7021 Temperature / Humidity Sensor, address: 0x40
     let si7021 = components::si7021::SI7021Component::new(sensors_i2c, mux_alarm, 0x40)
@@ -280,19 +289,19 @@ pub unsafe fn reset_handler() {
         capsules::fxos8700cq::Fxos8700cq<'static>,
         capsules::fxos8700cq::Fxos8700cq::new(
             fxos8700_i2c,
-            &sam4l::gpio::PA[9],
+            &peripherals.pa[9],
             &mut capsules::fxos8700cq::BUF
         )
     );
     fxos8700_i2c.set_client(fxos8700);
-    sam4l::gpio::PA[9].set_client(fxos8700);
+    peripherals.pa[9].set_client(fxos8700);
 
     let ninedof = components::ninedof::NineDofComponent::new(board_kernel)
         .finalize(components::ninedof_component_helper!(fxos8700));
 
     // SPI
     // Set up a SPI MUX, so there can be multiple clients.
-    let mux_spi = components::spi::SpiMuxComponent::new(&sam4l::spi::SPI)
+    let mux_spi = components::spi::SpiMuxComponent::new(&peripherals.spi)
         .finalize(components::spi_mux_component_helper!(sam4l::spi::SpiHw));
     // Create the SPI system call capsule.
     let spi_syscalls = components::spi::SpiSyscallComponent::new(mux_spi, 0)
@@ -302,15 +311,15 @@ pub unsafe fn reset_handler() {
     let led = components::led::LedsComponent::new(components::led_component_helper!(
         sam4l::gpio::GPIOPin,
         (
-            &sam4l::gpio::PA[13],
+            &peripherals.pa[13],
             kernel::hil::gpio::ActivationMode::ActiveLow
         ), // Red
         (
-            &sam4l::gpio::PA[15],
+            &peripherals.pa[15],
             kernel::hil::gpio::ActivationMode::ActiveLow
         ), // Green
         (
-            &sam4l::gpio::PA[14],
+            &peripherals.pa[14],
             kernel::hil::gpio::ActivationMode::ActiveLow
         ) // Blue
     ))
@@ -322,7 +331,7 @@ pub unsafe fn reset_handler() {
         components::button_component_helper!(
             sam4l::gpio::GPIOPin,
             (
-                &sam4l::gpio::PA[16],
+                &peripherals.pa[16],
                 kernel::hil::gpio::ActivationMode::ActiveLow,
                 kernel::hil::gpio::FloatingState::PullNone
             )
@@ -332,53 +341,66 @@ pub unsafe fn reset_handler() {
 
     // Setup ADC
     let adc_channels = static_init!(
-        [&'static sam4l::adc::AdcChannel; 6],
+        [sam4l::adc::AdcChannel; 6],
         [
-            &sam4l::adc::CHANNEL_AD0, // A0
-            &sam4l::adc::CHANNEL_AD1, // A1
-            &sam4l::adc::CHANNEL_AD3, // A2
-            &sam4l::adc::CHANNEL_AD4, // A3
-            &sam4l::adc::CHANNEL_AD5, // A4
-            &sam4l::adc::CHANNEL_AD6, // A5
+            sam4l::adc::AdcChannel::new(Channel::AD0), // A0
+            sam4l::adc::AdcChannel::new(Channel::AD1), // A1
+            sam4l::adc::AdcChannel::new(Channel::AD3), // A2
+            sam4l::adc::AdcChannel::new(Channel::AD4), // A3
+            sam4l::adc::AdcChannel::new(Channel::AD5), // A4
+            sam4l::adc::AdcChannel::new(Channel::AD6), // A5
+        ]
+    );
+    // Capsule expects references inside array bc it was built assuming model in which
+    // global structs are used, so this is a bit of a hack to pass it what it wants.
+    let ref_channels = static_init!(
+        [&sam4l::adc::AdcChannel; 6],
+        [
+            &adc_channels[0],
+            &adc_channels[1],
+            &adc_channels[2],
+            &adc_channels[3],
+            &adc_channels[4],
+            &adc_channels[5],
         ]
     );
     let adc = static_init!(
         capsules::adc::AdcDedicated<'static, sam4l::adc::Adc>,
         capsules::adc::AdcDedicated::new(
-            &sam4l::adc::ADC0,
+            &peripherals.adc,
             board_kernel.create_grant(&memory_allocation_capability),
-            adc_channels,
+            ref_channels,
             &mut capsules::adc::ADC_BUFFER1,
             &mut capsules::adc::ADC_BUFFER2,
             &mut capsules::adc::ADC_BUFFER3
         )
     );
-    sam4l::adc::ADC0.set_client(adc);
+    peripherals.adc.set_client(adc);
 
     // Setup RNG
-    let rng = components::rng::RngComponent::new(board_kernel, &sam4l::trng::TRNG).finalize(());
+    let rng = components::rng::RngComponent::new(board_kernel, &peripherals.trng).finalize(());
 
     // set GPIO driver controlling remaining GPIO pins
     let gpio = components::gpio::GpioComponent::new(
         board_kernel,
         components::gpio_component_helper!(
             sam4l::gpio::GPIOPin,
-            0 => &sam4l::gpio::PB[14], // D0
-            1 => &sam4l::gpio::PB[15], // D1
-            2 => &sam4l::gpio::PB[11], // D6
-            3 => &sam4l::gpio::PB[12]  // D7
+            0 => &peripherals.pb[14], // D0
+            1 => &peripherals.pb[15], // D1
+            2 => &peripherals.pb[11], // D6
+            3 => &peripherals.pb[12]  // D7
         ),
     )
     .finalize(components::gpio_component_buf!(sam4l::gpio::GPIOPin));
 
     // CRC
-    let crc = components::crc::CrcComponent::new(board_kernel, &sam4l::crccu::CRCCU)
+    let crc = components::crc::CrcComponent::new(board_kernel, &peripherals.crccu)
         .finalize(components::crc_component_helper!(sam4l::crccu::Crccu));
 
     // DAC
     let dac = static_init!(
         capsules::dac::Dac<'static>,
-        capsules::dac::Dac::new(&sam4l::dac::DAC)
+        capsules::dac::Dac::new(&peripherals.dac)
     );
 
     // // DEBUG Restart All Apps
@@ -395,11 +417,11 @@ pub unsafe fn reset_handler() {
     //     >,
     //     capsules::debug_process_restart::DebugProcessRestart::new(
     //         board_kernel,
-    //         &sam4l::gpio::PA[16],
+    //         &peripherals.pa[16],
     //         ProcessMgmtCap
     //     )
     // );
-    // sam4l::gpio::PA[16].set_client(debug_process_restart);
+    // peripherals.pa[16].set_client(debug_process_restart);
 
     // Configure application fault policy
     let restart_policy = static_init!(
@@ -409,22 +431,22 @@ pub unsafe fn reset_handler() {
     let fault_response = kernel::procs::FaultResponse::Restart(restart_policy);
 
     let hail = Hail {
-        console: console,
-        gpio: gpio,
-        alarm: alarm,
-        ambient_light: ambient_light,
-        temp: temp,
-        humidity: humidity,
-        ninedof: ninedof,
+        console,
+        gpio,
+        alarm,
+        ambient_light,
+        temp,
+        humidity,
+        ninedof,
         spi: spi_syscalls,
         nrf51822: nrf_serialization,
-        adc: adc,
-        led: led,
-        button: button,
-        rng: rng,
+        adc,
+        led,
+        button,
+        rng,
         ipc: kernel::ipc::IPC::new(board_kernel, &memory_allocation_capability),
-        crc: crc,
-        dac: dac,
+        crc,
+        dac,
     };
 
     // Setup the UART bus for nRF51 serialization..

--- a/boards/imix/src/alarm_test.rs
+++ b/boards/imix/src/alarm_test.rs
@@ -16,19 +16,21 @@ use capsules::test::alarm_edge_cases::TestAlarmEdgeCases;
 use kernel::debug;
 use kernel::hil::time::Alarm;
 use kernel::static_init;
-use sam4l::ast::{Ast, AST};
+use sam4l::ast::Ast;
 
-pub unsafe fn run_alarm() {
+pub unsafe fn run_alarm(ast: &'static Ast) {
     debug!("Starting alarm test.");
-    let test = static_init_alarm_test();
+    let test = static_init_alarm_test(ast);
     test.run();
 }
 
-unsafe fn static_init_alarm_test() -> &'static TestAlarmEdgeCases<'static, Ast<'static>> {
+unsafe fn static_init_alarm_test(
+    ast: &'static Ast,
+) -> &'static TestAlarmEdgeCases<'static, Ast<'static>> {
     let test = static_init!(
         TestAlarmEdgeCases<'static, Ast<'static>>,
-        TestAlarmEdgeCases::new(&AST)
+        TestAlarmEdgeCases::new(ast)
     );
-    AST.set_alarm_client(test);
+    ast.set_alarm_client(test);
     test
 }

--- a/boards/imix/src/imix_components/usb.rs
+++ b/boards/imix/src/imix_components/usb.rs
@@ -22,6 +22,7 @@ use kernel::static_init;
 
 pub struct UsbComponent {
     board_kernel: &'static kernel::Kernel,
+    usbc: &'static sam4l::usbc::Usbc<'static>,
 }
 
 type UsbDevice = capsules::usb::usb_user::UsbSyscallDriver<
@@ -30,10 +31,11 @@ type UsbDevice = capsules::usb::usb_user::UsbSyscallDriver<
 >;
 
 impl UsbComponent {
-    pub fn new(board_kernel: &'static kernel::Kernel) -> UsbComponent {
-        UsbComponent {
-            board_kernel: board_kernel,
-        }
+    pub fn new(
+        board_kernel: &'static kernel::Kernel,
+        usbc: &'static sam4l::usbc::Usbc<'static>,
+    ) -> UsbComponent {
+        UsbComponent { board_kernel, usbc }
     }
 }
 
@@ -48,11 +50,11 @@ impl Component for UsbComponent {
         let usb_client = static_init!(
             capsules::usb::usbc_client::Client<'static, sam4l::usbc::Usbc<'static>>,
             capsules::usb::usbc_client::Client::new(
-                &sam4l::usbc::USBC,
+                &self.usbc,
                 capsules::usb::usbc_client::MAX_CTRL_PACKET_SIZE_SAM4L
             )
         );
-        sam4l::usbc::USBC.set_client(usb_client);
+        self.usbc.set_client(usb_client);
 
         // Configure the USB userspace driver
         let usb_driver = static_init!(

--- a/boards/imix/src/io.rs
+++ b/boards/imix/src/io.rs
@@ -25,7 +25,10 @@ impl Write for Writer {
 
 impl IoWrite for Writer {
     fn write(&mut self, buf: &[u8]) {
-        let uart = unsafe { &mut sam4l::usart::USART3 };
+        // Here, we create a second instance of the USART3 struct.
+        // This is okay because we only call this during a panic, and
+        // we will never actually process the interrupts
+        let uart = unsafe { sam4l::usart::USART::new_usart3(CHIP.unwrap().pm) };
         let regs_manager = &sam4l::usart::USARTRegManager::panic_new(&uart);
         if !self.initialized {
             self.initialized = true;
@@ -51,7 +54,8 @@ impl IoWrite for Writer {
 #[no_mangle]
 #[panic_handler]
 pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
-    let led = &mut led::LedLow::new(&mut sam4l::gpio::PC[22]);
+    let mut led_pin = sam4l::gpio::GPIOPin::new(sam4l::gpio::Pin::PC22);
+    let led = &mut led::LedLow::new(&mut led_pin);
     let writer = &mut WRITER;
     debug::panic(
         &mut [led],

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -29,6 +29,7 @@ use kernel::hil::radio::{RadioConfig, RadioData};
 use kernel::hil::Controller;
 #[allow(unused_imports)]
 use kernel::{create_capability, debug, debug_gpio, static_init};
+use sam4l::chip::Sam4lDefaultPeripherals;
 
 use components;
 use components::alarm::{AlarmDriverComponent, AlarmMuxComponent};
@@ -92,7 +93,8 @@ const FAULT_RESPONSE: kernel::procs::FaultResponse = kernel::procs::FaultRespons
 
 static mut PROCESSES: [Option<&'static dyn kernel::procs::ProcessType>; NUM_PROCS] =
     [None; NUM_PROCS];
-static mut CHIP: Option<&'static sam4l::chip::Sam4l> = None;
+
+static mut CHIP: Option<&'static sam4l::chip::Sam4l<Sam4lDefaultPeripherals>> = None;
 
 /// Dummy buffer that causes the linker to reserve enough space for the stack.
 #[no_mangle]
@@ -179,75 +181,74 @@ impl kernel::Platform for Imix {
     }
 }
 
-unsafe fn set_pin_primary_functions() {
+unsafe fn set_pin_primary_functions(peripherals: &Sam4lDefaultPeripherals) {
     use sam4l::gpio::PeripheralFunction::{A, B, C, E};
-    use sam4l::gpio::{PA, PB, PC};
 
     // Right column: Imix pin name
     // Left  column: SAM4L peripheral function
-    PA[04].configure(Some(A)); // AD0         --  ADCIFE AD0
-    PA[05].configure(Some(A)); // AD1         --  ADCIFE AD1
-    PA[06].configure(Some(C)); // EXTINT1     --  EIC EXTINT1
-    PA[07].configure(Some(A)); // AD1         --  ADCIFE AD2
-    PA[08].configure(None); //... RF233 IRQ   --  GPIO pin
-    PA[09].configure(None); //... RF233 RST   --  GPIO pin
-    PA[10].configure(None); //... RF233 SLP   --  GPIO pin
-    PA[13].configure(None); //... TRNG EN     --  GPIO pin
-    PA[14].configure(None); //... TRNG_OUT    --  GPIO pin
-    PA[17].configure(None); //... NRF INT     -- GPIO pin
-    PA[18].configure(Some(A)); // NRF CLK     -- USART2_CLK
-    PA[20].configure(None); //... D8          -- GPIO pin
-    PA[21].configure(Some(E)); // TWI2 SDA    -- TWIM2_SDA
-    PA[22].configure(Some(E)); // TWI2 SCL    --  TWIM2 TWCK
-    PA[25].configure(Some(A)); // USB_N       --  USB DM
-    PA[26].configure(Some(A)); // USB_P       --  USB DP
-    PB[00].configure(Some(A)); // TWI1_SDA    --  TWIMS1 TWD
-    PB[01].configure(Some(A)); // TWI1_SCL    --  TWIMS1 TWCK
-    PB[02].configure(Some(A)); // AD3         --  ADCIFE AD3
-    PB[03].configure(Some(A)); // AD4         --  ADCIFE AD4
-    PB[04].configure(Some(A)); // AD5         --  ADCIFE AD5
-    PB[05].configure(Some(A)); // VHIGHSAMPLE --  ADCIFE AD6
-    PB[06].configure(Some(A)); // RTS3        --  USART3 RTS
-    PB[07].configure(None); //... NRF RESET   --  GPIO
-    PB[09].configure(Some(A)); // RX3         --  USART3 RX
-    PB[10].configure(Some(A)); // TX3         --  USART3 TX
-    PB[11].configure(Some(A)); // CTS0        --  USART0 CTS
-    PB[12].configure(Some(A)); // RTS0        --  USART0 RTS
-    PB[13].configure(Some(A)); // CLK0        --  USART0 CLK
-    PB[14].configure(Some(A)); // RX0         --  USART0 RX
-    PB[15].configure(Some(A)); // TX0         --  USART0 TX
-    PC[00].configure(Some(A)); // CS2         --  SPI NPCS2
-    PC[01].configure(Some(A)); // CS3 (RF233) --  SPI NPCS3
-    PC[02].configure(Some(A)); // CS1         --  SPI NPCS1
-    PC[03].configure(Some(A)); // CS0         --  SPI NPCS0
-    PC[04].configure(Some(A)); // MISO        --  SPI MISO
-    PC[05].configure(Some(A)); // MOSI        --  SPI MOSI
-    PC[06].configure(Some(A)); // SCK         --  SPI CLK
-    PC[07].configure(Some(B)); // RTS2 (BLE)  -- USART2_RTS
-    PC[08].configure(Some(E)); // CTS2 (BLE)  -- USART2_CTS
-                               //PC[09].configure(None); //... NRF GPIO    -- GPIO
-                               //PC[10].configure(None); //... USER LED    -- GPIO
-    PC[09].configure(Some(E)); // ACAN1       -- ACIFC comparator
-    PC[10].configure(Some(E)); // ACAP1       -- ACIFC comparator
-    PC[11].configure(Some(B)); // RX2 (BLE)   -- USART2_RX
-    PC[12].configure(Some(B)); // TX2 (BLE)   -- USART2_TX
-                               //PC[13].configure(None); //... ACC_INT1    -- GPIO
-                               //PC[14].configure(None); //... ACC_INT2    -- GPIO
-    PC[13].configure(Some(E)); //... ACBN1    -- ACIFC comparator
-    PC[14].configure(Some(E)); //... ACBP1    -- ACIFC comparator
-    PC[16].configure(None); //... SENSE_PWR   --  GPIO pin
-    PC[17].configure(None); //... NRF_PWR     --  GPIO pin
-    PC[18].configure(None); //... RF233_PWR   --  GPIO pin
-    PC[19].configure(None); //... TRNG_PWR    -- GPIO Pin
-    PC[22].configure(None); //... KERNEL LED  -- GPIO Pin
-    PC[24].configure(None); //... USER_BTN    -- GPIO Pin
-    PC[25].configure(Some(B)); // LI_INT      --  EIC EXTINT2
-    PC[26].configure(None); //... D7          -- GPIO Pin
-    PC[27].configure(None); //... D6          -- GPIO Pin
-    PC[28].configure(None); //... D5          -- GPIO Pin
-    PC[29].configure(None); //... D4          -- GPIO Pin
-    PC[30].configure(None); //... D3          -- GPIO Pin
-    PC[31].configure(None); //... D2          -- GPIO Pin
+    peripherals.pa[04].configure(Some(A)); // AD0         --  ADCIFE AD0
+    peripherals.pa[05].configure(Some(A)); // AD1         --  ADCIFE AD1
+    peripherals.pa[06].configure(Some(C)); // EXTINT1     --  EIC EXTINT1
+    peripherals.pa[07].configure(Some(A)); // AD1         --  ADCIFE AD2
+    peripherals.pa[08].configure(None); //... RF233 IRQ   --  GPIO pin
+    peripherals.pa[09].configure(None); //... RF233 RST   --  GPIO pin
+    peripherals.pa[10].configure(None); //... RF233 SLP   --  GPIO pin
+    peripherals.pa[13].configure(None); //... TRNG EN     --  GPIO pin
+    peripherals.pa[14].configure(None); //... TRNG_OUT    --  GPIO pin
+    peripherals.pa[17].configure(None); //... NRF INT     -- GPIO pin
+    peripherals.pa[18].configure(Some(A)); // NRF CLK     -- USART2_CLK
+    peripherals.pa[20].configure(None); //... D8          -- GPIO pin
+    peripherals.pa[21].configure(Some(E)); // TWI2 SDA    -- TWIM2_SDA
+    peripherals.pa[22].configure(Some(E)); // TWI2 SCL    --  TWIM2 TWCK
+    peripherals.pa[25].configure(Some(A)); // USB_N       --  USB DM
+    peripherals.pa[26].configure(Some(A)); // USB_P       --  USB DP
+    peripherals.pb[00].configure(Some(A)); // TWI1_SDA    --  TWIMS1 TWD
+    peripherals.pb[01].configure(Some(A)); // TWI1_SCL    --  TWIMS1 TWCK
+    peripherals.pb[02].configure(Some(A)); // AD3         --  ADCIFE AD3
+    peripherals.pb[03].configure(Some(A)); // AD4         --  ADCIFE AD4
+    peripherals.pb[04].configure(Some(A)); // AD5         --  ADCIFE AD5
+    peripherals.pb[05].configure(Some(A)); // VHIGHSAMPLE --  ADCIFE AD6
+    peripherals.pb[06].configure(Some(A)); // RTS3        --  USART3 RTS
+    peripherals.pb[07].configure(None); //... NRF RESET   --  GPIO
+    peripherals.pb[09].configure(Some(A)); // RX3         --  USART3 RX
+    peripherals.pb[10].configure(Some(A)); // TX3         --  USART3 TX
+    peripherals.pb[11].configure(Some(A)); // CTS0        --  USART0 CTS
+    peripherals.pb[12].configure(Some(A)); // RTS0        --  USART0 RTS
+    peripherals.pb[13].configure(Some(A)); // CLK0        --  USART0 CLK
+    peripherals.pb[14].configure(Some(A)); // RX0         --  USART0 RX
+    peripherals.pb[15].configure(Some(A)); // TX0         --  USART0 TX
+    peripherals.pc[00].configure(Some(A)); // CS2         --  SPI Nperipherals.pcS2
+    peripherals.pc[01].configure(Some(A)); // CS3 (RF233) --  SPI Nperipherals.pcS3
+    peripherals.pc[02].configure(Some(A)); // CS1         --  SPI Nperipherals.pcS1
+    peripherals.pc[03].configure(Some(A)); // CS0         --  SPI Nperipherals.pcS0
+    peripherals.pc[04].configure(Some(A)); // MISO        --  SPI MISO
+    peripherals.pc[05].configure(Some(A)); // MOSI        --  SPI MOSI
+    peripherals.pc[06].configure(Some(A)); // SCK         --  SPI CLK
+    peripherals.pc[07].configure(Some(B)); // RTS2 (BLE)  -- USART2_RTS
+    peripherals.pc[08].configure(Some(E)); // CTS2 (BLE)  -- USART2_CTS
+                                           //peripherals.pc[09].configure(None); //... NRF GPIO    -- GPIO
+                                           //peripherals.pc[10].configure(None); //... USER LED    -- GPIO
+    peripherals.pc[09].configure(Some(E)); // ACAN1       -- ACIFC comparator
+    peripherals.pc[10].configure(Some(E)); // ACAP1       -- ACIFC comparator
+    peripherals.pc[11].configure(Some(B)); // RX2 (BLE)   -- USART2_RX
+    peripherals.pc[12].configure(Some(B)); // TX2 (BLE)   -- USART2_TX
+                                           //peripherals.pc[13].configure(None); //... ACC_INT1    -- GPIO
+                                           //peripherals.pc[14].configure(None); //... ACC_INT2    -- GPIO
+    peripherals.pc[13].configure(Some(E)); //... ACBN1    -- ACIFC comparator
+    peripherals.pc[14].configure(Some(E)); //... ACBP1    -- ACIFC comparator
+    peripherals.pc[16].configure(None); //... SENSE_PWR   --  GPIO pin
+    peripherals.pc[17].configure(None); //... NRF_PWR     --  GPIO pin
+    peripherals.pc[18].configure(None); //... RF233_PWR   --  GPIO pin
+    peripherals.pc[19].configure(None); //... TRNG_PWR    -- GPIO Pin
+    peripherals.pc[22].configure(None); //... KERNEL LED  -- GPIO Pin
+    peripherals.pc[24].configure(None); //... USER_BTN    -- GPIO Pin
+    peripherals.pc[25].configure(Some(B)); // LI_INT      --  EIC EXTINT2
+    peripherals.pc[26].configure(None); //... D7          -- GPIO Pin
+    peripherals.pc[27].configure(None); //... D6          -- GPIO Pin
+    peripherals.pc[28].configure(None); //... D5          -- GPIO Pin
+    peripherals.pc[29].configure(None); //... D4          -- GPIO Pin
+    peripherals.pc[30].configure(None); //... D3          -- GPIO Pin
+    peripherals.pc[31].configure(None); //... D2          -- GPIO Pin
 }
 
 /// Reset Handler.
@@ -259,16 +260,28 @@ unsafe fn set_pin_primary_functions() {
 #[no_mangle]
 pub unsafe fn reset_handler() {
     sam4l::init();
+    let pm = static_init!(sam4l::pm::PowerManager, sam4l::pm::PowerManager::new());
+    let peripherals = static_init!(Sam4lDefaultPeripherals, Sam4lDefaultPeripherals::new(pm));
 
-    sam4l::pm::PM.setup_system_clock(sam4l::pm::SystemClockSource::PllExternalOscillatorAt48MHz {
-        frequency: sam4l::pm::OscillatorFrequency::Frequency16MHz,
-        startup_mode: sam4l::pm::OscillatorStartup::FastStart,
-    });
+    pm.setup_system_clock(
+        sam4l::pm::SystemClockSource::PllExternalOscillatorAt48MHz {
+            frequency: sam4l::pm::OscillatorFrequency::Frequency16MHz,
+            startup_mode: sam4l::pm::OscillatorStartup::FastStart,
+        },
+        &peripherals.flash_controller,
+    );
 
     // Source 32Khz and 1Khz clocks from RC23K (SAM4L Datasheet 11.6.8)
     sam4l::bpm::set_ck32source(sam4l::bpm::CK32Source::RC32K);
 
-    set_pin_primary_functions();
+    set_pin_primary_functions(peripherals);
+
+    peripherals.setup_dma();
+    let chip = static_init!(
+        sam4l::chip::Sam4l<Sam4lDefaultPeripherals>,
+        sam4l::chip::Sam4l::new(pm, peripherals)
+    );
+    CHIP = Some(chip);
 
     // Create capabilities that the board needs to call certain protected kernel
     // functions.
@@ -276,12 +289,17 @@ pub unsafe fn reset_handler() {
     let main_cap = create_capability!(capabilities::MainLoopCapability);
     let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
 
-    power::configure_submodules(power::SubmoduleConfig {
-        rf233: true,
-        nrf51422: true,
-        sensors: true,
-        trng: true,
-    });
+    power::configure_submodules(
+        &peripherals.pa,
+        &peripherals.pb,
+        &peripherals.pc,
+        power::SubmoduleConfig {
+            rf233: true,
+            nrf51422: true,
+            sensors: true,
+            trng: true,
+        },
+    );
 
     let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
 
@@ -295,34 +313,32 @@ pub unsafe fn reset_handler() {
 
     // # CONSOLE
     // Create a shared UART channel for the consoles and for kernel debug.
-    sam4l::usart::USART3.set_mode(sam4l::usart::UsartMode::Uart);
+    peripherals.usart3.set_mode(sam4l::usart::UsartMode::Uart);
     let uart_mux =
-        UartMuxComponent::new(&sam4l::usart::USART3, 115200, dynamic_deferred_caller).finalize(());
+        UartMuxComponent::new(&peripherals.usart3, 115200, dynamic_deferred_caller).finalize(());
 
     let pconsole = ProcessConsoleComponent::new(board_kernel, uart_mux).finalize(());
     let console = ConsoleComponent::new(board_kernel, uart_mux).finalize(());
     DebugWriterComponent::new(uart_mux).finalize(());
 
     // Allow processes to communicate over BLE through the nRF51822
-    sam4l::usart::USART2.set_mode(sam4l::usart::UsartMode::Uart);
+    peripherals.usart2.set_mode(sam4l::usart::UsartMode::Uart);
     let nrf_serialization =
-        Nrf51822Component::new(&sam4l::usart::USART2, &sam4l::gpio::PB[07], board_kernel)
-            .finalize(());
+        Nrf51822Component::new(&peripherals.usart2, &peripherals.pb[07], board_kernel).finalize(());
 
     // # TIMER
-    let ast = &sam4l::ast::AST;
-    let mux_alarm = AlarmMuxComponent::new(ast)
+    let mux_alarm = AlarmMuxComponent::new(&peripherals.ast)
         .finalize(components::alarm_mux_component_helper!(sam4l::ast::Ast));
-    ast.configure(mux_alarm);
+    peripherals.ast.configure(mux_alarm);
     let alarm = AlarmDriverComponent::new(board_kernel, mux_alarm)
         .finalize(components::alarm_component_helper!(sam4l::ast::Ast));
 
     // # I2C and I2C Sensors
     let mux_i2c = static_init!(
         MuxI2C<'static>,
-        MuxI2C::new(&sam4l::i2c::I2C2, None, dynamic_deferred_caller)
+        MuxI2C::new(&peripherals.i2c2, None, dynamic_deferred_caller)
     );
-    sam4l::i2c::I2C2.set_master_client(mux_i2c);
+    peripherals.i2c2.set_master_client(mux_i2c);
 
     let ambient_light = AmbientLightComponent::new(board_kernel, mux_i2c, mux_alarm)
         .finalize(components::isl29035_component_helper!(sam4l::ast::Ast));
@@ -331,10 +347,10 @@ pub unsafe fn reset_handler() {
     let temp =
         components::temperature::TemperatureComponent::new(board_kernel, si7021).finalize(());
     let humidity = HumidityComponent::new(board_kernel, si7021).finalize(());
-    let ninedof = NineDofComponent::new(board_kernel, mux_i2c, &sam4l::gpio::PC[13]).finalize(());
+    let ninedof = NineDofComponent::new(board_kernel, mux_i2c, &peripherals.pc[13]).finalize(());
 
     // SPI MUX, SPI syscall driver and RF233 radio
-    let mux_spi = components::spi::SpiMuxComponent::new(&sam4l::spi::SPI)
+    let mux_spi = components::spi::SpiMuxComponent::new(&peripherals.spi)
         .finalize(components::spi_mux_component_helper!(sam4l::spi::SpiHw));
 
     let spi_syscalls = SpiSyscallComponent::new(mux_spi, 3)
@@ -343,26 +359,26 @@ pub unsafe fn reset_handler() {
         .finalize(components::spi_component_helper!(sam4l::spi::SpiHw));
     let rf233 = RF233Component::new(
         rf233_spi,
-        &sam4l::gpio::PA[09], // reset
-        &sam4l::gpio::PA[10], // sleep
-        &sam4l::gpio::PA[08], // irq
-        &sam4l::gpio::PA[08],
+        &peripherals.pa[09], // reset
+        &peripherals.pa[10], // sleep
+        &peripherals.pa[08], // irq
+        &peripherals.pa[08],
         RADIO_CHANNEL,
     )
     .finalize(());
 
-    let adc = AdcComponent::new(board_kernel).finalize(());
+    let adc = AdcComponent::new(board_kernel, &peripherals.adc).finalize(());
     let gpio = GpioComponent::new(
         board_kernel,
         components::gpio_component_helper!(
             sam4l::gpio::GPIOPin,
-            0 => &sam4l::gpio::PC[31],
-            1 => &sam4l::gpio::PC[30],
-            2 => &sam4l::gpio::PC[29],
-            3 => &sam4l::gpio::PC[28],
-            4 => &sam4l::gpio::PC[27],
-            5 => &sam4l::gpio::PC[26],
-            6 => &sam4l::gpio::PA[20]
+            0 => &peripherals.pc[31],
+            1 => &peripherals.pc[30],
+            2 => &peripherals.pc[29],
+            3 => &peripherals.pc[28],
+            4 => &peripherals.pc[27],
+            5 => &peripherals.pc[26],
+            6 => &peripherals.pa[20]
         ),
     )
     .finalize(components::gpio_component_buf!(sam4l::gpio::GPIOPin));
@@ -370,7 +386,7 @@ pub unsafe fn reset_handler() {
     let led = LedsComponent::new(components::led_component_helper!(
         sam4l::gpio::GPIOPin,
         (
-            &sam4l::gpio::PC[10],
+            &peripherals.pc[10],
             kernel::hil::gpio::ActivationMode::ActiveHigh
         )
     ))
@@ -380,27 +396,44 @@ pub unsafe fn reset_handler() {
         components::button_component_helper!(
             sam4l::gpio::GPIOPin,
             (
-                &sam4l::gpio::PC[24],
+                &peripherals.pc[24],
                 kernel::hil::gpio::ActivationMode::ActiveLow,
                 kernel::hil::gpio::FloatingState::PullNone
             )
         ),
     )
     .finalize(components::button_component_buf!(sam4l::gpio::GPIOPin));
-    let crc = CrcComponent::new(board_kernel, &sam4l::crccu::CRCCU)
+    let crc = CrcComponent::new(board_kernel, &peripherals.crccu)
         .finalize(components::crc_component_helper!(sam4l::crccu::Crccu));
+
+    let ac_0 = static_init!(
+        sam4l::acifc::AcChannel,
+        sam4l::acifc::AcChannel::new(sam4l::acifc::Channel::AC0)
+    );
+    let ac_1 = static_init!(
+        sam4l::acifc::AcChannel,
+        sam4l::acifc::AcChannel::new(sam4l::acifc::Channel::AC0)
+    );
+    let ac_2 = static_init!(
+        sam4l::acifc::AcChannel,
+        sam4l::acifc::AcChannel::new(sam4l::acifc::Channel::AC0)
+    );
+    let ac_3 = static_init!(
+        sam4l::acifc::AcChannel,
+        sam4l::acifc::AcChannel::new(sam4l::acifc::Channel::AC0)
+    );
     let analog_comparator = components::analog_comparator::AcComponent::new(
-        &sam4l::acifc::ACIFC,
+        &peripherals.acifc,
         components::acomp_component_helper!(
             <sam4l::acifc::Acifc as kernel::hil::analog_comparator::AnalogComparator>::Channel,
-            &sam4l::acifc::CHANNEL_AC0,
-            &sam4l::acifc::CHANNEL_AC1,
-            &sam4l::acifc::CHANNEL_AC2,
-            &sam4l::acifc::CHANNEL_AC3
+            ac_0,
+            ac_1,
+            ac_2,
+            ac_3
         ),
     )
     .finalize(components::acomp_component_buf!(sam4l::acifc::Acifc));
-    let rng = RngComponent::new(board_kernel, &sam4l::trng::TRNG).finalize(());
+    let rng = RngComponent::new(board_kernel, &peripherals.trng).finalize(());
 
     // For now, assign the 802.15.4 MAC address on the device as
     // simply a 16-bit short address which represents the last 16 bits
@@ -416,7 +449,7 @@ pub unsafe fn reset_handler() {
     let (radio_driver, mux_mac) = components::ieee802154::Ieee802154Component::new(
         board_kernel,
         rf233,
-        &sam4l::aes::AES,
+        &peripherals.aes,
         PAN_ID,
         serial_num_bottom_16,
     )
@@ -425,7 +458,7 @@ pub unsafe fn reset_handler() {
         sam4l::aes::Aes<'static>
     ));
 
-    let usb_driver = UsbComponent::new(board_kernel).finalize(());
+    let usb_driver = UsbComponent::new(board_kernel, &peripherals.usbc).finalize(());
 
     // Kernel storage region, allocated with the storage_volume!
     // macro in common/utils.rs
@@ -437,7 +470,7 @@ pub unsafe fn reset_handler() {
 
     let nonvolatile_storage = components::nonvolatile_storage::NonvolatileStorageComponent::new(
         board_kernel,
-        &sam4l::flashcalw::FLASH_CONTROLLER,
+        &peripherals.flash_controller,
         0x60000,                          // Start address for userspace accessible region
         0x20000,                          // Length of userspace accessible region
         &_sstorage as *const u8 as usize, //start address of kernel region
@@ -505,11 +538,8 @@ pub unsafe fn reset_handler() {
         udp_driver,
         usb_driver,
         nrf51822: nrf_serialization,
-        nonvolatile_storage: nonvolatile_storage,
+        nonvolatile_storage,
     };
-
-    let chip = static_init!(sam4l::chip::Sam4l, sam4l::chip::Sam4l::new());
-    CHIP = Some(chip);
 
     // Need to initialize the UART for the nRF51 serialization.
     imix.nrf51822.initialize();
@@ -528,12 +558,20 @@ pub unsafe fn reset_handler() {
     // -pal, 11/20/18
     //
     //test::virtual_uart_rx_test::run_virtual_uart_receive(uart_mux);
-    //test::rng_test::run_entropy32();
-    //test::aes_ccm_test::run();
-    //test::aes_test::run_aes128_ctr();
-    //test::aes_test::run_aes128_cbc();
-    //test::log_test::run(mux_alarm, dynamic_deferred_caller);
-    //test::linear_log_test::run(mux_alarm, dynamic_deferred_caller);
+    //test::rng_test::run_entropy32(&peripherals.trng);
+    //test::aes_ccm_test::run(&peripherals.aes);
+    //test::aes_test::run_aes128_ctr(&peripherals.aes);
+    //test::aes_test::run_aes128_cbc(&peripherals.aes);
+    //test::log_test::run(
+    //    mux_alarm,
+    //    dynamic_deferred_caller,
+    //    &peripherals.flash_controller,
+    //);
+    //test::linear_log_test::run(
+    //    mux_alarm,
+    //    dynamic_deferred_caller,
+    //    &peripherals.flash_controller,
+    //);
     //test::icmp_lowpan_test::run(mux_mac, mux_alarm);
     //let lowpan_frag_test = test::ipv6_lowpan_test::initialize_all(mux_mac, mux_alarm);
     //lowpan_frag_test.start(); // If flashing the transmitting Imix
@@ -545,7 +583,7 @@ pub unsafe fn reset_handler() {
     );*/
     //udp_lowpan_test.start();
 
-    // alarm_test::run_alarm();
+    // alarm_test::run_alarm(&peripherals.ast);
     /*let virtual_alarm_timer = static_init!(
         VirtualMuxAlarm<'static, sam4l::ast::Ast>,
         VirtualMuxAlarm::new(mux_alarm)

--- a/boards/imix/src/power.rs
+++ b/boards/imix/src/power.rs
@@ -21,9 +21,8 @@
 
 use kernel::hil::Controller;
 use sam4l::gpio::GPIOPin;
-use sam4l::gpio::PeripheralFunction;
 use sam4l::gpio::PeripheralFunction::{A, B, E};
-use sam4l::gpio::{PA, PB, PC};
+use sam4l::gpio::{PeripheralFunction, Port};
 
 struct DetachablePin {
     pin: &'static GPIOPin<'static>,
@@ -74,64 +73,69 @@ pub struct SubmoduleConfig {
     pub trng: bool,
 }
 
-pub unsafe fn configure_submodules(enabled_submodules: SubmoduleConfig) {
+pub unsafe fn configure_submodules(
+    pa: &'static Port,
+    pb: &'static Port,
+    pc: &'static Port,
+    enabled_submodules: SubmoduleConfig,
+) {
     let rf233_detachable_pins = [
         DetachablePin {
-            pin: &PA[08],
+            pin: &pa[08],
             function: None,
         },
         DetachablePin {
-            pin: &PA[09],
+            pin: &pa[09],
             function: None,
         },
         DetachablePin {
-            pin: &PA[10],
+            pin: &pa[10],
             function: None,
         },
     ];
     let rf233 = Submodule {
-        gate_pin: &PC[18],
+        gate_pin: &pc[18],
         detachable_pins: &rf233_detachable_pins,
     };
 
     let nrf_detachable_pins = [
         DetachablePin {
-            pin: &PB[07],
+            pin: &pb[07],
             function: None,
         },
         DetachablePin {
-            pin: &PA[17],
+            pin: &pa[17],
             function: None,
         },
         DetachablePin {
-            pin: &PA[18],
+            pin: &pa[18],
             function: Some(A),
         },
         DetachablePin {
-            pin: &PC[07],
+            pin: &pc[07],
             function: Some(B),
         },
         DetachablePin {
-            pin: &PC[08],
+            pin: &pc[08],
             function: Some(E),
         },
         DetachablePin {
-            pin: &PC[09],
+            pin: &pc[09],
             function: None,
         },
     ];
     let nrf = Submodule {
-        gate_pin: &PC[17],
+        gate_pin: &pc[17],
         detachable_pins: &nrf_detachable_pins,
     };
 
     let sensors = Submodule {
-        gate_pin: &PC[16],
+        gate_pin: &pc[16],
         detachable_pins: &[],
     };
 
     let trng = Submodule {
-        gate_pin: &PC[19],
+        gate_pin: &pc[19],
         detachable_pins: &[],
     };
 

--- a/boards/imix/src/test/aes_ccm_test.rs
+++ b/boards/imix/src/test/aes_ccm_test.rs
@@ -16,11 +16,11 @@ use capsules::aes_ccm;
 use capsules::test::aes_ccm::Test;
 use kernel::hil::symmetric_encryption::{AES128, AES128CCM, AES128_BLOCK_SIZE};
 use kernel::static_init;
-use sam4l::aes::{Aes, AES};
+use sam4l::aes::Aes;
 
-pub unsafe fn run() {
-    let ccm = static_init_ccm();
-    AES.set_client(ccm);
+pub unsafe fn run(aes: &'static Aes) {
+    let ccm = static_init_ccm(aes);
+    aes.set_client(ccm);
 
     let t = static_init_test(ccm);
     ccm.set_client(t);
@@ -28,20 +28,18 @@ pub unsafe fn run() {
     t.run();
 }
 
-unsafe fn static_init_ccm() -> &'static mut aes_ccm::AES128CCM<'static, Aes<'static>> {
+unsafe fn static_init_ccm(aes: &'static Aes) -> &'static aes_ccm::AES128CCM<'static, Aes<'static>> {
     const CRYPT_SIZE: usize = 7 * AES128_BLOCK_SIZE;
     let crypt_buf = static_init!([u8; CRYPT_SIZE], [0x00; CRYPT_SIZE]);
     static_init!(
         aes_ccm::AES128CCM<'static, Aes<'static>>,
-        aes_ccm::AES128CCM::new(&AES, crypt_buf)
+        aes_ccm::AES128CCM::new(&aes, crypt_buf)
     )
 }
 
 type AESCCM = aes_ccm::AES128CCM<'static, Aes<'static>>;
 
-#[allow(clippy::mut_from_ref)]
-// Static init returns a singly owned mutable reference
-unsafe fn static_init_test(aes_ccm: &'static AESCCM) -> &'static mut Test<'static, AESCCM> {
+unsafe fn static_init_test(aes_ccm: &'static AESCCM) -> &'static Test<'static, AESCCM> {
     let data = static_init!([u8; 4 * AES128_BLOCK_SIZE], [0x00; 4 * AES128_BLOCK_SIZE]);
     static_init!(Test<'static, AESCCM>, Test::new(aes_ccm, data))
 }

--- a/boards/imix/src/test/aes_test.rs
+++ b/boards/imix/src/test/aes_test.rs
@@ -25,23 +25,23 @@ use capsules::test::aes::TestAes128Cbc;
 use capsules::test::aes::TestAes128Ctr;
 use kernel::hil::symmetric_encryption::{AES128, AES128_BLOCK_SIZE, AES128_KEY_SIZE};
 use kernel::static_init;
-use sam4l::aes::{Aes, AES};
+use sam4l::aes::Aes;
 
-pub unsafe fn run_aes128_ctr() {
-    let t = static_init_test_ctr();
-    AES.set_client(t);
-
-    t.run();
-}
-
-pub unsafe fn run_aes128_cbc() {
-    let t = static_init_test_cbc();
-    AES.set_client(t);
+pub unsafe fn run_aes128_ctr(aes: &'static Aes) {
+    let t = static_init_test_ctr(aes);
+    aes.set_client(t);
 
     t.run();
 }
 
-unsafe fn static_init_test_ctr() -> &'static mut TestAes128Ctr<'static, Aes<'static>> {
+pub unsafe fn run_aes128_cbc(aes: &'static Aes) {
+    let t = static_init_test_cbc(aes);
+    aes.set_client(t);
+
+    t.run();
+}
+
+unsafe fn static_init_test_ctr(aes: &'static Aes) -> &'static TestAes128Ctr<'static, Aes<'static>> {
     let source = static_init!([u8; 4 * AES128_BLOCK_SIZE], [0; 4 * AES128_BLOCK_SIZE]);
     let data = static_init!([u8; 6 * AES128_BLOCK_SIZE], [0; 6 * AES128_BLOCK_SIZE]);
     let key = static_init!([u8; AES128_KEY_SIZE], [0; AES128_KEY_SIZE]);
@@ -49,11 +49,11 @@ unsafe fn static_init_test_ctr() -> &'static mut TestAes128Ctr<'static, Aes<'sta
 
     static_init!(
         TestAes128Ctr<'static, Aes>,
-        TestAes128Ctr::new(&AES, key, iv, source, data)
+        TestAes128Ctr::new(&aes, key, iv, source, data)
     )
 }
 
-unsafe fn static_init_test_cbc() -> &'static mut TestAes128Cbc<'static, Aes<'static>> {
+unsafe fn static_init_test_cbc(aes: &'static Aes) -> &'static TestAes128Cbc<'static, Aes<'static>> {
     let source = static_init!([u8; 4 * AES128_BLOCK_SIZE], [0; 4 * AES128_BLOCK_SIZE]);
     let data = static_init!([u8; 6 * AES128_BLOCK_SIZE], [0; 6 * AES128_BLOCK_SIZE]);
     let key = static_init!([u8; AES128_KEY_SIZE], [0; AES128_KEY_SIZE]);
@@ -61,6 +61,6 @@ unsafe fn static_init_test_cbc() -> &'static mut TestAes128Cbc<'static, Aes<'sta
 
     static_init!(
         TestAes128Cbc<'static, Aes>,
-        TestAes128Cbc::new(&AES, key, iv, source, data)
+        TestAes128Cbc::new(&aes, key, iv, source, data)
     )
 }

--- a/boards/imix/src/test/i2c_dummy.rs
+++ b/boards/imix/src/test/i2c_dummy.rs
@@ -4,7 +4,6 @@ use core::cell::Cell;
 use kernel::debug;
 use kernel::hil;
 use kernel::hil::i2c::I2CMaster;
-use sam4l::i2c;
 
 // ===========================================
 // Scan for I2C Slaves
@@ -12,11 +11,17 @@ use sam4l::i2c;
 
 struct ScanClient {
     dev_id: Cell<u8>,
+    i2c_master: &'static dyn I2CMaster,
 }
 
-static mut SCAN_CLIENT: ScanClient = ScanClient {
-    dev_id: Cell::new(1),
-};
+impl ScanClient {
+    pub fn new(i2c_master: &'static dyn I2CMaster) -> Self {
+        Self {
+            dev_id: Cell::new(1),
+            i2c_master,
+        }
+    }
+}
 
 impl hil::i2c::I2CHwMasterClient for ScanClient {
     fn command_complete(&self, buffer: &'static mut [u8], error: hil::i2c::Error) {
@@ -26,7 +31,7 @@ impl hil::i2c::I2CHwMasterClient for ScanClient {
             debug!("{:#x}", dev_id);
         }
 
-        let dev: &mut dyn I2CMaster = unsafe { &mut i2c::I2C2 };
+        let dev: &dyn I2CMaster = self.i2c_master;
         if dev_id < 0x7F {
             dev_id += 1;
             self.dev_id.set(dev_id);
@@ -40,15 +45,15 @@ impl hil::i2c::I2CHwMasterClient for ScanClient {
     }
 }
 
-pub fn i2c_scan_slaves() {
+/// This test should be called with I2C2, specifically
+pub fn i2c_scan_slaves(i2c_master: &'static mut dyn I2CMaster) {
     static mut DATA: [u8; 255] = [0; 255];
 
-    let dev = unsafe { &mut i2c::I2C2 };
+    let dev = i2c_master;
 
-    let i2c_client = unsafe { &SCAN_CLIENT };
+    let i2c_client = unsafe { kernel::static_init!(ScanClient, ScanClient::new(dev)) };
     dev.set_master_client(i2c_client);
 
-    let dev: &mut dyn I2CMaster = dev;
     dev.enable();
 
     debug!("Scanning for I2C devices...");
@@ -69,15 +74,21 @@ enum AccelClientState {
 
 struct AccelClient {
     state: Cell<AccelClientState>,
+    i2c_master: &'static dyn I2CMaster,
 }
 
-static mut ACCEL_CLIENT: AccelClient = AccelClient {
-    state: Cell::new(AccelClientState::ReadingWhoami),
-};
+impl AccelClient {
+    pub fn new(i2c_master: &'static dyn I2CMaster) -> Self {
+        Self {
+            state: Cell::new(AccelClientState::ReadingWhoami),
+            i2c_master,
+        }
+    }
+}
 
 impl hil::i2c::I2CHwMasterClient for AccelClient {
     fn command_complete(&self, buffer: &'static mut [u8], error: hil::i2c::Error) {
-        let dev = unsafe { &mut i2c::I2C2 };
+        let dev = self.i2c_master;
 
         match self.state.get() {
             AccelClientState::ReadingWhoami => {
@@ -130,12 +141,13 @@ impl hil::i2c::I2CHwMasterClient for AccelClient {
     }
 }
 
-pub fn i2c_accel_test() {
+/// This test should be called with I2C2, specifically
+pub fn i2c_accel_test(i2c_master: &'static dyn I2CMaster) {
     static mut DATA: [u8; 255] = [0; 255];
 
-    let dev = unsafe { &mut i2c::I2C2 };
+    let dev = i2c_master;
 
-    let i2c_client = unsafe { &ACCEL_CLIENT };
+    let i2c_client = unsafe { kernel::static_init!(AccelClient, AccelClient::new(dev)) };
     dev.set_master_client(i2c_client);
     dev.enable();
 
@@ -158,15 +170,21 @@ enum LiClientState {
 
 struct LiClient {
     state: Cell<LiClientState>,
+    i2c_master: &'static dyn I2CMaster,
 }
 
-static mut LI_CLIENT: LiClient = LiClient {
-    state: Cell::new(LiClientState::Enabling),
-};
+impl LiClient {
+    pub fn new(i2c_master: &'static dyn I2CMaster) -> Self {
+        Self {
+            state: Cell::new(LiClientState::Enabling),
+            i2c_master,
+        }
+    }
+}
 
 impl hil::i2c::I2CHwMasterClient for LiClient {
     fn command_complete(&self, buffer: &'static mut [u8], error: hil::i2c::Error) {
-        let dev = unsafe { &mut i2c::I2C2 };
+        let dev = self.i2c_master;
 
         match self.state.get() {
             LiClientState::Enabling => {
@@ -187,17 +205,17 @@ impl hil::i2c::I2CHwMasterClient for LiClient {
     }
 }
 
-pub fn i2c_li_test() {
+/// This test should be called with I2C2, specifically
+pub fn i2c_li_test(i2c_master: &'static dyn I2CMaster) {
     static mut DATA: [u8; 255] = [0; 255];
 
-    unsafe {
-        sam4l::gpio::PA[16].enable_output();
-        sam4l::gpio::PA[16].set();
-    }
+    let pin = sam4l::gpio::GPIOPin::new(sam4l::gpio::Pin::PA16);
+    pin.enable_output();
+    pin.set();
 
-    let dev = unsafe { &mut i2c::I2C2 };
+    let dev = i2c_master;
 
-    let i2c_client = unsafe { &LI_CLIENT };
+    let i2c_client = unsafe { kernel::static_init!(LiClient, LiClient::new(dev)) };
     dev.set_master_client(i2c_client);
     dev.enable();
 

--- a/boards/imix/src/test/icmp_lowpan_test.rs
+++ b/boards/imix/src/test/icmp_lowpan_test.rs
@@ -81,8 +81,16 @@ pub unsafe fn run(
         capsules::ieee802154::virtual_mac::MacUser::new(mux_mac)
     );
     mux_mac.add_user(radio_mac);
+    let ipsender_virtual_alarm = static_init!(
+        VirtualMuxAlarm<'static, sam4l::ast::Ast>,
+        VirtualMuxAlarm::new(mux_alarm)
+    );
     let sixlowpan = static_init!(
-        Sixlowpan<'static, sam4l::ast::Ast<'static>, sixlowpan_compression::Context>,
+        Sixlowpan<
+            'static,
+            VirtualMuxAlarm<sam4l::ast::Ast<'static>>,
+            sixlowpan_compression::Context,
+        >,
         Sixlowpan::new(
             sixlowpan_compression::Context {
                 prefix: DEFAULT_CTX_PREFIX,
@@ -90,7 +98,7 @@ pub unsafe fn run(
                 id: 0,
                 compress: false,
             },
-            &sam4l::ast::AST
+            ipsender_virtual_alarm
         )
     );
 
@@ -105,11 +113,6 @@ pub unsafe fn run(
     };
 
     let ip6_dg = static_init!(IP6Packet<'static>, IP6Packet::new(ip_pyld));
-
-    let ipsender_virtual_alarm = static_init!(
-        VirtualMuxAlarm<'static, sam4l::ast::Ast>,
-        VirtualMuxAlarm::new(mux_alarm)
-    );
 
     let ip6_sender = static_init!(
         IP6SendStruct<'static, VirtualMuxAlarm<'static, sam4l::ast::Ast<'static>>>,

--- a/boards/imix/src/test/ipv6_lowpan_test.rs
+++ b/boards/imix/src/test/ipv6_lowpan_test.rs
@@ -136,8 +136,16 @@ pub unsafe fn initialize_all(
     mux_mac.add_user(radio_mac);
     let default_rx_state = static_init!(RxState<'static>, RxState::new(&mut RX_STATE_BUF));
 
+    let sixlo_alarm = static_init!(
+        VirtualMuxAlarm<sam4l::ast::Ast>,
+        VirtualMuxAlarm::new(mux_alarm)
+    );
     let sixlowpan = static_init!(
-        Sixlowpan<'static, sam4l::ast::Ast<'static>, sixlowpan_compression::Context>,
+        Sixlowpan<
+            'static,
+            VirtualMuxAlarm<sam4l::ast::Ast<'static>>,
+            sixlowpan_compression::Context,
+        >,
         Sixlowpan::new(
             sixlowpan_compression::Context {
                 prefix: DEFAULT_CTX_PREFIX,
@@ -145,7 +153,7 @@ pub unsafe fn initialize_all(
                 id: 0,
                 compress: false,
             },
-            &sam4l::ast::AST
+            sixlo_alarm
         )
     );
 

--- a/boards/imix/src/test/linear_log_test.rs
+++ b/boards/imix/src/test/linear_log_test.rs
@@ -34,9 +34,10 @@ storage_volume!(LINEAR_TEST_LOG, 1);
 pub unsafe fn run(
     mux_alarm: &'static MuxAlarm<'static, Ast>,
     deferred_caller: &'static DynamicDeferredCall,
+    flash_controller: &'static sam4l::flashcalw::FLASHCALW,
 ) {
     // Set up flash controller.
-    flashcalw::FLASH_CONTROLLER.configure();
+    flash_controller.configure();
     let pagebuffer = static_init!(flashcalw::Sam4lPage, flashcalw::Sam4lPage::default());
 
     // Create actual log storage abstraction on top of flash.
@@ -44,13 +45,13 @@ pub unsafe fn run(
         Log,
         log::Log::new(
             &LINEAR_TEST_LOG,
-            &flashcalw::FLASH_CONTROLLER,
+            &flash_controller,
             pagebuffer,
             deferred_caller,
             false
         )
     );
-    flash::HasClient::set_client(&flashcalw::FLASH_CONTROLLER, log);
+    flash::HasClient::set_client(flash_controller, log);
     log.initialize_callback_handle(
         deferred_caller
             .register(log)

--- a/boards/imix/src/test/rng_test.rs
+++ b/boards/imix/src/test/rng_test.rs
@@ -19,16 +19,16 @@ use capsules::test::rng::TestRng;
 use kernel::hil::entropy::{Entropy32, Entropy8};
 use kernel::hil::rng::Rng;
 use kernel::static_init;
-use sam4l::trng::TRNG;
+use sam4l::trng::Trng;
 
-pub unsafe fn run_entropy32() {
-    let t = static_init_test_entropy32();
+pub unsafe fn run_entropy32(trng: &'static Trng) {
+    let t = static_init_test_entropy32(trng);
     t.run();
 }
 
-unsafe fn static_init_test_entropy32() -> &'static TestRng<'static> {
-    let e1 = static_init!(rng::Entropy32To8<'static>, rng::Entropy32To8::new(&TRNG));
-    TRNG.set_client(e1);
+unsafe fn static_init_test_entropy32(trng: &'static Trng) -> &'static TestRng<'static> {
+    let e1 = static_init!(rng::Entropy32To8<'static>, rng::Entropy32To8::new(trng));
+    trng.set_client(e1);
     let e2 = static_init!(rng::Entropy8To32<'static>, rng::Entropy8To32::new(e1));
     e1.set_client(e2);
     let er = static_init!(

--- a/boards/redboard_artemis_nano/src/io.rs
+++ b/boards/redboard_artemis_nano/src/io.rs
@@ -32,9 +32,8 @@ impl Write for Writer {
 
 impl IoWrite for Writer {
     fn write(&mut self, buf: &[u8]) {
-        unsafe {
-            apollo3::uart::UART0.transmit_sync(buf);
-        }
+        let uart = apollo3::uart::Uart::new_uart_0(); // Aliases memory for uart0. Okay bc we are panicking.
+        uart.transmit_sync(buf);
     }
 }
 
@@ -42,7 +41,14 @@ impl IoWrite for Writer {
 #[no_mangle]
 #[panic_handler]
 pub unsafe extern "C" fn panic_fmt(info: &PanicInfo) -> ! {
-    let led = &mut led::LedLow::new(&mut apollo3::gpio::PORT[19]);
+    // just create a new pin reference here instead of using global
+    let led_pin = &mut apollo3::gpio::GpioPin::new(
+        kernel::common::StaticRef::new(
+            apollo3::gpio::GPIO_BASE_RAW as *const apollo3::gpio::GpioRegisters,
+        ),
+        apollo3::gpio::Pin::Pin19,
+    );
+    let led = &mut led::LedLow::new(led_pin);
     let writer = &mut WRITER;
 
     debug::panic(

--- a/chips/apollo3/src/ble.rs
+++ b/chips/apollo3/src/ble.rs
@@ -10,8 +10,6 @@ use kernel::common::StaticRef;
 use kernel::hil::ble_advertising;
 use kernel::hil::ble_advertising::RadioChannel;
 
-pub static mut BLE: Ble = Ble::new(BLE_BASE);
-
 const BLE_BASE: StaticRef<BleRegisters> =
     unsafe { StaticRef::new(0x5000_C000 as *const BleRegisters) };
 
@@ -268,9 +266,9 @@ pub struct Ble<'a> {
 }
 
 impl<'a> Ble<'a> {
-    pub const fn new(base: StaticRef<BleRegisters>) -> Self {
+    pub const fn new() -> Self {
         Self {
-            registers: base,
+            registers: BLE_BASE,
             rx_client: OptionalCell::empty(),
             tx_client: OptionalCell::empty(),
             buffer: TakeCell::empty(),

--- a/chips/apollo3/src/cachectrl.rs
+++ b/chips/apollo3/src/cachectrl.rs
@@ -3,8 +3,6 @@
 use kernel::common::registers::{register_bitfields, register_structs, ReadWrite};
 use kernel::common::StaticRef;
 
-pub static mut CACHECTRL: CacheCtrl = CacheCtrl::new(CACHECTRL_BASE);
-
 const CACHECTRL_BASE: StaticRef<CacheCtrlRegisters> =
     unsafe { StaticRef::new(0x4001_8000 as *const CacheCtrlRegisters) };
 
@@ -52,8 +50,10 @@ pub struct CacheCtrl {
 }
 
 impl CacheCtrl {
-    pub const fn new(base: StaticRef<CacheCtrlRegisters>) -> CacheCtrl {
-        CacheCtrl { registers: base }
+    pub const fn new() -> CacheCtrl {
+        CacheCtrl {
+            registers: CACHECTRL_BASE,
+        }
     }
 
     pub fn enable_cache(&self) {

--- a/chips/apollo3/src/chip.rs
+++ b/chips/apollo3/src/chip.rs
@@ -3,31 +3,87 @@
 use core::fmt::Write;
 use cortexm4;
 use kernel::Chip;
+use kernel::InterruptService;
 
-use crate::ble;
-use crate::gpio;
-use crate::iom;
-use crate::nvic;
-use crate::stimer;
-use crate::uart;
-
-pub struct Apollo3 {
+pub struct Apollo3<I: InterruptService<()> + 'static> {
     mpu: cortexm4::mpu::MPU,
     userspace_kernel_boundary: cortexm4::syscall::SysCall,
     scheduler_timer: cortexm4::systick::SysTick,
+    interrupt_service: &'static I,
 }
 
-impl Apollo3 {
-    pub unsafe fn new() -> Apollo3 {
-        Apollo3 {
+impl<I: InterruptService<()> + 'static> Apollo3<I> {
+    pub unsafe fn new(interrupt_service: &'static I) -> Self {
+        Self {
             mpu: cortexm4::mpu::MPU::new(),
             userspace_kernel_boundary: cortexm4::syscall::SysCall::new(),
             scheduler_timer: cortexm4::systick::SysTick::new_with_calibration(48_000_000),
+            interrupt_service,
         }
     }
 }
 
-impl Chip for Apollo3 {
+/// This struct, when initialized, instantiates all peripheral drivers for the apollo3.
+/// If a board wishes to use only a subset of these peripherals, this
+/// should not be used or imported, and a modified version should be
+/// constructed manually in main.rs.
+pub struct Apollo3DefaultPeripherals {
+    pub stimer: crate::stimer::STimer<'static>,
+    pub uart0: crate::uart::Uart<'static>,
+    pub uart1: crate::uart::Uart<'static>,
+    pub gpio_port: crate::gpio::Port<'static>,
+    pub iom0: crate::iom::Iom<'static>,
+    pub iom1: crate::iom::Iom<'static>,
+    pub iom2: crate::iom::Iom<'static>,
+    pub iom3: crate::iom::Iom<'static>,
+    pub iom4: crate::iom::Iom<'static>,
+    pub iom5: crate::iom::Iom<'static>,
+    pub ble: crate::ble::Ble<'static>,
+}
+
+impl Apollo3DefaultPeripherals {
+    pub fn new() -> Self {
+        Self {
+            stimer: crate::stimer::STimer::new(),
+            uart0: crate::uart::Uart::new_uart_0(),
+            uart1: crate::uart::Uart::new_uart_1(),
+            gpio_port: crate::gpio::Port::new(),
+            iom0: crate::iom::Iom::new0(),
+            iom1: crate::iom::Iom::new1(),
+            iom2: crate::iom::Iom::new2(),
+            iom3: crate::iom::Iom::new3(),
+            iom4: crate::iom::Iom::new4(),
+            iom5: crate::iom::Iom::new5(),
+            ble: crate::ble::Ble::new(),
+        }
+    }
+}
+
+impl kernel::InterruptService<()> for Apollo3DefaultPeripherals {
+    unsafe fn service_interrupt(&self, interrupt: u32) -> bool {
+        use crate::nvic;
+        match interrupt {
+            nvic::STIMER..=nvic::STIMER_CMPR7 => self.stimer.handle_interrupt(),
+            nvic::UART0 => self.uart0.handle_interrupt(),
+            nvic::UART1 => self.uart1.handle_interrupt(),
+            nvic::GPIO => self.gpio_port.handle_interrupt(),
+            nvic::IOMSTR0 => self.iom0.handle_interrupt(),
+            nvic::IOMSTR1 => self.iom1.handle_interrupt(),
+            nvic::IOMSTR2 => self.iom2.handle_interrupt(),
+            nvic::IOMSTR3 => self.iom3.handle_interrupt(),
+            nvic::IOMSTR4 => self.iom4.handle_interrupt(),
+            nvic::IOMSTR5 => self.iom5.handle_interrupt(),
+            nvic::BLE => self.ble.handle_interrupt(),
+            _ => return false,
+        }
+        true
+    }
+    unsafe fn service_deferred_call(&self, _: ()) -> bool {
+        false
+    }
+}
+
+impl<I: InterruptService<()> + 'static> Chip for Apollo3<I> {
     type MPU = cortexm4::mpu::MPU;
     type UserspaceKernelBoundary = cortexm4::syscall::SysCall;
     type SchedulerTimer = cortexm4::systick::SysTick;
@@ -37,21 +93,8 @@ impl Chip for Apollo3 {
         unsafe {
             loop {
                 if let Some(interrupt) = cortexm4::nvic::next_pending() {
-                    match interrupt {
-                        nvic::STIMER..=nvic::STIMER_CMPR7 => stimer::STIMER.handle_interrupt(),
-                        nvic::UART0 => uart::UART0.handle_interrupt(),
-                        nvic::UART1 => uart::UART1.handle_interrupt(),
-                        nvic::GPIO => gpio::PORT.handle_interrupt(),
-                        nvic::IOMSTR0 => iom::IOM0.handle_interrupt(),
-                        nvic::IOMSTR1 => iom::IOM1.handle_interrupt(),
-                        nvic::IOMSTR2 => iom::IOM2.handle_interrupt(),
-                        nvic::IOMSTR3 => iom::IOM3.handle_interrupt(),
-                        nvic::IOMSTR4 => iom::IOM4.handle_interrupt(),
-                        nvic::IOMSTR5 => iom::IOM5.handle_interrupt(),
-                        nvic::BLE => ble::BLE.handle_interrupt(),
-                        _ => {
-                            panic!("unhandled interrupt {}", interrupt);
-                        }
+                    if !self.interrupt_service.service_interrupt(interrupt) {
+                        panic!("unhandled interrupt, {}", interrupt);
                     }
 
                     let n = cortexm4::nvic::Nvic::new(interrupt);

--- a/chips/apollo3/src/clkgen.rs
+++ b/chips/apollo3/src/clkgen.rs
@@ -3,8 +3,6 @@
 use kernel::common::registers::{register_bitfields, register_structs, ReadWrite};
 use kernel::common::StaticRef;
 
-pub static mut CLKGEN: ClkGen = ClkGen::new(CLKGEN_BASE);
-
 const CLKGEN_BASE: StaticRef<ClkGenRegisters> =
     unsafe { StaticRef::new(0x4000_4000 as *const ClkGenRegisters) };
 
@@ -58,8 +56,10 @@ pub struct ClkGen {
 }
 
 impl ClkGen {
-    pub const fn new(base: StaticRef<ClkGenRegisters>) -> ClkGen {
-        ClkGen { registers: base }
+    pub const fn new() -> ClkGen {
+        ClkGen {
+            registers: CLKGEN_BASE,
+        }
     }
 
     pub fn set_clock_frequency(&self, frequency: ClockFrequency) {

--- a/chips/apollo3/src/gpio.rs
+++ b/chips/apollo3/src/gpio.rs
@@ -8,11 +8,72 @@ use kernel::common::registers::{register_bitfields, register_structs, ReadWrite}
 use kernel::common::StaticRef;
 use kernel::hil::gpio;
 
+pub const GPIO_BASE_RAW: usize = 0x4001_0000; //safe to export outside crate
+
 const GPIO_BASE: StaticRef<GpioRegisters> =
-    unsafe { StaticRef::new(0x4001_0000 as *const GpioRegisters) };
+    unsafe { StaticRef::new(GPIO_BASE_RAW as *const GpioRegisters) };
 
 pub struct Port<'a> {
     pins: [GpioPin<'a>; 50],
+}
+
+impl<'a> Port<'a> {
+    pub const fn new() -> Self {
+        Self {
+            pins: [
+                GpioPin::new(GPIO_BASE, Pin::Pin00),
+                GpioPin::new(GPIO_BASE, Pin::Pin01),
+                GpioPin::new(GPIO_BASE, Pin::Pin02),
+                GpioPin::new(GPIO_BASE, Pin::Pin03),
+                GpioPin::new(GPIO_BASE, Pin::Pin04),
+                GpioPin::new(GPIO_BASE, Pin::Pin05),
+                GpioPin::new(GPIO_BASE, Pin::Pin06),
+                GpioPin::new(GPIO_BASE, Pin::Pin07),
+                GpioPin::new(GPIO_BASE, Pin::Pin08),
+                GpioPin::new(GPIO_BASE, Pin::Pin09),
+                GpioPin::new(GPIO_BASE, Pin::Pin10),
+                GpioPin::new(GPIO_BASE, Pin::Pin11),
+                GpioPin::new(GPIO_BASE, Pin::Pin12),
+                GpioPin::new(GPIO_BASE, Pin::Pin13),
+                GpioPin::new(GPIO_BASE, Pin::Pin14),
+                GpioPin::new(GPIO_BASE, Pin::Pin15),
+                GpioPin::new(GPIO_BASE, Pin::Pin16),
+                GpioPin::new(GPIO_BASE, Pin::Pin17),
+                GpioPin::new(GPIO_BASE, Pin::Pin18),
+                GpioPin::new(GPIO_BASE, Pin::Pin19),
+                GpioPin::new(GPIO_BASE, Pin::Pin20),
+                GpioPin::new(GPIO_BASE, Pin::Pin21),
+                GpioPin::new(GPIO_BASE, Pin::Pin22),
+                GpioPin::new(GPIO_BASE, Pin::Pin23),
+                GpioPin::new(GPIO_BASE, Pin::Pin24),
+                GpioPin::new(GPIO_BASE, Pin::Pin25),
+                GpioPin::new(GPIO_BASE, Pin::Pin26),
+                GpioPin::new(GPIO_BASE, Pin::Pin27),
+                GpioPin::new(GPIO_BASE, Pin::Pin28),
+                GpioPin::new(GPIO_BASE, Pin::Pin29),
+                GpioPin::new(GPIO_BASE, Pin::Pin30),
+                GpioPin::new(GPIO_BASE, Pin::Pin31),
+                GpioPin::new(GPIO_BASE, Pin::Pin32),
+                GpioPin::new(GPIO_BASE, Pin::Pin33),
+                GpioPin::new(GPIO_BASE, Pin::Pin34),
+                GpioPin::new(GPIO_BASE, Pin::Pin35),
+                GpioPin::new(GPIO_BASE, Pin::Pin36),
+                GpioPin::new(GPIO_BASE, Pin::Pin37),
+                GpioPin::new(GPIO_BASE, Pin::Pin38),
+                GpioPin::new(GPIO_BASE, Pin::Pin39),
+                GpioPin::new(GPIO_BASE, Pin::Pin40),
+                GpioPin::new(GPIO_BASE, Pin::Pin41),
+                GpioPin::new(GPIO_BASE, Pin::Pin42),
+                GpioPin::new(GPIO_BASE, Pin::Pin43),
+                GpioPin::new(GPIO_BASE, Pin::Pin44),
+                GpioPin::new(GPIO_BASE, Pin::Pin45),
+                GpioPin::new(GPIO_BASE, Pin::Pin46),
+                GpioPin::new(GPIO_BASE, Pin::Pin47),
+                GpioPin::new(GPIO_BASE, Pin::Pin48),
+                GpioPin::new(GPIO_BASE, Pin::Pin49),
+            ],
+        }
+    }
 }
 
 impl<'a> Index<usize> for Port<'a> {
@@ -144,61 +205,6 @@ enum_from_primitive! {
         Pin48, Pin49,
     }
 }
-
-pub static mut PORT: Port = Port {
-    pins: [
-        GpioPin::new(GPIO_BASE, Pin::Pin00),
-        GpioPin::new(GPIO_BASE, Pin::Pin01),
-        GpioPin::new(GPIO_BASE, Pin::Pin02),
-        GpioPin::new(GPIO_BASE, Pin::Pin03),
-        GpioPin::new(GPIO_BASE, Pin::Pin04),
-        GpioPin::new(GPIO_BASE, Pin::Pin05),
-        GpioPin::new(GPIO_BASE, Pin::Pin06),
-        GpioPin::new(GPIO_BASE, Pin::Pin07),
-        GpioPin::new(GPIO_BASE, Pin::Pin08),
-        GpioPin::new(GPIO_BASE, Pin::Pin09),
-        GpioPin::new(GPIO_BASE, Pin::Pin10),
-        GpioPin::new(GPIO_BASE, Pin::Pin11),
-        GpioPin::new(GPIO_BASE, Pin::Pin12),
-        GpioPin::new(GPIO_BASE, Pin::Pin13),
-        GpioPin::new(GPIO_BASE, Pin::Pin14),
-        GpioPin::new(GPIO_BASE, Pin::Pin15),
-        GpioPin::new(GPIO_BASE, Pin::Pin16),
-        GpioPin::new(GPIO_BASE, Pin::Pin17),
-        GpioPin::new(GPIO_BASE, Pin::Pin18),
-        GpioPin::new(GPIO_BASE, Pin::Pin19),
-        GpioPin::new(GPIO_BASE, Pin::Pin20),
-        GpioPin::new(GPIO_BASE, Pin::Pin21),
-        GpioPin::new(GPIO_BASE, Pin::Pin22),
-        GpioPin::new(GPIO_BASE, Pin::Pin23),
-        GpioPin::new(GPIO_BASE, Pin::Pin24),
-        GpioPin::new(GPIO_BASE, Pin::Pin25),
-        GpioPin::new(GPIO_BASE, Pin::Pin26),
-        GpioPin::new(GPIO_BASE, Pin::Pin27),
-        GpioPin::new(GPIO_BASE, Pin::Pin28),
-        GpioPin::new(GPIO_BASE, Pin::Pin29),
-        GpioPin::new(GPIO_BASE, Pin::Pin30),
-        GpioPin::new(GPIO_BASE, Pin::Pin31),
-        GpioPin::new(GPIO_BASE, Pin::Pin32),
-        GpioPin::new(GPIO_BASE, Pin::Pin33),
-        GpioPin::new(GPIO_BASE, Pin::Pin34),
-        GpioPin::new(GPIO_BASE, Pin::Pin35),
-        GpioPin::new(GPIO_BASE, Pin::Pin36),
-        GpioPin::new(GPIO_BASE, Pin::Pin37),
-        GpioPin::new(GPIO_BASE, Pin::Pin38),
-        GpioPin::new(GPIO_BASE, Pin::Pin39),
-        GpioPin::new(GPIO_BASE, Pin::Pin40),
-        GpioPin::new(GPIO_BASE, Pin::Pin41),
-        GpioPin::new(GPIO_BASE, Pin::Pin42),
-        GpioPin::new(GPIO_BASE, Pin::Pin43),
-        GpioPin::new(GPIO_BASE, Pin::Pin44),
-        GpioPin::new(GPIO_BASE, Pin::Pin45),
-        GpioPin::new(GPIO_BASE, Pin::Pin46),
-        GpioPin::new(GPIO_BASE, Pin::Pin47),
-        GpioPin::new(GPIO_BASE, Pin::Pin48),
-        GpioPin::new(GPIO_BASE, Pin::Pin49),
-    ],
-};
 
 register_structs! {
     pub GpioRegisters {
@@ -482,7 +488,7 @@ impl<'a> GpioPin<'a> {
     pub const fn new(base: StaticRef<GpioRegisters>, pin: Pin) -> GpioPin<'a> {
         GpioPin {
             registers: base,
-            pin: pin,
+            pin,
             client: OptionalCell::empty(),
         }
     }

--- a/chips/apollo3/src/iom.rs
+++ b/chips/apollo3/src/iom.rs
@@ -8,13 +8,6 @@ use kernel::common::StaticRef;
 use kernel::hil;
 use kernel::hil::i2c;
 
-pub static mut IOM0: Iom = Iom::new(IOM0_BASE);
-pub static mut IOM1: Iom = Iom::new(IOM1_BASE);
-pub static mut IOM2: Iom = Iom::new(IOM2_BASE);
-pub static mut IOM3: Iom = Iom::new(IOM3_BASE);
-pub static mut IOM4: Iom = Iom::new(IOM4_BASE);
-pub static mut IOM5: Iom = Iom::new(IOM5_BASE);
-
 const IOM0_BASE: StaticRef<IomRegisters> =
     unsafe { StaticRef::new(0x5000_4000 as *const IomRegisters) };
 const IOM1_BASE: StaticRef<IomRegisters> =
@@ -281,9 +274,69 @@ pub struct Iom<'a> {
 }
 
 impl<'a> Iom<'_> {
-    pub const fn new(base: StaticRef<IomRegisters>) -> Iom<'a> {
+    pub const fn new0() -> Iom<'a> {
         Iom {
-            registers: base,
+            registers: IOM0_BASE,
+            master_client: OptionalCell::empty(),
+            buffer: TakeCell::empty(),
+            write_len: Cell::new(0),
+            write_index: Cell::new(0),
+            read_len: Cell::new(0),
+            read_index: Cell::new(0),
+            smbus: Cell::new(false),
+        }
+    }
+    pub const fn new1() -> Iom<'a> {
+        Iom {
+            registers: IOM1_BASE,
+            master_client: OptionalCell::empty(),
+            buffer: TakeCell::empty(),
+            write_len: Cell::new(0),
+            write_index: Cell::new(0),
+            read_len: Cell::new(0),
+            read_index: Cell::new(0),
+            smbus: Cell::new(false),
+        }
+    }
+    pub const fn new2() -> Iom<'a> {
+        Iom {
+            registers: IOM2_BASE,
+            master_client: OptionalCell::empty(),
+            buffer: TakeCell::empty(),
+            write_len: Cell::new(0),
+            write_index: Cell::new(0),
+            read_len: Cell::new(0),
+            read_index: Cell::new(0),
+            smbus: Cell::new(false),
+        }
+    }
+    pub const fn new3() -> Iom<'a> {
+        Iom {
+            registers: IOM3_BASE,
+            master_client: OptionalCell::empty(),
+            buffer: TakeCell::empty(),
+            write_len: Cell::new(0),
+            write_index: Cell::new(0),
+            read_len: Cell::new(0),
+            read_index: Cell::new(0),
+            smbus: Cell::new(false),
+        }
+    }
+    pub const fn new4() -> Iom<'a> {
+        Iom {
+            registers: IOM4_BASE,
+            master_client: OptionalCell::empty(),
+            buffer: TakeCell::empty(),
+            write_len: Cell::new(0),
+            write_index: Cell::new(0),
+            read_len: Cell::new(0),
+            read_index: Cell::new(0),
+            smbus: Cell::new(false),
+        }
+    }
+    pub const fn new5() -> Iom<'a> {
+        Iom {
+            registers: IOM5_BASE,
             master_client: OptionalCell::empty(),
             buffer: TakeCell::empty(),
             write_len: Cell::new(0),

--- a/chips/apollo3/src/lib.rs
+++ b/chips/apollo3/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![crate_name = "apollo3"]
 #![crate_type = "rlib"]
-#![feature(llvm_asm, const_fn, naked_functions)]
+#![feature(llvm_asm, naked_functions, const_fn)]
 #![no_std]
 
 // Peripherals
@@ -89,7 +89,8 @@ pub unsafe fn init() {
     tock_rt0::init_data(&mut _etext, &mut _srelocate, &mut _erelocate);
     tock_rt0::zero_bss(&mut _szero, &mut _ezero);
 
-    cachectrl::CACHECTRL.enable_cache();
+    let cache_ctrl = crate::cachectrl::CacheCtrl::new();
+    cache_ctrl.enable_cache();
 
     // Explicitly tell the core where Tock's vector table is located. If Tock is the
     // only thing on the chip then this is effectively a no-op. If, however, there is

--- a/chips/apollo3/src/mcuctrl.rs
+++ b/chips/apollo3/src/mcuctrl.rs
@@ -4,8 +4,6 @@ use kernel::common::registers::{register_bitfields, register_structs, ReadWrite}
 use kernel::common::StaticRef;
 use kernel::debug;
 
-pub static mut MCUCTRL: McuCtrl = McuCtrl::new(MCUCTRL_BASE);
-
 const MCUCTRL_BASE: StaticRef<McuCtrlRegisters> =
     unsafe { StaticRef::new(0x4002_0000 as *const McuCtrlRegisters) };
 
@@ -107,8 +105,10 @@ pub struct McuCtrl {
 }
 
 impl McuCtrl {
-    pub const fn new(base: StaticRef<McuCtrlRegisters>) -> McuCtrl {
-        McuCtrl { registers: base }
+    pub const fn new() -> McuCtrl {
+        McuCtrl {
+            registers: MCUCTRL_BASE,
+        }
     }
 
     pub fn print_chip_revision(&self) {

--- a/chips/apollo3/src/pwrctrl.rs
+++ b/chips/apollo3/src/pwrctrl.rs
@@ -3,8 +3,6 @@
 use kernel::common::registers::{register_bitfields, register_structs, ReadOnly, ReadWrite};
 use kernel::common::StaticRef;
 
-pub static mut PWRCTRL: PwrCtrl = PwrCtrl::new(PWRCTRL_BASE);
-
 const PWRCTRL_BASE: StaticRef<PwrCtrlRegisters> =
     unsafe { StaticRef::new(0x4002_1000 as *const PwrCtrlRegisters) };
 
@@ -72,8 +70,10 @@ pub struct PwrCtrl {
 }
 
 impl PwrCtrl {
-    pub const fn new(base: StaticRef<PwrCtrlRegisters>) -> PwrCtrl {
-        PwrCtrl { registers: base }
+    pub const fn new() -> PwrCtrl {
+        PwrCtrl {
+            registers: PWRCTRL_BASE,
+        }
     }
 
     pub fn enable_uart0(&self) {

--- a/chips/apollo3/src/stimer.rs
+++ b/chips/apollo3/src/stimer.rs
@@ -10,8 +10,6 @@ use kernel::hil::time::{
 
 use kernel::ReturnCode;
 
-pub static mut STIMER: STimer = STimer::new(STIMER_BASE);
-
 const STIMER_BASE: StaticRef<STimerRegisters> =
     unsafe { StaticRef::new(0x4000_8000 as *const STimerRegisters) };
 
@@ -100,9 +98,10 @@ pub struct STimer<'a> {
 }
 
 impl<'a> STimer<'_> {
-    const fn new(base: StaticRef<STimerRegisters>) -> STimer<'a> {
+    // Unsafe bc of use of STIMER_BASE internally
+    pub const fn new() -> STimer<'a> {
         STimer {
-            registers: base,
+            registers: STIMER_BASE,
             client: OptionalCell::empty(),
         }
     }

--- a/chips/apollo3/src/uart.rs
+++ b/chips/apollo3/src/uart.rs
@@ -9,14 +9,10 @@ use kernel::common::StaticRef;
 use kernel::hil;
 use kernel::ReturnCode;
 
-pub static mut UART0: Uart = Uart::new(UART0_BASE);
-
 const UART0_BASE: StaticRef<UartRegisters> =
     unsafe { StaticRef::new(0x4001_C000 as *const UartRegisters) };
 
-pub static mut UART1: Uart = Uart::new(UART1_BASE);
-
-const UART1_BASE: StaticRef<UartRegisters> =
+pub const UART1_BASE: StaticRef<UartRegisters> =
     unsafe { StaticRef::new(0x4001_D000 as *const UartRegisters) };
 
 register_structs! {
@@ -179,9 +175,23 @@ pub struct UartParams {
 }
 
 impl Uart<'_> {
-    pub const fn new(base: StaticRef<UartRegisters>) -> Self {
+    // unsafe bc of UART0_BASE usage, called twice would alias location
+    pub const fn new_uart_0() -> Self {
         Self {
-            registers: base,
+            registers: UART0_BASE,
+            clock_frequency: 24_000_000,
+            tx_client: OptionalCell::empty(),
+            rx_client: OptionalCell::empty(),
+            tx_buffer: TakeCell::empty(),
+            tx_len: Cell::new(0),
+            tx_index: Cell::new(0),
+        }
+    }
+
+    // unsafe bc of UART0_BASE usage, called twice would alias location
+    pub const fn new_uart_1() -> Self {
+        Self {
+            registers: UART1_BASE,
             clock_frequency: 24_000_000,
             tx_client: OptionalCell::empty(),
             rx_client: OptionalCell::empty(),

--- a/chips/sam4l/src/acifc.rs
+++ b/chips/sam4l/src/acifc.rs
@@ -40,7 +40,7 @@ pub struct AcChannel {
 
 #[derive(Copy, Clone, Debug)]
 #[repr(u8)]
-enum Channel {
+pub enum Channel {
     AC0 = 0x00,
     AC1 = 0x01,
     AC2 = 0x02,
@@ -52,18 +52,12 @@ impl AcChannel {
     /// Create a new AC channel.
     ///
     /// - `channel`: Channel enum representing the channel number
-    const fn new(channel: Channel) -> AcChannel {
+    pub const fn new(channel: Channel) -> AcChannel {
         AcChannel {
             chan_num: ((channel as u8) & 0x0F) as u32,
         }
     }
 }
-
-// SAM4L has 2 or 4 possible channels. Hail has 2, Imix has 4.
-pub static mut CHANNEL_AC0: AcChannel = AcChannel::new(Channel::AC0);
-pub static mut CHANNEL_AC1: AcChannel = AcChannel::new(Channel::AC1);
-pub static mut CHANNEL_AC2: AcChannel = AcChannel::new(Channel::AC2);
-pub static mut CHANNEL_AC3: AcChannel = AcChannel::new(Channel::AC3);
 
 #[repr(C)]
 struct AcifcRegisters {
@@ -279,7 +273,7 @@ pub struct Acifc<'a> {
 
 /// Implement constructor for struct Acifc
 impl<'a> Acifc<'a> {
-    const fn new() -> Acifc<'a> {
+    pub const fn new() -> Acifc<'a> {
         Acifc {
             client: Cell::new(None),
         }
@@ -336,7 +330,7 @@ impl<'a> Acifc<'a> {
     /// doesn't fire anymore until the condition is false (e.g. Vinp < Vinn).
     /// This way we won't get a barrage of interrupts as soon as Vinp > Vinn:
     /// we'll get just one.
-    pub fn handle_interrupt(&mut self) {
+    pub fn handle_interrupt(&self) {
         let regs = ACIFC_BASE;
 
         // We check which AC generated the interrupt, and callback to the client accordingly
@@ -537,6 +531,3 @@ impl<'a> analog_comparator::AnalogComparator<'a> for Acifc<'a> {
         self.client.set(Some(client));
     }
 }
-
-/// Static state to manage the ACIFC
-pub static mut ACIFC: Acifc = Acifc::new();

--- a/chips/sam4l/src/aes.rs
+++ b/chips/sam4l/src/aes.rs
@@ -161,7 +161,7 @@ pub struct Aes<'a> {
 }
 
 impl<'a> Aes<'a> {
-    const fn new() -> Aes<'a> {
+    pub const fn new() -> Aes<'a> {
         Aes {
             registers: AES_BASE,
             client: OptionalCell::empty(),
@@ -503,5 +503,3 @@ impl hil::symmetric_encryption::AES128CBC for Aes<'_> {
         self.set_mode(encrypting, ConfidentialityMode::CBC);
     }
 }
-
-pub static mut AES: Aes<'static> = Aes::new();

--- a/chips/sam4l/src/ast.rs
+++ b/chips/sam4l/src/ast.rs
@@ -170,10 +170,14 @@ pub struct Ast<'a> {
     callback: OptionalCell<&'a dyn time::AlarmClient>,
 }
 
-pub static mut AST: Ast<'static> = Ast {
-    registers: AST_ADDRESS,
-    callback: OptionalCell::empty(),
-};
+impl<'a> Ast<'a> {
+    pub const fn new() -> Self {
+        Self {
+            registers: AST_ADDRESS,
+            callback: OptionalCell::empty(),
+        }
+    }
+}
 
 impl Controller for Ast<'_> {
     type Config = &'static dyn time::AlarmClient;
@@ -294,7 +298,7 @@ impl<'a> Ast<'a> {
         regs.cv.set(val);
     }
 
-    pub fn handle_interrupt(&mut self) {
+    pub fn handle_interrupt(&self) {
         self.clear_alarm();
         self.callback.map(|cb| {
             cb.alarm();

--- a/chips/sam4l/src/crccu.rs
+++ b/chips/sam4l/src/crccu.rs
@@ -238,9 +238,9 @@ pub struct Crccu<'a> {
 const DSCR_RESERVE: usize = 512 + 5 * 4;
 
 impl Crccu<'_> {
-    const fn new(base_address: StaticRef<CrccuRegisters>) -> Self {
+    pub const fn new() -> Self {
         Crccu {
-            registers: base_address,
+            registers: BASE_ADDRESS,
             client: OptionalCell::empty(),
             state: Cell::new(State::Invalid),
             alg: Cell::new(CrcAlg::Crc32C),
@@ -297,7 +297,7 @@ impl Crccu<'_> {
     }
 
     /// Handle an interrupt from the CRCCU
-    pub fn handle_interrupt(&mut self) {
+    pub fn handle_interrupt(&self) {
         if self.registers.isr.is_set(Interrupt::ERR) {
             // A CRC error has occurred
         }
@@ -392,6 +392,3 @@ impl<'a> crc::CRC<'a> for Crccu<'a> {
         Crccu::disable(self);
     }
 }
-
-/// Static state to manage the CRCCU
-pub static mut CRCCU: Crccu<'static> = Crccu::new(BASE_ADDRESS);

--- a/chips/sam4l/src/dac.rs
+++ b/chips/sam4l/src/dac.rs
@@ -121,18 +121,16 @@ pub struct Dac {
     enabled: Cell<bool>,
 }
 
-pub static mut DAC: Dac = Dac::new(DAC_BASE);
-
 impl Dac {
-    const fn new(base_address: StaticRef<DacRegisters>) -> Dac {
-        Dac {
-            registers: base_address,
+    pub const fn new() -> Self {
+        Self {
+            registers: DAC_BASE,
             enabled: Cell::new(false),
         }
     }
 
     // Not currently using interrupt.
-    pub fn handle_interrupt(&mut self) {}
+    pub fn handle_interrupt(&self) {}
 }
 
 impl hil::dac::DacChannel for Dac {

--- a/chips/sam4l/src/dma.rs
+++ b/chips/sam4l/src/dma.rs
@@ -174,25 +174,6 @@ pub enum DMAWidth {
     Width32Bit = 2,
 }
 
-pub static mut DMA_CHANNELS: [DMAChannel; 16] = [
-    DMAChannel::new(DMAChannelNum::DMAChannel00),
-    DMAChannel::new(DMAChannelNum::DMAChannel01),
-    DMAChannel::new(DMAChannelNum::DMAChannel02),
-    DMAChannel::new(DMAChannelNum::DMAChannel03),
-    DMAChannel::new(DMAChannelNum::DMAChannel04),
-    DMAChannel::new(DMAChannelNum::DMAChannel05),
-    DMAChannel::new(DMAChannelNum::DMAChannel06),
-    DMAChannel::new(DMAChannelNum::DMAChannel07),
-    DMAChannel::new(DMAChannelNum::DMAChannel08),
-    DMAChannel::new(DMAChannelNum::DMAChannel09),
-    DMAChannel::new(DMAChannelNum::DMAChannel10),
-    DMAChannel::new(DMAChannelNum::DMAChannel11),
-    DMAChannel::new(DMAChannelNum::DMAChannel12),
-    DMAChannel::new(DMAChannelNum::DMAChannel13),
-    DMAChannel::new(DMAChannelNum::DMAChannel14),
-    DMAChannel::new(DMAChannelNum::DMAChannel15),
-];
-
 pub struct DMAChannel {
     registers: StaticRef<DMARegisters>,
     client: OptionalCell<&'static dyn DMAClient>,
@@ -206,7 +187,7 @@ pub trait DMAClient {
 }
 
 impl DMAChannel {
-    const fn new(channel: DMAChannelNum) -> DMAChannel {
+    pub const fn new(channel: DMAChannelNum) -> DMAChannel {
         DMAChannel {
             registers: unsafe {
                 StaticRef::new(
@@ -220,7 +201,7 @@ impl DMAChannel {
         }
     }
 
-    pub fn initialize(&self, client: &'static mut dyn DMAClient, width: DMAWidth) {
+    pub fn initialize(&self, client: &'static dyn DMAClient, width: DMAWidth) {
         self.client.set(client);
         self.width.set(width);
     }
@@ -261,7 +242,7 @@ impl DMAChannel {
         self.enabled.get()
     }
 
-    pub fn handle_interrupt(&mut self) {
+    pub fn handle_interrupt(&self) {
         self.registers
             .idr
             .write(Interrupt::TERR::SET + Interrupt::TRC::SET + Interrupt::RCZ::SET);

--- a/chips/sam4l/src/eic.rs
+++ b/chips/sam4l/src/eic.rs
@@ -237,7 +237,7 @@ impl<'a> Eic<'a> {
         }
     }
 
-    const fn new() -> Eic<'a> {
+    pub const fn new() -> Eic<'a> {
         Eic {
             callbacks: [
                 OptionalCell::empty(),
@@ -342,6 +342,3 @@ impl<'a> Eic<'a> {
         ((*line as u32) & regs.asynchronous.get()) != 0
     }
 }
-
-/// Static state to manage the EIC
-pub static mut EIC: Eic = Eic::new();

--- a/chips/sam4l/src/flashcalw.rs
+++ b/chips/sam4l/src/flashcalw.rs
@@ -418,14 +418,6 @@ pub struct FLASHCALW {
     buffer: TakeCell<'static, Sam4lPage>,
 }
 
-// static instance for the board. Only one FLASHCALW on chip.
-pub static mut FLASH_CONTROLLER: FLASHCALW = FLASHCALW::new(
-    FLASHCALW_ADDRESS,
-    pm::HSBClock::FLASHCALW,
-    pm::HSBClock::FLASHCALWP,
-    pm::PBBClock::FLASHCALW,
-);
-
 // Few constants relating to module configuration.
 const PAGE_SIZE: u32 = 512;
 
@@ -442,14 +434,13 @@ const FREQ_PS1_FWS_0_MAX_FREQ: u32 = 8000000;
 const FREQ_PS2_FWS_0_MAX_FREQ: u32 = 24000000;
 
 impl FLASHCALW {
-    const fn new(
-        registers: StaticRef<FlashcalwRegisters>,
+    pub const fn new(
         ahb_clk: pm::HSBClock,
         hramc1_clk: pm::HSBClock,
         pb_clk: pm::PBBClock,
     ) -> FLASHCALW {
         FLASHCALW {
-            registers: registers,
+            registers: FLASHCALW_ADDRESS,
             ahb_clock: pm::Clock::HSB(ahb_clk),
             hramc1_clock: pm::Clock::HSB(hramc1_clk),
             pb_clock: pm::Clock::PBB(pb_clk),

--- a/chips/sam4l/src/gloc.rs
+++ b/chips/sam4l/src/gloc.rs
@@ -53,9 +53,13 @@ pub struct Gloc {
     lut_regs: [StaticRef<GlocRegisters>; 2],
 }
 
-pub static mut GLOC: Gloc = Gloc {
-    lut_regs: [get_lut_reg(Lut::Lut0), get_lut_reg(Lut::Lut1)],
-};
+impl Gloc {
+    pub const fn new() -> Self {
+        Self {
+            lut_regs: [get_lut_reg(Lut::Lut0), get_lut_reg(Lut::Lut1)],
+        }
+    }
+}
 
 /// Gets the memory location of the memory-mapped registers of a LUT.
 const fn get_lut_reg(lut: Lut) -> StaticRef<GlocRegisters> {

--- a/chips/sam4l/src/gpio.rs
+++ b/chips/sam4l/src/gpio.rs
@@ -152,6 +152,126 @@ impl<'a> IndexMut<usize> for Port<'a> {
 }
 
 impl<'a> Port<'a> {
+    pub const fn new_port_a() -> Self {
+        Self {
+            port: unsafe { StaticRef::new(BASE_ADDRESS as *const GpioRegisters) },
+            pins: [
+                GPIOPin::new(Pin::PA00),
+                GPIOPin::new(Pin::PA01),
+                GPIOPin::new(Pin::PA02),
+                GPIOPin::new(Pin::PA03),
+                GPIOPin::new(Pin::PA04),
+                GPIOPin::new(Pin::PA05),
+                GPIOPin::new(Pin::PA06),
+                GPIOPin::new(Pin::PA07),
+                GPIOPin::new(Pin::PA08),
+                GPIOPin::new(Pin::PA09),
+                GPIOPin::new(Pin::PA10),
+                GPIOPin::new(Pin::PA11),
+                GPIOPin::new(Pin::PA12),
+                GPIOPin::new(Pin::PA13),
+                GPIOPin::new(Pin::PA14),
+                GPIOPin::new(Pin::PA15),
+                GPIOPin::new(Pin::PA16),
+                GPIOPin::new(Pin::PA17),
+                GPIOPin::new(Pin::PA18),
+                GPIOPin::new(Pin::PA19),
+                GPIOPin::new(Pin::PA20),
+                GPIOPin::new(Pin::PA21),
+                GPIOPin::new(Pin::PA22),
+                GPIOPin::new(Pin::PA23),
+                GPIOPin::new(Pin::PA24),
+                GPIOPin::new(Pin::PA25),
+                GPIOPin::new(Pin::PA26),
+                GPIOPin::new(Pin::PA27),
+                GPIOPin::new(Pin::PA28),
+                GPIOPin::new(Pin::PA29),
+                GPIOPin::new(Pin::PA30),
+                GPIOPin::new(Pin::PA31),
+            ],
+        }
+    }
+
+    pub const fn new_port_b() -> Self {
+        Self {
+            port: unsafe { StaticRef::new((BASE_ADDRESS + 1 * SIZE) as *const GpioRegisters) },
+            pins: [
+                GPIOPin::new(Pin::PB00),
+                GPIOPin::new(Pin::PB01),
+                GPIOPin::new(Pin::PB02),
+                GPIOPin::new(Pin::PB03),
+                GPIOPin::new(Pin::PB04),
+                GPIOPin::new(Pin::PB05),
+                GPIOPin::new(Pin::PB06),
+                GPIOPin::new(Pin::PB07),
+                GPIOPin::new(Pin::PB08),
+                GPIOPin::new(Pin::PB09),
+                GPIOPin::new(Pin::PB10),
+                GPIOPin::new(Pin::PB11),
+                GPIOPin::new(Pin::PB12),
+                GPIOPin::new(Pin::PB13),
+                GPIOPin::new(Pin::PB14),
+                GPIOPin::new(Pin::PB15),
+                GPIOPin::new(Pin::PB16),
+                GPIOPin::new(Pin::PB17),
+                GPIOPin::new(Pin::PB18),
+                GPIOPin::new(Pin::PB19),
+                GPIOPin::new(Pin::PB20),
+                GPIOPin::new(Pin::PB21),
+                GPIOPin::new(Pin::PB22),
+                GPIOPin::new(Pin::PB23),
+                GPIOPin::new(Pin::PB24),
+                GPIOPin::new(Pin::PB25),
+                GPIOPin::new(Pin::PB26),
+                GPIOPin::new(Pin::PB27),
+                GPIOPin::new(Pin::PB28),
+                GPIOPin::new(Pin::PB29),
+                GPIOPin::new(Pin::PB30),
+                GPIOPin::new(Pin::PB31),
+            ],
+        }
+    }
+
+    pub const fn new_port_c() -> Self {
+        Self {
+            port: unsafe { StaticRef::new((BASE_ADDRESS + 2 * SIZE) as *const GpioRegisters) },
+            pins: [
+                GPIOPin::new(Pin::PC00),
+                GPIOPin::new(Pin::PC01),
+                GPIOPin::new(Pin::PC02),
+                GPIOPin::new(Pin::PC03),
+                GPIOPin::new(Pin::PC04),
+                GPIOPin::new(Pin::PC05),
+                GPIOPin::new(Pin::PC06),
+                GPIOPin::new(Pin::PC07),
+                GPIOPin::new(Pin::PC08),
+                GPIOPin::new(Pin::PC09),
+                GPIOPin::new(Pin::PC10),
+                GPIOPin::new(Pin::PC11),
+                GPIOPin::new(Pin::PC12),
+                GPIOPin::new(Pin::PC13),
+                GPIOPin::new(Pin::PC14),
+                GPIOPin::new(Pin::PC15),
+                GPIOPin::new(Pin::PC16),
+                GPIOPin::new(Pin::PC17),
+                GPIOPin::new(Pin::PC18),
+                GPIOPin::new(Pin::PC19),
+                GPIOPin::new(Pin::PC20),
+                GPIOPin::new(Pin::PC21),
+                GPIOPin::new(Pin::PC22),
+                GPIOPin::new(Pin::PC23),
+                GPIOPin::new(Pin::PC24),
+                GPIOPin::new(Pin::PC25),
+                GPIOPin::new(Pin::PC26),
+                GPIOPin::new(Pin::PC27),
+                GPIOPin::new(Pin::PC28),
+                GPIOPin::new(Pin::PC29),
+                GPIOPin::new(Pin::PC30),
+                GPIOPin::new(Pin::PC31),
+            ],
+        }
+    }
+
     pub fn handle_interrupt(&self) {
         let port: &GpioRegisters = &*self.port;
 
@@ -171,122 +291,6 @@ impl<'a> Port<'a> {
     }
 }
 
-/// Port A
-pub static mut PA: Port = Port {
-    port: unsafe { StaticRef::new(BASE_ADDRESS as *const GpioRegisters) },
-    pins: [
-        GPIOPin::new(Pin::PA00),
-        GPIOPin::new(Pin::PA01),
-        GPIOPin::new(Pin::PA02),
-        GPIOPin::new(Pin::PA03),
-        GPIOPin::new(Pin::PA04),
-        GPIOPin::new(Pin::PA05),
-        GPIOPin::new(Pin::PA06),
-        GPIOPin::new(Pin::PA07),
-        GPIOPin::new(Pin::PA08),
-        GPIOPin::new(Pin::PA09),
-        GPIOPin::new(Pin::PA10),
-        GPIOPin::new(Pin::PA11),
-        GPIOPin::new(Pin::PA12),
-        GPIOPin::new(Pin::PA13),
-        GPIOPin::new(Pin::PA14),
-        GPIOPin::new(Pin::PA15),
-        GPIOPin::new(Pin::PA16),
-        GPIOPin::new(Pin::PA17),
-        GPIOPin::new(Pin::PA18),
-        GPIOPin::new(Pin::PA19),
-        GPIOPin::new(Pin::PA20),
-        GPIOPin::new(Pin::PA21),
-        GPIOPin::new(Pin::PA22),
-        GPIOPin::new(Pin::PA23),
-        GPIOPin::new(Pin::PA24),
-        GPIOPin::new(Pin::PA25),
-        GPIOPin::new(Pin::PA26),
-        GPIOPin::new(Pin::PA27),
-        GPIOPin::new(Pin::PA28),
-        GPIOPin::new(Pin::PA29),
-        GPIOPin::new(Pin::PA30),
-        GPIOPin::new(Pin::PA31),
-    ],
-};
-
-/// Port B
-pub static mut PB: Port = Port {
-    port: unsafe { StaticRef::new((BASE_ADDRESS + 1 * SIZE) as *const GpioRegisters) },
-    pins: [
-        GPIOPin::new(Pin::PB00),
-        GPIOPin::new(Pin::PB01),
-        GPIOPin::new(Pin::PB02),
-        GPIOPin::new(Pin::PB03),
-        GPIOPin::new(Pin::PB04),
-        GPIOPin::new(Pin::PB05),
-        GPIOPin::new(Pin::PB06),
-        GPIOPin::new(Pin::PB07),
-        GPIOPin::new(Pin::PB08),
-        GPIOPin::new(Pin::PB09),
-        GPIOPin::new(Pin::PB10),
-        GPIOPin::new(Pin::PB11),
-        GPIOPin::new(Pin::PB12),
-        GPIOPin::new(Pin::PB13),
-        GPIOPin::new(Pin::PB14),
-        GPIOPin::new(Pin::PB15),
-        GPIOPin::new(Pin::PB16),
-        GPIOPin::new(Pin::PB17),
-        GPIOPin::new(Pin::PB18),
-        GPIOPin::new(Pin::PB19),
-        GPIOPin::new(Pin::PB20),
-        GPIOPin::new(Pin::PB21),
-        GPIOPin::new(Pin::PB22),
-        GPIOPin::new(Pin::PB23),
-        GPIOPin::new(Pin::PB24),
-        GPIOPin::new(Pin::PB25),
-        GPIOPin::new(Pin::PB26),
-        GPIOPin::new(Pin::PB27),
-        GPIOPin::new(Pin::PB28),
-        GPIOPin::new(Pin::PB29),
-        GPIOPin::new(Pin::PB30),
-        GPIOPin::new(Pin::PB31),
-    ],
-};
-
-/// Port C
-pub static mut PC: Port = Port {
-    port: unsafe { StaticRef::new((BASE_ADDRESS + 2 * SIZE) as *const GpioRegisters) },
-    pins: [
-        GPIOPin::new(Pin::PC00),
-        GPIOPin::new(Pin::PC01),
-        GPIOPin::new(Pin::PC02),
-        GPIOPin::new(Pin::PC03),
-        GPIOPin::new(Pin::PC04),
-        GPIOPin::new(Pin::PC05),
-        GPIOPin::new(Pin::PC06),
-        GPIOPin::new(Pin::PC07),
-        GPIOPin::new(Pin::PC08),
-        GPIOPin::new(Pin::PC09),
-        GPIOPin::new(Pin::PC10),
-        GPIOPin::new(Pin::PC11),
-        GPIOPin::new(Pin::PC12),
-        GPIOPin::new(Pin::PC13),
-        GPIOPin::new(Pin::PC14),
-        GPIOPin::new(Pin::PC15),
-        GPIOPin::new(Pin::PC16),
-        GPIOPin::new(Pin::PC17),
-        GPIOPin::new(Pin::PC18),
-        GPIOPin::new(Pin::PC19),
-        GPIOPin::new(Pin::PC20),
-        GPIOPin::new(Pin::PC21),
-        GPIOPin::new(Pin::PC22),
-        GPIOPin::new(Pin::PC23),
-        GPIOPin::new(Pin::PC24),
-        GPIOPin::new(Pin::PC25),
-        GPIOPin::new(Pin::PC26),
-        GPIOPin::new(Pin::PC27),
-        GPIOPin::new(Pin::PC28),
-        GPIOPin::new(Pin::PC29),
-        GPIOPin::new(Pin::PC30),
-        GPIOPin::new(Pin::PC31),
-    ],
-};
 pub struct GPIOPin<'a> {
     port: StaticRef<GpioRegisters>,
     pin_mask: u32,
@@ -294,7 +298,7 @@ pub struct GPIOPin<'a> {
 }
 
 impl<'a> GPIOPin<'a> {
-    const fn new(pin: Pin) -> GPIOPin<'a> {
+    pub const fn new(pin: Pin) -> GPIOPin<'a> {
         GPIOPin {
             port: unsafe {
                 StaticRef::new(

--- a/chips/sam4l/src/lib.rs
+++ b/chips/sam4l/src/lib.rs
@@ -7,7 +7,7 @@
 #![feature(const_fn)]
 #![no_std]
 
-mod deferred_call_tasks;
+pub mod deferred_call_tasks;
 
 pub mod acifc;
 pub mod adc;

--- a/chips/sam4l/src/serial_num.rs
+++ b/chips/sam4l/src/serial_num.rs
@@ -22,6 +22,8 @@ pub struct SerialNum {
 
 impl SerialNum {
     /// Returns a struct that can read the serial number of the sam4l
+    /// This function aliases the memory location of the underlying serial num address, but because
+    /// this struct only provides read operations of the serial number, this is okay.
     pub fn new() -> SerialNum {
         SerialNum {
             regs: SERIAL_NUM_ADDRESS,

--- a/chips/sam4l/src/trng.rs
+++ b/chips/sam4l/src/trng.rs
@@ -50,11 +50,10 @@ pub struct Trng<'a> {
     client: OptionalCell<&'a dyn entropy::Client32>,
 }
 
-pub static mut TRNG: Trng<'static> = Trng::new();
 const KEY: u32 = 0x524e47;
 
 impl<'a> Trng<'a> {
-    const fn new() -> Trng<'a> {
+    pub const fn new() -> Trng<'a> {
         Trng {
             regs: BASE_ADDRESS,
             client: OptionalCell::empty(),

--- a/chips/sam4l/src/wdt.rs
+++ b/chips/sam4l/src/wdt.rs
@@ -103,8 +103,6 @@ pub struct Wdt {
     enabled: Cell<bool>,
 }
 
-pub static mut WDT: Wdt = Wdt::new();
-
 #[derive(Copy, Clone)]
 pub enum WdtClockSource {
     ClockRCSys = 0,
@@ -121,7 +119,7 @@ impl From<WdtClockSource> for FieldValue<u32, Control::Register> {
 }
 
 impl Wdt {
-    const fn new() -> Wdt {
+    pub const fn new() -> Wdt {
         Wdt {
             enabled: Cell::new(false),
         }

--- a/doc/Porting.md
+++ b/doc/Porting.md
@@ -96,6 +96,15 @@ Moving forward, chips tend to break down into reasonable units of work.
 Implement something like `kernel::hil::UART` for your chip, then submit a pull
 request. Pick a new peripheral and repeat!
 
+Historically, Tock chips defined peripherals as `static mut` global variables, which made
+them easy to access but encouraged use of unsafe code and prevented boards from
+instantiating only the set of peripherals they needed. Now, peripherals are instantiated
+at runtime in `main.rs`, which resolves these issues. To prevent each board from having
+to instantiate peripherals individually, chips should provide a `ChipNameDefaultPeripherals`
+struct that defines and creates all peripherals available for the chip in Tock. This will be
+used by upstream boards using the chip, without forcing the overhead and code size of all peripherals
+on more minimal out-of-tree boards.
+
 
 ### `board` Crate
 

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -116,7 +116,7 @@ pub use crate::grant::Grant;
 pub use crate::mem::{AppSlice, Private, Shared};
 pub use crate::platform::scheduler_timer::{SchedulerTimer, VirtualSchedulerTimer};
 pub use crate::platform::watchdog;
-pub use crate::platform::{mpu, Chip, Platform};
+pub use crate::platform::{mpu, Chip, InterruptService, Platform};
 pub use crate::platform::{ClockInterface, NoClockControl, NO_CLOCK_CONTROL};
 pub use crate::returncode::ReturnCode;
 pub use crate::sched::cooperative::{CoopProcessNode, CooperativeSched};

--- a/kernel/src/platform/mod.rs
+++ b/kernel/src/platform/mod.rs
@@ -139,6 +139,19 @@ pub trait Chip {
     unsafe fn print_state(&self, writer: &mut dyn Write);
 }
 
+/// Trait for objects that can map interrupts to hardware peripherals.
+/// Each chip should accept a generic argument of this type, and use it to
+/// map interrupts. This allows out-of-tree boards to exclude code for chip peripheral drivers
+/// they do not use.
+pub trait InterruptService<T> {
+    /// Service an interrupt, if supported by this chip. If this interrupt number is not supported,
+    /// return false.
+    unsafe fn service_interrupt(&self, interrupt: u32) -> bool;
+
+    /// Service a deferred call. If this task is not supported, return false.
+    unsafe fn service_deferred_call(&self, task: T) -> bool;
+}
+
 /// Generic operations that clock-like things are expected to support.
 pub trait ClockInterface {
     fn is_enabled(&self) -> bool;

--- a/libraries/tock-cells/src/lib.rs
+++ b/libraries/tock-cells/src/lib.rs
@@ -1,6 +1,5 @@
 //! Tock Cell types.
 
-#![feature(const_fn)]
 // Feature used to opt-in the new `core::Option::contains()` API.
 //
 // This feature can be removed if needed by manually reimplementing the
@@ -8,7 +7,7 @@
 //
 // Tock expects this feature to stabilize in the near future.
 // Tracking: https://github.com/rust-lang/rust/issues/62358
-#![feature(option_result_contains)]
+#![feature(option_result_contains, const_fn)]
 #![no_std]
 
 pub mod map_cell;

--- a/libraries/tock-cells/src/lib.rs
+++ b/libraries/tock-cells/src/lib.rs
@@ -1,5 +1,6 @@
 //! Tock Cell types.
 
+#![feature(const_fn)]
 // Feature used to opt-in the new `core::Option::contains()` API.
 //
 // This feature can be removed if needed by manually reimplementing the
@@ -7,7 +8,7 @@
 //
 // Tock expects this feature to stabilize in the near future.
 // Tracking: https://github.com/rust-lang/rust/issues/62358
-#![feature(option_result_contains, const_fn)]
+#![feature(option_result_contains)]
 #![no_std]
 
 pub mod map_cell;


### PR DESCRIPTION
### Pull Request Overview

This pull request proposes a new design for managing chip drivers and interrupts.
The new design makes boards responsible for instantiating chip drivers, and for defining the mapping from interrupt numbers --> drivers.
It also adds the `InterruptService` trait to `kernel/src/platform/mod.rs`, as it will no longer only be used by nordic boards.

I would appreciate feedback before I implement this for all chips/boards, and answers to my outstanding questions below.

#### Advantages of the design:
- makes it possible for boards to exclude code for chip drivers that they are not using (e.g. solves #625)
- makes boards responsible for static initialization of all chip drivers, much in the same way that boards are responsible for initializing capsules, which removes reliance on global `static mut` variables in these scenarios (a step in the right direction for #1545 / #1662 ).
- If so desired, out-of-tree board authors can write chip drivers that live in the boards crate, and still use the upstream chip crate. 
- introduces macros that live in `chips/` to define the default interrupt mapping, so that upstream boards will not have to reimplement interrupt -> driver mappings in the common case.
- removes all dependence on `const_fn` throughout Tock, except for in `tock-register-interface`. Most uses of `const_fn` in Tock today are only required because of the widespread practice of initializing drivers as globals. By transitioning away from this design, most constructors can be made non-const, a big step towards #1654 .
- I think these changes would enable OpenTitan to use the upstream `earlgray` crate, and maintain only a board crate out-of-tree, which is probably a win for both projects.

So far, this PR is only implemented for the `apollo3`/`redboard_artemis_nano` combination (I picked it because there aren't very many apollo3 drivers at this point, so the total work was smallest).

I have verified that this PR excludes chip driver code in a way that is not currently possible on master, by removing the ble and i2c drivers from the board. Unfortunately removing const_fn everywhere seems to have introduced some code size cost.

### Testing Strategy

This pull request was tested by compiling.

### TODO or Help Wanted

#### Outstanding Questions

1. How to handle deferred calls? I propose that they should be handled identically to interrupts in this design, that is `handle_deferred_call()` should be added to the `InterruptService` trait, and populated by a macro for the common case. -- Done.

2. ~~Is modifying the `Platform` trait ideal, or would it be better to use basically the `InterruptService` trait suggested in #1501, which could be implemented for the Platform, or for a struct containing just the drivers?~~ I decided that using `InterruptService` is clearer and makes more sense than conflating `Platform` with interrupt mapping. This technique allows for chips to still define some set of required interrupt mappings if it wishes, and should make adapting this to the nordic boards easier.

3. ~~Is it in fact desirable to remove all uses of `#[const_fn]`, or should I remove that portion of this PR and save it as a followup PR? It seems to me that const constructors would be preferable if the feature was stable, so maybe I am jumping the gun on this.~~ Decided to revert the const removals, for now.

4. Some drivers do not handle interrupts (`mcuctrl`, `pwrctrl`, `clkctrl` in the `Apollo3` case), but still do not need to be initialized as globals. I propose that when these drivers are only used in `main.rs`, they should simply be stack allocated in `reset_handler()`. If used in `chip.rs`, they should be made fields on the respective chip struct, and initialized with the Chip. This makes it clear which drivers are necessary for chip operation vs. optionally included by boards. In fact, this approach could be taken one step further, by making "required" drivers fields of the chip struct. Things like uart and timer which are prerequisites for including a board in Tock could be placed on the chip struct.

### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
