### PR TITLE
Adafruit CLUE nrf52840

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "boards/acd52832",
     "boards/arty_e21",
     "boards/earlgrey-nexysvideo",
+    "boards/clue_nrf52840",
     "boards/hail",
     "boards/hifive1",
     "boards/imix",

--- a/boards/README.md
+++ b/boards/README.md
@@ -13,6 +13,7 @@ that Tock supports.
 | [Nordic nRF52840-Dongle](nordic/nrf52840_dongle/README.md)           | ARM Cortex-M4   | nRF52840       | jLink      | tockloader     | No                |
 | [ACD52832](acd52832/README.md)                                       | ARM Cortex-M4   | nRF52832       | jLink      | tockloader     | No                |
 | [Nano 33 BLE](nano33ble/README.md)                                   | ARM Cortex-M4   | nRF52840       | BOSSA      | bossac         | No                |
+| [Clue nRF52840](clue_nrf52840/README.md)                             | ARM Cortex-M4   | nRF52840       | nrfutil    | custom         | No                |
 | [ST Nucleo F446RE](nucleo_f446re/README.md)                          | ARM Cortex-M4   | STM32F446      | openocd    | custom         | #1827             |
 | [ST Nucleo F429ZI](nucleo_f429zi/README.md)                          | ARM Cortex-M4   | STM32F429      | openocd    | custom         | #1827             |
 | [STM32F3Discovery kit](stm32f3discovery/README.md)                   | ARM Cortex-M4   | STM32F303VCT6  | openocd    | custom         | #1827             |

--- a/boards/clue_nrf52840/Cargo.toml
+++ b/boards/clue_nrf52840/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "clue_nrf52840"
+version = "0.1.0"
+authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+build = "build.rs"
+edition = "2018"
+
+[dependencies]
+cortexm4 = { path = "../../arch/cortex-m4" }
+capsules = { path = "../../capsules" }
+kernel = { path = "../../kernel" }
+nrf52 = { path = "../../chips/nrf52" }
+nrf52840 = { path = "../../chips/nrf52840" }
+components = { path = "../components" }
+nrf52_components = { path = "../nordic/nrf52_components" }

--- a/boards/clue_nrf52840/Makefile
+++ b/boards/clue_nrf52840/Makefile
@@ -10,14 +10,24 @@ ifdef PORT
   FLAGS += -p $(PORT)
 endif
 
-APP=../../../libtock-c/examples/buttons/build/cortex-m4/cortex-m4.tbf
+APP=../../../libtock-c/examples/screen/build/cortex-m4/cortex-m4.tbf
 KERNEL=$(TOCK_ROOT_DIRECTORY)/target/$(TARGET)/debug/$(PLATFORM).elf
 KERNEL_WITH_APP=$(TOCK_ROOT_DIRECTORY)/target/$(TARGET)/debug/$(PLATFORM)-app.elf
 
-# Upload the kernel using bossac
-.PHONY: program
-program: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/debug/$(PLATFORM).elf
+# Upload the kernel using nrfutil
+.PHONY: program program-apps
+
+program: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/debug/$(PLATFORM).bin
+	adafruit-nrfutil dfu genpkg --dev-type 0x0052 --sd-req 0x00B6 --application $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/debug/$(PLATFORM).bin $(KERNEL).zip
+	echo "Trying to reset device"
+	stty -F $(PORT) 1200
+	adafruit-nrfutil --verbose dfu serial -pkg $(KERNEL_WITH_APP).zip $(FLAGS) -b 115200 --singlebank
+
+# Upload the kernel and apps using nrfutil
+program-apps: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/debug/$(PLATFORM).elf
 	arm-none-eabi-objcopy --update-section .apps=$(APP) $(KERNEL) $(KERNEL_WITH_APP)
 	arm-none-eabi-objcopy --output-target=binary -S $(KERNEL_WITH_APP) $(KERNEL_WITH_APP).bin
 	adafruit-nrfutil dfu genpkg --dev-type 0x0052 --sd-req 0x00B6 --application $(KERNEL_WITH_APP).bin $(KERNEL_WITH_APP).zip
+	echo "Trying to reset device"
+	stty -F $(PORT) 1200
 	adafruit-nrfutil --verbose dfu serial -pkg $(KERNEL_WITH_APP).zip $(FLAGS) -b 115200 --singlebank

--- a/boards/clue_nrf52840/Makefile
+++ b/boards/clue_nrf52840/Makefile
@@ -11,7 +11,7 @@ ifdef PORT
 endif
 
 APP=../../../libtock-c/examples/screen/build/cortex-m4/cortex-m4.tbf
-KERNEL=$(TOCK_ROOT_DIRECTORY)/target/$(TARGET)/debug/$(PLATFORM).elf
+KERNEL=$(TOCK_ROOT_DIRECTORY)target/$(TARGET)/debug/$(PLATFORM).elf
 KERNEL_WITH_APP=$(TOCK_ROOT_DIRECTORY)/target/$(TARGET)/debug/$(PLATFORM)-app.elf
 
 # Upload the kernel using nrfutil
@@ -20,8 +20,8 @@ KERNEL_WITH_APP=$(TOCK_ROOT_DIRECTORY)/target/$(TARGET)/debug/$(PLATFORM)-app.el
 program: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/debug/$(PLATFORM).bin
 	adafruit-nrfutil dfu genpkg --dev-type 0x0052 --sd-req 0x00B6 --application $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/debug/$(PLATFORM).bin $(KERNEL).zip
 	echo "Trying to reset device"
-	stty -F $(PORT) 1200
-	adafruit-nrfutil --verbose dfu serial -pkg $(KERNEL_WITH_APP).zip $(FLAGS) -b 115200 --singlebank
+	stty -F $(PORT) 1200 && sleep 0.5 && stty -F $(PORT) 1200
+	adafruit-nrfutil --verbose dfu serial -pkg $(KERNEL).zip $(FLAGS) -b 115200 --singlebank
 
 # Upload the kernel and apps using nrfutil
 program-apps: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/debug/$(PLATFORM).elf
@@ -29,5 +29,5 @@ program-apps: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/debug/$(PLATFORM).elf
 	arm-none-eabi-objcopy --output-target=binary -S $(KERNEL_WITH_APP) $(KERNEL_WITH_APP).bin
 	adafruit-nrfutil dfu genpkg --dev-type 0x0052 --sd-req 0x00B6 --application $(KERNEL_WITH_APP).bin $(KERNEL_WITH_APP).zip
 	echo "Trying to reset device"
