### PR TITLE
kernel: syscall: use `from` fn

### DIFF
--- a/arch/cortex-m/src/syscall.rs
+++ b/arch/cortex-m/src/syscall.rs
@@ -178,7 +178,8 @@ impl kernel::syscall::UserspaceKernelBoundary for SysCall {
 
             // Use the helper function to convert these raw values into a Tock
             // `Syscall` type.
-            let syscall = kernel::syscall::arguments_to_syscall(svc_num, r0, r1, r2, r3);
+            let syscall =
+                kernel::syscall::Syscall::from_register_arguments(svc_num, r0, r1, r2, r3);
 
             match syscall {
                 Some(s) => kernel::syscall::ContextSwitchReason::SyscallFired { syscall: s },

--- a/arch/rv32i/src/syscall.rs
+++ b/arch/rv32i/src/syscall.rs
@@ -360,7 +360,7 @@ impl kernel::syscall::UserspaceKernelBoundary for SysCall {
                         // instruction. The hardware does not do this for us.
                         state.pc += 4;
 
-                        let syscall = kernel::syscall::arguments_to_syscall(
+                        let syscall = kernel::syscall::Syscall::from_register_arguments(
                             state.regs[R_A0] as u8,
                             state.regs[R_A1],
                             state.regs[R_A2],


### PR DESCRIPTION
Rather than a separate helper function, use a `From` pattern. This is more rust-y.

Backported from 2.0 branch.

Why? This will make the 2.0 diff easier to read, because the relevant code will show an inline diff, rather than just seeing one block of code deleted and a different block added.


### Testing Strategy

travis


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
