### PR TITLE
Cleanup RISC-V CSRs

### DIFF
--- a/arch/riscv/src/csr/mod.rs
+++ b/arch/riscv/src/csr/mod.rs
@@ -35,111 +35,6 @@ pub mod pmpconfig;
 pub mod stvec;
 pub mod utvec;
 
-riscv_csr!(MINSTRETH, ReadWriteRiscvCsrMinstreth);
-riscv_csr!(MINSTRET, ReadWriteRiscvCsrMinstret);
-riscv_csr!(MCYCLEH, ReadWriteRiscvCsrMcycleh);
-riscv_csr!(MCYCLE, ReadWriteRiscvCsrMcycle);
-riscv_csr!(MIE, ReadWriteRiscvCsrMie);
-riscv_csr!(MTVEC, ReadWriteRiscvCsrMtvec);
-riscv_csr!(MSCRATCH, ReadWriteRiscvCsrMscratch);
-riscv_csr!(MEPC, ReadWriteRiscvCsrMepc);
-riscv_csr!(MCAUSE, ReadWriteRiscvCsrMcause);
-riscv_csr!(MTVAL, ReadWriteRiscvCsrMtval);
-riscv_csr!(MIP, ReadWriteRiscvCsrMip);
-riscv_csr!(MSTATUS, ReadWriteRiscvCsrMstatus);
-riscv_csr!(STVEC, ReadWriteRiscvCsrStvec);
-riscv_csr!(UTVEC, ReadWriteRiscvCsrUtvec);
-
-riscv_csr!(PMPCFG0, ReadWriteRiscvCsrPmpcfg0);
-#[cfg(not(target_arch = "riscv64"))]
-riscv_csr!(PMPCFG1, ReadWriteRiscvCsrPmpcfg1);
-riscv_csr!(PMPCFG2, ReadWriteRiscvCsrPmpcfg2);
-#[cfg(not(target_arch = "riscv64"))]
-riscv_csr!(PMPCFG3, ReadWriteRiscvCsrPmpcfg3);
-riscv_csr!(PMPCFG4, ReadWriteRiscvCsrPmpcfg4);
-#[cfg(not(target_arch = "riscv64"))]
-riscv_csr!(PMPCFG5, ReadWriteRiscvCsrPmpcfg5);
-riscv_csr!(PMPCFG6, ReadWriteRiscvCsrPmpcfg6);
-#[cfg(not(target_arch = "riscv64"))]
-riscv_csr!(PMPCFG7, ReadWriteRiscvCsrPmpcfg7);
-riscv_csr!(PMPCFG8, ReadWriteRiscvCsrPmpcfg8);
-#[cfg(not(target_arch = "riscv64"))]
-riscv_csr!(PMPCFG9, ReadWriteRiscvCsrPmpcfg9);
-riscv_csr!(PMPCFG10, ReadWriteRiscvCsrPmpcfg10);
-#[cfg(not(target_arch = "riscv64"))]
-riscv_csr!(PMPCFG11, ReadWriteRiscvCsrPmpcfg11);
-riscv_csr!(PMPCFG12, ReadWriteRiscvCsrPmpcfg12);
-#[cfg(not(target_arch = "riscv64"))]
-riscv_csr!(PMPCFG13, ReadWriteRiscvCsrPmpcfg13);
-riscv_csr!(PMPCFG14, ReadWriteRiscvCsrPmpcfg14);
-#[cfg(not(target_arch = "riscv64"))]
-riscv_csr!(PMPCFG15, ReadWriteRiscvCsrPmpcfg15);
-
-riscv_csr!(PMPADDR0, ReadWriteRiscvCsrPmpaddr0);
-riscv_csr!(PMPADDR1, ReadWriteRiscvCsrPmpaddr1);
-riscv_csr!(PMPADDR2, ReadWriteRiscvCsrPmpaddr2);
-riscv_csr!(PMPADDR3, ReadWriteRiscvCsrPmpaddr3);
-riscv_csr!(PMPADDR4, ReadWriteRiscvCsrPmpaddr4);
-riscv_csr!(PMPADDR5, ReadWriteRiscvCsrPmpaddr5);
-riscv_csr!(PMPADDR6, ReadWriteRiscvCsrPmpaddr6);
-riscv_csr!(PMPADDR7, ReadWriteRiscvCsrPmpaddr7);
-riscv_csr!(PMPADDR8, ReadWriteRiscvCsrPmpaddr8);
-riscv_csr!(PMPADDR9, ReadWriteRiscvCsrPmpaddr9);
-riscv_csr!(PMPADDR10, ReadWriteRiscvCsrPmpaddr10);
-riscv_csr!(PMPADDR11, ReadWriteRiscvCsrPmpaddr11);
-riscv_csr!(PMPADDR12, ReadWriteRiscvCsrPmpaddr12);
-riscv_csr!(PMPADDR13, ReadWriteRiscvCsrPmpaddr13);
-riscv_csr!(PMPADDR14, ReadWriteRiscvCsrPmpaddr14);
-riscv_csr!(PMPADDR15, ReadWriteRiscvCsrPmpaddr15);
-riscv_csr!(PMPADDR16, ReadWriteRiscvCsrPmpaddr16);
-riscv_csr!(PMPADDR17, ReadWriteRiscvCsrPmpaddr17);
-riscv_csr!(PMPADDR18, ReadWriteRiscvCsrPmpaddr18);
-riscv_csr!(PMPADDR19, ReadWriteRiscvCsrPmpaddr19);
-riscv_csr!(PMPADDR20, ReadWriteRiscvCsrPmpaddr20);
-riscv_csr!(PMPADDR21, ReadWriteRiscvCsrPmpaddr21);
-riscv_csr!(PMPADDR22, ReadWriteRiscvCsrPmpaddr22);
-riscv_csr!(PMPADDR23, ReadWriteRiscvCsrPmpaddr23);
-riscv_csr!(PMPADDR24, ReadWriteRiscvCsrPmpaddr24);
-riscv_csr!(PMPADDR25, ReadWriteRiscvCsrPmpaddr25);
-riscv_csr!(PMPADDR26, ReadWriteRiscvCsrPmpaddr26);
-riscv_csr!(PMPADDR27, ReadWriteRiscvCsrPmpaddr27);
-riscv_csr!(PMPADDR28, ReadWriteRiscvCsrPmpaddr28);
-riscv_csr!(PMPADDR29, ReadWriteRiscvCsrPmpaddr29);
-riscv_csr!(PMPADDR30, ReadWriteRiscvCsrPmpaddr30);
-riscv_csr!(PMPADDR31, ReadWriteRiscvCsrPmpaddr31);
-riscv_csr!(PMPADDR32, ReadWriteRiscvCsrPmpaddr32);
-riscv_csr!(PMPADDR33, ReadWriteRiscvCsrPmpaddr33);
-riscv_csr!(PMPADDR34, ReadWriteRiscvCsrPmpaddr34);
-riscv_csr!(PMPADDR35, ReadWriteRiscvCsrPmpaddr35);
-riscv_csr!(PMPADDR36, ReadWriteRiscvCsrPmpaddr36);
-riscv_csr!(PMPADDR37, ReadWriteRiscvCsrPmpaddr37);
-riscv_csr!(PMPADDR38, ReadWriteRiscvCsrPmpaddr38);
-riscv_csr!(PMPADDR39, ReadWriteRiscvCsrPmpaddr39);
-riscv_csr!(PMPADDR40, ReadWriteRiscvCsrPmpaddr40);
-riscv_csr!(PMPADDR41, ReadWriteRiscvCsrPmpaddr41);
-riscv_csr!(PMPADDR42, ReadWriteRiscvCsrPmpaddr42);
-riscv_csr!(PMPADDR43, ReadWriteRiscvCsrPmpaddr43);
-riscv_csr!(PMPADDR44, ReadWriteRiscvCsrPmpaddr44);
-riscv_csr!(PMPADDR45, ReadWriteRiscvCsrPmpaddr45);
-riscv_csr!(PMPADDR46, ReadWriteRiscvCsrPmpaddr46);
-riscv_csr!(PMPADDR47, ReadWriteRiscvCsrPmpaddr47);
-riscv_csr!(PMPADDR48, ReadWriteRiscvCsrPmpaddr48);
-riscv_csr!(PMPADDR49, ReadWriteRiscvCsrPmpaddr49);
-riscv_csr!(PMPADDR50, ReadWriteRiscvCsrPmpaddr50);
-riscv_csr!(PMPADDR51, ReadWriteRiscvCsrPmpaddr51);
-riscv_csr!(PMPADDR52, ReadWriteRiscvCsrPmpaddr52);
-riscv_csr!(PMPADDR53, ReadWriteRiscvCsrPmpaddr53);
-riscv_csr!(PMPADDR54, ReadWriteRiscvCsrPmpaddr54);
-riscv_csr!(PMPADDR55, ReadWriteRiscvCsrPmpaddr55);
-riscv_csr!(PMPADDR56, ReadWriteRiscvCsrPmpaddr56);
-riscv_csr!(PMPADDR57, ReadWriteRiscvCsrPmpaddr57);
-riscv_csr!(PMPADDR58, ReadWriteRiscvCsrPmpaddr58);
-riscv_csr!(PMPADDR59, ReadWriteRiscvCsrPmpaddr59);
-riscv_csr!(PMPADDR60, ReadWriteRiscvCsrPmpaddr60);
-riscv_csr!(PMPADDR61, ReadWriteRiscvCsrPmpaddr61);
-riscv_csr!(PMPADDR62, ReadWriteRiscvCsrPmpaddr62);
-riscv_csr!(PMPADDR63, ReadWriteRiscvCsrPmpaddr63);
-
 // NOTE! We default to 32 bit if this is being compiled for debug/testing. We do
 // this by using `cfg` that check for either the architecture is `riscv32` (true
 // if we are compiling for a rv32i target), OR if the target OS is set to
