### PR TITLE
Tock 2.0: implement subscribe Callback swapping restrictions, part 1

### DIFF
--- a/capsules/src/alarm.rs
+++ b/capsules/src/alarm.rs
@@ -17,7 +17,6 @@ enum Expiration {
     Enabled { reference: u32, dt: u32 },
 }
 
-#[derive(Copy, Clone)]
 pub struct AlarmData {
     expiration: Expiration,
     callback: Callback,

--- a/capsules/src/analog_comparator.rs
+++ b/capsules/src/analog_comparator.rs
@@ -37,7 +37,7 @@
 use crate::driver;
 pub const DRIVER_NUM: usize = driver::NUM::AnalogComparator as usize;
 
-use core::cell::Cell;
+use core::cell::RefCell;
 use kernel::hil;
 use kernel::{AppId, Callback, CommandResult, Driver, ErrorCode, ReturnCode};
 
@@ -47,7 +47,7 @@ pub struct AnalogComparator<'a, A: hil::analog_comparator::AnalogComparator<'a> 
     channels: &'a [&'a <A as hil::analog_comparator::AnalogComparator<'a>>::Channel],
 
     // App state
-    callback: Cell<Callback>,
+    callback: RefCell<Callback>,
 }
 
 impl<'a, A: hil::analog_comparator::AnalogComparator<'a>> AnalogComparator<'a, A> {
@@ -61,7 +61,7 @@ impl<'a, A: hil::analog_comparator::AnalogComparator<'a>> AnalogComparator<'a, A
             channels,
 
             // App state
-            callback: Cell::new(Callback::default()),
+            callback: RefCell::new(Callback::default()),
         }
     }
 
@@ -155,6 +155,6 @@ impl<'a, A: hil::analog_comparator::AnalogComparator<'a>> hil::analog_comparator
 {
     /// Callback to userland, signaling the application
     fn fired(&self, channel: usize) {
-        self.callback.get().schedule(channel, 0, 0);
+        self.callback.borrow_mut().schedule(channel, 0, 0);
     }
 }

--- a/capsules/src/app_flash_driver.rs
+++ b/capsules/src/app_flash_driver.rs
@@ -118,7 +118,7 @@ impl hil::nonvolatile_storage::NonvolatileStorageClient<'static> for AppFlash<'_
         // Notify the current application that the command finished.
         self.current_app.take().map(|appid| {
             let _ = self.apps.enter(appid, |app, _| {
-                app.callback.map(|mut cb| {
+                app.callback.as_mut().map(|cb| {
                     cb.schedule(0, 0, 0);
                 });
             });

--- a/capsules/src/ble_advertising_driver.rs
+++ b/capsules/src/ble_advertising_driver.rs
@@ -463,7 +463,7 @@ where
                         .is_some();
 
                     if success {
-                        app.scan_callback.map(|mut cb| {
+                        app.scan_callback.as_mut().map(|cb| {
                             cb.schedule(usize::from(result), len as usize, 0);
                         });
                     }

--- a/capsules/src/gpio.rs
+++ b/capsules/src/gpio.rs
@@ -137,7 +137,9 @@ impl<'a, IP: gpio::InterruptPin<'a>> gpio::ClientWithValue for GPIO<'a, IP> {
 
             // schedule callback with the pin number and value
             self.apps.each(|callback| {
-                callback.map(|mut cb| cb.schedule(pin_num as usize, pin_state as usize, 0));
+                callback
+                    .as_mut()
+                    .map(|cb| cb.schedule(pin_num as usize, pin_state as usize, 0));
             });
         }
     }

--- a/capsules/src/gpio_async.rs
+++ b/capsules/src/gpio_async.rs
@@ -25,7 +25,7 @@
 //! }
 //! ```
 
-use core::cell::Cell;
+use core::cell::RefCell;
 use kernel::hil;
 use kernel::{AppId, Callback, ErrorCode};
 use kernel::{CommandResult, Driver, ReturnCode};
@@ -36,16 +36,16 @@ pub const DRIVER_NUM: usize = driver::NUM::GpioAsync as usize;
 
 pub struct GPIOAsync<'a, Port: hil::gpio_async::Port> {
     ports: &'a [&'a Port],
-    callback: Cell<Callback>,
-    interrupt_callback: Cell<Callback>,
+    callback: RefCell<Callback>,
+    interrupt_callback: RefCell<Callback>,
 }
 
 impl<'a, Port: hil::gpio_async::Port> GPIOAsync<'a, Port> {
     pub fn new(ports: &'a [&'a Port]) -> GPIOAsync<'a, Port> {
         GPIOAsync {
             ports,
-            callback: Cell::new(Callback::default()),
-            interrupt_callback: Cell::new(Callback::default()),
+            callback: RefCell::new(Callback::default()),
+            interrupt_callback: RefCell::new(Callback::default()),
         }
     }
 
@@ -74,11 +74,13 @@ impl<'a, Port: hil::gpio_async::Port> GPIOAsync<'a, Port> {
 
 impl<Port: hil::gpio_async::Port> hil::gpio_async::Client for GPIOAsync<'_, Port> {
     fn fired(&self, pin: usize, identifier: usize) {
-        self.interrupt_callback.get().schedule(identifier, pin, 0);
+        self.interrupt_callback
+            .borrow_mut()
+            .schedule(identifier, pin, 0);
     }
 
     fn done(&self, value: usize) {
-        self.callback.get().schedule(0, value, 0);
+        self.callback.borrow_mut().schedule(0, value, 0);
     }
 }
 

--- a/capsules/src/i2c_master.rs
+++ b/capsules/src/i2c_master.rs
@@ -213,7 +213,7 @@ impl<I: i2c::I2CMaster> i2c::I2CHwMasterClient for I2CMasterDriver<I> {
                 }
 
                 // signal to driver that tx complete
-                app.callback.map(|mut cb| {
+                app.callback.as_mut().map(|cb| {
                     cb.schedule(0, 0, 0);
                 });
             })

--- a/capsules/src/i2c_master_slave_driver.rs
+++ b/capsules/src/i2c_master_slave_driver.rs
@@ -90,7 +90,7 @@ impl hil::i2c::I2CHwMasterClient for I2CMasterSlaveDriver<'_> {
                 self.master_buffer.replace(buffer);
 
                 self.app.map(|app| {
-                    app.callback.map(|mut cb| {
+                    app.callback.as_mut().map(|cb| {
                         cb.schedule(0, err as usize, 0);
                     });
                 });
@@ -109,7 +109,7 @@ impl hil::i2c::I2CHwMasterClient for I2CMasterSlaveDriver<'_> {
                         self.master_buffer.replace(buffer);
                     });
 
-                    app.callback.map(|mut cb| {
+                    app.callback.as_mut().map(|cb| {
                         cb.schedule(1, err as usize, 0);
                     });
                 });
@@ -122,7 +122,7 @@ impl hil::i2c::I2CHwMasterClient for I2CMasterSlaveDriver<'_> {
                         app_buffer.as_mut()[..len].copy_from_slice(&buffer[..len]);
                         self.master_buffer.replace(buffer);
                     });
