### PR TITLE
Tock 2.0 - AppSlice: fix unsoundness with arbitrary pointers in slices

### DIFF
--- a/kernel/src/mem.rs
+++ b/kernel/src/mem.rs
@@ -170,6 +170,13 @@ pub struct ReadWriteAppSlice {
 }
 
 impl ReadWriteAppSlice {
+    /// Construct a new [`ReadWriteAppSlice`] over a given pointer and
+    /// length.
+    ///
+    /// # Safety requirements
+    ///
+    /// Refer to the safety requirments of
+    /// [`ReadWriteAppSlice::new_external`].
     pub(crate) unsafe fn new(ptr: *mut u8, len: usize, process_id: AppId) -> Self {
         ReadWriteAppSlice {
             ptr,
@@ -178,6 +185,44 @@ impl ReadWriteAppSlice {
         }
     }
 
+    /// Construct a new [`ReadWriteAppSlice`] over a given pointer and
+    /// length.
+    ///
+    /// Publicly accessible constructor, which requires the
+    /// [`capabilities::ExternalProcessCapability`] capability. This
+    /// is provided to allow implementations of the
+    /// [`ProcessType`](crate::process::ProcessType) trait outside of
+    /// the `kernel` crate.
+    ///
+    /// # Safety requirements
+    ///
+    /// In Rust, no two slices may point to the same memory location
+    /// if at least one is mutable. This constructor relies on the
+    /// fact that at most a single [`ReadWriteAppSlice`] or
+    /// [`ReadOnlyAppSlice`] will point to the memory region of `[ptr;
+    /// ptr + len)`, and no other slice in scope anywhere in the
+    /// kernel points to an overlapping memory region.
+    ///
+    /// If the length is `0`, an arbitrary pointer may be passed into
+    /// `ptr`. It does not necessarily have to point to allocated
+    /// memory, nor does it have to meet [Rust's pointer validity
+    /// requirements](https://doc.rust-lang.org/core/ptr/index.html#safety).
+    /// [`ReadWriteAppSlice`] must ensure that all Rust slices with a
+    /// length of `0` must be constructed over a valid (but not
+    /// necessarily allocated) base pointer.
+    ///
+    /// If the length is not `0`, the memory region of `[ptr; ptr +
+    /// len)` must be valid memory of the process of the given
+    /// [`AppId`]. It must be allocated and and accessible over the
+    /// entire lifetime of the [`ReadWriteAppSlice`]. It must not
+    /// point to memory outside of the process' accessible memory
+    /// range, or point (in part) to other processes or kernel
+    /// memory. The `ptr` must meet [Rust's requirements for pointer
+    /// validity](https://doc.rust-lang.org/core/ptr/index.html#safety),
+    /// in particular it must have a minimum alignment of
+    /// `core::mem::align_of::<u8>()` on the respective platform. It
+    /// must point to memory mapped as _readable_ and _writable_ and
+    /// optionally _executable_.
     pub unsafe fn new_external(
         ptr: *mut u8,
         len: usize,
@@ -283,6 +328,13 @@ pub struct ReadOnlyAppSlice {
 }
 
 impl ReadOnlyAppSlice {
+    /// Construct a new [`ReadOnlyAppSlice`] over a given pointer and
+    /// length.
+    ///
+    /// # Safety requirements
+    ///
+    /// Refer to the safety requirments of
+    /// [`ReadOnlyAppSlice::new_external`].
     pub(crate) unsafe fn new(ptr: *const u8, len: usize, process_id: AppId) -> Self {
         ReadOnlyAppSlice {
             ptr,
@@ -291,6 +343,44 @@ impl ReadOnlyAppSlice {
         }
     }
 
+    /// Construct a new [`ReadOnlyAppSlice`] over a given pointer and
+    /// length.
+    ///
+    /// Publicly accessible constructor, which requires the
+    /// [`capabilities::ExternalProcessCapability`] capability. This
+    /// is provided to allow implementations of the
+    /// [`ProcessType`](crate::process::ProcessType) trait outside of
+    /// the `kernel` crate.
+    ///
+    /// # Safety requirements
+    ///
+    /// In Rust, no two slices may point to the same memory location
+    /// if at least one is mutable. This constructor relies on the
+    /// fact that at most a single [`ReadWriteAppSlice`] or
+    /// [`ReadOnlyAppSlice`] will point to the memory region of `[ptr;
+    /// ptr + len)`, and no other slice in scope anywhere in the
+    /// kernel points to an overlapping memory region.
+    ///
+    /// If the length is `0`, an arbitrary pointer may be passed into
+    /// `ptr`. It does not necessarily have to point to allocated
+    /// memory, nor does it have to meet [Rust's pointer validity
+    /// requirements](https://doc.rust-lang.org/core/ptr/index.html#safety).
+    /// [`ReadOnlyAppSlice`] must ensure that all Rust slices with a
+    /// length of `0` must be constructed over a valid (but not
+    /// necessarily allocated) base pointer.
+    ///
+    /// If the length is not `0`, the memory region of `[ptr; ptr +
+    /// len)` must be valid memory of the process of the given
+    /// [`AppId`]. It must be allocated and and accessible over the
+    /// entire lifetime of the [`ReadOnlyAppSlice`]. It must not point
+    /// to memory outside of the process' accessible memory range, or
+    /// point (in part) to other processes or kernel memory. The `ptr`
+    /// must meet [Rust's requirements for pointer
+    /// validity](https://doc.rust-lang.org/core/ptr/index.html#safety),
+    /// in particular it must have a minimum alignment of
+    /// `core::mem::align_of::<u8>()` on the respective platform. It
+    /// must point to memory mapped as _readable_ and optionally
+    /// _writable_ and _executable_.
     pub unsafe fn new_external(
         ptr: *const u8,
         len: usize,


### PR DESCRIPTION
### Pull Request Overview

Rust has strict pointer validity requirements, which -- in part -- also apply to accesses of zero length. In Tock 2.0, `AppSlice`s are
allowed to have arbitrary pointers passed in by userspace as long as their length is set to be 0. However, it is still not automatically safe & sound to construct Rust slices from these pointers.

This change ensures that if an AppSlice of length 0 is used (i.e. a Rust slice is created), the pointer is set to the value returned by `NonNull::dangling()`, which is guaranteed to meet the alignment & other requirements for valid pointers posed by Rust, while not requiring (or ensuring) that the memory which the pointer points to is valid or allocated. Therefore, this is only safe for zero-length accesses (e.g. for zero-length slices).

This duplicates a bunch of documentation. However this is a very important invariant we must uphold and as such, I feel it justifies the additional verbosity and explicit explanation on each of the three occurrences.

Signed-off-by: Leon Schuermann <leon@is.currently.online>

### Testing Strategy

TODO! This pull request needs testing.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] ~Updated the relevant files in `/docs`, or~ no updates are required.

### Formatting

- [x] Ran `make prepush`.
