### PR TITLE
Allow processes to read from buffers shared with read-only allow

### DIFF
--- a/doc/reference/trd-syscalls.md
+++ b/doc/reference/trd-syscalls.md
@@ -459,9 +459,10 @@ again to re-allow it with a different size.
 ---------------------------------
 
 The Read-Only Allow class is identical to the Read-Write Allow class
-with one exception: the buffer it passes to the kernel is
-read-only. The kernel cannot write to it. It semantics and calling
-conventions are otherwise identical to Read-Write Allow.
+with two exceptions: the buffer it passes to the kernel is read-only, and the
+process retains read access to the buffer. The kernel cannot write to the
+buffer. Read-Only Allow's semantics and calling conventions are otherwise
+identical to Read-Write Allow.
 
 The Read-Only Allow class exists so that userspace can pass references to constant data
 to the kernel. Often, constant data is stored in flash rather than RAM. Constant data


### PR DESCRIPTION
### Pull Request Overview

This pull request changes the 2.0 syscalls TRD to allow processes that have shared a buffer with the kernel to read from that buffer.

The benefit of this change is it allows us to use `&[u8]` in `libtock-rs`' system call APIs to pass allow buffers. Without this change, `libtock-rs` would need to require processes to instantiate a custom type that tracks whether a buffer has been shared and mediates access to it, which is unergonomic to use.


### Testing Strategy

Ran `make prepush`, proofread changes.


### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
