### PR TITLE
Board based instantiation of chip drivers and interrupt mappings: Earlgrey/Opentitan

### DIFF
--- a/boards/opentitan/src/aes_test.rs
+++ b/boards/opentitan/src/aes_test.rs
@@ -2,7 +2,7 @@
 //!
 //! To test ECB mode, add the following line to the opentitan boot sequence:
 //! ```
-//!     aes_test::run_aes128_ecb();
+//!     aes_test::run_aes128_ecb(&peripherals.aes);
 //! ```
 //! You should see the following output:
 //! ```
@@ -13,24 +13,24 @@
 //! ```
 
 use capsules::test::aes::TestAes128Ecb;
-use earlgrey::aes::{Aes, AES};
+use earlgrey::aes::Aes;
 use kernel::hil::symmetric_encryption::{AES128, AES128_BLOCK_SIZE, AES128_KEY_SIZE};
 use kernel::static_init;
 
-pub unsafe fn run_aes128_ecb() {
-    let t = static_init_test_ecb();
-    AES.set_client(t);
+pub unsafe fn run_aes128_ecb(aes: &'static Aes) {
+    let t = static_init_test_ecb(aes);
+    aes.set_client(t);
 
     t.run();
 }
 
-unsafe fn static_init_test_ecb() -> &'static mut TestAes128Ecb<'static, Aes<'static>> {
+unsafe fn static_init_test_ecb(aes: &'static Aes) -> &'static TestAes128Ecb<'static, Aes<'static>> {
     let source = static_init!([u8; 4 * AES128_BLOCK_SIZE], [0; 4 * AES128_BLOCK_SIZE]);
     let data = static_init!([u8; 6 * AES128_BLOCK_SIZE], [0; 6 * AES128_BLOCK_SIZE]);
     let key = static_init!([u8; AES128_KEY_SIZE], [0; AES128_KEY_SIZE]);
 
     static_init!(
         TestAes128Ecb<'static, Aes>,
-        TestAes128Ecb::new(&AES, key, source, data)
+        TestAes128Ecb::new(aes, key, source, data)
     )
 }

--- a/boards/opentitan/src/main.rs
+++ b/boards/opentitan/src/main.rs
@@ -10,6 +10,7 @@
 
 use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use capsules::virtual_hmac::VirtualMuxHmac;
+use earlgrey::chip::EarlGreyDefaultPeripherals;
 use kernel::capabilities;
 use kernel::common::dynamic_deferred_call::{DynamicDeferredCall, DynamicDeferredCallClientState};
 use kernel::component::Component;
@@ -37,7 +38,10 @@ static mut PROCESSES: [Option<&'static dyn kernel::procs::ProcessType>; 4] =
     [None, None, None, None];
 
 static mut CHIP: Option<
-    &'static earlgrey::chip::EarlGrey<VirtualMuxAlarm<'static, earlgrey::timer::RvTimer>>,
+    &'static earlgrey::chip::EarlGrey<
+        VirtualMuxAlarm<'static, earlgrey::timer::RvTimer>,
+        EarlGreyDefaultPeripherals,
+    >,
 > = None;
 
 // How should the kernel respond when a process faults.
@@ -102,6 +106,11 @@ pub unsafe fn reset_handler() {
     // Ibex-specific handler
     earlgrey::chip::configure_trap_handler();
 
+    let peripherals = static_init!(
+        EarlGreyDefaultPeripherals,
+        EarlGreyDefaultPeripherals::new()
+    );
+
     // initialize capabilities
     let process_mgmt_cap = create_capability!(capabilities::ProcessManagementCapability);
     let memory_allocation_cap = create_capability!(capabilities::MemoryAllocationCapability);
@@ -120,14 +129,14 @@ pub unsafe fn reset_handler() {
 
     // Configure kernel debug gpios as early as possible
     kernel::debug::assign_gpios(
-        Some(&earlgrey::gpio::PORT[7]), // First LED
+        Some(&peripherals.gpio_port[7]), // First LED
         None,
         None,
     );
 
     // Create a shared UART channel for the console and for kernel debug.
     let uart_mux = components::console::UartMuxComponent::new(
-        &earlgrey::uart::UART0,
+        &peripherals.uart0,
         earlgrey::uart::UART0_BAUDRATE,
         dynamic_deferred_caller,
     )
@@ -138,35 +147,35 @@ pub unsafe fn reset_handler() {
     let led = components::led::LedsComponent::new(components::led_component_helper!(
         earlgrey::gpio::GpioPin,
         (
-            &earlgrey::gpio::PORT[8],
+            &peripherals.gpio_port[8],
             kernel::hil::gpio::ActivationMode::ActiveHigh
         ),
         (
-            &earlgrey::gpio::PORT[9],
+            &peripherals.gpio_port[9],
             kernel::hil::gpio::ActivationMode::ActiveHigh
         ),
         (
-            &earlgrey::gpio::PORT[10],
+            &peripherals.gpio_port[10],
             kernel::hil::gpio::ActivationMode::ActiveHigh
         ),
         (
-            &earlgrey::gpio::PORT[11],
+            &peripherals.gpio_port[11],
             kernel::hil::gpio::ActivationMode::ActiveHigh
         ),
         (
-            &earlgrey::gpio::PORT[12],
+            &peripherals.gpio_port[12],
             kernel::hil::gpio::ActivationMode::ActiveHigh
         ),
         (
-            &earlgrey::gpio::PORT[13],
+            &peripherals.gpio_port[13],
             kernel::hil::gpio::ActivationMode::ActiveHigh
         ),
         (
-            &earlgrey::gpio::PORT[14],
+            &peripherals.gpio_port[14],
             kernel::hil::gpio::ActivationMode::ActiveHigh
         ),
         (
-            &earlgrey::gpio::PORT[15],
+            &peripherals.gpio_port[15],
             kernel::hil::gpio::ActivationMode::ActiveHigh
         )
     ))
@@ -176,28 +185,28 @@ pub unsafe fn reset_handler() {
         board_kernel,
         components::gpio_component_helper!(
             earlgrey::gpio::GpioPin,
-            0 => &earlgrey::gpio::PORT[0],
-            1 => &earlgrey::gpio::PORT[1],
-            2 => &earlgrey::gpio::PORT[2],
-            3 => &earlgrey::gpio::PORT[3],
-            4 => &earlgrey::gpio::PORT[4],
-            5 => &earlgrey::gpio::PORT[5],
-            6 => &earlgrey::gpio::PORT[6],
-            7 => &earlgrey::gpio::PORT[15]
+            0 => &peripherals.gpio_port[0],
+            1 => &peripherals.gpio_port[1],
+            2 => &peripherals.gpio_port[2],
+            3 => &peripherals.gpio_port[3],
+            4 => &peripherals.gpio_port[4],
+            5 => &peripherals.gpio_port[5],
+            6 => &peripherals.gpio_port[6],
+            7 => &peripherals.gpio_port[15]
         ),
     )
     .finalize(components::gpio_component_buf!(earlgrey::gpio::GpioPin));
 
-    let alarm = &earlgrey::timer::TIMER;
-    alarm.setup();
+    let hardware_alarm = static_init!(earlgrey::timer::RvTimer, earlgrey::timer::RvTimer::new());
+    hardware_alarm.setup();
 
     // Create a shared virtualization mux layer on top of a single hardware
     // alarm.
     let mux_alarm = static_init!(
         MuxAlarm<'static, earlgrey::timer::RvTimer>,
-        MuxAlarm::new(alarm)
+        MuxAlarm::new(hardware_alarm)
     );
-    hil::time::Alarm::set_alarm_client(&earlgrey::timer::TIMER, mux_alarm);
+    hil::time::Alarm::set_alarm_client(hardware_alarm, mux_alarm);
 
     // Alarm
     let virtual_alarm_user = static_init!(
@@ -218,8 +227,11 @@ pub unsafe fn reset_handler() {
     hil::time::Alarm::set_alarm_client(virtual_alarm_user, alarm);
 
     let chip = static_init!(
-        earlgrey::chip::EarlGrey<VirtualMuxAlarm<'static, earlgrey::timer::RvTimer>>,
-        earlgrey::chip::EarlGrey::new(scheduler_timer_virtual_alarm)
+        earlgrey::chip::EarlGrey<
+            VirtualMuxAlarm<'static, earlgrey::timer::RvTimer>,
+            EarlGreyDefaultPeripherals,
+        >,
+        earlgrey::chip::EarlGrey::new(scheduler_timer_virtual_alarm, peripherals, hardware_alarm)
     );
     scheduler_timer_virtual_alarm.set_alarm_client(chip.scheduler_timer());
     CHIP = Some(chip);
@@ -242,7 +254,7 @@ pub unsafe fn reset_handler() {
     let hmac_data_buffer = static_init!([u8; 64], [0; 64]);
     let hmac_dest_buffer = static_init!([u8; 32], [0; 32]);
 
-    let mux_hmac = components::hmac::HmacMuxComponent::new(&earlgrey::hmac::HMAC).finalize(
+    let mux_hmac = components::hmac::HmacMuxComponent::new(&peripherals.hmac).finalize(
         components::hmac_mux_component_helper!(lowrisc::hmac::Hmac, [u8; 32]),
     );
 
@@ -260,13 +272,13 @@ pub unsafe fn reset_handler() {
     let i2c_master = static_init!(
         capsules::i2c_master::I2CMasterDriver<lowrisc::i2c::I2c<'static>>,
         capsules::i2c_master::I2CMasterDriver::new(
-            &earlgrey::i2c::I2C,
+            &peripherals.i2c,
             &mut capsules::i2c_master::BUF,
             board_kernel.create_grant(&memory_allocation_cap)
         )
     );
 
-    earlgrey::i2c::I2C.set_master_client(i2c_master);
+    peripherals.i2c.set_master_client(i2c_master);
 
     // USB support is currently broken in the OpenTitan hardware
     // See https://github.com/lowRISC/opentitan/issues/2598 for more details
@@ -283,7 +295,7 @@ pub unsafe fn reset_handler() {
     // Flash
     let nonvolatile_storage = components::nonvolatile_storage::NonvolatileStorageComponent::new(
         board_kernel,
-        &earlgrey::flash_ctrl::FLASH_CTRL,
+        &peripherals.flash_ctrl,
         0x20000000,                       // Start address for userspace accessible region
         0x8000,                           // Length of userspace accessible region
         &_sstorage as *const u8 as usize, // Start address of kernel region

--- a/boards/opentitan/src/usb.rs
+++ b/boards/opentitan/src/usb.rs
@@ -11,6 +11,7 @@
 
 #![allow(dead_code)] // Components are intended to be conditionally included
 
+use earlgrey::usbdev::Usb;
 use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
@@ -18,11 +19,12 @@ use kernel::static_init;
 
 pub struct UsbComponent {
     board_kernel: &'static kernel::Kernel,
+    usb: &'static Usb<'static>,
 }
 
 impl UsbComponent {
-    pub fn new(board_kernel: &'static kernel::Kernel) -> UsbComponent {
-        UsbComponent { board_kernel }
+    pub fn new(usb: &'static Usb, board_kernel: &'static kernel::Kernel) -> Self {
+        Self { usb, board_kernel }
     }
 }
 
@@ -40,7 +42,7 @@ impl Component for UsbComponent {
         let usb_client = static_init!(
             capsules::usb::usbc_client::Client<'static, lowrisc::usbdev::Usb<'static>>,
             capsules::usb::usbc_client::Client::new(
-                &earlgrey::usbdev::USB,
+                self.usb,
                 capsules::usb::usbc_client::MAX_CTRL_PACKET_SIZE_EARLGREY
             )
         );

--- a/chips/earlgrey/src/aes.rs
+++ b/chips/earlgrey/src/aes.rs
@@ -80,7 +80,7 @@ pub struct Aes<'a> {
 }
 
 impl<'a> Aes<'a> {
-    const fn new() -> Aes<'a> {
+    pub const fn new() -> Aes<'a> {
         Aes {
             registers: AES_BASE,
             client: OptionalCell::empty(),
@@ -340,8 +340,6 @@ impl<'a> hil::symmetric_encryption::AES128<'a> for Aes<'a> {
         None
     }
 }
-
-pub static mut AES: Aes<'static> = Aes::new();
 
 impl kernel::hil::symmetric_encryption::AES128ECB for Aes<'_> {
     fn set_mode_aes128ecb(&self, encrypting: bool) {

--- a/chips/earlgrey/src/flash_ctrl.rs
+++ b/chips/earlgrey/src/flash_ctrl.rs
@@ -1,7 +1,5 @@
 use kernel::common::StaticRef;
-use lowrisc::flash_ctrl::{FlashCtrl, FlashCtrlRegisters, FlashRegion};
+use lowrisc::flash_ctrl::FlashCtrlRegisters;
 
-pub static mut FLASH_CTRL: FlashCtrl = FlashCtrl::new(FLASH_CTRL_BASE, FlashRegion::REGION0);
-
-const FLASH_CTRL_BASE: StaticRef<FlashCtrlRegisters> =
+pub const FLASH_CTRL_BASE: StaticRef<FlashCtrlRegisters> =
     unsafe { StaticRef::new(0x4003_0000 as *const FlashCtrlRegisters) };

--- a/chips/earlgrey/src/gpio.rs
+++ b/chips/earlgrey/src/gpio.rs
@@ -3,18 +3,59 @@
 use core::ops::{Index, IndexMut};
 
 use kernel::common::StaticRef;
-pub use lowrisc::gpio::GpioPin;
-use lowrisc::gpio::{pins, GpioRegisters};
+use lowrisc::gpio::GpioRegisters;
+pub use lowrisc::gpio::{pins, GpioPin};
 use lowrisc::padctrl::PadCtrlRegisters;
 
-const PADCTRL_BASE: StaticRef<PadCtrlRegisters> =
+pub const PADCTRL_BASE: StaticRef<PadCtrlRegisters> =
     unsafe { StaticRef::new(0x4016_0000 as *const PadCtrlRegisters) };
 
-const GPIO0_BASE: StaticRef<GpioRegisters> =
+pub const GPIO0_BASE: StaticRef<GpioRegisters> =
     unsafe { StaticRef::new(0x4001_0000 as *const GpioRegisters) };
 
 pub struct Port<'a> {
     pins: [GpioPin<'a>; 32],
+}
+
+impl<'a> Port<'a> {
+    pub const fn new() -> Self {
+        Self {
+            pins: [
+                GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin0),
+                GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin1),
+                GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin2),
+                GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin3),
+                GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin4),
+                GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin5),
+                GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin6),
+                GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin7),
+                GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin8),
+                GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin9),
+                GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin10),
+                GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin11),
+                GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin12),
+                GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin13),
+                GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin14),
+                GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin15),
+                GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin16),
+                GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin17),
+                GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin18),
+                GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin19),
+                GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin20),
+                GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin21),
+                GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin22),
+                GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin23),
+                GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin24),
+                GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin25),
+                GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin26),
+                GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin27),
+                GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin28),
+                GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin29),
+                GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin30),
+                GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin31),
+            ],
+        }
+    }
 }
 
 impl<'a> Index<usize> for Port<'a> {
@@ -30,40 +71,3 @@ impl<'a> IndexMut<usize> for Port<'a> {
         &mut self.pins[index]
     }
 }
