### PR TITLE
USB: CTAP: support for FIDO HID as tested with OpenSK.

### DIFF
--- a/boards/components/src/lib.rs
+++ b/boards/components/src/lib.rs
@@ -39,3 +39,4 @@ pub mod temperature;
 pub mod temperature_stm;
 pub mod test;
 pub mod touch;
+pub mod usb_ctap;

--- a/boards/components/src/usb_ctap.rs
+++ b/boards/components/src/usb_ctap.rs
@@ -1,0 +1,88 @@
+//! Component for CTAP over USB.
+
+use capsules::usb::usb_ctap::CtapUsbSyscallDriver;
+use capsules::usb::usbc_ctap_hid::ClientCtapHID;
+use core::mem::MaybeUninit;
+use kernel::capabilities;
+use kernel::component::Component;
+use kernel::create_capability;
+use kernel::hil;
+use kernel::static_init_half;
+
+// Setup static space for the objects.
+#[macro_export]
+macro_rules! usb_ctap_component_buf {
+    ($C:ty) => {{
+        use capsules::usb::usb_ctap::CtapUsbSyscallDriver;
+        use capsules::usb::usbc_ctap_hid::ClientCtapHID;
+        use core::mem::MaybeUninit;
+        static mut BUF1: MaybeUninit<ClientCtapHID<'static, 'static, $C>> = MaybeUninit::uninit();
+        static mut BUF2: MaybeUninit<CtapUsbSyscallDriver<'static, 'static, $C>> =
+            MaybeUninit::uninit();
+        (&mut BUF1, &mut BUF2)
+    };};
+}
+
+pub struct UsbCtapComponent<C: 'static + hil::usb::UsbController<'static>> {
+    board_kernel: &'static kernel::Kernel,
+    controller: &'static C,
+    max_ctrl_packet_size: u8,
+    vendor_id: u16,
+    product_id: u16,
+    strings: &'static [&'static str],
+}
+
+impl<C: 'static + hil::usb::UsbController<'static>> UsbCtapComponent<C> {
+    pub fn new(
+        board_kernel: &'static kernel::Kernel,
+        controller: &'static C,
+        max_ctrl_packet_size: u8,
+        vendor_id: u16,
+        product_id: u16,
+        strings: &'static [&'static str],
+    ) -> Self {
+        Self {
+            board_kernel,
+            controller,
+            max_ctrl_packet_size,
+            vendor_id,
+            product_id,
+            strings,
+        }
+    }
+}
+
+impl<C: 'static + hil::usb::UsbController<'static>> Component for UsbCtapComponent<C> {
+    type StaticInput = (
+        &'static mut MaybeUninit<ClientCtapHID<'static, 'static, C>>,
+        &'static mut MaybeUninit<CtapUsbSyscallDriver<'static, 'static, C>>,
+    );
+    type Output = &'static CtapUsbSyscallDriver<'static, 'static, C>;
+
+    unsafe fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
+        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
+
+        let usb_ctap = static_init_half!(
+            static_buffer.0,
+            ClientCtapHID<'static, 'static, C>,
+            ClientCtapHID::new(
+                self.controller,
+                self.max_ctrl_packet_size,
+                self.vendor_id,
+                self.product_id,
+                self.strings,
+            )
+        );
+        self.controller.set_client(usb_ctap);
+
+        // Configure the USB userspace driver
+        let usb_driver = static_init_half!(
+            static_buffer.1,
+            CtapUsbSyscallDriver<'static, 'static, C>,
+            CtapUsbSyscallDriver::new(usb_ctap, self.board_kernel.create_grant(&grant_cap))
+        );
+        usb_ctap.set_client(usb_driver);
+
+        usb_driver
+    }
+}

