### PR TITLE
Add links to out-of-tree boards to boards/README.md.

### DIFF
--- a/boards/README.md
+++ b/boards/README.md
@@ -27,8 +27,8 @@ that Tock supports.
 Some projects that use Tock maintain their own board definitions outside the
 Tock repository.
 
-| Project                                                  | Boards                       | Architecture   | MCU      | Build System  |
-|----------------------------------------------------------|------------------------------|----------------|----------|---------------|
-| [OpenSK](https://github.com/google/opensk)               | nRF52840-DK, nRF52840-Dongle | ARM Cortex-M4  | nRF52840 | Python script |
-| [OpenTitan](https://github.com/lowrisc/opentitan)        | OpenTitan                    | RISC-V RV32IMC | EarlGrey | Meson         |
-| [Tock-on-Titan](https://github.com/google/tock-on-titan) | golf2, papa                  | ARM Cortex-M3  | H1       | Makefiles     |
+| Project                                                  | Boards                                     | Architecture   | MCU      | Build System  |
+|----------------------------------------------------------|--------------------------------------------|----------------|----------|---------------|
+| [OpenSK](https://github.com/google/opensk)               | nRF52840-DK, nRF52840-Dongle, nRF52840-MDK | ARM Cortex-M4  | nRF52840 | Python script |
+| [OpenTitan](https://github.com/lowrisc/opentitan)        | OpenTitan                                  | RISC-V RV32IMC | EarlGrey | Meson         |
+| [Tock-on-Titan](https://github.com/google/tock-on-titan) | golf2, papa                                | ARM Cortex-M3  | H1       | Makefiles     |

--- a/boards/README.md
+++ b/boards/README.md
@@ -21,3 +21,14 @@ that Tock supports.
 | [SiFive HiFive1](hifive1/README.md)                                  | RISC-V          | FE310-G000     | openocd    | tockloader     | [Yes (5.1)][qemu] |
 | [Digilent Arty A-7 100T](arty_e21/README.md)                         | RISC-V RV32IMAC | SiFive E21     | openocd    | tockloader     | No                |
 | [Nexys Video OpenTitan](opentitan/README.md)                         | RISC-V RV32IMC  | EarlGrey       | custom     | custom         | [Yes (5.1)][qemu] |
+
+# Out of Tree Boards
+
+Some projects that use Tock maintain their own board definitions outside the
+Tock repository.
+
+| Project                                                  | Boards                       | Architecture   | MCU      | Build System  |
+|----------------------------------------------------------|------------------------------|----------------|----------|---------------|
+| [OpenSK](https://github.com/google/opensk)               | nRF52840-DK, nRF52840-Dongle | ARM Cortex-M4  | nRF52840 | Python script |
+| [OpenTitan](https://github.com/lowrisc/opentitan)        | OpenTitan                    | RISC-V RV32IMC | EarlGrey | Meson         |
+| [Tock-on-Titan](https://github.com/google/tock-on-titan) | golf2, papa                  | ARM Cortex-M3  | H1       | Makefiles     |


### PR DESCRIPTION
This documentation is useful for two reasons. It should help raise awareness that out-of-tree Tock boards exist, and provide examples to future out-of-tree Tock board authors.

### Pull Request Overview

This pull request adds an out-of-tree board table to `boards/README.md`.

### Testing Strategy

Viewable at https://github.com/jrvanwhy/tock/tree/out-of-tree-boards/boards

### TODO or Help Wanted

I could use input on what columns are useful.

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
