### PR TITLE
github actions: auto label PRs based on files they change

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -32,6 +32,6 @@ WG-OpenTitan:
 kernel:
   - any: ['kernel/**/*', '!kernel/src/hil/*']
 
-# add documentation label only if all changes are in doc/, or in md or txt files
+# add documentation label only if all changes are in doc/
 documentation:
-  - all: ['doc/*', './**/*.md', './**/*.txt']
+  - all: ['doc/**/*']

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,30 @@
+stm32:
+  - chips/stm*/**/*
+
+nrf:
+  - chips/nrf5*/**/*
+
+sam4l:
+  - chips/sam4l/**/*
+
+hil:
+  - kernel/src/hil/*
+
+risc-v:
+  - arch/rv32i/**/*
+  - arch/riscv/**/*
+
+tock-libraries:
+  - libraries/**/*
+
+WG-OpenTitan:
+  - boards/earlgrey-nexysvideo/**/*
+  - chips/earlgrey/**/*
+
+# add kernel label unless already covered by hil label
+kernel:
+  - any: ['kernel/**/*', '!kernel/src/hil/*']
+
+# add documentation label only if all changes are in doc/, or in md or txt files
+documentation:
+  - all: ['doc/*', './**/*.md', './**/*.txt']

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -14,7 +14,7 @@ nrf:
 sam4l:
   - chips/sam4l/**/*
 
-hil:
+HIL:
   - kernel/src/hil/*
 
 risc-v:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,3 +1,10 @@
+# This is a configuration file for the labeler github action.
+# The labeler action runs uses this configuration to automatically
+# label each PR submitted to the Tock repository, by applying labels
+# that match the corresponding glob paths. More details on the rules
+# that apply to this configuration file can be found in the documentation
+# at https://github.com/actions/labeler
+
 stm32:
   - chips/stm*/**/*
 

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,11 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@main
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
### Pull Request Overview

This pull request adds the [labeler](https://github.com/actions/labeler) github action, along with a config file, to automatically label PRs based on the files they change. This has been made possible thanks to [changes](https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/) by Github that allow you to safely run github actions using the *actions* configuration in the base branch, on the non-actions code in the PR branch. 

Because of limitations with bors merging changes that touch the `.github` directory, I think this will have to be manually merged if it is approved.

### Testing Strategy

This pull request was tested by merging this code into "master" on my fork of Tock, and then submitting this test PR: https://github.com/hudson-ayers/tock/pull/8 


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] No updates are required.

### Formatting

- [x] Ran `make prepush`.
