### PR TITLE
chips/earlgrey: Use the peripheral clock frequency

### DIFF
--- a/chips/earlgrey/src/chip.rs
+++ b/chips/earlgrey/src/chip.rs
@@ -23,8 +23,6 @@ use crate::usbdev;
 
 PMPConfigMacro!(4);
 
-pub const CHIP_FREQ: u32 = CONFIG.chip_freq;
-
 pub struct EarlGrey<A: 'static + Alarm<'static>> {
     userspace_kernel_boundary: SysCall,
     pmp: PMP,

--- a/chips/earlgrey/src/chip_config.rs
+++ b/chips/earlgrey/src/chip_config.rs
@@ -15,8 +15,10 @@ pub struct Config<'a> {
     /// Identifier for the platform. This is useful for debugging to confirm the
     /// correct configuration of the chip is being used.
     pub name: &'a str,
-    /// The clock speed of the core in Hz.
-    pub chip_freq: u32,
+    /// The clock speed of the CPU in Hz.
+    pub cpu_freq: u32,
+    /// The clock speed of the peripherals in Hz.
+    pub peripheral_freq: u32,
     /// The baud rate for UART. This allows for a version of the chip that can
     /// support a faster baud rate to use it to help with debugging.
     pub uart_baudrate: u32,
@@ -29,7 +31,8 @@ pub struct Config<'a> {
 ))]
 pub const CONFIG: Config = Config {
     name: "fpga_nexysvideo",
-    chip_freq: 50_000_000,
+    cpu_freq: 50_000_000,
+    peripheral_freq: 12_500_000,
     uart_baudrate: 230400,
 };
 
@@ -37,6 +40,7 @@ pub const CONFIG: Config = Config {
 #[cfg(feature = "config_sim_verilator")]
 pub const CONFIG: Config = Config {
     name: "sim_verilator",
-    chip_freq: 500_000,
+    cpu_freq: 500_000,
+    peripheral_freq: 125_000,
     uart_baudrate: 9600,
 };

--- a/chips/earlgrey/src/i2c.rs
+++ b/chips/earlgrey/src/i2c.rs
@@ -1,8 +1,8 @@
-use crate::chip;
+use crate::chip_config::CONFIG;
 use kernel::common::StaticRef;
 use lowrisc::i2c::{I2c, I2cRegisters};
 
-pub static mut I2C: I2c = I2c::new(I2C_BASE, (1 / chip::CHIP_FREQ) * 1000 * 1000);
+pub static mut I2C: I2c = I2c::new(I2C_BASE, (1 / CONFIG.cpu_freq) * 1000 * 1000);
 
 // This is a placeholder address as the I2C MMIO interface isn't avaliable yet
 const I2C_BASE: StaticRef<I2cRegisters> =

--- a/chips/earlgrey/src/timer.rs
+++ b/chips/earlgrey/src/timer.rs
@@ -1,5 +1,6 @@
 //! Timer driver.
 
+use crate::chip_config::CONFIG;
 use kernel::common::cells::OptionalCell;
 use kernel::common::registers::{register_bitfields, register_structs, ReadWrite, WriteOnly};
 use kernel::common::StaticRef;
@@ -7,9 +8,7 @@ use kernel::hil::time;
 use kernel::hil::time::{Ticks, Ticks64, Time};
 use kernel::ReturnCode;
 
-use crate::chip::CHIP_FREQ;
-
-const PRESCALE: u16 = ((CHIP_FREQ / 10_000) - 1) as u16; // 10Khz
+const PRESCALE: u16 = ((CONFIG.cpu_freq / 10_000) - 1) as u16; // 10Khz
 
 /// 10KHz `Frequency`
 #[derive(Debug)]

--- a/chips/earlgrey/src/uart.rs
+++ b/chips/earlgrey/src/uart.rs
@@ -1,12 +1,10 @@
+use crate::chip_config::CONFIG;
 use kernel::common::StaticRef;
 use lowrisc::uart::{Uart, UartRegisters};
 
-use crate::chip;
-use crate::chip_config::CONFIG;
-
 pub const UART0_BAUDRATE: u32 = CONFIG.uart_baudrate;
 
-pub static mut UART0: Uart = Uart::new(UART0_BASE, chip::CHIP_FREQ);
+pub static mut UART0: Uart = Uart::new(UART0_BASE, CONFIG.peripheral_freq);
 
 const UART0_BASE: StaticRef<UartRegisters> =
     unsafe { StaticRef::new(0x4000_0000 as *const UartRegisters) };


### PR DESCRIPTION
### Pull Request Overview

Use the correct clock frequency to determine the UART config values.


### Testing Strategy

Running on OpenTitan.


### TODO or Help Wanted

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
