### PR TITLE
2.0: kernel: change filter_syscall to ErrorCode

### DIFF
--- a/doc/Syscalls.md
+++ b/doc/Syscalls.md
@@ -383,14 +383,14 @@ After a system call is made, the call is handled and routed by the Tock kernel
 in [`sched.rs`](../kernel/src/sched.rs) through a series of steps.
 
 1. The kernel calls a platform-provided syscall filter function to determine if
-   it should process the syscall or not. This does not apply to `yield`. The
+   it should handle the syscall or not. This does not apply to `yield`. The
    filter function takes the syscall and which process issued the syscall to
-   return a `Result((), ReturnCode)` to signal if the syscall should be handled
+   return a `Result((), ErrorCode)` to signal if the syscall should be handled
    or if an error should be returned to the process.
 
-   If the filter function disallows the syscall it returns `Err(ReturnCode)` and
-   the `ReturnCode` is provided to the app as the return code for the syscall.
-   Otherwise, the syscall proceeds.
+   If the filter function disallows the syscall it returns `Err(ErrorCode)` and
+   the `ErrorCode` is provided to the process as the return code for the
+   syscall. Otherwise, the syscall proceeds.
 
    _The filter interface is currently considered unstable and subject to change._
 

--- a/kernel/src/platform/mod.rs
+++ b/kernel/src/platform/mod.rs
@@ -1,8 +1,8 @@
 //! Interface for chips and boards.
 
 use crate::driver::{Driver, LegacyDriver};
+use crate::errorcode;
 use crate::process;
-use crate::returncode;
 use crate::syscall;
 use core::fmt::Write;
 
@@ -48,16 +48,18 @@ pub trait Platform {
         F: FnOnce(Option<Result<&dyn Driver, &dyn LegacyDriver>>) -> R;
 
     /// Check the platform-provided system call filter for all non-yield system
-    /// calls.  If the system call is allowed for the provided process then
-    /// return Ok(()).  Otherwise, return Err with a ReturnCode that will be
-    /// returned to the calling application.  The default implementation allows
-    /// all system calls. This API should be considered unstable, and is likely
-    /// to change in the future.
+    /// calls. If the system call is allowed for the provided process then
+    /// return `Ok(())`. Otherwise, return `Err()` with an `ErrorCode` that will
+    /// be returned to the calling application. The default implementation
+    /// allows all system calls.
+    ///
+    /// This API should be considered unstable, and is likely to change in the
+    /// future.
     fn filter_syscall(
         &self,
         _process: &dyn process::ProcessType,
         _syscall: &syscall::Syscall,
-    ) -> Result<(), returncode::ReturnCode> {
+    ) -> Result<(), errorcode::ErrorCode> {
         Ok(())
     }
 }

--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -759,9 +759,7 @@ impl Kernel {
             _ => {
                 // Check all other syscalls for filtering
                 if let Err(response) = platform.filter_syscall(process, &syscall) {
-                    process.set_syscall_return_value(GenericSyscallReturnValue::Legacy(
-                        response.into(),
-                    ));
+                    process.set_syscall_return_value(GenericSyscallReturnValue::Failure(response));
 
                     return;
                 }


### PR DESCRIPTION
### Pull Request Overview

This pull request updates the filter_syscall API to use ErrorCode rather than ReturnCode. I think this is an appropriate change.


### Testing Strategy

travis


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
