### PR TITLE
Tock 2.0: port nonvolatile storage & app flash driver

### DIFF
--- a/boards/earlgrey-nexysvideo/src/main.rs
+++ b/boards/earlgrey-nexysvideo/src/main.rs
@@ -94,7 +94,7 @@ impl Platform for EarlGreyNexysVideo {
             capsules::low_level_debug::DRIVER_NUM => f(Some(Err(self.lldb))),
             capsules::i2c_master::DRIVER_NUM => f(Some(Ok(self.i2c_master))),
             capsules::nonvolatile_storage_driver::DRIVER_NUM => {
-                f(Some(Err(self.nonvolatile_storage)))
+                f(Some(Ok(self.nonvolatile_storage)))
             }
             _ => f(None),
         }

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -177,7 +177,7 @@ impl kernel::Platform for Imix {
             capsules::net::udp::DRIVER_NUM => f(Some(Ok(self.udp_driver))),
             capsules::nrf51822_serialization::DRIVER_NUM => f(Some(Err(self.nrf51822))),
             capsules::nonvolatile_storage_driver::DRIVER_NUM => {
-                f(Some(Err(self.nonvolatile_storage)))
+                f(Some(Ok(self.nonvolatile_storage)))
             }
             capsules::rng::DRIVER_NUM => f(Some(Ok(self.rng))),
             kernel::ipc::DRIVER_NUM => f(Some(Err(&self.ipc))),

--- a/boards/microbit_v2/src/main.rs
+++ b/boards/microbit_v2/src/main.rs
@@ -124,7 +124,7 @@ impl kernel::Platform for Platform {
             capsules::rng::DRIVER_NUM => f(Some(Ok(self.rng))),
             capsules::ble_advertising_driver::DRIVER_NUM => f(Some(Err(self.ble_radio))),
             capsules::buzzer_driver::DRIVER_NUM => f(Some(Ok(self.buzzer))),
-            capsules::app_flash_driver::DRIVER_NUM => f(Some(Err(self.app_flash))),
+            capsules::app_flash_driver::DRIVER_NUM => f(Some(Ok(self.app_flash))),
             capsules::sound_pressure::DRIVER_NUM => f(Some(Err(self.sound_pressure))),
             kernel::ipc::DRIVER_NUM => f(Some(Err(&self.ipc))),
             _ => f(None),

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -192,7 +192,7 @@ impl kernel::Platform for Platform {
             capsules::temperature::DRIVER_NUM => f(Some(Ok(self.temp))),
             capsules::analog_comparator::DRIVER_NUM => f(Some(Ok(self.analog_comparator))),
             capsules::nonvolatile_storage_driver::DRIVER_NUM => {
-                f(Some(Err(self.nonvolatile_storage)))
+                f(Some(Ok(self.nonvolatile_storage)))
             }
             capsules::net::udp::DRIVER_NUM => f(Some(Ok(self.udp_driver))),
             kernel::ipc::DRIVER_NUM => f(Some(Err(&self.ipc))),

--- a/boards/stm32f3discovery/src/main.rs
+++ b/boards/stm32f3discovery/src/main.rs
@@ -91,7 +91,7 @@ impl Platform for STM32F3Discovery {
             kernel::ipc::DRIVER_NUM => f(Some(Err(&self.ipc))),
             capsules::adc::DRIVER_NUM => f(Some(Ok(self.adc))),
             capsules::nonvolatile_storage_driver::DRIVER_NUM => {
-                f(Some(Err(self.nonvolatile_storage)))
+                f(Some(Ok(self.nonvolatile_storage)))
             }
             _ => f(None),
         }

--- a/capsules/src/fm25cl.rs
+++ b/capsules/src/fm25cl.rs
@@ -42,8 +42,10 @@
 
 use core::cell::Cell;
 use core::cmp;
+use core::convert::TryInto;
 use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::hil;
+use kernel::ErrorCode;
 use kernel::ReturnCode;
 
 pub static mut TXBUFFER: [u8; 512] = [0; 512];
@@ -134,12 +136,17 @@ impl<'a, S: hil::spi::SpiMasterDevice> FM25CL<'a, S> {
         );
     }
 
-    pub fn write(&self, address: u16, buffer: &'static mut [u8], len: u16) -> ReturnCode {
+    pub fn write(
+        &self,
+        address: u16,
+        buffer: &'static mut [u8],
+        len: u16,
+    ) -> Result<(), ErrorCode> {
         self.configure_spi();
 
         self.txbuffer
             .take()
-            .map_or(ReturnCode::ERESERVE, move |txbuffer| {
+            .map_or(Err(ErrorCode::RESERVE), move |txbuffer| {
                 txbuffer[0] = Opcodes::WriteEnable as u8;
 
                 let write_len = cmp::min(txbuffer.len(), len as usize);
@@ -151,19 +158,25 @@ impl<'a, S: hil::spi::SpiMasterDevice> FM25CL<'a, S> {
                 self.client_write_len.set(write_len as u16);
 
                 self.state.set(State::WriteEnable);
-                self.spi.read_write_bytes(txbuffer, None, 1)
+                let res = self.spi.read_write_bytes(txbuffer, None, 1);
+                match res {
+                    ReturnCode::SUCCESS => Ok(()),
+                    rc => Err(rc
+                        .try_into()
+                        .expect("SPI read_write_bytes: unexpected SuccessWithValue")),
+                }
             })
     }
 
-    pub fn read(&self, address: u16, buffer: &'static mut [u8], len: u16) -> ReturnCode {
+    pub fn read(&self, address: u16, buffer: &'static mut [u8], len: u16) -> Result<(), ErrorCode> {
         self.configure_spi();
 
         self.txbuffer
             .take()
-            .map_or(ReturnCode::ERESERVE, |txbuffer| {
+            .map_or(Err(ErrorCode::RESERVE), |txbuffer| {
                 self.rxbuffer
                     .take()
-                    .map_or(ReturnCode::ERESERVE, move |rxbuffer| {
+                    .map_or(Err(ErrorCode::RESERVE), move |rxbuffer| {
                         txbuffer[0] = Opcodes::ReadMemory as u8;
                         txbuffer[1] = ((address >> 8) & 0xFF) as u8;
                         txbuffer[2] = (address & 0xFF) as u8;
@@ -174,8 +187,15 @@ impl<'a, S: hil::spi::SpiMasterDevice> FM25CL<'a, S> {
                         let read_len = cmp::min(rxbuffer.len() - 3, len as usize);
 
                         self.state.set(State::ReadMemory);
-                        self.spi
-                            .read_write_bytes(txbuffer, Some(rxbuffer), read_len + 3)
+                        let res = self
+                            .spi
+                            .read_write_bytes(txbuffer, Some(rxbuffer), read_len + 3);
+                        match res {
+                            ReturnCode::SUCCESS => Ok(()),
+                            rc => Err(rc
+                                .try_into()
+                                .expect("SPI read_write_bytes: unexpected SuccessWithValue")),
+                        }
                     })
             })
     }
@@ -298,11 +318,21 @@ impl<S: hil::spi::SpiMasterDevice> hil::nonvolatile_storage::NonvolatileStorage<
         self.client.set(client);
     }
 
-    fn read(&self, buffer: &'static mut [u8], address: usize, length: usize) -> ReturnCode {
+    fn read(
+        &self,
+        buffer: &'static mut [u8],
+        address: usize,
+        length: usize,
+    ) -> Result<(), ErrorCode> {
         self.read(address as u16, buffer, length as u16)
     }
 
-    fn write(&self, buffer: &'static mut [u8], address: usize, length: usize) -> ReturnCode {
+    fn write(
+        &self,
+        buffer: &'static mut [u8],
+        address: usize,
+        length: usize,
+    ) -> Result<(), ErrorCode> {
         self.write(address as u16, buffer, length as u16)
     }
 }

--- a/kernel/src/errorcode.rs
+++ b/kernel/src/errorcode.rs
@@ -70,3 +70,23 @@ impl TryFrom<ReturnCode> for ErrorCode {
         }
     }
 }
+
+impl From<ErrorCode> for ReturnCode {
+    fn from(ec: ErrorCode) -> Self {
+        match ec {
+            ErrorCode::FAIL => ReturnCode::FAIL,
+            ErrorCode::BUSY => ReturnCode::EBUSY,
+            ErrorCode::ALREADY => ReturnCode::EALREADY,
+            ErrorCode::OFF => ReturnCode::EOFF,
+            ErrorCode::RESERVE => ReturnCode::ERESERVE,
+            ErrorCode::INVAL => ReturnCode::EINVAL,
+            ErrorCode::SIZE => ReturnCode::ESIZE,
+            ErrorCode::CANCEL => ReturnCode::ECANCEL,
+            ErrorCode::NOMEM => ReturnCode::ENOMEM,
+            ErrorCode::NOSUPPORT => ReturnCode::ENOSUPPORT,
+            ErrorCode::NODEVICE => ReturnCode::ENODEVICE,
+            ErrorCode::UNINSTALLED => ReturnCode::EUNINSTALLED,
+            ErrorCode::NOACK => ReturnCode::ENOACK,
+        }
+    }
+}

--- a/kernel/src/hil/nonvolatile_storage.rs
+++ b/kernel/src/hil/nonvolatile_storage.rs
@@ -1,6 +1,6 @@
 //! Generic interface for nonvolatile memory.
 
-use crate::returncode::ReturnCode;
+use crate::errorcode::ErrorCode;
 
 /// Simple interface for reading and writing nonvolatile memory. It is expected
 /// that drivers for nonvolatile memory would implement this trait.
@@ -10,12 +10,12 @@ pub trait NonvolatileStorage<'a> {
     /// Read `length` bytes starting at address `address` in to the provided
     /// buffer. The buffer must be at least `length` bytes long. The address
     /// must be in the address space of the physical storage.
-    fn read(&self, buffer: &'a mut [u8], address: usize, length: usize) -> ReturnCode;
+    fn read(&self, buffer: &'a mut [u8], address: usize, length: usize) -> Result<(), ErrorCode>;
 
     /// Write `length` bytes starting at address `address` from the provided
     /// buffer. The buffer must be at least `length` bytes long. This address
     /// must be in the address space of the physical storage.
-    fn write(&self, buffer: &'a mut [u8], address: usize, length: usize) -> ReturnCode;
+    fn write(&self, buffer: &'a mut [u8], address: usize, length: usize) -> Result<(), ErrorCode>;
 }
 
 /// Client interface for nonvolatile storage.


### PR DESCRIPTION
### Pull Request Overview

This pull request ports both the nonvolatile storage driver and the app flash driver to the Tock 2.0 system call interface.

I first attempted to port the nonvolatile storage driver exclusively, but that appeared to be pretty complicated as we'd have to deal with converting between `ReturnCode` and `ErrorCode` quite a bit. It seemed more elegant to directly migrate the `NonvolatileStorage` HIL to use `Result<_, ErrorCode>` for its return values and change the rest of the infrastructure accordingly. This is also the reason why I've taken on the app flash driver as well. Hope that's okay with @ppannuto, who wanted to do that originally.

The commits changing the HIL (5600e76 .. 9c3097e) and the ones changing the ABI (LegacyDriver -> Driver, 619ed72 .. 7555d30) are separated such that they can be reviewed as a single PR, but (as long as we also backport ErrorCode) the HIL changes can be easily backported to master afterwards.

### Testing Strategy

This pull request was tested by running the `nonvolatile_storage` and `app_state` tests in `libtock-c` on the accompanying userspace PR.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
