### PR TITLE
reorder `make prepush` commands to avoid clippy bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,8 +198,8 @@ ci-nosetup:
 .PHONY: prepush
 prepush:\
 	format\
-	ci-job-syntax\
-	ci-job-clippy
+	ci-job-clippy\
+	ci-job-syntax
 	$(call banner,Pre-Push checks all passed!)
 	# Note: Tock runs additional and more intense CI checks on all PRs.
 	# If one of these error, you can run `make ci-job-NAME` to test locally.


### PR DESCRIPTION
### Pull Request Overview

Because of this bug: https://github.com/rust-lang/rust-clippy/issues/4612 , sometimes `make clean && make prepush` will fail to catch clippy errors that `make clean && make clippy` will catch. In the meantime, it helps to make sure that `cargo clippy` is called before any other `cargo` command that actually compiles the workspace.

### Testing Strategy

This pull request was tested by running `make prepush` on tock-2.0-dev, which had a clippy error that did not surface with the previous ordering.


### TODO or Help Wanted

N/A

### Documentation Updated

- [x] No updates are required.

### Formatting

- [x] Ran `make prepush`.
