### PR TITLE
Update stack-analysis script: reset_handler is now `main()`

### DIFF
--- a/tools/stack_analysis.sh
+++ b/tools/stack_analysis.sh
@@ -4,9 +4,9 @@
 # size information, and is thus most easily called using the `make stack-analysis`
 # rule.
 
-# Print the stack frame size of `reset_handler`
-printf "reset_handler stack frame: \n"
-$(find $(rustc --print sysroot) -name llvm-readobj) --elf-output-style GNU --stack-sizes $1 | grep 'reset_handler'
+# Print the stack frame size of `main`
+printf "main stack frame: \n"
+$(find $(rustc --print sysroot) -name llvm-readobj) --elf-output-style GNU --stack-sizes $1 | grep 'main'
 
 printf "\n"
 printf "5 largest stack frames: \n"


### PR DESCRIPTION
### Pull Request Overview

This should have happened in the re-write of memory initialization.


### Testing Strategy

Should be fine.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
