### PR TITLE
kernel: move tbf code to its own library

### DIFF
--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2018"
 [dependencies]
 tock-registers = { path = "../libraries/tock-register-interface" }
 tock-cells = { path = "../libraries/tock-cells" }
+tock-tbf = { path = "../libraries/tock-tbf" }

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -85,7 +85,7 @@
 //!    this use case. It is likely we will have to create new interfaces as new
 //!    use cases are discovered.
 
-#![feature(core_intrinsics, const_fn, try_trait)]
+#![feature(core_intrinsics, const_fn)]
 #![warn(unreachable_pub)]
 #![no_std]
 
@@ -108,7 +108,6 @@ mod platform;
 mod process;
 mod returncode;
 mod sched;
-mod tbfheader;
 
 pub use crate::callback::{AppId, Callback};
 pub use crate::driver::Driver;

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -7,6 +7,8 @@ use core::fmt::Write;
 use core::ptr::{write_volatile, NonNull};
 use core::{mem, ptr, slice, str};
 
+use tock_tbf::tbfheader;
+
 use crate::callback::{AppId, CallbackId};
 use crate::capabilities::ProcessManagementCapability;
 use crate::common::cells::{MapCell, NumericCellExt};
@@ -20,7 +22,7 @@ use crate::platform::Chip;
 use crate::returncode::ReturnCode;
 use crate::sched::Kernel;
 use crate::syscall::{self, Syscall, UserspaceKernelBoundary};
-use crate::tbfheader;
+
 use core::cmp::max;
 
 /// Errors that can occur when trying to load and create processes.

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -7,8 +7,6 @@ use core::fmt::Write;
 use core::ptr::{write_volatile, NonNull};
 use core::{mem, ptr, slice, str};
 
-use tock_tbf::tbfheader;
-
 use crate::callback::{AppId, CallbackId};
 use crate::capabilities::ProcessManagementCapability;
 use crate::common::cells::{MapCell, NumericCellExt};
