### PR TITLE
2.0: Remove SuccessWithValue

### DIFF
--- a/capsules/src/buzzer_driver.rs
+++ b/capsules/src/buzzer_driver.rs
@@ -40,7 +40,6 @@
 
 use core::cmp;
 
-use core::convert::TryFrom;
 use core::mem;
 use kernel::common::cells::OptionalCell;
 use kernel::hil;
@@ -235,21 +234,14 @@ impl<'a, A: hil::time::Alarm<'a>> Driver for Buzzer<'a, A> {
             1 => {
                 let frequency_hz = data1;
                 let duration_ms = cmp::min(data2, self.max_duration_ms);
-                let res = self.enqueue_command(
+                self.enqueue_command(
                     BuzzerCommand::Buzz {
                         frequency_hz,
                         duration_ms,
                     },
                     appid,
-                );
-                match res {
-                    ReturnCode::SUCCESS => CommandResult::success(),
-                    ReturnCode::SuccessWithValue { value } => {
-                        CommandResult::success_u32(value as u32)
-                    }
-                    // unwrap may be used as res cannot be SUCCESS or SuccessWithValue
-                    _ => CommandResult::failure(ErrorCode::try_from(res).unwrap()),
-                }
+                )
+                .into()
             }
 
             _ => CommandResult::failure(ErrorCode::NOSUPPORT),

--- a/capsules/src/fm25cl.rs
+++ b/capsules/src/fm25cl.rs
@@ -161,9 +161,7 @@ impl<'a, S: hil::spi::SpiMasterDevice> FM25CL<'a, S> {
                 let res = self.spi.read_write_bytes(txbuffer, None, 1);
                 match res {
                     ReturnCode::SUCCESS => Ok(()),
-                    rc => Err(rc
-                        .try_into()
-                        .expect("SPI read_write_bytes: unexpected SuccessWithValue")),
+                    rc => Err(rc.try_into().unwrap()),
                 }
             })
     }
@@ -192,9 +190,7 @@ impl<'a, S: hil::spi::SpiMasterDevice> FM25CL<'a, S> {
                             .read_write_bytes(txbuffer, Some(rxbuffer), read_len + 3);
                         match res {
                             ReturnCode::SUCCESS => Ok(()),
-                            rc => Err(rc
-                                .try_into()
-                                .expect("SPI read_write_bytes: unexpected SuccessWithValue")),
+                            rc => Err(rc.try_into().unwrap()),
                         }
                     })
             })

--- a/capsules/src/net/udp/driver.rs
+++ b/capsules/src/net/udp/driver.rs
@@ -424,7 +424,7 @@ impl<'a> Driver for UDPDriver<'a> {
     ///        transmit can produce two different success values. If success is returned,
     ///        this simply means that the packet was queued. In this case, the app still
     ///        still needs to wait for a callback to check if any errors occurred before
-    ///        the packet was passed to the radio. However, if SuccessWithValue
+    ///        the packet was passed to the radio. However, if Success_U32
     ///        is returned with value 1, this means the the packet was successfully passed
     ///        the radio without any errors, which tells the userland application that it does
     ///        not need to wait for a callback to check if any errors occured while the packet

--- a/doc/Syscalls.md
+++ b/doc/Syscalls.md
@@ -107,7 +107,6 @@ in C from the `tock.h` header (prepended with `TOCK_`):
 
 ```rust
 pub enum ReturnCode {
-    SuccessWithValue { value: usize }, // Success value must be >= 0
     SUCCESS,
     FAIL, //.......... Generic failure condition
     EBUSY, //......... Underlying system is busy; retry

--- a/kernel/src/driver.rs
+++ b/kernel/src/driver.rs
@@ -155,9 +155,6 @@ impl From<ReturnCode> for CommandResult {
     fn from(rc: ReturnCode) -> Self {
         match rc {
             ReturnCode::SUCCESS => CommandResult::success(),
-            ReturnCode::SuccessWithValue { .. } => {
-                panic!("SuccessWithValue is deprecated");
-            } //TODO: delete before Tock 2.0
             _ => CommandResult::failure(ErrorCode::try_from(rc).unwrap()),
         }
     }

--- a/kernel/src/errorcode.rs
+++ b/kernel/src/errorcode.rs
@@ -56,7 +56,6 @@ impl TryFrom<ReturnCode> for ErrorCode {
 
     fn try_from(rc: ReturnCode) -> Result<Self, Self::Error> {
         match rc {
-            ReturnCode::SuccessWithValue { .. } => Err(()),
             ReturnCode::SUCCESS => Err(()),
             ReturnCode::FAIL => Ok(ErrorCode::FAIL),
             ReturnCode::EBUSY => Ok(ErrorCode::BUSY),

--- a/kernel/src/returncode.rs
+++ b/kernel/src/returncode.rs
@@ -7,8 +7,6 @@
 /// Standard return errors in Tock.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ReturnCode {
-    /// Success value must be positive
-    SuccessWithValue { value: usize }, //TODO: Remove before Tock 2.0
     /// Operation completed successfully
     SUCCESS,
     /// Generic failure condition
@@ -42,7 +40,6 @@ pub enum ReturnCode {
 impl From<ReturnCode> for isize {
     fn from(original: ReturnCode) -> isize {
         match original {
-            ReturnCode::SuccessWithValue { value } => value as isize,
             ReturnCode::SUCCESS => 0,
             ReturnCode::FAIL => -1,
             ReturnCode::EBUSY => -2,

--- a/kernel/src/returncode.rs
+++ b/kernel/src/returncode.rs
@@ -6,6 +6,7 @@
 
 /// Standard return errors in Tock.
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(isize)] // Code size optimization compared to #[repr(rust)]
 pub enum ReturnCode {
     /// Operation completed successfully
     SUCCESS,


### PR DESCRIPTION
### Pull Request Overview

This pull request removes `SuccessWithValue` for 2.0. Other than IPC, nothing was using SuccessWithValue anymore.




### Testing Strategy

travis


### TODO or Help Wanted

Need the IPC updates first.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
