### PR TITLE
litex/{sim, arty}: bump tock-litex release (updating LiteX packages)

### DIFF
--- a/boards/litex/arty/README.md
+++ b/boards/litex/arty/README.md
@@ -11,9 +11,9 @@ differ significantly depending on the LiteX release and configuration
 options used. This board definition currently targets and has been
 tested with
 - [the LiteX SoC generator, revision
-  4092180662](https://github.com/enjoy-digital/litex/tree/4092180662ec62cf28b9283a020f1ff7f0892c19)
-- using the included [target
-  file](https://github.com/enjoy-digital/litex/blob/4092180662ec62cf28b9283a020f1ff7f0892c19/litex/boards/targets/arty.py)
+  11f7416e36](https://github.com/enjoy-digital/litex/tree/11f7416e3603bf404a3c603902162cf02551e98c)
+- using the companion [target
+  file](https://github.com/litex-hub/litex-boards/blob/ef662035b13a65955e94b018621c327448f9105e/litex_boards/targets/arty.py) from `litex-boards`
 - built around a VexRiscv-CPU with PMP, hardware multiplication and
   compressed instruction support
 - along with the following configuration options:
@@ -41,9 +41,9 @@ Verilog files) can be obtained from the [Tock on LiteX companion
 repository
 releases](https://github.com/lschuermann/tock-litex/releases/). The
 current board definition has been verified to work with [release
-2020122201](https://github.com/lschuermann/tock-litex/releases/tag/2020122201). The
+2021031601](https://github.com/lschuermann/tock-litex/releases/tag/2021031601). The
 bitstream for this board is located in `arty_a7-35t.zip` under
-`gateware/arty.bin`.
+`gateware/arty.bit`.
 
 Many bitstream customizations can be represented in the Tock board by
 simply changing the variables in `src/litex_generated.rs`. To support

--- a/boards/litex/arty/src/litex_generated_constants.rs
+++ b/boards/litex/arty/src/litex_generated_constants.rs
@@ -35,7 +35,7 @@ pub const UART_INTERRUPT: usize = 0;
 
 // constants defined in `generated/csr.h`
 
-pub const CSR_BASE: usize = 0x82000000;
+pub const CSR_BASE: usize = 0xf0000000;
 pub const CSR_CTRL_BASE: usize = CSR_BASE + 0x0000;
 pub const CSR_UART_PHY_BASE: usize = CSR_BASE + 0x1800;
 pub const CSR_UART_BASE: usize = CSR_BASE + 0x2000;

--- a/boards/litex/sim/README.md
+++ b/boards/litex/sim/README.md
@@ -11,7 +11,7 @@ options used. This board definition currently targets and has been
 tested with
 - [the LiteX SoC generator, revision
   11f7416e36](https://github.com/enjoy-digital/litex/tree/11f7416e3603bf404a3c603902162cf02551e98c)
-- using the included [lx_sim.py](https://github.com/enjoy-digital/litex/blob/11f7416e3603bf404a3c603902162cf02551e98c/litex/tools/litex_sim.py)
+- using the included [lxsim](https://github.com/enjoy-digital/litex/blob/11f7416e3603bf404a3c603902162cf02551e98c/litex/tools/litex_sim.py)
 - built around a VexRiscv-CPU
 - featuring a TIMER0 with 64-bit wide hardware uptime
 - along with the following configuration options:

--- a/boards/litex/sim/README.md
+++ b/boards/litex/sim/README.md
@@ -10,8 +10,8 @@ differ significantly depending on the release and configuration
 options used. This board definition currently targets and has been
 tested with
 - [the LiteX SoC generator, revision
-  444a605dea](https://github.com/enjoy-digital/litex/tree/4092180662ec62cf28b9283a020f1ff7f0892c19)
-- using the included [lx_sim.py](https://github.com/enjoy-digital/litex/blob/4092180662ec62cf28b9283a020f1ff7f0892c19/litex/tools/litex_sim.py)
+  11f7416e36](https://github.com/enjoy-digital/litex/tree/11f7416e3603bf404a3c603902162cf02551e98c)
+- using the included [lx_sim.py](https://github.com/enjoy-digital/litex/blob/11f7416e3603bf404a3c603902162cf02551e98c/litex/tools/litex_sim.py)
 - built around a VexRiscv-CPU
 - featuring a TIMER0 with 64-bit wide hardware uptime
 - along with the following configuration options:

--- a/boards/litex/sim/src/litex_generated_constants.rs
+++ b/boards/litex/sim/src/litex_generated_constants.rs
@@ -30,7 +30,7 @@ pub const TIMER0_INTERRUPT: usize = 1;
 pub const UART_INTERRUPT: usize = 0;
 
 // constants defined in `generated/csr.h`
-pub const CSR_BASE: usize = 0x82000000;
+pub const CSR_BASE: usize = 0xf0000000;
 pub const CSR_CTRL_BASE: usize = CSR_BASE + 0x0000;
 pub const CSR_UART_BASE: usize = CSR_BASE + 0x2000;
 pub const CSR_TIMER0_BASE: usize = CSR_BASE + 0x2800;


### PR DESCRIPTION
### Pull Request Overview

This bumps the supported tock-litex release to 2021031601, which includes many updates to LiteX packages. It also changes the location of the memory-mapped CSR registers according to the LiteX generated memory layout.

Cc @alevy 

### Testing Strategy

Running Tock with an app on LiteX Sim and Arty, using the generated bitstream included in the [tock-litex release](https://github.com/lschuermann/tock-litex/releases/tag/2021031601).


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] ~Updated the relevant files in `/docs`,~ or no updates are required.

### Formatting

- [x] Ran `make prepush`.