@@ -178,118 +73,118 @@ pub struct CSR<'a> {
 // Define the "addresses" of each CSR register.
 pub const CSR: &CSR = &CSR {
     #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
-    minstreth: &ReadWriteRiscvCsrMinstreth::new(),
-    minstret: &ReadWriteRiscvCsrMinstret::new(),
+    minstreth: riscv_csr!(MINSTRETH, ReadWriteRiscvCsrMinstreth),
+    minstret: riscv_csr!(MINSTRET, ReadWriteRiscvCsrMinstret),
 
     #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
-    mcycleh: &ReadWriteRiscvCsrMcycleh::new(),
-    mcycle: &ReadWriteRiscvCsrMcycle::new(),
+    mcycleh: riscv_csr!(MCYCLEH, ReadWriteRiscvCsrMcycleh),
+    mcycle: riscv_csr!(MCYCLE, ReadWriteRiscvCsrMcycle),
 
     pmpcfg: [
-        &ReadWriteRiscvCsrPmpcfg0::new(),
+        riscv_csr!(PMPCFG0, ReadWriteRiscvCsrPmpcfg0),
         #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
-        &ReadWriteRiscvCsrPmpcfg1::new(),
-        &ReadWriteRiscvCsrPmpcfg2::new(),
+        riscv_csr!(PMPCFG1, ReadWriteRiscvCsrPmpcfg1),
+        riscv_csr!(PMPCFG2, ReadWriteRiscvCsrPmpcfg2),
         #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
-        &ReadWriteRiscvCsrPmpcfg3::new(),
-        &ReadWriteRiscvCsrPmpcfg4::new(),
+        riscv_csr!(PMPCFG3, ReadWriteRiscvCsrPmpcfg3),
+        riscv_csr!(PMPCFG4, ReadWriteRiscvCsrPmpcfg4),
         #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
-        &ReadWriteRiscvCsrPmpcfg5::new(),
-        &ReadWriteRiscvCsrPmpcfg6::new(),
+        riscv_csr!(PMPCFG5, ReadWriteRiscvCsrPmpcfg5),
+        riscv_csr!(PMPCFG6, ReadWriteRiscvCsrPmpcfg6),
         #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
-        &ReadWriteRiscvCsrPmpcfg7::new(),
-        &ReadWriteRiscvCsrPmpcfg8::new(),
+        riscv_csr!(PMPCFG7, ReadWriteRiscvCsrPmpcfg7),
+        riscv_csr!(PMPCFG8, ReadWriteRiscvCsrPmpcfg8),
         #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
-        &ReadWriteRiscvCsrPmpcfg9::new(),
-        &ReadWriteRiscvCsrPmpcfg10::new(),
+        riscv_csr!(PMPCFG9, ReadWriteRiscvCsrPmpcfg9),
+        riscv_csr!(PMPCFG10, ReadWriteRiscvCsrPmpcfg10),
         #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
-        &ReadWriteRiscvCsrPmpcfg11::new(),
-        &ReadWriteRiscvCsrPmpcfg12::new(),
+        riscv_csr!(PMPCFG11, ReadWriteRiscvCsrPmpcfg11),
+        riscv_csr!(PMPCFG12, ReadWriteRiscvCsrPmpcfg12),
         #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
-        &ReadWriteRiscvCsrPmpcfg13::new(),
-        &ReadWriteRiscvCsrPmpcfg14::new(),
+        riscv_csr!(PMPCFG13, ReadWriteRiscvCsrPmpcfg13),
+        riscv_csr!(PMPCFG14, ReadWriteRiscvCsrPmpcfg14),
         #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
-        &ReadWriteRiscvCsrPmpcfg15::new(),
+        riscv_csr!(PMPCFG15, ReadWriteRiscvCsrPmpcfg15),
     ],
 
     pmpaddr: [
-        &ReadWriteRiscvCsrPmpaddr0::new(),
-        &ReadWriteRiscvCsrPmpaddr1::new(),
-        &ReadWriteRiscvCsrPmpaddr2::new(),
-        &ReadWriteRiscvCsrPmpaddr3::new(),
-        &ReadWriteRiscvCsrPmpaddr4::new(),
-        &ReadWriteRiscvCsrPmpaddr5::new(),
-        &ReadWriteRiscvCsrPmpaddr6::new(),
-        &ReadWriteRiscvCsrPmpaddr7::new(),
-        &ReadWriteRiscvCsrPmpaddr8::new(),
-        &ReadWriteRiscvCsrPmpaddr9::new(),
-        &ReadWriteRiscvCsrPmpaddr10::new(),
-        &ReadWriteRiscvCsrPmpaddr11::new(),
-        &ReadWriteRiscvCsrPmpaddr12::new(),
-        &ReadWriteRiscvCsrPmpaddr13::new(),
-        &ReadWriteRiscvCsrPmpaddr14::new(),
-        &ReadWriteRiscvCsrPmpaddr15::new(),
-        &ReadWriteRiscvCsrPmpaddr16::new(),
-        &ReadWriteRiscvCsrPmpaddr17::new(),
-        &ReadWriteRiscvCsrPmpaddr18::new(),
-        &ReadWriteRiscvCsrPmpaddr19::new(),
-        &ReadWriteRiscvCsrPmpaddr20::new(),
-        &ReadWriteRiscvCsrPmpaddr21::new(),
-        &ReadWriteRiscvCsrPmpaddr22::new(),
-        &ReadWriteRiscvCsrPmpaddr23::new(),
-        &ReadWriteRiscvCsrPmpaddr24::new(),
-        &ReadWriteRiscvCsrPmpaddr25::new(),
-        &ReadWriteRiscvCsrPmpaddr26::new(),
-        &ReadWriteRiscvCsrPmpaddr27::new(),
-        &ReadWriteRiscvCsrPmpaddr28::new(),
-        &ReadWriteRiscvCsrPmpaddr29::new(),
-        &ReadWriteRiscvCsrPmpaddr30::new(),
-        &ReadWriteRiscvCsrPmpaddr31::new(),
-        &ReadWriteRiscvCsrPmpaddr32::new(),
-        &ReadWriteRiscvCsrPmpaddr33::new(),
-        &ReadWriteRiscvCsrPmpaddr34::new(),
-        &ReadWriteRiscvCsrPmpaddr35::new(),
-        &ReadWriteRiscvCsrPmpaddr36::new(),
-        &ReadWriteRiscvCsrPmpaddr37::new(),
-        &ReadWriteRiscvCsrPmpaddr38::new(),
-        &ReadWriteRiscvCsrPmpaddr39::new(),
-        &ReadWriteRiscvCsrPmpaddr40::new(),
-        &ReadWriteRiscvCsrPmpaddr41::new(),
-        &ReadWriteRiscvCsrPmpaddr42::new(),
-        &ReadWriteRiscvCsrPmpaddr43::new(),
-        &ReadWriteRiscvCsrPmpaddr44::new(),
-        &ReadWriteRiscvCsrPmpaddr45::new(),
-        &ReadWriteRiscvCsrPmpaddr46::new(),
-        &ReadWriteRiscvCsrPmpaddr47::new(),
-        &ReadWriteRiscvCsrPmpaddr48::new(),
-        &ReadWriteRiscvCsrPmpaddr49::new(),
-        &ReadWriteRiscvCsrPmpaddr50::new(),
-        &ReadWriteRiscvCsrPmpaddr51::new(),
-        &ReadWriteRiscvCsrPmpaddr52::new(),
-        &ReadWriteRiscvCsrPmpaddr53::new(),
-        &ReadWriteRiscvCsrPmpaddr54::new(),
-        &ReadWriteRiscvCsrPmpaddr55::new(),
-        &ReadWriteRiscvCsrPmpaddr56::new(),
-        &ReadWriteRiscvCsrPmpaddr57::new(),
-        &ReadWriteRiscvCsrPmpaddr58::new(),
-        &ReadWriteRiscvCsrPmpaddr59::new(),
-        &ReadWriteRiscvCsrPmpaddr60::new(),
-        &ReadWriteRiscvCsrPmpaddr61::new(),
-        &ReadWriteRiscvCsrPmpaddr62::new(),
-        &ReadWriteRiscvCsrPmpaddr63::new(),
+        riscv_csr!(PMPADDR0, ReadWriteRiscvCsrPmpaddr0),
+        riscv_csr!(PMPADDR1, ReadWriteRiscvCsrPmpaddr1),
+        riscv_csr!(PMPADDR2, ReadWriteRiscvCsrPmpaddr2),
+        riscv_csr!(PMPADDR3, ReadWriteRiscvCsrPmpaddr3),
+        riscv_csr!(PMPADDR4, ReadWriteRiscvCsrPmpaddr4),
+        riscv_csr!(PMPADDR5, ReadWriteRiscvCsrPmpaddr5),
+        riscv_csr!(PMPADDR6, ReadWriteRiscvCsrPmpaddr6),
+        riscv_csr!(PMPADDR7, ReadWriteRiscvCsrPmpaddr7),
+        riscv_csr!(PMPADDR8, ReadWriteRiscvCsrPmpaddr8),
+        riscv_csr!(PMPADDR9, ReadWriteRiscvCsrPmpaddr9),
+        riscv_csr!(PMPADDR10, ReadWriteRiscvCsrPmpaddr10),
+        riscv_csr!(PMPADDR11, ReadWriteRiscvCsrPmpaddr11),
+        riscv_csr!(PMPADDR12, ReadWriteRiscvCsrPmpaddr12),
+        riscv_csr!(PMPADDR13, ReadWriteRiscvCsrPmpaddr13),
+        riscv_csr!(PMPADDR14, ReadWriteRiscvCsrPmpaddr14),
+        riscv_csr!(PMPADDR15, ReadWriteRiscvCsrPmpaddr15),
+        riscv_csr!(PMPADDR16, ReadWriteRiscvCsrPmpaddr16),
+        riscv_csr!(PMPADDR17, ReadWriteRiscvCsrPmpaddr17),
+        riscv_csr!(PMPADDR18, ReadWriteRiscvCsrPmpaddr18),
+        riscv_csr!(PMPADDR19, ReadWriteRiscvCsrPmpaddr19),
+        riscv_csr!(PMPADDR20, ReadWriteRiscvCsrPmpaddr20),
+        riscv_csr!(PMPADDR21, ReadWriteRiscvCsrPmpaddr21),
+        riscv_csr!(PMPADDR22, ReadWriteRiscvCsrPmpaddr22),
+        riscv_csr!(PMPADDR23, ReadWriteRiscvCsrPmpaddr23),
+        riscv_csr!(PMPADDR24, ReadWriteRiscvCsrPmpaddr24),
+        riscv_csr!(PMPADDR25, ReadWriteRiscvCsrPmpaddr25),
+        riscv_csr!(PMPADDR26, ReadWriteRiscvCsrPmpaddr26),
+        riscv_csr!(PMPADDR27, ReadWriteRiscvCsrPmpaddr27),
+        riscv_csr!(PMPADDR28, ReadWriteRiscvCsrPmpaddr28),
+        riscv_csr!(PMPADDR29, ReadWriteRiscvCsrPmpaddr29),
+        riscv_csr!(PMPADDR30, ReadWriteRiscvCsrPmpaddr30),
+        riscv_csr!(PMPADDR31, ReadWriteRiscvCsrPmpaddr31),
+        riscv_csr!(PMPADDR32, ReadWriteRiscvCsrPmpaddr32),
+        riscv_csr!(PMPADDR33, ReadWriteRiscvCsrPmpaddr33),
+        riscv_csr!(PMPADDR34, ReadWriteRiscvCsrPmpaddr34),
+        riscv_csr!(PMPADDR35, ReadWriteRiscvCsrPmpaddr35),
+        riscv_csr!(PMPADDR36, ReadWriteRiscvCsrPmpaddr36),
+        riscv_csr!(PMPADDR37, ReadWriteRiscvCsrPmpaddr37),
+        riscv_csr!(PMPADDR38, ReadWriteRiscvCsrPmpaddr38),
+        riscv_csr!(PMPADDR39, ReadWriteRiscvCsrPmpaddr39),
+        riscv_csr!(PMPADDR40, ReadWriteRiscvCsrPmpaddr40),
+        riscv_csr!(PMPADDR41, ReadWriteRiscvCsrPmpaddr41),
+        riscv_csr!(PMPADDR42, ReadWriteRiscvCsrPmpaddr42),
+        riscv_csr!(PMPADDR43, ReadWriteRiscvCsrPmpaddr43),
+        riscv_csr!(PMPADDR44, ReadWriteRiscvCsrPmpaddr44),
+        riscv_csr!(PMPADDR45, ReadWriteRiscvCsrPmpaddr45),
+        riscv_csr!(PMPADDR46, ReadWriteRiscvCsrPmpaddr46),
+        riscv_csr!(PMPADDR47, ReadWriteRiscvCsrPmpaddr47),
+        riscv_csr!(PMPADDR48, ReadWriteRiscvCsrPmpaddr48),
+        riscv_csr!(PMPADDR49, ReadWriteRiscvCsrPmpaddr49),
+        riscv_csr!(PMPADDR50, ReadWriteRiscvCsrPmpaddr50),
+        riscv_csr!(PMPADDR51, ReadWriteRiscvCsrPmpaddr51),
+        riscv_csr!(PMPADDR52, ReadWriteRiscvCsrPmpaddr52),
+        riscv_csr!(PMPADDR53, ReadWriteRiscvCsrPmpaddr53),
+        riscv_csr!(PMPADDR54, ReadWriteRiscvCsrPmpaddr54),
+        riscv_csr!(PMPADDR55, ReadWriteRiscvCsrPmpaddr55),
+        riscv_csr!(PMPADDR56, ReadWriteRiscvCsrPmpaddr56),
+        riscv_csr!(PMPADDR57, ReadWriteRiscvCsrPmpaddr57),
+        riscv_csr!(PMPADDR58, ReadWriteRiscvCsrPmpaddr58),
+        riscv_csr!(PMPADDR59, ReadWriteRiscvCsrPmpaddr59),
+        riscv_csr!(PMPADDR60, ReadWriteRiscvCsrPmpaddr60),
+        riscv_csr!(PMPADDR61, ReadWriteRiscvCsrPmpaddr61),
+        riscv_csr!(PMPADDR62, ReadWriteRiscvCsrPmpaddr62),
+        riscv_csr!(PMPADDR63, ReadWriteRiscvCsrPmpaddr63),
     ],
 
-    mie: &ReadWriteRiscvCsrMie::new(),
-    mtvec: &ReadWriteRiscvCsrMtvec::new(),
-    mscratch: &ReadWriteRiscvCsrMscratch::new(),
-    mepc: &ReadWriteRiscvCsrMepc::new(),
-    mcause: &ReadWriteRiscvCsrMcause::new(),
-    mtval: &ReadWriteRiscvCsrMtval::new(),
-    mip: &ReadWriteRiscvCsrMip::new(),
-    mstatus: &ReadWriteRiscvCsrMstatus::new(),
+    mie: riscv_csr!(MIE, ReadWriteRiscvCsrMie),
+    mtvec: riscv_csr!(MTVEC, ReadWriteRiscvCsrMtvec),
+    mscratch: riscv_csr!(MSCRATCH, ReadWriteRiscvCsrMscratch),
+    mepc: riscv_csr!(MEPC, ReadWriteRiscvCsrMepc),
+    mcause: riscv_csr!(MCAUSE, ReadWriteRiscvCsrMcause),
+    mtval: riscv_csr!(MTVAL, ReadWriteRiscvCsrMtval),
+    mip: riscv_csr!(MIP, ReadWriteRiscvCsrMip),
+    mstatus: riscv_csr!(MSTATUS, ReadWriteRiscvCsrMstatus),
 
-    stvec: &ReadWriteRiscvCsrStvec::new(),
-    utvec: &ReadWriteRiscvCsrUtvec::new(),
+    stvec: riscv_csr!(STVEC, ReadWriteRiscvCsrStvec),
+    utvec: riscv_csr!(UTVEC, ReadWriteRiscvCsrUtvec),
 };
 
 impl CSR<'_> {

