### PR TITLE
Define StatusCode which uses ErrorCode's numeric encoding

### DIFF
--- a/capsules/src/ble_advertising_driver.rs
+++ b/capsules/src/ble_advertising_driver.rs
@@ -469,7 +469,7 @@ where
 
                     if success {
                         app.scan_callback.schedule(
-                            kernel::retcode_into_usize(result),
+                            kernel::into_returncode(result),
                             len as usize,
                             0,
                         );

--- a/capsules/src/ble_advertising_driver.rs
+++ b/capsules/src/ble_advertising_driver.rs
@@ -469,7 +469,7 @@ where
 
                     if success {
                         app.scan_callback.schedule(
-                            kernel::into_returncode(result),
+                            kernel::into_statuscode(result),
                             len as usize,
                             0,
                         );

--- a/capsules/src/console.rs
+++ b/capsules/src/console.rs
@@ -338,7 +338,7 @@ impl uart::TransmitClient for Console<'_> {
                         app.write_remaining = 0;
                         app.pending_write = false;
                         app.write_callback
-                            .schedule(kernel::retcode_into_usize(return_code), 0, 0);
+                            .schedule(kernel::into_returncode(return_code), 0, 0);
                     }
                 }
             })
@@ -359,7 +359,7 @@ impl uart::TransmitClient for Console<'_> {
                                 app.write_remaining = 0;
                                 app.pending_write = false;
                                 app.write_callback.schedule(
-                                    kernel::retcode_into_usize(return_code),
+                                    kernel::into_returncode(return_code),
                                     0,
                                     0,
                                 );
@@ -440,7 +440,7 @@ impl uart::ReceiveClient for Console<'_> {
                                 };
 
                                 app.read_callback.schedule(
-                                    kernel::retcode_into_usize(ret),
+                                    kernel::into_returncode(ret),
                                     received_length,
                                     0,
                                 );
@@ -448,7 +448,7 @@ impl uart::ReceiveClient for Console<'_> {
                             _ => {
                                 // Some UART error occurred
                                 app.read_callback.schedule(
-                                    kernel::retcode_into_usize(Err(ErrorCode::FAIL)),
+                                    kernel::into_returncode(Err(ErrorCode::FAIL)),
                                     0,
                                     0,
                                 );

--- a/capsules/src/console.rs
+++ b/capsules/src/console.rs
@@ -338,7 +338,7 @@ impl uart::TransmitClient for Console<'_> {
                         app.write_remaining = 0;
                         app.pending_write = false;
                         app.write_callback
-                            .schedule(kernel::into_returncode(return_code), 0, 0);
+                            .schedule(kernel::into_statuscode(return_code), 0, 0);
                     }
                 }
             })
@@ -359,7 +359,7 @@ impl uart::TransmitClient for Console<'_> {
                                 app.write_remaining = 0;
                                 app.pending_write = false;
                                 app.write_callback.schedule(
-                                    kernel::into_returncode(return_code),
+                                    kernel::into_statuscode(return_code),
                                     0,
                                     0,
                                 );
@@ -440,7 +440,7 @@ impl uart::ReceiveClient for Console<'_> {
                                 };
 
                                 app.read_callback.schedule(
-                                    kernel::into_returncode(ret),
+                                    kernel::into_statuscode(ret),
                                     received_length,
                                     0,
                                 );
@@ -448,7 +448,7 @@ impl uart::ReceiveClient for Console<'_> {
                             _ => {
                                 // Some UART error occurred
                                 app.read_callback.schedule(
-                                    kernel::into_returncode(Err(ErrorCode::FAIL)),
+                                    kernel::into_statuscode(Err(ErrorCode::FAIL)),
                                     0,
                                     0,
                                 );

--- a/capsules/src/crc.rs
+++ b/capsules/src/crc.rs
@@ -140,8 +140,7 @@ impl<'a, C: hil::crc::CRC<'a>> Crc<'a, C> {
                         found = true;
                     } else {
                         // The app's request failed
-                        app.callback
-                            .schedule(kernel::retcode_into_usize(rcode), 0, 0);
+                        app.callback.schedule(kernel::into_returncode(rcode), 0, 0);
                         app.waiting = None;
                     }
                 }
@@ -343,7 +342,7 @@ impl<'a, C: hil::crc::CRC<'a>> hil::crc::Client for Crc<'a, C> {
                 .apps
                 .enter(appid, |app, _| {
                     app.callback
-                        .schedule(kernel::retcode_into_usize(Ok(())), result as usize, 0);
+                        .schedule(kernel::into_returncode(Ok(())), result as usize, 0);
                     app.waiting = None;
                     Ok(())
                 })

--- a/capsules/src/crc.rs
+++ b/capsules/src/crc.rs
@@ -140,7 +140,7 @@ impl<'a, C: hil::crc::CRC<'a>> Crc<'a, C> {
                         found = true;
                     } else {
                         // The app's request failed
-                        app.callback.schedule(kernel::into_returncode(rcode), 0, 0);
+                        app.callback.schedule(kernel::into_statuscode(rcode), 0, 0);
                         app.waiting = None;
                     }
                 }
