### PR TITLE
Tock 2.0: update text_screen driver to 2.0 API

### DIFF
--- a/capsules/src/hd44780.rs
+++ b/capsules/src/hd44780.rs
@@ -142,6 +142,7 @@ pub struct HD44780<'a, A: Alarm<'a>> {
 
     write_buffer: TakeCell<'static, [u8]>,
     write_len: Cell<u8>,
+    write_buffer_len: Cell<u8>,
     write_offset: Cell<u8>,
 }
 
@@ -190,6 +191,7 @@ impl<'a, A: Alarm<'a>> HD44780<'a, A> {
             done_printing: Cell::new(false),
             write_buffer: TakeCell::empty(),
             write_len: Cell::new(0),
+            write_buffer_len: Cell::new(0),
             write_offset: Cell::new(0),
         };
         hd44780.init(width, height);
@@ -336,9 +338,13 @@ impl<'a, A: Alarm<'a>> HD44780<'a, A> {
                     } else if self.done_printing.get() {
                         self.done_printing.set(false);
                         if self.write_buffer.is_some() {
-                            self.write_buffer
-                                .take()
-                                .map(|buffer| client.write_complete(buffer, ReturnCode::SUCCESS));
+                            self.write_buffer.take().map(|buffer| {
+                                client.write_complete(
+                                    buffer,
+                                    self.write_buffer_len.get() as usize,
+                                    ReturnCode::SUCCESS,
+                                )
+                            });
                         }
                     } else {
                         client.command_complete(ReturnCode::SUCCESS);
@@ -593,15 +599,20 @@ impl<'a, A: Alarm<'a>> TextScreen<'a> for HD44780<'a, A> {
         (16, 2)
     }
 
-    fn print(&self, buffer: &'static mut [u8], len: usize) -> ReturnCode {
+    fn print(
+        &self,
+        buffer: &'static mut [u8],
+        len: usize,
+    ) -> Result<(), (ReturnCode, &'static mut [u8])> {
         if self.lcd_status.get() == LCDStatus::Idle {
             self.write_buffer.replace(buffer);
             self.write_len.replace(len as u8);
+            self.write_buffer_len.replace(len as u8);
             self.write_offset.set(0);
             self.write_character();
-            ReturnCode::SUCCESS
+            Ok(())
         } else {
-            ReturnCode::EBUSY
+            Err((ReturnCode::EBUSY, buffer))
         }
     }
 

--- a/capsules/src/hd44780.rs
+++ b/capsules/src/hd44780.rs
@@ -69,7 +69,7 @@ static LCD_ENTRYSHIFTDECREMENT: u8 = 0x00;
 /// flags for display on/off control
 static LCD_DISPLAYON: u8 = 0x04;
 static LCD_CURSORON: u8 = 0x02;
-static LCD_BLINKON: u8 = 0x04;
+static LCD_BLINKON: u8 = 0x01;
 static LCD_BLINKOFF: u8 = 0x00;
 
 /// flags for function set

--- a/capsules/src/text_screen.rs
+++ b/capsules/src/text_screen.rs
@@ -12,10 +12,11 @@
 //! ```
 
 use core::convert::From;
+use core::{cmp, mem};
 use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::hil;
 use kernel::ReturnCode;
-use kernel::{AppId, AppSlice, Callback, Grant, LegacyDriver, SharedReadWrite};
+use kernel::{AppId, Callback, CommandResult, Driver, ErrorCode, Grant, Read, ReadOnlyAppSlice};
 
 /// Syscall driver number.
 use crate::driver;
@@ -38,9 +39,9 @@ enum TextScreenCommand {
 }
 
 pub struct App {
-    callback: Option<Callback>,
+    callback: Callback,
     pending_command: bool,
-    shared: Option<AppSlice<SharedReadWrite, u8>>,
+    shared: ReadOnlyAppSlice,
     write_position: usize,
     write_len: usize,
     command: TextScreenCommand,
@@ -51,9 +52,9 @@ pub struct App {
 impl Default for App {
     fn default() -> App {
         App {
-            callback: None,
+            callback: Callback::default(),
             pending_command: false,
-            shared: None,
+            shared: ReadOnlyAppSlice::default(),
             write_position: 0,
             write_len: 0,
             command: TextScreenCommand::Idle,
@@ -90,8 +91,9 @@ impl<'a> TextScreen<'a> {
         data1: usize,
         data2: usize,
         appid: AppId,
-    ) -> ReturnCode {
-        self.apps
+    ) -> CommandResult {
+        let res = self
+            .apps
             .enter(appid, |app, _| {
                 if self.current_app.is_none() {
                     self.current_app.set(appid);
@@ -114,7 +116,12 @@ impl<'a> TextScreen<'a> {
                     }
                 }
             })
-            .unwrap_or_else(|err| err.into())
+            .map_err(ErrorCode::from);
+        if let Err(err) = res {
+            CommandResult::failure(err)
+        } else {
+            CommandResult::success()
+        }
     }
 
     fn do_command(
@@ -143,16 +150,21 @@ impl<'a> TextScreen<'a> {
                     if data1 > 0 {
                         app.write_position = 0;
                         app.write_len = data1;
-                        if let Some(to_write_buffer) = &app.shared {
-                            self.buffer.take().map_or(ReturnCode::FAIL, |buffer| {
-                                for n in 0..data1 {
-                                    buffer[n] = to_write_buffer.as_ref()[n];
+                        app.shared.map_or(ReturnCode::ENOMEM, |to_write_buffer| {
+                            self.buffer.take().map_or(ReturnCode::EBUSY, |buffer| {
+                                let len = cmp::min(app.write_len, buffer.len());
+                                for n in 0..len {
+                                    buffer[n] = to_write_buffer[n];
                                 }
-                                self.text_screen.print(buffer, data1)
+                                match self.text_screen.print(buffer, len) {
+                                    Ok(()) => ReturnCode::SUCCESS,
+                                    Err((err, buffer)) => {
+                                        self.buffer.replace(buffer);
+                                        err
+                                    }
+                                }
                             })
-                        } else {
-                            ReturnCode::ENOMEM
-                        }
+                        })
                     } else {
                         ReturnCode::ENOMEM
                     }
@@ -191,37 +203,47 @@ impl<'a> TextScreen<'a> {
         self.current_app.take().map(|appid| {
             let _ = self.apps.enter(appid, |app, _| {
                 app.pending_command = false;
-                app.callback.map(|mut cb| {
-                    cb.schedule(data1, data2, data3);
-                });
+                app.callback.schedule(data1, data2, data3);
             });
         });
     }
 }
 
-impl<'a> LegacyDriver for TextScreen<'a> {
+impl<'a> Driver for TextScreen<'a> {
     fn subscribe(
         &self,
         subscribe_num: usize,
-        callback: Option<Callback>,
+        mut callback: Callback,
         app_id: AppId,
-    ) -> ReturnCode {
+    ) -> Result<Callback, (Callback, ErrorCode)> {
         match subscribe_num {
-            0 => self
-                .apps
-                .enter(app_id, |app, _| {
-                    app.callback = callback;
-                    ReturnCode::SUCCESS
-                })
-                .unwrap_or_else(|err| err.into()),
-            _ => ReturnCode::ENOSUPPORT,
+            0 => {
+                let res = self
+                    .apps
+                    .enter(app_id, |app, _| {
+                        mem::swap(&mut app.callback, &mut callback);
+                    })
+                    .map_err(ErrorCode::from);
+                if let Err(e) = res {
+                    Err((callback, e))
+                } else {
+                    Ok(callback)
+                }
+            }
+            _ => Err((callback, ErrorCode::NOSUPPORT)),
         }
     }
 
-    fn command(&self, command_num: usize, data1: usize, data2: usize, appid: AppId) -> ReturnCode {
+    fn command(
+        &self,
+        command_num: usize,
+        data1: usize,
+        data2: usize,
+        appid: AppId,
+    ) -> CommandResult {
         match command_num {
             // This driver exists.
-            0 => ReturnCode::SUCCESS,
+            0 => CommandResult::success(),
             // Get Resolution
             1 => self.enqueue_command(TextScreenCommand::GetResolution, data1, data2, appid),
             // Display
@@ -245,27 +267,32 @@ impl<'a> LegacyDriver for TextScreen<'a> {
             //Set Curosr
             11 => self.enqueue_command(TextScreenCommand::SetCursor, data1, data2, appid),
             // NOSUPPORT
-            _ => ReturnCode::ENOSUPPORT,
+            _ => CommandResult::failure(ErrorCode::NOSUPPORT),
         }
     }
 
-    fn allow_readwrite(
+    fn allow_readonly(
         &self,
         appid: AppId,
         allow_num: usize,
-        slice: Option<AppSlice<SharedReadWrite, u8>>,
-    ) -> ReturnCode {
+        mut slice: ReadOnlyAppSlice,
+    ) -> Result<ReadOnlyAppSlice, (ReadOnlyAppSlice, ErrorCode)> {
         match allow_num {
-            0 => self
-                .apps
-                .enter(appid, |app, _| {
-                    let _ = if let Some(ref s) = slice { s.len() } else { 0 };
-                    app.shared = slice;
-                    app.write_position = 0;
-                    ReturnCode::SUCCESS
-                })
-                .unwrap_or_else(|err| err.into()),
-            _ => ReturnCode::ENOSUPPORT,
+            0 => {
+                let res = self
+                    .apps
+                    .enter(appid, |app, _| {
+                        mem::swap(&mut app.shared, &mut slice);
+                        app.write_position = 0;
+                    })
+                    .map_err(ErrorCode::from);
+                if let Err(e) = res {
+                    Err((slice, e))
+                } else {
+                    Ok(slice)
+                }
+            }
+            _ => Err((slice, ErrorCode::NOSUPPORT)),
         }
     }
 }
@@ -276,9 +303,9 @@ impl<'a> hil::text_screen::TextScreenClient for TextScreen<'a> {
         self.run_next_command();
     }
 
-    fn write_complete(&self, buffer: &'static mut [u8], r: ReturnCode) {
+    fn write_complete(&self, buffer: &'static mut [u8], len: usize, r: ReturnCode) {
         self.buffer.replace(buffer);
-        self.schedule_callback(usize::from(r), 0, 0);
+        self.schedule_callback(usize::from(r), len, 0);
         self.run_next_command();
     }
 }

--- a/doc/syscalls/90001_screen.md
+++ b/doc/syscalls/90001_screen.md
@@ -1,0 +1,220 @@
+---
+driver number: 0x90001
+---
+
+# Screen
+
+## Overview
+
+The screen driver allows the process to write data to a framebuffer of a screen.
+
+## Command
+
+  * ### Command number: `0`
+
+    **Description**: Does the driver exist?
+
+    **Argument 1**: unused
+
+    **Argument 2**: unused
+
+    **Returns**: SUCCESS if it exists, otherwise ENODEVICE
+
+  * ### Command number: `1`
+
+    **Description**: Checks if the Setup API is available
+
+    **Argument 1**: unused
+
+    **Argument 2**: unused
+
+    **Returns**: SUCCESS_U32 with 1 if yes, and 0 if no
+
+  * ### Command number: `3`
+
+    **Description**: Set brightness
+
+    **Argument 1**: Percent of brightness, 0% should turn off the screen, greater than 0% should turn it on.
+
+    **Argument 2**: unused
+
+    **Returns**: SUCCESS if the command was successful, EBUSY if another command is in progress.
+
+  * ### Command number: `4`
+
+    **Description**: Turn on invert colors mode
+
+    **Argument 1**: unused
+
+    **Argument 2**: unused
+
+    **Returns**: SUCCESS if the command was successful, EBUSY if another command is in progress.
+  
+  * ### Command number: `5`
+
+    **Description**: Turn off invert colors mode
+
+    **Argument 1**: unused
+
+    **Argument 2**: unused
+
+    **Returns**: SUCCESS if the command was successful, EBUSY if another command is in progress.
+
+  * ### Command number: `11` 
+
+    **Description**: Get the number of supported resolutions (Setup API)
+
+    **Argument 1**: unused
+
+    **Argument 2**: unused
+
+    **Returns**: SUCCESS_U32 with a u32 being the number of supported resolutions (minimum 1), EBUSY if another command is in progress.
+
+  * ### Command number: `12` 
+
+    **Description**: Get the size of a supported resolution (Setup API)
+
+    **Argument 1**: index of the resolution (0, return of command 11)
+
+    **Argument 2**: unused
+
+    **Returns**: SUCCESS followed by a callback with the resolution, EBUSY if another command is in progress.
+  
+  * ### Command number: `13` 
+
+    **Description**: Get the number of supported color depth (Setup API)
+
+    **Argument 1**: unused
+
+    **Argument 2**: unused
+
+    **Returns**: SUCCESS_U32 with a u32 being the number of supported color depth (minimum 1), EBUSY if another command is in progress.
+
+  * ### Command number: `14` 
+
+    **Description**: Get the type of a supported color depth (Setup API)
+
+    **Argument 1**: index of the color depth (0, return of command 13)
+
+    **Argument 2**: unused
+
+    **Returns**: SUCCESS followed by a callback with the resolution, EBUSY if another command is in progress.
+
+  * ### Command number: `21` 
+
+    **Description**: Get the screen's rotation
+
+    **Argument 1**: unused
+
+    **Argument 2**: unused
+
+    **Returns**: SUCCESS followed by a callback with the rotation value, EBUSY if another command is in progress.
+
+  * ### Command number: `22` 
+
+    **Description**: Set the screen's rotation (Setup API)
+
+    **Argument 1**: rotation value (0 - normal, 1 - 90deg, 2 - 180deg, 3 - 270deg)
+
+    **Argument 2**: unused
+
+    **Returns**: SUCCESS followed by a callback when it is done, EBUSY if another command is in progress.
+
+  * ### Command number: `23` 
+
+    **Description**: Get the screen's resolution
+
+    **Argument 1**: unused
+
+    **Argument 2**: unused
+
+    **Returns**: SUCCESS followed by a callback with the rotation value, EBUSY if another command is in progress.
+
+  * ### Command number: `24` 
+
+    **Description**: Set the screen's resolution (Setup API)
+
+    **Argument 1**: width (pixels)
+
+    **Argument 2**: height (pixels)
+
+    **Returns**: SUCCESS followed by a callback when it is done, EBUSY if another command is in progress.
+
+  * ### Command number: `25` 
+
+    **Description**: Get the screen's color depth
+
+    **Argument 1**: unused
+
+    **Argument 2**: unused
+
+    **Returns**: SUCCESS followed by a callback with the rotation value, EBUSY if another command is in progress.
+
+  * ### Command number: `26` 
+
+    **Description**: Set the screen's color depth (Setup API)
+
+    **Argument 1**: color depth 
+
+    **Argument 2**: unused
+
+    **Returns**: SUCCESS followed by a callback when it is done, EBUSY if another command is in progress.
+
+  * ### Command number: `100` 
+
+    **Description**: Set the framebuffer write frame
+
+    **Argument 1**: x | y (pixels, 16 bit LE)
+
+    **Argument 2**: width | height (pixels, 16 bit LE)
+
+    **Returns**: SUCCESS followed by a callback when it is done, EBUSY if another command is in progress.
+
+  * ### Command number: `101` 
+
+    **Description**: Initiate a write transaction of a buffer shared using `allow_readonly`.
+    At the end of the transaction, a callback will be delivered if the process
+    has `subscribed`.
+
+    **Argument 1**: buffer length (in bytes)
+
+    **Argument 2**: unused
+
+    **Returns**: SUCCESS followed by a callback when it is done, EBUSY if another command is in progress.
+
+  * ### Command number: `102` 
+
+    **Description**: Initiate a fill transaction of a buffer shared using `allow_readonly`. This will fill the write frame with the first pixel in thhe buffer.
+    At the end of the transaction, a callback will be delivered if the process
+    has `subscribed`.
+
+    **Argument 1**: unused
+
+    **Argument 2**: unused
+
+    **Returns**: SUCCESS followed by a callback when it is done, EBUSY if another command is in progress.
+
+## Subscribe
+
+  * ### Subscribe number: `0`
+
+    **Description**: Subscribe to to all commands.
+
+    **Callback signature**: The callback receives different arguments 
+    depending on the issued command.
+
+    **Returns**: SUCCESS if the subscribe was successful.
+
+## Allow ReadOnly
+
+  * ### Allow number: `0`
+
+    **Description**: Sets a shared buffer to be used as a source of data for
+    the next write transaction. A shared buffer is released if it is replaced
+    by a subsequent call and after a write transaction is completed. Replacing
+    the buffer after beginning a write transaction but before receiving a
+    completion callback is undefined (most likely either the original buffer or
+    new buffer will be written in its entirety but not both).
+
+    **Returns**: SUCCESS if the subscribe was successful, INVAL if the buffer's length is not a multiple of the color depth length. 
+

--- a/doc/syscalls/90002_touch.md
+++ b/doc/syscalls/90002_touch.md
@@ -1,0 +1,134 @@
+---
+driver number: 0x90002
+---
+
+# Touch Panel
+
+## Overview
+
+The touch driver allows the process to interract with a touch panel.
+
+## Command
+
+  * ### Command number: `0`
+
+    **Description**: Does the driver exist?
+
+    **Argument 1**: unused
+
+    **Argument 2**: unused
+
+    **Returns**: SUCCESS if it exists, otherwise ENODEVICE
+
+  * ### Command number: `1`
+
+    **Description**: Enable the single touch function of the panel. This will enable the touch panel if at least one app enables it.
+
+    **Argument 1**: unused
+
+    **Argument 2**: unused
+
+    **Returns**: SUCCESS
+
+  * ### Command number: `2`
+
+    **Description**: Disable the single touch function of panel. This will disable the touch panel if all apps disable it.
+
+    **Argument 1**: unused
+
+    **Argument 2**: unused
+
+    **Returns**: SUCCESS
+
+  * ### Command number: `10`
+
+    **Description**: Acknowledge that the multi touch buffer has been read. Multi touch events are reported by filling a previously `allows_readwrite` buffer. When receving a callback with the notification for a multi touch event, the app must acknowledge it before it can recevie another callback.
+
+    **Argument 1**: unused
+
+    **Argument 2**: unused
+
+    **Returns**: SUCCESS
+
+  * ### Command number: `11`
+
+    **Description**: Enable the multi touch function of the panel. This will enable the touch panel if at least one app enables it.
+
+    **Argument 1**: unused
+
+    **Argument 2**: unused
+
+    **Returns**: SUCCESS
+
+  * ### Command number: `12`
+
+    **Description**: Disable the multi touch function of panel. This will disable the touch panel if all apps disable it.
+
+    **Argument 1**: unused
+
+    **Argument 2**: unused
+
+    **Returns**: SUCCESS
+
+  * ### Command number: `100`
+
+    **Description**: Get the number of touch points available
+
+    **Argument 1**: unused
+
+    **Argument 2**: unused
+
+    **Returns**: SUCCESS_U32 with U32 being the number of available touches
+
+## Subscribe
+
+  * ### Subscribe number: `0`
+
+    **Description**: Subscribe to single touch.
+
+    **Callback signature**: 
+      - data1: status
+      - data2: x (16 bit LE) | y (16 bit LE)
+      - data3: pressure (16 bit LE) | area (16 bit LE) 
+
+    **Returns**: SUCCESS if the subscribe was successful.
+
+  * ### Subscribe number: `1`
+
+    **Description**: Subscribe to gestures.
+
+    **Callback signature**: 
+      - data1: gesture
+
+    **Returns**: SUCCESS if the subscribe was successful.
+
+  * ### Subscribe number: `2`
+
+    **Description**: Subscribe to multi touch events.
+
+    **Callback signature**: 
+      - data1: number of touch events
+      - data2: number of dropped callback (ack sent too slow?)
+      - data3: number of dropped touch events (shared buffer too small?)
+
+    **Returns**: SUCCESS if the subscribe was successful.
+
+## Allow ReadWrite
+
+  * ### Allow number: `0`
+
+    **Description**: Buffer to write multi touch events
+
+    **Buffer format**:
+
+
+    ```
+    0         1           2                  4                  6           7             8         ...
+    +---------+-----------+------------------+------------------+-----------+---------------+--------- ...
+    | id (u8) | type (u8) | x (u16)          | y (u16)          | size (u8) | pressure (u8) |          ...
+    +---------+-----------+------------------+------------------+-----------+---------------+--------- ...
+    | Touch 0                                                                               | Touch 1  ...
+    ```
+
+    **Returns**: SUCCESS if the subscribe was successful, INVAL if the buffer's length is not a multiple of the color depth length. 
+

--- a/doc/syscalls/90003_text_screen.md
+++ b/doc/syscalls/90003_text_screen.md
@@ -1,0 +1,160 @@
+---
+driver number: 0x90003
+---
+
+# Text Screen
+
+## Overview
+
+The screen driver allows the process to write data to a text 
+screen like an LCD display.
+
+## Command
+
+  * ### Command number: `0`
+
+    **Description**: Does the driver exist?
+
+    **Argument 1**: unused
+
+    **Argument 2**: unused
+
+    **Returns**: SUCCESS if it exists, otherwise ENODEVICE
+
+  * ### Command number: `1` 
+
+    **Description**: Get the screen's resolution (in characters)
+
+    **Argument 1**: unused
+
+    **Argument 2**: unused
+
+    **Returns**: SUCCESS followed by a callback with the rotation value, EBUSY if another command is in progress.
+
+  * ### Command number: `2`
+
+    **Description**: Turn the display on
+
+    **Argument 1**: unused
+
+    **Argument 2**: unused
+
+    **Returns**: SUCCESS if the command was successful, EBUSY if another command is in progress.
+
+  * ### Command number: `3`
+
+    **Description**: Turn the display off
+
+    **Argument 1**: unused
+
+    **Argument 2**: unused
+
+    **Returns**: SUCCESS if the command was successful, EBUSY if another command is in progress.
+
+  * ### Command number: `4`
+
+    **Description**: Turn blink mode on
+
+    **Argument 1**: unused
+
+    **Argument 2**: unused
+
+    **Returns**: SUCCESS if the command was successful, EBUSY if another command is in progress.
+
+  * ### Command number: `5`
+
+    **Description**: Turn blink mode off
+
+    **Argument 1**: unused
+
+    **Argument 2**: unused
+
+    **Returns**: SUCCESS if the command was successful, EBUSY if another command is in progress.
+  
+  * ### Command number: `6`
+
+    **Description**: Show cursor
+
+    **Argument 1**: unused
+
+    **Argument 2**: unused
+
+    **Returns**: SUCCESS if the command was successful, EBUSY if another command is in progress.
+
+  * ### Command number: `7` 
+
+    **Description**: Hide cursor
+
+    **Argument 1**: unused
+
+    **Argument 2**: unused
+
+    **Returns**: SUCCESS_U32 with a u32 being the number of supported resolutions (minimum 1), EBUSY if another command is in progress.
+
+  * ### Command number: `8` 
+
+    **Description**: Initiate a write transaction of a buffer shared using `allow_readonly`. This will write the characters in the
+    buffer to the text screen.
+    At the end of the transaction, a callback will be delivered if the process
+    has `subscribed`.
+
+    **Argument 1**: unused
+
+    **Argument 2**: unused
+
+    **Returns**: SUCCESS followed by a callback when it is done, EBUSY if another command is in progress.
+  
+  * ### Command number: `9` 
+
+    **Description**: Clear screen
+
+    **Argument 1**: unused
+
+    **Argument 2**: unused
+
+    **Returns**: SUCCESS_U32 with a u32 being the number of supported color depth (minimum 1), EBUSY if another command is in progress.
+
+  * ### Command number: `10` 
+
+    **Description**: Set the cursor position at (0, 0)
+
+    **Argument 1**: unused
+
+    **Argument 2**: unused
+
+    **Returns**: SUCCESS followed by a callback with the rotation value, EBUSY if another command is in progress.
+
+  * ### Command number: `11` 
+
+    **Description**: Set cursor position
+
+    **Argument 1**: row
+
+    **Argument 2**: column
+
+    **Returns**: SUCCESS followed by a callback with the resolution, EBUSY if another command is in progress.
+
+## Subscribe
+
+  * ### Subscribe number: `0`
+
+    **Description**: Subscribe to to all commands.
+
+    **Callback signature**: The callback receives different arguments 
+    depending on the issued command.
+
+    **Returns**: SUCCESS if the subscribe was successful.
+
+## Allow ReadOnly
+
+  * ### Allow number: `0`
+
+    **Description**: Sets a shared buffer to be used as a source of data for
+    the next write transaction. A shared buffer is released if it is replaced
+    by a subsequent call and after a write transaction is completed. Replacing
+    the buffer after beginning a write transaction but before receiving a
+    completion callback is undefined (most likely either the original buffer or
+    new buffer will be written in its entirety but not both).
+
+    **Returns**: SUCCESS if the subscribe was successful, INVAL if the buffer's length is not a multiple of the color depth length. 
+

--- a/doc/syscalls/README.md
+++ b/doc/syscalls/README.md
@@ -125,3 +125,12 @@ _Note:_ GPIO is slated for re-numbering in Tock 2.0.
 |   | 0x80002       | PCA9544A         | I2C address multiplexing                   |
 |   | 0x80003       | GPIO Async       | Asynchronous GPIO pins                     |
 |   | 0x80004       | nRF51822         | nRF serialization link to nRF51822 BLE SoC |
+
+### Miscellaneous
+
+|2.0| Driver Number | Driver                                  | Description                                |
+|---|---------------|-----------------------------------------|--------------------------------------------|
+|   | 0x90000       | Buzzer                                  | Buzzer                                     |
+|   | 0x90001       | [Screen](90001_screen.md)               | Graphic Screen                             |
+|   | 0x90002       | [Touch](90002_touch.md)                 | Multi Touch Panel                          |
+|   | 0x90003       | [Text Screen](90003_text_screen.md)     | Text Screen                                |

--- a/doc/syscalls/README.md
+++ b/doc/syscalls/README.md
@@ -125,4 +125,3 @@ _Note:_ GPIO is slated for re-numbering in Tock 2.0.
 |   | 0x80002       | PCA9544A         | I2C address multiplexing                   |
 |   | 0x80003       | GPIO Async       | Asynchronous GPIO pins                     |
 |   | 0x80004       | nRF51822         | nRF serialization link to nRF51822 BLE SoC |
-|   | 0x80005       | [HD44780](80005_hd44780.md)          | LCD HD44780 capsule                        |

--- a/doc/syscalls/README.md
+++ b/doc/syscalls/README.md
@@ -21,6 +21,7 @@ provided syscalls, and the driver specific interfaces (using `allow`,
   * [Sensors](#sensors)
   * [Sensor ICs](#sensor-ics)
   * [Other ICs](#other-ics)
+  * [Miscellaneous](#miscellaneous)
 
 <!-- tocstop -->
 

--- a/kernel/src/hil/text_screen.rs
+++ b/kernel/src/hil/text_screen.rs
@@ -18,7 +18,11 @@ pub trait TextScreen<'a> {
     /// Return values:
     /// - `SUCCESS`: The write command is valid and will be sent to the driver.
     /// - `EBUSY`: The driver is busy with another command.
-    fn print(&self, buffer: &'static mut [u8], len: usize) -> ReturnCode;
+    fn print(
+        &self,
+        buffer: &'static mut [u8],
+        len: usize,
+    ) -> Result<(), (ReturnCode, &'static mut [u8])>;
 
     /// Sends to the driver a command to set the cursor at a given position
     /// (x_position, y_position). When finished, the driver will call the
@@ -92,5 +96,5 @@ pub trait TextScreenClient {
     fn command_complete(&self, r: ReturnCode);
 
     /// The driver calls this function when a write command finishes executing.
-    fn write_complete(&self, buffer: &'static mut [u8], r: ReturnCode);
+    fn write_complete(&self, buffer: &'static mut [u8], len: usize, r: ReturnCode);
 }


### PR DESCRIPTION
### Pull Request Overview

This pull request updates the text_screen driver to the 2.0 API.

This should replace #2321.


### Testing Strategy

This pull request was tested using a Nucelo STM429ZI board and an HD44780 LCD.

### TODO or Help Wanted

N/A

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
