### PR TITLE
Spi controller 2.0

### DIFF
--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -87,7 +87,7 @@ impl Platform for Hail {
             capsules::gpio::DRIVER_NUM => f(Some(Err(self.gpio))),
 
             capsules::alarm::DRIVER_NUM => f(Some(Err(self.alarm))),
-            capsules::spi_controller::DRIVER_NUM => f(Some(Err(self.spi))),
+            capsules::spi_controller::DRIVER_NUM => f(Some(Ok(self.spi))),
             capsules::nrf51822_serialization::DRIVER_NUM => f(Some(Err(self.nrf51822))),
             capsules::ambient_light::DRIVER_NUM => f(Some(Err(self.ambient_light))),
             capsules::adc::DRIVER_NUM => f(Some(Err(self.adc))),

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -161,7 +161,7 @@ impl kernel::Platform for Imix {
             capsules::console::DRIVER_NUM => f(Some(Ok(self.console))),
             capsules::gpio::DRIVER_NUM => f(Some(Err(self.gpio))),
             capsules::alarm::DRIVER_NUM => f(Some(Err(self.alarm))),
-            capsules::spi_controller::DRIVER_NUM => f(Some(Err(self.spi))),
+            capsules::spi_controller::DRIVER_NUM => f(Some(Ok(self.spi))),
             capsules::adc::DRIVER_NUM => f(Some(Err(self.adc))),
             capsules::led::DRIVER_NUM => f(Some(Ok(self.led))),
             capsules::button::DRIVER_NUM => f(Some(Err(self.button))),

--- a/capsules/src/spi_controller.rs
+++ b/capsules/src/spi_controller.rs
@@ -8,7 +8,7 @@ use kernel::hil::spi::ClockPhase;
 use kernel::hil::spi::ClockPolarity;
 use kernel::hil::spi::{SpiMasterClient, SpiMasterDevice};
 use kernel::{AppId, Callback, CommandResult, Driver, ErrorCode};
-use kernel::{Read, ReadWrite, ReadOnlyAppSlice, ReadWriteAppSlice};
+use kernel::{Read, ReadOnlyAppSlice, ReadWrite, ReadWriteAppSlice};
 
 /// Syscall driver number.
 use crate::driver;
@@ -30,7 +30,7 @@ pub const DEFAULT_WRITE_BUF_LENGTH: usize = 1024;
 #[derive(Default)]
 struct App {
     callback: Callback,
-    app_read: ReadWriteAppSlice, 
+    app_read: ReadWriteAppSlice,
     app_write: ReadOnlyAppSlice,
     len: usize,
     index: usize,
@@ -126,7 +126,7 @@ impl<'a, S: SpiMasterDevice> Driver for Spi<'a, S> {
             _ => Err((slice, ErrorCode::NOSUPPORT)),
         }
     }
-    
+
     fn subscribe(
         &self,
         subscribe_num: usize,
@@ -140,7 +140,7 @@ impl<'a, S: SpiMasterDevice> Driver for Spi<'a, S> {
                 });
                 Ok(callback)
             }
-            _ => Err((callback, ErrorCode::NOSUPPORT))
+            _ => Err((callback, ErrorCode::NOSUPPORT)),
         }
     }
 
@@ -189,7 +189,6 @@ impl<'a, S: SpiMasterDevice> Driver for Spi<'a, S> {
                 if self.busy.get() {
                     return CommandResult::failure(ErrorCode::BUSY);
                 }
-                
                 self.app.map_or(CommandResult::failure(ErrorCode::FAIL), |app| {
                     // When we do a read/write, the read part is optional.
                     // So there are three cases:
@@ -283,14 +282,14 @@ impl<S: SpiMasterDevice> SpiMasterClient for Spi<'_, S> {
 
                     let dest_area = &mut dest[start..end];
                     let real_len = end - start;
-                    
+
                     for (i, c) in src[0..real_len].iter().enumerate() {
                         dest_area[i] = *c;
                     }
                 });
                 src
             });
-                                       
+
             self.kernel_read.put(rbuf);
             self.kernel_write.replace(writebuf);
 

--- a/capsules/src/spi_controller.rs
+++ b/capsules/src/spi_controller.rs
@@ -2,12 +2,13 @@
 //! bus.
 
 use core::cell::Cell;
