### PR TITLE
Rename AppId to ProcessId (v2)

### DIFF
--- a/arch/cortex-m/src/mpu.rs
+++ b/arch/cortex-m/src/mpu.rs
@@ -10,7 +10,7 @@ use kernel::common::math;
 use kernel::common::registers::{register_bitfields, FieldValue, ReadOnly, ReadWrite};
 use kernel::common::StaticRef;
 use kernel::mpu;
-use kernel::AppId;
+use kernel::ProcessId;
 
 /// MPU Registers for the Cortex-M3, Cortex-M4 and Cortex-M7 families
 /// Described in section 4.5 of
@@ -133,7 +133,7 @@ pub struct MPU<const NUM_REGIONS: usize> {
     /// Optimization logic. This is used to indicate which application the MPU
     /// is currently configured for so that the MPU can skip updating when the
     /// kernel returns to the same app.
-    hardware_is_configured_for: OptionalCell<AppId>,
+    hardware_is_configured_for: OptionalCell<ProcessId>,
 }
 
 impl<const NUM_REGIONS: usize> MPU<NUM_REGIONS> {
@@ -687,7 +687,7 @@ impl<const NUM_REGIONS: usize> kernel::mpu::MPU for MPU<NUM_REGIONS> {
         Ok(())
     }
 
-    fn configure_mpu(&self, config: &Self::MpuConfig, app_id: &AppId) {
+    fn configure_mpu(&self, config: &Self::MpuConfig, app_id: &ProcessId) {
         // If the hardware is already configured for this app and the app's MPU
         // configuration has not changed, then skip the hardware update.
         if !self.hardware_is_configured_for.contains(app_id) || config.is_dirty.get() {

--- a/arch/rv32i/src/epmp.rs
+++ b/arch/rv32i/src/epmp.rs
@@ -14,7 +14,7 @@ use core::cell::Cell;
 use core::{cmp, fmt};
 use kernel::common::cells::{MapCell, OptionalCell};
 use kernel::common::registers::{self, register_bitfields};
-use kernel::{mpu, AppId};
+use kernel::{mpu, ProcessId};
 
 // Generic PMP config
 register_bitfields![u8,
@@ -53,7 +53,7 @@ pub struct PMP<const MAX_AVAILABLE_REGIONS_OVER_TWO: usize> {
     /// The application that the MPU was last configured for. Used (along with
     /// the `is_dirty` flag) to determine if MPU can skip writing the
     /// configuration to hardware.
-    last_configured_for: MapCell<AppId>,
+    last_configured_for: MapCell<ProcessId>,
     /// This is a 64-bit mask of locked regions.
     /// Each bit that is set in this mask indicates that the region is locked
     /// and cannot be used by Tock.
@@ -605,7 +605,7 @@ impl<const MAX_AVAILABLE_REGIONS_OVER_TWO: usize> kernel::mpu::MPU
         Ok(())
     }
 
-    fn configure_mpu(&self, config: &Self::MpuConfig, app_id: &AppId) {
+    fn configure_mpu(&self, config: &Self::MpuConfig, app_id: &ProcessId) {
         // Is the PMP already configured for this app?
         let last_configured_for_this_app = self
             .last_configured_for

--- a/arch/rv32i/src/pmp.rs
+++ b/arch/rv32i/src/pmp.rs
@@ -19,7 +19,7 @@ use kernel::common::cells::MapCell;
 use kernel::common::registers;
 use kernel::common::registers::register_bitfields;
 use kernel::mpu;
-use kernel::AppId;
+use kernel::ProcessId;
 
 // Generic PMP config
 register_bitfields![u8,
@@ -58,7 +58,7 @@ pub struct PMP<const MAX_AVAILABLE_REGIONS_OVER_TWO: usize> {
     /// The application that the MPU was last configured for. Used (along with
     /// the `is_dirty` flag) to determine if MPU can skip writing the
     /// configuration to hardware.
-    last_configured_for: MapCell<AppId>,
+    last_configured_for: MapCell<ProcessId>,
     /// This is a 64-bit mask of locked regions.
     /// Each bit that is set in this mask indicates that the region is locked
     /// and cannot be used by Tock.
@@ -513,7 +513,7 @@ impl<const MAX_AVAILABLE_REGIONS_OVER_TWO: usize> kernel::mpu::MPU
         Ok(())
     }
 
-    fn configure_mpu(&self, config: &Self::MpuConfig, app_id: &AppId) {
+    fn configure_mpu(&self, config: &Self::MpuConfig, app_id: &ProcessId) {
         // Is the PMP already configured for this app?
         let last_configured_for_this_app = self
             .last_configured_for

--- a/capsules/src/alarm.rs
+++ b/capsules/src/alarm.rs
@@ -4,7 +4,7 @@
 use core::cell::Cell;
 use core::mem;
 use kernel::hil::time::{self, Alarm, Frequency, Ticks, Ticks32};
-use kernel::{AppId, CommandReturn, Driver, ErrorCode, Grant, Upcall};
+use kernel::{CommandReturn, Driver, ErrorCode, Grant, ProcessId, Upcall};
 
 /// Syscall driver number.
 use crate::driver;
@@ -154,7 +154,7 @@ impl<'a, A: Alarm<'a>> Driver for AlarmDriver<'a, A> {
         &self,
         subscribe_num: usize,
         mut callback: Upcall,
-        app_id: AppId,
+        app_id: ProcessId,
     ) -> Result<Upcall, (Upcall, ErrorCode)> {
         let res: Result<(), ErrorCode> = match subscribe_num {
             0 => self
@@ -188,7 +188,7 @@ impl<'a, A: Alarm<'a>> Driver for AlarmDriver<'a, A> {
         cmd_type: usize,
         data: usize,
         data2: usize,
-        caller_id: AppId,
+        caller_id: ProcessId,
     ) -> CommandReturn {
         // Returns the error code to return to the user and whether we need to
         // reset which is the next active alarm. We _don't_ reset if

--- a/capsules/src/ambient_light.rs
+++ b/capsules/src/ambient_light.rs
@@ -16,7 +16,7 @@ use core::cell::Cell;
 use core::convert::TryFrom;
 use core::mem;
 use kernel::hil;
-use kernel::{AppId, CommandReturn, Driver, ErrorCode, Grant, Upcall};
+use kernel::{CommandReturn, Driver, ErrorCode, Grant, ProcessId, Upcall};
 
 /// Syscall driver number.
 use crate::driver;
@@ -44,7 +44,7 @@ impl<'a> AmbientLight<'a> {
         }
     }
 
-    fn enqueue_sensor_reading(&self, appid: AppId) -> Result<(), ErrorCode> {
+    fn enqueue_sensor_reading(&self, appid: ProcessId) -> Result<(), ErrorCode> {
         self.apps
             .enter(appid, |app| {
                 if app.pending {
@@ -73,7 +73,7 @@ impl Driver for AmbientLight<'_> {
         &self,
         subscribe_num: usize,
         mut callback: Upcall,
-        app_id: AppId,
+        app_id: ProcessId,
     ) -> Result<Upcall, (Upcall, ErrorCode)> {
         match subscribe_num {
             0 => {
@@ -106,7 +106,7 @@ impl Driver for AmbientLight<'_> {
     ///
     /// - `0`: Check driver presence
     /// - `1`: Start a light sensor reading
-    fn command(&self, command_num: usize, _: usize, _: usize, appid: AppId) -> CommandReturn {
+    fn command(&self, command_num: usize, _: usize, _: usize, appid: ProcessId) -> CommandReturn {
         match command_num {
             0 /* check if present */ => CommandReturn::success(),
             1 => {

--- a/capsules/src/app_flash_driver.rs
+++ b/capsules/src/app_flash_driver.rs
@@ -27,7 +27,7 @@ use core::mem;
 use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::hil;
 use kernel::ErrorCode;
-use kernel::{AppId, CommandReturn, Driver, Grant, Read, ReadOnlyAppSlice, Upcall};
+use kernel::{CommandReturn, Driver, Grant, ProcessId, Read, ReadOnlyAppSlice, Upcall};
 
 /// Syscall driver number.
 use crate::driver;
@@ -44,7 +44,7 @@ pub struct App {
 pub struct AppFlash<'a> {
     driver: &'a dyn hil::nonvolatile_storage::NonvolatileStorage<'static>,
     apps: Grant<App>,
-    current_app: OptionalCell<AppId>,
+    current_app: OptionalCell<ProcessId>,
     buffer: TakeCell<'static, [u8]>,
 }
 
@@ -65,7 +65,7 @@ impl<'a> AppFlash<'a> {
     // Check to see if we are doing something. If not, go ahead and do this
     // command. If so, this is queued and will be run when the pending command
     // completes.
-    fn enqueue_write(&self, flash_address: usize, appid: AppId) -> Result<(), ErrorCode> {
+    fn enqueue_write(&self, flash_address: usize, appid: ProcessId) -> Result<(), ErrorCode> {
         self.apps
             .enter(appid, |app| {
                 // Check that this is a valid range in the app's flash.
@@ -172,7 +172,7 @@ impl Driver for AppFlash<'_> {
     /// - `0`: Set write buffer. This entire buffer will be written to flash.
     fn allow_readonly(
         &self,
-        appid: AppId,
+        appid: ProcessId,
         allow_num: usize,
         mut slice: ReadOnlyAppSlice,
     ) -> Result<ReadOnlyAppSlice, (ReadOnlyAppSlice, ErrorCode)> {
@@ -202,7 +202,7 @@ impl Driver for AppFlash<'_> {
         &self,
         subscribe_num: usize,
         mut callback: Upcall,
-        app_id: AppId,
+        app_id: ProcessId,
     ) -> Result<Upcall, (Upcall, ErrorCode)> {
         let res = match subscribe_num {
             0 => self
@@ -227,7 +227,13 @@ impl Driver for AppFlash<'_> {
     ///
     /// - `0`: Driver check.
     /// - `1`: Write the memory from the `allow` buffer to the address in flash.
-    fn command(&self, command_num: usize, arg1: usize, _: usize, appid: AppId) -> CommandReturn {
+    fn command(
+        &self,
+        command_num: usize,
+        arg1: usize,
+        _: usize,
+        appid: ProcessId,
+    ) -> CommandReturn {
         match command_num {
             0 /* This driver exists. */ => {
                 CommandReturn::success()

--- a/capsules/src/app_flash_driver.rs
+++ b/capsules/src/app_flash_driver.rs
@@ -126,7 +126,7 @@ impl hil::nonvolatile_storage::NonvolatileStorageClient<'static> for AppFlash<'_
 
         // Check if there are any pending events.
         for cntr in self.apps.iter() {
-            let appid = cntr.appid();
+            let appid = cntr.processid();
             let started_command = cntr.enter(|app| {
                 if app.pending_command {
                     app.pending_command = false;

--- a/capsules/src/ble_advertising_driver.rs
+++ b/capsules/src/ble_advertising_driver.rs
@@ -223,8 +223,8 @@ impl App {
     // Byte 1            0xf0
     // Byte 2-5          random
     // Byte 6            0xf0
-    // FIXME: For now use AppId as "randomness"
-    fn generate_random_address(&mut self, appid: kernel::AppId) -> Result<(), ErrorCode> {
+    // FIXME: For now use ProcessId as "randomness"
+    fn generate_random_address(&mut self, appid: kernel::ProcessId) -> Result<(), ErrorCode> {
         self.address = [
             0xf0,
             (appid.id() & 0xff) as u8,
@@ -312,8 +312,8 @@ where
     app: kernel::Grant<App>,
     kernel_tx: kernel::common::cells::TakeCell<'static, [u8]>,
     alarm: &'a A,
-    sending_app: OptionalCell<kernel::AppId>,
-    receiving_app: OptionalCell<kernel::AppId>,
+    sending_app: OptionalCell<kernel::ProcessId>,
+    receiving_app: OptionalCell<kernel::ProcessId>,
 }
 
 impl<'a, B, A> BLE<'a, B, A>
@@ -555,7 +555,7 @@ where
         command_num: usize,
         data: usize,
         interval: usize,
-        appid: kernel::AppId,
+        appid: kernel::ProcessId,
     ) -> CommandReturn {
         match command_num {
             // Start periodic advertisements
@@ -667,7 +667,7 @@ where
 
     fn allow_readonly(
         &self,
-        appid: kernel::AppId,
+        appid: kernel::ProcessId,
         allow_num: usize,
         mut slice: ReadOnlyAppSlice,
     ) -> Result<ReadOnlyAppSlice, (ReadOnlyAppSlice, ErrorCode)> {
@@ -695,7 +695,7 @@ where
 
     fn allow_readwrite(
         &self,
-        appid: kernel::AppId,
+        appid: kernel::ProcessId,
         allow_num: usize,
         mut slice: ReadWriteAppSlice,
     ) -> Result<ReadWriteAppSlice, (ReadWriteAppSlice, ErrorCode)> {
@@ -727,7 +727,7 @@ where
         &self,
         subscribe_num: usize,
         mut callback: kernel::Upcall,
-        app_id: kernel::AppId,
+        app_id: kernel::ProcessId,
     ) -> Result<kernel::Upcall, (kernel::Upcall, ErrorCode)> {
         match subscribe_num {
             // Upcall for scanning

--- a/capsules/src/button.rs
+++ b/capsules/src/button.rs
@@ -54,7 +54,7 @@
 use core::cell::Cell;
 use kernel::hil::gpio;
 use kernel::hil::gpio::{Configure, Input, InterruptWithValue};
-use kernel::{AppId, CommandReturn, Driver, ErrorCode, Grant, Upcall};
+use kernel::{CommandReturn, Driver, ErrorCode, Grant, ProcessId, Upcall};
 
 /// Syscall driver number.
 use crate::driver;
@@ -117,7 +117,7 @@ impl<'a, P: gpio::InterruptPin<'a>> Driver for Button<'a, P> {
         &self,
         subscribe_num: usize,
         mut callback: Upcall,
-        app_id: AppId,
+        app_id: ProcessId,
     ) -> Result<Upcall, (Upcall, ErrorCode)> {
         let res = match subscribe_num {
             0 => self
@@ -153,7 +153,13 @@ impl<'a, P: gpio::InterruptPin<'a>> Driver for Button<'a, P> {
     /// - `2`: Disable interrupts for a button. No affect or reliance on
     ///   registered callback.
     /// - `3`: Read the current state of the button.
-    fn command(&self, command_num: usize, data: usize, _: usize, appid: AppId) -> CommandReturn {
+    fn command(
+        &self,
+        command_num: usize,
+        data: usize,
+        _: usize,
+        appid: ProcessId,
+    ) -> CommandReturn {
         let pins = self.pins;
         match command_num {
             // return button count

--- a/capsules/src/buzzer_driver.rs
+++ b/capsules/src/buzzer_driver.rs
@@ -149,7 +149,7 @@ impl<'a, A: hil::time::Alarm<'a>> Buzzer<'a, A> {
 
     fn check_queue(&self) {
         for appiter in self.apps.iter() {
-            let appid = appiter.appid();
+            let appid = appiter.processid();
             let started_command = appiter.enter(|app| {
                 // If this app has a pending command let's use it.
                 app.pending_command.take().map_or(false, |command| {

--- a/capsules/src/buzzer_driver.rs
+++ b/capsules/src/buzzer_driver.rs
@@ -44,7 +44,7 @@ use core::mem;
 use kernel::common::cells::OptionalCell;
 use kernel::hil;
 use kernel::hil::time::Frequency;
-use kernel::{AppId, CommandReturn, Driver, ErrorCode, Grant, Upcall};
+use kernel::{CommandReturn, Driver, ErrorCode, Grant, ProcessId, Upcall};
 
 /// Syscall driver number.
 use crate::driver;
@@ -75,7 +75,7 @@ pub struct Buzzer<'a, A: hil::time::Alarm<'a>> {
     // Per-app state.
     apps: Grant<App>,
     // Which app is currently using the buzzer.
-    active_app: OptionalCell<AppId>,
+    active_app: OptionalCell<ProcessId>,
     // Max buzz time.
     max_duration_ms: usize,
 }
@@ -99,7 +99,7 @@ impl<'a, A: hil::time::Alarm<'a>> Buzzer<'a, A> {
     // Check so see if we are doing something. If not, go ahead and do this
     // command. If so, this is queued and will be run when the pending
     // command completes.
-    fn enqueue_command(&self, command: BuzzerCommand, app_id: AppId) -> Result<(), ErrorCode> {
+    fn enqueue_command(&self, command: BuzzerCommand, app_id: ProcessId) -> Result<(), ErrorCode> {
         if self.active_app.is_none() {
             // No app is currently using the buzzer, so we just use this app.
             self.active_app.set(app_id);
@@ -194,7 +194,7 @@ impl<'a, A: hil::time::Alarm<'a>> Driver for Buzzer<'a, A> {
         &self,
         subscribe_num: usize,
         mut callback: Upcall,
-        app_id: AppId,
+        app_id: ProcessId,
     ) -> Result<Upcall, (Upcall, ErrorCode)> {
         let res = match subscribe_num {
             0 => self
@@ -223,7 +223,7 @@ impl<'a, A: hil::time::Alarm<'a>> Driver for Buzzer<'a, A> {
         command_num: usize,
         data1: usize,
         data2: usize,
-        appid: AppId,
+        appid: ProcessId,
     ) -> CommandReturn {
         match command_num {
             0 =>

--- a/capsules/src/console.rs
+++ b/capsules/src/console.rs
@@ -352,7 +352,7 @@ impl uart::TransmitClient for Console<'_> {
         // see if any other applications have pending messages.
         if self.tx_in_progress.is_none() {
             for cntr in self.apps.iter() {
-                let appid = cntr.appid();
+                let appid = cntr.processid();
                 let started_tx = cntr.enter(|app| {
                     if app.pending_write {
                         app.pending_write = false;

--- a/capsules/src/console.rs
+++ b/capsules/src/console.rs
@@ -42,8 +42,8 @@ use core::{cmp, mem};
 
 use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::hil::uart;
-use kernel::{AppId, ErrorCode, Grant, Upcall};
 use kernel::{CommandReturn, Driver};
+use kernel::{ErrorCode, Grant, ProcessId, Upcall};
 use kernel::{Read, ReadOnlyAppSlice, ReadWrite, ReadWriteAppSlice};
 
 /// Syscall driver number.
@@ -69,9 +69,9 @@ pub static mut READ_BUF: [u8; 64] = [0; 64];
 pub struct Console<'a> {
     uart: &'a dyn uart::UartData<'a>,
     apps: Grant<App>,
-    tx_in_progress: OptionalCell<AppId>,
+    tx_in_progress: OptionalCell<ProcessId>,
     tx_buffer: TakeCell<'static, [u8]>,
-    rx_in_progress: OptionalCell<AppId>,
+    rx_in_progress: OptionalCell<ProcessId>,
     rx_buffer: TakeCell<'static, [u8]>,
 }
 
@@ -93,7 +93,7 @@ impl<'a> Console<'a> {
     }
 
     /// Internal helper function for setting up a new send transaction
-    fn send_new(&self, app_id: AppId, app: &mut App, len: usize) -> Result<(), ErrorCode> {
+    fn send_new(&self, app_id: ProcessId, app: &mut App, len: usize) -> Result<(), ErrorCode> {
         app.write_len = cmp::min(len, app.write_buffer.len());
         app.write_remaining = app.write_len;
         self.send(app_id, app);
@@ -102,7 +102,11 @@ impl<'a> Console<'a> {
 
     /// Internal helper function for continuing a previously set up transaction
     /// Returns true if this send is still active, or false if it has completed
-    fn send_continue(&self, app_id: AppId, app: &mut App) -> Result<bool, Result<(), ErrorCode>> {
+    fn send_continue(
+        &self,
+        app_id: ProcessId,
+        app: &mut App,
+    ) -> Result<bool, Result<(), ErrorCode>> {
         if app.write_remaining > 0 {
             self.send(app_id, app);
             Ok(true)
@@ -113,7 +117,7 @@ impl<'a> Console<'a> {
 
     /// Internal helper function for sending data for an existing transaction.
     /// Cannot fail. If can't send now, it will schedule for sending later.
-    fn send(&self, app_id: AppId, app: &mut App) {
+    fn send(&self, app_id: ProcessId, app: &mut App) {
         if self.tx_in_progress.is_none() {
             self.tx_in_progress.set(app_id);
             self.tx_buffer.take().map(|buffer| {
@@ -145,7 +149,7 @@ impl<'a> Console<'a> {
     }
 
     /// Internal helper function for starting a receive operation
-    fn receive_new(&self, app_id: AppId, app: &mut App, len: usize) -> Result<(), ErrorCode> {
+    fn receive_new(&self, app_id: ProcessId, app: &mut App, len: usize) -> Result<(), ErrorCode> {
         if self.rx_buffer.is_none() {
             // For now, we tolerate only one concurrent receive operation on this console.
             // Competing apps will have to retry until success.
@@ -177,7 +181,7 @@ impl Driver for Console<'_> {
     /// - `1`: Writeable buffer for read buffer
     fn allow_readwrite(
         &self,
-        appid: AppId,
+        appid: ProcessId,
         allow_num: usize,
         mut slice: ReadWriteAppSlice,
     ) -> Result<ReadWriteAppSlice, (ReadWriteAppSlice, ErrorCode)> {
@@ -205,7 +209,7 @@ impl Driver for Console<'_> {
     /// - `1`: Readonly buffer for write buffer
     fn allow_readonly(
         &self,
-        appid: AppId,
+        appid: ProcessId,
         allow_num: usize,
         mut slice: ReadOnlyAppSlice,
     ) -> Result<ReadOnlyAppSlice, (ReadOnlyAppSlice, ErrorCode)> {
@@ -234,7 +238,7 @@ impl Driver for Console<'_> {
         &self,
         subscribe_num: usize,
         mut callback: Upcall,
-        app_id: AppId,
+        app_id: ProcessId,
     ) -> Result<Upcall, (Upcall, ErrorCode)> {
         let res = match subscribe_num {
             1 => {
@@ -274,7 +278,7 @@ impl Driver for Console<'_> {
     ///        passed in `arg1`
     /// - `3`: Cancel any in progress receives and return (via callback)
     ///        what has been received so far.
-    fn command(&self, cmd_num: usize, arg1: usize, _: usize, appid: AppId) -> CommandReturn {
+    fn command(&self, cmd_num: usize, arg1: usize, _: usize, appid: ProcessId) -> CommandReturn {
         let res = match cmd_num {
             0 => Ok(Ok(())),
             1 => {

--- a/capsules/src/crc.rs
+++ b/capsules/src/crc.rs
@@ -71,7 +71,7 @@ use core::mem;
 use kernel::common::cells::OptionalCell;
 use kernel::hil;
 use kernel::hil::crc::CrcAlg;
-use kernel::{AppId, CommandReturn, Driver, ErrorCode, Grant, Upcall};
+use kernel::{CommandReturn, Driver, ErrorCode, Grant, ProcessId, Upcall};
 use kernel::{Read, ReadOnlyAppSlice};
 
 /// Syscall driver number.
@@ -94,7 +94,7 @@ pub struct App {
 pub struct Crc<'a, C: hil::crc::CRC<'a>> {
     crc_unit: &'a C,
     apps: Grant<App>,
-    serving_app: OptionalCell<AppId>,
+    serving_app: OptionalCell<ProcessId>,
 }
 
 impl<'a, C: hil::crc::CRC<'a>> Crc<'a, C> {
@@ -172,7 +172,7 @@ impl<'a, C: hil::crc::CRC<'a>> Driver for Crc<'a, C> {
     ///
     fn allow_readonly(
         &self,
-        appid: AppId,
+        appid: ProcessId,
         allow_num: usize,
         mut slice: ReadOnlyAppSlice,
     ) -> Result<ReadOnlyAppSlice, (ReadOnlyAppSlice, ErrorCode)> {
@@ -215,7 +215,7 @@ impl<'a, C: hil::crc::CRC<'a>> Driver for Crc<'a, C> {
         &self,
         subscribe_num: usize,
         mut callback: Upcall,
-        app_id: AppId,
+        app_id: ProcessId,
     ) -> Result<Upcall, (Upcall, ErrorCode)> {
         let res = match subscribe_num {
             // Set callback for CRC result
@@ -299,7 +299,7 @@ impl<'a, C: hil::crc::CRC<'a>> Driver for Crc<'a, C> {
         command_num: usize,
         algorithm: usize,
         _: usize,
-        appid: AppId,
+        appid: ProcessId,
     ) -> CommandReturn {
         match command_num {
             // This driver is present

--- a/capsules/src/crc.rs
+++ b/capsules/src/crc.rs
@@ -128,7 +128,7 @@ impl<'a, C: hil::crc::CRC<'a>> Crc<'a, C> {
         // Find a waiting app and start its requested computation
         let mut found = false;
         for app in self.apps.iter() {
-            let appid = app.appid();
+            let appid = app.processid();
             app.enter(|app| {
                 if let Some(alg) = app.waiting {
                     let rcode = app

--- a/capsules/src/ctap.rs
+++ b/capsules/src/ctap.rs
@@ -33,7 +33,7 @@ use core::mem;
 use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::hil::usb_hid;
 use kernel::{
-    AppId, CommandReturn, Driver, ErrorCode, Grant, Read, ReadWrite, ReadWriteAppSlice, Upcall,
+    CommandReturn, Driver, ErrorCode, Grant, ProcessId, Read, ReadWrite, ReadWriteAppSlice, Upcall,
 };
 
 /// Syscall driver number.
@@ -62,7 +62,7 @@ pub struct CtapDriver<'a, U: usb_hid::UsbHid<'a, [u8; 64]>> {
     usb: Option<&'a U>,
 
     app: Grant<App>,
-    appid: OptionalCell<AppId>,
+    appid: OptionalCell<ProcessId>,
     phantom: PhantomData<&'a U>,
 
     send_buffer: TakeCell<'static, [u8; 64]>,
@@ -190,7 +190,7 @@ impl<'a, U: usb_hid::UsbHid<'a, [u8; 64]>> usb_hid::Client<'a, [u8; 64]> for Cta
 impl<'a, U: usb_hid::UsbHid<'a, [u8; 64]>> Driver for CtapDriver<'a, U> {
     fn allow_readwrite(
         &self,
-        appid: AppId,
+        appid: ProcessId,
         allow_num: usize,
         mut slice: ReadWriteAppSlice,
     ) -> Result<ReadWriteAppSlice, (ReadWriteAppSlice, ErrorCode)> {
@@ -235,7 +235,7 @@ impl<'a, U: usb_hid::UsbHid<'a, [u8; 64]>> Driver for CtapDriver<'a, U> {
         &self,
         subscribe_num: usize,
         mut callback: Upcall,
-        appid: AppId,
+        appid: ProcessId,
     ) -> Result<Upcall, (Upcall, ErrorCode)> {
         let res = match subscribe_num {
             0 => {
@@ -263,7 +263,7 @@ impl<'a, U: usb_hid::UsbHid<'a, [u8; 64]>> Driver for CtapDriver<'a, U> {
         command_num: usize,
         _data1: usize,
         _data2: usize,
-        appid: AppId,
+        appid: ProcessId,
     ) -> CommandReturn {
         let can_access = self.appid.map_or(true, |owning_app| {
             if owning_app == &appid {

--- a/capsules/src/dac.rs
+++ b/capsules/src/dac.rs
@@ -16,7 +16,7 @@ use crate::driver;
 pub const DRIVER_NUM: usize = driver::NUM::Dac as usize;
 
 use kernel::hil;
-use kernel::{AppId, CommandReturn, Driver, ErrorCode};
+use kernel::{CommandReturn, Driver, ErrorCode, ProcessId};
 
 pub struct Dac<'a> {
     dac: &'a dyn hil::dac::DacChannel,
@@ -36,7 +36,7 @@ impl Driver for Dac<'_> {
     /// - `0`: Driver check.
     /// - `1`: Initialize and enable the DAC.
     /// - `2`: Set the output to `data1`, a scaled output value.
-    fn command(&self, command_num: usize, data: usize, _: usize, _: AppId) -> CommandReturn {
+    fn command(&self, command_num: usize, data: usize, _: usize, _: ProcessId) -> CommandReturn {
         match command_num {
             0 /* check if present */ => CommandReturn::success(),
 

--- a/capsules/src/gpio.rs
+++ b/capsules/src/gpio.rs
@@ -54,7 +54,7 @@ pub const DRIVER_NUM: usize = driver::NUM::Gpio as usize;
 use core::mem;
 use kernel::hil::gpio;
 use kernel::hil::gpio::{Configure, Input, InterruptWithValue, Output};
-use kernel::{AppId, CommandReturn, Driver, ErrorCode, Grant, Upcall};
+use kernel::{CommandReturn, Driver, ErrorCode, Grant, ProcessId, Upcall};
 
 pub struct GPIO<'a, IP: gpio::InterruptPin<'a>> {
     pins: &'a [Option<&'a gpio::InterruptValueWrapper<'a, IP>>],
@@ -155,7 +155,7 @@ impl<'a, IP: gpio::InterruptPin<'a>> Driver for GPIO<'a, IP> {
         &self,
         subscribe_num: usize,
         mut callback: Upcall,
-        app_id: AppId,
+        app_id: ProcessId,
     ) -> Result<Upcall, (Upcall, ErrorCode)> {
         let res = match subscribe_num {
             // subscribe to all pin interrupts (no affect or reliance on
@@ -206,7 +206,13 @@ impl<'a, IP: gpio::InterruptPin<'a>> Driver for GPIO<'a, IP> {
     /// - `7`: Configure interrupt on `pin` with `irq_config` in 0x00XX00000
     /// - `8`: Disable interrupt on `pin`.
     /// - `9`: Disable `pin`.
-    fn command(&self, command_num: usize, data1: usize, data2: usize, _: AppId) -> CommandReturn {
+    fn command(
+        &self,
+        command_num: usize,
+        data1: usize,
+        data2: usize,
+        _: ProcessId,
+    ) -> CommandReturn {
         let pins = self.pins.as_ref();
         let pin_index = data1;
         match command_num {

--- a/capsules/src/gpio_async.rs
+++ b/capsules/src/gpio_async.rs
@@ -27,8 +27,8 @@
 
 use core::cell::Cell;
 use kernel::hil;
-use kernel::{AppId, ErrorCode, Upcall};
 use kernel::{CommandReturn, Driver};
+use kernel::{ErrorCode, ProcessId, Upcall};
 
 /// Syscall driver number.
 use crate::driver;
@@ -101,7 +101,7 @@ impl<Port: hil::gpio_async::Port> Driver for GPIOAsync<'_, Port> {
         &self,
         subscribe_num: usize,
         callback: Upcall,
-        _app_id: AppId,
+        _app_id: ProcessId,
     ) -> Result<Upcall, (Upcall, ErrorCode)> {
         match subscribe_num {
             // Set callback for `done()` events
@@ -144,7 +144,7 @@ impl<Port: hil::gpio_async::Port> Driver for GPIOAsync<'_, Port> {
         command_number: usize,
         pin: usize,
         data: usize,
-        _appid: AppId,
+        _appid: ProcessId,
     ) -> CommandReturn {
         let port = data & 0xFFFF;
         let other = (data >> 16) & 0xFFFF;

--- a/capsules/src/humidity.rs
+++ b/capsules/src/humidity.rs
@@ -52,7 +52,7 @@ use core::cell::Cell;
 use core::mem;
 
 use kernel::hil;
-use kernel::{AppId, CommandReturn, Driver, ErrorCode, Grant, Upcall};
+use kernel::{CommandReturn, Driver, ErrorCode, Grant, ProcessId, Upcall};
 
 /// Syscall driver number.
 use crate::driver;
@@ -92,7 +92,7 @@ impl<'a> HumiditySensor<'a> {
         &self,
         command: HumidityCommand,
         arg1: usize,
-        appid: AppId,
+        appid: ProcessId,
     ) -> CommandReturn {
         self.apps
             .enter(appid, |app| {
@@ -117,7 +117,7 @@ impl<'a> HumiditySensor<'a> {
     fn configure_callback(
         &self,
         mut callback: Upcall,
-        app_id: AppId,
+        app_id: ProcessId,
     ) -> Result<Upcall, (Upcall, ErrorCode)> {
         let res = self
             .apps
@@ -153,7 +153,7 @@ impl Driver for HumiditySensor<'_> {
         &self,
         subscribe_num: usize,
         callback: Upcall,
-        app_id: AppId,
+        app_id: ProcessId,
     ) -> Result<Upcall, (Upcall, ErrorCode)> {
         match subscribe_num {
             // subscribe to temperature reading with callback
@@ -162,7 +162,13 @@ impl Driver for HumiditySensor<'_> {
         }
     }
 
-    fn command(&self, command_num: usize, arg1: usize, _: usize, appid: AppId) -> CommandReturn {
+    fn command(
+        &self,
+        command_num: usize,
+        arg1: usize,
+        _: usize,
+        appid: ProcessId,
+    ) -> CommandReturn {
         match command_num {
             // check whether the driver exist!!
             0 => CommandReturn::success(),

--- a/capsules/src/i2c_master_slave_driver.rs
+++ b/capsules/src/i2c_master_slave_driver.rs
@@ -15,7 +15,7 @@ use core::cell::Cell;
 use core::cmp;
 use kernel::common::cells::{MapCell, TakeCell};
 use kernel::hil;
-use kernel::{AppId, CommandReturn, Upcall};
+use kernel::{CommandReturn, ProcessId, Upcall};
 use kernel::{Driver, ErrorCode, Read, ReadWrite, ReadWriteAppSlice};
 
 pub static mut BUFFER1: [u8; 256] = [0; 256];
@@ -222,7 +222,7 @@ impl hil::i2c::I2CHwSlaveClient for I2CMasterSlaveDriver<'_> {
 impl Driver for I2CMasterSlaveDriver<'_> {
     fn allow_readwrite(
         &self,
-        _appid: AppId,
+        _appid: ProcessId,
         allow_num: usize,
         mut slice: ReadWriteAppSlice,
     ) -> Result<ReadWriteAppSlice, (ReadWriteAppSlice, ErrorCode)> {
@@ -264,7 +264,7 @@ impl Driver for I2CMasterSlaveDriver<'_> {
         &self,
         subscribe_num: usize,
         mut callback: Upcall,
-        _app_id: AppId,
+        _app_id: ProcessId,
     ) -> Result<Upcall, (Upcall, ErrorCode)> {
         match subscribe_num {
             0 => {
@@ -279,7 +279,7 @@ impl Driver for I2CMasterSlaveDriver<'_> {
         }
     }
 
-    fn command(&self, command_num: usize, data: usize, _: usize, _: AppId) -> CommandReturn {
+    fn command(&self, command_num: usize, data: usize, _: usize, _: ProcessId) -> CommandReturn {
         match command_num {
             0 /* check if present */ => CommandReturn::success(),
 

--- a/capsules/src/ieee802154/driver.rs
+++ b/capsules/src/ieee802154/driver.rs
@@ -354,7 +354,7 @@ impl<'a> RadioDriver<'a> {
         }
         let mut pending_app = None;
         for app in self.apps.iter() {
-            let appid = app.appid();
+            let appid = app.processid();
             app.enter(|app| {
                 if app.pending_tx.is_some() {
                     pending_app = Some(appid);

--- a/capsules/src/l3gd20.rs
+++ b/capsules/src/l3gd20.rs
@@ -106,7 +106,7 @@ use core::cell::Cell;
 use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::hil::sensors;
 use kernel::hil::spi;
-use kernel::{AppId, CommandReturn, Driver, ErrorCode, Upcall};
+use kernel::{CommandReturn, Driver, ErrorCode, ProcessId, Upcall};
 
 use crate::driver;
 pub const DRIVER_NUM: usize = driver::NUM::L3gd20 as usize;
@@ -298,7 +298,7 @@ impl Driver for L3gd20Spi<'_> {
         command_num: usize,
         data1: usize,
         data2: usize,
-        _appid: AppId,
+        _appid: ProcessId,
     ) -> CommandReturn {
         match command_num {
             0 => CommandReturn::success(),
@@ -378,7 +378,7 @@ impl Driver for L3gd20Spi<'_> {
         &self,
         subscribe_num: usize,
         mut callback: Upcall,
-        _appid: AppId,
+        _appid: ProcessId,
     ) -> Result<Upcall, (Upcall, ErrorCode)> {
         match subscribe_num {
             0 /* set the one shot callback */ => {

--- a/capsules/src/led.rs
+++ b/capsules/src/led.rs
@@ -52,7 +52,7 @@
 
 use kernel::common::cells::TakeCell;
 use kernel::hil::led;
-use kernel::{AppId, CommandReturn, Driver, ErrorCode};
+use kernel::{CommandReturn, Driver, ErrorCode, ProcessId};
 
 /// Syscall driver number.
 use crate::driver;
@@ -91,7 +91,7 @@ impl<L: led::Led> Driver for LedDriver<'_, L> {
     ///        if the LED index is not valid.
     /// - `3`: Toggle the LED at index specified by `data` on or off. Returns
     ///        `INVAL` if the LED index is not valid.
-    fn command(&self, command_num: usize, data: usize, _: usize, _: AppId) -> CommandReturn {
+    fn command(&self, command_num: usize, data: usize, _: usize, _: ProcessId) -> CommandReturn {
         self.leds
             .map(|leds| {
                 match command_num {

--- a/capsules/src/led_matrix.rs
+++ b/capsules/src/led_matrix.rs
@@ -68,7 +68,7 @@
 //!   - Return: `Ok(())` if the LED index was valid, `INVAL` otherwise.
 
 use kernel::hil::gpio;
-use kernel::{AppId, CommandReturn, Driver, ErrorCode};
+use kernel::{CommandReturn, Driver, ErrorCode, ProcessId};
 
 use core::cell::Cell;
 use kernel::common::cells::TakeCell;
@@ -200,7 +200,7 @@ impl<'a, L: gpio::Pin, A: Alarm<'a>> Driver for LedMatrixDriver<'a, L, A> {
     ///        if the LED index is not valid.
     /// - `3`: Toggle the LED at index specified by `data` on or off. Returns
     ///        `INVAL` if the LED index is not valid.
-    fn command(&self, command_num: usize, data: usize, _: usize, _: AppId) -> CommandReturn {
+    fn command(&self, command_num: usize, data: usize, _: usize, _: ProcessId) -> CommandReturn {
         match command_num {
             // get number of LEDs
             0 => CommandReturn::success_u32((self.cols.len() * self.rows.len()) as u32),

--- a/capsules/src/low_level_debug/mod.rs
+++ b/capsules/src/low_level_debug/mod.rs
@@ -83,7 +83,7 @@ impl<'u, U: Transmit<'u>> TransmitClient for LowLevelDebug<'u, U> {
         }
 
         for process_grant in self.grant.iter() {
-            let appid = process_grant.appid();
+            let appid = process_grant.processid();
             let (app_num, first_entry) = process_grant.enter(|owned_app_data| {
                 owned_app_data.queue.rotate_left(1);
                 (appid.id(), owned_app_data.queue[QUEUE_SIZE - 1].take())

--- a/capsules/src/low_level_debug/mod.rs
+++ b/capsules/src/low_level_debug/mod.rs
@@ -5,7 +5,7 @@ mod fmt;
 
 use core::cell::Cell;
 use kernel::hil::uart::{Transmit, TransmitClient};
-use kernel::{AppId, CommandReturn, ErrorCode, Grant};
+use kernel::{CommandReturn, ErrorCode, Grant, ProcessId};
 
 // LowLevelDebug requires a &mut [u8] buffer of length at least BUF_LEN.
 pub use fmt::BUF_LEN;
@@ -41,7 +41,13 @@ impl<'u, U: Transmit<'u>> LowLevelDebug<'u, U> {
 }
 
 impl<'u, U: Transmit<'u>> kernel::Driver for LowLevelDebug<'u, U> {
-    fn command(&self, minor_num: usize, r2: usize, r3: usize, caller_id: AppId) -> CommandReturn {
+    fn command(
+        &self,
+        minor_num: usize,
+        r2: usize,
+        r3: usize,
+        caller_id: ProcessId,
+    ) -> CommandReturn {
         match minor_num {
             0 => return CommandReturn::success(),
             1 => self.push_entry(DebugEntry::AlertCode(r2), caller_id),
@@ -100,7 +106,7 @@ impl<'u, U: Transmit<'u>> TransmitClient for LowLevelDebug<'u, U> {
 impl<'u, U: Transmit<'u>> LowLevelDebug<'u, U> {
     // If the UART is not busy (the buffer is available), transmits the entry.
     // Otherwise, adds it to the app's queue.
-    fn push_entry(&self, entry: DebugEntry, appid: AppId) {
+    fn push_entry(&self, entry: DebugEntry, appid: ProcessId) {
         use DebugEntry::Dropped;
 
         if let Some(buffer) = self.buffer.take() {

--- a/capsules/src/lps25hb.rs
+++ b/capsules/src/lps25hb.rs
@@ -22,7 +22,7 @@ use core::cell::Cell;
 use kernel::common::cells::TakeCell;
 use kernel::hil::gpio;
 use kernel::hil::i2c;
-use kernel::{AppId, CommandReturn, Driver, ErrorCode, Upcall};
+use kernel::{CommandReturn, Driver, ErrorCode, ProcessId, Upcall};
 
 /// Syscall driver number.
 use crate::driver;
@@ -225,7 +225,7 @@ impl Driver for LPS25HB<'_> {
         &self,
         subscribe_num: usize,
         callback: Upcall,
-        _app_id: AppId,
+        _app_id: ProcessId,
     ) -> Result<Upcall, (Upcall, ErrorCode)> {
         match subscribe_num {
             // Set a callback
@@ -236,7 +236,7 @@ impl Driver for LPS25HB<'_> {
         }
     }
 
-    fn command(&self, command_num: usize, _: usize, _: usize, _: AppId) -> CommandReturn {
+    fn command(&self, command_num: usize, _: usize, _: usize, _: ProcessId) -> CommandReturn {
         match command_num {
             0 /* check if present */ => CommandReturn::success(),
             // Take a pressure measurement

--- a/capsules/src/lsm303agr.rs
+++ b/capsules/src/lsm303agr.rs
@@ -85,7 +85,7 @@ use enum_primitive::enum_from_primitive;
 use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::hil::i2c::{self, Error};
 use kernel::hil::sensors;
-use kernel::{AppId, CommandReturn, Driver, ErrorCode, Upcall};
+use kernel::{CommandReturn, Driver, ErrorCode, ProcessId, Upcall};
 
 use crate::driver;
 use crate::lsm303xx::{
@@ -496,7 +496,7 @@ impl Driver for Lsm303agrI2C<'_> {
         command_num: usize,
         data1: usize,
         data2: usize,
-        _appid: AppId,
+        _appid: ProcessId,
     ) -> CommandReturn {
         match command_num {
             0 => CommandReturn::success(),
@@ -597,7 +597,7 @@ impl Driver for Lsm303agrI2C<'_> {
         &self,
         subscribe_num: usize,
         callback: Upcall,
-        _appid: AppId,
+        _appid: ProcessId,
     ) -> Result<Upcall, (Upcall, ErrorCode)> {
         match subscribe_num {
             0 /* set the one shot callback */ => {

--- a/capsules/src/lsm303dlhc.rs
+++ b/capsules/src/lsm303dlhc.rs
@@ -84,7 +84,7 @@ use enum_primitive::enum_from_primitive;
 use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::hil::i2c::{self, Error};
 use kernel::hil::sensors;
-use kernel::{AppId, CommandReturn, Driver, ErrorCode, Upcall};
+use kernel::{CommandReturn, Driver, ErrorCode, ProcessId, Upcall};
 
 use crate::lsm303xx::{
     AccelerometerRegisters, Lsm303AccelDataRate, Lsm303MagnetoDataRate, Lsm303Range, Lsm303Scale,
@@ -505,7 +505,7 @@ impl Driver for Lsm303dlhcI2C<'_> {
         command_num: usize,
         data1: usize,
         data2: usize,
-        _appid: AppId,
+        _appid: ProcessId,
     ) -> CommandReturn {
         match command_num {
             0 => CommandReturn::success(),
@@ -609,7 +609,7 @@ impl Driver for Lsm303dlhcI2C<'_> {
         &self,
         subscribe_num: usize,
         callback: Upcall,
-        _appid: AppId,
+        _appid: ProcessId,
     ) -> Result<Upcall, (Upcall, ErrorCode)> {
         match subscribe_num {
             0 /* set the one shot callback */ => {

--- a/capsules/src/ltc294x.rs
+++ b/capsules/src/ltc294x.rs
@@ -49,7 +49,7 @@ use core::cell::Cell;
 use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::hil::gpio;
 use kernel::hil::i2c;
-use kernel::{AppId, CommandReturn, Driver, ErrorCode, Upcall};
+use kernel::{CommandReturn, Driver, ErrorCode, ProcessId, Upcall};
 
 /// Syscall driver number.
 use crate::driver;
@@ -476,7 +476,7 @@ impl Driver for LTC294XDriver<'_> {
         &self,
         subscribe_num: usize,
         callback: Upcall,
-        _app_id: AppId,
+        _app_id: ProcessId,
     ) -> Result<Upcall, (Upcall, ErrorCode)> {
         match subscribe_num {
             0 => Ok(self.callback.replace(callback)),
@@ -503,7 +503,7 @@ impl Driver for LTC294XDriver<'_> {
     /// - `9`: Get the current reading. Only supported on the LTC2943.
     /// - `10`: Set the model of the LTC294X actually being used. `data` is the
     ///   value of the X.
-    fn command(&self, command_num: usize, data: usize, _: usize, _: AppId) -> CommandReturn {
+    fn command(&self, command_num: usize, data: usize, _: usize, _: ProcessId) -> CommandReturn {
         match command_num {
             // Check this driver exists.
             0 => CommandReturn::success(),

--- a/capsules/src/max17205.rs
+++ b/capsules/src/max17205.rs
@@ -40,7 +40,7 @@
 use core::cell::Cell;
 use kernel::common::cells::{MapCell, OptionalCell, TakeCell};
 use kernel::hil::i2c;
-use kernel::{AppId, CommandReturn, Driver, ErrorCode, Upcall};
+use kernel::{CommandReturn, Driver, ErrorCode, ProcessId, Upcall};
 
 /// Syscall driver number.
 use crate::driver;
@@ -437,7 +437,7 @@ impl Driver for MAX17205Driver<'_> {
         &self,
         subscribe_num: usize,
         callback: Upcall,
-        _app_id: AppId,
+        _app_id: ProcessId,
     ) -> Result<Upcall, (Upcall, ErrorCode)> {
         match subscribe_num {
             0 => {
@@ -466,7 +466,7 @@ impl Driver for MAX17205Driver<'_> {
     /// - `3`: Read the current voltage and current draw.
     /// - `4`: Read the raw coulomb count.
     /// - `5`: Read the unique 64 bit RomID.
-    fn command(&self, command_num: usize, _data: usize, _: usize, _: AppId) -> CommandReturn {
+    fn command(&self, command_num: usize, _data: usize, _: usize, _: ProcessId) -> CommandReturn {
         match command_num {
             0 => CommandReturn::success(),
 

--- a/capsules/src/mlx90614.rs
+++ b/capsules/src/mlx90614.rs
@@ -22,7 +22,7 @@ use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::common::registers::register_bitfields;
 use kernel::hil::i2c::{self, Error};
 use kernel::hil::sensors;
-use kernel::{AppId, CommandReturn, Driver, ErrorCode, Upcall};
+use kernel::{CommandReturn, Driver, ErrorCode, ProcessId, Upcall};
 
 /// Syscall driver number.
 pub const DRIVER_NUM: usize = driver::NUM::Mlx90614 as usize;
@@ -152,7 +152,13 @@ impl<'a> i2c::I2CClient for Mlx90614SMBus<'a> {
 }
 
 impl<'a> Driver for Mlx90614SMBus<'a> {
-    fn command(&self, command_num: usize, _data1: usize, _data2: usize, _: AppId) -> CommandReturn {
+    fn command(
+        &self,
+        command_num: usize,
+        _data1: usize,
+        _data2: usize,
+        _: ProcessId,
+    ) -> CommandReturn {
         match command_num {
             0 => CommandReturn::success(),
             // Check is sensor is correctly connected
@@ -191,7 +197,7 @@ impl<'a> Driver for Mlx90614SMBus<'a> {
         &self,
         subscribe_num: usize,
         callback: Upcall,
-        _app_id: AppId,
+        _app_id: ProcessId,
     ) -> Result<Upcall, (Upcall, ErrorCode)> {
         match subscribe_num {
             0 /* set the one shot callback */ => {

--- a/capsules/src/net/udp/driver.rs
+++ b/capsules/src/net/udp/driver.rs
@@ -148,7 +148,7 @@ impl<'a> UDPDriver<'a> {
         }
         let mut pending_app = None;
         for app in self.apps.iter() {
-            let appid = app.appid();
+            let appid = app.processid();
             app.enter(|app| {
                 if app.pending_tx.is_some() {
                     pending_app = Some(appid);

--- a/capsules/src/ninedof.rs
+++ b/capsules/src/ninedof.rs
@@ -177,7 +177,7 @@ impl hil::sensors::NineDofClient for NineDof<'_> {
 
         // Check if there are any pending events.
         for cntr in self.apps.iter() {
-            let appid = cntr.appid();
+            let appid = cntr.processid();
             let started_command = cntr.enter(|app| {
                 if app.pending_command
                     && app.command == finished_command

--- a/capsules/src/nonvolatile_storage_driver.rs
+++ b/capsules/src/nonvolatile_storage_driver.rs
@@ -61,7 +61,7 @@ use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::hil;
 use kernel::ErrorCode;
 use kernel::{
-    AppId, CommandReturn, Driver, Grant, Read, ReadOnlyAppSlice, ReadWrite, ReadWriteAppSlice,
+    CommandReturn, Driver, Grant, ProcessId, Read, ReadOnlyAppSlice, ReadWrite, ReadWriteAppSlice,
     Upcall,
 };
 
@@ -81,7 +81,7 @@ pub enum NonvolatileCommand {
 
 #[derive(Clone, Copy)]
 pub enum NonvolatileUser {
-    App { app_id: AppId },
+    App { app_id: ProcessId },
     Kernel,
 }
 
@@ -183,7 +183,7 @@ impl<'a> NonvolatileStorage<'a> {
         command: NonvolatileCommand,
         offset: usize,
         length: usize,
-        app_id: Option<AppId>,
+        app_id: Option<ProcessId>,
     ) -> Result<(), ErrorCode> {
         // Do bounds check.
         match command {
@@ -494,7 +494,7 @@ impl Driver for NonvolatileStorage<'_> {
     /// - `1`: Setup a buffer to write bytes to the nonvolatile storage.
     fn allow_readwrite(
         &self,
-        appid: AppId,
+        appid: ProcessId,
         allow_num: usize,
         mut slice: ReadWriteAppSlice,
     ) -> Result<ReadWriteAppSlice, (ReadWriteAppSlice, ErrorCode)> {
@@ -522,7 +522,7 @@ impl Driver for NonvolatileStorage<'_> {
     /// - `0`: Setup a buffer to write bytes to the nonvolatile storage.
     fn allow_readonly(
         &self,
-        appid: AppId,
+        appid: ProcessId,
         allow_num: usize,
         mut slice: ReadOnlyAppSlice,
     ) -> Result<ReadOnlyAppSlice, (ReadOnlyAppSlice, ErrorCode)> {
@@ -553,7 +553,7 @@ impl Driver for NonvolatileStorage<'_> {
         &self,
         subscribe_num: usize,
         mut callback: Upcall,
-        app_id: AppId,
+        app_id: ProcessId,
     ) -> Result<Upcall, (Upcall, ErrorCode)> {
         let res = self
             .apps
@@ -591,7 +591,7 @@ impl Driver for NonvolatileStorage<'_> {
         command_num: usize,
         offset: usize,
         length: usize,
-        appid: AppId,
+        appid: ProcessId,
     ) -> CommandReturn {
         match command_num {
             0 /* This driver exists. */ => {

--- a/capsules/src/nonvolatile_storage_driver.rs
+++ b/capsules/src/nonvolatile_storage_driver.rs
@@ -371,7 +371,7 @@ impl<'a> NonvolatileStorage<'a> {
         } else {
             // If the kernel is not requesting anything, check all of the apps.
             for cntr in self.apps.iter() {
-                let appid = cntr.appid();
+                let appid = cntr.processid();
                 let started_command = cntr.enter(|app| {
                     if app.pending_command {
                         app.pending_command = false;

--- a/capsules/src/nrf51822_serialization.rs
+++ b/capsules/src/nrf51822_serialization.rs
@@ -26,7 +26,7 @@ use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::hil;
 use kernel::hil::uart;
 use kernel::{
-    AppId, CommandReturn, Driver, ErrorCode, Grant, Read, ReadOnlyAppSlice, ReadWrite,
+    CommandReturn, Driver, ErrorCode, Grant, ProcessId, Read, ReadOnlyAppSlice, ReadWrite,
     ReadWriteAppSlice, Upcall,
 };
 
@@ -52,7 +52,7 @@ pub struct Nrf51822Serialization<'a> {
     uart: &'a dyn uart::UartAdvanced<'a>,
     reset_pin: &'a dyn hil::gpio::Pin,
     apps: Grant<App>,
-    active_app: OptionalCell<AppId>,
+    active_app: OptionalCell<ProcessId>,
     tx_buffer: TakeCell<'static, [u8]>,
     rx_buffer: TakeCell<'static, [u8]>,
 }
@@ -107,7 +107,7 @@ impl Driver for Nrf51822Serialization<'_> {
     /// - `0`: Provide a RX buffer.
     fn allow_readwrite(
         &self,
-        appid: AppId,
+        appid: ProcessId,
         allow_type: usize,
         mut slice: ReadWriteAppSlice,
     ) -> Result<ReadWriteAppSlice, (ReadWriteAppSlice, ErrorCode)> {
@@ -142,7 +142,7 @@ impl Driver for Nrf51822Serialization<'_> {
     /// - `0`: Provide a TX buffer.
     fn allow_readonly(
         &self,
-        appid: AppId,
+        appid: ProcessId,
         allow_type: usize,
         mut slice: ReadOnlyAppSlice,
     ) -> Result<ReadOnlyAppSlice, (ReadOnlyAppSlice, ErrorCode)> {
@@ -177,7 +177,7 @@ impl Driver for Nrf51822Serialization<'_> {
         &self,
         subscribe_type: usize,
         mut callback: Upcall,
-        appid: AppId,
+        appid: ProcessId,
     ) -> Result<Upcall, (Upcall, ErrorCode)> {
         match subscribe_type {
             // Add a callback
@@ -206,7 +206,13 @@ impl Driver for Nrf51822Serialization<'_> {
     /// - `1`: Send the allowed buffer to the nRF.
     /// - `2`: Received from the nRF into the allowed buffer.
     /// - `3`: Reset the nRF51822.
-    fn command(&self, command_type: usize, arg1: usize, _: usize, appid: AppId) -> CommandReturn {
+    fn command(
+        &self,
+        command_type: usize,
+        arg1: usize,
+        _: usize,
+        appid: ProcessId,
+    ) -> CommandReturn {
         match command_type {
             0 /* check if present */ => CommandReturn::success(),
 

--- a/capsules/src/pca9544a.rs
+++ b/capsules/src/pca9544a.rs
@@ -31,7 +31,7 @@
 use core::cell::Cell;
 use kernel::common::cells::{MapCell, TakeCell};
 use kernel::hil::i2c;
-use kernel::{AppId, CommandReturn, Driver, ErrorCode, Upcall};
+use kernel::{CommandReturn, Driver, ErrorCode, ProcessId, Upcall};
 
 /// Syscall driver number.
 use crate::driver;
@@ -163,7 +163,7 @@ impl Driver for PCA9544A<'_> {
         &self,
         subscribe_num: usize,
         callback: Upcall,
-        _app_id: AppId,
+        _app_id: ProcessId,
     ) -> Result<Upcall, (Upcall, ErrorCode)> {
         match subscribe_num {
             0 => {
@@ -188,7 +188,7 @@ impl Driver for PCA9544A<'_> {
     /// - `2`: Disable all channels.
     /// - `3`: Read the list of fired interrupts.
     /// - `4`: Read which channels are selected.
-    fn command(&self, command_num: usize, data: usize, _: usize, _: AppId) -> CommandReturn {
+    fn command(&self, command_num: usize, data: usize, _: usize, _: ProcessId) -> CommandReturn {
         match command_num {
             // Check if present.
             0 => CommandReturn::success(),

--- a/capsules/src/process_console.rs
+++ b/capsules/src/process_console.rs
@@ -260,7 +260,7 @@ impl<'a, C: ProcessManagementCapability> ProcessConsole<'a, C> {
                                     let info: KernelInfo = KernelInfo::new(self.kernel);
 
                                     let pname = proc.get_process_name();
-                                    let appid = proc.appid();
+                                    let appid = proc.processid();
                                     let (grants_used, grants_total) = info.number_app_grant_uses(appid, &self.capability);
 
                                     debug!(

--- a/capsules/src/proximity.rs
+++ b/capsules/src/proximity.rs
@@ -51,7 +51,7 @@
 use core::cell::Cell;
 use core::mem;
 use kernel::hil;
-use kernel::{AppId, CommandReturn, Driver, ErrorCode, Grant, Upcall};
+use kernel::{CommandReturn, Driver, ErrorCode, Grant, ProcessId, Upcall};
 
 /// Syscall driver number.
 use crate::driver;
@@ -108,7 +108,7 @@ impl<'a> ProximitySensor<'a> {
         command: ProximityCommand,
         arg1: usize,
         arg2: usize,
-        appid: AppId,
+        appid: ProcessId,
     ) -> CommandReturn {
         // Enqueue command by saving command type, args, appid within app struct in grant region
         self.apps
@@ -283,7 +283,7 @@ impl Driver for ProximitySensor<'_> {
         &self,
         subscribe_num: usize,
         mut callback: Upcall,
-        app_id: AppId,
+        app_id: ProcessId,
     ) -> Result<Upcall, (Upcall, ErrorCode)> {
         let res = match subscribe_num {
             0 => self
@@ -299,7 +299,13 @@ impl Driver for ProximitySensor<'_> {
         }
     }
 
-    fn command(&self, command_num: usize, arg1: usize, arg2: usize, appid: AppId) -> CommandReturn {
+    fn command(
+        &self,
+        command_num: usize,
+        arg1: usize,
+        arg2: usize,
+        appid: ProcessId,
+    ) -> CommandReturn {
         match command_num {
             // check whether the driver exist!!
             0 => CommandReturn::success(),

--- a/capsules/src/rng.rs
+++ b/capsules/src/rng.rs
@@ -28,7 +28,7 @@ use kernel::hil::entropy::{Entropy32, Entropy8};
 use kernel::hil::rng;
 use kernel::hil::rng::{Client, Continue, Random, Rng};
 use kernel::{
-    AppId, CommandReturn, Driver, ErrorCode, Grant, ReadWrite, ReadWriteAppSlice, Upcall,
+    CommandReturn, Driver, ErrorCode, Grant, ProcessId, ReadWrite, ReadWriteAppSlice, Upcall,
 };
 
 /// Syscall driver number.
@@ -157,7 +157,7 @@ impl rng::Client for RngDriver<'_> {
 impl<'a> Driver for RngDriver<'a> {
     fn allow_readwrite(
         &self,
-        appid: AppId,
+        appid: ProcessId,
         allow_num: usize,
         mut slice: ReadWriteAppSlice,
     ) -> Result<ReadWriteAppSlice, (ReadWriteAppSlice, ErrorCode)> {
@@ -183,7 +183,7 @@ impl<'a> Driver for RngDriver<'a> {
         &self,
         subscribe_num: usize,
         mut callback: Upcall,
-        app_id: AppId,
+        app_id: ProcessId,
     ) -> Result<Upcall, (Upcall, ErrorCode)> {
         let res = match subscribe_num {
             0 => self
@@ -202,7 +202,13 @@ impl<'a> Driver for RngDriver<'a> {
         }
     }
 
-    fn command(&self, command_num: usize, data: usize, _: usize, appid: AppId) -> CommandReturn {
+    fn command(
+        &self,
+        command_num: usize,
+        data: usize,
+        _: usize,
+        appid: ProcessId,
+    ) -> CommandReturn {
         match command_num {
             0 /* Check if exists */ =>
             {

--- a/capsules/src/screen.rs
+++ b/capsules/src/screen.rs
@@ -373,7 +373,7 @@ impl<'a> Screen<'a> {
 
         // Check if there are any pending events.
         for app in self.apps.iter() {
-            let appid = app.appid();
+            let appid = app.processid();
             let started_command = app.enter(|app| {
                 if app.pending_command {
                     app.pending_command = false;

--- a/capsules/src/screen.rs
+++ b/capsules/src/screen.rs
@@ -16,7 +16,7 @@ use core::mem;
 use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::hil;
 use kernel::hil::screen::{ScreenPixelFormat, ScreenRotation};
-use kernel::{AppId, CommandReturn, Driver, ErrorCode, Grant, Read, ReadOnlyAppSlice, Upcall};
+use kernel::{CommandReturn, Driver, ErrorCode, Grant, ProcessId, Read, ReadOnlyAppSlice, Upcall};
 
 /// Syscall driver number.
 use crate::driver;
@@ -112,7 +112,7 @@ pub struct Screen<'a> {
     screen_setup: Option<&'a dyn hil::screen::ScreenSetup>,
     apps: Grant<App>,
     screen_ready: Cell<bool>,
-    current_app: OptionalCell<AppId>,
+    current_app: OptionalCell<ProcessId>,
     pixel_format: Cell<ScreenPixelFormat>,
     buffer: TakeCell<'static, [u8]>,
 }
@@ -143,7 +143,7 @@ impl<'a> Screen<'a> {
         command: ScreenCommand,
         data1: usize,
         data2: usize,
-        appid: AppId,
+        appid: ProcessId,
     ) -> CommandReturn {
         let res = self
             .apps
@@ -181,7 +181,7 @@ impl<'a> Screen<'a> {
         command: ScreenCommand,
         data1: usize,
         data2: usize,
-        appid: AppId,
+        appid: ProcessId,
     ) -> Result<(), ErrorCode> {
         match command {
             ScreenCommand::SetBrightness => self.screen.set_brightness(data1),
@@ -504,7 +504,7 @@ impl<'a> Driver for Screen<'a> {
         &self,
         subscribe_num: usize,
         mut callback: Upcall,
-        app_id: AppId,
+        app_id: ProcessId,
     ) -> Result<Upcall, (Upcall, ErrorCode)> {
         let res = match subscribe_num {
             0 => self
@@ -527,7 +527,7 @@ impl<'a> Driver for Screen<'a> {
         command_num: usize,
         data1: usize,
         data2: usize,
-        appid: AppId,
+        appid: ProcessId,
     ) -> CommandReturn {
         match command_num {
             0 =>
@@ -582,7 +582,7 @@ impl<'a> Driver for Screen<'a> {
 
     fn allow_readonly(
         &self,
-        appid: AppId,
+        appid: ProcessId,
         allow_num: usize,
         mut slice: ReadOnlyAppSlice,
     ) -> Result<ReadOnlyAppSlice, (ReadOnlyAppSlice, ErrorCode)> {

--- a/capsules/src/sdcard.rs
+++ b/capsules/src/sdcard.rs
@@ -47,7 +47,7 @@ use core::mem;
 use kernel::common::cells::{MapCell, OptionalCell, TakeCell};
 use kernel::hil;
 use kernel::ErrorCode;
-use kernel::{AppId, CommandReturn, Driver, Upcall};
+use kernel::{CommandReturn, Driver, ProcessId, Upcall};
 use kernel::{Read, ReadOnlyAppSlice, ReadWrite, ReadWriteAppSlice};
 
 /// Syscall driver number.
@@ -1500,7 +1500,7 @@ impl<'a, A: hil::time::Alarm<'a>> SDCardClient for SDCardDriver<'a, A> {
 impl<'a, A: hil::time::Alarm<'a>> Driver for SDCardDriver<'a, A> {
     fn allow_readwrite(
         &self,
-        _appid: AppId,
+        _appid: ProcessId,
         allow_num: usize,
         mut slice: ReadWriteAppSlice,
     ) -> Result<ReadWriteAppSlice, (ReadWriteAppSlice, ErrorCode)> {
@@ -1518,7 +1518,7 @@ impl<'a, A: hil::time::Alarm<'a>> Driver for SDCardDriver<'a, A> {
 
     fn allow_readonly(
         &self,
-        _appid: AppId,
+        _appid: ProcessId,
         allow_num: usize,
         mut slice: ReadOnlyAppSlice,
     ) -> Result<ReadOnlyAppSlice, (ReadOnlyAppSlice, ErrorCode)> {
@@ -1538,7 +1538,7 @@ impl<'a, A: hil::time::Alarm<'a>> Driver for SDCardDriver<'a, A> {
         &self,
         subscribe_num: usize,
         mut callback: Upcall,
-        _app_id: AppId,
+        _app_id: ProcessId,
     ) -> Result<Upcall, (Upcall, ErrorCode)> {
         match subscribe_num {
             // Set callback
@@ -1552,7 +1552,7 @@ impl<'a, A: hil::time::Alarm<'a>> Driver for SDCardDriver<'a, A> {
         }
     }
 
-    fn command(&self, command_num: usize, data: usize, _: usize, _: AppId) -> CommandReturn {
+    fn command(&self, command_num: usize, data: usize, _: usize, _: ProcessId) -> CommandReturn {
         match command_num {
             // check if present
             0 => CommandReturn::success(),

--- a/capsules/src/sound_pressure.rs
+++ b/capsules/src/sound_pressure.rs
@@ -56,7 +56,7 @@ use core::cell::Cell;
 use core::convert::TryFrom;
 use core::mem;
 use kernel::hil;
-use kernel::{AppId, CommandReturn, Driver, ErrorCode, Grant, Upcall};
+use kernel::{CommandReturn, Driver, ErrorCode, Grant, ProcessId, Upcall};
 
 /// Syscall driver number.
 use crate::driver;
@@ -87,7 +87,7 @@ impl<'a> SoundPressureSensor<'a> {
         }
     }
 
-    fn enqueue_command(&self, appid: AppId) -> CommandReturn {
+    fn enqueue_command(&self, appid: ProcessId) -> CommandReturn {
         self.apps
             .enter(appid, |app| {
                 if !self.busy.get() {
@@ -144,7 +144,7 @@ impl Driver for SoundPressureSensor<'_> {
         &self,
         subscribe_num: usize,
         mut callback: Upcall,
-        app_id: AppId,
+        app_id: ProcessId,
     ) -> Result<Upcall, (Upcall, ErrorCode)> {
         match subscribe_num {
             // subscribe to sound_pressure reading with callback
@@ -165,7 +165,7 @@ impl Driver for SoundPressureSensor<'_> {
         }
     }
 
-    fn command(&self, command_num: usize, _: usize, _: usize, appid: AppId) -> CommandReturn {
+    fn command(&self, command_num: usize, _: usize, _: usize, appid: ProcessId) -> CommandReturn {
         match command_num {
             // check whether the driver exists!!
             0 => CommandReturn::success(),

--- a/capsules/src/spi_controller.rs
+++ b/capsules/src/spi_controller.rs
@@ -7,7 +7,7 @@ use kernel::common::cells::{MapCell, TakeCell};
 use kernel::hil::spi::ClockPhase;
 use kernel::hil::spi::ClockPolarity;
 use kernel::hil::spi::{SpiMasterClient, SpiMasterDevice};
-use kernel::{AppId, CommandReturn, Driver, ErrorCode, Upcall};
+use kernel::{CommandReturn, Driver, ErrorCode, ProcessId, Upcall};
 use kernel::{Read, ReadOnlyAppSlice, ReadWrite, ReadWriteAppSlice};
 
 /// Syscall driver number.
@@ -93,7 +93,7 @@ impl<'a, S: SpiMasterDevice> Spi<'a, S> {
 impl<'a, S: SpiMasterDevice> Driver for Spi<'a, S> {
     fn allow_readwrite(
         &self,
-        _appid: AppId,
+        _appid: ProcessId,
         allow_num: usize,
         mut slice: ReadWriteAppSlice,
     ) -> Result<ReadWriteAppSlice, (ReadWriteAppSlice, ErrorCode)> {
@@ -111,7 +111,7 @@ impl<'a, S: SpiMasterDevice> Driver for Spi<'a, S> {
 
     fn allow_readonly(
         &self,
-        _appid: AppId,
+        _appid: ProcessId,
         allow_num: usize,
         mut slice: ReadOnlyAppSlice,
     ) -> Result<ReadOnlyAppSlice, (ReadOnlyAppSlice, ErrorCode)> {
@@ -131,7 +131,7 @@ impl<'a, S: SpiMasterDevice> Driver for Spi<'a, S> {
         &self,
         subscribe_num: usize,
         mut callback: Upcall,
-        _app_id: AppId,
+        _app_id: ProcessId,
     ) -> Result<Upcall, (Upcall, ErrorCode)> {
         match subscribe_num {
             0 => {
@@ -180,7 +180,7 @@ impl<'a, S: SpiMasterDevice> Driver for Spi<'a, S> {
     // x+1: unlock spi
     //   - does nothing if lock not held
     //
-    fn command(&self, cmd_num: usize, arg1: usize, _: usize, _: AppId) -> CommandReturn {
+    fn command(&self, cmd_num: usize, arg1: usize, _: usize, _: ProcessId) -> CommandReturn {
         match cmd_num {
             0 /* check if present */ => CommandReturn::success(),
             // No longer supported, wrap inside a read_write_bytes

--- a/capsules/src/spi_peripheral.rs
+++ b/capsules/src/spi_peripheral.rs
@@ -9,7 +9,7 @@ use kernel::common::cells::{MapCell, TakeCell};
 use kernel::hil::spi::ClockPhase;
 use kernel::hil::spi::ClockPolarity;
 use kernel::hil::spi::{SpiSlaveClient, SpiSlaveDevice};
-use kernel::{AppId, CommandReturn, Driver, ErrorCode, Upcall};
+use kernel::{CommandReturn, Driver, ErrorCode, ProcessId, Upcall};
 use kernel::{Read, ReadOnlyAppSlice, ReadWrite, ReadWriteAppSlice};
 
 /// Syscall driver number.
@@ -94,7 +94,7 @@ impl<S: SpiSlaveDevice> Driver for SpiPeripheral<'_, S> {
     ///
     fn allow_readwrite(
         &self,
-        _appid: AppId,
+        _appid: ProcessId,
         allow_num: usize,
         mut slice: ReadWriteAppSlice,
     ) -> Result<ReadWriteAppSlice, (ReadWriteAppSlice, ErrorCode)> {
@@ -115,7 +115,7 @@ impl<S: SpiSlaveDevice> Driver for SpiPeripheral<'_, S> {
     ///
     fn allow_readonly(
         &self,
-        _appid: AppId,
+        _appid: ProcessId,
         allow_num: usize,
         mut slice: ReadOnlyAppSlice,
     ) -> Result<ReadOnlyAppSlice, (ReadOnlyAppSlice, ErrorCode)> {
@@ -144,7 +144,7 @@ impl<S: SpiSlaveDevice> Driver for SpiPeripheral<'_, S> {
         &self,
         subscribe_num: usize,
         mut callback: Upcall,
-        _app_id: AppId,
+        _app_id: ProcessId,
     ) -> Result<Upcall, (Upcall, ErrorCode)> {
         match subscribe_num {
             0 /* read_write */ => {
@@ -193,7 +193,7 @@ impl<S: SpiSlaveDevice> Driver for SpiPeripheral<'_, S> {
     /// - x+1: unlock spi
     ///   - does nothing if lock not held
     ///   - not implemented or currently supported
-    fn command(&self, cmd_num: usize, arg1: usize, _: usize, _: AppId) -> CommandReturn {
+    fn command(&self, cmd_num: usize, arg1: usize, _: usize, _: ProcessId) -> CommandReturn {
         match cmd_num {
             0 /* check if present */ => CommandReturn::success(),
             1 /* read_write_bytes */ => {

--- a/capsules/src/temperature.rs
+++ b/capsules/src/temperature.rs
@@ -56,7 +56,7 @@ use core::cell::Cell;
 use core::convert::TryFrom;
 use core::mem;
 use kernel::hil;
-use kernel::{AppId, CommandReturn, Driver, ErrorCode, Grant, Upcall};
+use kernel::{CommandReturn, Driver, ErrorCode, Grant, ProcessId, Upcall};
 
 /// Syscall driver number.
 use crate::driver;
@@ -86,7 +86,7 @@ impl<'a> TemperatureSensor<'a> {
         }
     }
 
-    fn enqueue_command(&self, appid: AppId) -> CommandReturn {
+    fn enqueue_command(&self, appid: ProcessId) -> CommandReturn {
         self.apps
             .enter(appid, |app| {
                 if !self.busy.get() {
@@ -108,7 +108,7 @@ impl<'a> TemperatureSensor<'a> {
     fn configure_callback(
         &self,
         mut callback: Upcall,
-        app_id: AppId,
+        app_id: ProcessId,
     ) -> Result<Upcall, (Upcall, ErrorCode)> {
         let res = self
             .apps
@@ -143,7 +143,7 @@ impl Driver for TemperatureSensor<'_> {
         &self,
         subscribe_num: usize,
         callback: Upcall,
-        app_id: AppId,
+        app_id: ProcessId,
     ) -> Result<Upcall, (Upcall, ErrorCode)> {
         match subscribe_num {
             // subscribe to temperature reading with callback
@@ -152,7 +152,7 @@ impl Driver for TemperatureSensor<'_> {
         }
     }
 
-    fn command(&self, command_num: usize, _: usize, _: usize, appid: AppId) -> CommandReturn {
+    fn command(&self, command_num: usize, _: usize, _: usize, appid: ProcessId) -> CommandReturn {
         match command_num {
             // check whether the driver exists!!
             0 => CommandReturn::success(),

--- a/capsules/src/test/double_grant_entry.rs
+++ b/capsules/src/test/double_grant_entry.rs
@@ -57,7 +57,7 @@
 //!      // Setup the UART bus for nRF51 serialization..
 //!     ```
 
-use kernel::{AppId, CommandReturn, Driver, ErrorCode, Grant};
+use kernel::{CommandReturn, Driver, ErrorCode, Grant, ProcessId};
 
 /// Syscall driver number.
 pub const DRIVER_NUM: usize = 0xF001;
@@ -79,7 +79,7 @@ impl TestGrantDoubleEntry {
 }
 
 impl Driver for TestGrantDoubleEntry {
-    fn command(&self, command_num: usize, _: usize, _: usize, appid: AppId) -> CommandReturn {
+    fn command(&self, command_num: usize, _: usize, _: usize, appid: ProcessId) -> CommandReturn {
         match command_num {
             0 => CommandReturn::success(),
 

--- a/capsules/src/text_screen.rs
+++ b/capsules/src/text_screen.rs
@@ -15,7 +15,7 @@ use core::convert::From;
 use core::{cmp, mem};
 use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::hil;
-use kernel::{AppId, CommandReturn, Driver, ErrorCode, Grant, Read, ReadOnlyAppSlice, Upcall};
+use kernel::{CommandReturn, Driver, ErrorCode, Grant, ProcessId, Read, ReadOnlyAppSlice, Upcall};
 
 /// Syscall driver number.
 use crate::driver;
@@ -64,7 +64,7 @@ impl Default for App {
 pub struct TextScreen<'a> {
     text_screen: &'a dyn hil::text_screen::TextScreen<'static>,
     apps: Grant<App>,
-    current_app: OptionalCell<AppId>,
+    current_app: OptionalCell<ProcessId>,
     buffer: TakeCell<'static, [u8]>,
 }
 
@@ -87,7 +87,7 @@ impl<'a> TextScreen<'a> {
         command: TextScreenCommand,
         data1: usize,
         data2: usize,
-        appid: AppId,
+        appid: ProcessId,
     ) -> CommandReturn {
         let res = self
             .apps
@@ -125,7 +125,7 @@ impl<'a> TextScreen<'a> {
         command: TextScreenCommand,
         data1: usize,
         data2: usize,
-        appid: AppId,
+        appid: ProcessId,
     ) -> Result<(), ErrorCode> {
         match command {
             TextScreenCommand::GetResolution => {
@@ -210,7 +210,7 @@ impl<'a> Driver for TextScreen<'a> {
         &self,
         subscribe_num: usize,
         mut callback: Upcall,
-        app_id: AppId,
+        app_id: ProcessId,
     ) -> Result<Upcall, (Upcall, ErrorCode)> {
         match subscribe_num {
             0 => {
@@ -235,7 +235,7 @@ impl<'a> Driver for TextScreen<'a> {
         command_num: usize,
         data1: usize,
         data2: usize,
-        appid: AppId,
+        appid: ProcessId,
     ) -> CommandReturn {
         match command_num {
             // This driver exists.
@@ -269,7 +269,7 @@ impl<'a> Driver for TextScreen<'a> {
 
     fn allow_readonly(
         &self,
-        appid: AppId,
+        appid: ProcessId,
         allow_num: usize,
         mut slice: ReadOnlyAppSlice,
     ) -> Result<ReadOnlyAppSlice, (ReadOnlyAppSlice, ErrorCode)> {

--- a/capsules/src/text_screen.rs
+++ b/capsules/src/text_screen.rs
@@ -175,7 +175,7 @@ impl<'a> TextScreen<'a> {
     fn run_next_command(&self) {
         // Check for pending events.
         for app in self.apps.iter() {
-            let appid = app.appid();
+            let appid = app.processid();
             let current_command = app.enter(|app| {
                 if app.pending_command {
                     app.pending_command = false;

--- a/capsules/src/touch.rs
+++ b/capsules/src/touch.rs
@@ -17,7 +17,7 @@ use kernel::hil;
 use kernel::hil::screen::ScreenRotation;
 use kernel::hil::touch::{GestureEvent, TouchEvent, TouchStatus};
 use kernel::{
-    AppId, CommandReturn, Driver, ErrorCode, Grant, ReadWrite, ReadWriteAppSlice, Upcall,
+    CommandReturn, Driver, ErrorCode, Grant, ProcessId, ReadWrite, ReadWriteAppSlice, Upcall,
 };
 
 /// Syscall driver number.
@@ -290,7 +290,7 @@ impl<'a> hil::touch::GestureClient for Touch<'a> {
 impl<'a> Driver for Touch<'a> {
     fn allow_readwrite(
         &self,
-        appid: AppId,
+        appid: ProcessId,
         allow_num: usize,
         mut slice: ReadWriteAppSlice,
     ) -> Result<ReadWriteAppSlice, (ReadWriteAppSlice, ErrorCode)> {
@@ -326,7 +326,7 @@ impl<'a> Driver for Touch<'a> {
         &self,
         subscribe_num: usize,
         mut callback: Upcall,
-        app_id: AppId,
+        app_id: ProcessId,
     ) -> Result<Upcall, (Upcall, ErrorCode)> {
         let res = match subscribe_num {
             // subscribe to touch
@@ -383,7 +383,7 @@ impl<'a> Driver for Touch<'a> {
         command_num: usize,
         _data1: usize,
         _data2: usize,
-        appid: AppId,
+        appid: ProcessId,
     ) -> CommandReturn {
         match command_num {
             0 =>

--- a/capsules/src/tsl2561.rs
+++ b/capsules/src/tsl2561.rs
@@ -17,7 +17,7 @@ use core::cell::Cell;
 use kernel::common::cells::TakeCell;
 use kernel::hil::gpio;
 use kernel::hil::i2c;
-use kernel::{AppId, CommandReturn, Driver, ErrorCode, Upcall};
+use kernel::{CommandReturn, Driver, ErrorCode, ProcessId, Upcall};
 
 /// Syscall driver number.
 use crate::driver;
@@ -441,7 +441,7 @@ impl Driver for TSL2561<'_> {
         &self,
         subscribe_num: usize,
         callback: Upcall,
-        _app_id: AppId,
+        _app_id: ProcessId,
     ) -> Result<Upcall, (Upcall, ErrorCode)> {
         match subscribe_num {
             0 => Ok(self.callback.replace(callback)),
@@ -451,7 +451,7 @@ impl Driver for TSL2561<'_> {
         }
     }
 
-    fn command(&self, command_num: usize, _: usize, _: usize, _: AppId) -> CommandReturn {
+    fn command(&self, command_num: usize, _: usize, _: usize, _: ProcessId) -> CommandReturn {
         match command_num {
             0 /* check if present */ => CommandReturn::success(),
             // Take a measurement

--- a/capsules/src/usb/usb_user.rs
+++ b/capsules/src/usb/usb_user.rs
@@ -29,7 +29,7 @@
 use core::mem;
 use kernel::common::cells::OptionalCell;
 use kernel::hil;
-use kernel::{AppId, CommandReturn, Driver, ErrorCode, Grant, Upcall};
+use kernel::{CommandReturn, Driver, ErrorCode, Grant, ProcessId, Upcall};
 
 use crate::driver;
 pub const DRIVER_NUM: usize = driver::NUM::UsbUser as usize;
@@ -43,7 +43,7 @@ pub struct App {
 pub struct UsbSyscallDriver<'a, C: hil::usb::Client<'a>> {
     usbc_client: &'a C,
     apps: Grant<App>,
-    serving_app: OptionalCell<AppId>,
+    serving_app: OptionalCell<ProcessId>,
 }
 
 impl<'a, C> UsbSyscallDriver<'a, C>
@@ -107,7 +107,7 @@ where
         &self,
         subscribe_num: usize,
         mut callback: Upcall,
-        app_id: AppId,
+        app_id: ProcessId,
     ) -> Result<Upcall, (Upcall, ErrorCode)> {
         let res = match subscribe_num {
             // Set callback for result
@@ -127,7 +127,13 @@ where
         }
     }
 
-    fn command(&self, command_num: usize, _arg: usize, _: usize, appid: AppId) -> CommandReturn {
+    fn command(
+        &self,
+        command_num: usize,
+        _arg: usize,
+        _: usize,
+        appid: ProcessId,
+    ) -> CommandReturn {
         match command_num {
             // This driver is present
             0 => CommandReturn::success(),

--- a/kernel/src/driver.rs
+++ b/kernel/src/driver.rs
@@ -72,7 +72,7 @@
 use crate::errorcode::ErrorCode;
 use crate::mem::{ReadOnlyAppSlice, ReadWriteAppSlice};
 use crate::process;
-use crate::process::AppId;
+use crate::process::ProcessId;
 use crate::syscall::SyscallReturn;
 use crate::upcall::Upcall;
 use core::convert::TryFrom;
@@ -187,7 +187,7 @@ pub trait Driver {
         &self,
         subscribe_identifier: usize,
         upcall: Upcall,
-        app_id: AppId,
+        app_id: ProcessId,
     ) -> Result<Upcall, (Upcall, ErrorCode)> {
         Err((upcall, ErrorCode::NOSUPPORT))
     }
@@ -197,7 +197,7 @@ pub trait Driver {
     /// is signaled with an upcall). Command 0 is a reserved command to
     /// detect if a peripheral system call driver is installed and must
     /// always return a CommandReturn::Success.
-    fn command(&self, which: usize, r2: usize, r3: usize, caller_id: AppId) -> CommandReturn {
+    fn command(&self, which: usize, r2: usize, r3: usize, caller_id: ProcessId) -> CommandReturn {
         CommandReturn::failure(ErrorCode::NOSUPPORT)
     }
 
@@ -207,7 +207,7 @@ pub trait Driver {
     /// within memory the process can both read and write.
     fn allow_readwrite(
         &self,
-        app: AppId,
+        app: ProcessId,
         which: usize,
         slice: ReadWriteAppSlice,
     ) -> Result<ReadWriteAppSlice, (ReadWriteAppSlice, ErrorCode)> {
@@ -222,7 +222,7 @@ pub trait Driver {
     /// read-only data (e.g., in flash) to the kernel.
     fn allow_readonly(
         &self,
-        app: AppId,
+        app: ProcessId,
         which: usize,
         slice: ReadOnlyAppSlice,
     ) -> Result<ReadOnlyAppSlice, (ReadOnlyAppSlice, ErrorCode)> {

--- a/kernel/src/grant.rs
+++ b/kernel/src/grant.rs
@@ -217,7 +217,7 @@ impl<'a, T: Default> ProcessGrant<'a, T> {
         // used.
 
         let grant_num = grant.grant_num;
-        let appid = process.appid();
+        let processid = process.processid();
 
         // Check if the grant is allocated. If not, we allocate it process
         // memory first. We then create an `ProcessGrant` object for this grant.
@@ -233,19 +233,20 @@ impl<'a, T: Default> ProcessGrant<'a, T> {
                 // If the grant could not be allocated this will cause the
                 // `new()` function to return with an error.
                 let alloc_size = size_of::<T>();
-                let new_region =
-                    appid
-                        .kernel
-                        .process_map_or(Err(Error::NoSuchApp), appid, |process| {
-                            process
-                                .allocate_grant(grant_num, alloc_size, align_of::<T>())
-                                .map_or(Err(Error::OutOfMemory), |buf| {
-                                    // Convert untyped `*mut u8` allocation to
-                                    // allocated type
-                                    let ptr = NonNull::cast::<T>(buf);
-                                    Ok(ptr)
-                                })
-                        })?;
+                let new_region = processid.kernel.process_map_or(
+                    Err(Error::NoSuchApp),
+                    processid,
+                    |process| {
+                        process
+                            .allocate_grant(grant_num, alloc_size, align_of::<T>())
+                            .map_or(Err(Error::OutOfMemory), |buf| {
+                                // Convert untyped `*mut u8` allocation to
+                                // allocated type
+                                let ptr = NonNull::cast::<T>(buf);
+                                Ok(ptr)
+                            })
+                    },
+                )?;
 
                 // ### Safety
                 //
@@ -302,8 +303,8 @@ impl<'a, T: Default> ProcessGrant<'a, T> {
     }
 
     /// Return the ProcessId of the process this ProcessGrant is associated with.
-    pub fn appid(&self) -> ProcessId {
-        self.process.appid()
+    pub fn processid(&self) -> ProcessId {
+        self.process.processid()
     }
 
     /// Run a function with access to the memory in the related process for the
@@ -586,7 +587,7 @@ impl<'a, T: Default> ProcessGrant<'a, T> {
         // Setup an allocator in case the capsule needs additional memory in the
         // grant space.
         let mut allocator = GrantRegionAllocator {
-            appid: self.process.appid(),
+            processid: self.process.processid(),
         };
 
         // Allow the capsule to access the grant.
@@ -615,7 +616,7 @@ pub struct CustomGrant<T> {
     identifier: ProcessCustomGrantIdentifer,
 
     /// Identifier for the process where this custom grant is allocated.
-    appid: ProcessId,
+    processid: ProcessId,
 
     /// Used to keep the Rust type of the grant.
     _phantom: PhantomData<T>,
@@ -623,17 +624,17 @@ pub struct CustomGrant<T> {
 
 impl<T> CustomGrant<T> {
     /// Creates a new `CustomGrant`.
-    fn new(identifier: ProcessCustomGrantIdentifer, appid: ProcessId) -> Self {
+    fn new(identifier: ProcessCustomGrantIdentifer, processid: ProcessId) -> Self {
         CustomGrant {
             identifier,
-            appid,
+            processid,
             _phantom: PhantomData,
         }
     }
 
     /// Helper function to get the ProcessId from the custom grant.
-    pub fn appid(&self) -> ProcessId {
-        self.appid
+    pub fn processid(&self) -> ProcessId {
+        self.processid
     }
 
     /// Gives access to inner data within the given closure.
@@ -651,9 +652,9 @@ impl<T> CustomGrant<T> {
     {
         // Verify that the process this CustomGrant was allocated within still
         // exists.
-        self.appid
+        self.processid
             .kernel
-            .process_map_or(Err(Error::NoSuchApp), self.appid, |process| {
+            .process_map_or(Err(Error::NoSuchApp), self.processid, |process| {
                 // App is valid.
 
                 // Now try to access the custom grant memory.
@@ -681,7 +682,7 @@ impl<T> CustomGrant<T> {
 /// per-process dynamic allocation it can allocate additional memory.
 pub struct GrantRegionAllocator {
     /// The process the allocator will allocate memory from.
-    appid: ProcessId,
+    processid: ProcessId,
 }
 
 impl GrantRegionAllocator {
@@ -713,7 +714,7 @@ impl GrantRegionAllocator {
             write(typed_ptr.as_ptr(), init());
         }
 
-        Ok(CustomGrant::new(custom_grant_identifier, self.appid))
+        Ok(CustomGrant::new(custom_grant_identifier, self.processid))
     }
 
     /// Allocates a slice of n instances of a given type. Each instance is
@@ -745,7 +746,7 @@ impl GrantRegionAllocator {
             }
         }
 
-        Ok(CustomGrant::new(custom_grant_identifier, self.appid))
+        Ok(CustomGrant::new(custom_grant_identifier, self.processid))
     }
 
     /// Allocates uninitialized grant memory appropriate to store a `T`.
@@ -770,9 +771,9 @@ impl GrantRegionAllocator {
         let alloc_size = size_of::<T>()
             .checked_mul(num_items)
             .ok_or(Error::OutOfMemory)?;
-        self.appid
+        self.processid
             .kernel
-            .process_map_or(Err(Error::NoSuchApp), self.appid, |process| {
+            .process_map_or(Err(Error::NoSuchApp), self.processid, |process| {
                 process
                     .allocate_custom_grant(alloc_size, align_of::<T>())
                     .map_or(
@@ -829,14 +830,14 @@ impl<T: Default> Grant<T> {
     /// This creates a `ProcessGrant` which is a handle for a grant allocated
     /// for a specific process. Then, that `ProcessGrant` is entered and the
     /// provided closure is run with access to the memory in the grant region.
-    pub fn enter<F, R>(&self, appid: ProcessId, fun: F) -> Result<R, Error>
+    pub fn enter<F, R>(&self, processid: ProcessId, fun: F) -> Result<R, Error>
     where
         F: FnOnce(&mut GrantMemory<T>) -> R,
     {
         // Verify that this process actually exists.
-        appid
+        processid
             .kernel
-            .process_map_or(Err(Error::NoSuchApp), appid, |process| {
+            .process_map_or(Err(Error::NoSuchApp), processid, |process| {
                 // Get the `ProcessGrant` for the process, possibly needing to
                 // actually allocate the memory in the process's grant region to
                 // do so. This can fail for a variety of reasons, and if so we
@@ -859,14 +860,14 @@ impl<T: Default> Grant<T> {
     ///
     /// The allocator allows the caller to dynamically allocate additional
     /// memory in the process's grant region.
-    pub fn enter_with_allocator<F, R>(&self, appid: ProcessId, fun: F) -> Result<R, Error>
+    pub fn enter_with_allocator<F, R>(&self, processid: ProcessId, fun: F) -> Result<R, Error>
     where
         F: FnOnce(&mut GrantMemory<T>, &mut GrantRegionAllocator) -> R,
     {
         // Verify that this process actually exists.
-        appid
+        processid
             .kernel
-            .process_map_or(Err(Error::NoSuchApp), appid, |process| {
+            .process_map_or(Err(Error::NoSuchApp), processid, |process| {
                 // Get the `ProcessGrant` for the process, possibly needing to
                 // actually allocate the memory in the process's grant region to
                 // do so. This can fail for a variety of reasons, and if so we
@@ -895,10 +896,10 @@ impl<T: Default> Grant<T> {
     {
         // Create a the iterator across `ProcessGrant`s for each process.
         for pg in self.iter() {
-            let appid = pg.appid();
+            let processid = pg.processid();
             // Since we iterating, there is no return value we need to worry
             // about.
-            pg.enter(|memory| fun(appid, memory));
+            pg.enter(|memory| fun(processid, memory));
         }
     }
 

--- a/kernel/src/introspection.rs
+++ b/kernel/src/introspection.rs
@@ -15,7 +15,7 @@ use core::cell::Cell;
 use crate::capabilities::ProcessManagementCapability;
 use crate::common::cells::NumericCellExt;
 use crate::process;
-use crate::process::AppId;
+use crate::process::ProcessId;
 use crate::sched::Kernel;
 
 /// This struct provides the inspection functions.
@@ -74,7 +74,7 @@ impl KernelInfo {
     /// Get the name of the process.
     pub fn process_name(
         &self,
-        app: AppId,
+        app: ProcessId,
         _capability: &dyn ProcessManagementCapability,
     ) -> &'static str {
         self.kernel
@@ -84,7 +84,7 @@ impl KernelInfo {
     /// Returns the number of syscalls the app has called.
     pub fn number_app_syscalls(
         &self,
-        app: AppId,
+        app: ProcessId,
         _capability: &dyn ProcessManagementCapability,
     ) -> usize {
         self.kernel
@@ -96,7 +96,7 @@ impl KernelInfo {
     /// tries to schedule a upcall.
     pub fn number_app_dropped_upcalls(
         &self,
-        app: AppId,
+        app: ProcessId,
         _capability: &dyn ProcessManagementCapability,
     ) -> usize {
         self.kernel
@@ -106,7 +106,7 @@ impl KernelInfo {
     /// Returns the number of time this app has been restarted.
     pub fn number_app_restarts(
         &self,
-        app: AppId,
+        app: ProcessId,
         _capability: &dyn ProcessManagementCapability,
     ) -> usize {
         self.kernel
@@ -116,7 +116,7 @@ impl KernelInfo {
     /// Returns the number of time this app has exceeded its timeslice.
     pub fn number_app_timeslice_expirations(
         &self,
-        app: AppId,
+        app: ProcessId,
         _capability: &dyn ProcessManagementCapability,
     ) -> usize {
         self.kernel
@@ -127,7 +127,7 @@ impl KernelInfo {
     /// app has allocated, total number of grants that exist in the system).
     pub fn number_app_grant_uses(
         &self,
-        app: AppId,
+        app: ProcessId,
         _capability: &dyn ProcessManagementCapability,
     ) -> (usize, usize) {
         // Just need to get the number, this has already been finalized, but it

--- a/kernel/src/ipc.rs
+++ b/kernel/src/ipc.rs
@@ -7,7 +7,7 @@ use crate::capabilities::MemoryAllocationCapability;
 use crate::grant::Grant;
 use crate::mem::Read;
 use crate::process;
-use crate::process::AppId;
+use crate::process::ProcessId;
 use crate::sched::Kernel;
 use crate::upcall::Upcall;
 use crate::{CommandReturn, Driver, ErrorCode, ReadOnlyAppSlice, ReadWriteAppSlice};
@@ -68,8 +68,8 @@ impl<const NUM_PROCS: usize> IPC<NUM_PROCS> {
     /// scheduler loop if an IPC task was queued for the process.
     pub(crate) unsafe fn schedule_upcall(
         &self,
-        schedule_on: AppId,
-        called_from: AppId,
+        schedule_on: ProcessId,
+        called_from: ProcessId,
         cb_type: IPCUpcallType,
     ) -> Result<(), process::Error> {
         self.data
@@ -129,7 +129,7 @@ impl<const NUM_PROCS: usize> Driver for IPC<NUM_PROCS> {
         &self,
         subscribe_num: usize,
         mut upcall: Upcall,
-        app_id: AppId,
+        app_id: ProcessId,
     ) -> Result<Upcall, (Upcall, ErrorCode)> {
         match subscribe_num {
             // subscribe(0)
@@ -213,7 +213,7 @@ impl<const NUM_PROCS: usize> Driver for IPC<NUM_PROCS> {
         command_number: usize,
         target_id: usize,
         _: usize,
-        appid: AppId,
+        appid: ProcessId,
     ) -> CommandReturn {
         match command_number {
             0 => CommandReturn::success(),
@@ -300,7 +300,7 @@ impl<const NUM_PROCS: usize> Driver for IPC<NUM_PROCS> {
     /// The buffer should contain the package name of a process that exports an IPC service.
     fn allow_readonly(
         &self,
-        appid: AppId,
+        appid: ProcessId,
         subdriver: usize,
         mut slice: ReadOnlyAppSlice,
     ) -> Result<ReadOnlyAppSlice, (ReadOnlyAppSlice, ErrorCode)> {
@@ -329,7 +329,7 @@ impl<const NUM_PROCS: usize> Driver for IPC<NUM_PROCS> {
     /// target_id == 0 is currently unsupported and reserved for future use.
     fn allow_readwrite(
         &self,
-        appid: AppId,
+        appid: ProcessId,
         target_id: usize,
         mut slice: ReadWriteAppSlice,
     ) -> Result<ReadWriteAppSlice, (ReadWriteAppSlice, ErrorCode)> {

--- a/kernel/src/ipc.rs
+++ b/kernel/src/ipc.rs
@@ -234,7 +234,7 @@ impl<const NUM_PROCS: usize> Driver for IPC<NUM_PROCS> {
                                             && s.iter().zip(slice.iter()).all(|(c1, c2)| c1 == c2)
                                         {
                                             Some(CommandReturn::success_u32(
-                                                p.appid().id() as u32 + 1,
+                                                p.processid().id() as u32 + 1,
                                             ))
                                         } else {
                                             None

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -121,7 +121,7 @@ pub use crate::platform::scheduler_timer::{SchedulerTimer, VirtualSchedulerTimer
 pub use crate::platform::watchdog;
 pub use crate::platform::{mpu, Chip, InterruptService, Platform};
 pub use crate::platform::{ClockInterface, NoClockControl, NO_CLOCK_CONTROL};
-pub use crate::process::AppId;
+pub use crate::process::ProcessId;
 pub use crate::sched::cooperative::{CoopProcessNode, CooperativeSched};
 pub use crate::sched::mlfq::{MLFQProcessNode, MLFQSched};
 pub use crate::sched::priority::PrioritySched;

--- a/kernel/src/mem.rs
+++ b/kernel/src/mem.rs
@@ -14,7 +14,7 @@
 //! AppSlice-structs.
 
 use crate::capabilities;
-use crate::process::AppId;
+use crate::process::ProcessId;
 
 /// Convert an AppSlice's internal representation to a Rust slice.
 ///
@@ -154,7 +154,7 @@ pub trait ReadWrite: Read {
 pub struct ReadWriteAppSlice {
     ptr: *mut u8,
     len: usize,
-    process_id: Option<AppId>,
+    process_id: Option<ProcessId>,
 }
 
 impl ReadWriteAppSlice {
@@ -165,7 +165,7 @@ impl ReadWriteAppSlice {
     ///
     /// Refer to the safety requirments of
     /// [`ReadWriteAppSlice::new_external`].
-    pub(crate) unsafe fn new(ptr: *mut u8, len: usize, process_id: AppId) -> Self {
+    pub(crate) unsafe fn new(ptr: *mut u8, len: usize, process_id: ProcessId) -> Self {
         ReadWriteAppSlice {
             ptr,
             len,
@@ -201,7 +201,7 @@ impl ReadWriteAppSlice {
     ///
     /// If the length is not `0`, the memory region of `[ptr; ptr +
     /// len)` must be valid memory of the process of the given
-    /// [`AppId`]. It must be allocated and and accessible over the
+    /// [`ProcessId`]. It must be allocated and and accessible over the
     /// entire lifetime of the [`ReadWriteAppSlice`]. It must not
     /// point to memory outside of the process' accessible memory
     /// range, or point (in part) to other processes or kernel
@@ -214,7 +214,7 @@ impl ReadWriteAppSlice {
     pub unsafe fn new_external(
         ptr: *mut u8,
         len: usize,
-        process_id: AppId,
+        process_id: ProcessId,
         _cap: &dyn capabilities::ExternalProcessCapability,
     ) -> Self {
         Self::new(ptr, len, process_id)
@@ -311,7 +311,7 @@ impl Read for ReadWriteAppSlice {
 pub struct ReadOnlyAppSlice {
     ptr: *const u8,
     len: usize,
-    process_id: Option<AppId>,
+    process_id: Option<ProcessId>,
 }
 
 impl ReadOnlyAppSlice {
@@ -322,7 +322,7 @@ impl ReadOnlyAppSlice {
     ///
     /// Refer to the safety requirments of
     /// [`ReadOnlyAppSlice::new_external`].
-    pub(crate) unsafe fn new(ptr: *const u8, len: usize, process_id: AppId) -> Self {
+    pub(crate) unsafe fn new(ptr: *const u8, len: usize, process_id: ProcessId) -> Self {
         ReadOnlyAppSlice {
             ptr,
             len,
@@ -358,7 +358,7 @@ impl ReadOnlyAppSlice {
     ///
     /// If the length is not `0`, the memory region of `[ptr; ptr +
     /// len)` must be valid memory of the process of the given
-    /// [`AppId`]. It must be allocated and and accessible over the
+    /// [`ProcessId`]. It must be allocated and and accessible over the
     /// entire lifetime of the [`ReadOnlyAppSlice`]. It must not point
     /// to memory outside of the process' accessible memory range, or
     /// point (in part) to other processes or kernel memory. The `ptr`
@@ -371,7 +371,7 @@ impl ReadOnlyAppSlice {
     pub unsafe fn new_external(
         ptr: *const u8,
         len: usize,
-        process_id: AppId,
+        process_id: ProcessId,
         _cap: &dyn capabilities::ExternalProcessCapability,
     ) -> Self {
         Self::new(ptr, len, process_id)

--- a/kernel/src/platform/mpu.rs
+++ b/kernel/src/platform/mpu.rs
@@ -1,6 +1,6 @@
 //! Interface for configuring the Memory Protection Unit.
 
-use crate::process::AppId;
+use crate::process::ProcessId;
 use core::cmp;
 use core::fmt::{self, Display};
 
@@ -260,9 +260,9 @@ pub trait MPU {
     /// # Arguments
     ///
     /// - `config`: MPU region configuration
-    /// - `app_id`: AppId of the process that the MPU is configured for
+    /// - `app_id`: ProcessId of the process that the MPU is configured for
     #[allow(unused_variables)]
-    fn configure_mpu(&self, config: &Self::MpuConfig, app_id: &AppId) {}
+    fn configure_mpu(&self, config: &Self::MpuConfig, app_id: &ProcessId) {}
 }
 
 /// Implement default MPU trait for unit.

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -123,7 +123,7 @@ impl ProcessId {
     /// match then `None` will be returned.
     pub(crate) fn index(&self) -> Option<usize> {
         // Do a lookup to make sure that the index we have is correct.
-        if self.kernel.appid_is_valid(self) {
+        if self.kernel.processid_is_valid(self) {
             Some(self.index)
         } else {
             None

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -16,36 +16,36 @@ use crate::sched::Kernel;
 use crate::syscall::{self, Syscall, SyscallReturn};
 use crate::upcall::UpcallId;
 
-/// Userspace app identifier.
+/// Userspace process identifier.
 ///
-/// This should be treated as an opaque type that can be used to represent an
-/// application on the board without requiring an actual reference to a
-/// `Process` object. Having this `ProcessId` reference type is useful for
-/// managing ownership and type issues in Rust, but more importantly `ProcessId`
-/// serves as a tool for capsules to hold pointers to applications.
+/// This should be treated as an opaque type that can be used to represent a
+/// process on the board without requiring an actual reference to a `Process`
+/// object. Having this `ProcessId` reference type is useful for managing
+/// ownership and type issues in Rust, but more importantly `ProcessId` serves
+/// as a tool for capsules to hold pointers to applications.
 ///
-/// Since `ProcessId` implements `Copy`, having an `ProcessId` does _not_ ensure that
-/// the process the `ProcessId` refers to is still valid. The process may have been
-/// removed, terminated, or restarted as a new process. Therefore, all uses of
-/// `ProcessId` in the kernel must check that the `ProcessId` is still valid. This check
-/// happens automatically when `.index()` is called, as noted by the return
-/// type: `Option<usize>`. `.index()` will return the index of the process in
-/// the processes array, but if the process no longer exists then `None` is
-/// returned.
+/// Since `ProcessId` implements `Copy`, having an `ProcessId` does _not_ ensure
+/// that the process the `ProcessId` refers to is still valid. The process may
+/// have been removed, terminated, or restarted as a new process. Therefore, all
+/// uses of `ProcessId` in the kernel must check that the `ProcessId` is still
+/// valid. This check happens automatically when `.index()` is called, as noted
+/// by the return type: `Option<usize>`. `.index()` will return the index of the
+/// process in the processes array, but if the process no longer exists then
+/// `None` is returned.
 ///
-/// Outside of the kernel crate, holders of an `ProcessId` may want to use `.id()`
-/// to retrieve a simple identifier for the process that can be communicated
-/// over a UART bus or syscall interface. This call is guaranteed to return a
-/// suitable identifier for the `ProcessId`, but does not check that the
-/// corresponding application still exists.
+/// Outside of the kernel crate, holders of an `ProcessId` may want to use
+/// `.id()` to retrieve a simple identifier for the process that can be
+/// communicated over a UART bus or syscall interface. This call is guaranteed
+/// to return a suitable identifier for the `ProcessId`, but does not check that
+/// the corresponding application still exists.
 ///
 /// This type also provides capsules an interface for interacting with processes
 /// since they otherwise would have no reference to a `Process`. Very limited
 /// operations are available through this interface since capsules should not
 /// need to know the details of any given process. However, certain information
 /// makes certain capsules possible to implement. For example, capsules can use
-/// the `get_editable_flash_range()` function so they can safely allow an app
-/// to modify its own flash.
+/// the `get_editable_flash_range()` function so they can safely allow an app to
+/// modify its own flash.
 #[derive(Clone, Copy)]
 pub struct ProcessId {
     /// Reference to the main kernel struct. This is needed for checking on
@@ -68,7 +68,8 @@ pub struct ProcessId {
     /// The combination of (index, identifier) is used to check if the app this
     /// `ProcessId` refers to is still valid. If the stored identifier in the
     /// process at the given index does not match the value saved here, then the
-    /// process moved or otherwise ended, and this `ProcessId` is no longer valid.
+    /// process moved or otherwise ended, and this `ProcessId` is no longer
+    /// valid.
     identifier: usize,
 }
 
@@ -163,8 +164,8 @@ impl ProcessId {
 /// This trait represents a generic process that the Tock scheduler can
 /// schedule.
 pub trait Process {
-    /// Returns the process's identifier
-    fn appid(&self) -> ProcessId;
+    /// Returns the process's identifier.
+    fn processid(&self) -> ProcessId;
 
     /// Queue a `Task` for the process. This will be added to a per-process
     /// buffer and executed by the scheduler. `Task`s are some function the app

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -20,23 +20,23 @@ use crate::upcall::UpcallId;
 ///
 /// This should be treated as an opaque type that can be used to represent an
 /// application on the board without requiring an actual reference to a
-/// `Process` object. Having this `AppId` reference type is useful for
-/// managing ownership and type issues in Rust, but more importantly `AppId`
+/// `Process` object. Having this `ProcessId` reference type is useful for
+/// managing ownership and type issues in Rust, but more importantly `ProcessId`
 /// serves as a tool for capsules to hold pointers to applications.
 ///
-/// Since `AppId` implements `Copy`, having an `AppId` does _not_ ensure that
-/// the process the `AppId` refers to is still valid. The process may have been
+/// Since `ProcessId` implements `Copy`, having an `ProcessId` does _not_ ensure that
+/// the process the `ProcessId` refers to is still valid. The process may have been
 /// removed, terminated, or restarted as a new process. Therefore, all uses of
-/// `AppId` in the kernel must check that the `AppId` is still valid. This check
+/// `ProcessId` in the kernel must check that the `ProcessId` is still valid. This check
 /// happens automatically when `.index()` is called, as noted by the return
 /// type: `Option<usize>`. `.index()` will return the index of the process in
 /// the processes array, but if the process no longer exists then `None` is
 /// returned.
 ///
-/// Outside of the kernel crate, holders of an `AppId` may want to use `.id()`
+/// Outside of the kernel crate, holders of an `ProcessId` may want to use `.id()`
 /// to retrieve a simple identifier for the process that can be communicated
 /// over a UART bus or syscall interface. This call is guaranteed to return a
-/// suitable identifier for the `AppId`, but does not check that the
+/// suitable identifier for the `ProcessId`, but does not check that the
 /// corresponding application still exists.
 ///
 /// This type also provides capsules an interface for interacting with processes
@@ -47,7 +47,7 @@ use crate::upcall::UpcallId;
 /// the `get_editable_flash_range()` function so they can safely allow an app
 /// to modify its own flash.
 #[derive(Clone, Copy)]
-pub struct AppId {
+pub struct ProcessId {
     /// Reference to the main kernel struct. This is needed for checking on
     /// certain properties of the referred app (like its editable bounds), but
     /// also for checking that the index is valid.
@@ -66,38 +66,38 @@ pub struct AppId {
     /// when referring to specific applications across the syscall interface.
     ///
     /// The combination of (index, identifier) is used to check if the app this
-    /// `AppId` refers to is still valid. If the stored identifier in the
+    /// `ProcessId` refers to is still valid. If the stored identifier in the
     /// process at the given index does not match the value saved here, then the
-    /// process moved or otherwise ended, and this `AppId` is no longer valid.
+    /// process moved or otherwise ended, and this `ProcessId` is no longer valid.
     identifier: usize,
 }
 
-impl PartialEq for AppId {
-    fn eq(&self, other: &AppId) -> bool {
+impl PartialEq for ProcessId {
+    fn eq(&self, other: &ProcessId) -> bool {
         self.identifier == other.identifier
     }
 }
 
-impl Eq for AppId {}
+impl Eq for ProcessId {}
 
-impl fmt::Debug for AppId {
+impl fmt::Debug for ProcessId {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.identifier)
     }
 }
 
-impl AppId {
-    /// Create a new `AppId` object based on the app identifier and its index
+impl ProcessId {
+    /// Create a new `ProcessId` object based on the app identifier and its index
     /// in the processes array.
-    pub(crate) fn new(kernel: &'static Kernel, identifier: usize, index: usize) -> AppId {
-        AppId {
+    pub(crate) fn new(kernel: &'static Kernel, identifier: usize, index: usize) -> ProcessId {
+        ProcessId {
             kernel: kernel,
             identifier: identifier,
             index: index,
         }
     }
 
-    /// Create a new `AppId` object based on the app identifier and its index
+    /// Create a new `ProcessId` object based on the app identifier and its index
     /// in the processes array.
     ///
     /// This constructor is public but protected with a capability so that
@@ -107,8 +107,8 @@ impl AppId {
         identifier: usize,
         index: usize,
         _capability: &dyn capabilities::ExternalProcessCapability,
-    ) -> AppId {
-        AppId {
+    ) -> ProcessId {
+        ProcessId {
             kernel: kernel,
             identifier: identifier,
             index: index,
@@ -117,7 +117,7 @@ impl AppId {
 
     /// Get the location of this app in the processes array.
     ///
-    /// This will return `Some(index)` if the identifier stored in this `AppId`
+    /// This will return `Some(index)` if the identifier stored in this `ProcessId`
     /// matches the app saved at the known index. If the identifier does not
     /// match then `None` will be returned.
     pub(crate) fn index(&self) -> Option<usize> {
@@ -129,10 +129,10 @@ impl AppId {
         }
     }
 
-    /// Get a `usize` unique identifier for the app this `AppId` refers to.
+    /// Get a `usize` unique identifier for the app this `ProcessId` refers to.
     ///
     /// This function should not generally be used, instead code should just use
-    /// the `AppId` object itself to refer to various apps on the system.
+    /// the `ProcessId` object itself to refer to various apps on the system.
     /// However, getting just a `usize` identifier is particularly useful when
     /// referring to a specific app with things outside of the kernel, say for
     /// userspace (e.g. IPC) or tockloader (e.g. for debugging) where a concrete
@@ -164,7 +164,7 @@ impl AppId {
 /// schedule.
 pub trait Process {
     /// Returns the process's identifier
-    fn appid(&self) -> AppId;
+    fn appid(&self) -> ProcessId;
 
     /// Queue a `Task` for the process. This will be added to a per-process
     /// buffer and executed by the scheduler. `Task`s are some function the app
@@ -697,7 +697,7 @@ pub enum Task {
     /// from a capsule.
     FunctionCall(FunctionCall),
     /// An IPC operation that needs additional setup to configure memory access.
-    IPC((AppId, ipc::IPCUpcallType)),
+    IPC((ProcessId, ipc::IPCUpcallType)),
 }
 
 /// Enumeration to identify whether a function call for a process comes directly

--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -260,7 +260,7 @@ impl Kernel {
                 process_entry.map_or(None, |process| {
                     // Check that the process stored here matches the identifier
                     // in the `appid`.
-                    if process.appid() == appid {
+                    if process.processid() == appid {
                         Some(closure(process))
                     } else {
                         None
@@ -352,8 +352,8 @@ impl Kernel {
     pub(crate) fn lookup_app_by_identifier(&self, identifier: usize) -> Option<ProcessId> {
         self.processes.iter().find_map(|&p| {
             p.map_or(None, |p2| {
-                if p2.appid().id() == identifier {
-                    Some(p2.appid())
+                if p2.processid().id() == identifier {
+                    Some(p2.processid())
                 } else {
                     None
                 }
@@ -367,9 +367,9 @@ impl Kernel {
     ///
     /// This is needed for `ProcessId` itself to implement the `.index()` command to
     /// verify that the referenced app is still at the correct index.
-    pub(crate) fn appid_is_valid(&self, appid: &ProcessId) -> bool {
+    pub(crate) fn processid_is_valid(&self, appid: &ProcessId) -> bool {
         self.processes.get(appid.index).map_or(false, |p| {
-            p.map_or(false, |process| process.appid().id() == appid.id())
+            p.map_or(false, |process| process.processid().id() == appid.id())
         })
     }
 
@@ -603,7 +603,7 @@ impl Kernel {
             }
 
             // Check if the scheduler wishes to continue running this process.
-            let continue_process = unsafe { scheduler.continue_process(process.appid(), chip) };
+            let continue_process = unsafe { scheduler.continue_process(process.processid(), chip) };
             if !continue_process {
                 return_reason = StoppedExecutingReason::KernelPreemption;
                 break;
@@ -678,7 +678,7 @@ impl Kernel {
                                 if config::CONFIG.trace_syscalls {
                                     debug!(
                                         "[{:?}] function_call @{:#x}({:#x}, {:#x}, {:#x}, {:#x})",
-                                        process.appid(),
+                                        process.processid(),
                                         ccb.pc,
                                         ccb.argument0,
                                         ccb.argument1,
@@ -702,7 +702,7 @@ impl Kernel {
                                         // https://github.com/tock/tock/issues/1993
                                         unsafe {
                                             let _ = ipc.schedule_upcall(
-                                                process.appid(),
+                                                process.processid(),
                                                 otherapp,
                                                 ipc_type,
                                             );
@@ -811,7 +811,7 @@ impl Kernel {
                 if config::CONFIG.trace_syscalls {
                     debug!(
                         "[{:?}] memop({}, {:#x}) = {:?}",
-                        process.appid(),
+                        process.processid(),
                         operand,
                         arg0,
                         rval
@@ -821,7 +821,7 @@ impl Kernel {
             }
             Syscall::Yield { which, address } => {
                 if config::CONFIG.trace_syscalls {
-                    debug!("[{:?}] yield. which: {}", process.appid(), which);
+                    debug!("[{:?}] yield. which: {}", process.processid(), which);
                 }
                 if which > (YieldCall::Wait as usize) {
                     // Only 0 and 1 are valid, so this is not a valid
@@ -883,11 +883,11 @@ impl Kernel {
 
                 let ptr = NonNull::new(upcall_ptr);
                 let upcall = ptr.map_or(Upcall::default(), |ptr| {
-                    Upcall::new(process.appid(), upcall_id, appdata, ptr.cast())
+                    Upcall::new(process.processid(), upcall_id, appdata, ptr.cast())
                 });
                 let rval = platform.with_driver(driver_number, |driver| match driver {
                     Some(d) => {
-                        let res = d.subscribe(subdriver_number, upcall, process.appid());
+                        let res = d.subscribe(subdriver_number, upcall, process.processid());
                         match res {
                             // An Ok() returns the previous upcall, while
                             // Err() returns the one that was just passed
@@ -901,7 +901,7 @@ impl Kernel {
                 if config::CONFIG.trace_syscalls {
                     debug!(
                         "[{:?}] subscribe({:#x}, {}, @{:#x}, {:#x}) = {:?}",
-                        process.appid(),
+                        process.processid(),
                         driver_number,
                         subdriver_number,
                         upcall_ptr as usize,
@@ -919,7 +919,7 @@ impl Kernel {
                 arg1,
             } => {
                 let cres = platform.with_driver(driver_number, |driver| match driver {
-                    Some(d) => d.command(subdriver_number, arg0, arg1, process.appid()),
+                    Some(d) => d.command(subdriver_number, arg0, arg1, process.processid()),
                     None => CommandReturn::failure(ErrorCode::NODEVICE),
                 });
 
@@ -928,7 +928,7 @@ impl Kernel {
                 if config::CONFIG.trace_syscalls {
                     debug!(
                         "[{:?}] cmd({:#x}, {}, {:#x}, {:#x}) = {:?}",
-                        process.appid(),
+                        process.processid(),
                         driver_number,
                         subdriver_number,
                         arg0,
@@ -956,8 +956,11 @@ impl Kernel {
                             Ok(appslice) => {
                                 // Creating the [`ReadWriteAppSlice`] worked,
                                 // provide it to the capsule.
-                                match d.allow_readwrite(process.appid(), subdriver_number, appslice)
-                                {
+                                match d.allow_readwrite(
+                                    process.processid(),
+                                    subdriver_number,
+                                    appslice,
+                                ) {
                                     Ok(returned_appslice) => {
                                         // The capsule has accepted the allow
                                         // operation. Pass the previous buffer
@@ -995,7 +998,7 @@ impl Kernel {
                 if config::CONFIG.trace_syscalls {
                     debug!(
                         "[{:?}] read-write allow({:#x}, {}, @{:#x}, {:#x}) = {:?}",
-                        process.appid(),
+                        process.processid(),
                         driver_number,
                         subdriver_number,
                         allow_address as usize,
@@ -1023,8 +1026,11 @@ impl Kernel {
                             Ok(appslice) => {
                                 // Creating the [`ReadOnlyAppSlice`] worked,
                                 // provide it to the capsule.
-                                match d.allow_readonly(process.appid(), subdriver_number, appslice)
-                                {
+                                match d.allow_readonly(
+                                    process.processid(),
+                                    subdriver_number,
+                                    appslice,
+                                ) {
                                     Ok(returned_appslice) => {
                                         // The capsule has accepted the allow
                                         // operation. Pass the previous buffer
@@ -1068,7 +1074,7 @@ impl Kernel {
                 if config::CONFIG.trace_syscalls {
                     debug!(
                         "[{:?}] read-only allow({:#x}, {}, @{:#x}, {:#x}) = {:?}",
-                        process.appid(),
+                        process.processid(),
                         driver_number,
                         subdriver_number,
                         allow_address as usize,

--- a/kernel/src/sched/cooperative.rs
+++ b/kernel/src/sched/cooperative.rs
@@ -65,7 +65,7 @@ impl<'a, C: Chip> Scheduler<C> for CooperativeSched<'a> {
                 match node.proc {
                     Some(proc) => {
                         if proc.ready() {
-                            next = Some(proc.appid());
+                            next = Some(proc.processid());
                             break;
                         }
                         self.processes.push_tail(self.processes.pop_head().unwrap());

--- a/kernel/src/sched/mlfq.rs
+++ b/kernel/src/sched/mlfq.rs
@@ -21,8 +21,8 @@ use crate::common::list::{List, ListLink, ListNode};
 use crate::hil::time;
 use crate::hil::time::Ticks;
 use crate::platform::Chip;
-use crate::process::AppId;
 use crate::process::Process;
+use crate::process::ProcessId;
 use crate::sched::{Kernel, Scheduler, SchedulingDecision, StoppedExecutingReason};
 use core::cell::Cell;
 
@@ -189,7 +189,7 @@ impl<'a, A: 'static + time::Alarm<'static>, C: Chip> Scheduler<C> for MLFQSched<
         }
     }
 
-    unsafe fn continue_process(&self, _: AppId, _: &C) -> bool {
+    unsafe fn continue_process(&self, _: ProcessId, _: &C) -> bool {
         // This MLFQ scheduler only preempts processes if there is a timeslice expiration
         true
     }

--- a/kernel/src/sched/mlfq.rs
+++ b/kernel/src/sched/mlfq.rs
@@ -157,7 +157,7 @@ impl<'a, A: 'static + time::Alarm<'static>, C: Chip> Scheduler<C> for MLFQSched<
             let node_ref = node_ref_opt.unwrap(); // Panic if fail bc processes_blocked()!
             let timeslice =
                 self.get_timeslice_us(queue_idx) - node_ref.state.us_used_this_queue.get();
-            let next = node_ref.proc.unwrap().appid(); // Panic if fail bc processes_blocked()!
+            let next = node_ref.proc.unwrap().processid(); // Panic if fail bc processes_blocked()!
             self.last_queue_idx.set(queue_idx);
             self.last_timeslice.set(timeslice);
 

--- a/kernel/src/sched/priority.rs
+++ b/kernel/src/sched/priority.rs
@@ -13,13 +13,13 @@
 use crate::common::cells::OptionalCell;
 use crate::common::dynamic_deferred_call::DynamicDeferredCall;
 use crate::platform::Chip;
-use crate::process::AppId;
+use crate::process::ProcessId;
 use crate::sched::{Kernel, Scheduler, SchedulingDecision, StoppedExecutingReason};
 
 /// Priority scheduler based on the order of processes in the `PROCESSES` array.
 pub struct PrioritySched {
     kernel: &'static Kernel,
-    running: OptionalCell<AppId>,
+    running: OptionalCell<ProcessId>,
 }
 
 impl PrioritySched {
@@ -51,7 +51,7 @@ impl<C: Chip> Scheduler<C> for PrioritySched {
         }
     }
 
-    unsafe fn continue_process(&self, _: AppId, chip: &C) -> bool {
+    unsafe fn continue_process(&self, _: ProcessId, chip: &C) -> bool {
         // In addition to checking for interrupts, also checks if any higher
         // priority processes have become ready. This check is necessary because
         // a system call by this process could make another process ready, if

--- a/kernel/src/sched/priority.rs
+++ b/kernel/src/sched/priority.rs
@@ -44,7 +44,7 @@ impl<C: Chip> Scheduler<C> for PrioritySched {
                 .kernel
                 .get_process_iter()
                 .find(|&proc| proc.ready())
-                .map_or(None, |proc| Some(proc.appid()));
+                .map_or(None, |proc| Some(proc.processid()));
             self.running.insert(next);
 
             SchedulingDecision::RunProcess((next.unwrap(), None))

--- a/kernel/src/sched/round_robin.rs
+++ b/kernel/src/sched/round_robin.rs
@@ -76,7 +76,7 @@ impl<'a, C: Chip> Scheduler<C> for RoundRobinSched<'a> {
                 match node.proc {
                     Some(proc) => {
                         if proc.ready() {
-                            next = Some(proc.appid());
+                            next = Some(proc.processid());
                             break;
                         }
                         self.processes.push_tail(self.processes.pop_head().unwrap());

--- a/kernel/src/upcall.rs
+++ b/kernel/src/upcall.rs
@@ -5,7 +5,7 @@ use core::ptr::NonNull;
 use crate::config;
 use crate::debug;
 use crate::process;
-use crate::process::AppId;
+use crate::process::ProcessId;
 use crate::syscall::SyscallReturn;
 use crate::ErrorCode;
 
@@ -23,7 +23,7 @@ pub struct UpcallId {
 /// This is essentially a wrapper around a function pointer.
 #[derive(Clone, Copy)]
 struct ProcessUpcall {
-    app_id: AppId,
+    app_id: ProcessId,
     upcall_id: UpcallId,
     appdata: usize,
     fn_ptr: NonNull<*mut ()>,
@@ -36,7 +36,7 @@ pub struct Upcall {
 
 impl Upcall {
     pub(crate) fn new(
-        app_id: AppId,
+        app_id: ProcessId,
         upcall_id: UpcallId,
         appdata: usize,
         fn_ptr: NonNull<*mut ()>,
@@ -74,7 +74,7 @@ impl Upcall {
 
 impl ProcessUpcall {
     fn new(
-        app_id: AppId,
+        app_id: ProcessId,
         upcall_id: UpcallId,
         appdata: usize,
         fn_ptr: NonNull<*mut ()>,


### PR DESCRIPTION
### Pull Request Overview

This pull request is an update to #2184 which:

1. Renames `AppId` to `ProcessId`.
2. Renames `.appid()` to `.processid()`.
3. Renames `Process.app_id` to `Process.id`.

It does not update type names. I'm generally opposed to variable renaming, but that can be added to this PR. It's also more tricky to get correct.


### Testing Strategy

travis


### TODO or Help Wanted

More renaming maybe? Get rid of all `app*id` in Tock?


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
