### PR TITLE
tsl12561: Update to use Tock 2.0 Driver

### DIFF
--- a/capsules/src/tsl2561.rs
+++ b/capsules/src/tsl2561.rs
@@ -14,10 +14,10 @@
 //! > using an empirical formula to approximate the human eye response.
 
 use core::cell::Cell;
-use kernel::common::cells::{OptionalCell, TakeCell};
+use kernel::common::cells::TakeCell;
 use kernel::hil::gpio;
 use kernel::hil::i2c;
-use kernel::{AppId, Callback, LegacyDriver, ReturnCode};
+use kernel::{AppId, Callback, CommandResult, Driver, ErrorCode};
 
 /// Syscall driver number.
 use crate::driver;
@@ -204,7 +204,7 @@ enum State {
 pub struct TSL2561<'a> {
     i2c: &'a dyn i2c::I2CDevice,
     interrupt_pin: &'a dyn gpio::InterruptPin<'a>,
-    callback: OptionalCell<Callback>,
+    callback: Cell<Callback>,
     state: Cell<State>,
     buffer: TakeCell<'static, [u8]>,
 }
@@ -219,7 +219,7 @@ impl<'a> TSL2561<'a> {
         TSL2561 {
             i2c: i2c,
             interrupt_pin: interrupt_pin,
-            callback: OptionalCell::empty(),
+            callback: Cell::new(Callback::default()),
             state: Cell::new(State::Idle),
             buffer: TakeCell::new(buffer),
         }
@@ -404,7 +404,7 @@ impl i2c::I2CClient for TSL2561<'_> {
 
                 let lux = self.calculate_lux(chan0, chan1);
 
-                self.callback.map(|cb| cb.schedule(0, lux, 0));
+                self.callback.get().schedule(0, lux, 0);
 
                 buffer[0] = Registers::Control as u8 | COMMAND_REG;
                 buffer[1] = POWER_OFF;
@@ -436,35 +436,31 @@ impl gpio::Client for TSL2561<'_> {
     }
 }
 
-impl LegacyDriver for TSL2561<'_> {
+impl Driver for TSL2561<'_> {
     fn subscribe(
         &self,
         subscribe_num: usize,
-        callback: Option<Callback>,
+        callback: Callback,
         _app_id: AppId,
-    ) -> ReturnCode {
+    ) -> Result<Callback, (Callback, ErrorCode)> {
         match subscribe_num {
-            // Set a callback
-            0 => {
-                // Set callback function
-                self.callback.insert(callback);
-                ReturnCode::SUCCESS
-            }
+            0 => Ok(self.callback.replace(callback)),
+
             // default
-            _ => ReturnCode::ENOSUPPORT,
+            _ => Err((callback, ErrorCode::NOSUPPORT)),
         }
     }
 
-    fn command(&self, command_num: usize, _: usize, _: usize, _: AppId) -> ReturnCode {
+    fn command(&self, command_num: usize, _: usize, _: usize, _: AppId) -> CommandResult {
         match command_num {
-            0 /* check if present */ => ReturnCode::SUCCESS,
+            0 /* check if present */ => CommandResult::success(),
             // Take a measurement
             1 => {
                 self.take_measurement();
-                ReturnCode::SUCCESS
+                CommandResult::success()
             }
             // default
-            _ => ReturnCode::ENOSUPPORT,
+            _ => CommandResult::failure(ErrorCode::NOSUPPORT),
         }
     }
 }


### PR DESCRIPTION
### Pull Request Overview

This pull request updates the tsl12561 to Tock 2.0 interface.

### Testing Strategy

Compiling -- I'm not actually sure what hardware platform has this sensor (if any remain).

### TODO or Help Wanted

I'm late to the 2.0 conversion party, but I don't think I messed anything up.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
