### PR TITLE
Expose STM Temperature sensor

### DIFF
--- a/boards/stm32f412gdiscovery/src/main.rs
+++ b/boards/stm32f412gdiscovery/src/main.rs
@@ -55,6 +55,7 @@ struct STM32F412GDiscovery {
     adc: &'static capsules::adc::AdcVirtualized<'static>,
     ft6x06: &'static capsules::ft6x06::Ft6x06<'static>,
     touch: &'static capsules::touch::Touch<'static>,
+    temperature: &'static capsules::temperature::TemperatureSensor<'static>,
 }
 
 /// Mapping of integer syscalls to objects that implement syscalls.
@@ -73,6 +74,7 @@ impl Platform for STM32F412GDiscovery {
             capsules::adc::DRIVER_NUM => f(Some(self.adc)),
             capsules::ft6x06::DRIVER_NUM => f(Some(self.ft6x06)),
             capsules::touch::DRIVER_NUM => f(Some(self.touch)),
+            capsules::temperature::DRIVER_NUM => f(Some(self.temperature)),
             _ => f(None),
         }
     }
@@ -564,6 +566,7 @@ pub unsafe fn reset_handler() {
         adc: adc_syscall,
         ft6x06: ft6x06,
         touch: touch,
+        temperature: temp,
     };
 
     // // Optional kernel tests


### PR DESCRIPTION
### Pull Request Overview

This pull request adds the temperature capsule top the STM32F412G board.

The temperature sensor was initialized, but not exposed to the user land.

### Testing Strategy

This pull request was tested using an STM32F412G Discovery kit.

### TODO or Help Wanted

N/A

### Documentation Updated

- [x] no updates are required.

### Formatting

- [x] Ran `make prepush`.
