### PR TITLE
riscv: Use macros to create non-PMP CSRs

### DIFF
--- a/arch/riscv/src/csr/mod.rs
+++ b/arch/riscv/src/csr/mod.rs
@@ -1,6 +1,15 @@
 //! Tock Register interface for using CSR registers.
 
-use riscv_csr::csr::ReadWriteRiscvCsr;
+use core::marker::PhantomData;
+use tock_registers::registers::{
+    Field, FieldValue, IntLike, LocalRegisterCopy, RegisterLongName, TryFromValue,
+};
+
+use riscv_csr::csr::{
+    ReadWriteRiscvPmpCsr, MCAUSE, MCYCLE, MCYCLEH, MEPC, MIE, MINSTRET, MINSTRETH, MIP, MSCRATCH,
+    MSTATUS, MTVAL, MTVEC, STVEC, UTVEC,
+};
+use riscv_csr::riscv_csr;
 
 pub mod mcause;
 pub mod mcycle;
@@ -17,6 +26,21 @@ pub mod pmpconfig;
 pub mod stvec;
 pub mod utvec;
 
+riscv_csr!(MINSTRETH, ReadWriteRiscvCsrMinstreth);
+riscv_csr!(MINSTRET, ReadWriteRiscvCsrMinstret);
+riscv_csr!(MCYCLEH, ReadWriteRiscvCsrMcycleh);
+riscv_csr!(MCYCLE, ReadWriteRiscvCsrMcycle);
+riscv_csr!(MIE, ReadWriteRiscvCsrMie);
+riscv_csr!(MTVEC, ReadWriteRiscvCsrMtvec);
+riscv_csr!(MSCRATCH, ReadWriteRiscvCsrMscratch);
+riscv_csr!(MEPC, ReadWriteRiscvCsrMepc);
+riscv_csr!(MCAUSE, ReadWriteRiscvCsrMcause);
+riscv_csr!(MTVAL, ReadWriteRiscvCsrMtval);
+riscv_csr!(MIP, ReadWriteRiscvCsrMip);
+riscv_csr!(MSTATUS, ReadWriteRiscvCsrMstatus);
+riscv_csr!(STVEC, ReadWriteRiscvCsrStvec);
+riscv_csr!(UTVEC, ReadWriteRiscvCsrUtvec);
+
 // NOTE! We default to 32 bit if this is being compiled for debug/testing. We do
 // this by using `cfg` that check for either the architecture is `riscv32` (true
 // if we are compiling for a rv32i target), OR if the target OS is set to
