### PR TITLE
QDEC Hil and userspace driver + hardware driver for nrf52

### DIFF
--- a/capsules/README.md
+++ b/capsules/README.md
@@ -85,7 +85,7 @@ These capsules provide a `Driver` interface for common MCU peripherals.
 - **[RNG](src/rng.rs)**: Random number generation.
 - **[SPI Controller](src/spi_controller.rs)**: SPI controller device (SPI master)
 - **[SPI Peripheral](src/spi_peripheral.rs)**: SPI peripheral device (SPI slave)
-
+- **[QDEC](src/qdec.rs)**: Quadrature DECoder for quadrature-encoded sensor signals
 
 ### Helpful Userspace Capsules
 

--- a/capsules/src/driver.rs
+++ b/capsules/src/driver.rs
@@ -70,6 +70,6 @@ pub enum NUM {
     Buzzer                = 0x90000,
     Screen                = 0x90001,
     Touch                 = 0x90002,
-    Qdec                  = 0x90003
+    Qdec                  = 0x90003,
 }
 }

--- a/capsules/src/driver.rs
+++ b/capsules/src/driver.rs
@@ -69,6 +69,7 @@ pub enum NUM {
     // Misc
     Buzzer                = 0x90000,
     Screen                = 0x90001,
-    Touch                 = 0x90002
+    Touch                 = 0x90002,
+    Qdec                  = 0x90003
 }
 }

--- a/capsules/src/lib.rs
+++ b/capsules/src/lib.rs
@@ -52,6 +52,7 @@ pub mod nrf51822_serialization;
 pub mod panic_button;
 pub mod pca9544a;
 pub mod process_console;
+pub mod qdec;
 pub mod rf233;
 pub mod rf233_const;
 pub mod rng;

--- a/capsules/src/qdec.rs
+++ b/capsules/src/qdec.rs
@@ -1,0 +1,108 @@
+//! Provides userspace access to the Qdec on a board.
+//!
+//! Usage
+//! -----
+//!
+//! ````
+//! let qdec = static_init!(
+//!     capsules::qdec::Qdec<'static>,
+//!     capsules::qdec::QdecInterface::new(&nrf52::qdec::QDEC,
+//!                                         kernel::Grant::create())
+//! );
+//! kernel::hil::QdecDriver.set_client(qdec);
+//! ````
+//! #Interrupt Spurred Readings versus Regular Readings
+//! An application can either enable interrupts to get the
+//! accumulation value or manually read it whenever it wants
+
+use crate::driver;
+use kernel::hil;
+use kernel::{AppId, Callback, Driver, Grant, ReturnCode};
+
+pub const DRIVER_NUM: usize = driver::NUM::Qdec as usize;
+
+/// This struct contains the resources necessary for the QdecInterface
+pub struct QdecInterface<'a> {
+    driver: &'a dyn hil::qdec::QdecDriver,
+    apps: Grant<App>,
+}
+
+#[derive(Default)]
+/// This struct contains the necessary fields for an app
+pub struct App {
+    callback: Option<Callback>,
+    pos: u32,
+}
+
+impl<'a> QdecInterface<'a> {
+    /// Create a new instance of the QdecInterface
+    pub fn new(driver: &'a dyn hil::qdec::QdecDriver, grant: Grant<App>) -> Self {
+        Self {
+            driver: driver,
+            apps: grant,
+        }
+    }
+
+    fn configure_callback(&self, callback: Option<Callback>, app_id: AppId) -> ReturnCode {
+        self.apps
+            .enter(app_id, |app, _| {
+                app.callback = callback;
+                ReturnCode::SUCCESS
+            })
+            .unwrap_or_else(|err| err.into())
+    }
+}
+
+impl<'a> hil::qdec::QdecClient for QdecInterface<'a> {
+    /// Goes through all the apps and if the app is
+    /// subscribed then it sends back the acc value
+    fn sample_ready(&self) {
+        for cntr in self.apps.iter() {
+            cntr.enter(|app, _| {
+                app.pos = app.pos + self.driver.get_acc();
+                app.callback
+                    .map(|mut cb| cb.schedule(app.pos as usize, 0, 0));
+            });
+        }
+    }
+
+    /// Goes through all the apps and if the app recently
+    /// had an overflow, it records the occurance
+    fn overflow(&self) {
+        /*for now, we do not handle overflows*/
+    }
+}
+
+impl<'a> Driver for QdecInterface<'a> {
+    /// Subscribes a client to (newly enabled) interrupts
+    fn subscribe(
+        &self,
+        subscribe_num: usize,
+        callback: Option<Callback>,
+        app_id: AppId,
+    ) -> ReturnCode {
+        match subscribe_num {
+            0 => self.configure_callback(callback, app_id),
+            _ => ReturnCode::ENOSUPPORT,
+        }
+    }
+
+    /// Command switch statement for various essential processes
+    /// 0 is a sanity check for the switch statement
+    /// 1 enables the qdec
+    /// 2 checks that the qdec is enabled
+    /// 3 enables inerrupts
+    /// 4 gets the current displacement stored in the QDEC
+    fn command(&self, command_num: usize, _: usize, _: usize, _app_id: AppId) -> ReturnCode {
+        match command_num {
+            0 => ReturnCode::SUCCESS,
+            1 => self.driver.enable_qdec(),
+            2 => self.driver.enabled(),
+            3 => self.driver.enable_interrupts(),
+            4 => ReturnCode::SuccessWithValue {
+                value: self.driver.get_acc() as usize,
+            },
+            _ => ReturnCode::ENOSUPPORT,
+        }
+    }
+}