--- a/arch/riscv/src/csr/mod.rs
+++ b/arch/riscv/src/csr/mod.rs
@@ -1,6 +1,15 @@
 //! Tock Register interface for using CSR registers.
 
-use riscv_csr::csr::ReadWriteRiscvCsr;
+use core::marker::PhantomData;
+use tock_registers::registers::{
+    Field, FieldValue, IntLike, LocalRegisterCopy, RegisterLongName, TryFromValue,
+};
+
+use riscv_csr::csr::{
+    ReadWriteRiscvPmpCsr, MCAUSE, MCYCLE, MCYCLEH, MEPC, MIE, MINSTRET, MINSTRETH, MIP, MSCRATCH,
+    MSTATUS, MTVAL, MTVEC, STVEC, UTVEC,
+};
+use riscv_csr::riscv_csr;
 
 pub mod mcause;
 pub mod mcycle;
@@ -17,6 +26,21 @@ pub mod pmpconfig;
 pub mod stvec;
 pub mod utvec;
 
+riscv_csr!(MINSTRETH, ReadWriteRiscvCsrMinstreth);
+riscv_csr!(MINSTRET, ReadWriteRiscvCsrMinstret);
+riscv_csr!(MCYCLEH, ReadWriteRiscvCsrMcycleh);
+riscv_csr!(MCYCLE, ReadWriteRiscvCsrMcycle);
+riscv_csr!(MIE, ReadWriteRiscvCsrMie);
+riscv_csr!(MTVEC, ReadWriteRiscvCsrMtvec);
+riscv_csr!(MSCRATCH, ReadWriteRiscvCsrMscratch);
+riscv_csr!(MEPC, ReadWriteRiscvCsrMepc);
+riscv_csr!(MCAUSE, ReadWriteRiscvCsrMcause);
+riscv_csr!(MTVAL, ReadWriteRiscvCsrMtval);
+riscv_csr!(MIP, ReadWriteRiscvCsrMip);
+riscv_csr!(MSTATUS, ReadWriteRiscvCsrMstatus);
+riscv_csr!(STVEC, ReadWriteRiscvCsrStvec);
+riscv_csr!(UTVEC, ReadWriteRiscvCsrUtvec);
+
 // NOTE! We default to 32 bit if this is being compiled for debug/testing. We do
 // this by using `cfg` that check for either the architecture is `riscv32` (true
 // if we are compiling for a rv32i target), OR if the target OS is set to
