### PR TITLE
Nonvirtualized userspace driver Grant migration fixes

### DIFF
--- a/capsules/src/analog_comparator.rs
+++ b/capsules/src/analog_comparator.rs
@@ -196,8 +196,8 @@ impl<'a, A: hil::analog_comparator::AnalogComparator<'a>> hil::analog_comparator
 {
     /// Upcall to userland, signaling the application
     fn fired(&self, channel: usize) {
-        self.current_process.take().map(|appid| {
-            let _ = self.grants.enter(appid, |app| {
+        self.current_process.map(|appid| {
+            let _ = self.grants.enter(*appid, |app| {
                 app.callback.schedule(channel, 0, 0);
             });
         });


### PR DESCRIPTION
### Pull Request Overview

Two fixes (commits) for the ports to nonvirtualized drivers:

- capsules/spi_controller: properly propagate Grant enter errors

  As part of the transition of nonvirtualized userspace drivers to use Grants for #2462, the mechanism used to store appslices and upcalls did not propagate Grant enter errors back to userspace. This commit uses ErrorCode's From implementation to propagate these error cases to userspace.

  Thanks to @phil-levis for reporting!

- capsules/analog_comparator: don't reset current_process on upcall 


### Testing Strategy

This pull request was tested by compiling.


### TODO or Help Wanted

@bradjc Not sure about the second one... That might just work as intended? Though it would work differently compared to the other drivers then.


### Documentation Updated

- [x] ~Updated the relevant files in `/docs`,~ or no updates are required.

### Formatting

- [x] Ran `make prepush`.
