### PR TITLE
tock-registers: remove duplicate code, make local register copy read-write

### DIFF
--- a/libraries/tock-register-interface/src/registers.rs
+++ b/libraries/tock-register-interface/src/registers.rs
@@ -694,6 +694,9 @@ mod tests {
             let field64 = Field::<u64, ()>::new(0x12345678_9abcdef0, 1);
             assert_eq!(field64.mask, 0x12345678_9abcdef0_u64);
             assert_eq!(field64.shift, 1);
+            let field128 = Field::<u128, ()>::new(0x12345678_9abcdef0_0fedcba9_87654321, 1);
+            assert_eq!(field128.mask, 0x12345678_9abcdef0_0fedcba9_87654321_u128);
+            assert_eq!(field128.shift, 1);
         }
 
         #[test]

--- a/libraries/tock-register-interface/src/registers.rs
+++ b/libraries/tock-register-interface/src/registers.rs
@@ -584,6 +584,7 @@ FieldValue_impl_for!(u128);
 
 impl<T: IntLike, R: RegisterLongName> FieldValue<T, R> {
     /// Get the raw bitmask represented by this FieldValue.
+    #[inline]
     pub fn mask(&self) -> T {
         self.mask as T
     }
@@ -594,16 +595,19 @@ impl<T: IntLike, R: RegisterLongName> FieldValue<T, R> {
     }
 
     /// Modify fields in a register value
+    #[inline]
     pub fn modify(self, val: T) -> T {
         (val & !self.mask) | self.value
     }
 
     /// Check if any specified parts of a field match
+    #[inline]
     pub fn matches_any(&self, val: T) -> bool {
         val & self.mask != T::zero()
     }
 
     /// Check if all specified parts of a field match
+    #[inline]
     pub fn matches_all(&self, val: T) -> bool {
         val & self.mask == self.value
     }
@@ -612,6 +616,8 @@ impl<T: IntLike, R: RegisterLongName> FieldValue<T, R> {
 // Combine two fields with the addition operator
 impl<T: IntLike, R: RegisterLongName> Add for FieldValue<T, R> {
     type Output = Self;
+
+    #[inline]
     fn add(self, rhs: Self) -> Self {
         FieldValue {
             mask: self.mask | rhs.mask,
@@ -623,6 +629,7 @@ impl<T: IntLike, R: RegisterLongName> Add for FieldValue<T, R> {
 
 // Combine two fields with the += operator
 impl<T: IntLike, R: RegisterLongName> AddAssign for FieldValue<T, R> {
+    #[inline]
     fn add_assign(&mut self, rhs: FieldValue<T, R>) {
         self.mask |= rhs.mask;
         self.value |= rhs.value;

--- a/libraries/tock-register-interface/src/registers.rs
+++ b/libraries/tock-register-interface/src/registers.rs
@@ -584,7 +584,7 @@ FieldValue_impl_for!(u128);
 
 impl<T: IntLike, R: RegisterLongName> FieldValue<T, R> {
     /// Get the raw bitmask represented by this FieldValue.
-    pub fn mask(self) -> T {
+    pub fn mask(&self) -> T {
         self.mask as T
     }
 
@@ -599,12 +599,12 @@ impl<T: IntLike, R: RegisterLongName> FieldValue<T, R> {
     }
 
     /// Check if any specified parts of a field match
-    pub fn matches_any(self, val: T) -> bool {
+    pub fn matches_any(&self, val: T) -> bool {
         val & self.mask != T::zero()
     }
 
     /// Check if all specified parts of a field match
-    pub fn matches_all(self, val: T) -> bool {
+    pub fn matches_all(&self, val: T) -> bool {
         val & self.mask == self.value
     }
 }


### PR DESCRIPTION
### Pull Request Overview

* Added macros to replace some repetitive code. Add missing implementations of said code for u128.

The task was reducing cognitive complexity of a) repeated code with slight variations, b) too much unrelated code smashed under a single macro. Based on feedback from @lschuermann [elsewhere](https://github.com/tock/tock/pull/2210#issuecomment-733025295) I believe this is balanced enough to keep compilation still fast and code DRY.

* Add more aggressive inlining markers.

* Make LocalRegisterCopy modifiable. I found in the usage (and eventual abusage) of LocalRegsiterCopy that I actually use it to mimic structured bitfield accesses in a very convenient form on local variables, and for this original LocalRegisterCopy was a bit limited. 

* Don't consume self in several FieldValue<> accessors. Turns out I still need FieldValue after accessing its mask(). This makes these methods more akin to impls for other structs, too.

### Testing Strategy

* [x] Added test for u128 field.

### TODO or Help Wanted

* [x] Should be good to go.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

I believe nothing is needed to be updated there.

### Formatting

- [x] Ran `make prepush`.

I didn't, but running `rustfmt` on the only touched file (registers.rs) yields no changes.