### PR TITLE
Port BLE advertising to new 2.0 driver interface

### DIFF
--- a/boards/acd52832/src/main.rs
+++ b/boards/acd52832/src/main.rs
@@ -96,7 +96,7 @@ impl kernel::Platform for Platform {
             capsules::led::DRIVER_NUM => f(Some(Ok(self.led))),
             capsules::button::DRIVER_NUM => f(Some(Ok(self.button))),
             capsules::rng::DRIVER_NUM => f(Some(Ok(self.rng))),
-            capsules::ble_advertising_driver::DRIVER_NUM => f(Some(Err(self.ble_radio))),
+            capsules::ble_advertising_driver::DRIVER_NUM => f(Some(Ok(self.ble_radio))),
             capsules::temperature::DRIVER_NUM => f(Some(Ok(self.temp))),
             capsules::gpio_async::DRIVER_NUM => f(Some(Ok(self.gpio_async))),
             capsules::ambient_light::DRIVER_NUM => f(Some(Ok(self.light))),

--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -146,7 +146,7 @@ impl kernel::Platform for Platform {
             capsules::button::DRIVER_NUM => f(Some(Ok(self.button))),
             capsules::screen::DRIVER_NUM => f(Some(Ok(self.screen))),
             capsules::rng::DRIVER_NUM => f(Some(Ok(self.rng))),
-            capsules::ble_advertising_driver::DRIVER_NUM => f(Some(Err(self.ble_radio))),
+            capsules::ble_advertising_driver::DRIVER_NUM => f(Some(Ok(self.ble_radio))),
             capsules::ieee802154::DRIVER_NUM => f(Some(Ok(self.ieee802154_radio))),
             capsules::temperature::DRIVER_NUM => f(Some(Ok(self.temperature))),
             capsules::humidity::DRIVER_NUM => f(Some(Ok(self.humidity))),

--- a/boards/microbit_v2/src/main.rs
+++ b/boards/microbit_v2/src/main.rs
@@ -124,7 +124,7 @@ impl kernel::Platform for Platform {
             capsules::temperature::DRIVER_NUM => f(Some(Ok(self.temperature))),
             capsules::lsm303agr::DRIVER_NUM => f(Some(Ok(self.lsm303agr))),
             capsules::rng::DRIVER_NUM => f(Some(Ok(self.rng))),
-            capsules::ble_advertising_driver::DRIVER_NUM => f(Some(Err(self.ble_radio))),
+            capsules::ble_advertising_driver::DRIVER_NUM => f(Some(Ok(self.ble_radio))),
             capsules::buzzer_driver::DRIVER_NUM => f(Some(Ok(self.buzzer))),
             capsules::app_flash_driver::DRIVER_NUM => f(Some(Ok(self.app_flash))),
             capsules::sound_pressure::DRIVER_NUM => f(Some(Ok(self.sound_pressure))),

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -139,7 +139,7 @@ impl kernel::Platform for Platform {
             capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
             capsules::led::DRIVER_NUM => f(Some(Ok(self.led))),
             capsules::rng::DRIVER_NUM => f(Some(Ok(self.rng))),
-            capsules::ble_advertising_driver::DRIVER_NUM => f(Some(Err(self.ble_radio))),
+            capsules::ble_advertising_driver::DRIVER_NUM => f(Some(Ok(self.ble_radio))),
             capsules::ieee802154::DRIVER_NUM => f(Some(Ok(self.ieee802154_radio))),
             kernel::ipc::DRIVER_NUM => f(Some(Err(&self.ipc))),
             _ => f(None),

--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -111,7 +111,7 @@ impl kernel::Platform for Platform {
             capsules::led::DRIVER_NUM => f(Some(Ok(self.led))),
             capsules::button::DRIVER_NUM => f(Some(Ok(self.button))),
             capsules::rng::DRIVER_NUM => f(Some(Ok(self.rng))),
-            capsules::ble_advertising_driver::DRIVER_NUM => f(Some(Err(self.ble_radio))),
+            capsules::ble_advertising_driver::DRIVER_NUM => f(Some(Ok(self.ble_radio))),
             capsules::ieee802154::DRIVER_NUM => f(Some(Ok(self.ieee802154_radio))),
             capsules::temperature::DRIVER_NUM => f(Some(Ok(self.temp))),
             capsules::analog_comparator::DRIVER_NUM => f(Some(Ok(self.analog_comparator))),

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -187,7 +187,7 @@ impl kernel::Platform for Platform {
             capsules::led::DRIVER_NUM => f(Some(Ok(self.led))),
             capsules::button::DRIVER_NUM => f(Some(Ok(self.button))),
             capsules::rng::DRIVER_NUM => f(Some(Ok(self.rng))),
-            capsules::ble_advertising_driver::DRIVER_NUM => f(Some(Err(self.ble_radio))),
+            capsules::ble_advertising_driver::DRIVER_NUM => f(Some(Ok(self.ble_radio))),
             capsules::ieee802154::DRIVER_NUM => f(Some(Ok(self.ieee802154_radio))),
             capsules::temperature::DRIVER_NUM => f(Some(Ok(self.temp))),
             capsules::analog_comparator::DRIVER_NUM => f(Some(Ok(self.analog_comparator))),

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -170,7 +170,7 @@ impl kernel::Platform for Platform {
             capsules::led::DRIVER_NUM => f(Some(Ok(self.led))),
             capsules::button::DRIVER_NUM => f(Some(Ok(self.button))),
             capsules::rng::DRIVER_NUM => f(Some(Ok(self.rng))),
-            capsules::ble_advertising_driver::DRIVER_NUM => f(Some(Err(self.ble_radio))),
+            capsules::ble_advertising_driver::DRIVER_NUM => f(Some(Ok(self.ble_radio))),
             capsules::temperature::DRIVER_NUM => f(Some(Ok(self.temp))),
             capsules::analog_comparator::DRIVER_NUM => f(Some(Ok(self.analog_comparator))),
             kernel::ipc::DRIVER_NUM => f(Some(Err(&self.ipc))),

--- a/boards/redboard_artemis_nano/src/main.rs
+++ b/boards/redboard_artemis_nano/src/main.rs
@@ -77,7 +77,7 @@ impl Platform for RedboardArtemisNano {
             capsules::gpio::DRIVER_NUM => f(Some(Ok(self.gpio))),
             capsules::console::DRIVER_NUM => f(Some(Ok(self.console))),
             capsules::i2c_master::DRIVER_NUM => f(Some(Ok(self.i2c_master))),
-            capsules::ble_advertising_driver::DRIVER_NUM => f(Some(Err(self.ble_radio))),
+            capsules::ble_advertising_driver::DRIVER_NUM => f(Some(Ok(self.ble_radio))),
             _ => f(None),
         }
     }

--- a/capsules/src/ble_advertising_driver.rs
+++ b/capsules/src/ble_advertising_driver.rs
@@ -10,13 +10,14 @@
 //! Data payloads are limited to 31 bytes since the maximum advertising channel
 //! protocol data unit (PDU) is 37 bytes and includes a 6-byte header.
 //!
-//! ### Allow system call
+//! ### Allow system calls
 //!
-//! The allow systems calls are used for buffers from allocated by userland
+//! There is one ReadWrite and one ReadOnly allow buffers, both at index `0`.
 //!
-//! There are two different buffers:
-//! * 0: Advertising data
-//! * 1: Passive scanning buffer
+//! * ReadOnly: Advertising data, containing the full _payload_ (i.e. excluding the header) the
+//!             process wishes to advertise.
+//! * ReadWrite: Passive scanning buffer, which is populated during BLE scans with complete (i.e.
+//!              including headers) advertising packets received on channels 37, 38 and 39.
 //!
 //! The possible return codes from the 'allow' system call indicate the following:
 //!
@@ -102,12 +103,15 @@
 
 use core::cell::Cell;
 use core::cmp;
+use core::mem;
 use kernel::common::cells::OptionalCell;
 use kernel::debug;
 use kernel::hil::ble_advertising;
 use kernel::hil::ble_advertising::RadioChannel;
 use kernel::hil::time::{Frequency, Ticks};
-use kernel::{AppSlice, ReturnCode, SharedReadWrite};
+use kernel::{
+    CommandResult, ErrorCode, Read, ReadOnlyAppSlice, ReadWrite, ReadWriteAppSlice, ReturnCode,
+};
 
 /// Syscall driver number.
 use crate::driver;
@@ -170,7 +174,7 @@ pub struct App {
     alarm_data: AlarmData,
 
     // Advertising meta-data
-    adv_data: Option<AppSlice<SharedReadWrite, u8>>,
+    adv_data: ReadOnlyAppSlice,
     address: [u8; PACKET_ADDR_LEN],
     pdu_type: AdvPduType,
     advertisement_interval_ms: u32,
@@ -183,19 +187,19 @@ pub struct App {
     random_nonce: u32,
 
     // Scanning meta-data
-    scan_buffer: Option<AppSlice<SharedReadWrite, u8>>,
-    scan_callback: Option<kernel::Callback>,
+    scan_buffer: ReadWriteAppSlice,
+    scan_callback: kernel::Callback,
 }
 
 impl Default for App {
     fn default() -> App {
         App {
             alarm_data: AlarmData::new(),
-            adv_data: None,
-            scan_buffer: None,
+            adv_data: ReadOnlyAppSlice::default(),
+            scan_buffer: ReadWriteAppSlice::default(),
             address: [0; PACKET_ADDR_LEN],
             pdu_type: ADV_NONCONN_IND,
-            scan_callback: None,
+            scan_callback: kernel::Callback::default(),
             process_status: Some(BLEState::NotInitialized),
             tx_power: 0,
             advertisement_interval_ms: 200,
@@ -222,7 +226,7 @@ impl App {
     // Byte 2-5          random
     // Byte 6            0xf0
     // FIXME: For now use AppId as "randomness"
-    fn generate_random_address(&mut self, appid: kernel::AppId) -> ReturnCode {
+    fn generate_random_address(&mut self, appid: kernel::AppId) -> Result<(), ErrorCode> {
         self.address = [
             0xf0,
             (appid.id() & 0xff) as u8,
@@ -231,7 +235,7 @@ impl App {
             ((appid.id() << 24) & 0xff) as u8,
             0xf0,
         ];
-        ReturnCode::SUCCESS
+        Ok(())
     }
 
     fn send_advertisement<'a, B, A>(&self, ble: &BLE<'a, B, A>, channel: RadioChannel) -> ReturnCode
@@ -239,7 +243,7 @@ impl App {
         B: ble_advertising::BleAdvertisementDriver<'a> + ble_advertising::BleConfig,
         A: kernel::hil::time::Alarm<'a>,
     {
-        self.adv_data.as_ref().map_or(ReturnCode::FAIL, |adv_data| {
+        self.adv_data.map_or(ReturnCode::FAIL, |adv_data| {
             ble.kernel_tx.take().map_or(ReturnCode::FAIL, |kernel_tx| {
                 let adv_data_len = cmp::min(kernel_tx.len() - PACKET_ADDR_LEN - 2, adv_data.len());
                 let adv_data_corrected = &adv_data.as_ref()[..adv_data_len];
@@ -452,20 +456,14 @@ where
 
                 if len <= PACKET_LENGTH as u8 && result == ReturnCode::SUCCESS {
                     // write to buffer in userland
-                    let success = app
-                        .scan_buffer
-                        .as_mut()
-                        .map(|userland| {
-                            for (dst, src) in userland.iter_mut().zip(buf[0..len as usize].iter()) {
-                                *dst = *src;
-                            }
-                        })
-                        .is_some();
+                    let success = app.scan_buffer.mut_map_or(false, |userland| {
+                        userland[0..len as usize].copy_from_slice(&buf[0..len as usize]);
+                        true
+                    });
 
                     if success {
-                        app.scan_callback.map(|mut cb| {
-                            cb.schedule(usize::from(result), len as usize, 0);
-                        });
+                        app.scan_callback
+                            .schedule(usize::from(result), len as usize, 0);
                     }
                 }
 
@@ -542,7 +540,7 @@ where
 }
 
 // System Call implementation
-impl<'a, B, A> kernel::LegacyDriver for BLE<'a, B, A>
+impl<'a, B, A> kernel::Driver for BLE<'a, B, A>
 where
     B: ble_advertising::BleAdvertisementDriver<'a> + ble_advertising::BleConfig,
     A: kernel::hil::time::Alarm<'a>,
@@ -553,7 +551,7 @@ where
         data: usize,
         interval: usize,
         appid: kernel::AppId,
-    ) -> ReturnCode {
+    ) -> CommandResult {
         match command_num {
             // Start periodic advertisements
             0 => self
@@ -569,15 +567,15 @@ where
                                 app.advertisement_interval_ms = cmp::max(20, interval as u32);
                                 app.set_next_alarm::<A::Frequency>(self.alarm.now().into_u32());
                                 self.reset_active_alarm();
-                                ReturnCode::SUCCESS
+                                CommandResult::success()
                             }
-                            _ => ReturnCode::EINVAL,
+                            _ => CommandResult::failure(ErrorCode::INVAL),
                         }
                     } else {
-                        ReturnCode::EBUSY
+                        CommandResult::failure(ErrorCode::BUSY)
                     }
                 })
-                .unwrap_or_else(|err| err.into()),
+                .unwrap_or_else(|err| CommandResult::failure(err.into())),
 
             // Stop periodic advertisements or passive scanning
             1 => self
@@ -585,9 +583,9 @@ where
                 .enter(appid, |app, _| match app.process_status {
                     Some(BLEState::AdvertisingIdle) | Some(BLEState::ScanningIdle) => {
                         app.process_status = Some(BLEState::Initialized);
-                        ReturnCode::SUCCESS
+                        CommandResult::success()
                     }
-                    _ => ReturnCode::EBUSY,
+                    _ => CommandResult::failure(ErrorCode::BUSY),
                 })
                 .unwrap_or_else(|err| err.into()),
 
@@ -611,12 +609,12 @@ where
                                     if let ReturnCode::SUCCESS = status {
                                         app.tx_power = tx_power;
                                     }
-                                    status
+                                    status.into()
                                 }
-                                _ => ReturnCode::EINVAL,
+                                _ => CommandResult::failure(ErrorCode::INVAL),
                             }
                         } else {
-                            ReturnCode::EBUSY
+                            CommandResult::failure(ErrorCode::BUSY)
                         }
                     })
                     .unwrap_or_else(|err| err.into())
@@ -630,14 +628,43 @@ where
                         app.process_status = Some(BLEState::ScanningIdle);
                         app.set_next_alarm::<A::Frequency>(self.alarm.now().into_u32());
                         self.reset_active_alarm();
-                        ReturnCode::SUCCESS
+                        CommandResult::success()
                     } else {
-                        ReturnCode::EBUSY
+                        CommandResult::failure(ErrorCode::BUSY)
                     }
                 })
                 .unwrap_or_else(|err| err.into()),
 
-            _ => ReturnCode::ENOSUPPORT,
+            _ => CommandResult::failure(ErrorCode::NOSUPPORT),
+        }
+        .into()
+    }
+
+    fn allow_readonly(
+        &self,
+        appid: kernel::AppId,
+        allow_num: usize,
+        mut slice: ReadOnlyAppSlice,
+    ) -> Result<ReadOnlyAppSlice, (ReadOnlyAppSlice, ErrorCode)> {
+        let res = match allow_num {
+            // Advertisement buffer
+            0 => self
+                .app
+                .enter(appid, |app, _| {
+                    app.generate_random_address(appid).map(|_| {
+                        app.process_status = Some(BLEState::Initialized);
+                        mem::swap(&mut app.adv_data, &mut slice);
+                    })
+                })
+                .unwrap_or_else(|err| Err(err.into())),
+
+            // Operation not supported
+            _ => Err(ErrorCode::NOSUPPORT),
+        };
+
+        match res {
+            Ok(()) => Ok(slice),
+            Err(e) => Err((slice, e)),
         }
     }
 
@@ -645,60 +672,51 @@ where
         &self,
         appid: kernel::AppId,
         allow_num: usize,
-        slice: Option<AppSlice<SharedReadWrite, u8>>,
-    ) -> ReturnCode {
-        match allow_num {
-            // Advertisement buffer
-            0 => self
-                .app
-                .enter(appid, |app, _| {
-                    app.adv_data = slice;
-                    if let ReturnCode::SUCCESS = app.generate_random_address(appid) {
-                        app.process_status = Some(BLEState::Initialized);
-                        ReturnCode::SUCCESS
-                    } else {
-                        ReturnCode::FAIL
-                    }
-                })
-                .unwrap_or_else(|err| err.into()),
-
+        mut slice: ReadWriteAppSlice,
+    ) -> Result<ReadWriteAppSlice, (ReadWriteAppSlice, ErrorCode)> {
+        let res = match allow_num {
             // Passive scanning buffer
-            1 => self
+            0 => self
                 .app
                 .enter(appid, |app, _| match app.process_status {
                     Some(BLEState::NotInitialized) | Some(BLEState::Initialized) => {
-                        app.scan_buffer = slice;
+                        mem::swap(&mut app.scan_buffer, &mut slice);
                         app.process_status = Some(BLEState::Initialized);
-                        ReturnCode::SUCCESS
+                        Ok(())
                     }
-                    _ => ReturnCode::EINVAL,
+                    _ => Err(ErrorCode::INVAL),
                 })
-                .unwrap_or_else(|err| err.into()),
+                .unwrap_or_else(|err| Err(err.into())),
 
             // Operation not supported
-            _ => ReturnCode::ENOSUPPORT,
+            _ => Err(ErrorCode::NOSUPPORT),
+        };
+
+        match res {
+            Ok(()) => Ok(slice),
+            Err(e) => Err((slice, e)),
         }
     }
 
     fn subscribe(
         &self,
         subscribe_num: usize,
-        callback: Option<kernel::Callback>,
+        mut callback: kernel::Callback,
         app_id: kernel::AppId,
-    ) -> ReturnCode {
+    ) -> Result<kernel::Callback, (kernel::Callback, ErrorCode)> {
         match subscribe_num {
             // Callback for scanning
             0 => self
                 .app
                 .enter(app_id, |app, _| match app.process_status {
                     Some(BLEState::NotInitialized) | Some(BLEState::Initialized) => {
-                        app.scan_callback = callback;
-                        ReturnCode::SUCCESS
+                        mem::swap(&mut app.scan_callback, &mut callback);
+                        Ok(callback)
                     }
-                    _ => ReturnCode::EINVAL,
+                    _ => Err((callback, ErrorCode::INVAL)),
                 })
-                .unwrap_or_else(|err| err.into()),
-            _ => ReturnCode::ENOSUPPORT,
+                .unwrap_or_else(|err| Err((callback, err.into()))),
+            _ => Err((callback, ErrorCode::NOSUPPORT)),
         }
     }
 }


### PR DESCRIPTION
### Pull Request Overview

This pull request ports the BLE advertising system call capsule to the new 2.0 driver interface. Most of the port is straight forward translation of `ReturnCode` to `CommandResult` or Result<T, (T, ErrorCode)>, with two noteworthy points:

1. I moved the advertising data to allow_readonly insead of
   allow_readwrite, since it does _not_ need to be writable (and indeed
   putting advertising data in the code segment makes sense). This is a
   breaking change for the userland API, but we're breaking the userland
   API anyway for 2.0.

 2. I did _not_ change the BLE advertising HIL, which includes a bunch
    of ReturnCode's. So ReturnCode is still in there.


### Testing Strategy

Tested with libtock-c changes in tock/libtock-c#173

### TODO or Help Wanted

Port libtock-c counterpart

### Documentation Updated

- [X] ~~Updated the relevant files in `/docs`, or no updates are required.~~

### Formatting

- [X] Ran `make prepush`.