--- a/capsules/src/qdec.rs
+++ b/capsules/src/qdec.rs
@@ -59,9 +59,9 @@ impl<'a> hil::qdec::QdecClient for QdecInterface<'a> {
     fn sample_ready(&self) {
         for cntr in self.apps.iter() {
             cntr.enter(|app, _| {
-                app.pos = app.pos + self.driver.get_acc();
+                app.position = app.position + self.driver.get_acc();
                 app.callback
-                    .map(|mut cb| cb.schedule(app.pos as usize, 0, 0));
+                    .map(|mut cb| cb.schedule(app.position as usize, 0, 0));
             });
         }
     }
@@ -102,6 +102,8 @@ impl<'a> Driver for QdecInterface<'a> {
             4 => ReturnCode::SuccessWithValue {
                 value: self.driver.get_acc() as usize,
             },
+            5 => self.driver.disable_qdec(),
+            6 => self.driver.disabled(),
             _ => ReturnCode::ENOSUPPORT,
         }
     }

--- a/capsules/src/qdec.rs
+++ b/capsules/src/qdec.rs
@@ -1,4 +1,6 @@
-//! Provides userspace access to the Qdec on a board.
+//! Provides userspace access to the Quadrature Decoder (QDEC) on a board.
+//! A QDEC provides buffered decoding of quadrature-encoded sensor signals.
+//! It is generally used to decode mechanical and optical signals.
 //!
 //! Usage
 //! -----
@@ -102,7 +104,6 @@ impl<'a> Driver for QdecInterface<'a> {
             4 => ReturnCode::SuccessWithValue {
                 value: self.driver.get_acc() as usize,
             },
-            5 => self.driver.disable_qdec(),
             _ => ReturnCode::ENOSUPPORT,
         }
     }

--- a/capsules/src/qdec.rs
+++ b/capsules/src/qdec.rs
@@ -97,13 +97,12 @@ impl<'a> Driver for QdecInterface<'a> {
         match command_num {
             0 => ReturnCode::SUCCESS,
             1 => self.driver.enable_qdec(),
-            2 => self.driver.enabled(),
+            2 => self.driver.disable_qdec(),
             3 => self.driver.enable_interrupts(),
             4 => ReturnCode::SuccessWithValue {
                 value: self.driver.get_acc() as usize,
             },
             5 => self.driver.disable_qdec(),
-            6 => self.driver.disabled(),
             _ => ReturnCode::ENOSUPPORT,
         }
     }

