### PR TITLE
nrf52: i2c: address shift update

### DIFF
--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -322,17 +322,17 @@ pub unsafe fn reset_handler() {
 
     let sensors_i2c_bus = static_init!(
         capsules::virtual_i2c::MuxI2C<'static>,
-        capsules::virtual_i2c::MuxI2C::new(&base_peripherals.twim0, None, dynamic_deferred_caller)
+        capsules::virtual_i2c::MuxI2C::new(&base_peripherals.twim1, None, dynamic_deferred_caller)
     );
-    base_peripherals.twim0.configure(
+    base_peripherals.twim1.configure(
         nrf52840::pinmux::Pinmux::new(I2C_SCL_PIN as u32),
         nrf52840::pinmux::Pinmux::new(I2C_SDA_PIN as u32),
     );
-    base_peripherals.twim0.set_master_client(sensors_i2c_bus);
+    base_peripherals.twim1.set_master_client(sensors_i2c_bus);
 
     let apds9960_i2c = static_init!(
         capsules::virtual_i2c::I2CDevice,
-        capsules::virtual_i2c::I2CDevice::new(sensors_i2c_bus, 0x39 << 1)
+        capsules::virtual_i2c::I2CDevice::new(sensors_i2c_bus, 0x39)
     );
 
     let apds9960 = static_init!(

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -312,7 +312,7 @@ pub unsafe fn reset_handler() {
 
     let apds9960_i2c = static_init!(
         capsules::virtual_i2c::I2CDevice,
-        capsules::virtual_i2c::I2CDevice::new(sensors_i2c_bus, 0x39 << 1)
+        capsules::virtual_i2c::I2CDevice::new(sensors_i2c_bus, 0x39)
     );
 
     let apds9960 = static_init!(

--- a/capsules/src/apds9960.rs
+++ b/capsules/src/apds9960.rs
@@ -16,7 +16,7 @@
 //!
 //! let apds9960_i2c = static_init!(
 //!    capsules::virtual_i2c::I2CDevice,
-//!    capsules::virtual_i2c::I2CDevice::new(sensors_i2c_bus, 0x39 << 1)
+//!    capsules::virtual_i2c::I2CDevice::new(sensors_i2c_bus, 0x39)
 //!);
 //!
 //!let apds9960 = static_init!(

--- a/chips/nrf52/src/i2c.rs
+++ b/chips/nrf52/src/i2c.rs
@@ -144,7 +144,7 @@ impl hil::i2c::I2CMaster for TWIM {
     fn write_read(&self, addr: u8, data: &'static mut [u8], write_len: u8, read_len: u8) {
         self.registers
             .address
-            .write(ADDRESS::ADDRESS.val((addr >> 1) as u32));
+            .write(ADDRESS::ADDRESS.val(addr as u32));
         self.registers.txd_ptr.set(data.as_mut_ptr());
         self.registers
             .txd_maxcnt
@@ -171,7 +171,7 @@ impl hil::i2c::I2CMaster for TWIM {
     fn write(&self, addr: u8, data: &'static mut [u8], len: u8) {
         self.registers
             .address
-            .write(ADDRESS::ADDRESS.val((addr >> 1) as u32));
+            .write(ADDRESS::ADDRESS.val(addr as u32));
         self.registers.txd_ptr.set(data.as_mut_ptr());
         self.registers
             .txd_maxcnt
@@ -192,7 +192,7 @@ impl hil::i2c::I2CMaster for TWIM {
     fn read(&self, addr: u8, buffer: &'static mut [u8], len: u8) {
         self.registers
             .address
-            .write(ADDRESS::ADDRESS.val((addr >> 1) as u32));
+            .write(ADDRESS::ADDRESS.val(addr as u32));
         self.registers.rxd_ptr.set(buffer.as_mut_ptr());
         self.registers
             .rxd_maxcnt


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes the I2C address argument format (#2256) for the nRF52 chips. Addresses had to be shifted (<< 1) before passed as argument just to be shifted back (>> 1) when used. This prevented the usage of components for I2C capsules due to the address argument format.

### Testing Strategy

This pull request was tested using an Adafruit CLUE nRF52840 board.

### TODO or Help Wanted

N/A

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
