### PR TITLE
kernel: Remove setting/tracking the stack pointer in process.rs

### DIFF
--- a/arch/cortex-m/src/syscall.rs
+++ b/arch/cortex-m/src/syscall.rs
@@ -2,6 +2,7 @@
 //! system call interface.
 
 use core::fmt::Write;
+use core::mem;
 use core::ptr::{read_volatile, write_volatile};
 
 /// This is used in the syscall handler. When set to 1 this means the
@@ -33,6 +34,9 @@ extern "C" {
     pub fn switch_to_user(user_stack: *const usize, process_regs: &mut [usize; 8]) -> *const usize;
 }
 
+// Space for 8 u32s: r0-r3, r12, lr, pc, and xPSR
+const SVC_FRAME_SIZE: usize = 32;
+
 /// This holds all of the state that the kernel must keep for the process when
 /// the process is not executing.
 #[derive(Default)]
@@ -40,6 +44,7 @@ pub struct CortexMStoredState {
     regs: [usize; 8],
     yield_pc: usize,
     psr: usize,
+    psp: usize,
 }
 
 /// Implementation of the `UserspaceKernelBoundary` for the Cortex-M non-floating point
@@ -55,70 +60,99 @@ impl SysCall {
 impl kernel::syscall::UserspaceKernelBoundary for SysCall {
     type StoredState = CortexMStoredState;
 
+    fn initial_process_app_brk_size(&self) -> usize {
+        // TOCK 1.X
+        //
+        // The 1.x Tock kernel allocates at least 3 kB to processes, and we need
+        // to ensure that happens as userspace may expect it.
+        3 * 1024
+
+        // TOCK 2.0
+        //
+        // Cortex-M hardware use 8 words on the stack to implement context switches.
+        // So we need at least 32 bytes.
+        //32
+    }
+
     unsafe fn initialize_process(
         &self,
-        stack_pointer: *const usize,
-        stack_size: usize,
+        memory_start: *const u8,
+        app_brk: *const u8,
         state: &mut Self::StoredState,
-    ) -> Result<*const usize, ()> {
+    ) -> Result<(), ()> {
         // We need to initialize the stored state for the process here. This
         // initialization can be called multiple times for a process, for
         // example if the process is restarted.
         state.regs.iter_mut().for_each(|x| *x = 0);
         state.yield_pc = 0;
         state.psr = 0x01000000; // Set the Thumb bit and clear everything else.
+        state.psp = app_brk as usize; // Set to top of process-accessible memory.
 
-        // The first time a process runs it has no stack and we have to create
-        // a new stack frame for the svc handler to have "returned from".
-
-        // Space for 8 u32s: r0-r3, r12, lr, pc, and xPSR
-        let svc_frame_size = 32;
-
-        // Make sure there's enough room on the stack for the initial kernel frame
-        if stack_size < svc_frame_size {
+        // Make sure there's enough room on the stack for the initial SVC frame.
+        if (app_brk.offset_from(memory_start) as usize) < SVC_FRAME_SIZE {
             // Not enough room on the stack to add a frame.
             return Err(());
         }
 
         // Allocate the kernel frame
-        Ok((stack_pointer as *mut usize).offset(-8))
+        state.psp -= SVC_FRAME_SIZE;
+        Ok(())
     }
 
     unsafe fn set_syscall_return_value(
         &self,
-        stack_pointer: *const usize,
-        _state: &mut Self::StoredState,
+        memory_start: *const u8,
+        app_brk: *const u8,
+        state: &mut Self::StoredState,
         return_value: isize,
-    ) {
-        // For the Cortex-M arch we set this in the same place that r0 was
-        // passed.
-        let sp = stack_pointer as *mut isize;
+    ) -> Result<(), ()> {
+        // For the Cortex-M arch we set the return value in the same place that
+        // r0 was passed in, aka at the bottom the SVC structure on the stack.
+
+        // First, we need to validate that this location is inside of the
+        // process's accessible memory.
+        if state.psp < memory_start as usize
+            || (state.psp + mem::size_of::<isize>()) > app_brk as usize
+        {
+            return Err(());
+        }
+
+        // Do the write.
+        let sp = state.psp as *mut isize;
         write_volatile(sp, return_value);
+
+        Ok(())
     }
 
     /// When the process calls `svc` to enter the kernel, the hardware
-    /// automatically pushes a stack frame that will be unstacked when the
-    /// kernel returns to the process. In the special case of process startup,
-    /// `initialize_new_process` sets up an empty stack frame and stored state
-    /// as if an `svc` had been called.
+    /// automatically pushes an SVC frame that will be unstacked when the kernel
+    /// returns to the process. In the special case of process startup,
+    /// `initialize_new_process` sets up an empty SVC frame as if an `svc` had
+    /// been called.
     ///
     /// Here, we modify this stack frame such that the process resumes at the
     /// beginning of the callback function that we want the process to run. We
-    /// place the originally intended return addess in the link register so
+    /// place the originally intended return address in the link register so
     /// that when the function completes execution continues.
     ///
     /// In effect, this converts `svc` into `bl callback`.
     unsafe fn set_process_function(
         &self,
-        stack_pointer: *const usize,
-        _remaining_stack_memory: usize,
+        memory_start: *const u8,
+        app_brk: *const u8,
         state: &mut CortexMStoredState,
         callback: kernel::procs::FunctionCall,
-    ) -> Result<*mut usize, *mut usize> {
+    ) -> Result<(), ()> {
+        // Ensure that [`state.psp`, `state.psp + SVC_FRAME_SIZE`] is
+        // within process-accessible memory.
+        if state.psp < memory_start as usize || (state.psp + SVC_FRAME_SIZE) > app_brk as usize {
+            return Err(());
+        }
+
         // Notes:
         //  - Instruction addresses require `|1` to indicate thumb code
         //  - Stack offset 4 is R12, which the syscall interface ignores
-        let stack_bottom = stack_pointer as *mut usize;
+        let stack_bottom = state.psp as *mut usize;
         write_volatile(stack_bottom.offset(7), state.psr); //......... -> APSR
         write_volatile(stack_bottom.offset(6), callback.pc | 1); //... -> PC
         write_volatile(stack_bottom.offset(5), state.yield_pc | 1); // -> LR
@@ -127,15 +161,32 @@ impl kernel::syscall::UserspaceKernelBoundary for SysCall {
         write_volatile(stack_bottom.offset(1), callback.argument1); // -> R1
         write_volatile(stack_bottom.offset(0), callback.argument0); // -> R0
 
-        Ok(stack_bottom)
+        Ok(())
     }
 
     unsafe fn switch_to_process(
         &self,
-        stack_pointer: *const usize,
+        memory_start: *const u8,
+        app_brk: *const u8,
         state: &mut CortexMStoredState,
-    ) -> (*mut usize, kernel::syscall::ContextSwitchReason) {
-        let new_stack_pointer = switch_to_user(stack_pointer, &mut state.regs);
+    ) -> kernel::syscall::ContextSwitchReason {
+        let new_stack_pointer = switch_to_user(state.psp as *const usize, &mut state.regs);
+
+        // We need to keep track of the current stack pointer.
+        state.psp = new_stack_pointer as usize;
+
+        // We need to validate that the stack pointer and the SVC frame are
+        // within process accessible memory.
+        let invalid_stack_pointer = if state.psp < memory_start as usize
+            || (state.psp + SVC_FRAME_SIZE) > app_brk as usize
+        {
+            // Process corrupted its stack pointer, we can't continue and must
+            // fault.
+            true
+        } else {
+            // Everything looks good.
+            false
+        };
 
         // Determine why this returned and the process switched back to the
         // kernel.
@@ -151,7 +202,7 @@ impl kernel::syscall::UserspaceKernelBoundary for SysCall {
         write_volatile(&mut SYSCALL_FIRED, 0);
 
         // Now decide the reason based on which flags were set.
-        let switch_reason = if app_fault == 1 {
+        if app_fault == 1 || invalid_stack_pointer {
             // APP_HARD_FAULT takes priority. This means we hit the hardfault
             // handler and this process faulted.
             kernel::syscall::ContextSwitchReason::Fault
@@ -188,17 +239,22 @@ impl kernel::syscall::UserspaceKernelBoundary for SysCall {
             // If none of the above cases are true its because the process was interrupted by an
             // ISR for a hardware event
             kernel::syscall::ContextSwitchReason::Interrupted
-        };
-
-        (new_stack_pointer as *mut usize, switch_reason)
+        }
     }
 
     unsafe fn print_context(
         &self,
-        stack_pointer: *const usize,
+        memory_start: *const u8,
+        app_brk: *const u8,
         state: &CortexMStoredState,
         writer: &mut dyn Write,
     ) {
+        // Validate the stored stack pointer is valid.
+        if state.psp < memory_start as usize || (state.psp + SVC_FRAME_SIZE) > app_brk as usize {
+            return;
+        }
+
+        let stack_pointer = state.psp as *const usize;
         let r0 = read_volatile(stack_pointer.offset(0));
         let r1 = read_volatile(stack_pointer.offset(1));
         let r2 = read_volatile(stack_pointer.offset(2));

--- a/arch/cortex-m/src/syscall.rs
+++ b/arch/cortex-m/src/syscall.rs
@@ -71,7 +71,7 @@ impl kernel::syscall::UserspaceKernelBoundary for SysCall {
         //
         // Cortex-M hardware use 8 words on the stack to implement context switches.
         // So we need at least 32 bytes.
-        //32
+        //SVC_FRAME_SIZE
     }
 
     unsafe fn initialize_process(

--- a/arch/cortex-m/src/syscall.rs
+++ b/arch/cortex-m/src/syscall.rs
@@ -89,7 +89,7 @@ impl kernel::syscall::UserspaceKernelBoundary for SysCall {
         state.psp = app_brk as usize; // Set to top of process-accessible memory.
 
         // Make sure there's enough room on the stack for the initial SVC frame.
-        if (app_brk.offset_from(memory_start) as usize) < SVC_FRAME_SIZE {
+        if (app_brk as usize - memory_start as usize) < SVC_FRAME_SIZE {
             // Not enough room on the stack to add a frame.
             return Err(());
         }

--- a/arch/rv32i/src/syscall.rs
+++ b/arch/rv32i/src/syscall.rs
@@ -71,7 +71,7 @@ impl kernel::syscall::UserspaceKernelBoundary for SysCall {
 
     unsafe fn initialize_process(
         &self,
-        memory_start: *const u8,
+        accessible_memory_start: *const u8,
         _app_brk: *const u8,
         state: &mut Self::StoredState,
     ) -> Result<(), ()> {
@@ -84,12 +84,12 @@ impl kernel::syscall::UserspaceKernelBoundary for SysCall {
         // pointer in the sp register.
         //
         // TOCK 1.X
-        state.regs[R_SP] = memory_start.add(3 * 1024) as usize;
+        state.regs[R_SP] = accessible_memory_start.add(3 * 1024) as usize;
         //
         // TOCK 2.0
         //
         // We do not pre-allocate any stack for RV32I processes.
-        // state.regs[R_SP] = memory_start as usize;
+        // state.regs[R_SP] = accessible_memory_start as usize;
 
         // We do not use memory for UKB, so just return ok.
         Ok(())
@@ -97,7 +97,7 @@ impl kernel::syscall::UserspaceKernelBoundary for SysCall {
 
     unsafe fn set_syscall_return_value(
         &self,
-        _memory_start: *const u8,
+        _accessible_memory_start: *const u8,
         _app_brk: *const u8,
         state: &mut Self::StoredState,
         return_value: isize,
@@ -112,7 +112,7 @@ impl kernel::syscall::UserspaceKernelBoundary for SysCall {
 
     unsafe fn set_process_function(
         &self,
-        _memory_start: *const u8,
+        _accessible_memory_start: *const u8,
         _app_brk: *const u8,
         state: &mut Riscv32iStoredState,
         callback: kernel::procs::FunctionCall,
@@ -142,7 +142,7 @@ impl kernel::syscall::UserspaceKernelBoundary for SysCall {
     #[cfg(not(any(target_arch = "riscv32", target_os = "none")))]
     unsafe fn switch_to_process(
         &self,
-        _memory_start: *const u8,
+        _accessible_memory_start: *const u8,
         _app_brk: *const u8,
         _state: &mut Riscv32iStoredState,
     ) -> (ContextSwitchReason, Option<*const u8>) {
@@ -155,7 +155,7 @@ impl kernel::syscall::UserspaceKernelBoundary for SysCall {
     #[cfg(all(target_arch = "riscv32", target_os = "none"))]
     unsafe fn switch_to_process(
         &self,
-        _memory_start: *const u8,
+        _accessible_memory_start: *const u8,
         _app_brk: *const u8,
         state: &mut Riscv32iStoredState,
     ) -> (ContextSwitchReason, Option<*const u8>) {
@@ -414,7 +414,7 @@ impl kernel::syscall::UserspaceKernelBoundary for SysCall {
 
     unsafe fn print_context(
         &self,
-        _memory_start: *const u8,
+        _accessible_memory_start: *const u8,
         _app_brk: *const u8,
         state: &Riscv32iStoredState,
         writer: &mut dyn Write,

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -1,6 +1,7 @@
 //! Support for creating and running userspace applications.
 
 use core::cell::Cell;
+use core::cmp;
 use core::convert::TryInto;
 use core::fmt;
 use core::fmt::Write;
@@ -20,8 +21,6 @@ use crate::platform::Chip;
 use crate::returncode::ReturnCode;
 use crate::sched::Kernel;
 use crate::syscall::{self, Syscall, UserspaceKernelBoundary};
-
-use core::cmp::max;
 
 /// Errors that can occur when trying to load and create processes.
 pub enum ProcessLoadError {
@@ -453,6 +452,18 @@ pub trait ProcessType {
     ///
     /// It is not valid to call this function when the process is inactive (i.e.
     /// the process will not run again).
+    ///
+    /// This can fail, if the UKB implementation cannot correctly set the return value. An
+    /// example of how this might occur:
+    ///
+    /// 1. The UKB implementation uses the process's stack to transfer values
+    ///    between kernelspace and userspace.
+    /// 2. The process calls memop.brk and reduces its accessible memory region
+    ///    below its current stack.
+    /// 3. The UKB implementation can no longer set the return value on the
+    ///    stack since the process no longer has access to its stack.
+    ///
+    /// If it fails, the process will be put into the faulted state.
     unsafe fn set_syscall_return_value(&self, return_value: isize);
 
     /// Set the function that is to be executed when the process is resumed.
@@ -756,7 +767,7 @@ struct ProcessDebug {
     app_stack_start_pointer: Option<*const u8>,
 
     /// How low have we ever seen the stack pointer.
-    min_stack_pointer: *const u8,
+    app_stack_min_pointer: Option<*const u8>,
 
     /// How many syscalls have occurred since the process started.
     syscall_count: usize,
@@ -823,22 +834,11 @@ pub struct Process<'a, C: 'static + Chip> {
     /// Pointer to the end of the allocated (and MPU protected) grant region.
     kernel_memory_break: Cell<*const u8>,
 
-    /// Copy of where the kernel memory break is when the app is first started.
-    /// This is handy if the app is restarted so we know where to reset
-    /// the kernel_memory break to without having to recalculate it.
-    original_kernel_memory_break: *const u8,
-
     /// Pointer to the end of process RAM that has been sbrk'd to the process.
     app_break: Cell<*const u8>,
-    original_app_break: *const u8,
 
     /// Pointer to high water mark for process buffers shared through `allow`
     allow_high_water_mark: Cell<*const u8>,
-    original_allow_high_water_mark: *const u8,
-
-    /// Saved when the app switches to the kernel.
-    current_stack_pointer: Cell<*const u8>,
-    original_stack_pointer: *const u8,
 
     /// Process flash segment. This is the region of nonvolatile flash that
     /// the process occupies.
@@ -1052,7 +1052,7 @@ impl<C: Chip> ProcessType for Process<'_, C> {
 
                 // We also reset the minimum stack pointer because whatever value
                 // we had could be entirely wrong by now.
-                debug.min_stack_pointer = stack_pointer;
+                debug.app_stack_min_pointer = Some(stack_pointer);
             });
         }
     }
@@ -1160,7 +1160,7 @@ impl<C: Chip> ProcessType for Process<'_, C> {
                     // Valid slice, we need to adjust the app's watermark
                     // note: in_app_owned_memory ensures this offset does not wrap
                     let buf_end_addr = buf_start_addr.wrapping_add(size);
-                    let new_water_mark = max(self.allow_high_water_mark.get(), buf_end_addr);
+                    let new_water_mark = cmp::max(self.allow_high_water_mark.get(), buf_end_addr);
                     self.allow_high_water_mark.set(new_water_mark);
 
                     // The `unsafe` promise we should be making here is that this
@@ -1266,64 +1266,71 @@ impl<C: Chip> ProcessType for Process<'_, C> {
     }
 
     unsafe fn set_syscall_return_value(&self, return_value: isize) {
-        self.stored_state.map(|stored_state| {
+        match self.stored_state.map(|stored_state| {
             self.chip
                 .userspace_kernel_boundary()
-                .set_syscall_return_value(self.sp(), stored_state, return_value);
-        });
-    }
-
-    unsafe fn set_process_function(&self, callback: FunctionCall) {
-        // First we need to get how much memory is available for this app's
-        // stack. Since the stack is at the bottom of the process's memory
-        // region, this is straightforward.
-        let remaining_stack_bytes = self.sp() as usize - self.memory.as_ptr() as usize;
-
-        // Next we should see if we can actually add the frame to the process's
-        // stack. Architecture-specific code handles actually doing the push
-        // since we don't know the details of exactly what the stack frames look
-        // like.
-        match self.stored_state.map(|stored_state| {
-            self.chip.userspace_kernel_boundary().set_process_function(
-                self.sp(),
-                remaining_stack_bytes,
-                stored_state,
-                callback,
-            )
+                .set_syscall_return_value(
+                    self.memory.as_ptr(),
+                    self.app_break.get(),
+                    stored_state,
+                    return_value,
+                )
         }) {
-            Some(Ok(stack_bottom)) => {
-                // If we got an `Ok` with the new stack pointer we are all
-                // set and should mark that this process is ready to be
-                // scheduled.
-
-                // Move this process to the "running" state so the scheduler
-                // will schedule it.
-                self.state.update(State::Running);
-
-                // Update helpful debugging metadata.
-                self.current_stack_pointer.set(stack_bottom as *mut u8);
-                self.debug_set_max_stack_depth();
+            Some(Ok(())) => {
+                // If we get an `Ok` we are all set.
             }
 
-            Some(Err(bad_stack_bottom)) => {
-                // If we got an Error, then there was not enough room on the
-                // stack to allow the process to execute this function given the
-                // details of the particular architecture this is running on.
-                // This process has essentially faulted, so we mark it as such.
-                // We also update the debugging metadata so that if the process
-                // fault message prints then it should be easier to debug that
-                // the process exceeded its stack.
-                self.debug.map(|debug| {
-                    let bad_stack_bottom = bad_stack_bottom as *const u8;
-                    if bad_stack_bottom < debug.min_stack_pointer {
-                        debug.min_stack_pointer = bad_stack_bottom;
-                    }
-                });
+            Some(Err(())) => {
+                // If we get an `Err`, then the UKB implementation could not set
+                // the return value, likely because the process's stack is no
+                // longer accessible to it. All we can do is fault.
                 self.set_fault_state();
             }
 
             None => {
-                // We should never be here since `stored_state` should always be occupied.
+                // We should never be here since `stored_state` should always be
+                // occupied.
+                self.set_fault_state();
+            }
+        }
+    }
+
+    unsafe fn set_process_function(&self, callback: FunctionCall) {
+        // See if we can actually enqueue this function for this process.
+        // Architecture-specific code handles actually doing this since the
+        // exact method is both architecture- and implementation-specific.
+        //
+        // This can fail, for example if the process does not have enough memory
+        // remaining.
+        match self.stored_state.map(|stored_state| {
+            self.chip.userspace_kernel_boundary().set_process_function(
+                self.memory.as_ptr(),
+                self.app_break.get(),
+                stored_state,
+                callback,
+            )
+        }) {
+            Some(Ok(())) => {
+                // If we got an `Ok` we are all set and should mark that this
+                // process is ready to be scheduled.
+
+                // Move this process to the "running" state so the scheduler
+                // will schedule it.
+                self.state.update(State::Running);
+            }
+
+            Some(Err(())) => {
+                // If we got an Error, then there was likely not enough room on
+                // the stack to allow the process to execute this function given
+                // the details of the particular architecture this is running
+                // on. This process has essentially faulted, so we mark it as
+                // such.
+                self.set_fault_state();
+            }
+
+            None => {
+                // We should never be here since `stored_state` should always be
+                // occupied.
                 self.set_fault_state();
             }
         }
@@ -1336,20 +1343,12 @@ impl<C: Chip> ProcessType for Process<'_, C> {
         }
 
         let switch_reason = self.stored_state.map(|stored_state| {
-            let (stack_pointer, switch_reason) = self
-                .chip
-                .userspace_kernel_boundary()
-                .switch_to_process(self.sp(), stored_state);
-            self.current_stack_pointer.set(stack_pointer as *const u8);
+            let switch_reason = self.chip.userspace_kernel_boundary().switch_to_process(
+                self.memory.as_ptr(),
+                self.app_break.get(),
+                stored_state,
+            );
             switch_reason
-        });
-
-        // Update debug state as needed after running this process.
-        self.debug.map(|debug| {
-            // Update max stack depth if needed.
-            if self.current_stack_pointer.get() < debug.min_stack_pointer {
-                debug.min_stack_pointer = self.current_stack_pointer.get();
-            }
         });
 
         switch_reason
@@ -1398,9 +1397,9 @@ impl<C: Chip> ProcessType for Process<'_, C> {
         let sram_stack_start: Option<usize> = self.debug.map_or(None, |debug| {
             debug.app_stack_start_pointer.map(|p| p as usize)
         });
-        let sram_stack_bottom =
-            self.debug
-                .map_or(ptr::null(), |debug| debug.min_stack_pointer) as usize;
+        let sram_stack_bottom: Option<usize> = self.debug.map_or(None, |debug| {
+            debug.app_stack_min_pointer.map(|p| p as usize)
+        });
         let sram_start = self.memory.as_ptr() as usize;
 
         // SRAM sizes
@@ -1493,8 +1492,8 @@ impl<C: Chip> ProcessType for Process<'_, C> {
             }
         }
 
-        match sram_stack_start {
-            Some(sram_stack_start) => {
+        match (sram_stack_start, sram_stack_bottom) {
+            (Some(sram_stack_start), Some(sram_stack_bottom)) => {
                 let sram_stack_size = sram_stack_start - sram_stack_bottom;
                 let sram_stack_allocated = sram_stack_start - sram_start;
 
@@ -1508,7 +1507,7 @@ impl<C: Chip> ProcessType for Process<'_, C> {
                     exceeded_check(sram_stack_size, sram_stack_allocated),
                 ));
             }
-            None => {
+            _ => {
                 let _ = writer.write_str(
                     "\
                      \r\n  ?????????? ┼─────────────────────────────────────────── M\
@@ -1529,7 +1528,7 @@ impl<C: Chip> ProcessType for Process<'_, C> {
              \r\n             │ Protected    {:6}                        S\
              \r\n  {:#010X} ┴─────────────────────────────────────────── H\
              \r\n",
-            sram_stack_bottom,
+            sram_stack_bottom.unwrap_or(0),
             sram_start,
             flash_end,
             flash_app_size,
@@ -1543,9 +1542,12 @@ impl<C: Chip> ProcessType for Process<'_, C> {
         self.print_memory_map(writer);
 
         self.stored_state.map(|stored_state| {
-            self.chip
-                .userspace_kernel_boundary()
-                .print_context(self.sp(), stored_state, writer);
+            self.chip.userspace_kernel_boundary().print_context(
+                self.memory.as_ptr(),
+                self.app_break.get(),
+                stored_state,
+                writer,
+            );
         });
 
         // Display the current state of the MPU for this process.
@@ -1595,8 +1597,6 @@ fn exceeded_check(size: usize, allocated: usize) -> &'static str {
 }
 
 impl<C: 'static + Chip> Process<'_, C> {
-    const INITIAL_APP_MEMORY_SIZE: usize = 3 * 1024;
-
     // Memory offset for callback ring buffer (10 element length).
     const CALLBACK_LEN: usize = 10;
     const CALLBACKS_OFFSET: usize = mem::size_of::<Task>() * Self::CALLBACK_LEN;
@@ -1667,7 +1667,7 @@ impl<C: 'static + Chip> Process<'_, C> {
         }
 
         // Otherwise, actually load the app.
-        let mut min_app_ram_size = tbf_header.get_minimum_app_ram_size() as usize;
+        let process_ram_requested_size = tbf_header.get_minimum_app_ram_size() as usize;
         let init_fn = app_flash
             .as_ptr()
             .offset(tbf_header.get_init_function_offset() as isize) as usize;
@@ -1707,18 +1707,38 @@ impl<C: 'static + Chip> Process<'_, C> {
         let grant_ptrs_num = kernel.get_grant_count_and_finalize();
         let grant_ptrs_offset = grant_ptrs_num * grant_ptr_size;
 
-        // Initial sizes of the app-owned and kernel-owned parts of process
-        // memory. Provide the app with plenty of initial process accessible
-        // memory.
+        // Initial size of the kernel-owned part of process memory can be
+        // calculated directly based on the initial size of all kernel-owned
+        // data structures.
         let initial_kernel_memory_size =
             grant_ptrs_offset + Self::CALLBACKS_OFFSET + Self::PROCESS_STRUCT_OFFSET;
 
-        if min_app_ram_size < Self::INITIAL_APP_MEMORY_SIZE {
-            min_app_ram_size = Self::INITIAL_APP_MEMORY_SIZE;
-        }
+        // By default we start with the initial size of process-accessible
+        // memory set to 0. This maximizes the flexibility that processes have
+        // to allocate their memory as they see fit. If a process needs more
+        // accessible memory it must use the `brk` memop syscalls to request more
+        // memory.
+        //
+        // We must take into account any process-accessible memory required by
+        // the context switching implementation and allocate at least that much
+        // memory so that we can successfully switch to the process. This is
+        // architecture and implementation specific, so we query that now.
+        let min_process_memory_size = chip
+            .userspace_kernel_boundary()
+            .initial_process_app_brk_size();
+
+        // We have to ensure that we at least ask the MPU for
+        // `min_process_memory_size` so that we can be sure that `app_brk` is
+        // not set inside the kernel-owned memory region. Now, in practice,
+        // processes should not request 0 (or very few) bytes of memory in their
+        // TBF header (i.e. `process_ram_requested_size` will almost always be
+        // much larger than `min_process_memory_size`), as they are unlikely to
+        // work with essentially no available memory. But, we still must protect
+        // for that case.
+        let min_process_ram_size = cmp::max(process_ram_requested_size, min_process_memory_size);
 
         // Minimum memory size for the process.
-        let min_total_memory_size = min_app_ram_size + initial_kernel_memory_size;
+        let min_total_memory_size = min_process_ram_size + initial_kernel_memory_size;
 
         // Check if this process requires a fixed memory start address. If so,
         // try to adjust the memory region to work for this process.
@@ -1771,7 +1791,7 @@ impl<C: 'static + Chip> Process<'_, C> {
             remaining_memory.as_ptr() as *const u8,
             remaining_memory.len(),
             min_total_memory_size,
-            Self::INITIAL_APP_MEMORY_SIZE,
+            min_process_memory_size,
             initial_kernel_memory_size,
             mpu::Permissions::ReadWriteOnly,
             &mut mpu_config,
@@ -1823,9 +1843,13 @@ impl<C: 'static + Chip> Process<'_, C> {
             }
         }
 
-        // Set the initial process stack and memory to 3072 bytes.
-        let initial_stack_pointer = app_memory.as_ptr().add(Self::INITIAL_APP_MEMORY_SIZE);
-        let initial_sbrk_pointer = app_memory.as_ptr().add(Self::INITIAL_APP_MEMORY_SIZE);
+        // Set the initial process-accessible memory to the amount specified by
+        // the context switch implementation.
+        let initial_sbrk_pointer = app_memory.as_ptr().add(min_process_memory_size);
+
+        // Set the initial allow high water mark to the start of process memory
+        // since no `allow` calls have been made yet.
+        let initial_allow_high_water_mark = app_memory.as_ptr();
 
         // Set up initial grant region.
         let mut kernel_memory_break = app_memory.as_mut_ptr().add(app_memory.len());
@@ -1872,14 +1896,6 @@ impl<C: 'static + Chip> Process<'_, C> {
         kernel_memory_break = kernel_memory_break.offset(-(Self::PROCESS_STRUCT_OFFSET as isize));
         let process_struct_memory_location = kernel_memory_break;
 
-        // Determine the debug information to the best of our understanding.
-        // Since processes have to do their own setup (allocating a stack and
-        // heap), we don't know much when the process is first created.
-        // Processes should use memop syscalls to inform the kernel of what
-        // these values are to help with debugging.
-        let app_heap_start_pointer = None;
-        let app_stack_start_pointer = None;
-
         // Create the Process struct in the app grant region.
         let mut process: &mut Process<C> =
             &mut *(process_struct_memory_location as *mut Process<'static, C>);
@@ -1898,16 +1914,11 @@ impl<C: 'static + Chip> Process<'_, C> {
             .set(AppId::new(kernel, unique_identifier, index));
         process.kernel = kernel;
         process.chip = chip;
-        process.allow_high_water_mark = Cell::new(app_memory.as_ptr());
-        process.original_allow_high_water_mark = app_memory.as_ptr();
+        process.allow_high_water_mark = Cell::new(initial_allow_high_water_mark);
         process.memory = app_memory;
         process.header = tbf_header;
         process.kernel_memory_break = Cell::new(kernel_memory_break);
-        process.original_kernel_memory_break = kernel_memory_break;
         process.app_break = Cell::new(initial_sbrk_pointer);
-        process.original_app_break = initial_sbrk_pointer;
-        process.current_stack_pointer = Cell::new(initial_stack_pointer);
-        process.original_stack_pointer = initial_stack_pointer;
 
         process.flash = app_flash;
 
@@ -1932,9 +1943,9 @@ impl<C: 'static + Chip> Process<'_, C> {
         process.debug = MapCell::new(ProcessDebug {
             fixed_address_flash: fixed_address_flash,
             fixed_address_ram: fixed_address_ram,
-            app_heap_start_pointer: app_heap_start_pointer,
-            app_stack_start_pointer: app_stack_start_pointer,
-            min_stack_pointer: initial_stack_pointer,
+            app_heap_start_pointer: None,
+            app_stack_start_pointer: None,
+            app_stack_min_pointer: None,
             syscall_count: 0,
             last_syscall: None,
             dropped_callback_count: 0,
@@ -1958,17 +1969,12 @@ impl<C: 'static + Chip> Process<'_, C> {
         // Handle any architecture-specific requirements for a new process
         match process.stored_state.map(|stored_state| {
             chip.userspace_kernel_boundary().initialize_process(
-                process.sp(),
-                process.sp() as usize - process.memory.as_ptr() as usize,
+                app_memory_start,
+                initial_sbrk_pointer,
                 stored_state,
             )
         }) {
-            Some(Ok(new_stack_pointer)) => {
-                process
-                    .current_stack_pointer
-                    .set(new_stack_pointer as *mut u8);
-                process.debug_set_max_stack_depth();
-            }
+            Some(Ok(())) => {}
             _ => {
                 if config::CONFIG.debug_load_processes {
                     debug!(
@@ -2057,6 +2063,8 @@ impl<C: 'static + Chip> Process<'_, C> {
             debug.timeslice_expiration_count = 0;
         });
 
+        // FLASH
+
         // We are going to start this process over again, so need the init_fn
         // location.
         let app_flash_address = self.flash_start();
@@ -2064,34 +2072,35 @@ impl<C: 'static + Chip> Process<'_, C> {
             app_flash_address.offset(self.header.get_init_function_offset() as isize) as usize
         };
 
-        // Reset memory pointers back to how they were when first calculated by
-        // the process create function. Since these are based on properties in
-        // the TBF header, and processes can't change the TBF header, it is fine
-        // to use saved values.
-        self.kernel_memory_break
-            .set(self.original_kernel_memory_break);
-        self.app_break.set(self.original_app_break);
-        self.current_stack_pointer.set(self.original_stack_pointer);
-        self.allow_high_water_mark
-            .set(self.original_allow_high_water_mark);
-
         // Reset MPU region configuration.
         // TODO: ideally, this would be moved into a helper function used by both
         // create() and reset(), but process load debugging complicates this.
         // We just want to create new config with only flash and memory regions.
         let mut mpu_config: <<C as Chip>::MPU as MPU>::MpuConfig = Default::default();
         // Allocate MPU region for flash.
-        let app_mpu_flash_success = self
+        let app_mpu_flash = self.chip.mpu().allocate_region(
+            self.flash.as_ptr(),
+            self.flash.len(),
+            self.flash.len(),
+            mpu::Permissions::ReadExecuteOnly,
+            &mut mpu_config,
+        );
+        if app_mpu_flash.is_none() {
+            // We were unable to allocate an MPU region for flash. This is very
+            // unexpected since we previously ran this process. However, we
+            // return now and leave the process faulted and it will not be
+            // scheduled.
+            return;
+        }
+
+        // RAM
+
+        // Re-determine the minimum amount of RAM the kernel must allocate to the process
+        // based on the specific requirements of the syscall implementation.
+        let min_process_memory_size = self
             .chip
-            .mpu()
-            .allocate_region(
-                self.flash.as_ptr(),
-                self.flash.len(),
-                self.flash.len(),
-                mpu::Permissions::ReadExecuteOnly,
-                &mut mpu_config,
-            )
-            .is_some();
+            .userspace_kernel_boundary()
+            .initial_process_app_brk_size();
 
         // Recalculate initial_kernel_memory_size as was done in create()
         let grant_ptr_size = mem::size_of::<*const usize>();
@@ -2101,48 +2110,57 @@ impl<C: 'static + Chip> Process<'_, C> {
         let initial_kernel_memory_size =
             grant_ptrs_offset + Self::CALLBACKS_OFFSET + Self::PROCESS_STRUCT_OFFSET;
 
-        let app_mpu_mem_success = self
-            .chip
-            .mpu()
-            .allocate_app_memory_region(
-                self.memory.as_ptr() as *const u8,
-                self.memory.len(),
-                self.memory.len(), //we want exactly as much as we had before restart
-                Self::INITIAL_APP_MEMORY_SIZE,
-                initial_kernel_memory_size,
-                mpu::Permissions::ReadWriteOnly,
-                &mut mpu_config,
-            )
-            .is_some();
-
-        // Drop the old config and use the clean one
-        self.mpu_config.replace(mpu_config);
-
-        match (app_mpu_flash_success, app_mpu_mem_success) {
-            (true, true) => {}
-            _ => {
+        let app_mpu_mem = self.chip.mpu().allocate_app_memory_region(
+            self.memory.as_ptr() as *const u8,
+            self.memory.len(),
+            self.memory.len(), //we want exactly as much as we had before restart
+            min_process_memory_size,
+            initial_kernel_memory_size,
+            mpu::Permissions::ReadWriteOnly,
+            &mut mpu_config,
+        );
+        let (app_mpu_mem_start, app_mpu_mem_len) = match app_mpu_mem {
+            Some((start, len)) => (start, len),
+            None => {
                 // We couldn't configure the MPU for the process. This shouldn't
                 // happen since we were able to start the process before, but at
                 // this point it is better to leave the app faulted and not
                 // schedule it.
                 return;
             }
-        }
+        };
+
+        // Reset memory pointers now that we know the layout of the process
+        // memory and know that we can configure the MPU.
+
+        // app_brk is set based on minimum syscall size above the start of
+        // memory.
+        let app_brk = app_mpu_mem_start.wrapping_add(min_process_memory_size);
+        self.app_break.set(app_brk);
+        // kernel_brk is calculated backwards from the end of memory the size of
+        // the initial kernel data structures.
+        let kernel_brk = app_mpu_mem_start
+            .wrapping_add(app_mpu_mem_len)
+            .wrapping_sub(initial_kernel_memory_size);
+        self.kernel_memory_break.set(kernel_brk);
+        // High water mark for `allow`ed memory is reset to the start of the
+        // process's memory region.
+        self.allow_high_water_mark.set(app_mpu_mem_start);
+
+        // Drop the old config and use the clean one
+        self.mpu_config.replace(mpu_config);
 
         // Handle any architecture-specific requirements for a process when it
         // first starts (as it would when it is new).
-        let new_stack_pointer_res = self.stored_state.map_or(Err(()), |stored_state| unsafe {
+        let ukb_init_process = self.stored_state.map_or(Err(()), |stored_state| unsafe {
             self.chip.userspace_kernel_boundary().initialize_process(
-                self.sp(),
-                self.sp() as usize - self.memory.as_ptr() as usize,
+                app_mpu_mem_start,
+                app_brk,
                 stored_state,
             )
         });
-        match new_stack_pointer_res {
-            Ok(new_stack_pointer) => {
-                self.current_stack_pointer.set(new_stack_pointer as *mut u8);
-                self.debug_set_max_stack_depth();
-            }
+        match ukb_init_process {
+            Ok(()) => {}
             Err(_) => {
                 // We couldn't initialize the architecture-specific
                 // state for this process. This shouldn't happen since
@@ -2208,19 +2226,6 @@ impl<C: 'static + Chip> Process<'_, C> {
         self.state.update(State::StoppedFaulted);
     }
 
-    /// Get the current stack pointer as a pointer.
-    // This is currently safe as the the userspace/kernel boundary
-    // implementations of both Risc-V and ARM would fault on context switch if
-    // the stack pointer were misaligned.
-    //
-    // This is a bit of an undocumented assumption, but not sure there is
-    // likely to be an architecture in the near future where this is
-    // realistically a risk.
-    #[allow(clippy::cast_ptr_alignment)]
-    fn sp(&self) -> *const usize {
-        self.current_stack_pointer.get() as *const usize
-    }
-
     /// Checks if the buffer represented by the passed in base pointer and size
     /// are within the memory bounds currently exposed to the processes (i.e.
     /// ending at `app_break`. If this method returns true, the buffer
@@ -2248,14 +2253,6 @@ impl<C: 'static + Chip> Process<'_, C> {
             let ctr_ptr = (self.mem_end() as *mut *mut usize).offset(-(grant_num + 1));
             write_volatile(ctr_ptr, ptr::null_mut());
         }
-    }
-
-    fn debug_set_max_stack_depth(&self) {
-        self.debug.map(|debug| {
-            if self.current_stack_pointer.get() < debug.min_stack_pointer {
-                debug.min_stack_pointer = self.current_stack_pointer.get();
-            }
-        });
     }
 
     /// Check if the process is active.

--- a/kernel/src/syscall.rs
+++ b/kernel/src/syscall.rs
@@ -175,14 +175,20 @@ pub trait UserspaceKernelBoundary {
 
     /// Context switch to a specific process.
     ///
-    /// This returns why the process stopped executing and switched back to the
-    /// kernel.
+    /// This returns two values in a tuple.
+    ///
+    /// 1. A `ContextSwitchReason` indicating why the process stopped executing
+    ///    and switched back to the kernel.
+    /// 2. Optionally, the current stack pointer used by the process. This is
+    ///    optional because it is only for debugging in process.rs. By sharing
+    ///    the process's stack pointer with process.rs users can inspect the
+    ///    state and see the stack depth, which might be useful for debugging.
     unsafe fn switch_to_process(
         &self,
         memory_start: *const u8,
         app_brk: *const u8,
         state: &mut Self::StoredState,
-    ) -> ContextSwitchReason;
+    ) -> (ContextSwitchReason, Option<*const u8>);
 
     /// Display architecture specific (e.g. CPU registers or status flags) data
     /// for a process identified by the stored state for that process.


### PR DESCRIPTION
### Pull Request Overview

Background: Because cortex-m architectures use the stack to pass service call state between privileged and user modes, and tock was originally written for the cortex-m4, the core kernel has historically tracked the stack pointer of each process so the kernel knows where the svc state is and can use it during context switches. When the UserlandKernelBoundary trait was added, it was not obvious that this is the only reason the kernel tracks the stack pointer, and it was not factored out.

With more experience with RISC-V syscalls, and more thinking about what the interface should be between userspace apps and the kernel, it's more clear now that the core kernel should not have any expectations about a process's stack pointer. Process-accessible memory should be entirely managed by that process, and process.rs has no need to track something like the stack pointer.

Additionally, since the kernel only knows what the process's stack pointer is from the process telling it, we need to do a better job of treating the stack pointer as untrusted state. That is, we should be verifying that it is in fact within a process's accessible RAM region before dereferencing the stack pointer.

#### This PR

This refactors process.rs to remove keeping track of the stack pointer in process.rs (with one exception). To do this, the UKB interface changes to require each function to take in the memory bounds of the process. If the UKB implementation wants/needs to use the stack it can keep track of the stack pointer in the syscall stored_state for the process. The cortex-m implementation now checks that the stack pointer is valid before using it, as well.

This also copies from #2370 to add a function to the UKB trait so that each architecture can inform the kernel of the minimum amount of RAM space the process needs to context switch to it the first time. However, unlike #2370, this PR is still 1.x compatible.

The exception is that for debugging the kernel will still keep track of the lowest it sees the stack pointer if the UKB implementation shares the new stack pointer. Again, this is only for debugging when `panic!()` runs.

Lastly, this PR refactors the restart() function a bit, making it closer to process.new(). That means we save less state when the process starts, and re-compute more when the process finishes.

This helps with #1769.

### Testing Strategy

This pull request was tested by running various apps on hail and nano33ble. I also tried restarting apps.


### TODO or Help Wanted

n/a


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
