### PR TITLE
Board based instantiation of chip drivers and interrupt mappings: Stm32f4

### DIFF
--- a/boards/nucleo_f446re/src/io.rs
+++ b/boards/nucleo_f446re/src/io.rs
@@ -40,7 +40,8 @@ impl Write for Writer {
 
 impl IoWrite for Writer {
     fn write(&mut self, buf: &[u8]) {
-        let uart = unsafe { &mut stm32f446re::usart::USART2 };
+        let rcc = stm32f446re::rcc::Rcc::new();
+        let uart = stm32f446re::usart::Usart::new_usart2(&rcc);
 
         if !self.initialized {
             self.initialized = true;
@@ -65,7 +66,15 @@ impl IoWrite for Writer {
 #[panic_handler]
 pub unsafe extern "C" fn panic_fmt(info: &PanicInfo) -> ! {
     // User LD2 is connected to PA05
-    let led = &mut led::LedHigh::new(PinId::PA05.get_pin_mut().as_mut().unwrap());
+    // Have to reinitialize several peripherals because otherwise can't access them here.
+    let rcc = stm32f446re::rcc::Rcc::new();
+    let syscfg = stm32f446re::syscfg::Syscfg::new(&rcc);
+    let exti = stm32f446re::exti::Exti::new(&syscfg);
+    let mut pin = stm32f446re::gpio::Pin::new(PinId::PA05, &exti);
+    let gpio_ports = stm32f446re::gpio::GpioPorts::new(&rcc, &exti);
+    pin.set_ports_ref(&gpio_ports);
+    let led = &mut led::LedHigh::new(&mut pin);
+
     let writer = &mut WRITER;
 
     debug::panic(

--- a/boards/stm32f412gdiscovery/src/io.rs
+++ b/boards/stm32f412gdiscovery/src/io.rs
@@ -40,7 +40,8 @@ impl Write for Writer {
 
 impl IoWrite for Writer {
     fn write(&mut self, buf: &[u8]) {
-        let uart = unsafe { &mut stm32f412g::usart::USART2 };
+        let rcc = stm32f412g::rcc::Rcc::new();
+        let uart = stm32f412g::usart::Usart::new_usart2(&rcc);
 
         if !self.initialized {
             self.initialized = true;
@@ -65,7 +66,14 @@ impl IoWrite for Writer {
 #[panic_handler]
 pub unsafe extern "C" fn panic_fmt(info: &PanicInfo) -> ! {
     // User LD2 is connected to PB07
-    let led = &mut led::LedHigh::new(PinId::PE02.get_pin_mut().as_mut().unwrap());
+    // Have to reinitialize several peripherals because otherwise can't access them here.
+    let rcc = stm32f412g::rcc::Rcc::new();
+    let syscfg = stm32f412g::syscfg::Syscfg::new(&rcc);
+    let exti = stm32f412g::exti::Exti::new(&syscfg);
+    let mut pin = stm32f412g::gpio::Pin::new(PinId::PE02, &exti);
+    let gpio_ports = stm32f412g::gpio::GpioPorts::new(&rcc, &exti);
+    pin.set_ports_ref(&gpio_ports);
+    let led = &mut led::LedHigh::new(&mut pin);
     let writer = &mut WRITER;
 
     debug::panic(

--- a/boards/stm32f412gdiscovery/src/main.rs
+++ b/boards/stm32f412gdiscovery/src/main.rs
@@ -17,7 +17,7 @@ use kernel::hil::gpio;
 use kernel::hil::screen::ScreenRotation;
 use kernel::Platform;
 use kernel::{create_capability, debug, static_init};
-use stm32f412g::fsmc::FSMC;
+use stm32f412g::interrupt_service::Stm32f412gDefaultPeripherals;
 
 /// Support routines for debugging I/O.
 pub mod io;
@@ -32,7 +32,7 @@ const NUM_PROCS: usize = 4;
 static mut PROCESSES: [Option<&'static dyn kernel::procs::ProcessType>; NUM_PROCS] =
     [None, None, None, None];
 
-static mut CHIP: Option<&'static stm32f412g::chip::Stm32f4xx> = None;
+static mut CHIP: Option<&'static stm32f412g::chip::Stm32f4xx<Stm32f412gDefaultPeripherals>> = None;
 
 // How should the kernel respond when a process faults.
 const FAULT_RESPONSE: kernel::procs::FaultResponse = kernel::procs::FaultResponse::Panic;
@@ -85,23 +85,26 @@ impl Platform for STM32F412GDiscovery {
 }
 
 /// Helper function called during bring-up that configures DMA.
-unsafe fn setup_dma() {
-    use stm32f412g::dma1::{Dma1Peripheral, DMA1};
+unsafe fn setup_dma(
+    dma: &stm32f412g::dma1::Dma1,
+    dma_streams: &'static [stm32f412g::dma1::Stream; 8],
+    usart2: &'static stm32f412g::usart::Usart,
+) {
+    use stm32f412g::dma1::Dma1Peripheral;
     use stm32f412g::usart;
-    use stm32f412g::usart::USART2;
 
-    DMA1.enable_clock();
+    dma.enable_clock();
 
-    let usart2_tx_stream = Dma1Peripheral::USART2_TX.get_stream();
-    let usart2_rx_stream = Dma1Peripheral::USART2_RX.get_stream();
+    let usart2_tx_stream = &dma_streams[Dma1Peripheral::USART2_TX.get_stream_idx()];
+    let usart2_rx_stream = &dma_streams[Dma1Peripheral::USART2_RX.get_stream_idx()];
 
-    USART2.set_dma(
+    usart2.set_dma(
         usart::TxDMA(usart2_tx_stream),
         usart::RxDMA(usart2_rx_stream),
     );
 
-    usart2_tx_stream.set_client(&USART2);
-    usart2_rx_stream.set_client(&USART2);
+    usart2_tx_stream.set_client(usart2);
+    usart2_rx_stream.set_client(usart2);
 
     usart2_tx_stream.setup(Dma1Peripheral::USART2_TX);
     usart2_rx_stream.setup(Dma1Peripheral::USART2_RX);
@@ -111,33 +114,37 @@ unsafe fn setup_dma() {
 }
 
 /// Helper function called during bring-up that configures multiplexed I/O.
-unsafe fn set_pin_primary_functions() {
+unsafe fn set_pin_primary_functions(
+    syscfg: &stm32f412g::syscfg::Syscfg,
+    exti: &stm32f412g::exti::Exti,
+    i2c1: &stm32f412g::i2c::I2C,
+    gpio_ports: &'static stm32f412g::gpio::GpioPorts<'static>,
+) {
     use kernel::hil::gpio::Configure;
-    use stm32f412g::exti::{LineId, EXTI};
-    use stm32f412g::gpio::{AlternateFunction, Mode, PinId, PortId, PORT};
-    use stm32f412g::syscfg::SYSCFG;
+    use stm32f412g::exti::LineId;
+    use stm32f412g::gpio::{AlternateFunction, Mode, PinId, PortId};
 
-    SYSCFG.enable_clock();
+    syscfg.enable_clock();
 
-    PORT[PortId::E as usize].enable_clock();
+    gpio_ports.get_port_from_port_id(PortId::E).enable_clock();
 
     // User LD3 is connected to PE02. Configure PE02 as `debug_gpio!(0, ...)`
-    PinId::PE02.get_pin().as_ref().map(|pin| {
+    gpio_ports.get_pin(PinId::PE02).map(|pin| {
         pin.make_output();
 
         // Configure kernel debug gpios as early as possible
         kernel::debug::assign_gpios(Some(pin), None, None);
     });
 
-    PORT[PortId::A as usize].enable_clock();
+    gpio_ports.get_port_from_port_id(PortId::A).enable_clock();
 
     // pa2 and pa3 (USART2) is connected to ST-LINK virtual COM port
-    PinId::PA02.get_pin().as_ref().map(|pin| {
+    gpio_ports.get_pin(PinId::PA02).map(|pin| {
         pin.set_mode(Mode::AlternateFunctionMode);
         // AF7 is USART2_TX
         pin.set_alternate_function(AlternateFunction::AF7);
     });
-    PinId::PA03.get_pin().as_ref().map(|pin| {
+    gpio_ports.get_pin(PinId::PA03).map(|pin| {
         pin.set_mode(Mode::AlternateFunctionMode);
         // AF7 is USART2_RX
         pin.set_alternate_function(AlternateFunction::AF7);
@@ -145,77 +152,77 @@ unsafe fn set_pin_primary_functions() {
 
     // uncomment this if you do not plan to use the joystick up, as they both use Exti0
     // joystick selection is connected on pa00
-    // PinId::PA00.get_pin().as_ref().map(|pin| {
+    // gpio_ports.get_pin(PinId::PA00).map(|pin| {
     //     // By default, upon reset, the pin is in input mode, with no internal
     //     // pull-up, no internal pull-down (i.e., floating).
     //     //
     //     // Only set the mapping between EXTI line and the Pin and let capsule do
     //     // the rest.
-    //     EXTI.associate_line_gpiopin(LineId::Exti0, pin);
+    //     exti.associate_line_gpiopin(LineId::Exti0, pin);
     // });
     // // EXTI0 interrupts is delivered at IRQn 6 (EXTI0)
     // cortexm4::nvic::Nvic::new(stm32f412g::nvic::EXTI0).enable();
 
     // joystick down is connected on pg01
-    PinId::PG01.get_pin().as_ref().map(|pin| {
+    gpio_ports.get_pin(PinId::PG01).map(|pin| {
         // By default, upon reset, the pin is in input mode, with no internal
         // pull-up, no internal pull-down (i.e., floating).
         //
         // Only set the mapping between EXTI line and the Pin and let capsule do
         // the rest.
-        EXTI.associate_line_gpiopin(LineId::Exti1, pin);
+        exti.associate_line_gpiopin(LineId::Exti1, pin);
     });
     // EXTI1 interrupts is delivered at IRQn 7 (EXTI1)
     cortexm4::nvic::Nvic::new(stm32f412g::nvic::EXTI1).enable();
 
     // joystick left is connected on pf15
-    PinId::PF15.get_pin().as_ref().map(|pin| {
+    gpio_ports.get_pin(PinId::PF15).map(|pin| {
         // By default, upon reset, the pin is in input mode, with no internal
         // pull-up, no internal pull-down (i.e., floating).
         //
         // Only set the mapping between EXTI line and the Pin and let capsule do
         // the rest.
-        EXTI.associate_line_gpiopin(LineId::Exti15, pin);
+        exti.associate_line_gpiopin(LineId::Exti15, pin);
     });
     // EXTI15_10 interrupts is delivered at IRQn 40 (EXTI15_10)
     cortexm4::nvic::Nvic::new(stm32f412g::nvic::EXTI15_10).enable();
 
     // joystick right is connected on pf14
-    PinId::PF14.get_pin().as_ref().map(|pin| {
+    gpio_ports.get_pin(PinId::PF14).map(|pin| {
         // By default, upon reset, the pin is in input mode, with no internal
         // pull-up, no internal pull-down (i.e., floating).
         //
         // Only set the mapping between EXTI line and the Pin and let capsule do
         // the rest.
-        EXTI.associate_line_gpiopin(LineId::Exti14, pin);
+        exti.associate_line_gpiopin(LineId::Exti14, pin);
     });
     // EXTI15_10 interrupts is delivered at IRQn 40 (EXTI15_10)
     cortexm4::nvic::Nvic::new(stm32f412g::nvic::EXTI15_10).enable();
 
     // joystick up is connected on pg00
-    PinId::PG00.get_pin().as_ref().map(|pin| {
+    gpio_ports.get_pin(PinId::PG00).map(|pin| {
         // By default, upon reset, the pin is in input mode, with no internal
         // pull-up, no internal pull-down (i.e., floating).
         //
         // Only set the mapping between EXTI line and the Pin and let capsule do
         // the rest.
-        EXTI.associate_line_gpiopin(LineId::Exti0, pin);
+        exti.associate_line_gpiopin(LineId::Exti0, pin);
     });
     // EXTI0 interrupts is delivered at IRQn 6 (EXTI0)
     cortexm4::nvic::Nvic::new(stm32f412g::nvic::EXTI0).enable();
 
     // Enable clocks for GPIO Ports
     // Disable some of them if you don't need some of the GPIOs
-    PORT[PortId::B as usize].enable_clock();
+    gpio_ports.get_port_from_port_id(PortId::B).enable_clock();
     // Ports A and E are already enabled
-    PORT[PortId::C as usize].enable_clock();
-    PORT[PortId::D as usize].enable_clock();
-    PORT[PortId::F as usize].enable_clock();
-    PORT[PortId::G as usize].enable_clock();
-    PORT[PortId::H as usize].enable_clock();
+    gpio_ports.get_port_from_port_id(PortId::C).enable_clock();
+    gpio_ports.get_port_from_port_id(PortId::D).enable_clock();
+    gpio_ports.get_port_from_port_id(PortId::F).enable_clock();
+    gpio_ports.get_port_from_port_id(PortId::G).enable_clock();
+    gpio_ports.get_port_from_port_id(PortId::H).enable_clock();
 
     // I2C1 has the TouchPanel connected
-    PinId::PB06.get_pin().as_ref().map(|pin| {
+    gpio_ports.get_pin(PinId::PB06).map(|pin| {
         // pin.make_output();
         pin.set_mode_output_opendrain();
         pin.set_mode(Mode::AlternateFunctionMode);
@@ -223,7 +230,7 @@ unsafe fn set_pin_primary_functions() {
         // AF4 is I2C
         pin.set_alternate_function(AlternateFunction::AF4);
     });
-    PinId::PB07.get_pin().as_ref().map(|pin| {
+    gpio_ports.get_pin(PinId::PB07).map(|pin| {
         // pin.make_output();
         pin.set_mode_output_opendrain();
         pin.set_floating_state(kernel::hil::gpio::FloatingState::PullNone);
@@ -232,48 +239,48 @@ unsafe fn set_pin_primary_functions() {
         pin.set_alternate_function(AlternateFunction::AF4);
     });
 
-    stm32f412g::i2c::I2C1.enable_clock();
-    stm32f412g::i2c::I2C1.set_speed(stm32f412g::i2c::I2CSpeed::Speed100k, 16);
+    i2c1.enable_clock();
+    i2c1.set_speed(stm32f412g::i2c::I2CSpeed::Speed100k, 16);
 
     // FT6206 interrupt
-    PinId::PG05.get_pin().as_ref().map(|pin| {
+    gpio_ports.get_pin(PinId::PG05).map(|pin| {
         // By default, upon reset, the pin is in input mode, with no internal
         // pull-up, no internal pull-down (i.e., floating).
         //
         // Only set the mapping between EXTI line and the Pin and let capsule do
         // the rest.
-        EXTI.associate_line_gpiopin(LineId::Exti5, pin);
+        exti.associate_line_gpiopin(LineId::Exti5, pin);
     });
 
     // ADC
 
     // Arduino A0
-    PinId::PA01.get_pin().as_ref().map(|pin| {
+    gpio_ports.get_pin(PinId::PA01).map(|pin| {
         pin.set_mode(stm32f412g::gpio::Mode::AnalogMode);
     });
 
     // Arduino A1
-    PinId::PC01.get_pin().as_ref().map(|pin| {
+    gpio_ports.get_pin(PinId::PC01).map(|pin| {
         pin.set_mode(stm32f412g::gpio::Mode::AnalogMode);
     });
 
     // Arduino A2
-    PinId::PC03.get_pin().as_ref().map(|pin| {
+    gpio_ports.get_pin(PinId::PC03).map(|pin| {
         pin.set_mode(stm32f412g::gpio::Mode::AnalogMode);
     });
 
     // Arduino A3
-    PinId::PC04.get_pin().as_ref().map(|pin| {
+    gpio_ports.get_pin(PinId::PC04).map(|pin| {
         pin.set_mode(stm32f412g::gpio::Mode::AnalogMode);
     });
 
     // Arduino A4
-    PinId::PC05.get_pin().as_ref().map(|pin| {
+    gpio_ports.get_pin(PinId::PC05).map(|pin| {
         pin.set_mode(stm32f412g::gpio::Mode::AnalogMode);
     });
 
     // Arduino A5
-    PinId::PB00.get_pin().as_ref().map(|pin| {
+    gpio_ports.get_pin(PinId::PB00).map(|pin| {
         pin.set_mode(stm32f412g::gpio::Mode::AnalogMode);
     });
 
@@ -306,7 +313,7 @@ unsafe fn set_pin_primary_functions() {
     ];
 
     for pin in pins.iter() {
-        pin.get_pin().as_ref().map(|pin| {
+        gpio_ports.get_pin(*pin).map(|pin| {
             pin.set_mode(stm32f412g::gpio::Mode::AlternateFunctionMode);
             pin.set_floating_state(gpio::FloatingState::PullUp);
             pin.set_speed();
@@ -316,31 +323,29 @@ unsafe fn set_pin_primary_functions() {
 
     use kernel::hil::gpio::Output;
 
-    PinId::PF05.get_pin().as_ref().map(|pin| {
+    gpio_ports.get_pin(PinId::PF05).map(|pin| {
         pin.make_output();
         pin.set_floating_state(gpio::FloatingState::PullNone);
         pin.set();
     });
 
-    PinId::PG04.get_pin().as_ref().map(|pin| {
+    gpio_ports.get_pin(PinId::PG04).map(|pin| {
         pin.make_input();
     });
 }
 
 /// Helper function for miscellaneous peripheral functions
-unsafe fn setup_peripherals() {
-    use stm32f412g::tim2::TIM2;
-
+unsafe fn setup_peripherals(tim2: &stm32f412g::tim2::Tim2, fsmc: &stm32f412g::fsmc::Fsmc) {
     // USART2 IRQn is 38
     cortexm4::nvic::Nvic::new(stm32f412g::nvic::USART2).enable();
 
     // TIM2 IRQn is 28
-    TIM2.enable_clock();
-    TIM2.start();
+    tim2.enable_clock();
+    tim2.start();
     cortexm4::nvic::Nvic::new(stm32f412g::nvic::TIM2).enable();
 
     // FSMC
-    FSMC.enable();
+    fsmc.enable();
 }
 
 /// Reset Handler.
@@ -353,13 +358,35 @@ unsafe fn setup_peripherals() {
 pub unsafe fn reset_handler() {
     stm32f412g::init();
 
+    let rcc = static_init!(stm32f412g::rcc::Rcc, stm32f412g::rcc::Rcc::new());
+    let syscfg = static_init!(
+        stm32f412g::syscfg::Syscfg,
+        stm32f412g::syscfg::Syscfg::new(rcc)
+    );
+    let exti = static_init!(stm32f412g::exti::Exti, stm32f412g::exti::Exti::new(syscfg));
+    let dma1 = static_init!(stm32f412g::dma1::Dma1, stm32f412g::dma1::Dma1::new(rcc));
+
+    let peripherals = static_init!(
+        Stm32f412gDefaultPeripherals,
+        Stm32f412gDefaultPeripherals::new(rcc, exti, dma1)
+    );
+    peripherals.init();
+    let base_peripherals = &peripherals.stm32f4;
+    setup_peripherals(&base_peripherals.tim2, &base_peripherals.fsmc);
+
     // We use the default HSI 16Mhz clock
+    set_pin_primary_functions(
+        syscfg,
+        &base_peripherals.exti,
+        &base_peripherals.i2c1,
+        &base_peripherals.gpio_ports,
+    );
 
-    set_pin_primary_functions();
-
-    setup_dma();
-
-    setup_peripherals();
+    setup_dma(
+        dma1,
+        &base_peripherals.dma_streams,
+        &base_peripherals.usart2,
+    );
 
     let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
 
@@ -372,17 +399,17 @@ pub unsafe fn reset_handler() {
     DynamicDeferredCall::set_global_instance(dynamic_deferred_caller);
 
     let chip = static_init!(
-        stm32f412g::chip::Stm32f4xx,
-        stm32f412g::chip::Stm32f4xx::new()
+        stm32f412g::chip::Stm32f4xx<Stm32f412gDefaultPeripherals>,
+        stm32f412g::chip::Stm32f4xx::new(peripherals)
     );
     CHIP = Some(chip);
 
     // UART
 
     // Create a shared UART channel for kernel debug.
-    stm32f412g::usart::USART2.enable_clock();
+    base_peripherals.usart2.enable_clock();
     let uart_mux = components::console::UartMuxComponent::new(
-        &stm32f412g::usart::USART2,
+        &base_peripherals.usart2,
         115200,
         dynamic_deferred_caller,
     )
@@ -429,19 +456,31 @@ pub unsafe fn reset_handler() {
     let led = components::led::LedsComponent::new(components::led_component_helper!(
         stm32f412g::gpio::Pin,
         (
-            stm32f412g::gpio::PinId::PE00.get_pin().as_ref().unwrap(),
+            base_peripherals
+                .gpio_ports
+                .get_pin(stm32f412g::gpio::PinId::PE00)
+                .unwrap(),
             kernel::hil::gpio::ActivationMode::ActiveLow
         ),
         (
-            stm32f412g::gpio::PinId::PE01.get_pin().as_ref().unwrap(),
+            base_peripherals
+                .gpio_ports
+                .get_pin(stm32f412g::gpio::PinId::PE01)
+                .unwrap(),
             kernel::hil::gpio::ActivationMode::ActiveLow
         ),
         (
-            stm32f412g::gpio::PinId::PE02.get_pin().as_ref().unwrap(),
+            base_peripherals
+                .gpio_ports
+                .get_pin(stm32f412g::gpio::PinId::PE02)
+                .unwrap(),
             kernel::hil::gpio::ActivationMode::ActiveLow
         ),
         (
-            stm32f412g::gpio::PinId::PE03.get_pin().as_ref().unwrap(),
+            base_peripherals
+                .gpio_ports
+                .get_pin(stm32f412g::gpio::PinId::PE03)
+                .unwrap(),
             kernel::hil::gpio::ActivationMode::ActiveLow
         )
     ))
@@ -454,31 +493,46 @@ pub unsafe fn reset_handler() {
             stm32f412g::gpio::Pin,
             // Select
             (
-                stm32f412g::gpio::PinId::PA00.get_pin().as_ref().unwrap(),
+                base_peripherals
+                    .gpio_ports
+                    .get_pin(stm32f412g::gpio::PinId::PA00)
+                    .unwrap(),
                 kernel::hil::gpio::ActivationMode::ActiveHigh,
                 kernel::hil::gpio::FloatingState::PullNone
             ),
             // Down
             (
-                stm32f412g::gpio::PinId::PG01.get_pin().as_ref().unwrap(),
+                base_peripherals
+                    .gpio_ports
+                    .get_pin(stm32f412g::gpio::PinId::PG01)
+                    .unwrap(),
                 kernel::hil::gpio::ActivationMode::ActiveHigh,
                 kernel::hil::gpio::FloatingState::PullNone
             ),
             // Left
             (
-                stm32f412g::gpio::PinId::PF15.get_pin().as_ref().unwrap(),
+                base_peripherals
+                    .gpio_ports
+                    .get_pin(stm32f412g::gpio::PinId::PF15)
+                    .unwrap(),
                 kernel::hil::gpio::ActivationMode::ActiveHigh,
                 kernel::hil::gpio::FloatingState::PullNone
             ),
             // Right
             (
-                stm32f412g::gpio::PinId::PF14.get_pin().as_ref().unwrap(),
+                base_peripherals
+                    .gpio_ports
+                    .get_pin(stm32f412g::gpio::PinId::PF14)
+                    .unwrap(),
                 kernel::hil::gpio::ActivationMode::ActiveHigh,
                 kernel::hil::gpio::FloatingState::PullNone
             ),
             // Up
             (
-                stm32f412g::gpio::PinId::PG00.get_pin().as_ref().unwrap(),
+                base_peripherals
+                    .gpio_ports
+                    .get_pin(stm32f412g::gpio::PinId::PG00)
+                    .unwrap(),
                 kernel::hil::gpio::ActivationMode::ActiveHigh,
                 kernel::hil::gpio::FloatingState::PullNone
             )
@@ -488,7 +542,7 @@ pub unsafe fn reset_handler() {
 
     // ALARM
 
-    let tim2 = &stm32f412g::tim2::TIM2;
+    let tim2 = &base_peripherals.tim2;
     let mux_alarm = components::alarm::AlarmMuxComponent::new(tim2).finalize(
         components::alarm_mux_component_helper!(stm32f412g::tim2::Tim2),
     );
@@ -502,30 +556,30 @@ pub unsafe fn reset_handler() {
         components::gpio_component_helper!(
             stm32f412g::gpio::Pin,
             // Arduino like RX/TX
-            0 => stm32f412g::gpio::PinId::PG09.get_pin().as_ref().unwrap(), //D0
-            1 => stm32f412g::gpio::PinId::PG14.get_pin().as_ref().unwrap(), //D1
-            2 => stm32f412g::gpio::PinId::PG13.get_pin().as_ref().unwrap(), //D2
-            3 => stm32f412g::gpio::PinId::PF04.get_pin().as_ref().unwrap(), //D3
-            4 => stm32f412g::gpio::PinId::PG12.get_pin().as_ref().unwrap(), //D4
-            5 => stm32f412g::gpio::PinId::PF10.get_pin().as_ref().unwrap(), //D5
-            6 => stm32f412g::gpio::PinId::PF03.get_pin().as_ref().unwrap(), //D6
-            7 => stm32f412g::gpio::PinId::PG11.get_pin().as_ref().unwrap(), //D7
-            8 => stm32f412g::gpio::PinId::PG10.get_pin().as_ref().unwrap(), //D8
-            9 => stm32f412g::gpio::PinId::PB08.get_pin().as_ref().unwrap(), //D9
+            0 => base_peripherals.gpio_ports.get_pin(stm32f412g::gpio::PinId::PG09).unwrap(), //D0
+            1 => base_peripherals.gpio_ports.get_pin(stm32f412g::gpio::PinId::PG14).unwrap(), //D1
+            2 => base_peripherals.gpio_ports.get_pin(stm32f412g::gpio::PinId::PG13).unwrap(), //D2
+            3 => base_peripherals.gpio_ports.get_pin(stm32f412g::gpio::PinId::PF04).unwrap(), //D3
+            4 => base_peripherals.gpio_ports.get_pin(stm32f412g::gpio::PinId::PG12).unwrap(), //D4
+            5 => base_peripherals.gpio_ports.get_pin(stm32f412g::gpio::PinId::PF10).unwrap(), //D5
+            6 => base_peripherals.gpio_ports.get_pin(stm32f412g::gpio::PinId::PF03).unwrap(), //D6
+            7 => base_peripherals.gpio_ports.get_pin(stm32f412g::gpio::PinId::PG11).unwrap(), //D7
+            8 => base_peripherals.gpio_ports.get_pin(stm32f412g::gpio::PinId::PG10).unwrap(), //D8
+            9 => base_peripherals.gpio_ports.get_pin(stm32f412g::gpio::PinId::PB08).unwrap(), //D9
             // SPI Pins
-            10 => stm32f412g::gpio::PinId::PA15.get_pin().as_ref().unwrap(), //D10
-            11 => stm32f412g::gpio::PinId::PA07.get_pin().as_ref().unwrap(),  //D11
-            12 => stm32f412g::gpio::PinId::PA06.get_pin().as_ref().unwrap(),  //D12
-            13 => stm32f412g::gpio::PinId::PA15.get_pin().as_ref().unwrap()  //D13
+            10 => base_peripherals.gpio_ports.get_pin(stm32f412g::gpio::PinId::PA15).unwrap(), //D10
+            11 => base_peripherals.gpio_ports.get_pin(stm32f412g::gpio::PinId::PA07).unwrap(),  //D11
+            12 => base_peripherals.gpio_ports.get_pin(stm32f412g::gpio::PinId::PA06).unwrap(),  //D12
+            13 => base_peripherals.gpio_ports.get_pin(stm32f412g::gpio::PinId::PA15).unwrap()  //D13
 
             // ADC Pins
             // Enable the to use the ADC pins as GPIO
-            // 14 => stm32f412g::gpio::PinId::PA01.get_pin().as_ref().unwrap(), //A0
-            // 15 => stm32f412g::gpio::PinId::PC01.get_pin().as_ref().unwrap(), //A1
-            // 16 => stm32f412g::gpio::PinId::PC03.get_pin().as_ref().unwrap(), //A2
-            // 17 => stm32f412g::gpio::PinId::PC04.get_pin().as_ref().unwrap(), //A3
-            // 19 => stm32f412g::gpio::PinId::PC05.get_pin().as_ref().unwrap(), //A4
-            // 20 => stm32f412g::gpio::PinId::PB00.get_pin().as_ref().unwrap() //A5
+            // 14 => base_peripherals.gpio_ports.get_pin(stm32f412g::gpio::PinId::PA01).unwrap(), //A0
+            // 15 => base_peripherals.gpio_ports.get_pin(stm32f412g::gpio::PinId::PC01).unwrap(), //A1
+            // 16 => base_peripherals.gpio_ports.get_pin(stm32f412g::gpio::PinId::PC03).unwrap(), //A2
+            // 17 => base_peripherals.gpio_ports.get_pin(stm32f412g::gpio::PinId::PC04).unwrap(), //A3
+            // 19 => base_peripherals.gpio_ports.get_pin(stm32f412g::gpio::PinId::PC05).unwrap(), //A4
+            // 20 => base_peripherals.gpio_ports.get_pin(stm32f412g::gpio::PinId::PB00).unwrap() //A5
         ),
     )
     .finalize(components::gpio_component_buf!(stm32f412g::gpio::Pin));
@@ -533,14 +587,17 @@ pub unsafe fn reset_handler() {
     // FT6206
 
     let mux_i2c = components::i2c::I2CMuxComponent::new(
-        &stm32f412g::i2c::I2C1,
+        &base_peripherals.i2c1,
         None,
         dynamic_deferred_caller,
     )
     .finalize(components::i2c_mux_component_helper!());
 
     let ft6x06 = components::ft6x06::Ft6x06Component::new(
-        stm32f412g::gpio::PinId::PG05.get_pin().as_ref().unwrap(),
+        base_peripherals
+            .gpio_ports
+            .get_pin(stm32f412g::gpio::PinId::PG05)
+            .unwrap(),
     )
     .finalize(components::ft6x06_i2c_component_helper!(mux_i2c));
 
@@ -549,7 +606,7 @@ pub unsafe fn reset_handler() {
             // bus type
             stm32f412g::fsmc::Fsmc,
             // bus
-            &stm32f412g::fsmc::FSMC
+            &base_peripherals.fsmc
         ),
     );
 
@@ -568,7 +625,10 @@ pub unsafe fn reset_handler() {
             // dc pin (optional)
             None,
             // reset pin
-            stm32f412g::gpio::PinId::PD11.get_pin().as_ref().unwrap()
+            base_peripherals
+                .gpio_ports
+                .get_pin(stm32f412g::gpio::PinId::PD11)
+                .unwrap()
         ),
     );
 
@@ -589,7 +649,7 @@ pub unsafe fn reset_handler() {
     //         .finalize(());
 
     // ADC
-    let adc_mux = components::adc::AdcMuxComponent::new(&stm32f412g::adc::ADC1)
+    let adc_mux = components::adc::AdcMuxComponent::new(&base_peripherals.adc1)
         .finalize(components::adc_mux_component_helper!(stm32f412g::adc::Adc));
 
     let temp_sensor = components::temperature_stm::TemperatureSTMComponent::new(2.5, 0.76)
@@ -663,8 +723,8 @@ pub unsafe fn reset_handler() {
     // //
     // // See comment in `boards/imix/src/main.rs`
     // virtual_uart_rx_test::run_virtual_uart_receive(mux_uart);
-    // FSMC.write(0x04, 120);
-    // debug!("id {}", FSMC.read(0x05));
+    // base_peripherals.fsmc.write(0x04, 120);
+    // debug!("id {}", base_peripherals.fsmc.read(0x05));
 
     debug!("Initialization complete. Entering main loop");
 

--- a/chips/stm32f412g/src/interrupt_service.rs
+++ b/chips/stm32f412g/src/interrupt_service.rs
@@ -1,0 +1,34 @@
+use stm32f4xx::chip::Stm32f4xxDefaultPeripherals;
+use stm32f4xx::deferred_calls::DeferredCallTask;
+
+pub struct Stm32f412gDefaultPeripherals<'a> {
+    pub stm32f4: Stm32f4xxDefaultPeripherals<'a>,
+    // Once implemented, place Stm32f412g specific peripherals here
+}
+
+impl<'a> Stm32f412gDefaultPeripherals<'a> {
+    pub unsafe fn new(
+        rcc: &'a crate::rcc::Rcc,
+        exti: &'a crate::exti::Exti<'a>,
+        dma: &'a crate::dma1::Dma1<'a>,
+    ) -> Self {
+        Self {
+            stm32f4: Stm32f4xxDefaultPeripherals::new(rcc, exti, dma),
+        }
+    }
+    // Necessary for setting up circular dependencies
+    pub fn init(&'a self) {
+        self.stm32f4.setup_circular_deps();
+    }
+}
+impl<'a> kernel::InterruptService<DeferredCallTask> for Stm32f412gDefaultPeripherals<'a> {
+    unsafe fn service_interrupt(&self, interrupt: u32) -> bool {
+        match interrupt {
+            // put Stm32f412g specific interrupts here
+            _ => self.stm32f4.service_interrupt(interrupt),
+        }
+    }
+    unsafe fn service_deferred_call(&self, task: DeferredCallTask) -> bool {
+        self.stm32f4.service_deferred_call(task)
+    }
+}

--- a/chips/stm32f412g/src/lib.rs
+++ b/chips/stm32f412g/src/lib.rs
@@ -6,6 +6,7 @@ pub use stm32f4xx::{
     adc, chip, dbg, dma1, exti, fsmc, gpio, i2c, nvic, rcc, spi, syscfg, tim2, usart,
 };
 
+pub mod interrupt_service;
 pub mod stm32f412g_nvic;
 
 // STM32F412g has total of 97 interrupts

--- a/chips/stm32f429zi/src/interrupt_service.rs
+++ b/chips/stm32f429zi/src/interrupt_service.rs
@@ -1,0 +1,34 @@
+use stm32f4xx::chip::Stm32f4xxDefaultPeripherals;
+use stm32f4xx::deferred_calls::DeferredCallTask;
+
+pub struct Stm32f429ziDefaultPeripherals<'a> {
+    pub stm32f4: Stm32f4xxDefaultPeripherals<'a>,
+    // Once implemented, place Stm32f429zi specific peripherals here
+}
+
+impl<'a> Stm32f429ziDefaultPeripherals<'a> {
+    pub unsafe fn new(
+        rcc: &'a crate::rcc::Rcc,
+        exti: &'a crate::exti::Exti<'a>,
+        dma: &'a crate::dma1::Dma1<'a>,
+    ) -> Self {
+        Self {
+            stm32f4: Stm32f4xxDefaultPeripherals::new(rcc, exti, dma),
+        }
+    }
+    // Necessary for setting up circular dependencies
+    pub fn init(&'a self) {
+        self.stm32f4.setup_circular_deps();
+    }
+}
+impl<'a> kernel::InterruptService<DeferredCallTask> for Stm32f429ziDefaultPeripherals<'a> {
+    unsafe fn service_interrupt(&self, interrupt: u32) -> bool {
+        match interrupt {
+            // put Stm32f429zi specific interrupts here
+            _ => self.stm32f4.service_interrupt(interrupt),
+        }
+    }
+    unsafe fn service_deferred_call(&self, task: DeferredCallTask) -> bool {
+        self.stm32f4.service_deferred_call(task)
+    }
+}

--- a/chips/stm32f429zi/src/lib.rs
+++ b/chips/stm32f429zi/src/lib.rs
@@ -4,6 +4,7 @@ use cortexm4::generic_isr;
 
 pub use stm32f4xx::{adc, chip, dbg, dma1, exti, gpio, nvic, rcc, spi, syscfg, tim2, usart};
 
+pub mod interrupt_service;
 pub mod stm32f429zi_nvic;
 
 // STM32F42xxx and STM32F43xxx has total of 91 interrupts

--- a/chips/stm32f446re/src/interrupt_service.rs
+++ b/chips/stm32f446re/src/interrupt_service.rs
@@ -1,0 +1,34 @@
+use stm32f4xx::chip::Stm32f4xxDefaultPeripherals;
+use stm32f4xx::deferred_calls::DeferredCallTask;
+
+pub struct Stm32f446reDefaultPeripherals<'a> {
+    pub stm32f4: Stm32f4xxDefaultPeripherals<'a>,
+    // Once implemented, place Stm32f446re specific peripherals here
+}
+
+impl<'a> Stm32f446reDefaultPeripherals<'a> {
+    pub unsafe fn new(
+        rcc: &'a crate::rcc::Rcc,
+        exti: &'a crate::exti::Exti<'a>,
+        dma: &'a crate::dma1::Dma1<'a>,
+    ) -> Self {
+        Self {
+            stm32f4: Stm32f4xxDefaultPeripherals::new(rcc, exti, dma),
+        }
+    }
+    // Necessary for setting up circular dependencies
+    pub fn init(&'a self) {
+        self.stm32f4.setup_circular_deps();
+    }
+}
+impl<'a> kernel::InterruptService<DeferredCallTask> for Stm32f446reDefaultPeripherals<'a> {
+    unsafe fn service_interrupt(&self, interrupt: u32) -> bool {
+        match interrupt {
+            // put Stm32f446re specific interrupts here
+            _ => self.stm32f4.service_interrupt(interrupt),
+        }
+    }
+    unsafe fn service_deferred_call(&self, task: DeferredCallTask) -> bool {
+        self.stm32f4.service_deferred_call(task)
+    }
+}

--- a/chips/stm32f446re/src/lib.rs
+++ b/chips/stm32f446re/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub use stm32f4xx::{chip, dbg, dma1, exti, gpio, nvic, rcc, spi, syscfg, tim2, usart};
 
+pub mod interrupt_service;
 pub mod stm32f446re_nvic;
 
 use cortexm4::{generic_isr, unhandled_interrupt};

--- a/chips/stm32f4xx/src/chip.rs
+++ b/chips/stm32f4xx/src/chip.rs
@@ -5,36 +5,141 @@ use cortexm4;
 use kernel::Chip;
 
 use kernel::common::deferred_call;
+use kernel::InterruptService;
 
-use crate::adc;
 use crate::dma1;
-use crate::exti;
-use crate::fsmc;
-use crate::i2c;
 use crate::nvic;
-use crate::spi;
-use crate::tim2;
-use crate::usart;
 
 use crate::deferred_calls::DeferredCallTask;
 
-pub struct Stm32f4xx {
+pub struct Stm32f4xx<'a, I: InterruptService<DeferredCallTask> + 'a> {
     mpu: cortexm4::mpu::MPU,
     userspace_kernel_boundary: cortexm4::syscall::SysCall,
     scheduler_timer: cortexm4::systick::SysTick,
+    interrupt_service: &'a I,
 }
 
-impl Stm32f4xx {
-    pub unsafe fn new() -> Stm32f4xx {
-        Stm32f4xx {
+pub struct Stm32f4xxDefaultPeripherals<'a> {
+    pub adc1: crate::adc::Adc<'a>,
+    pub dma_streams: [crate::dma1::Stream<'a>; 8],
+    pub exti: &'a crate::exti::Exti<'a>,
+    pub i2c1: crate::i2c::I2C<'a>,
+    pub spi3: crate::spi::Spi<'a>,
+    pub tim2: crate::tim2::Tim2<'a>,
+    pub usart2: crate::usart::Usart<'a>,
+    pub usart3: crate::usart::Usart<'a>,
+    pub gpio_ports: crate::gpio::GpioPorts<'a>,
+    pub fsmc: crate::fsmc::Fsmc<'a>,
+}
+
+impl<'a> Stm32f4xxDefaultPeripherals<'a> {
+    pub fn new(
+        rcc: &'a crate::rcc::Rcc,
+        exti: &'a crate::exti::Exti<'a>,
+        dma: &'a crate::dma1::Dma1<'a>,
+    ) -> Self {
+        Self {
+            adc1: crate::adc::Adc::new(rcc),
+            dma_streams: crate::dma1::new_dma1_stream(dma),
+            exti,
+            i2c1: crate::i2c::I2C::new(rcc),
+            spi3: crate::spi::Spi::new(
+                crate::spi::SPI3_BASE,
+                crate::spi::SpiClock(crate::rcc::PeripheralClock::new(
+                    crate::rcc::PeripheralClockType::APB1(crate::rcc::PCLK1::SPI3),
+                    rcc,
+                )),
+                crate::dma1::Dma1Peripheral::SPI3_TX,
+                crate::dma1::Dma1Peripheral::SPI3_RX,
+            ),
+            tim2: crate::tim2::Tim2::new(rcc),
+            usart2: crate::usart::Usart::new_usart2(rcc),
+            usart3: crate::usart::Usart::new_usart3(rcc),
+            gpio_ports: crate::gpio::GpioPorts::new(rcc, exti),
+            fsmc: crate::fsmc::Fsmc::new(
+                [
+                    Some(crate::fsmc::FSMC_BANK1),
+                    None,
+                    Some(crate::fsmc::FSMC_BANK3),
+                    None,
+                ],
+                rcc,
+            ),
+        }
+    }
+
+    pub fn setup_circular_deps(&'a self) {
+        self.gpio_ports.setup_circular_deps();
+    }
+}
+
+impl<'a> InterruptService<DeferredCallTask> for Stm32f4xxDefaultPeripherals<'a> {
+    unsafe fn service_interrupt(&self, interrupt: u32) -> bool {
+        match interrupt {
+            nvic::DMA1_Stream1 => self.dma_streams
+                [dma1::Dma1Peripheral::USART3_RX.get_stream_idx()]
+            .handle_interrupt(),
+            nvic::DMA1_Stream2 => {
+                self.dma_streams[dma1::Dma1Peripheral::SPI3_RX.get_stream_idx()].handle_interrupt()
+            }
+            nvic::DMA1_Stream3 => self.dma_streams
+                [dma1::Dma1Peripheral::USART3_TX.get_stream_idx()]
+            .handle_interrupt(),
+            nvic::DMA1_Stream5 => self.dma_streams
+                [dma1::Dma1Peripheral::USART2_RX.get_stream_idx()]
+            .handle_interrupt(),
+            nvic::DMA1_Stream6 => self.dma_streams
+                [dma1::Dma1Peripheral::USART2_TX.get_stream_idx()]
+            .handle_interrupt(),
+            nvic::DMA1_Stream7 => {
+                self.dma_streams[dma1::Dma1Peripheral::SPI3_TX.get_stream_idx()].handle_interrupt()
+            }
+
+            nvic::USART2 => self.usart2.handle_interrupt(),
+            nvic::USART3 => self.usart3.handle_interrupt(),
+
+            nvic::ADC => self.adc1.handle_interrupt(),
+
+            nvic::I2C1_EV => self.i2c1.handle_event(),
+            nvic::I2C1_ER => self.i2c1.handle_error(),
+
+            nvic::SPI3 => self.spi3.handle_interrupt(),
+
+            nvic::EXTI0 => self.exti.handle_interrupt(),
+            nvic::EXTI1 => self.exti.handle_interrupt(),
+            nvic::EXTI2 => self.exti.handle_interrupt(),
+            nvic::EXTI3 => self.exti.handle_interrupt(),
+            nvic::EXTI4 => self.exti.handle_interrupt(),
+            nvic::EXTI9_5 => self.exti.handle_interrupt(),
+            nvic::EXTI15_10 => self.exti.handle_interrupt(),
+
+            nvic::TIM2 => self.tim2.handle_interrupt(),
+
+            _ => return false,
+        }
+        true
+    }
+
+    unsafe fn service_deferred_call(&self, task: DeferredCallTask) -> bool {
+        match task {
+            DeferredCallTask::Fsmc => self.fsmc.handle_interrupt(),
+        }
+        true
+    }
+}
+
+impl<'a, I: InterruptService<DeferredCallTask> + 'a> Stm32f4xx<'a, I> {
+    pub unsafe fn new(interrupt_service: &'a I) -> Self {
+        Self {
             mpu: cortexm4::mpu::MPU::new(),
             userspace_kernel_boundary: cortexm4::syscall::SysCall::new(),
             scheduler_timer: cortexm4::systick::SysTick::new(),
+            interrupt_service,
         }
     }
 }
 
-impl Chip for Stm32f4xx {
+impl<'a, I: InterruptService<DeferredCallTask> + 'a> Chip for Stm32f4xx<'a, I> {
     type MPU = cortexm4::mpu::MPU;
     type UserspaceKernelBoundary = cortexm4::syscall::SysCall;
     type SchedulerTimer = cortexm4::systick::SysTick;
@@ -44,53 +149,12 @@ impl Chip for Stm32f4xx {
         unsafe {
             loop {
                 if let Some(task) = deferred_call::DeferredCall::next_pending() {
-                    match task {
-                        DeferredCallTask::Fsmc => fsmc::FSMC.handle_interrupt(),
+                    if !self.interrupt_service.service_deferred_call(task) {
+                        panic!("Unhandled deferred call");
                     }
                 } else if let Some(interrupt) = cortexm4::nvic::next_pending() {
-                    match interrupt {
-                        nvic::DMA1_Stream1 => dma1::Dma1Peripheral::USART3_RX
-                            .get_stream()
-                            .handle_interrupt(),
-                        nvic::DMA1_Stream2 => dma1::Dma1Peripheral::SPI3_RX
-                            .get_stream()
-                            .handle_interrupt(),
-                        nvic::DMA1_Stream3 => dma1::Dma1Peripheral::USART3_TX
-                            .get_stream()
-                            .handle_interrupt(),
-                        nvic::DMA1_Stream5 => dma1::Dma1Peripheral::USART2_RX
-                            .get_stream()
-                            .handle_interrupt(),
-                        nvic::DMA1_Stream6 => dma1::Dma1Peripheral::USART2_TX
-                            .get_stream()
-                            .handle_interrupt(),
-                        nvic::DMA1_Stream7 => dma1::Dma1Peripheral::SPI3_TX
-                            .get_stream()
-                            .handle_interrupt(),
-
-                        nvic::USART2 => usart::USART2.handle_interrupt(),
-                        nvic::USART3 => usart::USART3.handle_interrupt(),
-
-                        nvic::ADC => adc::ADC1.handle_interrupt(),
-
-                        nvic::I2C1_EV => i2c::I2C1.handle_event(),
-                        nvic::I2C1_ER => i2c::I2C1.handle_error(),
-
-                        nvic::SPI3 => spi::SPI3.handle_interrupt(),
-
-                        nvic::EXTI0 => exti::EXTI.handle_interrupt(),
-                        nvic::EXTI1 => exti::EXTI.handle_interrupt(),
-                        nvic::EXTI2 => exti::EXTI.handle_interrupt(),
-                        nvic::EXTI3 => exti::EXTI.handle_interrupt(),
-                        nvic::EXTI4 => exti::EXTI.handle_interrupt(),
-                        nvic::EXTI9_5 => exti::EXTI.handle_interrupt(),
-                        nvic::EXTI15_10 => exti::EXTI.handle_interrupt(),
-
-                        nvic::TIM2 => tim2::TIM2.handle_interrupt(),
-
-                        _ => {
-                            panic!("unhandled interrupt {}", interrupt);
-                        }
+                    if !self.interrupt_service.service_interrupt(interrupt) {
+                        panic!("unhandled interrupt {}", interrupt);
                     }
 
                     let n = cortexm4::nvic::Nvic::new(interrupt);

--- a/chips/stm32f4xx/src/dbg.rs
+++ b/chips/stm32f4xx/src/dbg.rs
@@ -92,10 +92,8 @@ pub struct Dbg {
     registers: StaticRef<DbgRegisters>,
 }
 
-pub static mut DBG: Dbg = Dbg::new();
-
 impl Dbg {
-    const fn new() -> Dbg {
+    pub const fn new() -> Dbg {
         Dbg {
             registers: DBG_BASE,
         }

--- a/chips/stm32f4xx/src/rcc.rs
+++ b/chips/stm32f4xx/src/rcc.rs
@@ -726,10 +726,8 @@ pub struct Rcc {
     registers: StaticRef<RccRegisters>,
 }
 
-pub static mut RCC: Rcc = Rcc::new();
-
 impl Rcc {
-    const fn new() -> Rcc {
+    pub const fn new() -> Rcc {
         Rcc {
             registers: RCC_BASE,
         }
@@ -984,12 +982,17 @@ pub enum CPUClock {
     PPLLR,
 }
 
+pub struct PeripheralClock<'a> {
+    pub clock: PeripheralClockType,
+    rcc: &'a Rcc,
+}
+
 /// Bus + Clock name for the peripherals
 ///
 /// Not yet implemented clocks:
 ///
 /// AHB2(HCLK2)
-pub enum PeripheralClock {
+pub enum PeripheralClockType {
     AHB1(HCLK1),
     AHB3(HCLK3),
     APB1(PCLK1),
@@ -1029,157 +1032,163 @@ pub enum PCLK2 {
     SYSCFG,
 }
 
-impl ClockInterface for PeripheralClock {
+impl<'a> PeripheralClock<'a> {
+    pub const fn new(clock: PeripheralClockType, rcc: &'a Rcc) -> Self {
+        Self { clock, rcc }
+    }
+}
+
+impl<'a> ClockInterface for PeripheralClock<'a> {
     fn is_enabled(&self) -> bool {
-        match self {
-            &PeripheralClock::AHB1(ref v) => match v {
-                HCLK1::DMA1 => unsafe { RCC.is_enabled_dma1_clock() },
-                HCLK1::GPIOH => unsafe { RCC.is_enabled_gpioh_clock() },
-                HCLK1::GPIOG => unsafe { RCC.is_enabled_gpiog_clock() },
-                HCLK1::GPIOF => unsafe { RCC.is_enabled_gpiof_clock() },
-                HCLK1::GPIOE => unsafe { RCC.is_enabled_gpioe_clock() },
-                HCLK1::GPIOD => unsafe { RCC.is_enabled_gpiod_clock() },
-                HCLK1::GPIOC => unsafe { RCC.is_enabled_gpioc_clock() },
-                HCLK1::GPIOB => unsafe { RCC.is_enabled_gpiob_clock() },
-                HCLK1::GPIOA => unsafe { RCC.is_enabled_gpioa_clock() },
+        match self.clock {
+            PeripheralClockType::AHB1(ref v) => match v {
+                HCLK1::DMA1 => self.rcc.is_enabled_dma1_clock(),
+                HCLK1::GPIOH => self.rcc.is_enabled_gpioh_clock(),
+                HCLK1::GPIOG => self.rcc.is_enabled_gpiog_clock(),
+                HCLK1::GPIOF => self.rcc.is_enabled_gpiof_clock(),
+                HCLK1::GPIOE => self.rcc.is_enabled_gpioe_clock(),
+                HCLK1::GPIOD => self.rcc.is_enabled_gpiod_clock(),
+                HCLK1::GPIOC => self.rcc.is_enabled_gpioc_clock(),
+                HCLK1::GPIOB => self.rcc.is_enabled_gpiob_clock(),
+                HCLK1::GPIOA => self.rcc.is_enabled_gpioa_clock(),
             },
-            &PeripheralClock::AHB3(ref v) => match v {
-                HCLK3::FMC => unsafe { RCC.is_enabled_fmc_clock() },
+            PeripheralClockType::AHB3(ref v) => match v {
+                HCLK3::FMC => self.rcc.is_enabled_fmc_clock(),
             },
-            &PeripheralClock::APB1(ref v) => match v {
-                PCLK1::TIM2 => unsafe { RCC.is_enabled_tim2_clock() },
-                PCLK1::USART2 => unsafe { RCC.is_enabled_usart2_clock() },
-                PCLK1::USART3 => unsafe { RCC.is_enabled_usart3_clock() },
-                PCLK1::I2C1 => unsafe { RCC.is_enabled_i2c1_clock() },
-                PCLK1::SPI3 => unsafe { RCC.is_enabled_spi3_clock() },
+            PeripheralClockType::APB1(ref v) => match v {
+                PCLK1::TIM2 => self.rcc.is_enabled_tim2_clock(),
+                PCLK1::USART2 => self.rcc.is_enabled_usart2_clock(),
+                PCLK1::USART3 => self.rcc.is_enabled_usart3_clock(),
+                PCLK1::I2C1 => self.rcc.is_enabled_i2c1_clock(),
+                PCLK1::SPI3 => self.rcc.is_enabled_spi3_clock(),
             },
-            &PeripheralClock::APB2(ref v) => match v {
-                PCLK2::ADC1 => unsafe { RCC.is_enabled_adc1_clock() },
-                PCLK2::SYSCFG => unsafe { RCC.is_enabled_syscfg_clock() },
+            PeripheralClockType::APB2(ref v) => match v {
+                PCLK2::ADC1 => self.rcc.is_enabled_adc1_clock(),
+                PCLK2::SYSCFG => self.rcc.is_enabled_syscfg_clock(),
             },
         }
     }
 
     fn enable(&self) {
-        match self {
-            &PeripheralClock::AHB1(ref v) => match v {
-                HCLK1::DMA1 => unsafe {
-                    RCC.enable_dma1_clock();
-                },
-                HCLK1::GPIOH => unsafe {
-                    RCC.enable_gpioh_clock();
-                },
-                HCLK1::GPIOG => unsafe {
-                    RCC.enable_gpiog_clock();
-                },
-                HCLK1::GPIOF => unsafe {
-                    RCC.enable_gpiof_clock();
-                },
-                HCLK1::GPIOE => unsafe {
-                    RCC.enable_gpioe_clock();
-                },
-                HCLK1::GPIOD => unsafe {
-                    RCC.enable_gpiod_clock();
-                },
-                HCLK1::GPIOC => unsafe {
-                    RCC.enable_gpioc_clock();
-                },
-                HCLK1::GPIOB => unsafe {
-                    RCC.enable_gpiob_clock();
-                },
-                HCLK1::GPIOA => unsafe {
-                    RCC.enable_gpioa_clock();
-                },
+        match self.clock {
+            PeripheralClockType::AHB1(ref v) => match v {
+                HCLK1::DMA1 => {
+                    self.rcc.enable_dma1_clock();
+                }
+                HCLK1::GPIOH => {
+                    self.rcc.enable_gpioh_clock();
+                }
+                HCLK1::GPIOG => {
+                    self.rcc.enable_gpiog_clock();
+                }
+                HCLK1::GPIOF => {
+                    self.rcc.enable_gpiof_clock();
+                }
+                HCLK1::GPIOE => {
+                    self.rcc.enable_gpioe_clock();
+                }
+                HCLK1::GPIOD => {
+                    self.rcc.enable_gpiod_clock();
+                }
+                HCLK1::GPIOC => {
+                    self.rcc.enable_gpioc_clock();
+                }
+                HCLK1::GPIOB => {
+                    self.rcc.enable_gpiob_clock();
+                }
+                HCLK1::GPIOA => {
+                    self.rcc.enable_gpioa_clock();
+                }
             },
-            &PeripheralClock::AHB3(ref v) => match v {
-                HCLK3::FMC => unsafe { RCC.enable_fmc_clock() },
+            PeripheralClockType::AHB3(ref v) => match v {
+                HCLK3::FMC => self.rcc.enable_fmc_clock(),
             },
-            &PeripheralClock::APB1(ref v) => match v {
-                PCLK1::TIM2 => unsafe {
-                    RCC.enable_tim2_clock();
-                },
-                PCLK1::USART2 => unsafe {
-                    RCC.enable_usart2_clock();
-                },
-                PCLK1::USART3 => unsafe {
-                    RCC.enable_usart3_clock();
-                },
-                PCLK1::I2C1 => unsafe {
-                    RCC.enable_i2c1_clock();
-                },
-                PCLK1::SPI3 => unsafe {
-                    RCC.enable_spi3_clock();
-                },
+            PeripheralClockType::APB1(ref v) => match v {
+                PCLK1::TIM2 => {
+                    self.rcc.enable_tim2_clock();
+                }
+                PCLK1::USART2 => {
+                    self.rcc.enable_usart2_clock();
+                }
+                PCLK1::USART3 => {
+                    self.rcc.enable_usart3_clock();
+                }
+                PCLK1::I2C1 => {
+                    self.rcc.enable_i2c1_clock();
+                }
+                PCLK1::SPI3 => {
+                    self.rcc.enable_spi3_clock();
+                }
             },
-            &PeripheralClock::APB2(ref v) => match v {
-                PCLK2::ADC1 => unsafe {
-                    RCC.enable_adc1_clock();
-                },
-                PCLK2::SYSCFG => unsafe {
-                    RCC.enable_syscfg_clock();
-                },
+            PeripheralClockType::APB2(ref v) => match v {
+                PCLK2::ADC1 => {
+                    self.rcc.enable_adc1_clock();
+                }
+                PCLK2::SYSCFG => {
+                    self.rcc.enable_syscfg_clock();
+                }
             },
         }
     }
 
     fn disable(&self) {
-        match self {
-            &PeripheralClock::AHB1(ref v) => match v {
-                HCLK1::DMA1 => unsafe {
-                    RCC.disable_dma1_clock();
-                },
-                HCLK1::GPIOH => unsafe {
-                    RCC.disable_gpioh_clock();
-                },
-                HCLK1::GPIOG => unsafe {
-                    RCC.disable_gpiog_clock();
-                },
-                HCLK1::GPIOF => unsafe {
-                    RCC.disable_gpiof_clock();
-                },
-                HCLK1::GPIOE => unsafe {
-                    RCC.disable_gpioe_clock();
-                },
-                HCLK1::GPIOD => unsafe {
-                    RCC.disable_gpiod_clock();
-                },
-                HCLK1::GPIOC => unsafe {
-                    RCC.disable_gpioc_clock();
-                },
-                HCLK1::GPIOB => unsafe {
-                    RCC.disable_gpiob_clock();
-                },
-                HCLK1::GPIOA => unsafe {
-                    RCC.disable_gpioa_clock();
-                },
+        match self.clock {
+            PeripheralClockType::AHB1(ref v) => match v {
+                HCLK1::DMA1 => {
+                    self.rcc.disable_dma1_clock();
+                }
+                HCLK1::GPIOH => {
+                    self.rcc.disable_gpioh_clock();
+                }
+                HCLK1::GPIOG => {
+                    self.rcc.disable_gpiog_clock();
+                }
+                HCLK1::GPIOF => {
+                    self.rcc.disable_gpiof_clock();
+                }
+                HCLK1::GPIOE => {
+                    self.rcc.disable_gpioe_clock();
+                }
+                HCLK1::GPIOD => {
+                    self.rcc.disable_gpiod_clock();
+                }
+                HCLK1::GPIOC => {
+                    self.rcc.disable_gpioc_clock();
+                }
+                HCLK1::GPIOB => {
+                    self.rcc.disable_gpiob_clock();
+                }
+                HCLK1::GPIOA => {
+                    self.rcc.disable_gpioa_clock();
+                }
             },
-            &PeripheralClock::AHB3(ref v) => match v {
-                HCLK3::FMC => unsafe { RCC.disable_fmc_clock() },
+            PeripheralClockType::AHB3(ref v) => match v {
+                HCLK3::FMC => self.rcc.disable_fmc_clock(),
             },
-            &PeripheralClock::APB1(ref v) => match v {
-                PCLK1::TIM2 => unsafe {
-                    RCC.disable_tim2_clock();
-                },
-                PCLK1::USART2 => unsafe {
-                    RCC.disable_usart2_clock();
-                },
-                PCLK1::USART3 => unsafe {
-                    RCC.disable_usart3_clock();
-                },
-                PCLK1::I2C1 => unsafe {
-                    RCC.disable_i2c1_clock();
-                },
-                PCLK1::SPI3 => unsafe {
-                    RCC.disable_spi3_clock();
-                },
+            PeripheralClockType::APB1(ref v) => match v {
+                PCLK1::TIM2 => {
+                    self.rcc.disable_tim2_clock();
+                }
+                PCLK1::USART2 => {
+                    self.rcc.disable_usart2_clock();
+                }
+                PCLK1::USART3 => {
+                    self.rcc.disable_usart3_clock();
+                }
+                PCLK1::I2C1 => {
+                    self.rcc.disable_i2c1_clock();
+                }
+                PCLK1::SPI3 => {
+                    self.rcc.disable_spi3_clock();
+                }
             },
-            &PeripheralClock::APB2(ref v) => match v {
-                PCLK2::ADC1 => unsafe {
-                    RCC.disable_adc1_clock();
-                },
-                PCLK2::SYSCFG => unsafe {
-                    RCC.disable_syscfg_clock();
-                },
+            PeripheralClockType::APB2(ref v) => match v {
+                PCLK2::ADC1 => {
+                    self.rcc.disable_adc1_clock();
+                }
+                PCLK2::SYSCFG => {
+                    self.rcc.disable_syscfg_clock();
+                }
             },
         }
     }

--- a/chips/stm32f4xx/src/syscfg.rs
+++ b/chips/stm32f4xx/src/syscfg.rs
@@ -114,18 +114,19 @@ enum_from_primitive! {
     }
 }
 
-pub struct Syscfg {
+pub struct Syscfg<'a> {
     registers: StaticRef<SyscfgRegisters>,
-    clock: SyscfgClock,
+    clock: SyscfgClock<'a>,
 }
 
-pub static mut SYSCFG: Syscfg = Syscfg::new();
-
-impl Syscfg {
-    const fn new() -> Syscfg {
-        Syscfg {
+impl<'a> Syscfg<'a> {
+    pub const fn new(rcc: &'a rcc::Rcc) -> Self {
+        Self {
             registers: SYSCFG_BASE,
-            clock: SyscfgClock(rcc::PeripheralClock::APB2(rcc::PCLK2::SYSCFG)),
+            clock: SyscfgClock(rcc::PeripheralClock::new(
+                rcc::PeripheralClockType::APB2(rcc::PCLK2::SYSCFG),
+                rcc,
+            )),
         }
     }
 
@@ -224,9 +225,9 @@ impl Syscfg {
     }
 }
 
-struct SyscfgClock(rcc::PeripheralClock);
+struct SyscfgClock<'a>(rcc::PeripheralClock<'a>);
 
-impl ClockInterface for SyscfgClock {
+impl ClockInterface for SyscfgClock<'_> {
     fn is_enabled(&self) -> bool {
         self.0.is_enabled()
     }

--- a/chips/stm32f4xx/src/tim2.rs
+++ b/chips/stm32f4xx/src/tim2.rs
@@ -309,18 +309,19 @@ const TIM2_BASE: StaticRef<Tim2Registers> =
 
 pub struct Tim2<'a> {
     registers: StaticRef<Tim2Registers>,
-    clock: Tim2Clock,
+    clock: Tim2Clock<'a>,
     client: OptionalCell<&'a dyn AlarmClient>,
     irqn: u32,
 }
 
-pub static mut TIM2: Tim2<'static> = Tim2::new();
-
 impl<'a> Tim2<'a> {
-    const fn new() -> Tim2<'a> {
-        Tim2 {
+    pub const fn new(rcc: &'a rcc::Rcc) -> Self {
+        Self {
             registers: TIM2_BASE,
-            clock: Tim2Clock(rcc::PeripheralClock::APB1(rcc::PCLK1::TIM2)),
+            clock: Tim2Clock(rcc::PeripheralClock::new(
+                rcc::PeripheralClockType::APB1(rcc::PCLK1::TIM2),
+                rcc,
+            )),
             client: OptionalCell::empty(),
             irqn: nvic::TIM2,
         }
@@ -439,9 +440,9 @@ impl<'a> Alarm<'a> for Tim2<'a> {
     }
 }
 
-struct Tim2Clock(rcc::PeripheralClock);
+struct Tim2Clock<'a>(rcc::PeripheralClock<'a>);
 
-impl ClockInterface for Tim2Clock {
+impl ClockInterface for Tim2Clock<'_> {
     fn is_enabled(&self) -> bool {
         self.0.is_enabled()
     }


### PR DESCRIPTION
### Pull Request Overview

This pull request ports the stm32f4xx, stm32f446re, stm32f412g, stm32f429zi chips and the boards that use them to the new peripheral instantiation approach that does not rely on global variables (first proposed in #2069). 

This involved mostly the same changes as were required for the stm32f3xx chip, with some additional changes for handling DMA, because there is tons of duplicate code across those chips and boards. It would be nice if those chips and boards had an approach to code sharing more similar to that used by the nordic boards, but that would be a substantial refactor so not sure if its worth it for anyone to take that on.

This PR removes a ton of unsafe, which is nice. It also adds support for different stm chips to support different peripherals (in much the same way the nordic chips handle this) which should help for #2182 .


### Testing Strategy

This pull request was tested by compiling. But there are enough changes in this PR that hardware testing would be appreciated.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] No updates are required.

### Formatting

- [x] Ran `make prepush`.
