### PR TITLE
arch: cortex: fix MPU rounding calculation

### DIFF
--- a/arch/cortex-m/src/mpu.rs
+++ b/arch/cortex-m/src/mpu.rs
@@ -658,8 +658,8 @@ impl<const NUM_REGIONS: usize> kernel::mpu::MPU for MPU<NUM_REGIONS> {
                 // Calculate the minimum number of subregions needed to cover
                 // the `app_memory_size`.
                 //
-                // Want `round_up(app_memory_size / (region_size / 8))`.
-                ((app_memory_size + subregion_size - 1) * 8) / region_size
+                // Want `round_up(app_memory_size / subregion_size)`.
+                (app_memory_size + subregion_size - 1) / subregion_size
             }
         };
 


### PR DESCRIPTION
When determining if a `brk()` call is valid for a process, the MPU has to determine if a subregion (1/8th of the entire app memory region) will cover the new app break address _without_ also including the kernel reserved grant region. If so, it configures the MPU and approves the new app_brk.

Before this math was incorrect if the app break happened to fall on one of the subregion boundaries. The calculation would include an extra region, and if that extra region happened to include the grant region then the brk() would fail, even though it should have been valid. This fixes the calculation to not over-include subregions in that edge case.



Correct panic print:

```
App: no_grant_space   -   [Yielded]
 Events Queued: 0   Syscall Count: 6   Dropped Callback Count: 0
 Restart Count: 0
 Last Syscall: Some(YIELD)


 ╔═══════════╤══════════════════════════════════════════╗
 ║  Address  │ Region Name    Used | Allocated (bytes)  ║
 ╚0x2000A000═╪══════════════════════════════════════════╝
             │ ▼ Grant        1044 |   1044
  0x20009BEC ┼───────────────────────────────────────────
             │ Unused
  0x20009800 ┼───────────────────────────────────────────
             │ ▲ Heap            ? |      ?               S
  ?????????? ┼─────────────────────────────────────────── R
             │ Data              ? |      ?               A
  ?????????? ┼─────────────────────────────────────────── M
             │ ▼ Stack           ? |      ?
  0x20008BD8 ┼───────────────────────────────────────────
             │ Unused
  0x20008000 ┴───────────────────────────────────────────
             .....
  0x00030800 ┬─────────────────────────────────────────── F
             │ App Flash       460                        L
  0x00030634 ┼─────────────────────────────────────────── A
             │ Protected        52                        S
  0x00030600 ┴─────────────────────────────────────────── H

  R0 : 0x00000000    R6 : 0x20009800
  R1 : 0x20009800    R7 : 0x00000000
  R2 : 0x00002000    R8 : 0x00000000
  R3 : 0x20008C00    R10: 0x00000000
  R4 : 0x00000000    R11: 0x00000000
  R5 : 0x00000000    R12: 0x00030680
  R9 : 0x00000000 (Static Base Register)
  SP : 0x20008BD8 (Process Stack Pointer)
  LR : 0x00000001
  PC : 0x00030680
 YPC : 0x00030680

 APSR: N 0 Z 1 C 1 V 0 Q 0
       GE 0 0 0 0
 EPSR: ICI.IT 0x00
       ThumbBit true

 Cortex-M MPU
  Region 0: [0x20008000:0x2000A000], length: 8192 bytes; ReadWrite (0x3)
    Sub-region 0: [0x20008000:0x20008400], Enabled
    Sub-region 1: [0x20008400:0x20008800], Enabled
    Sub-region 2: [0x20008800:0x20008C00], Enabled
    Sub-region 3: [0x20008C00:0x20009000], Enabled
    Sub-region 4: [0x20009000:0x20009400], Enabled
    Sub-region 5: [0x20009400:0x20009800], Enabled
    Sub-region 6: [0x20009800:0x20009C00], Disabled
    Sub-region 7: [0x20009C00:0x2000A000], Disabled
  Region 1: [0x00030600:0x00030800], length: 512 bytes; UnprivilegedReadOnly (0x2)
    Sub-region 0: [0x00030600:0x00030640], Enabled
    Sub-region 1: [0x00030640:0x00030680], Enabled
    Sub-region 2: [0x00030680:0x000306C0], Enabled
    Sub-region 3: [0x000306C0:0x00030700], Enabled
    Sub-region 4: [0x00030700:0x00030740], Enabled
    Sub-region 5: [0x00030740:0x00030780], Enabled
    Sub-region 6: [0x00030780:0x000307C0], Enabled
    Sub-region 7: [0x000307C0:0x00030800], Enabled
```

