### PR TITLE
RISC-V: Add support for detecting locked PMP regions, no need to sort

### DIFF
--- a/arch/rv32i/src/pmp.rs
+++ b/arch/rv32i/src/pmp.rs
@@ -1,14 +1,5 @@
 //! Implementation of the physical memory protection unit (PMP).
 //!
-//! Different PMP implementations support different numbers of PMP entries. To
-//! reduce memory overhead, the PMP implementation supports customizing the
-//! number of supported entries to match the hardware. Ideally we would do this
-//! by templating the implementation on the number of entries, but that is an
-//! experimental feature in Rust. To mimic that functionality, we wrap this
-//! entire PMP implementation in a macro, and then require that each chip with
-//! an PMP instantiate their own PMP implementation with the size customized for
-//! the chip's hardware.
-//!
 //! ## Implementation
 //!
 //! We use the PMP Top of Region (TOR) alignment as there are alignment issues
@@ -47,19 +38,84 @@ register_bitfields![u8,
 ];
 
 /// Main PMP struct.
-pub struct PMP<const NUM_REGIONS: usize, const NUM_REGIONS_OVER_TWO: usize> {
+///
+/// Tock will ignore locked PMP regions. Note that Tock will not make any
+/// attempt to avoid access faults from locked regions.
+///
+/// `NUM_REGIONS_OVER_TWO`: The number of PMP regions divided by 2.
+///  The RISC-V spec mandates that there must be either 0, 16 or 64 PMP
+///  regions implemented. If you are using this PMP struct we are assuming
+///  there are more than 0 implemented. So this value should be either 8 or 32.
+///
+///  If however you know the exact number of PMP regions implemented by your
+///  platform and it's not going to change you can just specify the number.
+///  This means that Tock won't be able to dynamically handle more regions,
+///  but it will reduce runtime space requirements.
+///  Note: that this does not mean all PMP regions are connected.
+///  Some of the regions can be WARL (Write Any Read Legal). All this means
+///  is that accessing `NUM_REGIONS` won't cause a fault.
+pub struct PMP<const NUM_REGIONS_OVER_TWO: usize> {
     /// The application that the MPU was last configured for. Used (along with
     /// the `is_dirty` flag) to determine if MPU can skip writing the
     /// configuration to hardware.
     last_configured_for: MapCell<AppId>,
+    /// This is a 64-bit mask of locked regions.
+    /// Each bit that is set in this mask indicates that the region is locked
+    /// and cannot be used by Tock.
+    locked_region_mask: u64,
+    /// This is the total number of avaliable regions.
+    /// This will be between 0 and NUM_REGIONS_OVER_TWO * 2 depending
+    /// on the hardware and previous boot stages.
+    num_regions: usize,
 }
 
-impl<const NUM_REGIONS: usize, const NUM_REGIONS_OVER_TWO: usize>
-    PMP<NUM_REGIONS, NUM_REGIONS_OVER_TWO>
-{
-    pub const unsafe fn new() -> Self {
+impl<const NUM_REGIONS_OVER_TWO: usize> PMP<NUM_REGIONS_OVER_TWO> {
+    pub unsafe fn new() -> Self {
+        // RISC-V PMP can support from 0 to 64 PMP regions
+        // Let's figure out how many are supported.
+        // We count any regions that are locked as unsupported
+        let mut num_regions = 0;
+        let mut locked_region_mask = 0;
+
+        for i in 0..(NUM_REGIONS_OVER_TWO * 2) {
+            // Read the current value
+            let pmpcfg_og = csr::CSR.pmpcfg[i / 4].get();
+
+            // Flip R, W, X bits
+            let pmpcfg_new = pmpcfg_og ^ (3 << ((i % 4) * 8));
+            csr::CSR.pmpcfg[i / 4].set(pmpcfg_new);
+
+            // Check if the bits are set
+            let pmpcfg_check = csr::CSR.pmpcfg[i / 4].get();
+
+            // Check if the changes stuck
+            if pmpcfg_check == pmpcfg_og {
+                // If we get here then our changes didn't stick, let's figure
+                // out why
+
+                // Check if the locked bit is set
+                if pmpcfg_og & ((1 << 7) << ((i % 4) * 8)) > 0 {
+                    // The bit is locked. Mark this regions as not usable
+                    locked_region_mask |= 1 << i;
+                } else {
+                    // The locked bit isn't set
+                    // This region must not be connected, which means we have run out
+                    // of usable regions, break the loop
+                    break;
+                }
+            } else {
+                // Found a working region
+                num_regions += 1;
+            }
+
+            // Reset back to how we found it
+            csr::CSR.pmpcfg[i / 4].set(pmpcfg_og);
+        }
+
         Self {
             last_configured_for: MapCell::empty(),
+            num_regions,
+            locked_region_mask,
         }
     }
 }
@@ -145,7 +201,7 @@ impl PMPRegion {
 }
 
 /// Struct storing region configuration for RISCV PMP.
-pub struct PMPConfig<const NUM_REGIONS: usize, const NUM_REGIONS_OVER_TWO: usize> {
+pub struct PMPConfig<const NUM_REGIONS_OVER_TWO: usize> {
     /// Array of PMP regions. Each region requires two physical entries.
     regions: [Option<PMPRegion>; NUM_REGIONS_OVER_TWO],
     /// Indicates if the configuration has changed since the last time it was
@@ -155,9 +211,7 @@ pub struct PMPConfig<const NUM_REGIONS: usize, const NUM_REGIONS_OVER_TWO: usize
     app_memory_region: OptionalCell<usize>,
 }
 
-impl<const NUM_REGIONS: usize, const NUM_REGIONS_OVER_TWO: usize> Default
-    for PMPConfig<NUM_REGIONS, NUM_REGIONS_OVER_TWO>
-{
+impl<const NUM_REGIONS_OVER_TWO: usize> Default for PMPConfig<NUM_REGIONS_OVER_TWO> {
     /// `NUM_REGIONS` is the number of PMP entries the hardware supports.
     ///
     /// Since we use TOR, we will use two PMP entries for each region. So the actual
@@ -172,9 +226,7 @@ impl<const NUM_REGIONS: usize, const NUM_REGIONS_OVER_TWO: usize> Default
     }
 }
 
-impl<const NUM_REGIONS: usize, const NUM_REGIONS_OVER_TWO: usize> fmt::Display
-    for PMPConfig<NUM_REGIONS, NUM_REGIONS_OVER_TWO>
-{
+impl<const NUM_REGIONS_OVER_TWO: usize> fmt::Display for PMPConfig<NUM_REGIONS_OVER_TWO> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, " PMP regions:\r\n")?;
         for (n, region) in self.regions.iter().enumerate() {
@@ -187,12 +239,14 @@ impl<const NUM_REGIONS: usize, const NUM_REGIONS_OVER_TWO: usize> fmt::Display
     }
 }
 
-impl<const NUM_REGIONS: usize, const NUM_REGIONS_OVER_TWO: usize>
-    PMPConfig<NUM_REGIONS, NUM_REGIONS_OVER_TWO>
-{
-    fn unused_region_number(&self) -> Option<usize> {
+impl<const NUM_REGIONS_OVER_TWO: usize> PMPConfig<NUM_REGIONS_OVER_TWO> {
+    fn unused_region_number(&self, locked_region_mask: u64) -> Option<usize> {
         for (number, region) in self.regions.iter().enumerate() {
             if self.app_memory_region.contains(&number) {
+                continue;
+            }
+            // This region exists, but is locked
+            if locked_region_mask & (1 << number) > 0 {
                 continue;
             }
             if region.is_none() {
@@ -244,15 +298,13 @@ impl<const NUM_REGIONS: usize, const NUM_REGIONS_OVER_TWO: usize>
     }
 }
 
-impl<const NUM_REGIONS: usize, const NUM_REGIONS_OVER_TWO: usize> kernel::mpu::MPU
-    for PMP<NUM_REGIONS, NUM_REGIONS_OVER_TWO>
-{
-    type MpuConfig = PMPConfig<NUM_REGIONS, NUM_REGIONS_OVER_TWO>;
+impl<const NUM_REGIONS_OVER_TWO: usize> kernel::mpu::MPU for PMP<NUM_REGIONS_OVER_TWO> {
+    type MpuConfig = PMPConfig<NUM_REGIONS_OVER_TWO>;
 
     fn clear_mpu(&self) {
         // We want to disable all of the hardware entries, so we use `NUM_REGIONS` here,
         // and not `NUM_REGIONS / 2`.
-        for x in 0..NUM_REGIONS {
+        for x in 0..(NUM_REGIONS_OVER_TWO * 2) {
             match x % 4 {
                 0 => {
                     csr::CSR.pmpcfg[x / 4].modify(
@@ -314,7 +366,7 @@ impl<const NUM_REGIONS: usize, const NUM_REGIONS_OVER_TWO: usize> kernel::mpu::M
     }
 
     fn number_total_regions(&self) -> usize {
-        NUM_REGIONS / 2
+        self.num_regions / 2
     }
 
     fn allocate_region(
@@ -336,7 +388,7 @@ impl<const NUM_REGIONS: usize, const NUM_REGIONS_OVER_TWO: usize> kernel::mpu::M
             }
         }
 
-        let region_num = config.unused_region_number()?;
+        let region_num = config.unused_region_number(self.locked_region_mask)?;
 
         // Logical region
         let mut start = unallocated_memory_start as usize;
@@ -392,7 +444,7 @@ impl<const NUM_REGIONS: usize, const NUM_REGIONS_OVER_TWO: usize> kernel::mpu::M
         let region_num = if config.app_memory_region.is_some() {
             config.app_memory_region.unwrap_or(0)
         } else {
-            config.unused_region_number()?
+            config.unused_region_number(self.locked_region_mask)?
         };
 
         // App memory size is what we actual set the region to. So this region

--- a/chips/arty_e21_chip/src/chip.rs
+++ b/chips/arty_e21_chip/src/chip.rs
@@ -13,7 +13,7 @@ extern "C" {
 }
 
 pub struct ArtyExx<'a, I: InterruptService<()> + 'a> {
-    pmp: PMP<4, 2>,
+    pmp: PMP<2>,
     userspace_kernel_boundary: rv32i::syscall::SysCall,
     clic: rv32i::clic::Clic,
     machinetimer: &'a rv32i::machine_timer::MachineTimer<'a>,
@@ -142,7 +142,7 @@ impl<'a, I: InterruptService<()> + 'a> ArtyExx<'a, I> {
 }
 
 impl<'a, I: InterruptService<()> + 'a> kernel::Chip for ArtyExx<'a, I> {
-    type MPU = PMP<4, 2>;
+    type MPU = PMP<2>;
     type UserspaceKernelBoundary = rv32i::syscall::SysCall;
     type SchedulerTimer = ();
     type WatchDog = ();

--- a/chips/e310x/src/chip.rs
+++ b/chips/e310x/src/chip.rs
@@ -16,7 +16,7 @@ use kernel::InterruptService;
 
 pub struct E310x<'a, A: 'static + Alarm<'static>, I: InterruptService<()> + 'a> {
     userspace_kernel_boundary: rv32i::syscall::SysCall,
-    pmp: PMP<8, 4>,
+    pmp: PMP<4>,
     plic: &'a Plic,
     scheduler_timer: kernel::VirtualSchedulerTimer<A>,
     timer: &'a rv32i::machine_timer::MachineTimer<'a>,
@@ -105,7 +105,7 @@ impl<'a, A: 'static + Alarm<'static>, I: InterruptService<()> + 'a> E310x<'a, A,
 impl<'a, A: 'static + Alarm<'static>, I: InterruptService<()> + 'a> kernel::Chip
     for E310x<'a, A, I>
 {
-    type MPU = PMP<8, 4>;
+    type MPU = PMP<4>;
     type UserspaceKernelBoundary = rv32i::syscall::SysCall;
     type SchedulerTimer = kernel::VirtualSchedulerTimer<A>;
     type WatchDog = ();

--- a/chips/earlgrey/src/chip.rs
+++ b/chips/earlgrey/src/chip.rs
@@ -16,7 +16,7 @@ use crate::plic::PLIC;
 
 pub struct EarlGrey<'a, A: 'static + Alarm<'static>, I: InterruptService<()> + 'a> {
     userspace_kernel_boundary: SysCall,
-    pmp: PMP<4, 2>,
+    pmp: PMP<8>,
     plic: &'a Plic,
     scheduler_timer: kernel::VirtualSchedulerTimer<A>,
     timer: &'static crate::timer::RvTimer<'static>,
@@ -154,7 +154,7 @@ impl<'a, A: 'static + Alarm<'static>, I: InterruptService<()> + 'a> EarlGrey<'a,
 impl<'a, A: 'static + Alarm<'static>, I: InterruptService<()> + 'a> kernel::Chip
     for EarlGrey<'a, A, I>
 {
-    type MPU = PMP<4, 2>;
+    type MPU = PMP<8>;
     type UserspaceKernelBoundary = SysCall;
     type SchedulerTimer = kernel::VirtualSchedulerTimer<A>;
     type WatchDog = ();

--- a/chips/litex_vexriscv/src/chip.rs
+++ b/chips/litex_vexriscv/src/chip.rs
@@ -22,7 +22,7 @@ pub struct LiteXVexRiscv<A: 'static + Alarm<'static>, I: 'static + InterruptServ
     soc_identifier: &'static str,
     userspace_kernel_boundary: SysCall,
     interrupt_controller: &'static VexRiscvInterruptController,
-    pmp: PMP<16, 8>,
+    pmp: PMP<8>,
     scheduler_timer: kernel::VirtualSchedulerTimer<A>,
     interrupt_service: &'static I,
 }
@@ -60,7 +60,7 @@ impl<A: 'static + Alarm<'static>, I: 'static + InterruptService<()>> LiteXVexRis
 impl<A: 'static + Alarm<'static>, I: 'static + InterruptService<()>> kernel::Chip
     for LiteXVexRiscv<A, I>
 {
-    type MPU = PMP<16, 8>;
+    type MPU = PMP<8>;
     type UserspaceKernelBoundary = SysCall;
     type SchedulerTimer = kernel::VirtualSchedulerTimer<A>;
     type WatchDog = ();


### PR DESCRIPTION
### Pull Request Overview

Add support for dynamically detecting the number of PMP regions and determining if they are locked.

We also no longer sort the PMP regions:

The RISC-V spec describes TOR like this:

```
If TOR is selected, the associated address register forms the top of the address range, and the
preceding PMP address register forms the bottom of the address range. If PMP entry i’s A field is
set to TOR, the entry matches any address y such that pmpaddri−1 ≤ y < pmpaddri (irrespective of
the value of pmpcfgi−1 ). If PMP entry 0’s A field is set to TOR, zero is used for the lower bound,
and so it matches any address y < pmpaddr0.
```

The inital PMP implementation mis-interpreted this and required sorting
the regions and specifically made the previous region match AND then
disabled read/write/access.

This PR changes that operation. Now instead we do the following.

For a region i, we set pmpaddr[i-1] as the start address and pmpaddr[i]
as the end address (same as before). We then set pmpcfg[i-1] to be
disabled, so there is no region there. We then set pmpcfg[i] as TOR and
it matches between pmpaddr[i-1] and pmpaddr[i].

The advantage with this new approach is we no longer have to sort the
regions (which can take time). The main advantage of sorting the regions
is that we could share addresses, for example if a start and end address
are the same we can save a PMP regions by re-using those two addresses.

In reality though this doesn't happen for apps (as flash and memory are
split) and we don't support it anyway.

Sorting the regions will also break if we have a locked region in the
middle of the list.

### Testing Strategy

Running an app on OpenTitan and QEMU.

### TODO or Help Wanted

N/A

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
