### PR TITLE
tock-cells/OptionalCell: rename get-method to extract

### DIFF
--- a/libraries/tock-cells/src/optional_cell.rs
+++ b/libraries/tock-cells/src/optional_cell.rs
@@ -148,8 +148,8 @@ impl<T> OptionalCell<T> {
 }
 
 impl<T: Copy> OptionalCell<T> {
-    /// Returns a copy the contained [`Option`].
-    pub fn get(&self) -> Option<T> {
+    /// Returns a copy of the contained [`Option`].
+    pub fn extract(&self) -> Option<T> {
         self.value.get()
     }
 


### PR DESCRIPTION
### Pull Request Overview

As an OptionalCell is designed to look like a Cell which can also be empty, the get method as currently implemented does not match the expected behavior (as it will return an `Option<T>` instead of a `T`). Furthermore, as `OptionalCell::set` takes simply a `T` (not wrapped in an `Option`), `get` should not return an `Option<T>`.

Accordingly, this commit renames the `OptionalCell::get` method to `extract`, to distinguish it from the `Cell::get` method.

Fixes: a845aa8e27cfe0 ("tock-cells/OptionalCell: add get-method...") (GitHub PR #2531)
Suggested-by: Brad Campbell <bradjc5@gmail.com>
Signed-off-by: Leon Schuermann <leon@is.currently.online>

### Testing Strategy

This pull request was tested by compiling.


### TODO or Help Wanted

A discussion about the right method name to use.


### Documentation Updated

- [x] ~Updated the relevant files in `/docs`, or~ no updates are required.

### Formatting

- [x] Ran `make prepush`.
