### PR TITLE
RISC-V: Update panic debug print

### DIFF
--- a/arch/rv32i/src/lib.rs
+++ b/arch/rv32i/src/lib.rs
@@ -318,13 +318,16 @@ pub extern "C" fn _start_trap() {
             // need to store mcause because we use that to determine why the app
             // stopped executing and returned to the kernel. We store mepc
             // because it is where we need to return to in the app at some
-            // point.
+            // point. We need to store mtval in case the app faulted and we need
+            // mtval to help with debugging.
             csrr t0, 0x340    // CSR=0x340=mscratch
             sw   t0, 1*4(s0)  // Save the app sp to the stored state struct
             csrr t0, 0x341    // CSR=0x341=mepc
             sw   t0, 31*4(s0) // Save the PC to the stored state struct
             csrr t0, 0x342    // CSR=0x342=mcause
             sw   t0, 32*4(s0) // Save mcause to the stored state struct
+            csrr t0, 0x343    // CSR=0x343=mtval
+            sw   t0, 33*4(s0) // Save mtval to the stored state struct
 
             // Now we need to check if this was an interrupt, and if it was,
             // then we need to disable the interrupt before returning from this

--- a/arch/rv32i/src/lib.rs
+++ b/arch/rv32i/src/lib.rs
@@ -384,12 +384,8 @@ pub extern "C" fn abort() {
     }
 }
 
