### PR TITLE
chips/lowrisc: Ensure we don't write over the flash region

### DIFF
--- a/chips/lowrisc/src/flash_ctrl.rs
+++ b/chips/lowrisc/src/flash_ctrl.rs
@@ -142,7 +142,7 @@ register_bitfields![u32,
     ]
 ];
 
-const PAGE_SIZE: usize = 1024;
+const PAGE_SIZE: usize = 512;
 
 pub struct LowRiscPage(pub [u8; PAGE_SIZE as usize]);
 
@@ -465,7 +465,7 @@ impl hil::flash::Flash for FlashCtrl<'_> {
 
         // Write the data until we are full or have written all the data
         while !self.registers.status.is_set(STATUS::PROG_FULL)
-            && self.write_index.get() < buf.0.len()
+            && self.write_index.get() < (buf.0.len() - 4)
         {
             let buf_offset = self.write_index.get();
             let data: u32 = buf[buf_offset] as u32


### PR DESCRIPTION
### Pull Request Overview

Ensure that we don't write too much data. Also reduce the page size to
512 bytes to match the lowRISC software.

### Testing Strategy

OT hardware

### TODO or Help Wanted

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
