### PR TITLE
Port log tests from imix to nano33ble

### DIFF
--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -27,6 +27,9 @@ use kernel::{create_capability, debug, debug_gpio, debug_verbose, static_init};
 use nrf52840::gpio::Pin;
 use nrf52840::interrupt_service::Nrf52840DefaultPeripherals;
 
+#[allow(dead_code)]
+mod test;
+
 // Three-color LED.
 const LED_RED_PIN: Pin = Pin::P0_24;
 const LED_GREEN_PIN: Pin = Pin::P0_16;
@@ -357,6 +360,15 @@ pub unsafe fn reset_handler() {
     // Configure the USB stack to enable a serial port over CDC-ACM.
     cdc.enable();
     cdc.attach();
+
+    //--------------------------------------------------------------------------
+    // TESTS
+    //--------------------------------------------------------------------------
+    // test::linear_log_test::run(
+    //     mux_alarm,
+    //     dynamic_deferred_caller,
+    //     &nrf52840_peripherals.nrf52.nvmc,
+    // );
 
     debug!("Initialization complete. Entering main loop.");
 

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -369,6 +369,11 @@ pub unsafe fn reset_handler() {
     //     dynamic_deferred_caller,
     //     &nrf52840_peripherals.nrf52.nvmc,
     // );
+    // test::log_test::run(
+    //     mux_alarm,
+    //     dynamic_deferred_caller,
+    //     &nrf52840_peripherals.nrf52.nvmc,
+    // );
 
     debug!("Initialization complete. Entering main loop.");
 

--- a/boards/nano33ble/src/test/linear_log_test.rs
+++ b/boards/nano33ble/src/test/linear_log_test.rs
@@ -82,23 +82,23 @@ pub unsafe fn run(
 static TEST_OPS: [TestOp; 9] = [
     TestOp::Read,
     // Write to first page.
-    TestOp::Write(8),
-    TestOp::Write(300),
+    TestOp::Write(64),
+    TestOp::Write(2400),
     // Write to next page, too large to fit on first.
-    TestOp::Write(304),
+    TestOp::Write(2432),
     // Write should fail, not enough space remaining.
-    TestOp::Write(306),
+    TestOp::Write(2448),
     // Write should succeed, enough space for a smaller entry.
-    TestOp::Write(9),
+    TestOp::Write(72),
     // Read back everything to verify and sync.
     TestOp::Read,
     TestOp::Sync,
     // Write should still fail after sync.
-    TestOp::Write(308),
+    TestOp::Write(2464),
 ];
 
 // Buffer for reading from and writing to in the log tests.
-static mut BUFFER: [u8; 310] = [0; 310];
+static mut BUFFER: [u8; 2480] = [0; 2480];
 // Time to wait in between log operations.
 const WAIT_MS: u32 = 3;
 

--- a/boards/nano33ble/src/test/linear_log_test.rs
+++ b/boards/nano33ble/src/test/linear_log_test.rs
@@ -1,0 +1,326 @@
+//! Tests the log storage interface in linear mode. For testing in circular mode, see
+//! log_test.rs.
+//!
+//! The testing framework creates a non-circular log storage interface in flash and performs a
+//! series of writes and syncs to ensure that the non-circular log properly denies overly-large
+//! writes once it is full. For testing all of the general capabilities of the log storage
+//! interface, see log_test.rs.
+//!
+//! To run the test, add the following line to the imix boot sequence:
+//! ```
+//!     test::linear_log_test::run(mux_alarm, dynamic_deferred_caller);
+//! ```
+//! and use the `USER` and `RESET` buttons to manually erase the log and reboot the imix,
+//! respectively.
+
+use capsules::log;
+use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
+use core::cell::Cell;
+use kernel::common::cells::{NumericCellExt, TakeCell};
+use kernel::common::dynamic_deferred_call::DynamicDeferredCall;
+use kernel::debug;
+use kernel::hil::flash;
+use kernel::hil::log::{LogRead, LogReadClient, LogWrite, LogWriteClient};
+use kernel::hil::time::{Alarm, AlarmClient};
+use kernel::static_init;
+use kernel::storage_volume;
+use kernel::ReturnCode;
+use nrf52840::{
+    nvmc::{NrfPage, Nvmc},
+    rtc::Rtc,
+};
+
+// Allocate 4 KiB volume for log storage (the nano33ble page size is 4 KiB).
+storage_volume!(LINEAR_TEST_LOG, 4);
+
+pub unsafe fn run(
+    mux_alarm: &'static MuxAlarm<'static, Rtc>,
+    deferred_caller: &'static DynamicDeferredCall,
+    flash_controller: &'static Nvmc,
+) {
+    // Set up flash controller.
+    flash_controller.configure_writeable();
+    flash_controller.configure_eraseable();
+    let pagebuffer = static_init!(NrfPage, NrfPage::default());
+
+    // Create actual log storage abstraction on top of flash.
+    let log = static_init!(
+        Log,
+        log::Log::new(
+            &LINEAR_TEST_LOG,
+            &flash_controller,
+            pagebuffer,
+            deferred_caller,
+            false
+        )
+    );
+    flash::HasClient::set_client(flash_controller, log);
+    log.initialize_callback_handle(
+        deferred_caller
+            .register(log)
+            .expect("no deferred call slot available for log storage"),
+    );
+
+    // Create and run test for log storage.
+    let test = static_init!(
+        LogTest<VirtualMuxAlarm<'static, Rtc>>,
+        LogTest::new(log, &mut BUFFER, VirtualMuxAlarm::new(mux_alarm), &TEST_OPS)
+    );
+    log.set_read_client(test);
+    log.set_append_client(test);
+    test.alarm.set_alarm_client(test);
+
+    test.run();
+}
+
+static TEST_OPS: [TestOp; 9] = [
+    TestOp::Read,
+    // Write to first page.
+    TestOp::Write(8),
+    TestOp::Write(300),
+    // Write to next page, too large to fit on first.
+    TestOp::Write(304),
+    // Write should fail, not enough space remaining.
+    TestOp::Write(306),
+    // Write should succeed, enough space for a smaller entry.
+    TestOp::Write(9),
+    // Read back everything to verify and sync.
+    TestOp::Read,
+    TestOp::Sync,
+    // Write should still fail after sync.
+    TestOp::Write(308),
+];
+
+// Buffer for reading from and writing to in the log tests.
+static mut BUFFER: [u8; 310] = [0; 310];
+// Time to wait in between log operations.
+const WAIT_MS: u32 = 3;
+
+// A single operation within the test.
+#[derive(Clone, Copy, PartialEq)]
+enum TestOp {
+    Read,
+    Write(usize),
+    Sync,
+}
+
+type Log = log::Log<'static, Nvmc>;
+
+struct LogTest<A: Alarm<'static>> {
+    log: &'static Log,
+    buffer: TakeCell<'static, [u8]>,
+    alarm: A,
+    ops: &'static [TestOp],
+    op_index: Cell<usize>,
+}
+
+impl<A: Alarm<'static>> LogTest<A> {
+    fn new(
+        log: &'static Log,
+        buffer: &'static mut [u8],
+        alarm: A,
+        ops: &'static [TestOp],
+    ) -> LogTest<A> {
+        debug!(
+            "Log recovered from flash (Start and end entry IDs: {:?} to {:?})",
+            log.log_start(),
+            log.log_end()
+        );
+
+        LogTest {
+            log,
+            buffer: TakeCell::new(buffer),
+            alarm,
+            ops,
+            op_index: Cell::new(0),
+        }
+    }
+
+    fn run(&self) {
+        let op_index = self.op_index.get();
+        if op_index == self.ops.len() {
+            debug!("Linear Log Storage test succeeded!");
+            return;
+        }
+
+        match self.ops[op_index] {
+            TestOp::Read => self.read(),
+            TestOp::Write(len) => self.write(len),
+            TestOp::Sync => self.sync(),
+        }
+    }
+
+    fn read(&self) {
+        self.buffer.take().map_or_else(
+            || panic!("NO BUFFER"),
+            move |buffer| {
+                // Clear buffer first to make debugging more sane.
+                for e in buffer.iter_mut() {
+                    *e = 0;
+                }
+
+                if let Err((error, original_buffer)) = self.log.read(buffer, buffer.len()) {
+                    self.buffer
+                        .replace(original_buffer.expect("No buffer returned in error!"));
+                    match error {
+                        ReturnCode::FAIL => {
+                            // No more entries, start writing again.
+                            debug!(
+                                "READ DONE: READ OFFSET: {:?} / WRITE OFFSET: {:?}",
+                                self.log.next_read_entry_id(),
+                                self.log.log_end()
+                            );
+                            self.op_index.increment();
+                            self.run();
+                        }
+                        ReturnCode::EBUSY => {
+                            debug!("Flash busy, waiting before reattempting read");
+                            self.wait();
+                        }
+                        _ => panic!("READ FAILED: {:?}", error),
+                    }
+                }
+            },
+        );
+    }
+
+    fn write(&self, len: usize) {
+        self.buffer
+            .take()
+            .map(move |buffer| {
+                let expect_write_fail = self.log.log_end() + len > LINEAR_TEST_LOG.len();
+
+                // Set buffer value.
+                for i in 0..buffer.len() {
+                    buffer[i] = if i < len {
+                        len as u8
+                    } else {
+                        0
+                    };
+                }
+
+                if let Err((error, original_buffer)) = self.log.append(buffer, len) {
+                    self.buffer.replace(original_buffer.expect("No buffer returned in error!"));
+
+                    match error {
+                        ReturnCode::FAIL =>
+                            if expect_write_fail {
+                                debug!(
+                                    "Write failed on {} byte write, as expected",
+                                    len
+                                );
+                                self.op_index.increment();
+                                self.run();
+                            } else {
+                                panic!(
+                                    "Write failed unexpectedly on {} byte write (read entry ID: {:?}, append entry ID: {:?})",
+                                    len,
+                                    self.log.next_read_entry_id(),
+                                    self.log.log_end()
+                                );
+                            }
+                        ReturnCode::EBUSY => self.wait(),
+                        _ => panic!("WRITE FAILED: {:?}", error),
+                    }
+                } else if expect_write_fail {
+                    panic!(
+                        "Write succeeded unexpectedly on {} byte write (read entry ID: {:?}, append entry ID: {:?})",
+                        len,
+                        self.log.next_read_entry_id(),
+                        self.log.log_end()
+                    );
+                }
+            })
+            .unwrap();
+    }
+
+    fn sync(&self) {
+        match self.log.sync() {
+            ReturnCode::SUCCESS => (),
+            error => panic!("Sync failed: {:?}", error),
+        }
+    }
+
+    fn wait(&self) {
+        let delay = A::ticks_from_ms(WAIT_MS);
+        let now = self.alarm.now();
+        self.alarm.set_alarm(now, delay);
+    }
+}
+
+impl<A: Alarm<'static>> LogReadClient for LogTest<A> {
+    fn read_done(&self, buffer: &'static mut [u8], length: usize, error: ReturnCode) {
+        match error {
+            ReturnCode::SUCCESS => {
+                // Verify correct value was read.
+                assert!(length > 0);
+                for i in 0..length {
+                    if buffer[i] != length as u8 {
+                        panic!(
+                            "Read incorrect value {} at index {}, expected {}",
+                            buffer[i], i, length
+                        );
+                    }
+                }
+
+                debug!("Successful read of size {}", length);
+                self.buffer.replace(buffer);
+                self.wait();
+            }
+            _ => {
+                panic!("Read failed unexpectedly!");
+            }
+        }
+    }
+
+    fn seek_done(&self, _error: ReturnCode) {
+        unreachable!();
+    }
+}
+
+impl<A: Alarm<'static>> LogWriteClient for LogTest<A> {
+    fn append_done(
+        &self,
+        buffer: &'static mut [u8],
+        length: usize,
+        records_lost: bool,
+        error: ReturnCode,
+    ) {
+        assert!(!records_lost);
+        match error {
+            ReturnCode::SUCCESS => {
+                debug!("Write succeeded on {} byte write, as expected", length);
+
+                self.buffer.replace(buffer);
+                self.op_index.increment();
+                self.wait();
+            }
+            error => panic!("WRITE FAILED IN CALLBACK: {:?}", error),
+        }
+    }
+
+    fn sync_done(&self, error: ReturnCode) {
+        if error == ReturnCode::SUCCESS {
+            debug!(
+                "SYNC DONE: READ OFFSET: {:?} / WRITE OFFSET: {:?}",
+                self.log.next_read_entry_id(),
+                self.log.log_end()
+            );
+        } else {
+            panic!("Sync failed: {:?}", error);
+        }
+
+        self.op_index.increment();
+        self.run();
+    }
+
+    fn erase_done(&self, _error: ReturnCode) {
+        unreachable!();
+    }
+}
+
+impl<A: Alarm<'static>> AlarmClient for LogTest<A> {
+    fn alarm(&self) {
+        self.run();
+    }
+}

