### PR TITLE
MSP432 I2C driver

### DIFF
--- a/chips/msp432/src/chip.rs
+++ b/chips/msp432/src/chip.rs
@@ -41,7 +41,7 @@ impl<'a> Msp432DefaultPeripherals<'a> {
             timer_a2: crate::timer::TimerA::new(crate::timer::TIMER_A2_BASE),
             timer_a3: crate::timer::TimerA::new(crate::timer::TIMER_A3_BASE),
             gpio: crate::gpio::GpioManager::new(),
-            i2c0: crate::i2c::I2c::new(crate::usci::USCI_B1_BASE, 2, 3, 2, 2),
+            i2c0: crate::i2c::I2c::new(crate::usci::USCI_B0_BASE),
         }
     }
 
@@ -61,14 +61,6 @@ impl<'a> Msp432DefaultPeripherals<'a> {
             &self.dma_channels[self.adc.dma_chan],
         );
         self.dma_channels[self.adc.dma_chan].set_client(&self.adc);
-
-        // Setup DMA channels for the I2C
-        self.i2c0.set_dma(
-            &self.dma_channels[self.i2c0.tx_dma_chan],
-            &self.dma_channels[self.i2c0.rx_dma_chan],
-        );
-        self.dma_channels[self.i2c0.tx_dma_chan].set_client(&self.i2c0);
-        self.dma_channels[self.i2c0.rx_dma_chan].set_client(&self.i2c0);
     }
 }
 
@@ -92,7 +84,6 @@ impl<'a> kernel::InterruptService<()> for Msp432DefaultPeripherals<'a> {
             nvic::TIMER_A2_0 | nvic::TIMER_A2_1 => self.timer_a2.handle_interrupt(),
             nvic::TIMER_A3_0 | nvic::TIMER_A3_1 => self.timer_a3.handle_interrupt(),
             nvic::USCI_B0 => self.i2c0.handle_interrupt(),
-
             _ => return false,
         }
         true

--- a/chips/msp432/src/chip.rs
+++ b/chips/msp432/src/chip.rs
@@ -25,6 +25,7 @@ pub struct Msp432DefaultPeripherals<'a> {
     pub timer_a2: crate::timer::TimerA<'a>,
     pub timer_a3: crate::timer::TimerA<'a>,
     pub gpio: crate::gpio::GpioManager<'a>,
+    pub i2c0: crate::i2c::I2c<'a>,
 }
 
 impl<'a> Msp432DefaultPeripherals<'a> {
@@ -40,11 +41,12 @@ impl<'a> Msp432DefaultPeripherals<'a> {
             timer_a2: crate::timer::TimerA::new(crate::timer::TIMER_A2_BASE),
             timer_a3: crate::timer::TimerA::new(crate::timer::TIMER_A3_BASE),
             gpio: crate::gpio::GpioManager::new(),
+            i2c0: crate::i2c::I2c::new(crate::usci::USCI_B1_BASE, 2, 3, 2, 2),
         }
     }
 
     pub unsafe fn init(&'a self) {
-        // Setup DMA channels
+        // Setup DMA channels for the UART
         self.uart0.set_dma(
             &self.dma_channels[self.uart0.tx_dma_chan],
             &self.dma_channels[self.uart0.rx_dma_chan],
@@ -59,6 +61,14 @@ impl<'a> Msp432DefaultPeripherals<'a> {
             &self.dma_channels[self.adc.dma_chan],
         );
         self.dma_channels[self.adc.dma_chan].set_client(&self.adc);
+
+        // Setup DMA channels for the I2C
+        self.i2c0.set_dma(
+            &self.dma_channels[self.i2c0.tx_dma_chan],
+            &self.dma_channels[self.i2c0.rx_dma_chan],
+        );
+        self.dma_channels[self.i2c0.tx_dma_chan].set_client(&self.i2c0);
+        self.dma_channels[self.i2c0.rx_dma_chan].set_client(&self.i2c0);
     }
 }
 
