### PR TITLE
kernel: Fix potential unsoundness in dynamic grant allocation

### DIFF
--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -112,7 +112,7 @@ mod tbfheader;
 
 pub use crate::callback::{AppId, Callback};
 pub use crate::driver::Driver;
-pub use crate::grant::Grant;
+pub use crate::grant::{DynamicGrant, Grant};
 pub use crate::mem::{AppSlice, Private, Shared};
 pub use crate::platform::scheduler_timer::{SchedulerTimer, VirtualSchedulerTimer};
 pub use crate::platform::watchdog;


### PR DESCRIPTION
### Pull Request Overview

This is a rebase of the original PR: https://github.com/tock/tock/pull/2052

In the original code, dynamic grant allocation directly returns
`Owned`. This is problematic, as if a capsule stores these Owned values
outside of another app-specific grant, then it could keep it around
after the app has crashed/restarted, and then access deallocated
memory.

This fixes that by instead returning a new `DynamicGrant` type, which
requires an `enter` call to access.

Signed-off-by: David Ross <David.Ross@wdc.com>
Signed-off-by: Alistair Francis <alistair.francis@wdc.com>

### Testing Strategy

CI

### TODO or Help Wanted

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
