### PR TITLE
Add missing IntLike implementation

### DIFF
--- a/libraries/tock-register-interface/src/registers.rs
+++ b/libraries/tock-register-interface/src/registers.rs
@@ -99,6 +99,11 @@ impl IntLike for u64 {
         0
     }
 }
+impl IntLike for u128 {
+    fn zero() -> Self {
+        0
+    }
+}
 
 /// Descriptive name for each register.
 pub trait RegisterLongName {}


### PR DESCRIPTION
For u128 type.

- [x] Updated the relevant files in `/docs`, or no updates are required.
- [x] Ran `make prepush`.

I'm using this type to define a very wide bitfield type and need the impl.