### PR TITLE
capsules/mlx90614: use grant, enforce single process

### DIFF
--- a/capsules/src/mlx90614.rs
+++ b/capsules/src/mlx90614.rs
@@ -22,7 +22,7 @@ use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::common::registers::register_bitfields;
 use kernel::hil::i2c::{self, Error};
 use kernel::hil::sensors;
-use kernel::{CommandReturn, Driver, ErrorCode, ProcessId, Upcall};
+use kernel::{CommandReturn, Driver, ErrorCode, Grant, ProcessId, Upcall};
 
 /// Syscall driver number.
 pub const DRIVER_NUM: usize = driver::NUM::Mlx90614 as usize;
@@ -56,25 +56,33 @@ enum_from_primitive! {
     }
 }
 
+#[derive(Default)]
+pub struct App {
+    callback: Upcall,
+}
+
 pub struct Mlx90614SMBus<'a> {
     smbus_temp: &'a dyn i2c::SMBusDevice,
-    callback: Cell<Upcall>,
     temperature_client: OptionalCell<&'a dyn sensors::TemperatureClient>,
     buffer: TakeCell<'static, [u8]>,
     state: Cell<State>,
+    apps: Grant<App>,
+    owning_process: OptionalCell<ProcessId>,
 }
 
 impl<'a> Mlx90614SMBus<'_> {
     pub fn new(
         smbus_temp: &'a dyn i2c::SMBusDevice,
         buffer: &'static mut [u8],
+        grant: Grant<App>,
     ) -> Mlx90614SMBus<'a> {
         Mlx90614SMBus {
             smbus_temp,
-            callback: Cell::new(Upcall::default()),
             temperature_client: OptionalCell::empty(),
             buffer: TakeCell::new(buffer),
             state: Cell::new(State::Idle),
+            apps: grant,
+            owning_process: OptionalCell::empty(),
         }
     }
 
@@ -117,9 +125,11 @@ impl<'a> i2c::I2CClient for Mlx90614SMBus<'a> {
                     false
                 };
 
-                self.callback
-                    .get()
-                    .schedule(if present { 1 } else { 0 }, 0, 0);
+                self.owning_process.map(|pid| {
+                    let _ = self.apps.enter(*pid, |app| {
+                        app.callback.schedule(if present { 1 } else { 0 }, 0, 0);
+                    });
+                });
                 self.buffer.replace(buffer);
                 self.state.set(State::Idle);
             }
@@ -140,9 +150,17 @@ impl<'a> i2c::I2CClient for Mlx90614SMBus<'a> {
                     false
                 };
                 if values {
-                    self.callback.get().schedule(temp, 0, 0);
+                    self.owning_process.map(|pid| {
+                        let _ = self.apps.enter(*pid, |app| {
+                            app.callback.schedule(temp, 0, 0);
+                        });
+                    });
                 } else {
-                    self.callback.get().schedule(0, 0, 0);
+                    self.owning_process.map(|pid| {
+                        let _ = self.apps.enter(*pid, |app| {
+                            app.callback.schedule(0, 0, 0);
+                        });
+                    });
                 }
                 self.buffer.replace(buffer);
                 self.state.set(State::Idle);
@@ -157,8 +175,26 @@ impl<'a> Driver for Mlx90614SMBus<'a> {
         command_num: usize,
         _data1: usize,
         _data2: usize,
-        _: ProcessId,
+        process_id: ProcessId,
     ) -> CommandReturn {
+        if command_num == 0 {
+            // Handle this first as it should be returned
+            // unconditionally
+            return CommandReturn::success();
+        }
+        // Check if this non-virtualized driver is already in use by
+        // some (alive) process
+        let match_or_empty_or_nonexistant = self.owning_process.map_or(true, |current_process| {
+            self.apps
+                .enter(*current_process, |_| current_process == &process_id)
+                .unwrap_or(true)
+        });
+        if match_or_empty_or_nonexistant {
+            self.owning_process.set(process_id);
+        } else {
+            return CommandReturn::failure(ErrorCode::NOMEM);
+        }
+
         match command_num {
             0 => CommandReturn::success(),
             // Check is sensor is correctly connected
@@ -196,15 +232,26 @@ impl<'a> Driver for Mlx90614SMBus<'a> {
     fn subscribe(
         &self,
         subscribe_num: usize,
-        callback: Upcall,
-        _app_id: ProcessId,
+        mut callback: Upcall,
+        appid: ProcessId,
     ) -> Result<Upcall, (Upcall, ErrorCode)> {
-        match subscribe_num {
-            0 /* set the one shot callback */ => {
-                Ok(self.callback.replace(callback))
-            },
-            // default
-            _ => Err((callback, ErrorCode::NOSUPPORT)),
+        let res = self
+            .apps
+            .enter(appid, |app| {
+                match subscribe_num {
+                    0 => {
+                        core::mem::swap(&mut app.callback, &mut callback);
+                        Ok(())
+                    }
+
+                    // default
+                    _ => Err(ErrorCode::NOSUPPORT),
+                }
+            })
+            .unwrap_or_else(|e| Err(e.into()));
+        match res {
+            Ok(()) => Ok(callback),
+            Err(e) => Err((callback, e)),
         }
     }
 }


### PR DESCRIPTION
### Pull Request Overview

This pull request enforces that only a single process may (implicitly) reserve the nonvirtualized userspace driver. Also, the driver now store callbacks and appslices in grant regions.

This is one of the remaining capsules blocking #2462 .


### Testing Strategy

This pull request was tested by compiling.


### TODO or Help Wanted

N/A

### Documentation Updated

- [x] No updates are required.

### Formatting

- [x] Ran `make prepush`.