-
-pub static mut PORT: Port = Port {
-    pins: [
-        GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin0),
-        GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin1),
-        GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin2),
-        GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin3),
-        GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin4),
-        GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin5),
-        GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin6),
-        GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin7),
-        GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin8),
-        GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin9),
-        GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin10),
-        GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin11),
-        GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin12),
-        GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin13),
-        GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin14),
-        GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin15),
-        GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin16),
-        GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin17),
-        GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin18),
-        GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin19),
-        GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin20),
-        GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin21),
-        GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin22),
-        GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin23),
-        GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin24),
-        GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin25),
-        GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin26),
-        GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin27),
-        GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin28),
-        GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin29),
-        GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin30),
-        GpioPin::new(GPIO0_BASE, PADCTRL_BASE, pins::pin31),
-    ],
-};

--- a/chips/earlgrey/src/hmac.rs
+++ b/chips/earlgrey/src/hmac.rs
@@ -1,7 +1,5 @@
 use kernel::common::StaticRef;
-use lowrisc::hmac::{Hmac, HmacRegisters};
+use lowrisc::hmac::HmacRegisters;
 
-pub static mut HMAC: Hmac = Hmac::new(HMAC0_BASE);
-
-const HMAC0_BASE: StaticRef<HmacRegisters> =
+pub const HMAC0_BASE: StaticRef<HmacRegisters> =
     unsafe { StaticRef::new(0x4012_0000 as *const HmacRegisters) };

