### PR TITLE
rv32i: fix race condition of interrupt in switch_to_process

### DIFF
--- a/arch/rv32i/src/lib.rs
+++ b/arch/rv32i/src/lib.rs
@@ -158,6 +158,19 @@ pub extern "C" fn _start_trap() {
             //
             // We use the csrrw instruction to save the current stack pointer
             // so we can retrieve it if necessary.
+            //
+            // If we could enter this trap handler twice (for example,
+            // handling an interrupt while an exception is being
+            // handled), storing a non-zero value in mscratch
+            // temporarily could cause a race condition similar to the
+            // one of PR 2308[1].
+            // However, as indicated in section 3.1.6.1 of the RISC-V
+            // Privileged Spec[2], MIE will be set to 0 when taking a
+            // trap into machine mode. Therefore, this can only happen
+            // when causing an exception in the trap handler itself.
+            //
+            // [1] https://github.com/tock/tock/pull/2308
+            // [2] https://github.com/riscv/riscv-isa-manual/releases/download/draft-20201222-42dc13a/riscv-privileged.pdf
             csrrw sp, 0x340, sp // CSR=0x340=mscratch
             bnez  sp, _from_app // If sp != 0 then we must have come from an app.
 

--- a/arch/rv32i/src/syscall.rs
+++ b/arch/rv32i/src/syscall.rs
@@ -231,7 +231,7 @@ impl kernel::syscall::UserspaceKernelBoundary for SysCall {
           //   0x00000008 -> bit 3 -> MIE (disabling interrupts here)
           // + 0x00001800 -> bits 11,12 -> MPP (switch to usermode on mret)
           li t0, 0x00001808
-          csrrc x0, 0x300, t0
+          csrrc x0, 0x300, t0      // clear bits in mstatus, don't care about read
 
           // Afterwards, set the following bits in mstatus:
           //   0x00000080 -> bit 7 -> MPIE (enable interrupts on mret)

--- a/arch/rv32i/src/syscall.rs
+++ b/arch/rv32i/src/syscall.rs
@@ -236,7 +236,7 @@ impl kernel::syscall::UserspaceKernelBoundary for SysCall {
           // Afterwards, set the following bits in mstatus:
           //   0x00000080 -> bit 7 -> MPIE (enable interrupts on mret)
           li t0, 0x00000080
-          csrrs x0, 0x300, t0
+          csrrs x0, 0x300, t0      // set bits in mstatus, don't care about read
 
 
           // Store the address to jump back to on the stack so that the trap


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes a race condition in the `rv32i` implementation of `switch_to_process(`.

On `rv32i`, the machine mode only has a single trap handler. Upon entering this trap handler, the kernel uses the `mscratch` CSR to determine whether the trap came from usermode or kernelmode.

However, in `switch_to_process(`, the `mscratch` register is written with the address of the kernel stack _prior_ to disabling interrupts in machine mode. This introduces a race condition where, if an interrupt comes in between those two steps, the trap handler determines the trap to come from usermode where it really occured in kernel mode. As a consequence, the trap handler saves the CPU state (which belongs at least in part to the kernel) into the process state.

As soon as the process is scheduled again, the registers of the kernel (as saved in the trap handler) are unpacked. Furthermore, the `mepc` register is set to a program counter that belongs to kernel mode. The process will immediately fault due to an instruction memory access violation.

#### Analysis

This race condition was really hard to find, it took me a couple of days to catch up on many RISC-V details, the precise Tock architecture implementation, etc. I observed this behavior for the past few weeks while developing an Ethernet application on the LiteX Arty.

The race condition can be reliably reproduced on the LiteX Arty board, running an `lwip` network stack in userspace and executing a ping-flood against the board, which would send ~1400pkts/second to the hardware and cause ~2800 interrupts/second in unpredictable intervals. After at most 10-20 minutes, the board would show that a process has faulted:

```
---| App Status |---
App: tap_network   -   [Fault]
 Events Queued: 1   Syscall Count: 238540   Dropped Callback Count: 0
 Restart Count: 0
 Last Syscall: Some(COMMAND { driver_number: 0, subdriver_number: 2, arg0: 0, arg1: 0 })

 R0 : 0x00000000    R16: 0x00000000
 R1 : 0x4000A4E6    R17: 0x00000002
 R2 : 0x42004E48    R18: 0x00000000
 R3 : 0x42008800    R19: 0x42008C8C
 R4 : 0x00000000    R20: 0x40002430
 R5 : 0x00000080    R21: 0x4000F9AD
 R6 : 0xFFFFE7F7    R22: 0x42008C84
 R7 : 0x42017FD4    R23: 0x4000FE68
 R8 : 0x42017E28    R24: 0x4200C9F0
 R9 : 0x42004FA8    R25: 0x00000000
 R10: 0x42017ED4    R26: 0x00000001
 R11: 0x00000000    R27: 0x33333333
 R12: 0x00000004    R28: 0x00000000
 R13: 0x42009214    R29: 0x00000008
 R14: 0x00000004    R30: 0x00000001
 R15: 0x00000004    R31: 0x00000001
 PC : 0x40006EDE    SP : 0x42004E48

 mcause: 0x0000000C (Instruction page fault)
 mtval:  0x40006EDC

 PMP regions:
  [0]: addr=0x41000000, size=0x00020000, cfg=0xD (r-x)
  [1]: addr=0x4200d800, size=0x00003800, cfg=0xB (rw-)
```

It's been particularly interesting to see a bunch of kernel-pointers in the app's register file. Trying to debug the kernel using if-statements, printf-debugging and even branches in assembly often made the problem less likely to occur and didn't yield any results.

To diagnose the issue, I've added the ibex's `rvfi_tracer` module to the VexRiscv-CPU and ran a similar setup in the LiteX Verilated simulation. After running it for a few hours and generating over 60GB of instruction traces, the race condition occurred there too. With a lot of grep, head and tail the issue revealed itself :smile::

```
PC              Instruction     Decoded instruction       Registers
000037f8        09f12023        sw      x31,128(x2)       x2:0x40004e88 x31:0x00020000 PA:0x40004f08 load:0x00000000
000037fc        00b12223        sw      x11,4(x2)         x2:0x40004e88 x11:0x4001f6d4 PA:0x40004e8c load:0x00000000
00003800        000042b7        lui     x5,0x4            x5=0x00004000
00003804        8dc28293        addi    x5,x5,-1828       x5:0x00004000  x5=0x000038dc
00003808        00512423        sw      x5,8(x2)          x2:0x40004e88  x5:0x000038dc PA:0x40004e90 load:0x00000003
0000380c        34011073        csrrw   x0,mscratch,x2    x2:0x40004e88  x0=0x00000000
00003810        300022f3        csrrs   x5,mstatus,x0     x0:0x00000000  x5=0x00000088
00003814        00002337        lui     x6,0x2            x6=0x00002000
00003818        80830313        addi    x6,x6,-2040       x6:0x00002000  x6=0x00001808
0000381c        fff34313        xori    x6,x6,-1          x6:0x00001808  x6=0xffffe7f7
00003820        0062f2b3        and     x5,x5,x6          x5:0x00000088  x6:0xffffe7f7  x5=0x00000080
00003824        0802e293        ori     x5,x5,128         x5:0x00000080  x5=0x00000080
00000100        34011173        csrrw   x2,mscratch,x2    x2:0x40004e88  x2=0x40004e88
00000104        0a011a63        bne     x2,x0,1b8         x2:0x40004e88  x0:0x00000000  x0=0x00000000
000001b8        00812023        sw      x8,0(x2)          x2:0x40004e88  x8:0x4001f628 PA:0x40004e88 load:0x00000003
```

In this case, an interrupt occurred after (during) the intruction at `0x3824` (`ori x5, x5, 128`), which causes the CPU to jump to the trap handler. Given that the kernel stack pointer was already written to `mscratch` in `0x380c`, the trap handler will determine that this interrupt/exception must have come from a process context and will store the register file in the process state accordingly. When trying scheduling the process a second time, the program counter (along with other kernel state) will be unpacked, causing the process to fault immediately.

#### Proposed fix

This proposed fix changes the order of writing mscratch and disabling interrupts. It furthermore switches to using the "Atomic Read and Clear/Set Bit in CSR" instructions to avoid an interrupt from arriving and changing mstatus between the CSR read and CSR write.


### Testing Strategy

This pull request was tested by running a ping flood for ~10h. The app didn't fault.

```
~> sudo ping 10.11.12.13 -f
PING 10.11.12.13 (10.11.12.13) 56(84) bytes of data.
--- 10.11.12.13 ping statistics ---
53760885 packets transmitted, 53760738 received, 0.000273433% packet loss, time 39282028ms
rtt min/avg/max/mdev = 0.495/0.631/16.743/0.098 ms, pipe 2, ipg/ewma 0.730/0.582 ms
```

### Help Wanted

This used to contain [a question about nested traps, and whether it's safe to modify `mscratch` there](https://gist.github.com/lschuermann/8ace8d286810a8f1991bb300b6458048). As indicated in [this comment](https://gist.github.com/lschuermann/8ace8d286810a8f1991bb300b6458048), this does not seem to be an issue.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
