### PR TITLE
usb: Update to use Tock2.0 Driver

### DIFF
--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -172,7 +172,7 @@ impl kernel::Platform for Imix {
             capsules::humidity::DRIVER_NUM => f(Some(Ok(self.humidity))),
             capsules::ninedof::DRIVER_NUM => f(Some(Ok(self.ninedof))),
             capsules::crc::DRIVER_NUM => f(Some(Ok(self.crc))),
-            capsules::usb::usb_user::DRIVER_NUM => f(Some(Err(self.usb_driver))),
+            capsules::usb::usb_user::DRIVER_NUM => f(Some(Ok(self.usb_driver))),
             capsules::ieee802154::DRIVER_NUM => f(Some(Ok(self.radio_driver))),
             capsules::net::udp::DRIVER_NUM => f(Some(Ok(self.udp_driver))),
             capsules::nrf51822_serialization::DRIVER_NUM => f(Some(Err(self.nrf51822))),

--- a/capsules/src/usb/usb_user.rs
+++ b/capsules/src/usb/usb_user.rs
@@ -26,16 +26,17 @@
 //!         usb_client, board_kernel.create_grant(&grant_cap)));
 //! ```
 
+use core::mem;
 use kernel::common::cells::OptionalCell;
 use kernel::hil;
-use kernel::{AppId, Callback, Grant, LegacyDriver, ReturnCode};
+use kernel::{AppId, Callback, CommandResult, Driver, ErrorCode, Grant};
 
 use crate::driver;
 pub const DRIVER_NUM: usize = driver::NUM::UsbUser as usize;
 
 #[derive(Default)]
 pub struct App {
-    callback: Option<Callback>,
+    callback: Callback,
     awaiting: Option<Request>,
 }
 
@@ -76,9 +77,7 @@ where
                             self.usbc_client.attach();
 
                             // Schedule a callback immediately
-                            if let Some(mut callback) = app.callback {
-                                callback.schedule(From::from(ReturnCode::SUCCESS), 0, 0);
-                            }
+                            app.callback.schedule(0, 0, 0);
                             app.awaiting = None;
                         }
                     }
@@ -100,33 +99,38 @@ enum Request {
     EnableAndAttach,
 }
 
-impl<'a, C> LegacyDriver for UsbSyscallDriver<'a, C>
+impl<'a, C> Driver for UsbSyscallDriver<'a, C>
 where
     C: hil::usb::Client<'a>,
 {
     fn subscribe(
         &self,
         subscribe_num: usize,
-        callback: Option<Callback>,
+        mut callback: Callback,
         app_id: AppId,
-    ) -> ReturnCode {
-        match subscribe_num {
+    ) -> Result<Callback, (Callback, ErrorCode)> {
+        let res = match subscribe_num {
             // Set callback for result
             0 => self
                 .apps
                 .enter(app_id, |app, _| {
-                    app.callback = callback;
-                    ReturnCode::SUCCESS
+                    mem::swap(&mut app.callback, &mut callback);
+                    Ok(())
                 })
-                .unwrap_or_else(|err| err.into()),
-            _ => ReturnCode::ENOSUPPORT,
+                .unwrap_or_else(|err| Err(err.into())),
+            _ => Err(ErrorCode::NOSUPPORT),
+        };
+
+        match res {
+            Ok(()) => Ok(callback),
+            Err(e) => Err((callback, e)),
         }
     }
 
-    fn command(&self, command_num: usize, _arg: usize, _: usize, appid: AppId) -> ReturnCode {
+    fn command(&self, command_num: usize, _arg: usize, _: usize, appid: AppId) -> CommandResult {
         match command_num {
             // This driver is present
-            0 => ReturnCode::SUCCESS,
+            0 => CommandResult::success(),
 
             // Enable USB controller, attach to bus, and service default control endpoint
             1 => {
@@ -135,25 +139,24 @@ where
                     .enter(appid, |app, _| {
                         if app.awaiting.is_some() {
                             // Each app may make only one request at a time
-                            ReturnCode::EBUSY
+                            Err(ErrorCode::BUSY)
                         } else {
-                            if app.callback.is_some() {
-                                app.awaiting = Some(Request::EnableAndAttach);
-                                ReturnCode::SUCCESS
-                            } else {
-                                ReturnCode::EINVAL
-                            }
+                            app.awaiting = Some(Request::EnableAndAttach);
+                            Ok(())
                         }
                     })
-                    .unwrap_or_else(|err| err.into());
+                    .unwrap_or_else(|err| Err(err.into()));
 
-                if result == ReturnCode::SUCCESS {
-                    self.serve_waiting_apps();
+                match result {
+                    Ok(()) => {
+                        self.serve_waiting_apps();
+                        CommandResult::success()
+                    }
+                    Err(e) => CommandResult::failure(e),
                 }
-                result
             }
 
-            _ => ReturnCode::ENOSUPPORT,
+            _ => CommandResult::failure(ErrorCode::NOSUPPORT),
         }
     }
 }


### PR DESCRIPTION
### Pull Request Overview

Update the USB Tock2.0 Driver to use the new `Driver` API.

### Testing Strategy

I don't have a way to test this unfortunately. The changes seem very simple so I think it's fine.

### TODO or Help Wanted

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
