### PR TITLE
stm32f3: Watchdog Timers

### DIFF
--- a/boards/stm32f3discovery/src/main.rs
+++ b/boards/stm32f3discovery/src/main.rs
@@ -713,7 +713,7 @@ pub unsafe fn reset_handler() {
         debug!("{:?}", err);
     });
 
-    chip.enable_iwdg();
+    chip.enable_watchdog();
     let scheduler = components::sched::round_robin::RoundRobinComponent::new(&PROCESSES)
         .finalize(components::rr_component_helper!(NUM_PROCS));
 

--- a/boards/stm32f3discovery/src/main.rs
+++ b/boards/stm32f3discovery/src/main.rs
@@ -713,6 +713,7 @@ pub unsafe fn reset_handler() {
         debug!("{:?}", err);
     });
 
+    chip.enable_iwdg();
     let scheduler = components::sched::round_robin::RoundRobinComponent::new(&PROCESSES)
         .finalize(components::rr_component_helper!(NUM_PROCS));
 

--- a/boards/stm32f3discovery/src/main.rs
+++ b/boards/stm32f3discovery/src/main.rs
@@ -713,7 +713,9 @@ pub unsafe fn reset_handler() {
         debug!("{:?}", err);
     });
 
-    chip.enable_watchdog();
+    // Uncomment this to enable the watchdog
+    // chip.enable_watchdog();
+
     let scheduler = components::sched::round_robin::RoundRobinComponent::new(&PROCESSES)
         .finalize(components::rr_component_helper!(NUM_PROCS));
 

