### PR TITLE
arch/cortex-m3: Allow the kernel to access protected memory

### DIFF
--- a/arch/cortex-m3/src/mpu.rs
+++ b/arch/cortex-m3/src/mpu.rs
@@ -274,16 +274,18 @@ impl CortexMRegion {
                 RegionAttributes::AP::ReadWrite,
                 RegionAttributes::XN::Disable,
             ),
-            mpu::Permissions::ReadExecuteOnly => {
-                (RegionAttributes::AP::ReadOnly, RegionAttributes::XN::Enable)
-            }
+            mpu::Permissions::ReadExecuteOnly => (
+                RegionAttributes::AP::UnprivilegedReadOnly,
+                RegionAttributes::XN::Enable,
+            ),
             mpu::Permissions::ReadOnly => (
-                RegionAttributes::AP::ReadOnly,
+                RegionAttributes::AP::UnprivilegedReadOnly,
                 RegionAttributes::XN::Disable,
             ),
-            mpu::Permissions::ExecuteOnly => {
-                (RegionAttributes::AP::NoAccess, RegionAttributes::XN::Enable)
-            }
+            mpu::Permissions::ExecuteOnly => (
+                RegionAttributes::AP::PrivilegedOnly,
+                RegionAttributes::XN::Enable,
+            ),
         };
 
         // Base address register


### PR DESCRIPTION
### Pull Request Overview

Commit 128782dad5ad410d3 "mpu: Change the disable_mpu API" converted the
disable_app_mpu() function to not make any changes. This means when we
return from an app to the kernel we don't disable the MPU.

This resulted in some access failures when the kernel tried to access
direct write flash regions (https://github.com/tock/tock/pull/1873#issuecomment-696217269).

We can either disable the MPU when returning to the kernel or change the
app MPU configuration permissions to not impact the kernel.

This patch converts the Cortex-M3 MPU implementation to always allow the
kernel access when configuring the app. This way we can avoid the
overhead of disabling the MPU on context switches. There is no security
gap here as the kernel could just disable the MPU anyway if it was
malicious.

Signed-off-by: Alistair Francis <alistair.francis@wdc.com>

### Testing Strategy

None.

### TODO or Help Wanted

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
