### PR TITLE
Update I2C master/slave driver to 2.0 syscall API.

### DIFF
--- a/capsules/src/i2c_master_slave_driver.rs
+++ b/capsules/src/i2c_master_slave_driver.rs
@@ -15,8 +15,8 @@ use core::cell::Cell;
 use core::cmp;
 use kernel::common::cells::{MapCell, TakeCell};
 use kernel::hil;
-use kernel::ReturnCode;
-use kernel::{AppId, AppSlice, Callback, LegacyDriver, SharedReadWrite};
+use kernel::{AppId, Callback, CommandResult};
+use kernel::{Driver, ErrorCode, Read, ReadWrite, ReadWriteAppSlice};
 
 pub static mut BUFFER1: [u8; 256] = [0; 256];
 pub static mut BUFFER2: [u8; 256] = [0; 256];
@@ -28,11 +28,11 @@ pub const DRIVER_NUM: usize = driver::NUM::I2cMasterSlave as usize;
 
 #[derive(Default)]
 pub struct App {
-    callback: Option<Callback>,
-    master_tx_buffer: Option<AppSlice<SharedReadWrite, u8>>,
-    master_rx_buffer: Option<AppSlice<SharedReadWrite, u8>>,
-    slave_tx_buffer: Option<AppSlice<SharedReadWrite, u8>>,
-    slave_rx_buffer: Option<AppSlice<SharedReadWrite, u8>>,
+    callback: Callback,
+    master_tx_buffer: ReadWriteAppSlice,
+    master_rx_buffer: ReadWriteAppSlice, 
+    slave_tx_buffer: ReadWriteAppSlice, 
+    slave_rx_buffer: ReadWriteAppSlice,
 }
 
 #[derive(Clone, Copy, PartialEq)]
