### PR TITLE
MSP432: Misc platform fixes

### DIFF
--- a/boards/msp_exp432p401r/src/main.rs
+++ b/boards/msp_exp432p401r/src/main.rs
@@ -13,6 +13,7 @@ use kernel::capabilities;
 use kernel::common::dynamic_deferred_call::DynamicDeferredCall;
 use kernel::common::dynamic_deferred_call::DynamicDeferredCallClientState;
 use kernel::component::Component;
+use kernel::hil::gpio::Configure;
 use kernel::Platform;
 use kernel::{create_capability, debug, static_init};
 
@@ -167,10 +168,17 @@ pub unsafe fn reset_handler() {
     // Setup the clocks: MCLK: 48MHz, HSMCLK: 12MHz, SMCLK: 1.5MHz, ACLK: 32.768kHz
     peripherals.cs.setup_clocks();
 
+    // Setup the debug GPIOs
+    let dbg_gpio0 = &peripherals.gpio.int_pins[msp432::gpio::IntPinNr::P01_0 as usize];
+    let dbg_gpio1 = &peripherals.gpio.int_pins[msp432::gpio::IntPinNr::P03_5 as usize];
+    let dbg_gpio2 = &peripherals.gpio.int_pins[msp432::gpio::IntPinNr::P03_7 as usize];
+    dbg_gpio0.make_output();
+    dbg_gpio1.make_output();
+    dbg_gpio2.make_output();
     debug::assign_gpios(
-        Some(&peripherals.gpio.int_pins[msp432::gpio::IntPinNr::P01_0 as usize]), // Red LED
-        Some(&peripherals.gpio.int_pins[msp432::gpio::IntPinNr::P03_5 as usize]),
-        Some(&peripherals.gpio.int_pins[msp432::gpio::IntPinNr::P03_7 as usize]),
+        Some(dbg_gpio0), // Red LED
+        Some(dbg_gpio1),
+        Some(dbg_gpio2),
     );
 
     // Setup pins for UART0

--- a/chips/msp432/src/adc.rs
+++ b/chips/msp432/src/adc.rs
@@ -852,7 +852,7 @@ impl hil::adc::Adc for Adc<'_> {
         self.stop();
         if mode == AdcMode::Highspeed {
             self.dma.map(|dma| {
-                let (_tx1, rx1, _tx2, rx2) = dma.stop();
+                let (_nr_bytes, _tx1, rx1, _tx2, rx2) = dma.stop();
 
                 if let Some(buffer) = rx1 {
                     let buf = unsafe { buf_u8_to_buf_u16(buffer) };

--- a/chips/msp432/src/gpio.rs
+++ b/chips/msp432/src/gpio.rs
@@ -472,11 +472,15 @@ macro_rules! pin_implementation {
             }
 
             fn make_output(&self) -> gpio::Configuration {
+                use gpio::Output;
                 self.enable_module_function(ModuleFunction::Gpio);
 
                 let mut val = self.registers.dir[self.reg_idx].get();
                 val |= 1 << self.pin;
                 self.registers.dir[self.reg_idx].set(val);
+
+                // Clear the output since the state of an output is undefined after a reset
+                self.clear();
                 gpio::Configuration::Output
             }
 

--- a/chips/msp432/src/wdt.rs
+++ b/chips/msp432/src/wdt.rs
@@ -105,9 +105,9 @@ impl Wdt {
 
 impl kernel::watchdog::WatchDog for Wdt {
     fn setup(&self) {
-        // The clock-source of the watchdog is the SMCLK which runs at 750kHz. We configure a
-        // prescaler of 2^15 which results in a watchdog interval of approximately 44ms ->
-        // 2^15 / 750_000Hz = 32768 / 750_000 = 0.04369s
+        // The clock-source of the watchdog is the SMCLK which runs at 1.5MHz. We configure a
+        // prescaler of 2^15 which results in a watchdog interval of approximately 22ms ->
+        // 2^15 / 1_500_000Hz = 32768 / 1_500_000 = 0.02184s
 
         // According to the datasheet p. 759 section 17.2.3 it's necessary to disable the watchdog
         // before setting it up and it's also necessary to set the WDTCNTCL bit within the same


### PR DESCRIPTION
### Pull Request Overview

This PR adds a couple of fixes for the MSP432 platform:
- [x] Correct a comment within the watchdog driver where time calculation was wrong/deprecated
- [x] Set the level of a GPIO to low after it was configured to an output. This is necessary, since this state is undefined after a reset.
- [x] Configure the debug GPIOs as outputs, otherwise they unusable.
- [x] Implement the `transmit/receive_abort()` functions of the UART driver. In order to make them work, the `stop()` function of the DMA had to be modified in a way that it returns the number of already transferred bytes. 

### Testing Strategy

Tested on the evaluation board. The `receive_abort()` function was tested with the console_timeout example

### TODO or Help Wanted

-

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
