### PR TITLE
Remove variables which are never read

### DIFF
--- a/boards/msp_exp432p401r/src/io.rs
+++ b/boards/msp_exp432p401r/src/io.rs
@@ -10,19 +10,10 @@ use msp432::gpio::IntPinNr;
 use msp432::wdt::Wdt;
 
 /// Uart is used by kernel::debug to panic message to the serial port.
-pub struct Uart {
-    initialized: bool,
-}
+pub struct Uart {}
 
 /// Global static for debug writer
-pub static mut UART: Uart = Uart { initialized: false };
-
-impl Uart {
-    /// Indicate that UART has already been initialized.
-    pub fn set_initialized(&mut self) {
-        self.initialized = true;
-    }
-}
+pub static mut UART: Uart = Uart {};
 
 impl Write for Uart {
     fn write_str(&mut self, s: &str) -> ::core::fmt::Result {

--- a/boards/redboard_artemis_nano/src/io.rs
+++ b/boards/redboard_artemis_nano/src/io.rs
@@ -9,19 +9,10 @@ use kernel::debug::IoWrite;
 use kernel::hil::led;
 
 /// Writer is used by kernel::debug to panic message to the serial port.
-pub struct Writer {
-    initialized: bool,
-}
+pub struct Writer {}
 
 /// Global static for debug writer
-pub static mut WRITER: Writer = Writer { initialized: false };
-
-impl Writer {
-    /// Indicate that USART has already been initialized.
-    pub fn set_initialized(&mut self) {
-        self.initialized = true;
-    }
-}
+pub static mut WRITER: Writer = Writer {};
 
 impl Write for Writer {
     fn write_str(&mut self, s: &str) -> ::core::fmt::Result {

--- a/capsules/src/nrf51822_serialization.rs
+++ b/capsules/src/nrf51822_serialization.rs
@@ -39,8 +39,6 @@ pub struct App {
     callback: Upcall,
     tx_buffer: ReadOnlyAppSlice,
     rx_buffer: ReadWriteAppSlice,
-    rx_recv_so_far: usize, // How many RX bytes we have currently received.
-    rx_recv_total: usize,  // The total number of bytes we expect to receive.
 }
 
 // Local buffer for passing data between applications and the underlying
@@ -119,8 +117,6 @@ impl Driver for Nrf51822Serialization<'_> {
                 self.active_app.set(appid);
                 self.apps
                     .enter(appid, |app, _| {
-                        app.rx_recv_so_far = 0;
-                        app.rx_recv_total = 0;
                         core::mem::swap(&mut app.rx_buffer, &mut slice);
                     })
                     .map_err(ErrorCode::from)

--- a/capsules/src/text_screen.rs
+++ b/capsules/src/text_screen.rs
@@ -42,7 +42,6 @@ pub struct App {
     callback: Upcall,
     pending_command: bool,
     shared: ReadOnlyAppSlice,
-    write_position: usize,
     write_len: usize,
     command: TextScreenCommand,
     data1: usize,
@@ -55,7 +54,6 @@ impl Default for App {
             callback: Upcall::default(),
             pending_command: false,
             shared: ReadOnlyAppSlice::default(),
-            write_position: 0,
             write_len: 0,
             command: TextScreenCommand::Idle,
             data1: 1,
@@ -109,7 +107,6 @@ impl<'a> TextScreen<'a> {
                     } else {
                         app.pending_command = true;
                         app.command = command;
-                        app.write_position = 0;
                         app.data1 = data1;
                         app.data2 = data2;
                         ReturnCode::SUCCESS
@@ -148,7 +145,6 @@ impl<'a> TextScreen<'a> {
                 .apps
                 .enter(appid, |app, _| {
                     if data1 > 0 {
-                        app.write_position = 0;
                         app.write_len = data1;
                         app.shared.map_or(ReturnCode::ENOMEM, |to_write_buffer| {
                             self.buffer.take().map_or(ReturnCode::EBUSY, |buffer| {
@@ -283,7 +279,6 @@ impl<'a> Driver for TextScreen<'a> {
                     .apps
                     .enter(appid, |app, _| {
                         mem::swap(&mut app.shared, &mut slice);
-                        app.write_position = 0;
                     })
                     .map_err(ErrorCode::from);
                 if let Err(e) = res {


### PR DESCRIPTION
### Pull Request Overview

This PR removes some variables which are set in boards and capsules but never actually used. Found using a new version of rustc which throws warnings for these.

I'm assuming that the code works today, and so just removing them is fine.


### Testing Strategy

travis


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
