### PR TITLE
VirtualSchedulerTimer: fix incorrect set_alarm invocation

### DIFF
--- a/kernel/src/platform/scheduler_timer.rs
+++ b/kernel/src/platform/scheduler_timer.rs
@@ -176,9 +176,9 @@ impl<A: 'static + time::Alarm<'static>> SchedulerTimer for VirtualSchedulerTimer
 
             (hertz * us / 1_000_000) as u32
         };
-        let now = self.alarm.now();
-        let fire_at = now.wrapping_add(A::Ticks::from(tics));
-        self.alarm.set_alarm(now, fire_at);
+
+        let reference = self.alarm.now();
+        self.alarm.set_alarm(reference, A::Ticks::from(tics));
     }
 
     fn arm(&self) {


### PR DESCRIPTION
### Pull Request Overview

This fixes a subtle bug in the `VirtualSchedulerTimer` implementation, where a call to `set_alarm` would pass in the reference, along with the future alarm time, where it should be just the delta between the reference and alarm time.

This issue manifests itself when a round-robin scheduler is used in combination with the `VirtualSchedulerTimer`. It was probably unnoticed because no such combination exists in the upstream repository.

I think calling `.set_alarm(` by passing the absolute reference timestamp, along with the relative delta, is the correct invocation method (and have implemented my `Alarm` implementation in LiteX accordingly) based on this comment:

https://github.com/tock/tock/blob/d63f97706125b59c974a9438f70b5011a55f3b48/kernel/src/hil/time.rs#L178-L186


### Testing Strategy

This pull request was tested by running on `litex_sim` (of #2203) using the round robin scheduler. The application is no longer blocked for 15+ seconds.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