@@ -90,41 +90,36 @@ impl hil::i2c::I2CHwMasterClient for I2CMasterSlaveDriver<'_> {
                 self.master_buffer.replace(buffer);
 
                 self.app.map(|app| {
-                    app.callback.map(|mut cb| {
-                        cb.schedule(0, err as usize, 0);
-                    });
+                    app.callback.schedule(0, err as usize, 0);
                 });
             }
 
             MasterAction::Read(read_len) => {
                 self.app.map(|app| {
-                    app.master_rx_buffer.as_mut().map(move |app_buffer| {
+                    app.master_rx_buffer.mut_map_or(0, move |app_buffer| {
                         let len = cmp::min(app_buffer.len(), read_len as usize);
 
-                        let d = &mut app_buffer.as_mut()[0..(len as usize)];
                         for (i, c) in buffer[0..len].iter().enumerate() {
-                            d[i] = *c;
+                            app_buffer[i] = *c;
                         }
 
                         self.master_buffer.replace(buffer);
+                        0
                     });
 
-                    app.callback.map(|mut cb| {
-                        cb.schedule(1, err as usize, 0);
-                    });
+                    app.callback.schedule(1, err as usize, 0);
                 });
             }
 
             MasterAction::WriteRead(read_len) => {
                 self.app.map(|app| {
-                    app.master_tx_buffer.as_mut().map(move |app_buffer| {
+                    app.master_tx_buffer.mut_map_or(0, move |app_buffer| {
                         let len = cmp::min(app_buffer.len(), read_len as usize);
                         app_buffer.as_mut()[..len].copy_from_slice(&buffer[..len]);
                         self.master_buffer.replace(buffer);
+                        0
                     });
-                    app.callback.map(|mut cb| {
-                        cb.schedule(7, err as usize, 0);
-                    });
+                    app.callback.schedule(7, err as usize, 0);
                 });
             }
         }
@@ -150,26 +145,23 @@ impl hil::i2c::I2CHwSlaveClient for I2CMasterSlaveDriver<'_> {
         //     then pass buffer back to hw driver
         //   - on read, just signal upper layer and replace the read buffer
         //     in this driver
-
         match transmission_type {
             hil::i2c::SlaveTransmissionType::Write => {
                 self.app.map(|app| {
-                    app.slave_rx_buffer.as_mut().map(move |app_rx| {
+                    app.slave_rx_buffer.mut_map_or(0, move |app_rx| {
                         // Check bounds for write length
                         let buf_len = cmp::min(app_rx.len(), buffer.len());
                         let read_len = cmp::min(buf_len, length as usize);
 
-                        let d = &mut app_rx.as_mut()[0..read_len];
                         for (i, c) in buffer[0..read_len].iter_mut().enumerate() {
-                            d[i] = *c;
+                            app_rx[i] = *c;
                         }
 
                         self.slave_buffer1.replace(buffer);
+                        0
                     });
 
-                    app.callback.map(|mut cb| {
-                        cb.schedule(3, length as usize, 0);
-                    });
+                    app.callback.schedule(3, length as usize, 0);
                 });
             }
 
@@ -178,9 +170,7 @@ impl hil::i2c::I2CHwSlaveClient for I2CMasterSlaveDriver<'_> {
 
                 // Notify the app that the read finished
                 self.app.map(|app| {
-                    app.callback.map(|mut cb| {
-                        cb.schedule(4, length as usize, 0);
-                    });
+                    app.callback.schedule(4, length as usize, 0);
                 });
             }
         }
@@ -190,12 +180,10 @@ impl hil::i2c::I2CHwSlaveClient for I2CMasterSlaveDriver<'_> {
         // Pass this up to the client. Not much we can do until the application
         // has setup a buffer to read from.
         self.app.map(|app| {
-            app.callback.map(|mut cb| {
-                // Ask the app to setup a read buffer. The app must call
-                // command 3 after it has setup the shared read buffer with
-                // the correct bytes.
-                cb.schedule(2, 0, 0);
-            });
+            // Ask the app to setup a read buffer. The app must call
+            // command 3 after it has setup the shared read buffer with
+            // the correct bytes.
+            app.callback.schedule(2, 0, 0);
         });
     }
 
@@ -210,69 +198,69 @@ impl hil::i2c::I2CHwSlaveClient for I2CMasterSlaveDriver<'_> {
     }
 }
 
-impl LegacyDriver for I2CMasterSlaveDriver<'_> {
+impl Driver for I2CMasterSlaveDriver<'_> {
     fn allow_readwrite(
         &self,
         _appid: AppId,
         allow_num: usize,
-        slice: Option<AppSlice<SharedReadWrite, u8>>,
-    ) -> ReturnCode {
+        mut slice: ReadWriteAppSlice, 
+    ) -> Result<ReadWriteAppSlice, (ReadWriteAppSlice, ErrorCode)> {
         match allow_num {
             // Pass in a buffer for transmitting a `write` to another
             // I2C device.
             0 => {
                 self.app.map(|app| {
-                    app.master_tx_buffer = slice;
+                    core::mem::swap(&mut app.master_tx_buffer, &mut slice);
                 });
-                ReturnCode::SUCCESS
+                Ok(slice)
             }
             // Pass in a buffer for doing a read from another I2C device.
             1 => {
                 self.app.map(|app| {
-                    app.master_rx_buffer = slice;
+                    core::mem::swap(&mut app.master_rx_buffer, &mut slice);
                 });
-                ReturnCode::SUCCESS
+                Ok(slice)
             }
             // Pass in a buffer for handling a read issued by another I2C master.
             2 => {
                 self.app.map(|app| {
-                    app.slave_tx_buffer = slice;
+                    core::mem::swap(&mut app.slave_tx_buffer, &mut slice);
                 });
-                ReturnCode::SUCCESS
+                Ok(slice)
             }
             // Pass in a buffer for handling a write issued by another I2C master.
             3 => {
                 self.app.map(|app| {
-                    app.slave_rx_buffer = slice;
+                    core::mem::swap(&mut app.slave_rx_buffer, &mut slice);
                 });
-                ReturnCode::SUCCESS
+                Ok(slice)
             }
-            _ => ReturnCode::ENOSUPPORT,
+            _ => Err((slice, ErrorCode::NOSUPPORT))
         }
     }
 
     fn subscribe(
         &self,
         subscribe_num: usize,
-        callback: Option<Callback>,
+        mut callback: Callback,
         _app_id: AppId,
-    ) -> ReturnCode {
+    ) -> Result<Callback, (Callback, ErrorCode)> {
         match subscribe_num {
             0 => {
                 self.app.map(|app| {
-                    app.callback = callback;
+                    core::mem::swap(&mut app.callback, &mut callback);
                 });
-                ReturnCode::SUCCESS
-            }
+                Ok(callback)
+            },
 
             // default
-            _ => ReturnCode::ENOSUPPORT,
+            _ => Err((callback, ErrorCode::NOSUPPORT))
         }
     }
 
