### PR TITLE
Remove tab characters & protect against accidentally introducing them

### DIFF
--- a/boards/components/src/led.rs
+++ b/boards/components/src/led.rs
@@ -25,17 +25,17 @@ macro_rules! led_component_helper {
         use kernel::static_init;
         const NUM_LEDS: usize = count_expressions!($($L),+);
 
-	static_init!(
-	    [&'static $Led; NUM_LEDS],
-	    [
-		$(
-		    static_init!(
-			$Led,
-			$L
-		    )
-		),+
-	    ]
-	)
+        static_init!(
+            [&'static $Led; NUM_LEDS],
+            [
+                $(
+                    static_init!(
+                        $Led,
+                        $L
+                    )
+                ),+
+            ]
+        )
     };};
 }
 

--- a/boards/components/src/led_matrix.rs
+++ b/boards/components/src/led_matrix.rs
@@ -55,17 +55,17 @@ macro_rules! led_line_component_helper {
         use kernel::static_init;
         const NUM_LEDS: usize = count_expressions!($($L),+);
 
-	static_init!(
-	    [&'static $Pin; NUM_LEDS],
-	    [
-		$(
-		    static_init!(
-			&'static $Pin,
-			$L
-		    )
-		),+
-	    ]
-	)
+        static_init!(
+            [&'static $Pin; NUM_LEDS],
+            [
+                $(
+                    static_init!(
+                        &'static $Pin,
+                        $L
+                    )
+                ),+
+            ]
+        )
     };};
 }
 

--- a/capsules/src/l3gd20.rs
+++ b/capsules/src/l3gd20.rs
@@ -377,9 +377,9 @@ impl Driver for L3gd20Spi<'_> {
     ) -> ReturnCode {
         match subscribe_num {
             0 /* set the one shot callback */ => {
-				self.callback.insert (callback);
-				ReturnCode::SUCCESS
-			},
+                self.callback.insert (callback);
+                ReturnCode::SUCCESS
+            },
             // default
             _ => ReturnCode::ENOSUPPORT,
         }

--- a/capsules/src/lsm303agr.rs
+++ b/capsules/src/lsm303agr.rs
@@ -607,9 +607,9 @@ impl Driver for Lsm303agrI2C<'_> {
     ) -> ReturnCode {
         match subscribe_num {
             0 /* set the one shot callback */ => {
-				self.callback.insert (callback);
-				ReturnCode::SUCCESS
-			},
+                self.callback.insert (callback);
+                ReturnCode::SUCCESS
+            },
             // default
             _ => ReturnCode::ENOSUPPORT,
         }

--- a/capsules/src/lsm303dlhc.rs
+++ b/capsules/src/lsm303dlhc.rs
@@ -621,9 +621,9 @@ impl Driver for Lsm303dlhcI2C<'_> {
     ) -> ReturnCode {
         match subscribe_num {
             0 /* set the one shot callback */ => {
-				self.callback.insert (callback);
-				ReturnCode::SUCCESS
-			},
+                self.callback.insert (callback);
+                ReturnCode::SUCCESS
+            },
             // default
             _ => ReturnCode::ENOSUPPORT,
         }

--- a/capsules/src/mlx90614.rs
+++ b/capsules/src/mlx90614.rs
@@ -199,9 +199,9 @@ impl<'a> Driver for Mlx90614SMBus<'a> {
     ) -> ReturnCode {
         match subscribe_num {
             0 /* set the one shot callback */ => {
-				self.callback.insert(callback);
-				ReturnCode::SUCCESS
-			},
+                self.callback.insert(callback);
+                ReturnCode::SUCCESS
+            },
             // default
             _ => ReturnCode::ENOSUPPORT,
         }

--- a/chips/stm32f303xc/src/i2c.rs
+++ b/chips/stm32f303xc/src/i2c.rs
@@ -227,7 +227,7 @@ const I2C1_BASE: StaticRef<I2CRegisters> =
     unsafe { StaticRef::new(0x4000_5400 as *const I2CRegisters) };
 
 // const I2C2_BASE: StaticRef<I2CRegisters> =
