### PR TITLE
Update UDP driver to Tock 2.0 system calls

### DIFF
--- a/boards/components/src/udp_driver.rs
+++ b/boards/components/src/udp_driver.rs
@@ -36,10 +36,9 @@ use kernel::component::Component;
 use kernel::hil::time::Alarm;
 use kernel::{create_capability, static_init, static_init_half};
 
-const UDP_HDR_SIZE: usize = 8;
 const MAX_PAYLOAD_LEN: usize = super::udp_mux::MAX_PAYLOAD_LEN;
 
-static mut DRIVER_BUF: [u8; MAX_PAYLOAD_LEN - UDP_HDR_SIZE] = [0; MAX_PAYLOAD_LEN - UDP_HDR_SIZE];
+static mut DRIVER_BUF: [u8; MAX_PAYLOAD_LEN] = [0; MAX_PAYLOAD_LEN];
 
 // Setup static space for the objects.
 #[macro_export]

--- a/boards/components/src/udp_mux.rs
+++ b/boards/components/src/udp_mux.rs
@@ -60,8 +60,7 @@ static mut RADIO_BUF: [u8; radio::MAX_BUF_SIZE] = [0x00; radio::MAX_BUF_SIZE];
 static mut SIXLOWPAN_RX_BUF: [u8; 1280] = [0x00; 1280];
 
 pub const MAX_PAYLOAD_LEN: usize = 200; //The max size UDP message that can be sent by userspace apps or capsules
-const UDP_HDR_SIZE: usize = 8;
-static mut UDP_DGRAM: [u8; MAX_PAYLOAD_LEN - UDP_HDR_SIZE] = [0; MAX_PAYLOAD_LEN - UDP_HDR_SIZE];
+static mut UDP_DGRAM: [u8; MAX_PAYLOAD_LEN] = [0; MAX_PAYLOAD_LEN];
 
 // Rather than require a data structure with 65535 slots (number of UDP ports), we
 // use a structure that can hold up to 16 port bindings. Any given capsule can bind

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -173,7 +173,7 @@ impl kernel::Platform for Imix {
             capsules::crc::DRIVER_NUM => f(Some(Err(self.crc))),
             capsules::usb::usb_user::DRIVER_NUM => f(Some(Err(self.usb_driver))),
             capsules::ieee802154::DRIVER_NUM => f(Some(Err(self.radio_driver))),
-            capsules::net::udp::DRIVER_NUM => f(Some(Err(self.udp_driver))),
+            capsules::net::udp::DRIVER_NUM => f(Some(Ok(self.udp_driver))),
             capsules::nrf51822_serialization::DRIVER_NUM => f(Some(Err(self.nrf51822))),
             capsules::nonvolatile_storage_driver::DRIVER_NUM => {
                 f(Some(Err(self.nonvolatile_storage)))

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -138,7 +138,7 @@ static mut CHIP: Option<&'static nrf52840::chip::NRF52<Nrf52840DefaultPeripheral
 /// Dummy buffer that causes the linker to reserve enough space for the stack.
 #[no_mangle]
 #[link_section = ".stack_buffer"]
-pub static mut STACK_MEMORY: [u8; 0x1000] = [0; 0x1000];
+pub static mut STACK_MEMORY: [u8; 0x2000] = [0; 0x2000];
 
 /// Supported drivers by the platform
 pub struct Platform {
@@ -194,7 +194,7 @@ impl kernel::Platform for Platform {
             capsules::nonvolatile_storage_driver::DRIVER_NUM => {
                 f(Some(Err(self.nonvolatile_storage)))
             }
-            capsules::net::udp::DRIVER_NUM => f(Some(Err(self.udp_driver))),
+            capsules::net::udp::DRIVER_NUM => f(Some(Ok(self.udp_driver))),
             capsules::tock2_test::DRIVER_NUM => f(Some(Ok(self.tock2_test_driver))),
             kernel::ipc::DRIVER_NUM => f(Some(Err(&self.ipc))),
             _ => f(None),

--- a/capsules/src/net/udp/driver.rs
+++ b/capsules/src/net/udp/driver.rs
@@ -195,6 +195,9 @@ impl<'a> UDPDriver<'a> {
                 self.kernel_buffer
                     .take()
                     .map_or(ReturnCode::ENOMEM, |mut kernel_buffer| {
+                        if payload.len() > kernel_buffer.len() {
+                            return ReturnCode::ESIZE;
+                        }
                         kernel_buffer[0..payload.len()].copy_from_slice(payload.as_ref());
                         kernel_buffer.slice(0..payload.len());
                         match self.sender.driver_send_to(


### PR DESCRIPTION
### Pull Request Overview

This pull request updates the UDP driver to use Tock 2.0 system calls. It also increases the stack size on the nrf52840dk. 


### Testing Strategy

This pull request was tested by flashing an updated version of the UDP apps onto an Imix and an nrf52840dk and exchanging UDP packets between the two. The updated apps work but I noticed that when `Ok()` is returned by subscribe from the kernel the apps treat it as an unknown return value. I assume this is because the error codes still need updating in `libtock-c`.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] No updates are required.

### Formatting

- [x] Ran `make prepush`.
