### PR TITLE
Updating temperature driver to 2.0.

### DIFF
--- a/boards/acd52832/src/main.rs
+++ b/boards/acd52832/src/main.rs
@@ -98,7 +98,7 @@ impl kernel::Platform for Platform {
             capsules::button::DRIVER_NUM => f(Some(Err(self.button))),
             capsules::rng::DRIVER_NUM => f(Some(Err(self.rng))),
             capsules::ble_advertising_driver::DRIVER_NUM => f(Some(Err(self.ble_radio))),
-            capsules::temperature::DRIVER_NUM => f(Some(Err(self.temp))),
+            capsules::temperature::DRIVER_NUM => f(Some(Ok(self.temp))),
             capsules::gpio_async::DRIVER_NUM => f(Some(Err(self.gpio_async))),
             capsules::ambient_light::DRIVER_NUM => f(Some(Err(self.light))),
             capsules::buzzer_driver::DRIVER_NUM => f(Some(Err(self.buzzer))),

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -94,7 +94,7 @@ impl Platform for Hail {
             capsules::led::DRIVER_NUM => f(Some(Ok(self.led))),
             capsules::button::DRIVER_NUM => f(Some(Err(self.button))),
             capsules::humidity::DRIVER_NUM => f(Some(Ok(self.humidity))),
-            capsules::temperature::DRIVER_NUM => f(Some(Err(self.temp))),
+            capsules::temperature::DRIVER_NUM => f(Some(Ok(self.temp))),
             capsules::ninedof::DRIVER_NUM => f(Some(Err(self.ninedof))),
 
             capsules::rng::DRIVER_NUM => f(Some(Err(self.rng))),

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -167,7 +167,7 @@ impl kernel::Platform for Imix {
             capsules::button::DRIVER_NUM => f(Some(Err(self.button))),
             capsules::analog_comparator::DRIVER_NUM => f(Some(Err(self.analog_comparator))),
             capsules::ambient_light::DRIVER_NUM => f(Some(Err(self.ambient_light))),
-            capsules::temperature::DRIVER_NUM => f(Some(Err(self.temp))),
+            capsules::temperature::DRIVER_NUM => f(Some(Ok(self.temp))),
             capsules::humidity::DRIVER_NUM => f(Some(Ok(self.humidity))),
             capsules::ninedof::DRIVER_NUM => f(Some(Err(self.ninedof))),
             capsules::crc::DRIVER_NUM => f(Some(Err(self.crc))),

--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -112,7 +112,7 @@ impl kernel::Platform for Platform {
             capsules::rng::DRIVER_NUM => f(Some(Err(self.rng))),
             capsules::ble_advertising_driver::DRIVER_NUM => f(Some(Err(self.ble_radio))),
             capsules::ieee802154::DRIVER_NUM => f(Some(Err(self.ieee802154_radio))),
-            capsules::temperature::DRIVER_NUM => f(Some(Err(self.temp))),
+            capsules::temperature::DRIVER_NUM => f(Some(Ok(self.temp))),
             capsules::analog_comparator::DRIVER_NUM => f(Some(Err(self.analog_comparator))),
             kernel::ipc::DRIVER_NUM => f(Some(Err(&self.ipc))),
             _ => f(None),

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -189,7 +189,7 @@ impl kernel::Platform for Platform {
             capsules::rng::DRIVER_NUM => f(Some(Err(self.rng))),
             capsules::ble_advertising_driver::DRIVER_NUM => f(Some(Err(self.ble_radio))),
             capsules::ieee802154::DRIVER_NUM => f(Some(Err(self.ieee802154_radio))),
-            capsules::temperature::DRIVER_NUM => f(Some(Err(self.temp))),
+            capsules::temperature::DRIVER_NUM => f(Some(Ok(self.temp))),
             capsules::analog_comparator::DRIVER_NUM => f(Some(Err(self.analog_comparator))),
             capsules::nonvolatile_storage_driver::DRIVER_NUM => {
                 f(Some(Err(self.nonvolatile_storage)))

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -172,7 +172,7 @@ impl kernel::Platform for Platform {
             capsules::button::DRIVER_NUM => f(Some(Err(self.button))),
             capsules::rng::DRIVER_NUM => f(Some(Err(self.rng))),
             capsules::ble_advertising_driver::DRIVER_NUM => f(Some(Err(self.ble_radio))),
-            capsules::temperature::DRIVER_NUM => f(Some(Err(self.temp))),
+            capsules::temperature::DRIVER_NUM => f(Some(Ok(self.temp))),
             capsules::analog_comparator::DRIVER_NUM => f(Some(Err(self.analog_comparator))),
             kernel::ipc::DRIVER_NUM => f(Some(Err(&self.ipc))),
             _ => f(None),

--- a/boards/nucleo_f429zi/src/main.rs
+++ b/boards/nucleo_f429zi/src/main.rs
@@ -76,7 +76,7 @@ impl Platform for NucleoF429ZI {
             capsules::button::DRIVER_NUM => f(Some(Err(self.button))),
             capsules::adc::DRIVER_NUM => f(Some(Err(self.adc))),
             capsules::alarm::DRIVER_NUM => f(Some(Err(self.alarm))),
-            capsules::temperature::DRIVER_NUM => f(Some(Err(self.temperature))),
+            capsules::temperature::DRIVER_NUM => f(Some(Ok(self.temperature))),
             kernel::ipc::DRIVER_NUM => f(Some(Err(&self.ipc))),
             capsules::gpio::DRIVER_NUM => f(Some(Err(self.gpio))),
             _ => f(None),

--- a/boards/stm32f3discovery/src/main.rs
+++ b/boards/stm32f3discovery/src/main.rs
@@ -88,7 +88,7 @@ impl Platform for STM32F3Discovery {
             capsules::l3gd20::DRIVER_NUM => f(Some(Err(self.l3gd20))),
             capsules::lsm303dlhc::DRIVER_NUM => f(Some(Err(self.lsm303dlhc))),
             capsules::ninedof::DRIVER_NUM => f(Some(Err(self.ninedof))),
-            capsules::temperature::DRIVER_NUM => f(Some(Err(self.temp))),
+            capsules::temperature::DRIVER_NUM => f(Some(Ok(self.temp))),
             kernel::ipc::DRIVER_NUM => f(Some(Err(&self.ipc))),
             capsules::adc::DRIVER_NUM => f(Some(Err(self.adc))),
             capsules::nonvolatile_storage_driver::DRIVER_NUM => {

--- a/boards/stm32f412gdiscovery/src/main.rs
+++ b/boards/stm32f412gdiscovery/src/main.rs
@@ -80,7 +80,7 @@ impl Platform for STM32F412GDiscovery {
             capsules::ft6x06::DRIVER_NUM => f(Some(Err(self.ft6x06))),
             capsules::touch::DRIVER_NUM => f(Some(Err(self.touch))),
             capsules::screen::DRIVER_NUM => f(Some(Err(self.screen))),
-            capsules::temperature::DRIVER_NUM => f(Some(Err(self.temperature))),
+            capsules::temperature::DRIVER_NUM => f(Some(Ok(self.temperature))),
             _ => f(None),
         }
     }

--- a/capsules/src/temperature.rs
+++ b/capsules/src/temperature.rs
@@ -53,9 +53,10 @@
 //! ```
 
 use core::cell::Cell;
+use core::convert::TryFrom;
+use core::mem;
 use kernel::hil;
-use kernel::ReturnCode;
-use kernel::{AppId, Callback, Grant, LegacyDriver};
+use kernel::{AppId, Callback, CommandResult, Driver, ErrorCode, Grant};
 
 /// Syscall driver number.
 use crate::driver;
@@ -63,7 +64,7 @@ pub const DRIVER_NUM: usize = driver::NUM::Temperature as usize;
 
 #[derive(Default)]
 pub struct App {
-    callback: Option<Callback>,
+    callback: Callback,
     subscribed: bool,
 }
 
@@ -85,27 +86,36 @@ impl<'a> TemperatureSensor<'a> {
         }
     }
 
-    fn enqueue_command(&self, appid: AppId) -> ReturnCode {
+    fn enqueue_command(&self, appid: AppId) -> CommandResult {
         self.apps
             .enter(appid, |app, _| {
                 if !self.busy.get() {
                     app.subscribed = true;
                     self.busy.set(true);
-                    self.driver.read_temperature()
+                    let rcode = self.driver.read_temperature();
+                    let eres = ErrorCode::try_from(rcode);
+                    match eres {
+                        Ok(ecode) => CommandResult::failure(ecode),
+                        _ => CommandResult::success()
+                    }
                 } else {
-                    ReturnCode::EBUSY
+                    CommandResult::failure(ErrorCode::BUSY)
                 }
             })
-            .unwrap_or_else(|err| err.into())
+            .unwrap_or_else(|err| CommandResult::failure(err.into()))
     }
 
-    fn configure_callback(&self, callback: Option<Callback>, app_id: AppId) -> ReturnCode {
-        self.apps
+    fn configure_callback(&self, mut callback: Callback, app_id: AppId) -> Result<Callback, (Callback, ErrorCode)> {
+        let res = self.apps
             .enter(app_id, |app, _| {
-                app.callback = callback;
-                ReturnCode::SUCCESS
+                mem::swap(&mut app.callback, &mut callback);
             })
-            .unwrap_or_else(|err| err.into())
+            .map_err(ErrorCode::from);
+        if let Err(e) = res {
+            Err((callback, e))
+        } else {
+            Ok(callback)
+        }
     }
 }
 
@@ -116,35 +126,35 @@ impl hil::sensors::TemperatureClient for TemperatureSensor<'_> {
                 if app.subscribed {
                     self.busy.set(false);
                     app.subscribed = false;
-                    app.callback.map(|mut cb| cb.schedule(temp_val, 0, 0));
+                    app.callback.schedule(temp_val, 0, 0);
                 }
             });
         }
     }
 }
 
-impl LegacyDriver for TemperatureSensor<'_> {
+impl Driver for TemperatureSensor<'_> {
     fn subscribe(
         &self,
         subscribe_num: usize,
-        callback: Option<Callback>,
+        callback: Callback,
         app_id: AppId,
-    ) -> ReturnCode {
+    ) -> Result<Callback, (Callback, ErrorCode)> {
         match subscribe_num {
             // subscribe to temperature reading with callback
             0 => self.configure_callback(callback, app_id),
-            _ => ReturnCode::ENOSUPPORT,
+            _ => Err((callback, ErrorCode::NOSUPPORT)),
         }
     }
 
-    fn command(&self, command_num: usize, _: usize, _: usize, appid: AppId) -> ReturnCode {
+    fn command(&self, command_num: usize, _: usize, _: usize, appid: AppId) -> CommandResult {
         match command_num {
             // check whether the driver exists!!
-            0 => ReturnCode::SUCCESS,
+            0 => CommandResult::success(),
 
             // read temperature
             1 => self.enqueue_command(appid),
-            _ => ReturnCode::ENOSUPPORT,
+            _ => CommandResult::failure(ErrorCode::NOSUPPORT),
         }
     }
 }

--- a/capsules/src/temperature.rs
+++ b/capsules/src/temperature.rs
@@ -96,7 +96,7 @@ impl<'a> TemperatureSensor<'a> {
                     let eres = ErrorCode::try_from(rcode);
                     match eres {
                         Ok(ecode) => CommandResult::failure(ecode),
-                        _ => CommandResult::success()
+                        _ => CommandResult::success(),
                     }
                 } else {
                     CommandResult::failure(ErrorCode::BUSY)
@@ -105,8 +105,13 @@ impl<'a> TemperatureSensor<'a> {
             .unwrap_or_else(|err| CommandResult::failure(err.into()))
     }
 
-    fn configure_callback(&self, mut callback: Callback, app_id: AppId) -> Result<Callback, (Callback, ErrorCode)> {
-        let res = self.apps
+    fn configure_callback(
+        &self,
+        mut callback: Callback,
+        app_id: AppId,
+    ) -> Result<Callback, (Callback, ErrorCode)> {
+        let res = self
+            .apps
             .enter(app_id, |app, _| {
                 mem::swap(&mut app.callback, &mut callback);
             })


### PR DESCRIPTION
### Pull Request Overview

This PR updates the temperature capsule to the 2.0 syscall API.


### Testing Strategy

This pull request was tested by running the imix test app and verifying it received temperature readings correctly.


### TODO or Help Wanted

Nothing.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.

Ran it, but:

```
********************************************************************************
* CI-Job: Clippy                                                               *
********************************************************************************

error: toolchain 'nightly-2020-10-25-x86_64-apple-darwin' does not contain component 'clippy' for target 'x86_64-apple-darwin'
info: downloading component 'clippy-preview'
info: installing component 'clippy-preview'
error: no such subcommand: `clippy`
make: *** [ci-job-clippy] Error 101
```
