### PR TITLE
Add a "panic" command to process console

### DIFF
--- a/capsules/src/process_console.rs
+++ b/capsules/src/process_console.rs
@@ -12,6 +12,7 @@
 //!  - 'stop n' stops the process with name n
 //!  - 'start n' starts the stopped process with name n
 //!  - 'fault n' forces the process with name n into a fault state
+//!  - 'panic' causes the kernel to run the panic handler
 //!
 //! ### `list` Command Fields:
 //!
@@ -210,7 +211,7 @@ impl<'a, C: ProcessManagementCapability> ProcessConsole<'a, C> {
                         let clean_str = s.trim();
                         if clean_str.starts_with("help") {
                             debug!("Welcome to the process console.");
-                            debug!("Valid commands are: help status list stop start fault");
+                            debug!("Valid commands are: help status list stop start fault panic");
                         } else if clean_str.starts_with("start") {
                             let argument = clean_str.split_whitespace().nth(1);
                             argument.map(|name| {
@@ -290,6 +291,8 @@ impl<'a, C: ProcessManagementCapability> ProcessConsole<'a, C> {
                                 "Timeslice expirations: {}",
                                 info.timeslice_expirations(&self.capability)
                             );
+                        } else if clean_str.starts_with("panic") {
+                            panic!("ProcessConsole forced a kernel panic.");
                         } else {
                             debug!("Valid commands are: help status list stop start fault");
                         }


### PR DESCRIPTION
### Pull Request Overview

This pull request is supposed to be just adding a "panic" command to process console so that users can force a panic, and more importantly the debug information that comes along with it. This is a stop-gap if we can instead use the process console to display the per-process debug info without a full kernel panic someday.

Unfortunately, on the board I want to use this on (the nano33ble), just doing a normal `panic!()` in process console doesn't work. The issue is that process console commands are parsed in a UART TX done callback (which on the nano33 originates from the CDC/USB stack). Since panic changes the control flow immediately, the TX done callback never finishes returning down the callback chain, and the USB driver's state is effectively corrupted.

So, this implementation uses a deferred call so that the panic runs on a different callback. This makes it work on the nano33ble, but adds a deferred call for every process console user.


### Testing Strategy

Using it on the nano33ble.


### TODO or Help Wanted

I don't like this solution (hence why no other boards compile since I only fixed up the nano33ble). Any thoughts on a better way to handle this? Some possible options:

1. Use this approach, and implement for all boards that use process console.
2. Make the deferred call an `Option<>`, and just immediately panic for boards that use a `None`.
3. Try to hack the panic implementation in nano33ble/io.rs to cleanup the state that wasn't cleaned up if the panic happens in a UART callback.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
