### PR TITLE
Scheduler timer bugfix + documentation updates

### DIFF
--- a/arch/cortex-m/src/systick.rs
+++ b/arch/cortex-m/src/systick.rs
@@ -147,10 +147,6 @@ impl kernel::SchedulerTimer for SysTick {
             .write(ControlAndStatus::ENABLE::SET + clock_source);
     }
 
-    fn has_expired(&self) -> bool {
-        SYSTICK_BASE.syst_csr.is_set(ControlAndStatus::COUNTFLAG)
-    }
-
     fn reset(&self) {
         SYSTICK_BASE.syst_csr.set(0);
         SYSTICK_BASE.syst_rvr.set(0);
@@ -193,10 +189,14 @@ impl kernel::SchedulerTimer for SysTick {
             .write(ControlAndStatus::TICKINT::CLEAR + ControlAndStatus::ENABLE::SET + clock_source);
     }
 
-    fn get_remaining_us(&self) -> u32 {
+    fn get_remaining_us(&self) -> Option<u32> {
         // use u64 in case of overflow when multiplying by 1,000,000
         let tics = SYSTICK_BASE.syst_cvr.read(CurrentValue::CURRENT) as u64;
-        let hertz = self.hertz() as u64;
-        ((tics * 1_000_000) / hertz) as u32
+        if SYSTICK_BASE.syst_csr.is_set(ControlAndStatus::COUNTFLAG) {
+            None
+        } else {
+            let hertz = self.hertz() as u64;
+            Some(((tics * 1_000_000) / hertz) as u32)
+        }
     }
 }

--- a/arch/rv32i/src/machine_timer.rs
+++ b/arch/rv32i/src/machine_timer.rs
@@ -119,14 +119,25 @@ impl kernel::SchedulerTimer for MachineTimer<'_> {
         self.registers.mtimecmp.write(MTimeCmp::MTIMECMP.val(tics));
     }
 
