### PR TITLE
Remove @niklasad1 from Core Working Group

### DIFF
--- a/doc/wg/core/README.md
+++ b/doc/wg/core/README.md
@@ -20,7 +20,6 @@ are to:
 
 ## Members
 
-- Niklas Adolfsson, [niklasad1](https://github.com/niklasad1), Parity Tech
 - Hudson Ayers, [hudson-ayers](https://github.com/hudson-ayers), Stanford
 - Brad Campbell, [bradjc](https://github.com/bradjc), UVA
 - Branden Ghena, [brghena](https://github.com/brghena), UC Berkeley


### PR DESCRIPTION
### Pull Request Overview
Per @alevy, Niklas isn't planning on being actively involved in Tock, and no longer needs to be on the Core WG. This is helpful because of our PR merging and release process, which expects all core members to sign off on certain things.


### Testing Strategy

n/a


### TODO or Help Wanted

This is a strange PR to create. Maybe we should create at least a "past members" list?


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
