### PR TITLE
Tock 2.0: port #2383 (kernel: Remove setting/tracking the stack pointer in process.rs)

### DIFF
--- a/arch/rv32i/src/syscall.rs
+++ b/arch/rv32i/src/syscall.rs
@@ -52,12 +52,29 @@ impl SysCall {
 impl kernel::syscall::UserspaceKernelBoundary for SysCall {
     type StoredState = Riscv32iStoredState;
 
+    fn initial_process_app_brk_size(&self) -> usize {
+        // TOCK 1.X
+        //
+        // We do not need any memory to start with, but the 1.x Tock kernel
+        // allocates at least 3 kB to processes, and we need to ensure that
+        // happens as userspace may expect it.
+        3 * 1024
+
+        // TOCK 2.0
+        //
+        // The RV32I UKB implementation does not use process memory for any
+        // context switch state. Therefore, we do not need any process-accessible
+        // memory to start with to successfully context switch to the process the
+        // first time.
+        //0
+    }
+
     unsafe fn initialize_process(
         &self,
-        stack_pointer: *const usize,
-        _stack_size: usize,
+        accessible_memory_start: *const u8,
+        _app_brk: *const u8,
         state: &mut Self::StoredState,
-    ) -> Result<*const usize, ()> {
+    ) -> Result<(), ()> {
         // Need to clear the stored state when initializing.
         state.regs.iter_mut().for_each(|x| *x = 0);
         state.pc = 0;
@@ -65,19 +82,26 @@ impl kernel::syscall::UserspaceKernelBoundary for SysCall {
 
         // The first time the process runs we need to set the initial stack
         // pointer in the sp register.
-        state.regs[R_SP] = stack_pointer as u32;
+        //
+        // TOCK 1.X
+        state.regs[R_SP] = accessible_memory_start.add(3 * 1024) as u32;
+        //
+        // TOCK 2.0
+        //
+        // We do not pre-allocate any stack for RV32I processes.
+        // state.regs[R_SP] = accessible_memory_start as usize;
 
-        // Just return the stack pointer. For the RISC-V arch we do not need
-        // to make a stack frame to start the process.
-        Ok(stack_pointer as *mut usize)
+        // We do not use memory for UKB, so just return ok.
+        Ok(())
     }
 
     unsafe fn set_syscall_return_value(
         &self,
-        _stack_pointer: *const usize,
+        _accessible_memory_start: *const u8,
+        _app_brk: *const u8,
         state: &mut Self::StoredState,
         return_value: kernel::syscall::GenericSyscallReturnValue,
-    ) {
+    ) -> Result<(), ()> {
         // Encode the system call return value into registers,
         // available for when the process resumes
 
@@ -102,15 +126,18 @@ impl kernel::syscall::UserspaceKernelBoundary for SysCall {
             &mut a2slice[0],
             &mut a3slice[0],
         );
+
+        // We do not use process memory, so this cannot fail.
+        Ok(())
     }
 
     unsafe fn set_process_function(
         &self,
-        stack_pointer: *const usize,
-        _remaining_stack_memory: usize,
+        _accessible_memory_start: *const u8,
+        _app_brk: *const u8,
         state: &mut Riscv32iStoredState,
         callback: kernel::procs::FunctionCall,
-    ) -> Result<*mut usize, *mut usize> {
+    ) -> Result<(), ()> {
         // Set the register state for the application when it starts
         // executing. These are the argument registers.
         state.regs[R_A0] = callback.argument0 as u32;
@@ -129,16 +156,17 @@ impl kernel::syscall::UserspaceKernelBoundary for SysCall {
         // Save the PC we expect to execute.
         state.pc = callback.pc as u32;
 
-        Ok(stack_pointer as *mut usize)
+        Ok(())
     }
 
     // Mock implementation for tests on Travis-CI.
     #[cfg(not(any(target_arch = "riscv32", target_os = "none")))]
     unsafe fn switch_to_process(
         &self,
-        _stack_pointer: *const usize,
+        _accessible_memory_start: *const u8,
+        _app_brk: *const u8,
         _state: &mut Riscv32iStoredState,
-    ) -> (*mut usize, ContextSwitchReason) {
+    ) -> (ContextSwitchReason, Option<*const u8>) {
         // Convince lint that 'mcause' and 'R_A4' are used during test build
         let _cause = mcause::Trap::from(_state.mcause as usize);
         let _arg4 = _state.regs[R_A4];
@@ -148,9 +176,10 @@ impl kernel::syscall::UserspaceKernelBoundary for SysCall {
     #[cfg(all(target_arch = "riscv32", target_os = "none"))]
     unsafe fn switch_to_process(
         &self,
-        _stack_pointer: *const usize,
+        _accessible_memory_start: *const u8,
+        _app_brk: *const u8,
         state: &mut Riscv32iStoredState,
-    ) -> (*mut usize, ContextSwitchReason) {
+    ) -> (ContextSwitchReason, Option<*const u8>) {
         llvm_asm! ("
           // Before switching to the app we need to save the kernel registers to
           // the kernel stack. We then save the stack pointer in the mscratch
@@ -402,12 +431,13 @@ impl kernel::syscall::UserspaceKernelBoundary for SysCall {
             }
         };
         let new_stack_pointer = state.regs[R_SP];
-        (new_stack_pointer as *mut usize, ret)
+        (ret, Some(new_stack_pointer as *const u8))
     }
 
     unsafe fn print_context(
         &self,
-        stack_pointer: *const usize,
+        _accessible_memory_start: *const u8,
+        _app_brk: *const u8,
         state: &Riscv32iStoredState,
         writer: &mut dyn Write,
     ) {
@@ -429,7 +459,7 @@ impl kernel::syscall::UserspaceKernelBoundary for SysCall {
              \r\n R13: {:#010X}    R29: {:#010X}\
              \r\n R14: {:#010X}    R30: {:#010X}\
              \r\n R15: {:#010X}    R31: {:#010X}\
-             \r\n PC : {:#010X}    SP : {:#010X}\
+             \r\n PC : {:#010X}\
              \r\n\
              \r\n mcause: {:#010X} (",
             0,
@@ -465,7 +495,6 @@ impl kernel::syscall::UserspaceKernelBoundary for SysCall {
             state.regs[14],
             state.regs[30],
             state.pc,
-            stack_pointer as usize,
             state.mcause,
         ));
         crate::print_mcause(mcause::Trap::from(state.mcause as usize), writer);

--- a/kernel/src/syscall.rs
+++ b/kernel/src/syscall.rs
@@ -407,6 +407,13 @@ pub enum ContextSwitchReason {
 /// This trait must be implemented by the architecture of the chip Tock is
 /// running on. It allows the kernel to manage switching to and from processes
 /// in an architecture-agnostic manner.
+///
+/// Since exactly how callbacks and return values are passed between kernelspace
+/// and userspace is implementation specific, and may use process memory to
+/// store state when switching, functions in this trait are passed the bounds of
+/// process-accessible memory so that the implementation can verify it is
+/// reading and writing memory that the process has valid access to. These
+/// bounds are passed through `accessible_memory_start` and `app_brk` pointers.
 pub trait UserspaceKernelBoundary {
     /// Some architecture-specific struct containing per-process state that must
     /// be kept while the process is not running. For example, for keeping CPU
@@ -417,36 +424,64 @@ pub trait UserspaceKernelBoundary {
     /// initialization must happen in the `initialize_process()` function.
     type StoredState: Default;
 
+    /// Called by the kernel during process creation to inform the kernel of the
+    /// minimum amount of process-accessible RAM needed by a new process. This
+    /// allows for architecture-specific process layout decisions, such as stack
+    /// pointer initialization.
+    ///
+    /// This returns the minimum number of bytes of process-accessible memory
+    /// the kernel must allocate to a process so that a successful context
+    /// switch is possible.
+    ///
+    /// Some architectures may not need any allocated memory, and this should
+    /// return 0. In general, implementations should try to pre-allocate the
+    /// minimal amount of process-accessible memory (i.e. return as close to 0
+    /// as possible) to provide the most flexibility to the process. However,
+    /// the return value will be nonzero for architectures where values are
+    /// passed in memory between kernelspace and userspace during syscalls or a
+    /// stack needs to be setup.
+    fn initial_process_app_brk_size(&self) -> usize;
+
     /// Called by the kernel after it has memory allocated to it but before it
     /// is allowed to begin executing. Allows for architecture-specific process
     /// setup, e.g. allocating a syscall stack frame.
     ///
     /// This function must also initialize the stored state (if needed).
     ///
+    /// The kernel calls this function with the start of memory allocated to the
+    /// process by providing `accessible_memory_start`. It also provides the
+    /// `app_brk` pointer which marks the end of process-accessible memory. The
+    /// kernel guarantees that `accessible_memory_start` will be word-aligned.
+    ///
+    /// If successful, this function returns `Ok()`. If the process syscall
+    /// state cannot be initialized with the available amount of memory, or for
+    /// any other reason, it should return `Err()`.
+    ///
     /// This function may be called multiple times on the same process. For
     /// example, if a process crashes and is to be restarted, this must be
     /// called. Or if the process is moved this may need to be called.
     unsafe fn initialize_process(
         &self,
-        stack_pointer: *const usize,
-        stack_size: usize,
+        accessible_memory_start: *const u8,
+        app_brk: *const u8,
         state: &mut Self::StoredState,
-    ) -> Result<*const usize, ()>;
+    ) -> Result<(), ()>;
 
     /// Set the return value the process should see when it begins executing
     /// again after the syscall. This will only be called after a process has
     /// called a syscall.
     ///
-    /// To help implementations, both the current stack pointer of the process
-    /// and the saved state for the process are provided. The `return_value` is
-    /// the value that should be passed to the process so that when it resumes
-    /// executing it knows the return value of the syscall it called.
+    /// The process to set the return value for is specified by the `state`
+    /// value. The `return_value` is the value that should be passed to the
+    /// process so that when it resumes executing it knows the return value of
+    /// the syscall it called.
     unsafe fn set_syscall_return_value(
         &self,
-        stack_pointer: *const usize,
+        accessible_memory_start: *const u8,
+        app_brk: *const u8,
         state: &mut Self::StoredState,
         return_value: GenericSyscallReturnValue,
-    );
+    ) -> Result<(), ()>;
 
     /// Set the function that the process should execute when it is resumed.
     /// This has two major uses: 1) sets up the initial function call to
@@ -459,46 +494,53 @@ pub trait UserspaceKernelBoundary {
     ///
     /// ### Arguments
     ///
-    /// - `stack_pointer` is the address of the stack pointer for the current
-    ///   app.
-    /// - `remaining_stack_memory` is the number of bytes below the
-    ///   `stack_pointer` that is allocated for the process. This value is
-    ///   checked by the implementer to ensure that there is room for this stack
-    ///   frame without overflowing the stack.
+    /// - `accessible_memory_start` is the address of the start of the
+    ///   process-accessible memory region for this process.
+    /// - `app_brk` is the address of the current process break. This marks the
+    ///   end of the memory region the process has access to. Note, this is not
+    ///   the end of the entire memory region allocated to the process. Some
+    ///   memory above this address is still allocated for the process, but if
+    ///   the process tries to access it an MPU fault will occur.
     /// - `state` is the stored state for this process.
     /// - `callback` is the function that should be executed when the process
     ///   resumes.
     ///
     /// ### Return
     ///
-    /// Returns `Ok` or `Err` with the current address of the stack pointer for
-    /// the process. One reason for returning `Err` is that adding the function
-    /// call requires adding to the stack, and there is insufficient room on the
-    /// stack to add the function call.
+    /// Returns `Ok(())` if the function was successfully enqueued for the
+    /// process. Returns `Err(())` if the function was not, likely because there
+    /// is insufficient memory available to do so.
     unsafe fn set_process_function(
         &self,
-        stack_pointer: *const usize,
-        remaining_stack_memory: usize,
+        accessible_memory_start: *const u8,
+        app_brk: *const u8,
         state: &mut Self::StoredState,
         callback: process::FunctionCall,
-    ) -> Result<*mut usize, *mut usize>;
+    ) -> Result<(), ()>;
 
     /// Context switch to a specific process.
     ///
-    /// This returns a tuple:
-    /// - The new stack pointer address of the process.
-    /// - Why the process stopped executing and switched back to the kernel.
+    /// This returns two values in a tuple.
+    ///
+    /// 1. A `ContextSwitchReason` indicating why the process stopped executing
+    ///    and switched back to the kernel.
+    /// 2. Optionally, the current stack pointer used by the process. This is
+    ///    optional because it is only for debugging in process.rs. By sharing
+    ///    the process's stack pointer with process.rs users can inspect the
+    ///    state and see the stack depth, which might be useful for debugging.
     unsafe fn switch_to_process(
         &self,
-        stack_pointer: *const usize,
+        accessible_memory_start: *const u8,
+        app_brk: *const u8,
         state: &mut Self::StoredState,
-    ) -> (*mut usize, ContextSwitchReason);
+    ) -> (ContextSwitchReason, Option<*const u8>);
 
     /// Display architecture specific (e.g. CPU registers or status flags) data
-    /// for a process identified by its stack pointer.
+    /// for a process identified by the stored state for that process.
     unsafe fn print_context(
         &self,
-        stack_pointer: *const usize,
+        accessible_memory_start: *const u8,
+        app_brk: *const u8,
         state: &Self::StoredState,
         writer: &mut dyn Write,
     );


### PR DESCRIPTION
### Pull Request Overview

This pull request ports the changes of #2383 ("kernel: Remove setting/tracking the stack pointer in process.rs", thanks @bradjc!) to `tock-2.0-dev`.

This is a draft PR, because
- the changes are not yet tested
- I believe it would be a good idea to rework the stack management as already proposed in the `syscall.rs` implementations for `rv32i` and `cortex-m` in this PR, such that processes start preallocated with the smallest stack possible. I'd try to implement this in the coming days for `libtock-c` and update this PR accordingly.
- ...with that implemented, the documentation can be updated as part of this PR as well.

I'm opening this PR now to indicate that at least someone is working on it :smile:.

I'd be happy about feedback regarding the merge result.


### Testing Strategy

This pull request *is not yet tested*.


### TODO or Help Wanted

This pull request still needs actually changing the initial stack allocation for `rv32i` and `cortex-m`, along with userspace support and testing.


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
