### PR TITLE
RFC: Remove `AppPtr::Drop()` and `Owned::Drop()`

### DIFF
--- a/kernel/src/grant.rs
+++ b/kernel/src/grant.rs
@@ -56,17 +56,6 @@ impl<T: ?Sized> Owned<T> {
     }
 }
 
-impl<T: ?Sized> Drop for Owned<T> {
-    fn drop(&mut self) {
-        unsafe {
-            let data = self.data.as_ptr() as *mut u8;
-            self.appid.kernel.process_map_or((), self.appid, |process| {
-                process.free(data);
-            });
-        }
-    }
-}
-
 impl<T: ?Sized> Deref for Owned<T> {
     type Target = T;
     fn deref(&self) -> &T {

--- a/kernel/src/mem.rs
+++ b/kernel/src/mem.rs
@@ -34,16 +34,6 @@ impl<L, T> AppPtr<L, T> {
     }
 }
 
-impl<L, T> Drop for AppPtr<L, T> {
-    fn drop(&mut self) {
-        self.process
-            .kernel
-            .process_map_or((), self.process, |process| unsafe {
-                process.free(self.ptr.as_ptr() as *mut u8)
-            })
-    }
-}
-
 /// Buffer of memory shared from an app to the kernel.
 ///
 /// This is the type created after an app calls the `allow` syscall.


### PR DESCRIPTION
### Pull Request Overview

This PR proposes removing `AppPtr::Drop()` and `Owned::Drop()`, as well as the `ProcessType::free()` method that they each call. Currently, `Process::free()` is implemented with an empty body, merely dropping the passed raw pointer. Therefore, as far as I can tell, calls to `Drop()` on each type have no useful effect. Despite this, the presence of these implementations have a significant cost -- the implementations of `Drop` call `kernel.process_map_or()`, which takes a trait object reference (e.g. `&dyn ProcessType`), so the compiler cannot know that the concrete `free()` function that will be called is empty, and optimize the call out. 

Currently, anytime an `AppPtr` or `Owned` type goes out of scope -- including anytime a struct containing such a type goes out of scope -- `drop()` is called on each type until the underlying `drop()` implementation is called. This happens frequently: a single iteration of the loop in the `Imix` app calls `AppPtr::drop()` 45 times; a single iteration of the `hello_loop` app calls `AppPtr::drop()` 4 times and `Owned::drop()` 3 times. Further, each call has some cost:

##### Cycles per call, measured using cortex-m DWT cycle counter peripheral:

`AppSlice::drop()` - 139 cycles (increases to 145 if the board is configured for 8 processes instead of 4)

`Owned::drop()` - 84-150 cycles, depending on context.

Removing the Drop implementations for `AppPtr` and `Owned` reduces the measured cycle count in each case to 1 cycle.

`AppSlice::drop()` is called regularly (inserted by the compiler) within the body of `allow()` system call implementations, `Owned::drop()` is called within the body of `Grant::enter()` and `Grant::each()`.

Keeping in mind recent attempts to reduce Tock syscall overhead, I think that we should not pay all of this overhead for no benefit as Tock is implemented today.

Alternatively, if there is reason to believe these implementations will be useful in the future, I think we should document these functions (and `ProcessType::free()`) as to why they are present.

### Testing Strategy

This pull request was tested by running several apps with the drop implementations removed.


### TODO or Help Wanted

The Tock SOSP paper talks a bit about the `Owned::drop()` implementation, but as far as I can tell it does not actually do anything in Tock today. Is there reason to believe we will need these implementations for some future process type? Am I totally missing something here?


### Documentation Updated

- [x] No updates are required.

### Formatting

- [x] Ran `make prepush`.