-                    app.callback.map(|mut cb| {
+                    app.callback.as_mut().map(|cb| {
                         cb.schedule(7, err as usize, 0);
                     });
                 });
@@ -167,7 +167,7 @@ impl hil::i2c::I2CHwSlaveClient for I2CMasterSlaveDriver<'_> {
                         self.slave_buffer1.replace(buffer);
                     });
 
-                    app.callback.map(|mut cb| {
+                    app.callback.as_mut().map(|cb| {
                         cb.schedule(3, length as usize, 0);
                     });
                 });
@@ -178,7 +178,7 @@ impl hil::i2c::I2CHwSlaveClient for I2CMasterSlaveDriver<'_> {
 
                 // Notify the app that the read finished
                 self.app.map(|app| {
-                    app.callback.map(|mut cb| {
+                    app.callback.as_mut().map(|cb| {
                         cb.schedule(4, length as usize, 0);
                     });
                 });
@@ -190,7 +190,7 @@ impl hil::i2c::I2CHwSlaveClient for I2CMasterSlaveDriver<'_> {
         // Pass this up to the client. Not much we can do until the application
         // has setup a buffer to read from.
         self.app.map(|app| {
-            app.callback.map(|mut cb| {
+            app.callback.as_mut().map(|cb| {
                 // Ask the app to setup a read buffer. The app must call
                 // command 3 after it has setup the shared read buffer with
                 // the correct bytes.

--- a/capsules/src/l3gd20.rs
+++ b/capsules/src/l3gd20.rs
@@ -102,7 +102,7 @@
 //! Author: Alexandru Radovici <msg4alex@gmail.com>
 //!
 
-use core::cell::Cell;
+use core::cell::{Cell, RefCell};
 use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::hil::sensors;
 use kernel::hil::spi;
@@ -184,7 +184,7 @@ pub struct L3gd20Spi<'a> {
     hpf_mode: Cell<u8>,
     hpf_divider: Cell<u8>,
     scale: Cell<u8>,
-    callback: Cell<Callback>,
+    callback: RefCell<Callback>,
     nine_dof_client: OptionalCell<&'a dyn sensors::NineDofClient>,
     temperature_client: OptionalCell<&'a dyn sensors::TemperatureClient>,
 }
@@ -205,7 +205,7 @@ impl<'a> L3gd20Spi<'a> {
             hpf_mode: Cell::new(0),
             hpf_divider: Cell::new(0),
             scale: Cell::new(0),
-            callback: Cell::new(Callback::default()),
+            callback: RefCell::new(Callback::default()),
             nine_dof_client: OptionalCell::empty(),
             temperature_client: OptionalCell::empty(),
         }
@@ -411,7 +411,7 @@ impl spi::SpiMasterClient for L3gd20Spi<'_> {
                     false
                 };
                 self.callback
-                    .get()
+                    .borrow_mut()
                     .schedule(1, if present { 1 } else { 0 }, 0);
                 L3gd20Status::Idle
             }
@@ -456,9 +456,9 @@ impl spi::SpiMasterClient for L3gd20Spi<'_> {
                     false
                 };
                 if values {
-                    self.callback.get().schedule(x, y, z);
+                    self.callback.borrow_mut().schedule(x, y, z);
                 } else {
-                    self.callback.get().schedule(0, 0, 0);
+                    self.callback.borrow_mut().schedule(0, 0, 0);
                 }
                 L3gd20Status::Idle
             }
@@ -482,15 +482,15 @@ impl spi::SpiMasterClient for L3gd20Spi<'_> {
                     false
                 };
                 if value {
-                    self.callback.get().schedule(temperature, 0, 0);
+                    self.callback.borrow_mut().schedule(temperature, 0, 0);
                 } else {
-                    self.callback.get().schedule(0, 0, 0);
+                    self.callback.borrow_mut().schedule(0, 0, 0);
                 }
                 L3gd20Status::Idle
             }
 
             _ => {
-                self.callback.get().schedule(0, 0, 0);
+                self.callback.borrow_mut().schedule(0, 0, 0);
                 L3gd20Status::Idle
             }
         });

