### PR TITLE
Filtering fix 2.0

### DIFF
--- a/capsules/src/gpio_async.rs
+++ b/capsules/src/gpio_async.rs
@@ -139,7 +139,13 @@ impl<Port: hil::gpio_async::Port> Driver for GPIOAsync<'_, Port> {
     ///   interrupt, and 2 for a falling edge interrupt.
     /// - `8`: Disable an interrupt on a pin.
     /// - `9`: Disable a GPIO pin.
-    fn command(&self, command_number: usize, pin: usize, data: usize, _appid: AppId) -> CommandReturn {
+    fn command(
+        &self,
+        command_number: usize,
+        pin: usize,
+        data: usize,
+        _appid: AppId,
+    ) -> CommandReturn {
         let port = data & 0xFFFF;
         let other = (data >> 16) & 0xFFFF;
         let ports = self.ports.as_ref();

--- a/doc/Userland.md
+++ b/doc/Userland.md
@@ -11,7 +11,7 @@ of how applications function.
 
 - [Overview of Processes in Tock](#overview-of-processes-in-tock)
 - [System Calls](#system-calls)
-- [Callbacks](#callbacks)
+- [Upcalls and Termination](#upcalls-and-termination)
 - [Inter-Process Communication](#inter-process-communication)
   * [Services](#services)
   * [Clients](#clients)

--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -768,15 +768,15 @@ impl Kernel {
             Syscall::Yield {
                 which: _,
                 address: _,
-            } => {}, // Yield is not filterable
+            } => {} // Yield is not filterable
             Syscall::Exit {
                 which: _,
                 completion_code: _,
-            } => {}, // Exit is not filterable
+            } => {} // Exit is not filterable
             Syscall::Memop {
                 operand: _,
                 arg0: _,
-            } => {}, // Memop is not filterable
+            } => {} // Memop is not filterable
             _ => {
                 // Check all other syscalls for filtering
                 if let Err(response) = platform.filter_syscall(process, &syscall) {

--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -768,7 +768,15 @@ impl Kernel {
             Syscall::Yield {
                 which: _,
                 address: _,
-            } => {} // Do nothing
+            } => {}, // Yield is not filterable
+            Syscall::Exit {
+                which: _,
+                completion_code: _,
+            } => {}, // Exit is not filterable
+            Syscall::Memop {
+                operand: _,
+                arg0: _,
+            } => {}, // Memop is not filterable
             _ => {
                 // Check all other syscalls for filtering
                 if let Err(response) = platform.filter_syscall(process, &syscall) {


### PR DESCRIPTION
### Pull Request Overview

This pull request makes it so that the Exit and Memop system call classes cannot be filtered, following the conclusion on the 2/26/21 core call.

It also fixes a small formatting nit on the `gpio_async` capsule and the Userland.md TOC.

### Testing Strategy

This pull request was tested by compiling.


### TODO or Help Wanted

This pull request still needs nothing.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
