### PR TITLE
tock-cells: make TakeCell constructor a const fn

### DIFF
--- a/libraries/tock-cells/src/take_cell.rs
+++ b/libraries/tock-cells/src/take_cell.rs
@@ -23,7 +23,7 @@ impl<'a, T: ?Sized> TakeCell<'a, T> {
     }
 
     /// Creates a new `TakeCell` containing `value`
-    pub fn new(value: &'a mut T) -> TakeCell<'a, T> {
+    pub const fn new(value: &'a mut T) -> TakeCell<'a, T> {
         TakeCell {
             val: Cell::new(Some(value)),
         }


### PR DESCRIPTION
### Pull Request Overview

This pull request changes the TakeCell to be a `const fn`, such that it can be used in other `const fn`s (as used in PR #2203, port to LiteX SoCs).

This requires the `const_mut_refs` feature, which is already enabled in the `tock-cells` crate.


### Testing Strategy

This pull request was tested by compiling.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