-/// Prints out RISCV machine state, including basic system registers
-/// (mcause, mstatus, mtvec, mepc, mtval, interrupt status).
-pub unsafe fn print_riscv_state(writer: &mut dyn Write) {
-    let mcval: csr::mcause::Trap = core::convert::From::from(csr::CSR.mcause.extract());
-    let _ = writer.write_fmt(format_args!("\r\n---| RISC-V Machine State |---\r\n"));
-    let _ = writer.write_fmt(format_args!("Cause (mcause): "));
+/// Print a readable string for an mcause reason.
+pub unsafe fn print_mcause(mcval: csr::mcause::Trap, writer: &mut dyn Write) {
     match mcval {
         csr::mcause::Trap::Interrupt(interrupt) => match interrupt {
             csr::mcause::Interrupt::UserSoft => {
@@ -471,15 +467,24 @@ pub unsafe fn print_riscv_state(writer: &mut dyn Write) {
             }
         },
     }
+}
+
+/// Prints out RISCV machine state, including basic system registers
+/// (mcause, mstatus, mtvec, mepc, mtval, interrupt status).
+pub unsafe fn print_riscv_state(writer: &mut dyn Write) {
+    let mcval: csr::mcause::Trap = core::convert::From::from(csr::CSR.mcause.extract());
+    let _ = writer.write_fmt(format_args!("\r\n---| RISC-V Machine State |---\r\n"));
+    let _ = writer.write_fmt(format_args!("Last cause (mcause): "));
+    print_mcause(mcval, writer);
     let mval = csr::CSR.mcause.get();
     let interrupt = (mval & 0x80000000) == 0x80000000;
     let code = mval & 0x7fffffff;
     let _ = writer.write_fmt(format_args!(
-        " (interrupt={}, exception code={})",
+        " (interrupt={}, exception code={:#010X})",
         interrupt, code
     ));
     let _ = writer.write_fmt(format_args!(
-        "\r\nValue (mtval):  {:#010X}\
+        "\r\nLast value (mtval):  {:#010X}\
          \r\n\
          \r\nSystem register dump:\
          \r\n mepc:    {:#010X}    mstatus:     {:#010X}\
@@ -501,15 +506,19 @@ pub unsafe fn print_riscv_state(writer: &mut dyn Write) {
     let mpie = mstatus.is_set(csr::mstatus::mstatus::mpie);
     let spp = mstatus.is_set(csr::mstatus::mstatus::spp);
     let _ = writer.write_fmt(format_args!(
-        "\r\n mstatus:\
-         \r\n  uie:    {}\
-         \r\n  sie:    {}\
-         \r\n  mie:    {}\
-         \r\n  upie:   {}\
-         \r\n  spie:   {}\
-         \r\n  mpie:   {}\
+        "\r\n mstatus: {:#010X}\
+         \r\n  uie:    {:5}  upie:   {}\
+         \r\n  sie:    {:5}  spie:   {}\
+         \r\n  mie:    {:5}  mpie:   {}\
          \r\n  spp:    {}",
-        uie, sie, mie, upie, spie, mpie, spp
+        mstatus.get(),
+        uie,
+        upie,
+        sie,
+        spie,
+        mie,
+        mpie,
+        spp
     ));
     let e_usoft = csr::CSR.mie.is_set(csr::mie::mie::usoft);
     let e_ssoft = csr::CSR.mie.is_set(csr::mie::mie::ssoft);
@@ -531,7 +540,7 @@ pub unsafe fn print_riscv_state(writer: &mut dyn Write) {
     let p_sext = csr::CSR.mip.is_set(csr::mip::mip::sext);
     let p_mext = csr::CSR.mip.is_set(csr::mip::mip::mext);
     let _ = writer.write_fmt(format_args!(
-        "\r\n mie:   0x{:08X}   mip:   0x{:08X}\
+        "\r\n mie:   {:#010X}   mip:   {:#010X}\
          \r\n  usoft:  {:6}              {:6}\
          \r\n  ssoft:  {:6}              {:6}\
          \r\n  msoft:  {:6}              {:6}\

--- a/arch/rv32i/src/pmp.rs
+++ b/arch/rv32i/src/pmp.rs
@@ -90,7 +90,7 @@ impl fmt::Display for PMPRegion {
 
         write!(
             f,
-            "addr={:p}, size={:#X}, cfg={:#X} ({}{}{})",
+            "addr={:p}, size={:#010X}, cfg={:#X} ({}{}{})",
             self.location.0,
             self.location.1,
             u8::from(self.cfg),
@@ -175,11 +175,11 @@ impl Default for PMPConfig {
 
 impl fmt::Display for PMPConfig {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        writeln!(f, "PMP regions:")?;
+        writeln!(f, " PMP regions:")?;
         for (n, region) in self.regions.iter().enumerate() {
             match region {
-                None => writeln!(f, "<unset>")?,
-                Some(region) => writeln!(f, " [{}]: {}", n, region)?,
+                None => writeln!(f, "  <unset>")?,
+                Some(region) => writeln!(f, "  [{}]: {}", n, region)?,
             }
         }
         Ok(())

--- a/arch/rv32i/src/syscall.rs
+++ b/arch/rv32i/src/syscall.rs
@@ -394,9 +394,9 @@ impl kernel::syscall::UserspaceKernelBoundary for SysCall {
              \r\n R13: {:#010X}    R29: {:#010X}\
              \r\n R14: {:#010X}    R30: {:#010X}\
              \r\n R15: {:#010X}    R31: {:#010X}\
-             \r\n PC : {:#010X}\
-             \r\n SP:  {:#010X}\
-             \r\n",
+             \r\n PC : {:#010X}    SP : {:#010X}\
+             \r\n\
+             \r\n mcause: {:#010X} (",
             0,
             state.regs[15],
             state.regs[0],
@@ -431,6 +431,14 @@ impl kernel::syscall::UserspaceKernelBoundary for SysCall {
             state.regs[30],
             state.pc,
             stack_pointer as usize,
+            state.mcause,
+        ));
+        crate::print_mcause(mcause::Trap::from(state.mcause as u32), writer);
+        let _ = writer.write_fmt(format_args!(
+            ")\
+             \r\n mtval:  {:#010X}\
+             \r\n\r\n",
+            state.mtval,
         ));
     }
 }

--- a/arch/rv32i/src/syscall.rs
+++ b/arch/rv32i/src/syscall.rs
@@ -22,6 +22,11 @@ pub struct RiscvimacStoredState {
     /// We need to store the mcause CSR between when the trap occurs and after
     /// we exit the trap handler and resume the context switching code.
     mcause: usize,
+
+    /// We need to store the mtval CSR for the process in case the mcause
+    /// indicates a fault. In that case, the mtval contains useful debugging
+    /// information.
+    mtval: usize,
 }
 
 // Named offsets into the stored state registers.  These needs to be kept in


### PR DESCRIPTION
### Pull Request Overview

This pull request iterates on the riscv debug output a little. Main changes:

- We now save mtval on a per-process basis and print it for each process.
- General printout is a little easier to read.
- PMP is indented with the rest of the process.

Why save mtval? It is possible that mcause has changed between when an app faults and when the panic prints. If we don't save mtval we lose that useful debugging information to help debug why a process faulted. For example, here is a panic output I generated with these changes using crash dummy on arty-e21:

```
Initialization complete. Entering main loop.

panicked at 'Process crash_dummy had a fault', /Users/bradjc/.rustup/toolchains/nightly-2020-06-03-x86_64-apple-darwin/lib/rustlib/src/rust/src/libcore/macros/mod.rs:16:9
	Kernel version release-1.5-954-g361fa2143

---| No debug queue found. You can set it with the DebugQueue component.

---| RISC-V Machine State |---
Last cause (mcause): Machine timer interrupt (interrupt=true, exception code=0x08000007)
Last value (mtval):  0x00000000

System register dump:
 mepc:    0x4040AF00    mstatus:     0x00000088
 mcycle:  0x1B502377    minstret:    0x00134B10
 mtvec:   0x40400102
 mstatus: 0x00000088
  uie:    false  upie:   false
  sie:    false  spie:   false
  mie:    true   mpie:   true
  spp:    false
 mie:   0x00000000   mip:   0x00000000
  usoft:  false               false
  ssoft:  false               false
  msoft:  false               false
  utimer: false               false
  stimer: false               false
  mtimer: false               false
  uext:   false               false
  sext:   false               false
  mext:   false               false

---| App Status |---
App: crash_dummy   -   [Fault]
 Events Queued: 1   Syscall Count: 6   Dropped Callback Count: 0
 Restart Count: 0
 Last Syscall: Some(YIELD)

 ╔═══════════╤══════════════════════════════════════════╗
 ║  Address  │ Region Name    Used | Allocated (bytes)  ║
 ╚0x80005EC8═╪══════════════════════════════════════════╝
             │ ▼ Grant         960 |    960
  0x80005B08 ┼───────────────────────────────────────────
             │ Unused
  0x8000531C ┼───────────────────────────────────────────
             │ ▲ Heap            0 |   2028               S
  0x8000531C ┼─────────────────────────────────────────── R
             │ Data           2844 |   2844               A
  0x80004800 ┼─────────────────────────────────────────── M
             │ ▼ Stack          48 |   2048
  0x800047D0 ┼───────────────────────────────────────────
             │ Unused
  0x80004000 ┴───────────────────────────────────────────
             .....
  0x40440000 ┬─────────────────────────────────────────── F
             │ App Flash     65440                        L
  0x40430060 ┼─────────────────────────────────────────── A
             │ Protected        96                        S
  0x40430000 ┴─────────────────────────────────────────── H

 R0 : 0x00000000    R16: 0x00000001
 R1 : 0x404301D0    R17: 0x800051B4
 R2 : 0x800047D0    R18: 0x80004000
 R3 : 0x00000000    R19: 0x00000000
 R4 : 0x00000000    R20: 0x00000000
 R5 : 0x4043030C    R21: 0x00000000
 R6 : 0x4043012E    R22: 0x00000000
 R7 : 0x00000168    R23: 0x00000000
 R8 : 0x40430060    R24: 0x00000000
 R9 : 0x80004000    R25: 0x00000000
 R10: 0x00000000    R26: 0x00000000
 R11: 0x00000001    R27: 0x00000000
 R12: 0x00000000    R28: 0xFFFFFFFF
 R13: 0x00000000    R29: 0x80004800
 R14: 0x00000000    R30: 0x000B0CE0
 R15: 0x000B0CE0    R31: 0x00000000
 PC : 0x404300E6    SP : 0x800047D0

 mcause: 0x08000005 (Load access fault)
 mtval:  0x000B0CE0

 PMP regions:
  [0]: addr=0x40430000, size=0x00010004, cfg=0xD (r-x)
  [1]: addr=0x80004000, size=0x00001EC8, cfg=0xB (rw-)

To debug, run `make lst` in the app's folder
and open the arch.0x40430060.0x80004000.lst file.

App: led-1   -   [Yielded]
 Events Queued: 0   Syscall Count: 18   Dropped Callback Count: 0
 Restart Count: 0
 Last Syscall: Some(YIELD)

 ╔═══════════╤══════════════════════════════════════════╗
 ║  Address  │ Region Name    Used | Allocated (bytes)  ║
 ╚0x80007F90═╪══════════════════════════════════════════╝
             │ ▼ Grant         964 |    964
  0x80007BCC ┼───────────────────────────────────────────
             │ Unused
  0x800073E8 ┼───────────────────────────────────────────
             │ ▲ Heap            0 |   2020               S
  0x800073E8 ┼─────────────────────────────────────────── R
             │ Data           2848 |   2848               A
  0x800068C8 ┼─────────────────────────────────────────── M
             │ ▼ Stack         144 |   2048
  0x80006838 ┼───────────────────────────────────────────
             │ Unused
  0x800060C8 ┴───────────────────────────────────────────
             .....
  0x40450000 ┬─────────────────────────────────────────── F
             │ App Flash     65440                        L
  0x40440060 ┼─────────────────────────────────────────── A
             │ Protected        96                        S
  0x40440000 ┴─────────────────────────────────────────── H

 R0 : 0x00000000    R16: 0x00000004
 R1 : 0x404403FC    R17: 0x800073F0
 R2 : 0x80006848    R18: 0x800060C8
 R3 : 0x00000000    R19: 0x00000000
 R4 : 0x00000000    R20: 0x00000000
 R5 : 0x40440564    R21: 0x00000000
 R6 : 0x4044043E    R22: 0x00000000
 R7 : 0x00000168    R23: 0x00000000
 R8 : 0x80006873    R24: 0x00000000
 R9 : 0x000009C4    R25: 0x00000000
 R10: 0x00000000    R26: 0x00000000
 R11: 0x00000000    R27: 0x00000000
 R12: 0x00000004    R28: 0x00000000
 R13: 0x800073EC    R29: 0x00494943
 R14: 0x00000001    R30: 0x53410000
 R15: 0x00000001    R31: 0x00000000
 PC : 0x404403D8    SP : 0x80006848

 mcause: 0x08000008 (Environment call from U-mode)
 mtval:  0x00000000

 PMP regions:
  [0]: addr=0x40440000, size=0x00010004, cfg=0xD (r-x)
  [1]: addr=0x800060c8, size=0x00001EC8, cfg=0xB (rw-)

To debug, run `make lst` in the app's folder
and open the arch.0x40440060.0x800060c8.lst file.
```

Based on the start of that, it looks like the app crashed because the machine timer interrupt fired, which doesn't make any sense. Since we now save mtval per process and print it, you can see that the crash dummy app actually faulted due to a pmp violation at address boce.


### Testing Strategy

This pull request was tested by running crash dummy on arty-e21.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
