### PR TITLE
Tock 2.0 TRD: Allow new error codes to be added in the future.

### DIFF
--- a/doc/reference/trd-syscalls.md
+++ b/doc/reference/trd-syscalls.md
@@ -200,10 +200,11 @@ are additional error codes to include errors related to userspace.
 | 13    | NOACK       | The packet transmission was sent but not acknowledged.                                  |
 | 1024  | BADRVAL     | The variant of the return value did not match what the system call should return.       |
 
-Values in the range of 1-1023 reflect kernel return value error codes. Future
-Tock versions MAY define additional kernel error codes in this range. The kernel
-MUST NOT return an error code greater than 1023; processes MAY rely on kernels
-never returning greater error codes.
+Values in the range 1-1023 reflect kernel return value error codes. Kernel error
+codes not specified above are currently reserved. TRDs MAY specify reserved
+kernel error codes, but MUST NOT specify kernel error codes greater than 1023.
+The Tock kernel MUST NOT return an error code unless the error code is specified
+in a TRD.
 
 Values greater than 1023 are reserved for userspace library use. Value 1024
 (BADRVAL) is for when a system call returns a different failure or success

--- a/doc/reference/trd-syscalls.md
+++ b/doc/reference/trd-syscalls.md
@@ -200,14 +200,14 @@ are additional error codes to include errors related to userspace.
 | 13    | NOACK       | The packet transmission was sent but not acknowledged.                                  |
 | 1024  | BADRVAL     | The variant of the return value did not match what the system call should return.       |
 
-Any value not specified in the above table is reserved and it
-MUST NOT be used.
+Values in the range of 1-1023 reflect kernel return value error codes. Future
+Tock versions MAY define additional kernel error codes in this range. The kernel
+MUST NOT return an error code greater than 1023; processes MAY rely on kernels
+never returning greater error codes.
 
-Values in the range of 1-1023 reflect kernel return value error
-codes. Value 1024 (BADRVAL) is for when a system call returns a
-different failure or success variant than the userspace library
-expects. A kernel implementation of a system call MUST NOT return 
-BADRVAL: it is generated only by userspace library code.
+Values greater than 1023 are reserved for userspace library use. Value 1024
+(BADRVAL) is for when a system call returns a different failure or success
+variant than the userspace library expects.
 
 
 4 System Call API


### PR DESCRIPTION
### Pull Request Overview

This changes the wording of the error code section to be clear about how the error code list may change in the future. It also modifies the wording to allow us to add error codes in future Tock 2.x versions. Last, it restricts the kernel error code range to 1-1023, reducing the memory needed to store a return code to two bytes.

### Testing Strategy

Looked at the [rendered](https://github.com/jrvanwhy/tock/blob/error-code-evolution/doc/reference/trd-syscalls.md) document.

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