--- a/capsules/src/driver.rs
+++ b/capsules/src/driver.rs
@@ -26,6 +26,7 @@ pub enum NUM {
     I2cMaster             = 0x20003,
     UsbUser               = 0x20005,
     I2cMasterSlave        = 0x20006,
+    UsbCtap               = 0x20009,
 
     // Radio
     BleAdvertising        = 0x30000,

--- a/capsules/src/usb/mod.rs
+++ b/capsules/src/usb/mod.rs
@@ -1,5 +1,7 @@
 pub mod cdc;
 pub mod descriptors;
+pub mod usb_ctap;
 pub mod usb_user;
 pub mod usbc_client;
 pub mod usbc_client_ctrl;
+pub mod usbc_ctap_hid;

--- a/capsules/src/usb/usb_ctap.rs
+++ b/capsules/src/usb/usb_ctap.rs
@@ -1,0 +1,355 @@
+use super::usbc_ctap_hid::ClientCtapHID;
+use kernel::hil;
+use kernel::hil::usb::Client;
+use kernel::{AppId, AppSlice, Callback, Driver, Grant, ReturnCode, Shared};
+
+/// Syscall number
+use crate::driver;
+pub const DRIVER_NUM: usize = driver::NUM::UsbCtap as usize;
+
+pub const CTAP_CMD_CHECK: usize = 0;
+pub const CTAP_CMD_CONNECT: usize = 1;
+pub const CTAP_CMD_TRANSMIT: usize = 2;
+pub const CTAP_CMD_RECEIVE: usize = 3;
+pub const CTAP_CMD_TRANSMIT_OR_RECEIVE: usize = 4;
+pub const CTAP_CMD_CANCEL: usize = 5;
+
+pub const CTAP_ALLOW_TRANSMIT: usize = 1;
+pub const CTAP_ALLOW_RECEIVE: usize = 2;
+pub const CTAP_ALLOW_TRANSMIT_OR_RECEIVE: usize = 3;
+
+pub const CTAP_SUBSCRIBE_TRANSMIT: usize = 1;
+pub const CTAP_SUBSCRIBE_RECEIVE: usize = 2;
+pub const CTAP_SUBSCRIBE_TRANSMIT_OR_RECEIVE: usize = 3;
+
+pub const CTAP_CALLBACK_TRANSMITED: usize = 1;
+pub const CTAP_CALLBACK_RECEIVED: usize = 2;
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Side {
+    Transmit,
+    Receive,
+    TransmitOrReceive,
+}
+
+impl Side {
+    fn can_transmit(&self) -> bool {
+        match self {
+            Side::Transmit | Side::TransmitOrReceive => true,
+            Side::Receive => false,
+        }
+    }
+
+    fn can_receive(&self) -> bool {
+        match self {
+            Side::Receive | Side::TransmitOrReceive => true,
+            Side::Transmit => false,
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct App {
+    // Only one app can be connected to this driver, to avoid needing to route packets among apps.
+    // This field tracks this status.
+    connected: bool,
+    // Currently enabled transaction side. Subscribing to a callback or allowing a buffer
+    // automatically sets the corresponding side. Clearing both the callback and the buffer resets
+    // the side to None.
+    side: Option<Side>,
+    callback: Option<Callback>,
+    buffer: Option<AppSlice<Shared, u8>>,
+    // Whether the app is waiting for the kernel signaling a packet transfer.
+    waiting: bool,
+}
+
+impl App {
+    fn check_side(&mut self) {
+        if self.callback.is_none() && self.buffer.is_none() && !self.waiting {
+            self.side = None;
+        }
+    }
+
+    fn set_side(&mut self, side: Side) -> bool {
+        match self.side {
+            None => {
+                self.side = Some(side);
+                true
+            }
+            Some(app_side) => side == app_side,
+        }
+    }
+
+    fn is_ready_for_command(&self, side: Side) -> bool {
+        self.buffer.is_some() && self.callback.is_some() && self.side == Some(side)
+    }
+}
+
+pub trait CtapUsbClient {
+    // Whether this client is ready to receive a packet. This must be checked before calling
+    // packet_received().
+    fn can_receive_packet(&self) -> bool;
+
+    // Signal to the client that a packet has been received.
+    fn packet_received(&self, packet: &[u8; 64]);
+
+    // Signal to the client that a packet has been transmitted.
+    fn packet_transmitted(&self);
+}
+
+pub struct CtapUsbSyscallDriver<'a, 'b, C: 'a> {
+    usb_client: &'a ClientCtapHID<'a, 'b, C>,
+    apps: Grant<App>,
+}
+
+impl<'a, 'b, C: hil::usb::UsbController<'a>> CtapUsbSyscallDriver<'a, 'b, C> {
+    pub fn new(usb_client: &'a ClientCtapHID<'a, 'b, C>, apps: Grant<App>) -> Self {
+        CtapUsbSyscallDriver { usb_client, apps }
+    }
+}
+
+impl<'a, 'b, C: hil::usb::UsbController<'a>> CtapUsbClient for CtapUsbSyscallDriver<'a, 'b, C> {
+    fn can_receive_packet(&self) -> bool {
+        let mut result = false;
+        for app in self.apps.iter() {
+            app.enter(|app, _| {
+                if app.connected {
+                    result = app.waiting
+                        && app.side.map_or(false, |side| side.can_receive())
+                        && app.buffer.is_some();
+                }
+            });
+        }
+        result
+    }
+
+    fn packet_received(&self, packet: &[u8; 64]) {
+        for app in self.apps.iter() {
+            app.enter(|app, _| {
+                if app.connected && app.waiting && app.side.map_or(false, |side| side.can_receive())
+                {
+                    if let Some(buf) = &mut app.buffer {
+                        // Copy the packet to the app's allowed buffer.
+                        buf.as_mut().copy_from_slice(packet);
+                        app.waiting = false;
+                        // Signal to the app that a packet is ready.
+                        app.callback
+                            .map(|mut cb| cb.schedule(CTAP_CALLBACK_RECEIVED, 0, 0));
+                    }
+                }
+            });
+        }
+    }
+
+    fn packet_transmitted(&self) {
+        for app in self.apps.iter() {
+            app.enter(|app, _| {
+                if app.connected
+                    && app.waiting
+                    && app.side.map_or(false, |side| side.can_transmit())
+                {
+                    app.waiting = false;
+                    // Signal to the app that the packet was sent.
+                    app.callback
+                        .map(|mut cb| cb.schedule(CTAP_CALLBACK_TRANSMITED, 0, 0));
+                }
+            });
+        }
+    }
+}
+
+impl<'a, 'b, C: hil::usb::UsbController<'a>> Driver for CtapUsbSyscallDriver<'a, 'b, C> {
+    fn allow(
+        &self,
+        appid: AppId,
+        allow_num: usize,
+        slice: Option<AppSlice<Shared, u8>>,
+    ) -> ReturnCode {
+        let side = match allow_num {
+            CTAP_ALLOW_TRANSMIT => Side::Transmit,
+            CTAP_ALLOW_RECEIVE => Side::Receive,
+            CTAP_ALLOW_TRANSMIT_OR_RECEIVE => Side::TransmitOrReceive,
+            _ => return ReturnCode::ENOSUPPORT,
+        };
+        self.apps
+            .enter(appid, |app, _| {
+                if !app.connected {
+                    ReturnCode::ERESERVE
+                } else {
+                    if let Some(buf) = &slice {
+                        if buf.len() != 64 {
+                            return ReturnCode::EINVAL;
+                        }
+                    }
+                    if !app.set_side(side) {
+                        return ReturnCode::EALREADY;
+                    }
+                    app.buffer = slice;
+                    app.check_side();
+                    ReturnCode::SUCCESS
+                }
+            })
+            .unwrap_or_else(|err| err.into())
+    }
+
+    fn subscribe(
+        &self,
+        subscribe_num: usize,
+        callback: Option<Callback>,
+        appid: AppId,
+    ) -> ReturnCode {
+        let side = match subscribe_num {
+            CTAP_SUBSCRIBE_TRANSMIT => Side::Transmit,
+            CTAP_SUBSCRIBE_RECEIVE => Side::Receive,
+            CTAP_SUBSCRIBE_TRANSMIT_OR_RECEIVE => Side::TransmitOrReceive,
+            _ => return ReturnCode::ENOSUPPORT,
+        };
+        self.apps
+            .enter(appid, |app, _| {
+                if !app.connected {
+                    ReturnCode::ERESERVE
+                } else {
+                    if !app.set_side(side) {
+                        return ReturnCode::EALREADY;
+                    }
+                    app.callback = callback;
+                    app.check_side();
+                    ReturnCode::SUCCESS
+                }
+            })
+            .unwrap_or_else(|err| err.into())
+    }
+
+    fn command(&self, cmd_num: usize, _arg1: usize, _arg2: usize, appid: AppId) -> ReturnCode {
+        match cmd_num {
+            CTAP_CMD_CHECK => ReturnCode::SUCCESS,
+            CTAP_CMD_CONNECT => {
+                // First, check if any app is already connected to this driver.
+                let mut busy = false;
+                for app in self.apps.iter() {
+                    app.enter(|app, _| {
+                        busy |= app.connected;
+                    });
+                }
+
+                self.apps
+                    .enter(appid, |app, _| {
+                        if app.connected {
+                            ReturnCode::EALREADY
+                        } else if busy {
+                            ReturnCode::EBUSY
+                        } else {
+                            self.usb_client.enable();
+                            self.usb_client.attach();
+                            app.connected = true;
+                            ReturnCode::SUCCESS
+                        }
+                    })
+                    .unwrap_or_else(|err| err.into())
+            }
+            CTAP_CMD_TRANSMIT => self
+                .apps
+                .enter(appid, |app, _| {
+                    if !app.connected {
+                        ReturnCode::ERESERVE
+                    } else {
+                        if app.is_ready_for_command(Side::Transmit) {
+                            if app.waiting {
+                                ReturnCode::EALREADY
+                            } else if self
+                                .usb_client
+                                .transmit_packet(app.buffer.as_ref().unwrap().as_ref())
+                            {
+                                app.waiting = true;
+                                ReturnCode::SUCCESS
+                            } else {
+                                ReturnCode::EBUSY
+                            }
+                        } else {
+                            ReturnCode::EINVAL
+                        }
+                    }
+                })
+                .unwrap_or_else(|err| err.into()),
+            CTAP_CMD_RECEIVE => self
+                .apps
+                .enter(appid, |app, _| {
+                    if !app.connected {
+                        ReturnCode::ERESERVE
+                    } else {
+                        if app.is_ready_for_command(Side::Receive) {
+                            if app.waiting {
+                                ReturnCode::EALREADY
+                            } else {
+                                app.waiting = true;
+                                self.usb_client.receive_packet();
+                                ReturnCode::SUCCESS
+                            }
+                        } else {
+                            ReturnCode::EINVAL
+                        }
+                    }
+                })
+                .unwrap_or_else(|err| err.into()),
+            CTAP_CMD_TRANSMIT_OR_RECEIVE => self
+                .apps
+                .enter(appid, |app, _| {
+                    if !app.connected {
+                        ReturnCode::ERESERVE
+                    } else {
+                        if app.is_ready_for_command(Side::TransmitOrReceive) {
+                            if app.waiting {
+                                ReturnCode::EALREADY
+                            } else {
+                                // Indicates to the driver that we can receive any pending packet.
+                                app.waiting = true;
+                                self.usb_client.receive_packet();
+
+                                if !app.waiting {
+                                    // The call to receive_packet() collected a pending packet.
+                                    ReturnCode::SUCCESS
+                                } else {
+                                    // Indicates to the driver that we have a packet to send.
+                                    if self
+                                        .usb_client
+                                        .transmit_packet(app.buffer.as_ref().unwrap().as_ref())
+                                    {
+                                        ReturnCode::SUCCESS
+                                    } else {
+                                        ReturnCode::EBUSY
+                                    }
+                                }
+                            }
+                        } else {
+                            ReturnCode::EINVAL
+                        }
+                    }
+                })
+                .unwrap_or_else(|err| err.into()),
+            CTAP_CMD_CANCEL => self
+                .apps
+                .enter(appid, |app, _| {
+                    if !app.connected {
+                        ReturnCode::ERESERVE
+                    } else {
+                        if app.waiting {
+                            // FIXME: if cancellation failed, the app should still wait. But that
+                            // doesn't work yet.
+                            app.waiting = false;
+                            if self.usb_client.cancel_transaction() {
+                                ReturnCode::SUCCESS
+                            } else {
+                                // Cannot cancel now because the transaction is already in process.
+                                // The app should wait for the callback instead.
+                                ReturnCode::EBUSY
+                            }
+                        } else {
+                            ReturnCode::EALREADY
+                        }
+                    }
+                })
+                .unwrap_or_else(|err| err.into()),
+            _ => ReturnCode::ENOSUPPORT,
+        }
+    }
+}

