### PR TITLE
Port MAX17205 system call capsule to 2.0

### DIFF
--- a/capsules/src/max17205.rs
+++ b/capsules/src/max17205.rs
@@ -38,9 +38,9 @@
 //! ```
 
 use core::cell::Cell;
-use kernel::common::cells::{OptionalCell, TakeCell};
+use kernel::common::cells::{MapCell, OptionalCell, TakeCell};
 use kernel::hil::i2c;
-use kernel::{AppId, Callback, LegacyDriver, ReturnCode};
+use kernel::{AppId, Callback, CommandResult, Driver, ErrorCode, ReturnCode};
 
 /// Syscall driver number.
 use crate::driver;
@@ -361,14 +361,14 @@ impl i2c::I2CClient for MAX17205<'_> {
 
 pub struct MAX17205Driver<'a> {
     max17205: &'a MAX17205<'a>,
-    callback: OptionalCell<Callback>,
+    callback: MapCell<Callback>,
 }
 
 impl<'a> MAX17205Driver<'a> {
     pub fn new(max: &'a MAX17205) -> MAX17205Driver<'a> {
         MAX17205Driver {
             max17205: max,
-            callback: OptionalCell::empty(),
+            callback: MapCell::new(Callback::default()),
         }
     }
 }
@@ -410,7 +410,7 @@ impl MAX17205Client for MAX17205Driver<'_> {
     }
 }
 
-impl LegacyDriver for MAX17205Driver<'_> {
+impl Driver for MAX17205Driver<'_> {
     /// Setup callback.
     ///
     /// ### `subscribe_num`
@@ -419,17 +419,23 @@ impl LegacyDriver for MAX17205Driver<'_> {
     fn subscribe(
         &self,
         subscribe_num: usize,
-        callback: Option<Callback>,
+        callback: Callback,
         _app_id: AppId,
-    ) -> ReturnCode {
+    ) -> Result<Callback, (Callback, ErrorCode)> {
         match subscribe_num {
             0 => {
-                self.callback.insert(callback);
-                ReturnCode::SUCCESS
+                if let Some(prev) = self.callback.replace(callback) {
+                    Ok(prev)
+                } else {
+                    // TODO(alevy): This should never happen because we start with a full MapCell
+                    // and only ever replace it. This is just defensive until this module becomes
+                    // multi-user, which will preclude the need for a MapCell in the first place.
+                    Ok(Callback::default())
+                }
             }
 
             // default
-            _ => ReturnCode::ENOSUPPORT,
+            _ => Err((callback, ErrorCode::NOSUPPORT)),
         }
     }
 
@@ -443,27 +449,27 @@ impl LegacyDriver for MAX17205Driver<'_> {
     /// - `3`: Read the current voltage and current draw.
     /// - `4`: Read the raw coulomb count.
     /// - `5`: Read the unique 64 bit RomID.
-    fn command(&self, command_num: usize, _data: usize, _: usize, _: AppId) -> ReturnCode {
+    fn command(&self, command_num: usize, _data: usize, _: usize, _: AppId) -> CommandResult {
         match command_num {
-            0 => ReturnCode::SUCCESS,
+            0 => CommandResult::success(),
 
             // read status
-            1 => self.max17205.setup_read_status(),
+            1 => self.max17205.setup_read_status().into(),
 
             // get soc
-            2 => self.max17205.setup_read_soc(),
+            2 => self.max17205.setup_read_soc().into(),
 
             // get voltage & current
-            3 => self.max17205.setup_read_curvolt(),
+            3 => self.max17205.setup_read_curvolt().into(),
 
             // get raw coulombs
-            4 => self.max17205.setup_read_coulomb(),
+            4 => self.max17205.setup_read_coulomb().into(),
 
             //
-            5 => self.max17205.setup_read_romid(),
+            5 => self.max17205.setup_read_romid().into(),
 
             // default
-            _ => ReturnCode::ENOSUPPORT,
+            _ => CommandResult::failure(ErrorCode::NOSUPPORT),
         }
     }
 }


### PR DESCRIPTION
### Pull Request Overview

This pull request ports the MAX17205 "Fuel Guage" system call capsule to the new 2.0 driver interface.

This capsule is _not_ multi-process friendly, so this port is a tad bit
kludgey (in particular, need to use `MapCell` to store the callback,
unlike with other capsules).

I've also left ReturnCode in place for the internal interface since the
client/driver interface can probably generally be improved with the
removal of ReturnCode, but it's a fairly breaking change.

### Testing Strategy

This driver is only currently used (as far as we know) on Signpost. Luckily, @ppannuto has volunteered to help test!


### Documentation Updated

- [X] ~~Updated the relevant files in `/docs`, or no updates are required.~~

### Formatting

- [X] Ran `make prepush`.
