### PR TITLE
LED: remove need for `&mut self`

### DIFF
--- a/boards/components/src/led.rs
+++ b/boards/components/src/led.rs
@@ -26,7 +26,7 @@ macro_rules! led_component_helper {
         const NUM_LEDS: usize = count_expressions!($($L),+);
 
 	static_init!(
-	    [&'static mut $Led; NUM_LEDS],
+	    [&'static $Led; NUM_LEDS],
 	    [
 		$(
 		    static_init!(
@@ -50,11 +50,11 @@ macro_rules! led_component_buf {
 }
 
 pub struct LedsComponent<L: 'static + Led> {
-    leds: &'static mut [&'static mut L],
+    leds: &'static mut [&'static L],
 }
 
 impl<L: 'static + Led> LedsComponent<L> {
-    pub fn new(leds: &'static mut [&'static mut L]) -> Self {
+    pub fn new(leds: &'static mut [&'static L]) -> Self {
         Self { leds }
     }
 }

--- a/boards/litex/sim/src/io.rs
+++ b/boards/litex/sim/src/io.rs
@@ -1,3 +1,4 @@
+use core::cell::Cell;
 use core::fmt::Write;
 use core::panic::PanicInfo;
 use core::str;
@@ -28,22 +29,22 @@ impl IoWrite for Writer {
 
 // The LiteX simulation does not have LEDs, hence use a dummy type for
 // the debug::panic function
-struct DummyLed(bool);
+struct DummyLed(Cell<bool>);
 impl kernel::hil::led::Led for DummyLed {
-    fn init(&mut self) {
-        self.0 = false;
+    fn init(&self) {
+        self.0.set(false);
     }
-    fn on(&mut self) {
-        self.0 = true;
+    fn on(&self) {
+        self.0.set(true);
     }
-    fn off(&mut self) {
-        self.0 = false;
+    fn off(&self) {
+        self.0.set(false);
     }
-    fn toggle(&mut self) {
-        self.0 = !self.0;
+    fn toggle(&self) {
+        self.0.set(!self.0.get());
     }
     fn read(&self) -> bool {
-        self.0
+        self.0.get()
     }
 }
 

--- a/boards/microbit_v2/src/io.rs
+++ b/boards/microbit_v2/src/io.rs
@@ -67,18 +67,18 @@ struct MatrixLed(
 );
 
 impl led::Led for MatrixLed {
-    fn init(&mut self) {
+    fn init(&self) {
         self.0.make_output();
         self.1.make_output();
         self.1.clear();
     }
-    fn on(&mut self) {
+    fn on(&self) {
         self.1.set();
     }
-    fn off(&mut self) {
+    fn off(&self) {
         self.1.clear();
     }
-    fn toggle(&mut self) {
+    fn toggle(&self) {
         self.1.toggle();
     }
     fn read(&self) -> bool {

--- a/capsules/src/led.rs
+++ b/capsules/src/led.rs
@@ -61,11 +61,11 @@ pub const DRIVER_NUM: usize = driver::NUM::Led as usize;
 /// Holds the array of LEDs and implements a `Driver` interface to
 /// control them.
 pub struct LedDriver<'a, L: led::Led> {
-    leds: TakeCell<'a, [&'a mut L]>,
+    leds: TakeCell<'a, [&'a L]>,
 }
 
 impl<'a, L: led::Led> LedDriver<'a, L> {
-    pub fn new(leds: &'a mut [&'a mut L]) -> Self {
+    pub fn new(leds: &'a mut [&'a L]) -> Self {
         // Initialize all LEDs and turn them off
         for led in leds.iter_mut() {
             led.init();

--- a/chips/litex/src/led_controller.rs
+++ b/chips/litex/src/led_controller.rs
@@ -151,19 +151,19 @@ impl<'a, R: LiteXSoCRegisterConfiguration> LiteXLed<'a, R> {
 }
 
 impl<'a, R: LiteXSoCRegisterConfiguration> hil::led::Led for LiteXLed<'a, R> {
-    fn init(&mut self) {
+    fn init(&self) {
         self.controller.set_led(self.index, false);
     }
 
-    fn on(&mut self) {
+    fn on(&self) {
         self.controller.set_led(self.index, true);
     }
 
-    fn off(&mut self) {
+    fn off(&self) {
         self.controller.set_led(self.index, false);
     }
 
-    fn toggle(&mut self) {
+    fn toggle(&self) {
         self.controller
             .set_led(self.index, !self.controller.read_led(self.index));
     }

--- a/kernel/src/debug.rs
+++ b/kernel/src/debug.rs
@@ -92,7 +92,7 @@ pub trait IoWrite {
 ///
 /// **NOTE:** The supplied `writer` must be synchronous.
 pub unsafe fn panic<L: hil::led::Led, W: Write + IoWrite, C: Chip>(
-    leds: &mut [&mut L],
+    leds: &mut [&L],
     writer: &mut W,
     panic_info: &PanicInfo,
     nop: &dyn Fn(),
@@ -171,7 +171,7 @@ pub unsafe fn panic_process_info<W: Write>(
 /// boards may find it appropriate to blink multiple LEDs (e.g.
 /// one on the top and one on the bottom), thus this method
 /// accepts an array, however most will only need one.
-pub fn panic_blink_forever<L: hil::led::Led>(leds: &mut [&mut L]) -> ! {
+pub fn panic_blink_forever<L: hil::led::Led>(leds: &mut [&L]) -> ! {
     leds.iter_mut().for_each(|led| led.init());
     loop {
         for _ in 0..1000000 {

--- a/kernel/src/hil/led.rs
+++ b/kernel/src/hil/led.rs
@@ -6,11 +6,25 @@
 
 use crate::hil::gpio;
 
+/// Simple on/off interface for LED pins.
+///
+/// Since GPIO pins are synchronous in Tock the LED interface is synchronous as
+/// well.
 pub trait Led {
-    fn init(&mut self);
-    fn on(&mut self);
-    fn off(&mut self);
-    fn toggle(&mut self);
+    /// Initialize the LED. Must be called before the LED is used.
+    fn init(&self);
+
+    /// Turn the LED on.
+    fn on(&self);
+
+    /// Turn the LED off.
+    fn off(&self);
+
+    /// Toggle the LED.
+    fn toggle(&self);
+
+    /// Return the on/off state of the LED. `true` if the LED is on, `false` if
+    /// it is off.
     fn read(&self) -> bool;
 }
 
@@ -37,19 +51,19 @@ impl<'a, P: gpio::Pin> LedLow<'a, P> {
 }
 
 impl<P: gpio::Pin> Led for LedHigh<'_, P> {
-    fn init(&mut self) {
+    fn init(&self) {
         self.pin.make_output();
     }
 
-    fn on(&mut self) {
+    fn on(&self) {
         self.pin.set();
     }
 
-    fn off(&mut self) {
+    fn off(&self) {
         self.pin.clear();
     }
 
-    fn toggle(&mut self) {
+    fn toggle(&self) {
         self.pin.toggle();
     }
 
@@ -59,19 +73,19 @@ impl<P: gpio::Pin> Led for LedHigh<'_, P> {
 }
 
 impl<P: gpio::Pin> Led for LedLow<'_, P> {
-    fn init(&mut self) {
+    fn init(&self) {
         self.pin.make_output();
     }
 
-    fn on(&mut self) {
+    fn on(&self) {
         self.pin.clear();
     }
 
-    fn off(&mut self) {
+    fn off(&self) {
         self.pin.set();
     }
 
-    fn toggle(&mut self) {
+    fn toggle(&self) {
         self.pin.toggle();
     }
 


### PR DESCRIPTION
### Pull Request Overview

When adding an LED to the bootloader I noticed the LED trait requires mutable references. Requiring `mut` requires changing a lot of other code to `mut`, and this is not consistent with other Tock code.

This was a quick PR to implement, but I'm not sure why `Led` used mutable references. 


### Testing Strategy

travis


### TODO or Help Wanted

If there is a need for the mutable self references we can close this.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
