### PR TITLE
Kernel work increment/decrement prevents MCU going to sleep

### DIFF
--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -901,8 +901,11 @@ impl<C: Chip> ProcessType for Process<'_, C> {
                 },
                 _ => true,
             });
+            let count_after = tasks.len();
+            for _ in 0..count_before - count_after {
+                self.kernel.decrement_work();
+            }
             if config::CONFIG.trace_syscalls {
-                let count_after = tasks.len();
                 debug!(
                     "[{:?}] remove_pending_callbacks[{:#x}:{}] = {} callback(s) removed",
                     self.appid(),
@@ -910,9 +913,6 @@ impl<C: Chip> ProcessType for Process<'_, C> {
                     callback_id.subscribe_num,
                     count_before - count_after,
                 );
-                for _ in 0..count_before - count_after {
-                    self.kernel.decrement_work();
-                }
             }
         });
     }

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -869,8 +869,6 @@ impl<C: Chip> ProcessType for Process<'_, C> {
             return false;
         }
 
-        self.kernel.increment_work();
-
         let ret = self.tasks.map_or(false, |tasks| tasks.enqueue(task));
 
         // Make a note that we lost this callback if the enqueue function
@@ -879,6 +877,8 @@ impl<C: Chip> ProcessType for Process<'_, C> {
             self.debug.map(|debug| {
                 debug.dropped_callback_count += 1;
             });
+        } else {
+            self.kernel.increment_work();
         }
 
         ret
@@ -910,6 +910,9 @@ impl<C: Chip> ProcessType for Process<'_, C> {
                     callback_id.subscribe_num,
                     count_before - count_after,
                 );
+                for _ in 0..count_before - count_after {
+                    self.kernel.decrement_work();
+                }
             }
         });
     }


### PR DESCRIPTION
### Pull Request Overview

This pull request (hopefully) fixes an issue that seems to prevent the kernel from putting the MCU to sleep. The issue seems to be from the kernel work counter.

While running the following user space app, it seems that the kernel does not sleep the MCU after the process's last yield system call.

```c
char hello[] = "Hello World!\r\n";
char run[] = "system run\r\n";
char texte[] = "texte\r\n";

static void nop(
  int a __attribute__((unused)),
  int b __attribute__((unused)),
  int c __attribute__((unused)),
  void* d __attribute__((unused))) {}


int main(void) {
  putnstr_async(hello, sizeof(hello), nop, NULL);
  putnstr_async(run, sizeof(run), nop, NULL);
  putnstr_async(texte, sizeof(texte), nop, NULL);
  return 0;
}
```

I did some research and found out that the issue pops up only when there are several subscribes for the same callback (driver_id, subscribe_number). In the kernel:

1. I found that when a callback is overwritten:
  a. the kernel work is incremented
  b. the previous callback is removed, but the kernel work is not decremented accordingly

   This prevents sends the scheduler into an infinite loop.

2. I also noticed that `enqueue_task` increments the kernel work regardless of whether a callback is scheduled or not. We also experienced an interesting issue when trying to implement a real-time external interrupt counter. It seems that if the kernel drops callbacks, it starts having a strange behavior, the apps jam. I think it might be related to the kernel work. We still need to do some more research.

### Testing Strategy


### TODO or Help Wanted

N/A

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
