### PR TITLE
No more globals E310 / HiFive

### DIFF
--- a/chips/e310x/src/gpio.rs
+++ b/chips/e310x/src/gpio.rs
@@ -5,7 +5,7 @@ use core::ops::{Index, IndexMut};
 use kernel::common::StaticRef;
 use sifive::gpio::{pins, GpioPin, GpioRegisters};
 
-const GPIO0_BASE: StaticRef<GpioRegisters> =
+pub const GPIO0_BASE: StaticRef<GpioRegisters> =
     unsafe { StaticRef::new(0x1001_2000 as *const GpioRegisters) };
 
 pub struct Port<'a> {
@@ -26,149 +26,153 @@ impl<'a> IndexMut<usize> for Port<'a> {
     }
 }
 
-pub static mut PORT: Port = Port {
-    pins: [
-        GpioPin::new(GPIO0_BASE, pins::pin0, pins::pin0::SET, pins::pin0::CLEAR),
-        GpioPin::new(GPIO0_BASE, pins::pin1, pins::pin1::SET, pins::pin1::CLEAR),
-        GpioPin::new(GPIO0_BASE, pins::pin2, pins::pin2::SET, pins::pin2::CLEAR),
-        GpioPin::new(GPIO0_BASE, pins::pin3, pins::pin3::SET, pins::pin3::CLEAR),
-        GpioPin::new(GPIO0_BASE, pins::pin4, pins::pin4::SET, pins::pin4::CLEAR),
-        GpioPin::new(GPIO0_BASE, pins::pin5, pins::pin5::SET, pins::pin5::CLEAR),
-        GpioPin::new(GPIO0_BASE, pins::pin6, pins::pin6::SET, pins::pin6::CLEAR),
-        GpioPin::new(GPIO0_BASE, pins::pin7, pins::pin7::SET, pins::pin7::CLEAR),
-        GpioPin::new(GPIO0_BASE, pins::pin8, pins::pin8::SET, pins::pin8::CLEAR),
-        GpioPin::new(GPIO0_BASE, pins::pin9, pins::pin9::SET, pins::pin9::CLEAR),
-        GpioPin::new(
-            GPIO0_BASE,
-            pins::pin10,
-            pins::pin10::SET,
-            pins::pin10::CLEAR,
-        ),
-        GpioPin::new(
-            GPIO0_BASE,
-            pins::pin11,
-            pins::pin11::SET,
-            pins::pin11::CLEAR,
-        ),
-        GpioPin::new(
-            GPIO0_BASE,
-            pins::pin12,
-            pins::pin12::SET,
-            pins::pin12::CLEAR,
-        ),
-        GpioPin::new(
-            GPIO0_BASE,
-            pins::pin13,
-            pins::pin13::SET,
-            pins::pin13::CLEAR,
-        ),
-        GpioPin::new(
-            GPIO0_BASE,
-            pins::pin14,
-            pins::pin14::SET,
-            pins::pin14::CLEAR,
-        ),
-        GpioPin::new(
-            GPIO0_BASE,
-            pins::pin15,
-            pins::pin15::SET,
-            pins::pin15::CLEAR,
-        ),
-        GpioPin::new(
-            GPIO0_BASE,
-            pins::pin16,
-            pins::pin16::SET,
-            pins::pin16::CLEAR,
-        ),
-        GpioPin::new(
-            GPIO0_BASE,
-            pins::pin17,
-            pins::pin17::SET,
-            pins::pin17::CLEAR,
-        ),
-        GpioPin::new(
-            GPIO0_BASE,
-            pins::pin18,
-            pins::pin18::SET,
-            pins::pin18::CLEAR,
-        ),
-        GpioPin::new(
-            GPIO0_BASE,
-            pins::pin19,
-            pins::pin19::SET,
-            pins::pin19::CLEAR,
-        ),
-        GpioPin::new(
-            GPIO0_BASE,
-            pins::pin20,
-            pins::pin20::SET,
-            pins::pin20::CLEAR,
-        ),
-        GpioPin::new(
-            GPIO0_BASE,
-            pins::pin21,
-            pins::pin21::SET,
-            pins::pin21::CLEAR,
-        ),
-        GpioPin::new(
-            GPIO0_BASE,
-            pins::pin22,
-            pins::pin22::SET,
-            pins::pin22::CLEAR,
-        ),
-        GpioPin::new(
-            GPIO0_BASE,
-            pins::pin23,
-            pins::pin23::SET,
-            pins::pin23::CLEAR,
-        ),
-        GpioPin::new(
-            GPIO0_BASE,
-            pins::pin24,
-            pins::pin24::SET,
-            pins::pin24::CLEAR,
-        ),
-        GpioPin::new(
-            GPIO0_BASE,
-            pins::pin25,
-            pins::pin25::SET,
-            pins::pin25::CLEAR,
-        ),
-        GpioPin::new(
-            GPIO0_BASE,
-            pins::pin26,
-            pins::pin26::SET,
-            pins::pin26::CLEAR,
-        ),
-        GpioPin::new(
-            GPIO0_BASE,
-            pins::pin27,
-            pins::pin27::SET,
-            pins::pin27::CLEAR,
-        ),
-        GpioPin::new(
-            GPIO0_BASE,
-            pins::pin28,
-            pins::pin28::SET,
-            pins::pin28::CLEAR,
-        ),
-        GpioPin::new(
-            GPIO0_BASE,
-            pins::pin29,
-            pins::pin29::SET,
-            pins::pin29::CLEAR,
-        ),
-        GpioPin::new(
-            GPIO0_BASE,
-            pins::pin30,
-            pins::pin30::SET,
-            pins::pin30::CLEAR,
-        ),
-        GpioPin::new(
-            GPIO0_BASE,
-            pins::pin31,
-            pins::pin31::SET,
-            pins::pin31::CLEAR,
-        ),
-    ],
-};
+impl<'a> Port<'a> {
+    pub const fn new() -> Self {
+        Self {
+            pins: [
+                GpioPin::new(GPIO0_BASE, pins::pin0, pins::pin0::SET, pins::pin0::CLEAR),
+                GpioPin::new(GPIO0_BASE, pins::pin1, pins::pin1::SET, pins::pin1::CLEAR),
+                GpioPin::new(GPIO0_BASE, pins::pin2, pins::pin2::SET, pins::pin2::CLEAR),
+                GpioPin::new(GPIO0_BASE, pins::pin3, pins::pin3::SET, pins::pin3::CLEAR),
+                GpioPin::new(GPIO0_BASE, pins::pin4, pins::pin4::SET, pins::pin4::CLEAR),
+                GpioPin::new(GPIO0_BASE, pins::pin5, pins::pin5::SET, pins::pin5::CLEAR),
+                GpioPin::new(GPIO0_BASE, pins::pin6, pins::pin6::SET, pins::pin6::CLEAR),
+                GpioPin::new(GPIO0_BASE, pins::pin7, pins::pin7::SET, pins::pin7::CLEAR),
+                GpioPin::new(GPIO0_BASE, pins::pin8, pins::pin8::SET, pins::pin8::CLEAR),
+                GpioPin::new(GPIO0_BASE, pins::pin9, pins::pin9::SET, pins::pin9::CLEAR),
+                GpioPin::new(
+                    GPIO0_BASE,
+                    pins::pin10,
+                    pins::pin10::SET,
+                    pins::pin10::CLEAR,
+                ),
+                GpioPin::new(
+                    GPIO0_BASE,
+                    pins::pin11,
+                    pins::pin11::SET,
+                    pins::pin11::CLEAR,
+                ),
+                GpioPin::new(
+                    GPIO0_BASE,
+                    pins::pin12,
+                    pins::pin12::SET,
+                    pins::pin12::CLEAR,
+                ),
+                GpioPin::new(
+                    GPIO0_BASE,
+                    pins::pin13,
+                    pins::pin13::SET,
+                    pins::pin13::CLEAR,
+                ),
+                GpioPin::new(
+                    GPIO0_BASE,
+                    pins::pin14,
+                    pins::pin14::SET,
+                    pins::pin14::CLEAR,
+                ),
+                GpioPin::new(
+                    GPIO0_BASE,
+                    pins::pin15,
+                    pins::pin15::SET,
+                    pins::pin15::CLEAR,
+                ),
+                GpioPin::new(
+                    GPIO0_BASE,
+                    pins::pin16,
+                    pins::pin16::SET,
+                    pins::pin16::CLEAR,
+                ),
+                GpioPin::new(
+                    GPIO0_BASE,
+                    pins::pin17,
+                    pins::pin17::SET,
+                    pins::pin17::CLEAR,
+                ),
+                GpioPin::new(
+                    GPIO0_BASE,
+                    pins::pin18,
+                    pins::pin18::SET,
+                    pins::pin18::CLEAR,
+                ),
+                GpioPin::new(
+                    GPIO0_BASE,
+                    pins::pin19,
+                    pins::pin19::SET,
+                    pins::pin19::CLEAR,
+                ),
+                GpioPin::new(
+                    GPIO0_BASE,
+                    pins::pin20,
+                    pins::pin20::SET,
+                    pins::pin20::CLEAR,
+                ),
+                GpioPin::new(
+                    GPIO0_BASE,
+                    pins::pin21,
+                    pins::pin21::SET,
+                    pins::pin21::CLEAR,
+                ),
+                GpioPin::new(
+                    GPIO0_BASE,
+                    pins::pin22,
+                    pins::pin22::SET,
+                    pins::pin22::CLEAR,
+                ),
+                GpioPin::new(
+                    GPIO0_BASE,
+                    pins::pin23,
+                    pins::pin23::SET,
+                    pins::pin23::CLEAR,
+                ),
+                GpioPin::new(
+                    GPIO0_BASE,
+                    pins::pin24,
+                    pins::pin24::SET,
+                    pins::pin24::CLEAR,
+                ),
+                GpioPin::new(
+                    GPIO0_BASE,
+                    pins::pin25,
+                    pins::pin25::SET,
+                    pins::pin25::CLEAR,
+                ),
+                GpioPin::new(
+                    GPIO0_BASE,
+                    pins::pin26,
+                    pins::pin26::SET,
+                    pins::pin26::CLEAR,
+                ),
+                GpioPin::new(
+                    GPIO0_BASE,
+                    pins::pin27,
+                    pins::pin27::SET,
+                    pins::pin27::CLEAR,
+                ),
+                GpioPin::new(
+                    GPIO0_BASE,
+                    pins::pin28,
+                    pins::pin28::SET,
+                    pins::pin28::CLEAR,
+                ),
+                GpioPin::new(
+                    GPIO0_BASE,
+                    pins::pin29,
+                    pins::pin29::SET,
+                    pins::pin29::CLEAR,
+                ),
+                GpioPin::new(
+                    GPIO0_BASE,
+                    pins::pin30,
+                    pins::pin30::SET,
+                    pins::pin30::CLEAR,
+                ),
+                GpioPin::new(
+                    GPIO0_BASE,
+                    pins::pin31,
+                    pins::pin31::SET,
+                    pins::pin31::CLEAR,
+                ),
+            ],
+        }
+    }
+}

