### PR TITLE
Lsm303dlhc: Enforce use by a single process, move callback to Grant

### DIFF
--- a/boards/stm32f3discovery/src/main.rs
+++ b/boards/stm32f3discovery/src/main.rs
@@ -623,7 +623,7 @@ pub unsafe fn main() {
         components::i2c::I2CMuxComponent::new(&peripherals.i2c1, None, dynamic_deferred_caller)
             .finalize(components::i2c_mux_component_helper!());
 
-    let lsm303dlhc = components::lsm303dlhc::Lsm303dlhcI2CComponent::new()
+    let lsm303dlhc = components::lsm303dlhc::Lsm303dlhcI2CComponent::new(board_kernel)
         .finalize(components::lsm303dlhc_i2c_component_helper!(mux_i2c));
 
     lsm303dlhc.configure(


### PR DESCRIPTION
### Pull Request Overview

This pull request is the first in a series of PRs to enforce that all non-virtualized capsules cannot be used by multiple processes.

It adds a method to be able to check whether a process identifier is still valid (whether the same process _instance_ is still running, e.g. it has not restarted).

It adds helper infrastructure for reserving nonvirtualized drivers, in a new folder, `capsules/support`.

Finally, it enforce that only a single process may (implicitly) reserve the nonvirtualized userspace driver for the lsm303dlhc.
It also moves the `Upcall` type into the process `Grant` region, as a preparation for the upcoming PR implementing restrictions on callback swapping #2462 .

This PR was co-authored by @lschuermann .

### Testing Strategy

This pull request was tested by compiling, as we do not have hardware available for this driver. That said, the changes are pretty straightforward.


### TODO or Help Wanted

This pull request still needs testing.


### Documentation Updated

- [x] No updates are required.

### Formatting

- [x] Ran `make prepush`.
