### PR TITLE
litex: update LiteX revision, use "Secure"/"TockSecureIMC" cpu variant and integrate PMP

### DIFF
--- a/boards/litex/arty/Makefile
+++ b/boards/litex/arty/Makefile
@@ -1,7 +1,7 @@
 # Makefile for building the tock kernel for a LiteX SoC targeting a
 # Digilent Arty-A7 FPGA development board
 
-TARGET=riscv32i-unknown-none-elf
+TARGET=riscv32imc-unknown-none-elf
 PLATFORM=litex_arty
 
 include ../../Makefile.common

--- a/boards/litex/arty/README.md
+++ b/boards/litex/arty/README.md
@@ -26,6 +26,14 @@ tested with
   --with-ethernet
   ```
 
+Prebuilt and tested bitstreams can be obtained from the [Tock on LiteX
+companion repository
+releases](https://github.com/lschuermann/tock-litex/releases/). The
+current board definition has been verified to work with [release
+2020122001](https://github.com/lschuermann/tock-litex/releases/tag/2020122001). The
+bitstream for this board is located in `arty_a7-35t.zip` under
+`gateware/arty.bit`.
+
 Many bitstream customizations can be represented in the Tock board by
 simply changing the variables in `src/litex_generated.rs`. To support
 a different set of FPGA cores and perform further modifications, the

--- a/boards/litex/arty/README.md
+++ b/boards/litex/arty/README.md
@@ -11,9 +11,9 @@ differ significantly depending on the LiteX release and configuration
 options used. This board definition currently targets and has been
 tested with
 - [the LiteX SoC generator, revision
-  444a605dea](https://github.com/enjoy-digital/litex/tree/444a605deae6a561dbe2c49bf3062eae6f3cd887)
+  4092180662](https://github.com/enjoy-digital/litex/tree/4092180662ec62cf28b9283a020f1ff7f0892c19)
 - using the included [target
-  file](https://github.com/enjoy-digital/litex/blob/444a605deae6a561dbe2c49bf3062eae6f3cd887/litex/boards/targets/arty.py)
+  file](https://github.com/enjoy-digital/litex/blob/4092180662ec62cf28b9283a020f1ff7f0892c19/litex/boards/targets/arty.py)
 - built around a VexRiscv-CPU
 - along with the following configuration options:
 

--- a/boards/litex/arty/README.md
+++ b/boards/litex/arty/README.md
@@ -14,25 +14,36 @@ tested with
   4092180662](https://github.com/enjoy-digital/litex/tree/4092180662ec62cf28b9283a020f1ff7f0892c19)
 - using the included [target
   file](https://github.com/enjoy-digital/litex/blob/4092180662ec62cf28b9283a020f1ff7f0892c19/litex/boards/targets/arty.py)
-- built around a VexRiscv-CPU
+- built around a VexRiscv-CPU with PMP, hardware multiplication and
+  compressed instruction support
 - along with the following configuration options:
 
   ```
   --uart-baudrate=1000000
-  --cpu-variant=secure
+  --cpu-variant=tock+secure+imc
   --csr-data-width=32
   --timer-uptime
   --integrated-rom-size=0xb000
   --with-ethernet
   ```
 
-Prebuilt and tested bitstreams can be obtained from the [Tock on LiteX
-companion repository
+The `tock+secure+imc` is a custom VexRiscv CPU variant, based on the
+build infrastructure in
+[pythondata-cpu-vexriscv](https://github.com/litex-hub/pythondata-cpu-vexriscv),
+using a
+[patch](https://github.com/lschuermann/tock-litex/blob/master/pkgs/pythondata-cpu-vexriscv/0001-Add-TockSecureIMC-cpu-variant.patch)
+to introduce a CPU with physical memory protection, hardware
+multiplication and compressed instruction support (such that it is
+compatible with the `rv32imc` arch).
+
+Prebuilt and tested bitstreams (including the generated VexRiscv CPU
+Verilog files) can be obtained from the [Tock on LiteX companion
+repository
 releases](https://github.com/lschuermann/tock-litex/releases/). The
 current board definition has been verified to work with [release
-2020122001](https://github.com/lschuermann/tock-litex/releases/tag/2020122001). The
+2020122201](https://github.com/lschuermann/tock-litex/releases/tag/2020122201). The
 bitstream for this board is located in `arty_a7-35t.zip` under
-`gateware/arty.bit`.
+`gateware/arty.bin`.
 
 Many bitstream customizations can be represented in the Tock board by
 simply changing the variables in `src/litex_generated.rs`. To support

--- a/boards/litex/arty/README.md
+++ b/boards/litex/arty/README.md
@@ -19,7 +19,7 @@ tested with
 
   ```
   --uart-baudrate=1000000
-  --cpu-variant=full
+  --cpu-variant=secure
   --csr-data-width=32
   --timer-uptime
   --integrated-rom-size=0xb000
@@ -43,20 +43,14 @@ a different set of FPGA cores and perform further modifications, the
 Please note
 -----------
 
