### PR TITLE
Initial commit of the Cortex-M4F arch crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "arch/cortex-m0",
     "arch/cortex-m3",
     "arch/cortex-m4",
+    "arch/cortex-m4f",
     "arch/cortex-m7",
     "arch/riscv",
     "arch/rv32i",

--- a/arch/cortex-m/src/scb.rs
+++ b/arch/cortex-m/src/scb.rs
@@ -8,7 +8,7 @@ use kernel::common::StaticRef;
 register_structs! {
     /// In an ARMv7-M processor, a System Control Block (SCB) in the SCS
     /// provides key status information and control features for the processor.
-    ScbRegisters {
+    pub ScbRegisters {
         /// CPUID Base Register
         (0x00 => cpuid: ReadOnly<u32, CpuId::Register>),
 
@@ -58,7 +58,7 @@ register_structs! {
         (0x80 => _reserved1),
 
         /// Coprocessor Access Control Register
-        (0x88 => cpacr: ReadWrite<u32, CoprocessorAccessControl::Register>),
+        (0x88 => pub cpacr: ReadWrite<u32, CoprocessorAccessControl::Register>),
 
         /// 0xE000ED8C, Reserved.
         (0x8c => _reserved2),
@@ -251,7 +251,7 @@ register_bitfields![u32,
         ADDRESS         OFFSET(0)   NUMBITS(32)
     ],
 
-    CoprocessorAccessControl [
+    pub CoprocessorAccessControl [
         CP11            OFFSET(22)  NUMBITS(2),
         CP10            OFFSET(20)  NUMBITS(2),
         CP7             OFFSET(14)  NUMBITS(2),
@@ -265,7 +265,8 @@ register_bitfields![u32,
     ]
 ];
 
-const SCB: StaticRef<ScbRegisters> = unsafe { StaticRef::new(0xE000ED00 as *const ScbRegisters) };
+pub const SCB: StaticRef<ScbRegisters> =
+    unsafe { StaticRef::new(0xE000ED00 as *const ScbRegisters) };
 
 /// Allow the core to go into deep sleep on WFI.
 ///

--- a/arch/cortex-m/src/scb.rs
+++ b/arch/cortex-m/src/scb.rs
@@ -294,24 +294,3 @@ pub unsafe fn reset() {
 pub unsafe fn set_vector_table_offset(offset: *const ()) {
     SCB.vtor.set(offset as u32);
 }
-
-/// Disable the FPU
-#[cfg(all(target_arch = "arm", target_os = "none"))]
-pub unsafe fn disable_fpca() {
-    SCB.cpacr
-        .modify(CoprocessorAccessControl::CP10::CLEAR + CoprocessorAccessControl::CP11::CLEAR);
-
-    asm!("dsb", "isb", options(nomem, nostack, preserves_flags));
-
-    if SCB.cpacr.read(CoprocessorAccessControl::CP10) != 0
-        || SCB.cpacr.read(CoprocessorAccessControl::CP11) != 0
-    {
-        panic!("Unable to disable FPU");
-    }
-}
-
-// Mock implementation for tests on Travis-CI.
-#[cfg(not(any(target_arch = "arm", target_os = "none")))]
-pub unsafe fn disable_fpca() {
-    unimplemented!()
-}

--- a/arch/cortex-m4f/Cargo.toml
+++ b/arch/cortex-m4f/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "cortexm4f"
+version = "0.1.0"
+authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+edition = "2018"
+
+[dependencies]
+kernel = { path = "../../kernel" }
+cortexm4 = { path = "../cortex-m4" }

--- a/arch/cortex-m4f/README.md
+++ b/arch/cortex-m4f/README.md
@@ -1,0 +1,5 @@
+Cortex-M4F Architecture
+======================
+
+Architecture support for Cortex-M4F devices. This largely only re-exports the
+correct functions from the Cortex-M4 crate.

--- a/arch/cortex-m4f/src/fpu.rs
+++ b/arch/cortex-m4f/src/fpu.rs
@@ -1,0 +1,57 @@
+//! ARM FPU Block
+
+use kernel::common::registers::{register_bitfields, register_structs, ReadWrite};
+use kernel::common::StaticRef;
+
+register_structs! {
+    pub FpuRegisters {
+        (0x00 => _reserved0),
+
+        /// Floating-point Context Control Register
+        (0x04 => fpccr: ReadWrite<u32, FPCCR::Register>),
+
+        /// Floating-point Context Address Register
+        (0x08 => fpcar: ReadWrite<u32, FPCAR::Register>),
+
+        /// Floating-point Default Status Control Register
+        (0x0C => fpscr: ReadWrite<u32, FPSCR::Register>),
+
+        (0x10 => @END),
+    }
+}
+
+register_bitfields![u32,
+    FPCCR [
+        ASPEN   OFFSET(31)  NUMBITS(1),
+        LSPEN   OFFSET(30)  NUMBITS(1),
+        MONRDY  OFFSET(8)   NUMBITS(1),
+        BFRDY   OFFSET(6)   NUMBITS(1),
+        MMRDY   OFFSET(5)   NUMBITS(1),
+        HFRDY   OFFSET(4)   NUMBITS(1),
+        THREAD  OFFSET(3)   NUMBITS(1),
+        USER    OFFSET(1)   NUMBITS(1),
+        LSPACT  OFFSET(0)   NUMBITS(1),
+    ],
+
+    FPCAR [
+        ADDRESS OFFSET(3)   NUMBITS(29),
+    ],
+
+    FPSCR [
+        AHP     OFFSET(26)  NUMBITS(1),
+        DN      OFFSET(25)  NUMBITS(1),
+        FZ      OFFSET(24)  NUMBITS(1),
+        RMode   OFFSET(22)  NUMBITS(2),
+    ],
+];
+
+pub const FPU: StaticRef<FpuRegisters> =
+    unsafe { StaticRef::new(0xE000_EF30 as *const FpuRegisters) };
+
+pub unsafe fn enable_auto_state_save() {
+    FPU.fpccr.modify(FPCCR::ASPEN::SET);
+}
+
+pub unsafe fn enable_auto_lazy_store() {
+    FPU.fpccr.modify(FPCCR::LSPEN::SET);
+}

--- a/arch/cortex-m4f/src/lib.rs
+++ b/arch/cortex-m4f/src/lib.rs
@@ -1,0 +1,23 @@
+//! Shared implementations for ARM Cortex-M4F MCUs.
+
+#![crate_name = "cortexm4f"]
+#![crate_type = "rlib"]
+#![no_std]
+#![feature(asm)]
+
+pub mod scb;
+
+// Re-export the base generic cortex-m functions here as they are
+// valid on cortex-m4.
+pub use cortexm4::support;
+
+pub use cortexm4::generic_isr;
+pub use cortexm4::hard_fault_handler;
+pub use cortexm4::mpu;
+pub use cortexm4::nvic;
+pub use cortexm4::print_cortexm4_state as print_cortexm4f_state;
+pub use cortexm4::svc_handler;
+pub use cortexm4::syscall;
+pub use cortexm4::systick;
+pub use cortexm4::systick_handler;
+pub use cortexm4::unhandled_interrupt;

--- a/arch/cortex-m4f/src/lib.rs
+++ b/arch/cortex-m4f/src/lib.rs
@@ -5,6 +5,7 @@
 #![no_std]
 #![feature(asm)]
 
+pub mod fpu;
 pub mod scb;
 
 // Re-export the base generic cortex-m functions here as they are

--- a/arch/cortex-m4f/src/scb.rs
+++ b/arch/cortex-m4f/src/scb.rs
@@ -1,0 +1,50 @@
+//! ARM System Control Block
+//!
+//! <http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dui0553a/CIHFDJCA.html>
+
+pub use cortexm4::scb;
+pub use cortexm4::scb::{set_vector_table_offset, unset_sleepdeep};
+#[allow(unused_imports)]
+use cortexm4::scb::{CoprocessorAccessControl, SCB};
+
+/// Disable the FPU
+#[cfg(all(target_arch = "arm", target_os = "none"))]
+pub unsafe fn disable_fpca() {
+    SCB.cpacr
+        .modify(CoprocessorAccessControl::CP10::CLEAR + CoprocessorAccessControl::CP11::CLEAR);
+
+    asm!("dsb", "isb", options(nomem, nostack, preserves_flags));
+
+    if SCB.cpacr.read(CoprocessorAccessControl::CP10) != 0
+        || SCB.cpacr.read(CoprocessorAccessControl::CP11) != 0
+    {
+        panic!("Unable to disable FPU");
+    }
+}
+
+// Mock implementation for tests on Travis-CI.
+#[cfg(not(any(target_arch = "arm", target_os = "none")))]
+pub unsafe fn disable_fpca() {
+    unimplemented!()
+}
+
+/// Enable the FPU
+#[cfg(all(target_arch = "arm", target_os = "none"))]
+pub unsafe fn enable_fpca() {
+    SCB.cpacr
+        .modify(CoprocessorAccessControl::CP10::SET + CoprocessorAccessControl::CP11::SET);
+
+    asm!("dsb", "isb", options(nomem, nostack, preserves_flags));
+
+    if SCB.cpacr.read(CoprocessorAccessControl::CP10) != 3
+        || SCB.cpacr.read(CoprocessorAccessControl::CP11) != 3
+    {
+        panic!("Unable to enable FPU");
+    }
+}
+
+// Mock implementation for tests on Travis-CI.
+#[cfg(not(any(target_arch = "arm", target_os = "none")))]
+pub unsafe fn enable_fpca() {
+    unimplemented!()
+}

--- a/arch/cortex-m4f/src/scb.rs
+++ b/arch/cortex-m4f/src/scb.rs
@@ -3,7 +3,7 @@
 //! <http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dui0553a/CIHFDJCA.html>
 
 pub use cortexm4::scb;
-pub use cortexm4::scb::{set_vector_table_offset, unset_sleepdeep};
+pub use cortexm4::scb::{reset, set_vector_table_offset, unset_sleepdeep};
 #[allow(unused_imports)]
 use cortexm4::scb::{CoprocessorAccessControl, SCB};
 

--- a/boards/nordic/nrf52840_dongle/Cargo.toml
+++ b/boards/nordic/nrf52840_dongle/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 components = { path = "../../components" }
-cortexm4 = { path = "../../../arch/cortex-m4" }
+cortexm4f = { path = "../../../arch/cortex-m4f" }
 capsules = { path = "../../../capsules" }
 kernel = { path = "../../../kernel" }
 nrf52840 = { path = "../../../chips/nrf52840" }

--- a/boards/nordic/nrf52840_dongle/src/io.rs
+++ b/boards/nordic/nrf52840_dongle/src/io.rs
@@ -1,6 +1,6 @@
 use core::fmt::Write;
 use core::panic::PanicInfo;
-use cortexm4;
+use cortexm4f;
 use kernel::debug;
 use kernel::debug::IoWrite;
 use kernel::hil::led;
@@ -61,7 +61,7 @@ pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
         &mut [led],
         writer,
         pi,
-        &cortexm4::support::nop,
+        &cortexm4f::support::nop,
         &PROCESSES,
         &CHIP,
     )

--- a/boards/nordic/nrf52840dk/Cargo.toml
+++ b/boards/nordic/nrf52840dk/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 components = { path = "../../components" }
-cortexm4 = { path = "../../../arch/cortex-m4" }
+cortexm4f = { path = "../../../arch/cortex-m4f" }
 capsules = { path = "../../../capsules" }
 kernel = { path = "../../../kernel" }
 nrf52840 = { path = "../../../chips/nrf52840" }

--- a/boards/nordic/nrf52840dk/src/io.rs
+++ b/boards/nordic/nrf52840dk/src/io.rs
@@ -1,6 +1,6 @@
 use core::fmt::Write;
 use core::panic::PanicInfo;
-use cortexm4;
+use cortexm4f;
 use kernel::debug;
 use kernel::debug::IoWrite;
 use kernel::hil::led;
@@ -20,7 +20,7 @@ static mut WRITER: Writer = Writer::WriterUart(false);
 
 fn wait() {
     for _ in 0..100 {
-        cortexm4::support::nop();
+        cortexm4f::support::nop();
     }
 }
 
@@ -99,7 +99,7 @@ pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
         &mut [led],
         writer,
         pi,
-        &cortexm4::support::nop,
+        &cortexm4f::support::nop,
         &PROCESSES,
         &CHIP,
     )

--- a/boards/nordic/nrf52_components/Cargo.toml
+++ b/boards/nordic/nrf52_components/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 components = { path = "../../components" }
-cortexm4 = { path = "../../../arch/cortex-m4" }
+cortexm4f = { path = "../../../arch/cortex-m4f" }
 capsules = { path = "../../../capsules" }
 kernel = { path = "../../../kernel" }
 nrf52 = { path = "../../../chips/nrf52" }

--- a/boards/nordic/nrf52_components/src/startup.rs
+++ b/boards/nordic/nrf52_components/src/startup.rs
@@ -96,7 +96,7 @@ impl<'a> Component for NrfStartupComponent<'a> {
 
         // Any modification of UICR needs a soft reset for the changes to be taken into account.
         if needs_soft_reset {
-            cortexm4::scb::reset();
+            cortexm4f::scb::reset();
         }
     }
 }

--- a/boards/nordic/nrf52dk/Cargo.toml
+++ b/boards/nordic/nrf52dk/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 components = { path = "../../components" }
-cortexm4 = { path = "../../../arch/cortex-m4" }
+cortexm4f = { path = "../../../arch/cortex-m4f" }
 capsules = { path = "../../../capsules" }
 kernel = { path = "../../../kernel" }
 nrf52832 = { path = "../../../chips/nrf52832" }

--- a/boards/nordic/nrf52dk/src/io.rs
+++ b/boards/nordic/nrf52dk/src/io.rs
@@ -1,6 +1,6 @@
 use core::fmt::Write;
 use core::panic::PanicInfo;
-use cortexm4;
+use cortexm4f;
 use kernel::debug;
 use kernel::debug::IoWrite;
 use kernel::hil::led;
@@ -61,7 +61,7 @@ pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
         &mut [led],
         writer,
         pi,
-        &cortexm4::support::nop,
+        &cortexm4f::support::nop,
         &PROCESSES,
         &CHIP,
     )

--- a/boards/redboard_artemis_nano/Cargo.toml
+++ b/boards/redboard_artemis_nano/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 components = { path = "../components" }
-cortexm4 = { path = "../../arch/cortex-m4" }
+cortexm4f = { path = "../../arch/cortex-m4f" }
 capsules = { path = "../../capsules" }
 kernel = { path = "../../kernel" }
 apollo3 = { path = "../../chips/apollo3" }

--- a/boards/redboard_artemis_nano/src/io.rs
+++ b/boards/redboard_artemis_nano/src/io.rs
@@ -55,7 +55,7 @@ pub unsafe extern "C" fn panic_fmt(info: &PanicInfo) -> ! {
         &mut [led],
         writer,
         info,
-        &cortexm4::support::nop,
+        &cortexm4f::support::nop,
         &PROCESSES,
         &CHIP,
     )

--- a/chips/apollo3/Cargo.toml
+++ b/chips/apollo3/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
 edition = "2018"
 
 [dependencies]
-cortexm4 = { path = "../../arch/cortex-m4" }
+cortexm4f = { path = "../../arch/cortex-m4f" }
 enum_primitive = { path = "../../libraries/enum_primitive" }
 kernel = { path = "../../kernel" }
 tock-rt0 = { path = "../../libraries/tock-rt0" }

--- a/chips/apollo3/src/lib.rs
+++ b/chips/apollo3/src/lib.rs
@@ -18,7 +18,7 @@ pub mod pwrctrl;
 pub mod stimer;
 pub mod uart;
 
-use cortexm4::{
+use cortexm4f::{
     generic_isr, hard_fault_handler, scb, svc_handler, systick_handler, unhandled_interrupt,
 };
 
@@ -106,9 +106,9 @@ pub unsafe fn init() {
     // This ensures the FPU is actually disabled
     llvm_asm!("svc 0xff" : : : "r0","r1","r2","r3","r12" : "volatile" );
 
-    cortexm4::nvic::disable_all();
-    cortexm4::nvic::clear_all_pending();
-    cortexm4::nvic::enable_all();
+    cortexm4f::nvic::disable_all();
+    cortexm4f::nvic::clear_all_pending();
+    cortexm4f::nvic::enable_all();
 }
 
 // Mock implementation for tests

--- a/chips/nrf52/Cargo.toml
+++ b/chips/nrf52/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
 edition = "2018"
 
 [dependencies]
-cortexm4 = { path = "../../arch/cortex-m4" }
+cortexm4f = { path = "../../arch/cortex-m4f" }
 kernel = { path = "../../kernel" }
 tock-rt0 = { path = "../../libraries/tock-rt0" }
 enum_primitive = { path = "../../libraries/enum_primitive" }

--- a/chips/nrf52/src/chip.rs
+++ b/chips/nrf52/src/chip.rs
@@ -1,24 +1,24 @@
 use crate::deferred_call_tasks::DeferredCallTask;
 use core::fmt::Write;
-use cortexm4::{self, nvic};
+use cortexm4f::{self, nvic};
 use kernel::common::deferred_call;
 use kernel::InterruptService;
 
 pub struct NRF52<'a, I: InterruptService<DeferredCallTask> + 'a> {
-    mpu: cortexm4::mpu::MPU,
-    userspace_kernel_boundary: cortexm4::syscall::SysCall,
-    scheduler_timer: cortexm4::systick::SysTick,
+    mpu: cortexm4f::mpu::MPU,
+    userspace_kernel_boundary: cortexm4f::syscall::SysCall,
+    scheduler_timer: cortexm4f::systick::SysTick,
     interrupt_service: &'a I,
 }
 
 impl<'a, I: InterruptService<DeferredCallTask> + 'a> NRF52<'a, I> {
     pub unsafe fn new(interrupt_service: &'a I) -> Self {
         Self {
-            mpu: cortexm4::mpu::MPU::new(),
-            userspace_kernel_boundary: cortexm4::syscall::SysCall::new(),
+            mpu: cortexm4f::mpu::MPU::new(),
+            userspace_kernel_boundary: cortexm4f::syscall::SysCall::new(),
             // The NRF52's systick is uncalibrated, but is clocked from the
             // 64Mhz CPU clock.
-            scheduler_timer: cortexm4::systick::SysTick::new_with_calibration(64000000),
+            scheduler_timer: cortexm4f::systick::SysTick::new_with_calibration(64000000),
             interrupt_service,
         }
     }
@@ -153,9 +153,9 @@ impl<'a> kernel::InterruptService<DeferredCallTask> for Nrf52DefaultPeripherals<
 }
 
 impl<'a, I: InterruptService<DeferredCallTask> + 'a> kernel::Chip for NRF52<'a, I> {
-    type MPU = cortexm4::mpu::MPU;
-    type UserspaceKernelBoundary = cortexm4::syscall::SysCall;
-    type SchedulerTimer = cortexm4::systick::SysTick;
+    type MPU = cortexm4f::mpu::MPU;
+    type UserspaceKernelBoundary = cortexm4f::syscall::SysCall;
+    type SchedulerTimer = cortexm4f::systick::SysTick;
     type WatchDog = ();
 
     fn mpu(&self) -> &Self::MPU {
@@ -201,7 +201,7 @@ impl<'a, I: InterruptService<DeferredCallTask> + 'a> kernel::Chip for NRF52<'a, 
 
     fn sleep(&self) {
         unsafe {
-            cortexm4::support::wfi();
+            cortexm4f::support::wfi();
         }
     }
 
@@ -209,10 +209,10 @@ impl<'a, I: InterruptService<DeferredCallTask> + 'a> kernel::Chip for NRF52<'a, 
     where
         F: FnOnce() -> R,
     {
-        cortexm4::support::atomic(f)
+        cortexm4f::support::atomic(f)
     }
 
     unsafe fn print_state(&self, write: &mut dyn Write) {
-        cortexm4::print_cortexm4_state(write);
+        cortexm4f::print_cortexm4f_state(write);
     }
 }

--- a/chips/nrf52/src/crt1.rs
+++ b/chips/nrf52/src/crt1.rs
@@ -1,4 +1,4 @@
-use cortexm4::{
+use cortexm4f::{
     generic_isr, hard_fault_handler, nvic, scb, svc_handler, systick_handler, unhandled_interrupt,
 };
 use tock_rt0;

--- a/chips/nrf52/src/usbd.rs
+++ b/chips/nrf52/src/usbd.rs
@@ -1,7 +1,7 @@
 //! Universal Serial Bus Device with EasyDMA (USBD)
 
 use core::cell::Cell;
-use cortexm4::support::atomic;
+use cortexm4f::support::atomic;
 use kernel::common::cells::{OptionalCell, VolatileCell};
 use kernel::common::registers::{
     register_bitfields, register_structs, Field, InMemoryRegister, LocalRegisterCopy, ReadOnly,
@@ -1315,7 +1315,7 @@ impl<'a> Usbd<'a> {
         // ms), but then the EPDATA event on the very first IN transfer
         // immediately after the `client.bus_reset()` call below never occurs.
         for _ in 0..800000 {
-            cortexm4::support::nop();
+            cortexm4f::support::nop();
         }
 
         // TODO: reset controller stack


### PR DESCRIPTION
### Pull Request Overview

Following up no discussions here: https://github.com/tock/tock/pull/1010#issuecomment-400824717 this PR creates a Cortex-M4F arch crate that can be used for Cortex-M4F boards/chips.

Currently this just creates the crate and adds function to enable the FPU. This doesn't actually enable anything and should have no functional change.

### Testing Strategy

Build testing and running on some of the Nordic boards.

### TODO or Help Wanted

N/A

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
