### PR TITLE
opentitan: Disable USB support by default

### DIFF
--- a/boards/components/src/ctap.rs
+++ b/boards/components/src/ctap.rs
@@ -1,0 +1,128 @@
+//! Component for CTAP HID over USB support.
+//!
+//! This provides a component for using the CTAP driver. This allows for
+//! Client to Authenticator Protool Authentication
+//!
+//! Usage
+//! -----
+//! ```rust
+//! static STRINGS: &'static [&str; 3] = &[
+//!     "XYZ Corp.",     // Manufacturer
+//!     "FIDO Key",      // Product
+//!     "Serial No. 5",  // Serial number
+//! ];
+//!     let ctap_send_buffer = static_init!([u8; 64], [0; 64]);
+//!     let ctap_recv_buffer = static_init!([u8; 64], [0; 64]);
+//!
+//!     let (ctap, ctap_driver) = components::ctap::CtapComponent::new(
+//!         &earlgrey::usbdev::USB,
+//!         0x1337, // My important company
+//!         0x0DEC, // My device name
+//!         strings,
+//!         board_kernel,
+//!         ctap_send_buffer,
+//!         ctap_recv_buffer,
+//!     )
+//!     .finalize(components::usb_ctap_component_helper!(lowrisc::usbdev::Usb));
+//!
+//!     ctap.enable();
+//!     ctap.attach();
+//! ```
+
+use core::mem::MaybeUninit;
+use kernel::capabilities;
+use kernel::component::Component;
+use kernel::create_capability;
+use kernel::hil;
+use kernel::static_init_half;
+
+// Setup static space for the objects.
+#[macro_export]
+macro_rules! usb_ctap_component_helper {
+    ($U:ty) => {{
+        use core::mem::MaybeUninit;
+        static mut BUF1: MaybeUninit<capsules::usb::ctap::CtapHid<'static, $U>> =
+            MaybeUninit::uninit();
+        static mut BUF2: MaybeUninit<
+            capsules::ctap::CtapDriver<'static, capsules::usb::ctap::CtapHid<'static, $U>>,
+        > = MaybeUninit::uninit();
+        (&mut BUF1, &mut BUF2)
+    };};
+}
+
+pub struct CtapComponent<U: 'static + hil::usb::UsbController<'static>> {
+    usb: &'static U,
+    vendor_id: u16,
+    product_id: u16,
+    strings: &'static [&'static str; 3],
+    board_kernel: &'static kernel::Kernel,
+    send_buffer: &'static mut [u8; 64],
+    recv_buffer: &'static mut [u8; 64],
+}
+
+impl<U: 'static + hil::usb::UsbController<'static>> CtapComponent<U> {
+    pub fn new(
+        usb: &'static U,
+        vendor_id: u16,
+        product_id: u16,
+        strings: &'static [&'static str; 3],
+        board_kernel: &'static kernel::Kernel,
+        send_buffer: &'static mut [u8; 64],
+        recv_buffer: &'static mut [u8; 64],
+    ) -> CtapComponent<U> {
+        CtapComponent {
+            usb,
+            vendor_id,
+            product_id,
+            strings,
+            board_kernel,
+            send_buffer,
+            recv_buffer,
+        }
+    }
+}
+
+impl<U: 'static + hil::usb::UsbController<'static>> Component for CtapComponent<U> {
+    type StaticInput = (
+        &'static mut MaybeUninit<capsules::usb::ctap::CtapHid<'static, U>>,
+        &'static mut MaybeUninit<
+            capsules::ctap::CtapDriver<'static, capsules::usb::ctap::CtapHid<'static, U>>,
+        >,
+    );
+    type Output = (
+        &'static capsules::usb::ctap::CtapHid<'static, U>,
+        &'static capsules::ctap::CtapDriver<'static, capsules::usb::ctap::CtapHid<'static, U>>,
+    );
+
+    unsafe fn finalize(self, s: Self::StaticInput) -> Self::Output {
+        let ctap = static_init_half!(
+            s.0,
+            capsules::usb::ctap::CtapHid<'static, U>,
+            capsules::usb::ctap::CtapHid::new(
+                self.usb,
+                self.vendor_id,
+                self.product_id,
+                self.strings
+            )
+        );
+        self.usb.set_client(ctap);
+
+        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
+
+        let ctap_driver = static_init_half!(
+            s.1,
+            capsules::ctap::CtapDriver<'static, capsules::usb::ctap::CtapHid<'static, U>>,
+            capsules::ctap::CtapDriver::new(
+                Some(ctap),
+                self.send_buffer,
+                self.recv_buffer,
+                self.board_kernel.create_grant(&grant_cap),
+            )
+        );
+
+        ctap.set_client(ctap_driver);
+        ctap_driver.allow_receive();
+
+        (ctap, ctap_driver)
+    }
+}

