### PR TITLE
Mask USB interrupt to avoid hardware bug in OpenTitan

### DIFF
--- a/chips/earlgrey/src/plic.rs
+++ b/chips/earlgrey/src/plic.rs
@@ -41,9 +41,17 @@ pub unsafe fn clear_all_pending() {
 /// Enable all interrupts.
 pub unsafe fn enable_all() {
     let plic: &PlicRegisters = &*PLIC_BASE;
-    for enable in plic.enable.iter() {
-        enable.set(0xFFFF_FFFF);
-    }
+
+    // USB hardware on current OT master branch seems to have
+    // interrupt bugs: running Alarms causes persistent USB
+    // CONNECTED interrupts that can't be masked from USBDEV and
+    // cause the system to hang. So enable all interrupts except
+    // for the USB ones. Some open PRs on OT fix this, we'll re-enable
+    // USB interrurupts.
+    plic.enable[0].set(0xFFFF_FFFF);
+    plic.enable[1].set(0xFFFF_FFFF);
+    plic.enable[2].set(0xFFFF_0000); // USB are 64-79
+
 
     // Set the max priority for each interrupt. This is not really used
     // at this point.

--- a/chips/earlgrey/src/plic.rs
+++ b/chips/earlgrey/src/plic.rs
@@ -52,7 +52,6 @@ pub unsafe fn enable_all() {
     plic.enable[1].set(0xFFFF_FFFF);
     plic.enable[2].set(0xFFFF_0000); // USB are 64-79
 
-
     // Set the max priority for each interrupt. This is not really used
     // at this point.
     for priority in plic.priority.iter() {

--- a/chips/earlgrey/src/plic.rs
+++ b/chips/earlgrey/src/plic.rs
@@ -48,6 +48,8 @@ pub unsafe fn enable_all() {
     // cause the system to hang. So enable all interrupts except
     // for the USB ones. Some open PRs on OT fix this, we'll re-enable
     // USB interrurupts.
+    //
+    // https://github.com/lowRISC/opentitan/issues/3388
     plic.enable[0].set(0xFFFF_FFFF);
     plic.enable[1].set(0xFFFF_FFFF);
     plic.enable[2].set(0xFFFF_0000); // USB are 64-79


### PR DESCRIPTION
### Pull Request Overview

USB hardware on current OT master branch seems to have interrupt bugs: running Alarms causes persistent USB CONNECTED interrupts that can't be masked from USBDEV and cause the system to hang. So this PR modifies the PLIC to enable all interrupts *except* for the USB ones. Some open PRs on OT fix this, we'll re-enable USB interrupts when they are merged.
 
To observe this behavior, take a look at the  `opentitan-alarm-causes-usb-failures` branch.

This bug report came from the alarm redesign branch; separating USB interrupt handling into a separate PR seems advisable.

I've entered this as an issue for OpenTitan: https://github.com/lowRISC/opentitan/issues/3388

### Testing Strategy

Compiling and running the multi alarm test. 


### TODO or Help Wanted

None


### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