@@ -25,139 +49,148 @@ pub mod utvec;
 #[repr(C)]
 pub struct CSR {
     #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
-    pub minstreth: ReadWriteRiscvCsr<usize, minstret::minstreth::Register>,
-    pub minstret: ReadWriteRiscvCsr<usize, minstret::minstret::Register>,
+    pub minstreth: ReadWriteRiscvCsrMinstreth<usize, minstret::minstreth::Register>,
+    pub minstret: ReadWriteRiscvCsrMinstret<usize, minstret::minstret::Register>,
+
     #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
-    pub mcycleh: ReadWriteRiscvCsr<usize, mcycle::mcycleh::Register>,
-    pub mcycle: ReadWriteRiscvCsr<usize, mcycle::mcycle::Register>,
+    pub mcycleh: ReadWriteRiscvCsrMcycleh<usize, mcycle::mcycleh::Register>,
+    pub mcycle: ReadWriteRiscvCsrMcycle<usize, mcycle::mcycle::Register>,
+
     #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
-    pub pmpcfg: [ReadWriteRiscvCsr<usize, pmpconfig::pmpcfg::Register>; 16],
+    pub pmpcfg: [ReadWriteRiscvPmpCsr<usize, pmpconfig::pmpcfg::Register>; 16],
     #[cfg(target_arch = "riscv64")]
-    pub pmpcfg: [ReadWriteRiscvCsr<usize, pmpconfig::pmpcfg::Register>; 8],
-    pub pmpaddr: [ReadWriteRiscvCsr<usize, pmpaddr::pmpaddr::Register>; 64],
-    pub mie: ReadWriteRiscvCsr<usize, mie::mie::Register>,
-    pub mscratch: ReadWriteRiscvCsr<usize, mscratch::mscratch::Register>,
-    pub mepc: ReadWriteRiscvCsr<usize, mepc::mepc::Register>,
-    pub mcause: ReadWriteRiscvCsr<usize, mcause::mcause::Register>,
-    pub mtval: ReadWriteRiscvCsr<usize, mtval::mtval::Register>,
-    pub mip: ReadWriteRiscvCsr<usize, mip::mip::Register>,
-    pub mtvec: ReadWriteRiscvCsr<usize, mtvec::mtvec::Register>,
-    pub stvec: ReadWriteRiscvCsr<usize, stvec::stvec::Register>,
-    pub utvec: ReadWriteRiscvCsr<usize, utvec::utvec::Register>,
-    pub mstatus: ReadWriteRiscvCsr<usize, mstatus::mstatus::Register>,
+    pub pmpcfg: [ReadWriteRiscvPmpCsr<usize, pmpconfig::pmpcfg::Register>; 8],
+
+    pub pmpaddr: [ReadWriteRiscvPmpCsr<usize, pmpaddr::pmpaddr::Register>; 64],
+
+    pub mie: ReadWriteRiscvCsrMie<usize, mie::mie::Register>,
+    pub mtvec: ReadWriteRiscvCsrMtvec<usize, mtvec::mtvec::Register>,
+    pub mscratch: ReadWriteRiscvCsrMscratch<usize, mscratch::mscratch::Register>,
+    pub mepc: ReadWriteRiscvCsrMepc<usize, mepc::mepc::Register>,
+    pub mcause: ReadWriteRiscvCsrMcause<usize, mcause::mcause::Register>,
+    pub mtval: ReadWriteRiscvCsrMtval<usize, mtval::mtval::Register>,
+    pub mip: ReadWriteRiscvCsrMip<usize, mip::mip::Register>,
+    pub mstatus: ReadWriteRiscvCsrMstatus<usize, mstatus::mstatus::Register>,
+
+    pub stvec: ReadWriteRiscvCsrStvec<usize, stvec::stvec::Register>,
+    pub utvec: ReadWriteRiscvCsrUtvec<usize, utvec::utvec::Register>,
 }
 
 // Define the "addresses" of each CSR register.
 pub const CSR: &CSR = &CSR {
     #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
-    minstreth: ReadWriteRiscvCsr::new(riscv_csr::csr::MINSTRETH),
-    minstret: ReadWriteRiscvCsr::new(riscv_csr::csr::MINSTRET),
+    minstreth: ReadWriteRiscvCsrMinstreth::new(),
+    minstret: ReadWriteRiscvCsrMinstret::new(),
+
     #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
-    mcycleh: ReadWriteRiscvCsr::new(riscv_csr::csr::MCYCLEH),
-    mcycle: ReadWriteRiscvCsr::new(riscv_csr::csr::MCYCLE),
-    mie: ReadWriteRiscvCsr::new(riscv_csr::csr::MIE),
-    mtvec: ReadWriteRiscvCsr::new(riscv_csr::csr::MTVEC),
-    mstatus: ReadWriteRiscvCsr::new(riscv_csr::csr::MSTATUS),
-    utvec: ReadWriteRiscvCsr::new(riscv_csr::csr::UTVEC),
-    stvec: ReadWriteRiscvCsr::new(riscv_csr::csr::STVEC),
-    mscratch: ReadWriteRiscvCsr::new(riscv_csr::csr::MSCRATCH),
-    mepc: ReadWriteRiscvCsr::new(riscv_csr::csr::MEPC),
-    mcause: ReadWriteRiscvCsr::new(riscv_csr::csr::MCAUSE),
-    mtval: ReadWriteRiscvCsr::new(riscv_csr::csr::MTVAL),
-    mip: ReadWriteRiscvCsr::new(riscv_csr::csr::MIP),
+    mcycleh: ReadWriteRiscvCsrMcycleh::new(),
+    mcycle: ReadWriteRiscvCsrMcycle::new(),
 
     pmpcfg: [
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPCFG0),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPCFG0),
         #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPCFG1),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPCFG2),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPCFG1),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPCFG2),
         #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPCFG3),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPCFG4),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPCFG3),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPCFG4),
         #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPCFG5),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPCFG6),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPCFG5),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPCFG6),
         #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPCFG7),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPCFG8),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPCFG7),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPCFG8),
         #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPCFG9),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPCFG10),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPCFG9),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPCFG10),
         #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPCFG11),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPCFG12),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPCFG11),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPCFG12),
         #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPCFG13),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPCFG14),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPCFG13),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPCFG14),
         #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPCFG15),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPCFG15),
     ],
