### PR TITLE
Bump tockloader to version 1.6.0

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -20,14 +20,14 @@ let
 
     tockloader = buildPythonPackage rec {
       pname = "tockloader";
-      version = "1.3.1";
+      version = "1.6.0";
       name = "${pname}-${version}";
 
       propagatedBuildInputs = [ argcomplete colorama crcmod pyserial pytoml ];
 
       src = fetchPypi {
         inherit pname version;
-        sha256 = "1gralnhvl82xr7rkrmxj0c1rxn1y9dlbmkkrklcdjahragbknivn";
+        sha256 = "1aqkj1nplcw3gmklrhq6vxy6v9ad5mqiw4y1svasak2zkqdk1wyc";
       };
     };
   });


### PR DESCRIPTION
shell.nix provides a two-year old version of tockloader.   I was hoping that simply updating it would allow me to interact with a Tock kernel loaded on a Nucleo-F429zi board, but I have not yet gotten this to work.