### PR TITLE
bring back borrow_interior_mutable_const clippy lint

### DIFF
--- a/tools/run_clippy.sh
+++ b/tools/run_clippy.sh
@@ -18,11 +18,6 @@ fi
 #
 # - `clippy::if_same_then_else`: There are often good reasons to enumerate
 #   different states that have the same effect.
-# - `clippy::borrow_interior_mutable_const`: There's a common pattern of using
-#   a const `StaticRef` to reference mutable memory-mapped registers, and that
-#   triggers a false positive of this lint.
-#
-#   See https://github.com/rust-lang/rust-clippy/issues/5796.
 
 CLIPPY_ARGS="
 -A clippy::complexity
@@ -34,7 +29,6 @@ CLIPPY_ARGS="
 -A clippy::restriction
 
 -A clippy::if_same_then_else
--A clippy::borrow_interior_mutable_const
 
 -D clippy::needless_return
 -D clippy::unnecessary_mut_passed


### PR DESCRIPTION
### Pull Request Overview

We added an allow for this lint in `run_clippy.sh` in #2015 because of a false positive bug. That bug was fixed on August 26 (https://github.com/rust-lang/rust-clippy/issues/5796) and we have updated to a more recent nightly than that, so we can bring the lint back.


### Testing Strategy

This pull request was tested by running `make clippy`

### TODO or Help Wanted

N/A

### Documentation Updated

- [x] No updates are required.

### Formatting

- [x] Ran `make prepush`.
