### PR TITLE
generic components for UDP, UDP for nrf52840dk

### DIFF
--- a/boards/components/src/lib.rs
+++ b/boards/components/src/lib.rs
@@ -39,3 +39,5 @@ pub mod temperature;
 pub mod temperature_stm;
 pub mod test;
 pub mod touch;
+pub mod udp_driver;
+pub mod udp_mux;

--- a/boards/components/src/udp_driver.rs
+++ b/boards/components/src/udp_driver.rs
@@ -17,12 +17,6 @@
 //!     .finalize();
 //! ```
 
-// Author: Hudson Ayers <hayers@stanford.edu>
-// Author: Armin Namavari <arminn@stanford.edu>
-// Last Modified: 11/25/2019
-
-#![allow(dead_code)] // Components are intended to be conditionally included
-
 use capsules;
 use capsules::net::ipv6::ip_utils::IPAddr;
 use capsules::net::ipv6::ipv6_send::IP6SendStruct;
@@ -34,57 +28,80 @@ use capsules::net::udp::udp_recv::MuxUdpReceiver;
 use capsules::net::udp::udp_recv::UDPReceiver;
 use capsules::net::udp::udp_send::{MuxUdpSender, UDPSendStruct, UDPSender};
 use capsules::virtual_alarm::VirtualMuxAlarm;
-
-use kernel::{create_capability, static_init};
-
+use core::mem::MaybeUninit;
 use kernel;
 use kernel::capabilities;
 use kernel::capabilities::NetworkCapabilityCreationCapability;
 use kernel::component::Component;
-use sam4l;
+use kernel::hil::time::Alarm;
+use kernel::{create_capability, static_init, static_init_half};
 
 const UDP_HDR_SIZE: usize = 8;
-const PAYLOAD_LEN: usize = super::udp_mux::PAYLOAD_LEN;
+const MAX_PAYLOAD_LEN: usize = super::udp_mux::MAX_PAYLOAD_LEN;
 
-static mut DRIVER_BUF: [u8; PAYLOAD_LEN - UDP_HDR_SIZE] = [0; PAYLOAD_LEN - UDP_HDR_SIZE];
+static mut DRIVER_BUF: [u8; MAX_PAYLOAD_LEN - UDP_HDR_SIZE] = [0; MAX_PAYLOAD_LEN - UDP_HDR_SIZE];
 