-    fn command(&self, command_num: usize, data: usize, _: usize, _: AppId) -> ReturnCode {
+    fn command(&self, command_num: usize, data: usize, _: usize, _: AppId) -> CommandResult {
         match command_num {
-            0 /* check if present */ => ReturnCode::SUCCESS,
+            0 /* check if present */ => CommandResult::success(),
 
             // Do a write to another I2C device
             1 => {
@@ -280,15 +268,14 @@ impl LegacyDriver for I2CMasterSlaveDriver<'_> {
                 let len = (data >> 16) & 0xFFFF;
 
                 self.app.map(|app| {
-                    app.master_tx_buffer.as_mut().map(|app_tx| {
+                    app.master_tx_buffer.mut_map_or(0, |app_tx| {
                         self.master_buffer.take().map(|kernel_tx| {
                             // Check bounds for write length
                             let buf_len = cmp::min(app_tx.len(), kernel_tx.len());
                             let write_len = cmp::min(buf_len, len);
 
-                            let d = &mut app_tx.as_mut()[0..write_len];
                             for (i, c) in kernel_tx[0..write_len].iter_mut().enumerate() {
-                                *c = d[i];
+                                *c = app_tx[i];
                             }
 
                             self.master_action.set(MasterAction::Write);
@@ -299,10 +286,11 @@ impl LegacyDriver for I2CMasterSlaveDriver<'_> {
                                                        kernel_tx,
                                                        write_len as u8);
                         });
+                        0
                     });
                 });
 
-                ReturnCode::SUCCESS
+                CommandResult::success()
             }
 
             // Do a read to another I2C device
@@ -311,15 +299,14 @@ impl LegacyDriver for I2CMasterSlaveDriver<'_> {
                 let len = (data >> 16) & 0xFFFF;
 
                 self.app.map(|app| {
-                    app.master_rx_buffer.as_mut().map(|app_rx| {
+                    app.master_rx_buffer.map_or(0, |app_rx| {
                         self.master_buffer.take().map(|kernel_tx| {
                             // Check bounds for write length
                             let buf_len = cmp::min(app_rx.len(), kernel_tx.len());
                             let read_len = cmp::min(buf_len, len);
 
-                            let d = &mut app_rx.as_mut()[0..read_len];
                             for (i, c) in kernel_tx[0..read_len].iter_mut().enumerate() {
-                                *c = d[i];
+                                *c = app_rx[i];
                             }
 
                             self.master_action.set(MasterAction::Read(read_len as u8));
@@ -327,10 +314,11 @@ impl LegacyDriver for I2CMasterSlaveDriver<'_> {
                             hil::i2c::I2CMaster::enable(self.i2c);
                             hil::i2c::I2CMaster::read(self.i2c, address, kernel_tx, read_len as u8);
                         });
+                        0
                     });
                 });
 
-                ReturnCode::SUCCESS
+                CommandResult::success()
             }
 
             // Listen for messages to this device as a slave.
@@ -348,31 +336,31 @@ impl LegacyDriver for I2CMasterSlaveDriver<'_> {
                 // Note that we have enabled listening, so that if we switch
                 // to Master mode to send a message we can go back to listening.
                 self.listening.set(true);
-                ReturnCode::SUCCESS
+                CommandResult::success()
             }
 
             // Prepare for a read from another Master by passing what's
             // in the shared slice to the lower level I2C hardware driver.
             4 => {
                 self.app.map(|app| {
-                    app.slave_tx_buffer.as_mut().map(|app_tx| {
+                    app.slave_tx_buffer.map_or(0, |app_tx| {
                         self.slave_buffer2.take().map(|kernel_tx| {
                             // Check bounds for write length
                             let len = data;
                             let buf_len = cmp::min(app_tx.len(), kernel_tx.len());
                             let read_len = cmp::min(buf_len, len);
 
-                            let d = &mut app_tx.as_mut()[0..read_len];
                             for (i, c) in kernel_tx[0..read_len].iter_mut().enumerate() {
-                                *c = d[i];
+                                *c = app_tx[i];
                             }
 
                             hil::i2c::I2CSlave::read_send(self.i2c, kernel_tx, read_len as u8);
                         });
+                        0
                     });
                 });
 
-                ReturnCode::SUCCESS
+                CommandResult::success()
             }
 
             // Stop listening for messages as an I2C slave
@@ -382,7 +370,7 @@ impl LegacyDriver for I2CMasterSlaveDriver<'_> {
                 // We are no longer listening for I2C messages from a different
                 // master device.
                 self.listening.set(false);
-                ReturnCode::SUCCESS
+                CommandResult::success()
             }
 
             // Setup this device's slave address.
@@ -391,10 +379,10 @@ impl LegacyDriver for I2CMasterSlaveDriver<'_> {
                 // We do not count the R/W bit as part of the address, so the
                 // valid range is 0x00-0x7f
                 if address > 0x7f {
-                    return ReturnCode::EINVAL;
+                    return CommandResult::failure(ErrorCode::INVAL);
                 }
                 hil::i2c::I2CSlave::set_address(self.i2c, address);
-                ReturnCode::SUCCESS
+                CommandResult::success()
             }
 
             // Perform write-to then read-from a slave device.
@@ -404,13 +392,13 @@ impl LegacyDriver for I2CMasterSlaveDriver<'_> {
                 let read_len = (data >> 8) & 0xFF;
                 let write_len = (data >> 16) & 0xFF;
                 self.app.map(|app| {
-                    app.master_tx_buffer.as_mut().map(|app_tx| {
+                    app.master_tx_buffer.mut_map_or(0, |app_tx| {
                         self.master_buffer.take().map(|kernel_tx| {
                             // Check bounds for write length
                             let buf_len = cmp::min(app_tx.len(), kernel_tx.len());
                             let write_len = cmp::min(buf_len, write_len);
                             let read_len = cmp::min(buf_len, read_len);
-                            kernel_tx[..write_len].copy_from_slice(&app_tx.as_ref()[..write_len]);
+                            kernel_tx[..write_len].copy_from_slice(&app_tx[..write_len]);
                             self.master_action.set(MasterAction::WriteRead(read_len as u8));
                             hil::i2c::I2CMaster::enable(self.i2c);
                             hil::i2c::I2CMaster::write_read(self.i2c,
@@ -419,13 +407,14 @@ impl LegacyDriver for I2CMasterSlaveDriver<'_> {
                                                             write_len as u8,
                                                             read_len as u8);
                         });
+                        0
                     });
                 });
-                ReturnCode::SUCCESS
+                CommandResult::success()
             }
 
             // default
-            _ => ReturnCode::ENOSUPPORT,
+            _ => CommandResult::failure(ErrorCode::NOSUPPORT)
         }
     }
 }

--- a/capsules/src/i2c_master_slave_driver.rs
+++ b/capsules/src/i2c_master_slave_driver.rs
@@ -30,8 +30,8 @@ pub const DRIVER_NUM: usize = driver::NUM::I2cMasterSlave as usize;
 pub struct App {
     callback: Callback,
     master_tx_buffer: ReadWriteAppSlice,
-    master_rx_buffer: ReadWriteAppSlice, 
-    slave_tx_buffer: ReadWriteAppSlice, 
+    master_rx_buffer: ReadWriteAppSlice,
+    slave_tx_buffer: ReadWriteAppSlice,
     slave_rx_buffer: ReadWriteAppSlice,
 }
 
@@ -203,7 +203,7 @@ impl Driver for I2CMasterSlaveDriver<'_> {
         &self,
         _appid: AppId,
         allow_num: usize,
-        mut slice: ReadWriteAppSlice, 
+        mut slice: ReadWriteAppSlice,
     ) -> Result<ReadWriteAppSlice, (ReadWriteAppSlice, ErrorCode)> {
         match allow_num {
             // Pass in a buffer for transmitting a `write` to another
@@ -235,7 +235,7 @@ impl Driver for I2CMasterSlaveDriver<'_> {
                 });
                 Ok(slice)
             }
-            _ => Err((slice, ErrorCode::NOSUPPORT))
+            _ => Err((slice, ErrorCode::NOSUPPORT)),
         }
     }
 
@@ -251,10 +251,10 @@ impl Driver for I2CMasterSlaveDriver<'_> {
                     core::mem::swap(&mut app.callback, &mut callback);
                 });
                 Ok(callback)
-            },
+            }
 
             // default
-            _ => Err((callback, ErrorCode::NOSUPPORT))
+            _ => Err((callback, ErrorCode::NOSUPPORT)),
         }
     }
 


### PR DESCRIPTION
### Pull Request Overview

This pull request  updates the `i2c_master_slave_driver` capsule to  the 2.0 syscall API. It does not work on the tock-2.0-dev branch currently because of #2380 . When tested with #2380 it works. Given that the libtock-c API was using the wrong driver ID, I suspect this is not a critical system call driver (it only works on imix and isn't loaded by default), so we can merge this now and later merge in master/#2380.  


### Testing Strategy

This pull request was tested by changing the imix reset handler to use this driver on I2C1 and running the `i2c_master_slave_ping_pong` test with two imix. It works.


### TODO or Help Wanted

Nothing.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
