### PR TITLE
Board based instantiation of chip drivers and interrupt mappings: Msp432

### DIFF
--- a/boards/msp_exp432p401r/src/io.rs
+++ b/boards/msp_exp432p401r/src/io.rs
@@ -33,7 +33,7 @@ impl Write for Uart {
 
 impl IoWrite for Uart {
     fn write(&mut self, buf: &[u8]) {
-        let uart0 = msp432::uart::Uart::new(0, 1, 1, 1);
+        let uart0 = msp432::uart::Uart::new(msp432::usci::USCI_A0_BASE, 0, 1, 1, 1);
         uart0.transmit_sync(buf);
     }
 }

--- a/boards/msp_exp432p401r/src/io.rs
+++ b/boards/msp_exp432p401r/src/io.rs
@@ -33,9 +33,8 @@ impl Write for Uart {
 
 impl IoWrite for Uart {
     fn write(&mut self, buf: &[u8]) {
-        unsafe {
-            msp432::uart::UART0.transmit_sync(buf);
-        }
+        let uart0 = msp432::uart::Uart::new(0, 1, 1, 1);
+        uart0.transmit_sync(buf);
     }
 }
 
@@ -44,7 +43,8 @@ impl IoWrite for Uart {
 #[panic_handler]
 pub unsafe extern "C" fn panic_fmt(info: &PanicInfo) -> ! {
     const LED1_PIN: IntPinNr = IntPinNr::P01_0;
-    let led = &mut led::LedHigh::new(&msp432::gpio::INT_PINS[LED1_PIN as usize]);
+    let gpio_pin = msp432::gpio::IntPin::new(LED1_PIN);
+    let led = &mut led::LedHigh::new(&gpio_pin);
     let writer = &mut UART;
     let wdt = Wdt::new();
 

--- a/boards/msp_exp432p401r/src/main.rs
+++ b/boards/msp_exp432p401r/src/main.rs
@@ -31,7 +31,8 @@ static mut PROCESSES: [Option<&'static dyn kernel::procs::ProcessType>; NUM_PROC
     [None; NUM_PROCS];
 
 /// Static reference to chip for panic dumps.
-static mut CHIP: Option<&'static msp432::chip::Msp432> = None;
+static mut CHIP: Option<&'static msp432::chip::Msp432<msp432::chip::Msp432DefaultPeripherals>> =
+    None;
 
 /// How should the kernel respond when a process faults.
 const FAULT_RESPONSE: kernel::procs::FaultResponse = kernel::procs::FaultResponse::Panic;
@@ -56,7 +57,7 @@ struct MspExp432P401R {
         capsules::virtual_alarm::VirtualMuxAlarm<'static, msp432::timer::TimerA<'static>>,
     >,
     ipc: kernel::ipc::IPC,
-    adc: &'static capsules::adc::AdcDedicated<'static, msp432::adc::Adc>,
+    adc: &'static capsules::adc::AdcDedicated<'static, msp432::adc::Adc<'static>>,
 }
 
 /// Mapping of integer syscalls to objects that implement syscalls.
@@ -85,52 +86,59 @@ impl Platform for MspExp432P401R {
 /// (which is necessary for 48MHz operation) and enables waitstates and buffering in a way that
 /// the flash returns valid data with 48MHz CPU frequency.
 unsafe fn startup_intilialisation() {
-    let wdt = msp432::wdt::Wdt::new();
-
     msp432::init();
+
+    // For now, these peripherals are only used at startup, so we do not
+    // allocate them for the life of the program. If these are later used by the
+    // chip crate (such as for handling interrupts), they will need to be
+    // added to Msp432DefaultPeripherals
+    let wdt = msp432::wdt::Wdt::new();
+    let sysctl = msp432::sysctl::SysCtl::new();
+    let flctl = msp432::flctl::FlCtl::new();
+    let pcm = msp432::pcm::Pcm::new();
 
     // The watchdog must be disabled, because it is enabled by default on reset and has a
     // interval of approximately 10ms. See datasheet p. 759, section 17.2.2.
     // Do this in a separate function which is executed before the kernel is started in order to
     // make sure that not more than 1 watchdog instances exist at the same time.
     wdt.disable();
-    msp432::sysctl::SYSCTL.enable_all_sram_banks();
-    msp432::pcm::PCM.set_high_power();
-    msp432::flctl::FLCTL.set_waitstates(msp432::flctl::WaitStates::_1);
-    msp432::flctl::FLCTL.set_buffering(true);
+    sysctl.enable_all_sram_banks();
+    pcm.set_high_power();
+    flctl.set_waitstates(msp432::flctl::WaitStates::_1);
+    flctl.set_buffering(true);
 }
 
 /// Function to setup all ADC-capaable pins
 /// Since the chips has 100 pins, we really setup all capable pins to work as ADC-pins.
-unsafe fn setup_adc_pins() {
-    use msp432::gpio::{IntPinNr, PinNr, INT_PINS, PINS};
-    INT_PINS[IntPinNr::P05_5 as usize].enable_tertiary_function(); // A0
-    INT_PINS[IntPinNr::P05_4 as usize].enable_tertiary_function(); // A1
-    INT_PINS[IntPinNr::P05_3 as usize].enable_tertiary_function(); // A2
-    INT_PINS[IntPinNr::P05_2 as usize].enable_tertiary_function(); // A3
-    INT_PINS[IntPinNr::P05_1 as usize].enable_tertiary_function(); // A4
-    INT_PINS[IntPinNr::P05_0 as usize].enable_tertiary_function(); // A5
-    INT_PINS[IntPinNr::P04_7 as usize].enable_tertiary_function(); // A6
-    INT_PINS[IntPinNr::P04_6 as usize].enable_tertiary_function(); // A7
-    INT_PINS[IntPinNr::P04_5 as usize].enable_tertiary_function(); // A8
-    INT_PINS[IntPinNr::P04_4 as usize].enable_tertiary_function(); // A9
-    INT_PINS[IntPinNr::P04_3 as usize].enable_tertiary_function(); // A10
-    INT_PINS[IntPinNr::P04_2 as usize].enable_tertiary_function(); // A11
-    INT_PINS[IntPinNr::P04_1 as usize].enable_tertiary_function(); // A12
-    INT_PINS[IntPinNr::P04_0 as usize].enable_tertiary_function(); // A13
-    INT_PINS[IntPinNr::P06_1 as usize].enable_tertiary_function(); // A14
-    INT_PINS[IntPinNr::P06_0 as usize].enable_tertiary_function(); // A15
-    PINS[PinNr::P09_1 as usize].enable_tertiary_function(); // A16
-    PINS[PinNr::P09_0 as usize].enable_tertiary_function(); // A17
-    PINS[PinNr::P08_7 as usize].enable_tertiary_function(); // A18
-    PINS[PinNr::P08_6 as usize].enable_tertiary_function(); // A19
-    PINS[PinNr::P08_5 as usize].enable_tertiary_function(); // A20
-    PINS[PinNr::P08_4 as usize].enable_tertiary_function(); // A21
+unsafe fn setup_adc_pins(gpio: &msp432::gpio::GpioManager) {
+    use msp432::gpio::{IntPinNr, PinNr};
+    gpio.int_pins[IntPinNr::P05_5 as usize].enable_tertiary_function(); // A0
+    gpio.int_pins[IntPinNr::P05_4 as usize].enable_tertiary_function(); // A1
+    gpio.int_pins[IntPinNr::P05_3 as usize].enable_tertiary_function(); // A2
+    gpio.int_pins[IntPinNr::P05_2 as usize].enable_tertiary_function(); // A3
+    gpio.int_pins[IntPinNr::P05_1 as usize].enable_tertiary_function(); // A4
+    gpio.int_pins[IntPinNr::P05_0 as usize].enable_tertiary_function(); // A5
+    gpio.int_pins[IntPinNr::P04_7 as usize].enable_tertiary_function(); // A6
+    gpio.int_pins[IntPinNr::P04_6 as usize].enable_tertiary_function(); // A7
+    gpio.int_pins[IntPinNr::P04_5 as usize].enable_tertiary_function(); // A8
+    gpio.int_pins[IntPinNr::P04_4 as usize].enable_tertiary_function(); // A9
+    gpio.int_pins[IntPinNr::P04_3 as usize].enable_tertiary_function(); // A10
+    gpio.int_pins[IntPinNr::P04_2 as usize].enable_tertiary_function(); // A11
+    gpio.int_pins[IntPinNr::P04_1 as usize].enable_tertiary_function(); // A12
+    gpio.int_pins[IntPinNr::P04_0 as usize].enable_tertiary_function(); // A13
+    gpio.int_pins[IntPinNr::P06_1 as usize].enable_tertiary_function(); // A14
+    gpio.int_pins[IntPinNr::P06_0 as usize].enable_tertiary_function(); // A15
+    gpio.pins[PinNr::P09_1 as usize].enable_tertiary_function(); // A16
+    gpio.pins[PinNr::P09_0 as usize].enable_tertiary_function(); // A17
+    gpio.pins[PinNr::P08_7 as usize].enable_tertiary_function(); // A18
+    gpio.pins[PinNr::P08_6 as usize].enable_tertiary_function(); // A19
+    gpio.pins[PinNr::P08_5 as usize].enable_tertiary_function(); // A20
+    gpio.pins[PinNr::P08_4 as usize].enable_tertiary_function(); // A21
 
     // Don't configure these pins since their channels are used for the internal
     // temperature sensor (Channel 22) and the Battery Monitor (A23)
-    // PINS[PinNr::P08_3 as usize].enable_tertiary_function(); // A22
-    // PINS[PinNr::P08_2 as usize].enable_tertiary_function(); // A23
+    // gpio.pins[PinNr::P08_3 as usize].enable_tertiary_function(); // A22
+    // gpio.pins[PinNr::P08_2 as usize].enable_tertiary_function(); // A23
 }
 
 /// Reset Handler.
@@ -143,29 +151,38 @@ unsafe fn setup_adc_pins() {
 pub unsafe fn reset_handler() {
     startup_intilialisation();
 
+    let peripherals = static_init!(
+        msp432::chip::Msp432DefaultPeripherals,
+        msp432::chip::Msp432DefaultPeripherals::new()
+    );
+    peripherals.init();
+
     // Setup the GPIO pins to use the HFXT (high frequency external) oscillator (48MHz)
-    msp432::gpio::PINS[msp432::gpio::PinNr::PJ_2 as usize].enable_primary_function();
-    msp432::gpio::PINS[msp432::gpio::PinNr::PJ_3 as usize].enable_primary_function();
+    peripherals.gpio.pins[msp432::gpio::PinNr::PJ_2 as usize].enable_primary_function();
+    peripherals.gpio.pins[msp432::gpio::PinNr::PJ_3 as usize].enable_primary_function();
 
     // Setup the GPIO pins to use the LFXT (low frequency external) oscillator (32.768kHz)
-    msp432::gpio::PINS[msp432::gpio::PinNr::PJ_0 as usize].enable_primary_function();
-    msp432::gpio::PINS[msp432::gpio::PinNr::PJ_1 as usize].enable_primary_function();
+    peripherals.gpio.pins[msp432::gpio::PinNr::PJ_0 as usize].enable_primary_function();
+    peripherals.gpio.pins[msp432::gpio::PinNr::PJ_1 as usize].enable_primary_function();
 
     // Setup the clocks: MCLK: 48MHz, HSMCLK: 12MHz, SMCLK: 1.5MHz, ACLK: 32.768kHz
-    msp432::cs::CS.setup_clocks();
+    peripherals.cs.setup_clocks();
 
     debug::assign_gpios(
-        Some(&msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P01_0 as usize]), // Red LED
-        Some(&msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P03_5 as usize]),
-        Some(&msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P03_7 as usize]),
+        Some(&peripherals.gpio.int_pins[msp432::gpio::IntPinNr::P01_0 as usize]), // Red LED
+        Some(&peripherals.gpio.int_pins[msp432::gpio::IntPinNr::P03_5 as usize]),
+        Some(&peripherals.gpio.int_pins[msp432::gpio::IntPinNr::P03_7 as usize]),
     );
 
     // Setup pins for UART0
-    msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P01_2 as usize].enable_primary_function();
-    msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P01_3 as usize].enable_primary_function();
+    peripherals.gpio.int_pins[msp432::gpio::IntPinNr::P01_2 as usize].enable_primary_function();
+    peripherals.gpio.int_pins[msp432::gpio::IntPinNr::P01_3 as usize].enable_primary_function();
 
     let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
-    let chip = static_init!(msp432::chip::Msp432, msp432::chip::Msp432::new());
+    let chip = static_init!(
+        msp432::chip::Msp432<msp432::chip::Msp432DefaultPeripherals>,
+        msp432::chip::Msp432::new(peripherals)
+    );
     CHIP = Some(chip);
 
     // Setup buttons
@@ -174,12 +191,12 @@ pub unsafe fn reset_handler() {
         components::button_component_helper!(
             msp432::gpio::IntPin,
             (
-                &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P01_1 as usize],
+                &peripherals.gpio.int_pins[msp432::gpio::IntPinNr::P01_1 as usize],
                 kernel::hil::gpio::ActivationMode::ActiveLow,
                 kernel::hil::gpio::FloatingState::PullUp
             ),
             (
-                &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P01_4 as usize],
+                &peripherals.gpio.int_pins[msp432::gpio::IntPinNr::P01_4 as usize],
                 kernel::hil::gpio::ActivationMode::ActiveLow,
                 kernel::hil::gpio::FloatingState::PullUp
             )
@@ -191,13 +208,13 @@ pub unsafe fn reset_handler() {
     let leds = components::led::LedsComponent::new(components::led_component_helper!(
         kernel::hil::led::LedHigh<'static, msp432::gpio::IntPin>,
         kernel::hil::led::LedHigh::new(
-            &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P02_0 as usize]
+            &peripherals.gpio.int_pins[msp432::gpio::IntPinNr::P02_0 as usize]
         ),
         kernel::hil::led::LedHigh::new(
-            &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P02_1 as usize]
+            &peripherals.gpio.int_pins[msp432::gpio::IntPinNr::P02_1 as usize]
         ),
         kernel::hil::led::LedHigh::new(
-            &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P02_2 as usize]
+            &peripherals.gpio.int_pins[msp432::gpio::IntPinNr::P02_2 as usize]
         ),
     ))
     .finalize(components::led_component_buf!(
@@ -210,44 +227,44 @@ pub unsafe fn reset_handler() {
         components::gpio_component_helper!(
             msp432::gpio::IntPin<'static>,
             // Left outer connector, top to bottom
-            // 0 => &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P06_0 as usize], // A15
-            1 => &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P03_2 as usize],
-            2 => &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P03_3 as usize],
-            // 3 => &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P04_1 as usize], // A12
-            // 4 => &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P04_3 as usize], // A10
-            5 => &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P01_5 as usize],
-            // 6 => &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P04_6 as usize], // A7
-            7 => &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P06_5 as usize],
-            8 => &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P06_4 as usize],
+            // 0 => &peripherals.gpio.int_pins[msp432::gpio::IntPinNr::P06_0 as usize], // A15
+            1 => &peripherals.gpio.int_pins[msp432::gpio::IntPinNr::P03_2 as usize],
+            2 => &peripherals.gpio.int_pins[msp432::gpio::IntPinNr::P03_3 as usize],
+            // 3 => &peripherals.gpio.int_pins[msp432::gpio::IntPinNr::P04_1 as usize], // A12
+            // 4 => &peripherals.gpio.int_pins[msp432::gpio::IntPinNr::P04_3 as usize], // A10
+            5 => &peripherals.gpio.int_pins[msp432::gpio::IntPinNr::P01_5 as usize],
+            // 6 => &peripherals.gpio.int_pins[msp432::gpio::IntPinNr::P04_6 as usize], // A7
+            7 => &peripherals.gpio.int_pins[msp432::gpio::IntPinNr::P06_5 as usize],
+            8 => &peripherals.gpio.int_pins[msp432::gpio::IntPinNr::P06_4 as usize],
             // Left inner connector, top to bottom
-            // 9 => &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P06_1 as usize], // A14
-            // 10 => &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P04_0 as usize], // A13
-            // 11 => &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P04_2 as usize], // A11
-            // 12 => &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P04_4 as usize], // A9
-            // 13 => &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P04_5 as usize], // A8
-            // 14 => &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P04_7 as usize], // A6
-            // 15 => &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P05_4 as usize], // A1
-            // 16 => &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P05_5 as usize], // A0
+            // 9 => &peripherals.gpio.int_pins[msp432::gpio::IntPinNr::P06_1 as usize], // A14
+            // 10 => &peripherals.gpio.int_pins[msp432::gpio::IntPinNr::P04_0 as usize], // A13
+            // 11 => &peripherals.gpio.int_pins[msp432::gpio::IntPinNr::P04_2 as usize], // A11
+            // 12 => &peripherals.gpio.int_pins[msp432::gpio::IntPinNr::P04_4 as usize], // A9
+            // 13 => &peripherals.gpio.int_pins[msp432::gpio::IntPinNr::P04_5 as usize], // A8
+            // 14 => &peripherals.gpio.int_pins[msp432::gpio::IntPinNr::P04_7 as usize], // A6
+            // 15 => &peripherals.gpio.int_pins[msp432::gpio::IntPinNr::P05_4 as usize], // A1
+            // 16 => &peripherals.gpio.int_pins[msp432::gpio::IntPinNr::P05_5 as usize], // A0
             // Right inner connector, top to bottom
-            17 => &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P02_7 as usize],
-            18 => &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P02_6 as usize],
-            19 => &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P02_4 as usize],
-            20 => &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P05_6 as usize],
-            21 => &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P06_6 as usize],
-            22 => &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P06_7 as usize],
-            23 => &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P02_3 as usize],
-            // 24 => &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P05_1 as usize], // A4
-            // 25 => &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P03_5 as usize], // debug-gpio
-            // 26 => &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P03_7 as usize], // debug-gpio
+            17 => &peripherals.gpio.int_pins[msp432::gpio::IntPinNr::P02_7 as usize],
+            18 => &peripherals.gpio.int_pins[msp432::gpio::IntPinNr::P02_6 as usize],
+            19 => &peripherals.gpio.int_pins[msp432::gpio::IntPinNr::P02_4 as usize],
+            20 => &peripherals.gpio.int_pins[msp432::gpio::IntPinNr::P05_6 as usize],
+            21 => &peripherals.gpio.int_pins[msp432::gpio::IntPinNr::P06_6 as usize],
+            22 => &peripherals.gpio.int_pins[msp432::gpio::IntPinNr::P06_7 as usize],
+            23 => &peripherals.gpio.int_pins[msp432::gpio::IntPinNr::P02_3 as usize],
+            // 24 => &peripherals.gpio.int_pins[msp432::gpio::IntPinNr::P05_1 as usize], // A4
+            // 25 => &peripherals.gpio.int_pins[msp432::gpio::IntPinNr::P03_5 as usize], // debug-gpio
+            // 26 => &peripherals.gpio.int_pins[msp432::gpio::IntPinNr::P03_7 as usize], // debug-gpio
             // Right outer connector, top to bottom