-pub struct UDPDriverComponent {
+// Setup static space for the objects.
+#[macro_export]
+macro_rules! udp_driver_component_helper {
+    ($A:ty) => {{
+        use capsules::net::udp::udp_send::UDPSendStruct;
+        use core::mem::MaybeUninit;
+        static mut BUF0: MaybeUninit<
+            UDPSendStruct<
+                'static,
+                capsules::net::ipv6::ipv6_send::IP6SendStruct<
+                    'static,
+                    VirtualMuxAlarm<'static, $A>,
+                >,
+            >,
+        > = MaybeUninit::uninit();
+        (&mut BUF0,)
+    };};
+}
+
+pub struct UDPDriverComponent<A: Alarm<'static> + 'static> {
     board_kernel: &'static kernel::Kernel,
-    udp_send_mux: &'static MuxUdpSender<
-        'static,
-        IP6SendStruct<'static, VirtualMuxAlarm<'static, sam4l::ast::Ast<'static>>>,
-    >,
+    udp_send_mux:
+        &'static MuxUdpSender<'static, IP6SendStruct<'static, VirtualMuxAlarm<'static, A>>>,
     udp_recv_mux: &'static MuxUdpReceiver<'static>,
     port_table: &'static UdpPortManager,
     interface_list: &'static [IPAddr],
 }
 
-impl UDPDriverComponent {
+impl<A: Alarm<'static>> UDPDriverComponent<A> {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
         udp_send_mux: &'static MuxUdpSender<
             'static,
-            IP6SendStruct<'static, VirtualMuxAlarm<'static, sam4l::ast::Ast<'static>>>,
+            IP6SendStruct<'static, VirtualMuxAlarm<'static, A>>,
         >,
         udp_recv_mux: &'static MuxUdpReceiver<'static>,
         port_table: &'static UdpPortManager,
         interface_list: &'static [IPAddr],
-    ) -> UDPDriverComponent {
-        UDPDriverComponent {
-            board_kernel: board_kernel,
-            udp_send_mux: udp_send_mux,
-            udp_recv_mux: udp_recv_mux,
-            port_table: port_table,
-            interface_list: interface_list,
+    ) -> Self {
+        Self {
+            board_kernel,
+            udp_send_mux,
+            udp_recv_mux,
+            port_table,
+            interface_list,
         }
     }
 }
 
-impl Component for UDPDriverComponent {
-    type StaticInput = ();
+impl<A: Alarm<'static>> Component for UDPDriverComponent<A> {
+    type StaticInput = (
+        &'static mut MaybeUninit<
+            UDPSendStruct<
+                'static,
+                capsules::net::ipv6::ipv6_send::IP6SendStruct<'static, VirtualMuxAlarm<'static, A>>,
+            >,
+        >,
+    );
     type Output = &'static capsules::net::udp::UDPDriver<'static>;
 
-    unsafe fn finalize(self, _s: Self::StaticInput) -> Self::Output {
+    unsafe fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
         let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
         // TODO: change initialization below
         let create_cap = create_capability!(NetworkCapabilityCreationCapability);
@@ -92,13 +109,11 @@ impl Component for UDPDriverComponent {
             UdpVisibilityCapability,
             UdpVisibilityCapability::new(&create_cap)
         );
-        let udp_send = static_init!(
+        let udp_send = static_init_half!(
+            static_buffer.0,
             UDPSendStruct<
                 'static,
-                capsules::net::ipv6::ipv6_send::IP6SendStruct<
-                    'static,
-                    VirtualMuxAlarm<'static, sam4l::ast::Ast<'static>>,
-                >,
+                capsules::net::ipv6::ipv6_send::IP6SendStruct<'static, VirtualMuxAlarm<'static, A>>,
             >,
             UDPSendStruct::new(self.udp_send_mux, udp_vis)
         );
@@ -120,7 +135,7 @@ impl Component for UDPDriverComponent {
                 udp_send,
                 self.board_kernel.create_grant(&grant_cap),
                 self.interface_list,
-                PAYLOAD_LEN,
+                MAX_PAYLOAD_LEN,
                 self.port_table,
                 kernel::common::leasable_buffer::LeasableBuffer::new(&mut DRIVER_BUF),
                 &DRIVER_CAP,

--- a/boards/components/src/udp_mux.rs
+++ b/boards/components/src/udp_mux.rs
@@ -15,15 +15,13 @@
 //!        src_mac_from_serial_num,
 //!        local_ip_ifaces,
 //!        mux_alarm,
-//!        PAYLOAD_LEN,
+//!        MAX_PAYLOAD_LEN,
 //!    )
 //!    .finalize();
 //! ```
 
 // Author: Hudson Ayers <hayers@stanford.edu>
 // Last Modified: 5/21/2019
-
-#![allow(dead_code)] // Components are intended to be conditionally included
 
 use capsules;
 use capsules::ieee802154::device::MacDevice;
@@ -40,31 +38,30 @@ use capsules::net::udp::udp_port_table::{SocketBindingEntry, UdpPortManager, MAX
 use capsules::net::udp::udp_recv::MuxUdpReceiver;
 use capsules::net::udp::udp_send::MuxUdpSender;
 use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
+use core::mem::MaybeUninit;
 use kernel;
 use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
 use kernel::hil::radio;
 use kernel::hil::time::Alarm;
-use kernel::static_init;
+use kernel::{static_init, static_init_half};
 
-use sam4l;
-
-// The UDP stack requires exactly one of several packet buffers:
+// The UDP stack requires several packet buffers:
 //
-//   1. RF233_BUF: buffer the IP6_Sender uses to pass frames to the radio after fragmentation
+//   1. RADIO_BUF: buffer the IP6_Sender uses to pass frames to the radio after fragmentation
 //   2. SIXLOWPAN_RX_BUF: Buffer to hold full IP packets after they are decompressed by 6LoWPAN
-//   3. udp_dgram: The payload of the IP6_Packet, which holds full IP Packets before they are tx'd.
+//   3. UDP_DGRAM: The payload of the IP6_Packet, which holds full IP Packets before they are tx'd.
 //
 //   Additionally, every capsule using the stack needs an additional buffer to craft packets for
 //   tx which can then be passed to the MuxUdpSender for tx.
 
-static mut RF233_BUF: [u8; radio::MAX_BUF_SIZE] = [0x00; radio::MAX_BUF_SIZE];
+static mut RADIO_BUF: [u8; radio::MAX_BUF_SIZE] = [0x00; radio::MAX_BUF_SIZE];
 static mut SIXLOWPAN_RX_BUF: [u8; 1280] = [0x00; 1280];
 
-pub const PAYLOAD_LEN: usize = 200; //The max size UDP message that can be sent by userspace apps or capsules
+pub const MAX_PAYLOAD_LEN: usize = 200; //The max size UDP message that can be sent by userspace apps or capsules
 const UDP_HDR_SIZE: usize = 8;
-static mut UDP_DGRAM: [u8; PAYLOAD_LEN - UDP_HDR_SIZE] = [0; PAYLOAD_LEN - UDP_HDR_SIZE];
+static mut UDP_DGRAM: [u8; MAX_PAYLOAD_LEN - UDP_HDR_SIZE] = [0; MAX_PAYLOAD_LEN - UDP_HDR_SIZE];
 
 // Rather than require a data structure with 65535 slots (number of UDP ports), we
 // use a structure that can hold up to 16 port bindings. Any given capsule can bind
@@ -78,17 +75,55 @@ static mut UDP_DGRAM: [u8; PAYLOAD_LEN - UDP_HDR_SIZE] = [0; PAYLOAD_LEN - UDP_H
 static mut USED_KERNEL_PORTS: [Option<SocketBindingEntry>; MAX_NUM_BOUND_PORTS] =
     [None; MAX_NUM_BOUND_PORTS];
 
-pub struct UDPMuxComponent {
+// Setup static space for the objects.
+#[macro_export]
+macro_rules! udp_mux_component_helper {
+    ($A:ty) => {{
+        use capsules;
+        use capsules::net::sixlowpan::{sixlowpan_compression, sixlowpan_state};
+        use capsules::net::udp::udp_send::MuxUdpSender;
+        use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
+        use core::mem::MaybeUninit;
+        static mut BUF0: MaybeUninit<VirtualMuxAlarm<'static, $A>> = MaybeUninit::uninit();
+        static mut BUF1: MaybeUninit<capsules::ieee802154::virtual_mac::MacUser<'static>> =
+            MaybeUninit::uninit();
+        static mut BUF2: MaybeUninit<
+            sixlowpan_state::Sixlowpan<
+                'static,
+                VirtualMuxAlarm<'static, $A>,
+                sixlowpan_compression::Context,
+            >,
+        > = MaybeUninit::uninit();
+        static mut BUF3: MaybeUninit<sixlowpan_state::RxState<'static>> = MaybeUninit::uninit();
+        static mut BUF4: MaybeUninit<
+            capsules::net::ipv6::ipv6_send::IP6SendStruct<'static, VirtualMuxAlarm<'static, $A>>,
+        > = MaybeUninit::uninit();
+        static mut BUF5: MaybeUninit<
+            MuxUdpSender<
+                'static,
+                capsules::net::ipv6::ipv6_send::IP6SendStruct<
+                    'static,
+                    VirtualMuxAlarm<'static, $A>,
+                >,
+            >,
+        > = MaybeUninit::uninit();
+        (
+            &mut BUF0, &mut BUF1, &mut BUF2, &mut BUF3, &mut BUF4, &mut BUF5,
+        )
+    };};
+}
+
+pub struct UDPMuxComponent<A: Alarm<'static> + 'static> {
     mux_mac: &'static capsules::ieee802154::virtual_mac::MuxMac<'static>,
     ctx_pfix_len: u8,
     ctx_pfix: [u8; 16],
     dst_mac_addr: MacAddress,
     src_mac_addr: MacAddress,
     interface_list: &'static [IPAddr],
-    alarm_mux: &'static MuxAlarm<'static, sam4l::ast::Ast<'static>>,
+    alarm_mux: &'static MuxAlarm<'static, A>,
 }
 
-impl UDPMuxComponent {
+impl<A: Alarm<'static> + 'static> UDPMuxComponent<A> {
     pub fn new(
         mux_mac: &'static capsules::ieee802154::virtual_mac::MuxMac<'static>,
         ctx_pfix_len: u8,
@@ -96,38 +131,57 @@ impl UDPMuxComponent {
         dst_mac_addr: MacAddress,
         src_mac_addr: MacAddress,
         interface_list: &'static [IPAddr],
-        alarm: &'static MuxAlarm<'static, sam4l::ast::Ast<'static>>,
-    ) -> UDPMuxComponent {
-        UDPMuxComponent {
-            mux_mac: mux_mac,
-            ctx_pfix_len: ctx_pfix_len,
-            ctx_pfix: ctx_pfix,
-            dst_mac_addr: dst_mac_addr,
-            src_mac_addr: src_mac_addr,
-            interface_list: interface_list,
-            alarm_mux: alarm,
+        alarm_mux: &'static MuxAlarm<'static, A>,
+    ) -> Self {
+        Self {
+            mux_mac,
+            ctx_pfix_len,
+            ctx_pfix,
+            dst_mac_addr,
+            src_mac_addr,
+            interface_list,
+            alarm_mux,
         }
     }
 }
 
-impl Component for UDPMuxComponent {
-    type StaticInput = ();
-    type Output = (
-        &'static MuxUdpSender<
-            'static,
-            IP6SendStruct<'static, VirtualMuxAlarm<'static, sam4l::ast::Ast<'static>>>,
+impl<A: Alarm<'static> + 'static> Component for UDPMuxComponent<A> {
+    type StaticInput = (
+        &'static mut MaybeUninit<VirtualMuxAlarm<'static, A>>,
+        &'static mut MaybeUninit<capsules::ieee802154::virtual_mac::MacUser<'static>>,
+        &'static mut MaybeUninit<
+            sixlowpan_state::Sixlowpan<
+                'static,
+                VirtualMuxAlarm<'static, A>,
+                sixlowpan_compression::Context,
+            >,
         >,
+        &'static mut MaybeUninit<sixlowpan_state::RxState<'static>>,
+        &'static mut MaybeUninit<
+            capsules::net::ipv6::ipv6_send::IP6SendStruct<'static, VirtualMuxAlarm<'static, A>>,
+        >,
+        &'static mut MaybeUninit<
+            MuxUdpSender<
+                'static,
+                capsules::net::ipv6::ipv6_send::IP6SendStruct<'static, VirtualMuxAlarm<'static, A>>,
+            >,
+        >,
+    );
+    type Output = (
+        &'static MuxUdpSender<'static, IP6SendStruct<'static, VirtualMuxAlarm<'static, A>>>,
         &'static MuxUdpReceiver<'static>,
         &'static UdpPortManager,
     );
 
-    unsafe fn finalize(self, _s: Self::StaticInput) -> Self::Output {
-        let ipsender_virtual_alarm = static_init!(
-            VirtualMuxAlarm<'static, sam4l::ast::Ast>,
+    unsafe fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
+        let ipsender_virtual_alarm = static_init_half!(
+            static_buffer.0,
+            VirtualMuxAlarm<'static, A>,
             VirtualMuxAlarm::new(self.alarm_mux)
         );
 
-        let udp_mac = static_init!(
+        let udp_mac = static_init_half!(
+            static_buffer.1,
             capsules::ieee802154::virtual_mac::MacUser<'static>,
             capsules::ieee802154::virtual_mac::MacUser::new(self.mux_mac)
         );
@@ -142,10 +196,11 @@ impl Component for UDPMuxComponent {
             IpVisibilityCapability::new(&create_cap)
         );
 
-        let sixlowpan = static_init!(
+        let sixlowpan = static_init_half!(
+            static_buffer.2,
             sixlowpan_state::Sixlowpan<
                 'static,
-                sam4l::ast::Ast<'static>,
+                VirtualMuxAlarm<'static, A>,
                 sixlowpan_compression::Context,
             >,
             sixlowpan_state::Sixlowpan::new(
@@ -155,13 +210,14 @@ impl Component for UDPMuxComponent {
                     id: 0,
                     compress: false,
                 },
-                &sam4l::ast::AST
+                ipsender_virtual_alarm, // OK to reuse bc only used to get time, not set alarms
             )
         );
 
         let sixlowpan_state = sixlowpan as &dyn sixlowpan_state::SixlowpanState;
         let sixlowpan_tx = sixlowpan_state::TxState::new(sixlowpan_state);
-        let default_rx_state = static_init!(
+        let default_rx_state = static_init_half!(
+            static_buffer.3,
             sixlowpan_state::RxState<'static>,
             sixlowpan_state::RxState::new(&mut SIXLOWPAN_RX_BUF)
         );
@@ -181,15 +237,13 @@ impl Component for UDPMuxComponent {
         // of all packets being routed via a single gateway router, but doesn't work
         // if multiple senders want to send to different addresses on a local network.
         // This will be fixed once we have an ipv6_nd cache mapping IP addresses to dst macs
-        let ip_send = static_init!(
-            capsules::net::ipv6::ipv6_send::IP6SendStruct<
-                'static,
-                VirtualMuxAlarm<'static, sam4l::ast::Ast>,
-            >,
+        let ip_send = static_init_half!(
+            static_buffer.4,
+            capsules::net::ipv6::ipv6_send::IP6SendStruct<'static, VirtualMuxAlarm<'static, A>>,
             capsules::net::ipv6::ipv6_send::IP6SendStruct::new(
                 ip6_dg,
                 ipsender_virtual_alarm,
-                &mut RF233_BUF,
+                &mut RADIO_BUF,
                 sixlowpan_tx,
                 udp_mac,
                 self.dst_mac_addr,
@@ -214,13 +268,11 @@ impl Component for UDPMuxComponent {
         let udp_recv_mux = static_init!(MuxUdpReceiver<'static>, MuxUdpReceiver::new());
         ip_receive.set_client(udp_recv_mux);
 
-        let udp_send_mux = static_init!(
+        let udp_send_mux = static_init_half!(
+            static_buffer.5,
             MuxUdpSender<
                 'static,
-                capsules::net::ipv6::ipv6_send::IP6SendStruct<
-                    'static,
-                    VirtualMuxAlarm<'static, sam4l::ast::Ast<'static>>,
-                >,
+                capsules::net::ipv6::ipv6_send::IP6SendStruct<'static, VirtualMuxAlarm<'static, A>>,
             >,
             MuxUdpSender::new(ip_send)
         );

--- a/boards/imix/src/imix_components/mod.rs
+++ b/boards/imix/src/imix_components/mod.rs
@@ -2,13 +2,9 @@ pub mod adc;
 pub mod fxos8700;
 pub mod rf233;
 pub mod test;
-pub mod udp_driver;
-pub mod udp_mux;
 pub mod usb;
 
 pub use self::adc::AdcComponent;
 pub use self::fxos8700::NineDofComponent;
 pub use self::rf233::RF233Component;
-pub use self::udp_driver::UDPDriverComponent;
-pub use self::udp_mux::UDPMuxComponent;
 pub use self::usb::UsbComponent;

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -46,8 +46,6 @@ use components::spi::{SpiComponent, SpiSyscallComponent};
 use imix_components::adc::AdcComponent;
 use imix_components::fxos8700::NineDofComponent;
 use imix_components::rf233::RF233Component;
-use imix_components::udp_driver::UDPDriverComponent;
-use imix_components::udp_mux::UDPMuxComponent;
 use imix_components::usb::UsbComponent;
 
 /// Support routines for debugging I/O.
@@ -464,7 +462,7 @@ pub unsafe fn reset_handler() {
         ]
     );
 
-    let (udp_send_mux, udp_recv_mux, udp_port_table) = UDPMuxComponent::new(
+    let (udp_send_mux, udp_recv_mux, udp_port_table) = components::udp_mux::UDPMuxComponent::new(
         mux_mac,
         DEFAULT_CTX_PREFIX_LEN,
         DEFAULT_CTX_PREFIX,
@@ -474,17 +472,17 @@ pub unsafe fn reset_handler() {
         local_ip_ifaces,
         mux_alarm,
     )
-    .finalize(());
+    .finalize(components::udp_mux_component_helper!(sam4l::ast::Ast));
 
     // UDP driver initialization happens here
-    let udp_driver = UDPDriverComponent::new(
+    let udp_driver = components::udp_driver::UDPDriverComponent::new(
         board_kernel,
         udp_send_mux,
         udp_recv_mux,
         udp_port_table,
         local_ip_ifaces,
     )
-    .finalize(());
+    .finalize(components::udp_driver_component_helper!(sam4l::ast::Ast));
 
     let imix = Imix {
         pconsole,

--- a/boards/imix/src/test/udp_lowpan_test.rs
+++ b/boards/imix/src/test/udp_lowpan_test.rs
@@ -141,7 +141,7 @@ pub const TEST_LOOP: bool = false;
 static mut UDP_PAYLOAD: [u8; PAYLOAD_LEN] = [0; PAYLOAD_LEN]; //Becomes payload of UDP packet
 
 const UDP_HDR_SIZE: usize = 8;
-const PAYLOAD_LEN: usize = super::super::imix_components::udp_mux::PAYLOAD_LEN;
+const PAYLOAD_LEN: usize = components::udp_mux::MAX_PAYLOAD_LEN;
 static mut UDP_PAYLOAD1: [u8; PAYLOAD_LEN - UDP_HDR_SIZE] = [0; PAYLOAD_LEN - UDP_HDR_SIZE];
 static mut UDP_PAYLOAD2: [u8; PAYLOAD_LEN - UDP_HDR_SIZE] = [0; PAYLOAD_LEN - UDP_HDR_SIZE];
 


### PR DESCRIPTION
### Pull Request Overview

This pull request replaces the sam4l specific components for the UDP mux and UDP userspace driver with generic components. It then uses these generic components to add the UDP/IP networking stack to the nrf52840dk by default. 


### Testing Strategy

This pull request was tested by running the `udp_send` and `udp_rx` tests to exchange UDP packets between an nrf52840dk and an Imix, and vice versa.


### TODO or Help Wanted

N/A

### Documentation Updated

- [x] No updates are required.

### Formatting

- [x] Ran `make prepush`.