--- a/chips/e310x/src/prci.rs
+++ b/chips/e310x/src/prci.rs
@@ -1,9 +1,7 @@
 //! Power Reset Clock Interrupt controller instantiation.
 
 use kernel::common::StaticRef;
-use sifive::prci::{Prci, PrciRegisters};
+use sifive::prci::PrciRegisters;
 
-pub static mut PRCI: Prci = Prci::new(PRCI_BASE);
-
-const PRCI_BASE: StaticRef<PrciRegisters> =
+pub const PRCI_BASE: StaticRef<PrciRegisters> =
     unsafe { StaticRef::new(0x1000_8000 as *const PrciRegisters) };

--- a/chips/e310x/src/pwm.rs
+++ b/chips/e310x/src/pwm.rs
@@ -1,15 +1,11 @@
 //! PWM instantiation.
 
 use kernel::common::StaticRef;
-use sifive::pwm::{Pwm, PwmRegisters};
+use sifive::pwm::PwmRegisters;
 
-pub static mut PWM0: Pwm = Pwm::new(PWM0_BASE);
-pub static mut PWM1: Pwm = Pwm::new(PWM1_BASE);
-pub static mut PWM2: Pwm = Pwm::new(PWM2_BASE);
-
-const PWM0_BASE: StaticRef<PwmRegisters> =
+pub const PWM0_BASE: StaticRef<PwmRegisters> =
     unsafe { StaticRef::new(0x10015000 as *const PwmRegisters) };
