### PR TITLE
add 15.4 and ble to nano33ble

### DIFF
--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -322,7 +322,7 @@ pub unsafe fn reset_handler() {
             .finalize(());
 
     let serial_num = nrf52840::ficr::FICR_INSTANCE.address();
-    let serial_num_bottom_16 = serial_num[0] as u16 + ((serial_num[1] as u16) << 8);
+    let serial_num_bottom_16 = u16::from_le_bytes([serial_num[0], serial_num[1]]);
     let (ieee802154_radio, _mux_mac) = components::ieee802154::Ieee802154Component::new(
         board_kernel,
         &base_peripherals.ieee802154_radio,


### PR DESCRIPTION
### Pull Request Overview

This pull request adds the 15.4 and BLE drivers to the nano33ble, rather than leaving support as commented out, as the comments had already fallen out-of-date.


### Testing Strategy

BLE was tested using the `ble_advertising` and `ble_passive_scanning` apps in `libtock-c`.

15.4 was tested using the `radio_tx` and `radio_rx` apps in `libtock-c` and sending messages back and forth with an nrf52840-dk.

### TODO or Help Wanted

N/A

### Documentation Updated

- [x] No updates are required.

### Formatting

- [x] Ran `make prepush`.
