### PR TITLE
Update ninedof capsule to Tock 2.0 syscalls API

### DIFF
--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -95,7 +95,7 @@ impl Platform for Hail {
             capsules::button::DRIVER_NUM => f(Some(Err(self.button))),
             capsules::humidity::DRIVER_NUM => f(Some(Ok(self.humidity))),
             capsules::temperature::DRIVER_NUM => f(Some(Ok(self.temp))),
-            capsules::ninedof::DRIVER_NUM => f(Some(Err(self.ninedof))),
+            capsules::ninedof::DRIVER_NUM => f(Some(Ok(self.ninedof))),
 
             capsules::rng::DRIVER_NUM => f(Some(Err(self.rng))),
 

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -169,7 +169,7 @@ impl kernel::Platform for Imix {
             capsules::ambient_light::DRIVER_NUM => f(Some(Err(self.ambient_light))),
             capsules::temperature::DRIVER_NUM => f(Some(Ok(self.temp))),
             capsules::humidity::DRIVER_NUM => f(Some(Ok(self.humidity))),
-            capsules::ninedof::DRIVER_NUM => f(Some(Err(self.ninedof))),
+            capsules::ninedof::DRIVER_NUM => f(Some(Ok(self.ninedof))),
             capsules::crc::DRIVER_NUM => f(Some(Err(self.crc))),
             capsules::usb::usb_user::DRIVER_NUM => f(Some(Err(self.usb_driver))),
             capsules::ieee802154::DRIVER_NUM => f(Some(Err(self.radio_driver))),

--- a/boards/imxrt1050-evkb/src/main.rs
+++ b/boards/imxrt1050-evkb/src/main.rs
@@ -90,7 +90,7 @@ impl Platform for Imxrt1050EVKB {
             capsules::gpio::DRIVER_NUM => f(Some(Err(self.gpio))),
             kernel::ipc::DRIVER_NUM => f(Some(Err(&self.ipc))),
             capsules::led::DRIVER_NUM => f(Some(Ok(self.led))),
-            capsules::ninedof::DRIVER_NUM => f(Some(Err(self.ninedof))),
+            capsules::ninedof::DRIVER_NUM => f(Some(Ok(self.ninedof))),
             _ => f(None),
         }
     }

--- a/boards/stm32f3discovery/src/main.rs
+++ b/boards/stm32f3discovery/src/main.rs
@@ -87,7 +87,7 @@ impl Platform for STM32F3Discovery {
             capsules::gpio::DRIVER_NUM => f(Some(Err(self.gpio))),
             capsules::l3gd20::DRIVER_NUM => f(Some(Err(self.l3gd20))),
             capsules::lsm303dlhc::DRIVER_NUM => f(Some(Err(self.lsm303dlhc))),
-            capsules::ninedof::DRIVER_NUM => f(Some(Err(self.ninedof))),
+            capsules::ninedof::DRIVER_NUM => f(Some(Ok(self.ninedof))),
             capsules::temperature::DRIVER_NUM => f(Some(Ok(self.temp))),
             kernel::ipc::DRIVER_NUM => f(Some(Err(&self.ipc))),
             capsules::adc::DRIVER_NUM => f(Some(Err(self.adc))),

--- a/capsules/src/ninedof.rs
+++ b/capsules/src/ninedof.rs
@@ -21,8 +21,8 @@
 use core::mem;
 use kernel::common::cells::OptionalCell;
 use kernel::hil;
-use kernel::{AppId, Callback, CommandResult, Driver, ErrorCode, Grant};
 use kernel::ReturnCode;
+use kernel::{AppId, Callback, CommandResult, Driver, ErrorCode, Grant};
 
 /// Syscall driver number.
 use crate::driver;
@@ -135,9 +135,10 @@ impl<'a> NineDof<'a> {
         }
     }
 
-    fn configure_callback(&self,
-                          mut callback: Callback,
-                          app_id: AppId
+    fn configure_callback(
+        &self,
+        mut callback: Callback,
+        app_id: AppId
     ) -> Result<Callback, (Callback, ErrorCode)> {
         let res = self
             .apps

--- a/capsules/src/ninedof.rs
+++ b/capsules/src/ninedof.rs
@@ -138,7 +138,7 @@ impl<'a> NineDof<'a> {
     fn configure_callback(
         &self,
         mut callback: Callback,
-        app_id: AppId
+        app_id: AppId,
     ) -> Result<Callback, (Callback, ErrorCode)> {
         let res = self
             .apps

--- a/capsules/src/ninedof.rs
+++ b/capsules/src/ninedof.rs
@@ -18,10 +18,11 @@
 //! hil::sensors::NineDof::set_client(fxos8700, ninedof);
 //! ```
 
+use core::mem;
 use kernel::common::cells::OptionalCell;
 use kernel::hil;
+use kernel::{AppId, Callback, CommandResult, Driver, ErrorCode, Grant};
 use kernel::ReturnCode;
-use kernel::{AppId, Callback, Grant, LegacyDriver};
 
 /// Syscall driver number.
 use crate::driver;
@@ -36,7 +37,7 @@ pub enum NineDofCommand {
 }
 
 pub struct App {
-    callback: Option<Callback>,
+    callback: Callback,
     pending_command: bool,
     command: NineDofCommand,
     arg1: usize,
@@ -45,7 +46,7 @@ pub struct App {
 impl Default for App {
     fn default() -> App {
         App {
-            callback: None,
+            callback: Callback::default(),
             pending_command: false,
             command: NineDofCommand::Exists,
             arg1: 0,
@@ -71,7 +72,7 @@ impl<'a> NineDof<'a> {
     // Check so see if we are doing something. If not,
     // go ahead and do this command. If so, this is queued
     // and will be run when the pending command completes.
-    fn enqueue_command(&self, command: NineDofCommand, arg1: usize, appid: AppId) -> ReturnCode {
+    fn enqueue_command(&self, command: NineDofCommand, arg1: usize, appid: AppId) -> CommandResult {
         self.apps
             .enter(appid, |app, _| {
                 if self.current_app.is_none() {
@@ -80,19 +81,22 @@ impl<'a> NineDof<'a> {
                     if value != ReturnCode::SUCCESS {
                         self.current_app.clear();
                     }
-                    value
+                    CommandResult::from(value)
                 } else {
                     if app.pending_command == true {
-                        ReturnCode::ENOMEM
+                        CommandResult::failure(ErrorCode::BUSY)
                     } else {
                         app.pending_command = true;
                         app.command = command;
                         app.arg1 = arg1;
-                        ReturnCode::SUCCESS
+                        CommandResult::success()
                     }
                 }
             })
-            .unwrap_or_else(|err| err.into())
+            .unwrap_or_else(|err| {
+                let rcode: ReturnCode = err.into();
+                CommandResult::from(rcode)
+            })
     }
 
     fn call_driver(&self, command: NineDofCommand, _: usize) -> ReturnCode {
@@ -130,6 +134,24 @@ impl<'a> NineDof<'a> {
             _ => ReturnCode::ENOSUPPORT,
         }
     }
+
+    fn configure_callback(&self,
+                          mut callback: Callback,
+                          app_id: AppId
+    ) -> Result<Callback, (Callback, ErrorCode)> {
+        let res = self
+            .apps
+            .enter(app_id, |app, _| {
+                mem::swap(&mut app.callback, &mut callback);
+            })
+            .map_err(ErrorCode::from);
+
+        if let Err(e) = res {
+            Err((callback, e))
+        } else {
+            Ok(callback)
+        }
+    }
 }
 
 impl hil::sensors::NineDofClient for NineDof<'_> {
@@ -144,9 +166,7 @@ impl hil::sensors::NineDofClient for NineDof<'_> {
                 app.pending_command = false;
                 finished_command = app.command;
                 finished_command_arg = app.arg1;
-                app.callback.map(|mut cb| {
-                    cb.schedule(arg1, arg2, arg3);
-                });
+                app.callback.schedule(arg1, arg2, arg3);
             });
         });
 
@@ -160,9 +180,7 @@ impl hil::sensors::NineDofClient for NineDof<'_> {
                     // Don't bother re-issuing this command, just use
                     // the existing result.
                     app.pending_command = false;
-                    app.callback.map(|mut cb| {
-                        cb.schedule(arg1, arg2, arg3);
-                    });
+                    app.callback.schedule(arg1, arg2, arg3);
                     false
                 } else if app.pending_command {
                     app.pending_command = false;
@@ -179,33 +197,22 @@ impl hil::sensors::NineDofClient for NineDof<'_> {
     }
 }
 
-impl LegacyDriver for NineDof<'_> {
+impl Driver for NineDof<'_> {
     fn subscribe(
         &self,
         subscribe_num: usize,
-        callback: Option<Callback>,
+        callback: Callback,
         app_id: AppId,
-    ) -> ReturnCode {
+    ) -> Result<Callback, (Callback, ErrorCode)> {
         match subscribe_num {
-            0 => self
-                .apps
-                .enter(app_id, |app, _| {
-                    app.callback = callback;
-                    ReturnCode::SUCCESS
-                })
-                .unwrap_or_else(|err| err.into()),
-            _ => ReturnCode::ENOSUPPORT,
+            0 => self.configure_callback(callback, app_id),
+            _ => Err((callback, ErrorCode::NOSUPPORT)),
         }
     }
 
-    fn command(&self, command_num: usize, arg1: usize, _: usize, appid: AppId) -> ReturnCode {
+    fn command(&self, command_num: usize, arg1: usize, _: usize, appid: AppId) -> CommandResult {
         match command_num {
-            0 =>
-            /* This driver exists. */
-            {
-                ReturnCode::SUCCESS
-            }
-
+            0 => CommandResult::success(),
             // Single acceleration reading.
             1 => self.enqueue_command(NineDofCommand::ReadAccelerometer, arg1, appid),
 
@@ -215,7 +222,7 @@ impl LegacyDriver for NineDof<'_> {
             // Single gyroscope reading.
             200 => self.enqueue_command(NineDofCommand::ReadGyroscope, arg1, appid),
 
-            _ => ReturnCode::ENOSUPPORT,
+            _ => CommandResult::failure(ErrorCode::NOSUPPORT),
         }
     }
 }


### PR DESCRIPTION
### Pull Request Overview

This pull request updates the ninedof syscall capsule to use the Tock 2.0 system call API.


### Testing Strategy

This pull request was tested by running the imix test app and seeing it read ninedof acceleration correctly.


### TODO or Help Wanted

Nothing,


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
