### PR TITLE
nrf52: nvmc: remove global static

### DIFF
--- a/boards/acd52832/src/main.rs
+++ b/boards/acd52832/src/main.rs
@@ -142,11 +142,11 @@ pub unsafe fn reset_handler() {
 
     // Make non-volatile memory writable and activate the reset button
     let uicr = nrf52832::uicr::Uicr::new();
-    nrf52832::nvmc::NVMC.erase_uicr();
-    nrf52832::nvmc::NVMC.configure_writeable();
-    while !nrf52832::nvmc::NVMC.is_ready() {}
+    base_peripherals.nvmc.erase_uicr();
+    base_peripherals.nvmc.configure_writeable();
+    while !base_peripherals.nvmc.is_ready() {}
     uicr.set_psel0_reset_pin(BUTTON_RST_PIN);
-    while !nrf52832::nvmc::NVMC.is_ready() {}
+    while !base_peripherals.nvmc.is_ready() {}
     uicr.set_psel1_reset_pin(BUTTON_RST_PIN);
 
     // Configure kernel debug gpios as early as possible
@@ -445,14 +445,16 @@ pub unsafe fn reset_handler() {
 
     // Start all of the clocks. Low power operation will require a better
     // approach than this.
-    nrf52832::clock::CLOCK.low_stop();
-    nrf52832::clock::CLOCK.high_stop();
+    base_peripherals.clock.low_stop();
+    base_peripherals.clock.high_stop();
 
-    nrf52832::clock::CLOCK.low_set_source(nrf52832::clock::LowClockSource::XTAL);
-    nrf52832::clock::CLOCK.low_start();
-    nrf52832::clock::CLOCK.high_start();
-    while !nrf52832::clock::CLOCK.low_started() {}
-    while !nrf52832::clock::CLOCK.high_started() {}
+    base_peripherals
+        .clock
+        .low_set_source(nrf52832::clock::LowClockSource::XTAL);
+    base_peripherals.clock.low_start();
+    base_peripherals.clock.high_start();
+    while !base_peripherals.clock.low_started() {}
+    while !base_peripherals.clock.high_started() {}
 
     let platform = Platform {
         button: button,

--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -505,7 +505,7 @@ pub unsafe fn reset_handler() {
 
     // Start all of the clocks. Low power operation will require a better
     // approach than this.
-    nrf52_components::NrfClockComponent::new().finalize(());
+    nrf52_components::NrfClockComponent::new(&base_peripherals.clock).finalize(());
 
     let platform = Platform {
         ble_radio: ble_radio,

--- a/boards/microbit_v2/src/main.rs
+++ b/boards/microbit_v2/src/main.rs
@@ -426,12 +426,12 @@ pub unsafe fn reset_handler() {
     //--------------------------------------------------------------------------
 
     // it seems that microbit v2 has no external clock
-    nrf52::clock::CLOCK.low_stop();
-    nrf52::clock::CLOCK.high_stop();
-    nrf52::clock::CLOCK.low_start();
-    nrf52::clock::CLOCK.high_start();
-    while !nrf52::clock::CLOCK.low_started() {}
-    while !nrf52::clock::CLOCK.high_started() {}
+    base_peripherals.clock.low_stop();
+    base_peripherals.clock.high_stop();
+    base_peripherals.clock.low_start();
+    base_peripherals.clock.high_start();
+    while !base_peripherals.clock.low_started() {}
+    while !base_peripherals.clock.high_started() {}
 
     let platform = Platform {
         ble_radio: ble_radio,

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -374,7 +374,7 @@ pub unsafe fn reset_handler() {
 
     // Start all of the clocks. Low power operation will require a better
     // approach than this.
-    nrf52_components::NrfClockComponent::new().finalize(());
+    nrf52_components::NrfClockComponent::new(&base_peripherals.clock).finalize(());
 
     let platform = Platform {
         ble_radio,

--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -209,6 +209,7 @@ pub unsafe fn reset_handler() {
         false,
         BUTTON_RST_PIN,
         nrf52840::uicr::Regulator0Output::V3_0,
+        &base_peripherals.nvmc,
     )
     .finalize(());
 
@@ -310,7 +311,7 @@ pub unsafe fn reset_handler() {
         nrf52840::acomp::Comparator
     ));
 
-    nrf52_components::NrfClockComponent::new().finalize(());
+    nrf52_components::NrfClockComponent::new(&base_peripherals.clock).finalize(());
 
     let platform = Platform {
         button,

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -305,6 +305,7 @@ pub unsafe fn reset_handler() {
         false,
         BUTTON_RST_PIN,
         nrf52840::uicr::Regulator0Output::DEFAULT,
+        &base_peripherals.nvmc,
     )
     .finalize(());
 
@@ -485,7 +486,7 @@ pub unsafe fn reset_handler() {
         nrf52840::acomp::Comparator
     ));
 
-    nrf52_components::NrfClockComponent::new().finalize(());
+    nrf52_components::NrfClockComponent::new(&base_peripherals.clock).finalize(());
 
     // let alarm_test_component =
     //     components::test::multi_alarm_test::MultiAlarmTestComponent::new(&mux_alarm).finalize(

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -269,6 +269,7 @@ pub unsafe fn reset_handler() {
         false,
         BUTTON_RST_PIN,
         nrf52832::uicr::Regulator0Output::DEFAULT,
+        &base_peripherals.nvmc,
     )
     .finalize(());
 
@@ -346,7 +347,7 @@ pub unsafe fn reset_handler() {
         nrf52832::acomp::Comparator
     ));
 
-    nrf52_components::NrfClockComponent::new().finalize(());
+    nrf52_components::NrfClockComponent::new(&base_peripherals.clock).finalize(());
 
     let platform = Platform {
         button,

--- a/chips/nrf52/src/chip.rs
+++ b/chips/nrf52/src/chip.rs
@@ -49,6 +49,7 @@ pub struct Nrf52DefaultPeripherals<'a> {
     pub spim2: crate::spi::SPIM,
     pub adc: crate::adc::Adc,
     pub nvmc: crate::nvmc::Nvmc,
+    pub clock: crate::clock::Clock,
 }
 
 impl<'a> Nrf52DefaultPeripherals<'a> {
@@ -74,6 +75,7 @@ impl<'a> Nrf52DefaultPeripherals<'a> {
             spim2: crate::spi::SPIM::new(2),
             adc: crate::adc::Adc::new(),
             nvmc: crate::nvmc::Nvmc::new(),
+            clock: crate::clock::Clock::new(),
         }
     }
     // Necessary for setting up circular dependencies

--- a/chips/nrf52/src/clock.rs
+++ b/chips/nrf52/src/clock.rs
@@ -160,8 +160,6 @@ pub trait ClockClient {
     fn event(&self);
 }
 
-pub static mut CLOCK: Clock = Clock::new();
-
 impl Clock {
     /// Constructor
     pub const fn new() -> Clock {

--- a/chips/nrf52/src/nvmc.rs
+++ b/chips/nrf52/src/nvmc.rs
@@ -200,8 +200,6 @@ pub enum FlashState {
     Erase, // Performing an erase operation.
 }
 
-pub static mut NVMC: Nvmc = Nvmc::new();
-
 pub struct Nvmc {
     registers: StaticRef<NvmcRegisters>,
     client: OptionalCell<&'static dyn hil::flash::Client<Nvmc>>,


### PR DESCRIPTION
### Pull Request Overview

I think that with the new static init scheme for peripherals we shouldn't have these statics anymore.

I found this when using an old capsule that uses the nvmc and the state variable was somehow changing mysteriously! Turns out I had two copies of NVMC.


### Testing Strategy

Implementing bootloader on nrf52840dk over USB.


### TODO or Help Wanted

I don't think this will compile yet. Consider this a bug report.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
