### PR TITLE
Stm32f412g: Add rng support

### DIFF
--- a/boards/stm32f412gdiscovery/src/main.rs
+++ b/boards/stm32f412gdiscovery/src/main.rs
@@ -10,6 +10,7 @@
 #![feature(const_in_array_repeat_expressions)]
 use capsules::virtual_alarm::VirtualMuxAlarm;
 use components::gpio::GpioComponent;
+use components::rng::RngComponent;
 use kernel::capabilities;
 use kernel::common::dynamic_deferred_call::{DynamicDeferredCall, DynamicDeferredCallClientState};
 use kernel::component::Component;
@@ -59,6 +60,7 @@ struct STM32F412GDiscovery {
     touch: &'static capsules::touch::Touch<'static>,
     screen: &'static capsules::screen::Screen<'static>,
     temperature: &'static capsules::temperature::TemperatureSensor<'static>,
+    rng: &'static capsules::rng::RngDriver<'static>,
 }
 
 /// Mapping of integer syscalls to objects that implement syscalls.
@@ -79,6 +81,7 @@ impl Platform for STM32F412GDiscovery {
             capsules::touch::DRIVER_NUM => f(Some(self.touch)),
             capsules::screen::DRIVER_NUM => f(Some(self.screen)),
             capsules::temperature::DRIVER_NUM => f(Some(self.temperature)),
+            capsules::rng::DRIVER_NUM => f(Some(self.rng)),
             _ => f(None),
         }
     }
@@ -335,7 +338,11 @@ unsafe fn set_pin_primary_functions(
 }
 
 /// Helper function for miscellaneous peripheral functions
