### PR TITLE
[WIP] Rename AppId to ProcessId

### DIFF
--- a/capsules/src/alarm.rs
+++ b/capsules/src/alarm.rs
@@ -3,7 +3,7 @@
 
 use core::cell::Cell;
 use kernel::hil::time::{self, Alarm, Frequency, Ticks, Ticks32};
-use kernel::{AppId, Callback, Driver, Grant, ReturnCode};
+use kernel::{Callback, Driver, Grant, ProcessId, ReturnCode};
 
 /// Syscall driver number.
 use crate::driver;
@@ -154,7 +154,7 @@ impl<'a, A: Alarm<'a>> Driver for AlarmDriver<'a, A> {
         &self,
         _subscribe_num: usize,
         callback: Option<Callback>,
-        app_id: AppId,
+        app_id: ProcessId,
     ) -> ReturnCode {
         self.app_alarms
             .enter(app_id, |td, _allocator| {
@@ -174,7 +174,13 @@ impl<'a, A: Alarm<'a>> Driver for AlarmDriver<'a, A> {
     /// - `3`: Stop the alarm if it is outstanding
     /// - `4`: Set an alarm to fire at a given clock value `time`.
     /// - `5`: Set an alarm to fire at a given clock value `time` relative to `now` (EXPERIMENTAL).
-    fn command(&self, cmd_type: usize, data: usize, data2: usize, caller_id: AppId) -> ReturnCode {
+    fn command(
+        &self,
+        cmd_type: usize,
+        data: usize,
+        data2: usize,
+        caller_id: ProcessId,
+    ) -> ReturnCode {
         // Returns the error code to return to the user and whether we need to
         // reset which is the next active alarm. We _don't_ reset if
         //   - we're disabling the underlying alarm anyway,

--- a/capsules/src/ambient_light.rs
+++ b/capsules/src/ambient_light.rs
@@ -14,7 +14,7 @@
 
 use core::cell::Cell;
 use kernel::hil;
-use kernel::{AppId, Callback, Driver, Grant, ReturnCode};
+use kernel::{Callback, Driver, Grant, ProcessId, ReturnCode};
 
 /// Syscall driver number.
 use crate::driver;
@@ -42,7 +42,7 @@ impl<'a> AmbientLight<'a> {
         }
     }
 
-    fn enqueue_sensor_reading(&self, appid: AppId) -> ReturnCode {
+    fn enqueue_sensor_reading(&self, appid: ProcessId) -> ReturnCode {
         self.apps
             .enter(appid, |app, _| {
                 if app.pending {
@@ -71,7 +71,7 @@ impl Driver for AmbientLight<'_> {
         &self,
         subscribe_num: usize,
         callback: Option<Callback>,
-        app_id: AppId,
+        app_id: ProcessId,
     ) -> ReturnCode {
         match subscribe_num {
             0 => self
@@ -96,7 +96,7 @@ impl Driver for AmbientLight<'_> {
     ///
     /// - `0`: Check driver presence
     /// - `1`: Start a light sensor reading
-    fn command(&self, command_num: usize, _: usize, _: usize, appid: AppId) -> ReturnCode {
+    fn command(&self, command_num: usize, _: usize, _: usize, appid: ProcessId) -> ReturnCode {
         match command_num {
             0 /* check if present */ => ReturnCode::SUCCESS,
             1 => {

--- a/capsules/src/analog_comparator.rs
+++ b/capsules/src/analog_comparator.rs
@@ -39,7 +39,7 @@ pub const DRIVER_NUM: usize = driver::NUM::AnalogComparator as usize;
 
 use core::cell::Cell;
 use kernel::hil;
-use kernel::{AppId, Callback, Driver, ReturnCode};
+use kernel::{Callback, Driver, ProcessId, ReturnCode};
 
 pub struct AnalogComparator<'a, A: hil::analog_comparator::AnalogComparator<'a> + 'a> {
     // Analog Comparator driver
@@ -119,7 +119,7 @@ impl<'a, A: hil::analog_comparator::AnalogComparator<'a>> Driver for AnalogCompa
     /// - `3`: Stop interrupt-based comparisons.
     ///        Input x chooses the desired comparator ACx (e.g. 0 or 1 for
     ///        hail, 0-3 for imix)
-    fn command(&self, command_num: usize, channel: usize, _: usize, _: AppId) -> ReturnCode {
+    fn command(&self, command_num: usize, channel: usize, _: usize, _: ProcessId) -> ReturnCode {
         match command_num {
             0 => ReturnCode::SuccessWithValue {
                 value: self.channels.len() as usize,
@@ -140,7 +140,7 @@ impl<'a, A: hil::analog_comparator::AnalogComparator<'a>> Driver for AnalogCompa
         &self,
         subscribe_num: usize,
         callback: Option<Callback>,
-        _app_id: AppId,
+        _app_id: ProcessId,
     ) -> ReturnCode {
         match subscribe_num {
             // Subscribe to all interrupts

--- a/capsules/src/ble_advertising_driver.rs
+++ b/capsules/src/ble_advertising_driver.rs
@@ -221,8 +221,8 @@ impl App {
     // Byte 1            0xf0
     // Byte 2-5          random
     // Byte 6            0xf0
-    // FIXME: For now use AppId as "randomness"
-    fn generate_random_address(&mut self, appid: kernel::AppId) -> ReturnCode {
+    // FIXME: For now use ProcessId as "randomness"
+    fn generate_random_address(&mut self, appid: kernel::ProcessId) -> ReturnCode {
         self.address = [
             0xf0,
             (appid.id() & 0xff) as u8,
@@ -303,8 +303,8 @@ where
     app: kernel::Grant<App>,
     kernel_tx: kernel::common::cells::TakeCell<'static, [u8]>,
     alarm: &'a A,
-    sending_app: OptionalCell<kernel::AppId>,
-    receiving_app: OptionalCell<kernel::AppId>,
+    sending_app: OptionalCell<kernel::ProcessId>,
+    receiving_app: OptionalCell<kernel::ProcessId>,
 }
 
 impl<'a, B, A> BLE<'a, B, A>
@@ -552,7 +552,7 @@ where
         command_num: usize,
         data: usize,
         interval: usize,
-        appid: kernel::AppId,
+        appid: kernel::ProcessId,
     ) -> ReturnCode {
         match command_num {
             // Start periodic advertisements
@@ -643,7 +643,7 @@ where
 
     fn allow(
         &self,
-        appid: kernel::AppId,
+        appid: kernel::ProcessId,
         allow_num: usize,
         slice: Option<kernel::AppSlice<kernel::Shared, u8>>,
     ) -> ReturnCode {
@@ -684,7 +684,7 @@ where
         &self,
         subscribe_num: usize,
         callback: Option<kernel::Callback>,
-        app_id: kernel::AppId,
+        app_id: kernel::ProcessId,
     ) -> ReturnCode {
         match subscribe_num {
             // Callback for scanning

--- a/capsules/src/button.rs
+++ b/capsules/src/button.rs
@@ -54,7 +54,7 @@
 use core::cell::Cell;
 use kernel::hil::gpio;
 use kernel::hil::gpio::{Configure, Input, InterruptWithValue};
-use kernel::{AppId, Callback, Driver, Grant, ReturnCode};
+use kernel::{Callback, Driver, Grant, ProcessId, ReturnCode};
 
 /// Syscall driver number.
 use crate::driver;
@@ -117,7 +117,7 @@ impl<'a, P: gpio::InterruptPin<'a>> Driver for Button<'a, P> {
         &self,
         subscribe_num: usize,
         callback: Option<Callback>,
-        app_id: AppId,
+        app_id: ProcessId,
     ) -> ReturnCode {
         match subscribe_num {
             0 => self
@@ -149,7 +149,7 @@ impl<'a, P: gpio::InterruptPin<'a>> Driver for Button<'a, P> {
     /// - `2`: Disable interrupts for a button. No affect or reliance on
     ///   registered callback.
     /// - `3`: Read the current state of the button.
-    fn command(&self, command_num: usize, data: usize, _: usize, appid: AppId) -> ReturnCode {
+    fn command(&self, command_num: usize, data: usize, _: usize, appid: ProcessId) -> ReturnCode {
         let pins = self.pins;
         match command_num {
             // return button count

--- a/capsules/src/crc.rs
+++ b/capsules/src/crc.rs
@@ -70,7 +70,7 @@
 use kernel::common::cells::OptionalCell;
 use kernel::hil;
 use kernel::hil::crc::CrcAlg;
-use kernel::{AppId, AppSlice, Callback, Driver, Grant, ReturnCode, Shared};
+use kernel::{AppSlice, Callback, Driver, Grant, ProcessId, ReturnCode, Shared};
 
 /// Syscall driver number.
 use crate::driver;
@@ -92,7 +92,7 @@ pub struct App {
 pub struct Crc<'a, C: hil::crc::CRC<'a>> {
     crc_unit: &'a C,
     apps: Grant<App>,
-    serving_app: OptionalCell<AppId>,
+    serving_app: OptionalCell<ProcessId>,
 }
 
 impl<'a, C: hil::crc::CRC<'a>> Crc<'a, C> {
@@ -173,7 +173,7 @@ impl<'a, C: hil::crc::CRC<'a>> Driver for Crc<'a, C> {
     ///
     fn allow(
         &self,
-        appid: AppId,
+        appid: ProcessId,
         allow_num: usize,
         slice: Option<AppSlice<Shared, u8>>,
     ) -> ReturnCode {
@@ -213,7 +213,7 @@ impl<'a, C: hil::crc::CRC<'a>> Driver for Crc<'a, C> {
         &self,
         subscribe_num: usize,
         callback: Option<Callback>,
-        app_id: AppId,
+        app_id: ProcessId,
     ) -> ReturnCode {
         match subscribe_num {
             // Set callback for CRC result
@@ -287,7 +287,13 @@ impl<'a, C: hil::crc::CRC<'a>> Driver for Crc<'a, C> {
     ///   * `4: SAM4L-32C`  This algorithm uses the same polynomial as
     ///   `CRC-32C`, but does no post-processing on the output value.  It
     ///   can be performed purely in hardware on the SAM4L.
-    fn command(&self, command_num: usize, algorithm: usize, _: usize, appid: AppId) -> ReturnCode {
+    fn command(
+        &self,
+        command_num: usize,
+        algorithm: usize,
+        _: usize,
+        appid: ProcessId,
+    ) -> ReturnCode {
         match command_num {
             // This driver is present
             0 => ReturnCode::SUCCESS,

--- a/capsules/src/ctap.rs
+++ b/capsules/src/ctap.rs
@@ -31,7 +31,7 @@ use core::cell::Cell;
 use core::marker::PhantomData;
 use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::hil::usb_hid;
-use kernel::{AppId, AppSlice, Callback, Driver, Grant, ReturnCode, Shared};
+use kernel::{AppSlice, Callback, Driver, Grant, ProcessId, ReturnCode, Shared};
 
 /// Syscall driver number.
 use crate::driver;
@@ -59,7 +59,7 @@ pub struct CtapDriver<'a, U: usb_hid::UsbHid<'a, [u8; 64]>> {
     usb: Option<&'a U>,
 
     app: Grant<App>,
-    appid: OptionalCell<AppId>,
+    appid: OptionalCell<ProcessId>,
     phantom: PhantomData<&'a U>,
 
     send_buffer: TakeCell<'static, [u8; 64]>,
@@ -195,7 +195,7 @@ impl<'a, U: usb_hid::UsbHid<'a, [u8; 64]>> usb_hid::Client<'a, [u8; 64]> for Cta
 impl<'a, U: usb_hid::UsbHid<'a, [u8; 64]>> Driver for CtapDriver<'a, U> {
     fn allow(
         &self,
-        appid: AppId,
+        appid: ProcessId,
         allow_num: usize,
         slice: Option<AppSlice<Shared, u8>>,
     ) -> ReturnCode {
@@ -235,7 +235,7 @@ impl<'a, U: usb_hid::UsbHid<'a, [u8; 64]>> Driver for CtapDriver<'a, U> {
         &self,
         subscribe_num: usize,
         callback: Option<Callback>,
-        appid: AppId,
+        appid: ProcessId,
     ) -> ReturnCode {
         match subscribe_num {
             0 => {
@@ -258,7 +258,7 @@ impl<'a, U: usb_hid::UsbHid<'a, [u8; 64]>> Driver for CtapDriver<'a, U> {
         command_num: usize,
         _data1: usize,
         _data2: usize,
-        appid: AppId,
+        appid: ProcessId,
     ) -> ReturnCode {
         let can_access = self.appid.map_or(true, |owning_app| {
             if owning_app == &appid {

--- a/capsules/src/dac.rs
+++ b/capsules/src/dac.rs
@@ -16,7 +16,7 @@ use crate::driver;
 pub const DRIVER_NUM: usize = driver::NUM::Dac as usize;
 
 use kernel::hil;
-use kernel::{AppId, Driver, ReturnCode};
+use kernel::{Driver, ProcessId, ReturnCode};
 
 pub struct Dac<'a> {
     dac: &'a dyn hil::dac::DacChannel,
@@ -36,7 +36,7 @@ impl Driver for Dac<'_> {
     /// - `0`: Driver check.
     /// - `1`: Initialize and enable the DAC.
     /// - `2`: Set the output to `data1`, a scaled output value.
-    fn command(&self, command_num: usize, data: usize, _: usize, _: AppId) -> ReturnCode {
+    fn command(&self, command_num: usize, data: usize, _: usize, _: ProcessId) -> ReturnCode {
         match command_num {
             0 /* check if present */ => ReturnCode::SUCCESS,
 

--- a/capsules/src/ft6x06.rs
+++ b/capsules/src/ft6x06.rs
@@ -27,7 +27,7 @@ use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::hil::gpio;
 use kernel::hil::i2c::{self, Error};
 use kernel::hil::touch::{self, GestureEvent, TouchEvent, TouchStatus};
-use kernel::{AppId, Driver, ReturnCode};
+use kernel::{Driver, ProcessId, ReturnCode};
 
 use crate::driver;
 
@@ -250,7 +250,7 @@ impl<'a> touch::MultiTouch<'a> for Ft6x06<'a> {
 }
 
 impl Driver for Ft6x06<'_> {
-    fn command(&self, command_num: usize, _: usize, _: usize, _: AppId) -> ReturnCode {
+    fn command(&self, command_num: usize, _: usize, _: usize, _: ProcessId) -> ReturnCode {
         match command_num {
             // is driver present
             0 => ReturnCode::SUCCESS,

--- a/capsules/src/gpio.rs
+++ b/capsules/src/gpio.rs
@@ -53,7 +53,7 @@ pub const DRIVER_NUM: usize = driver::NUM::Gpio as usize;
 
 use kernel::hil::gpio;
 use kernel::hil::gpio::{Configure, Input, InterruptWithValue, Output};
-use kernel::{AppId, Callback, Driver, Grant, ReturnCode};
+use kernel::{Callback, Driver, Grant, ProcessId, ReturnCode};
 
 pub struct GPIO<'a, IP: gpio::InterruptPin<'a>> {
     pins: &'a [Option<&'a gpio::InterruptValueWrapper<'a, IP>>],
@@ -154,7 +154,7 @@ impl<'a, IP: gpio::InterruptPin<'a>> Driver for GPIO<'a, IP> {
         &self,
         subscribe_num: usize,
         callback: Option<Callback>,
-        app_id: AppId,
+        app_id: ProcessId,
     ) -> ReturnCode {
         match subscribe_num {
             // subscribe to all pin interrupts (no affect or reliance on
@@ -202,7 +202,7 @@ impl<'a, IP: gpio::InterruptPin<'a>> Driver for GPIO<'a, IP> {
     /// - `7`: Configure interrupt on `pin` with `irq_config` in 0x00XX00000
     /// - `8`: Disable interrupt on `pin`.
     /// - `9`: Disable `pin`.
-    fn command(&self, command_num: usize, data1: usize, data2: usize, _: AppId) -> ReturnCode {
+    fn command(&self, command_num: usize, data1: usize, data2: usize, _: ProcessId) -> ReturnCode {
         let pins = self.pins.as_ref();
         let pin_index = data1;
         match command_num {

--- a/capsules/src/gpio_async.rs
+++ b/capsules/src/gpio_async.rs
@@ -28,7 +28,7 @@
 use kernel::common::cells::OptionalCell;
 use kernel::hil;
 use kernel::ReturnCode;
-use kernel::{AppId, Callback, Driver};
+use kernel::{Callback, Driver, ProcessId};
 
 /// Syscall driver number.
 use crate::driver;
@@ -102,7 +102,7 @@ impl<Port: hil::gpio_async::Port> Driver for GPIOAsync<'_, Port> {
         &self,
         subscribe_num: usize,
         callback: Option<Callback>,
-        _app_id: AppId,
+        _app_id: ProcessId,
     ) -> ReturnCode {
         match subscribe_num {
             // Set callback for `done()` events
@@ -146,7 +146,7 @@ impl<Port: hil::gpio_async::Port> Driver for GPIOAsync<'_, Port> {
     ///   interrupt, and 2 for a falling edge interrupt.
     /// - `8`: Disable an interrupt on a pin.
     /// - `9`: Disable a GPIO pin.
-    fn command(&self, command_num: usize, pin: usize, data: usize, _: AppId) -> ReturnCode {
+    fn command(&self, command_num: usize, pin: usize, data: usize, _: ProcessId) -> ReturnCode {
         let port = data & 0xFFFF;
         let other = (data >> 16) & 0xFFFF;
         let ports = self.ports.as_ref();

--- a/capsules/src/hd44780.rs
+++ b/capsules/src/hd44780.rs
@@ -133,7 +133,7 @@ use core::cell::Cell;
 use kernel::common::cells::TakeCell;
 use kernel::hil::gpio;
 use kernel::hil::time::{self, Alarm};
-use kernel::{AppId, AppSlice, Callback, Driver, Grant, ReturnCode, Shared};
+use kernel::{AppSlice, Callback, Driver, Grant, ProcessId, ReturnCode, Shared};
 
 /// Syscall driver number.
 
@@ -697,7 +697,7 @@ impl<'a, A: Alarm<'a>> Driver for HD44780<'a, A> {
      */
     fn allow(
         &self,
-        appid: AppId,
+        appid: ProcessId,
         allow_num: usize,
         slice: Option<AppSlice<Shared, u8>>,
     ) -> ReturnCode {
@@ -774,7 +774,13 @@ impl<'a, A: Alarm<'a>> Driver for HD44780<'a, A> {
      * // save a Begin command with 16 and 1 as arguments
      * int ret = command(DRIVER_LCD_NUM, 0, 16, 1);
      */
-    fn command(&self, command_num: usize, data_1: usize, data_2: usize, _: AppId) -> ReturnCode {
+    fn command(
+        &self,
+        command_num: usize,
+        data_1: usize,
+        data_2: usize,
+        _: ProcessId,
+    ) -> ReturnCode {
         /* check to see how many slots we need in the command buffer for the
          * request
          */
@@ -1019,7 +1025,7 @@ impl<'a, A: Alarm<'a>> Driver for HD44780<'a, A> {
         &self,
         _subscribe_num: usize,
         _callback: Option<Callback>,
-        _app_id: AppId,
+        _app_id: ProcessId,
     ) -> ReturnCode {
         ReturnCode::ENOSUPPORT
     }

--- a/capsules/src/humidity.rs
+++ b/capsules/src/humidity.rs
@@ -51,7 +51,7 @@
 use core::cell::Cell;
 use kernel::hil;
 use kernel::ReturnCode;
-use kernel::{AppId, Callback, Driver, Grant};
+use kernel::{Callback, Driver, Grant, ProcessId};
 
 /// Syscall driver number.
 use crate::driver;
@@ -87,7 +87,12 @@ impl<'a> HumiditySensor<'a> {
         }
     }
 
-    fn enqueue_command(&self, command: HumidityCommand, arg1: usize, appid: AppId) -> ReturnCode {
+    fn enqueue_command(
+        &self,
+        command: HumidityCommand,
+        arg1: usize,
+        appid: ProcessId,
+    ) -> ReturnCode {
         self.apps
             .enter(appid, |app, _| {
                 if !self.busy.get() {
@@ -108,7 +113,7 @@ impl<'a> HumiditySensor<'a> {
         }
     }
 
-    fn configure_callback(&self, callback: Option<Callback>, app_id: AppId) -> ReturnCode {
+    fn configure_callback(&self, callback: Option<Callback>, app_id: ProcessId) -> ReturnCode {
         self.apps
             .enter(app_id, |app, _| {
                 app.callback = callback;
@@ -137,7 +142,7 @@ impl Driver for HumiditySensor<'_> {
         &self,
         subscribe_num: usize,
         callback: Option<Callback>,
-        app_id: AppId,
+        app_id: ProcessId,
     ) -> ReturnCode {
         match subscribe_num {
             // subscribe to temperature reading with callback
@@ -146,7 +151,7 @@ impl Driver for HumiditySensor<'_> {
         }
     }
 
-    fn command(&self, command_num: usize, arg1: usize, _: usize, appid: AppId) -> ReturnCode {
+    fn command(&self, command_num: usize, arg1: usize, _: usize, appid: ProcessId) -> ReturnCode {
         match command_num {
             // check whether the driver exist!!
             0 => ReturnCode::SUCCESS,

--- a/capsules/src/i2c_master.rs
+++ b/capsules/src/i2c_master.rs
@@ -3,7 +3,7 @@
 use enum_primitive::enum_from_primitive;
 use kernel::common::cells::{MapCell, OptionalCell, TakeCell};
 use kernel::hil::i2c;
-use kernel::{AppId, AppSlice, Callback, Driver, Grant, ReturnCode, Shared};
+use kernel::{AppSlice, Callback, Driver, Grant, ProcessId, ReturnCode, Shared};
 
 /// Syscall driver number.
 use crate::driver;
@@ -20,7 +20,7 @@ pub static mut BUF: [u8; 64] = [0; 64];
 struct Transaction {
     /// The buffer containing the bytes to transmit as it should be returned to
     /// the client
-    app_id: AppId,
+    app_id: ProcessId,
     /// The total amount to transmit
     read_len: OptionalCell<usize>,
 }
@@ -44,7 +44,7 @@ impl<I: 'static + i2c::I2CMaster> I2CMasterDriver<I> {
 
     fn operation(
         &self,
-        app_id: AppId,
+        app_id: ProcessId,
         app: &mut App,
         command: Cmd,
         addr: u8,
@@ -110,7 +110,7 @@ impl<I: i2c::I2CMaster> Driver for I2CMasterDriver<I> {
     /// - `1`: buffer for command
     fn allow(
         &self,
-        appid: AppId,
+        appid: ProcessId,
         allow_num: usize,
         slice: Option<AppSlice<Shared, u8>>,
     ) -> ReturnCode {
@@ -135,7 +135,7 @@ impl<I: i2c::I2CMaster> Driver for I2CMasterDriver<I> {
         &self,
         subscribe_num: usize,
         callback: Option<Callback>,
-        app_id: AppId,
+        app_id: ProcessId,
     ) -> ReturnCode {
         match subscribe_num {
             1 /* write_read_done */ => {
@@ -149,7 +149,7 @@ impl<I: i2c::I2CMaster> Driver for I2CMasterDriver<I> {
     }
 
     /// Initiate transfers
-    fn command(&self, cmd_num: usize, arg1: usize, arg2: usize, appid: AppId) -> ReturnCode {
+    fn command(&self, cmd_num: usize, arg1: usize, arg2: usize, appid: ProcessId) -> ReturnCode {
         if let Some(cmd) = Cmd::from_usize(cmd_num) {
             match cmd {
                 Cmd::Ping => ReturnCode::SUCCESS,

--- a/capsules/src/i2c_master_slave_driver.rs
+++ b/capsules/src/i2c_master_slave_driver.rs
@@ -16,7 +16,7 @@ use core::cmp;
 use kernel::common::cells::{MapCell, TakeCell};
 use kernel::hil;
 use kernel::ReturnCode;
-use kernel::{AppId, AppSlice, Callback, Driver, Shared};
+use kernel::{AppSlice, Callback, Driver, ProcessId, Shared};
 
 pub static mut BUFFER1: [u8; 256] = [0; 256];
 pub static mut BUFFER2: [u8; 256] = [0; 256];
@@ -213,7 +213,7 @@ impl hil::i2c::I2CHwSlaveClient for I2CMasterSlaveDriver<'_> {
 impl Driver for I2CMasterSlaveDriver<'_> {
     fn allow(
         &self,
-        _appid: AppId,
+        _appid: ProcessId,
         allow_num: usize,
         slice: Option<AppSlice<Shared, u8>>,
     ) -> ReturnCode {
@@ -255,7 +255,7 @@ impl Driver for I2CMasterSlaveDriver<'_> {
         &self,
         subscribe_num: usize,
         callback: Option<Callback>,
-        _app_id: AppId,
+        _app_id: ProcessId,
     ) -> ReturnCode {
         match subscribe_num {
             0 => {
@@ -270,7 +270,7 @@ impl Driver for I2CMasterSlaveDriver<'_> {
         }
     }
 
-    fn command(&self, command_num: usize, data: usize, _: usize, _: AppId) -> ReturnCode {
+    fn command(&self, command_num: usize, data: usize, _: usize, _: ProcessId) -> ReturnCode {
         match command_num {
             0 /* check if present */ => ReturnCode::SUCCESS,
 

--- a/capsules/src/l3gd20.rs
+++ b/capsules/src/l3gd20.rs
@@ -107,7 +107,7 @@ use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::hil::sensors;
 use kernel::hil::spi;
 use kernel::ReturnCode;
-use kernel::{AppId, Callback, Driver};
+use kernel::{Callback, Driver, ProcessId};
 
 use crate::driver;
 pub const DRIVER_NUM: usize = driver::NUM::L3gd20 as usize;
@@ -294,7 +294,7 @@ impl<'a> L3gd20Spi<'a> {
 }
 
 impl Driver for L3gd20Spi<'_> {
-    fn command(&self, command_num: usize, data1: usize, data2: usize, _: AppId) -> ReturnCode {
+    fn command(&self, command_num: usize, data1: usize, data2: usize, _: ProcessId) -> ReturnCode {
         match command_num {
             0 => ReturnCode::SUCCESS,
             // Check is sensor is correctly connected
@@ -373,7 +373,7 @@ impl Driver for L3gd20Spi<'_> {
         &self,
         subscribe_num: usize,
         callback: Option<Callback>,
-        _app_id: AppId,
+        _app_id: ProcessId,
     ) -> ReturnCode {
         match subscribe_num {
             0 /* set the one shot callback */ => {

--- a/capsules/src/led.rs
+++ b/capsules/src/led.rs
@@ -51,7 +51,7 @@
 //!   - Return: `SUCCESS` if the LED index was valid, `EINVAL` otherwise.
 
 use kernel::hil::gpio;
-use kernel::{AppId, Driver, ReturnCode};
+use kernel::{Driver, ProcessId, ReturnCode};
 
 /// Syscall driver number.
 use crate::driver;
@@ -90,7 +90,7 @@ impl<P: gpio::Pin> Driver for LED<'_, P> {
     ///        if the LED index is not valid.
     /// - `3`: Toggle the LED at index specified by `data` on or off. Returns
     ///        `EINVAL` if the LED index is not valid.
-    fn command(&self, command_num: usize, data: usize, _: usize, _: AppId) -> ReturnCode {
+    fn command(&self, command_num: usize, data: usize, _: usize, _: ProcessId) -> ReturnCode {
         let pins_init = self.pins_init.as_ref();
         match command_num {
             // get number of LEDs

--- a/capsules/src/low_level_debug/mod.rs
+++ b/capsules/src/low_level_debug/mod.rs
@@ -5,7 +5,7 @@ mod fmt;
 
 use core::cell::Cell;
 use kernel::hil::uart::{Transmit, TransmitClient};
-use kernel::{AppId, Grant, ReturnCode};
+use kernel::{Grant, ProcessId, ReturnCode};
 
 // LowLevelDebug requires a &mut [u8] buffer of length at least BUF_LEN.
 pub use fmt::BUF_LEN;
@@ -41,7 +41,7 @@ impl<'u, U: Transmit<'u>> LowLevelDebug<'u, U> {
 }
 
 impl<'u, U: Transmit<'u>> kernel::Driver for LowLevelDebug<'u, U> {
-    fn command(&self, minor_num: usize, r2: usize, r3: usize, caller_id: AppId) -> ReturnCode {
+    fn command(&self, minor_num: usize, r2: usize, r3: usize, caller_id: ProcessId) -> ReturnCode {
         match minor_num {
             0 => return ReturnCode::SUCCESS,
             1 => self.push_entry(DebugEntry::AlertCode(r2), caller_id),
@@ -94,7 +94,7 @@ impl<'u, U: Transmit<'u>> TransmitClient for LowLevelDebug<'u, U> {
 impl<'u, U: Transmit<'u>> LowLevelDebug<'u, U> {
     // If the UART is not busy (the buffer is available), transmits the entry.
     // Otherwise, adds it to the app's queue.
-    fn push_entry(&self, entry: DebugEntry, appid: AppId) {
+    fn push_entry(&self, entry: DebugEntry, appid: ProcessId) {
         use DebugEntry::Dropped;
 
         if let Some(buffer) = self.buffer.take() {

--- a/capsules/src/lps25hb.rs
+++ b/capsules/src/lps25hb.rs
@@ -22,7 +22,7 @@ use core::cell::Cell;
 use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::hil::gpio;
 use kernel::hil::i2c;
-use kernel::{AppId, Callback, Driver, ReturnCode};
+use kernel::{Callback, Driver, ProcessId, ReturnCode};
 
 /// Syscall driver number.
 use crate::driver;
@@ -226,7 +226,7 @@ impl Driver for LPS25HB<'_> {
         &self,
         subscribe_num: usize,
         callback: Option<Callback>,
-        _app_id: AppId,
+        _app_id: ProcessId,
     ) -> ReturnCode {
         match subscribe_num {
             // Set a callback
@@ -240,7 +240,7 @@ impl Driver for LPS25HB<'_> {
         }
     }
 
-    fn command(&self, command_num: usize, _: usize, _: usize, _: AppId) -> ReturnCode {
+    fn command(&self, command_num: usize, _: usize, _: usize, _: ProcessId) -> ReturnCode {
         match command_num {
             0 /* check if present */ => ReturnCode::SUCCESS,
             // Take a pressure measurement

--- a/capsules/src/lsm303dlhc.rs
+++ b/capsules/src/lsm303dlhc.rs
@@ -85,7 +85,7 @@ use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::common::registers::register_bitfields;
 use kernel::hil::i2c::{self, Error};
 use kernel::hil::sensors;
-use kernel::{AppId, Callback, Driver, ReturnCode};
+use kernel::{Callback, Driver, ProcessId, ReturnCode};
 
 register_bitfields![u8,
     CTRL_REG1 [
@@ -607,7 +607,7 @@ impl i2c::I2CClient for Lsm303dlhcI2C<'_> {
 }
 
 impl Driver for Lsm303dlhcI2C<'_> {
-    fn command(&self, command_num: usize, data1: usize, data2: usize, _: AppId) -> ReturnCode {
+    fn command(&self, command_num: usize, data1: usize, data2: usize, _: ProcessId) -> ReturnCode {
         match command_num {
             0 => ReturnCode::SUCCESS,
             // Check is sensor is correctly connected
@@ -710,7 +710,7 @@ impl Driver for Lsm303dlhcI2C<'_> {
         &self,
         subscribe_num: usize,
         callback: Option<Callback>,
-        _app_id: AppId,
+        _app_id: ProcessId,
     ) -> ReturnCode {
         match subscribe_num {
             0 /* set the one shot callback */ => {

--- a/capsules/src/ltc294x.rs
+++ b/capsules/src/ltc294x.rs
@@ -50,7 +50,7 @@ use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::hil::gpio;
 use kernel::hil::i2c;
 use kernel::ReturnCode;
-use kernel::{AppId, Callback, Driver};
+use kernel::{Callback, Driver, ProcessId};
 
 /// Syscall driver number.
 use crate::driver;
@@ -487,7 +487,7 @@ impl Driver for LTC294XDriver<'_> {
         &self,
         subscribe_num: usize,
         callback: Option<Callback>,
-        _app_id: AppId,
+        _app_id: ProcessId,
     ) -> ReturnCode {
         match subscribe_num {
             0 => {
@@ -517,7 +517,7 @@ impl Driver for LTC294XDriver<'_> {
     /// - `9`: Get the current reading. Only supported on the LTC2943.
     /// - `10`: Set the model of the LTC294X actually being used. `data` is the
     ///   value of the X.
-    fn command(&self, command_num: usize, data: usize, _: usize, _: AppId) -> ReturnCode {
+    fn command(&self, command_num: usize, data: usize, _: usize, _: ProcessId) -> ReturnCode {
         match command_num {
             // Check this driver exists.
             0 => ReturnCode::SUCCESS,

--- a/capsules/src/max17205.rs
+++ b/capsules/src/max17205.rs
@@ -40,7 +40,7 @@
 use core::cell::Cell;
 use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::hil::i2c;
-use kernel::{AppId, Callback, Driver, ReturnCode};
+use kernel::{Callback, Driver, ProcessId, ReturnCode};
 
 /// Syscall driver number.
 use crate::driver;
@@ -420,7 +420,7 @@ impl Driver for MAX17205Driver<'_> {
         &self,
         subscribe_num: usize,
         callback: Option<Callback>,
-        _app_id: AppId,
+        _app_id: ProcessId,
     ) -> ReturnCode {
         match subscribe_num {
             0 => {
@@ -443,7 +443,7 @@ impl Driver for MAX17205Driver<'_> {
     /// - `3`: Read the current voltage and current draw.
     /// - `4`: Read the raw coulomb count.
     /// - `5`: Read the unique 64 bit RomID.
-    fn command(&self, command_num: usize, _data: usize, _: usize, _: AppId) -> ReturnCode {
+    fn command(&self, command_num: usize, _data: usize, _: usize, _: ProcessId) -> ReturnCode {
         match command_num {
             0 => ReturnCode::SUCCESS,
 

--- a/capsules/src/mlx90614.rs
+++ b/capsules/src/mlx90614.rs
@@ -22,7 +22,7 @@ use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::common::registers::register_bitfields;
 use kernel::hil::i2c::{self, Error};
 use kernel::hil::sensors;
-use kernel::{AppId, Callback, Driver, ReturnCode};
+use kernel::{Callback, Driver, ProcessId, ReturnCode};
 
 /// Syscall driver number.
 pub const DRIVER_NUM: usize = driver::NUM::Mlx90614 as usize;
@@ -156,7 +156,13 @@ impl<'a> i2c::I2CClient for Mlx90614SMBus<'a> {
 }
 
 impl<'a> Driver for Mlx90614SMBus<'a> {
-    fn command(&self, command_num: usize, _data1: usize, _data2: usize, _: AppId) -> ReturnCode {
+    fn command(
+        &self,
+        command_num: usize,
+        _data1: usize,
+        _data2: usize,
+        _: ProcessId,
+    ) -> ReturnCode {
         match command_num {
             0 => ReturnCode::SUCCESS,
             // Check is sensor is correctly connected
@@ -195,7 +201,7 @@ impl<'a> Driver for Mlx90614SMBus<'a> {
         &self,
         subscribe_num: usize,
         callback: Option<Callback>,
-        _app_id: AppId,
+        _app_id: ProcessId,
     ) -> ReturnCode {
         match subscribe_num {
             0 /* set the one shot callback */ => {

--- a/capsules/src/ninedof.rs
+++ b/capsules/src/ninedof.rs
@@ -21,7 +21,7 @@
 use kernel::common::cells::OptionalCell;
 use kernel::hil;
 use kernel::ReturnCode;
-use kernel::{AppId, Callback, Driver, Grant};
+use kernel::{Callback, Driver, Grant, ProcessId};
 
 /// Syscall driver number.
 use crate::driver;
@@ -56,7 +56,7 @@ impl Default for App {
 pub struct NineDof<'a> {
     drivers: &'a [&'a dyn hil::sensors::NineDof<'a>],
     apps: Grant<App>,
-    current_app: OptionalCell<AppId>,
+    current_app: OptionalCell<ProcessId>,
 }
 
 impl<'a> NineDof<'a> {
@@ -71,7 +71,12 @@ impl<'a> NineDof<'a> {
     // Check so see if we are doing something. If not,
     // go ahead and do this command. If so, this is queued
     // and will be run when the pending command completes.
-    fn enqueue_command(&self, command: NineDofCommand, arg1: usize, appid: AppId) -> ReturnCode {
+    fn enqueue_command(
+        &self,
+        command: NineDofCommand,
+        arg1: usize,
+        appid: ProcessId,
+    ) -> ReturnCode {
         self.apps
             .enter(appid, |app, _| {
                 if self.current_app.is_none() {
@@ -184,7 +189,7 @@ impl Driver for NineDof<'_> {
         &self,
         subscribe_num: usize,
         callback: Option<Callback>,
-        app_id: AppId,
+        app_id: ProcessId,
     ) -> ReturnCode {
         match subscribe_num {
             0 => self
@@ -198,7 +203,7 @@ impl Driver for NineDof<'_> {
         }
     }
 
-    fn command(&self, command_num: usize, arg1: usize, _: usize, appid: AppId) -> ReturnCode {
+    fn command(&self, command_num: usize, arg1: usize, _: usize, appid: ProcessId) -> ReturnCode {
         match command_num {
             0 =>
             /* This driver exists. */

--- a/capsules/src/nonvolatile_storage_driver.rs
+++ b/capsules/src/nonvolatile_storage_driver.rs
@@ -58,7 +58,7 @@ use core::cell::Cell;
 use core::cmp;
 use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::hil;
-use kernel::{AppId, AppSlice, Callback, Driver, Grant, ReturnCode, Shared};
+use kernel::{AppSlice, Callback, Driver, Grant, ProcessId, ReturnCode, Shared};
 
 /// Syscall driver number.
 use crate::driver;
@@ -76,7 +76,7 @@ pub enum NonvolatileCommand {
 
 #[derive(Clone, Copy)]
 pub enum NonvolatileUser {
-    App { app_id: AppId },
+    App { app_id: ProcessId },
     Kernel,
 }
 
@@ -178,7 +178,7 @@ impl<'a> NonvolatileStorage<'a> {
         command: NonvolatileCommand,
         offset: usize,
         length: usize,
-        app_id: Option<AppId>,
+        app_id: Option<ProcessId>,
     ) -> ReturnCode {
         // Do bounds check.
         match command {
@@ -476,7 +476,7 @@ impl Driver for NonvolatileStorage<'_> {
     /// - `1`: Setup a buffer to write bytes to the nonvolatile storage.
     fn allow(
         &self,
-        appid: AppId,
+        appid: ProcessId,
         allow_num: usize,
         slice: Option<AppSlice<Shared, u8>>,
     ) -> ReturnCode {
@@ -502,7 +502,7 @@ impl Driver for NonvolatileStorage<'_> {
         &self,
         subscribe_num: usize,
         callback: Option<Callback>,
-        app_id: AppId,
+        app_id: ProcessId,
     ) -> ReturnCode {
         self.apps
             .enter(app_id, |app, _| {
@@ -526,7 +526,7 @@ impl Driver for NonvolatileStorage<'_> {
     /// - `1`: Return the number of bytes available to userspace.
     /// - `2`: Start a read from the nonvolatile storage.
     /// - `3`: Start a write to the nonvolatile_storage.
-    fn command(&self, arg0: usize, arg1: usize, _: usize, appid: AppId) -> ReturnCode {
+    fn command(&self, arg0: usize, arg1: usize, _: usize, appid: ProcessId) -> ReturnCode {
         let command_num = arg0 & 0xFF;
 
         match command_num {

--- a/capsules/src/nrf51822_serialization.rs
+++ b/capsules/src/nrf51822_serialization.rs
@@ -25,7 +25,7 @@ use core::cmp;
 use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::hil;
 use kernel::hil::uart;
-use kernel::{AppId, AppSlice, Callback, Driver, Grant, ReturnCode, Shared};
+use kernel::{AppSlice, Callback, Driver, Grant, ProcessId, ReturnCode, Shared};
 
 /// Syscall driver number.
 use crate::driver;
@@ -51,7 +51,7 @@ pub struct Nrf51822Serialization<'a> {
     uart: &'a dyn uart::UartAdvanced<'a>,
     reset_pin: &'a dyn hil::gpio::Pin,
     apps: Grant<App>,
-    active_app: OptionalCell<AppId>,
+    active_app: OptionalCell<ProcessId>,
     tx_buffer: TakeCell<'static, [u8]>,
     rx_buffer: TakeCell<'static, [u8]>,
 }
@@ -107,7 +107,7 @@ impl Driver for Nrf51822Serialization<'_> {
     /// - `1`: Provide a TX buffer.
     fn allow(
         &self,
-        appid: AppId,
+        appid: ProcessId,
         allow_type: usize,
         slice: Option<AppSlice<Shared, u8>>,
     ) -> ReturnCode {
@@ -151,7 +151,7 @@ impl Driver for Nrf51822Serialization<'_> {
         &self,
         subscribe_type: usize,
         callback: Option<Callback>,
-        appid: AppId,
+        appid: ProcessId,
     ) -> ReturnCode {
         match subscribe_type {
             // Add a callback
@@ -181,7 +181,7 @@ impl Driver for Nrf51822Serialization<'_> {
     /// - `0`: Driver check.
     /// - `1`: Send the allowed buffer to the nRF.
     /// - `2`: Reset the nRF51822.
-    fn command(&self, command_type: usize, _: usize, _: usize, appid: AppId) -> ReturnCode {
+    fn command(&self, command_type: usize, _: usize, _: usize, appid: ProcessId) -> ReturnCode {
         match command_type {
             0 /* check if present */ => ReturnCode::SUCCESS,
 

--- a/capsules/src/pca9544a.rs
+++ b/capsules/src/pca9544a.rs
@@ -31,7 +31,7 @@
 use core::cell::Cell;
 use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::hil::i2c;
-use kernel::{AppId, Callback, Driver, ReturnCode};
+use kernel::{Callback, Driver, ProcessId, ReturnCode};
 
 /// Syscall driver number.
 use crate::driver;
@@ -159,7 +159,7 @@ impl Driver for PCA9544A<'_> {
         &self,
         subscribe_num: usize,
         callback: Option<Callback>,
-        _app_id: AppId,
+        _app_id: ProcessId,
     ) -> ReturnCode {
         match subscribe_num {
             0 => {
@@ -181,7 +181,7 @@ impl Driver for PCA9544A<'_> {
     /// - `2`: Disable all channels.
     /// - `3`: Read the list of fired interrupts.
     /// - `4`: Read which channels are selected.
-    fn command(&self, command_num: usize, data: usize, _: usize, _: AppId) -> ReturnCode {
+    fn command(&self, command_num: usize, data: usize, _: usize, _: ProcessId) -> ReturnCode {
         match command_num {
             // Check if present.
             0 => ReturnCode::SUCCESS,

--- a/capsules/src/process_console.rs
+++ b/capsules/src/process_console.rs
@@ -260,7 +260,7 @@ impl<'a, C: ProcessManagementCapability> ProcessConsole<'a, C> {
                                     let info: KernelInfo = KernelInfo::new(self.kernel);
 
                                     let pname = proc.get_process_name();
-                                    let appid = proc.appid();
+                                    let appid = proc.process_id();
                                     let (grants_used, grants_total) = info.number_app_grant_uses(appid, &self.capability);
 
                                     debug!(

--- a/capsules/src/proximity.rs
+++ b/capsules/src/proximity.rs
@@ -51,7 +51,7 @@
 use core::cell::Cell;
 use kernel::hil;
 use kernel::ReturnCode;
-use kernel::{AppId, Callback, Driver, Grant};
+use kernel::{Callback, Driver, Grant, ProcessId};
 
 /// Syscall driver number.
 use crate::driver;
@@ -108,7 +108,7 @@ impl<'a> ProximitySensor<'a> {
         command: ProximityCommand,
         arg1: usize,
         arg2: usize,
-        appid: AppId,
+        appid: ProcessId,
     ) -> ReturnCode {
         // Enqueue command by saving command type, args, appid within app struct in grant region
         let r: ReturnCode = self
@@ -243,7 +243,7 @@ impl<'a> ProximitySensor<'a> {
         }
     }
 
-    fn configure_callback(&self, callback: Option<Callback>, app_id: AppId) -> ReturnCode {
+    fn configure_callback(&self, callback: Option<Callback>, app_id: ProcessId) -> ReturnCode {
         self.apps
             .enter(app_id, |app, _| {
                 app.callback = callback;
@@ -299,7 +299,7 @@ impl Driver for ProximitySensor<'_> {
         &self,
         subscribe_num: usize,
         callback: Option<Callback>,
-        app_id: AppId,
+        app_id: ProcessId,
     ) -> ReturnCode {
         match subscribe_num {
             0 => self.configure_callback(callback, app_id),
@@ -307,7 +307,13 @@ impl Driver for ProximitySensor<'_> {
         }
     }
 
-    fn command(&self, command_num: usize, arg1: usize, arg2: usize, appid: AppId) -> ReturnCode {
+    fn command(
+        &self,
+        command_num: usize,
+        arg1: usize,
+        arg2: usize,
+        appid: ProcessId,
+    ) -> ReturnCode {
         match command_num {
             // check whether the driver exist!!
             0 => ReturnCode::SUCCESS,

--- a/capsules/src/rng.rs
+++ b/capsules/src/rng.rs
@@ -25,7 +25,7 @@ use kernel::hil::entropy;
 use kernel::hil::entropy::{Entropy32, Entropy8};
 use kernel::hil::rng;
 use kernel::hil::rng::{Client, Continue, Random, Rng};
-use kernel::{AppId, AppSlice, Callback, Driver, Grant, ReturnCode, Shared};
+use kernel::{AppSlice, Callback, Driver, Grant, ProcessId, ReturnCode, Shared};
 
 /// Syscall driver number.
 use crate::driver;
@@ -136,7 +136,7 @@ impl rng::Client for RngDriver<'_> {
 impl<'a> Driver for RngDriver<'a> {
     fn allow(
         &self,
-        appid: AppId,
+        appid: ProcessId,
         allow_num: usize,
         slice: Option<AppSlice<Shared, u8>>,
     ) -> ReturnCode {
@@ -157,7 +157,7 @@ impl<'a> Driver for RngDriver<'a> {
         &self,
         subscribe_num: usize,
         callback: Option<Callback>,
-        app_id: AppId,
+        app_id: ProcessId,
     ) -> ReturnCode {
         match subscribe_num {
             0 => self
@@ -173,7 +173,7 @@ impl<'a> Driver for RngDriver<'a> {
         }
     }
 
-    fn command(&self, command_num: usize, data: usize, _: usize, appid: AppId) -> ReturnCode {
+    fn command(&self, command_num: usize, data: usize, _: usize, appid: ProcessId) -> ReturnCode {
         match command_num {
             0 =>
             /* Check if exists */

--- a/capsules/src/sdcard.rs
+++ b/capsules/src/sdcard.rs
@@ -44,7 +44,7 @@ use core::cell::Cell;
 use core::cmp;
 use kernel::common::cells::{MapCell, OptionalCell, TakeCell};
 use kernel::hil;
-use kernel::{AppId, AppSlice, Callback, Driver, ReturnCode, Shared};
+use kernel::{AppSlice, Callback, Driver, ProcessId, ReturnCode, Shared};
 
 /// Syscall driver number.
 use crate::driver;
@@ -1486,7 +1486,7 @@ impl<'a, A: hil::time::Alarm<'a>> SDCardClient for SDCardDriver<'a, A> {
 impl<'a, A: hil::time::Alarm<'a>> Driver for SDCardDriver<'a, A> {
     fn allow(
         &self,
-        _appid: AppId,
+        _appid: ProcessId,
         allow_num: usize,
         slice: Option<AppSlice<Shared, u8>>,
     ) -> ReturnCode {
@@ -1511,7 +1511,7 @@ impl<'a, A: hil::time::Alarm<'a>> Driver for SDCardDriver<'a, A> {
         &self,
         subscribe_num: usize,
         callback: Option<Callback>,
-        _app_id: AppId,
+        _app_id: ProcessId,
     ) -> ReturnCode {
         match subscribe_num {
             // Set callback
@@ -1524,7 +1524,7 @@ impl<'a, A: hil::time::Alarm<'a>> Driver for SDCardDriver<'a, A> {
         }
     }
 
-    fn command(&self, command_num: usize, data: usize, _: usize, _: AppId) -> ReturnCode {
+    fn command(&self, command_num: usize, data: usize, _: usize, _: ProcessId) -> ReturnCode {
         match command_num {
             // check if present
             0 => ReturnCode::SUCCESS,

--- a/capsules/src/spi_controller.rs
+++ b/capsules/src/spi_controller.rs
@@ -7,7 +7,7 @@ use kernel::common::cells::{MapCell, TakeCell};
 use kernel::hil::spi::ClockPhase;
 use kernel::hil::spi::ClockPolarity;
 use kernel::hil::spi::{SpiMasterClient, SpiMasterDevice};
-use kernel::{AppId, AppSlice, Callback, Driver, ReturnCode, Shared};
+use kernel::{AppSlice, Callback, Driver, ProcessId, ReturnCode, Shared};
 
 /// Syscall driver number.
 use crate::driver;
@@ -89,7 +89,7 @@ impl<'a, S: SpiMasterDevice> Spi<'a, S> {
 impl<'a, S: SpiMasterDevice> Driver for Spi<'a, S> {
     fn allow(
         &self,
-        _appid: AppId,
+        _appid: ProcessId,
         allow_num: usize,
         slice: Option<AppSlice<Shared, u8>>,
     ) -> ReturnCode {
@@ -116,7 +116,7 @@ impl<'a, S: SpiMasterDevice> Driver for Spi<'a, S> {
         &self,
         subscribe_num: usize,
         callback: Option<Callback>,
-        _app_id: AppId,
+        _app_id: ProcessId,
     ) -> ReturnCode {
         match subscribe_num {
             0 /* read_write */ => {
@@ -165,7 +165,7 @@ impl<'a, S: SpiMasterDevice> Driver for Spi<'a, S> {
     // x+1: unlock spi
     //   - does nothing if lock not held
     //
-    fn command(&self, cmd_num: usize, arg1: usize, _: usize, _: AppId) -> ReturnCode {
+    fn command(&self, cmd_num: usize, arg1: usize, _: usize, _: ProcessId) -> ReturnCode {
         match cmd_num {
             0 /* check if present */ => ReturnCode::SUCCESS,
             // No longer supported, wrap inside a read_write_bytes

--- a/capsules/src/spi_peripheral.rs
+++ b/capsules/src/spi_peripheral.rs
@@ -7,7 +7,7 @@ use kernel::common::cells::{MapCell, TakeCell};
 use kernel::hil::spi::ClockPhase;
 use kernel::hil::spi::ClockPolarity;
 use kernel::hil::spi::{SpiSlaveClient, SpiSlaveDevice};
-use kernel::{AppId, AppSlice, Callback, Driver, ReturnCode, Shared};
+use kernel::{AppSlice, Callback, Driver, ProcessId, ReturnCode, Shared};
 
 /// Syscall driver number.
 use crate::driver;
@@ -87,7 +87,7 @@ impl<S: SpiSlaveDevice> Driver for SpiPeripheral<'_, S> {
     ///
     fn allow(
         &self,
-        _appid: AppId,
+        _appid: ProcessId,
         allow_num: usize,
         slice: Option<AppSlice<Shared, u8>>,
     ) -> ReturnCode {
@@ -119,7 +119,7 @@ impl<S: SpiSlaveDevice> Driver for SpiPeripheral<'_, S> {
         &self,
         subscribe_num: usize,
         callback: Option<Callback>,
-        _app_id: AppId,
+        _app_id: ProcessId,
     ) -> ReturnCode {
         match subscribe_num {
             0 /* read_write */ => {
@@ -164,7 +164,7 @@ impl<S: SpiSlaveDevice> Driver for SpiPeripheral<'_, S> {
     /// - x+1: unlock spi
     ///   - does nothing if lock not held
     ///   - not implemented or currently supported
-    fn command(&self, cmd_num: usize, arg1: usize, _: usize, _: AppId) -> ReturnCode {
+    fn command(&self, cmd_num: usize, arg1: usize, _: usize, _: ProcessId) -> ReturnCode {
         match cmd_num {
             0 /* check if present */ => ReturnCode::SUCCESS,
             1 /* read_write_bytes */ => {

--- a/capsules/src/st77xx.rs
+++ b/capsules/src/st77xx.rs
@@ -38,7 +38,7 @@ use kernel::hil::screen::{
 };
 use kernel::hil::time::{self, Alarm};
 use kernel::ReturnCode;
-use kernel::{AppId, Callback, Driver};
+use kernel::{Callback, Driver, ProcessId};
 
 pub const BUFFER_SIZE: usize = 24;
 
@@ -755,7 +755,7 @@ impl<'a, A: Alarm<'a>, B: Bus<'a>, P: Pin> ST77XX<'a, A, B, P> {
 }
 
 impl<'a, A: Alarm<'a>, B: Bus<'a>, P: Pin> Driver for ST77XX<'a, A, B, P> {
-    fn command(&self, command_num: usize, data1: usize, data2: usize, _: AppId) -> ReturnCode {
+    fn command(&self, command_num: usize, data1: usize, data2: usize, _: ProcessId) -> ReturnCode {
         match command_num {
             0 => ReturnCode::SUCCESS,
             // reset
@@ -773,7 +773,7 @@ impl<'a, A: Alarm<'a>, B: Bus<'a>, P: Pin> Driver for ST77XX<'a, A, B, P> {
         &self,
         subscribe_num: usize,
         callback: Option<Callback>,
-        _app_id: AppId,
+        _app_id: ProcessId,
     ) -> ReturnCode {
         match subscribe_num {
             0 => {

--- a/capsules/src/temperature.rs
+++ b/capsules/src/temperature.rs
@@ -55,7 +55,7 @@
 use core::cell::Cell;
 use kernel::hil;
 use kernel::ReturnCode;
-use kernel::{AppId, Callback, Driver, Grant};
+use kernel::{Callback, Driver, Grant, ProcessId};
 
 /// Syscall driver number.
 use crate::driver;
@@ -85,7 +85,7 @@ impl<'a> TemperatureSensor<'a> {
         }
     }
 
-    fn enqueue_command(&self, appid: AppId) -> ReturnCode {
+    fn enqueue_command(&self, appid: ProcessId) -> ReturnCode {
         self.apps
             .enter(appid, |app, _| {
                 if !self.busy.get() {
@@ -99,7 +99,7 @@ impl<'a> TemperatureSensor<'a> {
             .unwrap_or_else(|err| err.into())
     }
 
-    fn configure_callback(&self, callback: Option<Callback>, app_id: AppId) -> ReturnCode {
+    fn configure_callback(&self, callback: Option<Callback>, app_id: ProcessId) -> ReturnCode {
         self.apps
             .enter(app_id, |app, _| {
                 app.callback = callback;
@@ -128,7 +128,7 @@ impl Driver for TemperatureSensor<'_> {
         &self,
         subscribe_num: usize,
         callback: Option<Callback>,
-        app_id: AppId,
+        app_id: ProcessId,
     ) -> ReturnCode {
         match subscribe_num {
             // subscribe to temperature reading with callback
@@ -137,7 +137,7 @@ impl Driver for TemperatureSensor<'_> {
         }
     }
 
-    fn command(&self, command_num: usize, _: usize, _: usize, appid: AppId) -> ReturnCode {
+    fn command(&self, command_num: usize, _: usize, _: usize, appid: ProcessId) -> ReturnCode {
         match command_num {
             // check whether the driver exists!!
             0 => ReturnCode::SUCCESS,

--- a/capsules/src/touch.rs
+++ b/capsules/src/touch.rs
@@ -17,7 +17,7 @@ use kernel::hil;
 use kernel::hil::screen::ScreenRotation;
 use kernel::hil::touch::{GestureEvent, TouchEvent, TouchStatus};
 use kernel::ReturnCode;
-use kernel::{AppId, AppSlice, Callback, Driver, Grant, Shared};
+use kernel::{AppSlice, Callback, Driver, Grant, ProcessId, Shared};
 
 /// Syscall driver number.
 use crate::driver;
@@ -294,7 +294,7 @@ impl<'a> hil::touch::GestureClient for Touch<'a> {
 impl<'a> Driver for Touch<'a> {
     fn allow(
         &self,
-        appid: AppId,
+        appid: ProcessId,
         allow_num: usize,
         slice: Option<AppSlice<Shared, u8>>,
     ) -> ReturnCode {
@@ -326,7 +326,7 @@ impl<'a> Driver for Touch<'a> {
         &self,
         subscribe_num: usize,
         callback: Option<Callback>,
-        app_id: AppId,
+        app_id: ProcessId,
     ) -> ReturnCode {
         match subscribe_num {
             // subscribe to touch
@@ -369,7 +369,7 @@ impl<'a> Driver for Touch<'a> {
         command_num: usize,
         _data1: usize,
         _data2: usize,
-        _appid: AppId,
+        _appid: ProcessId,
     ) -> ReturnCode {
         match command_num {
             0 =>

--- a/capsules/src/tsl2561.rs
+++ b/capsules/src/tsl2561.rs
@@ -17,7 +17,7 @@ use core::cell::Cell;
 use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::hil::gpio;
 use kernel::hil::i2c;
-use kernel::{AppId, Callback, Driver, ReturnCode};
+use kernel::{Callback, Driver, ProcessId, ReturnCode};
 
 /// Syscall driver number.
 use crate::driver;
@@ -441,7 +441,7 @@ impl Driver for TSL2561<'_> {
         &self,
         subscribe_num: usize,
         callback: Option<Callback>,
-        _app_id: AppId,
+        _app_id: ProcessId,
     ) -> ReturnCode {
         match subscribe_num {
             // Set a callback
@@ -455,7 +455,7 @@ impl Driver for TSL2561<'_> {
         }
     }
 
-    fn command(&self, command_num: usize, _: usize, _: usize, _: AppId) -> ReturnCode {
+    fn command(&self, command_num: usize, _: usize, _: usize, _: ProcessId) -> ReturnCode {
         match command_num {
             0 /* check if present */ => ReturnCode::SUCCESS,
             // Take a measurement

--- a/capsules/src/usb/usb_user.rs
+++ b/capsules/src/usb/usb_user.rs
@@ -28,7 +28,7 @@
 
 use kernel::common::cells::OptionalCell;
 use kernel::hil;
-use kernel::{AppId, Callback, Driver, Grant, ReturnCode};
+use kernel::{Callback, Driver, Grant, ProcessId, ReturnCode};
 
 use crate::driver;
 pub const DRIVER_NUM: usize = driver::NUM::UsbUser as usize;
@@ -42,7 +42,7 @@ pub struct App {
 pub struct UsbSyscallDriver<'a, C: hil::usb::Client<'a>> {
     usbc_client: &'a C,
     apps: Grant<App>,
-    serving_app: OptionalCell<AppId>,
+    serving_app: OptionalCell<ProcessId>,
 }
 
 impl<'a, C> UsbSyscallDriver<'a, C>
@@ -108,7 +108,7 @@ where
         &self,
         subscribe_num: usize,
         callback: Option<Callback>,
-        app_id: AppId,
+        app_id: ProcessId,
     ) -> ReturnCode {
         match subscribe_num {
             // Set callback for result
@@ -123,7 +123,7 @@ where
         }
     }
 
-    fn command(&self, command_num: usize, _arg: usize, _: usize, appid: AppId) -> ReturnCode {
+    fn command(&self, command_num: usize, _arg: usize, _: usize, appid: ProcessId) -> ReturnCode {
         match command_num {
             // This driver is present
             0 => ReturnCode::SUCCESS,

--- a/kernel/src/driver.rs
+++ b/kernel/src/driver.rs
@@ -38,7 +38,7 @@
 //! While drivers do not handle the `yield` system call, it is important to
 //! understand its function and how it interacts with `subscribe`.
 
-use crate::callback::{AppId, Callback};
+use crate::callback::{Callback, ProcessId};
 use crate::mem::{AppSlice, Shared};
 use crate::returncode::ReturnCode;
 
@@ -72,7 +72,12 @@ pub trait Driver {
     /// the magnitude of the return value of can signify extra information such
     /// as error type.
     #[allow(unused_variables)]
-    fn subscribe(&self, minor_num: usize, callback: Option<Callback>, app_id: AppId) -> ReturnCode {
+    fn subscribe(
+        &self,
+        minor_num: usize,
+        callback: Option<Callback>,
+        caller_id: ProcessId,
+    ) -> ReturnCode {
         ReturnCode::ENOSUPPORT
     }
 
@@ -92,7 +97,7 @@ pub trait Driver {
     /// side effects. This convention ensures that applications can query the
     /// kernel for supported drivers on a given platform.
     #[allow(unused_variables)]
-    fn command(&self, minor_num: usize, r2: usize, r3: usize, caller_id: AppId) -> ReturnCode {
+    fn command(&self, minor_num: usize, r2: usize, r3: usize, caller_id: ProcessId) -> ReturnCode {
         ReturnCode::ENOSUPPORT
     }
 
@@ -105,7 +110,7 @@ pub trait Driver {
     #[allow(unused_variables)]
     fn allow(
         &self,
-        app: AppId,
+        caller_id: ProcessId,
         minor_num: usize,
         slice: Option<AppSlice<Shared, u8>>,
     ) -> ReturnCode {

--- a/kernel/src/introspection.rs
+++ b/kernel/src/introspection.rs
@@ -12,7 +12,7 @@
 
 use core::cell::Cell;
 
-use crate::callback::AppId;
+use crate::callback::ProcessId;
 use crate::capabilities::ProcessManagementCapability;
 use crate::common::cells::NumericCellExt;
 use crate::process;
@@ -74,7 +74,7 @@ impl KernelInfo {
     /// Get the name of the process.
     pub fn process_name(
         &self,
-        app: AppId,
+        app: ProcessId,
         _capability: &dyn ProcessManagementCapability,
     ) -> &'static str {
         self.kernel
@@ -84,7 +84,7 @@ impl KernelInfo {
     /// Returns the number of syscalls the app has called.
     pub fn number_app_syscalls(
         &self,
-        app: AppId,
+        app: ProcessId,
         _capability: &dyn ProcessManagementCapability,
     ) -> usize {
         self.kernel
@@ -96,7 +96,7 @@ impl KernelInfo {
     /// tries to schedule a callback.
     pub fn number_app_dropped_callbacks(
         &self,
-        app: AppId,
+        app: ProcessId,
         _capability: &dyn ProcessManagementCapability,
     ) -> usize {
         self.kernel
@@ -106,7 +106,7 @@ impl KernelInfo {
     /// Returns the number of time this app has been restarted.
     pub fn number_app_restarts(
         &self,
-        app: AppId,
+        app: ProcessId,
         _capability: &dyn ProcessManagementCapability,
     ) -> usize {
         self.kernel
@@ -116,7 +116,7 @@ impl KernelInfo {
     /// Returns the number of time this app has exceeded its timeslice.
     pub fn number_app_timeslice_expirations(
         &self,
-        app: AppId,
+        app: ProcessId,
         _capability: &dyn ProcessManagementCapability,
     ) -> usize {
         self.kernel
@@ -127,7 +127,7 @@ impl KernelInfo {
     /// app has allocated, total number of grants that exist in the system).
     pub fn number_app_grant_uses(
         &self,
-        app: AppId,
+        app: ProcessId,
         _capability: &dyn ProcessManagementCapability,
     ) -> (usize, usize) {
         // Just need to get the number, this has already been finalized, but it

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -110,7 +110,7 @@ mod returncode;
 mod sched;
 mod tbfheader;
 
-pub use crate::callback::{AppId, Callback};
+pub use crate::callback::{Callback, ProcessId};
 pub use crate::driver::Driver;
 pub use crate::grant::Grant;
 pub use crate::mem::{AppSlice, Private, Shared};

--- a/kernel/src/platform/mpu.rs
+++ b/kernel/src/platform/mpu.rs
@@ -1,6 +1,6 @@
 //! Interface for configuring the Memory Protection Unit.
 
-use crate::callback::AppId;
+use crate::callback::ProcessId;
 use core::cmp;
 use core::fmt::{self, Display};
 
@@ -260,9 +260,9 @@ pub trait MPU {
     /// # Arguments
     ///
     /// - `config`: MPU region configuration
-    /// - `app_id`: AppId of the process that the MPU is configured for
+    /// - `process_id`: ProcessId of the process that the MPU is configured for
     #[allow(unused_variables)]
-    fn configure_mpu(&self, config: &Self::MpuConfig, app_id: &AppId) {}
+    fn configure_mpu(&self, config: &Self::MpuConfig, process_id: &ProcessId) {}
 }
 
 /// Implement default MPU trait for unit.

--- a/kernel/src/sched/cooperative.rs
+++ b/kernel/src/sched/cooperative.rs
@@ -65,7 +65,7 @@ impl<'a, C: Chip> Scheduler<C> for CooperativeSched<'a> {
                 match node.proc {
                     Some(proc) => {
                         if proc.ready() {
-                            next = Some(proc.appid());
+                            next = Some(proc.process_id());
                             break;
                         }
                         self.processes.push_tail(self.processes.pop_head().unwrap());

--- a/kernel/src/sched/mlfq.rs
+++ b/kernel/src/sched/mlfq.rs
@@ -17,7 +17,7 @@
 //! - Rule 5: After some time period S, move all the jobs in the system to the
 //!           topmost queue.
 
-use crate::callback::AppId;
+use crate::callback::ProcessId;
 use crate::common::list::{List, ListLink, ListNode};
 use crate::hil::time;
 use crate::hil::time::Ticks;
@@ -157,7 +157,7 @@ impl<'a, A: 'static + time::Alarm<'static>, C: Chip> Scheduler<C> for MLFQSched<
             let node_ref = node_ref_opt.unwrap(); // Panic if fail bc processes_blocked()!
             let timeslice =
                 self.get_timeslice_us(queue_idx) - node_ref.state.us_used_this_queue.get();
-            let next = node_ref.proc.unwrap().appid(); // Panic if fail bc processes_blocked()!
+            let next = node_ref.proc.unwrap().process_id(); // Panic if fail bc processes_blocked()!
             self.last_queue_idx.set(queue_idx);
             self.last_timeslice.set(timeslice);
 
@@ -189,7 +189,7 @@ impl<'a, A: 'static + time::Alarm<'static>, C: Chip> Scheduler<C> for MLFQSched<
         }
     }
 
-    unsafe fn continue_process(&self, _: AppId, _: &C) -> bool {
+    unsafe fn continue_process(&self, _: ProcessId, _: &C) -> bool {
         // This MLFQ scheduler only preempts processes if there is a timeslice expiration
         true
     }

--- a/kernel/src/sched/priority.rs
+++ b/kernel/src/sched/priority.rs
@@ -10,7 +10,7 @@
 //! is running. The only way for a process to longer be the highest priority is
 //! for an interrupt to occur, which will cause the process to stop running.
 
-use crate::callback::AppId;
+use crate::callback::ProcessId;
 use crate::common::cells::OptionalCell;
 use crate::common::dynamic_deferred_call::DynamicDeferredCall;
 use crate::platform::Chip;
@@ -19,7 +19,7 @@ use crate::sched::{Kernel, Scheduler, SchedulingDecision, StoppedExecutingReason
 /// Priority scheduler based on the order of processes in the `PROCESSES` array.
 pub struct PrioritySched {
     kernel: &'static Kernel,
-    running: OptionalCell<AppId>,
+    running: OptionalCell<ProcessId>,
 }
 
 impl PrioritySched {
@@ -44,14 +44,14 @@ impl<C: Chip> Scheduler<C> for PrioritySched {
                 .kernel
                 .get_process_iter()
                 .find(|&proc| proc.ready())
-                .map_or(None, |proc| Some(proc.appid()));
+                .map_or(None, |proc| Some(proc.process_id()));
             self.running.insert(next);
 
             SchedulingDecision::RunProcess((next.unwrap(), None))
         }
     }
 
-    unsafe fn continue_process(&self, _: AppId, chip: &C) -> bool {
+    unsafe fn continue_process(&self, _: ProcessId, chip: &C) -> bool {
         // In addition to checking for interrupts, also checks if any higher
         // priority processes have become ready. This check is necessary because
         // a system call by this process could make another process ready, if

--- a/kernel/src/sched/round_robin.rs
+++ b/kernel/src/sched/round_robin.rs
@@ -76,7 +76,7 @@ impl<'a, C: Chip> Scheduler<C> for RoundRobinSched<'a> {
                 match node.proc {
                     Some(proc) => {
                         if proc.ready() {
-                            next = Some(proc.appid());
+                            next = Some(proc.process_id());
                             break;
                         }
                         self.processes.push_tail(self.processes.pop_head().unwrap());


### PR DESCRIPTION
### Pull Request Overview

The `AppId` struct changes the returned `.id()` whenever an application restarts. It thereby refers to an _application binary instance_, or _process_ instead of the _application binary_ itself. This terminology is in line with the [definitions of threat model](https://github.com/tock/tock/blob/bb8c021833355bb69bd75e8ed652e9e88dcd07eb/doc/threat_model/README.md#definitions):

> A process is a runtime instantiation of an application binary. When an application binary "restarts", its process is terminated and a new process is started using the same binary. Note that the kernel is not considered a process, although it is a thread of execution.

I personally found this confusing [in the past](https://github.com/tock/tock/issues/1914). Especially [with the introduction of a proper application id](https://groups.google.com/forum/#!topic/tock-dev/aduN7fHWXdI), the current terminology would either collide or be very confusing.

This pull request is, in its current form, for the most part a very mechanical search-and-replace to rename the `AppId` struct to `ProcessId`. In addition to that, some variables and methods in the kernel have been renamed in line with the updated terminology. Some documentation comments have been updated.

In general much more work must be put into such a change to ensure a **consistent** naming throughout the kernel, which is in line with the definition of a threat model. Variables in capsules (`appid`, `app_id`, etc.) have not been renamed at this stage - I don't know whether those would need to be renamed as part of this changeset. If this change is beneficial, I am ready to invest time into continuing to develop it.

I'm open to suggestions on better naming schemes, other ways to approach these issues or to make these changes and whether such a change is good at all.

### Testing Strategy

This pull request ~was tested by CI~ needs testing.

### TODO

- [ ] **Verify that this does not change any functionality.**
- [ ] Check whether the MPU code refers to application binaries or processes in the individual statements and carefully update variable naming.
- [ ] Resolve `TODO`s in `kernel/src/grant.rs`.
- [ ] Thoroughly go through every changed file, verify the change, manually adjusting the variable naming whether it refers to a process or application binary respectively.


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
