### PR TITLE
capsules/gpio_async: enforce grant/single-process

### DIFF
--- a/boards/acd52832/src/main.rs
+++ b/boards/acd52832/src/main.rs
@@ -343,7 +343,10 @@ pub unsafe fn main() {
     // `gpio_async` is the object that manages all of the extenders.
     let gpio_async = static_init!(
         capsules::gpio_async::GPIOAsync<'static, capsules::mcp230xx::MCP230xx<'static>>,
-        capsules::gpio_async::GPIOAsync::new(async_gpio_ports)
+        capsules::gpio_async::GPIOAsync::new(
+            async_gpio_ports,
+            board_kernel.create_grant(&memory_allocation_capability)
+        ),
     );
     // Setup the clients correctly.
     for port in async_gpio_ports.iter() {

--- a/capsules/src/gpio_async.rs
+++ b/capsules/src/gpio_async.rs
@@ -25,10 +25,9 @@
 //! }
 //! ```
 
-use core::cell::Cell;
+use kernel::common::cells::OptionalCell;
 use kernel::hil;
-use kernel::{CommandReturn, Driver};
-use kernel::{ErrorCode, ProcessId, Upcall};
+use kernel::{CommandReturn, Driver, ErrorCode, Grant, ProcessId, Upcall};
 
 /// Syscall driver number.
 use crate::driver;
@@ -36,16 +35,37 @@ pub const DRIVER_NUM: usize = driver::NUM::GpioAsync as usize;
 
 pub struct GPIOAsync<'a, Port: hil::gpio_async::Port> {
     ports: &'a [&'a Port],
-    callback: Cell<Upcall>,
-    interrupt_callback: Cell<Upcall>,
+    grants: Grant<App>,
+    /// **Transient** ownership of the partially virtualized peripheral.
+    ///
+    /// Current GPIO HIL semantics notify *all* processes of interrupts
+    /// to any pin with interrupts configured (and it's left to higher
+    /// layers to filter activity based on which pin generated their
+    /// interrupt). For Async GPIO, this is awkward to virtualize, as
+    /// there is no owning process of a pin for activity interrupts, but
+    /// there is for configuration result interrupts. Also, the underlying
+    /// hardware likely can't handle multiple concurrent configurations
+    /// from multiple apps. Hence, this variable, which tracks a configuration
+    /// while it is in flight and notifies the correct process that their
+    /// configuration has succeeded. In the rare case where two apps attempt
+    /// concurrent configuration requests, the later app will receive `EBUSY`.
+    /// A retry loop should be sufficient for most apps to handle this rare
+    /// case.
+    configuring_process: OptionalCell<ProcessId>,
+}
+
+#[derive(Default)]
+pub struct App {
+    callback: Upcall,
+    interrupt_callback: Upcall,
 }
 
 impl<'a, Port: hil::gpio_async::Port> GPIOAsync<'a, Port> {
-    pub fn new(ports: &'a [&'a Port]) -> GPIOAsync<'a, Port> {
+    pub fn new(ports: &'a [&'a Port], grants: Grant<App>) -> GPIOAsync<'a, Port> {
         GPIOAsync {
             ports,
-            callback: Cell::new(Upcall::default()),
-            interrupt_callback: Cell::new(Upcall::default()),
+            grants,
+            configuring_process: OptionalCell::empty(),
         }
     }
 
@@ -74,11 +94,21 @@ impl<'a, Port: hil::gpio_async::Port> GPIOAsync<'a, Port> {
 
 impl<Port: hil::gpio_async::Port> hil::gpio_async::Client for GPIOAsync<'_, Port> {
     fn fired(&self, pin: usize, identifier: usize) {
-        self.interrupt_callback.get().schedule(identifier, pin, 0);
+        // schedule callback with the pin number and value for all apps
+        self.grants.each(|_, app| {
+            app.interrupt_callback.schedule(identifier, pin, 0);
+        });
     }
 
     fn done(&self, value: usize) {
-        self.callback.get().schedule(0, value, 0);
+        // alert currently configuring app
+        self.configuring_process.map(|pid| {
+            let _ = self.grants.enter(*pid, |app| {
+                app.callback.schedule(0, value, 0);
+            });
+        });
+        // then clear currently configuring app
+        self.configuring_process.clear();
     }
 }
 
