### PR TITLE
Make: Use -nmagic linker flag

### DIFF
--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -28,6 +28,11 @@ TARGET_DIRECTORY ?= $(TOCK_ROOT_DIRECTORY)target/
 # - `-nmagic`: lld by default uses a default page size to align program
 #   sections. Tock expects that program sections are set back-to-back. `-nmagic`
 #   instructs the linker to not page-align sections.
+# - `-icf=all`: Identical Code Folding (ICF) set to all. This tells the linker
+#   to be more aggressive about removing duplicate code. The default is `safe`,
+#   and the downside to `all` is that different functions in the code can end up
+#   with the same address in the binary. However, it can save a fair bit of code
+#   size.
 RUSTC_FLAGS ?= \
   -C link-arg=-Tlayout.ld \
   -C linker=rust-lld \

--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -24,15 +24,16 @@ TARGET_DIRECTORY ?= $(TOCK_ROOT_DIRECTORY)target/
 
 # RUSTC_FLAGS allows boards to define board-specific options.
 # This will hopefully move into Cargo.toml (or Cargo.toml.local) eventually.
-# lld uses the page size to align program sections. It defaults to 4096 and this
-# puts a gap between before the .relocate section. `zmax-page-size=512` tells
-# lld the actual page size so it doesn't have to be conservative.
+#
+# - `-nmagic`: lld by default uses a default page size to align program
+#   sections. Tock expects that program sections are set back-to-back. `-nmagic`
+#   instructs the linker to not page-align sections.
 RUSTC_FLAGS ?= \
   -C link-arg=-Tlayout.ld \
   -C linker=rust-lld \
   -C linker-flavor=ld.lld \
   -C relocation-model=dynamic-no-pic \
-  -C link-arg=-zmax-page-size=512 \
+  -C link-arg=-nmagic \
   -C link-arg=-icf=all \
 
 # RISC-V-specific flags.


### PR DESCRIPTION
### Pull Request Overview

This fixes #2219. After looking through the relevant discussions, `--nmagic` is the flag I should have used when original converting from gcc to llvm linkers. Setting the page size to a small value was a convenient workaround, but what we really wanted was for there to just not be padding.

Also I documented the `-icf` flag.


### Testing Strategy

Comparing kernel binaries before and after this change and verifying they are identical.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