-const PWM1_BASE: StaticRef<PwmRegisters> =
+pub const PWM1_BASE: StaticRef<PwmRegisters> =
     unsafe { StaticRef::new(0x10025000 as *const PwmRegisters) };
-const PWM2_BASE: StaticRef<PwmRegisters> =
+pub const PWM2_BASE: StaticRef<PwmRegisters> =
     unsafe { StaticRef::new(0x10035000 as *const PwmRegisters) };

--- a/chips/e310x/src/rtc.rs
+++ b/chips/e310x/src/rtc.rs
@@ -1,9 +1,7 @@
 //! RTC instantiation.
 
 use kernel::common::StaticRef;
-use sifive::rtc::{Rtc, RtcRegisters};
+use sifive::rtc::RtcRegisters;
 
-pub static mut RTC: Rtc = Rtc::new(RTC_BASE);
-
-const RTC_BASE: StaticRef<RtcRegisters> =
+pub const RTC_BASE: StaticRef<RtcRegisters> =
     unsafe { StaticRef::new(0x1000_0040 as *const RtcRegisters) };

--- a/chips/e310x/src/timer.rs
+++ b/chips/e310x/src/timer.rs
@@ -1,9 +1,7 @@
 //! Machine Timer instantiation.
 
 use kernel::common::StaticRef;
