### PR TITLE
kernel: add in_app_owned_flash fn

### DIFF
--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -2222,8 +2222,8 @@ impl<C: 'static + Chip> Process<'_, C> {
     }
 
     /// Checks if the buffer represented by the passed in base pointer and size
-    /// are within the memory bounds currently exposed to the processes (i.e.
-    /// ending at `app_break`. If this method returns true, the buffer
+    /// is within the memory bounds currently exposed to the processes (i.e.
+    /// ending at `app_break`). If this method returns `true`, the buffer
     /// is guaranteed to be accessible to the process and to not overlap with
     /// the grant region.
     fn in_app_owned_memory(&self, buf_start_addr: *const u8, size: usize) -> bool {
@@ -2232,6 +2232,19 @@ impl<C: 'static + Chip> Process<'_, C> {
         buf_end_addr >= buf_start_addr
             && buf_start_addr >= self.mem_start()
             && buf_end_addr <= self.app_break.get()
+    }
+
+    /// Checks if the buffer represented by the passed in base pointer and size
+    /// is within the readable region of an application's flash memory. If this
+    /// method returns `true`, the buffer is guaranteed to be readable to the
+    /// process.
+    #[allow(dead_code)] // used in 2.0
+    fn in_app_owned_flash(&self, buf_start_addr: *const u8, size: usize) -> bool {
+        let buf_end_addr = buf_start_addr.wrapping_add(size);
+
+        buf_end_addr >= buf_start_addr
+            && buf_start_addr >= self.flash_non_protected_start()
+            && buf_end_addr <= self.flash_end()
     }
 
     /// Reset all `grant_ptr`s to NULL.


### PR DESCRIPTION
Add `in_app_owned_flash()` to `Process`. This mirrors the RAM version.

Backported from 2.0 branch.

It didn't occur to me until after that this would raise the dead code warning, so maybe this isn't worth it? It just makes reviewing the 2.0 changes slightly easier since we can look at the check now, rather than with all of the other changes.




### Testing Strategy

travis / 2.0 branch


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