-use core::cmp;
+use core::{cmp, mem};
 use kernel::common::cells::{MapCell, TakeCell};
 use kernel::hil::spi::ClockPhase;
 use kernel::hil::spi::ClockPolarity;
 use kernel::hil::spi::{SpiMasterClient, SpiMasterDevice};
-use kernel::{AppId, AppSlice, Callback, LegacyDriver, ReturnCode, SharedReadWrite};
+use kernel::{AppId, Callback, CommandResult, Driver, ErrorCode};
+use kernel::{Read, ReadWrite, ReadOnlyAppSlice, ReadWriteAppSlice};
 
 /// Syscall driver number.
 use crate::driver;
@@ -28,9 +29,9 @@ pub const DEFAULT_WRITE_BUF_LENGTH: usize = 1024;
 
 #[derive(Default)]
 struct App {
-    callback: Option<Callback>,
-    app_read: Option<AppSlice<SharedReadWrite, u8>>,
-    app_write: Option<AppSlice<SharedReadWrite, u8>>,
+    callback: Callback,
+    app_read: ReadWriteAppSlice, 
+    app_write: ReadOnlyAppSlice,
     len: usize,
     index: usize,
 }
@@ -66,66 +67,80 @@ impl<'a, S: SpiMasterDevice> Spi<'a, S> {
     // Assumes checks for busy/etc. already done
     // Updates app.index to be index + length of op
     fn do_next_read_write(&self, app: &mut App) {
-        let start = app.index;
-        let len = cmp::min(app.len - start, self.kernel_len.get());
-        let end = start + len;
-        app.index = end;
+        let write_len = self.kernel_write.map_or(0, |kwbuf| {
+            let mut start = app.index;
+            let tmp_len = app.app_write.map_or(0, |src| {
+                let len = cmp::min(app.len - start, self.kernel_len.get());
+                let end = cmp::min(start + len, src.len());
+                start = cmp::min(start, end);
 
-        self.kernel_write.map(|kwbuf| {
-            app.app_write.as_mut().map(|src| {
                 for (i, c) in src.as_ref()[start..end].iter().enumerate() {
                     kwbuf[i] = *c;
                 }
+                end - start
             });
+            app.index = start + tmp_len;
+            tmp_len
         });
         self.spi_master.read_write_bytes(
             self.kernel_write.take().unwrap(),
             self.kernel_read.take(),
-            len,
+            write_len,
         );
     }
 }
 
-impl<'a, S: SpiMasterDevice> LegacyDriver for Spi<'a, S> {
+impl<'a, S: SpiMasterDevice> Driver for Spi<'a, S> {
     fn allow_readwrite(
         &self,
         _appid: AppId,
         allow_num: usize,
-        slice: Option<AppSlice<SharedReadWrite, u8>>,
-    ) -> ReturnCode {
+        mut slice: ReadWriteAppSlice,
+    ) -> Result<ReadWriteAppSlice, (ReadWriteAppSlice, ErrorCode)> {
         match allow_num {
             // Pass in a read buffer to receive bytes into.
             0 => {
                 self.app.map(|app| {
-                    app.app_read = slice;
+                    mem::swap(&mut app.app_read, &mut slice);
                 });
-                ReturnCode::SUCCESS
+                Ok(slice)
             }
-            // Pass in a write buffer to transmit bytes from.
-            1 => {
-                self.app.map(|app| {
-                    app.app_write = slice;
-                });
-                ReturnCode::SUCCESS
-            }
-            _ => ReturnCode::ENOSUPPORT,
+            _ => Err((slice, ErrorCode::NOSUPPORT)),
         }
     }
 
+    fn allow_readonly(
+        &self,
+        _appid: AppId,
+        allow_num: usize,
+        mut slice: ReadOnlyAppSlice,
+    ) -> Result<ReadOnlyAppSlice, (ReadOnlyAppSlice, ErrorCode)> {
+        match allow_num {
+            // Pass in a write buffer to transmit bytes from.
+            0 => {
+                self.app.map(|app| {
+                    mem::swap(&mut app.app_write, &mut slice);
+                });
+                Ok(slice)
+            }
+            _ => Err((slice, ErrorCode::NOSUPPORT)),
+        }
+    }
+    
     fn subscribe(
         &self,
         subscribe_num: usize,
-        callback: Option<Callback>,
+        mut callback: Callback,
         _app_id: AppId,
-    ) -> ReturnCode {
+    ) -> Result<Callback, (Callback, ErrorCode)> {
         match subscribe_num {
-            0 /* read_write */ => {
+            0 => {
                 self.app.map(|app| {
-                    app.callback = callback;
+                    mem::swap(&mut app.callback, &mut callback);
                 });
-                ReturnCode::SUCCESS
-            },
-            _ => ReturnCode::ENOSUPPORT
+                Ok(callback)
+            }
+            _ => Err((callback, ErrorCode::NOSUPPORT))
         }
     }
 
@@ -165,73 +180,77 @@ impl<'a, S: SpiMasterDevice> LegacyDriver for Spi<'a, S> {
     // x+1: unlock spi
     //   - does nothing if lock not held
     //
-    fn command(&self, cmd_num: usize, arg1: usize, _: usize, _: AppId) -> ReturnCode {
+    fn command(&self, cmd_num: usize, arg1: usize, _: usize, _: AppId) -> CommandResult {
         match cmd_num {
-            0 /* check if present */ => ReturnCode::SUCCESS,
+            0 /* check if present */ => CommandResult::success(),
             // No longer supported, wrap inside a read_write_bytes
-            1 /* read_write_byte */ => ReturnCode::ENOSUPPORT,
+            1 /* read_write_byte */ => CommandResult::failure(ErrorCode::NOSUPPORT),
             2 /* read_write_bytes */ => {
                 if self.busy.get() {
-                    return ReturnCode::EBUSY;
+                    return CommandResult::failure(ErrorCode::BUSY);
                 }
-                self.app.map_or(ReturnCode::FAIL, |app| {
-                    let mut mlen = 0;
-                    app.app_write.as_mut().map(|w| {
-                        mlen = w.len();
-                    });
-                    app.app_read.as_mut().map(|r| {
-                        mlen = cmp::min(mlen, r.len());
-                    });
-                    if mlen >= arg1 {
+                
+                self.app.map_or(CommandResult::failure(ErrorCode::FAIL), |app| {
+                    // When we do a read/write, the read part is optional.
+                    // So there are three cases:
+                    // 1) Write and read buffers present: len is min of lengths
+                    // 2) Only write buffer present: len is len of write
+                    // 3) No write buffer present: no operation
+                    let mut mlen = app.app_write.map_or(0, |w| w.len());
+                    let rlen = app.app_read.map_or(mlen, |r| r.len());
+                    mlen = cmp::min(mlen, rlen);
+                    
+                    if mlen >= arg1 && arg1 > 0 {
                         app.len = arg1;
                         app.index = 0;
                         self.busy.set(true);
                         self.do_next_read_write(app);
-                        ReturnCode::SUCCESS
+                        CommandResult::success()
                     } else {
-                        ReturnCode::EINVAL /* write buffer too small */
+                        /* write buffer too small, or zero length write */
+                        CommandResult::failure(ErrorCode::INVAL)
                     }
                 })
             }
             3 /* set chip select */ => {
                 // XXX: TODO: do nothing, for now, until we fix interface
                 // so virtual instances can use multiple chip selects
-                ReturnCode::ENOSUPPORT
+                CommandResult::failure(ErrorCode::NOSUPPORT)
             }
             4 /* get chip select */ => {
                 // XXX: We don't really know what chip select is being used
                 // since we can't set it. Return error until set chip select
                 // works.
-                ReturnCode::ENOSUPPORT
+                CommandResult::failure(ErrorCode::NOSUPPORT)
             }
             5 /* set baud rate */ => {
                 self.spi_master.set_rate(arg1 as u32);
-                ReturnCode::SUCCESS
+                CommandResult::success()
             }
             6 /* get baud rate */ => {
-                ReturnCode::SuccessWithValue { value: self.spi_master.get_rate() as usize }
+                CommandResult::success_u32(self.spi_master.get_rate() as u32)
             }
             7 /* set phase */ => {
                 match arg1 {
                     0 => self.spi_master.set_phase(ClockPhase::SampleLeading),
                     _ => self.spi_master.set_phase(ClockPhase::SampleTrailing),
                 };
-                ReturnCode::SUCCESS
+                CommandResult::success()
             }
             8 /* get phase */ => {
-                ReturnCode::SuccessWithValue { value: self.spi_master.get_phase() as usize }
+                CommandResult::success_u32(self.spi_master.get_phase() as u32)
             }
             9 /* set polarity */ => {
                 match arg1 {
                     0 => self.spi_master.set_polarity(ClockPolarity::IdleLow),
                     _ => self.spi_master.set_polarity(ClockPolarity::IdleHigh),
                 };
-                ReturnCode::SUCCESS
+                CommandResult::success()
             }
             10 /* get polarity */ => {
-                ReturnCode::SuccessWithValue { value: self.spi_master.get_polarity() as usize }
+                CommandResult::success_u32(self.spi_master.get_polarity() as u32)
             }
-            _ => ReturnCode::ENOSUPPORT
+            _ => CommandResult::failure(ErrorCode::NOSUPPORT)
         }
     }
 }
@@ -244,28 +263,43 @@ impl<S: SpiMasterDevice> SpiMasterClient for Spi<'_, S> {
         length: usize,
     ) {
         self.app.map(move |app| {
-            if app.app_read.is_some() {
-                let src = readbuf.as_ref().unwrap();
-                let dest = app.app_read.as_mut().unwrap();
-                let start = app.index - length;
-                let end = start + length;
+            let rbuf = readbuf.map(|src| {
+                app.app_read.mut_map_or((), |dest| {
+                    // Need to be careful that app_read hasn't changed
+                    // under us, so check all values against actual
+                    // slice lengths.
+                    //
+                    // If app_read is shorter than before, and shorter
+                    // than what we have read would require, then truncate.
+                    // -pal 12/9/20
+                    let end = app.index;
+                    let start = app.index - length;
+                    let end = cmp::min(end, cmp::min(src.len(), dest.len()));
 
-                let d = &mut dest.as_mut()[start..end];
-                for (i, c) in src[0..length].iter().enumerate() {
-                    d[i] = *c;
-                }
-            }
+                    // If the new endpoint is earlier than our expected
+                    // startpoint, we set the startpoint to be the same;
+                    // This results in a zero-length operation. -pal 12/9/20
+                    let start = cmp::min(start, end);
 
-            self.kernel_read.put(readbuf);
+                    let dest_area = &mut dest[start..end];
+                    let real_len = end - start;
+                    
+                    for (i, c) in src[0..real_len].iter().enumerate() {
+                        dest_area[i] = *c;
+                    }
+                });
+                src
+            });
+                                       
+            self.kernel_read.put(rbuf);
             self.kernel_write.replace(writebuf);
 
             if app.index == app.len {
                 self.busy.set(false);
+                let len = app.len;
                 app.len = 0;
                 app.index = 0;
-                app.callback.take().map(|mut cb| {
-                    cb.schedule(app.len, 0, 0);
-                });
+                app.callback.schedule(len, 0, 0);
             } else {
                 self.do_next_read_write(app);
             }

--- a/capsules/src/spi_controller.rs
+++ b/capsules/src/spi_controller.rs
@@ -198,7 +198,7 @@ impl<'a, S: SpiMasterDevice> Driver for Spi<'a, S> {
                     let mut mlen = app.app_write.map_or(0, |w| w.len());
                     let rlen = app.app_read.map_or(mlen, |r| r.len());
                     mlen = cmp::min(mlen, rlen);
-                    
+
                     if mlen >= arg1 && arg1 > 0 {
                         app.len = arg1;
                         app.index = 0;


### PR DESCRIPTION
### Pull Request Overview

This pull request updates the SPI controller syscall capsule to use the 2.0 syscall API.


### Testing Strategy

This pull request was tested by running the `spi_buf` test in libtock-c. Which turns out it doesn't work, because the syscall driver for imix uses the same CS as the radio, so you see weird behavior. So I checked it with other configurations, using a logic analyzer.


### TODO or Help Wanted

Once we have ported things, we will likely want to start writing tests for what happens if buffers are yanked.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
