### PR TITLE
add Makefile rules for analyzing stack frames

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ usage:
 	@echo "       allboards: Compiles Tock for all supported boards"
 	@echo "        allcheck: Checks, but does not compile, Tock for all supported boards"
 	@echo "          alldoc: Builds Tock documentation for all boards"
+	@echo "          allstack: Prints a basic stack frame analysis for all boards"
 	@echo "           clean: Clean all builds"
 	@echo "          format: Runs the rustfmt tool on all kernel sources"
 	@echo "            list: Lists available boards"
@@ -143,6 +144,12 @@ alldoc:
 	@for f in $(ALL_BOARDS);\
 		do echo "$$(tput bold)Documenting $$f";\
 		$(MAKE) -C "boards/$$f" doc || exit 1;\
+		done
+
+.PHONY: allstack
+allstack:
+	@for f in $(ALL_BOARDS);\
+		do $(MAKE) --no-print-directory -C "boards/$$f" stack-analysis || exit 1;\
 		done
 
 

--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -263,6 +263,15 @@ lst: $(TARGET_PATH)/release/$(PLATFORM).lst
 show-target:
 	$(info $(TARGET))
 
+
+.PHONY: stack-analysis
+#stack_analysis: RUSTC_FLAGS_TOCK += -Z emit-stack-sizes
+stack-analysis:
+	@$ echo $(PLATFORM)
+	@$ echo ----------------------
+	@$(MAKE) release RUSTC_FLAGS="$(RUSTC_FLAGS) -Z emit-stack-sizes" > /dev/null 2>&1
+	@$(TOCK_ROOT_DIRECTORY)/tools/stack_analysis.sh $(TARGET_PATH)/release/$(PLATFORM).elf
+
 # Support rules
 
 target:

--- a/tools/stack_analysis.sh
+++ b/tools/stack_analysis.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# This script requires that the .elf under analysis includes stack
+# size information, and is thus most easily called using the `make stack-analysis`
+# rule.
+
+# Print the stack frame size of `reset_handler`
+printf "reset_handler stack frame: \n"
+$(find $(rustc --print sysroot) -name llvm-readobj) --elf-output-style GNU --stack-sizes $1 | grep 'reset_handler'
+
+printf "\n"
+printf "5 largest stack frames: \n"
+
+# Print the 5 largest stack frames
+$(find $(rustc --print sysroot) -name llvm-readobj) --elf-output-style GNU --stack-sizes $1 | sort -n -r | head -5
+printf "\n"


### PR DESCRIPTION
### Pull Request Overview

This pull request adds 2 Makefile rules for basic stack frame analysis.

Running `make allstack` from the root directory will print out the size of the `reset_handler` stack frame, and the size of the top 5 stack frames, for each Tock board.

Running `make stack-analysis` from a board directory will print the analysis for just that board (which is much faster).

I did not want to include the `-Z emit-stack-sizes` flag in `RUSTC_FLAGS` for default building because it is an unstable flag.

I found this useful when working on #2425 .

Example output:
```
$ make allstack
stm32f3discovery
----------------------
reset_handler stack frame:
         2120     reset_handler

5 largest stack frames:
         2120     rust_begin_unwind
         2120     reset_handler
          800     _ZN82_$LT$kernel..process..Process$LT$C$GT$$u20$as$u20$kernel..process..ProcessType$GT$15set_fault_state17hd44790f64f1b33ffE
          624     _ZN6kernel7process14load_processes17hcdb00db676248f3dE
          608     _ZN7cortexm24kernel_hardfault_arm_v7m17hb8c3d66ce73db090E

clue_nrf52840
----------------------
reset_handler stack frame:
         2240     reset_handler

5 largest stack frames:
         2240     reset_handler
          864     _ZN6kernel5grant21AppliedGrant$LT$T$GT$15get_or_allocate17h5f755903a9485e74E
          824     _ZN98_$LT$capsules..ieee802154..framer..Framer$LT$M$C$A$GT$$u20$as$u20$kernel..hil..radio..RxClient$GT$7receive17haa8ed8843f57844eE
          824     _ZN94_$LT$components..cdc..CdcAcmComponent$LT$U$C$A$GT$$u20$as$u20$kernel..component..Component$GT$8finalize17h0f1adf26c291c333E
          760     _ZN8capsules10ieee8021546framer19Framer$LT$M$C$A$GT$18step_receive_state17he19fec6baf70d04eE

imix
----------------------
reset_handler stack frame:
         1488     reset_handler

5 largest stack frames:
         1488     reset_handler
          824     _ZN98_$LT$capsules..ieee802154..framer..Framer$LT$M$C$A$GT$$u20$as$u20$kernel..hil..radio..RxClient$GT$7receive17hb9c13cdcef8c90e5E
          760     _ZN8capsules10ieee8021546framer19Framer$LT$M$C$A$GT$18step_receive_state17h9f32e9a94d822594E
          760     _ZN82_$LT$kernel..process..Process$LT$C$GT$$u20$as$u20$kernel..process..ProcessType$GT$15set_fault_state17hfff5ff3477cbffb2E
          632     _ZN6kernel7process14load_processes17h0cb6d39a806171d2E
```

```
$ cd boards/imix
$ make stack-analysis
imix
----------------------
reset_handler stack frame:
         1488     reset_handler

5 largest stack frames:
         1488     reset_handler
          824     _ZN98_$LT$capsules..ieee802154..framer..Framer$LT$M$C$A$GT$$u20$as$u20$kernel..hil..radio..RxClient$GT$7receive17hb9c13cdcef8c90e5E
          760     _ZN8capsules10ieee8021546framer19Framer$LT$M$C$A$GT$18step_receive_state17h9f32e9a94d822594E
          760     _ZN82_$LT$kernel..process..Process$LT$C$GT$$u20$as$u20$kernel..process..ProcessType$GT$15set_fault_state17hfff5ff3477cbffb2E
          632     _ZN6kernel7process14load_processes17h0cb6d39a806171d2E

```

### Testing Strategy

This pull request was tested by running the Make rules.


### TODO or Help Wanted

N/A

### Documentation Updated

- [x] No updates are required.

### Formatting

- [x] Ran `make prepush`.
