### PR TITLE
arch/cortex-m: change more llvm_asm! to asm!

### DIFF
--- a/arch/cortex-m/src/lib.rs
+++ b/arch/cortex-m/src/lib.rs
@@ -395,6 +395,7 @@ unsafe fn kernel_hardfault_arm_v7m(faulting_stack: *mut u32) {
 #[naked]
 pub unsafe extern "C" fn hard_fault_handler_arm_v7m() {
     let faulting_stack: *mut u32;
+    // Variable `kernel_stack` stores a boolean value.
     let kernel_stack: u32;
 
     // First need to determine if this a kernel fault or a userspace fault.
@@ -417,6 +418,8 @@ pub unsafe extern "C" fn hard_fault_handler_arm_v7m() {
         // had any trouble stacking important registers to the stack during the
         // fault. If so, then we cannot use this stack while handling this fault
         // or we will trigger another fault.
+
+        // Variable `stack_overflow` stores a boolean value.
         let stack_overflow: u32;
         asm!(
             "ldr   r2, =0xE000ED29  /* SCB BFSR register address */",

--- a/arch/cortex-m/src/scb.rs
+++ b/arch/cortex-m/src/scb.rs
@@ -300,8 +300,7 @@ pub unsafe fn disable_fpca() {
     SCB.cpacr
         .modify(CoprocessorAccessControl::CP10::CLEAR + CoprocessorAccessControl::CP11::CLEAR);
 
-    llvm_asm!("dsb");
-    llvm_asm!("isb");
+    asm!("dsb", "isb");
 
     if SCB.cpacr.read(CoprocessorAccessControl::CP10) != 0
         || SCB.cpacr.read(CoprocessorAccessControl::CP11) != 0

--- a/arch/cortex-m/src/scb.rs
+++ b/arch/cortex-m/src/scb.rs
@@ -300,7 +300,7 @@ pub unsafe fn disable_fpca() {
     SCB.cpacr
         .modify(CoprocessorAccessControl::CP10::CLEAR + CoprocessorAccessControl::CP11::CLEAR);
 
-    asm!("dsb", "isb");
+    asm!("dsb", "isb", options(nomem, nostack, preserves_flags));
 
     if SCB.cpacr.read(CoprocessorAccessControl::CP10) != 0
         || SCB.cpacr.read(CoprocessorAccessControl::CP11) != 0

--- a/arch/cortex-m/src/support.rs
+++ b/arch/cortex-m/src/support.rs
@@ -22,12 +22,12 @@ where
     F: FnOnce() -> R,
 {
     // Set PRIMASK
-    llvm_asm!("cpsid i" :::: "volatile");
+    asm!("cpsid i", options(nomem, nostack));
 
     let res = f();
 
     // Unset PRIMASK
-    llvm_asm!("cpsie i" :::: "volatile");
+    asm!("cpsie i", options(nomem, nostack));
     return res;
 }
 


### PR DESCRIPTION
### Pull Request Overview

This PR changes 7 invocations of `llvm_asm!` to `asm!`.
Like #2092, this PR intends to make progress towards finishing #1923 .
I made the changes after reading through the [inline-asm RFC](https://github.com/Amanieu/rfcs/blob/inline-asm/text/0000-inline-asm.md#rules) .

#### A couple of notes on the changes
*  The first two `llvm_asm!` calls with `cc` clobbers are translated to `asm!` calls that don't explicitly state `cc` clobbers.
    In `asm!`, `cc` clobbers are assumed by default. (Option `preserve_flags` can be used when `cc` clobbers don't happen)
    * reference: [Rust Zulip chat stream 'project-inline-asm'](https://rust-lang.zulipchat.com/#narrow/stream/216763-project-inline-asm/topic/Moving.20forward.20with.20the.20RFC/near/185306638)
* `volatile` is assumed by default in `asm!`, so explicit `volatile` keywords were removed.
   (Option `pure` can be used to get rid of the `volatile` semantics)
   * reference: [Link to Q&A on `volatile` from Rust Zulip chat](https://rust-lang.zulipchat.com/#narrow/stream/216763-project-inline-asm/topic/volatile.20question/near/208320361)
*  `asm!` disallows use of `bool` variables as outputs. I replaced the output `bool` variables with `u32` variables.
```shell
   error: cannot use value of type `bool` for inline assembly
   --> arch/cortex-m/src/lib.rs:409:19
    |
409 |         out("r1") kernel_stack,
    |                   ^^^^^^^^^^^^
    |
    = note: only integers, floats, SIMD vectors, pointers and function pointers can be used as arguments for inline assembly
```

### Testing Strategy
I tested this PR by building the kernel and flashing to a `Hail` board with a blinky app.
Didn't see any erroneous behavior when pressing the reset button...

### TODO or Help Wanted
I somewhat naively replaced `bool` variables with `u32` variables.
Would it be better to replace the `bool` variables with `usize` instead?

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.

### Thank you for reviewing this PR :crab: 