### PR TITLE
MSP432 SPI driver

### DIFF
--- a/boards/msp_exp432p401r/Makefile
+++ b/boards/msp_exp432p401r/Makefile
@@ -19,7 +19,7 @@ flash-debug: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/debug/$(PLATFORM).elf
 	$(OPENOCD) $(OPENOCD_OPTIONS) -c "init; reset halt; flash write_image erase $<; verify_image $<; reset; shutdown"
 
 .PHONY: flash
-flash: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
+flash: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin
 	$(OPENOCD) $(OPENOCD_OPTIONS) -c "init; reset halt; flash write_image erase $<; verify_image $<; reset; shutdown"
 
 .PHONY: flash-app

--- a/boards/msp_exp432p401r/src/main.rs
+++ b/boards/msp_exp432p401r/src/main.rs
@@ -8,6 +8,7 @@
 #![cfg_attr(not(doc), no_main)]
 #![deny(missing_docs)]
 
+use capsules::virtual_spi::VirtualSpiMasterDevice;
 use components::gpio::GpioComponent;
 use kernel::capabilities;
 use kernel::common::dynamic_deferred_call::DynamicDeferredCall;
@@ -57,6 +58,10 @@ struct MspExp432P401R {
     >,
     ipc: kernel::ipc::IPC<NUM_PROCS>,
     adc: &'static capsules::adc::AdcDedicated<'static, msp432::adc::Adc<'static>>,
+    spi: &'static capsules::spi_controller::Spi<
+        'static,
+        VirtualSpiMasterDevice<'static, msp432::spi::Spi<'static>>,
+    >,
 }
 
 /// Mapping of integer syscalls to objects that implement syscalls.
@@ -73,6 +78,7 @@ impl Platform for MspExp432P401R {
             capsules::alarm::DRIVER_NUM => f(Some(self.alarm)),
             kernel::ipc::DRIVER_NUM => f(Some(&self.ipc)),
             capsules::adc::DRIVER_NUM => f(Some(self.adc)),
+            capsules::spi_controller::DRIVER_NUM => f(Some(self.spi)),
             _ => f(None),
         }
     }
