### PR TITLE
Remove associated_type_defaults feature

### DIFF
--- a/kernel/src/component.rs
+++ b/kernel/src/component.rs
@@ -20,7 +20,7 @@ pub trait Component {
     /// cannot setup static buffers for types which are chip-dependent, so those
     /// buffers have to be passed in manually, and the `StaticInput` type makes
     /// this possible.
-    type StaticInput = ();
+    type StaticInput;
 
     /// The type (e.g., capsule, peripheral) that this implementation
     /// of Component produces via `finalize()`. This is typically a

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -85,7 +85,7 @@
 //!    this use case. It is likely we will have to create new interfaces as new
 //!    use cases are discovered.
 
-#![feature(core_intrinsics, const_fn, associated_type_defaults, try_trait)]
+#![feature(core_intrinsics, const_fn, try_trait)]
 #![warn(unreachable_pub)]
 #![no_std]
 

--- a/kernel/src/platform/mpu.rs
+++ b/kernel/src/platform/mpu.rs
@@ -91,7 +91,7 @@ pub trait MPU {
     /// It is `Default` so we can create empty state when the process is
     /// created, and `Display` so that the `panic!()` output can display the
     /// current state to help with debugging.
-    type MpuConfig: Default + Display = MpuConfigDefault;
+    type MpuConfig: Default + Display;
 
     /// Clears the MPU.
     ///
@@ -266,7 +266,9 @@ pub trait MPU {
 }
 
 /// Implement default MPU trait for unit.
-impl MPU for () {}
+impl MPU for () {
+    type MpuConfig = MpuConfigDefault;
+}
 
 /// The generic trait that particular kernel level memory protection unit
 /// implementations need to implement.
@@ -285,7 +287,7 @@ pub trait KernelMPU {
     /// It is `Default` so we can create empty state when the kernel is
     /// created, and `Display` so that the `panic!()` output can display the
     /// current state to help with debugging.
-    type KernelMpuConfig: Default + Display = MpuConfigDefault;
+    type KernelMpuConfig: Default + Display;
 
     /// Mark a region of memory that the Tock kernel owns.
     ///


### PR DESCRIPTION
Re: #1654

This feature doesn't _seem_ to be making much progress in Rust: https://github.com/rust-lang/rust/issues/29661.

Also, that was easy.




### Testing Strategy

travis


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