+
     pmpaddr: [
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR0),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR1),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR2),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR3),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR4),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR5),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR6),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR7),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR8),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR9),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR10),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR11),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR12),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR13),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR14),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR15),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR16),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR17),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR18),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR19),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR20),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR21),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR22),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR23),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR24),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR25),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR26),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR27),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR28),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR29),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR30),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR31),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR32),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR33),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR34),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR35),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR36),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR37),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR38),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR39),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR40),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR41),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR42),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR43),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR44),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR45),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR46),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR47),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR48),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR49),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR50),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR51),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR52),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR53),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR54),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR55),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR56),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR57),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR58),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR59),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR60),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR61),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR62),
-        ReadWriteRiscvCsr::new(riscv_csr::csr::PMPADDR63),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR0),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR1),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR2),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR3),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR4),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR5),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR6),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR7),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR8),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR9),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR10),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR11),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR12),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR13),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR14),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR15),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR16),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR17),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR18),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR19),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR20),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR21),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR22),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR23),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR24),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR25),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR26),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR27),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR28),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR29),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR30),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR31),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR32),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR33),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR34),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR35),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR36),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR37),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR38),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR39),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR40),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR41),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR42),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR43),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR44),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR45),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR46),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR47),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR48),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR49),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR50),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR51),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR52),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR53),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR54),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR55),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR56),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR57),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR58),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR59),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR60),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR61),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR62),
+        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR63),
     ],
