### PR TITLE
tools/board-runner: Add automated OpenTitan and Apollo3 tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,10 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+      - name: Install dependencies
+        continue-on-error: true
+        run: |
+          sudo apt install libudev-dev
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
       - name: ci-job-libraries

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ members = [
 ]
 exclude = [
     "tools/alert_codes",
+    "tools/board-runner",
     "tools/qemu-runner",
     "tools/sha256sum",
     "tools/usb/bulk-echo",

--- a/Makefile
+++ b/Makefile
@@ -549,7 +549,7 @@ ci-job-qemu: ci-setup-qemu
 .PHONY: board-release-test
 board-release-test:
 	@cd tools/board-runner;\
-		cargo run
+		cargo run ${TARGET}
 
 
 ### ci-runner-netlify jobs:

--- a/Makefile
+++ b/Makefile
@@ -546,6 +546,10 @@ endef
 ci-job-qemu: ci-setup-qemu
 	$(if $(CI_JOB_QEMU),$(call ci_job_qemu))
 
+.PHONY: board-release-test
+board-release-test:
+	@cd tools/board-runner;\
+		cargo run
 
 
 ### ci-runner-netlify jobs:

--- a/boards/redboard_artemis_nano/Makefile
+++ b/boards/redboard_artemis_nano/Makefile
@@ -16,3 +16,7 @@ flash: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin
 .PHONY: flash-debug
 flash-debug: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/debug/$(PLATFORM).bin
 	python ambiq/ambiq_bin2board.py --bin $< --load-address-blob 0x20000 -b 115200 -port $(PORT) -r 2 -v --magic-num 0xCB --version 0x0 --load-address-wired 0xc000 -i 6 --options 0x1
+
+.PHONY: flash-app
+flash-app:
+	python ambiq/ambiq_bin2board.py --bin $(APP) --load-address-blob 0x20000 -b 115200 -port $(PORT) -r 2 -v --magic-num 0xCB --version 0x0 --load-address-wired 0x40000 -i 6 --options 0x1

--- a/tools/board-runner/Cargo.toml
+++ b/tools/board-runner/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "board-runner"
+version = "0.1.0"
+authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+edition = "2018"
+
+[dependencies]
+rexpect = "0.4"
+serialport = "3.3.0"

--- a/tools/board-runner/README.md
+++ b/tools/board-runner/README.md
@@ -15,3 +15,15 @@ OPENTITAN_TREE=<opentitan_repo> LIBTOCK_C_TREE=<libtock_c_repo> TARGET=opentitan
 ```
 
 Where `opentitan_repo` and `libtock_c_repo` point to the top level directory of the corresponding repos. You will need to make sure that the OpenTitan spiflash command has been built in the OpenTitan repo and that the c apps have been built in the libtock-c repo.
+
+### Redboard Artemis Nano
+
+This can be used to perform Tock release testing on the Sparkfun Redboard Artemis Nano board.
+
+This assumes that the ARtemis Nano serial console is available on the machines first serial port (`/dev/ttyUSB0` for Unix systems). The tests can be run from the top level of the Tock directory with the following command
+
+```shell
+LIBTOCK_C_TREE=<libtock_c_repo> TARGET=artemis_nano make board-release-test
+```
+
+Where `libtock_c_repo` points to the top level directory of the corresponding libtock-c repo.

--- a/tools/board-runner/README.md
+++ b/tools/board-runner/README.md
@@ -1,0 +1,17 @@
+# Tock Board Runner
+
+This is a Rust program that uses rexpect to test Tock on different boards. The goal of this is to automated the testing, currently it still requires manual steps though.
+
+## Supported Boards
+
+### OpenTitan
+
+This can be used to perform Tock release testing on the OpenTitan board.
+
+This assumes that the OpenTitan serial console is available on the machines first serial port (`/dev/ttyUSB0` for Unix systems). The tests can be run from the top level of the Tock direcotry with the following command
+
+```shell
+OPENTITAN_TREE=<opentitan_repo> LIBTOCK_C_TREE=<libtock_c_repo> TARGET=opentitan make board-release-test
+```
+
+Where `opentitan_repo` and `libtock_c_repo` point to the top level directory of the corresponding repos. You will need to make sure that the OpenTitan spiflash command has been built in the OpenTitan repo and that the c apps have been built in the libtock-c repo.

--- a/tools/board-runner/src/artemis_nano.rs
+++ b/tools/board-runner/src/artemis_nano.rs
@@ -1,0 +1,350 @@
+use rexpect::errors::Error;
+use rexpect::spawn_stream;
+use serialport::prelude::*;
+use serialport::SerialPortSettings;
+use std::env;
+use std::fs::OpenOptions;
+use std::process::{Command, Stdio};
+use std::time::Duration;
+use std::{thread, time};
+
+fn artemis_nano_flash(
+    app_name: &str,
+) -> Result<rexpect::session::StreamSession<std::boxed::Box<dyn serialport::SerialPort>>, Error> {
+    let s = SerialPortSettings {
+        baud_rate: 115200,
+        data_bits: DataBits::Eight,
+        flow_control: FlowControl::None,
+        parity: Parity::None,
+        stop_bits: StopBits::One,
+        timeout: Duration::from_millis(1000),
+    };
+
+    // Flash the app
+    let mut build = Command::new("make")
+        .arg("-C")
+        .arg("../../boards/redboard_artemis_nano")
+        .arg(format!("APP={}", app_name))
+        .arg("flash-app")
+        .stdout(Stdio::null())
+        .spawn()
+        .expect("failed to spawn build");
+    assert!(build.wait().unwrap().success());
+
+    // Open the first serialport available.
+    let port_name = &serialport::available_ports().expect("No serial port")[0].port_name;
+    println!("Connecting to redboard_artemis_nano port: {:?}", port_name);
+    let port = serialport::open_with_settings(port_name, &s).expect("Failed to open serial port");
+
+    // Clone the port
+    let port_clone = port.try_clone().expect("Failed to clone");
+
+    // Create the Rexpect instance
+    let mut p = spawn_stream(port, port_clone, Some(2000));
+
+    // Make sure the image is flashed
+    p.exp_string("Apollo3 chip revision: B")?;
+
+    Ok(p)
+}
+
+fn artemis_nano_c_hello() -> Result<(), Error> {
+    let app = format!(
+        "{}/{}",
+        env::var("LIBTOCK_C_TREE").unwrap(),
+        "examples/c_hello/build/cortex-m4/cortex-m4.tbf"
+    );
+    let mut p = artemis_nano_flash(&app).unwrap();
+
+    p.exp_string("Hello World!")?;
+
+    Ok(())
+}
+
+fn artemis_nano_blink() -> Result<(), Error> {
+    let app = format!(
+        "{}/{}",
+        env::var("LIBTOCK_C_TREE").unwrap(),
+        "examples/blink/build/cortex-m4/cortex-m4.tbf"
+    );
+    let _p = artemis_nano_flash(&app).unwrap();
+
+    println!("Make sure the LEDs are blinking");
+
+    let timeout = time::Duration::from_secs(10);
+    thread::sleep(timeout);
+
+    Ok(())
+}
+
+#[allow(dead_code)]
+fn artemis_nano_sensors() -> Result<(), Error> {
+    let app = format!(
+        "{}/{}",
+        env::var("LIBTOCK_C_TREE").unwrap(),
+        "examples/sensors/build/cortex-m4/cortex-m4.tbf"
+    );
+    let mut p = artemis_nano_flash(&app).unwrap();
+
+    p.exp_string("Hello World!")?;
+
+    Ok(())
+}
+
+#[allow(dead_code)]
+fn artemis_nano_c_hello_and_printf_long() -> Result<(), Error> {
+    let app = OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open("app")
+        .unwrap();
+
+    let mut build = Command::new("cat")
+        .arg(format!(
+            "{}/{}",
+            env::var("LIBTOCK_C_TREE").unwrap(),
+            "examples/c_hello/build/cortex-m4/cortex-m4.tbf"
+        ))
+        .stdout(app)
+        .spawn()
+        .expect("failed to spawn build");
+    assert!(build.wait().unwrap().success());
+
+    let app = OpenOptions::new()
+        .append(true)
+        .create(false)
+        .open("app")
+        .unwrap();
+
+    let mut build = Command::new("cat")
+        .arg(format!(
+            "{}/{}",
+            env::var("LIBTOCK_C_TREE").unwrap(),
+            "examples/tests/printf_long/build/cortex-m4/cortex-m4.tbf"
+        ))
+        .stdout(app)
+        .spawn()
+        .expect("failed to spawn build");
+    assert!(build.wait().unwrap().success());
+
+    let mut p = artemis_nano_flash("../../tools/board-runner/app").unwrap();
+
+    p.exp_string("Hello World!")?;
+    p.exp_string("Hi welcome to Tock. This test makes sure that a greater than 64 byte message can be printed.")?;
+    p.exp_string("And a short message.")?;
+
+    Ok(())
+}
+
+fn artemis_nano_blink_and_c_hello_and_buttons() -> Result<(), Error> {
+    let app = OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open("app")
+        .unwrap();
+
+    let mut build = Command::new("cat")
+        .arg(format!(
+            "{}/{}",
+            env::var("LIBTOCK_C_TREE").unwrap(),
+            "examples/blink/build/cortex-m4/cortex-m4.tbf"
+        ))
+        .stdout(app)
+        .spawn()
+        .expect("failed to spawn build");
+    assert!(build.wait().unwrap().success());
+
+    let app = OpenOptions::new()
+        .append(true)
+        .create(false)
+        .open("app")
+        .unwrap();
+
+    let mut build = Command::new("cat")
+        .arg(format!(
+            "{}/{}",
+            env::var("LIBTOCK_C_TREE").unwrap(),
+            "examples/c_hello/build/cortex-m4/cortex-m4.tbf"
+        ))
+        .stdout(app)
+        .spawn()
+        .expect("failed to spawn build");
+    assert!(build.wait().unwrap().success());
+
+    let app = OpenOptions::new()
+        .append(true)
+        .create(false)
+        .open("app")
+        .unwrap();
+
+    let mut build = Command::new("cat")
+        .arg(format!(
+            "{}/{}",
+            env::var("LIBTOCK_C_TREE").unwrap(),
+            "examples/buttons/build/cortex-m4/cortex-m4.tbf"
+        ))
+        .stdout(app)
+        .spawn()
+        .expect("failed to spawn build");
+    assert!(build.wait().unwrap().success());
+
+    let mut p = artemis_nano_flash("../../tools/board-runner/app").unwrap();
+
+    p.exp_string("Hello World!")?;
+
+    println!("Make sure the LEDs are flashing");
+
+    let timeout = time::Duration::from_secs(10);
+    thread::sleep(timeout);
+
+    Ok(())
+}
+
+fn artemis_nano_malloc_test1() -> Result<(), Error> {
+    let app = format!(
+        "{}/{}",
+        env::var("LIBTOCK_C_TREE").unwrap(),
+        "examples/tests/malloc_test01/build/cortex-m4/cortex-m4.tbf"
+    );
+    let mut p = artemis_nano_flash(&app).unwrap();
+
+    p.exp_string("malloc01: success")?;
+
+    Ok(())
+}
+
+#[allow(dead_code)]
+fn artemis_nano_stack_size_test1() -> Result<(), Error> {
+    let app = format!(
+        "{}/{}",
+        env::var("LIBTOCK_C_TREE").unwrap(),
+        "examples/tests/stack_size_test01/build/cortex-m4/cortex-m4.tbf"
+    );
+    let mut p = artemis_nano_flash(&app).unwrap();
+
+    p.exp_string("Stack Test App")?;
+    p.exp_string("Current stack pointer: 0x100")?;
+
+    Ok(())
+}
+
+#[allow(dead_code)]
+fn artemis_nano_stack_size_test2() -> Result<(), Error> {
+    let app = format!(
+        "{}/{}",
+        env::var("LIBTOCK_C_TREE").unwrap(),
+        "examples/tests/stack_size_test02/build/cortex-m4/cortex-m4.tbf"
+    );
+    let mut p = artemis_nano_flash(&app).unwrap();
+
+    p.exp_string("Stack Test App")?;
+    p.exp_string("Current stack pointer: 0x100")?;
+
+    Ok(())
+}
+
+#[allow(dead_code)]
+fn artemis_nano_mpu_stack_growth() -> Result<(), Error> {
+    let app = format!(
+        "{}/{}",
+        env::var("LIBTOCK_C_TREE").unwrap(),
+        "examples/tests/mpu_stack_growth/build/cortex-m4/cortex-m4.tbf"
+    );
+    let mut p = artemis_nano_flash(&app).unwrap();
+
+    p.exp_string("This test should recursively add stack frames until exceeding")?;
+    p.exp_string("panicked at 'Process mpu_stack_growth had a fault'")?;
+    p.exp_string("Store/AMO access fault")?;
+
+    Ok(())
+}
+
+#[allow(dead_code)]
+fn artemis_nano_mpu_walk_region() -> Result<(), Error> {
+    let app = format!(
+        "{}/{}",
+        env::var("LIBTOCK_C_TREE").unwrap(),
+        "examples/tests/mpu_walk_region/build/cortex-m4/cortex-m4.tbf"
+    );
+    let mut p = artemis_nano_flash(&app).unwrap();
+
+    p.exp_string("MPU Walk Regions")?;
+    p.exp_string("Walking flash")?;
+    p.exp_string("Will overrun")?;
+    p.exp_string("panicked at 'Process mpu_walk_region had a fault'")?;
+
+    Ok(())
+}
+
+fn artemis_nano_multi_alarm_test() -> Result<(), Error> {
+    let app = format!(
+        "{}/{}",
+        env::var("LIBTOCK_C_TREE").unwrap(),
+        "examples/tests/multi_alarm_test/build/cortex-m4/cortex-m4.tbf"
+    );
+    let _p = artemis_nano_flash(&app).unwrap();
+
+    println!("Make sure the LEDs are blinking");
+
+    let timeout = time::Duration::from_secs(10);
+    thread::sleep(timeout);
+
+    Ok(())
+}
+
+#[allow(dead_code)]
+fn artemis_nano_lua() -> Result<(), Error> {
+    let app = format!(
+        "{}/{}",
+        env::var("LIBTOCK_C_TREE").unwrap(),
+        "examples/lua-hello/build/cortex-m4/cortex-m4.tbf"
+    );
+    let _p = artemis_nano_flash(&app).unwrap();
+
+    Ok(())
+}
+
+fn artemis_nano_whileone() -> Result<(), Error> {
+    let app = format!(
+        "{}/{}",
+        env::var("LIBTOCK_C_TREE").unwrap(),
+        "examples/tests/whileone/build/cortex-m4/cortex-m4.tbf"
+    );
+    let mut p = artemis_nano_flash(&app).unwrap();
+
+    p.exp_eof()?;
+
+    Ok(())
+}
+
+pub fn all_artemis_nano_tests() {
+    println!("Tock board-runner starting...");
+    println!();
+    println!("Running artemis_nano tests...");
+    artemis_nano_c_hello().unwrap_or_else(|e| panic!("artemis_nano job failed with {}", e));
+    artemis_nano_blink().unwrap_or_else(|e| panic!("artemis_nano job failed with {}", e));
+    // Doesn't work
+    // artemis_nano_sensors().unwrap_or_else(|e| panic!("artemis_nano job failed with {}", e));
+    // Doesn't work
+    // artemis_nano_c_hello_and_printf_long().unwrap_or_else(|e| panic!("artemis_nano job failed with {}", e));
+    artemis_nano_blink_and_c_hello_and_buttons()
+        .unwrap_or_else(|e| panic!("artemis_nano job failed with {}", e));
+
+    artemis_nano_malloc_test1().unwrap_or_else(|e| panic!("artemis_nano job failed with {}", e));
+    // Doesn't work
+    // artemis_nano_stack_size_test1().unwrap_or_else(|e| panic!("artemis_nano job failed with {}", e));
+    // Doesn't work
+    // artemis_nano_stack_size_test2().unwrap_or_else(|e| panic!("artemis_nano job failed with {}", e));
+    // Doesn't work
+    // artemis_nano_mpu_stack_growth().unwrap_or_else(|e| panic!("artemis_nano job failed with {}", e));
+    artemis_nano_mpu_walk_region().unwrap_or_else(|e| panic!("artemis_nano job failed with {}", e));
+    artemis_nano_multi_alarm_test()
+        .unwrap_or_else(|e| panic!("artemis_nano job failed with {}", e));
+    // Doesn't work
+    // artemis_nano_lua().unwrap_or_else(|e| panic!("artemis_nano job failed with {}", e));
+    artemis_nano_whileone().unwrap_or_else(|e| panic!("artemis_nano job failed with {}", e));
+
+    println!("artemis_nano SUCCESS.");
+}

--- a/tools/board-runner/src/main.rs
+++ b/tools/board-runner/src/main.rs
@@ -1,0 +1,11 @@
+pub mod opentitan;
+
+fn main() {
+    println!("Tock board-runner starting...");
+    println!();
+    println!("Running opentitan tests...");
+    opentitan::all_opentitan_tests();
+    println!("opentitan SUCCESS.");
+}
+
+// p.exp_eof()?;

--- a/tools/board-runner/src/main.rs
+++ b/tools/board-runner/src/main.rs
@@ -1,11 +1,24 @@
+use std::env;
+
+pub mod artemis_nano;
 pub mod opentitan;
 
 fn main() {
-    println!("Tock board-runner starting...");
-    println!();
-    println!("Running opentitan tests...");
-    opentitan::all_opentitan_tests();
-    println!("opentitan SUCCESS.");
-}
+    let args: Vec<String> = env::args().collect();
 
-// p.exp_eof()?;
+    println!("Tock board-runner starting...");
+
+    for arg in args.iter() {
+        if arg == "opentitan" {
+            println!();
+            println!("Running opentitan tests...");
+            opentitan::all_opentitan_tests();
+            println!("opentitan SUCCESS.");
+        } else if arg == "artemis_nano" {
+            println!();
+            println!("Running Redboard tests...");
+            artemis_nano::all_artemis_nano_tests();
+            println!("artemis_nano SUCCESS.");
+        }
+    }
+}

--- a/tools/board-runner/src/opentitan.rs
+++ b/tools/board-runner/src/opentitan.rs
@@ -1,0 +1,423 @@
+use rexpect::errors::Error;
+use rexpect::spawn_stream;
+use serialport::prelude::*;
+use serialport::SerialPortSettings;
+use std::env;
+use std::fs::OpenOptions;
+use std::process::{Command, Stdio};
+use std::time::Duration;
+use std::{thread, time};
+
+fn opentitan_flash(
+    app_name: &str,
+) -> Result<rexpect::session::StreamSession<std::boxed::Box<dyn serialport::SerialPort>>, Error> {
+    let s = SerialPortSettings {
+        baud_rate: 115200,
+        data_bits: DataBits::Eight,
+        flow_control: FlowControl::None,
+        parity: Parity::None,
+        stop_bits: StopBits::One,
+        timeout: Duration::from_millis(1000),
+    };
+
+    // Open the first serialport available.
+    let port_name = &serialport::available_ports().expect("No serial port")[0].port_name;
+    println!("Connecting to OpenTitan port: {:?}", port_name);
+    let port = serialport::open_with_settings(port_name, &s).expect("Failed to open serial port");
+
+    // Clone the port
+    let port_clone = port.try_clone().expect("Failed to clone");
+
+    // Create the Rexpect instance
+    let mut p = spawn_stream(port, port_clone, Some(2000));
+
+    // Flash the Tock kernel and app
+    let mut build = Command::new("make")
+        .arg("-C")
+        .arg("../../boards/opentitan")
+        .arg(format!(
+            "OPENTITAN_TREE={}",
+            env::var("OPENTITAN_TREE").unwrap()
+        ))
+        .arg(format!("APP={}", app_name))
+        .arg("flash-app")
+        .stdout(Stdio::null())
+        .spawn()
+        .expect("failed to spawn build");
+    assert!(build.wait().unwrap().success());
+
+    // Make sure the image is flashed
+    p.exp_string("Processing frame #13, expecting #13")?;
+    p.exp_string("Processing frame #67, expecting #67")?;
+    p.exp_string("Processing frame #155, expecting #155")?;
+    p.exp_string("Processing frame #183, expecting #183")?;
+    p.exp_string("Processing frame #200, expecting #200")?;
+
+    p.exp_string("Boot ROM initialisation has completed, jump into flash")?;
+
+    Ok(p)
+}
+
+fn opentitan_c_hello() -> Result<(), Error> {
+    let app = format!(
+        "{}/{}",
+        env::var("LIBTOCK_C_TREE").unwrap(),
+        "examples/c_hello/build/rv32imc/rv32imc.0x20030080.0x10005000.tbf"
+    );
+    let mut p = opentitan_flash(&app).unwrap();
+
+    p.exp_string("Hello World!")?;
+
+    Ok(())
+}
+
+fn opentitan_blink() -> Result<(), Error> {
+    let app = format!(
+        "{}/{}",
+        env::var("LIBTOCK_C_TREE").unwrap(),
+        "examples/blink/build/rv32imc/rv32imc.0x20030080.0x10005000.tbf"
+    );
+    let _p = opentitan_flash(&app).unwrap();
+
+    println!("Make sure the LEDs are blinking");
+
+    let timeout = time::Duration::from_secs(10);
+    thread::sleep(timeout);
+
+    Ok(())
+}
+
+fn opentitan_c_hello_and_printf_long() -> Result<(), Error> {
+    let app = OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open("app")
+        .unwrap();
+
+    let mut build = Command::new("cat")
+        .arg(format!(
+            "{}/{}",
+            env::var("LIBTOCK_C_TREE").unwrap(),
+            "examples/c_hello/build/rv32imc/rv32imc.0x20030080.0x10005000.tbf"
+        ))
+        .stdout(app)
+        .spawn()
+        .expect("failed to spawn build");
+    assert!(build.wait().unwrap().success());
+
+    let app = OpenOptions::new()
+        .append(true)
+        .create(false)
+        .open("app")
+        .unwrap();
+
+    let mut build = Command::new("cat")
+        .arg(format!(
+            "{}/{}",
+            env::var("LIBTOCK_C_TREE").unwrap(),
+            "examples/tests/printf_long/build/rv32imc/rv32imc.0x20031080.0x10008000.tbf"
+        ))
+        .stdout(app)
+        .spawn()
+        .expect("failed to spawn build");
+    assert!(build.wait().unwrap().success());
+
+    let mut p = opentitan_flash("../../tools/board-runner/app").unwrap();
+
+    p.exp_string("Hello World!")?;
+    p.exp_string("Hi welcome to Tock. This test makes sure that a greater than 64 byte message can be printed.")?;
+    p.exp_string("And a short message.")?;
+
+    Ok(())
+}
+
+fn opentitan_recv_short_and_recv_long() -> Result<(), Error> {
+    let app = OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open("app")
+        .unwrap();
+
+    let mut build = Command::new("cat")
+        .arg(format!(
+            "{}/{}",
+            env::var("LIBTOCK_C_TREE").unwrap(),
+            "examples/tests/console_recv_short/build/rv32imc/rv32imc.0x20030080.0x10005000.tbf"
+        ))
+        .stdout(app)
+        .spawn()
+        .expect("failed to spawn build");
+    assert!(build.wait().unwrap().success());
+
+    let app = OpenOptions::new()
+        .append(true)
+        .create(false)
+        .open("app")
+        .unwrap();
+
+    let mut build = Command::new("cat")
+        .arg(format!(
+            "{}/{}",
+            env::var("LIBTOCK_C_TREE").unwrap(),
+            "examples/tests/console_recv_long/build/rv32imc/rv32imc.0x20040080.0x10008000.tbf"
+        ))
+        .stdout(app)
+        .spawn()
+        .expect("failed to spawn build");
+    assert!(build.wait().unwrap().success());
+
+    let mut p = opentitan_flash("../../tools/board-runner/app").unwrap();
+
+    p.exp_string("Error doing UART receive: -2")?;
+
+    Ok(())
+}
+
+fn opentitan_blink_and_c_hello_and_buttons() -> Result<(), Error> {
+    let app = OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open("app")
+        .unwrap();
+
+    let mut build = Command::new("cat")
+        .arg(format!(
+            "{}/{}",
+            env::var("LIBTOCK_C_TREE").unwrap(),
+            "examples/blink/build/rv32imc/rv32imc.0x20030080.0x10005000.tbf"
+        ))
+        .stdout(app)
+        .spawn()
+        .expect("failed to spawn build");
+    assert!(build.wait().unwrap().success());
+
+    let app = OpenOptions::new()
+        .append(true)
+        .create(false)
+        .open("app")
+        .unwrap();
+
+    let mut build = Command::new("cat")
+        .arg(format!(
+            "{}/{}",
+            env::var("LIBTOCK_C_TREE").unwrap(),
+            "examples/c_hello/build/rv32imc/rv32imc.0x20032080.0x10008000.tbf"
+        ))
+        .stdout(app)
+        .spawn()
+        .expect("failed to spawn build");
+    assert!(build.wait().unwrap().success());
+
+    let app = OpenOptions::new()
+        .append(true)
+        .create(false)
+        .open("app")
+        .unwrap();
+
+    let mut build = Command::new("cat")
+        .arg(format!(
+            "{}/{}",
+            env::var("LIBTOCK_C_TREE").unwrap(),
+            "examples/buttons/build/rv32imc/rv32imc.0x20033080.0x1000B000.tbf"
+        ))
+        .stdout(app)
+        .spawn()
+        .expect("failed to spawn build");
+    assert!(build.wait().unwrap().success());
+
+    let mut p = opentitan_flash("../../tools/board-runner/app").unwrap();
+
+    p.exp_string("Hello World!")?;
+
+    println!("Make sure the LEDs are flashing");
+
+    let timeout = time::Duration::from_secs(10);
+    thread::sleep(timeout);
+
+    Ok(())
+}
+
+fn opentitan_console_recv_short() -> Result<(), Error> {
+    let app = format!(
+        "{}/{}",
+        env::var("LIBTOCK_C_TREE").unwrap(),
+        "examples/tests/console_recv_short/build/rv32imc/rv32imc.0x20030080.0x10005000.tbf"
+    );
+    let mut p = opentitan_flash(&app).unwrap();
+
+    p.send_line("Short recv")?;
+
+    // Check the message
+    p.exp_string("console_recv_short: Short recv")?;
+
+    Ok(())
+}
+
+fn opentitan_console_timeout() -> Result<(), Error> {
+    let app = format!(
+        "{}/{}",
+        env::var("LIBTOCK_C_TREE").unwrap(),
+        "examples/tests/console_timeout/build/rv32imc/rv32imc.0x20030080.0x10005000.tbf"
+    );
+    let mut p = opentitan_flash(&app).unwrap();
+
+    // Send message
+    p.send_line("Test message")?;
+
+    // Wait 25 seconds
+    let timeout = time::Duration::from_secs(25);
+    thread::sleep(timeout);
+
+    // Send enter
+    p.send_line("")?;
+
+    // Check the message
+    p.exp_string("Userspace call to read console returned: Test message")?;
+
+    Ok(())
+}
+
+#[allow(dead_code)]
+fn opentitan_malloc_test1() -> Result<(), Error> {
+    let app = format!(
+        "{}/{}",
+        env::var("LIBTOCK_C_TREE").unwrap(),
+        "examples/tests/malloc_test01/build/rv32imc/rv32imc.0x20030080.0x10005000.tbf"
+    );
+    let mut p = opentitan_flash(&app).unwrap();
+
+    p.exp_string("malloc01: success")?;
+
+    Ok(())
+}
+
+#[allow(dead_code)]
+fn opentitan_stack_size_test1() -> Result<(), Error> {
+    let app = format!(
+        "{}/{}",
+        env::var("LIBTOCK_C_TREE").unwrap(),
+        "examples/tests/stack_size_test01/build/rv32imc/rv32imc.0x20030080.0x10005000.tbf"
+    );
+    let mut p = opentitan_flash(&app).unwrap();
+
+    p.exp_string("Stack Test App")?;
+    p.exp_string("Current stack pointer: 0x100")?;
+
+    Ok(())
+}
+
+#[allow(dead_code)]
+fn opentitan_stack_size_test2() -> Result<(), Error> {
+    let app = format!(
+        "{}/{}",
+        env::var("LIBTOCK_C_TREE").unwrap(),
+        "examples/tests/stack_size_test02/build/rv32imc/rv32imc.0x20030080.0x10005000.tbf"
+    );
+    let mut p = opentitan_flash(&app).unwrap();
+
+    p.exp_string("Stack Test App")?;
+    p.exp_string("Current stack pointer: 0x100")?;
+
+    Ok(())
+}
+
+fn opentitan_mpu_stack_growth() -> Result<(), Error> {
+    let app = format!(
+        "{}/{}",
+        env::var("LIBTOCK_C_TREE").unwrap(),
+        "examples/tests/mpu_stack_growth/build/rv32imc/rv32imc.0x20030080.0x10005000.tbf"
+    );
+    let mut p = opentitan_flash(&app).unwrap();
+
+    p.exp_string("This test should recursively add stack frames until exceeding")?;
+    p.exp_string("panicked at 'Process mpu_stack_growth had a fault'")?;
+    p.exp_string("Store/AMO access fault")?;
+
+    Ok(())
+}
+
+#[allow(dead_code)]
+fn opentitan_mpu_walk_region() -> Result<(), Error> {
+    let app = format!(
+        "{}/{}",
+        env::var("LIBTOCK_C_TREE").unwrap(),
+        "examples/tests/mpu_walk_region/build/rv32imc/rv32imc.0x20030080.0x10005000.tbf"
+    );
+    let mut p = opentitan_flash(&app).unwrap();
+
+    p.exp_string("MPU Walk Regions")?;
+    p.exp_string("Walking flash")?;
+    p.exp_string("Will overrun")?;
+    p.exp_string("panicked at 'Process mpu_walk_region had a fault'")?;
+
+    Ok(())
+}
+
+fn opentitan_multi_alarm_test() -> Result<(), Error> {
+    let app = format!(
+        "{}/{}",
+        env::var("LIBTOCK_C_TREE").unwrap(),
+        "examples/tests/multi_alarm_test/build/rv32imc/rv32imc.0x20030080.0x10005000.tbf"
+    );
+    let _p = opentitan_flash(&app).unwrap();
+
+    println!("Make sure the LEDs are blinking");
+
+    let timeout = time::Duration::from_secs(10);
+    thread::sleep(timeout);
+
+    Ok(())
+}
+
+pub fn all_opentitan_tests() {
+    println!("Tock board-runner starting...");
+    println!();
+    println!("Running opentitan tests...");
+    opentitan_c_hello().unwrap_or_else(|e| panic!("opentitan job failed with {}", e));
+    opentitan_blink().unwrap_or_else(|e| panic!("opentitan job failed with {}", e));
+    opentitan_c_hello_and_printf_long()
+        .unwrap_or_else(|e| panic!("opentitan job failed with {}", e));
+    opentitan_recv_short_and_recv_long()
+        .unwrap_or_else(|e| panic!("opentitan job failed with {}", e));
+    opentitan_blink_and_c_hello_and_buttons()
+        .unwrap_or_else(|e| panic!("opentitan job failed with {}", e));
+    opentitan_console_recv_short().unwrap_or_else(|e| panic!("opentitan job failed with {}", e));
+    opentitan_console_timeout().unwrap_or_else(|e| panic!("opentitan job failed with {}", e));
+
+    // Disabled by default.
+    // Requires:
+    //    STACK_SIZE       = 2048
+    //    APP_HEAP_SIZE    = 4096
+    //    KERNEL_HEAP_SIZE = 2048
+    // opentitan_malloc_test1().unwrap_or_else(|e| panic!("opentitan job failed with {}", e));
+
+    // Disabled by default.
+    // Requires:
+    //    STACK_SIZE       = 2048
+    //    APP_HEAP_SIZE    = 4096
+    //    KERNEL_HEAP_SIZE = 2048
+    // opentitan_stack_size_test1().unwrap_or_else(|e| panic!("opentitan job failed with {}", e));
+
+    // Disabled by default.
+    // Requires:
+    //    STACK_SIZE       = 2048
+    //    APP_HEAP_SIZE    = 4096
+    //    KERNEL_HEAP_SIZE = 2048
+    // opentitan_stack_size_test2().unwrap_or_else(|e| panic!("opentitan job failed with {}", e));
+
+    opentitan_mpu_stack_growth().unwrap_or_else(|e| panic!("opentitan job failed with {}", e));
+
+    // Disabled by default.
+    // Requires:
+    //    STACK_SIZE       = 2048
+    //    APP_HEAP_SIZE    = 4096
+    //    KERNEL_HEAP_SIZE = 2048
+    // opentitan_mpu_walk_region().unwrap_or_else(|e| panic!("opentitan job failed with {}", e));
+
+    opentitan_multi_alarm_test().unwrap_or_else(|e| panic!("opentitan job failed with {}", e));
+
+    println!("opentitan SUCCESS.");
+}


### PR DESCRIPTION
### Pull Request Overview

This PR adds automated tests to run the libtock-c release tests on OpenTitan and the Apollo3.

There is a fair bit of duplicated code here, so more clean-up can be done. For now though this seems like a good starting point to continue improving the Tock testing infrastructure.

### Testing Strategy

Running the release tests on OpenTitan and the Apollo3.

### TODO or Help Wanted

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
