### PR TITLE
usb-cdc: fake successful uart transmissions so that blocking debug calls resume

### DIFF
--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -81,7 +81,11 @@ static mut PROCESSES: [Option<&'static dyn kernel::procs::ProcessType>; NUM_PROC
 
 static mut CHIP: Option<&'static nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>> = None;
 static mut CDC_REF_FOR_PANIC: Option<
-    &'static capsules::usb::cdc::CdcAcm<'static, nrf52::usbd::Usbd>,
+    &'static capsules::usb::cdc::CdcAcm<
+        'static,
+        nrf52::usbd::Usbd,
+        capsules::virtual_alarm::VirtualMuxAlarm<'static, nrf52::rtc::Rtc>,
+    >,
 > = None;
 
 /// Dummy buffer that causes the linker to reserve enough space for the stack.
@@ -283,8 +287,13 @@ pub unsafe fn reset_handler() {
         0x239a,
         0x8071,
         strings,
+        mux_alarm,
+        dynamic_deferred_caller,
     )
-    .finalize(components::usb_cdc_acm_component_helper!(nrf52::usbd::Usbd));
+    .finalize(components::usb_cdc_acm_component_helper!(
+        nrf52::usbd::Usbd,
+        nrf52::rtc::Rtc
+    ));
     CDC_REF_FOR_PANIC = Some(cdc); //for use by panic handler
 
     // Create a shared UART channel for the console and for kernel debug.

--- a/boards/components/src/cdc.rs
+++ b/boards/components/src/cdc.rs
@@ -22,64 +22,101 @@
 
 use core::mem::MaybeUninit;
 
+use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
+use kernel::common::dynamic_deferred_call::DynamicDeferredCall;
 use kernel::component::Component;
 use kernel::hil;
+use kernel::hil::time::Alarm;
 use kernel::static_init_half;
 
 // Setup static space for the objects.
 #[macro_export]
 macro_rules! usb_cdc_acm_component_helper {
-    ($U:ty $(,)?) => {{
+    ($U:ty, $A:ty $(,)?) => {{
+        use capsules::virtual_alarm::VirtualMuxAlarm;
         use core::mem::MaybeUninit;
-        static mut BUF: MaybeUninit<capsules::usb::cdc::CdcAcm<'static, $U>> =
-            MaybeUninit::uninit();
-        &mut BUF
+        static mut BUF0: MaybeUninit<VirtualMuxAlarm<'static, $A>> = MaybeUninit::uninit();
+        static mut BUF1: MaybeUninit<
+            capsules::usb::cdc::CdcAcm<'static, $U, VirtualMuxAlarm<'static, $A>>,
+        > = MaybeUninit::uninit();
+        (&mut BUF0, &mut BUF1)
     };};
 }
 
-pub struct CdcAcmComponent<U: 'static + hil::usb::UsbController<'static>> {
+pub struct CdcAcmComponent<
+    U: 'static + hil::usb::UsbController<'static>,
+    A: 'static + Alarm<'static>,
+> {
     usb: &'static U,
     max_ctrl_packet_size: u8,
     vendor_id: u16,
     product_id: u16,
     strings: &'static [&'static str; 3],
+    alarm_mux: &'static MuxAlarm<'static, A>,
+    deferred_caller: &'static DynamicDeferredCall,
 }
 
-impl<U: 'static + hil::usb::UsbController<'static>> CdcAcmComponent<U> {
+impl<U: 'static + hil::usb::UsbController<'static>, A: 'static + Alarm<'static>>
+    CdcAcmComponent<U, A>
+{
     pub fn new(
         usb: &'static U,
         max_ctrl_packet_size: u8,
         vendor_id: u16,
         product_id: u16,
         strings: &'static [&'static str; 3],
-    ) -> CdcAcmComponent<U> {
-        CdcAcmComponent {
+        alarm_mux: &'static MuxAlarm<'static, A>,
+        deferred_caller: &'static DynamicDeferredCall,
+    ) -> Self {
+        Self {
             usb,
             max_ctrl_packet_size,
             vendor_id,
             product_id,
             strings,
+            alarm_mux,
+            deferred_caller,
         }
     }
 }
 
-impl<U: 'static + hil::usb::UsbController<'static>> Component for CdcAcmComponent<U> {
-    type StaticInput = &'static mut MaybeUninit<capsules::usb::cdc::CdcAcm<'static, U>>;
-    type Output = &'static capsules::usb::cdc::CdcAcm<'static, U>;
+impl<U: 'static + hil::usb::UsbController<'static>, A: 'static + Alarm<'static>> Component
+    for CdcAcmComponent<U, A>
+{
+    type StaticInput = (
+        &'static mut MaybeUninit<VirtualMuxAlarm<'static, A>>,
+        &'static mut MaybeUninit<
+            capsules::usb::cdc::CdcAcm<'static, U, VirtualMuxAlarm<'static, A>>,
+        >,
+    );
+    type Output = &'static capsules::usb::cdc::CdcAcm<'static, U, VirtualMuxAlarm<'static, A>>;
 
     unsafe fn finalize(self, s: Self::StaticInput) -> Self::Output {
+        let cdc_alarm = static_init_half!(
+            s.0,
+            VirtualMuxAlarm<'static, A>,
+            VirtualMuxAlarm::new(self.alarm_mux)
+        );
         let cdc = static_init_half!(
-            s,
-            capsules::usb::cdc::CdcAcm<'static, U>,
+            s.1,
+            capsules::usb::cdc::CdcAcm<'static, U, VirtualMuxAlarm<'static, A>>,
             capsules::usb::cdc::CdcAcm::new(
                 self.usb,
                 self.max_ctrl_packet_size,
                 self.vendor_id,
                 self.product_id,
-                self.strings
+                self.strings,
+                cdc_alarm,
+                self.deferred_caller,
             )
         );
         self.usb.set_client(cdc);
+        cdc.initialize_callback_handle(
+            self.deferred_caller
+                .register(cdc)
+                .expect("no deferred call slot available for USB-CDC"),
+        );
+        cdc_alarm.set_alarm_client(cdc);
 
         cdc
     }

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -74,7 +74,11 @@ static mut PROCESSES: [Option<&'static dyn kernel::procs::ProcessType>; NUM_PROC
 
 static mut CHIP: Option<&'static nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>> = None;
 static mut CDC_REF_FOR_PANIC: Option<
-    &'static capsules::usb::cdc::CdcAcm<'static, nrf52::usbd::Usbd>,
+    &'static capsules::usb::cdc::CdcAcm<
+        'static,
+        nrf52::usbd::Usbd,
+        capsules::virtual_alarm::VirtualMuxAlarm<'static, nrf52::rtc::Rtc>,
+    >,
 > = None;
 
 /// Dummy buffer that causes the linker to reserve enough space for the stack.
@@ -250,8 +254,13 @@ pub unsafe fn reset_handler() {
         0x2341,
         0x005a,
         strings,
+        mux_alarm,
+        dynamic_deferred_caller,
     )
-    .finalize(components::usb_cdc_acm_component_helper!(nrf52::usbd::Usbd));
+    .finalize(components::usb_cdc_acm_component_helper!(
+        nrf52::usbd::Usbd,
+        nrf52::rtc::Rtc
+    ));
     CDC_REF_FOR_PANIC = Some(cdc); //for use by panic handler
 
     // Create a shared UART channel for the console and for kernel debug.

--- a/capsules/src/usb/cdc.rs
+++ b/capsules/src/usb/cdc.rs
@@ -17,7 +17,11 @@ use super::usbc_client_ctrl::ClientCtrl;
 use kernel::common::cells::OptionalCell;
 use kernel::common::cells::TakeCell;
 use kernel::common::cells::VolatileCell;
+use kernel::common::dynamic_deferred_call::{
+    DeferredCallHandle, DynamicDeferredCall, DynamicDeferredCallClient,
+};
 use kernel::hil;
+use kernel::hil::time::{Alarm, AlarmClient};
 use kernel::hil::uart;
 use kernel::hil::usb::TransferType;
 use kernel::ReturnCode;
@@ -38,6 +42,11 @@ pub const MAX_CTRL_PACKET_SIZE_SAM4L: u8 = 8;
 pub const MAX_CTRL_PACKET_SIZE_NRF52840: u8 = 64;
 /// Platform-specific packet length for the `earlgrey` USB hardware.
 pub const MAX_CTRL_PACKET_SIZE_EARLGREY: u8 = 64;
+/// Number of ms to buffer uart transmissions before beginning to drop them.
+/// This is useful in that it allows users time to connect over CDC without losing message,
+/// while still guaranteeing that blocking uart transmissions eventually get a callback even
+/// if a debug output is not connected.
+pub const CDC_BUFFER_TIMEOUT_MS: u32 = 10000;
 
 const N_ENDPOINTS: usize = 3;
 
@@ -93,7 +102,7 @@ impl From<u8> for CDCCntrlMessage {
 
 /// Implementation of the Abstract Control Model (ACM) for the Communications
 /// Class Device (CDC) over USB.
-pub struct CdcAcm<'a, U: 'a> {
+pub struct CdcAcm<'a, U: 'a, A: 'a + Alarm<'a>> {
     /// Helper USB client library for handling many USB operations.
     client_ctrl: ClientCtrl<'a, 'static, U>,
 
@@ -127,15 +136,27 @@ pub struct CdcAcm<'a, U: 'a> {
     rx_offset: Cell<usize>,
     /// The RX client to use when RX data is received.
     rx_client: OptionalCell<&'a dyn uart::ReceiveClient>,
+    /// Alarm used to indicate that data should be dropped and callbacks returned.
+    timeout_alarm: &'a A,
+    /// Used to track whether we are in the initial boot up period during which messages
+    /// can be queued despite a CDC host not being connected (which is useful for ensuring debug
+    /// messages early in the boot process can be delivered over the console)
+    boot_period: Cell<bool>,
+    /// Deferred Caller
+    deferred_caller: &'a DynamicDeferredCall,
+    /// Deferred Call Handle
+    handle: OptionalCell<DeferredCallHandle>,
 }
 
-impl<'a, U: hil::usb::UsbController<'a>> CdcAcm<'a, U> {
+impl<'a, U: hil::usb::UsbController<'a>, A: 'a + Alarm<'a>> CdcAcm<'a, U, A> {
     pub fn new(
         controller: &'a U,
         max_ctrl_packet_size: u8,
         vendor_id: u16,
         product_id: u16,
         strings: &'static [&'static str; 3],
+        timeout_alarm: &'a A,
+        deferred_caller: &'a DynamicDeferredCall,
     ) -> Self {
         let interfaces: &mut [InterfaceDescriptor] = &mut [
             InterfaceDescriptor {
@@ -227,7 +248,7 @@ impl<'a, U: hil::usb::UsbController<'a>> CdcAcm<'a, U> {
                 Some(cdc_descriptors),
             );
 
-        CdcAcm {
+        Self {
             client_ctrl: ClientCtrl::new(
                 controller,
                 device_descriptor_buffer,
@@ -252,7 +273,15 @@ impl<'a, U: hil::usb::UsbController<'a>> CdcAcm<'a, U> {
             rx_len: Cell::new(0),
             rx_offset: Cell::new(0),
             rx_client: OptionalCell::empty(),
+            timeout_alarm,
+            boot_period: Cell::new(true),
+            deferred_caller,
+            handle: OptionalCell::empty(),
         }
+    }
+
+    pub fn initialize_callback_handle(&self, handle: DeferredCallHandle) {
+        self.handle.replace(handle);
     }
 
     #[inline]
@@ -264,9 +293,25 @@ impl<'a, U: hil::usb::UsbController<'a>> CdcAcm<'a, U> {
     fn buffer(&'a self, i: usize) -> &'a [VolatileCell<u8>; 64] {
         &self.buffers[i - 1].buf
     }
+
+    /// This is a helper function used to indicate successful uart transmission to
+    /// a higher layer client despite not actually being connected to a host. Allows
+    /// blocking debug interfaces to function in the same way they do when an actual UART
+    /// interface is in use. This should only be called in an upcall.
+    fn indicate_tx_success(&self) {
+        self.tx_len.set(0);
+        self.tx_offset.set(0);
+        self.tx_client.map(|client| {
+            self.tx_buffer.take().map(|buf| {
+                client.transmitted_buffer(buf, 0, ReturnCode::FAIL);
+            });
+        });
+    }
 }
 
-impl<'a, U: hil::usb::UsbController<'a>> hil::usb::Client<'a> for CdcAcm<'a, U> {
+impl<'a, U: hil::usb::UsbController<'a>, A: 'a + Alarm<'a>> hil::usb::Client<'a>
+    for CdcAcm<'a, U, A>
+{
     fn enable(&'a self) {
         // Set up the default control endpoint
         self.client_ctrl.enable();
@@ -283,6 +328,11 @@ impl<'a, U: hil::usb::UsbController<'a>> hil::usb::Client<'a> for CdcAcm<'a, U> 
             .endpoint_out_enable(TransferType::Bulk, ENDPOINT_OUT_NUM);
 
         self.state.set(State::Enabled);
+
+        self.timeout_alarm.set_alarm(
+            self.timeout_alarm.now(),
+            A::ticks_from_ms(CDC_BUFFER_TIMEOUT_MS),
+        );
     }
 
     fn attach(&'a self) {
@@ -521,7 +571,7 @@ impl<'a, U: hil::usb::UsbController<'a>> hil::usb::Client<'a> for CdcAcm<'a, U> 
     }
 }
 
-impl<'a, U: hil::usb::UsbController<'a>> uart::Configure for CdcAcm<'a, U> {
+impl<'a, U: hil::usb::UsbController<'a>, A: 'a + Alarm<'a>> uart::Configure for CdcAcm<'a, U, A> {
     fn configure(&self, _parameters: uart::Parameters) -> ReturnCode {
         // Since this is not a real UART, we don't need to consider these
         // parameters.
@@ -529,7 +579,9 @@ impl<'a, U: hil::usb::UsbController<'a>> uart::Configure for CdcAcm<'a, U> {
     }
 }
 
-impl<'a, U: hil::usb::UsbController<'a>> uart::Transmit<'a> for CdcAcm<'a, U> {
+impl<'a, U: hil::usb::UsbController<'a>, A: 'a + Alarm<'a>> uart::Transmit<'a>
+    for CdcAcm<'a, U, A>
+{
     fn set_transmit_client(&self, client: &'a dyn uart::TransmitClient) {
         self.tx_client.set(client);
     }
@@ -558,8 +610,16 @@ impl<'a, U: hil::usb::UsbController<'a>> uart::Transmit<'a> for CdcAcm<'a, U> {
                 // Then signal to the lower layer that we are ready to do a TX
                 // by putting data in the IN endpoint.
                 self.controller().endpoint_resume_in(ENDPOINT_IN_NUM);
+                (ReturnCode::SUCCESS, None)
+            } else if self.boot_period.get() {
+                // indicate success because we will try to send it once a host connects
+                (ReturnCode::SUCCESS, None)
+            } else {
+                // indicate success, but we will not actually queue this message -- just schedule
+                // a deferred callback to return the buffer immediately.
+                self.handle.map(|handle| self.deferred_caller.set(*handle));
+                (ReturnCode::SUCCESS, None)
             }
-            (ReturnCode::SUCCESS, None)
         }
     }
 
@@ -572,7 +632,7 @@ impl<'a, U: hil::usb::UsbController<'a>> uart::Transmit<'a> for CdcAcm<'a, U> {
     }
 }
 
-impl<'a, U: hil::usb::UsbController<'a>> uart::Receive<'a> for CdcAcm<'a, U> {
+impl<'a, U: hil::usb::UsbController<'a>, A: 'a + Alarm<'a>> uart::Receive<'a> for CdcAcm<'a, U, A> {
     fn set_receive_client(&self, client: &'a dyn uart::ReceiveClient) {
         self.rx_client.set(client);
     }
@@ -604,5 +664,30 @@ impl<'a, U: hil::usb::UsbController<'a>> uart::Receive<'a> for CdcAcm<'a, U> {
     }
 }
 
-impl<'a, U: hil::usb::UsbController<'a>> uart::Uart<'a> for CdcAcm<'a, U> {}
-impl<'a, U: hil::usb::UsbController<'a>> uart::UartData<'a> for CdcAcm<'a, U> {}
+impl<'a, U: hil::usb::UsbController<'a>, A: 'a + Alarm<'a>> AlarmClient for CdcAcm<'a, U, A> {
+    fn alarm(&self) {
+        self.boot_period.set(false);
+        if self.state.get() == State::Connected {
+            // we are already connected, so any queued messages are going to be sent.
+            // do nothing.
+        } else {
+            // no client has connected, but we do not want to block indefinitely, so go ahead
+            // and deliver a callback.
+            self.indicate_tx_success();
+        }
+    }
+}
+
+impl<'a, U: hil::usb::UsbController<'a>, A: 'a + Alarm<'a>> DynamicDeferredCallClient
+    for CdcAcm<'a, U, A>
+{
+    fn call(&self, _handle: DeferredCallHandle) {
+        self.indicate_tx_success();
+    }
+}
+
+impl<'a, U: hil::usb::UsbController<'a>, A: 'a + Alarm<'a>> uart::Uart<'a> for CdcAcm<'a, U, A> {}
+impl<'a, U: hil::usb::UsbController<'a>, A: 'a + Alarm<'a>> uart::UartData<'a>
+    for CdcAcm<'a, U, A>
+{
+}


### PR DESCRIPTION
### Pull Request Overview

Currently, `libtock-c` apps that contain `printf()` calls hang indefinitely after calling `printf()` on boards that use CDC-based console output, until a user calls `tockloader listen`. This can be observed by adding a print statement to the `blink` app.

As a fix for this issue, this PR modifies the CDC stack to deliver `SUCCESS` callbacks even when no CDC host is connected (basically pretending the data was sent). However, it only does so after a 10 second delay -- which ensures that queued debug statements made within the first 10 seconds after boot are not dropped in the time it might take a user to call `tockloader listen`. 


### Testing Strategy

This pull request was tested by adding a `printf()` call to `blink`, and running that app. With this change, the light begins blinking after 10 seconds if `tockloader listen` is not called. If `tockloader listen` is called after 5 seconds, all debug output is printed, including the initial "Initialization complete..." message.


### TODO or Help Wanted

This solution is a little hacky, but was my favorite of the options I thought of. Alternatives include:

- remove all blocking debug output from the kernel, `libtock-c` and `libtock-rs`. This would eventually lead to debug buffer overflow warnings, but perhaps those warnings could be suppressed somehow (or we could accept the wasted cycles?)

- Indicate failure rather than success, and modify the console driver to appropriately handle a specific error code as an indication that no callback will be delivered, and blocking should not occur. This is also probably more involved.


### Documentation Updated

- [x] No updates are required (I think? Is there somewhere I should document this?)

### Formatting

- [x] Ran `make prepush`.
