### PR TITLE
Unbreak CI by updating the package repositories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Update package repositories
+        run: |
+          sudo apt update
       - name: Install dependencies
         continue-on-error: true
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,9 +68,9 @@ jobs:
 
     steps:
       - name: Install dependencies
-        continue-on-error: true
         run: |
           sudo apt install libudev-dev
+        if: matrix.os == 'ubuntu-latest'
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
       - name: ci-job-libraries

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,10 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+      - name: Update package repositories
+        run: |
+          sudo apt update
+        if: matrix.os == 'ubuntu-latest'
       - name: Install dependencies
         run: |
           sudo apt install libudev-dev


### PR DESCRIPTION
### Pull Request Overview

This pull request
- updates the package repositories on Ubuntu-runners where packages are installed using apt
- calls to `apt` only when running on a `ubuntu-latest` machine

This unbreaks the `ci-tests` job on `ubuntu-latest`. It also makes the CI more resilient to outdated package repositories in the provided images from GitHub. Furthermore, it doesn't fail the _Install dependencies_ job silently to succeed on a macOS machine, which causes real errors on Ubuntu to be ignored.

### Testing Strategy

You're looking at it.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
