### PR TITLE
Simplify grant implementation and fix soundness errors

### DIFF
--- a/capsules/src/ieee802154/driver.rs
+++ b/capsules/src/ieee802154/driver.rs
@@ -777,7 +777,7 @@ impl Driver for RadioDriver<'_> {
             }),
             25 => self.remove_key(arg1),
             26 => {
-                self.do_with_app(appid, |app| {
+                let setup_tx = self.do_with_app(appid, |app| {
                     if app.pending_tx.is_some() {
                         // Cannot support more than one pending tx per process.
                         return ReturnCode::EBUSY;
@@ -809,9 +809,13 @@ impl Driver for RadioDriver<'_> {
                         return ReturnCode::EINVAL;
                     }
                     app.pending_tx = next_tx;
-
+                    ReturnCode::SUCCESS
+                });
+                if setup_tx == ReturnCode::SUCCESS {
                     self.do_next_tx_sync(appid)
-                })
+                } else {
+                    setup_tx
+                }
             }
             _ => ReturnCode::ENOSUPPORT,
         }

--- a/capsules/src/proximity.rs
+++ b/capsules/src/proximity.rs
@@ -180,6 +180,8 @@ impl<'a> ProximitySensor<'a> {
     fn run_next_command(&self) -> ReturnCode {
         let mut break_flag: bool = false;
 
+        // Find thresholds before entering any grant regions
+        let t: Thresholds = self.find_thresholds();
         // Find and run another command
         for cntr in self.apps.iter() {
             cntr.enter(|app, _| {
@@ -191,7 +193,6 @@ impl<'a> ProximitySensor<'a> {
                             self.command_running.set(ProximityCommand::ReadProximity);
                         }
                         ProximityCommand::ReadProximityOnInterrupt => {
-                            let t: Thresholds = self.find_thresholds();
                             self.driver.read_proximity_on_interrupt(t.lower, t.upper);
                             self.command_running
                                 .set(ProximityCommand::ReadProximityOnInterrupt);

--- a/kernel/src/grant.rs
+++ b/kernel/src/grant.rs
@@ -1,35 +1,215 @@
 //! Data structure to store a list of userspace applications.
 
-use crate::callback::AppId;
-use crate::process::{Error, ProcessType};
-use crate::sched::Kernel;
 use core::marker::PhantomData;
 use core::mem::{align_of, size_of};
 use core::ops::{Deref, DerefMut};
 use core::ptr::{slice_from_raw_parts_mut, write, NonNull};
 
-/// Region of process memory reserved for the kernel.
-pub struct Grant<T: Default> {
-    pub(crate) kernel: &'static Kernel,
-    grant_num: usize,
-    ptr: PhantomData<T>,
+use crate::callback::AppId;
+use crate::process::{Error, ProcessType};
+use crate::sched::Kernel;
+
+/// Type that indicates a grant region has been entered and borrowed.
+/// This is passed to capsules when they try to enter a grant region.
+pub struct Borrowed<'a, T: 'a + ?Sized> {
+    data: &'a mut T,
+    appid: AppId,
 }
 
-pub struct AppliedGrant<T> {
-    appid: AppId,
-    grant: NonNull<T>,
+impl<'a, T: 'a + ?Sized> Borrowed<'a, T> {
+    fn new(data: &'a mut T, appid: AppId) -> Borrowed<'a, T> {
+        Borrowed {
+            data: data,
+            appid: appid,
+        }
+    }
+
+    pub fn appid(&self) -> AppId {
+        self.appid
+    }
+}
+
+impl<'a, T: 'a + ?Sized> Deref for Borrowed<'a, T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        self.data
+    }
+}
+
+impl<'a, T: 'a + ?Sized> DerefMut for Borrowed<'a, T> {
+    fn deref_mut(&mut self) -> &mut T {
+        self.data
+    }
+}
+
+pub struct AppliedGrant<'a, T: 'a> {
+    process: &'a dyn ProcessType,
+    grant_num: usize,
+    grant: &'a mut T,
     _phantom: PhantomData<T>,
 }
 
-impl<T> AppliedGrant<T> {
+impl<'a, T: Default> AppliedGrant<'a, T> {
+    fn get_or_allocate(grant: &Grant<T>, process: &'a dyn ProcessType) -> Result<Self, Error> {
+        // Here is an example of how the grants are laid out in a
+        // process's memory:
+        //
+        // Mem. Addr.
+        // 0x0040000  ┌────────────────────
+        //            │   GrantPointer0 [0x003FFC8]
+        //            │   GrantPointer1 [0x003FFC0]
+        //            │   ...
+        //            │   GrantPointerN [0x0000000 (NULL)]
+        //            ├────────────────────
+        //            │   Process Control Block
+        // 0x003FFE0  ├────────────────────
+        //            │   GrantRegion0
+        // 0x003FFC8  ├────────────────────
+        //            │   GrantRegion1
+        // 0x003FFC0  ├────────────────────
+        //            │
+        //            │   --unallocated--
+        //            │
+        //            └────────────────────
+        //
+        // An array of pointers (one per possible grant region)
+        // point to where the actual grant memory is allocated
+        // inside of the process. The grant memory is not allocated
+        // until the actual grant region is actually used.
+        //
+        // A `GrantPointer` can be set to all 1s (0xFFFFFFFFF) as a flag
+        // that that grant is currently entered (aka being accessed). The actual
+        // pointer address is restored when the access finishes.
+        //
+        // This function provides the app access to the specific
+        // grant memory, and allocates the grant region in the
+        // process memory if needed.
+
+        // Get the GrantPointer to start. Since process.rs does not know
+        // anything about the datatype of the grant, and the grant
+        // memory may not yet be allocated, it can only return a `*mut
+        // u8` here. We will eventually convert this to a `*mut T`.
+        let grant_num = grant.grant_num;
+        let appid = process.appid();
+        if let Some(untyped_grant_ptr) = process.get_grant_ptr(grant_num) {
+            // If the grant pointer is NULL then the memory for the
+            // GrantRegion needs to be allocated. If the grant pointer is all 1s
+            // then the grant is already enetered and we return an error. Otherwise, we can
+            // convert the pointer to a `*mut T` because we know we
+            // previously allocated enough memory for type T.
+            unsafe {
+                let typed_grant_pointer = if untyped_grant_ptr.is_null() {
+                    // Allocate space in the process's memory for
+                    // something of type `T` for the grant.
+                    //
+                    // Note: This allocation is intentionally never
+                    // freed.  A grant region is valid once allocated
+                    // for the lifetime of the process.
+                    let alloc_size = size_of::<T>();
+                    let new_region =
+                        appid
+                            .kernel
+                            .process_map_or(Err(Error::NoSuchApp), appid, |process| {
+                                process.alloc(alloc_size, align_of::<T>()).map_or(
+                                    Err(Error::OutOfMemory),
+                                    |buf| {
+                                        // Convert untyped `*mut u8` allocation to allocated type
+                                        let ptr = NonNull::cast::<T>(buf);
+
+                                        Ok(ptr)
+                                    },
+                                )
+                            })?;
+
+                    // We use `ptr::write` to avoid `Drop`ping the uninitialized memory in
+                    // case `T` implements the `Drop` trait.
+                    write(new_region.as_ptr(), T::default());
+
+                    // Update the grant pointer in the process. Again,
+                    // since the process struct does not know about the
+                    // grant type we must use a `*mut u8` here.
+                    process.set_grant_ptr(grant_num, new_region.as_ptr() as *mut u8);
+
+                    // The allocator returns a `NonNull`, we just want
+                    // the raw pointer.
+                    new_region.as_ptr()
+                } else if untyped_grant_ptr == (!0 as *mut u8) {
+                    // Grant region currently entered, cannot enter again.
+                    return Err(Error::AlreadyInUse);
+                } else {
+                    // Grant region previously allocated, just convert the
+                    // pointer.
+                    untyped_grant_ptr as *mut T
+                };
+
+                Ok(AppliedGrant {
+                    process: process,
+                    grant_num: grant.grant_num,
+                    grant: &mut *(typed_grant_pointer as *mut T),
+                    _phantom: PhantomData,
+                })
+            }
+        } else {
+            Err(Error::InactiveApp)
+        }
+    }
+
+    /// Return an `AppliedGrant` for a grant in a process if that
+    /// grant has already been allocated.
+    ///
+    /// On `Err()`, returns `Err(None)` if the grant has not been allocated
+    /// for this process. Returns `Err(Some(Error))` with an appropriate
+    /// error otherwise.
+    fn get_if_allocated(
+        grant: &Grant<T>,
+        process: &'a dyn ProcessType,
+    ) -> Result<Self, Option<Error>> {
+        process
+            .get_grant_ptr(grant.grant_num)
+            .map_or(Err(None), |grant_ptr| {
+                if grant_ptr.is_null() {
+                    // Grant has not been allocated.
+                    Err(None)
+                } else if grant_ptr == (!0 as *mut u8) {
+                    // A grant pointer set to 0xFFFFFFFF is a flag signaling
+                    // that the grant has already been entered.
+                    Err(Some(Error::AlreadyInUse))
+                } else {
+                    Ok(AppliedGrant {
+                        process: process,
+                        grant_num: grant.grant_num,
+                        grant: unsafe { &mut *(grant_ptr as *mut T) },
+                        _phantom: PhantomData,
+                    })
+                }
+            })
+    }
+
+    /// Run a function with access to the contents of the grant region.
+    /// This is "entering" the grant region, and the _only_ time when
+    /// the contents of a grant region can be accessed.
     pub fn enter<F, R>(self, fun: F) -> R
     where
-        F: FnOnce(&mut Owned<T>, &mut Allocator) -> R,
+        F: FnOnce(&mut Borrowed<T>, &mut Allocator) -> R,
         R: Copy,
     {
-        let mut allocator = Allocator { appid: self.appid };
-        let mut root = Owned::new(self.grant, self.appid);
-        fun(&mut root, &mut allocator)
+        let mut allocator = Allocator {
+            appid: self.process.appid(),
+        };
+        let mut root = Borrowed::new(self.grant, self.process.appid());
+        // Mark the grant region as entered by replacing its grant pointer with
+        // all 1s. This allows us to check whether the grant region is already entered.
+        unsafe {
+            self.process.set_grant_ptr(self.grant_num, !0 as *mut u8);
+        }
+        let res = fun(&mut root, &mut allocator);
+        // Restore the grant pointer indicating that we are no longer accessing
+        // the grant.
+        unsafe {
+            self.process
+                .set_grant_ptr(self.grant_num, root.data as *mut _ as *mut u8);
+        }
+        res
     }
 }
 
@@ -58,6 +238,10 @@ impl<T: ?Sized> DynamicGrant<T> {
     /// If the app has since been restarted or crashed, or the memory is otherwise no longer
     /// present, then this function will not call the given closure, and will
     /// instead directly return `Err(Error::NoSuchApp)`.
+    ///
+    /// Because this function requires `&mut self`, it should be impossible to access
+    /// the inner data of a given `DynamicGrant` reentrantly. Thus the reentrance detection
+    /// we use for non-dynamic grants is not needed here.
     pub fn enter<F, R>(&mut self, fun: F) -> Result<R, Error>
     where
         F: FnOnce(Borrowed<'_, T>) -> R,
@@ -76,39 +260,8 @@ pub struct Allocator {
     appid: AppId,
 }
 
-pub struct Owned<T: ?Sized> {
-    data: NonNull<T>,
-    appid: AppId,
-}
-
-impl<T: ?Sized> Owned<T> {
-    fn new(data: NonNull<T>, appid: AppId) -> Owned<T> {
-        Owned {
-            data: data,
-            appid: appid,
-        }
-    }
-
-    pub fn appid(&self) -> AppId {
-        self.appid
-    }
-}
-
-impl<T: ?Sized> Deref for Owned<T> {
-    type Target = T;
-    fn deref(&self) -> &T {
-        unsafe { self.data.as_ref() }
-    }
-}
-
-impl<T: ?Sized> DerefMut for Owned<T> {
-    fn deref_mut(&mut self) -> &mut T {
-        unsafe { self.data.as_mut() }
-    }
-}
-
 impl Allocator {
-    /// Allocates a new owned grant initialized using the given closure.
+    /// Allocates a new dynamic grant initialized using the given closure.
     ///
     /// The closure will be called exactly once, and the result will be used to
     /// initialize the owned value.
@@ -170,21 +323,6 @@ impl Allocator {
         }
     }
 
-    /// Like `alloc`, but the caller is responsible for free-ing the allocated
-    /// memory, as it is not wrapped in a type that implements `Drop`.
-    ///
-    /// In contrast to `alloc_raw`, this method does initialize the returned
-    /// memory.
-    unsafe fn alloc_default_unowned<T: Default>(&mut self) -> Result<NonNull<T>, Error> {
-        let ptr = self.alloc_raw()?;
-
-        // We use `ptr::write` to avoid `Drop`ping the uninitialized memory in
-        // case `T` implements the `Drop` trait.
-        write(ptr.as_ptr(), T::default());
-
-        Ok(ptr)
-    }
-
     /// Allocates uninitialized memory appropriate to store a `T`, and returns a
     /// pointer to said memory. The caller is responsible for both initializing the
     /// returned memory, and dropping it properly when finished.
@@ -214,35 +352,11 @@ impl Allocator {
     }
 }
 
-pub struct Borrowed<'a, T: 'a + ?Sized> {
-    data: &'a mut T,
-    appid: AppId,
-}
-
-impl<'a, T: 'a + ?Sized> Borrowed<'a, T> {
-    pub fn new(data: &'a mut T, appid: AppId) -> Borrowed<'a, T> {
-        Borrowed {
-            data: data,
-            appid: appid,
-        }
-    }
-
-    pub fn appid(&self) -> AppId {
-        self.appid
-    }
-}
-
-impl<'a, T: 'a + ?Sized> Deref for Borrowed<'a, T> {
-    type Target = T;
-    fn deref(&self) -> &T {
-        self.data
-    }
-}
-
-impl<'a, T: 'a + ?Sized> DerefMut for Borrowed<'a, T> {
-    fn deref_mut(&mut self) -> &mut T {
-        self.data
-    }
+/// Region of process memory reserved for the kernel.
+pub struct Grant<T: Default> {
+    pub(crate) kernel: &'static Kernel,
+    grant_num: usize,
+    ptr: PhantomData<T>,
 }
 
 impl<T: Default> Grant<T> {
@@ -254,20 +368,6 @@ impl<T: Default> Grant<T> {
         }
     }
 
-    pub fn grant(&self, appid: AppId) -> Option<AppliedGrant<T>> {
-        appid.kernel.process_map_or(None, appid, |process| {
-            if let Some(grant_ptr) = process.get_grant_ptr(self.grant_num) {
-                NonNull::new(grant_ptr).map(|grant| AppliedGrant {
-                    appid: appid,
-                    grant: grant.cast::<T>(),
-                    _phantom: PhantomData,
-                })
-            } else {
-                None
-            }
-        })
-    }
-
     pub fn enter<F, R>(&self, appid: AppId, fun: F) -> Result<R, Error>
     where
         F: FnOnce(&mut Borrowed<T>, &mut Allocator) -> R,
@@ -276,110 +376,43 @@ impl<T: Default> Grant<T> {
         appid
             .kernel
             .process_map_or(Err(Error::NoSuchApp), appid, |process| {
-                // Here is an example of how the grants are laid out in a
-                // process's memory:
-                //
-                // Mem. Addr.
-                // 0x0040000  ┌────────────────────
-                //            │   GrantPointer0 [0x003FFC8]
-                //            │   GrantPointer1 [0x003FFC0]
-                //            │   ...
-                //            │   GrantPointerN [0x0000000 (NULL)]
-                //            ├────────────────────
-                //            │   Process Control Block
-                // 0x003FFE0  ├────────────────────
-                //            │   GrantRegion0
-                // 0x003FFC8  ├────────────────────
-                //            │   GrantRegion1
-                // 0x003FFC0  ├────────────────────
-                //            │
-                //            │   --unallocated--
-                //            │
-                //            └────────────────────
-                //
-                // An array of pointers (one per possible grant region)
-                // point to where the actual grant memory is allocated
-                // inside of the process. The grant memory is not allocated
-                // until the actual grant region is actually used.
-                //
-                // This function provides the app access to the specific
-                // grant memory, and allocates the grant region in the
-                // process memory if needed.
-
-                // Get the GrantPointer to start. Since process.rs does not know
-                // anything about the datatype of the grant, and the grant
-                // memory may not yet be allocated, it can only return a `*mut
-                // u8` here. We will eventually convert this to a `*mut T`.
-                if let Some(untyped_grant_ptr) = process.get_grant_ptr(self.grant_num) {
-                    // This is the allocator for this process when needed
-                    let mut allocator = Allocator { appid: appid };
-
-                    // If the grant pointer is NULL then the memory for the
-                    // GrantRegion needs to be allocated. Otherwise, we can
-                    // convert the pointer to a `*mut T` because we know we
-                    // previously allocated enough memory for type T.
-                    let typed_grant_pointer = if untyped_grant_ptr.is_null() {
-                        unsafe {
-                            // Allocate space in the process's memory for
-                            // something of type `T` for the grant.
-                            //
-                            // Note: This allocation is intentionally never
-                            // freed.  A grant region is valid once allocated
-                            // for the lifetime of the process.
-                            let new_region = allocator.alloc_default_unowned()?;
-
-                            // Update the grant pointer in the process. Again,
-                            // since the process struct does not know about the
-                            // grant type we must use a `*mut u8` here.
-                            process.set_grant_ptr(self.grant_num, new_region.as_ptr() as *mut u8);
-
-                            // The allocator returns a `NonNull`, we just want
-                            // the raw pointer.
-                            new_region.as_ptr()
-                        }
-                    } else {
-                        // Grant region previously allocated, just convert the
-                        // pointer.
-                        untyped_grant_ptr as *mut T
-                    };
-
-                    // Dereference the typed GrantPointer to make a GrantRegion
-                    // reference.
-                    let region = unsafe { &mut *typed_grant_pointer };
-
-                    // Wrap the grant reference in something that knows
-                    // what app its a part of.
-                    let mut borrowed_region = Borrowed::new(region, appid);
-
-                    // Call the passed in closure with the borrowed grant region.
-                    let res = fun(&mut borrowed_region, &mut allocator);
-                    Ok(res)
-                } else {
-                    Err(Error::InactiveApp)
-                }
+                let ag = AppliedGrant::get_or_allocate(self, process)?;
+                Ok(ag.enter(fun))
             })
     }
 
+    /// Call a function on every active grant region.
+    /// Calling this function when a grant region is currently entered
+    /// will lead to a panic.
     pub fn each<F>(&self, fun: F)
     where
-        F: Fn(&mut Owned<T>),
+        F: Fn(&mut Borrowed<T>),
     {
-        self.kernel.process_each(|process| {
-            if let Some(grant_ptr) = process.get_grant_ptr(self.grant_num) {
-                NonNull::new(grant_ptr).map(|grant| {
-                    let mut root = Owned::new(grant.cast::<T>(), process.appid());
-                    fun(&mut root);
-                });
-            }
-        });
+        for ag in self.iter() {
+            ag.enter(|borrowed, _| fun(borrowed));
+        }
     }
 
     /// Get an iterator over all processes and their active grant regions for
     /// this particular grant.
+    /// Calling this function when a grant region is currently entered
+    /// will lead to a panic.
     pub fn iter(&self) -> Iter<T> {
         Iter {
             grant: self,
             subiter: self.kernel.get_process_iter(),
+            skip_entered_grants: false,
+        }
+    }
+
+    /// Get an iterator over all processes and their active grant regions for
+    /// this particular grant, except grant regions that are already currently
+    /// entered.
+    pub fn iter_unentered_grants(&self) -> Iter<T> {
+        Iter {
+            grant: self,
+            subiter: self.kernel.get_process_iter(),
+            skip_entered_grants: true,
         }
     }
 }
@@ -390,34 +423,73 @@ pub struct Iter<'a, T: 'a + Default> {
         core::slice::Iter<'a, Option<&'static dyn ProcessType>>,
         fn(&Option<&'static dyn ProcessType>) -> Option<&'static dyn ProcessType>,
     >,
+    /// Whether this iterator must visit every grant region, or if
+    /// it should skip grant regions which are already entered.
+    /// A grant region cannot be entered twice. Therefore, if a capsule
+    /// tries to iterate over all grant regions while inside of a grant region,
+    /// the kernel will `panic!()` to prevent double entry. However, if this
+    /// is set, then the iterator will skip over already entered grant regions,
+    /// avoiding a panic but potentially creating subtly unintended code.
+    skip_entered_grants: bool,
 }
 
-impl<T: Default> Iterator for Iter<'_, T> {
-    type Item = AppliedGrant<T>;
+impl<'a, T: Default> Iterator for Iter<'a, T> {
+    type Item = AppliedGrant<'a, T>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        // Save a local copy of grant_num so we don't have to access `self`
-        // in the closure below.
-        let grant_num = self.grant.grant_num;
-
+        let grant = self.grant;
         // Get the next `AppId` from the kernel processes array that is setup to use this grant.
         // Since the iterator itself is saved calling this function
         // again will start where we left off.
-        let res = self.subiter.find(|process| {
-            // We have found a candidate process that exists in the
-            // processes array. Now we have to check if this grant is setup
-            // for this process. If not, we have to skip it and keep
-            // looking.
-            if let Some(grant_ptr) = process.get_grant_ptr(grant_num) {
-                !grant_ptr.is_null()
-            } else {
-                false
-            }
-        });
-
-        // Check if our find above returned another `AppId`, or if we hit the
-        // end of the iterator. If we found another app, try to access its grant
-        // region.
-        res.map_or(None, |process| self.grant.grant(process.appid()))
+        let skip_entered_grants = self.skip_entered_grants;
+        self.subiter.find_map(
+            |process| match AppliedGrant::get_if_allocated(grant, process) {
+                Ok(ag) => Some(ag),
+                Err(None) => None,
+                Err(Some(_err)) => {
+                    if skip_entered_grants {
+                        // This iter was created from `iter_unentered_grants()`,
+                        // so we skip entered grants to avoid double entry.
+                        None
+                    } else {
+                        // Panic if the capsule asked us to enter an already entered
+                        // grant region. This preserves type correctness (but does crash
+                        // the system).
+                        //
+                        // This panic represents a tradeoff. While it is undesirable to have the
+                        // potential for a runtime crash in this grant region code, it balances
+                        // usability with type correctness. The challenge is that calling `self.apps.iter()`
+                        // is a common pattern in capsules to access the grant region of every
+                        // app that is using the capsule, and sometimes it is intuitive to call that
+                        // inside of a `self.apps.enter(app_id, |app| {...})` closure. However, `.enter()`
+                        // means that app's grant region is entered, and then a naive `.iter()` would
+                        // re-enter the grant region and cause undefined behavior. We considered
+                        // different options to resolve this.
+                        //
+                        // 1. Have `.iter()` only iterate over grant regions which are not entered.
+                        //    This avoids the bug, but could lead to unexpected behavior, as `self.apps.iter()` will
+                        //    do different things depending on where in a capsule it is called.
+                        // 2. Have the compiler detect when `.iter()` is called when a grant region has
+                        //    already been entered. We don't know of a viable way to implement this.
+                        // 3. Panic if `.iter()` is called when a grant is already entered.
+                        //
+                        // We decided on option 3 because it balances minimizing surprises (`self.apps.iter()`
+                        // will always iterate all grants) while also protecting against the bug. We expect
+                        // that any code that attempts to call `self.apps.iter()` after calling `.enter()` will
+                        // immediately encounter this `panic!()` and have to be refactored before any tests
+                        // will be successful. Therefore, this `panic!()` should only occur at development/testing
+                        // time.
+                        //
+                        // ## How to fix this error
+                        //
+                        // If you are seeing this panic, you need to refactor your capsule to not
+                        // call `.iter()` or `.each()` from inside a `.enter()` closure. That is, you
+                        // need to close the grant region you are currently in before trying to iterate
+                        // over all grant regions.
+                        panic!("Attempted to re-enter a grant region.")
+                    }
+                }
+            },
+        )
     }
 }

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -574,6 +574,8 @@ pub enum Error {
     /// This likely indicates a bug in the kernel and that some state is
     /// inconsistent in the kernel.
     KernelError,
+    /// Indicates some process data, such as a Grant, is already borrowed.
+    AlreadyInUse,
 }
 
 impl From<Error> for ReturnCode {
@@ -584,6 +586,7 @@ impl From<Error> for ReturnCode {
             Error::NoSuchApp => ReturnCode::EINVAL,
             Error::InactiveApp => ReturnCode::FAIL,
             Error::KernelError => ReturnCode::FAIL,
+            Error::AlreadyInUse => ReturnCode::FAIL,
         }
     }
 }


### PR DESCRIPTION
### Pull Request Overview

This pull request addresses #2135 and partially the issue that #2052 addresses:

- Grants do not currently prevent re-entrancy which, in turn, allows mutable aliasing of Rust memory (that happens to be located in grant regions)
- The Allocator interface (which is currently totally unused except for @daboross's in progress BLE work) has similar, but harder to fix issues.

This pull request does three things:

1. It removes the `Allocator` struct and replaces the closure `enter` expects to take a `()` instead. This works because the allocator is totally unused at the moment, so users of `enter` don't care about the type. We _should_ bring this back and #2052 is likely close to the solution, but as an initial step, removing it is good too.

2. It attempts to dramatically simplify the grant module, leaving only four types:
    - `Borrowed` - a wrapper around a mutable reference to reified Grant memory and an appid that's yielded when "entering" a grant
    - `AppliedGrant` which is type that contains a grant that's guaranteed to be allocated and usable
    - `Grant` the main type a user interacts with. `Grant`s differ from `AppliedGrant` in that calling `enter` may initialize the grant for a particular process if it has not yet been allocated.
    - `Iter` - a helper type for iterating over all processes for a particular grant.

    In addition, it moves all use of `unsafe` to the creation of `AppliedGrant`s and implements everything else in terms of creation and access to `AppliedGrant`s.

3. Finally, it fixes #2135 by applying `TakeCell`-like semantics to the Grant's `enter` API. Entering a grant leaves behind a placeholder `0xffffffff` value in place of the pointer that means it's currently being used. Re-entrance to a grant checks for this value and will fail if it is present.
  

### Testing Strategy

So far tested on Imix and Hail with the `alarm` driver (which had reentrant code) and the UDP driver (which has reentrant code). Without fixing these capsules, both now fail, but can be fixed to work.

### TODO or Help Wanted

  * [ ] Document the grant module better
  * [ ] Find and fix other incorrectly written capsules

### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
