### PR TITLE
Makefile: Don't require root permissions to install npm modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,7 @@ tools/qemu/build
 
 # Python scripts
 __pycache__
+
+# Node.js modules
+node_modules
+package-lock.json

--- a/Makefile
+++ b/Makefile
@@ -334,20 +334,20 @@ ci-job-clippy:
 
 define ci_setup_markdown_toc
 	$(call banner,CI-Setup: Install markdown-toc)
-	npm install -g markdown-toc
+	npm install markdown-toc
 endef
 
 .PHONY: ci-setup-markdown-toc
 ci-setup-markdown-toc:
 	$(call ci_setup_helper,\
-		command -v markdown-toc,\
-		npm install -g markdown-toc,\
+		PATH="node_modules/.bin:${PATH}" command -v markdown-toc,\
+		npm install markdown-toc,\
 		ci_setup_markdown_toc,\
 		CI_JOB_MARKDOWN)
 
 define ci_job_markdown_toc
 	$(call banner,CI-Job: Markdown Table of Contents Validation)
-	@CI=true tools/toc.sh
+	@CI=true PATH="node_modules/.bin:${PATH}" tools/toc.sh
 endef
 
 .PHONY: ci-job-markdown-toc

--- a/tools/toc.sh
+++ b/tools/toc.sh
@@ -11,7 +11,7 @@
 let ERROR=0
 
 # Find all markdown files
-for f in $(find * -name "*.md"); do
+for f in $(find . -path ./node_modules -prune -false -o -name "*.md"); do
 
 	# Only use ones that include a table of contents
 	grep '<!-- toc -->' $f > /dev/null


### PR DESCRIPTION
### Pull Request Overview

Removes the requirement for root permissions when running the CI.

### Testing Strategy

Running CI.

### TODO or Help Wanted

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
