### PR TITLE
rv32i: use atomic CSR instructions for rv32i::support::atomic

### DIFF
--- a/libraries/riscv-csr/src/csr.rs
+++ b/libraries/riscv-csr/src/csr.rs
@@ -212,4 +212,119 @@ impl<R: RegisterLongName, const V: usize> ReadWriteRiscvCsr<usize, R, V> {
     pub fn matches_all(&self, field: FieldValue<usize, R>) -> bool {
         field.matches_all(self.get())
     }
+
+    // Special methods only available on RISC-V CSRs, not found in the
+    // usual tock-registers interface
+
+    /// Atomically swap the contents of a CSR
+    ///
+    /// Reads the current value of a CSR and replaces it with the
+    /// specified value in a single instruction, returning the
+    /// previous value.
+    ///
+    /// This method corresponds to the RISC-V `CSRRW rd, csr, rs1`
+    /// instruction where `rs1 = in(reg) value_to_set` and `rd =
+    /// out(reg) <return value>`.
+    #[cfg(all(
+        any(target_arch = "riscv32", target_arch = "riscv64"),
+        target_os = "none"
+    ))]
+    #[inline]
+    pub fn atomic_replace(&self, val_to_set: usize) -> usize {
+        let r: usize;
+        unsafe {
+            asm!("csrrw {rd}, {csr}, {rs1}",
+                 rd = out(reg) r,
+                 csr = const V,
+                 rs1 = in(reg) val_to_set);
+        }
+        r
+    }
+
+    /// Atomically swap the contents of a CSR
+    ///
+    /// Reads the current value of a CSR and replaces it with the
+    /// specified value in a single instruction, returning the
+    /// previous value.
+    ///
+    /// This method corresponds to the RISC-V `CSRRW rd, csr, rs1`
+    /// instruction where `rs1 = in(reg) value_to_set` and `rd =
+    /// out(reg) <return value>`.
+    // Mock implementations for tests on Travis-CI.
+    #[cfg(not(any(target_arch = "riscv32", target_arch = "riscv64", target_os = "none")))]
+    pub fn atomic_replace(&self, _value_to_set: usize) -> usize {
+        unimplemented!("RISC-V CSR {} Atomic Read/Write", V)
+    }
+
+    /// Atomically read a CSR and set bits specified in a bitmask
+    ///
+    /// This method corresponds to the RISC-V `CSRRS rd, csr, rs1`
+    /// instruction where `rs1 = in(reg) bitmask` and `rd = out(reg)
+    /// <return value>`.
+    #[cfg(all(
+        any(target_arch = "riscv32", target_arch = "riscv64"),
+        target_os = "none"
+    ))]
+    #[inline]
+    pub fn read_and_set_bits(&self, bitmask: usize) -> usize {
+        let r: usize;
+        unsafe {
+            asm!("csrrs {rd}, {csr}, {rs1}",
+                 rd = out(reg) r,
+                 csr = const V,
+                 rs1 = in(reg) bitmask);
+        }
+        r
+    }
+
+    /// Atomically read a CSR and set bits specified in a bitmask
+    ///
+    /// This method corresponds to the RISC-V `CSRRS rd, csr, rs1`
+    /// instruction where `rs1 = in(reg) bitmask` and `rd = out(reg)
+    /// <return value>`.
+    // Mock implementations for tests on Travis-CI.
+    #[cfg(not(any(target_arch = "riscv32", target_arch = "riscv64", target_os = "none")))]
+    pub fn read_and_set_bits(&self, bitmask: usize) -> usize {
+        unimplemented!(
+            "RISC-V CSR {} Atomic Read and Set Bits, bitmask {:04x}",
+            V,
+            bitmask
+        )
+    }
+
+    /// Atomically read a CSR and clear bits specified in a bitmask
+    ///
+    /// This method corresponds to the RISC-V `CSRRC rd, csr, rs1`
+    /// instruction where `rs1 = in(reg) bitmask` and `rd = out(reg)
+    /// <return value>`.
+    #[cfg(all(
+        any(target_arch = "riscv32", target_arch = "riscv64"),
+        target_os = "none"
+    ))]
+    #[inline]
+    pub fn read_and_clear_bits(&self, bitmask: usize) -> usize {
+        let r: usize;
+        unsafe {
+            asm!("csrrc {rd}, {csr}, {rs1}",
+                 rd = out(reg) r,
+                 csr = const V,
+                 rs1 = in(reg) bitmask);
+        }
+        r
+    }
+
+    /// Atomically read a CSR and clear bits specified in a bitmask
+    ///
+    /// This method corresponds to the RISC-V `CSRRC rd, csr, rs1`
+    /// instruction where `rs1 = in(reg) bitmask` and `rd = out(reg)
+    /// <return value>`.
+    // Mock implementations for tests on Travis-CI.
+    #[cfg(not(any(target_arch = "riscv32", target_arch = "riscv64", target_os = "none")))]
+    pub fn read_and_clear_bits(&self, bitmask: usize) -> usize {
+        unimplemented!(
+            "RISC-V CSR {} Atomic Read and Clear Bits, bitmask {:04x}",
+            V,
+            bitmask
+        )
+    }
 }

