### PR TITLE
Create a debug chip layout for adequate kernel ROM

### DIFF
--- a/boards/stm32f3discovery/README.md
+++ b/boards/stm32f3discovery/README.md
@@ -7,13 +7,20 @@ website](https://www.st.com/en/evaluation-tools/stm32f3discovery.html).
 ## Flashing the kernel
 
 The kernel can be programmed using OpenOCD. `cd` into `boards/stm32f3discovery`
-directory and run:
+directory and run the following in order to flash the optimized release version
+of the kernel.
 
 ```bash
 $ make flash
+```
 
-(or)
+To flash the unoptimized debug version of the kernel, go into `layout.ld`,
+comment out `chip_layout.ld`, and uncomment `chip_layout_debug.ld`. This
+increases the size of the flash memory partition for the kernel so that
+compilation can succeed (the unoptimized debug binary is much larger than the
+optimized release one). Then, run:
 
+```bash
 $ make flash-debug
 ```
 

--- a/boards/stm32f3discovery/chip_layout_debug.ld
+++ b/boards/stm32f3discovery/chip_layout_debug.ld
@@ -1,0 +1,15 @@
+/* Memory layout for the STM32F303VCT6
+ * rom = 256KB (LENGTH = 0x00040000)
+ * kernel = 192KB
+ * user = 64KB
+ * ram = 48KB */
+
+MEMORY
+{
+  rom (rx)  : ORIGIN = 0x08000000, LENGTH = 0x00030000
+  prog (rx) : ORIGIN = 0x08030000, LENGTH = 0x00010000
+  ram (rwx) : ORIGIN = 0x20000000, LENGTH = 48K
+}
+
+MPU_MIN_ALIGN = 8K;
+PAGE_SIZE = 2K;

--- a/boards/stm32f3discovery/layout.ld
+++ b/boards/stm32f3discovery/layout.ld
@@ -1,2 +1,3 @@
 INCLUDE ./chip_layout.ld
+/* INCLUDE ./chip_layout_debug.ld */
 INCLUDE ../kernel_layout.ld


### PR DESCRIPTION
### Pull Request Overview

Create a debug linker script so that `flash-debug` works more or less out of the box. Previously, running `make flash-debug` would give you this error: https://gist.github.com/kevtan/40239f93b11393c44aec8235c2d7c2ad.

### Testing

If you uncomment the debug linker script, you don't get the issue anymore.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
