### PR TITLE
MSP432: Fix bug in interrupt-handling of GPIOs

### DIFF
--- a/boards/msp_exp432p401r/src/io.rs
+++ b/boards/msp_exp432p401r/src/io.rs
@@ -6,7 +6,7 @@ use core::panic::PanicInfo;
 use kernel::debug;
 use kernel::debug::IoWrite;
 use kernel::hil::led;
-use msp432::gpio::PinNr;
+use msp432::gpio::IntPinNr;
 use msp432::wdt::Wdt;
 
 /// Uart is used by kernel::debug to panic message to the serial port.
@@ -43,8 +43,8 @@ impl IoWrite for Uart {
 #[no_mangle]
 #[panic_handler]
 pub unsafe extern "C" fn panic_fmt(info: &PanicInfo) -> ! {
-    const LED1_PIN: PinNr = PinNr::P01_0;
-    let led = &mut led::LedHigh::new(&mut msp432::gpio::PINS[LED1_PIN as usize]);
+    const LED1_PIN: IntPinNr = IntPinNr::P01_0;
+    let led = &mut led::LedHigh::new(&mut msp432::gpio::INT_PINS[LED1_PIN as usize]);
     let writer = &mut UART;
     let wdt = Wdt::new();
 

--- a/boards/msp_exp432p401r/src/main.rs
+++ b/boards/msp_exp432p401r/src/main.rs
@@ -9,6 +9,7 @@
 #![feature(const_in_array_repeat_expressions)]
 #![deny(missing_docs)]
 
+use components::gpio::GpioComponent;
 use kernel::capabilities;
 use kernel::common::dynamic_deferred_call::DynamicDeferredCall;
 use kernel::common::dynamic_deferred_call::DynamicDeferredCallClientState;
@@ -43,9 +44,10 @@ pub static mut STACK_MEMORY: [u8; 0x1000] = [0; 0x1000];
 /// A structure representing this platform that holds references to all
 /// capsules for this platform.
 struct MspExp432P401R {
-    led: &'static capsules::led::LED<'static, msp432::gpio::Pin<'static>>,
+    led: &'static capsules::led::LED<'static, msp432::gpio::IntPin<'static>>,
     console: &'static capsules::console::Console<'static>,
-    button: &'static capsules::button::Button<'static, msp432::gpio::Pin<'static>>,
+    button: &'static capsules::button::Button<'static, msp432::gpio::IntPin<'static>>,
+    gpio: &'static capsules::gpio::GPIO<'static, msp432::gpio::IntPin<'static>>,
     alarm: &'static capsules::alarm::AlarmDriver<
         'static,
         capsules::virtual_alarm::VirtualMuxAlarm<'static, msp432::timer::TimerA<'static>>,
@@ -63,6 +65,7 @@ impl Platform for MspExp432P401R {
             capsules::led::DRIVER_NUM => f(Some(self.led)),
             capsules::console::DRIVER_NUM => f(Some(self.console)),
             capsules::button::DRIVER_NUM => f(Some(self.button)),
+            capsules::gpio::DRIVER_NUM => f(Some(self.gpio)),
             capsules::alarm::DRIVER_NUM => f(Some(self.alarm)),
             kernel::ipc::DRIVER_NUM => f(Some(&self.ipc)),
             _ => f(None),
@@ -103,25 +106,25 @@ pub unsafe fn reset_handler() {
     startup_intilialisation();
 
     // Setup the GPIO pins to use the HFXT (high frequency external) oscillator (48MHz)
-    msp432::gpio::PINS_J[msp432::gpio::PinJNr::PJ_2 as usize].enable_primary_function();
-    msp432::gpio::PINS_J[msp432::gpio::PinJNr::PJ_3 as usize].enable_primary_function();
+    msp432::gpio::PINS[msp432::gpio::PinNr::PJ_2 as usize].enable_primary_function();
+    msp432::gpio::PINS[msp432::gpio::PinNr::PJ_3 as usize].enable_primary_function();
 
     // Setup the GPIO pins to use the LFXT (low frequency external) oscillator (32.768kHz)
-    msp432::gpio::PINS_J[msp432::gpio::PinJNr::PJ_0 as usize].enable_primary_function();
-    msp432::gpio::PINS_J[msp432::gpio::PinJNr::PJ_1 as usize].enable_primary_function();
+    msp432::gpio::PINS[msp432::gpio::PinNr::PJ_0 as usize].enable_primary_function();
+    msp432::gpio::PINS[msp432::gpio::PinNr::PJ_1 as usize].enable_primary_function();
 
     // Setup the clocks: MCLK: 48MHz, HSMCLK: 12MHz, SMCLK: 1.5MHz, ACLK: 32.768kHz
     msp432::cs::CS.setup_clocks();
 
     debug::assign_gpios(
-        Some(&msp432::gpio::PINS[msp432::gpio::PinNr::P01_0 as usize]), // Red LED
-        Some(&msp432::gpio::PINS[msp432::gpio::PinNr::P03_5 as usize]),
-        Some(&msp432::gpio::PINS[msp432::gpio::PinNr::P03_7 as usize]),
+        Some(&msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P01_0 as usize]), // Red LED
+        Some(&msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P03_5 as usize]),
+        Some(&msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P03_7 as usize]),
     );
 
     // Setup pins for UART0
-    msp432::gpio::PINS[msp432::gpio::PinNr::P01_2 as usize].enable_primary_function();
-    msp432::gpio::PINS[msp432::gpio::PinNr::P01_3 as usize].enable_primary_function();
+    msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P01_2 as usize].enable_primary_function();
+    msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P01_3 as usize].enable_primary_function();
 
     let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
     let chip = static_init!(msp432::chip::Msp432, msp432::chip::Msp432::new());
