### PR TITLE
rv32: pmp: Fix bounds

### DIFF
--- a/arch/rv32i/src/pmp.rs
+++ b/arch/rv32i/src/pmp.rs
@@ -337,9 +337,6 @@ impl kernel::mpu::MPU for PMP {
             start += 4 - (start % 4);
         }
 
-        // RISC-V PMP is not inclusive of the final address, while Tock is, increase the size by 1
-        size += 1;
-
         // Region size always has to align to 4 bytes
         if size % 4 != 0 {
             size += 4 - (size % 4);
@@ -389,13 +386,10 @@ impl kernel::mpu::MPU for PMP {
         };
 
         // Make sure there is enough memory for app memory and kernel memory.
-        let memory_size = cmp::max(
+        let mut region_size = cmp::max(
             min_memory_size,
             initial_app_memory_size + initial_kernel_memory_size,
-        );
-
-        // RISC-V PMP is not inclusive of the final address, while Tock is, increase the memory_size by 1
-        let mut region_size = memory_size as usize + 1;
+        ) as usize;
 
         // Region size always has to align to 4 bytes
         if region_size % 4 != 0 {


### PR DESCRIPTION


### Pull Request Overview

This pull request removes the size + 1 from the PMP implementation. I'm guessing those were left over from an older implementation.

This fixes #2034.


Without this change:

```
Initialization complete. Entering main loop.
[TEST] MPU Flash End
Reading last byte in flash...
Address: 0x4044ffff, value: 00
Reading next byte...
Address: 0x40450000, value: 00
FAIL! Should not be able to read after flash!!
```

After this change:

```
Initialization complete. Entering main loop.
[TEST] MPU Flash End
Reading last byte in flash...
Address: 0x4044ffff, value: 00
Reading next byte...

panicked at 'Process mpu_flash_end had a fault', /Users/bradjc/.rustup/toolchains/nightly-2020-06-03-x86_64-apple-darwin/lib/rustlib/src/rust/src/libcore/macros/mod.rs:16:9
	Kernel version release-1.5-960-g6923cc4ec

---| No debug queue found. You can set it with the DebugQueue component.

---| RISC-V Machine State |---
Last cause (mcause): Load access fault (interrupt=false, exception code=0x08000005)
Last value (mtval):  0x40450000

System register dump:
 mepc:    0x404024B0    mstatus:     0x00000088
 mcycle:  0x1C202EF4    minstret:    0x0014DBC9
 mtvec:   0x40400102
 mstatus: 0x00000088
  uie:    false  upie:   false
  sie:    false  spie:   false
  mie:    true   mpie:   true
  spp:    false
 mie:   0x00000000   mip:   0x00000000
  usoft:  false               false
  ssoft:  false               false
  msoft:  false               false
  utimer: false               false
  stimer: false               false
  mtimer: false               false
  uext:   false               false
  sext:   false               false
  mext:   false               false

---| App Status |---
App: mpu_flash_end   -   [Fault]
 Events Queued: 0   Syscall Count: 22   Dropped Callback Count: 0
 Restart Count: 0
 Last Syscall: Some(YIELD)

 ╔═══════════╤══════════════════════════════════════════╗
 ║  Address  │ Region Name    Used | Allocated (bytes)  ║
 ╚0x80006A68═╪══════════════════════════════════════════╝
             │ ▼ Grant        1040 |   1040
  0x80006658 ┼───────────────────────────────────────────
             │ Unused
  0x80006000 ┼───────────────────────────────────────────
             │ ▲ Heap         4288 |   5912               S
  0x80004F40 ┼─────────────────────────────────────────── R
             │ Data           2880 |   2880               A
  0x80004400 ┼─────────────────────────────────────────── M
             │ ▼ Stack         816 |   1024
  0x800040D0 ┼───────────────────────────────────────────
             │ Unused
  0x80004000 ┴───────────────────────────────────────────
             .....
  0x40450000 ┬─────────────────────────────────────────── F
             │ App Flash    130976                        L
  0x40430060 ┼─────────────────────────────────────────── A
             │ Protected        96                        S
  0x40430000 ┴─────────────────────────────────────────── H

 R0 : 0x00000000    R16: 0x00000001
 R1 : 0x40430136    R17: 0x80808080
 R2 : 0x800043E0    R18: 0x80004000
 R3 : 0x00000000    R19: 0x00000000
 R4 : 0x00000000    R20: 0x00000000
 R5 : 0x40430386    R21: 0x00000000
 R6 : 0x40435C26    R22: 0x00000000
 R7 : 0x00000190    R23: 0x00000000
 R8 : 0x40450000    R24: 0x00000000
 R9 : 0x4043F000    R25: 0x00000000
 R10: 0x0000000A    R26: 0x00000000
 R11: 0x80004828    R27: 0x00000000
 R12: 0x00000001    R28: 0x00000003
 R13: 0x00020000    R29: 0x00494943
 R14: 0x80005348    R30: 0x53410000
 R15: 0xFFFFFFFF    R31: 0x00000000
 PC : 0x40430136    SP : 0x800043E0

 mcause: 0x08000005 (Load access fault)
 mtval:  0x40450000

 PMP regions:
  [0]: addr=0x40430000, size=0x00020000, cfg=0xD (r-x)
  [1]: addr=0x80004000, size=0x00002A68, cfg=0xB (rw-)

To debug, run `make lst` in the app's folder
and open the arch.0x40430060.0x80004000.lst file.
```





### Testing Strategy

This pull request was tested by running mpu test apps on arty-e21.

I also tested that the RAM section works as expected as well.

### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
