### PR TITLE
Board based instantiation of chip drivers and interrupt mappings: Arty_e21

### DIFF
--- a/boards/arty_e21/src/io.rs
+++ b/boards/arty_e21/src/io.rs
@@ -7,6 +7,7 @@ use kernel::debug::IoWrite;
 use kernel::hil::gpio;
 use kernel::hil::led;
 use rv32i;
+use sifive;
 
 use crate::CHIP;
 use crate::PROCESSES;
@@ -24,9 +25,7 @@ impl Write for Writer {
 
 impl IoWrite for Writer {
     fn write(&mut self, buf: &[u8]) {
-        unsafe {
-            arty_e21_chip::uart::UART0.transmit_sync(buf);
-        }
+        sifive::uart::Uart::new(arty_e21_chip::uart::UART0_BASE, 32_000_000).transmit_sync(buf);
     }
 }
 
@@ -36,15 +35,32 @@ impl IoWrite for Writer {
 #[panic_handler]
 pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
     // turn off the non panic leds, just in case
-    let led_green = &arty_e21_chip::gpio::PORT[1];
+    let led_green = &sifive::gpio::GpioPin::new(
+        arty_e21_chip::gpio::GPIO0_BASE,
+        sifive::gpio::pins::pin1,
+        sifive::gpio::pins::pin1::SET,
+        sifive::gpio::pins::pin1::CLEAR,
+    );
     gpio::Pin::make_output(led_green);
     gpio::Pin::clear(led_green);
 
-    let led_blue = &arty_e21_chip::gpio::PORT[0];
+    let led_blue = &sifive::gpio::GpioPin::new(
+        arty_e21_chip::gpio::GPIO0_BASE,
+        sifive::gpio::pins::pin0,
+        sifive::gpio::pins::pin0::SET,
+        sifive::gpio::pins::pin0::CLEAR,
+    );
     gpio::Pin::make_output(led_blue);
     gpio::Pin::clear(led_blue);
 
-    let led_red = &mut led::LedHigh::new(&mut arty_e21_chip::gpio::PORT[2]);
+    let led_red_pin = &mut sifive::gpio::GpioPin::new(
+        arty_e21_chip::gpio::GPIO0_BASE,
+        sifive::gpio::pins::pin2,
+        sifive::gpio::pins::pin2::SET,
+        sifive::gpio::pins::pin2::CLEAR,
+    );
+
+    let led_red = &mut led::LedHigh::new(led_red_pin);
     let writer = &mut WRITER;
     debug::panic(
         &mut [led_red],

--- a/boards/arty_e21/src/main.rs
+++ b/boards/arty_e21/src/main.rs
@@ -6,6 +6,7 @@
 #![cfg_attr(not(doc), no_main)]
 #![feature(const_fn, const_in_array_repeat_expressions)]
 
+use arty_e21_chip::chip::ArtyExxDefaultPeripherals;
 use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use kernel::capabilities;
 use kernel::common::dynamic_deferred_call::{DynamicDeferredCall, DynamicDeferredCallClientState};
@@ -34,7 +35,7 @@ static mut PROCESSES: [Option<&'static dyn kernel::procs::ProcessType>; NUM_PROC
     [None, None, None, None];
 
 // Reference to the chip for panic dumps.
-static mut CHIP: Option<&'static arty_e21_chip::chip::ArtyExx> = None;
+static mut CHIP: Option<&'static arty_e21_chip::chip::ArtyExx<ArtyExxDefaultPeripherals>> = None;
 
 /// Dummy buffer that causes the linker to reserve enough space for the stack.
 #[no_mangle]
@@ -84,9 +85,11 @@ pub unsafe fn reset_handler() {
     // Basic setup of the platform.
     rv32i::init_memory();
 
+    let peripherals = static_init!(ArtyExxDefaultPeripherals, ArtyExxDefaultPeripherals::new());
+
     let chip = static_init!(
-        arty_e21_chip::chip::ArtyExx,
-        arty_e21_chip::chip::ArtyExx::new()
+        arty_e21_chip::chip::ArtyExx<ArtyExxDefaultPeripherals>,
+        arty_e21_chip::chip::ArtyExx::new(peripherals)
     );
     CHIP = Some(chip);
     chip.initialize();
@@ -106,14 +109,14 @@ pub unsafe fn reset_handler() {
 
     // Configure kernel debug gpios as early as possible
     kernel::debug::assign_gpios(
-        Some(&arty_e21_chip::gpio::PORT[0]), // Blue
-        Some(&arty_e21_chip::gpio::PORT[1]), // Green
-        Some(&arty_e21_chip::gpio::PORT[8]),
+        Some(&peripherals.gpio_port[0]), // Blue
+        Some(&peripherals.gpio_port[1]), // Green
+        Some(&peripherals.gpio_port[8]),
     );
 
     // Create a shared UART channel for the console and for kernel debug.
     let uart_mux = components::console::UartMuxComponent::new(
-        &arty_e21_chip::uart::UART0,
+        &peripherals.uart0,
         115200,
         dynamic_deferred_caller,
     )
@@ -125,9 +128,9 @@ pub unsafe fn reset_handler() {
     // alarm.
     let mux_alarm = static_init!(
         MuxAlarm<'static, rv32i::machine_timer::MachineTimer>,
-        MuxAlarm::new(&arty_e21_chip::timer::MACHINETIMER)
+        MuxAlarm::new(&peripherals.machinetimer)
     );
-    hil::time::Alarm::set_alarm_client(&arty_e21_chip::timer::MACHINETIMER, mux_alarm);
+    hil::time::Alarm::set_alarm_client(&peripherals.machinetimer, mux_alarm);
 
     // Alarm
     let alarm = components::alarm::AlarmDriverComponent::new(board_kernel, mux_alarm).finalize(
@@ -151,17 +154,17 @@ pub unsafe fn reset_handler() {
         arty_e21_chip::gpio::GpioPin,
         (
             // Red
-            &arty_e21_chip::gpio::PORT[2],
+            &peripherals.gpio_port[2],
             kernel::hil::gpio::ActivationMode::ActiveHigh
         ),
         (
             // Green
-            &arty_e21_chip::gpio::PORT[1],
+            &peripherals.gpio_port[1],
             kernel::hil::gpio::ActivationMode::ActiveHigh
         ),
         (
             // Blue
-            &arty_e21_chip::gpio::PORT[0],
+            &peripherals.gpio_port[0],
             kernel::hil::gpio::ActivationMode::ActiveHigh
         )
     ))
@@ -173,7 +176,7 @@ pub unsafe fn reset_handler() {
         components::button_component_helper!(
             arty_e21_chip::gpio::GpioPin,
             (
-                &arty_e21_chip::gpio::PORT[4],
+                &peripherals.gpio_port[4],
                 kernel::hil::gpio::ActivationMode::ActiveHigh,
                 kernel::hil::gpio::FloatingState::PullNone
             )
@@ -188,9 +191,9 @@ pub unsafe fn reset_handler() {
         board_kernel,
         components::gpio_component_helper!(
             arty_e21_chip::gpio::GpioPin,
-            0 => &arty_e21_chip::gpio::PORT[7],
-            1 => &arty_e21_chip::gpio::PORT[5],
-            2 => &arty_e21_chip::gpio::PORT[6]
+            0 => &peripherals.gpio_port[7],
+            1 => &peripherals.gpio_port[5],
+            2 => &peripherals.gpio_port[6]
         ),
     )
     .finalize(components::gpio_component_buf!(
@@ -211,7 +214,7 @@ pub unsafe fn reset_handler() {
     // Create virtual device for kernel debug.
     components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
 
-    // arty_e21_chip::uart::UART0.initialize_gpio_pins(&arty_e21_chip::gpio::PORT[17], &arty_e21_chip::gpio::PORT[16]);
+    // arty_e21_chip::uart::UART0.initialize_gpio_pins(&peripherals.gpio_port[17], &peripherals.gpio_port[16]);
 
     debug!("Initialization complete. Entering main loop.");
 

--- a/chips/arty_e21_chip/src/gpio.rs
+++ b/chips/arty_e21_chip/src/gpio.rs
@@ -4,7 +4,7 @@ use kernel::common::StaticRef;
 pub use sifive::gpio::GpioPin;
 use sifive::gpio::{pins, GpioRegisters};
 
-const GPIO0_BASE: StaticRef<GpioRegisters> =
+pub const GPIO0_BASE: StaticRef<GpioRegisters> =
     unsafe { StaticRef::new(0x2000_2000 as *const GpioRegisters) };
 
 pub struct Port<'a> {
@@ -25,53 +25,57 @@ impl<'a> IndexMut<usize> for Port<'a> {
     }
 }
 
-pub static mut PORT: Port = Port {
-    pins: [
-        GpioPin::new(GPIO0_BASE, pins::pin0, pins::pin0::SET, pins::pin0::CLEAR),
-        GpioPin::new(GPIO0_BASE, pins::pin1, pins::pin1::SET, pins::pin1::CLEAR),
-        GpioPin::new(GPIO0_BASE, pins::pin2, pins::pin2::SET, pins::pin2::CLEAR),
-        GpioPin::new(GPIO0_BASE, pins::pin3, pins::pin3::SET, pins::pin3::CLEAR),
-        GpioPin::new(GPIO0_BASE, pins::pin4, pins::pin4::SET, pins::pin4::CLEAR),
-        GpioPin::new(GPIO0_BASE, pins::pin5, pins::pin5::SET, pins::pin5::CLEAR),
-        GpioPin::new(GPIO0_BASE, pins::pin6, pins::pin6::SET, pins::pin6::CLEAR),
-        GpioPin::new(GPIO0_BASE, pins::pin7, pins::pin7::SET, pins::pin7::CLEAR),
-        GpioPin::new(GPIO0_BASE, pins::pin8, pins::pin8::SET, pins::pin8::CLEAR),
-        GpioPin::new(GPIO0_BASE, pins::pin9, pins::pin9::SET, pins::pin9::CLEAR),
-        GpioPin::new(
-            GPIO0_BASE,
-            pins::pin10,
-            pins::pin10::SET,
-            pins::pin10::CLEAR,
-        ),
-        GpioPin::new(
-            GPIO0_BASE,
-            pins::pin11,
-            pins::pin11::SET,
-            pins::pin11::CLEAR,
-        ),
-        GpioPin::new(
-            GPIO0_BASE,
-            pins::pin12,
-            pins::pin12::SET,
-            pins::pin12::CLEAR,
-        ),
-        GpioPin::new(
-            GPIO0_BASE,
-            pins::pin13,
-            pins::pin13::SET,
-            pins::pin13::CLEAR,
-        ),
-        GpioPin::new(
-            GPIO0_BASE,
-            pins::pin14,
-            pins::pin14::SET,
-            pins::pin14::CLEAR,
-        ),
-        GpioPin::new(
-            GPIO0_BASE,
-            pins::pin15,
-            pins::pin15::SET,
-            pins::pin15::CLEAR,
-        ),
-    ],
-};
+impl<'a> Port<'a> {
+    pub fn new() -> Self {
+        Self {
+            pins: [
+                GpioPin::new(GPIO0_BASE, pins::pin0, pins::pin0::SET, pins::pin0::CLEAR),
+                GpioPin::new(GPIO0_BASE, pins::pin1, pins::pin1::SET, pins::pin1::CLEAR),
+                GpioPin::new(GPIO0_BASE, pins::pin2, pins::pin2::SET, pins::pin2::CLEAR),
+                GpioPin::new(GPIO0_BASE, pins::pin3, pins::pin3::SET, pins::pin3::CLEAR),
+                GpioPin::new(GPIO0_BASE, pins::pin4, pins::pin4::SET, pins::pin4::CLEAR),
+                GpioPin::new(GPIO0_BASE, pins::pin5, pins::pin5::SET, pins::pin5::CLEAR),
+                GpioPin::new(GPIO0_BASE, pins::pin6, pins::pin6::SET, pins::pin6::CLEAR),
+                GpioPin::new(GPIO0_BASE, pins::pin7, pins::pin7::SET, pins::pin7::CLEAR),
+                GpioPin::new(GPIO0_BASE, pins::pin8, pins::pin8::SET, pins::pin8::CLEAR),
+                GpioPin::new(GPIO0_BASE, pins::pin9, pins::pin9::SET, pins::pin9::CLEAR),
+                GpioPin::new(
+                    GPIO0_BASE,
+                    pins::pin10,
+                    pins::pin10::SET,
+                    pins::pin10::CLEAR,
+                ),
+                GpioPin::new(
+                    GPIO0_BASE,
+                    pins::pin11,
+                    pins::pin11::SET,
+                    pins::pin11::CLEAR,
+                ),
+                GpioPin::new(
+                    GPIO0_BASE,
+                    pins::pin12,
+                    pins::pin12::SET,
+                    pins::pin12::CLEAR,
+                ),
+                GpioPin::new(
+                    GPIO0_BASE,
+                    pins::pin13,
+                    pins::pin13::SET,
+                    pins::pin13::CLEAR,
+                ),
+                GpioPin::new(
+                    GPIO0_BASE,
+                    pins::pin14,
+                    pins::pin14::SET,
+                    pins::pin14::CLEAR,
+                ),
+                GpioPin::new(
+                    GPIO0_BASE,
+                    pins::pin15,
+                    pins::pin15::SET,
+                    pins::pin15::CLEAR,
+                ),
+            ],
+        }
+    }
+}

--- a/chips/arty_e21_chip/src/timer.rs
+++ b/chips/arty_e21_chip/src/timer.rs
@@ -1,9 +1,7 @@
 //! Machine Timer instantiation.
 
 use kernel::common::StaticRef;
-use rv32i::machine_timer::{MachineTimer, MachineTimerRegisters};
+use rv32i::machine_timer::MachineTimerRegisters;
 
-pub static mut MACHINETIMER: MachineTimer = MachineTimer::new(MTIME_BASE);
-
-const MTIME_BASE: StaticRef<MachineTimerRegisters> =
+pub const MTIME_BASE: StaticRef<MachineTimerRegisters> =
     unsafe { StaticRef::new(0x0200_0000 as *const MachineTimerRegisters) };

--- a/chips/arty_e21_chip/src/uart.rs
+++ b/chips/arty_e21_chip/src/uart.rs
@@ -1,7 +1,5 @@
 use kernel::common::StaticRef;
-use sifive::uart::{Uart, UartRegisters};
+use sifive::uart::UartRegisters;
 
-pub static mut UART0: Uart = Uart::new(UART0_BASE, 32_000_000);
-
-const UART0_BASE: StaticRef<UartRegisters> =
+pub const UART0_BASE: StaticRef<UartRegisters> =
     unsafe { StaticRef::new(0x2000_0000 as *const UartRegisters) };

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -116,7 +116,7 @@ pub use crate::grant::Grant;
 pub use crate::mem::{AppSlice, Private, Shared};
 pub use crate::platform::scheduler_timer::{SchedulerTimer, VirtualSchedulerTimer};
 pub use crate::platform::watchdog;
-pub use crate::platform::{mpu, Chip, Platform};
+pub use crate::platform::{mpu, Chip, InterruptService, Platform};
 pub use crate::platform::{ClockInterface, NoClockControl, NO_CLOCK_CONTROL};
 pub use crate::returncode::ReturnCode;
 pub use crate::sched::cooperative::{CoopProcessNode, CooperativeSched};

--- a/kernel/src/platform/mod.rs
+++ b/kernel/src/platform/mod.rs
@@ -139,6 +139,51 @@ pub trait Chip {
     unsafe fn print_state(&self, writer: &mut dyn Write);
 }
 
+/// Interface for handling interrupts and deferred calls on a hardware chip.
+///
+/// Each board must construct an implementation of this trait to handle specific
+/// interrupts. When an interrupt (identified by number) has triggered and
+/// should be handled, the implementation of this trait will be called with the
+/// interrupt number. The implementation can then handle the interrupt, or
+/// return `false` to signify that it does not know how to handle the interrupt.
+///
+/// This functionality is given this `InterruptService` interface so that
+/// multiple objects can be chained together to handle interrupts for a chip.
+/// This is useful for code organization and removing the need for duplication
+/// when multiple variations of a specific microcontroller exist. Then a shared,
+/// base object can handle most interrupts, and variation-specific objects can
+/// handle the variation-specific interrupts.
+///
+/// To simplify structuring the Rust code when using `InterruptService`, the
+/// interrupt number should be passed "top-down". That is, an interrupt to be
+/// handled will first be passed to the `InterruptService` object that is most
+/// specific. If that object cannot handle the interrupt, then it should
+/// maintain a reference to the second most specific object, and return by
+/// calling to that object to handle the interrupt. This continues until the
+/// base object handles the interrupt or decides that the chip does not know how
+/// to handle the interrupt. For example, consider a `nRF52840` chip that
+/// depends on the `nRF52` crate. If both have specific interrupts they
+/// know how to handle, the flow would look like:
+///
+/// ```ignore
+///           +---->nrf52840_peripherals
+///           |        |
+///           |        |
+///           |        v
+/// kernel-->nrf52     nrf52_peripherals
+/// ```
+/// where the kernel instructs the `nrf52` crate to handle interrupts, and if
+/// there is an interrupt ready then that interrupt is passed through the InterruptService objects
+/// until something can service it.
+pub trait InterruptService<T> {
+    /// Service an interrupt, if supported by this chip. If this interrupt number is not supported,
+    /// return false.
+    unsafe fn service_interrupt(&self, interrupt: u32) -> bool;
+
+    /// Service a deferred call. If this task is not supported, return false.
+    unsafe fn service_deferred_call(&self, task: T) -> bool;
+}
+
 /// Generic operations that clock-like things are expected to support.
 pub trait ClockInterface {
     fn is_enabled(&self) -> bool;


### PR DESCRIPTION
### Pull Request Overview

This pull request applies the new, non-global based peripheral design to the arty_e21 chip/board. Rather than apply this on top of #2069 / #2084 , the first commit just duplicates the kernel changes from the original PR, so that it is easy to review only the arty_e21 changes in this PR.

I am just working through all of the Tock chips as I have time, not sure what the merge strategy is for each of these at this point.


### Testing Strategy

This pull request was tested by compiling, hardware testing is needed to verify I didn't break anything.


### TODO or Help Wanted

N/A

### Documentation Updated

- [x] no updates are required.

### Formatting

- [x] Ran `make prepush`.