@@ -131,38 +134,88 @@ pub unsafe fn reset_handler() {
     let button = components::button::ButtonComponent::new(
         board_kernel,
         components::button_component_helper!(
-            msp432::gpio::Pin,
+            msp432::gpio::IntPin,
             (
-                &msp432::gpio::PINS[msp432::gpio::PinNr::P01_1 as usize],
+                &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P01_1 as usize],
                 kernel::hil::gpio::ActivationMode::ActiveLow,
                 kernel::hil::gpio::FloatingState::PullUp
             ),
             (
-                &msp432::gpio::PINS[msp432::gpio::PinNr::P01_4 as usize],
+                &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P01_4 as usize],
                 kernel::hil::gpio::ActivationMode::ActiveLow,
                 kernel::hil::gpio::FloatingState::PullUp
             )
         ),
     )
-    .finalize(components::button_component_buf!(msp432::gpio::Pin));
+    .finalize(components::button_component_buf!(msp432::gpio::IntPin));
 
     // Setup LEDs
     let leds = components::led::LedsComponent::new(components::led_component_helper!(
-        msp432::gpio::Pin,
+        msp432::gpio::IntPin,
         (
-            &msp432::gpio::PINS[msp432::gpio::PinNr::P02_0 as usize],
+            &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P02_0 as usize],
             kernel::hil::gpio::ActivationMode::ActiveHigh
         ),
         (
-            &msp432::gpio::PINS[msp432::gpio::PinNr::P02_1 as usize],
+            &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P02_1 as usize],
             kernel::hil::gpio::ActivationMode::ActiveHigh
         ),
         (
-            &msp432::gpio::PINS[msp432::gpio::PinNr::P02_2 as usize],
+            &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P02_2 as usize],
             kernel::hil::gpio::ActivationMode::ActiveHigh
         )
     ))
