### PR TITLE
Change the Nano33BLE to the StopWithDebug fault response

### DIFF
--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -75,13 +75,17 @@ const DEFAULT_CTX_PREFIX: [u8; 16] = [0x0 as u8; 16]; //Context for 6LoWPAN Comp
 /// UART Writer for panic!()s.
 pub mod io;
 
-// State for loading and holding applications.
-// How should the kernel respond when a process faults.
-const FAULT_RESPONSE: kernel::procs::PanicFaultPolicy = kernel::procs::PanicFaultPolicy {};
+// How should the kernel respond when a process faults. For this board we choose
+// to stop the app and print a notice, but not immediately panic. This allows
+// users to debug their apps, but avoids issues with using the USB/CDC stack
+// synchronously for panic! too early after the board boots.
+const FAULT_RESPONSE: kernel::procs::StopWithDebugFaultPolicy =
+    kernel::procs::StopWithDebugFaultPolicy {};
 
 // Number of concurrent processes this platform supports.
 const NUM_PROCS: usize = 8;
 
+// State for loading and holding applications.
 static mut PROCESSES: [Option<&'static dyn kernel::procs::Process>; NUM_PROCS] = [None; NUM_PROCS];
 
 static mut CHIP: Option<&'static nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>> = None;


### PR DESCRIPTION
### Pull Request Overview

This PR makes the `StopWithDebug` the default fault policy on Nano 33 BLE because if a process fails immediately, the USB/CDC stack doesn't have time to setup, and the panic print message doesn't work. This avoids that issue by having the kernel just stop the process and notify the user via a debug message that it faulted. Then the user can use process console to panic the kernel and see the debug message if they wish.

Replaces #2527.

~~Blocked on #2537.~~


### Testing Strategy

Trying crash apps on the nano33ble.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
