### PR TITLE
Tock 2.0: from_command_result -> from_command_return

### DIFF
--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -894,7 +894,7 @@ impl Kernel {
                     None => CommandReturn::failure(ErrorCode::NOSUPPORT),
                 });
 
-                let res = SyscallReturn::from_command_result(cres);
+                let res = SyscallReturn::from_command_return(cres);
 
                 if config::CONFIG.trace_syscalls {
                     debug!(

--- a/kernel/src/syscall.rs
+++ b/kernel/src/syscall.rs
@@ -296,11 +296,11 @@ pub enum SyscallReturn {
 impl SyscallReturn {
     /// Transforms a CommandReturn, which is wrapper around a subset of
     /// SyscallReturn, into a SyscallReturn.
-    /// This allows CommandReturn to include only the variants of
-    /// SyscallReturn that can be returned from a Command,
-    /// while having an inexpensive way to handle it as a
-    /// SyscallReturn for more generic code paths.
-    pub(crate) fn from_command_result(res: CommandReturn) -> Self {
+    ///
+    /// This allows CommandReturn to include only the variants of SyscallReturn
+    /// that can be returned from a Command, while having an inexpensive way to
+    /// handle it as a SyscallReturn for more generic code paths.
+    pub(crate) fn from_command_return(res: CommandReturn) -> Self {
         res.into_inner()
     }
 


### PR DESCRIPTION
### Pull Request Overview

This updates function name to match the type name. I also reformatted the comment just a tad.


### Testing Strategy

travis


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
