### PR TITLE
tock-registers: accept trailing comma in bitfields and bitmasks

### DIFF
--- a/libraries/tock-register-interface/src/macros.rs
+++ b/libraries/tock-register-interface/src/macros.rs
@@ -15,7 +15,7 @@ macro_rules! register_bitmasks {
         // BITFIELD_NAME OFFSET(x)
         $(#[$outer:meta])*
         $valtype:ident, $reg_desc:ident, [
-            $( $(#[$inner:meta])* $field:ident OFFSET($offset:expr)),+
+            $( $(#[$inner:meta])* $field:ident OFFSET($offset:expr)),+ $(,)?
         ]
     } => {
         $(#[$outer])*
@@ -26,7 +26,7 @@ macro_rules! register_bitmasks {
         // All fields are 1 bit
         $(#[$outer:meta])*
         $valtype:ident, $reg_desc:ident, [
-            $( $(#[$inner:meta])* $field:ident $offset:expr ),+
+            $( $(#[$inner:meta])* $field:ident $offset:expr ),+ $(,)?
         ]
     } => {
         $(#[$outer])*
@@ -37,7 +37,7 @@ macro_rules! register_bitmasks {
         // BITFIELD_NAME OFFSET(x) NUMBITS(y)
         $(#[$outer:meta])*
         $valtype:ident, $reg_desc:ident, [
-            $( $(#[$inner:meta])* $field:ident OFFSET($offset:expr) NUMBITS($numbits:expr) ),+
+            $( $(#[$inner:meta])* $field:ident OFFSET($offset:expr) NUMBITS($numbits:expr) ),+ $(,)?
         ]
     } => {
         $(#[$outer])*
@@ -49,7 +49,7 @@ macro_rules! register_bitmasks {
         $(#[$outer:meta])*
         $valtype:ident, $reg_desc:ident, [
             $( $(#[$inner:meta])* $field:ident OFFSET($offset:expr) NUMBITS($numbits:expr)
-               $values:tt ),+
+               $values:tt ),+ $(,)?
         ]
     } => {
         $(#[$outer])*
@@ -59,7 +59,7 @@ macro_rules! register_bitmasks {
     {
         $valtype:ident, $reg_desc:ident, $(#[$outer:meta])* $field:ident,
                     $offset:expr, $numbits:expr,
-                    [$( $(#[$inner:meta])* $valname:ident = $value:expr ),+]
+                    [$( $(#[$inner:meta])* $valname:ident = $value:expr ),+ $(,)?]
     } => { // this match arm is duplicated below with an allowance for 0 elements in the valname -> value array,
         // to seperately support the case of zero-variant enums not supporting non-default
         // representations.
@@ -174,7 +174,7 @@ macro_rules! register_bitmasks {
 #[macro_export]
 macro_rules! register_bitfields {
     {
-        $valtype:ident, $( $(#[$inner:meta])* $vis:vis $reg:ident $fields:tt ),*
+        $valtype:ident, $( $(#[$inner:meta])* $vis:vis $reg:ident $fields:tt ),* $(,)?
     } => {
         $(
             #[allow(non_snake_case)]


### PR DESCRIPTION
### Pull Request Overview

This pull request changes the macro rules to accept one trailing comma at the end of the `register_bitfields` and `register_bitmasks`-macro variadic arguments interfaces.

This is not a deal breaker, but an error I've done countless number of times. (For me) It's intuitive to write the trailing comma in lists which span multiple lines and it's generally valid in Rust syntax. Also, having a trailing comma prevents the macro from expanding, which Rusts treats as if it wasn't called, so the compiler output is flooded with subsequent errors. Changing the syntax to accept the comma seems appropriate.

With this change, the syntax is accepted:
```
register_bitfields![u32,
    TESTREG [
        TESTBIT OFFSET(7) NUMBITS(1) [
            TestStateA = 0,
            TestStateB = 1,
        ],
    ],
];
```


This pull request was tested by compiling with trailing commas.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.


