### PR TITLE
TicKV: Update the TicKV implementation

### DIFF
--- a/libraries/tickv/README.md
+++ b/libraries/tickv/README.md
@@ -100,10 +100,10 @@ that data is lost.
 
 ### Security
 
-TicKV uses checksums to check data integrity. TicKV does not have any measures
-to prevent malicious manipulation or privacy. An attacker with access to the
-flash can change the values without being detected. An attacked with access
-to flash can also read all of the information. Any privacy, security or
+TicKV uses CRC-32 checksums to check data integrity. TicKV does not have any
+measures to prevent malicious manipulation or privacy. An attacker with access
+to the flash can change the values without being detected. An attacked with
+access to flash can also read all of the information. Any privacy, security or
 authentication measures need to be layered on top of TicKV.
 
 ### Hardware Requirements

--- a/libraries/tickv/src/async_ops.rs
+++ b/libraries/tickv/src/async_ops.rs
@@ -9,10 +9,17 @@
 //! // EXAMPLE ONLY: The `DefaultHasher` is subject to change
 //! // and hence is not a good fit.
 //! use std::collections::hash_map::DefaultHasher;
+//! use core::hash::{Hash, Hasher};
 //! use std::cell::{Cell, RefCell};
-//! use tickv::AsyncTicKV;
+//! use tickv::{AsyncTicKV, MAIN_KEY};
 //! use tickv::error_codes::ErrorCode;
 //! use tickv::flash_controller::FlashController;
+//!
+//! fn get_hashed_key(unhashed_key: &[u8]) -> u64 {
+//!     let mut hash_function = DefaultHasher::new();
+//!     unhashed_key.hash(&mut hash_function);
+//!     hash_function.finish()
+//! }
 //!
 //! struct FlashCtrl {
 //!     buf: RefCell<[[u8; 1024]; 64]>,
@@ -68,14 +75,15 @@
 //! // callbacks/interrupts and make this async.
 //!
 //! let mut read_buf: [u8; 1024] = [0; 1024];
-//! let tickv = AsyncTicKV::<FlashCtrl, DefaultHasher, 1024>::new(FlashCtrl::new(),
+//! let mut hash_function = DefaultHasher::new();
+//! MAIN_KEY.hash(&mut hash_function);
+//! let tickv = AsyncTicKV::<FlashCtrl, 1024>::new(FlashCtrl::new(),
 //!                   &mut read_buf, 0x1000);
 //!
-//! let mut ret = tickv.initalise((&mut DefaultHasher::new(), &mut DefaultHasher::new()));
+//! let mut ret = tickv.initalise(hash_function.finish());
 //! while ret.is_err() {
 //!     // There is no actual delay here, in a real implementation wait on some event
-//!     ret = tickv.continue_operation(
-//!         (&mut DefaultHasher::new(), &mut DefaultHasher::new())).0;
+//!     ret = tickv.continue_operation().0;
 //!
 //!     match ret {
 //!         Err(ErrorCode::ReadNotReady(reg)) => {
@@ -93,14 +101,14 @@
 //!
 //! // Add a key
 //! static VALUE: [u8; 32] = [0x23; 32];
-//! let ret = unsafe { tickv.append_key(&mut DefaultHasher::new(), b"ONE", &VALUE) };
+//! let ret = unsafe { tickv.append_key(get_hashed_key(b"ONE"), &VALUE) };
 //!
 //! match ret {
 //!     Err(ErrorCode::ReadNotReady(reg)) => {
 //!         // There is no actual delay in the test, just continue now
 //!         tickv.set_read_buffer(&tickv.tickv.controller.buf.borrow()[reg]);
 //!         tickv
-//!             .continue_operation((&mut DefaultHasher::new(), &mut DefaultHasher::new())).0
+//!             .continue_operation().0
 //!             .unwrap();
 //!     }
 //!     Ok(_) => {}
@@ -120,7 +128,6 @@ use crate::flash_controller::FlashController;
 use crate::success_codes::SuccessCode;
 use crate::tickv::{State, TicKV};
 use core::cell::Cell;
-use core::hash::Hasher;
 
 /// The return type from the continue operation
 type ContinueReturn = (
@@ -131,15 +138,15 @@ type ContinueReturn = (
 );
 
 /// The struct storing all of the TicKV information for the async implementation.
-pub struct AsyncTicKV<'a, C: FlashController<S>, H: Hasher, const S: usize> {
+pub struct AsyncTicKV<'a, C: FlashController<S>, const S: usize> {
     /// The main TicKV struct
-    pub tickv: TicKV<'a, C, H, S>,
-    key: Cell<Option<&'static [u8]>>,
+    pub tickv: TicKV<'a, C, S>,
+    key: Cell<Option<u64>>,
     value: Cell<Option<&'static [u8]>>,
     buf: Cell<Option<&'static mut [u8]>>,
 }
 
