### PR TITLE
Double stack buffer for i.MX RT-based boards, prune panic! allocations

### DIFF
--- a/boards/imxrt1050-evkb/src/io.rs
+++ b/boards/imxrt1050-evkb/src/io.rs
@@ -63,9 +63,8 @@ impl IoWrite for Writer {
 #[panic_handler]
 pub unsafe extern "C" fn panic_fmt(info: &PanicInfo) -> ! {
     // User Led is connected to AdB0_09
-    let ccm = crate::imxrt1050::ccm::Ccm::new();
-    let ports = imxrt1050::gpio::Ports::new(&ccm);
-    let led = &mut led::LedLow::new(ports.pin(PinId::AdB0_09));
+    let pin = imxrt1050::gpio::Pin::from_pin_id(PinId::AdB0_09);
+    let led = &mut led::LedLow::new(&pin);
     let writer = &mut WRITER;
 
     debug::panic(

--- a/boards/imxrt1050-evkb/src/main.rs
+++ b/boards/imxrt1050-evkb/src/main.rs
@@ -59,7 +59,7 @@ static BOOT_HDR: [u8; 8192] = boot_header::BOOT_HDR;
 /// Dummy buffer that causes the linker to reserve enough space for the stack.
 #[no_mangle]
 #[link_section = ".stack_buffer"]
-pub static mut STACK_MEMORY: [u8; 0x1000] = [0; 0x1000];
+pub static mut STACK_MEMORY: [u8; 0x2000] = [0; 0x2000];
 
 // const NUM_LEDS: usize = 1;
 

--- a/boards/teensy40/src/io.rs
+++ b/boards/teensy40/src/io.rs
@@ -48,8 +48,8 @@ impl Write for Writer<'_> {
 #[panic_handler]
 unsafe fn panic_handler(panic_info: &core::panic::PanicInfo) -> ! {
     let ccm = crate::imxrt1060::ccm::Ccm::new();
-    let ports = imxrt10xx::gpio::Ports::new(&ccm);
-    let led = &mut led::LedHigh::new(ports.pin(gpio::PinId::B0_03));
+    let pin = crate::imxrt1060::gpio::Pin::from_pin_id(gpio::PinId::B0_03);
+    let led = &mut led::LedHigh::new(&pin);
     let mut lpuart2 = lpuart::Lpuart::new_lpuart2(&ccm);
     let mut writer = Writer::new(&mut lpuart2);
     debug::panic(

--- a/boards/teensy40/src/main.rs
+++ b/boards/teensy40/src/main.rs
@@ -227,7 +227,7 @@ pub unsafe fn reset_handler() {
 #[no_mangle]
 #[link_section = ".stack_buffer"]
 #[used]
-static mut STACK_BUFFER: [u8; 0x1000] = [0; 0x1000];
+static mut STACK_BUFFER: [u8; 0x2000] = [0; 0x2000];
 
 const FCB_SIZE: usize = core::mem::size_of::<fcb::FCB>();
 

--- a/chips/imxrt10xx/src/gpio.rs
+++ b/chips/imxrt10xx/src/gpio.rs
@@ -569,6 +569,19 @@ impl U32Ext for u32 {
 }
 
 impl<'a> Pin<'a> {
+    /// Fabricate a new `Pin` from a `PinId`
+    pub fn from_pin_id(pin_id: PinId) -> Self {
+        Self::new(
+            match pin_id.port() {
+                GpioPort::GPIO1 => GPIO1_BASE,
+                GpioPort::GPIO2 => GPIO2_BASE,
+                GpioPort::GPIO3 => GPIO3_BASE,
+                GpioPort::GPIO4 => GPIO4_BASE,
+                GpioPort::GPIO5 => GPIO5_BASE,
+            },
+            pin_id.offset(),
+        )
+    }
     const fn new(registers: StaticRef<GpioRegisters>, offset: usize) -> Self {
         Pin {
             registers,


### PR DESCRIPTION
### Pull Request Overview

This pull request doubles the stack buffer for boards that use i.MX RT chips. #2311 added board-based peripheral initialization for i.MX RT boards. We use more stack space (at least ~2KiB, most memory for GPIO pins) to initialize the static peripherals, which might exceed the stack buffer once the kernel starts running. Doubling the stack size seems to suffice for running the kernel and two applications on a Teensy 4.0. This approach is similar to #2223, which noted the issue in STM32 boards.

I first bisected the issue down to a commit in #2334. After that compiler update, I couldn't run the Tock kernel on the Teensy 4.0. But it turns out that, after #2311 and before the updated compiler, a `panic!()` would overflow the stack. So this seems to be a latent issue that manifested with a compiler update. The boards' panic handlers were allocating large GPIO ports structures just to access a single LED. This PR fixes that by exposing a constructor for individual GPIO pins, and using that constructor in the panic handler.

### Testing Strategy

This pull request was tested by rebasing onto trunk, compiling the kernel for a Teensy 4.0, and using the kernel to run two `libtock-c` example apps. Then, I added a `panic!()` just before the main kernel loop, and showed that the panic handler worked as expected.


### TODO or Help Wanted

There may be other boards that allocate large objects (GPIO ports and pins) in the panic handler. See the [stm32f3discovery board](https://github.com/tock/tock/blob/86079650ae9d2e5b7287571a2219050c76aa3f1c/boards/stm32f3discovery/src/io.rs#L72) and the [stm32f412gdiscovery board](https://github.com/tock/tock/blob/86079650ae9d2e5b7287571a2219050c76aa3f1c/boards/stm32f412gdiscovery/src/io.rs#L74) for two examples. Are we aware of this behaviors in these boards, or in other boards?

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