-    .finalize(components::led_component_buf!(msp432::gpio::Pin));
+    .finalize(components::led_component_buf!(msp432::gpio::IntPin));
+
+    // Setup user-GPIOs
+    let gpio = GpioComponent::new(
+        board_kernel,
+        components::gpio_component_helper!(
+            msp432::gpio::IntPin<'static>,
+            // Left outer connector, top to bottom
+            // 0 => &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P06_0 as usize], // A15
+            1 => &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P03_2 as usize],
+            2 => &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P03_3 as usize],
+            // 3 => &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P04_1 as usize], // A12
+            // 4 => &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P04_3 as usize], // A10
+            5 => &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P01_5 as usize],
+            // 6 => &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P04_6 as usize], // A7
+            7 => &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P06_5 as usize],
+            8 => &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P06_4 as usize],
+            // Left inner connector, top to bottom
+            // 9 => &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P06_1 as usize], // A14
+            // 10 => &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P04_0 as usize], // A13
+            // 11 => &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P04_2 as usize], // A11
+            // 12 => &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P04_4 as usize], // A9
+            // 13 => &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P04_5 as usize], // A8
+            // 14 => &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P04_7 as usize], // A6
+            // 15 => &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P05_4 as usize], // A1
+            // 16 => &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P05_5 as usize], // A0
+            // Right inner connector, top to bottom
+            17 => &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P02_7 as usize],
+            18 => &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P02_6 as usize],
+            19 => &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P02_4 as usize],
+            20 => &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P05_6 as usize],
+            21 => &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P06_6 as usize],
+            22 => &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P06_7 as usize],
+            23 => &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P02_3 as usize],
+            // 24 => &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P05_1 as usize], // A4
+            // 25 => &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P03_5 as usize], // debug-gpio
+            // 26 => &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P03_7 as usize], // debug-gpio
+            // Right outer connector, top to bottom
+            27 => &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P02_5 as usize],
+            28 => &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P03_0 as usize],
+            29 => &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P05_7 as usize],
+            30 => &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P01_6 as usize],
+            31 => &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P01_7 as usize],
+            // 32 => &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P05_0 as usize], // A5
+            // 33 => &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P05_2 as usize], // A3
+            34 => &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P03_6 as usize]
+        ),
+    )
+    .finalize(components::gpio_component_buf!(
+        msp432::gpio::IntPin<'static>
+    ));
 
     let memory_allocation_capability = create_capability!(capabilities::MemoryAllocationCapability);
     let main_loop_capability = create_capability!(capabilities::MainLoopCapability);
@@ -200,6 +253,7 @@ pub unsafe fn reset_handler() {
         led: leds,
         console: console,
         button: button,
+        gpio: gpio,
         alarm: alarm,
         ipc: kernel::ipc::IPC::new(board_kernel, &memory_allocation_capability),
     };

