### PR TITLE
Fix ADC 2.0 Bug

### DIFF
--- a/capsules/src/adc.rs
+++ b/capsules/src/adc.rs
@@ -938,7 +938,7 @@ impl<A: hil::adc::Adc + hil::adc::AdcHighSpeed> hil::adc::HighSpeedClient for Ad
                             });
                         }
 
-                        let skip_amt = app.app_buf_offset.get();
+                        let skip_amt = app.app_buf_offset.get() / 2;
 
                         {
                             let app_buf;


### PR DESCRIPTION
The divide by two was left off in #2312 when updating to Tock 2.0

### Pull Request Overview

`app_buf_offset` is the buffer offset in bytes. `skip_amt` is used below as the number of `chunks_mut(2)` that get skipped, so it should be in units of "samples" (each of which are two bytes), which is why it should be set to `app_buf_offset / 2`. 

Later, in the code we call `app.app_buf_offset.set(app.app_buf_offset.get() + length * 2);`, which reinforces that `app_buf_offset` is a number of bytes, not a number of samples.

@hudson-ayers took a look at this and agreed it was a mistake. @alexandruradovici do you remember any reason why this would be intentional and I'm incorrect?

### Testing Strategy

Looking at it very carefully.


### TODO or Help Wanted

Should be tested on actual hardware.


### Documentation Updated

- [N/A] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