--- a/capsules/src/lsm303dlhc.rs
+++ b/capsules/src/lsm303dlhc.rs
@@ -78,7 +78,7 @@
 
 #![allow(non_camel_case_types)]
 
-use core::cell::Cell;
+use core::cell::{Cell, RefCell};
 use enum_primitive::cast::FromPrimitive;
 use enum_primitive::enum_from_primitive;
 use kernel::common::cells::{OptionalCell, TakeCell};
@@ -134,7 +134,7 @@ pub struct Lsm303dlhcI2C<'a> {
     config_in_progress: Cell<bool>,
     i2c_accelerometer: &'a dyn i2c::I2CDevice,
     i2c_magnetometer: &'a dyn i2c::I2CDevice,
-    callback: Cell<Callback>,
+    callback: RefCell<Callback>,
     state: Cell<State>,
     accel_scale: Cell<Lsm303Scale>,
     mag_range: Cell<Lsm303Range>,
@@ -159,7 +159,7 @@ impl<'a> Lsm303dlhcI2C<'a> {
             config_in_progress: Cell::new(false),
             i2c_accelerometer: i2c_accelerometer,
             i2c_magnetometer: i2c_magnetometer,
-            callback: Cell::new(Callback::default()),
+            callback: RefCell::new(Callback::default()),
             state: Cell::new(State::Idle),
             accel_scale: Cell::new(Lsm303Scale::Scale2G),
             mag_range: Cell::new(Lsm303Range::Range1G),
@@ -319,7 +319,7 @@ impl i2c::I2CClient for Lsm303dlhcI2C<'_> {
                 };
 
                 self.callback
-                    .get()
+                    .borrow_mut()
                     .schedule(if present { 1 } else { 0 }, 0, 0);
                 self.buffer.replace(buffer);
                 self.i2c_magnetometer.disable();
@@ -329,7 +329,7 @@ impl i2c::I2CClient for Lsm303dlhcI2C<'_> {
                 let set_power = error == Error::CommandComplete;
 
                 self.callback
-                    .get()
+                    .borrow_mut()
                     .schedule(if set_power { 1 } else { 0 }, 0, 0);
                 self.buffer.replace(buffer);
                 self.i2c_accelerometer.disable();
@@ -344,9 +344,11 @@ impl i2c::I2CClient for Lsm303dlhcI2C<'_> {
             State::SetScaleAndResolution => {
                 let set_scale_and_resolution = error == Error::CommandComplete;
 
-                self.callback
-                    .get()
-                    .schedule(if set_scale_and_resolution { 1 } else { 0 }, 0, 0);
+                self.callback.borrow_mut().schedule(
+                    if set_scale_and_resolution { 1 } else { 0 },
+                    0,
+                    0,
+                );
                 self.buffer.replace(buffer);
                 self.i2c_accelerometer.disable();
                 self.state.set(State::Idle);
@@ -391,9 +393,9 @@ impl i2c::I2CClient for Lsm303dlhcI2C<'_> {
                     false
                 };
                 if values {
-                    self.callback.get().schedule(x, y, z);
+                    self.callback.borrow_mut().schedule(x, y, z);
                 } else {
-                    self.callback.get().schedule(0, 0, 0);
+                    self.callback.borrow_mut().schedule(0, 0, 0);
                 }
                 self.buffer.replace(buffer);
                 self.i2c_accelerometer.disable();
