### PR TITLE
tools: sdv2regs allow registers with no fields and fix imports

### DIFF
--- a/tools/svd2regs.py
+++ b/tools/svd2regs.py
@@ -91,7 +91,7 @@ class CodeBlock(str):
 class Includes(CodeBlock):
     TEMPLATE = """
 use kernel::common::StaticRef;
-use kernel::common::registers::{{self, ReadOnly, ReadWrite, WriteOnly}};
+use kernel::common::registers::{{self, register_bitfields, register_structs, ReadOnly, ReadWrite, WriteOnly}};
     """
 
 
@@ -235,7 +235,10 @@ class Bitfield(CodeBlock):
 
     @staticmethod
     def fields(register):
-        fields = ",\n".join(BitfieldField(field) for field in register._fields)
+        if len (register._fields) > 0:
+            fields = ",\n".join(BitfieldField(field) for field in register._fields)
+        else:
+            fields = "    VALUE OFFSET (0) NUMBITS (32) []"
         return {
             "name": register.name,
             "fields": fields,
@@ -278,10 +281,13 @@ class BitfieldFieldEnum(CodeBlock):
     @staticmethod
     def fields(enum):
         def identifier(desc):
-            if any(desc.startswith(str(digit)) for digit in range(10)):
-                desc = "_{}".format(desc)
-            i = pydentifier.upper_camel(desc)
-            return i if len(i) < 80 else None
+            if desc != None:
+                if any(desc.startswith(str(digit)) for digit in range(10)):
+                    desc = "_{}".format(desc)
+                i = pydentifier.upper_camel(desc)
+                return i if len(i) < 80 else None
+            else:
+                return None
 
         def enum_identifier(e):
             for t in [e.description, e.name, e.value]:
@@ -326,8 +332,7 @@ def generate(name, peripherals, dev):
     main_peripheral = peripherals[0]
     return Includes() \
            + PeripheralStruct(name, main_peripheral, dev) \
-           + generate_bitfields_macro(filter(lambda r: len(r._fields) > 1,
-                                             main_peripheral.registers)) \
+           + generate_bitfields_macro(main_peripheral.registers) \
            + "\n".join(PeripheralBaseDeclaration(name, peripheral)
                        for peripheral in peripherals)
 


### PR DESCRIPTION
### Pull Request Overview

This pull request:
 * adds the ability to write registers without fields (the whole register is used)
 * fixes the imports (register macros were not imported)


### Testing Strategy

This pull request was tested with the RP2040.

### TODO or Help Wanted

N/A

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
