### PR TITLE
Tock 2.0: Remove userspace IEEE 802.15.4 driver from Imix platform

### DIFF
--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -129,7 +129,6 @@ struct Imix {
     >,
     ipc: kernel::ipc::IPC<NUM_PROCS>,
     ninedof: &'static capsules::ninedof::NineDof<'static>,
-    radio_driver: &'static capsules::ieee802154::RadioDriver<'static>,
     udp_driver: &'static capsules::net::udp::UDPDriver<'static>,
     crc: &'static capsules::crc::Crc<'static, sam4l::crccu::Crccu<'static>>,
     usb_driver: &'static capsules::usb::usb_user::UsbSyscallDriver<
@@ -173,7 +172,6 @@ impl kernel::Platform for Imix {
             capsules::ninedof::DRIVER_NUM => f(Some(self.ninedof)),
             capsules::crc::DRIVER_NUM => f(Some(self.crc)),
             capsules::usb::usb_user::DRIVER_NUM => f(Some(self.usb_driver)),
-            capsules::ieee802154::DRIVER_NUM => f(Some(self.radio_driver)),
             capsules::net::udp::DRIVER_NUM => f(Some(self.udp_driver)),
             capsules::nrf51822_serialization::DRIVER_NUM => f(Some(self.nrf51822)),
             capsules::nonvolatile_storage_driver::DRIVER_NUM => f(Some(self.nonvolatile_storage)),
@@ -461,7 +459,7 @@ pub unsafe fn reset_handler() {
 
     // Can this initialize be pushed earlier, or into component? -pal
     rf233.initialize(&mut RF233_BUF, &mut RF233_REG_WRITE, &mut RF233_REG_READ);
-    let (radio_driver, mux_mac) = components::ieee802154::Ieee802154Component::new(
+    let (_, mux_mac) = components::ieee802154::Ieee802154Component::new(
         board_kernel,
         rf233,
         aes_mux,
@@ -550,7 +548,6 @@ pub unsafe fn reset_handler() {
         spi: spi_syscalls,
         ipc: kernel::ipc::IPC::new(board_kernel, &grant_cap),
         ninedof,
-        radio_driver,
         udp_driver,
         usb_driver,
         nrf51822: nrf_serialization,


### PR DESCRIPTION
### Pull Request Overview

This pull request removes the userspace 15.4 driver from Imix. The primary motivation is to reduce code size, as tock 2.0 development has been hung up several times by code size issues on Imix. Most recently, my attempt to merge master into tock-2.0-dev failed because the kernel could not fit in flash.

I chose to remove the userspace 15.4 driver because we now have the higher level UDP interface, which should be used instead of this one anyway. In fact, the presence of the 15.4 driver breaks many of the security guarantees of the UDP stack because a second app could just listen-in directly on the contents of 15.4 packets.

 Eventually the component for 15.4 should be factored out into two components, one for creating the 15.4 mux and one for creating the userspace driver, but I prefer to leave that task for the future, as dead code elimination gets us far enough here.

### Testing Strategy

This pull request was tested by compiling. It reduced code size by about 6kB.

### TODO or Help Wanted

N/A

### Documentation Updated

- [x] No updates are required.

### Formatting

- [x] Ran `make prepush`.
