### PR TITLE
Better method parsing for accounting for code size.

### DIFF
--- a/tools/github_actions_size_changes.sh
+++ b/tools/github_actions_size_changes.sh
@@ -16,7 +16,7 @@ make allboards > /dev/null 2>&1
 for elf in $(find . -maxdepth 8 | grep 'release' | egrep '\.elf$' | grep -v 'riscv'); do
     tmp=${elf#*release/}
     b=${tmp%.elf}
-    ./tools/print_tock_memory_usage.py -s ${elf} > current-benchmark-${b}
+    ./tools/print_tock_memory_usage.py -w ${elf} > current-benchmark-${b}
 done
 
 git remote set-branches "$UPSTREAM_REMOTE_NAME" "$GITHUB_BASE_REF"  > /dev/null 2>&1
@@ -29,7 +29,7 @@ make allboards > /dev/null 2>&1
 for elf in $(find . -maxdepth 8 | grep 'release' | egrep '\.elf$' | grep -v 'riscv'); do
     tmp=${elf#*release/}
     b=${tmp%.elf}
-    ./tools/print_tock_memory_usage.py -s ${elf} > previous-benchmark-${b}
+    ./tools/print_tock_memory_usage.py -w ${elf} > previous-benchmark-${b}
 done
 
 DIFF_DETECTED=0


### PR DESCRIPTION
### Pull Request Overview

This pull request improves the `print_tock_memory_usage` tool. It parses method names inside traits, so you can now account for individual methods. It also allows you to order symbol groups by size.

It changes the `-s` option to be sort by size; the previous `-s`, show waste, is now `-w`.


### Testing Strategy

This pull request was tested by running it on an imix ELF file.


### TODO or Help Wanted

This pull request still needs some use, make sure it's not missing some cases that imix doesn't trigger.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
