### PR TITLE
cortex-m: fix hardfault in systick_handler due to naked_fn noreturn

### DIFF
--- a/arch/cortex-m/src/lib.rs
+++ b/arch/cortex-m/src/lib.rs
@@ -51,6 +51,7 @@ pub unsafe extern "C" fn systick_handler() {
 
     // This will resume in the switch to user function where application state
     // is saved and the scheduler can choose what to do next.
+    bx   LR
     ",
         options(noreturn)
     );


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes a hardfault on Cortex-M by explicitly returning from the `systick_handler_ naked_fn using the BX instruction. The issue was introduced with d7e210be3842b132037e3f68561f0bbd1e068180.

Otherwise the CPU runs into a UDF instruction at the end of the function:
```asm
00018308 <_ZN7cortexm15systick_handler17hbc2ffcfa292064dcE>:
   18308:       f04f 0000       mov.w   r0, #0
   1830c:       f380 8814       msr     CONTROL, r0
   18310:       f3bf 8f6f       isb     sy
   18314:       f64f 7ef9       movw    lr, #65529      ; 0xfff9
   18318:       f6cf 7eff       movt    lr, #65535      ; 0xffff
   1831c:       defe            udf     #254    ; 0xfe
   1831e:       d4d4            bmi.n   182ca <_ZN4core7unicode12unicode_data11white_space6lookup17h1ad50959f85d8234E+0x9c>
```


### Testing Strategy

This pull request was tested by running an app which caused a hard fault previously.

### TODO or Help Wanted

This pull request still needs extensive review! I'm certainly no expert on ARM assembly, but the `bx LR` was "suggested" by the compiler when removing the `noreturn` option, so it looks correct to me.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
