### PR TITLE
Virtual log

### DIFF
--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -27,6 +27,10 @@ use kernel::{create_capability, debug, debug_gpio, debug_verbose, static_init};
 use nrf52840::gpio::Pin;
 use nrf52840::interrupt_service::Nrf52840DefaultPeripherals;
 
+// Unit Tests for drivers.
+#[allow(dead_code)]
+mod test;
+
 // Three-color LED.
 const LED_RED_PIN: Pin = Pin::P0_24;
 const LED_GREEN_PIN: Pin = Pin::P0_16;
@@ -357,6 +361,16 @@ pub unsafe fn reset_handler() {
     // Configure the USB stack to enable a serial port over CDC-ACM.
     cdc.enable();
     cdc.attach();
+
+    //--------------------------------------------------------------------------
+    // OPTIONAL KERNEL TESTS
+    //--------------------------------------------------------------------------
+
+    // Test logging facilities in linear mode.
+    test::linear_log_test::run(mux_alarm, dynamic_deferred_caller, &base_peripherals.nvmc);
+
+    // Test logging facilities in circular mode.
+    test::log_test::run(mux_alarm, dynamic_deferred_caller, &base_peripherals.nvmc);
 
     debug!("Initialization complete. Entering main loop.");
 

--- a/boards/nano33ble/src/test/linear_log_test.rs
+++ b/boards/nano33ble/src/test/linear_log_test.rs
@@ -94,7 +94,7 @@ static mut BUFFER: [u8; 310] = [0; 310];
 const WAIT_MS: u32 = 3;
 
 // A single operation within the test.
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, PartialEq, Debug)]
 enum TestOp {
     Read,
     Write(usize),
@@ -135,14 +135,22 @@ impl<A: Alarm<'static>> LogTest<A> {
     fn run(&self) {
         let op_index = self.op_index.get();
         if op_index == self.ops.len() {
-            debug!("Linear Log Storage test succeeded!");
-            return;
-        }
-
-        match self.ops[op_index] {
-            TestOp::Read => self.read(),
-            TestOp::Write(len) => self.write(len),
-            TestOp::Sync => self.sync(),
+            // There are no operations to perform.
+            debug!("[LinearLogTest] Success!");
+        } else {
+            // There are still operations to perform.
+            let op_total = self.ops.len();
+            debug!(
+                "[LinearLogTest] Executing operation {} of {}: {:?}.",
+                op_index + 1,
+                op_total,
+                self.ops[op_index]
+            );
+            match self.ops[op_index] {
+                TestOp::Read => self.read(),
+                TestOp::Write(len) => self.write(len),
+                TestOp::Sync => self.sync(),
+            }
         }
     }
 

--- a/boards/nano33ble/src/test/linear_log_test.rs
+++ b/boards/nano33ble/src/test/linear_log_test.rs
@@ -173,10 +173,15 @@ impl<A: Alarm<'static>> LogTest<A> {
         match self.buffer.take() {
             Some(buffer) => match self.log.read(buffer, buffer.len()) {
                 Ok(_) => debug_verbose!("Dispatch of asynchronous log read succeeded."),
-                Err((error_code, _)) => debug_verbose!(
-                    "Dispatch of asynchronous log read failed with error code {:?}.",
-                    error_code
-                ),
+                Err((error_code, buffer)) => {
+                    debug_verbose!(
+                        "Dispatch of asynchronous log read failed with error code {:?}.",
+                        error_code
+                    );
+                    self.buffer.replace(buffer);
+                    self.op_index.increment();
+                    self.run();
+                }
             },
             None => panic!("Aborting read with no buffer."),
         }

--- a/boards/nano33ble/src/test/linear_log_test.rs
+++ b/boards/nano33ble/src/test/linear_log_test.rs
@@ -1,0 +1,322 @@
+//! Tests the log storage interface in linear mode. For testing in circular mode, see
+//! log_test.rs.
+//!
+//! The testing framework creates a non-circular log storage interface in flash and performs a
+//! series of writes and syncs to ensure that the non-circular log properly denies overly-large
+//! writes once it is full. For testing all of the general capabilities of the log storage
+//! interface, see log_test.rs.
+//!
+//! To run the test, add the following line to the imix boot sequence:
+//! ```
+//!     test::linear_log_test::run(mux_alarm, dynamic_deferred_caller);
+//! ```
+//! and use the `USER` and `RESET` buttons to manually erase the log and reboot the imix,
+//! respectively.
+
+use capsules::log;
+use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
+use core::cell::Cell;
+use kernel::common::cells::{NumericCellExt, TakeCell};
+use kernel::common::dynamic_deferred_call::DynamicDeferredCall;
+use kernel::debug;
+use kernel::hil::flash;
+use kernel::hil::log::{LogRead, LogReadClient, LogWrite, LogWriteClient};
+use kernel::hil::time::{Alarm, AlarmClient};
+use kernel::static_init;
+use kernel::storage_volume;
+use kernel::ReturnCode;
+use nrf52840::{nvmc, rtc::Rtc};
+
+// Allocate 1kiB volume for log storage.
+storage_volume!(LINEAR_TEST_LOG, 1);
+
+pub unsafe fn run(
+    mux_alarm: &'static MuxAlarm<'static, Rtc>,
+    deferred_caller: &'static DynamicDeferredCall,
+    flash_controller: &'static nvmc::Nvmc,
+) {
+    // Set up flash controller.
+    flash_controller.configure_writeable();
+    flash_controller.configure_eraseable();
+    let pagebuffer = static_init!(nvmc::NrfPage, nvmc::NrfPage::default());
+
+    // Create actual log storage abstraction on top of flash.
+    let log = static_init!(
+        Log,
+        log::Log::new(
+            &LINEAR_TEST_LOG,
+            &flash_controller,
+            pagebuffer,
+            deferred_caller,
+            false
+        )
+    );
+    flash::HasClient::set_client(flash_controller, log);
+    log.initialize_callback_handle(
+        deferred_caller
+            .register(log)
+            .expect("no deferred call slot available for log storage"),
+    );
+
+    // Create and run test for log storage.
+    let test = static_init!(
+        LogTest<VirtualMuxAlarm<'static, Rtc>>,
+        LogTest::new(log, &mut BUFFER, VirtualMuxAlarm::new(mux_alarm), &TEST_OPS)
+    );
+    log.set_read_client(test);
+    log.set_append_client(test);
+    test.alarm.set_alarm_client(test);
+
+    test.run();
+}
+
+static TEST_OPS: [TestOp; 9] = [
+    TestOp::Read,
+    // Write to first page.
+    TestOp::Write(8),
+    TestOp::Write(300),
+    // Write to next page, too large to fit on first.
+    TestOp::Write(304),
+    // Write should fail, not enough space remaining.
+    TestOp::Write(306),
+    // Write should succeed, enough space for a smaller entry.
+    TestOp::Write(9),
+    // Read back everything to verify and sync.
+    TestOp::Read,
+    TestOp::Sync,
+    // Write should still fail after sync.
+    TestOp::Write(308),
+];
+
+// Buffer for reading from and writing to in the log tests.
+static mut BUFFER: [u8; 310] = [0; 310];
+// Time to wait in between log operations.
+const WAIT_MS: u32 = 3;
+
+// A single operation within the test.
+#[derive(Clone, Copy, PartialEq)]
+enum TestOp {
+    Read,
+    Write(usize),
+    Sync,
+}
+
+type Log = log::Log<'static, nvmc::Nvmc>;
+struct LogTest<A: Alarm<'static>> {
+    log: &'static Log,
+    buffer: TakeCell<'static, [u8]>,
+    alarm: A,
+    ops: &'static [TestOp],
+    op_index: Cell<usize>,
+}
+
+impl<A: Alarm<'static>> LogTest<A> {
+    fn new(
+        log: &'static Log,
+        buffer: &'static mut [u8],
+        alarm: A,
+        ops: &'static [TestOp],
+    ) -> LogTest<A> {
+        debug!(
+            "Log recovered from flash (Start and end entry IDs: {:?} to {:?})",
+            log.log_start(),
+            log.log_end()
+        );
+
+        LogTest {
+            log,
+            buffer: TakeCell::new(buffer),
+            alarm,
+            ops,
+            op_index: Cell::new(0),
+        }
+    }
+
+    fn run(&self) {
+        let op_index = self.op_index.get();
+        if op_index == self.ops.len() {
+            debug!("Linear Log Storage test succeeded!");
+            return;
+        }
+
+        match self.ops[op_index] {
+            TestOp::Read => self.read(),
+            TestOp::Write(len) => self.write(len),
+            TestOp::Sync => self.sync(),
+        }
+    }
+
+    fn read(&self) {
+        self.buffer.take().map_or_else(
+            || panic!("NO BUFFER"),
+            move |buffer| {
+                // Clear buffer first to make debugging more sane.
+                for e in buffer.iter_mut() {
+                    *e = 0;
+                }
+
+                if let Err((error, original_buffer)) = self.log.read(buffer, buffer.len()) {
+                    self.buffer
+                        .replace(original_buffer.expect("No buffer returned in error!"));
+                    match error {
+                        ReturnCode::FAIL => {
+                            // No more entries, start writing again.
+                            debug!(
+                                "READ DONE: READ OFFSET: {:?} / WRITE OFFSET: {:?}",
+                                self.log.next_read_entry_id(),
+                                self.log.log_end()
+                            );
+                            self.op_index.increment();
+                            self.run();
+                        }
+                        ReturnCode::EBUSY => {
+                            debug!("Flash busy, waiting before reattempting read");
+                            self.wait();
+                        }
+                        _ => panic!("READ FAILED: {:?}", error),
+                    }
+                }
+            },
+        );
+    }
+
+    fn write(&self, len: usize) {
+        self.buffer
+            .take()
+            .map(move |buffer| {
+                let expect_write_fail = self.log.log_end() + len > LINEAR_TEST_LOG.len();
+
+                // Set buffer value.
+                for i in 0..buffer.len() {
+                    buffer[i] = if i < len {
+                        len as u8
+                    } else {
+                        0
+                    };
+                }
+
+                if let Err((error, original_buffer)) = self.log.append(buffer, len) {
+                    self.buffer.replace(original_buffer.expect("No buffer returned in error!"));
+
+                    match error {
+                        ReturnCode::FAIL =>
+                            if expect_write_fail {
+                                debug!(
+                                    "Write failed on {} byte write, as expected",
+                                    len
+                                );
+                                self.op_index.increment();
+                                self.run();
+                            } else {
+                                panic!(
+                                    "Write failed unexpectedly on {} byte write (read entry ID: {:?}, append entry ID: {:?})",
+                                    len,
+                                    self.log.next_read_entry_id(),
+                                    self.log.log_end()
+                                );
+                            }
+                        ReturnCode::EBUSY => self.wait(),
+                        _ => panic!("WRITE FAILED: {:?}", error),
+                    }
+                } else if expect_write_fail {
+                    panic!(
+                        "Write succeeded unexpectedly on {} byte write (read entry ID: {:?}, append entry ID: {:?})",
+                        len,
+                        self.log.next_read_entry_id(),
+                        self.log.log_end()
+                    );
+                }
+            })
+            .unwrap();
+    }
+
+    fn sync(&self) {
+        match self.log.sync() {
+            ReturnCode::SUCCESS => (),
+            error => panic!("Sync failed: {:?}", error),
+        }
+    }
+
+    fn wait(&self) {
+        let delay = A::ticks_from_ms(WAIT_MS);
+        let now = self.alarm.now();
+        self.alarm.set_alarm(now, delay);
+    }
+}
+
+impl<A: Alarm<'static>> LogReadClient for LogTest<A> {
+    fn read_done(&self, buffer: &'static mut [u8], length: usize, error: ReturnCode) {
+        match error {
+            ReturnCode::SUCCESS => {
+                // Verify correct value was read.
+                assert!(length > 0);
+                for i in 0..length {
+                    if buffer[i] != length as u8 {
+                        panic!(
+                            "Read incorrect value {} at index {}, expected {}",
+                            buffer[i], i, length
+                        );
+                    }
+                }
+
+                debug!("Successful read of size {}", length);
+                self.buffer.replace(buffer);
+                self.wait();
+            }
+            _ => {
+                panic!("Read failed unexpectedly!");
+            }
+        }
+    }
+
+    fn seek_done(&self, _error: ReturnCode) {
+        unreachable!();
+    }
+}
+
+impl<A: Alarm<'static>> LogWriteClient for LogTest<A> {
+    fn append_done(
+        &self,
+        buffer: &'static mut [u8],
+        length: usize,
+        records_lost: bool,
+        error: ReturnCode,
+    ) {
+        assert!(!records_lost);
+        match error {
+            ReturnCode::SUCCESS => {
+                debug!("Write succeeded on {} byte write, as expected", length);
+
+                self.buffer.replace(buffer);
+                self.op_index.increment();
+                self.wait();
+            }
+            error => panic!("WRITE FAILED IN CALLBACK: {:?}", error),
+        }
+    }
+
+    fn sync_done(&self, error: ReturnCode) {
+        if error == ReturnCode::SUCCESS {
+            debug!(
+                "SYNC DONE: READ OFFSET: {:?} / WRITE OFFSET: {:?}",
+                self.log.next_read_entry_id(),
+                self.log.log_end()
+            );
+        } else {
+            panic!("Sync failed: {:?}", error);
+        }
+
+        self.op_index.increment();
+        self.run();
+    }
+
+    fn erase_done(&self, _error: ReturnCode) {
+        unreachable!();
+    }
+}
+
+impl<A: Alarm<'static>> AlarmClient for LogTest<A> {
+    fn alarm(&self) {
+        self.run();
+    }
+}

