### PR TITLE
Cortex-m: document that userspace stack pointer will always be aligned on entry to the kernel

### DIFF
--- a/arch/cortex-m/src/syscall.rs
+++ b/arch/cortex-m/src/syscall.rs
@@ -113,11 +113,13 @@ impl kernel::syscall::UserspaceKernelBoundary for SysCall {
         let sp = state.psp as *mut u32;
         let (r0, r1, r2, r3) = (sp.offset(0), sp.offset(1), sp.offset(2), sp.offset(3));
 
-        // TODO: Are these guarantees _always_ satisfied? E.g. must
-        // the stack_pointer always be properly aligned?
-
         // These operations are only safe so long as
-        // - the pointers are properly aligned
+        // - the pointers are properly aligned. This is guaranteed because the
+        //   pointers are all offset multiples of 4 bytes from the stack
+        //   pointer, which is guaranteed to be properly aligned after
+        //   exception entry on Cortex-M. See
+        //   https://github.com/tock/tock/pull/2478#issuecomment-796389747
+        //   for more details.
         // - the pointer is dereferencable, i.e. the memory range of
         //   the given size starting at the pointer must all be within
         //   the bounds of a single allocated object


### PR DESCRIPTION
### Pull Request Overview

~~This pull request checks that the process stack pointer is aligned upon return from userspace. This is needed because Rust requires references be correctly aligned, and `set_syscall_return_value()` creates references to items on the stack offset from the stack pointer value.~~
This PR updates code comments.


### Testing Strategy

~~This pull request was tested by running blink, stack_size_test01, and stack_size_test02 on Imix. I also tried to make a test that would intentionally unalign the stack pointer from userspace to verify these changes would catch it (I used inline asm to decrement the stack pointer by 1), but the process faults before returning to the kernel. So we have to take this on faith for now unless someone can make a better test.~~
None needed


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] No updates are required.

### Formatting

- [x] Ran `make prepush`.
