### PR TITLE
kernel: process: Remove unsafe by switching flash function from add to wrapping_add

### DIFF
--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -1168,7 +1168,7 @@ impl<C: Chip> ProcessType for Process<'_, C> {
     }
 
     fn flash_end(&self) -> *const u8 {
-        unsafe { self.flash.as_ptr().add(self.flash.len()) }
+        self.flash.as_ptr().wrapping_add(self.flash.len())
     }
 
     fn kernel_memory_break(&self) -> *const u8 {


### PR DESCRIPTION
### Pull Request Overview

This PR removes an unsafe from process.rs by switching to wrapping_add.


### Testing Strategy

travis


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
