### PR TITLE
Removing bad comment in Alarm syscall driver as per Leon's suggestion.

### DIFF
--- a/capsules/src/alarm.rs
+++ b/capsules/src/alarm.rs
@@ -9,7 +9,6 @@ use kernel::{AppId, Callback, Driver, Grant, ReturnCode};
 use crate::driver;
 pub const DRIVER_NUM: usize = driver::NUM::Alarm as usize;
 
-// This should transition to using Ticks
 #[derive(Copy, Clone, Debug)]
 enum Expiration {
     Disabled,


### PR DESCRIPTION
### Pull Request Overview

This removes a misleading comment in the Alarm syscall driver.


### Testing Strategy




### TODO or Help Wanted




### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