--- a/capsules/src/qdec.rs
+++ b/capsules/src/qdec.rs
@@ -31,7 +31,7 @@ pub struct QdecInterface<'a> {
 /// This struct contains the necessary fields for an app
 pub struct App {
     callback: Option<Callback>,
-    pos: i32,
+    position: i32,
 }
 
 impl<'a> QdecInterface<'a> {

--- a/capsules/src/qdec.rs
+++ b/capsules/src/qdec.rs
@@ -31,7 +31,7 @@ pub struct QdecInterface<'a> {
 /// This struct contains the necessary fields for an app
 pub struct App {
     callback: Option<Callback>,
-    pos: u32,
+    pos: i32,
 }
 
 impl<'a> QdecInterface<'a> {

--- a/chips/nrf52/src/interrupt_service.rs
+++ b/chips/nrf52/src/interrupt_service.rs
@@ -4,6 +4,7 @@ use crate::ble_radio;
 use crate::i2c;
 use crate::ieee802154_radio;
 use crate::power;
+use crate::qdec;
 use crate::spi;
 use crate::uart;
 use kernel::debug;
@@ -123,6 +124,7 @@ impl InterruptService for Nrf52InterruptService<'_> {
             }
             peripheral_interrupts::SPIM2_SPIS2_SPI2 => spi::SPIM2.handle_interrupt(),
             peripheral_interrupts::ADC => adc::ADC.handle_interrupt(),
+            peripheral_interrupts::QDEC => qdec::QDEC.handle_interrupt(),
             _ => return false,
         }
         true

--- a/chips/nrf52/src/lib.rs
+++ b/chips/nrf52/src/lib.rs
@@ -18,6 +18,7 @@ pub mod nvmc;
 pub mod power;
 pub mod ppi;
 pub mod pwm;
+pub mod qdec;
 pub mod spi;
 pub mod uart;
 pub mod uicr;

--- a/chips/nrf52/src/qdec.rs
+++ b/chips/nrf52/src/qdec.rs
@@ -322,14 +322,6 @@ impl kernel::hil::qdec::QdecDriver for Qdec {
         self.is_disabled()
     }
 
