### PR TITLE
dont let linker assume 512 byte page size

### DIFF
--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -24,15 +24,11 @@ TARGET_DIRECTORY ?= $(TOCK_ROOT_DIRECTORY)target/
 
 # RUSTC_FLAGS allows boards to define board-specific options.
 # This will hopefully move into Cargo.toml (or Cargo.toml.local) eventually.
-# lld uses the page size to align program sections. It defaults to 4096 and this
-# puts a gap between before the .relocate section. `zmax-page-size=512` tells
-# lld the actual page size so it doesn't have to be conservative.
 RUSTC_FLAGS ?= \
   -C link-arg=-Tlayout.ld \
   -C linker=rust-lld \
   -C linker-flavor=ld.lld \
   -C relocation-model=dynamic-no-pic \
-  -C link-arg=-zmax-page-size=512 \
   -C link-arg=-icf=all \
 
 # RISC-V-specific flags.


### PR DESCRIPTION
### Pull Request Overview

Now that we support non-SAM4L chips, I don't think it is safe for the linker to assume a maximum page size of 512 bytes. While https://github.com/tock/tock/pull/2090/ added a variable to the layout file for each board to specify its page size, I am not sure how to access that variable, so this PR just removes the linker option. However if someone better at Makefiles than me does know an easy way to access that, we should just use it instead of 512.


### Testing Strategy

CI

### TODO or Help Wanted

N/A

### Documentation Updated

- [x] No updates are required.

### Formatting

- [x] Ran `make prepush`.
