### PR TITLE
Tock 2.0 IPC

### DIFF
--- a/boards/acd52832/src/main.rs
+++ b/boards/acd52832/src/main.rs
@@ -101,7 +101,7 @@ impl kernel::Platform for Platform {
             capsules::gpio_async::DRIVER_NUM => f(Some(Ok(self.gpio_async))),
             capsules::ambient_light::DRIVER_NUM => f(Some(Ok(self.light))),
             capsules::buzzer_driver::DRIVER_NUM => f(Some(Ok(self.buzzer))),
-            kernel::ipc::DRIVER_NUM => f(Some(Err(&self.ipc))),
+            kernel::ipc::DRIVER_NUM => f(Some(Ok(&self.ipc))),
             _ => f(None),
         }
     }

--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -151,7 +151,7 @@ impl kernel::Platform for Platform {
             capsules::temperature::DRIVER_NUM => f(Some(Ok(self.temperature))),
             capsules::humidity::DRIVER_NUM => f(Some(Ok(self.humidity))),
             capsules::buzzer_driver::DRIVER_NUM => f(Some(Ok(self.buzzer))),
-            kernel::ipc::DRIVER_NUM => f(Some(Err(&self.ipc))),
+            kernel::ipc::DRIVER_NUM => f(Some(Ok(&self.ipc))),
             _ => f(None),
         }
     }

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -102,7 +102,7 @@ impl Platform for Hail {
 
             capsules::dac::DRIVER_NUM => f(Some(Ok(self.dac))),
 
-            kernel::ipc::DRIVER_NUM => f(Some(Err(&self.ipc))),
+            kernel::ipc::DRIVER_NUM => f(Some(Ok(&self.ipc))),
             _ => f(None),
         }
     }

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -180,7 +180,7 @@ impl kernel::Platform for Imix {
                 f(Some(Ok(self.nonvolatile_storage)))
             }
             capsules::rng::DRIVER_NUM => f(Some(Ok(self.rng))),
-            kernel::ipc::DRIVER_NUM => f(Some(Err(&self.ipc))),
+            kernel::ipc::DRIVER_NUM => f(Some(Ok(&self.ipc))),
             _ => f(None),
         }
     }

--- a/boards/imxrt1050-evkb/src/main.rs
+++ b/boards/imxrt1050-evkb/src/main.rs
@@ -89,7 +89,7 @@ impl Platform for Imxrt1050EVKB {
             capsules::button::DRIVER_NUM => f(Some(Ok(self.button))),
             capsules::console::DRIVER_NUM => f(Some(Ok(self.console))),
             capsules::gpio::DRIVER_NUM => f(Some(Ok(self.gpio))),
-            kernel::ipc::DRIVER_NUM => f(Some(Err(&self.ipc))),
+            kernel::ipc::DRIVER_NUM => f(Some(Ok(&self.ipc))),
             capsules::led::DRIVER_NUM => f(Some(Ok(self.led))),
             capsules::ninedof::DRIVER_NUM => f(Some(Ok(self.ninedof))),
             _ => f(None),

--- a/boards/microbit_v2/src/main.rs
+++ b/boards/microbit_v2/src/main.rs
@@ -128,7 +128,7 @@ impl kernel::Platform for Platform {
             capsules::buzzer_driver::DRIVER_NUM => f(Some(Ok(self.buzzer))),
             capsules::app_flash_driver::DRIVER_NUM => f(Some(Ok(self.app_flash))),
             capsules::sound_pressure::DRIVER_NUM => f(Some(Ok(self.sound_pressure))),
-            kernel::ipc::DRIVER_NUM => f(Some(Err(&self.ipc))),
+            kernel::ipc::DRIVER_NUM => f(Some(Ok(&self.ipc))),
             _ => f(None),
         }
     }

