### PR TITLE
capsules: hmac: Replace the digest buffer after completion

### DIFF
--- a/capsules/src/hmac.rs
+++ b/capsules/src/hmac.rs
@@ -246,7 +246,7 @@ impl<'a, H: digest::Digest<'a, T> + digest::HMACSha256, T: DigestType> digest::C
         });
     }
 
-    fn hash_done(&'a self, result: Result<(), ReturnCode>, digest: &mut T) {
+    fn hash_done(&'a self, result: Result<(), ReturnCode>, digest: &'static mut T) {
         self.appid.map(|id| {
             self.apps
                 .enter(*id, |app, _| {
@@ -279,6 +279,8 @@ impl<'a, H: digest::Digest<'a, T> + digest::HMACSha256, T: DigestType> digest::C
                     }
                 })
         });
+
+        self.dest_buffer.replace(digest);
     }
 }
 


### PR DESCRIPTION
### Pull Request Overview

Replace the digest buffer after completion.

### Testing Strategy

Running CTAP on OpenTitan.

### TODO or Help Wanted

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
