### PR TITLE
cfg: add `target_arch_specific`

### DIFF
--- a/arch/cortex-m/src/lib.rs
+++ b/arch/cortex-m/src/lib.rs
@@ -214,7 +214,11 @@ pub unsafe extern "C" fn unhandled_interrupt() {
 /// Assembly function called from `UserspaceKernelBoundary` to switch to an
 /// an application. This handles storing and restoring application state before
 /// and after the switch.
-#[cfg(all(target_arch = "arm", target_os = "none"))]
+#[cfg(all(
+    target_arch = "arm",
+    target_arch_specific = "thumbv7em",
+    target_os = "none"
+))]
 #[no_mangle]
 pub unsafe extern "C" fn switch_to_user_arm_v7m(
     mut user_stack: *const usize,
@@ -254,7 +258,11 @@ pub unsafe extern "C" fn switch_to_user_arm_v7m(
     user_stack
 }
 
-#[cfg(all(target_arch = "arm", target_os = "none"))]
+#[cfg(all(
+    target_arch = "arm",
+    target_arch_specific = "thumbv7em",
+    target_os = "none"
+))]
 #[inline(never)]
 unsafe fn kernel_hardfault_arm_v7m(faulting_stack: *mut u32) -> ! {
     let stacked_r0: u32 = *faulting_stack.offset(0);
@@ -397,7 +405,11 @@ unsafe fn kernel_hardfault_arm_v7m(faulting_stack: *mut u32) -> ! {
     );
 }
 
-#[cfg(all(target_arch = "arm", target_os = "none"))]
+#[cfg(all(
+    target_arch = "arm",
+    target_arch_specific = "thumbv7em",
+    target_os = "none"
+))]
 /// Continue the hardfault handler. This function is not `#[naked]`, meaning we can mix
 /// `asm!()` and Rust. We separate this logic to not have to write the entire fault
 /// handler entirely in assembly.
@@ -454,7 +466,11 @@ unsafe extern "C" fn hard_fault_handler_arm_v7m_continued(
     }
 }
 