Incorrect (before):

```
App: no_grant_space   -   [Yielded]
 Events Queued: 0   Syscall Count: 515   Dropped Callback Count: 0
 Restart Count: 0
 Last Syscall: Some(YIELD)


 ╔═══════════╤══════════════════════════════════════════╗
 ║  Address  │ Region Name    Used | Allocated (bytes)  ║
 ╚0x2000A000═╪══════════════════════════════════════════╝
             │ ▼ Grant        1044 |   1044
  0x20009BEC ┼───────────────────────────────────────────
             │ Unused
  0x200097FC ┼───────────────────────────────────────────
             │ ▲ Heap            ? |      ?               S
  ?????????? ┼─────────────────────────────────────────── R
             │ Data              ? |      ?               A
  ?????????? ┼─────────────────────────────────────────── M
             │ ▼ Stack           ? |      ?
  0x20008BD8 ┼───────────────────────────────────────────
             │ Unused
  0x20008000 ┴───────────────────────────────────────────
             .....
  0x00030800 ┬─────────────────────────────────────────── F
             │ App Flash       460                        L
  0x00030634 ┼─────────────────────────────────────────── A
             │ Protected        52                        S
  0x00030600 ┴─────────────────────────────────────────── H

  R0 : 0x00000000    R6 : 0x200097FC
  R1 : 0x200097FC    R7 : 0x00000000
  R2 : 0x00002000    R8 : 0x00000000
  R3 : 0x20008C00    R10: 0x00000000
  R4 : 0x00000000    R11: 0x00000000
  R5 : 0x00000000    R12: 0x00030668
  R9 : 0x00000000 (Static Base Register)
  SP : 0x20008BD8 (Process Stack Pointer)
  LR : 0x00000001
  PC : 0x00030674
 YPC : 0x00030674

 APSR: N 0 Z 1 C 1 V 0 Q 0
       GE 0 0 0 0
 EPSR: ICI.IT 0x00
       ThumbBit true

 Cortex-M MPU
  Region 0: [0x20008000:0x2000A000], length: 8192 bytes; ReadWrite (0x3)
    Sub-region 0: [0x20008000:0x20008400], Enabled
    Sub-region 1: [0x20008400:0x20008800], Enabled
    Sub-region 2: [0x20008800:0x20008C00], Enabled
    Sub-region 3: [0x20008C00:0x20009000], Enabled
    Sub-region 4: [0x20009000:0x20009400], Enabled
    Sub-region 5: [0x20009400:0x20009800], Enabled
    Sub-region 6: [0x20009800:0x20009C00], Disabled
    Sub-region 7: [0x20009C00:0x2000A000], Disabled
  Region 1: [0x00030600:0x00030800], length: 512 bytes; UnprivilegedReadOnly (0x2)
    Sub-region 0: [0x00030600:0x00030640], Enabled
    Sub-region 1: [0x00030640:0x00030680], Enabled
    Sub-region 2: [0x00030680:0x000306C0], Enabled
    Sub-region 3: [0x000306C0:0x00030700], Enabled
    Sub-region 4: [0x00030700:0x00030740], Enabled
    Sub-region 5: [0x00030740:0x00030780], Enabled
    Sub-region 6: [0x00030780:0x000307C0], Enabled
    Sub-region 7: [0x000307C0:0x00030800], Enabled
```

Notice how the top of the heap is at `0x200097FC` even though the MPU has allocated all of the way to `0x20009800`. My test app is trying to set the largest app_brk it can (decrementing by 4 bytes each time). `brk(0x200097FC)` worked while `brk(0x20009800)` did not.


### Testing Strategy

Using an app to set the largest break I can.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
