### PR TITLE
Proximity capsule: don't double enter grant

### DIFF
--- a/capsules/src/apds9960.rs
+++ b/capsules/src/apds9960.rs
@@ -211,6 +211,7 @@ impl<'a> APDS9960<'a> {
         self.interrupt_pin.make_input();
         self.interrupt_pin
             .set_floating_state(gpio::FloatingState::PullUp);
+        self.interrupt_pin.disable_interrupts();
         self.interrupt_pin
             .enable_interrupts(gpio::InterruptEdge::FallingEdge);
 

--- a/capsules/src/proximity.rs
+++ b/capsules/src/proximity.rs
@@ -133,7 +133,13 @@ impl<'a> ProximitySensor<'a> {
                 if (self.command_running.get() == ProximityCommand::ReadProximityOnInterrupt)
                     && (command == ProximityCommand::ReadProximityOnInterrupt)
                 {
-                    let t: Thresholds = self.find_thresholds();
+                    let mut t: Thresholds = self.find_thresholds();
+                    if t.lower < app.lower_proximity {
+                        t.lower = app.lower_proximity;
+                    }
+                    if t.upper > app.upper_proximity {
+                        t.upper = app.upper_proximity;
+                    }
                     let _ = self.driver.read_proximity_on_interrupt(t.lower, t.upper);
                     self.command_running
                         .set(ProximityCommand::ReadProximityOnInterrupt);
@@ -151,19 +157,20 @@ impl<'a> ProximitySensor<'a> {
                     return CommandReturn::success();
                 }
 
-                // Only run command if it is only one in queue otherwise we wait for callback() for last run command to trigger another command to run
-                let mut num_commands: u8 = 0;
-
-                for cntr in self.apps.iter() {
-                    cntr.enter(|app, _| {
-                        if app.subscribed {
-                            num_commands += 1;
+                if self.command_running.get() == ProximityCommand::NoCommand {
+                    match app.enqueued_command_type {
+                        ProximityCommand::ReadProximity => {
+                            let _ = self.driver.read_proximity();
+                            self.command_running.set(ProximityCommand::ReadProximity);
                         }
-                    });
-                }
-
-                if num_commands == 1 {
-                    let _ = self.run_next_command();
+                        ProximityCommand::ReadProximityOnInterrupt => {
+                            let t: Thresholds = self.find_thresholds();
+                            let _ = self.driver.read_proximity_on_interrupt(t.lower, t.upper);
+                            self.command_running
+                                .set(ProximityCommand::ReadProximityOnInterrupt);
+                        }
+                        ProximityCommand::NoCommand => {}
+                    }
                 }
 
                 CommandReturn::success()
@@ -172,13 +179,11 @@ impl<'a> ProximitySensor<'a> {
     }
 
     fn run_next_command(&self) -> Result<(), ErrorCode> {
-        let mut break_flag: bool = false;
-
         // Find thresholds before entering any grant regions
         let t: Thresholds = self.find_thresholds();
         // Find and run another command
         for cntr in self.apps.iter() {
-            cntr.enter(|app, _| {
+            let break_flag = cntr.enter(|app, _| {
                 if app.subscribed {
                     // run it
                     match app.enqueued_command_type {
@@ -191,10 +196,11 @@ impl<'a> ProximitySensor<'a> {
                             self.command_running
                                 .set(ProximityCommand::ReadProximityOnInterrupt);
                         }
-                        _ => {}
+                        ProximityCommand::NoCommand => {}
                     }
-
-                    break_flag = true;
+                    true
+                } else {
+                    false
                 }
             });
 
@@ -214,7 +220,7 @@ impl<'a> ProximitySensor<'a> {
         let mut highest_lower_proximity: u8 = 0;
         let mut lowest_upper_proximity: u8 = 255;
 
-        for cntr in self.apps.iter() {
+        for cntr in self.apps.iter_unentered_grants() {
             cntr.enter(|app, _| {
                 if (app.lower_proximity > highest_lower_proximity)
                     && app.subscribed

--- a/capsules/src/proximity.rs
+++ b/capsules/src/proximity.rs
@@ -164,7 +164,13 @@ impl<'a> ProximitySensor<'a> {
                             self.command_running.set(ProximityCommand::ReadProximity);
                         }
                         ProximityCommand::ReadProximityOnInterrupt => {
-                            let t: Thresholds = self.find_thresholds();
+                            let mut t: Thresholds = self.find_thresholds();
+                            if t.lower < app.lower_proximity {
+                                t.lower = app.lower_proximity;
+                            }
+                            if t.upper > app.upper_proximity {
+                                t.upper = app.upper_proximity;
+                            }
                             let _ = self.driver.read_proximity_on_interrupt(t.lower, t.upper);
                             self.command_running
                                 .set(ProximityCommand::ReadProximityOnInterrupt);


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes a bug in the proximity driver introduced by #2137. The proximty driver re-enters an entered grant while enqueuing a command by iterating through _all_ grants to determine if any have outstanding commands.

Instead of iterating through grants to determine whether there are outstanding commands, this PR simply uses the outstanding command field.

### Testing Strategy

Tested using the `sensors` app in libtock-c. Without this PR, the app results in a kernel panic, with this change it works (sort of, see TODO)

### TODO

The apds9960 driver, which implements the `ProximityDriver` hil for the nano33ble sense does not currently implement the startup sequence properly. As a result, the chip is, by default, (probably) left in either a low power mode or some other unintended state.

Several restarts of the board after programming or power up seem to eventually put the chip into the right state.

### Documentation Updated

- [X] ~Updated the relevant files in `/docs`, or no updates are required.~

### Formatting

- [X] Ran `make prepush`.
