### PR TITLE
Tock 2.0 - ReadWriteAppSlice: require mutable borrow for ReadWrite::mut_map_or 

### DIFF
--- a/capsules/src/spi_controller.rs
+++ b/capsules/src/spi_controller.rs
@@ -263,6 +263,7 @@ impl<S: SpiMasterDevice> SpiMasterClient for Spi<'_, S> {
     ) {
         self.app.map(move |app| {
             let rbuf = readbuf.map(|src| {
+                let index = app.index;
                 app.app_read.mut_map_or((), |dest| {
                     // Need to be careful that app_read hasn't changed
                     // under us, so check all values against actual
@@ -271,8 +272,8 @@ impl<S: SpiMasterDevice> SpiMasterClient for Spi<'_, S> {
                     // If app_read is shorter than before, and shorter
                     // than what we have read would require, then truncate.
                     // -pal 12/9/20
-                    let end = app.index;
-                    let start = app.index - length;
+                    let end = index;
+                    let start = index - length;
                     let end = cmp::min(end, cmp::min(src.len(), dest.len()));
 
                     // If the new endpoint is earlier than our expected

--- a/capsules/src/spi_peripheral.rs
+++ b/capsules/src/spi_peripheral.rs
@@ -253,6 +253,7 @@ impl<S: SpiSlaveDevice> SpiSlaveClient for SpiPeripheral<'_, S> {
     ) {
         self.app.map(move |app| {
             let rbuf = readbuf.map(|src| {
+                let index = app.index;
                 app.app_read.mut_map_or((), |dest| {
                     // Need to be careful that app_read hasn't changed
                     // under us, so check all values against actual
@@ -261,8 +262,8 @@ impl<S: SpiSlaveDevice> SpiSlaveClient for SpiPeripheral<'_, S> {
                     // If app_read is shorter than before, and shorter
                     // than what we have read would require, then truncate.
                     // -pal 12/9/20
-                    let end = app.index;
-                    let start = app.index - length;
+                    let end = index;
+                    let start = index - length;
                     let end = cmp::min(end, cmp::min(src.len(), dest.len()));
 
                     // If the new endpoint is earlier than our expected

--- a/kernel/src/mem.rs
+++ b/kernel/src/mem.rs
@@ -94,7 +94,7 @@ pub trait ReadWrite: Read {
     ///
     /// A default instance of an AppSlice must return the passed
     /// default value without executing the closure.
-    fn mut_map_or<F, R>(&self, default: R, fun: F) -> R
+    fn mut_map_or<F, R>(&mut self, default: R, fun: F) -> R
     where
         F: FnOnce(&mut [u8]) -> R;
 }
@@ -162,7 +162,7 @@ impl ReadWrite for ReadWriteAppSlice {
         }
     }
 
-    fn mut_map_or<F, R>(&self, default: R, fun: F) -> R
+    fn mut_map_or<F, R>(&mut self, default: R, fun: F) -> R
     where
         F: FnOnce(&mut [u8]) -> R,
     {


### PR DESCRIPTION
### Pull Request Overview

Prior to this change, a `ReadWriteAppSlice` could be used to obtain two mutable Rust slices to the same memory region. In Rust, at any given time, one can have either one mutable reference or any number of immutable references to some object / memory, and as such this is incorrect.

This changes `ReadWriteAppSlice::mut_map_or` to take a mutable reference to `self` and as such enforces these rules when taking a mutable borrow of the `ReadWriteAppSlice` itself.

Furthermore, this changes the way references to a `ReadWriteAppSlice` are handled in capsules such that a call to `ReadWrite::mut_map_or` can take a mutable reference to `self`. The changes were rather mechanical, and while there are possibly more elegant solutions by refactoring larger parts of the capsule code, this is outside of the scope of this PR.

### Testing Strategy

This pull request was tested by compiling.

### TODO or Help Wanted

N/A

### Documentation Updated

- [x] ~Updated the relevant files in `/docs`, or~ no updates are required.

### Formatting

- [x] Ran `make prepush`.

### Acknowledgements

Thanks to @jrvanwhy for reporting this issue on #2464.
