### PR TITLE
Tock 2.0 syscall TRD: Allow us to add new return variants in the future.

### DIFF
--- a/doc/reference/trd-syscalls.md
+++ b/doc/reference/trd-syscalls.md
@@ -136,7 +136,7 @@ and replaced with `&self` when the actual system call method is invoked.
 ----------------------------------
 
 All system calls have the same return value format. A system call can
-return one of nine variants, having different associated value types,
+return one of several variants, having different associated value types,
 which are shown here. `r0`-`r3` refer to the return value registers:
 for CortexM they are `r0`-`r3` and for RISC-V they are `a0`-`a3`.
 
@@ -173,7 +173,8 @@ The presence of many difference cases suggests that the operation should be spli
 there is non-determinism in its execution or its meaning is overloaded. It also fits
 well with Rust's `Result` type.
 
-All values not specified for r0 in the above table are reserved.
+All 32-bit values not specified for `r0` in the above table are reserved and may
+be used in future Tock versions.
 
 3.3 Error Codes
 ---------------------------------

--- a/doc/reference/trd-syscalls.md
+++ b/doc/reference/trd-syscalls.md
@@ -173,8 +173,10 @@ The presence of many difference cases suggests that the operation should be spli
 there is non-determinism in its execution or its meaning is overloaded. It also fits
 well with Rust's `Result` type.
 
-All 32-bit values not specified for `r0` in the above table are reserved and may
-be used in future Tock versions.
+All 32-bit values not specified for `r0` in the above table are reserved.
+Reserved `r0` values MAY be used by a future TRD and MUST NOT be returned by the
+kernel unless specified in a TRD. Therefore, for future compatibility, userspace
+code MUST tolerate `r0` values that it does not recognize.
 
 3.3 Error Codes
 ---------------------------------


### PR DESCRIPTION
### Pull Request Overview

With the existing wording of the TRD, it is unclear to me whether new return variants can be added in the future. This PR makes the wording unambiguous: new return variants may be added in the future, having arbitrary 32-bit discriminants. Userspace code (e.g. `libtock-rs` and `libtock-c`) must be ready to handle return variants they are unfamiliar with, in case they are run on a newer Tock 2.x kernel than they were written for.

Here are a few reasons why we might want to add return variants in the future:

A. If we add support for 64-bit chips, we *may* want to add a "Success with usize" variant.
B. We may want to do something clever in the future, such as treat the three least-significant bytes of `r0` as separate discriminants for `r1`-`r3`.

We can change this to be more restrictive in the future (e.g. restrict the range to a `u8`) without breaking backwards compatibility.


### Testing Strategy

Looked at the [rendered](https://github.com/jrvanwhy/tock/blob/return-variant-evolution/doc/reference/trd-syscalls.md) document.

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