--- a/chips/msp432/src/gpio.rs
+++ b/chips/msp432/src/gpio.rs
@@ -7,55 +7,58 @@ use kernel::common::registers::{register_bitfields, register_structs, ReadOnly, 
 use kernel::common::StaticRef;
 use kernel::hil::gpio;
 
-pub static mut PINS: [Pin; 80] = [
-    Pin::new(PinNr::P01_0),
-    Pin::new(PinNr::P01_1),
-    Pin::new(PinNr::P01_2),
-    Pin::new(PinNr::P01_3),
-    Pin::new(PinNr::P01_4),
-    Pin::new(PinNr::P01_5),
-    Pin::new(PinNr::P01_6),
-    Pin::new(PinNr::P01_7),
-    Pin::new(PinNr::P02_0),
-    Pin::new(PinNr::P02_1),
-    Pin::new(PinNr::P02_2),
-    Pin::new(PinNr::P02_3),
-    Pin::new(PinNr::P02_4),
-    Pin::new(PinNr::P02_5),
-    Pin::new(PinNr::P02_6),
-    Pin::new(PinNr::P02_7),
-    Pin::new(PinNr::P03_0),
-    Pin::new(PinNr::P03_1),
-    Pin::new(PinNr::P03_2),
-    Pin::new(PinNr::P03_3),
-    Pin::new(PinNr::P03_4),
-    Pin::new(PinNr::P03_5),
-    Pin::new(PinNr::P03_6),
-    Pin::new(PinNr::P03_7),
-    Pin::new(PinNr::P04_0),
-    Pin::new(PinNr::P04_1),
-    Pin::new(PinNr::P04_2),
-    Pin::new(PinNr::P04_3),
-    Pin::new(PinNr::P04_4),
-    Pin::new(PinNr::P04_5),
-    Pin::new(PinNr::P04_6),
-    Pin::new(PinNr::P04_7),
-    Pin::new(PinNr::P05_0),
-    Pin::new(PinNr::P05_1),
-    Pin::new(PinNr::P05_2),
-    Pin::new(PinNr::P05_3),
-    Pin::new(PinNr::P05_4),
-    Pin::new(PinNr::P05_5),
-    Pin::new(PinNr::P05_6),
-    Pin::new(PinNr::P05_7),
-    Pin::new(PinNr::P06_0),
-    Pin::new(PinNr::P06_1),
-    Pin::new(PinNr::P06_2),
-    Pin::new(PinNr::P06_3),
-    Pin::new(PinNr::P06_4),
-    Pin::new(PinNr::P06_5),
-    Pin::new(PinNr::P06_6),
-    Pin::new(PinNr::P06_7),
+pub static mut INT_PINS: [IntPin; 48] = [
+    IntPin::new(IntPinNr::P01_0),
+    IntPin::new(IntPinNr::P01_1),
+    IntPin::new(IntPinNr::P01_2),
+    IntPin::new(IntPinNr::P01_3),
+    IntPin::new(IntPinNr::P01_4),
+    IntPin::new(IntPinNr::P01_5),
+    IntPin::new(IntPinNr::P01_6),
+    IntPin::new(IntPinNr::P01_7),
+    IntPin::new(IntPinNr::P02_0),
+    IntPin::new(IntPinNr::P02_1),
+    IntPin::new(IntPinNr::P02_2),
+    IntPin::new(IntPinNr::P02_3),
+    IntPin::new(IntPinNr::P02_4),
+    IntPin::new(IntPinNr::P02_5),
+    IntPin::new(IntPinNr::P02_6),
+    IntPin::new(IntPinNr::P02_7),
+    IntPin::new(IntPinNr::P03_0),
+    IntPin::new(IntPinNr::P03_1),
+    IntPin::new(IntPinNr::P03_2),
+    IntPin::new(IntPinNr::P03_3),
+    IntPin::new(IntPinNr::P03_4),
+    IntPin::new(IntPinNr::P03_5),
+    IntPin::new(IntPinNr::P03_6),
+    IntPin::new(IntPinNr::P03_7),
+    IntPin::new(IntPinNr::P04_0),
+    IntPin::new(IntPinNr::P04_1),
+    IntPin::new(IntPinNr::P04_2),
+    IntPin::new(IntPinNr::P04_3),
+    IntPin::new(IntPinNr::P04_4),
+    IntPin::new(IntPinNr::P04_5),
+    IntPin::new(IntPinNr::P04_6),
+    IntPin::new(IntPinNr::P04_7),
+    IntPin::new(IntPinNr::P05_0),
+    IntPin::new(IntPinNr::P05_1),
+    IntPin::new(IntPinNr::P05_2),
+    IntPin::new(IntPinNr::P05_3),
+    IntPin::new(IntPinNr::P05_4),
+    IntPin::new(IntPinNr::P05_5),
+    IntPin::new(IntPinNr::P05_6),
+    IntPin::new(IntPinNr::P05_7),
+    IntPin::new(IntPinNr::P06_0),
+    IntPin::new(IntPinNr::P06_1),
+    IntPin::new(IntPinNr::P06_2),
+    IntPin::new(IntPinNr::P06_3),
+    IntPin::new(IntPinNr::P06_4),
+    IntPin::new(IntPinNr::P06_5),
+    IntPin::new(IntPinNr::P06_6),
+    IntPin::new(IntPinNr::P06_7),
+];
+
+pub static mut PINS: [Pin; 40] = [
     Pin::new(PinNr::P07_0),
     Pin::new(PinNr::P07_1),
     Pin::new(PinNr::P07_2),
@@ -88,17 +91,14 @@ pub static mut PINS: [Pin; 80] = [
     Pin::new(PinNr::P10_5),
     Pin::new(PinNr::P10_6),
     Pin::new(PinNr::P10_7),
-];
-
-pub static mut PINS_J: [PinJ; 8] = [
-    PinJ::new(PinJNr::PJ_0),
-    PinJ::new(PinJNr::PJ_1),
-    PinJ::new(PinJNr::PJ_2),
-    PinJ::new(PinJNr::PJ_3),
-    PinJ::new(PinJNr::PJ_4),
-    PinJ::new(PinJNr::PJ_5),
-    PinJ::new(PinJNr::PJ_6),
-    PinJ::new(PinJNr::PJ_7),
+    Pin::new(PinNr::PJ_0),
+    Pin::new(PinNr::PJ_1),
+    Pin::new(PinNr::PJ_2),
+    Pin::new(PinNr::PJ_3),
+    Pin::new(PinNr::PJ_4),
+    Pin::new(PinNr::PJ_5),
+    Pin::new(PinNr::PJ_6),
+    Pin::new(PinNr::PJ_7),
 ];
 
 const GPIO_BASES: [StaticRef<GpioRegisters>; 6] = [
@@ -268,31 +268,25 @@ register_bitfields! [u16,
 #[rustfmt::skip]
 #[repr(u8)]
 #[derive(Copy, Clone)]
-pub enum PinNr {
+pub enum IntPinNr {
     P01_0, P01_1, P01_2, P01_3, P01_4, P01_5, P01_6, P01_7,
     P02_0, P02_1, P02_2, P02_3, P02_4, P02_5, P02_6, P02_7,
     P03_0, P03_1, P03_2, P03_3, P03_4, P03_5, P03_6, P03_7,
     P04_0, P04_1, P04_2, P04_3, P04_4, P04_5, P04_6, P04_7,
     P05_0, P05_1, P05_2, P05_3, P05_4, P05_5, P05_6, P05_7,
     P06_0, P06_1, P06_2, P06_3, P06_4, P06_5, P06_6, P06_7,
+}
+
+#[rustfmt::skip]
+#[allow(non_camel_case_types)]
+#[repr(u8)]
+#[derive(Copy, Clone)]
+pub enum PinNr {
     P07_0, P07_1, P07_2, P07_3, P07_4, P07_5, P07_6, P07_7,
     P08_0, P08_1, P08_2, P08_3, P08_4, P08_5, P08_6, P08_7,
     P09_0, P09_1, P09_2, P09_3, P09_4, P09_5, P09_6, P09_7,
     P10_0, P10_1, P10_2, P10_3, P10_4, P10_5, P10_6, P10_7,
-}
-
-#[allow(non_camel_case_types)]
-#[repr(u8)]
-#[derive(Copy, Clone)]
-pub enum PinJNr {
-    PJ_0,
-    PJ_1,
-    PJ_2,
-    PJ_3,
-    PJ_4,
-    PJ_5,
-    PJ_6,
-    PJ_7,
+    PJ_0,  PJ_1,  PJ_2,  PJ_3,  PJ_4,  PJ_5,  PJ_6,  PJ_7,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -304,7 +298,7 @@ enum ModuleFunction {
 }
 
 /// Supports interrupts
-pub struct Pin<'a> {
+pub struct IntPin<'a> {
     pin: u8,
     registers: StaticRef<GpioRegisters>,
     reg_idx: usize,
@@ -312,26 +306,14 @@ pub struct Pin<'a> {
     client: OptionalCell<&'a dyn gpio::Client>,
 }
 
-/// Doesn't support interrupts
-pub struct PinJ<'a> {
+/// Does not support interrupts
+pub struct Pin<'a> {
     pin: u8,
     registers: StaticRef<GpioRegisters>,
     reg_idx: usize,
     // Add the phantom data in order to make the macro implementation work
-    // because Pin requires a lifetime parameter
+    // because IntPin requires a lifetime parameter
     phantom: PhantomData<&'a ()>,
-}
-
-impl<'a> PinJ<'a> {
-    const fn new(pin: PinJNr) -> PinJ<'a> {
-        let pin_nr = (pin as u8) % PINS_PER_PORT;
-        PinJ {
-            pin: pin_nr,
-            registers: GPIO_BASES[5],
-            reg_idx: 0,
-            phantom: PhantomData,
-        }
-    }
 }
 
 impl<'a> Pin<'a> {
@@ -339,6 +321,19 @@ impl<'a> Pin<'a> {
         let pin_nr = (pin as u8) % PINS_PER_PORT;
         let p = (pin as u8) / PINS_PER_PORT;
         Pin {
+            pin: pin_nr,
+            registers: GPIO_BASES[3 + ((p / 2) as usize)],
+            reg_idx: (p % 2) as usize,
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<'a> IntPin<'a> {
+    const fn new(pin: IntPinNr) -> IntPin<'a> {
+        let pin_nr = (pin as u8) % PINS_PER_PORT;
+        let p = (pin as u8) / PINS_PER_PORT;
+        IntPin {
             pin: pin_nr,
             registers: GPIO_BASES[(p / 2) as usize],
             reg_idx: (p % 2) as usize,
@@ -540,10 +535,10 @@ macro_rules! pin_implementation {
     };
 }
 
+pin_implementation!(IntPin);
 pin_implementation!(Pin);
-pin_implementation!(PinJ);
 
-impl<'a> gpio::Interrupt<'a> for Pin<'a> {
+impl<'a> gpio::Interrupt<'a> for IntPin<'a> {
     fn set_client(&self, client: &'a dyn gpio::Client) {
         self.client.set(client);
     }
@@ -598,31 +593,26 @@ impl<'a> gpio::Interrupt<'a> for Pin<'a> {
     }
 }
 
-impl<'a> gpio::InterruptPin<'a> for Pin<'a> {}
+impl<'a> gpio::InterruptPin<'a> for IntPin<'a> {}
 
 pub fn handle_interrupt(port_idx: usize) {
-    let regs: StaticRef<GpioRegisters> = GPIO_BASES[port_idx];
-    let ifg0 = regs.ifg[0].get();
-    let ifg1 = regs.ifg[1].get();
+    let regs: StaticRef<GpioRegisters> = GPIO_BASES[port_idx / 2];
+    let ifgs: [u8; 2] = [regs.ifg[0].get(), regs.ifg[1].get()];
+
+    let handle_int = |ifg_idx: usize, i: usize| {
+        let bit = 1 << i;
+        if (ifgs[ifg_idx] & bit) > 0 {
+            unsafe {
+                INT_PINS[(port_idx * 8) + i].handle_interrupt();
+            }
+            // read back the current register value to avoid loosing interrupts which occured
+            // within this function
+            regs.ifg[ifg_idx].set(regs.ifg[ifg_idx].get() & !bit);
+        }
+    };
 
     for i in 0..8 {
-        let bit = 1 << i;
-        if (ifg0 & bit) > 0 {
-            unsafe {
-                PINS[(port_idx * 16) + i].handle_interrupt();
-            }
-            // read back the current register value to avoid loosing interrupts which occured
-            // within this function
-            regs.ifg[0].set(regs.ifg[0].get() & !bit);
-        }
-
-        if (ifg1 & bit) > 0 {
-            unsafe {
-                PINS[port_idx * 16 + 8 + i].handle_interrupt();
-            }
-            // read back the current register value to avoid loosing interrupts which occured
-            // within this function
-            regs.ifg[1].set(regs.ifg[1].get() & !bit);
-        }
+        handle_int(0, i);
+        handle_int(1, i);
     }
 }


### PR DESCRIPTION
### Pull Request Overview
This PR fixes a bug in handling interrupts for GPIOs. I initially thought that every pin except the PIN_J port was capable of detecting interrupts. Obviously this is not the case, only the first 6 ports (equals the first 48 pins) are able to detect interrupts.

Now I renamed all interrupt-capable pins `IntPin` and all the others just `Pin`. And the core change was the interrupt-handler itself, since it mapped the occurred interrupt to the wrong pin.

Also the user gpio-pins were not declared until now.

I detected the bug when I wanted to run the `test/gpio` example in mode 0 which is a necessary test for release 1.6

### Testing Strategy
This PR was tested by running the example `button`, `test/gpio` and `test/print_button`. 

### TODO or Help Wanted
n/a

### Documentation Updated
- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
