### PR TITLE
Makefile rule updated

### DIFF
--- a/boards/nano33ble/Makefile
+++ b/boards/nano33ble/Makefile
@@ -11,6 +11,6 @@ ifdef PORT
 endif
 
 # Upload the kernel using bossac
-.PHONY: program
-program: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin
+.PHONY: flash
+flash: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin
 	bossac $(FLAGS) -U -i -e -w $< -R

--- a/boards/nano33ble/README.md
+++ b/boards/nano33ble/README.md
@@ -37,17 +37,17 @@ on the board which then flashes the kernel. This requires that the bootloader be
 active. To force the board into bootloader mode, press the button on the board
 twice in rapid succession. You should see the yellow LED pulse on and off.
 
-At this point you should be able to simply run `make program` in this directory
+At this point you should be able to simply run `make flash` in this directory
 to install a fresh kernel.
 
 ```
-$ make program
+$ make flash
 ```
 
 You may need to specify the port like so:
 
 ```
-$ make program PORT=<serial port path>
+$ make flash PORT=<serial port path>
 ```
 
 ## Programming Applications


### PR DESCRIPTION
### Pull Request Overview

This pull request changes the makefile rule for flashing the kernel on the ```nano33ble``` to be in line with the other makefile semantics boards' makefiles.


### Testing Strategy

This pull request was tested by running the ```make flash``` command.


### TODO or Help Wanted

N/A

### Documentation Updated

-  [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
