### PR TITLE
kernel,arch,components: accept trailing commas in macro_rules

### DIFF
--- a/arch/rv32i/src/pmp.rs
+++ b/arch/rv32i/src/pmp.rs
@@ -26,7 +26,7 @@
 /// number of regions we can protect is `$x/2`.
 #[macro_export]
 macro_rules! PMPConfigMacro {
-    ( $x:expr ) => {
+    ( $x:expr $(,)? ) => {
 
 use core::cell::Cell;
 use core::cmp;

--- a/boards/components/src/adc.rs
+++ b/boards/components/src/adc.rs
@@ -9,7 +9,7 @@ use kernel::static_init_half;
 
 #[macro_export]
 macro_rules! adc_mux_component_helper {
-    ($A:ty) => {{
+    ($A:ty $(,)?) => {{
         use capsules::virtual_adc::MuxAdc;
         use core::mem::MaybeUninit;
         static mut BUF: MaybeUninit<MuxAdc<'static, $A>> = MaybeUninit::uninit();
@@ -19,7 +19,7 @@ macro_rules! adc_mux_component_helper {
 
 #[macro_export]
 macro_rules! adc_component_helper {
-    ($A:ty) => {{
+    ($A:ty $(,)?) => {{
         use capsules::virtual_adc::AdcDevice;
         use core::mem::MaybeUninit;
         static mut BUF: MaybeUninit<AdcDevice<'static, $A>> = MaybeUninit::uninit();
@@ -29,7 +29,7 @@ macro_rules! adc_component_helper {
 
 #[macro_export]
 macro_rules! adc_syscall_component_helper {
-    ($($P:expr),+ ) => {{
+    ($($P:expr),+ $(,)?) => {{
         use capsules::adc::AdcVirtualized;
         use core::mem::MaybeUninit;
         use kernel::hil;

--- a/boards/components/src/alarm.rs
+++ b/boards/components/src/alarm.rs
@@ -31,7 +31,7 @@ use kernel::static_init_half;
 // Setup static space for the objects.
 #[macro_export]
 macro_rules! alarm_mux_component_helper {
-    ($A:ty) => {{
+    ($A:ty $(,)?) => {{
         use capsules::virtual_alarm::MuxAlarm;
         use core::mem::MaybeUninit;
         static mut BUF: MaybeUninit<MuxAlarm<'static, $A>> = MaybeUninit::uninit();
@@ -42,7 +42,7 @@ macro_rules! alarm_mux_component_helper {
 // Setup static space for the objects.
 #[macro_export]
 macro_rules! alarm_component_helper {
-    ($A:ty) => {{
+    ($A:ty $(,)?) => {{
         use capsules::alarm::AlarmDriver;
         use capsules::virtual_alarm::VirtualMuxAlarm;
         use core::mem::MaybeUninit;

--- a/boards/components/src/analog_comparator.rs
+++ b/boards/components/src/analog_comparator.rs
@@ -27,7 +27,7 @@ use kernel::static_init_half;
 
 #[macro_export]
 macro_rules! acomp_component_helper {
-    ($Channel:ty, $($P:expr),+ ) => {{
+    ($Channel:ty, $($P:expr),+ $(,)?) => {{
         use kernel::count_expressions;
         use kernel::static_init;
         const NUM_CHANNELS: usize = count_expressions!($($P),+);
@@ -43,7 +43,7 @@ macro_rules! acomp_component_helper {
 
 #[macro_export]
 macro_rules! acomp_component_buf {
-    ($Comp:ty) => {{
+    ($Comp:ty $(,)?) => {{
         use capsules::analog_comparator::AnalogComparator;
         use core::mem::MaybeUninit;
         static mut BUF: MaybeUninit<AnalogComparator<'static, $Comp>> = MaybeUninit::uninit();

--- a/boards/components/src/bus.rs
+++ b/boards/components/src/bus.rs
@@ -40,7 +40,7 @@ use kernel::static_init_half;
 // Setup static space for the objects.
 #[macro_export]
 macro_rules! bus8080_bus_component_helper {
-    ($B:ty, $bus8080: expr) => {{
+    ($B:ty, $bus8080:expr $(,)?) => {{
         use capsules::bus::Bus8080Bus;
         use core::mem::{size_of, MaybeUninit};
         static mut bus: MaybeUninit<Bus8080Bus<'static, $B>> = MaybeUninit::uninit();
@@ -50,7 +50,7 @@ macro_rules! bus8080_bus_component_helper {
 
 #[macro_export]
 macro_rules! spi_bus_component_helper {
-    ($S:ty, $select:expr, $spi_mux: expr) => {{
+    ($S:ty, $select:expr, $spi_mux:expr $(,)?) => {{
         use capsules::bus::SpiMasterBus;
         use capsules::virtual_spi::VirtualSpiMasterDevice;
         use core::mem::{size_of, MaybeUninit};

--- a/boards/components/src/button.rs
+++ b/boards/components/src/button.rs
@@ -33,7 +33,7 @@ use kernel::static_init_half;
 
 #[macro_export]
 macro_rules! button_component_helper {
-    ($Pin:ty, $(($P:expr, $M:expr, $F:expr)),+ ) => {{
+    ($Pin:ty, $(($P:expr, $M:expr, $F:expr)),+ $(,)?) => {{
         use kernel::static_init;
         use kernel::count_expressions;
         use kernel::hil::gpio::InterruptValueWrapper;
@@ -56,7 +56,7 @@ macro_rules! button_component_helper {
 
 #[macro_export]
 macro_rules! button_component_buf {
-    ($Pin:ty) => {{
+    ($Pin:ty $(,)?) => {{
         use capsules::button::Button;
         use core::mem::MaybeUninit;
         static mut BUF: MaybeUninit<Button<'static, $Pin>> = MaybeUninit::uninit();

--- a/boards/components/src/cdc.rs
+++ b/boards/components/src/cdc.rs
@@ -29,7 +29,7 @@ use kernel::static_init_half;
 // Setup static space for the objects.
 #[macro_export]
 macro_rules! usb_cdc_acm_component_helper {
-    ($U:ty) => {{
+    ($U:ty $(,)?) => {{
         use core::mem::MaybeUninit;
         static mut BUF: MaybeUninit<capsules::usb::cdc::CdcAcm<'static, $U>> =
             MaybeUninit::uninit();

--- a/boards/components/src/crc.rs
+++ b/boards/components/src/crc.rs
@@ -25,7 +25,7 @@ use kernel::static_init_half;
 // Setup static space for the objects.
 #[macro_export]
 macro_rules! crc_component_helper {
-    ($C:ty) => {{
+    ($C:ty $(,)?) => {{
         use capsules::crc;
         use core::mem::MaybeUninit;
         static mut BUF: MaybeUninit<crc::Crc<'static, $C>> = MaybeUninit::uninit();

--- a/boards/components/src/ctap.rs
+++ b/boards/components/src/ctap.rs
@@ -39,7 +39,7 @@ use kernel::static_init_half;
 // Setup static space for the objects.
 #[macro_export]
 macro_rules! usb_ctap_component_helper {
-    ($U:ty) => {{
+    ($U:ty $(,)?) => {{
         use core::mem::MaybeUninit;
         static mut BUF1: MaybeUninit<capsules::usb::ctap::CtapHid<'static, $U>> =
             MaybeUninit::uninit();

--- a/boards/components/src/ft6x06.rs
+++ b/boards/components/src/ft6x06.rs
@@ -17,7 +17,7 @@ use kernel::static_init_half;
 // Setup static space for the objects.
 #[macro_export]
 macro_rules! ft6x06_i2c_component_helper {
-    ($i2c_mux: expr) => {{
+    ($i2c_mux:expr $(,)?) => {{
         use capsules::ft6x06::Ft6x06;
         use capsules::ft6x06::NO_TOUCH;
         use capsules::virtual_i2c::I2CDevice;

--- a/boards/components/src/gpio.rs
+++ b/boards/components/src/gpio.rs
@@ -51,8 +51,8 @@ use kernel::static_init_half;
 #[macro_export]
 macro_rules! gpio_component_helper_max_pin {
     () => { 0usize };
-    ($a: expr, $b: expr, $($tail:expr,)*) => { $crate::gpio_component_helper_max_pin! (max ($a, $b), $($tail,)*) };
-    ($a: expr,) => { $a };
+    ($a:expr, $b:expr, $($tail:expr),* $(,)?) => { $crate::gpio_component_helper_max_pin! (max ($a, $b), $($tail,)*) };
+    ($a:expr $(,)?) => { $a };
 }
 
 #[macro_export]
@@ -64,7 +64,7 @@ macro_rules! gpio_component_helper_max_pin {
 macro_rules! gpio_component_helper {
     (
         $Pin:ty,
-        $($nr:literal => $pin:expr),*
+        $($nr:literal => $pin:expr),* $(,)?
     ) => {{
         use kernel::count_expressions;
         use kernel::hil::gpio::InterruptValueWrapper;
@@ -91,7 +91,7 @@ macro_rules! gpio_component_helper {
 
 #[macro_export]
 macro_rules! gpio_component_buf {
-    ($Pin:ty) => {{
+    ($Pin:ty $(,)?) => {{
         use capsules::gpio::GPIO;
         use core::mem::MaybeUninit;
         static mut BUF: MaybeUninit<GPIO<'static, $Pin>> = MaybeUninit::uninit();

--- a/boards/components/src/hd44780.rs
+++ b/boards/components/src/hd44780.rs
@@ -34,7 +34,7 @@ use kernel::static_init_half;
 // Setup static space for the objects.
 #[macro_export]
 macro_rules! hd44780_component_helper {
-    ($A:ty, $rs:expr, $en: expr, $data_4_pin: expr, $data_5_pin: expr, $data_6_pin: expr, $data_7_pin: expr) => {{
+    ($A:ty, $rs:expr, $en:expr, $data_4_pin:expr, $data_5_pin:expr, $data_6_pin:expr, $data_7_pin:expr $(,)?) => {{
         use capsules::hd44780::HD44780;
         use core::mem::MaybeUninit;
         static mut BUF1: MaybeUninit<VirtualMuxAlarm<'static, $A>> = MaybeUninit::uninit();

--- a/boards/components/src/hmac.rs
+++ b/boards/components/src/hmac.rs
@@ -38,7 +38,7 @@ use kernel::static_init_half;
 // Setup static space for the objects.
 #[macro_export]
 macro_rules! hmac_mux_component_helper {
-    ($A:ty, $T:ty) => {{
+    ($A:ty, $T:ty $(,)?) => {{
         use capsules::virtual_hmac::MuxHmac;
         use capsules::virtual_hmac::VirtualMuxHmac;
         use core::mem::MaybeUninit;
@@ -82,7 +82,7 @@ impl<A: 'static + digest::Digest<'static, T>, T: 'static + digest::DigestType> C
 // Setup static space for the objects.
 #[macro_export]
 macro_rules! hmac_component_helper {
-    ($A:ty, $T:ty) => {{
+    ($A:ty, $T:ty $(,)?) => {{
         use capsules::hmac::HmacDriver;
         use capsules::virtual_hmac::MuxHmac;
         use capsules::virtual_hmac::VirtualMuxHmac;

--- a/boards/components/src/ieee802154.rs
+++ b/boards/components/src/ieee802154.rs
@@ -33,7 +33,7 @@ use kernel::{create_capability, static_init, static_init_half};
 // Setup static space for the objects.
 #[macro_export]
 macro_rules! ieee802154_component_helper {
-    ($R:ty, $A:ty) => {{
+    ($R:ty, $A:ty $(,)?) => {{
         use capsules::ieee802154::mac::AwakeMac;
         use core::mem::MaybeUninit;
         use kernel::hil::symmetric_encryption::{AES128Ctr, AES128, AES128CBC, AES128CCM};

--- a/boards/components/src/isl29035.rs
+++ b/boards/components/src/isl29035.rs
@@ -37,7 +37,7 @@ use kernel::{static_init, static_init_half};
 // Setup static space for the objects.
 #[macro_export]
 macro_rules! isl29035_component_helper {
-    ($A:ty) => {{
+    ($A:ty $(,)?) => {{
         use capsules::isl29035::Isl29035;
         use core::mem::MaybeUninit;
         static mut BUF1: MaybeUninit<VirtualMuxAlarm<'static, $A>> = MaybeUninit::uninit();

--- a/boards/components/src/l3gd20.rs
+++ b/boards/components/src/l3gd20.rs
@@ -27,7 +27,7 @@ use kernel::static_init_half;
 // Setup static space for the objects.
 #[macro_export]
 macro_rules! l3gd20_spi_component_helper {
-    ($A:ty, $select: expr, $spi_mux: expr) => {{
+    ($A:ty, $select:expr, $spi_mux:expr $(,)?) => {{
         use capsules::l3gd20::L3gd20Spi;
         use capsules::virtual_spi::VirtualSpiMasterDevice;
         use core::mem::MaybeUninit;

--- a/boards/components/src/led.rs
+++ b/boards/components/src/led.rs
@@ -41,7 +41,7 @@ macro_rules! led_component_helper {
 
 #[macro_export]
 macro_rules! led_component_buf {
-    ($Led:ty) => {{
+    ($Led:ty $(,)?) => {{
         use capsules::led::LedDriver;
         use core::mem::MaybeUninit;
         static mut BUF: MaybeUninit<LedDriver<'static, $Led>> = MaybeUninit::uninit();

--- a/boards/components/src/lsm303dlhc.rs
+++ b/boards/components/src/lsm303dlhc.rs
@@ -27,7 +27,7 @@ use kernel::static_init_half;
 // Setup static space for the objects.
 #[macro_export]
 macro_rules! lsm303dlhc_i2c_component_helper {
-    ($i2c_mux: expr) => {{
+    ($i2c_mux:expr $(,)?) => {{
         use capsules::lsm303dlhc::Lsm303dlhcI2C;
         use capsules::virtual_i2c::I2CDevice;
         use core::mem::MaybeUninit;

--- a/boards/components/src/mx25r6435f.rs
+++ b/boards/components/src/mx25r6435f.rs
@@ -28,7 +28,7 @@ use kernel::static_init_half;
 // Setup static space for the objects.
 #[macro_export]
 macro_rules! mx25r6435f_component_helper {
-    ($S:ty, $P: ty, $A: ty) => {{
+    ($S:ty, $P:ty, $A:ty $(,)?) => {{
         use capsules::mx25r6435f::MX25R6435F;
         use capsules::virtual_alarm::VirtualMuxAlarm;
         use capsules::virtual_spi::VirtualSpiMasterDevice;

--- a/boards/components/src/ninedof.rs
+++ b/boards/components/src/ninedof.rs
@@ -18,7 +18,7 @@ use kernel::static_init_half;
 
 #[macro_export]
 macro_rules! ninedof_component_helper {
-    ($($P:expr),+ ) => {{
+    ($($P:expr),+ $(,)?) => {{
         use capsules::ninedof::NineDof;
         use core::mem::MaybeUninit;
         use kernel::hil;

--- a/boards/components/src/nonvolatile_storage.rs
+++ b/boards/components/src/nonvolatile_storage.rs
@@ -31,7 +31,7 @@ use kernel::{static_init, static_init_half};
 // Setup static space for the objects.
 #[macro_export]
 macro_rules! nv_storage_component_helper {
-    ($F:ty) => {{
+    ($F:ty $(,)?) => {{
         use capsules::nonvolatile_to_pages::NonvolatileToPages;
         use core::mem::MaybeUninit;
         use kernel::hil;

--- a/boards/components/src/panic_button.rs
+++ b/boards/components/src/panic_button.rs
@@ -23,7 +23,7 @@ use kernel::static_init_half;
 
 #[macro_export]
 macro_rules! panic_button_component_buf {
-    ($Pin:ty) => {{
+    ($Pin:ty $(,)?) => {{
         use capsules::button::PanicButton;
         use core::mem::MaybeUninit;
         static mut BUF: MaybeUninit<PanicButton<'static, $Pin>> = MaybeUninit::uninit();

--- a/boards/components/src/sched/cooperative.rs
+++ b/boards/components/src/sched/cooperative.rs
@@ -19,7 +19,7 @@ use kernel::{CoopProcessNode, CooperativeSched};
 
 #[macro_export]
 macro_rules! coop_component_helper {
-    ($N:expr) => {{
+    ($N:expr $(,)?) => {{
         use core::mem::MaybeUninit;
         use kernel::static_buf;
         use kernel::CoopProcessNode;

--- a/boards/components/src/sched/mlfq.rs
+++ b/boards/components/src/sched/mlfq.rs
@@ -16,7 +16,7 @@ use kernel::{MLFQProcessNode, MLFQSched};
 
 #[macro_export]
 macro_rules! mlfq_component_helper {
-    ($A:ty, $N:expr) => {{
+    ($A:ty, $N:expr $(,)?) => {{
         use core::mem::MaybeUninit;
         use kernel::static_init;
         use kernel::{MLFQProcessNode, MLFQSched};

--- a/boards/components/src/sched/round_robin.rs
+++ b/boards/components/src/sched/round_robin.rs
@@ -20,7 +20,7 @@ use kernel::{RoundRobinProcessNode, RoundRobinSched};
 
 #[macro_export]
 macro_rules! rr_component_helper {
-    ($N:expr) => {{
+    ($N:expr $(,)?) => {{
         use core::mem::MaybeUninit;
         use kernel::static_buf;
         use kernel::RoundRobinProcessNode;

--- a/boards/components/src/screen.rs
+++ b/boards/components/src/screen.rs
@@ -32,7 +32,7 @@ use kernel::static_init;
 
 #[macro_export]
 macro_rules! screen_buffer_size {
-    ($s:literal) => {{
+    ($s:literal $(,)?) => {{
         static mut BUFFER: [u8; $s] = [0; $s];
         (&mut BUFFER)
     }};

--- a/boards/components/src/segger_rtt.rs
+++ b/boards/components/src/segger_rtt.rs
@@ -28,7 +28,7 @@ use kernel::{static_init, static_init_half};
 // Setup static space for the objects.
 #[macro_export]
 macro_rules! segger_rtt_component_helper {
-    ($A:ty) => {{
+    ($A:ty $(,)?) => {{
         use capsules::segger_rtt::SeggerRtt;
         use capsules::virtual_alarm::VirtualMuxAlarm;
         use core::mem::MaybeUninit;

--- a/boards/components/src/si7021.rs
+++ b/boards/components/src/si7021.rs
@@ -32,7 +32,7 @@ use kernel::{static_init, static_init_half};
 // Setup static space for the objects.
 #[macro_export]
 macro_rules! si7021_component_helper {
-    ($A:ty) => {{
+    ($A:ty $(,)?) => {{
         use capsules::si7021::SI7021;
         use core::mem::MaybeUninit;
         static mut BUF1: MaybeUninit<VirtualMuxAlarm<'static, $A>> = MaybeUninit::uninit();

--- a/boards/components/src/spi.rs
+++ b/boards/components/src/spi.rs
@@ -37,7 +37,7 @@ use kernel::{static_init, static_init_half};
 // Setup static space for the objects.
 #[macro_export]
 macro_rules! spi_mux_component_helper {
-    ($S:ty) => {{
+    ($S:ty $(,)?) => {{
         use capsules::virtual_spi::MuxSpiMaster;
         use core::mem::MaybeUninit;
         static mut BUF: MaybeUninit<MuxSpiMaster<'static, $S>> = MaybeUninit::uninit();
@@ -47,7 +47,7 @@ macro_rules! spi_mux_component_helper {
 
 #[macro_export]
 macro_rules! spi_syscall_component_helper {
-    ($S:ty) => {{
+    ($S:ty $(,)?) => {{
         use capsules::spi_controller::Spi;
         use capsules::virtual_spi::VirtualSpiMasterDevice;
         use core::mem::MaybeUninit;
@@ -60,7 +60,7 @@ macro_rules! spi_syscall_component_helper {
 
 #[macro_export]
 macro_rules! spi_component_helper {
-    ($S:ty) => {{
+    ($S:ty $(,)?) => {{
         use capsules::virtual_spi::VirtualSpiMasterDevice;
         use core::mem::MaybeUninit;
         static mut BUF: MaybeUninit<VirtualSpiMasterDevice<'static, $S>> = MaybeUninit::uninit();
@@ -70,7 +70,7 @@ macro_rules! spi_component_helper {
 
 #[macro_export]
 macro_rules! spi_peripheral_component_helper {
-    ($S:ty) => {{
+    ($S:ty $(,)?) => {{
         use capsules::spi_peripheral::SpiPeripheral;
         use core::mem::MaybeUninit;
         static mut BUF: MaybeUninit<SpiPeripheral<'static, $S>> = MaybeUninit::uninit();

--- a/boards/components/src/st77xx.rs
+++ b/boards/components/src/st77xx.rs
@@ -50,7 +50,7 @@ use kernel::static_init_half;
 // Setup static space for the objects.
 #[macro_export]
 macro_rules! st77xx_component_helper {
-    ($screen:expr, $B: ty, $bus:expr, $A:ty, $P:ty, $dc:expr, $reset:expr) => {{
+    ($screen:expr, $B: ty, $bus:expr, $A:ty, $P:ty, $dc:expr, $reset:expr $(,)?) => {{
         use capsules::bus::Bus;
         use capsules::st77xx::{SendCommand, BUFFER_SIZE, SEQUENCE_BUFFER_SIZE, ST77XX};
         use capsules::virtual_alarm::VirtualMuxAlarm;

--- a/boards/components/src/temperature_stm.rs
+++ b/boards/components/src/temperature_stm.rs
@@ -9,7 +9,7 @@ use kernel::static_init_half;
 
 #[macro_export]
 macro_rules! temperaturestm_adc_component_helper {
-    ($A:ty, $channel: expr, $adc_mux: expr) => {{
+    ($A:ty, $channel:expr, $adc_mux:expr $(,)?) => {{
         use capsules::temperature_stm::TemperatureSTM;
         use capsules::virtual_adc::AdcDevice;
         use core::mem::MaybeUninit;

--- a/boards/components/src/test/multi_alarm_test.rs
+++ b/boards/components/src/test/multi_alarm_test.rs
@@ -8,7 +8,7 @@ use kernel::static_init_half;
 
 #[macro_export]
 macro_rules! multi_alarm_test_component_buf {
-    ($A:ty) => {{
+    ($A:ty $(,)?) => {{
         use capsules::test::random_alarm::TestRandomAlarm;
         use capsules::virtual_alarm::VirtualMuxAlarm;
         use core::mem::MaybeUninit;

--- a/boards/components/src/udp_driver.rs
+++ b/boards/components/src/udp_driver.rs
@@ -44,7 +44,7 @@ static mut DRIVER_BUF: [u8; MAX_PAYLOAD_LEN - UDP_HDR_SIZE] = [0; MAX_PAYLOAD_LE
 // Setup static space for the objects.
 #[macro_export]
 macro_rules! udp_driver_component_helper {
-    ($A:ty) => {{
+    ($A:ty $(,)?) => {{
         use capsules::net::udp::udp_send::UDPSendStruct;
         use core::mem::MaybeUninit;
         static mut BUF0: MaybeUninit<

--- a/boards/components/src/udp_mux.rs
+++ b/boards/components/src/udp_mux.rs
@@ -78,7 +78,7 @@ static mut USED_KERNEL_PORTS: [Option<SocketBindingEntry>; MAX_NUM_BOUND_PORTS] 
 // Setup static space for the objects.
 #[macro_export]
 macro_rules! udp_mux_component_helper {
-    ($A:ty) => {{
+    ($A:ty $(,)?) => {{
         use capsules;
         use capsules::net::sixlowpan::{sixlowpan_compression, sixlowpan_state};
         use capsules::net::udp::udp_send::MuxUdpSender;

--- a/kernel/src/common/utils.rs
+++ b/kernel/src/common/utils.rs
@@ -15,7 +15,7 @@
 /// destructor.
 #[macro_export]
 macro_rules! static_init {
-    ($T:ty, $e:expr) => {{
+    ($T:ty, $e:expr $(,)?) => {{
         let mut buf = $crate::static_buf!($T);
         buf.initialize($e)
     }};
@@ -45,7 +45,7 @@ macro_rules! static_init {
 /// possible.
 #[macro_export]
 macro_rules! static_buf {
-    ($T:ty) => {{
+    ($T:ty $(,)?) => {{
         // Statically allocate a read-write buffer for the value, write our
         // initial value into it (without dropping the initial zeros) and
         // return a reference to it.
@@ -137,7 +137,7 @@ impl<T> StaticUninitializedBuffer<T> {
 /// The static buffer must be passed in.
 #[macro_export]
 macro_rules! static_init_half {
-    ($B:expr, $T:ty, $e:expr) => {
+    ($B:expr, $T:ty, $e:expr $(,)?) => {
         {
             use core::mem::MaybeUninit;
             let buf: &'static mut MaybeUninit<$T> = $B;
@@ -168,7 +168,7 @@ macro_rules! static_init_half {
 /// and the next section is aligned as well.
 #[macro_export]
 macro_rules! storage_volume {
-    ($N:ident, $kB:expr) => {
+    ($N:ident, $kB:expr $(,)?) => {
         #[link_section = ".storage"]
         #[used]
         #[no_mangle]
@@ -190,7 +190,7 @@ macro_rules! storage_volume {
 /// or pass to another module.
 #[macro_export]
 macro_rules! create_capability {
-    ($T:ty) => {{
+    ($T:ty $(,)?) => {{
         struct Cap;
         #[allow(unsafe_code)]
         unsafe impl $T for Cap {}
@@ -210,6 +210,6 @@ macro_rules! create_capability {
 #[macro_export]
 macro_rules! count_expressions {
     () => (0usize);
-    ($head:expr) => (1usize);
-    ($head:expr, $($tail:expr),*) => (1usize + count_expressions!($($tail),*));
+    ($head:expr $(,)?) => (1usize);
+    ($head:expr, $($tail:expr),* $(,)?) => (1usize + count_expressions!($($tail),*));
 }

--- a/kernel/src/debug.rs
+++ b/kernel/src/debug.rs
@@ -214,7 +214,7 @@ pub unsafe fn assign_gpios(
 /// In-kernel gpio debugging, accepts any GPIO HIL method
 #[macro_export]
 macro_rules! debug_gpio {
-    ($i:tt, $method:ident) => {{
+    ($i:tt, $method:ident $(,)?) => {{
         #[allow(unused_unsafe)]
         unsafe {
             $crate::debug::DEBUG_GPIOS.$i.map(|g| g.$method());
@@ -300,7 +300,7 @@ macro_rules! debug_enqueue {
     () => ({
         debug_enqueue!("")
     });
-    ($msg:expr) => ({
+    ($msg:expr $(,)?) => ({
         $crate::debug::debug_enqueue_fmt(format_args!($msg))
     });
     ($fmt:expr, $($arg:tt)+) => ({
@@ -519,7 +519,7 @@ macro_rules! debug {
         // Allow an empty debug!() to print the location when hit
         debug!("")
     });
-    ($msg:expr) => ({
+    ($msg:expr $(,)?) => ({
         $crate::debug::begin_debug_fmt(format_args!($msg))
     });
     ($fmt:expr, $($arg:tt)+) => ({
@@ -534,7 +534,7 @@ macro_rules! debug_verbose {
         // Allow an empty debug_verbose!() to print the location when hit
         debug_verbose!("")
     });
-    ($msg:expr) => ({
+    ($msg:expr $(,)?) => ({
         $crate::debug::begin_debug_verbose_fmt(format_args!($msg), {
             // TODO: Maybe make opposite choice of panic!, no `static`, more
             // runtime code for less static data

--- a/kernel/src/tbfheader.rs
+++ b/kernel/src/tbfheader.rs
@@ -10,7 +10,7 @@ use core::{mem, str};
 
 /// Takes a value and rounds it up to be aligned % 4
 macro_rules! align4 {
-    ($e:expr) => {
+    ($e:expr $(,)?) => {
         ($e) + ((4 - (($e) % 4)) % 4)
     };
 }


### PR DESCRIPTION
### Pull Request Overview

This pull request makes the various `macro_rules!` macros in the `kernel`, `arch` and `components` crates accept trailing commas, wherever the Rust function calling syntax would allow it too.

This is in line with the changes of #2197, inspired by a comment of @hudson-ayers. :)

While these changes may not make much sense in `macro_rules!` with only a single argument, I'd rather change these consistently and to the way how Rust syntax would behave. Furthermore, this might increase the chance that someone copying a component helper macro will get this right on the first try.

### Testing Strategy

This pull request was tested by compiling.


### TODO or Help Wanted

I haven't touched `chips` and `capsules` yet, as I do not know whether it is fine to "police" / update these macros. Furthermore, I'm not sure whether we want to further deviate from upstream in the copied and modified `enum_primitive` library by possibly changing those macros too.

The kernel-provided (especially `static_init!`) and component-helper macros seemed the most important to change (as I've often ran into errors here :) ).

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