@@ -25,139 +49,148 @@ pub mod utvec;
 #[repr(C)]
 pub struct CSR {
     #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
-    pub minstreth: ReadWriteRiscvCsr<usize, minstret::minstreth::Register>,
-    pub minstret: ReadWriteRiscvCsr<usize, minstret::minstret::Register>,
+    pub minstreth: ReadWriteRiscvCsrMinstreth<usize, minstret::minstreth::Register>,
+    pub minstret: ReadWriteRiscvCsrMinstret<usize, minstret::minstret::Register>,
+
     #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
-    pub mcycleh: ReadWriteRiscvCsr<usize, mcycle::mcycleh::Register>,
-    pub mcycle: ReadWriteRiscvCsr<usize, mcycle::mcycle::Register>,
+    pub mcycleh: ReadWriteRiscvCsrMcycleh<usize, mcycle::mcycleh::Register>,
+    pub mcycle: ReadWriteRiscvCsrMcycle<usize, mcycle::mcycle::Register>,
+
     #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
-    pub pmpcfg: [ReadWriteRiscvCsr<usize, pmpconfig::pmpcfg::Register>; 16],
+    pub pmpcfg: [ReadWriteRiscvPmpCsr<usize, pmpconfig::pmpcfg::Register>; 16],
     #[cfg(target_arch = "riscv64")]
-    pub pmpcfg: [ReadWriteRiscvCsr<usize, pmpconfig::pmpcfg::Register>; 8],
-    pub pmpaddr: [ReadWriteRiscvCsr<usize, pmpaddr::pmpaddr::Register>; 64],
-    pub mie: ReadWriteRiscvCsr<usize, mie::mie::Register>,
-    pub mscratch: ReadWriteRiscvCsr<usize, mscratch::mscratch::Register>,
-    pub mepc: ReadWriteRiscvCsr<usize, mepc::mepc::Register>,
-    pub mcause: ReadWriteRiscvCsr<usize, mcause::mcause::Register>,
-    pub mtval: ReadWriteRiscvCsr<usize, mtval::mtval::Register>,
-    pub mip: ReadWriteRiscvCsr<usize, mip::mip::Register>,
-    pub mtvec: ReadWriteRiscvCsr<usize, mtvec::mtvec::Register>,
-    pub stvec: ReadWriteRiscvCsr<usize, stvec::stvec::Register>,
-    pub utvec: ReadWriteRiscvCsr<usize, utvec::utvec::Register>,
-    pub mstatus: ReadWriteRiscvCsr<usize, mstatus::mstatus::Register>,
+    pub pmpcfg: [ReadWriteRiscvPmpCsr<usize, pmpconfig::pmpcfg::Register>; 8],
+
+    pub pmpaddr: [ReadWriteRiscvPmpCsr<usize, pmpaddr::pmpaddr::Register>; 64],
+
+    pub mie: ReadWriteRiscvCsrMie<usize, mie::mie::Register>,
+    pub mtvec: ReadWriteRiscvCsrMtvec<usize, mtvec::mtvec::Register>,
+    pub mscratch: ReadWriteRiscvCsrMscratch<usize, mscratch::mscratch::Register>,
+    pub mepc: ReadWriteRiscvCsrMepc<usize, mepc::mepc::Register>,
+    pub mcause: ReadWriteRiscvCsrMcause<usize, mcause::mcause::Register>,
+    pub mtval: ReadWriteRiscvCsrMtval<usize, mtval::mtval::Register>,
+    pub mip: ReadWriteRiscvCsrMip<usize, mip::mip::Register>,
+    pub mstatus: ReadWriteRiscvCsrMstatus<usize, mstatus::mstatus::Register>,
+
+    pub stvec: ReadWriteRiscvCsrStvec<usize, stvec::stvec::Register>,
+    pub utvec: ReadWriteRiscvCsrUtvec<usize, utvec::utvec::Register>,
 }
 
 // Define the "addresses" of each CSR register.
 pub const CSR: &CSR = &CSR {
     #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
-    minstreth: ReadWriteRiscvCsr::new(riscv_csr::csr::MINSTRETH),
-    minstret: ReadWriteRiscvCsr::new(riscv_csr::csr::MINSTRET),
+    minstreth: ReadWriteRiscvCsrMinstreth::new(),
+    minstret: ReadWriteRiscvCsrMinstret::new(),
+
     #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
-    mcycleh: ReadWriteRiscvCsr::new(riscv_csr::csr::MCYCLEH),
-    mcycle: ReadWriteRiscvCsr::new(riscv_csr::csr::MCYCLE),
-    mie: ReadWriteRiscvCsr::new(riscv_csr::csr::MIE),
-    mtvec: ReadWriteRiscvCsr::new(riscv_csr::csr::MTVEC),
-    mstatus: ReadWriteRiscvCsr::new(riscv_csr::csr::MSTATUS),
-    utvec: ReadWriteRiscvCsr::new(riscv_csr::csr::UTVEC),
-    stvec: ReadWriteRiscvCsr::new(riscv_csr::csr::STVEC),
-    mscratch: ReadWriteRiscvCsr::new(riscv_csr::csr::MSCRATCH),
-    mepc: ReadWriteRiscvCsr::new(riscv_csr::csr::MEPC),
-    mcause: ReadWriteRiscvCsr::new(riscv_csr::csr::MCAUSE),
-    mtval: ReadWriteRiscvCsr::new(riscv_csr::csr::MTVAL),
-    mip: ReadWriteRiscvCsr::new(riscv_csr::csr::MIP),
+    mcycleh: ReadWriteRiscvCsrMcycleh::new(),
+    mcycle: ReadWriteRiscvCsrMcycle::new(),
 
     pmpcfg: [
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPCFG0),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPCFG0),
         #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPCFG1),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPCFG2),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPCFG1),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPCFG2),
         #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPCFG3),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPCFG4),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPCFG3),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPCFG4),
         #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPCFG5),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPCFG6),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPCFG5),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPCFG6),
         #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPCFG7),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPCFG8),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPCFG7),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPCFG8),
         #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPCFG9),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPCFG10),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPCFG9),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPCFG10),
         #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPCFG11),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPCFG12),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPCFG11),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPCFG12),
         #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPCFG13),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPCFG14),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPCFG13),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPCFG14),
         #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPCFG15),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPCFG15),
     ],