--- a/boards/nano33ble/src/test/log_test.rs
+++ b/boards/nano33ble/src/test/log_test.rs
@@ -1,0 +1,649 @@
+//! Tests the log storage interface in circular mode. For testing in linear mode, see
+//! linear_log_test.rs.
+//!
+//! This testing framework creates a circular log storage interface in flash and runs a series of
+//! operations upon it. The tests check to make sure that the correct values are read and written
+//! after each operation, that errors are properly detected and handled, and that the log generally
+//! behaves as expected. The tests perform both valid and invalid operations to fully test the log's
+//! behavior.
+//!
+//! Pressing the `USER` button on the imix at any time during the test will erase the log and reset
+//! the test state. Pressing the `RESET` button will reboot the imix without erasing the log,
+//! allowing for testing logs across reboots.
+//!
+//! In order to fully test the log, the tester should try a variety of erases and reboots to ensure
+//! that the log works correctly across these operations. The tester can also modify the testing
+//! operations and parameters defined below to test logs in different configurations. Different
+//! configurations should be tested in order to exercise the log under a greater number of
+//! scenarios (e.g. saturating/not saturating log pages with data, always/not always ending
+//! operations at page boundaries, etc.).
+//!
+//! To run the test, add the following line to the imix boot sequence:
+//! ```
+//!     test::log_test::run(mux_alarm, dynamic_deferred_caller, &peripherals.flash_controller);
+//! ```
+//! and use the `USER` and `RESET` buttons to manually erase the log and reboot the imix,
+//! respectively.
+
+use capsules::log;
+use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
+use core::cell::Cell;
+use kernel::common::cells::{NumericCellExt, TakeCell};
+use kernel::common::dynamic_deferred_call::DynamicDeferredCall;
+use kernel::debug;
+use kernel::hil::flash;
+use kernel::hil::gpio::{self};
+use kernel::hil::log::{LogRead, LogReadClient, LogWrite, LogWriteClient};
+use kernel::hil::time::{Alarm, AlarmClient};
+use kernel::static_init;
+use kernel::storage_volume;
+use kernel::ReturnCode;
+use nrf52840::{nvmc, rtc::Rtc};
+
+// Allocate 2kiB volume for log storage.
+storage_volume!(TEST_LOG, 2);
+
+pub unsafe fn run(
+    mux_alarm: &'static MuxAlarm<'static, Rtc>,
+    deferred_caller: &'static DynamicDeferredCall,
+    flash_controller: &'static nvmc::Nvmc,
+) {
+    // Set up flash controller.
+    flash_controller.configure_writeable();
+    flash_controller.configure_eraseable();
+    let pagebuffer = static_init!(nvmc::NrfPage, nvmc::NrfPage::default());
+
+    // Create actual log storage abstraction on top of flash.
+    let log = static_init!(
+        Log,
+        log::Log::new(
+            &TEST_LOG,
+            &flash_controller,
+            pagebuffer,
+            deferred_caller,
+            true
+        )
+    );
+    flash::HasClient::set_client(flash_controller, log);
+    log.initialize_callback_handle(
+        deferred_caller
+            .register(log)
+            .expect("no deferred call slot available for log storage"),
+    );
+
+    // Create and run test for log storage.
+    let test = static_init!(
+        LogTest<VirtualMuxAlarm<'static, Rtc>>,
+        LogTest::new(log, &mut BUFFER, VirtualMuxAlarm::new(mux_alarm), &TEST_OPS)
+    );
+    log.set_read_client(test);
+    log.set_append_client(test);
+    test.alarm.set_alarm_client(test);
+
+    test.run();
+}
+
+static TEST_OPS: [TestOp; 24] = [
+    // Read back any existing entries.
+    TestOp::BadRead,
+    TestOp::Read,
+    // Write multiple pages, but don't fill log.
+    TestOp::BadWrite,
+    TestOp::Write,
+    TestOp::Read,
+    TestOp::BadWrite,
+    TestOp::Write,
+    TestOp::Read,
+    // Seek to beginning and re-verify entire log.
+    TestOp::SeekBeginning,
+    TestOp::Read,
+    // Write multiple pages, over-filling log and overwriting oldest entries.
+    TestOp::SeekBeginning,
+    TestOp::Write,
+    // Read offset should be incremented since it was invalidated by previous write.
+    TestOp::BadRead,
+    TestOp::Read,
+    // Write multiple pages and sync. Read offset should be invalidated due to sync clobbering
+    // previous read offset.
+    TestOp::Write,
+    TestOp::Sync,
+    TestOp::Read,
+    // Try bad seeks, should fail and not change read entry ID.
+    TestOp::Write,
+    TestOp::BadSeek(0),
+    TestOp::BadSeek(core::usize::MAX),
+    TestOp::Read,
+    // Try bad write, nothing should change.
+    TestOp::BadWrite,
+    TestOp::Read,
+    // Sync log before finishing test so that all changes persist for next test iteration.
+    TestOp::Sync,
+];
+
+// Buffer for reading from and writing to in the log tests.
+static mut BUFFER: [u8; 8] = [0; 8];
+// Length of buffer to actually use.
+const BUFFER_LEN: usize = 8;
+// Amount to shift value before adding to magic in order to fit in buffer.
+const VALUE_SHIFT: usize = 8 * (8 - BUFFER_LEN);
+// Dummy buffer for testing bad writes.
+static mut DUMMY_BUFFER: [u8; 520] = [0; 520];
+// Time to wait in between log operations.
+const WAIT_MS: u32 = 2;
+// Magic number to write to log storage (+ offset).
+const MAGIC: u64 = 0x0102030405060708;
+// Number of entries to write per write operation.
+const ENTRIES_PER_WRITE: u64 = 120;
+
+// Test's current state.
+#[derive(Clone, Copy, PartialEq)]
+enum TestState {
+    Operate, // Running through test operations.
+    Erase,   // Erasing log and restarting test.
+    CleanUp, // Cleaning up test after all operations complete.
+}
+
+// A single operation within the test.
+#[derive(Clone, Copy, PartialEq)]
+enum TestOp {
+    Read,
+    BadRead,
+    Write,
+    BadWrite,
+    Sync,
+    SeekBeginning,
+    BadSeek(usize),
+}
+
+type Log = log::Log<'static, nvmc::Nvmc>;
+struct LogTest<A: Alarm<'static>> {
+    log: &'static Log,
+    buffer: TakeCell<'static, [u8]>,
+    alarm: A,
+    state: Cell<TestState>,
+    ops: &'static [TestOp],
+    op_index: Cell<usize>,
+    op_start: Cell<bool>,
+    read_val: Cell<u64>,
+    write_val: Cell<u64>,
+}
+
+impl<A: Alarm<'static>> LogTest<A> {
+    fn new(
+        log: &'static Log,
+        buffer: &'static mut [u8],
+        alarm: A,
+        ops: &'static [TestOp],
+    ) -> LogTest<A> {
+        // Recover test state.
+        let read_val = entry_id_to_test_value(log.next_read_entry_id());
+        let write_val = entry_id_to_test_value(log.log_end());
+
+        debug!(
+            "Log recovered from flash (Start and end entry IDs: {:?} to {:?}; read and write values: {} and {})",
+            log.next_read_entry_id(),
+            log.log_end(),
+            read_val,
+            write_val
+        );
+
+        LogTest {
+            log,
+            buffer: TakeCell::new(buffer),
+            alarm,
+            state: Cell::new(TestState::Operate),
+            ops,
+            op_index: Cell::new(0),
+            op_start: Cell::new(true),
+            read_val: Cell::new(read_val),
+            write_val: Cell::new(write_val),
+        }
+    }
+
+    fn run(&self) {
+        match self.state.get() {
+            TestState::Operate => {
+                let op_index = self.op_index.get();
+                if op_index == self.ops.len() {
+                    self.state.set(TestState::CleanUp);
+                    self.log.seek(self.log.log_start());
+                    return;
+                }
+
+                match self.ops[op_index] {
+                    TestOp::Read => self.read(),
+                    TestOp::BadRead => self.bad_read(),
+                    TestOp::Write => self.write(),
+                    TestOp::BadWrite => self.bad_write(),
+                    TestOp::Sync => self.sync(),
+                    TestOp::SeekBeginning => self.seek_beginning(),
+                    TestOp::BadSeek(entry_id) => self.bad_seek(entry_id),
+                }
+            }
+            TestState::Erase => self.erase(),
+            TestState::CleanUp => {
+                debug!(
+                    "Log Storage test succeeded! (Final log start and end entry IDs: {:?} to {:?})",
+                    self.log.next_read_entry_id(),
+                    self.log.log_end()
+                );
+            }
+        }
+    }
+
+    fn next_op(&self) {
+        self.op_index.increment();
+        self.op_start.set(true);
+    }
+
+    fn erase(&self) {
+        match self.log.erase() {
+            ReturnCode::SUCCESS => (),
+            ReturnCode::EBUSY => {
+                self.wait();
+            }
+            _ => panic!("Could not erase log storage!"),
+        }
+    }
+
+    fn read(&self) {
+        // Update read value if clobbered by previous operation.
+        if self.op_start.get() {
+            let next_read_val = entry_id_to_test_value(self.log.next_read_entry_id());
+            if self.read_val.get() < next_read_val {
+                debug!(
+                    "Increasing read value from {} to {} due to clobbering (read entry ID is {:?})!",
+                    self.read_val.get(),
+                    next_read_val,
+                    self.log.next_read_entry_id()
+                );
+                self.read_val.set(next_read_val);
+            }
+        }
+
+        self.buffer.take().map_or_else(
+            || panic!("NO BUFFER"),
+            move |buffer| {
+                // Clear buffer first to make debugging more sane.
+                buffer.clone_from_slice(&0u64.to_be_bytes());
+
+                if let Err((error, original_buffer)) = self.log.read(buffer, BUFFER_LEN) {
+                    self.buffer
+                        .replace(original_buffer.expect("No buffer returned in error!"));
+                    match error {
+                        ReturnCode::FAIL => {
+                            // No more entries, start writing again.
+                            debug!(
+                                "READ DONE: READ OFFSET: {:?} / WRITE OFFSET: {:?}",
+                                self.log.next_read_entry_id(),
+                                self.log.log_end()
+                            );
+                            self.next_op();
+                            self.run();
+                        }
+                        ReturnCode::EBUSY => {
+                            debug!("Flash busy, waiting before reattempting read");
+                            self.wait();
+                        }
+                        _ => panic!("READ #{} FAILED: {:?}", self.read_val.get(), error),
+                    }
+                }
+            },
+        );
+    }
+
+    fn bad_read(&self) {
+        // Ensure failure if buffer is smaller than provided max read length.
+        self.buffer
+            .take()
+            .map(
+                move |buffer| match self.log.read(buffer, buffer.len() + 1) {
+                    Ok(_) => panic!("Read with too-large max read length succeeded unexpectedly!"),
+                    Err((error, original_buffer)) => {
+                        self.buffer
+                            .replace(original_buffer.expect("No buffer returned in error!"));
+                        assert_eq!(error, ReturnCode::EINVAL);
+                    }
+                },
+            )
+            .unwrap();
+
+        // Ensure failure if buffer is too small to hold entry.
+        self.buffer
+            .take()
+            .map(move |buffer| match self.log.read(buffer, BUFFER_LEN - 1) {
+                Ok(_) => panic!("Read with too-small buffer succeeded unexpectedly!"),
+                Err((error, original_buffer)) => {
+                    self.buffer
+                        .replace(original_buffer.expect("No buffer returned in error!"));
+                    if self.read_val.get() == self.write_val.get() {
+                        assert_eq!(error, ReturnCode::FAIL);
+                    } else {
+                        assert_eq!(error, ReturnCode::ESIZE);
+                    }
+                }
+            })
+            .unwrap();
+
+        self.next_op();
+        self.run();
+    }
+
+    fn write(&self) {
+        self.buffer
+            .take()
+            .map(move |buffer| {
+                buffer.clone_from_slice(
+                    &(MAGIC + (self.write_val.get() << VALUE_SHIFT)).to_be_bytes(),
+                );
+                if let Err((error, original_buffer)) = self.log.append(buffer, BUFFER_LEN) {
+                    self.buffer
+                        .replace(original_buffer.expect("No buffer returned in error!"));
+
+                    match error {
+                        ReturnCode::EBUSY => self.wait(),
+                        _ => panic!("WRITE FAILED: {:?}", error),
+                    }
+                }
+            })
+            .unwrap();
+    }
+
+    fn bad_write(&self) {
+        let original_offset = self.log.log_end();
+
+        // Ensure failure if entry length is 0.
+        self.buffer
+            .take()
+            .map(move |buffer| match self.log.append(buffer, 0) {
+                Ok(_) => panic!("Appending entry of size 0 succeeded unexpectedly!"),
+                Err((error, original_buffer)) => {
+                    self.buffer
+                        .replace(original_buffer.expect("No buffer returned in error!"));
+                    assert_eq!(error, ReturnCode::EINVAL);
+                }
+            })
+            .unwrap();
+
+        // Ensure failure if proposed entry length is greater than buffer length.
+        self.buffer
+            .take()
+            .map(
+                move |buffer| match self.log.append(buffer, buffer.len() + 1) {
+                    Ok(_) => panic!("Appending with too-small buffer succeeded unexpectedly!"),
+                    Err((error, original_buffer)) => {
+                        self.buffer
+                            .replace(original_buffer.expect("No buffer returned in error!"));
+                        assert_eq!(error, ReturnCode::EINVAL);
+                    }
+                },
+            )
+            .unwrap();
+
+        // Ensure failure if entry is too large to fit within a single flash page.
+        unsafe {
+            match self.log.append(&mut DUMMY_BUFFER, DUMMY_BUFFER.len()) {
+                Ok(_) => panic!("Appending with too-small buffer succeeded unexpectedly!"),
+                Err((error, _original_buffer)) => assert_eq!(error, ReturnCode::ESIZE),
+            }
+        }
+
+        // Make sure that append offset was not changed by failed writes.
+        assert_eq!(original_offset, self.log.log_end());
+        self.next_op();
+        self.run();
+    }
+
+    fn sync(&self) {
+        match self.log.sync() {
+            ReturnCode::SUCCESS => (),
+            error => panic!("Sync failed: {:?}", error),
+        }
+    }
+
+    fn seek_beginning(&self) {
+        let entry_id = self.log.log_start();
+        match self.log.seek(entry_id) {
+            ReturnCode::SUCCESS => debug!("Seeking to {:?}...", entry_id),
+            error => panic!("Seek failed: {:?}", error),
+        }
+    }
+
+    fn bad_seek(&self, entry_id: usize) {
+        // Make sure seek fails with EINVAL.
+        let original_offset = self.log.next_read_entry_id();
+        match self.log.seek(entry_id) {
+            ReturnCode::EINVAL => (),
+            ReturnCode::SUCCESS => panic!(
+                "Seek to invalid entry ID {:?} succeeded unexpectedly!",
+                entry_id
+            ),
+            error => panic!(
+                "Seek to invalid entry ID {:?} failed with unexpected error {:?}!",
+                entry_id, error
+            ),
+        }
+
+        // Make sure that read offset was not changed by failed seek.
+        assert_eq!(original_offset, self.log.next_read_entry_id());
+        self.next_op();
+        self.run();
+    }
+
+    fn wait(&self) {
+        let delay = A::ticks_from_ms(WAIT_MS);
+        let now = self.alarm.now();
+        self.alarm.set_alarm(now, delay);
+    }
+}
+
+impl<A: Alarm<'static>> LogReadClient for LogTest<A> {
+    fn read_done(&self, buffer: &'static mut [u8], length: usize, error: ReturnCode) {
+        match error {
+            ReturnCode::SUCCESS => {
+                // Verify correct number of bytes were read.
+                if length != BUFFER_LEN {
+                    panic!(
+                        "{} bytes read, expected {} on read number {} (offset {:?}). Value read was {:?}",
+                        length,
+                        BUFFER_LEN,
+                        self.read_val.get(),
+                        self.log.next_read_entry_id(),
+                        &buffer[0..length],
+                    );
+                }
+
+                // Verify correct value was read.
+                let expected = (MAGIC + (self.read_val.get() << VALUE_SHIFT)).to_be_bytes();
+                for i in 0..BUFFER_LEN {
+                    if buffer[i] != expected[i] {
+                        panic!(
+                            "Expected {:?}, read {:?} on read number {} (offset {:?})",
+                            &expected[0..BUFFER_LEN],
+                            &buffer[0..BUFFER_LEN],
+                            self.read_val.get(),
+                            self.log.next_read_entry_id(),
+                        );
+                    }
+                }
+
+                self.buffer.replace(buffer);
+                self.read_val.set(self.read_val.get() + 1);
+                self.op_start.set(false);
+                self.wait();
+            }
+            _ => {
+                panic!("Read failed unexpectedly!");
+            }
+        }
+    }
+
+    fn seek_done(&self, error: ReturnCode) {
+        if error == ReturnCode::SUCCESS {
+            debug!("Seeked");
+            self.read_val
+                .set(entry_id_to_test_value(self.log.next_read_entry_id()));
+        } else {
+            panic!("Seek failed: {:?}", error);
+        }
+
+        if self.state.get() == TestState::Operate {
+            self.next_op();
+        }
+        self.run();
+    }
+}
+
+impl<A: Alarm<'static>> LogWriteClient for LogTest<A> {
+    fn append_done(
+        &self,
+        buffer: &'static mut [u8],
+        length: usize,
+        records_lost: bool,
+        error: ReturnCode,
+    ) {
+        self.buffer.replace(buffer);
+        self.op_start.set(false);
+
+        match error {
+            ReturnCode::SUCCESS => {
+                if length != BUFFER_LEN {
+                    panic!(
+                        "Appended {} bytes, expected {} (write #{}, offset {:?})!",
+                        length,
+                        BUFFER_LEN,
+                        self.write_val.get(),
+                        self.log.log_end()
+                    );
+                }
+                let expected_records_lost =
+                    self.write_val.get() > entry_id_to_test_value(TEST_LOG.len());
+                if records_lost && records_lost != expected_records_lost {
+                    panic!("Append callback states records_lost = {}, expected {} (write #{}, offset {:?})!",
+                           records_lost,
+                           expected_records_lost,
+                           self.write_val.get(),
+                           self.log.log_end()
+                    );
+                }
+
+                // Stop writing after `ENTRIES_PER_WRITE` entries have been written.
+                if (self.write_val.get() + 1) % ENTRIES_PER_WRITE == 0 {
+                    debug!(
+                        "WRITE DONE: READ OFFSET: {:?} / WRITE OFFSET: {:?}",
+                        self.log.next_read_entry_id(),
+                        self.log.log_end()
+                    );
+                    self.next_op();
+                }
+
+                self.write_val.set(self.write_val.get() + 1);
+            }
+            ReturnCode::FAIL => {
+                assert_eq!(length, 0);
+                assert!(!records_lost);
+                debug!("Append failed due to flash error, retrying...");
+            }
+            error => panic!("UNEXPECTED APPEND FAILURE: {:?}", error),
+        }
+
+        self.wait();
+    }
+
+    fn sync_done(&self, error: ReturnCode) {
+        if error == ReturnCode::SUCCESS {
+            debug!(
+                "SYNC DONE: READ OFFSET: {:?} / WRITE OFFSET: {:?}",
+                self.log.next_read_entry_id(),
+                self.log.log_end()
+            );
+        } else {
+            panic!("Sync failed: {:?}", error);
+        }
+
+        self.next_op();
+        self.run();
+    }
+
+    fn erase_done(&self, error: ReturnCode) {
+        match error {
+            ReturnCode::SUCCESS => {
+                // Reset test state.
+                self.op_index.set(0);
+                self.op_start.set(true);
+                self.read_val.set(0);
+                self.write_val.set(0);
+
+                // Make sure that flash has been erased.
+                for i in 0..TEST_LOG.len() {
+                    if TEST_LOG[i] != 0xFF {
+                        panic!(
+                            "Log not properly erased, read {} at byte {}. SUMMARY: {:?}",
+                            TEST_LOG[i],
+                            i,
+                            &TEST_LOG[i..i + 8]
+                        );
+                    }
+                }
+
+                // Make sure that a read on an empty log fails normally.
+                self.buffer.take().map(move |buffer| {
+                    if let Err((error, original_buffer)) = self.log.read(buffer, BUFFER_LEN) {
+                        self.buffer
+                            .replace(original_buffer.expect("No buffer returned in error!"));
+                        match error {
+                            ReturnCode::FAIL => (),
+                            ReturnCode::EBUSY => {
+                                self.wait();
+                            }
+                            _ => panic!("Read on empty log did not fail as expected: {:?}", error),
+                        }
+                    } else {
+                        panic!("Read on empty log succeeded! (it shouldn't)");
+                    }
+                });
+
+                // Move to next operation.
+                debug!("Log Storage erased");
+                self.state.set(TestState::Operate);
+                self.run();
+            }
+            ReturnCode::EBUSY => {
+                // Flash busy, try again.
+                self.wait();
+            }
+            _ => {
+                panic!("Erase failed: {:?}", error);
+            }
+        }
+    }
+}
+
+impl<A: Alarm<'static>> AlarmClient for LogTest<A> {
+    fn alarm(&self) {
+        self.run();
+    }
+}
+
+impl<A: Alarm<'static>> gpio::Client for LogTest<A> {
+    fn fired(&self) {
+        // Erase log.
+        self.state.set(TestState::Erase);
+        self.erase();
+    }
+}
+
+fn entry_id_to_test_value(entry_id: usize) -> u64 {
+    // Page and entry header sizes for log storage.
+    const PAGE_SIZE: usize = 512;
+
+    let pages_written = entry_id / PAGE_SIZE;
+    let entry_size = log::ENTRY_HEADER_SIZE + BUFFER_LEN;
+    let entries_per_page = (PAGE_SIZE - log::PAGE_HEADER_SIZE) / entry_size;
+    let entries_last_page = if entry_id % PAGE_SIZE >= log::PAGE_HEADER_SIZE {
+        (entry_id % PAGE_SIZE - log::PAGE_HEADER_SIZE) / entry_size
+    } else {
+        0
+    };
+    (pages_written * entries_per_page + entries_last_page) as u64
+}

