### PR TITLE
usb: cdc: add 1200 baud reset interface

### DIFF
--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -344,6 +344,7 @@ pub unsafe fn reset_handler() {
         strings,
         mux_alarm,
         dynamic_deferred_caller,
+        None,
     )
     .finalize(components::usb_cdc_acm_component_helper!(
         nrf52::usbd::Usbd,

--- a/boards/components/src/cdc.rs
+++ b/boards/components/src/cdc.rs
@@ -54,6 +54,7 @@ pub struct CdcAcmComponent<
     strings: &'static [&'static str; 3],
     alarm_mux: &'static MuxAlarm<'static, A>,
     deferred_caller: &'static DynamicDeferredCall,
+    host_initiated_function: Option<&'static (dyn Fn() + 'static)>,
 }
 
 impl<U: 'static + hil::usb::UsbController<'static>, A: 'static + Alarm<'static>>
@@ -67,6 +68,7 @@ impl<U: 'static + hil::usb::UsbController<'static>, A: 'static + Alarm<'static>>
         strings: &'static [&'static str; 3],
         alarm_mux: &'static MuxAlarm<'static, A>,
         deferred_caller: &'static DynamicDeferredCall,
+        host_initiated_function: Option<&'static (dyn Fn() + 'static)>,
     ) -> Self {
         Self {
             usb,
@@ -76,6 +78,7 @@ impl<U: 'static + hil::usb::UsbController<'static>, A: 'static + Alarm<'static>>
             strings,
             alarm_mux,
             deferred_caller,
+            host_initiated_function,
         }
     }
 }
@@ -108,6 +111,7 @@ impl<U: 'static + hil::usb::UsbController<'static>, A: 'static + Alarm<'static>>
                 self.strings,
                 cdc_alarm,
                 self.deferred_caller,
+                self.host_initiated_function,
             )
         );
         self.usb.set_client(cdc);

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -267,6 +267,7 @@ pub unsafe fn reset_handler() {
         strings,
         mux_alarm,
         dynamic_deferred_caller,
+        None,
     )
     .finalize(components::usb_cdc_acm_component_helper!(
         nrf52::usbd::Usbd,


### PR DESCRIPTION
### Pull Request Overview

This pull request adds an optional hook in the USB-CDC stack for a function to run if the host sets the baud rate to 1200.

This is useful for implementing a "switch to bootloader" function.

I don't know exactly where this convention came from but it might be from Arduino (https://store.arduino.cc/usa/leonardo).


### Testing Strategy

This pull request was tested by implementing the tock bootloader on cdc.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