@@ -342,7 +342,7 @@ impl<'a, C: hil::crc::CRC<'a>> hil::crc::Client for Crc<'a, C> {
                 .apps
                 .enter(appid, |app, _| {
                     app.callback
-                        .schedule(kernel::into_returncode(Ok(())), result as usize, 0);
+                        .schedule(kernel::into_statuscode(Ok(())), result as usize, 0);
                     app.waiting = None;
                     Ok(())
                 })

--- a/capsules/src/hmac.rs
+++ b/capsules/src/hmac.rs
@@ -220,7 +220,7 @@ impl<'a, H: digest::Digest<'a, T> + digest::HMACSha256, T: DigestType> digest::C
                         self.appid.clear();
 
                         app.callback
-                            .schedule(kernel::into_returncode(e.0.into()), 0, 0);
+                            .schedule(kernel::into_statuscode(e.0.into()), 0, 0);
 
                         self.check_queue();
                         return;
@@ -252,7 +252,7 @@ impl<'a, H: digest::Digest<'a, T> + digest::HMACSha256, T: DigestType> digest::C
                     match result {
                         Ok(_) => app.callback.schedule(0, pointer as usize, 0),
                         Err(e) => app.callback.schedule(
-                            kernel::into_returncode(e.into()),
+                            kernel::into_statuscode(e.into()),
                             pointer as usize,
                             0,
                         ),

--- a/capsules/src/hmac.rs
+++ b/capsules/src/hmac.rs
@@ -220,7 +220,7 @@ impl<'a, H: digest::Digest<'a, T> + digest::HMACSha256, T: DigestType> digest::C
                         self.appid.clear();
 
                         app.callback
-                            .schedule(kernel::retcode_into_usize(e.0.into()), 0, 0);
+                            .schedule(kernel::into_returncode(e.0.into()), 0, 0);
 
                         self.check_queue();
                         return;
@@ -252,7 +252,7 @@ impl<'a, H: digest::Digest<'a, T> + digest::HMACSha256, T: DigestType> digest::C
                     match result {
                         Ok(_) => app.callback.schedule(0, pointer as usize, 0),
                         Err(e) => app.callback.schedule(
-                            kernel::retcode_into_usize(e.into()),
+                            kernel::into_returncode(e.into()),
                             pointer as usize,
                             0,
                         ),

--- a/capsules/src/ieee802154/driver.rs
+++ b/capsules/src/ieee802154/driver.rs
@@ -468,7 +468,7 @@ impl DynamicDeferredCallClient for RadioDriver<'_> {
             .apps
             .enter(self.saved_appid.expect("missing appid"), |app, _| {
                 app.tx_callback.schedule(
-                    kernel::into_returncode(self.saved_result.expect("missing result")),
+                    kernel::into_statuscode(self.saved_result.expect("missing result")),
                     0,
                     0,
                 );
@@ -877,7 +877,7 @@ impl device::TxClient for RadioDriver<'_> {
         self.current_app.take().map(|appid| {
             let _ = self.apps.enter(appid, |app, _| {
                 app.tx_callback
-                    .schedule(kernel::into_returncode(result), acked as usize, 0);
+                    .schedule(kernel::into_statuscode(result), acked as usize, 0);
             });
         });
         self.do_next_tx_async();

--- a/capsules/src/ieee802154/driver.rs
+++ b/capsules/src/ieee802154/driver.rs
@@ -468,7 +468,7 @@ impl DynamicDeferredCallClient for RadioDriver<'_> {
             .apps
             .enter(self.saved_appid.expect("missing appid"), |app, _| {
                 app.tx_callback.schedule(
-                    kernel::retcode_into_usize(self.saved_result.expect("missing result")),
+                    kernel::into_returncode(self.saved_result.expect("missing result")),
                     0,
                     0,
                 );
@@ -877,7 +877,7 @@ impl device::TxClient for RadioDriver<'_> {
         self.current_app.take().map(|appid| {
             let _ = self.apps.enter(appid, |app, _| {
                 app.tx_callback
-                    .schedule(kernel::retcode_into_usize(result), acked as usize, 0);
+                    .schedule(kernel::into_returncode(result), acked as usize, 0);
             });
         });
         self.do_next_tx_async();

--- a/capsules/src/max17205.rs
+++ b/capsules/src/max17205.rs
@@ -382,7 +382,7 @@ impl<'a> MAX17205Driver<'a> {
 impl MAX17205Client for MAX17205Driver<'_> {
     fn status(&self, status: u16, error: Result<(), ErrorCode>) {
         self.callback
-            .map(|cb| cb.schedule(kernel::into_returncode(error), status as usize, 0));
+            .map(|cb| cb.schedule(kernel::into_statuscode(error), status as usize, 0));
     }
 
     fn state_of_charge(
@@ -394,7 +394,7 @@ impl MAX17205Client for MAX17205Driver<'_> {
     ) {
         self.callback.map(|cb| {
             cb.schedule(
-                kernel::into_returncode(error),
+                kernel::into_statuscode(error),
                 percent as usize,
                 (capacity as usize) << 16 | (full_capacity as usize),
             );
@@ -404,7 +404,7 @@ impl MAX17205Client for MAX17205Driver<'_> {
     fn voltage_current(&self, voltage: u16, current: u16, error: Result<(), ErrorCode>) {
         self.callback.map(|cb| {
             cb.schedule(
-                kernel::into_returncode(error),
+                kernel::into_statuscode(error),
                 voltage as usize,
                 current as usize,
             )
@@ -413,13 +413,13 @@ impl MAX17205Client for MAX17205Driver<'_> {
 
     fn coulomb(&self, coulomb: u16, error: Result<(), ErrorCode>) {
         self.callback
-            .map(|cb| cb.schedule(kernel::into_returncode(error), coulomb as usize, 0));
+            .map(|cb| cb.schedule(kernel::into_statuscode(error), coulomb as usize, 0));
     }
 
     fn romid(&self, rid: u64, error: Result<(), ErrorCode>) {
         self.callback.map(|cb| {
             cb.schedule(
-                kernel::into_returncode(error),
+                kernel::into_statuscode(error),
                 (rid & 0xffffffff) as usize,
                 (rid >> 32) as usize,
             )

--- a/capsules/src/max17205.rs
+++ b/capsules/src/max17205.rs
@@ -382,7 +382,7 @@ impl<'a> MAX17205Driver<'a> {
 impl MAX17205Client for MAX17205Driver<'_> {
     fn status(&self, status: u16, error: Result<(), ErrorCode>) {
         self.callback
-            .map(|cb| cb.schedule(kernel::retcode_into_usize(error), status as usize, 0));
+            .map(|cb| cb.schedule(kernel::into_returncode(error), status as usize, 0));
     }
 
     fn state_of_charge(
@@ -394,7 +394,7 @@ impl MAX17205Client for MAX17205Driver<'_> {
     ) {
         self.callback.map(|cb| {
             cb.schedule(
-                kernel::retcode_into_usize(error),
+                kernel::into_returncode(error),
                 percent as usize,
                 (capacity as usize) << 16 | (full_capacity as usize),
             );
@@ -404,7 +404,7 @@ impl MAX17205Client for MAX17205Driver<'_> {
     fn voltage_current(&self, voltage: u16, current: u16, error: Result<(), ErrorCode>) {
         self.callback.map(|cb| {
             cb.schedule(
-                kernel::retcode_into_usize(error),
+                kernel::into_returncode(error),
                 voltage as usize,
                 current as usize,
             )
@@ -413,13 +413,13 @@ impl MAX17205Client for MAX17205Driver<'_> {
 
     fn coulomb(&self, coulomb: u16, error: Result<(), ErrorCode>) {
         self.callback
-            .map(|cb| cb.schedule(kernel::retcode_into_usize(error), coulomb as usize, 0));
+            .map(|cb| cb.schedule(kernel::into_returncode(error), coulomb as usize, 0));
     }
 
     fn romid(&self, rid: u64, error: Result<(), ErrorCode>) {
         self.callback.map(|cb| {
             cb.schedule(
-                kernel::retcode_into_usize(error),
+                kernel::into_returncode(error),
                 (rid & 0xffffffff) as usize,
                 (rid >> 32) as usize,
             )

--- a/capsules/src/net/udp/driver.rs
+++ b/capsules/src/net/udp/driver.rs
@@ -170,7 +170,7 @@ impl<'a> UDPDriver<'a> {
         if result != Ok(()) {
             let _ = self.apps.enter(appid, |app, _| {
                 app.tx_callback
-                    .schedule(kernel::retcode_into_usize(result), 0, 0);
+                    .schedule(kernel::into_returncode(result), 0, 0);
             });
         }
     }
@@ -603,7 +603,7 @@ impl<'a> UDPSendClient for UDPDriver<'a> {
         self.current_app.get().map(|appid| {
             let _ = self.apps.enter(appid, |app, _| {
                 app.tx_callback
-                    .schedule(kernel::retcode_into_usize(result), 0, 0);
+                    .schedule(kernel::into_returncode(result), 0, 0);
             });
         });
         self.current_app.set(None);

--- a/capsules/src/net/udp/driver.rs
+++ b/capsules/src/net/udp/driver.rs
@@ -170,7 +170,7 @@ impl<'a> UDPDriver<'a> {
         if result != Ok(()) {
             let _ = self.apps.enter(appid, |app, _| {
                 app.tx_callback
-                    .schedule(kernel::into_returncode(result), 0, 0);
+                    .schedule(kernel::into_statuscode(result), 0, 0);
             });
         }
     }
@@ -603,7 +603,7 @@ impl<'a> UDPSendClient for UDPDriver<'a> {
         self.current_app.get().map(|appid| {
             let _ = self.apps.enter(appid, |app, _| {
                 app.tx_callback
-                    .schedule(kernel::into_returncode(result), 0, 0);
+                    .schedule(kernel::into_statuscode(result), 0, 0);
             });
         });
         self.current_app.set(None);

--- a/capsules/src/screen.rs
+++ b/capsules/src/screen.rs
@@ -197,7 +197,7 @@ impl<'a> Screen<'a> {
             }
             ScreenCommand::GetRotation => {
                 let rotation = self.screen.get_rotation();
-                self.run_next_command(kernel::into_returncode(Ok(())), rotation as usize, 0);
+                self.run_next_command(kernel::into_statuscode(Ok(())), rotation as usize, 0);
                 Ok(())
             }
             ScreenCommand::SetResolution => {
@@ -209,7 +209,7 @@ impl<'a> Screen<'a> {
             }
             ScreenCommand::GetResolution => {
                 let (width, height) = self.screen.get_resolution();
-                self.run_next_command(kernel::into_returncode(Ok(())), width, height);
+                self.run_next_command(kernel::into_statuscode(Ok(())), width, height);
                 Ok(())
             }
             ScreenCommand::SetPixelFormat => {
@@ -225,13 +225,13 @@ impl<'a> Screen<'a> {
             }
             ScreenCommand::GetPixelFormat => {
                 let pixel_format = self.screen.get_pixel_format();
-                self.run_next_command(kernel::into_returncode(Ok(())), pixel_format as usize, 0);
+                self.run_next_command(kernel::into_statuscode(Ok(())), pixel_format as usize, 0);
                 Ok(())
             }
             ScreenCommand::GetSupportedResolutionModes => {
                 if let Some(screen) = self.screen_setup {
                     let resolution_modes = screen.get_num_supported_resolutions();
-                    self.run_next_command(kernel::into_returncode(Ok(())), resolution_modes, 0);
+                    self.run_next_command(kernel::into_statuscode(Ok(())), resolution_modes, 0);
                     Ok(())
                 } else {
                     Err(ErrorCode::NOSUPPORT)
@@ -241,7 +241,7 @@ impl<'a> Screen<'a> {
                 if let Some(screen) = self.screen_setup {
                     if let Some((width, height)) = screen.get_supported_resolution(data1) {
                         self.run_next_command(
-                            kernel::into_returncode(if width > 0 && height > 0 {
+                            kernel::into_statuscode(if width > 0 && height > 0 {
                                 Ok(())
                             } else {
                                 Err(ErrorCode::INVAL)
@@ -260,7 +260,7 @@ impl<'a> Screen<'a> {
             ScreenCommand::GetSupportedPixelFormats => {
                 if let Some(screen) = self.screen_setup {
                     let color_modes = screen.get_num_supported_pixel_formats();
-                    self.run_next_command(kernel::into_returncode(Ok(())), color_modes, 0);
+                    self.run_next_command(kernel::into_statuscode(Ok(())), color_modes, 0);
                     Ok(())
                 } else {
                     Err(ErrorCode::NOSUPPORT)
@@ -270,7 +270,7 @@ impl<'a> Screen<'a> {
                 if let Some(screen) = self.screen_setup {
                     if let Some(pixel_format) = screen.get_supported_pixel_format(data1) {
                         self.run_next_command(
-                            kernel::into_returncode(Ok(())),
+                            kernel::into_statuscode(Ok(())),
                             pixel_format as usize,
                             0,
                         );
@@ -302,7 +302,7 @@ impl<'a> Screen<'a> {
                                     self.screen.write(buffer, len)
                                 } else {
                                     self.buffer.replace(buffer);
-                                    self.run_next_command(kernel::into_returncode(Ok(())), 0, 0);
+                                    self.run_next_command(kernel::into_statuscode(Ok(())), 0, 0);
                                     Ok(())
                                 }
                             })
@@ -334,7 +334,7 @@ impl<'a> Screen<'a> {
                                 self.screen.write(buffer, len)
                             } else {
                                 self.buffer.replace(buffer);
-                                self.run_next_command(kernel::into_returncode(Ok(())), 0, 0);
+                                self.run_next_command(kernel::into_statuscode(Ok(())), 0, 0);
                                 Ok(())
                             }
                         })
@@ -473,7 +473,7 @@ impl<'a> Screen<'a> {
 
 impl<'a> hil::screen::ScreenClient for Screen<'a> {
     fn command_complete(&self, r: Result<(), ErrorCode>) {
-        self.run_next_command(kernel::into_returncode(r), 0, 0);
+        self.run_next_command(kernel::into_statuscode(r), 0, 0);
     }
 
     fn write_complete(&self, buffer: &'static mut [u8], r: Result<(), ErrorCode>) {
@@ -483,18 +483,18 @@ impl<'a> hil::screen::ScreenClient for Screen<'a> {
             let _ = self.screen.write_continue(buffer, len);
         } else {
             self.buffer.replace(buffer);
-            self.run_next_command(kernel::into_returncode(r), 0, 0);
+            self.run_next_command(kernel::into_statuscode(r), 0, 0);
         }
     }
 
     fn screen_is_ready(&self) {
-        self.run_next_command(kernel::into_returncode(Ok(())), 0, 0);
+        self.run_next_command(kernel::into_statuscode(Ok(())), 0, 0);
     }
 }
 
 impl<'a> hil::screen::ScreenSetupClient for Screen<'a> {
     fn command_complete(&self, r: Result<(), ErrorCode>) {
-        self.run_next_command(kernel::into_returncode(r), 0, 0);
+        self.run_next_command(kernel::into_statuscode(r), 0, 0);
     }
 }
 

--- a/capsules/src/screen.rs
+++ b/capsules/src/screen.rs
@@ -197,7 +197,7 @@ impl<'a> Screen<'a> {
             }
             ScreenCommand::GetRotation => {
                 let rotation = self.screen.get_rotation();
-                self.run_next_command(kernel::retcode_into_usize(Ok(())), rotation as usize, 0);
+                self.run_next_command(kernel::into_returncode(Ok(())), rotation as usize, 0);
                 Ok(())
             }
             ScreenCommand::SetResolution => {
@@ -209,7 +209,7 @@ impl<'a> Screen<'a> {
             }
             ScreenCommand::GetResolution => {
                 let (width, height) = self.screen.get_resolution();
-                self.run_next_command(kernel::retcode_into_usize(Ok(())), width, height);
+                self.run_next_command(kernel::into_returncode(Ok(())), width, height);
                 Ok(())
             }
             ScreenCommand::SetPixelFormat => {
@@ -225,13 +225,13 @@ impl<'a> Screen<'a> {
             }
             ScreenCommand::GetPixelFormat => {
                 let pixel_format = self.screen.get_pixel_format();
-                self.run_next_command(kernel::retcode_into_usize(Ok(())), pixel_format as usize, 0);
+                self.run_next_command(kernel::into_returncode(Ok(())), pixel_format as usize, 0);
                 Ok(())
             }
             ScreenCommand::GetSupportedResolutionModes => {
                 if let Some(screen) = self.screen_setup {
                     let resolution_modes = screen.get_num_supported_resolutions();
-                    self.run_next_command(kernel::retcode_into_usize(Ok(())), resolution_modes, 0);
+                    self.run_next_command(kernel::into_returncode(Ok(())), resolution_modes, 0);
                     Ok(())
                 } else {
                     Err(ErrorCode::NOSUPPORT)
@@ -241,7 +241,7 @@ impl<'a> Screen<'a> {
                 if let Some(screen) = self.screen_setup {
                     if let Some((width, height)) = screen.get_supported_resolution(data1) {
                         self.run_next_command(
-                            kernel::retcode_into_usize(if width > 0 && height > 0 {
+                            kernel::into_returncode(if width > 0 && height > 0 {
                                 Ok(())
                             } else {
                                 Err(ErrorCode::INVAL)
@@ -260,7 +260,7 @@ impl<'a> Screen<'a> {
             ScreenCommand::GetSupportedPixelFormats => {
                 if let Some(screen) = self.screen_setup {
                     let color_modes = screen.get_num_supported_pixel_formats();
-                    self.run_next_command(kernel::retcode_into_usize(Ok(())), color_modes, 0);
+                    self.run_next_command(kernel::into_returncode(Ok(())), color_modes, 0);
                     Ok(())
                 } else {
                     Err(ErrorCode::NOSUPPORT)
@@ -270,7 +270,7 @@ impl<'a> Screen<'a> {
                 if let Some(screen) = self.screen_setup {
                     if let Some(pixel_format) = screen.get_supported_pixel_format(data1) {
                         self.run_next_command(
-                            kernel::retcode_into_usize(Ok(())),
+                            kernel::into_returncode(Ok(())),
                             pixel_format as usize,
                             0,
                         );
@@ -302,7 +302,7 @@ impl<'a> Screen<'a> {
                                     self.screen.write(buffer, len)
                                 } else {
                                     self.buffer.replace(buffer);
-                                    self.run_next_command(kernel::retcode_into_usize(Ok(())), 0, 0);
+                                    self.run_next_command(kernel::into_returncode(Ok(())), 0, 0);
                                     Ok(())
                                 }
                             })
@@ -334,7 +334,7 @@ impl<'a> Screen<'a> {
                                 self.screen.write(buffer, len)
                             } else {
                                 self.buffer.replace(buffer);
-                                self.run_next_command(kernel::retcode_into_usize(Ok(())), 0, 0);
+                                self.run_next_command(kernel::into_returncode(Ok(())), 0, 0);
                                 Ok(())
                             }
                         })
@@ -473,7 +473,7 @@ impl<'a> Screen<'a> {
 
 impl<'a> hil::screen::ScreenClient for Screen<'a> {
     fn command_complete(&self, r: Result<(), ErrorCode>) {
-        self.run_next_command(kernel::retcode_into_usize(r), 0, 0);
+        self.run_next_command(kernel::into_returncode(r), 0, 0);
     }
 
     fn write_complete(&self, buffer: &'static mut [u8], r: Result<(), ErrorCode>) {
@@ -483,18 +483,18 @@ impl<'a> hil::screen::ScreenClient for Screen<'a> {
             let _ = self.screen.write_continue(buffer, len);
         } else {
             self.buffer.replace(buffer);
-            self.run_next_command(kernel::retcode_into_usize(r), 0, 0);
+            self.run_next_command(kernel::into_returncode(r), 0, 0);
         }
     }
 
     fn screen_is_ready(&self) {
-        self.run_next_command(kernel::retcode_into_usize(Ok(())), 0, 0);
+        self.run_next_command(kernel::into_returncode(Ok(())), 0, 0);
     }
 }
 
 impl<'a> hil::screen::ScreenSetupClient for Screen<'a> {
     fn command_complete(&self, r: Result<(), ErrorCode>) {
-        self.run_next_command(kernel::retcode_into_usize(r), 0, 0);
+        self.run_next_command(kernel::into_returncode(r), 0, 0);
     }
 }
 

--- a/capsules/src/text_screen.rs
+++ b/capsules/src/text_screen.rs
@@ -130,7 +130,7 @@ impl<'a> TextScreen<'a> {
         match command {
             TextScreenCommand::GetResolution => {
                 let (x, y) = self.text_screen.get_size();
-                self.schedule_callback(kernel::into_returncode(Ok(())), x, y);
+                self.schedule_callback(kernel::into_statuscode(Ok(())), x, y);
                 self.run_next_command();
                 Ok(())
             }
@@ -293,13 +293,13 @@ impl<'a> Driver for TextScreen<'a> {
 
 impl<'a> hil::text_screen::TextScreenClient for TextScreen<'a> {
     fn command_complete(&self, r: Result<(), ErrorCode>) {
-        self.schedule_callback(kernel::into_returncode(r), 0, 0);
+        self.schedule_callback(kernel::into_statuscode(r), 0, 0);
         self.run_next_command();
     }
 
     fn write_complete(&self, buffer: &'static mut [u8], len: usize, r: Result<(), ErrorCode>) {
         self.buffer.replace(buffer);
-        self.schedule_callback(kernel::into_returncode(r), len, 0);
+        self.schedule_callback(kernel::into_statuscode(r), len, 0);
         self.run_next_command();
     }
 }

--- a/capsules/src/text_screen.rs
+++ b/capsules/src/text_screen.rs
@@ -130,7 +130,7 @@ impl<'a> TextScreen<'a> {
         match command {
             TextScreenCommand::GetResolution => {
                 let (x, y) = self.text_screen.get_size();
-                self.schedule_callback(kernel::retcode_into_usize(Ok(())), x, y);
+                self.schedule_callback(kernel::into_returncode(Ok(())), x, y);
                 self.run_next_command();
                 Ok(())
             }
@@ -293,13 +293,13 @@ impl<'a> Driver for TextScreen<'a> {
 
 impl<'a> hil::text_screen::TextScreenClient for TextScreen<'a> {
     fn command_complete(&self, r: Result<(), ErrorCode>) {
-        self.schedule_callback(kernel::retcode_into_usize(r), 0, 0);
+        self.schedule_callback(kernel::into_returncode(r), 0, 0);
         self.run_next_command();
     }
 
     fn write_complete(&self, buffer: &'static mut [u8], len: usize, r: Result<(), ErrorCode>) {
         self.buffer.replace(buffer);
-        self.schedule_callback(kernel::retcode_into_usize(r), len, 0);
+        self.schedule_callback(kernel::into_returncode(r), len, 0);
         self.run_next_command();
     }
 }

--- a/capsules/src/usb/usb_user.rs
+++ b/capsules/src/usb/usb_user.rs
@@ -77,7 +77,7 @@ where
                             self.usbc_client.attach();
 
                             // Schedule a callback immediately
-                            app.callback.schedule(0, 0, 0);
+                            app.callback.schedule(kernel::into_statuscode(Ok(())), 0, 0);
                             app.awaiting = None;
                         }
                     }

--- a/doc/Syscalls.md
+++ b/doc/Syscalls.md
@@ -3,9 +3,9 @@ Syscalls
 
 This document explains how [system
 calls](https://en.wikipedia.org/wiki/System_call) work in Tock with regards
-to both the kernel and applications. [TRD104](reference/trd-syscalls.md) contains 
+to both the kernel and applications. [TRD104](reference/trd-syscalls.md) contains
 the more formal specification
-of the system call API and ABI for 32-bit systems. 
+of the system call API and ABI for 32-bit systems.
 This document describes the considerations behind the system call design.
 
 <!-- toc -->
@@ -19,6 +19,9 @@ This document describes the considerations behind the system call design.
   * [Cortex-M Architecture Details](#cortex-m-architecture-details)
   * [RISC-V Architecture Details](#risc-v-architecture-details)
 - [How System Calls Connect to Drivers](#how-system-calls-connect-to-drivers)
+- [Error and Return Types](#error-and-return-types)
+  * [Naming Conventions](#naming-conventions)
+  * [Type Descriptions](#type-descriptions)
 - [Allocated Driver Numbers](#allocated-driver-numbers)
 
 <!-- tocstop -->
@@ -43,7 +46,7 @@ modes](http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dui0553a/CHDI
 
 Second, context switching to the kernel allows it to do other resource handling
 before returning to the application. This could include running other
-applications, servicing queued upcalls, or many other activities. 
+applications, servicing queued upcalls, or many other activities.
 
 Finally,
 and most importantly, using system calls allows applications to be built
@@ -58,30 +61,31 @@ version uploaded, all without modifying the kernel running on a platform.
 
 In Tock, a process can be in one of seven states:
 
- - **Running**: Normal operation. A Running process is eligible to be scheduled
- for execution, although is subject to being paused by Tock to allow interrupt
- handlers or other processes to run. During normal operation, a process remains
- in the Running state until it explicitly yields. Upcalls from other kernel
- operations are not delivered to Running processes (i.e. upcalls do not
- interrupt processes), rather they are enqueued until the process yields.
- - **Yielded**: Suspended operation. A Yielded process will not be scheduled by
- Tock. Processes often yield while they are waiting for I/O or other operations
- to complete and have no immediately useful work to do. Whenever the kernel issues
- an upcall to a Yielded process, the process is transitioned to the Running state.
- - **Fault**: Erroneous operation. A Fault-ed process will not be scheduled by
- Tock. Processes enter the Fault state by performing an illegal operation, such
- as accessing memory outside of their address space.
- - **Terminated** The process ended itself by calling the `Exit` system call and
- the kernel has not restarted it.
- - **Unstarted** The process has not yet started; this state is typically very 
- short-lived, between process loading and it started. However, in cases when
- processes might be loaded for a long time without running, this state might
- be long-lived.
- - **StoppedRunning**, **StoppedYielded** These states correspond to a process
- that was in either the Running or Yielded state but was then explicitly stopped
- by the kernel (e.g., by the process console). A process in these states will not
- be made runnable until it is restarted, at which point it will continue execution
- where it was stopped.
+- **Running**: Normal operation. A Running process is eligible to be scheduled
+  for execution, although is subject to being paused by Tock to allow interrupt
+  handlers or other processes to run. During normal operation, a process remains
+  in the Running state until it explicitly yields. Upcalls from other kernel
+  operations are not delivered to Running processes (i.e. upcalls do not
+  interrupt processes), rather they are enqueued until the process yields.
+- **Yielded**: Suspended operation. A Yielded process will not be scheduled by
+  Tock. Processes often yield while they are waiting for I/O or other operations
+  to complete and have no immediately useful work to do. Whenever the kernel
+  issues an upcall to a Yielded process, the process is transitioned to the
+  Running state.
+- **Fault**: Erroneous operation. A Fault-ed process will not be scheduled by
+  Tock. Processes enter the Fault state by performing an illegal operation, such
+  as accessing memory outside of their address space.
+- **Terminated** The process ended itself by calling the `Exit` system call and
+  the kernel has not restarted it.
+- **Unstarted** The process has not yet started; this state is typically very
+  short-lived, between process loading and it started. However, in cases when
+  processes might be loaded for a long time without running, this state might be
+  long-lived.
+- **StoppedRunning**, **StoppedYielded** These states correspond to a process
+  that was in either the Running or Yielded state but was then explicitly
+  stopped by the kernel (e.g., by the process console). A process in these
+  states will not be made runnable until it is restarted, at which point it will
+  continue execution where it was stopped.
 
 ## Startup
 
@@ -263,7 +267,42 @@ number 0. Any `command`, `subscribe`, and `allow` sycalls to driver number 0
 will get routed to the console, and all other driver numbers will return
 `Err(ErrorCode::NODEVICE)`.
 
+## Error and Return Types
 
+Tock includes some defined types and conventions for errors and return values
+between the kernel and userspace.
+
+### Naming Conventions
+
+- `*Code` (e.g. `ErrorCode`, `StatusCode`): These types are mappings between
+  numeric values and semantic meanings. These can always be encoded in a
+  `usize`.
+- `*Return` (e.g. `SyscallReturn`): These are more complex return types that can
+  include arbitrary values, errors, or `*Code` types.
+
+### Type Descriptions
+
+- `*Code` Types:
+  - `ErrorCode`: A standard set of errors and their numeric representations in
+    Tock.  This is used to represent errors for syscalls, and elsewhere in the
+    kernel.
+  - `StatusCode`: All errors in `ErrorCode` plus a Success value (represented by
+    0). This is used to pass a success/error status between the kernel and
+    userspace.
+
+    `StatusCode` is a pseudotype that is not actually defined as a concrete Rust
+    type. Instead, it is always encoded as a `usize`. Even though it is not a
+    concrete type, it is useful to be able to return to it conceptually, so we
+    give it the name `StatusCode`.
+
+    The intended use of `StatusCode` is to convey success/failure to userspace
+    in upcalls. To try to keep things simple, we use the same numeric
+    representations in `StatusCode` as we do with `ErrorCode`.
+
+- `*Return` Types:
+  - `SyscallReturn`: The return type for a syscall. Includes whether the syscall
+    succeeded or failed, optionally additional data values, and in the case of
+    failure an `ErrorCode`.
 
 ## Allocated Driver Numbers
 

--- a/kernel/src/errorcode.rs
+++ b/kernel/src/errorcode.rs
@@ -4,10 +4,10 @@ use core::convert::TryFrom;
 
 /// Standard errors in Tock.
 ///
-/// In contrast to [`Result<(), ErrorCode>`](crate::Result<(), ErrorCode>) this does not
-/// feature any success cases and is therefore more approriate for the
-/// Tock 2.0 system call interface, where success payloads and errors
-/// are not packed into the same 32-bit wide register.
+/// In contrast to [`Result<(), ErrorCode>`](crate::Result<(), ErrorCode>) this
+/// does not feature any success cases and is therefore more appropriate for the
+/// Tock 2.0 system call interface, where success payloads and errors are not
+/// packed into the same 32-bit wide register.
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[repr(usize)]
 pub enum ErrorCode {
@@ -92,24 +92,19 @@ impl From<ErrorCode> for Result<(), ErrorCode> {
     }
 }
 
-pub fn retcode_into_usize(original: Result<(), ErrorCode>) -> usize {
-    let out = match original {
+/// Convert a `Result<(), ErrorCode>` to a ReturnCode (usize) for userspace.
+///
+/// This helper function converts the Tock and Rust convention for a
+/// success/error type to a usize sufficient to send to userspace via an upcall.
+/// Tock terms this usize value a `ReturnCode`.
+///
+/// The key to this conversion and portability between the kernel and userspace
+/// is that `ErrorCode`, which only expresses errors, is assigned fixed values,
+/// but does not use value 0 by convention. This allows us to use 0 as success
+/// in ReturnCode.
+pub fn into_returncode(r: Result<(), ErrorCode>) -> usize {
+    match r {
         Ok(()) => 0,
-        Err(e) => match e {
-            ErrorCode::FAIL => -1,
-            ErrorCode::BUSY => -2,
-            ErrorCode::ALREADY => -3,
-            ErrorCode::OFF => -4,
-            ErrorCode::RESERVE => -5,
-            ErrorCode::INVAL => -6,
-            ErrorCode::SIZE => -7,
-            ErrorCode::CANCEL => -8,
-            ErrorCode::NOMEM => -9,
-            ErrorCode::NOSUPPORT => -10,
-            ErrorCode::NODEVICE => -11,
-            ErrorCode::UNINSTALLED => -12,
-            ErrorCode::NOACK => -13,
-        },
-    };
-    out as usize
+        Err(e) => e as usize,
+    }
 }

--- a/kernel/src/errorcode.rs
+++ b/kernel/src/errorcode.rs
@@ -92,17 +92,32 @@ impl From<ErrorCode> for Result<(), ErrorCode> {
     }
 }
 
-/// Convert a `Result<(), ErrorCode>` to a ReturnCode (usize) for userspace.
+/// Convert a `Result<(), ErrorCode>` to a StatusCode (usize) for userspace.
+///
+/// StatusCode is a useful "pseudotype" (there is no actual Rust type called
+/// StatusCode in Tock) for three reasons:
+///
+/// 1. It can be represented in a single `usize`. This allows StatusCode to be
+///    easily passed across the syscall interface between the kernel and
+///    userspace.
+///
+/// 2. It extends ErrorCode, but keeps the same error-to-number mappings as
+///    ErrorCode. For example, in both StatusCode and ErrorCode, the `SIZE`
+///    error is always represented as 7.
+///
+/// 3. It can encode success values, whereas ErrorCode can only encode errors.
+///    Number 0 in ErrorCode is reserved, and is used for `SUCCESS` in
+///    StatusCode.
 ///
 /// This helper function converts the Tock and Rust convention for a
-/// success/error type to a usize sufficient to send to userspace via an upcall.
-/// Tock terms this usize value a `ReturnCode`.
+/// success/error type to a StatusCode. StatusCode is represented as a usize
+/// which is sufficient to send to userspace via an upcall.
 ///
 /// The key to this conversion and portability between the kernel and userspace
 /// is that `ErrorCode`, which only expresses errors, is assigned fixed values,
 /// but does not use value 0 by convention. This allows us to use 0 as success
 /// in ReturnCode.
-pub fn into_returncode(r: Result<(), ErrorCode>) -> usize {
+pub fn into_statuscode(r: Result<(), ErrorCode>) -> usize {
     match r {
         Ok(()) => 0,
         Err(e) => e as usize,

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -110,7 +110,7 @@ mod sched;
 mod upcall;
 
 pub use crate::driver::{CommandReturn, Driver};
-pub use crate::errorcode::retcode_into_usize;
+pub use crate::errorcode::into_returncode;
 pub use crate::errorcode::ErrorCode;
 pub use crate::grant::{DynamicGrant, Grant};
 pub use crate::mem::{Read, ReadOnlyAppSlice, ReadWrite, ReadWriteAppSlice};

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -110,7 +110,7 @@ mod sched;
 mod upcall;
 
 pub use crate::driver::{CommandReturn, Driver};
-pub use crate::errorcode::into_returncode;
+pub use crate::errorcode::into_statuscode;
 pub use crate::errorcode::ErrorCode;
 pub use crate::grant::{DynamicGrant, Grant};
 pub use crate::mem::{Read, ReadOnlyAppSlice, ReadWrite, ReadWriteAppSlice};


### PR DESCRIPTION
This switches error handling between the kernel and userspace to use the same number <-> error mapping as ErrorCode uses.

Part of #2320 and #2449

#### libtock-c changes

Userspace drivers need to be updated to use the new error numbers.

- [x] ble_advertising_driver
- [x] console
- [x] crc
- [x] hmac
- [x] ieee802154
- [x] max17205
- [x] udp
- [x] screen
- [x] text_screen

### Testing Strategy

todo


### TODO or Help Wanted

This pull request still needs...


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
