### PR TITLE
capsules/i2c_master_slave_driver: use grant, enforce single process

### DIFF
--- a/capsules/src/i2c_master_slave_driver.rs
+++ b/capsules/src/i2c_master_slave_driver.rs
@@ -13,10 +13,10 @@
 
 use core::cell::Cell;
 use core::cmp;
-use kernel::common::cells::{MapCell, TakeCell};
+use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::hil;
 use kernel::{CommandReturn, ProcessId, Upcall};
-use kernel::{Driver, ErrorCode, Read, ReadWrite, ReadWriteAppSlice};
+use kernel::{Driver, ErrorCode, Grant, Read, ReadWrite, ReadWriteAppSlice};
 
 pub static mut BUFFER1: [u8; 256] = [0; 256];
 pub static mut BUFFER2: [u8; 256] = [0; 256];
@@ -49,7 +49,8 @@ pub struct I2CMasterSlaveDriver<'a> {
     master_buffer: TakeCell<'static, [u8]>,
     slave_buffer1: TakeCell<'static, [u8]>,
     slave_buffer2: TakeCell<'static, [u8]>,
-    app: MapCell<App>,
+    app: OptionalCell<ProcessId>,
+    apps: Grant<App>,
 }
 
 impl<'a> I2CMasterSlaveDriver<'a> {
@@ -58,15 +59,17 @@ impl<'a> I2CMasterSlaveDriver<'a> {
         master_buffer: &'static mut [u8],
         slave_buffer1: &'static mut [u8],
         slave_buffer2: &'static mut [u8],
+        grant: Grant<App>,
     ) -> I2CMasterSlaveDriver<'a> {
         I2CMasterSlaveDriver {
-            i2c: i2c,
+            i2c,
             listening: Cell::new(false),
             master_action: Cell::new(MasterAction::Write),
             master_buffer: TakeCell::new(master_buffer),
             slave_buffer1: TakeCell::new(slave_buffer1),
             slave_buffer2: TakeCell::new(slave_buffer2),
-            app: MapCell::new(App::default()),
+            app: OptionalCell::empty(),
+            apps: grant,
         }
     }
 }
