### PR TITLE
Update tock-registers doc to fix mistake

### DIFF
--- a/libraries/tock-register-interface/README.md
+++ b/libraries/tock-register-interface/README.md
@@ -166,9 +166,8 @@ Bitfields are defined through the `register_bitfields!` macro:
 
 ```rust
 register_bitfields! [
-    // First parameter is the register width for the bitfields. Can be u8, u16,
-    // u32, or u64.
-    u8,
+    // First parameter is the register width. Can be u8, u16, u32, or u64.
+    u32,
 
     // Each subsequent parameter is a register abbreviation, its descriptive
     // name, and its associated bitfields.


### PR DESCRIPTION
Default is u32, and register fields in the example were greater than 8 bits in size, so we should just use 32-bits as the register size in the example.

### Pull Request Overview

Modifies tock-registers README.


### Testing Strategy

N/A


### TODO or Help Wanted

N/A


### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [N/A] Ran `make prepush`.
