### PR TITLE
Transitions Callback to Upcall for 2.0. In a seprate PR for review sanity.

### DIFF
--- a/capsules/src/adc.rs
+++ b/capsules/src/adc.rs
@@ -54,7 +54,7 @@ use core::{cmp, mem};
 use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::hil;
 use kernel::{
-    AppId, Callback, CommandReturn, Driver, ErrorCode, Grant, Read, ReadWrite, ReadWriteAppSlice,
+    AppId, Upcall, CommandReturn, Driver, ErrorCode, Grant, Read, ReadWrite, ReadWriteAppSlice,
     ReturnCode,
 };
 
@@ -109,7 +109,7 @@ pub(crate) enum AdcMode {
 
 // Datas passed by the application to us
 pub struct AppSys {
-    callback: Callback,
+    callback: Upcall,
     pending_command: bool,
     command: OptionalCell<Operation>,
     channel: usize,
@@ -119,7 +119,7 @@ pub struct AppSys {
 pub struct App {
     app_buf1: ReadWriteAppSlice,
     app_buf2: ReadWriteAppSlice,
-    callback: Callback,
+    callback: Upcall,
     app_buf_offset: Cell<usize>,
     samples_remaining: Cell<usize>,
     samples_outstanding: Cell<usize>,
@@ -132,7 +132,7 @@ impl Default for App {
         App {
             app_buf1: ReadWriteAppSlice::default(),
             app_buf2: ReadWriteAppSlice::default(),
-            callback: Callback::default(),
+            callback: Upcall::default(),
             app_buf_offset: Cell::new(0),
             samples_remaining: Cell::new(0),
             samples_outstanding: Cell::new(0),
@@ -145,7 +145,7 @@ impl Default for App {
 impl Default for AppSys {
     fn default() -> AppSys {
         AppSys {
-            callback: Callback::default(),
+            callback: Upcall::default(),
             pending_command: false,
             command: OptionalCell::empty(),
             channel: 0,
@@ -439,7 +439,7 @@ impl<'a, A: hil::adc::Adc + hil::adc::AdcHighSpeed> AdcDedicated<'a, A> {
     /// Collect analog samples continuously.
     ///
     /// Fills one "allowed" application buffer at a time and then swaps to
-    /// filling the second buffer. Callbacks occur when the in use "allowed"
+    /// filling the second buffer. Upcalls occur when the in use "allowed"
     /// buffer fills.
     ///
     /// - `channel` - index into `channels` array, which channel to sample
@@ -1163,9 +1163,9 @@ impl<A: hil::adc::Adc + hil::adc::AdcHighSpeed> Driver for AdcDedicated<'_, A> {
     fn subscribe(
         &self,
         subscribe_num: usize,
-        mut callback: Callback,
+        mut callback: Upcall,
         appid: AppId,
-    ) -> Result<Callback, (Callback, ErrorCode)> {
+    ) -> Result<Upcall, (Upcall, ErrorCode)> {
         // Return true if this app already owns the ADC capsule, if no app owns
         // the ADC capsule, or if the app that is marked as owning the ADC
         // capsule no longer exists.
@@ -1338,9 +1338,9 @@ impl Driver for AdcVirtualized<'_> {
     fn subscribe(
         &self,
         subscribe_num: usize,
-        mut callback: Callback,
+        mut callback: Upcall,
         app_id: AppId,
-    ) -> Result<Callback, (Callback, ErrorCode)> {
+    ) -> Result<Upcall, (Upcall, ErrorCode)> {
         match subscribe_num {
             // subscribe to ADC sample done (from all types of sampling)
             0 => {

--- a/capsules/src/adc.rs
+++ b/capsules/src/adc.rs
@@ -54,8 +54,8 @@ use core::{cmp, mem};
 use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::hil;
 use kernel::{
-    AppId, Upcall, CommandReturn, Driver, ErrorCode, Grant, Read, ReadWrite, ReadWriteAppSlice,
-    ReturnCode,
+    AppId, CommandReturn, Driver, ErrorCode, Grant, Read, ReadWrite, ReadWriteAppSlice, ReturnCode,
+    Upcall,
 };
 
 /// Syscall driver number.

--- a/capsules/src/alarm.rs
+++ b/capsules/src/alarm.rs
@@ -4,7 +4,7 @@
 use core::cell::Cell;
 use core::mem;
 use kernel::hil::time::{self, Alarm, Frequency, Ticks, Ticks32};
-use kernel::{AppId, Upcall, CommandReturn, Driver, ErrorCode, Grant};
+use kernel::{AppId, CommandReturn, Driver, ErrorCode, Grant, Upcall};
 
 /// Syscall driver number.
 use crate::driver;

--- a/capsules/src/alarm.rs
+++ b/capsules/src/alarm.rs
@@ -4,7 +4,7 @@
 use core::cell::Cell;
 use core::mem;
 use kernel::hil::time::{self, Alarm, Frequency, Ticks, Ticks32};
-use kernel::{AppId, Callback, CommandReturn, Driver, ErrorCode, Grant};
+use kernel::{AppId, Upcall, CommandReturn, Driver, ErrorCode, Grant};
 
 /// Syscall driver number.
 use crate::driver;
@@ -19,14 +19,14 @@ enum Expiration {
 #[derive(Copy, Clone)]
 pub struct AlarmData {
     expiration: Expiration,
-    callback: Callback,
+    callback: Upcall,
 }
 
 impl Default for AlarmData {
     fn default() -> AlarmData {
         AlarmData {
             expiration: Expiration::Disabled,
-            callback: Callback::default(),
+            callback: Upcall::default(),
         }
     }
 }
@@ -153,9 +153,9 @@ impl<'a, A: Alarm<'a>> Driver for AlarmDriver<'a, A> {
     fn subscribe(
         &self,
         subscribe_num: usize,
-        mut callback: Callback,
+        mut callback: Upcall,
         app_id: AppId,
-    ) -> Result<Callback, (Callback, ErrorCode)> {
+    ) -> Result<Upcall, (Upcall, ErrorCode)> {
         let res: Result<(), ErrorCode> = match subscribe_num {
             0 => self
                 .app_alarms

--- a/capsules/src/ambient_light.rs
+++ b/capsules/src/ambient_light.rs
@@ -16,7 +16,7 @@ use core::cell::Cell;
 use core::convert::TryFrom;
 use core::mem;
 use kernel::hil;
-use kernel::{AppId, Callback, CommandReturn, Driver, ErrorCode, Grant, ReturnCode};
+use kernel::{AppId, Upcall, CommandReturn, Driver, ErrorCode, Grant, ReturnCode};
 
 /// Syscall driver number.
 use crate::driver;
@@ -25,7 +25,7 @@ pub const DRIVER_NUM: usize = driver::NUM::AmbientLight as usize;
 /// Per-process metadata
 #[derive(Default)]
 pub struct App {
-    callback: Callback,
+    callback: Upcall,
     pending: bool,
 }
 
@@ -72,9 +72,9 @@ impl Driver for AmbientLight<'_> {
     fn subscribe(
         &self,
         subscribe_num: usize,
-        mut callback: Callback,
+        mut callback: Upcall,
         app_id: AppId,
-    ) -> Result<Callback, (Callback, ErrorCode)> {
+    ) -> Result<Upcall, (Upcall, ErrorCode)> {
         match subscribe_num {
             0 => {
                 let rcode = self

--- a/capsules/src/ambient_light.rs
+++ b/capsules/src/ambient_light.rs
@@ -16,7 +16,7 @@ use core::cell::Cell;
 use core::convert::TryFrom;
 use core::mem;
 use kernel::hil;
-use kernel::{AppId, Upcall, CommandReturn, Driver, ErrorCode, Grant, ReturnCode};
+use kernel::{AppId, CommandReturn, Driver, ErrorCode, Grant, ReturnCode, Upcall};
 
 /// Syscall driver number.
 use crate::driver;

--- a/capsules/src/analog_comparator.rs
+++ b/capsules/src/analog_comparator.rs
@@ -39,7 +39,7 @@ pub const DRIVER_NUM: usize = driver::NUM::AnalogComparator as usize;
 
 use core::cell::Cell;
 use kernel::hil;
-use kernel::{AppId, Upcall, CommandReturn, Driver, ErrorCode, ReturnCode};
+use kernel::{AppId, CommandReturn, Driver, ErrorCode, ReturnCode, Upcall};
 
 pub struct AnalogComparator<'a, A: hil::analog_comparator::AnalogComparator<'a> + 'a> {
     // Analog Comparator driver

--- a/capsules/src/analog_comparator.rs
+++ b/capsules/src/analog_comparator.rs
@@ -39,7 +39,7 @@ pub const DRIVER_NUM: usize = driver::NUM::AnalogComparator as usize;
 
 use core::cell::Cell;
 use kernel::hil;
-use kernel::{AppId, Callback, CommandReturn, Driver, ErrorCode, ReturnCode};
+use kernel::{AppId, Upcall, CommandReturn, Driver, ErrorCode, ReturnCode};
 
 pub struct AnalogComparator<'a, A: hil::analog_comparator::AnalogComparator<'a> + 'a> {
     // Analog Comparator driver
@@ -47,7 +47,7 @@ pub struct AnalogComparator<'a, A: hil::analog_comparator::AnalogComparator<'a> 
     channels: &'a [&'a <A as hil::analog_comparator::AnalogComparator<'a>>::Channel],
 
     // App state
-    callback: Cell<Callback>,
+    callback: Cell<Upcall>,
 }
 
 impl<'a, A: hil::analog_comparator::AnalogComparator<'a>> AnalogComparator<'a, A> {
@@ -61,7 +61,7 @@ impl<'a, A: hil::analog_comparator::AnalogComparator<'a>> AnalogComparator<'a, A
             channels,
 
             // App state
-            callback: Cell::new(Callback::default()),
+            callback: Cell::new(Upcall::default()),
         }
     }
 
@@ -138,9 +138,9 @@ impl<'a, A: hil::analog_comparator::AnalogComparator<'a>> Driver for AnalogCompa
     fn subscribe(
         &self,
         subscribe_num: usize,
-        callback: Callback,
+        callback: Upcall,
         _app_id: AppId,
-    ) -> Result<Callback, (Callback, ErrorCode)> {
+    ) -> Result<Upcall, (Upcall, ErrorCode)> {
         match subscribe_num {
             // Subscribe to all interrupts
             0 => Ok(self.callback.replace(callback)),
@@ -153,7 +153,7 @@ impl<'a, A: hil::analog_comparator::AnalogComparator<'a>> Driver for AnalogCompa
 impl<'a, A: hil::analog_comparator::AnalogComparator<'a>> hil::analog_comparator::Client
     for AnalogComparator<'a, A>
 {
-    /// Callback to userland, signaling the application
+    /// Upcall to userland, signaling the application
     fn fired(&self, channel: usize) {
         self.callback.get().schedule(channel, 0, 0);
     }

--- a/capsules/src/app_flash_driver.rs
+++ b/capsules/src/app_flash_driver.rs
@@ -27,7 +27,7 @@ use core::mem;
 use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::hil;
 use kernel::ErrorCode;
-use kernel::{AppId, Callback, CommandReturn, Driver, Grant, Read, ReadOnlyAppSlice};
+use kernel::{AppId, Upcall, CommandReturn, Driver, Grant, Read, ReadOnlyAppSlice};
 
 /// Syscall driver number.
 use crate::driver;
@@ -35,7 +35,7 @@ pub const DRIVER_NUM: usize = driver::NUM::AppFlash as usize;
 
 #[derive(Default)]
 pub struct App {
-    callback: Callback,
+    callback: Upcall,
     buffer: ReadOnlyAppSlice,
     pending_command: bool,
     flash_address: usize,
@@ -200,9 +200,9 @@ impl Driver for AppFlash<'_> {
     fn subscribe(
         &self,
         subscribe_num: usize,
-        mut callback: Callback,
+        mut callback: Upcall,
         app_id: AppId,
-    ) -> Result<Callback, (Callback, ErrorCode)> {
+    ) -> Result<Upcall, (Upcall, ErrorCode)> {
         let res = match subscribe_num {
             0 => self
                 .apps

--- a/capsules/src/app_flash_driver.rs
+++ b/capsules/src/app_flash_driver.rs
@@ -27,7 +27,7 @@ use core::mem;
 use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::hil;
 use kernel::ErrorCode;
-use kernel::{AppId, Upcall, CommandReturn, Driver, Grant, Read, ReadOnlyAppSlice};
+use kernel::{AppId, CommandReturn, Driver, Grant, Read, ReadOnlyAppSlice, Upcall};
 
 /// Syscall driver number.
 use crate::driver;

--- a/capsules/src/ble_advertising_driver.rs
+++ b/capsules/src/ble_advertising_driver.rs
@@ -188,7 +188,7 @@ pub struct App {
 
     // Scanning meta-data
     scan_buffer: ReadWriteAppSlice,
-    scan_callback: kernel::Callback,
+    scan_callback: kernel::Upcall,
 }
 
 impl Default for App {
@@ -199,7 +199,7 @@ impl Default for App {
             scan_buffer: ReadWriteAppSlice::default(),
             address: [0; PACKET_ADDR_LEN],
             pdu_type: ADV_NONCONN_IND,
-            scan_callback: kernel::Callback::default(),
+            scan_callback: kernel::Upcall::default(),
             process_status: Some(BLEState::NotInitialized),
             tx_power: 0,
             advertisement_interval_ms: 200,
@@ -721,11 +721,11 @@ where
     fn subscribe(
         &self,
         subscribe_num: usize,
-        mut callback: kernel::Callback,
+        mut callback: kernel::Upcall,
         app_id: kernel::AppId,
-    ) -> Result<kernel::Callback, (kernel::Callback, ErrorCode)> {
+    ) -> Result<kernel::Upcall, (kernel::Upcall, ErrorCode)> {
         match subscribe_num {
-            // Callback for scanning
+            // Upcall for scanning
             0 => self
                 .app
                 .enter(app_id, |app, _| match app.process_status {

--- a/capsules/src/button.rs
+++ b/capsules/src/button.rs
@@ -54,7 +54,7 @@
 use core::cell::Cell;
 use kernel::hil::gpio;
 use kernel::hil::gpio::{Configure, Input, InterruptWithValue};
-use kernel::{AppId, Upcall, CommandReturn, Driver, ErrorCode, Grant};
+use kernel::{AppId, CommandReturn, Driver, ErrorCode, Grant, Upcall};
 
 /// Syscall driver number.
 use crate::driver;

--- a/capsules/src/button.rs
+++ b/capsules/src/button.rs
@@ -54,7 +54,7 @@
 use core::cell::Cell;
 use kernel::hil::gpio;
 use kernel::hil::gpio::{Configure, Input, InterruptWithValue};
-use kernel::{AppId, Callback, CommandReturn, Driver, ErrorCode, Grant};
+use kernel::{AppId, Upcall, CommandReturn, Driver, ErrorCode, Grant};
 
 /// Syscall driver number.
 use crate::driver;
@@ -73,7 +73,7 @@ pub struct Button<'a, P: gpio::InterruptPin<'a>> {
         gpio::ActivationMode,
         gpio::FloatingState,
     )],
-    apps: Grant<(Callback, SubscribeMap)>,
+    apps: Grant<(Upcall, SubscribeMap)>,
 }
 
 impl<'a, P: gpio::InterruptPin<'a>> Button<'a, P> {
@@ -83,7 +83,7 @@ impl<'a, P: gpio::InterruptPin<'a>> Button<'a, P> {
             gpio::ActivationMode,
             gpio::FloatingState,
         )],
-        grant: Grant<(Callback, SubscribeMap)>,
+        grant: Grant<(Upcall, SubscribeMap)>,
     ) -> Self {
         for (i, &(pin, _, floating_state)) in pins.iter().enumerate() {
             pin.make_input();
@@ -116,9 +116,9 @@ impl<'a, P: gpio::InterruptPin<'a>> Driver for Button<'a, P> {
     fn subscribe(
         &self,
         subscribe_num: usize,
-        mut callback: Callback,
+        mut callback: Upcall,
         app_id: AppId,
-    ) -> Result<Callback, (Callback, ErrorCode)> {
+    ) -> Result<Upcall, (Upcall, ErrorCode)> {
         let res = match subscribe_num {
             0 => self
                 .apps

--- a/capsules/src/buzzer_driver.rs
+++ b/capsules/src/buzzer_driver.rs
@@ -44,7 +44,7 @@ use core::mem;
 use kernel::common::cells::OptionalCell;
 use kernel::hil;
 use kernel::hil::time::Frequency;
-use kernel::{AppId, Callback, CommandReturn, Driver, ErrorCode, Grant, ReturnCode};
+use kernel::{AppId, Upcall, CommandReturn, Driver, ErrorCode, Grant, ReturnCode};
 
 /// Syscall driver number.
 use crate::driver;
@@ -63,7 +63,7 @@ pub enum BuzzerCommand {
 
 #[derive(Default)]
 pub struct App {
-    callback: Callback, // Optional callback to signal when the buzzer event is over.
+    callback: Upcall, // Optional callback to signal when the buzzer event is over.
     pending_command: Option<BuzzerCommand>, // What command to run when the buzzer is free.
 }
 
@@ -192,9 +192,9 @@ impl<'a, A: hil::time::Alarm<'a>> Driver for Buzzer<'a, A> {
     fn subscribe(
         &self,
         subscribe_num: usize,
-        mut callback: Callback,
+        mut callback: Upcall,
         app_id: AppId,
-    ) -> Result<Callback, (Callback, ErrorCode)> {
+    ) -> Result<Upcall, (Upcall, ErrorCode)> {
         let res = match subscribe_num {
             0 => self
                 .apps

--- a/capsules/src/buzzer_driver.rs
+++ b/capsules/src/buzzer_driver.rs
@@ -44,7 +44,7 @@ use core::mem;
 use kernel::common::cells::OptionalCell;
 use kernel::hil;
 use kernel::hil::time::Frequency;
-use kernel::{AppId, Upcall, CommandReturn, Driver, ErrorCode, Grant, ReturnCode};
+use kernel::{AppId, CommandReturn, Driver, ErrorCode, Grant, ReturnCode, Upcall};
 
 /// Syscall driver number.
 use crate::driver;

--- a/capsules/src/console.rs
+++ b/capsules/src/console.rs
@@ -42,7 +42,7 @@ use core::{cmp, mem};
 
 use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::hil::uart;
-use kernel::{AppId, Upcall, ErrorCode, Grant};
+use kernel::{AppId, ErrorCode, Grant, Upcall};
 use kernel::{CommandReturn, Driver, ReturnCode};
 use kernel::{Read, ReadOnlyAppSlice, ReadWrite, ReadWriteAppSlice};
 

--- a/capsules/src/console.rs
+++ b/capsules/src/console.rs
@@ -42,7 +42,7 @@ use core::{cmp, mem};
 
 use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::hil::uart;
-use kernel::{AppId, Callback, ErrorCode, Grant};
+use kernel::{AppId, Upcall, ErrorCode, Grant};
 use kernel::{CommandReturn, Driver, ReturnCode};
 use kernel::{Read, ReadOnlyAppSlice, ReadWrite, ReadWriteAppSlice};
 
@@ -52,13 +52,13 @@ pub const DRIVER_NUM: usize = driver::NUM::Console as usize;
 
 #[derive(Default)]
 pub struct App {
-    write_callback: Callback,
+    write_callback: Upcall,
     write_buffer: ReadOnlyAppSlice,
     write_len: usize,
     write_remaining: usize, // How many bytes didn't fit in the buffer and still need to be printed.
     pending_write: bool,
 
-    read_callback: Callback,
+    read_callback: Upcall,
     read_buffer: ReadWriteAppSlice,
     read_len: usize,
 }
@@ -233,9 +233,9 @@ impl Driver for Console<'_> {
     fn subscribe(
         &self,
         subscribe_num: usize,
-        mut callback: Callback,
+        mut callback: Upcall,
         app_id: AppId,
-    ) -> Result<Callback, (Callback, ErrorCode)> {
+    ) -> Result<Upcall, (Upcall, ErrorCode)> {
         let res = match subscribe_num {
             1 => {
                 // putstr/write done

--- a/capsules/src/crc.rs
+++ b/capsules/src/crc.rs
@@ -71,7 +71,7 @@ use core::mem;
 use kernel::common::cells::OptionalCell;
 use kernel::hil;
 use kernel::hil::crc::CrcAlg;
-use kernel::{AppId, Upcall, CommandReturn, Driver, ErrorCode, Grant};
+use kernel::{AppId, CommandReturn, Driver, ErrorCode, Grant, Upcall};
 use kernel::{Read, ReadOnlyAppSlice, ReturnCode};
 
 /// Syscall driver number.

--- a/capsules/src/crc.rs
+++ b/capsules/src/crc.rs
@@ -71,7 +71,7 @@ use core::mem;
 use kernel::common::cells::OptionalCell;
 use kernel::hil;
 use kernel::hil::crc::CrcAlg;
-use kernel::{AppId, Callback, CommandReturn, Driver, ErrorCode, Grant};
+use kernel::{AppId, Upcall, CommandReturn, Driver, ErrorCode, Grant};
 use kernel::{Read, ReadOnlyAppSlice, ReturnCode};
 
 /// Syscall driver number.
@@ -81,7 +81,7 @@ pub const DRIVER_NUM: usize = driver::NUM::Crc as usize;
 /// An opaque value maintaining state for one application's request
 #[derive(Default)]
 pub struct App {
-    callback: Callback,
+    callback: Upcall,
     buffer: ReadOnlyAppSlice,
 
     // if Some, the application is awaiting the result of a CRC
@@ -214,9 +214,9 @@ impl<'a, C: hil::crc::CRC<'a>> Driver for Crc<'a, C> {
     fn subscribe(
         &self,
         subscribe_num: usize,
-        mut callback: Callback,
+        mut callback: Upcall,
         app_id: AppId,
-    ) -> Result<Callback, (Callback, ErrorCode)> {
+    ) -> Result<Upcall, (Upcall, ErrorCode)> {
         let res = match subscribe_num {
             // Set callback for CRC result
             0 => self

--- a/capsules/src/ctap.rs
+++ b/capsules/src/ctap.rs
@@ -33,7 +33,7 @@ use core::mem;
 use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::hil::usb_hid;
 use kernel::{
-    AppId, Upcall, CommandReturn, Driver, ErrorCode, Grant, Read, ReadWrite, ReadWriteAppSlice,
+    AppId, CommandReturn, Driver, ErrorCode, Grant, Read, ReadWrite, ReadWriteAppSlice, Upcall,
 };
 
 /// Syscall driver number.

--- a/capsules/src/ctap.rs
+++ b/capsules/src/ctap.rs
@@ -33,7 +33,7 @@ use core::mem;
 use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::hil::usb_hid;
 use kernel::{
-    AppId, Callback, CommandReturn, Driver, ErrorCode, Grant, Read, ReadWrite, ReadWriteAppSlice,
+    AppId, Upcall, CommandReturn, Driver, ErrorCode, Grant, Read, ReadWrite, ReadWriteAppSlice,
 };
 
 /// Syscall driver number.
@@ -41,7 +41,7 @@ use crate::driver;
 pub const DRIVER_NUM: usize = driver::NUM::CtapHid as usize;
 
 pub struct App {
-    callback: Callback,
+    callback: Upcall,
     recv_buf: ReadWriteAppSlice,
     send_buf: ReadWriteAppSlice,
     can_receive: Cell<bool>,
@@ -50,7 +50,7 @@ pub struct App {
 impl Default for App {
     fn default() -> App {
         App {
-            callback: Callback::default(),
+            callback: Upcall::default(),
             recv_buf: ReadWriteAppSlice::default(),
             send_buf: ReadWriteAppSlice::default(),
             can_receive: Cell::new(false),
@@ -234,9 +234,9 @@ impl<'a, U: usb_hid::UsbHid<'a, [u8; 64]>> Driver for CtapDriver<'a, U> {
     fn subscribe(
         &self,
         subscribe_num: usize,
-        mut callback: Callback,
+        mut callback: Upcall,
         appid: AppId,
-    ) -> Result<Callback, (Callback, ErrorCode)> {
+    ) -> Result<Upcall, (Upcall, ErrorCode)> {
         let res = match subscribe_num {
             0 => {
                 // set callback

--- a/capsules/src/gpio.rs
+++ b/capsules/src/gpio.rs
@@ -54,7 +54,7 @@ pub const DRIVER_NUM: usize = driver::NUM::Gpio as usize;
 use core::mem;
 use kernel::hil::gpio;
 use kernel::hil::gpio::{Configure, Input, InterruptWithValue, Output};
-use kernel::{AppId, Upcall, CommandReturn, Driver, ErrorCode, Grant};
+use kernel::{AppId, CommandReturn, Driver, ErrorCode, Grant, Upcall};
 
 pub struct GPIO<'a, IP: gpio::InterruptPin<'a>> {
     pins: &'a [Option<&'a gpio::InterruptValueWrapper<'a, IP>>],

--- a/capsules/src/gpio.rs
+++ b/capsules/src/gpio.rs
@@ -54,17 +54,17 @@ pub const DRIVER_NUM: usize = driver::NUM::Gpio as usize;
 use core::mem;
 use kernel::hil::gpio;
 use kernel::hil::gpio::{Configure, Input, InterruptWithValue, Output};
-use kernel::{AppId, Callback, CommandReturn, Driver, ErrorCode, Grant};
+use kernel::{AppId, Upcall, CommandReturn, Driver, ErrorCode, Grant};
 
 pub struct GPIO<'a, IP: gpio::InterruptPin<'a>> {
     pins: &'a [Option<&'a gpio::InterruptValueWrapper<'a, IP>>],
-    apps: Grant<Callback>,
+    apps: Grant<Upcall>,
 }
 
 impl<'a, IP: gpio::InterruptPin<'a>> GPIO<'a, IP> {
     pub fn new(
         pins: &'a [Option<&'a gpio::InterruptValueWrapper<'a, IP>>],
-        grant: Grant<Callback>,
+        grant: Grant<Upcall>,
     ) -> Self {
         for (i, maybe_pin) in pins.iter().enumerate() {
             if let Some(pin) = maybe_pin {
@@ -154,9 +154,9 @@ impl<'a, IP: gpio::InterruptPin<'a>> Driver for GPIO<'a, IP> {
     fn subscribe(
         &self,
         subscribe_num: usize,
-        mut callback: Callback,
+        mut callback: Upcall,
         app_id: AppId,
-    ) -> Result<Callback, (Callback, ErrorCode)> {
+    ) -> Result<Upcall, (Upcall, ErrorCode)> {
         let res = match subscribe_num {
             // subscribe to all pin interrupts (no affect or reliance on
             // individual pins being configured as interrupts)

--- a/capsules/src/gpio_async.rs
+++ b/capsules/src/gpio_async.rs
@@ -27,7 +27,7 @@
 
 use core::cell::Cell;
 use kernel::hil;
-use kernel::{AppId, Upcall, ErrorCode};
+use kernel::{AppId, ErrorCode, Upcall};
 use kernel::{CommandReturn, Driver, ReturnCode};
 
 /// Syscall driver number.

--- a/capsules/src/gpio_async.rs
+++ b/capsules/src/gpio_async.rs
@@ -27,7 +27,7 @@
 
 use core::cell::Cell;
 use kernel::hil;
-use kernel::{AppId, Callback, ErrorCode};
+use kernel::{AppId, Upcall, ErrorCode};
 use kernel::{CommandReturn, Driver, ReturnCode};
 
 /// Syscall driver number.
@@ -36,16 +36,16 @@ pub const DRIVER_NUM: usize = driver::NUM::GpioAsync as usize;
 
 pub struct GPIOAsync<'a, Port: hil::gpio_async::Port> {
     ports: &'a [&'a Port],
-    callback: Cell<Callback>,
-    interrupt_callback: Cell<Callback>,
+    callback: Cell<Upcall>,
+    interrupt_callback: Cell<Upcall>,
 }
 
 impl<'a, Port: hil::gpio_async::Port> GPIOAsync<'a, Port> {
     pub fn new(ports: &'a [&'a Port]) -> GPIOAsync<'a, Port> {
         GPIOAsync {
             ports,
-            callback: Cell::new(Callback::default()),
-            interrupt_callback: Cell::new(Callback::default()),
+            callback: Cell::new(Upcall::default()),
+            interrupt_callback: Cell::new(Upcall::default()),
         }
     }
 
@@ -100,9 +100,9 @@ impl<Port: hil::gpio_async::Port> Driver for GPIOAsync<'_, Port> {
     fn subscribe(
         &self,
         subscribe_num: usize,
-        callback: Callback,
+        callback: Upcall,
         _app_id: AppId,
-    ) -> Result<Callback, (Callback, ErrorCode)> {
+    ) -> Result<Upcall, (Upcall, ErrorCode)> {
         match subscribe_num {
             // Set callback for `done()` events
             0 => Ok(self.callback.replace(callback)),

--- a/capsules/src/hmac.rs
+++ b/capsules/src/hmac.rs
@@ -36,8 +36,8 @@ use kernel::common::leasable_buffer::LeasableBuffer;
 use kernel::hil::digest;
 use kernel::hil::digest::DigestType;
 use kernel::{
-    AppId, Upcall, CommandReturn, Driver, ErrorCode, Grant, Read, ReadWrite, ReadWriteAppSlice,
-    ReturnCode,
+    AppId, CommandReturn, Driver, ErrorCode, Grant, Read, ReadWrite, ReadWriteAppSlice, ReturnCode,
+    Upcall,
 };
 
 pub struct HmacDriver<'a, H: digest::Digest<'a, T>, T: 'static + DigestType> {

--- a/capsules/src/hmac.rs
+++ b/capsules/src/hmac.rs
@@ -36,7 +36,7 @@ use kernel::common::leasable_buffer::LeasableBuffer;
 use kernel::hil::digest;
 use kernel::hil::digest::DigestType;
 use kernel::{
-    AppId, Callback, CommandReturn, Driver, ErrorCode, Grant, Read, ReadWrite, ReadWriteAppSlice,
+    AppId, Upcall, CommandReturn, Driver, ErrorCode, Grant, Read, ReadWrite, ReadWriteAppSlice,
     ReturnCode,
 };
 
@@ -348,9 +348,9 @@ impl<'a, H: digest::Digest<'a, T> + digest::HMACSha256, T: DigestType> Driver
     fn subscribe(
         &self,
         subscribe_num: usize,
-        mut callback: Callback,
+        mut callback: Upcall,
         appid: AppId,
-    ) -> Result<Callback, (Callback, ErrorCode)> {
+    ) -> Result<Upcall, (Upcall, ErrorCode)> {
         let res = match subscribe_num {
             0 => {
                 // set callback
@@ -476,7 +476,7 @@ impl<'a, H: digest::Digest<'a, T> + digest::HMACSha256, T: DigestType> Driver
 
 #[derive(Default)]
 pub struct App {
-    callback: Callback,
+    callback: Upcall,
     pending_run_app: Option<AppId>,
     key: ReadWriteAppSlice,
     data: ReadWriteAppSlice,

--- a/capsules/src/humidity.rs
+++ b/capsules/src/humidity.rs
@@ -53,7 +53,7 @@ use core::convert::TryFrom;
 use core::mem;
 
 use kernel::hil;
-use kernel::{AppId, Callback, CommandReturn, Driver, ErrorCode, Grant};
+use kernel::{AppId, Upcall, CommandReturn, Driver, ErrorCode, Grant};
 
 /// Syscall driver number.
 use crate::driver;
@@ -67,7 +67,7 @@ pub enum HumidityCommand {
 
 #[derive(Default)]
 pub struct App {
-    callback: Callback,
+    callback: Upcall,
     subscribed: bool,
 }
 
@@ -124,9 +124,9 @@ impl<'a> HumiditySensor<'a> {
 
     fn configure_callback(
         &self,
-        mut callback: Callback,
+        mut callback: Upcall,
         app_id: AppId,
-    ) -> Result<Callback, (Callback, ErrorCode)> {
+    ) -> Result<Upcall, (Upcall, ErrorCode)> {
         let res = self
             .apps
             .enter(app_id, |app, _| {
@@ -160,9 +160,9 @@ impl Driver for HumiditySensor<'_> {
     fn subscribe(
         &self,
         subscribe_num: usize,
-        callback: Callback,
+        callback: Upcall,
         app_id: AppId,
-    ) -> Result<Callback, (Callback, ErrorCode)> {
+    ) -> Result<Upcall, (Upcall, ErrorCode)> {
         match subscribe_num {
             // subscribe to temperature reading with callback
             0 => self.configure_callback(callback, app_id),

--- a/capsules/src/humidity.rs
+++ b/capsules/src/humidity.rs
@@ -53,7 +53,7 @@ use core::convert::TryFrom;
 use core::mem;
 
 use kernel::hil;
-use kernel::{AppId, Upcall, CommandReturn, Driver, ErrorCode, Grant};
+use kernel::{AppId, CommandReturn, Driver, ErrorCode, Grant, Upcall};
 
 /// Syscall driver number.
 use crate::driver;

--- a/capsules/src/i2c_master.rs
+++ b/capsules/src/i2c_master.rs
@@ -4,7 +4,7 @@ use enum_primitive::enum_from_primitive;
 use kernel::common::cells::{MapCell, OptionalCell, TakeCell};
 use kernel::hil::i2c;
 use kernel::{
-    AppId, Callback, CommandReturn, Driver, ErrorCode, Grant, Read, ReadWrite, ReadWriteAppSlice,
+    AppId, Upcall, CommandReturn, Driver, ErrorCode, Grant, Read, ReadWrite, ReadWriteAppSlice,
 };
 
 /// Syscall driver number.
@@ -13,7 +13,7 @@ pub const DRIVER_NUM: usize = driver::NUM::I2cMaster as usize;
 
 #[derive(Default)]
 pub struct App {
-    callback: Callback,
+    callback: Upcall,
     slice: ReadWriteAppSlice,
 }
 
@@ -127,9 +127,9 @@ impl<'a, I: 'a + i2c::I2CMaster> Driver for I2CMasterDriver<'a, I> {
     fn subscribe(
         &self,
         subscribe_num: usize,
-        mut callback: Callback,
+        mut callback: Upcall,
         app_id: AppId,
-    ) -> Result<Callback, (Callback, ErrorCode)> {
+    ) -> Result<Upcall, (Upcall, ErrorCode)> {
         let res = match subscribe_num {
             1 /* write_read_done */ => {
                 self.apps.enter(app_id, |app, _| {

--- a/capsules/src/i2c_master.rs
+++ b/capsules/src/i2c_master.rs
@@ -4,7 +4,7 @@ use enum_primitive::enum_from_primitive;
 use kernel::common::cells::{MapCell, OptionalCell, TakeCell};
 use kernel::hil::i2c;
 use kernel::{
-    AppId, Upcall, CommandReturn, Driver, ErrorCode, Grant, Read, ReadWrite, ReadWriteAppSlice,
+    AppId, CommandReturn, Driver, ErrorCode, Grant, Read, ReadWrite, ReadWriteAppSlice, Upcall,
 };
 
 /// Syscall driver number.

--- a/capsules/src/i2c_master_slave_driver.rs
+++ b/capsules/src/i2c_master_slave_driver.rs
@@ -15,7 +15,7 @@ use core::cell::Cell;
 use core::cmp;
 use kernel::common::cells::{MapCell, TakeCell};
 use kernel::hil;
-use kernel::{AppId, Callback, CommandReturn};
+use kernel::{AppId, Upcall, CommandReturn};
 use kernel::{Driver, ErrorCode, Read, ReadWrite, ReadWriteAppSlice};
 
 pub static mut BUFFER1: [u8; 256] = [0; 256];
@@ -28,7 +28,7 @@ pub const DRIVER_NUM: usize = driver::NUM::I2cMasterSlave as usize;
 
 #[derive(Default)]
 pub struct App {
-    callback: Callback,
+    callback: Upcall,
     master_tx_buffer: ReadWriteAppSlice,
     master_rx_buffer: ReadWriteAppSlice,
     slave_tx_buffer: ReadWriteAppSlice,
@@ -242,9 +242,9 @@ impl Driver for I2CMasterSlaveDriver<'_> {
     fn subscribe(
         &self,
         subscribe_num: usize,
-        mut callback: Callback,
+        mut callback: Upcall,
         _app_id: AppId,
-    ) -> Result<Callback, (Callback, ErrorCode)> {
+    ) -> Result<Upcall, (Upcall, ErrorCode)> {
         match subscribe_num {
             0 => {
                 self.app.map(|app| {

--- a/capsules/src/i2c_master_slave_driver.rs
+++ b/capsules/src/i2c_master_slave_driver.rs
@@ -15,7 +15,7 @@ use core::cell::Cell;
 use core::cmp;
 use kernel::common::cells::{MapCell, TakeCell};
 use kernel::hil;
-use kernel::{AppId, Upcall, CommandReturn};
+use kernel::{AppId, CommandReturn, Upcall};
 use kernel::{Driver, ErrorCode, Read, ReadWrite, ReadWriteAppSlice};
 
 pub static mut BUFFER1: [u8; 256] = [0; 256];

--- a/capsules/src/ieee802154/driver.rs
+++ b/capsules/src/ieee802154/driver.rs
@@ -15,7 +15,7 @@ use kernel::common::dynamic_deferred_call::{
     DeferredCallHandle, DynamicDeferredCall, DynamicDeferredCallClient,
 };
 use kernel::{
-    AppId, Callback, CommandReturn, Driver, ErrorCode, Grant, Read, ReadOnlyAppSlice, ReadWrite,
+    AppId, Upcall, CommandReturn, Driver, ErrorCode, Grant, Read, ReadOnlyAppSlice, ReadWrite,
     ReadWriteAppSlice, ReturnCode,
 };
 
@@ -153,8 +153,8 @@ impl KeyDescriptor {
 
 #[derive(Default)]
 pub struct App {
-    rx_callback: Callback,
-    tx_callback: Callback,
+    rx_callback: Upcall,
+    tx_callback: Upcall,
     app_read: ReadWriteAppSlice,
     app_write: ReadOnlyAppSlice,
     app_cfg: ReadWriteAppSlice,
@@ -563,9 +563,9 @@ impl Driver for RadioDriver<'_> {
     fn subscribe(
         &self,
         subscribe_num: usize,
-        mut callback: Callback,
+        mut callback: Upcall,
         app_id: AppId,
-    ) -> Result<Callback, (Callback, ErrorCode)> {
+    ) -> Result<Upcall, (Upcall, ErrorCode)> {
         self.apps
             .enter(app_id, |app, _| match subscribe_num {
                 0 => {

--- a/capsules/src/ieee802154/driver.rs
+++ b/capsules/src/ieee802154/driver.rs
@@ -15,8 +15,8 @@ use kernel::common::dynamic_deferred_call::{
     DeferredCallHandle, DynamicDeferredCall, DynamicDeferredCallClient,
 };
 use kernel::{
-    AppId, Upcall, CommandReturn, Driver, ErrorCode, Grant, Read, ReadOnlyAppSlice, ReadWrite,
-    ReadWriteAppSlice, ReturnCode,
+    AppId, CommandReturn, Driver, ErrorCode, Grant, Read, ReadOnlyAppSlice, ReadWrite,
+    ReadWriteAppSlice, ReturnCode, Upcall,
 };
 
 const MAX_NEIGHBORS: usize = 4;

--- a/capsules/src/l3gd20.rs
+++ b/capsules/src/l3gd20.rs
@@ -107,7 +107,7 @@ use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::hil::sensors;
 use kernel::hil::spi;
 use kernel::ReturnCode;
-use kernel::{AppId, Upcall, CommandReturn, Driver, ErrorCode};
+use kernel::{AppId, CommandReturn, Driver, ErrorCode, Upcall};
 
 use crate::driver;
 pub const DRIVER_NUM: usize = driver::NUM::L3gd20 as usize;

--- a/capsules/src/l3gd20.rs
+++ b/capsules/src/l3gd20.rs
@@ -107,7 +107,7 @@ use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::hil::sensors;
 use kernel::hil::spi;
 use kernel::ReturnCode;
-use kernel::{AppId, Callback, CommandReturn, Driver, ErrorCode};
+use kernel::{AppId, Upcall, CommandReturn, Driver, ErrorCode};
 
 use crate::driver;
 pub const DRIVER_NUM: usize = driver::NUM::L3gd20 as usize;
@@ -184,7 +184,7 @@ pub struct L3gd20Spi<'a> {
     hpf_mode: Cell<u8>,
     hpf_divider: Cell<u8>,
     scale: Cell<u8>,
-    callback: Cell<Callback>,
+    callback: Cell<Upcall>,
     nine_dof_client: OptionalCell<&'a dyn sensors::NineDofClient>,
     temperature_client: OptionalCell<&'a dyn sensors::TemperatureClient>,
 }
@@ -205,7 +205,7 @@ impl<'a> L3gd20Spi<'a> {
             hpf_mode: Cell::new(0),
             hpf_divider: Cell::new(0),
             scale: Cell::new(0),
-            callback: Cell::new(Callback::default()),
+            callback: Cell::new(Upcall::default()),
             nine_dof_client: OptionalCell::empty(),
             temperature_client: OptionalCell::empty(),
         }
@@ -378,9 +378,9 @@ impl Driver for L3gd20Spi<'_> {
     fn subscribe(
         &self,
         subscribe_num: usize,
-        mut callback: Callback,
+        mut callback: Upcall,
         _appid: AppId,
-    ) -> Result<Callback, (Callback, ErrorCode)> {
+    ) -> Result<Upcall, (Upcall, ErrorCode)> {
         match subscribe_num {
             0 /* set the one shot callback */ => {
                 callback = self.callback.replace (callback);

--- a/capsules/src/lps25hb.rs
+++ b/capsules/src/lps25hb.rs
@@ -22,7 +22,7 @@ use core::cell::Cell;
 use kernel::common::cells::TakeCell;
 use kernel::hil::gpio;
 use kernel::hil::i2c;
-use kernel::{AppId, Upcall, CommandReturn, Driver, ErrorCode};
+use kernel::{AppId, CommandReturn, Driver, ErrorCode, Upcall};
 
 /// Syscall driver number.
 use crate::driver;

--- a/capsules/src/lps25hb.rs
+++ b/capsules/src/lps25hb.rs
@@ -22,7 +22,7 @@ use core::cell::Cell;
 use kernel::common::cells::TakeCell;
 use kernel::hil::gpio;
 use kernel::hil::i2c;
-use kernel::{AppId, Callback, CommandReturn, Driver, ErrorCode};
+use kernel::{AppId, Upcall, CommandReturn, Driver, ErrorCode};
 
 /// Syscall driver number.
 use crate::driver;
@@ -96,7 +96,7 @@ enum State {
 pub struct LPS25HB<'a> {
     i2c: &'a dyn i2c::I2CDevice,
     interrupt_pin: &'a dyn gpio::InterruptPin<'a>,
-    callback: Cell<Callback>,
+    callback: Cell<Upcall>,
     state: Cell<State>,
     buffer: TakeCell<'static, [u8]>,
 }
@@ -111,7 +111,7 @@ impl<'a> LPS25HB<'a> {
         LPS25HB {
             i2c: i2c,
             interrupt_pin: interrupt_pin,
-            callback: Cell::new(Callback::default()),
+            callback: Cell::new(Upcall::default()),
             state: Cell::new(State::Idle),
             buffer: TakeCell::new(buffer),
         }
@@ -224,9 +224,9 @@ impl Driver for LPS25HB<'_> {
     fn subscribe(
         &self,
         subscribe_num: usize,
-        callback: Callback,
+        callback: Upcall,
         _app_id: AppId,
-    ) -> Result<Callback, (Callback, ErrorCode)> {
+    ) -> Result<Upcall, (Upcall, ErrorCode)> {
         match subscribe_num {
             // Set a callback
             0 => Ok(self.callback.replace(callback)),

--- a/capsules/src/lsm303agr.rs
+++ b/capsules/src/lsm303agr.rs
@@ -85,7 +85,7 @@ use enum_primitive::enum_from_primitive;
 use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::hil::i2c::{self, Error};
 use kernel::hil::sensors;
-use kernel::{AppId, Upcall, CommandReturn, Driver, ErrorCode, ReturnCode};
+use kernel::{AppId, CommandReturn, Driver, ErrorCode, ReturnCode, Upcall};
 
 use crate::driver;
 use crate::lsm303xx::{

--- a/capsules/src/lsm303agr.rs
+++ b/capsules/src/lsm303agr.rs
@@ -85,7 +85,7 @@ use enum_primitive::enum_from_primitive;
 use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::hil::i2c::{self, Error};
 use kernel::hil::sensors;
-use kernel::{AppId, Callback, CommandReturn, Driver, ErrorCode, ReturnCode};
+use kernel::{AppId, Upcall, CommandReturn, Driver, ErrorCode, ReturnCode};
 
 use crate::driver;
 use crate::lsm303xx::{
@@ -137,7 +137,7 @@ pub struct Lsm303agrI2C<'a> {
     config_in_progress: Cell<bool>,
     i2c_accelerometer: &'a dyn i2c::I2CDevice,
     i2c_magnetometer: &'a dyn i2c::I2CDevice,
-    callback: Cell<Callback>,
+    callback: Cell<Upcall>,
     state: Cell<State>,
     accel_scale: Cell<Lsm303Scale>,
     mag_range: Cell<Lsm303Range>,
@@ -162,7 +162,7 @@ impl<'a> Lsm303agrI2C<'a> {
             config_in_progress: Cell::new(false),
             i2c_accelerometer: i2c_accelerometer,
             i2c_magnetometer: i2c_magnetometer,
-            callback: Cell::new(Callback::default()),
+            callback: Cell::new(Upcall::default()),
             state: Cell::new(State::Idle),
             accel_scale: Cell::new(Lsm303Scale::Scale2G),
             mag_range: Cell::new(Lsm303Range::Range1G),
@@ -596,9 +596,9 @@ impl Driver for Lsm303agrI2C<'_> {
     fn subscribe(
         &self,
         subscribe_num: usize,
-        callback: Callback,
+        callback: Upcall,
         _appid: AppId,
-    ) -> Result<Callback, (Callback, ErrorCode)> {
+    ) -> Result<Upcall, (Upcall, ErrorCode)> {
         match subscribe_num {
             0 /* set the one shot callback */ => {
                 Ok (self.callback.replace (callback))

--- a/capsules/src/lsm303dlhc.rs
+++ b/capsules/src/lsm303dlhc.rs
@@ -84,7 +84,7 @@ use enum_primitive::enum_from_primitive;
 use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::hil::i2c::{self, Error};
 use kernel::hil::sensors;
-use kernel::{AppId, Callback, CommandReturn, Driver, ErrorCode, ReturnCode};
+use kernel::{AppId, Upcall, CommandReturn, Driver, ErrorCode, ReturnCode};
 
 use crate::lsm303xx::{
     AccelerometerRegisters, Lsm303AccelDataRate, Lsm303MagnetoDataRate, Lsm303Range, Lsm303Scale,
@@ -134,7 +134,7 @@ pub struct Lsm303dlhcI2C<'a> {
     config_in_progress: Cell<bool>,
     i2c_accelerometer: &'a dyn i2c::I2CDevice,
     i2c_magnetometer: &'a dyn i2c::I2CDevice,
-    callback: Cell<Callback>,
+    callback: Cell<Upcall>,
     state: Cell<State>,
     accel_scale: Cell<Lsm303Scale>,
     mag_range: Cell<Lsm303Range>,
@@ -159,7 +159,7 @@ impl<'a> Lsm303dlhcI2C<'a> {
             config_in_progress: Cell::new(false),
             i2c_accelerometer: i2c_accelerometer,
             i2c_magnetometer: i2c_magnetometer,
-            callback: Cell::new(Callback::default()),
+            callback: Cell::new(Upcall::default()),
             state: Cell::new(State::Idle),
             accel_scale: Cell::new(Lsm303Scale::Scale2G),
             mag_range: Cell::new(Lsm303Range::Range1G),
@@ -608,9 +608,9 @@ impl Driver for Lsm303dlhcI2C<'_> {
     fn subscribe(
         &self,
         subscribe_num: usize,
-        callback: Callback,
+        callback: Upcall,
         _appid: AppId,
-    ) -> Result<Callback, (Callback, ErrorCode)> {
+    ) -> Result<Upcall, (Upcall, ErrorCode)> {
         match subscribe_num {
             0 /* set the one shot callback */ => {
                 Ok (self.callback.replace (callback))

--- a/capsules/src/lsm303dlhc.rs
+++ b/capsules/src/lsm303dlhc.rs
@@ -84,7 +84,7 @@ use enum_primitive::enum_from_primitive;
 use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::hil::i2c::{self, Error};
 use kernel::hil::sensors;
-use kernel::{AppId, Upcall, CommandReturn, Driver, ErrorCode, ReturnCode};
+use kernel::{AppId, CommandReturn, Driver, ErrorCode, ReturnCode, Upcall};
 
 use crate::lsm303xx::{
     AccelerometerRegisters, Lsm303AccelDataRate, Lsm303MagnetoDataRate, Lsm303Range, Lsm303Scale,

--- a/capsules/src/ltc294x.rs
+++ b/capsules/src/ltc294x.rs
@@ -50,7 +50,7 @@ use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::hil::gpio;
 use kernel::hil::i2c;
 use kernel::ReturnCode;
-use kernel::{AppId, Upcall, CommandReturn, Driver, ErrorCode};
+use kernel::{AppId, CommandReturn, Driver, ErrorCode, Upcall};
 
 /// Syscall driver number.
 use crate::driver;

--- a/capsules/src/ltc294x.rs
+++ b/capsules/src/ltc294x.rs
@@ -50,7 +50,7 @@ use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::hil::gpio;
 use kernel::hil::i2c;
 use kernel::ReturnCode;
-use kernel::{AppId, Callback, CommandReturn, Driver, ErrorCode};
+use kernel::{AppId, Upcall, CommandReturn, Driver, ErrorCode};
 
 /// Syscall driver number.
 use crate::driver;
@@ -407,14 +407,14 @@ impl gpio::Client for LTC294X<'_> {
 /// interface for providing access to applications.
 pub struct LTC294XDriver<'a> {
     ltc294x: &'a LTC294X<'a>,
-    callback: Cell<Callback>,
+    callback: Cell<Upcall>,
 }
 
 impl<'a> LTC294XDriver<'a> {
     pub fn new(ltc: &'a LTC294X<'a>) -> LTC294XDriver<'a> {
         LTC294XDriver {
             ltc294x: ltc,
-            callback: Cell::new(Callback::default()),
+            callback: Cell::new(Upcall::default()),
         }
     }
 }
@@ -476,9 +476,9 @@ impl Driver for LTC294XDriver<'_> {
     fn subscribe(
         &self,
         subscribe_num: usize,
-        callback: Callback,
+        callback: Upcall,
         _app_id: AppId,
-    ) -> Result<Callback, (Callback, ErrorCode)> {
+    ) -> Result<Upcall, (Upcall, ErrorCode)> {
         match subscribe_num {
             0 => Ok(self.callback.replace(callback)),
 

--- a/capsules/src/max17205.rs
+++ b/capsules/src/max17205.rs
@@ -40,7 +40,7 @@
 use core::cell::Cell;
 use kernel::common::cells::{MapCell, OptionalCell, TakeCell};
 use kernel::hil::i2c;
-use kernel::{AppId, Upcall, CommandReturn, Driver, ErrorCode, ReturnCode};
+use kernel::{AppId, CommandReturn, Driver, ErrorCode, ReturnCode, Upcall};
 
 /// Syscall driver number.
 use crate::driver;

--- a/capsules/src/max17205.rs
+++ b/capsules/src/max17205.rs
@@ -40,7 +40,7 @@
 use core::cell::Cell;
 use kernel::common::cells::{MapCell, OptionalCell, TakeCell};
 use kernel::hil::i2c;
-use kernel::{AppId, Callback, CommandReturn, Driver, ErrorCode, ReturnCode};
+use kernel::{AppId, Upcall, CommandReturn, Driver, ErrorCode, ReturnCode};
 
 /// Syscall driver number.
 use crate::driver;
@@ -361,14 +361,14 @@ impl i2c::I2CClient for MAX17205<'_> {
 
 pub struct MAX17205Driver<'a> {
     max17205: &'a MAX17205<'a>,
-    callback: MapCell<Callback>,
+    callback: MapCell<Upcall>,
 }
 
 impl<'a> MAX17205Driver<'a> {
     pub fn new(max: &'a MAX17205) -> MAX17205Driver<'a> {
         MAX17205Driver {
             max17205: max,
-            callback: MapCell::new(Callback::default()),
+            callback: MapCell::new(Upcall::default()),
         }
     }
 }
@@ -419,9 +419,9 @@ impl Driver for MAX17205Driver<'_> {
     fn subscribe(
         &self,
         subscribe_num: usize,
-        callback: Callback,
+        callback: Upcall,
         _app_id: AppId,
-    ) -> Result<Callback, (Callback, ErrorCode)> {
+    ) -> Result<Upcall, (Upcall, ErrorCode)> {
         match subscribe_num {
             0 => {
                 if let Some(prev) = self.callback.replace(callback) {
@@ -430,7 +430,7 @@ impl Driver for MAX17205Driver<'_> {
                     // TODO(alevy): This should never happen because we start with a full MapCell
                     // and only ever replace it. This is just defensive until this module becomes
                     // multi-user, which will preclude the need for a MapCell in the first place.
-                    Ok(Callback::default())
+                    Ok(Upcall::default())
                 }
             }
 

--- a/capsules/src/mlx90614.rs
+++ b/capsules/src/mlx90614.rs
@@ -22,7 +22,7 @@ use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::common::registers::register_bitfields;
 use kernel::hil::i2c::{self, Error};
 use kernel::hil::sensors;
-use kernel::{AppId, Upcall, CommandReturn, Driver, ErrorCode, ReturnCode};
+use kernel::{AppId, CommandReturn, Driver, ErrorCode, ReturnCode, Upcall};
 
 /// Syscall driver number.
 pub const DRIVER_NUM: usize = driver::NUM::Mlx90614 as usize;

--- a/capsules/src/mlx90614.rs
+++ b/capsules/src/mlx90614.rs
@@ -22,7 +22,7 @@ use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::common::registers::register_bitfields;
 use kernel::hil::i2c::{self, Error};
 use kernel::hil::sensors;
-use kernel::{AppId, Callback, CommandReturn, Driver, ErrorCode, ReturnCode};
+use kernel::{AppId, Upcall, CommandReturn, Driver, ErrorCode, ReturnCode};
 
 /// Syscall driver number.
 pub const DRIVER_NUM: usize = driver::NUM::Mlx90614 as usize;
@@ -58,7 +58,7 @@ enum_from_primitive! {
 
 pub struct Mlx90614SMBus<'a> {
     smbus_temp: &'a dyn i2c::SMBusDevice,
-    callback: Cell<Callback>,
+    callback: Cell<Upcall>,
     temperature_client: OptionalCell<&'a dyn sensors::TemperatureClient>,
     buffer: TakeCell<'static, [u8]>,
     state: Cell<State>,
@@ -71,7 +71,7 @@ impl<'a> Mlx90614SMBus<'_> {
     ) -> Mlx90614SMBus<'a> {
         Mlx90614SMBus {
             smbus_temp,
-            callback: Cell::new(Callback::default()),
+            callback: Cell::new(Upcall::default()),
             temperature_client: OptionalCell::empty(),
             buffer: TakeCell::new(buffer),
             state: Cell::new(State::Idle),
@@ -190,9 +190,9 @@ impl<'a> Driver for Mlx90614SMBus<'a> {
     fn subscribe(
         &self,
         subscribe_num: usize,
-        callback: Callback,
+        callback: Upcall,
         _app_id: AppId,
-    ) -> Result<Callback, (Callback, ErrorCode)> {
+    ) -> Result<Upcall, (Upcall, ErrorCode)> {
         match subscribe_num {
             0 /* set the one shot callback */ => {
                 Ok(self.callback.replace(callback))

--- a/capsules/src/net/udp/driver.rs
+++ b/capsules/src/net/udp/driver.rs
@@ -24,7 +24,7 @@ use kernel::capabilities::UdpDriverCapability;
 use kernel::common::cells::MapCell;
 use kernel::common::leasable_buffer::LeasableBuffer;
 use kernel::{
-    debug, AppId, Callback, CommandReturn, Driver, ErrorCode, Grant, Read, ReadOnlyAppSlice,
+    debug, AppId, Upcall, CommandReturn, Driver, ErrorCode, Grant, Read, ReadOnlyAppSlice,
     ReadWrite, ReadWriteAppSlice, ReturnCode,
 };
 
@@ -68,8 +68,8 @@ impl UDPEndpoint {
 
 #[derive(Default)]
 pub struct App {
-    rx_callback: Callback,
-    tx_callback: Callback,
+    rx_callback: Upcall,
+    tx_callback: Upcall,
     app_read: ReadWriteAppSlice,
     app_write: ReadOnlyAppSlice,
     app_cfg: ReadWriteAppSlice,
@@ -371,9 +371,9 @@ impl<'a> Driver for UDPDriver<'a> {
     fn subscribe(
         &self,
         subscribe_num: usize,
-        mut callback: Callback,
+        mut callback: Upcall,
         app_id: AppId,
-    ) -> Result<Callback, (Callback, ErrorCode)> {
+    ) -> Result<Upcall, (Upcall, ErrorCode)> {
         match subscribe_num {
             0 => {
                 let res = self.apps.enter(app_id, |app, _| {

--- a/capsules/src/net/udp/driver.rs
+++ b/capsules/src/net/udp/driver.rs
@@ -24,8 +24,8 @@ use kernel::capabilities::UdpDriverCapability;
 use kernel::common::cells::MapCell;
 use kernel::common::leasable_buffer::LeasableBuffer;
 use kernel::{
-    debug, AppId, Upcall, CommandReturn, Driver, ErrorCode, Grant, Read, ReadOnlyAppSlice,
-    ReadWrite, ReadWriteAppSlice, ReturnCode,
+    debug, AppId, CommandReturn, Driver, ErrorCode, Grant, Read, ReadOnlyAppSlice, ReadWrite,
+    ReadWriteAppSlice, ReturnCode, Upcall,
 };
 
 use crate::driver;

--- a/capsules/src/ninedof.rs
+++ b/capsules/src/ninedof.rs
@@ -22,7 +22,7 @@ use core::mem;
 use kernel::common::cells::OptionalCell;
 use kernel::hil;
 use kernel::ReturnCode;
-use kernel::{AppId, Upcall, CommandReturn, Driver, ErrorCode, Grant};
+use kernel::{AppId, CommandReturn, Driver, ErrorCode, Grant, Upcall};
 
 /// Syscall driver number.
 use crate::driver;

--- a/capsules/src/ninedof.rs
+++ b/capsules/src/ninedof.rs
@@ -22,7 +22,7 @@ use core::mem;
 use kernel::common::cells::OptionalCell;
 use kernel::hil;
 use kernel::ReturnCode;
-use kernel::{AppId, Callback, CommandReturn, Driver, ErrorCode, Grant};
+use kernel::{AppId, Upcall, CommandReturn, Driver, ErrorCode, Grant};
 
 /// Syscall driver number.
 use crate::driver;
@@ -37,7 +37,7 @@ pub enum NineDofCommand {
 }
 
 pub struct App {
-    callback: Callback,
+    callback: Upcall,
     pending_command: bool,
     command: NineDofCommand,
     arg1: usize,
@@ -46,7 +46,7 @@ pub struct App {
 impl Default for App {
     fn default() -> App {
         App {
-            callback: Callback::default(),
+            callback: Upcall::default(),
             pending_command: false,
             command: NineDofCommand::Exists,
             arg1: 0,
@@ -137,9 +137,9 @@ impl<'a> NineDof<'a> {
 
     fn configure_callback(
         &self,
-        mut callback: Callback,
+        mut callback: Upcall,
         app_id: AppId,
-    ) -> Result<Callback, (Callback, ErrorCode)> {
+    ) -> Result<Upcall, (Upcall, ErrorCode)> {
         let res = self
             .apps
             .enter(app_id, |app, _| {
@@ -202,9 +202,9 @@ impl Driver for NineDof<'_> {
     fn subscribe(
         &self,
         subscribe_num: usize,
-        callback: Callback,
+        callback: Upcall,
         app_id: AppId,
-    ) -> Result<Callback, (Callback, ErrorCode)> {
+    ) -> Result<Upcall, (Upcall, ErrorCode)> {
         match subscribe_num {
             0 => self.configure_callback(callback, app_id),
             _ => Err((callback, ErrorCode::NOSUPPORT)),

--- a/capsules/src/nonvolatile_storage_driver.rs
+++ b/capsules/src/nonvolatile_storage_driver.rs
@@ -61,7 +61,7 @@ use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::hil;
 use kernel::ErrorCode;
 use kernel::{
-    AppId, Callback, CommandReturn, Driver, Grant, Read, ReadOnlyAppSlice, ReadWrite,
+    AppId, Upcall, CommandReturn, Driver, Grant, Read, ReadOnlyAppSlice, ReadWrite,
     ReadWriteAppSlice,
 };
 
@@ -86,8 +86,8 @@ pub enum NonvolatileUser {
 }
 
 pub struct App {
-    callback_read: Callback,
-    callback_write: Callback,
+    callback_read: Upcall,
+    callback_write: Upcall,
     pending_command: bool,
     command: NonvolatileCommand,
     offset: usize,
@@ -99,8 +99,8 @@ pub struct App {
 impl Default for App {
     fn default() -> App {
         App {
-            callback_read: Callback::default(),
-            callback_write: Callback::default(),
+            callback_read: Upcall::default(),
+            callback_write: Upcall::default(),
             pending_command: false,
             command: NonvolatileCommand::UserspaceRead,
             offset: 0,
@@ -552,9 +552,9 @@ impl Driver for NonvolatileStorage<'_> {
     fn subscribe(
         &self,
         subscribe_num: usize,
-        mut callback: Callback,
+        mut callback: Upcall,
         app_id: AppId,
-    ) -> Result<Callback, (Callback, ErrorCode)> {
+    ) -> Result<Upcall, (Upcall, ErrorCode)> {
         let res = self
             .apps
             .enter(app_id, |app, _| match subscribe_num {

--- a/capsules/src/nonvolatile_storage_driver.rs
+++ b/capsules/src/nonvolatile_storage_driver.rs
@@ -61,8 +61,8 @@ use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::hil;
 use kernel::ErrorCode;
 use kernel::{
-    AppId, Upcall, CommandReturn, Driver, Grant, Read, ReadOnlyAppSlice, ReadWrite,
-    ReadWriteAppSlice,
+    AppId, CommandReturn, Driver, Grant, Read, ReadOnlyAppSlice, ReadWrite, ReadWriteAppSlice,
+    Upcall,
 };
 
 /// Syscall driver number.

--- a/capsules/src/nrf51822_serialization.rs
+++ b/capsules/src/nrf51822_serialization.rs
@@ -26,7 +26,7 @@ use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::hil;
 use kernel::hil::uart;
 use kernel::{
-    AppId, Callback, CommandReturn, Driver, ErrorCode, Grant, Read, ReadOnlyAppSlice, ReadWrite,
+    AppId, Upcall, CommandReturn, Driver, ErrorCode, Grant, Read, ReadOnlyAppSlice, ReadWrite,
     ReadWriteAppSlice, ReturnCode,
 };
 
@@ -36,7 +36,7 @@ pub const DRIVER_NUM: usize = driver::NUM::Nrf51822Serialization as usize;
 
 #[derive(Default)]
 pub struct App {
-    callback: Callback,
+    callback: Upcall,
     tx_buffer: ReadOnlyAppSlice,
     rx_buffer: ReadWriteAppSlice,
     rx_recv_so_far: usize, // How many RX bytes we have currently received.
@@ -182,9 +182,9 @@ impl Driver for Nrf51822Serialization<'_> {
     fn subscribe(
         &self,
         subscribe_type: usize,
-        mut callback: Callback,
+        mut callback: Upcall,
         appid: AppId,
-    ) -> Result<Callback, (Callback, ErrorCode)> {
+    ) -> Result<Upcall, (Upcall, ErrorCode)> {
         match subscribe_type {
             // Add a callback
             0 => {

--- a/capsules/src/nrf51822_serialization.rs
+++ b/capsules/src/nrf51822_serialization.rs
@@ -26,8 +26,8 @@ use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::hil;
 use kernel::hil::uart;
 use kernel::{
-    AppId, Upcall, CommandReturn, Driver, ErrorCode, Grant, Read, ReadOnlyAppSlice, ReadWrite,
-    ReadWriteAppSlice, ReturnCode,
+    AppId, CommandReturn, Driver, ErrorCode, Grant, Read, ReadOnlyAppSlice, ReadWrite,
+    ReadWriteAppSlice, ReturnCode, Upcall,
 };
 
 /// Syscall driver number.

--- a/capsules/src/pca9544a.rs
+++ b/capsules/src/pca9544a.rs
@@ -31,7 +31,7 @@
 use core::cell::Cell;
 use kernel::common::cells::{MapCell, TakeCell};
 use kernel::hil::i2c;
-use kernel::{AppId, Upcall, CommandReturn, Driver, ErrorCode};
+use kernel::{AppId, CommandReturn, Driver, ErrorCode, Upcall};
 
 /// Syscall driver number.
 use crate::driver;

--- a/capsules/src/pca9544a.rs
+++ b/capsules/src/pca9544a.rs
@@ -31,7 +31,7 @@
 use core::cell::Cell;
 use kernel::common::cells::{MapCell, TakeCell};
 use kernel::hil::i2c;
-use kernel::{AppId, Callback, CommandReturn, Driver, ErrorCode};
+use kernel::{AppId, Upcall, CommandReturn, Driver, ErrorCode};
 
 /// Syscall driver number.
 use crate::driver;
@@ -59,7 +59,7 @@ pub struct PCA9544A<'a> {
     i2c: &'a dyn i2c::I2CDevice,
     state: Cell<State>,
     buffer: TakeCell<'static, [u8]>,
-    callback: MapCell<Callback>,
+    callback: MapCell<Upcall>,
 }
 
 impl<'a> PCA9544A<'a> {
@@ -68,7 +68,7 @@ impl<'a> PCA9544A<'a> {
             i2c: i2c,
             state: Cell::new(State::Idle),
             buffer: TakeCell::new(buffer),
-            callback: MapCell::new(Callback::default()),
+            callback: MapCell::new(Upcall::default()),
         }
     }
 
@@ -157,20 +157,20 @@ impl Driver for PCA9544A<'_> {
     ///
     /// ### `subscribe_num`
     ///
-    /// - `0`: Callback is triggered when a channel is finished being selected
+    /// - `0`: Upcall is triggered when a channel is finished being selected
     ///   or when the current channel setup is returned.
     fn subscribe(
         &self,
         subscribe_num: usize,
-        callback: Callback,
+        callback: Upcall,
         _app_id: AppId,
-    ) -> Result<Callback, (Callback, ErrorCode)> {
+    ) -> Result<Upcall, (Upcall, ErrorCode)> {
         match subscribe_num {
             0 => {
                 if let Some(prev) = self.callback.replace(callback) {
                     Ok(prev)
                 } else {
-                    Ok(Callback::default())
+                    Ok(Upcall::default())
                 }
             }
 

--- a/capsules/src/process_console.rs
+++ b/capsules/src/process_console.rs
@@ -21,7 +21,7 @@
 //! - `Quanta`: How many times this process has exceeded its alloted time
 //!   quanta.
 //! - `Syscalls`: The number of system calls the process has made to the kernel.
-//! - `Dropped Callbacks`: How many callbacks were dropped for this process
+//! - `Dropped Upcalls`: How many callbacks were dropped for this process
 //!   because the queue was full.
 //! - `Restarts`: How many times this process has crashed and been restarted by
 //!   the kernel.
@@ -90,7 +90,7 @@
 //! Initialization complete. Entering main loop
 //! Hello World!
 //! list
-//! PID    Name    Quanta  Syscalls  Dropped Callbacks  Restarts    State  Grants
+//! PID    Name    Quanta  Syscalls  Dropped Upcalls  Restarts    State  Grants
 //! 00     blink        0       113                  0         0  Yielded    1/12
 //! 01     c_hello      0         8                  0         0  Yielded    3/12
 //! ```
@@ -254,7 +254,7 @@ impl<'a, C: ProcessManagementCapability> ProcessConsole<'a, C> {
                                 );
                             });
                         } else if clean_str.starts_with("list") {
-                            debug!(" PID    Name                Quanta  Syscalls  Dropped Callbacks  Restarts    State  Grants");
+                            debug!(" PID    Name                Quanta  Syscalls  Dropped Upcalls  Restarts    State  Grants");
                             self.kernel
                                 .process_each_capability(&self.capability, |proc| {
                                     let info: KernelInfo = KernelInfo::new(self.kernel);
@@ -269,7 +269,7 @@ impl<'a, C: ProcessManagementCapability> ProcessConsole<'a, C> {
                                         pname,
                                         proc.debug_timeslice_expiration_count(),
                                         proc.debug_syscall_count(),
-                                        proc.debug_dropped_callback_count(),
+                                        proc.debug_dropped_upcall_count(),
                                         proc.get_restart_count(),
                                         proc.get_state(),
                                         grants_used,

--- a/capsules/src/proximity.rs
+++ b/capsules/src/proximity.rs
@@ -52,7 +52,7 @@ use core::cell::Cell;
 use core::mem;
 use kernel::hil;
 use kernel::ReturnCode;
-use kernel::{AppId, Callback, CommandReturn, Driver, ErrorCode, Grant};
+use kernel::{AppId, Upcall, CommandReturn, Driver, ErrorCode, Grant};
 
 /// Syscall driver number.
 use crate::driver;
@@ -60,7 +60,7 @@ pub const DRIVER_NUM: usize = driver::NUM::Proximity as usize;
 
 #[derive(Default)]
 pub struct App {
-    callback: Callback,
+    callback: Upcall,
     subscribed: bool,
     enqueued_command_type: ProximityCommand,
     lower_proximity: u8,
@@ -263,7 +263,7 @@ impl hil::sensors::ProximityClient for ProximitySensor<'_> {
                         }
                     } else {
                         // Case: ReadProximity
-                        // Callback to all apps waiting on read_proximity.
+                        // Upcall to all apps waiting on read_proximity.
                         app.callback.schedule(temp_val as usize, 0, 0);
                         app.subscribed = false; // dequeue
                     }
@@ -283,9 +283,9 @@ impl Driver for ProximitySensor<'_> {
     fn subscribe(
         &self,
         subscribe_num: usize,
-        mut callback: Callback,
+        mut callback: Upcall,
         app_id: AppId,
-    ) -> Result<Callback, (Callback, ErrorCode)> {
+    ) -> Result<Upcall, (Upcall, ErrorCode)> {
         let res = match subscribe_num {
             0 => self
                 .apps
@@ -308,7 +308,7 @@ impl Driver for ProximitySensor<'_> {
             // Instantaneous proximity measurement
             1 => self.enqueue_command(ProximityCommand::ReadProximity, arg1, arg2, appid),
 
-            // Callback occurs only after interrupt is fired
+            // Upcall occurs only after interrupt is fired
             2 => self.enqueue_command(
                 ProximityCommand::ReadProximityOnInterrupt,
                 arg1,

--- a/capsules/src/proximity.rs
+++ b/capsules/src/proximity.rs
@@ -52,7 +52,7 @@ use core::cell::Cell;
 use core::mem;
 use kernel::hil;
 use kernel::ReturnCode;
-use kernel::{AppId, Upcall, CommandReturn, Driver, ErrorCode, Grant};
+use kernel::{AppId, CommandReturn, Driver, ErrorCode, Grant, Upcall};
 
 /// Syscall driver number.
 use crate::driver;

--- a/capsules/src/rng.rs
+++ b/capsules/src/rng.rs
@@ -28,8 +28,8 @@ use kernel::hil::entropy::{Entropy32, Entropy8};
 use kernel::hil::rng;
 use kernel::hil::rng::{Client, Continue, Random, Rng};
 use kernel::{
-    AppId, Upcall, CommandReturn, Driver, ErrorCode, Grant, ReadWrite, ReadWriteAppSlice,
-    ReturnCode,
+    AppId, CommandReturn, Driver, ErrorCode, Grant, ReadWrite, ReadWriteAppSlice, ReturnCode,
+    Upcall,
 };
 
 /// Syscall driver number.

--- a/capsules/src/rng.rs
+++ b/capsules/src/rng.rs
@@ -28,7 +28,7 @@ use kernel::hil::entropy::{Entropy32, Entropy8};
 use kernel::hil::rng;
 use kernel::hil::rng::{Client, Continue, Random, Rng};
 use kernel::{
-    AppId, Callback, CommandReturn, Driver, ErrorCode, Grant, ReadWrite, ReadWriteAppSlice,
+    AppId, Upcall, CommandReturn, Driver, ErrorCode, Grant, ReadWrite, ReadWriteAppSlice,
     ReturnCode,
 };
 
@@ -38,7 +38,7 @@ pub const DRIVER_NUM: usize = driver::NUM::Rng as usize;
 
 #[derive(Default)]
 pub struct App {
-    callback: Callback,
+    callback: Upcall,
     buffer: ReadWriteAppSlice,
     remaining: usize,
     idx: usize,
@@ -183,9 +183,9 @@ impl<'a> Driver for RngDriver<'a> {
     fn subscribe(
         &self,
         subscribe_num: usize,
-        mut callback: Callback,
+        mut callback: Upcall,
         app_id: AppId,
-    ) -> Result<Callback, (Callback, ErrorCode)> {
+    ) -> Result<Upcall, (Upcall, ErrorCode)> {
         let res = match subscribe_num {
             0 => self
                 .apps

--- a/capsules/src/screen.rs
+++ b/capsules/src/screen.rs
@@ -17,7 +17,7 @@ use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::hil;
 use kernel::hil::screen::{ScreenPixelFormat, ScreenRotation};
 use kernel::{
-    AppId, Upcall, CommandReturn, Driver, ErrorCode, Grant, Read, ReadOnlyAppSlice, ReturnCode,
+    AppId, CommandReturn, Driver, ErrorCode, Grant, Read, ReadOnlyAppSlice, ReturnCode, Upcall,
 };
 
 /// Syscall driver number.

--- a/capsules/src/screen.rs
+++ b/capsules/src/screen.rs
@@ -17,7 +17,7 @@ use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::hil;
 use kernel::hil::screen::{ScreenPixelFormat, ScreenRotation};
 use kernel::{
-    AppId, Callback, CommandReturn, Driver, ErrorCode, Grant, Read, ReadOnlyAppSlice, ReturnCode,
+    AppId, Upcall, CommandReturn, Driver, ErrorCode, Grant, Read, ReadOnlyAppSlice, ReturnCode,
 };
 
 /// Syscall driver number.
@@ -76,7 +76,7 @@ fn pixels_in_bytes(pixels: usize, bits_per_pixel: usize) -> usize {
 }
 
 pub struct App {
-    callback: Callback,
+    callback: Upcall,
     pending_command: bool,
     shared: ReadOnlyAppSlice,
     write_position: usize,
@@ -93,7 +93,7 @@ pub struct App {
 impl Default for App {
     fn default() -> App {
         App {
-            callback: Callback::default(),
+            callback: Upcall::default(),
             pending_command: false,
             shared: ReadOnlyAppSlice::default(),
             command: ScreenCommand::Nop,
@@ -504,9 +504,9 @@ impl<'a> Driver for Screen<'a> {
     fn subscribe(
         &self,
         subscribe_num: usize,
-        mut callback: Callback,
+        mut callback: Upcall,
         app_id: AppId,
-    ) -> Result<Callback, (Callback, ErrorCode)> {
+    ) -> Result<Upcall, (Upcall, ErrorCode)> {
         let res = match subscribe_num {
             0 => self
                 .apps

--- a/capsules/src/sdcard.rs
+++ b/capsules/src/sdcard.rs
@@ -46,7 +46,7 @@ use core::mem;
 
 use kernel::common::cells::{MapCell, OptionalCell, TakeCell};
 use kernel::hil;
-use kernel::{AppId, Upcall, CommandReturn, Driver};
+use kernel::{AppId, CommandReturn, Driver, Upcall};
 use kernel::{ErrorCode, ReturnCode};
 use kernel::{Read, ReadOnlyAppSlice, ReadWrite, ReadWriteAppSlice};
 

--- a/capsules/src/sdcard.rs
+++ b/capsules/src/sdcard.rs
@@ -46,7 +46,7 @@ use core::mem;
 
 use kernel::common::cells::{MapCell, OptionalCell, TakeCell};
 use kernel::hil;
-use kernel::{AppId, Callback, CommandReturn, Driver};
+use kernel::{AppId, Upcall, CommandReturn, Driver};
 use kernel::{ErrorCode, ReturnCode};
 use kernel::{Read, ReadOnlyAppSlice, ReadWrite, ReadWriteAppSlice};
 
@@ -1395,7 +1395,7 @@ pub struct SDCardDriver<'a, A: hil::time::Alarm<'a>> {
 /// Holds buffers and whatnot that the application has passed us.
 #[derive(Default)]
 struct App {
-    callback: Callback,
+    callback: Upcall,
     write_buffer: ReadOnlyAppSlice,
     read_buffer: ReadWriteAppSlice,
 }
@@ -1520,9 +1520,9 @@ impl<'a, A: hil::time::Alarm<'a>> Driver for SDCardDriver<'a, A> {
     fn subscribe(
         &self,
         subscribe_num: usize,
-        mut callback: Callback,
+        mut callback: Upcall,
         _app_id: AppId,
-    ) -> Result<Callback, (Callback, ErrorCode)> {
+    ) -> Result<Upcall, (Upcall, ErrorCode)> {
         match subscribe_num {
             // Set callback
             0 => {

--- a/capsules/src/sound_pressure.rs
+++ b/capsules/src/sound_pressure.rs
@@ -57,7 +57,7 @@ use core::convert::TryFrom;
 use core::mem;
 use kernel::hil;
 use kernel::ReturnCode;
-use kernel::{AppId, Callback, CommandReturn, Driver, ErrorCode, Grant};
+use kernel::{AppId, Upcall, CommandReturn, Driver, ErrorCode, Grant};
 
 /// Syscall driver number.
 use crate::driver;
@@ -65,7 +65,7 @@ pub const DRIVER_NUM: usize = driver::NUM::SoundPressure as usize;
 
 #[derive(Default)]
 pub struct App {
-    callback: Callback,
+    callback: Upcall,
     subscribed: bool,
     enable: bool,
 }
@@ -144,9 +144,9 @@ impl Driver for SoundPressureSensor<'_> {
     fn subscribe(
         &self,
         subscribe_num: usize,
-        mut callback: Callback,
+        mut callback: Upcall,
         app_id: AppId,
-    ) -> Result<Callback, (Callback, ErrorCode)> {
+    ) -> Result<Upcall, (Upcall, ErrorCode)> {
         match subscribe_num {
             // subscribe to sound_pressure reading with callback
             0 => {

--- a/capsules/src/sound_pressure.rs
+++ b/capsules/src/sound_pressure.rs
@@ -57,7 +57,7 @@ use core::convert::TryFrom;
 use core::mem;
 use kernel::hil;
 use kernel::ReturnCode;
-use kernel::{AppId, Upcall, CommandReturn, Driver, ErrorCode, Grant};
+use kernel::{AppId, CommandReturn, Driver, ErrorCode, Grant, Upcall};
 
 /// Syscall driver number.
 use crate::driver;

--- a/capsules/src/spi_controller.rs
+++ b/capsules/src/spi_controller.rs
@@ -7,7 +7,7 @@ use kernel::common::cells::{MapCell, TakeCell};
 use kernel::hil::spi::ClockPhase;
 use kernel::hil::spi::ClockPolarity;
 use kernel::hil::spi::{SpiMasterClient, SpiMasterDevice};
-use kernel::{AppId, Upcall, CommandReturn, Driver, ErrorCode};
+use kernel::{AppId, CommandReturn, Driver, ErrorCode, Upcall};
 use kernel::{Read, ReadOnlyAppSlice, ReadWrite, ReadWriteAppSlice};
 
 /// Syscall driver number.

--- a/capsules/src/spi_controller.rs
+++ b/capsules/src/spi_controller.rs
@@ -7,7 +7,7 @@ use kernel::common::cells::{MapCell, TakeCell};
 use kernel::hil::spi::ClockPhase;
 use kernel::hil::spi::ClockPolarity;
 use kernel::hil::spi::{SpiMasterClient, SpiMasterDevice};
-use kernel::{AppId, Callback, CommandReturn, Driver, ErrorCode};
+use kernel::{AppId, Upcall, CommandReturn, Driver, ErrorCode};
 use kernel::{Read, ReadOnlyAppSlice, ReadWrite, ReadWriteAppSlice};
 
 /// Syscall driver number.
@@ -29,7 +29,7 @@ pub const DEFAULT_WRITE_BUF_LENGTH: usize = 1024;
 
 #[derive(Default)]
 struct App {
-    callback: Callback,
+    callback: Upcall,
     app_read: ReadWriteAppSlice,
     app_write: ReadOnlyAppSlice,
     len: usize,
@@ -130,9 +130,9 @@ impl<'a, S: SpiMasterDevice> Driver for Spi<'a, S> {
     fn subscribe(
         &self,
         subscribe_num: usize,
-        mut callback: Callback,
+        mut callback: Upcall,
         _app_id: AppId,
-    ) -> Result<Callback, (Callback, ErrorCode)> {
+    ) -> Result<Upcall, (Upcall, ErrorCode)> {
         match subscribe_num {
             0 => {
                 self.app.map(|app| {

--- a/capsules/src/spi_peripheral.rs
+++ b/capsules/src/spi_peripheral.rs
@@ -9,7 +9,7 @@ use kernel::common::cells::{MapCell, TakeCell};
 use kernel::hil::spi::ClockPhase;
 use kernel::hil::spi::ClockPolarity;
 use kernel::hil::spi::{SpiSlaveClient, SpiSlaveDevice};
-use kernel::{AppId, Callback, CommandReturn, Driver, ErrorCode};
+use kernel::{AppId, Upcall, CommandReturn, Driver, ErrorCode};
 use kernel::{Read, ReadOnlyAppSlice, ReadWrite, ReadWriteAppSlice};
 
 /// Syscall driver number.
@@ -25,8 +25,8 @@ pub const DEFAULT_WRITE_BUF_LENGTH: usize = 1024;
 // that includes this new callback field.
 #[derive(Default)]
 struct PeripheralApp {
-    callback: Callback,
-    selected_callback: Callback,
+    callback: Upcall,
+    selected_callback: Upcall,
     app_read: ReadWriteAppSlice,
     app_write: ReadOnlyAppSlice,
     len: usize,
@@ -143,9 +143,9 @@ impl<S: SpiSlaveDevice> Driver for SpiPeripheral<'_, S> {
     fn subscribe(
         &self,
         subscribe_num: usize,
-        mut callback: Callback,
+        mut callback: Upcall,
         _app_id: AppId,
-    ) -> Result<Callback, (Callback, ErrorCode)> {
+    ) -> Result<Upcall, (Upcall, ErrorCode)> {
         match subscribe_num {
             0 /* read_write */ => {
                 self.app.map(|app| {

--- a/capsules/src/spi_peripheral.rs
+++ b/capsules/src/spi_peripheral.rs
@@ -9,7 +9,7 @@ use kernel::common::cells::{MapCell, TakeCell};
 use kernel::hil::spi::ClockPhase;
 use kernel::hil::spi::ClockPolarity;
 use kernel::hil::spi::{SpiSlaveClient, SpiSlaveDevice};
-use kernel::{AppId, Upcall, CommandReturn, Driver, ErrorCode};
+use kernel::{AppId, CommandReturn, Driver, ErrorCode, Upcall};
 use kernel::{Read, ReadOnlyAppSlice, ReadWrite, ReadWriteAppSlice};
 
 /// Syscall driver number.

--- a/capsules/src/temperature.rs
+++ b/capsules/src/temperature.rs
@@ -56,7 +56,7 @@ use core::cell::Cell;
 use core::convert::TryFrom;
 use core::mem;
 use kernel::hil;
-use kernel::{AppId, Upcall, CommandReturn, Driver, ErrorCode, Grant};
+use kernel::{AppId, CommandReturn, Driver, ErrorCode, Grant, Upcall};
 
 /// Syscall driver number.
 use crate::driver;

--- a/capsules/src/temperature.rs
+++ b/capsules/src/temperature.rs
@@ -56,7 +56,7 @@ use core::cell::Cell;
 use core::convert::TryFrom;
 use core::mem;
 use kernel::hil;
-use kernel::{AppId, Callback, CommandReturn, Driver, ErrorCode, Grant};
+use kernel::{AppId, Upcall, CommandReturn, Driver, ErrorCode, Grant};
 
 /// Syscall driver number.
 use crate::driver;
@@ -64,7 +64,7 @@ pub const DRIVER_NUM: usize = driver::NUM::Temperature as usize;
 
 #[derive(Default)]
 pub struct App {
-    callback: Callback,
+    callback: Upcall,
     subscribed: bool,
 }
 
@@ -107,9 +107,9 @@ impl<'a> TemperatureSensor<'a> {
 
     fn configure_callback(
         &self,
-        mut callback: Callback,
+        mut callback: Upcall,
         app_id: AppId,
-    ) -> Result<Callback, (Callback, ErrorCode)> {
+    ) -> Result<Upcall, (Upcall, ErrorCode)> {
         let res = self
             .apps
             .enter(app_id, |app, _| {
@@ -142,9 +142,9 @@ impl Driver for TemperatureSensor<'_> {
     fn subscribe(
         &self,
         subscribe_num: usize,
-        callback: Callback,
+        callback: Upcall,
         app_id: AppId,
-    ) -> Result<Callback, (Callback, ErrorCode)> {
+    ) -> Result<Upcall, (Upcall, ErrorCode)> {
         match subscribe_num {
             // subscribe to temperature reading with callback
             0 => self.configure_callback(callback, app_id),

--- a/capsules/src/text_screen.rs
+++ b/capsules/src/text_screen.rs
@@ -16,7 +16,7 @@ use core::{cmp, mem};
 use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::hil;
 use kernel::ReturnCode;
-use kernel::{AppId, Upcall, CommandReturn, Driver, ErrorCode, Grant, Read, ReadOnlyAppSlice};
+use kernel::{AppId, CommandReturn, Driver, ErrorCode, Grant, Read, ReadOnlyAppSlice, Upcall};
 
 /// Syscall driver number.
 use crate::driver;

--- a/capsules/src/text_screen.rs
+++ b/capsules/src/text_screen.rs
@@ -16,7 +16,7 @@ use core::{cmp, mem};
 use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::hil;
 use kernel::ReturnCode;
-use kernel::{AppId, Callback, CommandReturn, Driver, ErrorCode, Grant, Read, ReadOnlyAppSlice};
+use kernel::{AppId, Upcall, CommandReturn, Driver, ErrorCode, Grant, Read, ReadOnlyAppSlice};
 
 /// Syscall driver number.
 use crate::driver;
@@ -39,7 +39,7 @@ enum TextScreenCommand {
 }
 
 pub struct App {
-    callback: Callback,
+    callback: Upcall,
     pending_command: bool,
     shared: ReadOnlyAppSlice,
     write_position: usize,
@@ -52,7 +52,7 @@ pub struct App {
 impl Default for App {
     fn default() -> App {
         App {
-            callback: Callback::default(),
+            callback: Upcall::default(),
             pending_command: false,
             shared: ReadOnlyAppSlice::default(),
             write_position: 0,
@@ -213,9 +213,9 @@ impl<'a> Driver for TextScreen<'a> {
     fn subscribe(
         &self,
         subscribe_num: usize,
-        mut callback: Callback,
+        mut callback: Upcall,
         app_id: AppId,
-    ) -> Result<Callback, (Callback, ErrorCode)> {
+    ) -> Result<Upcall, (Upcall, ErrorCode)> {
         match subscribe_num {
             0 => {
                 let res = self

--- a/capsules/src/touch.rs
+++ b/capsules/src/touch.rs
@@ -18,7 +18,7 @@ use kernel::hil::screen::ScreenRotation;
 use kernel::hil::touch::{GestureEvent, TouchEvent, TouchStatus};
 use kernel::ReturnCode;
 use kernel::{
-    AppId, Callback, CommandReturn, Driver, ErrorCode, Grant, ReadWrite, ReadWriteAppSlice,
+    AppId, Upcall, CommandReturn, Driver, ErrorCode, Grant, ReadWrite, ReadWriteAppSlice,
 };
 
 /// Syscall driver number.
@@ -35,9 +35,9 @@ fn touch_status_to_number(status: &TouchStatus) -> usize {
 }
 
 pub struct App {
-    touch_callback: Callback,
-    gesture_callback: Callback,
-    multi_touch_callback: Callback,
+    touch_callback: Upcall,
+    gesture_callback: Upcall,
+    multi_touch_callback: Upcall,
     events_buffer: ReadWriteAppSlice,
     ack: bool,
     dropped_events: usize,
@@ -51,9 +51,9 @@ pub struct App {
 impl Default for App {
     fn default() -> App {
         App {
-            touch_callback: Callback::default(),
-            gesture_callback: Callback::default(),
-            multi_touch_callback: Callback::default(),
+            touch_callback: Upcall::default(),
+            gesture_callback: Upcall::default(),
+            multi_touch_callback: Upcall::default(),
             events_buffer: ReadWriteAppSlice::default(),
             ack: true,
             dropped_events: 0,
@@ -325,9 +325,9 @@ impl<'a> Driver for Touch<'a> {
     fn subscribe(
         &self,
         subscribe_num: usize,
-        mut callback: Callback,
+        mut callback: Upcall,
         app_id: AppId,
-    ) -> Result<Callback, (Callback, ErrorCode)> {
+    ) -> Result<Upcall, (Upcall, ErrorCode)> {
         let res = match subscribe_num {
             // subscribe to touch
             0 => {

--- a/capsules/src/touch.rs
+++ b/capsules/src/touch.rs
@@ -18,7 +18,7 @@ use kernel::hil::screen::ScreenRotation;
 use kernel::hil::touch::{GestureEvent, TouchEvent, TouchStatus};
 use kernel::ReturnCode;
 use kernel::{
-    AppId, Upcall, CommandReturn, Driver, ErrorCode, Grant, ReadWrite, ReadWriteAppSlice,
+    AppId, CommandReturn, Driver, ErrorCode, Grant, ReadWrite, ReadWriteAppSlice, Upcall,
 };
 
 /// Syscall driver number.

--- a/capsules/src/tsl2561.rs
+++ b/capsules/src/tsl2561.rs
@@ -17,7 +17,7 @@ use core::cell::Cell;
 use kernel::common::cells::TakeCell;
 use kernel::hil::gpio;
 use kernel::hil::i2c;
-use kernel::{AppId, Upcall, CommandReturn, Driver, ErrorCode};
+use kernel::{AppId, CommandReturn, Driver, ErrorCode, Upcall};
 
 /// Syscall driver number.
 use crate::driver;

--- a/capsules/src/tsl2561.rs
+++ b/capsules/src/tsl2561.rs
@@ -17,7 +17,7 @@ use core::cell::Cell;
 use kernel::common::cells::TakeCell;
 use kernel::hil::gpio;
 use kernel::hil::i2c;
-use kernel::{AppId, Callback, CommandReturn, Driver, ErrorCode};
+use kernel::{AppId, Upcall, CommandReturn, Driver, ErrorCode};
 
 /// Syscall driver number.
 use crate::driver;
@@ -204,7 +204,7 @@ enum State {
 pub struct TSL2561<'a> {
     i2c: &'a dyn i2c::I2CDevice,
     interrupt_pin: &'a dyn gpio::InterruptPin<'a>,
-    callback: Cell<Callback>,
+    callback: Cell<Upcall>,
     state: Cell<State>,
     buffer: TakeCell<'static, [u8]>,
 }
@@ -219,7 +219,7 @@ impl<'a> TSL2561<'a> {
         TSL2561 {
             i2c: i2c,
             interrupt_pin: interrupt_pin,
-            callback: Cell::new(Callback::default()),
+            callback: Cell::new(Upcall::default()),
             state: Cell::new(State::Idle),
             buffer: TakeCell::new(buffer),
         }
@@ -440,9 +440,9 @@ impl Driver for TSL2561<'_> {
     fn subscribe(
         &self,
         subscribe_num: usize,
-        callback: Callback,
+        callback: Upcall,
         _app_id: AppId,
-    ) -> Result<Callback, (Callback, ErrorCode)> {
+    ) -> Result<Upcall, (Upcall, ErrorCode)> {
         match subscribe_num {
             0 => Ok(self.callback.replace(callback)),
 

--- a/capsules/src/usb/usb_user.rs
+++ b/capsules/src/usb/usb_user.rs
@@ -29,7 +29,7 @@
 use core::mem;
 use kernel::common::cells::OptionalCell;
 use kernel::hil;
-use kernel::{AppId, Upcall, CommandReturn, Driver, ErrorCode, Grant};
+use kernel::{AppId, CommandReturn, Driver, ErrorCode, Grant, Upcall};
 
 use crate::driver;
 pub const DRIVER_NUM: usize = driver::NUM::UsbUser as usize;

--- a/capsules/src/usb/usb_user.rs
+++ b/capsules/src/usb/usb_user.rs
@@ -29,14 +29,14 @@
 use core::mem;
 use kernel::common::cells::OptionalCell;
 use kernel::hil;
-use kernel::{AppId, Callback, CommandReturn, Driver, ErrorCode, Grant};
+use kernel::{AppId, Upcall, CommandReturn, Driver, ErrorCode, Grant};
 
 use crate::driver;
 pub const DRIVER_NUM: usize = driver::NUM::UsbUser as usize;
 
 #[derive(Default)]
 pub struct App {
-    callback: Callback,
+    callback: Upcall,
     awaiting: Option<Request>,
 }
 
@@ -106,9 +106,9 @@ where
     fn subscribe(
         &self,
         subscribe_num: usize,
-        mut callback: Callback,
+        mut callback: Upcall,
         app_id: AppId,
-    ) -> Result<Callback, (Callback, ErrorCode)> {
+    ) -> Result<Upcall, (Upcall, ErrorCode)> {
         let res = match subscribe_num {
             // Set callback for result
             0 => self

--- a/chips/litex/src/timer.rs
+++ b/chips/litex/src/timer.rs
@@ -375,7 +375,7 @@ impl<'t, 'c, R: LiteXSoCRegisterConfiguration, F: Frequency> LiteXAlarm<'t, 'c, 
         self.timer.set_timer_client(self);
     }
 
-    fn timer_tick(&self, is_upcall: bool) {
+    fn timer_tick(&self, is_callback: bool) {
         // Check whether we've already reached the alarm time,
         // otherwise set the timer to the difference or the max value
         // respectively
@@ -392,10 +392,10 @@ impl<'t, 'c, R: LiteXSoCRegisterConfiguration, F: Frequency> LiteXAlarm<'t, 'c, 
         if !self.now().within_range(reference, alarm_time) {
             // It's time, ring the alarm
 
-            // Make sure we're in an upcall, otherwise set the timer
+            // Make sure we're in an callback, otherwise set the timer
             // to a very small value to trigger a Timer interrupt
             // immediately
-            if is_upcall {
+            if is_callback {
                 // Reset the alarm to 0
                 self.alarm_time.clear();
 
@@ -452,7 +452,7 @@ impl<'t, 'c, R: LiteXSoCRegisterConfiguration, F: Frequency> Alarm<'c>
         self.reference_time.set(reference);
         self.alarm_time.set(reference.wrapping_add(dt));
 
-        // Set the underlying timer at least once (`is_upcall =
+        // Set the underlying timer at least once (`is_callback =
         // false`) to trigger a callback to the client in a different
         // call stack
         self.timer_tick(false);

--- a/chips/litex/src/uart.rs
+++ b/chips/litex/src/uart.rs
@@ -237,7 +237,7 @@ impl<'a, R: LiteXSoCRegisterConfiguration> LiteXUart<'a, R> {
 
     // This is either called as a deferred call or by a
     // hardware-generated interrupt, hence it is guaranteed to be an
-    // upcall
+    // callback
     fn resume_tx(&self) {
         let len = self.tx_len.get();
         let mut progress = self.tx_progress.get();
@@ -344,12 +344,12 @@ impl<'a, R: LiteXSoCRegisterConfiguration> uart::Transmit<'a> for LiteXUart<'a, 
         //
         // If it does not fill the FIFO, an
         // interrupt will _not_ be generated and hence we have to
-        // perform the upcall using a deferred call.
+        // perform the callback using a deferred call.
         //
         // If we fill up the FIFO, an interrupt _will_ be
         // generated. We can transmit the rest using `resume_tx` and
         // directly call the callback there, as we are guaranteed to
-        // be in an upcall.
+        // be in a callback.
         let mut fifo_full: bool;
         let mut progress: usize = 0;
         while {
@@ -370,7 +370,7 @@ impl<'a, R: LiteXSoCRegisterConfiguration> uart::Transmit<'a> for LiteXUart<'a, 
         // _must_ have been written to the device
         //
         // In this case, we must request a deferred call for the
-        // upcall
+        // callback
         if !fifo_full {
             assert!(progress == tx_len);
 

--- a/doc/Userland.md
+++ b/doc/Userland.md
@@ -11,7 +11,7 @@ of how applications function.
 
 - [Overview of Processes in Tock](#overview-of-processes-in-tock)
 - [System Calls](#system-calls)
-- [Callbacks](#callbacks)
+- [Upcalls and Termination](#upcalls-and-termination)
 - [Inter-Process Communication](#inter-process-communication)
   * [Services](#services)
   * [Clients](#clients)

--- a/doc/Userland.md
+++ b/doc/Userland.md
@@ -2,14 +2,14 @@ Userland
 ========
 
 This document explains how application code works in Tock. This is not a guide
-to creating your own applications, but rather documentation of the design
-thoughts behind how applications function.
+to writing  applications, but rather documentation of the overall design
+of how applications function.
 
 <!-- npm i -g markdown-toc; markdown-toc -i Userland.md -->
 
 <!-- toc -->
 
-- [Overview of Applications in Tock](#overview-of-applications-in-tock)
+- [Overview of Processes in Tock](#overview-of-processes-in-tock)
 - [System Calls](#system-calls)
 - [Callbacks](#callbacks)
 - [Inter-Process Communication](#inter-process-communication)
@@ -22,40 +22,59 @@ thoughts behind how applications function.
 
 <!-- tocstop -->
 
-## Overview of Applications in Tock
+## Overview of Processes in Tock
 
-Applications in Tock are the user-level code meant to accomplish some type of
-task for the end user. Applications are distinguished from kernel code which
-handles device drivers, chip-specific details, and general operating system
-tasks. Unlike many existing embedded operating systems, in Tock applications
-are not compiled with the kernel. Instead they are entirely separate code
-that interact with the kernel and each other through [system
-calls](https://en.wikipedia.org/wiki/System_call).
+Processes in Tock run application code meant to accomplish some type
+of task for the end user. Processes run in user mode. Unlike kernel
+code, which runs in supervisor mode and handles device drivers,
+chip-specific details, as well as general operating system tasks,
+appliction code running in processes is independent of the details of
+the underlying hardware (except the instruction set
+architecture). Unlike many existing embedded operating systems, in
+Tock processes are not compiled with the kernel. Instead they are
+entirely separate code that interact with the kernel and each other
+through [system calls](https://en.wikipedia.org/wiki/System_call).
 
-Since applications are not a part of the kernel, they may be written in any
-language that can be compiled into code capable of running on a microcontroller.
-Tock supports running multiple applications concurrently. Co-operatively
-multiprogramming is the default, but applications may also be time sliced.
-Applications may talk to each other via Inter-Process Communication (IPC)
+Since processes are not a part of the kernel, application code running
+in a process may be written in any language that can be compiled into
+code capable of running on a microcontroller.  Tock supports running
+multiple processes concurrently. Co-operatively multiprogramming is
+the default, but processes may also be time sliced.  Processes may
+share data with each other via Inter-Process Communication (IPC)
 through system calls.
 
-Applications do not have compile-time knowledge of the address at which they
-will be installed and loaded. In the current design of Tock, applications must
-be compiled as [position independent
-code](https://en.wikipedia.org/wiki/Position-independent_code) (PIC). This
-allows them to be run from any address they happen to be loaded into. The use
-of PIC for Tock apps is not a fundamental choice, future versions of the system
-may support run-time relocatable code.
+Processes run code in unprivileged code (e.g., user mode on CortexM or
+RV32I microcontrollers). The Tock kernel uses hardware memory
+protection (an MPU on CortexM and a PMP on RV32I) to restrict which
+addresses application code running in a process can access. A process
+makes system calls to access hardware peripherals or modify what
+memory is accessible to it.
 
-Applications are unprivileged code. They may not access all portions of memory
-and will fault if they attempt to access memory outside of their boundaries
-(similarly to segmentation faults in Linux code). To interact with hardware,
-applications must make calls to the kernel.
+Tock supports dynamically loading and unloading independently compiled
+applications. In this setting, applications not not know at compile
+time what address they will be installed at and loaded from. To be 
+dynamically loadable, application code must be compiled as [position
+independent
+code](https://en.wikipedia.org/wiki/Position-independent_code)
+(PIC). This allows them to be run from any address they happen to be
+loaded into. 
+
+In some cases, applications may know their location at compile-time. This
+happens, for example, in cases where the kernel and applications are combined
+into a single cryptographically signed binary that is accepted by 
+a secure bootloader. In these cases, compiling an application with
+explicit addresses works.
+
+Tock supports running multiple processes at the same time. The maximum
+number of processes supported by the kernel is typically a compile-time
+constant in the range of 2-4, but is limited only by the available RAM
+and Flash resources of the chip. Tock scheduling generally assumes that
+it is a small number (e.g., uses O(n) scheduling algorithms).
 
 
 ## System Calls
 
-System calls (aka syscalls) are used to send commands to the kernel. These
+System calls are how processes and the kernel share data and interact. These
 could include commands to drivers, subscriptions to callbacks, granting of
 memory to the kernel so it can store data related to the application,
 communication with other application code, and many others. In practice,
@@ -80,41 +99,66 @@ command(uint32_t driver, uint32_t command, int data) {
 }
 ```
 
-A more in-depth discussion can be found in the [system call
-documentation](./Syscalls.md).
+A detailed description of Tock's system call API and ABI can be found in
+[TRD104](reference/trd-syscalls.md). The [system call
+documentation](./Syscalls.md) describes how the are implemented in the
+kernel.
 
 
-## Callbacks
+## Upcalls and Termination
 
-Tock is designed to support embedded applications, which often handle
-asynchronous events through the use of [callback
-functions](https://en.wikipedia.org/wiki/Callback_(computer_programming)). For
-example, in order to receive timer callbacks, you first call `timer_subscribe`
-with a function pointer to your own function that you want called when the
-timer fires. Specific state that you want the callback to act upon can be
-passed as the pointer `userdata`. After the application has started the timer,
-calls `yield`, and the timer fires, the callback function will be called.
+The Tock kernel is completely non-blocking, and it pushes this 
+asynchronous behavior to userspace code. This means that system calls
+(with one exception) do not block. Instead, they always return very quickly.
+Long-running operations (e.g., sending data over a bus, samping a sensor)
+signal their completion to userspace through upcalls. An upcall is a function 
+call the kernel makes on userspace code.
 
-It is important to note that `yield` must be called for events to be serviced in
-the current implementation of Tock. Callbacks to the application will be queued
-when they occur but the application will not receive them until it yields. This
-is not fundamental to Tock, and future version may service callbacks on any
-system call or when performing application time slicing. After receiving and
-running the callback, application code will continue after the `yield`.
-Applications which are "finished" (i.e. have returned from `main()`) should call
-`yield` in a loop to avoid being scheduled by the kernel.
+Yield system calls are the exception to this non-blocking rule. The yield-wait 
+system call blocks until the kernel invokes an upcall on the process. 
+The kernel only invokes upcalls when a process issues the yield system call:
+it does not invoke upcalls at arbitrary points in the program.
 
+For example, consider the case of when a process wants to sleep for 100 
+milliseconds. The timer library might break this into three operations:
+
+1. It registers an upcall for the timer system call driver with a Subscribe
+system call.
+2. It tells the timer system call driver to issue an upcall in 100 
+milliseconds by invoking a Command system call.
+3. It calls the yield-wait system call. This causes the process to block
+until the timer upcall executes. The kernel pushes a stack frame onto
+the process to execute the upcall; this function call returns to the
+instruction after yield was invoked.
+
+When a process registers an upcall with a call to a Subcribe system call,
+it may pass a pointer `userdata`. The kernel does not access or use this
+data: it simply passes it back on each invocation of the upcall. This
+allows a process to register the same function as multiple upcalls, and
+distinguish them by the data passed in the argument.
+
+It is important to note that upcalls are not executed until a process
+calls `yield`. The kernel will enqueue upcalls as events occur within
+the kernel, but the application will not handle them until it yields.
+
+Applications which are "finished" (i.e. have returned from `main()`)
+should call an Exit system call. There are two variants of Exit:
+exit-terminate and exit-restart. They differ in what they signal to
+the kernel: does the application wish to stop running, or be rebooted?
 
 ## Inter-Process Communication
 
-IPC allows for multiple applications to communicate directly through shared
-buffers. IPC in Tock is implemented with a service-client model. Each app can
-support one service and the service is identified by its package name which is
-included in the Tock Binary Format Header for the app. An app can communicate
-with multiple services and will get a unique handle for each discovered service.
-Clients and services communicate through shared buffers. Each client can share
-some of its own application memory with the service and then notify the service
-to instruct it to parse the shared buffer.
+inter-process communication (IPC) allows for separate processes to
+communicate directly through shared buffers. IPC in Tock is
+implemented with a service-client model. Each process can support one
+service. The service is identified by the name of the application running
+in the process, which is
+included in the Tock Binary Format Header for the application. A process can
+communicate with multiple services and will get a unique handle for
+each discovered service.  Clients and services communicate through
+shared buffers. Each client can share some of its own application
+memory with the service and then notify the service to instruct it to
+parse the shared buffer.
 
 ### Services
 
@@ -167,9 +211,12 @@ will crash (see the [Debugging](#debugging) section for an example).
 
 ## Debugging
 
-If an application crashes, Tock can provide a lot of useful information.
+If an application crashes, Tock provides a very detailed stack dump.
 By default, when an application crashes Tock prints a crash dump over the
-platform's default console interface.
+platform's default console interface. When your application crases,
+we recommend looking at this output very carefully: often we have spent 
+hours trying to track down a bug which in retrospect was quite obviously
+indicated in the dump, if we had just looked at the right fields.
 
 Note that because an application is relocated when it is loaded, the binaries
 and debugging .lst files generated when the app was originally compiled will not

--- a/kernel/src/common/leasable_buffer.rs
+++ b/kernel/src/common/leasable_buffer.rs
@@ -62,7 +62,7 @@ impl<'a, T> LeasableBuffer<'a, T> {
 
     /// Resets the LeasableBuffer to its full size, making the entire buffer
     /// accessible again. Typically this would be called once a sliced
-    /// LeasableBuffer is returned through a callback.
+    /// LeasableBuffer is returned through a callback
     pub fn reset(&mut self) {
         self.active_range = 0..self.internal.len();
     }

--- a/kernel/src/config.rs
+++ b/kernel/src/config.rs
@@ -31,7 +31,7 @@ pub(crate) struct Config {
     /// Whether the kernel should trace syscalls to the debug output.
     ///
     /// If enabled, the kernel will print a message in the debug output for each system call and
-    /// callback, with details including the application ID, and system call or callback parameters.
+    /// upcall, with details including the application ID, and system call or upcall parameters.
     pub(crate) trace_syscalls: bool,
 
     /// Whether the kernel should show debugging output when loading processes.

--- a/kernel/src/driver.rs
+++ b/kernel/src/driver.rs
@@ -69,12 +69,12 @@
 //! kernel (the scheduler and syscall dispatcher) is responsible for
 //! encoding these types into the Tock system call ABI specification.
 
-use crate::upcall::{AppId, Upcall};
 use crate::errorcode::ErrorCode;
 use crate::mem::{ReadOnlyAppSlice, ReadWriteAppSlice};
 use crate::process;
 use crate::returncode::ReturnCode;
 use crate::syscall::GenericSyscallReturnValue;
+use crate::upcall::{AppId, Upcall};
 
 /// Possible return values of a `command` driver method, as specified
 /// in TRD104.

--- a/kernel/src/driver.rs
+++ b/kernel/src/driver.rs
@@ -7,7 +7,7 @@
 //! Tock supports six system calls. The `yield` and `memop` system calls are
 //! handled by the core kernel, while four others are implemented by drivers:
 //!
-//!   * `subscribe` passes a callback to the driver which it can
+//!   * `subscribe` passes a upcall to the driver which it can
 //!   invoke on the process later, when an event has occurred or data
 //!   of interest is available.
 //!
@@ -43,12 +43,12 @@
 //!
 //! While drivers do not handle `yield` system calls, it is important
 //! to understand them and how they interact with `subscribe`, which
-//! registers callback functions with the kernel. When a process calls
+//! registers upcall functions with the kernel. When a process calls
 //! a `yield` system call, the kernel checks if there are any pending
-//! callbacks for the process. If there are pending callbacks, it
-//! pushes one callback onto the process stack. If there are no
-//! pending callbacks, `yield-wait` will cause the process to sleep
-//! until a callback is trigered, while `yield-no-wait` returns
+//! upcalls for the process. If there are pending upcalls, it
+//! pushes one upcall onto the process stack. If there are no
+//! pending upcalls, `yield-wait` will cause the process to sleep
+//! until a upcall is trigered, while `yield-no-wait` returns
 //! immediately.
 //!
 //! # Method result types
@@ -69,7 +69,7 @@
 //! kernel (the scheduler and syscall dispatcher) is responsible for
 //! encoding these types into the Tock system call ABI specification.
 
-use crate::callback::{AppId, Callback};
+use crate::upcall::{AppId, Upcall};
 use crate::errorcode::ErrorCode;
 use crate::mem::{ReadOnlyAppSlice, ReadWriteAppSlice};
 use crate::process;
@@ -184,10 +184,10 @@ pub trait Driver {
     fn subscribe(
         &self,
         subscribe_identifier: usize,
-        callback: Callback,
+        upcall: Upcall,
         app_id: AppId,
-    ) -> Result<Callback, (Callback, ErrorCode)> {
-        Err((callback, ErrorCode::NOSUPPORT))
+    ) -> Result<Upcall, (Upcall, ErrorCode)> {
+        Err((upcall, ErrorCode::NOSUPPORT))
     }
 
     /// System call for a process to perform a short synchronous operation

--- a/kernel/src/grant.rs
+++ b/kernel/src/grant.rs
@@ -5,9 +5,9 @@ use core::mem::{align_of, size_of};
 use core::ops::{Deref, DerefMut};
 use core::ptr::{slice_from_raw_parts_mut, write, NonNull};
 
-use crate::upcall::AppId;
 use crate::process::{Error, ProcessType};
 use crate::sched::Kernel;
+use crate::upcall::AppId;
 
 /// Type that indicates a grant region has been entered and borrowed.
 /// This is passed to capsules when they try to enter a grant region.

--- a/kernel/src/grant.rs
+++ b/kernel/src/grant.rs
@@ -5,7 +5,7 @@ use core::mem::{align_of, size_of};
 use core::ops::{Deref, DerefMut};
 use core::ptr::{slice_from_raw_parts_mut, write, NonNull};
 
-use crate::callback::AppId;
+use crate::upcall::AppId;
 use crate::process::{Error, ProcessType};
 use crate::sched::Kernel;
 

--- a/kernel/src/introspection.rs
+++ b/kernel/src/introspection.rs
@@ -12,11 +12,11 @@
 
 use core::cell::Cell;
 
-use crate::upcall::AppId;
 use crate::capabilities::ProcessManagementCapability;
 use crate::common::cells::NumericCellExt;
 use crate::process;
 use crate::sched::Kernel;
+use crate::upcall::AppId;
 
 /// This struct provides the inspection functions.
 pub struct KernelInfo {

--- a/kernel/src/introspection.rs
+++ b/kernel/src/introspection.rs
@@ -12,7 +12,7 @@
 
 use core::cell::Cell;
 
-use crate::callback::AppId;
+use crate::upcall::AppId;
 use crate::capabilities::ProcessManagementCapability;
 use crate::common::cells::NumericCellExt;
 use crate::process;
@@ -91,16 +91,16 @@ impl KernelInfo {
             .process_map_or(0, app, |process| process.debug_syscall_count())
     }
 
-    /// Returns the number of dropped callbacks the app has experience.
-    /// Callbacks can be dropped if the queue for the app is full when a capsule
-    /// tries to schedule a callback.
-    pub fn number_app_dropped_callbacks(
+    /// Returns the number of dropped upcalls the app has experience.
+    /// Upcalls can be dropped if the queue for the app is full when a capsule
+    /// tries to schedule a upcall.
+    pub fn number_app_dropped_upcalls(
         &self,
         app: AppId,
         _capability: &dyn ProcessManagementCapability,
     ) -> usize {
         self.kernel
-            .process_map_or(0, app, |process| process.debug_dropped_callback_count())
+            .process_map_or(0, app, |process| process.debug_dropped_upcall_count())
     }
 
     /// Returns the number of time this app has been restarted.

--- a/kernel/src/ipc.rs
+++ b/kernel/src/ipc.rs
@@ -3,7 +3,7 @@
 //! This is a special syscall driver that allows userspace applications to
 //! share memory.
 
-use crate::callback::{AppId, Callback};
+use crate::upcall::{AppId, Upcall};
 use crate::capabilities::MemoryAllocationCapability;
 use crate::grant::Grant;
 use crate::mem::Read;
@@ -14,14 +14,14 @@ use crate::{CommandReturn, Driver, ErrorCode, ReadOnlyAppSlice, ReadWriteAppSlic
 /// Syscall number
 pub const DRIVER_NUM: usize = 0x10000;
 
-/// Enum to mark which type of callback is scheduled for the IPC mechanism.
+/// Enum to mark which type of upcall is scheduled for the IPC mechanism.
 #[derive(Copy, Clone, Debug)]
-pub enum IPCCallbackType {
-    /// Indicates that the callback is for the service callback handler this
+pub enum IPCUpcallType {
+    /// Indicates that the upcall is for the service upcall handler this
     /// process has setup.
     Service,
-    /// Indicates that the callback is from a different service app and will
-    /// call one of the client callbacks setup by this process.
+    /// Indicates that the upcall is from a different service app and will
+    /// call one of the client upcalls setup by this process.
     Client,
 }
 
@@ -31,11 +31,11 @@ struct IPCData<const NUM_PROCS: usize> {
     /// applications.
     shared_memory: [ReadWriteAppSlice; NUM_PROCS],
     search_slice: ReadOnlyAppSlice,
-    /// An array of callbacks this process has registered to receive callbacks
+    /// An array of upcalls this process has registered to receive upcalls
     /// from other services.
-    client_callbacks: [Callback; NUM_PROCS],
-    /// The callback setup by a service. Each process can only be one service.
-    callback: Callback,
+    client_upcalls: [Upcall; NUM_PROCS],
+    /// The upcall setup by a service. Each process can only be one service.
+    upcall: Upcall,
 }
 
 impl<const NUM_PROCS: usize> Default for IPCData<NUM_PROCS> {
@@ -44,8 +44,8 @@ impl<const NUM_PROCS: usize> Default for IPCData<NUM_PROCS> {
         IPCData {
             shared_memory: [DEFAULT_RW_APP_SLICE; NUM_PROCS],
             search_slice: ReadOnlyAppSlice::default(),
-            client_callbacks: [Callback::default(); NUM_PROCS],
-            callback: Callback::default(),
+            client_upcalls: [Upcall::default(); NUM_PROCS],
+            upcall: Upcall::default(),
         }
     }
 }
@@ -63,31 +63,31 @@ impl<const NUM_PROCS: usize> IPC<NUM_PROCS> {
         }
     }
 
-    /// Schedule an IPC callback for a process. This is called by the main
+    /// Schedule an IPC upcall for a process. This is called by the main
     /// scheduler loop if an IPC task was queued for the process.
-    pub(crate) unsafe fn schedule_callback(
+    pub(crate) unsafe fn schedule_upcall(
         &self,
         schedule_on: AppId,
         called_from: AppId,
-        cb_type: IPCCallbackType,
+        cb_type: IPCUpcallType,
     ) -> Result<(), process::Error> {
         self.data
             .enter(schedule_on, |mydata, _| {
-                let mut callback = match cb_type {
-                    IPCCallbackType::Service => mydata.callback,
-                    IPCCallbackType::Client => match called_from.index() {
+                let mut upcall = match cb_type {
+                    IPCUpcallType::Service => mydata.upcall,
+                    IPCUpcallType::Client => match called_from.index() {
                         Some(i) => *mydata
-                            .client_callbacks
+                            .client_upcalls
                             .get(i)
-                            .unwrap_or(&Callback::default()),
-                        None => Callback::default(),
+                            .unwrap_or(&Upcall::default()),
+                        None => Upcall::default(),
                     },
                 };
                 self.data.enter(called_from, |called_from_data, _| {
                     // If the other app shared a buffer with us, make
                     // sure we have access to that slice and then call
-                    // the callback. If no slice was shared then just
-                    // call the callback.
+                    // the upcall. If no slice was shared then just
+                    // call the upcall.
                     match schedule_on.index() {
                         Some(i) => {
                             if i >= called_from_data.shared_memory.len() {
@@ -105,14 +105,14 @@ impl<const NUM_PROCS: usize> IPC<NUM_PROCS> {
                                                 slice.len(),
                                             )
                                         });
-                                    callback.schedule(
+                                    upcall.schedule(
                                         called_from.id() + 1,
                                         crate::mem::Read::len(slice),
                                         crate::mem::Read::ptr(slice) as usize,
                                     );
                                 }
                                 None => {
-                                    callback.schedule(called_from.id() + 1, 0, 0);
+                                    upcall.schedule(called_from.id() + 1, 0, 0);
                                 }
                             }
                         }
@@ -125,14 +125,14 @@ impl<const NUM_PROCS: usize> IPC<NUM_PROCS> {
 }
 
 impl<const NUM_PROCS: usize> Driver for IPC<NUM_PROCS> {
-    /// subscribe enables processes using IPC to register callbacks that fire
+    /// subscribe enables processes using IPC to register upcalls that fire
     /// when notify() is called.
     fn subscribe(
         &self,
         subscribe_num: usize,
-        mut callback: Callback,
+        mut upcall: Upcall,
         app_id: AppId,
-    ) -> Result<Callback, (Callback, ErrorCode)> {
+    ) -> Result<Upcall, (Upcall, ErrorCode)> {
         match subscribe_num {
             // subscribe(0)
             //
@@ -140,22 +140,22 @@ impl<const NUM_PROCS: usize> Driver for IPC<NUM_PROCS> {
             // itself as an IPC service. Each process can only register as a
             // single IPC service. The identifier for the IPC service is the
             // application name stored in the TBF header of the application.
-            // The callback that is passed to subscribe is called when another
+            // The upcall that is passed to subscribe is called when another
             // process notifies the server process.
             0 => self
                 .data
                 .enter(app_id, |data, _| {
-                    core::mem::swap(&mut data.callback, &mut callback);
-                    callback
+                    core::mem::swap(&mut data.upcall, &mut upcall);
+                    upcall
                 })
-                .map_err(|e| (callback, e.into())),
+                .map_err(|e| (upcall, e.into())),
 
             // subscribe(>=1)
             //
             // Subscribe with subscribe_num >= 1 is how a client registers
-            // a callback for a given service. The service number (passed
+            // a upcall for a given service. The service number (passed
             // here as subscribe_num) is returned from the allow() call.
-            // Once subscribed, the client will receive callbacks when the
+            // Once subscribed, the client will receive upcalls when the
             // service process calls notify_client().
             svc_id => {
                 // The app passes in a number which is the app identifier of the
@@ -166,15 +166,15 @@ impl<const NUM_PROCS: usize> Driver for IPC<NUM_PROCS> {
                 let otherapp = self.data.kernel.lookup_app_by_identifier(app_identifier);
 
                 // This type annotation is here for documentation, it's not actually necessary
-                let result: Result<Result<Callback, ErrorCode>, process::Error> =
+                let result: Result<Result<Upcall, ErrorCode>, process::Error> =
                     self.data.enter(app_id, |data, _| {
                         match otherapp.map_or(None, |oa| oa.index()) {
                             Some(i) => {
                                 if i >= NUM_PROCS {
                                     Err(ErrorCode::INVAL)
                                 } else {
-                                    core::mem::swap(&mut data.client_callbacks[i], &mut callback);
-                                    Ok(callback)
+                                    core::mem::swap(&mut data.client_upcalls[i], &mut upcall);
+                                    Ok(upcall)
                                 }
                             }
                             None => Err(ErrorCode::INVAL),
@@ -184,7 +184,7 @@ impl<const NUM_PROCS: usize> Driver for IPC<NUM_PROCS> {
                 result
                     .map_err(|e| e.into()) // transform the outer Result's process::Error into an ErrorCode
                     .and_then(|x| x) // Flatten the Result<Result<T,E>, E> into a Result<T,E>
-                    .map_err(|e| (callback, e)) // Add `callback` to the Error case
+                    .map_err(|e| (upcall, e)) // Add `upcall` to the Error case
             }
         }
     }
@@ -193,7 +193,7 @@ impl<const NUM_PROCS: usize> Driver for IPC<NUM_PROCS> {
     /// Notifying an IPC service is done by setting client_or_svc to 0,
     /// and notifying an IPC client is done by setting client_or_svc to 1.
     /// In either case, the target_id is the same number as provided in a notify
-    /// callback or as returned by allow.
+    /// upcall or as returned by allow.
     ///
     /// Returns EINVAL if the other process doesn't exist.
 
@@ -251,7 +251,7 @@ impl<const NUM_PROCS: usize> Driver for IPC<NUM_PROCS> {
             2 =>
             /* Service notify */
             {
-                let cb_type = IPCCallbackType::Service;
+                let cb_type = IPCUpcallType::Service;
                 let app_identifier = target_id - 1;
 
                 self.data
@@ -274,7 +274,7 @@ impl<const NUM_PROCS: usize> Driver for IPC<NUM_PROCS> {
             3 =>
             /* Client notify */
             {
-                let cb_type = IPCCallbackType::Client;
+                let cb_type = IPCUpcallType::Client;
                 let app_identifier = target_id - 1;
 
                 self.data

--- a/kernel/src/ipc.rs
+++ b/kernel/src/ipc.rs
@@ -3,12 +3,12 @@
 //! This is a special syscall driver that allows userspace applications to
 //! share memory.
 
-use crate::upcall::{AppId, Upcall};
 use crate::capabilities::MemoryAllocationCapability;
 use crate::grant::Grant;
 use crate::mem::Read;
 use crate::process;
 use crate::sched::Kernel;
+use crate::upcall::{AppId, Upcall};
 use crate::{CommandReturn, Driver, ErrorCode, ReadOnlyAppSlice, ReadWriteAppSlice};
 
 /// Syscall number
@@ -76,10 +76,7 @@ impl<const NUM_PROCS: usize> IPC<NUM_PROCS> {
                 let mut upcall = match cb_type {
                     IPCUpcallType::Service => mydata.upcall,
                     IPCUpcallType::Client => match called_from.index() {
-                        Some(i) => *mydata
-                            .client_upcalls
-                            .get(i)
-                            .unwrap_or(&Upcall::default()),
+                        Some(i) => *mydata.client_upcalls.get(i).unwrap_or(&Upcall::default()),
                         None => Upcall::default(),
                     },
                 };

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -98,7 +98,7 @@ pub mod introspection;
 pub mod ipc;
 pub mod syscall;
 
-mod callback;
+mod upcall;
 mod config;
 mod driver;
 mod errorcode;
@@ -110,7 +110,7 @@ mod process;
 mod returncode;
 mod sched;
 
-pub use crate::callback::{AppId, Callback};
+pub use crate::upcall::{AppId, Upcall};
 pub use crate::driver::{CommandReturn, Driver};
 pub use crate::errorcode::ErrorCode;
 pub use crate::grant::{DynamicGrant, Grant};

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -98,7 +98,6 @@ pub mod introspection;
 pub mod ipc;
 pub mod syscall;
 
-mod upcall;
 mod config;
 mod driver;
 mod errorcode;
@@ -109,8 +108,8 @@ mod platform;
 mod process;
 mod returncode;
 mod sched;
+mod upcall;
 
-pub use crate::upcall::{AppId, Upcall};
 pub use crate::driver::{CommandReturn, Driver};
 pub use crate::errorcode::ErrorCode;
 pub use crate::grant::{DynamicGrant, Grant};
@@ -125,6 +124,7 @@ pub use crate::sched::mlfq::{MLFQProcessNode, MLFQSched};
 pub use crate::sched::priority::PrioritySched;
 pub use crate::sched::round_robin::{RoundRobinProcessNode, RoundRobinSched};
 pub use crate::sched::{Kernel, Scheduler};
+pub use crate::upcall::{AppId, Upcall};
 
 // Export only select items from the process module. To remove the name conflict
 // this cannot be called `process`, so we use a shortened version. These

--- a/kernel/src/platform/mpu.rs
+++ b/kernel/src/platform/mpu.rs
@@ -1,6 +1,6 @@
 //! Interface for configuring the Memory Protection Unit.
 
-use crate::callback::AppId;
+use crate::upcall::AppId;
 use core::cmp;
 use core::fmt::{self, Display};
 

--- a/kernel/src/platform/scheduler_timer.rs
+++ b/kernel/src/platform/scheduler_timer.rs
@@ -49,7 +49,7 @@ use crate::hil::time::{self, Frequency, Ticks};
 /// `SchedulerTimer` is used in the core kernel loop and scheduler, top half
 /// interrupt handlers may not have executed before `SchedulerTimer` functions
 /// are called. In particular, implementations on top of virtualized timers may
-/// receive the interrupt fired callback "late" (i.e. after the kernel calls
+/// receive the interrupt fired upcall "late" (i.e. after the kernel calls
 /// `has_expired()`). Implementations should ensure that they can reliably check
 /// for timeslice expirations.
 pub trait SchedulerTimer {

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -8,7 +8,7 @@ use core::fmt::Write;
 use core::ptr::{write_volatile, NonNull};
 use core::{mem, ptr, slice, str};
 
-use crate::callback::{AppId, CallbackId};
+use crate::upcall::{AppId, UpcallId};
 use crate::capabilities::ProcessManagementCapability;
 use crate::common::cells::{MapCell, NumericCellExt};
 use crate::common::{Queue, RingBuffer};
@@ -266,7 +266,7 @@ pub trait ProcessType {
 
     /// Queue a `Task` for the process. This will be added to a per-process
     /// buffer and executed by the scheduler. `Task`s are some function the app
-    /// should run, for example a callback or an IPC call.
+    /// should run, for example a upcall or an IPC call.
     ///
     /// This function returns `true` if the `Task` was successfully enqueued,
     /// and `false` otherwise. This is represented as a simple `bool` because
@@ -279,7 +279,7 @@ pub trait ProcessType {
     /// Returns whether this process is ready to execute.
     fn ready(&self) -> bool;
 
-    /// Return if there are any Tasks (callbacks/IPC requests) enqueued
+    /// Return if there are any Tasks (upcalls/IPC requests) enqueued
     /// for the process.
     fn has_tasks(&self) -> bool;
 
@@ -290,9 +290,9 @@ pub trait ProcessType {
     /// `None`.
     fn dequeue_task(&self) -> Option<Task>;
 
-    /// Remove all scheduled callbacks for a given callback id from the task
+    /// Remove all scheduled upcalls for a given upcall id from the task
     /// queue.
-    fn remove_pending_callbacks(&self, callback_id: CallbackId);
+    fn remove_pending_upcalls(&self, upcall_id: UpcallId);
 
     /// Returns the current state the process is in. Common states are "running"
     /// or "yielded".
@@ -532,7 +532,7 @@ pub trait ProcessType {
     ///
     /// It is not valid to call this function when the process is inactive (i.e.
     /// the process will not run again).
-    unsafe fn set_process_function(&self, callback: FunctionCall);
+    unsafe fn set_process_function(&self, upcall: FunctionCall);
 
     /// Context switch to a specific process.
     ///
@@ -553,8 +553,8 @@ pub trait ProcessType {
     /// Returns how many syscalls this app has called.
     fn debug_syscall_count(&self) -> usize;
 
-    /// Returns how many callbacks for this process have been dropped.
-    fn debug_dropped_callback_count(&self) -> usize;
+    /// Returns how many upcalls for this process have been dropped.
+    fn debug_dropped_upcall_count(&self) -> usize;
 
     /// Returns how many times this process has exceeded its timeslice.
     fn debug_timeslice_expiration_count(&self) -> usize;
@@ -779,15 +779,15 @@ pub enum FaultResponse {
 /// This is public for external implementations of `ProcessType`.
 #[derive(Copy, Clone)]
 pub enum Task {
-    /// Function pointer in the process to execute. Generally this is a callback
+    /// Function pointer in the process to execute. Generally this is a upcall
     /// from a capsule.
     FunctionCall(FunctionCall),
     /// An IPC operation that needs additional setup to configure memory access.
-    IPC((AppId, ipc::IPCCallbackType)),
+    IPC((AppId, ipc::IPCUpcallType)),
 }
 
 /// Enumeration to identify whether a function call for a process comes directly
-/// from the kernel or from a callback subscribed through a `Driver`
+/// from the kernel or from a upcall subscribed through a `Driver`
 /// implementation.
 ///
 /// An example of a kernel function is the application entry point.
@@ -796,18 +796,18 @@ pub enum FunctionCallSource {
     /// For functions coming directly from the kernel, such as `init_fn`.
     Kernel,
     /// For functions coming from capsules or any implementation of `Driver`.
-    Driver(CallbackId),
+    Driver(UpcallId),
 }
 
-/// Struct that defines a callback that can be passed to a process. The callback
-/// takes four arguments that are `Driver` and callback specific, so they are
+/// Struct that defines a upcall that can be passed to a process. The upcall
+/// takes four arguments that are `Driver` and upcall specific, so they are
 /// represented generically here.
 ///
 /// Likely these four arguments will get passed as the first four register
 /// values, but this is architecture-dependent.
 ///
-/// A `FunctionCall` also identifies the callback that scheduled it, if any, so
-/// that it can be unscheduled when the process unsubscribes from this callback.
+/// A `FunctionCall` also identifies the upcall that scheduled it, if any, so
+/// that it can be unscheduled when the process unsubscribes from this upcall.
 #[derive(Copy, Clone, Debug)]
 pub struct FunctionCall {
     pub source: FunctionCallSource,
@@ -850,9 +850,9 @@ struct ProcessDebug {
     /// What was the most recent syscall.
     last_syscall: Option<Syscall>,
 
-    /// How many callbacks were dropped because the queue was insufficiently
+    /// How many upcalls were dropped because the queue was insufficiently
     /// long.
-    dropped_callback_count: usize,
+    dropped_upcall_count: usize,
 
     /// How many times this process has been paused because it exceeded its
     /// timeslice.
@@ -947,7 +947,7 @@ pub struct Process<'a, C: 'static + Chip> {
     /// MPU regions are saved as a pointer-size pair.
     mpu_regions: [Cell<Option<mpu::Region>>; 6],
 
-    /// Essentially a list of callbacks that want to call functions in the
+    /// Essentially a list of upcalls that want to call functions in the
     /// process.
     tasks: MapCell<RingBuffer<'a, Task>>,
 
@@ -977,11 +977,11 @@ impl<C: Chip> ProcessType for Process<'_, C> {
 
         let ret = self.tasks.map_or(false, |tasks| tasks.enqueue(task));
 
-        // Make a note that we lost this callback if the enqueue function
+        // Make a note that we lost this upcall if the enqueue function
         // fails.
         if ret == false {
             self.debug.map(|debug| {
-                debug.dropped_callback_count += 1;
+                debug.dropped_upcall_count += 1;
             });
         } else {
             self.kernel.increment_work();
@@ -995,16 +995,16 @@ impl<C: Chip> ProcessType for Process<'_, C> {
             || self.state.get() == State::Running
     }
 
-    fn remove_pending_callbacks(&self, callback_id: CallbackId) {
+    fn remove_pending_upcalls(&self, upcall_id: UpcallId) {
         self.tasks.map(|tasks| {
             let count_before = tasks.len();
             tasks.retain(|task| match task {
                 // Remove only tasks that are function calls with an id equal
-                // to `callback_id`.
+                // to `upcall_id`.
                 Task::FunctionCall(function_call) => match function_call.source {
                     FunctionCallSource::Kernel => true,
                     FunctionCallSource::Driver(id) => {
-                        if id != callback_id {
+                        if id != upcall_id {
                             true
                         } else {
                             self.kernel.decrement_work();
@@ -1017,10 +1017,10 @@ impl<C: Chip> ProcessType for Process<'_, C> {
             if config::CONFIG.trace_syscalls {
                 let count_after = tasks.len();
                 debug!(
-                    "[{:?}] remove_pending_callbacks[{:#x}:{}] = {} callback(s) removed",
+                    "[{:?}] remove_pending_upcalls[{:#x}:{}] = {} upcall(s) removed",
                     self.appid(),
-                    callback_id.driver_num,
-                    callback_id.subscribe_num,
+                    upcall_id.driver_num,
+                    upcall_id.subscribe_num,
                     count_before - count_after,
                 );
             }
@@ -1593,7 +1593,7 @@ impl<C: Chip> ProcessType for Process<'_, C> {
         }
     }
 
-    unsafe fn set_process_function(&self, callback: FunctionCall) {
+    unsafe fn set_process_function(&self, upcall: FunctionCall) {
         // See if we can actually enqueue this function for this process.
         // Architecture-specific code handles actually doing this since the
         // exact method is both architecture- and implementation-specific.
@@ -1605,7 +1605,7 @@ impl<C: Chip> ProcessType for Process<'_, C> {
                 self.memory.as_ptr(),
                 self.app_break.get(),
                 stored_state,
-                callback,
+                upcall,
             )
         }) {
             Some(Ok(())) => {
@@ -1672,8 +1672,8 @@ impl<C: Chip> ProcessType for Process<'_, C> {
         self.debug.map_or(0, |debug| debug.syscall_count)
     }
 
-    fn debug_dropped_callback_count(&self) -> usize {
-        self.debug.map_or(0, |debug| debug.dropped_callback_count)
+    fn debug_dropped_upcall_count(&self) -> usize {
+        self.debug.map_or(0, |debug| debug.dropped_upcall_count)
     }
 
     fn debug_timeslice_expiration_count(&self) -> usize {
@@ -1724,19 +1724,19 @@ impl<C: Chip> ProcessType for Process<'_, C> {
         let events_queued = self.tasks.map_or(0, |tasks| tasks.len());
         let syscall_count = self.debug.map_or(0, |debug| debug.syscall_count);
         let last_syscall = self.debug.map(|debug| debug.last_syscall);
-        let dropped_callback_count = self.debug.map_or(0, |debug| debug.dropped_callback_count);
+        let dropped_upcall_count = self.debug.map_or(0, |debug| debug.dropped_upcall_count);
         let restart_count = self.restart_count.get();
 
         let _ = writer.write_fmt(format_args!(
             "\
              App: {}   -   [{:?}]\
-             \r\n Events Queued: {}   Syscall Count: {}   Dropped Callback Count: {}\
+             \r\n Events Queued: {}   Syscall Count: {}   Dropped Upcall Count: {}\
              \r\n Restart Count: {}\r\n",
             self.process_name,
             self.state.get(),
             events_queued,
             syscall_count,
-            dropped_callback_count,
+            dropped_upcall_count,
             restart_count,
         ));
 
@@ -1911,7 +1911,7 @@ fn exceeded_check(size: usize, allocated: usize) -> &'static str {
 }
 
 impl<C: 'static + Chip> Process<'_, C> {
-    // Memory offset for callback ring buffer (10 element length).
+    // Memory offset for upcall ring buffer (10 element length).
     const CALLBACK_LEN: usize = 10;
     const CALLBACKS_OFFSET: usize = mem::size_of::<Task>() * Self::CALLBACK_LEN;
 
@@ -2189,7 +2189,7 @@ impl<C: 'static + Chip> Process<'_, C> {
         }
 
         // Now that we know we have the space we can setup the memory for the
-        // callbacks.
+        // upcalls.
         kernel_memory_break = kernel_memory_break.offset(-(Self::CALLBACKS_OFFSET as isize));
 
         // This is safe today, as MPU constraints ensure that `memory_start`
@@ -2201,10 +2201,10 @@ impl<C: 'static + Chip> Process<'_, C> {
         //
         // TODO: https://github.com/tock/tock/issues/1739
         #[allow(clippy::cast_ptr_alignment)]
-        // Set up ring buffer for callbacks to the process.
-        let callback_buf =
+        // Set up ring buffer for upcalls to the process.
+        let upcall_buf =
             slice::from_raw_parts_mut(kernel_memory_break as *mut Task, Self::CALLBACK_LEN);
-        let tasks = RingBuffer::new(callback_buf);
+        let tasks = RingBuffer::new(upcall_buf);
 
         // Last thing in the kernel region of process RAM is the process struct.
         kernel_memory_break = kernel_memory_break.offset(-(Self::PROCESS_STRUCT_OFFSET as isize));
@@ -2262,7 +2262,7 @@ impl<C: 'static + Chip> Process<'_, C> {
             app_stack_min_pointer: None,
             syscall_count: 0,
             last_syscall: None,
-            dropped_callback_count: 0,
+            dropped_upcall_count: 0,
             timeslice_expiration_count: 0,
         });
 
@@ -2334,7 +2334,7 @@ impl<C: 'static + Chip> Process<'_, C> {
         self.debug.map(|debug| {
             debug.syscall_count = 0;
             debug.last_syscall = None;
-            debug.dropped_callback_count = 0;
+            debug.dropped_upcall_count = 0;
             debug.timeslice_expiration_count = 0;
         });
 

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -8,7 +8,6 @@ use core::fmt::Write;
 use core::ptr::{write_volatile, NonNull};
 use core::{mem, ptr, slice, str};
 
-use crate::upcall::{AppId, UpcallId};
 use crate::capabilities::ProcessManagementCapability;
 use crate::common::cells::{MapCell, NumericCellExt};
 use crate::common::{Queue, RingBuffer};
@@ -22,6 +21,7 @@ use crate::platform::Chip;
 use crate::returncode::ReturnCode;
 use crate::sched::Kernel;
 use crate::syscall::{self, GenericSyscallReturnValue, Syscall, UserspaceKernelBoundary};
+use crate::upcall::{AppId, UpcallId};
 use core::cmp::max;
 
 // The completion code for a process if it faulted.

--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -13,7 +13,7 @@ pub(crate) mod round_robin;
 use core::cell::Cell;
 use core::ptr::NonNull;
 
-use crate::callback::{AppId, Callback, CallbackId};
+use crate::upcall::{AppId, Upcall, UpcallId};
 use crate::capabilities;
 use crate::common::cells::NumericCellExt;
 use crate::common::dynamic_deferred_call::DynamicDeferredCall;
@@ -125,7 +125,7 @@ pub enum SchedulingDecision {
 /// Main object for the kernel. Each board will need to create one.
 pub struct Kernel {
     /// How many "to-do" items exist at any given time. These include
-    /// outstanding callbacks and processes in the Running state.
+    /// outstanding upcalls and processes in the Running state.
     work: Cell<usize>,
 
     /// This holds a pointer to the static array of Process pointers.
@@ -532,7 +532,7 @@ impl Kernel {
     /// running after calling a syscall. However, the scheduler is given an out,
     /// as `do_process()` will check with the scheduler before re-executing the
     /// process to allow it to return from the syscall. If a process yields with
-    /// no callbacks pending, exits, exceeds its timeslice, or is interrupted,
+    /// no upcalls pending, exits, exceeds its timeslice, or is interrupted,
     /// then `do_process()` will return.
     ///
     /// Depending on the particular scheduler in use, this function may act in a
@@ -655,7 +655,7 @@ impl Kernel {
                 }
                 process::State::Yielded | process::State::Unstarted => {
                     // If the process is yielded or hasn't been started it is
-                    // waiting for a callback. If there is a task scheduled for
+                    // waiting for a upcall. If there is a task scheduled for
                     // this process go ahead and set the process to execute it.
                     match process.dequeue_task() {
                         None => break,
@@ -686,7 +686,7 @@ impl Kernel {
                                         // TODO(alevy): this could error for a variety of reasons.
                                         // Should we communicate the error somehow?
                                         // https://github.com/tock/tock/issues/1993
-                                        let _ = ipc.schedule_callback(
+                                        let _ = ipc.schedule_upcall(
                                             process.appid(),
                                             otherapp,
                                             ipc_type,
@@ -811,14 +811,14 @@ impl Kernel {
                 // yielded state and execute tasks now or when they arrive.
                 let return_now = !wait && !process.has_tasks();
                 if return_now {
-                    // Set the "did I trigger callbacks" flag to be 0,
+                    // Set the "did I trigger upcalls" flag to be 0,
                     // return immediately. If address is invalid does
                     // nothing.
                     process.set_byte(address, 0);
                 } else {
-                    // There are already enqueued callbacks to execute or
+                    // There are already enqueued upcalls to execute or
                     // we should wait for them: handle in the next loop
-                    // iteration and set the "did I trigger callbacks" flag
+                    // iteration and set the "did I trigger upcalls" flag
                     // to be 1. If address is invalid does nothing.
                     process.set_byte(address, 1);
                     process.set_yielded_state();
@@ -827,30 +827,30 @@ impl Kernel {
             Syscall::Subscribe {
                 driver_number,
                 subdriver_number,
-                callback_ptr,
+                upcall_ptr,
                 appdata,
             } => {
-                // A callback is identified as a tuple of
+                // A upcall is identified as a tuple of
                 // the driver number and the subdriver
                 // number.
-                let callback_id = CallbackId {
+                let upcall_id = UpcallId {
                     driver_num: driver_number,
                     subscribe_num: subdriver_number,
                 };
-                // Only one callback should exist per tuple.
+                // Only one upcall should exist per tuple.
                 // To ensure that there are no pending
-                // callbacks with the same identifier but
+                // upcalls with the same identifier but
                 // with the old function pointer, we clear
                 // them now.
-                process.remove_pending_callbacks(callback_id);
+                process.remove_pending_upcalls(upcall_id);
 
-                let ptr = NonNull::new(callback_ptr);
-                let callback = ptr.map_or(Callback::default(), |ptr| {
-                    Callback::new(process.appid(), callback_id, appdata, ptr.cast())
+                let ptr = NonNull::new(upcall_ptr);
+                let upcall = ptr.map_or(Upcall::default(), |ptr| {
+                    Upcall::new(process.appid(), upcall_id, appdata, ptr.cast())
                 });
                 let rval = platform.with_driver(driver_number, |driver| match driver {
                     Some(d) => {
-                        let res = d.subscribe(subdriver_number, callback, process.appid());
+                        let res = d.subscribe(subdriver_number, upcall, process.appid());
                         match res {
                             // An Ok() returns the previous upcall, while
                             // Err() returns the one that was just passed
@@ -859,7 +859,7 @@ impl Kernel {
                             Err((newcb, err)) => newcb.into_subscribe_failure(err),
                         }
                     }
-                    None => callback.into_subscribe_failure(ErrorCode::NOSUPPORT),
+                    None => upcall.into_subscribe_failure(ErrorCode::NOSUPPORT),
                 });
                 if config::CONFIG.trace_syscalls {
                     debug!(
@@ -867,7 +867,7 @@ impl Kernel {
                         process.appid(),
                         driver_number,
                         subdriver_number,
-                        callback_ptr as usize,
+                        upcall_ptr as usize,
                         appdata,
                         rval
                     );

--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -13,7 +13,6 @@ pub(crate) mod round_robin;
 use core::cell::Cell;
 use core::ptr::NonNull;
 
-use crate::upcall::{AppId, Upcall, UpcallId};
 use crate::capabilities;
 use crate::common::cells::NumericCellExt;
 use crate::common::dynamic_deferred_call::DynamicDeferredCall;
@@ -31,6 +30,7 @@ use crate::platform::{Chip, Platform};
 use crate::process::{self, Task};
 use crate::syscall::{ContextSwitchReason, GenericSyscallReturnValue};
 use crate::syscall::{Syscall, YieldCall};
+use crate::upcall::{AppId, Upcall, UpcallId};
 
 /// Threshold in microseconds to consider a process's timeslice to be exhausted.
 /// That is, Tock will skip re-scheduling a process if its remaining timeslice

--- a/kernel/src/sched/mlfq.rs
+++ b/kernel/src/sched/mlfq.rs
@@ -17,13 +17,13 @@
 //! - Rule 5: After some time period S, move all the jobs in the system to the
 //!           topmost queue.
 
-use crate::upcall::AppId;
 use crate::common::list::{List, ListLink, ListNode};
 use crate::hil::time;
 use crate::hil::time::Ticks;
 use crate::platform::Chip;
 use crate::process::ProcessType;
 use crate::sched::{Kernel, Scheduler, SchedulingDecision, StoppedExecutingReason};
+use crate::upcall::AppId;
 use core::cell::Cell;
 
 #[derive(Default)]

--- a/kernel/src/sched/mlfq.rs
+++ b/kernel/src/sched/mlfq.rs
@@ -17,7 +17,7 @@
 //! - Rule 5: After some time period S, move all the jobs in the system to the
 //!           topmost queue.
 
-use crate::callback::AppId;
+use crate::upcall::AppId;
 use crate::common::list::{List, ListLink, ListNode};
 use crate::hil::time;
 use crate::hil::time::Ticks;

--- a/kernel/src/sched/priority.rs
+++ b/kernel/src/sched/priority.rs
@@ -10,11 +10,11 @@
 //! is running. The only way for a process to longer be the highest priority is
 //! for an interrupt to occur, which will cause the process to stop running.
 
-use crate::upcall::AppId;
 use crate::common::cells::OptionalCell;
 use crate::common::dynamic_deferred_call::DynamicDeferredCall;
 use crate::platform::Chip;
 use crate::sched::{Kernel, Scheduler, SchedulingDecision, StoppedExecutingReason};
+use crate::upcall::AppId;
 
 /// Priority scheduler based on the order of processes in the `PROCESSES` array.
 pub struct PrioritySched {

--- a/kernel/src/sched/priority.rs
+++ b/kernel/src/sched/priority.rs
@@ -10,7 +10,7 @@
 //! is running. The only way for a process to longer be the highest priority is
 //! for an interrupt to occur, which will cause the process to stop running.
 
-use crate::callback::AppId;
+use crate::upcall::AppId;
 use crate::common::cells::OptionalCell;
 use crate::common::dynamic_deferred_call::DynamicDeferredCall;
 use crate::platform::Chip;

--- a/kernel/src/upcall.rs
+++ b/kernel/src/upcall.rs
@@ -1,4 +1,4 @@
-//! Data structure for storing a callback to userspace or kernelspace.
+//! Data structure for storing an upcall from the kernel to a process.
 
 use core::fmt;
 use core::ptr::NonNull;
@@ -155,46 +155,46 @@ impl AppId {
     }
 }
 
-/// Type to uniquely identify a callback subscription across all drivers.
+/// Type to uniquely identify an upcall subscription across all drivers.
 ///
 /// This contains the driver number and the subscribe number within the driver.
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct CallbackId {
+pub struct UpcallId {
     pub driver_num: usize,
     pub subscribe_num: usize,
 }
 
-/// Type for calling a callback in a process.
+/// Type for calling an upcall in a process.
 ///
 /// This is essentially a wrapper around a function pointer.
 #[derive(Clone, Copy)]
-struct ProcessCallback {
+struct ProcessUpcall {
     app_id: AppId,
-    callback_id: CallbackId,
+    upcall_id: UpcallId,
     appdata: usize,
     fn_ptr: NonNull<*mut ()>,
 }
 
 #[derive(Clone, Copy, Default)]
-pub struct Callback {
-    cb: Option<ProcessCallback>,
+pub struct Upcall {
+    cb: Option<ProcessUpcall>,
 }
 
-impl Callback {
+impl Upcall {
     pub(crate) fn new(
         app_id: AppId,
-        callback_id: CallbackId,
+        upcall_id: UpcallId,
         appdata: usize,
         fn_ptr: NonNull<*mut ()>,
-    ) -> Callback {
-        Callback {
-            cb: Some(ProcessCallback::new(app_id, callback_id, appdata, fn_ptr)),
+    ) -> Upcall {
+        Upcall {
+            cb: Some(ProcessUpcall::new(app_id, upcall_id, appdata, fn_ptr)),
         }
     }
 
-    /// Tell the scheduler to run this callback for the process.
+    /// Tell the scheduler to run this upcall for the process.
     ///
-    /// The three arguments are passed to the callback in userspace.
+    /// The three arguments are passed to the upcall in userspace.
     pub fn schedule(&mut self, r0: usize, r1: usize, r2: usize) -> bool {
         self.cb.map_or(true, |mut cb| cb.schedule(r0, r1, r2))
     }
@@ -221,27 +221,27 @@ impl Callback {
     }
 }
 
-impl ProcessCallback {
+impl ProcessUpcall {
     fn new(
         app_id: AppId,
-        callback_id: CallbackId,
+        upcall_id: UpcallId,
         appdata: usize,
         fn_ptr: NonNull<*mut ()>,
-    ) -> ProcessCallback {
-        ProcessCallback {
+    ) -> ProcessUpcall {
+        ProcessUpcall {
             app_id,
-            callback_id,
+            upcall_id,
             appdata,
             fn_ptr,
         }
     }
 }
 
-impl ProcessCallback {
-    /// Actually trigger the callback.
+impl ProcessUpcall {
+    /// Actually trigger the upcall.
     ///
-    /// This will queue the `Callback` for the associated process. It returns
-    /// `false` if the queue for the process is full and the callback could not
+    /// This will queue the `Upcall` for the associated process. It returns
+    /// `false` if the queue for the process is full and the upcall could not
     /// be scheduled.
     ///
     /// The arguments (`r0-r2`) are the values passed back to the process and
@@ -252,7 +252,7 @@ impl ProcessCallback {
             .kernel
             .process_map_or(false, self.app_id, |process| {
                 process.enqueue_task(process::Task::FunctionCall(process::FunctionCall {
-                    source: process::FunctionCallSource::Driver(self.callback_id),
+                    source: process::FunctionCallSource::Driver(self.upcall_id),
                     argument0: r0,
                     argument1: r1,
                     argument2: r2,
@@ -264,8 +264,8 @@ impl ProcessCallback {
             debug!(
                 "[{:?}] schedule[{:#x}:{}] @{:#x}({:#x}, {:#x}, {:#x}, {:#x}) = {}",
                 self.app_id,
-                self.callback_id.driver_num,
-                self.callback_id.subscribe_num,
+                self.upcall_id.driver_num,
+                self.upcall_id.subscribe_num,
                 self.fn_ptr.as_ptr() as usize,
                 r0,
                 r1,


### PR DESCRIPTION
### Pull Request Overview

This pull request changes `kernel::callback::Callback` to `kernel::upcall::Upcall`. It updates the rest of the codebase to use this, and also tries to change all of the comments to distinguish general callbacks from upcalls.

Given that this touches so many files, I suggest that we merge this after the major code review for 2.0.

### Testing Strategy

This pull request was tested by compiling.


### TODO or Help Wanted

I think the terminology is 95% right -- given the scope of these changes, I think that simply fixing the last few when we encounter them will be sufficient.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
