### PR TITLE
kernel: Add StopWithDebug Process Fault Response

### DIFF
--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -69,13 +69,20 @@ const PAN_ID: u16 = 0xABCD;
 /// UART Writer for panic!()s.
 pub mod io;
 
-// State for loading and holding applications.
-// How should the kernel respond when a process faults.
-const FAULT_RESPONSE: kernel::procs::FaultResponse = kernel::procs::FaultResponse::Panic;
+// How should the kernel respond when a process faults. Stop but do not
+// immediately panic.
+//
+// We choose this fault response for the nano33ble because it does not have
+// dedicated UART-to-USB hardware. If a process faults very early after boot,
+// the USB stack does not have enough time for initialization, and a `panic!()`
+// leads to the USB-CDC stack to put the serial port in a bad state. By only
+// stopping the app, the user can request a panic later to avoid the issue.
+const FAULT_RESPONSE: kernel::procs::FaultResponse = kernel::procs::FaultResponse::StopWithDebug;
 
 // Number of concurrent processes this platform supports.
 const NUM_PROCS: usize = 8;
 
+// State for loading and holding applications.
 static mut PROCESSES: [Option<&'static dyn kernel::procs::ProcessType>; NUM_PROCS] =
     [None; NUM_PROCS];
 

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -789,6 +789,10 @@ pub enum FaultResponse {
 
     /// Stop the app by no longer scheduling it to run.
     Stop,
+
+    /// Stop the app by no longer scheduling it to run, leave the app in a fault
+    /// state, and print a debug message indicating what happened.
+    StopWithDebug,
 }
 
 /// Tasks that can be enqueued for a process.
@@ -1103,6 +1107,13 @@ impl<C: Chip> ProcessType for Process<'_, C> {
                 // this app as well.
                 self.terminate(COMPLETION_FAULT);
                 self.state.update(State::Faulted);
+            }
+            FaultResponse::StopWithDebug => {
+                // This is the same as `Stop`, but also prints a debug message
+                // noting that the process faulted.
+                self.terminate(COMPLETION_FAULT);
+                self.state.update(State::Faulted);
+                debug!("Process {} faulted and was stopped.", self.process_name);
             }
         }
     }


### PR DESCRIPTION
### Pull Request Overview

The `FaultResponse::StopWithDebug` is the same as `Stop`, but the kernel also prints a debug message letting the user know the process faulted and was stopped.

This PR also makes that the default on Nano 33 BLE because if a process fails immediately, the USB/CDC stack doesn't have time to setup, and the panic print message doesn't work. This avoids that issue by having the kernel just stop the process and notify the user via a debug message that it faulted. Then the user can use process console to panic the kernel and see the debug message if they wish.


### Testing Strategy

This pull request was tested by using my `crash-immediately-syscall` app and the pconsole panic command.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
