### PR TITLE
Adafruit Clue Buzzer initialization

### DIFF
--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -17,6 +17,7 @@ use kernel::hil::gpio::Interrupt;
 use kernel::hil::i2c::I2CMaster;
 use kernel::hil::led::LedHigh;
 use kernel::hil::symmetric_encryption::AES128;
+use kernel::hil::time::Alarm;
 use kernel::hil::time::Counter;
 use kernel::hil::usb::Client;
 use kernel::mpu::MPU;
@@ -277,8 +278,6 @@ pub unsafe fn reset_handler() {
     //--------------------------------------------------------------------------
     // PWM & BUZZER
     //--------------------------------------------------------------------------
-
-    use kernel::hil::time::Alarm;
 
     let mux_pwm = static_init!(
         capsules::virtual_pwm::MuxPwm<'static, nrf52840::pwm::Pwm>,

--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -35,7 +35,6 @@ const LED_WHITE_PIN: Pin = Pin::P0_10;
 const LED_KERNEL_PIN: Pin = Pin::P1_01;
 
 // Speaker
-
 const SPEAKER_PIN: Pin = Pin::P1_00;
 
 // Buttons


### PR DESCRIPTION
### Pull Request Overview

This pull request adds the buzzer initialization for the Adafruit Clue


### Testing Strategy

This pull request was tested by using Adafruit Clue


### TODO or Help Wanted

N/A


### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