-unsafe fn setup_peripherals(tim2: &stm32f412g::tim2::Tim2, fsmc: &stm32f412g::fsmc::Fsmc) {
+unsafe fn setup_peripherals(
+    tim2: &stm32f412g::tim2::Tim2,
+    fsmc: &stm32f412g::fsmc::Fsmc,
+    trng: &stm32f412g::trng::Trng,
+) {
     // USART2 IRQn is 38
     cortexm4::nvic::Nvic::new(stm32f412g::nvic::USART2).enable();
 
@@ -346,6 +353,8 @@ unsafe fn setup_peripherals(tim2: &stm32f412g::tim2::Tim2, fsmc: &stm32f412g::fs
 
     // FSMC
     fsmc.enable();
+
+    trng.enable_clock();
 }
 
 /// Reset Handler.
@@ -372,7 +381,11 @@ pub unsafe fn reset_handler() {
     );
     peripherals.init();
     let base_peripherals = &peripherals.stm32f4;
-    setup_peripherals(&base_peripherals.tim2, &base_peripherals.fsmc);
+    setup_peripherals(
+        &base_peripherals.tim2,
+        &base_peripherals.fsmc,
+        &peripherals.trng,
+    );
 
     // We use the default HSI 16Mhz clock
     set_pin_primary_functions(
@@ -584,6 +597,9 @@ pub unsafe fn reset_handler() {
     )
     .finalize(components::gpio_component_buf!(stm32f412g::gpio::Pin));
 
+    // RNG
+    let rng = RngComponent::new(board_kernel, &peripherals.trng).finalize(());
+
     // FT6206
 
     let mux_i2c = components::i2c::I2CMuxComponent::new(
@@ -717,6 +733,7 @@ pub unsafe fn reset_handler() {
         touch: touch,
         screen: screen,
         temperature: temp,
+        rng: rng,
     };
 
     // // Optional kernel tests

--- a/chips/stm32f412g/src/chip.rs
+++ b/chips/stm32f412g/src/chip.rs
@@ -1,0 +1,8 @@
+use crate::interrupt::Stm32f412gInterruptService;
+use stm32f4xx::chip::Stm32f4xx;
+
+pub type Chip = Stm32f4xx<Stm32f412gInterruptService>;
+
+pub unsafe fn new() -> Chip {
+    Stm32f4xx::new(Stm32f412gInterruptService::new())
+}

--- a/chips/stm32f412g/src/interrupt_service.rs
+++ b/chips/stm32f412g/src/interrupt_service.rs
@@ -1,9 +1,11 @@
+use crate::stm32f412g_nvic;
 use stm32f4xx::chip::Stm32f4xxDefaultPeripherals;
 use stm32f4xx::deferred_calls::DeferredCallTask;
 
 pub struct Stm32f412gDefaultPeripherals<'a> {
     pub stm32f4: Stm32f4xxDefaultPeripherals<'a>,
     // Once implemented, place Stm32f412g specific peripherals here
+    pub trng: stm32f4xx::trng::Trng<'a>,
 }
 
 impl<'a> Stm32f412gDefaultPeripherals<'a> {
@@ -14,6 +16,7 @@ impl<'a> Stm32f412gDefaultPeripherals<'a> {
     ) -> Self {
         Self {
             stm32f4: Stm32f4xxDefaultPeripherals::new(rcc, exti, dma),
+            trng: stm32f4xx::trng::Trng::new(rcc),
         }
     }
     // Necessary for setting up circular dependencies
@@ -25,6 +28,10 @@ impl<'a> kernel::InterruptService<DeferredCallTask> for Stm32f412gDefaultPeriphe
     unsafe fn service_interrupt(&self, interrupt: u32) -> bool {
         match interrupt {
             // put Stm32f412g specific interrupts here
+            stm32f412g_nvic::RNG => {
+                self.trng.handle_interrupt();
+                true
+            }
             _ => self.stm32f4.service_interrupt(interrupt),
         }
     }

--- a/chips/stm32f412g/src/lib.rs
+++ b/chips/stm32f412g/src/lib.rs
@@ -3,7 +3,7 @@
 use cortexm4::generic_isr;
 
 pub use stm32f4xx::{
-    adc, chip, dbg, dma1, exti, fsmc, gpio, i2c, nvic, rcc, spi, syscfg, tim2, usart,
+    adc, chip, dbg, dma1, exti, fsmc, gpio, i2c, nvic, rcc, spi, syscfg, tim2, trng, usart,
 };
 
 pub mod interrupt_service;

--- a/chips/stm32f4xx/src/chip.rs
+++ b/chips/stm32f4xx/src/chip.rs
@@ -2,9 +2,8 @@
 
 use core::fmt::Write;
 use cortexm4;
-use kernel::Chip;
-
 use kernel::common::deferred_call;
+use kernel::Chip;
 use kernel::InterruptService;
 
 use crate::dma1;

--- a/chips/stm32f4xx/src/lib.rs
+++ b/chips/stm32f4xx/src/lib.rs
@@ -24,6 +24,7 @@ pub mod rcc;
 pub mod spi;
 pub mod syscfg;
 pub mod tim2;
+pub mod trng;
 pub mod usart;
 
 use cortexm4::{hard_fault_handler, svc_handler, systick_handler, unhandled_interrupt};

--- a/chips/stm32f4xx/src/trng.rs
+++ b/chips/stm32f4xx/src/trng.rs
@@ -1,0 +1,159 @@
+//! True random number generator
+
+use crate::rcc;
+use kernel::common::cells::OptionalCell;
+use kernel::common::registers::{register_bitfields, ReadOnly, ReadWrite};
+use kernel::common::StaticRef;
+use kernel::hil;
+use kernel::hil::entropy::Continue;
+use kernel::ClockInterface;
+use kernel::ReturnCode;
+
+const RNG_BASE: StaticRef<RngRegisters> =
+    unsafe { StaticRef::new(0x5006_0800 as *const RngRegisters) };
+
+#[repr(C)]
+pub struct RngRegisters {
+    cr: ReadWrite<u32, Control::Register>,
+    sr: ReadWrite<u32, Status::Register>,
+    data: ReadOnly<u32, Data::Register>,
+}
+
+register_bitfields![u32,
+    Control [
+        /// Clock error detection
+        CED OFFSET(5) NUMBITS(1) [
+            ENABLE = 0,
+            DISABLE = 1
+        ],
+        /// Interrupt enable
+        IE OFFSET(3) NUMBITS(1) [],
+        /// True random number generator enable
+        RNGEN OFFSET(2) NUMBITS(1) []
+    ],
+    Status [
+        /// Seed error interrupt status
+        SEIS OFFSET(6) NUMBITS(1) [],
+        /// Clock error interrupt status
+        CEIS OFFSET(5) NUMBITS(1) [],
+        /// Seed error current status
+        SECS OFFSET(2) NUMBITS(1) [],
+        /// Clock error current status
+        CECS OFFSET(1) NUMBITS(1) [],
+        /// Data ready
+        DRDY OFFSET(0) NUMBITS(1) []
+    ],
+    Data [
+        /// Random data
+        RNDATA OFFSET(0) NUMBITS(32) []
+    ]
+];
+
+pub struct Trng<'a> {
+    registers: StaticRef<RngRegisters>,
+    clock: RngClock<'a>,
+    client: OptionalCell<&'a dyn hil::entropy::Client32>,
+}
+
+impl<'a> Trng<'a> {
+    pub const fn new(rcc: &'a rcc::Rcc) -> Trng<'a> {
+        Trng {
+            registers: RNG_BASE,
+            clock: RngClock(rcc::PeripheralClock::new(
+                rcc::PeripheralClockType::AHB2(rcc::HCLK2::RNG),
+                rcc,
+            )),
+            client: OptionalCell::empty(),
+        }
+    }
+
+    pub fn is_enabled_clock(&self) -> bool {
+        self.clock.is_enabled()
+    }
+
+    pub fn enable_clock(&self) {
+        self.clock.enable();
+    }
+
+    pub fn disable_clock(&self) {
+        self.clock.disable();
+    }
+
+    pub fn handle_interrupt(&self) {
+        if self.registers.sr.is_set(Status::SEIS) {
+            self.registers.sr.modify(Status::SEIS::CLEAR);
+
+            // Throw away the content of the data register.
+            self.registers.data.read(Data::RNDATA);
+
+            // Restart the rng.
+            self.registers.cr.modify(Control::RNGEN::CLEAR);
+            self.registers.cr.modify(Control::RNGEN::SET);
+            return;
+        } else if self.registers.sr.is_set(Status::CEIS) {
+            self.clock.0.configure_rng_clock();
+            self.registers.sr.modify(Status::CEIS::CLEAR);
+            return;
+        }
+
+        self.client.map(|client| {
+            let res = client.entropy_available(&mut TrngIter(self), ReturnCode::SUCCESS);
+            if let Continue::Done = res {
+                self.registers.cr.modify(Control::IE::CLEAR);
+                self.registers.cr.modify(Control::RNGEN::CLEAR);
+            }
+        });
+    }
+}
+
+struct RngClock<'a>(rcc::PeripheralClock<'a>);
+
+impl ClockInterface for RngClock<'_> {
+    fn is_enabled(&self) -> bool {
+        self.0.is_enabled()
+    }
+
+    fn enable(&self) {
+        self.0.enable();
+    }
+
+    fn disable(&self) {
+        self.0.disable();
+    }
+}
+
+struct TrngIter<'a, 'b: 'a>(&'a Trng<'b>);
+
+impl Iterator for TrngIter<'_, '_> {
+    type Item = u32;
+
+    fn next(&mut self) -> Option<u32> {
+        if self.0.registers.sr.is_set(Status::DRDY) {
+            // This also clears the DRDY bit in the Status register.
+            Some(self.0.registers.data.read(Data::RNDATA))
+        } else {
+            None
+        }
+    }
+}
+
+impl<'a> hil::entropy::Entropy32<'a> for Trng<'a> {
+    fn get(&self) -> ReturnCode {
+        // Enable interrupts.
+        self.registers.cr.modify(Control::IE::SET);
+        self.registers.cr.modify(Control::RNGEN::SET);
+
+        ReturnCode::SUCCESS
+    }
+
+    fn cancel(&self) -> ReturnCode {
+        self.registers.cr.modify(Control::RNGEN::CLEAR);
+        self.registers.cr.modify(Control::IE::CLEAR);
+
+        ReturnCode::SUCCESS
+    }
+
+    fn set_client(&'a self, client: &'a dyn hil::entropy::Client32) {
+        self.client.set(client);
+    }
+}


### PR DESCRIPTION
### Pull Request Overview

This pull request adds true random number generation support for the stm32f412gdiscovery board. 
I had to tweak the Stm32f4xx struct a little bit, making it generic over an interrupt service. This makes it possible to access interrupts that are specific to supersets of the stm32f4xx chip (stm32f412 in this case). 

### Testing Strategy

This pull request was tested using a stm32f412gdisco board by running the rng test from libtock-c.


### TODO or Help Wanted

N/O


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
