### PR TITLE
GPIO for Tock 2.0.

### DIFF
--- a/boards/acd52832/src/main.rs
+++ b/boards/acd52832/src/main.rs
@@ -91,7 +91,7 @@ impl kernel::Platform for Platform {
     {
         match driver_num {
             capsules::console::DRIVER_NUM => f(Some(Ok(self.console))),
-            capsules::gpio::DRIVER_NUM => f(Some(Err(self.gpio))),
+            capsules::gpio::DRIVER_NUM => f(Some(Ok(self.gpio))),
             capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
             capsules::led::DRIVER_NUM => f(Some(Ok(self.led))),
             capsules::button::DRIVER_NUM => f(Some(Ok(self.button))),

--- a/boards/arty_e21/src/main.rs
+++ b/boards/arty_e21/src/main.rs
@@ -67,7 +67,7 @@ impl Platform for ArtyE21 {
     {
         match driver_num {
             capsules::console::DRIVER_NUM => f(Some(Ok(self.console))),
-            capsules::gpio::DRIVER_NUM => f(Some(Err(self.gpio))),
+            capsules::gpio::DRIVER_NUM => f(Some(Ok(self.gpio))),
 
             capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
             capsules::led::DRIVER_NUM => f(Some(Ok(self.led))),

--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -140,7 +140,7 @@ impl kernel::Platform for Platform {
         match driver_num {
             capsules::console::DRIVER_NUM => f(Some(Ok(self.console))),
             capsules::proximity::DRIVER_NUM => f(Some(Ok(self.proximity))),
-            capsules::gpio::DRIVER_NUM => f(Some(Err(self.gpio))),
+            capsules::gpio::DRIVER_NUM => f(Some(Ok(self.gpio))),
             capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
             capsules::led::DRIVER_NUM => f(Some(Ok(self.led))),
             capsules::button::DRIVER_NUM => f(Some(Ok(self.button))),

--- a/boards/earlgrey-nexysvideo/src/main.rs
+++ b/boards/earlgrey-nexysvideo/src/main.rs
@@ -88,7 +88,7 @@ impl Platform for EarlGreyNexysVideo {
         match driver_num {
             capsules::led::DRIVER_NUM => f(Some(Ok(self.led))),
             capsules::hmac::DRIVER_NUM => f(Some(Err(self.hmac))),
-            capsules::gpio::DRIVER_NUM => f(Some(Err(self.gpio))),
+            capsules::gpio::DRIVER_NUM => f(Some(Ok(self.gpio))),
             capsules::console::DRIVER_NUM => f(Some(Ok(self.console))),
             capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
             capsules::low_level_debug::DRIVER_NUM => f(Some(Ok(self.lldb))),

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -83,7 +83,7 @@ impl Platform for Hail {
     {
         match driver_num {
             capsules::console::DRIVER_NUM => f(Some(Ok(self.console))),
-            capsules::gpio::DRIVER_NUM => f(Some(Err(self.gpio))),
+            capsules::gpio::DRIVER_NUM => f(Some(Ok(self.gpio))),
 
             capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
             capsules::spi_controller::DRIVER_NUM => f(Some(Ok(self.spi))),

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -160,7 +160,7 @@ impl kernel::Platform for Imix {
     {
         match driver_num {
             capsules::console::DRIVER_NUM => f(Some(Ok(self.console))),
-            capsules::gpio::DRIVER_NUM => f(Some(Err(self.gpio))),
+            capsules::gpio::DRIVER_NUM => f(Some(Ok(self.gpio))),
             capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
             capsules::spi_controller::DRIVER_NUM => f(Some(Ok(self.spi))),
             capsules::adc::DRIVER_NUM => f(Some(Ok(self.adc))),

--- a/boards/imxrt1050-evkb/src/main.rs
+++ b/boards/imxrt1050-evkb/src/main.rs
@@ -88,7 +88,7 @@ impl Platform for Imxrt1050EVKB {
             capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
             capsules::button::DRIVER_NUM => f(Some(Ok(self.button))),
             capsules::console::DRIVER_NUM => f(Some(Ok(self.console))),
-            capsules::gpio::DRIVER_NUM => f(Some(Err(self.gpio))),
+            capsules::gpio::DRIVER_NUM => f(Some(Ok(self.gpio))),
             kernel::ipc::DRIVER_NUM => f(Some(Err(&self.ipc))),
             capsules::led::DRIVER_NUM => f(Some(Ok(self.led))),
             capsules::ninedof::DRIVER_NUM => f(Some(Ok(self.ninedof))),

--- a/boards/microbit_v2/src/main.rs
+++ b/boards/microbit_v2/src/main.rs
@@ -113,7 +113,7 @@ impl kernel::Platform for Platform {
     {
         match driver_num {
             capsules::console::DRIVER_NUM => f(Some(Ok(self.console))),
-            capsules::gpio::DRIVER_NUM => f(Some(Err(self.gpio))),
+            capsules::gpio::DRIVER_NUM => f(Some(Ok(self.gpio))),
             capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
             capsules::button::DRIVER_NUM => f(Some(Ok(self.button))),
             capsules::led_matrix::DRIVER_NUM => f(Some(Ok(self.led))),

--- a/boards/msp_exp432p401r/src/main.rs
+++ b/boards/msp_exp432p401r/src/main.rs
@@ -70,7 +70,7 @@ impl Platform for MspExp432P401R {
             capsules::led::DRIVER_NUM => f(Some(Ok(self.led))),
             capsules::console::DRIVER_NUM => f(Some(Ok(self.console))),
             capsules::button::DRIVER_NUM => f(Some(Ok(self.button))),
-            capsules::gpio::DRIVER_NUM => f(Some(Err(self.gpio))),
+            capsules::gpio::DRIVER_NUM => f(Some(Ok(self.gpio))),
             capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
             kernel::ipc::DRIVER_NUM => f(Some(Err(&self.ipc))),
             capsules::adc::DRIVER_NUM => f(Some(Ok(self.adc))),

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -135,7 +135,7 @@ impl kernel::Platform for Platform {
         match driver_num {
             capsules::console::DRIVER_NUM => f(Some(Ok(self.console))),
             capsules::proximity::DRIVER_NUM => f(Some(Ok(self.proximity))),
-            capsules::gpio::DRIVER_NUM => f(Some(Err(self.gpio))),
+            capsules::gpio::DRIVER_NUM => f(Some(Ok(self.gpio))),
             capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
             capsules::led::DRIVER_NUM => f(Some(Ok(self.led))),
             capsules::rng::DRIVER_NUM => f(Some(Ok(self.rng))),

--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -106,7 +106,7 @@ impl kernel::Platform for Platform {
     {
         match driver_num {
             capsules::console::DRIVER_NUM => f(Some(Ok(self.console))),
-            capsules::gpio::DRIVER_NUM => f(Some(Err(self.gpio))),
+            capsules::gpio::DRIVER_NUM => f(Some(Ok(self.gpio))),
             capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
             capsules::led::DRIVER_NUM => f(Some(Ok(self.led))),
             capsules::button::DRIVER_NUM => f(Some(Ok(self.button))),

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -182,7 +182,7 @@ impl kernel::Platform for Platform {
     {
         match driver_num {
             capsules::console::DRIVER_NUM => f(Some(Ok(self.console))),
-            capsules::gpio::DRIVER_NUM => f(Some(Err(self.gpio))),
+            capsules::gpio::DRIVER_NUM => f(Some(Ok(self.gpio))),
             capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
             capsules::led::DRIVER_NUM => f(Some(Ok(self.led))),
             capsules::button::DRIVER_NUM => f(Some(Ok(self.button))),

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -165,7 +165,7 @@ impl kernel::Platform for Platform {
     {
         match driver_num {
             capsules::console::DRIVER_NUM => f(Some(Ok(self.console))),
-            capsules::gpio::DRIVER_NUM => f(Some(Err(self.gpio))),
+            capsules::gpio::DRIVER_NUM => f(Some(Ok(self.gpio))),
             capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
             capsules::led::DRIVER_NUM => f(Some(Ok(self.led))),
             capsules::button::DRIVER_NUM => f(Some(Ok(self.button))),

--- a/boards/nucleo_f429zi/src/main.rs
+++ b/boards/nucleo_f429zi/src/main.rs
@@ -77,7 +77,7 @@ impl Platform for NucleoF429ZI {
             capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
             capsules::temperature::DRIVER_NUM => f(Some(Ok(self.temperature))),
             kernel::ipc::DRIVER_NUM => f(Some(Err(&self.ipc))),
-            capsules::gpio::DRIVER_NUM => f(Some(Err(self.gpio))),
+            capsules::gpio::DRIVER_NUM => f(Some(Ok(self.gpio))),
             _ => f(None),
         }
     }

--- a/boards/redboard_artemis_nano/src/main.rs
+++ b/boards/redboard_artemis_nano/src/main.rs
@@ -74,7 +74,7 @@ impl Platform for RedboardArtemisNano {
         match driver_num {
             capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
             capsules::led::DRIVER_NUM => f(Some(Ok(self.led))),
-            capsules::gpio::DRIVER_NUM => f(Some(Err(self.gpio))),
+            capsules::gpio::DRIVER_NUM => f(Some(Ok(self.gpio))),
             capsules::console::DRIVER_NUM => f(Some(Ok(self.console))),
             capsules::i2c_master::DRIVER_NUM => f(Some(Ok(self.i2c_master))),
             capsules::ble_advertising_driver::DRIVER_NUM => f(Some(Err(self.ble_radio))),

--- a/boards/stm32f3discovery/src/main.rs
+++ b/boards/stm32f3discovery/src/main.rs
@@ -83,7 +83,7 @@ impl Platform for STM32F3Discovery {
             capsules::led::DRIVER_NUM => f(Some(Ok(self.led))),
             capsules::button::DRIVER_NUM => f(Some(Ok(self.button))),
             capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
-            capsules::gpio::DRIVER_NUM => f(Some(Err(self.gpio))),
+            capsules::gpio::DRIVER_NUM => f(Some(Ok(self.gpio))),
             capsules::lsm303dlhc::DRIVER_NUM => f(Some(Ok(self.lsm303dlhc))),
             capsules::l3gd20::DRIVER_NUM => f(Some(Ok(self.l3gd20))),
             capsules::ninedof::DRIVER_NUM => f(Some(Ok(self.ninedof))),

--- a/boards/stm32f412gdiscovery/src/main.rs
+++ b/boards/stm32f412gdiscovery/src/main.rs
@@ -76,7 +76,7 @@ impl Platform for STM32F412GDiscovery {
             capsules::button::DRIVER_NUM => f(Some(Ok(self.button))),
             capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
             kernel::ipc::DRIVER_NUM => f(Some(Err(&self.ipc))),
-            capsules::gpio::DRIVER_NUM => f(Some(Err(self.gpio))),
+            capsules::gpio::DRIVER_NUM => f(Some(Ok(self.gpio))),
             capsules::adc::DRIVER_NUM => f(Some(Ok(self.adc))),
             capsules::ft6x06::DRIVER_NUM => f(Some(Ok(self.ft6x06))),
             capsules::touch::DRIVER_NUM => f(Some(Ok(self.touch))),

--- a/boards/weact_f401ccu6/src/main.rs
+++ b/boards/weact_f401ccu6/src/main.rs
@@ -75,7 +75,7 @@ impl Platform for WeactF401CC {
             capsules::adc::DRIVER_NUM => f(Some(Ok(self.adc))),
             capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
             kernel::ipc::DRIVER_NUM => f(Some(Err(&self.ipc))),
-            capsules::gpio::DRIVER_NUM => f(Some(Err(self.gpio))),
+            capsules::gpio::DRIVER_NUM => f(Some(Ok(self.gpio))),
             _ => f(None),
         }
     }

--- a/capsules/src/gpio.rs
+++ b/capsules/src/gpio.rs
@@ -54,7 +54,7 @@ pub const DRIVER_NUM: usize = driver::NUM::Gpio as usize;
 use core::mem;
 use kernel::hil::gpio;
 use kernel::hil::gpio::{Configure, Input, InterruptWithValue, Output};
-use kernel::{AppId, Callback, CommandResult, Grant, Driver, ErrorCode};
+use kernel::{AppId, Callback, CommandResult, Driver, ErrorCode, Grant};
 
 pub struct GPIO<'a, IP: gpio::InterruptPin<'a>> {
     pins: &'a [Option<&'a gpio::InterruptValueWrapper<'a, IP>>],
@@ -94,7 +94,7 @@ impl<'a, IP: gpio::InterruptPin<'a>> GPIO<'a, IP> {
                     pin.set_floating_state(gpio::FloatingState::PullDown);
                     CommandResult::success()
                 }
-                _ => CommandResult::failure(ErrorCode::NOSUPPORT)
+                _ => CommandResult::failure(ErrorCode::NOSUPPORT),
             }
         } else {
             CommandResult::failure(ErrorCode::NODEVICE)
@@ -167,7 +167,7 @@ impl<'a, IP: gpio::InterruptPin<'a>> Driver for GPIO<'a, IP> {
                 })
                 .map_err(ErrorCode::from),
             // default
-            _ => Err(ErrorCode::NOSUPPORT)
+            _ => Err(ErrorCode::NOSUPPORT),
         };
         if let Err(e) = res {
             Err((callback, e))
@@ -211,9 +211,7 @@ impl<'a, IP: gpio::InterruptPin<'a>> Driver for GPIO<'a, IP> {
         let pin_index = data1;
         match command_num {
             // number of pins
-            0 => {
-                CommandResult::success_u32(pins.len() as u32)
-            },
+            0 => CommandResult::success_u32(pins.len() as u32),
 
             // enable output
             1 => {

--- a/capsules/src/gpio.rs
+++ b/capsules/src/gpio.rs
@@ -51,19 +51,20 @@
 use crate::driver;
 pub const DRIVER_NUM: usize = driver::NUM::Gpio as usize;
 
+use core::mem;
 use kernel::hil::gpio;
 use kernel::hil::gpio::{Configure, Input, InterruptWithValue, Output};
-use kernel::{AppId, Callback, Grant, LegacyDriver, ReturnCode};
+use kernel::{AppId, Callback, CommandResult, Grant, Driver, ErrorCode};
 
 pub struct GPIO<'a, IP: gpio::InterruptPin<'a>> {
     pins: &'a [Option<&'a gpio::InterruptValueWrapper<'a, IP>>],
-    apps: Grant<Option<Callback>>,
+    apps: Grant<Callback>,
 }
 
 impl<'a, IP: gpio::InterruptPin<'a>> GPIO<'a, IP> {
     pub fn new(
         pins: &'a [Option<&'a gpio::InterruptValueWrapper<'a, IP>>],
-        grant: Grant<Option<Callback>>,
+        grant: Grant<Callback>,
     ) -> Self {
         for (i, maybe_pin) in pins.iter().enumerate() {
             if let Some(pin) = maybe_pin {
@@ -76,54 +77,54 @@ impl<'a, IP: gpio::InterruptPin<'a>> GPIO<'a, IP> {
         }
     }
 
-    fn configure_input_pin(&self, pin_num: u32, config: usize) -> ReturnCode {
+    fn configure_input_pin(&self, pin_num: u32, config: usize) -> CommandResult {
         let maybe_pin = self.pins[pin_num as usize];
         if let Some(pin) = maybe_pin {
             pin.make_input();
             match config {
                 0 => {
                     pin.set_floating_state(gpio::FloatingState::PullNone);
-                    ReturnCode::SUCCESS
+                    CommandResult::success()
                 }
                 1 => {
                     pin.set_floating_state(gpio::FloatingState::PullUp);
-                    ReturnCode::SUCCESS
+                    CommandResult::success()
                 }
                 2 => {
                     pin.set_floating_state(gpio::FloatingState::PullDown);
-                    ReturnCode::SUCCESS
+                    CommandResult::success()
                 }
-                _ => ReturnCode::ENOSUPPORT,
+                _ => CommandResult::failure(ErrorCode::NOSUPPORT)
             }
         } else {
-            ReturnCode::ENODEVICE
+            CommandResult::failure(ErrorCode::NODEVICE)
         }
     }
 
-    fn configure_interrupt(&self, pin_num: u32, config: usize) -> ReturnCode {
+    fn configure_interrupt(&self, pin_num: u32, config: usize) -> CommandResult {
         let pins = self.pins.as_ref();
         let index = pin_num as usize;
         if let Some(pin) = pins[index] {
             match config {
                 0 => {
                     pin.enable_interrupts(gpio::InterruptEdge::EitherEdge);
-                    ReturnCode::SUCCESS
+                    CommandResult::success()
                 }
 
                 1 => {
                     pin.enable_interrupts(gpio::InterruptEdge::RisingEdge);
-                    ReturnCode::SUCCESS
+                    CommandResult::success()
                 }
 
                 2 => {
                     pin.enable_interrupts(gpio::InterruptEdge::FallingEdge);
-                    ReturnCode::SUCCESS
+                    CommandResult::success()
                 }
 
-                _ => ReturnCode::ENOSUPPORT,
+                _ => CommandResult::failure(ErrorCode::NOSUPPORT),
             }
         } else {
-            ReturnCode::ENODEVICE
+            CommandResult::failure(ErrorCode::NODEVICE)
         }
     }
 }
@@ -137,13 +138,13 @@ impl<'a, IP: gpio::InterruptPin<'a>> gpio::ClientWithValue for GPIO<'a, IP> {
 
             // schedule callback with the pin number and value
             self.apps.each(|callback| {
-                callback.map(|mut cb| cb.schedule(pin_num as usize, pin_state as usize, 0));
+                callback.schedule(pin_num as usize, pin_state as usize, 0);
             });
         }
     }
 }
 
-impl<'a, IP: gpio::InterruptPin<'a>> LegacyDriver for GPIO<'a, IP> {
+impl<'a, IP: gpio::InterruptPin<'a>> Driver for GPIO<'a, IP> {
     /// Subscribe to GPIO pin events.
     ///
     /// ### `subscribe_num`
@@ -153,22 +154,25 @@ impl<'a, IP: gpio::InterruptPin<'a>> LegacyDriver for GPIO<'a, IP> {
     fn subscribe(
         &self,
         subscribe_num: usize,
-        callback: Option<Callback>,
+        mut callback: Callback,
         app_id: AppId,
-    ) -> ReturnCode {
-        match subscribe_num {
+    ) -> Result<Callback, (Callback, ErrorCode)> {
+        let res = match subscribe_num {
             // subscribe to all pin interrupts (no affect or reliance on
             // individual pins being configured as interrupts)
             0 => self
                 .apps
                 .enter(app_id, |app, _| {
-                    **app = callback;
-                    ReturnCode::SUCCESS
+                    mem::swap(&mut **app, &mut callback);
                 })
-                .unwrap_or_else(|err| err.into()),
-
+                .map_err(ErrorCode::from),
             // default
-            _ => ReturnCode::ENOSUPPORT,
+            _ => Err(ErrorCode::NOSUPPORT)
+        };
+        if let Err(e) = res {
+            Err((callback, e))
+        } else {
+            Ok(callback)
         }
     }
 
@@ -202,25 +206,26 @@ impl<'a, IP: gpio::InterruptPin<'a>> LegacyDriver for GPIO<'a, IP> {
     /// - `7`: Configure interrupt on `pin` with `irq_config` in 0x00XX00000
     /// - `8`: Disable interrupt on `pin`.
     /// - `9`: Disable `pin`.
-    fn command(&self, command_num: usize, data1: usize, data2: usize, _: AppId) -> ReturnCode {
+    fn command(&self, command_num: usize, data1: usize, data2: usize, _: AppId) -> CommandResult {
         let pins = self.pins.as_ref();
         let pin_index = data1;
         match command_num {
             // number of pins
-            0 => ReturnCode::SuccessWithValue {
-                value: pins.len() as usize,
+            0 => {
+                CommandResult::success_u32(pins.len() as u32)
             },
 
             // enable output
             1 => {
                 if pin_index >= pins.len() {
-                    ReturnCode::EINVAL /* impossible pin */
+                    /* impossible pin */
+                    CommandResult::failure(ErrorCode::INVAL)
                 } else {
                     if let Some(pin) = pins[pin_index] {
                         pin.make_output();
-                        ReturnCode::SUCCESS
+                        CommandResult::success()
                     } else {
-                        ReturnCode::ENODEVICE
+                        CommandResult::failure(ErrorCode::NODEVICE)
                     }
                 }
             }
@@ -228,13 +233,14 @@ impl<'a, IP: gpio::InterruptPin<'a>> LegacyDriver for GPIO<'a, IP> {
             // set pin
             2 => {
                 if pin_index >= pins.len() {
-                    ReturnCode::EINVAL /* impossible pin */
+                    /* impossible pin */
+                    CommandResult::failure(ErrorCode::INVAL)
                 } else {
                     if let Some(pin) = pins[pin_index] {
                         pin.set();
-                        ReturnCode::SUCCESS
+                        CommandResult::success()
                     } else {
-                        ReturnCode::ENODEVICE
+                        CommandResult::failure(ErrorCode::NODEVICE)
                     }
                 }
             }
@@ -242,13 +248,14 @@ impl<'a, IP: gpio::InterruptPin<'a>> LegacyDriver for GPIO<'a, IP> {
             // clear pin
             3 => {
                 if pin_index >= pins.len() {
-                    ReturnCode::EINVAL /* impossible pin */
+                    /* impossible pin */
+                    CommandResult::failure(ErrorCode::INVAL)
                 } else {
                     if let Some(pin) = pins[pin_index] {
                         pin.clear();
-                        ReturnCode::SUCCESS
+                        CommandResult::success()
                     } else {
-                        ReturnCode::ENODEVICE
+                        CommandResult::failure(ErrorCode::NODEVICE)
                     }
                 }
             }
@@ -256,13 +263,14 @@ impl<'a, IP: gpio::InterruptPin<'a>> LegacyDriver for GPIO<'a, IP> {
             // toggle pin
             4 => {
                 if pin_index >= pins.len() {
-                    ReturnCode::EINVAL /* impossible pin */
+                    /* impossible pin */
+                    CommandResult::failure(ErrorCode::INVAL)
                 } else {
                     if let Some(pin) = pins[pin_index] {
                         pin.toggle();
-                        ReturnCode::SUCCESS
+                        CommandResult::success()
                     } else {
-                        ReturnCode::ENODEVICE
+                        CommandResult::failure(ErrorCode::NODEVICE)
                     }
                 }
             }
@@ -271,7 +279,8 @@ impl<'a, IP: gpio::InterruptPin<'a>> LegacyDriver for GPIO<'a, IP> {
             5 => {
                 let pin_config = data2;
                 if pin_index >= pins.len() {
-                    ReturnCode::EINVAL /* impossible pin */
+                    /* impossible pin */
+                    CommandResult::failure(ErrorCode::INVAL)
                 } else {
                     self.configure_input_pin(pin_index as u32, pin_config)
                 }
@@ -280,15 +289,14 @@ impl<'a, IP: gpio::InterruptPin<'a>> LegacyDriver for GPIO<'a, IP> {
             // read input
             6 => {
                 if pin_index >= pins.len() {
-                    ReturnCode::EINVAL /* impossible pin */
+                    /* impossible pin */
+                    CommandResult::failure(ErrorCode::INVAL)
                 } else {
                     if let Some(pin) = pins[pin_index] {
                         let pin_state = pin.read();
-                        ReturnCode::SuccessWithValue {
-                            value: pin_state as usize,
-                        }
+                        CommandResult::success_u32(pin_state as u32)
                     } else {
-                        ReturnCode::ENODEVICE
+                        CommandResult::failure(ErrorCode::NODEVICE)
                     }
                 }
             }
@@ -298,7 +306,8 @@ impl<'a, IP: gpio::InterruptPin<'a>> LegacyDriver for GPIO<'a, IP> {
             7 => {
                 let irq_config = data2;
                 if pin_index >= pins.len() {
-                    ReturnCode::EINVAL /* impossible pin */
+                    /* impossible pin */
+                    CommandResult::failure(ErrorCode::INVAL)
                 } else {
                     self.configure_interrupt(pin_index as u32, irq_config)
                 }
@@ -308,14 +317,15 @@ impl<'a, IP: gpio::InterruptPin<'a>> LegacyDriver for GPIO<'a, IP> {
             // (no affect or reliance on registered callback)
             8 => {
                 if pin_index >= pins.len() {
-                    ReturnCode::EINVAL /* impossible pin */
+                    /* impossible pin */
+                    CommandResult::failure(ErrorCode::INVAL)
                 } else {
                     if let Some(pin) = pins[pin_index] {
                         pin.disable_interrupts();
                         pin.deactivate_to_low_power();
-                        ReturnCode::SUCCESS
+                        CommandResult::success()
                     } else {
-                        ReturnCode::ENODEVICE
+                        CommandResult::failure(ErrorCode::NODEVICE)
                     }
                 }
             }
@@ -323,19 +333,20 @@ impl<'a, IP: gpio::InterruptPin<'a>> LegacyDriver for GPIO<'a, IP> {
             // disable pin
             9 => {
                 if pin_index >= pins.len() {
-                    ReturnCode::EINVAL /* impossible pin */
+                    /* impossible pin */
+                    CommandResult::failure(ErrorCode::INVAL)
                 } else {
                     if let Some(pin) = pins[pin_index] {
                         pin.deactivate_to_low_power();
-                        ReturnCode::SUCCESS
+                        CommandResult::success()
                     } else {
-                        ReturnCode::ENODEVICE
+                        CommandResult::failure(ErrorCode::NODEVICE)
                     }
                 }
             }
 
             // default
-            _ => ReturnCode::ENOSUPPORT,
+            _ => CommandResult::failure(ErrorCode::NOSUPPORT),
         }
     }
 }


### PR DESCRIPTION
### Pull Request Overview

This pull request updates the GPIO capsule for the Tock 2.0 syscall API.


### Testing Strategy

This pull request has been tested with the GPIO test app in libtock-c, testing input, output, and interrupts.

### TODO or Help Wanted

None.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
