### PR TITLE
Earlgrey: dont call debug in interrupt top half

### DIFF
--- a/chips/earlgrey/src/chip.rs
+++ b/chips/earlgrey/src/chip.rs
@@ -215,12 +215,12 @@ unsafe fn handle_interrupt(intr: mcause::Interrupt) {
         mcause::Interrupt::UserSoft
         | mcause::Interrupt::UserTimer
         | mcause::Interrupt::UserExternal => {
-            debug!("unexpected user-mode interrupt");
+            panic!("unexpected user-mode interrupt");
         }
         mcause::Interrupt::SupervisorExternal
         | mcause::Interrupt::SupervisorTimer
         | mcause::Interrupt::SupervisorSoft => {
-            debug!("unexpected supervisor-mode interrupt");
+            panic!("unexpected supervisor-mode interrupt");
         }
 
         mcause::Interrupt::MachineSoft => {
@@ -234,7 +234,7 @@ unsafe fn handle_interrupt(intr: mcause::Interrupt) {
         }
 
         mcause::Interrupt::Unknown => {
-            debug!("interrupt of unknown cause");
+            panic!("interrupt of unknown cause");
         }
     }
 }


### PR DESCRIPTION
### Pull Request Overview

This pull request replaces calls to `debug!()` in the top half interrupt handler for the `earlgrey` chip with `panic!()`. If these calls executed it could cause UB, as the Tock kernel assumes that kernel code is not reentrant, and `debug!()` calls UART code.

I came across this while symbolically executing interrupt handlers in Tock.

### Testing Strategy

N/A

### TODO or Help Wanted

How bad is the possibility of a reentrant panic that this in theory could introduce?

### Documentation Updated

- [x] No updates are required.

### Formatting

- [x] Ran `make prepush`.
