### PR TITLE
Update Stm32f3discovery Button state

### DIFF
--- a/boards/stm32f3discovery/src/main.rs
+++ b/boards/stm32f3discovery/src/main.rs
@@ -409,7 +409,7 @@ pub unsafe fn reset_handler() {
             stm32f303xc::gpio::Pin<'static>,
             (
                 stm32f303xc::gpio::PinId::PA00.get_pin().as_ref().unwrap(),
-                kernel::hil::gpio::ActivationMode::ActiveLow,
+                kernel::hil::gpio::ActivationMode::ActiveHigh,
                 kernel::hil::gpio::FloatingState::PullNone
             )
         ),


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes the stm32f3discovery button active state, similar to #2162.


### Testing Strategy

This pull request was tested using the stm32f3discovery board.


### TODO or Help Wanted
N/A

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
