### PR TITLE
kernel: sched: check for process.ready()

### DIFF
--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -608,6 +608,14 @@ impl Kernel {
                 break;
             }
 
+            // Check if this process is actually ready to run. If not, we don't
+            // try to run it. This case can happen if a process faults and is
+            // stopped, for example.
+            if !process.ready() {
+                return_reason = StoppedExecutingReason::NoWorkLeft;
+                break;
+            }
+
             match process.get_state() {
                 process::State::Running => {
                     // Running means that this process expects to be running, so


### PR DESCRIPTION
If a process is stopped after faulting, it ends up in the `Faulted` state. Then, if that process still has time in its timeslice remaining, do_process will try to run it again where it hits a panic because the kernel has tried to run a faulted/terminated process. To avoid this we must check if a process actually has any work to do before trying to run it according to its state.

This patch has the side effect that a yield-ed process with nothing to do will no longer hit the yield -> next_task() -> None check in the do_process match statement. I believe this does not matter because both cases result in a break, and there is no way for a process to have work scheduled for it between the new check and the existing yield case check.



### Testing Strategy

Trying the Stop fault response on the nano33ble and seeing that we no longer hit the "tried to schedule a faulted process" panic.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