-            27 => &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P02_5 as usize],
-            28 => &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P03_0 as usize],
-            29 => &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P05_7 as usize],
-            30 => &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P01_6 as usize],
-            31 => &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P01_7 as usize],
-            // 32 => &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P05_0 as usize], // A5
-            // 33 => &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P05_2 as usize], // A3
-            34 => &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P03_6 as usize]
+            27 => &peripherals.gpio.int_pins[msp432::gpio::IntPinNr::P02_5 as usize],
+            28 => &peripherals.gpio.int_pins[msp432::gpio::IntPinNr::P03_0 as usize],
+            29 => &peripherals.gpio.int_pins[msp432::gpio::IntPinNr::P05_7 as usize],
+            30 => &peripherals.gpio.int_pins[msp432::gpio::IntPinNr::P01_6 as usize],
+            31 => &peripherals.gpio.int_pins[msp432::gpio::IntPinNr::P01_7 as usize],
+            // 32 => &peripherals.gpio.int_pins[msp432::gpio::IntPinNr::P05_0 as usize], // A5
+            // 33 => &peripherals.gpio.int_pins[msp432::gpio::IntPinNr::P05_2 as usize], // A3
+            34 => &peripherals.gpio.int_pins[msp432::gpio::IntPinNr::P03_6 as usize]
         ),
     )
     .finalize(components::gpio_component_buf!(
@@ -268,7 +285,7 @@ pub unsafe fn reset_handler() {
 
     // Setup UART0
     let uart_mux = components::console::UartMuxComponent::new(
-        &msp432::uart::UART0,
+        &peripherals.uart0,
         115200,
         dynamic_deferred_caller,
     )
@@ -280,7 +297,7 @@ pub unsafe fn reset_handler() {
     components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
 
     // Setup alarm
-    let timer0 = &msp432::timer::TIMER_A0;
+    let timer0 = &peripherals.timer_a0;
     let mux_alarm = components::alarm::AlarmMuxComponent::new(timer0).finalize(
         components::alarm_mux_component_helper!(msp432::timer::TimerA),
     );
@@ -289,7 +306,7 @@ pub unsafe fn reset_handler() {
 
     // Setup ADC
 
-    setup_adc_pins();
+    setup_adc_pins(&peripherals.gpio);
 
     let adc_channels = static_init!(
         [&'static msp432::adc::Channel; 24],
@@ -326,7 +343,7 @@ pub unsafe fn reset_handler() {
     let adc = static_init!(
         capsules::adc::AdcDedicated<'static, msp432::adc::Adc>,
         capsules::adc::AdcDedicated::new(
-            &msp432::adc::ADC,
+            &peripherals.adc,
             grant_adc,
             adc_channels,
             &mut capsules::adc::ADC_BUFFER1,
@@ -335,12 +352,14 @@ pub unsafe fn reset_handler() {
         )
     );
 
-    msp432::adc::ADC.set_client(adc);
+    peripherals.adc.set_client(adc);
 
     // Set the reference voltage for the ADC to 2.5V
-    msp432::ref_module::REF.select_ref_voltage(msp432::ref_module::ReferenceVoltage::Volt2_5);
+    peripherals
+        .adc_ref
+        .select_ref_voltage(msp432::ref_module::ReferenceVoltage::Volt2_5);
     // Enable the internal temperature sensor on ADC Channel 22
-    msp432::ref_module::REF.enable_temp_sensor(true);
+    peripherals.adc_ref.enable_temp_sensor(true);
 
     let msp_exp432p4014 = MspExp432P401R {
         led: leds,

--- a/chips/msp432/src/chip.rs
+++ b/chips/msp432/src/chip.rs
@@ -31,7 +31,7 @@ impl<'a> Msp432DefaultPeripherals<'a> {
     pub fn new() -> Self {
         Self {
             adc: crate::adc::Adc::new(),
-            uart0: crate::uart::Uart::new(0, 1, 1, 1),
+            uart0: crate::uart::Uart::new(crate::usci::USCI_A0_BASE, 0, 1, 1, 1),
             cs: crate::cs::ClockSystem::new(),
             dma_channels: crate::dma::DmaChannels::new(),
             adc_ref: crate::ref_module::Ref::new(),

--- a/chips/msp432/src/cs.rs
+++ b/chips/msp432/src/cs.rs
@@ -7,8 +7,6 @@ use kernel::common::registers::{
 use kernel::common::StaticRef;
 use kernel::NoClockControl;
 
-pub static mut CS: ClockSystem = ClockSystem::new();
-
 pub const MCLK_HZ: u32 = 48_000_000;
 pub const HSMCLK_HZ: u32 = 12_000_000;
 pub const SMCLK_HZ: u32 = 1_500_000;
@@ -250,11 +248,13 @@ register_bitfields! [u32,
 
 type CsRegisterManager<'a> = PeripheralManager<'a, ClockSystem, NoClockControl>;
 
-pub struct ClockSystem {}
+pub struct ClockSystem {
+    registers: StaticRef<CsRegisters>,
+}
 
 impl ClockSystem {
-    const fn new() -> ClockSystem {
-        ClockSystem {}
+    pub const fn new() -> ClockSystem {
+        ClockSystem { registers: CS_BASE }
     }
 
     fn set_mclk_48mhz(&self) {
@@ -320,7 +320,7 @@ impl<'a> PeripheralManagement<NoClockControl> for ClockSystem {
     type RegisterType = CsRegisters;
 
     fn get_registers(&self) -> &CsRegisters {
-        &*CS_BASE
+        &self.registers
     }
 
     fn get_clock(&self) -> &NoClockControl {

--- a/chips/msp432/src/flctl.rs
+++ b/chips/msp432/src/flctl.rs
@@ -3,8 +3,6 @@
 use kernel::common::registers::{register_bitfields, register_structs, ReadOnly, ReadWrite};
 use kernel::common::StaticRef;
 
-pub static mut FLCTL: FlCtl = FlCtl::new();
-
 const FLCTL_BASE: StaticRef<FlCtlRegisters> =
     unsafe { StaticRef::new(0x4001_1000u32 as *const FlCtlRegisters) };
 
@@ -827,7 +825,7 @@ pub struct FlCtl {
 }
 
 impl FlCtl {
-    const fn new() -> FlCtl {
+    pub const fn new() -> FlCtl {
         FlCtl {
             registers: FLCTL_BASE,
         }

--- a/chips/msp432/src/gpio.rs
+++ b/chips/msp432/src/gpio.rs
@@ -7,100 +7,6 @@ use kernel::common::registers::{register_bitfields, register_structs, ReadOnly, 
 use kernel::common::StaticRef;
 use kernel::hil::gpio;
 
-pub static mut INT_PINS: [IntPin; 48] = [
-    IntPin::new(IntPinNr::P01_0),
-    IntPin::new(IntPinNr::P01_1),
-    IntPin::new(IntPinNr::P01_2),
-    IntPin::new(IntPinNr::P01_3),
-    IntPin::new(IntPinNr::P01_4),
-    IntPin::new(IntPinNr::P01_5),
-    IntPin::new(IntPinNr::P01_6),
-    IntPin::new(IntPinNr::P01_7),
-    IntPin::new(IntPinNr::P02_0),
-    IntPin::new(IntPinNr::P02_1),
-    IntPin::new(IntPinNr::P02_2),
-    IntPin::new(IntPinNr::P02_3),
-    IntPin::new(IntPinNr::P02_4),
-    IntPin::new(IntPinNr::P02_5),
-    IntPin::new(IntPinNr::P02_6),
-    IntPin::new(IntPinNr::P02_7),
-    IntPin::new(IntPinNr::P03_0),
-    IntPin::new(IntPinNr::P03_1),
-    IntPin::new(IntPinNr::P03_2),
-    IntPin::new(IntPinNr::P03_3),
-    IntPin::new(IntPinNr::P03_4),
-    IntPin::new(IntPinNr::P03_5),
-    IntPin::new(IntPinNr::P03_6),
-    IntPin::new(IntPinNr::P03_7),
-    IntPin::new(IntPinNr::P04_0),
-    IntPin::new(IntPinNr::P04_1),
-    IntPin::new(IntPinNr::P04_2),
-    IntPin::new(IntPinNr::P04_3),
-    IntPin::new(IntPinNr::P04_4),
-    IntPin::new(IntPinNr::P04_5),
-    IntPin::new(IntPinNr::P04_6),
-    IntPin::new(IntPinNr::P04_7),
-    IntPin::new(IntPinNr::P05_0),
-    IntPin::new(IntPinNr::P05_1),
-    IntPin::new(IntPinNr::P05_2),
-    IntPin::new(IntPinNr::P05_3),
-    IntPin::new(IntPinNr::P05_4),
-    IntPin::new(IntPinNr::P05_5),
-    IntPin::new(IntPinNr::P05_6),
-    IntPin::new(IntPinNr::P05_7),
-    IntPin::new(IntPinNr::P06_0),
-    IntPin::new(IntPinNr::P06_1),
-    IntPin::new(IntPinNr::P06_2),
-    IntPin::new(IntPinNr::P06_3),
-    IntPin::new(IntPinNr::P06_4),
-    IntPin::new(IntPinNr::P06_5),
-    IntPin::new(IntPinNr::P06_6),
-    IntPin::new(IntPinNr::P06_7),
-];
-
-pub static mut PINS: [Pin; 40] = [
-    Pin::new(PinNr::P07_0),
-    Pin::new(PinNr::P07_1),
-    Pin::new(PinNr::P07_2),
-    Pin::new(PinNr::P07_3),
-    Pin::new(PinNr::P07_4),
-    Pin::new(PinNr::P07_5),
-    Pin::new(PinNr::P07_6),
-    Pin::new(PinNr::P07_7),
-    Pin::new(PinNr::P08_0),
-    Pin::new(PinNr::P08_1),
-    Pin::new(PinNr::P08_2),
-    Pin::new(PinNr::P08_3),
-    Pin::new(PinNr::P08_4),
-    Pin::new(PinNr::P08_5),
-    Pin::new(PinNr::P08_6),
-    Pin::new(PinNr::P08_7),
-    Pin::new(PinNr::P09_0),
-    Pin::new(PinNr::P09_1),
-    Pin::new(PinNr::P09_2),
-    Pin::new(PinNr::P09_3),
-    Pin::new(PinNr::P09_4),
-    Pin::new(PinNr::P09_5),
-    Pin::new(PinNr::P09_6),
-    Pin::new(PinNr::P09_7),
-    Pin::new(PinNr::P10_0),
-    Pin::new(PinNr::P10_1),
-    Pin::new(PinNr::P10_2),
-    Pin::new(PinNr::P10_3),
-    Pin::new(PinNr::P10_4),
-    Pin::new(PinNr::P10_5),
-    Pin::new(PinNr::P10_6),
-    Pin::new(PinNr::P10_7),
-    Pin::new(PinNr::PJ_0),
-    Pin::new(PinNr::PJ_1),
-    Pin::new(PinNr::PJ_2),
-    Pin::new(PinNr::PJ_3),
-    Pin::new(PinNr::PJ_4),
-    Pin::new(PinNr::PJ_5),
-    Pin::new(PinNr::PJ_6),
-    Pin::new(PinNr::PJ_7),
-];
-
 const GPIO_BASES: [StaticRef<GpioRegisters>; 6] = [
     unsafe { StaticRef::new(0x4000_4C00u32 as *const GpioRegisters) }, // PORT 1&2
     unsafe { StaticRef::new(0x4000_4C20u32 as *const GpioRegisters) }, // PORT 3&4
@@ -297,6 +203,110 @@ enum ModuleFunction {
     Tertiary,
 }
 
+pub struct GpioManager<'a> {
+    pub int_pins: [IntPin<'a>; 48],
+    pub pins: [Pin<'a>; 40],
+}
+
+impl GpioManager<'_> {
+    pub fn new() -> Self {
+        Self {
+            int_pins: [
+                IntPin::new(IntPinNr::P01_0),
+                IntPin::new(IntPinNr::P01_1),
+                IntPin::new(IntPinNr::P01_2),
+                IntPin::new(IntPinNr::P01_3),
+                IntPin::new(IntPinNr::P01_4),
+                IntPin::new(IntPinNr::P01_5),
+                IntPin::new(IntPinNr::P01_6),
+                IntPin::new(IntPinNr::P01_7),
+                IntPin::new(IntPinNr::P02_0),
+                IntPin::new(IntPinNr::P02_1),
+                IntPin::new(IntPinNr::P02_2),
+                IntPin::new(IntPinNr::P02_3),
+                IntPin::new(IntPinNr::P02_4),
+                IntPin::new(IntPinNr::P02_5),
+                IntPin::new(IntPinNr::P02_6),
+                IntPin::new(IntPinNr::P02_7),
+                IntPin::new(IntPinNr::P03_0),
+                IntPin::new(IntPinNr::P03_1),
+                IntPin::new(IntPinNr::P03_2),
+                IntPin::new(IntPinNr::P03_3),
+                IntPin::new(IntPinNr::P03_4),
+                IntPin::new(IntPinNr::P03_5),
+                IntPin::new(IntPinNr::P03_6),
+                IntPin::new(IntPinNr::P03_7),
+                IntPin::new(IntPinNr::P04_0),
+                IntPin::new(IntPinNr::P04_1),
+                IntPin::new(IntPinNr::P04_2),
+                IntPin::new(IntPinNr::P04_3),
+                IntPin::new(IntPinNr::P04_4),
+                IntPin::new(IntPinNr::P04_5),
+                IntPin::new(IntPinNr::P04_6),
+                IntPin::new(IntPinNr::P04_7),
+                IntPin::new(IntPinNr::P05_0),
+                IntPin::new(IntPinNr::P05_1),
+                IntPin::new(IntPinNr::P05_2),
+                IntPin::new(IntPinNr::P05_3),
+                IntPin::new(IntPinNr::P05_4),
+                IntPin::new(IntPinNr::P05_5),
+                IntPin::new(IntPinNr::P05_6),
+                IntPin::new(IntPinNr::P05_7),
+                IntPin::new(IntPinNr::P06_0),
+                IntPin::new(IntPinNr::P06_1),
+                IntPin::new(IntPinNr::P06_2),
+                IntPin::new(IntPinNr::P06_3),
+                IntPin::new(IntPinNr::P06_4),
+                IntPin::new(IntPinNr::P06_5),
+                IntPin::new(IntPinNr::P06_6),
+                IntPin::new(IntPinNr::P06_7),
+            ],
+            pins: [
+                Pin::new(PinNr::P07_0),
+                Pin::new(PinNr::P07_1),
+                Pin::new(PinNr::P07_2),
+                Pin::new(PinNr::P07_3),
+                Pin::new(PinNr::P07_4),
+                Pin::new(PinNr::P07_5),
+                Pin::new(PinNr::P07_6),
+                Pin::new(PinNr::P07_7),
+                Pin::new(PinNr::P08_0),
+                Pin::new(PinNr::P08_1),
+                Pin::new(PinNr::P08_2),
+                Pin::new(PinNr::P08_3),
+                Pin::new(PinNr::P08_4),
+                Pin::new(PinNr::P08_5),
+                Pin::new(PinNr::P08_6),
+                Pin::new(PinNr::P08_7),
+                Pin::new(PinNr::P09_0),
+                Pin::new(PinNr::P09_1),
+                Pin::new(PinNr::P09_2),
+                Pin::new(PinNr::P09_3),
+                Pin::new(PinNr::P09_4),
+                Pin::new(PinNr::P09_5),
+                Pin::new(PinNr::P09_6),
+                Pin::new(PinNr::P09_7),
+                Pin::new(PinNr::P10_0),
+                Pin::new(PinNr::P10_1),
+                Pin::new(PinNr::P10_2),
+                Pin::new(PinNr::P10_3),
+                Pin::new(PinNr::P10_4),
+                Pin::new(PinNr::P10_5),
+                Pin::new(PinNr::P10_6),
+                Pin::new(PinNr::P10_7),
+                Pin::new(PinNr::PJ_0),
+                Pin::new(PinNr::PJ_1),
+                Pin::new(PinNr::PJ_2),
+                Pin::new(PinNr::PJ_3),
+                Pin::new(PinNr::PJ_4),
+                Pin::new(PinNr::PJ_5),
+                Pin::new(PinNr::PJ_6),
+                Pin::new(PinNr::PJ_7),
+            ],
+        }
+    }
+}
+
 /// Supports interrupts
 pub struct IntPin<'a> {
     pin: u8,
@@ -330,7 +340,7 @@ impl<'a> Pin<'a> {
 }
 
 impl<'a> IntPin<'a> {
-    const fn new(pin: IntPinNr) -> IntPin<'a> {
+    pub const fn new(pin: IntPinNr) -> IntPin<'a> {
         let pin_nr = (pin as u8) % PINS_PER_PORT;
         let p = (pin as u8) / PINS_PER_PORT;
         IntPin {
@@ -595,24 +605,24 @@ impl<'a> gpio::Interrupt<'a> for IntPin<'a> {
 
 impl<'a> gpio::InterruptPin<'a> for IntPin<'a> {}
 
-pub fn handle_interrupt(port_idx: usize) {
-    let regs: StaticRef<GpioRegisters> = GPIO_BASES[port_idx / 2];
-    let ifgs: [u8; 2] = [regs.ifg[0].get(), regs.ifg[1].get()];
+impl<'a> GpioManager<'a> {
+    pub fn handle_interrupt(&self, port_idx: usize) {
+        let regs: StaticRef<GpioRegisters> = GPIO_BASES[port_idx / 2];
+        let ifgs: [u8; 2] = [regs.ifg[0].get(), regs.ifg[1].get()];
 
-    let handle_int = |ifg_idx: usize, i: usize| {
-        let bit = 1 << i;
-        if (ifgs[ifg_idx] & bit) > 0 {
-            unsafe {
-                INT_PINS[(port_idx * 8) + i].handle_interrupt();
+        let handle_int = |ifg_idx: usize, i: usize| {
+            let bit = 1 << i;
+            if (ifgs[ifg_idx] & bit) > 0 {
+                self.int_pins[(port_idx * 8) + i].handle_interrupt();
+                // read back the current register value to avoid loosing interrupts which occured
+                // within this function
+                regs.ifg[ifg_idx].set(regs.ifg[ifg_idx].get() & !bit);
             }
-            // read back the current register value to avoid loosing interrupts which occured
-            // within this function
-            regs.ifg[ifg_idx].set(regs.ifg[ifg_idx].get() & !bit);
-        }
-    };
+        };
 
-    for i in 0..8 {
-        handle_int(0, i);
-        handle_int(1, i);
+        for i in 0..8 {
+            handle_int(0, i);
+            handle_int(1, i);
+        }
     }
 }

--- a/chips/msp432/src/lib.rs
+++ b/chips/msp432/src/lib.rs
@@ -19,7 +19,7 @@ pub mod ref_module;
 pub mod sysctl;
 pub mod timer;
 pub mod uart;
-pub(crate) mod usci;
+pub mod usci;
 pub mod wdt;
 
 extern "C" {

--- a/chips/msp432/src/pcm.rs
+++ b/chips/msp432/src/pcm.rs
@@ -5,8 +5,6 @@ use kernel::common::registers::{
 };
 use kernel::common::StaticRef;
 
-pub static mut PCM: Pcm = Pcm::new();
-
 const PCM_BASE: StaticRef<PcmRegisters> =
     unsafe { StaticRef::new(0x4001_0000 as *const PcmRegisters) };
 
@@ -171,7 +169,7 @@ pub struct Pcm {
 }
 
 impl Pcm {
-    const fn new() -> Pcm {
+    pub const fn new() -> Pcm {
         Pcm {
             registers: PCM_BASE,
         }

--- a/chips/msp432/src/ref_module.rs
+++ b/chips/msp432/src/ref_module.rs
@@ -4,8 +4,6 @@ use core::cell::Cell;
 use kernel::common::registers::{register_bitfields, register_structs, ReadWrite};
 use kernel::common::StaticRef;
 
-pub static mut REF: Ref = Ref::new();
-
 register_structs! {
     /// REF
     RefRegisters {
@@ -127,7 +125,7 @@ pub trait AnalogReference {
 }
 
 impl Ref {
-    const fn new() -> Ref {
+    pub const fn new() -> Ref {
         Ref {
             registers: REF_BASE,
             ref_voltage: Cell::new(ReferenceVoltage::Volt1_2),

--- a/chips/msp432/src/sysctl.rs
+++ b/chips/msp432/src/sysctl.rs
@@ -3,8 +3,6 @@
 use kernel::common::registers::{register_bitfields, register_structs, ReadOnly, ReadWrite};
 use kernel::common::StaticRef;
 
-pub static mut SYSCTL: SysCtl = SysCtl::new();
-
 const SYSCTL_BASE: StaticRef<SysCtlRegisters> =
     unsafe { StaticRef::new(0xE004_3000 as *const SysCtlRegisters) };
 
@@ -406,7 +404,7 @@ pub struct SysCtl {
 }
 
 impl SysCtl {
-    const fn new() -> SysCtl {
+    pub const fn new() -> SysCtl {
         SysCtl {
             registers: SYSCTL_BASE,
         }

--- a/chips/msp432/src/timer.rs
+++ b/chips/msp432/src/timer.rs
@@ -9,26 +9,21 @@ use kernel::hil::time::{
 };
 use kernel::ReturnCode;
 
-pub static mut TIMER_A0: TimerA = TimerA::new(TIMER_A0_BASE);
-pub static mut TIMER_A1: TimerA = TimerA::new(TIMER_A1_BASE);
-pub static mut TIMER_A2: TimerA = TimerA::new(TIMER_A2_BASE);
-pub static mut TIMER_A3: TimerA = TimerA::new(TIMER_A3_BASE);
-
-const TIMER_A0_BASE: StaticRef<TimerRegisters> =
+pub const TIMER_A0_BASE: StaticRef<TimerRegisters> =
     unsafe { StaticRef::new(0x4000_0000u32 as *const TimerRegisters) };
 
-const TIMER_A1_BASE: StaticRef<TimerRegisters> =
+pub const TIMER_A1_BASE: StaticRef<TimerRegisters> =
     unsafe { StaticRef::new(0x4000_0400u32 as *const TimerRegisters) };
 
-const TIMER_A2_BASE: StaticRef<TimerRegisters> =
+pub const TIMER_A2_BASE: StaticRef<TimerRegisters> =
     unsafe { StaticRef::new(0x4000_0800u32 as *const TimerRegisters) };
 
-const TIMER_A3_BASE: StaticRef<TimerRegisters> =
+pub const TIMER_A3_BASE: StaticRef<TimerRegisters> =
     unsafe { StaticRef::new(0x4000_0C00u32 as *const TimerRegisters) };
 
 register_structs! {
     /// Timer_Ax
-    TimerRegisters {
+    pub TimerRegisters {
         /// Timer_Ax Control
         (0x00 => ctl: ReadWrite<u16, TAxCTL::Register>),
         /// Timer_Ax Capture/Compare Control 0
@@ -268,7 +263,7 @@ pub struct TimerA<'a> {
 }
 
 impl<'a> TimerA<'a> {
-    const fn new(base: StaticRef<TimerRegisters>) -> TimerA<'a> {
+    pub const fn new(base: StaticRef<TimerRegisters>) -> TimerA<'a> {
         TimerA {
             registers: base,
             mode: Cell::new(TimerMode::Disabled),

--- a/chips/msp432/src/uart.rs
+++ b/chips/msp432/src/uart.rs
@@ -76,13 +76,14 @@ pub struct Uart<'a> {
 
 impl<'a> Uart<'a> {
     pub const fn new(
+        registers: StaticRef<UsciARegisters>,
         tx_dma_chan: usize,
         rx_dma_chan: usize,
         tx_dma_src: u8,
         rx_dma_src: u8,
     ) -> Self {
         Self {
-            registers: usci::USCI_A0_BASE,
+            registers,
             clock_frequency: DEFAULT_CLOCK_FREQ_HZ,
 
             tx_client: OptionalCell::empty(),

--- a/chips/msp432/src/uart.rs
+++ b/chips/msp432/src/uart.rs
@@ -9,8 +9,6 @@ use kernel::common::StaticRef;
 use kernel::hil;
 use kernel::ReturnCode;
 
-pub static mut UART0: Uart<'static> = Uart::new(usci::USCI_A0_BASE, 0, 1, 1, 1);
-
 const DEFAULT_CLOCK_FREQ_HZ: u32 = crate::cs::SMCLK_HZ;
 
 struct BaudFraction {
@@ -77,15 +75,14 @@ pub struct Uart<'a> {
 }
 
 impl<'a> Uart<'a> {
-    pub(crate) const fn new(
-        regs: StaticRef<UsciARegisters>,
+    pub const fn new(
         tx_dma_chan: usize,
         rx_dma_chan: usize,
         tx_dma_src: u8,
         rx_dma_src: u8,
-    ) -> Uart<'static> {
-        Uart {
-            registers: regs,
+    ) -> Self {
+        Self {
+            registers: usci::USCI_A0_BASE,
             clock_frequency: DEFAULT_CLOCK_FREQ_HZ,
 
             tx_client: OptionalCell::empty(),

--- a/chips/msp432/src/usci.rs
+++ b/chips/msp432/src/usci.rs
@@ -3,7 +3,7 @@
 use kernel::common::registers::{register_bitfields, register_structs, ReadOnly, ReadWrite};
 use kernel::common::StaticRef;
 
-pub(crate) const USCI_A0_BASE: StaticRef<UsciARegisters> =
+pub const USCI_A0_BASE: StaticRef<UsciARegisters> =
     unsafe { StaticRef::new(0x4000_1000 as *const UsciARegisters) };
 #[allow(dead_code)]
 pub(crate) const USCI_A1_BASE: StaticRef<UsciARegisters> =
@@ -29,7 +29,7 @@ pub(crate) const USCI_B3_BASE: StaticRef<UsciBRegisters> =
 
 register_structs! {
     /// EUSCI_Ax
-    pub(crate) UsciARegisters {
+    pub UsciARegisters {
         /// eUSCI_Ax Control Word Register 0
         (0x00 => pub(crate) ctlw0: ReadWrite<u16, UCAxCTLW0::Register>),
         /// eUSCI_Ax Control Word Register 1


### PR DESCRIPTION
### Pull Request Overview

This pull request ports the MSP432 chip/board to the new peripheral instantiation approach that does not rely on global variables (first proposed in #2069).

This chip was relatively easy to change compared to some of the others, but @lebakassemmerl I would still appreciate a quick look over the changes or a test of a couple apps to ensure I haven't done anything stupid.

This is the last remaining chip before all upstream chips/boards have been ported!


### Testing Strategy

This pull request was tested by compiling, hardware testing would be nice.


### TODO or Help Wanted

N/A

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