-#[cfg(all(target_arch = "arm", target_os = "none"))]
+#[cfg(all(
+    target_arch = "arm",
+    target_arch_specific = "thumbv7em",
+    target_os = "none"
+))]
 #[naked]
 pub unsafe extern "C" fn hard_fault_handler_arm_v7m() {
     // First need to determine if this a kernel fault or a userspace fault, and store

--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -49,6 +49,38 @@ ifneq ($(findstring riscv32i, $(TARGET)),)
   RUSTC_FLAGS += -C force-frame-pointers=no
 endif
 
+# TARGET_ARCH_SPECIFIC helps extend the `[cfg(all(target_arch = "arm"))]` like
+# flags available when doing conditional compilation in Tock code. In
+# particular, this was added because `target_arch` is insufficiently specific as
+# it only specifies an _architecture family_ (like "arm"), and not a specific
+# architecture (like "thumbv7em").
+#
+# We add our own cfg option called "target_arch_specific" which provides the
+# actual architecture the code is being compiled for. This allows for correct
+# and fine-grained hardware-based conditional compilation.
+#
+# Note! We want to avoid abusing this, as using `cfg`s can get confusing for
+# readers of the code. Specifically, trying to track exactly what cfgs are set
+# to what values at any specific time is very difficult for someone reading and
+# understanding the code. Therefore, we limit these to only values based
+# directly on hardware, where the only valid value is clear based on the target
+# platform. That is, these should not be used to enable/disable certain Tock
+# features, or omit particular code blocks.
+ifneq ($(findstring thumbv7em, $(TARGET)),)
+  TARGET_ARCH_SPECIFIC = thumbv7em
+else ifneq ($(findstring thumbv6m, $(TARGET)),)
+  TARGET_ARCH_SPECIFIC = thumbv6m
+else ifneq ($(findstring riscv32imac, $(TARGET)),)
+  TARGET_ARCH_SPECIFIC = rv32imac
+else ifneq ($(findstring riscv32imc, $(TARGET)),)
+  TARGET_ARCH_SPECIFIC = rv32imc
+else ifneq ($(findstring riscv32i, $(TARGET)),)
+  TARGET_ARCH_SPECIFIC = rv32i
+else
+  # If you get here, please also update `doc/Compilation.md`.
+  $(error "Must add new TARGET_ARCH_SPECIFIC for new target in Makefile.common")
+endif
+
 # RUSTC_FLAGS_TOCK by default extends RUSTC_FLAGS with options
 # that are global to all Tock boards.
 #
@@ -57,6 +89,7 @@ endif
 RUSTC_FLAGS_TOCK ?= \
   $(RUSTC_FLAGS) \
   --remap-path-prefix=$(TOCK_ROOT_DIRECTORY)= \
+  --cfg target_arch_specific=\"$(TARGET_ARCH_SPECIFIC)\" \
 
 # Disallow warnings for continuous integration builds. Disallowing them here
 # ensures that warnings during testing won't prevent compilation from succeeding.

--- a/doc/Compilation.md
+++ b/doc/Compilation.md
@@ -11,6 +11,8 @@ of how platforms program each onto an actual board.
 <!-- toc -->
 
 - [Compiling the kernel](#compiling-the-kernel)
+  * [Tock-Specific `cfg` Key-Value Pairs](#tock-specific-cfg-key-value-pairs)
+    + [`target_arch_specific`](#target_arch_specific)
   * [Life of a Tock compilation](#life-of-a-tock-compilation)
   * [LLVM Binutils](#llvm-binutils)
   * [Special `.apps` section](#special-apps-section)
@@ -66,6 +68,40 @@ The `--release` argument tells Cargo to invoke the Rust compiler with
 optimizations turned on. `--target` points Cargo to the target specification
 which includes the LLVM data-layout definition and architecture definitions for
 the compiler.
+
+### Tock-Specific `cfg` Key-Value Pairs
+
+Tock uses statements like `#[cfg(all(target_arch = "arm", target_os = "none"))]`
+in select places to conditionally compile code for specific hardware components.
+In general, Tock _only_ uses these types of flags for hardware-based
+configurations where this is little or no ambiguity about what the flag will be
+set to. Since the hardware configuration for a platform should be well known, a
+reader of the code should be able to easily understand what the `cfg` key-value
+pairs will be set to when the code is compiled. This is different from more
+general software feature gating, where specific features or code blocks are
+included or not to change the operation of the Tock kernel. Tock tries to avoid
+that type of conditional compilation.
+
+Tock tries to use the built-in Rust `cfg` features, but that is not always
+sufficient. In this section we document the tock-specific `cfg` features we use.
+
+#### `target_arch_specific`
+
+Rust provides `target_arch` based on the compilation target. However, in
+practice `target_arch` only specifies an architecture family, and not a specific
+architecture (for example "arm" vs. "thumbv7em"). Differences between
+architectures in the same family (like what assembly instructions are valid) can
+make just having the family insufficient. Therefore Tock (through the build
+system) includes a `target_arch_specific` key-value pair for every target
+platform. This is configured in `Makefile.common`.
+
+| Rust Target                    | `target_arch_specific` |
+|--------------------------------|------------------------|
+| `thumbv7em-none-eabi`          | `thumbv7em`            |
+| `thumbv6m-none-eabi`           | `thumbv6m`             |
+| `riscv32imac-unknown-none-elf` | `rv32imac`             |
+| `riscv32imc-unknown-none-elf`  | `rv32imc`              |
+| `riscv32i-unknown-none-elf`    | `rv32i`                |
 
 
 ### Life of a Tock compilation


### PR DESCRIPTION
### Pull Request Overview

Right now Rust only gives us `target_arch`, which is a family, not a specific architecture. This uses our build system to add `target_arch_specific` which allows us to cfg on an actual architecture.

Inspired by #2442.

I view `target_arch` being so vague as a failing of Rust that Rust should remedy either by adding another cfg flag (like this PR), or making `target_arch` actually point to specific architectures. I like this approach because it fills in a Rust gap that Rust may someday take care of for us.


### Testing Strategy

Compiling the cortex-m crate.


### TODO or Help Wanted

Thoughts?


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
