### PR TITLE
[tools] Update svd2regs to work without description

### DIFF
--- a/tools/svd2regs.py
+++ b/tools/svd2regs.py
@@ -69,7 +69,10 @@ COMMENT_MAX_LENGTH = 80
 
 
 def comment(text):
-    return "/// {}".format(text[:COMMENT_MAX_LENGTH].strip())
+    if text:
+        return "/// {}".format(text[:COMMENT_MAX_LENGTH].strip())
+    else:
+        return "/// (no description)"
 
 
 class CodeBlock(str):

--- a/tools/svd2regs.py
+++ b/tools/svd2regs.py
@@ -70,7 +70,9 @@ COMMENT_MAX_LENGTH = 80
 
 def comment(text):
     if text:
-        return "/// {}".format(text[:COMMENT_MAX_LENGTH].strip())
+        lines = text.split ("\n")
+        lines = ["/// {}".format(line[:COMMENT_MAX_LENGTH].strip()) for line in lines]
+        return "\n".join (lines)
     else:
         return "/// (no description)"
 

--- a/tools/svd2regs.py
+++ b/tools/svd2regs.py
@@ -74,7 +74,7 @@ def comment(text):
         lines = ["/// {}".format(line[:COMMENT_MAX_LENGTH].strip()) for line in lines]
         return "\n".join (lines)
     else:
-        return "/// (no description)"
+        return ""
 
 
 class CodeBlock(str):


### PR DESCRIPTION
### Pull Request Overview

This pull request
 - updates svd2regs so that it works even if there is no description present in the svd file.
 - adds support for multiple lines descriptions


### Testing Strategy

This pull request was tested using the RP2040 svd file.


### TODO or Help Wanted

N/A

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
