### PR TITLE
hil: uart: fix grammar mistakes in comments

### DIFF
--- a/kernel/src/hil/uart.rs
+++ b/kernel/src/hil/uart.rs
@@ -87,7 +87,7 @@ pub trait Transmit<'a> {
     /// not SUCCESS, then the `tx_buffer` argument is returned in the
     /// `Option`. Other valid `ReturnCode` values are:
     ///  - EOFF: The underlying hardware is not available, perhaps because
-    ///          because it has not been initialized or in the case of a shared
+    ///          it has not been initialized or in the case of a shared
     ///          hardware USART controller because it is set up for SPI.
     ///  - EBUSY: the UART is already transmitting and has not made a
     ///           transmission callback yet.
@@ -114,7 +114,7 @@ pub trait Transmit<'a> {
     /// `transmitted_word` will be called on the `TransmitClient`.
     /// Other valid `ReturnCode` values are:
     ///  - EOFF: The underlying hardware is not available, perhaps because
-    ///          because it has not been initialized or in the case of a shared
+    ///          it has not been initialized or in the case of a shared
     ///          hardware USART controller because it is set up for SPI.
     ///  - EBUSY: the UART is already transmitting and has not made a
     ///           transmission callback yet.
@@ -137,8 +137,8 @@ pub trait Transmit<'a> {
     /// `transmit_word` or `transmit_buffer` then a call to
     /// `abort_transmit` returns SUCCESS. If there was a `transmit`
     /// outstanding and is cancelled successfully then `EBUSY` will
-    /// be returned and a there will be a callback with a `ReturnCode`
-    /// of `ECANCEL`.  If there was a reception outstanding, which is
+    /// be returned and there will be a callback with a `ReturnCode`
+    /// of `ECANCEL`. If there was a reception outstanding, which is
     /// not cancelled successfully, then `FAIL` will be returned and
     /// there will be a later callback.
     ///
@@ -161,7 +161,7 @@ pub trait Receive<'a> {
     /// not SUCCESS, then the `rx_buffer` argument is returned in the
     /// `Option`. Other valid return values are:
     ///  - EOFF: The underlying hardware is not available, perhaps because
-    ///          because it has not been initialized or in the case of a shared
+    ///          it has not been initialized or in the case of a shared
     ///          hardware USART controller because it is set up for SPI.
     ///  - EBUSY: the UART is already receiving and has not made a
     ///           reception `complete` callback yet.
@@ -184,7 +184,7 @@ pub trait Receive<'a> {
     /// `received_word` will be called on the `ReceiveClient`.
     /// Other valid `ReturnCode` values are:
     ///  - EOFF: The underlying hardware is not available, perhaps because
-    ///          because it has not been initialized or in the case of a shared
+    ///          it has not been initialized or in the case of a shared
     ///          hardware USART controller because it is set up for SPI.
     ///  - EBUSY: the UART is already receiving and has not made a
     ///           reception callback yet.
@@ -199,7 +199,7 @@ pub trait Receive<'a> {
     /// SUCCESS is returned, there will be no callback (no call to
     /// `receive` was outstanding). If there was a `receive`
     /// outstanding, which is cancelled successfully then `EBUSY` will
-    /// be returned and a there will be a callback with a `ReturnCode`
+    /// be returned and there will be a callback with a `ReturnCode`
     /// of `ECANCEL`.  If there was a reception outstanding, which is
     /// not cancelled successfully, then `FAIL` will be returned and
     /// there will be a later callback.


### PR DESCRIPTION
Several grammar mistakes in the Uart HIL were corrected.