@@ -402,7 +404,7 @@ impl i2c::I2CClient for Lsm303dlhcI2C<'_> {
             State::SetTemperatureDataRate => {
                 let set_temperature_and_magneto_data_rate = error == Error::CommandComplete;
 
-                self.callback.get().schedule(
+                self.callback.borrow_mut().schedule(
                     if set_temperature_and_magneto_data_rate {
                         1
                     } else {
@@ -422,7 +424,7 @@ impl i2c::I2CClient for Lsm303dlhcI2C<'_> {
                 let set_range = error == Error::CommandComplete;
 
                 self.callback
-                    .get()
+                    .borrow_mut()
                     .schedule(if set_range { 1 } else { 0 }, 0, 0);
                 if self.config_in_progress.get() {
                     self.config_in_progress.set(false);
@@ -446,9 +448,9 @@ impl i2c::I2CClient for Lsm303dlhcI2C<'_> {
                     false
                 };
                 if values {
-                    self.callback.get().schedule(temp, 0, 0);
+                    self.callback.borrow_mut().schedule(temp, 0, 0);
                 } else {
-                    self.callback.get().schedule(0, 0, 0);
+                    self.callback.borrow_mut().schedule(0, 0, 0);
                 }
                 self.buffer.replace(buffer);
                 self.i2c_magnetometer.disable();
@@ -482,9 +484,9 @@ impl i2c::I2CClient for Lsm303dlhcI2C<'_> {
                     false
                 };
                 if values {
-                    self.callback.get().schedule(x, y, z);
+                    self.callback.borrow_mut().schedule(x, y, z);
                 } else {
-                    self.callback.get().schedule(0, 0, 0);
+                    self.callback.borrow_mut().schedule(0, 0, 0);
                 }
                 self.buffer.replace(buffer);
                 self.i2c_magnetometer.disable();
@@ -613,8 +615,8 @@ impl Driver for Lsm303dlhcI2C<'_> {
     ) -> Result<Callback, (Callback, ErrorCode)> {
         match subscribe_num {
             0 /* set the one shot callback */ => {
-				Ok (self.callback.replace (callback))
-			},
+	        Ok(self.callback.replace(callback))
+	    },
             // default
             _ => Err ((callback, ErrorCode::NOSUPPORT)),
         }

--- a/capsules/src/ltc294x.rs
+++ b/capsules/src/ltc294x.rs
@@ -46,7 +46,7 @@
 //! ```
 
 use core::cell::Cell;
-use kernel::common::cells::{OptionalCell, TakeCell};
+use kernel::common::cells::{MapCell, OptionalCell, TakeCell};
 use kernel::hil::gpio;
 use kernel::hil::i2c;
 use kernel::ReturnCode;
@@ -407,14 +407,14 @@ impl gpio::Client for LTC294X<'_> {
 /// interface for providing access to applications.
 pub struct LTC294XDriver<'a> {
     ltc294x: &'a LTC294X<'a>,
-    callback: OptionalCell<Callback>,
+    callback: MapCell<Callback>,
 }
 
 impl<'a> LTC294XDriver<'a> {
     pub fn new(ltc: &'a LTC294X<'a>) -> LTC294XDriver<'a> {
         LTC294XDriver {
             ltc294x: ltc,
-            callback: OptionalCell::empty(),
+            callback: MapCell::empty(),
         }
     }
 }
@@ -491,7 +491,11 @@ impl LegacyDriver for LTC294XDriver<'_> {
     ) -> ReturnCode {
         match subscribe_num {
             0 => {
-                self.callback.insert(callback);
+                if let Some(cb) = callback {
+                    self.callback.replace(cb);
+                } else {
+                    self.callback.take();
+                }
                 ReturnCode::SUCCESS
             }
 

--- a/capsules/src/nonvolatile_storage_driver.rs
+++ b/capsules/src/nonvolatile_storage_driver.rs
@@ -415,7 +415,9 @@ impl hil::nonvolatile_storage::NonvolatileStorageClient<'static> for Nonvolatile
                         self.buffer.replace(buffer);
 
                         // And then signal the app.
-                        app.callback_read.map(|mut cb| cb.schedule(length, 0, 0));
+                        app.callback_read
+                            .as_mut()
+                            .map(|cb| cb.schedule(length, 0, 0));
                     });
                 }
             }
@@ -439,7 +441,9 @@ impl hil::nonvolatile_storage::NonvolatileStorageClient<'static> for Nonvolatile
                         self.buffer.replace(buffer);
 
                         // And then signal the app.
-                        app.callback_write.map(|mut cb| cb.schedule(length, 0, 0));
+                        app.callback_write
+                            .as_mut()
+                            .map(|cb| cb.schedule(length, 0, 0));
                     });
                 }
             }