+
+    mie: ReadWriteRiscvCsrMie::new(),
+    mtvec: ReadWriteRiscvCsrMtvec::new(),
+    mscratch: ReadWriteRiscvCsrMscratch::new(),
+    mepc: ReadWriteRiscvCsrMepc::new(),
+    mcause: ReadWriteRiscvCsrMcause::new(),
+    mtval: ReadWriteRiscvCsrMtval::new(),
+    mip: ReadWriteRiscvCsrMip::new(),
+    mstatus: ReadWriteRiscvCsrMstatus::new(),
+
+    stvec: ReadWriteRiscvCsrStvec::new(),
+    utvec: ReadWriteRiscvCsrUtvec::new(),
 };
 
 impl CSR {

--- a/arch/riscv/src/csr/mod.rs
+++ b/arch/riscv/src/csr/mod.rs
@@ -1,15 +1,24 @@
 //! Tock Register interface for using CSR registers.
 
 use core::marker::PhantomData;
-use tock_registers::registers::{
-    Field, FieldValue, IntLike, LocalRegisterCopy, RegisterLongName, TryFromValue,
-};
+use tock_registers::registers::{IntLike, RegisterLongName};
 
 use riscv_csr::csr::{
-    ReadWriteRiscvPmpCsr, MCAUSE, MCYCLE, MCYCLEH, MEPC, MIE, MINSTRET, MINSTRETH, MIP, MSCRATCH,
-    MSTATUS, MTVAL, MTVEC, STVEC, UTVEC,
+    MCAUSE, MCYCLE, MCYCLEH, MEPC, MIE, MINSTRET, MINSTRETH, MIP, MSCRATCH, MSTATUS, MTVAL, MTVEC,
+    PMPADDR0, PMPADDR1, PMPADDR10, PMPADDR11, PMPADDR12, PMPADDR13, PMPADDR14, PMPADDR15,
+    PMPADDR16, PMPADDR17, PMPADDR18, PMPADDR19, PMPADDR2, PMPADDR20, PMPADDR21, PMPADDR22,
+    PMPADDR23, PMPADDR24, PMPADDR25, PMPADDR26, PMPADDR27, PMPADDR28, PMPADDR29, PMPADDR3,
+    PMPADDR30, PMPADDR31, PMPADDR32, PMPADDR33, PMPADDR34, PMPADDR35, PMPADDR36, PMPADDR37,
+    PMPADDR38, PMPADDR39, PMPADDR4, PMPADDR40, PMPADDR41, PMPADDR42, PMPADDR43, PMPADDR44,
+    PMPADDR45, PMPADDR46, PMPADDR47, PMPADDR48, PMPADDR49, PMPADDR5, PMPADDR50, PMPADDR51,
+    PMPADDR52, PMPADDR53, PMPADDR54, PMPADDR55, PMPADDR56, PMPADDR57, PMPADDR58, PMPADDR59,
+    PMPADDR6, PMPADDR60, PMPADDR61, PMPADDR62, PMPADDR63, PMPADDR7, PMPADDR8, PMPADDR9, PMPCFG0,
+    PMPCFG1, PMPCFG10, PMPCFG11, PMPCFG12, PMPCFG13, PMPCFG14, PMPCFG15, PMPCFG2, PMPCFG3, PMPCFG4,
+    PMPCFG5, PMPCFG6, PMPCFG7, PMPCFG8, PMPCFG9, STVEC, UTVEC,
 };
 use riscv_csr::riscv_csr;
+
+pub use riscv_csr::csr::RISCVCSRReadWrite;
 
 pub mod mcause;
 pub mod mcycle;
@@ -41,159 +50,249 @@ riscv_csr!(MSTATUS, ReadWriteRiscvCsrMstatus);
 riscv_csr!(STVEC, ReadWriteRiscvCsrStvec);
 riscv_csr!(UTVEC, ReadWriteRiscvCsrUtvec);
 
+riscv_csr!(PMPCFG0, ReadWriteRiscvCsrPmpcfg0);
+#[cfg(not(target_arch = "riscv64"))]
+riscv_csr!(PMPCFG1, ReadWriteRiscvCsrPmpcfg1);
+riscv_csr!(PMPCFG2, ReadWriteRiscvCsrPmpcfg2);
+#[cfg(not(target_arch = "riscv64"))]
+riscv_csr!(PMPCFG3, ReadWriteRiscvCsrPmpcfg3);
+riscv_csr!(PMPCFG4, ReadWriteRiscvCsrPmpcfg4);
+#[cfg(not(target_arch = "riscv64"))]
+riscv_csr!(PMPCFG5, ReadWriteRiscvCsrPmpcfg5);
+riscv_csr!(PMPCFG6, ReadWriteRiscvCsrPmpcfg6);
+#[cfg(not(target_arch = "riscv64"))]
+riscv_csr!(PMPCFG7, ReadWriteRiscvCsrPmpcfg7);
+riscv_csr!(PMPCFG8, ReadWriteRiscvCsrPmpcfg8);
+#[cfg(not(target_arch = "riscv64"))]
+riscv_csr!(PMPCFG9, ReadWriteRiscvCsrPmpcfg9);
+riscv_csr!(PMPCFG10, ReadWriteRiscvCsrPmpcfg10);
+#[cfg(not(target_arch = "riscv64"))]
+riscv_csr!(PMPCFG11, ReadWriteRiscvCsrPmpcfg11);
+riscv_csr!(PMPCFG12, ReadWriteRiscvCsrPmpcfg12);
+#[cfg(not(target_arch = "riscv64"))]
+riscv_csr!(PMPCFG13, ReadWriteRiscvCsrPmpcfg13);
+riscv_csr!(PMPCFG14, ReadWriteRiscvCsrPmpcfg14);
+#[cfg(not(target_arch = "riscv64"))]
+riscv_csr!(PMPCFG15, ReadWriteRiscvCsrPmpcfg15);
+
+riscv_csr!(PMPADDR0, ReadWriteRiscvCsrPmpaddr0);
+riscv_csr!(PMPADDR1, ReadWriteRiscvCsrPmpaddr1);
+riscv_csr!(PMPADDR2, ReadWriteRiscvCsrPmpaddr2);
+riscv_csr!(PMPADDR3, ReadWriteRiscvCsrPmpaddr3);
+riscv_csr!(PMPADDR4, ReadWriteRiscvCsrPmpaddr4);
+riscv_csr!(PMPADDR5, ReadWriteRiscvCsrPmpaddr5);
+riscv_csr!(PMPADDR6, ReadWriteRiscvCsrPmpaddr6);
+riscv_csr!(PMPADDR7, ReadWriteRiscvCsrPmpaddr7);
+riscv_csr!(PMPADDR8, ReadWriteRiscvCsrPmpaddr8);
+riscv_csr!(PMPADDR9, ReadWriteRiscvCsrPmpaddr9);
+riscv_csr!(PMPADDR10, ReadWriteRiscvCsrPmpaddr10);
+riscv_csr!(PMPADDR11, ReadWriteRiscvCsrPmpaddr11);
+riscv_csr!(PMPADDR12, ReadWriteRiscvCsrPmpaddr12);
+riscv_csr!(PMPADDR13, ReadWriteRiscvCsrPmpaddr13);
+riscv_csr!(PMPADDR14, ReadWriteRiscvCsrPmpaddr14);
+riscv_csr!(PMPADDR15, ReadWriteRiscvCsrPmpaddr15);
+riscv_csr!(PMPADDR16, ReadWriteRiscvCsrPmpaddr16);
+riscv_csr!(PMPADDR17, ReadWriteRiscvCsrPmpaddr17);
+riscv_csr!(PMPADDR18, ReadWriteRiscvCsrPmpaddr18);
+riscv_csr!(PMPADDR19, ReadWriteRiscvCsrPmpaddr19);
+riscv_csr!(PMPADDR20, ReadWriteRiscvCsrPmpaddr20);
+riscv_csr!(PMPADDR21, ReadWriteRiscvCsrPmpaddr21);
+riscv_csr!(PMPADDR22, ReadWriteRiscvCsrPmpaddr22);
+riscv_csr!(PMPADDR23, ReadWriteRiscvCsrPmpaddr23);
+riscv_csr!(PMPADDR24, ReadWriteRiscvCsrPmpaddr24);
+riscv_csr!(PMPADDR25, ReadWriteRiscvCsrPmpaddr25);
+riscv_csr!(PMPADDR26, ReadWriteRiscvCsrPmpaddr26);
+riscv_csr!(PMPADDR27, ReadWriteRiscvCsrPmpaddr27);
+riscv_csr!(PMPADDR28, ReadWriteRiscvCsrPmpaddr28);
+riscv_csr!(PMPADDR29, ReadWriteRiscvCsrPmpaddr29);
+riscv_csr!(PMPADDR30, ReadWriteRiscvCsrPmpaddr30);
+riscv_csr!(PMPADDR31, ReadWriteRiscvCsrPmpaddr31);
+riscv_csr!(PMPADDR32, ReadWriteRiscvCsrPmpaddr32);
+riscv_csr!(PMPADDR33, ReadWriteRiscvCsrPmpaddr33);
+riscv_csr!(PMPADDR34, ReadWriteRiscvCsrPmpaddr34);
+riscv_csr!(PMPADDR35, ReadWriteRiscvCsrPmpaddr35);
+riscv_csr!(PMPADDR36, ReadWriteRiscvCsrPmpaddr36);
+riscv_csr!(PMPADDR37, ReadWriteRiscvCsrPmpaddr37);
+riscv_csr!(PMPADDR38, ReadWriteRiscvCsrPmpaddr38);
+riscv_csr!(PMPADDR39, ReadWriteRiscvCsrPmpaddr39);
+riscv_csr!(PMPADDR40, ReadWriteRiscvCsrPmpaddr40);
+riscv_csr!(PMPADDR41, ReadWriteRiscvCsrPmpaddr41);
+riscv_csr!(PMPADDR42, ReadWriteRiscvCsrPmpaddr42);
+riscv_csr!(PMPADDR43, ReadWriteRiscvCsrPmpaddr43);
+riscv_csr!(PMPADDR44, ReadWriteRiscvCsrPmpaddr44);
+riscv_csr!(PMPADDR45, ReadWriteRiscvCsrPmpaddr45);
+riscv_csr!(PMPADDR46, ReadWriteRiscvCsrPmpaddr46);
+riscv_csr!(PMPADDR47, ReadWriteRiscvCsrPmpaddr47);
+riscv_csr!(PMPADDR48, ReadWriteRiscvCsrPmpaddr48);
+riscv_csr!(PMPADDR49, ReadWriteRiscvCsrPmpaddr49);
+riscv_csr!(PMPADDR50, ReadWriteRiscvCsrPmpaddr50);
+riscv_csr!(PMPADDR51, ReadWriteRiscvCsrPmpaddr51);
+riscv_csr!(PMPADDR52, ReadWriteRiscvCsrPmpaddr52);
+riscv_csr!(PMPADDR53, ReadWriteRiscvCsrPmpaddr53);
+riscv_csr!(PMPADDR54, ReadWriteRiscvCsrPmpaddr54);
+riscv_csr!(PMPADDR55, ReadWriteRiscvCsrPmpaddr55);
+riscv_csr!(PMPADDR56, ReadWriteRiscvCsrPmpaddr56);
+riscv_csr!(PMPADDR57, ReadWriteRiscvCsrPmpaddr57);
+riscv_csr!(PMPADDR58, ReadWriteRiscvCsrPmpaddr58);
+riscv_csr!(PMPADDR59, ReadWriteRiscvCsrPmpaddr59);
+riscv_csr!(PMPADDR60, ReadWriteRiscvCsrPmpaddr60);
+riscv_csr!(PMPADDR61, ReadWriteRiscvCsrPmpaddr61);
+riscv_csr!(PMPADDR62, ReadWriteRiscvCsrPmpaddr62);
+riscv_csr!(PMPADDR63, ReadWriteRiscvCsrPmpaddr63);
+
 // NOTE! We default to 32 bit if this is being compiled for debug/testing. We do
 // this by using `cfg` that check for either the architecture is `riscv32` (true
 // if we are compiling for a rv32i target), OR if the target OS is set to
 // something (as it would be if compiled for a host OS).
 
 #[repr(C)]
-pub struct CSR {
+pub struct CSR<'a> {
     #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
-    pub minstreth: ReadWriteRiscvCsrMinstreth<usize, minstret::minstreth::Register>,
-    pub minstret: ReadWriteRiscvCsrMinstret<usize, minstret::minstret::Register>,
+    pub minstreth: &'a dyn RISCVCSRReadWrite<usize, minstret::minstreth::Register>,
+    pub minstret: &'a dyn RISCVCSRReadWrite<usize, minstret::minstret::Register>,
 
     #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
-    pub mcycleh: ReadWriteRiscvCsrMcycleh<usize, mcycle::mcycleh::Register>,
-    pub mcycle: ReadWriteRiscvCsrMcycle<usize, mcycle::mcycle::Register>,
+    pub mcycleh: &'a dyn RISCVCSRReadWrite<usize, mcycle::mcycleh::Register>,
+    pub mcycle: &'a dyn RISCVCSRReadWrite<usize, mcycle::mcycle::Register>,
 
     #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
-    pub pmpcfg: [ReadWriteRiscvPmpCsr<usize, pmpconfig::pmpcfg::Register>; 16],
+    pub pmpcfg: [&'a dyn RISCVCSRReadWrite<usize, pmpconfig::pmpcfg::Register>; 16],
     #[cfg(target_arch = "riscv64")]
-    pub pmpcfg: [ReadWriteRiscvPmpCsr<usize, pmpconfig::pmpcfg::Register>; 8],
+    pub pmpcfg: [&'a dyn RISCVCSRReadWrite<usize, pmpconfig::pmpcfg::Register>; 8],
 
-    pub pmpaddr: [ReadWriteRiscvPmpCsr<usize, pmpaddr::pmpaddr::Register>; 64],
+    pub pmpaddr: [&'a dyn RISCVCSRReadWrite<usize, pmpaddr::pmpaddr::Register>; 64],
 
-    pub mie: ReadWriteRiscvCsrMie<usize, mie::mie::Register>,
-    pub mtvec: ReadWriteRiscvCsrMtvec<usize, mtvec::mtvec::Register>,
-    pub mscratch: ReadWriteRiscvCsrMscratch<usize, mscratch::mscratch::Register>,
-    pub mepc: ReadWriteRiscvCsrMepc<usize, mepc::mepc::Register>,
-    pub mcause: ReadWriteRiscvCsrMcause<usize, mcause::mcause::Register>,
-    pub mtval: ReadWriteRiscvCsrMtval<usize, mtval::mtval::Register>,
-    pub mip: ReadWriteRiscvCsrMip<usize, mip::mip::Register>,
-    pub mstatus: ReadWriteRiscvCsrMstatus<usize, mstatus::mstatus::Register>,
+    pub mie: &'a dyn RISCVCSRReadWrite<usize, mie::mie::Register>,
+    pub mtvec: &'a dyn RISCVCSRReadWrite<usize, mtvec::mtvec::Register>,
+    pub mscratch: &'a dyn RISCVCSRReadWrite<usize, mscratch::mscratch::Register>,
+    pub mepc: &'a dyn RISCVCSRReadWrite<usize, mepc::mepc::Register>,
+    pub mcause: &'a dyn RISCVCSRReadWrite<usize, mcause::mcause::Register>,
+    pub mtval: &'a dyn RISCVCSRReadWrite<usize, mtval::mtval::Register>,
+    pub mip: &'a dyn RISCVCSRReadWrite<usize, mip::mip::Register>,
+    pub mstatus: &'a dyn RISCVCSRReadWrite<usize, mstatus::mstatus::Register>,
 
-    pub stvec: ReadWriteRiscvCsrStvec<usize, stvec::stvec::Register>,
-    pub utvec: ReadWriteRiscvCsrUtvec<usize, utvec::utvec::Register>,
+    pub stvec: &'a dyn RISCVCSRReadWrite<usize, stvec::stvec::Register>,
+    pub utvec: &'a dyn RISCVCSRReadWrite<usize, utvec::utvec::Register>,
 }
 
 // Define the "addresses" of each CSR register.
 pub const CSR: &CSR = &CSR {
     #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
-    minstreth: ReadWriteRiscvCsrMinstreth::new(),
-    minstret: ReadWriteRiscvCsrMinstret::new(),
+    minstreth: &ReadWriteRiscvCsrMinstreth::new(),
+    minstret: &ReadWriteRiscvCsrMinstret::new(),
 
     #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
-    mcycleh: ReadWriteRiscvCsrMcycleh::new(),
-    mcycle: ReadWriteRiscvCsrMcycle::new(),
+    mcycleh: &ReadWriteRiscvCsrMcycleh::new(),
+    mcycle: &ReadWriteRiscvCsrMcycle::new(),
 
     pmpcfg: [
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPCFG0),
+        &ReadWriteRiscvCsrPmpcfg0::new(),
         #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPCFG1),
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPCFG2),
+        &ReadWriteRiscvCsrPmpcfg1::new(),
+        &ReadWriteRiscvCsrPmpcfg2::new(),
         #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPCFG3),
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPCFG4),
+        &ReadWriteRiscvCsrPmpcfg3::new(),
+        &ReadWriteRiscvCsrPmpcfg4::new(),
         #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPCFG5),
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPCFG6),
+        &ReadWriteRiscvCsrPmpcfg5::new(),
+        &ReadWriteRiscvCsrPmpcfg6::new(),
         #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPCFG7),
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPCFG8),
+        &ReadWriteRiscvCsrPmpcfg7::new(),
+        &ReadWriteRiscvCsrPmpcfg8::new(),
         #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPCFG9),
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPCFG10),
+        &ReadWriteRiscvCsrPmpcfg9::new(),
+        &ReadWriteRiscvCsrPmpcfg10::new(),
         #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPCFG11),
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPCFG12),
+        &ReadWriteRiscvCsrPmpcfg11::new(),
+        &ReadWriteRiscvCsrPmpcfg12::new(),
         #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPCFG13),
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPCFG14),
+        &ReadWriteRiscvCsrPmpcfg13::new(),
+        &ReadWriteRiscvCsrPmpcfg14::new(),
         #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPCFG15),
