### PR TITLE
Synchronous panic output over USB for nano33ble

### DIFF
--- a/boards/nano33ble/README.md
+++ b/boards/nano33ble/README.md
@@ -108,7 +108,10 @@ supports reading and writing to a serial console with `tockloader listen`.
 If the kernel or an app encounter a `panic!()`, the panic handler specified in
 `io.rs` is called. This causes the kernel to stop. You will notice the yellow
 LED starts blinking in a repeating but slightly irregular pattern. There is also
-a panic print out that provides a fair bit of debugging information. However,
-currently that panic print info is transmitted over `UARTE0`, not the USB port.
-So, to view the panic info, you will need to connect to the two pins on the
-board labeled `TX1` and `RX0` and view the UART information there.
+a panic print out that provides a fair bit of debugging information. That panic
+output is output over the USB CDC connection and so should be visible as part
+of the output of `tockloader listen`, however if your kernel panics so early
+that the USB connection has not yet been established you will be unable to view
+any panic output. In this case, you can modify the panic handler to instead
+output panic information over the UART pins, but you will have to separately interface
+with the UART pins on the board in order to observe the serial output.

--- a/boards/nano33ble/src/io.rs
+++ b/boards/nano33ble/src/io.rs
@@ -75,14 +75,14 @@ impl IoWrite for Writer {
         }
 
         unsafe {
-            // If CDC_REF is not yet set we panicked very early,
+            // If CDC_REF_FOR_PANIC is not yet set we panicked very early,
             // and not much we can do. Don't want to double fault,
             // so just return.
-            super::CDC_REF.map(|cdc| {
+            super::CDC_REF_FOR_PANIC.map(|cdc| {
                 // Lots of unsafe dereferencing of global static mut objects here.
                 // However, this should be okay, because it all happens within
                 // a single thread, and:
-                // - This is the only place the global CDC_REF is used, the logic is the same
+                // - This is the only place the global CDC_REF_FOR_PANIC is used, the logic is the same
                 //   as applies for the global CHIP variable used in the panic handler.
                 // - We do create multiple mutable references to the STATIC_PANIC_BUF, but we never
                 //   access the STATIC_PANIC_BUF after a slice of it is passed to transmit_buffer

--- a/boards/nano33ble/src/io.rs
+++ b/boards/nano33ble/src/io.rs
@@ -5,11 +5,13 @@ use cortexm4;
 use kernel::debug;
 use kernel::debug::IoWrite;
 use kernel::hil::led;
-use kernel::hil::uart::{self, Configure};
+use kernel::hil::uart::{self};
 use nrf52840::gpio::Pin;
 
 use crate::CHIP;
 use crate::PROCESSES;
+use kernel::common::cells::VolatileCell;
+use kernel::hil::uart::Transmit;
 
 struct Writer {
     initialized: bool,
@@ -24,24 +26,91 @@ impl Write for Writer {
     }
 }
 
+const BUF_LEN: usize = 512;
+static mut STATIC_PANIC_BUF: [u8; BUF_LEN] = [0; BUF_LEN];
+
+static mut DUMMY: DummyUsbClient = DummyUsbClient {
+    fired: VolatileCell::new(false),
+};
+
+struct DummyUsbClient {
+    fired: VolatileCell<bool>,
+}
+
+impl uart::TransmitClient for DummyUsbClient {
+    fn transmitted_buffer(&self, _: &'static mut [u8], _: usize, _: kernel::ReturnCode) {
+        self.fired.set(true);
+    }
+}
+
 impl IoWrite for Writer {
     fn write(&mut self, buf: &[u8]) {
-        let uart = unsafe { &mut nrf52840::uart::UARTE0 };
         if !self.initialized {
             self.initialized = true;
-            uart.configure(uart::Parameters {
-                baud_rate: 115200,
-                stop_bits: uart::StopBits::One,
-                parity: uart::Parity::None,
-                hw_flow_control: false,
-                width: uart::Width::Eight,
-            });
         }
-        for &c in buf {
-            unsafe {
-                uart.send_byte(c);
+        // Here we mimic a synchronous UART output by calling transmit_buffer
+        // on the CDC stack and then spinning on USB interrupts until the transaction
+        // is complete. If the USB or CDC stack panicked, this may fail. It will also
+        // fail if the panic occurred prior to the USB connection being initialized.
+        // In the latter case, the LEDs should still blink in the panic pattern.
+
+        // spin so that if any USB DMA is ongoing it will finish
+        // we should only need this on the first call to write()
+        let mut i = 0;
+        loop {
+            i += 1;
+            cortexm4::support::nop();
+            if i > 10000 {
+                break;
             }
-            while !uart.tx_ready() {}
+        }
+
+        // copy_from_slice() requires equal length slices
+        // This will truncate any writes longer than BUF_LEN, but simplifies the
+        // code. In practice, BUF_LEN=512 always seems sufficient for the size of
+        // individual calls to write made by the panic handler.
+        let mut max = BUF_LEN;
+        if buf.len() < BUF_LEN {
+            max = buf.len();
+        }
+
+        unsafe {
+            // If CDC_REF is not yet set we panicked very early,
+            // and not much we can do. Don't want to double fault,
+            // so just return.
+            super::CDC_REF.map(|cdc| {
+                // Lots of unsafe dereferencing of global static mut objects here.
+                // However, this should be okay, because it all happens within
+                // a single thread, and:
+                // - This is the only place the global CDC_REF is used, the logic is the same
+                //   as applies for the global CHIP variable used in the panic handler.
+                // - We do create multiple mutable references to the STATIC_PANIC_BUF, but we never
+                //   access the STATIC_PANIC_BUF after a slice of it is passed to transmit_buffer
+                //   until the slice has been returned in the uart callback.
+                // - Similarly, only this function uses the global DUMMY variable, and we do not
+                //   mutate it.
+                let usb = &mut nrf52840::usbd::USBD;
+                STATIC_PANIC_BUF[..max].copy_from_slice(&buf[..max]);
+                let static_buf = &mut STATIC_PANIC_BUF;
+                cdc.set_transmit_client(&DUMMY);
+                cdc.transmit_buffer(static_buf, max);
+                loop {
+                    if let Some(interrupt) = cortexm4::nvic::next_pending() {
+                        if interrupt == 39 {
+                            usb.handle_interrupt();
+                        }
+                        let n = cortexm4::nvic::Nvic::new(interrupt);
+                        n.clear_pending();
+                        n.enable();
+                    }
+                    if DUMMY.fired.get() == true {
+                        // buffer finished transmitting, return so we can output additional
+                        // messages when requested by the panic handler.
+                        break;
+                    }
+                }
+                DUMMY.fired.set(false);
+            });
         }
     }
 }

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -71,6 +71,7 @@ const NUM_PROCS: usize = 8;
 static mut PROCESSES: [Option<&'static dyn kernel::procs::ProcessType>; NUM_PROCS] = [None; 8];
 
 static mut CHIP: Option<&'static nrf52840::chip::Chip> = None;
+static mut CDC_REF: Option<&'static capsules::usb::cdc::CdcAcm<'static, nrf52::usbd::Usbd>> = None;
 
 /// Dummy buffer that causes the linker to reserve enough space for the stack.
 #[no_mangle]
@@ -231,6 +232,7 @@ pub unsafe fn reset_handler() {
         strings,
     )
     .finalize(components::usb_cdc_acm_component_helper!(nrf52::usbd::Usbd));
+    CDC_REF = Some(cdc); //for use by panic handler
 
     // Create a shared UART channel for the console and for kernel debug.
     let uart_mux = components::console::UartMuxComponent::new(cdc, 115200, dynamic_deferred_caller)

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -71,7 +71,9 @@ const NUM_PROCS: usize = 8;
 static mut PROCESSES: [Option<&'static dyn kernel::procs::ProcessType>; NUM_PROCS] = [None; 8];
 
 static mut CHIP: Option<&'static nrf52840::chip::Chip> = None;
-static mut CDC_REF: Option<&'static capsules::usb::cdc::CdcAcm<'static, nrf52::usbd::Usbd>> = None;
+static mut CDC_REF_FOR_PANIC: Option<
+    &'static capsules::usb::cdc::CdcAcm<'static, nrf52::usbd::Usbd>,
+> = None;
 
 /// Dummy buffer that causes the linker to reserve enough space for the stack.
 #[no_mangle]
@@ -232,7 +234,7 @@ pub unsafe fn reset_handler() {
         strings,
     )
     .finalize(components::usb_cdc_acm_component_helper!(nrf52::usbd::Usbd));
-    CDC_REF = Some(cdc); //for use by panic handler
+    CDC_REF_FOR_PANIC = Some(cdc); //for use by panic handler
 
     // Create a shared UART channel for the console and for kernel debug.
     let uart_mux = components::console::UartMuxComponent::new(cdc, 115200, dynamic_deferred_caller)


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes #1972 by implementing a "synchronous" panic output via USB CDC for the nano33ble. It does so by spin-waiting for USB interrupts to allow the USB and CDC state machines to operate as intended despite the fact that the core kernel is no longer running and dispatching interrupts. It also requires some creative use of `static mut` global variables to give the panic handler access to the resources it needs.

Of course, this approach will not provide panic output if the USB connection is not yet established. Still it is a substantial improvement over the current state of affairs which requires using a separate serial port adapter to get panic output off the device.


### Testing Strategy

This pull request was tested by manually inserting a panic in the LED capsule, and observing the panic output using `tockloader listen` when running the blink app.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`

### Formatting

- [x] Ran `make prepush`.
