### PR TITLE
Tock 2.0: fix system call return variant discriminators

### DIFF
--- a/kernel/src/syscall.rs
+++ b/kernel/src/syscall.rs
@@ -213,8 +213,8 @@ pub enum SyscallReturnVariant {
     Success = 128,
     SuccessU32 = 129,
     SuccessU32U32 = 130,
-    SuccessU32U32U32 = 131,
-    SuccessU64 = 132,
+    SuccessU64 = 131,
+    SuccessU32U32U32 = 132,
     SuccessU64U32 = 133,
 }
 


### PR DESCRIPTION
### Pull Request Overview

The discriminators for the return variants

- Success with u64 (`131`) and
- Success with 3 u32 (`132`)

were accidentally swapped in the initial implementation. This implements the correct encoding as per the Syscalls Tock Reference Document.

Fixes: 78bfb87c2a747e ("Implement the 2.0 syscall return value types")
Reported-by: Pat Pannuto <pat.pannuto@gmail.com> (@ppannuto) in #2394 

### Testing Strategy

This pull request was not tested. It was verified that `libtock-c` does indeed use the correct encoding as specified in the TRD.


### TODO or Help Wanted

N/A

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
