### PR TITLE
kernel: Change ProcessFaultPolicy to a trait, add StopWithDebug policy

### DIFF
--- a/boards/acd52832/src/main.rs
+++ b/boards/acd52832/src/main.rs
@@ -41,7 +41,7 @@ pub mod io;
 
 // State for loading and holding applications.
 // How should the kernel respond when a process faults.
-const FAULT_RESPONSE: kernel::procs::FaultResponse = kernel::procs::FaultResponse::Panic;
+const FAULT_RESPONSE: kernel::procs::PanicFaultPolicy = kernel::procs::PanicFaultPolicy {};
 
 // Number of concurrent processes this platform supports.
 const NUM_PROCS: usize = 4;
@@ -520,7 +520,7 @@ pub unsafe fn main() {
             &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
         ),
         &mut PROCESSES,
-        FAULT_RESPONSE,
+        &FAULT_RESPONSE,
         &process_management_capability,
     )
     .unwrap_or_else(|err| {

--- a/boards/arty_e21/src/main.rs
+++ b/boards/arty_e21/src/main.rs
@@ -28,7 +28,7 @@ pub mod io;
 const NUM_PROCS: usize = 4;
 
 // How should the kernel respond when a process faults.
-const FAULT_RESPONSE: kernel::procs::FaultResponse = kernel::procs::FaultResponse::Panic;
+const FAULT_RESPONSE: kernel::procs::PanicFaultPolicy = kernel::procs::PanicFaultPolicy {};
 
 // Actual memory for holding the active process structures.
 static mut PROCESSES: [Option<&'static dyn kernel::procs::Process>; NUM_PROCS] =
@@ -235,7 +235,7 @@ pub unsafe fn main() {
             &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
         ),
         &mut PROCESSES,
-        FAULT_RESPONSE,
+        &FAULT_RESPONSE,
         &process_mgmt_cap,
     )
     .unwrap_or_else(|err| {

--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -81,7 +81,7 @@ pub mod io;
 
 // State for loading and holding applications.
 // How should the kernel respond when a process faults.
-const FAULT_RESPONSE: kernel::procs::FaultResponse = kernel::procs::FaultResponse::Panic;
+const FAULT_RESPONSE: kernel::procs::PanicFaultPolicy = kernel::procs::PanicFaultPolicy {};
 
 // Number of concurrent processes this platform supports.
 const NUM_PROCS: usize = 8;
@@ -578,7 +578,7 @@ pub unsafe fn main() {
             &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
         ),
         &mut PROCESSES,
-        FAULT_RESPONSE,
+        &FAULT_RESPONSE,
         &process_management_capability,
     )
     .unwrap_or_else(|err| {

--- a/boards/earlgrey-nexysvideo/src/main.rs
+++ b/boards/earlgrey-nexysvideo/src/main.rs
@@ -48,7 +48,7 @@ static mut CHIP: Option<
 > = None;
 
 // How should the kernel respond when a process faults.
-const FAULT_RESPONSE: kernel::procs::FaultResponse = kernel::procs::FaultResponse::Panic;
+const FAULT_RESPONSE: kernel::procs::PanicFaultPolicy = kernel::procs::PanicFaultPolicy {};
 
 /// Dummy buffer that causes the linker to reserve enough space for the stack.
 #[no_mangle]
@@ -398,7 +398,7 @@ pub unsafe fn main() {
             &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
         ),
         &mut PROCESSES,
-        FAULT_RESPONSE,
+        &FAULT_RESPONSE,
         &process_mgmt_cap,
     )
     .unwrap_or_else(|err| {

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -414,11 +414,10 @@ pub unsafe fn main() {
     // peripherals.pa[16].set_client(debug_process_restart);
 
     // Configure application fault policy
-    let restart_policy = static_init!(
-        kernel::procs::ThresholdRestartThenPanic,
-        kernel::procs::ThresholdRestartThenPanic::new(4)
+    let fault_policy = static_init!(
+        kernel::procs::ThresholdRestartThenPanicFaultPolicy,
+        kernel::procs::ThresholdRestartThenPanicFaultPolicy::new(4)
     );
-    let fault_response = kernel::procs::FaultResponse::Restart(restart_policy);
 
     let hail = Hail {
         console,
@@ -473,7 +472,7 @@ pub unsafe fn main() {
             &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
         ),
         &mut PROCESSES,
-        fault_response,
+        fault_policy,
         &process_management_capability,
     )
     .unwrap_or_else(|err| {

--- a/boards/hifive1/src/main.rs
+++ b/boards/hifive1/src/main.rs
@@ -42,7 +42,7 @@ static mut CHIP: Option<
 > = None;
 
 // How should the kernel respond when a process faults.
-const FAULT_RESPONSE: kernel::procs::FaultResponse = kernel::procs::FaultResponse::Panic;
+const FAULT_RESPONSE: kernel::procs::PanicFaultPolicy = kernel::procs::PanicFaultPolicy {};
 
 /// Dummy buffer that causes the linker to reserve enough space for the stack.
 #[no_mangle]
@@ -238,7 +238,7 @@ pub unsafe fn main() {
             &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
         ),
         &mut PROCESSES,
-        FAULT_RESPONSE,
+        &FAULT_RESPONSE,
         &process_mgmt_cap,
     )
     .unwrap_or_else(|err| {

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -91,7 +91,7 @@ const DEFAULT_CTX_PREFIX: [u8; 16] = [0x0 as u8; 16]; //Context for 6LoWPAN Comp
 const PAN_ID: u16 = 0xABCD;
 
 // how should the kernel respond when a process faults
-const FAULT_RESPONSE: kernel::procs::FaultResponse = kernel::procs::FaultResponse::Panic;
+const FAULT_RESPONSE: kernel::procs::PanicFaultPolicy = kernel::procs::PanicFaultPolicy {};
 
 static mut PROCESSES: [Option<&'static dyn kernel::procs::Process>; NUM_PROCS] = [None; NUM_PROCS];
 
@@ -633,7 +633,7 @@ pub unsafe fn main() {
             &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
         ),
         &mut PROCESSES,
-        FAULT_RESPONSE,
+        &FAULT_RESPONSE,
         &process_mgmt_cap,
     )
     .unwrap_or_else(|err| {

--- a/boards/imxrt1050-evkb/src/main.rs
+++ b/boards/imxrt1050-evkb/src/main.rs
@@ -49,7 +49,7 @@ type Chip = imxrt1050::chip::Imxrt10xx<imxrt1050::chip::Imxrt10xxDefaultPeripher
 static mut CHIP: Option<&'static Chip> = None;
 
 // How should the kernel respond when a process faults.
-const FAULT_RESPONSE: kernel::procs::FaultResponse = kernel::procs::FaultResponse::Panic;
+const FAULT_RESPONSE: kernel::procs::PanicFaultPolicy = kernel::procs::PanicFaultPolicy {};
 
 // Manually setting the boot header section that contains the FCB header
 #[used]
@@ -446,7 +446,7 @@ pub unsafe fn main() {
             &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
         ),
         &mut PROCESSES,
-        FAULT_RESPONSE,
+        &FAULT_RESPONSE,
         &process_management_capability,
     )
     .unwrap_or_else(|err| {

--- a/boards/litex/arty/src/main.rs
+++ b/boards/litex/arty/src/main.rs
@@ -103,7 +103,7 @@ static mut PANIC_REFERENCES: LiteXArtyPanicReferences = LiteXArtyPanicReferences
 };
 
 // How should the kernel respond when a process faults.
-const FAULT_RESPONSE: kernel::procs::FaultResponse = kernel::procs::FaultResponse::Panic;
+const FAULT_RESPONSE: kernel::procs::PanicFaultPolicy = kernel::procs::PanicFaultPolicy {};
 
 /// Dummy buffer that causes the linker to reserve enough space for the stack.
 #[no_mangle]
@@ -454,7 +454,7 @@ pub unsafe fn main() {
             &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
         ),
         &mut PROCESSES,
-        FAULT_RESPONSE,
+        &FAULT_RESPONSE,
         &process_mgmt_cap,
     )
     .unwrap_or_else(|err| {

--- a/boards/litex/sim/src/main.rs
+++ b/boards/litex/sim/src/main.rs
@@ -99,7 +99,7 @@ static mut PANIC_REFERENCES: LiteXSimPanicReferences = LiteXSimPanicReferences {
 };
 
 // How should the kernel respond when a process faults.
-const FAULT_RESPONSE: kernel::procs::FaultResponse = kernel::procs::FaultResponse::Panic;
+const FAULT_RESPONSE: kernel::procs::PanicFaultPolicy = kernel::procs::PanicFaultPolicy {};
 
 /// Dummy buffer that causes the linker to reserve enough space for the stack.
 #[no_mangle]
@@ -403,7 +403,7 @@ pub unsafe fn main() {
             &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
         ),
         &mut PROCESSES,
-        FAULT_RESPONSE,
+        &FAULT_RESPONSE,
         &process_mgmt_cap,
     )
     .unwrap_or_else(|err| {

--- a/boards/microbit_v2/src/main.rs
+++ b/boards/microbit_v2/src/main.rs
@@ -58,7 +58,7 @@ pub mod io;
 
 // State for loading and holding applications.
 // How should the kernel respond when a process faults.
-const FAULT_RESPONSE: kernel::procs::FaultResponse = kernel::procs::FaultResponse::Panic;
+const FAULT_RESPONSE: kernel::procs::PanicFaultPolicy = kernel::procs::PanicFaultPolicy {};
 
 // Number of concurrent processes this platform supports.
 const NUM_PROCS: usize = 4;
@@ -548,7 +548,7 @@ pub unsafe fn main() {
             &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
         ),
         &mut PROCESSES,
-        FAULT_RESPONSE,
+        &FAULT_RESPONSE,
         &process_management_capability,
     )
     .unwrap_or_else(|err| {

--- a/boards/msp_exp432p401r/src/main.rs
+++ b/boards/msp_exp432p401r/src/main.rs
@@ -34,7 +34,7 @@ static mut CHIP: Option<&'static msp432::chip::Msp432<msp432::chip::Msp432Defaul
     None;
 
 /// How should the kernel respond when a process faults.
-const FAULT_RESPONSE: kernel::procs::FaultResponse = kernel::procs::FaultResponse::Panic;
+const FAULT_RESPONSE: kernel::procs::PanicFaultPolicy = kernel::procs::PanicFaultPolicy {};
 
 /// Dummy buffer that causes the linker to reserve enough space for the stack.
 #[no_mangle]
@@ -400,7 +400,7 @@ pub unsafe fn main() {
             &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
         ),
         &mut PROCESSES,
-        FAULT_RESPONSE,
+        &FAULT_RESPONSE,
         &process_management_capability,
     )
     .unwrap();

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -71,7 +71,7 @@ pub mod io;
 
 // State for loading and holding applications.
 // How should the kernel respond when a process faults.
-const FAULT_RESPONSE: kernel::procs::FaultResponse = kernel::procs::FaultResponse::Panic;
+const FAULT_RESPONSE: kernel::procs::PanicFaultPolicy = kernel::procs::PanicFaultPolicy {};
 
 // Number of concurrent processes this platform supports.
 const NUM_PROCS: usize = 8;
@@ -472,7 +472,7 @@ pub unsafe fn main() {
             &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
         ),
         &mut PROCESSES,
-        FAULT_RESPONSE,
+        &FAULT_RESPONSE,
         &process_management_capability,
     )
     .unwrap_or_else(|err| {

--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -51,7 +51,7 @@ pub mod io;
 
 // State for loading and holding applications.
 // How should the kernel respond when a process faults.
-const FAULT_RESPONSE: kernel::procs::FaultResponse = kernel::procs::FaultResponse::Panic;
+const FAULT_RESPONSE: kernel::procs::PanicFaultPolicy = kernel::procs::PanicFaultPolicy {};
 
 // Number of concurrent processes this platform supports.
 const NUM_PROCS: usize = 8;
@@ -367,7 +367,7 @@ pub unsafe fn main() {
             &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
         ),
         &mut PROCESSES,
-        FAULT_RESPONSE,
+        &FAULT_RESPONSE,
         &process_management_capability,
     )
     .unwrap_or_else(|err| {

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -126,7 +126,7 @@ const USB_DEBUGGING: bool = false;
 
 // State for loading and holding applications.
 // How should the kernel respond when a process faults.
-const FAULT_RESPONSE: kernel::procs::FaultResponse = kernel::procs::FaultResponse::Panic;
+const FAULT_RESPONSE: kernel::procs::PanicFaultPolicy = kernel::procs::PanicFaultPolicy {};
 
 // Number of concurrent processes this platform supports.
 const NUM_PROCS: usize = 8;
@@ -583,7 +583,7 @@ pub unsafe fn main() {
             &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
         ),
         &mut PROCESSES,
-        FAULT_RESPONSE,
+        &FAULT_RESPONSE,
         &process_management_capability,
     )
     .unwrap_or_else(|err| {

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -112,7 +112,7 @@ mod tests;
 
 // State for loading and holding applications.
 // How should the kernel respond when a process faults.
-const FAULT_RESPONSE: kernel::procs::FaultResponse = kernel::procs::FaultResponse::Panic;
+const FAULT_RESPONSE: kernel::procs::PanicFaultPolicy = kernel::procs::PanicFaultPolicy {};
 
 // Number of concurrent processes this platform supports.
 const NUM_PROCS: usize = 4;
@@ -402,7 +402,7 @@ pub unsafe fn main() {
             &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
         ),
         &mut PROCESSES,
-        FAULT_RESPONSE,
+        &FAULT_RESPONSE,
         &process_management_capability,
     )
     .unwrap_or_else(|err| {

--- a/boards/nucleo_f429zi/src/main.rs
+++ b/boards/nucleo_f429zi/src/main.rs
@@ -37,7 +37,7 @@ static mut CHIP: Option<&'static stm32f429zi::chip::Stm32f4xx<Stm32f429ziDefault
     None;
 
 // How should the kernel respond when a process faults.
-const FAULT_RESPONSE: kernel::procs::FaultResponse = kernel::procs::FaultResponse::Panic;
+const FAULT_RESPONSE: kernel::procs::PanicFaultPolicy = kernel::procs::PanicFaultPolicy {};
 
 /// Dummy buffer that causes the linker to reserve enough space for the stack.
 #[no_mangle]
@@ -563,7 +563,7 @@ pub unsafe fn main() {
             &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
         ),
         &mut PROCESSES,
-        FAULT_RESPONSE,
+        &FAULT_RESPONSE,
         &process_management_capability,
     )
     .unwrap_or_else(|err| {

--- a/boards/nucleo_f446re/src/main.rs
+++ b/boards/nucleo_f446re/src/main.rs
@@ -39,7 +39,7 @@ static mut CHIP: Option<&'static stm32f446re::chip::Stm32f4xx<Stm32f446reDefault
     None;
 
 // How should the kernel respond when a process faults.
-const FAULT_RESPONSE: kernel::procs::FaultResponse = kernel::procs::FaultResponse::Panic;
+const FAULT_RESPONSE: kernel::procs::PanicFaultPolicy = kernel::procs::PanicFaultPolicy {};
 
 /// Dummy buffer that causes the linker to reserve enough space for the stack.
 #[no_mangle]
@@ -353,7 +353,7 @@ pub unsafe fn main() {
             &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
         ),
         &mut PROCESSES,
-        FAULT_RESPONSE,
+        &FAULT_RESPONSE,
         &process_management_capability,
     )
     .unwrap_or_else(|err| {

--- a/boards/redboard_artemis_nano/src/main.rs
+++ b/boards/redboard_artemis_nano/src/main.rs
@@ -37,7 +37,7 @@ static mut PROCESSES: [Option<&'static dyn kernel::procs::Process>; NUM_PROCS] =
 static mut CHIP: Option<&'static apollo3::chip::Apollo3<Apollo3DefaultPeripherals>> = None;
 
 // How should the kernel respond when a process faults.
-const FAULT_RESPONSE: kernel::procs::FaultResponse = kernel::procs::FaultResponse::Panic;
+const FAULT_RESPONSE: kernel::procs::PanicFaultPolicy = kernel::procs::PanicFaultPolicy {};
 
 /// Dummy buffer that causes the linker to reserve enough space for the stack.
 #[no_mangle]
@@ -250,7 +250,7 @@ pub unsafe fn main() {
             &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
         ),
         &mut PROCESSES,
-        FAULT_RESPONSE,
+        &FAULT_RESPONSE,
         &process_mgmt_cap,
     )
     .unwrap_or_else(|err| {

--- a/boards/stm32f3discovery/src/main.rs
+++ b/boards/stm32f3discovery/src/main.rs
@@ -42,7 +42,7 @@ static mut PROCESSES: [Option<&'static dyn kernel::procs::Process>; NUM_PROCS] =
 static mut CHIP: Option<&'static stm32f303xc::chip::Stm32f3xx<Stm32f3xxDefaultPeripherals>> = None;
 
 // How should the kernel respond when a process faults.
-const FAULT_RESPONSE: kernel::procs::FaultResponse = kernel::procs::FaultResponse::Panic;
+const FAULT_RESPONSE: kernel::procs::PanicFaultPolicy = kernel::procs::PanicFaultPolicy {};
 
 /// Dummy buffer that causes the linker to reserve enough space for the stack.
 #[no_mangle]
@@ -762,7 +762,7 @@ pub unsafe fn main() {
             &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
         ),
         &mut PROCESSES,
-        FAULT_RESPONSE,
+        &FAULT_RESPONSE,
         &process_management_capability,
     )
     .unwrap_or_else(|err| {

--- a/boards/stm32f412gdiscovery/src/main.rs
+++ b/boards/stm32f412gdiscovery/src/main.rs
@@ -36,7 +36,7 @@ static mut PROCESSES: [Option<&'static dyn kernel::procs::Process>; NUM_PROCS] =
 static mut CHIP: Option<&'static stm32f412g::chip::Stm32f4xx<Stm32f412gDefaultPeripherals>> = None;
 
 // How should the kernel respond when a process faults.
-const FAULT_RESPONSE: kernel::procs::FaultResponse = kernel::procs::FaultResponse::Panic;
+const FAULT_RESPONSE: kernel::procs::PanicFaultPolicy = kernel::procs::PanicFaultPolicy {};
 
 /// Dummy buffer that causes the linker to reserve enough space for the stack.
 #[no_mangle]
@@ -788,7 +788,7 @@ pub unsafe fn main() {
             &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
         ),
         &mut PROCESSES,
-        FAULT_RESPONSE,
+        &FAULT_RESPONSE,
         &process_management_capability,
     )
     .unwrap_or_else(|err| {

--- a/boards/swervolf/src/main.rs
+++ b/boards/swervolf/src/main.rs
@@ -30,7 +30,7 @@ static mut PROCESSES: [Option<&'static dyn kernel::procs::Process>; NUM_PROCS] =
 static mut CHIP: Option<&'static swervolf_eh1::chip::SweRVolf<SweRVolfDefaultPeripherals>> = None;
 
 // How should the kernel respond when a process faults.
-const FAULT_RESPONSE: kernel::procs::FaultResponse = kernel::procs::FaultResponse::Panic;
+const FAULT_RESPONSE: kernel::procs::PanicFaultPolicy = kernel::procs::PanicFaultPolicy {};
 
 /// Dummy buffer that causes the linker to reserve enough space for the stack.
 #[no_mangle]
@@ -184,7 +184,7 @@ pub unsafe fn main() {
             &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
         ),
         &mut PROCESSES,
-        FAULT_RESPONSE,
+        &FAULT_RESPONSE,
         &process_mgmt_cap,
     )
     .unwrap_or_else(|err| {

--- a/boards/teensy40/src/main.rs
+++ b/boards/teensy40/src/main.rs
@@ -27,7 +27,7 @@ const NUM_PROCS: usize = 4;
 static mut PROCESSES: [Option<&'static dyn kernel::procs::Process>; NUM_PROCS] = [None; NUM_PROCS];
 
 /// What should we do if a process faults?
-const FAULT_RESPONSE: kernel::procs::FaultResponse = kernel::procs::FaultResponse::Panic;
+const FAULT_RESPONSE: kernel::procs::PanicFaultPolicy = kernel::procs::PanicFaultPolicy {};
 
 /// Teensy 4 platform
 struct Teensy40 {
@@ -257,7 +257,7 @@ pub unsafe fn main() {
             &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
         ),
         &mut PROCESSES,
-        FAULT_RESPONSE,
+        &FAULT_RESPONSE,
         &process_management_capability,
     )
     .unwrap();

--- a/boards/weact_f401ccu6/src/main.rs
+++ b/boards/weact_f401ccu6/src/main.rs
@@ -37,7 +37,7 @@ static mut CHIP: Option<&'static stm32f401cc::chip::Stm32f4xx<Stm32f401ccDefault
     None;
 
 // How should the kernel respond when a process faults.
-const FAULT_RESPONSE: kernel::procs::FaultResponse = kernel::procs::FaultResponse::Panic;
+const FAULT_RESPONSE: kernel::procs::PanicFaultPolicy = kernel::procs::PanicFaultPolicy {};
 
 /// Dummy buffer that causes the linker to reserve enough space for the stack.
 #[no_mangle]
@@ -418,7 +418,7 @@ pub unsafe fn main() {
             &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
         ),
         &mut PROCESSES,
-        FAULT_RESPONSE,
+        &FAULT_RESPONSE,
         &process_management_capability,
     )
     .unwrap_or_else(|err| {

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -140,7 +140,8 @@ pub mod procs {
     };
     pub use crate::process_policies::{
         PanicFaultPolicy, ProcessFaultPolicy, RestartFaultPolicy, StopFaultPolicy,
-        ThresholdRestartFaultPolicy, ThresholdRestartThenPanicFaultPolicy,
+        StopWithDebugFaultPolicy, ThresholdRestartFaultPolicy,
+        ThresholdRestartThenPanicFaultPolicy,
     };
     pub use crate::process_standard::ProcessStandard;
     pub use crate::process_utilities::{load_processes, ProcessLoadError};

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -136,10 +136,11 @@ pub use crate::upcall::Upcall;
 /// Publicly available process-related objects.
 pub mod procs {
     pub use crate::process::{
-        Error, FaultResponse, FunctionCall, FunctionCallSource, Process, State, Task,
+        Error, FaultAction, FunctionCall, FunctionCallSource, Process, State, Task,
     };
     pub use crate::process_policies::{
-        AlwaysRestart, ProcessRestartPolicy, ThresholdRestart, ThresholdRestartThenPanic,
+        PanicFaultPolicy, ProcessFaultPolicy, RestartFaultPolicy, StopFaultPolicy,
+        ThresholdRestartFaultPolicy, ThresholdRestartThenPanicFaultPolicy,
     };
     pub use crate::process_standard::ProcessStandard;
     pub use crate::process_utilities::{load_processes, ProcessLoadError};

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -11,7 +11,6 @@ use crate::errorcode::ErrorCode;
 use crate::ipc;
 use crate::mem::{ReadOnlyAppSlice, ReadWriteAppSlice};
 use crate::platform::mpu::{self};
-use crate::process_policies::ProcessRestartPolicy;
 use crate::sched::Kernel;
 use crate::syscall::{self, Syscall, SyscallReturn};
 use crate::upcall::UpcallId;
@@ -664,28 +663,28 @@ impl<'a> ProcessStateCell<'a> {
     }
 }
 
-/// The reaction the kernel should take when an app encounters a fault.
+/// The action the kernel should take when a process encounters a fault.
 ///
-/// When an exception occurs during an app's execution (a common example is an
-/// app trying to access memory outside of its allowed regions) the system will
-/// trap back to the kernel, and the kernel has to decide what to do with the
-/// app at that point.
+/// When an exception occurs during a process's execution (a common example is a
+/// process trying to access memory outside of its allowed regions) the system
+/// will trap back to the kernel, and the kernel has to decide what to do with
+/// the process at that point.
+///
+/// The actions are separate from the policy on deciding which action to take. A
+/// separate process-specific policy should determine which action to take.
 #[derive(Copy, Clone)]
-pub enum FaultResponse {
+pub enum FaultAction {
     /// Generate a `panic!()` call and crash the entire system. This is useful
     /// for debugging applications as the error is displayed immediately after
     /// it occurs.
     Panic,
 
-    /// Attempt to cleanup and restart the app which caused the fault. This
-    /// resets the app's memory to how it was when the app was started and
-    /// schedules the app to run again from its init function.
-    ///
-    /// The provided restart policy is used to determine whether to reset the
-    /// app, and can be specified on a per-app basis.
-    Restart(&'static dyn ProcessRestartPolicy),
+    /// Attempt to cleanup and restart the process which caused the fault. This
+    /// resets the process's memory to how it was when the process was started
+    /// and schedules the process to run again from its init function.
+    Restart,
 
-    /// Stop the app by no longer scheduling it to run.
+    /// Stop the process by no longer scheduling it to run.
     Stop,
 }
 

--- a/kernel/src/process_policies.rs
+++ b/kernel/src/process_policies.rs
@@ -35,6 +35,21 @@ impl ProcessFaultPolicy for StopFaultPolicy {
     }
 }
 
+/// Stop the process and no longer schedule it if a process faults, but also
+/// print a debug message notifying the user that the process faulted and
+/// stopped.
+pub struct StopWithDebugFaultPolicy {}
+
+impl ProcessFaultPolicy for StopWithDebugFaultPolicy {
+    fn action(&self, process: &dyn Process) -> process::FaultAction {
+        crate::debug!(
+            "Process {} faulted and was stopped.",
+            process.get_process_name()
+        );
+        process::FaultAction::Stop
+    }
+}
+
 /// Always restart the process if it faults.
 pub struct RestartFaultPolicy {}
 

--- a/kernel/src/process_policies.rs
+++ b/kernel/src/process_policies.rs
@@ -4,73 +4,89 @@
 //! kernel can use when managing processes. For example, these policies control
 //! decisions such as whether a specific process should be restarted.
 
+use crate::process;
 use crate::process::Process;
 
-/// Generic trait for implementing process restart policies.
+/// Generic trait for implementing a policy on what to do when a process faults.
 ///
-/// This policy allows a board to specify how the kernel should decide whether
-/// to restart an app after it crashes.
-pub trait ProcessRestartPolicy {
-    /// Decide whether to restart the `process` or not.
-    ///
-    /// Returns `true` if the process should be restarted, `false` otherwise.
-    fn should_restart(&self, process: &dyn Process) -> bool;
+/// Implementations can use the `Process` reference to decide which action to
+/// take. Implementations can also use `debug!()` to print messages if desired.
+pub trait ProcessFaultPolicy {
+    /// Decide which action the kernel should take in response to `process`
+    /// faulting.
+    fn action(&self, process: &dyn Process) -> process::FaultAction;
 }
 
-/// Implementation of `ProcessRestartPolicy` that uses a threshold to decide
-/// whether to restart an app. If the app has been restarted more times than the
-/// threshold then the app will no longer be restarted.
-pub struct ThresholdRestart {
+/// Simply panic the entire board if a process faults.
+pub struct PanicFaultPolicy {}
+
+impl ProcessFaultPolicy for PanicFaultPolicy {
+    fn action(&self, _: &dyn Process) -> process::FaultAction {
+        process::FaultAction::Panic
+    }
+}
+
+/// Simply stop the process and no longer schedule it if a process faults.
+pub struct StopFaultPolicy {}
+
+impl ProcessFaultPolicy for StopFaultPolicy {
+    fn action(&self, _: &dyn Process) -> process::FaultAction {
+        process::FaultAction::Stop
+    }
+}
+
+/// Always restart the process if it faults.
+pub struct RestartFaultPolicy {}
+
+impl ProcessFaultPolicy for RestartFaultPolicy {
+    fn action(&self, _: &dyn Process) -> process::FaultAction {
+        process::FaultAction::Restart
+    }
+}
+
+/// Implementation of `ProcessFaultPolicy` that uses a threshold to decide
+/// whether to restart a process when it faults. If the process has been
+/// restarted more times than the threshold then the process will be stopped
+/// and no longer scheduled.
+pub struct ThresholdRestartFaultPolicy {
     threshold: usize,
 }
 
-impl ThresholdRestart {
-    pub const fn new(threshold: usize) -> ThresholdRestart {
-        ThresholdRestart { threshold }
+impl ThresholdRestartFaultPolicy {
+    pub const fn new(threshold: usize) -> ThresholdRestartFaultPolicy {
+        ThresholdRestartFaultPolicy { threshold }
     }
 }
 
-impl ProcessRestartPolicy for ThresholdRestart {
-    fn should_restart(&self, process: &dyn Process) -> bool {
-        process.get_restart_count() <= self.threshold
-    }
-}
-
-/// Implementation of `ProcessRestartPolicy` that uses a threshold to decide
-/// whether to restart an app. If the app has been restarted more times than the
-/// threshold then the system will panic.
-pub struct ThresholdRestartThenPanic {
-    threshold: usize,
-}
-
-impl ThresholdRestartThenPanic {
-    pub const fn new(threshold: usize) -> ThresholdRestartThenPanic {
-        ThresholdRestartThenPanic { threshold }
-    }
-}
-
-impl ProcessRestartPolicy for ThresholdRestartThenPanic {
-    fn should_restart(&self, process: &dyn Process) -> bool {
+impl ProcessFaultPolicy for ThresholdRestartFaultPolicy {
+    fn action(&self, process: &dyn Process) -> process::FaultAction {
         if process.get_restart_count() <= self.threshold {
-            true
+            process::FaultAction::Restart
         } else {
-            panic!("Restart threshold surpassed!");
+            process::FaultAction::Stop
         }
     }
 }
 
-/// Implementation of `ProcessRestartPolicy` that unconditionally restarts the
-/// app.
-pub struct AlwaysRestart {}
+/// Implementation of `ProcessFaultPolicy` that uses a threshold to decide
+/// whether to restart a process when it faults. If the process has been
+/// restarted more times than the threshold then the board will panic.
+pub struct ThresholdRestartThenPanicFaultPolicy {
+    threshold: usize,
+}
 
-impl AlwaysRestart {
-    pub const fn new() -> AlwaysRestart {
-        AlwaysRestart {}
+impl ThresholdRestartThenPanicFaultPolicy {
+    pub const fn new(threshold: usize) -> ThresholdRestartThenPanicFaultPolicy {
+        ThresholdRestartThenPanicFaultPolicy { threshold }
     }
 }
 
-impl ProcessRestartPolicy for AlwaysRestart {
-    fn should_restart(&self, _process: &dyn Process) -> bool {
-        true
+impl ProcessFaultPolicy for ThresholdRestartThenPanicFaultPolicy {
+    fn action(&self, process: &dyn Process) -> process::FaultAction {
+        if process.get_restart_count() <= self.threshold {
+            process::FaultAction::Restart
+        } else {
+            process::FaultAction::Panic
+        }
     }
 }

--- a/kernel/src/process_standard.rs
+++ b/kernel/src/process_standard.rs
@@ -18,7 +18,8 @@ use crate::mem::{ReadOnlyAppSlice, ReadWriteAppSlice};
 use crate::platform::mpu::{self, MPU};
 use crate::platform::Chip;
 use crate::process::{Error, FunctionCall, FunctionCallSource, Process, State, Task};
-use crate::process::{FaultResponse, ProcessCustomGrantIdentifer, ProcessId, ProcessStateCell};
+use crate::process::{FaultAction, ProcessCustomGrantIdentifer, ProcessId, ProcessStateCell};
+use crate::process_policies::ProcessFaultPolicy;
 use crate::process_utilities::ProcessLoadError;
 use crate::sched::Kernel;
 use crate::syscall::{self, Syscall, SyscallReturn, UserspaceKernelBoundary};
@@ -159,8 +160,8 @@ pub struct ProcessStandard<'a, C: 'static + Chip> {
     /// scheduling it.
     state: ProcessStateCell<'static>,
 
-    /// How to deal with Faults occurring in the process
-    fault_response: FaultResponse,
+    /// How to respond if this process faults.
+    fault_policy: &'a dyn ProcessFaultPolicy,
 
     /// Configuration data for the MPU
     mpu_config: MapCell<<<C as Chip>::MPU as MPU>::MpuConfig>,
@@ -275,26 +276,20 @@ impl<C: Chip> Process for ProcessStandard<'_, C> {
     }
 
     fn set_fault_state(&self) {
-        match self.fault_response {
-            FaultResponse::Panic => {
+        // Use the per-process fault policy to determine what action the kernel
+        // should take since the process faulted.
+        let action = self.fault_policy.action(self);
+
+        match action {
+            FaultAction::Panic => {
                 // process faulted. Panic and print status
                 self.state.update(State::Faulted);
                 panic!("Process {} had a fault", self.process_name);
             }
-            FaultResponse::Restart(restart_policy) => {
-                // Apply the process policy for whether to try to restart
-                // on a fault. We sometimes don't want to (e.g., too
-                // many faults). If we decide to try to restart, the
-                // kernel applies its own policy for how to reuse the
-                // process: it may or may not restart the application.
-                if restart_policy.should_restart(self) {
-                    self.try_restart(COMPLETION_FAULT);
-                } else {
-                    self.terminate(COMPLETION_FAULT);
-                    self.state.update(State::Faulted);
-                }
+            FaultAction::Restart => {
+                self.try_restart(COMPLETION_FAULT);
             }
-            FaultResponse::Stop => {
+            FaultAction::Stop => {
                 // This looks a lot like restart, except we just leave the app
                 // how it faulted and mark it as `Faulted`. By clearing
                 // all of the app's todo work it will not be scheduled, and
@@ -1244,7 +1239,7 @@ impl<C: 'static + Chip> ProcessStandard<'_, C> {
         header_length: usize,
         app_version: u16,
         remaining_memory: &'a mut [u8],
-        fault_response: FaultResponse,
+        fault_policy: &'static dyn ProcessFaultPolicy,
         index: usize,
     ) -> Result<(Option<&'static dyn Process>, &'a mut [u8]), ProcessLoadError> {
         // Get a slice for just the app header.
@@ -1559,7 +1554,7 @@ impl<C: 'static + Chip> ProcessStandard<'_, C> {
         process.stored_state = MapCell::new(Default::default());
         // Mark this process as unstarted
         process.state = ProcessStateCell::new(process.kernel);
-        process.fault_response = fault_response;
+        process.fault_policy = fault_policy;
         process.restart_count = Cell::new(0);
 
         process.mpu_config = MapCell::new(mpu_config);

--- a/kernel/src/process_utilities.rs
+++ b/kernel/src/process_utilities.rs
@@ -7,7 +7,8 @@ use crate::capabilities::ProcessManagementCapability;
 use crate::config;
 use crate::debug;
 use crate::platform::Chip;
-use crate::process::{FaultResponse, Process};
+use crate::process::Process;
+use crate::process_policies::ProcessFaultPolicy;
 use crate::process_standard::ProcessStandard;
 use crate::sched::Kernel;
 
@@ -130,7 +131,7 @@ pub fn load_processes<C: Chip>(
     app_flash: &'static [u8],
     app_memory: &mut [u8], // not static, so that process.rs cannot hold on to slice w/o unsafe
     procs: &'static mut [Option<&'static dyn Process>],
-    fault_response: FaultResponse,
+    fault_policy: &'static dyn ProcessFaultPolicy,
     _capability: &dyn ProcessManagementCapability,
 ) -> Result<(), ProcessLoadError> {
     if config::CONFIG.debug_load_processes {
@@ -216,7 +217,7 @@ pub fn load_processes<C: Chip>(
                     header_length as usize,
                     version,
                     remaining_memory,
-                    fault_response,
+                    fault_policy,
                     i,
                 )?
             };


### PR DESCRIPTION
### Pull Request Overview

This pull request changes how per-process fault policies are handled in the kernel. Now, each process has a reference to a policy with trait:

```rust
pub trait ProcessFaultPolicy {
    fn action(&self, process: &dyn Process) -> process::FaultAction;
}
```

and all that policy has to do is return one action out of `Panic`, `Stop`, `Restart`. _How_ it decides on the action is completely up to the policy.

I also added a new policy called `StopWithDebug`, which prints a debug message if a process faults and then stops the process.

Each board is updated to the new policy mechanism.


### Testing Strategy

travis


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
