### PR TITLE
kernel: process: Add debug information on panic for grants

### DIFF
--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -1569,6 +1569,40 @@ impl<C: Chip> ProcessType for Process<'_, C> {
             );
         });
 
+        // Display grant information.
+        let number_grants = self.kernel.get_grant_count_and_finalize();
+        let _ = writer.write_fmt(format_args!(
+            "\
+             \r\n Total number of grant regions defined: {}\r\n",
+            self.kernel.get_grant_count_and_finalize()
+        ));
+        let rows = (number_grants + 2) / 3;
+        // Iterate each grant and show its address.
+        for i in 0..rows {
+            for j in 0..3 {
+                let index = i + (rows * j);
+                if index >= number_grants {
+                    break;
+                }
+
+                match self.get_grant_ptr(index) {
+                    Some(ptr) => {
+                        if ptr.is_null() {
+                            let _ =
+                                writer.write_fmt(format_args!("  Grant {:>2}: --        ", index));
+                        } else {
+                            let _ =
+                                writer.write_fmt(format_args!("  Grant {:>2}: {:p}", index, ptr));
+                        }
+                    }
+                    None => {
+                        // Don't display if the grant ptr is completely invalid.
+                    }
+                }
+            }
+            let _ = writer.write_fmt(format_args!("\r\n"));
+        }
+
         // Display the current state of the MPU for this process.
         self.mpu_config.map(|config| {
             let _ = writer.write_fmt(format_args!("{}", config));

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -1434,7 +1434,7 @@ impl<C: Chip> ProcessType for Process<'_, C> {
 
         let _ = writer.write_fmt(format_args!(
             "\
-             App: {}   -   [{:?}]\
+             𝐀𝐩𝐩: {}   -   [{:?}]\
              \r\n Events Queued: {}   Syscall Count: {}   Dropped Callback Count: {}\
              \r\n Restart Count: {}\r\n",
             self.process_name,


### PR DESCRIPTION
### Pull Request Overview

When I was playing around with IPC I found it useful to be able to get some insight into grant usage for a particular app. This is what I ended up with. This expands the app panic print to include the grant pointer addresses if set.

Example:

```
𝐀𝐩𝐩: no_grant_space   -   [Yielded]
 Events Queued: 0   Syscall Count: 514   Dropped Callback Count: 0
 Restart Count: 0
 Last Syscall: Some(YIELD)


 ╔═══════════╤══════════════════════════════════════════╗
 ║  Address  │ Region Name    Used | Allocated (bytes)  ║
 ╚0x20010000═╪══════════════════════════════════════════╝
             │ ▼ Grant        2032 |   2032
  0x2000F810 ┼───────────────────────────────────────────
             │ Unused
  0x2000F800 ┼───────────────────────────────────────────
             │ ▲ Heap            ? |      ?               S
  ?????????? ┼─────────────────────────────────────────── R
             │ Data              ? |      ?               A
  ?????????? ┼─────────────────────────────────────────── M
             │ ▼ Stack           ? |      ?
  0x2000CBD8 ┼───────────────────────────────────────────
             │ Unused
  0x2000C000 ┴───────────────────────────────────────────
             .....
  0x00032800 ┬─────────────────────────────────────────── F
             │ App Flash       460                        L
  0x00032634 ┼─────────────────────────────────────────── A
             │ Protected        52                        S
  0x00032600 ┴─────────────────────────────────────────── H

  R0 : 0x00000000    R6 : 0x2000F800
  R1 : 0x2000F800    R7 : 0x00000000
  R2 : 0x00004000    R8 : 0x00000000
  R3 : 0x2000CC00    R10: 0x00000000
  R4 : 0x00000000    R11: 0x00000000
  R5 : 0x00000000    R12: 0x00032674
  R9 : 0x00000000 (Static Base Register)
  SP : 0x2000CBD8 (Process Stack Pointer)
  LR : 0x00000001
  PC : 0x00032674
 YPC : 0x00032674

 APSR: N 0 Z 1 C 1 V 0 Q 0
       GE 0 0 0 0
 EPSR: ICI.IT 0x00
       ThumbBit true

 Total number of grant regions defined: 13
  Grant  0: --          Grant  5: --          Grant 10: --
  Grant  1: --          Grant  6: --          Grant 11: --
  Grant  2: --          Grant  7: --          Grant 12: 0x2000f810
  Grant  3: --          Grant  8: --
  Grant  4: --          Grant  9: --

 Cortex-M MPU
  Region 0: [0x2000C000:0x20010000], length: 16384 bytes; ReadWrite (0x3)
    Sub-region 0: [0x2000C000:0x2000C800], Enabled
    Sub-region 1: [0x2000C800:0x2000D000], Enabled
    Sub-region 2: [0x2000D000:0x2000D800], Enabled
    Sub-region 3: [0x2000D800:0x2000E000], Enabled
    Sub-region 4: [0x2000E000:0x2000E800], Enabled
    Sub-region 5: [0x2000E800:0x2000F000], Enabled
    Sub-region 6: [0x2000F000:0x2000F800], Enabled
    Sub-region 7: [0x2000F800:0x20010000], Disabled
  Region 1: [0x00032600:0x00032800], length: 512 bytes; UnprivilegedReadOnly (0x2)
    Sub-region 0: [0x00032600:0x00032640], Enabled
    Sub-region 1: [0x00032640:0x00032680], Enabled
    Sub-region 2: [0x00032680:0x000326C0], Enabled
    Sub-region 3: [0x000326C0:0x00032700], Enabled
    Sub-region 4: [0x00032700:0x00032740], Enabled
    Sub-region 5: [0x00032740:0x00032780], Enabled
    Sub-region 6: [0x00032780:0x000327C0], Enabled
    Sub-region 7: [0x000327C0:0x00032800], Enabled
  Region 2: Unused
  Region 3: Unused
  Region 4: Unused
  Region 5: Unused
  Region 6: Unused
  Region 7: Unused

To debug, run `make debug RAM_START=0x2000c000 FLASH_INIT=0x3265d`
in the app's folder and open the .lst file.
```

I also bolded "App" to make it easier to tell when one process's printout ends and another starts.


### Testing Strategy

Using crash_dummy to see the panic output for various apps on hail.


### TODO or Help Wanted

Thoughts? Is this useful? I would like to do more, but processes don't keep track of a grant's size, for example.


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