@@ -181,6 +187,11 @@ pub unsafe fn main() {
     peripherals.gpio.int_pins[msp432::gpio::IntPinNr::P01_2 as usize].enable_primary_function();
     peripherals.gpio.int_pins[msp432::gpio::IntPinNr::P01_3 as usize].enable_primary_function();
 
+    // Setup pins for SPI1
+    peripherals.gpio.int_pins[msp432::gpio::IntPinNr::P06_3 as usize].enable_primary_function();
+    peripherals.gpio.int_pins[msp432::gpio::IntPinNr::P06_4 as usize].enable_primary_function();
+    peripherals.gpio.int_pins[msp432::gpio::IntPinNr::P06_5 as usize].enable_primary_function();
+
     let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
     let chip = static_init!(
         msp432::chip::Msp432<msp432::chip::Msp432DefaultPeripherals>,
@@ -237,8 +248,8 @@ pub unsafe fn main() {
             // 4 => &peripherals.gpio.int_pins[msp432::gpio::IntPinNr::P04_3 as usize], // A10
             5 => &peripherals.gpio.int_pins[msp432::gpio::IntPinNr::P01_5 as usize],
             // 6 => &peripherals.gpio.int_pins[msp432::gpio::IntPinNr::P04_6 as usize], // A7
-            7 => &peripherals.gpio.int_pins[msp432::gpio::IntPinNr::P06_5 as usize],
-            8 => &peripherals.gpio.int_pins[msp432::gpio::IntPinNr::P06_4 as usize],
+            // 7 => &peripherals.gpio.int_pins[msp432::gpio::IntPinNr::P06_5 as usize], //SPI1
+            // 8 => &peripherals.gpio.int_pins[msp432::gpio::IntPinNr::P06_4 as usize], //SPI1
             // Left inner connector, top to bottom
             // 9 => &peripherals.gpio.int_pins[msp432::gpio::IntPinNr::P06_1 as usize], // A14
             // 10 => &peripherals.gpio.int_pins[msp432::gpio::IntPinNr::P04_0 as usize], // A13
@@ -307,8 +318,19 @@ pub unsafe fn main() {
     let alarm = components::alarm::AlarmDriverComponent::new(board_kernel, mux_alarm)
         .finalize(components::alarm_component_helper!(msp432::timer::TimerA));
 
-    // Setup ADC
+    //Setup SPI
 
+    // Set up a SPI MUX, so there can be multiple clients.
+    let mux_spi = components::spi::SpiMuxComponent::new(&peripherals.spi1)
+        .finalize(components::spi_mux_component_helper!(msp432::spi::Spi));
+    // Create the SPI system call capsule.
+    let spi_syscalls = components::spi::SpiSyscallComponent::new(
+        mux_spi,
+        &peripherals.gpio.int_pins[msp432::gpio::IntPinNr::P01_5 as usize],
+    )
+    .finalize(components::spi_syscall_component_helper!(msp432::spi::Spi));
+
+    // Setup ADC
     setup_adc_pins(&peripherals.gpio);
 
     let adc_channels = static_init!(
@@ -372,6 +394,7 @@ pub unsafe fn main() {
         alarm: alarm,
         ipc: kernel::ipc::IPC::new(board_kernel, &memory_allocation_capability),
         adc: adc,
+        spi: spi_syscalls,
     };
 
     debug!("Initialization complete. Entering main loop");

--- a/chips/msp432/src/chip.rs
+++ b/chips/msp432/src/chip.rs
@@ -26,6 +26,7 @@ pub struct Msp432DefaultPeripherals<'a> {
     pub timer_a3: crate::timer::TimerA<'a>,
     pub gpio: crate::gpio::GpioManager<'a>,
     pub i2c0: crate::i2c::I2c<'a>,
+    pub spi1: crate::spi::Spi<'a>,
 }
 
 impl<'a> Msp432DefaultPeripherals<'a> {
@@ -42,6 +43,7 @@ impl<'a> Msp432DefaultPeripherals<'a> {
             timer_a3: crate::timer::TimerA::new(crate::timer::TIMER_A3_BASE),
             gpio: crate::gpio::GpioManager::new(),
             i2c0: crate::i2c::I2c::new(crate::usci::USCI_B0_BASE),
+            spi1: crate::spi::Spi::new(&crate::usci::USCI_B1_BASE, 2, 3, 2, 2),
         }
     }
 
@@ -53,6 +55,14 @@ impl<'a> Msp432DefaultPeripherals<'a> {
         );
         self.dma_channels[self.uart0.tx_dma_chan].set_client(&self.uart0);
         self.dma_channels[self.uart0.rx_dma_chan].set_client(&self.uart0);
+
+        // Setup DMA channels for SPI
+        self.spi1.set_dma(
+            &self.dma_channels[self.spi1.tx_dma_chan],
+            &self.dma_channels[self.spi1.rx_dma_chan],
+        );
+        self.dma_channels[self.spi1.tx_dma_chan].set_client(&self.spi1);
+        self.dma_channels[self.spi1.rx_dma_chan].set_client(&self.spi1);
 
         // Setup Reference Module, Timer and DMA for ADC
         self.adc.set_modules(

--- a/chips/msp432/src/lib.rs
+++ b/chips/msp432/src/lib.rs
@@ -18,6 +18,7 @@ pub mod i2c;
 pub mod nvic;
 pub mod pcm;
 pub mod ref_module;
+pub mod spi;
 pub mod sysctl;
 pub mod timer;
 pub mod uart;

--- a/chips/msp432/src/spi.rs
+++ b/chips/msp432/src/spi.rs
@@ -1,3 +1,10 @@
+//! Serial Peripheral Interface (SPI)
+//!
+//! Implementation of DMA-based SPI master communication for the MSP432.
+//! Both eUSCI_A and eUSCI_B can be used for SPI communication, but the
+//! the registers have a different meaning than in UART/I2C mode.
+//!
+
 use crate::dma;
 use crate::usci::{self, UCSPIxCTLW0, UCSPIxIE, UCSPIxIFG, UCSPIxSTATW};
 use core::cell::Cell;

--- a/chips/msp432/src/spi.rs
+++ b/chips/msp432/src/spi.rs
@@ -1,0 +1,469 @@
+use crate::dma;
+use crate::usci::{self, UCSPIxCTLW0, UCSPIxIE, UCSPIxIFG, UCSPIxSTATW};
+use core::cell::Cell;
+use kernel::common::{
+    cells::{OptionalCell, TakeCell},
+    registers::{ReadOnly, ReadWrite},
+    StaticRef,
+};
+use kernel::hil::gpio::Pin;
+use kernel::hil::spi;
+use kernel::ErrorCode;
+
+/// The SPI related registers are identical between the USCI_A and the USCI_B module, but the usage
+/// of the certain bits is different to UART and I2C mode. Thus we simply cast the concerned
+/// registers to a UCSPIx-registers instead of UCAx or UCBx registers. With this trick we can pass
+/// references of USCI_A and USCI_B modules to the Spi-constructor.
+pub trait UsciSpiRef {
+    fn ctlw0(&self) -> &ReadWrite<u16, UCSPIxCTLW0::Register>;
+    fn brw(&self) -> &ReadWrite<u16>;
+    fn statw(&self) -> &ReadWrite<u16, UCSPIxSTATW::Register>;
+    fn rxbuf(&self) -> &ReadOnly<u16>;
+    fn txbuf(&self) -> &ReadWrite<u16>;
+    fn ie(&self) -> &ReadWrite<u16, UCSPIxIE::Register>;
+    fn ifg(&self) -> &ReadWrite<u16, UCSPIxIFG::Register>;
+}
+
+impl UsciSpiRef for StaticRef<usci::UsciBRegisters> {
+    fn ctlw0(&self) -> &ReadWrite<u16, usci::UCSPIxCTLW0::Register> {
+        unsafe {
+            &*(&self.ctlw0 as *const ReadWrite<u16, usci::UCBxCTLW0::Register>
+                as *const ReadWrite<u16, usci::UCSPIxCTLW0::Register>)
+        }
+    }
+
+    fn brw(&self) -> &ReadWrite<u16> {
+        &self.brw
+    }
+
+    fn statw(&self) -> &ReadWrite<u16, usci::UCSPIxSTATW::Register> {
+        unsafe {
+            &*(&self.statw as *const ReadWrite<u16, usci::UCBxSTATW::Register>
+                as *const ReadWrite<u16, usci::UCSPIxSTATW::Register>)
+        }
+    }
+
+    fn rxbuf(&self) -> &ReadOnly<u16> {
+        &self.rxbuf
+    }
+
+    fn txbuf(&self) -> &ReadWrite<u16> {
+        &self.txbuf
+    }
+
+    fn ie(&self) -> &ReadWrite<u16, usci::UCSPIxIE::Register> {
+        unsafe {
+            &*(&self.ie as *const ReadWrite<u16, usci::UCBxIE::Register>
+                as *const ReadWrite<u16, usci::UCSPIxIE::Register>)
+        }
+    }
+
+    fn ifg(&self) -> &ReadWrite<u16, usci::UCSPIxIFG::Register> {
+        unsafe {
+            &*(&self.ifg as *const ReadWrite<u16, usci::UCBxIFG::Register>
+                as *const ReadWrite<u16, usci::UCSPIxIFG::Register>)
+        }
+    }
+}
+
+impl UsciSpiRef for StaticRef<usci::UsciARegisters> {
+    fn ctlw0(&self) -> &ReadWrite<u16, usci::UCSPIxCTLW0::Register> {
+        unsafe {
+            &*(&self.ctlw0 as *const ReadWrite<u16, usci::UCAxCTLW0::Register>
+                as *const ReadWrite<u16, usci::UCSPIxCTLW0::Register>)
+        }
+    }
+
+    fn brw(&self) -> &ReadWrite<u16> {
+        &self.brw
+    }
+
+    fn statw(&self) -> &ReadWrite<u16, usci::UCSPIxSTATW::Register> {
+        unsafe {
+            &*(&self.statw as *const ReadWrite<u16, usci::UCAxSTATW::Register>
+                as *const ReadWrite<u16, usci::UCSPIxSTATW::Register>)
+        }
+    }
+
+    fn rxbuf(&self) -> &ReadOnly<u16> {
+        &self.rxbuf
+    }
+
+    fn txbuf(&self) -> &ReadWrite<u16> {
+        &self.txbuf
+    }
+
+    fn ie(&self) -> &ReadWrite<u16, usci::UCSPIxIE::Register> {
+        unsafe {
+            &*(&self.ie as *const ReadWrite<u16, usci::UCAxIE::Register>
+                as *const ReadWrite<u16, usci::UCSPIxIE::Register>)
+        }
+    }
+
+    fn ifg(&self) -> &ReadWrite<u16, usci::UCSPIxIFG::Register> {
+        unsafe {
+            &*(&self.ifg as *const ReadWrite<u16, usci::UCAxIFG::Register>
+                as *const ReadWrite<u16, usci::UCSPIxIFG::Register>)
+        }
+    }
+}
+
+#[derive(Clone, Copy, PartialEq)]
+enum OperatingMode {
+    Unconfigured,
+    Idle,
+    Write,
+    WriteRead,
+}
+
+#[derive(Clone, Copy)]
+#[repr(u16)]
+enum SpiClock {
+    K1500 = 1, // 1.5MHz
+    K750 = 2,  // 750kHz
+    K500 = 3,  // 500kHz
+    K375 = 4,  // 375kHz
+    K300 = 5,  // 300kHz
+    K250 = 6,  // 250kHz
+    K150 = 10, // 150kHz
+    K100 = 15, // 100kHz
+}
+
+impl From<u32> for SpiClock {
+    fn from(rate: u32) -> Self {
+        match rate {
+            0..=124_999 => SpiClock::K100,
+            125_000..=199_999 => SpiClock::K150,
+            200_000..=274_999 => SpiClock::K250,
+            275_000..=337_499 => SpiClock::K300,
+            337_500..=437_499 => SpiClock::K375,
+            437_500..=624_999 => SpiClock::K500,
+            625_000..=1124_999 => SpiClock::K750,
+            _ => SpiClock::K1500,
+        }
+    }
+}
+
+impl From<SpiClock> for u32 {
+    fn from(clk: SpiClock) -> Self {
+        match clk {
+            SpiClock::K100 => 100_000,
+            SpiClock::K150 => 150_000,
+            SpiClock::K250 => 250_000,
+            SpiClock::K300 => 300_000,
+            SpiClock::K375 => 375_000,
+            SpiClock::K500 => 500_000,
+            SpiClock::K750 => 750_000,
+            SpiClock::K1500 => 1_500_000,
+        }
+    }
+}
+
+pub struct Spi<'a> {
+    registers: &'static dyn UsciSpiRef,
+    cs: OptionalCell<&'a dyn Pin>,
+    hold_cs: Cell<bool>,
+    operating_mode: Cell<OperatingMode>,
+    clock: Cell<SpiClock>,
+    tx_buf: TakeCell<'static, [u8]>,
+    master_client: OptionalCell<&'a dyn spi::SpiMasterClient>,
+
+    tx_dma: OptionalCell<&'a dma::DmaChannel<'a>>,
+    pub(crate) tx_dma_chan: usize,
+    tx_dma_src: u8,
+
+    rx_dma: OptionalCell<&'a dma::DmaChannel<'a>>,
+    pub(crate) rx_dma_chan: usize,
+    rx_dma_src: u8,
+}
+
+impl<'a> Spi<'a> {
+    pub fn new(
+        registers: &'static dyn UsciSpiRef,
+        tx_dma_chan: usize,
+        rx_dma_chan: usize,
+        tx_dma_src: u8,
+        rx_dma_src: u8,
+    ) -> Self {
+        Self {
+            registers: registers,
+            cs: OptionalCell::empty(),
+            hold_cs: Cell::new(false),
+            operating_mode: Cell::new(OperatingMode::Unconfigured),
+            clock: Cell::new(SpiClock::K100),
+            tx_buf: TakeCell::empty(),
+            master_client: OptionalCell::empty(),
+
+            tx_dma: OptionalCell::empty(),
+            tx_dma_chan: tx_dma_chan,
+            tx_dma_src: tx_dma_src,
+
+            rx_dma: OptionalCell::empty(),
+            rx_dma_chan: rx_dma_chan,
+            rx_dma_src: rx_dma_src,
+        }
+    }
+
+    pub fn set_dma(&self, tx_dma: &'a dma::DmaChannel<'a>, rx_dma: &'a dma::DmaChannel<'a>) {
+        self.tx_dma.replace(tx_dma);
+        self.rx_dma.replace(rx_dma);
+    }
+
+    fn set_module_to_reset(&self) {
+        // Set module to reset in order to enable the configuration
+        self.registers.ctlw0().modify(UCSPIxCTLW0::UCSWRST::Enabled);
+    }
+
+    fn clear_module_reset(&self) {
+        self.registers
+            .ctlw0()
+            .modify(UCSPIxCTLW0::UCSWRST::Disabled);
+    }
+
+    fn finish_transfer(&self) {
+        self.operating_mode.set(OperatingMode::Idle);
+
+        if !self.hold_cs.get() {
+            self.cs.map(|pin| pin.set());
+        }
+    }
+}
+
+impl<'a> dma::DmaClient for Spi<'a> {
+    fn transfer_done(
+        &self,
+        tx_buf: Option<&'static mut [u8]>,
+        rx_buf: Option<&'static mut [u8]>,
+        transmitted_bytes: usize,
+    ) {
+        if let Some(buf) = tx_buf {
+            // Transmitting finished
+            if self.operating_mode.get() == OperatingMode::Write {
+                // Only a write operation was done -> invoke callback
+
+                self.finish_transfer();
+                self.master_client
+                    .map(move |cl| cl.read_write_done(buf, None, transmitted_bytes));
+            } else {
+                // Also a read operation was done -> wait for RX callback
+                self.tx_buf.replace(buf);
+            }
+        }
+
+        if let Some(buf) = rx_buf {
+            // Receiving finished
+
+            self.finish_transfer();
+            self.master_client.map(move |cl| {
+                cl.read_write_done(
+                    self.tx_buf
+                        .take()
+                        .unwrap_or_else(|| panic!("SPI: no TX buffer was returned from DMA")),
+                    Some(buf),
+                    transmitted_bytes,
+                )
+            });
+        }
+    }
+}
+
+impl<'a> spi::SpiMaster for Spi<'a> {
+    type ChipSelect = &'a dyn Pin;
+
+    fn set_client(&self, client: &'static dyn spi::SpiMasterClient) {
+        self.master_client.set(client);
+    }
+
+    fn init(&self) {
+        self.set_module_to_reset();
+
+        self.registers.ctlw0().modify(
+            // Transmit LSB first
+            UCSPIxCTLW0::UCMSB::MSBFirst
+            // Enable 8bit modus
+            + UCSPIxCTLW0::UC7BIT::_8Bit
+            // Configure to Master mode
+            + UCSPIxCTLW0::UCMST::Master
+            // Use 3-pin SPI mode since CS is controlled by hand
+            + UCSPIxCTLW0::UCMODE::_3PinSPI
+            // Enable synchronous mode
+            + UCSPIxCTLW0::UCSYNC::SynchronousMode
+            // Use SMCLK as clock
+            + UCSPIxCTLW0::UCSSEL::SMCLK
+            //enable clk high
+            + UCSPIxCTLW0::UCCKPL::InactiveLow,
+        );
+
+        // Configure the DMA
+        let tx_conf = dma::DmaConfig {
+            src_chan: self.tx_dma_src,
+            mode: dma::DmaMode::Basic,
+            width: dma::DmaDataWidth::Width8Bit,
+            src_incr: dma::DmaPtrIncrement::Incr8Bit,
+            dst_incr: dma::DmaPtrIncrement::NoIncr,
+        };
+
+        let rx_conf = dma::DmaConfig {
+            src_chan: self.rx_dma_src,
+            mode: dma::DmaMode::Basic,
+            width: dma::DmaDataWidth::Width8Bit,
+            src_incr: dma::DmaPtrIncrement::NoIncr,
+            dst_incr: dma::DmaPtrIncrement::Incr8Bit,
+        };
+
+        self.tx_dma.map(|dma| dma.initialize(&tx_conf));
+        self.rx_dma.map(|dma| dma.initialize(&rx_conf));
+
+        self.operating_mode.set(OperatingMode::Idle);
+        self.clear_module_reset();
+    }
+
+    fn is_busy(&self) -> bool {
+        self.operating_mode.get() != OperatingMode::Idle
+    }
+
+    fn read_write_bytes(
+        &self,
+        write_buffer: &'static mut [u8],
+        read_buffer: Option<&'static mut [u8]>,
+        len: usize,
+    ) -> Result<(), ErrorCode> {
+        if self.is_busy() {
+            return Err(ErrorCode::BUSY);
+        }
+
+        let mut cnt = len;
+        cnt = core::cmp::min(cnt, write_buffer.len());
+
+        // Set chip select
+        self.cs.map(|pin| pin.clear());
+
+        // If a read-buffer was supplied too, we also start a read transaction
+        if let Some(read_buf) = read_buffer {
+            self.operating_mode.set(OperatingMode::WriteRead);
+            cnt = core::cmp::min(cnt, read_buf.len());
+
+            let rx_reg = self.registers.rxbuf() as *const ReadOnly<u16> as *const ();
+            self.rx_dma
+                .map(move |dma| dma.transfer_periph_to_mem(rx_reg, read_buf, cnt));
+        } else {
+            self.operating_mode.set(OperatingMode::Write);
+        }
+
+        // Start a write transaction
+        let tx_reg = self.registers.txbuf() as *const ReadWrite<u16> as *const ();
+        self.tx_dma
+            .map(move |dma| dma.transfer_mem_to_periph(tx_reg, write_buffer, cnt));
+
+        Ok(())
+    }
+
+    fn write_byte(&self, val: u8) {
+        if self.is_busy() {
+            return;
+        }
+
+        while self.registers.statw().is_set(UCSPIxSTATW::UCBUSY) {}
+        self.registers.txbuf().set(val as u16);
+        while self.registers.statw().is_set(UCSPIxSTATW::UCBUSY) {}
+    }
+
+    fn read_byte(&self) -> u8 {
+        if self.is_busy() {
+            return 0;
+        }
+
+        while self.registers.statw().is_set(UCSPIxSTATW::UCBUSY) {}
+        self.registers.txbuf().set(0);
+        while self.registers.statw().is_set(UCSPIxSTATW::UCBUSY) {}
+        self.registers.rxbuf().get() as u8
+    }
+
+    fn read_write_byte(&self, val: u8) -> u8 {
+        if self.is_busy() {
+            return 0;
+        }
+
+        while self.registers.statw().is_set(UCSPIxSTATW::UCBUSY) {}
+        self.registers.txbuf().set(val as u16);
+        while self.registers.statw().is_set(UCSPIxSTATW::UCBUSY) {}
+        self.registers.rxbuf().get() as u8
+    }
+
+    fn specify_chip_select(&self, cs: Self::ChipSelect) {
+        cs.make_output();
+        cs.set();
+        self.cs.set(cs);
+    }
+
+    fn set_rate(&self, rate: u32) -> u32 {
+        let clk = SpiClock::from(rate);
+
+        self.set_module_to_reset();
+        self.registers.brw().set(clk as u16);
+        self.clear_module_reset();
+
+        self.clock.set(clk);
+        clk.into()
+    }
+
+    fn get_rate(&self) -> u32 {
+        self.clock.get().into()
+    }
+
+    fn set_clock(&self, polarity: spi::ClockPolarity) {
+        self.set_module_to_reset();
+
+        match polarity {
+            spi::ClockPolarity::IdleLow => self
+                .registers
+                .ctlw0()
+                .modify(UCSPIxCTLW0::UCCKPL::InactiveLow),
+            spi::ClockPolarity::IdleHigh => self
+                .registers
+                .ctlw0()
+                .modify(UCSPIxCTLW0::UCCKPL::InactiveHigh),
+        }
+
+        self.clear_module_reset();
+    }
+
+    fn get_clock(&self) -> spi::ClockPolarity {
+        match self.registers.ctlw0().is_set(UCSPIxCTLW0::UCCKPL) {
+            false => spi::ClockPolarity::IdleLow,
+            true => spi::ClockPolarity::IdleHigh,
+        }
+    }
+
+    fn set_phase(&self, phase: spi::ClockPhase) {
+        self.set_module_to_reset();
+
+        match phase {
+            spi::ClockPhase::SampleLeading => self
+                .registers
+                .ctlw0()
+                .modify(UCSPIxCTLW0::UCCKPH::CaptureFirstChangeFollowing),
+            spi::ClockPhase::SampleTrailing => self
+                .registers
+                .ctlw0()
+                .modify(UCSPIxCTLW0::UCCKPH::ChangeFirstCaptureFollowing),
+        }
+
+        self.clear_module_reset();
+    }
+
+    fn get_phase(&self) -> spi::ClockPhase {
+        match self.registers.ctlw0().is_set(UCSPIxCTLW0::UCCKPH) {
+            false => spi::ClockPhase::SampleTrailing,
+            true => spi::ClockPhase::SampleLeading,
+        }
+    }
+
+    fn hold_low(&self) {
+        self.hold_cs.set(true);
+    }
+
+    fn release_low(&self) {
+        self.hold_cs.set(false);
+    }
+}

--- a/chips/msp432/src/usci.rs
+++ b/chips/msp432/src/usci.rs
@@ -102,6 +102,147 @@ register_structs! {
 }
 
 register_bitfields![u16,
+    pub(crate) UCSPIxCTLW0 [
+        /// Software reset enable
+        UCSWRST OFFSET(0) NUMBITS(1) [
+            /// Disabled. eUSCI reset released for operation
+            Disabled = 0,
+            /// Enabled. eUSCI logic held in reset state
+            Enabled = 1
+        ],
+        /// STE mode select in master mode
+        UCSTEM OFFSET(1) NUMBITS(1) [
+            /// STE pin is used to prevent conflicts with other masters
+            PreventConflicts = 0,
+            /// STE pin is used to generate the enable signal for a 4-wire slave
+            ChipSelect = 1
+        ],
+        /// eUSCI clock source select
+        UCSSEL OFFSET(6) NUMBITS(2) [
+            /// UCLK
+            UCLK = 0,
+            /// ACLK
+            ACLK = 1,
+            /// SMCLK
+            SMCLK = 2
+        ],
+        /// Synchronous mode enable
+        UCSYNC OFFSET(8) NUMBITS(1) [
+            /// Asynchronous mode
+            AsynchronousMode = 0,
+            /// Synchronous mode
+            SynchronousMode = 1
+        ],
+        /// eUSCI mode
+        UCMODE OFFSET(9) NUMBITS(2) [
+            /// 3-pin SPI
+            _3PinSPI = 0,
+            /// 4-pin SPI (master or slave enabled if STE = 1)
+            _4PinSPIMasterOrSlaveEnabledIfSTE1 = 1,
+            /// 4-pin SPI (master or slave enabled if STE = 0)
+            _4PinSPIMasterOrSlaveEnabledIfSTE0 = 2,
+            /// I2C mode
+            I2CMode = 3
+        ],
+        /// Master mode select
+        UCMST OFFSET(11) NUMBITS(1) [
+            /// Slave mode
+            Slave = 0,
+            /// Master mode
+            Master = 1
+        ],
+        /// Character length. Selects 7-bit or 8-bit character length
+        UC7BIT OFFSET(12) NUMBITS(1) [
+            /// 8-bit data
+            _8Bit = 0,
+            /// 7-bit data
+            _7Bit = 1
+        ],
+        /// MSB first select. Controls the direction of the receive and transmit shift register
+        UCMSB OFFSET(13) NUMBITS(1) [
+            /// LSB first
+            LSBFirst = 0,
+            /// MSB first
+            MSBFirst = 1
+        ],
+        /// Clock polarity select
+        UCCKPL OFFSET(14) NUMBITS(1) [
+            /// The inactive state is low
+            InactiveLow = 0,
+            /// The inactive state is high
+            InactiveHigh = 1
+        ],
+        /// Clock phase select
+        UCCKPH OFFSET(15) NUMBITS(1) [
+            /// Data is changed on the first UCLK edge and captured on the following edge
+            ChangeFirstCaptureFollowing = 0,
+            /// Data is captured on the first UCLK edge and changed on the following edge
+            CaptureFirstChangeFollowing = 1
+
+        ]
+    ],
+    pub(crate) UCSPIxSTATW [
+        /// eUSCI busy
+        UCBUSY OFFSET(0) NUMBITS(1) [
+            /// eUSCI inactive
+            Inactive = 0,
+            /// eUSCI transmitting or receiving
+            TransmittingOrReceiving = 1
+        ],
+        /// Overrun error flag
+        UCOE OFFSET(5) NUMBITS(1) [
+            /// No error
+            NoError = 0,
+            /// Overrun error occurred
+            OverrunError = 1
+        ],
+        /// Framing error flag
+        UCFE OFFSET(6) NUMBITS(1) [
+            /// No error
+            NoError = 0,
+            /// Bus conflict occurred
+            BusConflict = 1
+        ],
+        /// Listen enable
+        UCLISTEN OFFSET(7) NUMBITS(1) [
+            /// Disabled
+            Disabled = 0,
+            /// Enabled. The transmitter output is internally fed back to the receiver
+            Enabled = 1
+        ]
+    ],
+    pub(crate) UCSPIxIE [
+        /// Receive interrupt enable
+        UCRXIE OFFSET(0) NUMBITS(1) [
+            /// Interrupt disabled
+            InterruptDisabled = 0,
+            /// Interrupt enabled
+            InterruptEnabled = 1
+        ],
+        /// Transmit interrupt enable
+        UCTXIE OFFSET(1) NUMBITS(1) [
+            /// Interrupt disabled
+            InterruptDisabled = 0,
+            /// Interrupt enabled
+            InterruptEnabled = 1
+        ]
+    ],
+    pub(crate) UCSPIxIFG [
+        /// Receive interrupt flag
+        UCRXIFG OFFSET(0) NUMBITS(1) [
+            /// No interrupt pending
+            NoInterruptPending = 0,
+            /// Interrupt pending
+            InterruptPending = 1
+        ],
+        /// Transmit interrupt flag
+        UCTXIFG OFFSET(1) NUMBITS(1) [
+            /// No interrupt pending
+            NoInterruptPending = 0,
+            /// Interrupt pending
+            InterruptPending = 1
+        ]
+    ],
     pub(crate) UCAxCTLW0 [
         /// Software reset enable
         UCSWRST OFFSET(0) NUMBITS(1) [


### PR DESCRIPTION
### Pull Request Overview

This PR adds support for SPI on the MSP432. The SPI related registers in the USCI modules are identical, but the usage of certain bits is different to UART and I2C mode. As a solution I simply cast the concerned registers to UCSPIx-registers instead of using the UCAx/UCBx-registers. With this trick the references of UCAx/UCBx-registers can be passed to the SPI-constructor.

### Testing Strategy

Tested on the evaluation board using a the spi_controller_transfer example as application.

### TODO or Help Wanted

* Is the approach of casting the UCAx/UCBx-registers to a common type ok/fine? Or should I rewrite the driver to use a different approach?
* I tested the SPI driver also using a [Waveshare 2.7inch E-Ink display](https://www.waveshare.com/w/upload/2/2d/2.7inch-e-paper-Specification.pdf) as a slave. Is there an interest for a driver-support for this E-Ink display? If yes, I could create a new PR for it.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
