### PR TITLE
make: rustup now prints to stderr

### DIFF
--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -115,7 +115,7 @@ export TOCK_KERNEL_VERSION := $(shell git describe --tags --always 2> /dev/null 
 
 # Validate that rustup is new enough.
 MINIMUM_RUSTUP_VERSION := 1.11.0
-RUSTUP_VERSION := $(strip $(word 2, $(shell $(RUSTUP) --version)))
+RUSTUP_VERSION := $(strip $(word 2, $(shell $(RUSTUP) --version 2> /dev/null)))
 ifeq ($(shell $(TOCK_ROOT_DIRECTORY)tools/semver.sh $(RUSTUP_VERSION) \< $(MINIMUM_RUSTUP_VERSION)), true)
   $(warning Required tool `$(RUSTUP)` is out-of-date.)
   $(warning Running `$(RUSTUP) update` in 3 seconds (ctrl-c to cancel))


### PR DESCRIPTION
### Pull Request Overview

I updated rustup and got:

```
$ make
info: This is the version for the rustup toolchain manager, not the rustc compiler.
info: The currently active `rustc` version is `rustc 1.51.0-nightly (c2de47a9a 2021-01-06)`
   Compiling kernel v0.1.0 (/Users/bradjc/git/tock/kernel)
   Compiling riscv v0.1.0 (/Users/bradjc/git/tock/arch/riscv)
   Compiling capsules v0.1.0 (/Users/bradjc/git/tock/capsules)
   Compiling rv32i v0.1.0 (/Users/bradjc/git/tock/arch/rv32i)
   Compiling sifive v0.1.0 (/Users/bradjc/git/tock/chips/sifive)
   Compiling arty_e21_chip v0.1.0 (/Users/bradjc/git/tock/chips/arty_e21_chip)
   Compiling components v0.1.0 (/Users/bradjc/git/tock/boards/components)
   Compiling arty_e21 v0.1.0 (/Users/bradjc/git/tock/boards/arty_e21)
    Finished release [optimized + debuginfo] target(s) in 22.23s
   text	   data	    bss	    dec	    hex	filename
  65705	   3780	  12600	  82085	  140a5	/Users/bradjc/git/tock/target/riscv32imac-unknown-none-elf/release/arty_e21
6f897a1cc487e331fe19e2a4791a24fe4b57df245460b0dcb2cc82ae8b94bfef	/Users/bradjc/git/tock/target/riscv32imac-unknown-none-elf/release/arty_e21.bin
```

This removes the "info: " lines.


### Testing Strategy

travis


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