--- a/boards/nano33ble/src/test/linear_log_test.rs
+++ b/boards/nano33ble/src/test/linear_log_test.rs
@@ -97,7 +97,7 @@ static mut BUFFER: [u8; 310] = [0; 310];
 const WAIT_MS: u32 = 3;
 
 // A single operation within the test.
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, PartialEq, Debug)]
 enum TestOp {
     Read,
     Write(usize),
@@ -137,16 +137,20 @@ impl<A: Alarm<'static>> LogTest<A> {
     }
 
     fn run(&self) {
-        let op_index = self.op_index.get();
-        if op_index == self.ops.len() {
-            debug_verbose!("Linear Log Storage test succeeded!");
-            return;
-        }
-
-        match self.ops[op_index] {
-            TestOp::Read => self.read(),
-            TestOp::Write(len) => self.write(len),
-            TestOp::Sync => self.sync(),
+        if self.op_index.get() == self.ops.len() {
+            debug_verbose!("Success!")
+        } else {
+            debug_verbose!(
+                "Executing operation {} of {} - {:?}.",
+                self.op_index.get() + 1,
+                self.ops.len(),
+                self.ops[self.op_index.get()]
+            );
+            match self.ops[self.op_index.get()] {
+                TestOp::Read => self.read(),
+                TestOp::Write(length) => self.write(length),
+                TestOp::Sync => self.sync(),
+            }
         }
     }
 

--- a/boards/nano33ble/src/test/linear_log_test.rs
+++ b/boards/nano33ble/src/test/linear_log_test.rs
@@ -36,8 +36,8 @@ use nrf52840::{
     rtc::Rtc,
 };
 
-// Allocate 4 KiB volume for log storage (the nano33ble page size is 4 KiB).
-storage_volume!(LINEAR_TEST_LOG, 4);
+// Allocate 8 KiB volume for log storage (the nano33ble page size is 4 KiB).
+storage_volume!(LINEAR_TEST_LOG, 8);
 
 pub unsafe fn run(
     mux_alarm: &'static MuxAlarm<'static, Rtc>,

--- a/boards/nano33ble/src/test/linear_log_test.rs
+++ b/boards/nano33ble/src/test/linear_log_test.rs
@@ -6,10 +6,16 @@
 //! writes once it is full. For testing all of the general capabilities of the log storage
 //! interface, see log_test.rs.
 //!
-//! To run the test, add the following line to the imix boot sequence:
+//! To run the test, uncomment the following line to the nano33ble boot sequence:
+//!
+//! ```rust
+//! test::linear_log_test::run(
+//!     mux_alarm,
+//!     dynamic_deferred_caller,
+//!     &nrf52840_peripherals.nrf52.nvmc,
+//! );
 //! ```
-//!     test::linear_log_test::run(mux_alarm, dynamic_deferred_caller);
-//! ```
+//!
 //! and use the `USER` and `RESET` buttons to manually erase the log and reboot the imix,
 //! respectively.
 

--- a/boards/nano33ble/src/test/linear_log_test.rs
+++ b/boards/nano33ble/src/test/linear_log_test.rs
@@ -18,7 +18,7 @@ use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use core::cell::Cell;
 use kernel::common::cells::{NumericCellExt, TakeCell};
 use kernel::common::dynamic_deferred_call::DynamicDeferredCall;
-use kernel::debug;
+use kernel::debug_verbose;
 use kernel::hil::flash;
 use kernel::hil::log::{LogRead, LogReadClient, LogWrite, LogWriteClient};
 use kernel::hil::time::{Alarm, AlarmClient};
@@ -121,7 +121,7 @@ impl<A: Alarm<'static>> LogTest<A> {
         alarm: A,
         ops: &'static [TestOp],
     ) -> LogTest<A> {
-        debug!(
+        debug_verbose!(
             "Log recovered from flash (Start and end entry IDs: {:?} to {:?})",
             log.log_start(),
             log.log_end()
@@ -139,7 +139,7 @@ impl<A: Alarm<'static>> LogTest<A> {
     fn run(&self) {
         let op_index = self.op_index.get();
         if op_index == self.ops.len() {
-            debug!("Linear Log Storage test succeeded!");
+            debug_verbose!("Linear Log Storage test succeeded!");
             return;
         }
 
@@ -165,7 +165,7 @@ impl<A: Alarm<'static>> LogTest<A> {
                     match error {
                         ReturnCode::FAIL => {
                             // No more entries, start writing again.
-                            debug!(
+                            debug_verbose!(
                                 "READ DONE: READ OFFSET: {:?} / WRITE OFFSET: {:?}",
                                 self.log.next_read_entry_id(),
                                 self.log.log_end()
@@ -174,7 +174,7 @@ impl<A: Alarm<'static>> LogTest<A> {
                             self.run();
                         }
                         ReturnCode::EBUSY => {
-                            debug!("Flash busy, waiting before reattempting read");
+                            debug_verbose!("Flash busy, waiting before reattempting read");
                             self.wait();
                         }
                         _ => panic!("READ FAILED: {:?}", error),
@@ -205,7 +205,7 @@ impl<A: Alarm<'static>> LogTest<A> {
                     match error {
                         ReturnCode::FAIL =>
                             if expect_write_fail {
-                                debug!(
+                                debug_verbose!(
                                     "Write failed on {} byte write, as expected",
                                     len
                                 );
@@ -263,7 +263,7 @@ impl<A: Alarm<'static>> LogReadClient for LogTest<A> {
                     }
                 }
 
-                debug!("Successful read of size {}", length);
+                debug_verbose!("Successful read of size {}", length);
                 self.buffer.replace(buffer);
                 self.wait();
             }
@@ -289,7 +289,7 @@ impl<A: Alarm<'static>> LogWriteClient for LogTest<A> {
         assert!(!records_lost);
         match error {
             ReturnCode::SUCCESS => {
-                debug!("Write succeeded on {} byte write, as expected", length);
+                debug_verbose!("Write succeeded on {} byte write, as expected", length);
 
                 self.buffer.replace(buffer);
                 self.op_index.increment();
@@ -301,7 +301,7 @@ impl<A: Alarm<'static>> LogWriteClient for LogTest<A> {
 
     fn sync_done(&self, error: ReturnCode) {
         if error == ReturnCode::SUCCESS {
-            debug!(
+            debug_verbose!(
                 "SYNC DONE: READ OFFSET: {:?} / WRITE OFFSET: {:?}",
                 self.log.next_read_entry_id(),
                 self.log.log_end()

--- a/boards/nano33ble/src/test/linear_log_test.rs
+++ b/boards/nano33ble/src/test/linear_log_test.rs
@@ -100,7 +100,7 @@ static TEST_OPS: [TestOp; 9] = [
 // Buffer for reading from and writing to in the log tests.
 static mut BUFFER: [u8; 2480] = [0; 2480];
 // Time to wait in between log operations.
-const WAIT_MS: u32 = 3;
+const WAIT_MS: u32 = 100;
 
 // A single operation within the test.
 #[derive(Clone, Copy, PartialEq, Debug)]

--- a/boards/nano33ble/src/test/log_test.rs
+++ b/boards/nano33ble/src/test/log_test.rs
@@ -1,0 +1,659 @@
+//! Tests the log storage interface in circular mode. For testing in linear mode, see
+//! linear_log_test.rs.
+//!
+//! This testing framework creates a circular log storage interface in flash and runs a series of
+//! operations upon it. The tests check to make sure that the correct values are read and written
+//! after each operation, that errors are properly detected and handled, and that the log generally
+//! behaves as expected. The tests perform both valid and invalid operations to fully test the log's
+//! behavior.
+//!
+//! Pressing the `USER` button on the imix at any time during the test will erase the log and reset
+//! the test state. Pressing the `RESET` button will reboot the imix without erasing the log,
+//! allowing for testing logs across reboots.
+//!
+//! In order to fully test the log, the tester should try a variety of erases and reboots to ensure
+//! that the log works correctly across these operations. The tester can also modify the testing
+//! operations and parameters defined below to test logs in different configurations. Different
+//! configurations should be tested in order to exercise the log under a greater number of
+//! scenarios (e.g. saturating/not saturating log pages with data, always/not always ending
+//! operations at page boundaries, etc.).
+//!
+//! To run the test, add the following line to the imix boot sequence:
+//! ```
+//!     test::log_test::run(mux_alarm, dynamic_deferred_caller, &peripherals.flash_controller);
+//! ```
+//! and use the `USER` and `RESET` buttons to manually erase the log and reboot the imix,
+//! respectively.
+
+use capsules::log;
+use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
+use core::cell::Cell;
+use kernel::common::cells::{NumericCellExt, TakeCell};
+use kernel::common::dynamic_deferred_call::DynamicDeferredCall;
+use kernel::debug;
+use kernel::hil::flash;
+use kernel::hil::gpio::{self, Interrupt, InterruptEdge};
+use kernel::hil::log::{LogRead, LogReadClient, LogWrite, LogWriteClient};
+use kernel::hil::time::{Alarm, AlarmClient};
+use kernel::static_init;
+use kernel::storage_volume;
+use kernel::ReturnCode;
+use nrf52840::{
+    gpio::{GPIOPin, Pin},
+    nvmc::{NrfPage, Nvmc},
+    rtc::Rtc,
+};
+
+// Allocate 16 KiB volume for log storage (the nano33ble page size is 4 KiB).
+storage_volume!(TEST_LOG, 16);
+
+pub unsafe fn run(
+    mux_alarm: &'static MuxAlarm<'static, Rtc>,
+    deferred_caller: &'static DynamicDeferredCall,
+    flash_controller: &'static Nvmc,
+) {
+    // Set up flash controller.
+    flash_controller.configure_writeable();
+    flash_controller.configure_eraseable();
+    let pagebuffer = static_init!(NrfPage, NrfPage::default());
+
+    // Create actual log storage abstraction on top of flash.
+    let log = static_init!(
+        Log,
+        log::Log::new(
+            &TEST_LOG,
+            &flash_controller,
+            pagebuffer,
+            deferred_caller,
+            true
+        )
+    );
+    flash::HasClient::set_client(flash_controller, log);
+    log.initialize_callback_handle(
+        deferred_caller
+            .register(log)
+            .expect("no deferred call slot available for log storage"),
+    );
+
+    // Create and run test for log storage.
+    let test = static_init!(
+        LogTest<VirtualMuxAlarm<'static, Rtc>>,
+        LogTest::new(log, &mut BUFFER, VirtualMuxAlarm::new(mux_alarm), &TEST_OPS)
+    );
+    log.set_read_client(test);
+    log.set_append_client(test);
+    test.alarm.set_alarm_client(test);
+
+    // Configure GPIO pin P1.08 as the log erase pin.
+    let log_erase_pin = GPIOPin::new(Pin::P0_08);
+    log_erase_pin.enable_interrupts(InterruptEdge::RisingEdge);
+    log_erase_pin.set_client(test);
+
+    test.wait();
+}
+
+static TEST_OPS: [TestOp; 24] = [
+    // Read back any existing entries.
+    TestOp::BadRead,
+    TestOp::Read,
+    // Write multiple pages, but don't fill log.
+    TestOp::BadWrite,
+    TestOp::Write,
+    TestOp::Read,
+    TestOp::BadWrite,
+    TestOp::Write,
+    TestOp::Read,
+    // Seek to beginning and re-verify entire log.
+    TestOp::SeekBeginning,
+    TestOp::Read,
+    // Write multiple pages, over-filling log and overwriting oldest entries.
+    TestOp::SeekBeginning,
+    TestOp::Write,
+    // Read offset should be incremented since it was invalidated by previous write.
+    TestOp::BadRead,
+    TestOp::Read,
+    // Write multiple pages and sync. Read offset should be invalidated due to sync clobbering
+    // previous read offset.
+    TestOp::Write,
+    TestOp::Sync,
+    TestOp::Read,
+    // Try bad seeks, should fail and not change read entry ID.
+    TestOp::Write,
+    TestOp::BadSeek(0),
+    TestOp::BadSeek(core::usize::MAX),
+    TestOp::Read,
+    // Try bad write, nothing should change.
+    TestOp::BadWrite,
+    TestOp::Read,
+    // Sync log before finishing test so that all changes persist for next test iteration.
+    TestOp::Sync,
+];
+
+// Buffer for reading from and writing to in the log tests.
+static mut BUFFER: [u8; 8] = [0; 8];
+// Length of buffer to actually use.
+const BUFFER_LEN: usize = 8;
+// Amount to shift value before adding to magic in order to fit in buffer.
+const VALUE_SHIFT: usize = 8 * (8 - BUFFER_LEN);
+// Dummy buffer for testing bad writes.
+static mut DUMMY_BUFFER: [u8; 4160] = [0; 4160];
+// Time to wait in between log operations.
+const WAIT_MS: u32 = 10;
+// Magic number to write to log storage (+ offset).
+const MAGIC: u64 = 0x0102030405060708;
+// Number of entries to write per write operation.
+const ENTRIES_PER_WRITE: u64 = 120;
+
+// Test's current state.
+#[derive(Clone, Copy, PartialEq)]
+enum TestState {
+    Operate, // Running through test operations.
+    Erase,   // Erasing log and restarting test.
+    CleanUp, // Cleaning up test after all operations complete.
+}
+
+// A single operation within the test.
+#[derive(Clone, Copy, PartialEq, Debug)]
+enum TestOp {
+    Read,
+    BadRead,
+    Write,
+    BadWrite,
+    Sync,
+    SeekBeginning,
+    BadSeek(usize),
+}
+
+type Log = log::Log<'static, Nvmc>;
+
+struct LogTest<A: Alarm<'static>> {
+    log: &'static Log,
+    buffer: TakeCell<'static, [u8]>,
+    alarm: A,
+    state: Cell<TestState>,
+    ops: &'static [TestOp],
+    op_index: Cell<usize>,
+    op_start: Cell<bool>,
+    read_val: Cell<u64>,
+    write_val: Cell<u64>,
+}
+
+impl<A: Alarm<'static>> LogTest<A> {
+    fn new(
+        log: &'static Log,
+        buffer: &'static mut [u8],
+        alarm: A,
+        ops: &'static [TestOp],
+    ) -> LogTest<A> {
+        // Recover test state.
+        let read_val = entry_id_to_test_value(log.next_read_entry_id());
+        let write_val = entry_id_to_test_value(log.log_end());
+
+        debug!(
+            "Log recovered (Start & end entry IDs: {:?} & {:?}; read & write values: {} & {})",
+            log.next_read_entry_id(),
+            log.log_end(),
+            read_val,
+            write_val
+        );
+
+        LogTest {
+            log,
+            buffer: TakeCell::new(buffer),
+            alarm,
+            state: Cell::new(TestState::Operate),
+            ops,
+            op_index: Cell::new(0),
+            op_start: Cell::new(true),
+            read_val: Cell::new(read_val),
+            write_val: Cell::new(write_val),
+        }
+    }
+
+    fn run(&self) {
+        match self.state.get() {
+            TestState::Operate => {
+                let op_index = self.op_index.get();
+                if op_index == self.ops.len() {
+                    self.state.set(TestState::CleanUp);
+                    self.log.seek(self.log.log_start());
+                    return;
+                }
+
+                match self.ops[op_index] {
+                    TestOp::Read => self.read(),
+                    TestOp::BadRead => self.bad_read(),
+                    TestOp::Write => self.write(),
+                    TestOp::BadWrite => self.bad_write(),
+                    TestOp::Sync => self.sync(),
+                    TestOp::SeekBeginning => self.seek_beginning(),
+                    TestOp::BadSeek(entry_id) => self.bad_seek(entry_id),
+                }
+            }
+            TestState::Erase => self.erase(),
+            TestState::CleanUp => {
+                debug!(
+                    "Success! Final start & end entry IDs: {:?} & {:?})",
+                    self.log.next_read_entry_id(),
+                    self.log.log_end()
+                );
+            }
+        }
+    }
+
+    fn next_op(&self) {
+        self.op_index.increment();
+        self.op_start.set(true);
+    }
+
+    fn erase(&self) {
+        match self.log.erase() {
+            ReturnCode::SUCCESS => (),
+            ReturnCode::EBUSY => {
+                self.wait();
+            }
+            _ => panic!("Couldn't erase log!"),
+        }
+    }
+
+    fn read(&self) {
+        // Update read value if clobbered by previous operation.
+        if self.op_start.get() {
+            let next_read_val = entry_id_to_test_value(self.log.next_read_entry_id());
+            if self.read_val.get() < next_read_val {
+                debug!(
+                    "Increasing read value from {} to {} due to clobbering (read entry ID is {:?})!",
+                    self.read_val.get(),
+                    next_read_val,
+                    self.log.next_read_entry_id()
+                );
+                self.read_val.set(next_read_val);
+            }
+        }
+
+        self.buffer.take().map_or_else(
+            || panic!("NO BUFFER"),
+            move |buffer| {
+                // Clear buffer first to make debugging more sane.
+                buffer.clone_from_slice(&0u64.to_be_bytes());
+
+                if let Err((error, original_buffer)) = self.log.read(buffer, BUFFER_LEN) {
+                    self.buffer
+                        .replace(original_buffer.expect("No buffer returned in error!"));
+                    match error {
+                        ReturnCode::FAIL => {
+                            // No more entries, start writing again.
+                            debug!(
+                                "READ DONE: READ OFFSET: {:?} / WRITE OFFSET: {:?}",
+                                self.log.next_read_entry_id(),
+                                self.log.log_end()
+                            );
+                            self.next_op();
+                            self.run();
+                        }
+                        ReturnCode::EBUSY => {
+                            debug!("Flash busy, waiting before reattempting read");
+                            self.wait();
+                        }
+                        _ => panic!("READ #{} FAILED: {:?}", self.read_val.get(), error),
+                    }
+                }
+            },
+        );
+    }
+
+    fn bad_read(&self) {
+        // Ensure failure if buffer is smaller than provided max read length.
+        self.buffer
+            .take()
+            .map(
+                move |buffer| match self.log.read(buffer, buffer.len() + 1) {
+                    Ok(_) => panic!("Read with too-large max read length succeeded unexpectedly!"),
+                    Err((error, original_buffer)) => {
+                        self.buffer
+                            .replace(original_buffer.expect("No buffer returned in error!"));
+                        assert_eq!(error, ReturnCode::EINVAL);
+                    }
+                },
+            )
+            .unwrap();
+
+        // Ensure failure if buffer is too small to hold entry.
+        self.buffer
+            .take()
+            .map(move |buffer| match self.log.read(buffer, BUFFER_LEN - 1) {
+                Ok(_) => panic!("Read with too-small buffer succeeded unexpectedly!"),
+                Err((error, original_buffer)) => {
+                    self.buffer
+                        .replace(original_buffer.expect("No buffer returned in error!"));
+                    if self.read_val.get() == self.write_val.get() {
+                        assert_eq!(error, ReturnCode::FAIL);
+                    } else {
+                        assert_eq!(error, ReturnCode::ESIZE);
+                    }
+                }
+            })
+            .unwrap();
+
+        self.next_op();
+        self.run();
+    }
+
+    fn write(&self) {
+        self.buffer
+            .take()
+            .map(move |buffer| {
+                buffer.clone_from_slice(
+                    &(MAGIC + (self.write_val.get() << VALUE_SHIFT)).to_be_bytes(),
+                );
+                if let Err((error, original_buffer)) = self.log.append(buffer, BUFFER_LEN) {
+                    self.buffer
+                        .replace(original_buffer.expect("No buffer returned in error!"));
+
+                    match error {
+                        ReturnCode::EBUSY => self.wait(),
+                        _ => panic!("WRITE FAILED: {:?}", error),
+                    }
+                }
+            })
+            .unwrap();
+    }
+
+    fn bad_write(&self) {
+        let original_offset = self.log.log_end();
+
+        // Ensure failure if entry length is 0.
+        self.buffer
+            .take()
+            .map(move |buffer| match self.log.append(buffer, 0) {
+                Ok(_) => panic!("Appending entry of size 0 succeeded unexpectedly!"),
+                Err((error, original_buffer)) => {
+                    self.buffer
+                        .replace(original_buffer.expect("No buffer returned in error!"));
+                    assert_eq!(error, ReturnCode::EINVAL);
+                }
+            })
+            .unwrap();
+
+        // Ensure failure if proposed entry length is greater than buffer length.
+        self.buffer
+            .take()
+            .map(
+                move |buffer| match self.log.append(buffer, buffer.len() + 1) {
+                    Ok(_) => panic!("Appending with too-small buffer succeeded unexpectedly!"),
+                    Err((error, original_buffer)) => {
+                        self.buffer
+                            .replace(original_buffer.expect("No buffer returned in error!"));
+                        assert_eq!(error, ReturnCode::EINVAL);
+                    }
+                },
+            )
+            .unwrap();
+
+        // Ensure failure if entry is too large to fit within a single flash page.
+        unsafe {
+            match self.log.append(&mut DUMMY_BUFFER, DUMMY_BUFFER.len()) {
+                Ok(_) => panic!("Appending with too-small buffer succeeded unexpectedly!"),
+                Err((error, _original_buffer)) => assert_eq!(error, ReturnCode::ESIZE),
+            }
+        }
+
+        // Make sure that append offset was not changed by failed writes.
+        assert_eq!(original_offset, self.log.log_end());
+        self.next_op();
+        self.run();
+    }
+
+    fn sync(&self) {
+        match self.log.sync() {
+            ReturnCode::SUCCESS => (),
+            error => panic!("Sync failed: {:?}", error),
+        }
+    }
+
+    fn seek_beginning(&self) {
+        let entry_id = self.log.log_start();
+        match self.log.seek(entry_id) {
+            ReturnCode::SUCCESS => debug!("Seeking to {:?}...", entry_id),
+            error => panic!("Seek failed: {:?}", error),
+        }
+    }
+
+    fn bad_seek(&self, entry_id: usize) {
+        // Make sure seek fails with EINVAL.
+        let original_offset = self.log.next_read_entry_id();
+        match self.log.seek(entry_id) {
+            ReturnCode::EINVAL => (),
+            ReturnCode::SUCCESS => panic!(
+                "Seek to invalid entry ID {:?} succeeded unexpectedly!",
+                entry_id
+            ),
+            error => panic!(
+                "Seek to invalid entry ID {:?} failed with unexpected error {:?}!",
+                entry_id, error
+            ),
+        }
+
+        // Make sure that read offset was not changed by failed seek.
+        assert_eq!(original_offset, self.log.next_read_entry_id());
+        self.next_op();
+        self.run();
+    }
+
+    fn wait(&self) {
+        let delay = A::ticks_from_ms(WAIT_MS);
+        let now = self.alarm.now();
+        self.alarm.set_alarm(now, delay);
+    }
+}
+
+impl<A: Alarm<'static>> LogReadClient for LogTest<A> {
+    fn read_done(&self, buffer: &'static mut [u8], length: usize, error: ReturnCode) {
+        match error {
+            ReturnCode::SUCCESS => {
+                // Verify correct number of bytes were read.
+                if length != BUFFER_LEN {
+                    panic!(
+                        "{} bytes read, expected {} on read number {} (offset {:?}). Value read was {:?}",
+                        length,
+                        BUFFER_LEN,
+                        self.read_val.get(),
+                        self.log.next_read_entry_id(),
+                        &buffer[0..length],
+                    );
+                }
+
+                // Verify correct value was read.
+                let expected = (MAGIC + (self.read_val.get() << VALUE_SHIFT)).to_be_bytes();
+                for i in 0..BUFFER_LEN {
+                    if buffer[i] != expected[i] {
+                        panic!(
+                            "Expected {:?}, read {:?} on read number {} (offset {:?})",
+                            &expected[0..BUFFER_LEN],
+                            &buffer[0..BUFFER_LEN],
+                            self.read_val.get(),
+                            self.log.next_read_entry_id(),
+                        );
+                    }
+                }
+
+                self.buffer.replace(buffer);
+                self.read_val.set(self.read_val.get() + 1);
+                self.op_start.set(false);
+                self.wait();
+            }
+            _ => {
+                panic!("Read failed unexpectedly!");
+            }
+        }
+    }
+
+    fn seek_done(&self, error: ReturnCode) {
+        if error == ReturnCode::SUCCESS {
+            debug!("Seeked");
+            self.read_val
+                .set(entry_id_to_test_value(self.log.next_read_entry_id()));
+        } else {
+            panic!("Seek failed: {:?}", error);
+        }
+
+        if self.state.get() == TestState::Operate {
+            self.next_op();
+        }
+        self.run();
+    }
+}
+
+impl<A: Alarm<'static>> LogWriteClient for LogTest<A> {
+    fn append_done(
+        &self,
+        buffer: &'static mut [u8],
+        length: usize,
+        records_lost: bool,
+        error: ReturnCode,
+    ) {
+        self.buffer.replace(buffer);
+        self.op_start.set(false);
+
+        match error {
+            ReturnCode::SUCCESS => {
+                if length != BUFFER_LEN {
+                    panic!(
+                        "Appended {} bytes, expected {} (write #{}, offset {:?})!",
+                        length,
+                        BUFFER_LEN,
+                        self.write_val.get(),
+                        self.log.log_end()
+                    );
+                }
+                let expected_records_lost =
+                    self.write_val.get() > entry_id_to_test_value(TEST_LOG.len());
+                if records_lost && records_lost != expected_records_lost {
+                    panic!("Append callback states records_lost = {}, expected {} (write #{}, offset {:?})!",
+                           records_lost,
+                           expected_records_lost,
+                           self.write_val.get(),
+                           self.log.log_end()
+                    );
+                }
+
+                // Stop writing after `ENTRIES_PER_WRITE` entries have been written.
+                if (self.write_val.get() + 1) % ENTRIES_PER_WRITE == 0 {
+                    debug!(
+                        "WRITE DONE: READ OFFSET: {:?} / WRITE OFFSET: {:?}",
+                        self.log.next_read_entry_id(),
+                        self.log.log_end()
+                    );
+                    self.next_op();
+                }
+
+                self.write_val.set(self.write_val.get() + 1);
+            }
+            ReturnCode::FAIL => {
+                assert_eq!(length, 0);
+                assert!(!records_lost);
+                debug!("Append failed due to flash error, retrying...");
+            }
+            error => panic!("UNEXPECTED APPEND FAILURE: {:?}", error),
+        }
+
+        self.wait();
+    }
+
+    fn sync_done(&self, error: ReturnCode) {
+        if error == ReturnCode::SUCCESS {
+            debug!(
+                "SYNC DONE: READ OFFSET: {:?} / WRITE OFFSET: {:?}",
+                self.log.next_read_entry_id(),
+                self.log.log_end()
+            );
+        } else {
+            panic!("Sync failed: {:?}", error);
+        }
+
+        self.next_op();
+        self.run();
+    }
+
+    fn erase_done(&self, error: ReturnCode) {
+        match error {
+            ReturnCode::SUCCESS => {
+                // Reset test state.
+                self.op_index.set(0);
+                self.op_start.set(true);
+                self.read_val.set(0);
+                self.write_val.set(0);
+
+                // Make sure that flash has been erased.
+                for i in 0..TEST_LOG.len() {
+                    if TEST_LOG[i] != 0xFF {
+                        panic!(
+                            "Log not properly erased, read {} at byte {}. SUMMARY: {:?}",
+                            TEST_LOG[i],
+                            i,
+                            &TEST_LOG[i..i + 8]
+                        );
+                    }
+                }
+
+                // Make sure that a read on an empty log fails normally.
+                self.buffer.take().map(move |buffer| {
+                    if let Err((error, original_buffer)) = self.log.read(buffer, BUFFER_LEN) {
+                        self.buffer
+                            .replace(original_buffer.expect("No buffer returned in error!"));
+                        match error {
+                            ReturnCode::FAIL => (),
+                            ReturnCode::EBUSY => {
+                                self.wait();
+                            }
+                            _ => panic!("Read on empty log did not fail as expected: {:?}", error),
+                        }
+                    } else {
+                        panic!("Read on empty log succeeded! (it shouldn't)");
+                    }
+                });
+
+                // Move to next operation.
+                debug!("Log Storage erased");
+                self.state.set(TestState::Operate);
+                self.run();
+            }
+            ReturnCode::EBUSY => {
+                // Flash busy, try again.
+                self.wait();
+            }
+            _ => {
+                panic!("Erase failed: {:?}", error);
+            }
+        }
+    }
+}
+
+impl<A: Alarm<'static>> AlarmClient for LogTest<A> {
+    fn alarm(&self) {
+        self.run();
+    }
+}
+
+impl<A: Alarm<'static>> gpio::Client for LogTest<A> {
+    fn fired(&self) {
+        // Erase log.
+        self.state.set(TestState::Erase);
+        self.erase();
+    }
+}
+
+fn entry_id_to_test_value(entry_id: usize) -> u64 {
+    // Page and entry header sizes for log storage.
+    const PAGE_SIZE: usize = 512;
+
+    let pages_written = entry_id / PAGE_SIZE;
+    let entry_size = log::ENTRY_HEADER_SIZE + BUFFER_LEN;
+    let entries_per_page = (PAGE_SIZE - log::PAGE_HEADER_SIZE) / entry_size;
+    let entries_lRtc_page = if entry_id % PAGE_SIZE >= log::PAGE_HEADER_SIZE {
+        (entry_id % PAGE_SIZE - log::PAGE_HEADER_SIZE) / entry_size
+    } else {
+        0
+    };
+    (pages_written * entries_per_page + entries_lRtc_page) as u64
+}

--- a/boards/nano33ble/src/test/log_test.rs
+++ b/boards/nano33ble/src/test/log_test.rs
@@ -7,8 +7,8 @@
 //! behaves as expected. The tests perform both valid and invalid operations to fully test the log's
 //! behavior.
 //!
-//! Pressing the `USER` button on the imix at any time during the test will erase the log and reset
-//! the test state. Pressing the `RESET` button will reboot the imix without erasing the log,
+//! Shorting the `P1.08` button on the nano33ble at any time during the test will erase the log and reset
+//! the test state. Pressing the `RESET` button will reboot the nano33ble without erasing the log,
 //! allowing for testing logs across reboots.
 //!
 //! In order to fully test the log, the tester should try a variety of erases and reboots to ensure
@@ -18,11 +18,15 @@
 //! scenarios (e.g. saturating/not saturating log pages with data, always/not always ending
 //! operations at page boundaries, etc.).
 //!
-//! To run the test, add the following line to the imix boot sequence:
+//! To run the test, uncomment the following line to the nano33ble boot sequence:
 //! ```
-//!     test::log_test::run(mux_alarm, dynamic_deferred_caller, &peripherals.flash_controller);
+//! test::log_test::run(
+//!     mux_alarm,
+//!     dynamic_deferred_caller,
+//!     &nrf52840_peripherals.nrf52.nvmc,
+//! );
 //! ```
-//! and use the `USER` and `RESET` buttons to manually erase the log and reboot the imix,
+//! and use the `USER` and `RESET` buttons to manually erase the log and reboot the nano33ble,
 //! respectively.
 
 use capsules::log;

--- a/boards/nano33ble/src/test/log_test.rs
+++ b/boards/nano33ble/src/test/log_test.rs
@@ -89,7 +89,7 @@ pub unsafe fn run(
     test.alarm.set_alarm_client(test);
 
     // Configure GPIO pin P1.08 as the log erase pin.
-    let log_erase_pin = GPIOPin::new(Pin::P0_08);
+    let log_erase_pin = GPIOPin::new(Pin::P1_08);
     log_erase_pin.enable_interrupts(InterruptEdge::RisingEdge);
     log_erase_pin.set_client(test);
 

--- a/boards/nano33ble/src/test/log_test.rs
+++ b/boards/nano33ble/src/test/log_test.rs
@@ -654,10 +654,10 @@ fn entry_id_to_test_value(entry_id: usize) -> u64 {
     let pages_written = entry_id / PAGE_SIZE;
     let entry_size = log::ENTRY_HEADER_SIZE + BUFFER_LEN;
     let entries_per_page = (PAGE_SIZE - log::PAGE_HEADER_SIZE) / entry_size;
-    let entries_lRtc_page = if entry_id % PAGE_SIZE >= log::PAGE_HEADER_SIZE {
+    let entries_lrtc_page = if entry_id % PAGE_SIZE >= log::PAGE_HEADER_SIZE {
         (entry_id % PAGE_SIZE - log::PAGE_HEADER_SIZE) / entry_size
     } else {
         0
     };
-    (pages_written * entries_per_page + entries_lRtc_page) as u64
+    (pages_written * entries_per_page + entries_lrtc_page) as u64
 }

--- a/boards/nano33ble/src/test/log_test.rs
+++ b/boards/nano33ble/src/test/log_test.rs
@@ -649,7 +649,7 @@ impl<A: Alarm<'static>> gpio::Client for LogTest<A> {
 
 fn entry_id_to_test_value(entry_id: usize) -> u64 {
     // Page and entry header sizes for log storage.
-    const PAGE_SIZE: usize = 512;
+    const PAGE_SIZE: usize = 4096;
 
     let pages_written = entry_id / PAGE_SIZE;
     let entry_size = log::ENTRY_HEADER_SIZE + BUFFER_LEN;

--- a/boards/nano33ble/src/test/mod.rs
+++ b/boards/nano33ble/src/test/mod.rs
@@ -1,1 +1,2 @@
 pub(crate) mod linear_log_test;
+pub(crate) mod log_test;

--- a/boards/nano33ble/src/test/mod.rs
+++ b/boards/nano33ble/src/test/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod linear_log_test;


### PR DESCRIPTION
### Pull Request Overview

I ported the persistent log tests (`linear_log_test.rs` and `log_test.rs`) from the imix to the nano33ble so that all the tests can be in place before we virtualize the log. This way, it'll hopefully be easier to test the correctness of the log virtualization.

### Testing Strategy

1. Compile and flash the kernel.
2. Retrieve debug output tockloader.
3. Manually verify that the debug output is as expected.

The debug output of `linear_log_test.rs` can be found [here](https://gist.github.com/kevtan/1b862aa166906dd3fe5189c5b5b0d215) and the debug output of `log_test.rs` can be found [here](https://gist.github.com/kevtan/78d9a567028369ee4a050895e92d4a4a).

### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
