### PR TITLE
Rewrite the interface between process.rs and grant.rs

### DIFF
--- a/capsules/src/adc.rs
+++ b/capsules/src/adc.rs
@@ -340,7 +340,7 @@ impl<'a, A: hil::adc::Adc + hil::adc::AdcHighSpeed> AdcDedicated<'a, A> {
         let mut app_buf_length = 0;
         let exists = self.appid.map_or(false, |id| {
             self.apps
-                .enter(*id, |state, _| {
+                .enter(*id, |state| {
                     app_buf_length = state.app_buf1.len();
                     app_buf_length > 0
                 })
@@ -362,7 +362,7 @@ impl<'a, A: hil::adc::Adc + hil::adc::AdcHighSpeed> AdcDedicated<'a, A> {
         self.mode.set(AdcMode::SingleBuffer);
         let ret = self.appid.map_or(Err(ErrorCode::NOMEM), |id| {
             self.apps
-                .enter(*id, |app, _| {
+                .enter(*id, |app| {
                     app.app_buf_offset.set(0);
                     self.channel.set(channel);
                     // start a continuous sample
@@ -419,7 +419,7 @@ impl<'a, A: hil::adc::Adc + hil::adc::AdcHighSpeed> AdcDedicated<'a, A> {
             self.mode.set(AdcMode::NoMode);
             self.appid.map(|id| {
                 self.apps
-                    .enter(*id, |app, _| {
+                    .enter(*id, |app| {
                         app.samples_remaining.set(0);
                         app.samples_outstanding.set(0);
                     })
@@ -460,7 +460,7 @@ impl<'a, A: hil::adc::Adc + hil::adc::AdcHighSpeed> AdcDedicated<'a, A> {
         let mut next_app_buf_length = 0;
         let exists = self.appid.map_or(false, |id| {
             self.apps
-                .enter(*id, |state, _| {
+                .enter(*id, |state| {
                     app_buf_length = state.app_buf1.len();
                     next_app_buf_length = state.app_buf2.len();
                     state.app_buf1.len() > 0 && state.app_buf2.len() > 0
@@ -484,7 +484,7 @@ impl<'a, A: hil::adc::Adc + hil::adc::AdcHighSpeed> AdcDedicated<'a, A> {
 
         let ret = self.appid.map_or(Err(ErrorCode::NOMEM), |id| {
             self.apps
-                .enter(*id, |app, _| {
+                .enter(*id, |app| {
                     app.app_buf_offset.set(0);
                     self.channel.set(channel);
                     // start a continuous sample
@@ -554,7 +554,7 @@ impl<'a, A: hil::adc::Adc + hil::adc::AdcHighSpeed> AdcDedicated<'a, A> {
             self.mode.set(AdcMode::NoMode);
             self.appid.map(|id| {
                 self.apps
-                    .enter(*id, |app, _| {
+                    .enter(*id, |app| {
                         app.samples_remaining.set(0);
                         app.samples_outstanding.set(0);
                     })
@@ -583,7 +583,7 @@ impl<'a, A: hil::adc::Adc + hil::adc::AdcHighSpeed> AdcDedicated<'a, A> {
         // clean up state
         self.appid.map_or(Err(ErrorCode::FAIL), |id| {
             self.apps
-                .enter(*id, |app, _| {
+                .enter(*id, |app| {
                     self.active.set(false);
                     self.mode.set(AdcMode::NoMode);
                     app.app_buf_offset.set(0);
@@ -653,7 +653,7 @@ impl<'a> AdcVirtualized<'a> {
     ) -> Result<(), ErrorCode> {
         if channel < self.drivers.len() {
             self.apps
-                .enter(appid, |app, _| {
+                .enter(appid, |app| {
                     if self.current_app.is_none() {
                         self.current_app.set(appid);
                         let value = self.call_driver(command, channel);
@@ -704,7 +704,7 @@ impl<A: hil::adc::Adc + hil::adc::AdcHighSpeed> hil::adc::Client for AdcDedicate
 
             self.appid.map(|id| {
                 self.apps
-                    .enter(*id, |app, _| {
+                    .enter(*id, |app| {
                         calledback = true;
                         app.callback.schedule(
                             AdcMode::SingleSample as usize,
@@ -726,7 +726,7 @@ impl<A: hil::adc::Adc + hil::adc::AdcHighSpeed> hil::adc::Client for AdcDedicate
             // perform callback
             self.appid.map(|id| {
                 self.apps
-                    .enter(*id, |app, _| {
+                    .enter(*id, |app| {
                         calledback = true;
                         app.callback.schedule(
                             AdcMode::ContinuousSample as usize,
@@ -784,7 +784,7 @@ impl<A: hil::adc::Adc + hil::adc::AdcHighSpeed> hil::adc::HighSpeedClient for Ad
             // we did expect a buffer. Determine the current application state
             self.appid.map(|id| {
                 self.apps
-                    .enter(*id, |app, _| {
+                    .enter(*id, |app| {
                         // determine which app buffer to copy data into and which is
                         // next up if we're in continuous mode
                         let use1 = app.using_app_buf1.get();
@@ -1047,7 +1047,7 @@ impl<A: hil::adc::Adc + hil::adc::AdcHighSpeed> hil::adc::HighSpeedClient for Ad
             self.mode.set(AdcMode::NoMode);
             self.appid.map(|id| {
                 self.apps
-                    .enter(*id, |app, _| {
+                    .enter(*id, |app| {
                         app.app_buf_offset.set(0);
                     })
                     .map_err(|err| {
@@ -1098,7 +1098,7 @@ impl<A: hil::adc::Adc + hil::adc::AdcHighSpeed> Driver for AdcDedicated<'_, A> {
                 owning_app == &appid
             } else {
                 self.apps
-                    .enter(*owning_app, |_, _| owning_app == &appid)
+                    .enter(*owning_app, |_| owning_app == &appid)
                     .unwrap_or(true)
             }
         });
@@ -1113,7 +1113,7 @@ impl<A: hil::adc::Adc + hil::adc::AdcHighSpeed> Driver for AdcDedicated<'_, A> {
                 // set first buffer
                 let res = self.appid.map_or(Err(ErrorCode::FAIL), |id| {
                     self.apps
-                        .enter(*id, |app, _| {
+                        .enter(*id, |app| {
                             mem::swap(&mut app.app_buf1, &mut slice);
                         })
                         .map_err(|err| {
@@ -1137,7 +1137,7 @@ impl<A: hil::adc::Adc + hil::adc::AdcHighSpeed> Driver for AdcDedicated<'_, A> {
                 // set second buffer
                 let res = self.appid.map_or(Err(ErrorCode::FAIL), |id| {
                     self.apps
-                        .enter(*id, |app, _| {
+                        .enter(*id, |app| {
                             mem::swap(&mut app.app_buf2, &mut slice);
                         })
                         .map_err(|err| {
@@ -1180,7 +1180,7 @@ impl<A: hil::adc::Adc + hil::adc::AdcHighSpeed> Driver for AdcDedicated<'_, A> {
                 owning_app == &appid
             } else {
                 self.apps
-                    .enter(*owning_app, |_, _| owning_app == &appid)
+                    .enter(*owning_app, |_| owning_app == &appid)
                     .unwrap_or(true)
             }
         });
@@ -1196,7 +1196,7 @@ impl<A: hil::adc::Adc + hil::adc::AdcHighSpeed> Driver for AdcDedicated<'_, A> {
                 self.appid.map_or(Err((callback, ErrorCode::FAIL)), |id| {
                     let res = self
                         .apps
-                        .enter(*id, |app, _| {
+                        .enter(*id, |app| {
                             mem::swap(&mut app.callback, &mut callback);
                         })
                         .map_err(|err| {
@@ -1254,7 +1254,7 @@ impl<A: hil::adc::Adc + hil::adc::AdcHighSpeed> Driver for AdcDedicated<'_, A> {
                 // longer exists and we return `true` to signify the
                 // "or_nonexistant" case.
                 self.apps
-                    .enter(*owning_app, |_, _| owning_app == &appid)
+                    .enter(*owning_app, |_| owning_app == &appid)
                     .unwrap_or(true)
             }
         });
@@ -1352,7 +1352,7 @@ impl Driver for AdcVirtualized<'_> {
             0 => {
                 let res = self
                     .apps
-                    .enter(app_id, |app, _| {
+                    .enter(app_id, |app| {
                         mem::swap(&mut app.callback, &mut callback);
                     })
                     .map_err(ErrorCode::from);
@@ -1419,7 +1419,7 @@ impl Driver for AdcVirtualized<'_> {
 impl<'a> hil::adc::Client for AdcVirtualized<'a> {
     fn sample_ready(&self, sample: u16) {
         self.current_app.take().map(|appid| {
-            let _ = self.apps.enter(appid, |app, _| {
+            let _ = self.apps.enter(appid, |app| {
                 app.pending_command = false;
                 let channel = app.channel;
                 app.callback

--- a/capsules/src/alarm.rs
+++ b/capsules/src/alarm.rs
@@ -63,7 +63,7 @@ impl<'a, A: Alarm<'a>> AlarmDriver<'a, A> {
         // are multiple alarms in the past, just store one of them
         // and resolve ordering later, when we fire.
         for alarm in self.app_alarms.iter() {
-            alarm.enter(|alarm, _| match alarm.expiration {
+            alarm.enter(|alarm| match alarm.expiration {
                 Expiration::Enabled { reference, dt } => {
                     // Do this because `reference` shadowed below
                     let current_reference = reference;
@@ -159,7 +159,7 @@ impl<'a, A: Alarm<'a>> Driver for AlarmDriver<'a, A> {
         let res: Result<(), ErrorCode> = match subscribe_num {
             0 => self
                 .app_alarms
-                .enter(app_id, |td, _allocator| {
+                .enter(app_id, |td| {
                     mem::swap(&mut callback, &mut td.callback);
                 })
                 .map_err(ErrorCode::from),
@@ -196,7 +196,7 @@ impl<'a, A: Alarm<'a>> Driver for AlarmDriver<'a, A> {
         //   - the underlying alarm is currently disabled and we're enabling the first alarm, or
         //   - on an error (i.e. no change to the alarms).
         self.app_alarms
-            .enter(caller_id, |td, _alloc| {
+            .enter(caller_id, |td| {
                 // helper function to rearm alarm
                 let mut rearm = |reference: usize, dt: usize| {
                     if let Expiration::Disabled = td.expiration {

--- a/capsules/src/alarm.rs
+++ b/capsules/src/alarm.rs
@@ -276,7 +276,7 @@ impl<'a, A: Alarm<'a>> Driver for AlarmDriver<'a, A> {
 impl<'a, A: Alarm<'a>> time::AlarmClient for AlarmDriver<'a, A> {
     fn alarm(&self) {
         let now: Ticks32 = Ticks32::from(self.alarm.now().into_u32());
-        self.app_alarms.each(|alarm| {
+        self.app_alarms.each(|_, alarm| {
             if let Expiration::Enabled { reference, dt } = alarm.expiration {
                 // Now is not within reference, reference + ticks; this timer
                 // as passed (since reference must be in the past)

--- a/capsules/src/ambient_light.rs
+++ b/capsules/src/ambient_light.rs
@@ -46,7 +46,7 @@ impl<'a> AmbientLight<'a> {
 
     fn enqueue_sensor_reading(&self, appid: AppId) -> Result<(), ErrorCode> {
         self.apps
-            .enter(appid, |app, _| {
+            .enter(appid, |app| {
                 if app.pending {
                     Err(ErrorCode::NOMEM)
                 } else {
@@ -79,7 +79,7 @@ impl Driver for AmbientLight<'_> {
             0 => {
                 let rcode = self
                     .apps
-                    .enter(app_id, |app, _| {
+                    .enter(app_id, |app| {
                         mem::swap(&mut callback, &mut app.callback);
                         Ok(())
                     })

--- a/capsules/src/ambient_light.rs
+++ b/capsules/src/ambient_light.rs
@@ -121,7 +121,7 @@ impl Driver for AmbientLight<'_> {
 impl hil::sensors::AmbientLightClient for AmbientLight<'_> {
     fn callback(&self, lux: usize) {
         self.command_pending.set(false);
-        self.apps.each(|app| {
+        self.apps.each(|_, app| {
             if app.pending {
                 app.pending = false;
                 app.callback.schedule(lux, 0, 0);

--- a/capsules/src/analog_comparator.rs
+++ b/capsules/src/analog_comparator.rs
@@ -133,7 +133,7 @@ impl<'a, A: hil::analog_comparator::AnalogComparator<'a>> Driver for AnalogCompa
         // Check if this driver is free, or already dedicated to this process.
         let match_or_empty_or_nonexistant = self.current_process.map_or(true, |current_process| {
             self.grants
-                .enter(*current_process, |_, _| current_process == &appid)
+                .enter(*current_process, |_| current_process == &appid)
                 .unwrap_or(true)
         });
         if match_or_empty_or_nonexistant {
@@ -170,7 +170,7 @@ impl<'a, A: hil::analog_comparator::AnalogComparator<'a>> Driver for AnalogCompa
             0 => {
                 let res = self
                     .grants
-                    .enter(app_id, |app, _| {
+                    .enter(app_id, |app| {
                         mem::swap(&mut app.callback, &mut callback);
                     })
                     .map_err(ErrorCode::from);
@@ -191,7 +191,7 @@ impl<'a, A: hil::analog_comparator::AnalogComparator<'a>> hil::analog_comparator
     /// Upcall to userland, signaling the application
     fn fired(&self, channel: usize) {
         self.current_process.take().map(|appid| {
-            let _ = self.grants.enter(appid, |app, _| {
+            let _ = self.grants.enter(appid, |app| {
                 app.callback.schedule(channel, 0, 0);
             });
         });

--- a/capsules/src/app_flash_driver.rs
+++ b/capsules/src/app_flash_driver.rs
@@ -126,10 +126,11 @@ impl hil::nonvolatile_storage::NonvolatileStorageClient<'static> for AppFlash<'_
 
         // Check if there are any pending events.
         for cntr in self.apps.iter() {
+            let appid = cntr.appid();
             let started_command = cntr.enter(|app, _| {
                 if app.pending_command {
                     app.pending_command = false;
-                    self.current_app.set(app.appid());
+                    self.current_app.set(appid);
                     let flash_address = app.flash_address;
 
                     app.buffer.map_or(false, |app_buffer| {

--- a/capsules/src/button.rs
+++ b/capsules/src/button.rs
@@ -191,7 +191,7 @@ impl<'a, P: gpio::InterruptPin<'a>> Driver for Button<'a, P> {
 
                     // are any processes waiting for this button?
                     let interrupt_count = Cell::new(0);
-                    self.apps.each(|cntr| {
+                    self.apps.each(|_, cntr| {
                         if cntr.1 & (1 << data) != 0 {
                             interrupt_count.set(interrupt_count.get() + 1);
                         }
@@ -229,7 +229,7 @@ impl<'a, P: gpio::InterruptPin<'a>> gpio::ClientWithValue for Button<'a, P> {
         let interrupt_count = Cell::new(0);
 
         // schedule callback with the pin number and value
-        self.apps.each(|cntr| {
+        self.apps.each(|_, cntr| {
             if cntr.1 & (1 << pin_num) != 0 {
                 interrupt_count.set(interrupt_count.get() + 1);
                 cntr.0.schedule(pin_num as usize, button_state as usize, 0);

--- a/capsules/src/button.rs
+++ b/capsules/src/button.rs
@@ -122,7 +122,7 @@ impl<'a, P: gpio::InterruptPin<'a>> Driver for Button<'a, P> {
         let res = match subscribe_num {
             0 => self
                 .apps
-                .enter(app_id, |cntr, _| {
+                .enter(app_id, |cntr| {
                     core::mem::swap(&mut cntr.0, &mut callback);
                 })
                 .map_err(|err| err.into()),
@@ -163,7 +163,7 @@ impl<'a, P: gpio::InterruptPin<'a>> Driver for Button<'a, P> {
             1 => {
                 if data < pins.len() {
                     self.apps
-                        .enter(appid, |cntr, _| {
+                        .enter(appid, |cntr| {
                             cntr.1 |= 1 << data;
                             let _ = pins[data]
                                 .0
@@ -183,7 +183,7 @@ impl<'a, P: gpio::InterruptPin<'a>> Driver for Button<'a, P> {
                 } else {
                     let res = self
                         .apps
-                        .enter(appid, |cntr, _| {
+                        .enter(appid, |cntr| {
                             cntr.1 &= !(1 << data);
                             CommandReturn::success()
                         })

--- a/capsules/src/buzzer_driver.rs
+++ b/capsules/src/buzzer_driver.rs
@@ -107,7 +107,7 @@ impl<'a, A: hil::time::Alarm<'a>> Buzzer<'a, A> {
         } else {
             // There is an active app, so queue this request (if possible).
             self.apps
-                .enter(app_id, |app, _| {
+                .enter(app_id, |app| {
                     // Some app is using the storage, we must wait.
                     if app.pending_command.is_some() {
                         // No more room in the queue, nowhere to store this
@@ -150,7 +150,7 @@ impl<'a, A: hil::time::Alarm<'a>> Buzzer<'a, A> {
     fn check_queue(&self) {
         for appiter in self.apps.iter() {
             let appid = appiter.appid();
-            let started_command = appiter.enter(|app, _| {
+            let started_command = appiter.enter(|app| {
                 // If this app has a pending command let's use it.
                 app.pending_command.take().map_or(false, |command| {
                     // Mark this driver as being in use.
@@ -173,7 +173,7 @@ impl<'a, A: hil::time::Alarm<'a>> hil::time::AlarmClient for Buzzer<'a, A> {
         let _ = self.pwm_pin.stop();
         // Mark the active app as None and see if there is a callback.
         self.active_app.take().map(|app_id| {
-            let _ = self.apps.enter(app_id, |app, _| {
+            let _ = self.apps.enter(app_id, |app| {
                 app.callback.schedule(0, 0, 0);
             });
         });
@@ -199,7 +199,7 @@ impl<'a, A: hil::time::Alarm<'a>> Driver for Buzzer<'a, A> {
         let res = match subscribe_num {
             0 => self
                 .apps
-                .enter(app_id, |app, _| mem::swap(&mut app.callback, &mut callback))
+                .enter(app_id, |app| mem::swap(&mut app.callback, &mut callback))
                 .map_err(ErrorCode::from),
             _ => Err(ErrorCode::NOSUPPORT),
         };

--- a/capsules/src/buzzer_driver.rs
+++ b/capsules/src/buzzer_driver.rs
@@ -149,11 +149,12 @@ impl<'a, A: hil::time::Alarm<'a>> Buzzer<'a, A> {
 
     fn check_queue(&self) {
         for appiter in self.apps.iter() {
+            let appid = appiter.appid();
             let started_command = appiter.enter(|app, _| {
                 // If this app has a pending command let's use it.
                 app.pending_command.take().map_or(false, |command| {
                     // Mark this driver as being in use.
-                    self.active_app.set(app.appid());
+                    self.active_app.set(appid);
                     // Actually make the buzz happen.
                     self.buzz(command) == Ok(())
                 })

--- a/capsules/src/console.rs
+++ b/capsules/src/console.rs
@@ -348,10 +348,11 @@ impl uart::TransmitClient for Console<'_> {
         // see if any other applications have pending messages.
         if self.tx_in_progress.is_none() {
             for cntr in self.apps.iter() {
+                let appid = cntr.appid();
                 let started_tx = cntr.enter(|app, _| {
                     if app.pending_write {
                         app.pending_write = false;
-                        match self.send_continue(app.appid(), app) {
+                        match self.send_continue(appid, app) {
                             Ok(more_to_send) => more_to_send,
                             Err(return_code) => {
                                 // XXX This shouldn't ever happen?

--- a/capsules/src/crc.rs
+++ b/capsules/src/crc.rs
@@ -129,7 +129,7 @@ impl<'a, C: hil::crc::CRC<'a>> Crc<'a, C> {
         let mut found = false;
         for app in self.apps.iter() {
             let appid = app.appid();
-            app.enter(|app, _| {
+            app.enter(|app| {
                 if let Some(alg) = app.waiting {
                     let rcode = app
                         .buffer
@@ -181,7 +181,7 @@ impl<'a, C: hil::crc::CRC<'a>> Driver for Crc<'a, C> {
             // Provide user buffer to compute CRC over
             0 => self
                 .apps
-                .enter(appid, |app, _| {
+                .enter(appid, |app| {
                     mem::swap(&mut app.buffer, &mut slice);
                 })
                 .map_err(ErrorCode::from),
@@ -222,7 +222,7 @@ impl<'a, C: hil::crc::CRC<'a>> Driver for Crc<'a, C> {
             // Set callback for CRC result
             0 => self
                 .apps
-                .enter(app_id, |app, _| {
+                .enter(app_id, |app| {
                     mem::swap(&mut app.callback, &mut callback);
                 })
                 .map_err(ErrorCode::from),
@@ -310,7 +310,7 @@ impl<'a, C: hil::crc::CRC<'a>> Driver for Crc<'a, C> {
             2 => {
                 let result = if let Some(alg) = alg_from_user_int(algorithm) {
                     self.apps
-                        .enter(appid, |app, _| {
+                        .enter(appid, |app| {
                             if app.waiting.is_some() {
                                 // Each app may make only one request at a time
                                 Err(ErrorCode::BUSY)
@@ -342,7 +342,7 @@ impl<'a, C: hil::crc::CRC<'a>> hil::crc::Client for Crc<'a, C> {
         self.serving_app.take().map(|appid| {
             let _ = self
                 .apps
-                .enter(appid, |app, _| {
+                .enter(appid, |app| {
                     app.callback
                         .schedule(kernel::retcode_into_usize(Ok(())), result as usize, 0);
                     app.waiting = None;

--- a/capsules/src/crc.rs
+++ b/capsules/src/crc.rs
@@ -128,6 +128,7 @@ impl<'a, C: hil::crc::CRC<'a>> Crc<'a, C> {
         // Find a waiting app and start its requested computation
         let mut found = false;
         for app in self.apps.iter() {
+            let appid = app.appid();
             app.enter(|app, _| {
                 if let Some(alg) = app.waiting {
                     let rcode = app
@@ -136,7 +137,7 @@ impl<'a, C: hil::crc::CRC<'a>> Crc<'a, C> {
 
                     if rcode == Ok(()) {
                         // The unit is now computing a CRC for this app
-                        self.serving_app.set(app.appid());
+                        self.serving_app.set(appid);
                         found = true;
                     } else {
                         // The app's request failed

--- a/capsules/src/ctap.rs
+++ b/capsules/src/ctap.rs
@@ -136,7 +136,7 @@ impl<'a, U: usb_hid::UsbHid<'a, [u8; 64]>> usb_hid::Client<'a, [u8; 64]> for Cta
     ) {
         self.appid.map(|id| {
             self.app
-                .enter(*id, |app, _| {
+                .enter(*id, |app| {
                     app.recv_buf.mut_map_or((), |dest| {
                         dest.as_mut().copy_from_slice(buffer.as_ref());
                     });
@@ -162,7 +162,7 @@ impl<'a, U: usb_hid::UsbHid<'a, [u8; 64]>> usb_hid::Client<'a, [u8; 64]> for Cta
     ) {
         self.appid.map(|id| {
             self.app
-                .enter(*id, |app, _| {
+                .enter(*id, |app| {
                     app.callback.schedule(1, 0, 0);
                 })
                 .map_err(|err| {
@@ -180,7 +180,7 @@ impl<'a, U: usb_hid::UsbHid<'a, [u8; 64]>> usb_hid::Client<'a, [u8; 64]> for Cta
         self.appid
             .map(|id| {
                 self.app
-                    .enter(*id, |app, _| app.can_receive.get())
+                    .enter(*id, |app| app.can_receive.get())
                     .unwrap_or(false)
             })
             .unwrap_or(false)
@@ -198,7 +198,7 @@ impl<'a, U: usb_hid::UsbHid<'a, [u8; 64]>> Driver for CtapDriver<'a, U> {
             // Pass buffer for the recvieved data to be stored in
             0 => self
                 .app
-                .enter(appid, |app, _| {
+                .enter(appid, |app| {
                     mem::swap(&mut slice, &mut app.recv_buf);
                     Ok(())
                 })
@@ -207,7 +207,7 @@ impl<'a, U: usb_hid::UsbHid<'a, [u8; 64]>> Driver for CtapDriver<'a, U> {
             // Pass buffer for the sent data to be stored in
             1 => self
                 .app
-                .enter(appid, |app, _| {
+                .enter(appid, |app| {
                     mem::swap(&mut slice, &mut app.send_buf);
                     Ok(())
                 })
@@ -241,7 +241,7 @@ impl<'a, U: usb_hid::UsbHid<'a, [u8; 64]>> Driver for CtapDriver<'a, U> {
             0 => {
                 // set callback
                 self.app
-                    .enter(appid, |app, _| {
+                    .enter(appid, |app| {
                         mem::swap(&mut app.callback, &mut callback);
                         Ok(())
                     })
@@ -282,7 +282,7 @@ impl<'a, U: usb_hid::UsbHid<'a, [u8; 64]>> Driver for CtapDriver<'a, U> {
             // Send data
             0 => self
                 .app
-                .enter(appid, |app, _| {
+                .enter(appid, |app| {
                     self.appid.set(appid);
                     if let Some(usb) = self.usb {
                         app.send_buf
@@ -308,7 +308,7 @@ impl<'a, U: usb_hid::UsbHid<'a, [u8; 64]>> Driver for CtapDriver<'a, U> {
             // Allow receive
             1 => self
                 .app
-                .enter(appid, |app, _| {
+                .enter(appid, |app| {
                     self.appid.set(appid);
                     if let Some(usb) = self.usb {
                         app.can_receive.set(true);
@@ -331,7 +331,7 @@ impl<'a, U: usb_hid::UsbHid<'a, [u8; 64]>> Driver for CtapDriver<'a, U> {
             // Cancel send
             2 => self
                 .app
-                .enter(appid, |_app, _| {
+                .enter(appid, |_app| {
                     self.appid.set(appid);
                     if let Some(usb) = self.usb {
                         match usb.receive_cancel() {
@@ -349,7 +349,7 @@ impl<'a, U: usb_hid::UsbHid<'a, [u8; 64]>> Driver for CtapDriver<'a, U> {
             // Cancel receive
             3 => self
                 .app
-                .enter(appid, |_app, _| {
+                .enter(appid, |_app| {
                     self.appid.set(appid);
                     if let Some(usb) = self.usb {
                         match usb.receive_cancel() {
@@ -380,7 +380,7 @@ impl<'a, U: usb_hid::UsbHid<'a, [u8; 64]>> Driver for CtapDriver<'a, U> {
             //            send buffer.
             4 => self
                 .app
-                .enter(appid, |app, _| {
+                .enter(appid, |app| {
                     if let Some(usb) = self.usb {
                         if app.can_receive.get() {
                             // We are already receiving

--- a/capsules/src/gpio.rs
+++ b/capsules/src/gpio.rs
@@ -137,7 +137,7 @@ impl<'a, IP: gpio::InterruptPin<'a>> gpio::ClientWithValue for GPIO<'a, IP> {
             let pin_state = pin.read();
 
             // schedule callback with the pin number and value
-            self.apps.each(|callback| {
+            self.apps.each(|_, callback| {
                 callback.schedule(pin_num as usize, pin_state as usize, 0);
             });
         }

--- a/capsules/src/gpio.rs
+++ b/capsules/src/gpio.rs
@@ -162,7 +162,7 @@ impl<'a, IP: gpio::InterruptPin<'a>> Driver for GPIO<'a, IP> {
             // individual pins being configured as interrupts)
             0 => self
                 .apps
-                .enter(app_id, |app, _| {
+                .enter(app_id, |app| {
                     mem::swap(&mut **app, &mut callback);
                 })
                 .map_err(ErrorCode::from),

--- a/capsules/src/humidity.rs
+++ b/capsules/src/humidity.rs
@@ -95,7 +95,7 @@ impl<'a> HumiditySensor<'a> {
         appid: AppId,
     ) -> CommandReturn {
         self.apps
-            .enter(appid, |app, _| {
+            .enter(appid, |app| {
                 if !self.busy.get() {
                     app.subscribed = true;
                     self.busy.set(true);
@@ -121,7 +121,7 @@ impl<'a> HumiditySensor<'a> {
     ) -> Result<Upcall, (Upcall, ErrorCode)> {
         let res = self
             .apps
-            .enter(app_id, |app, _| {
+            .enter(app_id, |app| {
                 mem::swap(&mut app.callback, &mut callback);
             })
             .map_err(ErrorCode::from);
@@ -137,7 +137,7 @@ impl<'a> HumiditySensor<'a> {
 impl hil::sensors::HumidityClient for HumiditySensor<'_> {
     fn callback(&self, tmp_val: usize) {
         for cntr in self.apps.iter() {
-            cntr.enter(|app, _| {
+            cntr.enter(|app| {
                 if app.subscribed {
                     self.busy.set(false);
                     app.subscribed = false;

--- a/capsules/src/ieee802154/driver.rs
+++ b/capsules/src/ieee802154/driver.rs
@@ -354,9 +354,10 @@ impl<'a> RadioDriver<'a> {
         }
         let mut pending_app = None;
         for app in self.apps.iter() {
+            let appid = app.appid();
             app.enter(|app, _| {
                 if app.pending_tx.is_some() {
-                    pending_app = Some(app.appid());
+                    pending_app = Some(appid);
                 }
             });
             if pending_app.is_some() {
@@ -902,7 +903,7 @@ fn encode_address(addr: &Option<MacAddress>) -> usize {
 
 impl device::RxClient for RadioDriver<'_> {
     fn receive<'b>(&self, buf: &'b [u8], header: Header<'b>, data_offset: usize, data_len: usize) {
-        self.apps.each(|app| {
+        self.apps.each(|_, app| {
             let read_present = app.app_read.mut_map_or(false, |rbuf| {
                 let rbuf = rbuf.as_mut();
                 let len = min(rbuf.len(), data_offset + data_len);

--- a/capsules/src/low_level_debug/mod.rs
+++ b/capsules/src/low_level_debug/mod.rs
@@ -77,12 +77,10 @@ impl<'u, U: Transmit<'u>> TransmitClient for LowLevelDebug<'u, U> {
         }
 
         for applied_grant in self.grant.iter() {
+            let appid = applied_grant.appid();
             let (app_num, first_entry) = applied_grant.enter(|owned_app_data, _| {
                 owned_app_data.queue.rotate_left(1);
-                (
-                    owned_app_data.appid().id(),
-                    owned_app_data.queue[QUEUE_SIZE - 1].take(),
-                )
+                (appid.id(), owned_app_data.queue[QUEUE_SIZE - 1].take())
             });
             let to_print = match first_entry {
                 None => continue,

--- a/capsules/src/low_level_debug/mod.rs
+++ b/capsules/src/low_level_debug/mod.rs
@@ -76,9 +76,9 @@ impl<'u, U: Transmit<'u>> TransmitClient for LowLevelDebug<'u, U> {
             return;
         }
 
-        for applied_grant in self.grant.iter() {
-            let appid = applied_grant.appid();
-            let (app_num, first_entry) = applied_grant.enter(|owned_app_data, _| {
+        for process_grant in self.grant.iter() {
+            let appid = process_grant.appid();
+            let (app_num, first_entry) = process_grant.enter(|owned_app_data| {
                 owned_app_data.queue.rotate_left(1);
                 (appid.id(), owned_app_data.queue[QUEUE_SIZE - 1].take())
             });
@@ -108,7 +108,7 @@ impl<'u, U: Transmit<'u>> LowLevelDebug<'u, U> {
             return;
         }
 
-        let result = self.grant.enter(appid, |borrow, _| {
+        let result = self.grant.enter(appid, |borrow| {
             for queue_entry in &mut borrow.queue {
                 if queue_entry.is_none() {
                     *queue_entry = Some(entry);

--- a/capsules/src/net/udp/driver.rs
+++ b/capsules/src/net/udp/driver.rs
@@ -148,9 +148,10 @@ impl<'a> UDPDriver<'a> {
         }
         let mut pending_app = None;
         for app in self.apps.iter() {
+            let appid = app.appid();
             app.enter(|app, _| {
                 if app.pending_tx.is_some() {
-                    pending_app = Some(app.appid());
+                    pending_app = Some(appid);
                 }
             });
             if pending_app.is_some() {
@@ -620,7 +621,7 @@ impl<'a> UDPRecvClient for UDPDriver<'a> {
         dst_port: u16,
         payload: &[u8],
     ) {
-        self.apps.each(|app| {
+        self.apps.each(|_, app| {
             if app.bound_port.is_some() {
                 let mut for_me = false;
                 app.bound_port.as_ref().map(|requested_addr| {

--- a/capsules/src/ninedof.rs
+++ b/capsules/src/ninedof.rs
@@ -73,7 +73,7 @@ impl<'a> NineDof<'a> {
     // and will be run when the pending command completes.
     fn enqueue_command(&self, command: NineDofCommand, arg1: usize, appid: AppId) -> CommandReturn {
         self.apps
-            .enter(appid, |app, _| {
+            .enter(appid, |app| {
                 if self.current_app.is_none() {
                     self.current_app.set(appid);
                     let value = self.call_driver(command, arg1);
@@ -141,7 +141,7 @@ impl<'a> NineDof<'a> {
     ) -> Result<Upcall, (Upcall, ErrorCode)> {
         let res = self
             .apps
-            .enter(app_id, |app, _| {
+            .enter(app_id, |app| {
                 mem::swap(&mut app.callback, &mut callback);
             })
             .map_err(ErrorCode::from);
@@ -162,7 +162,7 @@ impl hil::sensors::NineDofClient for NineDof<'_> {
         let mut finished_command = NineDofCommand::Exists;
         let mut finished_command_arg = 0;
         self.current_app.take().map(|appid| {
-            let _ = self.apps.enter(appid, |app, _| {
+            let _ = self.apps.enter(appid, |app| {
                 app.pending_command = false;
                 finished_command = app.command;
                 finished_command_arg = app.arg1;
@@ -173,7 +173,7 @@ impl hil::sensors::NineDofClient for NineDof<'_> {
         // Check if there are any pending events.
         for cntr in self.apps.iter() {
             let appid = cntr.appid();
-            let started_command = cntr.enter(|app, _| {
+            let started_command = cntr.enter(|app| {
                 if app.pending_command
                     && app.command == finished_command
                     && app.arg1 == finished_command_arg

--- a/capsules/src/ninedof.rs
+++ b/capsules/src/ninedof.rs
@@ -172,6 +172,7 @@ impl hil::sensors::NineDofClient for NineDof<'_> {
 
         // Check if there are any pending events.
         for cntr in self.apps.iter() {
+            let appid = cntr.appid();
             let started_command = cntr.enter(|app, _| {
                 if app.pending_command
                     && app.command == finished_command
@@ -184,7 +185,7 @@ impl hil::sensors::NineDofClient for NineDof<'_> {
                     false
                 } else if app.pending_command {
                     app.pending_command = false;
-                    self.current_app.set(app.appid());
+                    self.current_app.set(appid);
                     self.call_driver(app.command, app.arg1) == Ok(())
                 } else {
                     false

--- a/capsules/src/nonvolatile_storage_driver.rs
+++ b/capsules/src/nonvolatile_storage_driver.rs
@@ -371,12 +371,12 @@ impl<'a> NonvolatileStorage<'a> {
         } else {
             // If the kernel is not requesting anything, check all of the apps.
             for cntr in self.apps.iter() {
+                let appid = cntr.appid();
                 let started_command = cntr.enter(|app, _| {
                     if app.pending_command {
                         app.pending_command = false;
-                        self.current_user.set(NonvolatileUser::App {
-                            app_id: app.appid(),
-                        });
+                        self.current_user
+                            .set(NonvolatileUser::App { app_id: appid });
                         if let Ok(()) =
                             self.userspace_call_driver(app.command, app.offset, app.length)
                         {

--- a/capsules/src/rng.rs
+++ b/capsules/src/rng.rs
@@ -67,7 +67,7 @@ impl rng::Client for RngDriver<'_> {
     ) -> rng::Continue {
         let mut done = true;
         for cntr in self.apps.iter() {
-            cntr.enter(|app, _| {
+            cntr.enter(|app| {
                 // Check if this app needs random values.
                 if app.remaining > 0 {
                     // Provide the current application values to the closure
@@ -165,7 +165,7 @@ impl<'a> Driver for RngDriver<'a> {
         let res = match allow_num {
             0 => self
                 .apps
-                .enter(appid, |app, _| {
+                .enter(appid, |app| {
                     mem::swap(&mut app.buffer, &mut slice);
                     Ok(())
                 })
@@ -188,7 +188,7 @@ impl<'a> Driver for RngDriver<'a> {
         let res = match subscribe_num {
             0 => self
                 .apps
-                .enter(app_id, |app, _| {
+                .enter(app_id, |app| {
                     mem::swap(&mut app.callback, &mut callback);
                     Ok(())
                 })
@@ -211,7 +211,7 @@ impl<'a> Driver for RngDriver<'a> {
 
             1 /* Ask for a given number of random bytes */ => self
                 .apps
-                .enter(appid, |app, _| {
+                .enter(appid, |app| {
                     app.remaining = data;
                     app.idx = 0;
 

--- a/capsules/src/screen.rs
+++ b/capsules/src/screen.rs
@@ -147,7 +147,7 @@ impl<'a> Screen<'a> {
     ) -> CommandReturn {
         let res = self
             .apps
-            .enter(appid, |app, _| {
+            .enter(appid, |app| {
                 if self.screen_ready.get() && self.current_app.is_none() {
                     self.current_app.set(appid);
                     app.command = command;
@@ -285,7 +285,7 @@ impl<'a> Screen<'a> {
             ScreenCommand::Fill => {
                 let res = self
                     .apps
-                    .enter(appid, |app, _| {
+                    .enter(appid, |app| {
                         // if it is larger than 0, we know it fits
                         // the size has been verified by subscribe
                         if app.shared.len() > 0 {
@@ -319,7 +319,7 @@ impl<'a> Screen<'a> {
             }
             ScreenCommand::Write => self
                 .apps
-                .enter(appid, |app, _| {
+                .enter(appid, |app| {
                     let len = if app.shared.len() < data1 {
                         app.shared.len()
                     } else {
@@ -345,7 +345,7 @@ impl<'a> Screen<'a> {
                 .unwrap_or_else(|err| err.into()),
             ScreenCommand::SetWriteFrame => self
                 .apps
-                .enter(appid, |app, _| {
+                .enter(appid, |app| {
                     app.write_position = 0;
                     app.x = (data1 >> 16) & 0xFFFF;
                     app.y = data1 & 0xFFFF;
@@ -364,7 +364,7 @@ impl<'a> Screen<'a> {
             self.screen_ready.set(true);
         } else {
             self.current_app.take().map(|appid| {
-                let _ = self.apps.enter(appid, |app, _| {
+                let _ = self.apps.enter(appid, |app| {
                     app.pending_command = false;
                     app.callback.schedule(data1, data2, data3);
                 });
@@ -374,7 +374,7 @@ impl<'a> Screen<'a> {
         // Check if there are any pending events.
         for app in self.apps.iter() {
             let appid = app.appid();
-            let started_command = app.enter(|app, _| {
+            let started_command = app.enter(|app| {
                 if app.pending_command {
                     app.pending_command = false;
                     self.current_app.set(appid);
@@ -398,7 +398,7 @@ impl<'a> Screen<'a> {
             || 0,
             |appid| {
                 self.apps
-                    .enter(*appid, |app, _| {
+                    .enter(*appid, |app| {
                         let position = app.write_position;
                         let mut len = app.write_len;
                         if position < len {
@@ -509,7 +509,7 @@ impl<'a> Driver for Screen<'a> {
         let res = match subscribe_num {
             0 => self
                 .apps
-                .enter(app_id, |app, _| {
+                .enter(app_id, |app| {
                     mem::swap(&mut app.callback, &mut callback);
                 })
                 .map_err(ErrorCode::from),
@@ -591,7 +591,7 @@ impl<'a> Driver for Screen<'a> {
             0 => {
                 let res = self
                     .apps
-                    .enter(appid, |app, _| {
+                    .enter(appid, |app| {
                         let depth =
                             pixels_in_bytes(1, self.screen.get_pixel_format().get_bits_per_pixel());
                         let len = slice.len();

--- a/capsules/src/screen.rs
+++ b/capsules/src/screen.rs
@@ -373,11 +373,12 @@ impl<'a> Screen<'a> {
 
         // Check if there are any pending events.
         for app in self.apps.iter() {
+            let appid = app.appid();
             let started_command = app.enter(|app, _| {
                 if app.pending_command {
                     app.pending_command = false;
-                    self.current_app.set(app.appid());
-                    let r = self.call_screen(app.command, app.data1, app.data2, app.appid());
+                    self.current_app.set(appid);
+                    let r = self.call_screen(app.command, app.data1, app.data2, appid);
                     if r != Ok(()) {
                         self.current_app.clear();
                     }

--- a/capsules/src/sound_pressure.rs
+++ b/capsules/src/sound_pressure.rs
@@ -89,7 +89,7 @@ impl<'a> SoundPressureSensor<'a> {
 
     fn enqueue_command(&self, appid: AppId) -> CommandReturn {
         self.apps
-            .enter(appid, |app, _| {
+            .enter(appid, |app| {
                 if !self.busy.get() {
                     app.subscribed = true;
                     self.busy.set(true);
@@ -109,7 +109,7 @@ impl<'a> SoundPressureSensor<'a> {
     fn enable(&self) {
         let mut enable = false;
         for app in self.apps.iter() {
-            app.enter(|app, _| {
+            app.enter(|app| {
                 if app.enable {
                     enable = true;
                 }
@@ -126,7 +126,7 @@ impl<'a> SoundPressureSensor<'a> {
 impl hil::sensors::SoundPressureClient for SoundPressureSensor<'_> {
     fn callback(&self, ret: Result<(), ErrorCode>, sound_val: u8) {
         for cntr in self.apps.iter() {
-            cntr.enter(|app, _| {
+            cntr.enter(|app| {
                 if app.subscribed {
                     self.busy.set(false);
                     app.subscribed = false;
@@ -151,7 +151,7 @@ impl Driver for SoundPressureSensor<'_> {
             0 => {
                 let res = self
                     .apps
-                    .enter(app_id, |app, _| {
+                    .enter(app_id, |app| {
                         mem::swap(&mut app.callback, &mut callback);
                     })
                     .map_err(ErrorCode::from);
@@ -177,7 +177,7 @@ impl Driver for SoundPressureSensor<'_> {
             2 => {
                 let res = self
                     .apps
-                    .enter(appid, |app, _| {
+                    .enter(appid, |app| {
                         app.enable = true;
                         CommandReturn::success()
                     })
@@ -194,7 +194,7 @@ impl Driver for SoundPressureSensor<'_> {
             3 => {
                 let res = self
                     .apps
-                    .enter(appid, |app, _| {
+                    .enter(appid, |app| {
                         app.enable = false;
                         CommandReturn::success()
                     })

--- a/capsules/src/temperature.rs
+++ b/capsules/src/temperature.rs
@@ -88,7 +88,7 @@ impl<'a> TemperatureSensor<'a> {
 
     fn enqueue_command(&self, appid: AppId) -> CommandReturn {
         self.apps
-            .enter(appid, |app, _| {
+            .enter(appid, |app| {
                 if !self.busy.get() {
                     app.subscribed = true;
                     self.busy.set(true);
@@ -112,7 +112,7 @@ impl<'a> TemperatureSensor<'a> {
     ) -> Result<Upcall, (Upcall, ErrorCode)> {
         let res = self
             .apps
-            .enter(app_id, |app, _| {
+            .enter(app_id, |app| {
                 mem::swap(&mut app.callback, &mut callback);
             })
             .map_err(ErrorCode::from);
@@ -127,7 +127,7 @@ impl<'a> TemperatureSensor<'a> {
 impl hil::sensors::TemperatureClient for TemperatureSensor<'_> {
     fn callback(&self, temp_val: usize) {
         for cntr in self.apps.iter() {
-            cntr.enter(|app, _| {
+            cntr.enter(|app| {
                 if app.subscribed {
                     self.busy.set(false);
                     app.subscribed = false;

--- a/capsules/src/test/double_grant_entry.rs
+++ b/capsules/src/test/double_grant_entry.rs
@@ -93,7 +93,7 @@ impl Driver for TestGrantDoubleEntry {
                 // Enter the grant for the app.
                 let err = self
                     .grant
-                    .enter(appid, |appgrant, _allocator| {
+                    .enter(appid, |appgrant| {
                         // We can now change the state of the app's grant
                         // region.
                         appgrant.pending = true;
@@ -101,7 +101,7 @@ impl Driver for TestGrantDoubleEntry {
                         // Now, try to iterate all grant regions.
                         for grant in self.grant.iter() {
                             // And, try to enter each grant! This should fail.
-                            grant.enter(|appgrant2, _allocator| {
+                            grant.enter(|appgrant2| {
                                 if appgrant2.pending {
                                     found_pending = true;
                                 }
@@ -127,17 +127,17 @@ impl Driver for TestGrantDoubleEntry {
                 let mut found_pending = false;
 
                 // Make sure the grant is allocated.
-                let _ = self.grant.enter(appid, |appgrant, _| {
+                let _ = self.grant.enter(appid, |appgrant| {
                     appgrant.pending = false;
                 });
 
                 for app in self.grant.iter() {
-                    let _ = self.grant.enter(appid, |appgrant, _| {
+                    let _ = self.grant.enter(appid, |appgrant| {
                         // Mark the field.
                         appgrant.pending = true;
 
                         // Check if we can access this grant twice.
-                        app.enter(|appgrant2, _| {
+                        app.enter(|appgrant2| {
                             if appgrant2.pending {
                                 found_pending = true;
                             }
@@ -161,10 +161,10 @@ impl Driver for TestGrantDoubleEntry {
                 // entered the same grant twice.
                 let mut found_pending = false;
 
-                let _ = self.grant.enter(appid, |appgrant, _| {
+                let _ = self.grant.enter(appid, |appgrant| {
                     appgrant.pending = true;
 
-                    let _ = self.grant.enter(appid, |appgrant2, _| {
+                    let _ = self.grant.enter(appid, |appgrant2| {
                         if appgrant2.pending {
                             found_pending = true;
                         }

--- a/capsules/src/test/double_grant_entry.rs
+++ b/capsules/src/test/double_grant_entry.rs
@@ -1,0 +1,186 @@
+//! Test that tries to enter a grant twice.
+//!
+//! This must fail or Tock allows multiple mutable references to the same memory
+//! which is undefined behavior.
+//!
+//! To use, setup this capsule and connect the syscall `Driver` implementation
+//! to userspace. Then call the commands to test various double grant entries.
+//!
+//! # Usage
+//!
+//! Here is my example usage for hail:
+//!
+//! ```diff
+//! diff --git a/boards/hail/src/main.rs b/boards/hail/src/main.rs
+//! index 110d45fa7..e8f4728c2 100644
+//! --- a/boards/hail/src/main.rs
+//! +++ b/boards/hail/src/main.rs
+//! @@ -73,6 +73,7 @@ struct Hail {
+//!      ipc: kernel::ipc::IPC<NUM_PROCS>,
+//!      crc: &'static capsules::crc::Crc<'static, sam4l::crccu::Crccu<'static>>,
+//!      dac: &'static capsules::dac::Dac<'static>,
+//! +    dge: &'static capsules::test::double_grant_entry::TestGrantDoubleEntry,
+//!  }
+//!
+//!  /// Mapping of integer syscalls to objects that implement syscalls.
+//! @@ -102,6 +103,8 @@ impl Platform for Hail {
+//!
+//!              capsules::dac::DRIVER_NUM => f(Some(self.dac)),
+//!
+//! +            capsules::test::double_grant_entry::DRIVER_NUM => f(Some(self.dge)),
+//! +
+//!              kernel::ipc::DRIVER_NUM => f(Some(&self.ipc)),
+//!              _ => f(None),
+//!          }
+//! @@ -396,6 +399,14 @@ pub unsafe fn reset_handler() {
+//!          capsules::dac::Dac::new(&peripherals.dac)
+//!      );
+//!
+//! +    // Test double grant entry
+//! +    let dge = static_init!(
+//! +        capsules::test::double_grant_entry::TestGrantDoubleEntry,
+//! +        capsules::test::double_grant_entry::TestGrantDoubleEntry::new(
+//! +            board_kernel.create_grant(&memory_allocation_capability)
+//! +        )
+//! +    );
+//! +
+//!      // // DEBUG Restart All Apps
+//!      // //
+//!      // // Uncomment to enable a button press to restart all apps.
+//! @@ -440,6 +451,7 @@ pub unsafe fn reset_handler() {
+//!          ipc: kernel::ipc::IPC::new(board_kernel, &memory_allocation_capability),
+//!          crc,
+//!          dac,
+//! +        dge,
+//!      };
+//!
+//!      // Setup the UART bus for nRF51 serialization..
+//!     ```
+
+use kernel::{AppId, CommandReturn, Driver, ErrorCode, Grant};
+
+/// Syscall driver number.
+pub const DRIVER_NUM: usize = 0xF001;
+
+/// Need a grant for the process.
+#[derive(Default)]
+pub struct App {
+    pending: bool,
+}
+
+pub struct TestGrantDoubleEntry {
+    grant: Grant<App>,
+}
+
+impl TestGrantDoubleEntry {
+    pub fn new(grant: Grant<App>) -> TestGrantDoubleEntry {
+        TestGrantDoubleEntry { grant }
+    }
+}
+
+impl Driver for TestGrantDoubleEntry {
+    fn command(&self, command_num: usize, _: usize, _: usize, appid: AppId) -> CommandReturn {
+        match command_num {
+            0 => CommandReturn::success(),
+
+            1 => {
+                // Try Grant.enter() then Grant.iter().enter()
+
+                // Check if we saw a grant with pending as true. If so, we
+                // entered the same grant twice.
+                let mut found_pending = false;
+
+                // Enter the grant for the app.
+                let err = self
+                    .grant
+                    .enter(appid, |appgrant, _allocator| {
+                        // We can now change the state of the app's grant
+                        // region.
+                        appgrant.pending = true;
+
+                        // Now, try to iterate all grant regions.
+                        for grant in self.grant.iter() {
+                            // And, try to enter each grant! This should fail.
+                            grant.enter(|appgrant2, _allocator| {
+                                if appgrant2.pending {
+                                    found_pending = true;
+                                }
+                            });
+                        }
+                        CommandReturn::success()
+                    })
+                    .unwrap_or_else(|err| err.into());
+
+                // If found pending is true, things are broken.
+                if found_pending {
+                    kernel::debug!("ERROR! Entered a grant twice simultaneously!!");
+                }
+
+                err
+            }
+
+            2 => {
+                // Try Grant.iter() then Grant.enter() then Grant.iter().enter()
+
+                // Check if we saw a grant with pending as true. If so, we
+                // entered the same grant twice.
+                let mut found_pending = false;
+
+                // Make sure the grant is allocated.
+                let _ = self.grant.enter(appid, |appgrant, _| {
+                    appgrant.pending = false;
+                });
+
+                for app in self.grant.iter() {
+                    let _ = self.grant.enter(appid, |appgrant, _| {
+                        // Mark the field.
+                        appgrant.pending = true;
+
+                        // Check if we can access this grant twice.
+                        app.enter(|appgrant2, _| {
+                            if appgrant2.pending {
+                                found_pending = true;
+                            }
+                        });
+                    });
+                }
+
+                // If found pending is true, things are broken.
+                if found_pending {
+                    kernel::debug!("ERROR! Entered a grant twice simultaneously!!");
+                }
+
+                // Since we expect a panic these return values don't matter.
+                CommandReturn::success()
+            }
+
+            3 => {
+                // Try Grant.enter() then Grant.enter()
+
+                // Check if we saw a grant with pending as true. If so, we
+                // entered the same grant twice.
+                let mut found_pending = false;
+
+                let _ = self.grant.enter(appid, |appgrant, _| {
+                    appgrant.pending = true;
+
+                    let _ = self.grant.enter(appid, |appgrant2, _| {
+                        if appgrant2.pending {
+                            found_pending = true;
+                        }
+                    });
+                });
+
+                // If found pending is true, things are broken.
+                if found_pending {
+                    kernel::debug!("ERROR! Entered a grant twice simultaneously!!");
+                }
+
+                // Since we expect a panic these return values don't matter.
+                CommandReturn::success()
+            }
+
+            _ => CommandReturn::failure(ErrorCode::NOSUPPORT),
+        }
+    }
+}

--- a/capsules/src/test/mod.rs
+++ b/capsules/src/test/mod.rs
@@ -2,6 +2,7 @@ pub mod aes;
 pub mod aes_ccm;
 pub mod alarm;
 pub mod alarm_edge_cases;
+pub mod double_grant_entry;
 pub mod kv_system;
 pub mod random_alarm;
 pub mod random_timer;

--- a/capsules/src/text_screen.rs
+++ b/capsules/src/text_screen.rs
@@ -175,11 +175,12 @@ impl<'a> TextScreen<'a> {
     fn run_next_command(&self) {
         // Check for pending events.
         for app in self.apps.iter() {
+            let appid = app.appid();
             let current_command = app.enter(|app, _| {
                 if app.pending_command {
                     app.pending_command = false;
-                    self.current_app.set(app.appid());
-                    let r = self.do_command(app.command, app.data1, app.data2, app.appid());
+                    self.current_app.set(appid);
+                    let r = self.do_command(app.command, app.data1, app.data2, appid);
                     if r != Ok(()) {
                         self.current_app.clear();
                     }

--- a/capsules/src/text_screen.rs
+++ b/capsules/src/text_screen.rs
@@ -91,7 +91,7 @@ impl<'a> TextScreen<'a> {
     ) -> CommandReturn {
         let res = self
             .apps
-            .enter(appid, |app, _| {
+            .enter(appid, |app| {
                 if self.current_app.is_none() {
                     self.current_app.set(appid);
                     app.command = command;
@@ -142,7 +142,7 @@ impl<'a> TextScreen<'a> {
             TextScreenCommand::NoCursor => self.text_screen.hide_cursor(),
             TextScreenCommand::Write => self
                 .apps
-                .enter(appid, |app, _| {
+                .enter(appid, |app| {
                     if data1 > 0 {
                         app.write_len = data1;
                         app.shared.map_or(Err(ErrorCode::NOMEM), |to_write_buffer| {
@@ -176,7 +176,7 @@ impl<'a> TextScreen<'a> {
         // Check for pending events.
         for app in self.apps.iter() {
             let appid = app.appid();
-            let current_command = app.enter(|app, _| {
+            let current_command = app.enter(|app| {
                 if app.pending_command {
                     app.pending_command = false;
                     self.current_app.set(appid);
@@ -197,7 +197,7 @@ impl<'a> TextScreen<'a> {
 
     fn schedule_callback(&self, data1: usize, data2: usize, data3: usize) {
         self.current_app.take().map(|appid| {
-            let _ = self.apps.enter(appid, |app, _| {
+            let _ = self.apps.enter(appid, |app| {
                 app.pending_command = false;
                 app.callback.schedule(data1, data2, data3);
             });
@@ -216,7 +216,7 @@ impl<'a> Driver for TextScreen<'a> {
             0 => {
                 let res = self
                     .apps
-                    .enter(app_id, |app, _| {
+                    .enter(app_id, |app| {
                         mem::swap(&mut app.callback, &mut callback);
                     })
                     .map_err(ErrorCode::from);
@@ -277,7 +277,7 @@ impl<'a> Driver for TextScreen<'a> {
             0 => {
                 let res = self
                     .apps
-                    .enter(appid, |app, _| {
+                    .enter(appid, |app| {
                         mem::swap(&mut app.shared, &mut slice);
                     })
                     .map_err(ErrorCode::from);

--- a/capsules/src/touch.rs
+++ b/capsules/src/touch.rs
@@ -101,7 +101,7 @@ impl<'a> Touch<'a> {
     fn touch_enable(&self) -> Result<(), ErrorCode> {
         let mut enabled = false;
         for app in self.apps.iter() {
-            if app.enter(|app, _| if app.touch_enable { true } else { false }) {
+            if app.enter(|app| if app.touch_enable { true } else { false }) {
                 enabled = true;
                 break;
             }
@@ -118,7 +118,7 @@ impl<'a> Touch<'a> {
     fn multi_touch_enable(&self) -> Result<(), ErrorCode> {
         let mut enabled = false;
         for app in self.apps.iter() {
-            if app.enter(|app, _| if app.multi_touch_enable { true } else { false }) {
+            if app.enter(|app| if app.multi_touch_enable { true } else { false }) {
                 enabled = true;
                 break;
             }
@@ -170,7 +170,7 @@ impl<'a> hil::touch::TouchClient for Touch<'a> {
         //     event.status, event.x, event.y, event.size, event.pressure
         // );
         for app in self.apps.iter() {
-            app.enter(|app, _| {
+            app.enter(|app| {
                 let event_status = touch_status_to_number(&event.status);
                 if app.x != event.x || app.y != event.y || app.status != event_status {
                     app.x = event.x;
@@ -204,7 +204,7 @@ impl<'a> hil::touch::MultiTouchClient for Touch<'a> {
         };
         // debug!("{} touch(es)", len);
         for app in self.apps.iter() {
-            app.enter(|app, _| {
+            app.enter(|app| {
                 if app.ack {
                     app.dropped_events = 0;
 
@@ -272,7 +272,7 @@ impl<'a> hil::touch::GestureClient for Touch<'a> {
     fn gesture_event(&self, event: GestureEvent) {
         // debug!("gesture {:?}", event);
         for app in self.apps.iter() {
-            app.enter(|app, _| {
+            app.enter(|app| {
                 let gesture_id = match event {
                     GestureEvent::SwipeUp => 1,
                     GestureEvent::SwipeDown => 2,
@@ -306,7 +306,7 @@ impl<'a> Driver for Touch<'a> {
                 if self.multi_touch.is_some() {
                     let res = self
                         .apps
-                        .enter(appid, |app, _| {
+                        .enter(appid, |app| {
                             mem::swap(&mut app.events_buffer, &mut slice);
                         })
                         .map_err(ErrorCode::from);
@@ -333,7 +333,7 @@ impl<'a> Driver for Touch<'a> {
             0 => {
                 let r = self
                     .apps
-                    .enter(app_id, |app, _| {
+                    .enter(app_id, |app| {
                         mem::swap(&mut app.touch_callback, &mut callback);
                     })
                     .map_err(ErrorCode::from);
@@ -345,7 +345,7 @@ impl<'a> Driver for Touch<'a> {
             1 => {
                 let r = self
                     .apps
-                    .enter(app_id, |app, _| {
+                    .enter(app_id, |app| {
                         mem::swap(&mut app.gesture_callback, &mut callback);
                     })
                     .map_err(ErrorCode::from);
@@ -358,7 +358,7 @@ impl<'a> Driver for Touch<'a> {
                 if self.multi_touch.is_some() {
                     let r = self
                         .apps
-                        .enter(app_id, |app, _| {
+                        .enter(app_id, |app| {
                             mem::swap(&mut app.multi_touch_callback, &mut callback);
                         })
                         .map_err(ErrorCode::from);
@@ -395,7 +395,7 @@ impl<'a> Driver for Touch<'a> {
             // touch enable
             1 => {
                 self.apps
-                    .enter(appid, |app, _| {
+                    .enter(appid, |app| {
                         app.touch_enable = true;
                     })
                     .unwrap_or(());
@@ -406,7 +406,7 @@ impl<'a> Driver for Touch<'a> {
             // touch disable
             2 => {
                 self.apps
-                    .enter(appid, |app, _| {
+                    .enter(appid, |app| {
                         app.touch_enable = false;
                     })
                     .unwrap_or(());
@@ -417,7 +417,7 @@ impl<'a> Driver for Touch<'a> {
             // multi touch ack
             10 => {
                 self.apps
-                    .enter(appid, |app, _| {
+                    .enter(appid, |app| {
                         app.ack = true;
                     })
                     .unwrap_or(());
@@ -427,7 +427,7 @@ impl<'a> Driver for Touch<'a> {
             // multi touch enable
             11 => {
                 self.apps
-                    .enter(appid, |app, _| {
+                    .enter(appid, |app| {
                         app.multi_touch_enable = true;
                     })
                     .unwrap_or(());
@@ -438,7 +438,7 @@ impl<'a> Driver for Touch<'a> {
             // multi touch disable
             12 => {
                 self.apps
-                    .enter(appid, |app, _| {
+                    .enter(appid, |app| {
                         app.multi_touch_enable = false;
                     })
                     .unwrap_or(());

--- a/capsules/src/usb/usb_user.rs
+++ b/capsules/src/usb/usb_user.rs
@@ -67,7 +67,7 @@ where
         // Find a waiting app and start its requested computation
         let mut found = false;
         for app in self.apps.iter() {
-            app.enter(|app, _| {
+            app.enter(|app| {
                 if let Some(request) = app.awaiting {
                     found = true;
                     match request {
@@ -113,7 +113,7 @@ where
             // Set callback for result
             0 => self
                 .apps
-                .enter(app_id, |app, _| {
+                .enter(app_id, |app| {
                     mem::swap(&mut app.callback, &mut callback);
                     Ok(())
                 })
@@ -136,7 +136,7 @@ where
             1 => {
                 let result = self
                     .apps
-                    .enter(appid, |app, _| {
+                    .enter(appid, |app| {
                         if app.awaiting.is_some() {
                             // Each app may make only one request at a time
                             Err(ErrorCode::BUSY)

--- a/kernel/src/grant.rs
+++ b/kernel/src/grant.rs
@@ -30,7 +30,7 @@
 //! operation, they can use an `Allocator` to request additional memory from
 //! the process's grant region.
 //!
-//! ```
+//! ```skip
 //!                            ┌──────────────────┐
 //!                            │                  │
 //!                            │ Capsule          │
@@ -79,7 +79,7 @@
 //! Here is an overview of the types used by grant.rs to implement the Grant
 //! functionality in Tock:
 //!
-//! ```
+//! ```skip
 //!                         ┌──────────────────────────┐
 //!                         │ struct Grant<T> {        │
 //!                         │   number: usize          │
@@ -333,7 +333,7 @@ impl<'a, T: Default> ProcessGrant<'a, T> {
     /// bug in the code and not a condition that should be handled. For example,
     /// this benign looking code is wrong:
     ///
-    /// ```
+    /// ```skip
     /// self.apps.enter(thisapp, |app_grant, _| {
     ///     // Update state in the grant region of `thisapp`. Also, mark that
     ///     // `thisapp` needs to run again.

--- a/kernel/src/grant.rs
+++ b/kernel/src/grant.rs
@@ -719,43 +719,42 @@ impl GrantRegionAllocator {
         Ok(CustomGrant::new(custom_grant_identifier, self.appid))
     }
 
-    // /// Allocates a slice of n instances of a given type. Each instance is
-    // /// initialized using the provided function.
-    // ///
-    // /// The provided function will be called exactly `n` times, and will be
-    // /// passed the index it's initializing, from `0` through `num_items - 1`.
-    // ///
-    // /// # Panic Safety
-    // ///
-    // /// If `val_func` panics, the freshly allocated memory and any values
-    // /// already written will be leaked.
-    // pub fn alloc_n_with<T, F>(
-    //     &mut self,
-    //     num_items: usize,
-    //     mut init: F,
-    // ) -> Result<CustomGrant<[T]>, Error>
-    // where
-    //     F: FnMut(usize) -> T,
-    // {
-    //     let (custom_grant_identifier, typed_ptr) = self.alloc_n_raw::<T>(num_items)?;
+    /// Allocates a slice of n instances of a given type. Each instance is
+    /// initialized using the provided function.
+    ///
+    /// The provided function will be called exactly `n` times, and will be
+    /// passed the index it's initializing, from `0` through `NUM_ITEMS - 1`.
+    ///
+    /// # Panic Safety
+    ///
+    /// If `val_func` panics, the freshly allocated memory and any values
+    /// already written will be leaked.
+    pub fn alloc_n_with<T, F, const NUM_ITEMS: usize>(
+        &mut self,
+        mut init: F,
+    ) -> Result<CustomGrant<[T; NUM_ITEMS]>, Error>
+    where
+        F: FnMut(usize) -> T,
+    {
+        let (custom_grant_identifier, typed_ptr) = self.alloc_n_raw::<T>(NUM_ITEMS)?;
 
-    //     for i in 0..num_items {
-    //         // # Safety
-    //         //
-    //         // The allocate function guarantees that `ptr` points to memory
-    //         // large enough to allocate `num_items` copies of the object.
-    //         unsafe {
-    //             write(typed_ptr.as_ptr().add(i), init(i));
-    //         }
-    //     }
+        for i in 0..NUM_ITEMS {
+            // # Safety
+            //
+            // The allocate function guarantees that `ptr` points to memory
+            // large enough to allocate `num_items` copies of the object.
+            unsafe {
+                write(typed_ptr.as_ptr().add(i), init(i));
+            }
+        }
 
-    //     // // convert `NonNull<T>` to a fat pointer `NonNull<[T]>` which includes
-    //     // // the length information. We do this here as initialization is more
-    //     // // convenient with the non-slice ptr.
-    //     // let slice_ptr = NonNull::new(slice_from_raw_parts_mut(typed_ptr.as_ptr(), num_items)).unwrap();
+        // // convert `NonNull<T>` to a fat pointer `NonNull<[T]>` which includes
+        // // the length information. We do this here as initialization is more
+        // // convenient with the non-slice ptr.
+        // let slice_ptr = NonNull::new(slice_from_raw_parts_mut(typed_ptr.as_ptr(), num_items)).unwrap();
 
-    //     Ok(CustomGrant::new(custom_grant_identifier, self.appid))
-    // }
+        Ok(CustomGrant::new(custom_grant_identifier, self.appid))
+    }
 
     /// Allocates uninitialized grant memory appropriate to store a `T`.
     ///

--- a/kernel/src/grant.rs
+++ b/kernel/src/grant.rs
@@ -30,7 +30,7 @@
 //! operation, they can use an `Allocator` to request additional memory from
 //! the process's grant region.
 //!
-//! ```ignore
+//! ```text,ignore
 //!                            ┌──────────────────┐
 //!                            │                  │
 //!                            │ Capsule          │
@@ -79,7 +79,7 @@
 //! Here is an overview of the types used by grant.rs to implement the Grant
 //! functionality in Tock:
 //!
-//! ```ignore
+//! ```text,ignore
 //!                         ┌──────────────────────────┐
 //!                         │ struct Grant<T> {        │
 //!                         │   number: usize          │

--- a/kernel/src/grant.rs
+++ b/kernel/src/grant.rs
@@ -302,7 +302,8 @@ impl<'a, T: Default> ProcessGrant<'a, T> {
         self.process.appid()
     }
 
-    /// Run a function with access to the contents of the grant region.
+    /// Run a function with access to the memory in the related process for the
+    /// related Grant.
     ///
     /// This is "entering" the grant region, and the _only_ time when the
     /// contents of a grant region can be accessed.
@@ -322,9 +323,9 @@ impl<'a, T: Default> ProcessGrant<'a, T> {
         self.access_grant(fun, true).unwrap()
     }
 
-    /// Run a function with access to the contents of the grant region only if
-    /// that grant region is not already entered. If the grant is already
-    /// entered silently skip it.
+    /// Run a function with access to the memory in the related process for the
+    /// related Grant only if that grant region is not already entered. If the
+    /// grant is already entered silently skip it.
     ///
     /// **You almost certainly should use `.enter()` rather than
     /// `.try_enter()`.**
@@ -381,8 +382,9 @@ impl<'a, T: Default> ProcessGrant<'a, T> {
         self.access_grant(fun, false)
     }
 
-    /// Run a function with access to the contents of the grant region and an
-    /// allocator for allocating additional memory in a process's grant region.
+    /// Run a function with access to the memory in the related process for the
+    /// related Grant. Also provide this function with an allocator for
+    /// allocating additional memory in the process's grant region.
     ///
     /// This is "entering" the grant region, and the _only_ time when the
     /// contents of a grant region can be accessed.

--- a/kernel/src/grant.rs
+++ b/kernel/src/grant.rs
@@ -164,6 +164,11 @@ impl<'a, T: 'a + ?Sized> DerefMut for GrantMemory<'a, T> {
 /// process.
 pub struct ProcessGrant<'a, T: 'a> {
     /// The process the grant is applied to.
+    ///
+    /// We use a reference here because instances of `ProcessGrant` are very
+    /// short lived. They only exist while a `Grant` is being entered, so we can
+    /// be sure the process still exists while a `ProcessGrant` exists. No
+    /// `ProcessGrant` can be stored.
     process: &'a dyn ProcessType,
 
     /// The identifier of the Grant this is applied for.
@@ -794,12 +799,13 @@ impl GrantRegionAllocator {
 }
 
 /// Type for storing an object of type T in process memory that is only
-/// accessible by the kernel. A single `Grant` can allocate space one object
-/// of type T for each process on the board. Each object allocated will
-/// come out of the memory region of the process that object is allocated for.
-/// The `Grant` type is used to get access to `ProcessGrant`'s, which are
-/// tied to a specific process and provide access to the memory object allocated
-/// for that process.
+/// accessible by the kernel.
+///
+/// A single `Grant` can allocate space for one object of type T for each
+/// process on the board. Each allocated object will reside in the grant region
+/// belonging to the process that the object is allocated for. The `Grant` type
+/// is used to get access to `ProcessGrant`s, which are tied to a specific
+/// process and provide access to the memory object allocated for that process.
 pub struct Grant<T: Default> {
     /// Hold a reference to the core kernel so we can iterate processes.
     pub(crate) kernel: &'static Kernel,

--- a/kernel/src/grant.rs
+++ b/kernel/src/grant.rs
@@ -30,7 +30,7 @@
 //! operation, they can use an `Allocator` to request additional memory from
 //! the process's grant region.
 //!
-//! ```skip
+//! ```ignore
 //!                            ┌──────────────────┐
 //!                            │                  │
 //!                            │ Capsule          │
@@ -79,7 +79,7 @@
 //! Here is an overview of the types used by grant.rs to implement the Grant
 //! functionality in Tock:
 //!
-//! ```skip
+//! ```ignore
 //!                         ┌──────────────────────────┐
 //!                         │ struct Grant<T> {        │
 //!                         │   number: usize          │
@@ -333,7 +333,7 @@ impl<'a, T: Default> ProcessGrant<'a, T> {
     /// bug in the code and not a condition that should be handled. For example,
     /// this benign looking code is wrong:
     ///
-    /// ```skip
+    /// ```ignore
     /// self.apps.enter(thisapp, |app_grant, _| {
     ///     // Update state in the grant region of `thisapp`. Also, mark that
     ///     // `thisapp` needs to run again.

--- a/kernel/src/grant.rs
+++ b/kernel/src/grant.rs
@@ -748,11 +748,6 @@ impl GrantRegionAllocator {
             }
         }
 
-        // // convert `NonNull<T>` to a fat pointer `NonNull<[T]>` which includes
-        // // the length information. We do this here as initialization is more
-        // // convenient with the non-slice ptr.
-        // let slice_ptr = NonNull::new(slice_from_raw_parts_mut(typed_ptr.as_ptr(), num_items)).unwrap();
-
         Ok(CustomGrant::new(custom_grant_identifier, self.appid))
     }
 

--- a/kernel/src/grant.rs
+++ b/kernel/src/grant.rs
@@ -488,11 +488,9 @@ impl<'a, T: Default> ProcessGrant<'a, T> {
             })
             .ok();
 
-        // # `unwrap()` Safety
-        //
-        // Only `unwrap()` if some, otherwise return early.
-        let grant_ptr = if optional_grant_ptr.is_some() {
-            optional_grant_ptr.unwrap()
+        // Return early if no grant
+        let grant_ptr = if let Some(ptr) = optional_grant_ptr {
+            ptr
         } else {
             return None;
         };

--- a/kernel/src/introspection.rs
+++ b/kernel/src/introspection.rs
@@ -133,18 +133,11 @@ impl KernelInfo {
         // Just need to get the number, this has already been finalized, but it
         // doesn't hurt to call this again.
         let number_of_grants = self.kernel.get_grant_count_and_finalize();
-        let mut used = 0;
-        self.kernel.process_map_or((), app, |process| {
-            for i in 0..number_of_grants {
-                if let Some(grant_ptr) = process.get_grant_ptr(i) {
-                    // If the pointer at that location is not NULL then the
-                    // grant memory has been allocated and the grant is
-                    // being used.
-                    if !(grant_ptr.is_null()) {
-                        used += 1;
-                    }
-                }
-            }
+        let used = self.kernel.process_map_or(0, app, |process| {
+            // Have process tell us the number of allocated grants. If this
+            // process isn't valid then we can't count the grants and all we can
+            // do is return 0.
+            process.grant_allocated_count().unwrap_or(0)
         });
 
         (used, number_of_grants)

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -112,7 +112,7 @@ mod upcall;
 pub use crate::driver::{CommandReturn, Driver};
 pub use crate::errorcode::retcode_into_usize;
 pub use crate::errorcode::ErrorCode;
-pub use crate::grant::{DynamicGrant, Grant};
+pub use crate::grant::{Grant, ProcessGrant};
 pub use crate::mem::{Read, ReadOnlyAppSlice, ReadWrite, ReadWriteAppSlice};
 pub use crate::platform::scheduler_timer::{SchedulerTimer, VirtualSchedulerTimer};
 pub use crate::platform::watchdog;

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -520,11 +520,11 @@ pub trait ProcessType {
     /// Allocate memory from the grant region and store the reference in the
     /// proper grant pointer index.
     ///
-    /// This function must check that the doing the allocation does not cause
+    /// This function must check that doing the allocation does not cause
     /// the kernel memory break to go below the top of the process accessible
     /// memory region allowed by the MPU. Note, this can be different from the
     /// actual app_brk, as MPU alignment and size constraints may result in the
-    /// PMP enforced region differing from the app_brk.
+    /// MPU enforced region differing from the app_brk.
     ///
     /// This will return `None` and fail if:
     /// - The process is inactive, or
@@ -997,7 +997,8 @@ pub struct Process<'a, C: 'static + Chip> {
     /// Reference to the slice of pointers stored in the process's memory
     /// reserved for the kernel. These pointers are null if the grant region has
     /// not been allocated. When the grant region is allocated these pointers
-    /// are updated to point to the allocated memory.
+    /// are updated to point to the allocated memory. No other reference to these
+    /// pointers exists in the Tock kernel.
     grant_pointers: MapCell<&'static mut [*mut u8]>,
 
     /// Pointer to the end of the allocated (and MPU protected) grant region.


### PR DESCRIPTION
### Pull Request Overview

This PR is motivated by:

1. The interface for grants between process.rs (which owns the actual memory for the grant region) and grant.rs (which manages the interface for grants presented to capsules) is full of `unsafe` functions, and requires both sides to be very careful to ensure that all the unsafe calls are actually OK. Also the interface that process.rs exposes is very low level, and essentially provides direct memory access to a process's memory.
2. The protections to avoid entering a grant twice had a hole, and doing `app = grant.iter()` -> `grant.enter(appid)` -> `app.enter()` would still allow a grant to be entered twice.

The new interface encapsulates the unsafety and makes it clear what the expectations are. Process now better manages the grant memory and verifies that the memory is being handled correctly.

This turned into really a full re-write of the interface.

#### Specific Notable Changes

- Double grant entry is checked on `.enter()` and not when the grant is allocated. This makes the logic more robust and avoids loopholes like the one described above. To do this, process.rs now handles enter/leave tracking.
- `.iter_skip_unentered()` has been replaced with `.enter_if_unentered()`. Since double entry is tracked on enter, the iterator cannot guarantee it is providing all unentered grants. Note: it is very unlikely anyone should use `.enter_if_unentered()`. If you notice it in a PR you should ask for an explanation and a comment if one isn't there.
- `Borrowed` no longer has a (random) `.appid()` interface. It seemed strange to me that the actual grant memory had this bonus function, rather than just the AppliedGrant. This change required changing `.each()` to use the closure `fn (AppId, Borrowed)` so that capsules can still get the appid.
- Dynamic grants are managed by Process as well. Before, dynamic grants stored the raw pointer and an AppId. Having the AppId meant that grant.rs could check the process still exists before using the pointer. However, it could not check that the dynamic grant had not been free()d or if the process memory is still valid. Now, using a dynamic grant requires going through Process, so all relevant checks can occur.


### Testing Strategy

Running various apps.

I also created a capsule test which verifies that in three different cases the board panics if a double grant is entered.


### TODO or Help Wanted

I need help with Rust on arrays of dynamic grants. You can see it commented out in the diff. I couldn't figure out how to get the pointer casts to work correctly.


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
