### PR TITLE
[RFC] multicore support

### DIFF
--- a/chips/apollo3/src/chip.rs
+++ b/chips/apollo3/src/chip.rs
@@ -88,6 +88,7 @@ impl<I: InterruptService<()> + 'static> Chip for Apollo3<I> {
     type UserspaceKernelBoundary = cortexm4::syscall::SysCall;
     type SchedulerTimer = cortexm4::systick::SysTick;
     type WatchDog = ();
+    type Core = ();
 
     fn service_pending_interrupts(&self) {
         unsafe {
@@ -143,5 +144,9 @@ impl<I: InterruptService<()> + 'static> Chip for Apollo3<I> {
 
     unsafe fn print_state(&self, write: &mut dyn Write) {
         cortexm4::print_cortexm4_state(write);
+    }
+
+    fn current_core(&self) -> &Self::Core {
+        &()
     }
 }

--- a/chips/arty_e21_chip/src/chip.rs
+++ b/chips/arty_e21_chip/src/chip.rs
@@ -146,6 +146,7 @@ impl<'a, I: InterruptService<()> + 'a> kernel::Chip for ArtyExx<'a, I> {
     type UserspaceKernelBoundary = rv32i::syscall::SysCall;
     type SchedulerTimer = ();
     type WatchDog = ();
+    type Core = ();
 
     fn mpu(&self) -> &Self::MPU {
         &self.pmp
@@ -196,6 +197,10 @@ impl<'a, I: InterruptService<()> + 'a> kernel::Chip for ArtyExx<'a, I> {
 
     unsafe fn print_state(&self, write: &mut dyn Write) {
         rv32i::print_riscv_state(write);
+    }
+
+    fn current_core(&self) -> &Self::Core {
+        &()
     }
 }
 

--- a/chips/e310x/src/chip.rs
+++ b/chips/e310x/src/chip.rs
@@ -109,6 +109,7 @@ impl<'a, A: 'static + Alarm<'static>, I: InterruptService<()> + 'a> kernel::Chip
     type UserspaceKernelBoundary = rv32i::syscall::SysCall;
     type SchedulerTimer = kernel::VirtualSchedulerTimer<A>;
     type WatchDog = ();
+    type Core = ();
 
     fn mpu(&self) -> &Self::MPU {
         &self.pmp
@@ -168,6 +169,10 @@ impl<'a, A: 'static + Alarm<'static>, I: InterruptService<()> + 'a> kernel::Chip
 
     unsafe fn print_state(&self, writer: &mut dyn Write) {
         rv32i::print_riscv_state(writer);
+    }
+
+    fn current_core(&self) -> &Self::Core {
+        &()
     }
 }
 

--- a/chips/earlgrey/src/chip.rs
+++ b/chips/earlgrey/src/chip.rs
@@ -158,6 +158,7 @@ impl<'a, A: 'static + Alarm<'static>, I: InterruptService<()> + 'a> kernel::Chip
     type UserspaceKernelBoundary = SysCall;
     type SchedulerTimer = kernel::VirtualSchedulerTimer<A>;
     type WatchDog = ();
+    type Core = ();
 
     fn mpu(&self) -> &Self::MPU {
         &self.pmp
@@ -225,6 +226,10 @@ impl<'a, A: 'static + Alarm<'static>, I: InterruptService<()> + 'a> kernel::Chip
             CONFIG.name
         ));
         rv32i::print_riscv_state(writer);
+    }
+
+    fn current_core(&self) -> &Self::Core {
+        &()
     }
 }
 

--- a/chips/imxrt10xx/src/chip.rs
+++ b/chips/imxrt10xx/src/chip.rs
@@ -93,6 +93,7 @@ impl<I: InterruptService<()> + 'static> Chip for Imxrt10xx<I> {
     type UserspaceKernelBoundary = cortexm7::syscall::SysCall;
     type SchedulerTimer = cortexm7::systick::SysTick;
     type WatchDog = ();
