### PR TITLE
Make out-of-tree builds easier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,8 +53,8 @@ doc/rustdoc
 # are manually included for releases.
 Cargo.lock
 
-# The QEMU build directory
-tools/qemu/build
+# The QEMU directory
+tools/qemu
 
 # Python scripts
 __pycache__

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "tools/qemu"]
-	path = tools/qemu
-	url = https://git.qemu.org/git/qemu.git

--- a/Makefile
+++ b/Makefile
@@ -78,8 +78,9 @@ define ci_setup_helper
 	$(eval explanation := $(strip $(2)))
 	$(eval build_function := $(strip $(3)))
 	$(eval guard_variable := $(strip $(4)))
+	$(eval already_installed := $(shell $(1)))
 	@# First, if the dependency is installed, we can bail early
-	$(if $(shell '$(1)'),$(eval $(guard_variable) := true),
+	$(if $(already_installed),$(eval $(guard_variable) := true),
 	@# If running in CI context always yes
 	$(if $(CI),$(eval do_install := yes_CI),
 	@# If running nosetup always no
@@ -494,12 +495,13 @@ ci-job-miri: ci-setup-miri
 
 ### ci-runner-github-qemu jobs:
 
+QEMU_COMMIT_HASH=a05f8ecd88f15273d033b6f044b850a8af84a5b8
 define ci_setup_qemu_riscv
 	$(call banner,CI-Setup: Build QEMU)
 	@# Use the latest QEMU as it has OpenTitan support
 	@printf "Building QEMU, this could take a few minutes\n\n"
-	@git submodule sync; git submodule update --init
-	@cd tools/qemu; ../qemu/configure --target-list=riscv32-softmmu --disable-linux-io-uring --disable-libdaxctl;
+  @git clone https://github.com/qemu/qemu ./tools/qemu 2>/dev/null || echo "qemu already cloned, checking out"
+	@cd tools/qemu; git checkout ${QEMU_COMMIT_HASH}; ../qemu/configure --target-list=riscv32-softmmu --disable-linux-io-uring --disable-libdaxctl;
 	@# Build qemu
 	@$(MAKE) -C "tools/qemu/build" || (echo "You might need to install some missing packages" || exit 127)
 endef
@@ -523,8 +525,7 @@ endef
 .PHONY: ci-setup-qemu
 ci-setup-qemu:
 	$(call ci_setup_helper,\
-		status=$$(git submodule status -- tools/qemu); \
-		[[ "$${status:0:1}" != "" ]] && \
+		[[ $$(git -C ./tools/qemu rev-parse HEAD 2>/dev/null || echo 0) == "${QEMU_COMMIT_HASH}" ]] && \
 			cd tools/qemu/build && make -q riscv32-softmmu && echo yes,\
 		Clone QEMU and run its build scripts,\
 		ci_setup_qemu_riscv,\

--- a/Makefile
+++ b/Makefile
@@ -500,7 +500,7 @@ define ci_setup_qemu_riscv
 	$(call banner,CI-Setup: Build QEMU)
 	@# Use the latest QEMU as it has OpenTitan support
 	@printf "Building QEMU, this could take a few minutes\n\n"
-  @git clone https://github.com/qemu/qemu ./tools/qemu 2>/dev/null || echo "qemu already cloned, checking out"
+	@git clone https://github.com/qemu/qemu ./tools/qemu 2>/dev/null || echo "qemu already cloned, checking out"
 	@cd tools/qemu; git checkout ${QEMU_COMMIT_HASH}; ../qemu/configure --target-list=riscv32-softmmu --disable-linux-io-uring --disable-libdaxctl;
 	@# Build qemu
 	@$(MAKE) -C "tools/qemu/build" || (echo "You might need to install some missing packages" || exit 127)


### PR DESCRIPTION
I'm trying to use Tock as a dependency for the Tock bootloader. Here is an example Cargo.toml file:

```
[package]
name = "nano33-bootloader"
version = "0.1.0"
authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
build = "build.rs"
edition = "2018"

[dependencies]
cortexm4 = { git = "https://github.com/tock/tock", branch = "master" }
capsules = { git = "https://github.com/tock/tock", branch = "master" }
kernel = { git = "https://github.com/tock/tock", branch = "master" }
nrf52 = { git = "https://github.com/tock/tock", branch = "master" }
nrf52840 = { git = "https://github.com/tock/tock", branch = "master" }
components = { git = "https://github.com/tock/tock", branch = "master" }
nrf52_components = { git = "https://github.com/tock/tock", branch = "master" }

bootloader = { path = "../../bootloader" }
bootloader_nrf52 = { path = "../../chips/bootloader_nrf52" }
bootloader_cortexm = { path = "../../arch/bootloader_cortexm" }
```

This however causes cargo to fetch all Tock submodules and all of _their_ submodules. This takes a very long time (10-15 minutes on my computer). Worse, `cmocka.git` doesn't work for some reason, so I get the following output:

```shell
$ make
    Updating git repository `https://github.com/tock/tock`
    Updating git submodule `https://git.qemu.org/git/qemu.git`
    Updating git submodule `https://git.qemu.org/git/capstone.git`
    Updating git submodule `https://git.qemu.org/git/dtc.git`
    Updating git submodule `https://git.qemu.org/git/meson.git`
    Updating git submodule `https://git.qemu.org/git/QemuMacDrivers.git`
    Updating git submodule `https://git.qemu.org/git/SLOF.git`
    Updating git submodule `https://git.qemu.org/git/edk2.git`
    Updating git submodule `https://github.com/google/brotli`
    Updating git submodule `https://github.com/hillbig/esaxx`
    Updating git submodule `https://github.com/y-256/libdivsufsort.git`
    Updating git submodule `https://github.com/openssl/openssl`
    Updating git submodule `https://boringssl.googlesource.com/boringssl`
    Updating git submodule `https://github.com/krb5/krb5`
    Updating git submodule `https://github.com/pyca/cryptography.git`
    Updating git submodule `https://github.com/google/brotli`
    Updating git submodule `https://github.com/hillbig/esaxx`
    Updating git submodule `https://github.com/y-256/libdivsufsort.git`
    Updating git submodule `https://github.com/kkos/oniguruma`
    Updating git submodule `https://github.com/ucb-bar/berkeley-softfloat-3.git`
    Updating git submodule `https://git.cryptomilk.org/projects/cmocka.git`
warning: spurious network error (2 tries remaining): early EOF; class=Net (12); code=Eof (-20)
warning: spurious network error (1 tries remaining): early EOF; class=Net (12); code=Eof (-20)
error: failed to get `capsules` as a dependency of package `nano33-bootloader v0.1.0 (/Users/bradjc/git/tock-bootloader/boards/nano33-bootloader)`

Caused by:
  failed to load source for dependency `capsules`

Caused by:
  Unable to update https://github.com/tock/tock?branch=master

Caused by:
  failed to update submodule `tools/qemu`

Caused by:
  failed to update submodule `roms/edk2`

Caused by:
  failed to update submodule `UnitTestFrameworkPkg/Library/CmockaLib/cmocka`

Caused by:
  failed to fetch submodule `UnitTestFrameworkPkg/Library/CmockaLib/cmocka` from https://git.cryptomilk.org/projects/cmocka.git

Caused by:
  network failure seems to have happened
  if a proxy or similar is necessary `net.git-fetch-with-cli` may help here
  https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli

Caused by:
  early EOF; class=Net (12); code=Eof (-20)
make: *** [/Users/bradjc/git/tock-bootloader/target/thumbv7em-none-eabi/release/nano33-bootloader] Error 101
```

I have no idea why cargo cannot clone cmocka. I've been able to work around this by cloning cmocka elsewhere and copying it to where cargo is trying to clone it. Then cargo continues after it.


I don't think that I'm doing anything unusual to cause this, but this is a somewhat big ask for anyone to do when trying to use Tock from github as a dependency. I also don't think we intended to make out-of-tree development difficult when adding the submodule.


### Testing Strategy

Todo? I'm not sure how to test this without merging it first.


### TODO or Help Wanted

I have no idea if this is the best way to fix this. However, I've now been stung by this twice, so I wanted to make it sure it got written down somewhere.


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
