### PR TITLE
sam4l: i2c: set clocks

### DIFF
--- a/chips/sam4l/src/i2c.rs
+++ b/chips/sam4l/src/i2c.rs
@@ -665,7 +665,10 @@ impl I2CHw {
         I2CHw::new(
             I2C_BASE_ADDRS[0],
             Some(I2C_SLAVE_BASE_ADDRS[0]),
-            create_twims_clocks(pm::Clock::PBA(pm::PBAClock::TWIM0), None),
+            create_twims_clocks(
+                pm::Clock::PBA(pm::PBAClock::TWIM0),
+                Some(pm::Clock::PBA(pm::PBAClock::TWIS0)),
+            ),
             DMAPeripheral::TWIM0_RX,
             DMAPeripheral::TWIM0_TX,
             pm,
@@ -676,7 +679,10 @@ impl I2CHw {
         I2CHw::new(
             I2C_BASE_ADDRS[1],
             Some(I2C_SLAVE_BASE_ADDRS[1]),
-            create_twims_clocks(pm::Clock::PBA(pm::PBAClock::TWIM1), None),
+            create_twims_clocks(
+                pm::Clock::PBA(pm::PBAClock::TWIM1),
+                Some(pm::Clock::PBA(pm::PBAClock::TWIS1)),
+            ),
             DMAPeripheral::TWIM1_RX,
             DMAPeripheral::TWIM1_TX,
             pm,


### PR DESCRIPTION
### Pull Request Overview

Fixes:

```
tockloader listen
[INFO   ] No device name specified. Using default name "tock".
[INFO   ] Using "/dev/cu.usbserial-c098e5130152 - Hail IoT Module - TockOS".
[INFO   ] Listening for serial output.
Initialization complete. Entering main loop.
No rot13 service
[Hail] Test App!
[Hail] Samples all sensors.
[Hail] Transmits name over BLE.
[Hail] Button controls LED.

panicked at 'I2C: Use of slave with no clock', chips/sam4l/src/i2c.rs:525:38
	Kernel version release-1.6-634-g0fb0200c4

---| No debug queue found. You can set it with the DebugQueue component.

---| Fault Status |---
No faults detected.
```

when running Hail app.


### Testing Strategy

Running hail app.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
