### PR TITLE
Update print_tock_memory_usage.py to properly parse Rust symbols.

### DIFF
--- a/tools/print_tock_memory_usage.py
+++ b/tools/print_tock_memory_usage.py
@@ -89,6 +89,24 @@ def trim_hash_from_symbol(symbol):
     else:
         return symbol
 
+escape_sequences = [
+    ["$C$",     ","],
+    ["$SP$",    "@"],
+    ["$BP$",    "*"],
+    ["$RF$",    "&"],
+    ["$LT,GT$", "<>"],
+    ["$LT$",    "<"],
+    ["$GT$",    ">"],
+    ["$LP$",    "("],
+    ["$RP$",    ")"],
+    ["$u20$",   " "],
+    ["$u27$",   "\'"],
+    ["$u5b$",   "["],
+    ["$u5d$",   "]"],
+    ["..",      ":"],
+    [".",       "-"]
+]
+
 def parse_mangled_name(name):
     """Take a potentially mangled symbol name and demangle it to its
        name, removing the trailing hash. This is not just a simple
@@ -114,69 +132,44 @@ def parse_mangled_name(name):
         demangled = name
         
     corrected_name = trim_hash_from_symbol(demangled)
+    for escape in escape_sequences:
+        corrected_name = corrected_name.replace(escape[0], escape[1])
 
-    #print("  - Demangled:  ", demangled);
-    #print("  - Corrected:  ", corrected_name);
+    # Need to separate the name of the structure from the name of
+    # the method. If it starts with a _, then it's of the form
+    # _<structure as trait>::method otherwise it's
+    # structure::method. So first carve off the method name, then
+    # figure out the structure.
 
-    # Rust-specific mangled names triggered by Tock Components, e.g.
-    # ZN100_$LT$capsules..ieee802154..driver..RadioDriver$u20$as$u20$capsules..ieee802154..device..RxClient$GT$7receive
-    # This name has two parts: the structure, then the trait method it is
-    # implementing.
+    structure_end = corrected_name.rfind("::")
+    full_structure_name = ""
 
-    if corrected_name[0:5] == "_$LT$":
-        # Trim off the _$LT$
-        corrected_name = corrected_name[len("_$LT$"):]
-        
-    # If this is an implementation of a trait method, the trait's name
-    # is interposed between the structure and method. Cut it out.
-    # It starts with $u20$as$u20$ and ends with $GT$.
+    if structure_end >= 0:
+        method = corrected_name[structure_end + 2:]
+        full_structure_name = corrected_name[0:structure_end]
+    else:
+        method = corrected_name
 
-    structure_name = corrected_name
-    structure_end = len(structure_name)
-    # If there is an "as", cut it off
-    as_end = structure_name.find("$u20$as$u20$");
-    if as_end >= 0:
-        structure_name = structure_name[:as_end]
-        structure_end = as_end
+    structure = full_structure_name
+    if corrected_name[0:1] == "_":
+        split = full_structure_name.split(" as ")
+        structure = split[0]
+        # trim the _<
+        structure = structure[2:]
 
-    # If there is a "for", cut it off
-    for_end = structure_name.find("$u20$for$u20$");
-    if for_end >= 0:
-        structure_name = structure_name[:for_end]
-        structure_end = for_end
+    symbol = structure
+    if len(symbol) > 0:
+      symbol = symbol + "::" + method
+    else :
+        # No structure, just a method
+        symbol = method
 
-    # Structures can have a trailing $LT$ which takes one
-    # of 3 forms: trim all of them.
-    shorter_structure_end = structure_name.find("::_$LT");
-    if shorter_structure_end >= 0:
-        structure_name = structure_name[:shorter_structure_end]
+    if symbol[0:2] == "-L" or symbol[0:2] == "-l" or symbol[0:4] == "anon":
+        symbol = "Anonymous"
+    if symbol[0:7] == "-hidden":
+        symbol = "Hidden"
 
-    shorter_structure_end = structure_name.find("_$LT");
-    if shorter_structure_end >= 0:
-        structure_name = structure_name[:shorter_structure_end]
-        
-    shorter_structure_end = structure_name.find("$LT");
-    if shorter_structure_end >= 0:
-        structure_name = structure_name[:shorter_structure_end]
-
-    # mangled_method is the symbol after the structure and trait.
-    # It can have a lot of extra stuff besides the name, including
-    # "as" elements and "$GT$". Remove them.
-    mangled_method = corrected_name[structure_end:]
-    trait_start = mangled_method.find("$u20$as$u20$") + len("$u20$as$u20$")
-    mangled_method = mangled_method[trait_start:]
-
-
-    method = mangled_method
-    trait_end = method.find("$GT$")
-    if trait_end >= 0:
-        trait_end = trait_end + len("$GT$")
-        method = method[trait_end:]
-    #print("  - Method:     ", method)
-    
-    symbol = structure_name + method
-    symbol = symbol.replace("..", "::")
-    
+#    print(name, "->", symbol)
     return symbol
 
 def process_symbol_line(line):

--- a/tools/print_tock_memory_usage.py
+++ b/tools/print_tock_memory_usage.py
@@ -112,9 +112,7 @@ def parse_mangled_name(name):
        name, removing the trailing hash. This is not just a simple
        demangling: for methods, it outputs the structure + method
        as a :: separated name, eliding the trait (if any)."""
