### PR TITLE
Tock 2.0: Deprecate SuccessWithValue

### DIFF
--- a/kernel/src/driver.rs
+++ b/kernel/src/driver.rs
@@ -149,6 +149,19 @@ impl CommandResult {
     }
 }
 
+use core::convert::TryFrom;
+impl From<ReturnCode> for CommandResult {
+    fn from(rc: ReturnCode) -> Self {
+        match rc {
+            ReturnCode::SUCCESS => CommandResult::success(),
+            ReturnCode::SuccessWithValue { .. } => {
+                panic!("SuccessWithValue is deprecated");
+            } //TODO: delete before Tock 2.0
+            _ => CommandResult::failure(ErrorCode::try_from(rc).unwrap()),
+        }
+    }
+}
+
 #[allow(unused_variables)]
 pub trait Driver {
     fn subscribe(

--- a/kernel/src/returncode.rs
+++ b/kernel/src/returncode.rs
@@ -8,7 +8,7 @@
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ReturnCode {
     /// Success value must be positive
-    SuccessWithValue { value: usize },
+    SuccessWithValue { value: usize }, //TODO: Remove before Tock 2.0
     /// Operation completed successfully
     SUCCESS,
     /// Generic failure condition


### PR DESCRIPTION
### Pull Request Overview

This PR removes all uses of `ReturnCode::SuccessWithValue` aside from those contained directly within an implementation of `LegacyDriver::command()`.

It also updates the porting guide to reflect that part of porting requires removing all uses of `SuccessWithValue` when moving to Driver.

This should make it extremely easy to remove `SuccessWithValue` entirely once all capsules have been ported.

Given that `SuccessWithValue` is no longer a consideration, this PR also adds a helper function to the kernel for converting a `ReturnCode` to a `CommandResult`.

There were 5 locations outside `LegacyDriver::command()` implementations that constructed `SuccessWithValue`:

1. UDP driver. I modified this code to ensure that SuccessWithValue is only constructed within `command()`, and not in any helper functions, by replacing its use with `Result`.

2. Hd44780 capsule returned `SuccessWithValue` from `allow()`, but allow() cannot return values in the case of success in the Tock 2.0 API. I modified it to just return Success, and made the previously returned value accessible via a new command. This will require userspace updates to work, but was a necessary change irrespective of deprecating `SuccessWithValue`.

3. IPC also returns `SuccessWithValue` from `allow()` -- I did not touch this, as I am told @alevy is working on porting IPC anyway, which will inevitably remove this use.

4. Memop liberally uses `SuccessWithValue`, but all of these will naturally be replaced as part of the switch to Tock 2.0

5. The analog comparator driver constructs `SuccessWithValue` in a helper function -- this has already been removed in #2245 , so I did not duplicate it here.

### Testing Strategy

This pull request has not been tested.


### TODO or Help Wanted

This pull request still needs thoughts on the `CommandResult::from(ReturnCode)` addition, and the changes to the porting guide.


### Documentation Updated

- [x] Updated the porting doc, but other reference to SuccessWithValue may still exist

### Formatting

- [x] Ran `make prepush`.
