### PR TITLE
Update Nucelo F429ZI Button

### DIFF
--- a/boards/nucleo_f429zi/src/main.rs
+++ b/boards/nucleo_f429zi/src/main.rs
@@ -276,7 +276,7 @@ pub unsafe fn reset_handler() {
             stm32f429zi::gpio::Pin,
             (
                 stm32f429zi::gpio::PinId::PC13.get_pin().as_ref().unwrap(),
-                kernel::hil::gpio::ActivationMode::ActiveLow,
+                kernel::hil::gpio::ActivationMode::ActiveHigh,
                 kernel::hil::gpio::FloatingState::PullNone
             )
         ),


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes the Nucleo 429ZI button active state.

### Testing Strategy

This pull request was tested Nucleo 429ZI board


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] no updates are required.

### Formatting

- [x] Ran `make prepush`.
