### PR TITLE
MLFQ scheduler bug fix

### DIFF
--- a/kernel/src/sched/mlfq.rs
+++ b/kernel/src/sched/mlfq.rs
@@ -59,6 +59,7 @@ pub struct MLFQSched<'a, A: 'static + time::Alarm<'static>> {
     alarm: &'static A,
     pub processes: [List<'a, MLFQProcessNode<'a>>; 3], // Using Self::NUM_QUEUES causes rustc to crash..
     next_reset: Cell<u32>,
+    last_reset_check: Cell<u32>,
     last_timeslice: Cell<u32>,
     last_queue_idx: Cell<usize>,
 }
@@ -73,6 +74,7 @@ impl<'a, A: 'static + time::Alarm<'static>> MLFQSched<'a, A> {
             alarm,
             processes: [List::new(), List::new(), List::new()],
             next_reset: Cell::new(0),
+            last_reset_check: Cell::new(0),
             last_timeslice: Cell::new(0),
             last_queue_idx: Cell::new(0),
         }
@@ -139,12 +141,18 @@ impl<'a, A: 'static + time::Alarm<'static>, C: Chip> Scheduler<C> for MLFQSched<
             SchedulingDecision::TrySleep
         } else {
             let now = self.alarm.now();
-            if now >= self.next_reset.get() {
+            let next_reset = self.next_reset.get();
+            let last_reset_check = self.last_reset_check.get();
+
+            // storing last reset check is necessary to avoid missing a reset when the underlying
+            // alarm wraps around
+            if !(now.wrapping_sub(last_reset_check) < next_reset.wrapping_sub(last_reset_check)) {
                 // Promote all processes to highest priority queue
                 let delta = (Self::PRIORITY_REFRESH_PERIOD_MS * A::Frequency::frequency()) / 1000;
                 self.next_reset.set(now.wrapping_add(delta));
                 self.redeem_all_procs();
             }
+            self.last_reset_check.set(now);
             let (node_ref_opt, queue_idx) = self.get_next_ready_process_node();
             let node_ref = node_ref_opt.unwrap(); // Panic if fail bc processes_blocked()!
             let timeslice =


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes a bug identified by @phil-levis where it is possible for a redemption of processes to the top priority queue to be missed when the underlying alarm wraps around. The fix just involves correctly handling the wrap around case.


### Testing Strategy

This pull request was tested by compiling / looking at the code.


### TODO or Help Wanted

N/A

### Documentation Updated

- [x] No updates are required.

### Formatting

- [x] Ran `make prepush`.
