### PR TITLE
doc: add missing crate readmes

### DIFF
--- a/arch/cortex-m/README.md
+++ b/arch/cortex-m/README.md
@@ -1,0 +1,12 @@
+Cortex-M Architecture
+=====================
+
+This crate includes shared low-level code for the Cortex-M family of CPU
+architectures. In some cases this crate includes multiple versions of the same
+code, but targeted towards different Cortex-M versions. In general, if code is
+used by multiple Cortex-M variants it is included here.
+
+Boards and chips should not depend on this crate directly. Instead, all of the
+relevant modules and features should be exported through the specific Cortex-M
+crates (e.g. Cortex-M4), and chips and boards should depend on the more specific
+crate.

--- a/arch/cortex-m0/README.md
+++ b/arch/cortex-m0/README.md
@@ -1,0 +1,10 @@
+Cortex-M0 Architecture
+======================
+
+This crate includes legacy support for the Cortex-M0 architecture. We include
+this in the Tock repo in case a future board (or out-of-tree board) wants to use
+the Cortex-M0 architecture. However, Cortex-M0-based chips tend to be very
+limited, and we have found them to largely not be well suited to support Tock.
+
+Note: This crate may be out-of-date since it is largely not maintained currently
+(as of December 2020).

--- a/arch/cortex-m3/README.md
+++ b/arch/cortex-m3/README.md
@@ -1,0 +1,5 @@
+Cortex-M3 Architecture
+======================
+
+Architecture support for Cortex-M3 devices. This largely only re-exports the
+correct functions from the Cortex-M crate.

--- a/arch/cortex-m4/README.md
+++ b/arch/cortex-m4/README.md
@@ -1,0 +1,5 @@
+Cortex-M4 Architecture
+======================
+
+Architecture support for Cortex-M4 devices. This largely only re-exports the
+correct functions from the Cortex-M crate.

--- a/arch/cortex-m7/README.md
+++ b/arch/cortex-m7/README.md
@@ -1,0 +1,5 @@
+Cortex-M7 Architecture
+======================
+
+Architecture support for Cortex-M7 devices. This largely only re-exports the
+correct functions from the Cortex-M crate.

--- a/boards/components/README.md
+++ b/boards/components/README.md
@@ -1,0 +1,37 @@
+Tock Components
+===============
+
+Components in Tock are helper files that simplify initializing a board with
+various capsules and other resources.
+
+Motivation
+----------
+
+Initializing a board mainly consists of three steps:
+
+1. Setting any MCU-specific configurations necessary for the MCU to operate
+   correctly.
+2. Statically declaring memory for various kernel resources (i.e. capsules) and
+   configuring the capsules correctly.
+3. Loading processes, configuring the core kernel, and starting the kernel.
+
+Components are designed to simplify the second step (configuring capsules) while
+also reducing the chance for misconfiguration or other setup errors.
+
+Configuring capsules can be tricky because i) the exact type needs to be
+specified, and types can be complicated and tedious to define correctly, ii)
+capsules can be complex and require several arguments or setup steps, and iii)
+capsules often require `set_client()` to be called to setup in-kernel callback
+chains, and these can be easy to forget. Components allow most of a capsule's
+configuration to be written just once in a component, and then various boards
+can use the component to reduce the complexity of their setup code and reduce
+the chance for errors. Components also reduce the burden when changes are made
+to capsules, as the change can likely be reflected in the single component and
+not in every board's main.rs file.
+
+Adding Components
+-----------------
+
+We are always happy to merge new components for various capsules or different
+configurations. Generally copying an existing component is the best place to
+start when creating a new component.

--- a/boards/nordic/nrf52_components/README.md
+++ b/boards/nordic/nrf52_components/README.md
@@ -1,0 +1,7 @@
+nRF52 Components
+================
+
+These are components that are only relevant to the nRF52 family of
+microcontrollers. Since we support several boards based on various nRF52
+variants, it is currently worthwhile to have components specific to these
+microcontrollers.

--- a/tools/check-for-readmes.sh
+++ b/tools/check-for-readmes.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# Find folders with Cargo.toml files but no README.md file.
+for f in $(find . | grep Cargo.toml); do
+	dir=$(dirname $f)
+	readme=${dir}/README.md
+
+	if [ ! -f "$readme" ]; then
+	    echo "$readme does not exist!"
+	fi
+done


### PR DESCRIPTION
### Pull Request Overview

This pull request adds READMEs to crates that didn't have them. I find these to be very helpful when exploring a new project.


### Testing Strategy

n/a


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
