### PR TITLE
Tock 2.0: Remove LegacyDriver

### DIFF
--- a/boards/acd52832/src/main.rs
+++ b/boards/acd52832/src/main.rs
@@ -87,21 +87,21 @@ pub struct Platform {
 impl kernel::Platform for Platform {
     fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
     where
-        F: FnOnce(Option<Result<&dyn kernel::Driver, &dyn kernel::LegacyDriver>>) -> R,
+        F: FnOnce(Option<&dyn kernel::Driver>) -> R,
     {
         match driver_num {
-            capsules::console::DRIVER_NUM => f(Some(Ok(self.console))),
-            capsules::gpio::DRIVER_NUM => f(Some(Ok(self.gpio))),
-            capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
-            capsules::led::DRIVER_NUM => f(Some(Ok(self.led))),
-            capsules::button::DRIVER_NUM => f(Some(Ok(self.button))),
-            capsules::rng::DRIVER_NUM => f(Some(Ok(self.rng))),
-            capsules::ble_advertising_driver::DRIVER_NUM => f(Some(Ok(self.ble_radio))),
-            capsules::temperature::DRIVER_NUM => f(Some(Ok(self.temp))),
-            capsules::gpio_async::DRIVER_NUM => f(Some(Ok(self.gpio_async))),
-            capsules::ambient_light::DRIVER_NUM => f(Some(Ok(self.light))),
-            capsules::buzzer_driver::DRIVER_NUM => f(Some(Ok(self.buzzer))),
-            kernel::ipc::DRIVER_NUM => f(Some(Ok(&self.ipc))),
+            capsules::console::DRIVER_NUM => f(Some(self.console)),
+            capsules::gpio::DRIVER_NUM => f(Some(self.gpio)),
+            capsules::alarm::DRIVER_NUM => f(Some(self.alarm)),
+            capsules::led::DRIVER_NUM => f(Some(self.led)),
+            capsules::button::DRIVER_NUM => f(Some(self.button)),
+            capsules::rng::DRIVER_NUM => f(Some(self.rng)),
+            capsules::ble_advertising_driver::DRIVER_NUM => f(Some(self.ble_radio)),
+            capsules::temperature::DRIVER_NUM => f(Some(self.temp)),
+            capsules::gpio_async::DRIVER_NUM => f(Some(self.gpio_async)),
+            capsules::ambient_light::DRIVER_NUM => f(Some(self.light)),
+            capsules::buzzer_driver::DRIVER_NUM => f(Some(self.buzzer)),
+            kernel::ipc::DRIVER_NUM => f(Some(&self.ipc)),
             _ => f(None),
         }
     }

--- a/boards/arty_e21/src/main.rs
+++ b/boards/arty_e21/src/main.rs
@@ -63,15 +63,15 @@ struct ArtyE21 {
 impl Platform for ArtyE21 {
     fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
     where
-        F: FnOnce(Option<Result<&dyn kernel::Driver, &dyn kernel::LegacyDriver>>) -> R,
+        F: FnOnce(Option<&dyn kernel::Driver>) -> R,
     {
         match driver_num {
-            capsules::console::DRIVER_NUM => f(Some(Ok(self.console))),
-            capsules::gpio::DRIVER_NUM => f(Some(Ok(self.gpio))),
+            capsules::console::DRIVER_NUM => f(Some(self.console)),
+            capsules::gpio::DRIVER_NUM => f(Some(self.gpio)),
 
-            capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
-            capsules::led::DRIVER_NUM => f(Some(Ok(self.led))),
-            capsules::button::DRIVER_NUM => f(Some(Ok(self.button))),
+            capsules::alarm::DRIVER_NUM => f(Some(self.alarm)),
+            capsules::led::DRIVER_NUM => f(Some(self.led)),
+            capsules::button::DRIVER_NUM => f(Some(self.button)),
 
             // kernel::ipc::DRIVER_NUM => f(Some(&self.ipc)),
             _ => f(None),

--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -135,23 +135,23 @@ pub struct Platform {
 impl kernel::Platform for Platform {
     fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
     where
-        F: FnOnce(Option<Result<&dyn kernel::Driver, &dyn kernel::LegacyDriver>>) -> R,
+        F: FnOnce(Option<&dyn kernel::Driver>) -> R,
     {
         match driver_num {
-            capsules::console::DRIVER_NUM => f(Some(Ok(self.console))),
-            capsules::proximity::DRIVER_NUM => f(Some(Ok(self.proximity))),
-            capsules::gpio::DRIVER_NUM => f(Some(Ok(self.gpio))),
-            capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
-            capsules::led::DRIVER_NUM => f(Some(Ok(self.led))),
-            capsules::button::DRIVER_NUM => f(Some(Ok(self.button))),
-            capsules::screen::DRIVER_NUM => f(Some(Ok(self.screen))),
-            capsules::rng::DRIVER_NUM => f(Some(Ok(self.rng))),
-            capsules::ble_advertising_driver::DRIVER_NUM => f(Some(Ok(self.ble_radio))),
-            capsules::ieee802154::DRIVER_NUM => f(Some(Ok(self.ieee802154_radio))),
-            capsules::temperature::DRIVER_NUM => f(Some(Ok(self.temperature))),
-            capsules::humidity::DRIVER_NUM => f(Some(Ok(self.humidity))),
-            capsules::buzzer_driver::DRIVER_NUM => f(Some(Ok(self.buzzer))),
-            kernel::ipc::DRIVER_NUM => f(Some(Ok(&self.ipc))),
+            capsules::console::DRIVER_NUM => f(Some(self.console)),
+            capsules::proximity::DRIVER_NUM => f(Some(self.proximity)),
+            capsules::gpio::DRIVER_NUM => f(Some(self.gpio)),
+            capsules::alarm::DRIVER_NUM => f(Some(self.alarm)),
+            capsules::led::DRIVER_NUM => f(Some(self.led)),
+            capsules::button::DRIVER_NUM => f(Some(self.button)),
+            capsules::screen::DRIVER_NUM => f(Some(self.screen)),
+            capsules::rng::DRIVER_NUM => f(Some(self.rng)),
+            capsules::ble_advertising_driver::DRIVER_NUM => f(Some(self.ble_radio)),
+            capsules::ieee802154::DRIVER_NUM => f(Some(self.ieee802154_radio)),
+            capsules::temperature::DRIVER_NUM => f(Some(self.temperature)),
+            capsules::humidity::DRIVER_NUM => f(Some(self.humidity)),
+            capsules::buzzer_driver::DRIVER_NUM => f(Some(self.buzzer)),
+            kernel::ipc::DRIVER_NUM => f(Some(&self.ipc)),
             _ => f(None),
         }
     }

--- a/boards/earlgrey-nexysvideo/src/main.rs
+++ b/boards/earlgrey-nexysvideo/src/main.rs
@@ -83,16 +83,16 @@ struct EarlGreyNexysVideo {
 impl Platform for EarlGreyNexysVideo {
     fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
     where
-        F: FnOnce(Option<Result<&dyn kernel::Driver, &dyn kernel::LegacyDriver>>) -> R,
+        F: FnOnce(Option<&dyn kernel::Driver>) -> R,
     {
         match driver_num {
-            capsules::led::DRIVER_NUM => f(Some(Ok(self.led))),
-            capsules::hmac::DRIVER_NUM => f(Some(Ok(self.hmac))),
-            capsules::gpio::DRIVER_NUM => f(Some(Ok(self.gpio))),
-            capsules::console::DRIVER_NUM => f(Some(Ok(self.console))),
-            capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
-            capsules::low_level_debug::DRIVER_NUM => f(Some(Ok(self.lldb))),
-            capsules::i2c_master::DRIVER_NUM => f(Some(Ok(self.i2c_master))),
+            capsules::led::DRIVER_NUM => f(Some(self.led)),
+            capsules::hmac::DRIVER_NUM => f(Some(self.hmac)),
+            capsules::gpio::DRIVER_NUM => f(Some(self.gpio)),
+            capsules::console::DRIVER_NUM => f(Some(self.console)),
+            capsules::alarm::DRIVER_NUM => f(Some(self.alarm)),
+            capsules::low_level_debug::DRIVER_NUM => f(Some(self.lldb)),
+            capsules::i2c_master::DRIVER_NUM => f(Some(self.i2c_master)),
             _ => f(None),
         }
     }

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -79,30 +79,30 @@ struct Hail {
 impl Platform for Hail {
     fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
     where
-        F: FnOnce(Option<Result<&dyn kernel::Driver, &dyn kernel::LegacyDriver>>) -> R,
+        F: FnOnce(Option<&dyn kernel::Driver>) -> R,
     {
         match driver_num {
-            capsules::console::DRIVER_NUM => f(Some(Ok(self.console))),
-            capsules::gpio::DRIVER_NUM => f(Some(Ok(self.gpio))),
+            capsules::console::DRIVER_NUM => f(Some(self.console)),
+            capsules::gpio::DRIVER_NUM => f(Some(self.gpio)),
 
-            capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
-            capsules::spi_controller::DRIVER_NUM => f(Some(Ok(self.spi))),
-            capsules::nrf51822_serialization::DRIVER_NUM => f(Some(Ok(self.nrf51822))),
-            capsules::ambient_light::DRIVER_NUM => f(Some(Ok(self.ambient_light))),
-            capsules::adc::DRIVER_NUM => f(Some(Ok(self.adc))),
-            capsules::led::DRIVER_NUM => f(Some(Ok(self.led))),
-            capsules::button::DRIVER_NUM => f(Some(Ok(self.button))),
-            capsules::humidity::DRIVER_NUM => f(Some(Ok(self.humidity))),
-            capsules::temperature::DRIVER_NUM => f(Some(Ok(self.temp))),
-            capsules::ninedof::DRIVER_NUM => f(Some(Ok(self.ninedof))),
+            capsules::alarm::DRIVER_NUM => f(Some(self.alarm)),
+            capsules::spi_controller::DRIVER_NUM => f(Some(self.spi)),
+            capsules::nrf51822_serialization::DRIVER_NUM => f(Some(self.nrf51822)),
+            capsules::ambient_light::DRIVER_NUM => f(Some(self.ambient_light)),
+            capsules::adc::DRIVER_NUM => f(Some(self.adc)),
+            capsules::led::DRIVER_NUM => f(Some(self.led)),
+            capsules::button::DRIVER_NUM => f(Some(self.button)),
+            capsules::humidity::DRIVER_NUM => f(Some(self.humidity)),
+            capsules::temperature::DRIVER_NUM => f(Some(self.temp)),
+            capsules::ninedof::DRIVER_NUM => f(Some(self.ninedof)),
 
-            capsules::rng::DRIVER_NUM => f(Some(Ok(self.rng))),
+            capsules::rng::DRIVER_NUM => f(Some(self.rng)),
 
-            capsules::crc::DRIVER_NUM => f(Some(Ok(self.crc))),
+            capsules::crc::DRIVER_NUM => f(Some(self.crc)),
 
-            capsules::dac::DRIVER_NUM => f(Some(Ok(self.dac))),
+            capsules::dac::DRIVER_NUM => f(Some(self.dac)),
 
-            kernel::ipc::DRIVER_NUM => f(Some(Ok(&self.ipc))),
+            kernel::ipc::DRIVER_NUM => f(Some(&self.ipc)),
             _ => f(None),
         }
     }

--- a/boards/hifive1/src/main.rs
+++ b/boards/hifive1/src/main.rs
@@ -70,13 +70,13 @@ struct HiFive1 {
 impl Platform for HiFive1 {
     fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
     where
-        F: FnOnce(Option<Result<&dyn kernel::Driver, &dyn kernel::LegacyDriver>>) -> R,
+        F: FnOnce(Option<&dyn kernel::Driver>) -> R,
     {
         match driver_num {
-            capsules::led::DRIVER_NUM => f(Some(Ok(self.led))),
-            capsules::console::DRIVER_NUM => f(Some(Ok(self.console))),
-            capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
-            capsules::low_level_debug::DRIVER_NUM => f(Some(Ok(self.lldb))),
+            capsules::led::DRIVER_NUM => f(Some(self.led)),
+            capsules::console::DRIVER_NUM => f(Some(self.console)),
+            capsules::alarm::DRIVER_NUM => f(Some(self.alarm)),
+            capsules::low_level_debug::DRIVER_NUM => f(Some(self.lldb)),
             _ => f(None),
         }
     }

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -155,30 +155,28 @@ static mut RF233_REG_READ: [u8; 2] = [0x00; 2];
 impl kernel::Platform for Imix {
     fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
     where
-        F: FnOnce(Option<Result<&dyn kernel::Driver, &dyn kernel::LegacyDriver>>) -> R,
+        F: FnOnce(Option<&dyn kernel::Driver>) -> R,
     {
         match driver_num {
-            capsules::console::DRIVER_NUM => f(Some(Ok(self.console))),
-            capsules::gpio::DRIVER_NUM => f(Some(Ok(self.gpio))),
-            capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
-            capsules::spi_controller::DRIVER_NUM => f(Some(Ok(self.spi))),
-            capsules::adc::DRIVER_NUM => f(Some(Ok(self.adc))),
-            capsules::led::DRIVER_NUM => f(Some(Ok(self.led))),
-            capsules::button::DRIVER_NUM => f(Some(Ok(self.button))),
-            capsules::analog_comparator::DRIVER_NUM => f(Some(Ok(self.analog_comparator))),
-            capsules::ambient_light::DRIVER_NUM => f(Some(Ok(self.ambient_light))),
-            capsules::temperature::DRIVER_NUM => f(Some(Ok(self.temp))),
-            capsules::humidity::DRIVER_NUM => f(Some(Ok(self.humidity))),
-            capsules::ninedof::DRIVER_NUM => f(Some(Ok(self.ninedof))),
-            capsules::crc::DRIVER_NUM => f(Some(Ok(self.crc))),
-            capsules::usb::usb_user::DRIVER_NUM => f(Some(Ok(self.usb_driver))),
-            capsules::net::udp::DRIVER_NUM => f(Some(Ok(self.udp_driver))),
-            capsules::nrf51822_serialization::DRIVER_NUM => f(Some(Ok(self.nrf51822))),
-            capsules::nonvolatile_storage_driver::DRIVER_NUM => {
-                f(Some(Ok(self.nonvolatile_storage)))
-            }
-            capsules::rng::DRIVER_NUM => f(Some(Ok(self.rng))),
-            kernel::ipc::DRIVER_NUM => f(Some(Ok(&self.ipc))),
+            capsules::console::DRIVER_NUM => f(Some(self.console)),
+            capsules::gpio::DRIVER_NUM => f(Some(self.gpio)),
+            capsules::alarm::DRIVER_NUM => f(Some(self.alarm)),
+            capsules::spi_controller::DRIVER_NUM => f(Some(self.spi)),
+            capsules::adc::DRIVER_NUM => f(Some(self.adc)),
+            capsules::led::DRIVER_NUM => f(Some(self.led)),
+            capsules::button::DRIVER_NUM => f(Some(self.button)),
+            capsules::analog_comparator::DRIVER_NUM => f(Some(self.analog_comparator)),
+            capsules::ambient_light::DRIVER_NUM => f(Some(self.ambient_light)),
+            capsules::temperature::DRIVER_NUM => f(Some(self.temp)),
+            capsules::humidity::DRIVER_NUM => f(Some(self.humidity)),
+            capsules::ninedof::DRIVER_NUM => f(Some(self.ninedof)),
+            capsules::crc::DRIVER_NUM => f(Some(self.crc)),
+            capsules::usb::usb_user::DRIVER_NUM => f(Some(self.usb_driver)),
+            capsules::net::udp::DRIVER_NUM => f(Some(self.udp_driver)),
+            capsules::nrf51822_serialization::DRIVER_NUM => f(Some(self.nrf51822)),
+            capsules::nonvolatile_storage_driver::DRIVER_NUM => f(Some(self.nonvolatile_storage)),
+            capsules::rng::DRIVER_NUM => f(Some(self.rng)),
+            kernel::ipc::DRIVER_NUM => f(Some(&self.ipc)),
             _ => f(None),
         }
     }

--- a/boards/imxrt1050-evkb/src/main.rs
+++ b/boards/imxrt1050-evkb/src/main.rs
@@ -82,16 +82,16 @@ struct Imxrt1050EVKB {
 impl Platform for Imxrt1050EVKB {
     fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
     where
-        F: FnOnce(Option<Result<&dyn kernel::Driver, &dyn kernel::LegacyDriver>>) -> R,
+        F: FnOnce(Option<&dyn kernel::Driver>) -> R,
     {
         match driver_num {
-            capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
-            capsules::button::DRIVER_NUM => f(Some(Ok(self.button))),
-            capsules::console::DRIVER_NUM => f(Some(Ok(self.console))),
-            capsules::gpio::DRIVER_NUM => f(Some(Ok(self.gpio))),
-            kernel::ipc::DRIVER_NUM => f(Some(Ok(&self.ipc))),
-            capsules::led::DRIVER_NUM => f(Some(Ok(self.led))),
-            capsules::ninedof::DRIVER_NUM => f(Some(Ok(self.ninedof))),
+            capsules::alarm::DRIVER_NUM => f(Some(self.alarm)),
+            capsules::button::DRIVER_NUM => f(Some(self.button)),
+            capsules::console::DRIVER_NUM => f(Some(self.console)),
+            capsules::gpio::DRIVER_NUM => f(Some(self.gpio)),
+            kernel::ipc::DRIVER_NUM => f(Some(&self.ipc)),
+            capsules::led::DRIVER_NUM => f(Some(self.led)),
+            capsules::ninedof::DRIVER_NUM => f(Some(self.ninedof)),
             _ => f(None),
         }
     }

--- a/boards/litex/arty/src/main.rs
+++ b/boards/litex/arty/src/main.rs
@@ -141,13 +141,13 @@ struct LiteXArty {
 impl Platform for LiteXArty {
     fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
     where
-        F: FnOnce(Option<Result<&dyn kernel::Driver, &dyn kernel::LegacyDriver>>) -> R,
+        F: FnOnce(Option<&dyn kernel::Driver>) -> R,
     {
         match driver_num {
-            capsules::led::DRIVER_NUM => f(Some(Ok(self.led_driver))),
-            capsules::console::DRIVER_NUM => f(Some(Ok(self.console))),
-            capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
-            capsules::low_level_debug::DRIVER_NUM => f(Some(Ok(self.lldb))),
+            capsules::led::DRIVER_NUM => f(Some(self.led_driver)),
+            capsules::console::DRIVER_NUM => f(Some(self.console)),
+            capsules::alarm::DRIVER_NUM => f(Some(self.alarm)),
+            capsules::low_level_debug::DRIVER_NUM => f(Some(self.lldb)),
             _ => f(None),
         }
     }

--- a/boards/litex/sim/src/main.rs
+++ b/boards/litex/sim/src/main.rs
@@ -133,12 +133,12 @@ struct LiteXSim {
 impl Platform for LiteXSim {
     fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
     where
-        F: FnOnce(Option<Result<&dyn kernel::Driver, &dyn kernel::LegacyDriver>>) -> R,
+        F: FnOnce(Option<&dyn kernel::Driver>) -> R,
     {
         match driver_num {
-            capsules::console::DRIVER_NUM => f(Some(Ok(self.console))),
-            capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
-            capsules::low_level_debug::DRIVER_NUM => f(Some(Ok(self.lldb))),
+            capsules::console::DRIVER_NUM => f(Some(self.console)),
+            capsules::alarm::DRIVER_NUM => f(Some(self.alarm)),
+            capsules::low_level_debug::DRIVER_NUM => f(Some(self.lldb)),
             _ => f(None),
         }
     }

--- a/boards/microbit_v2/src/main.rs
+++ b/boards/microbit_v2/src/main.rs
@@ -111,24 +111,24 @@ pub struct Platform {
 impl kernel::Platform for Platform {
     fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
     where
-        F: FnOnce(Option<Result<&dyn kernel::Driver, &dyn kernel::LegacyDriver>>) -> R,
+        F: FnOnce(Option<&dyn kernel::Driver>) -> R,
     {
         match driver_num {
-            capsules::console::DRIVER_NUM => f(Some(Ok(self.console))),
-            capsules::gpio::DRIVER_NUM => f(Some(Ok(self.gpio))),
-            capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
-            capsules::button::DRIVER_NUM => f(Some(Ok(self.button))),
-            capsules::led_matrix::DRIVER_NUM => f(Some(Ok(self.led))),
-            capsules::ninedof::DRIVER_NUM => f(Some(Ok(self.ninedof))),
-            capsules::adc::DRIVER_NUM => f(Some(Ok(self.adc))),
-            capsules::temperature::DRIVER_NUM => f(Some(Ok(self.temperature))),
-            capsules::lsm303agr::DRIVER_NUM => f(Some(Ok(self.lsm303agr))),
-            capsules::rng::DRIVER_NUM => f(Some(Ok(self.rng))),
-            capsules::ble_advertising_driver::DRIVER_NUM => f(Some(Ok(self.ble_radio))),
-            capsules::buzzer_driver::DRIVER_NUM => f(Some(Ok(self.buzzer))),
-            capsules::app_flash_driver::DRIVER_NUM => f(Some(Ok(self.app_flash))),
-            capsules::sound_pressure::DRIVER_NUM => f(Some(Ok(self.sound_pressure))),
-            kernel::ipc::DRIVER_NUM => f(Some(Ok(&self.ipc))),
+            capsules::console::DRIVER_NUM => f(Some(self.console)),
+            capsules::gpio::DRIVER_NUM => f(Some(self.gpio)),
+            capsules::alarm::DRIVER_NUM => f(Some(self.alarm)),
+            capsules::button::DRIVER_NUM => f(Some(self.button)),
+            capsules::led_matrix::DRIVER_NUM => f(Some(self.led)),
+            capsules::ninedof::DRIVER_NUM => f(Some(self.ninedof)),
+            capsules::adc::DRIVER_NUM => f(Some(self.adc)),
+            capsules::temperature::DRIVER_NUM => f(Some(self.temperature)),
+            capsules::lsm303agr::DRIVER_NUM => f(Some(self.lsm303agr)),
+            capsules::rng::DRIVER_NUM => f(Some(self.rng)),
+            capsules::ble_advertising_driver::DRIVER_NUM => f(Some(self.ble_radio)),
+            capsules::buzzer_driver::DRIVER_NUM => f(Some(self.buzzer)),
+            capsules::app_flash_driver::DRIVER_NUM => f(Some(self.app_flash)),
+            capsules::sound_pressure::DRIVER_NUM => f(Some(self.sound_pressure)),
+            kernel::ipc::DRIVER_NUM => f(Some(&self.ipc)),
             _ => f(None),
         }
     }

--- a/boards/msp_exp432p401r/src/main.rs
+++ b/boards/msp_exp432p401r/src/main.rs
@@ -64,16 +64,16 @@ struct MspExp432P401R {
 impl Platform for MspExp432P401R {
     fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
     where
-        F: FnOnce(Option<Result<&dyn kernel::Driver, &dyn kernel::LegacyDriver>>) -> R,
+        F: FnOnce(Option<&dyn kernel::Driver>) -> R,
     {
         match driver_num {
-            capsules::led::DRIVER_NUM => f(Some(Ok(self.led))),
-            capsules::console::DRIVER_NUM => f(Some(Ok(self.console))),
-            capsules::button::DRIVER_NUM => f(Some(Ok(self.button))),
-            capsules::gpio::DRIVER_NUM => f(Some(Ok(self.gpio))),
-            capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
-            kernel::ipc::DRIVER_NUM => f(Some(Ok(&self.ipc))),
-            capsules::adc::DRIVER_NUM => f(Some(Ok(self.adc))),
+            capsules::led::DRIVER_NUM => f(Some(self.led)),
+            capsules::console::DRIVER_NUM => f(Some(self.console)),
+            capsules::button::DRIVER_NUM => f(Some(self.button)),
+            capsules::gpio::DRIVER_NUM => f(Some(self.gpio)),
+            capsules::alarm::DRIVER_NUM => f(Some(self.alarm)),
+            kernel::ipc::DRIVER_NUM => f(Some(&self.ipc)),
+            capsules::adc::DRIVER_NUM => f(Some(self.adc)),
             _ => f(None),
         }
     }

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -130,18 +130,18 @@ pub struct Platform {
 impl kernel::Platform for Platform {
     fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
     where
-        F: FnOnce(Option<Result<&dyn kernel::Driver, &dyn kernel::LegacyDriver>>) -> R,
+        F: FnOnce(Option<&dyn kernel::Driver>) -> R,
     {
         match driver_num {
-            capsules::console::DRIVER_NUM => f(Some(Ok(self.console))),
-            capsules::proximity::DRIVER_NUM => f(Some(Ok(self.proximity))),
-            capsules::gpio::DRIVER_NUM => f(Some(Ok(self.gpio))),
-            capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
-            capsules::led::DRIVER_NUM => f(Some(Ok(self.led))),
-            capsules::rng::DRIVER_NUM => f(Some(Ok(self.rng))),
-            capsules::ble_advertising_driver::DRIVER_NUM => f(Some(Ok(self.ble_radio))),
-            capsules::ieee802154::DRIVER_NUM => f(Some(Ok(self.ieee802154_radio))),
-            kernel::ipc::DRIVER_NUM => f(Some(Ok(&self.ipc))),
+            capsules::console::DRIVER_NUM => f(Some(self.console)),
+            capsules::proximity::DRIVER_NUM => f(Some(self.proximity)),
+            capsules::gpio::DRIVER_NUM => f(Some(self.gpio)),
+            capsules::alarm::DRIVER_NUM => f(Some(self.alarm)),
+            capsules::led::DRIVER_NUM => f(Some(self.led)),
+            capsules::rng::DRIVER_NUM => f(Some(self.rng)),
+            capsules::ble_advertising_driver::DRIVER_NUM => f(Some(self.ble_radio)),
+            capsules::ieee802154::DRIVER_NUM => f(Some(self.ieee802154_radio)),
+            kernel::ipc::DRIVER_NUM => f(Some(&self.ipc)),
             _ => f(None),
         }
     }

--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -102,20 +102,20 @@ pub struct Platform {
 impl kernel::Platform for Platform {
     fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
     where
-        F: FnOnce(Option<Result<&dyn kernel::Driver, &dyn kernel::LegacyDriver>>) -> R,
+        F: FnOnce(Option<&dyn kernel::Driver>) -> R,
     {
         match driver_num {
-            capsules::console::DRIVER_NUM => f(Some(Ok(self.console))),
-            capsules::gpio::DRIVER_NUM => f(Some(Ok(self.gpio))),
-            capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
-            capsules::led::DRIVER_NUM => f(Some(Ok(self.led))),
-            capsules::button::DRIVER_NUM => f(Some(Ok(self.button))),
-            capsules::rng::DRIVER_NUM => f(Some(Ok(self.rng))),
-            capsules::ble_advertising_driver::DRIVER_NUM => f(Some(Ok(self.ble_radio))),
-            capsules::ieee802154::DRIVER_NUM => f(Some(Ok(self.ieee802154_radio))),
-            capsules::temperature::DRIVER_NUM => f(Some(Ok(self.temp))),
-            capsules::analog_comparator::DRIVER_NUM => f(Some(Ok(self.analog_comparator))),
-            kernel::ipc::DRIVER_NUM => f(Some(Ok(&self.ipc))),
+            capsules::console::DRIVER_NUM => f(Some(self.console)),
+            capsules::gpio::DRIVER_NUM => f(Some(self.gpio)),
+            capsules::alarm::DRIVER_NUM => f(Some(self.alarm)),
+            capsules::led::DRIVER_NUM => f(Some(self.led)),
+            capsules::button::DRIVER_NUM => f(Some(self.button)),
+            capsules::rng::DRIVER_NUM => f(Some(self.rng)),
+            capsules::ble_advertising_driver::DRIVER_NUM => f(Some(self.ble_radio)),
+            capsules::ieee802154::DRIVER_NUM => f(Some(self.ieee802154_radio)),
+            capsules::temperature::DRIVER_NUM => f(Some(self.temp)),
+            capsules::analog_comparator::DRIVER_NUM => f(Some(self.analog_comparator)),
+            kernel::ipc::DRIVER_NUM => f(Some(&self.ipc)),
             _ => f(None),
         }
     }

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -178,24 +178,22 @@ pub struct Platform {
 impl kernel::Platform for Platform {
     fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
     where
-        F: FnOnce(Option<Result<&dyn kernel::Driver, &dyn kernel::LegacyDriver>>) -> R,
+        F: FnOnce(Option<&dyn kernel::Driver>) -> R,
     {
         match driver_num {
-            capsules::console::DRIVER_NUM => f(Some(Ok(self.console))),
-            capsules::gpio::DRIVER_NUM => f(Some(Ok(self.gpio))),
-            capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
-            capsules::led::DRIVER_NUM => f(Some(Ok(self.led))),
-            capsules::button::DRIVER_NUM => f(Some(Ok(self.button))),
-            capsules::rng::DRIVER_NUM => f(Some(Ok(self.rng))),
-            capsules::ble_advertising_driver::DRIVER_NUM => f(Some(Ok(self.ble_radio))),
-            capsules::ieee802154::DRIVER_NUM => f(Some(Ok(self.ieee802154_radio))),
-            capsules::temperature::DRIVER_NUM => f(Some(Ok(self.temp))),
-            capsules::analog_comparator::DRIVER_NUM => f(Some(Ok(self.analog_comparator))),
-            capsules::nonvolatile_storage_driver::DRIVER_NUM => {
-                f(Some(Ok(self.nonvolatile_storage)))
-            }
-            capsules::net::udp::DRIVER_NUM => f(Some(Ok(self.udp_driver))),
-            kernel::ipc::DRIVER_NUM => f(Some(Ok(&self.ipc))),
+            capsules::console::DRIVER_NUM => f(Some(self.console)),
+            capsules::gpio::DRIVER_NUM => f(Some(self.gpio)),
+            capsules::alarm::DRIVER_NUM => f(Some(self.alarm)),
+            capsules::led::DRIVER_NUM => f(Some(self.led)),
+            capsules::button::DRIVER_NUM => f(Some(self.button)),
+            capsules::rng::DRIVER_NUM => f(Some(self.rng)),
+            capsules::ble_advertising_driver::DRIVER_NUM => f(Some(self.ble_radio)),
+            capsules::ieee802154::DRIVER_NUM => f(Some(self.ieee802154_radio)),
+            capsules::temperature::DRIVER_NUM => f(Some(self.temp)),
+            capsules::analog_comparator::DRIVER_NUM => f(Some(self.analog_comparator)),
+            capsules::nonvolatile_storage_driver::DRIVER_NUM => f(Some(self.nonvolatile_storage)),
+            capsules::net::udp::DRIVER_NUM => f(Some(self.udp_driver)),
+            kernel::ipc::DRIVER_NUM => f(Some(&self.ipc)),
             _ => f(None),
         }
     }

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -161,19 +161,19 @@ pub struct Platform {
 impl kernel::Platform for Platform {
     fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
     where
-        F: FnOnce(Option<Result<&dyn kernel::Driver, &dyn kernel::LegacyDriver>>) -> R,
+        F: FnOnce(Option<&dyn kernel::Driver>) -> R,
     {
         match driver_num {
-            capsules::console::DRIVER_NUM => f(Some(Ok(self.console))),
-            capsules::gpio::DRIVER_NUM => f(Some(Ok(self.gpio))),
-            capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
-            capsules::led::DRIVER_NUM => f(Some(Ok(self.led))),
-            capsules::button::DRIVER_NUM => f(Some(Ok(self.button))),
-            capsules::rng::DRIVER_NUM => f(Some(Ok(self.rng))),
-            capsules::ble_advertising_driver::DRIVER_NUM => f(Some(Ok(self.ble_radio))),
-            capsules::temperature::DRIVER_NUM => f(Some(Ok(self.temp))),
-            capsules::analog_comparator::DRIVER_NUM => f(Some(Ok(self.analog_comparator))),
-            kernel::ipc::DRIVER_NUM => f(Some(Ok(&self.ipc))),
+            capsules::console::DRIVER_NUM => f(Some(self.console)),
+            capsules::gpio::DRIVER_NUM => f(Some(self.gpio)),
+            capsules::alarm::DRIVER_NUM => f(Some(self.alarm)),
+            capsules::led::DRIVER_NUM => f(Some(self.led)),
+            capsules::button::DRIVER_NUM => f(Some(self.button)),
+            capsules::rng::DRIVER_NUM => f(Some(self.rng)),
+            capsules::ble_advertising_driver::DRIVER_NUM => f(Some(self.ble_radio)),
+            capsules::temperature::DRIVER_NUM => f(Some(self.temp)),
+            capsules::analog_comparator::DRIVER_NUM => f(Some(self.analog_comparator)),
+            kernel::ipc::DRIVER_NUM => f(Some(&self.ipc)),
             _ => f(None),
         }
     }

--- a/boards/nucleo_f429zi/src/main.rs
+++ b/boards/nucleo_f429zi/src/main.rs
@@ -67,17 +67,17 @@ struct NucleoF429ZI {
 impl Platform for NucleoF429ZI {
     fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
     where
-        F: FnOnce(Option<Result<&dyn kernel::Driver, &dyn kernel::LegacyDriver>>) -> R,
+        F: FnOnce(Option<&dyn kernel::Driver>) -> R,
     {
         match driver_num {
-            capsules::console::DRIVER_NUM => f(Some(Ok(self.console))),
-            capsules::led::DRIVER_NUM => f(Some(Ok(self.led))),
-            capsules::button::DRIVER_NUM => f(Some(Ok(self.button))),
-            capsules::adc::DRIVER_NUM => f(Some(Ok(self.adc))),
-            capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
-            capsules::temperature::DRIVER_NUM => f(Some(Ok(self.temperature))),
-            kernel::ipc::DRIVER_NUM => f(Some(Ok(&self.ipc))),
-            capsules::gpio::DRIVER_NUM => f(Some(Ok(self.gpio))),
+            capsules::console::DRIVER_NUM => f(Some(self.console)),
+            capsules::led::DRIVER_NUM => f(Some(self.led)),
+            capsules::button::DRIVER_NUM => f(Some(self.button)),
+            capsules::adc::DRIVER_NUM => f(Some(self.adc)),
+            capsules::alarm::DRIVER_NUM => f(Some(self.alarm)),
+            capsules::temperature::DRIVER_NUM => f(Some(self.temperature)),
+            kernel::ipc::DRIVER_NUM => f(Some(&self.ipc)),
+            capsules::gpio::DRIVER_NUM => f(Some(self.gpio)),
             _ => f(None),
         }
     }

--- a/boards/nucleo_f446re/src/main.rs
+++ b/boards/nucleo_f446re/src/main.rs
@@ -66,14 +66,14 @@ struct NucleoF446RE {
 impl Platform for NucleoF446RE {
     fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
     where
-        F: FnOnce(Option<Result<&dyn kernel::Driver, &dyn kernel::LegacyDriver>>) -> R,
+        F: FnOnce(Option<&dyn kernel::Driver>) -> R,
     {
         match driver_num {
-            capsules::console::DRIVER_NUM => f(Some(Ok(self.console))),
-            capsules::led::DRIVER_NUM => f(Some(Ok(self.led))),
-            capsules::button::DRIVER_NUM => f(Some(Ok(self.button))),
-            capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
-            kernel::ipc::DRIVER_NUM => f(Some(Ok(&self.ipc))),
+            capsules::console::DRIVER_NUM => f(Some(self.console)),
+            capsules::led::DRIVER_NUM => f(Some(self.led)),
+            capsules::button::DRIVER_NUM => f(Some(self.button)),
+            capsules::alarm::DRIVER_NUM => f(Some(self.alarm)),
+            kernel::ipc::DRIVER_NUM => f(Some(&self.ipc)),
             _ => f(None),
         }
     }

--- a/boards/redboard_artemis_nano/src/main.rs
+++ b/boards/redboard_artemis_nano/src/main.rs
@@ -69,15 +69,15 @@ struct RedboardArtemisNano {
 impl Platform for RedboardArtemisNano {
     fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
     where
-        F: FnOnce(Option<Result<&dyn kernel::Driver, &dyn kernel::LegacyDriver>>) -> R,
+        F: FnOnce(Option<&dyn kernel::Driver>) -> R,
     {
         match driver_num {
-            capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
-            capsules::led::DRIVER_NUM => f(Some(Ok(self.led))),
-            capsules::gpio::DRIVER_NUM => f(Some(Ok(self.gpio))),
-            capsules::console::DRIVER_NUM => f(Some(Ok(self.console))),
-            capsules::i2c_master::DRIVER_NUM => f(Some(Ok(self.i2c_master))),
-            capsules::ble_advertising_driver::DRIVER_NUM => f(Some(Ok(self.ble_radio))),
+            capsules::alarm::DRIVER_NUM => f(Some(self.alarm)),
+            capsules::led::DRIVER_NUM => f(Some(self.led)),
+            capsules::gpio::DRIVER_NUM => f(Some(self.gpio)),
+            capsules::console::DRIVER_NUM => f(Some(self.console)),
+            capsules::i2c_master::DRIVER_NUM => f(Some(self.i2c_master)),
+            capsules::ble_advertising_driver::DRIVER_NUM => f(Some(self.ble_radio)),
             _ => f(None),
         }
     }

--- a/boards/stm32f3discovery/src/main.rs
+++ b/boards/stm32f3discovery/src/main.rs
@@ -76,23 +76,21 @@ struct STM32F3Discovery {
 impl Platform for STM32F3Discovery {
     fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
     where
-        F: FnOnce(Option<Result<&dyn kernel::Driver, &dyn kernel::LegacyDriver>>) -> R,
+        F: FnOnce(Option<&dyn kernel::Driver>) -> R,
     {
         match driver_num {
-            capsules::console::DRIVER_NUM => f(Some(Ok(self.console))),
-            capsules::led::DRIVER_NUM => f(Some(Ok(self.led))),
-            capsules::button::DRIVER_NUM => f(Some(Ok(self.button))),
-            capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
-            capsules::gpio::DRIVER_NUM => f(Some(Ok(self.gpio))),
-            capsules::lsm303dlhc::DRIVER_NUM => f(Some(Ok(self.lsm303dlhc))),
-            capsules::l3gd20::DRIVER_NUM => f(Some(Ok(self.l3gd20))),
-            capsules::ninedof::DRIVER_NUM => f(Some(Ok(self.ninedof))),
-            capsules::temperature::DRIVER_NUM => f(Some(Ok(self.temp))),
-            kernel::ipc::DRIVER_NUM => f(Some(Ok(&self.ipc))),
-            capsules::adc::DRIVER_NUM => f(Some(Ok(self.adc))),
-            capsules::nonvolatile_storage_driver::DRIVER_NUM => {
-                f(Some(Ok(self.nonvolatile_storage)))
-            }
+            capsules::console::DRIVER_NUM => f(Some(self.console)),
+            capsules::led::DRIVER_NUM => f(Some(self.led)),
+            capsules::button::DRIVER_NUM => f(Some(self.button)),
+            capsules::alarm::DRIVER_NUM => f(Some(self.alarm)),
+            capsules::gpio::DRIVER_NUM => f(Some(self.gpio)),
+            capsules::lsm303dlhc::DRIVER_NUM => f(Some(self.lsm303dlhc)),
+            capsules::l3gd20::DRIVER_NUM => f(Some(self.l3gd20)),
+            capsules::ninedof::DRIVER_NUM => f(Some(self.ninedof)),
+            capsules::temperature::DRIVER_NUM => f(Some(self.temp)),
+            kernel::ipc::DRIVER_NUM => f(Some(&self.ipc)),
+            capsules::adc::DRIVER_NUM => f(Some(self.adc)),
+            capsules::nonvolatile_storage_driver::DRIVER_NUM => f(Some(self.nonvolatile_storage)),
             _ => f(None),
         }
     }

--- a/boards/stm32f412gdiscovery/src/main.rs
+++ b/boards/stm32f412gdiscovery/src/main.rs
@@ -67,20 +67,20 @@ struct STM32F412GDiscovery {
 impl Platform for STM32F412GDiscovery {
     fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
     where
-        F: FnOnce(Option<Result<&dyn kernel::Driver, &dyn kernel::LegacyDriver>>) -> R,
+        F: FnOnce(Option<&dyn kernel::Driver>) -> R,
     {
         match driver_num {
-            capsules::console::DRIVER_NUM => f(Some(Ok(self.console))),
-            capsules::led::DRIVER_NUM => f(Some(Ok(self.led))),
-            capsules::button::DRIVER_NUM => f(Some(Ok(self.button))),
-            capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
-            kernel::ipc::DRIVER_NUM => f(Some(Ok(&self.ipc))),
-            capsules::gpio::DRIVER_NUM => f(Some(Ok(self.gpio))),
-            capsules::adc::DRIVER_NUM => f(Some(Ok(self.adc))),
-            capsules::touch::DRIVER_NUM => f(Some(Ok(self.touch))),
-            capsules::screen::DRIVER_NUM => f(Some(Ok(self.screen))),
-            capsules::temperature::DRIVER_NUM => f(Some(Ok(self.temperature))),
-            capsules::rng::DRIVER_NUM => f(Some(Ok(self.rng))),
+            capsules::console::DRIVER_NUM => f(Some(self.console)),
+            capsules::led::DRIVER_NUM => f(Some(self.led)),
+            capsules::button::DRIVER_NUM => f(Some(self.button)),
+            capsules::alarm::DRIVER_NUM => f(Some(self.alarm)),
+            kernel::ipc::DRIVER_NUM => f(Some(&self.ipc)),
+            capsules::gpio::DRIVER_NUM => f(Some(self.gpio)),
+            capsules::adc::DRIVER_NUM => f(Some(self.adc)),
+            capsules::touch::DRIVER_NUM => f(Some(self.touch)),
+            capsules::screen::DRIVER_NUM => f(Some(self.screen)),
+            capsules::temperature::DRIVER_NUM => f(Some(self.temperature)),
+            capsules::rng::DRIVER_NUM => f(Some(self.rng)),
             _ => f(None),
         }
     }

--- a/boards/teensy40/src/main.rs
+++ b/boards/teensy40/src/main.rs
@@ -44,13 +44,13 @@ struct Teensy40 {
 impl kernel::Platform for Teensy40 {
     fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
     where
-        F: FnOnce(Option<Result<&dyn kernel::Driver, &dyn kernel::LegacyDriver>>) -> R,
+        F: FnOnce(Option<&dyn kernel::Driver>) -> R,
     {
         match driver_num {
-            capsules::led::DRIVER_NUM => f(Some(Ok(self.led))),
-            capsules::console::DRIVER_NUM => f(Some(Ok(self.console))),
-            kernel::ipc::DRIVER_NUM => f(Some(Ok(&self.ipc))),
-            capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
+            capsules::led::DRIVER_NUM => f(Some(self.led)),
+            capsules::console::DRIVER_NUM => f(Some(self.console)),
+            kernel::ipc::DRIVER_NUM => f(Some(&self.ipc)),
+            capsules::alarm::DRIVER_NUM => f(Some(self.alarm)),
             _ => f(None),
         }
     }

--- a/boards/weact_f401ccu6/src/main.rs
+++ b/boards/weact_f401ccu6/src/main.rs
@@ -66,16 +66,16 @@ struct WeactF401CC {
 impl Platform for WeactF401CC {
     fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
     where
-        F: FnOnce(Option<Result<&dyn kernel::Driver, &dyn kernel::LegacyDriver>>) -> R,
+        F: FnOnce(Option<&dyn kernel::Driver>) -> R,
     {
         match driver_num {
-            capsules::console::DRIVER_NUM => f(Some(Ok(self.console))),
-            capsules::led::DRIVER_NUM => f(Some(Ok(self.led))),
-            capsules::button::DRIVER_NUM => f(Some(Ok(self.button))),
-            capsules::adc::DRIVER_NUM => f(Some(Ok(self.adc))),
-            capsules::alarm::DRIVER_NUM => f(Some(Ok(self.alarm))),
-            kernel::ipc::DRIVER_NUM => f(Some(Ok(&self.ipc))),
-            capsules::gpio::DRIVER_NUM => f(Some(Ok(self.gpio))),
+            capsules::console::DRIVER_NUM => f(Some(self.console)),
+            capsules::led::DRIVER_NUM => f(Some(self.led)),
+            capsules::button::DRIVER_NUM => f(Some(self.button)),
+            capsules::adc::DRIVER_NUM => f(Some(self.adc)),
+            capsules::alarm::DRIVER_NUM => f(Some(self.alarm)),
+            kernel::ipc::DRIVER_NUM => f(Some(&self.ipc)),
+            capsules::gpio::DRIVER_NUM => f(Some(self.gpio)),
             _ => f(None),
         }
     }

--- a/kernel/src/driver.rs
+++ b/kernel/src/driver.rs
@@ -71,7 +71,6 @@
 
 use crate::callback::{AppId, Callback};
 use crate::errorcode::ErrorCode;
-use crate::mem::legacy::{AppSlice, SharedReadWrite};
 use crate::mem::{ReadOnlyAppSlice, ReadWriteAppSlice};
 use crate::process;
 use crate::returncode::ReturnCode;
@@ -200,78 +199,5 @@ pub trait Driver {
         slice: ReadOnlyAppSlice,
     ) -> Result<ReadOnlyAppSlice, (ReadOnlyAppSlice, ErrorCode)> {
         Err((slice, ErrorCode::NOSUPPORT))
-    }
-}
-
-/// Tock 1.x "legacy" system call interface
-///
-/// This is included for compatibility with capsules not ported to the
-/// new system call interface. It will be removed prior to a Tock 2.0
-/// release.
-// TODO: Remove prior to Tock 2.0
-pub trait LegacyDriver {
-    /// `subscribe` lets an application pass a callback to the driver to be
-    /// called later. This returns `ENOSUPPORT` if not used.
-    ///
-    /// Calls to subscribe should do minimal synchronous work.  Instead, they
-    /// should defer most work and returns results to the application via the
-    /// callback. For example, a subscribe call might setup a DMA transfer to
-    /// read from a sensor, and asynchronously respond to the application by
-    /// passing the result to the application via the callback.
-    ///
-    /// Drivers should allow each application to register a single callback for
-    /// each minor number subscription. Thus, a second call to subscribe from
-    /// the same application would replace a previous callback.
-    ///
-    /// This pushes most per-application virtualization to the application
-    /// itself. For example, a timer driver exposes only one timer to each
-    /// application, and the application is responsible for virtualizing that
-    /// timer if it needs to.
-    ///
-    /// The driver should signal success or failure through the sign of the
-    /// return value from `subscribe`. A negative return value signifies an
-    /// error, while positive a return values signifies success. In addition,
-    /// the magnitude of the return value of can signify extra information such
-    /// as error type.
-    #[allow(unused_variables)]
-    fn subscribe(&self, minor_num: usize, callback: Option<Callback>, app_id: AppId) -> ReturnCode {
-        ReturnCode::ENOSUPPORT
-    }
-
-    /// `command` instructs a driver to perform some action synchronously. This
-    /// returns `ENOSUPPORT` if not used.
-    ///
-    /// The return value should reflect the result of an action. For example,
-    /// enabling/disabling a peripheral should return a success or error code.
-    /// Reading the current system time should return the time as an integer.
-    ///
-    /// Commands should not execute long running tasks synchronously. However,
-    /// commands might "kick-off" asynchronous tasks in coordination with a
-    /// `subscribe` call.
-    ///
-    /// All drivers must support the command with `minor_num` 0, and return 0
-    /// or greater if the driver is supported. This command should not have any
-    /// side effects. This convention ensures that applications can query the
-    /// kernel for supported drivers on a given platform.
-    #[allow(unused_variables)]
-    fn command(&self, minor_num: usize, r2: usize, r3: usize, caller_id: AppId) -> ReturnCode {
-        ReturnCode::ENOSUPPORT
-    }
-
-    /// `allow_readwrite` lets an application give the driver
-    /// read-write access to a buffer in the application's
-    /// memory. This returns `ENOSUPPORT` if not used.
-    ///
-    /// The buffer is __shared__ between the application and driver, meaning the
-    /// driver should not rely on the contents of the buffer to remain
-    /// unchanged.
-    #[allow(unused_variables)]
-    fn allow_readwrite(
-        &self,
-        app: AppId,
-        minor_num: usize,
-        slice: Option<AppSlice<SharedReadWrite, u8>>,
-    ) -> ReturnCode {
-        ReturnCode::ENOSUPPORT
     }
 }

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -111,7 +111,7 @@ mod returncode;
 mod sched;
 
 pub use crate::callback::{AppId, Callback};
-pub use crate::driver::{CommandResult, Driver, LegacyDriver};
+pub use crate::driver::{CommandResult, Driver};
 pub use crate::errorcode::ErrorCode;
 pub use crate::grant::{DynamicGrant, Grant};
 pub use crate::mem::legacy::{AppSlice, SharedReadWrite};

--- a/kernel/src/platform/mod.rs
+++ b/kernel/src/platform/mod.rs
@@ -1,6 +1,6 @@
 //! Interface for chips and boards.
 
-use crate::driver::{Driver, LegacyDriver};
+use crate::driver::Driver;
 use crate::errorcode;
 use crate::process;
 use crate::syscall;
@@ -45,7 +45,7 @@ pub trait Platform {
     /// the Driver methods for that syscall.
     fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
     where
-        F: FnOnce(Option<Result<&dyn Driver, &dyn LegacyDriver>>) -> R;
+        F: FnOnce(Option<&dyn Driver>) -> R;
 
     /// Check the platform-provided system call filter for all non-yield system
     /// calls. If the system call is allowed for the provided process then

--- a/kernel/src/syscall.rs
+++ b/kernel/src/syscall.rs
@@ -6,7 +6,6 @@ use core::fmt::Write;
 use crate::driver::CommandResult;
 use crate::errorcode::ErrorCode;
 use crate::process;
-use crate::returncode::ReturnCode;
 
 /// Helper function to split a u64 into a higher and lower u32
 ///
@@ -282,8 +281,6 @@ pub enum GenericSyscallReturnValue {
     SubscribeSuccess(*const u8, usize),
     /// Subscribe failure case
     SubscribeFailure(ErrorCode, *const u8, usize),
-
-    Legacy(ReturnCode),
 }
 
 impl GenericSyscallReturnValue {
@@ -383,9 +380,6 @@ impl GenericSyscallReturnValue {
                 *a1 = usize::from(err) as u32;
                 *a2 = ptr as u32;
                 *a3 = data as u32;
-            }
-            &GenericSyscallReturnValue::Legacy(rcode) => {
-                *a0 = usize::from(rcode) as u32;
             }
         }
     }


### PR DESCRIPTION
### Pull Request Overview

Now that capsules have switched, this removes LegacyDriver.


### Testing Strategy

travis


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
