### PR TITLE
capsules/spi_peripheral: migrate non-virtualized driver to Grants

### DIFF
--- a/capsules/src/spi_peripheral.rs
+++ b/capsules/src/spi_peripheral.rs
@@ -5,11 +5,11 @@ use core::cell::Cell;
 use core::cmp;
 use core::mem;
 
-use kernel::common::cells::{MapCell, TakeCell};
+use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::hil::spi::ClockPhase;
 use kernel::hil::spi::ClockPolarity;
 use kernel::hil::spi::{SpiSlaveClient, SpiSlaveDevice};
-use kernel::{CommandReturn, Driver, ErrorCode, ProcessId, Upcall};
+use kernel::{CommandReturn, Driver, ErrorCode, Grant, ProcessId, Upcall};
 use kernel::{Read, ReadOnlyAppSlice, ReadWrite, ReadWriteAppSlice};
 
 /// Syscall driver number.
@@ -24,7 +24,7 @@ pub const DEFAULT_WRITE_BUF_LENGTH: usize = 1024;
 // when the chip is selected, we have added a "PeripheralApp" struct
 // that includes this new callback field.
 #[derive(Default)]
-struct PeripheralApp {
+pub struct PeripheralApp {
     callback: Upcall,
     selected_callback: Upcall,
     app_read: ReadWriteAppSlice,
@@ -36,21 +36,23 @@ struct PeripheralApp {
 pub struct SpiPeripheral<'a, S: SpiSlaveDevice> {
     spi_slave: &'a S,
     busy: Cell<bool>,
-    app: MapCell<PeripheralApp>,
     kernel_read: TakeCell<'static, [u8]>,
     kernel_write: TakeCell<'static, [u8]>,
     kernel_len: Cell<usize>,
+    grants: Grant<PeripheralApp>,
+    current_process: OptionalCell<ProcessId>,
 }
 
 impl<'a, S: SpiSlaveDevice> SpiPeripheral<'a, S> {
-    pub fn new(spi_slave: &'a S) -> SpiPeripheral<'a, S> {
+    pub fn new(spi_slave: &'a S, grants: Grant<PeripheralApp>) -> SpiPeripheral<'a, S> {
         SpiPeripheral {
             spi_slave: spi_slave,
             busy: Cell::new(false),
-            app: MapCell::new(PeripheralApp::default()),
             kernel_len: Cell::new(0),
             kernel_read: TakeCell::empty(),
             kernel_write: TakeCell::empty(),
+            grants,
+            current_process: OptionalCell::empty(),
         }
     }
 
@@ -94,18 +96,24 @@ impl<S: SpiSlaveDevice> Driver for SpiPeripheral<'_, S> {
     ///
     fn allow_readwrite(
         &self,
-        _appid: ProcessId,
+        process_id: ProcessId,
         allow_num: usize,
         mut slice: ReadWriteAppSlice,
     ) -> Result<ReadWriteAppSlice, (ReadWriteAppSlice, ErrorCode)> {
-        match allow_num {
-            0 => {
-                self.app.map(|app| {
-                    mem::swap(&mut app.app_read, &mut slice);
-                });
-                Ok(slice)
-            }
-            _ => Err((slice, ErrorCode::NOSUPPORT)),
+        let res = self
+            .grants
+            .enter(process_id, |grant| match allow_num {
+                0 => {
+                    mem::swap(&mut grant.app_read, &mut slice);
+                    Ok(())
+                }
+                _ => Err(ErrorCode::NOSUPPORT),
+            })
+            .unwrap_or_else(|e| e.into());
+
+        match res {
+            Ok(()) => Ok(slice),
+            Err(e) => Err((slice, e)),
         }
     }
 
@@ -115,18 +123,24 @@ impl<S: SpiSlaveDevice> Driver for SpiPeripheral<'_, S> {
     ///
     fn allow_readonly(
         &self,
-        _appid: ProcessId,
+        process_id: ProcessId,
         allow_num: usize,
         mut slice: ReadOnlyAppSlice,
     ) -> Result<ReadOnlyAppSlice, (ReadOnlyAppSlice, ErrorCode)> {
-        match allow_num {
-            0 => {
-                self.app.map(|app| {
-                    mem::swap(&mut app.app_write, &mut slice);
-                });
-                Ok(slice)
-            }
-            _ => Err((slice, ErrorCode::NOSUPPORT)),
+        let res = self
+            .grants
+            .enter(process_id, |grant| match allow_num {
+                0 => {
+                    mem::swap(&mut grant.app_write, &mut slice);
+                    Ok(())
+                }
+                _ => Err(ErrorCode::NOSUPPORT),
+            })
+            .unwrap_or_else(|e| e.into());
+
+        match res {
+            Ok(()) => Ok(slice),
+            Err(e) => Err((slice, e)),
         }
     }
     /// Set callbacks for SpiPeripheral
@@ -144,22 +158,28 @@ impl<S: SpiSlaveDevice> Driver for SpiPeripheral<'_, S> {
         &self,
         subscribe_num: usize,
         mut callback: Upcall,
-        _app_id: ProcessId,
+        process_id: ProcessId,
     ) -> Result<Upcall, (Upcall, ErrorCode)> {
-        match subscribe_num {
-            0 /* read_write */ => {
-                self.app.map(|app| {
-                    mem::swap(&mut app.callback, &mut callback);
-                });
-                Ok(callback)
-            },
-            1 /* chip selected */ => {
-                self.app.map(|app| {
-                    mem::swap(&mut app.selected_callback, &mut callback);
-                });
-                Ok(callback)
-            },
-            _ => Err((callback, ErrorCode::NOSUPPORT))
+        let res = self
+            .grants
+            .enter(process_id, |grant| {
+                match subscribe_num {
+                0 /* read_write */ => {
+                    mem::swap(&mut grant.callback, &mut callback);
+                    Ok(())
+                },
+                1 /* chip selected */ => {
+                    mem::swap(&mut grant.selected_callback, &mut callback);
+                    Ok(())
+                },
+                _ => Err(ErrorCode::NOSUPPORT)
+            }
+            })
+            .unwrap_or_else(|e| e.into());
+
+        match res {
+            Ok(()) => Ok(callback),
+            Err(e) => Err((callback, e)),
         }
     }
 
@@ -193,14 +213,36 @@ impl<S: SpiSlaveDevice> Driver for SpiPeripheral<'_, S> {
     /// - x+1: unlock spi
     ///   - does nothing if lock not held
     ///   - not implemented or currently supported
-    fn command(&self, cmd_num: usize, arg1: usize, _: usize, _: ProcessId) -> CommandReturn {
-        match cmd_num {
-            0 /* check if present */ => CommandReturn::success(),
+    fn command(
+        &self,
+        command_num: usize,
+        arg1: usize,
+        _: usize,
+        process_id: ProcessId,
+    ) -> CommandReturn {
+        if command_num == 0 {
+            // Handle this first as it should be returned unconditionally.
+            return CommandReturn::success();
+        }
+
+        // Check if this driver is free, or already dedicated to this process.
+        let match_or_empty_or_nonexistant = self.current_process.map_or(true, |current_process| {
+            self.grants
+                .enter(*current_process, |_| current_process == &process_id)
+                .unwrap_or(true)
+        });
+        if match_or_empty_or_nonexistant {
+            self.current_process.set(process_id);
+        } else {
+            return CommandReturn::failure(ErrorCode::NOMEM);
+        }
+
+        match command_num {
             1 /* read_write_bytes */ => {
                 if self.busy.get() {
                     return CommandReturn::failure(ErrorCode::BUSY);
                 }
-                self.app.map_or(CommandReturn::failure(ErrorCode::NOMEM), |app| {
+                self.grants.enter(process_id, |app| {
                     let mut mlen = app.app_write.map_or(0, |w| w.len());
                     let rlen = app.app_read.map_or(mlen, |r| r.len());
                     mlen = cmp::min(mlen, rlen);
@@ -213,7 +255,7 @@ impl<S: SpiSlaveDevice> Driver for SpiPeripheral<'_, S> {
                     } else {
                         CommandReturn::failure(ErrorCode::INVAL)
                     }
-                })
+                }).unwrap_or(CommandReturn::failure(ErrorCode::NOMEM))
             }
             2 /* get chip select */ => {
                 // Only 0 is supported
@@ -251,55 +293,60 @@ impl<S: SpiSlaveDevice> SpiSlaveClient for SpiPeripheral<'_, S> {
         readbuf: Option<&'static mut [u8]>,
         length: usize,
     ) {
-        self.app.map(move |app| {
-            let rbuf = readbuf.map(|src| {
-                let index = app.index;
-                app.app_read.mut_map_or((), |dest| {
-                    // Need to be careful that app_read hasn't changed
-                    // under us, so check all values against actual
-                    // slice lengths.
-                    //
-                    // If app_read is shorter than before, and shorter
-                    // than what we have read would require, then truncate.
-                    // -pal 12/9/20
-                    let end = index;
-                    let start = index - length;
-                    let end = cmp::min(end, cmp::min(src.len(), dest.len()));
+        self.current_process.map(|process_id| {
+            let _ = self.grants.enter(*process_id, move |app| {
+                let rbuf = readbuf.map(|src| {
+                    let index = app.index;
+                    app.app_read.mut_map_or((), |dest| {
+                        // Need to be careful that app_read hasn't changed
+                        // under us, so check all values against actual
+                        // slice lengths.
+                        //
+                        // If app_read is shorter than before, and shorter
+                        // than what we have read would require, then truncate.
+                        // -pal 12/9/20
+                        let end = index;
+                        let start = index - length;
+                        let end = cmp::min(end, cmp::min(src.len(), dest.len()));
 
-                    // If the new endpoint is earlier than our expected
-                    // startpoint, we set the startpoint to be the same;
-                    // This results in a zero-length operation. -pal 12/9/20
-                    let start = cmp::min(start, end);
+                        // If the new endpoint is earlier than our expected
+                        // startpoint, we set the startpoint to be the same;
+                        // This results in a zero-length operation. -pal 12/9/20
+                        let start = cmp::min(start, end);
 
-                    let dest_area = &mut dest[start..end];
-                    let real_len = end - start;
+                        let dest_area = &mut dest[start..end];
+                        let real_len = end - start;
 
-                    for (i, c) in src[0..real_len].iter().enumerate() {
-                        dest_area[i] = *c;
-                    }
+                        for (i, c) in src[0..real_len].iter().enumerate() {
+                            dest_area[i] = *c;
+                        }
+                    });
+                    src
                 });
-                src
+
+                self.kernel_read.put(rbuf);
+                self.kernel_write.put(writebuf);
+
+                if app.index == app.len {
+                    self.busy.set(false);
+                    let len = app.len;
+                    app.len = 0;
+                    app.index = 0;
+                    app.callback.schedule(len, 0, 0);
+                } else {
+                    self.do_next_read_write(app);
+                }
             });
-
-            self.kernel_read.put(rbuf);
-            self.kernel_write.put(writebuf);
-
-            if app.index == app.len {
-                self.busy.set(false);
-                let len = app.len;
-                app.len = 0;
-                app.index = 0;
-                app.callback.schedule(len, 0, 0);
-            } else {
-                self.do_next_read_write(app);
-            }
         });
     }
 
     // Simple callback for when chip has been selected
     fn chip_selected(&self) {
-        self.app.map(move |app| {
-            app.selected_callback.schedule(app.len, 0, 0);
+        self.current_process.map(|process_id| {
+            let _ = self.grants.enter(*process_id, move |app| {
+                let len = app.len;
+                app.selected_callback.schedule(len, 0, 0);
+            });
         });
     }
 }


### PR DESCRIPTION
### Pull Request Overview

As part of tock/tock#2462, this migrates the spi_peripheral non-virtualized userspace driver to keep process state in a Grant region. It adopts the mechanism to reserve a driver as introduced in tock/tock#2521.

Signed-off-by: Leon Schuermann <leon@is.currently.online>

### Testing Strategy

This pull request was tested by compiling.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] ~Updated the relevant files in `/docs`,~ or no updates are required.

### Formatting

- [x] Ran `make prepush`.