--- a/chips/earlgrey/src/i2c.rs
+++ b/chips/earlgrey/src/i2c.rs
@@ -1,9 +1,6 @@
-use crate::chip_config::CONFIG;
 use kernel::common::StaticRef;
-use lowrisc::i2c::{I2c, I2cRegisters};
-
-pub static mut I2C: I2c = I2c::new(I2C_BASE, (1 / CONFIG.cpu_freq) * 1000 * 1000);
+use lowrisc::i2c::I2cRegisters;
 
 // This is a placeholder address as the I2C MMIO interface isn't avaliable yet
-const I2C_BASE: StaticRef<I2cRegisters> =
+pub const I2C_BASE: StaticRef<I2cRegisters> =
     unsafe { StaticRef::new(0x4005_0000 as *const I2cRegisters) };

--- a/chips/earlgrey/src/lib.rs
+++ b/chips/earlgrey/src/lib.rs
@@ -5,7 +5,7 @@
 #![crate_name = "earlgrey"]
 #![crate_type = "rlib"]
 
-mod chip_config;
+pub mod chip_config;
 mod interrupts;
 
 pub mod aes;

--- a/chips/earlgrey/src/pwrmgr.rs
+++ b/chips/earlgrey/src/pwrmgr.rs
@@ -1,7 +1,5 @@
 use kernel::common::StaticRef;