+    type Core = ();
 
     fn service_pending_interrupts(&self) {
         unsafe {
@@ -146,5 +147,9 @@ impl<I: InterruptService<()> + 'static> Chip for Imxrt10xx<I> {
 
     unsafe fn print_state(&self, write: &mut dyn Write) {
         cortexm7::print_cortexm7_state(write);
+    }
+
+    fn current_core(&self) -> &Self::Core {
+        &()
     }
 }

--- a/chips/litex_vexriscv/src/chip.rs
+++ b/chips/litex_vexriscv/src/chip.rs
@@ -64,6 +64,7 @@ impl<A: 'static + Alarm<'static>, I: 'static + InterruptService<()>> kernel::Chi
     type UserspaceKernelBoundary = SysCall;
     type SchedulerTimer = kernel::VirtualSchedulerTimer<A>;
     type WatchDog = ();
+    type Core = ();
 
     fn mpu(&self) -> &Self::MPU {
         &self.pmp
@@ -117,6 +118,10 @@ impl<A: 'static + Alarm<'static>, I: 'static + InterruptService<()>> kernel::Chi
             self.soc_identifier,
         ));
         rv32i::print_riscv_state(writer);
+    }
+
+    fn current_core(&self) -> &Self::Core {
+        &()
     }
 }
 

--- a/chips/msp432/src/chip.rs
+++ b/chips/msp432/src/chip.rs
@@ -110,6 +110,7 @@ impl<'a, I: InterruptService<()> + 'a> Chip for Msp432<'a, I> {
     type UserspaceKernelBoundary = cortexm4::syscall::SysCall;
     type SchedulerTimer = cortexm4::systick::SysTick;
     type WatchDog = wdt::Wdt;