-	stty -F $(PORT) 1200
+	stty -F $(PORT) 1200 && sleep 0.5 && stty -F $(PORT) 1200
 	adafruit-nrfutil --verbose dfu serial -pkg $(KERNEL_WITH_APP).zip $(FLAGS) -b 115200 --singlebank

--- a/boards/clue_nrf52840/Makefile
+++ b/boards/clue_nrf52840/Makefile
@@ -1,4 +1,4 @@
-# Makefile for building the tock kernel for the Arduino Nano 33 BLE board.
+# Makefile for building the tock kernel for the CLUE nRF52840 board.
 
 TOCK_ARCH=cortex-m4
 TARGET=thumbv7em-none-eabi

--- a/boards/clue_nrf52840/Makefile
+++ b/boards/clue_nrf52840/Makefile
@@ -1,0 +1,23 @@
+# Makefile for building the tock kernel for the Arduino Nano 33 BLE board.
+
+TOCK_ARCH=cortex-m4
+TARGET=thumbv7em-none-eabi
+PLATFORM=clue_nrf52840
+
+include ../Makefile.common
+
+ifdef PORT
+  FLAGS += -p $(PORT)
+endif
+
+APP=../../../libtock-c/examples/buttons/build/cortex-m4/cortex-m4.tbf
+KERNEL=$(TOCK_ROOT_DIRECTORY)/target/$(TARGET)/debug/$(PLATFORM).elf
+KERNEL_WITH_APP=$(TOCK_ROOT_DIRECTORY)/target/$(TARGET)/debug/$(PLATFORM)-app.elf
+
+# Upload the kernel using bossac
+.PHONY: program
+program: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/debug/$(PLATFORM).elf
+	arm-none-eabi-objcopy --update-section .apps=$(APP) $(KERNEL) $(KERNEL_WITH_APP)
+	arm-none-eabi-objcopy --output-target=binary -S $(KERNEL_WITH_APP) $(KERNEL_WITH_APP).bin
+	adafruit-nrfutil dfu genpkg --dev-type 0x0052 --sd-req 0x00B6 --application $(KERNEL_WITH_APP).bin $(KERNEL_WITH_APP).zip
+	adafruit-nrfutil --verbose dfu serial -pkg $(KERNEL_WITH_APP).zip $(FLAGS) -b 115200 --singlebank

