### PR TITLE
tock-registers: release v0.6

### DIFF
--- a/libraries/tock-register-interface/CHANGELOG.md
+++ b/libraries/tock-register-interface/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## master
 
+## v0.6
+
+ - #2095: Fix syntax errors and inconsistencies in documentation
+ - #2071: Clarify bit widths in documentation examples
+ - #2015: Use UnsafeCell in registers (see issue #2005)
+ - #1939: Make the Field::mask and FieldValue::mask fields private
  - #1823: Allow large unsigned values as bitmasks + add bitmask! helper macro
  - #1554: Allow lifetime parameters for `register_structs! { Foo<'a> { ..`
  - #1661: Add `Aliased` register type for MMIO with differing R/W behavior

--- a/libraries/tock-register-interface/Cargo.toml
+++ b/libraries/tock-register-interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tock-registers"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
 description = "Memory-Mapped I/O and register interface developed for Tock."
 homepage = "https://www.tockos.org/"


### PR DESCRIPTION
Changes since v0.5:

 - #2095: Fix syntax errors and inconsistencies in documentation
 - #2071: Clarify bit widths in documentation examples
 - #2015: Use UnsafeCell in registers (see issue #2005)
 - #1939: Make the Field::mask and FieldValue::mask fields private
 - #1823: Allow large unsigned values as bitmasks + add bitmask! helper macro
 - #1554: Allow lifetime parameters for `register_structs! { Foo<'a> { ..`
 - #1661: Add `Aliased` register type for MMIO with differing R/W behavior

Thanks to @namyoonw, @brghena, @daboross, @gendx, @hudson-ayers, and @pfmooney
for contributions, fixes, and testing!

Closes #2138.

### Pull Request Overview

This PR updates the library version number and the changelog with all the major changes since v0.5.

I will push v0.6 to crates.io once this is merged.

### Testing Strategy

N/A.

### TODO or Help Wanted

N/A.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