-    
-    #print("Name:           ", name);
-    
+
     # Trim a trailing . number (e.g., ".71") which breaks demangling
     match = re.search('\.\d+$', name)
     if match != None:
@@ -125,12 +123,12 @@ def parse_mangled_name(name):
     if match != None:
         name = name[:match.start()]
 
-    demangled = ""       
+    demangled = ""
     try:
         demangled = cxxfilt.demangle(name, external_only=False)
     except cxxfilt.InvalidName:
         demangled = name
-        
+
     corrected_name = trim_hash_from_symbol(demangled)
     for escape in escape_sequences:
         corrected_name = corrected_name.replace(escape[0], escape[1])
@@ -303,9 +301,9 @@ def group_symbols(groups, symbols, waste, section):
 
     if waste and waste_sum > 0:
         output = output + "Total of " + str(waste_sum) + " bytes wasted in " + section + "\n"
-        
+
     return output
-        
+
 def string_for_group(key, padding_size, group_size, num_elements):
     """Return the string for a group of variables, with padding added on the
        right; decides whether to add a * or not based on the name of the group
@@ -331,7 +329,7 @@ def print_groups(title, groups):
     output = ""
     max_string_len = len(max(groups.keys(), key=len))
     group_sizes = {}
-    
+
     for key in groups.keys():
         symbols = groups[key]
 
@@ -362,7 +360,7 @@ def print_symbol_information():
     gaps = gaps + group_symbols(variable_groups, kernel_uninitialized, show_waste, "RAM")
     print_groups("Variable groups (RAM)", variable_groups)
     print(gaps)
-    
+
     print("Embedded data (flash): " + str(padding_text) + " bytes")
     print()
     function_groups = {}
@@ -397,7 +395,7 @@ def compute_padding(symbols):
 def parse_options(opts):
     """Parse command line options."""
     global symbol_depth, verbose, show_waste, sort_by_size
-    valid = 'd:vsw' 
+    valid = 'd:vsw'
     long_valid = ['depth=', 'verbose', 'show-waste', 'size']
     optlist, leftover = getopt.getopt(opts, valid, long_valid)
     for (opt, val) in optlist:
@@ -419,7 +417,7 @@ def parse_options(opts):
 
 
  # Script starts here ######################################
-if __name__ == "__main__": 
+if __name__ == "__main__":
     arguments = sys.argv[1:]
     if len(arguments) < 1:
         usage("no ELF specified")


### PR DESCRIPTION
### Pull Request Overview

This pull request gets rid of the hacky symbol handling in this tool. Rather than rely on a bunch of special cases for different patterns, it now fully escapes all the control sequences to derive the structure and trait names. This gives much greater precision on the symbols and therefore where space is going.

It now clusters anonymous functions under "Anonymous" and hidden functions (e.g., software floating point) under "Hidden".

### Testing Strategy

This pull request was tested by running it on an imix binary.


### TODO or Help Wanted

Please let me know if this output is good, or whether it should cluster stuff like `&mut T::fmt` and `&T::fmt` into some special categories.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
