### PR TITLE
Fix make alldoc / rustdoc builds

### DIFF
--- a/boards/components/src/hmac.rs
+++ b/boards/components/src/hmac.rs
@@ -20,7 +20,6 @@
 //!        lowrisc::hmac::Hmac,
 //!        [u8; 32]
 //!    ));
-//! ));
 //! ```
 
 use capsules;

--- a/capsules/src/bus.rs
+++ b/capsules/src/bus.rs
@@ -8,7 +8,6 @@
 //! ```rust
 //! let bus = components::bus::I2CMasterBusComponent::new(i2c_mux, address)
 //!     .finalize(components::spi_bus_component_helper!());
-//! ));
 //! ```
 //!
 //! SPI example


### PR DESCRIPTION
### Pull Request Overview
This fixes invalid Rust syntax in some documentation tests.

### Testing Strategy
This pull request was tested by running `make alldoc`.

### TODO or Help Wanted
N/A

### Documentation Updated
- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting
- [x] Ran `make prepush`.

Pinging someone (@ppannuto) with experience with and access to Netlify.
