### PR TITLE
capsules: usb/cdc: Fixup the CDC control message logic

### DIFF
--- a/capsules/src/usb/cdc.rs
+++ b/capsules/src/usb/cdc.rs
@@ -285,12 +285,7 @@ impl<'a, U: hil::usb::UsbController<'a>> hil::usb::Client<'a> for CdcAcm<'a, U> 
                     // Currently we don't care about the value
 
                     if self.state.get() != State::Connected {
-                        // We weren't previously connected so this must mean
-                        // a client connected.
                         self.state.set(State::Connecting);
-                    } else {
-                        // We were connected, so disconnect.
-                        self.state.set(State::Enumerated)
                     }
                 }
                 0x23 => {

--- a/capsules/src/usb/cdc.rs
+++ b/capsules/src/usb/cdc.rs
@@ -63,6 +63,15 @@ enum State {
     Connected,
 }
 
+/// States of the Control Endpoint related to CDC-ACM.
+#[derive(Debug, Copy, Clone, PartialEq)]
+enum CtrlState {
+    /// No ongoing ctrl transcation.
+    Idle,
+    /// Host has sent a SET_LINE_CODING configuration request.
+    SetLineCoding,
+}
+
 /// Implementation of the Abstract Control Model (ACM) for the Communications
 /// Class Device (CDC) over USB.
 pub struct CdcAcm<'a, U: 'a> {
@@ -75,6 +84,10 @@ pub struct CdcAcm<'a, U: 'a> {
     /// Current state of the CDC driver. This helps us track if a CDC client is
     /// connected and listening or not.
     state: Cell<State>,
+
+    /// Current state of the Control Endpoint. This tracks which configuration
+    /// request the host is currently sending us.
+    ctrl_state: Cell<CtrlState>,
 
     /// A holder reference for the TX buffer we are transmitting from.
     tx_buffer: TakeCell<'static, [u8]>,
@@ -211,6 +224,7 @@ impl<'a, U: hil::usb::UsbController<'a>> CdcAcm<'a, U> {
                 Buffer64::default(),
             ],
             state: Cell::new(State::Disabled),
+            ctrl_state: Cell::new(CtrlState::Idle),
             tx_buffer: TakeCell::empty(),
             tx_len: Cell::new(0),
             tx_offset: Cell::new(0),
@@ -270,10 +284,14 @@ impl<'a, U: hil::usb::UsbController<'a>> hil::usb::Client<'a> for CdcAcm<'a, U> 
         descriptors::SetupData::get(&self.client_ctrl.ctrl_buffer.buf).map(|setup_data| {
             let b_request = setup_data.request_code;
 
-            // Match on the two CDC control messages we care about:
+            // Match on the CDC control messages we care about:
+            // - `0x20`: SET_LINE_CODING
             // - `0x22`: SET_CONTROL_LINE_STATE
             // - `0x23`: SEND_BREAK
             match b_request {
+                0x20 => {
+                    self.ctrl_state.set(CtrlState::SetLineCoding);
+                }
                 0x22 => {
                     // Bit 0 and 1 of the value (setup_data.value) can be set
                     // D0: Indicates to DCE if DTE is present or not.
@@ -283,10 +301,6 @@ impl<'a, U: hil::usb::UsbController<'a>> hil::usb::Client<'a> for CdcAcm<'a, U> 
                     //     - 0 -> Deactivate carrier
                     //     - 1 -> Activate carrier
                     // Currently we don't care about the value
-
-                    if self.state.get() != State::Connected {
-                        self.state.set(State::Connecting);
-                    }
                 }
                 0x23 => {
                     // On Mac, we seem to get the SEND_BREAK to signal that a
@@ -307,6 +321,23 @@ impl<'a, U: hil::usb::UsbController<'a>> hil::usb::Client<'a> for CdcAcm<'a, U> 
 
     /// Handle a Control Out transaction
     fn ctrl_out(&'a self, endpoint: usize, packet_bytes: u32) -> hil::usb::CtrlOutResult {
+        // Check what state our Ctrl endpoint is in.
+        if self.ctrl_state.get() == CtrlState::SetLineCoding {
+            // We got a Ctrl SET_LINE_CODING setup, now we are getting the data.
+            // We can parse the data we got.
+            descriptors::CdcAcmSetLineCodingData::get(&self.client_ctrl.ctrl_buffer.buf).map(
+                |line_coding| {
+                    // Check if we should switch our main state machine to
+                    // connecting meaning that the host is connecting to the virtual
+                    // serial port. We decide this based on if the host is
+                    // configuring the baud rate to what we expect.
+                    if self.state.get() == State::Enumerated && line_coding.baud_rate == 115200 {
+                        self.state.set(State::Connecting);
+                    }
+                },
+            );
+        }
+
         self.client_ctrl.ctrl_out(endpoint, packet_bytes)
     }
 
@@ -316,6 +347,8 @@ impl<'a, U: hil::usb::UsbController<'a>> hil::usb::Client<'a> for CdcAcm<'a, U> 
 
     /// Handle the completion of a Control transfer
     fn ctrl_status_complete(&'a self, endpoint: usize) {
+        self.ctrl_state.set(CtrlState::Idle);
+
         // Here we check to see if we just got connected to a CDC client. If so,
         // we can begin transmitting if needed.
         if self.state.get() == State::Connecting {

--- a/capsules/src/usb/descriptors.rs
+++ b/capsules/src/usb/descriptors.rs
@@ -859,6 +859,31 @@ impl Descriptor for CdcInterfaceDescriptor {
     }
 }
 
+/// The data structure sent in a CDC-ACM Set Line Coding message.
+#[derive(Debug, Copy, Clone)]
+pub struct CdcAcmSetLineCodingData {
+    pub baud_rate: u32,
+    pub stop_bits: u8,
+    pub parity: u8,
+    pub data_bits: u8,
+}
+
+impl CdcAcmSetLineCodingData {
+    /// Create a `CdcAcmSetLineCodingData` structure from a packet received
+    /// after the ctrl endpoint setup.
+    pub fn get(p: &[VolatileCell<u8>]) -> Option<Self> {
+        if p.len() < 7 {
+            return None;
+        }
+        Some(CdcAcmSetLineCodingData {
+            baud_rate: get_u32(p[0].get(), p[1].get(), p[2].get(), p[3].get()),
+            stop_bits: p[4].get(),
+            parity: p[5].get(),
+            data_bits: p[6].get(),
+        })
+    }
+}
+
 pub struct LanguagesDescriptor<'a> {
     pub langs: &'a [u16],
 }
@@ -911,6 +936,11 @@ impl<'a> Descriptor for StringDescriptor<'a> {
 /// Parse a `u16` from two bytes as received on the bus
 fn get_u16(b0: u8, b1: u8) -> u16 {
     (b0 as u16) | ((b1 as u16) << 8)
+}
+
+/// Parse a `u32` from four bytes as received on the bus
+fn get_u32(b0: u8, b1: u8, b2: u8, b3: u8) -> u32 {
+    (b0 as u32) | ((b1 as u32) << 8) | ((b2 as u32) << 16) | ((b3 as u32) << 24)
 }
 
 /// Write a `u16` to a buffer for transmission on the bus


### PR DESCRIPTION
### Pull Request Overview

Update the comment to use SET_CONTROL_LINE_STATE to match the phrase in
the spec. As well as that accept the request no matter what the value
is, but let's document what the options are.

### Testing Strategy

Test USB CDC on OpenTitan.

### TODO or Help Wanted

N/A

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
