### PR TITLE
Tock 2.0: implement Callback swapping restrictions

### DIFF
--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -106,6 +106,28 @@ impl Platform for Hail {
             _ => f(None),
         }
     }
+
+    fn iter_drivers<F>(&self, f: F)
+    where
+        F: Fn(usize, &dyn kernel::Driver),
+    {
+        f(capsules::console::DRIVER_NUM, self.console);
+        f(capsules::gpio::DRIVER_NUM, self.gpio);
+        f(capsules::alarm::DRIVER_NUM, self.alarm);
+        f(capsules::spi_controller::DRIVER_NUM, self.spi);
+        // TODO: nrf51822_serialization
+        f(capsules::ambient_light::DRIVER_NUM, self.ambient_light);
+        f(capsules::adc::DRIVER_NUM, self.adc);
+        f(capsules::led::DRIVER_NUM, self.led);
+        f(capsules::button::DRIVER_NUM, self.button);
+        f(capsules::humidity::DRIVER_NUM, self.humidity);
+        f(capsules::temperature::DRIVER_NUM, self.temp);
+        f(capsules::ninedof::DRIVER_NUM, self.ninedof);
+        f(capsules::rng::DRIVER_NUM, self.rng);
+        f(capsules::crc::DRIVER_NUM, self.crc);
+        f(capsules::dac::DRIVER_NUM, self.dac);
+        // TODO: ipc
+    }
 }
 
 /// Helper function called during bring-up that configures multiplexed I/O.

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -489,6 +489,7 @@ pub unsafe fn reset_handler() {
     kernel::procs::load_processes(
         board_kernel,
         chip,
+        &hail,
         core::slice::from_raw_parts(
             &_sapps as *const u8,
             &_eapps as *const u8 as usize - &_sapps as *const u8 as usize,

--- a/boards/litex/sim/src/main.rs
+++ b/boards/litex/sim/src/main.rs
@@ -142,6 +142,14 @@ impl Platform for LiteXSim {
             _ => f(None),
         }
     }
+
+    fn iter_drivers<F>(&self, f: F)
+    where
+        F: Fn(usize, &dyn kernel::Driver),
+    {
+        f(capsules::console::DRIVER_NUM, self.console);
+        f(capsules::alarm::DRIVER_NUM, self.alarm);
+    }
 }
 
 /// Reset Handler.

--- a/boards/litex/sim/src/main.rs
+++ b/boards/litex/sim/src/main.rs
@@ -404,6 +404,7 @@ pub unsafe fn reset_handler() {
     kernel::procs::load_processes(
         board_kernel,
         chip,
+        &litex_sim,
         core::slice::from_raw_parts(
             &_sapps as *const u8,
             &_eapps as *const u8 as usize - &_sapps as *const u8 as usize,

--- a/capsules/src/adc.rs
+++ b/capsules/src/adc.rs
@@ -1187,9 +1187,8 @@ impl<A: hil::adc::Adc + hil::adc::AdcHighSpeed> Driver for AdcDedicated<'_, A> {
             // subscribe to ADC sample done (from all types of sampling)
             0 => {
                 // set callback
-                self.appid.map_or(Err((callback, ErrorCode::FAIL)), |id| {
-                    let res = self
-                        .apps
+                let res = self.appid.map_or(Err(ErrorCode::FAIL), |id| {
+                    self.apps
                         .enter(*id, |app, _| {
                             mem::swap(&mut app.callback, &mut callback);
                         })
@@ -1200,13 +1199,14 @@ impl<A: hil::adc::Adc + hil::adc::AdcHighSpeed> Driver for AdcDedicated<'_, A> {
                                 self.appid.clear();
                             }
                             ErrorCode::from(err)
-                        });
-                    if let Err(err) = res {
-                        Err((callback, err))
-                    } else {
-                        Ok(callback)
-                    }
-                })
+                        })
+                });
+
+                if let Err(err) = res {
+                    Err((callback, err))
+                } else {
+                    Ok(callback)
+                }
             }
 
             // default

--- a/capsules/src/alarm.rs
+++ b/capsules/src/alarm.rs
@@ -16,7 +16,6 @@ enum Expiration {
     Enabled { reference: u32, dt: u32 },
 }
 
