### PR TITLE
CI: format on ubuntu, separate clippy

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -2,7 +2,7 @@
 # pushed to master.
 status = [
   "ci-format (ubuntu-latest)", "ci-build (ubuntu-latest)", "ci-tests (ubuntu-latest)", "ci-qemu",
-  "ci-format (macos-latest)", "ci-build (macos-latest)", "ci-tests (macos-latest)"
+  "ci-build (macos-latest)", "ci-tests (macos-latest)"
 ]
 
 # List of PR labels that may not be attached to a PR when it is r+-ed.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1 # pulls version from rust-toolchain file
-      - uses: actions/setup-node@v1
         with:
           components: clippy
       - name: ci-job-clippy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
   ci-format:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
     # The type of runner that the job will run on
     runs-on: ${{ matrix.os }}
 
@@ -27,13 +27,28 @@ jobs:
       - uses: actions-rs/toolchain@v1 # pulls version from rust-toolchain file
       - uses: actions/setup-node@v1
         with:
-          components: rustfmt, clippy
+          components: rustfmt
       - name: ci-job-format
         run:  make ci-job-format
-      - name: ci-job-clippy
-        run:  make ci-job-clippy
       - name: ci-markdown-toc
         run: make ci-job-markdown-toc
+
+  ci-clippy:
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+    # The type of runner that the job will run on
+    runs-on: ${{ matrix.os }}
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1 # pulls version from rust-toolchain file
+      - uses: actions/setup-node@v1
+        with:
+          components: clippy
+      - name: ci-job-clippy
+        run:  make ci-job-clippy
 
   ci-build:
     strategy:


### PR DESCRIPTION
### Pull Request Overview

Having `ci-format` also run clippy catches me every time, because I don't expect to fail formatting when I have rustfmt run everytime I save a file. I think clippy should be it's own check.

Also, I don't see the need to run formatting and clippy on multiple OSes, as those are purely source checks. This change will make the github CI UI easier to read.


### Testing Strategy

travis


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
