### PR TITLE
tock-cells/OptionalCell: add get-method for retrieving inner Option

### DIFF
--- a/libraries/tock-cells/src/optional_cell.rs
+++ b/libraries/tock-cells/src/optional_cell.rs
@@ -148,6 +148,11 @@ impl<T> OptionalCell<T> {
 }
 
 impl<T: Copy> OptionalCell<T> {
+    /// Returns a copy the contained [`Option`].
+    pub fn get(&self) -> Option<T> {
+        self.value.get()
+    }
+
     /// Returns the contained value or panics if contents is `None`.
     pub fn expect(&self, msg: &str) -> T {
         self.value.get().expect(msg)


### PR DESCRIPTION
### Pull Request Overview

Adds an OptionalCell::get() method which returns a copy of the
contained Option<T>, which is either None or Some. This allows a user
to treat an OptionalCell<T> as a Cell<Option<T>> in most cases, while
still providing the benefits of a regular OptionalCell<T>.

### Testing Strategy

This pull request was tested by compiling.


### TODO or Help Wanted

N/A


### Documentation Updated

- [X] ~Updated the relevant files in `/docs`, or~ no updates are required.

### Formatting

- [X] Ran `make prepush`.
