### PR TITLE
nano33ble: increase .rom section, add process console 

### DIFF
--- a/boards/nano33ble/README.md
+++ b/boards/nano33ble/README.md
@@ -69,11 +69,11 @@ blink app, first press the button on the board twice in rapid succession to
 enter the bootloader, and then:
 
 ```
-$ bossac -i -e -o 0x20000 -w build/cortex-m4/cortex-m4.tbf -R
+$ bossac -i -e -o 0x40000 -w build/cortex-m4/cortex-m4.tbf -R
 ```
 
 That tells the BOSSA tool to flash the application in the Tock Binary Format to
-the correct offset (the app will end up at address 0x30000). You may also need
+the correct offset (the app will end up at address 0x50000). You may also need
 to pass the `--port` flag.
 
 ### Userspace Resource Mapping

--- a/boards/nano33ble/layout.ld
+++ b/boards/nano33ble/layout.ld
@@ -1,7 +1,7 @@
 MEMORY
 {
-  rom (rx)  : ORIGIN = 0x00010000, LENGTH = 128K
-  prog (rx) : ORIGIN = 0x00030000, LENGTH = 832K
+  rom (rx)  : ORIGIN = 0x00010000, LENGTH = 256K
+  prog (rx) : ORIGIN = 0x00050000, LENGTH = 704K
   ram (rwx) : ORIGIN = 0x20000000, LENGTH = 256K
 }
 


### PR DESCRIPTION
### Pull Request Overview

This pull request increases the size of the .rom section from 128 kB to 256 kB for the nano33ble, and adds the process console to the board. The size change was necessary to fit the process console code. As an aside, the size change is also necessary to use the rubble stack in #2233.

Notably, the command for flashing apps changes because apps are now located at a different address. If, like me, you had an alias for flashing apps, you will need to update it.


### Testing Strategy

Ran the process console alongside blink and hello_loop and tried out various commands.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the README with the new flash address

### Formatting

- [x] Ran `make prepush`.