--- a/boards/components/src/lib.rs
+++ b/boards/components/src/lib.rs
@@ -7,6 +7,7 @@ pub mod button;
 pub mod cdc;
 pub mod console;
 pub mod crc;
+pub mod ctap;
 pub mod debug_queue;
 pub mod debug_writer;
 pub mod ft6x06;

--- a/capsules/src/ctap.rs
+++ b/capsules/src/ctap.rs
@@ -1,0 +1,301 @@
+//! Provides userspace with access CTAP devices over any transport
+//! layer (USB HID, BLE, NFC). Currently only USB HID is supported.
+//!
+//! Setup
+//! -----
+//!
+//! You need a device that provides the `hil::usb::UsbController` and
+//! `hil::usb_hid::UsbHid` trait.
+//!
+//! ```rust
+//!     let ctap_send_buffer = static_init!([u8; 64], [0; 64]);
+//!     let ctap_recv_buffer = static_init!([u8; 64], [0; 64]);
+//!
+//!     let (ctap, ctap_driver) = components::ctap::CtapComponent::new(
+//!         &earlgrey::usbdev::USB,
+//!         0x1337, // My important company
+//!         0x0DEC, // My device name
+//!         strings,
+//!         board_kernel,
+//!         ctap_send_buffer,
+//!         ctap_recv_buffer,
+//!     )
+//!     .finalize(components::usb_ctap_component_helper!(lowrisc::usbdev::Usb));
+//!
+//!     ctap.enable();
+//!     ctap.attach();
+//! ```
+//!
+
+use core::cell::Cell;
+use core::marker::PhantomData;
+use kernel::common::cells::{OptionalCell, TakeCell};
+use kernel::hil::usb_hid;
+use kernel::{AppId, AppSlice, Callback, Driver, Grant, ReturnCode, Shared};
+
+/// Syscall driver number.
+use crate::driver;
+pub const DRIVER_NUM: usize = driver::NUM::Ctap as usize;
+
+pub struct App {
+    callback: OptionalCell<Callback>,
+    recv_buf: Option<AppSlice<Shared, u8>>,
+    send_buf: Option<AppSlice<Shared, u8>>,
+    can_receive: Cell<bool>,
+}
+
+impl Default for App {
+    fn default() -> App {
+        App {
+            callback: OptionalCell::empty(),
+            recv_buf: None,
+            send_buf: None,
+            can_receive: Cell::new(false),
+        }
+    }
+}
+
+pub static mut WRITE_BUF: [u8; 64] = [0; 64];
+pub static mut READ_BUF: [u8; 64] = [0; 64];
+
+pub struct CtapDriver<'a, U: usb_hid::UsbHid<'a>> {
+    usb: Option<&'a U>,
+
+    app: Grant<App>,
+    recv_appid: OptionalCell<AppId>,
+    send_appid: OptionalCell<AppId>,
+    phantom: PhantomData<&'a U>,
+
+    send_buffer: TakeCell<'static, [u8; 64]>,
+    recv_buffer: TakeCell<'static, [u8; 64]>,
+}
+
+impl<'a, U: usb_hid::UsbHid<'a>> CtapDriver<'a, U> {
+    pub fn new(
+        usb: Option<&'a U>,
+        send_buffer: &'static mut [u8; 64],
+        recv_buffer: &'static mut [u8; 64],
+        grant: Grant<App>,
+    ) -> CtapDriver<'a, U> {
+        CtapDriver {
+            usb: usb,
+            app: grant,
+            recv_appid: OptionalCell::empty(),
+            send_appid: OptionalCell::empty(),
+            phantom: PhantomData,
+            send_buffer: TakeCell::new(send_buffer),
+            recv_buffer: TakeCell::new(recv_buffer),
+        }
+    }
+
+    pub fn allow_receive(&'a self) {
+        if let Some(usb) = self.usb {
+            usb.set_recv_buffer(self.recv_buffer.take().unwrap());
+        }
+    }
+}
+
+impl<'a, U: usb_hid::UsbHid<'a>> usb_hid::UsbHid<'a> for CtapDriver<'a, U> {
+    fn set_recv_buffer(&'a self, recv: &'static mut [u8; 64]) {
+        if let Some(usb) = self.usb {
+            usb.set_recv_buffer(recv);
+        }
+    }
+
+    fn send_buffer(
+        &'a self,
+        send: &'static mut [u8; 64],
+    ) -> Result<usize, (ReturnCode, &'static mut [u8; 64])> {
+        if let Some(usb) = self.usb {
+            usb.send_buffer(send)
+        } else {
+            Err((ReturnCode::ENOSUPPORT, send))
+        }
+    }
+
+    fn allow_receive(&'a self) {
+        unreachable!()
+    }
+}
+
+impl<'a, U: usb_hid::UsbHid<'a>> usb_hid::Client<'a> for CtapDriver<'a, U> {
+    fn packet_received(&'a self, buffer: &'static mut [u8; 64], _len: usize, _endpoint: usize) {
+        self.recv_appid.map(|id| {
+            self.app
+                .enter(*id, |app, _| {
+                    match app.recv_buf.as_mut() {
+                        Some(dest) => {
+                            dest.as_mut().copy_from_slice(buffer.as_ref());
+                        }
+                        None => {}
+                    };
+
+                    app.callback.map(|cb| {
+                        cb.schedule(0, 0, 0);
+                        // Set that we can't receive until the app says we can
+                        app.can_receive.set(false);
+                    });
+                })
+                .map_err(|err| {
+                    if err == kernel::procs::Error::NoSuchApp
+                        || err == kernel::procs::Error::InactiveApp
+                    {}
+                })
+        });
+
+        // Give the USB back it's receive buffer
+        if let Some(usb) = self.usb {
+            usb.set_recv_buffer(buffer);
+        }
+    }
+
+    fn packet_transmitted(
+        &'a self,
+        _result: Result<(), ReturnCode>,
+        buffer: &'static mut [u8; 64],
+        _len: usize,
+        _endpoint: usize,
+    ) {
+        self.send_appid.map(|id| {
+            self.app
+                .enter(*id, |app, _| {
+                    app.callback.map(|cb| {
+                        cb.schedule(1, 0, 0);
+                    });
+                })
+                .map_err(|err| {
+                    if err == kernel::procs::Error::NoSuchApp
+                        || err == kernel::procs::Error::InactiveApp
+                    {}
+                })
+        });
+
+        // Save our send buffer so we can use it later
+        self.send_buffer.replace(buffer);
+    }
+
+    fn can_receive(&'a self) -> bool {
+        self.recv_appid
+            .map(|id| {
+                self.app
+                    .enter(*id, |app, _| app.can_receive.get())
+                    .unwrap_or(false)
+            })
+            .unwrap_or(false)
+    }
+}
+
+impl<'a, U: usb_hid::UsbHid<'a>> Driver for CtapDriver<'a, U> {
+    fn allow(
+        &self,
+        appid: AppId,
+        allow_num: usize,
+        slice: Option<AppSlice<Shared, u8>>,
+    ) -> ReturnCode {
+        match allow_num {
+            // Pass buffer for the recvieved data to be stored in
+            0 => self
+                .app
+                .enter(appid, |app, _| {
+                    app.recv_buf = slice;
+                    self.recv_appid.set(appid);
+                    ReturnCode::SUCCESS
+                })
+                .unwrap_or(ReturnCode::FAIL),
+
+            // Pass buffer for the sent data to be stored in
+            1 => self
+                .app
+                .enter(appid, |app, _| {
+                    app.send_buf = slice;
+                    self.send_appid.set(appid);
+                    ReturnCode::SUCCESS
+                })
+                .unwrap_or(ReturnCode::FAIL),
+
+            // default
+            _ => ReturnCode::ENOSUPPORT,
+        }
+    }
+
+    /// Subscribe to HmacDriver events.
+    ///
+    /// ### `subscribe_num`
+    ///
+    /// - `0`: Subscribe to interrupts from HMAC events.
+    ///        The callback signature is `fn(result: u32)`
+    fn subscribe(
+        &self,
+        subscribe_num: usize,
+        callback: Option<Callback>,
+        appid: AppId,
+    ) -> ReturnCode {
+        match subscribe_num {
+            0 => {
+                // set recv callback
+                self.app
+                    .enter(appid, |app, _| {
+                        app.callback.insert(callback);
+                        ReturnCode::SUCCESS
+                    })
+                    .unwrap_or(ReturnCode::FAIL)
+            }
+
+            // default
+            _ => ReturnCode::ENOSUPPORT,
+        }
+    }
+
+    fn command(
+        &self,
+        command_num: usize,
+        _data1: usize,
+        _data2: usize,
+        appid: AppId,
+    ) -> ReturnCode {
+        match command_num {
+            // Send data
+            0 => self
+                .app
+                .enter(appid, |app, _| {
+                    if let Some(usb) = self.usb {
+                        match app.send_buf.as_ref() {
+                            Some(d) => {
+                                self.send_buffer.take().map(|buf| {
+                                    let data = d.as_ref();
+
+                                    // Copy the data into the static buffer
+                                    buf.copy_from_slice(&data[0..]);
+
+                                    let _ = usb.send_buffer(buf);
+                                });
+                            }
+                            None => {
+                                return ReturnCode::ERESERVE;
+                            }
+                        };
+                        ReturnCode::SUCCESS
+                    } else {
+                        ReturnCode::ENOSUPPORT
+                    }
+                })
+                .unwrap_or_else(|err| err.into()),
+            // Allow receive
+            1 => self
+                .app
+                .enter(appid, |app, _| {
+                    if let Some(usb) = self.usb {
+                        app.can_receive.set(true);
+                        usb.allow_receive();
+                        ReturnCode::SUCCESS
+                    } else {
+                        ReturnCode::ENOSUPPORT
+                    }
+                })
+                .unwrap_or_else(|err| err.into()),
+
+            // default
+            _ => ReturnCode::ENOSUPPORT,
+        }
+    }
+}