@@ -90,50 +93,56 @@ impl hil::i2c::I2CHwMasterClient for I2CMasterSlaveDriver<'_> {
                 self.master_buffer.replace(buffer);
 
                 self.app.map(|app| {
-                    app.callback.schedule(0, err as usize, 0);
+                    let _ = self.apps.enter(*app, |app| {
+                        app.callback.schedule(0, err as usize, 0);
+                    });
                 });
             }
 
             MasterAction::Read(read_len) => {
                 self.app.map(|app| {
-                    // Because this (somewhat incorrectly) doesn't report
-                    // back how many bytes were read, the result of mut_map_or
-                    // is ignored. Note that this requires userspace to keep
-                    // track of this information, and if read_len is longer
-                    // than the buffer could lead to array overrun errors in
-                    // userspace. The I2C syscall API should pass back lengths.
-                    // -pal 3/5/21
-                    app.master_rx_buffer.mut_map_or(0, move |app_buffer| {
-                        let len = cmp::min(app_buffer.len(), read_len as usize);
+                    let _ = self.apps.enter(*app, |app| {
+                        // Because this (somewhat incorrectly) doesn't report
+                        // back how many bytes were read, the result of mut_map_or
+                        // is ignored. Note that this requires userspace to keep
+                        // track of this information, and if read_len is longer
+                        // than the buffer could lead to array overrun errors in
+                        // userspace. The I2C syscall API should pass back lengths.
+                        // -pal 3/5/21
+                        app.master_rx_buffer.mut_map_or(0, move |app_buffer| {
+                            let len = cmp::min(app_buffer.len(), read_len as usize);
 
-                        for (i, c) in buffer[0..len].iter().enumerate() {
-                            app_buffer[i] = *c;
-                        }
+                            for (i, c) in buffer[0..len].iter().enumerate() {
+                                app_buffer[i] = *c;
+                            }
 
-                        self.master_buffer.replace(buffer);
-                        0
+                            self.master_buffer.replace(buffer);
+                            0
+                        });
+
+                        app.callback.schedule(1, err as usize, 0);
                     });
-
-                    app.callback.schedule(1, err as usize, 0);
                 });
             }
 
             MasterAction::WriteRead(read_len) => {
                 self.app.map(|app| {
-                    // Because this (somewhat incorrectly) doesn't report
-                    // back how many bytes were read, the result of mut_map_or
-                    // is ignored. Note that this requires userspace to keep
-                    // track of this information, and if read_len is longer
-                    // than the buffer could lead to array overrun errors in
-                    // userspace. The I2C syscall API should pass back lengths.
-                    // -pal 3/5/21
-                    app.master_tx_buffer.mut_map_or(0, move |app_buffer| {
-                        let len = cmp::min(app_buffer.len(), read_len as usize);
-                        app_buffer.as_mut()[..len].copy_from_slice(&buffer[..len]);
-                        self.master_buffer.replace(buffer);
-                        0
+                    let _ = self.apps.enter(*app, |app| {
+                        // Because this (somewhat incorrectly) doesn't report
+                        // back how many bytes were read, the result of mut_map_or
+                        // is ignored. Note that this requires userspace to keep
+                        // track of this information, and if read_len is longer
+                        // than the buffer could lead to array overrun errors in
+                        // userspace. The I2C syscall API should pass back lengths.
+                        // -pal 3/5/21
+                        app.master_tx_buffer.mut_map_or(0, move |app_buffer| {
+                            let len = cmp::min(app_buffer.len(), read_len as usize);
+                            app_buffer.as_mut()[..len].copy_from_slice(&buffer[..len]);
+                            self.master_buffer.replace(buffer);
+                            0
+                        });
+                        app.callback.schedule(7, err as usize, 0);
                     });
-                    app.callback.schedule(7, err as usize, 0);
                 });
             }
         }
@@ -162,27 +171,29 @@ impl hil::i2c::I2CHwSlaveClient for I2CMasterSlaveDriver<'_> {
         match transmission_type {
             hil::i2c::SlaveTransmissionType::Write => {
                 self.app.map(|app| {
-                    app.slave_rx_buffer.mut_map_or(0, move |app_rx| {
-                        // Check bounds for write length
-                        // Because this (somewhat incorrectly) doesn't report
-                        // back how many bytes were read, the result of mut_map_or
-                        // is ignored. Note that this requires userspace to keep
-                        // track of this information, and if read_len is longer
-                        // than the buffer could lead to array overrun errors in
-                        // userspace. The I2C syscall API should pass back lengths.
-                        // -pal 3/5/21
-                        let buf_len = cmp::min(app_rx.len(), buffer.len());
-                        let read_len = cmp::min(buf_len, length as usize);
+                    let _ = self.apps.enter(*app, |app| {
+                        app.slave_rx_buffer.mut_map_or(0, move |app_rx| {
+                            // Check bounds for write length
+                            // Because this (somewhat incorrectly) doesn't report
+                            // back how many bytes were read, the result of mut_map_or
+                            // is ignored. Note that this requires userspace to keep
+                            // track of this information, and if read_len is longer
+                            // than the buffer could lead to array overrun errors in
+                            // userspace. The I2C syscall API should pass back lengths.
+                            // -pal 3/5/21
+                            let buf_len = cmp::min(app_rx.len(), buffer.len());
+                            let read_len = cmp::min(buf_len, length as usize);
 
-                        for (i, c) in buffer[0..read_len].iter_mut().enumerate() {
-                            app_rx[i] = *c;
-                        }
+                            for (i, c) in buffer[0..read_len].iter_mut().enumerate() {
+                                app_rx[i] = *c;
+                            }
 
-                        self.slave_buffer1.replace(buffer);
-                        0
+                            self.slave_buffer1.replace(buffer);
+                            0
+                        });
+
+                        app.callback.schedule(3, length as usize, 0);
                     });
-
-                    app.callback.schedule(3, length as usize, 0);
                 });
             }
 
@@ -191,7 +202,9 @@ impl hil::i2c::I2CHwSlaveClient for I2CMasterSlaveDriver<'_> {
 
                 // Notify the app that the read finished
                 self.app.map(|app| {
-                    app.callback.schedule(4, length as usize, 0);
+                    let _ = self.apps.enter(*app, |app| {
+                        app.callback.schedule(4, length as usize, 0);
+                    });
                 });
             }
         }
@@ -201,10 +214,12 @@ impl hil::i2c::I2CHwSlaveClient for I2CMasterSlaveDriver<'_> {
         // Pass this up to the client. Not much we can do until the application
         // has setup a buffer to read from.
         self.app.map(|app| {
-            // Ask the app to setup a read buffer. The app must call
-            // command 3 after it has setup the shared read buffer with
-            // the correct bytes.
-            app.callback.schedule(2, 0, 0);
+            let _ = self.apps.enter(*app, |app| {
+                // Ask the app to setup a read buffer. The app must call
+                // command 3 after it has setup the shared read buffer with
+                // the correct bytes.
+                app.callback.schedule(2, 0, 0);
+            });
         });
     }
 
@@ -222,41 +237,42 @@ impl hil::i2c::I2CHwSlaveClient for I2CMasterSlaveDriver<'_> {
 impl Driver for I2CMasterSlaveDriver<'_> {
     fn allow_readwrite(
         &self,
-        _appid: ProcessId,
+        app: ProcessId,
         allow_num: usize,
         mut slice: ReadWriteAppSlice,
     ) -> Result<ReadWriteAppSlice, (ReadWriteAppSlice, ErrorCode)> {
-        match allow_num {
-            // Pass in a buffer for transmitting a `write` to another
-            // I2C device.
-            0 => {
-                self.app.map(|app| {
-                    core::mem::swap(&mut app.master_tx_buffer, &mut slice);
-                });
-                Ok(slice)
-            }
-            // Pass in a buffer for doing a read from another I2C device.
-            1 => {
-                self.app.map(|app| {
-                    core::mem::swap(&mut app.master_rx_buffer, &mut slice);
-                });
-                Ok(slice)
-            }
-            // Pass in a buffer for handling a read issued by another I2C master.
-            2 => {
-                self.app.map(|app| {
-                    core::mem::swap(&mut app.slave_tx_buffer, &mut slice);
-                });
-                Ok(slice)
-            }
-            // Pass in a buffer for handling a write issued by another I2C master.
-            3 => {
-                self.app.map(|app| {
-                    core::mem::swap(&mut app.slave_rx_buffer, &mut slice);
-                });
-                Ok(slice)
-            }
-            _ => Err((slice, ErrorCode::NOSUPPORT)),
+        let res = self
+            .apps
+            .enter(app, |app| {
+                match allow_num {
+                    // Pass in a buffer for transmitting a `write` to another
+                    // I2C device.
+                    0 => {
+                        core::mem::swap(&mut app.master_tx_buffer, &mut slice);
+                        Ok(())
+                    }
+                    // Pass in a buffer for doing a read from another I2C device.
+                    1 => {
+                        core::mem::swap(&mut app.master_rx_buffer, &mut slice);
+                        Ok(())
+                    }
+                    // Pass in a buffer for handling a read issued by another I2C master.
+                    2 => {
+                        core::mem::swap(&mut app.slave_tx_buffer, &mut slice);
+                        Ok(())
+                    }
+                    // Pass in a buffer for handling a write issued by another I2C master.
+                    3 => {
+                        core::mem::swap(&mut app.slave_rx_buffer, &mut slice);
+                        Ok(())
+                    }
+                    _ => Err(ErrorCode::NOSUPPORT),
+                }
+            })
+            .unwrap_or_else(|e| Err(e.into()));
+        match res {
+            Ok(()) => Ok(slice),
+            Err(e) => Err((slice, e)),
         }
     }
 
@@ -264,31 +280,64 @@ impl Driver for I2CMasterSlaveDriver<'_> {
         &self,
         subscribe_num: usize,
         mut callback: Upcall,
-        _app_id: ProcessId,
+        app: ProcessId,
     ) -> Result<Upcall, (Upcall, ErrorCode)> {
-        match subscribe_num {
-            0 => {
-                self.app.map(|app| {
-                    core::mem::swap(&mut app.callback, &mut callback);
-                });
-                Ok(callback)
-            }
+        let res = self
+            .apps
+            .enter(app, |app| {
+                match subscribe_num {
+                    0 => {
+                        core::mem::swap(&mut app.callback, &mut callback);
+                        Ok(())
+                    }
 
-            // default
-            _ => Err((callback, ErrorCode::NOSUPPORT)),
+                    // default
+                    _ => Err(ErrorCode::NOSUPPORT),
+                }
+            })
+            .unwrap_or_else(|e| Err(e.into()));
+        match res {
+            Ok(()) => Ok(callback),
+            Err(e) => Err((callback, e)),
         }
     }
 
-    fn command(&self, command_num: usize, data: usize, _: usize, _: ProcessId) -> CommandReturn {
-        match command_num {
-            0 /* check if present */ => CommandReturn::success(),
+    fn command(
+        &self,
+        command_num: usize,
+        data: usize,
+        _: usize,
+        process_id: ProcessId,
+    ) -> CommandReturn {
+        if command_num == 0 {
+            // Handle this first as it should be returned
+            // unconditionally
+            return CommandReturn::success();
+        }
+        // Check if this non-virtualized driver is already in use by
+        // some (alive) process
+        let match_or_empty_or_nonexistant = self.app.map_or(true, |current_process| {
+            self.apps
+                .enter(*current_process, |_| current_process == &process_id)
+                .unwrap_or(true)
+        });
+        if match_or_empty_or_nonexistant {
+            self.app.set(process_id);
+        } else {
+            return CommandReturn::failure(ErrorCode::NOMEM);
+        }
+        let app = self.app.expect("cannot fail");
 
+        match command_num {
             // Do a write to another I2C device
             1 => {
                 let address = (data & 0xFFFF) as u8;
                 let len = (data >> 16) & 0xFFFF;
 
-                self.app.map(|app| {
+                // No need to check error on enter() -- we entered successfully
+                // above, so grant is allocated, and the app can't disappear
+                // while we are in the kernel.
+                let _ = self.apps.enter(app, |app| {
                     app.master_tx_buffer.mut_map_or(0, |app_tx| {
                         // Because this (somewhat incorrectly) doesn't report
                         // back how many bytes are being written, the result of mut_map_or
@@ -308,10 +357,12 @@ impl Driver for I2CMasterSlaveDriver<'_> {
                             self.master_action.set(MasterAction::Write);
 
                             hil::i2c::I2CMaster::enable(self.i2c);
-                            hil::i2c::I2CMaster::write(self.i2c,
-                                                       address,
-                                                       kernel_tx,
-                                                       write_len as u8);
+                            hil::i2c::I2CMaster::write(
+                                self.i2c,
+                                address,
+                                kernel_tx,
+                                write_len as u8,
+                            );
                         });
                         0
                     });
@@ -325,7 +376,7 @@ impl Driver for I2CMasterSlaveDriver<'_> {
                 let address = (data & 0xFFFF) as u8;
                 let len = (data >> 16) & 0xFFFF;
 
-                self.app.map(|app| {
+                let _ = self.apps.enter(app, |app| {
                     // Because this (somewhat incorrectly) doesn't report
                     // back how many bytes are being read, the result of mut_map_or
                     // is ignored. Note that this does not provide useful feedback
@@ -375,7 +426,7 @@ impl Driver for I2CMasterSlaveDriver<'_> {
             // Prepare for a read from another Master by passing what's
             // in the shared slice to the lower level I2C hardware driver.
             4 => {
-                self.app.map(|app| {
+                let _ = self.apps.enter(app, |app| {
                     // Because this (somewhat incorrectly) doesn't report
                     // back how many bytes are being read, the result of mut_map_or
                     // is ignored. Note that this does not provide useful feedback
@@ -430,7 +481,7 @@ impl Driver for I2CMasterSlaveDriver<'_> {
                 let address = (data & 0xFF) as u8;
                 let read_len = (data >> 8) & 0xFF;
                 let write_len = (data >> 16) & 0xFF;
-                self.app.map(|app| {
+                let _ = self.apps.enter(app, |app| {
                     // Because this (somewhat incorrectly) doesn't report
                     // back how many bytes are being read/read, the result of mut_map_or
                     // is ignored. Note that this does not provide useful feedback
@@ -444,13 +495,16 @@ impl Driver for I2CMasterSlaveDriver<'_> {
                             let write_len = cmp::min(buf_len, write_len);
                             let read_len = cmp::min(buf_len, read_len);
                             kernel_tx[..write_len].copy_from_slice(&app_tx[..write_len]);
-                            self.master_action.set(MasterAction::WriteRead(read_len as u8));
+                            self.master_action
+                                .set(MasterAction::WriteRead(read_len as u8));
                             hil::i2c::I2CMaster::enable(self.i2c);
-                            hil::i2c::I2CMaster::write_read(self.i2c,
-                                                            address,
-                                                            kernel_tx,
-                                                            write_len as u8,
-                                                            read_len as u8);
+                            hil::i2c::I2CMaster::write_read(
+                                self.i2c,
+                                address,
+                                kernel_tx,
+                                write_len as u8,
+                                read_len as u8,
+                            );
                         });
                         0
                     });
@@ -459,7 +513,7 @@ impl Driver for I2CMasterSlaveDriver<'_> {
             }
 
             // default
-            _ => CommandReturn::failure(ErrorCode::NOSUPPORT)
+            _ => CommandReturn::failure(ErrorCode::NOSUPPORT),
         }
     }
 }


### PR DESCRIPTION
### Pull Request Overview

This pull request enforces that only a single process may (implicitly) reserve the nonvirtualized userspace driver. Also, the driver now store callbacks and appslices in grant regions.

This is one of the remaining capsules blocking #2462 .

One observation: repeatedly handling the possibility of a grant entrance (within a single function) failing is a pain. But I do not think it is possible for a grant entrance to fail after the first entrance -- the grant is already allocated at that point, and the process is present. So I omitted the error handling in `command()` after the first grant entrance.


### Testing Strategy

This pull request was tested by compiling.


### TODO or Help Wanted

N/A

### Documentation Updated

- [x] No updates are required.

### Formatting

- [x] Ran `make prepush`.