-#[derive(Copy, Clone)]
 pub struct AlarmData {
     expiration: Expiration,
     callback: Callback,

--- a/capsules/src/analog_comparator.rs
+++ b/capsules/src/analog_comparator.rs
@@ -37,7 +37,7 @@
 use crate::driver;
 pub const DRIVER_NUM: usize = driver::NUM::AnalogComparator as usize;
 
-use core::cell::Cell;
+use core::cell::RefCell;
 use kernel::hil;
 use kernel::{AppId, Callback, CommandResult, Driver, ErrorCode, ReturnCode};
 
@@ -47,7 +47,7 @@ pub struct AnalogComparator<'a, A: hil::analog_comparator::AnalogComparator<'a> 
     channels: &'a [&'a <A as hil::analog_comparator::AnalogComparator<'a>>::Channel],
 
     // App state
-    callback: Cell<Callback>,
+    callback: RefCell<Callback>,
 }
 
 impl<'a, A: hil::analog_comparator::AnalogComparator<'a>> AnalogComparator<'a, A> {
@@ -61,7 +61,7 @@ impl<'a, A: hil::analog_comparator::AnalogComparator<'a>> AnalogComparator<'a, A
             channels,
 
             // App state
-            callback: Cell::new(Callback::default()),
+            callback: RefCell::new(Callback::default()),
         }
     }
 
@@ -155,6 +155,6 @@ impl<'a, A: hil::analog_comparator::AnalogComparator<'a>> hil::analog_comparator
 {
     /// Callback to userland, signaling the application
     fn fired(&self, channel: usize) {
-        self.callback.get().schedule(channel, 0, 0);
+        self.callback.borrow_mut().schedule(channel, 0, 0);
     }
 }

--- a/capsules/src/gpio_async.rs
+++ b/capsules/src/gpio_async.rs
@@ -25,7 +25,7 @@
 //! }
 //! ```
 
-use core::cell::Cell;
+use core::cell::RefCell;
 use kernel::hil;
 use kernel::{AppId, Callback, ErrorCode};
 use kernel::{CommandResult, Driver, ReturnCode};
@@ -36,16 +36,16 @@ pub const DRIVER_NUM: usize = driver::NUM::GpioAsync as usize;
 
 pub struct GPIOAsync<'a, Port: hil::gpio_async::Port> {
     ports: &'a [&'a Port],
-    callback: Cell<Callback>,
-    interrupt_callback: Cell<Callback>,
+    callback: RefCell<Callback>,
+    interrupt_callback: RefCell<Callback>,
 }
 
 impl<'a, Port: hil::gpio_async::Port> GPIOAsync<'a, Port> {
     pub fn new(ports: &'a [&'a Port]) -> GPIOAsync<'a, Port> {
         GPIOAsync {
             ports,
-            callback: Cell::new(Callback::default()),
-            interrupt_callback: Cell::new(Callback::default()),
+            callback: RefCell::new(Callback::default()),
+            interrupt_callback: RefCell::new(Callback::default()),
         }
     }
 
@@ -74,11 +74,13 @@ impl<'a, Port: hil::gpio_async::Port> GPIOAsync<'a, Port> {
 
 impl<Port: hil::gpio_async::Port> hil::gpio_async::Client for GPIOAsync<'_, Port> {
     fn fired(&self, pin: usize, identifier: usize) {
-        self.interrupt_callback.get().schedule(identifier, pin, 0);
+        self.interrupt_callback
+            .borrow_mut()
+            .schedule(identifier, pin, 0);
     }
 
     fn done(&self, value: usize) {
-        self.callback.get().schedule(0, value, 0);
+        self.callback.borrow_mut().schedule(0, value, 0);
     }
 }
 

--- a/capsules/src/l3gd20.rs
+++ b/capsules/src/l3gd20.rs
@@ -102,7 +102,7 @@
 //! Author: Alexandru Radovici <msg4alex@gmail.com>
 //!
 
-use core::cell::Cell;
+use core::cell::{Cell, RefCell};
 use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::hil::sensors;
 use kernel::hil::spi;
