### PR TITLE
capsules/spi_controller: migrate non-virtualized driver to Grants

### DIFF
--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -301,7 +301,7 @@ pub unsafe fn main() {
     let mux_spi = components::spi::SpiMuxComponent::new(&peripherals.spi)
         .finalize(components::spi_mux_component_helper!(sam4l::spi::SpiHw));
     // Create the SPI system call capsule.
-    let spi_syscalls = components::spi::SpiSyscallComponent::new(mux_spi, 0)
+    let spi_syscalls = components::spi::SpiSyscallComponent::new(board_kernel, mux_spi, 0)
         .finalize(components::spi_syscall_component_helper!(sam4l::spi::SpiHw));
 
     // LEDs

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -350,7 +350,7 @@ pub unsafe fn main() {
     let mux_spi = components::spi::SpiMuxComponent::new(&peripherals.spi)
         .finalize(components::spi_mux_component_helper!(sam4l::spi::SpiHw));
 
-    let spi_syscalls = SpiSyscallComponent::new(mux_spi, 2)
+    let spi_syscalls = SpiSyscallComponent::new(board_kernel, mux_spi, 2)
         .finalize(components::spi_syscall_component_helper!(sam4l::spi::SpiHw));
     let rf233_spi = SpiComponent::new(mux_spi, 3)
         .finalize(components::spi_component_helper!(sam4l::spi::SpiHw));

--- a/capsules/src/spi_controller.rs
+++ b/capsules/src/spi_controller.rs
@@ -3,11 +3,11 @@
 
 use core::cell::Cell;
 use core::{cmp, mem};
-use kernel::common::cells::{MapCell, TakeCell};
+use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::hil::spi::ClockPhase;
 use kernel::hil::spi::ClockPolarity;
 use kernel::hil::spi::{SpiMasterClient, SpiMasterDevice};
-use kernel::{CommandReturn, Driver, ErrorCode, ProcessId, Upcall};
+use kernel::{CommandReturn, Driver, ErrorCode, Grant, ProcessId, Upcall};
 use kernel::{Read, ReadOnlyAppSlice, ReadWrite, ReadWriteAppSlice};
 
 /// Syscall driver number.
@@ -28,7 +28,7 @@ pub const DEFAULT_WRITE_BUF_LENGTH: usize = 1024;
 // index an ongoing operation is at in the buffers.
 
 #[derive(Default)]
-struct App {
+pub struct App {
     callback: Upcall,
     app_read: ReadWriteAppSlice,
     app_write: ReadOnlyAppSlice,
@@ -39,21 +39,23 @@ struct App {
 pub struct Spi<'a, S: SpiMasterDevice> {
     spi_master: &'a S,
     busy: Cell<bool>,
-    app: MapCell<App>,
     kernel_read: TakeCell<'static, [u8]>,
     kernel_write: TakeCell<'static, [u8]>,
     kernel_len: Cell<usize>,
+    grants: Grant<App>,
+    current_process: OptionalCell<ProcessId>,
 }
 
 impl<'a, S: SpiMasterDevice> Spi<'a, S> {
-    pub fn new(spi_master: &'a S) -> Spi<'a, S> {
+    pub fn new(spi_master: &'a S, grants: Grant<App>) -> Spi<'a, S> {
         Spi {
             spi_master: spi_master,
             busy: Cell::new(false),
-            app: MapCell::new(App::default()),
             kernel_len: Cell::new(0),
             kernel_read: TakeCell::empty(),
             kernel_write: TakeCell::empty(),
+            grants,
+            current_process: OptionalCell::empty(),
         }
     }
 
@@ -93,15 +95,15 @@ impl<'a, S: SpiMasterDevice> Spi<'a, S> {
 impl<'a, S: SpiMasterDevice> Driver for Spi<'a, S> {
     fn allow_readwrite(
         &self,
-        _appid: ProcessId,
+        process_id: ProcessId,
         allow_num: usize,
         mut slice: ReadWriteAppSlice,
     ) -> Result<ReadWriteAppSlice, (ReadWriteAppSlice, ErrorCode)> {
         match allow_num {
             // Pass in a read buffer to receive bytes into.
             0 => {
-                self.app.map(|app| {
-                    mem::swap(&mut app.app_read, &mut slice);
+                let _ = self.grants.enter(process_id, |grant| {
+                    mem::swap(&mut grant.app_read, &mut slice);
                 });
                 Ok(slice)
             }
@@ -111,15 +113,15 @@ impl<'a, S: SpiMasterDevice> Driver for Spi<'a, S> {
 
     fn allow_readonly(
         &self,
-        _appid: ProcessId,
+        process_id: ProcessId,
         allow_num: usize,
         mut slice: ReadOnlyAppSlice,
     ) -> Result<ReadOnlyAppSlice, (ReadOnlyAppSlice, ErrorCode)> {
         match allow_num {
             // Pass in a write buffer to transmit bytes from.
             0 => {
-                self.app.map(|app| {
-                    mem::swap(&mut app.app_write, &mut slice);
+                let _ = self.grants.enter(process_id, |grant| {
+                    mem::swap(&mut grant.app_write, &mut slice);
                 });
                 Ok(slice)
             }
@@ -131,12 +133,12 @@ impl<'a, S: SpiMasterDevice> Driver for Spi<'a, S> {
         &self,
         subscribe_num: usize,
         mut callback: Upcall,
-        _app_id: ProcessId,
+        process_id: ProcessId,
     ) -> Result<Upcall, (Upcall, ErrorCode)> {
         match subscribe_num {
             0 => {
-                self.app.map(|app| {
-                    mem::swap(&mut app.callback, &mut callback);
+                let _ = self.grants.enter(process_id, |grant| {
+                    mem::swap(&mut grant.callback, &mut callback);
                 });
                 Ok(callback)
             }
@@ -180,16 +182,38 @@ impl<'a, S: SpiMasterDevice> Driver for Spi<'a, S> {
     // x+1: unlock spi
     //   - does nothing if lock not held
     //
-    fn command(&self, cmd_num: usize, arg1: usize, _: usize, _: ProcessId) -> CommandReturn {
-        match cmd_num {
-            0 /* check if present */ => CommandReturn::success(),
+    fn command(
+        &self,
+        command_num: usize,
+        arg1: usize,
+        _: usize,
+        process_id: ProcessId,
+    ) -> CommandReturn {
+        if command_num == 0 {
+            // Handle this first as it should be returned unconditionally.
+            return CommandReturn::success();
+        }
+
+        // Check if this driver is free, or already dedicated to this process.
+        let match_or_empty_or_nonexistant = self.current_process.map_or(true, |current_process| {
+            self.grants
+                .enter(*current_process, |_| current_process == &process_id)
+                .unwrap_or(true)
+        });
+        if match_or_empty_or_nonexistant {
+            self.current_process.set(process_id);
+        } else {
+            return CommandReturn::failure(ErrorCode::NOMEM);
+        }
+
+        match command_num {
             // No longer supported, wrap inside a read_write_bytes
             1 /* read_write_byte */ => CommandReturn::failure(ErrorCode::NOSUPPORT),
             2 /* read_write_bytes */ => {
                 if self.busy.get() {
                     return CommandReturn::failure(ErrorCode::BUSY);
                 }
-                self.app.map_or(CommandReturn::failure(ErrorCode::FAIL), |app| {
+                self.grants.enter(process_id, |app| {
                     // When we do a read/write, the read part is optional.
                     // So there are three cases:
                     // 1) Write and read buffers present: len is min of lengths
@@ -209,7 +233,7 @@ impl<'a, S: SpiMasterDevice> Driver for Spi<'a, S> {
                         /* write buffer too small, or zero length write */
                         CommandReturn::failure(ErrorCode::INVAL)
                     }
-                })
+                }).unwrap_or(CommandReturn::failure(ErrorCode::FAIL))
             }
             3 /* set chip select */ => {
                 // XXX: TODO: do nothing, for now, until we fix interface
@@ -261,48 +285,50 @@ impl<S: SpiMasterDevice> SpiMasterClient for Spi<'_, S> {
         readbuf: Option<&'static mut [u8]>,
         length: usize,
     ) {
-        self.app.map(move |app| {
-            let rbuf = readbuf.map(|src| {
-                let index = app.index;
-                app.app_read.mut_map_or((), |dest| {
-                    // Need to be careful that app_read hasn't changed
-                    // under us, so check all values against actual
-                    // slice lengths.
-                    //
-                    // If app_read is shorter than before, and shorter
-                    // than what we have read would require, then truncate.
-                    // -pal 12/9/20
-                    let end = index;
-                    let start = index - length;
-                    let end = cmp::min(end, cmp::min(src.len(), dest.len()));
+        self.current_process.map(|process_id| {
+            let _ = self.grants.enter(*process_id, move |app| {
+                let rbuf = readbuf.map(|src| {
+                    let index = app.index;
+                    app.app_read.mut_map_or((), |dest| {
+                        // Need to be careful that app_read hasn't changed
+                        // under us, so check all values against actual
+                        // slice lengths.
+                        //
+                        // If app_read is shorter than before, and shorter
+                        // than what we have read would require, then truncate.
+                        // -pal 12/9/20
+                        let end = index;
+                        let start = index - length;
+                        let end = cmp::min(end, cmp::min(src.len(), dest.len()));
 
-                    // If the new endpoint is earlier than our expected
-                    // startpoint, we set the startpoint to be the same;
-                    // This results in a zero-length operation. -pal 12/9/20
-                    let start = cmp::min(start, end);
+                        // If the new endpoint is earlier than our expected
+                        // startpoint, we set the startpoint to be the same;
+                        // This results in a zero-length operation. -pal 12/9/20
+                        let start = cmp::min(start, end);
 
-                    let dest_area = &mut dest[start..end];
-                    let real_len = end - start;
+                        let dest_area = &mut dest[start..end];
+                        let real_len = end - start;
 
-                    for (i, c) in src[0..real_len].iter().enumerate() {
-                        dest_area[i] = *c;
-                    }
+                        for (i, c) in src[0..real_len].iter().enumerate() {
+                            dest_area[i] = *c;
+                        }
+                    });
+                    src
                 });
-                src
+
+                self.kernel_read.put(rbuf);
+                self.kernel_write.replace(writebuf);
+
+                if app.index == app.len {
+                    self.busy.set(false);
+                    let len = app.len;
+                    app.len = 0;
+                    app.index = 0;
+                    app.callback.schedule(len, 0, 0);
+                } else {
+                    self.do_next_read_write(app);
+                }
             });
-
-            self.kernel_read.put(rbuf);
-            self.kernel_write.replace(writebuf);
-
-            if app.index == app.len {
-                self.busy.set(false);
-                let len = app.len;
-                app.len = 0;
-                app.index = 0;
-                app.callback.schedule(len, 0, 0);
-            } else {
-                self.do_next_read_write(app);
-            }
         });
     }
 }


### PR DESCRIPTION
### Pull Request Overview

As part of tock/tock#2462, this migrates the spi_controller nonvirtualized userspace driver to keep process state in a Grant region. It adopts the mechanism to reserve a driver as introduced in tock/tock#2521.

Signed-off-by: Leon Schuermann <leon@is.currently.online>

### Testing Strategy

This pull request was tested by compiling.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] ~Updated the relevant files in `/docs`, or~ no updates are required.

### Formatting

- [x] Ran `make prepush`.
