### PR TITLE
Tock 2.0: clarify subscribe behavior w.r.t. invalid/refused callback

### DIFF
--- a/doc/reference/trd-syscalls.md
+++ b/doc/reference/trd-syscalls.md
@@ -351,14 +351,18 @@ unmodified.
 If the passed callback is not valid (is outside process executable
 memory and is not the Null Callback described below), the kernel MUST
 NOT invoke the requested driver and MUST immediately return a failure
-with a return code of EINVAL.
+with a return code of EINVAL. The currently registered callback
+remains registered and the kernel does not cancel any pending invocations
+of the existing callback.
 
-A passed callback MUST be valid until the next invocation of `subscribe`
-with the same syscall and driver identifier. When userspace invokes
-subscribe, the kernel MUST cancel all pending callbacks for that driver
-and subscribe identifier: it MUST NOT invoke the previous callback after
-the call to subscribe, and MUST NOT invoke the new callback for events
-that occurred before the call to subscribe.
+Any callback passed from a process MUST remain valid until the next successful invocation of
+`subscribe` by that process with the same syscall and driver identifier. When
+a process makes a successful subscribe system call (one which results
+in the `Success with 2 u32` return variant), the kernel MUST cancel
+all pending callbacks on that process for that driver and subscribe identifier: it
+MUST NOT invoke the previous callback after the call to `subscribe`, and
+MUST NOT invoke the new callback for events that the kernel handled before the
+call to `subscribe`.
 
 Note that these semantics create a period over which callbacks might
 be lost: any callbacks that were pending when `subscribe` was called


### PR DESCRIPTION
### Pull Request Overview

The description of the Subscribe system call semantics was possibly contradicting itself by stating that, in case of passing an invalid Callback, both

- the driver would never be invoked and
- the previously registered callback must not be invoked after the call to subscribe.

This resolves this issue by clearly stating that only in case of "accepted" callbacks (i.e. the kernel has invoked the driver's `subscribe`method AND the driver has returned the old callback through the `Ok` variant) this guarantee is made.

Fixes #2396
Reported-By: @ppannuto 

### Testing Strategy

N/A

### TODO or Help Wanted

It's going to be very interesting to see how this is actually going to be implemented, as it implicitly imposes some requirements about the precise ordering of when a callback is deemed "valid", when the driver is invoked and when the callback queue is cleared. A valid implementation strategy could look like:
- the kernel checks whether a callback is "valid" (optional, see #2270 for a discussion on whether that's necessary / a good idea)
- the kernel invokes the driver's `subscribe` method
- _if_ the callback has been swapped successfully, the callback queue would be cleared

This would have two major consequences:
- we would need to guarantee that, because during the invocation of `subscribe` the driver has access to both the new and old Callbacks, it cannot queue a callback on the new address and at the same time revoke it
- by clearing the callback queue _after_ the driver's `subscribe` was invoked, any callbacks which were queued while executing `subscribe` would be removed as well

Nonetheless, having a clear definition in the TRD is important. All other ways I can think of to implement something like this would come with similar headaches.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
