### PR TITLE
capsules/pca9544a: use grant, enforce single process …

### DIFF
--- a/capsules/src/pca9544a.rs
+++ b/capsules/src/pca9544a.rs
@@ -29,9 +29,9 @@
 //! ```
 
 use core::cell::Cell;
-use kernel::common::cells::{MapCell, TakeCell};
+use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::hil::i2c;
-use kernel::{CommandReturn, Driver, ErrorCode, ProcessId, Upcall};
+use kernel::{CommandReturn, Driver, ErrorCode, Grant, ProcessId, Upcall};
 
 /// Syscall driver number.
 use crate::driver;
@@ -55,20 +55,27 @@ enum ControlField {
     SelectedChannels,
 }
 
+#[derive(Default)]
+pub struct App {
+    callback: Upcall,
+}
+
 pub struct PCA9544A<'a> {
     i2c: &'a dyn i2c::I2CDevice,
     state: Cell<State>,
     buffer: TakeCell<'static, [u8]>,
-    callback: MapCell<Upcall>,
+    apps: Grant<App>,
+    owning_process: OptionalCell<ProcessId>,
 }
 
 impl<'a> PCA9544A<'a> {
-    pub fn new(i2c: &'a dyn i2c::I2CDevice, buffer: &'static mut [u8]) -> PCA9544A<'a> {
-        PCA9544A {
-            i2c: i2c,
+    pub fn new(i2c: &'a dyn i2c::I2CDevice, buffer: &'static mut [u8], grant: Grant<App>) -> Self {
+        Self {
+            i2c,
             state: Cell::new(State::Idle),
             buffer: TakeCell::new(buffer),
-            callback: MapCell::new(Upcall::default()),
+            apps: grant,
+            owning_process: OptionalCell::empty(),
         }
     }
 
@@ -133,15 +140,22 @@ impl i2c::I2CClient for PCA9544A<'_> {
                     ControlField::SelectedChannels => buffer[0] & 0x07,
                 };
 
-                self.callback
-                    .map(|cb| cb.schedule((field as usize) + 1, ret as usize, 0));
+                self.owning_process.map(|pid| {
+                    let _ = self.apps.enter(*pid, |app| {
+                        app.callback.schedule((field as usize) + 1, ret as usize, 0);
+                    });
+                });
 
                 self.buffer.replace(buffer);
                 self.i2c.disable();
                 self.state.set(State::Idle);
             }
             State::Done => {
-                self.callback.map(|cb| cb.schedule(0, 0, 0));
+                self.owning_process.map(|pid| {
+                    let _ = self.apps.enter(*pid, |app| {
+                        app.callback.schedule(0, 0, 0);
+                    });
+                });
 
                 self.buffer.replace(buffer);
                 self.i2c.disable();
@@ -162,20 +176,26 @@ impl Driver for PCA9544A<'_> {
     fn subscribe(
         &self,
         subscribe_num: usize,
-        callback: Upcall,
-        _app_id: ProcessId,
+        mut callback: Upcall,
+        appid: ProcessId,
     ) -> Result<Upcall, (Upcall, ErrorCode)> {
-        match subscribe_num {
-            0 => {
-                if let Some(prev) = self.callback.replace(callback) {
-                    Ok(prev)
-                } else {
-                    Ok(Upcall::default())
-                }
-            }
+        let res = self
+            .apps
+            .enter(appid, |app| {
+                match subscribe_num {
+                    0 => {
+                        core::mem::swap(&mut app.callback, &mut callback);
+                        Ok(())
+                    }
 
-            // default
-            _ => Err((callback, ErrorCode::NOSUPPORT)),
+                    // default
+                    _ => Err(ErrorCode::NOSUPPORT),
+                }
+            })
+            .unwrap_or_else(|e| Err(e.into()));
+        match res {
+            Ok(()) => Ok(callback),
+            Err(e) => Err((callback, e)),
         }
     }
 
@@ -188,7 +208,31 @@ impl Driver for PCA9544A<'_> {
     /// - `2`: Disable all channels.
     /// - `3`: Read the list of fired interrupts.
     /// - `4`: Read which channels are selected.
-    fn command(&self, command_num: usize, data: usize, _: usize, _: ProcessId) -> CommandReturn {
+    fn command(
+        &self,
+        command_num: usize,
+        data: usize,
+        _: usize,
+        process_id: ProcessId,
+    ) -> CommandReturn {
+        if command_num == 0 {
+            // Handle this first as it should be returned
+            // unconditionally
+            return CommandReturn::success();
+        }
+        // Check if this non-virtualized driver is already in use by
+        // some (alive) process
+        let match_or_empty_or_nonexistant = self.owning_process.map_or(true, |current_process| {
+            self.apps
+                .enter(*current_process, |_| current_process == &process_id)
+                .unwrap_or(true)
+        });
+        if match_or_empty_or_nonexistant {
+            self.owning_process.set(process_id);
+        } else {
+            return CommandReturn::failure(ErrorCode::NOMEM);
+        }
+
         match command_num {
             // Check if present.
             0 => CommandReturn::success(),


### PR DESCRIPTION
### Pull Request Overview

This pull request enforces that only a single process may (implicitly) reserve the nonvirtualized userspace driver. Also, the driver now store callbacks and appslices in grant regions.

This is one of the remaining capsules blocking #2462 .


### Testing Strategy

This pull request was tested by compiling.


### TODO or Help Wanted

N/A

### Documentation Updated

- [x] No updates are required.

### Formatting

- [x] Ran `make prepush`.