### PR TITLE
fix bug in `_start_trap()` assembly

### DIFF
--- a/arch/rv32i/src/lib.rs
+++ b/arch/rv32i/src/lib.rs
@@ -337,10 +337,10 @@ pub extern "C" fn _start_trap() {
             sw   t0, 1*4(s0)  // Save the app sp to the stored state struct
             csrr t0, 0x341    // CSR=0x341=mepc
             sw   t0, 31*4(s0) // Save the PC to the stored state struct
-            csrr t0, 0x342    // CSR=0x342=mcause
-            sw   t0, 32*4(s0) // Save mcause to the stored state struct
             csrr t0, 0x343    // CSR=0x343=mtval
             sw   t0, 33*4(s0) // Save mtval to the stored state struct
+            csrr t0, 0x342    // CSR=0x342=mcause
+            sw   t0, 32*4(s0) // Save mcause to the stored state struct, leave in t0
 
             // Now we need to check if this was an interrupt, and if it was,
             // then we need to disable the interrupt before returning from this

--- a/arch/rv32i/src/lib.rs
+++ b/arch/rv32i/src/lib.rs
@@ -339,6 +339,8 @@ pub extern "C" fn _start_trap() {
             sw   t0, 31*4(s0) // Save the PC to the stored state struct
             csrr t0, 0x343    // CSR=0x343=mtval
             sw   t0, 33*4(s0) // Save mtval to the stored state struct
+
+            // Save mcause last, as we depend on it being loaded in t0 below
             csrr t0, 0x342    // CSR=0x342=mcause
             sw   t0, 32*4(s0) // Save mcause to the stored state struct, leave in t0
 


### PR DESCRIPTION
### Pull Request Overview

@vsukhoml found a bug in #2073 after it was merged, this PR fixes it. That PR added code to save `mtval` to the stored state struct, but overwrote the value in t0 (the saved `mcause` value) in the process. `t0` is used after that under the assumption it still holds `mcause`. This PR just moves the code to save `mtval` above the code that saves `mcause`.


### Testing Strategy

This pull request was tested by CI.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] N/A

### Formatting

- [x] Ran `make prepush`.
