### PR TITLE
RFC: Add `install` make target for boards

### DIFF
--- a/boards/acd52832/Makefile
+++ b/boards/acd52832/Makefile
@@ -17,6 +17,10 @@ endif
 
 TOCKLOADER_JTAG_FLAGS = --jlink --board nrf52dk
 
+# Default target for installing the kernel.
+.PHONY: install
+install: flash
+
 # Upload the kernel over JTAG
 .PHONY: flash
 flash: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin

--- a/boards/arty_e21/Makefile
+++ b/boards/arty_e21/Makefile
@@ -10,6 +10,10 @@ KERNEL_ADDRESS=0x400000
 
 TOCKLOADER_OPENOCD_FLAGS = --openocd --board arty
 
+# Default target for installing the kernel.
+.PHONY: install
+install: flash
+
 .PHONY: flash-tockloader
 flash-tockloader: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin
 	$(TOCKLOADER) $(TOCKLOADER_GENERAL_FLAGS) flash --address $(KERNEL_ADDRESS) $(TOCKLOADER_OPENOCD_FLAGS) $<

--- a/boards/clue_nrf52840/Makefile
+++ b/boards/clue_nrf52840/Makefile
@@ -16,9 +16,13 @@ KERNEL_WITH_APP=$(TOCK_ROOT_DIRECTORY)/target/$(TARGET)/debug/$(PLATFORM)-app.el
 # Upload the kernel using nrfutil
 .PHONY: program program-apps
 
+# Default target for installing the kernel.
+.PHONY: install
+install: program
+
 program: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/debug/$(PLATFORM).bin
 	ifndef PORT
-		$(error Please specify the serial port using the PORT variable) 
+		$(error Please specify the serial port using the PORT variable)
 	endif
 	adafruit-nrfutil dfu genpkg --dev-type 0x0052 --sd-req 0x00B6 --application $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/debug/$(PLATFORM).bin $(KERNEL).zip
 	echo "Trying to reset device"
@@ -28,10 +32,10 @@ program: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/debug/$(PLATFORM).bin
 # Upload the kernel and apps using nrfutil
 program-apps: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/debug/$(PLATFORM).elf
 	ifndef PORT
-		$(error Please specify the serial port using the PORT variable) 
+		$(error Please specify the serial port using the PORT variable)
 	endif
 	ifndef APP
-		$(error Please define the APP variable with the TBF file to flash an application) 
+		$(error Please define the APP variable with the TBF file to flash an application)
 	endif
 	arm-none-eabi-objcopy --update-section .apps=$(APP) $(KERNEL) $(KERNEL_WITH_APP)
 	arm-none-eabi-objcopy --output-target=binary -S $(KERNEL_WITH_APP) $(KERNEL_WITH_APP).bin

--- a/boards/earlgrey-nexysvideo/Makefile
+++ b/boards/earlgrey-nexysvideo/Makefile
@@ -17,6 +17,10 @@ else
 	CARGO_FLAGS += --features=$(DEFAULT_BOARD_CONFIGURATION)
 endif
 
+# Default target for installing the kernel.
+.PHONY: install
+install: flash
+
 qemu: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
 	$(call check_defined, OPENTITAN_BOOT_ROM)
 	qemu-system-riscv32 -M opentitan -kernel $^ -bios $(OPENTITAN_BOOT_ROM) -nographic -serial mon:stdio

--- a/boards/hail/Makefile
+++ b/boards/hail/Makefile
@@ -17,6 +17,10 @@ endif
 
 TOCKLOADER_JTAG_FLAGS = --jtag --board hail --arch cortex-m4 --jtag-device ATSAM4LC8C
 
+# Default target for installing the kernel.
+.PHONY: install
+install: program
+
 .PHONY: program
 program: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin
 	$(TOCKLOADER) $(TOCKLOADER_GENERAL_FLAGS) flash --address $(KERNEL_ADDRESS) $<

--- a/boards/hifive1/Makefile
+++ b/boards/hifive1/Makefile
@@ -5,6 +5,10 @@ PLATFORM=hifive1
 
 include ../Makefile.common
 
+# Default target for installing the kernel.
+.PHONY: install
+install: flash
+
 flash: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
 	openocd \
 		-c "source [find board/sifive-hifive1.cfg]; program $<; resume 0x20000000; exit"

