### PR TITLE
shell.nix: fix missing lib import

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -14,7 +14,7 @@
 
 with builtins;
 let
-  inherit (pkgs) stdenv;
+  inherit (pkgs) stdenv lib;
   pythonPackages = lib.fix' (self: with self; pkgs.python3Packages //
   {
 


### PR DESCRIPTION
### Pull Request Overview

As part of the transition from pkgs.stdenv.lib to pkgs.lib it seems only a part of the required changes made it into the commit 2baaf24e5 ("shell.nix: remove deprecated stdenv.lib"). This adds the required import such that the Nix expression evaluates again.

Fixes: 2baaf24e5 ("shell.nix: remove deprecated stdenv.lib") (fixes PR #2469)
Signed-off-by: Leon Schuermann <leon@is.currently.online>

I'm not quite sure how I could've missed that, sorry. With this change, on a clean repository, I can confirm the Nix expression evaluates correctly. I was absolutely sure I've tested the previous PR #2469 properly.

### Testing Strategy

This pull request was tested by...


### TODO or Help Wanted

N/A


### Documentation Updated

- [ ] ~Updated the relevant files in `/docs`,~ or no updates are required.

### Formatting

- [x] Ran `make prepush`.
