### PR TITLE
Add University of Stuttgart to list of authors

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -17,6 +17,7 @@ Organizations that have contributed code to Tock include:
   * University of California, Berkeley
   * University of California, San Diego
   * University of Michigan
+  * University of Stuttgart
   * University of Virginia
   * Western Digital
 


### PR DESCRIPTION
### Pull Request Overview

The University of Stuttgart, Germany has been enabling me to contribute to the Tock embedded operating system. Examples include the port to LiteX SoCs and fixes to bugs such as b229f2b70 ("rv32i: fix race condition of interrupt in switch_to_process").

Therefore, I'd kindly request to have them added to the list of authors.


### Testing Strategy

N/A


### TODO or Help Wanted

N/A

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