-    fn enabled(&self) -> ReturnCode {
-        self.is_enabled()
-    }
-
-    fn disabled(&self) -> ReturnCode {
-        self.is_disabled()
-    }
-
     fn get_acc(&self) -> i32 {
         let regs = &*self.registers;
         regs.tasks_readclracc.write(Task::ENABLE::SET);

--- a/chips/nrf52/src/qdec.rs
+++ b/chips/nrf52/src/qdec.rs
@@ -249,7 +249,7 @@ impl Qdec {
                         2 => {
                             client.overflow();
                         }
-                        3 => { /*No handling for DBLRDY*/ }
+                        3 => { /*For the time being, there will be no  handling for DBLRDY.*/ }
                         4 => {
                             if self.state == QdecState::Stop {
                                 self.registers.sample_per.write(SampPer::SAMPLEPER.val(5));

--- a/chips/nrf52/src/qdec.rs
+++ b/chips/nrf52/src/qdec.rs
@@ -1,0 +1,278 @@
+//!  Qdec driver, nRF5x-family
+//!  set_client(), enable, get_ticks,
+//!  The nRF5x quadrature decoder
+//!
+#[allow(unused_imports)]
+use core;
+use kernel::common::cells::OptionalCell;
+use kernel::common::registers::{
+    register_bitfields, register_structs, ReadOnly, ReadWrite, WriteOnly,
+};
+use kernel::common::StaticRef;
+use kernel::ReturnCode;
+use nrf5x::pinmux;
+// In this section I declare a struct called QdecRegisters, which contains all the
+// relevant registers as outlined in the Nordic 5x specification of the Qdec.
+register_structs! {
+    pub QdecRegisters {
+        /// Start Qdec sampling
+        (0x000 => tasks_start: WriteOnly<u32, Task::Register>),
+        /// Stop Qdec sampling
+        (0x004 => tasks_stop: WriteOnly<u32, Task::Register>),
+        /// Read and clear ACC and ACCDBL
+        (0x008 => tasks_readclracc: WriteOnly<u32, Task::Register>),
+        /// Read and clear ACC
+        (0x00C => tasks_rdclracc: WriteOnly<u32, Task::Register>),
+        /// Read nad clear ACCDBL
+        (0x010 => tasks_rdclrdbl: WriteOnly<u32, Task::Register>),
+        ///Reserve space so tasks_rdclrdbl has access to its entire address space (?)
+        (0x0014 => _reserved),
+        /// All the events which have interrupts!
+        (0x100 => events_arr: [ReadWrite<u32, Event::Register>; 5]),
+        (0x0114 => _reserved2),
+        /// Shortcut register
+        (0x200 => shorts: ReadWrite<u32, Shorts::Register>),
+        (0x204 => _reserved3),
+        /// Enable interrupt
+        (0x304 => intenset: ReadWrite<u32, Inte::Register>),
+        /// Disable Interrupt
+        (0x308 => intenclr: ReadWrite<u32, Inte::Register>),
+        (0x30C => _reserved4),
+        /// Enable the quad decoder
+        (0x500 => enable: ReadWrite<u32, Task::Register>),
+        /// Set the LED output pin polarity
+        (0x504 => ledpol: WriteOnly<u32, LedPol::Register>),
+        /// Sampling-rate register
+        (0x508 => sample_per: WriteOnly<u32, SampPer::Register>),
+        /// Sample register (receives all samples)
+        (0x50C => sample: WriteOnly<u32, Sample::Register>),
+        /// Reportper
+        (0x510 => report_per: ReadOnly<u32, ReportPer::Register>),
+        /// Accumulating motion-sample values register
+        (0x514 => acc: ReadOnly<u32, Acc::Register>),
+        (0x518 => acc_read: ReadOnly<u32, Acc::Register>),
+        (0x51C => reserved6),
+        (0x520 => psel_a: ReadWrite<u32, PinSelect::Register>),
+        (0x524 => psel_b: ReadWrite<u32, PinSelect::Register>),
+        (0x528 => reserved5),
+        (0x544 => accdbl: ReadOnly<u32, AccDbl::Register>),
+        (0x548 => accdbl_read: ReadOnly<u32, AccDbl::Register>),
+        (0x54C => @END),
+    }
+}
+
+register_bitfields![u32,
+    Task [
+        ENABLE 0
+    ],
+    Shorts [
+        /// Write '1' to Enable shortcut on EVENTS_COMPARE\[0\] event
+        REPORTRDY_READCLRACC 0,
+        /// Write '1' to Enable shortcut on EVENTS_COMPARE\[1\] event
+        SAMPLERDY_STOP 1,
+        /// Write '1' to Enable shortcut on EVENTS_COMPARE\[2\] event
+        REPORTRDY_RDCLRACC 2,
+        /// Write '1' to Enable shortcut on EVENTS_COMPARE\[3\] event
+        REPORTRDY_STOP 3,
+        /// Write '1' to Enable shortcut on EVENTS_COMPARE\[4\] event
+        DBLRDY_RDCLRDBL 4,
+        /// Write '1' to Enable shortcut on EVENTS_COMPARE\[5\] event
+        DBLRDY_STOP 5,
+        /// Write '1' to Enable shortcut on EVENTS_COMPARE\[6\] event
+        SAMPLERDY_READCLRACC 6
+    ],
+    Event [
+        READY 0
+    ],
+    PinSelect [
+        Pin OFFSET(0) NUMBITS(5),
+        Port OFFSET(5) NUMBITS(1),
+        Connect OFFSET(31) NUMBITS(1)
+    ],
+    Inte [
+        /// Write '1' to Enable interrupt on EVENTS_COMPARE\[0\] event
+        SAMPLERDY 0,
+        /// Write '1' to Enable interrupt on EVENTS_COMPARE\[1\] event
+        REPORTRDY 1,
+        /// Write '1' to Enable interrupt on EVENTS_COMPARE\[2\] event
+        ACCOF 2,
+        /// Write '1' to Enable interrupt on EVENTS_COMPARE\[3\] event
+        DBLRDY 3,
+        /// Write '1' to Enable interrupt on EVENTS_COMPARE\[4\] event
+        STOPPED 4
+    ],
+    LedPol [
+        LedPol OFFSET(0) NUMBITS(1) [
+            ActiveLow = 0,
+            ActiveHigh = 1
+        ]
+    ],
+    Sample [
+        SAMPLE 1
+    ],
+    SampPer [
+        SAMPLEPER OFFSET(0) NUMBITS(4) [
+            us128 = 0,
+            us256 = 1,
+            us512 = 2,
+            us1024 = 3,
+            us2048 = 4,
+            us4096 = 5,
+            us8192 = 6,
+            us16384 = 7,
+            ms32 = 8,
+            ms65 = 9,
+            ms131 = 10
+        ]
+    ],
+    ReportPer [
+        REPORTPER OFFSET(0) NUMBITS(4) [
+            hz10 = 0,
+            hz40 = 1,
+            hz80 = 2,
+            hz120 = 3,
+            hz160 = 4,
+            hz200 = 5,
+            hz240 = 6,
+            hz280 = 7,
+            hz1 = 8
+        ]
+    ],
+    Acc [
+        ACC OFFSET(0) NUMBITS(32)
+    ],
+    AccDbl [
+        ACCDBL OFFSET(0) NUMBITS(4)
+    ]
+];
+
+/// This defines the beginning of memory which is memory-mapped to the Qdec
+/// This base is declared under the Registers Table 3
+const QDEC_BASE: StaticRef<QdecRegisters> =
+    unsafe { StaticRef::new(0x40012000 as *const QdecRegisters) };
+
+pub static mut QDEC: Qdec = Qdec::new();
+
+#[derive(PartialEq, Eq)]
+enum QdecState {
+    Start,
+    Stop,
+}
+/// Qdec type declaration: gives the Qdec instance registers and a client
+pub struct Qdec {
+    registers: StaticRef<QdecRegisters>,
+    client: OptionalCell<&'static dyn kernel::hil::qdec::QdecClient>,
+    state: QdecState,
+}
+
+/// Qdec impl: provides the Qdec type with vital functionality including:
+impl Qdec {
+    const fn new() -> Qdec {
+        let qdec = Qdec {
+            registers: QDEC_BASE,
+            client: OptionalCell::empty(),
+            state: QdecState::Start,
+        };
+        qdec
+    }
+
+    /// sets pins_a and pins_b to be the output pins for whatever the encoding device is  
+    pub fn set_pins(&self, pin_a: pinmux::Pinmux, pin_b: pinmux::Pinmux) {
+        let regs = self.registers;
+        regs.psel_a.write(
+            PinSelect::Pin.val(pin_a.into()) + PinSelect::Port.val(0) + PinSelect::Connect.val(0),
+        );
+        regs.psel_b.write(
+            PinSelect::Pin.val(pin_b.into()) + PinSelect::Port.val(0) + PinSelect::Connect.val(0),
+        );
+    }
+
+    pub fn set_client(&self, client: &'static dyn kernel::hil::qdec::QdecClient) {
+        self.client.set(client);
+    }
+
+    /// When an interrupt occurs, check to see if any
+    /// of the interrupt register bits are set. If it
+    /// is, then put it in the client's bitmask
+    pub(crate) fn handle_interrupt(&self) {
+        let regs = &*self.registers;
+        self.client.map(|client| {
+            // For each of 4 possible compare events, if it's happened,
+            // clear it and sort its bit in val to pass in callback
+            for i in 0..regs.events_arr.len() {
+                if regs.events_arr[i].is_set(Event::READY) {
+                    regs.events_arr[i].set(0);
+                    match i {
+                        0 => {
+                            client.sample_ready();
+                        }
+                        1 => { /*No handling for REPORTRDY*/ }
+                        2 => {
+                            client.overflow();
+                        }
+                        3 => { /*No handling for DBLRDY*/ }
+                        4 => {
+                            if self.state == QdecState::Stop {
+                                self.registers.sample_per.write(SampPer::SAMPLEPER.val(5));
+                                self.registers.tasks_start.write(Task::ENABLE::SET);
+                            }
+                        }
+                        _ => panic!("Unsupported interrupt value {}!", i),
+                    }
+                }
+            }
+        });
+    }
+
+    fn enable_samplerdy_interrupts(&self) {
+        let regs = &*self.registers;
+
+        regs.intenset.write(Inte::REPORTRDY::SET); /*SET REPORT READY*/
+        regs.intenset.write(Inte::ACCOF::SET); /*SET ACCOF READY*/
+    }
+
+    fn enable(&self) {
+        let regs = &*self.registers;
+        regs.enable.write(Task::ENABLE::SET);
+        regs.tasks_start.write(Task::ENABLE::SET);
+    }
+
+    fn is_enabled(&self) -> ReturnCode {
+        let regs = &*self.registers;
+        let result = if regs.enable.is_set(Task::ENABLE) {
+            ReturnCode::SUCCESS
+        } else {
+            ReturnCode::FAIL
+        };
+        result
+    }
+}
+
+impl kernel::hil::qdec::QdecDriver for Qdec {
+    fn enable_interrupts(&self) -> ReturnCode {
+        self.enable_samplerdy_interrupts();
+        ReturnCode::SUCCESS
+    }
+
+    fn enable_qdec(&self) -> ReturnCode {
+        if self.is_enabled() != ReturnCode::SUCCESS {
+            self.enable();
+        }
+        self.is_enabled()
+    }
+
+    fn enabled(&self) -> ReturnCode {
+        self.is_enabled()
+    }
+
+    fn get_acc(&self) -> u32 {
+        let regs = &*self.registers;
+        regs.tasks_readclracc.write(Task::ENABLE::SET);
+        let val = regs.acc_read.read(Acc::ACC);
+        val
+    }
+
+    fn set_client(&self, client: &'static dyn kernel::hil::qdec::QdecClient) {
+        self.client.set(client);
+    }
+}

--- a/chips/nrf52/src/qdec.rs
+++ b/chips/nrf52/src/qdec.rs
@@ -265,11 +265,11 @@ impl kernel::hil::qdec::QdecDriver for Qdec {
         self.is_enabled()
     }
 
-    fn get_acc(&self) -> u32 {
+    fn get_acc(&self) -> i32 {
         let regs = &*self.registers;
         regs.tasks_readclracc.write(Task::ENABLE::SET);
         let val = regs.acc_read.read(Acc::ACC);
-        val
+        val as i32
     }
 
     fn set_client(&self, client: &'static dyn kernel::hil::qdec::QdecClient) {

--- a/chips/nrf52/src/qdec.rs
+++ b/chips/nrf52/src/qdec.rs
@@ -63,6 +63,7 @@ register_structs! {
 
 register_bitfields![u32,
     Task [
+        /// Enable
         ENABLE 0
     ],
     Shorts [
@@ -82,11 +83,15 @@ register_bitfields![u32,
         SAMPLERDY_READCLRACC 6
     ],
     Event [
+        /// Ready to receive interrupts
         READY 0
     ],
     PinSelect [
+        /// Pins the QDEC is attached to
         Pin OFFSET(0) NUMBITS(5),
+        /// Port the QDEC is using
         Port OFFSET(5) NUMBITS(1),
+        /// Connects pins
         Connect OFFSET(31) NUMBITS(1)
     ],
     Inte [
@@ -102,46 +107,74 @@ register_bitfields![u32,
         STOPPED 4
     ],
     LedPol [
+        /// LED pin polarity
         LedPol OFFSET(0) NUMBITS(1) [
+            /// Active: Low
             ActiveLow = 0,
+            /// Active: High
             ActiveHigh = 1
         ]
     ],
     Sample [
+        /// Last motion sample
         SAMPLE 1
     ],
     SampPer [
+        /// Sample period
         SAMPLEPER OFFSET(0) NUMBITS(4) [
+            /// Sample every 128 microseconds
             us128 = 0,
+            /// Sample every 256 microseconds
             us256 = 1,
+            /// Sample every 512 microseconds
             us512 = 2,
+            /// Sample every 1024 microseconds
             us1024 = 3,
+            /// Sample every 2048 microseconds
             us2048 = 4,
+            /// Sample every 4096 microseconds
             us4096 = 5,
+            /// Sample every 8192 microseconds
             us8192 = 6,
+            /// Sample every 16384 microseconds
             us16384 = 7,
+            /// Sample every 32 milliseconds
             ms32 = 8,
+            /// Sample every 65 milliseconds
             ms65 = 9,
+            /// Sample every 131 milliseconds
             ms131 = 10
         ]
     ],
     ReportPer [
+        /// Captures several samples before being sent out by REPORTRDY event
         REPORTPER OFFSET(0) NUMBITS(4) [
+            /// 10 samples/report
             hz10 = 0,
+            /// 40 samples/report
             hz40 = 1,
+            /// 80 samples/report
             hz80 = 2,
+            /// 120 samples/report
             hz120 = 3,
+            /// 160 samples/report
             hz160 = 4,
+            /// 200 samples/report
             hz200 = 5,
+            /// 240 samples/report
             hz240 = 6,
+            /// 280 samples/report
             hz280 = 7,
+            /// 1 sample/report
             hz1 = 8
         ]
     ],
     Acc [
+        /// Valid motion value samples 
         ACC OFFSET(0) NUMBITS(32)
     ],
     AccDbl [
+        /// Invalid motion value samples
         ACCDBL OFFSET(0) NUMBITS(4)
     ]
 ];
@@ -153,6 +186,7 @@ const QDEC_BASE: StaticRef<QdecRegisters> =
 
 pub static mut QDEC: Qdec = Qdec::new();
 
+/// Enum defining the current QDEC state of started or stopped
 #[derive(PartialEq, Eq)]
 enum QdecState {
     Start,
@@ -206,7 +240,11 @@ impl Qdec {
                         0 => {
                             client.sample_ready();
                         }
-                        1 => { /*No handling for REPORTRDY*/ }
+                        1 => { /*For the time being, there will be no implementation in respone
+                                 to the firing of the REPORTRDY interrupt. It fires too frequently
+                                 in order to utilize it for position measuring. However, by that same 
+                                 token, it cannot merely be marked as unimplemented since it would
+                                 crash the program.*/ }
                         2 => {
                             client.overflow();
                         }

--- a/chips/nrf52/src/qdec.rs
+++ b/chips/nrf52/src/qdec.rs
@@ -275,12 +275,28 @@ impl Qdec {
         regs.tasks_start.write(Task::ENABLE::SET);
     }
 
+    fn disable(&self) {
+        let regs = &*self.registers;
+        regs.enable.write(Task::ENABLE::CLEAR);
+        regs.tasks_start.write(Task::ENABLE::CLEAR);
+    }
+
     fn is_enabled(&self) -> ReturnCode {
         let regs = &*self.registers;
         let result = if regs.enable.is_set(Task::ENABLE) {
             ReturnCode::SUCCESS
         } else {
             ReturnCode::FAIL
+        };
+        result
+    }
+
+    fn is_disabled(&self) -> ReturnCode {
+        let regs = &*self.registers;
+        let result = if regs.enable.is_set(Task::ENABLE) {
+            ReturnCode::FAIL
+        } else {
+            ReturnCode::SUCCESS
         };
         result
     }
@@ -299,8 +315,19 @@ impl kernel::hil::qdec::QdecDriver for Qdec {
         self.is_enabled()
     }
 
+    fn disable_qdec(&self) -> ReturnCode {
+        if self.is_enabled() == ReturnCode::SUCCESS {
+            self.disable();
+        }
+        self.is_disabled()
+    }
+
     fn enabled(&self) -> ReturnCode {
         self.is_enabled()
+    }
+
+    fn disabled(&self) -> ReturnCode {
+        self.is_disabled()
     }
 
     fn get_acc(&self) -> i32 {

--- a/chips/nrf52/src/qdec.rs
+++ b/chips/nrf52/src/qdec.rs
@@ -170,7 +170,7 @@ register_bitfields![u32,
         ]
     ],
     Acc [
-        /// Valid motion value samples 
+        /// Valid motion value samples
         ACC OFFSET(0) NUMBITS(32)
     ],
     AccDbl [
@@ -241,10 +241,11 @@ impl Qdec {
                             client.sample_ready();
                         }
                         1 => { /*For the time being, there will be no implementation in respone
-                                 to the firing of the REPORTRDY interrupt. It fires too frequently
-                                 in order to utilize it for position measuring. However, by that same 
-                                 token, it cannot merely be marked as unimplemented since it would
-                                 crash the program.*/ }
+                             to the firing of the REPORTRDY interrupt. It fires too frequently
+                             in order to utilize it for position measuring. However, by that same
+                             token, it cannot merely be marked as unimplemented since it would
+                             crash the program.*/
+                        }
                         2 => {
                             client.overflow();
                         }

--- a/chips/nrf52840/src/lib.rs
+++ b/chips/nrf52840/src/lib.rs
@@ -2,7 +2,7 @@
 
 pub use nrf52::{
     acomp, adc, aes, ble_radio, clock, constants, crt1, ficr, i2c, ieee802154_radio, init, nvmc,
-    pinmux, ppi, pwm, rtc, spi, temperature, timer, trng, uart, uicr, usbd,
+    pinmux, ppi, pwm, qdec, rtc, spi, temperature, timer, trng, uart, uicr, usbd,
 };
 pub mod chip;
 pub mod gpio;

--- a/kernel/src/hil/mod.rs
+++ b/kernel/src/hil/mod.rs
@@ -16,6 +16,7 @@ pub mod led;
 pub mod log;
 pub mod nonvolatile_storage;
 pub mod pwm;
+pub mod qdec;
 pub mod radio;
 pub mod rng;
 pub mod screen;

--- a/kernel/src/hil/qdec.rs
+++ b/kernel/src/hil/qdec.rs
@@ -1,0 +1,33 @@
+//! Interface for a Qdec compatible chip
+//!
+//! This trait provides a stanfard interface for chips with a
+//! quadrature decoder. Note this interface is experimental and
+//! may need further updates once implemented on additional chips
+
+use crate::returncode::ReturnCode;
+
+pub trait QdecDriver {
+    /// Sets the client which will receive interrupts
+    fn set_client(&self, client: &'static dyn QdecClient);
+
+    /// Enables the SAMPLERDY interrupt
+    fn enable_interrupts(&self) -> ReturnCode;
+
+    /// Enables the Qdec, returning error if Qdec does not exist
+    fn enable_qdec(&self) -> ReturnCode;
+
+    /// Checks if the qdec has been enabled
+    fn enabled(&self) -> ReturnCode;
+
+    /// Reads the accumulator value and resets it
+    /// Note accumulator means the measure of how many ticks the
+    /// QDEC has moved since the last time the function was called
+    fn get_acc(&self) -> u32;
+}
+
+pub trait QdecClient {
+    /// Indicate to the client that the status of the accumulator has changed
+    fn sample_ready(&self);
+    /// Indicate to the client that an overflow has occurred
+    fn overflow(&self);
+}

--- a/kernel/src/hil/qdec.rs
+++ b/kernel/src/hil/qdec.rs
@@ -10,7 +10,7 @@ pub trait QdecDriver {
     /// Sets the client which will receive interrupts
     fn set_client(&self, client: &'static dyn QdecClient);
 
-    /// Enables the SAMPLERDY interrupt
+    /// Enables the interrupt collecting and storing samples
     fn enable_interrupts(&self) -> ReturnCode;
 
     /// Enables the Qdec, returning error if QDEC is not working
@@ -18,12 +18,6 @@ pub trait QdecDriver {
 
     /// Disables the QDEC
     fn disable_qdec(&self) -> ReturnCode;
-
-    /// Checks if the qdec has been enabled
-    fn enabled(&self) -> ReturnCode;
-
-    /// Checks if the qdec has been disabled
-    fn disabled(&self) -> ReturnCode;
 
     /// Reads the accumulator value and resets it
     /// Note accumulator means the measure of how many ticks the

--- a/kernel/src/hil/qdec.rs
+++ b/kernel/src/hil/qdec.rs
@@ -16,8 +16,14 @@ pub trait QdecDriver {
     /// Enables the Qdec, returning error if QDEC is not working
     fn enable_qdec(&self) -> ReturnCode;
 
+    /// Disables the QDEC
+    fn disable_qdec(&self) -> ReturnCode;
+
     /// Checks if the qdec has been enabled
     fn enabled(&self) -> ReturnCode;
+
+    /// Checks if the qdec has been disabled
+    fn disabled(&self) -> ReturnCode;
 
     /// Reads the accumulator value and resets it
     /// Note accumulator means the measure of how many ticks the

--- a/kernel/src/hil/qdec.rs
+++ b/kernel/src/hil/qdec.rs
@@ -13,7 +13,7 @@ pub trait QdecDriver {
     /// Enables the SAMPLERDY interrupt
     fn enable_interrupts(&self) -> ReturnCode;
 
-    /// Enables the Qdec, returning error if Qdec does not exist
+    /// Enables the Qdec, returning error if QDEC is not working
     fn enable_qdec(&self) -> ReturnCode;
 
     /// Checks if the qdec has been enabled
@@ -22,7 +22,7 @@ pub trait QdecDriver {
     /// Reads the accumulator value and resets it
     /// Note accumulator means the measure of how many ticks the
     /// QDEC has moved since the last time the function was called
-    fn get_acc(&self) -> u32;
+    fn get_acc(&self) -> i32;
 }
 
 pub trait QdecClient {


### PR DESCRIPTION
### Pull Request Overview

This pull request adds the QDEC peripheral functionality to TockOS. This includes an addition of HIL and Capsule files. The associated documentation that helped guide the design and implementation of the qdec can be found [here](https://infocenter.nordicsemi.com/index.jsp?topic=%2Fcom.nordic.infocenter.nrf52832.ps.v1.1%2Fqdec.html).

### Testing Strategy

There is a corresponding userspace application which actively tests the full end-to-end functionality of the QDEC peripheral. In order to test the QDEC, a rotary encoder,  nrf52840dk board, and three wires hooked up between the rotary encoder and the GPIO Pins 02, 29, and GND.

This pull request was tested and verified by Michaela Murray (author) and Hudson Ayers.

### TODO or Help Wanted

n/a

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
