### PR TITLE
Add riscv32i-unknown-none-elf arch to Nix shell

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -37,7 +37,7 @@ let
   rust_channel = "nightly";
   rust_targets = [
     "thumbv7em-none-eabi" "thumbv7em-none-eabihf" "thumbv6m-none-eabi"
-    "riscv32imac-unknown-none-elf" "riscv32imc-unknown-none-elf"
+    "riscv32imac-unknown-none-elf" "riscv32imc-unknown-none-elf" "riscv32i-unknown-none-elf"
   ];
   rust_build = nixpkgs.rustChannelOfTargets rust_channel rust_date rust_targets;
 in


### PR DESCRIPTION
### Pull Request Overview

This adds the `riscv32i-unknown-none-elf` Rust target to the Nix shell script, in order to easily compile the litex board under Nix.


### Testing Strategy

Compiled with `make allboards`

### TODO or Help Wanted

N/A

### Documentation Updated

- [X] ~Updated the relevant files in `/docs`, or no updates are required.~

### Formatting

- [X] Ran `make prepush`.