--- a/boards/msp_exp432p401r/src/main.rs
+++ b/boards/msp_exp432p401r/src/main.rs
@@ -72,7 +72,7 @@ impl Platform for MspExp432P401R {
             capsules::button::DRIVER_NUM => f(Some(Ok(self.button))),
             capsules::gpio::DRIVER_NUM => f(Some(Ok(self.gpio))),
             capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
-            kernel::ipc::DRIVER_NUM => f(Some(Err(&self.ipc))),
+            kernel::ipc::DRIVER_NUM => f(Some(Ok(&self.ipc))),
             capsules::adc::DRIVER_NUM => f(Some(Ok(self.adc))),
             _ => f(None),
         }

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -141,7 +141,7 @@ impl kernel::Platform for Platform {
             capsules::rng::DRIVER_NUM => f(Some(Ok(self.rng))),
             capsules::ble_advertising_driver::DRIVER_NUM => f(Some(Ok(self.ble_radio))),
             capsules::ieee802154::DRIVER_NUM => f(Some(Ok(self.ieee802154_radio))),
-            kernel::ipc::DRIVER_NUM => f(Some(Err(&self.ipc))),
+            kernel::ipc::DRIVER_NUM => f(Some(Ok(&self.ipc))),
             _ => f(None),
         }
     }

--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -115,7 +115,7 @@ impl kernel::Platform for Platform {
             capsules::ieee802154::DRIVER_NUM => f(Some(Ok(self.ieee802154_radio))),
             capsules::temperature::DRIVER_NUM => f(Some(Ok(self.temp))),
             capsules::analog_comparator::DRIVER_NUM => f(Some(Ok(self.analog_comparator))),
-            kernel::ipc::DRIVER_NUM => f(Some(Err(&self.ipc))),
+            kernel::ipc::DRIVER_NUM => f(Some(Ok(&self.ipc))),
             _ => f(None),
         }
     }

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -195,7 +195,7 @@ impl kernel::Platform for Platform {
                 f(Some(Ok(self.nonvolatile_storage)))
             }
             capsules::net::udp::DRIVER_NUM => f(Some(Ok(self.udp_driver))),
-            kernel::ipc::DRIVER_NUM => f(Some(Err(&self.ipc))),
+            kernel::ipc::DRIVER_NUM => f(Some(Ok(&self.ipc))),
             _ => f(None),
         }
     }

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -173,7 +173,7 @@ impl kernel::Platform for Platform {
             capsules::ble_advertising_driver::DRIVER_NUM => f(Some(Ok(self.ble_radio))),
             capsules::temperature::DRIVER_NUM => f(Some(Ok(self.temp))),
             capsules::analog_comparator::DRIVER_NUM => f(Some(Ok(self.analog_comparator))),
-            kernel::ipc::DRIVER_NUM => f(Some(Err(&self.ipc))),
+            kernel::ipc::DRIVER_NUM => f(Some(Ok(&self.ipc))),
             _ => f(None),
         }
     }

--- a/boards/nucleo_f429zi/src/main.rs
+++ b/boards/nucleo_f429zi/src/main.rs
@@ -76,7 +76,7 @@ impl Platform for NucleoF429ZI {
             capsules::adc::DRIVER_NUM => f(Some(Ok(self.adc))),
             capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
             capsules::temperature::DRIVER_NUM => f(Some(Ok(self.temperature))),
-            kernel::ipc::DRIVER_NUM => f(Some(Err(&self.ipc))),
+            kernel::ipc::DRIVER_NUM => f(Some(Ok(&self.ipc))),
             capsules::gpio::DRIVER_NUM => f(Some(Ok(self.gpio))),
             _ => f(None),
         }

--- a/boards/nucleo_f446re/src/main.rs
+++ b/boards/nucleo_f446re/src/main.rs
@@ -73,7 +73,7 @@ impl Platform for NucleoF446RE {
             capsules::led::DRIVER_NUM => f(Some(Ok(self.led))),
             capsules::button::DRIVER_NUM => f(Some(Ok(self.button))),
             capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
-            kernel::ipc::DRIVER_NUM => f(Some(Err(&self.ipc))),
+            kernel::ipc::DRIVER_NUM => f(Some(Ok(&self.ipc))),
             _ => f(None),
         }
     }

