### PR TITLE
boards: reduce stack frame size of main()

### DIFF
--- a/boards/acd52832/src/main.rs
+++ b/boards/acd52832/src/main.rs
@@ -107,16 +107,27 @@ impl kernel::Platform for Platform {
     }
 }
 
-/// Main function called after RAM initialized.
-#[no_mangle]
-pub unsafe fn main() {
-    nrf52832::init();
+/// This is in a separate, inline(never) function so that its stack frame is
+/// removed when this function returns. Otherwise, the stack space used for
+/// these static_inits is wasted.
+#[inline(never)]
+unsafe fn get_peripherals() -> &'static mut Nrf52832DefaultPeripherals<'static> {
     let ppi = static_init!(nrf52832::ppi::Ppi, nrf52832::ppi::Ppi::new());
     // Initialize chip peripheral drivers
     let nrf52832_peripherals = static_init!(
         Nrf52832DefaultPeripherals,
         Nrf52832DefaultPeripherals::new(ppi)
     );
+
+    nrf52832_peripherals
+}
+
+/// Main function called after RAM initialized.
+#[no_mangle]
+pub unsafe fn main() {
+    nrf52832::init();
+
+    let nrf52832_peripherals = get_peripherals();
 
     // set up circular peripheral dependencies
     nrf52832_peripherals.init();

--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -157,16 +157,27 @@ impl kernel::Platform for Platform {
     }
 }
 
-/// Main function called after RAM initialized.
-#[no_mangle]
-pub unsafe fn main() {
-    nrf52840::init();
+/// This is in a separate, inline(never) function so that its stack frame is
+/// removed when this function returns. Otherwise, the stack space used for
+/// these static_inits is wasted.
+#[inline(never)]
+unsafe fn get_peripherals() -> &'static mut Nrf52840DefaultPeripherals<'static> {
     let ppi = static_init!(nrf52840::ppi::Ppi, nrf52840::ppi::Ppi::new());
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
         Nrf52840DefaultPeripherals::new(ppi)
     );
+
+    nrf52840_peripherals
+}
+
+/// Main function called after RAM initialized.
+#[no_mangle]
+pub unsafe fn main() {
+    nrf52840::init();
+
+    let nrf52840_peripherals = get_peripherals();
 
     // set up circular peripheral dependencies
     nrf52840_peripherals.init();

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -147,16 +147,27 @@ impl kernel::Platform for Platform {
     }
 }
 
-/// Main function called after RAM initialized.
-#[no_mangle]
-pub unsafe fn main() {
-    nrf52840::init();
+/// This is in a separate, inline(never) function so that its stack frame is
+/// removed when this function returns. Otherwise, the stack space used for
+/// these static_inits is wasted.
+#[inline(never)]
+unsafe fn get_peripherals() -> &'static mut Nrf52840DefaultPeripherals<'static> {
     let ppi = static_init!(nrf52840::ppi::Ppi, nrf52840::ppi::Ppi::new());
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
         Nrf52840DefaultPeripherals::new(ppi)
     );
+
+    nrf52840_peripherals
+}
+
+/// Main function called after RAM initialized.
+#[no_mangle]
+pub unsafe fn main() {
+    nrf52840::init();
+
+    let nrf52840_peripherals = get_peripherals();
 
     // set up circular peripheral dependencies
     nrf52840_peripherals.init();

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -199,16 +199,27 @@ impl kernel::Platform for Platform {
     }
 }
 
-/// Main function called after RAM initialized.
-#[no_mangle]
-pub unsafe fn main() {
-    nrf52840::init();
+/// This is in a separate, inline(never) function so that its stack frame is
+/// removed when this function returns. Otherwise, the stack space used for
+/// these static_inits is wasted.
+#[inline(never)]
+unsafe fn get_peripherals() -> &'static mut Nrf52840DefaultPeripherals<'static> {
     let ppi = static_init!(nrf52840::ppi::Ppi, nrf52840::ppi::Ppi::new());
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
         Nrf52840DefaultPeripherals::new(ppi)
     );
+
+    nrf52840_peripherals
+}
+
+/// Main function called after RAM initialized.
+#[no_mangle]
+pub unsafe fn main() {
+    nrf52840::init();
+
+    let nrf52840_peripherals = get_peripherals();
 
     // set up circular peripheral dependencies
     nrf52840_peripherals.init();

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -179,16 +179,27 @@ impl kernel::Platform for Platform {
     }
 }
 
-/// Main function called after RAM initialized.
-#[no_mangle]
-pub unsafe fn main() {
-    nrf52832::init();
+/// This is in a separate, inline(never) function so that its stack frame is
+/// removed when this function returns. Otherwise, the stack space used for
+/// these static_inits is wasted.
+#[inline(never)]
+unsafe fn get_peripherals() -> &'static mut Nrf52832DefaultPeripherals<'static> {
     let ppi = static_init!(nrf52832::ppi::Ppi, nrf52832::ppi::Ppi::new());
     // Initialize chip peripheral drivers
     let nrf52832_peripherals = static_init!(
         Nrf52832DefaultPeripherals,
         Nrf52832DefaultPeripherals::new(ppi)
     );
+
+    nrf52832_peripherals
+}
+
+/// Main function called after RAM initialized.
+#[no_mangle]
+pub unsafe fn main() {
+    nrf52832::init();
+
+    let nrf52832_peripherals = get_peripherals();
 
     // set up circular peripheral dependencies
     nrf52832_peripherals.init();

--- a/boards/nucleo_f429zi/src/main.rs
+++ b/boards/nucleo_f429zi/src/main.rs
@@ -213,13 +213,17 @@ unsafe fn setup_peripherals(tim2: &stm32f429zi::tim2::Tim2) {
     cortexm4::nvic::Nvic::new(stm32f429zi::nvic::TIM2).enable();
 }
 
-/// Main function.
+/// Statically initialize the core peripherals for the chip.
 ///
-/// This is called after RAM initialization is complete.
-#[no_mangle]
-pub unsafe fn main() {
-    stm32f429zi::init();
-
+/// This is in a separate, inline(never) function so that its stack frame is
+/// removed when this function returns. Otherwise, the stack space used for
+/// these static_inits is wasted.
+#[inline(never)]
+unsafe fn get_peripherals() -> (
+    &'static mut Stm32f429ziDefaultPeripherals<'static>,
+    &'static stm32f429zi::syscfg::Syscfg<'static>,
+    &'static stm32f429zi::dma1::Dma1<'static>,
+) {
     // We use the default HSI 16Mhz clock
     let rcc = static_init!(stm32f429zi::rcc::Rcc, stm32f429zi::rcc::Rcc::new());
     let syscfg = static_init!(
@@ -235,6 +239,17 @@ pub unsafe fn main() {
         Stm32f429ziDefaultPeripherals,
         Stm32f429ziDefaultPeripherals::new(rcc, exti, dma1)
     );
+    (peripherals, syscfg, dma1)
+}
+
+/// Main function.
+///
+/// This is called after RAM initialization is complete.
+#[no_mangle]
+pub unsafe fn main() {
+    stm32f429zi::init();
+
+    let (peripherals, syscfg, dma1) = get_peripherals();
     peripherals.init();
     let base_peripherals = &peripherals.stm32f4;
 

--- a/boards/nucleo_f446re/src/main.rs
+++ b/boards/nucleo_f446re/src/main.rs
@@ -167,13 +167,17 @@ unsafe fn setup_peripherals(tim2: &stm32f446re::tim2::Tim2) {
     cortexm4::nvic::Nvic::new(stm32f446re::nvic::TIM2).enable();
 }
 
-/// Main function.
+/// Statically initialize the core peripherals for the chip.
 ///
-/// This is called after RAM initialization is complete.
-#[no_mangle]
-pub unsafe fn main() {
-    stm32f446re::init();
-
+/// This is in a separate, inline(never) function so that its stack frame is
+/// removed when this function returns. Otherwise, the stack space used for
+/// these static_inits is wasted.
+#[inline(never)]
+unsafe fn get_peripherals() -> (
+    &'static mut Stm32f446reDefaultPeripherals<'static>,
+    &'static stm32f446re::syscfg::Syscfg<'static>,
+    &'static stm32f446re::dma1::Dma1<'static>,
+) {
     // We use the default HSI 16Mhz clock
     let rcc = static_init!(stm32f446re::rcc::Rcc, stm32f446re::rcc::Rcc::new());
     let syscfg = static_init!(
@@ -189,6 +193,17 @@ pub unsafe fn main() {
         Stm32f446reDefaultPeripherals,
         Stm32f446reDefaultPeripherals::new(rcc, exti, dma1)
     );
+    (peripherals, syscfg, dma1)
+}
+
+/// Main function.
+///
+/// This is called after RAM initialization is complete.
+#[no_mangle]
+pub unsafe fn main() {
+    stm32f446re::init();
+
+    let (peripherals, syscfg, dma1) = get_peripherals();
     peripherals.init();
     let base_peripherals = &peripherals.stm32f4;
 

--- a/boards/stm32f3discovery/src/main.rs
+++ b/boards/stm32f3discovery/src/main.rs
@@ -288,13 +288,17 @@ unsafe fn setup_peripherals(tim2: &stm32f303xc::tim2::Tim2) {
     cortexm4::nvic::Nvic::new(stm32f303xc::nvic::TIM2).enable();
 }
 
-/// Main function.
+/// Statically initialize the core peripherals for the chip.
 ///
-/// This is called after RAM initialization is complete.
-#[no_mangle]
-pub unsafe fn main() {
-    stm32f303xc::init();
-
+/// This is in a separate, inline(never) function so that its stack frame is
+/// removed when this function returns. Otherwise, the stack space used for
+/// these static_inits is wasted.
+#[inline(never)]
+unsafe fn get_peripherals() -> (
+    &'static mut Stm32f3xxDefaultPeripherals<'static>,
+    &'static stm32f303xc::syscfg::Syscfg<'static>,
+    &'static stm32f303xc::rcc::Rcc,
+) {
     // We use the default HSI 8Mhz clock
 
     let rcc = static_init!(stm32f303xc::rcc::Rcc, stm32f303xc::rcc::Rcc::new());
@@ -311,6 +315,17 @@ pub unsafe fn main() {
         Stm32f3xxDefaultPeripherals,
         Stm32f3xxDefaultPeripherals::new(rcc, exti)
     );
+    (peripherals, syscfg, rcc)
+}
+
+/// Main function.
+///
+/// This is called after RAM initialization is complete.
+#[no_mangle]
+pub unsafe fn main() {
+    stm32f303xc::init();
+
+    let (peripherals, syscfg, rcc) = get_peripherals();
     set_pin_primary_functions(
         syscfg,
         &peripherals.exti,


### PR DESCRIPTION

### Pull Request Overview

Re: #2425

Updates the main.rs files for boards that have a large stack frame for main.


### Testing Strategy

travis


### TODO or Help Wanted

Please contribute fixes for more boards that need it. I think we can merge this when all boards have reasonable stack frame sizes for `main()`.

To do:

- [x] nrf52dk
- [x] nrf52840_dongle
- [x] nrf52840dk
- [x] nano33ble
- [x] teensy40
- [x] weact-f401ccu6
- [x] nucleo_f429zi
- [x] microbit_v2
- [x] imxrt1050-evkb
- [x] acd52832
- [x] nucleo_f446re
- [x] clue_nrf52840



### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