--- a/boards/nano33ble/src/test/mod.rs
+++ b/boards/nano33ble/src/test/mod.rs
@@ -1,0 +1,2 @@
+pub(crate) mod linear_log_test;
+pub(crate) mod log_test;

--- a/capsules/src/lib.rs
+++ b/capsules/src/lib.rs
@@ -77,6 +77,7 @@ pub mod virtual_digest;
 pub mod virtual_flash;
 pub mod virtual_hmac;
 pub mod virtual_i2c;
+pub mod virtual_log;
 pub mod virtual_pwm;
 pub mod virtual_spi;
 pub mod virtual_timer;

--- a/capsules/src/log.rs
+++ b/capsules/src/log.rs
@@ -802,12 +802,14 @@ impl<'a, F: Flash + 'static> LogWrite<'a> for Log<'a, F> {
     }
 
     /// Erase the entire log.
+    ///
     /// ReturnCodes used:
-    ///     * SUCCESS: flush started successfully.
-    ///     * EBUSY: log busy, try again later.
+    /// * SUCCESS: flush started successfully.
+    /// * EBUSY: log busy, try again later.
+    ///
     /// ReturnCodes used in erase_done callback:
-    ///     * SUCCESS: erase succeeded.
-    ///     * EBUSY: erase interrupted by busy flash driver. Call erase again to resume.
+    /// * SUCCESS: erase succeeded.
+    /// * EBUSY: erase interrupted by busy flash driver. Call erase again to resume.
     fn erase(&self) -> ReturnCode {
         if self.state.get() != State::Idle {
             // Log busy, try appending again later.

--- a/capsules/src/log.rs
+++ b/capsules/src/log.rs
@@ -10,7 +10,7 @@
 //! after an entry with a smaller ID. IDs can also be used to determine the physical position of
 //! entries within the log's underlying storage volume - taking the ID modulo the size of the
 //! underlying storage volume yields the position of the entry's header relative to the start of
-//! the volume. Entries should not be created manually by clients, only retrieved through the
+//! the volume. Entry IDs should not be created manually by clients, only retrieved through the
 //! `log_start()`, `log_end()`, and `next_read_entry_id()` functions.
 //!
 //! Entry IDs are not explicitly stored in the log. Instead, each page of the log contains a header

--- a/capsules/src/log.rs
+++ b/capsules/src/log.rs
@@ -73,6 +73,7 @@
 //! ```
 
 use core::cell::Cell;
+use core::cmp;
 use core::convert::TryFrom;
 use core::mem::size_of;
 use core::unreachable;

--- a/capsules/src/log.rs
+++ b/capsules/src/log.rs
@@ -40,32 +40,36 @@
 //! Usage
 //! -----
 //!
-//! ```
-//!     storage_volume!(VOLUME, 2);
-//!     static mut PAGEBUFFER: sam4l::flashcalw::Sam4lPage = sam4l::flashcalw::Sam4lPage::new();
+//! ```rust
+//! storage_volume!(VOLUME, 2);
+//! static mut PAGEBUFFER: sam4l::flashcalw::Sam4lPage = sam4l::flashcalw::Sam4lPage::new();
 //!
-//!     let dynamic_deferred_call_clients =
-//!         static_init!([DynamicDeferredCallClientState; 2], Default::default());
-//!     let dynamic_deferred_caller = static_init!(
-//!         DynamicDeferredCall,
-//!         DynamicDeferredCall::new(dynamic_deferred_call_clients)
-//!     );
+//! let dynamic_deferred_call_clients =
+//!     static_init!([DynamicDeferredCallClientState; 2], Default::default());
+//! let dynamic_deferred_caller = static_init!(
+//!     DynamicDeferredCall,
+//!     DynamicDeferredCall::new(dynamic_deferred_call_clients)
+//! );
 //!
-//!     let log = static_init!(
-//!         capsules::log::Log,
-//!         capsules::log::Log::new(
-//!             &VOLUME,
-//!             &mut sam4l::flashcalw::FLASH_CONTROLLER,
-//!             &mut PAGEBUFFER,
-//!             dynamic_deferred_caller,
-//!             true
-//!         )
-//!     );
-//!     kernel::hil::flash::HasClient::set_client(&sam4l::flashcalw::FLASH_CONTROLLER, log);
-//!     log.initialize_callback_handle(dynamic_deferred_caller.register(log).expect("no deferred call slot available for log storage"));
+//! let log = static_init!(
+//!     capsules::log::Log,
+//!     capsules::log::Log::new(
+//!         &VOLUME,
+//!         &mut sam4l::flashcalw::FLASH_CONTROLLER,
+//!         &mut PAGEBUFFER,
+//!         dynamic_deferred_caller,
+//!         true
+//!     )
+//! );
+//! kernel::hil::flash::HasClient::set_client(&sam4l::flashcalw::FLASH_CONTROLLER, log);
+//! log.initialize_callback_handle(
+//!     dynamic_deferred_caller
+//!         .register(log)
+//!         .expect("no deferred call slot available for log storage")
+//! );
 //!
-//!     log.set_read_client(log_storage_read_client);
-//!     log.set_append_client(log_storage_append_client);
+//! log.set_read_client(log_storage_read_client);
+//! log.set_append_client(log_storage_append_client);
 //! ```
 
 use core::cell::Cell;

--- a/capsules/src/log.rs
+++ b/capsules/src/log.rs
@@ -683,7 +683,7 @@ impl<'a, F: Flash + 'static> LogRead<'a> for Log<'a, F> {
     fn seek(&self, entry_id: Self::EntryID) -> ReturnCode {
         if self.state.get() != State::Idle {
             ReturnCode::EBUSY
-        } else if entry_id <= self.append_entry_id.get() && entry_id >= self.oldest_entry_id.get() {
+        } else if entry_id < self.append_entry_id.get() && entry_id >= self.oldest_entry_id.get() {
             self.read_entry_id.set(entry_id);
             self.state.set(State::Seek);
             self.error.set(ReturnCode::SUCCESS);

--- a/capsules/src/log.rs
+++ b/capsules/src/log.rs
@@ -219,16 +219,17 @@ impl<'a, F: Flash + 'static> Log<'a, F> {
         &buffer[offset..offset + num_bytes]
     }
 
-    /// Resets a log back to an empty log. Returns whether or not the log was reset successfully.
+    /// Resets the log back to an empty state. Returns whether or not the log was reset successfully.
     fn reset(&self) -> bool {
-        self.oldest_entry_id.set(PAGE_HEADER_SIZE);
-        self.read_entry_id.set(PAGE_HEADER_SIZE);
-        self.append_entry_id.set(PAGE_HEADER_SIZE);
-        self.pagebuffer.take().map_or(false, move |pagebuffer| {
-            for e in pagebuffer.as_mut().iter_mut() {
-                *e = 0;
+        self.pagebuffer.map_or(false, |pagebuffer| {
+            // Reset internal entry IDs.
+            self.oldest_entry_id.set(PAGE_HEADER_SIZE);
+            self.read_entry_id.set(PAGE_HEADER_SIZE);
+            self.append_entry_id.set(PAGE_HEADER_SIZE);
+            // Clear internal page buffer.
+            for byte_pointer in pagebuffer.as_mut().iter_mut() {
+                *byte_pointer = 0;
             }
-            self.pagebuffer.replace(pagebuffer);
             true
         })
     }

--- a/capsules/src/log.rs
+++ b/capsules/src/log.rs
@@ -666,7 +666,10 @@ impl<'a, F: Flash + 'static> LogRead<'a> for Log<'a, F> {
     ///
     /// ReturnCodes used:
     /// * SUCCESS: seek succeeded.
+<<<<<<< HEAD
     /// * EBUSY: log busy with another operation, try again later.
+=======
+>>>>>>> 7598e876f... 💡 Make "append" documentation render correctly
     /// * EINVAL: entry ID not valid seek position within current log.
     /// * ERESERVE: no log client set.
     fn seek(&self, entry_id: Self::EntryID) -> ReturnCode {

--- a/capsules/src/log.rs
+++ b/capsules/src/log.rs
@@ -187,7 +187,10 @@ impl<'a, F: Flash + 'static> Log<'a, F> {
 
     /// Returns the page number of the page containing the entry with the given ID.
     fn page_number(&self, entry_id: EntryID) -> usize {
-        (self.volume.as_ptr() as usize + entry_id % self.volume.len()) / self.page_size
+        let offset_global = self.volume.as_ptr() as usize;
+        let offset_local = entry_id % self.volume.len();
+        let offset_total = offset_global + offset_local;
+        offset_total / self.page_size
     }
 
     /// Gets the buffer containing the byte at the given position in the log.

--- a/capsules/src/log.rs
+++ b/capsules/src/log.rs
@@ -595,19 +595,22 @@ impl<'a, F: Flash + 'static> LogRead<'a> for Log<'a, F> {
 
     /// Read an entire log entry into a buffer, if there are any remaining. Updates the read entry
     /// ID to point at the next entry when done.
+    ///
     /// Returns:
-    ///     * Ok(()) on success.
-    ///     * Err((ReturnCode, Option<buffer>)) on failure. The buffer will only be `None` if the
-    ///       error is due to a loss of the buffer.
+    /// * Ok(()) on success.
+    /// * Err((ReturnCode, Option<buffer>)) on failure. The buffer will only be `None` if the error
+    ///     is due to a loss of the buffer.
+    ///
     /// ReturnCodes used:
-    ///     * FAIL: reached end of log, nothing to read.
-    ///     * EBUSY: log busy with another operation, try again later.
-    ///     * EINVAL: provided client buffer is too small.
-    ///     * ECANCEL: invalid internal state, read entry ID was reset to start of log.
-    ///     * ERESERVE: client or internal pagebuffer missing.
-    ///     * ESIZE: buffer not large enough to contain entry being read.
+    /// * FAIL: reached end of log, nothing to read.
+    /// * EBUSY: log busy with another operation, try again later.
+    /// * EINVAL: provided client buffer is too small.
+    /// * ECANCEL: invalid internal state, read entry ID was reset to start of log.
+    /// * ERESERVE: client or internal pagebuffer missing.
+    /// * ESIZE: buffer not large enough to contain entry being read.
+    ///
     /// ReturnCodes used in read_done callback:
-    ///     * SUCCESS: read succeeded.
+    /// * SUCCESS: read succeeded.
     fn read(
         &self,
         buffer: &'static mut [u8],

--- a/capsules/src/log.rs
+++ b/capsules/src/log.rs
@@ -508,13 +508,15 @@ impl<'a, F: Flash + 'static> Log<'a, F> {
 
         // Increment append entry ID to point at start of next page.
         if append_entry_id % self.page_size != 0 {
-            append_entry_id += self.page_size - append_entry_id % self.page_size;
+            let page_offset = append_entry_id % self.page_size;
+            let remaining_bytes = self.page_size - page_offset;
+            append_entry_id += remaining_bytes;
         }
 
-        // Write page header to pagebuffer.
+        // Write page header to the pagebuffer.
         let id_bytes = append_entry_id.to_ne_bytes();
-        for index in 0..id_bytes.len() {
-            pagebuffer.as_mut()[index] = id_bytes[index];
+        for i in 0..id_bytes.len() {
+            pagebuffer.as_mut()[i] = id_bytes[i];
         }
 
         // Note: this is the only place where the append entry ID can cross page boundaries.

--- a/capsules/src/log.rs
+++ b/capsules/src/log.rs
@@ -559,8 +559,11 @@ impl<'a, F: Flash + 'static> Log<'a, F> {
                         State::Read => self
                             .buffer
                             .take()
-                            .map(|buffer| {
-                                read_client.read_done(buffer, self.length.get(), self.error.get());
+                            .map(|buffer| match self.error.get() {
+                                ReturnCode::SUCCESS => {
+                                    read_client.read_done(buffer, Ok(self.length.get()))
+                                }
+                                _ => read_client.read_done(buffer, Err(self.error.get())),
                             })
                             .unwrap(),
                         State::Seek => read_client.seek_done(self.error.get()),

--- a/capsules/src/log.rs
+++ b/capsules/src/log.rs
@@ -524,13 +524,14 @@ impl<'a, F: Flash + 'static> Log<'a, F> {
         true
     }
 
-    /// Erases a single page from storage.
+    /// Erases the oldest page from storage.
+    ///
+    /// When the flash driver is done with erasing the oldest page, it will call the `erase_complete`
+    /// callback which triggers the erasure of the next oldest page. Pages are erased from oldest to
+    /// newest so that the log will remain valid even if it fails to be erase completely.
     fn erase_page(&self) -> ReturnCode {
-        // Uses oldest entry ID to keep track of which page to erase. Thus, the oldest pages will be
-        // erased first and the log will remain in a valid state even if it fails to be erased
-        // completely.
-        self.driver
-            .erase_page(self.page_number(self.oldest_entry_id.get()))
+        let oldest_page = self.page_number(self.oldest_entry_id.get());
+        self.driver.erase_page(oldest_page)
     }
 
     /// Initializes a callback handle for deferred callbacks.

--- a/capsules/src/log.rs
+++ b/capsules/src/log.rs
@@ -453,8 +453,8 @@ impl<'a, F: Flash + 'static> Log<'a, F> {
         self.client_callback();
     }
 
-    /// Flushes the pagebuffer to flash. Log state must be idle before calling otherwise data races
-    /// may occur due to the asynchronous nature of page writes.
+    /// Flushes the pagebuffer to flash. The log must be set to a non-idle state to prevent other
+    /// operations from happening concurrently.
     ///
     /// ReturnCodes used:
     ///

--- a/capsules/src/log.rs
+++ b/capsules/src/log.rs
@@ -406,13 +406,10 @@ impl<'a, F: Flash + 'static> Log<'a, F> {
             })
     }
 
-    /// Writes an entry header at the given position within a page. Must write at most
-    /// ENTRY_HEADER_SIZE bytes.
-    fn write_entry_header(&self, length: usize, pos: usize, pagebuffer: &mut F::Page) {
-        let mut offset = 0;
-        for byte in &length.to_ne_bytes() {
-            pagebuffer.as_mut()[pos + offset] = *byte;
-            offset += 1;
+    /// Writes an entry header at the given position within a page.
+    fn write_entry_header(&self, header: usize, pos: usize, pagebuffer: &mut F::Page) {
+        for (offset, &byte) in header.to_ne_bytes().iter().enumerate() {
+            pagebuffer.as_mut()[pos + offset] = byte;
         }
     }
 

--- a/capsules/src/log.rs
+++ b/capsules/src/log.rs
@@ -666,10 +666,8 @@ impl<'a, F: Flash + 'static> LogRead<'a> for Log<'a, F> {
     ///
     /// ReturnCodes used:
     /// * SUCCESS: seek succeeded.
-<<<<<<< HEAD
     /// * EBUSY: log busy with another operation, try again later.
-=======
->>>>>>> 7598e876f... 💡 Make "append" documentation render correctly
+    /// * EBUSY: log busy with another operation, try again later.
     /// * EINVAL: entry ID not valid seek position within current log.
     /// * ERESERVE: no log client set.
     fn seek(&self, entry_id: Self::EntryID) -> ReturnCode {

--- a/capsules/src/log.rs
+++ b/capsules/src/log.rs
@@ -578,13 +578,12 @@ impl<'a, F: Flash + 'static> Log<'a, F> {
                         State::Append => self
                             .buffer
                             .take()
-                            .map(|buffer| {
-                                append_client.append_done(
+                            .map(|buffer| match self.error.get() {
+                                ReturnCode::SUCCESS => append_client.append_done(
                                     buffer,
-                                    self.length.get(),
-                                    self.records_lost.get(),
-                                    self.error.get(),
-                                );
+                                    Ok((self.length.get(), self.records_lost.get())),
+                                ),
+                                _ => append_client.append_done(buffer, Err(self.error.get())),
                             })
                             .unwrap(),
                         State::Sync => append_client.sync_done(self.error.get()),

--- a/capsules/src/log.rs
+++ b/capsules/src/log.rs
@@ -555,11 +555,11 @@ impl<'a, F: Flash + 'static> Log<'a, F> {
             State::Read | State::Seek => {
                 self.state.set(State::Idle);
                 self.read_client
-                    .map(move |read_client| match state {
+                    .map(|read_client| match state {
                         State::Read => self
                             .buffer
                             .take()
-                            .map(move |buffer| {
+                            .map(|buffer| {
                                 read_client.read_done(buffer, self.length.get(), self.error.get());
                             })
                             .unwrap(),
@@ -571,11 +571,11 @@ impl<'a, F: Flash + 'static> Log<'a, F> {
             State::Append | State::Sync | State::Erase => {
                 self.state.set(State::Idle);
                 self.append_client
-                    .map(move |append_client| match state {
+                    .map(|append_client| match state {
                         State::Append => self
                             .buffer
                             .take()
-                            .map(move |buffer| {
+                            .map(|buffer| {
                                 append_client.append_done(
                                     buffer,
                                     self.length.get(),

--- a/capsules/src/log.rs
+++ b/capsules/src/log.rs
@@ -813,20 +813,22 @@ impl<'a, F: Flash + 'static> LogWrite<'a> for Log<'a, F> {
     /// Erase the entire log.
     ///
     /// ReturnCodes used:
-    /// * SUCCESS: flush started successfully.
+    ///
+    /// * SUCCESS: erase started successfully.
     /// * EBUSY: log busy, try again later.
     ///
-    /// ReturnCodes used in erase_done callback:
+    /// ReturnCodes used in the erase_done callback:
+    ///
     /// * SUCCESS: erase succeeded.
     /// * EBUSY: erase interrupted by busy flash driver. Call erase again to resume.
     fn erase(&self) -> ReturnCode {
-        if self.state.get() != State::Idle {
-            // Log busy, try appending again later.
-            return ReturnCode::EBUSY;
+        match self.state.get() {
+            State::Idle => {
+                self.state.set(State::Erase);
+                self.erase_page()
+            }
+            _ => ReturnCode::EBUSY,
         }
-
-        self.state.set(State::Erase);
-        self.erase_page()
     }
 }
 

--- a/capsules/src/log.rs
+++ b/capsules/src/log.rs
@@ -770,14 +770,16 @@ impl<'a, F: Flash + 'static> LogWrite<'a> for Log<'a, F> {
     }
 
     /// Sync log to storage.
+    ///
     /// ReturnCodes used:
-    ///     * SUCCESS: flush started successfully.
-    ///     * FAIL: flash driver not configured.
-    ///     * EBUSY: log or flash driver busy, try again later.
-    ///     * ERESERVE: no log client set.
+    /// * SUCCESS: flush started successfully.
+    /// * FAIL: flash driver not configured.
+    /// * EBUSY: log or flash driver busy, try again later.
+    /// * ERESERVE: no log client set.
+    ///
     /// ReturnCodes used in sync_done callback:
-    ///     * SUCCESS: append succeeded.
-    ///     * FAIL: write failed due to flash error.
+    /// * SUCCESS: append succeeded.
+    /// * FAIL: write failed due to flash error.
     fn sync(&self) -> ReturnCode {
         if self.append_entry_id.get() % self.page_size == PAGE_HEADER_SIZE {
             // Pagebuffer empty, don't need to flush.

--- a/capsules/src/log.rs
+++ b/capsules/src/log.rs
@@ -23,14 +23,16 @@
 //! ID). Entries also have a header of their own, which contains the length of the entry.
 //!
 //! Logs support the following basic operations:
-//!     * Read:     Read back previously written entries in whole. Entries are read in their
-//!                 entirety (no partial reads) from oldest to newest.
-//!     * Seek:     Seek to different entries to begin reading from a different entry (can only
-//!                 seek to the start of entries).
-//!     * Append:   Append new data entries onto the end of a log. Can fail if the new entry is too
-//!                 large to fit within the log.
-//!     * Sync:     Sync a log to flash to ensure that all changes are persistent.
-//!     * Erase:    Erase a log in its entirety, clearing the underlying flash volume.
+//!
+//! * Read:     Read back previously written entries in whole. Entries are read in their entirety
+//!             (no partial reads) from oldest to newest.
+//! * Seek:     Seek to different entries to begin reading from a different entry (can only seek to
+//!             the start of entries).
+//! * Append:   Append new data entries onto the end of a log. Can fail if the new entry is too
+//!             large to fit within the log.
+//! * Sync:     Sync a log to flash to ensure that all changes are persistent.
+//! * Erase:    Erase a log in its entirety, clearing the underlying flash volume.
+//!
 //! See the documentation for each individual function for more detail on how they operate.
 //!
 //! Note that while logs persist across reboots, they will be erased upon flashing a new kernel.

--- a/capsules/src/log.rs
+++ b/capsules/src/log.rs
@@ -7,7 +7,7 @@
 //!
 //! Entries can be identified and seeked-to with their unique Entry IDs. Entry IDs maintain the
 //! ordering of the underlying entries, and an entry with a larger entry ID is newer and comes
-//! after an entry with a smaller ID. IDs can also be used to determing the physical position of
+//! after an entry with a smaller ID. IDs can also be used to determine the physical position of
 //! entries within the log's underlying storage volume - taking the ID modulo the size of the
 //! underlying storage volume yields the position of the entry's header relative to the start of
 //! the volume. Entries should not be created manually by clients, only retrieved through the

--- a/capsules/src/log.rs
+++ b/capsules/src/log.rs
@@ -663,10 +663,11 @@ impl<'a, F: Flash + 'static> LogRead<'a> for Log<'a, F> {
 
     /// Seek to a new read entry ID. It is only legal to seek to entry IDs retrieved through the
     /// `log_start()`, `log_end()`, and `next_read_entry_id()` functions.
+    ///
     /// ReturnCodes used:
-    ///     * SUCCESS: seek succeeded.
-    ///     * EINVAL: entry ID not valid seek position within current log.
-    ///     * ERESERVE: no log client set.
+    /// * SUCCESS: seek succeeded.
+    /// * EINVAL: entry ID not valid seek position within current log.
+    /// * ERESERVE: no log client set.
     fn seek(&self, entry_id: Self::EntryID) -> ReturnCode {
         if entry_id <= self.append_entry_id.get() && entry_id >= self.oldest_entry_id.get() {
             self.read_entry_id.set(entry_id);
@@ -694,20 +695,23 @@ impl<'a, F: Flash + 'static> LogWrite<'a> for Log<'a, F> {
 
     /// Appends an entry onto the end of the log. Entry must fit within a page (including log
     /// metadata).
+    ///
     /// Returns:
-    ///     * Ok(()) on success.
-    ///     * Err((ReturnCode, Option<buffer>)) on failure. The buffer will only be `None` if the
-    ///       error is due to a loss of the buffer.
+    /// * Ok(()) on success.
+    /// * Err((ReturnCode, Option<buffer>)) on failure. The buffer will only be `None` if the error
+    ///     error is due to a loss of the buffer.
+    ///
     /// ReturnCodes used:
-    ///     * FAIL: end of non-circular log reached, cannot append any more entries.
-    ///     * EBUSY: log busy with another operation, try again later.
-    ///     * EINVAL: provided client buffer is too small.
-    ///     * ERESERVE: client or internal pagebuffer missing.
-    ///     * ESIZE: entry too large to append to log.
+    /// * FAIL: end of non-circular log reached, cannot append any more entries.
+    /// * EBUSY: log busy with another operation, try again later.
+    /// * EINVAL: provided client buffer is too small.
+    /// * ERESERVE: client or internal pagebuffer missing.
+    /// * ESIZE: entry too large to append to log.
+    ///
     /// ReturnCodes used in append_done callback:
-    ///     * SUCCESS: append succeeded.
-    ///     * FAIL: write failed due to flash error.
-    ///     * ECANCEL: write failed due to reaching the end of a non-circular log.
+    /// * SUCCESS: append succeeded.
+    /// * FAIL: write failed due to flash error.
+    /// * ECANCEL: write failed due to reaching the end of a non-circular log.
     fn append(
         &self,
         buffer: &'static mut [u8],

--- a/capsules/src/virtual_log.rs
+++ b/capsules/src/virtual_log.rs
@@ -83,8 +83,13 @@ where
         buffer: &'static mut [u8],
         length: usize,
     ) -> Result<(), (ReturnCode, Option<&'static mut [u8]>)> {
-        self.buffer.replace(buffer);
         self.operation.set(Op::Read(length));
+        match self.buffer.replace(buffer) {
+            Some(_) => {
+                debug!("Unexpected replacement of a read buffer that should've been returned via read_done.")
+            }
+            None => (),
+        }
         self.mux.do_next_op();
         Ok(())
     }

--- a/capsules/src/virtual_log.rs
+++ b/capsules/src/virtual_log.rs
@@ -139,8 +139,13 @@ where
         buffer: &'static mut [u8],
         length: usize,
     ) -> Result<(), (ReturnCode, Option<&'static mut [u8]>)> {
-        self.buffer.replace(buffer);
         self.operation.set(Op::Append(length));
+        match self.buffer.replace(buffer) {
+            Some(_) => {
+                debug!("Unexpected replacement of an append buffer that should've been returned via append_done.")
+            }
+            None => (),
+        }
         self.mux.do_next_op();
         Ok(())
     }

--- a/capsules/src/virtual_log.rs
+++ b/capsules/src/virtual_log.rs
@@ -172,7 +172,9 @@ impl<'a, Log: LogRead<'a> + LogWrite<'a>> LogWriteClient for VirtualLogDevice<'a
     }
 }
 
-/// The MuxLog struct manages multiple virtual log devices (i.e. VirtualLogDevice).
+/// The MuxLog struct manages multiple virtual log devices (i.e. VirtualLogDevice) and is the lone
+/// client of the underlying log device. Each of the virtual log devices can have at most one
+/// outstanding log request.
 pub struct MuxLog<'a, Log: LogRead<'a> + LogWrite<'a>> {
     // The underlying log device being virtualized.
     log: &'a Log,

--- a/capsules/src/virtual_log.rs
+++ b/capsules/src/virtual_log.rs
@@ -1,0 +1,171 @@
+use core::cell::Cell;
+use kernel::common::cells::OptionalCell;
+use kernel::common::list::{List, ListLink};
+use kernel::hil::log::{LogRead, LogReadClient, LogWrite, LogWriteClient};
+use kernel::ReturnCode;
+
+// The purpose of this type alias is to make it clear when a usize represents a log entry ID.
+type EntryID = usize;
+
+// This enum represents the current operation that a virtual log device is performing.
+#[derive(Copy, PartialEq)]
+enum Op {
+    Idle,
+    Read(&'static mut [u8], usize),
+    Append(&'static mut [u8], usize),
+    Sync,
+    Erase,
+}
+
+pub struct VirtualLogDevice<'a, Log: LogRead<'a> + LogWrite<'a>> {
+    // Every virtual log device has a reference to the mux.
+    mux: &'a MuxLog<'a, Log>,
+    // Every virtual log device has a pointer to the next virtual log device.
+    next: ListLink<'a, VirtualLogDevice<'a, Log>>,
+    // Every virtual log device has some local state.
+    read_client: OptionalCell<&'a dyn LogReadClient>;
+    append_client: OptionalCell<&'a dyn LogWriteClient>;
+    operation: Cell<Op>,
+    read_entry_id: Cell<EntryID>,
+}
+
+impl<'a, Log: LogRead<'a> + LogWrite<'a>> VirtualLogDevice<'a, Log> {
+    pub const fn new(mux: &'a MuxLog<'a, Log>) -> VirtualLogDevice<'a, Log> {
+        VirtualLogDevice {
+            mux: mux,
+            next: ListLink::empty(),
+            read_client: OptionalCell::empty(),
+            append_client: OptionalCell::empty(),
+            operation: Cell::new(Op::Idle),
+            read_entry_id: Cell::new(PAGE_HEADER_SIZE),
+        }
+    }
+}
+
+impl<'a, Log: LogRead<'a> + LogWrite<'a>> LogRead<'a> for VirtualLogDevice<'a, Log> {
+    type EntryID = usize;
+
+    // This method is used by a capsule to register itself as a read client of the virtual log device.
+    fn set_read_client(&'a self, read_client: &'a dyn LogReadClient) {
+        // TODO: Should we check if we're already part of the mux's devices list?
+        self.mux.devices.push_head(self);
+        self.read_client.set(client);
+    }
+
+    fn read(
+        &self,
+        buffer: &'static mut [u8],
+        length: usize,
+    ) -> Result<(), (ReturnCode, Option<&'static mut [u8]>)> {
+        self.operation.set(Op::Read(buffer, length));
+        self.mux.do_next_op();
+        Ok(()))
+    }
+
+    fn log_start(&self) -> Self::EntryID {
+        self.mux.log.log_start()
+    }
+
+    fn log_end(&self) -> Self::EntryID {
+        self.mux.log.log_end()
+    }
+
+    // TODO: this needs to be virtualized
+    fn next_read_entry_id(&self) -> Self::EntryID {
+        self.mux.log.next_read_entry_id()
+    }
+
+    // The seek function on the virtual log device doesn't actually cause a seek to occur on the
+    // underlying persistent storage device. All it does is update a state variable representing
+    // the location of its position in the log file.
+    // TODO: check for errors
+    fn seek(&self, entry: Self::EntryID) -> ReturnCode {
+        self.read_entry_id.set(entry);
+        ReturnCode::SUCCESS
+    }
+
+    fn get_size(&self) -> usize {
+        self.mux.log.get_size()
+    }
+}
+
+// TODO: Should the append, sync, and erase functions check to make sure the virtual log device is idle?
+// TODO: Should the virtual log device do some queuing of operations on its own?
+impl<'a, Log: LogRead<'a> + LogWrite<'a>> LogWrite<'a> for VirtualLogDevice<'a, Log> {
+    // This method is used by a capsule to register itself as an append client of the virtual log device.
+    fn set_append_client(&'a self, append_client: &'a dyn LogWriteClient) {
+        // TODO: Should we check if we're already part of the mux's devices list?
+        self.mux.devices.push_head(self);
+        self.append_client.set(append_client);
+    }
+
+    fn append(
+        &self,
+        buffer: &'static mut [u8],
+        length: usize,
+    ) -> Result<(), (ReturnCode, Option<&'static mut [u8]>)> {
+        self.operation.set(Op::Append(buffer, length));
+        self.mux.do_next_op();
+        Ok(())
+    }
+
+    fn sync(&self) -> ReturnCode {
+        self.operation.set(Op::Sync);
+        self.mux.do_next_op();
+        ReturnCode::SUCCESS
+    }
+
+    fn erase(&self) -> ReturnCode {
+        self.operation.set(Op::Erase);
+        self.mux.do_next_op();
+        ReturnCode::SUCCESS
+    }
+}
+
+/// The MuxLog struct manages multiple virtual log devices (i.e. VirtualLogDevice).
+pub struct MuxLog<'a, Log: LogRead<'a> + LogWrite<'a>> {
+    // The underlying log device being virtualized.
+    log: &'a Log,
+    // A list of virtual log devices that the mux manages.
+    devices: List<'a, VirtualLogDevice<'a, Log>>,
+    // Which virtual log device is currently being serviced.
+    inflight: OptionalCell<&'a VirtualLogDevice<'a, Log>>,
+}
+
+impl<'a, Log: LogRead<'a> + LogWrite<'a>> MuxLog<'a, Log> {
+    /// Creates a multiplexer around an underlying log device to virtualize it.
+    pub const fn new(log: &'a Log) -> MuxLog<'a, Log> {
+        MuxLog {
+            log: log,
+            devices: List::new(),
+            inflight: OptionalCell::empty(),
+        }
+    }
+
+    fn do_next_op(&self) {
+        // If there's already a virtual log device being serviced, then return.
+        if self.inflight.is_some() {
+            return;
+        }
+        // Otherwise, we service the first log device that has something to do.
+        // FIXME: Are there any fairness concerns here? What if we start searching where we left off?
+        let mnode = self
+            .devices
+            .iter()
+            .find(|node| node.operation.get() != Op::Idle);
+        mnode.map(|node| {
+            // Set the virtual log device's state to be idle after saving its operation locally.
+            let op = node.operation.get();
+            node.operation.set(Op::Idle);
+            match op {
+                Op::Read(buffer, length) => {
+                    self.inflight.set(node);
+                    self.log.read(buffer, length);
+                }
+                Op::Append(buffer, length) => {}
+                Op::Sync => {}
+                Op::Erase => {}
+            }
+        })
+    }
+}

--- a/capsules/src/virtual_log.rs
+++ b/capsules/src/virtual_log.rs
@@ -138,7 +138,7 @@ where
         &self,
         buffer: &'static mut [u8],
         length: usize,
-    ) -> Result<(), (ReturnCode, Option<&'static mut [u8]>)> {
+    ) -> Result<(), (ReturnCode, &'static mut [u8])> {
         self.operation.set(Op::Append(length));
         match self.buffer.replace(buffer) {
             Some(_) => {
@@ -313,10 +313,9 @@ where
                         Op::Append(length) => match virtual_log_device.buffer.take() {
                             Some(append_buffer) => match self.log.append(append_buffer, length) {
                                 Ok(()) => (),
-                                Err((error_code, Some(append_buffer))) => {
+                                Err((error_code, append_buffer)) => {
                                     self.append_done(append_buffer, Err(error_code))
                                 }
-                                Err((_, None)) => unreachable!(), // FIXME: change the return type of append() to get rid of this case
                             },
                             None => {
                                 debug!("Error: append buffer is missing when issuing log append.")

--- a/capsules/src/virtual_log.rs
+++ b/capsules/src/virtual_log.rs
@@ -82,7 +82,7 @@ where
         &self,
         buffer: &'static mut [u8],
         length: usize,
-    ) -> Result<(), (ReturnCode, Option<&'static mut [u8]>)> {
+    ) -> Result<(), (ReturnCode, &'static mut [u8])> {
         self.operation.set(Op::Read(length));
         match self.buffer.replace(buffer) {
             Some(_) => {
@@ -304,10 +304,9 @@ where
                         Op::Read(length) => match virtual_log_device.buffer.take() {
                             Some(read_buffer) => match self.log.read(read_buffer, length) {
                                 Ok(()) => (),
-                                Err((error_code, Some(read_buffer))) => {
+                                Err((error_code, read_buffer)) => {
                                     self.read_done(read_buffer, Err(error_code))
                                 }
-                                Err((_, None)) => unreachable!(), // FIXME: change the return type of read() to get rid of this case
                             },
                             None => debug!("Error: read buffer is missing when issuing log read."),
                         },

--- a/capsules/src/virtual_log.rs
+++ b/capsules/src/virtual_log.rs
@@ -336,12 +336,14 @@ where
                                 debug!("Error: append buffer is missing when issuing log append.")
                             }
                         },
-                        Op::Sync => {
-                            self.log.sync();
-                        }
-                        Op::Erase => {
-                            self.log.erase();
-                        }
+                        Op::Sync => match self.log.sync() {
+                            ReturnCode::SUCCESS => (),
+                            error_code => self.sync_done(error_code),
+                        },
+                        Op::Erase => match self.log.erase() {
+                            ReturnCode::SUCCESS => (),
+                            error_code => self.erase_done(error_code),
+                        },
                         Op::Idle => unreachable!(),
                     }
                 });

--- a/capsules/src/virtual_log.rs
+++ b/capsules/src/virtual_log.rs
@@ -140,7 +140,7 @@ impl<'a, Log: LogRead<'a> + LogWrite<'a>> LogReadClient for VirtualLogDevice<'a,
     }
 
     fn seek_done(&self, error: ReturnCode) {
-        self.read_client.map(move |client| {
+        self.read_client.map(|client| {
             client.seek_done(error);
         });
     }

--- a/capsules/src/virtual_log.rs
+++ b/capsules/src/virtual_log.rs
@@ -4,10 +4,10 @@ use kernel::common::list::{List, ListLink};
 use kernel::hil::log::{LogRead, LogReadClient, LogWrite, LogWriteClient};
 use kernel::ReturnCode;
 
-// The purpose of this type alias is to make it clear when a usize represents a log entry ID.
+// Make it clear when a usize represents a log entry ID
 type EntryID = usize;
 
-// This enum represents the current operation that a virtual log device is performing.
+// Represents the current operation that a virtual log device is performing.
 #[derive(Copy, PartialEq)]
 enum Op {
     Idle,
@@ -18,11 +18,11 @@ enum Op {
 }
 
 pub struct VirtualLogDevice<'a, Log: LogRead<'a> + LogWrite<'a>> {
-    // Every virtual log device has a reference to the mux.
+    // A reference to the mux
     mux: &'a MuxLog<'a, Log>,
-    // Every virtual log device has a pointer to the next virtual log device.
+    // A pointer to the next virtual log device
     next: ListLink<'a, VirtualLogDevice<'a, Log>>,
-    // Every virtual log device has some local state.
+    // Local state for the virtual log device
     read_client: OptionalCell<&'a dyn LogReadClient>;
     append_client: OptionalCell<&'a dyn LogWriteClient>;
     operation: Cell<Op>,

--- a/kernel/src/hil/log.rs
+++ b/kernel/src/hil/log.rs
@@ -59,7 +59,7 @@ pub trait LogWrite<'a> {
         &self,
         buffer: &'static mut [u8],
         length: usize,
-    ) -> Result<(), (ReturnCode, Option<&'static mut [u8]>)>;
+    ) -> Result<(), (ReturnCode, &'static mut [u8])>;
 
     /// Sync log to storage, making all entries persistent (not including any entries that were
     /// previously overwritten). There is no guarantee that any changes to the log are persistent

--- a/kernel/src/hil/log.rs
+++ b/kernel/src/hil/log.rs
@@ -74,15 +74,10 @@ pub trait LogWrite<'a> {
 
 /// Receive callbacks from `LogWrite`.
 pub trait LogWriteClient {
-    /// Returns the original buffer that contained the data to write, the number of bytes written,
-    /// and whether any old entries in the log were lost (due to a circular log being filled up).
-    fn append_done(
-        &self,
-        buffer: &'static mut [u8],
-        length: usize,
-        records_lost: bool,
-        error: ReturnCode,
-    );
+    /// Returns the original buffer that contained the data to write. If the append was successful,
+    /// then also returns the number of bytes written and whether any old entries in the log were
+    /// lost (due to a circular log being filled up). Otherwise, returns the error code.
+    fn append_done(&self, buffer: &'static mut [u8], result: Result<(usize, bool), ReturnCode>);
 
     /// Returns whether or not all pages were correctly synced, making all changes persistent.
     fn sync_done(&self, error: ReturnCode);

--- a/kernel/src/hil/log.rs
+++ b/kernel/src/hil/log.rs
@@ -19,7 +19,7 @@ pub trait LogRead<'a> {
         &self,
         buffer: &'static mut [u8],
         length: usize,
-    ) -> Result<(), (ReturnCode, Option<&'static mut [u8]>)>;
+    ) -> Result<(), (ReturnCode, &'static mut [u8])>;
 
     /// Returns the entry ID at the start of the log. This is the ID of the oldest remaining entry.
     fn log_start(&self) -> Self::EntryID;

--- a/kernel/src/hil/log.rs
+++ b/kernel/src/hil/log.rs
@@ -43,7 +43,7 @@ pub trait LogRead<'a> {
 pub trait LogReadClient {
     /// Returns a buffer containing data read and the length of the number of bytes read or an error
     /// code if the read failed.
-    fn read_done(&self, buffer: &'static mut [u8], length: usize, error: ReturnCode);
+    fn read_done(&self, buffer: &'static mut [u8], result: Result<usize, ReturnCode>);
 
     /// Returns whether the seek succeeded or failed.
     fn seek_done(&self, error: ReturnCode);


### PR DESCRIPTION
### Pull Request Overview

This pull request implements the virtualization of the log interface, which makes it possible for multiple in-kernel capsules to write persistent logs to flash. It also fixes a minor error in the original `Log::seek` method where the log device would not check to see it was in an idle state before it initiated a seek operation.

### Testing Strategy

This pull request was tested by...
@hudson-ayers @TPackard @phil-levis 
(I'm tagging you guys because I'm not sure who to tag)

### TODO or Help Wanted

This pull request still needs...


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
