### PR TITLE
RFC: kernel: change `unsafe` handling

### DIFF
--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -1557,6 +1557,12 @@ impl<C: Chip> ProcessType for Process<'_, C> {
 
     fn set_syscall_return_value(&self, return_value: SyscallReturn) {
         match self.stored_state.map(|stored_state| unsafe {
+            // Actually set the return value for a particular process.
+            //
+            // The UKB implementation uses the bounds of process-accessible
+            // memory to verify that any memory changes are valid. Here, the
+            // unsafe promise we are making is that the bounds passed to the UKB
+            // are correct.
             self.chip
                 .userspace_kernel_boundary()
                 .set_syscall_return_value(

--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -826,13 +826,25 @@ impl Kernel {
                     // Set the "did I trigger callbacks" flag to be 0,
                     // return immediately. If address is invalid does
                     // nothing.
-                    process.set_byte(address, 0);
+                    //
+                    // Safety: this is fine as long as no references to the
+                    // process's memory exist. We do not have a reference,
+                    // so we can safely call `set_byte()`.
+                    unsafe {
+                        process.set_byte(address, 0);
+                    }
                 } else {
                     // There are already enqueued callbacks to execute or
                     // we should wait for them: handle in the next loop
                     // iteration and set the "did I trigger callbacks" flag
                     // to be 1. If address is invalid does nothing.
-                    process.set_byte(address, 1);
+                    //
+                    // Safety: this is fine as long as no references to the
+                    // process's memory exist. We do not have a reference,
+                    // so we can safely call `set_byte()`.
+                    unsafe {
+                        process.set_byte(address, 1);
+                    }
                     process.set_yielded_state();
                 }
             }

--- a/kernel/src/syscall.rs
+++ b/kernel/src/syscall.rs
@@ -471,6 +471,13 @@ pub trait UserspaceKernelBoundary {
     /// This function may be called multiple times on the same process. For
     /// example, if a process crashes and is to be restarted, this must be
     /// called. Or if the process is moved this may need to be called.
+    ///
+    /// ### Safety
+    ///
+    /// This function guarantees that it if needs to change process memory, it
+    /// will only change memory starting at `accessible_memory_start` and before
+    /// `app_brk`. The caller is responsible for guaranteeing that those
+    /// pointers are valid for the process.
     unsafe fn initialize_process(
         &self,
         accessible_memory_start: *const u8,
@@ -486,6 +493,13 @@ pub trait UserspaceKernelBoundary {
     /// value. The `return_value` is the value that should be passed to the
     /// process so that when it resumes executing it knows the return value of
     /// the syscall it called.
+    ///
+    /// ### Safety
+    ///
+    /// This function guarantees that it if needs to change process memory, it
+    /// will only change memory starting at `accessible_memory_start` and before
+    /// `app_brk`. The caller is responsible for guaranteeing that those
+    /// pointers are valid for the process.
     unsafe fn set_syscall_return_value(
         &self,
         accessible_memory_start: *const u8,
@@ -521,6 +535,13 @@ pub trait UserspaceKernelBoundary {
     /// Returns `Ok(())` if the function was successfully enqueued for the
     /// process. Returns `Err(())` if the function was not, likely because there
     /// is insufficient memory available to do so.
+    ///
+    /// ### Safety
+    ///
+    /// This function guarantees that it if needs to change process memory, it
+    /// will only change memory starting at `accessible_memory_start` and before
+    /// `app_brk`. The caller is responsible for guaranteeing that those
+    /// pointers are valid for the process.
     unsafe fn set_process_function(
         &self,
         accessible_memory_start: *const u8,
@@ -539,6 +560,13 @@ pub trait UserspaceKernelBoundary {
     ///    optional because it is only for debugging in process.rs. By sharing
     ///    the process's stack pointer with process.rs users can inspect the
     ///    state and see the stack depth, which might be useful for debugging.
+    ///
+    /// ### Safety
+    ///
+    /// This function guarantees that it if needs to change process memory, it
+    /// will only change memory starting at `accessible_memory_start` and before
+    /// `app_brk`. The caller is responsible for guaranteeing that those
+    /// pointers are valid for the process.
     unsafe fn switch_to_process(
         &self,
         accessible_memory_start: *const u8,
@@ -548,6 +576,13 @@ pub trait UserspaceKernelBoundary {
 
     /// Display architecture specific (e.g. CPU registers or status flags) data
     /// for a process identified by the stored state for that process.
+    ///
+    /// ### Safety
+    ///
+    /// This function guarantees that it if needs to change process memory, it
+    /// will only change memory starting at `accessible_memory_start` and before
+    /// `app_brk`. The caller is responsible for guaranteeing that those
+    /// pointers are valid for the process.
     unsafe fn print_context(
         &self,
         accessible_memory_start: *const u8,


### PR DESCRIPTION
sched.rs and process.rs had several functions marked entirely `unsafe`, resulting in hundreds of lines of code where unsafe operations were allowed and no clear "ownership" of where the unsafe operations were actually being checked.

This PR:

1. Significantly reduces the LoC where `unsafe` is implicitly allowed, and 
2. Tries to clarify where we are doing checks to ensure the unsafe operations are OK.

RFC:

In Tock we try to define `unsafe` as strictly "memory unsafe", not "sensitive function that should be called carefully". I argue that the process.X functions that used to be marked `unsafe` are doing the required checks to ensure that they are memory safe, and therefore shouldn't be marked `unsafe`. I think I was the one who asked for `set_byte()` to be marked `unsafe`, but I think I was wrong about that, since the set_byte implementation does the required check.

Does this seem like the approach we want to take? Should we do something else?





### Testing Strategy

travis


### TODO or Help Wanted

Comments?


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
