### PR TITLE
Change process setup to minimize the initially-accessible amount of memory.

### DIFF
--- a/arch/cortex-m/src/syscall.rs
+++ b/arch/cortex-m/src/syscall.rs
@@ -61,17 +61,9 @@ impl kernel::syscall::UserspaceKernelBoundary for SysCall {
     type StoredState = CortexMStoredState;
 
     fn initial_process_app_brk_size(&self) -> usize {
-        // TOCK 1.X
-        //
-        // The 1.x Tock kernel allocates at least 3 kB to processes, and we need
-        // to ensure that happens as userspace may expect it.
-        3 * 1024
-
-        // TOCK 2.0
-        //
-        // Cortex-M hardware use 8 words on the stack to implement context switches.
-        // So we need at least 32 bytes.
-        //SVC_FRAME_SIZE
+        // Cortex-M hardware uses 8 words on the stack to implement context
+        // switches. So we need at least 32 bytes.
+        SVC_FRAME_SIZE
     }
 
     unsafe fn initialize_process(

--- a/arch/rv32i/src/syscall.rs
+++ b/arch/rv32i/src/syscall.rs
@@ -53,20 +53,11 @@ impl kernel::syscall::UserspaceKernelBoundary for SysCall {
     type StoredState = Riscv32iStoredState;
 
     fn initial_process_app_brk_size(&self) -> usize {
-        // TOCK 1.X
-        //
-        // We do not need any memory to start with, but the 1.x Tock kernel
-        // allocates at least 3 kB to processes, and we need to ensure that
-        // happens as userspace may expect it.
-        3 * 1024
-
-        // TOCK 2.0
-        //
         // The RV32I UKB implementation does not use process memory for any
         // context switch state. Therefore, we do not need any process-accessible
         // memory to start with to successfully context switch to the process the
         // first time.
-        //0
+        0
     }
 
     unsafe fn initialize_process(


### PR DESCRIPTION
### Pull Request Overview

This was discussed at https://github.com/tock/tock/issues/1769. This change removes the Tock 1.0 behavior of always giving processes at least 3 kB of usable memory, and instead provides processes the minimum-possible amount of accessible memory to start. This simplifies the C and Rust runtimes, as the runtime initialization assembly can now unconditionally adjust the process break before setting the stack pointer.

The Tock 2.0 rewrite of `libtock-rs` already uses the new semantics on RISC-V, and will use these new semantics on ARM when I merge my work-in-progress code upstream.

### Testing Strategy

Running the tock-on-titan `flash_test` app on H1 (a Cortex-M3 chip) using these changes.

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
