### PR TITLE
chips: e310x: check for pending mtimer interrupt

### DIFF
--- a/chips/e310x/src/chip.rs
+++ b/chips/e310x/src/chip.rs
@@ -150,6 +150,14 @@ impl<'a, A: 'static + Alarm<'static>, I: InterruptService<()> + 'a> kernel::Chip
     }
 
     fn has_pending_interrupts(&self) -> bool {
+        // First check if the global machine timer interrupt is set.
+        // We would also need to check for additional global interrupt bits
+        // if there were to be used for anything in the future.
+        if CSR.mip.is_set(mip::mtimer) {
+            return true;
+        }
+
+        // Then we can check the PLIC.
         self.plic.get_saved_interrupts().is_some()
     }
 


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes the e310x chip to check for the mtimer interrupt when checking if any interrupts are pending.

This allows the timer (and hence the blink app) to work.


### Testing Strategy

Running the blink app on hifive1b.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
