### PR TITLE
kernel: sched: Allow Platform to handle app faults

### DIFF
--- a/kernel/src/platform/mod.rs
+++ b/kernel/src/platform/mod.rs
@@ -62,6 +62,43 @@ pub trait Platform {
     ) -> Result<(), errorcode::ErrorCode> {
         Ok(())
     }
+
+    /// This function is called when an app faults.
+    ///
+    /// This is an optional function that can be implemented by `Platform`s that
+    /// allows the chip to handle the app fault and not terminate or restart
+    /// the app.
+    ///
+    /// If `Ok(())` is returned by this function then the kernel will not
+    /// terminate or restart the app, but instead allow it to continue
+    /// running. NOTE in this case the chip must have fixed the underlying
+    /// reason for fault otherwise it will re-occur.
+    ///
+    /// This can not be used for apps to circumvent Tock's protections. If
+    /// for example this function just ignored the error and allowed the app
+    /// to continue the fault would continue to occur.
+    ///
+    /// If `Err(())` is returned then the kernel will set the app as faulted
+    /// and follow the `FaultResponse` protocol.
+    ///
+    /// It is unlikey a `Platform` will need to implement this. This should be used
+    /// for only a handul of use cases. Possible use cases include:
+    ///    - Allowing the kernel to emulate unimplemented instructions
+    ///      This could be used to allow apps to run on hardware that doesn't
+    ///      implement some instructions, for example atomics.
+    ///    - Allow the kernel to handle hardware faults, triggered by the app.
+    ///      This can allow an app to continue running if it triggers certain
+    ///      types of faults. For example if an app triggers a memory parity
+    ///      error the kernel can handle the error and allow the app to
+    ///      continue (or not).
+    ///    - Allow an app to execute from external QSPI.
+    ///      This could be used to allow an app to execute from external QSPI
+    ///      where access faults can be handled by the `Platform` to ensure the
+    ///      QPSI is mapped correctly.
+    #[allow(unused_variables)]
+    fn process_fault_hook(&self, process: &dyn process::ProcessType) -> Result<(), ()> {
+        Err(())
+    }
 }
 
 /// Interface for individual MCUs.

--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -627,8 +627,12 @@ impl Kernel {
                     // why and handle the process as appropriate.
                     match context_switch_reason {
                         Some(ContextSwitchReason::Fault) => {
-                            // Let process deal with it as appropriate.
-                            process.set_fault_state();
+                            // The app faulted, check if the chip wants to
+                            // handle the fault.
+                            if platform.process_fault_hook(process).is_err() {
+                                // Let process deal with it as appropriate.
+                                process.set_fault_state();
+                            }
                         }
                         Some(ContextSwitchReason::SyscallFired { syscall }) => {
                             self.handle_syscall(platform, process, syscall);

--- a/kernel/src/syscall.rs
+++ b/kernel/src/syscall.rs
@@ -400,6 +400,9 @@ pub enum ContextSwitchReason {
     /// Process called a syscall. Also returns the syscall and relevant values.
     SyscallFired { syscall: Syscall },
     /// Process triggered the hardfault handler.
+    /// The implementation should still save registers in the event that the
+    /// `Platform` can handle the fault and allow the app to continue running.
+    /// For more details on this see `Platform::process_fault_hook()`.
     Fault,
     /// Process interrupted (e.g. by a hardware event)
     Interrupted,


### PR DESCRIPTION
### Pull Request Overview

This commit adds a function to the Platform trait that can be used to allow 
a Platform to handle an app fault. This avoids terminating or restarting and
app and instead allows it to continue execution.

This is an optional function that can be implemented by `Chip`s that
allows the chip to handle the app fault and not terminate or restart
the app.

If `Ok(())` is returned by this function then the kernel will not
terminate or restart the app, but instead allow it to continue
running. NOTE in this case the chip must have fixed the underlying
reason for fault otherwise it will re-occur.

This can not be used to get around Tock's protections. If for example
this function just ignored the error and allowed the app to continue
the fault would continue to occur,

If `Err(())` is returned then the kernel will set the app as faulted
and follow the `FaultResponse` protocol.

It is unlikey a `Chip` will need to implement this. This should be used
for only a handul of use cases. Possible use cases include:
- Allowing the kernel to emulate un-implemented instructions
  This could be used to allow apps to run on hardware that doesn't
  implement some instructions, for example atomics.
- Allow the kernel to handle hardware faults, triggered by the app
  This can allow an app to continue running if it triggers certain
  types of faults. For example if an app triggers a memory parity
  error the kernel can handle the error and allow the app to
  continue (or not).
- Allow an app to execute from external QSPI
  This could be used to allow an app to execute from external QSPI
  where access faults can be handled by the `Chip` to ensure the
  QPSI is mapped correctly.


### Testing Strategy

Running in the CI

### TODO or Help Wanted

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
