### PR TITLE
kernel: Reorganize crate exports

### DIFF
--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -89,45 +89,36 @@
 #![warn(unreachable_pub)]
 #![no_std]
 
+// Kernel crate resources exposed as `kernel::module::Type`.
+pub mod appslice;
 pub mod capabilities;
 pub mod common;
 pub mod component;
 pub mod debug;
+pub mod driver;
+pub mod errorcode;
+pub mod grant;
 pub mod hil;
 pub mod introspection;
 pub mod ipc;
+pub mod schedulers;
 pub mod syscall;
+pub mod traits;
+pub mod upcall;
 
 mod config;
-mod driver;
-mod errorcode;
-mod grant;
-mod mem;
 mod memop;
-mod platform;
 mod process;
 mod process_policies;
 mod process_standard;
 mod process_utilities;
-mod sched;
-mod upcall;
 
-pub use crate::driver::{CommandReturn, Driver};
-pub use crate::errorcode::into_statuscode;
+// Core resources exposed as `kernel::Type`.
+pub use crate::driver::Driver;
 pub use crate::errorcode::ErrorCode;
-pub use crate::grant::{Grant, ProcessGrant};
-pub use crate::mem::{Read, ReadOnlyAppSlice, ReadWrite, ReadWriteAppSlice};
-pub use crate::platform::scheduler_timer::{SchedulerTimer, VirtualSchedulerTimer};
-pub use crate::platform::watchdog;
-pub use crate::platform::{mpu, Chip, InterruptService, Platform};
-pub use crate::platform::{ClockInterface, NoClockControl, NO_CLOCK_CONTROL};
+pub use crate::kernel::Kernel;
 pub use crate::process::ProcessId;
-pub use crate::sched::cooperative::{CoopProcessNode, CooperativeSched};
-pub use crate::sched::mlfq::{MLFQProcessNode, MLFQSched};
-pub use crate::sched::priority::PrioritySched;
-pub use crate::sched::round_robin::{RoundRobinProcessNode, RoundRobinSched};
-pub use crate::sched::{Kernel, Scheduler};
-pub use crate::upcall::Upcall;
+pub use crate::scheduler::Scheduler;
 
 // Export only select items from the process module. To remove the name conflict
 // this cannot be called `process`, so we use a shortened version. These


### PR DESCRIPTION
### Pull Request Overview

This pull request is a discussion point for addressing #1088.

Initial idea:

```rust
// Kernel crate resources exposed as `kernel::module::Type`.
pub mod appslice;
pub mod capabilities;
pub mod common;
pub mod component;
pub mod debug;
pub mod driver;
pub mod errorcode;
pub mod grant;
pub mod hil;
pub mod introspection;
pub mod ipc;
pub mod schedulers;
pub mod syscall;
pub mod traits;
pub mod upcall;

mod config;
mod memop;
mod process;
mod process_policies;
mod process_standard;
mod process_utilities;

// Core resources exposed as `kernel::Type`.
pub use crate::driver::Driver;
pub use crate::errorcode::ErrorCode;
pub use crate::kernel::Kernel;
pub use crate::process::ProcessId;
pub use crate::scheduler::Scheduler;

// Export only select items from the process module. To remove the name conflict
// this cannot be called `process`, so we use a shortened version. These
// functions and types are used by board files to setup the platform and setup
// processes.
/// Publicly available process-related objects.
pub mod procs {
    pub use crate::process::{
        Error, FaultAction, FunctionCall, FunctionCallSource, Process, State, Task,
    };
    pub use crate::process_policies::{
        PanicFaultPolicy, ProcessFaultPolicy, RestartFaultPolicy, StopFaultPolicy,
        StopWithDebugFaultPolicy, ThresholdRestartFaultPolicy,
        ThresholdRestartThenPanicFaultPolicy,
    };
    pub use crate::process_standard::ProcessStandard;
    pub use crate::process_utilities::{load_processes, ProcessLoadError};
}
```

Basically everything is exposed through the module (file) rather than being `kernel::Type` except for a few key types that are so essential seem to make sense as `kernel::X` types.

Other changes:

- `/platform` is now `/traits`.
  - Added `chip.rs` and `platform.rs` to `/traits`.
- `mem.rs` -> `appslice.rs`.
- `/sched` -> `/schedulers`.

Questions:

- Right now we have `kernel::procs::`. That's not my favorite. Should we do `kernel::processes::`?
- `trait Platform` doesn't match that it is implemented by what we call boards. Should we change it to `trait Board`?
- `trait Driver` is a very generic name which has many meanings in embedded code. Should we change it?


### Testing Strategy

travis


### TODO or Help Wanted

Discussion.


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
