### PR TITLE
Migrate the LowLevelDebug capsule to the Tock 2.0 syscall API.

### DIFF
--- a/boards/earlgrey-nexysvideo/src/main.rs
+++ b/boards/earlgrey-nexysvideo/src/main.rs
@@ -91,7 +91,7 @@ impl Platform for EarlGreyNexysVideo {
             capsules::gpio::DRIVER_NUM => f(Some(Err(self.gpio))),
             capsules::console::DRIVER_NUM => f(Some(Ok(self.console))),
             capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
-            capsules::low_level_debug::DRIVER_NUM => f(Some(Err(self.lldb))),
+            capsules::low_level_debug::DRIVER_NUM => f(Some(Ok(self.lldb))),
             capsules::i2c_master::DRIVER_NUM => f(Some(Ok(self.i2c_master))),
             capsules::nonvolatile_storage_driver::DRIVER_NUM => {
                 f(Some(Ok(self.nonvolatile_storage)))

--- a/boards/hifive1/src/main.rs
+++ b/boards/hifive1/src/main.rs
@@ -76,7 +76,7 @@ impl Platform for HiFive1 {
             capsules::led::DRIVER_NUM => f(Some(Ok(self.led))),
             capsules::console::DRIVER_NUM => f(Some(Ok(self.console))),
             capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
-            capsules::low_level_debug::DRIVER_NUM => f(Some(Err(self.lldb))),
+            capsules::low_level_debug::DRIVER_NUM => f(Some(Ok(self.lldb))),
             _ => f(None),
         }
     }

--- a/boards/litex/arty/src/main.rs
+++ b/boards/litex/arty/src/main.rs
@@ -147,7 +147,7 @@ impl Platform for LiteXArty {
             capsules::led::DRIVER_NUM => f(Some(Ok(self.led_driver))),
             capsules::console::DRIVER_NUM => f(Some(Ok(self.console))),
             capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
-            capsules::low_level_debug::DRIVER_NUM => f(Some(Err(self.lldb))),
+            capsules::low_level_debug::DRIVER_NUM => f(Some(Ok(self.lldb))),
             _ => f(None),
         }
     }

--- a/boards/litex/sim/src/main.rs
+++ b/boards/litex/sim/src/main.rs
@@ -138,7 +138,7 @@ impl Platform for LiteXSim {
         match driver_num {
             capsules::console::DRIVER_NUM => f(Some(Ok(self.console))),
             capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
-            capsules::low_level_debug::DRIVER_NUM => f(Some(Err(self.lldb))),
+            capsules::low_level_debug::DRIVER_NUM => f(Some(Ok(self.lldb))),
             _ => f(None),
         }
     }

--- a/capsules/src/low_level_debug/mod.rs
+++ b/capsules/src/low_level_debug/mod.rs
@@ -5,7 +5,7 @@ mod fmt;
 
 use core::cell::Cell;
 use kernel::hil::uart::{Transmit, TransmitClient};
-use kernel::{AppId, Grant, ReturnCode};
+use kernel::{AppId, CommandResult, ErrorCode, Grant, ReturnCode};
 
 // LowLevelDebug requires a &mut [u8] buffer of length at least BUF_LEN.
 pub use fmt::BUF_LEN;
@@ -40,16 +40,16 @@ impl<'u, U: Transmit<'u>> LowLevelDebug<'u, U> {
     }
 }
 
-impl<'u, U: Transmit<'u>> kernel::LegacyDriver for LowLevelDebug<'u, U> {
-    fn command(&self, minor_num: usize, r2: usize, r3: usize, caller_id: AppId) -> ReturnCode {
+impl<'u, U: Transmit<'u>> kernel::Driver for LowLevelDebug<'u, U> {
+    fn command(&self, minor_num: usize, r2: usize, r3: usize, caller_id: AppId) -> CommandResult {
         match minor_num {
-            0 => return ReturnCode::SUCCESS,
+            0 => return CommandResult::success(),
             1 => self.push_entry(DebugEntry::AlertCode(r2), caller_id),
             2 => self.push_entry(DebugEntry::Print1(r2), caller_id),
             3 => self.push_entry(DebugEntry::Print2(r2, r3), caller_id),
-            _ => return ReturnCode::ENOSUPPORT,
+            _ => return CommandResult::failure(ErrorCode::NOSUPPORT),
         }
-        ReturnCode::SUCCESS
+        CommandResult::success()
     }
 }
 

--- a/doc/syscalls/00008_low_level_debug.md
+++ b/doc/syscalls/00008_low_level_debug.md
@@ -27,7 +27,7 @@ driver is in capsules/src/low\_level\_debug.rs.
 
     **Argument 2**: Unused
 
-    **Returns**: SUCCESS
+    **Returns**: Success
 
   * ### Command Number: 1
 
@@ -39,7 +39,7 @@ driver is in capsules/src/low\_level\_debug.rs.
 
     **Argument 2**: Unused
 
-    **Returns**: SUCCESS
+    **Returns**: Success
 
   * ### Command Number: 2
 
@@ -51,7 +51,7 @@ driver is in capsules/src/low\_level\_debug.rs.
 
     **Argument 2**: Unused
 
-    **Returns**: SUCCESS
+    **Returns**: Success
 
   * ### Command Number: 3
 
@@ -65,7 +65,7 @@ driver is in capsules/src/low\_level\_debug.rs.
 
     **Argument 2**: Second number to print
 
-    **Returns**: SUCCESS
+    **Returns**: Success
 
 ## Predefined Alert Codes
 


### PR DESCRIPTION
### Testing Strategy

Ran `make prepush`. I don't currently have the ability to test `LowLevelDebug` on hardware, unfortunately.

*I don't see how these changes could go wrong...*

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