--- a/capsules/src/usb/usbc_ctap_hid.rs
+++ b/capsules/src/usb/usbc_ctap_hid.rs
@@ -1,0 +1,369 @@
+//! A USB HID client of the USB hardware interface
+
+use super::descriptors;
+use super::descriptors::Buffer64;
+use super::descriptors::DescriptorType;
+use super::descriptors::EndpointAddress;
+use super::descriptors::EndpointDescriptor;
+use super::descriptors::HIDCountryCode;
+use super::descriptors::HIDDescriptor;
+use super::descriptors::HIDSubordinateDescriptor;
+use super::descriptors::InterfaceDescriptor;
+use super::descriptors::ReportDescriptor;
+use super::descriptors::TransferDirection;
+use super::usb_ctap::CtapUsbClient;
+use super::usbc_client_ctrl::ClientCtrl;
+use core::cell::Cell;
+use kernel::common::cells::OptionalCell;
+use kernel::debug;
+use kernel::hil;
+use kernel::hil::usb::TransferType;
+
+static LANGUAGES: &'static [u16; 1] = &[
+    0x0409, // English (United States)
+];
+
+const ENDPOINT_NUM: usize = 1;
+
+static CTAP_REPORT_DESCRIPTOR: &'static [u8] = &[
+    0x06, 0xD0, 0xF1, // HID_UsagePage ( FIDO_USAGE_PAGE ),
+    0x09, 0x01, // HID_Usage ( FIDO_USAGE_CTAPHID ),
+    0xA1, 0x01, // HID_Collection ( HID_Application ),
+    0x09, 0x20, // HID_Usage ( FIDO_USAGE_DATA_IN ),
+    0x15, 0x00, // HID_LogicalMin ( 0 ),
+    0x26, 0xFF, 0x00, // HID_LogicalMaxS ( 0xff ),
+    0x75, 0x08, // HID_ReportSize ( 8 ),
+    0x95, 0x40, // HID_ReportCount ( HID_INPUT_REPORT_BYTES ),
+    0x81, 0x02, // HID_Input ( HID_Data | HID_Absolute | HID_Variable ),
+    0x09, 0x21, // HID_Usage ( FIDO_USAGE_DATA_OUT ),
+    0x15, 0x00, // HID_LogicalMin ( 0 ),
+    0x26, 0xFF, 0x00, // HID_LogicalMaxS ( 0xff ),
+    0x75, 0x08, // HID_ReportSize ( 8 ),
+    0x95, 0x40, // HID_ReportCount ( HID_OUTPUT_REPORT_BYTES ),
+    0x91, 0x02, // HID_Output ( HID_Data | HID_Absolute | HID_Variable ),
+    0xC0, // HID_EndCollection
+];
+
+static CTAP_REPORT: ReportDescriptor<'static> = ReportDescriptor {
+    desc: CTAP_REPORT_DESCRIPTOR,
+};
+
+static HID_SUB_DESCRIPTORS: &'static [HIDSubordinateDescriptor] = &[HIDSubordinateDescriptor {
+    typ: DescriptorType::Report,
+    len: CTAP_REPORT_DESCRIPTOR.len() as u16,
+}];
+
+static HID: HIDDescriptor<'static> = HIDDescriptor {
+    hid_class: 0x0110,
+    country_code: HIDCountryCode::NotSupported,
+    sub_descriptors: HID_SUB_DESCRIPTORS,
+};
+
+pub struct ClientCtapHID<'a, 'b, C: 'a> {
+    client_ctrl: ClientCtrl<'a, 'static, C>,
+
+    // 64-byte buffers for the endpoint
+    in_buffer: Buffer64,
+    out_buffer: Buffer64,
+
+    // Interaction with the client
+    client: OptionalCell<&'b dyn CtapUsbClient>,
+    tx_packet: OptionalCell<[u8; 64]>,
+    pending_in: Cell<bool>,
+    pending_out: Cell<bool>,
+    delayed_out: Cell<bool>,
+}
+
+impl<'a, 'b, C: hil::usb::UsbController<'a>> ClientCtapHID<'a, 'b, C> {
+    pub fn new(
+        controller: &'a C,
+        max_ctrl_packet_size: u8,
+        vendor_id: u16,
+        product_id: u16,
+        strings: &'static [&'static str],
+    ) -> Self {
+        let interfaces: &mut [InterfaceDescriptor] = &mut [
+            // Interface declared in the FIDO2 specification, section 8.1.8.1
+            InterfaceDescriptor {
+                interface_class: 0x03, // HID
+                interface_subclass: 0x00,
+                interface_protocol: 0x00,
+                ..InterfaceDescriptor::default()
+            },
+        ];
+
+        let endpoints: &[&[EndpointDescriptor]] = &[&[
+            EndpointDescriptor {
+                endpoint_address: EndpointAddress::new_const(
+                    ENDPOINT_NUM,
+                    TransferDirection::HostToDevice,
+                ),
+                transfer_type: TransferType::Interrupt,
+                max_packet_size: 64,
+                interval: 5,
+            },
+            EndpointDescriptor {
+                endpoint_address: EndpointAddress::new_const(
+                    ENDPOINT_NUM,
+                    TransferDirection::DeviceToHost,
+                ),
+                transfer_type: TransferType::Interrupt,
+                max_packet_size: 64,
+                interval: 5,
+            },
+        ]];
+
+        let (device_descriptor_buffer, other_descriptor_buffer) =
+            descriptors::create_descriptor_buffers(
+                descriptors::DeviceDescriptor {
+                    vendor_id,
+                    product_id,
+                    manufacturer_string: 1,
+                    product_string: 2,
+                    serial_number_string: 3,
+                    max_packet_size_ep0: max_ctrl_packet_size,
+                    ..descriptors::DeviceDescriptor::default()
+                },
+                descriptors::ConfigurationDescriptor {
+                    configuration_value: 1,
+                    ..descriptors::ConfigurationDescriptor::default()
+                },
+                interfaces,
+                endpoints,
+                Some(&HID),
+                None, // No CDC descriptor array
+            );
+
+        ClientCtapHID {
+            client_ctrl: ClientCtrl::new(
+                controller,
+                device_descriptor_buffer,
+                other_descriptor_buffer,
+                Some(&HID),
+                Some(&CTAP_REPORT),
+                LANGUAGES,
+                strings,
+            ),
+            in_buffer: Buffer64::default(),
+            out_buffer: Buffer64::default(),
+            client: OptionalCell::empty(),
+            tx_packet: OptionalCell::empty(),
+            pending_in: Cell::new(false),
+            pending_out: Cell::new(false),
+            delayed_out: Cell::new(false),
+        }
+    }
+
+    pub fn set_client(&'a self, client: &'b dyn CtapUsbClient) {
+        self.client.set(client);
+    }
+
+    pub fn transmit_packet(&'a self, packet: &[u8]) -> bool {
+        if self.pending_in.get() {
+            // The previous packet has not yet been transmitted, reject the new one.
+            false
+        } else {
+            self.pending_in.set(true);
+            let mut buf: [u8; 64] = [0; 64];
+            buf.copy_from_slice(packet);
+            self.tx_packet.set(buf);
+            // Alert the controller that we now have data to send on the Interrupt IN endpoint.
+            self.controller().endpoint_resume_in(1);
+            true
+        }
+    }
+
+    pub fn receive_packet(&'a self) -> bool {
+        if self.pending_out.get() {
+            // The previous packet has not yet been received, reject the new one.
+            false
+        } else {
+            self.pending_out.set(true);
+            // In case we reported Delay before, send the pending packet back to the client.
+            // Otherwise, there's nothing to do, the controller will send us a packet_out when a
+            // packet arrives.
+            if self.delayed_out.take() {
+                if self.send_packet_to_client() {
+                    // If that succeeds, alert the controller that we can now
+                    // receive data on the Interrupt OUT endpoint.
+                    self.controller().endpoint_resume_out(1);
+                }
+            }
+            true
+        }
+    }
+
+    // Send an OUT packet available in the controller back to the client.
+    // This returns false if the client is not ready to receive a packet, and true if the client
+    // successfully accepted the packet.
+    fn send_packet_to_client(&'a self) -> bool {
+        // Copy the packet into a buffer to send to the client.
+        let mut buf: [u8; 64] = [0; 64];
+        for (i, x) in self.out_buffer.buf.iter().enumerate() {
+            buf[i] = x.get();
+        }
+
+        assert!(!self.delayed_out.get());
+
+        // Notify the client
+        if self
+            .client
+            .map_or(false, |client| client.can_receive_packet())
+        {
+            assert!(self.pending_out.take());
+
+            // Clear any pending packet on the transmitting side.
+            // It's up to the client to handle the received packet and decide if this packet
+            // should be re-transmitted or not.
+            self.cancel_in_transaction();
+
+            self.client.map(|client| client.packet_received(&buf));
+            true
+        } else {
+            // Cannot receive now, indicate a delay to the controller.
+            self.delayed_out.set(true);
+            false
+        }
+    }
+
+    pub fn cancel_transaction(&'a self) -> bool {
+        self.cancel_in_transaction() | self.cancel_out_transaction()
+    }
+
+    fn cancel_in_transaction(&'a self) -> bool {
+        self.tx_packet.take();
+        self.pending_in.take()
+    }
+
+    fn cancel_out_transaction(&'a self) -> bool {
+        self.pending_out.take()
+    }
+
+    #[inline]
+    fn controller(&'a self) -> &'a C {
+        self.client_ctrl.controller()
+    }
+}
+
+impl<'a, 'b, C: hil::usb::UsbController<'a>> hil::usb::Client<'a> for ClientCtapHID<'a, 'b, C> {
+    fn enable(&'a self) {
+        // Set up the default control endpoint
+        self.client_ctrl.enable();
+
+        // Set up the interrupt in-out endpoint
+        self.controller()
+            .endpoint_set_in_buffer(1, &self.in_buffer.buf);
+        self.controller()
+            .endpoint_set_out_buffer(1, &self.out_buffer.buf);
+        self.controller()
+            .endpoint_in_out_enable(TransferType::Interrupt, 1);
+    }
+
+    fn attach(&'a self) {
+        self.client_ctrl.attach();
+    }
+
+    fn bus_reset(&'a self) {
+        // Should the client initiate reconfiguration here?
+        // For now, the hardware layer does it.
+
+        debug!("Bus reset");
+    }
+
+    /// Handle a Control Setup transaction
+    fn ctrl_setup(&'a self, endpoint: usize) -> hil::usb::CtrlSetupResult {
+        self.client_ctrl.ctrl_setup(endpoint)
+    }
+
+    /// Handle a Control In transaction
+    fn ctrl_in(&'a self, endpoint: usize) -> hil::usb::CtrlInResult {
+        self.client_ctrl.ctrl_in(endpoint)
+    }
+
+    /// Handle a Control Out transaction
+    fn ctrl_out(&'a self, endpoint: usize, packet_bytes: u32) -> hil::usb::CtrlOutResult {
+        self.client_ctrl.ctrl_out(endpoint, packet_bytes)
+    }
+
+    fn ctrl_status(&'a self, endpoint: usize) {
+        self.client_ctrl.ctrl_status(endpoint)
+    }
+
+    /// Handle the completion of a Control transfer
+    fn ctrl_status_complete(&'a self, endpoint: usize) {
+        self.client_ctrl.ctrl_status_complete(endpoint)
+    }
+
+    /// Handle a Bulk/Interrupt IN transaction
+    fn packet_in(&'a self, transfer_type: TransferType, endpoint: usize) -> hil::usb::InResult {
+        match transfer_type {
+            TransferType::Bulk => hil::usb::InResult::Error,
+            TransferType::Interrupt => {
+                if endpoint != 1 {
+                    return hil::usb::InResult::Error;
+                }
+
+                if let Some(packet) = self.tx_packet.take() {
+                    let buf = &self.in_buffer.buf;
+                    for i in 0..64 {
+                        buf[i].set(packet[i]);
+                    }
+
+                    hil::usb::InResult::Packet(64)
+                } else {
+                    // Nothing to send
+                    hil::usb::InResult::Delay
+                }
+            }
+            TransferType::Control | TransferType::Isochronous => unreachable!(),
+        }
+    }
+
+    /// Handle a Bulk/Interrupt OUT transaction
+    fn packet_out(
+        &'a self,
+        transfer_type: TransferType,
+        endpoint: usize,
+        packet_bytes: u32,
+    ) -> hil::usb::OutResult {
+        match transfer_type {
+            TransferType::Bulk => hil::usb::OutResult::Error,
+            TransferType::Interrupt => {
+                if endpoint != 1 {
+                    return hil::usb::OutResult::Error;
+                }
+
+                if packet_bytes != 64 {
+                    // Cannot process this packet
+                    hil::usb::OutResult::Error
+                } else {
+                    if self.send_packet_to_client() {
+                        hil::usb::OutResult::Ok
+                    } else {
+                        hil::usb::OutResult::Delay
+                    }
+                }
+            }
+            TransferType::Control | TransferType::Isochronous => unreachable!(),
+        }
+    }
+
+    fn packet_transmitted(&'a self, endpoint: usize) {
+        if endpoint != 1 {
+            panic!("Unexpected transmission on ep {}", endpoint);
+        }
+
+        if self.tx_packet.is_some() {
+            panic!("Unexpected tx_packet while a packet was being transmitted.");
+        }
+        self.pending_in.set(false);
+
+        // Clear any pending packet on the receiving side.
+        // It's up to the client to handle the transmitted packet and decide if they want to
+        // receive another packet.
+        self.cancel_out_transaction();
+
+        // Notify the client
+        self.client.map(|client| client.packet_transmitted());
+    }
+}