--- a/capsules/src/driver.rs
+++ b/capsules/src/driver.rs
@@ -36,6 +36,7 @@ pub enum NUM {
     Rng                   = 0x40001,
     Crc                   = 0x40002,
     Hmac                  = 0x40003,
+    Ctap                  = 0x40004,
 
     // Storage
     AppFlash              = 0x50000,

--- a/capsules/src/hmac.rs
+++ b/capsules/src/hmac.rs
@@ -246,7 +246,7 @@ impl<'a, H: digest::Digest<'a, T> + digest::HMACSha256, T: DigestType> digest::C
         });
     }
 
-    fn hash_done(&'a self, result: Result<(), ReturnCode>, digest: &mut T) {
+    fn hash_done(&'a self, result: Result<(), ReturnCode>, digest: &'static mut T) {
         self.appid.map(|id| {
             self.apps
                 .enter(*id, |app, _| {
@@ -279,6 +279,8 @@ impl<'a, H: digest::Digest<'a, T> + digest::HMACSha256, T: DigestType> digest::C
                     }
                 })
         });
+
+        self.dest_buffer.replace(digest);
     }
 }
 

--- a/capsules/src/lib.rs
+++ b/capsules/src/lib.rs
@@ -19,6 +19,7 @@ pub mod button;
 pub mod buzzer_driver;
 pub mod console;
 pub mod crc;