-// 	unsafe { StaticRef::new(0x4000_5800 as *const I2CRegisters) };
+//     unsafe { StaticRef::new(0x4000_5800 as *const I2CRegisters) };
 
 pub struct I2C<'a> {
     registers: StaticRef<I2CRegisters>,

--- a/kernel/src/debug.rs
+++ b/kernel/src/debug.rs
@@ -570,7 +570,7 @@ pub unsafe fn flush<W: Write + IoWrite>(writer: &mut W) {
             if ring_buffer.has_elements() {
                 let _ = writer.write_str(
                     "\r\n---| Debug buffer not empty. Flushing. May repeat some of last message(s):\r\n",
-		);
+                );
 
                 writer.write_ring_buffer(ring_buffer);
             }
@@ -580,7 +580,7 @@ pub unsafe fn flush<W: Write + IoWrite>(writer: &mut W) {
             None => {
                 let _ = writer.write_str(
                     "\r\n---| No debug queue found. You can set it with the DebugQueue component.\r\n",
-		);
+                );
             }
             Some(buffer) => {
                 let _ = writer.write_str("\r\n---| Flushing debug queue:\r\n");

--- a/tools/run_cargo_fmt.sh
+++ b/tools/run_cargo_fmt.sh
@@ -86,6 +86,15 @@ done
 rm xx00
 printf "\rFormatting complete. %-$((39))s\n" ""
 
+# Check for tab characters in Rust source files that haven't been
+# removed by rustfmt
+RUST_FILES_WITH_TABS="$(git grep --files-with-matches $'\t' -- '*.rs' || grep -lr --include '*.rs' $'\t' . || true)"
+if [ "$RUST_FILES_WITH_TABS" != "" ]; then
+        echo "ERROR: The following files contain tab characters, please use spaces instead:"
+        echo "$RUST_FILES_WITH_TABS" | sed 's/^/    -> /'
+        let FAIL=FAIL+1
+fi
+
 if [[ $FAIL -ne 0 ]]; then
 	echo
 	echo "$(tput bold)Formatting errors.$(tput sgr0)"


### PR DESCRIPTION
### Pull Request Overview

This pull request removes tab characters from Tock's Rust codebase, most of which have been accidentally introduced by me. Whoops, sorry!

While I don't want to "police" anyone's code style, Tock's codebase uses almost exclusively spaces. `rustfmt` seems to replace tabs by spaces pretty consistently, but it appears to have a hard time in macro invocations and some other places. Given that there is no _defined_ standard width for representing tabs in Tock's Rust files, and we're interleaving tabs with spaces, this makes for a very inconsistent indentation depending on the editor's configuration.

Furthermore, this adds a check for tab characters in the codebase to the `run_cargo_fmt.sh` script. It uses `git grep` if available, and falls back to the system's `grep` otherwise. It has been tested with GNU `grep` and might require small modifications for BSD `grep`. The check's overhead isn't noticeable (compared to the `cargo fmt` invocations), even on some low-end systems of mine.

Output prior to removing the tab characters from the codebase:
```
$ make format
Formatting complete.                                        
ERROR: The following files contain tab characters, please use spaces instead:
    -> boards/components/src/led.rs
    -> boards/components/src/led_matrix.rs
    -> capsules/src/l3gd20.rs
    -> capsules/src/lsm303agr.rs
    -> capsules/src/lsm303dlhc.rs
    -> capsules/src/mlx90614.rs
    -> chips/stm32f303xc/src/i2c.rs
    -> kernel/src/debug.rs

Formatting errors.
See above for details
make: *** [Makefile:166: tools/.format_fresh] Error 1
```

### Testing Strategy

This pull request was tested by running the script against the codebase with tab characters, and against the properly formatted one. It requires testing on a machine with BSD grep (such as macOS).


### TODO or Help Wanted

I'd appreciate someone with access to a machine having BSD `grep` to test the fallback to the system's installed `grep`.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