+        &ReadWriteRiscvCsrPmpcfg15::new(),
     ],
 
     pmpaddr: [
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR0),
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR1),
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR2),
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR3),
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR4),
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR5),
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR6),
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR7),
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR8),
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR9),
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR10),
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR11),
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR12),
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR13),
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR14),
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR15),
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR16),
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR17),
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR18),
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR19),
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR20),
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR21),
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR22),
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR23),
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR24),
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR25),
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR26),
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR27),
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR28),
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR29),
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR30),
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR31),
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR32),
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR33),
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR34),
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR35),
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR36),
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR37),
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR38),
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR39),
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR40),
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR41),
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR42),
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR43),
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR44),
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR45),
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR46),
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR47),
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR48),
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR49),
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR50),
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR51),
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR52),
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR53),
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR54),
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR55),
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR56),
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR57),
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR58),
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR59),
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR60),
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR61),
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR62),
-        ReadWriteRiscvPmpCsr::new(riscv_csr::csr::PMPADDR63),
+        &ReadWriteRiscvCsrPmpaddr0::new(),
+        &ReadWriteRiscvCsrPmpaddr1::new(),
+        &ReadWriteRiscvCsrPmpaddr2::new(),
+        &ReadWriteRiscvCsrPmpaddr3::new(),
+        &ReadWriteRiscvCsrPmpaddr4::new(),
+        &ReadWriteRiscvCsrPmpaddr5::new(),
+        &ReadWriteRiscvCsrPmpaddr6::new(),
+        &ReadWriteRiscvCsrPmpaddr7::new(),
+        &ReadWriteRiscvCsrPmpaddr8::new(),
+        &ReadWriteRiscvCsrPmpaddr9::new(),
+        &ReadWriteRiscvCsrPmpaddr10::new(),
+        &ReadWriteRiscvCsrPmpaddr11::new(),
+        &ReadWriteRiscvCsrPmpaddr12::new(),
+        &ReadWriteRiscvCsrPmpaddr13::new(),
+        &ReadWriteRiscvCsrPmpaddr14::new(),
+        &ReadWriteRiscvCsrPmpaddr15::new(),
+        &ReadWriteRiscvCsrPmpaddr16::new(),
+        &ReadWriteRiscvCsrPmpaddr17::new(),
+        &ReadWriteRiscvCsrPmpaddr18::new(),
+        &ReadWriteRiscvCsrPmpaddr19::new(),
+        &ReadWriteRiscvCsrPmpaddr20::new(),
+        &ReadWriteRiscvCsrPmpaddr21::new(),
+        &ReadWriteRiscvCsrPmpaddr22::new(),
+        &ReadWriteRiscvCsrPmpaddr23::new(),
+        &ReadWriteRiscvCsrPmpaddr24::new(),
+        &ReadWriteRiscvCsrPmpaddr25::new(),
+        &ReadWriteRiscvCsrPmpaddr26::new(),
+        &ReadWriteRiscvCsrPmpaddr27::new(),
+        &ReadWriteRiscvCsrPmpaddr28::new(),
+        &ReadWriteRiscvCsrPmpaddr29::new(),
+        &ReadWriteRiscvCsrPmpaddr30::new(),
+        &ReadWriteRiscvCsrPmpaddr31::new(),
+        &ReadWriteRiscvCsrPmpaddr32::new(),
+        &ReadWriteRiscvCsrPmpaddr33::new(),
+        &ReadWriteRiscvCsrPmpaddr34::new(),
+        &ReadWriteRiscvCsrPmpaddr35::new(),
+        &ReadWriteRiscvCsrPmpaddr36::new(),
+        &ReadWriteRiscvCsrPmpaddr37::new(),
+        &ReadWriteRiscvCsrPmpaddr38::new(),
+        &ReadWriteRiscvCsrPmpaddr39::new(),
+        &ReadWriteRiscvCsrPmpaddr40::new(),
+        &ReadWriteRiscvCsrPmpaddr41::new(),
+        &ReadWriteRiscvCsrPmpaddr42::new(),
+        &ReadWriteRiscvCsrPmpaddr43::new(),
+        &ReadWriteRiscvCsrPmpaddr44::new(),
+        &ReadWriteRiscvCsrPmpaddr45::new(),
+        &ReadWriteRiscvCsrPmpaddr46::new(),
+        &ReadWriteRiscvCsrPmpaddr47::new(),
+        &ReadWriteRiscvCsrPmpaddr48::new(),
+        &ReadWriteRiscvCsrPmpaddr49::new(),
+        &ReadWriteRiscvCsrPmpaddr50::new(),
+        &ReadWriteRiscvCsrPmpaddr51::new(),
+        &ReadWriteRiscvCsrPmpaddr52::new(),
+        &ReadWriteRiscvCsrPmpaddr53::new(),
+        &ReadWriteRiscvCsrPmpaddr54::new(),
+        &ReadWriteRiscvCsrPmpaddr55::new(),
+        &ReadWriteRiscvCsrPmpaddr56::new(),
+        &ReadWriteRiscvCsrPmpaddr57::new(),
+        &ReadWriteRiscvCsrPmpaddr58::new(),
+        &ReadWriteRiscvCsrPmpaddr59::new(),
+        &ReadWriteRiscvCsrPmpaddr60::new(),
+        &ReadWriteRiscvCsrPmpaddr61::new(),
+        &ReadWriteRiscvCsrPmpaddr62::new(),
+        &ReadWriteRiscvCsrPmpaddr63::new(),
     ],
 
