### PR TITLE
Fix NRF52 802.15.4 radio bug on CCA busy + add UDP/802154 driver to Nano 33

### DIFF
--- a/boards/acd52832/src/main.rs
+++ b/boards/acd52832/src/main.rs
@@ -111,11 +111,10 @@ impl kernel::Platform for Platform {
 /// these static_inits is wasted.
 #[inline(never)]
 unsafe fn get_peripherals() -> &'static mut Nrf52832DefaultPeripherals<'static> {
-    let ppi = static_init!(nrf52832::ppi::Ppi, nrf52832::ppi::Ppi::new());
     // Initialize chip peripheral drivers
     let nrf52832_peripherals = static_init!(
         Nrf52832DefaultPeripherals,
-        Nrf52832DefaultPeripherals::new(ppi)
+        Nrf52832DefaultPeripherals::new()
     );
 
     nrf52832_peripherals

--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -161,11 +161,10 @@ impl kernel::Platform for Platform {
 /// these static_inits is wasted.
 #[inline(never)]
 unsafe fn get_peripherals() -> &'static mut Nrf52840DefaultPeripherals<'static> {
-    let ppi = static_init!(nrf52840::ppi::Ppi, nrf52840::ppi::Ppi::new());
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
-        Nrf52840DefaultPeripherals::new(ppi)
+        Nrf52840DefaultPeripherals::new()
     );
 
     nrf52840_peripherals

--- a/boards/microbit_v2/src/main.rs
+++ b/boards/microbit_v2/src/main.rs
@@ -138,11 +138,10 @@ impl kernel::Platform for Platform {
 /// these static_inits is wasted.
 #[inline(never)]
 unsafe fn get_peripherals() -> &'static mut Nrf52833DefaultPeripherals<'static> {
-    let ppi = static_init!(nrf52833::ppi::Ppi, nrf52833::ppi::Ppi::new());
     // Initialize chip peripheral drivers
     let nrf52833_peripherals = static_init!(
         Nrf52833DefaultPeripherals,
-        Nrf52833DefaultPeripherals::new(ppi)
+        Nrf52833DefaultPeripherals::new()
     );
 
     nrf52833_peripherals

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -77,7 +77,7 @@ pub mod io;
 
 // State for loading and holding applications.
 // How should the kernel respond when a process faults.
-const FAULT_RESPONSE: kernel::procs::FaultResponse = kernel::procs::FaultResponse::Stop;
+const FAULT_RESPONSE: kernel::procs::FaultResponse = kernel::procs::FaultResponse::Panic;
 
 // Number of concurrent processes this platform supports.
 const NUM_PROCS: usize = 8;

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -159,11 +159,10 @@ impl kernel::Platform for Platform {
 /// these static_inits is wasted.
 #[inline(never)]
 unsafe fn get_peripherals() -> &'static mut Nrf52840DefaultPeripherals<'static> {
-    let ppi = static_init!(nrf52840::ppi::Ppi, nrf52840::ppi::Ppi::new());
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
-        Nrf52840DefaultPeripherals::new(ppi)
+        Nrf52840DefaultPeripherals::new()
     );
 
     nrf52840_peripherals

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -63,15 +63,21 @@ const I2C_PULLUP_PIN: Pin = Pin::P1_00;
 /// Interrupt pin for the APDS9960 sensor.
 const APDS9960_PIN: Pin = Pin::P0_19;
 
+// Constants related to the configuration of the 15.4 network stack
 /// Personal Area Network ID for the IEEE 802.15.4 radio
 const PAN_ID: u16 = 0xABCD;
+/// Gateway (or next hop) MAC Address
+const DST_MAC_ADDR: capsules::net::ieee802154::MacAddress =
+    capsules::net::ieee802154::MacAddress::Short(49138);
+const DEFAULT_CTX_PREFIX_LEN: u8 = 8; //Length of context for 6LoWPAN compression
+const DEFAULT_CTX_PREFIX: [u8; 16] = [0x0 as u8; 16]; //Context for 6LoWPAN Compression
 
 /// UART Writer for panic!()s.
 pub mod io;
 
 // State for loading and holding applications.
 // How should the kernel respond when a process faults.
-const FAULT_RESPONSE: kernel::procs::FaultResponse = kernel::procs::FaultResponse::Panic;
+const FAULT_RESPONSE: kernel::procs::FaultResponse = kernel::procs::FaultResponse::Stop;
 
 // Number of concurrent processes this platform supports.
 const NUM_PROCS: usize = 8;
@@ -124,6 +130,7 @@ pub struct Platform {
         'static,
         capsules::virtual_alarm::VirtualMuxAlarm<'static, nrf52::rtc::Rtc<'static>>,
     >,
+    udp_driver: &'static capsules::net::udp::UDPDriver<'static>,
 }
 
 impl kernel::Platform for Platform {
@@ -140,6 +147,7 @@ impl kernel::Platform for Platform {
             capsules::rng::DRIVER_NUM => f(Some(self.rng)),
             capsules::ble_advertising_driver::DRIVER_NUM => f(Some(self.ble_radio)),
             capsules::ieee802154::DRIVER_NUM => f(Some(self.ieee802154_radio)),
+            capsules::net::udp::DRIVER_NUM => f(Some(self.udp_driver)),
             kernel::ipc::DRIVER_NUM => f(Some(&self.ipc)),
             _ => f(None),
         }
@@ -377,10 +385,13 @@ pub unsafe fn main() {
             .register(aes_mux)
             .expect("no deferred call slot available for ccm mux"),
     );
+    use capsules::net::ieee802154::MacAddress;
+    use capsules::virtual_alarm::VirtualMuxAlarm;
 
     let serial_num = nrf52840::ficr::FICR_INSTANCE.address();
     let serial_num_bottom_16 = u16::from_le_bytes([serial_num[0], serial_num[1]]);
-    let (ieee802154_radio, _mux_mac) = components::ieee802154::Ieee802154Component::new(
+    let src_mac_from_serial_num: MacAddress = MacAddress::Short(serial_num_bottom_16);
+    let (ieee802154_radio, mux_mac) = components::ieee802154::Ieee802154Component::new(
         board_kernel,
         &base_peripherals.ieee802154_radio,
         aes_mux,
@@ -392,6 +403,45 @@ pub unsafe fn main() {
         nrf52840::ieee802154_radio::Radio,
         nrf52840::aes::AesECB<'static>
     ));
+    use capsules::net::ipv6::ip_utils::IPAddr;
+
+    let local_ip_ifaces = static_init!(
+        [IPAddr; 3],
+        [
+            IPAddr([
+                0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d,
+                0x0e, 0x0f,
+            ]),
+            IPAddr([
+                0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d,
+                0x1e, 0x1f,
+            ]),
+            IPAddr::generate_from_mac(capsules::net::ieee802154::MacAddress::Short(
+                serial_num_bottom_16
+            )),
+        ]
+    );
+
+    let (udp_send_mux, udp_recv_mux, udp_port_table) = components::udp_mux::UDPMuxComponent::new(
+        mux_mac,
+        DEFAULT_CTX_PREFIX_LEN,
+        DEFAULT_CTX_PREFIX,
+        DST_MAC_ADDR,
+        src_mac_from_serial_num,
+        local_ip_ifaces,
+        mux_alarm,
+    )
+    .finalize(components::udp_mux_component_helper!(nrf52840::rtc::Rtc));
+
+    // UDP driver initialization happens here
+    let udp_driver = components::udp_driver::UDPDriverComponent::new(
+        board_kernel,
+        udp_send_mux,
+        udp_recv_mux,
+        udp_port_table,
+        local_ip_ifaces,
+    )
+    .finalize(components::udp_driver_component_helper!(nrf52840::rtc::Rtc));
 
     //--------------------------------------------------------------------------
     // FINAL SETUP AND BOARD BOOT
@@ -411,6 +461,7 @@ pub unsafe fn main() {
         gpio,
         rng,
         alarm,
+        udp_driver,
         ipc: kernel::ipc::IPC::new(board_kernel, &memory_allocation_capability),
     };
 

--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -125,11 +125,10 @@ impl kernel::Platform for Platform {
 /// these static_inits is wasted.
 #[inline(never)]
 unsafe fn get_peripherals() -> &'static mut Nrf52840DefaultPeripherals<'static> {
-    let ppi = static_init!(nrf52840::ppi::Ppi, nrf52840::ppi::Ppi::new());
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
-        Nrf52840DefaultPeripherals::new(ppi)
+        Nrf52840DefaultPeripherals::new()
     );
 
     nrf52840_peripherals

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -203,11 +203,10 @@ impl kernel::Platform for Platform {
 /// these static_inits is wasted.
 #[inline(never)]
 unsafe fn get_peripherals() -> &'static mut Nrf52840DefaultPeripherals<'static> {
-    let ppi = static_init!(nrf52840::ppi::Ppi, nrf52840::ppi::Ppi::new());
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
-        Nrf52840DefaultPeripherals::new(ppi)
+        Nrf52840DefaultPeripherals::new()
     );
 
     nrf52840_peripherals

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -184,11 +184,10 @@ impl kernel::Platform for Platform {
 /// these static_inits is wasted.
 #[inline(never)]
 unsafe fn get_peripherals() -> &'static mut Nrf52832DefaultPeripherals<'static> {
-    let ppi = static_init!(nrf52832::ppi::Ppi, nrf52832::ppi::Ppi::new());
     // Initialize chip peripheral drivers
     let nrf52832_peripherals = static_init!(
         Nrf52832DefaultPeripherals,
-        Nrf52832DefaultPeripherals::new(ppi)
+        Nrf52832DefaultPeripherals::new()
     );
 
     nrf52832_peripherals

--- a/chips/nrf52/src/ieee802154_radio.rs
+++ b/chips/nrf52/src/ieee802154_radio.rs
@@ -7,10 +7,9 @@ use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::common::registers::{register_bitfields, ReadOnly, ReadWrite, WriteOnly};
 use kernel::common::StaticRef;
 use kernel::hil::radio::{self, PowerClient};
-use kernel::hil::time::Alarm;
+use kernel::hil::time::{Alarm, AlarmClient};
 use kernel::ErrorCode;
 
-use crate::ppi;
 use nrf5x;
 use nrf5x::constants::TxPower;
 
@@ -674,11 +673,16 @@ pub struct Radio<'p> {
     channel: Cell<RadioChannel>,
     transmitting: Cell<bool>,
     timer0: OptionalCell<&'p crate::timer::TimerAlarm<'p>>,
-    ppi: &'p crate::ppi::Ppi,
+}
+
+impl<'a> AlarmClient for Radio<'a> {
+    fn alarm(&self) {
+        self.rx();
+    }
 }
 
 impl<'p> Radio<'p> {
-    pub const fn new(ppi: &'p crate::ppi::Ppi) -> Self {
+    pub const fn new() -> Self {
         Self {
             registers: RADIO_BASE,
             tx_power: Cell::new(TxPower::ZerodBm),
@@ -695,7 +699,6 @@ impl<'p> Radio<'p> {
             channel: Cell::new(RadioChannel::DataChannel26),
             transmitting: Cell::new(false),
             timer0: OptionalCell::empty(),
-            ppi,
         }
     }
 
@@ -776,9 +779,6 @@ impl<'p> Radio<'p> {
             if self.transmitting.get()
                 && self.registers.state.get() == nrf5x::constants::RADIO_STATE_RXIDLE
             {
-                if self.cca_count.get() > 0 {
-                    self.ppi.disable(ppi::Channel::CH21::SET);
-                }
                 self.registers.task_ccastart.write(Task::ENABLE::SET);
             } else {
                 self.registers.task_start.write(Task::ENABLE::SET);
@@ -798,6 +798,10 @@ impl<'p> Radio<'p> {
 
         if self.registers.event_ccabusy.is_set(Event::READY) {
             self.registers.event_ccabusy.write(Event::READY::CLEAR);
+            self.registers.event_ready.write(Event::READY::CLEAR);
+            self.registers.task_disable.write(Task::ENABLE::SET);
+            while self.registers.event_disabled.get() == 0 {}
+            self.registers.event_disabled.write(Event::READY::CLEAR);
             //need to back off for a period of time outlined
             //in the IEEE 802.15.4 standard (see Figure 69 in
             //section 7.5.1.4 The CSMA-CA algorithm of the
@@ -806,7 +810,6 @@ impl<'p> Radio<'p> {
                 self.cca_count.set(self.cca_count.get() + 1);
                 self.cca_be.set(self.cca_be.get() + 1);
                 let backoff_periods = self.random_nonce() & ((1 << self.cca_be.get()) - 1);
-                self.ppi.enable(ppi::Channel::CH21::SET);
                 self.timer0
                     .expect("Missing timer reference for CSMA")
                     .set_alarm(
@@ -827,8 +830,6 @@ impl<'p> Radio<'p> {
                     });
             }
 
-            self.registers.event_ready.write(Event::READY::CLEAR);
-            self.registers.task_disable.write(Task::ENABLE::SET);
             self.enable_interrupts();
         }
 

--- a/chips/nrf52832/src/interrupt_service.rs
+++ b/chips/nrf52832/src/interrupt_service.rs
@@ -10,9 +10,9 @@ pub struct Nrf52832DefaultPeripherals<'a> {
     pub gpio_port: crate::gpio::Port<'a, { crate::gpio::NUM_PINS }>,
 }
 impl<'a> Nrf52832DefaultPeripherals<'a> {
-    pub unsafe fn new(ppi: &'a crate::ppi::Ppi) -> Self {
+    pub unsafe fn new() -> Self {
         Self {
-            nrf52: Nrf52DefaultPeripherals::new(ppi),
+            nrf52: Nrf52DefaultPeripherals::new(),
             gpio_port: crate::gpio::nrf52832_gpio_create(),
         }
     }

--- a/chips/nrf52833/src/interrupt_service.rs
+++ b/chips/nrf52833/src/interrupt_service.rs
@@ -10,9 +10,9 @@ pub struct Nrf52833DefaultPeripherals<'a> {
     pub gpio_port: crate::gpio::Port<'a, { crate::gpio::NUM_PINS }>,
 }
 impl<'a> Nrf52833DefaultPeripherals<'a> {
-    pub unsafe fn new(ppi: &'a crate::ppi::Ppi) -> Self {
+    pub unsafe fn new() -> Self {
         Self {
-            nrf52: Nrf52DefaultPeripherals::new(ppi),
+            nrf52: Nrf52DefaultPeripherals::new(),
             gpio_port: crate::gpio::nrf52833_gpio_create(),
         }
     }

--- a/chips/nrf52840/src/interrupt_service.rs
+++ b/chips/nrf52840/src/interrupt_service.rs
@@ -13,9 +13,9 @@ pub struct Nrf52840DefaultPeripherals<'a> {
 }
 
 impl<'a> Nrf52840DefaultPeripherals<'a> {
-    pub unsafe fn new(ppi: &'a crate::ppi::Ppi) -> Self {
+    pub unsafe fn new() -> Self {
         Self {
-            nrf52: Nrf52DefaultPeripherals::new(ppi),
+            nrf52: Nrf52DefaultPeripherals::new(),
             usbd: crate::usbd::Usbd::new(),
             gpio_port: crate::gpio::nrf52840_gpio_create(),
         }


### PR DESCRIPTION
### Pull Request Overview

This pull request accomplishes two main things:

1. Add 802.15.4 & the UDP driver to the Nano 33 Sense board (thanks @hudson-ayers!)
2. Fixes a bug in the nrf52 ieee802154 driver that was causing a state machine failure (i.e. the driver just got stuck) upon frame transmission when CCA fails.

#### What was the bug and how did you fix it?

Very simply, if ever in preparation for a transmission, the radio performed a CCA check and it failed (i.e. someone else is already transmitting on that channel), it's supposed to wait a specified period of time then retry. What was happening prior to this PR is there would never be a retry. So, if there was ever a CCA check failure, there could be no more transmission/receptions.

The problem was that while the timer was setup properly, the radio never got reconfigured in response to the timer expiring. I don't _actually_ know the exact reason the strategy coded in the previous coding wasn't working, however, I just went with a more straight forward (though in the long run, worse) approach. At least it works.

Instead of using the Prorgammable Peripheral Interconnect on the NRF52's
ieee802154 radio driver to retry CCA after a timer expires when it
fails, use simple software logic instead. PPI invokes tasks in one
peripheral (the radio) in response to an event in another (the timer),
without requiring an interrupts serviced in software.

The best thing to do would be to use PPI as well as shortcuts to
simplify the radio logic significantly, as well as likely improve
transition time performance. I'll leave that for another adventure.


#### Why is this PR touching so many files?

Most of the changes are small refactoring in the NRF52-based boards. The NRF52's ieee802154 driver no longer requires a PPI, which had been passed down all the way from the board (it's not clear this was ever a good thing, this was required even for boards that used an nrf52 with no ieee802154 driver). So now, each board that relies on any nrf52 chip has a couple line changes removing the PPI initializing.

### Testing Strategy

If anyone has ideas on how to test this reliably, please share. Meanwhile, I tested this by running the `examples/tests/udp/udp_send` app from `libtock-c` with a much smaller interval than the default (I used 50 ms) and waiting for a CCA to fail (probably because randomly some other 2.4GHz device was transmitting---maybe those Philips Hues I have are not completely useless after all). Without this change eventually transmissions stop. With the changes, they continue.

To help my debugging I added some debug statements in the kernel to identify when a CCA failed, confirming that (a) this was the problem and (b) that my fix addresses the problem. You might consider adding similar debug statements if you want to test---again, it's otherwise pretty hard to tell whether you got a collision.

### TODO or Help Wanted

### Documentation Updated

- [X] ~~Updated the relevant files in `/docs`, or no updates are required.~~

### Formatting

- [x] Ran `make prepush`.