@@ -100,18 +130,33 @@ impl<Port: hil::gpio_async::Port> Driver for GPIOAsync<'_, Port> {
     fn subscribe(
         &self,
         subscribe_num: usize,
-        callback: Upcall,
-        _app_id: ProcessId,
+        mut callback: Upcall,
+        app_id: ProcessId,
     ) -> Result<Upcall, (Upcall, ErrorCode)> {
-        match subscribe_num {
-            // Set callback for `done()` events
-            0 => Ok(self.callback.replace(callback)),
+        let res = self
+            .grants
+            .enter(app_id, |app| {
+                match subscribe_num {
+                    // Set callback for `done()` events
+                    0 => {
+                        core::mem::swap(&mut app.callback, &mut callback);
+                        Ok(())
+                    }
 
-            // Set callback for pin interrupts
-            1 => Ok(self.interrupt_callback.replace(callback)),
+                    // Set callback for pin interrupts
+                    1 => {
+                        core::mem::swap(&mut app.interrupt_callback, &mut callback);
+                        Ok(())
+                    }
 
-            // default
-            _ => Err((callback, ErrorCode::NOSUPPORT)),
+                    // default
+                    _ => Err(ErrorCode::NOSUPPORT),
+                }
+            })
+            .unwrap_or_else(|e| Err(e.into()));
+        match res {
+            Ok(()) => Ok(callback),
+            Err(e) => Err((callback, e)),
         }
     }
 
@@ -144,50 +189,67 @@ impl<Port: hil::gpio_async::Port> Driver for GPIOAsync<'_, Port> {
         command_number: usize,
         pin: usize,
         data: usize,
-        _appid: ProcessId,
+        process_id: ProcessId,
     ) -> CommandReturn {
         let port = data & 0xFFFF;
         let other = (data >> 16) & 0xFFFF;
         let ports = self.ports.as_ref();
 
+        // Special case command 0; everything else results in a process-owned,
+        // split-phase call.
+        if command_number == 0 {
+            // How many ports
+            return CommandReturn::success_u32(ports.len() as u32);
+        }
+
         // On any command other than 0, we check for ports length.
-        if command_number != 0 && port >= ports.len() {
+        if port >= ports.len() {
             return CommandReturn::failure(ErrorCode::INVAL);
         }
 
-        match command_number {
-            // How many ports
-            0 => CommandReturn::success_u32(ports.len() as u32),
+        // On any command other than 0, we check if another command is in flight
+        if self.configuring_process.is_some() {
+            return CommandReturn::failure(ErrorCode::BUSY);
+        };
 
+        let res = match command_number {
             // enable output
-            1 => ports[port].make_output(pin).into(),
+            1 => ports[port].make_output(pin),
 
             // set pin
-            2 => ports[port].set(pin).into(),
+            2 => ports[port].set(pin),
 
             // clear pin
-            3 => ports[port].clear(pin).into(),
+            3 => ports[port].clear(pin),
 
             // toggle pin
-            4 => ports[port].toggle(pin).into(),
+            4 => ports[port].toggle(pin),
 
             // enable and configure input
-            5 => self.configure_input_pin(port, pin, other & 0xFF).into(),
+            5 => self.configure_input_pin(port, pin, other & 0xFF),
 
             // read input
-            6 => ports[port].read(pin).into(),
+            6 => ports[port].read(pin),
 
             // enable interrupt on pin
-            7 => self.configure_interrupt(port, pin, other & 0xFF).into(),
+            7 => self.configure_interrupt(port, pin, other & 0xFF),
 
             // disable interrupt on pin
-            8 => ports[port].disable_interrupt(pin).into(),
+            8 => ports[port].disable_interrupt(pin),
 
             // disable pin
-            9 => ports[port].disable(pin).into(),
+            9 => ports[port].disable(pin),
 
             // default
-            _ => CommandReturn::failure(ErrorCode::NOSUPPORT),
+            _ => return CommandReturn::failure(ErrorCode::NOSUPPORT),
+        };
+
+        // If any async command kicked off, note that the peripheral is busy
+        // and which process to return the command result to
+        if res.is_ok() {
+            self.configuring_process.set(process_id);
         }
+
+        res.into()
     }
 }


### PR DESCRIPTION
### Pull Request Overview

This is one of the capsules blocking #2462.

In contrast to the other PRs in the #2462 series, there's not really so much
meaning to "owning" an Async GPIO peripheral, so this PR effectively
just virtualizes the peripheral rather than enforcing single-process semantics.

Current GPIO HIL semantics notify *all* processes of interrupts to any
pin with interrupts configured (and it's left to higher layers to filter
activity based on which pin generated their interrupt). For Async GPIO,
this is awkward to virtualize (or not), as there is no owning process of
a pin for activity interrupts, but there is for configuration result
interrupts.

Note, however, that the underlying hardware likely can't handle multiple
concurrent configurations from multiple apps.
For now then, this capsule tracks a configuration while it is in flight
and notifies the correct process that their configuration has succeeded.
It does not track pin "owners", and notifies all apps of events on pins
(which is the same behavior as the regular gpio capsule).
In the rare case where two apps attempt concurrent configuration
requests, the later app will receive `EBUSY`. A retry loop should be
sufficient for most apps to handle this case.


### Testing Strategy

Compiling.


### TODO or Help Wanted

Not sure I love the 'notify all apps of all GPIO events' behavior, but
I believe we made that call because assigning owners to each pin
would incur non-trivial memory overhead. Might be worth thinking
through whether the same argument holds for Aysnc GPIO, but this
PR probably isn't the best place for that discussion.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