--- a/boards/imix/Makefile
+++ b/boards/imix/Makefile
@@ -17,6 +17,10 @@ endif
 
 TOCKLOADER_JTAG_FLAGS = --jtag --board imix --arch cortex-m4 --jtag-device ATSAM4LC8C
 
+# Default target for installing the kernel.
+.PHONY: install
+install: program
+
 .PHONY: program
 program: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin
 	$(TOCKLOADER) $(TOCKLOADER_GENERAL_FLAGS) flash --address $(KERNEL_ADDRESS) $<

--- a/boards/imxrt1050-evkb/Makefile
+++ b/boards/imxrt1050-evkb/Makefile
@@ -1,7 +1,7 @@
 # Makefile for building the tock kernel for the i.MX RT1052 platform
-# 
+#
 APP=../../../libtock-c/examples/c_hello/build/cortex-m7/cortex-m7.tbf
-# APP=../../../libtock-rs/target/thumbv7em-none-eabi/tab/imxrt1050/hello_world/cortex-m7.tbf 
+# APP=../../../libtock-rs/target/thumbv7em-none-eabi/tab/imxrt1050/hello_world/cortex-m7.tbf
 TARGET=thumbv7em-none-eabi
 PLATFORM=imxrt1050-evkb
 
@@ -13,6 +13,10 @@ R_KERNEL_WITH_APP=$(TOCK_ROOT_DIRECTORY)/target/$(TARGET)/release/$(PLATFORM)-ap
 MCUX_IDE_BIN=/Applications/MCUXpressoIDE_11.1.1_3241/ide/plugins/com.nxp.mcuxpresso.tools.bin.macosx_11.1.0.202002241259/binaries/
 
 include ../Makefile.common
+
+# Default target for installing the kernel.
+.PHONY: install
+install: flash
 
 .PHONY: $(TOCK_ROOT_DIRECTORY)program
 program: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/debug/$(PLATFORM).elf

