### PR TITLE
arch/cortex-m: change a few `llvm_asm!`s to `asm!`s

### DIFF
--- a/arch/cortex-m/src/lib.rs
+++ b/arch/cortex-m/src/lib.rs
@@ -197,6 +197,7 @@ pub unsafe extern "C" fn unhandled_interrupt() {
     asm!(
         "mrs r0, ipsr",
         out("r0") interrupt_number,
+        options(nomem, nostack, preserves_flags)
     );
 
     interrupt_number = interrupt_number & 0x1ff;

--- a/arch/cortex-m/src/lib.rs
+++ b/arch/cortex-m/src/lib.rs
@@ -3,6 +3,7 @@
 #![crate_name = "cortexm"]
 #![crate_type = "rlib"]
 #![feature(llvm_asm)]
+#![feature(asm)]
 #![feature(naked_functions)]
 #![no_std]
 
@@ -193,12 +194,9 @@ pub unsafe extern "C" fn unhandled_interrupt() {
     let mut interrupt_number: u32;
 
     // IPSR[8:0] holds the currently active interrupt
-    llvm_asm!(
-    "mrs    r0, ipsr                    "
-    : "={r0}"(interrupt_number)
-    :
-    : "r0"
-    :
+    asm!(
+        "mrs r0, ipsr",
+        out("r0") interrupt_number,
     );
 
     interrupt_number = interrupt_number & 0x1ff;

--- a/arch/cortex-m/src/support.rs
+++ b/arch/cortex-m/src/support.rs
@@ -5,7 +5,7 @@ use core::ops::FnOnce;
 /// NOP instruction
 pub fn nop() {
     unsafe {
-        asm!("nop");
+        asm!("nop", options(nomem, nostack, preserves_flags));
     }
 }
 
@@ -13,7 +13,7 @@ pub fn nop() {
 #[inline(always)]
 /// WFI instruction
 pub unsafe fn wfi() {
-    asm!("wfi");
+    asm!("wfi", options(nomem, preserves_flags));
 }
 
 #[cfg(all(target_arch = "arm", target_os = "none"))]

--- a/arch/cortex-m/src/support.rs
+++ b/arch/cortex-m/src/support.rs
@@ -5,7 +5,7 @@ use core::ops::FnOnce;
 /// NOP instruction
 pub fn nop() {
     unsafe {
-        llvm_asm!("nop" :::: "volatile");
+        asm!("nop");
     }
 }
 
@@ -13,7 +13,7 @@ pub fn nop() {
 #[inline(always)]
 /// WFI instruction
 pub unsafe fn wfi() {
-    llvm_asm!("wfi" :::: "volatile");
+    asm!("wfi");
 }
 
 #[cfg(all(target_arch = "arm", target_os = "none"))]


### PR DESCRIPTION
### Pull Request Overview

This PR changes 3 invocations of `llvm_asm!` to `asm!`.
This PR intends to make a small step towards the direction of #1923 .
I made the changes after reading through the [inline-asm RFC](https://github.com/Amanieu/rfcs/blob/inline-asm/text/0000-inline-asm.md#summary) .

##### Brief overview of changes made
1. `llvm_asm!("nop" :::: "volatile");` => `asm!("nop");`
2. `llvm_asm!("wfi" :::: "volatile");` => `asm!("wfi");`

* The only notable change in the first two cases is that the `volatile` keyword is gone. In the new `asm!` macro, `volatile` is assumed by default and there is an option called `pure` which can be used to get rid of the `volatile` semantics.
  * reference: [Link to Q&A on `volatile` from Rust Zulip chat](https://rust-lang.zulipchat.com/#narrow/stream/216763-project-inline-asm/topic/volatile.20question/near/208320361) (requires sign-in)

3. `llvm_asm!("mrs    r0, ipsr": "={r0}"(interrupt_number) : :"r0" :);`
    => `asm!("mrs r0, ipsr", out("r0") interrupt_number);`

* The current `llvm_asm!` invocation specifies `r0` both as output and clobbered register. [It is specified in the LLVM docs that "clobbering named registers that are also present in output constraints is not legal."](http://llvm.org/docs/LangRef.html#clobber-constraints), and it is not possible to do that under the new `asm!` macro syntax. Note the `asm!` macro invocation doesn't have any clobber constraints.

### TODO or Help Wanted

Although the changes made in this PR are quite simple, I'm not sure how to properly test the changes.
I'd appreciate any advice on testing strategy for this PR :smiley_cat: 

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