+
     pmpaddr: [
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR0),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR1),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR2),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR3),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR4),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR5),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR6),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR7),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR8),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR9),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR10),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR11),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR12),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR13),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR14),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR15),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR16),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR17),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR18),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR19),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR20),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR21),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR22),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR23),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR24),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR25),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR26),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR27),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR28),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR29),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR30),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR31),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR32),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR33),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR34),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR35),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR36),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR37),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR38),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR39),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR40),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR41),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR42),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR43),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR44),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR45),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR46),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR47),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR48),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR49),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR50),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR51),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR52),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR53),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR54),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR55),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR56),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR57),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR58),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR59),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR60),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR61),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR62),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR63),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR0),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR1),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR2),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR3),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR4),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR5),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR6),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR7),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR8),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR9),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR10),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR11),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR12),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR13),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR14),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR15),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR16),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR17),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR18),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR19),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR20),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR21),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR22),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR23),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR24),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR25),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR26),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR27),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR28),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR29),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR30),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR31),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR32),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR33),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR34),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR35),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR36),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR37),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR38),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR39),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR40),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR41),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR42),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR43),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR44),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR45),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR46),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR47),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR48),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR49),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR50),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR51),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR52),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR53),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR54),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR55),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR56),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR57),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR58),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR59),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR60),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR61),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR62),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR63),
     ],
+
+    mie: ReadWriteRiscvCsrMie::new(),
+    mtvec: ReadWriteRiscvCsrMtvec::new(),
+    mscratch: ReadWriteRiscvCsrMscratch::new(),
+    mepc: ReadWriteRiscvCsrMepc::new(),
+    mcause: ReadWriteRiscvCsrMcause::new(),
+    mtval: ReadWriteRiscvCsrMtval::new(),
+    mip: ReadWriteRiscvCsrMip::new(),
+    mstatus: ReadWriteRiscvCsrMstatus::new(),
+
+    stvec: ReadWriteRiscvCsrStvec::new(),
+    utvec: ReadWriteRiscvCsrUtvec::new(),
 };
 
 impl CSR {

--- a/arch/riscv/src/lib.rs
+++ b/arch/riscv/src/lib.rs
@@ -3,6 +3,8 @@
 #![crate_name = "riscv"]
 #![crate_type = "rlib"]
 #![no_std]
+#![feature(asm)]
+#![feature(const_fn)]
 
 pub mod csr;
 


### PR DESCRIPTION
### Pull Request Overview

The current giant switch table for RISC-V CSRs is a pain to edit and extend.

With more RISC-V extensions on the way and with some RISC-V implementations using CSRs to modify the system the list of CSRs is only growing.

In an effort to try and cleanup and improve the RISC-V CSRs (which are also some of the largest functions in the Tock kernel) I have added a macro that generates RISC-V CSR access functions.

Unfortunately I can't figure out a way to do with for the array of PMP CSRs.

### Testing Strategy

CI

### TODO or Help Wanted

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