--- a/boards/clue_nrf52840/README.md
+++ b/boards/clue_nrf52840/README.md
@@ -1,0 +1,113 @@
+Adafruit CLUE - nRF52840 Express with Bluetooth LE
+==================================================
+
+<img src="https://cdn-learn.adafruit.com/assets/assets/000/087/843/medium640/adafruit_products_Clue_top_angle.jpg?1580406577" width="35%">
+
+The [Adafruit CLUE - nRF52840 Express with Bluetooth LE](https://www.adafruit.com/product/4500) is a
+board based on the Nordic nRF52840 SoC. Includes the
+following sensors:
+
+- 9 axis inertial sensor
+- humidity and temperature sensor
+- barometric sensor
+- microphone
+- gesture, proximity, light color and light intensity sensor
+
+It has thhe same form factor with BBC:Microbit
+
+
+## Getting Started
+
+First, follow the [Tock Getting Started guide](../../../doc/Getting_Started.md)
+
+You will need the bossac bootloader tool:
+
+```shell
+$ pip3 install --user adafruit-nrfutil
+```
+
+## Programming the Kernel
+
+To program the kernel we use the BOSSA tool to communicate with the bootloader
+on the board which then flashes the kernel. This requires that the bootloader be
+active. To force the board into bootloader mode, press the button on the board
+twice in rapid succession. You should see the yellow LED pulse on and off.
+
+At this point you should be able to simply run `make program` in this directory
+to install a fresh kernel.
+
+```
+$ make program
+```
+
+You may need to specify the port like so:
+
+```
+$ make program PORT=<serial port path>
+```
+
+## Programming Applications
+
+This is currently a weakness of the Nano 33 board as flashing applications is
+not as ergonomic as Tock expects. Right now, you should be able to flash a
+single application. For example, to flash the "blink" app, first compile it:
+
+```
+$ git clone https://github.com/tock/libtock-c
+$ cd libtock-c/examples/blink
+$ make
+```
+
+This previous step will create a TAB (`.tab` file) that normally tockloader
+would use to program on the board. However, tockloader is currently not
+supported. As a workaround, we can directly program a single app. To load the
+blink app, first press the button on the board twice in rapid succession to
+enter the bootloader, and then:
+
+```
+$ bossac -i -e -o 0x20000 -w build/cortex-m4/cortex-m4.tbf -R
+```
+
+That tells the BOSSA tool to flash the application in the Tock Binary Format to
+the correct offset (the app will end up at address 0x30000). You may also need
+to pass the `--port` flag.
+
+### Userspace Resource Mapping
+
+This table shows the mappings between resources available in userspace
+and the physical elements on the Nano 33 BLE board.
+
+| Software Resource | Physical Element    |
+|-------------------|---------------------|
+| GPIO[2]           | Pin D2              |
+| GPIO[3]           | Pin D3              |
+| GPIO[4]           | Pin D4              |
+| GPIO[5]           | Pin D5              |
+| GPIO[6]           | Pin D6              |
+| GPIO[7]           | Pin D7              |
+| GPIO[8]           | Pin D8              |
+| GPIO[9]           | Pin D9              |
+| GPIO[10]          | Pin D10             |
+| LED[0]            | Tri-color LED Red   |
+| LED[1]            | Tri-color LED Green |
+| LED[2]            | Tri-color LED Blue  |
+
+## Debugging
+
+The Nano 33 board uses a virtual serial console over USB to send debugging info
+from the kernel and print messages from applications. You can use whatever your
+favorite serial terminal program is to view the output. Tockloader also
+supports reading and writing to a serial console with `tockloader listen`.
+
+### Kernel Panics
+
+If the kernel or an app encounter a `panic!()`, the panic handler specified in
+`io.rs` is called. This causes the kernel to stop. You will notice the yellow
+LED starts blinking in a repeating but slightly irregular pattern. There is also
+a panic print out that provides a fair bit of debugging information. That panic
+output is output over the USB CDC connection and so should be visible as part
+of the output of `tockloader listen`, however if your kernel panics so early
+that the USB connection has not yet been established you will be unable to view
+any panic output. In this case, you can modify the panic handler to instead
+output panic information over the UART pins, but you will have to separately interface
+with the UART pins on the board in order to observe the serial output.

--- a/boards/clue_nrf52840/README.md
+++ b/boards/clue_nrf52840/README.md
@@ -19,7 +19,7 @@ It has the same form factor with BBC:Microbit
 
 First, follow the [Tock Getting Started guide](../../../doc/Getting_Started.md)
 
-You will need the bossac bootloader tool:
+You will need Adafruit's nrfutil bootloader tool:
 
 ```shell
 $ pip3 install --user adafruit-nrfutil
@@ -62,25 +62,25 @@ supported.
 ### Userspace Resource Mapping
 
 This table shows the mappings between resources available in userspace
-and the physical elements on the Nano 33 BLE board.
+and the physical elements on the CLUE nRF52480 board.
 
 | Software Resource | Physical Element    |
 |-------------------|---------------------|
-| GPIO[2]           | Pin D2              |
-| GPIO[3]           | Pin D3              |
-| GPIO[4]           | Pin D4              |
-| GPIO[6]           | Pin D6              |
-| GPIO[7]           | Pin D7              |
-| GPIO[8]           | Pin D8              |
-| GPIO[9]           | Pin D9              |
-| GPIO[10]          | Pin D10             |
-| GPIO[12]          | Pin D12             |
+| GPIO[2]           | Pad D2              |
+| GPIO[3]           | Pad D3              |
+| GPIO[4]           | Pad D4              |
+| GPIO[6]           | Pad D6              |
+| GPIO[7]           | Pad D7              |
+| GPIO[8]           | Pad D8              |
+| GPIO[9]           | Pad D9              |
+| GPIO[10]          | Pad D10             |
+| GPIO[12]          | Pad D12             |
 | LED[0]            | Red LED Red         |
 | LED[1]            | White LEDs          |
 
 ## Debugging
 
-The Nano 33 board uses a virtual serial console over USB to send debugging info
+The CLUE nRF2840 board uses a virtual serial console over USB to send debugging info
 from the kernel and print messages from applications. You can use whatever your
 favorite serial terminal program is to view the output. Tockloader also
 supports reading and writing to a serial console with `tockloader listen`.

--- a/boards/clue_nrf52840/README.md
+++ b/boards/clue_nrf52840/README.md
@@ -4,17 +4,16 @@ Adafruit CLUE - nRF52840 Express with Bluetooth LE
 <img src="https://cdn-learn.adafruit.com/assets/assets/000/087/843/medium640/adafruit_products_Clue_top_angle.jpg?1580406577" width="35%">
 
 The [Adafruit CLUE - nRF52840 Express with Bluetooth LE](https://www.adafruit.com/product/4500) is a
-board based on the Nordic nRF52840 SoC. Includes the
+board based on the Nordic nRF52840 SoC. It includes the
 following sensors:
 
-- 9 axis inertial sensor
+- 9 axis inertial LSM6DS33 + LIS3MDL sensor 
 - humidity and temperature sensor
 - barometric sensor
 - microphone
 - gesture, proximity, light color and light intensity sensor
 
-It has thhe same form factor with BBC:Microbit
-
+It has the same form factor with BBC:Microbit
 
 ## Getting Started
 
@@ -28,10 +27,10 @@ $ pip3 install --user adafruit-nrfutil
 
 ## Programming the Kernel
 
-To program the kernel we use the BOSSA tool to communicate with the bootloader
+To program the kernel we use the Adafruit version of nRFUtil tool to communicate with the bootloader
 on the board which then flashes the kernel. This requires that the bootloader be
-active. To force the board into bootloader mode, press the button on the board
-twice in rapid succession. You should see the yellow LED pulse on and off.
+active. To force the board into bootloader mode, press the button on the back of the board
+twice in rapid succession. You should see the red LED pulse on and off.
 
 At this point you should be able to simply run `make program` in this directory
 to install a fresh kernel.
@@ -48,9 +47,7 @@ $ make program PORT=<serial port path>
 
 ## Programming Applications
 
-This is currently a weakness of the Nano 33 board as flashing applications is
-not as ergonomic as Tock expects. Right now, you should be able to flash a
-single application. For example, to flash the "blink" app, first compile it:
+For now, flashing apps is only available together with the kernel
 
 ```
 $ git clone https://github.com/tock/libtock-c
@@ -60,17 +57,7 @@ $ make
 
 This previous step will create a TAB (`.tab` file) that normally tockloader
 would use to program on the board. However, tockloader is currently not
-supported. As a workaround, we can directly program a single app. To load the
-blink app, first press the button on the board twice in rapid succession to
-enter the bootloader, and then:
-
-```
-$ bossac -i -e -o 0x20000 -w build/cortex-m4/cortex-m4.tbf -R
-```
-
-That tells the BOSSA tool to flash the application in the Tock Binary Format to
-the correct offset (the app will end up at address 0x30000). You may also need
-to pass the `--port` flag.
+supported.
 
 ### Userspace Resource Mapping
 
@@ -82,15 +69,14 @@ and the physical elements on the Nano 33 BLE board.
 | GPIO[2]           | Pin D2              |
 | GPIO[3]           | Pin D3              |
 | GPIO[4]           | Pin D4              |
-| GPIO[5]           | Pin D5              |
 | GPIO[6]           | Pin D6              |
 | GPIO[7]           | Pin D7              |
 | GPIO[8]           | Pin D8              |
 | GPIO[9]           | Pin D9              |
 | GPIO[10]          | Pin D10             |
-| LED[0]            | Tri-color LED Red   |
-| LED[1]            | Tri-color LED Green |
-| LED[2]            | Tri-color LED Blue  |
+| GPIO[12]          | Pin D12             |
+| LED[0]            | Red LED Red         |
+| LED[1]            | White LEDs          |
 
 ## Debugging
 
@@ -102,7 +88,7 @@ supports reading and writing to a serial console with `tockloader listen`.
 ### Kernel Panics
 
 If the kernel or an app encounter a `panic!()`, the panic handler specified in
-`io.rs` is called. This causes the kernel to stop. You will notice the yellow
+`io.rs` is called. This causes the kernel to stop. You will notice the red
 LED starts blinking in a repeating but slightly irregular pattern. There is also
 a panic print out that provides a fair bit of debugging information. That panic
 output is output over the USB CDC connection and so should be visible as part

--- a/boards/clue_nrf52840/build.rs
+++ b/boards/clue_nrf52840/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    println!("cargo:rerun-if-changed=layout.ld");
+    println!("cargo:rerun-if-changed=../kernel_layout.ld");
+}

