### PR TITLE
fix rustdoc CI, force bash for Makefile.common

### DIFF
--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -1,3 +1,6 @@
+# Force the Shell to be bash as some systems have strange default shells
+SHELL := bash
+
 # Remove built-in rules and variables
 # n.b. no-op for make --version < 4.0
 MAKEFLAGS += -r

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -3,7 +3,9 @@
 //! It is based on nRF52840 SoC (Cortex M4 core with a BLE + IEEE 802.15.4 transceiver).
 
 #![no_std]
-#![no_main]
+// Disable this attribute when documenting, as a workaround for
+// https://github.com/rust-lang/rust/issues/62184.
+#![cfg_attr(not(doc), no_main)]
 #![feature(const_in_array_repeat_expressions)]
 #![deny(missing_docs)]
 


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes #2124 by uniting `boards/Makefile.common` and `Makefile` such that `bash` is the default shell for both. This fixes an issue where when `Makefile.common` was called by a shell script from the `Makefile` on the ubuntu CI machine, it would use the default ubuntu shell `dash` which does not support the syntax used to detect warnings in rustdoc.


### Testing Strategy

This pull request was tested by running the CI locally on Ubuntu 20.04 before and after this change.


### TODO or Help Wanted

N/A

### Documentation Updated

- [x] No updates are required.

### Formatting

- [x] Ran `make prepush`.
