### PR TITLE
Board based instantiation of chip drivers and interrupt mappings: Stm32f3

### DIFF
--- a/boards/stm32f3discovery/src/io.rs
+++ b/boards/stm32f3discovery/src/io.rs
@@ -38,7 +38,8 @@ impl Write for Writer {
 
 impl IoWrite for Writer {
     fn write(&mut self, buf: &[u8]) {
-        let uart = unsafe { &mut stm32f303xc::usart::USART1 };
+        let rcc = stm32f303xc::rcc::Rcc::new();
+        let uart = stm32f303xc::usart::Usart::new_usart1(&rcc);
 
         if !self.initialized {
             self.initialized = true;
@@ -63,7 +64,14 @@ impl IoWrite for Writer {
 #[panic_handler]
 pub unsafe extern "C" fn panic_fmt(info: &PanicInfo) -> ! {
     // User LD3 is connected to PE09
-    let led = &mut led::LedHigh::new(PinId::PE09.get_pin_mut().as_mut().unwrap());
+    // Have to reinitialize several peripherals because otherwise can't access them here.
+    let rcc = stm32f303xc::rcc::Rcc::new();
+    let syscfg = stm32f303xc::syscfg::Syscfg::new(&rcc);
+    let exti = stm32f303xc::exti::Exti::new(&syscfg);
+    let mut pin = stm32f303xc::gpio::Pin::new(PinId::PE09, &exti);
+    let gpio_ports = stm32f303xc::gpio::GpioPorts::new(&rcc, &exti);
+    pin.set_ports_ref(&gpio_ports);
+    let led = &mut led::LedHigh::new(&mut pin);
     let writer = &mut WRITER;
 
     debug::panic(

--- a/boards/stm32f3discovery/src/main.rs
+++ b/boards/stm32f3discovery/src/main.rs
@@ -20,6 +20,7 @@ use kernel::hil::gpio::Output;
 use kernel::hil::time::Counter;
 use kernel::Platform;
 use kernel::{create_capability, debug, static_init};
+use stm32f303xc::chip::Stm32f3xxDefaultPeripherals;
 
 /// Support routines for debugging I/O.
 pub mod io;
@@ -38,7 +39,7 @@ static mut PROCESSES: [Option<&'static dyn kernel::procs::ProcessType>; NUM_PROC
     [None, None, None, None];
 
 // Static reference to chip for panic dumps.
-static mut CHIP: Option<&'static stm32f303xc::chip::Stm32f3xx> = None;
+static mut CHIP: Option<&'static stm32f303xc::chip::Stm32f3xx<Stm32f3xxDefaultPeripherals>> = None;
 
 // How should the kernel respond when a process faults.
 const FAULT_RESPONSE: kernel::procs::FaultResponse = kernel::procs::FaultResponse::Panic;
@@ -93,27 +94,32 @@ impl Platform for STM32F3Discovery {
 }
 
 /// Helper function called during bring-up that configures multiplexed I/O.
-unsafe fn set_pin_primary_functions() {
-    use stm32f303xc::exti::{LineId, EXTI};
-    use stm32f303xc::gpio::{AlternateFunction, Mode, PinId, PortId, PORT};
-    use stm32f303xc::syscfg::SYSCFG;
+unsafe fn set_pin_primary_functions(
+    syscfg: &stm32f303xc::syscfg::Syscfg,
+    exti: &stm32f303xc::exti::Exti,
+    spi1: &stm32f303xc::spi::Spi,
+    i2c1: &stm32f303xc::i2c::I2C,
+    gpio_ports: &'static stm32f303xc::gpio::GpioPorts<'static>,
+) {
+    use stm32f303xc::exti::LineId;
+    use stm32f303xc::gpio::{AlternateFunction, Mode, PinId, PortId};
 
-    SYSCFG.enable_clock();
+    syscfg.enable_clock();
 
-    PORT[PortId::A as usize].enable_clock();
-    PORT[PortId::B as usize].enable_clock();
-    PORT[PortId::C as usize].enable_clock();
-    PORT[PortId::D as usize].enable_clock();
-    PORT[PortId::E as usize].enable_clock();
-    PORT[PortId::F as usize].enable_clock();
+    gpio_ports.get_port_from_port_id(PortId::A).enable_clock();
+    gpio_ports.get_port_from_port_id(PortId::B).enable_clock();
+    gpio_ports.get_port_from_port_id(PortId::C).enable_clock();
+    gpio_ports.get_port_from_port_id(PortId::D).enable_clock();
+    gpio_ports.get_port_from_port_id(PortId::E).enable_clock();
+    gpio_ports.get_port_from_port_id(PortId::F).enable_clock();
 
-    PinId::PE14.get_pin().as_ref().map(|pin| {
+    gpio_ports.get_pin(PinId::PE14).map(|pin| {
         pin.make_output();
         pin.set();
     });
 
     // User LD3 is connected to PE09. Configure PE09 as `debug_gpio!(0, ...)`
-    PinId::PE09.get_pin().as_ref().map(|pin| {
+    gpio_ports.get_pin(PinId::PE09).map(|pin| {
         pin.make_output();
 
         // Configure kernel debug gpios as early as possible
@@ -121,43 +127,43 @@ unsafe fn set_pin_primary_functions() {
     });
 
     // pc4 and pc5 (USART1) is connected to ST-LINK virtual COM port
-    PinId::PC04.get_pin().as_ref().map(|pin| {
+    gpio_ports.get_pin(PinId::PC04).map(|pin| {
         pin.set_mode(Mode::AlternateFunctionMode);
         // AF7 is USART1_TX
         pin.set_alternate_function(AlternateFunction::AF7);
     });
-    PinId::PC05.get_pin().as_ref().map(|pin| {
+    gpio_ports.get_pin(PinId::PC05).map(|pin| {
         pin.set_mode(Mode::AlternateFunctionMode);
         // AF7 is USART1_RX
         pin.set_alternate_function(AlternateFunction::AF7);
     });
 
     // button is connected on pa00
-    PinId::PA00.get_pin().as_ref().map(|pin| {
+    gpio_ports.get_pin(PinId::PA00).map(|pin| {
         // By default, upon reset, the pin is in input mode, with no internal
         // pull-up, no internal pull-down (i.e., floating).
         //
         // Only set the mapping between EXTI line and the Pin and let capsule do
         // the rest.
-        EXTI.associate_line_gpiopin(LineId::Exti0, pin);
+        exti.associate_line_gpiopin(LineId::Exti0, &pin);
     });
     cortexm4::nvic::Nvic::new(stm32f303xc::nvic::EXTI0).enable();
 
     // SPI1 has the l3gd20 sensor connected
-    PinId::PA06.get_pin().as_ref().map(|pin| {
+    gpio_ports.get_pin(PinId::PA06).map(|pin| {
         pin.set_mode(Mode::AlternateFunctionMode);
         pin.set_floating_state(kernel::hil::gpio::FloatingState::PullNone);
         // AF5 is SPI1/SPI2
         pin.set_alternate_function(AlternateFunction::AF5);
     });
-    PinId::PA07.get_pin().as_ref().map(|pin| {
+    gpio_ports.get_pin(PinId::PA07).map(|pin| {
         pin.make_output();
         pin.set_floating_state(kernel::hil::gpio::FloatingState::PullNone);
         pin.set_mode(Mode::AlternateFunctionMode);
         // AF5 is SPI1/SPI2
         pin.set_alternate_function(AlternateFunction::AF5);
     });
-    PinId::PA05.get_pin().as_ref().map(|pin| {
+    gpio_ports.get_pin(PinId::PA05).map(|pin| {
         pin.make_output();
         pin.set_floating_state(kernel::hil::gpio::FloatingState::PullNone);
         pin.set_mode(Mode::AlternateFunctionMode);
@@ -165,22 +171,22 @@ unsafe fn set_pin_primary_functions() {
         pin.set_alternate_function(AlternateFunction::AF5);
     });
     // PE03 is the chip select pin from the l3gd20 sensor
-    PinId::PE03.get_pin().as_ref().map(|pin| {
+    gpio_ports.get_pin(PinId::PE03).map(|pin| {
         pin.make_output();
         pin.set_floating_state(kernel::hil::gpio::FloatingState::PullNone);
         pin.set();
     });
 
-    stm32f303xc::spi::SPI1.enable_clock();
+    spi1.enable_clock();
 
     // I2C1 has the LSM303DLHC sensor connected
-    PinId::PB06.get_pin().as_ref().map(|pin| {
+    gpio_ports.get_pin(PinId::PB06).map(|pin| {
         pin.set_mode(Mode::AlternateFunctionMode);
         pin.set_floating_state(kernel::hil::gpio::FloatingState::PullNone);
         // AF4 is I2C
         pin.set_alternate_function(AlternateFunction::AF4);
     });
-    PinId::PB07.get_pin().as_ref().map(|pin| {
+    gpio_ports.get_pin(PinId::PB07).map(|pin| {
         pin.make_output();
         pin.set_floating_state(kernel::hil::gpio::FloatingState::PullNone);
         pin.set_mode(Mode::AlternateFunctionMode);
@@ -189,95 +195,93 @@ unsafe fn set_pin_primary_functions() {
     });
 
     // ADC1
-    PinId::PA00.get_pin().as_ref().map(|pin| {
+    gpio_ports.get_pin(PinId::PA00).map(|pin| {
         pin.set_mode(stm32f303xc::gpio::Mode::AnalogMode);
     });
 
-    PinId::PA01.get_pin().as_ref().map(|pin| {
+    gpio_ports.get_pin(PinId::PA01).map(|pin| {
         pin.set_mode(stm32f303xc::gpio::Mode::AnalogMode);
     });
 
-    PinId::PA02.get_pin().as_ref().map(|pin| {
+    gpio_ports.get_pin(PinId::PA02).map(|pin| {
         pin.set_mode(stm32f303xc::gpio::Mode::AnalogMode);
     });
 
-    PinId::PA03.get_pin().as_ref().map(|pin| {
+    gpio_ports.get_pin(PinId::PA03).map(|pin| {
         pin.set_mode(stm32f303xc::gpio::Mode::AnalogMode);
     });
 
-    PinId::PF04.get_pin().as_ref().map(|pin| {
+    gpio_ports.get_pin(PinId::PF04).map(|pin| {
         pin.set_mode(stm32f303xc::gpio::Mode::AnalogMode);
     });
 
     // ADC2
-    PinId::PA04.get_pin().as_ref().map(|pin| {
+    gpio_ports.get_pin(PinId::PA04).map(|pin| {
         pin.set_mode(stm32f303xc::gpio::Mode::AnalogMode);
     });
 
-    PinId::PA05.get_pin().as_ref().map(|pin| {
+    gpio_ports.get_pin(PinId::PA05).map(|pin| {
         pin.set_mode(stm32f303xc::gpio::Mode::AnalogMode);
     });
 
-    PinId::PA06.get_pin().as_ref().map(|pin| {
+    gpio_ports.get_pin(PinId::PA06).map(|pin| {
         pin.set_mode(stm32f303xc::gpio::Mode::AnalogMode);
     });
 
-    PinId::PA07.get_pin().as_ref().map(|pin| {
+    gpio_ports.get_pin(PinId::PA07).map(|pin| {
         pin.set_mode(stm32f303xc::gpio::Mode::AnalogMode);
     });
 
     // ADC3
-    PinId::PB01.get_pin().as_ref().map(|pin| {
+    gpio_ports.get_pin(PinId::PB01).map(|pin| {
         pin.set_mode(stm32f303xc::gpio::Mode::AnalogMode);
     });
 
-    PinId::PE09.get_pin().as_ref().map(|pin| {
+    gpio_ports.get_pin(PinId::PE09).map(|pin| {
         pin.set_mode(stm32f303xc::gpio::Mode::AnalogMode);
     });
 
-    PinId::PE13.get_pin().as_ref().map(|pin| {
+    gpio_ports.get_pin(PinId::PE13).map(|pin| {
         pin.set_mode(stm32f303xc::gpio::Mode::AnalogMode);
     });
 
-    PinId::PB13.get_pin().as_ref().map(|pin| {
+    gpio_ports.get_pin(PinId::PB13).map(|pin| {
         pin.set_mode(stm32f303xc::gpio::Mode::AnalogMode);
     });
 
     // ADC4
-    PinId::PE14.get_pin().as_ref().map(|pin| {
+    gpio_ports.get_pin(PinId::PE14).map(|pin| {
         pin.set_mode(stm32f303xc::gpio::Mode::AnalogMode);
     });
 
-    PinId::PE15.get_pin().as_ref().map(|pin| {
+    gpio_ports.get_pin(PinId::PE15).map(|pin| {
         pin.set_mode(stm32f303xc::gpio::Mode::AnalogMode);
     });
 
-    PinId::PB12.get_pin().as_ref().map(|pin| {
+    gpio_ports.get_pin(PinId::PB12).map(|pin| {
         pin.set_mode(stm32f303xc::gpio::Mode::AnalogMode);
     });
 
-    PinId::PB14.get_pin().as_ref().map(|pin| {
+    gpio_ports.get_pin(PinId::PB14).map(|pin| {
         pin.set_mode(stm32f303xc::gpio::Mode::AnalogMode);
     });
 
-    PinId::PB15.get_pin().as_ref().map(|pin| {
+    gpio_ports.get_pin(PinId::PB15).map(|pin| {
         pin.set_mode(stm32f303xc::gpio::Mode::AnalogMode);
     });
 
-    stm32f303xc::i2c::I2C1.enable_clock();
-    stm32f303xc::i2c::I2C1.set_speed(stm32f303xc::i2c::I2CSpeed::Speed400k, 8);
+    i2c1.enable_clock();
+    i2c1.set_speed(stm32f303xc::i2c::I2CSpeed::Speed400k, 8);
 }
 
 /// Helper function for miscellaneous peripheral functions
-unsafe fn setup_peripherals() {
-    use stm32f303xc::tim2::TIM2;
-
+unsafe fn setup_peripherals(tim2: &stm32f303xc::tim2::Tim2) {
     // USART1 IRQn is 37
     cortexm4::nvic::Nvic::new(stm32f303xc::nvic::USART1).enable();
 
     // TIM2 IRQn is 28
-    TIM2.enable_clock();
-    TIM2.start();
+    tim2.enable_clock();
+    tim2.start();
     cortexm4::nvic::Nvic::new(stm32f303xc::nvic::TIM2).enable();
 }
 
@@ -293,9 +297,30 @@ pub unsafe fn reset_handler() {
 
     // We use the default HSI 8Mhz clock
 
-    set_pin_primary_functions();
+    let rcc = static_init!(stm32f303xc::rcc::Rcc, stm32f303xc::rcc::Rcc::new());
+    let syscfg = static_init!(
+        stm32f303xc::syscfg::Syscfg,
+        stm32f303xc::syscfg::Syscfg::new(rcc)
+    );
+    let exti = static_init!(
+        stm32f303xc::exti::Exti,
+        stm32f303xc::exti::Exti::new(syscfg)
+    );
 
-    setup_peripherals();
+    let peripherals = static_init!(
+        Stm32f3xxDefaultPeripherals,
+        Stm32f3xxDefaultPeripherals::new(rcc, exti)
+    );
+    set_pin_primary_functions(
+        syscfg,
+        &peripherals.exti,
+        &peripherals.spi1,
+        &peripherals.i2c1,
+        &peripherals.gpio_ports,
+    );
+
+    setup_peripherals(&peripherals.tim2);
+    peripherals.setup_circular_deps();
 
     let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
     let dynamic_deferred_call_clients =
@@ -307,17 +332,17 @@ pub unsafe fn reset_handler() {
     DynamicDeferredCall::set_global_instance(dynamic_deferred_caller);
 
     let chip = static_init!(
-        stm32f303xc::chip::Stm32f3xx,
-        stm32f303xc::chip::Stm32f3xx::new()
+        stm32f303xc::chip::Stm32f3xx<Stm32f3xxDefaultPeripherals>,
+        stm32f303xc::chip::Stm32f3xx::new(peripherals, rcc)
     );
     CHIP = Some(chip);
 
     // UART
 
     // Create a shared UART channel for kernel debug.
-    stm32f303xc::usart::USART1.enable_clock();
+    peripherals.usart1.enable_clock();
     let uart_mux = components::console::UartMuxComponent::new(
-        &stm32f303xc::usart::USART1,
+        &peripherals.usart1,
         115200,
         dynamic_deferred_caller,
     )
@@ -366,35 +391,59 @@ pub unsafe fn reset_handler() {
     let led = components::led::LedsComponent::new(components::led_component_helper!(
         stm32f303xc::gpio::Pin<'static>,
         (
-            stm32f303xc::gpio::PinId::PE09.get_pin().as_ref().unwrap(),
+            &peripherals
+                .gpio_ports
+                .get_pin(stm32f303xc::gpio::PinId::PE09)
+                .unwrap(),
             kernel::hil::gpio::ActivationMode::ActiveHigh
         ),
         (
-            stm32f303xc::gpio::PinId::PE08.get_pin().as_ref().unwrap(),
+            &peripherals
+                .gpio_ports
+                .get_pin(stm32f303xc::gpio::PinId::PE08)
+                .unwrap(),
             kernel::hil::gpio::ActivationMode::ActiveHigh
         ),
         (
-            stm32f303xc::gpio::PinId::PE10.get_pin().as_ref().unwrap(),
+            &peripherals
+                .gpio_ports
+                .get_pin(stm32f303xc::gpio::PinId::PE10)
+                .unwrap(),
             kernel::hil::gpio::ActivationMode::ActiveHigh
         ),
         (
-            stm32f303xc::gpio::PinId::PE15.get_pin().as_ref().unwrap(),
+            &peripherals
+                .gpio_ports
+                .get_pin(stm32f303xc::gpio::PinId::PE15)
+                .unwrap(),
             kernel::hil::gpio::ActivationMode::ActiveHigh
         ),
         (
-            stm32f303xc::gpio::PinId::PE11.get_pin().as_ref().unwrap(),
+            &peripherals
+                .gpio_ports
+                .get_pin(stm32f303xc::gpio::PinId::PE11)
+                .unwrap(),
             kernel::hil::gpio::ActivationMode::ActiveHigh
         ),
         (
-            stm32f303xc::gpio::PinId::PE14.get_pin().as_ref().unwrap(),
+            &peripherals
+                .gpio_ports
+                .get_pin(stm32f303xc::gpio::PinId::PE14)
+                .unwrap(),
             kernel::hil::gpio::ActivationMode::ActiveHigh
         ),
         (
-            stm32f303xc::gpio::PinId::PE12.get_pin().as_ref().unwrap(),
+            &peripherals
+                .gpio_ports
+                .get_pin(stm32f303xc::gpio::PinId::PE12)
+                .unwrap(),
             kernel::hil::gpio::ActivationMode::ActiveHigh
         ),
         (
-            stm32f303xc::gpio::PinId::PE13.get_pin().as_ref().unwrap(),
+            &peripherals
+                .gpio_ports
+                .get_pin(stm32f303xc::gpio::PinId::PE13)
+                .unwrap(),
             kernel::hil::gpio::ActivationMode::ActiveHigh
         )
     ))
@@ -408,7 +457,10 @@ pub unsafe fn reset_handler() {
         components::button_component_helper!(
             stm32f303xc::gpio::Pin<'static>,
             (
-                stm32f303xc::gpio::PinId::PA00.get_pin().as_ref().unwrap(),
+                &peripherals
+                    .gpio_ports
+                    .get_pin(stm32f303xc::gpio::PinId::PA00)
+                    .unwrap(),
                 kernel::hil::gpio::ActivationMode::ActiveHigh,
                 kernel::hil::gpio::FloatingState::PullNone
             )
@@ -420,7 +472,7 @@ pub unsafe fn reset_handler() {
 
     // ALARM
 
-    let tim2 = &stm32f303xc::tim2::TIM2;
+    let tim2 = &peripherals.tim2;
     let mux_alarm = components::alarm::AlarmMuxComponent::new(tim2).finalize(
         components::alarm_mux_component_helper!(stm32f303xc::tim2::Tim2),
     );
@@ -428,102 +480,103 @@ pub unsafe fn reset_handler() {
     let alarm = components::alarm::AlarmDriverComponent::new(board_kernel, mux_alarm)
         .finalize(components::alarm_component_helper!(stm32f303xc::tim2::Tim2));
 
+    let gpio_ports = &peripherals.gpio_ports;
     // GPIO
     let gpio = GpioComponent::new(
         board_kernel,
         components::gpio_component_helper!(
             stm32f303xc::gpio::Pin<'static>,
             // Left outer connector
-            0 => stm32f303xc::gpio::PinId::PC01.get_pin().as_ref().unwrap(),
-            1 => stm32f303xc::gpio::PinId::PC03.get_pin().as_ref().unwrap(),
-            // 2 => stm32f303xc::gpio::PinId::PA01.get_pin().as_ref().unwrap(),
-            // 3 => stm32f303xc::gpio::PinId::PA03.get_pin().as_ref().unwrap(),
-            // 4 => stm32f303xc::gpio::PinId::PF04.get_pin().as_ref().unwrap(),
-            // 5 => stm32f303xc::gpio::PinId::PA05.get_pin().as_ref().unwrap(),
-            // 6 => stm32f303xc::gpio::PinId::PA07.get_pin().as_ref().unwrap(),
-            // 7 => stm32f303xc::gpio::PinId::PC05.get_pin().as_ref().unwrap(),
-            // 8 => stm32f303xc::gpio::PinId::PB01.get_pin().as_ref().unwrap(),
-            9 => stm32f303xc::gpio::PinId::PE07.get_pin().as_ref().unwrap(),
-            // 10 => stm32f303xc::gpio::PinId::PE09.get_pin().as_ref().unwrap(),
-            11 => stm32f303xc::gpio::PinId::PE11.get_pin().as_ref().unwrap(),
-            // 12 => stm32f303xc::gpio::PinId::PE13.get_pin().as_ref().unwrap(),
-            // 13 => stm32f303xc::gpio::PinId::PE15.get_pin().as_ref().unwrap(),
-            14 => stm32f303xc::gpio::PinId::PB11.get_pin().as_ref().unwrap(),
-            // 15 => stm32f303xc::gpio::PinId::PB13.get_pin().as_ref().unwrap(),
-            // 16 => stm32f303xc::gpio::PinId::PB15.get_pin().as_ref().unwrap(),
-            17 => stm32f303xc::gpio::PinId::PD09.get_pin().as_ref().unwrap(),
-            18 => stm32f303xc::gpio::PinId::PD11.get_pin().as_ref().unwrap(),
-            19 => stm32f303xc::gpio::PinId::PD13.get_pin().as_ref().unwrap(),
-            20 => stm32f303xc::gpio::PinId::PD15.get_pin().as_ref().unwrap(),
-            21 => stm32f303xc::gpio::PinId::PC06.get_pin().as_ref().unwrap(),
+            0 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PC01).unwrap(),
+            1 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PC03).unwrap(),
+            // 2 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PA01).unwrap(),
+            // 3 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PA03).unwrap(),
+            // 4 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PF04).unwrap(),
+            // 5 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PA05).unwrap(),
+            // 6 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PA07).unwrap(),
+            // 7 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PC05).unwrap(),
+            // 8 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PB01).unwrap(),
+            9 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PE07).unwrap(),
+            // 10 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PE09).unwrap(),
+            11 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PE11).unwrap(),
+            // 12 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PE13).unwrap(),
+            // 13 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PE15).unwrap(),
+            14 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PB11).unwrap(),
+            // 15 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PB13).unwrap(),
+            // 16 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PB15).unwrap(),
+            17 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PD09).unwrap(),
+            18 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PD11).unwrap(),
+            19 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PD13).unwrap(),
+            20 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PD15).unwrap(),
+            21 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PC06).unwrap(),
             // Left inner connector
-            22 => stm32f303xc::gpio::PinId::PC00.get_pin().as_ref().unwrap(),
-            23 => stm32f303xc::gpio::PinId::PC02.get_pin().as_ref().unwrap(),
-            24 => stm32f303xc::gpio::PinId::PF02.get_pin().as_ref().unwrap(),
-            // 25 => stm32f303xc::gpio::PinId::PA00.get_pin().as_ref().unwrap(),
-            // 26 => stm32f303xc::gpio::PinId::PA02.get_pin().as_ref().unwrap(),
-            // 27 => stm32f303xc::gpio::PinId::PA04.get_pin().as_ref().unwrap(),
-            // 28 => stm32f303xc::gpio::PinId::PA06.get_pin().as_ref().unwrap(),
-            // 29 => stm32f303xc::gpio::PinId::PC04.get_pin().as_ref().unwrap(),
-            30 => stm32f303xc::gpio::PinId::PB00.get_pin().as_ref().unwrap(),
-            31 => stm32f303xc::gpio::PinId::PB02.get_pin().as_ref().unwrap(),
-            32 => stm32f303xc::gpio::PinId::PE08.get_pin().as_ref().unwrap(),
-            33 => stm32f303xc::gpio::PinId::PE10.get_pin().as_ref().unwrap(),
-            34 => stm32f303xc::gpio::PinId::PE12.get_pin().as_ref().unwrap(),
-            // 35 => stm32f303xc::gpio::PinId::PE14.get_pin().as_ref().unwrap(),
-            36 => stm32f303xc::gpio::PinId::PB10.get_pin().as_ref().unwrap(),
-            // 37 => stm32f303xc::gpio::PinId::PB12.get_pin().as_ref().unwrap(),
-            // 38 => stm32f303xc::gpio::PinId::PB14.get_pin().as_ref().unwrap(),
-            39 => stm32f303xc::gpio::PinId::PD08.get_pin().as_ref().unwrap(),
-            40 => stm32f303xc::gpio::PinId::PD10.get_pin().as_ref().unwrap(),
-            41 => stm32f303xc::gpio::PinId::PD12.get_pin().as_ref().unwrap(),
-            42 => stm32f303xc::gpio::PinId::PD14.get_pin().as_ref().unwrap(),
-            43 => stm32f303xc::gpio::PinId::PC07.get_pin().as_ref().unwrap(),
+            22 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PC00).unwrap(),
+            23 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PC02).unwrap(),
+            24 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PF02).unwrap(),
+            // 25 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PA00).unwrap(),
+            // 26 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PA02).unwrap(),
+            // 27 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PA04).unwrap(),
+            // 28 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PA06).unwrap(),
+            // 29 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PC04).unwrap(),
+            30 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PB00).unwrap(),
+            31 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PB02).unwrap(),
+            32 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PE08).unwrap(),
+            33 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PE10).unwrap(),
+            34 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PE12).unwrap(),
+            // 35 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PE14).unwrap(),
+            36 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PB10).unwrap(),
+            // 37 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PB12).unwrap(),
+            // 38 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PB14).unwrap(),
+            39 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PD08).unwrap(),
+            40 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PD10).unwrap(),
+            41 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PD12).unwrap(),
+            42 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PD14).unwrap(),
+            43 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PC07).unwrap(),
             // Right inner connector
-            44 => stm32f303xc::gpio::PinId::PF09.get_pin().as_ref().unwrap(),
-            45 => stm32f303xc::gpio::PinId::PF00.get_pin().as_ref().unwrap(),
-            46 => stm32f303xc::gpio::PinId::PC14.get_pin().as_ref().unwrap(),
-            47 => stm32f303xc::gpio::PinId::PE06.get_pin().as_ref().unwrap(),
-            48 => stm32f303xc::gpio::PinId::PE04.get_pin().as_ref().unwrap(),
-            49 => stm32f303xc::gpio::PinId::PE02.get_pin().as_ref().unwrap(),
-            50 => stm32f303xc::gpio::PinId::PE00.get_pin().as_ref().unwrap(),
-            51 => stm32f303xc::gpio::PinId::PB08.get_pin().as_ref().unwrap(),
-            // 52 => stm32f303xc::gpio::PinId::PB06.get_pin().as_ref().unwrap(),
-            53 => stm32f303xc::gpio::PinId::PB04.get_pin().as_ref().unwrap(),
-            54 => stm32f303xc::gpio::PinId::PD07.get_pin().as_ref().unwrap(),
-            55 => stm32f303xc::gpio::PinId::PD05.get_pin().as_ref().unwrap(),
-            56 => stm32f303xc::gpio::PinId::PD03.get_pin().as_ref().unwrap(),
-            57 => stm32f303xc::gpio::PinId::PD01.get_pin().as_ref().unwrap(),
-            58 => stm32f303xc::gpio::PinId::PC12.get_pin().as_ref().unwrap(),
-            59 => stm32f303xc::gpio::PinId::PC10.get_pin().as_ref().unwrap(),
-            60 => stm32f303xc::gpio::PinId::PA14.get_pin().as_ref().unwrap(),
-            61 => stm32f303xc::gpio::PinId::PF06.get_pin().as_ref().unwrap(),
-            62 => stm32f303xc::gpio::PinId::PA12.get_pin().as_ref().unwrap(),
-            63 => stm32f303xc::gpio::PinId::PA10.get_pin().as_ref().unwrap(),
-            64 => stm32f303xc::gpio::PinId::PA08.get_pin().as_ref().unwrap(),
-            65 => stm32f303xc::gpio::PinId::PC08.get_pin().as_ref().unwrap(),
+            44 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PF09).unwrap(),
+            45 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PF00).unwrap(),
+            46 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PC14).unwrap(),
+            47 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PE06).unwrap(),
+            48 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PE04).unwrap(),
+            49 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PE02).unwrap(),
+            50 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PE00).unwrap(),
+            51 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PB08).unwrap(),
+            // 52 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PB06).unwrap(),
+            53 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PB04).unwrap(),
+            54 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PD07).unwrap(),
+            55 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PD05).unwrap(),
+            56 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PD03).unwrap(),
+            57 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PD01).unwrap(),
+            58 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PC12).unwrap(),
+            59 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PC10).unwrap(),
+            60 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PA14).unwrap(),
+            61 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PF06).unwrap(),
+            62 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PA12).unwrap(),
+            63 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PA10).unwrap(),
+            64 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PA08).unwrap(),
+            65 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PC08).unwrap(),
             // Right outer connector
-            66 => stm32f303xc::gpio::PinId::PF10.get_pin().as_ref().unwrap(),
-            67 => stm32f303xc::gpio::PinId::PF01.get_pin().as_ref().unwrap(),
-            68 => stm32f303xc::gpio::PinId::PC15.get_pin().as_ref().unwrap(),
-            69 => stm32f303xc::gpio::PinId::PC13.get_pin().as_ref().unwrap(),
-            70 => stm32f303xc::gpio::PinId::PE05.get_pin().as_ref().unwrap(),
-            71 => stm32f303xc::gpio::PinId::PE03.get_pin().as_ref().unwrap(),
-            72 => stm32f303xc::gpio::PinId::PE01.get_pin().as_ref().unwrap(),
-            73 => stm32f303xc::gpio::PinId::PB09.get_pin().as_ref().unwrap(),
-            // 74 => stm32f303xc::gpio::PinId::PB07.get_pin().as_ref().unwrap(),
-            75 => stm32f303xc::gpio::PinId::PB05.get_pin().as_ref().unwrap(),
-            76 => stm32f303xc::gpio::PinId::PB03.get_pin().as_ref().unwrap(),
-            77 => stm32f303xc::gpio::PinId::PD06.get_pin().as_ref().unwrap(),
-            78 => stm32f303xc::gpio::PinId::PD04.get_pin().as_ref().unwrap(),
-            79 => stm32f303xc::gpio::PinId::PD02.get_pin().as_ref().unwrap(),
-            80 => stm32f303xc::gpio::PinId::PD00.get_pin().as_ref().unwrap(),
-            81 => stm32f303xc::gpio::PinId::PC11.get_pin().as_ref().unwrap(),
-            82 => stm32f303xc::gpio::PinId::PA15.get_pin().as_ref().unwrap(),
-            83 => stm32f303xc::gpio::PinId::PA13.get_pin().as_ref().unwrap(),
-            84 => stm32f303xc::gpio::PinId::PA11.get_pin().as_ref().unwrap(),
-            85 => stm32f303xc::gpio::PinId::PA09.get_pin().as_ref().unwrap(),
-            86 => stm32f303xc::gpio::PinId::PC09.get_pin().as_ref().unwrap()
+            66 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PF10).unwrap(),
+            67 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PF01).unwrap(),
+            68 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PC15).unwrap(),
+            69 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PC13).unwrap(),
+            70 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PE05).unwrap(),
+            71 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PE03).unwrap(),
+            72 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PE01).unwrap(),
+            73 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PB09).unwrap(),
+            // 74 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PB07).unwrap(),
+            75 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PB05).unwrap(),
+            76 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PB03).unwrap(),
+            77 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PD06).unwrap(),
+            78 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PD04).unwrap(),
+            79 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PD02).unwrap(),
+            80 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PD00).unwrap(),
+            81 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PC11).unwrap(),
+            82 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PA15).unwrap(),
+            83 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PA13).unwrap(),
+            84 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PA11).unwrap(),
+            85 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PA09).unwrap(),
+            86 => &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PC09).unwrap()
         ),
     )
     .finalize(components::gpio_component_buf!(
@@ -531,7 +584,7 @@ pub unsafe fn reset_handler() {
     ));
 
     // L3GD20 sensor
-    let spi_mux = components::spi::SpiMuxComponent::new(&stm32f303xc::spi::SPI1)
+    let spi_mux = components::spi::SpiMuxComponent::new(&peripherals.spi1)
         .finalize(components::spi_mux_component_helper!(stm32f303xc::spi::Spi));
 
     let l3gd20 = components::l3gd20::L3gd20SpiComponent::new().finalize(
@@ -539,7 +592,7 @@ pub unsafe fn reset_handler() {
             // spi type
             stm32f303xc::spi::Spi,
             // chip select
-            stm32f303xc::gpio::PinId::PE03,
+            &gpio_ports.get_pin(stm32f303xc::gpio::PinId::PE03).unwrap(),
             // spi mux
             spi_mux
         ),
@@ -559,12 +612,9 @@ pub unsafe fn reset_handler() {
 
     // LSM303DLHC
 
-    let mux_i2c = components::i2c::I2CMuxComponent::new(
-        &stm32f303xc::i2c::I2C1,
-        None,
-        dynamic_deferred_caller,
-    )
-    .finalize(components::i2c_mux_component_helper!());
+    let mux_i2c =
+        components::i2c::I2CMuxComponent::new(&peripherals.i2c1, None, dynamic_deferred_caller)
+            .finalize(components::i2c_mux_component_helper!());
 
     let lsm303dlhc = components::lsm303dlhc::Lsm303dlhcI2CComponent::new()
         .finalize(components::lsm303dlhc_i2c_component_helper!(mux_i2c));
@@ -582,7 +632,7 @@ pub unsafe fn reset_handler() {
     let ninedof = components::ninedof::NineDofComponent::new(board_kernel)
         .finalize(components::ninedof_component_helper!(l3gd20, lsm303dlhc));
 
-    let adc_mux = components::adc::AdcMuxComponent::new(&stm32f303xc::adc::ADC1)
+    let adc_mux = components::adc::AdcMuxComponent::new(&peripherals.adc1)
         .finalize(components::adc_mux_component_helper!(stm32f303xc::adc::Adc));
 
     // Uncomment this if you want to use ADC MCU temp sensor
@@ -649,7 +699,7 @@ pub unsafe fn reset_handler() {
 
     let nonvolatile_storage = components::nonvolatile_storage::NonvolatileStorageComponent::new(
         board_kernel,
-        &stm32f303xc::flash::FLASH,
+        &peripherals.flash,
         0x08038000, // Start address for userspace accesible region
         0x8000,     // Length of userspace accesible region (16 pages)
         &_sstorage as *const u8 as usize,

--- a/chips/stm32f303xc/src/chip.rs
+++ b/chips/stm32f303xc/src/chip.rs
@@ -4,32 +4,99 @@ use core::fmt::Write;
 use cortexm4;
 use kernel::common::deferred_call;
 use kernel::Chip;
+use kernel::InterruptService;
 
-use crate::adc;
 use crate::deferred_call_tasks::DeferredCallTask;
-use crate::exti;
-use crate::flash;
-use crate::i2c;
 use crate::nvic;
-use crate::spi;
-use crate::tim2;
-use crate::usart;
 use crate::wdt;
 
-pub struct Stm32f3xx {
+pub struct Stm32f3xx<'a, I: InterruptService<DeferredCallTask> + 'a> {
     mpu: cortexm4::mpu::MPU,
     userspace_kernel_boundary: cortexm4::syscall::SysCall,
     scheduler_timer: cortexm4::systick::SysTick,
-    watchdog: wdt::WindoWdg,
+    watchdog: wdt::WindoWdg<'a>,
+    interrupt_service: &'a I,
 }
 
-impl Stm32f3xx {
-    pub unsafe fn new() -> Stm32f3xx {
-        Stm32f3xx {
+pub struct Stm32f3xxDefaultPeripherals<'a> {
+    pub adc1: crate::adc::Adc<'a>,
+    pub dma: crate::dma::Dma1<'a>,
+    pub exti: &'a crate::exti::Exti<'a>,
+    pub flash: crate::flash::Flash,
+    pub i2c1: crate::i2c::I2C<'a>,
+    pub spi1: crate::spi::Spi<'a>,
+    pub tim2: crate::tim2::Tim2<'a>,
+    pub usart1: crate::usart::Usart<'a>,
+    pub usart2: crate::usart::Usart<'a>,
+    pub usart3: crate::usart::Usart<'a>,
+    pub gpio_ports: crate::gpio::GpioPorts<'a>,
+}
+
+impl<'a> Stm32f3xxDefaultPeripherals<'a> {
+    pub fn new(rcc: &'a crate::rcc::Rcc, exti: &'a crate::exti::Exti<'a>) -> Self {
+        Self {
+            adc1: crate::adc::Adc::new(rcc),
+            dma: crate::dma::Dma1::new(rcc),
+            exti,
+            flash: crate::flash::Flash::new(),
+            i2c1: crate::i2c::I2C::new_i2c1(rcc),
+            spi1: crate::spi::Spi::new_spi1(rcc),
+            tim2: crate::tim2::Tim2::new(rcc),
+            usart1: crate::usart::Usart::new_usart1(rcc),
+            usart2: crate::usart::Usart::new_usart2(rcc),
+            usart3: crate::usart::Usart::new_usart3(rcc),
+            gpio_ports: crate::gpio::GpioPorts::new(rcc, exti),
+        }
+    }
+
+    pub fn setup_circular_deps(&'a self) {
+        self.gpio_ports.setup_circular_deps();
+    }
+}
+
+impl<'a> InterruptService<DeferredCallTask> for Stm32f3xxDefaultPeripherals<'a> {
+    unsafe fn service_interrupt(&self, interrupt: u32) -> bool {
+        match interrupt {
+            nvic::USART1 => self.usart1.handle_interrupt(),
+
+            nvic::TIM2 => self.tim2.handle_interrupt(),
+
+            nvic::SPI1 => self.spi1.handle_interrupt(),
+
+            nvic::FLASH => self.flash.handle_interrupt(),
+
+            nvic::I2C1_EV => self.i2c1.handle_event(),
+            nvic::I2C1_ER => self.i2c1.handle_error(),
+            nvic::ADC1_2 => self.adc1.handle_interrupt(),
+
+            nvic::EXTI0 => self.exti.handle_interrupt(),
+            nvic::EXTI1 => self.exti.handle_interrupt(),
+            nvic::EXTI2 => self.exti.handle_interrupt(),
+            nvic::EXTI3 => self.exti.handle_interrupt(),
+            nvic::EXTI4 => self.exti.handle_interrupt(),
+            nvic::EXTI9_5 => self.exti.handle_interrupt(),
+            nvic::EXTI15_10 => self.exti.handle_interrupt(),
+            _ => return false,
+        }
+        true
+    }
+
+    unsafe fn service_deferred_call(&self, task: DeferredCallTask) -> bool {
+        match task {
+            DeferredCallTask::Flash => self.flash.handle_interrupt(),
+        }
+        true
+    }
+}
+
+impl<'a, I: InterruptService<DeferredCallTask> + 'a> Stm32f3xx<'a, I> {
+    pub unsafe fn new(interrupt_service: &'a I, rcc: &'a crate::rcc::Rcc) -> Self {
+        Self {
             mpu: cortexm4::mpu::MPU::new(),
             userspace_kernel_boundary: cortexm4::syscall::SysCall::new(),
             scheduler_timer: cortexm4::systick::SysTick::new(),
-            watchdog: wdt::WindoWdg::new(),
+            watchdog: wdt::WindoWdg::new(rcc),
+            interrupt_service,
         }
     }
 
@@ -38,46 +105,23 @@ impl Stm32f3xx {
     }
 }
 
-impl Chip for Stm32f3xx {
+impl<'a, I: InterruptService<DeferredCallTask> + 'a> Chip for Stm32f3xx<'a, I> {
     type MPU = cortexm4::mpu::MPU;
     type UserspaceKernelBoundary = cortexm4::syscall::SysCall;
     type SchedulerTimer = cortexm4::systick::SysTick;
-    type WatchDog = wdt::WindoWdg;
+    type WatchDog = wdt::WindoWdg<'a>;
 
     fn service_pending_interrupts(&self) {
         unsafe {
             loop {
                 if let Some(task) = deferred_call::DeferredCall::next_pending() {
-                    match task {
-                        DeferredCallTask::Flash => flash::FLASH.handle_interrupt(),
+                    if !self.interrupt_service.service_deferred_call(task) {
+                        panic!("unhandled deferred call");
                     }
                 } else if let Some(interrupt) = cortexm4::nvic::next_pending() {
-                    match interrupt {
-                        nvic::USART1 => usart::USART1.handle_interrupt(),
-
-                        nvic::TIM2 => tim2::TIM2.handle_interrupt(),
-
-                        nvic::SPI1 => spi::SPI1.handle_interrupt(),
-
-                        nvic::FLASH => flash::FLASH.handle_interrupt(),
-
-                        nvic::I2C1_EV => i2c::I2C1.handle_event(),
-                        nvic::I2C1_ER => i2c::I2C1.handle_error(),
-                        nvic::ADC1_2 => adc::ADC1.handle_interrupt(),
-
-                        nvic::EXTI0 => exti::EXTI.handle_interrupt(),
-                        nvic::EXTI1 => exti::EXTI.handle_interrupt(),
-                        nvic::EXTI2 => exti::EXTI.handle_interrupt(),
-                        nvic::EXTI3 => exti::EXTI.handle_interrupt(),
-                        nvic::EXTI4 => exti::EXTI.handle_interrupt(),
-                        nvic::EXTI9_5 => exti::EXTI.handle_interrupt(),
-                        nvic::EXTI15_10 => exti::EXTI.handle_interrupt(),
-
-                        _ => {
-                            panic!("unhandled interrupt {}", interrupt);
-                        }
+                    if !self.interrupt_service.service_interrupt(interrupt) {
+                        panic!("unhandled interrupt {}", interrupt);
                     }
-
                     let n = cortexm4::nvic::Nvic::new(interrupt);
                     n.clear_pending();
                     n.enable();

--- a/chips/stm32f303xc/src/dma.rs
+++ b/chips/stm32f303xc/src/dma.rs
@@ -291,7 +291,9 @@ enum Size {
     Word = 0b10,
 }
 
+#[allow(unused)]
 struct Msize(Size);
+#[allow(unused)]
 struct Psize(Size);
 
 /// List of peripherals managed by DMA1
@@ -303,18 +305,19 @@ pub enum Dma1Peripheral {
     USART1_RX,
 }
 
-pub struct Dma1 {
-    registers: StaticRef<Dma1Registers>,
-    clock: Dma1Clock,
+pub struct Dma1<'a> {
+    _registers: StaticRef<Dma1Registers>,
+    clock: Dma1Clock<'a>,
 }
 
-pub static mut DMA1: Dma1 = Dma1::new();
-
-impl Dma1 {
-    const fn new() -> Dma1 {
-        Dma1 {
-            registers: DMA1_BASE,
-            clock: Dma1Clock(rcc::PeripheralClock::AHB(rcc::HCLK::DMA1)),
+impl<'a> Dma1<'a> {
+    pub const fn new(rcc: &'a rcc::Rcc) -> Self {
+        Self {
+            _registers: DMA1_BASE,
+            clock: Dma1Clock(rcc::PeripheralClock::new(
+                rcc::PeripheralClockType::AHB(rcc::HCLK::DMA1),
+                rcc,
+            )),
         }
     }
 
@@ -331,9 +334,9 @@ impl Dma1 {
     }
 }
 
-struct Dma1Clock(rcc::PeripheralClock);
+struct Dma1Clock<'a>(rcc::PeripheralClock<'a>);
 
-impl ClockInterface for Dma1Clock {
+impl ClockInterface for Dma1Clock<'_> {
     fn is_enabled(&self) -> bool {
         self.0.is_enabled()
     }

--- a/chips/stm32f303xc/src/exti.rs
+++ b/chips/stm32f303xc/src/exti.rs
@@ -502,17 +502,16 @@ enum_from_primitive! {
 // // `line_gpiopin_map` is used to call `handle_interrupt()` on the pin.
 pub struct Exti<'a> {
     registers: StaticRef<ExtiRegisters>,
-    clock: ExtiClock,
-    line_gpiopin_map: [OptionalCell<&'a gpio::Pin<'a>>; 16],
+    clock: ExtiClock<'a>,
+    line_gpiopin_map: [OptionalCell<&'static gpio::Pin<'static>>; 16],
+    syscfg: &'a syscfg::Syscfg<'a>,
 }
 
-pub static mut EXTI: Exti<'static> = Exti::new();
-
 impl<'a> Exti<'a> {
-    const fn new() -> Exti<'a> {
+    pub const fn new(syscfg: &'a syscfg::Syscfg<'a>) -> Exti<'a> {
         Exti {
             registers: EXTI_BASE,
-            clock: ExtiClock(),
+            clock: ExtiClock(syscfg),
             line_gpiopin_map: [
                 OptionalCell::empty(),
                 OptionalCell::empty(),
@@ -531,6 +530,7 @@ impl<'a> Exti<'a> {
                 OptionalCell::empty(),
                 OptionalCell::empty(),
             ],
+            syscfg,
         }
     }
 
@@ -546,11 +546,9 @@ impl<'a> Exti<'a> {
         self.clock.disable();
     }
 
-    pub fn associate_line_gpiopin(&self, lineid: LineId, pin: &'a gpio::Pin<'a>) {
+    pub fn associate_line_gpiopin(&self, lineid: LineId, pin: &'static gpio::Pin<'static>) {
         self.line_gpiopin_map[usize::from(lineid as u8)].set(pin);
-        unsafe {
-            syscfg::SYSCFG.configure_interrupt(pin.get_pinid());
-        }
+        self.syscfg.configure_interrupt(pin.get_pinid());
         pin.set_exti_lineid(lineid);
 
         // By default, all interrupts are masked. But, this will ensure that it
@@ -766,22 +764,18 @@ impl<'a> Exti<'a> {
 
 /// The configuration registers for Exti is in Syscfg, so we need to
 /// enable clock to Syscfg, when using Exti.
-struct ExtiClock();
+struct ExtiClock<'a>(&'a syscfg::Syscfg<'a>);
 
-impl ClockInterface for ExtiClock {
+impl ClockInterface for ExtiClock<'_> {
     fn is_enabled(&self) -> bool {
-        unsafe { syscfg::SYSCFG.is_enabled_clock() }
+        self.0.is_enabled_clock()
     }
 
     fn enable(&self) {
-        unsafe {
-            syscfg::SYSCFG.enable_clock();
-        }
+        self.0.enable_clock();
     }
 
     fn disable(&self) {
-        unsafe {
-            syscfg::SYSCFG.disable_clock();
-        }
+        self.0.disable_clock();
     }
 }

--- a/chips/stm32f303xc/src/flash.rs
+++ b/chips/stm32f303xc/src/flash.rs
@@ -280,8 +280,6 @@ pub enum FlashState {
     EraseOption, // Option bytes erase procedure.
 }
 
-pub static mut FLASH: Flash = Flash::new();
-
 pub struct Flash {
     registers: StaticRef<FlashRegisters>,
     client: OptionalCell<&'static dyn hil::flash::Client<Flash>>,

--- a/chips/stm32f303xc/src/lib.rs
+++ b/chips/stm32f303xc/src/lib.rs
@@ -13,6 +13,7 @@ pub mod nvic;
 
 // Peripherals
 pub mod adc;
+pub mod dma;
 pub mod exti;
 pub mod flash;
 pub mod gpio;

--- a/chips/stm32f303xc/src/syscfg.rs
+++ b/chips/stm32f303xc/src/syscfg.rs
@@ -114,18 +114,19 @@ enum_from_primitive! {
     }
 }
 
-pub struct Syscfg {
+pub struct Syscfg<'a> {
     registers: StaticRef<SyscfgRegisters>,
-    clock: SyscfgClock,
+    clock: SyscfgClock<'a>,
 }
 
-pub static mut SYSCFG: Syscfg = Syscfg::new();
-
-impl Syscfg {
-    const fn new() -> Syscfg {
+impl<'a> Syscfg<'a> {
+    pub const fn new(rcc: &'a rcc::Rcc) -> Syscfg {
         Syscfg {
             registers: SYSCFG_BASE,
-            clock: SyscfgClock(rcc::PeripheralClock::APB2(rcc::PCLK2::SYSCFG)),
+            clock: SyscfgClock(rcc::PeripheralClock::new(
+                rcc::PeripheralClockType::APB2(rcc::PCLK2::SYSCFG),
+                rcc,
+            )),
         }
     }
 
@@ -224,9 +225,9 @@ impl Syscfg {
     }
 }
 
-struct SyscfgClock(rcc::PeripheralClock);
+struct SyscfgClock<'a>(rcc::PeripheralClock<'a>);
 
-impl ClockInterface for SyscfgClock {
+impl ClockInterface for SyscfgClock<'_> {
     fn is_enabled(&self) -> bool {
         self.0.is_enabled()
     }


### PR DESCRIPTION
### Pull Request Overview

This pull request ports the stm32f3xx chip and the stm32f3discovery board to the new peripheral instantiation approach that does not rely on global variables (first proposed in #2069). 

This chip was more challenging than most of the previous ones I have switched over, because it extensively relied on shared use of global statics for GPIO Pins / Ports, the clock manager (RCC), and the interrupt controller (EXTI). As a result I had to do a semi-significant refactoring of the GPIO driver to not rely on the assumption that references to gpio pins could be created from anywhere. The GPIO driver is now closer to the design of the GPIO driver for most other chips, but the "ports" and "pins" are still stored separately so that I could minimize the total amount of code I had to change.

Bright side: This PR removes 60 uses of `unsafe` across the `stm32f3xx` and `stm32f3discovery` crates!


### Testing Strategy

This pull request was tested by compiling. But there are enough changes in this PR that hardware testing would be greatly appreciated.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] No updates are required.

### Formatting

- [x] Ran `make prepush`.