-impl<'a, C: FlashController<S>, H: Hasher, const S: usize> AsyncTicKV<'a, C, H, S> {
+impl<'a, C: FlashController<S>, const S: usize> AsyncTicKV<'a, C, S> {
     /// Create a new struct
     ///
     /// `C`: An implementation of the `FlashController` trait
@@ -148,7 +155,7 @@ impl<'a, C: FlashController<S>, H: Hasher, const S: usize> AsyncTicKV<'a, C, H, 
     /// `flash_size`: The total size of the flash used for TicKV
     pub fn new(controller: C, read_buffer: &'a mut [u8; S], flash_size: usize) -> Self {
         Self {
-            tickv: TicKV::<C, H, S>::new(controller, read_buffer, flash_size),
+            tickv: TicKV::<C, S>::new(controller, read_buffer, flash_size),
             key: Cell::new(None),
             value: Cell::new(None),
             buf: Cell::new(None),
@@ -158,39 +165,31 @@ impl<'a, C: FlashController<S>, H: Hasher, const S: usize> AsyncTicKV<'a, C, H, 
     /// This function setups the flash region to be used as a key-value store.
     /// If the region is already initalised this won't make any changes.
     ///
-    /// `H`: An implementation of a `core::hash::Hasher` trait. This MUST
-    ///      always return the same hash for the same input. That is the
-    ///      implementation can NOT change over time.
+    /// `hashed_main_key`: The u64 hash of the const string `MAIN_KEY`.
     ///
     /// If the specified region has not already been setup for TicKV
     /// the entire region will be erased.
     ///
     /// On success a `SuccessCode` will be returned.
     /// On error a `ErrorCode` will be returned.
-    pub fn initalise(&self, hash_function: (&mut H, &mut H)) -> Result<SuccessCode, ErrorCode> {
-        self.tickv.initalise(hash_function)
+    pub fn initalise(&self, hashed_main_key: u64) -> Result<SuccessCode, ErrorCode> {
+        self.key.replace(Some(hashed_main_key));
+        self.tickv.initalise(hashed_main_key)
     }
 
     /// Appends the key/value pair to flash storage.
     ///
-    /// `hash_function`: Hash function with no previous state. This is
-    ///                  usually a newly created hash.
-    /// `key`: A unhashed key. This will be hashed internally. This key
-    ///        will be used in future to retrieve or remove the `value`.
+    /// `hash`: A hashed key. This key will be used in future to retrieve
+    ///         or remove the `value`.
     /// `value`: A buffer containing the data to be stored to flash.
     ///
     /// On success nothing will be returned.
     /// On error a `ErrorCode` will be returned.
-    pub fn append_key(
-        &self,
-        hash_function: &mut H,
-        key: &'static [u8],
-        value: &'static [u8],
-    ) -> Result<SuccessCode, ErrorCode> {
-        match self.tickv.append_key(hash_function, key, value) {
+    pub fn append_key(&self, hash: u64, value: &'static [u8]) -> Result<SuccessCode, ErrorCode> {
+        match self.tickv.append_key(hash, value) {
             Ok(code) => Ok(code),
             Err(e) => {
-                self.key.replace(Some(key));
+                self.key.replace(Some(hash));
                 self.value.replace(Some(value));
                 Err(e)
             }
@@ -199,9 +198,7 @@ impl<'a, C: FlashController<S>, H: Hasher, const S: usize> AsyncTicKV<'a, C, H, 
 
     /// Retrieves the value from flash storage.
     ///
-    /// `hash_function`: Hash function with no previous state. This is
-    ///                  usually a newly created hash.
-    /// `key`: A unhashed key. This will be hashed internally.
+    /// `hash`: A hashed key.
     /// `buf`: A buffer to store the value to.
     ///
     /// On success a `SuccessCode` will be returned.
@@ -209,16 +206,11 @@ impl<'a, C: FlashController<S>, H: Hasher, const S: usize> AsyncTicKV<'a, C, H, 
     ///
     /// If a power loss occurs before success is returned the data is
     /// assumed to be lost.
-    pub fn get_key(
-        &self,
-        hash_function: &mut H,
-        key: &'static [u8],
-        buf: &'static mut [u8],
-    ) -> Result<SuccessCode, ErrorCode> {
-        match self.tickv.get_key(hash_function, key, buf) {
+    pub fn get_key(&self, hash: u64, buf: &'static mut [u8]) -> Result<SuccessCode, ErrorCode> {
+        match self.tickv.get_key(hash, buf) {
             Ok(code) => Ok(code),
             Err(e) => {
-                self.key.replace(Some(key));
+                self.key.replace(Some(hash));
                 self.buf.replace(Some(buf));
                 Err(e)
             }
@@ -227,8 +219,7 @@ impl<'a, C: FlashController<S>, H: Hasher, const S: usize> AsyncTicKV<'a, C, H, 
 
     /// Invalidates the key in flash storage
     ///
-    /// `hash_function`: Hash function with no previous state. This is
-    ///                  usually a newly created hash.
+    /// `hash`: A hashed key.
     /// `key`: A unhashed key. This will be hashed internally.
     ///
     /// On success a `SuccessCode` will be returned.
@@ -236,15 +227,11 @@ impl<'a, C: FlashController<S>, H: Hasher, const S: usize> AsyncTicKV<'a, C, H, 
     ///
     /// If a power loss occurs before success is returned the data is
     /// assumed to be lost.
-    pub fn invalidate_key(
-        &self,
-        hash_function: &mut H,
-        key: &'static [u8],
-    ) -> Result<SuccessCode, ErrorCode> {
-        match self.tickv.invalidate_key(hash_function, key) {
+    pub fn invalidate_key(&self, hash: u64) -> Result<SuccessCode, ErrorCode> {
+        match self.tickv.invalidate_key(hash) {
             Ok(code) => Ok(code),
             Err(e) => {
-                self.key.replace(Some(key));
+                self.key.replace(Some(hash));
                 Err(e)
             }
         }
@@ -283,25 +270,19 @@ impl<'a, C: FlashController<S>, H: Hasher, const S: usize> AsyncTicKV<'a, C, H, 
     ///    Buf Buffer:
     ///        An option of the buf buffer used
     /// The buffers will only be returned on a non async error or on success.
-    pub fn continue_operation(&self, hash_function: (&mut H, &mut H)) -> ContinueReturn {
+    pub fn continue_operation(&self) -> ContinueReturn {
         let ret = match self.tickv.state.get() {
-            State::Init(_) => self.tickv.initalise(hash_function),
-            State::AppendKey(_) => self.tickv.append_key(
-                hash_function.0,
-                self.key.get().unwrap(),
-                self.value.get().unwrap(),
-            ),
+            State::Init(_) => self.tickv.initalise(self.key.get().unwrap()),
+            State::AppendKey(_) => self
+                .tickv
+                .append_key(self.key.get().unwrap(), self.value.get().unwrap()),
             State::GetKey(_) => {
                 let buf = self.buf.take().unwrap();
-                let ret = self
-                    .tickv
-                    .get_key(hash_function.0, self.key.get().unwrap(), buf);
+                let ret = self.tickv.get_key(self.key.get().unwrap(), buf);
                 self.buf.replace(Some(buf));
                 ret
             }
-            State::InvalidateKey(_) => self
-                .tickv
-                .invalidate_key(hash_function.0, self.key.get().unwrap()),
+            State::InvalidateKey(_) => self.tickv.invalidate_key(self.key.get().unwrap()),
             State::GarbageCollect(_) => match self.tickv.garbage_collect() {
                 Ok(_) => Ok(SuccessCode::Complete),
                 Err(e) => Err(e),
@@ -335,7 +316,8 @@ mod store_flast_ctrl {
     use crate::async_ops::AsyncTicKV;
     use crate::error_codes::ErrorCode;
     use crate::flash_controller::FlashController;
-    use crate::tickv::{HASH_OFFSET, LEN_OFFSET, VERSION, VERSION_OFFSET};
+    use crate::tickv::{HASH_OFFSET, LEN_OFFSET, MAIN_KEY, VERSION, VERSION_OFFSET};
+    use core::hash::{Hash, Hasher};
     use std::cell::Cell;
     use std::cell::RefCell;
     use std::collections::hash_map::DefaultHasher;
@@ -423,6 +405,12 @@ mod store_flast_ctrl {
         assert_eq!(buf[44], 0x6a);
         assert_eq!(buf[45], 0xba);
         assert_eq!(buf[46], 0xba);
+    }
+
+    fn get_hashed_key(unhashed_key: &[u8]) -> u64 {
+        let mut hash_function = DefaultHasher::new();
+        unhashed_key.hash(&mut hash_function);
+        hash_function.finish()
     }
 
     // An example FlashCtrl implementation
@@ -521,45 +509,37 @@ mod store_flast_ctrl {
     #[test]
     fn test_simple_append() {
         let mut read_buf: [u8; 1024] = [0; 1024];
-        let tickv = AsyncTicKV::<FlashCtrl, DefaultHasher, 1024>::new(
-            FlashCtrl::new(),
-            &mut read_buf,
-            0x1000,
-        );
+        let mut hash_function = DefaultHasher::new();
+        MAIN_KEY.hash(&mut hash_function);
 
-        let mut ret = tickv.initalise((&mut DefaultHasher::new(), &mut DefaultHasher::new()));
+        let tickv = AsyncTicKV::<FlashCtrl, 1024>::new(FlashCtrl::new(), &mut read_buf, 0x1000);
+
+        let mut ret = tickv.initalise(hash_function.finish());
         while ret.is_err() {
             // There is no actual delay in the test, just continue now
-            let (r, _buf) =
-                tickv.continue_operation((&mut DefaultHasher::new(), &mut DefaultHasher::new()));
+            let (r, _buf) = tickv.continue_operation();
             ret = r;
         }
 
         static VALUE: [u8; 32] = [0x23; 32];
 
-        let ret = tickv.append_key(&mut DefaultHasher::new(), b"ONE", &VALUE);
+        let ret = tickv.append_key(get_hashed_key(b"ONE"), &VALUE);
         match ret {
             Err(ErrorCode::ReadNotReady(reg)) => {
                 // There is no actual delay in the test, just continue now
                 tickv.set_read_buffer(&tickv.tickv.controller.buf.borrow()[reg]);
-                tickv
-                    .continue_operation((&mut DefaultHasher::new(), &mut DefaultHasher::new()))
-                    .0
-                    .unwrap();
+                tickv.continue_operation().0.unwrap();
             }
             Ok(_) => {}
             _ => unreachable!(),
         }
 
-        let ret = tickv.append_key(&mut DefaultHasher::new(), b"TWO", &VALUE);
+        let ret = tickv.append_key(get_hashed_key(b"TWO"), &VALUE);
         match ret {
             Err(ErrorCode::ReadNotReady(reg)) => {
                 // There is no actual delay in the test, just continue now
                 tickv.set_read_buffer(&tickv.tickv.controller.buf.borrow()[reg]);
-                tickv
-                    .continue_operation((&mut DefaultHasher::new(), &mut DefaultHasher::new()))
-                    .0
-                    .unwrap();
+                tickv.continue_operation().0.unwrap();
             }
             Ok(_) => {}
             _ => unreachable!(),
@@ -569,17 +549,15 @@ mod store_flast_ctrl {
     #[test]
     fn test_double_append() {
         let mut read_buf: [u8; 1024] = [0; 1024];
-        let tickv = AsyncTicKV::<FlashCtrl, DefaultHasher, 1024>::new(
-            FlashCtrl::new(),
-            &mut read_buf,
-            0x10000,
-        );
+        let mut hash_function = DefaultHasher::new();
+        MAIN_KEY.hash(&mut hash_function);
 
-        let mut ret = tickv.initalise((&mut DefaultHasher::new(), &mut DefaultHasher::new()));
+        let tickv = AsyncTicKV::<FlashCtrl, 1024>::new(FlashCtrl::new(), &mut read_buf, 0x10000);
+
+        let mut ret = tickv.initalise(hash_function.finish());
         while ret.is_err() {
             // There is no actual delay in the test, just continue now
-            let (r, _buf) =
-                tickv.continue_operation((&mut DefaultHasher::new(), &mut DefaultHasher::new()));
+            let (r, _buf) = tickv.continue_operation();
             ret = r;
         }
 
@@ -587,54 +565,44 @@ mod store_flast_ctrl {
         static mut BUF: [u8; 32] = [0; 32];
 
         println!("Add key ONE");
-        let ret = tickv.append_key(&mut DefaultHasher::new(), b"ONE", &VALUE);
+        let ret = tickv.append_key(get_hashed_key(b"ONE"), &VALUE);
         match ret {
             Err(ErrorCode::ReadNotReady(reg)) => {
                 // There is no actual delay in the test, just continue now
                 tickv.set_read_buffer(&tickv.tickv.controller.buf.borrow()[reg]);
-                tickv
-                    .continue_operation((&mut DefaultHasher::new(), &mut DefaultHasher::new()))
-                    .0
-                    .unwrap();
+                tickv.continue_operation().0.unwrap();
             }
             Ok(_) => {}
             _ => unreachable!(),
         }
 
         println!("Get key ONE");
+        #[allow(unsafe_code)]
         unsafe {
-            tickv
-                .get_key(&mut DefaultHasher::new(), b"ONE", &mut BUF)
-                .unwrap();
+            tickv.get_key(get_hashed_key(b"ONE"), &mut BUF).unwrap();
         }
 
         println!("Get non-existant key TWO");
-        let ret = unsafe { tickv.get_key(&mut DefaultHasher::new(), b"TWO", &mut BUF) };
+        #[allow(unsafe_code)]
+        let ret = unsafe { tickv.get_key(get_hashed_key(b"TWO"), &mut BUF) };
         match ret {
             Err(ErrorCode::ReadNotReady(reg)) => {
                 // There is no actual delay in the test, just continue now
                 tickv.set_read_buffer(&tickv.tickv.controller.buf.borrow()[reg]);
-                assert_eq!(
-                    tickv
-                        .continue_operation((&mut DefaultHasher::new(), &mut DefaultHasher::new()))
-                        .0,
-                    Err(ErrorCode::KeyNotFound)
-                );
+                assert_eq!(tickv.continue_operation().0, Err(ErrorCode::KeyNotFound));
             }
             Err(ErrorCode::KeyNotFound) => {}
             _ => unreachable!(),
         }
 
         println!("Add key ONE again");
-        let ret = tickv.append_key(&mut DefaultHasher::new(), b"ONE", &VALUE);
+        let ret = tickv.append_key(get_hashed_key(b"ONE"), &VALUE);
         match ret {
             Err(ErrorCode::ReadNotReady(reg)) => {
                 // There is no actual delay in the test, just continue now
                 tickv.set_read_buffer(&tickv.tickv.controller.buf.borrow()[reg]);
                 assert_eq!(
-                    tickv
-                        .continue_operation((&mut DefaultHasher::new(), &mut DefaultHasher::new()))
-                        .0,
+                    tickv.continue_operation().0,
                     Err(ErrorCode::KeyAlreadyExists)
                 );
             }
@@ -643,86 +611,76 @@ mod store_flast_ctrl {
         }
 
         println!("Add key TWO");
-        let ret = tickv.append_key(&mut DefaultHasher::new(), b"TWO", &VALUE);
+        let ret = tickv.append_key(get_hashed_key(b"TWO"), &VALUE);
         match ret {
             Err(ErrorCode::ReadNotReady(reg)) => {
                 // There is no actual delay in the test, just continue now
                 tickv.set_read_buffer(&tickv.tickv.controller.buf.borrow()[reg]);
-                tickv
-                    .continue_operation((&mut DefaultHasher::new(), &mut DefaultHasher::new()))
-                    .0
-                    .unwrap();
+                tickv.continue_operation().0.unwrap();
             }
             Ok(_) => {}
             _ => unreachable!(),
         }
 
         println!("Get key ONE");
-        let ret = unsafe { tickv.get_key(&mut DefaultHasher::new(), b"ONE", &mut BUF) };
+        #[allow(unsafe_code)]
+        let ret = unsafe { tickv.get_key(get_hashed_key(b"ONE"), &mut BUF) };
         match ret {
             Err(ErrorCode::ReadNotReady(reg)) => {
                 // There is no actual delay in the test, just continue now
                 tickv.set_read_buffer(&tickv.tickv.controller.buf.borrow()[reg]);
-                tickv
-                    .continue_operation((&mut DefaultHasher::new(), &mut DefaultHasher::new()))
-                    .0
-                    .unwrap();
+                tickv.continue_operation().0.unwrap();
             }
             Ok(_) => {}
             _ => unreachable!(),
         }
 
         println!("Get key TWO");
-        let ret = unsafe { tickv.get_key(&mut DefaultHasher::new(), b"TWO", &mut BUF) };
+        #[allow(unsafe_code)]
+        let ret = unsafe { tickv.get_key(get_hashed_key(b"TWO"), &mut BUF) };
         match ret {
             Err(ErrorCode::ReadNotReady(reg)) => {
                 // There is no actual delay in the test, just continue now
                 tickv.set_read_buffer(&tickv.tickv.controller.buf.borrow()[reg]);
-                tickv
-                    .continue_operation((&mut DefaultHasher::new(), &mut DefaultHasher::new()))
-                    .0
-                    .unwrap();
+                tickv.continue_operation().0.unwrap();
             }
             Ok(_) => {}
             _ => unreachable!(),
         }
 
         println!("Get non-existant key THREE");
-        let ret = unsafe { tickv.get_key(&mut DefaultHasher::new(), b"THREE", &mut BUF) };
+        #[allow(unsafe_code)]
+        let ret = unsafe { tickv.get_key(get_hashed_key(b"THREE"), &mut BUF) };
         match ret {
             Err(ErrorCode::ReadNotReady(reg)) => {
                 // There is no actual delay in the test, just continue now
                 tickv.set_read_buffer(&tickv.tickv.controller.buf.borrow()[reg]);
-                assert_eq!(
-                    tickv
-                        .continue_operation((&mut DefaultHasher::new(), &mut DefaultHasher::new()))
-                        .0,
-                    Err(ErrorCode::KeyNotFound)
-                );
+                assert_eq!(tickv.continue_operation().0, Err(ErrorCode::KeyNotFound));
             }
             _ => unreachable!(),
         }
 
-        assert_eq!(
-            unsafe { tickv.get_key(&mut DefaultHasher::new(), b"THREE", &mut BUF) },
-            Err(ErrorCode::KeyNotFound)
-        );
+        #[allow(unsafe_code)]
+        unsafe {
+            assert_eq!(
+                tickv.get_key(get_hashed_key(b"THREE"), &mut BUF),
+                Err(ErrorCode::KeyNotFound)
+            );
+        }
     }
 
     #[test]
     fn test_append_and_delete() {
         let mut read_buf: [u8; 1024] = [0; 1024];
-        let tickv = AsyncTicKV::<FlashCtrl, DefaultHasher, 1024>::new(
-            FlashCtrl::new(),
-            &mut read_buf,
-            0x10000,
-        );
+        let mut hash_function = DefaultHasher::new();
+        MAIN_KEY.hash(&mut hash_function);
 
-        let mut ret = tickv.initalise((&mut DefaultHasher::new(), &mut DefaultHasher::new()));
+        let tickv = AsyncTicKV::<FlashCtrl, 1024>::new(FlashCtrl::new(), &mut read_buf, 0x10000);
+
+        let mut ret = tickv.initalise(hash_function.finish());
         while ret.is_err() {
             // There is no actual delay in the test, just continue now
-            let (r, _buf) =
-                tickv.continue_operation((&mut DefaultHasher::new(), &mut DefaultHasher::new()));
+            let (r, _buf) = tickv.continue_operation();
             ret = r;
         }
 
@@ -730,41 +688,38 @@ mod store_flast_ctrl {
         static mut BUF: [u8; 32] = [0; 32];
 
         println!("Add key ONE");
-        let ret = tickv.append_key(&mut DefaultHasher::new(), b"ONE", &VALUE);
+        let ret = tickv.append_key(get_hashed_key(b"ONE"), &VALUE);
         match ret {
             Err(ErrorCode::ReadNotReady(reg)) => {
                 // There is no actual delay in the test, just continue now
                 tickv.set_read_buffer(&tickv.tickv.controller.buf.borrow()[reg]);
-                tickv
-                    .continue_operation((&mut DefaultHasher::new(), &mut DefaultHasher::new()))
-                    .0
-                    .unwrap();
+                tickv.continue_operation().0.unwrap();
             }
             Ok(_) => {}
             _ => unreachable!(),
         }
 
         println!("Get key ONE");
+        #[allow(unsafe_code)]
         unsafe {
-            tickv
-                .get_key(&mut DefaultHasher::new(), b"ONE", &mut BUF)
-                .unwrap();
+            tickv.get_key(get_hashed_key(b"ONE"), &mut BUF).unwrap();
         }
 
         println!("Delete Key ONE");
-        tickv
-            .invalidate_key(&mut DefaultHasher::new(), b"ONE")
-            .unwrap();
+        tickv.invalidate_key(get_hashed_key(b"ONE")).unwrap();
 
         println!("Get non-existant key ONE");
-        assert_eq!(
-            unsafe { tickv.get_key(&mut DefaultHasher::new(), b"ONE", &mut BUF) },
-            Err(ErrorCode::KeyNotFound)
-        );
+        #[allow(unsafe_code)]
+        unsafe {
+            assert_eq!(
+                tickv.get_key(get_hashed_key(b"ONE"), &mut BUF),
+                Err(ErrorCode::KeyNotFound)
+            );
+        }
 
         println!("Try to delete Key ONE Again");
         assert_eq!(
-            tickv.invalidate_key(&mut DefaultHasher::new(), b"ONE"),
+            tickv.invalidate_key(get_hashed_key(b"ONE")),
             Err(ErrorCode::KeyNotFound)
         );
     }
@@ -772,17 +727,15 @@ mod store_flast_ctrl {
     #[test]
     fn test_garbage_collect() {
         let mut read_buf: [u8; 1024] = [0; 1024];
-        let tickv = AsyncTicKV::<FlashCtrl, DefaultHasher, 1024>::new(
-            FlashCtrl::new(),
-            &mut read_buf,
-            0x10000,
-        );
+        let mut hash_function = DefaultHasher::new();
+        MAIN_KEY.hash(&mut hash_function);
 
-        let mut ret = tickv.initalise((&mut DefaultHasher::new(), &mut DefaultHasher::new()));
+        let tickv = AsyncTicKV::<FlashCtrl, 1024>::new(FlashCtrl::new(), &mut read_buf, 0x10000);
+
+        let mut ret = tickv.initalise(hash_function.finish());
         while ret.is_err() {
             // There is no actual delay in the test, just continue now
-            let (r, _buf) =
-                tickv.continue_operation((&mut DefaultHasher::new(), &mut DefaultHasher::new()));
+            let (r, _buf) = tickv.continue_operation();
             ret = r;
         }
 
@@ -793,25 +746,19 @@ mod store_flast_ctrl {
         let mut ret = tickv.garbage_collect();
         while ret.is_err() {
             // There is no actual delay in the test, just continue now
-            ret = match tickv
-                .continue_operation((&mut DefaultHasher::new(), &mut DefaultHasher::new()))
-                .0
-            {
+            ret = match tickv.continue_operation().0 {
                 Ok(_) => Ok(0),
                 Err(e) => Err(e),
             };
         }
 
         println!("Add key ONE");
-        let ret = tickv.append_key(&mut DefaultHasher::new(), b"ONE", &VALUE);
+        let ret = tickv.append_key(get_hashed_key(b"ONE"), &VALUE);
         match ret {
             Err(ErrorCode::ReadNotReady(reg)) => {
                 // There is no actual delay in the test, just continue now
                 tickv.set_read_buffer(&tickv.tickv.controller.buf.borrow()[reg]);
-                tickv
-                    .continue_operation((&mut DefaultHasher::new(), &mut DefaultHasher::new()))
-                    .0
-                    .unwrap();
+                tickv.continue_operation().0.unwrap();
             }
             Ok(_) => {}
             _ => unreachable!(),
@@ -824,10 +771,7 @@ mod store_flast_ctrl {
                 Err(ErrorCode::ReadNotReady(reg)) => {
                     // There is no actual delay in the test, just continue now
                     tickv.set_read_buffer(&tickv.tickv.controller.buf.borrow()[reg]);
-                    ret = match tickv
-                        .continue_operation((&mut DefaultHasher::new(), &mut DefaultHasher::new()))
-                        .0
-                    {
+                    ret = match tickv.continue_operation().0 {
                         Ok(_) => Ok(0),
                         Err(e) => Err(e),
                     };
@@ -840,15 +784,12 @@ mod store_flast_ctrl {
         }
 
         println!("Delete Key ONE");
-        let ret = tickv.invalidate_key(&mut DefaultHasher::new(), b"ONE");
+        let ret = tickv.invalidate_key(get_hashed_key(b"ONE"));
         match ret {
             Err(ErrorCode::ReadNotReady(reg)) => {
                 // There is no actual delay in the test, just continue now
                 tickv.set_read_buffer(&tickv.tickv.controller.buf.borrow()[reg]);
-                tickv
-                    .continue_operation((&mut DefaultHasher::new(), &mut DefaultHasher::new()))
-                    .0
-                    .unwrap();
+                tickv.continue_operation().0.unwrap();
             }
             Ok(_) => {}
             _ => unreachable!("ret: {:?}", ret),
@@ -861,20 +802,14 @@ mod store_flast_ctrl {
                 Err(ErrorCode::ReadNotReady(reg)) => {
                     // There is no actual delay in the test, just continue now
                     tickv.set_read_buffer(&tickv.tickv.controller.buf.borrow()[reg]);
-                    ret = match tickv
-                        .continue_operation((&mut DefaultHasher::new(), &mut DefaultHasher::new()))
-                        .0
-                    {
+                    ret = match tickv.continue_operation().0 {
                         Ok(_) => Ok(0),
                         Err(e) => Err(e),
                     };
                 }
                 Err(ErrorCode::EraseNotReady(_reg)) => {
                     // There is no actual delay in the test, just continue now
-                    ret = match tickv
-                        .continue_operation((&mut DefaultHasher::new(), &mut DefaultHasher::new()))
-                        .0
-                    {
+                    ret = match tickv.continue_operation().0 {
                         Ok(_) => Ok(0),
                         Err(e) => Err(e),
                     };
@@ -887,25 +822,19 @@ mod store_flast_ctrl {
         }
 
         println!("Get non-existant key ONE");
-        let ret = unsafe { tickv.get_key(&mut DefaultHasher::new(), b"ONE", &mut BUF) };
+        #[allow(unsafe_code)]
+        let ret = unsafe { tickv.get_key(get_hashed_key(b"ONE"), &mut BUF) };
         match ret {
             Err(ErrorCode::ReadNotReady(reg)) => {
                 // There is no actual delay in the test, just continue now
                 tickv.set_read_buffer(&tickv.tickv.controller.buf.borrow()[reg]);
-                assert_eq!(
-                    tickv
-                        .continue_operation((&mut DefaultHasher::new(), &mut DefaultHasher::new()))
-                        .0,
-                    Err(ErrorCode::KeyNotFound)
-                );
+                assert_eq!(tickv.continue_operation().0, Err(ErrorCode::KeyNotFound));
             }
             Err(ErrorCode::KeyNotFound) => {}
             _ => unreachable!("ret: {:?}", ret),
         }
 
         println!("Add Key ONE");
-        tickv
-            .append_key(&mut DefaultHasher::new(), b"ONE", &VALUE)
-            .unwrap();
+        tickv.append_key(get_hashed_key(b"ONE"), &VALUE).unwrap();
     }
 }

--- a/libraries/tickv/src/async_ops.rs
+++ b/libraries/tickv/src/async_ops.rs
@@ -346,7 +346,7 @@ mod store_flast_ctrl {
 
         // Check the length
         assert_eq!(buf[LEN_OFFSET], 0x80);
-        assert_eq!(buf[LEN_OFFSET + 1], 19);
+        assert_eq!(buf[LEN_OFFSET + 1], 15);
 
         // Check the hash
         assert_eq!(buf[HASH_OFFSET + 0], 0x7b);
@@ -359,14 +359,10 @@ mod store_flast_ctrl {
         assert_eq!(buf[HASH_OFFSET + 7], 0x44);
 
         // Check the check hash
-        assert_eq!(buf[HASH_OFFSET + 8], 0x39);
-        assert_eq!(buf[HASH_OFFSET + 9], 0x20);
-        assert_eq!(buf[HASH_OFFSET + 10], 0x9f);
-        assert_eq!(buf[HASH_OFFSET + 11], 0xfc);
-        assert_eq!(buf[HASH_OFFSET + 12], 0x5e);
-        assert_eq!(buf[HASH_OFFSET + 13], 0x64);
-        assert_eq!(buf[HASH_OFFSET + 14], 0xf3);
-        assert_eq!(buf[HASH_OFFSET + 15], 0x7e);
+        assert_eq!(buf[HASH_OFFSET + 8], 0x55);
+        assert_eq!(buf[HASH_OFFSET + 9], 0xb5);
+        assert_eq!(buf[HASH_OFFSET + 10], 0xd8);
+        assert_eq!(buf[HASH_OFFSET + 11], 0xe4);
     }
 
     fn check_region_one(buf: &[u8]) {
@@ -375,7 +371,7 @@ mod store_flast_ctrl {
 
         // Check the length
         assert_eq!(buf[LEN_OFFSET], 0x80);
-        assert_eq!(buf[LEN_OFFSET + 1], 51);
+        assert_eq!(buf[LEN_OFFSET + 1], 47);
 
         // Check the hash
         assert_eq!(buf[HASH_OFFSET + 0], 0x81);
@@ -393,14 +389,10 @@ mod store_flast_ctrl {
         assert_eq!(buf[42], 0x23);
 
         // Check the check hash
-        assert_eq!(buf[43], 0x08);
-        assert_eq!(buf[44], 0x05);
-        assert_eq!(buf[45], 0x89);
-        assert_eq!(buf[46], 0xef);
-        assert_eq!(buf[47], 0x5d);
-        assert_eq!(buf[48], 0x42);
-        assert_eq!(buf[49], 0x42);
-        assert_eq!(buf[50], 0xdc);
+        assert_eq!(buf[43], 0xf7);
+        assert_eq!(buf[44], 0x1d);
+        assert_eq!(buf[45], 0xb3);
+        assert_eq!(buf[46], 0xe9);
     }
 
     fn check_region_two(buf: &[u8]) {
@@ -409,7 +401,7 @@ mod store_flast_ctrl {
 
         // Check the length
         assert_eq!(buf[LEN_OFFSET], 0x80);
-        assert_eq!(buf[LEN_OFFSET + 1], 51);
+        assert_eq!(buf[LEN_OFFSET + 1], 47);
 
         // Check the hash
         assert_eq!(buf[HASH_OFFSET + 0], 0x9d);
@@ -427,14 +419,10 @@ mod store_flast_ctrl {
         assert_eq!(buf[42], 0x23);
 
         // Check the check hash
-        assert_eq!(buf[43], 0xdb);
-        assert_eq!(buf[44], 0x1d);
-        assert_eq!(buf[45], 0xd4);
-        assert_eq!(buf[46], 0x8a);
-        assert_eq!(buf[47], 0x7b);
-        assert_eq!(buf[48], 0x39);
-        assert_eq!(buf[49], 0x53);
-        assert_eq!(buf[50], 0x8f);
+        assert_eq!(buf[43], 0x11);
+        assert_eq!(buf[44], 0x6a);
+        assert_eq!(buf[45], 0xba);
+        assert_eq!(buf[46], 0xba);
     }
 
     // An example FlashCtrl implementation

--- a/libraries/tickv/src/crc32.rs
+++ b/libraries/tickv/src/crc32.rs
@@ -1,0 +1,366 @@
+//! A standalone CRC32 implementation
+//!
+//! This is based on the CRC32 implementation
+//!  from: https://github.com/mrhooray/crc-rs
+//!
+//! This implemented the CRC-32 checksum
+//!     poly: 0x04c11db7
+//!     init: 0x00000000
+//!     refin: false
+//!     refout: false
+//!     xorout: 0xffffffff
+//!
+//! Licensed under either of:
+//!     Apache License, Version 2.0 (LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0)
+//!     MIT License (LICENSE-MIT or http://opensource.org/licenses/MIT)
+//! at your option.
+
+const fn crc32_table(poly: u32) -> [u32; 256] {
+    let mut table = [0u32; 256];
+    table[0] = crc32(poly, 0);
+    table[1] = crc32(poly, 1);
+    table[2] = crc32(poly, 2);
+    table[3] = crc32(poly, 3);
+    table[4] = crc32(poly, 4);
+    table[5] = crc32(poly, 5);
+    table[6] = crc32(poly, 6);
+    table[7] = crc32(poly, 7);
+    table[8] = crc32(poly, 8);
+    table[9] = crc32(poly, 9);
+    table[10] = crc32(poly, 10);
+    table[11] = crc32(poly, 11);
+    table[12] = crc32(poly, 12);
+    table[13] = crc32(poly, 13);
+    table[14] = crc32(poly, 14);
+    table[15] = crc32(poly, 15);
+    table[16] = crc32(poly, 16);
+    table[17] = crc32(poly, 17);
+    table[18] = crc32(poly, 18);
+    table[19] = crc32(poly, 19);
+    table[20] = crc32(poly, 20);
+    table[21] = crc32(poly, 21);
+    table[22] = crc32(poly, 22);
+    table[23] = crc32(poly, 23);
+    table[24] = crc32(poly, 24);
+    table[25] = crc32(poly, 25);
+    table[26] = crc32(poly, 26);
+    table[27] = crc32(poly, 27);
+    table[28] = crc32(poly, 28);
+    table[29] = crc32(poly, 29);
+    table[30] = crc32(poly, 30);
+    table[31] = crc32(poly, 31);
+    table[32] = crc32(poly, 32);
+    table[33] = crc32(poly, 33);
+    table[34] = crc32(poly, 34);
+    table[35] = crc32(poly, 35);
+    table[36] = crc32(poly, 36);
+    table[37] = crc32(poly, 37);
+    table[38] = crc32(poly, 38);
+    table[39] = crc32(poly, 39);
+    table[40] = crc32(poly, 40);
+    table[41] = crc32(poly, 41);
+    table[42] = crc32(poly, 42);
+    table[43] = crc32(poly, 43);
+    table[44] = crc32(poly, 44);
+    table[45] = crc32(poly, 45);
+    table[46] = crc32(poly, 46);
+    table[47] = crc32(poly, 47);
+    table[48] = crc32(poly, 48);
+    table[49] = crc32(poly, 49);
+    table[50] = crc32(poly, 50);
+    table[51] = crc32(poly, 51);
+    table[52] = crc32(poly, 52);
+    table[53] = crc32(poly, 53);
+    table[54] = crc32(poly, 54);
+    table[55] = crc32(poly, 55);
+    table[56] = crc32(poly, 56);
+    table[57] = crc32(poly, 57);
+    table[58] = crc32(poly, 58);
+    table[59] = crc32(poly, 59);
+    table[60] = crc32(poly, 60);
+    table[61] = crc32(poly, 61);
+    table[62] = crc32(poly, 62);
+    table[63] = crc32(poly, 63);
+    table[64] = crc32(poly, 64);
+    table[65] = crc32(poly, 65);
+    table[66] = crc32(poly, 66);
+    table[67] = crc32(poly, 67);
+    table[68] = crc32(poly, 68);
+    table[69] = crc32(poly, 69);
+    table[70] = crc32(poly, 70);
+    table[71] = crc32(poly, 71);
+    table[72] = crc32(poly, 72);
+    table[73] = crc32(poly, 73);
+    table[74] = crc32(poly, 74);
+    table[75] = crc32(poly, 75);
+    table[76] = crc32(poly, 76);
+    table[77] = crc32(poly, 77);
+    table[78] = crc32(poly, 78);
+    table[79] = crc32(poly, 79);
+    table[80] = crc32(poly, 80);
+    table[81] = crc32(poly, 81);
+    table[82] = crc32(poly, 82);
+    table[83] = crc32(poly, 83);
+    table[84] = crc32(poly, 84);
+    table[85] = crc32(poly, 85);
+    table[86] = crc32(poly, 86);
+    table[87] = crc32(poly, 87);
+    table[88] = crc32(poly, 88);
+    table[89] = crc32(poly, 89);
+    table[90] = crc32(poly, 90);
+    table[91] = crc32(poly, 91);
+    table[92] = crc32(poly, 92);
+    table[93] = crc32(poly, 93);
+    table[94] = crc32(poly, 94);
+    table[95] = crc32(poly, 95);
+    table[96] = crc32(poly, 96);
+    table[97] = crc32(poly, 97);
+    table[98] = crc32(poly, 98);
+    table[99] = crc32(poly, 99);
+    table[100] = crc32(poly, 100);
+    table[101] = crc32(poly, 101);
+    table[102] = crc32(poly, 102);
+    table[103] = crc32(poly, 103);
+    table[104] = crc32(poly, 104);
+    table[105] = crc32(poly, 105);
+    table[106] = crc32(poly, 106);
+    table[107] = crc32(poly, 107);
+    table[108] = crc32(poly, 108);
+    table[109] = crc32(poly, 109);
+    table[110] = crc32(poly, 110);
+    table[111] = crc32(poly, 111);
+    table[112] = crc32(poly, 112);
+    table[113] = crc32(poly, 113);
+    table[114] = crc32(poly, 114);
+    table[115] = crc32(poly, 115);
+    table[116] = crc32(poly, 116);
+    table[117] = crc32(poly, 117);
+    table[118] = crc32(poly, 118);
+    table[119] = crc32(poly, 119);
+    table[120] = crc32(poly, 120);
+    table[121] = crc32(poly, 121);
+    table[122] = crc32(poly, 122);
+    table[123] = crc32(poly, 123);
+    table[124] = crc32(poly, 124);
+    table[125] = crc32(poly, 125);
+    table[126] = crc32(poly, 126);
+    table[127] = crc32(poly, 127);
+    table[128] = crc32(poly, 128);
+    table[129] = crc32(poly, 129);
+    table[130] = crc32(poly, 130);
+    table[131] = crc32(poly, 131);
+    table[132] = crc32(poly, 132);
+    table[133] = crc32(poly, 133);
+    table[134] = crc32(poly, 134);
+    table[135] = crc32(poly, 135);
+    table[136] = crc32(poly, 136);
+    table[137] = crc32(poly, 137);
+    table[138] = crc32(poly, 138);
+    table[139] = crc32(poly, 139);
+    table[140] = crc32(poly, 140);
+    table[141] = crc32(poly, 141);
+    table[142] = crc32(poly, 142);
+    table[143] = crc32(poly, 143);
+    table[144] = crc32(poly, 144);
+    table[145] = crc32(poly, 145);
+    table[146] = crc32(poly, 146);
+    table[147] = crc32(poly, 147);
+    table[148] = crc32(poly, 148);
+    table[149] = crc32(poly, 149);
+    table[150] = crc32(poly, 150);
+    table[151] = crc32(poly, 151);
+    table[152] = crc32(poly, 152);
+    table[153] = crc32(poly, 153);
+    table[154] = crc32(poly, 154);
+    table[155] = crc32(poly, 155);
+    table[156] = crc32(poly, 156);
+    table[157] = crc32(poly, 157);
+    table[158] = crc32(poly, 158);
+    table[159] = crc32(poly, 159);
+    table[160] = crc32(poly, 160);
+    table[161] = crc32(poly, 161);
+    table[162] = crc32(poly, 162);
+    table[163] = crc32(poly, 163);
+    table[164] = crc32(poly, 164);
+    table[165] = crc32(poly, 165);
+    table[166] = crc32(poly, 166);
+    table[167] = crc32(poly, 167);
+    table[168] = crc32(poly, 168);
+    table[169] = crc32(poly, 169);
+    table[170] = crc32(poly, 170);
+    table[171] = crc32(poly, 171);
+    table[172] = crc32(poly, 172);
+    table[173] = crc32(poly, 173);
+    table[174] = crc32(poly, 174);
+    table[175] = crc32(poly, 175);
+    table[176] = crc32(poly, 176);
+    table[177] = crc32(poly, 177);
+    table[178] = crc32(poly, 178);
+    table[179] = crc32(poly, 179);
+    table[180] = crc32(poly, 180);
+    table[181] = crc32(poly, 181);
+    table[182] = crc32(poly, 182);
+    table[183] = crc32(poly, 183);
+    table[184] = crc32(poly, 184);
+    table[185] = crc32(poly, 185);
+    table[186] = crc32(poly, 186);
+    table[187] = crc32(poly, 187);
+    table[188] = crc32(poly, 188);
+    table[189] = crc32(poly, 189);
+    table[190] = crc32(poly, 190);
+    table[191] = crc32(poly, 191);
+    table[192] = crc32(poly, 192);
+    table[193] = crc32(poly, 193);
+    table[194] = crc32(poly, 194);
+    table[195] = crc32(poly, 195);
+    table[196] = crc32(poly, 196);
+    table[197] = crc32(poly, 197);
+    table[198] = crc32(poly, 198);
+    table[199] = crc32(poly, 199);
+    table[200] = crc32(poly, 200);
+    table[201] = crc32(poly, 201);
+    table[202] = crc32(poly, 202);
+    table[203] = crc32(poly, 203);
+    table[204] = crc32(poly, 204);
+    table[205] = crc32(poly, 205);
+    table[206] = crc32(poly, 206);
+    table[207] = crc32(poly, 207);
+    table[208] = crc32(poly, 208);
+    table[209] = crc32(poly, 209);
+    table[210] = crc32(poly, 210);
+    table[211] = crc32(poly, 211);
+    table[212] = crc32(poly, 212);
+    table[213] = crc32(poly, 213);
+    table[214] = crc32(poly, 214);
+    table[215] = crc32(poly, 215);
+    table[216] = crc32(poly, 216);
+    table[217] = crc32(poly, 217);
+    table[218] = crc32(poly, 218);
+    table[219] = crc32(poly, 219);
+    table[220] = crc32(poly, 220);
+    table[221] = crc32(poly, 221);
+    table[222] = crc32(poly, 222);
+    table[223] = crc32(poly, 223);
+    table[224] = crc32(poly, 224);
+    table[225] = crc32(poly, 225);
+    table[226] = crc32(poly, 226);
+    table[227] = crc32(poly, 227);
+    table[228] = crc32(poly, 228);
+    table[229] = crc32(poly, 229);
+    table[230] = crc32(poly, 230);
+    table[231] = crc32(poly, 231);
+    table[232] = crc32(poly, 232);
+    table[233] = crc32(poly, 233);
+    table[234] = crc32(poly, 234);
+    table[235] = crc32(poly, 235);
+    table[236] = crc32(poly, 236);
+    table[237] = crc32(poly, 237);
+    table[238] = crc32(poly, 238);
+    table[239] = crc32(poly, 239);
+    table[240] = crc32(poly, 240);
+    table[241] = crc32(poly, 241);
+    table[242] = crc32(poly, 242);
+    table[243] = crc32(poly, 243);
+    table[244] = crc32(poly, 244);
+    table[245] = crc32(poly, 245);
+    table[246] = crc32(poly, 246);
+    table[247] = crc32(poly, 247);
+    table[248] = crc32(poly, 248);
+    table[249] = crc32(poly, 249);
+    table[250] = crc32(poly, 250);
+    table[251] = crc32(poly, 251);
+    table[252] = crc32(poly, 252);
+    table[253] = crc32(poly, 253);
+    table[254] = crc32(poly, 254);
+    table[255] = crc32(poly, 255);
+    table
+}
+
+const fn reflect_8(mut b: u8) -> u8 {
+    b = (b & 0xF0) >> 4 | (b & 0x0F) << 4;
+    b = (b & 0xCC) >> 2 | (b & 0x33) << 2;
+    b = (b & 0xAA) >> 1 | (b & 0x55) << 1;
+    b
+}
+
+const fn reflect_32(mut b: u32) -> u32 {
+    b = (b & 0xFFFF0000) >> 16 | (b & 0x0000FFFF) << 16;
+    b = (b & 0xFF00FF00) >> 8 | (b & 0x00FF00FF) << 8;
+    b = (b & 0xF0F0F0F0) >> 4 | (b & 0x0F0F0F0F) << 4;
+    b = (b & 0xCCCCCCCC) >> 2 | (b & 0x33333333) << 2;
+    b = (b & 0xAAAAAAAA) >> 1 | (b & 0x55555555) << 1;
+    b
+}
+
+const fn crc32(poly: u32, mut byte: u8) -> u32 {
+    const fn poly_sum_crc32(poly: u32, value: u32) -> u32 {
+        (value << 1) ^ ((value >> 31) * poly)
+    }
+    byte = [byte, reflect_8(byte)][0];
+    let mut value = (byte as u32) << 24;
+    value = poly_sum_crc32(poly, value);
+    value = poly_sum_crc32(poly, value);
+    value = poly_sum_crc32(poly, value);
+    value = poly_sum_crc32(poly, value);
+    value = poly_sum_crc32(poly, value);
+    value = poly_sum_crc32(poly, value);
+    value = poly_sum_crc32(poly, value);
+    value = poly_sum_crc32(poly, value);
+    [value, reflect_32(value)][0]
+}
+
+pub struct Crc {
+    table: [u32; 256],
+}
+
+pub struct Digest<'a> {
+    crc: &'a Crc,
+    value: u32,
+}
+
+impl Crc {
+    pub const fn new() -> Self {
+        let table = crc32_table(0x04c11db7);
+        Self { table }
+    }
+
+    const fn init(&self) -> u32 {
+        0x00000000
+    }
+
+    const fn table_entry(&self, index: u32) -> u32 {
+        self.table[(index & 0xFF) as usize]
+    }
+
+    const fn update(&self, mut crc: u32, bytes: &[u8]) -> u32 {
+        let mut i = 0;
+        while i < bytes.len() {
+            crc = self.table_entry(bytes[i] as u32 ^ (crc >> 24)) ^ (crc << 8);
+            i += 1;
+        }
+        crc
+    }
+
+    const fn finalise(&self, crc: u32) -> u32 {
+        crc ^ 0xffffffff
+    }
+
+    pub const fn digest(&self) -> Digest {
+        Digest::new(self)
+    }
+}
+
+impl<'a> Digest<'a> {
+    const fn new(crc: &'a Crc) -> Self {
+        let value = crc.init();
+        Digest { crc, value }
+    }
+
+    pub fn update(&mut self, bytes: &[u8]) {
+        self.value = self.crc.update(self.value, bytes);
+    }
+
+    pub const fn finalise(self) -> u32 {
+        self.crc.finalise(self.value)
+    }
+}

--- a/libraries/tickv/src/lib.rs
+++ b/libraries/tickv/src/lib.rs
@@ -217,6 +217,7 @@
 #![deny(missing_docs)]
 
 pub mod async_ops;
+mod crc32;
 pub mod error_codes;
 pub mod flash_controller;
 pub mod success_codes;

--- a/libraries/tickv/src/lib.rs
+++ b/libraries/tickv/src/lib.rs
@@ -204,7 +204,7 @@
 //!
 
 #![no_std]
-#![forbid(unsafe_code)]
+#![deny(unsafe_code)]
 #![deny(missing_docs)]
 
 pub mod async_ops;

--- a/libraries/tickv/src/lib.rs
+++ b/libraries/tickv/src/lib.rs
@@ -93,10 +93,17 @@
 //! // EXAMPLE ONLY: The `DefaultHasher` is subject to change
 //! // and hence is not a good fit.
 //! use std::collections::hash_map::DefaultHasher;
+//! use std::hash::{Hash, Hasher};
 //! use std::cell::RefCell;
-//! use tickv::TicKV;
+//! use tickv::{TicKV, MAIN_KEY};
 //! use tickv::error_codes::ErrorCode;
 //! use tickv::flash_controller::FlashController;
+//!
+//! fn get_hashed_key(unhashed_key: &[u8]) -> u64 {
+//!     let mut hash_function = DefaultHasher::new();
+//!     unhashed_key.hash(&mut hash_function);
+//!     hash_function.finish()
+//! }
 //!
 //! struct FlashCtrl {
 //!     buf: RefCell<[[u8; 1024]; 64]>,
@@ -134,19 +141,23 @@
 //! }
 //!
 //! let mut read_buf: [u8; 1024] = [0; 1024];
-//! let tickv = TicKV::<FlashCtrl, DefaultHasher, 1024>::new(FlashCtrl::new(),
+//!
+//! let mut hash_function = DefaultHasher::new();
+//! MAIN_KEY.hash(&mut hash_function);
+//!
+//! let tickv = TicKV::<FlashCtrl, 1024>::new(FlashCtrl::new(),
 //!                   &mut read_buf, 0x1000);
 //! tickv
-//!    .initalise((&mut DefaultHasher::new(), &mut DefaultHasher::new()))
+//!    .initalise(hash_function.finish())
 //!    .unwrap();
 //!
 //! // Add a key
 //! let value: [u8; 32] = [0x23; 32];
-//! tickv.append_key(&mut DefaultHasher::new(), b"ONE", &value).unwrap();
+//! tickv.append_key(get_hashed_key(b"ONE"), &value).unwrap();
 //!
 //! // Get the same key back
 //! let mut buf: [u8; 32] = [0; 32];
-//! tickv.get_key(&mut DefaultHasher::new(), b"ONE", &mut buf).unwrap();
+//! tickv.get_key(get_hashed_key(b"ONE"), &mut buf).unwrap();
 //! ```
 //!
 //! You can then use the `get_key()` function to get the key back from flash.
@@ -180,26 +191,6 @@
 //! to flash can also read all of the information. Any privacy, security or
 //! authentication measures need to be layered on top of TicKV.
 //!
-//! # Hash Function
-//!
-//! Any hash function that implements Rust's `core::hash::Hasher` trait can be used.
-//!
-//! The hash function ideally should generate uniform hashes and must not change during
-//! the lifetime of the filesystem.
-//!
-//! The Rust `core::hash::Hasher` implementation is a little strange. When the
-//! hash is calculated with the `finish()` function the internal state of the
-//! `Hasher` is not reset. This means that the check sum is generated with the
-//! following code and the key input becomes part of the check sum.
-//!
-//! ```rust,ignore
-//!         key.hash(hash_function);
-//!         let hash = hash_function.finish();
-//!
-//!         buf.hash(hash_function);
-//!         value.hash(hash_function);
-//!         let check_sum = hash_function.finish();
-//! ```
 //! ## Versions
 //!
 //! TicKV stores the version when adding objects to the flash storage.
@@ -232,6 +223,7 @@ pub use crate::error_codes::ErrorCode;
 pub use crate::flash_controller::FlashController;
 #[doc(inline)]
 pub use crate::tickv::TicKV;
+pub use crate::tickv::MAIN_KEY;
 
 // This is used to run the tests on a host
 #[cfg(test)]

--- a/libraries/tickv/src/tests.rs
+++ b/libraries/tickv/src/tests.rs
@@ -11,7 +11,7 @@ fn check_region_main(buf: &[u8]) {
 
     // Check the length
     assert_eq!(buf[LEN_OFFSET], 0x80);
-    assert_eq!(buf[LEN_OFFSET + 1], 19);
+    assert_eq!(buf[LEN_OFFSET + 1], 15);
 
     // Check the hash
     assert_eq!(buf[HASH_OFFSET + 0], 0x7b);
@@ -24,14 +24,10 @@ fn check_region_main(buf: &[u8]) {
     assert_eq!(buf[HASH_OFFSET + 7], 0x44);
 
     // Check the check hash
-    assert_eq!(buf[HASH_OFFSET + 8], 0x39);
-    assert_eq!(buf[HASH_OFFSET + 9], 0x20);
-    assert_eq!(buf[HASH_OFFSET + 10], 0x9f);
-    assert_eq!(buf[HASH_OFFSET + 11], 0xfc);
-    assert_eq!(buf[HASH_OFFSET + 12], 0x5e);
-    assert_eq!(buf[HASH_OFFSET + 13], 0x64);
-    assert_eq!(buf[HASH_OFFSET + 14], 0xf3);
-    assert_eq!(buf[HASH_OFFSET + 15], 0x7e);
+    assert_eq!(buf[HASH_OFFSET + 8], 0x55);
+    assert_eq!(buf[HASH_OFFSET + 9], 0xb5);
+    assert_eq!(buf[HASH_OFFSET + 10], 0xd8);
+    assert_eq!(buf[HASH_OFFSET + 11], 0xe4);
 }
 
 fn check_region_one(buf: &[u8]) {
@@ -40,7 +36,7 @@ fn check_region_one(buf: &[u8]) {
 
     // Check the length
     assert_eq!(buf[LEN_OFFSET], 0x80);
-    assert_eq!(buf[LEN_OFFSET + 1], 51);
+    assert_eq!(buf[LEN_OFFSET + 1], 47);
 
     // Check the hash
     assert_eq!(buf[HASH_OFFSET + 0], 0x81);
@@ -58,14 +54,10 @@ fn check_region_one(buf: &[u8]) {
     assert_eq!(buf[42], 0x23);
 
     // Check the check hash
-    assert_eq!(buf[43], 0x08);
-    assert_eq!(buf[44], 0x05);
-    assert_eq!(buf[45], 0x89);
-    assert_eq!(buf[46], 0xef);
-    assert_eq!(buf[47], 0x5d);
-    assert_eq!(buf[48], 0x42);
-    assert_eq!(buf[49], 0x42);
-    assert_eq!(buf[50], 0xdc);
+    assert_eq!(buf[43], 0xf7);
+    assert_eq!(buf[44], 0x1d);
+    assert_eq!(buf[45], 0xb3);
+    assert_eq!(buf[46], 0xe9);
 }
 
 fn check_region_two(buf: &[u8]) {
@@ -74,7 +66,7 @@ fn check_region_two(buf: &[u8]) {
 
     // Check the length
     assert_eq!(buf[LEN_OFFSET], 0x80);
-    assert_eq!(buf[LEN_OFFSET + 1], 51);
+    assert_eq!(buf[LEN_OFFSET + 1], 47);
 
     // Check the hash
     assert_eq!(buf[HASH_OFFSET + 0], 0x9d);
@@ -92,14 +84,10 @@ fn check_region_two(buf: &[u8]) {
     assert_eq!(buf[42], 0x23);
 
     // Check the check hash
-    assert_eq!(buf[43], 0xdb);
-    assert_eq!(buf[44], 0x1d);
-    assert_eq!(buf[45], 0xd4);
-    assert_eq!(buf[46], 0x8a);
-    assert_eq!(buf[47], 0x7b);
-    assert_eq!(buf[48], 0x39);
-    assert_eq!(buf[49], 0x53);
-    assert_eq!(buf[50], 0x8f);
+    assert_eq!(buf[43], 0x11);
+    assert_eq!(buf[44], 0x6a);
+    assert_eq!(buf[45], 0xba);
+    assert_eq!(buf[46], 0xba);
 }
 
 /// Tests using a NOP flash controller
@@ -538,8 +526,13 @@ mod no_check_store_flast_ctrl {
             .unwrap();
 
         println!("Add Key SIX");
+        tickv
+            .append_key(&mut DefaultHasher::new(), b"SIX", &value)
+            .unwrap();
+
+        println!("Add Key SEVEN");
         assert_eq!(
-            tickv.append_key(&mut DefaultHasher::new(), b"SIX", &value),
+            tickv.append_key(&mut DefaultHasher::new(), b"SEVEN", &value),
             Err(ErrorCode::FlashFull)
         );
 
@@ -569,8 +562,13 @@ mod no_check_store_flast_ctrl {
             .unwrap();
 
         println!("Get key SIX");
+        tickv
+            .get_key(&mut DefaultHasher::new(), b"SIX", &mut buf)
+            .unwrap();
+
+        println!("Get key SEVEN");
         assert_eq!(
-            tickv.get_key(&mut DefaultHasher::new(), b"SIX", &mut buf),
+            tickv.get_key(&mut DefaultHasher::new(), b"SEVEN", &mut buf),
             Err(ErrorCode::KeyNotFound)
         );
 
@@ -600,8 +598,13 @@ mod no_check_store_flast_ctrl {
             .unwrap();
 
         println!("Delete Key SIX");
+        tickv
+            .invalidate_key(&mut DefaultHasher::new(), b"SIX")
+            .unwrap();
+
+        println!("Delete Key SEVEN");
         assert_eq!(
-            tickv.invalidate_key(&mut DefaultHasher::new(), b"SIX"),
+            tickv.invalidate_key(&mut DefaultHasher::new(), b"SEVEN"),
             Err(ErrorCode::KeyNotFound)
         );
     }

--- a/libraries/tickv/src/tests.rs
+++ b/libraries/tickv/src/tests.rs
@@ -1,6 +1,7 @@
 use crate::error_codes::ErrorCode;
 use crate::flash_controller::FlashController;
-use crate::tickv::{TicKV, HASH_OFFSET, LEN_OFFSET, VERSION, VERSION_OFFSET};
+use crate::tickv::{TicKV, HASH_OFFSET, LEN_OFFSET, MAIN_KEY, VERSION, VERSION_OFFSET};
+use core::hash::{Hash, Hasher};
 use std::cell::Cell;
 use std::cell::RefCell;
 use std::collections::hash_map::DefaultHasher;
@@ -90,6 +91,12 @@ fn check_region_two(buf: &[u8]) {
     assert_eq!(buf[46], 0xba);
 }
 
+fn get_hashed_key(unhashed_key: &[u8]) -> u64 {
+    let mut hash_function = DefaultHasher::new();
+    unhashed_key.hash(&mut hash_function);
+    hash_function.finish()
+}
+
 /// Tests using a NOP flash controller
 mod simple_flash_ctrl {
     use super::*;
@@ -130,11 +137,12 @@ mod simple_flash_ctrl {
     #[test]
     fn test_init() {
         let mut read_buf: [u8; 2048] = [0; 2048];
-        let tickv =
-            TicKV::<FlashCtrl, DefaultHasher, 2048>::new(FlashCtrl::new(), &mut read_buf, 0x20000);
-        tickv
-            .initalise((&mut DefaultHasher::new(), &mut DefaultHasher::new()))
-            .unwrap();
+        let mut hash_function = DefaultHasher::new();
+        MAIN_KEY.hash(&mut hash_function);
+        let hash = hash_function.finish();
+
+        let tickv = TicKV::<FlashCtrl, 2048>::new(FlashCtrl::new(), &mut read_buf, 0x20000);
+        tickv.initalise(hash).unwrap();
     }
 }
 
@@ -184,18 +192,16 @@ mod single_erase_flash_ctrl {
     #[test]
     fn test_double_init() {
         let mut read_buf1: [u8; 2048] = [0; 2048];
-        let tickv1 =
-            TicKV::<FlashCtrl, DefaultHasher, 2048>::new(FlashCtrl::new(), &mut read_buf1, 0x20000);
-        tickv1
-            .initalise((&mut DefaultHasher::new(), &mut DefaultHasher::new()))
-            .unwrap();
+        let mut hash_function = DefaultHasher::new();
+        MAIN_KEY.hash(&mut hash_function);
+        let hash = hash_function.finish();
+
+        let tickv1 = TicKV::<FlashCtrl, 2048>::new(FlashCtrl::new(), &mut read_buf1, 0x20000);
+        tickv1.initalise(hash).unwrap();
 
         let mut read_buf2: [u8; 2048] = [0; 2048];
-        let tickv2 =
-            TicKV::<FlashCtrl, DefaultHasher, 2048>::new(FlashCtrl::new(), &mut read_buf2, 0x20000);
-        tickv2
-            .initalise((&mut DefaultHasher::new(), &mut DefaultHasher::new()))
-            .unwrap();
+        let tickv2 = TicKV::<FlashCtrl, 2048>::new(FlashCtrl::new(), &mut read_buf2, 0x20000);
+        tickv2.initalise(hash).unwrap();
     }
 }
 
@@ -278,72 +284,60 @@ mod store_flast_ctrl {
     #[test]
     fn test_simple_append() {
         let mut read_buf: [u8; 1024] = [0; 1024];
-        let tickv =
-            TicKV::<FlashCtrl, DefaultHasher, 1024>::new(FlashCtrl::new(), &mut read_buf, 0x10000);
-        tickv
-            .initalise((&mut DefaultHasher::new(), &mut DefaultHasher::new()))
-            .unwrap();
+        let mut hash_function = DefaultHasher::new();
+        MAIN_KEY.hash(&mut hash_function);
+        let hash = hash_function.finish();
+
+        let tickv = TicKV::<FlashCtrl, 1024>::new(FlashCtrl::new(), &mut read_buf, 0x10000);
+        tickv.initalise(hash).unwrap();
 
         let value: [u8; 32] = [0x23; 32];
 
-        tickv
-            .append_key(&mut DefaultHasher::new(), b"ONE", &value)
-            .unwrap();
-        tickv
-            .append_key(&mut DefaultHasher::new(), b"TWO", &value)
-            .unwrap();
+        tickv.append_key(get_hashed_key(b"ONE"), &value).unwrap();
+        tickv.append_key(get_hashed_key(b"TWO"), &value).unwrap();
     }
 
     #[test]
     fn test_double_append() {
         let mut read_buf: [u8; 1024] = [0; 1024];
-        let tickv =
-            TicKV::<FlashCtrl, DefaultHasher, 1024>::new(FlashCtrl::new(), &mut read_buf, 0x10000);
-        tickv
-            .initalise((&mut DefaultHasher::new(), &mut DefaultHasher::new()))
-            .unwrap();
+        let mut hash_function = DefaultHasher::new();
+        MAIN_KEY.hash(&mut hash_function);
+        let hash = hash_function.finish();
+
+        let tickv = TicKV::<FlashCtrl, 1024>::new(FlashCtrl::new(), &mut read_buf, 0x10000);
+        tickv.initalise(hash).unwrap();
 
         let value: [u8; 32] = [0x23; 32];
         let mut buf: [u8; 32] = [0; 32];
 
         println!("Add key ONE");
-        tickv
-            .append_key(&mut DefaultHasher::new(), b"ONE", &value)
-            .unwrap();
+        tickv.append_key(get_hashed_key(b"ONE"), &value).unwrap();
 
         println!("Get key ONE");
-        tickv
-            .get_key(&mut DefaultHasher::new(), b"ONE", &mut buf)
-            .unwrap();
+        tickv.get_key(get_hashed_key(b"ONE"), &mut buf).unwrap();
 
         println!("Get non-existant key TWO");
         assert_eq!(
-            tickv.get_key(&mut DefaultHasher::new(), b"TWO", &mut buf),
+            tickv.get_key(get_hashed_key(b"TWO"), &mut buf),
             Err(ErrorCode::KeyNotFound)
         );
 
         println!("Add key ONE again");
         assert_eq!(
-            tickv.append_key(&mut DefaultHasher::new(), b"ONE", &value),
+            tickv.append_key(get_hashed_key(b"ONE"), &value),
             Err(ErrorCode::KeyAlreadyExists)
         );
 
         println!("Add key TWO");
-        tickv
-            .append_key(&mut DefaultHasher::new(), b"TWO", &value)
-            .unwrap();
+        tickv.append_key(get_hashed_key(b"TWO"), &value).unwrap();
         println!("Get key ONE");
-        tickv
-            .get_key(&mut DefaultHasher::new(), b"ONE", &mut buf)
-            .unwrap();
+        tickv.get_key(get_hashed_key(b"ONE"), &mut buf).unwrap();
         println!("Get key TWO");
-        tickv
-            .get_key(&mut DefaultHasher::new(), b"TWO", &mut buf)
-            .unwrap();
+        tickv.get_key(get_hashed_key(b"TWO"), &mut buf).unwrap();
 
         println!("Get non-existant key THREE");
         assert_eq!(
-            tickv.get_key(&mut DefaultHasher::new(), b"THREE", &mut buf),
+            tickv.get_key(get_hashed_key(b"THREE"), &mut buf),
             Err(ErrorCode::KeyNotFound)
         );
     }
@@ -351,39 +345,34 @@ mod store_flast_ctrl {
     #[test]
     fn test_append_and_delete() {
         let mut read_buf: [u8; 1024] = [0; 1024];
-        let tickv =
-            TicKV::<FlashCtrl, DefaultHasher, 1024>::new(FlashCtrl::new(), &mut read_buf, 0x10000);
-        tickv
-            .initalise((&mut DefaultHasher::new(), &mut DefaultHasher::new()))
-            .unwrap();
+        let mut hash_function = DefaultHasher::new();
+        MAIN_KEY.hash(&mut hash_function);
+        let hash = hash_function.finish();
+
+        let tickv = TicKV::<FlashCtrl, 1024>::new(FlashCtrl::new(), &mut read_buf, 0x10000);
+        tickv.initalise(hash).unwrap();
 
         let value: [u8; 32] = [0x23; 32];
         let mut buf: [u8; 32] = [0; 32];
 
         println!("Add Key ONE");
-        tickv
-            .append_key(&mut DefaultHasher::new(), b"ONE", &value)
-            .unwrap();
+        tickv.append_key(get_hashed_key(b"ONE"), &value).unwrap();
 
         println!("Get key ONE");
-        tickv
-            .get_key(&mut DefaultHasher::new(), b"ONE", &mut buf)
-            .unwrap();
+        tickv.get_key(get_hashed_key(b"ONE"), &mut buf).unwrap();
 
         println!("Delete Key ONE");
-        tickv
-            .invalidate_key(&mut DefaultHasher::new(), b"ONE")
-            .unwrap();
+        tickv.invalidate_key(get_hashed_key(b"ONE")).unwrap();
 
         println!("Get non-existant key ONE");
         assert_eq!(
-            tickv.get_key(&mut DefaultHasher::new(), b"ONE", &mut buf),
+            tickv.get_key(get_hashed_key(b"ONE"), &mut buf),
             Err(ErrorCode::KeyNotFound)
         );
 
         println!("Try to delete Key ONE Again");
         assert_eq!(
-            tickv.invalidate_key(&mut DefaultHasher::new(), b"ONE"),
+            tickv.invalidate_key(get_hashed_key(b"ONE")),
             Err(ErrorCode::KeyNotFound)
         );
     }
@@ -391,11 +380,12 @@ mod store_flast_ctrl {
     #[test]
     fn test_garbage_collect() {
         let mut read_buf: [u8; 1024] = [0; 1024];
-        let tickv =
-            TicKV::<FlashCtrl, DefaultHasher, 1024>::new(FlashCtrl::new(), &mut read_buf, 0x10000);
-        tickv
-            .initalise((&mut DefaultHasher::new(), &mut DefaultHasher::new()))
-            .unwrap();
+        let mut hash_function = DefaultHasher::new();
+        MAIN_KEY.hash(&mut hash_function);
+        let hash = hash_function.finish();
+
+        let tickv = TicKV::<FlashCtrl, 1024>::new(FlashCtrl::new(), &mut read_buf, 0x10000);
+        tickv.initalise(hash).unwrap();
 
         let value: [u8; 32] = [0x23; 32];
         let mut buf: [u8; 32] = [0; 32];
@@ -404,31 +394,25 @@ mod store_flast_ctrl {
         assert_eq!(tickv.garbage_collect(), Ok(0));
 
         println!("Add Key ONE");
-        tickv
-            .append_key(&mut DefaultHasher::new(), b"ONE", &value)
-            .unwrap();
+        tickv.append_key(get_hashed_key(b"ONE"), &value).unwrap();
 
         println!("Garbage collect flash with valid key");
         assert_eq!(tickv.garbage_collect(), Ok(0));
 
         println!("Delete Key ONE");
-        tickv
-            .invalidate_key(&mut DefaultHasher::new(), b"ONE")
-            .unwrap();
+        tickv.invalidate_key(get_hashed_key(b"ONE")).unwrap();
 
         println!("Garbage collect flash with deleted key");
         assert_eq!(tickv.garbage_collect(), Ok(1024));
 
         println!("Get non-existant key ONE");
         assert_eq!(
-            tickv.get_key(&mut DefaultHasher::new(), b"ONE", &mut buf),
+            tickv.get_key(get_hashed_key(b"ONE"), &mut buf),
             Err(ErrorCode::KeyNotFound)
         );
 
         println!("Add Key ONE");
-        tickv
-            .append_key(&mut DefaultHasher::new(), b"ONE", &value)
-            .unwrap();
+        tickv.append_key(get_hashed_key(b"ONE"), &value).unwrap();
     }
 }
 
@@ -491,120 +475,85 @@ mod no_check_store_flast_ctrl {
     #[test]
     fn test_region_full() {
         let mut read_buf: [u8; 256] = [0; 256];
-        let tickv =
-            TicKV::<FlashCtrl, DefaultHasher, 256>::new(FlashCtrl::new(), &mut read_buf, 0x200);
-        tickv
-            .initalise((&mut DefaultHasher::new(), &mut DefaultHasher::new()))
-            .unwrap();
+        let mut hash_function = DefaultHasher::new();
+        MAIN_KEY.hash(&mut hash_function);
+        let hash = hash_function.finish();
+
+        let tickv = TicKV::<FlashCtrl, 256>::new(FlashCtrl::new(), &mut read_buf, 0x200);
+        tickv.initalise(hash).unwrap();
 
         let value: [u8; 64] = [0x23; 64];
         let mut buf: [u8; 64] = [0; 64];
 
         println!("Add Key ONE");
-        tickv
-            .append_key(&mut DefaultHasher::new(), b"ONE", &value)
-            .unwrap();
+        tickv.append_key(get_hashed_key(b"ONE"), &value).unwrap();
 
         println!("Add Key TWO");
-        tickv
-            .append_key(&mut DefaultHasher::new(), b"TWO", &value)
-            .unwrap();
+        tickv.append_key(get_hashed_key(b"TWO"), &value).unwrap();
 
         println!("Add Key THREE");
-        tickv
-            .append_key(&mut DefaultHasher::new(), b"THREE", &value)
-            .unwrap();
+        tickv.append_key(get_hashed_key(b"THREE"), &value).unwrap();
 
         println!("Add Key FOUR");
-        tickv
-            .append_key(&mut DefaultHasher::new(), b"FOUR", &value)
-            .unwrap();
+        tickv.append_key(get_hashed_key(b"FOUR"), &value).unwrap();
 
         println!("Add Key FIVE");
-        tickv
-            .append_key(&mut DefaultHasher::new(), b"FIVE", &value)
-            .unwrap();
+        tickv.append_key(get_hashed_key(b"FIVE"), &value).unwrap();
 
         println!("Add Key SIX");
-        tickv
-            .append_key(&mut DefaultHasher::new(), b"SIX", &value)
-            .unwrap();
+        tickv.append_key(get_hashed_key(b"SIX"), &value).unwrap();
 
         println!("Add Key SEVEN");
         assert_eq!(
-            tickv.append_key(&mut DefaultHasher::new(), b"SEVEN", &value),
+            tickv.append_key(get_hashed_key(b"SEVEN"), &value),
             Err(ErrorCode::FlashFull)
         );
 
         println!("Get key ONE");
-        tickv
-            .get_key(&mut DefaultHasher::new(), b"ONE", &mut buf)
-            .unwrap();
+        tickv.get_key(get_hashed_key(b"ONE"), &mut buf).unwrap();
 
         println!("Get key TWO");
-        tickv
-            .get_key(&mut DefaultHasher::new(), b"TWO", &mut buf)
-            .unwrap();
+        tickv.get_key(get_hashed_key(b"TWO"), &mut buf).unwrap();
 
         println!("Get key THREE");
-        tickv
-            .get_key(&mut DefaultHasher::new(), b"THREE", &mut buf)
-            .unwrap();
+        tickv.get_key(get_hashed_key(b"THREE"), &mut buf).unwrap();
 
         println!("Get key FOUR");
-        tickv
-            .get_key(&mut DefaultHasher::new(), b"FOUR", &mut buf)
-            .unwrap();
+        tickv.get_key(get_hashed_key(b"FOUR"), &mut buf).unwrap();
 
         println!("Get key FIVE");
-        tickv
-            .get_key(&mut DefaultHasher::new(), b"FIVE", &mut buf)
-            .unwrap();
+        tickv.get_key(get_hashed_key(b"FIVE"), &mut buf).unwrap();
 
         println!("Get key SIX");
-        tickv
-            .get_key(&mut DefaultHasher::new(), b"SIX", &mut buf)
-            .unwrap();
+        tickv.get_key(get_hashed_key(b"SIX"), &mut buf).unwrap();
 
         println!("Get key SEVEN");
         assert_eq!(
-            tickv.get_key(&mut DefaultHasher::new(), b"SEVEN", &mut buf),
+            tickv.get_key(get_hashed_key(b"SEVEN"), &mut buf),
             Err(ErrorCode::KeyNotFound)
         );
 
         println!("Delete Key ONE");
-        tickv
-            .invalidate_key(&mut DefaultHasher::new(), b"ONE")
-            .unwrap();
+        tickv.invalidate_key(get_hashed_key(b"ONE")).unwrap();
 
         println!("Delete Key TWO");
-        tickv
-            .invalidate_key(&mut DefaultHasher::new(), b"TWO")
-            .unwrap();
+        tickv.invalidate_key(get_hashed_key(b"TWO")).unwrap();
 
         println!("Delete Key THREE");
-        tickv
-            .invalidate_key(&mut DefaultHasher::new(), b"THREE")
-            .unwrap();
+        tickv.invalidate_key(get_hashed_key(b"THREE")).unwrap();
 
         println!("Delete Key FOUR");
-        tickv
-            .invalidate_key(&mut DefaultHasher::new(), b"FOUR")
-            .unwrap();
+        tickv.invalidate_key(get_hashed_key(b"FOUR")).unwrap();
 
         println!("Delete Key FIVE");
-        tickv
-            .invalidate_key(&mut DefaultHasher::new(), b"FIVE")
-            .unwrap();
+        tickv.invalidate_key(get_hashed_key(b"FIVE")).unwrap();
 
         println!("Delete Key SIX");
-        tickv
-            .invalidate_key(&mut DefaultHasher::new(), b"SIX")
-            .unwrap();
+        tickv.invalidate_key(get_hashed_key(b"SIX")).unwrap();
 
         println!("Delete Key SEVEN");
         assert_eq!(
-            tickv.invalidate_key(&mut DefaultHasher::new(), b"SEVEN"),
+            tickv.invalidate_key(get_hashed_key(b"SEVEN")),
             Err(ErrorCode::KeyNotFound)
         );
     }


### PR DESCRIPTION
### Pull Request Overview

This PR updates the current TicKV implementation to use a pre-hashed key and to generate a CRC32 checksum. This is the first step towards adapting TicKV to use the Tock KV Library HIL.

### Testing Strategy

Run the unit tests.

### TODO or Help Wanted

This PR is good to go, next steps are to connect this up in a capsule and implement the HIL.

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
