### PR TITLE
Corrected hifive1 README.md

### DIFF
--- a/boards/hifive1/README.md
+++ b/boards/hifive1/README.md
@@ -51,7 +51,7 @@ the Hello World exmple app from the libtock-rs repository by running:
 
 ```
 $ cd [LIBTOCK-RS-DIR]
-$ make flash-hifive1
+$ make EXAMPLE=hello_world flash-hifive1
 $ tar xf target/riscv32imac-unknown-none-elf/tab/hifive1/hello_world.tab
 $ cd [TOCK_ROOT]/boards/hifive
 $ make APP=[LIBTOCK-RS-DIR]/rv32imac.tbf qemu-app


### PR DESCRIPTION
### Pull Request Overview

While trying to build TockOS I've noticed a missing parameter in the make command for the hifive1 example application.


### Testing Strategy

The build works after specifying the `EXAMPLE` variable.
