### PR TITLE
Tock 2.0 analog comparator: use `ErrorCode::From`

### DIFF
--- a/capsules/src/analog_comparator.rs
+++ b/capsules/src/analog_comparator.rs
@@ -38,7 +38,6 @@ use crate::driver;
 pub const DRIVER_NUM: usize = driver::NUM::AnalogComparator as usize;
 
 use core::cell::Cell;
-use core::convert::TryFrom;
 use kernel::hil;
 use kernel::{AppId, Callback, CommandResult, Driver, ErrorCode, ReturnCode};
 
@@ -127,15 +126,9 @@ impl<'a, A: hil::analog_comparator::AnalogComparator<'a>> Driver for AnalogCompa
                 Err(e) => CommandResult::failure(e),
             },
 
-            2 => match ErrorCode::try_from(self.start_comparing(channel)) {
-                Err(_) => CommandResult::success(),
-                Ok(e) => CommandResult::failure(e),
-            },
+            2 => self.start_comparing(channel).into(),
 
-            3 => match ErrorCode::try_from(self.stop_comparing(channel)) {
-                Err(_) => CommandResult::success(),
-                Ok(e) => CommandResult::failure(e),
-            },
+            3 => self.stop_comparing(channel).into(),
 
             _ => CommandResult::failure(ErrorCode::NOSUPPORT),
         }


### PR DESCRIPTION
### Pull Request Overview

Updates new analog comparator driver to use utilities added in #2252 .


### Testing Strategy

This pull request was tested by compiling.

### TODO or Help Wanted

N/A

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
