### PR TITLE
arch: cortex-m: clarify panic

### DIFF
--- a/arch/cortex-m/src/lib.rs
+++ b/arch/cortex-m/src/lib.rs
@@ -538,7 +538,7 @@ pub unsafe fn print_cortexm_state(writer: &mut dyn Write) {
     let vecttbl = (hfsr & 0x02) == 0x02;
     let forced = (hfsr & 0x40000000) == 0x40000000;
 
-    let _ = writer.write_fmt(format_args!("\r\n---| Fault Status |---\r\n"));
+    let _ = writer.write_fmt(format_args!("\r\n---| Cortex-M Fault Status |---\r\n"));
 
     if iaccviol {
         let _ = writer.write_fmt(format_args!(
@@ -671,7 +671,7 @@ pub unsafe fn print_cortexm_state(writer: &mut dyn Write) {
     }
 
     if cfsr == 0 && hfsr == 0 {
-        let _ = writer.write_fmt(format_args!("No faults detected.\r\n"));
+        let _ = writer.write_fmt(format_args!("No Cortex-M faults detected.\r\n"));
     } else {
         let _ = writer.write_fmt(format_args!(
             "Fault Status Register (CFSR):       {:#010X}\r\n",


### PR DESCRIPTION
Minor textual change in cortex-m panic handler. Saying "no faults detected" when the a process faulted is a little confusing.

This mostly mirrors the rv32i implementation.


### Testing Strategy

travis


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