@@ -184,7 +184,7 @@ pub struct L3gd20Spi<'a> {
     hpf_mode: Cell<u8>,
     hpf_divider: Cell<u8>,
     scale: Cell<u8>,
-    callback: Cell<Callback>,
+    callback: RefCell<Callback>,
     nine_dof_client: OptionalCell<&'a dyn sensors::NineDofClient>,
     temperature_client: OptionalCell<&'a dyn sensors::TemperatureClient>,
 }
@@ -205,7 +205,7 @@ impl<'a> L3gd20Spi<'a> {
             hpf_mode: Cell::new(0),
             hpf_divider: Cell::new(0),
             scale: Cell::new(0),
-            callback: Cell::new(Callback::default()),
+            callback: RefCell::new(Callback::default()),
             nine_dof_client: OptionalCell::empty(),
             temperature_client: OptionalCell::empty(),
         }
@@ -411,7 +411,7 @@ impl spi::SpiMasterClient for L3gd20Spi<'_> {
                     false
                 };
                 self.callback
-                    .get()
+                    .borrow_mut()
                     .schedule(1, if present { 1 } else { 0 }, 0);
                 L3gd20Status::Idle
             }
@@ -456,9 +456,9 @@ impl spi::SpiMasterClient for L3gd20Spi<'_> {
                     false
                 };
                 if values {
-                    self.callback.get().schedule(x, y, z);
+                    self.callback.borrow_mut().schedule(x, y, z);
                 } else {
-                    self.callback.get().schedule(0, 0, 0);
+                    self.callback.borrow_mut().schedule(0, 0, 0);
                 }
                 L3gd20Status::Idle
             }
@@ -482,15 +482,15 @@ impl spi::SpiMasterClient for L3gd20Spi<'_> {
                     false
                 };
                 if value {
-                    self.callback.get().schedule(temperature, 0, 0);
+                    self.callback.borrow_mut().schedule(temperature, 0, 0);
                 } else {
-                    self.callback.get().schedule(0, 0, 0);
+                    self.callback.borrow_mut().schedule(0, 0, 0);
                 }
                 L3gd20Status::Idle
             }
 
             _ => {
-                self.callback.get().schedule(0, 0, 0);
+                self.callback.borrow_mut().schedule(0, 0, 0);
                 L3gd20Status::Idle
             }
         });

--- a/kernel/src/callback.rs
+++ b/kernel/src/callback.rs
@@ -172,7 +172,7 @@ struct ProcessCallback {
     app_id: AppId,
     callback_id: CallbackId,
     appdata: usize,
-    fn_ptr: NonNull<*mut ()>,
+    fn_ptr: NonNull<()>,
 }
 
 #[derive(Clone, Copy, Default)]
