### PR TITLE
hil: Flash: Add blocking flash operations

### DIFF
--- a/kernel/src/hil/flash.rs
+++ b/kernel/src/hil/flash.rs
@@ -71,6 +71,7 @@
 //! }
 //! ```
 
+use crate::common::leasable_buffer::LeasableBuffer;
 use crate::returncode::ReturnCode;
 
 pub trait HasClient<'a, C> {
@@ -84,16 +85,36 @@ pub trait Flash<const S: usize> {
     /// Read a page of flash into the buffer.
     ///
     /// This function will read the flash page specified by `page_number`
-    /// at an offset of `offset` and store it in the buffer `buf`.
+    /// and store it in the buffer `buf`.
     ///
     /// On success returns nothing
     /// On failure returns a `ReturnCode` and the buffer passed in.
     fn read_page(
         &self,
         page_number: usize,
-        offset: usize,
         buf: &'static mut [u8; S],
     ) -> Result<(), (ReturnCode, &'static mut [u8; S])>;
+
+    /// Read an address of flash into the buffer.
+    ///
+    /// This function will read data stored in flash at `address` and
+    /// `length` into the buffer `buf`.
+    ///
+    /// Not all implementations support this, in that case `read_page`
+    /// should be used instead.
+    ///
+    /// On success returns nothing
+    /// On failure returns a `ReturnCode` and the buffer passed in.
+    #[allow(unused_variables)]
+    fn read_slice(
+        &self,
+        address: usize,
+        length: usize,
+        buf: LeasableBuffer<'static, u8>,
+    ) -> Result<(), (ReturnCode, &'static mut [u8])> {
+        /* Default to not supported as not all flash controller allow this */
+        Err((ReturnCode::ENOSUPPORT, buf.take()))
+    }
 
     /// Write a page of flash from the buffer.
     ///

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -85,7 +85,13 @@
 //!    this use case. It is likely we will have to create new interfaces as new
 //!    use cases are discovered.
 
-#![feature(core_intrinsics, const_fn, associated_type_defaults, try_trait)]
+#![feature(
+    core_intrinsics,
+    const_fn,
+    associated_type_defaults,
+    try_trait,
+    min_const_generics
+)]
 #![warn(unreachable_pub)]
 #![no_std]
 


### PR DESCRIPTION
### Pull Request Overview

This PR builds on top of: https://github.com/tock/tock/pull/2248

This should address most issues raised in: https://github.com/tock/tock/issues/1459

Most flash chips require a blocking write/erase to the flash bank that is being executed from. In this case the CPU will stop executing as it is also trying to read instructions from the same flash and is unable to do both at the same time. Some chips will helpfully just halt CPU execution, which makes this easy with a DMA engine. Others are more complex and will require code in RAM to perform the operation.

In this case Tock's async model falls apart as doing an async operation will either stall the CPU or in some cases can result in a broken state. For example, what happens if an interrupt occurs during the write process?

This PR adds blocking HIL flash operations. The idea is that a driver can return an error via the async calls and then the user can fallback to the blocking calls. Implementations can then have their own blocking implementation.

#### Documentation

The STM series ([Datasheet, section 2.5, page 11](https://www.st.com/resource/ja/programming_manual/cd00233952-stm32f205-215-stm32f207-217-flash-programming-manual-stmicroelectronics.pdf)) of chips will result in a bus stall on all flash reads while an erase or write is occuring. "This means that code or data fetches cannot be performed while a write/erase operation is ongoing."

The Apollo3 ([Datasheet, section 3.10.0, page 164](https://ambiq.com/wp-content/uploads/2020/10/Apollo3-Blue-MCU-Datasheet.pdf)) says: "When  erase  orprogramming operations are active, instructions cannot be fetched for execution from the Flash memory,so the on-chip SRAM would have to be used for code execution"

The nRF ([Datasheet, section 11.1, page 28](https://infocenter.nordicsemi.com/pdf/nRF52840_OPS_v0.5.pdf)) will "The CPU is halted if the CPU executescode from the flash while the NVMC is writing to the flash."

### Testing Strategy

None

### TODO or Help Wanted

The actual implementation.

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