-use rv32i::machine_timer::{MachineTimer, MachineTimerRegisters};
+use rv32i::machine_timer::MachineTimerRegisters;
 
-pub static mut MACHINETIMER: MachineTimer = MachineTimer::new(MTIME_BASE);
-
-const MTIME_BASE: StaticRef<MachineTimerRegisters> =
+pub const MTIME_BASE: StaticRef<MachineTimerRegisters> =
     unsafe { StaticRef::new(0x0200_0000 as *const MachineTimerRegisters) };

--- a/chips/e310x/src/uart.rs
+++ b/chips/e310x/src/uart.rs
@@ -1,9 +1,7 @@
 //! UART instantiation.
 
 use kernel::common::StaticRef;
-use sifive::uart::{Uart, UartRegisters};
+use sifive::uart::UartRegisters;
 
-pub static mut UART0: Uart = Uart::new(UART0_BASE, 16_000_000);
-
-const UART0_BASE: StaticRef<UartRegisters> =
+pub const UART0_BASE: StaticRef<UartRegisters> =
     unsafe { StaticRef::new(0x1001_3000 as *const UartRegisters) };

--- a/chips/e310x/src/watchdog.rs
+++ b/chips/e310x/src/watchdog.rs
@@ -1,10 +1,8 @@
-//! Watchdog instantiation.
+//! Watchdog registers.
 
 use kernel::common::StaticRef;
 
-use sifive::watchdog::{Watchdog, WatchdogRegisters};
+use sifive::watchdog::WatchdogRegisters;
 
-pub static mut WATCHDOG: Watchdog = Watchdog::new(WATCHDOG_BASE);
-
-const WATCHDOG_BASE: StaticRef<WatchdogRegisters> =
+pub const WATCHDOG_BASE: StaticRef<WatchdogRegisters> =
     unsafe { StaticRef::new(0x1000_0000 as *const WatchdogRegisters) };


### PR DESCRIPTION
### Pull Request Overview

This pull request ports the HiFive board / E310 chip to use the new peripheral instantiation design first proposed in #2069 . The first commit is a duplicate from that PR which can be removed once the original is merged.


### Testing Strategy

This pull request was tested by compiling, some hardware test would probably be useful.


### TODO or Help Wanted

N/A

### Documentation Updated

- [x] No updates are required.

### Formatting

- [x] Ran `make prepush`.
