### PR TITLE
const generics instead of macro for pmp configuration

### DIFF
--- a/chips/arty_e21_chip/src/chip.rs
+++ b/chips/arty_e21_chip/src/chip.rs
@@ -5,15 +5,15 @@ use kernel::InterruptService;
 use rv32i;
 
 use crate::interrupts;
-use crate::pmp;
 use crate::timer;
+use rv32i::pmp::PMP;
 
 extern "C" {
     fn _start_trap();
 }
 
 pub struct ArtyExx<'a, I: InterruptService<()> + 'a> {
-    pmp: pmp::PMP,
+    pmp: PMP<4, 2>,
     userspace_kernel_boundary: rv32i::syscall::SysCall,
     clic: rv32i::clic::Clic,
     machinetimer: &'a rv32i::machine_timer::MachineTimer<'a>,
@@ -81,7 +81,7 @@ impl<'a, I: InterruptService<()> + 'a> ArtyExx<'a, I> {
         let in_use_interrupts: u64 = 0x1FFFF0080;
 
         Self {
-            pmp: pmp::PMP::new(),
+            pmp: PMP::new(),
             userspace_kernel_boundary: rv32i::syscall::SysCall::new(),
             clic: rv32i::clic::Clic::new(in_use_interrupts),
             machinetimer,
@@ -142,7 +142,7 @@ impl<'a, I: InterruptService<()> + 'a> ArtyExx<'a, I> {
 }
 
 impl<'a, I: InterruptService<()> + 'a> kernel::Chip for ArtyExx<'a, I> {
-    type MPU = pmp::PMP;
+    type MPU = PMP<4, 2>;
     type UserspaceKernelBoundary = rv32i::syscall::SysCall;
     type SchedulerTimer = ();
     type WatchDog = ();

--- a/chips/arty_e21_chip/src/lib.rs
+++ b/chips/arty_e21_chip/src/lib.rs
@@ -6,7 +6,6 @@
 #![crate_type = "rlib"]
 
 mod interrupts;
-mod pmp;
 
 pub mod chip;
 pub mod gpio;

--- a/chips/arty_e21_chip/src/pmp.rs
+++ b/chips/arty_e21_chip/src/pmp.rs
@@ -1,6 +1,0 @@
-//! Instantiate the PMP for the e21 core.
-
-use rv32i::PMPConfigMacro;
-
-// The arty-e21 has four PMP entries.
-PMPConfigMacro!(4);

--- a/chips/e310x/src/chip.rs
+++ b/chips/e310x/src/chip.rs
@@ -7,18 +7,16 @@ use kernel::hil::time::Alarm;
 use kernel::Chip;
 use rv32i;
 use rv32i::csr::{mcause, mie::mie, mip::mip, CSR};
-use rv32i::PMPConfigMacro;
+use rv32i::pmp::PMP;
 
 use crate::interrupts;
 use crate::plic::Plic;
 use crate::plic::PLIC;
 use kernel::InterruptService;
 
-PMPConfigMacro!(8);
-
 pub struct E310x<'a, A: 'static + Alarm<'static>, I: InterruptService<()> + 'a> {
     userspace_kernel_boundary: rv32i::syscall::SysCall,
-    pmp: PMP,
+    pmp: PMP<8, 4>,
     plic: &'a Plic,
     scheduler_timer: kernel::VirtualSchedulerTimer<A>,
     timer: &'a rv32i::machine_timer::MachineTimer<'a>,
@@ -107,7 +105,7 @@ impl<'a, A: 'static + Alarm<'static>, I: InterruptService<()> + 'a> E310x<'a, A,
 impl<'a, A: 'static + Alarm<'static>, I: InterruptService<()> + 'a> kernel::Chip
     for E310x<'a, A, I>
 {
-    type MPU = PMP;
+    type MPU = PMP<8, 4>;
     type UserspaceKernelBoundary = rv32i::syscall::SysCall;
     type SchedulerTimer = kernel::VirtualSchedulerTimer<A>;
     type WatchDog = ();

--- a/chips/earlgrey/src/chip.rs
+++ b/chips/earlgrey/src/chip.rs
@@ -6,19 +6,17 @@ use kernel::debug;
 use kernel::hil::time::Alarm;
 use kernel::{Chip, InterruptService};
 use rv32i::csr::{mcause, mie::mie, mip::mip, mtvec::mtvec, CSR};
+use rv32i::pmp::PMP;
 use rv32i::syscall::SysCall;
-use rv32i::PMPConfigMacro;
 
 use crate::chip_config::CONFIG;
 use crate::interrupts;
 use crate::plic::Plic;
 use crate::plic::PLIC;
 
-PMPConfigMacro!(4);
-
 pub struct EarlGrey<'a, A: 'static + Alarm<'static>, I: InterruptService<()> + 'a> {
     userspace_kernel_boundary: SysCall,
-    pmp: PMP,
+    pmp: PMP<4, 2>,
     plic: &'a Plic,
     scheduler_timer: kernel::VirtualSchedulerTimer<A>,
     timer: &'static crate::timer::RvTimer<'static>,
@@ -156,7 +154,7 @@ impl<'a, A: 'static + Alarm<'static>, I: InterruptService<()> + 'a> EarlGrey<'a,
 impl<'a, A: 'static + Alarm<'static>, I: InterruptService<()> + 'a> kernel::Chip
     for EarlGrey<'a, A, I>
 {
-    type MPU = PMP;
+    type MPU = PMP<4, 2>;
     type UserspaceKernelBoundary = SysCall;
     type SchedulerTimer = kernel::VirtualSchedulerTimer<A>;
     type WatchDog = ();

--- a/chips/litex_vexriscv/src/chip.rs
+++ b/chips/litex_vexriscv/src/chip.rs
@@ -6,8 +6,8 @@ use kernel::debug;
 use kernel::hil::time::Alarm;
 use kernel::InterruptService;
 use rv32i::csr::{mcause, mie::mie, CSR};
+use rv32i::pmp::PMP;
 use rv32i::syscall::SysCall;
-use rv32i::PMPConfigMacro;
 
 use crate::interrupt_controller::VexRiscvInterruptController;
 
@@ -18,13 +18,11 @@ static mut INTERRUPT_CONTROLLER: VexRiscvInterruptController = VexRiscvInterrupt
 // The VexRiscv "Secure" variant of
 // [pythondata-cpu-vexriscv](https://github.com/litex-hub/pythondata-cpu-vexriscv)
 // has 16 PMP slots
-PMPConfigMacro!(16);
-
 pub struct LiteXVexRiscv<A: 'static + Alarm<'static>, I: 'static + InterruptService<()>> {
     soc_identifier: &'static str,
     userspace_kernel_boundary: SysCall,
     interrupt_controller: &'static VexRiscvInterruptController,
-    pmp: PMP,
+    pmp: PMP<16, 8>,
     scheduler_timer: kernel::VirtualSchedulerTimer<A>,
     interrupt_service: &'static I,
 }
@@ -62,7 +60,7 @@ impl<A: 'static + Alarm<'static>, I: 'static + InterruptService<()>> LiteXVexRis
 impl<A: 'static + Alarm<'static>, I: 'static + InterruptService<()>> kernel::Chip
     for LiteXVexRiscv<A, I>
 {
-    type MPU = PMP;
+    type MPU = PMP<16, 8>;
     type UserspaceKernelBoundary = SysCall;
     type SchedulerTimer = kernel::VirtualSchedulerTimer<A>;
     type WatchDog = ();


### PR DESCRIPTION
### Pull Request Overview

This pull request replaces the use of a giant macro for configuring the risc-v PMP with use of const generics so that the struct is generic over the number of regions available. Unfortunately, one shortcoming of `min_const_generics` (which is now stable) is that arbitrary expressions involving generic constants are not yet supported when those constants are used in the definition of types. Because PMP has some array types of size `NUM_REGIONS`, and some of size `NUM_REGIONS / 2`, both of these values actually have to be separate generic parameters.


### Testing Strategy

This pull request was tested by compiling.


### TODO or Help Wanted

N/A

### Documentation Updated

- [x] No updates are required.

### Formatting

- [x] Ran `make prepush`.
