### PR TITLE
capsules/lsm303agr: migrating non-virtualized driver to Grants

### DIFF
--- a/boards/components/src/lsm303agr.rs
+++ b/boards/components/src/lsm303agr.rs
@@ -59,13 +59,13 @@ macro_rules! lsm303agr_i2c_component_helper {
 }
 
 pub struct Lsm303agrI2CComponent {
-    board_kernel: &'static kernel::Kernel
+    board_kernel: &'static kernel::Kernel,
 }
 
 impl Lsm303agrI2CComponent {
     pub fn new(board_kernel: &'static kernel::Kernel) -> Lsm303agrI2CComponent {
         Lsm303agrI2CComponent {
-            board_kernel: board_kernel
+            board_kernel: board_kernel,
         }
     }
 }
@@ -85,10 +85,7 @@ impl Component for Lsm303agrI2CComponent {
         let lsm303agr = static_init_half!(
             static_buffer.3,
             Lsm303agrI2C<'static>,
-            Lsm303agrI2C::new(static_buffer.0,
-                              static_buffer.1,
-                              static_buffer.2,
-                              grant)
+            Lsm303agrI2C::new(static_buffer.0, static_buffer.1, static_buffer.2, grant)
         );
         static_buffer.0.set_client(lsm303agr);
         static_buffer.1.set_client(lsm303agr);

--- a/boards/components/src/lsm303agr.rs
+++ b/boards/components/src/lsm303agr.rs
@@ -21,8 +21,9 @@
 use capsules::lsm303agr::Lsm303agrI2C;
 use capsules::virtual_i2c::I2CDevice;
 use core::mem::MaybeUninit;
+use kernel::capabilities;
 use kernel::component::Component;
-use kernel::static_init_half;
+use kernel::{create_capability, static_init_half};
 
 // Setup static space for the objects.
 #[macro_export]
@@ -57,11 +58,15 @@ macro_rules! lsm303agr_i2c_component_helper {
     }};
 }
 
-pub struct Lsm303agrI2CComponent {}
+pub struct Lsm303agrI2CComponent {
+    board_kernel: &'static kernel::Kernel
+}
 
 impl Lsm303agrI2CComponent {
-    pub fn new() -> Lsm303agrI2CComponent {
-        Lsm303agrI2CComponent {}
+    pub fn new(board_kernel: &'static kernel::Kernel) -> Lsm303agrI2CComponent {
+        Lsm303agrI2CComponent {
+            board_kernel: board_kernel
+        }
     }
 }
 
@@ -75,10 +80,15 @@ impl Component for Lsm303agrI2CComponent {
     type Output = &'static Lsm303agrI2C<'static>;
 
     unsafe fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
+        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
+        let grant = self.board_kernel.create_grant(&grant_cap);
         let lsm303agr = static_init_half!(
             static_buffer.3,
             Lsm303agrI2C<'static>,
-            Lsm303agrI2C::new(static_buffer.0, static_buffer.1, static_buffer.2)
+            Lsm303agrI2C::new(static_buffer.0,
+                              static_buffer.1,
+                              static_buffer.2,
+                              grant)
         );
         static_buffer.0.set_client(lsm303agr);
         static_buffer.1.set_client(lsm303agr);

--- a/boards/microbit_v2/src/main.rs
+++ b/boards/microbit_v2/src/main.rs
@@ -339,7 +339,7 @@ pub unsafe fn main() {
 
     // LSM303AGR
 
-    let lsm303agr = components::lsm303agr::Lsm303agrI2CComponent::new()
+    let lsm303agr = components::lsm303agr::Lsm303agrI2CComponent::new(board_kernel)
         .finalize(components::lsm303agr_i2c_component_helper!(sensors_i2c_bus));
 
     lsm303agr.configure(

--- a/capsules/src/lsm303agr.rs
+++ b/capsules/src/lsm303agr.rs
@@ -543,7 +543,6 @@ impl Driver for Lsm303agrI2C<'_> {
         }
 
         match command_num {
-            0 => CommandReturn::success(),
             // Check is sensor is correctly connected
             1 => {
                 if self.state.get() == State::Idle {

--- a/capsules/src/lsm303agr.rs
+++ b/capsules/src/lsm303agr.rs
@@ -135,7 +135,7 @@ enum State {
 
 #[derive(Default)]
 pub struct App {
-    upcall: Upcall
+    upcall: Upcall,
 }
 
 pub struct Lsm303agrI2C<'a> {
@@ -162,7 +162,7 @@ impl<'a> Lsm303agrI2C<'a> {
         i2c_accelerometer: &'a dyn i2c::I2CDevice,
         i2c_magnetometer: &'a dyn i2c::I2CDevice,
         buffer: &'static mut [u8],
-        grant: Grant<App>
+        grant: Grant<App>,
     ) -> Lsm303agrI2C<'a> {
         // setup and return struct
         Lsm303agrI2C {
@@ -355,7 +355,8 @@ impl i2c::I2CClient for Lsm303agrI2C<'_> {
                 let set_scale_and_resolution = error == Error::CommandComplete;
                 self.owning_process.map(|pid| {
                     let _res = self.apps.enter(*pid, |app| {
-                        app.upcall.schedule(if set_scale_and_resolution { 1 } else { 0 }, 0, 0);
+                        app.upcall
+                            .schedule(if set_scale_and_resolution { 1 } else { 0 }, 0, 0);
                     });
                 });
                 self.buffer.replace(buffer);
@@ -415,7 +416,8 @@ impl i2c::I2CClient for Lsm303agrI2C<'_> {
                 let set_magneto_data_rate = error == Error::CommandComplete;
                 self.owning_process.map(|pid| {
                     let _res = self.apps.enter(*pid, |app| {
-                        app.upcall.schedule(if set_magneto_data_rate { 1 } else { 0 }, 0, 0);
+                        app.upcall
+                            .schedule(if set_magneto_data_rate { 1 } else { 0 }, 0, 0);
                     });
                 });
                 self.buffer.replace(buffer);
@@ -528,7 +530,7 @@ impl Driver for Lsm303agrI2C<'_> {
             // unconditionally
             return CommandReturn::success();
         }
-        
+
         let match_or_empty_or_nonexistant = self.owning_process.map_or(true, |current_process| {
             self.apps
                 .enter(*current_process, |_| current_process == &process_id)


### PR DESCRIPTION
### Pull Request Overview

As part of #2462, this migrates the lsm303agr nonvirtualized userspace driver to keep process state in a Grant region. It adopts the mechanism to reserve a driver as introduced in #2521.

### Testing Strategy

This pull request was tested by compiling.


### TODO or Help Wanted

N/A

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
