### PR TITLE
Updating Alarm syscall driver to 2.0 syscall API

### DIFF
--- a/boards/acd52832/src/main.rs
+++ b/boards/acd52832/src/main.rs
@@ -92,7 +92,7 @@ impl kernel::Platform for Platform {
         match driver_num {
             capsules::console::DRIVER_NUM => f(Some(Ok(self.console))),
             capsules::gpio::DRIVER_NUM => f(Some(Err(self.gpio))),
-            capsules::alarm::DRIVER_NUM => f(Some(Err(self.alarm))),
+            capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
             capsules::led::DRIVER_NUM => f(Some(Ok(self.led))),
             capsules::button::DRIVER_NUM => f(Some(Err(self.button))),
             capsules::rng::DRIVER_NUM => f(Some(Ok(self.rng))),

--- a/boards/arty_e21/src/main.rs
+++ b/boards/arty_e21/src/main.rs
@@ -69,7 +69,7 @@ impl Platform for ArtyE21 {
             capsules::console::DRIVER_NUM => f(Some(Ok(self.console))),
             capsules::gpio::DRIVER_NUM => f(Some(Err(self.gpio))),
 
-            capsules::alarm::DRIVER_NUM => f(Some(Err(self.alarm))),
+            capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
             capsules::led::DRIVER_NUM => f(Some(Ok(self.led))),
             capsules::button::DRIVER_NUM => f(Some(Err(self.button))),
 

--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -142,7 +142,7 @@ impl kernel::Platform for Platform {
             capsules::console::DRIVER_NUM => f(Some(Ok(self.console))),
             capsules::proximity::DRIVER_NUM => f(Some(Ok(self.proximity))),
             capsules::gpio::DRIVER_NUM => f(Some(Err(self.gpio))),
-            capsules::alarm::DRIVER_NUM => f(Some(Err(self.alarm))),
+            capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
             capsules::led::DRIVER_NUM => f(Some(Ok(self.led))),
             capsules::button::DRIVER_NUM => f(Some(Err(self.button))),
             capsules::screen::DRIVER_NUM => f(Some(Ok(self.screen))),

--- a/boards/earlgrey-nexysvideo/src/main.rs
+++ b/boards/earlgrey-nexysvideo/src/main.rs
@@ -89,7 +89,7 @@ impl Platform for EarlGreyNexysVideo {
             capsules::hmac::DRIVER_NUM => f(Some(Err(self.hmac))),
             capsules::gpio::DRIVER_NUM => f(Some(Err(self.gpio))),
             capsules::console::DRIVER_NUM => f(Some(Ok(self.console))),
-            capsules::alarm::DRIVER_NUM => f(Some(Err(self.alarm))),
+            capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
             capsules::low_level_debug::DRIVER_NUM => f(Some(Err(self.lldb))),
             capsules::i2c_master::DRIVER_NUM => f(Some(Err(self.i2c_master))),
             capsules::nonvolatile_storage_driver::DRIVER_NUM => {

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -85,7 +85,7 @@ impl Platform for Hail {
             capsules::console::DRIVER_NUM => f(Some(Ok(self.console))),
             capsules::gpio::DRIVER_NUM => f(Some(Err(self.gpio))),
 
-            capsules::alarm::DRIVER_NUM => f(Some(Err(self.alarm))),
+            capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
             capsules::spi_controller::DRIVER_NUM => f(Some(Ok(self.spi))),
             capsules::nrf51822_serialization::DRIVER_NUM => f(Some(Err(self.nrf51822))),
             capsules::ambient_light::DRIVER_NUM => f(Some(Ok(self.ambient_light))),

--- a/boards/hifive1/src/main.rs
+++ b/boards/hifive1/src/main.rs
@@ -75,7 +75,7 @@ impl Platform for HiFive1 {
         match driver_num {
             capsules::led::DRIVER_NUM => f(Some(Ok(self.led))),
             capsules::console::DRIVER_NUM => f(Some(Ok(self.console))),
-            capsules::alarm::DRIVER_NUM => f(Some(Err(self.alarm))),
+            capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
             capsules::low_level_debug::DRIVER_NUM => f(Some(Err(self.lldb))),
             _ => f(None),
         }

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -173,9 +173,9 @@ impl kernel::Platform for Imix {
             capsules::ninedof::DRIVER_NUM => f(Some(Ok(self.ninedof))),
             capsules::crc::DRIVER_NUM => f(Some(Ok(self.crc))),
             capsules::usb::usb_user::DRIVER_NUM => f(Some(Err(self.usb_driver))),
-//            capsules::ieee802154::DRIVER_NUM => f(Some(Ok(self.radio_driver))),
+            capsules::ieee802154::DRIVER_NUM => f(Some(Ok(self.radio_driver))),
             capsules::net::udp::DRIVER_NUM => f(Some(Ok(self.udp_driver))),
-//            capsules::nrf51822_serialization::DRIVER_NUM => f(Some(Err(self.nrf51822))),
+            capsules::nrf51822_serialization::DRIVER_NUM => f(Some(Err(self.nrf51822))),
             capsules::nonvolatile_storage_driver::DRIVER_NUM => {
                 f(Some(Err(self.nonvolatile_storage)))
             }

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -161,7 +161,7 @@ impl kernel::Platform for Imix {
         match driver_num {
             capsules::console::DRIVER_NUM => f(Some(Ok(self.console))),
             capsules::gpio::DRIVER_NUM => f(Some(Err(self.gpio))),
-            capsules::alarm::DRIVER_NUM => f(Some(Err(self.alarm))),
+            capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
             capsules::spi_controller::DRIVER_NUM => f(Some(Ok(self.spi))),
             capsules::adc::DRIVER_NUM => f(Some(Err(self.adc))),
             capsules::led::DRIVER_NUM => f(Some(Ok(self.led))),
@@ -173,9 +173,9 @@ impl kernel::Platform for Imix {
             capsules::ninedof::DRIVER_NUM => f(Some(Ok(self.ninedof))),
             capsules::crc::DRIVER_NUM => f(Some(Ok(self.crc))),
             capsules::usb::usb_user::DRIVER_NUM => f(Some(Err(self.usb_driver))),
-            capsules::ieee802154::DRIVER_NUM => f(Some(Ok(self.radio_driver))),
+//            capsules::ieee802154::DRIVER_NUM => f(Some(Ok(self.radio_driver))),
             capsules::net::udp::DRIVER_NUM => f(Some(Ok(self.udp_driver))),
-            capsules::nrf51822_serialization::DRIVER_NUM => f(Some(Err(self.nrf51822))),
+//            capsules::nrf51822_serialization::DRIVER_NUM => f(Some(Err(self.nrf51822))),
             capsules::nonvolatile_storage_driver::DRIVER_NUM => {
                 f(Some(Err(self.nonvolatile_storage)))
             }

--- a/boards/imxrt1050-evkb/src/main.rs
+++ b/boards/imxrt1050-evkb/src/main.rs
@@ -84,7 +84,7 @@ impl Platform for Imxrt1050EVKB {
         F: FnOnce(Option<Result<&dyn kernel::Driver, &dyn kernel::LegacyDriver>>) -> R,
     {
         match driver_num {
-            capsules::alarm::DRIVER_NUM => f(Some(Err(self.alarm))),
+            capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
             capsules::button::DRIVER_NUM => f(Some(Err(self.button))),
             capsules::console::DRIVER_NUM => f(Some(Ok(self.console))),
             capsules::gpio::DRIVER_NUM => f(Some(Err(self.gpio))),

--- a/boards/litex/arty/src/main.rs
+++ b/boards/litex/arty/src/main.rs
@@ -147,7 +147,7 @@ impl Platform for LiteXArty {
         match driver_num {
             capsules::led::DRIVER_NUM => f(Some(Ok(self.led_driver))),
             capsules::console::DRIVER_NUM => f(Some(Ok(self.console))),
-            capsules::alarm::DRIVER_NUM => f(Some(Err(self.alarm))),
+            capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
             capsules::low_level_debug::DRIVER_NUM => f(Some(Err(self.lldb))),
             _ => f(None),
         }

--- a/boards/litex/sim/src/main.rs
+++ b/boards/litex/sim/src/main.rs
@@ -138,7 +138,7 @@ impl Platform for LiteXSim {
     {
         match driver_num {
             capsules::console::DRIVER_NUM => f(Some(Ok(self.console))),
-            capsules::alarm::DRIVER_NUM => f(Some(Err(self.alarm))),
+            capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
             capsules::low_level_debug::DRIVER_NUM => f(Some(Err(self.lldb))),
             _ => f(None),
         }

--- a/boards/microbit_v2/src/main.rs
+++ b/boards/microbit_v2/src/main.rs
@@ -113,7 +113,7 @@ impl kernel::Platform for Platform {
         match driver_num {
             capsules::console::DRIVER_NUM => f(Some(Ok(self.console))),
             capsules::gpio::DRIVER_NUM => f(Some(Err(self.gpio))),
-            capsules::alarm::DRIVER_NUM => f(Some(Err(self.alarm))),
+            capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
             capsules::button::DRIVER_NUM => f(Some(Err(self.button))),
             capsules::led_matrix::DRIVER_NUM => f(Some(Err(self.led))),
             capsules::ninedof::DRIVER_NUM => f(Some(Ok(self.ninedof))),

--- a/boards/msp_exp432p401r/src/main.rs
+++ b/boards/msp_exp432p401r/src/main.rs
@@ -71,7 +71,7 @@ impl Platform for MspExp432P401R {
             capsules::console::DRIVER_NUM => f(Some(Ok(self.console))),
             capsules::button::DRIVER_NUM => f(Some(Err(self.button))),
             capsules::gpio::DRIVER_NUM => f(Some(Err(self.gpio))),
-            capsules::alarm::DRIVER_NUM => f(Some(Err(self.alarm))),
+            capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
             kernel::ipc::DRIVER_NUM => f(Some(Err(&self.ipc))),
             capsules::adc::DRIVER_NUM => f(Some(Err(self.adc))),
             _ => f(None),

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -126,7 +126,7 @@ impl kernel::Platform for Platform {
             capsules::console::DRIVER_NUM => f(Some(Ok(self.console))),
             capsules::proximity::DRIVER_NUM => f(Some(Ok(self.proximity))),
             capsules::gpio::DRIVER_NUM => f(Some(Err(self.gpio))),
-            capsules::alarm::DRIVER_NUM => f(Some(Err(self.alarm))),
+            capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
             capsules::led::DRIVER_NUM => f(Some(Ok(self.led))),
             capsules::rng::DRIVER_NUM => f(Some(Ok(self.rng))),
             capsules::ble_advertising_driver::DRIVER_NUM => f(Some(Err(self.ble_radio))),

--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -107,7 +107,7 @@ impl kernel::Platform for Platform {
         match driver_num {
             capsules::console::DRIVER_NUM => f(Some(Ok(self.console))),
             capsules::gpio::DRIVER_NUM => f(Some(Err(self.gpio))),
-            capsules::alarm::DRIVER_NUM => f(Some(Err(self.alarm))),
+            capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
             capsules::led::DRIVER_NUM => f(Some(Ok(self.led))),
             capsules::button::DRIVER_NUM => f(Some(Err(self.button))),
             capsules::rng::DRIVER_NUM => f(Some(Ok(self.rng))),

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -184,7 +184,7 @@ impl kernel::Platform for Platform {
         match driver_num {
             capsules::console::DRIVER_NUM => f(Some(Ok(self.console))),
             capsules::gpio::DRIVER_NUM => f(Some(Err(self.gpio))),
-            capsules::alarm::DRIVER_NUM => f(Some(Err(self.alarm))),
+            capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
             capsules::led::DRIVER_NUM => f(Some(Ok(self.led))),
             capsules::button::DRIVER_NUM => f(Some(Err(self.button))),
             capsules::rng::DRIVER_NUM => f(Some(Ok(self.rng))),

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -166,7 +166,7 @@ impl kernel::Platform for Platform {
         match driver_num {
             capsules::console::DRIVER_NUM => f(Some(Ok(self.console))),
             capsules::gpio::DRIVER_NUM => f(Some(Err(self.gpio))),
-            capsules::alarm::DRIVER_NUM => f(Some(Err(self.alarm))),
+            capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
             capsules::led::DRIVER_NUM => f(Some(Ok(self.led))),
             capsules::button::DRIVER_NUM => f(Some(Err(self.button))),
             capsules::rng::DRIVER_NUM => f(Some(Ok(self.rng))),

--- a/boards/nucleo_f429zi/src/main.rs
+++ b/boards/nucleo_f429zi/src/main.rs
@@ -74,7 +74,7 @@ impl Platform for NucleoF429ZI {
             capsules::led::DRIVER_NUM => f(Some(Ok(self.led))),
             capsules::button::DRIVER_NUM => f(Some(Err(self.button))),
             capsules::adc::DRIVER_NUM => f(Some(Err(self.adc))),
-            capsules::alarm::DRIVER_NUM => f(Some(Err(self.alarm))),
+            capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
             capsules::temperature::DRIVER_NUM => f(Some(Ok(self.temperature))),
             kernel::ipc::DRIVER_NUM => f(Some(Err(&self.ipc))),
             capsules::gpio::DRIVER_NUM => f(Some(Err(self.gpio))),

--- a/boards/nucleo_f446re/src/main.rs
+++ b/boards/nucleo_f446re/src/main.rs
@@ -72,7 +72,7 @@ impl Platform for NucleoF446RE {
             capsules::console::DRIVER_NUM => f(Some(Ok(self.console))),
             capsules::led::DRIVER_NUM => f(Some(Ok(self.led))),
             capsules::button::DRIVER_NUM => f(Some(Err(self.button))),
-            capsules::alarm::DRIVER_NUM => f(Some(Err(self.alarm))),
+            capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
             kernel::ipc::DRIVER_NUM => f(Some(Err(&self.ipc))),
             _ => f(None),
         }

--- a/boards/redboard_artemis_nano/src/main.rs
+++ b/boards/redboard_artemis_nano/src/main.rs
@@ -72,7 +72,7 @@ impl Platform for RedboardArtemisNano {
         F: FnOnce(Option<Result<&dyn kernel::Driver, &dyn kernel::LegacyDriver>>) -> R,
     {
         match driver_num {
-            capsules::alarm::DRIVER_NUM => f(Some(Err(self.alarm))),
+            capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
             capsules::led::DRIVER_NUM => f(Some(Ok(self.led))),
             capsules::gpio::DRIVER_NUM => f(Some(Err(self.gpio))),
             capsules::console::DRIVER_NUM => f(Some(Ok(self.console))),

--- a/boards/stm32f3discovery/src/main.rs
+++ b/boards/stm32f3discovery/src/main.rs
@@ -82,7 +82,7 @@ impl Platform for STM32F3Discovery {
             capsules::console::DRIVER_NUM => f(Some(Ok(self.console))),
             capsules::led::DRIVER_NUM => f(Some(Ok(self.led))),
             capsules::button::DRIVER_NUM => f(Some(Err(self.button))),
-            capsules::alarm::DRIVER_NUM => f(Some(Err(self.alarm))),
+            capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
             capsules::gpio::DRIVER_NUM => f(Some(Err(self.gpio))),
             capsules::l3gd20::DRIVER_NUM => f(Some(Ok(self.l3gd20))),
             capsules::lsm303dlhc::DRIVER_NUM => f(Some(Err(self.lsm303dlhc))),

--- a/boards/stm32f412gdiscovery/src/main.rs
+++ b/boards/stm32f412gdiscovery/src/main.rs
@@ -74,7 +74,7 @@ impl Platform for STM32F412GDiscovery {
             capsules::console::DRIVER_NUM => f(Some(Ok(self.console))),
             capsules::led::DRIVER_NUM => f(Some(Ok(self.led))),
             capsules::button::DRIVER_NUM => f(Some(Err(self.button))),
-            capsules::alarm::DRIVER_NUM => f(Some(Err(self.alarm))),
+            capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
             kernel::ipc::DRIVER_NUM => f(Some(Err(&self.ipc))),
             capsules::gpio::DRIVER_NUM => f(Some(Err(self.gpio))),
             capsules::adc::DRIVER_NUM => f(Some(Err(self.adc))),

--- a/boards/teensy40/src/main.rs
+++ b/boards/teensy40/src/main.rs
@@ -50,7 +50,7 @@ impl kernel::Platform for Teensy40 {
             capsules::led::DRIVER_NUM => f(Some(Ok(self.led))),
             capsules::console::DRIVER_NUM => f(Some(Ok(self.console))),
             kernel::ipc::DRIVER_NUM => f(Some(Err(&self.ipc))),
-            capsules::alarm::DRIVER_NUM => f(Some(Err(self.alarm))),
+            capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
             _ => f(None),
         }
     }

--- a/capsules/src/alarm.rs
+++ b/capsules/src/alarm.rs
@@ -3,7 +3,6 @@
 
 use core::cell::Cell;
 use core::mem;
-use kernel::debug;
 use kernel::hil::time::{self, Alarm, Frequency, Ticks, Ticks32};
 use kernel::ReturnCode;
 use kernel::{AppId, Callback, CommandResult, Driver, ErrorCode, Grant};

--- a/capsules/src/alarm.rs
+++ b/capsules/src/alarm.rs
@@ -242,7 +242,6 @@ impl<'a, A: Alarm<'a>> Driver for AlarmDriver<'a, A> {
                         let future_time = data;
                         let dt = future_time.wrapping_sub(reference);
                         // if previously unarmed, but now will become armed
-                        debug!("Alarm.rs: setting to {} + {}", reference, dt);
                         rearm(reference, dt)
                     },
                     5 /* Set relative expiration */ => {

--- a/capsules/src/alarm.rs
+++ b/capsules/src/alarm.rs
@@ -2,8 +2,11 @@
 //! a point in time has been reached.
 
 use core::cell::Cell;
+use core::mem;
 use kernel::hil::time::{self, Alarm, Frequency, Ticks, Ticks32};
-use kernel::{AppId, Callback, Grant, LegacyDriver, ReturnCode};
+use kernel::{AppId, Callback, CommandResult, Driver, ErrorCode, Grant};
+use kernel::{ReturnCode};
+use kernel::debug;
 
 /// Syscall driver number.
 use crate::driver;
@@ -18,14 +21,14 @@ enum Expiration {
 #[derive(Copy, Clone)]
 pub struct AlarmData {
     expiration: Expiration,
-    callback: Option<Callback>,
+    callback: Callback,
 }
 
 impl Default for AlarmData {
     fn default() -> AlarmData {
         AlarmData {
             expiration: Expiration::Disabled,
-            callback: None,
+            callback: Callback::default(),
         }
     }
 }
@@ -143,7 +146,7 @@ impl<'a, A: Alarm<'a>> AlarmDriver<'a, A> {
     }
 }
 
-impl<'a, A: Alarm<'a>> LegacyDriver for AlarmDriver<'a, A> {
+impl<'a, A: Alarm<'a>> Driver for AlarmDriver<'a, A> {
     /// Subscribe to alarm expiration
     ///
     /// ### `_subscribe_num`
@@ -151,16 +154,26 @@ impl<'a, A: Alarm<'a>> LegacyDriver for AlarmDriver<'a, A> {
     /// - `0`: Subscribe to alarm expiration
     fn subscribe(
         &self,
-        _subscribe_num: usize,
-        callback: Option<Callback>,
+        subscribe_num: usize,
+        mut callback: Callback,
         app_id: AppId,
-    ) -> ReturnCode {
-        self.app_alarms
-            .enter(app_id, |td, _allocator| {
-                td.callback = callback;
-                ReturnCode::SUCCESS
-            })
-            .unwrap_or_else(|err| err.into())
+    ) -> Result<Callback, (Callback, ErrorCode)> {
+        let res: Result<(), ErrorCode> = match subscribe_num {
+            0 => {
+                self.app_alarms
+                    .enter(app_id, |td, _allocator| {
+                        mem::swap(&mut callback, &mut td.callback);
+                    })
+                    .map_err(ErrorCode::from)
+            },
+            _ => Err(ErrorCode::NOSUPPORT)
+        };
+
+        if let Err(e) = res {
+            Err((callback, e))
+        } else {
+            Ok(callback)
+        }
     }
 
     /// Setup and read the alarm.
@@ -173,7 +186,7 @@ impl<'a, A: Alarm<'a>> LegacyDriver for AlarmDriver<'a, A> {
     /// - `3`: Stop the alarm if it is outstanding
     /// - `4`: Set an alarm to fire at a given clock value `time`.
     /// - `5`: Set an alarm to fire at a given clock value `time` relative to `now` (EXPERIMENTAL).
-    fn command(&self, cmd_type: usize, data: usize, data2: usize, caller_id: AppId) -> ReturnCode {
+    fn command(&self, cmd_type: usize, data: usize, data2: usize, caller_id: AppId) -> CommandResult {
         // Returns the error code to return to the user and whether we need to
         // reset which is the next active alarm. We _don't_ reset if
         //   - we're disabling the underlying alarm anyway,
@@ -191,34 +204,31 @@ impl<'a, A: Alarm<'a>> LegacyDriver for AlarmDriver<'a, A> {
                         dt: dt as u32,
                     };
                     (
-                        ReturnCode::SuccessWithValue {
-                            value: reference.wrapping_add(dt),
-                        },
+                        CommandResult::success_u32(reference.wrapping_add(dt) as u32),
                         true,
                     )
                 };
                 let now = self.alarm.now();
-                let (return_code, reset) = match cmd_type {
-                    0 /* check if present */ => (ReturnCode::SuccessWithValue { value: 1 }, false),
+                let (result, reset) = match cmd_type {
+                    0 /* check if present */ => (CommandResult::success(), false),
                     1 /* Get clock frequency */ => {
-                        let freq = <A::Frequency>::frequency() as usize;
-                        (ReturnCode::SuccessWithValue { value: freq }, false)
+                        let freq = <A::Frequency>::frequency();
+                        (CommandResult::success_u32(freq), false)
                     },
                     2 /* capture time */ => {
-                        (ReturnCode::SuccessWithValue { value: now.into_u32() as usize },
-                         false)
+                        (CommandResult::success_u32(now.into_u32()), false)
                     },
                     3 /* Stop */ => {
                         match td.expiration {
                             Expiration::Disabled => {
                                 // Request to stop when already stopped
-                                (ReturnCode::EALREADY, false)
+                                (CommandResult::failure(ErrorCode::ALREADY), false)
                             },
                             _ => {
                                 td.expiration = Expiration::Disabled;
                                 let new_num_armed = self.num_armed.get() - 1;
                                 self.num_armed.set(new_num_armed);
-                                (ReturnCode::SUCCESS, true)
+                                (CommandResult::success(), true)
                             }
                         }
                     },
@@ -227,6 +237,7 @@ impl<'a, A: Alarm<'a>> LegacyDriver for AlarmDriver<'a, A> {
                         let future_time = data;
                         let dt = future_time.wrapping_sub(reference);
                         // if previously unarmed, but now will become armed
+                        debug!("Alarm.rs: setting to {} + {}", reference, dt);
                         rearm(reference, dt)
                     },
                     5 /* Set relative expiration */ => {
@@ -245,14 +256,17 @@ impl<'a, A: Alarm<'a>> LegacyDriver for AlarmDriver<'a, A> {
                         let dt = data2;
                         rearm(reference, dt)
                     }
-                    _ => (ReturnCode::ENOSUPPORT, false)
+                    _ => (CommandResult::failure(ErrorCode::NOSUPPORT), false)
                 };
                 if reset {
                     self.reset_active_alarm();
                 }
-                return_code
+                result
             })
-            .unwrap_or_else(|err| err.into())
+            .unwrap_or_else(|err| {
+                let rcode: ReturnCode = err.into();
+                CommandResult::from(rcode)
+            })
     }
 }
 
@@ -269,13 +283,11 @@ impl<'a, A: Alarm<'a>> time::AlarmClient for AlarmDriver<'a, A> {
                 ) {
                     alarm.expiration = Expiration::Disabled;
                     self.num_armed.set(self.num_armed.get() - 1);
-                    alarm.callback.map(|mut cb| {
-                        cb.schedule(
-                            now.into_u32() as usize,
-                            reference.wrapping_add(dt) as usize,
-                            0,
-                        )
-                    });
+                    alarm.callback.schedule(
+                        now.into_u32() as usize,
+                        reference.wrapping_add(dt) as usize,
+                        0,
+                    );
                 }
             }
         });


### PR DESCRIPTION
### Pull Request Overview

This pull requests updates the alarm system call driver to use the 2.0 syscall API.


### Testing Strategy

This pull request was tested by running two copies of multi_alarm_test in parallel on the imix platform. I found a few bugs while doing so, which led me to update libtock-c's alarm code to use the new (reference, dt) system calls. It had still be using just an absolute time, which if there are long delays due to printfs can cause the hang-on-alarm-in-the-past bug.


### TODO or Help Wanted


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
