### PR TITLE
register-interface: Allow expressions in register_bitfields

### DIFF
--- a/libraries/tock-register-interface/src/macros.rs
+++ b/libraries/tock-register-interface/src/macros.rs
@@ -75,6 +75,7 @@ macro_rules! register_bitmasks {
             #[allow(unused_imports)]
             use $crate::registers::{FieldValue, TryFromValue};
             use super::$reg_desc;
+            pub use super::*;
 
             $(
             #[allow(non_upper_case_globals)]
@@ -115,7 +116,7 @@ macro_rules! register_bitmasks {
                     match v {
                         $(
                             $(#[$inner])*
-                            x if x == Value::$valname as $valtype => Some(Value::$valname),
+                            _x if _x == $value => Some(Value::$valname),
                         )*
 
                         _ => Option::None
@@ -141,6 +142,7 @@ macro_rules! register_bitmasks {
             #[allow(unused_imports)]
             use $crate::registers::{FieldValue, TryFromValue};
             use super::$reg_desc;
+            pub use super::*;
 
             #[allow(non_upper_case_globals)]
             #[allow(unused)]
@@ -190,6 +192,7 @@ macro_rules! register_bitfields {
                 impl $crate::registers::RegisterLongName for Register {}
 
                 use $crate::registers::Field;
+                pub use super::*;
 
                 $crate::register_bitmasks!( $valtype, Register, $fields );
             }


### PR DESCRIPTION
I'm working on getting at least a subset of #2041 merged in. This is one commit necessary to nicely support 32 or 64 bit CSRs on RISC-V, and can be merged separately.

The goal of this behavior is to allow things like

    register_bitfields![usize,
        pub pmpaddr [
            addr OFFSET(0) NUMBITS(XLEN) []
        ]
    ];

where XLEN is the width of usize. This will make it much easier to
create ISA-word-size-agnostic ports. Without these changes, it would be
necessary to declare each bitfield twice with cfg attributes, even when
only the width of the bitfield differs.

The primary drawback to this feature is that register_bitfields is no
longer hygenic. This is a necessary consequence because otherwise the
new submodules have no way to see the register type, or any constants
used in the bit width. This could have been mitigated by creating a
typedef for the register type and using that typedef in each submodule,
but that would not have solved the problem of using constants in
NUMBITS, etc. Unfortunately, there is already one collision,
necessitating the renaming of x to _x. However, I suspect such
collisions will be rare, since files declaring bitfields tend to declare
little else.

Signed-off-by: Sean Anderson <seanga2@gmail.com>



### Testing Strategy

This pull request was tested as part of #2041.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