-    fn get_remaining_us(&self) -> u32 {
-        let tics = self.get_alarm().wrapping_sub(self.now()) as u64;
-        let hertz = <Self as Time>::Frequency::frequency() as u64;
-        ((tics * 1_000_000) / hertz) as u32
-    }
+    fn get_remaining_us(&self) -> Option<u32> {
+        // We need to convert from native tics to us, multiplication could overflow in 32-bit
+        // arithmetic. So we convert to 64-bit.
 
-    fn has_expired(&self) -> bool {
-        self.now() < self.get_alarm()
+        let diff = self.get_alarm().wrapping_sub(self.now()) as u64;
+        // If next alarm is more than one second away from now, alarm must have expired.
+        // Use this formulation to protect against errors when systick wraps around.
+        // 1 second was chosen because it is significantly greater than the 400ms max value allowed
+        // by start(), and requires no computational overhead (e.g. using 500ms would require
+        // dividing the returned ticks by 2)
+        // However, if the alarm frequency is slow enough relative to the cpu frequency, it is
+        // possible this will be evaluated while now() == get_alarm(), so we special case that
+        // result where the alarm has fired but the subtraction has not overflowed
+        if diff >= <Self as Time>::Frequency::frequency() as u64 || diff == 0 {
+            None
+        } else {
+            let hertz = <Self as Time>::Frequency::frequency() as u64;
+            Some(((diff * 1_000_000) / hertz) as u32)
+        }
     }
 
     fn reset(&self) {

--- a/kernel/src/platform/scheduler_timer.rs
+++ b/kernel/src/platform/scheduler_timer.rs
@@ -105,28 +105,20 @@ pub trait SchedulerTimer {
     /// time keeping mechanism, this function should be a no-op implementation.
     fn disarm(&self);
 
-    /// Return the number of microseconds remaining in the process's timeslice.
+    /// Return the number of microseconds remaining in the process's timeslice
+    /// if the timeslice is still active.
     ///
-    /// This function only needs to return a valid value if the timeslice has
-    /// not been exhausted. Therefore, if a process' timeslice has expired, this
-    /// is not guaranteed to return a valid value.
-    fn get_remaining_us(&self) -> u32;
-
-    /// Check if the process timeslice has expired.
+    /// If the timeslice is still active, this returns `Some()` with the number
+    /// of microseconds remaining in the timeslice. If the timeslice has
+    /// expired, this returns `None`.
     ///
-    /// Returns `true` if the timer has expired since the last time this
-    /// function or `start()` has been called. This function may not be called
-    /// after it has returned `true` for a given timeslice until `start()` is
-    /// called again (to start a new timeslice). If `has_expired()` is called
-    /// again after returning `true` without an intervening call to `start()`,
-    /// the return the return value is unspecified and implementations may
+    /// This function may not be called after it has returned `None` (signifying
+    /// the timeslice has expired) for a given timeslice until `start()` is
+    /// called again (to start a new timeslice). If `get_remaining_us()` is
+    /// called again after returning `None` without an intervening call to
+    /// `start()`, the return value is unspecified and implementations may
     /// return whatever they like.
-    ///
-    /// The requirement that this may not be called again after it returns
-    /// `true` simplifies implementation on hardware platforms where the
-    /// hardware automatically clears the expired flag on a read, as with the
-    /// ARM SysTick peripheral.
-    fn has_expired(&self) -> bool;
+    fn get_remaining_us(&self) -> Option<u32>;
 }
 
 /// A dummy `SchedulerTimer` implementation in which the timer never expires.
@@ -142,12 +134,8 @@ impl SchedulerTimer for () {
 
     fn arm(&self) {}
 
-    fn has_expired(&self) -> bool {
-        false
-    }
-
     fn get_remaining_us(&self) -> u32 {
-        10000 // chose arbitrary large value
+        Some(10000) // chose arbitrary large value
     }
 }
 

--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -587,9 +587,11 @@ impl Kernel {
         // no longer wants to execute this process or if it exceeds its
         // timeslice.
         loop {
-            if scheduler_timer.has_expired()
-                || scheduler_timer.get_remaining_us() <= MIN_QUANTA_THRESHOLD_US
-            {
+            let stop_running = match scheduler_timer.get_remaining_us() {
+                Some(us) => us <= MIN_QUANTA_THRESHOLD_US,
+                None => true,
+            };
+            if stop_running {
                 // Process ran out of time while the kernel was executing.
                 process.debug_timeslice_expired();
                 return_reason = StoppedExecutingReason::TimesliceExpired;
@@ -798,7 +800,7 @@ impl Kernel {
                             }
                         }
                         Some(ContextSwitchReason::Interrupted) => {
-                            if scheduler_timer.has_expired() {
+                            if scheduler_timer.get_remaining_us().is_none() {
                                 // This interrupt was a timeslice expiration.
                                 process.debug_timeslice_expired();
                                 return_reason = StoppedExecutingReason::TimesliceExpired;
@@ -877,18 +879,16 @@ impl Kernel {
         // Check how much time the process used while it was executing, and
         // return the value so we can provide it to the scheduler.
         let time_executed_us = timeslice_us.map_or(None, |timeslice| {
-            // Note, we cannot call `.has_expired()` again if it has previously
-            // returned `true`, so we _must_ check the return reason first.
-            if return_reason == StoppedExecutingReason::TimesliceExpired
-                || scheduler_timer.has_expired()
-            {
-                // Note we cannot call `.get_remaining_us()` as it will return
-                // an invalid value after a timeslice expiration. Instead, we
-                // just return the original length of the timeslice.
+            // Note, we cannot call `.get_remaining_us()` again if it has previously
+            // returned `None`, so we _must_ check the return reason first.
+            if return_reason == StoppedExecutingReason::TimesliceExpired {
+                // used the whole timeslice
                 Some(timeslice)
             } else {
-                let remaining = scheduler_timer.get_remaining_us();
-                Some(timeslice - remaining)
+                match scheduler_timer.get_remaining_us() {
+                    Some(remaining) => Some(timeslice - remaining),
+                    None => Some(timeslice), // used whole timeslice
+                }
             }
         });
 


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes a potential (though as of yet undetected) bug in the kernel's use of the SchedulerTimer trait, where the kernel checked for expiration of the timer, then checked the amount of time remaining, not considering the possibility that the timer could wraparound in period between those checks, causing the kernel to read an invalid time remaining value. This was identified by @bradjc .

Rather than just fix the bug, we decided  to change the interface slightly to make this misuse impossible -- rather than separate `has_expired()` and `get_remaining_us()` functions, there is now only a `get_remaining_us()` function, which returns `None` if the timer has expired.

This PR also includes lots of documentation updates by @bradjc that clarify the `SchedulerTimer` interface further.

### Testing Strategy

This pull request was tested by running several apps simultaneously on Imix, incuding whileone, and verifying that timeslice expiration still works as expected.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] No updates are required.

### Formatting

- [x] Ran `make prepush`.