@@ -28,7 +26,7 @@ use core::cmp::max;
 /// Errors that can occur when trying to load and create processes.
 pub enum ProcessLoadError {
     /// The TBF header for the process could not be successfully parsed.
-    TbfHeaderParseFailure(tbfheader::TbfParseError),
+    TbfHeaderParseFailure(tock_tbf::types::TbfParseError),
 
     /// Not enough flash remaining to parse a process and its header.
     NotEnoughFlash,
@@ -63,12 +61,12 @@ pub enum ProcessLoadError {
     InternalError,
 }
 
-impl From<tbfheader::TbfParseError> for ProcessLoadError {
+impl From<tock_tbf::types::TbfParseError> for ProcessLoadError {
     /// Convert between a TBF Header parse error and a process load error.
     ///
     /// We note that the process load error is because a TBF header failed to
     /// parse, and just pass through the parse error.
-    fn from(error: tbfheader::TbfParseError) -> Self {
+    fn from(error: tock_tbf::types::TbfParseError) -> Self {
         ProcessLoadError::TbfHeaderParseFailure(error)
     }
 }
@@ -173,18 +171,18 @@ pub fn load_processes<C: Chip>(
         // Pass the first eight bytes to tbfheader to parse out the length of
         // the tbf header and app. We then use those values to see if we have
         // enough flash remaining to parse the remainder of the header.
-        let (version, header_length, entry_length) = match tbfheader::parse_tbf_header_lengths(
+        let (version, header_length, entry_length) = match tock_tbf::parse::parse_tbf_header_lengths(
             test_header_slice
                 .try_into()
                 .or(Err(ProcessLoadError::InternalError))?,
         ) {
             Ok((v, hl, el)) => (v, hl, el),
-            Err(tbfheader::InitialTbfParseError::InvalidHeader(entry_length)) => {
+            Err(tock_tbf::types::InitialTbfParseError::InvalidHeader(entry_length)) => {
                 // If we could not parse the header, then we want to skip over
                 // this app and look for the next one.
                 (0, 0, entry_length)
             }
-            Err(tbfheader::InitialTbfParseError::UnableToParse) => {
+            Err(tock_tbf::types::InitialTbfParseError::UnableToParse) => {
                 // Since Tock apps use a linked list, it is very possible the
                 // header we started to parse is intentionally invalid to signal
                 // the end of apps. This is ok and just means we have finished
@@ -847,7 +845,7 @@ pub struct Process<'a, C: 'static + Chip> {
     flash: &'static [u8],
 
     /// Collection of pointers to the TBF header in flash.
-    header: tbfheader::TbfHeader,
+    header: tock_tbf::types::TbfHeader,
 
     /// State saved on behalf of the process each time the app switches to the
     /// kernel.
@@ -1623,7 +1621,7 @@ impl<C: 'static + Chip> Process<'_, C> {
 
         // Parse the full TBF header to see if this is a valid app. If the
         // header can't parse, we will error right here.
-        let tbf_header = tbfheader::parse_tbf_header(header_flash, app_version)?;
+        let tbf_header = tock_tbf::parse::parse_tbf_header(header_flash, app_version)?;
 
         // First thing: check that the process is at the correct location in
         // flash if the TBF header specified a fixed address. If there is a

--- a/libraries/tock-tbf/Cargo.toml
+++ b/libraries/tock-tbf/Cargo.toml
@@ -1,0 +1,5 @@
+[package]
+name = "tock-tbf"
+version = "0.1.0"
+authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+

--- a/libraries/tock-tbf/Cargo.toml
+++ b/libraries/tock-tbf/Cargo.toml
@@ -2,4 +2,4 @@
 name = "tock-tbf"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-
+edition = "2018"

--- a/libraries/tock-tbf/README.md
+++ b/libraries/tock-tbf/README.md
@@ -1,0 +1,8 @@
+Tock Binary Format (TBF) Parsing Library
+========================================
+
+This crate contains code the kernel uses to parse TBF headers for processes on a
+board. It is split into a library because other code besides the kernel (for
+example elf2tab) may want to use this shared library code.
+
+This code was originally at `kernel/src/tbfheader.rs`.

--- a/libraries/tock-tbf/src/lib.rs
+++ b/libraries/tock-tbf/src/lib.rs
@@ -4,4 +4,5 @@
 #![forbid(unsafe_code)]
 #![no_std]
 
-pub mod tbfheader;
+pub mod parse;
+pub mod types;

--- a/libraries/tock-tbf/src/lib.rs
+++ b/libraries/tock-tbf/src/lib.rs
@@ -3,6 +3,5 @@
 // Parsing the headers does not require any unsafe operations.
 #![forbid(unsafe_code)]
 #![no_std]
-#![feature(try_trait)]
 
 pub mod tbfheader;

--- a/libraries/tock-tbf/src/lib.rs
+++ b/libraries/tock-tbf/src/lib.rs
@@ -1,0 +1,8 @@
+//! Tock Binary Format (TBF) header parsing library.
+
+// Parsing the headers does not require any unsafe operations.
+#![forbid(unsafe_code)]
+#![no_std]
+#![feature(try_trait)]
+
+pub mod tbfheader;

--- a/libraries/tock-tbf/src/parse.rs
+++ b/libraries/tock-tbf/src/parse.rs
@@ -1,0 +1,246 @@
+//! Tock Binary Format parsing code.
+
+use core::convert::TryInto;
+use core::iter::Iterator;
+use core::{mem, str};
+
+use crate::types;
+
+/// Takes a value and rounds it up to be aligned % 4
+macro_rules! align4 {
+    ($e:expr $(,)?) => {
+        ($e) + ((4 - (($e) % 4)) % 4)
+    };
+}
+
+/// Parse the TBF header length and the entire length of the TBF binary.
+///
+/// ## Return
+///
+/// If all parsing is successful:
+/// - Ok((Version, TBF header length, entire TBF length))
+///
+/// If we cannot parse the header because we have run out of flash, or the
+/// values are entirely wrong we return `UnableToParse`. This means we have hit
+/// the end of apps in flash.
+/// - Err(InitialTbfParseError::UnableToParse)
+///
+/// Any other error we return an error and the length of the entire app so that
+/// we can skip over it and check for the next app.
+/// - Err(InitialTbfParseError::InvalidHeader(app_length))
+pub fn parse_tbf_header_lengths(
+    app: &'static [u8; 8],
+) -> Result<(u16, u16, u32), types::InitialTbfParseError> {
+    // Version is the first 16 bits of the app TBF contents. We need this to
+    // correctly parse the other lengths.
+    //
+    // ## Safety
+    // We trust that the version number has been checked prior to running this
+    // parsing code. That is, whatever loaded this application has verified that
+    // the version is valid and therefore we can trust it.
+    let version = u16::from_le_bytes([app[0], app[1]]);
+
+    match version {
+        2 => {
+            // In version 2, the next 16 bits after the version represent
+            // the size of the TBF header in bytes.
+            let tbf_header_size = u16::from_le_bytes([app[2], app[3]]);
+
+            // The next 4 bytes are the size of the entire app's TBF space
+            // including the header. This also must be checked before parsing
+            // this header and we trust the value in flash.
+            let tbf_size = u32::from_le_bytes([app[4], app[5], app[6], app[7]]);
+
+            // Check that the header length isn't greater than the entire app,
+            // and is at least as large as the v2 required header (which is 16
+            // bytes). If that at least looks good then return the sizes.
+            if u32::from(tbf_header_size) > tbf_size || tbf_header_size < 16 {
+                Err(types::InitialTbfParseError::InvalidHeader(tbf_size))
+            } else {
+                Ok((version, tbf_header_size, tbf_size))
+            }
+        }
+
+        // Since we have to trust the total size, and by extension the version
+        // number, if we don't know how to handle the version this must not be
+        // an actual app. Likely this is just the end of the app linked list.
+        _ => Err(types::InitialTbfParseError::UnableToParse),
+    }
+}
+
+/// Parse a TBF header stored in flash.
+///
+/// The `header` must be a slice that only contains the TBF header. The caller
+/// should use the `parse_tbf_header_lengths()` function to determine this
+/// length to create the correct sized slice.
+pub fn parse_tbf_header(
+    header: &'static [u8],
+    version: u16,
+) -> Result<types::TbfHeader, types::TbfParseError> {
+    match version {
+        2 => {
+            // Get the required base. This will succeed because we parsed the
+            // first bit of the header already in `parse_tbf_header_lengths()`.
+            let tbf_header_base: types::TbfHeaderV2Base = header.try_into()?;
+
+            // Calculate checksum. The checksum is the XOR of each 4 byte word
+            // in the header.
+            let mut checksum: u32 = 0;
+
+            // Get an iterator across 4 byte fields in the header.
+            let header_iter = header.chunks_exact(4);
+
+            // Iterate all chunks and XOR the chunks to compute the checksum.
+            for (i, chunk) in header_iter.enumerate() {
+                let word = u32::from_le_bytes(chunk.try_into()?);
+                if i == 3 {
+                    // Skip the checksum field.
+                } else {
+                    checksum ^= word;
+                }
+            }
+
+            // Verify the header matches.
+            if checksum != tbf_header_base.checksum {
+                return Err(types::TbfParseError::ChecksumMismatch(
+                    tbf_header_base.checksum,
+                    checksum,
+                ));
+            }
+
+            // Get the rest of the header. The `remaining` variable will
+            // continue to hold the remainder of the header we have not
+            // processed.
+            let mut remaining = header
+                .get(16..)
+                .ok_or(types::TbfParseError::NotEnoughFlash)?;
+
+            // If there is nothing left in the header then this is just a
+            // padding "app" between two other apps.
+            if remaining.len() == 0 {
+                // Just padding.
+                Ok(types::TbfHeader::Padding(tbf_header_base))
+            } else {
+                // This is an actual app.
+
+                // Places to save fields that we parse out of the header
+                // options.
+                let mut main_pointer: Option<types::TbfHeaderV2Main> = None;
+                let mut wfr_pointer: [Option<types::TbfHeaderV2WriteableFlashRegion>; 4] =
+                    Default::default();
+                let mut app_name_str = "";
+                let mut fixed_address_pointer: Option<types::TbfHeaderV2FixedAddresses> = None;
+
+                // Iterate the remainder of the header looking for TLV entries.
+                while remaining.len() > 0 {
+                    // Get the T and L portions of the next header (if it is
+                    // there).
+                    let tlv_header: types::TbfHeaderTlv = remaining.try_into()?;
+                    remaining = remaining
+                        .get(4..)
+                        .ok_or(types::TbfParseError::NotEnoughFlash)?;
+
+                    match tlv_header.tipe {
+                        types::TbfHeaderTypes::TbfHeaderMain => {
+                            let entry_len = mem::size_of::<types::TbfHeaderV2Main>();
+
+                            // Check that the size of the TLV entry matches the
+                            // size of the Main TLV. If so we can store it.
+                            // Otherwise, we fail to parse this TBF header and
+                            // throw an error.
+                            if tlv_header.length as usize == entry_len {
+                                main_pointer = Some(remaining.try_into()?);
+                            } else {
+                                return Err(types::TbfParseError::BadTlvEntry(
+                                    tlv_header.tipe as usize,
+                                ));
+                            }
+                        }
+
+                        types::TbfHeaderTypes::TbfHeaderWriteableFlashRegions => {
+                            // Length must be a multiple of the size of a region definition.
+                            if tlv_header.length as usize
+                                % mem::size_of::<types::TbfHeaderV2WriteableFlashRegion>()
+                                == 0
+                            {
+                                // Calculate how many writeable flash regions
+                                // there are specified in this header.
+                                let wfr_len =
+                                    mem::size_of::<types::TbfHeaderV2WriteableFlashRegion>();
+                                let mut number_regions = tlv_header.length as usize / wfr_len;
+
+                                // Capture a slice with just the wfr information.
+                                let wfr_slice = remaining
+                                    .get(0..tlv_header.length as usize)
+                                    .ok_or(types::TbfParseError::NotEnoughFlash)?;
+
+                                // To enable a static buffer, we only support up
+                                // to four writeable flash regions.
+                                if number_regions > 4 {
+                                    number_regions = 4;
+                                }
+
+                                // Convert and store each wfr.
+                                for i in 0..number_regions {
+                                    wfr_pointer[i] = Some(
+                                        wfr_slice
+                                            .get(i * wfr_len..(i + 1) * wfr_len)
+                                            .ok_or(types::TbfParseError::NotEnoughFlash)?
+                                            .try_into()?,
+                                    );
+                                }
+                            } else {
+                                return Err(types::TbfParseError::BadTlvEntry(
+                                    tlv_header.tipe as usize,
+                                ));
+                            }
+                        }
+
+                        types::TbfHeaderTypes::TbfHeaderPackageName => {
+                            let name_buf = remaining
+                                .get(0..tlv_header.length as usize)
+                                .ok_or(types::TbfParseError::NotEnoughFlash)?;
+
+                            str::from_utf8(name_buf)
+                                .map(|name_str| {
+                                    app_name_str = name_str;
+                                })
+                                .or(Err(types::TbfParseError::BadProcessName))?;
+                        }
+
+                        types::TbfHeaderTypes::TbfHeaderFixedAddresses => {
+                            let entry_len = 8;
+                            if tlv_header.length as usize == entry_len {
+                                fixed_address_pointer = Some(remaining.try_into()?);
+                            } else {
+                                return Err(types::TbfParseError::BadTlvEntry(
+                                    tlv_header.tipe as usize,
+                                ));
+                            }
+                        }
+
+                        _ => {}
+                    }
+
+                    // All TLV blocks are padded to 4 bytes, so we need to skip
+                    // more if the length is not a multiple of 4.
+                    let skip_len: usize = align4!(tlv_header.length as usize);
+                    remaining = remaining
+                        .get(skip_len..)
+                        .ok_or(types::TbfParseError::NotEnoughFlash)?;
+                }
+
+                let tbf_header = types::TbfHeaderV2 {
+                    base: tbf_header_base,
+                    main: main_pointer,
+                    package_name: Some(app_name_str),
+                    writeable_regions: Some(wfr_pointer),
+                    fixed_addresses: fixed_address_pointer,
+                };
+
+                Ok(types::TbfHeader::TbfHeaderV2(tbf_header))
+            }
+        }
+        _ => Err(types::TbfParseError::UnsupportedVersion(version)),
+    }
+}

--- a/libraries/tock-tbf/src/types.rs
+++ b/libraries/tock-tbf/src/types.rs
@@ -1,16 +1,7 @@
-//! Tock Binary Format Header definitions and parsing code.
+//! Types and Data Structures for TBFs.
 
 use core::convert::TryInto;
 use core::fmt;
-use core::iter::Iterator;
-use core::{mem, str};
-
-/// Takes a value and rounds it up to be aligned % 4
-macro_rules! align4 {
-    ($e:expr $(,)?) => {
-        ($e) + ((4 - (($e) % 4)) % 4)
-    };
-}
 
 /// Error when parsing just the beginning of the TBF header. This is only used
 /// when establishing the linked list structure of apps installed in flash.
@@ -100,11 +91,11 @@ impl fmt::Debug for TbfParseError {
 /// TBF fields that must be present in all v2 headers.
 #[derive(Clone, Copy, Debug)]
 pub struct TbfHeaderV2Base {
-    version: u16,
-    header_size: u16,
-    total_size: u32,
-    flags: u32,
-    checksum: u32,
+    pub(crate) version: u16,
+    pub(crate) header_size: u16,
+    pub(crate) total_size: u32,
+    pub(crate) flags: u32,
+    pub(crate) checksum: u32,
 }
 
 /// Types in TLV structures for each optional block of the header.
@@ -124,8 +115,8 @@ pub enum TbfHeaderTypes {
 /// The TLV header (T and L).
 #[derive(Clone, Copy, Debug)]
 pub struct TbfHeaderTlv {
-    tipe: TbfHeaderTypes,
-    length: u16,
+    pub(crate) tipe: TbfHeaderTypes,
+    pub(crate) length: u16,
 }
 
 /// The v2 main section for apps.
@@ -312,11 +303,11 @@ impl core::convert::TryFrom<&[u8]> for TbfHeaderV2FixedAddresses {
 /// this type.
 #[derive(Clone, Copy, Debug)]
 pub struct TbfHeaderV2 {
-    base: TbfHeaderV2Base,
-    main: Option<TbfHeaderV2Main>,
-    package_name: Option<&'static str>,
-    writeable_regions: Option<[Option<TbfHeaderV2WriteableFlashRegion>; 4]>,
-    fixed_addresses: Option<TbfHeaderV2FixedAddresses>,
+    pub(crate) base: TbfHeaderV2Base,
+    pub(crate) main: Option<TbfHeaderV2Main>,
+    pub(crate) package_name: Option<&'static str>,
+    pub(crate) writeable_regions: Option<[Option<TbfHeaderV2WriteableFlashRegion>; 4]>,
+    pub(crate) fixed_addresses: Option<TbfHeaderV2FixedAddresses>,
 }
 
 /// Type that represents the fields of the Tock Binary Format header.
@@ -442,223 +433,5 @@ impl TbfHeader {
             0xFFFFFFFF => None,
             start => Some(start),
         }
-    }
-}
-
-/// Parse the TBF header length and the entire length of the TBF binary.
-///
-/// ## Return
-///
-/// If all parsing is successful:
-/// - Ok((Version, TBF header length, entire TBF length))
-///
-/// If we cannot parse the header because we have run out of flash, or the
-/// values are entirely wrong we return `UnableToParse`. This means we have hit
-/// the end of apps in flash.
-/// - Err(InitialTbfParseError::UnableToParse)
-///
-/// Any other error we return an error and the length of the entire app so that
-/// we can skip over it and check for the next app.
-/// - Err(InitialTbfParseError::InvalidHeader(app_length))
-pub fn parse_tbf_header_lengths(
-    app: &'static [u8; 8],
-) -> Result<(u16, u16, u32), InitialTbfParseError> {
-    // Version is the first 16 bits of the app TBF contents. We need this to
-    // correctly parse the other lengths.
-    //
-    // ## Safety
-    // We trust that the version number has been checked prior to running this
-    // parsing code. That is, whatever loaded this application has verified that
-    // the version is valid and therefore we can trust it.
-    let version = u16::from_le_bytes([app[0], app[1]]);
-
-    match version {
-        2 => {
-            // In version 2, the next 16 bits after the version represent
-            // the size of the TBF header in bytes.
-            let tbf_header_size = u16::from_le_bytes([app[2], app[3]]);
-
-            // The next 4 bytes are the size of the entire app's TBF space
-            // including the header. This also must be checked before parsing
-            // this header and we trust the value in flash.
-            let tbf_size = u32::from_le_bytes([app[4], app[5], app[6], app[7]]);
-
-            // Check that the header length isn't greater than the entire app,
-            // and is at least as large as the v2 required header (which is 16
-            // bytes). If that at least looks good then return the sizes.
-            if u32::from(tbf_header_size) > tbf_size || tbf_header_size < 16 {
-                Err(InitialTbfParseError::InvalidHeader(tbf_size))
-            } else {
-                Ok((version, tbf_header_size, tbf_size))
-            }
-        }
-
-        // Since we have to trust the total size, and by extension the version
-        // number, if we don't know how to handle the version this must not be
-        // an actual app. Likely this is just the end of the app linked list.
-        _ => Err(InitialTbfParseError::UnableToParse),
-    }
-}
-
-/// Parse a TBF header stored in flash.
-///
-/// The `header` must be a slice that only contains the TBF header. The caller
-/// should use the `parse_tbf_header_lengths()` function to determine this
-/// length to create the correct sized slice.
-pub fn parse_tbf_header(header: &'static [u8], version: u16) -> Result<TbfHeader, TbfParseError> {
-    match version {
-        2 => {
-            // Get the required base. This will succeed because we parsed the
-            // first bit of the header already in `parse_tbf_header_lengths()`.
-            let tbf_header_base: TbfHeaderV2Base = header.try_into()?;
-
-            // Calculate checksum. The checksum is the XOR of each 4 byte word
-            // in the header.
-            let mut checksum: u32 = 0;
-
-            // Get an iterator across 4 byte fields in the header.
-            let header_iter = header.chunks_exact(4);
-
-            // Iterate all chunks and XOR the chunks to compute the checksum.
-            for (i, chunk) in header_iter.enumerate() {
-                let word = u32::from_le_bytes(chunk.try_into()?);
-                if i == 3 {
-                    // Skip the checksum field.
-                } else {
-                    checksum ^= word;
-                }
-            }
-
-            // Verify the header matches.
-            if checksum != tbf_header_base.checksum {
-                return Err(TbfParseError::ChecksumMismatch(
-                    tbf_header_base.checksum,
-                    checksum,
-                ));
-            }
-
-            // Get the rest of the header. The `remaining` variable will
-            // continue to hold the remainder of the header we have not
-            // processed.
-            let mut remaining = header.get(16..).ok_or(TbfParseError::NotEnoughFlash)?;
-
-            // If there is nothing left in the header then this is just a
-            // padding "app" between two other apps.
-            if remaining.len() == 0 {
-                // Just padding.
-                Ok(TbfHeader::Padding(tbf_header_base))
-            } else {
-                // This is an actual app.
-
-                // Places to save fields that we parse out of the header
-                // options.
-                let mut main_pointer: Option<TbfHeaderV2Main> = None;
-                let mut wfr_pointer: [Option<TbfHeaderV2WriteableFlashRegion>; 4] =
-                    Default::default();
-                let mut app_name_str = "";
-                let mut fixed_address_pointer: Option<TbfHeaderV2FixedAddresses> = None;
-
-                // Iterate the remainder of the header looking for TLV entries.
-                while remaining.len() > 0 {
-                    // Get the T and L portions of the next header (if it is
-                    // there).
-                    let tlv_header: TbfHeaderTlv = remaining.try_into()?;
-                    remaining = remaining.get(4..).ok_or(TbfParseError::NotEnoughFlash)?;
-
-                    match tlv_header.tipe {
-                        TbfHeaderTypes::TbfHeaderMain => {
-                            let entry_len = mem::size_of::<TbfHeaderV2Main>();
-
-                            // Check that the size of the TLV entry matches the
-                            // size of the Main TLV. If so we can store it.
-                            // Otherwise, we fail to parse this TBF header and
-                            // throw an error.
-                            if tlv_header.length as usize == entry_len {
-                                main_pointer = Some(remaining.try_into()?);
-                            } else {
-                                return Err(TbfParseError::BadTlvEntry(tlv_header.tipe as usize));
-                            }
-                        }
-
-                        TbfHeaderTypes::TbfHeaderWriteableFlashRegions => {
-                            // Length must be a multiple of the size of a region definition.
-                            if tlv_header.length as usize
-                                % mem::size_of::<TbfHeaderV2WriteableFlashRegion>()
-                                == 0
-                            {
-                                // Calculate how many writeable flash regions
-                                // there are specified in this header.
-                                let wfr_len = mem::size_of::<TbfHeaderV2WriteableFlashRegion>();
-                                let mut number_regions = tlv_header.length as usize / wfr_len;
-
-                                // Capture a slice with just the wfr information.
-                                let wfr_slice = remaining
-                                    .get(0..tlv_header.length as usize)
-                                    .ok_or(TbfParseError::NotEnoughFlash)?;
-
-                                // To enable a static buffer, we only support up
-                                // to four writeable flash regions.
-                                if number_regions > 4 {
-                                    number_regions = 4;
-                                }
-
-                                // Convert and store each wfr.
-                                for i in 0..number_regions {
-                                    wfr_pointer[i] = Some(
-                                        wfr_slice
-                                            .get(i * wfr_len..(i + 1) * wfr_len)
-                                            .ok_or(TbfParseError::NotEnoughFlash)?
-                                            .try_into()?,
-                                    );
-                                }
-                            } else {
-                                return Err(TbfParseError::BadTlvEntry(tlv_header.tipe as usize));
-                            }
-                        }
-
-                        TbfHeaderTypes::TbfHeaderPackageName => {
-                            let name_buf = remaining
-                                .get(0..tlv_header.length as usize)
-                                .ok_or(TbfParseError::NotEnoughFlash)?;
-
-                            str::from_utf8(name_buf)
-                                .map(|name_str| {
-                                    app_name_str = name_str;
-                                })
-                                .or(Err(TbfParseError::BadProcessName))?;
-                        }
-
-                        TbfHeaderTypes::TbfHeaderFixedAddresses => {
-                            let entry_len = 8;
-                            if tlv_header.length as usize == entry_len {
-                                fixed_address_pointer = Some(remaining.try_into()?);
-                            } else {
-                                return Err(TbfParseError::BadTlvEntry(tlv_header.tipe as usize));
-                            }
-                        }
-
-                        _ => {}
-                    }
-
-                    // All TLV blocks are padded to 4 bytes, so we need to skip
-                    // more if the length is not a multiple of 4.
-                    let skip_len: usize = align4!(tlv_header.length as usize);
-                    remaining = remaining
-                        .get(skip_len..)
-                        .ok_or(TbfParseError::NotEnoughFlash)?;
-                }
-
-                let tbf_header = TbfHeaderV2 {
-                    base: tbf_header_base,
-                    main: main_pointer,
-                    package_name: Some(app_name_str),
-                    writeable_regions: Some(wfr_pointer),
-                    fixed_addresses: fixed_address_pointer,
-                };
-
-                Ok(TbfHeader::TbfHeaderV2(tbf_header))
-            }
-        }
-        _ => Err(TbfParseError::UnsupportedVersion(version)),
     }
 }


### PR DESCRIPTION
### Pull Request Overview

As part of the effort to remove `unsafe` from the TBF parsing code (#1465), the last goal was always to move all of the TBF parsing code to its own library since by definition the kernel is not the only thing that needs to handle TBFs. Rather than have TBF code re-implemented, this would allow there to be a single TBF parsing crate that can be used by the kernel and also tools like elf2tab.

Turns out, moving this to a library is quite easy. I didn't want to do this earlier in case there were fixes or updates needed to the earlier tbf parsing re-write from #1465. But since the code has been working now seems like a reasonable time to move it to a library.

Apologies to @alistair23 for moving code, but I can help update if git doesn't do it automatically.

### Testing Strategy

This pull request was tested by running kernels on nano33 and hail, but really this doesn't change any logic.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
