### PR TITLE
Update analog comparator to tock 2.0 syscalls

### DIFF
--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -165,7 +165,7 @@ impl kernel::Platform for Imix {
             capsules::adc::DRIVER_NUM => f(Some(Err(self.adc))),
             capsules::led::DRIVER_NUM => f(Some(Ok(self.led))),
             capsules::button::DRIVER_NUM => f(Some(Err(self.button))),
-            capsules::analog_comparator::DRIVER_NUM => f(Some(Err(self.analog_comparator))),
+            capsules::analog_comparator::DRIVER_NUM => f(Some(Ok(self.analog_comparator))),
             capsules::ambient_light::DRIVER_NUM => f(Some(Err(self.ambient_light))),
             capsules::temperature::DRIVER_NUM => f(Some(Ok(self.temp))),
             capsules::humidity::DRIVER_NUM => f(Some(Ok(self.humidity))),

--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -113,7 +113,7 @@ impl kernel::Platform for Platform {
             capsules::ble_advertising_driver::DRIVER_NUM => f(Some(Err(self.ble_radio))),
             capsules::ieee802154::DRIVER_NUM => f(Some(Err(self.ieee802154_radio))),
             capsules::temperature::DRIVER_NUM => f(Some(Ok(self.temp))),
-            capsules::analog_comparator::DRIVER_NUM => f(Some(Err(self.analog_comparator))),
+            capsules::analog_comparator::DRIVER_NUM => f(Some(Ok(self.analog_comparator))),
             kernel::ipc::DRIVER_NUM => f(Some(Err(&self.ipc))),
             _ => f(None),
         }

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -190,7 +190,7 @@ impl kernel::Platform for Platform {
             capsules::ble_advertising_driver::DRIVER_NUM => f(Some(Err(self.ble_radio))),
             capsules::ieee802154::DRIVER_NUM => f(Some(Err(self.ieee802154_radio))),
             capsules::temperature::DRIVER_NUM => f(Some(Ok(self.temp))),
-            capsules::analog_comparator::DRIVER_NUM => f(Some(Err(self.analog_comparator))),
+            capsules::analog_comparator::DRIVER_NUM => f(Some(Ok(self.analog_comparator))),
             capsules::nonvolatile_storage_driver::DRIVER_NUM => {
                 f(Some(Err(self.nonvolatile_storage)))
             }

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -173,7 +173,7 @@ impl kernel::Platform for Platform {
             capsules::rng::DRIVER_NUM => f(Some(Err(self.rng))),
             capsules::ble_advertising_driver::DRIVER_NUM => f(Some(Err(self.ble_radio))),
             capsules::temperature::DRIVER_NUM => f(Some(Ok(self.temp))),
-            capsules::analog_comparator::DRIVER_NUM => f(Some(Err(self.analog_comparator))),
+            capsules::analog_comparator::DRIVER_NUM => f(Some(Ok(self.analog_comparator))),
             kernel::ipc::DRIVER_NUM => f(Some(Err(&self.ipc))),
             _ => f(None),
         }

--- a/kernel/src/driver.rs
+++ b/kernel/src/driver.rs
@@ -75,7 +75,6 @@ use crate::mem::legacy::{AppSlice, SharedReadWrite};
 use crate::mem::{ReadOnlyAppSlice, ReadWriteAppSlice};
 use crate::returncode::ReturnCode;
 use crate::syscall::GenericSyscallReturnValue;
-use core::convert::TryFrom;
 
 /// Possible return values of a `command` driver method
 ///
@@ -159,16 +158,6 @@ impl From<ReturnCode> for CommandResult {
                 panic!("SuccessWithValue is deprecated");
             } //TODO: delete before Tock 2.0
             _ => CommandResult::failure(ErrorCode::try_from(rc).unwrap()),
-        }
-    }
-}
-
-impl From<ReturnCode> for CommandResult {
-    fn from(rc: ReturnCode) -> Self {
-        match rc {
-            ReturnCode::SuccessWithValue { value } => Self::success_u32(value as u32),
-            ReturnCode::SUCCESS => Self::success(),
-            _ => Self::failure(ErrorCode::try_from(rc).unwrap()),
         }
     }
 }

--- a/kernel/src/driver.rs
+++ b/kernel/src/driver.rs
@@ -75,6 +75,7 @@ use crate::mem::legacy::{AppSlice, SharedReadWrite};
 use crate::mem::{ReadOnlyAppSlice, ReadWriteAppSlice};
 use crate::returncode::ReturnCode;
 use crate::syscall::GenericSyscallReturnValue;
+use core::convert::TryFrom;
 
 /// Possible return values of a `command` driver method
 ///
@@ -158,6 +159,16 @@ impl From<ReturnCode> for CommandResult {
                 panic!("SuccessWithValue is deprecated");
             } //TODO: delete before Tock 2.0
             _ => CommandResult::failure(ErrorCode::try_from(rc).unwrap()),
+        }
+    }
+}
+
+impl From<ReturnCode> for CommandResult {
+    fn from(rc: ReturnCode) -> Self {
+        match rc {
+            ReturnCode::SuccessWithValue { value } => Self::success_u32(value as u32),
+            ReturnCode::SUCCESS => Self::success(),
+            _ => Self::failure(ErrorCode::try_from(rc).unwrap()),
         }
     }
 }


### PR DESCRIPTION
### Pull Request Overview

This pull request ~~adds a helper function for converting `ReturnCode` to `CommandResult`, and~~ updates the analog comparator to use the Tock 2.0 system calls.

~~Note the somewhat unusual approach to swapping the passed callback, which I elaborate on in #2235.~~

### Testing Strategy

This pull request was tested by flashing the analog comparator test app on the `tock-2.0-dev` branch of `libtock-c`.


### TODO or Help Wanted

N/A

### Documentation Updated

- [x] No updates are required.

### Formatting

- [x] Ran `make prepush`.
