### PR TITLE
shell.nix: remove deprecated stdenv.lib

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -15,7 +15,7 @@
 with builtins;
 let
   inherit (pkgs) stdenv;
-  pythonPackages = stdenv.lib.fix' (self: with self; pkgs.python3Packages //
+  pythonPackages = lib.fix' (self: with self; pkgs.python3Packages //
   {
 
     tockloader = buildPythonPackage rec {


### PR DESCRIPTION
### Pull Request Overview

As indicated in [1], upstream Nixpkgs has decided to deprecate providing `lib` as part of the standard environments (`stdenv`), given that those are independent of each other as documented in [2].

Accordingly, this changes usage of `pkgs.stdenv.lib` to `pkgs.lib`. A remaining warning about usage of `stdenv.lib` might still be caused by the Mozilla Rust overlay, which must be fixed upstream.

[1]: https://github.com/NixOS/nixpkgs/issues/108938
[2]: https://github.com/NixOS/nixpkgs/commit/c06b2b3d671da4847f950e7e9041920b40eca0bf

Signed-off-by: Leon Schuermann <leon@is.currently.online>

Cc @alevy 

### Testing Strategy

This pull request was tested by evaluating the Nix derivation.

### TODO or Help Wanted

N/A

### Documentation Updated

- [x] ~Updated the relevant files in `/docs`, or~ no updates are required.

### Formatting

- [x] Ran `make prepush`.