+    type Core = ();
 
     fn service_pending_interrupts(&self) {
         unsafe {
@@ -164,5 +165,9 @@ impl<'a, I: InterruptService<()> + 'a> Chip for Msp432<'a, I> {
 
     unsafe fn print_state(&self, write: &mut dyn Write) {
         cortexm4::print_cortexm4_state(write);
+    }
+
+    fn current_core(&self) -> &Self::Core {
+        &()
     }
 }

--- a/chips/nrf52/src/chip.rs
+++ b/chips/nrf52/src/chip.rs
@@ -156,6 +156,7 @@ impl<'a, I: InterruptService<DeferredCallTask> + 'a> kernel::Chip for NRF52<'a, 
     type UserspaceKernelBoundary = cortexm4::syscall::SysCall;
     type SchedulerTimer = cortexm4::systick::SysTick;
     type WatchDog = ();
+    type Core = ();
 
     fn mpu(&self) -> &Self::MPU {
         &self.mpu
@@ -213,5 +214,9 @@ impl<'a, I: InterruptService<DeferredCallTask> + 'a> kernel::Chip for NRF52<'a, 
 
     unsafe fn print_state(&self, write: &mut dyn Write) {
         cortexm4::print_cortexm4_state(write);
+    }
+
+    fn current_core(&self) -> &Self::Core {
+        &()
     }
 }

--- a/chips/sam4l/src/chip.rs
+++ b/chips/sam4l/src/chip.rs
@@ -240,6 +240,7 @@ impl<I: InterruptService<Task> + 'static> Chip for Sam4l<I> {
     type UserspaceKernelBoundary = cortexm4::syscall::SysCall;
     type SchedulerTimer = cortexm4::systick::SysTick;
     type WatchDog = ();
+    type Core = ();
 
     fn service_pending_interrupts(&self) {
         unsafe {
@@ -309,5 +310,9 @@ impl<I: InterruptService<Task> + 'static> Chip for Sam4l<I> {
 
     unsafe fn print_state(&self, writer: &mut dyn Write) {
         cortexm4::print_cortexm4_state(writer);
+    }
+
+    fn current_core(&self) -> &Self::Core {
+        &()
     }
 }

--- a/chips/stm32f303xc/src/chip.rs
+++ b/chips/stm32f303xc/src/chip.rs
@@ -110,6 +110,7 @@ impl<'a, I: InterruptService<DeferredCallTask> + 'a> Chip for Stm32f3xx<'a, I> {
     type UserspaceKernelBoundary = cortexm4::syscall::SysCall;
     type SchedulerTimer = cortexm4::systick::SysTick;
     type WatchDog = wdt::WindoWdg<'a>;
+    type Core = ();
 
     fn service_pending_interrupts(&self) {
         unsafe {
@@ -168,5 +169,9 @@ impl<'a, I: InterruptService<DeferredCallTask> + 'a> Chip for Stm32f3xx<'a, I> {
 
     unsafe fn print_state(&self, write: &mut dyn Write) {
         cortexm4::print_cortexm4_state(write);
+    }
+
+    fn current_core(&self) -> &Self::Core {
+        &()
     }
 }

--- a/chips/stm32f4xx/src/chip.rs
+++ b/chips/stm32f4xx/src/chip.rs
@@ -143,6 +143,7 @@ impl<'a, I: InterruptService<DeferredCallTask> + 'a> Chip for Stm32f4xx<'a, I> {
     type UserspaceKernelBoundary = cortexm4::syscall::SysCall;
     type SchedulerTimer = cortexm4::systick::SysTick;
     type WatchDog = ();
+    type Core = ();
 
     fn service_pending_interrupts(&self) {
         unsafe {
@@ -202,5 +203,9 @@ impl<'a, I: InterruptService<DeferredCallTask> + 'a> Chip for Stm32f4xx<'a, I> {
 
     unsafe fn print_state(&self, write: &mut dyn Write) {
         cortexm4::print_cortexm4_state(write);
+    }
+
+    fn current_core(&self) -> &Self::Core {
+        &()
     }
 }

--- a/chips/swervolf-eh1/src/chip.rs
+++ b/chips/swervolf-eh1/src/chip.rs
@@ -101,6 +101,7 @@ impl<'a, I: InterruptService<()> + 'a> kernel::Chip for SweRVolf<'a, I> {
     type UserspaceKernelBoundary = SysCall;
     type SchedulerTimer = swerv::eh1_timer::Timer<'static>;
     type WatchDog = ();
+    type Core = ();
 
     fn mpu(&self) -> &Self::MPU {
         &()
@@ -188,6 +189,10 @@ impl<'a, I: InterruptService<()> + 'a> kernel::Chip for SweRVolf<'a, I> {
 
     unsafe fn print_state(&self, writer: &mut dyn Write) {
         rv32i::print_riscv_state(writer);
+    }
+
+    fn current_core(&self) -> &Self::Core {
+        &()
     }
 }
 

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -85,7 +85,7 @@
 //!    this use case. It is likely we will have to create new interfaces as new
 //!    use cases are discovered.
 
-#![feature(core_intrinsics, const_fn)]
+#![feature(core_intrinsics, const_fn, never_type)]
 #![warn(unreachable_pub)]
 #![no_std]
 


### PR DESCRIPTION
### Pull Request Overview

Several MCUs provide multiple processing core within the ARM Cortex. One example is the Raspberry Pi Pico that is a dual core M0+. Another example is Arduino Portenta H7 (STM32 with two cores, an M4 and an M7).

I am not sure how this should be handled by Tock so I am opening this PR to get some feedback.

I think there might be several approaches to this, with pros and cons for each of them.

#### SMP
This seems to be the most intuitive approach. The kernel runs and schedules all the processes on any of the available cores.
##### Pros
 - easy to understand and use for use space developer perspective, no changes are needed
 - allows faster processing no matter what actions the apps perform
##### Cons
 - breaks the idea that drivers run uninterrupted on a single thread, requires drivers rewrite
 - make the kernel scheduler more complex as it needs to take into account processes that might have already been scheduled by the kernel running on another core

#### Dedicated core for a specific process
The idea is to use the additional cores for one single user space process. This process:
  - should only perform processing task
  - should never be preempted
  - may only use system calls to a specific set of drivers that are never used by the main core kernel
 
##### Pros
  - allows real time processing in user space
  - rather simple implementation in the kernel, no scheduling required
##### Cons
  - user space programming is different, due to limited API that is usable
  - might not use all the processing power available, as the core is used only by one single process

#### Separated kernels
The idea is to run a separate kernel on each core. Each kernel:
  - has its own memory space
  - loads a different subset of applications
  - loads a different subset of drivers
 
##### Pros
 - easy to implement, requires minimal kernel changes
 - should work with different core types (Arduino Protenta H7 has an M4 and an M7)
##### Cons
  - might waste memory resources
  - requires some driver changes to be able to share peripherals among the kernels

### Testing Strategy

N/A


### TODO or Help Wanted

As this requires several changes, I am looking for a lot of feedback.


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