@@ -81,6 +91,7 @@ impl<'a> kernel::InterruptService<()> for Msp432DefaultPeripherals<'a> {
             nvic::TIMER_A1_0 | nvic::TIMER_A1_1 => self.timer_a1.handle_interrupt(),
             nvic::TIMER_A2_0 | nvic::TIMER_A2_1 => self.timer_a2.handle_interrupt(),
             nvic::TIMER_A3_0 | nvic::TIMER_A3_1 => self.timer_a3.handle_interrupt(),
+            nvic::USCI_B0 => self.i2c0.handle_interrupt(),
 
             _ => return false,
         }

--- a/chips/msp432/src/i2c.rs
+++ b/chips/msp432/src/i2c.rs
@@ -1,0 +1,371 @@
+use crate::dma;
+use crate::usci::{self, UsciBRegisters};
+use core::cell::Cell;
+use kernel::common::cells::OptionalCell;
+use kernel::common::peripherals::{PeripheralManagement, PeripheralManager};
+use kernel::common::registers::{ReadOnly, ReadWrite};
+use kernel::common::StaticRef;
+use kernel::hil::i2c;
+use kernel::NoClockControl;
+use kernel::ReturnCode;
+
+#[derive(Copy, Clone, PartialEq)]
+pub enum Speed {
+    K100, // 100kHz
+    K375, // 375kHz
+}
+
+#[derive(Copy, Clone, PartialEq)]
+enum OperatingMode {
+    Idle,
+    Write,
+    Read,
+    WriteRead,
+}
+
+pub struct I2c<'a> {
+    registers: StaticRef<UsciBRegisters>,
+    mode: Cell<OperatingMode>,
+    read_len: Cell<u8>,
+    master_client: OptionalCell<&'a dyn i2c::I2CHwMasterClient>,
+
+    tx_dma: OptionalCell<&'a dma::DmaChannel<'a>>,
+    pub(crate) tx_dma_chan: usize,
+    tx_dma_src: u8,
+
+    rx_dma: OptionalCell<&'a dma::DmaChannel<'a>>,
+    pub(crate) rx_dma_chan: usize,
+    rx_dma_src: u8,
+}
+
+type I2cRegisterManager<'a> = PeripheralManager<'a, I2c<'a>, NoClockControl>;
+
+impl<'a> PeripheralManagement<NoClockControl> for I2c<'a> {
+    type RegisterType = UsciBRegisters;
+
+    fn get_registers(&self) -> &Self::RegisterType {
+        &self.registers
+    }
+
+    fn get_clock(&self) -> &NoClockControl {
+        unsafe { &kernel::NO_CLOCK_CONTROL }
+    }
+
+    fn before_peripheral_access(&self, _c: &NoClockControl, r: &Self::RegisterType) {
+        // Set USCI module to reset in order to make a proper configuration possible
+        r.ctlw0.modify(usci::UCBxCTLW0::UCSWRST::SET);
+    }
+
+    fn after_peripheral_access(&self, _c: &NoClockControl, r: &Self::RegisterType) {
+        // Set USCI module to reset in order to make a proper configuration possible
+        r.ctlw0.modify(usci::UCBxCTLW0::UCSWRST::CLEAR);
+    }
+}
+
+impl<'a> I2c<'a> {
+    pub const fn new(
+        registers: StaticRef<UsciBRegisters>,
+        tx_dma_chan: usize,
+        rx_dma_chan: usize,
+        tx_dma_src: u8,
+        rx_dma_src: u8,
+    ) -> Self {
+        Self {
+            registers: registers,
+            mode: Cell::new(OperatingMode::Idle),
+            read_len: Cell::new(0),
+            master_client: OptionalCell::empty(),
+            tx_dma: OptionalCell::empty(),
+            tx_dma_chan: tx_dma_chan,
+            tx_dma_src: tx_dma_src,
+            rx_dma: OptionalCell::empty(),
+            rx_dma_chan: rx_dma_chan,
+            rx_dma_src: rx_dma_src,
+        }
+    }
+
+    pub fn set_dma(&self, tx_dma: &'a dma::DmaChannel<'a>, rx_dma: &'a dma::DmaChannel<'a>) {
+        self.tx_dma.replace(tx_dma);
+        self.rx_dma.replace(rx_dma);
+    }
+
+    pub fn set_speed(&self, speed: Speed) {
+        // let i2c = I2cRegisterManager::new(self);
+        // SMCLK is running at 1.5MHz
+        // In order to achieve a speed of 100kHz or 375kHz, it's necessary to divide the clock
+        // by either 15 (100kHz) or 4 (375kHz)
+        if speed == Speed::K100 {
+            self.registers.brw.set(15);
+        } else if speed == Speed::K375 {
+            self.registers.brw.set(4);
+        }
+    }
+
+    fn setup(&self) {
+        // let i2c = I2cRegisterManager::new(&self);
+        self.set_module_to_reset();
+
+        self.registers.ctlw0.modify(
+            // Use 7 bit addresses
+            usci::UCBxCTLW0::UCSLA10::AddressSlaveWith7BitAddress
+            // Setup to master mode
+            + usci::UCBxCTLW0::UCMST::MasterMode
+            // Setup to single master environment
+            + usci::UCBxCTLW0::UCMM::SingleMasterEnvironment
+            // Configure USCI module to I2C mode
+            + usci::UCBxCTLW0::UCMODE::I2CMode
+            // Set clock source to SMCLK (1.5MHz)
+            + usci::UCBxCTLW0::UCSSEL::SMCLK,
+        );
+
+        self.registers.ctlw1.modify(
+            // Disable clock low timeout
+            usci::UCBxCTLW1::UCCLTO::CLEAR
+            // Send a NACK before a stop condition
+            + usci::UCBxCTLW1::UCSTPNACK::NackBeforeStop
+            // Generate the ACK bit by hardware
+            + usci::UCBxCTLW1::UCSWACK::HardwareTriggered
+            // Set glitch filtering to 50ns (according to I2C standard)
+            + usci::UCBxCTLW1::UCGLIT::_50ns,
+        );
+
+        // Enable interrupts
+        self.registers.ie.modify(
+            // Enable NACK interrupt
+            usci::UCBxIE::UCNACKIE::SET
+            // Enable 'arbitration lost' interrupt
+            + usci::UCBxIE::UCALIE::SET,
+        );
+
+        self.clear_module_reset();
+    }
+
+    fn set_module_to_reset(&self) {
+        // Set USCI module to reset in order to make a proper configuration possible
+        self.registers.ctlw0.modify(usci::UCBxCTLW0::UCSWRST::SET);
+    }
+
+    fn clear_module_reset(&self) {
+        // Set USCI module to reset in order to make a proper configuration possible
+        self.registers.ctlw0.modify(usci::UCBxCTLW0::UCSWRST::CLEAR);
+    }
+
+    fn set_slave_address(&self, addr: u8) {
+        self.registers.i2csa.set(addr as u16);
+    }
+
+    fn generate_start_condition(&self) {
+        self.registers
+            .ctlw0
+            .modify(usci::UCBxCTLW0::UCTXSTT::GenerateSTARTCondition);
+    }
+
+    fn generate_stop_condition(&self) {
+        self.registers
+            .ctlw0
+            .modify(usci::UCBxCTLW0::UCTXSTP::GenerateSTOP);
+    }
+
+    fn set_stop_condition_automatically(&self, val: bool) {
+        if val {
+            self.registers
+                .ctlw1
+                .modify(usci::UCBxCTLW1::UCASTP::ByteCounterStopCondition)
+        } else {
+            self.registers.ctlw1.modify(usci::UCBxCTLW1::UCASTP::Manual);
+        }
+    }
+
+    fn enable_transmit_mode(&self) {
+        self.registers
+            .ctlw0
+            .modify(usci::UCBxCTLW0::UCTR::Transmitter);
+    }
+
+    fn enable_receive_mode(&self) {
+        self.registers.ctlw0.modify(usci::UCBxCTLW0::UCTR::Receiver);
+    }
+
+    fn set_byte_counter(&self, val: u8) {
+        self.registers.tbcnt.set(val as u16);
+    }
+}
+
+impl<'a> dma::DmaClient for I2c<'a> {
+    fn transfer_done(
+        &self,
+        tx_buf: Option<&'static mut [u8]>,
+        rx_buf: Option<&'static mut [u8]>,
+        _transmitted_bytes: usize,
+    ) {
+        // If this function is entered, an I2C transaction finished without any error.
+        // If an error occurs, the interrupt-handler of the I2C module will handle it and invoke the
+        // callback with the appropriate error
+
+        match self.mode.get() {
+            OperatingMode::Write => {
+                self.master_client.map(move |cl| {
+                    tx_buf.map(|buf| cl.command_complete(buf, i2c::Error::CommandComplete));
+                });
+                self.mode.replace(OperatingMode::Idle);
+            }
+            OperatingMode::Read => {
+                self.master_client.map(move |cl| {
+                    rx_buf.map(|buf| cl.command_complete(buf, i2c::Error::CommandComplete));
+                });
+                self.mode.replace(OperatingMode::Idle);
+            }
+            OperatingMode::WriteRead => {
+                if tx_buf.is_some() {
+                    // Write part finished
+
+                    // Configure module to receive mode
+                    self.enable_receive_mode();
+
+                    // Setup DMA transfer
+                    let rx_reg = &self.registers.rxbuf as *const ReadOnly<u16> as *const ();
+                    self.rx_dma.map(move |dma| {
+                        dma.transfer_periph_to_mem(
+                            rx_reg,
+                            tx_buf.unwrap(),
+                            self.read_len.get() as usize,
+                        )
+                    });
+
+                    // Generate repeated start condition
+                    self.generate_start_condition();
+                } else if rx_buf.is_some() {
+                    // Read part finished
+
+                    // Generate stop condition to finish the I2c transaction
+                    self.generate_stop_condition();
+
+                    // Invoke client callback
+                    self.master_client.map(|cl| {
+                        cl.command_complete(rx_buf.unwrap(), i2c::Error::CommandComplete)
+                    });
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+impl<'a> i2c::I2CMaster for I2c<'a> {
+    fn set_master_client(&self, master_client: &'static dyn i2c::I2CHwMasterClient) {
+        self.master_client.replace(master_client);
+    }
+
+    fn enable(&self) {
+        self.setup();
+    }
+
+    fn disable(&self) {
+        self.set_module_to_reset();
+        self.mode.replace(OperatingMode::Idle);
+    }
+
+    fn write(&self, addr: u8, data: &'static mut [u8], len: u8) {
+        if self.mode.get() != OperatingMode::Idle {
+            // Module is busy
+            return;
+        }
+
+        // Set module to reset since some of the registers cannot be modified in running state
+        self.set_module_to_reset();
+
+        // Setup the slave address
+        self.set_slave_address(addr);
+
+        // Setup the I2C module to transmit mode
+        self.enable_transmit_mode();
+
+        // Setup the byte counter in order to automatically generate a stop condition after the
+        // desired number of bytes were transmitted
+        self.set_byte_counter(len);
+
+        // Create stop condition automatically after the number of bytes in the byte counter
+        // register were transmitted
+        self.set_stop_condition_automatically(true);
+
+        self.clear_module_reset();
+        self.mode.replace(OperatingMode::Write);
+
+        // Setup a DMA transfer
+        let tx_reg = &self.registers.txbuf as *const ReadWrite<u16> as *const ();
+        self.tx_dma
+            .map(move |dma| dma.transfer_mem_to_periph(tx_reg, data, len as usize));
+
+        // Start transfer
+        self.generate_start_condition();
+    }
+
+    fn read(&self, addr: u8, buffer: &'static mut [u8], len: u8) {
+        if self.mode.get() != OperatingMode::Idle {
+            // Module is busy
+            return;
+        }
+
+        // Set module to reset since some of the registers cannot be modified in running state
+        self.set_module_to_reset();
+
+        // Setup the slave address
+        self.set_slave_address(addr);
+
+        // Setup the I2C module to receive mode
+        self.enable_receive_mode();
+
+        // Setup the byte counter in order to automatically generate a stop condition after the
+        // desired number of bytes were transmitted
+        self.set_byte_counter(len);
+
+        // Generate a stop condition automatically after the number of bytes in the byte counter
+        // register were transmitted
+        self.set_stop_condition_automatically(true);
+
+        self.clear_module_reset();
+        self.mode.replace(OperatingMode::Read);
+
+        // Setup a DMA transfer
+        let rx_reg = &self.registers.rxbuf as *const ReadOnly<u16> as *const ();
+        self.rx_dma
+            .map(move |dma| dma.transfer_periph_to_mem(rx_reg, buffer, len as usize));
+
+        // Start transfer
+        self.generate_start_condition();
+    }
+
+    fn write_read(&self, addr: u8, data: &'static mut [u8], write_len: u8, read_len: u8) {
+        if self.mode.get() != OperatingMode::Idle {
+            // Module is busy
+            return;
+        }
+
+        // Set module to reset since some of the registers cannot be modified in running state
+        self.set_module_to_reset();
+
+        // Setup the slave address
+        self.set_slave_address(addr);
+
+        // Setup the I2C module to transmit mode
+        self.enable_transmit_mode();
+
+        // Disable generating a stop condition automatically since after the write, a repeated
+        // start condition will be generated in order to continue reading from the slave
+        self.set_stop_condition_automatically(false);
+
+        // Store read_len since it will be used in the DMA callback to setup the read transfer
+        self.read_len.replace(read_len);
+
+        self.clear_module_reset();
+        self.mode.replace(OperatingMode::WriteRead);
+
+        // Setup a DMA transfer
+        let tx_reg = &self.registers.txbuf as *const ReadWrite<u16> as *const ();
+        self.tx_dma
+            .map(move |dma| dma.transfer_mem_to_periph(tx_reg, data, write_len as usize));
+
+        // Start transfer
+        self.generate_start_condition();
+    }
+}

--- a/chips/msp432/src/lib.rs
+++ b/chips/msp432/src/lib.rs
@@ -13,6 +13,7 @@ pub mod cs;
 pub mod dma;
 pub mod flctl;
 pub mod gpio;
+pub mod i2c;
 pub mod nvic;
 pub mod pcm;
 pub mod ref_module;

--- a/chips/msp432/src/usci.rs
+++ b/chips/msp432/src/usci.rs
@@ -6,25 +6,25 @@ use kernel::common::StaticRef;
 pub const USCI_A0_BASE: StaticRef<UsciARegisters> =
     unsafe { StaticRef::new(0x4000_1000 as *const UsciARegisters) };
 #[allow(dead_code)]
-pub(crate) const USCI_A1_BASE: StaticRef<UsciARegisters> =
+pub const USCI_A1_BASE: StaticRef<UsciARegisters> =
     unsafe { StaticRef::new(0x4000_1400 as *const UsciARegisters) };
 #[allow(dead_code)]
-pub(crate) const USCI_A2_BASE: StaticRef<UsciARegisters> =
+pub const USCI_A2_BASE: StaticRef<UsciARegisters> =
     unsafe { StaticRef::new(0x4000_1800 as *const UsciARegisters) };
 #[allow(dead_code)]
-pub(crate) const USCI_A3_BASE: StaticRef<UsciARegisters> =
+pub const USCI_A3_BASE: StaticRef<UsciARegisters> =
     unsafe { StaticRef::new(0x4000_1C00 as *const UsciARegisters) };
 #[allow(dead_code)]
-pub(crate) const USCI_B0_BASE: StaticRef<UsciBRegisters> =
+pub const USCI_B0_BASE: StaticRef<UsciBRegisters> =
     unsafe { StaticRef::new(0x4000_2000 as *const UsciBRegisters) };
 #[allow(dead_code)]
-pub(crate) const USCI_B1_BASE: StaticRef<UsciBRegisters> =
+pub const USCI_B1_BASE: StaticRef<UsciBRegisters> =
     unsafe { StaticRef::new(0x4000_2400 as *const UsciBRegisters) };
 #[allow(dead_code)]
-pub(crate) const USCI_B2_BASE: StaticRef<UsciBRegisters> =
+pub const USCI_B2_BASE: StaticRef<UsciBRegisters> =
     unsafe { StaticRef::new(0x4000_2800 as *const UsciBRegisters) };
 #[allow(dead_code)]
-pub(crate) const USCI_B3_BASE: StaticRef<UsciBRegisters> =
+pub const USCI_B3_BASE: StaticRef<UsciBRegisters> =
     unsafe { StaticRef::new(0x4000_2C00 as *const UsciBRegisters) };
 
 register_structs! {
@@ -59,7 +59,7 @@ register_structs! {
         (0x20 => @END),
     },
     /// EUSCI_Bx
-    pub(crate) UsciBRegisters {
+    pub UsciBRegisters {
         /// eUSCI_Bx Control Word Register 0
         (0x00 => pub(crate) ctlw0: ReadWrite<u16, UCBxCTLW0::Register>),
         /// eUSCI_Bx Control Word Register 1
@@ -508,7 +508,7 @@ register_bitfields![u16,
         /// Multi-master environment select
         UCMM OFFSET(13) NUMBITS(1) [
             /// Single master environment. There is no other master in the system. The address c
-            UCMM_0 = 0,
+            SingleMasterEnvironment = 0,
             /// Multi-master environment
             MultiMasterEnvironment = 1
         ],
@@ -531,36 +531,36 @@ register_bitfields![u16,
         /// Deglitch time
         UCGLIT OFFSET(0) NUMBITS(2) [
             /// 50 ns
-            _50Ns = 0,
+            _50ns = 0,
             /// 25 ns
-            _25Ns = 1,
+            _25ns = 1,
             /// 12.5 ns
-            _125Ns = 2,
+            _125ns = 2,
             /// 6.25 ns
-            _625Ns = 3
+            _625ns = 3
         ],
         /// Automatic STOP condition generation
         UCASTP OFFSET(2) NUMBITS(2) [
             /// No automatic STOP generation. The STOP condition is generated after the user set
-            UCASTP_0 = 0,
+            Manual = 0,
             /// UCBCNTIFG is set with the byte counter reaches the threshold defined in UCBxTBCN
-            UCBCNTIFGIsSetWithTheByteCounterReachesTheThresholdDefinedInUCBxTBCNT = 1,
+            ByteCounterInterrupt = 1,
             /// A STOP condition is generated automatically after the byte counter value reached
-            UCASTP_2 = 2
+            ByteCounterStopCondition = 2
         ],
         /// SW or HW ACK control
         UCSWACK OFFSET(4) NUMBITS(1) [
             /// The address acknowledge of the slave is controlled by the eUSCI_B module
-            TheAddressAcknowledgeOfTheSlaveIsControlledByTheEUSCI_BModule = 0,
+            HardwareTriggered = 0,
             /// The user needs to trigger the sending of the address ACK by issuing UCTXACK
-            TheUserNeedsToTriggerTheSendingOfTheAddressACKByIssuingUCTXACK = 1
+            SoftwareTriggered = 1
         ],
         /// ACK all master bytes
         UCSTPNACK OFFSET(5) NUMBITS(1) [
             /// Send a non-acknowledge before the STOP condition as a master receiver (conform t
-            SendANonAcknowledgeBeforeTheSTOPConditionAsAMasterReceiverConformToI2CStandard = 0,
+            NackBeforeStop = 0,
             /// All bytes are acknowledged by the eUSCI_B when configured as master receiver
-            AllBytesAreAcknowledgedByTheEUSCI_BWhenConfiguredAsMasterReceiver = 1
+            AckBeforeStop = 1
         ],
         /// Clock low timeout select
         UCCLTO OFFSET(6) NUMBITS(2) [


### PR DESCRIPTION
### I2C driver support for the MSP432

This PR adds support for I2C on the MSP432. The implementation is done without the usage of DMA since the MSP432 has only 8 DMA channel and 1 I2C bus would require 2 channels (TX and RX). Due to the fact that in most of the cases only a few bytes are transmitted over I2C I thought it would be better to handle the complete implementation via interrupts and save the DMA channels for other peripherals.

### Testing Strategy

Tested on the evaluation board using a [DS1621 temperature sensor](https://pdfserv.maximintegrated.com/en/ds/DS1621.pdf) as slave and the sensor example as application. 

### TODO or Help Wanted

* Is the no-DMA approach ok/fine? Or should I rewrite the driver to use DMA channels?
* For testing I wrote a capsule driver for the DS1621 chip. It's a very simple temperature sensor which works with I2C. Also not all functionalities are implemented but it works well as a standard temperature sensor. Is there an interest for this driver-support? If yes, I could create another PR for it.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make ci-nosetup`.
