### PR TITLE
kernel: introduce debug::panic_print for boards without LEDs

### DIFF
--- a/boards/swervolf/src/io.rs
+++ b/boards/swervolf/src/io.rs
@@ -37,9 +37,7 @@ impl IoWrite for Writer {
 pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
     let writer = &mut WRITER;
 
-    debug::panic_banner(writer, pi);
-    debug::panic_cpu_state(&CHIP, writer);
-    debug::panic_process_info(&PROCESSES, writer);
+    debug::panic_print(writer, pi, &rv32i::support::nop, &PROCESSES, &CHIP);
 
     // By writing to address 0x80001009 we can exit the simulation.
     // So instead of blinking in a loop let's exit the simulation.


### PR DESCRIPTION
### Pull Request Overview

Introduce an alternative to `debug::panic` which does not require an LED type parameter and returns instead of blinking an LED in an infinite loop.

This is useful for boards which do not feature any GPIO or LEDs, such as the SweRVolf and LiteX sim boards running inside Verilator, and other virtualized boards (for example, QEMU riscv32-virt as currently developed in #2516) in the future.

Consequently, the SweRVolf and LiteX sim boards have been changed to use this function instead.

### Testing Strategy

This pull request was tested by issuing a panic after loading processes on the LIteX simulation. It requires testing on SweRVolf and some board using the regular `debug::panic` function.


### TODO or Help Wanted

- I'm not sure enough boards can benefit from this justify splitting it into two functions in `debug!`?

  Alternatives include a mock LED type implementation as done in LiteX sim right now, or duplicating the `debug::panic` method body as done in SweRVolf right now.

  I'll happily continue to use one of those approaches if this isn't deemed worth it.

- ~`debug::panic_noloop` might be a really bad name for this.~


### Documentation Updated

- [x] ~Updated the relevant files in `/docs`, or~ no updates are required.

### Formatting

- [x] Ran `make prepush`.