-    mie: ReadWriteRiscvCsrMie::new(),
-    mtvec: ReadWriteRiscvCsrMtvec::new(),
-    mscratch: ReadWriteRiscvCsrMscratch::new(),
-    mepc: ReadWriteRiscvCsrMepc::new(),
-    mcause: ReadWriteRiscvCsrMcause::new(),
-    mtval: ReadWriteRiscvCsrMtval::new(),
-    mip: ReadWriteRiscvCsrMip::new(),
-    mstatus: ReadWriteRiscvCsrMstatus::new(),
+    mie: &ReadWriteRiscvCsrMie::new(),
+    mtvec: &ReadWriteRiscvCsrMtvec::new(),
+    mscratch: &ReadWriteRiscvCsrMscratch::new(),
+    mepc: &ReadWriteRiscvCsrMepc::new(),
+    mcause: &ReadWriteRiscvCsrMcause::new(),
+    mtval: &ReadWriteRiscvCsrMtval::new(),
+    mip: &ReadWriteRiscvCsrMip::new(),
+    mstatus: &ReadWriteRiscvCsrMstatus::new(),
 
-    stvec: ReadWriteRiscvCsrStvec::new(),
-    utvec: ReadWriteRiscvCsrUtvec::new(),
+    stvec: &ReadWriteRiscvCsrStvec::new(),
+    utvec: &ReadWriteRiscvCsrUtvec::new(),
 };
 
-impl CSR {
+impl CSR<'_> {
     // resets the cycle counter to 0
     #[cfg(any(target_arch = "riscv32", not(target_os = "none")))]
     pub fn reset_cycle_counter(&self) {

--- a/arch/riscv/src/lib.rs
+++ b/arch/riscv/src/lib.rs
@@ -3,6 +3,8 @@
 #![crate_name = "riscv"]
 #![crate_type = "rlib"]
 #![no_std]
+#![feature(asm)]
+#![feature(const_fn)]
 
 pub mod csr;
 

--- a/libraries/riscv-csr/src/csr.rs
+++ b/libraries/riscv-csr/src/csr.rs
@@ -144,6 +144,7 @@ pub trait RISCVCSRReadWrite<T: IntLike, R: RegisterLongName = ()> {
 #[macro_export]
 macro_rules! riscv_csr {
     ( $a:tt, $name:ident ) => {
+        {
             #[derive(Copy, Clone)]
             pub struct $name<T: IntLike, R: RegisterLongName = ()> {
                 associated_register: PhantomData<R>,
@@ -191,5 +192,7 @@ macro_rules! riscv_csr {
                     unimplemented!("writing RISC-V CSR {}", $a)
                 }
             }
+            &$name::new()
+        }
     };
 }

--- a/libraries/riscv-csr/src/lib.rs
+++ b/libraries/riscv-csr/src/lib.rs
@@ -2,8 +2,6 @@
 //!
 //! Uses the Tock Register Interface to control RISC-V CSRs.
 
-#![feature(asm)]
-#![feature(const_fn)]
 #![no_std]
 
 pub mod csr;


### PR DESCRIPTION
### Pull Request Overview

This PR builds on https://github.com/tock/tock/pull/2470 and I believe really improves of the readability of the RISC-V CSRs.

The problem is the use of the dynamic dispatch adds 10K (about 10%) to the size of the binary as the helper functions aren't optimised out.

Any ideas on a better way of handling this?

### Testing Strategy

CI

### TODO or Help Wanted

Size reduction

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
