### PR TITLE
riscv: more llvm_asm --> asm

### DIFF
--- a/chips/earlgrey/src/chip.rs
+++ b/chips/earlgrey/src/chip.rs
@@ -1,7 +1,6 @@
 //! High-level setup and interrupt mapping for the chip.
 
 use core::fmt::Write;
-use core::hint::unreachable_unchecked;
 use kernel;
 use kernel::debug;
 use kernel::hil::time::Alarm;
@@ -344,6 +343,7 @@ pub unsafe fn configure_trap_handler() {
 // compilation environment may not allow the section name.
 #[cfg(not(any(target_arch = "riscv32", target_os = "none")))]
 pub extern "C" fn _start_trap_vectored() {
+    use core::hint::unreachable_unchecked;
     unsafe {
         unreachable_unchecked();
     }
@@ -362,8 +362,8 @@ pub extern "C" fn _start_trap_vectored() -> ! {
         //
         // Below are 32 (non-compressed) jumps to cover the entire possible
         // range of vectored traps.
-        #[cfg(all(target_arch = "riscv32", target_os = "none"))]
-        llvm_asm!("
+        asm!(
+            "
             j _start_trap
             j _start_trap
             j _start_trap
@@ -396,11 +396,8 @@ pub extern "C" fn _start_trap_vectored() -> ! {
             j _start_trap
             j _start_trap
             j _start_trap
-        "
-        :
-        :
-        :
-        : "volatile");
-        unreachable_unchecked()
+        ",
+            options(noreturn)
+        );
     }
 }

--- a/chips/earlgrey/src/lib.rs
+++ b/chips/earlgrey/src/lib.rs
@@ -1,6 +1,6 @@
 //! Drivers and chip support for EarlGrey.
 
-#![feature(llvm_asm, const_fn, naked_functions)]
+#![feature(llvm_asm, asm, const_fn, naked_functions)]
 #![no_std]
 #![crate_name = "earlgrey"]
 #![crate_type = "rlib"]


### PR DESCRIPTION
### Pull Request Overview

This pull request converts several more uses of llvm_asm --> asm, for a few risc-v platforms. I specifically chose the instances contained within `#[naked]` functions, which are disallowed in newer versions of rustc.


### Testing Strategy

This pull request was tested by *compiling only*!


### TODO or Help Wanted

testing plz

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