--- a/chips/stm32f303xc/src/chip.rs
+++ b/chips/stm32f303xc/src/chip.rs
@@ -53,8 +53,6 @@ impl Chip for Stm32f3xx {
                     }
                 } else if let Some(interrupt) = cortexm4::nvic::next_pending() {
                     match interrupt {
-                        nvic::WWDG => wdt::WATCHDOG.handle_interrupt(),
-
                         nvic::USART1 => usart::USART1.handle_interrupt(),
 
                         nvic::TIM2 => tim2::TIM2.handle_interrupt(),

--- a/chips/stm32f303xc/src/chip.rs
+++ b/chips/stm32f303xc/src/chip.rs
@@ -20,7 +20,7 @@ pub struct Stm32f3xx {
     mpu: cortexm4::mpu::MPU,
     userspace_kernel_boundary: cortexm4::syscall::SysCall,
     scheduler_timer: cortexm4::systick::SysTick,
-    watchdog: wdt::Wdt,
+    watchdog: wdt::WindoWdg,
 }
 
 impl Stm32f3xx {
@@ -29,16 +29,12 @@ impl Stm32f3xx {
             mpu: cortexm4::mpu::MPU::new(),
             userspace_kernel_boundary: cortexm4::syscall::SysCall::new(),
             scheduler_timer: cortexm4::systick::SysTick::new(),
-            watchdog: wdt::Wdt::new(),
+            watchdog: wdt::WindoWdg::new(),
         }
     }
 
-    pub fn enable_wwdg(&self) {
-        self.watchdog.enable_windo();
-    }
-
-    pub fn enable_iwdg(&self) {
-        self.watchdog.enable_indep();
+    pub fn enable_watchdog(&self) {
+        self.watchdog.enable();
     }
 }
 
@@ -46,7 +42,7 @@ impl Chip for Stm32f3xx {
     type MPU = cortexm4::mpu::MPU;
     type UserspaceKernelBoundary = cortexm4::syscall::SysCall;
     type SchedulerTimer = cortexm4::systick::SysTick;
-    type WatchDog = wdt::Wdt;
+    type WatchDog = wdt::WindoWdg;
 
     fn service_pending_interrupts(&self) {
         unsafe {
@@ -57,7 +53,8 @@ impl Chip for Stm32f3xx {
                     }
                 } else if let Some(interrupt) = cortexm4::nvic::next_pending() {
                     match interrupt {
-                        nvic::WWDG => wdt::WATCHDOG.windo_wdg.handle_interrupt(),
+                        nvic::WWDG => wdt::WATCHDOG.handle_interrupt(),
+
                         nvic::USART1 => usart::USART1.handle_interrupt(),
 
                         nvic::TIM2 => tim2::TIM2.handle_interrupt(),

--- a/chips/stm32f303xc/src/lib.rs
+++ b/chips/stm32f303xc/src/lib.rs
@@ -22,6 +22,8 @@ pub mod spi;
 pub mod syscfg;
 pub mod tim2;
 pub mod usart;
+pub mod wdt;
+
 use cortexm4::{
     generic_isr, hard_fault_handler, svc_handler, systick_handler, unhandled_interrupt,
 };

--- a/chips/stm32f303xc/src/rcc.rs
+++ b/chips/stm32f303xc/src/rcc.rs
@@ -623,6 +623,20 @@ impl Rcc {
     fn disable_adc34_clock(&self) {
         self.registers.ahbenr.modify(AHBENR::ADC34EN::CLEAR);
     }
+
+    // WWDG clock
+
+    fn is_enabled_wwdg_clock(&self) -> bool {
+        self.registers.apb1enr.is_set(APB1ENR::WWDGEN)
+    }
+
+    fn enable_wwdg_clock(&self) {
+        self.registers.apb1enr.modify(APB1ENR::WWDGEN::SET);
+    }
+
+    fn disable_wwdg_clock(&self) {
+        self.registers.apb1enr.modify(APB1ENR::WWDGEN::CLEAR);
+    }
 }
 
 /// Clock sources for CPU
@@ -667,6 +681,7 @@ pub enum PCLK1 {
     USART2,
     USART3,
     I2C1,
+    WWDG,
     // I2C2,
     // SPI3,
 }
@@ -697,6 +712,7 @@ impl ClockInterface for PeripheralClock {
                 PCLK1::USART2 => unsafe { RCC.is_enabled_usart2_clock() },
                 PCLK1::USART3 => unsafe { RCC.is_enabled_usart3_clock() },
                 PCLK1::I2C1 => unsafe { RCC.is_enabled_i2c1_clock() },
+                PCLK1::WWDG => unsafe { RCC.is_enabled_wwdg_clock() },
             },
             &PeripheralClock::APB2(ref v) => match v {
                 PCLK2::SPI1 => unsafe { RCC.is_enabled_spi1_clock() },
@@ -750,6 +766,9 @@ impl ClockInterface for PeripheralClock {
                 PCLK1::I2C1 => unsafe {
                     RCC.enable_i2c1_clock();
                     RCC.reset_i2c1();
+                },
+                PCLK1::WWDG => unsafe {
+                    RCC.enable_wwdg_clock();
                 },
             },
             &PeripheralClock::APB2(ref v) => match v {
@@ -809,6 +828,9 @@ impl ClockInterface for PeripheralClock {
                 },
                 PCLK1::I2C1 => unsafe {
                     RCC.disable_i2c1_clock();
+                },
+                PCLK1::WWDG => unsafe {
+                    RCC.disable_wwdg_clock();
                 },
             },
             &PeripheralClock::APB2(ref v) => match v {

--- a/chips/stm32f303xc/src/wdt.rs
+++ b/chips/stm32f303xc/src/wdt.rs
@@ -59,8 +59,6 @@ register_bitfields![u32,
     ]
 ];
 
-pub static mut WATCHDOG: WindoWdg = WindoWdg::new();
-
 pub struct WindoWdg {
     registers: StaticRef<WwdgRegisters>,
     clock: WdgClock,
@@ -104,19 +102,21 @@ impl WindoWdg {
         // Enable the APB1 clock for the watchdog.
         self.clock.enable();
 
-        // This disables the window feature.
+        // This disables the window feature. Set this to a value smaller than
+        // 0x7F if you want to enable it.
         self.set_window(0x7F);
         self.set_prescaler(3);
 
-        // Set T[6] bit to avoid a reset just when the watchdog is activated.
+        // Set the T[6] bit to avoid a reset when the watchdog is activated.
         self.tickle();
 
-        // With the APB1 clock running at 36Mhz we are getting timeout value
+        // With the APB1 clock running at 36Mhz we are getting timeout value of
         // t_WWDG = (1 / 36000) * 4096 * 2^3 * (63 + 1) = 58ms
         self.registers.cr.modify(Control::WDGA::SET);
     }
 
     pub fn tickle(&self) {
+        // Uses 63 as the value the watchdog starts counting from.
         self.registers.cr.modify(Control::T.val(0x7F));
     }
 }

--- a/chips/stm32f303xc/src/wdt.rs
+++ b/chips/stm32f303xc/src/wdt.rs
@@ -2,29 +2,17 @@
 
 use core::cell::Cell;
 use kernel::common::cells::OptionalCell;
-use kernel::common::registers::{register_bitfields, ReadOnly, ReadWrite, WriteOnly};
+use kernel::common::registers::{register_bitfields, ReadWrite};
 use kernel::common::StaticRef;
 
 const WINDOW_WATCHDOG_BASE: StaticRef<WwdgRegisters> =
     unsafe { StaticRef::new(0x4000_2C00 as *const WwdgRegisters) };
-
-const INDEPENDENT_WATCHDOG_BASE: StaticRef<IwdgRegisters> =
-    unsafe { StaticRef::new(0x4000_3000 as *const IwdgRegisters) };
 
 #[repr(C)]
 pub struct WwdgRegisters {
     cr: ReadWrite<u32, Control::Register>,
     cfr: ReadWrite<u32, Config::Register>,
     sr: ReadWrite<u32, Status::Register>,
-}
-
-#[repr(C)]
-pub struct IwdgRegisters {
-    kr: WriteOnly<u32, Key::Register>,
-    pr: ReadWrite<u32, Prescaler::Register>,
-    rlr: ReadWrite<u32, Reload::Register>,
-    sr: ReadOnly<u32, IStatus::Register>,
-    winr: ReadWrite<u32, Window::Register>,
 }
 
 register_bitfields![u32,
@@ -70,74 +58,14 @@ register_bitfields![u32,
     ]
 ];
 
-register_bitfields![u32,
-    Key [
-        /// Key value
-        /// These bits must be written by software at regular intervals with
-        /// the value 0xAAAA, otherwise the watchdog generates a reset when the
-        /// counter reaches 0.
-        /// Writing the value 0x5555 to enable access to the Prescaler, Reload
-        /// and Window registers.
-        /// Writing the value 0xCCCC starts the watchdog (except if the
-        /// hardware watchdog option is selected).
-        KEY OFFSET(0) NUMBITS(16) []
-    ],
-    Prescaler [
-        /// Prescaler divider
-        /// These bits are written by software to select the prescaler divider
-        /// feeding the counter clock. PVU bit of the Status register must be
-        /// reset in order to be able to change the prescaler divider.
-        PR OFFSET(0) NUMBITS(3) [
-            /// Divider /4
-            DIVIDER4 = 0,
-            /// Divider /8
-            DIVIDER8 = 1,
-            /// Divider /16
-            DIVIDER16 = 2,
-            /// Divider /32
-            DIVIDER32 = 3,
-            /// Divider /64
-            DIVIDER64 = 4,
-            /// Divider /128
-            DIVIDER128 = 5,
-            /// Divider /256
-            DIVIDERA256 = 6,
-            /// Divider /256
-            DIVIDERB256 = 7
-        ]
-    ],
-    Reload [
-        /// Watchdog counter reload value
-        /// These bits are written by software to define the value to be loaded
-        /// in the watchdog counter each time the value 0xAAAA is written in
-        /// Key register. The watchdog counter counts down from this value.
-        RL OFFSET(0) NUMBITS(12) []
-    ],
-    IStatus [
-        /// Watchdog counter window value update
-        /// This bit is set by hardware to indicate that an update of the
-        /// window value is ongoing.
-        WVU OFFSET(2) NUMBITS(1) [],
-        /// Watchdog counter reload value update
-        /// This bit is set by hardware to indicate that an update of the
-        /// reload value is ongoing.
-        RVU OFFSET(1) NUMBITS(1) [],
-        /// Watchdog prescaler value update
-        /// This bit is set by hardware to indicate that an update of the
-        /// prescaler value is ongoing.
-        PVU OFFSET(0) NUMBITS(1) []
-    ],
-    Window [
-        /// Watchdog counter window value
-        /// These bits contain the high limit of the window value to be
-        /// compared to the downcounter.
-        WIN OFFSET(0) NUMBITS(12) []
-    ]
-];
+pub static mut WATCHDOG: WindoWdg = WindoWdg::new();
+
+static mut WATCHDOG_SLEEP_FLAG: bool = false;
 
 pub struct WindoWdg {
     registers: StaticRef<WwdgRegisters>,
     client: OptionalCell<&'static dyn kernel::watchdog::WatchdogClient>,
+    enabled: Cell<bool>,
 }
 
 impl WindoWdg {
@@ -145,7 +73,12 @@ impl WindoWdg {
         WindoWdg {
             registers: WINDOW_WATCHDOG_BASE,
             client: OptionalCell::empty(),
+            enabled: Cell::new(false),
         }
+    }
+
+    pub fn enable(&self) {
+        self.enabled.set(true);
     }
 
     pub fn set_client(&self, client: &'static dyn kernel::watchdog::WatchdogClient) {
@@ -153,8 +86,14 @@ impl WindoWdg {
     }
 
     pub fn handle_interrupt(&self) {
-        self.tickle();
-        self.client.map(|client| client.reset_happened());
+        if unsafe { WATCHDOG_SLEEP_FLAG } {
+            self.tickle();
+            unsafe {
+                WATCHDOG_SLEEP_FLAG = false;
+            }
+        } else {
+            self.client.map(|client| client.reset_happened());
+        }
     }
 
     /// This interrupt is only cleared by hardware after a reset.
@@ -194,124 +133,28 @@ impl WindoWdg {
 
 impl kernel::watchdog::WatchDog for WindoWdg {
     fn setup(&self) {
-        self.start();
-    }
-
-    fn tickle(&self) {
-        self.tickle();
-    }
-
-    fn suspend(&self) {}
-    fn resume(&self) {}
-}
-
-pub struct IndepWdg {
-    registers: StaticRef<IwdgRegisters>,
-}
-
-impl IndepWdg {
-    pub const fn new() -> IndepWdg {
-        IndepWdg {
-            registers: INDEPENDENT_WATCHDOG_BASE,
-        }
-    }
-
-    pub fn set_prescaler(&self, value: u8) {
-        // Enable register access
-        self.registers.kr.set(0x5555);
-
-        match value {
-            0 => self.registers.pr.write(Prescaler::PR::DIVIDER4),
-            1 => self.registers.pr.write(Prescaler::PR::DIVIDER8),
-            2 => self.registers.pr.write(Prescaler::PR::DIVIDER16),
-            3 => self.registers.pr.write(Prescaler::PR::DIVIDER32),
-            4 => self.registers.pr.write(Prescaler::PR::DIVIDER64),
-            5 => self.registers.pr.write(Prescaler::PR::DIVIDER128),
-            6 => self.registers.pr.write(Prescaler::PR::DIVIDERA256),
-            7 => self.registers.pr.write(Prescaler::PR::DIVIDERB256),
-            _ => {}
-        }
-    }
-
-    pub fn start(&self) {
-        // Activate the Independent watchdog
-        self.registers.kr.set(0xCCCC);
-
-        // Enable register access
-        self.registers.kr.set(0x5555);
-
-        // Set the value to be loaded in the counter after each tickle
-        self.registers.rlr.modify(Reload::RL.val(0xFFF));
-        self.tickle();
-    }
-
-    pub fn tickle(&self) {
-        self.registers.kr.set(0xAAAA);
-    }
-}
-
-impl kernel::watchdog::WatchDog for IndepWdg {
-    fn setup(&self) {
-        self.start();
-    }
-
-    fn tickle(&self) {
-        self.tickle();
-    }
-
-    fn suspend(&self) {}
-    fn resume(&self) {}
-}
-
-pub static mut WATCHDOG: Wdt = Wdt::new();
-
-pub struct Wdt {
-    pub windo_wdg: WindoWdg,
-    pub indep_wdg: IndepWdg,
-    windo_enabled: Cell<bool>,
-    indep_enabled: Cell<bool>,
-}
-
-impl Wdt {
-    pub const fn new() -> Wdt {
-        Wdt {
-            windo_wdg: WindoWdg::new(),
-            indep_wdg: IndepWdg::new(),
-            windo_enabled: Cell::new(false),
-            indep_enabled: Cell::new(false),
-        }
-    }
-
-    pub fn enable_windo(&self) {
-        self.windo_enabled.set(true);
-    }
-
-    pub fn enable_indep(&self) {
-        self.indep_enabled.set(true);
-    }
-}
-
-impl kernel::watchdog::WatchDog for Wdt {
-    fn setup(&self) {
-        if self.windo_enabled.get() {
-            self.windo_wdg.setup();
-        }
-
-        if self.indep_enabled.get() {
-            self.indep_wdg.setup();
+        if self.enabled.get() {
+            self.start();
         }
     }
 
     fn tickle(&self) {
-        if self.windo_enabled.get() {
-            self.windo_wdg.tickle();
-        }
-
-        if self.indep_enabled.get() {
-            self.indep_wdg.tickle();
+        if self.enabled.get() {
+            self.tickle();
         }
     }
 
-    fn suspend(&self) {}
-    fn resume(&self) {}
+    fn suspend(&self) {
+        if self.enabled.get() {
+            unsafe {
+                WATCHDOG_SLEEP_FLAG = true;
+            }
+        }
+    }
+
+    fn resume(&self) {
+        if self.enabled.get() {
+            self.tickle();
+        }
+    }
 }

--- a/chips/stm32f303xc/src/wdt.rs
+++ b/chips/stm32f303xc/src/wdt.rs
@@ -1,0 +1,317 @@
+//! Implementation of the stm32f3 watchdog timers.
+
+use core::cell::Cell;
+use kernel::common::cells::OptionalCell;
+use kernel::common::registers::{register_bitfields, ReadOnly, ReadWrite, WriteOnly};
+use kernel::common::StaticRef;
+
+const WINDOW_WATCHDOG_BASE: StaticRef<WwdgRegisters> =
+    unsafe { StaticRef::new(0x4000_2C00 as *const WwdgRegisters) };
+
+const INDEPENDENT_WATCHDOG_BASE: StaticRef<IwdgRegisters> =
+    unsafe { StaticRef::new(0x4000_3000 as *const IwdgRegisters) };
+
+#[repr(C)]
+pub struct WwdgRegisters {
+    cr: ReadWrite<u32, Control::Register>,
+    cfr: ReadWrite<u32, Config::Register>,
+    sr: ReadWrite<u32, Status::Register>,
+}
+
+#[repr(C)]
+pub struct IwdgRegisters {
+    kr: WriteOnly<u32, Key::Register>,
+    pr: ReadWrite<u32, Prescaler::Register>,
+    rlr: ReadWrite<u32, Reload::Register>,
+    sr: ReadOnly<u32, IStatus::Register>,
+    winr: ReadWrite<u32, Window::Register>,
+}
+
+register_bitfields![u32,
+    Control [
+        /// Watch dog activation
+        /// Set by software and only cleared by hardware after a reset.
+        /// When set, the watchdog can generate a reset.
+        WDGA OFFSET(7) NUMBITS(1) [],
+        /// 7 bit counter
+        /// These bits contain the value of the watchdog counter. It is
+        /// decremented every 4096 * 2^WDGTB PCLK cycles. A reset is produced
+        /// when it is decremented from 0x40 to 0x3F (T[6] becomes cleared).
+        T OFFSET(0) NUMBITS(7) []
+    ],
+    Config [
+        /// Early wakeup interrupt
+        /// When set, interrupt occurs whenever the counter reaches the value
+        /// of 0x40. This interrupt is only cleared by hardware after a reset.
+        EWI OFFSET(9) NUMBITS(1) [],
+        /// Timer base
+        /// This allows modifying the time base of the prescaler.
+        WDGTB OFFSET(7) NUMBITS(2) [
+            /// CK Counter Clock (PCLK div 4096) div 1
+            DIVONE = 0,
+            /// CK Counter Clock (PCLK div 4096) div 2
+            DIVTWO = 1,
+            /// CK Counter Clock (PCLK div 4096) div 4
+            DIVFOUR = 2,
+            /// CK Counter Clock (PCLK div 4096) div 8
+            DIVEIGHT = 3
+        ],
+        /// 7 bit window value
+        /// These bits contain the window value to be compared to the
+        /// downcounter.
+        W OFFSET(0) NUMBITS(7) []
+    ],
+    Status [
+        /// Early wakeup interrupt flag
+        /// This is set when the counter has reached the value 0x40. It must be
+        /// cleared by software by writing 0. This bit is also set when the
+        /// interrupt is not enabled.
+        EWIF OFFSET(0) NUMBITS(1) []
+    ]
+];
+
+register_bitfields![u32,
+    Key [
+        /// Key value
+        /// These bits must be written by software at regular intervals with
+        /// the value 0xAAAA, otherwise the watchdog generates a reset when the
+        /// counter reaches 0.
+        /// Writing the value 0x5555 to enable access to the Prescaler, Reload
+        /// and Window registers.
+        /// Writing the value 0xCCCC starts the watchdog (except if the
+        /// hardware watchdog option is selected).
+        KEY OFFSET(0) NUMBITS(16) []
+    ],
+    Prescaler [
+        /// Prescaler divider
+        /// These bits are written by software to select the prescaler divider
+        /// feeding the counter clock. PVU bit of the Status register must be
+        /// reset in order to be able to change the prescaler divider.
+        PR OFFSET(0) NUMBITS(3) [
+            /// Divider /4
+            DIVIDER4 = 0,
+            /// Divider /8
+            DIVIDER8 = 1,
+            /// Divider /16
+            DIVIDER16 = 2,
+            /// Divider /32
+            DIVIDER32 = 3,
+            /// Divider /64
+            DIVIDER64 = 4,
+            /// Divider /128
+            DIVIDER128 = 5,
+            /// Divider /256
+            DIVIDERA256 = 6,
+            /// Divider /256
+            DIVIDERB256 = 7
+        ]
+    ],
+    Reload [
+        /// Watchdog counter reload value
+        /// These bits are written by software to define the value to be loaded
+        /// in the watchdog counter each time the value 0xAAAA is written in
+        /// Key register. The watchdog counter counts down from this value.
+        RL OFFSET(0) NUMBITS(12) []
+    ],
+    IStatus [
+        /// Watchdog counter window value update
+        /// This bit is set by hardware to indicate that an update of the
+        /// window value is ongoing.
+        WVU OFFSET(2) NUMBITS(1) [],
+        /// Watchdog counter reload value update
+        /// This bit is set by hardware to indicate that an update of the
+        /// reload value is ongoing.
+        RVU OFFSET(1) NUMBITS(1) [],
+        /// Watchdog prescaler value update
+        /// This bit is set by hardware to indicate that an update of the
+        /// prescaler value is ongoing.
+        PVU OFFSET(0) NUMBITS(1) []
+    ],
+    Window [
+        /// Watchdog counter window value
+        /// These bits contain the high limit of the window value to be
+        /// compared to the downcounter.
+        WIN OFFSET(0) NUMBITS(12) []
+    ]
+];
+
+pub struct WindoWdg {
+    registers: StaticRef<WwdgRegisters>,
+    client: OptionalCell<&'static dyn kernel::watchdog::WatchdogClient>,
+}
+
+impl WindoWdg {
+    pub const fn new() -> WindoWdg {
+        WindoWdg {
+            registers: WINDOW_WATCHDOG_BASE,
+            client: OptionalCell::empty(),
+        }
+    }
+
+    pub fn set_client(&self, client: &'static dyn kernel::watchdog::WatchdogClient) {
+        self.client.set(client);
+    }
+
+    pub fn handle_interrupt(&self) {
+        self.tickle();
+        self.client.map(|client| client.reset_happened());
+    }
+
+    /// This interrupt is only cleared by hardware after a reset.
+    fn enable_interrupt(&self) {
+        self.registers.cfr.modify(Config::EWI::SET);
+    }
+
+    fn set_window(&self, value: u32) {
+        // Set the window value to the biggest possible one.
+        self.registers.cfr.modify(Config::W.val(value));
+    }
+
+    /// Modifies the time base of the prescaler.
+    pub fn set_prescaler(&self, time_base: u8) {
+        match time_base {
+            1 => self.registers.cfr.modify(Config::WDGTB::DIVONE),
+            2 => self.registers.cfr.modify(Config::WDGTB::DIVTWO),
+            4 => self.registers.cfr.modify(Config::WDGTB::DIVFOUR),
+            8 => self.registers.cfr.modify(Config::WDGTB::DIVEIGHT),
+            _ => {}
+        }
+    }
+
+    pub fn start(&self) {
+        self.enable_interrupt();
+        self.set_window(0x7F);
+
+        // Set T[6] bit to avoid a reset just when the watchdog is activated.
+        self.tickle();
+        self.registers.cr.modify(Control::WDGA::SET);
+    }
+
+    pub fn tickle(&self) {
+        self.registers.cr.modify(Control::T.val(0x7F));
+    }
+}
+
+impl kernel::watchdog::WatchDog for WindoWdg {
+    fn setup(&self) {
+        self.start();
+    }
+
+    fn tickle(&self) {
+        self.tickle();
+    }
+
+    fn suspend(&self) {}
+    fn resume(&self) {}
+}
+
+pub struct IndepWdg {
+    registers: StaticRef<IwdgRegisters>,
+}
+
+impl IndepWdg {
+    pub const fn new() -> IndepWdg {
+        IndepWdg {
+            registers: INDEPENDENT_WATCHDOG_BASE,
+        }
+    }
+
+    pub fn set_prescaler(&self, value: u8) {
+        // Enable register access
+        self.registers.kr.set(0x5555);
+
+        match value {
+            0 => self.registers.pr.write(Prescaler::PR::DIVIDER4),
+            1 => self.registers.pr.write(Prescaler::PR::DIVIDER8),
+            2 => self.registers.pr.write(Prescaler::PR::DIVIDER16),
+            3 => self.registers.pr.write(Prescaler::PR::DIVIDER32),
+            4 => self.registers.pr.write(Prescaler::PR::DIVIDER64),
+            5 => self.registers.pr.write(Prescaler::PR::DIVIDER128),
+            6 => self.registers.pr.write(Prescaler::PR::DIVIDERA256),
+            7 => self.registers.pr.write(Prescaler::PR::DIVIDERB256),
+            _ => {}
+        }
+    }
+
+    pub fn start(&self) {
+        // Activate the Independent watchdog
+        self.registers.kr.set(0xCCCC);
+
+        // Enable register access
+        self.registers.kr.set(0x5555);
+
+        // Set the value to be loaded in the counter after each tickle
+        self.registers.rlr.modify(Reload::RL.val(0xFFF));
+        self.tickle();
+    }
+
+    pub fn tickle(&self) {
+        self.registers.kr.set(0xAAAA);
+    }
+}
+
+impl kernel::watchdog::WatchDog for IndepWdg {
+    fn setup(&self) {
+        self.start();
+    }
+
+    fn tickle(&self) {
+        self.tickle();
+    }
+
+    fn suspend(&self) {}
+    fn resume(&self) {}
+}
+
+pub static mut WATCHDOG: Wdt = Wdt::new();
+
+pub struct Wdt {
+    pub windo_wdg: WindoWdg,
+    pub indep_wdg: IndepWdg,
+    windo_enabled: Cell<bool>,
+    indep_enabled: Cell<bool>,
+}
+
+impl Wdt {
+    pub const fn new() -> Wdt {
+        Wdt {
+            windo_wdg: WindoWdg::new(),
+            indep_wdg: IndepWdg::new(),
+            windo_enabled: Cell::new(false),
+            indep_enabled: Cell::new(false),
+        }
+    }
+
+    pub fn enable_windo(&self) {
+        self.windo_enabled.set(true);
+    }
+
+    pub fn enable_indep(&self) {
+        self.indep_enabled.set(true);
+    }
+}
+
+impl kernel::watchdog::WatchDog for Wdt {
+    fn setup(&self) {
+        if self.windo_enabled.get() {
+            self.windo_wdg.setup();
+        }
+
+        if self.indep_enabled.get() {
+            self.indep_wdg.setup();
+        }
+    }
+
+    fn tickle(&self) {
+        if self.windo_enabled.get() {
+            self.windo_wdg.tickle();
+        }
+
+        if self.indep_enabled.get() {
+            self.indep_wdg.tickle();
+        }
+    }
+
+    fn suspend(&self) {}
+    fn resume(&self) {}
+}

--- a/chips/stm32f303xc/src/wdt.rs
+++ b/chips/stm32f303xc/src/wdt.rs
@@ -80,11 +80,6 @@ impl WindoWdg {
         self.enabled.set(true);
     }
 
-    /// This interrupt is only cleared by hardware after a reset.
-    // fn enable_interrupt(&self) {
-    //     self.registers.cfr.modify(Config::EWI::SET);
-    // }
-
     fn set_window(&self, value: u32) {
         // Set the window value to the biggest possible one.
         self.registers.cfr.modify(Config::W.val(value));
@@ -108,9 +103,6 @@ impl WindoWdg {
     pub fn start(&self) {
         // Enable the APB1 clock for the watchdog.
         self.clock.enable();
-
-        // Activate interrupts.
-        // self.enable_interrupt();
 
         // This disables the window feature.
         self.set_window(0x7F);

--- a/kernel/src/platform/watchdog.rs
+++ b/kernel/src/platform/watchdog.rs
@@ -31,5 +31,9 @@ pub trait WatchDog {
     }
 }
 
+pub trait WatchdogClient {
+    fn reset_happened(&self) {}
+}
+
 /// Implement default WatchDog trait for unit.
 impl WatchDog for () {}

--- a/kernel/src/platform/watchdog.rs
+++ b/kernel/src/platform/watchdog.rs
@@ -31,9 +31,5 @@ pub trait WatchDog {
     }
 }
 
-pub trait WatchdogClient {
-    fn reset_happened(&self) {}
-}
-
 /// Implement default WatchDog trait for unit.
 impl WatchDog for () {}


### PR DESCRIPTION
### Pull Request Overview

This pull request adds both watchdogs supported by the stm32f3 boards. The difference between the two of them is thoroughly described [here](https://electronics.stackexchange.com/questions/123080/independent-watchdog-iwdg-or-window-watchdog-wwdg). TLDR: The independent watchdog  is clocked by its own dedicated low-speed clock, but is not as precise, while the window watchdog is more precise, has a configurable time window that can be used to detect early or late abnormalities and can also generate an interrupt just before resetting.

At this point, someone could configure the board to use one, both or neither of the two watchdogs. I don't know if there's need for both, but i wanted to consult with you first before deleting one or the other. I also tried to have this configuration done in the boards file, as it was discussed in a previous [pr](https://github.com/tock/tock/pull/1887#issuecomment-654236192), but I am not entirely satisfied with how i did it.

### Testing Strategy

This pull request was tested using the stm32f3discovery board.


### TODO or Help Wanted

The main problem with both of the watchdogs is that none of them provides a way to suspend them once they are started, except by a full system reset. Since suspend and resume functions are unimplemented, sleeping in the kernel_loop [function](https://github.com/tock/tock/blob/ad9387a577405675b044d5bde85badf0274995c8/kernel/src/sched.rs#L495-L514) will probably end up causing a watchdog reset.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
