### PR TITLE
OpenTitan-Earlgrey: Integrate TickFS into Tock

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ members = [
     "libraries/tock-cells",
     "libraries/tock-register-interface",
     "libraries/tock-rt0",
+    "libraries/tickfs",
 ]
 exclude = [
     "tools/alert_codes",

--- a/boards/components/src/kv_store.rs
+++ b/boards/components/src/kv_store.rs
@@ -1,0 +1,141 @@
+//! Component for non-volatile storage Drivers.
+//!
+//! This provides one component, KVStoreComponent, which provides
+//! a system call inteface to non-volatile storage.
+//!
+//! Usage
+//! -----
+//! ```rust
+//! let nonvolatile_storage = components::nonvolatile_storage::KVStoreComponent::new(
+//!     board_kernel,
+//!     &sam4l::flashcalw::FLASH_CONTROLLER,
+//!     0x60000,
+//!     0x20000,
+//!     &_sstorage as *const u8 as usize,
+//!     &_estorage as *const u8 as usize,
+//! )
+//! .finalize(components::nv_storage_component_helper!(
+//!     sam4l::flashcalw::FLASHCALW
+//! ));
+//! ```
+
+use capsules::kv_store::KVStoreDriver;
+use capsules::virtual_flash::FlashUser;
+use capsules::virtual_flash::MuxFlash;
+use core::mem::MaybeUninit;
+use kernel::capabilities;
+use kernel::component::Component;
+use kernel::create_capability;
+use kernel::hil;
+use kernel::hil::flash::HasClient;
+use kernel::static_init_half;
+
+// Setup static space for the objects.
+#[macro_export]
+macro_rules! flash_user_component_helper {
+    ($F:ty) => {{
+        use capsules::virtual_flash::MuxFlash;
+        use core::mem::MaybeUninit;
+        static mut BUF1: MaybeUninit<MuxFlash<'static, $F>> = MaybeUninit::uninit();
+        &mut BUF1
+    };};
+}
+
+pub struct FlashMuxComponent<F: 'static + hil::flash::Flash> {
+    flash: &'static F,
+}
+
+impl<F: 'static + hil::flash::Flash> FlashMuxComponent<F> {
+    pub fn new(flash: &'static F) -> FlashMuxComponent<F> {
+        FlashMuxComponent { flash }
+    }
+}
+
+impl<F: 'static + hil::flash::Flash> Component for FlashMuxComponent<F> {
+    type StaticInput = &'static mut MaybeUninit<MuxFlash<'static, F>>;
+    type Output = &'static MuxFlash<'static, F>;
+
+    unsafe fn finalize(self, s: Self::StaticInput) -> Self::Output {
+        let mux_flash = static_init_half!(s, MuxFlash<'static, F>, MuxFlash::new(self.flash));
+
+        mux_flash
+    }
+}
+
+// Setup static space for the objects.
+#[macro_export]
+macro_rules! kv_store_component_helper {
+    ($F:ty) => {{
+        use capsules::kv_store::KVStoreDriver;
+        use capsules::virtual_flash::FlashUser;
+        use core::mem::MaybeUninit;
+        use kernel::hil;
+        static mut BUF1: MaybeUninit<FlashUser<'static, $F>> = MaybeUninit::uninit();
+        static mut BUF2: MaybeUninit<KVStoreDriver<'static, FlashUser<'static, $F>>> =
+            MaybeUninit::uninit();
+        (&mut BUF1, &mut BUF2)
+    };};
+}
+
+pub struct KVStoreComponent<F: 'static + hil::flash::Flash> {
+    board_kernel: &'static kernel::Kernel,
+    mux_flash: &'static MuxFlash<'static, F>,
+    region_offset: usize,
+    length: usize,
+    read_buf: &'static mut [u8],
+    page_buffer: &'static mut F::Page,
+}
+
+impl<F: 'static + hil::flash::Flash> KVStoreComponent<F> {
+    pub fn new(
+        board_kernel: &'static kernel::Kernel,
+        mux_flash: &'static MuxFlash<'static, F>,
+        region_offset: usize,
+        length: usize,
+        read_buf: &'static mut [u8],
+        page_buffer: &'static mut F::Page,
+    ) -> Self {
+        Self {
+            board_kernel,
+            mux_flash,
+            region_offset,
+            length,
+            read_buf,
+            page_buffer,
+        }
+    }
+}
+
+impl<F: 'static + hil::flash::Flash> Component for KVStoreComponent<F> {
+    type StaticInput = (
+        &'static mut MaybeUninit<FlashUser<'static, F>>,
+        &'static mut MaybeUninit<KVStoreDriver<'static, FlashUser<'static, F>>>,
+    );
+    type Output = &'static KVStoreDriver<'static, FlashUser<'static, F>>;
+
+    unsafe fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
+        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
+
+        let virtual_flash = static_init_half!(
+            static_buffer.0,
+            FlashUser<'static, F>,
+            FlashUser::new(self.mux_flash)
+        );
+
+        let driver = static_init_half!(
+            static_buffer.1,
+            KVStoreDriver<'static, FlashUser<'static, F>>,
+            KVStoreDriver::new(
+                virtual_flash,
+                self.board_kernel.create_grant(&grant_cap),
+                self.read_buf,
+                self.length,
+                self.page_buffer,
+                self.region_offset,
+            )
+        );
+        virtual_flash.set_client(driver);
+        driver.initalise();
+        driver
+    }
+}

--- a/boards/components/src/kv_store.rs
+++ b/boards/components/src/kv_store.rs
@@ -81,9 +81,10 @@ pub struct KVStoreComponent<F: 'static + hil::flash::Flash> {
     board_kernel: &'static kernel::Kernel,
     mux_flash: &'static MuxFlash<'static, F>,
     region_offset: usize,
-    length: usize,
-    read_buf: &'static mut [u8],
-    page_buffer: &'static mut F::Page,
+    tickfs_read_buf: &'static mut [u8; 512],
+    flash_read_buffer: &'static mut F::Page,
+    static_key_buf: &'static mut [u8; 64],
+    static_value_buf: &'static mut [u8; 64],
 }
 
 impl<F: 'static + hil::flash::Flash> KVStoreComponent<F> {
@@ -91,17 +92,19 @@ impl<F: 'static + hil::flash::Flash> KVStoreComponent<F> {
         board_kernel: &'static kernel::Kernel,
         mux_flash: &'static MuxFlash<'static, F>,
         region_offset: usize,
-        length: usize,
-        read_buf: &'static mut [u8],
-        page_buffer: &'static mut F::Page,
+        tickfs_read_buf: &'static mut [u8; 512],
+        flash_read_buffer: &'static mut F::Page,
+        static_key_buf: &'static mut [u8; 64],
+        static_value_buf: &'static mut [u8; 64],
     ) -> Self {
         Self {
             board_kernel,
             mux_flash,
             region_offset,
-            length,
-            read_buf,
-            page_buffer,
+            tickfs_read_buf,
+            flash_read_buffer,
+            static_key_buf,
+            static_value_buf,
         }
     }
 }
@@ -128,10 +131,11 @@ impl<F: 'static + hil::flash::Flash> Component for KVStoreComponent<F> {
             KVStoreDriver::new(
                 virtual_flash,
                 self.board_kernel.create_grant(&grant_cap),
-                self.read_buf,
-                self.length,
-                self.page_buffer,
+                self.tickfs_read_buf,
+                self.flash_read_buffer,
                 self.region_offset,
+                self.static_key_buf,
+                self.static_value_buf,
             )
         );
         virtual_flash.set_client(driver);

--- a/boards/components/src/lib.rs
+++ b/boards/components/src/lib.rs
@@ -19,6 +19,7 @@ pub mod hmac;
 pub mod i2c;
 pub mod ieee802154;
 pub mod isl29035;
+pub mod kv_store;
 pub mod l3gd20;
 pub mod led;
 pub mod lldb;

--- a/boards/earlgrey-nexysvideo/src/main.rs
+++ b/boards/earlgrey-nexysvideo/src/main.rs
@@ -8,6 +8,7 @@
 #![cfg_attr(not(doc), no_main)]
 
 use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
+use capsules::virtual_flash::FlashUser;
 use capsules::virtual_hmac::VirtualMuxHmac;
 use earlgrey::chip::EarlGreyDefaultPeripherals;
 use kernel::capabilities;
@@ -75,7 +76,10 @@ struct EarlGreyNexysVideo {
         capsules::virtual_uart::UartDevice<'static>,
     >,
     i2c_master: &'static capsules::i2c_master::I2CMasterDriver<lowrisc::i2c::I2c<'static>>,
-    nonvolatile_storage: &'static capsules::nonvolatile_storage_driver::NonvolatileStorage<'static>,
+    kvstore: &'static capsules::kv_store::KVStoreDriver<
+        'static,
+        FlashUser<'static, lowrisc::flash_ctrl::FlashCtrl<'static>>,
+    >,
 }
 
 /// Mapping of integer syscalls to objects that implement syscalls.
@@ -92,7 +96,7 @@ impl Platform for EarlGreyNexysVideo {
             capsules::alarm::DRIVER_NUM => f(Some(self.alarm)),
             capsules::low_level_debug::DRIVER_NUM => f(Some(self.lldb)),
             capsules::i2c_master::DRIVER_NUM => f(Some(self.i2c_master)),
-            capsules::nonvolatile_storage_driver::DRIVER_NUM => f(Some(self.nonvolatile_storage)),
+            capsules::kv_store::DRIVER_NUM => f(Some(self.kvstore)),
             _ => f(None),
         }
     }
@@ -274,17 +278,31 @@ pub unsafe fn reset_handler() {
     }
 
     // Flash
