### PR TITLE
Make I2C trait return buffers upon request error

### DIFF
--- a/boards/imix/src/test/i2c_dummy.rs
+++ b/boards/imix/src/test/i2c_dummy.rs
@@ -4,6 +4,7 @@ use core::cell::Cell;
 use kernel::debug;
 use kernel::hil;
 use kernel::hil::i2c::I2CMaster;
+use kernel::ErrorCode;
 
 // ===========================================
 // Scan for I2C Slaves
@@ -24,10 +25,10 @@ impl ScanClient {
 }
 
 impl hil::i2c::I2CHwMasterClient for ScanClient {
-    fn command_complete(&self, buffer: &'static mut [u8], error: hil::i2c::Error) {
+    fn command_complete(&self, buffer: &'static mut [u8], status: Result<(), ErrorCode>) {
         let mut dev_id = self.dev_id.get();
 
-        if error == hil::i2c::Error::CommandComplete {
+        if status == Ok(()) {
             debug!("{:#x}", dev_id);
         }
 
@@ -35,7 +36,7 @@ impl hil::i2c::I2CHwMasterClient for ScanClient {
         if dev_id < 0x7F {
             dev_id += 1;
             self.dev_id.set(dev_id);
-            dev.write(dev_id, buffer, 2);
+            dev.write(dev_id, buffer, 2).unwrap();
         } else {
             debug!(
                 "Done scanning for I2C devices. Buffer len: {}",
@@ -57,7 +58,8 @@ pub fn i2c_scan_slaves(i2c_master: &'static mut dyn I2CMaster) {
     dev.enable();
 
     debug!("Scanning for I2C devices...");
-    dev.write(i2c_client.dev_id.get(), unsafe { &mut DATA }, 2);
+    dev.write(i2c_client.dev_id.get(), unsafe { &mut DATA }, 2)
+        .unwrap();
 }
 
 // ===========================================
@@ -87,24 +89,24 @@ impl AccelClient {
 }
 
 impl hil::i2c::I2CHwMasterClient for AccelClient {
-    fn command_complete(&self, buffer: &'static mut [u8], error: hil::i2c::Error) {
+    fn command_complete(&self, buffer: &'static mut [u8], status: Result<(), ErrorCode>) {
         let dev = self.i2c_master;
 
         match self.state.get() {
             AccelClientState::ReadingWhoami => {
-                debug!("WHOAMI Register 0x{:x} ({})", buffer[0], error);
+                debug!("WHOAMI Register 0x{:x} ({:?})", buffer[0], status);
                 debug!("Activating Sensor...");
                 buffer[0] = 0x2A as u8; // CTRL_REG1
                 buffer[1] = 1; // Bit 1 sets `active`
-                dev.write(0x1e, buffer, 2);
+                dev.write(0x1e, buffer, 2).unwrap();
                 self.state.set(AccelClientState::Activating);
             }
             AccelClientState::Activating => {
-                debug!("Sensor Activated ({})", error);
+                debug!("Sensor Activated ({:?})", status);
                 buffer[0] = 0x01 as u8; // X-MSB register
                                         // Reading 6 bytes will increment the register pointer through
                                         // X-MSB, X-LSB, Y-MSB, Y-LSB, Z-MSB, Z-LSB
-                dev.write_read(0x1e, buffer, 1, 6);
+                dev.write_read(0x1e, buffer, 1, 6).unwrap();
                 self.state.set(AccelClientState::ReadingAccelData);
             }
             AccelClientState::ReadingAccelData => {
@@ -117,24 +119,24 @@ impl hil::i2c::I2CHwMasterClient for AccelClient {
                 let z = ((z >> 2) * 976) / 1000;
 
                 debug!(
-                    "Accel data ready x: {}, y: {}, z: {} ({})",
+                    "Accel data ready x: {}, y: {}, z: {} ({:?})",
                     x >> 2,
                     y >> 2,
                     z >> 2,
-                    error
+                    status
                 );
 
                 buffer[0] = 0x01 as u8; // X-MSB register
                                         // Reading 6 bytes will increment the register pointer through
                                         // X-MSB, X-LSB, Y-MSB, Y-LSB, Z-MSB, Z-LSB
-                dev.write_read(0x1e, buffer, 1, 6);
+                dev.write_read(0x1e, buffer, 1, 6).unwrap();
                 self.state.set(AccelClientState::ReadingAccelData);
             }
             AccelClientState::Deactivating => {
-                debug!("Sensor deactivated ({})", error);
+                debug!("Sensor deactivated ({:?})", status);
                 debug!("Reading Accel's WHOAMI...");
                 buffer[0] = 0x0D as u8; // 0x0D == WHOAMI register
-                dev.write_read(0x1e, buffer, 1, 1);
+                dev.write_read(0x1e, buffer, 1, 1).unwrap();
                 self.state.set(AccelClientState::ReadingWhoami);
             }
         }
@@ -154,7 +156,7 @@ pub fn i2c_accel_test(i2c_master: &'static dyn I2CMaster) {
     let buf = unsafe { &mut DATA };
     debug!("Reading Accel's WHOAMI...");
     buf[0] = 0x0D as u8; // 0x0D == WHOAMI register
-    dev.write_read(0x1e, buf, 1, 1);
+    dev.write_read(0x1e, buf, 1, 1).unwrap();
     i2c_client.state.set(AccelClientState::ReadingWhoami);
 }
 
@@ -183,22 +185,26 @@ impl LiClient {
 }
 
 impl hil::i2c::I2CHwMasterClient for LiClient {
-    fn command_complete(&self, buffer: &'static mut [u8], error: hil::i2c::Error) {
+    fn command_complete(&self, buffer: &'static mut [u8], status: Result<(), ErrorCode>) {
         let dev = self.i2c_master;
 
         match self.state.get() {
             LiClientState::Enabling => {
-                debug!("Reading Lumminance Registers ({})", error);
+                debug!("Reading Lumminance Registers ({:?})", status);
                 buffer[0] = 0x02 as u8;
                 buffer[0] = 0;
-                dev.write_read(0x44, buffer, 1, 2);
+                dev.write_read(0x44, buffer, 1, 2).unwrap();
                 self.state.set(LiClientState::ReadingLI);
             }
             LiClientState::ReadingLI => {
                 let intensity = ((buffer[1] as usize) << 8) | buffer[0] as usize;
-                debug!("Light Intensity: {}% ({})", (intensity * 100) >> 16, error);
+                debug!(
+                    "Light Intensity: {}% ({:?})",
+                    (intensity * 100) >> 16,
+                    status
+                );
                 buffer[0] = 0x02 as u8;
-                dev.write_read(0x44, buffer, 1, 2);
+                dev.write_read(0x44, buffer, 1, 2).unwrap();
                 self.state.set(LiClientState::ReadingLI);
             }
         }
@@ -224,6 +230,6 @@ pub fn i2c_li_test(i2c_master: &'static dyn I2CMaster) {
     buf[0] = 0;
     buf[1] = 0b10100000;
     buf[2] = 0b00000000;
-    dev.write(0x44, buf, 3);
+    dev.write(0x44, buf, 3).unwrap();
     i2c_client.state.set(LiClientState::Enabling);
 }

--- a/boards/imix/src/test/i2c_dummy.rs
+++ b/boards/imix/src/test/i2c_dummy.rs
@@ -3,8 +3,7 @@
 use core::cell::Cell;
 use kernel::debug;
 use kernel::hil;
-use kernel::hil::i2c::I2CMaster;
-use kernel::ErrorCode;
+use kernel::hil::i2c::{Error, I2CMaster};
 
 // ===========================================
 // Scan for I2C Slaves
@@ -25,7 +24,7 @@ impl ScanClient {
 }
 
 impl hil::i2c::I2CHwMasterClient for ScanClient {
-    fn command_complete(&self, buffer: &'static mut [u8], status: Result<(), ErrorCode>) {
+    fn command_complete(&self, buffer: &'static mut [u8], status: Result<(), Error>) {
         let mut dev_id = self.dev_id.get();
 
         if status == Ok(()) {
@@ -89,7 +88,7 @@ impl AccelClient {
 }
 
 impl hil::i2c::I2CHwMasterClient for AccelClient {
-    fn command_complete(&self, buffer: &'static mut [u8], status: Result<(), ErrorCode>) {
+    fn command_complete(&self, buffer: &'static mut [u8], status: Result<(), Error>) {
         let dev = self.i2c_master;
 
         match self.state.get() {
@@ -185,7 +184,7 @@ impl LiClient {
 }
 
 impl hil::i2c::I2CHwMasterClient for LiClient {
-    fn command_complete(&self, buffer: &'static mut [u8], status: Result<(), ErrorCode>) {
+    fn command_complete(&self, buffer: &'static mut [u8], status: Result<(), Error>) {
         let dev = self.i2c_master;
 
         match self.state.get() {

--- a/capsules/src/apds9960.rs
+++ b/capsules/src/apds9960.rs
@@ -229,7 +229,7 @@ impl<'a> APDS9960<'a> {
 }
 
 impl i2c::I2CClient for APDS9960<'_> {
-    fn command_complete(&self, buffer: &'static mut [u8], _status: Result<(), ErrorCode>) {
+    fn command_complete(&self, buffer: &'static mut [u8], _status: Result<(), i2c::Error>) {
         match self.state.get() {
             State::ReadId => {
                 // The ID is in `buffer[0]`, and should be 0xAB.

--- a/capsules/src/apds9960.rs
+++ b/capsules/src/apds9960.rs
@@ -229,7 +229,7 @@ impl<'a> APDS9960<'a> {
 }
 
 impl i2c::I2CClient for APDS9960<'_> {
-    fn command_complete(&self, buffer: &'static mut [u8], _error: i2c::Error) {
+    fn command_complete(&self, buffer: &'static mut [u8], _status: Result<(), ErrorCode>) {
         match self.state.get() {
             State::ReadId => {
                 // The ID is in `buffer[0]`, and should be 0xAB.

--- a/capsules/src/apds9960.rs
+++ b/capsules/src/apds9960.rs
@@ -137,7 +137,8 @@ impl<'a> APDS9960<'a> {
             self.i2c.enable();
 
             buffer[0] = Registers::ID as u8;
-            self.i2c.write_read(buffer, 1, 1);
+            // TODO verify errors
+            let _ = self.i2c.write_read(buffer, 1, 1);
 
             self.state.set(State::ReadId); // Reading ID
         });
@@ -157,7 +158,8 @@ impl<'a> APDS9960<'a> {
 
             buffer[0] = Registers::PROXPULSEREG as u8;
             buffer[1] = (length << 6 | count) as u8;
-            self.i2c.write(buffer, 2);
+            // TODO verify errors
+            let _ = self.i2c.write(buffer, 2);
 
             self.state.set(State::SetPulse); // Send pulse control command to device
         });
@@ -174,7 +176,8 @@ impl<'a> APDS9960<'a> {
 
             buffer[0] = Registers::CONTROLREG1 as u8;
             buffer[1] = (ldrive << 6) as u8;
-            self.i2c.write(buffer, 2);
+            // TODO verify errors
+            let _ = self.i2c.write(buffer, 2);
 
             self.state.set(State::SetLdrive); // Send LED Current Control gain
         });
@@ -189,7 +192,8 @@ impl<'a> APDS9960<'a> {
             buffer[0] = Registers::ENABLE as u8;
             buffer[1] = PON | PEN;
 
-            self.i2c.write(buffer, 2);
+            // TODO verify errors
+            let _ = self.i2c.write(buffer, 2);
 
             self.state.set(State::TakeMeasurement1);
         });
@@ -221,7 +225,8 @@ impl<'a> APDS9960<'a> {
 
             buffer[0] = Registers::CONFIG3 as u8;
             buffer[1] = SAI;
-            self.i2c.write(buffer, 2);
+            // TODO verify errors
+            let _ = self.i2c.write(buffer, 2);
 
             self.state.set(State::SendSAI);
         });
@@ -241,34 +246,39 @@ impl i2c::I2CClient for APDS9960<'_> {
                 // Set persistence to 4
                 buffer[0] = Registers::PERS as u8;
                 buffer[1] = (PERS) << 4;
-                self.i2c.write(buffer, 2);
+                // TODO verify errors
+                let _ = self.i2c.write(buffer, 2);
                 self.state.set(State::StartingProximity);
             }
             State::StartingProximity => {
                 // Set low prox thresh to value in buffer
                 buffer[0] = Registers::PILT as u8;
                 buffer[1] = buffer[14];
-                self.i2c.write(buffer, 2);
+                // TODO verify errors
+                let _ = self.i2c.write(buffer, 2);
                 self.state.set(State::ConfiguringProximity1);
             }
             State::ConfiguringProximity1 => {
                 // Set high prox thresh to value in buffer
                 buffer[0] = Registers::PIHT as u8;
                 buffer[1] = buffer[15];
-                self.i2c.write(buffer, 2);
+                // TODO verify errors
+                let _ = self.i2c.write(buffer, 2);
                 self.state.set(State::ConfiguringProximity2);
             }
             State::ConfiguringProximity2 => {
                 // Clear proximity interrupt.
                 buffer[0] = Registers::PICCLR as u8;
-                self.i2c.write(buffer, 1);
+                // TODO verify errors
+                let _ = self.i2c.write(buffer, 1);
                 self.state.set(State::ConfiguringProximity3);
             }
             State::ConfiguringProximity3 => {
                 // Enable Device
                 buffer[0] = Registers::ENABLE as u8;
                 buffer[1] = PON | PEN | PIEN;
-                self.i2c.write(buffer, 2);
+                // TODO verify errors
+                let _ = self.i2c.write(buffer, 2);
                 self.state.set(State::PowerOn);
             }
             State::PowerOn => {
@@ -283,7 +293,8 @@ impl i2c::I2CClient for APDS9960<'_> {
 
                 // Clear proximity interrupt
                 buffer[0] = Registers::PICCLR as u8;
-                self.i2c.write(buffer, 1);
+                // TODO verify errors
+                let _ = self.i2c.write(buffer, 1);
                 self.interrupt_pin.disable_interrupts();
                 self.state.set(State::PowerOff);
             }
@@ -292,7 +303,8 @@ impl i2c::I2CClient for APDS9960<'_> {
 
                 buffer[0] = Registers::ENABLE as u8;
                 buffer[1] = 0 as u8;
-                self.i2c.write(buffer, 2);
+                // TODO verify errors
+                let _ = self.i2c.write(buffer, 2);
                 self.state.set(State::Done);
             }
             State::Done => {
@@ -308,7 +320,8 @@ impl i2c::I2CClient for APDS9960<'_> {
             State::TakeMeasurement1 => {
                 // Read status reg
                 buffer[0] = Registers::STATUS as u8;
-                self.i2c.write_read(buffer, 1, 1);
+                // TODO verify errors
+                let _ = self.i2c.write_read(buffer, 1, 1);
 
                 self.state.set(State::TakeMeasurement2);
             }
@@ -319,12 +332,14 @@ impl i2c::I2CClient for APDS9960<'_> {
 
                 if status_reg & PVALID > 0 {
                     buffer[0] = Registers::PDATA as u8;
-                    self.i2c.write_read(buffer, 1, 1);
+                    // TODO verify errors
+                    let _ = self.i2c.write_read(buffer, 1, 1);
                     self.state.set(State::TakeMeasurement3);
                 } else {
                     // If not valid then keep rechecking status reg
                     buffer[0] = Registers::STATUS as u8;
-                    self.i2c.write_read(buffer, 1, 1);
+                    // TODO verify errors
+                    let _ = self.i2c.write_read(buffer, 1, 1);
                     self.state.set(State::TakeMeasurement2);
                 }
             }
@@ -334,7 +349,8 @@ impl i2c::I2CClient for APDS9960<'_> {
                 // Reset callback value
                 buffer[0] = Registers::ENABLE as u8;
                 buffer[1] = 0;
-                self.i2c.write(buffer, 2);
+                // TODO verify errors
+                let _ = self.i2c.write(buffer, 2);
                 self.state.set(State::TakeMeasurement4);
             }
             State::TakeMeasurement4 => {
@@ -374,7 +390,8 @@ impl gpio::Client for APDS9960<'_> {
             self.i2c.enable();
 
             buffer[0] = Registers::PDATA as u8;
-            self.i2c.write_read(buffer, 1, 1);
+            // TODO verify errors
+            let _ = self.i2c.write_read(buffer, 1, 1);
             self.state.set(State::ReadData);
         });
     }

--- a/capsules/src/bus.rs
+++ b/capsules/src/bus.rs
@@ -264,7 +264,8 @@ impl<'a, I: I2CDevice> Bus<'a> for I2CMasterBus<'a, I> {
                 .map_or(Err(ErrorCode::NOMEM), |buffer| {
                     buffer[0] = addr as u8;
                     self.status.set(BusStatus::SetAddress);
-                    self.i2c.write(buffer, 1);
+                    // TODO verify errors
+                    let _ = self.i2c.write(buffer, 1);
                     Ok(())
                 }),
 
@@ -285,7 +286,8 @@ impl<'a, I: I2CDevice> Bus<'a> for I2CMasterBus<'a, I> {
             debug!("write len {}", len);
             self.len.set(len);
             self.status.set(BusStatus::Write);
-            self.i2c.write(buffer, (len * bytes) as u8);
+            // TODO verify errors
+            let _ = self.i2c.write(buffer, (len * bytes) as u8);
             Ok(())
         } else {
             Err(ErrorCode::NOMEM)
@@ -304,7 +306,8 @@ impl<'a, I: I2CDevice> Bus<'a> for I2CMasterBus<'a, I> {
         if len & bytes < 255 && buffer.len() >= len * bytes {
             self.len.set(len);
             self.status.set(BusStatus::Read);
-            self.i2c.read(buffer, (len * bytes) as u8);
+            // TODO verify errors
+            let _ = self.i2c.read(buffer, (len * bytes) as u8);
             Ok(())
         } else {
             Err(ErrorCode::NOMEM)

--- a/capsules/src/bus.rs
+++ b/capsules/src/bus.rs
@@ -27,7 +27,7 @@ use core::cell::Cell;
 use kernel::common::cells::OptionalCell;
 use kernel::debug;
 use kernel::hil::bus8080::{self, Bus8080};
-use kernel::hil::i2c::{I2CClient, I2CDevice};
+use kernel::hil::i2c::{Error, I2CClient, I2CDevice};
 use kernel::hil::spi::{ClockPhase, ClockPolarity, SpiMasterClient, SpiMasterDevice};
 use kernel::ErrorCode;
 
@@ -317,7 +317,7 @@ impl<'a, I: I2CDevice> Bus<'a> for I2CMasterBus<'a, I> {
 }
 
 impl<'a, I: I2CDevice> I2CClient for I2CMasterBus<'a, I> {
-    fn command_complete(&self, buffer: &'static mut [u8], status: Result<(), ErrorCode>) {
+    fn command_complete(&self, buffer: &'static mut [u8], status: Result<(), Error>) {
         let len = match status {
             Ok(()) => self.len.get(),
             _ => 0,

--- a/capsules/src/bus.rs
+++ b/capsules/src/bus.rs
@@ -27,7 +27,7 @@ use core::cell::Cell;
 use kernel::common::cells::OptionalCell;
 use kernel::debug;
 use kernel::hil::bus8080::{self, Bus8080};
-use kernel::hil::i2c::{Error, I2CClient, I2CDevice};
+use kernel::hil::i2c::{I2CClient, I2CDevice};
 use kernel::hil::spi::{ClockPhase, ClockPolarity, SpiMasterClient, SpiMasterDevice};
 use kernel::ErrorCode;
 
@@ -317,9 +317,9 @@ impl<'a, I: I2CDevice> Bus<'a> for I2CMasterBus<'a, I> {
 }
 
 impl<'a, I: I2CDevice> I2CClient for I2CMasterBus<'a, I> {
-    fn command_complete(&self, buffer: &'static mut [u8], error: Error) {
-        let len = match error {
-            Error::CommandComplete => self.len.get(),
+    fn command_complete(&self, buffer: &'static mut [u8], status: Result<(), ErrorCode>) {
+        let len = match status {
+            Ok(()) => self.len.get(),
             _ => 0,
         };
         match self.status.get() {

--- a/capsules/src/crc.rs
+++ b/capsules/src/crc.rs
@@ -199,7 +199,7 @@ impl<'a, C: hil::crc::CRC<'a>> Driver for Crc<'a, C> {
     ///
     /// ```
     ///
-    /// fn callback(status: Result<(), ErrorCode>, result: usize) {}
+    /// fn callback(status: Result<(), i2c::Error>, result: usize) {}
     /// ```
     ///
     /// where

--- a/capsules/src/ft6x06.rs
+++ b/capsules/src/ft6x06.rs
@@ -25,7 +25,7 @@ use enum_primitive::cast::FromPrimitive;
 use enum_primitive::enum_from_primitive;
 use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::hil::gpio;
-use kernel::hil::i2c::{self, Error};
+use kernel::hil::i2c;
 use kernel::hil::touch::{self, GestureEvent, TouchEvent, TouchStatus};
 use kernel::ErrorCode;
 
@@ -87,7 +87,7 @@ impl<'a> Ft6x06<'a> {
 }
 
 impl<'a> i2c::I2CClient for Ft6x06<'a> {
-    fn command_complete(&self, buffer: &'static mut [u8], _error: Error) {
+    fn command_complete(&self, buffer: &'static mut [u8], _status: Result<(), ErrorCode>) {
         self.state.set(State::Idle);
         self.num_touches.set((buffer[1] & 0x0F) as usize);
         self.touch_client.map(|client| {

--- a/capsules/src/ft6x06.rs
+++ b/capsules/src/ft6x06.rs
@@ -87,7 +87,7 @@ impl<'a> Ft6x06<'a> {
 }
 
 impl<'a> i2c::I2CClient for Ft6x06<'a> {
-    fn command_complete(&self, buffer: &'static mut [u8], _status: Result<(), ErrorCode>) {
+    fn command_complete(&self, buffer: &'static mut [u8], _status: Result<(), i2c::Error>) {
         self.state.set(State::Idle);
         self.num_touches.set((buffer[1] & 0x0F) as usize);
         self.touch_client.map(|client| {

--- a/capsules/src/ft6x06.rs
+++ b/capsules/src/ft6x06.rs
@@ -174,7 +174,8 @@ impl<'a> gpio::Client for Ft6x06<'a> {
             self.state.set(State::ReadingTouches);
 
             buffer[0] = Registers::REG_GEST_ID as u8;
-            self.i2c.write_read(buffer, 1, 15);
+            // TODO verify errors
+            let _ = self.i2c.write_read(buffer, 1, 15);
         });
     }
 }

--- a/capsules/src/fxos8700cq.rs
+++ b/capsules/src/fxos8700cq.rs
@@ -208,7 +208,7 @@ impl<'a> Fxos8700cq<'a> {
             buf[0] = Registers::CtrlReg4 as u8;
             buf[1] = 1; // CtrlReg4 data ready interrupt
             buf[2] = 1; // CtrlReg5 drdy on pin 1
-                        // TODO verify errors
+            // TODO verify errors
             let _ = self.i2c.write(buf, 3);
             self.state.set(State::ReadAccelSetup);
         });
@@ -258,7 +258,7 @@ impl I2CClient for Fxos8700cq<'_> {
             });
             return;
         }
-        match self.state.get() {
+        match self.state.get() { 
             State::ReadAccelSetup => {
                 // Setup the interrupt so we know when the sample is ready
                 self.interrupt_pin1
@@ -298,7 +298,7 @@ impl I2CClient for Fxos8700cq<'_> {
                 // Now put the chip into standby mode.
                 buffer[0] = Registers::CtrlReg1 as u8;
                 buffer[1] = 0; // Set the active bit to 0.
-                               // TODO verify errors
+                // TODO verify errors
                 let _ = self.i2c.write(buffer, 2);
                 self.state
                     .set(State::ReadAccelDeactivating(x as i16, y as i16, z as i16));

--- a/capsules/src/fxos8700cq.rs
+++ b/capsules/src/fxos8700cq.rs
@@ -208,7 +208,8 @@ impl<'a> Fxos8700cq<'a> {
             buf[0] = Registers::CtrlReg4 as u8;
             buf[1] = 1; // CtrlReg4 data ready interrupt
             buf[2] = 1; // CtrlReg5 drdy on pin 1
-            self.i2c.write(buf, 3);
+                        // TODO verify errors
+            let _ = self.i2c.write(buf, 3);
             self.state.set(State::ReadAccelSetup);
         });
     }
@@ -220,7 +221,8 @@ impl<'a> Fxos8700cq<'a> {
             buf[0] = Registers::MCtrlReg1 as u8;
             // Enable both accelerometer and magnetometer, and set one-shot read.
             buf[1] = 0b00100011;
-            self.i2c.write(buf, 2);
+            // TODO verify errors
+            let _ = self.i2c.write(buf, 2);
             self.state.set(State::ReadMagStart);
         });
     }
@@ -234,7 +236,8 @@ impl gpio::Client for Fxos8700cq<'_> {
             // When we get this interrupt we can read the sample.
             self.i2c.enable();
             buffer[0] = Registers::OutXMsb as u8;
-            self.i2c.write_read(buffer, 1, 6); // read 6 accel registers for xyz
+            // TODO verify errors
+            let _ = self.i2c.write_read(buffer, 1, 6); // read 6 accel registers for xyz
             self.state.set(State::ReadAccelReading);
         });
     }
@@ -264,7 +267,8 @@ impl I2CClient for Fxos8700cq<'_> {
                 // Enable the accelerometer.
                 buffer[0] = Registers::CtrlReg1 as u8;
                 buffer[1] = 1;
-                self.i2c.write(buffer, 2);
+                // TODO verify errors
+                let _ = self.i2c.write(buffer, 2);
                 self.state.set(State::ReadAccelWait);
             }
             State::ReadAccelWait => {
@@ -272,7 +276,8 @@ impl I2CClient for Fxos8700cq<'_> {
                     // Sample is already ready.
                     self.interrupt_pin1.disable_interrupts();
                     buffer[0] = Registers::OutXMsb as u8;
-                    self.i2c.write_read(buffer, 1, 6); // read 6 accel registers for xyz
+                    // TODO verify errors
+                    let _ = self.i2c.write_read(buffer, 1, 6); // read 6 accel registers for xyz
                     self.state.set(State::ReadAccelReading);
                 } else {
                     // Wait for the interrupt to trigger
@@ -293,7 +298,8 @@ impl I2CClient for Fxos8700cq<'_> {
                 // Now put the chip into standby mode.
                 buffer[0] = Registers::CtrlReg1 as u8;
                 buffer[1] = 0; // Set the active bit to 0.
-                self.i2c.write(buffer, 2);
+                               // TODO verify errors
+                let _ = self.i2c.write(buffer, 2);
                 self.state
                     .set(State::ReadAccelDeactivating(x as i16, y as i16, z as i16));
             }
@@ -309,7 +315,8 @@ impl I2CClient for Fxos8700cq<'_> {
                 // One shot measurement taken, now read result.
                 buffer[0] = Registers::MOutXMsb as u8;
                 self.state.set(State::ReadMagValues);
-                self.i2c.write_read(buffer, 1, 6);
+                // TODO verify errors
+                let _ = self.i2c.write_read(buffer, 1, 6);
             }
             State::ReadMagValues => {
                 let x = (((buffer[0] as u16) << 8) | buffer[1] as u16) as i16;

--- a/capsules/src/fxos8700cq.rs
+++ b/capsules/src/fxos8700cq.rs
@@ -25,7 +25,7 @@ use core::cell::Cell;
 use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::hil;
 use kernel::hil::gpio;
-use kernel::hil::i2c::{I2CClient, I2CDevice};
+use kernel::hil::i2c::{Error, I2CClient, I2CDevice};
 use kernel::ErrorCode;
 
 pub static mut BUF: [u8; 6] = [0; 6];
@@ -241,7 +241,7 @@ impl gpio::Client for Fxos8700cq<'_> {
 }
 
 impl I2CClient for Fxos8700cq<'_> {
-    fn command_complete(&self, buffer: &'static mut [u8], status: Result<(), ErrorCode>) {
+    fn command_complete(&self, buffer: &'static mut [u8], status: Result<(), Error>) {
         // If there's an I2C error, just reset and issue a callback
         // with all 0s. Otherwise, if there's no sensor attacherd,
         // it's possible to have nondeterminstic behavior, where

--- a/capsules/src/fxos8700cq.rs
+++ b/capsules/src/fxos8700cq.rs
@@ -208,6 +208,7 @@ impl<'a> Fxos8700cq<'a> {
             buf[0] = Registers::CtrlReg4 as u8;
             buf[1] = 1; // CtrlReg4 data ready interrupt
             buf[2] = 1; // CtrlReg5 drdy on pin 1
+
             // TODO verify errors
             let _ = self.i2c.write(buf, 3);
             self.state.set(State::ReadAccelSetup);
@@ -258,7 +259,7 @@ impl I2CClient for Fxos8700cq<'_> {
             });
             return;
         }
-        match self.state.get() { 
+        match self.state.get() {
             State::ReadAccelSetup => {
                 // Setup the interrupt so we know when the sample is ready
                 self.interrupt_pin1
@@ -298,6 +299,7 @@ impl I2CClient for Fxos8700cq<'_> {
                 // Now put the chip into standby mode.
                 buffer[0] = Registers::CtrlReg1 as u8;
                 buffer[1] = 0; // Set the active bit to 0.
+
                 // TODO verify errors
                 let _ = self.i2c.write(buffer, 2);
                 self.state

--- a/capsules/src/fxos8700cq.rs
+++ b/capsules/src/fxos8700cq.rs
@@ -25,7 +25,7 @@ use core::cell::Cell;
 use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::hil;
 use kernel::hil::gpio;
-use kernel::hil::i2c::{Error, I2CClient, I2CDevice};
+use kernel::hil::i2c::{I2CClient, I2CDevice};
 use kernel::ErrorCode;
 
 pub static mut BUF: [u8; 6] = [0; 6];
@@ -241,13 +241,13 @@ impl gpio::Client for Fxos8700cq<'_> {
 }
 
 impl I2CClient for Fxos8700cq<'_> {
-    fn command_complete(&self, buffer: &'static mut [u8], error: Error) {
+    fn command_complete(&self, buffer: &'static mut [u8], status: Result<(), ErrorCode>) {
         // If there's an I2C error, just reset and issue a callback
         // with all 0s. Otherwise, if there's no sensor attacherd,
         // it's possible to have nondeterminstic behavior, where
         // sometimes you get callbacks and sometimes you don't, based
         // on whether a floating interrupt line triggers. -pal 3/19/21
-        if error != Error::CommandComplete {
+        if status != Ok(()) {
             self.state.set(State::Disabled);
             self.buffer.replace(buffer);
             self.callback.map(|cb| {

--- a/capsules/src/hts221.rs
+++ b/capsules/src/hts221.rs
@@ -117,14 +117,16 @@ impl<'a> Hts221<'a> {
                 match self.state.get() {
                     State::Reset => {
                         buffer[0] = REG_AUTO_INCREMENT | CALIB_REG_1ST;
-                        self.i2c.write_read(buffer, 1, 16);
+                        // TODO verify errors
+                        let _ = self.i2c.write_read(buffer, 1, 16);
                         self.state.set(State::Calibrating);
                     }
                     State::Idle(calibration_data, _, _) => {
                         buffer[0] = REG_AUTO_INCREMENT | CTRL_REG1;
                         buffer[1] = 1 << 2 | 1 << 7; // BDU + PD
                         buffer[2] = 1; // ONE SHOT
-                        self.i2c.write(buffer, 3);
+                                       // TODO verify errors
+                        let _ = self.i2c.write(buffer, 3);
                         self.state.set(State::InitiateReading(calibration_data));
                     }
                     _ => {} // Should really never happen since we only have `buffer` available in the above two states
@@ -202,7 +204,8 @@ impl<'a> I2CClient for Hts221<'a> {
                         buffer[0] = REG_AUTO_INCREMENT | CTRL_REG1;
                         buffer[1] = 1 << 2 | 1 << 7; // BDU + PD
                         buffer[2] = 1; // ONE SHOT
-                        self.i2c.write(buffer, 3);
+                                       // TODO verify errors
+                        let _ = self.i2c.write(buffer, 3);
                         self.state.set(State::InitiateReading(CalibrationData {
                             temp_slope,
                             temp_intercept,
@@ -212,17 +215,20 @@ impl<'a> I2CClient for Hts221<'a> {
                     }
                     State::InitiateReading(calibration_data) => {
                         buffer[0] = STATUS_REG;
-                        self.i2c.write_read(buffer, 1, 1);
+                        // TODO verify errors
+                        let _ = self.i2c.write_read(buffer, 1, 1);
                         self.state.set(State::CheckStatus(calibration_data));
                     }
                     State::CheckStatus(calibration_data) => {
                         if buffer[0] & 0b11 == 0b11 {
                             buffer[0] = REG_AUTO_INCREMENT | HUMID0_REG;
-                            self.i2c.write_read(buffer, 1, 4);
+                            // TODO verify errors
+                            let _ = self.i2c.write_read(buffer, 1, 4);
                             self.state.set(State::Read(calibration_data));
                         } else {
                             buffer[0] = STATUS_REG;
-                            self.i2c.write_read(buffer, 1, 1);
+                            // TODO verify errors
+                            let _ = self.i2c.write_read(buffer, 1, 1);
                         }
                     }
                     State::Read(calibration_data) => {
@@ -243,7 +249,8 @@ impl<'a> I2CClient for Hts221<'a> {
                         // Status register never updates to read after the first transaction. For
                         // now, leave it on and waste 2uA.
                         buffer[1] = 1 << 7; // Leave PD bit on
-                        self.i2c.write(buffer, 2);
+                                            // TODO verify errors
+                        let _ = self.i2c.write(buffer, 2);
                         self.state
                             .set(State::Idle(calibration_data, temperature, humidity));
                     }

--- a/capsules/src/hts221.rs
+++ b/capsules/src/hts221.rs
@@ -125,7 +125,8 @@ impl<'a> Hts221<'a> {
                         buffer[0] = REG_AUTO_INCREMENT | CTRL_REG1;
                         buffer[1] = 1 << 2 | 1 << 7; // BDU + PD
                         buffer[2] = 1; // ONE SHOT
-                                       // TODO verify errors
+
+                        // TODO verify errors
                         let _ = self.i2c.write(buffer, 3);
                         self.state.set(State::InitiateReading(calibration_data));
                     }
@@ -204,6 +205,7 @@ impl<'a> I2CClient for Hts221<'a> {
                         buffer[0] = REG_AUTO_INCREMENT | CTRL_REG1;
                         buffer[1] = 1 << 2 | 1 << 7; // BDU + PD
                         buffer[2] = 1; // ONE SHOT
+
                         // TODO verify errors
                         let _ = self.i2c.write(buffer, 3);
                         self.state.set(State::InitiateReading(CalibrationData {
@@ -249,7 +251,8 @@ impl<'a> I2CClient for Hts221<'a> {
                         // Status register never updates to read after the first transaction. For
                         // now, leave it on and waste 2uA.
                         buffer[1] = 1 << 7; // Leave PD bit on
-                                            // TODO verify errors
+
+                        // TODO verify errors
                         let _ = self.i2c.write(buffer, 2);
                         self.state
                             .set(State::Idle(calibration_data, temperature, humidity));

--- a/capsules/src/hts221.rs
+++ b/capsules/src/hts221.rs
@@ -204,7 +204,7 @@ impl<'a> I2CClient for Hts221<'a> {
                         buffer[0] = REG_AUTO_INCREMENT | CTRL_REG1;
                         buffer[1] = 1 << 2 | 1 << 7; // BDU + PD
                         buffer[2] = 1; // ONE SHOT
-                                       // TODO verify errors
+                        // TODO verify errors
                         let _ = self.i2c.write(buffer, 3);
                         self.state.set(State::InitiateReading(CalibrationData {
                             temp_slope,

--- a/capsules/src/hts221.rs
+++ b/capsules/src/hts221.rs
@@ -175,7 +175,7 @@ enum State {
 }
 
 impl<'a> I2CClient for Hts221<'a> {
-    fn command_complete(&self, buffer: &'static mut [u8], status: Result<(), ErrorCode>) {
+    fn command_complete(&self, buffer: &'static mut [u8], status: Result<(), i2c::Error>) {
         match status {
             Ok(()) => {
                 match self.state.get() {

--- a/capsules/src/hts221.rs
+++ b/capsules/src/hts221.rs
@@ -175,9 +175,9 @@ enum State {
 }
 
 impl<'a> I2CClient for Hts221<'a> {
-    fn command_complete(&self, buffer: &'static mut [u8], err: i2c::Error) {
-        match err {
-            i2c::Error::CommandComplete => {
+    fn command_complete(&self, buffer: &'static mut [u8], status: Result<(), ErrorCode>) {
+        match status {
+            Ok(()) => {
                 match self.state.get() {
                     State::Calibrating => {
                         let h0rh = buffer[0] as f32;
@@ -264,7 +264,7 @@ impl<'a> I2CClient for Hts221<'a> {
                 }
             }
             _ => {
-                kernel::debug!("Oops, some sort of error {:?}", err);
+                kernel::debug!("Oops, some sort of error {:?}", status);
             }
         }
     }

--- a/capsules/src/i2c_master.rs
+++ b/capsules/src/i2c_master.rs
@@ -81,7 +81,7 @@ impl<'a, I: 'a + i2c::I2CMaster> I2CMasterDriver<'a, I> {
                             Ok(_) => Ok(()),
                             Err((error, data)) => {
                                 self.buf.put(Some(data));
-                                Err(error)
+                                Err(error.into())
                             }
                         }
                     })
@@ -208,7 +208,7 @@ impl<'a, I: 'a + i2c::I2CMaster> Driver for I2CMasterDriver<'a, I> {
 }
 
 impl<'a, I: 'a + i2c::I2CMaster> i2c::I2CHwMasterClient for I2CMasterDriver<'a, I> {
-    fn command_complete(&self, buffer: &'static mut [u8], _status: Result<(), ErrorCode>) {
+    fn command_complete(&self, buffer: &'static mut [u8], _status: Result<(), i2c::Error>) {
         self.tx.take().map(|tx| {
             self.apps.enter(tx.app_id, |app| {
                 if let Some(read_len) = tx.read_len.take() {

--- a/capsules/src/i2c_master.rs
+++ b/capsules/src/i2c_master.rs
@@ -169,7 +169,8 @@ impl<'a, I: 'a + i2c::I2CMaster> Driver for I2CMasterDriver<'a, I> {
                     .enter(appid, |app| {
                         let addr = arg1 as u8;
                         let write_len = arg2;
-                        self.operation(appid, app, Cmd::Write, addr, write_len as u8, 0);
+                        // TODO verify errors
+                        let _ = self.operation(appid, app, Cmd::Write, addr, write_len as u8, 0);
                         CommandReturn::success()
                     })
                     .unwrap_or_else(|err| err.into()),
@@ -178,7 +179,8 @@ impl<'a, I: 'a + i2c::I2CMaster> Driver for I2CMasterDriver<'a, I> {
                     .enter(appid, |app| {
                         let addr = arg1 as u8;
                         let read_len = arg2;
-                        self.operation(appid, app, Cmd::Read, addr, 0, read_len as u8);
+                        // TODO verify errors
+                        let _ = self.operation(appid, app, Cmd::Read, addr, 0, read_len as u8);
                         CommandReturn::success()
                     })
                     .unwrap_or_else(|err| err.into()),
@@ -188,7 +190,8 @@ impl<'a, I: 'a + i2c::I2CMaster> Driver for I2CMasterDriver<'a, I> {
                     let read_len = arg2; // can extend to 32 bit read length
                     self.apps
                         .enter(appid, |app| {
-                            self.operation(
+                            // TODO verify errors
+                            let _ = self.operation(
                                 appid,
                                 app,
                                 Cmd::WriteRead,

--- a/capsules/src/i2c_master.rs
+++ b/capsules/src/i2c_master.rs
@@ -208,7 +208,7 @@ impl<'a, I: 'a + i2c::I2CMaster> Driver for I2CMasterDriver<'a, I> {
 }
 
 impl<'a, I: 'a + i2c::I2CMaster> i2c::I2CHwMasterClient for I2CMasterDriver<'a, I> {
-    fn command_complete(&self, buffer: &'static mut [u8], _error: i2c::Error) {
+    fn command_complete(&self, buffer: &'static mut [u8], _status: Result<(), ErrorCode>) {
         self.tx.take().map(|tx| {
             self.apps.enter(tx.app_id, |app| {
                 if let Some(read_len) = tx.read_len.take() {

--- a/capsules/src/i2c_master.rs
+++ b/capsules/src/i2c_master.rs
@@ -52,7 +52,7 @@ impl<'a, I: 'a + i2c::I2CMaster> I2CMasterDriver<'a, I> {
         addr: u8,
         wlen: u8,
         rlen: u8,
-    ) {
+    ) -> Result<(), ErrorCode> {
         // TODO(alevy) this function used to try and return Result<(), ErrorCode>s, but would always return
         // ENOSUPPORT and all call-sites simply ignore the return value. Nonetheless, some error
         // handling is probably useful. Comments inline where there used to be non-success results.
@@ -60,8 +60,8 @@ impl<'a, I: 'a + i2c::I2CMaster> I2CMasterDriver<'a, I> {
             .enter(app_id, |_| {
                 // TODO(alevy): if app.slice.map doesn't have a slice, we would have returned
                 // INVAL here. I.e., the driver is attempting an operation without sharing memory.
-                app.slice.map_or((), |app_buffer| {
-                    self.buf.take().map(|buffer| {
+                app.slice.map_or(Err(ErrorCode::INVAL), |app_buffer| {
+                    self.buf.take().map_or(Err(ErrorCode::NOMEM), |buffer| {
                         buffer[..(wlen as usize)].copy_from_slice(&app_buffer[..(wlen as usize)]);
 
                         let read_len: OptionalCell<usize>;
@@ -72,18 +72,24 @@ impl<'a, I: 'a + i2c::I2CMaster> I2CMasterDriver<'a, I> {
                         }
                         self.tx.put(Transaction { app_id, read_len });
 
-                        match command {
-                            Cmd::Ping => (), // Unexpected, shouldn't get here (was Err(ErrorCode::INVAL))
+                        match match command {
+                            Cmd::Ping => unreachable!(), // Unexpected, shouldn't get here (was Err(ErrorCode::INVAL))
                             Cmd::Write => self.i2c.write(addr, buffer, wlen),
                             Cmd::Read => self.i2c.read(addr, buffer, rlen),
                             Cmd::WriteRead => self.i2c.write_read(addr, buffer, wlen, rlen),
+                        } {
+                            Ok(_) => Ok(()),
+                            Err((error, data)) => {
+                                self.buf.put(Some(data));
+                                Err(error)
+                            }
                         }
-                    });
+                    })
                     // TODO(alevy): if buf.take() returned None, the I2C hadn't returned the
                     // buffer. This shouldn't happen and previous this returned NOMEM
                 })
             })
-            .expect("Appid does not map to app");
+            .expect("Appid does not map to app")
     }
 }
 

--- a/capsules/src/i2c_master_slave_driver.rs
+++ b/capsules/src/i2c_master_slave_driver.rs
@@ -75,9 +75,12 @@ impl<'a> I2CMasterSlaveDriver<'a> {
 }
 
 impl hil::i2c::I2CHwMasterClient for I2CMasterSlaveDriver<'_> {
-    fn command_complete(&self, buffer: &'static mut [u8], status: Result<(), ErrorCode>) {
+    fn command_complete(&self, buffer: &'static mut [u8], status: Result<(), hil::i2c::Error>) {
         // Map I2C error to a number we can pass back to the application
-        let status = kernel::into_statuscode(status);
+        let status = kernel::into_statuscode(match status {
+            Ok(_) => Ok(()),
+            Err(e) => Err(e.into()),
+        });
 
         // Signal the application layer. Need to copy read in bytes if this
         // was a read call.

--- a/capsules/src/i2c_master_slave_driver.rs
+++ b/capsules/src/i2c_master_slave_driver.rs
@@ -224,7 +224,8 @@ impl hil::i2c::I2CHwSlaveClient for I2CMasterSlaveDriver<'_> {
         // just let the hardware layer have it. But, if it does happen
         // we can respond.
         self.slave_buffer1.take().map(|buffer| {
-            hil::i2c::I2CSlave::write_receive(self.i2c, buffer, 255);
+            // TODO verify errors
+            let _ = hil::i2c::I2CSlave::write_receive(self.i2c, buffer, 255);
         });
     }
 }
@@ -352,7 +353,8 @@ impl Driver for I2CMasterSlaveDriver<'_> {
                             self.master_action.set(MasterAction::Write);
 
                             hil::i2c::I2CMaster::enable(self.i2c);
-                            hil::i2c::I2CMaster::write(
+                            // TODO verify errors
+                            let _ = hil::i2c::I2CMaster::write(
                                 self.i2c,
                                 address,
                                 kernel_tx,
@@ -391,7 +393,13 @@ impl Driver for I2CMasterSlaveDriver<'_> {
                             self.master_action.set(MasterAction::Read(read_len as u8));
 
                             hil::i2c::I2CMaster::enable(self.i2c);
-                            hil::i2c::I2CMaster::read(self.i2c, address, kernel_tx, read_len as u8);
+                            // TODO verify errors
+                            let _ = hil::i2c::I2CMaster::read(
+                                self.i2c,
+                                address,
+                                kernel_tx,
+                                read_len as u8,
+                            );
                         });
                         0
                     });
@@ -405,7 +413,8 @@ impl Driver for I2CMasterSlaveDriver<'_> {
                 // We can always handle a write since this module has a buffer.
                 // .map will handle if we have already done this.
                 self.slave_buffer1.take().map(|buffer| {
-                    hil::i2c::I2CSlave::write_receive(self.i2c, buffer, 255);
+                    // TODO verify errors
+                    let _ = hil::i2c::I2CSlave::write_receive(self.i2c, buffer, 255);
                 });
 
                 // Actually get things going
@@ -439,7 +448,9 @@ impl Driver for I2CMasterSlaveDriver<'_> {
                                 *c = app_tx[i];
                             }
 
-                            hil::i2c::I2CSlave::read_send(self.i2c, kernel_tx, read_len as u8);
+                            // TODO verify errors
+                            let _ =
+                                hil::i2c::I2CSlave::read_send(self.i2c, kernel_tx, read_len as u8);
                         });
                         0
                     });
@@ -466,7 +477,8 @@ impl Driver for I2CMasterSlaveDriver<'_> {
                 if address > 0x7f {
                     return CommandReturn::failure(ErrorCode::INVAL);
                 }
-                hil::i2c::I2CSlave::set_address(self.i2c, address);
+                // TODO verify errors
+                let _ = hil::i2c::I2CSlave::set_address(self.i2c, address);
                 CommandReturn::success()
             }
 
@@ -493,7 +505,8 @@ impl Driver for I2CMasterSlaveDriver<'_> {
                             self.master_action
                                 .set(MasterAction::WriteRead(read_len as u8));
                             hil::i2c::I2CMaster::enable(self.i2c);
-                            hil::i2c::I2CMaster::write_read(
+                            // TODO verify errors
+                            let _ = hil::i2c::I2CMaster::write_read(
                                 self.i2c,
                                 address,
                                 kernel_tx,

--- a/capsules/src/i2c_master_slave_driver.rs
+++ b/capsules/src/i2c_master_slave_driver.rs
@@ -84,6 +84,8 @@ impl hil::i2c::I2CHwMasterClient for I2CMasterSlaveDriver<'_> {
             hil::i2c::Error::Overrun => -4,
             hil::i2c::Error::NotSupported => -5,
             hil::i2c::Error::CommandComplete => 0,
+            // TODO most probaly this should not occur as this is used for the mux
+            hil::i2c::Error::Request(_) => unreachable!(),
         };
 
         // Signal the application layer. Need to copy read in bytes if this

--- a/capsules/src/isl29035.rs
+++ b/capsules/src/isl29035.rs
@@ -30,7 +30,7 @@
 
 use core::cell::Cell;
 use kernel::common::cells::{OptionalCell, TakeCell};
-use kernel::hil::i2c::{I2CClient, I2CDevice};
+use kernel::hil::i2c::{Error, I2CClient, I2CDevice};
 use kernel::hil::sensors::{AmbientLight, AmbientLightClient};
 use kernel::hil::time;
 use kernel::ErrorCode;
@@ -114,7 +114,7 @@ impl<'a, A: time::Alarm<'a>> time::AlarmClient for Isl29035<'a, A> {
 }
 
 impl<'a, A: time::Alarm<'a>> I2CClient for Isl29035<'a, A> {
-    fn command_complete(&self, buffer: &'static mut [u8], _status: Result<(), ErrorCode>) {
+    fn command_complete(&self, buffer: &'static mut [u8], _status: Result<(), Error>) {
         // TODO(alevy): handle I2C errors
         match self.state.get() {
             State::Enabling => {

--- a/capsules/src/isl29035.rs
+++ b/capsules/src/isl29035.rs
@@ -30,7 +30,7 @@
 
 use core::cell::Cell;
 use kernel::common::cells::{OptionalCell, TakeCell};
-use kernel::hil::i2c::{Error, I2CClient, I2CDevice};
+use kernel::hil::i2c::{I2CClient, I2CDevice};
 use kernel::hil::sensors::{AmbientLight, AmbientLightClient};
 use kernel::hil::time;
 use kernel::ErrorCode;
@@ -114,7 +114,7 @@ impl<'a, A: time::Alarm<'a>> time::AlarmClient for Isl29035<'a, A> {
 }
 
 impl<'a, A: time::Alarm<'a>> I2CClient for Isl29035<'a, A> {
-    fn command_complete(&self, buffer: &'static mut [u8], _error: Error) {
+    fn command_complete(&self, buffer: &'static mut [u8], _status: Result<(), ErrorCode>) {
         // TODO(alevy): handle I2C errors
         match self.state.get() {
             State::Enabling => {

--- a/capsules/src/isl29035.rs
+++ b/capsules/src/isl29035.rs
@@ -82,7 +82,8 @@ impl<'a, A: time::Alarm<'a>> Isl29035<'a, A> {
                 // ADC resolution 8-bit (bits 2,3)
                 // Other bits are reserved
                 buf[2] = 0b00001001;
-                self.i2c.write(buf, 3);
+                // TODO verify errors
+                let _ = self.i2c.write(buf, 3);
                 self.state.set(State::Enabling);
             });
         }
@@ -107,7 +108,8 @@ impl<'a, A: time::Alarm<'a>> time::AlarmClient for Isl29035<'a, A> {
             self.i2c.enable();
 
             buffer[0] = 0x02 as u8;
-            self.i2c.write_read(buffer, 1, 2);
+            // TODO verify errors
+            let _ = self.i2c.write_read(buffer, 1, 2);
             self.state.set(State::ReadingLI);
         });
     }
@@ -140,7 +142,8 @@ impl<'a, A: time::Alarm<'a>> I2CClient for Isl29035<'a, A> {
                 let lux = (data * 4000) >> 8;
 
                 buffer[0] = 0;
-                self.i2c.write(buffer, 2);
+                // TODO verify errors
+                let _ = self.i2c.write(buffer, 2);
                 self.state.set(State::Disabling(lux));
             }
             State::Disabling(lux) => {

--- a/capsules/src/lps25hb.rs
+++ b/capsules/src/lps25hb.rs
@@ -157,7 +157,7 @@ impl<'a> LPS25HB<'a> {
 }
 
 impl i2c::I2CClient for LPS25HB<'_> {
-    fn command_complete(&self, buffer: &'static mut [u8], _error: i2c::Error) {
+    fn command_complete(&self, buffer: &'static mut [u8], _status: Result<(), ErrorCode>) {
         match self.state.get() {
             State::SelectWhoAmI => {
                 self.i2c.read(buffer, 1);

--- a/capsules/src/lps25hb.rs
+++ b/capsules/src/lps25hb.rs
@@ -131,7 +131,8 @@ impl<'a> LPS25HB<'a> {
             self.i2c.enable();
 
             buf[0] = Registers::WhoAmI as u8;
-            self.i2c.write(buf, 1);
+            // TODO verify errors
+            let _ = self.i2c.write(buf, 1);
             self.state.set(State::SelectWhoAmI);
         });
     }
@@ -150,7 +151,8 @@ impl<'a> LPS25HB<'a> {
             buf[2] = 0;
             buf[3] = 0;
             buf[4] = CTRL_REG4_INTERRUPT1_DATAREADY;
-            self.i2c.write(buf, 5);
+            // TODO verify errors
+            let _ = self.i2c.write(buf, 5);
             self.state.set(State::TakeMeasurementInit);
         });
     }
@@ -160,7 +162,8 @@ impl i2c::I2CClient for LPS25HB<'_> {
     fn command_complete(&self, buffer: &'static mut [u8], _status: Result<(), i2c::Error>) {
         match self.state.get() {
             State::SelectWhoAmI => {
-                self.i2c.read(buffer, 1);
+                // TODO verify errors
+                let _ = self.i2c.read(buffer, 1);
                 self.state.set(State::ReadingWhoAmI);
             }
             State::ReadingWhoAmI => {
@@ -170,22 +173,26 @@ impl i2c::I2CClient for LPS25HB<'_> {
             }
             State::TakeMeasurementInit => {
                 buffer[0] = Registers::PressOutXl as u8 | REGISTER_AUTO_INCREMENT;
-                self.i2c.write(buffer, 1);
+                // TODO verify errors
+                let _ = self.i2c.write(buffer, 1);
                 self.state.set(State::TakeMeasurementClear);
             }
             State::TakeMeasurementClear => {
-                self.i2c.read(buffer, 3);
+                // TODO verify errors
+                let _ = self.i2c.read(buffer, 3);
                 self.state.set(State::TakeMeasurementConfigure);
             }
             State::TakeMeasurementConfigure => {
                 buffer[0] = Registers::CtrlReg1 as u8 | REGISTER_AUTO_INCREMENT;
                 buffer[1] = CTRL_REG1_POWER_ON | CTRL_REG1_BLOCK_DATA_ENABLE;
                 buffer[2] = CTRL_REG2_ONE_SHOT;
-                self.i2c.write(buffer, 3);
+                // TODO verify errors
+                let _ = self.i2c.write(buffer, 3);
                 self.state.set(State::Done);
             }
             State::ReadMeasurement => {
-                self.i2c.read(buffer, 3);
+                // TODO verify errors
+                let _ = self.i2c.read(buffer, 3);
                 self.state.set(State::GotMeasurement);
             }
             State::GotMeasurement => {
@@ -204,7 +211,8 @@ impl i2c::I2CClient for LPS25HB<'_> {
 
                 buffer[0] = Registers::CtrlReg1 as u8;
                 buffer[1] = 0;
-                self.i2c.write(buffer, 2);
+                // TODO verify errors
+                let _ = self.i2c.write(buffer, 2);
                 self.interrupt_pin.disable_interrupts();
                 self.state.set(State::Done);
             }
@@ -226,7 +234,8 @@ impl gpio::Client for LPS25HB<'_> {
 
             // select sensor voltage register and read it
             buf[0] = Registers::PressOutXl as u8 | REGISTER_AUTO_INCREMENT;
-            self.i2c.write(buf, 1);
+            // TODO verify errors
+            let _ = self.i2c.write(buf, 1);
             self.state.set(State::ReadMeasurement);
         });
     }

--- a/capsules/src/lps25hb.rs
+++ b/capsules/src/lps25hb.rs
@@ -157,7 +157,7 @@ impl<'a> LPS25HB<'a> {
 }
 
 impl i2c::I2CClient for LPS25HB<'_> {
-    fn command_complete(&self, buffer: &'static mut [u8], _status: Result<(), ErrorCode>) {
+    fn command_complete(&self, buffer: &'static mut [u8], _status: Result<(), i2c::Error>) {
         match self.state.get() {
             State::SelectWhoAmI => {
                 self.i2c.read(buffer, 1);

--- a/capsules/src/lsm303agr.rs
+++ b/capsules/src/lsm303agr.rs
@@ -317,7 +317,7 @@ impl<'a> Lsm303agrI2C<'a> {
 }
 
 impl i2c::I2CClient for Lsm303agrI2C<'_> {
-    fn command_complete(&self, buffer: &'static mut [u8], status: Result<(), ErrorCode>) {
+    fn command_complete(&self, buffer: &'static mut [u8], status: Result<(), i2c::Error>) {
         match self.state.get() {
             State::IsPresent => {
                 let present = if status == Ok(()) && buffer[0] == 60 {

--- a/capsules/src/lsm303agr.rs
+++ b/capsules/src/lsm303agr.rs
@@ -216,7 +216,8 @@ impl<'a> Lsm303agrI2C<'a> {
             // turn on i2c to send commands
             buf[0] = 0x0F;
             self.i2c_magnetometer.enable();
-            self.i2c_magnetometer.write_read(buf, 1, 1);
+            // TODO verify errors
+            let _ = self.i2c_magnetometer.write_read(buf, 1, 1);
         });
     }
 
@@ -232,7 +233,8 @@ impl<'a> Lsm303agrI2C<'a> {
                     + CTRL_REG1::XEN::SET)
                     .value;
                 self.i2c_accelerometer.enable();
-                self.i2c_accelerometer.write(buf, 2);
+                // TODO verify errors
+                let _ = self.i2c_accelerometer.write(buf, 2);
             });
         }
     }
@@ -250,7 +252,8 @@ impl<'a> Lsm303agrI2C<'a> {
                     + CTRL_REG4::BDU::SET)
                     .value;
                 self.i2c_accelerometer.enable();
-                self.i2c_accelerometer.write(buf, 2);
+                // TODO verify errors
+                let _ = self.i2c_accelerometer.write(buf, 2);
             });
         }
     }
@@ -261,7 +264,8 @@ impl<'a> Lsm303agrI2C<'a> {
             self.buffer.take().map(|buf| {
                 buf[0] = AccelerometerRegisters::OUT_X_L_A as u8 | REGISTER_AUTO_INCREMENT;
                 self.i2c_accelerometer.enable();
-                self.i2c_accelerometer.write_read(buf, 1, 6);
+                // TODO verify errors
+                let _ = self.i2c_accelerometer.write_read(buf, 1, 6);
             });
         }
     }
@@ -273,7 +277,8 @@ impl<'a> Lsm303agrI2C<'a> {
                 buf[0] = MagnetometerRegisters::CRA_REG_M as u8;
                 buf[1] = ((data_rate as u8) << 2) | 1 << 7;
                 self.i2c_magnetometer.enable();
-                self.i2c_magnetometer.write(buf, 2);
+                // TODO verify errors
+                let _ = self.i2c_magnetometer.write(buf, 2);
             });
         }
     }
@@ -288,7 +293,8 @@ impl<'a> Lsm303agrI2C<'a> {
                 buf[1] = (range as u8) << 5;
                 buf[2] = 0;
                 self.i2c_magnetometer.enable();
-                self.i2c_magnetometer.write(buf, 3);
+                // TODO verify errors
+                let _ = self.i2c_magnetometer.write(buf, 3);
             });
         }
     }
@@ -299,7 +305,8 @@ impl<'a> Lsm303agrI2C<'a> {
             self.buffer.take().map(|buf| {
                 buf[0] = AgrAccelerometerRegisters::TEMP_OUT_H_A as u8;
                 self.i2c_accelerometer.enable();
-                self.i2c_accelerometer.write_read(buf, 1, 2);
+                // TODO verify errors
+                let _ = self.i2c_accelerometer.write_read(buf, 1, 2);
             });
         }
     }
@@ -310,7 +317,8 @@ impl<'a> Lsm303agrI2C<'a> {
             self.buffer.take().map(|buf| {
                 buf[0] = MagnetometerRegisters::OUT_X_H_M as u8;
                 self.i2c_magnetometer.enable();
-                self.i2c_magnetometer.write_read(buf, 1, 6);
+                // TODO verify errors
+                let _ = self.i2c_magnetometer.write_read(buf, 1, 6);
             });
         }
     }

--- a/capsules/src/lsm303agr.rs
+++ b/capsules/src/lsm303agr.rs
@@ -335,7 +335,7 @@ impl i2c::I2CClient for Lsm303agrI2C<'_> {
                 self.state.set(State::Idle);
             }
             State::SetPowerMode => {
-                let set_power = error == Error::CommandComplete;
+                let set_power = status == Ok(());
                 self.owning_process.map(|pid| {
                     let _res = self.apps.enter(*pid, |app| {
                         app.upcall.schedule(if set_power { 1 } else { 0 }, 0, 0);
@@ -352,7 +352,7 @@ impl i2c::I2CClient for Lsm303agrI2C<'_> {
                 }
             }
             State::SetScaleAndResolution => {
-                let set_scale_and_resolution = error == Error::CommandComplete;
+                let set_scale_and_resolution = status == Ok(());
                 self.owning_process.map(|pid| {
                     let _res = self.apps.enter(*pid, |app| {
                         app.upcall
@@ -413,7 +413,7 @@ impl i2c::I2CClient for Lsm303agrI2C<'_> {
                 self.state.set(State::Idle);
             }
             State::SetDataRate => {
-                let set_magneto_data_rate = error == Error::CommandComplete;
+                let set_magneto_data_rate = status == Ok(());
                 self.owning_process.map(|pid| {
                     let _res = self.apps.enter(*pid, |app| {
                         app.upcall
@@ -428,7 +428,7 @@ impl i2c::I2CClient for Lsm303agrI2C<'_> {
                 }
             }
             State::SetRange => {
-                let set_range = error == Error::CommandComplete;
+                let set_range = status == Ok(());
                 self.owning_process.map(|pid| {
                     let _res = self.apps.enter(*pid, |app| {
                         app.upcall.schedule(if set_range { 1 } else { 0 }, 0, 0);

--- a/capsules/src/lsm303dlhc.rs
+++ b/capsules/src/lsm303dlhc.rs
@@ -221,7 +221,8 @@ impl<'a> Lsm303dlhcI2C<'a> {
             // turn on i2c to send commands
             buf[0] = 0x0F;
             self.i2c_magnetometer.enable();
-            self.i2c_magnetometer.write_read(buf, 1, 1);
+            // TODO verify errors
+            let _ = self.i2c_magnetometer.write_read(buf, 1, 1);
         });
     }
 
@@ -237,7 +238,8 @@ impl<'a> Lsm303dlhcI2C<'a> {
                     + CTRL_REG1::XEN::SET)
                     .value;
                 self.i2c_accelerometer.enable();
-                self.i2c_accelerometer.write(buf, 2);
+                // TODO verify errors
+                let _ = self.i2c_accelerometer.write(buf, 2);
             });
         }
     }
@@ -254,7 +256,8 @@ impl<'a> Lsm303dlhcI2C<'a> {
                     + CTRL_REG4::HR.val(high_resolution as u8))
                 .value;
                 self.i2c_accelerometer.enable();
-                self.i2c_accelerometer.write(buf, 2);
+                // TODO verify errors
+                let _ = self.i2c_accelerometer.write(buf, 2);
             });
         }
     }
@@ -265,7 +268,8 @@ impl<'a> Lsm303dlhcI2C<'a> {
             self.buffer.take().map(|buf| {
                 buf[0] = AccelerometerRegisters::OUT_X_L_A as u8 | REGISTER_AUTO_INCREMENT;
                 self.i2c_accelerometer.enable();
-                self.i2c_accelerometer.write_read(buf, 1, 6);
+                // TODO verify errors
+                let _ = self.i2c_accelerometer.write_read(buf, 1, 6);
             });
         }
     }
@@ -281,7 +285,8 @@ impl<'a> Lsm303dlhcI2C<'a> {
                 buf[0] = MagnetometerRegisters::CRA_REG_M as u8;
                 buf[1] = ((data_rate as u8) << 2) | if temperature { 1 << 7 } else { 0 };
                 self.i2c_magnetometer.enable();
-                self.i2c_magnetometer.write(buf, 2);
+                // TODO verify errors
+                let _ = self.i2c_magnetometer.write(buf, 2);
             });
         }
     }
@@ -296,7 +301,8 @@ impl<'a> Lsm303dlhcI2C<'a> {
                 buf[1] = (range as u8) << 5;
                 buf[2] = 0;
                 self.i2c_magnetometer.enable();
-                self.i2c_magnetometer.write(buf, 3);
+                // TODO verify errors
+                let _ = self.i2c_magnetometer.write(buf, 3);
             });
         }
     }
@@ -307,7 +313,8 @@ impl<'a> Lsm303dlhcI2C<'a> {
             self.buffer.take().map(|buf| {
                 buf[0] = MagnetometerRegisters::TEMP_OUT_H_M as u8;
                 self.i2c_magnetometer.enable();
-                self.i2c_magnetometer.write_read(buf, 1, 2);
+                // TODO verify errors
+                let _ = self.i2c_magnetometer.write_read(buf, 1, 2);
             });
         }
     }
@@ -318,7 +325,8 @@ impl<'a> Lsm303dlhcI2C<'a> {
             self.buffer.take().map(|buf| {
                 buf[0] = MagnetometerRegisters::OUT_X_H_M as u8;
                 self.i2c_magnetometer.enable();
-                self.i2c_magnetometer.write_read(buf, 1, 6);
+                // TODO verify errors
+                let _ = self.i2c_magnetometer.write_read(buf, 1, 6);
             });
         }
     }

--- a/capsules/src/lsm303dlhc.rs
+++ b/capsules/src/lsm303dlhc.rs
@@ -325,7 +325,7 @@ impl<'a> Lsm303dlhcI2C<'a> {
 }
 
 impl i2c::I2CClient for Lsm303dlhcI2C<'_> {
-    fn command_complete(&self, buffer: &'static mut [u8], status: Result<(), ErrorCode>) {
+    fn command_complete(&self, buffer: &'static mut [u8], status: Result<(), i2c::Error>) {
         match self.state.get() {
             State::IsPresent => {
                 let present = if status == Ok(()) && buffer[0] == 60 {

--- a/capsules/src/ltc294x.rs
+++ b/capsules/src/ltc294x.rs
@@ -172,7 +172,8 @@ impl<'a> LTC294X<'a> {
             self.i2c.enable();
 
             // Address pointer automatically resets to the status register.
-            self.i2c.read(buffer, 1);
+            // TODO verify errors
+            let _ = self.i2c.read(buffer, 1);
             self.state.set(State::ReadStatus);
 
             Ok(())
@@ -191,7 +192,8 @@ impl<'a> LTC294X<'a> {
             buffer[0] = Registers::Control as u8;
             buffer[1] = ((int_pin_conf as u8) << 1) | (prescaler << 3) | ((vbat_alert as u8) << 6);
 
-            self.i2c.write(buffer, 2);
+            // TODO verify errors
+            let _ = self.i2c.write(buffer, 2);
             self.state.set(State::Done);
 
             Ok(())
@@ -207,7 +209,8 @@ impl<'a> LTC294X<'a> {
             buffer[1] = 0;
             buffer[2] = 0;
 
-            self.i2c.write(buffer, 3);
+            // TODO verify errors
+            let _ = self.i2c.write(buffer, 3);
             self.state.set(State::Done);
 
             Ok(())
@@ -222,7 +225,8 @@ impl<'a> LTC294X<'a> {
             buffer[1] = ((threshold & 0xFF00) >> 8) as u8;
             buffer[2] = (threshold & 0xFF) as u8;
 
-            self.i2c.write(buffer, 3);
+            // TODO verify errors
+            let _ = self.i2c.write(buffer, 3);
             self.state.set(State::Done);
 
             Ok(())
@@ -237,7 +241,8 @@ impl<'a> LTC294X<'a> {
             buffer[1] = ((threshold & 0xFF00) >> 8) as u8;
             buffer[2] = (threshold & 0xFF) as u8;
 
-            self.i2c.write(buffer, 3);
+            // TODO verify errors
+            let _ = self.i2c.write(buffer, 3);
             self.state.set(State::Done);
 
             Ok(())
@@ -251,7 +256,8 @@ impl<'a> LTC294X<'a> {
 
             // Read all of the first four registers rather than wasting
             // time writing an address.
-            self.i2c.read(buffer, 4);
+            // TODO verify errors
+            let _ = self.i2c.read(buffer, 4);
             self.state.set(State::ReadCharge);
 
             Ok(())
@@ -266,7 +272,8 @@ impl<'a> LTC294X<'a> {
                 self.buffer.take().map_or(Err(ErrorCode::NOMEM), |buffer| {
                     self.i2c.enable();
 
-                    self.i2c.read(buffer, 10);
+                    // TODO verify errors
+                    let _ = self.i2c.read(buffer, 10);
                     self.state.set(State::ReadVoltage);
 
                     Ok(())
@@ -283,7 +290,8 @@ impl<'a> LTC294X<'a> {
             ChipModel::LTC2943 => self.buffer.take().map_or(Err(ErrorCode::NOMEM), |buffer| {
                 self.i2c.enable();
 
-                self.i2c.read(buffer, 16);
+                // TODO verify errors
+                let _ = self.i2c.read(buffer, 16);
                 self.state.set(State::ReadCurrent);
 
                 Ok(())
@@ -299,7 +307,8 @@ impl<'a> LTC294X<'a> {
 
             // Read both the status and control register rather than
             // writing an address.
-            self.i2c.read(buffer, 2);
+            // TODO verify errors
+            let _ = self.i2c.read(buffer, 2);
             self.state.set(State::ReadShutdown);
 
             Ok(())
@@ -382,7 +391,8 @@ impl i2c::I2CClient for LTC294X<'_> {
                 // Write the control register back but with a 1 in the shutdown
                 // bit.
                 buffer[0] = Registers::Control as u8;
-                self.i2c.write(buffer, 2);
+                // TODO verify errors
+                let _ = self.i2c.write(buffer, 2);
                 self.state.set(State::Done);
             }
             State::Done => {

--- a/capsules/src/ltc294x.rs
+++ b/capsules/src/ltc294x.rs
@@ -327,7 +327,7 @@ impl<'a> LTC294X<'a> {
 }
 
 impl i2c::I2CClient for LTC294X<'_> {
-    fn command_complete(&self, buffer: &'static mut [u8], _status: Result<(), ErrorCode>) {
+    fn command_complete(&self, buffer: &'static mut [u8], _status: Result<(), i2c::Error>) {
         match self.state.get() {
             State::ReadStatus => {
                 let status = buffer[0];

--- a/capsules/src/ltc294x.rs
+++ b/capsules/src/ltc294x.rs
@@ -327,7 +327,7 @@ impl<'a> LTC294X<'a> {
 }
 
 impl i2c::I2CClient for LTC294X<'_> {
-    fn command_complete(&self, buffer: &'static mut [u8], _error: i2c::Error) {
+    fn command_complete(&self, buffer: &'static mut [u8], _status: Result<(), ErrorCode>) {
         match self.state.get() {
             State::ReadStatus => {
                 let status = buffer[0];

--- a/capsules/src/max17205.rs
+++ b/capsules/src/max17205.rs
@@ -140,7 +140,8 @@ impl<'a> MAX17205<'a> {
 
             buffer[0] = Registers::Status as u8;
 
-            self.i2c_lower.write(buffer, 2);
+            // TODO verify errors
+            let _ = self.i2c_lower.write(buffer, 2);
             self.state.set(State::SetupReadStatus);
 
             Ok(())
@@ -154,7 +155,8 @@ impl<'a> MAX17205<'a> {
             // Get SOC mAh and percentage
             // Write reqcap address
             buffer[0] = Registers::RepCap as u8;
-            self.i2c_lower.write(buffer, 1);
+            // TODO verify errors
+            let _ = self.i2c_lower.write(buffer, 1);
             self.state.set(State::SetupReadSOC);
 
             Ok(())
@@ -168,7 +170,8 @@ impl<'a> MAX17205<'a> {
             // Get current and voltage
             // Write Batt address
             buffer[0] = Registers::Batt as u8;
-            self.i2c_lower.write(buffer, 1);
+            // TODO verify errors
+            let _ = self.i2c_lower.write(buffer, 1);
             self.state.set(State::SetupReadVolt);
 
             Ok(())
@@ -182,7 +185,8 @@ impl<'a> MAX17205<'a> {
             // Get raw coulomb count.
             // Write Coulomb address
             buffer[0] = Registers::Coulomb as u8;
-            self.i2c_lower.write(buffer, 1);
+            // TODO verify errors
+            let _ = self.i2c_lower.write(buffer, 1);
             self.state.set(State::SetupReadCoulomb);
 
             Ok(())
@@ -194,7 +198,8 @@ impl<'a> MAX17205<'a> {
             self.i2c_upper.enable();
 
             buffer[0] = Registers::NRomID as u8;
-            self.i2c_upper.write(buffer, 1);
+            // TODO verify errors
+            let _ = self.i2c_upper.write(buffer, 1);
             self.state.set(State::SetupReadRomID);
 
             Ok(())
@@ -207,7 +212,8 @@ impl i2c::I2CClient for MAX17205<'_> {
         match self.state.get() {
             State::SetupReadStatus => {
                 // Read status
-                self.i2c_lower.read(buffer, 2);
+                // TODO verify errors
+                let _ = self.i2c_lower.read(buffer, 2);
                 self.state.set(State::ReadStatus);
             }
             State::ReadStatus => {
@@ -229,7 +235,8 @@ impl i2c::I2CClient for MAX17205<'_> {
             }
             State::SetupReadSOC => {
                 // Write of SOC memory address complete, now issue read
-                self.i2c_lower.read(buffer, 4);
+                // TODO verify errors
+                let _ = self.i2c_lower.read(buffer, 4);
                 self.state.set(State::ReadSOC);
             }
             State::ReadSOC => {
@@ -246,14 +253,16 @@ impl i2c::I2CClient for MAX17205<'_> {
                     // Get SOC mAh and percentage
                     // Write reqcap address
                     selfbuf[0] = ((Registers::FullCapRep as u8) & 0xFF) as u8;
-                    self.i2c_lower.write(selfbuf, 1);
+                    // TODO verify errors
+                    let _ = self.i2c_lower.write(selfbuf, 1);
 
                     self.state.set(State::SetupReadCap);
                 });
             }
             State::SetupReadCap => {
                 // Now issue read
-                self.i2c_lower.read(buffer, 2);
+                // TODO verify errors
+                let _ = self.i2c_lower.read(buffer, 2);
                 self.state.set(State::ReadCap);
             }
             State::ReadCap => {
@@ -277,7 +286,8 @@ impl i2c::I2CClient for MAX17205<'_> {
             }
             State::SetupReadCoulomb => {
                 // Write of voltage memory address complete, now issue read
-                self.i2c_lower.read(buffer, 2);
+                // TODO verify errors
+                let _ = self.i2c_lower.read(buffer, 2);
                 self.state.set(State::ReadCoulomb);
             }
             State::ReadCoulomb => {
@@ -300,7 +310,8 @@ impl i2c::I2CClient for MAX17205<'_> {
             }
             State::SetupReadVolt => {
                 // Write of voltage memory address complete, now issue read
-                self.i2c_lower.read(buffer, 2);
+                // TODO verify errors
+                let _ = self.i2c_lower.read(buffer, 2);
                 self.state.set(State::ReadVolt);
             }
             State::ReadVolt => {
@@ -314,14 +325,16 @@ impl i2c::I2CClient for MAX17205<'_> {
                 // Setup read capacity
                 self.buffer.take().map(|selfbuf| {
                     selfbuf[0] = ((Registers::Current as u8) & 0xFF) as u8;
-                    self.i2c_lower.write(selfbuf, 1);
+                    // TODO verify errors
+                    let _ = self.i2c_lower.write(selfbuf, 1);
 
                     self.state.set(State::SetupReadCurrent);
                 });
             }
             State::SetupReadCurrent => {
                 // Now issue read
-                self.i2c_lower.read(buffer, 2);
+                // TODO verify errors
+                let _ = self.i2c_lower.read(buffer, 2);
                 self.state.set(State::ReadCurrent);
             }
             State::ReadCurrent => {
@@ -343,7 +356,8 @@ impl i2c::I2CClient for MAX17205<'_> {
                 self.state.set(State::Idle);
             }
             State::SetupReadRomID => {
-                self.i2c_upper.read(buffer, 8);
+                // TODO verify errors
+                let _ = self.i2c_upper.read(buffer, 8);
                 self.state.set(State::ReadRomID);
             }
             State::ReadRomID => {

--- a/capsules/src/mcp230xx.rs
+++ b/capsules/src/mcp230xx.rs
@@ -382,7 +382,7 @@ impl<'a> MCP230xx<'a> {
 }
 
 impl hil::i2c::I2CClient for MCP230xx<'_> {
-    fn command_complete(&self, buffer: &'static mut [u8], _status: Result<(), ErrorCode>) {
+    fn command_complete(&self, buffer: &'static mut [u8], _status: Result<(), hil::i2c::Error>) {
         match self.state.get() {
             State::SelectIoDir(pin_number, direction) => {
                 self.i2c.read(buffer, 1);

--- a/capsules/src/mcp230xx.rs
+++ b/capsules/src/mcp230xx.rs
@@ -218,7 +218,8 @@ impl<'a> MCP230xx<'a> {
             self.i2c.enable();
 
             buffer[0] = self.calc_register_addr(Registers::IoDir, pin_number);
-            self.i2c.write(buffer, 1);
+            // TODO verify errors
+            let _ = self.i2c.write(buffer, 1);
             self.state.set(State::SelectIoDir(pin_number, direction));
 
             Ok(())
@@ -231,7 +232,8 @@ impl<'a> MCP230xx<'a> {
             self.i2c.enable();
 
             buffer[0] = self.calc_register_addr(Registers::IoDir, pin_number);
-            self.i2c.write(buffer, 1);
+            // TODO verify errors
+            let _ = self.i2c.write(buffer, 1);
             self.state
                 .set(State::SelectIoDirForGpPu(pin_number, enabled));
 
@@ -244,7 +246,8 @@ impl<'a> MCP230xx<'a> {
             self.i2c.enable();
 
             buffer[0] = self.calc_register_addr(Registers::Gpio, pin_number);
-            self.i2c.write(buffer, 1);
+            // TODO verify errors
+            let _ = self.i2c.write(buffer, 1);
             self.state.set(State::SelectGpio(pin_number, value));
 
             Ok(())
@@ -256,7 +259,8 @@ impl<'a> MCP230xx<'a> {
             self.i2c.enable();
 
             buffer[0] = self.calc_register_addr(Registers::Gpio, pin_number);
-            self.i2c.write(buffer, 1);
+            // TODO verify errors
+            let _ = self.i2c.write(buffer, 1);
             self.state.set(State::SelectGpioToggle(pin_number));
 
             Ok(())
@@ -268,7 +272,8 @@ impl<'a> MCP230xx<'a> {
             self.i2c.enable();
 
             buffer[0] = self.calc_register_addr(Registers::Gpio, pin_number);
-            self.i2c.write(buffer, 1);
+            // TODO verify errors
+            let _ = self.i2c.write(buffer, 1);
             self.state.set(State::SelectGpioRead(pin_number));
 
             Ok(())
@@ -302,7 +307,8 @@ impl<'a> MCP230xx<'a> {
             // The next register is the IoCon (configuration) register, which
             // we also want to set.
             buffer[i] = 0b00000010; // Make MCP230xx interrupt pin active high.
-            self.i2c.write(buffer, (i + 1) as u8);
+                                    // TODO verify errors
+            let _ = self.i2c.write(buffer, (i + 1) as u8);
             self.state.set(State::EnableInterruptSettings(pin_number));
 
             Ok(())
@@ -319,7 +325,8 @@ impl<'a> MCP230xx<'a> {
             // Just have to write the new interrupt settings.
             buffer[0] = self.calc_register_addr(Registers::GpIntEn, pin_number);
             buffer[1] = self.get_pin_interrupt_enabled_state(pin_number);
-            self.i2c.write(buffer, 2);
+            // TODO verify errors
+            let _ = self.i2c.write(buffer, 2);
             self.state.set(State::Done);
 
             Ok(())
@@ -385,7 +392,8 @@ impl hil::i2c::I2CClient for MCP230xx<'_> {
     fn command_complete(&self, buffer: &'static mut [u8], _status: Result<(), hil::i2c::Error>) {
         match self.state.get() {
             State::SelectIoDir(pin_number, direction) => {
-                self.i2c.read(buffer, 1);
+                // TODO verify errors
+                let _ = self.i2c.read(buffer, 1);
                 self.state.set(State::ReadIoDir(pin_number, direction));
             }
             State::ReadIoDir(pin_number, direction) => {
@@ -395,23 +403,27 @@ impl hil::i2c::I2CClient for MCP230xx<'_> {
                     buffer[1] = buffer[0] & !(1 << pin_number);
                 }
                 buffer[0] = self.calc_register_addr(Registers::IoDir, pin_number);
-                self.i2c.write(buffer, 2);
+                // TODO verify errors
+                let _ = self.i2c.write(buffer, 2);
                 self.state.set(State::Done);
             }
             State::SelectIoDirForGpPu(pin_number, enabled) => {
-                self.i2c.read(buffer, 1);
+                // TODO verify errors
+                let _ = self.i2c.read(buffer, 1);
                 self.state.set(State::ReadIoDirForGpPu(pin_number, enabled));
             }
             State::ReadIoDirForGpPu(pin_number, enabled) => {
                 // Make sure the pin is enabled.
                 buffer[1] = buffer[0] | (1 << pin_number);
                 buffer[0] = self.calc_register_addr(Registers::IoDir, pin_number);
-                self.i2c.write(buffer, 2);
+                // TODO verify errors
+                let _ = self.i2c.write(buffer, 2);
                 self.state.set(State::SetIoDirForGpPu(pin_number, enabled));
             }
             State::SetIoDirForGpPu(pin_number, enabled) => {
                 buffer[0] = self.calc_register_addr(Registers::GpPu, pin_number);
-                self.i2c.write(buffer, 1);
+                // TODO verify errors
+                let _ = self.i2c.write(buffer, 1);
                 self.state.set(State::ReadGpPu(pin_number, enabled));
             }
             State::ReadGpPu(pin_number, enabled) => {
@@ -422,11 +434,13 @@ impl hil::i2c::I2CClient for MCP230xx<'_> {
                 };
                 buffer[0] = self.calc_register_addr(Registers::GpPu, pin_number);
                 buffer[1] = pullup;
-                self.i2c.write(buffer, 2);
+                // TODO verify errors
+                let _ = self.i2c.write(buffer, 2);
                 self.state.set(State::Done);
             }
             State::SelectGpio(pin_number, value) => {
-                self.i2c.read(buffer, 1);
+                // TODO verify errors
+                let _ = self.i2c.read(buffer, 1);
                 self.state.set(State::ReadGpio(pin_number, value));
             }
             State::ReadGpio(pin_number, value) => {
@@ -435,21 +449,25 @@ impl hil::i2c::I2CClient for MCP230xx<'_> {
                     PinState::Low => buffer[0] & !(1 << pin_number),
                 };
                 buffer[0] = self.calc_register_addr(Registers::Gpio, pin_number);
-                self.i2c.write(buffer, 2);
+                // TODO verify errors
+                let _ = self.i2c.write(buffer, 2);
                 self.state.set(State::Done);
             }
             State::SelectGpioToggle(pin_number) => {
-                self.i2c.read(buffer, 1);
+                // TODO verify errors
+                let _ = self.i2c.read(buffer, 1);
                 self.state.set(State::ReadGpioToggle(pin_number));
             }
             State::ReadGpioToggle(pin_number) => {
                 buffer[1] = buffer[0] ^ (1 << pin_number);
                 buffer[0] = self.calc_register_addr(Registers::Gpio, pin_number);
-                self.i2c.write(buffer, 2);
+                // TODO verify errors
+                let _ = self.i2c.write(buffer, 2);
                 self.state.set(State::Done);
             }
             State::SelectGpioRead(pin_number) => {
-                self.i2c.read(buffer, 1);
+                // TODO verify errors
+                let _ = self.i2c.read(buffer, 1);
                 self.state.set(State::ReadGpioRead(pin_number));
             }
             State::ReadGpioRead(pin_number) => {
@@ -468,12 +486,14 @@ impl hil::i2c::I2CClient for MCP230xx<'_> {
                 // back, just write the entire register with our saved state.
                 buffer[0] = self.calc_register_addr(Registers::GpIntEn, pin_number);
                 buffer[1] = self.get_pin_interrupt_enabled_state(pin_number);
-                self.i2c.write(buffer, 2);
+                // TODO verify errors
+                let _ = self.i2c.write(buffer, 2);
                 self.state.set(State::Done);
             }
             State::ReadInterruptSetup(bank_number) => {
                 // Now read the interrupt flags and the state of the lines
-                self.i2c.read(buffer, 3);
+                // TODO verify errors
+                let _ = self.i2c.read(buffer, 3);
                 self.state.set(State::ReadInterruptValues(bank_number));
             }
             State::ReadInterruptValues(bank_number) => {
@@ -543,7 +563,8 @@ impl gpio::ClientWithValue for MCP230xx<'_> {
             // interrupted.
             buffer[0] =
                 self.calc_register_addr(Registers::IntF, bank_number as u8 * self.bank_size);
-            self.i2c.write(buffer, 1);
+            // TODO verify errors
+            let _ = self.i2c.write(buffer, 1);
             self.state.set(State::ReadInterruptSetup(bank_number as u8));
         });
     }

--- a/capsules/src/mcp230xx.rs
+++ b/capsules/src/mcp230xx.rs
@@ -382,7 +382,7 @@ impl<'a> MCP230xx<'a> {
 }
 
 impl hil::i2c::I2CClient for MCP230xx<'_> {
-    fn command_complete(&self, buffer: &'static mut [u8], _error: hil::i2c::Error) {
+    fn command_complete(&self, buffer: &'static mut [u8], _status: Result<(), ErrorCode>) {
         match self.state.get() {
             State::SelectIoDir(pin_number, direction) => {
                 self.i2c.read(buffer, 1);

--- a/capsules/src/mlx90614.rs
+++ b/capsules/src/mlx90614.rs
@@ -113,7 +113,7 @@ impl<'a> Mlx90614SMBus<'_> {
 }
 
 impl<'a> i2c::I2CClient for Mlx90614SMBus<'a> {
-    fn command_complete(&self, buffer: &'static mut [u8], status: Result<(), ErrorCode>) {
+    fn command_complete(&self, buffer: &'static mut [u8], status: Result<(), i2c::Error>) {
         match self.state.get() {
             State::Idle => {
                 self.buffer.replace(buffer);

--- a/capsules/src/pca9544a.rs
+++ b/capsules/src/pca9544a.rs
@@ -101,7 +101,8 @@ impl<'a> PCA9544A<'a> {
                     }
                 }
 
-                self.i2c.write(buffer, index as u8);
+                // TODO verify errors
+                let _ = self.i2c.write(buffer, index as u8);
                 self.state.set(State::Done);
 
                 CommandReturn::success()
@@ -123,7 +124,8 @@ impl<'a> PCA9544A<'a> {
                 self.i2c.enable();
 
                 // Just issuing a read to the selector reads its control register.
-                self.i2c.read(buffer, 1);
+                // TODO verify errors
+                let _ = self.i2c.read(buffer, 1);
                 self.state.set(State::ReadControl(field));
 
                 CommandReturn::success()

--- a/capsules/src/pca9544a.rs
+++ b/capsules/src/pca9544a.rs
@@ -132,7 +132,7 @@ impl<'a> PCA9544A<'a> {
 }
 
 impl i2c::I2CClient for PCA9544A<'_> {
-    fn command_complete(&self, buffer: &'static mut [u8], _status: Result<(), ErrorCode>) {
+    fn command_complete(&self, buffer: &'static mut [u8], _status: Result<(), i2c::Error>) {
         match self.state.get() {
             State::ReadControl(field) => {
                 let ret = match field {

--- a/capsules/src/pca9544a.rs
+++ b/capsules/src/pca9544a.rs
@@ -132,7 +132,7 @@ impl<'a> PCA9544A<'a> {
 }
 
 impl i2c::I2CClient for PCA9544A<'_> {
-    fn command_complete(&self, buffer: &'static mut [u8], _error: i2c::Error) {
+    fn command_complete(&self, buffer: &'static mut [u8], _status: Result<(), ErrorCode>) {
         match self.state.get() {
             State::ReadControl(field) => {
                 let ret = match field {

--- a/capsules/src/sht3x.rs
+++ b/capsules/src/sht3x.rs
@@ -165,7 +165,7 @@ impl<'a, A: Alarm<'a>> time::AlarmClient for SHT3x<'a, A> {
 }
 
 impl<'a, A: Alarm<'a>> i2c::I2CClient for SHT3x<'a, A> {
-    fn command_complete(&self, buffer: &'static mut [u8], status: Result<(), ErrorCode>) {
+    fn command_complete(&self, buffer: &'static mut [u8], status: Result<(), i2c::Error>) {
         match status {
             Ok(()) => {
                 let state = self.state.get();

--- a/capsules/src/sht3x.rs
+++ b/capsules/src/sht3x.rs
@@ -135,7 +135,8 @@ impl<'a, A: Alarm<'a>> SHT3x<'a, A> {
                 buffer[0] = ((Registers::MEASHIGHREP as u16) >> 8) as u8;
                 buffer[1] = ((Registers::MEASHIGHREP as u16) & 0xff) as u8;
 
-                self.i2c.write(buffer, 2);
+                // TODO verify errors
+                let _ = self.i2c.write(buffer, 2);
 
                 Ok(())
             },

--- a/capsules/src/sht3x.rs
+++ b/capsules/src/sht3x.rs
@@ -165,9 +165,9 @@ impl<'a, A: Alarm<'a>> time::AlarmClient for SHT3x<'a, A> {
 }
 
 impl<'a, A: Alarm<'a>> i2c::I2CClient for SHT3x<'a, A> {
-    fn command_complete(&self, buffer: &'static mut [u8], error: i2c::Error) {
-        match error {
-            i2c::Error::CommandComplete => {
+    fn command_complete(&self, buffer: &'static mut [u8], status: Result<(), ErrorCode>) {
+        match status {
+            Ok(()) => {
                 let state = self.state.get();
 
                 match state {

--- a/capsules/src/si7021.rs
+++ b/capsules/src/si7021.rs
@@ -151,7 +151,7 @@ impl<'a, A: time::Alarm<'a>> SI7021<'a, A> {
 }
 
 impl<'a, A: time::Alarm<'a>> i2c::I2CClient for SI7021<'a, A> {
-    fn command_complete(&self, buffer: &'static mut [u8], _error: i2c::Error) {
+    fn command_complete(&self, buffer: &'static mut [u8], _status: Result<(), ErrorCode>) {
         match self.state.get() {
             State::SelectElectronicId1 => {
                 self.i2c.read(buffer, 8);

--- a/capsules/src/si7021.rs
+++ b/capsules/src/si7021.rs
@@ -151,7 +151,7 @@ impl<'a, A: time::Alarm<'a>> SI7021<'a, A> {
 }
 
 impl<'a, A: time::Alarm<'a>> i2c::I2CClient for SI7021<'a, A> {
-    fn command_complete(&self, buffer: &'static mut [u8], _status: Result<(), ErrorCode>) {
+    fn command_complete(&self, buffer: &'static mut [u8], _status: Result<(), i2c::Error>) {
         match self.state.get() {
             State::SelectElectronicId1 => {
                 self.i2c.read(buffer, 8);

--- a/capsules/src/si7021.rs
+++ b/capsules/src/si7021.rs
@@ -129,7 +129,8 @@ impl<'a, A: time::Alarm<'a>> SI7021<'a, A> {
 
             buffer[0] = Registers::ReadElectronicIdByteOneA as u8;
             buffer[1] = Registers::ReadElectronicIdByteOneB as u8;
-            self.i2c.write(buffer, 2);
+            // TODO verify errors
+            let _ = self.i2c.write(buffer, 2);
             self.state.set(State::SelectElectronicId1);
         });
     }
@@ -154,7 +155,8 @@ impl<'a, A: time::Alarm<'a>> i2c::I2CClient for SI7021<'a, A> {
     fn command_complete(&self, buffer: &'static mut [u8], _status: Result<(), i2c::Error>) {
         match self.state.get() {
             State::SelectElectronicId1 => {
-                self.i2c.read(buffer, 8);
+                // TODO verify errors
+                let _ = self.i2c.read(buffer, 8);
                 self.state.set(State::ReadElectronicId1);
             }
             State::ReadElectronicId1 => {
@@ -168,11 +170,13 @@ impl<'a, A: time::Alarm<'a>> i2c::I2CClient for SI7021<'a, A> {
                 buffer[13] = buffer[7];
                 buffer[0] = Registers::ReadElectronicIdByteTwoA as u8;
                 buffer[1] = Registers::ReadElectronicIdByteTwoB as u8;
-                self.i2c.write(buffer, 2);
+                // TODO verify errors
+                let _ = self.i2c.write(buffer, 2);
                 self.state.set(State::SelectElectronicId2);
             }
             State::SelectElectronicId2 => {
-                self.i2c.read(buffer, 6);
+                // TODO verify errors
+                let _ = self.i2c.read(buffer, 6);
                 self.state.set(State::ReadElectronicId2);
             }
             State::ReadElectronicId2 => {
@@ -187,11 +191,13 @@ impl<'a, A: time::Alarm<'a>> i2c::I2CClient for SI7021<'a, A> {
                 self.state.set(State::WaitRh);
             }
             State::ReadRhMeasurement => {
-                self.i2c.read(buffer, 2);
+                // TODO verify errors
+                let _ = self.i2c.read(buffer, 2);
                 self.state.set(State::GotRhMeasurement);
             }
             State::ReadTempMeasurement => {
-                self.i2c.read(buffer, 2);
+                // TODO verify errors
+                let _ = self.i2c.read(buffer, 2);
                 self.state.set(State::GotTempMeasurement);
             }
             State::GotTempMeasurement => {
@@ -205,7 +211,8 @@ impl<'a, A: time::Alarm<'a>> i2c::I2CClient for SI7021<'a, A> {
                     OnDeck::Humidity => {
                         self.on_deck.set(OnDeck::Nothing);
                         buffer[0] = Registers::MeasRelativeHumidityNoHoldMode as u8;
-                        self.i2c.write(buffer, 1);
+                        // TODO verify errors
+                        let _ = self.i2c.write(buffer, 1);
                         self.state.set(State::TakeRhMeasurementInit);
                     }
                     _ => {
@@ -224,7 +231,8 @@ impl<'a, A: time::Alarm<'a>> i2c::I2CClient for SI7021<'a, A> {
                     OnDeck::Temperature => {
                         self.on_deck.set(OnDeck::Nothing);
                         buffer[0] = Registers::MeasTemperatureNoHoldMode as u8;
-                        self.i2c.write(buffer, 1);
+                        // TODO verify errors
+                        let _ = self.i2c.write(buffer, 1);
                         self.state.set(State::TakeTempMeasurementInit);
                     }
                     _ => {
@@ -249,7 +257,8 @@ impl<'a, A: time::Alarm<'a>> kernel::hil::sensors::TemperatureDriver<'a> for SI7
                 self.i2c.enable();
 
                 buffer[0] = Registers::MeasTemperatureNoHoldMode as u8;
-                self.i2c.write(buffer, 1);
+                // TODO verify errors
+                let _ = self.i2c.write(buffer, 1);
                 self.state.set(State::TakeTempMeasurementInit);
                 Ok(())
             })
@@ -281,7 +290,8 @@ impl<'a, A: time::Alarm<'a>> kernel::hil::sensors::HumidityDriver<'a> for SI7021
                 self.i2c.enable();
 
                 buffer[0] = Registers::MeasRelativeHumidityNoHoldMode as u8;
-                self.i2c.write(buffer, 1);
+                // TODO verify errors
+                let _ = self.i2c.write(buffer, 1);
                 self.state.set(State::TakeRhMeasurementInit);
                 Ok(())
             })
@@ -308,7 +318,8 @@ impl<'a, A: time::Alarm<'a>> time::AlarmClient for SI7021<'a, A> {
             // turn on i2c to send commands
             self.i2c.enable();
 
-            self.i2c.read(buffer, 2);
+            // TODO verify errors
+            let _ = self.i2c.read(buffer, 2);
             match self.state.get() {
                 State::WaitRh => self.state.set(State::ReadRhMeasurement),
                 State::WaitTemp => self.state.set(State::ReadTempMeasurement),

--- a/capsules/src/tsl2561.rs
+++ b/capsules/src/tsl2561.rs
@@ -354,7 +354,7 @@ impl<'a> TSL2561<'a> {
 }
 
 impl i2c::I2CClient for TSL2561<'_> {
-    fn command_complete(&self, buffer: &'static mut [u8], _error: i2c::Error) {
+    fn command_complete(&self, buffer: &'static mut [u8], _status: Result<(), ErrorCode>) {
         match self.state.get() {
             State::SelectId => {
                 self.i2c.read(buffer, 1);

--- a/capsules/src/tsl2561.rs
+++ b/capsules/src/tsl2561.rs
@@ -240,7 +240,8 @@ impl<'a> TSL2561<'a> {
 
             buffer[0] = Registers::Id as u8 | COMMAND_REG;
             // buffer[0] = Registers::Id as u8;
-            self.i2c.write(buffer, 1);
+            // TODO verify errors
+            let _ = self.i2c.write(buffer, 1);
             self.state.set(State::SelectId);
         });
     }
@@ -257,7 +258,8 @@ impl<'a> TSL2561<'a> {
 
             buf[0] = Registers::Control as u8 | COMMAND_REG;
             buf[1] = POWER_ON;
-            self.i2c.write(buf, 2);
+            // TODO verify errors
+            let _ = self.i2c.write(buf, 2);
             self.state.set(State::TakeMeasurementTurnOn);
         });
     }
@@ -357,7 +359,8 @@ impl i2c::I2CClient for TSL2561<'_> {
     fn command_complete(&self, buffer: &'static mut [u8], _status: Result<(), i2c::Error>) {
         match self.state.get() {
             State::SelectId => {
-                self.i2c.read(buffer, 1);
+                // TODO verify errors
+                let _ = self.i2c.read(buffer, 1);
                 self.state.set(State::ReadingId);
             }
             State::ReadingId => {
@@ -368,29 +371,34 @@ impl i2c::I2CClient for TSL2561<'_> {
             State::TakeMeasurementTurnOn => {
                 buffer[0] = Registers::Timing as u8 | COMMAND_REG;
                 buffer[1] = INTEGRATE_TIME_101_MS | LOW_GAIN_MODE;
-                self.i2c.write(buffer, 2);
+                // TODO verify errors
+                let _ = self.i2c.write(buffer, 2);
                 self.state.set(State::TakeMeasurementConfigMeasurement);
             }
             State::TakeMeasurementConfigMeasurement => {
                 buffer[0] = Registers::Interrupt as u8 | COMMAND_REG;
                 buffer[1] = INTERRUPT_CONTROL_LEVEL | INTERRUPT_ON_ADC_DONE;
-                self.i2c.write(buffer, 2);
+                // TODO verify errors
+                let _ = self.i2c.write(buffer, 2);
                 self.state.set(State::TakeMeasurementReset1);
             }
             State::TakeMeasurementReset1 => {
                 buffer[0] = Registers::Control as u8 | COMMAND_REG;
                 buffer[1] = POWER_OFF;
-                self.i2c.write(buffer, 2);
+                // TODO verify errors
+                let _ = self.i2c.write(buffer, 2);
                 self.state.set(State::TakeMeasurementReset2);
             }
             State::TakeMeasurementReset2 => {
                 buffer[0] = Registers::Control as u8 | COMMAND_REG;
                 buffer[1] = POWER_ON;
-                self.i2c.write(buffer, 2);
+                // TODO verify errors
+                let _ = self.i2c.write(buffer, 2);
                 self.state.set(State::Done);
             }
             State::ReadMeasurement1 => {
-                self.i2c.read(buffer, 2);
+                // TODO verify errors
+                let _ = self.i2c.read(buffer, 2);
                 self.state.set(State::ReadMeasurement2);
             }
             State::ReadMeasurement2 => {
@@ -399,11 +407,13 @@ impl i2c::I2CClient for TSL2561<'_> {
                 buffer[2] = buffer[0];
                 buffer[3] = buffer[1];
                 buffer[0] = Registers::Data0Low as u8 | COMMAND_REG | WORD_PROTOCOL;
-                self.i2c.write(buffer, 2);
+                // TODO verify errors
+                let _ = self.i2c.write(buffer, 2);
                 self.state.set(State::ReadMeasurement3);
             }
             State::ReadMeasurement3 => {
-                self.i2c.read(buffer, 2);
+                // TODO verify errors
+                let _ = self.i2c.read(buffer, 2);
                 self.state.set(State::GotMeasurement);
             }
             State::GotMeasurement => {
@@ -420,7 +430,8 @@ impl i2c::I2CClient for TSL2561<'_> {
 
                 buffer[0] = Registers::Control as u8 | COMMAND_REG;
                 buffer[1] = POWER_OFF;
-                self.i2c.write(buffer, 2);
+                // TODO verify errors
+                let _ = self.i2c.write(buffer, 2);
                 self.interrupt_pin.disable_interrupts();
                 self.state.set(State::Done);
             }
@@ -442,7 +453,8 @@ impl gpio::Client for TSL2561<'_> {
 
             // Read the first of the ADC registers.
             buffer[0] = Registers::Data1Low as u8 | COMMAND_REG | WORD_PROTOCOL;
-            self.i2c.write(buffer, 1);
+            // TODO verify errors
+            let _ = self.i2c.write(buffer, 1);
             self.state.set(State::ReadMeasurement1);
         });
     }

--- a/capsules/src/tsl2561.rs
+++ b/capsules/src/tsl2561.rs
@@ -354,7 +354,7 @@ impl<'a> TSL2561<'a> {
 }
 
 impl i2c::I2CClient for TSL2561<'_> {
-    fn command_complete(&self, buffer: &'static mut [u8], _status: Result<(), ErrorCode>) {
+    fn command_complete(&self, buffer: &'static mut [u8], _status: Result<(), i2c::Error>) {
         match self.state.get() {
             State::SelectId => {
                 self.i2c.read(buffer, 1);

--- a/chips/apollo3/src/iom.rs
+++ b/chips/apollo3/src/iom.rs
@@ -7,6 +7,7 @@ use kernel::common::registers::{register_bitfields, register_structs, ReadOnly, 
 use kernel::common::StaticRef;
 use kernel::hil;
 use kernel::hil::i2c;
+use kernel::ErrorCode;
 
 const IOM0_BASE: StaticRef<IomRegisters> =
     unsafe { StaticRef::new(0x5000_4000 as *const IomRegisters) };
@@ -505,10 +506,7 @@ impl<'a> Iom<'_> {
                 || (self.write_len.get() > 0 && self.write_index.get() == self.write_len.get())
             {
                 self.master_client.map(|client| {
-                    client.command_complete(
-                        self.buffer.take().unwrap(),
-                        hil::i2c::Error::CommandComplete,
-                    );
+                    client.command_complete(self.buffer.take().unwrap(), Ok(()));
                 });
 
                 // Finished with SMBus
@@ -529,7 +527,13 @@ impl<'a> Iom<'_> {
         }
     }
 
-    fn tx_rx(&self, addr: u8, data: &'static mut [u8], write_len: u8, read_len: u8) {
+    fn tx_rx(
+        &self,
+        addr: u8,
+        data: &'static mut [u8],
+        write_len: u8,
+        read_len: u8,
+    ) -> Result<(), (ErrorCode, &'static mut [u8])> {
         let regs = self.registers;
         let mut offsetlo = 0;
 
@@ -563,37 +567,42 @@ impl<'a> Iom<'_> {
             regs.offsethi.set(data[1] as u32 | ((data[2] as u32) << 8));
         }
 
-        // Save all the data and offsets we still need to send
-        self.buffer.replace(data);
-        self.write_len.set(write_len as usize);
-        self.read_len.set(read_len as usize);
-        self.write_index.set(0);
-        self.read_index.set(0);
-
         if write_len > 3 {
             // We can't suppord that much data, bail out now
-            self.master_client.map(|client| {
-                client.command_complete(self.buffer.take().unwrap(), hil::i2c::Error::NotSupported);
-            });
-            return;
+            // self.master_client.map(|client| {
+            //     client.command_complete(self.buffer.take().unwrap(), Err(ErrorCode::NOSUPPORT));
+            // });
+            Err((ErrorCode::NOSUPPORT, data))
+        } else {
+            // Save all the data and offsets we still need to send
+            self.buffer.replace(data);
+            self.write_len.set(write_len as usize);
+            self.read_len.set(read_len as usize);
+            self.write_index.set(0);
+            self.read_index.set(0);
+            // Clear and enable interrupts
+            regs.intclr.set(0xFFFF_FFFF);
+            regs.inten.set(0xFFFF_FFFF);
+
+            // Start the transfer
+            regs.cmd.write(
+                CMD::TSIZE.val(read_len as u32)
+                    + CMD::CMD::READ
+                    + CMD::OFFSETCNT.val(write_len as u32)
+                    + CMD::OFFSETLO.val(offsetlo),
+            );
+
+            self.read_data();
+            Ok(())
         }
-
-        // Clear and enable interrupts
-        regs.intclr.set(0xFFFF_FFFF);
-        regs.inten.set(0xFFFF_FFFF);
-
-        // Start the transfer
-        regs.cmd.write(
-            CMD::TSIZE.val(read_len as u32)
-                + CMD::CMD::READ
-                + CMD::OFFSETCNT.val(write_len as u32)
-                + CMD::OFFSETLO.val(offsetlo),
-        );
-
-        self.read_data();
     }
 
-    fn tx(&self, addr: u8, data: &'static mut [u8], len: u8) {
+    fn tx(
+        &self,
+        addr: u8,
+        data: &'static mut [u8],
+        len: u8,
+    ) -> Result<(), (ErrorCode, &'static mut [u8])> {
         let regs = self.registers;
 
         // Disable DMA as we don't support it
@@ -631,9 +640,15 @@ impl<'a> Iom<'_> {
         // Start the transfer
         regs.cmd
             .write(CMD::TSIZE.val(len as u32) + CMD::CMD::WRITE + CMD::CONT::CLEAR);
+        Ok(())
     }
 
-    fn rx(&self, addr: u8, buffer: &'static mut [u8], len: u8) {
+    fn rx(
+        &self,
+        addr: u8,
+        buffer: &'static mut [u8],
+        len: u8,
+    ) -> Result<(), (ErrorCode, &'static mut [u8])> {
         let regs = self.registers;
 
         // Disable DMA as we don't support it
@@ -671,6 +686,8 @@ impl<'a> Iom<'_> {
         self.read_index.set(0);
 
         self.read_data();
+
+        Ok(())
     }
 }
 
@@ -717,16 +734,32 @@ impl<'a> hil::i2c::I2CMaster for Iom<'a> {
         regs.submodctrl.write(SUBMODCTRL::SMOD1EN::CLEAR);
     }
 
-    fn write_read(&self, addr: u8, data: &'static mut [u8], write_len: u8, read_len: u8) {
-        self.tx_rx(addr, data, write_len, read_len);
+    fn write_read(
+        &self,
+        addr: u8,
+        data: &'static mut [u8],
+        write_len: u8,
+        read_len: u8,
+    ) -> Result<(), (ErrorCode, &'static mut [u8])> {
+        self.tx_rx(addr, data, write_len, read_len)
     }
 
-    fn write(&self, addr: u8, data: &'static mut [u8], len: u8) {
-        self.tx(addr, data, len);
+    fn write(
+        &self,
+        addr: u8,
+        data: &'static mut [u8],
+        len: u8,
+    ) -> Result<(), (ErrorCode, &'static mut [u8])> {
+        self.tx(addr, data, len)
     }
 
-    fn read(&self, addr: u8, buffer: &'static mut [u8], len: u8) {
-        self.rx(addr, buffer, len);
+    fn read(
+        &self,
+        addr: u8,
+        buffer: &'static mut [u8],
+        len: u8,
+    ) -> Result<(), (ErrorCode, &'static mut [u8])> {
+        self.rx(addr, buffer, len)
     }
 }
 
@@ -737,7 +770,7 @@ impl<'a> hil::i2c::SMBusMaster for Iom<'a> {
         data: &'static mut [u8],
         write_len: u8,
         read_len: u8,
-    ) -> Result<(), (i2c::Error, &'static mut [u8])> {
+    ) -> Result<(), (ErrorCode, &'static mut [u8])> {
         let regs = self.registers;
 
         // Setup 100kHz
@@ -752,8 +785,7 @@ impl<'a> hil::i2c::SMBusMaster for Iom<'a> {
 
         self.smbus.set(true);
 
-        self.tx_rx(addr, data, write_len, read_len);
-        Ok(())
+        self.tx_rx(addr, data, write_len, read_len)
     }
 
     fn smbus_write(
@@ -761,7 +793,7 @@ impl<'a> hil::i2c::SMBusMaster for Iom<'a> {
         addr: u8,
         data: &'static mut [u8],
         len: u8,
-    ) -> Result<(), (i2c::Error, &'static mut [u8])> {
+    ) -> Result<(), (ErrorCode, &'static mut [u8])> {
         let regs = self.registers;
 
         // Setup 100kHz
@@ -776,8 +808,7 @@ impl<'a> hil::i2c::SMBusMaster for Iom<'a> {
 
         self.smbus.set(true);
 
-        self.tx(addr, data, len);
-        Ok(())
+        self.tx(addr, data, len)
     }
 
     fn smbus_read(
@@ -785,7 +816,7 @@ impl<'a> hil::i2c::SMBusMaster for Iom<'a> {
         addr: u8,
         buffer: &'static mut [u8],
         len: u8,
-    ) -> Result<(), (i2c::Error, &'static mut [u8])> {
+    ) -> Result<(), (ErrorCode, &'static mut [u8])> {
         let regs = self.registers;
 
         // Setup 100kHz
@@ -800,7 +831,6 @@ impl<'a> hil::i2c::SMBusMaster for Iom<'a> {
 
         self.smbus.set(true);
 
-        self.rx(addr, buffer, len);
-        Ok(())
+        self.rx(addr, buffer, len)
     }
 }

--- a/chips/apollo3/src/iom.rs
+++ b/chips/apollo3/src/iom.rs
@@ -7,7 +7,6 @@ use kernel::common::registers::{register_bitfields, register_structs, ReadOnly, 
 use kernel::common::StaticRef;
 use kernel::hil;
 use kernel::hil::i2c;
-use kernel::ErrorCode;
 
 const IOM0_BASE: StaticRef<IomRegisters> =
     unsafe { StaticRef::new(0x5000_4000 as *const IomRegisters) };
@@ -533,7 +532,7 @@ impl<'a> Iom<'_> {
         data: &'static mut [u8],
         write_len: u8,
         read_len: u8,
-    ) -> Result<(), (ErrorCode, &'static mut [u8])> {
+    ) -> Result<(), (i2c::Error, &'static mut [u8])> {
         let regs = self.registers;
         let mut offsetlo = 0;
 
@@ -568,7 +567,7 @@ impl<'a> Iom<'_> {
         }
 
         if write_len > 3 {
-            Err((ErrorCode::NOSUPPORT, data))
+            Err((i2c::Error::NotSupported, data))
         } else {
             // Save all the data and offsets we still need to send
             self.buffer.replace(data);
@@ -598,7 +597,7 @@ impl<'a> Iom<'_> {
         addr: u8,
         data: &'static mut [u8],
         len: u8,
-    ) -> Result<(), (ErrorCode, &'static mut [u8])> {
+    ) -> Result<(), (i2c::Error, &'static mut [u8])> {
         let regs = self.registers;
 
         // Disable DMA as we don't support it
@@ -644,7 +643,7 @@ impl<'a> Iom<'_> {
         addr: u8,
         buffer: &'static mut [u8],
         len: u8,
-    ) -> Result<(), (ErrorCode, &'static mut [u8])> {
+    ) -> Result<(), (i2c::Error, &'static mut [u8])> {
         let regs = self.registers;
 
         // Disable DMA as we don't support it
@@ -736,7 +735,7 @@ impl<'a> hil::i2c::I2CMaster for Iom<'a> {
         data: &'static mut [u8],
         write_len: u8,
         read_len: u8,
-    ) -> Result<(), (ErrorCode, &'static mut [u8])> {
+    ) -> Result<(), (hil::i2c::Error, &'static mut [u8])> {
         self.tx_rx(addr, data, write_len, read_len)
     }
 
@@ -745,7 +744,7 @@ impl<'a> hil::i2c::I2CMaster for Iom<'a> {
         addr: u8,
         data: &'static mut [u8],
         len: u8,
-    ) -> Result<(), (ErrorCode, &'static mut [u8])> {
+    ) -> Result<(), (hil::i2c::Error, &'static mut [u8])> {
         self.tx(addr, data, len)
     }
 
@@ -754,7 +753,7 @@ impl<'a> hil::i2c::I2CMaster for Iom<'a> {
         addr: u8,
         buffer: &'static mut [u8],
         len: u8,
-    ) -> Result<(), (ErrorCode, &'static mut [u8])> {
+    ) -> Result<(), (hil::i2c::Error, &'static mut [u8])> {
         self.rx(addr, buffer, len)
     }
 }
@@ -766,7 +765,7 @@ impl<'a> hil::i2c::SMBusMaster for Iom<'a> {
         data: &'static mut [u8],
         write_len: u8,
         read_len: u8,
-    ) -> Result<(), (ErrorCode, &'static mut [u8])> {
+    ) -> Result<(), (hil::i2c::Error, &'static mut [u8])> {
         let regs = self.registers;
 
         // Setup 100kHz
@@ -789,7 +788,7 @@ impl<'a> hil::i2c::SMBusMaster for Iom<'a> {
         addr: u8,
         data: &'static mut [u8],
         len: u8,
-    ) -> Result<(), (ErrorCode, &'static mut [u8])> {
+    ) -> Result<(), (hil::i2c::Error, &'static mut [u8])> {
         let regs = self.registers;
 
         // Setup 100kHz
@@ -812,7 +811,7 @@ impl<'a> hil::i2c::SMBusMaster for Iom<'a> {
         addr: u8,
         buffer: &'static mut [u8],
         len: u8,
-    ) -> Result<(), (ErrorCode, &'static mut [u8])> {
+    ) -> Result<(), (hil::i2c::Error, &'static mut [u8])> {
         let regs = self.registers;
 
         // Setup 100kHz

--- a/chips/apollo3/src/iom.rs
+++ b/chips/apollo3/src/iom.rs
@@ -568,10 +568,6 @@ impl<'a> Iom<'_> {
         }
 
         if write_len > 3 {
-            // We can't suppord that much data, bail out now
-            // self.master_client.map(|client| {
-            //     client.command_complete(self.buffer.take().unwrap(), Err(ErrorCode::NOSUPPORT));
-            // });
             Err((ErrorCode::NOSUPPORT, data))
         } else {
             // Save all the data and offsets we still need to send

--- a/chips/lowrisc/src/i2c.rs
+++ b/chips/lowrisc/src/i2c.rs
@@ -9,7 +9,6 @@ use kernel::common::registers::{
 use kernel::common::StaticRef;
 use kernel::hil;
 use kernel::hil::i2c;
-use kernel::ErrorCode;
 
 register_structs! {
     pub I2cRegisters {
@@ -395,7 +394,7 @@ impl<'a> hil::i2c::I2CMaster for I2c<'a> {
         data: &'static mut [u8],
         write_len: u8,
         read_len: u8,
-    ) -> Result<(), (ErrorCode, &'static mut [u8])> {
+    ) -> Result<(), (hil::i2c::Error, &'static mut [u8])> {
         let regs = self.registers;
 
         // Set the FIFO depth and reset the FIFO
@@ -442,7 +441,7 @@ impl<'a> hil::i2c::I2CMaster for I2c<'a> {
         addr: u8,
         data: &'static mut [u8],
         len: u8,
-    ) -> Result<(), (ErrorCode, &'static mut [u8])> {
+    ) -> Result<(), (hil::i2c::Error, &'static mut [u8])> {
         let regs = self.registers;
 
         // Set the FIFO depth and reset the FIFO
@@ -479,7 +478,7 @@ impl<'a> hil::i2c::I2CMaster for I2c<'a> {
         addr: u8,
         buffer: &'static mut [u8],
         len: u8,
-    ) -> Result<(), (ErrorCode, &'static mut [u8])> {
+    ) -> Result<(), (hil::i2c::Error, &'static mut [u8])> {
         let regs = self.registers;
 
         // Set the FIFO depth and reset the FIFO

--- a/chips/msp432/src/i2c.rs
+++ b/chips/msp432/src/i2c.rs
@@ -3,6 +3,7 @@ use core::cell::Cell;
 use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::common::StaticRef;
 use kernel::hil::i2c;
+use kernel::ErrorCode;
 
 #[derive(Copy, Clone, PartialEq)]
 pub enum Speed {
@@ -123,14 +124,14 @@ impl<'a> I2c<'a> {
         self.registers.tbcnt.set(val as u16);
     }
 
-    fn invoke_callback(&self, err: i2c::Error) {
+    fn invoke_callback(&self, status: Result<(), ErrorCode>) {
         // Reset buffer index and set mode to Idle in order to start a new transfer properly
         self.buf_idx.set(0);
         self.mode.set(OperatingMode::Idle);
 
         self.buffer.take().map(|buf| {
             self.master_client
-                .map(move |cl| cl.command_complete(buf, err))
+                .map(move |cl| cl.command_complete(buf, status))
         });
     }
 
@@ -232,7 +233,7 @@ impl<'a> I2c<'a> {
                 // For some reason generating a stop condition manually in receive mode doesn't
                 // trigger a stop condition interrupt -> invoke the callback here when all bytes
                 // were received
-                self.invoke_callback(i2c::Error::CommandComplete);
+                self.invoke_callback(Ok(()));
             }
         } else if (ifg & (1 << usci::UCBxIFG::UCSTTIFG.shift)) > 0 {
             // Start condition interrupt
@@ -246,20 +247,20 @@ impl<'a> I2c<'a> {
 
             // This interrupt is the default indicator that a transaction finished, thus raise the
             // callback here and prepare for another transfer
-            self.invoke_callback(i2c::Error::CommandComplete);
+            self.invoke_callback(Ok(()));
         } else if (ifg & (1 << usci::UCBxIFG::UCNACKIFG.shift)) > 0 {
             // NACK interrupt
             // TODO: use byte counter to detect address NAK
 
             // Cancel i2c transfer
             self.generate_stop_condition();
-            self.invoke_callback(i2c::Error::DataNak);
+            self.invoke_callback(Err(ErrorCode::NOACK));
         } else if (ifg & (1 << usci::UCBxIFG::UCALIFG.shift)) > 0 {
             // Arbitration lost  interrupt
 
             // Cancel i2c transfer
             self.generate_stop_condition();
-            self.invoke_callback(i2c::Error::ArbitrationLost);
+            self.invoke_callback(Err(ErrorCode::BUSY));
         } else {
             panic!("I2C: unhandled interrupt, ifg: {}", ifg);
         }
@@ -285,10 +286,15 @@ impl<'a> i2c::I2CMaster for I2c<'a> {
         self.mode.set(OperatingMode::Disabled);
     }
 
-    fn write(&self, addr: u8, data: &'static mut [u8], len: u8) {
+    fn write(
+        &self,
+        addr: u8,
+        data: &'static mut [u8],
+        len: u8,
+    ) -> Result<(), (ErrorCode, &'static mut [u8])> {
         if self.mode.get() != OperatingMode::Idle {
             // Module is busy or not activated
-            return;
+            return Err((ErrorCode::BUSY, data));
         }
 
         self.buffer.replace(data);
@@ -314,12 +320,19 @@ impl<'a> i2c::I2CMaster for I2c<'a> {
 
         // Start transfer
         self.generate_start_condition();
+
+        Ok(())
     }
 
-    fn read(&self, addr: u8, buffer: &'static mut [u8], len: u8) {
+    fn read(
+        &self,
+        addr: u8,
+        buffer: &'static mut [u8],
+        len: u8,
+    ) -> Result<(), (ErrorCode, &'static mut [u8])> {
         if self.mode.get() != OperatingMode::Idle {
             // Module is busy or not activated
-            return;
+            return Err((ErrorCode::BUSY, buffer));
         }
 
         self.buffer.replace(buffer);
@@ -343,12 +356,19 @@ impl<'a> i2c::I2CMaster for I2c<'a> {
 
         // Start transfer
         self.generate_start_condition();
+        Ok(())
     }
 
-    fn write_read(&self, addr: u8, data: &'static mut [u8], write_len: u8, read_len: u8) {
+    fn write_read(
+        &self,
+        addr: u8,
+        data: &'static mut [u8],
+        write_len: u8,
+        read_len: u8,
+    ) -> Result<(), (ErrorCode, &'static mut [u8])> {
         if self.mode.get() != OperatingMode::Idle {
             // Module is busy or not activated
-            return;
+            return Err((ErrorCode::BUSY, data));
         }
 
         self.buffer.replace(data);
@@ -370,5 +390,7 @@ impl<'a> i2c::I2CMaster for I2c<'a> {
 
         // Start transfer
         self.generate_start_condition();
+
+        Ok(())
     }
 }

--- a/chips/nrf52/src/i2c.rs
+++ b/chips/nrf52/src/i2c.rs
@@ -13,7 +13,6 @@ use kernel::common::cells::VolatileCell;
 use kernel::common::registers::{register_bitfields, ReadWrite, WriteOnly};
 use kernel::common::StaticRef;
 use kernel::hil;
-use kernel::ErrorCode;
 use nrf5x::pinmux::Pinmux;
 
 /// Uninitialized `TWIM` instances.
@@ -107,9 +106,9 @@ impl TWIM {
                 None => (),
                 Some(buf) => {
                     let status = if errorsrc.is_set(ERRORSRC::ANACK) {
-                        Err(ErrorCode::NOACK)
+                        Err(hil::i2c::Error::AddressNak)
                     } else if errorsrc.is_set(ERRORSRC::DNACK) {
-                        Err(ErrorCode::NOACK)
+                        Err(hil::i2c::Error::DataNak)
                     } else {
                         Ok(())
                     };
@@ -148,7 +147,7 @@ impl hil::i2c::I2CMaster for TWIM {
         data: &'static mut [u8],
         write_len: u8,
         read_len: u8,
-    ) -> Result<(), (ErrorCode, &'static mut [u8])> {
+    ) -> Result<(), (hil::i2c::Error, &'static mut [u8])> {
         self.registers
             .address
             .write(ADDRESS::ADDRESS.val(addr as u32));
@@ -181,7 +180,7 @@ impl hil::i2c::I2CMaster for TWIM {
         addr: u8,
         data: &'static mut [u8],
         len: u8,
-    ) -> Result<(), (ErrorCode, &'static mut [u8])> {
+    ) -> Result<(), (hil::i2c::Error, &'static mut [u8])> {
         self.registers
             .address
             .write(ADDRESS::ADDRESS.val(addr as u32));
@@ -208,7 +207,7 @@ impl hil::i2c::I2CMaster for TWIM {
         addr: u8,
         buffer: &'static mut [u8],
         len: u8,
-    ) -> Result<(), (ErrorCode, &'static mut [u8])> {
+    ) -> Result<(), (hil::i2c::Error, &'static mut [u8])> {
         self.registers
             .address
             .write(ADDRESS::ADDRESS.val(addr as u32));

--- a/chips/nrf52/src/i2c.rs
+++ b/chips/nrf52/src/i2c.rs
@@ -13,6 +13,7 @@ use kernel::common::cells::VolatileCell;
 use kernel::common::registers::{register_bitfields, ReadWrite, WriteOnly};
 use kernel::common::StaticRef;
 use kernel::hil;
+use kernel::ErrorCode;
 use nrf5x::pinmux::Pinmux;
 
 /// Uninitialized `TWIM` instances.
@@ -141,7 +142,13 @@ impl hil::i2c::I2CMaster for TWIM {
         self.disable();
     }
 
-    fn write_read(&self, addr: u8, data: &'static mut [u8], write_len: u8, read_len: u8) {
+    fn write_read(
+        &self,
+        addr: u8,
+        data: &'static mut [u8],
+        write_len: u8,
+        read_len: u8,
+    ) -> Result<(), (ErrorCode, &'static mut [u8])> {
         self.registers
             .address
             .write(ADDRESS::ADDRESS.val(addr as u32));
@@ -166,9 +173,15 @@ impl hil::i2c::I2CMaster for TWIM {
         // start the transfer
         self.registers.tasks_starttx.write(TASK::TASK::SET);
         self.buf.replace(data);
+        Ok(())
     }
 
-    fn write(&self, addr: u8, data: &'static mut [u8], len: u8) {
+    fn write(
+        &self,
+        addr: u8,
+        data: &'static mut [u8],
+        len: u8,
+    ) -> Result<(), (ErrorCode, &'static mut [u8])> {
         self.registers
             .address
             .write(ADDRESS::ADDRESS.val(addr as u32));
@@ -187,9 +200,15 @@ impl hil::i2c::I2CMaster for TWIM {
         // start the transfer
         self.registers.tasks_starttx.write(TASK::TASK::SET);
         self.buf.replace(data);
+        Ok(())
     }
 
-    fn read(&self, addr: u8, buffer: &'static mut [u8], len: u8) {
+    fn read(
+        &self,
+        addr: u8,
+        buffer: &'static mut [u8],
+        len: u8,
+    ) -> Result<(), (ErrorCode, &'static mut [u8])> {
         self.registers
             .address
             .write(ADDRESS::ADDRESS.val(addr as u32));
@@ -208,6 +227,7 @@ impl hil::i2c::I2CMaster for TWIM {
         // start the transfer
         self.registers.tasks_startrx.write(TASK::TASK::SET);
         self.buf.replace(buffer);
+        Ok(())
     }
 }
 

--- a/chips/nrf52/src/i2c.rs
+++ b/chips/nrf52/src/i2c.rs
@@ -92,7 +92,7 @@ impl TWIM {
             self.client.map(|client| match self.buf.take() {
                 None => (),
                 Some(buf) => {
-                    client.command_complete(buf, hil::i2c::Error::CommandComplete);
+                    client.command_complete(buf, Ok(()));
                 }
             });
         }
@@ -106,14 +106,14 @@ impl TWIM {
             self.client.map(|client| match self.buf.take() {
                 None => (),
                 Some(buf) => {
-                    let i2c_error = if errorsrc.is_set(ERRORSRC::ANACK) {
-                        hil::i2c::Error::AddressNak
+                    let status = if errorsrc.is_set(ERRORSRC::ANACK) {
+                        Err(ErrorCode::NOACK)
                     } else if errorsrc.is_set(ERRORSRC::DNACK) {
-                        hil::i2c::Error::DataNak
+                        Err(ErrorCode::NOACK)
                     } else {
-                        hil::i2c::Error::CommandComplete
+                        Ok(())
                     };
-                    client.command_complete(buf, i2c_error);
+                    client.command_complete(buf, status);
                 }
             });
         }

--- a/chips/sam4l/src/i2c.rs
+++ b/chips/sam4l/src/i2c.rs
@@ -17,7 +17,7 @@ use kernel::common::peripherals::{PeripheralManagement, PeripheralManager};
 use kernel::common::registers::{register_bitfields, FieldValue, ReadOnly, ReadWrite, WriteOnly};
 use kernel::common::StaticRef;
 use kernel::hil;
-use kernel::ClockInterface;
+use kernel::{ClockInterface, ErrorCode};
 
 // Listing of all registers related to the TWIM peripheral.
 // Section 27.9 of the datasheet
@@ -748,8 +748,6 @@ impl I2CHw {
     }
 
     pub fn handle_interrupt(&self) {
-        use kernel::hil::i2c::Error;
-
         let old_status = {
             let twim = &TWIMRegisterManager::new(&self);
 
@@ -771,13 +769,13 @@ impl I2CHw {
         };
 
         let err = if old_status.is_set(Status::ANAK) {
-            Some(Error::AddressNak)
+            Some(Err(ErrorCode::NOACK))
         } else if old_status.is_set(Status::DNAK) {
-            Some(Error::DataNak)
+            Some(Err(ErrorCode::NOACK))
         } else if old_status.is_set(Status::ARBLST) {
-            Some(Error::ArbitrationLost)
+            Some(Err(ErrorCode::BUSY))
         } else if old_status.is_set(Status::CCOMP) {
-            Some(Error::CommandComplete)
+            Some(Ok(()))
         } else {
             None
         };
@@ -939,15 +937,20 @@ impl I2CHw {
         flags: FieldValue<u32, Command::Register>,
         data: &'static mut [u8],
         len: u8,
-    ) {
+    ) -> Result<(), (ErrorCode, &'static mut [u8])> {
         let twim = &TWIMRegisterManager::new(&self);
-        self.dma.map(move |dma| {
-            dma.enable();
-            dma.prepare_transfer(self.dma_pids.1, data, len as usize);
-            self.setup_transfer(twim, chip, flags, Command::READ::Transmit, len);
-            self.master_enable(twim);
-            dma.start_transfer();
-        });
+        if self.dma.is_some() {
+            self.dma.map(move |dma| {
+                dma.enable();
+                dma.prepare_transfer(self.dma_pids.1, data, len as usize);
+                self.setup_transfer(twim, chip, flags, Command::READ::Transmit, len);
+                self.master_enable(twim);
+                dma.start_transfer();
+            });
+            Ok(())
+        } else {
+            Err((ErrorCode::FAIL, data))
+        }
     }
 
     fn read(
@@ -956,39 +959,55 @@ impl I2CHw {
         flags: FieldValue<u32, Command::Register>,
         data: &'static mut [u8],
         len: u8,
-    ) {
+    ) -> Result<(), (ErrorCode, &'static mut [u8])> {
         let twim = &TWIMRegisterManager::new(&self);
-        self.dma.map(move |dma| {
-            dma.enable();
-            dma.prepare_transfer(self.dma_pids.0, data, len as usize);
-            self.setup_transfer(twim, chip, flags, Command::READ::Receive, len);
-            self.master_enable(twim);
-            dma.start_transfer();
-        });
+        if self.dma.is_some() {
+            self.dma.map(move |dma| {
+                dma.enable();
+                dma.prepare_transfer(self.dma_pids.0, data, len as usize);
+                self.setup_transfer(twim, chip, flags, Command::READ::Receive, len);
+                self.master_enable(twim);
+                dma.start_transfer();
+            });
+            Ok(())
+        } else {
+            Err((ErrorCode::FAIL, data))
+        }
     }
 
-    fn write_read(&self, chip: u8, data: &'static mut [u8], split: u8, read_len: u8) {
+    fn write_read(
+        &self,
+        chip: u8,
+        data: &'static mut [u8],
+        split: u8,
+        read_len: u8,
+    ) -> Result<(), (ErrorCode, &'static mut [u8])> {
         let twim = &TWIMRegisterManager::new(&self);
-        self.dma.map(move |dma| {
-            dma.enable();
-            dma.prepare_transfer(self.dma_pids.1, data, split as usize);
-            self.setup_transfer(
-                twim,
-                chip,
-                Command::START::StartCondition,
-                Command::READ::Transmit,
-                split,
-            );
-            self.setup_nextfer(
-                twim,
-                chip,
-                Command::START::StartCondition + Command::STOP::SendStop,
-                Command::READ::Receive,
-                read_len,
-            );
-            self.on_deck.set(Some((self.dma_pids.0, read_len as usize)));
-            dma.start_transfer();
-        });
+        if self.dma.is_some() {
+            self.dma.map(move |dma| {
+                dma.enable();
+                dma.prepare_transfer(self.dma_pids.1, data, split as usize);
+                self.setup_transfer(
+                    twim,
+                    chip,
+                    Command::START::StartCondition,
+                    Command::READ::Transmit,
+                    split,
+                );
+                self.setup_nextfer(
+                    twim,
+                    chip,
+                    Command::START::StartCondition + Command::STOP::SendStop,
+                    Command::READ::Receive,
+                    read_len,
+                );
+                self.on_deck.set(Some((self.dma_pids.0, read_len as usize)));
+                dma.start_transfer();
+            });
+            Ok(())
+        } else {
+            Err((ErrorCode::FAIL, data))
+        }
     }
 
     fn disable_interrupts(&self, twim: &TWIMRegisterManager) {
@@ -1219,12 +1238,15 @@ impl I2CHw {
     }
 
     /// Receive the bytes the I2C master is writing to us.
-    fn slave_write_receive(&self, buffer: &'static mut [u8], len: u8) {
-        self.slave_write_buffer.replace(buffer);
-        self.slave_write_buffer_len.set(len);
-
+    fn slave_write_receive(
+        &self,
+        buffer: &'static mut [u8],
+        len: u8,
+    ) -> Result<(), (ErrorCode, &'static mut [u8])> {
         if self.slave_enabled.get() {
             if self.slave_mmio_address.is_some() {
+                self.slave_write_buffer.replace(buffer);
+                self.slave_write_buffer_len.set(len);
                 let twis = &TWISRegisterManager::new(&self);
 
                 let status = twis.registers.sr.extract();
@@ -1236,18 +1258,26 @@ impl I2CHw {
                 if interrupts.is_set(StatusSlave::SAM) && !status.is_set(StatusSlave::TRA) {
                     twis.registers.scr.set(status.get());
                 }
+                Ok(())
+            } else {
+                Err((ErrorCode::INVAL, buffer))
             }
+        } else {
+            Err((ErrorCode::OFF, buffer))
         }
     }
 
     /// Prepare a buffer for the I2C master to read from after a read call.
-    fn slave_read_send(&self, buffer: &'static mut [u8], len: u8) {
-        self.slave_read_buffer.replace(buffer);
-        self.slave_read_buffer_len.set(len);
-        self.slave_read_buffer_index.set(0);
-
+    fn slave_read_send(
+        &self,
+        buffer: &'static mut [u8],
+        len: u8,
+    ) -> Result<(), (ErrorCode, &'static mut [u8])> {
         if self.slave_enabled.get() {
             if self.slave_mmio_address.is_some() {
+                self.slave_read_buffer.replace(buffer);
+                self.slave_read_buffer_len.set(len);
+                self.slave_read_buffer_index.set(0);
                 let twis = &TWISRegisterManager::new(&self);
 
                 // Check to see if we should send the first byte.
@@ -1278,7 +1308,12 @@ impl I2CHw {
                     // Make it happen by clearing status.
                     twis.registers.scr.set(status.get());
                 }
+                Ok(())
+            } else {
+                Err((ErrorCode::INVAL, buffer))
             }
+        } else {
+            Err((ErrorCode::OFF, buffer))
         }
     }
 
@@ -1349,27 +1384,43 @@ impl hil::i2c::I2CMaster for I2CHw {
         self.disable_interrupts(twim);
     }
 
-    fn write(&self, addr: u8, data: &'static mut [u8], len: u8) {
+    fn write(
+        &self,
+        addr: u8,
+        data: &'static mut [u8],
+        len: u8,
+    ) -> Result<(), (ErrorCode, &'static mut [u8])> {
         I2CHw::write(
             self,
             addr,
             Command::START::StartCondition + Command::STOP::SendStop,
             data,
             len,
-        );
+        )
     }
 
-    fn read(&self, addr: u8, data: &'static mut [u8], len: u8) {
+    fn read(
+        &self,
+        addr: u8,
+        data: &'static mut [u8],
+        len: u8,
+    ) -> Result<(), (ErrorCode, &'static mut [u8])> {
         I2CHw::read(
             self,
             addr,
             Command::START::StartCondition + Command::STOP::SendStop,
             data,
             len,
-        );
+        )
     }
 
-    fn write_read(&self, addr: u8, data: &'static mut [u8], write_len: u8, read_len: u8) {
+    fn write_read(
+        &self,
+        addr: u8,
+        data: &'static mut [u8],
+        write_len: u8,
+        read_len: u8,
+    ) -> Result<(), (ErrorCode, &'static mut [u8])> {
         I2CHw::write_read(self, addr, data, write_len, read_len)
     }
 }
@@ -1424,16 +1475,25 @@ impl hil::i2c::I2CSlave for I2CHw {
         }
     }
 
-    fn set_address(&self, addr: u8) {
+    fn set_address(&self, addr: u8) -> Result<(), ErrorCode> {
         self.slave_set_address(addr);
+        Ok(())
     }
 
-    fn write_receive(&self, data: &'static mut [u8], max_len: u8) {
-        self.slave_write_receive(data, max_len);
+    fn write_receive(
+        &self,
+        data: &'static mut [u8],
+        max_len: u8,
+    ) -> Result<(), (ErrorCode, &'static mut [u8])> {
+        self.slave_write_receive(data, max_len)
     }
 
-    fn read_send(&self, data: &'static mut [u8], max_len: u8) {
-        self.slave_read_send(data, max_len);
+    fn read_send(
+        &self,
+        data: &'static mut [u8],
+        max_len: u8,
+    ) -> Result<(), (ErrorCode, &'static mut [u8])> {
+        self.slave_read_send(data, max_len)
     }
 
     fn listen(&self) {

--- a/chips/stm32f4xx/src/i2c.rs
+++ b/chips/stm32f4xx/src/i2c.rs
@@ -4,8 +4,8 @@ use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::common::registers::{register_bitfields, ReadWrite};
 use kernel::common::StaticRef;
 use kernel::hil;
-use kernel::hil::i2c::{self, Error, I2CHwMasterClient, I2CMaster};
-use kernel::ClockInterface;
+use kernel::hil::i2c::{self, I2CHwMasterClient, I2CMaster};
+use kernel::{ClockInterface, ErrorCode};
 
 use crate::rcc;
 
@@ -308,7 +308,7 @@ impl<'a> I2C<'a> {
                 self.master_client.map(|client| {
                     self.buffer
                         .take()
-                        .map(|buf| client.command_complete(buf, Error::CommandComplete))
+                        .map(|buf| client.command_complete(buf, Ok(())))
                 });
             }
         }
@@ -322,7 +322,7 @@ impl<'a> I2C<'a> {
                         self.master_client.map(|client| {
                             self.buffer
                                 .take()
-                                .map(|buf| client.command_complete(buf, Error::DataNak))
+                                .map(|buf| client.command_complete(buf, Err(ErrorCode::NOACK)))
                         });
                     } else {
                         if self.status.get() == I2CStatus::Writing {
@@ -331,7 +331,7 @@ impl<'a> I2C<'a> {
                             self.master_client.map(|client| {
                                 self.buffer
                                     .take()
-                                    .map(|buf| client.command_complete(buf, Error::CommandComplete))
+                                    .map(|buf| client.command_complete(buf, Ok(())))
                             });
                         } else {
                             self.status.set(I2CStatus::Reading);
@@ -340,17 +340,17 @@ impl<'a> I2C<'a> {
                     }
                 }
                 I2CStatus::Reading => {
-                    let error = if self.rx_position.get() == self.rx_len.get() {
-                        Error::CommandComplete
+                    let status = if self.rx_position.get() == self.rx_len.get() {
+                        Ok(())
                     } else {
-                        Error::DataNak
+                        Err(ErrorCode::NOACK)
                     };
                     self.registers.cr1.modify(CR1::STOP::SET);
                     self.stop();
                     self.master_client.map(|client| {
                         self.buffer
                             .take()
-                            .map(|buf| client.command_complete(buf, error))
+                            .map(|buf| client.command_complete(buf, status))
                     });
                 }
                 _ => panic!("i2c status error"),
@@ -362,7 +362,7 @@ impl<'a> I2C<'a> {
         self.master_client.map(|client| {
             self.buffer
                 .take()
-                .map(|buf| client.command_complete(buf, Error::DataNak))
+                .map(|buf| client.command_complete(buf, Err(ErrorCode::NOACK)))
         });
         self.stop();
     }
@@ -409,7 +409,13 @@ impl i2c::I2CMaster for I2C<'_> {
     fn disable(&self) {
         self.registers.cr1.modify(CR1::PE::CLEAR);
     }
-    fn write_read(&self, addr: u8, data: &'static mut [u8], write_len: u8, read_len: u8) {
+    fn write_read(
+        &self,
+        addr: u8,
+        data: &'static mut [u8],
+        write_len: u8,
+        read_len: u8,
+    ) -> Result<(), (ErrorCode, &'static mut [u8])> {
         if self.status.get() == I2CStatus::Idle {
             self.reset();
             self.status.set(I2CStatus::WritingReading);
@@ -418,9 +424,17 @@ impl i2c::I2CMaster for I2C<'_> {
             self.tx_len.set(write_len);
             self.rx_len.set(read_len);
             self.start_write();
+            Ok(())
+        } else {
+            Err((ErrorCode::BUSY, data))
         }
     }
-    fn write(&self, addr: u8, data: &'static mut [u8], len: u8) {
+    fn write(
+        &self,
+        addr: u8,
+        data: &'static mut [u8],
+        len: u8,
+    ) -> Result<(), (ErrorCode, &'static mut [u8])> {
         if self.status.get() == I2CStatus::Idle {
             self.reset();
             self.status.set(I2CStatus::Writing);
@@ -428,9 +442,17 @@ impl i2c::I2CMaster for I2C<'_> {
             self.buffer.replace(data);
             self.tx_len.set(len);
             self.start_write();
+            Ok(())
+        } else {
+            Err((ErrorCode::BUSY, data))
         }
     }
-    fn read(&self, addr: u8, buffer: &'static mut [u8], len: u8) {
+    fn read(
+        &self,
+        addr: u8,
+        buffer: &'static mut [u8],
+        len: u8,
+    ) -> Result<(), (ErrorCode, &'static mut [u8])> {
         if self.status.get() == I2CStatus::Idle {
             self.reset();
             self.status.set(I2CStatus::Reading);
@@ -438,6 +460,9 @@ impl i2c::I2CMaster for I2C<'_> {
             self.buffer.replace(buffer);
             self.rx_len.set(len);
             self.start_read();
+            Ok(())
+        } else {
+            Err((ErrorCode::BUSY, buffer))
         }
     }
 }

--- a/kernel/src/errorcode.rs
+++ b/kernel/src/errorcode.rs
@@ -8,7 +8,7 @@ use core::convert::TryFrom;
 /// does not feature any success cases and is therefore more appropriate for the
 /// Tock 2.0 system call interface, where success payloads and errors are not
 /// packed into the same 32-bit wide register.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(usize)]
 pub enum ErrorCode {
     // Reserved value, for when "no error" / "success" should be


### PR DESCRIPTION
### Pull Request Overview

This pull request modifies the I2C HIL so that request functions return the given buffer upon error. Without this, the i2c caller will loose the buffers if the I2C device is busy or is not able to perform the request. I noticed that the SMBus already did implement this.

This PR also:
 - modifies the error the the SMBus returns so that it follows the StatusCode (extended - as buffers are also returned) way.
 - adds checking for an outstanding request for the I2C Virtual device

A small problem arises when the I2C Virtualization is used. Request functions may fail due to two reasons:
1. The virtual device already has an outstanding request, in which case it immediately returns an error and the buffers
2. The virtual device accept the request, but later on the Mux is not able to perform it, in which case the error should be returned asynchronously via `read_write_done`. As the I2C Error enum did not provide a suitable option for this error, this PR adds a new `Result (ErrorCode)` item.

This PR does not yet modify drivers as I am waiting for feedback first.

### Testing Strategy

This pull request was tested by...


### TODO or Help Wanted

While I think this is useful as it corrects some corner cases, I am not sure that this approach is the best. Function definitions become a little for complicated. Any feedback would be greatly appreciated.


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
