### PR TITLE
OpenTitan: Specify minimum QEMU version

### DIFF
--- a/boards/opentitan/README.md
+++ b/boards/opentitan/README.md
@@ -26,7 +26,7 @@ In the OpenTitan repo build the `spiflash` program.
 make -C sw/host/spiflash clean all
 ```
 
-Export the `OPENTITAN_TREE` enviroment variable to point to the OpenTitan tree.
+Export the `OPENTITAN_TREE` environment variable to point to the OpenTitan tree.
 
 ```shell
 export OPENTITAN_TREE=/home/opentitan/
@@ -72,7 +72,7 @@ Programming Apps
 
 Tock apps for OpenTitan must be included in the Tock binary file flashed with the steps mentioned above.
 
-Apps are built out of tree. Currently [libtock-rs](https://github.com/tock/libtock-rs) apps work well while [libtock-c](https://github.com/tock/libtock-c) apps require a special branch and complex work arounds. It is recomended that libtock-rs apps are used.
+Apps are built out of tree. Currently [libtock-rs](https://github.com/tock/libtock-rs) apps work well while [libtock-c](https://github.com/tock/libtock-c) apps require a special branch and complex work arounds. It is recommended that libtock-rs apps are used.
 
 Once an app is built and a tbf file is generated, you can use `riscv32-none-elf-objcopy` with `--update-section` to create an ELF image with the
 apps included.
@@ -108,7 +108,7 @@ Running in QEMU
 
 The OpenTitan application can be run in the QEMU emulation platform for RISC-V, allowing quick and easy testing.
 
-Unfortunately you need QEMU 5.2, which at the time of writing is unlikely to be avaliable in your distro. Luckily Tock can build QEMU for you. From the top level of the Tock source just run `make ci-setup-qemu` and follow the steps.
+Unfortunately you need QEMU 5.1, which at the time of writing is unlikely to be available in your distro. Luckily Tock can build QEMU for you. From the top level of the Tock source just run `make ci-setup-qemu` and follow the steps.
 
 QEMU can be started with Tock using the `qemu` make target:
 
@@ -126,7 +126,7 @@ $ make OPENTITAN_BOOT_ROM=<path_to_opentitan/sw/device/boot_rom/boot_rom_fpga_ne
 
 The TBF must be compiled for the OpenTitan board which is, at the time of writing,
 supported for Rust userland apps using libtock-rs. For example, you can build
-the Hello World exmple app from the libtock-rs repository by running:
+the Hello World example app from the libtock-rs repository by running:
 
 ```
 $ cd [LIBTOCK-RS-DIR]


### PR DESCRIPTION
The OpenTitan README.md specifies minimum QEMU is 5.2.
I have QEMU 5.1 installed and maybe this is enough?

```
% qemu-system-riscv32 --version                  
QEMU emulator version 5.1.0
Copyright (c) 2003-2020 Fabrice Bellard and the QEMU Project developers
% qemu-system-riscv32 -machine help              
Supported machines are:
none                 empty machine
opentitan            RISC-V Board compatible with OpenTitan
sifive_e             RISC-V Board compatible with SiFive E SDK
sifive_u             RISC-V Board compatible with SiFive U SDK
spike                RISC-V Spike Board (default)
virt                 RISC-V VirtIO board
% qemu-system-riscv32 -cpu help     
any
lowrisc-ibex
rv32
sifive-e31
sifive-e34
sifive-u34
```

Looks like it is working.
@alistair23 feel free to dismiss this PR if 5.2 is really required.
