### PR TITLE
 Backport 802.15.4 deferred call update from 2.0

### DIFF
--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -260,7 +260,7 @@ pub unsafe fn reset_handler() {
     //--------------------------------------------------------------------------
 
     let dynamic_deferred_call_clients =
-        static_init!([DynamicDeferredCallClientState; 3], Default::default());
+        static_init!([DynamicDeferredCallClientState; 4], Default::default());
     let dynamic_deferred_caller = static_init!(
         DynamicDeferredCall,
         DynamicDeferredCall::new(dynamic_deferred_call_clients)
@@ -494,6 +494,7 @@ pub unsafe fn reset_handler() {
         aes_mux,
         PAN_ID,
         serial_num_bottom_16,
+        dynamic_deferred_caller,
     )
     .finalize(components::ieee802154_component_helper!(
         nrf52840::ieee802154_radio::Radio,

--- a/boards/components/src/ieee802154.rs
+++ b/boards/components/src/ieee802154.rs
@@ -13,6 +13,7 @@
 //!     &nrf52::aes::AESECB,
 //!     PAN_ID,
 //!     SRC_MAC,
+//!     deferred_caller,
 //! )
 //! .finalize(components::ieee802154_component_helper!(
 //!     nrf52::ieee802154_radio::Radio,
@@ -25,6 +26,7 @@ use capsules::ieee802154::device::MacDevice;
 use capsules::ieee802154::mac::{AwakeMac, Mac};
 use core::mem::MaybeUninit;
 use kernel::capabilities;
+use kernel::common::dynamic_deferred_call::DynamicDeferredCall;
 use kernel::component::Component;
 use kernel::hil::radio;
 use kernel::hil::symmetric_encryption::{self, AES128Ctr, AES128, AES128CBC, AES128CCM};
@@ -61,6 +63,7 @@ pub struct Ieee802154Component<
     aes_mux: &'static capsules::virtual_aes_ccm::MuxAES128CCM<'static, A>,
     pan_id: capsules::net::ieee802154::PanID,
     short_addr: u16,
+    deferred_caller: &'static DynamicDeferredCall,
 }
 
 impl<
@@ -74,6 +77,7 @@ impl<
         aes_mux: &'static capsules::virtual_aes_ccm::MuxAES128CCM<'static, A>,
         pan_id: capsules::net::ieee802154::PanID,
         short_addr: u16,
+        deferred_caller: &'static DynamicDeferredCall,
     ) -> Self {
         Self {
             board_kernel,
@@ -81,6 +85,7 @@ impl<
             aes_mux,
             pan_id,
             short_addr,
+            deferred_caller,
         }
     }
 }
@@ -169,7 +174,8 @@ impl<
             capsules::ieee802154::RadioDriver::new(
                 userspace_mac,
                 self.board_kernel.create_grant(&grant_cap),
-                &mut RADIO_BUF
+                &mut RADIO_BUF,
+                self.deferred_caller,
             )
         );
 
@@ -179,6 +185,11 @@ impl<
         userspace_mac.set_receive_client(radio_driver);
         userspace_mac.set_pan(self.pan_id);
         userspace_mac.set_address(self.short_addr);
+        radio_driver.initialize_callback_handle(
+            self.deferred_caller
+                .register(radio_driver)
+                .expect("no deferred call slot available for ieee802154 driver"),
+        );
 
         (radio_driver, mux_mac)
     }

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -467,6 +467,7 @@ pub unsafe fn reset_handler() {
         aes_mux,
         PAN_ID,
         serial_num_bottom_16,
+        dynamic_deferred_caller,
     )
     .finalize(components::ieee802154_component_helper!(
         capsules::rf233::RF233<'static, VirtualSpiMasterDevice<'static, sam4l::spi::SpiHw>>,

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -377,6 +377,7 @@ pub unsafe fn reset_handler() {
         aes_mux,
         PAN_ID,
         serial_num_bottom_16,
+        dynamic_deferred_caller,
     )
     .finalize(components::ieee802154_component_helper!(
         nrf52840::ieee802154_radio::Radio,

--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -244,7 +244,7 @@ pub unsafe fn reset_handler() {
     .finalize(());
 
     let dynamic_deferred_call_clients =
-        static_init!([DynamicDeferredCallClientState; 2], Default::default());
+        static_init!([DynamicDeferredCallClientState; 3], Default::default());
     let dynamic_deferred_caller = static_init!(
         DynamicDeferredCall,
         DynamicDeferredCall::new(dynamic_deferred_call_clients)
@@ -286,6 +286,7 @@ pub unsafe fn reset_handler() {
         aes_mux,
         PAN_ID,
         SRC_MAC,
+        dynamic_deferred_caller,
     )
     .finalize(components::ieee802154_component_helper!(
         nrf52840::ieee802154_radio::Radio,

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -338,7 +338,7 @@ pub unsafe fn reset_handler() {
     .finalize(());
 
     let dynamic_deferred_call_clients =
-        static_init!([DynamicDeferredCallClientState; 2], Default::default());
+        static_init!([DynamicDeferredCallClientState; 3], Default::default());
     let dynamic_deferred_caller = static_init!(
         DynamicDeferredCall,
         DynamicDeferredCall::new(dynamic_deferred_call_clients)
@@ -383,6 +383,7 @@ pub unsafe fn reset_handler() {
         aes_mux,
         PAN_ID,
         serial_num_bottom_16,
+        dynamic_deferred_caller,
     )
     .finalize(components::ieee802154_component_helper!(
         nrf52840::ieee802154_radio::Radio,


### PR DESCRIPTION
### Pull Request Overview

This pull request pulls the deferred call updates for 802.15.4 from the 2.0 branch into 1.x. This main benefit of this is that numerous changes to board files that are unrelated to 2.0 can now be reviewed separately.


### Testing Strategy

travis / 2.0 work


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
