### PR TITLE
rng: port to Tock 2.0 system call interface

### DIFF
--- a/boards/acd52832/src/main.rs
+++ b/boards/acd52832/src/main.rs
@@ -95,7 +95,7 @@ impl kernel::Platform for Platform {
             capsules::alarm::DRIVER_NUM => f(Some(Err(self.alarm))),
             capsules::led::DRIVER_NUM => f(Some(Ok(self.led))),
             capsules::button::DRIVER_NUM => f(Some(Err(self.button))),
-            capsules::rng::DRIVER_NUM => f(Some(Err(self.rng))),
+            capsules::rng::DRIVER_NUM => f(Some(Ok(self.rng))),
             capsules::ble_advertising_driver::DRIVER_NUM => f(Some(Err(self.ble_radio))),
             capsules::temperature::DRIVER_NUM => f(Some(Ok(self.temp))),
             capsules::gpio_async::DRIVER_NUM => f(Some(Ok(self.gpio_async))),

--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -146,7 +146,7 @@ impl kernel::Platform for Platform {
             capsules::led::DRIVER_NUM => f(Some(Ok(self.led))),
             capsules::button::DRIVER_NUM => f(Some(Err(self.button))),
             capsules::screen::DRIVER_NUM => f(Some(Ok(self.screen))),
-            capsules::rng::DRIVER_NUM => f(Some(Err(self.rng))),
+            capsules::rng::DRIVER_NUM => f(Some(Ok(self.rng))),
             capsules::ble_advertising_driver::DRIVER_NUM => f(Some(Err(self.ble_radio))),
             capsules::ieee802154::DRIVER_NUM => f(Some(Err(self.ieee802154_radio))),
             capsules::buzzer_driver::DRIVER_NUM => f(Some(Err(self.buzzer))),

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -96,7 +96,7 @@ impl Platform for Hail {
             capsules::temperature::DRIVER_NUM => f(Some(Ok(self.temp))),
             capsules::ninedof::DRIVER_NUM => f(Some(Ok(self.ninedof))),
 
-            capsules::rng::DRIVER_NUM => f(Some(Err(self.rng))),
+            capsules::rng::DRIVER_NUM => f(Some(Ok(self.rng))),
 
             capsules::crc::DRIVER_NUM => f(Some(Ok(self.crc))),
 

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -179,7 +179,7 @@ impl kernel::Platform for Imix {
             capsules::nonvolatile_storage_driver::DRIVER_NUM => {
                 f(Some(Err(self.nonvolatile_storage)))
             }
-            capsules::rng::DRIVER_NUM => f(Some(Err(self.rng))),
+            capsules::rng::DRIVER_NUM => f(Some(Ok(self.rng))),
             kernel::ipc::DRIVER_NUM => f(Some(Err(&self.ipc))),
             _ => f(None),
         }

--- a/boards/microbit_v2/src/main.rs
+++ b/boards/microbit_v2/src/main.rs
@@ -120,7 +120,7 @@ impl kernel::Platform for Platform {
             capsules::adc::DRIVER_NUM => f(Some(Err(self.adc))),
             capsules::temperature::DRIVER_NUM => f(Some(Ok(self.temperature))),
             capsules::lsm303agr::DRIVER_NUM => f(Some(Err(self.lsm303agr))),
-            capsules::rng::DRIVER_NUM => f(Some(Err(self.rng))),
+            capsules::rng::DRIVER_NUM => f(Some(Ok(self.rng))),
             capsules::ble_advertising_driver::DRIVER_NUM => f(Some(Err(self.ble_radio))),
             capsules::buzzer_driver::DRIVER_NUM => f(Some(Err(self.buzzer))),
             capsules::app_flash_driver::DRIVER_NUM => f(Some(Err(self.app_flash))),

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -128,7 +128,7 @@ impl kernel::Platform for Platform {
             capsules::gpio::DRIVER_NUM => f(Some(Err(self.gpio))),
             capsules::alarm::DRIVER_NUM => f(Some(Err(self.alarm))),
             capsules::led::DRIVER_NUM => f(Some(Ok(self.led))),
-            capsules::rng::DRIVER_NUM => f(Some(Err(self.rng))),
+            capsules::rng::DRIVER_NUM => f(Some(Ok(self.rng))),
             capsules::ble_advertising_driver::DRIVER_NUM => f(Some(Err(self.ble_radio))),
             capsules::ieee802154::DRIVER_NUM => f(Some(Err(self.ieee802154_radio))),
             kernel::ipc::DRIVER_NUM => f(Some(Err(&self.ipc))),

--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -110,7 +110,7 @@ impl kernel::Platform for Platform {
             capsules::alarm::DRIVER_NUM => f(Some(Err(self.alarm))),
             capsules::led::DRIVER_NUM => f(Some(Ok(self.led))),
             capsules::button::DRIVER_NUM => f(Some(Err(self.button))),
-            capsules::rng::DRIVER_NUM => f(Some(Err(self.rng))),
+            capsules::rng::DRIVER_NUM => f(Some(Ok(self.rng))),
             capsules::ble_advertising_driver::DRIVER_NUM => f(Some(Err(self.ble_radio))),
             capsules::ieee802154::DRIVER_NUM => f(Some(Err(self.ieee802154_radio))),
             capsules::temperature::DRIVER_NUM => f(Some(Ok(self.temp))),

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -187,7 +187,7 @@ impl kernel::Platform for Platform {
             capsules::alarm::DRIVER_NUM => f(Some(Err(self.alarm))),
             capsules::led::DRIVER_NUM => f(Some(Ok(self.led))),
             capsules::button::DRIVER_NUM => f(Some(Err(self.button))),
-            capsules::rng::DRIVER_NUM => f(Some(Err(self.rng))),
+            capsules::rng::DRIVER_NUM => f(Some(Ok(self.rng))),
             capsules::ble_advertising_driver::DRIVER_NUM => f(Some(Err(self.ble_radio))),
             capsules::ieee802154::DRIVER_NUM => f(Some(Err(self.ieee802154_radio))),
             capsules::temperature::DRIVER_NUM => f(Some(Ok(self.temp))),

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -169,7 +169,7 @@ impl kernel::Platform for Platform {
             capsules::alarm::DRIVER_NUM => f(Some(Err(self.alarm))),
             capsules::led::DRIVER_NUM => f(Some(Ok(self.led))),
             capsules::button::DRIVER_NUM => f(Some(Err(self.button))),
-            capsules::rng::DRIVER_NUM => f(Some(Err(self.rng))),
+            capsules::rng::DRIVER_NUM => f(Some(Ok(self.rng))),
             capsules::ble_advertising_driver::DRIVER_NUM => f(Some(Err(self.ble_radio))),
             capsules::temperature::DRIVER_NUM => f(Some(Ok(self.temp))),
             capsules::analog_comparator::DRIVER_NUM => f(Some(Ok(self.analog_comparator))),

--- a/boards/stm32f412gdiscovery/src/main.rs
+++ b/boards/stm32f412gdiscovery/src/main.rs
@@ -82,7 +82,7 @@ impl Platform for STM32F412GDiscovery {
             capsules::touch::DRIVER_NUM => f(Some(Ok(self.touch))),
             capsules::screen::DRIVER_NUM => f(Some(Ok(self.screen))),
             capsules::temperature::DRIVER_NUM => f(Some(Ok(self.temperature))),
-            capsules::rng::DRIVER_NUM => f(Some(Err(self.rng))),
+            capsules::rng::DRIVER_NUM => f(Some(Ok(self.rng))),
             _ => f(None),
         }
     }

--- a/capsules/src/rng.rs
+++ b/capsules/src/rng.rs
@@ -14,18 +14,23 @@
 //! # use kernel::static_init;
 //!
 //! let rng = static_init!(
-//!         capsules::rng::RngDriver<'static, sam4l::trng::Trng>,
-//!         capsules::rng::RngDriver::new(&sam4l::trng::TRNG, board_kernel.create_grant(&grant_cap)));
+//!     capsules::rng::RngDriver<'static, sam4l::trng::Trng>,
+//!     capsules::rng::RngDriver::new(&sam4l::trng::TRNG, board_kernel.create_grant(&grant_cap)),
+//! );
 //! sam4l::trng::TRNG.set_client(rng);
 //! ```
 
 use core::cell::Cell;
+use core::mem;
 use kernel::common::cells::OptionalCell;
 use kernel::hil::entropy;
 use kernel::hil::entropy::{Entropy32, Entropy8};
 use kernel::hil::rng;
 use kernel::hil::rng::{Client, Continue, Random, Rng};
-use kernel::{AppId, AppSlice, Callback, Grant, LegacyDriver, ReturnCode, SharedReadWrite};
+use kernel::{
+    AppId, Callback, CommandResult, Driver, ErrorCode, Grant, ReadWrite, ReadWriteAppSlice,
+    ReturnCode,
+};
 
 /// Syscall driver number.
 use crate::driver;
@@ -33,8 +38,8 @@ pub const DRIVER_NUM: usize = driver::NUM::Rng as usize;
 
 #[derive(Default)]
 pub struct App {
-    callback: Option<Callback>,
-    buffer: Option<AppSlice<SharedReadWrite, u8>>,
+    callback: Callback,
+    buffer: ReadWriteAppSlice,
     remaining: usize,
     idx: usize,
 }
@@ -65,26 +70,41 @@ impl rng::Client for RngDriver<'_> {
         for cntr in self.apps.iter() {
             cntr.enter(|app, _| {
                 // Check if this app needs random values.
-                if app.remaining > 0 && app.callback.is_some() && app.buffer.is_some() {
-                    app.buffer.take().map(|mut buffer| {
-                        // Check that the app is not asking for more than can
-                        // fit in the provided buffer.
+                if app.remaining > 0 {
+                    // Provide the current application values to the closure
+                    let (oldidx, oldremaining) = (app.idx, app.remaining);
 
-                        if buffer.len() < app.idx + app.remaining {
-                            app.remaining = buffer.len() - app.idx;
-                        }
+                    let (newidx, newremaining) = app.buffer.mut_map_or(
+                        // If the process is no longer alive
+                        // (or this is a default AppSlice),
+                        // set the idx and remaining values of
+                        // this app to (0, 0)
+                        (0, 0),
+                        |buffer| {
+                            let mut idx = oldidx;
+                            let mut remaining = oldremaining;
 
-                        {
+                            // Check that the app is not asking for more than can
+                            // fit in the provided buffer
+                            if buffer.len() < idx {
+                                // The buffer does not fit at all
+                                // anymore (the app must've swapped
+                                // buffers), end the operation
+                                return (0, 0);
+                            } else if buffer.len() < idx + remaining {
+                                remaining = buffer.len() - idx;
+                            }
+
                             // Add all available and requested randomness to the app buffer.
 
                             // 1. Slice buffer to start from current idx
-                            let buf = &mut buffer.as_mut()[app.idx..(app.idx + app.remaining)];
+                            let buf = &mut buffer.as_mut()[idx..(idx + remaining)];
                             // 2. Take at most as many random samples as needed to fill the buffer
                             //    (if app.remaining is not word-sized, take an extra one).
-                            let remaining_ints = if app.remaining % 4 == 0 {
-                                app.remaining / 4
+                            let remaining_ints = if remaining % 4 == 0 {
+                                remaining / 4
                             } else {
-                                app.remaining / 4 + 1
+                                remaining / 4 + 1
                             };
 
                             // 3. Zip over the randomness iterator and chunks
@@ -94,24 +114,26 @@ impl rng::Client for RngDriver<'_> {
                             {
                                 // 4. For each word of randomness input, update
                                 //    the remaining and idx and add to buffer.
-                                for (i, b) in outs.iter_mut().enumerate() {
-                                    *b = ((inp >> i * 8) & 0xff) as u8;
-                                    app.remaining -= 1;
-                                    app.idx += 1;
-                                }
+                                let inbytes = u32::to_le_bytes(inp);
+                                outs.iter_mut().zip(inbytes.iter()).for_each(|(out, inb)| {
+                                    *out = *inb;
+                                    remaining -= 1;
+                                    idx += 1;
+                                });
                             }
-                        }
 
-                        // Replace taken buffer
-                        app.buffer = Some(buffer);
-                    });
+                            (idx, remaining)
+                        },
+                    );
+
+                    // Store the updated values in the application
+                    app.idx = newidx;
+                    app.remaining = newremaining;
 
                     if app.remaining > 0 {
                         done = false;
                     } else {
-                        app.callback.map(|mut cb| {
-                            cb.schedule(0, app.idx, 0);
-                        });
+                        app.callback.schedule(0, newidx, 0);
                     }
                 }
             });
@@ -133,73 +155,79 @@ impl rng::Client for RngDriver<'_> {
     }
 }
 
-impl<'a> LegacyDriver for RngDriver<'a> {
+impl<'a> Driver for RngDriver<'a> {
     fn allow_readwrite(
         &self,
         appid: AppId,
         allow_num: usize,
-        slice: Option<AppSlice<SharedReadWrite, u8>>,
-    ) -> ReturnCode {
+        mut slice: ReadWriteAppSlice,
+    ) -> Result<ReadWriteAppSlice, (ReadWriteAppSlice, ErrorCode)> {
         // pass buffer in from application
-        match allow_num {
+        let res = match allow_num {
             0 => self
                 .apps
                 .enter(appid, |app, _| {
-                    app.buffer = slice;
-                    ReturnCode::SUCCESS
+                    mem::swap(&mut app.buffer, &mut slice);
+                    Ok(())
                 })
-                .unwrap_or_else(|err| err.into()),
-            _ => ReturnCode::ENOSUPPORT,
+                .unwrap_or_else(|err| Err(err.into())),
+            _ => Err(ErrorCode::NOSUPPORT),
+        };
+
+        match res {
+            Ok(()) => Ok(slice),
+            Err(e) => Err((slice, e)),
         }
     }
 
     fn subscribe(
         &self,
         subscribe_num: usize,
-        callback: Option<Callback>,
+        mut callback: Callback,
         app_id: AppId,
-    ) -> ReturnCode {
-        match subscribe_num {
+    ) -> Result<Callback, (Callback, ErrorCode)> {
+        let res = match subscribe_num {
             0 => self
                 .apps
                 .enter(app_id, |app, _| {
-                    app.callback = callback;
-                    ReturnCode::SUCCESS
+                    mem::swap(&mut app.callback, &mut callback);
+                    Ok(())
                 })
-                .unwrap_or_else(|err| err.into()),
+                .unwrap_or_else(|err| Err(err.into())),
+            _ => Err(ErrorCode::NOSUPPORT),
+        };
 
-            // default
-            _ => ReturnCode::ENOSUPPORT,
+        match res {
+            Ok(()) => Ok(callback),
+            Err(e) => Err((callback, e)),
         }
     }
 
-    fn command(&self, command_num: usize, data: usize, _: usize, appid: AppId) -> ReturnCode {
+    fn command(&self, command_num: usize, data: usize, _: usize, appid: AppId) -> CommandResult {
         match command_num {
-            0 =>
-            /* Check if exists */
+            0 /* Check if exists */ =>
             {
-                ReturnCode::SUCCESS
+                CommandResult::success()
             }
 
-            // Ask for a given number of random bytes.
-            1 => self
+            1 /* Ask for a given number of random bytes */ => self
                 .apps
                 .enter(appid, |app, _| {
                     app.remaining = data;
                     app.idx = 0;
 
-                    if app.callback.is_some() && app.buffer.is_some() {
-                        if !self.getting_randomness.get() {
-                            self.getting_randomness.set(true);
-                            self.rng.get();
-                        }
-                        ReturnCode::SUCCESS
-                    } else {
-                        ReturnCode::ERESERVE
+		    // Assume that the process has a callback & slice
+		    // set. It might die or revoke them before the
+		    // result arrives anyways
+                    if !self.getting_randomness.get() {
+                        self.getting_randomness.set(true);
+                        self.rng.get();
                     }
+
+		    CommandResult::success()
                 })
-                .unwrap_or_else(|err| err.into()),
-            _ => ReturnCode::ENOSUPPORT,
+                .unwrap_or_else(|err| CommandResult::failure(err.into())),
+            _ => CommandResult::failure(ErrorCode::NOSUPPORT),
         }
     }
 }


### PR DESCRIPTION
### Pull Request Overview

This pull request migrates the RNG userspace driver from `LegacyDriver` to `Driver`. The migration was pretty easy.


### Testing Strategy

This pull request was tested using a Hail, printing obtained randomness through the accompanying userspace PR.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
