### PR TITLE
chips: e310: improve interrupt handling

### DIFF
--- a/chips/e310x/src/chip.rs
+++ b/chips/e310x/src/chip.rs
@@ -2,7 +2,6 @@
 
 use core::fmt::Write;
 use kernel;
-use kernel::common::registers::FieldValue;
 use kernel::debug;
 use kernel::hil::time::Alarm;
 use rv32i;
@@ -76,8 +75,6 @@ impl<A: 'static + Alarm<'static>> kernel::Chip for E310x<A> {
     }
 
     fn service_pending_interrupts(&self) {
-        let mut reenable_intr = FieldValue::<u32, mie::Register>::new(0, 0, 0);
-
         loop {
             let mip = CSR.mip.extract();
 
@@ -85,13 +82,11 @@ impl<A: 'static + Alarm<'static>> kernel::Chip for E310x<A> {
                 unsafe {
                     timer::MACHINETIMER.handle_interrupt();
                 }
-                reenable_intr += mie::mtimer::SET;
             }
             if mip.is_set(mip::mext) {
                 unsafe {
                     Self::handle_plic_interrupts();
                 }
-                reenable_intr += mie::mext::SET;
             }
 
             if !mip.matches_any(mip::mext::SET + mip::mtimer::SET) {
@@ -99,12 +94,13 @@ impl<A: 'static + Alarm<'static>> kernel::Chip for E310x<A> {
             }
         }
 
-        // re-enable any interrupt classes which we handled
-        CSR.mie.modify(reenable_intr);
+        // Re-enable all MIE interrupts that we care about. Since we looped
+        // until we handled them all, we can re-enable all of them.
+        CSR.mie.modify(mie::mext::SET + mie::mtimer::SET);
     }
 
     fn has_pending_interrupts(&self) -> bool {
-        unsafe { plic::has_pending() }
+        CSR.mip.matches_any(mip::mext::SET + mip::mtimer::SET)
     }
 
     fn sleep(&self) {


### PR DESCRIPTION
### Pull Request Overview

This pull request changes the e310 chip to:

1. Not only look at the plic, but also the MIE register for if interrupts have occurred.
2. Not accidentally disable interrupts when servicing them.

This fixes timer issues on the hifive1b.


### Testing Strategy

Running the alarm multi test on hifive1b hardware.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
