### PR TITLE
Change the OpenTitan boot ROM download URL to one that does not expire.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -506,14 +506,17 @@ endef
 
 define ci_setup_qemu_opentitan
 	$(call banner,CI-Setup: Get OpenTitan boot ROM image)
-	# Download OpenTitan image
-	@printf "Downloading OpenTitan boot rom from: 4429c362900713c059fbd870db140e0058e1c0eb\n"
+	# Download OpenTitan image. The latest image URL is available at
+	# https://storage.googleapis.com/artifacts.opentitan.org/latest.txt
+	# We download a fixed version so that new OpenTitan images do not
+	# unexpectedly change OpenTitan's behavior in our CI.
+	@printf "Downloading OpenTitan boot ROM\n"
 	@pwd=$$(pwd) && \
 		temp=$$(mktemp -d) && \
 		cd $$temp && \
-		curl $$(curl "https://dev.azure.com/lowrisc/opentitan/_apis/build/builds/23197/artifacts?artifactName=opentitan-dist&api-version=5.1" | cut -d \" -f 38) --output opentitan-dist.zip; \
-		unzip opentitan-dist.zip; \
-		tar -xf opentitan-dist/opentitan-snapshot-20191101-*.tar.xz; \
+		curl 'https://storage.googleapis.com/artifacts.opentitan.org/opentitan-snapshot-20191101-1-2744-g528004a3.tar.xz' \
+			--output opentitan-dist.tar.xz; \
+		tar -xf opentitan-dist.tar.xz; \
 		mv opentitan-snapshot-20191101-*/sw/device/boot_rom/boot_rom_fpga_nexysvideo.elf $$pwd/tools/qemu-runner/opentitan-boot-rom.elf
 endef
 
@@ -527,7 +530,7 @@ ci-setup-qemu:
 		ci_setup_qemu_riscv,\
 		CI_JOB_QEMU_RISCV)
 	$(call ci_setup_helper,\
-		[[ $$(cksum tools/qemu-runner/opentitan-boot-rom.elf | cut -d" " -f1) == "2835238144" ]] && echo yes,\
+		[[ $$(cksum tools/qemu-runner/opentitan-boot-rom.elf | cut -d" " -f1) == "328682170" ]] && echo yes,\
 		Download opentitan archive and unpack a ROM image,\
 		ci_setup_qemu_opentitan,\
 		CI_JOB_QEMU_OPENTITAN)


### PR DESCRIPTION
### Pull Request Overview

Previously, the OpenTitan boot ROM was downloaded from the OpenTitan CI system's artifact storage. Those artifacts are temporary, and expire after some time, which has required repeated updates to the URL to keep Tock's CI working. This has been particularly painful for libtock-rs, which uses Tock as a git submodule.

To avoid the expiration-based CI breakage, we have hosted a copy of the CI artifacts in long-term storage for use by Tock's CI system. This commit points Tock's CI at the new storage location.

### Testing Strategy

This pull request was tested by manually running `make -j4 ci-setup-qemu` on my development system.

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`. *`make prepush` made a hundreds of changes that are unrelated to this PR -- I think it needs to be run on master.*
