### PR TITLE
Clarify the semantics of erase_page

### DIFF
--- a/kernel/src/hil/flash.rs
+++ b/kernel/src/hil/flash.rs
@@ -127,7 +127,7 @@ pub trait Flash {
         buf: &'static mut Self::Page,
     ) -> Result<(), (ReturnCode, &'static mut Self::Page)>;
 
-    /// Erase a page of flash.
+    /// Erase a page of flash by setting every byte to 0xFF.
     fn erase_page(&self, page_number: usize) -> ReturnCode;
 }
 


### PR DESCRIPTION
### Pull Request Overview

Users of Tock would like to know that data is not being unintentionally leaked. This was not clear from the flash HIL originally, but is fixed now.

### Testing Strategy

Admittedly, there is an implied assumption that chips will actually zero out the page, but this seems like a reasonable one. I consulted @hudson-ayers on this one.

### Documentation Updated

No updates are required.

### Formatting

- [x] Ran `make prepush`.