--- a/libraries/riscv-csr/src/csr.rs
+++ b/libraries/riscv-csr/src/csr.rs
@@ -327,4 +327,28 @@ impl<R: RegisterLongName, const V: usize> ReadWriteRiscvCsr<usize, R, V> {
             bitmask
         )
     }
+
+    /// Atomically read field and set all bits to 1
+    ///
+    /// This method corresponds to the RISC-V `CSRRS rd, csr, rs1`
+    /// instruction, where `rs1` is the bitmask described by the
+    /// [`Field`].
+    ///
+    /// The previous value of the field is returned.
+    #[inline]
+    pub fn read_and_set_field(&self, field: Field<usize, R>) -> usize {
+        field.read(self.read_and_set_bits(field.mask << field.shift))
+    }
+
+    /// Atomically read field and set all bits to 0
+    ///
+    /// This method corresponds to the RISC-V `CSRRC rd, csr, rs1`
+    /// instruction, where `rs1` is the bitmask described by the
+    /// [`Field`].
+    ///
+    /// The previous value of the field is returned.
+    #[inline]
+    pub fn read_and_clear_field(&self, field: Field<usize, R>) -> usize {
+        field.read(self.read_and_clear_bits(field.mask << field.shift))
+    }
 }

--- a/libraries/tock-register-interface/src/registers.rs
+++ b/libraries/tock-register-interface/src/registers.rs
@@ -520,7 +520,7 @@ impl<T: IntLike, R: RegisterLongName> InMemoryRegister<T, R> {
 /// For the Field, the mask is unshifted, ie. the LSB should always be set.
 #[derive(Copy, Clone)]
 pub struct Field<T: IntLike, R: RegisterLongName> {
-    mask: T,
+    pub mask: T,
     pub shift: usize,
     associated_register: PhantomData<R>,
 }


### PR DESCRIPTION
### Pull Request Overview

This pull request contains a bunch of cleanly separated commits, enabling us to switch the `rv32i::support::atomic` to use RISC-V atomic CSR instructions.

Previously, the mstatus CSR was first read and then written to clear the machine mode interrupts. If an interrupt would arrive between these instructions, it could have changed mstatus, whereas this function would write back the previously read and modified register contents. Furthermore, if an interrupt handler would have cleared MIE between reading and writing the CSR, this function would set MIE again after execution of the passed in function.

As far as I can tell, this is not a real issue currently, due to the way interrupt handlers work and the fact that rv32i::support::atomic is already executed when the CPU is already in machine mode. However, it's best not to rely on this and use proper RISC-V instructions.

Additionally, this eliminates 7 instructions and one branch on rustc 1.52.0-nightly.

The other commits leading up to this are:

- riscv-csr: support atomic read/write & bit-field-set/clear ops

  Add atomic_replace, read_and_set_bits and read_and_clear_bits methods to the RISC-V CSR register wrappers to support the corresponding CSRRW, CSRRS and CSRRC RISV-C instructions.

  Using the atomic instructions can be required to prevent race conditions in interrupt contexts and context switches. Furthermore, using a combined read and write can often save instructions compared to a sequential read and write.

  The CSRR rd, csr and CSRW csr, rs1 instructions used in the RISC-V CSR register wrapper currently are assembler pseudo-instructions encoded as CSRRS rd, csr, x0 and CSRRW x0, csr, rs1 respectively (see RISC-V Specification v2.2, Volume I, 2.8 Control and Status Register Instructions).

- tock-registers: make Field::mask field public

  This partially reverts commit fed7a58 ("Make the Field::mask and FieldValue::mask fields private.") introduced through GitHub pull request tock#1939.

  In order to be able to implement atomic RISC-V CSR bit-field-set and bit-field-clear operations which operate on tock-register's Fields, access to the Field::mask field is required.

- tock-registers: fix Copy and Clone implementation on Field

  A Field contains a PhantomData over a generic R: RegisterLongName, and a PhantomData<R> is copyable regardless of whether R: Copy. However, using #[derive(Copy, Clone)] will generate

      #[automatically_derived]
      #[allow(unused_qualifications)]
      impl<T: ::core::marker::Copy + IntLike,
           R: ::core::marker::Copy + RegisterLongName>
              ::core::marker::Copy for Field<T, R> {}

  and hence Field will only implement Copy when R: Copy.

  Manually implementing Clone and Copy works around this issue. See rust-lang/rust#26925 for more information on this issue.

- riscv-csr: provide atomic read and set/clear field methods

  Add atomic read and set/clear methods for Fields on RISC-V CSR register wrappers. This wraps the read_and_set_bits and read_and_clear_bits into a more developer-friendly method that is compatible with the tock-registers types.


### Testing Strategy

This pull request was tested by compiling and looking at the generated assembly, as well as running litex/sim in Verilator and looking at the instruction trace.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] ~Updated the relevant files in `/docs`, or~ no updates are required.

### Formatting

- [x] Ran `make prepush`.