--- a/boards/clue_nrf52840/layout.ld
+++ b/boards/clue_nrf52840/layout.ld
@@ -1,0 +1,12 @@
+MEMORY
+{
+  # Make space for the UF2 bootloader
+  rom (rx)  : ORIGIN = 0x00026000, LENGTH = 192K
+  prog (rx) : ORIGIN = 0x00056000, LENGTH = 640K
+  ram (rwx) : ORIGIN = 0x20006000, LENGTH = 232K
+}
+
+MPU_MIN_ALIGN = 8K;
+PAGE_SIZE = 4K;
+
+INCLUDE ../kernel_layout.ld

--- a/boards/clue_nrf52840/src/io.rs
+++ b/boards/clue_nrf52840/src/io.rs
@@ -1,0 +1,136 @@
+use core::fmt::Write;
+use core::panic::PanicInfo;
+
+use cortexm4;
+use kernel::debug;
+use kernel::debug::IoWrite;
+use kernel::hil::led;
+use kernel::hil::uart::{self};
+use nrf52840::gpio::Pin;
+
+use crate::CHIP;
+use crate::PROCESSES;
+use kernel::common::cells::VolatileCell;
+use kernel::hil::uart::Transmit;
+
+struct Writer {
+    initialized: bool,
+}
+
+static mut WRITER: Writer = Writer { initialized: false };
+
+impl Write for Writer {
+    fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
+        self.write(s.as_bytes());
+        Ok(())
+    }
+}
+
+const BUF_LEN: usize = 512;
+static mut STATIC_PANIC_BUF: [u8; BUF_LEN] = [0; BUF_LEN];
+
+static mut DUMMY: DummyUsbClient = DummyUsbClient {
+    fired: VolatileCell::new(false),
+};
+
+struct DummyUsbClient {
+    fired: VolatileCell<bool>,
+}
+
+impl uart::TransmitClient for DummyUsbClient {
+    fn transmitted_buffer(&self, _: &'static mut [u8], _: usize, _: kernel::ReturnCode) {
+        self.fired.set(true);
+    }
+}
+
+impl IoWrite for Writer {
+    fn write(&mut self, buf: &[u8]) {
+        if !self.initialized {
+            self.initialized = true;
+        }
+        // Here we mimic a synchronous UART output by calling transmit_buffer
+        // on the CDC stack and then spinning on USB interrupts until the transaction
+        // is complete. If the USB or CDC stack panicked, this may fail. It will also
+        // fail if the panic occurred prior to the USB connection being initialized.
+        // In the latter case, the LEDs should still blink in the panic pattern.
+
+        // spin so that if any USB DMA is ongoing it will finish
+        // we should only need this on the first call to write()
+        let mut i = 0;
+        loop {
+            i += 1;
+            cortexm4::support::nop();
+            if i > 10000 {
+                break;
+            }
+        }
+
+        // copy_from_slice() requires equal length slices
+        // This will truncate any writes longer than BUF_LEN, but simplifies the
+        // code. In practice, BUF_LEN=512 always seems sufficient for the size of
+        // individual calls to write made by the panic handler.
+        let mut max = BUF_LEN;
+        if buf.len() < BUF_LEN {
+            max = buf.len();
+        }
+
+        unsafe {
+            // If CDC_REF_FOR_PANIC is not yet set we panicked very early,
+            // and not much we can do. Don't want to double fault,
+            // so just return.
+            super::CDC_REF_FOR_PANIC.map(|cdc| {
+                // Lots of unsafe dereferencing of global static mut objects here.
+                // However, this should be okay, because it all happens within
+                // a single thread, and:
+                // - This is the only place the global CDC_REF_FOR_PANIC is used, the logic is the same
+                //   as applies for the global CHIP variable used in the panic handler.
+                // - We do create multiple mutable references to the STATIC_PANIC_BUF, but we never
+                //   access the STATIC_PANIC_BUF after a slice of it is passed to transmit_buffer
+                //   until the slice has been returned in the uart callback.
+                // - Similarly, only this function uses the global DUMMY variable, and we do not
+                //   mutate it.
+                let usb = &mut cdc.controller();
+                STATIC_PANIC_BUF[..max].copy_from_slice(&buf[..max]);
+                let static_buf = &mut STATIC_PANIC_BUF;
+                cdc.set_transmit_client(&DUMMY);
+                cdc.transmit_buffer(static_buf, max);
+                loop {
+                    if let Some(interrupt) = cortexm4::nvic::next_pending() {
+                        if interrupt == 39 {
+                            usb.handle_interrupt();
+                        }
+                        let n = cortexm4::nvic::Nvic::new(interrupt);
+                        n.clear_pending();
+                        n.enable();
+                    }
+                    if DUMMY.fired.get() == true {
+                        // buffer finished transmitting, return so we can output additional
+                        // messages when requested by the panic handler.
+                        break;
+                    }
+                }
+                DUMMY.fired.set(false);
+            });
+        }
+    }
+}
+
+/// Default panic handler for the Nano 33 Board.
+///
+/// We just use the standard default provided by the debug module in the kernel.
+#[cfg(not(test))]
+#[no_mangle]
+#[panic_handler]
+pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
+    const LED_KERNEL_PIN: Pin = Pin::P0_13;
+    let led = &mut led::LedLow::new(&nrf52840::gpio::PORT[LED_KERNEL_PIN]);
+    let writer = &mut WRITER;
+    debug::panic(
+        &mut [led],
+        writer,
+        pi,
+        &cortexm4::support::nop,
+        &PROCESSES,
+        &CHIP,
+    )
+}

--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -76,7 +76,8 @@ const FAULT_RESPONSE: kernel::procs::FaultResponse = kernel::procs::FaultRespons
 // Number of concurrent processes this platform supports.
 const NUM_PROCS: usize = 8;
 