--- a/chips/nrf52840/src/lib.rs
+++ b/chips/nrf52840/src/lib.rs
@@ -2,7 +2,7 @@
 
 pub use nrf52::{
     acomp, adc, aes, ble_radio, clock, constants, crt1, ficr, i2c, ieee802154_radio, init, nvmc,
-    pinmux, ppi, pwm, rtc, spi, temperature, timer, trng, uart, uicr, usbd,
+    pinmux, power, ppi, pwm, rtc, spi, temperature, timer, trng, uart, uicr, usbd,
 };
 pub mod chip;
 pub mod gpio;

--- a/kernel/src/hil/mod.rs
+++ b/kernel/src/hil/mod.rs
@@ -26,6 +26,7 @@ pub mod time;
 pub mod touch;
 pub mod uart;
 pub mod usb;
+pub mod usb_hid;
 
 /// Shared interface for configuring components.
 pub trait Controller {

--- a/kernel/src/hil/usb_hid.rs
+++ b/kernel/src/hil/usb_hid.rs
@@ -1,0 +1,100 @@
+//! Interface for USB HID (Human Interface Device) class
+
+use crate::returncode::ReturnCode;
+
+/// Implement this trait and use `set_client()` in order to receive callbacks.
+pub trait Client<'a> {
+    /// Called when a packet is received.
+    /// This will return the buffer passed into `receive_buffer()` as well as
+    /// the endpoint where the data was received. The `len` argument contains
+    /// the length of the packet received. If the buffer length is smaller
+    /// then this length the buffer will only contain part of the packet and
+    /// `result` will contain indicate an `ESIZE` error.
+    fn packet_received(
+        &'a self,
+        result: ReturnCode,
+        buffer: &'static mut [u8; 64],
+        len: usize,
+        endpoint: usize,
+    );
+
+    /// Called when a packet has been finished transmitting.
+    /// This will return the buffer passed into `send_buffer()` as well as
+    /// the endpoint where the data was sent. The `len` argument contains
+    /// the number of bytes sent. If this is less then the size of the
+    /// buffer `result` will contain the `ESIZE` error.
+    fn packet_transmitted(
+        &'a self,
+        result: ReturnCode,
+        buffer: &'static mut [u8; 64],
+        len: usize,
+        endpoint: usize,
+    );
+
+    /// Called when checking if we can start a new receive operation.
+    /// Should return true if we are ready to receive and not currently
+    /// in the process of receiving anything. That is if we are currently
+    /// idle.
+    /// If there is an outstanding call to receive, a callback already
+    /// waiting to be called then this will return false.
+    fn can_receive(&'a self) -> bool;
+}
+
+pub trait UsbHid<'a> {
+    /// Sets the buffer to be sent and starts a send transaction.
+    /// On success returns the number of bytes that will be sent.
+    /// On failure returns an error code and the buffer passed in.
+    fn send_buffer(
+        &'a self,
+        send: &'static mut [u8; 64],
+    ) -> Result<usize, (ReturnCode, &'static mut [u8; 64])>;
+
+    /// Cancels a send called by `send_buffer()`.
+    /// If `send_cancel()` successfully cancels a send transaction
+    /// before the transaction has been acted upon this function will
+    /// return the buffer passed via `send_buffer()` and no callback
+    /// will occur.
+    /// If there is currently no send transaction (`send_buffer()`
+    /// hasn't been called) this will return `Err(EINVAL)`.
+    /// If the transaction can't be cancelled cleanly, either because
+    /// the send has already occured, a partial send has occured or the
+    /// send can not be cancelled by the hardware this will return
+    /// `Err(EBUSY)` and the callback will still occur.
+    /// Note that unless the transaction completes the callback will
+    /// indicate a result of `ECANCEL`.
+    fn send_cancel(&'a self) -> Result<&'static mut [u8; 64], ReturnCode>;
+
+    /// Sets the buffer for received data to be stored and enables receive
+    /// transactions. Once this is called the implementation will enable
+    /// receiving via USB. Once a packet is received the `packet_received()`
+    /// callback will be triggered and no more data will be received until
+    /// this is called again.
+    ///
+    /// Once this is called, the implementation will wait until either
+    /// a packet is received or `receive_cancel()` is called.
+    ///
+    /// Calling `receive_buffer()` while there is an outstanding
+    /// `receive_buffer()` operation will return EBUSY.
+    ///
+    /// On success returns nothing.
+    /// On failure returns an error code and the buffer passed in.
+    fn receive_buffer(
+        &'a self,
+        recv: &'static mut [u8; 64],
+    ) -> Result<(), (ReturnCode, &'static mut [u8; 64])>;
+
+    /// Cancels a receive called by `receive_buffer()`.
+    /// If `receive_cancel()` successfully cancels a receive transaction
+    /// before the transaction has been acted upon this function will
+    /// return the buffer passed via `receive_buffer()` and no callback
+    /// will occur.
+    /// If there is currently no receive transaction (`receive_buffer()`
+    /// hasn't been called) this will return `Err(EINVAL)`.
+    /// If the transaction can't be cancelled cleanly, either because
+    /// the receive has already occured, a partial receive has occured or the
+    /// receive can not be cancelled by the hardware this will return
+    /// `Err(EBUSY)` and the callback will still occur.
+    /// Note that unless the transaction completes the callback will
+    /// indicate a result of `ECANCEL`.
+    fn receive_cancel(&'a self) -> Result<&'static mut [u8; 64], ReturnCode>;
+}


### PR DESCRIPTION
### Pull Request Overview

This pull request adds support for the USB-CTAP-HID protocol as specified by FIDO2. This is an alternative proposal to #2094 - contrary to #2094, this proposal was extensively tested on nRF52840 chips in the context of [OpenSK](https://github.com/google/OpenSK).

The main differences with the other proposal are the following.
- The driver supports all necessary operations to build a fully-fledged FIDO2 application (as opposed to a simple demo of exchanging HID messages), namely:
  - **Transfer direction**: #2094 only supports "send" and "receive" operations, which isn't sufficient. Indeed, with USB the host decides whether to initiate an OUT transaction or an IN transaction. So it's possible that while a Tock app wants to send a packet to the host, the host actually decided to send a packet to Tock. This in particular happens with FIDO2 "cancel" messages - the host stops receiving any response from Tock and instead sends a cancel packet to Tock. This proposal supports a more general "send_or_receive" operation for this use case where the app aims to send a packet, but is ready to instead receive a packet if the host sends one (in which case sending the packet is aborted).
  - **Cancellation**: Again, because USB transactions are initiated by the host, it's possible that no transaction happens for some time. An application may want to setup a timeout (timeouts are actually mandated by FIDO2 specs). To implement that, the application can separately use the alarm driver to get notified of the timeout, and in that case send a cancellation command to the CTAP-USB driver. This use case isn't supported in #2094.
  - **Allow**: #2094 supports an allow buffer in each direction. This proposal has a single allow buffer, but keeps track of the current direction (send, receive or send+receive). I don't think it makes sense to concurrently set up separate send & receive buffers (the send+receive operation supports that).
  - **Subscribe**: #2094 only supports a callback for receiving. This is incorrect, as even a send operation should get a completion callback (similarly to the console driver for example). Otherwise, the application has no way to know when it can claim back the allowed buffer! This proposal supports a single callback, but keeping track of the current direction (send, receive or send+receive).
  - **Command**: #2094 supports commands for sending and receiving data. This proposal additionally support the aforementioned send+receive, as well as cancel operations. Besides, an explicit "connect" command is required to identify which app currently "owns" the USB stack - whereas #2094 makes it implicit.
- **Testing**: This proposal was extensively tested on nRF52840. #2094 only mentions basic tests on OpenTitan. This proposal was not yet tested on OpenTitan, although I don't expect much chip-specific traps above the USB HIL.
- **Component**: This proposal has a parameter for the `max_ctrl_packet_size` to forward to the USB controller. #2094 unconditionally uses a `max_packet_size_ep0` of `MAX_CTRL_PACKET_SIZE = 64` in the `DeviceDescriptor`, which is not compatible with Tock's current USB implementation on sam4l (#2123). We should fix #2123 or remove USB support on sam4l (is it really supported?) before hard-coding a control packet of 64-bytes.
- **Endpoint configuration**: #2094 unconditionally calls `endpoint_in_enable` and `endpoint_out_enable` separately, even if the same endpoint number is used for the sending and receiving ends (as in the [CTAP spec example](https://fidoalliance.org/specs/fido-v2.0-id-20180227/fido-client-to-authenticator-protocol-v2.0-id-20180227.html#usb-descriptors)). This doesn't work with the current USB HIL, which expects `endpoint_in_out_enable` in that case. This proposal works with a single endpoint in IN+OUT mode.
- **HIL**: #2094 adds a new USB-HID HIL. I don't think it makes sense to stabilize such a HIL in the kernel at this point because (1) there is currently only one user of this HIL - the CTAP-USB driver - so we don't know what to unify on and (2) there is currently only one implementation of this HIL - based on USB. It seems therefore premature to me to define a kernel HIL without much more thought given on it. There is already a USB HIL to abstract over multiple chips at a lower level.


### Testing Strategy

This pull request was extensively tested together with the [OpenSK](https://github.com/google/OpenSK) app, on a wide range of FIDO2 scenarios, on various boards based on nRF52840 chips.


### TODO or Help Wanted

This pull request still needs to agree on an implementation that fits the needs of both #2094 and OpenSK.


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
