### PR TITLE
capsules/led: migrate from hil::gpio::Pin to hil::led::Led

### DIFF
--- a/boards/acd52832/src/io.rs
+++ b/boards/acd52832/src/io.rs
@@ -10,6 +10,6 @@ use nrf52832::gpio::Pin;
 #[panic_handler]
 pub unsafe extern "C" fn panic_fmt(_pi: &PanicInfo) -> ! {
     const LED1_PIN: Pin = Pin::P0_22;
-    let led = &mut led::LedLow::new(&mut nrf52832::gpio::PORT[LED1_PIN]);
+    let led = &mut led::LedLow::new(&nrf52832::gpio::PORT[LED1_PIN]);
     debug::panic_blink_forever(&mut [led])
 }

--- a/boards/arty_e21/src/main.rs
+++ b/boards/arty_e21/src/main.rs
@@ -51,7 +51,10 @@ struct ArtyE21 {
         'static,
         VirtualMuxAlarm<'static, rv32i::machine_timer::MachineTimer<'static>>,
     >,
-    led: &'static capsules::led::LED<'static, arty_e21_chip::gpio::GpioPin<'static>>,
+    led: &'static capsules::led::LedDriver<
+        'static,
+        hil::led::LedHigh<'static, arty_e21_chip::gpio::GpioPin<'static>>,
+    >,
     button: &'static capsules::button::Button<'static, arty_e21_chip::gpio::GpioPin<'static>>,
     // ipc: kernel::ipc::IPC,
 }
