### PR TITLE
Tock 2.0: update ADC driver to 2.0 API

### DIFF
--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -89,7 +89,7 @@ impl Platform for Hail {
             capsules::spi_controller::DRIVER_NUM => f(Some(Ok(self.spi))),
             capsules::nrf51822_serialization::DRIVER_NUM => f(Some(Err(self.nrf51822))),
             capsules::ambient_light::DRIVER_NUM => f(Some(Ok(self.ambient_light))),
-            capsules::adc::DRIVER_NUM => f(Some(Err(self.adc))),
+            capsules::adc::DRIVER_NUM => f(Some(Ok(self.adc))),
             capsules::led::DRIVER_NUM => f(Some(Ok(self.led))),
             capsules::button::DRIVER_NUM => f(Some(Err(self.button))),
             capsules::humidity::DRIVER_NUM => f(Some(Ok(self.humidity))),

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -163,7 +163,7 @@ impl kernel::Platform for Imix {
             capsules::gpio::DRIVER_NUM => f(Some(Err(self.gpio))),
             capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
             capsules::spi_controller::DRIVER_NUM => f(Some(Ok(self.spi))),
-            capsules::adc::DRIVER_NUM => f(Some(Err(self.adc))),
+            capsules::adc::DRIVER_NUM => f(Some(Ok(self.adc))),
             capsules::led::DRIVER_NUM => f(Some(Ok(self.led))),
             capsules::button::DRIVER_NUM => f(Some(Err(self.button))),
             capsules::analog_comparator::DRIVER_NUM => f(Some(Ok(self.analog_comparator))),

--- a/boards/microbit_v2/src/main.rs
+++ b/boards/microbit_v2/src/main.rs
@@ -117,7 +117,7 @@ impl kernel::Platform for Platform {
             capsules::button::DRIVER_NUM => f(Some(Err(self.button))),
             capsules::led_matrix::DRIVER_NUM => f(Some(Ok(self.led))),
             capsules::ninedof::DRIVER_NUM => f(Some(Ok(self.ninedof))),
-            capsules::adc::DRIVER_NUM => f(Some(Err(self.adc))),
+            capsules::adc::DRIVER_NUM => f(Some(Ok(self.adc))),
             capsules::temperature::DRIVER_NUM => f(Some(Ok(self.temperature))),
             capsules::lsm303agr::DRIVER_NUM => f(Some(Ok(self.lsm303agr))),
             capsules::rng::DRIVER_NUM => f(Some(Ok(self.rng))),

--- a/boards/msp_exp432p401r/src/main.rs
+++ b/boards/msp_exp432p401r/src/main.rs
@@ -73,7 +73,7 @@ impl Platform for MspExp432P401R {
             capsules::gpio::DRIVER_NUM => f(Some(Err(self.gpio))),
             capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
             kernel::ipc::DRIVER_NUM => f(Some(Err(&self.ipc))),
-            capsules::adc::DRIVER_NUM => f(Some(Err(self.adc))),
+            capsules::adc::DRIVER_NUM => f(Some(Ok(self.adc))),
             _ => f(None),
         }
     }

--- a/boards/nucleo_f429zi/src/main.rs
+++ b/boards/nucleo_f429zi/src/main.rs
@@ -73,7 +73,7 @@ impl Platform for NucleoF429ZI {
             capsules::console::DRIVER_NUM => f(Some(Ok(self.console))),
             capsules::led::DRIVER_NUM => f(Some(Ok(self.led))),
             capsules::button::DRIVER_NUM => f(Some(Err(self.button))),
-            capsules::adc::DRIVER_NUM => f(Some(Err(self.adc))),
+            capsules::adc::DRIVER_NUM => f(Some(Ok(self.adc))),
             capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
             capsules::temperature::DRIVER_NUM => f(Some(Ok(self.temperature))),
             kernel::ipc::DRIVER_NUM => f(Some(Err(&self.ipc))),

--- a/boards/stm32f3discovery/src/main.rs
+++ b/boards/stm32f3discovery/src/main.rs
@@ -89,7 +89,7 @@ impl Platform for STM32F3Discovery {
             capsules::ninedof::DRIVER_NUM => f(Some(Ok(self.ninedof))),
             capsules::temperature::DRIVER_NUM => f(Some(Ok(self.temp))),
             kernel::ipc::DRIVER_NUM => f(Some(Err(&self.ipc))),
-            capsules::adc::DRIVER_NUM => f(Some(Err(self.adc))),
+            capsules::adc::DRIVER_NUM => f(Some(Ok(self.adc))),
             capsules::nonvolatile_storage_driver::DRIVER_NUM => {
                 f(Some(Err(self.nonvolatile_storage)))
             }

--- a/boards/stm32f412gdiscovery/src/main.rs
+++ b/boards/stm32f412gdiscovery/src/main.rs
@@ -77,7 +77,7 @@ impl Platform for STM32F412GDiscovery {
             capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
             kernel::ipc::DRIVER_NUM => f(Some(Err(&self.ipc))),
             capsules::gpio::DRIVER_NUM => f(Some(Err(self.gpio))),
-            capsules::adc::DRIVER_NUM => f(Some(Err(self.adc))),
+            capsules::adc::DRIVER_NUM => f(Some(Ok(self.adc))),
             capsules::ft6x06::DRIVER_NUM => f(Some(Ok(self.ft6x06))),
             capsules::touch::DRIVER_NUM => f(Some(Ok(self.touch))),
             capsules::screen::DRIVER_NUM => f(Some(Ok(self.screen))),

--- a/capsules/src/adc.rs
+++ b/capsules/src/adc.rs
@@ -343,7 +343,7 @@ impl<'a, A: hil::adc::Adc + hil::adc::AdcHighSpeed> AdcDedicated<'a, A> {
             self.apps
                 .enter(*id, |state, _| {
                     app_buf_length = state.app_buf1.len();
-                    state.app_buf1.len() > 0
+                    app_buf_length > 0
                 })
                 .map_err(|err| {
                     if err == kernel::procs::Error::NoSuchApp

--- a/capsules/src/adc.rs
+++ b/capsules/src/adc.rs
@@ -1251,7 +1251,6 @@ impl<A: hil::adc::Adc + hil::adc::AdcHighSpeed> Driver for AdcDedicated<'_, A> {
             // Single sample on channel
             1 => match self.sample(channel) {
                 ReturnCode::SUCCESS => CommandResult::success(),
-                ReturnCode::SuccessWithValue { value } => CommandResult::success_u32(value as u32),
                 e => CommandResult::failure(if let Ok(err) = ErrorCode::try_from(e) {
                     err
                 } else {
@@ -1262,7 +1261,6 @@ impl<A: hil::adc::Adc + hil::adc::AdcHighSpeed> Driver for AdcDedicated<'_, A> {
             // Repeated single samples on a channel
             2 => match self.sample_continuous(channel, frequency as u32) {
                 ReturnCode::SUCCESS => CommandResult::success(),
-                ReturnCode::SuccessWithValue { value } => CommandResult::success_u32(value as u32),
                 e => CommandResult::failure(if let Ok(err) = ErrorCode::try_from(e) {
                     err
                 } else {
@@ -1273,7 +1271,6 @@ impl<A: hil::adc::Adc + hil::adc::AdcHighSpeed> Driver for AdcDedicated<'_, A> {
             // Multiple sample on a channel
             3 => match self.sample_buffer(channel, frequency as u32) {
                 ReturnCode::SUCCESS => CommandResult::success(),
-                ReturnCode::SuccessWithValue { value } => CommandResult::success_u32(value as u32),
                 e => CommandResult::failure(if let Ok(err) = ErrorCode::try_from(e) {
                     err
                 } else {
@@ -1284,7 +1281,6 @@ impl<A: hil::adc::Adc + hil::adc::AdcHighSpeed> Driver for AdcDedicated<'_, A> {
             // Continuous buffered sampling on a channel
             4 => match self.sample_buffer_continuous(channel, frequency as u32) {
                 ReturnCode::SUCCESS => CommandResult::success(),
-                ReturnCode::SuccessWithValue { value } => CommandResult::success_u32(value as u32),
                 e => CommandResult::failure(if let Ok(err) = ErrorCode::try_from(e) {
                     err
                 } else {
@@ -1295,7 +1291,6 @@ impl<A: hil::adc::Adc + hil::adc::AdcHighSpeed> Driver for AdcDedicated<'_, A> {
             // Stop sampling
             5 => match self.stop_sampling() {
                 ReturnCode::SUCCESS => CommandResult::success(),
-                ReturnCode::SuccessWithValue { value } => CommandResult::success_u32(value as u32),
                 e => CommandResult::failure(if let Ok(err) = ErrorCode::try_from(e) {
                     err
                 } else {


### PR DESCRIPTION
### Pull Request Overview

This pull request updates the ADC driver to Tock 2.0 API.

### Testing Strategy

I tested the simple ADC using a Microbit v2.
High Speed ADC has not yet been tested.

### TODO or Help Wanted

As I have no board that supports the high speed ADC, @hudson-ayers offered to help and test it. A PR with the new API is available (tock/libtock-c#149).

As the high speed part has some tricky code parts, this PR needs a careful review, mostly for the buffer filling part.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