-This board is still in development. The memory protection (PMP)
-mechanism is not yet integrated into the VexRiscv core and more
-peripherals require drivers. Nonetheless, the Tock kernel works and
-can run multiple userspace applications.
-
-The following on-board components and cores are supported:
+This board is still in development. The following on-board components
+and cores are supported:
 - [X] Timer (with uptime support)
 - [X] UART output via USB-FTDI
 - [X] Green onboard LEDs
 - [X] 100MBit/s Ethernet MAC
 
 The following components and cores require porting:
-- [ ] Memory protection (PMP) support in the VexRiscv CPU ([upstream
-      PR](https://github.com/SpinalHDL/VexRiscv/pull/147))
 - [ ] GPIO Interface
 - [ ] Buttons and Switches
 - [ ] RGB LEDs

--- a/boards/litex/sim/README.md
+++ b/boards/litex/sim/README.md
@@ -10,8 +10,8 @@ differ significantly depending on the release and configuration
 options used. This board definition currently targets and has been
 tested with
 - [the LiteX SoC generator, revision
-  444a605dea](https://github.com/enjoy-digital/litex/tree/444a605deae6a561dbe2c49bf3062eae6f3cd887)
-- using the included [lx_sim.py](https://github.com/enjoy-digital/litex/blob/444a605deae6a561dbe2c49bf3062eae6f3cd887/litex/tools/litex_sim.py)
+  444a605dea](https://github.com/enjoy-digital/litex/tree/4092180662ec62cf28b9283a020f1ff7f0892c19)
+- using the included [lx_sim.py](https://github.com/enjoy-digital/litex/blob/4092180662ec62cf28b9283a020f1ff7f0892c19/litex/tools/litex_sim.py)
 - built around a VexRiscv-CPU
 - featuring a TIMER0 with 64-bit wide hardware uptime
 - along with the following configuration options:

--- a/boards/litex/sim/README.md
+++ b/boards/litex/sim/README.md
@@ -19,7 +19,7 @@ tested with
   ```
   --csr-data-width=32
   --integrated-rom-size=1048576
-  --cpu-variant=full
+  --cpu-variant=secure
   --with-ethernet
   --rom-init $PATH_TO_TOCK_BINARY
   ```
@@ -28,23 +28,6 @@ Many bitstream customizations can be represented in the Tock board by
 simply changing the variables in `src/litex_generated.rs`. To support
 a different set of FPGA cores and perform further modifications, the
 `src/main.rs` file will have to be modified.
-
-
-Please note
------------
-
-This board is still in development. The memory protection (PMP)
-mechanism is not yet integrated into the VexRiscv core. Nonetheless,
-the Tock kernel works and can run multiple userspace applications.
-
-The following on-board components and cores are supported:
-- [X] Timer (with uptime support)
-- [X] UART console output
-- [X] Ethernet MAC
-
-The following components and cores require porting:
-- [ ] Memory protection (PMP) support in the VexRiscv CPU ([upstream
-      PR](https://github.com/SpinalHDL/VexRiscv/pull/147))
 
 
 Building the SoC / Programming the FPGA


### PR DESCRIPTION
### Pull Request Overview

This pull request

- updates the targeted LiteX revision for both boards (`litex/sim` and `litex/arty`)

- points to a companion repository ([tock-litex](https://github.com/lschuermann/tock-litex)), which contains prebuilt bitstreams and build scripts for generating these

  The board definitions in this repository are tested against bitstreams obtained by these build scripts, so it makes sense to publish the bitstreams themselves as well.

- changes the LiteX boards to require the "Secure" / "TockSecureIMC" VexRiscv CPU variant containing a PMP and enables PMP support in the `litex_vexriscv` chip crate

  "TockSecureIMC" is a custom VexRiscv CPU configuration which has support for PMP, hardware multiplication and compressed instructions. It significantly reduces code size and should improve performance. The patch to the upstream `pythondata-cpu-vexriscv` can be found [here](https://github.com/lschuermann/tock-litex/blob/master/pkgs/pythondata-cpu-vexriscv/0001-Add-TockSecureIMC-cpu-variant.patch). Prebuilt Verilog-files and complete bitstreams are published as part of the `tock-litex` repository [releases](https://github.com/lschuermann/tock-litex/releases/).

### Testing Strategy

This pull request was tested by running the `mpu` test app with all test cases on both the Arty A7 35T and the Verilated simulation.


### TODO or Help Wanted

I don't think it's very elegant to point to some outside repository for the generated bitstreams. It might be more trustworthy to have this repository under the Tock GitHub organization, given that we already have the _Community_ GitHub team. I'd be open to moving it, but also fine if it stays in the current location.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.

### Acknowledgements

A huge thanks to @lindemer for contributing PMP support to VexRiscv. This must have been a lot of work.

I was also impressed by the PMP infrastructure in Tock. Everything worked flawlessly on the first try. Thanks to @bradjc, @alistair23 and all other contributors!