--- a/boards/stm32f3discovery/src/main.rs
+++ b/boards/stm32f3discovery/src/main.rs
@@ -88,7 +88,7 @@ impl Platform for STM32F3Discovery {
             capsules::l3gd20::DRIVER_NUM => f(Some(Ok(self.l3gd20))),
             capsules::ninedof::DRIVER_NUM => f(Some(Ok(self.ninedof))),
             capsules::temperature::DRIVER_NUM => f(Some(Ok(self.temp))),
-            kernel::ipc::DRIVER_NUM => f(Some(Err(&self.ipc))),
+            kernel::ipc::DRIVER_NUM => f(Some(Ok(&self.ipc))),
             capsules::adc::DRIVER_NUM => f(Some(Ok(self.adc))),
             capsules::nonvolatile_storage_driver::DRIVER_NUM => {
                 f(Some(Ok(self.nonvolatile_storage)))

--- a/boards/stm32f412gdiscovery/src/main.rs
+++ b/boards/stm32f412gdiscovery/src/main.rs
@@ -74,7 +74,7 @@ impl Platform for STM32F412GDiscovery {
             capsules::led::DRIVER_NUM => f(Some(Ok(self.led))),
             capsules::button::DRIVER_NUM => f(Some(Ok(self.button))),
             capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
-            kernel::ipc::DRIVER_NUM => f(Some(Err(&self.ipc))),
+            kernel::ipc::DRIVER_NUM => f(Some(Ok(&self.ipc))),
             capsules::gpio::DRIVER_NUM => f(Some(Ok(self.gpio))),
             capsules::adc::DRIVER_NUM => f(Some(Ok(self.adc))),
             capsules::touch::DRIVER_NUM => f(Some(Ok(self.touch))),

--- a/boards/teensy40/src/main.rs
+++ b/boards/teensy40/src/main.rs
@@ -49,7 +49,7 @@ impl kernel::Platform for Teensy40 {
         match driver_num {
             capsules::led::DRIVER_NUM => f(Some(Ok(self.led))),
             capsules::console::DRIVER_NUM => f(Some(Ok(self.console))),
-            kernel::ipc::DRIVER_NUM => f(Some(Err(&self.ipc))),
+            kernel::ipc::DRIVER_NUM => f(Some(Ok(&self.ipc))),
             capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
             _ => f(None),
         }

--- a/boards/weact_f401ccu6/src/main.rs
+++ b/boards/weact_f401ccu6/src/main.rs
@@ -74,7 +74,7 @@ impl Platform for WeactF401CC {
             capsules::button::DRIVER_NUM => f(Some(Ok(self.button))),
             capsules::adc::DRIVER_NUM => f(Some(Ok(self.adc))),
             capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
-            kernel::ipc::DRIVER_NUM => f(Some(Err(&self.ipc))),
+            kernel::ipc::DRIVER_NUM => f(Some(Ok(&self.ipc))),
             capsules::gpio::DRIVER_NUM => f(Some(Ok(self.gpio))),
             _ => f(None),
         }

--- a/kernel/src/ipc.rs
+++ b/kernel/src/ipc.rs
@@ -5,12 +5,11 @@
 
 use crate::callback::{AppId, Callback};
 use crate::capabilities::MemoryAllocationCapability;
-use crate::driver::LegacyDriver;
 use crate::grant::Grant;
-use crate::mem::legacy::{AppSlice, SharedReadWrite};
+use crate::mem::Read;
 use crate::process;
-use crate::returncode::ReturnCode;
 use crate::sched::Kernel;
+use crate::{CommandResult, Driver, ErrorCode, ReadOnlyAppSlice, ReadWriteAppSlice};
 
 /// Syscall number
 pub const DRIVER_NUM: usize = 0x10000;
@@ -30,22 +29,23 @@ pub enum IPCCallbackType {
 struct IPCData<const NUM_PROCS: usize> {
     /// An array of app slices that this application has shared with other
     /// applications.
-    shared_memory: [Option<AppSlice<SharedReadWrite, u8>>; NUM_PROCS],
+    shared_memory: [ReadWriteAppSlice; NUM_PROCS],
+    search_slice: ReadOnlyAppSlice,
     /// An array of callbacks this process has registered to receive callbacks
     /// from other services.
-    client_callbacks: [Option<Callback>; NUM_PROCS],
+    client_callbacks: [Callback; NUM_PROCS],
     /// The callback setup by a service. Each process can only be one service.
-    callback: Option<Callback>,
+    callback: Callback,
 }
 
 impl<const NUM_PROCS: usize> Default for IPCData<NUM_PROCS> {
     fn default() -> IPCData<NUM_PROCS> {
-        // need this until const_in_array_repeat_expressions is stable
-        const NONE_APPSLICE: Option<AppSlice<SharedReadWrite, u8>> = None;
+        const DEFAULT_RW_APP_SLICE: ReadWriteAppSlice = ReadWriteAppSlice::const_default();
         IPCData {
-            shared_memory: [NONE_APPSLICE; NUM_PROCS],
-            client_callbacks: [None; NUM_PROCS],
-            callback: None,
+            shared_memory: [DEFAULT_RW_APP_SLICE; NUM_PROCS],
+            search_slice: ReadOnlyAppSlice::default(),
+            client_callbacks: [Callback::default(); NUM_PROCS],
+            callback: Callback::default(),
         }
     }
 }
@@ -67,66 +67,72 @@ impl<const NUM_PROCS: usize> IPC<NUM_PROCS> {
     /// scheduler loop if an IPC task was queued for the process.
     pub(crate) unsafe fn schedule_callback(
         &self,
-        appid: AppId,
-        otherapp: AppId,
+        schedule_on: AppId,
+        called_from: AppId,
         cb_type: IPCCallbackType,
-    ) {
+    ) -> Result<(), process::Error> {
         self.data
-            .enter(appid, |mydata, _| {
-                let callback = match cb_type {
+            .enter(schedule_on, |mydata, _| {
+                let mut callback = match cb_type {
                     IPCCallbackType::Service => mydata.callback,
-                    IPCCallbackType::Client => match otherapp.index() {
-                        Some(i) => *mydata.client_callbacks.get(i).unwrap_or(&None),
-                        None => None,
+                    IPCCallbackType::Client => match called_from.index() {
+                        Some(i) => *mydata
+                            .client_callbacks
+                            .get(i)
+                            .unwrap_or(&Callback::default()),
+                        None => Callback::default(),
                     },
                 };
-                callback.map_or((), |mut callback| {
-                    self.data
-                        .enter(otherapp, |otherdata, _| {
-                            // If the other app shared a buffer with us, make
-                            // sure we have access to that slice and then call
-                            // the callback. If no slice was shared then just
-                            // call the callback.
-                            match appid.index() {
-                                Some(i) => {
-                                    if i >= otherdata.shared_memory.len() {
-                                        return;
-                                    }
-
-                                    match otherdata.shared_memory[i] {
-                                        Some(ref slice) => {
-                                            slice.expose_to(appid);
-                                            callback.schedule(
-                                                otherapp.id() + 1,
-                                                slice.len(),
-                                                slice.ptr() as usize,
-                                            );
-                                        }
-                                        None => {
-                                            callback.schedule(otherapp.id() + 1, 0, 0);
-                                        }
-                                    }
-                                }
-                                None => {}
+                self.data.enter(called_from, |called_from_data, _| {
+                    // If the other app shared a buffer with us, make
+                    // sure we have access to that slice and then call
+                    // the callback. If no slice was shared then just
+                    // call the callback.
+                    match schedule_on.index() {
+                        Some(i) => {
+                            if i >= called_from_data.shared_memory.len() {
+                                return;
                             }
-                        })
-                        .unwrap_or(());
-                });
+
+                            match called_from_data.shared_memory.get(i) {
+                                Some(slice) => {
+                                    self.data
+                                        .kernel
+                                        .process_map_or(None, schedule_on, |process| {
+                                            process.add_mpu_region(
+                                                slice.ptr(),
+                                                slice.len(),
+                                                slice.len(),
+                                            )
+                                        });
+                                    callback.schedule(
+                                        called_from.id() + 1,
+                                        crate::mem::Read::len(slice),
+                                        crate::mem::Read::ptr(slice) as usize,
+                                    );
+                                }
+                                None => {
+                                    callback.schedule(called_from.id() + 1, 0, 0);
+                                }
+                            }
+                        }
+                        None => {}
+                    }
+                })
             })
-            .unwrap_or(());
+            .and_then(|x| x)
     }
 }
 
-// TODO: Write a Tock 2.0 driver implementation
-impl<const NUM_PROCS: usize> LegacyDriver for IPC<NUM_PROCS> {
+impl<const NUM_PROCS: usize> Driver for IPC<NUM_PROCS> {
     /// subscribe enables processes using IPC to register callbacks that fire
     /// when notify() is called.
     fn subscribe(
         &self,
         subscribe_num: usize,
-        callback: Option<Callback>,
+        mut callback: Callback,
         app_id: AppId,
-    ) -> ReturnCode {
+    ) -> Result<Callback, (Callback, ErrorCode)> {
         match subscribe_num {
             // subscribe(0)
             //
@@ -139,10 +145,10 @@ impl<const NUM_PROCS: usize> LegacyDriver for IPC<NUM_PROCS> {
             0 => self
                 .data
                 .enter(app_id, |data, _| {
-                    data.callback = callback;
-                    ReturnCode::SUCCESS
+                    core::mem::swap(&mut data.callback, &mut callback);
+                    callback
                 })
-                .unwrap_or(ReturnCode::EBUSY),
+                .map_err(|e| (callback, e.into())),
 
             // subscribe(>=1)
             //
@@ -159,21 +165,26 @@ impl<const NUM_PROCS: usize> LegacyDriver for IPC<NUM_PROCS> {
                 // valid application by asking the kernel to do a lookup for us.
                 let otherapp = self.data.kernel.lookup_app_by_identifier(app_identifier);
 
-                self.data
-                    .enter(app_id, |data, _| {
+                // This type annotation is here for documentation, it's not actually necessary
+                let result: Result<Result<Callback, ErrorCode>, process::Error> =
+                    self.data.enter(app_id, |data, _| {
                         match otherapp.map_or(None, |oa| oa.index()) {
                             Some(i) => {
                                 if i >= NUM_PROCS {
-                                    ReturnCode::EINVAL
+                                    Err(ErrorCode::INVAL)
                                 } else {
-                                    data.client_callbacks[i] = callback;
-                                    ReturnCode::SUCCESS
+                                    core::mem::swap(&mut data.client_callbacks[i], &mut callback);
+                                    Ok(callback)
                                 }
                             }
-                            None => ReturnCode::EINVAL,
+                            None => Err(ErrorCode::INVAL),
                         }
-                    })
-                    .unwrap_or(ReturnCode::EBUSY)
+                    });
+                // OK, some type sorcery to transform result into what we want
+                result
+                    .map_err(|e| e.into()) // transform the outer Result's process::Error into an ErrorCode
+                    .and_then(|x| x) // Flatten the Result<Result<T,E>, E> into a Result<T,E>
+                    .map_err(|e| (callback, e)) // Add `callback` to the Error case
             }
         }
     }
@@ -185,102 +196,172 @@ impl<const NUM_PROCS: usize> LegacyDriver for IPC<NUM_PROCS> {
     /// callback or as returned by allow.
     ///
     /// Returns EINVAL if the other process doesn't exist.
+
+    /// Initiates a service discovery or notifies a client or service.
+    ///
+    /// ### `command_num`
+    ///
+    /// - `0`: Driver check, always returns SUCCESS
+    /// - `1`: Perform discovery on the package name passed to `allow_readonly`. Returns the
+    ///        service descriptor if the service is found, otherwise returns an error.
+    /// - `2`: Notify a service previously discovered to have the service descriptor in
+    ///        `target_id`. Returns an error if `target_id` refers to an invalid service or the
+    ///        notify fails to enqueue.
+    /// - `3`: Notify a client with descriptor `target_id`, typically in response to a previous
+    ///        notify from the client. Returns an error if `target_id` refers to an invalid client
+    ///        or the notify fails to enqueue.
     fn command(
         &self,
+        command_number: usize,
         target_id: usize,
-        client_or_svc: usize,
         _: usize,
         appid: AppId,
-    ) -> ReturnCode {
-        let cb_type = if client_or_svc == 0 {
-            IPCCallbackType::Service
-        } else {
-            IPCCallbackType::Client
-        };
+    ) -> CommandResult {
+        match command_number {
+            0 => CommandResult::success(),
+            1 =>
+            /* Discover */
+            {
+                self.data
+                    .enter(appid, |data, _| {
+                        data.search_slice.map_or(
+                            CommandResult::failure(ErrorCode::INVAL),
+                            |slice| {
+                                self.data
+                                    .kernel
+                                    .process_until(|p| {
+                                        let s = p.get_process_name().as_bytes();
+                                        // are slices equal?
+                                        if s.len() == slice.len()
+                                            && s.iter().zip(slice.iter()).all(|(c1, c2)| c1 == c2)
+                                        {
+                                            Some(CommandResult::success_u32(
+                                                p.appid().id() as u32 + 1,
+                                            ))
+                                        } else {
+                                            None
+                                        }
+                                    })
+                                    .unwrap_or(CommandResult::failure(ErrorCode::NODEVICE))
+                            },
+                        )
+                    })
+                    .unwrap_or(CommandResult::failure(ErrorCode::NOMEM))
+            }
+            2 =>
+            /* Service notify */
+            {
+                let cb_type = IPCCallbackType::Service;
+                let app_identifier = target_id - 1;
 
-        let app_identifier = target_id - 1;
-
-        self.data
-            .kernel
-            .lookup_app_by_identifier(app_identifier)
-            .map_or(ReturnCode::EINVAL, |otherapp| {
                 self.data
                     .kernel
-                    .process_map_or(ReturnCode::EINVAL, otherapp, |target| {
-                        let ret = target.enqueue_task(process::Task::IPC((appid, cb_type)));
-                        match ret {
-                            true => ReturnCode::SUCCESS,
-                            false => ReturnCode::FAIL,
-                        }
+                    .lookup_app_by_identifier(app_identifier)
+                    .map_or(CommandResult::failure(ErrorCode::INVAL), |otherapp| {
+                        self.data.kernel.process_map_or(
+                            CommandResult::failure(ErrorCode::INVAL),
+                            otherapp,
+                            |target| {
+                                let ret = target.enqueue_task(process::Task::IPC((appid, cb_type)));
+                                match ret {
+                                    true => CommandResult::success(),
+                                    false => CommandResult::failure(ErrorCode::FAIL),
+                                }
+                            },
+                        )
                     })
-            })
+            }
+            3 =>
+            /* Client notify */
+            {
+                let cb_type = IPCCallbackType::Client;
+                let app_identifier = target_id - 1;
+
+                self.data
+                    .kernel
+                    .lookup_app_by_identifier(app_identifier)
+                    .map_or(CommandResult::failure(ErrorCode::INVAL), |otherapp| {
+                        self.data.kernel.process_map_or(
+                            CommandResult::failure(ErrorCode::INVAL),
+                            otherapp,
+                            |target| {
+                                let ret = target.enqueue_task(process::Task::IPC((appid, cb_type)));
+                                match ret {
+                                    true => CommandResult::success(),
+                                    false => CommandResult::failure(ErrorCode::FAIL),
+                                }
+                            },
+                        )
+                    })
+            }
+            _ => CommandResult::failure(ErrorCode::NOSUPPORT),
+        }
     }
 
-    /// allow enables processes to discover IPC services on the platform or
+    /// allow_readonly with subdriver number `0` stores the provided buffer for service discovery.
+    /// The buffer should contain the package name of a process that exports an IPC service.
+    fn allow_readonly(
+        &self,
+        appid: AppId,
+        subdriver: usize,
+        mut slice: ReadOnlyAppSlice,
+    ) -> Result<ReadOnlyAppSlice, (ReadOnlyAppSlice, ErrorCode)> {
+        if subdriver == 0 {
+            // Package name for discovery
+            let res = self.data.enter(appid, |data, _| {
+                core::mem::swap(&mut data.search_slice, &mut slice);
+            });
+            match res {
+                Ok(_) => Ok(slice),
+                Err(e) => Err((slice, e.into())),
+            }
+        } else {
+            Err((slice, ErrorCode::NOSUPPORT))
+        }
+    }
+
+    /// allow_readwrite enables processes to discover IPC services on the platform or
     /// share buffers with existing services.
-    ///
-    /// If allow is called with target_id == 0, it is an IPC service discover
-    /// call. The contents of the slice should be the string name of the IPC
-    /// service. If this mechanism can find that service, allow will return
-    /// an ID that can be used to notify that service. Otherwise an error will
-    /// be returned.
     ///
     /// If allow is called with target_id >= 1, it is a share command where the
     /// application is explicitly sharing a slice with an IPC service (as
     /// specified by the target_id). allow() simply allows both processes to
     /// access the buffer, it does not signal the service.
+    ///
+    /// target_id == 0 is currently unsupported and reserved for future use.
     fn allow_readwrite(
         &self,
         appid: AppId,
         target_id: usize,
-        slice: Option<AppSlice<SharedReadWrite, u8>>,
-    ) -> ReturnCode {
+        mut slice: ReadWriteAppSlice,
+    ) -> Result<ReadWriteAppSlice, (ReadWriteAppSlice, ErrorCode)> {
         if target_id == 0 {
-            match slice {
-                Some(slice_data) => {
-                    let ret = self.data.kernel.process_until(|p| {
-                        let s = p.get_process_name().as_bytes();
-                        // are slices equal?
-                        if s.len() == slice_data.len()
-                            && s.iter().zip(slice_data.iter()).all(|(c1, c2)| c1 == c2)
-                        {
-                            ReturnCode::SuccessWithValue {
-                                value: (p.appid().id() as usize) + 1,
-                            }
-                        } else {
-                            ReturnCode::FAIL
-                        }
-                    });
-                    if ret != ReturnCode::FAIL {
-                        return ret;
-                    }
-                }
-                None => {}
-            }
-
-            return ReturnCode::EINVAL; /* AppSlice must have non-zero length */
-        }
-        self.data
-            .enter(appid, |data, _| {
+            Err((slice, ErrorCode::NOSUPPORT))
+        } else {
+            match self.data.enter(appid, |data, _| {
                 // Lookup the index of the app based on the passed in
                 // identifier. This also let's us check that the other app is
                 // actually valid.
                 let app_identifier = target_id - 1;
                 let otherapp = self.data.kernel.lookup_app_by_identifier(app_identifier);
-
-                match otherapp.map_or(None, |oa| oa.index()) {
-                    Some(i) => {
-                        data.shared_memory.get_mut(i).map_or(
-                            ReturnCode::EINVAL, /* Target process does not exist */
-                            |smem| {
-                                *smem = slice;
-                                ReturnCode::SUCCESS
-                            },
-                        )
+                if let Some(oa) = otherapp {
+                    if let Some(i) = oa.index() {
+                        if let Some(smem) = data.shared_memory.get_mut(i) {
+                            core::mem::swap(smem, &mut slice);
+                            Ok(())
+                        } else {
+                            Err(ErrorCode::INVAL)
+                        }
+                    } else {
+                        Err(ErrorCode::INVAL)
                     }
-                    None => ReturnCode::EINVAL,
+                } else {
+                    Err(ErrorCode::BUSY)
                 }
-            })
-            .unwrap_or(ReturnCode::EBUSY)
+            }) {
+                Ok(_) => Ok(slice),
+                Err(e) => Err((slice, e.into())),
+            }
+        }
     }
 }


### PR DESCRIPTION
### Pull Request Overview
This pull request ports the IPC driver to the Tock 2.0 driver interface.

This is a mostly fairly straightforward port. However, the old driver API relied on `allow` to return a discovered IPC endpoint upon success, which is no longer possible in the 2.0 driver interface (allow cannot return a value).

Recall that IPC works as follows:

1. A client "discovers" an IPC service by supplying the kernel with the service's name (taken from the process's TBF name header)
2. If such a service exists, the kernel supplies the client process with a 32-bit non-zero descriptor to reference the service (implemented as the AppId + 1, but that's not guaranteed).
3. The client can use this descriptor to share memory with the service (using allow) and to `notify` it (using command).

For discovery, `allow(IPC, 0)` had been used to both share a buffer containing the service name _and_ request that the kernel perform discovery, returning a descriptor on success.

_This is no longer possible_, and it also not canonical driver semantics.

With this PR, discovery is split into an `allow_readonly` (which is nice anyway so
package names can be hardcoded in ROM rather than copied to
memory) followed by a `command(IPC, 1)` to actually perform the discovery and return a descriptor.

To make this cleaner, I also rejiggerd the arguments in `command`, which now has to mean more than _just_ notify.

Previously, the arguments were:

1. Descriptor (as opposed to the normal command number)
2. Service-or-client-notify (which is actually kind of like a command number)
3. Unused

Now, the arguments are:

1. Command number (can be "discover," "service notify," or "client notify")
2. Target descriptor
3. Unused

There are a number of other changes I believe _could_ make sense to make to IPC before releasing 2.0, but I think they should be decoupled from this pull request, which merely adapts the interface very little to get it working. These are just ideas, and we should discuss all these _separately_:

- Allow both read-only and read-write buffer sharing between client/service
- Use borrow semantics for memory ownership
- Let client subscribe to be notified when a service is available
- Probably more...

### Testing Strategy

Tested using the IPC tutorial in libtock-c (examples/tutorial/05-ipc) after applying changes from tock/libtock-c#176

### TODO or Help Wanted

~~Still need to adapt libtock-c userspace to properly test.~~ (Done in tock/libtock-c#176)

Still need to update documentation

Please review not only the implementation but the change in interface described above. As I said, there are a variety of changes that might make sense for IPC that go beyond these minimal changes. I ask that we get something in that reliably reproduces the existing high-level semantics for IPC and after (or maybe concurrently) decide whether other changes should happen (either before or after 2.0).

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
