### PR TITLE
chips: nrf52: add gpregret setter/getter

### DIFF
--- a/chips/nrf52/src/power.rs
+++ b/chips/nrf52/src/power.rs
@@ -342,4 +342,25 @@ impl<'a> Power<'a> {
     pub fn is_usb_power_ready(&self) -> bool {
         self.registers.usbregstatus.is_set(UsbRegStatus::OUTPUTRDY)
     }
+
+    /// Return the contents of the GPREGRET (general purpose retention register)
+    /// register.
+    ///
+    /// This register is a "retention" register because it preserves its state
+    /// across a soft reset.
+    ///
+    /// This is used to set a flag before a reset to instruct the bootloader to
+    /// stay in the bootloader mode.
+    pub fn get_gpregret(&self) -> u32 {
+        self.registers.gpregret.get()
+    }
+
+    /// Set the value of the GPREGRET (general purpose retention register)
+    /// register.
+    ///
+    /// This is used to set a flag before a reset to instruct the bootloader to
+    /// stay in the bootloader mode.
+    pub fn set_gpregret(&self, val: u32) {
+        self.registers.gpregret.set(val);
+    }
 }

--- a/chips/nrf52/src/power.rs
+++ b/chips/nrf52/src/power.rs
@@ -346,13 +346,13 @@ impl<'a> Power<'a> {
     /// Return the contents of the GPREGRET (general purpose retention register)
     /// register.
     ///
-    /// This register is a "retention" register because it preserves its state
-    /// across a soft reset.
+    /// This register is a "retention" register because it preserves eight bits
+    /// of its state across a soft reset.
     ///
     /// This is used to set a flag before a reset to instruct the bootloader to
     /// stay in the bootloader mode.
-    pub fn get_gpregret(&self) -> u32 {
-        self.registers.gpregret.get()
+    pub fn get_gpregret(&self) -> u8 {
+        self.registers.gpregret.read(Byte::VALUE) as u8
     }
 
     /// Set the value of the GPREGRET (general purpose retention register)
@@ -360,7 +360,7 @@ impl<'a> Power<'a> {
     ///
     /// This is used to set a flag before a reset to instruct the bootloader to
     /// stay in the bootloader mode.
-    pub fn set_gpregret(&self, val: u32) {
-        self.registers.gpregret.set(val);
+    pub fn set_gpregret(&self, val: u8) {
+        self.registers.gpregret.write(Byte::VALUE.val(val as u32));
     }
 }


### PR DESCRIPTION
### Pull Request Overview

This is used for detecting entry into the bootloader on nRF platforms.


### Testing Strategy

Implementing the tock bootloader on top of nrf52 and USB.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
