### PR TITLE
build capsules/examples in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -424,7 +424,7 @@ ci-job-kernel:
 ci-job-capsules:
 	$(call banner,CI-Job: Capsules)
 	@# Capsule initialization depends on board/chip specific imports, so ignore doc tests
-	@cd capsules && CI=true RUSTFLAGS="-D warnings" TOCK_KERNEL_VERSION=ci_test cargo test --lib
+	@cd capsules && CI=true RUSTFLAGS="-D warnings" TOCK_KERNEL_VERSION=ci_test cargo test --lib --examples
 
 .PHONY: ci-job-chips
 ci-job-chips:


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes #1075. It is a very straightforward fix now that we already run `cargo test --lib` for capsules.


### Testing Strategy

This pull request was tested by introducing an error in `capsules/examples/traitobj_list.rs` and verifying that doing so now causes CI to fail, while it did not before.


### TODO or Help Wanted

N/A

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
