### PR TITLE
capsules/l3gd20: migrating non-virtualized driver to Grants

### DIFF
--- a/boards/components/src/l3gd20.rs
+++ b/boards/components/src/l3gd20.rs
@@ -64,7 +64,7 @@ impl<S: 'static + spi::SpiMaster> Component for L3gd20SpiComponent<S> {
     unsafe fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
         let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
         let grant = self.board_kernel.create_grant(&grant_cap);
-        
+
         let l3gd20 = static_init_half!(
             static_buffer.1,
             L3gd20Spi<'static>,

--- a/boards/components/src/l3gd20.rs
+++ b/boards/components/src/l3gd20.rs
@@ -20,9 +20,10 @@ use capsules::l3gd20::L3gd20Spi;
 use capsules::virtual_spi::VirtualSpiMasterDevice;
 use core::marker::PhantomData;
 use core::mem::MaybeUninit;
+use kernel::capabilities;
 use kernel::component::Component;
 use kernel::hil::spi;
-use kernel::static_init_half;
+use kernel::{create_capability, static_init_half};
 
 // Setup static space for the objects.
 #[macro_export]
@@ -41,12 +42,14 @@ macro_rules! l3gd20_spi_component_helper {
 
 pub struct L3gd20SpiComponent<S: 'static + spi::SpiMaster> {
     _select: PhantomData<S>,
+    board_kernel: &'static kernel::Kernel,
 }
 
 impl<S: 'static + spi::SpiMaster> L3gd20SpiComponent<S> {
-    pub fn new() -> L3gd20SpiComponent<S> {
+    pub fn new(board_kernel: &'static kernel::Kernel) -> L3gd20SpiComponent<S> {
         L3gd20SpiComponent {
             _select: PhantomData,
+            board_kernel: board_kernel,
         }
     }
 }
@@ -59,13 +62,17 @@ impl<S: 'static + spi::SpiMaster> Component for L3gd20SpiComponent<S> {
     type Output = &'static L3gd20Spi<'static>;
 
     unsafe fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
+        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
+        let grant = self.board_kernel.create_grant(&grant_cap);
+        
         let l3gd20 = static_init_half!(
             static_buffer.1,
             L3gd20Spi<'static>,
             L3gd20Spi::new(
                 static_buffer.0,
                 &mut capsules::l3gd20::TXBUFFER,
-                &mut capsules::l3gd20::RXBUFFER
+                &mut capsules::l3gd20::RXBUFFER,
+                grant
             )
         );
         static_buffer.0.set_client(l3gd20);

--- a/boards/stm32f3discovery/src/main.rs
+++ b/boards/stm32f3discovery/src/main.rs
@@ -594,7 +594,7 @@ pub unsafe fn main() {
     let spi_mux = components::spi::SpiMuxComponent::new(&peripherals.spi1)
         .finalize(components::spi_mux_component_helper!(stm32f303xc::spi::Spi));
 
-    let l3gd20 = components::l3gd20::L3gd20SpiComponent::new().finalize(
+    let l3gd20 = components::l3gd20::L3gd20SpiComponent::new(board_kernel).finalize(
         components::l3gd20_spi_component_helper!(
             // spi type
             stm32f303xc::spi::Spi,

--- a/capsules/src/l3gd20.rs
+++ b/capsules/src/l3gd20.rs
@@ -404,8 +404,7 @@ impl Driver for L3gd20Spi<'_> {
         mut upcall: Upcall,
         process_id: ProcessId,
     ) -> Result<Upcall, (Upcall, ErrorCode)> {
-        let res =
-            self
+        let res = self
             .grants
             .enter(process_id, |app| {
                 match subscribe_num {
@@ -420,7 +419,7 @@ impl Driver for L3gd20Spi<'_> {
             .unwrap_or_else(|e| Err(e.into()));
         match res {
             Ok(()) => Ok(upcall),
-            Err(e) => Err((upcall, e))
+            Err(e) => Err((upcall, e)),
         }
     }
 }

--- a/capsules/src/l3gd20.rs
+++ b/capsules/src/l3gd20.rs
@@ -182,7 +182,7 @@ pub struct App {
 impl Default for App {
     fn default() -> App {
         App {
-            upcall: Upcall::default()
+            upcall: Upcall::default(),
         }
     }
 }
@@ -220,7 +220,7 @@ impl<'a> L3gd20Spi<'a> {
             hpf_divider: Cell::new(0),
             scale: Cell::new(0),
             current_process: OptionalCell::empty(),
-            grants: grants,            
+            grants: grants,
             nine_dof_client: OptionalCell::empty(),
             temperature_client: OptionalCell::empty(),
         }
@@ -331,7 +331,7 @@ impl Driver for L3gd20Spi<'_> {
         } else {
             return CommandReturn::failure(ErrorCode::RESERVE);
         }
-        
+
         match command_num {
             // Check is sensor is correctly connected
             1 => {
@@ -445,11 +445,10 @@ impl spi::SpiMasterClient for L3gd20Spi<'_> {
                         } else {
                             false
                         };
-                        app.upcall
-                            .schedule(1, if present { 1 } else { 0 }, 0);
+                        app.upcall.schedule(1, if present { 1 } else { 0 }, 0);
                         L3gd20Status::Idle
                     }
-                    
+
                     L3gd20Status::ReadXYZ => {
                         let mut x: usize = 0;
                         let mut y: usize = 0;
@@ -463,19 +462,22 @@ impl spi::SpiMasterClient for L3gd20Spi<'_> {
                                         1 => L3GD20_SCALE_500,
                                         _ => L3GD20_SCALE_2000,
                                     };
-                                    let x: usize = ((buf[1] as i16 | ((buf[2] as i16) << 8)) as isize
-                                                    * scale
-                                                    / 100000) as usize;
-                                    let y: usize = ((buf[3] as i16 | ((buf[4] as i16) << 8)) as isize
-                                                    * scale
-                                                    / 100000) as usize;
-                                    let z: usize = ((buf[5] as i16 | ((buf[6] as i16) << 8)) as isize
-                                                    * scale
-                                                    / 100000) as usize;
+                                    let x: usize =
+                                        ((buf[1] as i16 | ((buf[2] as i16) << 8)) as isize * scale
+                                            / 100000)
+                                            as usize;
+                                    let y: usize =
+                                        ((buf[3] as i16 | ((buf[4] as i16) << 8)) as isize * scale
+                                            / 100000)
+                                            as usize;
+                                    let z: usize =
+                                        ((buf[5] as i16 | ((buf[6] as i16) << 8)) as isize * scale
+                                            / 100000)
+                                            as usize;
                                     client.callback(x, y, z);
                                 });
                                 // actual computation is this one
-                                
+
                                 x = (buf[1] as i16 | ((buf[2] as i16) << 8)) as usize;
                                 y = (buf[3] as i16 | ((buf[4] as i16) << 8)) as usize;
                                 z = (buf[5] as i16 | ((buf[6] as i16) << 8)) as usize;
@@ -496,7 +498,7 @@ impl spi::SpiMasterClient for L3gd20Spi<'_> {
                         }
                         L3gd20Status::Idle
                     }
-                    
+
                     L3gd20Status::ReadTemperature => {
                         let mut temperature: usize = 0;
                         let value = if let Some(ref buf) = read_buffer {
@@ -522,7 +524,7 @@ impl spi::SpiMasterClient for L3gd20Spi<'_> {
                         }
                         L3gd20Status::Idle
                     }
-                    
+
                     _ => {
                         app.upcall.schedule(0, 0, 0);
                         L3gd20Status::Idle
@@ -536,7 +538,7 @@ impl spi::SpiMasterClient for L3gd20Spi<'_> {
         }
     }
 }
-        
+
 impl<'a> sensors::NineDof<'a> for L3gd20Spi<'a> {
     fn set_client(&self, nine_dof_client: &'a dyn sensors::NineDofClient) {
         self.nine_dof_client.replace(nine_dof_client);


### PR DESCRIPTION
### Pull Request Overview

As part of #2462, this migrates the l3gd20 nonvirtualized userspace driver to keep process state in a Grant region. It adopts the mechanism to reserve a driver as introduced in #2521.

### Testing Strategy

This pull request was tested by compiling.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