+pub mod ctap;
 pub mod dac;
 pub mod debug_process_restart;
 pub mod driver;

--- a/capsules/src/usb/ctap.rs
+++ b/capsules/src/usb/ctap.rs
@@ -1,0 +1,397 @@
+//! Client to Authenticator Protocol CTAPv2 over USB HID
+//!
+//! Based on the spec avaliable at: https://fidoalliance.org/specs/fido-v2.0-id-20180227/fido-client-to-authenticator-protocol-v2.0-id-20180227.html
+
+use core::cell::Cell;
+use core::cmp;
+
+use super::descriptors;
+use super::descriptors::Buffer64;
+use super::descriptors::DescriptorType;
+use super::descriptors::EndpointAddress;
+use super::descriptors::EndpointDescriptor;
+use super::descriptors::HIDCountryCode;
+use super::descriptors::HIDDescriptor;
+use super::descriptors::HIDSubordinateDescriptor;
+use super::descriptors::InterfaceDescriptor;
+use super::descriptors::ReportDescriptor;
+use super::descriptors::TransferDirection;
+use super::usbc_client_ctrl::ClientCtrl;
+
+use kernel::common::cells::OptionalCell;
+use kernel::common::cells::TakeCell;
+use kernel::common::cells::VolatileCell;
+use kernel::hil;
+use kernel::hil::usb::TransferType;
+use kernel::ReturnCode;
+
+/// The spec defines 1 Interrupt transfer in endpoint
+const ENDPOINT_IN_NUM: usize = 2;
+/// The spec defines 1 Interrupt transfer out endpoint
+const ENDPOINT_OUT_NUM: usize = 1;
+
+static LANGUAGES: &'static [u16; 1] = &[
+    0x0409, // English (United States)
+];
+/// Max packet size specified by spec
+pub const MAX_CTRL_PACKET_SIZE: u8 = 64;
+
+const N_ENDPOINTS: usize = 2;
+
+/// The HID report descriptor for CTAP
+/// This is a combinfrom of:
+///     - the CTAP spec, example 8
+///     - USB HID spec examples
+/// Plus it matches: https://chromium.googlesource.com/chromiumos/platform2/+/master/u2fd/u2fhid.cc
+static REPORT_DESCRIPTOR: &'static [u8] = &[
+    0x06, 0xD0, 0xF1, // HID_UsagePage ( FIDO_USAGE_PAGE ),
+    0x09, 0x01, // HID_Usage ( FIDO_USAGE_CTAPHID ),
+    0xA1, 0x01, // HID_Collection ( HID_Application ),
+    0x09, 0x20, // HID_Usage ( FIDO_USAGE_DATA_IN ),
+    0x15, 0x00, // HID_LogicalMin ( 0 ),
+    0x26, 0xFF, 0x00, // HID_LogicalMaxS ( 0xff ),
+    0x75, 0x08, // HID_ReportSize ( 8 ),
+    0x95, 0x40, // HID_ReportCount ( HID_INPUT_REPORT_BYTES ),
+    0x81, 0x02, // HID_Input ( HID_Data | HID_Absolute | HID_Variable ),
+    0x09, 0x21, // HID_Usage ( FIDO_USAGE_DATA_OUT ),
+    0x15, 0x00, // HID_LogicalMin ( 0 ),
+    0x26, 0xFF, 0x00, // HID_LogicalMaxS ( 0xff ),
+    0x75, 0x08, // HID_ReportSize ( 8 ),
+    0x95, 0x40, // HID_ReportCount ( HID_OUTPUT_REPORT_BYTES ),
+    0x91, 0x02, // HID_Output ( HID_Data | HID_Absolute | HID_Variable ),
+    0xC0, // HID_EndCollection
+];
+
+static REPORT: ReportDescriptor<'static> = ReportDescriptor {
+    desc: REPORT_DESCRIPTOR,
+};
+
+static SUB_HID_DESCRIPTOR: &'static [HIDSubordinateDescriptor] = &[HIDSubordinateDescriptor {
+    typ: DescriptorType::Report,
+    len: REPORT_DESCRIPTOR.len() as u16,
+}];
+
+static HID_DESCRIPTOR: HIDDescriptor<'static> = HIDDescriptor {
+    hid_class: 0x0110,
+    country_code: HIDCountryCode::NotSupported,
+    sub_descriptors: SUB_HID_DESCRIPTOR,
+};
+
+/// Implementation of the CTAP HID (Human Interface Device)
+pub struct CtapHid<'a, U: 'a> {
+    /// Helper USB client library for handling many USB operations.
+    client_ctrl: ClientCtrl<'a, 'static, U>,
+
+    /// 64 byte buffers for each endpoint.
+    buffers: [Buffer64; N_ENDPOINTS],
+
+    client: OptionalCell<&'a dyn hil::usb_hid::Client<'a>>,
+
+    /// A buffer to hold the data we want to send
+    send_buffer: TakeCell<'static, [u8; 64]>,
+
+    /// A holder for the buffer to receive bytes into. We use this as a flag as
+    /// well, if we have a buffer then we are actively doing a receive.
+    recv_buffer: TakeCell<'static, [u8; 64]>,
+    /// How many bytes the client wants us to receive.
+    recv_len: Cell<usize>,
+    /// How many bytes we have received so far.
+    recv_offset: Cell<usize>,
+
+    saved_endpoint: OptionalCell<usize>,
+}
+
+impl<'a, U: hil::usb::UsbController<'a>> CtapHid<'a, U> {
+    pub fn new(
+        controller: &'a U,
+        vendor_id: u16,
+        product_id: u16,
+        strings: &'static [&'static str; 3],
+    ) -> Self {
+        let interfaces: &mut [InterfaceDescriptor] = &mut [InterfaceDescriptor {
+            interface_number: 0,
+            interface_class: 0x03,    // HID
+            interface_subclass: 0x00, // No subcall
+            interface_protocol: 0x00, // No protocol
+            ..InterfaceDescriptor::default()
+        }];
+
+        let endpoints: &[&[EndpointDescriptor]] = &[&[
+            EndpointDescriptor {
+                endpoint_address: EndpointAddress::new_const(0x02, TransferDirection::DeviceToHost),
+                transfer_type: TransferType::Interrupt,
+                max_packet_size: 64,
+                interval: 5,
+            },
+            EndpointDescriptor {
+                endpoint_address: EndpointAddress::new_const(0x01, TransferDirection::HostToDevice),
+                transfer_type: TransferType::Interrupt,
+                max_packet_size: 64,
+                interval: 5,
+            },
+        ]];
+
+        let (device_descriptor_buffer, other_descriptor_buffer) =
+            descriptors::create_descriptor_buffers(
+                descriptors::DeviceDescriptor {
+                    vendor_id: vendor_id,
+                    product_id: product_id,
+                    manufacturer_string: 1,
+                    product_string: 2,
+                    serial_number_string: 3,
+                    class: 0x03, // Class: HID
+                    max_packet_size_ep0: MAX_CTRL_PACKET_SIZE,
+                    ..descriptors::DeviceDescriptor::default()
+                },
+                descriptors::ConfigurationDescriptor {
+                    ..descriptors::ConfigurationDescriptor::default()
+                },
+                interfaces,
+                endpoints,
+                Some(&HID_DESCRIPTOR),
+                None,
+            );
+
+        CtapHid {
+            client_ctrl: ClientCtrl::new(
+                controller,
+                device_descriptor_buffer,
+                other_descriptor_buffer,
+                Some(&HID_DESCRIPTOR),
+                Some(&REPORT),
+                LANGUAGES,
+                strings,
+            ),
+            buffers: [Buffer64::default(), Buffer64::default()],
+            client: OptionalCell::empty(),
+            send_buffer: TakeCell::empty(),
+            recv_buffer: TakeCell::empty(),
+            recv_len: Cell::new(0),
+            recv_offset: Cell::new(0),
+            saved_endpoint: OptionalCell::empty(),
+        }
+    }
+
+    #[inline]
+    fn controller(&self) -> &'a U {
+        self.client_ctrl.controller()
+    }
+
+    #[inline]
+    fn buffer(&'a self, i: usize) -> &'a [VolatileCell<u8>; 64] {
+        &self.buffers[i - 1].buf
+    }
+
+    pub fn set_client(&'a self, client: &'a dyn hil::usb_hid::Client<'a>) {
+        self.client.set(client);
+    }
+
+    fn can_receive(&'a self) -> bool {
+        self.client
+            .map(move |client| client.can_receive())
+            .unwrap_or(false)
+    }
+}
+
+impl<'a, U: hil::usb::UsbController<'a>> hil::usb_hid::UsbHid<'a> for CtapHid<'a, U> {
+    fn set_recv_buffer(&'a self, recv: &'static mut [u8; 64]) {
+        self.recv_buffer.replace(recv);
+    }
+
+    fn send_buffer(
+        &'a self,
+        send: &'static mut [u8; 64],
+    ) -> Result<usize, (ReturnCode, &'static mut [u8; 64])> {
+        let len = send.len();
+
+        self.send_buffer.replace(send);
+        self.controller().endpoint_resume_in(ENDPOINT_IN_NUM);
+
+        Ok(len)
+    }
+
+    fn allow_receive(&'a self) {
+        if self.saved_endpoint.is_some() {
+            // We have saved data from before, let's send it.
+            if self.can_receive() {
+                self.recv_buffer.take().map(|buf| {
+                    self.client.map(move |client| {
+                        client.packet_received(
+                            buf,
+                            self.recv_offset.get(),
+                            self.saved_endpoint.take().unwrap(),
+                        );
+                    });
+                });
+                // Reset the offset
+                self.recv_offset.set(0);
+            }
+        } else {
+            // If we have nothing to process, accept more data
+            self.controller().endpoint_resume_out(ENDPOINT_OUT_NUM);
+        }
+    }
+}
+
+impl<'a, U: hil::usb::UsbController<'a>> hil::usb::Client<'a> for CtapHid<'a, U> {
+    fn enable(&'a self) {
+        // Set up the default control endpoint
+        self.client_ctrl.enable();
+
+        // Setup buffers for IN and OUT data transfer.
+        self.controller()
+            .endpoint_set_in_buffer(ENDPOINT_IN_NUM, self.buffer(ENDPOINT_IN_NUM));
+        self.controller()
+            .endpoint_in_enable(TransferType::Interrupt, ENDPOINT_IN_NUM);
+
+        self.controller()
+            .endpoint_set_out_buffer(ENDPOINT_OUT_NUM, self.buffer(ENDPOINT_OUT_NUM));
+        self.controller()
+            .endpoint_out_enable(TransferType::Interrupt, ENDPOINT_OUT_NUM);
+    }
+
+    fn attach(&'a self) {
+        self.client_ctrl.attach();
+    }
+
+    fn bus_reset(&'a self) {}
+
+    /// Handle a Control Setup transaction.
+    fn ctrl_setup(&'a self, endpoint: usize) -> hil::usb::CtrlSetupResult {
+        descriptors::SetupData::get(&self.client_ctrl.ctrl_buffer.buf).map(|setup_data| {
+            let _b_request = setup_data.request_code;
+            let _value = setup_data.value;
+        });
+
+        self.client_ctrl.ctrl_setup(endpoint)
+    }
+
+    /// Handle a Control In transaction
+    fn ctrl_in(&'a self, endpoint: usize) -> hil::usb::CtrlInResult {
+        self.client_ctrl.ctrl_in(endpoint)
+    }
+
+    /// Handle a Control Out transaction
+    fn ctrl_out(&'a self, endpoint: usize, packet_bytes: u32) -> hil::usb::CtrlOutResult {
+        self.client_ctrl.ctrl_out(endpoint, packet_bytes)
+    }
+
+    fn ctrl_status(&'a self, endpoint: usize) {
+        self.client_ctrl.ctrl_status(endpoint)
+    }
+
+    /// Handle the completion of a Control transfer
+    fn ctrl_status_complete(&'a self, endpoint: usize) {
+        if self.send_buffer.is_some() {
+            self.controller().endpoint_resume_in(ENDPOINT_IN_NUM);
+        }
+
+        self.client_ctrl.ctrl_status_complete(endpoint)
+    }
+
+    /// Handle a Bulk/Interrupt IN transaction.
+    ///
+    /// This is called when we can send data to the host. It should get called
+    /// when we tell the controller we want to resume the IN endpoint (meaning
+    /// we know we have data to send) and afterwards until we return
+    /// `hil::usb::InResult::Delay` from this function. That means we can use
+    /// this as a callback to mean that the transmission finished by waiting
+    /// until this function is called when we don't have anything left to send.
+    fn packet_in(&'a self, transfer_type: TransferType, endpoint: usize) -> hil::usb::InResult {
+        match transfer_type {
+            TransferType::Interrupt => {
+                self.send_buffer
+                    .take()
+                    .map_or(hil::usb::InResult::Delay, |buf| {
+                        // Get packet that we have shared with the underlying
+                        // USB stack to copy the tx into.
+                        let packet = self.buffer(endpoint);
+
+                        // Copy from the TX buffer to the outgoing USB packet.
+                        for i in 0..64 {
+                            packet[i].set(buf[i]);
+                        }
+
+                        // Put the TX buffer back so we can keep sending from it.
+                        self.send_buffer.replace(buf);
+
+                        // Return that we have data to send.
+                        hil::usb::InResult::Packet(64)
+                    })
+            }
+            TransferType::Bulk | TransferType::Control | TransferType::Isochronous => {
+                panic!("Transfer protocol not supported by CTAP v2");
+            }
+        }
+    }
+
+    /// Handle a Bulk/Interrupt OUT transaction
+    ///
+    /// This is data going from the host to the device (us)
+    fn packet_out(
+        &'a self,
+        transfer_type: TransferType,
+        endpoint: usize,
+        packet_bytes: u32,
+    ) -> hil::usb::OutResult {
+        match transfer_type {
+            TransferType::Interrupt => {
+                self.recv_buffer
+                    .take()
+                    .map_or(hil::usb::OutResult::Error, |buf| {
+                        let recv_offset = self.recv_offset.get();
+
+                        // How many more bytes can we store in our RX buffer?
+                        let available_bytes = buf.len() - recv_offset;
+                        let copy_length = cmp::min(packet_bytes as usize, available_bytes);
+
+                        // Do the copy into the RX buffer.
+                        let packet = self.buffer(endpoint);
+                        for i in 0..copy_length {
+                            buf[recv_offset + i] = packet[i].get();
+                        }
+
+                        // Keep track of how many bytes we have received so far.
+                        let total_received_bytes = recv_offset + copy_length;
+
+                        // Update how many bytes we have gotten.
+                        self.recv_offset.set(total_received_bytes);
+
+                        // Check if we have received at least as many bytes as the
+                        // client asked for.
+                        if total_received_bytes >= self.recv_len.get() {
+                            if self.can_receive() {
+                                self.client.map(move |client| {
+                                    client.packet_received(buf, total_received_bytes, endpoint);
+                                });
+                                // Reset the offset
+                                self.recv_offset.set(0);
+                                hil::usb::OutResult::Ok
+                            } else {
+                                // We can't receive data. Record that we have data to send later
+                                // and apply back pressure to USB
+                                self.saved_endpoint.set(endpoint);
+                                self.recv_buffer.replace(buf);
+                                hil::usb::OutResult::Delay
+                            }
+                        } else {
+                            // Make sure to put the RX buffer back.
+                            self.recv_buffer.replace(buf);
+                            hil::usb::OutResult::Ok
+                        }
+                    })
+            }
+            TransferType::Bulk | TransferType::Control | TransferType::Isochronous => {
+                panic!("Transfer protocol not supported by CTAP v2");
+            }
+        }
+    }
+
+    fn packet_transmitted(&'a self, endpoint: usize) {
+        self.send_buffer.take().map(|buf| {
+            self.client.map(move |client| {
+                client.packet_transmitted(Ok(()), buf, 64, endpoint);
+            });
+        });
+    }
+}

--- a/capsules/src/usb/mod.rs
+++ b/capsules/src/usb/mod.rs
@@ -1,4 +1,5 @@
 pub mod cdc;
+pub mod ctap;
 pub mod descriptors;
 pub mod usb_user;
 pub mod usbc_client;

--- a/kernel/src/hil/mod.rs
+++ b/kernel/src/hil/mod.rs
@@ -26,6 +26,7 @@ pub mod time;
 pub mod touch;
 pub mod uart;
 pub mod usb;
+pub mod usb_hid;
 
 /// Shared interface for configuring components.
 pub trait Controller {

--- a/kernel/src/hil/usb_hid.rs
+++ b/kernel/src/hil/usb_hid.rs
@@ -1,0 +1,39 @@
+//! Interface for USB HID (Human Interface Device) class
+
+use crate::returncode::ReturnCode;
+
+/// Implement this trait and use `set_client()` in order to receive callbacks.
+pub trait Client<'a> {
+    /// Called when a packet is received
+    fn packet_received(&'a self, buffer: &'static mut [u8; 64], len: usize, endpoint: usize);
+
+    /// Called when a packet has been finished transmitting.
+    fn packet_transmitted(
+        &'a self,
+        result: Result<(), ReturnCode>,
+        buffer: &'static mut [u8; 64],
+        len: usize,
+        endpoint: usize,
+    );
+
+    /// Called when checking if we can receive any more data.
+    /// Should return true if we are ready to receive.
+    fn can_receive(&'a self) -> bool;
+}
+
+pub trait UsbHid<'a> {
+    /// Sets the buffer where recevied data should be set.
+    fn set_recv_buffer(&'a self, recv: &'static mut [u8; 64]);
+
+    /// Sets the buffer to be sent and starts a send transaction.
+    /// On success returns the number of bytes sent.
+    /// On failure returns an error code and the buffer passed in.
+    fn send_buffer(
+        &'a self,
+        send: &'static mut [u8; 64],
+    ) -> Result<usize, (ReturnCode, &'static mut [u8; 64])>;
+
+    /// Indicate that we can now receive data. Nothing will be received until
+    /// this is called.
+    fn allow_receive(&'a self);
+}


### PR DESCRIPTION
### Pull Request Overview

Due to an OpenTitan hardware bug (see lowRISC/opentitan#2598)
USB doesn't work. Let's just disable USB by default to avoid confusing
people.

This applies on top of: https://github.com/tock/tock/pull/2094

### Testing Strategy

N/A

### TODO or Help Wanted

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