-    let nonvolatile_storage = components::nonvolatile_storage::NonvolatileStorageComponent::new(
+    let flash_ctrl_read_buf = static_init!(
+        [u8; lowrisc::flash_ctrl::PAGE_SIZE],
+        [0; lowrisc::flash_ctrl::PAGE_SIZE]
+    );
+    let page_buffer = static_init!(
+        lowrisc::flash_ctrl::LowRiscPage,
+        lowrisc::flash_ctrl::LowRiscPage::default()
+    );
+
+    let mux_flash = components::kv_store::FlashMuxComponent::new(&peripherals.flash_ctrl).finalize(
+        components::flash_user_component_helper!(lowrisc::flash_ctrl::FlashCtrl),
+    );
+
+    let kvstore = components::kv_store::KVStoreComponent::new(
         board_kernel,
-        &peripherals.flash_ctrl,
-        0x20000000,                       // Start address for userspace accessible region
-        0x8000,                           // Length of userspace accessible region
-        &_sstorage as *const u8 as usize, // Start address of kernel region
-        &_estorage as *const u8 as usize - &_sstorage as *const u8 as usize, // Length of kernel region
+        &mux_flash,
+        0x20040000 / lowrisc::flash_ctrl::PAGE_SIZE,
+        0x10000, // Length of region
+        flash_ctrl_read_buf,
+        page_buffer,
     )
-    .finalize(components::nv_storage_component_helper!(
+    .finalize(components::kv_store_component_helper!(
         lowrisc::flash_ctrl::FlashCtrl
     ));
+    hil::flash::HasClient::set_client(&peripherals.flash_ctrl, mux_flash);
 
     /// These symbols are defined in the linker script.
     extern "C" {
@@ -306,7 +324,7 @@ pub unsafe fn reset_handler() {
         hmac,
         lldb: lldb,
         i2c_master,
-        nonvolatile_storage,
+        kvstore,
     };
 
     kernel::procs::load_processes(

--- a/boards/earlgrey-nexysvideo/src/main.rs
+++ b/boards/earlgrey-nexysvideo/src/main.rs
@@ -286,6 +286,8 @@ pub unsafe fn reset_handler() {
         lowrisc::flash_ctrl::LowRiscPage,
         lowrisc::flash_ctrl::LowRiscPage::default()
     );
+    let static_key_buf = static_init!([u8; 64], [0; 64]);
+    let static_value_buf = static_init!([u8; 64], [0; 64]);
 
     let mux_flash = components::kv_store::FlashMuxComponent::new(&peripherals.flash_ctrl).finalize(
         components::flash_user_component_helper!(lowrisc::flash_ctrl::FlashCtrl),
@@ -295,9 +297,10 @@ pub unsafe fn reset_handler() {
         board_kernel,
         &mux_flash,
         0x20040000 / lowrisc::flash_ctrl::PAGE_SIZE,
-        0x10000, // Length of region
         flash_ctrl_read_buf,
         page_buffer,
+        static_key_buf,
+        static_value_buf,
     )
     .finalize(components::kv_store_component_helper!(
         lowrisc::flash_ctrl::FlashCtrl

--- a/capsules/Cargo.toml
+++ b/capsules/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2018"
 [dependencies]
 kernel = { path = "../kernel" }
 enum_primitive = { path = "../libraries/enum_primitive" }
+tickfs = { path = "../libraries/tickfs" }

--- a/capsules/src/driver.rs
+++ b/capsules/src/driver.rs
@@ -42,6 +42,7 @@ pub enum NUM {
     AppFlash              = 0x50000,
     NvmStorage            = 0x50001,
     SdCard                = 0x50002,
+    KVStore               = 0x50003,
 
     // Sensors
     Temperature           = 0x60000,

--- a/capsules/src/kv_store.rs
+++ b/capsules/src/kv_store.rs
@@ -1,0 +1,445 @@
+//! TODO
+
+use crate::driver;
+/// Syscall driver number.
+pub const DRIVER_NUM: usize = driver::NUM::KVStore as usize;
+
+use core::cell::Cell;
+use core::hash::SipHasher;
+use kernel::common::cells::{OptionalCell, TakeCell};
+use kernel::hil::flash::{self, Client, Flash};
+use kernel::{AppId, AppSlice, Callback, Driver, Grant, ReturnCode, Shared};
+use tickfs;
+use tickfs::TickFS;
+
+#[derive(Clone, Copy)]
+enum State {
+    None,
+    ReadComplete(isize),
+    WriteComplete,
+    EraseComplete(usize),
+}
+
+#[derive(Clone, Copy)]
+enum Operation {
+    None,
+    Init,
+    GetKey,
+}
+
+pub struct TickFSFlastCtrl<'a, F: Flash + 'static> {
+    flash: &'a F,
+    data_buffer: TakeCell<'static, F::Page>,
+    state: Cell<State>,
+    region_offset: usize,
+}
+
+impl<'a, F: Flash> TickFSFlastCtrl<'a, F> {
+    pub fn new(
+        flash: &'a F,
+        data_buffer: &'static mut F::Page,
+        region_offset: usize,
+    ) -> TickFSFlastCtrl<'a, F> {
+        Self {
+            flash,
+            data_buffer: TakeCell::new(data_buffer),
+            state: Cell::new(State::None),
+            region_offset,
+        }
+    }
+}
+
+impl<'a, F: Flash> tickfs::flash_controller::FlashController for TickFSFlastCtrl<'a, F> {
+    fn read_region(
+        &self,
+        region_number: usize,
+        _offset: usize,
+        buf: &mut [u8],
+    ) -> Result<(), tickfs::error_codes::ErrorCode> {
+        match self.state.get() {
+            State::ReadComplete(reg) => {
+                if reg as usize == region_number {
+                    // We already have read the data.
+                    let data_buf = self.data_buffer.take().unwrap();
+                    for (i, d) in data_buf.as_mut().iter().enumerate() {
+                        buf[i] = *d;
+                    }
+                    self.data_buffer.replace(data_buf);
+                    self.state.set(State::None);
+
+                    return Ok(());
+                }
+
+                if self
+                    .flash
+                    .read_page(
+                        self.region_offset + region_number,
+                        self.data_buffer.take().unwrap(),
+                    )
+                    .is_err()
+                {
+                    return Err(tickfs::error_codes::ErrorCode::ReadFail);
+                }
+            }
+            _ => {
+                if self
+                    .flash
+                    .read_page(
+                        self.region_offset + region_number,
+                        self.data_buffer.take().unwrap(),
+                    )
+                    .is_err()
+                {
+                    return Err(tickfs::error_codes::ErrorCode::ReadFail);
+                }
+            }
+        }
+
+        Err(tickfs::error_codes::ErrorCode::ReadNotReady(region_number))
+    }
+
+    fn write_region(
+        &self,
+        address: usize,
+        buf: &[u8],
+    ) -> Result<(), tickfs::error_codes::ErrorCode> {
+        let data_buf = self.data_buffer.take().unwrap();
+
+        for (i, d) in buf.iter().enumerate() {
+            data_buf.as_mut()[i] = *d;
+        }
+
+        if self
+            .flash
+            .write_page((0x20040000 + address) / 1024, data_buf)
+            .is_err()
+        {
+            return Err(tickfs::error_codes::ErrorCode::WriteFail);
+        }
+
+        Err(tickfs::error_codes::ErrorCode::WriteNotReady(address))
+    }
+
+    fn erase_region(&self, region_number: usize) -> Result<(), tickfs::error_codes::ErrorCode> {
+        self.flash.erase_page(self.region_offset + region_number);
+
+        Err(tickfs::error_codes::ErrorCode::EraseNotReady(region_number))
+    }
+}
+
+pub struct KVStoreDriver<'a, F: Flash + 'static> {
+    tickfs: TickFS<'a, TickFSFlastCtrl<'a, F>, SipHasher>,
+    apps: Grant<App>,
+    appid: OptionalCell<AppId>,
+    operation: Cell<Operation>,
+}
+
+impl<'a, F: Flash> KVStoreDriver<'a, F> {
+    pub fn new(
+        flash: &'a F,
+        grant: Grant<App>,
+        read_buf: &'static mut [u8],
+        region_size: usize,
+        data_buffer: &'static mut F::Page,
+        region_offset: usize,
+    ) -> KVStoreDriver<'a, F> {
+        let tickfs = TickFS::<TickFSFlastCtrl<F>, SipHasher>::new(
+            TickFSFlastCtrl::new(flash, data_buffer, region_offset),
+            read_buf,
+            region_size,
+            read_buf.len(),
+        );
+
+        Self {
+            tickfs,
+            apps: grant,
+            appid: OptionalCell::empty(),
+            operation: Cell::new(Operation::None),
+        }
+    }
+
+    pub fn initalise(&self) {
+        let ret = self
+            .tickfs
+            .initalise((&mut SipHasher::new(), &mut SipHasher::new()));
+
+        let state = match ret {
+            Err(tickfs::error_codes::ErrorCode::ReadNotReady(reg)) => {
+                // Read isn't ready, save the state
+                State::ReadComplete(reg as isize)
+            }
+            Err(tickfs::error_codes::ErrorCode::EraseNotReady(reg)) => {
+                // Erase isn't ready, save the state
+                State::EraseComplete(reg)
+            }
+            Ok(tickfs::success_codes::SuccessCode::Queued) => {
+                // Write isn't ready, save the state
+                State::WriteComplete
+            }
+            Ok(_) => State::None,
+            _ => unreachable!(),
+        };
+
+        self.tickfs.controller.state.set(state);
+        self.operation.set(Operation::Init);
+    }
+
+    fn update_state(
+        &self,
+        ret: Result<tickfs::success_codes::SuccessCode, tickfs::error_codes::ErrorCode>,
+    ) {
+        let state = match ret {
+            Err(tickfs::error_codes::ErrorCode::ReadNotReady(reg)) => {
+                // Read isn't ready, save the state
+                State::ReadComplete(reg as isize)
+            }
+            Err(tickfs::error_codes::ErrorCode::EraseNotReady(reg)) => {
+                // Erase isn't ready, save the state
+                State::EraseComplete(reg)
+            }
+            Ok(tickfs::success_codes::SuccessCode::Queued) => {
+                // Write isn't ready, save the state
+                State::WriteComplete
+            }
+            Ok(_) => {
+                self.operation.set(Operation::None);
+                State::None
+            }
+            Err(e) => panic!("Error: {:?}", e),
+        };
+
+        self.tickfs.controller.state.set(state);
+    }
+}
+
+impl<'a, F: Flash> Client<F> for KVStoreDriver<'a, F> {
+    fn read_complete(&self, pagebuffer: &'static mut F::Page, _error: flash::Error) {
+        self.tickfs.controller.data_buffer.replace(pagebuffer);
+
+        match self.operation.get() {
+            Operation::Init => {
+                let ret = self
+                    .tickfs
+                    .continue_initalise((&mut SipHasher::new(), &mut SipHasher::new()));
+
+                self.update_state(ret);
+
+                match ret {
+                    Ok(tickfs::success_codes::SuccessCode::Complete)
+                    | Ok(tickfs::success_codes::SuccessCode::Written) => {
+                        self.operation.set(Operation::None)
+                    }
+                    _ => {}
+                }
+            }
+            Operation::GetKey => {
+                let data_buf = self.tickfs.controller.data_buffer.take().unwrap();
+                self.tickfs.controller.data_buffer.replace(data_buf);
+
+                self.appid.map(|id| {
+                    self.apps
+                        .enter(*id, |app, _| {
+                            if let Some(key) = app.key.take() {
+                                if let Some(mut value) = app.value.take() {
+                                    let key_len = app.key_len.take().unwrap();
+
+                                    let ret = self.tickfs.continue_operation(
+                                        Some(&mut SipHasher::new()),
+                                        Some(&key.as_ref()[0..key_len]),
+                                        None,
+                                        Some(&mut value.as_mut()),
+                                    );
+
+                                    self.update_state(ret);
+
+                                    if ret.is_ok() {
+                                        self.appid.map(|id| {
+                                            self.apps
+                                                .enter(*id, |app, _| {
+                                                    app.callback.map(|cb| {
+                                                        cb.schedule(0, 0, 0);
+                                                    });
+                                                })
+                                                .unwrap();
+                                        });
+
+                                        self.operation.set(Operation::None);
+                                    }
+                                    app.key_len.set(key_len);
+                                    app.value.replace(value);
+                                    app.key.replace(key);
+                                }
+                            }
+                        })
+                        .unwrap();
+                });
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    fn write_complete(&self, pagebuffer: &'static mut F::Page, _error: flash::Error) {
+        self.tickfs.controller.data_buffer.replace(pagebuffer);
+        self.tickfs.controller.state.set(State::None);
+
+        match self.operation.get() {
+            Operation::Init => {}
+            _ => unreachable!(),
+        }
+
+        self.operation.set(Operation::None);
+    }
+
+    fn erase_complete(&self, _error: flash::Error) {
+        match self.operation.get() {
+            Operation::Init => {
+                let ret = self
+                    .tickfs
+                    .continue_initalise((&mut SipHasher::new(), &mut SipHasher::new()));
+
+                self.update_state(ret);
+            }
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl<'a, F: Flash> Driver for KVStoreDriver<'a, F> {
+    /// Specify memory regions to be used.
+    ///
+    /// ### `allow_num`
+    ///
+    fn allow(
+        &self,
+        appid: AppId,
+        allow_num: usize,
+        slice: Option<AppSlice<Shared, u8>>,
+    ) -> ReturnCode {
+        match allow_num {
+            // Key buffer
+            0 => self
+                .apps
+                .enter(appid, |app, _| {
+                    app.key = slice;
+                    ReturnCode::SUCCESS
+                })
+                .unwrap_or(ReturnCode::FAIL),
+
+            // Value buffer
+            1 => self
+                .apps
+                .enter(appid, |app, _| {
+                    app.value = slice;
+                    ReturnCode::SUCCESS
+                })
+                .unwrap_or(ReturnCode::FAIL),
+
+            // default
+            _ => ReturnCode::ENOSUPPORT,
+        }
+    }
+
+    /// Subscribe to events.
+    ///
+    /// ### `subscribe_num`
+    ///
+    fn subscribe(
+        &self,
+        subscribe_num: usize,
+        callback: Option<Callback>,
+        appid: AppId,
+    ) -> ReturnCode {
+        match subscribe_num {
+            0 => {
+                // set callback
+                self.apps
+                    .enter(appid, |app, _| {
+                        app.callback.insert(callback);
+                        ReturnCode::SUCCESS
+                    })
+                    .unwrap_or(ReturnCode::FAIL)
+            }
+
+            // default
+            _ => ReturnCode::ENOSUPPORT,
+        }
+    }
+
+    /// Access the KV Store
+    ///
+    /// ### `command_num`
+    ///
+    fn command(
+        &self,
+        command_num: usize,
+        key_len: usize,
+        _data2: usize,
+        appid: AppId,
+    ) -> ReturnCode {
+        match command_num {
+            // Append key
+            0 => ReturnCode::SUCCESS,
+
+            // Get key
+            1 => self
+                .apps
+                .enter(appid, |app, _| {
+                    if let Some(key) = app.key.take() {
+                        if let Some(mut value) = app.value.take() {
+                            self.appid.set(appid);
+                            self.operation.set(Operation::GetKey);
+                            app.key_len.set(key_len);
+
+                            let ret = self.tickfs.get_key(
+                                &mut SipHasher::new(),
+                                &key.as_ref()[0..key_len],
+                                value.as_mut(),
+                            );
+
+                            self.update_state(ret);
+
+                            app.value.replace(value);
+                            app.key.replace(key);
+
+                            ReturnCode::SUCCESS
+                        } else {
+                            app.key.replace(key);
+                            ReturnCode::EBUSY
+                        }
+                    } else {
+                        ReturnCode::EBUSY
+                    }
+                })
+                .unwrap_or_else(|err| err.into()),
+
+            // Invalidate ke
+            2 => ReturnCode::SUCCESS,
+
+            // Trigger garbage collection
+            3 => ReturnCode::SUCCESS,
+
+            // default
+            _ => ReturnCode::ENOSUPPORT,
+        }
+    }
+}
+
+pub struct App {
+    callback: OptionalCell<Callback>,
+    _pending_run_app: Option<AppId>,
+    key: Option<AppSlice<Shared, u8>>,
+    key_len: OptionalCell<usize>,
+    value: Option<AppSlice<Shared, u8>>,
+}
+
+impl Default for App {
+    fn default() -> App {
+        App {
+            callback: OptionalCell::empty(),
+            _pending_run_app: None,
+            key: None,
+            key_len: OptionalCell::empty(),
+            value: None,
+        }
+    }
+}

--- a/capsules/src/lib.rs
+++ b/capsules/src/lib.rs
@@ -36,6 +36,7 @@ pub mod i2c_master;
 pub mod i2c_master_slave_driver;
 pub mod ieee802154;
 pub mod isl29035;
+pub mod kv_store;
 pub mod l3gd20;
 pub mod led;
 pub mod log;

--- a/chips/lowrisc/src/flash_ctrl.rs
+++ b/chips/lowrisc/src/flash_ctrl.rs
@@ -142,7 +142,7 @@ register_bitfields![u32,
     ]
 ];
 
-const PAGE_SIZE: usize = 1024;
+pub const PAGE_SIZE: usize = 1024;
 
 pub struct LowRiscPage(pub [u8; PAGE_SIZE as usize]);
 

--- a/chips/lowrisc/src/flash_ctrl.rs
+++ b/chips/lowrisc/src/flash_ctrl.rs
@@ -142,7 +142,7 @@ register_bitfields![u32,
     ]
 ];
 
-pub const PAGE_SIZE: usize = 1024;
+pub const PAGE_SIZE: usize = 512;
 
 pub struct LowRiscPage(pub [u8; PAGE_SIZE as usize]);
 
@@ -465,7 +465,7 @@ impl hil::flash::Flash for FlashCtrl<'_> {
 
         // Write the data until we are full or have written all the data
         while !self.registers.status.is_set(STATUS::PROG_FULL)
-            && self.write_index.get() < buf.0.len()
+            && self.write_index.get() < (buf.0.len() - 4)
         {
             let buf_offset = self.write_index.get();
             let data: u32 = buf[buf_offset] as u32

--- a/libraries/tickfs/Cargo.toml
+++ b/libraries/tickfs/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "tickfs"
+repository = "https://github.com/tock/tock"
+version = "0.1.0"
+authors = ["Alistair Francis <alistair.francis@wdc.com>"]
+edition = "2018"
+readme = "README.md"

--- a/libraries/tickfs/README.md
+++ b/libraries/tickfs/README.md
@@ -1,0 +1,93 @@
+# TickFS
+
+TickFS (Tiny Circular Key Value File System) is a small file system allowing
+key value pairs to be stored in Flash Memory.
+
+TickFS was written to allow the Tock OS kernel to persistently store app data
+on flash. It was written to be generic though, so other Rust applications can
+use it if they want.
+
+TickFS is based on similar concepts as
+[Yaffs1](https://yaffs.net/documents/how-yaffs-works]).
+
+TickFS provides ACID properties.
+
+## Goals of TickFS
+
+TickFS is designed with these main goals (in order)
+
+ * Fully implemented in no_std Rust
+ * Power loss resilient
+ * Maintain data integrity and detect media errors
+ * Wear leveling
+ * Low memory usage
+ * Low storage overhead
+ * No external crates in use (not including unit tests)
+
+TickFS is also designed with some assumptions
+
+ * Most operations will be retrieving keys
+ * Some operations will be storing keys
+ * Keys will rarely be deleted
+ * Key values will rarely need to be modified
+
+## Using TickFS
+
+See the generated Rust documentation for details on using this in your project.
+
+## How TickFS works
+
+Unlike a regular File System (FS) TickFS is only designed to store Key/Value (KV)
+pairs in flash. It does not support writing actual files, directories or other
+complex objects. Although a traditional file system layer could be added on top
+to add such features.
+
+TickFS allows writing new key/value pairs (by appending them) and removing
+old key/value pairs.
+
+TickFS has two important types, regions and objects.
+
+A TickFS region is the smallest region of the flash memory that can be erased
+in a single command.
+
+TickFS saves and restores objects from flash. TickFS objects contain the value
+the user wanted to store as well as extra header data. Objects are internal to
+TickFS and users don't need to understand them in detail to use it.
+
+For more details on the technical implementation see the [SPEC.md](./spec.md) file.
+
+### Collisions
+
+TickFS will prevent a new key/value pair with a colliding hash of the key to be
+added. The collision will be reported to the user with
+`ErrorCode::KeyAlreadyExists`.
+
+### Power loss protection
+
+TickFS ensures that in the event of a power loss, all commited data remains
+commited. This is the durability guarantee as part of the ACID semantics.
+The only data that can be lost in the event of a power loss is
+the data which hasn't been write to flash yet.
+
+If a power loss occurs after calling `append_key()` or `invalidate_key()`
+before it has completed then the operation probably did not complete and
+that data is lost.
+
+### Security
+
+TickFS uses checksums to check data integrity. TickFS does not have any measures
+to prevent malicious manipulation or privacy. An attacker with access to the
+flash can change the values without being detected. An attacked with access
+to flash can also read all of the information. Any privacy, security or
+authentication measures need to be layered on top of TickFS.
+
+## Versions
+
+TickFS stores the version when adding objects to the flash storage.
+
+TickFS is currently version 0.
+
+ * Version 0
+   * Version 0 is a draft version. It should NOT be used for important data!
+     Version 0 maintains no backwards compatible support and could change at
+     any time.

--- a/libraries/tickfs/SPEC.md
+++ b/libraries/tickfs/SPEC.md
@@ -482,13 +482,28 @@ At a minimum TickFS requires a `PageSize` amount of free memory to store the
 buffer obtained when reading flash. This could be reduced by instead performing
 multiple reads of a smaller fixed size.
 
-### Synchronous
+### Synchronous and Asynchronous Usage
 
-TickFS is fully synchronous and every call is blocking.
+TickFS supports both an synchronous and asynchronous usage. For developers
+used to Tock's callback method the the async usage might seem strange and
+sub-optimal. There are a few reasons that it is done this way.
 
-This is unfortunately inherently different to Tock's asynchronous design. The
-justification for this design is that in general writing and erasing flash
-can be tricky if we are executing from the same bank. A synchronous design
-seems like an overall more useful implementation to allow this. It also means
-we block in the critical moments where a power loss would loose the data we
-want to preserve.
+One of the goals of TickFS is to allow other non Tock users to use it. The
+current method should allow the library to be used to crates.io by other
+developers.
+
+Another reason for the synchronous support is that generally when there is
+only a single flash bank all flash writes and erases must be done synchronously.
+The synchronous API should allow these type of operations to occur.
+
+On top of that it is much simpler to unit test a synchronous API. This means the
+TickFS implementation can take advantage of a large range of unit tests to
+ensure correctness in the design. This is more difficult and complex to do in
+a async only operation.
+
+The async functions (see the documentation) can be used to implement a fully
+async operation. This is done using a "retry" method, such that special busy
+error codes indicate operations should be retried. This ends up being easier to
+implement as TickFS uses loops to find keys. This could be split out into
+callbacks, but it is expected that the end result will look very similar as the
+callbacks will maintain state and then restart the loop where it last left off.

--- a/libraries/tickfs/SPEC.md
+++ b/libraries/tickfs/SPEC.md
@@ -1,0 +1,494 @@
+# TickFS Technical Details
+
+## How TickFS works
+
+Unlike a regular File System (FS) TickFS is only designed to store Key/Value (KV)
+pairs in flash. It does not support writing actual files, directories or other
+complex objects. Although a traditional file system layer could be added on top
+to add such features.
+
+TickFS allows writing new key/value pairs (by appending them) and removing
+old key/value pairs.
+
+Similar to Yaffs1 TickFS uses a log structure and will circle over the flash
+data. This means that the file system is inherently wear leveling as we don't
+regularly write to the same flash region.
+
+## Storage Format
+
+TickFS flash storage is formatted as a sorting of regions with each region
+containing TickFS objects.
+
+### TickFS Regions
+
+A TickFS region is the smallest set of contiguous flash storage space that can
+be erased with a single command.
+
+For example if a flash controller allows erasing lengths of 1024 (0x400) bytes
+then the length of a region will be 1024 (0x400) bytes.
+
+The number of regions is determined by the capacity of the flash storage and
+the size of regions.
+
+The start and end address of flash used for TickFS must be region aligned.
+
+### TickFS Objects
+
+A TickFS object is the representation of a key/value pair in flash. An object
+contains the value to be saved as well as useful header data.
+
+TickFS saves and reads objects from flash. TickFS objects contain the value
+the user wanted to store as well as extra header data.
+
+A TickFS object consists of multiple parts:
+
+```
+|||||||||||||||||
+|               |
+| Object Header |
+|               |
+|||||||||||||||||
+|               |
+|     Value     |
+|               |
+|||||||||||||||||
+|               |
+|   Check Sum   |
+|               |
+|||||||||||||||||
+```
+
+#### Object Header
+
+Currently ObjectHeader includes these fields:
+
+```Rust
+struct ObjectHeader {
+    version: u8,
+    flags: u4,
+    len: u12,
+    hashed_key: u64,
+}
+```
+
+The `version` field is a byte containing the version of TickFS used when the
+object was written.
+This allows us to upgrade this library in the future, while still supporting
+old data formats.
+
+The `flags` field is a bitmap of at most 4 flags that can be OR-ed together to
+describe an object state or features. The only flag defined is the `valid` flag
+(bit 3), indicating that an object is valid.
+
+It looks like this in flash:
+
+```
+|valid|Reserved|Reserved|Reserved|
+|     |        |        |        |
+|  1  |    0   |    0   |    0   |
+```
+
+Where `valid` indicates if an object is valid. A `1` indicates it is a valid
+object, a `0` indicates that it has been marked as invalid (see below).
+
+The `len` field is 12-bits long.
+This field indicates the total length of the object, including the
+header and check sum. The maximum length of the entire object is
+4KiB (0xFFF) or the region size, whichever is smaller.
+
+The `hashed_key` field stores the 64-bit (8 byte) output of the key hash.
+
+ObjectHeader is internal to TickFS and users of TickFS do not need to
+understand it.
+
+#### Object Value
+
+The Value component of the TickFS object is the value that the user wants to
+store.
+
+The values can be any length as long as they follow both:
+ * Don't span multiple regions. That limits the maximum value length to
+   `region_size - size_of::<ObjectHeader>()`
+ * Don't have a maximum length greater then 4KiB (0xFFF).
+
+#### Checksum
+
+The checksum is a hash of the entire object (not including the checksum).
+The checksum is calculated using the same hash algorithm used for the keys.
+
+A simple CRC isn't used to avoid depending on external crates and to
+re-use the already implemented Hash. This will potentially allow
+hardware accelerated implementation of `core::hash::Hasher` to be used
+for the checksum.
+
+### Object overhead
+
+Currently the overhead of an TickFS object is 21 bytes. Most of this is the 8
+bytes for the key hash and 8 bytes for a checksum.
+
+### Location of objects
+
+The region where a TickFS object is stored is dependent on the output of the
+key hash and the number of regions.
+
+TickFS determines the region an object will be stored or retrieved from using
+region numbers, starting from 0. The region number of an object is equal to the
+last two bytes of an object hashed-key modulo the number of regions.
+
+This will produce a number that is between zero and the total number of
+TickFS regions. This number is the regions number where the data is stored
+or loaded from.
+
+This allows us to quickly determine which flash region a key is stored in. This
+should improve lookup time by reducing the number of reads required.
+
+If a give region is full, we will start to look in neighboring regions. We first
+perform the same search in the next (increment region number) region. If this
+region doesn't exist (we are at the end of the regions) or if the region is full
+we then search in the previous region (decrement region number).
+
+When storing a object this process continues until we either:
+ * Search all regions
+ * Find a free space
+
+When retrieving an object the process continues until we either:
+ * Search all regions
+ * Find the key we are looking for
+ * Find a region that is empty
+
+### Invalidating keys
+
+Flash has the characteristic that although read/writes can happen at small
+granularities an erase operation requires a entire block (specified
+by the region size).
+
+Due to this removing a key with the `invalidate_key()` function does NOT
+remove anything from flash. Instead calling `invalidate_key()`
+will mark the `valid` boolean for that object as `false` (0).
+
+This is done because changing a `1` to a `0` in flash can be done with a
+write to a single byte (where only 1 bit changes). While changing a `0`
+to a `1` requires an erase of the entire region.
+
+The key point here is that removing a key does NOT remove it or the object
+from the flash storage. If the key contains sensitive information it will
+still be in flash. Once invalidated though `get_key()` will not return the key
+any more.
+
+If all the objects in a region are no longer valid then that region will be
+erased when `garbage_collect()` is called. Note that even if the flash is
+full `garbage_collect()` will not be called automatically.
+
+### Initialisation
+
+When setting up a block of flash for the first time the entire size of flash
+is erased. Then a super key called "tickfs-super-key" is added with no
+attached data.
+
+On future initialisation the implementation will check for the
+"tickfs-super-key" key. If it exists no erase operations will occur. If it
+doesn't exist the entire block of flash will be erased.
+
+## What is looks like in flash
+
+### Adding a key
+
+This is an example of what `TickFS::new(..., 0xC00, 0x400)` will
+look like in flash.
+
+```
+0x000                  0x400                  0x800                 0xC00
+--------------------------------------------------------------------------
+|||||     Region 0     |||||     Region 1     |||||     Region 2     |||||
+|||||                  |||||                  |||||                  |||||
+|||||                  |||||                  |||||                  |||||
+--------------------------------------------------------------------------
+```
+
+All values in flash will be `0xFF` as the flash has just been erased.
+
+When a key is added with a `[u8; 32]` `value` with `append_key()` it will
+look like this:
+
+```
+Key:    "ONE"
+Hash:   0xeda10078886193bb
+Region: 1 (0x93bb % 3)
+```
+
+`Region` is the flash region where the object will be stored. In this case it's
+region 1 of 3.
+
+```
+0x000                  0x400                  0x800                 0xC00
+--------------------------------------------------------------------------
+|||||     Region 0     |||||     Region 1     |||||     Region 2     |||||
+|||||                  |||||                  |||||                  |||||
+|||||                  |||||ONE               |||||                  |||||
+--------------------------------------------------------------------------
+```
+
+Where the TickFS object ONE will look like this
+
+```
+0x400                                                                                              0x42C
+--------------------------------------------------------------------------------------------------------
+||||| version|len/flag|   len  |                              hashed_key                               |
+|||||        |        |        |        |        |        |        |        |        |        |        |
+|||||    0x00|10000000|    0x34|    0xed|    0xa1|    0x00|    0x78|    0x88|    0x61|    0x93|    0xbb|
+-------------------------------------------------------------------------------------------------------|
+```
+
+```
+0x42C                                                                                              0x52C
+--------------------------------------------------------------------------------------------------------
+|||||                                               value                                              |
+|||||                                                                                                  |
+|||||xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx|
+-------------------------------------------------------------------------------------------------------|
+```
+
+```
+0x52C                                                                   0x54C
+-----------------------------------------------------------------------------
+|||||                                checksum                               |
+|||||        |        |        |        |        |        |        |        |
+|||||    0xe5|    0x5d|    0x99|    0x22|    0x0a|    0x3c|    0xe1|    0x17|
+----------------------------------------------------------------------------|
+```
+
+In this case the header information takes up 19 bytes of a total of 51 bytes,
+which is around 37% of the space.
+
+Note that if region 1 is full, we would then try to save the ONE object in
+region 2, then try again in region 0.
+
+### Adding a second key
+
+When a new key TWO with a `[u8; 32]` `value` is added with `append_key()` the
+flash might look like this:
+
+```
+0x000                  0x400                  0x800                 0xC00
+--------------------------------------------------------------------------
+|||||     Region 0     |||||     Region 1     |||||     Region 2     |||||
+|||||                  |||||                  |||||                  |||||
+|||||                  |||||ONE|TWO           |||||                  |||||
+--------------------------------------------------------------------------
+```
+
+Where TWO will have the same structure as ONE, except with a different hash
+value, different checksum and starts at address 0x54C. Note that depending
+on the hash of TWO it could be added to any region.
+
+### Adding a third key
+
+When a new key THRID with a `[u8; 32]` `value` is added with `append_key()` the
+flash might look like this
+
+```
+0x000                  0x400                  0x800                 0xC00
+--------------------------------------------------------------------------
+|||||     Region 0     |||||     Region 1     |||||     Region 2     |||||
+|||||                  |||||                  |||||                  |||||
+|||||THRID             |||||ONE|TWO           |||||                  |||||
+--------------------------------------------------------------------------
+```
+
+Note that although region 1 isn't full, it is placed in region 0 based on the
+region calculated from the lower byte of it's hash.
+
+Objects will be placed in chronological order inside a region. Objects will
+not be placed in order inside flash though. Instead they are placed at a
+region depending on their hash. This is described in more detail above.
+
+### Finding keys
+
+Locating keys in flash follows a similar process to writing them.
+
+First we calculate the hash and determine the region where we expect the
+object to be stored. With the same key input and hash function we will always
+get the same hash and region.
+
+Using the same example as above, we will get this:
+
+```
+Key:    "ONE"
+Hash:   0xeda10078886193bb
+Region: 1 (0x93bb % 3)
+```
+
+Then we load the entire region from flash. In this example that would be
+region 1. So we read the entire region 1 from flash.
+
+We then iterate over the loaded region, starting with the first byte.
+
+We check to make sure the version is supported and that the object isn't
+marked as !`valid`.
+
+We then check to see if the object hash matches the hash we are
+looking for. If it doesn't we move forward in the loaded region by the
+total length of the object we just checked and start the process again.
+
+We continue this loop until we either find the key we are looking for or
+find a version 0xFF, indicating the end of the blocks in that region.
+
+This method allows a quick retrieval of data from a given key. We only
+require a single read and store the entire region in memory. This should
+only have a small memory foot print as regions are generally less then 4KiB.
+
+### Adding keys to full regions
+
+In the previous example we added the ONE object to an empty flash region. This
+example shows what would happen if region 1 was full.
+
+Image if the flash storage looked like this:
+
+```
+0x000                  0x400                  0x800                 0xC00
+--------------------------------------------------------------------------
+|||||     Region 0     |||||     Region 1     |||||     Region 2     |||||
+|||||                  |||||                  |||||                  |||||
+|||||                  |||||KEY|EXAMPLE|TEST| |||||                  |||||
+--------------------------------------------------------------------------
+```
+
+and we wanted to add the same ONE key:
+
+```
+Key:    "ONE"
+Hash:   0xeda10078886193bb
+Region: 1 (0x93bb % 3)
+```
+
+We can't add the key to region 1 as it is full. Instead we fall back to trying
+region 2. If region 2 was full we would then try region 0 and so on.
+
+Adding key ONE would look like this:
+
+
+```
+0x000                  0x400                  0x800                 0xC00
+--------------------------------------------------------------------------
+|||||     Region 0     |||||     Region 1     |||||     Region 2     |||||
+|||||                  |||||                  |||||                  |||||
+|||||                  |||||KEY|EXAMPLE|TEST| |||||ONE               |||||
+--------------------------------------------------------------------------
+```
+
+### Finding keys from full regions
+
+Image the flash layout from above and then we wanted to find the non-existent
+key TWO.
+
+The hash of TWO indicates it should be in region 1. First we check region 1,
+but we don't find TWO. Next we try to find TWO in region 2. We don't kind the
+TWO object there, but as the region isn't empty we can't determine if it didn't
+fit. Next we try region 0. As this region is empty we stop looking.
+
+### Invalidating a key
+
+When the key ONE is invalidated with `invalidate_key()`, the only change in
+flash will be the `valid` flag. The object header for ONE will now look like:
+
+```
+0x400                                                                                              0x52C
+--------------------------------------------------------------------------------------------------------
+||||| version|len/flag|   len  |                              hashed_key                               |
+|||||        |        |        |        |        |        |        |        |        |        |        |
+|||||    0x00|00000000|    0x34|    0xed|    0xa1|    0x00|    0x78|    0x88|    0x61|    0x93|    0xbb|
+--------------------------------------------------------------------------------------------------------
+              ^
+```
+
+No changes will happen in flash until key TWO has also been invalidated.
+At which point `garbage_collect()` can erase the region.
+
+## Limitations of TickFS
+
+### Fragmentation
+
+Although TickFS has a `garbage_collect()` function, it makes no effort to
+handle fragmentation.
+
+That means that if you have the following objects in a region
+
+```
+0x000                  0x400
+----------------------------
+|||||     Region 0     |||||
+|||||                  |||||
+|||||ONE|TWO|THREE|FOUR|||||
+----------------------------
+```
+
+Where ONE, TWO and FOUR have been marked as invalid the entire region will still
+be classified as full. It will only not be full when all four objects are marked
+for invalid.
+
+It would be possible to have a reserved region and then free up the region with
+the following steps:
+ 1. Move the region to the reserved region
+ 1. Erase the above region
+ 1. Move the valid objects from the reserved region to the original region,
+    after being defraged in memory
+ 1. Erase the reserved region
+
+The above steps would ensure we don't loose data on a power loss, as long as
+we could ensure we could continue the operation after regaining power.
+
+There are a few problems with this approach though.
+
+In order to maintain "garbage collecting" state to restore after a power loss
+we would need some sore of super block. This would then break the requirement
+on wear leveling as whichever region that block is in will be written and
+erased more often the others.
+
+The other problem is the reserved region where we would move data to. This
+would cost space as an entire region would be dedicated to garbage collecting.
+The garbage collecting region would also have more erase and writes performed
+on it breaking the wear leveling requirement.
+
+### Somewhat high storage overhead
+
+The storage overhead is somewhat high for TickFS. This is mostly due to the
+two 64-bit hashes that are stored with every object.
+
+The 64-bit value is determined by the output of the standard Rust
+`core::hash::Hasher` trait.
+
+For the hash of the key a 64-bit value can be justified by the lack of
+collision avoidance in the implementation. If two keys have the same
+hash the second key will be dropped. In this case a 64-bit hash should
+hopefully make that occurrence very unlikely. Also by following the standard
+Rust `core::hash::Hasher` trait the user is free to implement any standard
+Hasher of their choosing. Some systems will even be able to offload the
+hash to hardware.
+
+As for the check-sum. It was seriously considered to change this to a
+32-bit or even 16-bit CRC. This would reduce the overhead for each object
+by 4 or 6 bytes. Although a CRC is relatively easy to implement, it can still
+be time consuming. For this reason lots of embedded hardware will include a
+CRC offload engine to offload the calculation. By implementing a CRC in this
+library I would remove the option of allowing a offload engine. As there
+doesn't seem to be a generic CRC Rust trait to take advantage of the decision
+was made to reuse the `core::hash::Hasher` trait for the checksum. This costs
+space, but hopefully reduces implementation burden and allows for more hardware
+offloading.
+
+### Memory usage
+
+At a minimum TickFS requires a `PageSize` amount of free memory to store the
+buffer obtained when reading flash. This could be reduced by instead performing
+multiple reads of a smaller fixed size.
+
+### Synchronous
+
+TickFS is fully synchronous and every call is blocking.
+
+This is unfortunately inherently different to Tock's asynchronous design. The
+justification for this design is that in general writing and erasing flash
+can be tricky if we are executing from the same bank. A synchronous design
+seems like an overall more useful implementation to allow this. It also means
+we block in the critical moments where a power loss would loose the data we
+want to preserve.

--- a/libraries/tickfs/src/async_ops.rs
+++ b/libraries/tickfs/src/async_ops.rs
@@ -100,7 +100,7 @@
 //!         let ret = tickfs.
 //!                       continue_operation(Some(&mut DefaultHasher::new()), Some(b"ONE"), Some(&value), None);
 //!     }
-//!     Ok(()) => {},
+//!     Ok(_) => {},
 //!     _ => panic!("Other error"),
 //! }
 //!
@@ -339,7 +339,7 @@ mod store_flast_ctrl {
                     )
                     .unwrap();
             }
-            Ok(()) => {}
+            Ok(_) => {}
             _ => unreachable!(),
         }
 
@@ -356,7 +356,7 @@ mod store_flast_ctrl {
                     )
                     .unwrap();
             }
-            Ok(()) => {}
+            Ok(_) => {}
             _ => unreachable!(),
         }
     }
@@ -394,7 +394,7 @@ mod store_flast_ctrl {
                     )
                     .unwrap();
             }
-            Ok(()) => {}
+            Ok(_) => {}
             _ => unreachable!(),
         }
 
@@ -441,175 +441,257 @@ mod store_flast_ctrl {
             _ => unreachable!(),
         }
 
-        // println!("Add key TWO");
-        // tickfs
-        //     .append_key(&mut DefaultHasher::new(), b"TWO", &value)
-        //     .unwrap();
-        // println!("Get key ONE");
-        // tickfs
-        //     .get_key(&mut DefaultHasher::new(), b"ONE", &mut buf)
-        //     .unwrap();
-        // println!("Get key TWO");
-        // tickfs
-        //     .get_key(&mut DefaultHasher::new(), b"TWO", &mut buf)
-        //     .unwrap();
+        println!("Add key TWO");
+        let ret = tickfs.append_key(&mut DefaultHasher::new(), b"TWO", &value);
+        match ret {
+            Err(ErrorCode::ReadNotReady(_reg)) => {
+                // There is no actual delay in the test, just continue now
+                tickfs
+                    .continue_operation(
+                        Some(&mut DefaultHasher::new()),
+                        Some(b"TWO"),
+                        Some(&value),
+                        None,
+                    )
+                    .unwrap();
+            }
+            Ok(_) => {}
+            _ => unreachable!(),
+        }
 
-        // println!("Get non-existant key THREE");
-        // assert_eq!(
-        //     tickfs.get_key(&mut DefaultHasher::new(), b"THREE", &mut buf),
-        //     Err(ErrorCode::KeyNotFound)
-        // );
+        println!("Get key ONE");
+        let ret = tickfs.get_key(&mut DefaultHasher::new(), b"ONE", &mut buf);
+        match ret {
+            Err(ErrorCode::ReadNotReady(_reg)) => {
+                // There is no actual delay in the test, just continue now
+                tickfs
+                    .continue_operation(
+                        Some(&mut DefaultHasher::new()),
+                        Some(b"ONE"),
+                        None,
+                        Some(&mut buf),
+                    )
+                    .unwrap();
+            }
+            Ok(_) => {}
+            _ => unreachable!(),
+        }
+
+        println!("Get key TWO");
+        let ret = tickfs.get_key(&mut DefaultHasher::new(), b"TWO", &mut buf);
+        match ret {
+            Err(ErrorCode::ReadNotReady(_reg)) => {
+                // There is no actual delay in the test, just continue now
+                tickfs
+                    .continue_operation(
+                        Some(&mut DefaultHasher::new()),
+                        Some(b"TWO"),
+                        None,
+                        Some(&mut buf),
+                    )
+                    .unwrap();
+            }
+            Ok(_) => {}
+            _ => unreachable!(),
+        }
+
+        println!("Get non-existant key THREE");
+        let ret = tickfs.get_key(&mut DefaultHasher::new(), b"THREE", &mut buf);
+        match ret {
+            Err(ErrorCode::ReadNotReady(_reg)) => {
+                // There is no actual delay in the test, just continue now
+                assert_eq!(
+                    tickfs.continue_operation(
+                        Some(&mut DefaultHasher::new()),
+                        Some(b"TWO"),
+                        None,
+                        Some(&mut buf),
+                    ),
+                    Err(ErrorCode::KeyNotFound)
+                );
+            }
+            _ => unreachable!(),
+        }
+
+        assert_eq!(
+            tickfs.get_key(&mut DefaultHasher::new(), b"THREE", &mut buf),
+            Err(ErrorCode::KeyNotFound)
+        );
     }
 
-    // #[test]
-    // fn test_append_and_delete() {
-    //     let mut read_buf: [u8; 1024] = [0; 1024];
-    //     let tickfs = TickFS::<FlashCtrl, DefaultHasher>::new(
-    //         FlashCtrl::new(),
-    //         &mut read_buf,
-    //         0x10000,
-    //         0x400,
-    //     );
+    #[test]
+    fn test_append_and_delete() {
+        let mut read_buf: [u8; 1024] = [0; 1024];
+        let tickfs = TickFS::<FlashCtrl, DefaultHasher>::new(
+            FlashCtrl::new(),
+            &mut read_buf,
+            0x10000,
+            0x400,
+        );
 
-    //     let mut ret = tickfs.initalise((&mut DefaultHasher::new(), &mut DefaultHasher::new()));
-    //     while ret.is_err() {
-    //         // There is no actual delay in the test, just continue now
-    //         ret = tickfs.continue_initalise((&mut DefaultHasher::new(), &mut DefaultHasher::new()));
-    //     }
+        let mut ret = tickfs.initalise((&mut DefaultHasher::new(), &mut DefaultHasher::new()));
+        while ret.is_err() {
+            // There is no actual delay in the test, just continue now
+            ret = tickfs.continue_initalise((&mut DefaultHasher::new(), &mut DefaultHasher::new()));
+        }
 
-    //     let value: [u8; 32] = [0x23; 32];
-    //     let mut buf: [u8; 32] = [0; 32];
+        let value: [u8; 32] = [0x23; 32];
+        let mut buf: [u8; 32] = [0; 32];
 
-    //     println!("Add key ONE");
-    //     let ret = tickfs.append_key(&mut DefaultHasher::new(), b"ONE", &value);
-    //     match ret {
-    //         Err(ErrorCode::ReadNotReady(_reg)) => {
-    //             // Read isn't ready, save the state
-    //             let operation = Operation::AppendKey;
+        println!("Add key ONE");
+        let ret = tickfs.append_key(&mut DefaultHasher::new(), b"ONE", &value);
+        match ret {
+            Err(ErrorCode::ReadNotReady(_reg)) => {
+                // There is no actual delay in the test, just continue now
+                tickfs
+                    .continue_operation(
+                        Some(&mut DefaultHasher::new()),
+                        Some(b"ONE"),
+                        Some(&value),
+                        None,
+                    )
+                    .unwrap();
+            }
+            Ok(_) => {}
+            _ => unreachable!(),
+        }
 
-    //             // There is no actual delay in the test, just continue now
-    //             tickfs
-    //                 .continue_operation(
-    //                     operation,
-    //                     Some(&mut DefaultHasher::new()),
-    //                     Some(b"ONE"),
-    //                     Some(&value),
-    //                     None,
-    //                 )
-    //                 .unwrap();
-    //         }
-    //         Ok(()) => {}
-    //         _ => unreachable!(),
-    //     }
+        println!("Get key ONE");
+        tickfs
+            .get_key(&mut DefaultHasher::new(), b"ONE", &mut buf)
+            .unwrap();
 
-    //     println!("Get key ONE");
-    //     tickfs
-    //         .get_key(&mut DefaultHasher::new(), b"ONE", &mut buf)
-    //         .unwrap();
+        println!("Delete Key ONE");
+        tickfs
+            .invalidate_key(&mut DefaultHasher::new(), b"ONE")
+            .unwrap();
 
-    //     println!("Delete Key ONE");
-    //     tickfs
-    //         .invalidate_key(&mut DefaultHasher::new(), b"ONE")
-    //         .unwrap();
+        println!("Get non-existant key ONE");
+        assert_eq!(
+            tickfs.get_key(&mut DefaultHasher::new(), b"ONE", &mut buf),
+            Err(ErrorCode::KeyNotFound)
+        );
 
-    //     println!("Get non-existant key ONE");
-    //     assert_eq!(
-    //         tickfs.get_key(&mut DefaultHasher::new(), b"ONE", &mut buf),
-    //         Err(ErrorCode::KeyNotFound)
-    //     );
+        println!("Try to delete Key ONE Again");
+        assert_eq!(
+            tickfs.invalidate_key(&mut DefaultHasher::new(), b"ONE"),
+            Err(ErrorCode::KeyNotFound)
+        );
+    }
 
-    //     println!("Try to delete Key ONE Again");
-    //     assert_eq!(
-    //         tickfs.invalidate_key(&mut DefaultHasher::new(), b"ONE"),
-    //         Err(ErrorCode::KeyNotFound)
-    //     );
-    // }
+    #[test]
+    fn test_garbage_collect() {
+        let mut read_buf: [u8; 1024] = [0; 1024];
+        let tickfs = TickFS::<FlashCtrl, DefaultHasher>::new(
+            FlashCtrl::new(),
+            &mut read_buf,
+            0x10000,
+            0x400,
+        );
 
-    // #[test]
-    // fn test_garbage_collect() {
-    //     let mut read_buf: [u8; 1024] = [0; 1024];
-    //     let tickfs = TickFS::<FlashCtrl, DefaultHasher>::new(
-    //         FlashCtrl::new(),
-    //         &mut read_buf,
-    //         0x10000,
-    //         0x400,
-    //     );
+        let mut ret = tickfs.initalise((&mut DefaultHasher::new(), &mut DefaultHasher::new()));
+        while ret.is_err() {
+            // There is no actual delay in the test, just continue now
+            ret = tickfs.continue_initalise((&mut DefaultHasher::new(), &mut DefaultHasher::new()));
+        }
 
-    //     let mut ret = tickfs.initalise((&mut DefaultHasher::new(), &mut DefaultHasher::new()));
-    //     while ret.is_err() {
-    //         // There is no actual delay in the test, just continue now
-    //         ret = tickfs.continue_initalise((&mut DefaultHasher::new(), &mut DefaultHasher::new()));
-    //     }
+        let value: [u8; 32] = [0x23; 32];
+        let mut buf: [u8; 32] = [0; 32];
 
-    //     let value: [u8; 32] = [0x23; 32];
-    //     let mut buf: [u8; 32] = [0; 32];
+        println!("Garbage collect empty flash");
+        let mut ret = tickfs.garbage_collect();
+        while ret.is_err() {
+            // There is no actual delay in the test, just continue now
+            ret = tickfs.continue_garbage_collection();
+        }
 
-    //     println!("Garbage collect empty flash");
-    //     let mut ret = tickfs.garbage_collect();
-    //     while ret.is_err() {
-    //         // There is no actual delay in the test, just continue now
-    //         ret = tickfs.continue_garbage_collection();
-    //     }
+        println!("Add key ONE");
+        let ret = tickfs.append_key(&mut DefaultHasher::new(), b"ONE", &value);
+        match ret {
+            Err(ErrorCode::ReadNotReady(_reg)) => {
+                // There is no actual delay in the test, just continue now
+                tickfs
+                    .continue_operation(
+                        Some(&mut DefaultHasher::new()),
+                        Some(b"ONE"),
+                        Some(&value),
+                        None,
+                    )
+                    .unwrap();
+            }
+            Ok(_) => {}
+            _ => unreachable!(),
+        }
 
-    //     println!("Add key ONE");
-    //     let ret = tickfs.append_key(&mut DefaultHasher::new(), b"ONE", &value);
-    //     match ret {
-    //         Err(ErrorCode::ReadNotReady(_reg)) => {
-    //             // Read isn't ready, save the state
-    //             let operation = Operation::AppendKey;
+        println!("Garbage collect flash with valid key");
+        let mut ret = tickfs.garbage_collect();
+        while ret.is_err() {
+            match ret {
+                Err(ErrorCode::ReadNotReady(_reg)) => {
+                    // There is no actual delay in the test, just continue now
+                    ret = tickfs.continue_garbage_collection();
+                }
+                Ok(num) => {
+                    assert_eq!(num, 0);
+                }
+                _ => unreachable!(),
+            }
+        }
 
-    //             // There is no actual delay in the test, just continue now
-    //             tickfs
-    //                 .continue_operation(
-    //                     operation,
-    //                     Some(&mut DefaultHasher::new()),
-    //                     Some(b"ONE"),
-    //                     Some(&value),
-    //                     None,
-    //                 )
-    //                 .unwrap();
-    //         }
-    //         Ok(()) => {}
-    //         _ => unreachable!(),
-    //     }
+        println!("Delete Key ONE");
+        let ret = tickfs.invalidate_key(&mut DefaultHasher::new(), b"ONE");
+        match ret {
+            Err(ErrorCode::ReadNotReady(_reg)) => {
+                // There is no actual delay in the test, just continue now
+                tickfs
+                    .continue_operation(Some(&mut DefaultHasher::new()), Some(b"ONE"), None, None)
+                    .unwrap();
+            }
+            Ok(_) => {}
+            _ => unreachable!("ret: {:?}", ret),
+        }
 
-    //     println!("Garbage collect flash with valid key");
-    //     assert_eq!(tickfs.garbage_collect(), Ok(0));
+        println!("Garbage collect flash with deleted key");
+        let mut ret = tickfs.garbage_collect();
+        while ret.is_err() {
+            match ret {
+                Err(ErrorCode::ReadNotReady(_reg)) => {
+                    // There is no actual delay in the test, just continue now
+                    ret = tickfs.continue_garbage_collection();
+                }
+                Err(ErrorCode::EraseNotReady(_reg)) => {
+                    // There is no actual delay in the test, just continue now
+                    ret = tickfs.continue_garbage_collection();
+                }
+                Ok(num) => {
+                    assert_eq!(num, 1024);
+                }
+                _ => unreachable!("ret: {:?}", ret),
+            }
+        }
 
-    //     println!("Delete Key ONE");
-    //     let ret = tickfs.invalidate_key(&mut DefaultHasher::new(), b"ONE");
-    //     match ret {
-    //         Err(ErrorCode::ReadNotReady(_reg)) => {
-    //             // Read isn't ready, save the state
-    //             let operation = Operation::InvalidateKey;
+        println!("Get non-existant key ONE");
+        let ret = tickfs.get_key(&mut DefaultHasher::new(), b"ONE", &mut buf);
+        match ret {
+            Err(ErrorCode::ReadNotReady(_reg)) => {
+                // There is no actual delay in the test, just continue now
+                assert_eq!(
+                    tickfs.continue_operation(
+                        Some(&mut DefaultHasher::new()),
+                        Some(b"ONE"),
+                        None,
+                        Some(&mut buf),
+                    ),
+                    Err(ErrorCode::KeyNotFound)
+                );
+            }
+            Err(ErrorCode::KeyNotFound) => {}
+            _ => unreachable!("ret: {:?}", ret),
+        }
 
-    //             // There is no actual delay in the test, just continue now
-    //             tickfs
-    //                 .continue_operation(
-    //                     operation,
-    //                     Some(&mut DefaultHasher::new()),
-    //                     Some(b"ONE"),
-    //                     None,
-    //                     None,
-    //                 )
-    //                 .unwrap();
-    //         }
-    //         Ok(()) => {}
-    //         _ => unreachable!(),
-    //     }
-
-    //     println!("Garbage collect flash with deleted key");
-    //     assert_eq!(tickfs.garbage_collect(), Ok(1024));
-
-    //     println!("Get non-existant key ONE");
-    //     assert_eq!(
-    //         tickfs.get_key(&mut DefaultHasher::new(), b"ONE", &mut buf),
-    //         Err(ErrorCode::KeyNotFound)
-    //     );
-
-    //     println!("Add Key ONE");
-    //     tickfs
-    //         .append_key(&mut DefaultHasher::new(), b"ONE", &value)
-    //         .unwrap();
-    // }
+        println!("Add Key ONE");
+        tickfs
+            .append_key(&mut DefaultHasher::new(), b"ONE", &value)
+            .unwrap();
+    }
 }

--- a/libraries/tickfs/src/async_ops.rs
+++ b/libraries/tickfs/src/async_ops.rs
@@ -30,12 +30,12 @@
 //!     }
 //! }
 //!
-//! impl FlashController for FlashCtrl {
+//! impl FlashController<1024> for FlashCtrl {
 //!     fn read_region(
 //!         &self,
 //!         region_number: usize,
 //!         offset: usize,
-//!         buf: &mut [u8],
+//!         buf: &mut [u8; 1024],
 //!     ) -> Result<(), ErrorCode> {
 //!         if self.async_read_region.get() != region_number {
 //!             // We aren't ready yet, launch the async operation
@@ -74,8 +74,8 @@
 //! // callbacks/interrupts and make this async.
 //!
 //! let mut read_buf: [u8; 1024] = [0; 1024];
-//! let tickfs = TickFS::<FlashCtrl, DefaultHasher>::new(FlashCtrl::new(),
-//!                   &mut read_buf, 0x1000, 0x400);
+//! let tickfs = TickFS::<FlashCtrl, DefaultHasher, 1024>::new(FlashCtrl::new(),
+//!                   &mut read_buf, 0x1000);
 //!
 //! let mut ret = tickfs.initalise((&mut DefaultHasher::new(), &mut DefaultHasher::new()));
 //! while ret.is_err() {
@@ -238,12 +238,12 @@ mod store_flast_ctrl {
         }
     }
 
-    impl FlashController for FlashCtrl {
+    impl FlashController<1024> for FlashCtrl {
         fn read_region(
             &self,
             region_number: usize,
             offset: usize,
-            buf: &mut [u8],
+            buf: &mut [u8; 1024],
         ) -> Result<(), ErrorCode> {
             println!("Read from region: {}", region_number);
 
@@ -316,7 +316,7 @@ mod store_flast_ctrl {
     fn test_simple_append() {
         let mut read_buf: [u8; 1024] = [0; 1024];
         let tickfs =
-            TickFS::<FlashCtrl, DefaultHasher>::new(FlashCtrl::new(), &mut read_buf, 0x1000, 0x400);
+            TickFS::<FlashCtrl, DefaultHasher, 1024>::new(FlashCtrl::new(), &mut read_buf, 0x1000);
 
         let mut ret = tickfs.initalise((&mut DefaultHasher::new(), &mut DefaultHasher::new()));
         while ret.is_err() {
@@ -364,12 +364,8 @@ mod store_flast_ctrl {
     #[test]
     fn test_double_append() {
         let mut read_buf: [u8; 1024] = [0; 1024];
-        let tickfs = TickFS::<FlashCtrl, DefaultHasher>::new(
-            FlashCtrl::new(),
-            &mut read_buf,
-            0x10000,
-            0x400,
-        );
+        let tickfs =
+            TickFS::<FlashCtrl, DefaultHasher, 1024>::new(FlashCtrl::new(), &mut read_buf, 0x10000);
 
         let mut ret = tickfs.initalise((&mut DefaultHasher::new(), &mut DefaultHasher::new()));
         while ret.is_err() {
@@ -522,12 +518,8 @@ mod store_flast_ctrl {
     #[test]
     fn test_append_and_delete() {
         let mut read_buf: [u8; 1024] = [0; 1024];
-        let tickfs = TickFS::<FlashCtrl, DefaultHasher>::new(
-            FlashCtrl::new(),
-            &mut read_buf,
-            0x10000,
-            0x400,
-        );
+        let tickfs =
+            TickFS::<FlashCtrl, DefaultHasher, 1024>::new(FlashCtrl::new(), &mut read_buf, 0x10000);
 
         let mut ret = tickfs.initalise((&mut DefaultHasher::new(), &mut DefaultHasher::new()));
         while ret.is_err() {
@@ -582,12 +574,8 @@ mod store_flast_ctrl {
     #[test]
     fn test_garbage_collect() {
         let mut read_buf: [u8; 1024] = [0; 1024];
-        let tickfs = TickFS::<FlashCtrl, DefaultHasher>::new(
-            FlashCtrl::new(),
-            &mut read_buf,
-            0x10000,
-            0x400,
-        );
+        let tickfs =
+            TickFS::<FlashCtrl, DefaultHasher, 1024>::new(FlashCtrl::new(), &mut read_buf, 0x10000);
 
         let mut ret = tickfs.initalise((&mut DefaultHasher::new(), &mut DefaultHasher::new()));
         while ret.is_err() {

--- a/libraries/tickfs/src/async_ops.rs
+++ b/libraries/tickfs/src/async_ops.rs
@@ -10,7 +10,7 @@
 //! // and hence is not a good fit.
 //! use std::collections::hash_map::DefaultHasher;
 //! use std::cell::{Cell, RefCell};
-//! use tickfs::TickFS;
+//! use tickfs::AsyncTickFS;
 //! use tickfs::error_codes::ErrorCode;
 //! use tickfs::flash_controller::FlashController;
 //!
@@ -74,7 +74,7 @@
 //! // callbacks/interrupts and make this async.
 //!
 //! let mut read_buf: [u8; 1024] = [0; 1024];
-//! let tickfs = TickFS::<FlashCtrl, DefaultHasher, 1024>::new(FlashCtrl::new(),
+//! let tickfs = AsyncTickFS::<FlashCtrl, DefaultHasher, 1024>::new(FlashCtrl::new(),
 //!                   &mut read_buf, 0x1000);
 //!
 //! let mut ret = tickfs.initalise((&mut DefaultHasher::new(), &mut DefaultHasher::new()));
@@ -112,12 +112,209 @@
 //! error types can still be used.
 //!
 
+use crate::error_codes::ErrorCode;
+use crate::flash_controller::FlashController;
+use crate::success_codes::SuccessCode;
+use crate::tickfs::{State, TickFS};
+use core::hash::Hasher;
+
+/// The struct storing all of the TickFS information for the async implementation.
+pub struct AsyncTickFS<'a, C: FlashController<S>, H: Hasher, const S: usize> {
+    /// The controller used for flash commands
+    pub tickfs: TickFS<'a, C, H, S>,
+}
+
+impl<'a, C: FlashController<S>, H: Hasher, const S: usize> AsyncTickFS<'a, C, H, S> {
+    /// Create a new struct
+    ///
+    /// `C`: An implementation of the `FlashController` trait
+    ///
+    /// `controller`: An new struct implementing `FlashController`
+    /// `flash_size`: The total size of the flash used for TickFS
+    pub fn new(controller: C, read_buffer: &'a mut [u8; S], flash_size: usize) -> Self {
+        Self {
+            tickfs: TickFS::<C, H, S>::new(controller, read_buffer, flash_size),
+        }
+    }
+
+    /// This function setups the flash region to be used as a key-value store.
+    /// If the region is already initalised this won't make any changes.
+    ///
+    /// `H`: An implementation of a `core::hash::Hasher` trait. This MUST
+    ///      always return the same hash for the same input. That is the
+    ///      implementation can NOT change over time.
+    ///
+    /// If the specified region has not already been setup for TickFS
+    /// the entire region will be erased.
+    ///
+    /// On success nothing will be returned.
+    /// On error a `ErrorCode` will be returned.
+    pub fn initalise(&self, hash_function: (&mut H, &mut H)) -> Result<SuccessCode, ErrorCode> {
+        self.tickfs.initalise(hash_function)
+    }
+
+    /// Appends the key/value pair to flash storage.
+    ///
+    /// `hash_function`: Hash function with no previous state. This is
+    ///                  usually a newly created hash.
+    /// `key`: A unhashed key. This will be hashed internally. This key
+    ///        will be used in future to retrieve or remove the `value`.
+    /// `value`: A buffer containing the data to be stored to flash.
+    ///
+    /// On success nothing will be returned.
+    /// On error a `ErrorCode` will be returned.
+    pub fn append_key(
+        &self,
+        hash_function: &mut H,
+        key: &[u8],
+        value: &[u8],
+    ) -> Result<SuccessCode, ErrorCode> {
+        self.tickfs.append_key(hash_function, key, value)
+    }
+
+    /// Retrieves the value from flash storage.
+    ///
+    /// `hash_function`: Hash function with no previous state. This is
+    ///                  usually a newly created hash.
+    /// `key`: A unhashed key. This will be hashed internally.
+    /// `buf`: A buffer to store the value to.
+    ///
+    /// On success nothing will be returned.
+    /// On error a `ErrorCode` will be returned.
+    ///
+    /// If a power loss occurs before success is returned the data is
+    /// assumed to be lost.
+    pub fn get_key(
+        &self,
+        hash_function: &mut H,
+        key: &[u8],
+        buf: &mut [u8],
+    ) -> Result<SuccessCode, ErrorCode> {
+        self.tickfs.get_key(hash_function, key, buf)
+    }
+
+    /// Invalidates the key in flash storage
+    ///
+    /// `hash_function`: Hash function with no previous state. This is
+    ///                  usually a newly created hash.
+    /// `key`: A unhashed key. This will be hashed internally.
+    ///
+    /// On success nothing will be returned.
+    /// On error a `ErrorCode` will be returned.
+    ///
+    /// If a power loss occurs before success is returned the data is
+    /// assumed to be lost.
+    pub fn invalidate_key(
+        &self,
+        hash_function: &mut H,
+        key: &[u8],
+    ) -> Result<SuccessCode, ErrorCode> {
+        self.tickfs.invalidate_key(hash_function, key)
+    }
+
+    /// Perform a garbage collection on TickFS
+    ///
+    /// On success the number of bytes freed will be returned.
+    /// On error a `ErrorCode` will be returned.
+    pub fn garbage_collect(&self) -> Result<usize, ErrorCode> {
+        self.tickfs.garbage_collect()
+    }
+
+    /// Continue the initalise process after an async access.
+    ///
+    /// `H`: An implementation of a `core::hash::Hasher` trait. This MUST
+    ///      always return the same hash for the same input. That is the
+    ///      implementation can NOT change over time.
+    ///
+    /// On success nothing will be returned.
+    /// On error a `ErrorCode` will be returned.
+    pub fn continue_initalise(
+        &self,
+        hash_function: (&mut H, &mut H),
+    ) -> Result<SuccessCode, ErrorCode> {
+        let ret = self.tickfs.initalise(hash_function);
+
+        match ret {
+            Ok(_) => self.tickfs.state.set(State::None),
+            Err(e) => match e {
+                ErrorCode::ReadNotReady(_) | ErrorCode::EraseNotReady(_) => {}
+                _ => self.tickfs.state.set(State::None),
+            },
+        }
+
+        ret
+    }
+
+    /// Continue a previous key operation after an async access.
+    ///
+    /// `hash_function`: Hash function with no previous state. This is
+    ///                  usually a newly created hash.
+    /// `key`: A unhashed key. This will be hashed internally. This key
+    ///        will be used in future to retrieve or remove the `value`.
+    /// `value`: A buffer containing the data to be stored to flash.
+    /// `buf`: A buffer to store the value to.
+    ///
+    /// On success nothing will be returned.
+    /// On error a `ErrorCode` will be returned.
+    pub fn continue_operation(
+        &self,
+        hash_function: Option<&mut H>,
+        key: Option<&[u8]>,
+        value: Option<&[u8]>,
+        buf: Option<&mut [u8]>,
+    ) -> Result<SuccessCode, ErrorCode> {
+        let ret = match self.tickfs.state.get() {
+            State::AppendKey(_) => {
+                self.tickfs
+                    .append_key(hash_function.unwrap(), key.unwrap(), value.unwrap())
+            }
+            State::GetKey(_) => {
+                self.tickfs
+                    .get_key(hash_function.unwrap(), key.unwrap(), buf.unwrap())
+            }
+            State::InvalidateKey(_) => self
+                .tickfs
+                .invalidate_key(hash_function.unwrap(), key.unwrap()),
+            _ => unreachable!(),
+        };
+
+        match ret {
+            Ok(_) => self.tickfs.state.set(State::None),
+            Err(e) => match e {
+                ErrorCode::ReadNotReady(_) | ErrorCode::EraseNotReady(_) => {}
+                _ => self.tickfs.state.set(State::None),
+            },
+        }
+
+        ret
+    }
+
+    /// Continue the garbage collection process after an async access.
+    ///
+    /// On success the number of bytes freed will be returned.
+    /// On error a `ErrorCode` will be returned.
+    pub fn continue_garbage_collection(&self) -> Result<usize, ErrorCode> {
+        let ret = self.tickfs.garbage_collect();
+
+        match ret {
+            Ok(_) => self.tickfs.state.set(State::None),
+            Err(e) => match e {
+                ErrorCode::ReadNotReady(_) | ErrorCode::EraseNotReady(_) => {}
+                _ => self.tickfs.state.set(State::None),
+            },
+        }
+
+        ret
+    }
+}
+
 /// Tests using a flash controller that can store data
 #[cfg(test)]
 mod store_flast_ctrl {
+    use crate::async_ops::AsyncTickFS;
     use crate::error_codes::ErrorCode;
     use crate::flash_controller::FlashController;
-    use crate::tickfs::{TickFS, HASH_OFFSET, LEN_OFFSET, VERSION, VERSION_OFFSET};
+    use crate::tickfs::{HASH_OFFSET, LEN_OFFSET, VERSION, VERSION_OFFSET};
     use std::cell::Cell;
     use std::cell::RefCell;
     use std::collections::hash_map::DefaultHasher;
@@ -315,8 +512,11 @@ mod store_flast_ctrl {
     #[test]
     fn test_simple_append() {
         let mut read_buf: [u8; 1024] = [0; 1024];
-        let tickfs =
-            TickFS::<FlashCtrl, DefaultHasher, 1024>::new(FlashCtrl::new(), &mut read_buf, 0x1000);
+        let tickfs = AsyncTickFS::<FlashCtrl, DefaultHasher, 1024>::new(
+            FlashCtrl::new(),
+            &mut read_buf,
+            0x1000,
+        );
 
         let mut ret = tickfs.initalise((&mut DefaultHasher::new(), &mut DefaultHasher::new()));
         while ret.is_err() {
@@ -364,8 +564,11 @@ mod store_flast_ctrl {
     #[test]
     fn test_double_append() {
         let mut read_buf: [u8; 1024] = [0; 1024];
-        let tickfs =
-            TickFS::<FlashCtrl, DefaultHasher, 1024>::new(FlashCtrl::new(), &mut read_buf, 0x10000);
+        let tickfs = AsyncTickFS::<FlashCtrl, DefaultHasher, 1024>::new(
+            FlashCtrl::new(),
+            &mut read_buf,
+            0x10000,
+        );
 
         let mut ret = tickfs.initalise((&mut DefaultHasher::new(), &mut DefaultHasher::new()));
         while ret.is_err() {
@@ -518,8 +721,11 @@ mod store_flast_ctrl {
     #[test]
     fn test_append_and_delete() {
         let mut read_buf: [u8; 1024] = [0; 1024];
-        let tickfs =
-            TickFS::<FlashCtrl, DefaultHasher, 1024>::new(FlashCtrl::new(), &mut read_buf, 0x10000);
+        let tickfs = AsyncTickFS::<FlashCtrl, DefaultHasher, 1024>::new(
+            FlashCtrl::new(),
+            &mut read_buf,
+            0x10000,
+        );
 
         let mut ret = tickfs.initalise((&mut DefaultHasher::new(), &mut DefaultHasher::new()));
         while ret.is_err() {
@@ -574,8 +780,11 @@ mod store_flast_ctrl {
     #[test]
     fn test_garbage_collect() {
         let mut read_buf: [u8; 1024] = [0; 1024];
-        let tickfs =
-            TickFS::<FlashCtrl, DefaultHasher, 1024>::new(FlashCtrl::new(), &mut read_buf, 0x10000);
+        let tickfs = AsyncTickFS::<FlashCtrl, DefaultHasher, 1024>::new(
+            FlashCtrl::new(),
+            &mut read_buf,
+            0x10000,
+        );
 
         let mut ret = tickfs.initalise((&mut DefaultHasher::new(), &mut DefaultHasher::new()));
         while ret.is_err() {

--- a/libraries/tickfs/src/async_ops.rs
+++ b/libraries/tickfs/src/async_ops.rs
@@ -37,15 +37,9 @@
 //!         offset: usize,
 //!         buf: &mut [u8; 1024],
 //!     ) -> Result<(), ErrorCode> {
-//!         if self.async_read_region.get() != region_number {
-//!             // We aren't ready yet, launch the async operation
-//!             self.async_read_region.set(region_number);
-//!             return Err(ErrorCode::ReadNotReady(region_number));
-//!         }
-//!
-//!         for (i, b) in buf.iter_mut().enumerate() {
-//!             *b = self.buf.borrow()[region_number][offset + i]
-//!         }
+//!          // We aren't ready yet, launch the async operation
+//!          self.async_read_region.set(region_number);
+//!          return Err(ErrorCode::ReadNotReady(region_number));
 //!
 //!         Ok(())
 //!     }
@@ -80,28 +74,37 @@
 //! let mut ret = tickfs.initalise((&mut DefaultHasher::new(), &mut DefaultHasher::new()));
 //! while ret.is_err() {
 //!     // There is no actual delay here, in a real implementation wait on some event
-//!     ret = tickfs.continue_initalise(
-//!         (&mut DefaultHasher::new(), &mut DefaultHasher::new()),
-//!     );
+//!     ret = tickfs.continue_operation(
+//!         (&mut DefaultHasher::new(), &mut DefaultHasher::new()));
+//!
+//!     match ret {
+//!         Err(ErrorCode::ReadNotReady(reg)) => {
+//!             tickfs.set_read_buffer(&tickfs.tickfs.controller.buf.borrow()[reg]);
+//!         }
+//!         Ok(_) => break,
+//!         Err(ErrorCode::WriteNotReady(reg)) => break,
+//!         Err(ErrorCode::EraseNotReady(reg)) => {}
+//!         _ => unreachable!(),
+//!     }
 //! }
 //!
 //! // Then when calling the TickFS function check for the error. For example
 //! // when appending a key:
 //!
 //! // Add a key
-//! let value: [u8; 32] = [0x23; 32];
-//! let ret = tickfs.append_key(&mut DefaultHasher::new(), b"ONE", &value);
+//! static VALUE: [u8; 32] = [0x23; 32];
+//! let ret = unsafe { tickfs.append_key(&mut DefaultHasher::new(), b"ONE", &VALUE) };
 //!
 //! match ret {
 //!     Err(ErrorCode::ReadNotReady(reg)) => {
-//!         // Then once the read operation is ready call the `continue_operation()`
-//!         // function.
-//!
-//!         let ret = tickfs.
-//!                       continue_operation(Some(&mut DefaultHasher::new()), Some(b"ONE"), Some(&value), None);
+//!         // There is no actual delay in the test, just continue now
+//!         tickfs.set_read_buffer(&tickfs.tickfs.controller.buf.borrow()[reg]);
+//!         tickfs
+//!             .continue_operation((&mut DefaultHasher::new(), &mut DefaultHasher::new()))
+//!             .unwrap();
 //!     }
-//!     Ok(_) => {},
-//!     _ => panic!("Other error"),
+//!     Ok(_) => {}
+//!     _ => unreachable!(),
 //! }
 //!
 //! ```
@@ -116,12 +119,16 @@ use crate::error_codes::ErrorCode;
 use crate::flash_controller::FlashController;
 use crate::success_codes::SuccessCode;
 use crate::tickfs::{State, TickFS};
+use core::cell::Cell;
 use core::hash::Hasher;
 
 /// The struct storing all of the TickFS information for the async implementation.
 pub struct AsyncTickFS<'a, C: FlashController<S>, H: Hasher, const S: usize> {
     /// The controller used for flash commands
     pub tickfs: TickFS<'a, C, H, S>,
+    key: Cell<Option<&'static [u8]>>,
+    value: Cell<Option<&'static [u8]>>,
+    buf: Cell<Option<&'static mut [u8]>>,
 }
 
 impl<'a, C: FlashController<S>, H: Hasher, const S: usize> AsyncTickFS<'a, C, H, S> {
@@ -134,6 +141,9 @@ impl<'a, C: FlashController<S>, H: Hasher, const S: usize> AsyncTickFS<'a, C, H,
     pub fn new(controller: C, read_buffer: &'a mut [u8; S], flash_size: usize) -> Self {
         Self {
             tickfs: TickFS::<C, H, S>::new(controller, read_buffer, flash_size),
+            key: Cell::new(None),
+            value: Cell::new(None),
+            buf: Cell::new(None),
         }
     }
 
@@ -147,7 +157,7 @@ impl<'a, C: FlashController<S>, H: Hasher, const S: usize> AsyncTickFS<'a, C, H,
     /// If the specified region has not already been setup for TickFS
     /// the entire region will be erased.
     ///
-    /// On success nothing will be returned.
+    /// On success a `SuccessCode` will be returned.
     /// On error a `ErrorCode` will be returned.
     pub fn initalise(&self, hash_function: (&mut H, &mut H)) -> Result<SuccessCode, ErrorCode> {
         self.tickfs.initalise(hash_function)
@@ -166,10 +176,17 @@ impl<'a, C: FlashController<S>, H: Hasher, const S: usize> AsyncTickFS<'a, C, H,
     pub fn append_key(
         &self,
         hash_function: &mut H,
-        key: &[u8],
-        value: &[u8],
+        key: &'static [u8],
+        value: &'static [u8],
     ) -> Result<SuccessCode, ErrorCode> {
-        self.tickfs.append_key(hash_function, key, value)
+        match self.tickfs.append_key(hash_function, key, value) {
+            Ok(code) => Ok(code),
+            Err(e) => {
+                self.key.replace(Some(key));
+                self.value.replace(Some(value));
+                Err(e)
+            }
+        }
     }
 
     /// Retrieves the value from flash storage.
@@ -179,7 +196,7 @@ impl<'a, C: FlashController<S>, H: Hasher, const S: usize> AsyncTickFS<'a, C, H,
     /// `key`: A unhashed key. This will be hashed internally.
     /// `buf`: A buffer to store the value to.
     ///
-    /// On success nothing will be returned.
+    /// On success a `SuccessCode` will be returned.
     /// On error a `ErrorCode` will be returned.
     ///
     /// If a power loss occurs before success is returned the data is
@@ -187,10 +204,17 @@ impl<'a, C: FlashController<S>, H: Hasher, const S: usize> AsyncTickFS<'a, C, H,
     pub fn get_key(
         &self,
         hash_function: &mut H,
-        key: &[u8],
-        buf: &mut [u8],
+        key: &'static [u8],
+        buf: &'static mut [u8],
     ) -> Result<SuccessCode, ErrorCode> {
-        self.tickfs.get_key(hash_function, key, buf)
+        match self.tickfs.get_key(hash_function, key, buf) {
+            Ok(code) => Ok(code),
+            Err(e) => {
+                self.key.replace(Some(key));
+                self.buf.replace(Some(buf));
+                Err(e)
+            }
+        }
     }
 
     /// Invalidates the key in flash storage
@@ -199,7 +223,7 @@ impl<'a, C: FlashController<S>, H: Hasher, const S: usize> AsyncTickFS<'a, C, H,
     ///                  usually a newly created hash.
     /// `key`: A unhashed key. This will be hashed internally.
     ///
-    /// On success nothing will be returned.
+    /// On success a `SuccessCode` will be returned.
     /// On error a `ErrorCode` will be returned.
     ///
     /// If a power loss occurs before success is returned the data is
@@ -207,9 +231,15 @@ impl<'a, C: FlashController<S>, H: Hasher, const S: usize> AsyncTickFS<'a, C, H,
     pub fn invalidate_key(
         &self,
         hash_function: &mut H,
-        key: &[u8],
+        key: &'static [u8],
     ) -> Result<SuccessCode, ErrorCode> {
-        self.tickfs.invalidate_key(hash_function, key)
+        match self.tickfs.invalidate_key(hash_function, key) {
+            Ok(code) => Ok(code),
+            Err(e) => {
+                self.key.replace(Some(key));
+                Err(e)
+            }
+        }
     }
 
     /// Perform a garbage collection on TickFS
@@ -220,81 +250,52 @@ impl<'a, C: FlashController<S>, H: Hasher, const S: usize> AsyncTickFS<'a, C, H,
         self.tickfs.garbage_collect()
     }
 
-    /// Continue the initalise process after an async access.
-    ///
-    /// `H`: An implementation of a `core::hash::Hasher` trait. This MUST
-    ///      always return the same hash for the same input. That is the
-    ///      implementation can NOT change over time.
-    ///
-    /// On success nothing will be returned.
-    /// On error a `ErrorCode` will be returned.
-    pub fn continue_initalise(
-        &self,
-        hash_function: (&mut H, &mut H),
-    ) -> Result<SuccessCode, ErrorCode> {
-        let ret = self.tickfs.initalise(hash_function);
-
-        match ret {
-            Ok(_) => self.tickfs.state.set(State::None),
-            Err(e) => match e {
-                ErrorCode::ReadNotReady(_) | ErrorCode::EraseNotReady(_) => {}
-                _ => self.tickfs.state.set(State::None),
-            },
-        }
-
-        ret
+    /// Copy data from `read_buffer` argument to the internal read_buffer.
+    /// This should be used to copy the data that the implementation wanted
+    /// to read when calling `read_region` after the async operation has
+    /// completed.
+    pub fn set_read_buffer(&self, read_buffer: &[u8]) {
+        let buf = self.tickfs.read_buffer.take().unwrap();
+        buf.copy_from_slice(read_buffer);
+        self.tickfs.read_buffer.replace(Some(buf));
     }
 
-    /// Continue a previous key operation after an async access.
+    /// Continue the last operation after the async operation has completed.
+    /// This should be called from a read/erase complete callback.
+    /// NOTE: If called from a read callback, `set_read_buffer` should be
+    /// called first to update the data.
     ///
     /// `hash_function`: Hash function with no previous state. This is
     ///                  usually a newly created hash.
-    /// `key`: A unhashed key. This will be hashed internally. This key
-    ///        will be used in future to retrieve or remove the `value`.
-    /// `value`: A buffer containing the data to be stored to flash.
-    /// `buf`: A buffer to store the value to.
     ///
-    /// On success nothing will be returned.
+    /// On success a `SuccessCode` will be returned.
     /// On error a `ErrorCode` will be returned.
     pub fn continue_operation(
         &self,
-        hash_function: Option<&mut H>,
-        key: Option<&[u8]>,
-        value: Option<&[u8]>,
-        buf: Option<&mut [u8]>,
+        hash_function: (&mut H, &mut H),
     ) -> Result<SuccessCode, ErrorCode> {
         let ret = match self.tickfs.state.get() {
-            State::AppendKey(_) => {
-                self.tickfs
-                    .append_key(hash_function.unwrap(), key.unwrap(), value.unwrap())
-            }
-            State::GetKey(_) => {
-                self.tickfs
-                    .get_key(hash_function.unwrap(), key.unwrap(), buf.unwrap())
-            }
+            State::Init(_) => self.tickfs.initalise(hash_function),
+            State::AppendKey(_) => self.tickfs.append_key(
+                hash_function.0,
+                self.key.take().unwrap(),
+                self.value.take().unwrap(),
+            ),
+            State::GetKey(_) => self.tickfs.get_key(
+                hash_function.0,
+                self.key.take().unwrap(),
+                self.buf.take().unwrap(),
+            ),
+
             State::InvalidateKey(_) => self
                 .tickfs
-                .invalidate_key(hash_function.unwrap(), key.unwrap()),
+                .invalidate_key(hash_function.0, self.key.take().unwrap()),
+            State::GarbageCollect(_) => match self.tickfs.garbage_collect() {
+                Ok(_) => Ok(SuccessCode::Complete),
+                Err(e) => Err(e),
+            },
             _ => unreachable!(),
         };
-
-        match ret {
-            Ok(_) => self.tickfs.state.set(State::None),
-            Err(e) => match e {
-                ErrorCode::ReadNotReady(_) | ErrorCode::EraseNotReady(_) => {}
-                _ => self.tickfs.state.set(State::None),
-            },
-        }
-
-        ret
-    }
-
-    /// Continue the garbage collection process after an async access.
-    ///
-    /// On success the number of bytes freed will be returned.
-    /// On error a `ErrorCode` will be returned.
-    pub fn continue_garbage_collection(&self) -> Result<usize, ErrorCode> {
-        let ret = self.tickfs.garbage_collect();
 
         match ret {
             Ok(_) => self.tickfs.state.set(State::None),
@@ -521,39 +522,31 @@ mod store_flast_ctrl {
         let mut ret = tickfs.initalise((&mut DefaultHasher::new(), &mut DefaultHasher::new()));
         while ret.is_err() {
             // There is no actual delay in the test, just continue now
-            ret = tickfs.continue_initalise((&mut DefaultHasher::new(), &mut DefaultHasher::new()));
+            ret = tickfs.continue_operation((&mut DefaultHasher::new(), &mut DefaultHasher::new()));
         }
 
-        let value: [u8; 32] = [0x23; 32];
+        static VALUE: [u8; 32] = [0x23; 32];
 
-        let ret = tickfs.append_key(&mut DefaultHasher::new(), b"ONE", &value);
+        let ret = tickfs.append_key(&mut DefaultHasher::new(), b"ONE", &VALUE);
         match ret {
-            Err(ErrorCode::ReadNotReady(_reg)) => {
+            Err(ErrorCode::ReadNotReady(reg)) => {
                 // There is no actual delay in the test, just continue now
+                tickfs.set_read_buffer(&tickfs.tickfs.controller.buf.borrow()[reg]);
                 tickfs
-                    .continue_operation(
-                        Some(&mut DefaultHasher::new()),
-                        Some(b"ONE"),
-                        Some(&value),
-                        None,
-                    )
+                    .continue_operation((&mut DefaultHasher::new(), &mut DefaultHasher::new()))
                     .unwrap();
             }
             Ok(_) => {}
             _ => unreachable!(),
         }
 
-        let ret = tickfs.append_key(&mut DefaultHasher::new(), b"TWO", &value);
+        let ret = tickfs.append_key(&mut DefaultHasher::new(), b"TWO", &VALUE);
         match ret {
-            Err(ErrorCode::ReadNotReady(_reg)) => {
+            Err(ErrorCode::ReadNotReady(reg)) => {
                 // There is no actual delay in the test, just continue now
+                tickfs.set_read_buffer(&tickfs.tickfs.controller.buf.borrow()[reg]);
                 tickfs
-                    .continue_operation(
-                        Some(&mut DefaultHasher::new()),
-                        Some(b"TWO"),
-                        Some(&value),
-                        None,
-                    )
+                    .continue_operation((&mut DefaultHasher::new(), &mut DefaultHasher::new()))
                     .unwrap();
             }
             Ok(_) => {}
@@ -573,24 +566,20 @@ mod store_flast_ctrl {
         let mut ret = tickfs.initalise((&mut DefaultHasher::new(), &mut DefaultHasher::new()));
         while ret.is_err() {
             // There is no actual delay in the test, just continue now
-            ret = tickfs.continue_initalise((&mut DefaultHasher::new(), &mut DefaultHasher::new()));
+            ret = tickfs.continue_operation((&mut DefaultHasher::new(), &mut DefaultHasher::new()));
         }
 
-        let value: [u8; 32] = [0x23; 32];
-        let mut buf: [u8; 32] = [0; 32];
+        static VALUE: [u8; 32] = [0x23; 32];
+        static mut BUF: [u8; 32] = [0; 32];
 
         println!("Add key ONE");
-        let ret = tickfs.append_key(&mut DefaultHasher::new(), b"ONE", &value);
+        let ret = tickfs.append_key(&mut DefaultHasher::new(), b"ONE", &VALUE);
         match ret {
-            Err(ErrorCode::ReadNotReady(_reg)) => {
+            Err(ErrorCode::ReadNotReady(reg)) => {
                 // There is no actual delay in the test, just continue now
+                tickfs.set_read_buffer(&tickfs.tickfs.controller.buf.borrow()[reg]);
                 tickfs
-                    .continue_operation(
-                        Some(&mut DefaultHasher::new()),
-                        Some(b"ONE"),
-                        Some(&value),
-                        None,
-                    )
+                    .continue_operation((&mut DefaultHasher::new(), &mut DefaultHasher::new()))
                     .unwrap();
             }
             Ok(_) => {}
@@ -598,22 +587,21 @@ mod store_flast_ctrl {
         }
 
         println!("Get key ONE");
-        tickfs
-            .get_key(&mut DefaultHasher::new(), b"ONE", &mut buf)
-            .unwrap();
+        unsafe {
+            tickfs
+                .get_key(&mut DefaultHasher::new(), b"ONE", &mut BUF)
+                .unwrap();
+        }
 
         println!("Get non-existant key TWO");
-        let ret = tickfs.get_key(&mut DefaultHasher::new(), b"TWO", &mut buf);
+        let ret = unsafe { tickfs.get_key(&mut DefaultHasher::new(), b"TWO", &mut BUF) };
         match ret {
-            Err(ErrorCode::ReadNotReady(_reg)) => {
+            Err(ErrorCode::ReadNotReady(reg)) => {
                 // There is no actual delay in the test, just continue now
+                tickfs.set_read_buffer(&tickfs.tickfs.controller.buf.borrow()[reg]);
                 assert_eq!(
-                    tickfs.continue_operation(
-                        Some(&mut DefaultHasher::new()),
-                        Some(b"ONE"),
-                        None,
-                        Some(&mut buf),
-                    ),
+                    tickfs
+                        .continue_operation((&mut DefaultHasher::new(), &mut DefaultHasher::new())),
                     Err(ErrorCode::KeyNotFound)
                 );
             }
@@ -622,17 +610,14 @@ mod store_flast_ctrl {
         }
 
         println!("Add key ONE again");
-        let ret = tickfs.append_key(&mut DefaultHasher::new(), b"ONE", &value);
+        let ret = tickfs.append_key(&mut DefaultHasher::new(), b"ONE", &VALUE);
         match ret {
-            Err(ErrorCode::ReadNotReady(_reg)) => {
+            Err(ErrorCode::ReadNotReady(reg)) => {
                 // There is no actual delay in the test, just continue now
+                tickfs.set_read_buffer(&tickfs.tickfs.controller.buf.borrow()[reg]);
                 assert_eq!(
-                    tickfs.continue_operation(
-                        Some(&mut DefaultHasher::new()),
-                        Some(b"ONE"),
-                        Some(&value),
-                        None,
-                    ),
+                    tickfs
+                        .continue_operation((&mut DefaultHasher::new(), &mut DefaultHasher::new())),
                     Err(ErrorCode::KeyAlreadyExists)
                 );
             }
@@ -641,17 +626,13 @@ mod store_flast_ctrl {
         }
 
         println!("Add key TWO");
-        let ret = tickfs.append_key(&mut DefaultHasher::new(), b"TWO", &value);
+        let ret = tickfs.append_key(&mut DefaultHasher::new(), b"TWO", &VALUE);
         match ret {
-            Err(ErrorCode::ReadNotReady(_reg)) => {
+            Err(ErrorCode::ReadNotReady(reg)) => {
                 // There is no actual delay in the test, just continue now
+                tickfs.set_read_buffer(&tickfs.tickfs.controller.buf.borrow()[reg]);
                 tickfs
-                    .continue_operation(
-                        Some(&mut DefaultHasher::new()),
-                        Some(b"TWO"),
-                        Some(&value),
-                        None,
-                    )
+                    .continue_operation((&mut DefaultHasher::new(), &mut DefaultHasher::new()))
                     .unwrap();
             }
             Ok(_) => {}
@@ -659,17 +640,13 @@ mod store_flast_ctrl {
         }
 
         println!("Get key ONE");
-        let ret = tickfs.get_key(&mut DefaultHasher::new(), b"ONE", &mut buf);
+        let ret = unsafe { tickfs.get_key(&mut DefaultHasher::new(), b"ONE", &mut BUF) };
         match ret {
-            Err(ErrorCode::ReadNotReady(_reg)) => {
+            Err(ErrorCode::ReadNotReady(reg)) => {
                 // There is no actual delay in the test, just continue now
+                tickfs.set_read_buffer(&tickfs.tickfs.controller.buf.borrow()[reg]);
                 tickfs
-                    .continue_operation(
-                        Some(&mut DefaultHasher::new()),
-                        Some(b"ONE"),
-                        None,
-                        Some(&mut buf),
-                    )
+                    .continue_operation((&mut DefaultHasher::new(), &mut DefaultHasher::new()))
                     .unwrap();
             }
             Ok(_) => {}
@@ -677,17 +654,13 @@ mod store_flast_ctrl {
         }
 
         println!("Get key TWO");
-        let ret = tickfs.get_key(&mut DefaultHasher::new(), b"TWO", &mut buf);
+        let ret = unsafe { tickfs.get_key(&mut DefaultHasher::new(), b"TWO", &mut BUF) };
         match ret {
-            Err(ErrorCode::ReadNotReady(_reg)) => {
+            Err(ErrorCode::ReadNotReady(reg)) => {
                 // There is no actual delay in the test, just continue now
+                tickfs.set_read_buffer(&tickfs.tickfs.controller.buf.borrow()[reg]);
                 tickfs
-                    .continue_operation(
-                        Some(&mut DefaultHasher::new()),
-                        Some(b"TWO"),
-                        None,
-                        Some(&mut buf),
-                    )
+                    .continue_operation((&mut DefaultHasher::new(), &mut DefaultHasher::new()))
                     .unwrap();
             }
             Ok(_) => {}
@@ -695,17 +668,14 @@ mod store_flast_ctrl {
         }
 
         println!("Get non-existant key THREE");
-        let ret = tickfs.get_key(&mut DefaultHasher::new(), b"THREE", &mut buf);
+        let ret = unsafe { tickfs.get_key(&mut DefaultHasher::new(), b"THREE", &mut BUF) };
         match ret {
-            Err(ErrorCode::ReadNotReady(_reg)) => {
+            Err(ErrorCode::ReadNotReady(reg)) => {
                 // There is no actual delay in the test, just continue now
+                tickfs.set_read_buffer(&tickfs.tickfs.controller.buf.borrow()[reg]);
                 assert_eq!(
-                    tickfs.continue_operation(
-                        Some(&mut DefaultHasher::new()),
-                        Some(b"TWO"),
-                        None,
-                        Some(&mut buf),
-                    ),
+                    tickfs
+                        .continue_operation((&mut DefaultHasher::new(), &mut DefaultHasher::new())),
                     Err(ErrorCode::KeyNotFound)
                 );
             }
@@ -713,7 +683,7 @@ mod store_flast_ctrl {
         }
 
         assert_eq!(
-            tickfs.get_key(&mut DefaultHasher::new(), b"THREE", &mut buf),
+            unsafe { tickfs.get_key(&mut DefaultHasher::new(), b"THREE", &mut BUF) },
             Err(ErrorCode::KeyNotFound)
         );
     }
@@ -730,24 +700,20 @@ mod store_flast_ctrl {
         let mut ret = tickfs.initalise((&mut DefaultHasher::new(), &mut DefaultHasher::new()));
         while ret.is_err() {
             // There is no actual delay in the test, just continue now
-            ret = tickfs.continue_initalise((&mut DefaultHasher::new(), &mut DefaultHasher::new()));
+            ret = tickfs.continue_operation((&mut DefaultHasher::new(), &mut DefaultHasher::new()));
         }
 
-        let value: [u8; 32] = [0x23; 32];
-        let mut buf: [u8; 32] = [0; 32];
+        static VALUE: [u8; 32] = [0x23; 32];
+        static mut BUF: [u8; 32] = [0; 32];
 
         println!("Add key ONE");
-        let ret = tickfs.append_key(&mut DefaultHasher::new(), b"ONE", &value);
+        let ret = tickfs.append_key(&mut DefaultHasher::new(), b"ONE", &VALUE);
         match ret {
-            Err(ErrorCode::ReadNotReady(_reg)) => {
+            Err(ErrorCode::ReadNotReady(reg)) => {
                 // There is no actual delay in the test, just continue now
+                tickfs.set_read_buffer(&tickfs.tickfs.controller.buf.borrow()[reg]);
                 tickfs
-                    .continue_operation(
-                        Some(&mut DefaultHasher::new()),
-                        Some(b"ONE"),
-                        Some(&value),
-                        None,
-                    )
+                    .continue_operation((&mut DefaultHasher::new(), &mut DefaultHasher::new()))
                     .unwrap();
             }
             Ok(_) => {}
@@ -755,9 +721,11 @@ mod store_flast_ctrl {
         }
 
         println!("Get key ONE");
-        tickfs
-            .get_key(&mut DefaultHasher::new(), b"ONE", &mut buf)
-            .unwrap();
+        unsafe {
+            tickfs
+                .get_key(&mut DefaultHasher::new(), b"ONE", &mut BUF)
+                .unwrap();
+        }
 
         println!("Delete Key ONE");
         tickfs
@@ -766,7 +734,7 @@ mod store_flast_ctrl {
 
         println!("Get non-existant key ONE");
         assert_eq!(
-            tickfs.get_key(&mut DefaultHasher::new(), b"ONE", &mut buf),
+            unsafe { tickfs.get_key(&mut DefaultHasher::new(), b"ONE", &mut BUF) },
             Err(ErrorCode::KeyNotFound)
         );
 
@@ -789,31 +757,32 @@ mod store_flast_ctrl {
         let mut ret = tickfs.initalise((&mut DefaultHasher::new(), &mut DefaultHasher::new()));
         while ret.is_err() {
             // There is no actual delay in the test, just continue now
-            ret = tickfs.continue_initalise((&mut DefaultHasher::new(), &mut DefaultHasher::new()));
+            ret = tickfs.continue_operation((&mut DefaultHasher::new(), &mut DefaultHasher::new()));
         }
 
-        let value: [u8; 32] = [0x23; 32];
-        let mut buf: [u8; 32] = [0; 32];
+        static VALUE: [u8; 32] = [0x23; 32];
+        static mut BUF: [u8; 32] = [0; 32];
 
         println!("Garbage collect empty flash");
         let mut ret = tickfs.garbage_collect();
         while ret.is_err() {
             // There is no actual delay in the test, just continue now
-            ret = tickfs.continue_garbage_collection();
+            ret = match tickfs
+                .continue_operation((&mut DefaultHasher::new(), &mut DefaultHasher::new()))
+            {
+                Ok(_) => Ok(0),
+                Err(e) => Err(e),
+            };
         }
 
         println!("Add key ONE");
-        let ret = tickfs.append_key(&mut DefaultHasher::new(), b"ONE", &value);
+        let ret = tickfs.append_key(&mut DefaultHasher::new(), b"ONE", &VALUE);
         match ret {
-            Err(ErrorCode::ReadNotReady(_reg)) => {
+            Err(ErrorCode::ReadNotReady(reg)) => {
                 // There is no actual delay in the test, just continue now
+                tickfs.set_read_buffer(&tickfs.tickfs.controller.buf.borrow()[reg]);
                 tickfs
-                    .continue_operation(
-                        Some(&mut DefaultHasher::new()),
-                        Some(b"ONE"),
-                        Some(&value),
-                        None,
-                    )
+                    .continue_operation((&mut DefaultHasher::new(), &mut DefaultHasher::new()))
                     .unwrap();
             }
             Ok(_) => {}
@@ -824,9 +793,15 @@ mod store_flast_ctrl {
         let mut ret = tickfs.garbage_collect();
         while ret.is_err() {
             match ret {
-                Err(ErrorCode::ReadNotReady(_reg)) => {
+                Err(ErrorCode::ReadNotReady(reg)) => {
                     // There is no actual delay in the test, just continue now
-                    ret = tickfs.continue_garbage_collection();
+                    tickfs.set_read_buffer(&tickfs.tickfs.controller.buf.borrow()[reg]);
+                    ret = match tickfs
+                        .continue_operation((&mut DefaultHasher::new(), &mut DefaultHasher::new()))
+                    {
+                        Ok(_) => Ok(0),
+                        Err(e) => Err(e),
+                    };
                 }
                 Ok(num) => {
                     assert_eq!(num, 0);
@@ -838,10 +813,11 @@ mod store_flast_ctrl {
         println!("Delete Key ONE");
         let ret = tickfs.invalidate_key(&mut DefaultHasher::new(), b"ONE");
         match ret {
-            Err(ErrorCode::ReadNotReady(_reg)) => {
+            Err(ErrorCode::ReadNotReady(reg)) => {
                 // There is no actual delay in the test, just continue now
+                tickfs.set_read_buffer(&tickfs.tickfs.controller.buf.borrow()[reg]);
                 tickfs
-                    .continue_operation(Some(&mut DefaultHasher::new()), Some(b"ONE"), None, None)
+                    .continue_operation((&mut DefaultHasher::new(), &mut DefaultHasher::new()))
                     .unwrap();
             }
             Ok(_) => {}
@@ -852,13 +828,24 @@ mod store_flast_ctrl {
         let mut ret = tickfs.garbage_collect();
         while ret.is_err() {
             match ret {
-                Err(ErrorCode::ReadNotReady(_reg)) => {
+                Err(ErrorCode::ReadNotReady(reg)) => {
                     // There is no actual delay in the test, just continue now
-                    ret = tickfs.continue_garbage_collection();
+                    tickfs.set_read_buffer(&tickfs.tickfs.controller.buf.borrow()[reg]);
+                    ret = match tickfs
+                        .continue_operation((&mut DefaultHasher::new(), &mut DefaultHasher::new()))
+                    {
+                        Ok(_) => Ok(0),
+                        Err(e) => Err(e),
+                    };
                 }
                 Err(ErrorCode::EraseNotReady(_reg)) => {
                     // There is no actual delay in the test, just continue now
-                    ret = tickfs.continue_garbage_collection();
+                    ret = match tickfs
+                        .continue_operation((&mut DefaultHasher::new(), &mut DefaultHasher::new()))
+                    {
+                        Ok(_) => Ok(0),
+                        Err(e) => Err(e),
+                    };
                 }
                 Ok(num) => {
                     assert_eq!(num, 1024);
@@ -868,17 +855,14 @@ mod store_flast_ctrl {
         }
 
         println!("Get non-existant key ONE");
-        let ret = tickfs.get_key(&mut DefaultHasher::new(), b"ONE", &mut buf);
+        let ret = unsafe { tickfs.get_key(&mut DefaultHasher::new(), b"ONE", &mut BUF) };
         match ret {
-            Err(ErrorCode::ReadNotReady(_reg)) => {
+            Err(ErrorCode::ReadNotReady(reg)) => {
                 // There is no actual delay in the test, just continue now
+                tickfs.set_read_buffer(&tickfs.tickfs.controller.buf.borrow()[reg]);
                 assert_eq!(
-                    tickfs.continue_operation(
-                        Some(&mut DefaultHasher::new()),
-                        Some(b"ONE"),
-                        None,
-                        Some(&mut buf),
-                    ),
+                    tickfs
+                        .continue_operation((&mut DefaultHasher::new(), &mut DefaultHasher::new())),
                     Err(ErrorCode::KeyNotFound)
                 );
             }
@@ -888,7 +872,7 @@ mod store_flast_ctrl {
 
         println!("Add Key ONE");
         tickfs
-            .append_key(&mut DefaultHasher::new(), b"ONE", &value)
+            .append_key(&mut DefaultHasher::new(), b"ONE", &VALUE)
             .unwrap();
     }
 }

--- a/libraries/tickfs/src/async_ops.rs
+++ b/libraries/tickfs/src/async_ops.rs
@@ -1,0 +1,703 @@
+//! TickFS can be used asynchronously. This module provides documentation and
+//! tests for using it with an async `FlashController` interface.
+//!
+//! To do this first there are special error values to return from the
+//! `FlashController` functions. These are the `ReadNotReady`, `WriteNotReady`
+//! and `EraseNotReady` types.
+//!
+//! ```rust
+//! // EXAMPLE ONLY: The `DefaultHasher` is subject to change
+//! // and hence is not a good fit.
+//! use std::collections::hash_map::DefaultHasher;
+//! use std::cell::{Cell, RefCell};
+//! use tickfs::{TickFS, State, Operation};
+//! use tickfs::error_codes::ErrorCode;
+//! use tickfs::flash_controller::FlashController;
+//!
+//! struct FlashCtrl {
+//!     buf: RefCell<[[u8; 1024]; 64]>,
+//!     async_read_region: Cell<usize>,
+//!     async_erase_region: Cell<usize>,
+//! }
+//!
+//! impl FlashCtrl {
+//!     fn new() -> Self {
+//!         Self {
+//!             buf: RefCell::new([[0xFF; 1024]; 64]),
+//!             async_read_region: Cell::new(10),
+//!             async_erase_region: Cell::new(10),
+//!         }
+//!     }
+//! }
+//!
+//! impl FlashController for FlashCtrl {
+//!     fn read_region(
+//!         &self,
+//!         region_number: usize,
+//!         offset: usize,
+//!         buf: &mut [u8],
+//!     ) -> Result<(), ErrorCode> {
+//!         if self.async_read_region.get() != region_number {
+//!             // We aren't ready yet, launch the async operation
+//!             self.async_read_region.set(region_number);
+//!             return Err(ErrorCode::ReadNotReady(region_number));
+//!         }
+//!
+//!         for (i, b) in buf.iter_mut().enumerate() {
+//!             *b = self.buf.borrow()[region_number][offset + i]
+//!         }
+//!
+//!         Ok(())
+//!     }
+//!
+//!     fn write(&self, address: usize, buf: &[u8]) -> Result<(), ErrorCode> {
+//!         // Save the write operation to a queue, we don't need to re-call
+//!         for (i, d) in buf.iter().enumerate() {
+//!             self.buf.borrow_mut()[address / 1024][(address % 1024) + i] = *d;
+//!         }
+//!         Ok(())
+//!     }
+//!
+//!     fn erase_region(&self, region_number: usize) -> Result<(), ErrorCode> {
+//!         if self.async_erase_region.get() != region_number {
+//!             // We aren't ready yet, launch the async operation
+//!             self.async_erase_region.set(region_number);
+//!             return Err(ErrorCode::EraseNotReady(region_number));
+//!         }
+//!
+//!         Ok(())
+//!     }
+//! }
+//!
+//! // Create the TickFS instance and loop until everything is done
+//! // NOTE in an real implementation you will want to wait on
+//! // callbacks/interrupts and make this async.
+//!
+//! let mut read_buf: [u8; 1024] = [0; 1024];
+//! let tickfs = TickFS::<FlashCtrl, DefaultHasher>::new(FlashCtrl::new(),
+//!                   &mut read_buf, 0x1000, 0x400);
+//!
+//! let mut ret = tickfs.initalise((&mut DefaultHasher::new(), &mut DefaultHasher::new()));
+//! while ret.is_err() {
+//!     let state;
+//!     match ret {
+//!         Err(ErrorCode::ReadNotReady(reg)) => {
+//!             // Read isn't ready, save the state
+//!             state = State::ReadComplete(reg as isize);
+//!         }
+//!         Err(ErrorCode::EraseNotReady(reg)) => {
+//!             // Erase isn't ready, save the state
+//!             state = State::EraseComplete(reg);
+//!         }
+//!         Ok(()) => {
+//!             break;
+//!         }
+//!         _ => unreachable!(),
+//!     }
+//!     // There is no actual delay here, in a real implementation wait on some event
+//!     ret = tickfs.continue_initalise(
+//!         state,
+//!         (&mut DefaultHasher::new(), &mut DefaultHasher::new()),
+//!     );
+//! }
+//!
+//! // Then when calling the TickFS function check for the error. For example
+//! // when appending a key:
+//!
+//! // Add a key
+//! let value: [u8; 32] = [0x23; 32];
+//! let ret = tickfs.append_key(&mut DefaultHasher::new(), b"ONE", &value);
+//!
+//! match ret {
+//!     Err(ErrorCode::ReadNotReady(reg)) => {
+//!         // Read isn't ready, save the state
+//!         let operation = Operation::AppendKey;
+//!         let state = State::ReadComplete(reg as isize);
+//!
+//!         // Then once the read operation is ready call the `continue_operation()`
+//!         // function.
+//!
+//!         let ret = tickfs.
+//!                       continue_operation(operation, state, Some(&mut DefaultHasher::new()), Some(b"ONE"), Some(&value), None);
+//!     }
+//!     Ok(()) => {},
+//!     _ => panic!("Other error"),
+//! }
+//!
+//! ```
+//!
+//! This will call into the `FlashController` again where the
+//! `FlashController` implementation must return the data that is requested.
+//! If the data isn't ready (multiple reads might occur) then the `NotReady`
+//! error types can still be used.
+//!
+
+/// Tests using a flash controller that can store data
+#[cfg(test)]
+mod store_flast_ctrl {
+    use crate::error_codes::ErrorCode;
+    use crate::flash_controller::FlashController;
+    use crate::tickfs::{
+        Operation, State, TickFS, HASH_OFFSET, LEN_OFFSET, VERSION, VERSION_OFFSET,
+    };
+    use std::cell::Cell;
+    use std::cell::RefCell;
+    use std::collections::hash_map::DefaultHasher;
+
+    fn check_region_main(buf: &[u8]) {
+        // Check the version
+        assert_eq!(buf[VERSION_OFFSET], VERSION);
+
+        // Check the length
+        assert_eq!(buf[LEN_OFFSET], 0x80);
+        assert_eq!(buf[LEN_OFFSET + 1], 19);
+
+        // Check the hash
+        assert_eq!(buf[HASH_OFFSET + 0], 0x13);
+        assert_eq!(buf[HASH_OFFSET + 1], 0x67);
+        assert_eq!(buf[HASH_OFFSET + 2], 0xd3);
+        assert_eq!(buf[HASH_OFFSET + 3], 0xe4);
+        assert_eq!(buf[HASH_OFFSET + 4], 0xe0);
+        assert_eq!(buf[HASH_OFFSET + 5], 0x9b);
+        assert_eq!(buf[HASH_OFFSET + 6], 0xf7);
+        assert_eq!(buf[HASH_OFFSET + 7], 0x6e);
+
+        // Check the check hash
+        assert_eq!(buf[HASH_OFFSET + 8], 0xdb);
+        assert_eq!(buf[HASH_OFFSET + 9], 0x6d);
+        assert_eq!(buf[HASH_OFFSET + 10], 0x81);
+        assert_eq!(buf[HASH_OFFSET + 11], 0xc6);
+        assert_eq!(buf[HASH_OFFSET + 12], 0x6b);
+        assert_eq!(buf[HASH_OFFSET + 13], 0x95);
+        assert_eq!(buf[HASH_OFFSET + 14], 0x50);
+        assert_eq!(buf[HASH_OFFSET + 15], 0xdc);
+    }
+
+    fn check_region_one(buf: &[u8]) {
+        // Check the version
+        assert_eq!(buf[VERSION_OFFSET], VERSION);
+
+        // Check the length
+        assert_eq!(buf[LEN_OFFSET], 0x80);
+        assert_eq!(buf[LEN_OFFSET + 1], 51);
+
+        // Check the hash
+        assert_eq!(buf[HASH_OFFSET + 0], 0x81);
+        assert_eq!(buf[HASH_OFFSET + 1], 0x13);
+        assert_eq!(buf[HASH_OFFSET + 2], 0x7e);
+        assert_eq!(buf[HASH_OFFSET + 3], 0x95);
+        assert_eq!(buf[HASH_OFFSET + 4], 0x9e);
+        assert_eq!(buf[HASH_OFFSET + 5], 0x93);
+        assert_eq!(buf[HASH_OFFSET + 6], 0xaa);
+        assert_eq!(buf[HASH_OFFSET + 7], 0x3d);
+
+        // Check the value
+        assert_eq!(buf[HASH_OFFSET + 8], 0x23);
+        assert_eq!(buf[28], 0x23);
+        assert_eq!(buf[42], 0x23);
+
+        // Check the check hash
+        assert_eq!(buf[43], 0x08);
+        assert_eq!(buf[44], 0x05);
+        assert_eq!(buf[45], 0x89);
+        assert_eq!(buf[46], 0xef);
+        assert_eq!(buf[47], 0x5d);
+        assert_eq!(buf[48], 0x42);
+        assert_eq!(buf[49], 0x42);
+        assert_eq!(buf[50], 0xdc);
+    }
+
+    fn check_region_two(buf: &[u8]) {
+        // Check the version
+        assert_eq!(buf[VERSION_OFFSET], VERSION);
+
+        // Check the length
+        assert_eq!(buf[LEN_OFFSET], 0x80);
+        assert_eq!(buf[LEN_OFFSET + 1], 51);
+
+        // Check the hash
+        assert_eq!(buf[HASH_OFFSET + 0], 0x9d);
+        assert_eq!(buf[HASH_OFFSET + 1], 0xd3);
+        assert_eq!(buf[HASH_OFFSET + 2], 0x71);
+        assert_eq!(buf[HASH_OFFSET + 3], 0x45);
+        assert_eq!(buf[HASH_OFFSET + 4], 0x05);
+        assert_eq!(buf[HASH_OFFSET + 5], 0xc2);
+        assert_eq!(buf[HASH_OFFSET + 6], 0xf8);
+        assert_eq!(buf[HASH_OFFSET + 7], 0x66);
+
+        // Check the value
+        assert_eq!(buf[HASH_OFFSET + 8], 0x23);
+        assert_eq!(buf[28], 0x23);
+        assert_eq!(buf[42], 0x23);
+
+        // Check the check hash
+        assert_eq!(buf[43], 0xdb);
+        assert_eq!(buf[44], 0x1d);
+        assert_eq!(buf[45], 0xd4);
+        assert_eq!(buf[46], 0x8a);
+        assert_eq!(buf[47], 0x7b);
+        assert_eq!(buf[48], 0x39);
+        assert_eq!(buf[49], 0x53);
+        assert_eq!(buf[50], 0x8f);
+    }
+
+    // An example FlashCtrl implementation
+    struct FlashCtrl {
+        buf: RefCell<[[u8; 1024]; 64]>,
+        run: Cell<u8>,
+        async_read_region: Cell<usize>,
+        async_erase_region: Cell<usize>,
+    }
+
+    impl FlashCtrl {
+        fn new() -> Self {
+            Self {
+                buf: RefCell::new([[0xFF; 1024]; 64]),
+                run: Cell::new(0),
+                async_read_region: Cell::new(100),
+                async_erase_region: Cell::new(100),
+            }
+        }
+    }
+
+    impl FlashController for FlashCtrl {
+        fn read_region(
+            &self,
+            region_number: usize,
+            offset: usize,
+            buf: &mut [u8],
+        ) -> Result<(), ErrorCode> {
+            println!("Read from region: {}", region_number);
+
+            if self.async_read_region.get() != region_number {
+                // Pretend that we aren't ready
+                self.async_read_region.set(region_number);
+                println!("  Not ready");
+                return Err(ErrorCode::ReadNotReady(region_number));
+            }
+
+            for (i, b) in buf.iter_mut().enumerate() {
+                *b = self.buf.borrow()[region_number][offset + i]
+            }
+
+            // println!("  buf: {:#x?}", self.buf.borrow()[region_number]);
+
+            Ok(())
+        }
+
+        fn write(&self, address: usize, buf: &[u8]) -> Result<(), ErrorCode> {
+            println!(
+                "Write to address: {:#x}, region: {}",
+                address,
+                address / 1024
+            );
+
+            for (i, d) in buf.iter().enumerate() {
+                self.buf.borrow_mut()[address / 1024][(address % 1024) + i] = *d;
+            }
+
+            // Check to see if we are adding a key
+            if buf.len() > 1 {
+                if self.run.get() == 0 {
+                    println!("Writing main key: {:#x?}", buf);
+                    check_region_main(buf);
+                } else if self.run.get() == 1 {
+                    println!("Writing key ONE: {:#x?}", buf);
+                    check_region_one(buf);
+                } else if self.run.get() == 2 {
+                    println!("Writing key TWO: {:#x?}", buf);
+                    check_region_two(buf);
+                }
+            }
+
+            self.run.set(self.run.get() + 1);
+
+            Ok(())
+        }
+
+        fn erase_region(&self, region_number: usize) -> Result<(), ErrorCode> {
+            println!("Erase region: {}", region_number);
+
+            if self.async_erase_region.get() != region_number {
+                // Pretend that we aren't ready
+                self.async_erase_region.set(region_number);
+                return Err(ErrorCode::EraseNotReady(region_number));
+            }
+
+            let mut local_buf = self.buf.borrow_mut()[region_number];
+
+            for d in local_buf.iter_mut() {
+                *d = 0xFF;
+            }
+
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn test_simple_append() {
+        let mut read_buf: [u8; 1024] = [0; 1024];
+        let tickfs =
+            TickFS::<FlashCtrl, DefaultHasher>::new(FlashCtrl::new(), &mut read_buf, 0x1000, 0x400);
+
+        let mut ret = tickfs.initalise((&mut DefaultHasher::new(), &mut DefaultHasher::new()));
+        while ret.is_err() {
+            let state;
+            match ret {
+                Err(ErrorCode::ReadNotReady(reg)) => {
+                    // Read isn't ready, save the state
+                    state = State::ReadComplete(reg as isize);
+                }
+                Err(ErrorCode::EraseNotReady(reg)) => {
+                    // Erase isn't ready, save the state
+                    state = State::EraseComplete(reg);
+                }
+                Ok(()) => {
+                    break;
+                }
+                _ => unreachable!(),
+            }
+            // There is no actual delay in the test, just continue now
+            ret = tickfs.continue_initalise(
+                state,
+                (&mut DefaultHasher::new(), &mut DefaultHasher::new()),
+            );
+        }
+
+        let value: [u8; 32] = [0x23; 32];
+
+        let ret = tickfs.append_key(&mut DefaultHasher::new(), b"ONE", &value);
+        match ret {
+            Err(ErrorCode::ReadNotReady(reg)) => {
+                // Read isn't ready, save the state
+                let operation = Operation::AppendKey;
+                let state = State::ReadComplete(reg as isize);
+
+                // There is no actual delay in the test, just continue now
+                tickfs
+                    .continue_operation(
+                        operation,
+                        state,
+                        Some(&mut DefaultHasher::new()),
+                        Some(b"ONE"),
+                        Some(&value),
+                        None,
+                    )
+                    .unwrap();
+            }
+            Ok(()) => {}
+            _ => unreachable!(),
+        }
+
+        tickfs
+            .append_key(&mut DefaultHasher::new(), b"TWO", &value)
+            .unwrap();
+    }
+
+    #[test]
+    fn test_double_append() {
+        let mut read_buf: [u8; 1024] = [0; 1024];
+        let tickfs = TickFS::<FlashCtrl, DefaultHasher>::new(
+            FlashCtrl::new(),
+            &mut read_buf,
+            0x10000,
+            0x400,
+        );
+
+        let mut ret = tickfs.initalise((&mut DefaultHasher::new(), &mut DefaultHasher::new()));
+        while ret.is_err() {
+            let state;
+            match ret {
+                Err(ErrorCode::ReadNotReady(reg)) => {
+                    // Read isn't ready, save the state
+                    state = State::ReadComplete(reg as isize);
+                }
+                Err(ErrorCode::EraseNotReady(reg)) => {
+                    // Erase isn't ready, save the state
+                    state = State::EraseComplete(reg);
+                }
+                Ok(()) => {
+                    break;
+                }
+                _ => unreachable!(),
+            }
+            // There is no actual delay in the test, just continue now
+            ret = tickfs.continue_initalise(
+                state,
+                (&mut DefaultHasher::new(), &mut DefaultHasher::new()),
+            );
+        }
+
+        let value: [u8; 32] = [0x23; 32];
+        let mut buf: [u8; 32] = [0; 32];
+
+        println!("Add key ONE");
+        let ret = tickfs.append_key(&mut DefaultHasher::new(), b"ONE", &value);
+        match ret {
+            Err(ErrorCode::ReadNotReady(reg)) => {
+                // Read isn't ready, save the state
+                let operation = Operation::AppendKey;
+                let state = State::ReadComplete(reg as isize);
+
+                // There is no actual delay in the test, just continue now
+                tickfs
+                    .continue_operation(
+                        operation,
+                        state,
+                        Some(&mut DefaultHasher::new()),
+                        Some(b"ONE"),
+                        Some(&value),
+                        None,
+                    )
+                    .unwrap();
+            }
+            Ok(()) => {}
+            _ => unreachable!(),
+        }
+
+        println!("Get key ONE");
+        tickfs
+            .get_key(&mut DefaultHasher::new(), b"ONE", &mut buf)
+            .unwrap();
+
+        println!("Get non-existant key TWO");
+        assert_eq!(
+            tickfs.get_key(&mut DefaultHasher::new(), b"TWO", &mut buf),
+            Err(ErrorCode::KeyNotFound)
+        );
+
+        println!("Add key ONE again");
+        assert_eq!(
+            tickfs.append_key(&mut DefaultHasher::new(), b"ONE", &value),
+            Err(ErrorCode::KeyAlreadyExists)
+        );
+
+        println!("Add key TWO");
+        tickfs
+            .append_key(&mut DefaultHasher::new(), b"TWO", &value)
+            .unwrap();
+        println!("Get key ONE");
+        tickfs
+            .get_key(&mut DefaultHasher::new(), b"ONE", &mut buf)
+            .unwrap();
+        println!("Get key TWO");
+        tickfs
+            .get_key(&mut DefaultHasher::new(), b"TWO", &mut buf)
+            .unwrap();
+
+        println!("Get non-existant key THREE");
+        assert_eq!(
+            tickfs.get_key(&mut DefaultHasher::new(), b"THREE", &mut buf),
+            Err(ErrorCode::KeyNotFound)
+        );
+    }
+
+    #[test]
+    fn test_append_and_delete() {
+        let mut read_buf: [u8; 1024] = [0; 1024];
+        let tickfs = TickFS::<FlashCtrl, DefaultHasher>::new(
+            FlashCtrl::new(),
+            &mut read_buf,
+            0x10000,
+            0x400,
+        );
+
+        let mut ret = tickfs.initalise((&mut DefaultHasher::new(), &mut DefaultHasher::new()));
+        while ret.is_err() {
+            let state;
+            match ret {
+                Err(ErrorCode::ReadNotReady(reg)) => {
+                    // Read isn't ready, save the state
+                    state = State::ReadComplete(reg as isize);
+                }
+                Err(ErrorCode::EraseNotReady(reg)) => {
+                    // Erase isn't ready, save the state
+                    state = State::EraseComplete(reg);
+                }
+                Ok(()) => {
+                    break;
+                }
+                _ => unreachable!(),
+            }
+            // There is no actual delay in the test, just continue now
+            ret = tickfs.continue_initalise(
+                state,
+                (&mut DefaultHasher::new(), &mut DefaultHasher::new()),
+            );
+        }
+
+        let value: [u8; 32] = [0x23; 32];
+        let mut buf: [u8; 32] = [0; 32];
+
+        println!("Add key ONE");
+        let ret = tickfs.append_key(&mut DefaultHasher::new(), b"ONE", &value);
+        match ret {
+            Err(ErrorCode::ReadNotReady(reg)) => {
+                // Read isn't ready, save the state
+                let operation = Operation::AppendKey;
+                let state = State::ReadComplete(reg as isize);
+
+                // There is no actual delay in the test, just continue now
+                tickfs
+                    .continue_operation(
+                        operation,
+                        state,
+                        Some(&mut DefaultHasher::new()),
+                        Some(b"ONE"),
+                        Some(&value),
+                        None,
+                    )
+                    .unwrap();
+            }
+            Ok(()) => {}
+            _ => unreachable!(),
+        }
+
+        println!("Get key ONE");
+        tickfs
+            .get_key(&mut DefaultHasher::new(), b"ONE", &mut buf)
+            .unwrap();
+
+        println!("Delete Key ONE");
+        tickfs
+            .invalidate_key(&mut DefaultHasher::new(), b"ONE")
+            .unwrap();
+
+        println!("Get non-existant key ONE");
+        assert_eq!(
+            tickfs.get_key(&mut DefaultHasher::new(), b"ONE", &mut buf),
+            Err(ErrorCode::KeyNotFound)
+        );
+
+        println!("Try to delete Key ONE Again");
+        assert_eq!(
+            tickfs.invalidate_key(&mut DefaultHasher::new(), b"ONE"),
+            Err(ErrorCode::KeyNotFound)
+        );
+    }
+
+    #[test]
+    fn test_garbage_collect() {
+        let mut read_buf: [u8; 1024] = [0; 1024];
+        let tickfs = TickFS::<FlashCtrl, DefaultHasher>::new(
+            FlashCtrl::new(),
+            &mut read_buf,
+            0x10000,
+            0x400,
+        );
+
+        let mut ret = tickfs.initalise((&mut DefaultHasher::new(), &mut DefaultHasher::new()));
+        while ret.is_err() {
+            let state;
+            match ret {
+                Err(ErrorCode::ReadNotReady(reg)) => {
+                    // Read isn't ready, save the state
+                    state = State::ReadComplete(reg as isize);
+                }
+                Err(ErrorCode::EraseNotReady(reg)) => {
+                    // Erase isn't ready, save the state
+                    state = State::EraseComplete(reg);
+                }
+                Ok(()) => {
+                    break;
+                }
+                _ => unreachable!(),
+            }
+            // There is no actual delay in the test, just continue now
+            ret = tickfs.continue_initalise(
+                state,
+                (&mut DefaultHasher::new(), &mut DefaultHasher::new()),
+            );
+        }
+
+        let value: [u8; 32] = [0x23; 32];
+        let mut buf: [u8; 32] = [0; 32];
+
+        println!("Garbage collect empty flash");
+        let mut ret = tickfs.garbage_collect();
+        while ret.is_err() {
+            let state;
+            match ret {
+                Err(ErrorCode::ReadNotReady(reg)) => {
+                    // Read isn't ready, save the state
+                    state = State::ReadComplete(reg as isize);
+                }
+                Err(ErrorCode::EraseNotReady(reg)) => {
+                    // Erase isn't ready, save the state
+                    state = State::EraseComplete(reg);
+                }
+                Ok(_) => {
+                    break;
+                }
+                _ => unreachable!(),
+            }
+            // There is no actual delay in the test, just continue now
+            ret = tickfs.continue_garbage_collection(state);
+        }
+
+        println!("Add key ONE");
+        let ret = tickfs.append_key(&mut DefaultHasher::new(), b"ONE", &value);
+        match ret {
+            Err(ErrorCode::ReadNotReady(reg)) => {
+                // Read isn't ready, save the state
+                let operation = Operation::AppendKey;
+                let state = State::ReadComplete(reg as isize);
+
+                // There is no actual delay in the test, just continue now
+                tickfs
+                    .continue_operation(
+                        operation,
+                        state,
+                        Some(&mut DefaultHasher::new()),
+                        Some(b"ONE"),
+                        Some(&value),
+                        None,
+                    )
+                    .unwrap();
+            }
+            Ok(()) => {}
+            _ => unreachable!(),
+        }
+
+        println!("Garbage collect flash with valid key");
+        assert_eq!(tickfs.garbage_collect(), Ok(0));
+
+        println!("Delete Key ONE");
+        let ret = tickfs.invalidate_key(&mut DefaultHasher::new(), b"ONE");
+        match ret {
+            Err(ErrorCode::ReadNotReady(reg)) => {
+                // Read isn't ready, save the state
+                let operation = Operation::InvalidateKey;
+                let state = State::ReadComplete(reg as isize);
+
+                // There is no actual delay in the test, just continue now
+                tickfs
+                    .continue_operation(
+                        operation,
+                        state,
+                        Some(&mut DefaultHasher::new()),
+                        Some(b"ONE"),
+                        None,
+                        None,
+                    )
+                    .unwrap();
+            }
+            Ok(()) => {}
+            _ => unreachable!(),
+        }
+
+        println!("Garbage collect flash with deleted key");
+        assert_eq!(tickfs.garbage_collect(), Ok(1024));
+
+        println!("Get non-existant key ONE");
+        assert_eq!(
+            tickfs.get_key(&mut DefaultHasher::new(), b"ONE", &mut buf),
+            Err(ErrorCode::KeyNotFound)
+        );
+
+        println!("Add Key ONE");
+        tickfs
+            .append_key(&mut DefaultHasher::new(), b"ONE", &value)
+            .unwrap();
+    }
+}

--- a/libraries/tickfs/src/error_codes.rs
+++ b/libraries/tickfs/src/error_codes.rs
@@ -33,6 +33,13 @@ pub enum ErrorCode {
     /// The supplied buffer is too small.
     /// The error code includes the total length of the value.
     BufferTooSmall(usize),
+    /// Indicates that the flash read operation is not yet ready.
+    /// The process can be retried by calling `continue_operation()`.
+    ReadNotReady(usize),
+    /// Indicates that the flash write operation is not yet ready.
+    WriteNotReady(usize),
+    /// Indicates that the flash erase operation is not yet ready.
+    EraseNotReady(usize),
 }
 
 impl From<ErrorCode> for isize {
@@ -50,6 +57,9 @@ impl From<ErrorCode> for isize {
             ErrorCode::EraseFail => -10,
             ErrorCode::ObjectTooLarge => -11,
             ErrorCode::BufferTooSmall(_) => -12,
+            ErrorCode::ReadNotReady(_) => -13,
+            ErrorCode::WriteNotReady(_) => -14,
+            ErrorCode::EraseNotReady(_) => -15,
         }
     }
 }

--- a/libraries/tickfs/src/error_codes.rs
+++ b/libraries/tickfs/src/error_codes.rs
@@ -1,0 +1,61 @@
+//! The standard error codes used by TickFS.
+
+/// Standard error codes.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum ErrorCode {
+    /// We found a header in the flash that we don't support
+    UnsupportedVersion,
+    /// Some of the data in flash appears to be corrupt
+    CorruptData,
+    /// The check sum doesn't match
+    /// Note that the value buffer is still filled
+    InvalidCheckSum,
+    /// The requested key couldn't be found
+    KeyNotFound,
+    /// Indicates that we can't add this key as one with
+    /// the same key hash already exists.
+    KeyAlreadyExists,
+    /// Indicates that the region where this object should be added
+    /// is full. In future this error should be handled internally
+    /// by allocating the object in a different region.
+    RegionFull,
+    /// Unable to add a key, the flash is full. Note that the flash
+    /// might not be full after running a garbage collection.
+    FlashFull,
+    /// Unable to read the flash region
+    ReadFail,
+    /// Unable to write the buffer to the flash address
+    WriteFail,
+    /// Unable to erase the flash region
+    EraseFail,
+    /// The object is larger then 0x7FFF
+    ObjectTooLarge,
+    /// The supplied buffer is too small.
+    /// The error code includes the total length of the value.
+    BufferTooSmall(usize),
+}
+
+impl From<ErrorCode> for isize {
+    fn from(original: ErrorCode) -> isize {
+        match original {
+            ErrorCode::UnsupportedVersion => -1,
+            ErrorCode::CorruptData => -2,
+            ErrorCode::InvalidCheckSum => -3,
+            ErrorCode::KeyNotFound => -4,
+            ErrorCode::KeyAlreadyExists => -5,
+            ErrorCode::RegionFull => -6,
+            ErrorCode::FlashFull => -7,
+            ErrorCode::ReadFail => -8,
+            ErrorCode::WriteFail => -9,
+            ErrorCode::EraseFail => -10,
+            ErrorCode::ObjectTooLarge => -11,
+            ErrorCode::BufferTooSmall(_) => -12,
+        }
+    }
+}
+
+impl From<ErrorCode> for usize {
+    fn from(original: ErrorCode) -> usize {
+        isize::from(original) as usize
+    }
+}

--- a/libraries/tickfs/src/flash_controller.rs
+++ b/libraries/tickfs/src/flash_controller.rs
@@ -62,6 +62,10 @@ pub trait FlashController {
     /// By returning `ErrorCode::ReadNotReady(region_number)`
     /// `read_region()` can indicate that the operation should be retried in
     /// the future.
+    /// After running the `continue_()` functions after a async
+    /// `read_region()` has returned `ErrorCode::ReadNotReady(region_number)`
+    /// the `read_region()` function will be called again and this time should
+    /// return the data.
     fn read_region(
         &self,
         region_number: usize,
@@ -77,11 +81,22 @@ pub trait FlashController {
     ///
     /// On success it should return nothing, on failure it
     /// should return ErrorCode::WriteFail.
+    ///
+    /// If the write operation is to be complete asynchronously then
+    /// `write()` can return `ErrorCode::WriteNotReady(region_number)`.
+    /// By returning `ErrorCode::WriteNotReady(region_number)`
+    /// `read_region()` can indicate that the operation should be retried in
+    /// the future. Note that that region will not be written
+    /// again so the write must occur otherwise the operation fails.
     fn write(&self, address: usize, buf: &[u8]) -> Result<(), ErrorCode>;
 
     /// This function must erase the region specified by `region_number`.
     ///
     /// On success it should return nothing, on failure it
     /// should return ErrorCode::WriteFail.
+    ///
+    /// If the erase is going to happen asynchronously then this should return
+    /// `EraseNotReady(region_number)`. Note that that region will not be erased
+    /// again so the erasure must occur otherwise the operation fails.
     fn erase_region(&self, region_number: usize) -> Result<(), ErrorCode>;
 }

--- a/libraries/tickfs/src/flash_controller.rs
+++ b/libraries/tickfs/src/flash_controller.rs
@@ -1,0 +1,81 @@
+//! The Flash Controller interface with hardware
+
+use crate::error_codes::ErrorCode;
+
+/// Implementation required for the flash controller hardware. This
+/// should read, write and erase flash from the hardware using the
+/// flash controller.
+///
+/// This is the public trait for the Flash controller implementation.
+///
+/// The size of the regions (pages) must be the smallest size that can be
+/// erased in a single operation. This must match the `region_size`
+/// and the length of the `read_buffer` slice used in TickFS.
+///
+/// The start and end address of the FlashController must be aligned
+/// to the size of regions.
+/// All `region_number`s and `address`es are offset from zero. If you
+/// want to use flash that doesn't start at zero, or is a partition
+/// offset from the start of flash you will need to add that offset
+/// to the values in your implementation.
+///
+/// The boiler plate for an implementation will look something like this
+///
+/// ```rust
+/// use tickfs::error_codes::ErrorCode;
+/// use tickfs::flash_controller::FlashController;
+///
+/// #[derive(Default)]
+/// struct FlashCtrl {}
+///
+/// impl FlashCtrl {
+///     fn new() -> Self {
+///         Self { /* fields */ }
+///     }
+/// }
+///
+/// impl FlashController for FlashCtrl {
+///     fn read_region(&self, region_number: usize, offset: usize, buf: &mut [u8]) -> Result<(), ErrorCode> {
+///         unimplemented!()
+///     }
+///
+///     fn write(&self, address: usize, buf: &[u8]) -> Result<(), ErrorCode> {
+///         unimplemented!()
+///     }
+///
+///     fn erase_region(&self, region_number: usize) -> Result<(), ErrorCode> {
+///         unimplemented!()
+///     }
+/// }
+/// ```
+pub trait FlashController {
+    /// This function must read the data from the flash region specified by
+    /// `region_number` into `buf`. The length of the data read should be the
+    /// same length as buf. `offset` indicates an offset into the region that
+    /// should be read.
+    ///
+    /// On success it should return nothing, on failure it
+    /// should return ErrorCode::ReadFail.
+    fn read_region(
+        &self,
+        region_number: usize,
+        offset: usize,
+        buf: &mut [u8],
+    ) -> Result<(), ErrorCode>;
+
+    /// This function must write the length of `buf` to the specified address
+    /// in flash.
+    /// If the length of `buf` is smaller then the minimum supported write size
+    /// the implementation can write a larger value. This should be done by first
+    /// reading the value, making the changed from `buf` and then writing it back.
+    ///
+    /// On success it should return nothing, on failure it
+    /// should return ErrorCode::WriteFail.
+    fn write(&self, address: usize, buf: &[u8]) -> Result<(), ErrorCode>;
+
+    /// This function must erase the region specified by `region_number`.
+    ///
+    /// On success it should return nothing, on failure it
+    /// should return ErrorCode::WriteFail.
+    fn erase_region(&self, region_number: usize) -> Result<(), ErrorCode>;
+}

--- a/libraries/tickfs/src/flash_controller.rs
+++ b/libraries/tickfs/src/flash_controller.rs
@@ -56,6 +56,12 @@ pub trait FlashController {
     ///
     /// On success it should return nothing, on failure it
     /// should return ErrorCode::ReadFail.
+    ///
+    /// If the read operation is to be complete asynchronously then
+    /// `read_region()` can return `ErrorCode::ReadNotReady(region_number)`.
+    /// By returning `ErrorCode::ReadNotReady(region_number)`
+    /// `read_region()` can indicate that the operation should be retried in
+    /// the future.
     fn read_region(
         &self,
         region_number: usize,

--- a/libraries/tickfs/src/flash_controller.rs
+++ b/libraries/tickfs/src/flash_controller.rs
@@ -9,8 +9,9 @@ use crate::error_codes::ErrorCode;
 /// This is the public trait for the Flash controller implementation.
 ///
 /// The size of the regions (pages) must be the smallest size that can be
-/// erased in a single operation. This must match the `region_size`
-/// and the length of the `read_buffer` slice used in TickFS.
+/// erased in a single operation. This is specified as the constant `S`
+/// when implementing `FlashController` and `TickFS` and it must match
+/// the length of the `read_buffer`.
 ///
 /// The start and end address of the FlashController must be aligned
 /// to the size of regions.
@@ -34,8 +35,8 @@ use crate::error_codes::ErrorCode;
 ///     }
 /// }
 ///
-/// impl FlashController for FlashCtrl {
-///     fn read_region(&self, region_number: usize, offset: usize, buf: &mut [u8]) -> Result<(), ErrorCode> {
+/// impl FlashController<1024> for FlashCtrl {
+///     fn read_region(&self, region_number: usize, offset: usize, buf: &mut [u8; 1024]) -> Result<(), ErrorCode> {
 ///         unimplemented!()
 ///     }
 ///
@@ -48,7 +49,7 @@ use crate::error_codes::ErrorCode;
 ///     }
 /// }
 /// ```
-pub trait FlashController {
+pub trait FlashController<const S: usize> {
     /// This function must read the data from the flash region specified by
     /// `region_number` into `buf`. The length of the data read should be the
     /// same length as buf. `offset` indicates an offset into the region that
@@ -70,7 +71,7 @@ pub trait FlashController {
         &self,
         region_number: usize,
         offset: usize,
-        buf: &mut [u8],
+        buf: &mut [u8; S],
     ) -> Result<(), ErrorCode>;
 
     /// This function must write the length of `buf` to the specified address

--- a/libraries/tickfs/src/lib.rs
+++ b/libraries/tickfs/src/lib.rs
@@ -1,0 +1,83 @@
+//! TickFS (Tiny Circular Key Value File System) is a small file system allowing
+//! key value pairs to be stored in Flash Memory.
+//!
+//! TickFS was written to allow the Tock OS kernel to persistently store app data
+//! on flash. It was written to be generic though, so other Rust applications can
+//! use it if they want.
+//!
+//! TickFS is based on similar concepts as
+//! [Yaffs1](https://yaffs.net/documents/how-yaffs-works]).
+//!
+//! # Goals of TickFS
+//!
+//! TickFS is designed with these main goals (in order)
+//!
+//!  * Fully implemented in no_std Rust
+//!  * Power loss resilient
+//!  * Maintain data integrity and detect media errors
+//!  * Wear leveling
+//!  * Low memory usage
+//!  * Low storage overhead
+//!  * No external crates in use (not including unit tests)
+//!
+//! TickFS is also designed with some assumptions
+//!
+//!  * Most operations will be retrieving keys
+//!  * Some operations will be storing keys
+//!  * Keys will rarely be deleted
+//!  * Key values will rarely need to be modified
+//!
+//! # How TickFS works
+//!
+//! Unlike a regular File System (FS) TickFS is only designed to store Key/Value (KV)
+//! pairs in flash. It does not support writing actual files, directories or other
+//! complex objects. Although a traditional file system layer could be added on top
+//! to add such features.
+//!
+//! TickFS allows writing new key/value pairs (by appending them) and removing
+//! old key/value pairs.
+//!
+//! TickFS has two important types, regions and objects.
+//!
+//! A TickFS region is the smallest region of the flash memory that can be erased
+//! in a single command.
+//!
+//! TickFS saves and restores objects from flash. TickFS objects contain the value
+//! the user wanted to store as well as extra header data. Objects are internal to
+//! TickFS and users don't need to understand them in detail to use it.
+//!
+//! To see the full TickFS spec check the [README.md file](https://github.com/tock/tock/blob/master/libraries/tickfs/README.md).
+//!
+//! # Collisions
+//!
+//! TickFS will prevent a new key/value pair with a colliding hash of the key to be
+//! added. The collision will be reported to the user with the `KeyAlreadyExists`
+//! `ErroCode`.
+//!
+//! # Power loss protection
+//!
+//! TickFS ensures that in the event of a power loss, no stored data is lost or
+//! corrupted. The only data that can be lost in the event of a power loss is
+//! the data currently being written (if it hasn't been write to flash yet).
+//!
+//! If a power loss occurs after calling `append_key()` or `invalidate_key()`
+//! before it has completed then the operation probably did not complete and
+//! that data is lost.
+//!
+//! To help reduce this time to be as short as possible the `FlashController`
+//! is synchronous. Although flash writes can take a considerable amount of time
+//! and this will stall the application, this still seems like a good idea
+//! to avoid loosing data.
+//!
+//! # Security
+//!
+//! TickFS uses check sums to check data integrity. TickFS does not have any measures
+//! to prevent malicious manipulation or privacy. An attacker with access to the
+//! flash can change the values without being detected. An attacked with access
+//! to flash can also read all of the information. Any privacy, security or
+//! authentication measures need to be layered on top of TickFS.
+
+#![no_std]
+#![deny(missing_docs)]
+
+pub mod error_codes;

--- a/libraries/tickfs/src/lib.rs
+++ b/libraries/tickfs/src/lib.rs
@@ -50,6 +50,73 @@
 //!
 //! TickFS provides ACID properties.
 //!
+//! # Using TickFS
+//!
+//! To use TickFS first you need to implemented the `FlashCtrl<P>` trait.
+//!
+//! Then you will need to create a TickFS implementation.
+//!
+//!
+//! ```rust
+//! // EXAMPLE ONLY: The `DefaultHasher` is subject to change
+//! // and hence is not a good fit.
+//! use std::collections::hash_map::DefaultHasher;
+//! use std::cell::RefCell;
+//! use tickfs::TickFS;
+//! use tickfs::error_codes::ErrorCode;
+//! use tickfs::flash_controller::FlashController;
+//!
+//! struct FlashCtrl {
+//!     buf: RefCell<[[u8; 1024]; 64]>,
+//! }
+//!
+//! impl FlashCtrl {
+//!     fn new() -> Self {
+//!         Self {
+//!             buf: RefCell::new([[0xFF; 1024]; 64]),
+//!         }
+//!     }
+//! }
+//!
+//! impl FlashController for FlashCtrl {
+//!     fn read_region(&self, region_number: usize, offset: usize, buf: &mut [u8]) -> Result<(), ErrorCode> {
+//!         // TODO: Read the specified flash region
+//!         for (i, b) in buf.iter_mut().enumerate() {
+//!             *b = self.buf.borrow()[region_number][offset + i]
+//!         }
+//!         Ok(())
+//!     }
+//!
+//!     fn write(&self, address: usize, buf: &[u8]) -> Result<(), ErrorCode> {
+//!         // TODO: Write the data to the specified flash address
+//!         for (i, d) in buf.iter().enumerate() {
+//!             self.buf.borrow_mut()[address / 1024][(address % 1024) + i] = *d;
+//!         }
+//!         Ok(())
+//!     }
+//!
+//!     fn erase_region(&self, region_number: usize) -> Result<(), ErrorCode> {
+//!         // TODO: Erase the specified flash region
+//!         Ok(())
+//!     }
+//! }
+//!
+//! let mut read_buf: [u8; 1024] = [0; 1024];
+//! let tickfs = TickFS::<FlashCtrl, DefaultHasher>::new(FlashCtrl::new(),
+//!                   (&mut DefaultHasher::new(), &mut DefaultHasher::new()),
+//!                   &mut read_buf, 0x1000, 0x400).unwrap();
+//!
+//! // Add a key
+//! let value: [u8; 32] = [0x23; 32];
+//! tickfs.append_key(&mut DefaultHasher::new(), "ONE", &value).unwrap();
+//!
+//! // Get the same key back
+//! let mut buf: [u8; 32] = [0; 32];
+//! tickfs.get_key(&mut DefaultHasher::new(), "ONE", &mut buf).unwrap();
+//! ```
+//!
+//! You can then use the `get_key()` function to get the key back from flash.
+//!
 //! # Collisions
 //!
 //! TickFS will prevent a new key/value pair with a colliding hash of the key to be
@@ -106,3 +173,11 @@
 pub mod error_codes;
 pub mod flash_controller;
 pub mod tickfs;
+
+// Use this to generate nicer docs
+#[doc(inline)]
+pub use crate::error_codes::ErrorCode;
+#[doc(inline)]
+pub use crate::flash_controller::FlashController;
+#[doc(inline)]
+pub use crate::tickfs::TickFS;

--- a/libraries/tickfs/src/lib.rs
+++ b/libraries/tickfs/src/lib.rs
@@ -48,6 +48,8 @@
 //!
 //! To see the full TickFS spec check the [README.md file](https://github.com/tock/tock/blob/master/libraries/tickfs/README.md).
 //!
+//! TickFS provides ACID properties.
+//!
 //! # Collisions
 //!
 //! TickFS will prevent a new key/value pair with a colliding hash of the key to be
@@ -76,9 +78,31 @@
 //! flash can change the values without being detected. An attacked with access
 //! to flash can also read all of the information. Any privacy, security or
 //! authentication measures need to be layered on top of TickFS.
+//!
+//! # Hash Function
+//!
+//! Any hash function that implements Rust's `core::hash::Hasher` trait can be used.
+//!
+//! The hash function ideally should generate uniform hashes and must not change during
+//! the lifetime of the filesystem.
+//!
+//! The Rust `core::hash::Hasher` implementation is a little strange. When the
+//! hash is calculated with the `finish()` function the internal state of the
+//! `Hasher` is not reset. This means that the check sum is generated with the
+//! following code and the key input becomes part of the check sum.
+//!
+//! ```rust,ignore
+//!         key.hash(hash_function);
+//!         let hash = hash_function.finish();
+//!
+//!         buf.hash(hash_function);
+//!         value.hash(hash_function);
+//!         let check_sum = hash_function.finish();
+//! ```
 
 #![no_std]
 #![deny(missing_docs)]
 
 pub mod error_codes;
 pub mod flash_controller;
+pub mod tickfs;

--- a/libraries/tickfs/src/lib.rs
+++ b/libraries/tickfs/src/lib.rs
@@ -182,6 +182,8 @@ pub mod tickfs;
 
 // Use this to generate nicer docs
 #[doc(inline)]
+pub use crate::async_ops::AsyncTickFS;
+#[doc(inline)]
 pub use crate::error_codes::ErrorCode;
 #[doc(inline)]
 pub use crate::flash_controller::FlashController;

--- a/libraries/tickfs/src/lib.rs
+++ b/libraries/tickfs/src/lib.rs
@@ -181,3 +181,11 @@ pub use crate::error_codes::ErrorCode;
 pub use crate::flash_controller::FlashController;
 #[doc(inline)]
 pub use crate::tickfs::TickFS;
+
+// This is used to run the tests on a host
+#[cfg(test)]
+#[macro_use]
+extern crate std;
+
+#[cfg(test)]
+mod tests;

--- a/libraries/tickfs/src/lib.rs
+++ b/libraries/tickfs/src/lib.rs
@@ -103,8 +103,10 @@
 //!
 //! let mut read_buf: [u8; 1024] = [0; 1024];
 //! let tickfs = TickFS::<FlashCtrl, DefaultHasher>::new(FlashCtrl::new(),
-//!                   (&mut DefaultHasher::new(), &mut DefaultHasher::new()),
-//!                   &mut read_buf, 0x1000, 0x400).unwrap();
+//!                   &mut read_buf, 0x1000, 0x400);
+//! tickfs
+//!    .initalise((&mut DefaultHasher::new(), &mut DefaultHasher::new()))
+//!    .unwrap();
 //!
 //! // Add a key
 //! let value: [u8; 32] = [0x23; 32];

--- a/libraries/tickfs/src/lib.rs
+++ b/libraries/tickfs/src/lib.rs
@@ -172,8 +172,10 @@
 #![no_std]
 #![deny(missing_docs)]
 
+pub mod async_ops;
 pub mod error_codes;
 pub mod flash_controller;
+pub mod success_codes;
 pub mod tickfs;
 
 // Use this to generate nicer docs
@@ -181,6 +183,10 @@ pub mod tickfs;
 pub use crate::error_codes::ErrorCode;
 #[doc(inline)]
 pub use crate::flash_controller::FlashController;
+#[doc(inline)]
+pub use crate::tickfs::Operation;
+#[doc(inline)]
+pub use crate::tickfs::State;
 #[doc(inline)]
 pub use crate::tickfs::TickFS;
 

--- a/libraries/tickfs/src/lib.rs
+++ b/libraries/tickfs/src/lib.rs
@@ -184,10 +184,6 @@ pub use crate::error_codes::ErrorCode;
 #[doc(inline)]
 pub use crate::flash_controller::FlashController;
 #[doc(inline)]
-pub use crate::tickfs::Operation;
-#[doc(inline)]
-pub use crate::tickfs::State;
-#[doc(inline)]
 pub use crate::tickfs::TickFS;
 
 // This is used to run the tests on a host

--- a/libraries/tickfs/src/lib.rs
+++ b/libraries/tickfs/src/lib.rs
@@ -108,11 +108,11 @@
 //!
 //! // Add a key
 //! let value: [u8; 32] = [0x23; 32];
-//! tickfs.append_key(&mut DefaultHasher::new(), "ONE", &value).unwrap();
+//! tickfs.append_key(&mut DefaultHasher::new(), b"ONE", &value).unwrap();
 //!
 //! // Get the same key back
 //! let mut buf: [u8; 32] = [0; 32];
-//! tickfs.get_key(&mut DefaultHasher::new(), "ONE", &mut buf).unwrap();
+//! tickfs.get_key(&mut DefaultHasher::new(), b"ONE", &mut buf).unwrap();
 //! ```
 //!
 //! You can then use the `get_key()` function to get the key back from flash.

--- a/libraries/tickfs/src/lib.rs
+++ b/libraries/tickfs/src/lib.rs
@@ -81,3 +81,4 @@
 #![deny(missing_docs)]
 
 pub mod error_codes;
+pub mod flash_controller;

--- a/libraries/tickfs/src/lib.rs
+++ b/libraries/tickfs/src/lib.rs
@@ -52,7 +52,8 @@
 //!
 //! # Using TickFS
 //!
-//! To use TickFS first you need to implemented the `FlashCtrl<P>` trait.
+//! To use TickFS first you need to implemented the `FlashCtrl` trait. The
+//! example below is for 1024 byte region sizes.
 //!
 //! Then you will need to create a TickFS implementation.
 //!
@@ -78,8 +79,8 @@
 //!     }
 //! }
 //!
-//! impl FlashController for FlashCtrl {
-//!     fn read_region(&self, region_number: usize, offset: usize, buf: &mut [u8]) -> Result<(), ErrorCode> {
+//! impl FlashController<1024> for FlashCtrl {
+//!     fn read_region(&self, region_number: usize, offset: usize, buf: &mut [u8; 1024]) -> Result<(), ErrorCode> {
 //!         // TODO: Read the specified flash region
 //!         for (i, b) in buf.iter_mut().enumerate() {
 //!             *b = self.buf.borrow()[region_number][offset + i]
@@ -102,8 +103,8 @@
 //! }
 //!
 //! let mut read_buf: [u8; 1024] = [0; 1024];
-//! let tickfs = TickFS::<FlashCtrl, DefaultHasher>::new(FlashCtrl::new(),
-//!                   &mut read_buf, 0x1000, 0x400);
+//! let tickfs = TickFS::<FlashCtrl, DefaultHasher, 1024>::new(FlashCtrl::new(),
+//!                   &mut read_buf, 0x1000);
 //! tickfs
 //!    .initalise((&mut DefaultHasher::new(), &mut DefaultHasher::new()))
 //!    .unwrap();
@@ -169,6 +170,7 @@
 //!         let check_sum = hash_function.finish();
 //! ```
 
+#![feature(min_const_generics)]
 #![no_std]
 #![deny(missing_docs)]
 

--- a/libraries/tickfs/src/success_codes.rs
+++ b/libraries/tickfs/src/success_codes.rs
@@ -1,0 +1,25 @@
+//! The standard success codes used by TickFS.
+
+/// Standard success codes.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum SuccessCode {
+    /// The key was written to flash, the operation is complete
+    Written,
+    /// The write operation has been queued
+    Queued,
+}
+
+impl From<SuccessCode> for isize {
+    fn from(original: SuccessCode) -> isize {
+        match original {
+            SuccessCode::Written => -1,
+            SuccessCode::Queued => -2,
+        }
+    }
+}
+
+impl From<SuccessCode> for usize {
+    fn from(original: SuccessCode) -> usize {
+        isize::from(original) as usize
+    }
+}

--- a/libraries/tickfs/src/success_codes.rs
+++ b/libraries/tickfs/src/success_codes.rs
@@ -3,7 +3,9 @@
 /// Standard success codes.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum SuccessCode {
-    /// The key was written to flash, the operation is complete
+    /// Operation complete, no changes have been made to flash.
+    Complete,
+    /// All changes have been written to flash. The operation is complete.
     Written,
     /// The write operation has been queued
     Queued,
@@ -12,8 +14,9 @@ pub enum SuccessCode {
 impl From<SuccessCode> for isize {
     fn from(original: SuccessCode) -> isize {
         match original {
-            SuccessCode::Written => -1,
-            SuccessCode::Queued => -2,
+            SuccessCode::Complete => -1,
+            SuccessCode::Written => -2,
+            SuccessCode::Queued => -3,
         }
     }
 }

--- a/libraries/tickfs/src/tests.rs
+++ b/libraries/tickfs/src/tests.rs
@@ -114,12 +114,12 @@ mod simple_flash_ctrl {
         }
     }
 
-    impl FlashController for FlashCtrl {
+    impl FlashController<2048> for FlashCtrl {
         fn read_region(
             &self,
             _region_number: usize,
             _offset: usize,
-            buf: &mut [u8],
+            buf: &mut [u8; 2048],
         ) -> Result<(), ErrorCode> {
             for b in buf.iter_mut() {
                 *b = 0xFF;
@@ -142,12 +142,8 @@ mod simple_flash_ctrl {
     #[test]
     fn test_init() {
         let mut read_buf: [u8; 2048] = [0; 2048];
-        let tickfs = TickFS::<FlashCtrl, DefaultHasher>::new(
-            FlashCtrl::new(),
-            &mut read_buf,
-            0x20000,
-            0x800,
-        );
+        let tickfs =
+            TickFS::<FlashCtrl, DefaultHasher, 2048>::new(FlashCtrl::new(), &mut read_buf, 0x20000);
         tickfs
             .initalise((&mut DefaultHasher::new(), &mut DefaultHasher::new()))
             .unwrap();
@@ -168,12 +164,12 @@ mod single_erase_flash_ctrl {
         }
     }
 
-    impl FlashController for FlashCtrl {
+    impl FlashController<2048> for FlashCtrl {
         fn read_region(
             &self,
             _region_number: usize,
             _offset: usize,
-            buf: &mut [u8],
+            buf: &mut [u8; 2048],
         ) -> Result<(), ErrorCode> {
             for b in buf.iter_mut() {
                 *b = 0xFF;
@@ -200,22 +196,20 @@ mod single_erase_flash_ctrl {
     #[test]
     fn test_double_init() {
         let mut read_buf1: [u8; 2048] = [0; 2048];
-        let tickfs1 = TickFS::<FlashCtrl, DefaultHasher>::new(
+        let tickfs1 = TickFS::<FlashCtrl, DefaultHasher, 2048>::new(
             FlashCtrl::new(),
             &mut read_buf1,
             0x20000,
-            0x800,
         );
         tickfs1
             .initalise((&mut DefaultHasher::new(), &mut DefaultHasher::new()))
             .unwrap();
 
         let mut read_buf2: [u8; 2048] = [0; 2048];
-        let tickfs2 = TickFS::<FlashCtrl, DefaultHasher>::new(
+        let tickfs2 = TickFS::<FlashCtrl, DefaultHasher, 2048>::new(
             FlashCtrl::new(),
             &mut read_buf2,
             0x20000,
-            0x800,
         );
         tickfs2
             .initalise((&mut DefaultHasher::new(), &mut DefaultHasher::new()))
@@ -241,12 +235,12 @@ mod store_flast_ctrl {
         }
     }
 
-    impl FlashController for FlashCtrl {
+    impl FlashController<1024> for FlashCtrl {
         fn read_region(
             &self,
             region_number: usize,
             offset: usize,
-            buf: &mut [u8],
+            buf: &mut [u8; 1024],
         ) -> Result<(), ErrorCode> {
             println!("Read from region: {}", region_number);
 
@@ -302,12 +296,8 @@ mod store_flast_ctrl {
     #[test]
     fn test_simple_append() {
         let mut read_buf: [u8; 1024] = [0; 1024];
-        let tickfs = TickFS::<FlashCtrl, DefaultHasher>::new(
-            FlashCtrl::new(),
-            &mut read_buf,
-            0x10000,
-            0x400,
-        );
+        let tickfs =
+            TickFS::<FlashCtrl, DefaultHasher, 1024>::new(FlashCtrl::new(), &mut read_buf, 0x10000);
         tickfs
             .initalise((&mut DefaultHasher::new(), &mut DefaultHasher::new()))
             .unwrap();
@@ -325,12 +315,8 @@ mod store_flast_ctrl {
     #[test]
     fn test_double_append() {
         let mut read_buf: [u8; 1024] = [0; 1024];
-        let tickfs = TickFS::<FlashCtrl, DefaultHasher>::new(
-            FlashCtrl::new(),
-            &mut read_buf,
-            0x10000,
-            0x400,
-        );
+        let tickfs =
+            TickFS::<FlashCtrl, DefaultHasher, 1024>::new(FlashCtrl::new(), &mut read_buf, 0x10000);
         tickfs
             .initalise((&mut DefaultHasher::new(), &mut DefaultHasher::new()))
             .unwrap();
@@ -383,12 +369,8 @@ mod store_flast_ctrl {
     #[test]
     fn test_append_and_delete() {
         let mut read_buf: [u8; 1024] = [0; 1024];
-        let tickfs = TickFS::<FlashCtrl, DefaultHasher>::new(
-            FlashCtrl::new(),
-            &mut read_buf,
-            0x10000,
-            0x400,
-        );
+        let tickfs =
+            TickFS::<FlashCtrl, DefaultHasher, 1024>::new(FlashCtrl::new(), &mut read_buf, 0x10000);
         tickfs
             .initalise((&mut DefaultHasher::new(), &mut DefaultHasher::new()))
             .unwrap();
@@ -427,12 +409,8 @@ mod store_flast_ctrl {
     #[test]
     fn test_garbage_collect() {
         let mut read_buf: [u8; 1024] = [0; 1024];
-        let tickfs = TickFS::<FlashCtrl, DefaultHasher>::new(
-            FlashCtrl::new(),
-            &mut read_buf,
-            0x10000,
-            0x400,
-        );
+        let tickfs =
+            TickFS::<FlashCtrl, DefaultHasher, 1024>::new(FlashCtrl::new(), &mut read_buf, 0x10000);
         tickfs
             .initalise((&mut DefaultHasher::new(), &mut DefaultHasher::new()))
             .unwrap();
@@ -487,12 +465,12 @@ mod no_check_store_flast_ctrl {
         }
     }
 
-    impl FlashController for FlashCtrl {
+    impl FlashController<256> for FlashCtrl {
         fn read_region(
             &self,
             region_number: usize,
             offset: usize,
-            buf: &mut [u8],
+            buf: &mut [u8; 256],
         ) -> Result<(), ErrorCode> {
             println!("Read from region: {}", region_number);
 
@@ -532,7 +510,7 @@ mod no_check_store_flast_ctrl {
     fn test_region_full() {
         let mut read_buf: [u8; 256] = [0; 256];
         let tickfs =
-            TickFS::<FlashCtrl, DefaultHasher>::new(FlashCtrl::new(), &mut read_buf, 0x200, 0x100);
+            TickFS::<FlashCtrl, DefaultHasher, 256>::new(FlashCtrl::new(), &mut read_buf, 0x200);
         tickfs
             .initalise((&mut DefaultHasher::new(), &mut DefaultHasher::new()))
             .unwrap();

--- a/libraries/tickfs/src/tests.rs
+++ b/libraries/tickfs/src/tests.rs
@@ -142,14 +142,15 @@ mod simple_flash_ctrl {
     #[test]
     fn test_init() {
         let mut read_buf: [u8; 2048] = [0; 2048];
-        TickFS::<FlashCtrl, DefaultHasher>::new(
+        let tickfs = TickFS::<FlashCtrl, DefaultHasher>::new(
             FlashCtrl::new(),
-            (&mut DefaultHasher::new(), &mut DefaultHasher::new()),
             &mut read_buf,
             0x20000,
             0x800,
-        )
-        .unwrap();
+        );
+        tickfs
+            .initalise((&mut DefaultHasher::new(), &mut DefaultHasher::new()))
+            .unwrap();
     }
 }
 
@@ -199,24 +200,26 @@ mod single_erase_flash_ctrl {
     #[test]
     fn test_double_init() {
         let mut read_buf1: [u8; 2048] = [0; 2048];
-        TickFS::<FlashCtrl, DefaultHasher>::new(
+        let tickfs1 = TickFS::<FlashCtrl, DefaultHasher>::new(
             FlashCtrl::new(),
-            (&mut DefaultHasher::new(), &mut DefaultHasher::new()),
             &mut read_buf1,
             0x20000,
             0x800,
-        )
-        .unwrap();
+        );
+        tickfs1
+            .initalise((&mut DefaultHasher::new(), &mut DefaultHasher::new()))
+            .unwrap();
 
         let mut read_buf2: [u8; 2048] = [0; 2048];
-        TickFS::<FlashCtrl, DefaultHasher>::new(
+        let tickfs2 = TickFS::<FlashCtrl, DefaultHasher>::new(
             FlashCtrl::new(),
-            (&mut DefaultHasher::new(), &mut DefaultHasher::new()),
             &mut read_buf2,
             0x20000,
             0x800,
-        )
-        .unwrap();
+        );
+        tickfs2
+            .initalise((&mut DefaultHasher::new(), &mut DefaultHasher::new()))
+            .unwrap();
     }
 }
 
@@ -301,12 +304,13 @@ mod store_flast_ctrl {
         let mut read_buf: [u8; 1024] = [0; 1024];
         let tickfs = TickFS::<FlashCtrl, DefaultHasher>::new(
             FlashCtrl::new(),
-            (&mut DefaultHasher::new(), &mut DefaultHasher::new()),
             &mut read_buf,
             0x10000,
             0x400,
-        )
-        .unwrap();
+        );
+        tickfs
+            .initalise((&mut DefaultHasher::new(), &mut DefaultHasher::new()))
+            .unwrap();
 
         let value: [u8; 32] = [0x23; 32];
 
@@ -323,12 +327,13 @@ mod store_flast_ctrl {
         let mut read_buf: [u8; 1024] = [0; 1024];
         let tickfs = TickFS::<FlashCtrl, DefaultHasher>::new(
             FlashCtrl::new(),
-            (&mut DefaultHasher::new(), &mut DefaultHasher::new()),
             &mut read_buf,
             0x10000,
             0x400,
-        )
-        .unwrap();
+        );
+        tickfs
+            .initalise((&mut DefaultHasher::new(), &mut DefaultHasher::new()))
+            .unwrap();
 
         let value: [u8; 32] = [0x23; 32];
         let mut buf: [u8; 32] = [0; 32];
@@ -380,12 +385,13 @@ mod store_flast_ctrl {
         let mut read_buf: [u8; 1024] = [0; 1024];
         let tickfs = TickFS::<FlashCtrl, DefaultHasher>::new(
             FlashCtrl::new(),
-            (&mut DefaultHasher::new(), &mut DefaultHasher::new()),
             &mut read_buf,
             0x10000,
             0x400,
-        )
-        .unwrap();
+        );
+        tickfs
+            .initalise((&mut DefaultHasher::new(), &mut DefaultHasher::new()))
+            .unwrap();
 
         let value: [u8; 32] = [0x23; 32];
         let mut buf: [u8; 32] = [0; 32];
@@ -423,12 +429,13 @@ mod store_flast_ctrl {
         let mut read_buf: [u8; 1024] = [0; 1024];
         let tickfs = TickFS::<FlashCtrl, DefaultHasher>::new(
             FlashCtrl::new(),
-            (&mut DefaultHasher::new(), &mut DefaultHasher::new()),
             &mut read_buf,
             0x10000,
             0x400,
-        )
-        .unwrap();
+        );
+        tickfs
+            .initalise((&mut DefaultHasher::new(), &mut DefaultHasher::new()))
+            .unwrap();
 
         let value: [u8; 32] = [0x23; 32];
         let mut buf: [u8; 32] = [0; 32];
@@ -524,14 +531,11 @@ mod no_check_store_flast_ctrl {
     #[test]
     fn test_region_full() {
         let mut read_buf: [u8; 256] = [0; 256];
-        let tickfs = TickFS::<FlashCtrl, DefaultHasher>::new(
-            FlashCtrl::new(),
-            (&mut DefaultHasher::new(), &mut DefaultHasher::new()),
-            &mut read_buf,
-            0x200,
-            0x100,
-        )
-        .unwrap();
+        let tickfs =
+            TickFS::<FlashCtrl, DefaultHasher>::new(FlashCtrl::new(), &mut read_buf, 0x200, 0x100);
+        tickfs
+            .initalise((&mut DefaultHasher::new(), &mut DefaultHasher::new()))
+            .unwrap();
 
         let value: [u8; 64] = [0x23; 64];
         let mut buf: [u8; 64] = [0; 64];

--- a/libraries/tickfs/src/tests.rs
+++ b/libraries/tickfs/src/tests.rs
@@ -1,0 +1,632 @@
+use crate::error_codes::ErrorCode;
+use crate::flash_controller::FlashController;
+use crate::tickfs::{TickFS, HASH_OFFSET, LEN_OFFSET, VERSION, VERSION_OFFSET};
+use std::cell::Cell;
+use std::cell::RefCell;
+use std::collections::hash_map::DefaultHasher;
+
+fn check_region_main(buf: &[u8]) {
+    // Check the version
+    assert_eq!(buf[VERSION_OFFSET], VERSION);
+
+    // Check the length
+    assert_eq!(buf[LEN_OFFSET], 0x80);
+    assert_eq!(buf[LEN_OFFSET + 1], 19);
+
+    // Check the hash
+    assert_eq!(buf[HASH_OFFSET + 0], 0x8e);
+    assert_eq!(buf[HASH_OFFSET + 1], 0x31);
+    assert_eq!(buf[HASH_OFFSET + 2], 0xe3);
+    assert_eq!(buf[HASH_OFFSET + 3], 0x3d);
+    assert_eq!(buf[HASH_OFFSET + 4], 0xac);
+    assert_eq!(buf[HASH_OFFSET + 5], 0xbf);
+    assert_eq!(buf[HASH_OFFSET + 6], 0xb9);
+    assert_eq!(buf[HASH_OFFSET + 7], 0x58);
+
+    // Check the check hash
+    assert_eq!(buf[HASH_OFFSET + 8], 0x59);
+    assert_eq!(buf[HASH_OFFSET + 9], 0xe4);
+    assert_eq!(buf[HASH_OFFSET + 10], 0x6b);
+    assert_eq!(buf[HASH_OFFSET + 11], 0xa6);
+    assert_eq!(buf[HASH_OFFSET + 12], 0x61);
+    assert_eq!(buf[HASH_OFFSET + 13], 0x30);
+    assert_eq!(buf[HASH_OFFSET + 14], 0xac);
+    assert_eq!(buf[HASH_OFFSET + 15], 0x1b);
+}
+
+fn check_region_one(buf: &[u8]) {
+    // Check the version
+    assert_eq!(buf[VERSION_OFFSET], VERSION);
+
+    // Check the length
+    assert_eq!(buf[LEN_OFFSET], 0x80);
+    assert_eq!(buf[LEN_OFFSET + 1], 51);
+
+    // Check the hash
+    assert_eq!(buf[HASH_OFFSET + 0], 0xED);
+    assert_eq!(buf[HASH_OFFSET + 1], 0xA1);
+    assert_eq!(buf[HASH_OFFSET + 2], 0x00);
+    assert_eq!(buf[HASH_OFFSET + 3], 0x78);
+    assert_eq!(buf[HASH_OFFSET + 4], 0x88);
+    assert_eq!(buf[HASH_OFFSET + 5], 0x61);
+    assert_eq!(buf[HASH_OFFSET + 6], 0x93);
+    assert_eq!(buf[HASH_OFFSET + 7], 0xba);
+
+    // Check the value
+    assert_eq!(buf[HASH_OFFSET + 8], 0x23);
+    assert_eq!(buf[28], 0x23);
+    assert_eq!(buf[42], 0x23);
+
+    // Check the check hash
+    assert_eq!(buf[43], 0x08);
+    assert_eq!(buf[44], 0xD0);
+    assert_eq!(buf[45], 0x5E);
+    assert_eq!(buf[46], 0x25);
+    assert_eq!(buf[47], 0xDD);
+    assert_eq!(buf[48], 0xAD);
+    assert_eq!(buf[49], 0x4F);
+    assert_eq!(buf[50], 0x8C);
+}
+
+fn check_region_two(buf: &[u8]) {
+    // Check the version
+    assert_eq!(buf[VERSION_OFFSET], VERSION);
+
+    // Check the length
+    assert_eq!(buf[LEN_OFFSET], 0x80);
+    assert_eq!(buf[LEN_OFFSET + 1], 51);
+
+    // Check the hash
+    assert_eq!(buf[HASH_OFFSET + 0], 0xcd);
+    assert_eq!(buf[HASH_OFFSET + 1], 0xf8);
+    assert_eq!(buf[HASH_OFFSET + 2], 0xf5);
+    assert_eq!(buf[HASH_OFFSET + 3], 0x91);
+    assert_eq!(buf[HASH_OFFSET + 4], 0xb7);
+    assert_eq!(buf[HASH_OFFSET + 5], 0x7b);
+    assert_eq!(buf[HASH_OFFSET + 6], 0x80);
+    assert_eq!(buf[HASH_OFFSET + 7], 0xf6);
+
+    // Check the value
+    assert_eq!(buf[HASH_OFFSET + 8], 0x23);
+    assert_eq!(buf[28], 0x23);
+    assert_eq!(buf[42], 0x23);
+
+    // Check the check hash
+    assert_eq!(buf[43], 0x9f);
+    assert_eq!(buf[44], 0xbb);
+    assert_eq!(buf[45], 0xd0);
+    assert_eq!(buf[46], 0xdd);
+    assert_eq!(buf[47], 0xe6);
+    assert_eq!(buf[48], 0x62);
+    assert_eq!(buf[49], 0x4b);
+    assert_eq!(buf[50], 0x8a);
+}
+
+/// Tests using a NOP flash controller
+mod simple_flash_ctrl {
+    use super::*;
+
+    struct FlashCtrl {}
+
+    impl FlashCtrl {
+        fn new() -> Self {
+            Self {}
+        }
+    }
+
+    impl FlashController for FlashCtrl {
+        fn read_region(
+            &self,
+            _region_number: usize,
+            _offset: usize,
+            buf: &mut [u8],
+        ) -> Result<(), ErrorCode> {
+            for b in buf.iter_mut() {
+                *b = 0xFF;
+            }
+
+            Ok(())
+        }
+
+        fn write(&self, _address: usize, buf: &[u8]) -> Result<(), ErrorCode> {
+            check_region_main(buf);
+
+            Ok(())
+        }
+
+        fn erase_region(&self, _region_number: usize) -> Result<(), ErrorCode> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn test_init() {
+        let mut read_buf: [u8; 2048] = [0; 2048];
+        TickFS::<FlashCtrl, DefaultHasher>::new(
+            FlashCtrl::new(),
+            (&mut DefaultHasher::new(), &mut DefaultHasher::new()),
+            &mut read_buf,
+            0x20000,
+            0x800,
+        )
+        .unwrap();
+    }
+}
+
+/// Tests using a simple flash controller that can only erase once
+mod single_erase_flash_ctrl {
+    use super::*;
+
+    struct FlashCtrl {
+        run: Cell<u8>,
+    }
+
+    impl FlashCtrl {
+        fn new() -> Self {
+            Self { run: Cell::new(0) }
+        }
+    }
+
+    impl FlashController for FlashCtrl {
+        fn read_region(
+            &self,
+            _region_number: usize,
+            _offset: usize,
+            buf: &mut [u8],
+        ) -> Result<(), ErrorCode> {
+            for b in buf.iter_mut() {
+                *b = 0xFF;
+            }
+
+            Ok(())
+        }
+
+        fn write(&self, _address: usize, buf: &[u8]) -> Result<(), ErrorCode> {
+            check_region_main(buf);
+
+            Ok(())
+        }
+
+        fn erase_region(&self, _region_number: usize) -> Result<(), ErrorCode> {
+            // There are 64 regions, ensure this doesn't erase any a second time
+            assert_ne!(self.run.get(), 64);
+            self.run.set(self.run.get() + 1);
+
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn test_double_init() {
+        let mut read_buf1: [u8; 2048] = [0; 2048];
+        TickFS::<FlashCtrl, DefaultHasher>::new(
+            FlashCtrl::new(),
+            (&mut DefaultHasher::new(), &mut DefaultHasher::new()),
+            &mut read_buf1,
+            0x20000,
+            0x800,
+        )
+        .unwrap();
+
+        let mut read_buf2: [u8; 2048] = [0; 2048];
+        TickFS::<FlashCtrl, DefaultHasher>::new(
+            FlashCtrl::new(),
+            (&mut DefaultHasher::new(), &mut DefaultHasher::new()),
+            &mut read_buf2,
+            0x20000,
+            0x800,
+        )
+        .unwrap();
+    }
+}
+
+/// Tests using a flash controller that can store data
+mod store_flast_ctrl {
+    use super::*;
+    // An example FlashCtrl implementation
+    struct FlashCtrl {
+        buf: RefCell<[[u8; 1024]; 64]>,
+        run: Cell<u8>,
+    }
+
+    impl FlashCtrl {
+        fn new() -> Self {
+            Self {
+                buf: RefCell::new([[0xFF; 1024]; 64]),
+                run: Cell::new(0),
+            }
+        }
+    }
+
+    impl FlashController for FlashCtrl {
+        fn read_region(
+            &self,
+            region_number: usize,
+            offset: usize,
+            buf: &mut [u8],
+        ) -> Result<(), ErrorCode> {
+            println!("Read from region: {}", region_number);
+
+            for (i, b) in buf.iter_mut().enumerate() {
+                *b = self.buf.borrow()[region_number][offset + i]
+            }
+
+            Ok(())
+        }
+
+        fn write(&self, address: usize, buf: &[u8]) -> Result<(), ErrorCode> {
+            println!(
+                "Write to address: {:#x}, region: {}",
+                address,
+                address / 1024
+            );
+
+            for (i, d) in buf.iter().enumerate() {
+                self.buf.borrow_mut()[address / 1024][(address % 1024) + i] = *d;
+            }
+
+            // Check to see if we are adding a key
+            if buf.len() > 1 {
+                if self.run.get() == 0 {
+                    println!("Writing main key: {:#x?}", buf);
+                    check_region_main(buf);
+                } else if self.run.get() == 1 {
+                    println!("Writing key ONE: {:#x?}", buf);
+                    check_region_one(buf);
+                } else if self.run.get() == 2 {
+                    println!("Writing key TWO: {:#x?}", buf);
+                    check_region_two(buf);
+                }
+            }
+
+            self.run.set(self.run.get() + 1);
+
+            Ok(())
+        }
+
+        fn erase_region(&self, region_number: usize) -> Result<(), ErrorCode> {
+            println!("Erase region: {}", region_number);
+            let mut local_buf = self.buf.borrow_mut()[region_number];
+
+            for d in local_buf.iter_mut() {
+                *d = 0xFF;
+            }
+
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn test_simple_append() {
+        let mut read_buf: [u8; 1024] = [0; 1024];
+        let tickfs = TickFS::<FlashCtrl, DefaultHasher>::new(
+            FlashCtrl::new(),
+            (&mut DefaultHasher::new(), &mut DefaultHasher::new()),
+            &mut read_buf,
+            0x10000,
+            0x400,
+        )
+        .unwrap();
+
+        let value: [u8; 32] = [0x23; 32];
+
+        tickfs
+            .append_key(&mut DefaultHasher::new(), "ONE", &value)
+            .unwrap();
+        tickfs
+            .append_key(&mut DefaultHasher::new(), "TWO", &value)
+            .unwrap();
+    }
+
+    #[test]
+    fn test_double_append() {
+        let mut read_buf: [u8; 1024] = [0; 1024];
+        let tickfs = TickFS::<FlashCtrl, DefaultHasher>::new(
+            FlashCtrl::new(),
+            (&mut DefaultHasher::new(), &mut DefaultHasher::new()),
+            &mut read_buf,
+            0x10000,
+            0x400,
+        )
+        .unwrap();
+
+        let value: [u8; 32] = [0x23; 32];
+        let mut buf: [u8; 32] = [0; 32];
+
+        println!("Add key ONE");
+        tickfs
+            .append_key(&mut DefaultHasher::new(), "ONE", &value)
+            .unwrap();
+
+        println!("Get key ONE");
+        tickfs
+            .get_key(&mut DefaultHasher::new(), "ONE", &mut buf)
+            .unwrap();
+
+        println!("Get non-existant key TWO");
+        assert_eq!(
+            tickfs.get_key(&mut DefaultHasher::new(), "TWO", &mut buf),
+            Err(ErrorCode::KeyNotFound)
+        );
+
+        println!("Add key ONE again");
+        assert_eq!(
+            tickfs.append_key(&mut DefaultHasher::new(), "ONE", &value),
+            Err(ErrorCode::KeyAlreadyExists)
+        );
+
+        println!("Add key TWO");
+        tickfs
+            .append_key(&mut DefaultHasher::new(), "TWO", &value)
+            .unwrap();
+        println!("Get key ONE");
+        tickfs
+            .get_key(&mut DefaultHasher::new(), "ONE", &mut buf)
+            .unwrap();
+        println!("Get key TWO");
+        tickfs
+            .get_key(&mut DefaultHasher::new(), "TWO", &mut buf)
+            .unwrap();
+
+        println!("Get non-existant key THREE");
+        assert_eq!(
+            tickfs.get_key(&mut DefaultHasher::new(), "THREE", &mut buf),
+            Err(ErrorCode::KeyNotFound)
+        );
+    }
+
+    #[test]
+    fn test_append_and_delete() {
+        let mut read_buf: [u8; 1024] = [0; 1024];
+        let tickfs = TickFS::<FlashCtrl, DefaultHasher>::new(
+            FlashCtrl::new(),
+            (&mut DefaultHasher::new(), &mut DefaultHasher::new()),
+            &mut read_buf,
+            0x10000,
+            0x400,
+        )
+        .unwrap();
+
+        let value: [u8; 32] = [0x23; 32];
+        let mut buf: [u8; 32] = [0; 32];
+
+        println!("Add Key ONE");
+        tickfs
+            .append_key(&mut DefaultHasher::new(), "ONE", &value)
+            .unwrap();
+
+        println!("Get key ONE");
+        tickfs
+            .get_key(&mut DefaultHasher::new(), "ONE", &mut buf)
+            .unwrap();
+
+        println!("Delete Key ONE");
+        tickfs
+            .invalidate_key(&mut DefaultHasher::new(), "ONE")
+            .unwrap();
+
+        println!("Get non-existant key ONE");
+        assert_eq!(
+            tickfs.get_key(&mut DefaultHasher::new(), "ONE", &mut buf),
+            Err(ErrorCode::KeyNotFound)
+        );
+
+        println!("Try to delete Key ONE Again");
+        assert_eq!(
+            tickfs.invalidate_key(&mut DefaultHasher::new(), "ONE"),
+            Err(ErrorCode::KeyNotFound)
+        );
+    }
+
+    #[test]
+    fn test_garbage_collect() {
+        let mut read_buf: [u8; 1024] = [0; 1024];
+        let tickfs = TickFS::<FlashCtrl, DefaultHasher>::new(
+            FlashCtrl::new(),
+            (&mut DefaultHasher::new(), &mut DefaultHasher::new()),
+            &mut read_buf,
+            0x10000,
+            0x400,
+        )
+        .unwrap();
+
+        let value: [u8; 32] = [0x23; 32];
+        let mut buf: [u8; 32] = [0; 32];
+
+        println!("Garbage collect empty flash");
+        assert_eq!(tickfs.garbage_collect(), Ok(0));
+
+        println!("Add Key ONE");
+        tickfs
+            .append_key(&mut DefaultHasher::new(), "ONE", &value)
+            .unwrap();
+
+        println!("Garbage collect flash with valid key");
+        assert_eq!(tickfs.garbage_collect(), Ok(0));
+
+        println!("Delete Key ONE");
+        tickfs
+            .invalidate_key(&mut DefaultHasher::new(), "ONE")
+            .unwrap();
+
+        println!("Garbage collect flash with deleted key");
+        assert_eq!(tickfs.garbage_collect(), Ok(1024));
+
+        println!("Get non-existant key ONE");
+        assert_eq!(
+            tickfs.get_key(&mut DefaultHasher::new(), "ONE", &mut buf),
+            Err(ErrorCode::KeyNotFound)
+        );
+
+        println!("Add Key ONE");
+        tickfs
+            .append_key(&mut DefaultHasher::new(), "ONE", &value)
+            .unwrap();
+    }
+}
+
+mod no_check_store_flast_ctrl {
+    use super::*;
+    // An example FlashCtrl implementation
+    struct FlashCtrl {
+        buf: RefCell<[[u8; 256]; 2]>,
+    }
+
+    impl FlashCtrl {
+        fn new() -> Self {
+            Self {
+                buf: RefCell::new([[0xFF; 256]; 2]),
+            }
+        }
+    }
+
+    impl FlashController for FlashCtrl {
+        fn read_region(
+            &self,
+            region_number: usize,
+            offset: usize,
+            buf: &mut [u8],
+        ) -> Result<(), ErrorCode> {
+            println!("Read from region: {}", region_number);
+
+            for (i, b) in buf.iter_mut().enumerate() {
+                *b = self.buf.borrow()[region_number][offset + i]
+            }
+
+            Ok(())
+        }
+
+        fn write(&self, address: usize, buf: &[u8]) -> Result<(), ErrorCode> {
+            println!(
+                "Write to address: {:#x}, region: {}",
+                address,
+                address / 256
+            );
+
+            for (i, d) in buf.iter().enumerate() {
+                self.buf.borrow_mut()[address / 256][(address % 256) + i] = *d;
+            }
+
+            Ok(())
+        }
+
+        fn erase_region(&self, region_number: usize) -> Result<(), ErrorCode> {
+            println!("Erase region: {}", region_number);
+            let mut local_buf = self.buf.borrow_mut()[region_number];
+
+            for d in local_buf.iter_mut() {
+                *d = 0xFF;
+            }
+
+            Ok(())
+        }
+    }
+    #[test]
+    fn test_region_full() {
+        let mut read_buf: [u8; 256] = [0; 256];
+        let tickfs = TickFS::<FlashCtrl, DefaultHasher>::new(
+            FlashCtrl::new(),
+            (&mut DefaultHasher::new(), &mut DefaultHasher::new()),
+            &mut read_buf,
+            0x200,
+            0x100,
+        )
+        .unwrap();
+
+        let value: [u8; 64] = [0x23; 64];
+        let mut buf: [u8; 64] = [0; 64];
+
+        println!("Add Key ONE");
+        tickfs
+            .append_key(&mut DefaultHasher::new(), "ONE", &value)
+            .unwrap();
+
+        println!("Add Key TWO");
+        tickfs
+            .append_key(&mut DefaultHasher::new(), "TWO", &value)
+            .unwrap();
+
+        println!("Add Key THREE");
+        tickfs
+            .append_key(&mut DefaultHasher::new(), "THREE", &value)
+            .unwrap();
+
+        println!("Add Key FOUR");
+        tickfs
+            .append_key(&mut DefaultHasher::new(), "FOUR", &value)
+            .unwrap();
+
+        println!("Add Key FIVE");
+        tickfs
+            .append_key(&mut DefaultHasher::new(), "FIVE", &value)
+            .unwrap();
+
+        println!("Add Key SIX");
+        assert_eq!(
+            tickfs.append_key(&mut DefaultHasher::new(), "SIX", &value),
+            Err(ErrorCode::FlashFull)
+        );
+
+        println!("Get key ONE");
+        tickfs
+            .get_key(&mut DefaultHasher::new(), "ONE", &mut buf)
+            .unwrap();
+
+        println!("Get key TWO");
+        tickfs
+            .get_key(&mut DefaultHasher::new(), "TWO", &mut buf)
+            .unwrap();
+
+        println!("Get key THREE");
+        tickfs
+            .get_key(&mut DefaultHasher::new(), "THREE", &mut buf)
+            .unwrap();
+
+        println!("Get key FOUR");
+        tickfs
+            .get_key(&mut DefaultHasher::new(), "FOUR", &mut buf)
+            .unwrap();
+
+        println!("Get key FIVE");
+        tickfs
+            .get_key(&mut DefaultHasher::new(), "FIVE", &mut buf)
+            .unwrap();
+
+        println!("Get key SIX");
+        assert_eq!(
+            tickfs.get_key(&mut DefaultHasher::new(), "SIX", &mut buf),
+            Err(ErrorCode::KeyNotFound)
+        );
+
+        println!("Delete Key ONE");
+        tickfs
+            .invalidate_key(&mut DefaultHasher::new(), "ONE")
+            .unwrap();
+
+        println!("Delete Key TWO");
+        tickfs
+            .invalidate_key(&mut DefaultHasher::new(), "TWO")
+            .unwrap();
+
+        println!("Delete Key THREE");
+        tickfs
+            .invalidate_key(&mut DefaultHasher::new(), "THREE")
+            .unwrap();
+
+        println!("Delete Key FOUR");
+        tickfs
+            .invalidate_key(&mut DefaultHasher::new(), "FOUR")
+            .unwrap();
+
+        println!("Delete Key FIVE");
+        tickfs
+            .invalidate_key(&mut DefaultHasher::new(), "FIVE")
+            .unwrap();
+
+        println!("Delete Key SIX");
+        assert_eq!(
+            tickfs.invalidate_key(&mut DefaultHasher::new(), "SIX"),
+            Err(ErrorCode::KeyNotFound)
+        );
+    }
+}

--- a/libraries/tickfs/src/tests.rs
+++ b/libraries/tickfs/src/tests.rs
@@ -14,24 +14,24 @@ fn check_region_main(buf: &[u8]) {
     assert_eq!(buf[LEN_OFFSET + 1], 19);
 
     // Check the hash
-    assert_eq!(buf[HASH_OFFSET + 0], 0x8e);
-    assert_eq!(buf[HASH_OFFSET + 1], 0x31);
-    assert_eq!(buf[HASH_OFFSET + 2], 0xe3);
-    assert_eq!(buf[HASH_OFFSET + 3], 0x3d);
-    assert_eq!(buf[HASH_OFFSET + 4], 0xac);
-    assert_eq!(buf[HASH_OFFSET + 5], 0xbf);
-    assert_eq!(buf[HASH_OFFSET + 6], 0xb9);
-    assert_eq!(buf[HASH_OFFSET + 7], 0x58);
+    assert_eq!(buf[HASH_OFFSET + 0], 0x13);
+    assert_eq!(buf[HASH_OFFSET + 1], 0x67);
+    assert_eq!(buf[HASH_OFFSET + 2], 0xd3);
+    assert_eq!(buf[HASH_OFFSET + 3], 0xe4);
+    assert_eq!(buf[HASH_OFFSET + 4], 0xe0);
+    assert_eq!(buf[HASH_OFFSET + 5], 0x9b);
+    assert_eq!(buf[HASH_OFFSET + 6], 0xf7);
+    assert_eq!(buf[HASH_OFFSET + 7], 0x6e);
 
     // Check the check hash
-    assert_eq!(buf[HASH_OFFSET + 8], 0x59);
-    assert_eq!(buf[HASH_OFFSET + 9], 0xe4);
-    assert_eq!(buf[HASH_OFFSET + 10], 0x6b);
-    assert_eq!(buf[HASH_OFFSET + 11], 0xa6);
-    assert_eq!(buf[HASH_OFFSET + 12], 0x61);
-    assert_eq!(buf[HASH_OFFSET + 13], 0x30);
-    assert_eq!(buf[HASH_OFFSET + 14], 0xac);
-    assert_eq!(buf[HASH_OFFSET + 15], 0x1b);
+    assert_eq!(buf[HASH_OFFSET + 8], 0xdb);
+    assert_eq!(buf[HASH_OFFSET + 9], 0x6d);
+    assert_eq!(buf[HASH_OFFSET + 10], 0x81);
+    assert_eq!(buf[HASH_OFFSET + 11], 0xc6);
+    assert_eq!(buf[HASH_OFFSET + 12], 0x6b);
+    assert_eq!(buf[HASH_OFFSET + 13], 0x95);
+    assert_eq!(buf[HASH_OFFSET + 14], 0x50);
+    assert_eq!(buf[HASH_OFFSET + 15], 0xdc);
 }
 
 fn check_region_one(buf: &[u8]) {
@@ -43,14 +43,14 @@ fn check_region_one(buf: &[u8]) {
     assert_eq!(buf[LEN_OFFSET + 1], 51);
 
     // Check the hash
-    assert_eq!(buf[HASH_OFFSET + 0], 0xED);
-    assert_eq!(buf[HASH_OFFSET + 1], 0xA1);
-    assert_eq!(buf[HASH_OFFSET + 2], 0x00);
-    assert_eq!(buf[HASH_OFFSET + 3], 0x78);
-    assert_eq!(buf[HASH_OFFSET + 4], 0x88);
-    assert_eq!(buf[HASH_OFFSET + 5], 0x61);
-    assert_eq!(buf[HASH_OFFSET + 6], 0x93);
-    assert_eq!(buf[HASH_OFFSET + 7], 0xba);
+    assert_eq!(buf[HASH_OFFSET + 0], 0x81);
+    assert_eq!(buf[HASH_OFFSET + 1], 0x13);
+    assert_eq!(buf[HASH_OFFSET + 2], 0x7e);
+    assert_eq!(buf[HASH_OFFSET + 3], 0x95);
+    assert_eq!(buf[HASH_OFFSET + 4], 0x9e);
+    assert_eq!(buf[HASH_OFFSET + 5], 0x93);
+    assert_eq!(buf[HASH_OFFSET + 6], 0xaa);
+    assert_eq!(buf[HASH_OFFSET + 7], 0x3d);
 
     // Check the value
     assert_eq!(buf[HASH_OFFSET + 8], 0x23);
@@ -59,13 +59,13 @@ fn check_region_one(buf: &[u8]) {
 
     // Check the check hash
     assert_eq!(buf[43], 0x08);
-    assert_eq!(buf[44], 0xD0);
-    assert_eq!(buf[45], 0x5E);
-    assert_eq!(buf[46], 0x25);
-    assert_eq!(buf[47], 0xDD);
-    assert_eq!(buf[48], 0xAD);
-    assert_eq!(buf[49], 0x4F);
-    assert_eq!(buf[50], 0x8C);
+    assert_eq!(buf[44], 0x05);
+    assert_eq!(buf[45], 0x89);
+    assert_eq!(buf[46], 0xef);
+    assert_eq!(buf[47], 0x5d);
+    assert_eq!(buf[48], 0x42);
+    assert_eq!(buf[49], 0x42);
+    assert_eq!(buf[50], 0xdc);
 }
 
 fn check_region_two(buf: &[u8]) {
@@ -77,14 +77,14 @@ fn check_region_two(buf: &[u8]) {
     assert_eq!(buf[LEN_OFFSET + 1], 51);
 
     // Check the hash
-    assert_eq!(buf[HASH_OFFSET + 0], 0xcd);
-    assert_eq!(buf[HASH_OFFSET + 1], 0xf8);
-    assert_eq!(buf[HASH_OFFSET + 2], 0xf5);
-    assert_eq!(buf[HASH_OFFSET + 3], 0x91);
-    assert_eq!(buf[HASH_OFFSET + 4], 0xb7);
-    assert_eq!(buf[HASH_OFFSET + 5], 0x7b);
-    assert_eq!(buf[HASH_OFFSET + 6], 0x80);
-    assert_eq!(buf[HASH_OFFSET + 7], 0xf6);
+    assert_eq!(buf[HASH_OFFSET + 0], 0x9d);
+    assert_eq!(buf[HASH_OFFSET + 1], 0xd3);
+    assert_eq!(buf[HASH_OFFSET + 2], 0x71);
+    assert_eq!(buf[HASH_OFFSET + 3], 0x45);
+    assert_eq!(buf[HASH_OFFSET + 4], 0x05);
+    assert_eq!(buf[HASH_OFFSET + 5], 0xc2);
+    assert_eq!(buf[HASH_OFFSET + 6], 0xf8);
+    assert_eq!(buf[HASH_OFFSET + 7], 0x66);
 
     // Check the value
     assert_eq!(buf[HASH_OFFSET + 8], 0x23);
@@ -92,14 +92,14 @@ fn check_region_two(buf: &[u8]) {
     assert_eq!(buf[42], 0x23);
 
     // Check the check hash
-    assert_eq!(buf[43], 0x9f);
-    assert_eq!(buf[44], 0xbb);
-    assert_eq!(buf[45], 0xd0);
-    assert_eq!(buf[46], 0xdd);
-    assert_eq!(buf[47], 0xe6);
-    assert_eq!(buf[48], 0x62);
-    assert_eq!(buf[49], 0x4b);
-    assert_eq!(buf[50], 0x8a);
+    assert_eq!(buf[43], 0xdb);
+    assert_eq!(buf[44], 0x1d);
+    assert_eq!(buf[45], 0xd4);
+    assert_eq!(buf[46], 0x8a);
+    assert_eq!(buf[47], 0x7b);
+    assert_eq!(buf[48], 0x39);
+    assert_eq!(buf[49], 0x53);
+    assert_eq!(buf[50], 0x8f);
 }
 
 /// Tests using a NOP flash controller
@@ -311,10 +311,10 @@ mod store_flast_ctrl {
         let value: [u8; 32] = [0x23; 32];
 
         tickfs
-            .append_key(&mut DefaultHasher::new(), "ONE", &value)
+            .append_key(&mut DefaultHasher::new(), b"ONE", &value)
             .unwrap();
         tickfs
-            .append_key(&mut DefaultHasher::new(), "TWO", &value)
+            .append_key(&mut DefaultHasher::new(), b"TWO", &value)
             .unwrap();
     }
 
@@ -335,42 +335,42 @@ mod store_flast_ctrl {
 
         println!("Add key ONE");
         tickfs
-            .append_key(&mut DefaultHasher::new(), "ONE", &value)
+            .append_key(&mut DefaultHasher::new(), b"ONE", &value)
             .unwrap();
 
         println!("Get key ONE");
         tickfs
-            .get_key(&mut DefaultHasher::new(), "ONE", &mut buf)
+            .get_key(&mut DefaultHasher::new(), b"ONE", &mut buf)
             .unwrap();
 
         println!("Get non-existant key TWO");
         assert_eq!(
-            tickfs.get_key(&mut DefaultHasher::new(), "TWO", &mut buf),
+            tickfs.get_key(&mut DefaultHasher::new(), b"TWO", &mut buf),
             Err(ErrorCode::KeyNotFound)
         );
 
         println!("Add key ONE again");
         assert_eq!(
-            tickfs.append_key(&mut DefaultHasher::new(), "ONE", &value),
+            tickfs.append_key(&mut DefaultHasher::new(), b"ONE", &value),
             Err(ErrorCode::KeyAlreadyExists)
         );
 
         println!("Add key TWO");
         tickfs
-            .append_key(&mut DefaultHasher::new(), "TWO", &value)
+            .append_key(&mut DefaultHasher::new(), b"TWO", &value)
             .unwrap();
         println!("Get key ONE");
         tickfs
-            .get_key(&mut DefaultHasher::new(), "ONE", &mut buf)
+            .get_key(&mut DefaultHasher::new(), b"ONE", &mut buf)
             .unwrap();
         println!("Get key TWO");
         tickfs
-            .get_key(&mut DefaultHasher::new(), "TWO", &mut buf)
+            .get_key(&mut DefaultHasher::new(), b"TWO", &mut buf)
             .unwrap();
 
         println!("Get non-existant key THREE");
         assert_eq!(
-            tickfs.get_key(&mut DefaultHasher::new(), "THREE", &mut buf),
+            tickfs.get_key(&mut DefaultHasher::new(), b"THREE", &mut buf),
             Err(ErrorCode::KeyNotFound)
         );
     }
@@ -392,28 +392,28 @@ mod store_flast_ctrl {
 
         println!("Add Key ONE");
         tickfs
-            .append_key(&mut DefaultHasher::new(), "ONE", &value)
+            .append_key(&mut DefaultHasher::new(), b"ONE", &value)
             .unwrap();
 
         println!("Get key ONE");
         tickfs
-            .get_key(&mut DefaultHasher::new(), "ONE", &mut buf)
+            .get_key(&mut DefaultHasher::new(), b"ONE", &mut buf)
             .unwrap();
 
         println!("Delete Key ONE");
         tickfs
-            .invalidate_key(&mut DefaultHasher::new(), "ONE")
+            .invalidate_key(&mut DefaultHasher::new(), b"ONE")
             .unwrap();
 
         println!("Get non-existant key ONE");
         assert_eq!(
-            tickfs.get_key(&mut DefaultHasher::new(), "ONE", &mut buf),
+            tickfs.get_key(&mut DefaultHasher::new(), b"ONE", &mut buf),
             Err(ErrorCode::KeyNotFound)
         );
 
         println!("Try to delete Key ONE Again");
         assert_eq!(
-            tickfs.invalidate_key(&mut DefaultHasher::new(), "ONE"),
+            tickfs.invalidate_key(&mut DefaultHasher::new(), b"ONE"),
             Err(ErrorCode::KeyNotFound)
         );
     }
@@ -438,7 +438,7 @@ mod store_flast_ctrl {
 
         println!("Add Key ONE");
         tickfs
-            .append_key(&mut DefaultHasher::new(), "ONE", &value)
+            .append_key(&mut DefaultHasher::new(), b"ONE", &value)
             .unwrap();
 
         println!("Garbage collect flash with valid key");
@@ -446,7 +446,7 @@ mod store_flast_ctrl {
 
         println!("Delete Key ONE");
         tickfs
-            .invalidate_key(&mut DefaultHasher::new(), "ONE")
+            .invalidate_key(&mut DefaultHasher::new(), b"ONE")
             .unwrap();
 
         println!("Garbage collect flash with deleted key");
@@ -454,13 +454,13 @@ mod store_flast_ctrl {
 
         println!("Get non-existant key ONE");
         assert_eq!(
-            tickfs.get_key(&mut DefaultHasher::new(), "ONE", &mut buf),
+            tickfs.get_key(&mut DefaultHasher::new(), b"ONE", &mut buf),
             Err(ErrorCode::KeyNotFound)
         );
 
         println!("Add Key ONE");
         tickfs
-            .append_key(&mut DefaultHasher::new(), "ONE", &value)
+            .append_key(&mut DefaultHasher::new(), b"ONE", &value)
             .unwrap();
     }
 }
@@ -538,94 +538,94 @@ mod no_check_store_flast_ctrl {
 
         println!("Add Key ONE");
         tickfs
-            .append_key(&mut DefaultHasher::new(), "ONE", &value)
+            .append_key(&mut DefaultHasher::new(), b"ONE", &value)
             .unwrap();
 
         println!("Add Key TWO");
         tickfs
-            .append_key(&mut DefaultHasher::new(), "TWO", &value)
+            .append_key(&mut DefaultHasher::new(), b"TWO", &value)
             .unwrap();
 
         println!("Add Key THREE");
         tickfs
-            .append_key(&mut DefaultHasher::new(), "THREE", &value)
+            .append_key(&mut DefaultHasher::new(), b"THREE", &value)
             .unwrap();
 
         println!("Add Key FOUR");
         tickfs
-            .append_key(&mut DefaultHasher::new(), "FOUR", &value)
+            .append_key(&mut DefaultHasher::new(), b"FOUR", &value)
             .unwrap();
 
         println!("Add Key FIVE");
         tickfs
-            .append_key(&mut DefaultHasher::new(), "FIVE", &value)
+            .append_key(&mut DefaultHasher::new(), b"FIVE", &value)
             .unwrap();
 
         println!("Add Key SIX");
         assert_eq!(
-            tickfs.append_key(&mut DefaultHasher::new(), "SIX", &value),
+            tickfs.append_key(&mut DefaultHasher::new(), b"SIX", &value),
             Err(ErrorCode::FlashFull)
         );
 
         println!("Get key ONE");
         tickfs
-            .get_key(&mut DefaultHasher::new(), "ONE", &mut buf)
+            .get_key(&mut DefaultHasher::new(), b"ONE", &mut buf)
             .unwrap();
 
         println!("Get key TWO");
         tickfs
-            .get_key(&mut DefaultHasher::new(), "TWO", &mut buf)
+            .get_key(&mut DefaultHasher::new(), b"TWO", &mut buf)
             .unwrap();
 
         println!("Get key THREE");
         tickfs
-            .get_key(&mut DefaultHasher::new(), "THREE", &mut buf)
+            .get_key(&mut DefaultHasher::new(), b"THREE", &mut buf)
             .unwrap();
 
         println!("Get key FOUR");
         tickfs
-            .get_key(&mut DefaultHasher::new(), "FOUR", &mut buf)
+            .get_key(&mut DefaultHasher::new(), b"FOUR", &mut buf)
             .unwrap();
 
         println!("Get key FIVE");
         tickfs
-            .get_key(&mut DefaultHasher::new(), "FIVE", &mut buf)
+            .get_key(&mut DefaultHasher::new(), b"FIVE", &mut buf)
             .unwrap();
 
         println!("Get key SIX");
         assert_eq!(
-            tickfs.get_key(&mut DefaultHasher::new(), "SIX", &mut buf),
+            tickfs.get_key(&mut DefaultHasher::new(), b"SIX", &mut buf),
             Err(ErrorCode::KeyNotFound)
         );
 
         println!("Delete Key ONE");
         tickfs
-            .invalidate_key(&mut DefaultHasher::new(), "ONE")
+            .invalidate_key(&mut DefaultHasher::new(), b"ONE")
             .unwrap();
 
         println!("Delete Key TWO");
         tickfs
-            .invalidate_key(&mut DefaultHasher::new(), "TWO")
+            .invalidate_key(&mut DefaultHasher::new(), b"TWO")
             .unwrap();
 
         println!("Delete Key THREE");
         tickfs
-            .invalidate_key(&mut DefaultHasher::new(), "THREE")
+            .invalidate_key(&mut DefaultHasher::new(), b"THREE")
             .unwrap();
 
         println!("Delete Key FOUR");
         tickfs
-            .invalidate_key(&mut DefaultHasher::new(), "FOUR")
+            .invalidate_key(&mut DefaultHasher::new(), b"FOUR")
             .unwrap();
 
         println!("Delete Key FIVE");
         tickfs
-            .invalidate_key(&mut DefaultHasher::new(), "FIVE")
+            .invalidate_key(&mut DefaultHasher::new(), b"FIVE")
             .unwrap();
 
         println!("Delete Key SIX");
         assert_eq!(
-            tickfs.invalidate_key(&mut DefaultHasher::new(), "SIX"),
+            tickfs.invalidate_key(&mut DefaultHasher::new(), b"SIX"),
             Err(ErrorCode::KeyNotFound)
         );
     }

--- a/libraries/tickfs/src/tickfs.rs
+++ b/libraries/tickfs/src/tickfs.rs
@@ -49,7 +49,7 @@ pub(crate) const HASH_OFFSET: usize = 3;
 pub(crate) const HEADER_LENGTH: usize = HASH_OFFSET + 8;
 pub(crate) const CHECK_SUM_LEN: usize = 8;
 
-const MAIN_KEY: &str = "tickfs-super-key";
+const MAIN_KEY: &[u8; 16] = b"tickfs-super-key";
 
 /// This is the main TickFS struct.
 impl<'a, C: FlashController, H: Hasher> TickFS<'a, C, H> {
@@ -105,7 +105,7 @@ impl<'a, C: FlashController, H: Hasher> TickFS<'a, C, H> {
     }
 
     /// Generate the hash and region number from a key
-    fn get_hash_and_region(&self, hash_function: &mut H, key: &str) -> (u64, usize) {
+    fn get_hash_and_region(&self, hash_function: &mut H, key: &[u8]) -> (u64, usize) {
         // Generate a hash of the key
         key.hash(hash_function);
         let hash = hash_function.finish();
@@ -242,7 +242,7 @@ impl<'a, C: FlashController, H: Hasher> TickFS<'a, C, H> {
     pub fn append_key(
         &self,
         hash_function: &mut H,
-        key: &str,
+        key: &[u8],
         value: &[u8],
     ) -> Result<(), ErrorCode> {
         let (hash, region) = self.get_hash_and_region(hash_function, key);
@@ -423,7 +423,7 @@ impl<'a, C: FlashController, H: Hasher> TickFS<'a, C, H> {
     pub fn get_key(
         &self,
         hash_function: &mut H,
-        key: &str,
+        key: &[u8],
         buf: &mut [u8],
     ) -> Result<(), ErrorCode> {
         let (hash, region) = self.get_hash_and_region(hash_function, key);
@@ -522,7 +522,7 @@ impl<'a, C: FlashController, H: Hasher> TickFS<'a, C, H> {
     ///
     /// If a power loss occurs before success is returned the data is
     /// assumed to be lost.
-    pub fn invalidate_key(&self, hash_function: &mut H, key: &str) -> Result<(), ErrorCode> {
+    pub fn invalidate_key(&self, hash_function: &mut H, key: &[u8]) -> Result<(), ErrorCode> {
         let (hash, region) = self.get_hash_and_region(hash_function, key);
 
         let mut region_offset: isize = 0;

--- a/libraries/tickfs/src/tickfs.rs
+++ b/libraries/tickfs/src/tickfs.rs
@@ -10,11 +10,11 @@ use core::marker::PhantomData;
 pub const VERSION: u8 = 0;
 
 /// The struct storing all of the TickFS information.
-pub struct TickFS<C: FlashController, H: Hasher> {
+pub struct TickFS<'a, C: FlashController, H: Hasher> {
     controller: C,
     flash_size: usize,
     region_size: usize,
-    read_buffer: Cell<&'static mut [u8]>,
+    read_buffer: Cell<&'a mut [u8]>,
     phantom_hasher: PhantomData<H>,
 }
 
@@ -52,7 +52,7 @@ pub(crate) const CHECK_SUM_LEN: usize = 8;
 const MAIN_KEY: &str = "tickfs-super-key";
 
 /// This is the main TickFS struct.
-impl<C: FlashController, H: Hasher> TickFS<C, H> {
+impl<'a, C: FlashController, H: Hasher> TickFS<'a, C, H> {
     /// Create a new struct
     ///
     /// `C`: An implementation of the `FlashController` trait
@@ -70,7 +70,7 @@ impl<C: FlashController, H: Hasher> TickFS<C, H> {
     pub fn new(
         controller: C,
         hash_function: (&mut H, &mut H),
-        read_buffer: &'static mut [u8],
+        read_buffer: &'a mut [u8],
         flash_size: usize,
         region_size: usize,
     ) -> Option<Self> {

--- a/libraries/tickfs/src/tickfs.rs
+++ b/libraries/tickfs/src/tickfs.rs
@@ -1,0 +1,673 @@
+//! The TickFS implementation.
+
+use crate::error_codes::ErrorCode;
+use crate::flash_controller::FlashController;
+use core::cell::Cell;
+use core::hash::{Hash, Hasher};
+use core::marker::PhantomData;
+
+/// The current version of TickFS
+pub const VERSION: u8 = 0;
+
+/// The struct storing all of the TickFS information.
+pub struct TickFS<C: FlashController, H: Hasher> {
+    controller: C,
+    flash_size: usize,
+    region_size: usize,
+    read_buffer: Cell<&'static mut [u8]>,
+    phantom_hasher: PhantomData<H>,
+}
+
+/// This is the current object header used for TickFS objects
+struct ObjectHeader {
+    version: u8,
+    // In reality this is a u4.
+    flags: u8,
+    // In reality this is a u12.
+    len: u16,
+    hashed_key: u64,
+}
+
+pub(crate) const FLAGS_VALID: u8 = 8;
+
+impl ObjectHeader {
+    fn new(hashed_key: u64, len: u16) -> Self {
+        assert!(len < 0xFFF);
+        Self {
+            version: VERSION,
+            flags: FLAGS_VALID,
+            len,
+            hashed_key,
+        }
+    }
+}
+
+// A list of offsets into the ObjectHeader
+pub(crate) const VERSION_OFFSET: usize = 0;
+pub(crate) const LEN_OFFSET: usize = 1;
+pub(crate) const HASH_OFFSET: usize = 3;
+pub(crate) const HEADER_LENGTH: usize = HASH_OFFSET + 8;
+pub(crate) const CHECK_SUM_LEN: usize = 8;
+
+const MAIN_KEY: &str = "tickfs-super-key";
+
+/// This is the main TickFS struct.
+impl<C: FlashController, H: Hasher> TickFS<C, H> {
+    /// Create a new struct
+    ///
+    /// `C`: An implementation of the `FlashController` trait
+    /// `H`: An implementation of a `core::hash::Hasher` trait. This MUST
+    ///      always return the same hash for the same input. That is the
+    ///      implementation can NOT change over time.
+    ///
+    /// `controller`: An new struct implementing `FlashController`
+    /// `flash_size`: The total size of the flash used for TickFS
+    /// `region_size`: The smallest size that can be erased in a single operation.
+    ///                This must be a multiple of the start address and `flash_size`
+    ///
+    /// If the specified region has not already been setup for TickFS
+    /// the entire region will be erased.
+    pub fn new(
+        controller: C,
+        hash_function: (&mut H, &mut H),
+        read_buffer: &'static mut [u8],
+        flash_size: usize,
+        region_size: usize,
+    ) -> Option<Self> {
+        let tickfs = Self {
+            controller,
+            flash_size,
+            region_size,
+            read_buffer: Cell::new(read_buffer),
+            phantom_hasher: PhantomData,
+        };
+
+        let mut buf: [u8; 0] = [0; 0];
+
+        match tickfs.get_key(hash_function.0, MAIN_KEY, &mut buf) {
+            Ok(()) => {}
+            Err(_e) => {
+                // Erase all regions
+                for r in 0..(flash_size / region_size) {
+                    if tickfs.controller.erase_region(r).is_err() {
+                        return None;
+                    }
+                }
+
+                // Save the main key
+                if tickfs.append_key(hash_function.1, MAIN_KEY, &buf).is_err() {
+                    return None;
+                }
+            }
+        };
+
+        Some(tickfs)
+    }
+
+    /// Generate the hash and region number from a key
+    fn get_hash_and_region(&self, hash_function: &mut H, key: &str) -> (u64, usize) {
+        // Generate a hash of the key
+        key.hash(hash_function);
+        let hash = hash_function.finish();
+
+        assert_ne!(hash, 0xFFFF_FFFF_FFFF_FFFF);
+        assert_ne!(hash, 0);
+
+        // Determine the number of regions
+        let num_region = self.flash_size / self.region_size;
+
+        // Determine the block where the data should be
+        let region = (hash as usize & 0xFFFF) % num_region;
+
+        (hash, region)
+    }
+
+    // Determine the new region offset to try.
+    // Returns None if there aren't any more in range.
+    fn increment_region_offset(&self, region_offset: isize) -> Option<isize> {
+        let mut too_big = false;
+        let mut too_small = false;
+        // Loop until we find a region we can use
+        while !too_big && !too_small {
+            let new_offset = match region_offset {
+                0 => 1,
+                region_offset if region_offset > 0 => -region_offset,
+                region_offset if region_offset < 0 => -region_offset + 1,
+                _ => unreachable!(),
+            };
+
+            // Make sure our new offset is valid
+            if new_offset as usize > ((self.flash_size / self.region_size) - 1) {
+                too_big = true;
+                continue;
+            }
+
+            if new_offset < 0 {
+                too_small = true;
+                continue;
+            }
+
+            return Some(new_offset);
+        }
+
+        None
+    }
+
+    /// Find a key in some loaded region data.
+    ///
+    /// On success return the offset in the region_data where the key is and the
+    /// total length of the key.
+    /// On failure return a bool indicating if the caller should keep looking in
+    /// neighboring regions and the error code.
+    fn find_key_offset(
+        &self,
+        hash: u64,
+        region_data: &[u8],
+    ) -> Result<(usize, u16), (bool, ErrorCode)> {
+        // Determine the total size of our payload
+
+        // Split the hash
+        let hash = hash.to_ne_bytes();
+
+        let mut offset: usize = 0;
+        let mut empty: bool = true;
+
+        loop {
+            if offset + HEADER_LENGTH >= self.region_size {
+                // We have reached the end of the region
+                return Err((false, ErrorCode::KeyNotFound));
+            }
+
+            // Check to see if we have data
+            if region_data[offset + VERSION_OFFSET] != 0xFF {
+                // Mark that this region isn't empty
+                empty = false;
+
+                // We found a version, check that we support it
+                if region_data[offset + VERSION_OFFSET] != VERSION {
+                    return Err((false, ErrorCode::UnsupportedVersion));
+                }
+
+                // Find this entries length
+                let total_length = ((region_data[offset + LEN_OFFSET] as u16) & !0xF0) << 8
+                    | region_data[offset + LEN_OFFSET + 1] as u16;
+
+                // Check to see if all fields are just 0
+                if total_length == 0 {
+                    // We found something invalid here
+                    return Err((false, ErrorCode::KeyNotFound));
+                }
+
+                // Check to see if the entry has been deleted
+                if region_data[offset + LEN_OFFSET] & 0x80 != 0x80 {
+                    // Increment our offset by the length and repeat the loop
+                    offset += total_length as usize;
+                    continue;
+                }
+
+                // We have found a valid entry, see if it is ours.
+                if region_data[offset + HASH_OFFSET] != hash[7]
+                    || region_data[offset + HASH_OFFSET + 1] != hash[6]
+                    || region_data[offset + HASH_OFFSET + 2] != hash[5]
+                    || region_data[offset + HASH_OFFSET + 3] != hash[4]
+                    || region_data[offset + HASH_OFFSET + 4] != hash[3]
+                    || region_data[offset + HASH_OFFSET + 5] != hash[2]
+                    || region_data[offset + HASH_OFFSET + 6] != hash[1]
+                    || region_data[offset + HASH_OFFSET + 7] != hash[0]
+                {
+                    // Increment our offset by the length and repeat the loop
+                    offset += total_length as usize;
+                    continue;
+                }
+
+                // If we get here we have found out value (assuming no collisions)
+                return Ok((offset, total_length));
+            } else {
+                // We hit the end.
+                return Err((!empty, ErrorCode::KeyNotFound));
+            }
+        }
+    }
+
+    /// Appends the key/value pair to flash storage.
+    ///
+    /// `hash_function`: Hash function with no previous state. This is
+    ///                  usually a newly created hash.
+    /// `key`: A unhashed key. This will be hashed internally. This key
+    ///        will be used in future to retrieve or remove the `value`.
+    /// `value`: A buffer containing the data to be stored to flash.
+    ///
+    /// On success nothing will be returned.
+    /// On error a `ErrorCode` will be returned.
+    pub fn append_key(
+        &self,
+        hash_function: &mut H,
+        key: &str,
+        value: &[u8],
+    ) -> Result<(), ErrorCode> {
+        let (hash, region) = self.get_hash_and_region(hash_function, key);
+
+        // Length not including check sum
+        let package_length = HEADER_LENGTH + value.len();
+        let object_length = HEADER_LENGTH + value.len() + CHECK_SUM_LEN;
+
+        if object_length > 0xFFF {
+            return Err(ErrorCode::ObjectTooLarge);
+        }
+
+        // Create the header:
+        let header = ObjectHeader::new(hash, object_length as u16);
+
+        let mut region_offset: isize = 0;
+
+        loop {
+            // Get the data from that region
+            let new_region = region as isize + region_offset;
+
+            let mut region_data = self.read_buffer.take();
+            match self
+                .controller
+                .read_region(new_region as usize, 0, &mut region_data)
+            {
+                Ok(()) => {}
+                Err(e) => {
+                    self.read_buffer.replace(region_data);
+                    return Err(e);
+                }
+            };
+
+            if self.find_key_offset(hash, &region_data).is_ok() {
+                // Check to make sure we don't already have this key
+                self.read_buffer.replace(region_data);
+                return Err(ErrorCode::KeyAlreadyExists);
+            }
+
+            let mut offset: usize = 0;
+
+            loop {
+                if offset + package_length >= self.region_size {
+                    // We have reached the end of the region
+                    // We will need to try the next region
+
+                    // Replace the buffer
+                    self.read_buffer.replace(region_data);
+
+                    match self.increment_region_offset(new_region) {
+                        Some(o) => {
+                            region_offset = o;
+                        }
+                        None => {
+                            return Err(ErrorCode::FlashFull);
+                        }
+                    }
+                    break;
+                }
+
+                // Check to see if we have data
+                if region_data[offset + VERSION_OFFSET] != 0xFF {
+                    // We found a version, check that we support it
+                    if region_data[offset + VERSION_OFFSET] != VERSION {
+                        self.read_buffer.replace(region_data);
+                        return Err(ErrorCode::UnsupportedVersion);
+                    }
+
+                    // Find this entries length
+                    let total_length = ((region_data[offset + LEN_OFFSET] as u16) & !0xF0) << 8
+                        | region_data[offset + LEN_OFFSET + 1] as u16;
+
+                    // Increment our offset by the length and repeat the loop
+                    offset += total_length as usize;
+                    continue;
+                }
+
+                // If we get here we have found an empty spot
+                // Double check that there is no valid hash
+
+                // Check to see if the entire header is 0xFFFF_FFFF_FFFF_FFFF
+                // To avoid operating on 64-bit values check every 8 bytes at a time
+                if region_data[offset + HASH_OFFSET] != 0xFF {
+                    self.read_buffer.replace(region_data);
+                    return Err(ErrorCode::CorruptData);
+                }
+                if region_data[offset + HASH_OFFSET + 1] != 0xFF {
+                    self.read_buffer.replace(region_data);
+                    return Err(ErrorCode::CorruptData);
+                }
+                if region_data[offset + HASH_OFFSET + 2] != 0xFF {
+                    self.read_buffer.replace(region_data);
+                    return Err(ErrorCode::CorruptData);
+                }
+                if region_data[offset + HASH_OFFSET + 3] != 0xFF {
+                    self.read_buffer.replace(region_data);
+                    return Err(ErrorCode::CorruptData);
+                }
+                if region_data[offset + HASH_OFFSET + 4] != 0xFF {
+                    self.read_buffer.replace(region_data);
+                    return Err(ErrorCode::CorruptData);
+                }
+                if region_data[offset + HASH_OFFSET + 5] != 0xFF {
+                    self.read_buffer.replace(region_data);
+                    return Err(ErrorCode::CorruptData);
+                }
+                if region_data[offset + HASH_OFFSET + 6] != 0xFF {
+                    self.read_buffer.replace(region_data);
+                    return Err(ErrorCode::CorruptData);
+                }
+                if region_data[offset + HASH_OFFSET + 7] != 0xFF {
+                    self.read_buffer.replace(region_data);
+                    return Err(ErrorCode::CorruptData);
+                }
+
+                // If we get here we have found an empty spot
+
+                // Copy in new header
+                // This is a little painful, but avoids any unsafe Rust
+                region_data[offset + VERSION_OFFSET] = header.version;
+                region_data[offset + LEN_OFFSET] =
+                    (header.len >> 8) as u8 & 0x0F | (header.flags << 4) & 0xF0;
+                region_data[offset + LEN_OFFSET + 1] = (header.len & 0xFF) as u8;
+                region_data[offset + HASH_OFFSET] = (header.hashed_key >> 56) as u8;
+                region_data[offset + HASH_OFFSET + 1] = (header.hashed_key >> 48) as u8;
+                region_data[offset + HASH_OFFSET + 2] = (header.hashed_key >> 40) as u8;
+                region_data[offset + HASH_OFFSET + 3] = (header.hashed_key >> 32) as u8;
+                region_data[offset + HASH_OFFSET + 4] = (header.hashed_key >> 24) as u8;
+                region_data[offset + HASH_OFFSET + 5] = (header.hashed_key >> 16) as u8;
+                region_data[offset + HASH_OFFSET + 6] = (header.hashed_key >> 8) as u8;
+                region_data[offset + HASH_OFFSET + 7] = (header.hashed_key) as u8;
+
+                // Hash the new header data
+                for d in &region_data[offset + VERSION_OFFSET..=offset + HASH_OFFSET + 7] {
+                    hash_function.write_u8(*d);
+                }
+
+                // Copy the value
+                let slice = &mut region_data[(offset + HEADER_LENGTH)..(offset + package_length)];
+                slice.copy_from_slice(value);
+
+                // Include the value in the hash
+                value.hash(hash_function);
+
+                // Append a Check Hash
+                let check_sum = hash_function.finish();
+                let slice = &mut region_data
+                    [(offset + package_length)..(offset + package_length + CHECK_SUM_LEN)];
+                slice.copy_from_slice(&check_sum.to_ne_bytes());
+
+                // Write the data back to the region
+                if let Err(e) = self.controller.write(
+                    self.region_size * new_region as usize + offset,
+                    &region_data[offset..(offset + package_length + CHECK_SUM_LEN)],
+                ) {
+                    self.read_buffer.replace(region_data);
+                    return Err(e);
+                }
+
+                self.read_buffer.replace(region_data);
+                return Ok(());
+            }
+        }
+    }
+
+    /// Retrieves the value from flash storage.
+    ///
+    /// `hash_function`: Hash function with no previous state. This is
+    ///                  usually a newly created hash.
+    /// `key`: A unhashed key. This will be hashed internally.
+    /// `buf`: A buffer to store the value to.
+    ///
+    /// On success nothing will be returned.
+    /// On error a `ErrorCode` will be returned.
+    ///
+    /// If a power loss occurs before success is returned the data is
+    /// assumed to be lost.
+    pub fn get_key(
+        &self,
+        hash_function: &mut H,
+        key: &str,
+        buf: &mut [u8],
+    ) -> Result<(), ErrorCode> {
+        let (hash, region) = self.get_hash_and_region(hash_function, key);
+
+        let mut region_offset: isize = 0;
+
+        loop {
+            // Get the data from that region
+            let new_region = region as isize + region_offset;
+
+            // Get the data from that region
+            let mut region_data = self.read_buffer.take();
+            match self
+                .controller
+                .read_region(new_region as usize, 0, &mut region_data)
+            {
+                Ok(()) => {}
+                Err(e) => {
+                    self.read_buffer.replace(region_data);
+                    return Err(e);
+                }
+            };
+
+            match self.find_key_offset(hash, &region_data) {
+                Ok((offset, total_length)) => {
+                    // Add the header data to the check hash
+                    for i in 0..HEADER_LENGTH {
+                        hash_function.write_u8(region_data[offset + i]);
+                    }
+
+                    // Make sure if will fit in the buffer
+                    if buf.len() < (total_length as usize - HEADER_LENGTH - CHECK_SUM_LEN) {
+                        self.read_buffer.replace(region_data);
+                        return Err(ErrorCode::BufferTooSmall(
+                            total_length as usize - HEADER_LENGTH - CHECK_SUM_LEN,
+                        ));
+                    }
+
+                    // Copy in the value
+                    for i in 0..(total_length as usize - HEADER_LENGTH - CHECK_SUM_LEN) {
+                        buf[i] = region_data[offset + HEADER_LENGTH + i];
+                    }
+
+                    // Include the value in the hash
+                    buf.hash(hash_function);
+
+                    // Check the hash
+                    let check_sum = hash_function.finish();
+
+                    let check_sum = check_sum.to_ne_bytes();
+
+                    if check_sum[7] != region_data[offset + total_length as usize - 1]
+                        || check_sum[6] != region_data[offset + total_length as usize - 2]
+                        || check_sum[5] != region_data[offset + total_length as usize - 3]
+                        || check_sum[4] != region_data[offset + total_length as usize - 4]
+                        || check_sum[3] != region_data[offset + total_length as usize - 5]
+                        || check_sum[2] != region_data[offset + total_length as usize - 6]
+                        || check_sum[1] != region_data[offset + total_length as usize - 7]
+                        || check_sum[0] != region_data[offset + total_length as usize - 8]
+                    {
+                        self.read_buffer.replace(region_data);
+                        return Err(ErrorCode::InvalidCheckSum);
+                    }
+
+                    self.read_buffer.replace(region_data);
+                    return Ok(());
+                }
+                Err((cont, e)) => {
+                    self.read_buffer.replace(region_data);
+
+                    if cont {
+                        match self.increment_region_offset(new_region) {
+                            Some(o) => {
+                                region_offset = o;
+                            }
+                            None => {
+                                return Err(e);
+                            }
+                        }
+                    } else {
+                        return Err(e);
+                    }
+                }
+            }
+        }
+    }
+
+    /// Invalidates the key in flash storage
+    ///
+    /// `hash_function`: Hash function with no previous state. This is
+    ///                  usually a newly created hash.
+    /// `key`: A unhashed key. This will be hashed internally.
+    ///
+    /// On success nothing will be returned.
+    /// On error a `ErrorCode` will be returned.
+    ///
+    /// If a power loss occurs before success is returned the data is
+    /// assumed to be lost.
+    pub fn invalidate_key(&self, hash_function: &mut H, key: &str) -> Result<(), ErrorCode> {
+        let (hash, region) = self.get_hash_and_region(hash_function, key);
+
+        let mut region_offset: isize = 0;
+
+        loop {
+            // Get the data from that region
+            let new_region = region as isize + region_offset;
+
+            let mut region_data = self.read_buffer.take();
+            match self
+                .controller
+                .read_region(new_region as usize, 0, &mut region_data)
+            {
+                Ok(()) => {}
+                Err(e) => {
+                    self.read_buffer.replace(region_data);
+                    return Err(e);
+                }
+            };
+
+            match self.find_key_offset(hash, &region_data) {
+                Ok((offset, _data_len)) => {
+                    // We found a key, let's delete it
+                    region_data[offset + LEN_OFFSET] &= !0x80;
+
+                    if let Err(e) = self.controller.write(
+                        self.region_size * new_region as usize + offset + LEN_OFFSET,
+                        &region_data[offset + LEN_OFFSET..offset + LEN_OFFSET + 1],
+                    ) {
+                        self.read_buffer.replace(region_data);
+                        return Err(e);
+                    }
+
+                    self.read_buffer.replace(region_data);
+                    return Ok(());
+                }
+                Err((cont, e)) => {
+                    self.read_buffer.replace(region_data);
+
+                    if cont {
+                        match self.increment_region_offset(new_region) {
+                            Some(o) => {
+                                region_offset = o;
+                            }
+                            None => {
+                                return Err(e);
+                            }
+                        }
+                    } else {
+                        return Err(e);
+                    }
+                }
+            }
+        }
+    }
+
+    fn garbage_collect_region(&self, region: usize) -> Result<usize, ErrorCode> {
+        // Get the data from that region
+        let mut region_data = self.read_buffer.take();
+        match self.controller.read_region(region, 0, &mut region_data) {
+            Ok(()) => {}
+            Err(e) => {
+                self.read_buffer.replace(region_data);
+                return Err(e);
+            }
+        };
+
+        let mut entry_found = false;
+        let mut offset: usize = 0;
+
+        loop {
+            if offset >= self.region_size {
+                // We have reached the end of the region without finding a
+                // valid object. All entries must be marked for deletion then.
+                break;
+            }
+
+            // Check to see if we have data
+            if region_data[offset + VERSION_OFFSET] != 0xFF {
+                // We found a version, check that we support it
+                if region_data[offset + VERSION_OFFSET] != VERSION {
+                    self.read_buffer.replace(region_data);
+                    return Err(ErrorCode::UnsupportedVersion);
+                }
+
+                entry_found = true;
+
+                // Find this entries length
+                let total_length = ((region_data[offset + LEN_OFFSET] as u16) & !0xF0) << 8
+                    | region_data[offset + LEN_OFFSET + 1] as u16;
+
+                // Check to see if the entry has been deleted
+                if region_data[offset + LEN_OFFSET] & 0x80 != 0x80 {
+                    // The entry has been deleted, this region might be ready
+                    // for erasure.
+                    // Increment our offset by the length and repeat the loop
+                    offset += total_length as usize;
+                    continue;
+                }
+
+                // We have found a valid entry!
+                // Don't perform an erase!
+                self.read_buffer.replace(region_data);
+                return Ok(0);
+            } else {
+                // We hit the end of valid data.
+                // The possible outcomes:
+                //    * The region is empty, we don't need to do anything
+                //    * The region has entries, all of which are marked for
+                //      deletion
+                if !entry_found {
+                    // We didn't find anything, don't bother erasing an empty region.
+                    self.read_buffer.replace(region_data);
+                    return Ok(0);
+                }
+                break;
+            }
+        }
+
+        self.read_buffer.replace(region_data);
+
+        // If we got down here, the region is ready to be erased.
+
+        if let Err(e) = self.controller.erase_region(region) {
+            return Err(e);
+        }
+
+        Ok(self.region_size)
+    }
+
+    /// Perform a garbage collection on TickFS
+    ///
+    /// On success the number of bytes freed will be returned.
+    /// On error a `ErrorCode` will be returned.
+    pub fn garbage_collect(&self) -> Result<usize, ErrorCode> {
+        let num_region = self.flash_size / self.region_size;
+        let mut flash_freed = 0;
+
+        for i in 0..num_region {
+            match self.garbage_collect_region(i) {
+                Ok(freed) => flash_freed += freed,
+                Err(e) => return Err(e),
+            }
+        }
+
+        Ok(flash_freed)
+    }
+}


### PR DESCRIPTION
### Pull Request Overview

This is the first stab at integrating [TickFS](https://github.com/tock/tock/pull/2156), which needs review, into Tock.

This adds a internal state machine to TickFS and some continue functions to allow it to work async while also being friendly to sync users.

This is a WIP PR with debug statements, lots that isn't yet implementation and using the deprecated `core::hash::SipHasher`. It's hopefully just a way to get reviews for https://github.com/tock/tock/pull/2156

### Testing Strategy

This pull request was tested by running on OpenTitain.

I can store a key in flash and then reboot Tock and see that it's still in flash and read it back.

### TODO or Help Wanted

Review: https://github.com/tock/tock/pull/2156

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