@@ -151,24 +154,14 @@ pub unsafe fn reset_handler() {
 
     // LEDs
     let led = components::led::LedsComponent::new(components::led_component_helper!(
-        arty_e21_chip::gpio::GpioPin,
-        (
-            // Red
-            &peripherals.gpio_port[2],
-            kernel::hil::gpio::ActivationMode::ActiveHigh
-        ),
-        (
-            // Green
-            &peripherals.gpio_port[1],
-            kernel::hil::gpio::ActivationMode::ActiveHigh
-        ),
-        (
-            // Blue
-            &peripherals.gpio_port[0],
-            kernel::hil::gpio::ActivationMode::ActiveHigh
-        )
+        hil::led::LedHigh<'static, arty_e21_chip::gpio::GpioPin>,
+        hil::led::LedHigh::new(&peripherals.gpio_port[2]), // Red
+        hil::led::LedHigh::new(&peripherals.gpio_port[1]), // Green
+        hil::led::LedHigh::new(&peripherals.gpio_port[0]), // Blue
     ))
-    .finalize(components::led_component_buf!(arty_e21_chip::gpio::GpioPin));
+    .finalize(components::led_component_buf!(
+        hil::led::LedHigh<'static, arty_e21_chip::gpio::GpioPin>
+    ));
 
     // BUTTONs
     let button = components::button::ButtonComponent::new(

--- a/boards/hail/src/io.rs
+++ b/boards/hail/src/io.rs
@@ -62,8 +62,8 @@ pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
     led_blue.enable_output();
     led_blue.set();
 
-    let mut red_pin = sam4l::gpio::GPIOPin::new(sam4l::gpio::Pin::PA13);
-    let led_red = &mut led::LedLow::new(&mut red_pin);
+    let red_pin = sam4l::gpio::GPIOPin::new(sam4l::gpio::Pin::PA13);
+    let led_red = &mut led::LedLow::new(&red_pin);
     let writer = &mut WRITER;
     debug::panic(
         &mut [led_red],

--- a/boards/hifive1/src/io.rs
+++ b/boards/hifive1/src/io.rs
@@ -53,13 +53,13 @@ pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
     gpio::Pin::make_output(&led_blue);
     gpio::Pin::set(&led_blue);
 
-    let mut led_red_pin = sifive::gpio::GpioPin::new(
+    let led_red_pin = sifive::gpio::GpioPin::new(
         e310x::gpio::GPIO0_BASE,
         sifive::gpio::pins::pin22,
         sifive::gpio::pins::pin22::SET,
         sifive::gpio::pins::pin22::CLEAR,
     );
-    let led_red = &mut led::LedLow::new(&mut led_red_pin);
+    let led_red = &mut led::LedLow::new(&led_red_pin);
     let writer = &mut WRITER;
 
     debug::panic(

--- a/boards/hifive1/src/main.rs
+++ b/boards/hifive1/src/main.rs
@@ -16,6 +16,7 @@ use kernel::capabilities;
 use kernel::common::dynamic_deferred_call::{DynamicDeferredCall, DynamicDeferredCallClientState};
 use kernel::component::Component;
 use kernel::hil;
+use kernel::hil::led::LedLow;
 use kernel::hil::time::Alarm;
 use kernel::Chip;
 use kernel::Platform;
@@ -53,7 +54,8 @@ pub static mut STACK_MEMORY: [u8; 0x900] = [0; 0x900];
 /// A structure representing this platform that holds references to all
 /// capsules for this platform. We've included an alarm and console.
 struct HiFive1 {
-    led: &'static capsules::led::LED<'static, sifive::gpio::GpioPin<'static>>,
+    led:
+        &'static capsules::led::LedDriver<'static, LedLow<'static, sifive::gpio::GpioPin<'static>>>,
     console: &'static capsules::console::Console<'static>,
     lldb: &'static capsules::low_level_debug::LowLevelDebug<
         'static,
@@ -137,21 +139,14 @@ pub unsafe fn reset_handler() {
 
     // LEDs
     let led = components::led::LedsComponent::new(components::led_component_helper!(
-        sifive::gpio::GpioPin,
-        (
-            &peripherals.gpio_port[22], // Red
-            kernel::hil::gpio::ActivationMode::ActiveLow
-        ),
-        (
-            &peripherals.gpio_port[19], // Green
-            kernel::hil::gpio::ActivationMode::ActiveLow
-        ),
-        (
-            &peripherals.gpio_port[21], // Blue
-            kernel::hil::gpio::ActivationMode::ActiveLow
-        )
+        LedLow<'static, sifive::gpio::GpioPin>,
+        LedLow::new(&peripherals.gpio_port[22]), // Red
+        LedLow::new(&peripherals.gpio_port[19]), // Green
+        LedLow::new(&peripherals.gpio_port[21]), // Blue
     ))
-    .finalize(components::led_component_buf!(sifive::gpio::GpioPin));
+    .finalize(components::led_component_buf!(
+        LedLow<'static, sifive::gpio::GpioPin>
+    ));
 
     peripherals
         .uart0

--- a/boards/imix/src/io.rs
+++ b/boards/imix/src/io.rs
@@ -54,8 +54,8 @@ impl IoWrite for Writer {
 #[no_mangle]
 #[panic_handler]
 pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
-    let mut led_pin = sam4l::gpio::GPIOPin::new(sam4l::gpio::Pin::PC22);
-    let led = &mut led::LedLow::new(&mut led_pin);
+    let led_pin = sam4l::gpio::GPIOPin::new(sam4l::gpio::Pin::PC22);
+    let led = &mut led::LedLow::new(&led_pin);
     let writer = &mut WRITER;
     debug::panic(
         &mut [led],

--- a/boards/imxrt1050-evkb/src/main.rs
+++ b/boards/imxrt1050-evkb/src/main.rs
@@ -13,6 +13,7 @@ use kernel::common::dynamic_deferred_call::{DynamicDeferredCall, DynamicDeferred
 use kernel::component::Component;
 use kernel::debug;
 use kernel::hil::gpio::Configure;
+use kernel::hil::led::LedLow;
 use kernel::Platform;
 use kernel::{create_capability, static_init};
 
@@ -72,7 +73,7 @@ struct Imxrt1050EVKB {
     console: &'static capsules::console::Console<'static>,
     gpio: &'static capsules::gpio::GPIO<'static, imxrt1050::gpio::Pin<'static>>,
     ipc: kernel::ipc::IPC,
-    led: &'static capsules::led::LED<'static, imxrt1050::gpio::Pin<'static>>,
+    led: &'static capsules::led::LedDriver<'static, LedLow<'static, imxrt1050::gpio::Pin<'static>>>,
     ninedof: &'static capsules::ninedof::NineDof<'static>,
 }
 
@@ -275,14 +276,11 @@ pub unsafe fn reset_handler() {
 
     // Clock to Port A is enabled in `set_pin_primary_functions()
     let led = components::led::LedsComponent::new(components::led_component_helper!(
-        imxrt1050::gpio::Pin<'static>,
-        (
-            imxrt1050::gpio::PinId::AdB0_09.get_pin().as_ref().unwrap(),
-            kernel::hil::gpio::ActivationMode::ActiveLow
-        )
+        LedLow<'static, imxrt1050::gpio::Pin<'static>>,
+        LedLow::new(imxrt1050::gpio::PinId::AdB0_09.get_pin().as_ref().unwrap()),
     ))
     .finalize(components::led_component_buf!(
-        imxrt1050::gpio::Pin<'static>
+        LedLow<'static, imxrt1050::gpio::Pin<'static>>
     ));
 
     // BUTTONs

--- a/boards/msp_exp432p401r/src/io.rs
+++ b/boards/msp_exp432p401r/src/io.rs
@@ -44,7 +44,7 @@ impl IoWrite for Uart {
 #[panic_handler]
 pub unsafe extern "C" fn panic_fmt(info: &PanicInfo) -> ! {
     const LED1_PIN: IntPinNr = IntPinNr::P01_0;
-    let led = &mut led::LedHigh::new(&mut msp432::gpio::INT_PINS[LED1_PIN as usize]);
+    let led = &mut led::LedHigh::new(&msp432::gpio::INT_PINS[LED1_PIN as usize]);
     let writer = &mut UART;
     let wdt = Wdt::new();
 

--- a/boards/msp_exp432p401r/src/main.rs
+++ b/boards/msp_exp432p401r/src/main.rs
@@ -44,7 +44,10 @@ pub static mut STACK_MEMORY: [u8; 0x1000] = [0; 0x1000];
 /// A structure representing this platform that holds references to all
 /// capsules for this platform.
 struct MspExp432P401R {
-    led: &'static capsules::led::LED<'static, msp432::gpio::IntPin<'static>>,
+    led: &'static capsules::led::LedDriver<
+        'static,
+        kernel::hil::led::LedHigh<'static, msp432::gpio::IntPin<'static>>,
+    >,
     console: &'static capsules::console::Console<'static>,
     button: &'static capsules::button::Button<'static, msp432::gpio::IntPin<'static>>,
     gpio: &'static capsules::gpio::GPIO<'static, msp432::gpio::IntPin<'static>>,
@@ -186,21 +189,20 @@ pub unsafe fn reset_handler() {
 
     // Setup LEDs
     let leds = components::led::LedsComponent::new(components::led_component_helper!(
-        msp432::gpio::IntPin,
-        (
-            &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P02_0 as usize],
-            kernel::hil::gpio::ActivationMode::ActiveHigh
+        kernel::hil::led::LedHigh<'static, msp432::gpio::IntPin>,
+        kernel::hil::led::LedHigh::new(
+            &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P02_0 as usize]
         ),
-        (
-            &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P02_1 as usize],
-            kernel::hil::gpio::ActivationMode::ActiveHigh
+        kernel::hil::led::LedHigh::new(
+            &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P02_1 as usize]
         ),
-        (
-            &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P02_2 as usize],
-            kernel::hil::gpio::ActivationMode::ActiveHigh
-        )
+        kernel::hil::led::LedHigh::new(
+            &msp432::gpio::INT_PINS[msp432::gpio::IntPinNr::P02_2 as usize]
+        ),
     ))
-    .finalize(components::led_component_buf!(msp432::gpio::IntPin));
+    .finalize(components::led_component_buf!(
+        kernel::hil::led::LedHigh<'static, msp432::gpio::IntPin>
+    ));
 
     // Setup user-GPIOs
     let gpio = GpioComponent::new(

--- a/boards/nano33ble/src/io.rs
+++ b/boards/nano33ble/src/io.rs
@@ -123,7 +123,7 @@ impl IoWrite for Writer {
 #[panic_handler]
 pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
     const LED_KERNEL_PIN: Pin = Pin::P0_13;
-    let led = &mut led::LedLow::new(&mut nrf52840::gpio::PORT[LED_KERNEL_PIN]);
+    let led = &mut led::LedLow::new(&nrf52840::gpio::PORT[LED_KERNEL_PIN]);
     let writer = &mut WRITER;
     debug::panic(
         &mut [led],

--- a/boards/nordic/nrf52840_dongle/src/io.rs
+++ b/boards/nordic/nrf52840_dongle/src/io.rs
@@ -55,7 +55,7 @@ impl IoWrite for Writer {
 pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
     // The nRF52840 Dongle LEDs (see back of board)
     const LED1_PIN: Pin = Pin::P0_06;
-    let led = &mut led::LedLow::new(&mut nrf52840::gpio::PORT[LED1_PIN]);
+    let led = &mut led::LedLow::new(&nrf52840::gpio::PORT[LED1_PIN]);
     let writer = &mut WRITER;
     debug::panic(
         &mut [led],

--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -13,6 +13,7 @@
 use capsules::virtual_alarm::VirtualMuxAlarm;
 use kernel::common::dynamic_deferred_call::{DynamicDeferredCall, DynamicDeferredCallClientState};
 use kernel::component::Component;
+use kernel::hil::led::LedLow;
 use kernel::hil::time::Counter;
 #[allow(unused_imports)]
 use kernel::{capabilities, create_capability, debug, debug_gpio, debug_verbose, static_init};
@@ -80,7 +81,10 @@ pub struct Platform {
     >,
     console: &'static capsules::console::Console<'static>,
     gpio: &'static capsules::gpio::GPIO<'static, nrf52840::gpio::GPIOPin<'static>>,
-    led: &'static capsules::led::LED<'static, nrf52840::gpio::GPIOPin<'static>>,
+    led: &'static capsules::led::LedDriver<
+        'static,
+        LedLow<'static, nrf52840::gpio::GPIOPin<'static>>,
+    >,
     rng: &'static capsules::rng::RngDriver<'static>,
     temp: &'static capsules::temperature::TemperatureSensor<'static>,
     ipc: kernel::ipc::IPC,
@@ -184,25 +188,15 @@ pub unsafe fn reset_handler() {
     .finalize(components::button_component_buf!(nrf52840::gpio::GPIOPin));
 
     let led = components::led::LedsComponent::new(components::led_component_helper!(
-        nrf52840::gpio::GPIOPin,
-        (
-            &base_peripherals.gpio_port[LED1_PIN],
-            kernel::hil::gpio::ActivationMode::ActiveLow
-        ),
-        (
-            &base_peripherals.gpio_port[LED2_R_PIN],
-            kernel::hil::gpio::ActivationMode::ActiveLow
-        ),
-        (
-            &base_peripherals.gpio_port[LED2_G_PIN],
-            kernel::hil::gpio::ActivationMode::ActiveLow
-        ),
-        (
-            &base_peripherals.gpio_port[LED2_B_PIN],
-            kernel::hil::gpio::ActivationMode::ActiveLow
-        )
+        LedLow<'static, nrf52840::gpio::GPIOPin>,
+        LedLow::new(&base_peripherals.gpio_port[LED1_PIN]),
+        LedLow::new(&base_peripherals.gpio_port[LED2_R_PIN]),
+        LedLow::new(&base_peripherals.gpio_port[LED2_G_PIN]),
+        LedLow::new(&base_peripherals.gpio_port[LED2_B_PIN]),
     ))
-    .finalize(components::led_component_buf!(nrf52840::gpio::GPIOPin));
+    .finalize(components::led_component_buf!(
+        LedLow<'static, nrf52840::gpio::GPIOPin>
+    ));
 
     let chip = static_init!(
         nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>,

--- a/boards/nordic/nrf52840dk/src/io.rs
+++ b/boards/nordic/nrf52840dk/src/io.rs
@@ -93,7 +93,7 @@ impl IoWrite for Writer {
 pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
     // The nRF52840DK LEDs (see back of board)
     const LED1_PIN: Pin = Pin::P0_13;
-    let led = &mut led::LedLow::new(&mut nrf52840::gpio::PORT[LED1_PIN]);
+    let led = &mut led::LedLow::new(&nrf52840::gpio::PORT[LED1_PIN]);
     let writer = &mut WRITER;
     debug::panic(
         &mut [led],

--- a/boards/nordic/nrf52dk/src/io.rs
+++ b/boards/nordic/nrf52dk/src/io.rs
@@ -55,7 +55,7 @@ impl IoWrite for Writer {
 pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
     // The nRF52 DK LEDs (see back of board)
     const LED1_PIN: Pin = Pin::P0_17;
-    let led = &mut led::LedLow::new(&mut nrf52832::gpio::PORT[LED1_PIN]);
+    let led = &mut led::LedLow::new(&nrf52832::gpio::PORT[LED1_PIN]);
     let writer = &mut WRITER;
     debug::panic(
         &mut [led],

--- a/boards/nucleo_f429zi/src/io.rs
+++ b/boards/nucleo_f429zi/src/io.rs
@@ -70,10 +70,10 @@ pub unsafe extern "C" fn panic_fmt(info: &PanicInfo) -> ! {
     let rcc = stm32f429zi::rcc::Rcc::new();
     let syscfg = stm32f429zi::syscfg::Syscfg::new(&rcc);
     let exti = stm32f429zi::exti::Exti::new(&syscfg);
-    let mut pin = stm32f429zi::gpio::Pin::new(PinId::PB07, &exti);
+    let pin = stm32f429zi::gpio::Pin::new(PinId::PB07, &exti);
     let gpio_ports = stm32f429zi::gpio::GpioPorts::new(&rcc, &exti);
     pin.set_ports_ref(&gpio_ports);
-    let led = &mut led::LedHigh::new(&mut pin);
+    let led = &mut led::LedHigh::new(&pin);
 
     let writer = &mut WRITER;
 

--- a/boards/nucleo_f446re/src/io.rs
+++ b/boards/nucleo_f446re/src/io.rs
@@ -70,10 +70,10 @@ pub unsafe extern "C" fn panic_fmt(info: &PanicInfo) -> ! {
     let rcc = stm32f446re::rcc::Rcc::new();
     let syscfg = stm32f446re::syscfg::Syscfg::new(&rcc);
     let exti = stm32f446re::exti::Exti::new(&syscfg);
-    let mut pin = stm32f446re::gpio::Pin::new(PinId::PA05, &exti);
+    let pin = stm32f446re::gpio::Pin::new(PinId::PA05, &exti);
     let gpio_ports = stm32f446re::gpio::GpioPorts::new(&rcc, &exti);
     pin.set_ports_ref(&gpio_ports);
-    let led = &mut led::LedHigh::new(&mut pin);
+    let led = &mut led::LedHigh::new(&pin);
 
     let writer = &mut WRITER;
 

--- a/boards/nucleo_f446re/src/main.rs
+++ b/boards/nucleo_f446re/src/main.rs
@@ -14,6 +14,7 @@ use kernel::capabilities;
 use kernel::common::dynamic_deferred_call::{DynamicDeferredCall, DynamicDeferredCallClientState};
 use kernel::component::Component;
 use kernel::hil::gpio::Configure;
+use kernel::hil::led::LedHigh;
 use kernel::Platform;
 use kernel::{create_capability, debug, static_init};
 use stm32f446re::interrupt_service::Stm32f446reDefaultPeripherals;
@@ -51,7 +52,10 @@ pub static mut STACK_MEMORY: [u8; 0x1000] = [0; 0x1000];
 struct NucleoF446RE {
     console: &'static capsules::console::Console<'static>,
     ipc: kernel::ipc::IPC,
-    led: &'static capsules::led::LED<'static, stm32f446re::gpio::Pin<'static>>,
+    led: &'static capsules::led::LedDriver<
+        'static,
+        LedHigh<'static, stm32f446re::gpio::Pin<'static>>,
+    >,
     button: &'static capsules::button::Button<'static, stm32f446re::gpio::Pin<'static>>,
     alarm: &'static capsules::alarm::AlarmDriver<
         'static,
@@ -269,13 +273,12 @@ pub unsafe fn reset_handler() {
 
     // Clock to Port A is enabled in `set_pin_primary_functions()`
     let led = components::led::LedsComponent::new(components::led_component_helper!(
-        stm32f446re::gpio::Pin,
-        (
-            gpio_ports.get_pin(stm32f446re::gpio::PinId::PA05).unwrap(),
-            kernel::hil::gpio::ActivationMode::ActiveHigh
-        )
+        LedHigh<'static, stm32f446re::gpio::Pin>,
+        LedHigh::new(gpio_ports.get_pin(stm32f446re::gpio::PinId::PA05).unwrap()),
     ))
-    .finalize(components::led_component_buf!(stm32f446re::gpio::Pin));
+    .finalize(components::led_component_buf!(
+        LedHigh<'static, stm32f446re::gpio::Pin>
+    ));
 
     // BUTTONs
     let button = components::button::ButtonComponent::new(

--- a/boards/opentitan/src/main.rs
+++ b/boards/opentitan/src/main.rs
@@ -16,6 +16,7 @@ use kernel::common::dynamic_deferred_call::{DynamicDeferredCall, DynamicDeferred
 use kernel::component::Component;
 use kernel::hil;
 use kernel::hil::i2c::I2CMaster;
+use kernel::hil::led::LedHigh;
 use kernel::hil::time::Alarm;
 use kernel::Chip;
 use kernel::Platform;
@@ -55,7 +56,10 @@ pub static mut STACK_MEMORY: [u8; 0x1000] = [0; 0x1000];
 /// A structure representing this platform that holds references to all
 /// capsules for this platform. We've included an alarm and console.
 struct OpenTitan {
-    led: &'static capsules::led::LED<'static, earlgrey::gpio::GpioPin<'static>>,
+    led: &'static capsules::led::LedDriver<
+        'static,
+        LedHigh<'static, earlgrey::gpio::GpioPin<'static>>,
+    >,
     gpio: &'static capsules::gpio::GPIO<'static, earlgrey::gpio::GpioPin<'static>>,
     console: &'static capsules::console::Console<'static>,
     alarm: &'static capsules::alarm::AlarmDriver<
@@ -145,41 +149,19 @@ pub unsafe fn reset_handler() {
     // LEDs
     // Start with half on and half off
     let led = components::led::LedsComponent::new(components::led_component_helper!(
-        earlgrey::gpio::GpioPin,
-        (
-            &peripherals.gpio_port[8],
-            kernel::hil::gpio::ActivationMode::ActiveHigh
-        ),
-        (
-            &peripherals.gpio_port[9],
-            kernel::hil::gpio::ActivationMode::ActiveHigh
-        ),
-        (
-            &peripherals.gpio_port[10],
-            kernel::hil::gpio::ActivationMode::ActiveHigh
-        ),
-        (
-            &peripherals.gpio_port[11],
-            kernel::hil::gpio::ActivationMode::ActiveHigh
-        ),
-        (
-            &peripherals.gpio_port[12],
-            kernel::hil::gpio::ActivationMode::ActiveHigh
-        ),
-        (
-            &peripherals.gpio_port[13],
-            kernel::hil::gpio::ActivationMode::ActiveHigh
-        ),
-        (
-            &peripherals.gpio_port[14],
-            kernel::hil::gpio::ActivationMode::ActiveHigh
-        ),
-        (
-            &peripherals.gpio_port[15],
-            kernel::hil::gpio::ActivationMode::ActiveHigh
-        )
+        LedHigh<'static, earlgrey::gpio::GpioPin>,
+        LedHigh::new(&peripherals.gpio_port[8]),
+        LedHigh::new(&peripherals.gpio_port[9]),
+        LedHigh::new(&peripherals.gpio_port[10]),
+        LedHigh::new(&peripherals.gpio_port[11]),
+        LedHigh::new(&peripherals.gpio_port[12]),
+        LedHigh::new(&peripherals.gpio_port[13]),
+        LedHigh::new(&peripherals.gpio_port[14]),
+        LedHigh::new(&peripherals.gpio_port[15]),
     ))
-    .finalize(components::led_component_buf!(earlgrey::gpio::GpioPin));
+    .finalize(components::led_component_buf!(
+        LedHigh<'static, earlgrey::gpio::GpioPin>
+    ));
 
     let gpio = components::gpio::GpioComponent::new(
         board_kernel,

--- a/boards/stm32f3discovery/src/io.rs
+++ b/boards/stm32f3discovery/src/io.rs
@@ -68,10 +68,10 @@ pub unsafe extern "C" fn panic_fmt(info: &PanicInfo) -> ! {
     let rcc = stm32f303xc::rcc::Rcc::new();
     let syscfg = stm32f303xc::syscfg::Syscfg::new(&rcc);
     let exti = stm32f303xc::exti::Exti::new(&syscfg);
-    let mut pin = stm32f303xc::gpio::Pin::new(PinId::PE09, &exti);
+    let pin = stm32f303xc::gpio::Pin::new(PinId::PE09, &exti);
     let gpio_ports = stm32f303xc::gpio::GpioPorts::new(&rcc, &exti);
     pin.set_ports_ref(&gpio_ports);
-    let led = &mut led::LedHigh::new(&mut pin);
+    let led = &mut led::LedHigh::new(&pin);
     let writer = &mut WRITER;
 
     debug::panic(

--- a/boards/stm32f3discovery/src/main.rs
+++ b/boards/stm32f3discovery/src/main.rs
@@ -17,6 +17,7 @@ use kernel::common::dynamic_deferred_call::{DynamicDeferredCall, DynamicDeferred
 use kernel::component::Component;
 use kernel::hil::gpio::Configure;
 use kernel::hil::gpio::Output;
+use kernel::hil::led::LedHigh;
 use kernel::hil::time::Counter;
 use kernel::Platform;
 use kernel::{create_capability, debug, static_init};
@@ -55,7 +56,10 @@ struct STM32F3Discovery {
     console: &'static capsules::console::Console<'static>,
     ipc: kernel::ipc::IPC,
     gpio: &'static capsules::gpio::GPIO<'static, stm32f303xc::gpio::Pin<'static>>,
-    led: &'static capsules::led::LED<'static, stm32f303xc::gpio::Pin<'static>>,
+    led: &'static capsules::led::LedDriver<
+        'static,
+        LedHigh<'static, stm32f303xc::gpio::Pin<'static>>,
+    >,
     button: &'static capsules::button::Button<'static, stm32f303xc::gpio::Pin<'static>>,
     ninedof: &'static capsules::ninedof::NineDof<'static>,
     l3gd20: &'static capsules::l3gd20::L3gd20Spi<'static>,
@@ -389,66 +393,58 @@ pub unsafe fn reset_handler() {
     // Clock to Port E is enabled in `set_pin_primary_functions()`
 
     let led = components::led::LedsComponent::new(components::led_component_helper!(
-        stm32f303xc::gpio::Pin<'static>,
-        (
+        LedHigh<'static, stm32f303xc::gpio::Pin<'static>>,
+        LedHigh::new(
             &peripherals
                 .gpio_ports
                 .get_pin(stm32f303xc::gpio::PinId::PE09)
-                .unwrap(),
-            kernel::hil::gpio::ActivationMode::ActiveHigh
+                .unwrap()
         ),
-        (
+        LedHigh::new(
             &peripherals
                 .gpio_ports
                 .get_pin(stm32f303xc::gpio::PinId::PE08)
-                .unwrap(),
-            kernel::hil::gpio::ActivationMode::ActiveHigh
+                .unwrap()
         ),
-        (
+        LedHigh::new(
             &peripherals
                 .gpio_ports
                 .get_pin(stm32f303xc::gpio::PinId::PE10)
-                .unwrap(),
-            kernel::hil::gpio::ActivationMode::ActiveHigh
+                .unwrap()
         ),
-        (
+        LedHigh::new(
             &peripherals
                 .gpio_ports
                 .get_pin(stm32f303xc::gpio::PinId::PE15)
-                .unwrap(),
-            kernel::hil::gpio::ActivationMode::ActiveHigh
+                .unwrap()
         ),
-        (
+        LedHigh::new(
             &peripherals
                 .gpio_ports
                 .get_pin(stm32f303xc::gpio::PinId::PE11)
-                .unwrap(),
-            kernel::hil::gpio::ActivationMode::ActiveHigh
+                .unwrap()
         ),
-        (
+        LedHigh::new(
             &peripherals
                 .gpio_ports
                 .get_pin(stm32f303xc::gpio::PinId::PE14)
-                .unwrap(),
-            kernel::hil::gpio::ActivationMode::ActiveHigh
+                .unwrap()
         ),
-        (
+        LedHigh::new(
             &peripherals
                 .gpio_ports
                 .get_pin(stm32f303xc::gpio::PinId::PE12)
-                .unwrap(),
-            kernel::hil::gpio::ActivationMode::ActiveHigh
+                .unwrap()
         ),
-        (
+        LedHigh::new(
             &peripherals
                 .gpio_ports
                 .get_pin(stm32f303xc::gpio::PinId::PE13)
-                .unwrap(),
-            kernel::hil::gpio::ActivationMode::ActiveHigh
-        )
+                .unwrap()
+        ),
     ))
     .finalize(components::led_component_buf!(
-        stm32f303xc::gpio::Pin<'static>
+        LedHigh<'static, stm32f303xc::gpio::Pin<'static>>
     ));
 
     // BUTTONs

--- a/boards/stm32f412gdiscovery/src/io.rs
+++ b/boards/stm32f412gdiscovery/src/io.rs
@@ -70,10 +70,10 @@ pub unsafe extern "C" fn panic_fmt(info: &PanicInfo) -> ! {
     let rcc = stm32f412g::rcc::Rcc::new();
     let syscfg = stm32f412g::syscfg::Syscfg::new(&rcc);
     let exti = stm32f412g::exti::Exti::new(&syscfg);
-    let mut pin = stm32f412g::gpio::Pin::new(PinId::PE02, &exti);
+    let pin = stm32f412g::gpio::Pin::new(PinId::PE02, &exti);
     let gpio_ports = stm32f412g::gpio::GpioPorts::new(&rcc, &exti);
     pin.set_ports_ref(&gpio_ports);
-    let led = &mut led::LedHigh::new(&mut pin);
+    let led = &mut led::LedHigh::new(&pin);
     let writer = &mut WRITER;
 
     debug::panic(

--- a/kernel/src/hil/led.rs
+++ b/kernel/src/hil/led.rs
@@ -16,22 +16,22 @@ pub trait Led {
 
 /// For LEDs in which on is when GPIO is high.
 pub struct LedHigh<'a, P: gpio::Pin> {
-    pub pin: &'a mut P,
+    pub pin: &'a P,
 }
 
 /// For LEDs in which on is when GPIO is low.
 pub struct LedLow<'a, P: gpio::Pin> {
-    pub pin: &'a mut P,
+    pub pin: &'a P,
 }
 
 impl<'a, P: gpio::Pin> LedHigh<'a, P> {
-    pub fn new(p: &'a mut P) -> Self {
+    pub fn new(p: &'a P) -> Self {
         Self { pin: p }
     }
 }
 
 impl<'a, P: gpio::Pin> LedLow<'a, P> {
-    pub fn new(p: &'a mut P) -> Self {
+    pub fn new(p: &'a P) -> Self {
         Self { pin: p }
     }
 }


### PR DESCRIPTION
### Pull Request Overview

This pull request
- changes the LED driver capsule to use the trait `hil::led::Led` instead of `hil::gpio::Pin`
- renames the LED driver capsule from `LED` to `LedDriver`, to disambiguate it from the `Led` trait
- changes the `LedHigh` and `LedLow` wrappers to use immutable references of `hil::gpio::Pin` structs, as `Pin`s don't require mutable references for mutation and this would otherwise break reference handling in some board files
- updates the led component to take instances of `hil::led::Led`
  - makes the variadic `led_component_helper!` interface accept trailing commas
- updates the boards accommodating for these changes

These changes are done as I'm porting to a board which has a dedicated LED controller. Technically the LEDs are therefore not connected to GPIOs. I would still like to expose them to userspace though. These changes seem reasonable, since in the future one might want to support shift registers, dedicated LED driver chips or chained LEDs through the driver.

Implications:
- In this implementation, the `LedDriver` is made generic over a specific `hil::led::Led` type. As the LED polarity is encoded in the wrapper types, this makes it impossible to operate LEDs that are active-low and active-high through the same driver.

  This can be solved in two ways
  - use `dyn hil::led::Led` in the `LedDriver`: this will make all calls go through a vtable lookup and has a runtime performance impact for all boards
  - create a `DynLed<'a>` wrapper in `kernel/hil/led.rs` that wraps a `&'a mut dyn hil::led::Led`, which can then be used as the generic type for `LedDriver`

    This approach is essentially the same as the first one, but only boards which had the requirement of using different `hil::led::Led` types would go through the vtable lookup. It would add one level of indirection for these boards though, and the amount of initialization code for the boards would increase.
  
- This changeset should not have any (significant) runtime performance or code size impact. The `LedHigh` and `LedLow` wrappers are essentially zero-sized. This does add another layer of references, as each GPIO wrapper has to be statically allocated and calls go through a reference.

### Testing Strategy

This pull request was tested by
- the blink example on an nRF52840DK
- the blink example on an nRF52840DK with `LedHigh`, to confirm that the pattern is inverted

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.

Requesting a review of @hudson-ayers because of changes to the component and macros.