-static mut PROCESSES: [Option<&'static dyn kernel::procs::ProcessType>; NUM_PROCS] = [None; NUM_PROCS];
+static mut PROCESSES: [Option<&'static dyn kernel::procs::ProcessType>; NUM_PROCS] =
+    [None; NUM_PROCS];
 
 static mut CHIP: Option<&'static nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>> = None;
 static mut CDC_REF_FOR_PANIC: Option<

--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -76,7 +76,7 @@ const FAULT_RESPONSE: kernel::procs::FaultResponse = kernel::procs::FaultRespons
 // Number of concurrent processes this platform supports.
 const NUM_PROCS: usize = 8;
 
-static mut PROCESSES: [Option<&'static dyn kernel::procs::ProcessType>; NUM_PROCS] = [None; 8];
+static mut PROCESSES: [Option<&'static dyn kernel::procs::ProcessType>; NUM_PROCS] = [None; NUM_PROCS];
 
 static mut CHIP: Option<&'static nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>> = None;
 static mut CDC_REF_FOR_PANIC: Option<

--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -1,0 +1,441 @@
+//! Tock kernel for the Arduino Nano 33 BLE.
+//!
+//! It is based on nRF52840 SoC (Cortex M4 core with a BLE + IEEE 802.15.4 transceiver).
+
+#![no_std]
+// Disable this attribute when documenting, as a workaround for
+// https://github.com/rust-lang/rust/issues/62184.
+#![cfg_attr(not(doc), no_main)]
+#![feature(const_in_array_repeat_expressions)]
+#![deny(missing_docs)]
+
+use kernel::capabilities;
+use kernel::common::dynamic_deferred_call::{DynamicDeferredCall, DynamicDeferredCallClientState};
+use kernel::component::Component;
+use kernel::hil::gpio::Configure;
+use kernel::hil::gpio::Interrupt;
+use kernel::hil::gpio::Output;
+use kernel::hil::i2c::I2CMaster;
+use kernel::hil::led::LedHigh;
+use kernel::hil::time::Counter;
+use kernel::hil::usb::Client;
+use kernel::mpu::MPU;
+use kernel::Chip;
+#[allow(unused_imports)]
+use kernel::{create_capability, debug, debug_gpio, debug_verbose, static_init};
+
+use nrf52840::gpio::Pin;
+use nrf52840::interrupt_service::Nrf52840DefaultPeripherals;
+
+// LEDs.
+const LED_RED_PIN: Pin = Pin::P1_01;
+const LED_WHITE_PIN: Pin = Pin::P0_10;
+
+const LED_KERNEL_PIN: Pin = Pin::P1_01;
+
+
+// Buttons
+const BUTTON_LEFT: Pin = Pin::P1_02;
+const BUTTON_RIGHT: Pin = Pin::P1_10;
+
+const GPIO_D2: Pin = Pin::P0_03;
+const GPIO_D3: Pin = Pin::P0_28;
+const GPIO_D4: Pin = Pin::P0_02;
+const GPIO_D6: Pin = Pin::P1_09;
+const GPIO_D7: Pin = Pin::P0_07;
+const GPIO_D8: Pin = Pin::P1_04;
+const GPIO_D9: Pin = Pin::P0_27;
+const GPIO_D10: Pin = Pin::P0_30;
+// const GPIO_D11: Pin = Pin::P1_10;
+// const GPIO_D12: Pin = Pin::P0_31;
+// const GPIO_D13: Pin = Pin::P0_08;
+// const GPIO_D14: Pin = Pin::P0_06;
+// const GPIO_D15: Pin = Pin::P0_26;
+// const GPIO_D16: Pin = Pin::P0_29;
+// const GPIO_D17: Pin = Pin::P1_01;
+// const GPIO_D18: Pin = Pin::P0_16;
+// const GPIO_D19: Pin = Pin::P0_25;
+// const GPIO_D20: Pin = Pin::P0_24;
+
+const _UART_TX_PIN: Pin = Pin::P0_05;
+const _UART_RX_PIN: Pin = Pin::P0_04;
+
+/// I2C pins for all of the sensors.
+const I2C_SDA_PIN: Pin = Pin::P0_24;
+const I2C_SCL_PIN: Pin = Pin::P0_25;
+
+/// GPIO tied to the VCC of the I2C pullup resistors.
+const I2C_PULLUP_PIN: Pin = Pin::P1_00;
+
+/// Interrupt pin for the APDS9960 sensor.
+const APDS9960_PIN: Pin = Pin::P0_09;
+
+/// UART Writer for panic!()s.
+pub mod io;
+
+// State for loading and holding applications.
+// How should the kernel respond when a process faults.
+const FAULT_RESPONSE: kernel::procs::FaultResponse = kernel::procs::FaultResponse::Panic;
+
+// Number of concurrent processes this platform supports.
+const NUM_PROCS: usize = 8;
+
+static mut PROCESSES: [Option<&'static dyn kernel::procs::ProcessType>; NUM_PROCS] = [None; 8];
+
+static mut CHIP: Option<&'static nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>> = None;
+static mut CDC_REF_FOR_PANIC: Option<
+    &'static capsules::usb::cdc::CdcAcm<'static, nrf52::usbd::Usbd>,
+> = None;
+
+/// Dummy buffer that causes the linker to reserve enough space for the stack.
+#[no_mangle]
+#[link_section = ".stack_buffer"]
+pub static mut STACK_MEMORY: [u8; 0x1000] = [0; 0x1000];
+
+/// Supported drivers by the platform
+pub struct Platform {
+    // ble_radio: &'static capsules::ble_advertising_driver::BLE<
+    //     'static,
+    //     nrf52::ble_radio::Radio,
+    //     VirtualMuxAlarm<'static, Rtc<'static>>,
+    // >,
+    // ieee802154_radio: &'static capsules::ieee802154::RadioDriver<'static>,
+    console: &'static capsules::console::Console<'static>,
+    proximity: &'static capsules::proximity::ProximitySensor<'static>,
+    gpio: &'static capsules::gpio::GPIO<'static, nrf52::gpio::GPIOPin<'static>>,
+    led: &'static capsules::led::LedDriver<'static, LedHigh<'static, nrf52::gpio::GPIOPin<'static>>>,
+    button: &'static capsules::button::Button<'static, nrf52::gpio::GPIOPin<'static>>,
+    rng: &'static capsules::rng::RngDriver<'static>,
+    ipc: kernel::ipc::IPC,
+    alarm: &'static capsules::alarm::AlarmDriver<
+        'static,
+        capsules::virtual_alarm::VirtualMuxAlarm<'static, nrf52::rtc::Rtc<'static>>,
+    >,
+}
+
+impl kernel::Platform for Platform {
+    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    where
+        F: FnOnce(Option<&dyn kernel::Driver>) -> R,
+    {
+        match driver_num {
+            capsules::console::DRIVER_NUM => f(Some(self.console)),
+            capsules::proximity::DRIVER_NUM => f(Some(self.proximity)),
+            capsules::gpio::DRIVER_NUM => f(Some(self.gpio)),
+            capsules::alarm::DRIVER_NUM => f(Some(self.alarm)),
+            capsules::led::DRIVER_NUM => f(Some(self.led)),
+            capsules::button::DRIVER_NUM => f(Some(self.button)),
+            capsules::rng::DRIVER_NUM => f(Some(self.rng)),
+            // capsules::ble_advertising_driver::DRIVER_NUM => f(Some(self.ble_radio)),
+            // capsules::ieee802154::DRIVER_NUM => f(Some(radio)),
+            kernel::ipc::DRIVER_NUM => f(Some(&self.ipc)),
+            _ => f(None),
+        }
+    }
+}
+
+/// Entry point in the vector table called on hard reset.
+#[no_mangle]
+pub unsafe fn reset_handler() {
+    // Loads relocations and clears BSS
+    nrf52840::init();
+    let ppi = static_init!(nrf52840::ppi::Ppi, nrf52840::ppi::Ppi::new());
+    // Initialize chip peripheral drivers
+    let nrf52840_peripherals = static_init!(
+        Nrf52840DefaultPeripherals,
+        Nrf52840DefaultPeripherals::new(ppi)
+    );
+
+    // set up circular peripheral dependencies
+    nrf52840_peripherals.init();
+    let base_peripherals = &nrf52840_peripherals.nrf52;
+
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
+
+    //--------------------------------------------------------------------------
+    // CAPABILITIES
+    //--------------------------------------------------------------------------
+
+    // Create capabilities that the board needs to call certain protected kernel
+    // functions.
+    let process_management_capability =
+        create_capability!(capabilities::ProcessManagementCapability);
+    let main_loop_capability = create_capability!(capabilities::MainLoopCapability);
+    let memory_allocation_capability = create_capability!(capabilities::MemoryAllocationCapability);
+
+    //--------------------------------------------------------------------------
+    // DEBUG GPIO
+    //--------------------------------------------------------------------------
+
+    // Configure kernel debug GPIOs as early as possible. These are used by the
+    // `debug_gpio!(0, toggle)` macro. We configure these early so that the
+    // macro is available during most of the setup code and kernel execution.
+    kernel::debug::assign_gpios(
+        Some(&base_peripherals.gpio_port[LED_KERNEL_PIN]),
+        None,
+        None,
+    );
+
+    //--------------------------------------------------------------------------
+    // GPIO
+    //--------------------------------------------------------------------------
+
+    let gpio = components::gpio::GpioComponent::new(
+        board_kernel,
+        components::gpio_component_helper!(
+            nrf52840::gpio::GPIOPin,
+            2 => &base_peripherals.gpio_port[GPIO_D2],
+            3 => &base_peripherals.gpio_port[GPIO_D3],
+            4 => &base_peripherals.gpio_port[GPIO_D4],
+            6 => &base_peripherals.gpio_port[GPIO_D6],
+            7 => &base_peripherals.gpio_port[GPIO_D7],
+            8 => &base_peripherals.gpio_port[GPIO_D8],
+            9 => &base_peripherals.gpio_port[GPIO_D9],
+            10 => &base_peripherals.gpio_port[GPIO_D10]
+        ),
+    )
+    .finalize(components::gpio_component_buf!(nrf52840::gpio::GPIOPin));
+
+    //--------------------------------------------------------------------------
+    // LEDs
+    //--------------------------------------------------------------------------
+
+    let led = components::led::LedsComponent::new(components::led_component_helper!(
+        LedHigh<'static, nrf52840::gpio::GPIOPin>,
+        LedHigh::new(&base_peripherals.gpio_port[LED_RED_PIN]),
+        LedHigh::new(&base_peripherals.gpio_port[LED_WHITE_PIN])
+    ))
+    .finalize(components::led_component_buf!(
+        LedHigh<'static, nrf52840::gpio::GPIOPin>
+    ));
+
+    //--------------------------------------------------------------------------
+    // Buttons
+    //--------------------------------------------------------------------------
+    let button = components::button::ButtonComponent::new(
+        board_kernel,
+        components::button_component_helper!(
+            nrf52840::gpio::GPIOPin,
+            (
+                &base_peripherals.gpio_port[BUTTON_LEFT],
+                kernel::hil::gpio::ActivationMode::ActiveHigh,
+                kernel::hil::gpio::FloatingState::PullUp
+            ), // Left
+            (
+                &base_peripherals.gpio_port[BUTTON_RIGHT],
+                kernel::hil::gpio::ActivationMode::ActiveLow,
+                kernel::hil::gpio::FloatingState::PullUp
+            ) // Right
+        ),
+    )
+    .finalize(components::button_component_buf!(nrf52840::gpio::GPIOPin));
+
+    //--------------------------------------------------------------------------
+    // Deferred Call (Dynamic) Setup
+    //--------------------------------------------------------------------------
+
+    let dynamic_deferred_call_clients =
+        static_init!([DynamicDeferredCallClientState; 2], Default::default());
+    let dynamic_deferred_caller = static_init!(
+        DynamicDeferredCall,
+        DynamicDeferredCall::new(dynamic_deferred_call_clients)
+    );
+    DynamicDeferredCall::set_global_instance(dynamic_deferred_caller);
+
+    //--------------------------------------------------------------------------
+    // ALARM & TIMER
+    //--------------------------------------------------------------------------
+
+    let rtc = &base_peripherals.rtc;
+    rtc.start();
+
+    let mux_alarm = components::alarm::AlarmMuxComponent::new(rtc)
+        .finalize(components::alarm_mux_component_helper!(nrf52::rtc::Rtc));
+    let alarm = components::alarm::AlarmDriverComponent::new(board_kernel, mux_alarm)
+        .finalize(components::alarm_component_helper!(nrf52::rtc::Rtc));
+
+    //--------------------------------------------------------------------------
+    // UART & CONSOLE & DEBUG
+    //--------------------------------------------------------------------------
+
+    // Setup the CDC-ACM over USB driver that we will use for UART.
+    // We use the Arduino Vendor ID and Product ID since the device is the same.
+
+    // Create the strings we include in the USB descriptor. We use the hardcoded
+    // DEVICEADDR register on the nRF52 to set the serial number.
+    let serial_number_buf = static_init!([u8; 17], [0; 17]);
+    let serial_number_string: &'static str =
+        nrf52::ficr::FICR_INSTANCE.address_str(serial_number_buf);
+    let strings = static_init!(
+        [&str; 3],
+        [
+            "Adafruit",              // Manufacturer
+            "CLUE nRF52840 - TockOS", // Product
+            serial_number_string,   // Serial number
+        ]
+    );
+
+    let cdc = components::cdc::CdcAcmComponent::new(
+        &nrf52840_peripherals.usbd,
+        capsules::usb::cdc::MAX_CTRL_PACKET_SIZE_NRF52840,
+        0x239a,
+        0x8071,
+        strings,
+    )
+    .finalize(components::usb_cdc_acm_component_helper!(nrf52::usbd::Usbd));
+    CDC_REF_FOR_PANIC = Some(cdc); //for use by panic handler
+
+    // Create a shared UART channel for the console and for kernel debug.
+    let uart_mux = components::console::UartMuxComponent::new(cdc, 115200, dynamic_deferred_caller)
+        .finalize(());
+
+    // Setup the console.
+    let console = components::console::ConsoleComponent::new(board_kernel, uart_mux).finalize(());
+    // Create the debugger object that handles calls to `debug!()`.
+    components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
+
+    //--------------------------------------------------------------------------
+    // RANDOM NUMBERS
+    //--------------------------------------------------------------------------
+
+    let rng = components::rng::RngComponent::new(board_kernel, &base_peripherals.trng).finalize(());
+
+    //--------------------------------------------------------------------------
+    // SENSORS
+    //--------------------------------------------------------------------------
+
+    let sensors_i2c_bus = static_init!(
+        capsules::virtual_i2c::MuxI2C<'static>,
+        capsules::virtual_i2c::MuxI2C::new(&base_peripherals.twim0, None, dynamic_deferred_caller)
+    );
+    base_peripherals.twim0.configure(
+        nrf52840::pinmux::Pinmux::new(I2C_SCL_PIN as u32),
+        nrf52840::pinmux::Pinmux::new(I2C_SDA_PIN as u32),
+    );
+    base_peripherals.twim0.set_master_client(sensors_i2c_bus);
+
+    &nrf52840::gpio::PORT[I2C_PULLUP_PIN].make_output();
+    &nrf52840::gpio::PORT[I2C_PULLUP_PIN].set();
+
+    let apds9960_i2c = static_init!(
+        capsules::virtual_i2c::I2CDevice,
+        capsules::virtual_i2c::I2CDevice::new(sensors_i2c_bus, 0x39 << 1)
+    );
+
+    let apds9960 = static_init!(
+        capsules::apds9960::APDS9960<'static>,
+        capsules::apds9960::APDS9960::new(
+            apds9960_i2c,
+            &nrf52840::gpio::PORT[APDS9960_PIN],
+            &mut capsules::apds9960::BUFFER
+        )
+    );
+    apds9960_i2c.set_client(apds9960);
+    nrf52840::gpio::PORT[APDS9960_PIN].set_client(apds9960);
+
+    let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
+
+    let proximity = static_init!(
+        capsules::proximity::ProximitySensor<'static>,
+        capsules::proximity::ProximitySensor::new(apds9960, board_kernel.create_grant(&grant_cap))
+    );
+
+    kernel::hil::sensors::ProximityDriver::set_client(apds9960, proximity);
+
+    //--------------------------------------------------------------------------
+    // WIRELESS
+    //--------------------------------------------------------------------------
+
+    // let ble_radio =
+    //     BLEComponent::new(board_kernel, &base_peripherals.ble_radio, mux_alarm).finalize(());
+
+    // let (ieee802154_radio, _) = Ieee802154Component::new(
+    //     board_kernel,
+    //     &base_peripherals.ieee802154_radio,
+    //     PAN_ID,
+    //     SRC_MAC,
+    // )
+    // .finalize(());
+
+    //--------------------------------------------------------------------------
+    // FINAL SETUP AND BOARD BOOT
+    //--------------------------------------------------------------------------
+
+    // Start all of the clocks. Low power operation will require a better
+    // approach than this.
+    nrf52_components::NrfClockComponent::new().finalize(());
+
+    let platform = Platform {
+        // ble_radio: ble_radio,
+        // ieee802154_radio: ieee802154_radio,
+        console: console,
+        proximity: proximity,
+        led: led,
+        gpio: gpio,
+        button: button,
+        rng: rng,
+        alarm: alarm,
+        ipc: kernel::ipc::IPC::new(board_kernel, &memory_allocation_capability),
+    };
+
+    let chip = static_init!(
+        nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>,
+        nrf52840::chip::NRF52::new(nrf52840_peripherals)
+    );
+    CHIP = Some(chip);
+
+    // Need to disable the MPU because the bootloader seems to set it up.
+    chip.mpu().clear_mpu();
+
+    // Configure the USB stack to enable a serial port over CDC-ACM.
+    cdc.enable();
+    cdc.attach();
+
+    debug!("Initialization complete. Entering main loop.");
+
+    //--------------------------------------------------------------------------
+    // PROCESSES AND MAIN LOOP
+    //--------------------------------------------------------------------------
+
+    /// These symbols are defined in the linker script.
+    extern "C" {
+        /// Beginning of the ROM region containing app images.
+        static _sapps: u8;
+        /// End of the ROM region containing app images.
+        static _eapps: u8;
+        /// Beginning of the RAM region for app memory.
+        static mut _sappmem: u8;
+        /// End of the RAM region for app memory.
+        static _eappmem: u8;
+    }
+
+    kernel::procs::load_processes(
+        board_kernel,
+        chip,
+        core::slice::from_raw_parts(
+            &_sapps as *const u8,
+            &_eapps as *const u8 as usize - &_sapps as *const u8 as usize,
+        ),
+        core::slice::from_raw_parts_mut(
+            &mut _sappmem as *mut u8,
+            &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
+        ),
+        &mut PROCESSES,
+        FAULT_RESPONSE,
+        &process_management_capability,
+    )
+    .unwrap_or_else(|err| {
+        debug!("Error loading processes!");
+        debug!("{:?}", err);
+    });
+
+    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&PROCESSES)
+        .finalize(components::rr_component_helper!(NUM_PROCS));
+    board_kernel.kernel_loop(
+        &platform,
+        chip,
+        Some(&platform.ipc),
+        scheduler,
+        &main_loop_capability,
+    );
+}

--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -1,6 +1,6 @@
-//! Tock kernel for the Arduino Nano 33 BLE.
+//! Tock kernel for the Adafruit CLUE nRF52480 Express.
 //!
-//! It is based on nRF52840 SoC (Cortex M4 core with a BLE + IEEE 802.15.4 transceiver).
+//! It is based on nRF52840 Express SoC (Cortex M4 core with a BLE + IEEE 802.15.4 transceiver).
 
 #![no_std]
 // Disable this attribute when documenting, as a workaround for

--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -12,9 +12,7 @@
 use kernel::capabilities;
 use kernel::common::dynamic_deferred_call::{DynamicDeferredCall, DynamicDeferredCallClientState};
 use kernel::component::Component;
-use kernel::hil::gpio::Configure;
 use kernel::hil::gpio::Interrupt;
-use kernel::hil::gpio::Output;
 use kernel::hil::i2c::I2CMaster;
 use kernel::hil::led::LedHigh;
 use kernel::hil::time::Counter;
@@ -53,9 +51,6 @@ const _UART_RX_PIN: Pin = Pin::P0_04;
 /// I2C pins for all of the sensors.
 const I2C_SDA_PIN: Pin = Pin::P0_24;
 const I2C_SCL_PIN: Pin = Pin::P0_25;
-
-/// GPIO tied to the VCC of the I2C pullup resistors.
-const I2C_PULLUP_PIN: Pin = Pin::P1_00;
 
 /// Interrupt pin for the APDS9960 sensor.
 const APDS9960_PIN: Pin = Pin::P0_09;
@@ -152,6 +147,7 @@ pub unsafe fn reset_handler() {
 
     // set up circular peripheral dependencies
     nrf52840_peripherals.init();
+
     let base_peripherals = &nrf52840_peripherals.nrf52;
 
     let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
@@ -318,9 +314,6 @@ pub unsafe fn reset_handler() {
         nrf52840::pinmux::Pinmux::new(I2C_SDA_PIN as u32),
     );
     base_peripherals.twim0.set_master_client(sensors_i2c_bus);
-
-    &nrf52840::gpio::PORT[I2C_PULLUP_PIN].make_output();
-    &nrf52840::gpio::PORT[I2C_PULLUP_PIN].set();
 
     let apds9960_i2c = static_init!(
         capsules::virtual_i2c::I2CDevice,

--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -260,7 +260,7 @@ pub unsafe fn reset_handler() {
     //--------------------------------------------------------------------------
 
     // Setup the CDC-ACM over USB driver that we will use for UART.
-    // We use the Arduino Vendor ID and Product ID since the device is the same.
+    // We use the Adafruit Vendor ID and Product ID since the device is the same.
 
     // Create the strings we include in the USB descriptor. We use the hardcoded
     // DEVICEADDR register on the nRF52 to set the serial number.

--- a/boards/components/src/hmac.rs
+++ b/boards/components/src/hmac.rs
@@ -20,7 +20,6 @@
 //!        lowrisc::hmac::Hmac,
 //!        [u8; 32]
 //!    ));
-//! ));
 //! ```
 
 use capsules;

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -69,7 +69,7 @@ const FAULT_RESPONSE: kernel::procs::FaultResponse = kernel::procs::FaultRespons
 // Number of concurrent processes this platform supports.
 const NUM_PROCS: usize = 8;
 
-static mut PROCESSES: [Option<&'static dyn kernel::procs::ProcessType>; NUM_PROCS] = [None; 8];
+static mut PROCESSES: [Option<&'static dyn kernel::procs::ProcessType>; NUM_PROCS] = [None; NUM_PROCS];
 
 static mut CHIP: Option<&'static nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>> = None;
 static mut CDC_REF_FOR_PANIC: Option<

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -69,7 +69,8 @@ const FAULT_RESPONSE: kernel::procs::FaultResponse = kernel::procs::FaultRespons
 // Number of concurrent processes this platform supports.
 const NUM_PROCS: usize = 8;
 
-static mut PROCESSES: [Option<&'static dyn kernel::procs::ProcessType>; NUM_PROCS] = [None; NUM_PROCS];
+static mut PROCESSES: [Option<&'static dyn kernel::procs::ProcessType>; NUM_PROCS] =
+    [None; NUM_PROCS];
 
 static mut CHIP: Option<&'static nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>> = None;
 static mut CDC_REF_FOR_PANIC: Option<

--- a/capsules/src/bus.rs
+++ b/capsules/src/bus.rs
@@ -8,7 +8,6 @@
 //! ```rust
 //! let bus = components::bus::I2CMasterBusComponent::new(i2c_mux, address)
 //!     .finalize(components::spi_bus_component_helper!());
-//! ));
 //! ```
 //!
 //! SPI example

--- a/chips/nrf52/src/spi.rs
+++ b/chips/nrf52/src/spi.rs
@@ -270,14 +270,14 @@ impl SPIM {
             self.chip_select.map(|cs| cs.set());
             self.registers.events_end.write(EVENT::EVENT::CLEAR);
 
+            self.busy.set(false);
+
             self.client.map(|client| match self.tx_buf.take() {
                 None => (),
                 Some(tx_buf) => {
                     client.read_write_done(tx_buf, self.rx_buf.take(), self.transfer_len.take())
                 }
             });
-
-            self.busy.set(false);
         }
 
         // Although we only configured the chip interrupt on the


### PR DESCRIPTION
### Pull Request Overview

This pull request adds the Adafruit CLUE nRF52840 board. This is a perfect board for getting started as it
has a screen, buzzer, buttons LEDs and sensors, all in one.

The board runs more or less the same hardware as the Nano 33 BLE Sense.

Supported features so far:
- GPIO/interrupts
- buttons
- LEDs
- screen
- proximity sensor
- USB console

NOTE: This PR modifies the nrf52840 spi driver to reset the busy flag before notifying the client.

### Testing Strategy

This pull request was tested using an Adafruit CLUE nRF52840 board

### TODO or Help Wanted

We were able to program the kernel using Adafruit's version of nrfutil. This allows:
- flashing the kernel
- flashing the kernel bundled with apps 

We have not been succeeded in flashing the apps separately, as it is not clear how to load a bin file at a specific address.

Any idea are appreciated. We tried using the USB UF2 bootloader, but the file is not getting flashed. No idea how to debug this.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
