### PR TITLE
capsules: fxo: need to enable both mag and accel

### DIFF
--- a/capsules/src/fxos8700cq.rs
+++ b/capsules/src/fxos8700cq.rs
@@ -219,7 +219,8 @@ impl<'a> Fxos8700cq<'a> {
             self.i2c.enable();
             // Configure the magnetometer.
             buf[0] = Registers::MCtrlReg1 as u8;
-            buf[1] = 0b00100001; // Enable magnetometer and one-shot read.
+            // Enable both accelerometer and magnetometer, and set one-shot read.
+            buf[1] = 0b00100011;
             self.i2c.write(buf, 2);
             self.state.set(State::ReadMagStart);
         });


### PR DESCRIPTION
Enabling just the magnetometer causes the accelerometer to stop working.
We never tested the magnetometer at the same time before and never
noticed this.




### Testing Strategy

This pull request was tested by running sensors app on hail.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
