### PR TITLE
Add TakeCell::get_mut function

### DIFF
--- a/libraries/tock-cells/src/take_cell.rs
+++ b/libraries/tock-cells/src/take_cell.rs
@@ -77,7 +77,7 @@ impl<'a, T: ?Sized> TakeCell<'a, T> {
     /// as the reference to this does.
     ///
     /// This escapes the "take" aspect of TakeCell in a way which is guaranteed
-    /// safe due to the difference in lifetimes.
+    /// safe due to the returned reference sharing the lifetime of `&mut self`.
     pub fn get_mut(&mut self) -> Option<&mut T> {
         self.val.get_mut().as_mut().map(|v| &mut **v)
     }

--- a/libraries/tock-cells/src/take_cell.rs
+++ b/libraries/tock-cells/src/take_cell.rs
@@ -73,6 +73,15 @@ impl<'a, T: ?Sized> TakeCell<'a, T> {
         self.val.replace(Some(val))
     }
 
+    /// Retrieves a mutable reference to the inner value that only lives as long
+    /// as the reference to this does.
+    ///
+    /// This escapes the "take" aspect of TakeCell in a way which is guaranteed
+    /// safe due to the difference in lifetimes.
+    pub fn get_mut(&mut self) -> Option<&mut T> {
+        self.val.get_mut().as_mut().map(|v| &mut **v)
+    }
+
     /// Allows `closure` to borrow the contents of the `TakeCell` if-and-only-if
     /// it is not `take`n already. The state of the `TakeCell` is unchanged
     /// after the closure completes.


### PR DESCRIPTION
### Pull Request Overview

This adds `TakeCell::get_mut`, a function with the signature `fn get_mut(&mut self) -> Option<&mut T>`. Specifically, it bypasses the Cell nature of take_cell for when you already have access to an `&mut TakeCell`.

This is entirely safe, and works similarly to the corresponding method in `Cell`, `Cell::get_mut`. It's made safe by the fact that the returned value is lifetime bound to the mutable borrow of the `TakeCell` itself, not to `'a` - and thus, requires no new unsafe code to implement.

This was useful for an odd interaction with the rubble interface when implementing tock_rubble - it needs to retrieve an `&mut [u8]` multiple times safely, and then also use that buffer as an `&'static mut [u8]` which can be taken out. Thus a `TakeCell`, with the addition of this `get_mut` method, works well.

### Testing Strategy

CI

### TODO or Help Wanted


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