-use lowrisc::pwrmgr::{PwrMgr, PwrMgrRegisters};
+use lowrisc::pwrmgr::PwrMgrRegisters;
 
-pub static mut PWRMGR: PwrMgr = PwrMgr::new(PWRMGR_BASE);
-
-const PWRMGR_BASE: StaticRef<PwrMgrRegisters> =
+pub(crate) const PWRMGR_BASE: StaticRef<PwrMgrRegisters> =
     unsafe { StaticRef::new(0x400A_0000 as *const PwrMgrRegisters) };

--- a/chips/earlgrey/src/timer.rs
+++ b/chips/earlgrey/src/timer.rs
@@ -60,9 +60,9 @@ pub struct RvTimer<'a> {
 }
 
 impl<'a> RvTimer<'a> {
-    const fn new(base: StaticRef<TimerRegisters>) -> RvTimer<'a> {
+    pub const fn new() -> RvTimer<'a> {
         RvTimer {
-            registers: base,
+            registers: TIMER_BASE,
             alarm_client: OptionalCell::empty(),
             overflow_client: OptionalCell::empty(),
         }
@@ -194,5 +194,3 @@ impl<'a> time::Alarm<'a> for RvTimer<'a> {
 
 const TIMER_BASE: StaticRef<TimerRegisters> =
     unsafe { StaticRef::new(0x4008_0000 as *const TimerRegisters) };
-
-pub static mut TIMER: RvTimer = RvTimer::new(TIMER_BASE);

--- a/chips/earlgrey/src/uart.rs
+++ b/chips/earlgrey/src/uart.rs
@@ -1,10 +1,10 @@
-use crate::chip_config::CONFIG;
 use kernel::common::StaticRef;
-use lowrisc::uart::{Uart, UartRegisters};
+pub use lowrisc::uart::Uart;
+use lowrisc::uart::UartRegisters;
+
+use crate::chip_config::CONFIG;
 
 pub const UART0_BAUDRATE: u32 = CONFIG.uart_baudrate;
 
-pub static mut UART0: Uart = Uart::new(UART0_BASE, CONFIG.peripheral_freq);
-
-const UART0_BASE: StaticRef<UartRegisters> =
+pub const UART0_BASE: StaticRef<UartRegisters> =
     unsafe { StaticRef::new(0x4000_0000 as *const UartRegisters) };

--- a/chips/earlgrey/src/usbdev.rs
+++ b/chips/earlgrey/src/usbdev.rs
@@ -1,7 +1,6 @@
 use kernel::common::StaticRef;
-use lowrisc::usbdev::{Usb, UsbRegisters};
+pub use lowrisc::usbdev::Usb;
+use lowrisc::usbdev::UsbRegisters;
 
-pub static mut USB: Usb = Usb::new(USB0_BASE);
-
-const USB0_BASE: StaticRef<UsbRegisters> =
+pub const USB0_BASE: StaticRef<UsbRegisters> =
     unsafe { StaticRef::new(0x4015_0000 as *const UsbRegisters) };


### PR DESCRIPTION
### Pull Request Overview

This pull request applies the new, non-global based peripheral design to the earlgrey chip and OpenTitan board. Rather than apply this on top of #2069 / #2084 , the first commit just duplicates the kernel changes from the original PR, so that it is easy to review only the earlgrey/opentitan changes in this PR.


### Testing Strategy

This pull request was tested by compiling. Testing in verilator or on the FPGA board is needed before this is merged.


### TODO or Help Wanted

N/A


### Documentation Updated

- [ ] Docs updated in the other PRs associated with this change.

### Formatting

- [x] Ran `make prepush`.
