### PR TITLE
capsules: Convert analog comparator to use grant

### DIFF
--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -430,6 +430,7 @@ pub unsafe fn main() {
             ac_2,
             ac_3
         ),
+        board_kernel,
     )
     .finalize(components::acomp_component_buf!(sam4l::acifc::Acifc));
     let rng = RngComponent::new(board_kernel, &peripherals.trng).finalize(());

--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -317,6 +317,7 @@ pub unsafe fn main() {
             nrf52840::acomp::Channel,
             &nrf52840::acomp::CHANNEL_AC0
         ),
+        board_kernel,
     )
     .finalize(components::acomp_component_buf!(
         nrf52840::acomp::Comparator

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -492,6 +492,7 @@ pub unsafe fn main() {
             nrf52840::acomp::Channel,
             &nrf52840::acomp::CHANNEL_AC0
         ),
+        board_kernel,
     )
     .finalize(components::acomp_component_buf!(
         nrf52840::acomp::Comparator

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -352,6 +352,7 @@ pub unsafe fn main() {
             nrf52832::acomp::Channel,
             &nrf52832::acomp::CHANNEL_AC0
         ),
+        board_kernel,
     )
     .finalize(components::acomp_component_buf!(
         nrf52832::acomp::Comparator


### PR DESCRIPTION
### Pull Request Overview

As part of #2462 this switches the analog comparator capsule to use a grant.


### Testing Strategy

travis


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
