### PR TITLE
Rework the initial stack pointer and memory break the kernel gives to process.

### DIFF
--- a/arch/cortex-m/src/syscall.rs
+++ b/arch/cortex-m/src/syscall.rs
@@ -63,9 +63,7 @@ impl kernel::syscall::UserspaceKernelBoundary for SysCall {
         // interrupt executes, so we need to give the process an initial usable
         // stack. We set the initial break at the top of the stack -- processes
         // must move the break upwards in their runtime implementation.
-        // TODO: 56 is a placeholder -- how large a space do we need to allocate
-        // here?
-        let original_stack_pointer = process_memory_start.wrapping_add(56);
+        let original_stack_pointer = process_memory_start.wrapping_add(0x20);
         kernel::syscall::InitialProcessLayout {
             original_break: original_stack_pointer,
             original_stack_pointer,

--- a/arch/cortex-m/src/syscall.rs
+++ b/arch/cortex-m/src/syscall.rs
@@ -58,16 +58,13 @@ impl kernel::syscall::UserspaceKernelBoundary for SysCall {
     fn initial_process_layout(
         &self,
         process_memory_start: *const u8,
-    ) -> kernel::syscall::InitialProcessLayout {
+    ) -> (*const u8, *const u8) {
         // ARM uses the userspace stack to store register values when an
         // interrupt executes, so we need to give the process an initial usable
         // stack. We set the initial break at the top of the stack -- processes
         // must move the break upwards in their runtime implementation.
         let original_stack_pointer = process_memory_start.wrapping_add(0x20);
-        kernel::syscall::InitialProcessLayout {
-            original_break: original_stack_pointer,
-            original_stack_pointer,
-        }
+        (original_stack_pointer, original_stack_pointer)
     }
 
     unsafe fn initialize_process(

--- a/arch/cortex-m3/src/mpu.rs
+++ b/arch/cortex-m3/src/mpu.rs
@@ -2,7 +2,6 @@
 //! Cortex-M4.
 
 use core::cell::Cell;
-use core::cmp;
 use core::fmt;
 use kernel;
 use kernel::common::cells::OptionalCell;
@@ -519,7 +518,6 @@ impl kernel::mpu::MPU for MPU {
         unallocated_memory_start: *const u8,
         unallocated_memory_size: usize,
         min_memory_size: usize,
-        initial_app_memory_size: usize,
         initial_kernel_memory_size: usize,
         permissions: mpu::Permissions,
         config: &mut Self::MpuConfig,
@@ -531,14 +529,8 @@ impl kernel::mpu::MPU for MPU {
             }
         }
 
-        // Make sure there is enough memory for app memory and kernel memory.
-        let memory_size = cmp::max(
-            min_memory_size,
-            initial_app_memory_size + initial_kernel_memory_size,
-        );
-
         // Size must be a power of two, so: https://www.youtube.com/watch?v=ovo6zwv6DX4
-        let mut region_size = math::closest_power_of_two(memory_size as u32) as usize;
+        let mut region_size = math::closest_power_of_two(min_memory_size as u32) as usize;
         let exponent = math::log_base_two(region_size as u32);
 
         if exponent < 8 {
@@ -569,7 +561,7 @@ impl kernel::mpu::MPU for MPU {
             if initial_kernel_memory_size == 0 {
                 8
             } else {
-                initial_app_memory_size * 8 / region_size + 1
+                min_memory_size * 8 / region_size + 1
             }
         };
 
@@ -593,7 +585,7 @@ impl kernel::mpu::MPU for MPU {
                 if initial_kernel_memory_size == 0 {
                     8
                 } else {
-                    initial_app_memory_size * 8 / region_size + 1
+                    min_memory_size * 8 / region_size + 1
                 }
             };
         }

--- a/arch/rv32i/src/pmp.rs
+++ b/arch/rv32i/src/pmp.rs
@@ -372,7 +372,6 @@ impl<const NUM_REGIONS: usize, const NUM_REGIONS_OVER_TWO: usize> kernel::mpu::M
         unallocated_memory_start: *const u8,
         unallocated_memory_size: usize,
         min_memory_size: usize,
-        initial_app_memory_size: usize,
         initial_kernel_memory_size: usize,
         permissions: mpu::Permissions,
         config: &mut Self::MpuConfig,
@@ -397,7 +396,7 @@ impl<const NUM_REGIONS: usize, const NUM_REGIONS_OVER_TWO: usize> kernel::mpu::M
 
         // App memory size is what we actual set the region to. So this region
         // has to be aligned to 4 bytes.
-        let mut initial_app_memory_size: usize = initial_app_memory_size;
+        let mut initial_app_memory_size: usize = min_memory_size;
         if initial_app_memory_size % 4 != 0 {
             initial_app_memory_size += 4 - (initial_app_memory_size % 4);
         }

--- a/arch/rv32i/src/syscall.rs
+++ b/arch/rv32i/src/syscall.rs
@@ -52,6 +52,20 @@ impl SysCall {
 impl kernel::syscall::UserspaceKernelBoundary for SysCall {
     type StoredState = Riscv32iStoredState;
 
+    fn initial_process_layout(
+        &self,
+        process_memory_start: *const u8,
+    ) -> kernel::syscall::InitialProcessLayout {
+        // RISC-V processes do not need to start with memory access. Processes
+        // must set their break during runtime setup before using memory.
+        // Processes must not rely on this original stack pointer value; it may
+        // change in future kernel versions.
+        kernel::syscall::InitialProcessLayout {
+            original_break: process_memory_start,
+            original_stack_pointer: 0 as *const u8,
+        }
+    }
+
     unsafe fn initialize_process(
         &self,
         stack_pointer: *const usize,

--- a/arch/rv32i/src/syscall.rs
+++ b/arch/rv32i/src/syscall.rs
@@ -55,15 +55,12 @@ impl kernel::syscall::UserspaceKernelBoundary for SysCall {
     fn initial_process_layout(
         &self,
         process_memory_start: *const u8,
-    ) -> kernel::syscall::InitialProcessLayout {
+    ) -> (*const u8, *const u8) {
         // RISC-V processes do not need to start with memory access. Processes
         // must set their break during runtime setup before using memory.
         // Processes must not rely on this original stack pointer value; it may
         // change in future kernel versions.
-        kernel::syscall::InitialProcessLayout {
-            original_break: process_memory_start,
-            original_stack_pointer: 0 as *const u8,
-        }
+        (process_memory_start, 0 as *const u8)
     }
 
     unsafe fn initialize_process(

--- a/kernel/src/platform/mpu.rs
+++ b/kernel/src/platform/mpu.rs
@@ -1,7 +1,6 @@
 //! Interface for configuring the Memory Protection Unit.
 
 use crate::callback::AppId;
-use core::cmp;
 use core::fmt::{self, Display};
 
 /// User mode access permissions.
@@ -202,19 +201,14 @@ pub trait MPU {
         unallocated_memory_start: *const u8,
         unallocated_memory_size: usize,
         min_memory_size: usize,
-        initial_app_memory_size: usize,
         initial_kernel_memory_size: usize,
         permissions: Permissions,
         config: &mut Self::MpuConfig,
     ) -> Option<(*const u8, usize)> {
-        let memory_size = cmp::max(
-            min_memory_size,
-            initial_app_memory_size + initial_kernel_memory_size,
-        );
-        if memory_size > unallocated_memory_size {
+        if min_memory_size > unallocated_memory_size {
             None
         } else {
-            Some((unallocated_memory_start, memory_size))
+            Some((unallocated_memory_start, min_memory_size))
         }
     }
 

--- a/kernel/src/syscall.rs
+++ b/kernel/src/syscall.rs
@@ -376,6 +376,12 @@ pub enum ContextSwitchReason {
     Interrupted,
 }
 
+/// Return type for UserspaceKernelBoundary::initial_process_shape
+pub struct InitialProcessLayout {
+    pub original_break: *const u8,
+    pub original_stack_pointer: *const u8,
+}
+
 /// This trait must be implemented by the architecture of the chip Tock is
 /// running on. It allows the kernel to manage switching to and from processes
 /// in an architecture-agnostic manner.
@@ -388,6 +394,11 @@ pub trait UserspaceKernelBoundary {
     /// or derived) for any initialization of a process's stored state. The
     /// initialization must happen in the `initialize_process()` function.
     type StoredState: Default;
+
+    /// Called by the kernel during process creation. Allows for
+    /// architecture-specific process layout decisions, such as stack pointer
+    /// initialization.
+    fn initial_process_layout(&self, process_memory_start: *const u8) -> InitialProcessLayout;
 
     /// Called by the kernel after it has memory allocated to it but before it
     /// is allowed to begin executing. Allows for architecture-specific process

--- a/kernel/src/syscall.rs
+++ b/kernel/src/syscall.rs
@@ -376,12 +376,6 @@ pub enum ContextSwitchReason {
     Interrupted,
 }
 
-/// Return type for UserspaceKernelBoundary::initial_process_shape
-pub struct InitialProcessLayout {
-    pub original_break: *const u8,
-    pub original_stack_pointer: *const u8,
-}
-
 /// This trait must be implemented by the architecture of the chip Tock is
 /// running on. It allows the kernel to manage switching to and from processes
 /// in an architecture-agnostic manner.
@@ -402,7 +396,7 @@ pub trait UserspaceKernelBoundary {
     /// Returns two pointers. First, the address where the kernel should set the
     /// start of the process's stack, and second the address where the kernel
     /// should set the app_brk.
-    fn initial_process_layout(&self, process_memory_start: *const u8) -> InitialProcessLayout;
+    fn initial_process_layout(&self, process_memory_start: *const u8) -> (*const u8, *const u8);
 
     /// Called by the kernel after it has memory allocated to it but before it
     /// is allowed to begin executing. Allows for architecture-specific process

--- a/kernel/src/syscall.rs
+++ b/kernel/src/syscall.rs
@@ -398,6 +398,10 @@ pub trait UserspaceKernelBoundary {
     /// Called by the kernel during process creation. Allows for
     /// architecture-specific process layout decisions, such as stack pointer
     /// initialization.
+    ///
+    /// Returns two pointers. First, the address where the kernel should set the
+    /// start of the process's stack, and second the address where the kernel
+    /// should set the app_brk.
     fn initial_process_layout(&self, process_memory_start: *const u8) -> InitialProcessLayout;
 
     /// Called by the kernel after it has memory allocated to it but before it


### PR DESCRIPTION
### Pull Request Overview

Previously, the kernel gave the app 3 KiB of usable memory and initialized the stack pointer to the top of that memory. This was a backwards-compatibility measure to support Tock 1.0 process binaries. This commit makes the `UserspaceKernelBoundary` responsible for picking the initial stack pointer and process break, and reduces the guarantees the kernel provides to userspace.

In particular:

1. The memory break is now set as small as possible. Process initialization should move the break upwards before setting the stack pointer.
2. The stack pointer is set to the memory break on ARM and set to an unspecified value (currently 0) on RISC-V

This has the following benefits over the previous setup:

1. It supports processes that use less than 3KiB of memory.
2. It makes process runtime setup easier on ARM, as the memory break should unconditionally be set before the stack pointer, whereas this previously depended on the process' stack size and desired break.

I am unsure how much stack space ARM needs at startup, so there is currently a placeholder value. I intend to set that value correctly before merging this.

### Testing Strategy

This PR is untested. I do not have physical hardware to test on. I could test in QEMU on HiFive using `libtock-rs`, but I would need to write the entry point to do so.


### TODO or Help Wanted

I need help identifying the correct stack size to use on ARM. I also need help (ideas?) testing this.

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required. *I don't think updates are required*

### Formatting

- [X] Ran `make prepush`.
