### PR TITLE
Adafruit CLUE enabled BLE and 15.4

### DIFF
--- a/boards/clue_nrf52840/README.md
+++ b/boards/clue_nrf52840/README.md
@@ -35,11 +35,7 @@ twice in rapid succession. You should see the red LED pulse on and off.
 At this point you should be able to simply run `make program` in this directory
 to install a fresh kernel.
 
-```
-$ make program
-```
-
-You may need to specify the port like so:
+You will need to specify the port like so:
 
 ```
 $ make program PORT=<serial port path>
@@ -58,6 +54,22 @@ $ make
 This previous step will create a TAB (`.tab` file) that normally tockloader
 would use to program on the board. However, tockloader is currently not
 supported.
+
+Modify the `APP` variable in the `Makefile` to point towards the TBF file.
+
+```makefile
+APP=../../../libtock-c/examples/screen/build/cortex-m4/cortex-m4.tbf
+
+```
+
+At this point you should be able to simply run `make program-apps` in this directory
+to install a fresh kernel with the app(s).
+
+You will need to specify the port like so:
+
+```
+$ make program-apps PORT=<serial port path>
+```
 
 ### Userspace Resource Mapping
 

--- a/boards/clue_nrf52840/layout.ld
+++ b/boards/clue_nrf52840/layout.ld
@@ -1,8 +1,14 @@
 MEMORY
 {
-  # Make space for the UF2 bootloader
-  rom (rx)  : ORIGIN = 0x00026000, LENGTH = 192K
-  prog (rx) : ORIGIN = 0x00056000, LENGTH = 640K
+  # Make space for the UF2 bootloader (152K)
+  rom (rx)  : ORIGIN = 0x00026000, LENGTH = 360K
+  prog (rx) : ORIGIN = 0x00080000, LENGTH = 512K
+
+  # if you need more space for apps, this configuration works
+  # but there might be some MPU issues
+  # rom (rx)  : ORIGIN = 0x00026000, LENGTH = 256K
+  # prog (rx) : ORIGIN = 0x00066000, LENGTH = 616K
+
   ram (rwx) : ORIGIN = 0x20006000, LENGTH = 232K
 }
 

--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -55,6 +55,9 @@ const I2C_SCL_PIN: Pin = Pin::P0_25;
 /// Interrupt pin for the APDS9960 sensor.
 const APDS9960_PIN: Pin = Pin::P0_09;
 
+/// Personal Area Network ID for the IEEE 802.15.4 radio
+const PAN_ID: u16 = 0xABCD;
+
 /// TFT ST7789H2
 const ST7789H2_SCK: Pin = Pin::P0_14;
 const ST7789H2_MOSI: Pin = Pin::P0_15;
@@ -95,12 +98,12 @@ pub static mut STACK_MEMORY: [u8; 0x1000] = [0; 0x1000];
 
 /// Supported drivers by the platform
 pub struct Platform {
-    // ble_radio: &'static capsules::ble_advertising_driver::BLE<
-    //     'static,
-    //     nrf52::ble_radio::Radio,
-    //     VirtualMuxAlarm<'static, Rtc<'static>>,
-    // >,
-    // ieee802154_radio: &'static capsules::ieee802154::RadioDriver<'static>,
+    ble_radio: &'static capsules::ble_advertising_driver::BLE<
+        'static,
+        nrf52::ble_radio::Radio<'static>,
+        capsules::virtual_alarm::VirtualMuxAlarm<'static, nrf52::rtc::Rtc<'static>>,
+    >,
+    ieee802154_radio: &'static capsules::ieee802154::RadioDriver<'static>,
     console: &'static capsules::console::Console<'static>,
     proximity: &'static capsules::proximity::ProximitySensor<'static>,
     gpio: &'static capsules::gpio::GPIO<'static, nrf52::gpio::GPIOPin<'static>>,
@@ -130,8 +133,8 @@ impl kernel::Platform for Platform {
             capsules::button::DRIVER_NUM => f(Some(self.button)),
             capsules::screen::DRIVER_NUM => f(Some(self.screen)),
             capsules::rng::DRIVER_NUM => f(Some(self.rng)),
-            // capsules::ble_advertising_driver::DRIVER_NUM => f(Some(self.ble_radio)),
-            // capsules::ieee802154::DRIVER_NUM => f(Some(radio)),
+            capsules::ble_advertising_driver::DRIVER_NUM => f(Some(self.ble_radio)),
+            capsules::ieee802154::DRIVER_NUM => f(Some(self.ieee802154_radio)),
             kernel::ipc::DRIVER_NUM => f(Some(&self.ipc)),
             _ => f(None),
         }
@@ -405,16 +408,25 @@ pub unsafe fn reset_handler() {
     // WIRELESS
     //--------------------------------------------------------------------------
 
-    // let ble_radio =
-    //     BLEComponent::new(board_kernel, &base_peripherals.ble_radio, mux_alarm).finalize(());
+    let ble_radio =
+        nrf52_components::BLEComponent::new(board_kernel, &base_peripherals.ble_radio, mux_alarm)
+            .finalize(());
 
-    // let (ieee802154_radio, _) = Ieee802154Component::new(
-    //     board_kernel,
-    //     &base_peripherals.ieee802154_radio,
-    //     PAN_ID,
-    //     SRC_MAC,
-    // )
-    // .finalize(());
+    let serial_num = nrf52840::ficr::FICR_INSTANCE.address();
+
+    let serial_num_bottom_16 = u16::from_le_bytes([serial_num[0], serial_num[1]]);
+
+    let (ieee802154_radio, _mux_mac) = components::ieee802154::Ieee802154Component::new(
+        board_kernel,
+        &base_peripherals.ieee802154_radio,
+        &base_peripherals.ecb,
+        PAN_ID,
+        serial_num_bottom_16,
+    )
+    .finalize(components::ieee802154_component_helper!(
+        nrf52840::ieee802154_radio::Radio,
+        nrf52840::aes::AesECB<'static>
+    ));
 
     //--------------------------------------------------------------------------
     // FINAL SETUP AND BOARD BOOT
@@ -425,8 +437,8 @@ pub unsafe fn reset_handler() {
     nrf52_components::NrfClockComponent::new().finalize(());
 
     let platform = Platform {
-        // ble_radio: ble_radio,
-        // ieee802154_radio: ieee802154_radio,
+        ble_radio: ble_radio,
+        ieee802154_radio: ieee802154_radio,
         console: console,
         proximity: proximity,
         led: led,


### PR DESCRIPTION
### Pull Request Overview

This pull request adds BLE and 15.4 to Adafruit CLUE. It is same as #2216, but for Adafruit CLUE.
### Testing Strategy

This pull request was tested using `ble_advertising` and `ble_passive_scanning`, `radio_rx` and `radio_tx` using two CLUE boards sending messages to each other.

The memory layout file is modified to better suit the MPU requirements.

### TODO or Help Wanted

N/A

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
