### PR TITLE
Fix serial console line breaks in process fault message

### DIFF
--- a/arch/rv32i/src/pmp.rs
+++ b/arch/rv32i/src/pmp.rs
@@ -175,11 +175,11 @@ impl Default for PMPConfig {
 
 impl fmt::Display for PMPConfig {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        writeln!(f, " PMP regions:")?;
+        write!(f, " PMP regions:\r\n")?;
         for (n, region) in self.regions.iter().enumerate() {
             match region {
-                None => writeln!(f, "  <unset>")?,
-                Some(region) => writeln!(f, "  [{}]: {}", n, region)?,
+                None => write!(f, "  <unset>\r\n")?,
+                Some(region) => write!(f, "  [{}]: {}\r\n", n, region)?,
             }
         }
         Ok(())

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -1418,7 +1418,7 @@ impl<C: Chip> ProcessType for Process<'_, C> {
             "\
              App: {}   -   [{:?}]\
              \r\n Events Queued: {}   Syscall Count: {}   Dropped Callback Count: {}\
-             \n Restart Count: {}\n",
+             \r\n Restart Count: {}\r\n",
             self.process_name,
             self.state.get(),
             events_queued,
@@ -1428,8 +1428,8 @@ impl<C: Chip> ProcessType for Process<'_, C> {
         ));
 
         let _ = match last_syscall {
-            Some(syscall) => writer.write_fmt(format_args!(" Last Syscall: {:?}", syscall)),
-            None => writer.write_str(" Last Syscall: None"),
+            Some(syscall) => writer.write_fmt(format_args!(" Last Syscall: {:?}\r\n", syscall)),
+            None => writer.write_str(" Last Syscall: None\r\n"),
         };
 
         let _ = writer.write_fmt(format_args!(


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes linebreaks in the process fault messages to include a carriage return. On my serial terminal the current output is rendered like this:

```
App: mpu   -   [Fault]
 Events Queued: 0   Syscall Count: 82   Dropped Callback Count: 0
                                                                  Restart Count: 0
                                                                                   Last Syscall: Some(YI
ELD)
```

```

 PMP regions:
               [0]: addr=0x41000000, size=0x00010000, cfg=0xD (r-x)
                                                                     [1]: addr=0x42004400, size=0x00001C
00, cfg=0xB (rw-)                                                                                      
                   <unset>
                            <unset>
                                     <unset>
                                              <unset>
                                                       <unset>
                                                                <unset>
```

This is a very minor change but has been bugging me for quite some time. :smile: 

### Testing Strategy

This pull request was tested by making a process fault and checking the output.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