--- a/capsules/src/sdcard.rs
+++ b/capsules/src/sdcard.rs
@@ -1421,7 +1421,7 @@ impl<'a, A: hil::time::Alarm<'a>> SDCardDriver<'a, A> {
 impl<'a, A: hil::time::Alarm<'a>> SDCardClient for SDCardDriver<'a, A> {
     fn card_detection_changed(&self, installed: bool) {
         self.app.map(|app| {
-            app.callback.map(|mut cb| {
+            app.callback.as_mut().map(|cb| {
                 cb.schedule(0, installed as usize, 0);
             });
         });
@@ -1429,7 +1429,7 @@ impl<'a, A: hil::time::Alarm<'a>> SDCardClient for SDCardDriver<'a, A> {
 
     fn init_done(&self, block_size: u32, total_size: u64) {
         self.app.map(|app| {
-            app.callback.map(|mut cb| {
+            app.callback.as_mut().map(|cb| {
                 let size_in_kb = ((total_size >> 10) & 0xFFFFFFFF) as usize;
                 cb.schedule(1, block_size as usize, size_in_kb);
             });
@@ -1457,7 +1457,7 @@ impl<'a, A: hil::time::Alarm<'a>> SDCardClient for SDCardDriver<'a, A> {
             // perform callback
             // Note that we are explicitly performing the callback even if no
             // data was read or if the app's read_buffer doesn't exist
-            app.callback.map(|mut cb| {
+            app.callback.as_mut().map(|cb| {
                 cb.schedule(2, read_len, 0);
             });
         });
@@ -1467,7 +1467,7 @@ impl<'a, A: hil::time::Alarm<'a>> SDCardClient for SDCardDriver<'a, A> {
         self.kernel_buf.replace(buffer);
 
         self.app.map(|app| {
-            app.callback.map(|mut cb| {
+            app.callback.as_mut().map(|cb| {
                 cb.schedule(3, 0, 0);
             });
         });
@@ -1475,7 +1475,7 @@ impl<'a, A: hil::time::Alarm<'a>> SDCardClient for SDCardDriver<'a, A> {
 
     fn error(&self, error: u32) {
         self.app.map(|app| {
-            app.callback.map(|mut cb| {
+            app.callback.as_mut().map(|cb| {
                 cb.schedule(4, error as usize, 0);
             });
         });

--- a/capsules/src/tsl2561.rs
+++ b/capsules/src/tsl2561.rs
@@ -14,7 +14,7 @@
 //! > using an empirical formula to approximate the human eye response.
 
 use core::cell::Cell;
-use kernel::common::cells::{OptionalCell, TakeCell};
+use kernel::common::cells::{MapCell, TakeCell};
 use kernel::hil::gpio;
 use kernel::hil::i2c;
 use kernel::{AppId, Callback, LegacyDriver, ReturnCode};
@@ -204,7 +204,7 @@ enum State {
 pub struct TSL2561<'a> {
     i2c: &'a dyn i2c::I2CDevice,
     interrupt_pin: &'a dyn gpio::InterruptPin<'a>,
-    callback: OptionalCell<Callback>,
+    callback: MapCell<Callback>,
     state: Cell<State>,
     buffer: TakeCell<'static, [u8]>,
 }
@@ -219,7 +219,7 @@ impl<'a> TSL2561<'a> {
         TSL2561 {
             i2c: i2c,
             interrupt_pin: interrupt_pin,
-            callback: OptionalCell::empty(),
+            callback: MapCell::empty(),
             state: Cell::new(State::Idle),
             buffer: TakeCell::new(buffer),
         }
@@ -447,7 +447,11 @@ impl LegacyDriver for TSL2561<'_> {
             // Set a callback
             0 => {
                 // Set callback function
-                self.callback.insert(callback);
+                if let Some(cb) = callback {
+                    self.callback.replace(cb);
+                } else {
+                    self.callback.take();
+                }
                 ReturnCode::SUCCESS
             }
             // default

--- a/capsules/src/usb/usb_user.rs
+++ b/capsules/src/usb/usb_user.rs
@@ -76,7 +76,7 @@ where
                             self.usbc_client.attach();
 
                             // Schedule a callback immediately
-                            if let Some(mut callback) = app.callback {
+                            if let Some(ref mut callback) = &mut app.callback {
                                 callback.schedule(From::from(ReturnCode::SUCCESS), 0, 0);
                             }
                             app.awaiting = None;

--- a/kernel/src/callback.rs
+++ b/kernel/src/callback.rs
@@ -172,7 +172,7 @@ struct ProcessCallback {
     app_id: AppId,
     callback_id: CallbackId,
     appdata: usize,
-    fn_ptr: NonNull<*mut ()>,
+    fn_ptr: NonNull<()>,
 }
 
 #[derive(Clone, Copy, Default)]
@@ -185,7 +185,7 @@ impl Callback {
         app_id: AppId,
         callback_id: CallbackId,
         appdata: usize,
-        fn_ptr: NonNull<*mut ()>,
+        fn_ptr: NonNull<()>,
     ) -> Callback {
         Callback {
             cb: Some(ProcessCallback::new(app_id, callback_id, appdata, fn_ptr)),
@@ -223,7 +223,7 @@ impl ProcessCallback {
         app_id: AppId,
         callback_id: CallbackId,
         appdata: usize,
-        fn_ptr: NonNull<*mut ()>,
+        fn_ptr: NonNull<()>,
     ) -> ProcessCallback {
         ProcessCallback {
             app_id,

--- a/kernel/src/callback.rs
+++ b/kernel/src/callback.rs
@@ -172,7 +172,6 @@ pub struct CallbackId {
 /// In contrast to the contained [`ProcessCallback`], this type does
 /// not actually have to point to a userspace process. This is the
 /// case in the [default instances](<Callback as Default>::default).
-#[derive(Clone, Copy)]
 pub struct Callback(Option<ProcessCallback>);
 
 impl Callback {
@@ -228,7 +227,7 @@ impl Callback {
     ///
     /// Otherwise, this function returns `true`.
     pub fn schedule(&mut self, r0: usize, r1: usize, r2: usize) -> bool {
-        self.0.map_or(true, |mut cb| cb.schedule(r0, r1, r2))
+        self.0.as_mut().map_or(true, |cb| cb.schedule(r0, r1, r2))
     }
 
     pub(crate) fn into_subscribe_success(self) -> GenericSyscallReturnValue {
@@ -305,7 +304,6 @@ impl Default for Callback {
 /// A [`ProcessCallback`] may be a _null callback_, not pointing to a
 /// valid function. In this case, the callback won't actually be
 /// called in userspace.
-#[derive(Clone, Copy)]
 struct ProcessCallback {
     app_id: AppId,
     callback_id: CallbackId,

--- a/kernel/src/callback.rs
+++ b/kernel/src/callback.rs
@@ -8,8 +8,6 @@ use crate::config;
 use crate::debug;
 use crate::process;
 use crate::sched::Kernel;
-use crate::syscall::GenericSyscallReturnValue;
-use crate::ErrorCode;
 
 /// Userspace app identifier.
 ///
@@ -160,8 +158,8 @@ impl AppId {
 /// This contains the driver number and the subscribe number within the driver.
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub struct CallbackId {
-    pub driver_num: usize,
-    pub subscribe_num: usize,
+    pub driver_num: u32,
+    pub subscribe_num: u32,
 }
 
 /// A callback to userspace
@@ -169,9 +167,12 @@ pub struct CallbackId {
 /// This is essentially a wrapper around a function pointer with
 /// additional data.
 ///
-/// In contrast to the contained [`ProcessCallback`], this type does
+/// In contrast to the contained `ProcessCallback`, this type does
 /// not actually have to point to a userspace process. This is the
-/// case in the [default instances](<Callback as Default>::default).
+/// case in the [default instances](Callback::default).
+///
+/// A default instance will never schedule an actual callback to
+/// userspace.
 pub struct Callback(Option<ProcessCallback>);
 
 impl Callback {
@@ -195,6 +196,14 @@ impl Callback {
             appdata,
             fn_ptr,
         )))
+    }
+
+    /// Get the contained [`ProcessCallback`] struct
+    ///
+    /// If the [`Callback`] refers to a process, this returns the
+    /// contained [`ProcessCallback`] struct.
+    pub(crate) fn into_inner(self) -> Option<ProcessCallback> {
+        self.0
     }
 
     /// Attempt to trigger the callback.
@@ -229,57 +238,6 @@ impl Callback {
     pub fn schedule(&mut self, r0: usize, r1: usize, r2: usize) -> bool {
         self.0.as_mut().map_or(true, |cb| cb.schedule(r0, r1, r2))
     }
-
-    pub(crate) fn into_subscribe_success(self) -> GenericSyscallReturnValue {
-        match self.0 {
-            None => {
-                // Default instance of a [`Callback`]
-                GenericSyscallReturnValue::SubscribeSuccess(0 as *mut u8, 0)
-            }
-            Some(cb) => {
-                // Process callback
-                match cb.fn_ptr {
-                    Some(ptr) => {
-                        // Valid callback
-                        GenericSyscallReturnValue::SubscribeSuccess(
-                            ptr.as_ptr() as *const u8,
-                            cb.appdata,
-                        )
-                    }
-                    None => {
-                        // Null callback
-                        GenericSyscallReturnValue::SubscribeSuccess(0 as *mut u8, 0)
-                    }
-                }
-            }
-        }
-    }
-
-    pub(crate) fn into_subscribe_failure(self, err: ErrorCode) -> GenericSyscallReturnValue {
-        match self.0 {
-            None => {
-                // Default instance of a [`Callback`]
-                GenericSyscallReturnValue::SubscribeFailure(err, 0 as *mut u8, 0)
-            }
-            Some(cb) => {
-                // Process callback
-                match cb.fn_ptr {
-                    Some(ptr) => {
-                        // Valid callback
-                        GenericSyscallReturnValue::SubscribeFailure(
-                            err,
-                            ptr.as_ptr() as *const u8,
-                            cb.appdata,
-                        )
-                    }
-                    None => {
-                        // Null callback
-                        GenericSyscallReturnValue::SubscribeFailure(err, 0 as *mut u8, 0)
-                    }
-                }
-            }
-        }
-    }
 }
 
 impl Default for Callback {
@@ -304,11 +262,11 @@ impl Default for Callback {
 /// A [`ProcessCallback`] may be a _null callback_, not pointing to a
 /// valid function. In this case, the callback won't actually be
 /// called in userspace.
-struct ProcessCallback {
-    app_id: AppId,
-    callback_id: CallbackId,
-    appdata: usize,
-    fn_ptr: Option<NonNull<()>>,
+pub(crate) struct ProcessCallback {
+    pub(crate) app_id: AppId,
+    pub(crate) callback_id: CallbackId,
+    pub(crate) appdata: usize,
+    pub(crate) fn_ptr: Option<NonNull<()>>,
 }
 
 impl ProcessCallback {

--- a/kernel/src/callback.rs
+++ b/kernel/src/callback.rs
@@ -345,6 +345,19 @@ impl ProcessCallback {
                 } else {
                     // This is a null callback, behave as if the
                     // callback was scheduled
+		    if config::CONFIG.trace_syscalls {
+                        debug!(
+                            "[{:?}] schedule[{:#x}:{}] @NULL({:#x}, {:#x}, {:#x}, {:#x}) (null-callback not scheduled!)",
+                            self.app_id,
+                            self.callback_id.driver_num,
+                            self.callback_id.subscribe_num,
+                            r0,
+                            r1,
+                            r2,
+                            self.appdata,
+                        );
+                    }
+
                     true
                 }
             })

--- a/kernel/src/ipc.rs
+++ b/kernel/src/ipc.rs
@@ -63,13 +63,16 @@ impl IPC {
         self.data
             .enter(appid, |mydata, _| {
                 let callback = match cb_type {
-                    IPCCallbackType::Service => mydata.callback,
+                    IPCCallbackType::Service => mydata.callback.as_mut(),
                     IPCCallbackType::Client => match otherapp.index() {
-                        Some(i) => *mydata.client_callbacks.get(i).unwrap_or(&None),
+                        Some(i) => mydata
+                            .client_callbacks
+                            .get_mut(i)
+                            .and_then(|opt| opt.as_mut()),
                         None => None,
                     },
                 };
-                callback.map_or((), |mut callback| {
+                callback.map_or((), |callback| {
                     self.data
                         .enter(otherapp, |otherdata, _| {
                             // If the other app shared a buffer with us, make

--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -812,7 +812,7 @@ impl Kernel {
 
                 let ptr = NonNull::new(callback_ptr);
                 let callback = ptr.map_or(Callback::default(), |ptr| {
-                    Callback::new(process.appid(), callback_id, appdata, ptr.cast())
+                    Callback::new(process.appid(), callback_id, appdata, ptr)
                 });
                 let rval = platform.with_driver(driver_number, |driver| match driver {
                     Some(Ok(d)) => {

--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -796,41 +796,46 @@ impl Kernel {
                 callback_ptr,
                 appdata,
             } => {
-                // A callback is identified as a tuple of
-                // the driver number and the subdriver
-                // number.
-                let callback_id = CallbackId {
-                    driver_num: driver_number,
-                    subscribe_num: subdriver_number,
-                };
-                // Only one callback should exist per tuple.
-                // To ensure that there are no pending
-                // callbacks with the same identifier but
-                // with the old function pointer, we clear
-                // them now.
-                process.remove_pending_callbacks(callback_id);
-
-                let ptr = NonNull::new(callback_ptr);
-                let callback = Callback::new(process.appid(), callback_id, appdata, ptr);
-
-                let rval = platform.with_driver(driver_number, |driver| match driver {
+                let res = platform.with_driver(driver_number, |driver| match driver {
                     Some(Ok(d)) => {
-                        let res = d.subscribe(subdriver_number, callback, process.appid());
-                        match res {
-                            Ok(newcb) => newcb.into_subscribe_success(),
-                            Err((newcb, err)) => newcb.into_subscribe_failure(err),
-                        }
+                        // Tock 2.0 driver
+                        process.subscribe(
+                            driver_number as u32,
+                            subdriver_number as u32,
+                            callback_ptr,
+                            appdata,
+                            &|callback| d.subscribe(subdriver_number, callback, process.appid()),
+                        )
                     }
-                    Some(Err(d)) => {
+                    Some(Err(ld)) => {
                         // Legacy Tock 1.x driver handling
+
+                        // A callback is identified as a tuple of
+                        // the driver number and the subdriver
+                        // number.
+                        let callback_id = CallbackId {
+                            driver_num: driver_number as u32,
+                            subscribe_num: subdriver_number as u32,
+                        };
+
+                        // Only one callback should exist per tuple.
+                        // To ensure that there are no pending
+                        // callbacks with the same identifier but
+                        // with the old function pointer, we clear
+                        // them now.
+                        process.remove_pending_callbacks(callback_id);
+
+                        let ptr = NonNull::new(callback_ptr);
                         if ptr.is_some() {
-                            GenericSyscallReturnValue::Legacy(d.subscribe(
+                            let callback =
+                                Callback::new(process.appid(), callback_id, appdata, ptr);
+                            GenericSyscallReturnValue::Legacy(ld.subscribe(
                                 subdriver_number,
                                 Some(callback),
                                 process.appid(),
                             ))
                         } else {
-                            GenericSyscallReturnValue::Legacy(d.subscribe(
+                            GenericSyscallReturnValue::Legacy(ld.subscribe(
                                 subdriver_number,
                                 None,
                                 process.appid(),
@@ -839,6 +844,7 @@ impl Kernel {
                     }
                     None => GenericSyscallReturnValue::Legacy(ReturnCode::ENOSUPPORT),
                 });
+
                 if config::CONFIG.trace_syscalls {
                     debug!(
                         "[{:?}] subscribe({:#x}, {}, @{:#x}, {:#x}) = {:?}",
@@ -847,11 +853,11 @@ impl Kernel {
                         subdriver_number,
                         callback_ptr as usize,
                         appdata,
-                        rval
+                        res
                     );
                 }
 
-                process.set_syscall_return_value(rval);
+                process.set_syscall_return_value(res);
             }
             Syscall::Command {
                 driver_number,
@@ -901,6 +907,7 @@ impl Kernel {
                         res,
                     );
                 }
+
                 process.set_syscall_return_value(res);
             }
             Syscall::ReadWriteAllow {
@@ -955,6 +962,7 @@ impl Kernel {
                         res
                     );
                 }
+
                 process.set_syscall_return_value(res);
             }
             Syscall::ReadOnlyAllow {

--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -811,9 +811,8 @@ impl Kernel {
                 process.remove_pending_callbacks(callback_id);
 
                 let ptr = NonNull::new(callback_ptr);
-                let callback = ptr.map_or(Callback::default(), |ptr| {
-                    Callback::new(process.appid(), callback_id, appdata, ptr)
-                });
+                let callback = Callback::new(process.appid(), callback_id, appdata, ptr);
+
                 let rval = platform.with_driver(driver_number, |driver| match driver {
                     Some(Ok(d)) => {
                         let res = d.subscribe(subdriver_number, callback, process.appid());

--- a/kernel/src/syscall.rs
+++ b/kernel/src/syscall.rs
@@ -251,9 +251,9 @@ pub enum GenericSyscallReturnValue {
     AllowReadOnlyFailure(ErrorCode, *const u8, usize),
 
     /// Subscribe success case
-    SubscribeSuccess(*const u8, usize),
+    SubscribeSuccess(*mut (), usize),
     /// Subscribe failure case
-    SubscribeFailure(ErrorCode, *const u8, usize),
+    SubscribeFailure(ErrorCode, *mut (), usize),
 
     Legacy(ReturnCode),
 }


### PR DESCRIPTION
### Pull Request Overview

This pull request contains various commits, performing changes required to implement the Tock 2.0 subscribe system call, including the restrictions on capsules illegally swapping `Callback`s of other subscribe nums, different drivers or other processes.

This is quite a large changeset. I tried keeping the commits themselves clean and can suggest going through them individually. The "Files changes" view on GitHub is cluttered with mechanical capsule updates.

The changes are:

- `0807887`: removing a double (indirect) pointer inside of `Callback`.

  This was likely introduced due to the (slightly confusing) fact that `NonNull` is already a "pointer type", and as such does not need to have the pointer specified as part of it's generic type.

- `3885d20`: make the contained pointer in `ProcessCallback` optional (`NonNull<()>` -> `Option<NonNull>`).

  This allows us to differentiate between default instances of a `Callback` (ones which don't contain a `ProcessCallback` at all) vs. _null callbacks_, so explicitly set callbacks from a specific process which do not fire.

  This is required because we cannot check the `AppId` and `CallbackId` (driver num + subscribe num) on a default instance of a Callback, whereas we must check them on an explicit _null callback_ to ensure that the capsule has not swapped this `Callback`. Furthermore, the _null callback_ is allowed to contain `appdata` and this must not be leaked to other processes, which this change allows to assure.

- `2466a3a`, `064bb56`: remove the `Copy` trait implementation on `Callback`.

  All of these checks will ultimately rely on the fact that one cannot copy or clone a `Callback` type. With a `Copy` implementation a capsule might be able to hold onto a process-specific `Callback` and return the same (technically matching for this driver + subscribe num combination) instance on each call. Furthermore, a capsule might be able to schedule a callback which userspace believes has been unsubscribed from.

  The first commit includes all kernel changes, including `IPC`. I'd appreciate if someone more knowledgeable can confirm that I didn't break anything. @alevy?

  The second commit changes all of the capsules. Most capsules required a mechanical change from `OptionalCell` to `MapCell`, or taking a mutable reference instead of moving (copying).

- `39c4ade`: This rewrites the system call handler for `subscribe`.

  The subscribe system call is now handled as a method on `dyn ProcessType`, similar to the allow system calls.

  Checks have been introduced that a capsule must return the previous `Callback` or a default instance in the success case, and the passed parameter in the error case.

   This is not yet sufficient to guarantee that a capsule cannot hold onto a `Callback`, but severely limits the ways it can misbehave w.r.t. the Tock 2.0 subscribe semantics. Most importantly, this prevents leaking data from one process to another implicity through   the function pointer and appdata of a `Callback` instance.

All of these changes should have minimal runtime complexity and memory overhead. Removing the `Copy` trait will cause some inefficiencies due to the use of `MapCell` and `RefCell`, but this appears strictly necessary if we want to avoid a central lookup table for valid Callbacks.

Notably, this does not introduce any memory overhead in the `Callback` type and requires no external database keeping track of `Callback` instances.

### Testing Strategy

This pull request was tested by compiling without the `touch` driver.


### TODO or Help Wanted

This pull request still needs
- changing the touch driver to use `MapCell`


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
