### PR TITLE
OpenTitan: Enable PMP for kernel regions

### DIFF
--- a/chips/earlgrey/src/chip.rs
+++ b/chips/earlgrey/src/chip.rs
@@ -16,7 +16,7 @@ use crate::plic::PLIC;
 
 pub struct EarlGrey<'a, A: 'static + Alarm<'static>, I: InterruptService<()> + 'a> {
     userspace_kernel_boundary: SysCall,
-    pmp: PMP<8>,
+    pub pmp: PMP<8>,
     plic: &'a Plic,
     scheduler_timer: kernel::VirtualSchedulerTimer<A>,
     timer: &'static crate::timer::RvTimer<'static>,


### PR DESCRIPTION
### Pull Request Overview

This PR applies on top of https://github.com/tock/tock/pull/2420

This PR adds support for marking regions of the kernel as protected by PMP.

This allows some regions to have reduced permissions applied to them. This can be used to restrict write/execute to different regions used by the kernel.

### Testing Strategy

Boot Tock and an app on OpenTitan FPGA and QEMU.

### TODO or Help Wanted

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
