### PR TITLE
Add information about erasing apps

### DIFF
--- a/boards/nano33ble/README.md
+++ b/boards/nano33ble/README.md
@@ -73,8 +73,23 @@ $ bossac -i -e -o 0x40000 -w build/cortex-m4/cortex-m4.tbf -R
 ```
 
 That tells the BOSSA tool to flash the application in the Tock Binary Format to
-the correct offset (the app will end up at address 0x50000). You may also need
-to pass the `--port` flag.
+the correct offset (the app will actually end up at address 0x50000 because
+offsets are specified with respect to the end of the bootloader at address
+0x10000). You may also need to pass the `--port` flag.
+
+To unload or remove the flashed application from the board, first double-press
+the reset button to enter the bootloader (just like with flashing applications)
+and then run the following:
+
+```
+$ dd if=/dev/zero bs=1 count=104 | tr "\000" "\377" > /tmp/foo
+$ bossac -i -e -o 0x40000 -w /tmp/foo -R
+```
+
+This creates a temporary file `/tmp/foo` with size 104 (the size of a version 2
+TBF header) of all ones and then overwrites the existing TBF header of the
+application with this temporary file. We do this because the native erase option
+does not appear to be working.
 
 ### Userspace Resource Mapping
 


### PR DESCRIPTION
### Pull Request Overview

- Explanatory comment about why the app is located at `0x50000` even when the offset was `0x40000`.
- Shell command for erasing applications.

### Testing Strategy

1. Load the `number_guess_game` application.
2. Unload the `number_guess_game`.
3. Use the process console to tell whether the application was present or not.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
