### PR TITLE
Transition I2CMaster system call driver to 2.0 syscall API

### DIFF
--- a/boards/earlgrey-nexysvideo/src/main.rs
+++ b/boards/earlgrey-nexysvideo/src/main.rs
@@ -75,7 +75,7 @@ struct EarlGreyNexysVideo {
         'static,
         capsules::virtual_uart::UartDevice<'static>,
     >,
-    i2c_master: &'static capsules::i2c_master::I2CMasterDriver<lowrisc::i2c::I2c<'static>>,
+    i2c_master: &'static capsules::i2c_master::I2CMasterDriver<'static>,
     nonvolatile_storage: &'static capsules::nonvolatile_storage_driver::NonvolatileStorage<'static>,
 }
 
@@ -254,7 +254,7 @@ pub unsafe fn reset_handler() {
     ));
 
     let i2c_master = static_init!(
-        capsules::i2c_master::I2CMasterDriver<lowrisc::i2c::I2c<'static>>,
+        capsules::i2c_master::I2CMasterDriver<'static>,
         capsules::i2c_master::I2CMasterDriver::new(
             &peripherals.i2c,
             &mut capsules::i2c_master::BUF,

--- a/boards/earlgrey-nexysvideo/src/main.rs
+++ b/boards/earlgrey-nexysvideo/src/main.rs
@@ -75,7 +75,7 @@ struct EarlGreyNexysVideo {
         'static,
         capsules::virtual_uart::UartDevice<'static>,
     >,
-    i2c_master: &'static capsules::i2c_master::I2CMasterDriver<'static>,
+    i2c_master: &'static capsules::i2c_master::I2CMasterDriver<'static, lowrisc::i2c::I2c<'static>>,
     nonvolatile_storage: &'static capsules::nonvolatile_storage_driver::NonvolatileStorage<'static>,
 }
 
@@ -254,7 +254,7 @@ pub unsafe fn reset_handler() {
     ));
 
     let i2c_master = static_init!(
-        capsules::i2c_master::I2CMasterDriver<'static>,
+        capsules::i2c_master::I2CMasterDriver<'static, lowrisc::i2c::I2c<'static>>,
         capsules::i2c_master::I2CMasterDriver::new(
             &peripherals.i2c,
             &mut capsules::i2c_master::BUF,

--- a/boards/redboard_artemis_nano/src/main.rs
+++ b/boards/redboard_artemis_nano/src/main.rs
@@ -57,7 +57,7 @@ struct RedboardArtemisNano {
     >,
     gpio: &'static capsules::gpio::GPIO<'static, apollo3::gpio::GpioPin<'static>>,
     console: &'static capsules::console::Console<'static>,
-    i2c_master: &'static capsules::i2c_master::I2CMasterDriver<'static>,
+    i2c_master: &'static capsules::i2c_master::I2CMasterDriver<'static, apollo3::iom::Iom<'static>>,
     ble_radio: &'static capsules::ble_advertising_driver::BLE<
         'static,
         apollo3::ble::Ble<'static>,
@@ -185,7 +185,7 @@ pub unsafe fn reset_handler() {
 
     // Init the I2C device attached via Qwiic
     let i2c_master = static_init!(
-        capsules::i2c_master::I2CMasterDriver<'static>,
+        capsules::i2c_master::I2CMasterDriver<'static, apollo3::iom::Iom<'static>>,
         capsules::i2c_master::I2CMasterDriver::new(
             &peripherals.iom2,
             &mut capsules::i2c_master::BUF,

--- a/boards/redboard_artemis_nano/src/main.rs
+++ b/boards/redboard_artemis_nano/src/main.rs
@@ -57,7 +57,7 @@ struct RedboardArtemisNano {
     >,
     gpio: &'static capsules::gpio::GPIO<'static, apollo3::gpio::GpioPin<'static>>,
     console: &'static capsules::console::Console<'static>,
-    i2c_master: &'static capsules::i2c_master::I2CMasterDriver<apollo3::iom::Iom<'static>>,
+    i2c_master: &'static capsules::i2c_master::I2CMasterDriver<'static>,
     ble_radio: &'static capsules::ble_advertising_driver::BLE<
         'static,
         apollo3::ble::Ble<'static>,
@@ -185,7 +185,7 @@ pub unsafe fn reset_handler() {
 
     // Init the I2C device attached via Qwiic
     let i2c_master = static_init!(
-        capsules::i2c_master::I2CMasterDriver<apollo3::iom::Iom<'static>>,
+        capsules::i2c_master::I2CMasterDriver<'static>,
         capsules::i2c_master::I2CMasterDriver::new(
             &peripherals.iom2,
             &mut capsules::i2c_master::BUF,

--- a/capsules/src/i2c_master.rs
+++ b/capsules/src/i2c_master.rs
@@ -35,7 +35,11 @@ pub struct I2CMasterDriver<'a> {
 }
 
 impl<'a> I2CMasterDriver<'a> {
-    pub fn new(i2c: &'a dyn i2c::I2CMaster, buf: &'static mut [u8], apps: Grant<App>) -> I2CMasterDriver<'a> {
+    pub fn new(
+        i2c: &'a dyn i2c::I2CMaster,
+        buf: &'static mut [u8],
+        apps: Grant<App>,
+    ) -> I2CMasterDriver<'a> {
         I2CMasterDriver {
             i2c,
             buf: TakeCell::new(buf),

--- a/capsules/src/i2c_master.rs
+++ b/capsules/src/i2c_master.rs
@@ -27,15 +27,15 @@ struct Transaction {
     read_len: OptionalCell<usize>,
 }
 
-pub struct I2CMasterDriver<I: 'static + i2c::I2CMaster> {
-    i2c: &'static I,
+pub struct I2CMasterDriver<'a> {
+    i2c: &'a dyn i2c::I2CMaster,
     buf: TakeCell<'static, [u8]>,
     tx: MapCell<Transaction>,
     apps: Grant<App>,
 }
 
-impl<I: 'static + i2c::I2CMaster> I2CMasterDriver<I> {
-    pub fn new(i2c: &'static I, buf: &'static mut [u8], apps: Grant<App>) -> I2CMasterDriver<I> {
+impl<'a> I2CMasterDriver<'a> {
+    pub fn new(i2c: &'a dyn i2c::I2CMaster, buf: &'static mut [u8], apps: Grant<App>) -> I2CMasterDriver<'a> {
         I2CMasterDriver {
             i2c,
             buf: TakeCell::new(buf),
@@ -91,7 +91,7 @@ pub enum Cmd {
 }
 }
 
-impl<I: i2c::I2CMaster> Driver for I2CMasterDriver<I> {
+impl<'a> Driver for I2CMasterDriver<'a> {
     /// Setup shared buffers.
     ///
     /// ### `allow_num`
@@ -193,7 +193,7 @@ impl<I: i2c::I2CMaster> Driver for I2CMasterDriver<I> {
     }
 }
 
-impl<I: i2c::I2CMaster> i2c::I2CHwMasterClient for I2CMasterDriver<I> {
+impl<'a> i2c::I2CHwMasterClient for I2CMasterDriver<'a> {
     fn command_complete(&self, buffer: &'static mut [u8], _error: i2c::Error) {
         self.tx.take().map(|tx| {
             self.apps.enter(tx.app_id, |app, _| {

--- a/capsules/src/i2c_master.rs
+++ b/capsules/src/i2c_master.rs
@@ -35,11 +35,7 @@ pub struct I2CMasterDriver<'a, I: 'a + i2c::I2CMaster> {
 }
 
 impl<'a, I: 'a + i2c::I2CMaster> I2CMasterDriver<'a, I> {
-    pub fn new(
-        i2c: &'a I,
-        buf: &'static mut [u8],
-        apps: Grant<App>,
-    ) -> I2CMasterDriver<'a, I> {
+    pub fn new(i2c: &'a I, buf: &'static mut [u8], apps: Grant<App>) -> I2CMasterDriver<'a, I> {
         I2CMasterDriver {
             i2c,
             buf: TakeCell::new(buf),
@@ -197,7 +193,7 @@ impl<'a, I: 'a + i2c::I2CMaster> Driver for I2CMasterDriver<'a, I> {
     }
 }
 
-impl<'a, I: 'a+ i2c::I2CMaster> i2c::I2CHwMasterClient for I2CMasterDriver<'a, I> {
+impl<'a, I: 'a + i2c::I2CMaster> i2c::I2CHwMasterClient for I2CMasterDriver<'a, I> {
     fn command_complete(&self, buffer: &'static mut [u8], _error: i2c::Error) {
         self.tx.take().map(|tx| {
             self.apps.enter(tx.app_id, |app, _| {

--- a/capsules/src/i2c_master.rs
+++ b/capsules/src/i2c_master.rs
@@ -27,19 +27,19 @@ struct Transaction {
     read_len: OptionalCell<usize>,
 }
 
-pub struct I2CMasterDriver<'a> {
-    i2c: &'a dyn i2c::I2CMaster,
+pub struct I2CMasterDriver<'a, I: 'a + i2c::I2CMaster> {
+    i2c: &'a I,
     buf: TakeCell<'static, [u8]>,
     tx: MapCell<Transaction>,
     apps: Grant<App>,
 }
 
-impl<'a> I2CMasterDriver<'a> {
+impl<'a, I: 'a + i2c::I2CMaster> I2CMasterDriver<'a, I> {
     pub fn new(
-        i2c: &'a dyn i2c::I2CMaster,
+        i2c: &'a I,
         buf: &'static mut [u8],
         apps: Grant<App>,
-    ) -> I2CMasterDriver<'a> {
+    ) -> I2CMasterDriver<'a, I> {
         I2CMasterDriver {
             i2c,
             buf: TakeCell::new(buf),
@@ -95,7 +95,7 @@ pub enum Cmd {
 }
 }
 
-impl<'a> Driver for I2CMasterDriver<'a> {
+impl<'a, I: 'a + i2c::I2CMaster> Driver for I2CMasterDriver<'a, I> {
     /// Setup shared buffers.
     ///
     /// ### `allow_num`
@@ -197,7 +197,7 @@ impl<'a> Driver for I2CMasterDriver<'a> {
     }
 }
 
-impl<'a> i2c::I2CHwMasterClient for I2CMasterDriver<'a> {
+impl<'a, I: 'a+ i2c::I2CMaster> i2c::I2CHwMasterClient for I2CMasterDriver<'a, I> {
     fn command_complete(&self, buffer: &'static mut [u8], _error: i2c::Error) {
         self.tx.take().map(|tx| {
             self.apps.enter(tx.app_id, |app, _| {


### PR DESCRIPTION
### Pull Request Overview

This pull request adds pulls I2CMaster fully into the Tock 2.0 syscall API, also removing its dependence on an I2C by making it a `dyn I2CMaster` reference (in line with more modern capsule designs).

### Testing Strategy

This pull request was tested by adding support in libtock-c, writing a test application, and testing it along with a slave in the Master/Slave test app.


### TODO or Help Wanted

Nothing.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.