@@ -185,7 +185,7 @@ impl Callback {
         app_id: AppId,
         callback_id: CallbackId,
         appdata: usize,
-        fn_ptr: NonNull<*mut ()>,
+        fn_ptr: NonNull<()>,
     ) -> Callback {
         Callback {
             cb: Some(ProcessCallback::new(app_id, callback_id, appdata, fn_ptr)),
@@ -223,7 +223,7 @@ impl ProcessCallback {
         app_id: AppId,
         callback_id: CallbackId,
         appdata: usize,
-        fn_ptr: NonNull<*mut ()>,
+        fn_ptr: NonNull<()>,
     ) -> ProcessCallback {
         ProcessCallback {
             app_id,

--- a/kernel/src/callback.rs
+++ b/kernel/src/callback.rs
@@ -354,6 +354,19 @@ impl ProcessCallback {
                 } else {
                     // This is a null callback, behave as if the
                     // callback was scheduled
+                    if config::CONFIG.trace_syscalls {
+                        debug!(
+                            "[{:?}] schedule[{:#x}:{}] @NULL({:#x}, {:#x}, {:#x}, {:#x}) (null-callback not scheduled!)",
+                            self.app_id,
+                            self.callback_id.driver_num,
+                            self.callback_id.subscribe_num,
+                            r0,
+                            r1,
+                            r2,
+                            self.appdata,
+                        );
+                    }
+
                     true
                 }
             })

--- a/kernel/src/driver.rs
+++ b/kernel/src/driver.rs
@@ -171,6 +171,10 @@ impl From<process::Error> for CommandResult {
 
 #[allow(unused_variables)]
 pub trait Driver {
+    fn process_init(&self, process: AppId, callback_factory: &mut crate::ProcessCallbackFactory) {
+        // Empty default implementation
+    }
+
     fn subscribe(
         &self,
         which: usize,

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -110,7 +110,7 @@ mod process;
 mod returncode;
 mod sched;
 
-pub use crate::callback::{AppId, Callback};
+pub use crate::callback::{AppId, Callback, ProcessCallbackFactory};
 pub use crate::driver::{CommandResult, Driver, LegacyDriver};
 pub use crate::errorcode::ErrorCode;
 pub use crate::grant::{DynamicGrant, Grant};

--- a/kernel/src/platform/mod.rs
+++ b/kernel/src/platform/mod.rs
@@ -47,6 +47,15 @@ pub trait Platform {
     where
         F: FnOnce(Option<Result<&dyn Driver, &dyn LegacyDriver>>) -> R;
 
+    /// Invoke the passed closure for every object that implements the
+    /// Driver method on this platform.
+    ///
+    /// This is used to signal all installed drivers generic events,
+    /// such as a process initialization or cleanup.
+    fn iter_drivers<F>(&self, _f: F)
+    where
+        F: Fn(usize, &dyn Driver);
+
     /// Check the platform-provided system call filter for all non-yield system
     /// calls. If the system call is allowed for the provided process then
     /// return `Ok(())`. Otherwise, return `Err()` with an `ErrorCode` that will

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -8,7 +8,7 @@ use core::fmt::Write;
 use core::ptr::{write_volatile, NonNull};
 use core::{mem, ptr, slice, str};
 
-use crate::callback::{AppId, CallbackId};
+use crate::callback::{AppId, Callback, CallbackId};
 use crate::capabilities::ProcessManagementCapability;
 use crate::common::cells::{MapCell, NumericCellExt};
 use crate::common::{Queue, RingBuffer};
@@ -409,6 +409,49 @@ pub trait ProcessType {
         buf_start_addr: *const u8,
         size: usize,
     ) -> Result<Option<AppSlice<SharedReadWrite, u8>>, ReturnCode>;
+
+    /// Process a `Subscribe` request for a given process.
+    ///
+    /// This function is called as a result of a `Subscribe`-type
+    /// system call, if a corresponding driver is found.
+    ///
+    /// If the process is not active then this will return an error,
+    /// as it is not valid to "subscribe" a callback for a process
+    /// that will not resume executing. In practice this case should
+    /// not happen as the process will not be executing to call the
+    /// `Subscribe`-type syscall.
+    ///
+    /// This function must construct the high-level [`Callback`] type
+    /// and enforce constraints required by this type. It must clear
+    /// all callbacks on a previous instance, such that only callbacks
+    /// scheduled on the newly constructed type will be called to
+    /// userspace.
+    ///
+    /// It can invoke the driver by executing the passed closure. As a
+    /// result the driver can either
+    ///
+    /// - accept the Subscribe operation (`Ok()` variant):
+    ///
+    ///   In this case, the driver must pass the previous [`Callback`]
+    ///   instance from this driver num and subscribe num back.
+    ///
+    /// - refuse the Subscribe operation (`Err()` variant):
+    ///
+    ///   In this case, the driver must pass the [`Callback`] argument
+    ///   back as its return value, along with an [`ErrorCode`] passed
+    ///   back to the process.
+    ///
+    /// It is this function's responsibility to enforce these
+    /// constraints and check that a driver always returns the correct
+    /// results across system calls.
+    fn subscribe(
+        &self,
+        driver_num: u32,
+        subscribe_num: u32,
+        callback_ptr: *mut (),
+        appdata: usize,
+        driver_invoc_closure: &dyn Fn(Callback) -> Result<Callback, (Callback, ErrorCode)>,
+    ) -> GenericSyscallReturnValue;
 
     fn allow_readwrite(
         &self,
@@ -1306,6 +1349,125 @@ impl<C: Chip> ProcessType for Process<'_, C> {
                     Ok(Some(slice))
                 } else {
                     Err(ReturnCode::EINVAL)
+                }
+            }
+        }
+    }
+
+    fn subscribe(
+        &self,
+        driver_num: u32,
+        subscribe_num: u32,
+        callback_ptr: *mut (),
+        appdata: usize,
+        driver_invoc_closure: &dyn Fn(Callback) -> Result<Callback, (Callback, ErrorCode)>,
+    ) -> GenericSyscallReturnValue {
+        if !self.is_active() {
+            // Do not operate on an inactive process
+            return GenericSyscallReturnValue::SubscribeFailure(
+                ErrorCode::FAIL,
+                callback_ptr,
+                appdata,
+            );
+        }
+
+        // Construct the callback pointer
+        //
+        // The pointer may be NULL, in which case this is a _null
+        // callback_.
+        //
+        // The pointer is not verified to be in bounds of process
+        // accessible memory. If a process passes an invalid pointer
+        // (outside of its memory regions), the MPU must catch this
+        // memory access and fault the process accordingly.
+        let fn_ptr: Option<NonNull<()>> = NonNull::new(callback_ptr);
+
+        // A callback is identified by a tuple of the driver number
+        // and the subscribe number
+        let callback_id = CallbackId {
+            driver_num,
+            subscribe_num,
+        };
+
+        // Only one callback should exist per tuple, to ensure that
+        // there are no pending callbacks with the same identifier but
+        // an old function pointer, clear them now.
+        //
+        // This operates only on the current process, so the passed
+        // pointer does not need to be trusted.
+        self.remove_pending_callbacks(callback_id);
+
+        // Construct the callback struct
+        let callback = Callback::new(self.appid(), callback_id, appdata, fn_ptr);
+
+        // Invoke the capsule
+        let driver_res = driver_invoc_closure(callback);
+
+        match driver_res {
+            Err((returned_callback, err)) => {
+                // The capsule has refused the subscribe operation,
+                // verify that it passed back the new callback
+                if let Some(process_callback) = returned_callback.into_inner() {
+                    if process_callback.app_id != self.appid()
+                        || process_callback.callback_id != callback_id
+                        || process_callback.appdata != appdata
+                        || process_callback.fn_ptr != fn_ptr
+                    {
+                        // The capsule did not return the Callback passed in
+                        // TODO: How to handle this?
+                        panic!(
+                            "Driver {}, subscribe num {}: Callback swapped in error case",
+                            driver_num, subscribe_num
+                        );
+                    } else {
+                        // Capsule returned the correct Callback
+                        GenericSyscallReturnValue::SubscribeFailure(err, callback_ptr, appdata)
+                    }
+                } else {
+                    // The capsule returned a default Callback
+                    // instance in the error-case return value, where
+                    // it should have passed the argument back
+                    panic!(
+                        "Driver {}, subcribe_num {}: Default callback returned in error case",
+                        driver_num, subscribe_num
+                    );
+                }
+            }
+            Ok(returned_callback) => {
+                // The capsule indicated that the subscribe operation succeeded
+                match returned_callback.into_inner() {
+                    None => {
+                        // The capsule returned a default callback, we
+                        // have to believe this to be correct
+                        //
+                        // TODO: Limit the default constructor on
+                        // Callback to require a capability for Grant
+                        // initializations
+                        GenericSyscallReturnValue::SubscribeSuccess(0x0 as *mut (), 0)
+                    }
+                    Some(process_callback) => {
+                        // The capsule returned some other callback,
+                        // ensure that it belongs to the same process,
+                        // driver and subdriver number
+                        if process_callback.app_id != self.appid()
+                            || process_callback.callback_id != callback_id
+                        {
+                            // The capsule returned some other Callback
+                            panic!(
+                                "Driver {}, subscribe num {}: unknown Callback returned",
+                                driver_num, subscribe_num
+                            );
+                        } else {
+                            // The capsule returned a matching
+                            // Callback, return it to userspace
+                            GenericSyscallReturnValue::SubscribeSuccess(
+                                process_callback
+                                    .fn_ptr
+                                    .map_or(0x0 as *mut (), |nonnull| nonnull.as_ptr()),
+                                process_callback.appdata,
+                            )
+                        }
+                    }
                 }
             }
         }

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -1457,12 +1457,17 @@ impl<C: Chip> ProcessType for Process<'_, C> {
                 // The capsule indicated that the subscribe operation succeeded
                 match returned_callback.into_inner() {
                     None => {
-                        // The capsule returned a default callback, we
-                        // have to believe this to be correct
-                        //
-                        // TODO: Limit the default constructor on
-                        // Callback to require a capability for Grant
-                        // initializations
+                        // The capsule returned a default
+                        // callback. This is incorrect, it should've
+                        // returned a process bound callback (either a
+                        // previously subscribed one, or one retrieved
+                        // using the ProcessCallbackFactory)
+
+                        // TODO: How to handle this?
+                        debug!("Driver {}, subscribe_num {}: Default callback returned, this will become an error!",
+                               driver_num,
+                               subscribe_num,
+                        );
                         GenericSyscallReturnValue::SubscribeSuccess(0x0 as *mut (), 0)
                     }
                     Some(process_callback) => {
@@ -1480,6 +1485,11 @@ impl<C: Chip> ProcessType for Process<'_, C> {
                         } else {
                             // The capsule returned a matching
                             // Callback, return it to userspace
+
+                            // TODO: We still don't know whether the
+                            // capsule has simply returned the passed
+                            // in callback again, only using Ok(_)
+                            // instead of Err(_).
                             GenericSyscallReturnValue::SubscribeSuccess(
                                 process_callback
                                     .fn_ptr

--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -835,7 +835,7 @@ impl Kernel {
 
                 let ptr = NonNull::new(callback_ptr);
                 let callback = ptr.map_or(Callback::default(), |ptr| {
-                    Callback::new(process.appid(), callback_id, appdata, ptr.cast())
+                    Callback::new(process.appid(), callback_id, appdata, ptr)
                 });
                 let rval = platform.with_driver(driver_number, |driver| match driver {
                     Some(Ok(d)) => {

--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -834,9 +834,8 @@ impl Kernel {
                 process.remove_pending_callbacks(callback_id);
 
                 let ptr = NonNull::new(callback_ptr);
-                let callback = ptr.map_or(Callback::default(), |ptr| {
-                    Callback::new(process.appid(), callback_id, appdata, ptr)
-                });
+                let callback = Callback::new(process.appid(), callback_id, appdata, ptr);
+
                 let rval = platform.with_driver(driver_number, |driver| match driver {
                     Some(Ok(d)) => {
                         let res = d.subscribe(subdriver_number, callback, process.appid());

--- a/kernel/src/syscall.rs
+++ b/kernel/src/syscall.rs
@@ -279,9 +279,9 @@ pub enum GenericSyscallReturnValue {
     AllowReadOnlyFailure(ErrorCode, *const u8, usize),
 
     /// Subscribe success case
-    SubscribeSuccess(*const u8, usize),
+    SubscribeSuccess(*mut (), usize),
     /// Subscribe failure case
-    SubscribeFailure(ErrorCode, *const u8, usize),
+    SubscribeFailure(ErrorCode, *mut (), usize),
 
     Legacy(ReturnCode),
 }


### PR DESCRIPTION
### Pull Request Overview

This pull request is a follow-up to #2282, which was especially criticized for being only a part of the changes required to uphold all safety requirements we'd like to have with regards to Callback swapping restrictions. It's one implementation strategy out of many.

#### Issue

Essentially, the protections introduced in this PR are required because in the Tock 2.0 system call architecture, with every call to `subscribe`, the previous `Callback` provided by the application must be returned. If we were to not enforce any constraints here, this would have serious side effects:

- a `Callback` subscribed by process A could be handed back to process B.

  This leaks both the callback pointer and the `appdata` field of the `Callback` to another application.

- a `Callback` from one capsule could be given to another capsule and returned as part of a call to subscribe there.
- a `Callback`, passed to a driver under subscribe (subdriver) number `x` could be returned as part of a call to `subscribe` to the same driver under subscribe (subdriver) number `y`, where `x != y`.
- a capsule could pass back a _null callback_ (with callback pointer and appdata being 0), where a process has actually subscribed a `Callback` with non-null values before.

  All of these cases could cause inconsistencies and undefined behavior in userspace, if a process were to rely on the fact that the returned `Callback` is the one previously passed to the capsule.

  It was indicated that userspace libraries might want to rely on this behaviour for stack-allocated callbacks (especially in libtock-rs).

#### Guarantees made by this PR 

As a whole, this PR enables the kernel to check for these various cases

- a capsule cannot return a `Callback` originally passed to a different capsule in a `subscribe` invocation
- a capsule cannot return, as a result of a `subscribe` invocation, a callback which was provided by a different process
- a capsule cannot return, as a result of a `subscribe` invocation, a callback which was provided by the same process under a different subscribe / subdriver number
- a capsule cannot return a _null callback_ (e.g. a default Callback instance) where a process had subscribe a non-null `Callback` before

#### Why do we need a _default_ AND a _null_ callback?

As callbacks are commonly stored in Grant regions which must implement the `Default` trait, there must be some instance of a `Callback` which is also instantiable either through the `Default` trait, or without involving other components such as the core kernel. It is impractical to change Grant regions to have an alternative `Default`-like trait implementation for constructing them with a context.

However, if a capsule can construct an arbitrary number of `Callback` instances, this poses a problem: how can we know whether a `Callback` returned as a result of a `subscribe` invocation is an arbitrary default instance, or one which has been set by the process explicitly and how can we know whether this is the first `subscribe` invocation for this `(driver, subdriver, process)` combination, where it is legal to return a default callback instance?

This PR proposes a particular solution to this issue: by distinguishing between _default_ and _null_ callbacks (where _null_ callbacks are always bound to a specific process), and replacing all _default_ callbacks with process-bound callbacks upon process initialization, we can be sure that if a capsule returns a _null_ callback, it must belong to a specific process and couldn't have been created arbitrarily. Furthermore, `Callback`s do not implement `Clone` any longer, such that for each `(driver, subdriver, process)` combination only a single `Callback` instance can exist in the kernel, except for the time where a subscribe operation is being processed by the kernel.

Semantically, `struct Callback(Option<ProcessCallback>)`, where `Callback(None)` is a default callback and `Callback(ProcessCallback { appid: some_app, appdata: 0, fn_ptr: 0x0 })` is a process-bound null callback, is equivalent to just using `Option<ProcessCallback>` in the capsules directly. In my opinion that's also a bit cleaner, as it expresses the need to create a process-bound callback through the type system itself. However, I didn't want to do extensive changes to every capsule in this PR. it's already sufficiently long.

#### Implications

- This PR removes `Copy, Clone` trait implementations from `Callbacks`. I don't see any solution which wouldn't heavily modify larger parts of the OS to get around this. Most approaches I've come up with use the fact that through ownership and move semantics, we can control & limit the lifetime of `Callback`s effectively and at compile time.

- This PR adds another method to the `Driver` trait, which is called upon process initialization. This gives capsules a chance to replace all of their `Callback`s with process-bound _null_ `Callback`s by use of a `ProcessCallbackFactory` which guarantees that for each `(driver, subdriver, process)` combination only a single null `Callback` can be initialized.

  This can even be extended through an `AppSliceFactory` later, which would also register how many `AppSlice`s a specific capsule for a given process holds, such that the required AppSlice table in the kernel can be sized sufficiently.

  However, it introduces another hook where capsules are called and handed control in the system.

- This PR adds another method to the `Platform` trait, which can be used to invoke a closure on all installed drivers on the system. This is used to message global events to all capsules, such as process initialization.

  One could think about using this infrastructure to also communicate process exits / dies. This can, for instance, be used to turn off wireless radios when no process uses the hardware any more.

- This implementation strategy, in contrast to some others, does not require any central registry or other data structures. By tightly controlling the instances of the `Callback` type at compile time, we can uphold the desired guarantees without using additional data fields.

### Testing Strategy

This pull request was tested by trying to swap callbacks on a Hail board. It need more testing.

### TODO or Help Wanted

This pull request has the required changes to capsules and platforms implemented for only a small subset capsules and platforms respectively. I'd like to get feedback on this first prior to putting in even more work.

Currently, this PR only prints debug messages when a capsule misbehaves. This is done for compatibility and easier testing. Different handling strategies could be implemented later, such as "blocking" the capsule from further operation or panicing the system.

### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