--- a/boards/microbit_v2/Makefile
+++ b/boards/microbit_v2/Makefile
@@ -13,6 +13,10 @@ APP=../../../libtock-c/examples/sensors/build/cortex-m4/cortex-m4.tbf
 KERNEL=$(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
 KERNEL_WITH_APP=$(TOCK_ROOT_DIRECTORY)/target/$(TARGET)/release/$(PLATFORM)-app.elf
 
+# Default target for installing the kernel.
+.PHONY: install
+install: flash
+
 .PHONY: flash-debug
 flash-debug: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/debug/$(PLATFORM).elf
 	$(OPENOCD) $(OPENOCD_OPTIONS) -c "program $<; verify_image $<;  reset; shutdown;"

--- a/boards/msp_exp432p401r/Makefile
+++ b/boards/msp_exp432p401r/Makefile
@@ -10,6 +10,10 @@ OPENOCD_OPTIONS=-f openocd.cfg
 APP_START_ADDR=0x20000
 APP?=
 
+# Default target for installing the kernel.
+.PHONY: install
+install: flash
+
 .PHONY: flash-debug
 flash-debug: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/debug/$(PLATFORM).elf
 	$(OPENOCD) $(OPENOCD_OPTIONS) -c "init; reset halt; flash write_image erase $<; verify_image $<; reset; shutdown"

--- a/boards/nano33ble/Makefile
+++ b/boards/nano33ble/Makefile
@@ -10,6 +10,10 @@ ifdef PORT
   FLAGS += --port $(PORT)
 endif
 
+# Default target for installing the kernel.
+.PHONY: install
+install: program
+
 # Upload the kernel using tockloader and the tock bootloader
 .PHONY: program
 program: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin

--- a/boards/nordic/nrf52840_dongle/Makefile
+++ b/boards/nordic/nrf52840_dongle/Makefile
@@ -17,6 +17,10 @@ endif
 
 TOCKLOADER_JTAG_FLAGS = --jlink --board nrf52dk
 
+# Default target for installing the kernel.
+.PHONY: install
+install: flash
+
 # Upload the kernel over JTAG
 .PHONY: flash
 flash: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin

--- a/boards/nordic/nrf52840dk/Makefile
+++ b/boards/nordic/nrf52840dk/Makefile
@@ -15,6 +15,10 @@ ifdef PORT
   TOCKLOADER_GENERAL_FLAGS += --port $(PORT)
 endif
 
+# Default target for installing the kernel.
+.PHONY: install
+install: flash
+
 # Upload the kernel over JTAG
 .PHONY: flash
 flash: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin

--- a/boards/nordic/nrf52dk/Makefile
+++ b/boards/nordic/nrf52dk/Makefile
@@ -17,6 +17,10 @@ endif
 
 TOCKLOADER_JTAG_FLAGS = --jlink --board nrf52dk
 
+# Default target for installing the kernel.
+.PHONY: install
+install: flash
+
 # Upload the kernel over JTAG
 .PHONY: flash
 flash: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin

--- a/boards/nucleo_f429zi/Makefile
+++ b/boards/nucleo_f429zi/Makefile
@@ -8,6 +8,10 @@ include ../Makefile.common
 OPENOCD=openocd
 OPENOCD_OPTIONS=-f openocd.cfg
 
+# Default target for installing the kernel.
+.PHONY: install
+install: flash
+
 .PHONY: flash-debug
 flash-debug: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/debug/$(PLATFORM).elf
 	$(OPENOCD) $(OPENOCD_OPTIONS) -c "init; reset halt; flash write_image erase $<; verify_image $<; reset; shutdown"

--- a/boards/nucleo_f446re/Makefile
+++ b/boards/nucleo_f446re/Makefile
@@ -8,6 +8,10 @@ include ../Makefile.common
 OPENOCD=openocd
 OPENOCD_OPTIONS=-f openocd.cfg
 
+# Default target for installing the kernel.
+.PHONY: install
+install: flash
+
 .PHONY: flash-debug
 flash-debug: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/debug/$(PLATFORM).elf
 	$(OPENOCD) $(OPENOCD_OPTIONS) -c "init; reset halt; flash write_image erase $<; verify_image $<; reset; shutdown"

--- a/boards/redboard_artemis_nano/Makefile
+++ b/boards/redboard_artemis_nano/Makefile
@@ -9,6 +9,10 @@ ifndef PORT
   PORT="/dev/ttyUSB0"
 endif
 
+# Default target for installing the kernel.
+.PHONY: install
+install: flash
+
 .PHONY: flash
 flash: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin
 	python ambiq/ambiq_bin2board.py --bin $< --load-address-blob 0x20000 -b 115200 -port $(PORT) -r 2 -v --magic-num 0xCB --version 0x0 --load-address-wired 0xc000 -i 6 --options 0x1

--- a/boards/stm32f3discovery/Makefile
+++ b/boards/stm32f3discovery/Makefile
@@ -8,6 +8,10 @@ include ../Makefile.common
 OPENOCD=openocd
 OPENOCD_OPTIONS=-f openocd.cfg
 
+# Default target for installing the kernel.
+.PHONY: install
+install: flash
+
 .PHONY: flash-debug
 flash-debug: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/debug/$(PLATFORM).elf
 	$(OPENOCD) $(OPENOCD_OPTIONS) -c "init; reset halt; flash write_image erase $<; verify_image $<; reset; shutdown"

--- a/boards/stm32f412gdiscovery/Makefile
+++ b/boards/stm32f412gdiscovery/Makefile
@@ -8,6 +8,10 @@ include ../Makefile.common
 OPENOCD=openocd
 OPENOCD_OPTIONS=-f openocd.cfg
 
+# Default target for installing the kernel.
+.PHONY: install
+install: flash
+
 .PHONY: flash-debug
 flash-debug: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/debug/$(PLATFORM).elf
 	$(OPENOCD) $(OPENOCD_OPTIONS) -c "init; reset halt; flash write_image erase $<; verify_image $<; reset; shutdown"

--- a/boards/teensy40/Makefile
+++ b/boards/teensy40/Makefile
@@ -5,6 +5,10 @@ PLATFORM=teensy40
 
 include ../Makefile.common
 
+# Default target for installing the kernel.
+.PHONY: install
+install: program
+
 %.hex: %.elf
 	$(Q)$(OBJCOPY) -O ihex $< $@
 

--- a/boards/weact_f401ccu6/Makefile
+++ b/boards/weact_f401ccu6/Makefile
@@ -9,6 +9,10 @@ include ../Makefile.common
 OPENOCD=openocd
 OPENOCD_OPTIONS=-f openocd.cfg
 
+# Default target for installing the kernel.
+.PHONY: flash
+install: program
+
 flash: $(KERNEL)
 	$(OPENOCD) $(OPENOCD_OPTIONS) -c "init; reset halt; flash write_image erase $<; verify_image $<; reset; shutdown"
 

--- a/boards/weact_f401ccu6/Makefile
+++ b/boards/weact_f401ccu6/Makefile
@@ -10,8 +10,8 @@ OPENOCD=openocd
 OPENOCD_OPTIONS=-f openocd.cfg
 
 # Default target for installing the kernel.
-.PHONY: flash
-install: program
+.PHONY: install
+install: flash
 
 flash: $(KERNEL)
 	$(OPENOCD) $(OPENOCD_OPTIONS) -c "init; reset halt; flash write_image erase $<; verify_image $<; reset; shutdown"

--- a/doc/Design.md
+++ b/doc/Design.md
@@ -381,7 +381,7 @@ Tock also tries to ensure Tock "just works" for users. This manifests by trying
 to minimize the number of steps to get Tock running. The build system uses
 `make` which is familiar to many developers, and just running `make` in a board
 folder will compile the kernel. The most supported boards (Hail and imix) can
-then be programmed by just running `make program`. Installing an app just
+then be programmed by just running `make install`. Installing an app just
 requires one more command: `tockloader install blink`. Tockloader will continue
 to expand to support the ease-of-use with Tock. Now, "just works" is a design
 goal that Tock is not completely meeting. But, future design decisions should

--- a/doc/Getting_Started.md
+++ b/doc/Getting_Started.md
@@ -132,33 +132,21 @@ subdirectory provide more details for each platform.
 
 ## Loading the kernel onto a board
 
-The process to load the kernel onto the board depends on the board.
-There are two main variants: some boards (notably the
-[Imix](../boards/imix/README.md) and [Hail](../boards/hail/README.md)
-boards) have a serial bootloader, most other boards use a programming
-adapter that supports the JTAG or SWD protocol instead.
+The process to load the kernel onto the board depends on the board. You should
+be able to program the kernel by running:
 
-To load a kernel onto a board using a serial bootloader, no other
-software is required and you can just run
+    $ make install
 
-    $ make program
-
-in the board's directory. To load the kernel using a programming
-adapter, you need the appropriate software that supports the adapter
-and can then install the kernel by running
-
-    $ make flash
-
-Depending on the adapter, you will need either the free `openocd` or
-Segger's proprietary `JLinkExe`. Programming adapters are available as
+For some boards, you will need a programming adapter to flash code. Depending on
+the board and which adapter it supports, you will need either the free `openocd`
+or Segger's proprietary `JLinkExe`. Programming adapters are available as
 standalone devices (for example the [JLink EDU JTAG
 debugger](https://www.segger.com/j-link-edu.html) available on
 [Digikey](https://www.digikey.com/product-detail/en/segger-microcontroller-systems/8.08.90-J-LINK-EDU/899-1008-ND/2263130)),
-but most development boards come with an onboard programming and
-debugging adapter. In that case, the board you use determines which
-software you will need and the `Makefile` in the board directory will
-know which one to call. Again, the [board-specific
-READMEs](../boards/README.md) provide the required details.
+but most development boards come with an onboard programming and debugging
+adapter. In that case, the board you use determines which software you will need
+and the `Makefile` in the board directory will know which one to call. Again,
+the [board-specific READMEs](../boards/README.md) provide the required details.
 
 ### Installing `JLinkExe`
 

--- a/doc/Porting.md
+++ b/doc/Porting.md
@@ -207,6 +207,8 @@ but Tock does have two targets normally supplied:
     hardware is required, though some of the development kit boards have an
     integrated JTAG on-board, so external hardware is not a hard and fast
     rule.
+  - _install_: This should be an alias to either `program` or `flash`, whichever
+    is the preferred approach for this board.
 
 If you don't support _program_ or _flash_, you should define an empty rule
 that explains how to program the board:


### PR DESCRIPTION
Tock has had a long standing convention of two makefile targets for boards to load a kernel onto a board.

1. flash: Uses JTAG to flash the kernel.
1. program: Uses UART and a bootloader to flash the kernel.

This is helpful because some boards support both but require different hardware, and it gives the user some idea of what tools will be needed to load the kernel.

However, new users must figure out which is appropriate if a board supports both. Often there is one target that experienced users just know to use, and we should make this more clear to new users. Also, having different targets on different boards complicates writing a common tutorial guide for multiple platforms.

This patch adds a new target `make install` that just uses the default for the platform. The expectation is that most users can install the kernel using `make install`. The other targets are of course there for users who need something more specific.




### Testing Strategy

This pull request was tested by using `make install` to flash the kernel on hail.


### TODO or Help Wanted

Thoughts?


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
