### PR TITLE
trd: syscalls, 64 bit types in AAPCS friendly way

### DIFF
--- a/doc/reference/trd-syscalls.md
+++ b/doc/reference/trd-syscalls.md
@@ -149,7 +149,7 @@ for CortexM they are `r0`-`r3` and for RISC-V they are `a0`-`a3`.
 | Success                    | 128  |                    |                    |                    |
 | Success with u32           | 129  | Return Value 0     |                    |                    |
 | Success with 2 u32         | 130  | Return Value 0     | Return Value 1     |                    |
-| Success with u64           | 131  | Return Value 0 LSB | Return Value 0 MSB |                    |
+| Success with u64           | 131  |                    | Return Value 0 LSB | Return Value 0 MSB |
 | Success with 3 u32         | 132  | Return Value 0     | Return Value 1     | Return Value 2     |
 | Success with u32 and u64   | 133  | Return Value 0     | Return Value 1 LSB | Return Value 1 MSB |
 


### PR DESCRIPTION
### Pull Request Overview

Given the goal of minimizing register moving and churn, change the
syscall return for 64-bit values to something that can be expressed
in ARM. From the AAPCS:

> A double-word sized type is passed in two consecutive registers
> (e.g., r0 and > r1, or r2 and r3). The content of the registers
> is as if the value had been loaded from memory representation with
> a single LDM instruction.
>
> If the argument requires double-word alignment (8-byte), the NCRN is rounded
> up to the next even register number.

The point: A function signature of the form `f(int x, long long y);` will map
`x -> r0` and `y -> r2,r3` on ARM.

This change will avoid the need to move 64-bit values.

### Testing Strategy

N/A

### TODO or Help Wanted

N/A

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
