### PR TITLE
Remove ExitCall type, don't specify representation of YieldCall type

### DIFF
--- a/kernel/src/syscall.rs
+++ b/kernel/src/syscall.rs
@@ -41,20 +41,10 @@ pub enum SyscallClass {
 
 /// Enumeration of the yield system calls based on the Yield identifier
 /// values specified in the Tock ABI.
-#[repr(u8)]
 #[derive(Copy, Clone, Debug)]
 pub enum YieldCall {
     NoWait = 0,
     Wait = 1,
-}
-
-/// Enumeration of the exit system calls based on the Exit identifier values
-/// specified in the Tock ABI.
-#[repr(u8)]
-#[derive(Copy, Clone, Debug)]
-pub enum ExitCall {
-    Terminate = 0,
-    Restart = 1,
 }
 
 // Required as long as no solution to


### PR DESCRIPTION
### Pull Request Overview

This pull request removes the completely unused `ExitCall` type, and removes the `#[repr(u8)]` from `YieldCall`, as `YieldCall` is not used across the system call boundary, so there is no need to specify its representation.


### Testing Strategy

This pull request was tested by compiling


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] No updates are required.

### Formatting

- [x] Ran `make prepush`.
