### PR TITLE
Initial support for the ESP32-C3 early dev board

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ boards/swervolf/binary.hex
 boards/swervolf/build/
 boards/swervolf/fusesoc.conf
 boards/swervolf/fusesoc_libraries/
+
+# ESP C3 temp hex
+boards/esp32-c3-devkitM-1/binary.hex

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ members = [
     "chips/e310x",
     "chips/earlgrey",
     "chips/esp32",
+    "chips/esp32-c3",
     "chips/imxrt10xx",
     "chips/litex",
     "chips/litex_vexriscv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ members = [
     "chips/arty_e21_chip",
     "chips/e310x",
     "chips/earlgrey",
+    "chips/esp32",
     "chips/imxrt10xx",
     "chips/litex",
     "chips/litex_vexriscv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "boards/acd52832",
     "boards/arty_e21",
     "boards/earlgrey-nexysvideo",
+    "boards/esp32-c3-devkitM-1",
     "boards/clue_nrf52840",
     "boards/hail",
     "boards/hifive1",

--- a/boards/README.md
+++ b/boards/README.md
@@ -29,6 +29,7 @@ that Tock supports.
 | [Earlgrey on Nexys Video](earlgrey-nexysvideo/README.md)             | RISC-V RV32IMC  | EarlGrey       | custom     | custom         | Yes (5.1)     |
 | [LiteX on Digilent Arty A-7](litex/arty/README.md)                   | RISC-V RV32I    | LiteX+VexRiscV | custom     | custom         | No            |
 | [Verilated LiteX Simulation](litex/sim/README.md)                    | RISC-V RV32I    | LiteX+VexRiscv | custom     | custom         | No            |
+| [ESP32-C3-DevKitM-1](esp32-c3-devkitM-1/README.md)                   | RISC-V-ish RV32I| ESP32-C3       | custom     | custom         | No            |
 
 # Out of Tree Boards
 

--- a/boards/esp32-c3-devkitM-1/.cargo/config
+++ b/boards/esp32-c3-devkitM-1/.cargo/config
@@ -1,0 +1,2 @@
+[target.'cfg(target_arch = "riscv32")']
+runner = "./run.sh"

--- a/boards/esp32-c3-devkitM-1/Cargo.toml
+++ b/boards/esp32-c3-devkitM-1/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "esp32-c3-board"
+version = "0.1.0"
+authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+build = "build.rs"
+edition = "2018"
+
+[dependencies]
+components = { path = "../components" }
+rv32i = { path = "../../arch/rv32i" }
+capsules = { path = "../../capsules" }
+kernel = { path = "../../kernel" }
+esp32 = { path = "../../chips/esp32" }
+esp32-c3 = { path = "../../chips/esp32-c3" }

--- a/boards/esp32-c3-devkitM-1/Makefile
+++ b/boards/esp32-c3-devkitM-1/Makefile
@@ -12,3 +12,9 @@ install: flash
 flash: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
 	esptool.py --port /dev/ttyUSB0 --chip esp32c3 elf2image --use_segments --output binary.hex $^
 	esptool.py --port /dev/ttyUSB0 --chip esp32c3 write_flash --flash_mode dio --flash_size detect --flash_freq 80m  0x0 binary.hex
+
+test:
+	mkdir -p $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/
+	$(Q)cp layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/
+	$(Q)cp ../kernel_layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/
+	$(Q)RUSTFLAGS="$(RUSTC_FLAGS_TOCK)" $(CARGO) test $(CARGO_FLAGS_TOCK) --bin $(PLATFORM) --release

--- a/boards/esp32-c3-devkitM-1/Makefile
+++ b/boards/esp32-c3-devkitM-1/Makefile
@@ -1,0 +1,14 @@
+# Makefile for building the tock kernel for the ESP32-C3 platform
+
+TARGET=riscv32imc-unknown-none-elf
+PLATFORM=esp32-c3-board
+
+include ../Makefile.common
+
+# Default target for installing the kernel.
+.PHONY: install
+install: flash
+
+flash: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
+	esptool.py --port /dev/ttyUSB0 --chip esp32c3 elf2image --use_segments --output binary.hex $^
+	esptool.py --port /dev/ttyUSB0 --chip esp32c3 write_flash --flash_mode dio --flash_size detect --flash_freq 80m  0x0 binary.hex

--- a/boards/esp32-c3-devkitM-1/README.md
+++ b/boards/esp32-c3-devkitM-1/README.md
@@ -1,0 +1,102 @@
+ESP32-C3 Board
+==============
+
+ESP32-C3 is a system on a chip that integrates the following features:
+ * Wi-Fi (2.4 GHz band)
+ * Bluetooth Low Energy
+ * High performance 32-bit RISC-V single-core processor
+ * Multiple peripherals
+ * Built-in security hardware
+
+Powered by 40 nm technology, ESP32-C3 provides a robust, highly integrated
+platform, which helps meet the continuous demands for efficient power usage,
+compact design, security, high performance, and reliability.
+
+Setup
+-----
+
+Install the ESP tool
+
+```shell
+git clone https://github.com/espressif/esptool.git
+cd esptool
+pip install --user -e .
+```
+
+The first time you are installing Tock you probably want to erase the
+flash first. This can be done with:
+
+```shell
+esptool.py --port /dev/ttyUSB0 --chip esp32c3 erase_flash
+```
+
+After that you can run:
+
+```shell
+make flash
+```
+
+To install Tock.
+
+You can then connect to the serial device exposed from the USB header on the
+board.
+
+You can use the `RST` button on the board to reset Tock. You should see
+something similar to:
+
+```text
+ESP-ROM:esp32c3-20200918
+Build:Sep 18 2020
+rst:0x1 (POWERON),boot:0xc (SPI_FAST_FLASH_BOOT)
+SPIWP:0xee
+mode:DIO, clock div:1
+load:0x40380000,len:0xd15c
+load:0x4038d15c,len:0xccc
+load:0x00000000,len:0x21a0
+load:0x42000000,len:0x24
+SHA-256 comparison failed:
+Calculated: 63cf02fff6c0e3f60d140721bbd74adf0072c368b3bfafb6d4195511a55ba8c9
+Expected: f4494a64f93940e1bb4d0edce76f041e6a411337097c697b254b784af1e2bcd5
+Attempting to boot anyway...
+entry 0x40380000
+ESP32-C3 initialisation complete.
+Entering main loop.
+```
+
+```shell
+screen /dev/ttyUSB0  115200
+```
+
+JTAG Debugging
+--------------
+
+In order to use JTAG debugging you first need to build a fork of OpenOCD
+
+```shell
+git clone https://github.com/espressif/openocd-esp32
+cd openocd-esp32
+./bootstrap
+./configure --disable-werror
+make -j8
+```
+
+Then connect an [FDTI C232HM](https://ftdichip.com/products/c232hm-ddhsl-0-2/)
+cable as described here:
+https://docs.espressif.com/projects/esp-idf/en/latest/esp32c3/api-guides/jtag-debugging/configure-other-jtag.html.
+
+Make sure that the board is powered by the JTAG and that the usual USB
+connection is unplugged when doing JTAG debugging.
+
+Then run OpenOCD
+
+```shell
+./src/openocd -s tcl -f tcl/board/esp32c3-ftdi.cfg
+```
+
+Then connect from GDB
+
+```shell
+target remote :3333
+set remote hardware-watchpoint-limit 2
+set mem inaccessible-by-default off
+```

--- a/boards/esp32-c3-devkitM-1/README.md
+++ b/boards/esp32-c3-devkitM-1/README.md
@@ -4,7 +4,7 @@ ESP32-C3 Board
 ESP32-C3 is a system on a chip that integrates the following features:
  * Wi-Fi (2.4 GHz band)
  * Bluetooth Low Energy
- * High performance 32-bit RISC-V single-core processor
+ * High performance 32-bit RISC-V-ish single-core processor
  * Multiple peripherals
  * Built-in security hardware
 

--- a/boards/esp32-c3-devkitM-1/build.rs
+++ b/boards/esp32-c3-devkitM-1/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    println!("cargo:rerun-if-changed=layout.ld");
+    println!("cargo:rerun-if-changed=../kernel_layout.ld");
+}

--- a/boards/esp32-c3-devkitM-1/layout.ld
+++ b/boards/esp32-c3-devkitM-1/layout.ld
@@ -1,0 +1,10 @@
+MEMORY
+{
+  rom (rx)  : ORIGIN = 0x40380000, LENGTH = 0x30000
+  ram (rwx) : ORIGIN = 0x403B0000, LENGTH = 0x30000
+  prog (rx) : ORIGIN = 0x42000000, LENGTH = 0x80000
+}
+
+MPU_MIN_ALIGN = 1K;
+
+INCLUDE ../kernel_layout.ld

--- a/boards/esp32-c3-devkitM-1/run.sh
+++ b/boards/esp32-c3-devkitM-1/run.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+esptool.py --port /dev/ttyUSB0 --chip esp32c3 elf2image --use_segments --output binary.hex ${1}
+esptool.py --port /dev/ttyUSB0 --chip esp32c3 write_flash --flash_mode dio --flash_size detect --flash_freq 80m  0x0 binary.hex

--- a/boards/esp32-c3-devkitM-1/src/io.rs
+++ b/boards/esp32-c3-devkitM-1/src/io.rs
@@ -1,0 +1,44 @@
+use core::fmt::Write;
+use core::panic::PanicInfo;
+use core::str;
+use kernel::debug;
+use kernel::debug::IoWrite;
+
+use crate::CHIP;
+use crate::PROCESSES;
+
+struct Writer {}
+
+static mut WRITER: Writer = Writer {};
+
+impl Write for Writer {
+    fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
+        self.write(s.as_bytes());
+        Ok(())
+    }
+}
+
+impl IoWrite for Writer {
+    fn write(&mut self, buf: &[u8]) {
+        let uart = esp32::uart::Uart::new(esp32::uart::UART0_BASE);
+        uart.disable_tx_interrupt();
+        uart.disable_rx_interrupt();
+        uart.transmit_sync(buf);
+    }
+}
+
+/// Panic handler.
+#[cfg(not(test))]
+#[no_mangle]
+#[panic_handler]
+pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
+    let writer = &mut WRITER;
+
+    debug::panic_banner(writer, pi);
+    debug::panic_cpu_state(&CHIP, writer);
+    debug::panic_process_info(&PROCESSES, writer);
+
+    loop {
+        rv32i::support::nop();
+    }
+}

--- a/boards/esp32-c3-devkitM-1/src/io.rs
+++ b/boards/esp32-c3-devkitM-1/src/io.rs
@@ -42,3 +42,15 @@ pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
         rv32i::support::nop();
     }
 }
+
+#[cfg(test)]
+#[no_mangle]
+#[panic_handler]
+pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
+    let writer = &mut WRITER;
+
+    debug::panic_print(writer, pi, &rv32i::support::nop, &PROCESSES, &CHIP);
+
+    let _ = writeln!(writer, "{}", pi);
+    loop {}
+}

--- a/boards/esp32-c3-devkitM-1/src/main.rs
+++ b/boards/esp32-c3-devkitM-1/src/main.rs
@@ -1,0 +1,189 @@
+//! Board file for ESP32-C3 RISC-V development platform.
+//!
+
+#![no_std]
+// Disable this attribute when documenting, as a workaround for
+// https://github.com/rust-lang/rust/issues/62184.
+#![cfg_attr(not(doc), no_main)]
+
+use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
+use esp32_c3::chip::Esp32C3DefaultPeripherals;
+use kernel::capabilities;
+use kernel::common::dynamic_deferred_call::{DynamicDeferredCall, DynamicDeferredCallClientState};
+use kernel::common::registers::interfaces::ReadWriteable;
+use kernel::component::Component;
+use kernel::hil;
+use kernel::Platform;
+use kernel::{create_capability, debug, static_init};
+use rv32i::csr;
+
+pub mod io;
+
+pub const NUM_PROCS: usize = 4;
+//
+// Actual memory for holding the active process structures. Need an empty list
+// at least.
+static mut PROCESSES: [Option<&'static dyn kernel::procs::Process>; NUM_PROCS] = [None; NUM_PROCS];
+
+// Reference to the chip for panic dumps.
+static mut CHIP: Option<&'static esp32_c3::chip::Esp32C3<Esp32C3DefaultPeripherals>> = None;
+
+// How should the kernel respond when a process faults.
+const FAULT_RESPONSE: kernel::procs::PanicFaultPolicy = kernel::procs::PanicFaultPolicy {};
+
+/// Dummy buffer that causes the linker to reserve enough space for the stack.
+#[no_mangle]
+#[link_section = ".stack_buffer"]
+pub static mut STACK_MEMORY: [u8; 0x900] = [0; 0x900];
+
+/// A structure representing this platform that holds references to all
+/// capsules for this platform. We've included an alarm and console.
+struct Esp32C3Board {
+    console: &'static capsules::console::Console<'static>,
+    alarm: &'static capsules::alarm::AlarmDriver<
+        'static,
+        VirtualMuxAlarm<'static, esp32::timg::TimG<'static>>,
+    >,
+}
+
+/// Mapping of integer syscalls to objects that implement syscalls.
+impl Platform for Esp32C3Board {
+    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    where
+        F: FnOnce(Option<&dyn kernel::Driver>) -> R,
+    {
+        match driver_num {
+            capsules::console::DRIVER_NUM => f(Some(self.console)),
+            capsules::alarm::DRIVER_NUM => f(Some(self.alarm)),
+            _ => f(None),
+        }
+    }
+}
+
+/// Main function called after RAM initialised.
+#[no_mangle]
+pub unsafe fn main() {
+    // only machine mode
+    rv32i::configure_trap_handler(rv32i::PermissionMode::Machine);
+
+    let peripherals = static_init!(Esp32C3DefaultPeripherals, Esp32C3DefaultPeripherals::new());
+
+    peripherals.timg0.disable_wdt();
+    peripherals.rtc_cntl.disable_wdt();
+    peripherals.rtc_cntl.disable_super_wdt();
+
+    // initialise capabilities
+    let process_mgmt_cap = create_capability!(capabilities::ProcessManagementCapability);
+    let memory_allocation_cap = create_capability!(capabilities::MemoryAllocationCapability);
+
+    let main_loop_cap = create_capability!(capabilities::MainLoopCapability);
+
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
+
+    let dynamic_deferred_call_clients =
+        static_init!([DynamicDeferredCallClientState; 1], Default::default());
+    let dynamic_deferred_caller = static_init!(
+        DynamicDeferredCall,
+        DynamicDeferredCall::new(dynamic_deferred_call_clients)
+    );
+    DynamicDeferredCall::set_global_instance(dynamic_deferred_caller);
+
+    // Configure kernel debug gpios as early as possible
+    kernel::debug::assign_gpios(None, None, None);
+
+    // Create a shared UART channel for the console and for kernel debug.
+    let uart_mux = components::console::UartMuxComponent::new(
+        &peripherals.uart0,
+        115200,
+        dynamic_deferred_caller,
+    )
+    .finalize(());
+
+    // Create a shared virtualization mux layer on top of a single hardware
+    // alarm.
+    let mux_alarm = static_init!(
+        MuxAlarm<'static, esp32::timg::TimG>,
+        MuxAlarm::new(&peripherals.timg0)
+    );
+    hil::time::Alarm::set_alarm_client(&peripherals.timg0, mux_alarm);
+
+    // Alarm
+    let virtual_alarm_user = static_init!(
+        VirtualMuxAlarm<'static, esp32::timg::TimG>,
+        VirtualMuxAlarm::new(mux_alarm)
+    );
+    let alarm = static_init!(
+        capsules::alarm::AlarmDriver<'static, VirtualMuxAlarm<'static, esp32::timg::TimG>>,
+        capsules::alarm::AlarmDriver::new(
+            virtual_alarm_user,
+            board_kernel.create_grant(&memory_allocation_cap)
+        )
+    );
+    hil::time::Alarm::set_alarm_client(virtual_alarm_user, alarm);
+
+    let chip = static_init!(
+        esp32_c3::chip::Esp32C3<
+            Esp32C3DefaultPeripherals,
+        >,
+        esp32_c3::chip::Esp32C3::new(peripherals)
+    );
+    CHIP = Some(chip);
+
+    // Need to enable all interrupts for Tock Kernel
+    chip.enable_pic_interrupts();
+
+    // enable interrupts globally
+    csr::CSR.mstatus.modify(csr::mstatus::mstatus::mie::SET);
+
+    // Setup the console.
+    let console = components::console::ConsoleComponent::new(board_kernel, uart_mux).finalize(());
+    // Create the debugger object that handles calls to `debug!()`.
+    components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
+
+    debug!("ESP32-C3 initialisation complete.");
+    debug!("Entering main loop.");
+
+    /// These symbols are defined in the linker script.
+    extern "C" {
+        /// Beginning of the ROM region containing app images.
+        static _sapps: u8;
+        /// End of the ROM region containing app images.
+        static _eapps: u8;
+        /// Beginning of the RAM region for app memory.
+        static mut _sappmem: u8;
+        /// End of the RAM region for app memory.
+        static _eappmem: u8;
+    }
+
+    let esp32_c3_board = Esp32C3Board { console, alarm };
+
+    kernel::procs::load_processes(
+        board_kernel,
+        chip,
+        core::slice::from_raw_parts(
+            &_sapps as *const u8,
+            &_eapps as *const u8 as usize - &_sapps as *const u8 as usize,
+        ),
+        core::slice::from_raw_parts_mut(
+            &mut _sappmem as *mut u8,
+            &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
+        ),
+        &mut PROCESSES,
+        &FAULT_RESPONSE,
+        &process_mgmt_cap,
+    )
+    .unwrap_or_else(|err| {
+        debug!("Error loading processes!");
+        debug!("{:?}", err);
+    });
+
+    let scheduler = components::sched::cooperative::CooperativeComponent::new(&PROCESSES)
+        .finalize(components::coop_component_helper!(NUM_PROCS));
+    board_kernel.kernel_loop(
+        &esp32_c3_board,
+        chip,
+        None::<&kernel::ipc::IPC<NUM_PROCS>>,
+        scheduler,
+        &main_loop_cap,
+    );
+}

--- a/boards/esp32-c3-devkitM-1/src/main.rs
+++ b/boards/esp32-c3-devkitM-1/src/main.rs
@@ -5,6 +5,9 @@
 // Disable this attribute when documenting, as a workaround for
 // https://github.com/rust-lang/rust/issues/62184.
 #![cfg_attr(not(doc), no_main)]
+#![feature(custom_test_frameworks)]
+#![test_runner(test_runner)]
+#![reexport_test_harness_main = "test_main"]
 
 use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use esp32_c3::chip::Esp32C3DefaultPeripherals;
@@ -12,14 +15,16 @@ use kernel::capabilities;
 use kernel::common::dynamic_deferred_call::{DynamicDeferredCall, DynamicDeferredCallClientState};
 use kernel::common::registers::interfaces::ReadWriteable;
 use kernel::component::Component;
-use kernel::hil;
-use kernel::Platform;
-use kernel::{create_capability, debug, static_init};
+use kernel::{create_capability, debug, hil, static_init, Platform};
 use rv32i::csr;
 
 pub mod io;
 
-pub const NUM_PROCS: usize = 4;
+#[cfg(test)]
+mod tests;
+
+const NUM_PROCS: usize = 4;
+const NUM_UPCALLS_IPC: usize = NUM_PROCS + 1;
 //
 // Actual memory for holding the active process structures. Need an empty list
 // at least.
@@ -30,6 +35,24 @@ static mut CHIP: Option<&'static esp32_c3::chip::Esp32C3<Esp32C3DefaultPeriphera
 
 // How should the kernel respond when a process faults.
 const FAULT_RESPONSE: kernel::procs::PanicFaultPolicy = kernel::procs::PanicFaultPolicy {};
+
+// Test access to the peripherals
+#[cfg(test)]
+static mut PERIPHERALS: Option<&'static Esp32C3DefaultPeripherals> = None;
+// Test access to scheduler
+#[cfg(test)]
+static mut SCHEDULER: Option<&kernel::PrioritySched> = None;
+// Test access to board
+#[cfg(test)]
+static mut BOARD: Option<&'static kernel::Kernel> = None;
+// Test access to platform
+#[cfg(test)]
+static mut PLATFORM: Option<&'static Esp32C3Board> = None;
+// Test access to main loop capability
+#[cfg(test)]
+static mut MAIN_CAP: Option<&dyn kernel::capabilities::MainLoopCapability> = None;
+// Test access to alarm
+static mut ALARM: Option<&'static MuxAlarm<'static, esp32::timg::TimG<'static>>> = None;
 
 /// Dummy buffer that causes the linker to reserve enough space for the stack.
 #[no_mangle]
@@ -60,9 +83,12 @@ impl Platform for Esp32C3Board {
     }
 }
 
-/// Main function called after RAM initialised.
-#[no_mangle]
-pub unsafe fn main() {
+unsafe fn setup() -> (
+    &'static kernel::Kernel,
+    &'static Esp32C3Board,
+    &'static esp32_c3::chip::Esp32C3<'static, Esp32C3DefaultPeripherals<'static>>,
+    &'static Esp32C3DefaultPeripherals<'static>,
+) {
     // only machine mode
     rv32i::configure_trap_handler(rv32i::PermissionMode::Machine);
 
@@ -75,8 +101,6 @@ pub unsafe fn main() {
     // initialise capabilities
     let process_mgmt_cap = create_capability!(capabilities::ProcessManagementCapability);
     let memory_allocation_cap = create_capability!(capabilities::MemoryAllocationCapability);
-
-    let main_loop_cap = create_capability!(capabilities::MainLoopCapability);
 
     let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
 
@@ -107,6 +131,8 @@ pub unsafe fn main() {
     );
     hil::time::Alarm::set_alarm_client(&peripherals.timg0, mux_alarm);
 
+    ALARM = Some(mux_alarm);
+
     // Alarm
     let virtual_alarm_user = static_init!(
         VirtualMuxAlarm<'static, esp32::timg::TimG>,
@@ -116,7 +142,7 @@ pub unsafe fn main() {
         capsules::alarm::AlarmDriver<'static, VirtualMuxAlarm<'static, esp32::timg::TimG>>,
         capsules::alarm::AlarmDriver::new(
             virtual_alarm_user,
-            board_kernel.create_grant(&memory_allocation_cap)
+            board_kernel.create_grant(capsules::alarm::DRIVER_NUM, &memory_allocation_cap)
         )
     );
     hil::time::Alarm::set_alarm_client(virtual_alarm_user, alarm);
@@ -136,7 +162,12 @@ pub unsafe fn main() {
     csr::CSR.mstatus.modify(csr::mstatus::mstatus::mie::SET);
 
     // Setup the console.
-    let console = components::console::ConsoleComponent::new(board_kernel, uart_mux).finalize(());
+    let console = components::console::ConsoleComponent::new(
+        board_kernel,
+        capsules::console::DRIVER_NUM,
+        uart_mux,
+    )
+    .finalize(());
     // Create the debugger object that handles calls to `debug!()`.
     components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
 
@@ -155,7 +186,7 @@ pub unsafe fn main() {
         static _eappmem: u8;
     }
 
-    let esp32_c3_board = Esp32C3Board { console, alarm };
+    let esp32_c3_board = static_init!(Esp32C3Board, Esp32C3Board { console, alarm });
 
     kernel::procs::load_processes(
         board_kernel,
@@ -177,13 +208,59 @@ pub unsafe fn main() {
         debug!("{:?}", err);
     });
 
-    let scheduler = components::sched::cooperative::CooperativeComponent::new(&PROCESSES)
-        .finalize(components::coop_component_helper!(NUM_PROCS));
-    board_kernel.kernel_loop(
-        &esp32_c3_board,
-        chip,
-        None::<&kernel::ipc::IPC<NUM_PROCS>>,
-        scheduler,
-        &main_loop_cap,
-    );
+    (board_kernel, esp32_c3_board, chip, peripherals)
+}
+
+/// Main function.
+///
+/// This function is called from the arch crate after some very basic RISC-V
+/// setup and RAM initialization.
+#[no_mangle]
+pub unsafe fn main() {
+    #[cfg(test)]
+    test_main();
+
+    #[cfg(not(test))]
+    {
+        let (board_kernel, esp32_c3_board, chip, _peripherals) = setup();
+
+        let scheduler =
+            components::sched::priority::PriorityComponent::new(board_kernel).finalize(());
+        let main_loop_cap = create_capability!(capabilities::MainLoopCapability);
+
+        board_kernel.kernel_loop(
+            esp32_c3_board,
+            chip,
+            None::<&kernel::ipc::IPC<NUM_PROCS, NUM_UPCALLS_IPC>>,
+            scheduler,
+            &main_loop_cap,
+        );
+    }
+}
+
+#[cfg(test)]
+use kernel::watchdog::WatchDog;
+#[cfg(test)]
+use kernel::Chip;
+
+#[cfg(test)]
+fn test_runner(tests: &[&dyn Fn()]) {
+    unsafe {
+        let (board_kernel, esp32_c3_board, chip, peripherals) = setup();
+
+        BOARD = Some(board_kernel);
+        PLATFORM = Some(&esp32_c3_board);
+        PERIPHERALS = Some(peripherals);
+        SCHEDULER =
+            Some(components::sched::priority::PriorityComponent::new(board_kernel).finalize(()));
+        MAIN_CAP = Some(&create_capability!(capabilities::MainLoopCapability));
+
+        chip.watchdog().setup();
+
+        for test in tests {
+            test();
+        }
+    }
+
+    loop {}
 }

--- a/boards/esp32-c3-devkitM-1/src/main.rs
+++ b/boards/esp32-c3-devkitM-1/src/main.rs
@@ -175,6 +175,7 @@ unsafe fn setup() -> (
     CHIP = Some(chip);
 
     // Need to enable all interrupts for Tock Kernel
+    chip.map_pic_interrupts();
     chip.enable_pic_interrupts();
 
     // enable interrupts globally

--- a/boards/esp32-c3-devkitM-1/src/tests/mod.rs
+++ b/boards/esp32-c3-devkitM-1/src/tests/mod.rs
@@ -1,0 +1,51 @@
+use crate::BOARD;
+use crate::CHIP;
+use crate::MAIN_CAP;
+use crate::PLATFORM;
+use crate::SCHEDULER;
+use crate::{NUM_PROCS, NUM_UPCALLS_IPC};
+use kernel::debug;
+
+pub fn semihost_command_exit_success() -> ! {
+    // Exit QEMU with a return code of 0
+    unsafe {
+        rv32i::semihost_command(0x18, 0x20026, 0);
+    }
+    loop {}
+}
+
+pub fn semihost_command_exit_failure() -> ! {
+    // Exit QEMU with a return code of 1
+    unsafe {
+        rv32i::semihost_command(0x18, 1, 0);
+    }
+    loop {}
+}
+
+fn run_kernel_op(loops: usize) {
+    unsafe {
+        for _i in 0..loops {
+            BOARD.unwrap().kernel_loop_operation(
+                PLATFORM.unwrap(),
+                CHIP.unwrap(),
+                None::<&kernel::ipc::IPC<NUM_PROCS, NUM_UPCALLS_IPC>>,
+                SCHEDULER.unwrap(),
+                true,
+                MAIN_CAP.unwrap(),
+            );
+        }
+    }
+}
+
+#[test_case]
+fn trivial_assertion() {
+    debug!("trivial assertion... ");
+    run_kernel_op(100);
+
+    assert_eq!(1, 1);
+
+    debug!("    [ok]");
+    run_kernel_op(100);
+}
+
+mod multi_alarm;

--- a/boards/esp32-c3-devkitM-1/src/tests/multi_alarm.rs
+++ b/boards/esp32-c3-devkitM-1/src/tests/multi_alarm.rs
@@ -1,0 +1,82 @@
+//! Test the behavior of a single alarm.
+//! To add this test, include the line
+//! ```
+//!    multi_alarm_test::run_alarm(alarm_mux);
+//! ```
+//! to the OpenTitan boot sequence, where `alarm_mux` is a
+//! `capsules::virtual_alarm::MuxAlarm`. The test sets up 3
+//! different virtualized alarms of random durations and prints
+//! out when they fire. The durations are uniformly random with
+//! one caveat, that 1 in 11 is of duration 0; this is to test
+//! that alarms whose expiration was in the past due to the
+//! latency of software work correctly.
+
+use crate::tests::run_kernel_op;
+use crate::ALARM;
+use capsules::test::random_alarm::TestRandomAlarm;
+use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
+use esp32::timg::TimG;
+use kernel::debug;
+use kernel::hil::time::Alarm;
+use kernel::static_init;
+
+static mut TESTS: Option<
+    [&'static TestRandomAlarm<'static, VirtualMuxAlarm<'static, TimG<'static>>>; 3],
+> = None;
+
+#[test_case]
+pub fn run_multi_alarm() {
+    debug!("start multi alarm test...");
+    unsafe {
+        TESTS = Some(static_init_multi_alarm_test(ALARM.unwrap()));
+        TESTS.unwrap()[0].run();
+        TESTS.unwrap()[1].run();
+        TESTS.unwrap()[2].run();
+    }
+
+    run_kernel_op(10000);
+
+    unsafe {
+        assert!(TESTS.unwrap()[0].counter.get() > 15);
+        assert!(TESTS.unwrap()[1].counter.get() > 30);
+        assert!(TESTS.unwrap()[2].counter.get() > 80);
+    }
+
+    debug!("    [ok]");
+    run_kernel_op(100);
+}
+
+unsafe fn static_init_multi_alarm_test(
+    mux: &'static MuxAlarm<'static, TimG<'static>>,
+) -> [&'static TestRandomAlarm<'static, VirtualMuxAlarm<'static, TimG<'static>>>; 3] {
+    let virtual_alarm1 = static_init!(
+        VirtualMuxAlarm<'static, TimG<'static>>,
+        VirtualMuxAlarm::new(mux)
+    );
+    let test1 = static_init!(
+        TestRandomAlarm<'static, VirtualMuxAlarm<'static, TimG<'static>>>,
+        TestRandomAlarm::new(virtual_alarm1, 19, 'A')
+    );
+    virtual_alarm1.set_alarm_client(test1);
+
+    let virtual_alarm2 = static_init!(
+        VirtualMuxAlarm<'static, TimG<'static>>,
+        VirtualMuxAlarm::new(mux)
+    );
+    let test2 = static_init!(
+        TestRandomAlarm<'static, VirtualMuxAlarm<'static, TimG<'static>>>,
+        TestRandomAlarm::new(virtual_alarm2, 37, 'B')
+    );
+    virtual_alarm2.set_alarm_client(test2);
+
+    let virtual_alarm3 = static_init!(
+        VirtualMuxAlarm<'static, TimG<'static>>,
+        VirtualMuxAlarm::new(mux)
+    );
+    let test3 = static_init!(
+        TestRandomAlarm<'static, VirtualMuxAlarm<'static, TimG<'static>>>,
+        TestRandomAlarm::new(virtual_alarm3, 89, 'C')
+    );
+    virtual_alarm3.set_alarm_client(test3);
+    [&*test1, &*test2, &*test3]
+}

--- a/chips/esp32-c3/Cargo.toml
+++ b/chips/esp32-c3/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "esp32-c3"
+version = "0.1.0"
+authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+edition = "2018"
+
+[dependencies]
+esp32 = { path = "../esp32" }
+rv32i = { path = "../../arch/rv32i" }
+kernel = { path = "../../kernel" }
+

--- a/chips/esp32-c3/README.md
+++ b/chips/esp32-c3/README.md
@@ -1,0 +1,11 @@
+Espressif ESP32-C3
+==================
+
+ESP32-C3 is a single-core, 32-bit, RISC-V-based MCU with 400KB of SRAM,
+which is capable of running at 160MHz. It has integrated 2.4 GHz Wi-Fi and
+Bluetooth 5 (LE) with a long-range support. It has 22 programmable GPIOs with
+support for ADC, SPI, UART, I2C, I2S, RMT, TWAI, and PWM.
+
+[The data sheet is available](https://www.espressif.com/sites/default/files/documentation/esp32-c3_datasheet_en.pdf)
+
+[For more details from Espressif](https://www.espressif.com/en/news/ESP32_C3)

--- a/chips/esp32-c3/src/chip.rs
+++ b/chips/esp32-c3/src/chip.rs
@@ -26,6 +26,7 @@ pub struct Esp32C3<'a, I: InterruptService<()> + 'a> {
 pub struct Esp32C3DefaultPeripherals<'a> {
     pub uart0: esp32::uart::Uart<'a>,
     pub timg0: esp32::timg::TimG<'a>,
+    pub gpio: esp32::gpio::Port<'a>,
     pub rtc_cntl: esp32::rtc_cntl::RtcCntl,
 }
 
@@ -34,6 +35,7 @@ impl<'a> Esp32C3DefaultPeripherals<'a> {
         Self {
             uart0: esp32::uart::Uart::new(esp32::uart::UART0_BASE),
             timg0: esp32::timg::TimG::new(esp32::timg::TIMG0_BASE),
+            gpio: esp32::gpio::Port::new(),
             rtc_cntl: esp32::rtc_cntl::RtcCntl::new(esp32::rtc_cntl::RTC_CNTL_BASE),
         }
     }

--- a/chips/esp32-c3/src/chip.rs
+++ b/chips/esp32-c3/src/chip.rs
@@ -1,0 +1,218 @@
+//! High-level setup and interrupt mapping for the chip.
+
+use crate::intc::{Intc, IntcRegisters};
+use core::fmt::Write;
+use kernel;
+use kernel::common::registers::interfaces::{ReadWriteable, Readable};
+use kernel::common::StaticRef;
+use kernel::{Chip, InterruptService};
+use rv32i::csr::{self, mcause, CSR};
+use rv32i::syscall::SysCall;
+
+pub const INTC_BASE: StaticRef<IntcRegisters> =
+    unsafe { StaticRef::new(0x600C_2000 as *const IntcRegisters) };
+
+pub static mut INTC: Intc = Intc::new(INTC_BASE);
+
+pub struct Esp32C3<'a, I: InterruptService<()> + 'a> {
+    userspace_kernel_boundary: SysCall,
+    intc: &'a Intc,
+    scheduler_timer: esp32::timg::TimG<'a>,
+    pic_interrupt_service: &'a I,
+}
+
+pub struct Esp32C3DefaultPeripherals<'a> {
+    pub uart0: esp32::uart::Uart<'a>,
+    pub timg0: esp32::timg::TimG<'a>,
+    pub rtc_cntl: esp32::rtc_cntl::RtcCntl,
+}
+
+impl<'a> Esp32C3DefaultPeripherals<'a> {
+    pub fn new() -> Self {
+        Self {
+            uart0: esp32::uart::Uart::new(esp32::uart::UART0_BASE),
+            timg0: esp32::timg::TimG::new(esp32::timg::TIMG0_BASE),
+            rtc_cntl: esp32::rtc_cntl::RtcCntl::new(esp32::rtc_cntl::RTC_CNTL_BASE),
+        }
+    }
+}
+
+impl<'a> InterruptService<()> for Esp32C3DefaultPeripherals<'a> {
+    unsafe fn service_interrupt(&self, interrupt: u32) -> bool {
+        match interrupt {
+            5 => {
+                self.uart0.handle_interrupt();
+            }
+            _ => return false,
+        }
+        true
+    }
+
+    unsafe fn service_deferred_call(&self, _: ()) -> bool {
+        false
+    }
+}
+
+impl<'a, I: InterruptService<()> + 'a> Esp32C3<'a, I> {
+    pub unsafe fn new(pic_interrupt_service: &'a I) -> Self {
+        Self {
+            userspace_kernel_boundary: SysCall::new(),
+            intc: &INTC,
+            scheduler_timer: esp32::timg::TimG::new(esp32::timg::TIMG1_BASE),
+            pic_interrupt_service,
+        }
+    }
+
+    pub unsafe fn enable_pic_interrupts(&self) {
+        self.intc.enable_all();
+    }
+
+    unsafe fn handle_pic_interrupts(&self) {
+        while let Some(interrupt) = self.intc.get_saved_interrupts() {
+            if !self.pic_interrupt_service.service_interrupt(interrupt) {
+                panic!("Unhandled interrupt {}", interrupt);
+            }
+            self.atomic(|| {
+                // Safe as interrupts are disabled
+                self.intc.complete(interrupt);
+            });
+        }
+    }
+}
+
+impl<'a, I: InterruptService<()> + 'a> kernel::Chip for Esp32C3<'a, I> {
+    type MPU = ();
+    type UserspaceKernelBoundary = SysCall;
+    type SchedulerTimer = esp32::timg::TimG<'a>;
+    type WatchDog = ();
+
+    fn mpu(&self) -> &Self::MPU {
+        &()
+    }
+
+    fn scheduler_timer(&self) -> &Self::SchedulerTimer {
+        &self.scheduler_timer
+    }
+
+    fn watchdog(&self) -> &Self::WatchDog {
+        &()
+    }
+
+    fn userspace_kernel_boundary(&self) -> &SysCall {
+        &self.userspace_kernel_boundary
+    }
+
+    fn service_pending_interrupts(&self) {
+        loop {
+            if self.intc.get_saved_interrupts().is_some() {
+                unsafe {
+                    self.handle_pic_interrupts();
+                }
+            }
+
+            if self.intc.get_saved_interrupts().is_none() {
+                break;
+            }
+        }
+
+        self.intc.enable_all();
+    }
+
+    fn has_pending_interrupts(&self) -> bool {
+        self.intc.get_saved_interrupts().is_some()
+    }
+
+    fn sleep(&self) {
+        unsafe {
+            rv32i::support::wfi();
+        }
+    }
+
+    unsafe fn atomic<F, R>(&self, f: F) -> R
+    where
+        F: FnOnce() -> R,
+    {
+        rv32i::support::atomic(f)
+    }
+
+    unsafe fn print_state(&self, writer: &mut dyn Write) {
+        rv32i::print_riscv_state(writer);
+    }
+}
+
+fn handle_exception(exception: mcause::Exception) {
+    match exception {
+        mcause::Exception::UserEnvCall | mcause::Exception::SupervisorEnvCall => (),
+
+        mcause::Exception::InstructionMisaligned
+        | mcause::Exception::InstructionFault
+        | mcause::Exception::IllegalInstruction
+        | mcause::Exception::Breakpoint
+        | mcause::Exception::LoadMisaligned
+        | mcause::Exception::LoadFault
+        | mcause::Exception::StoreMisaligned
+        | mcause::Exception::StoreFault
+        | mcause::Exception::MachineEnvCall
+        | mcause::Exception::InstructionPageFault
+        | mcause::Exception::LoadPageFault
+        | mcause::Exception::StorePageFault
+        | mcause::Exception::Unknown => {
+            panic!("fatal exception: {:?}: {:#x}", exception, CSR.mtval.get());
+        }
+    }
+}
+
+unsafe fn handle_interrupt(_intr: mcause::Interrupt) {
+    CSR.mstatus.modify(csr::mstatus::mstatus::mie::CLEAR);
+
+    // Claim the interrupt, unwrap() as we know an interrupt exists
+    // Once claimed this interrupt won't fire until it's completed
+    // NOTE: The interrupt is no longer pending in the PLIC
+    loop {
+        let interrupt = INTC.next_pending();
+
+        match interrupt {
+            Some(irq) => {
+                // Safe as interrupts are disabled
+                INTC.save_interrupt(irq);
+                INTC.disable(irq);
+            }
+            None => {
+                // Enable generic interrupts
+                CSR.mstatus.modify(csr::mstatus::mstatus::mie::SET);
+                break;
+            }
+        }
+    }
+}
+
+/// Trap handler for board/chip specific code.
+///
+/// This gets called when an interrupt occurs while the chip is
+/// in kernel mode.
+#[export_name = "_start_trap_rust_from_kernel"]
+pub unsafe extern "C" fn start_trap_rust() {
+    match mcause::Trap::from(CSR.mcause.extract()) {
+        mcause::Trap::Interrupt(interrupt) => {
+            handle_interrupt(interrupt);
+        }
+        mcause::Trap::Exception(exception) => {
+            handle_exception(exception);
+        }
+    }
+}
+
+/// Function that gets called if an interrupt occurs while an app was running.
+/// mcause is passed in, and this function should correctly handle disabling the
+/// interrupt that fired so that it does not trigger again.
+#[export_name = "_disable_interrupt_trap_rust_from_app"]
+pub unsafe extern "C" fn disable_interrupt_trap_handler(mcause_val: u32) {
+    match mcause::Trap::from(mcause_val as usize) {
+        mcause::Trap::Interrupt(interrupt) => {
+            handle_interrupt(interrupt);
+        }
+        _ => {
+            panic!("unexpected non-interrupt\n");
+        }
+    }
+}

--- a/chips/esp32-c3/src/intc.rs
+++ b/chips/esp32-c3/src/intc.rs
@@ -1,0 +1,134 @@
+//! Platform Level Interrupt Control peripheral driver.
+
+use kernel::common::cells::VolatileCell;
+use kernel::common::registers::interfaces::{Readable, Writeable};
+use kernel::common::registers::{
+    register_bitfields, register_structs, LocalRegisterCopy, ReadWrite,
+};
+use kernel::common::StaticRef;
+
+register_structs! {
+    pub IntcRegisters {
+        (0x000 => _reserved0),
+        (0x104 => enable: ReadWrite<u32, INT::Register>),
+        (0x108 => type_reg: ReadWrite<u32, INT::Register>),
+        (0x10C => clear: ReadWrite<u32, INT::Register>),
+        (0x110 => eip: ReadWrite<u32, INT::Register>),
+        (0x114 => _reserved1),
+        (0x118 => priority: [ReadWrite<u32, PRIORITY::Register>; 31]),
+        (0x194 => thresh: ReadWrite<u32, THRESH::Register>),
+        (0x198 => @END),
+    }
+}
+
+register_bitfields![u32,
+    INT [
+        ONE OFFSET(1) NUMBITS(1) [],
+        TWO OFFSET(2) NUMBITS(1) [],
+        THREE OFFSET(3) NUMBITS(1) [],
+        FOUR OFFSET(4) NUMBITS(1) [],
+        FIVE OFFSET(5) NUMBITS(1) [],
+        SIX OFFSET(6) NUMBITS(1) [],
+        SEVEN OFFSET(7) NUMBITS(1) [],
+        EIGHT OFFSET(8) NUMBITS(1) [],
+    ],
+    PRIORITY [
+        PRIORITY OFFSET(0) NUMBITS(4) [],
+    ],
+    THRESH [
+        THRESH OFFSET(0) NUMBITS(4) [],
+    ],
+];
+
+pub struct Intc {
+    registers: StaticRef<IntcRegisters>,
+    saved: VolatileCell<LocalRegisterCopy<u32>>,
+}
+
+impl Intc {
+    pub const fn new(base: StaticRef<IntcRegisters>) -> Self {
+        Intc {
+            registers: base,
+            saved: VolatileCell::new(LocalRegisterCopy::new(0)),
+        }
+    }
+
+    /// Clear all pending interrupts.
+    pub fn clear_all_pending(&self) {
+        self.registers.clear.set(0xFF);
+    }
+
+    /// Enable all interrupts.
+    pub fn enable_all(&self) {
+        self.registers.enable.set(0xFF);
+
+        // Set some default priority for each interrupt. This is not really used
+        // at this point.
+        for priority in self.registers.priority.iter() {
+            priority.write(PRIORITY::PRIORITY.val(3));
+        }
+
+        // Accept all interrupts.
+        self.registers.thresh.write(THRESH::THRESH.val(1));
+    }
+
+    /// Disable interrupt.
+    pub fn disable(&self, irq: u32) {
+        let mask = !(1 << irq);
+        let value = self.registers.enable.get() & mask;
+        self.registers.enable.set(value);
+    }
+
+    /// Disable all interrupts.
+    pub fn disable_all(&self) {
+        self.registers.enable.set(0x00);
+    }
+
+    /// Get the index (0-256) of the lowest number pending interrupt, or `None` if
+    /// none is pending. RISC-V Intc has a "claim" register which makes it easy
+    /// to grab the highest priority pending interrupt.
+    pub fn next_pending(&self) -> Option<u32> {
+        let eip = self.registers.eip.get();
+        if eip == 0 {
+            None
+        } else {
+            Some(eip.trailing_zeros())
+        }
+    }
+
+    /// Save the current interrupt to be handled later
+    /// This will save the interrupt at index internally to be handled later.
+    /// Interrupts must be disabled before this is called.
+    /// Saved interrupts can be retrieved by calling `get_saved_interrupts()`.
+    /// Saved interrupts are cleared when `'complete()` is called.
+    pub unsafe fn save_interrupt(&self, irq: u32) {
+        // OR the current saved state with the new value
+        let new_saved = self.saved.get().get() | 1 << irq;
+
+        // Set the new state
+        self.saved.set(LocalRegisterCopy::new(new_saved));
+    }
+
+    /// The `next_pending()` function will only return enabled interrupts.
+    /// This function will return a pending interrupt that has been disabled by
+    /// `save_interrupt()`.
+    pub fn get_saved_interrupts(&self) -> Option<u32> {
+        let saved = self.saved.get().get();
+        if saved != 0 {
+            return Some(saved.trailing_zeros());
+        }
+
+        None
+    }
+
+    /// Signal that an interrupt is finished being handled. In Tock, this should be
+    /// called from the normal main loop (not the interrupt handler).
+    /// Interrupts must be disabled before this is called.
+    pub unsafe fn complete(&self, irq: u32) {
+        // OR the current saved state with the new value
+        let new_saved = self.saved.get().get() & !(1 << irq);
+
+        // Set the new state
+        self.saved.set(LocalRegisterCopy::new(new_saved));
+    }
+}

--- a/chips/esp32-c3/src/interrupts.rs
+++ b/chips/esp32-c3/src/interrupts.rs
@@ -1,0 +1,67 @@
+//! Named interrupts for the ESP32C3 chip.
+//! This matches what the HAL uses
+
+#![allow(dead_code)]
+
+pub const IRQ_WIFI_MAC: u32 = 0;
+pub const IRQ_WIFI_NMI: u32 = 1;
+pub const IRQ_WIFI_PWR: u32 = 2;
+pub const IRQ_WIFI_BB: u32 = 3;
+pub const IRQ_BT_MAC: u32 = 4;
+pub const IRQ_BT_BB: u32 = 5;
+pub const IRQ_BT_BB_NMI: u32 = 6;
+pub const IRQ_RWBT: u32 = 7;
+pub const IRQ_RWBLE: u32 = 8;
+pub const IRQ_RWBT_NMI: u32 = 9;
+pub const IRQ_RWBLE_NMI: u32 = 10;
+pub const IRQ_I2C: u32 = 11;
+pub const IRQ_SLC0: u32 = 12;
+pub const IRQ_SLC1: u32 = 13;
+pub const IRQ_APB_CTRL: u32 = 14;
+pub const IRQ_UHCI0: u32 = 15;
+pub const IRQ_GPIO: u32 = 16;
+pub const IRQ_GPIO_NMI: u32 = 17;
+pub const IRQ_SPI1: u32 = 18;
+pub const IRQ_SPI2: u32 = 19;
+pub const IRQ_I2S1: u32 = 20;
+pub const IRQ_UART0: u32 = 21;
+pub const IRQ_UART1: u32 = 22;
+pub const IRQ_LEDC: u32 = 23;
+pub const IRQ_EFUSE: u32 = 24;
+pub const IRQ_CAN: u32 = 25;
+pub const IRQ_USB: u32 = 26;
+pub const IRQ_RTC_CORE: u32 = 27;
+pub const IRQ_RMT: u32 = 28;
+pub const IRQ_I2C_EXT0: u32 = 29;
+pub const IRQ_TIMER1: u32 = 30;
+pub const IRQ_TIMER2: u32 = 31;
+pub const IRQ_TG0_T0_LEVEL: u32 = 32;
+pub const IRQ_TG0_WDT_LEVEL: u32 = 33;
+pub const IRQ_TG1_T0_LEVEL: u32 = 34;
+pub const IRQ_TG1_WDT_LEVEL: u32 = 35;
+pub const IRQ_CACHE_IA: u32 = 36;
+pub const IRQ_SYSTIMER_TARGET0_EDGE: u32 = 37;
+pub const IRQ_SYSTIMER_TARGET1_EDGE: u32 = 38;
+pub const IRQ_SYSTIMER_TARGET2_EDGE: u32 = 39;
+pub const IRQ_SPI_MEM_REJECT_CACHE: u32 = 40;
+pub const IRQ_ICACHE_PRELOAD0: u32 = 41;
+pub const IRQ_ICACHE_SYNC0: u32 = 42;
+pub const IRQ_APB_ADC: u32 = 43;
+pub const IRQ_DMA_CH0: u32 = 44;
+pub const IRQ_DMA_CH1: u32 = 45;
+pub const IRQ_DMA_CH2: u32 = 46;
+pub const IRQ_RSA: u32 = 47;
+pub const IRQ_AES: u32 = 48;
+pub const IRQ_SHA: u32 = 49;
+pub const IRQ_ETS_FROM_CPU_INTR0: u32 = 50;
+pub const IRQ_ETS_FROM_CPU_INTR1: u32 = 51;
+pub const IRQ_ETS_FROM_CPU_INTR2: u32 = 52;
+pub const IRQ_ETS_FROM_CPU_INTR3: u32 = 53;
+pub const IRQ_ETS_ASSIST_DEBUG: u32 = 54;
+pub const IRQ_ETS_DMA_APBPERI_PMS: u32 = 55;
+pub const IRQ_ETS_CORE0_IRAM0_PMS: u32 = 56;
+pub const IRQ_ETS_CORE0_DRAM0_PMS: u32 = 57;
+pub const IRQ_ETS_CORE0_PIF_PMS: u32 = 58;
+pub const IRQ_ETS_CORE0_PIF_PMS_SIZE: u32 = 59;
+pub const IRQ_ETS_BAK_PMS_VIOLATE: u32 = 60;
+pub const IRQ_ETS_CACHE_CORE0_ACS: u32 = 61;

--- a/chips/esp32-c3/src/lib.rs
+++ b/chips/esp32-c3/src/lib.rs
@@ -1,0 +1,9 @@
+//! Drivers and chip support for ESP32-C3.
+
+#![feature(const_fn_trait_bound)]
+#![no_std]
+#![crate_name = "esp32_c3"]
+#![crate_type = "rlib"]
+
+pub mod chip;
+pub mod intc;

--- a/chips/esp32-c3/src/lib.rs
+++ b/chips/esp32-c3/src/lib.rs
@@ -1,9 +1,10 @@
 //! Drivers and chip support for ESP32-C3.
 
-#![feature(const_fn_trait_bound)]
+#![feature(const_fn_trait_bound, naked_functions, asm)]
 #![no_std]
 #![crate_name = "esp32_c3"]
 #![crate_type = "rlib"]
 
 pub mod chip;
 pub mod intc;
+pub mod interrupts;

--- a/chips/esp32/Cargo.toml
+++ b/chips/esp32/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "esp32"
+version = "0.1.0"
+authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+edition = "2018"
+
+[dependencies]
+kernel = { path = "../../kernel" }

--- a/chips/esp32/README.md
+++ b/chips/esp32/README.md
@@ -1,0 +1,5 @@
+ESP32 Peripherals
+=======================
+
+This crate contains various peripherals shared between various ESP32
+cores.

--- a/chips/esp32/src/gpio.rs
+++ b/chips/esp32/src/gpio.rs
@@ -1,0 +1,284 @@
+//! GPIO driver.
+
+use core::ops::{Index, IndexMut};
+use kernel::common::cells::OptionalCell;
+use kernel::common::registers::interfaces::{ReadWriteable, Readable, Writeable};
+use kernel::common::registers::{
+    register_bitfields, register_structs, Field, ReadWrite, WriteOnly,
+};
+use kernel::common::StaticRef;
+use kernel::hil::gpio;
+
+pub const GPIO_BASE: StaticRef<GpioRegisters> =
+    unsafe { StaticRef::new(0x6000_4000 as *const GpioRegisters) };
+
+register_structs! {
+    pub GpioRegisters {
+        (0x0 => bt_select: ReadWrite<u32>),
+        (0x4 => gpio_out: ReadWrite<u32, pins::Register>),
+        (0x8 => gpio_out_w1ts: WriteOnly<u32, pins::Register>),
+        (0xC => gpio_out_w1tc: WriteOnly<u32, pins::Register>),
+        (0x10 => _reserved0),
+        (0x1C => sdio_select: ReadWrite<u32>),
+        (0x20 => enable: ReadWrite<u32, pins::Register>),
+        (0x24 => enable_w1ts: ReadWrite<u32, pins::Register>),
+        (0x28 => enable_w1tc: ReadWrite<u32, pins::Register>),
+        (0x2C => _reserved1),
+        (0x38 => strap: ReadWrite<u32>),
+        (0x3C => gpio_in: ReadWrite<u32, pins::Register>),
+        (0x40 => _reserved2),
+        (0x44 => status: ReadWrite<u32, pins::Register>),
+        (0x48 => status_w1ts: ReadWrite<u32, pins::Register>),
+        (0x4C => status_w1tc: ReadWrite<u32, pins::Register>),
+        (0x50 => _reserved3),
+        (0x5C => pcpu_int: ReadWrite<u32>),
+        (0x60 => pcpu_nmi_int: ReadWrite<u32>),
+        (0x64 => cpusdio_int: ReadWrite<u32>),
+        (0x68 => _reserved4),
+        (0x74 => pin: [ReadWrite<u32, PIN::Register>; 26]),
+        (0xDC => _reserved5),
+        (0x14C => status_next: ReadWrite<u32>),
+        (0x150 => _reserved6),
+        (0x154 => func_in_sel_cfg: [ReadWrite<u32>; 128]),
+        (0x354 => _reserved7),
+        (0x554 => func_out_sel_cfg: [ReadWrite<u32>; 26]),
+        (0x5BC => _reserved8),
+        (0x62C => clock_gate: ReadWrite<u32>),
+        (0x630 => _reserved9),
+        (0x6FC => date: ReadWrite<u32>),
+        (0x700 => @END),
+    }
+}
+
+register_bitfields![u32,
+    pub pins [
+        pin0 0,
+        pin1 1,
+        pin2 2,
+        pin3 3,
+        pin4 4,
+        pin5 5,
+        pin6 6,
+        pin7 7,
+        pin8 8,
+        pin9 9,
+        pin10 10,
+        pin11 11,
+        pin12 12,
+        pin13 13,
+        pin14 14,
+        pin15 15,
+        pin16 16,
+        pin17 17,
+        pin18 18,
+        pin19 19,
+        pin20 20,
+        pin21 21,
+        pin22 22,
+        pin23 23,
+        pin24 24,
+        pin25 25
+    ],
+    MASK_HALF [
+        DATA OFFSET(0) NUMBITS(16) [],
+        MASK OFFSET(16) NUMBITS(16) [],
+    ],
+    PIN [
+        INT_ENA OFFSET(13) NUMBITS(5) [
+            Disabled = 0,
+            Enable = 1,
+            NMI = 2,
+        ],
+        CONFIG OFFSET(11) NUMBITS(2) [],
+        WAKEUP_ENABLE OFFSET(10) NUMBITS(1) [],
+        INT_TYPE OFFSET(7) NUMBITS(3) [
+            DISABLE = 0,
+            POSEDGE = 1,
+            NEGEDGE = 2,
+            ANYEDGE = 3,
+            LOW_LEVEL = 4,
+            HIGH_LEVEL = 5,
+        ],
+        SYNC1_BYPASS OFFSET(3) NUMBITS(2) [],
+        PAD_DRIVER OFFSET(2) NUMBITS(1) [],
+        SYNC2_BYPASS OFFSET(0) NUMBITS(2) [],
+    ],
+];
+
+pub struct GpioPin<'a> {
+    registers: StaticRef<GpioRegisters>,
+    pin: Field<u32, pins::Register>,
+    client: OptionalCell<&'a dyn gpio::Client>,
+}
+
+impl<'a> GpioPin<'a> {
+    pub const fn new(
+        gpio_base: StaticRef<GpioRegisters>,
+        pin: Field<u32, pins::Register>,
+    ) -> GpioPin<'a> {
+        GpioPin {
+            registers: gpio_base,
+            pin,
+            client: OptionalCell::empty(),
+        }
+    }
+}
+
+impl gpio::Configure for GpioPin<'_> {
+    fn configuration(&self) -> gpio::Configuration {
+        if self.registers.enable.is_set(self.pin) {
+            gpio::Configuration::Input
+        } else {
+            gpio::Configuration::InputOutput
+        }
+    }
+
+    fn set_floating_state(&self, _mode: gpio::FloatingState) {
+        unimplemented!()
+    }
+
+    fn floating_state(&self) -> gpio::FloatingState {
+        unimplemented!()
+    }
+
+    fn deactivate_to_low_power(&self) {
+        self.disable_input();
+        self.disable_output();
+    }
+
+    fn make_output(&self) -> gpio::Configuration {
+        self.registers
+            .enable_w1ts
+            .set(self.pin.mask << self.pin.shift);
+        gpio::Configuration::Output
+    }
+
+    fn disable_output(&self) -> gpio::Configuration {
+        self.registers
+            .enable_w1tc
+            .set(self.pin.mask << self.pin.shift);
+        gpio::Configuration::Input
+    }
+
+    fn make_input(&self) -> gpio::Configuration {
+        self.configuration()
+    }
+
+    fn disable_input(&self) -> gpio::Configuration {
+        /* We can't do this from the GPIO contorller.
+         * It does look like the IO Mux is capable of this
+         * though.
+         */
+        gpio::Configuration::Input
+    }
+}
+
+impl gpio::Input for GpioPin<'_> {
+    fn read(&self) -> bool {
+        self.registers.gpio_in.is_set(self.pin)
+    }
+}
+
+impl gpio::Output for GpioPin<'_> {
+    fn toggle(&self) -> bool {
+        let old_state = self.registers.gpio_out.is_set(self.pin);
+        if old_state {
+            self.clear();
+        } else {
+            self.set();
+        }
+        self.registers.gpio_out.is_set(self.pin)
+    }
+
+    fn set(&self) {
+        self.registers
+            .gpio_out_w1ts
+            .set(self.pin.mask << self.pin.shift);
+    }
+
+    fn clear(&self) {
+        self.registers
+            .gpio_out_w1tc
+            .set(self.pin.mask << self.pin.shift);
+    }
+}
+
+impl<'a> gpio::Interrupt<'a> for GpioPin<'a> {
+    fn set_client(&self, client: &'a dyn gpio::Client) {
+        self.client.set(client);
+    }
+
+    fn enable_interrupts(&self, mode: gpio::InterruptEdge) {
+        self.registers.pin[self.pin.shift].modify(PIN::INT_ENA::Enable);
+
+        match mode {
+            gpio::InterruptEdge::RisingEdge => {
+                self.registers.pin[self.pin.shift].modify(PIN::INT_TYPE::POSEDGE);
+            }
+            gpio::InterruptEdge::FallingEdge => {
+                self.registers.pin[self.pin.shift].modify(PIN::INT_TYPE::NEGEDGE);
+            }
+            gpio::InterruptEdge::EitherEdge => {
+                self.registers.pin[self.pin.shift].modify(PIN::INT_TYPE::ANYEDGE);
+            }
+        }
+
+        self.registers.pin[self.pin.shift].modify(PIN::WAKEUP_ENABLE::SET);
+    }
+
+    fn disable_interrupts(&self) {
+        self.registers.pin[self.pin.shift].modify(PIN::INT_ENA::Disabled);
+    }
+
+    fn is_pending(&self) -> bool {
+        self.registers.status.is_set(self.pin)
+    }
+}
+
+pub struct Port<'a> {
+    pins: [GpioPin<'a>; 17],
+}
+
+impl<'a> Port<'a> {
+    pub const fn new() -> Self {
+        Self {
+            pins: [
+                GpioPin::new(GPIO_BASE, pins::pin0),
+                GpioPin::new(GPIO_BASE, pins::pin1),
+                GpioPin::new(GPIO_BASE, pins::pin2),
+                GpioPin::new(GPIO_BASE, pins::pin3),
+                GpioPin::new(GPIO_BASE, pins::pin4),
+                GpioPin::new(GPIO_BASE, pins::pin5),
+                GpioPin::new(GPIO_BASE, pins::pin6),
+                GpioPin::new(GPIO_BASE, pins::pin7),
+                GpioPin::new(GPIO_BASE, pins::pin8),
+                GpioPin::new(GPIO_BASE, pins::pin9),
+                GpioPin::new(GPIO_BASE, pins::pin10),
+                GpioPin::new(GPIO_BASE, pins::pin11),
+                GpioPin::new(GPIO_BASE, pins::pin12),
+                GpioPin::new(GPIO_BASE, pins::pin13),
+                GpioPin::new(GPIO_BASE, pins::pin14),
+                GpioPin::new(GPIO_BASE, pins::pin15),
+                GpioPin::new(GPIO_BASE, pins::pin16),
+            ],
+        }
+    }
+
+    pub fn handle_interrupt(&self) {
+        unimplemented!()
+    }
+}
+
+impl<'a> Index<usize> for Port<'a> {
+    type Output = GpioPin<'a>;
+
+    fn index(&self, index: usize) -> &GpioPin<'a> {
+        &self.pins[index]
+    }
+}
+
+impl<'a> IndexMut<usize> for Port<'a> {
+    fn index_mut(&mut self, index: usize) -> &mut GpioPin<'a> {
+        &mut self.pins[index]
+    }
+}

--- a/chips/esp32/src/lib.rs
+++ b/chips/esp32/src/lib.rs
@@ -5,6 +5,7 @@
 #![crate_name = "esp32"]
 #![crate_type = "rlib"]
 
+pub mod gpio;
 pub mod rtc_cntl;
 pub mod timg;
 pub mod uart;

--- a/chips/esp32/src/lib.rs
+++ b/chips/esp32/src/lib.rs
@@ -1,0 +1,8 @@
+//! Drivers and chip support for Espressif ESP32 boards.
+
+#![feature(const_fn_trait_bound)]
+#![no_std]
+#![crate_name = "esp32"]
+#![crate_type = "rlib"]
+
+pub mod uart;

--- a/chips/esp32/src/lib.rs
+++ b/chips/esp32/src/lib.rs
@@ -6,4 +6,5 @@
 #![crate_type = "rlib"]
 
 pub mod rtc_cntl;
+pub mod timg;
 pub mod uart;

--- a/chips/esp32/src/lib.rs
+++ b/chips/esp32/src/lib.rs
@@ -5,4 +5,5 @@
 #![crate_name = "esp32"]
 #![crate_type = "rlib"]
 
+pub mod rtc_cntl;
 pub mod uart;

--- a/chips/esp32/src/rtc_cntl.rs
+++ b/chips/esp32/src/rtc_cntl.rs
@@ -1,0 +1,165 @@
+//! Low Power Management driver.
+
+use kernel::common::registers::interfaces::{ReadWriteable, Readable, Writeable};
+use kernel::common::registers::{register_bitfields, register_structs, ReadWrite};
+use kernel::common::StaticRef;
+use kernel::watchdog::WatchDog;
+
+pub const RTC_CNTL_BASE: StaticRef<RtcCntlRegisters> =
+    unsafe { StaticRef::new(0x6000_8000 as *const RtcCntlRegisters) };
+
+register_structs! {
+    pub RtcCntlRegisters {
+        (0x000 => options0: ReadWrite<u32>),
+        (0x004 => slp_timer0: ReadWrite<u32>),
+        (0x008 => slp_timer1: ReadWrite<u32>),
+        (0x00C => time_updaet: ReadWrite<u32>),
+        (0x010 => time_low0: ReadWrite<u32>),
+        (0x014 => time_high0: ReadWrite<u32>),
+        (0x018 => state0: ReadWrite<u32>),
+        (0x01C => timer1: ReadWrite<u32>),
+        (0x020 => timer2: ReadWrite<u32>),
+        (0x024 => timer3: ReadWrite<u32>),
+        (0x028 => timer4: ReadWrite<u32>),
+        (0x02C => timer5: ReadWrite<u32>),
+        (0x030 => timer6: ReadWrite<u32>),
+        (0x034 => ana_conf: ReadWrite<u32>),
+        (0x038 => reset_state: ReadWrite<u32>),
+        (0x03C => wakeup_state: ReadWrite<u32>),
+        (0x040 => int_ena: ReadWrite<u32>),
+        (0x044 => int_raw: ReadWrite<u32>),
+        (0x048 => int_st: ReadWrite<u32>),
+        (0x04C => int_clr: ReadWrite<u32>),
+        (0x050 => store0: ReadWrite<u32>),
+        (0x054 => store1: ReadWrite<u32>),
+        (0x058 => store2: ReadWrite<u32>),
+        (0x05C => store3: ReadWrite<u32>),
+        (0x060 => ext_xtl_conf: ReadWrite<u32>),
+        (0x064 => ext_wakeup_conf: ReadWrite<u32>),
+        (0x068 => slp_reject_conf: ReadWrite<u32>),
+        (0x06C => cpu_period_conf: ReadWrite<u32>),
+        (0x070 => clk_conf: ReadWrite<u32>),
+        (0x074 => slow_clk_conf: ReadWrite<u32>),
+        (0x078 => sdio_conf: ReadWrite<u32>),
+        (0x07C => bias_conf: ReadWrite<u32>),
+        (0x080 => vreg: ReadWrite<u32>),
+        (0x084 => pwc: ReadWrite<u32>),
+        (0x088 => dig_pwc: ReadWrite<u32>),
+        (0x08C => dig_iso: ReadWrite<u32>),
+        (0x090 => wdtconfig0: ReadWrite<u32, WDTCONFIG0::Register>),
+        (0x094 => wdtconfig1: ReadWrite<u32>),
+        (0x098 => wdtconfig2: ReadWrite<u32>),
+        (0x09C => wdtconfig3: ReadWrite<u32>),
+        (0x0A0 => wdtconfig4: ReadWrite<u32>),
+        (0x0A4 => wdtfeed: ReadWrite<u32>),
+        (0x0A8 => wdtprotect: ReadWrite<u32>),
+        (0x0AC => swd_conf: ReadWrite<u32, SWD_CONF::Register>),
+        (0x0B0 => swd_wprotect: ReadWrite<u32>),
+        (0x0B4 => sw_cpu_stall: ReadWrite<u32>),
+        (0x0B8 => store4: ReadWrite<u32>),
+        (0x0BC => store5: ReadWrite<u32>),
+        (0x0C0 => store6: ReadWrite<u32>),
+        (0x0C4 => store7: ReadWrite<u32>),
+        (0x0C8 => low_power_st: ReadWrite<u32>),
+        (0x0CC => daig0: ReadWrite<u32>),
+        (0x0D0 => pad_hold: ReadWrite<u32>),
+
+        (0x0D4 => _reserved0),
+        (0x10C => fib_sel: ReadWrite<u32, FIB_SEL::Register>),
+        (0x110 => @END),
+    }
+}
+
+register_bitfields![u32,
+    WDTCONFIG0 [
+        CHIP_RESET_EN OFFSET(8) NUMBITS(1) [],
+        PAUSE_INSLEEP OFFSET(9) NUMBITS(1) [],
+        APPCPU_RESET_EN OFFSET(10) NUMBITS(1) [],
+        PROCPU_RESET_EN OFFSET(11) NUMBITS(1) [],
+        FLASHBOOT_MOD_EN OFFSET(12) NUMBITS(1) [],
+        SYS_RESET_LENGTH OFFSET(13) NUMBITS(3) [],
+        CPU_RESET_LENGTH OFFSET(16) NUMBITS(3) [],
+        STG3 OFFSET(19) NUMBITS(3) [],
+        STG2 OFFSET(22) NUMBITS(3) [],
+        STG1 OFFSET(25) NUMBITS(3) [],
+        STG0 OFFSET(28) NUMBITS(3) [],
+        EN OFFSET(31) NUMBITS(1) [],
+    ],
+    SWD_CONF [
+        AUTO_FEED OFFSET(31) NUMBITS(1) [],
+    ],
+    FIB_SEL [
+        FIB_SEL OFFSET(0) NUMBITS(3) [
+            GLITCH_RST = 1,
+            BOR_RST = 2,
+            SUPER_WDT_RST = 3,
+        ],
+    ],
+];
+
+pub struct RtcCntl {
+    registers: StaticRef<RtcCntlRegisters>,
+}
+
+impl<'a> RtcCntl {
+    pub const fn new(base: StaticRef<RtcCntlRegisters>) -> RtcCntl {
+        Self { registers: base }
+    }
+
+    /// Enable WDT config writes
+    fn enable_wdt_access(&self) {
+        self.registers.wdtprotect.set(0x50d8_3aa1);
+    }
+
+    /// Disable WDT config writes
+    fn disable_wdt_access(&self) {
+        self.registers.wdtprotect.set(0);
+    }
+
+    pub fn disable_wdt(&self) {
+        self.enable_wdt_access();
+
+        self.registers
+            .wdtconfig0
+            .modify(WDTCONFIG0::EN::CLEAR + WDTCONFIG0::FLASHBOOT_MOD_EN::CLEAR);
+        if self
+            .registers
+            .wdtconfig0
+            .is_set(WDTCONFIG0::FLASHBOOT_MOD_EN)
+        {
+            panic!("Can't disable RTC CNTL WDT");
+        }
+
+        self.disable_wdt_access();
+    }
+
+    /// Enable SW WDT config writes
+    fn enable_sw_wdt_access(&self) {
+        self.registers.swd_wprotect.set(0x8F1D_312A);
+    }
+
+    /// Disable SW WDT config writes
+    fn disable_sw_wdt_access(&self) {
+        self.registers.swd_wprotect.set(0);
+    }
+
+    pub fn disable_super_wdt(&self) {
+        self.registers.fib_sel.modify(FIB_SEL::FIB_SEL::BOR_RST);
+
+        self.enable_sw_wdt_access();
+        self.registers.swd_conf.modify(SWD_CONF::AUTO_FEED::SET);
+        self.disable_sw_wdt_access();
+    }
+}
+
+impl WatchDog for RtcCntl {
+    fn setup(&self) {}
+
+    fn tickle(&self) {}
+
+    fn suspend(&self) {}
+
+    fn resume(&self) {
+        self.tickle();
+    }
+}

--- a/chips/esp32/src/timg.rs
+++ b/chips/esp32/src/timg.rs
@@ -1,0 +1,232 @@
+//! TimG Group driver.
+
+use kernel::common::cells::OptionalCell;
+use kernel::common::registers::interfaces::{ReadWriteable, Readable, Writeable};
+use kernel::common::registers::register_bitfields;
+use kernel::common::registers::{register_structs, ReadWrite};
+use kernel::common::StaticRef;
+use kernel::hil::time;
+use kernel::hil::time::{Alarm, Counter, Ticks64};
+use kernel::ErrorCode;
+
+pub const TIMG0_BASE: StaticRef<TimgRegisters> =
+    unsafe { StaticRef::new(0x6001_F000 as *const TimgRegisters) };
+
+pub const TIMG1_BASE: StaticRef<TimgRegisters> =
+    unsafe { StaticRef::new(0x6002_0000 as *const TimgRegisters) };
+
+/// 80MHz `Frequency`
+#[derive(Debug)]
+pub struct Freq80MHz;
+impl time::Frequency for Freq80MHz {
+    fn frequency() -> u32 {
+        80_000_000
+    }
+}
+
+register_structs! {
+    pub TimgRegisters {
+        (0x000 => t0config: ReadWrite<u32, CONFIG::Register>),
+        (0x004 => t0lo: ReadWrite<u32>),
+        (0x008 => t0hi: ReadWrite<u32>),
+        (0x00C => t0update: ReadWrite<u32>),
+        (0x010 => t0alarmlo: ReadWrite<u32>),
+        (0x014 => t0alarmhi: ReadWrite<u32>),
+        (0x018 => t0loadlo: ReadWrite<u32>),
+        (0x01C => _reserved0),
+        (0x020 => t0load: ReadWrite<u32>),
+
+        (0x024 => t1config: ReadWrite<u32, CONFIG::Register>),
+        (0x028 => t1lo: ReadWrite<u32>),
+        (0x02C => t1hi: ReadWrite<u32>),
+        (0x030 => t1update: ReadWrite<u32>),
+        (0x034 => t1alarmlo: ReadWrite<u32>),
+        (0x038 => t1alarmhi: ReadWrite<u32>),
+        (0x03C => t1loadlo: ReadWrite<u32>),
+        (0x040 => _reserved1),
+        (0x044 => t1load: ReadWrite<u32>),
+
+        (0x048 => wdtconfig0: ReadWrite<u32, WDTCONFIG0::Register>),
+        (0x04C => wdtconfig1: ReadWrite<u32, WDTCONFIG1::Register>),
+        (0x050 => wdtconfig2: ReadWrite<u32>),
+        (0x054 => wdtconfig3: ReadWrite<u32>),
+        (0x058 => wdtconfig4: ReadWrite<u32>),
+        (0x05C => wdtconfig5: ReadWrite<u32>),
+        (0x060 => wdtfeed: ReadWrite<u32>),
+        (0x064 => wdtwprotect: ReadWrite<u32>),
+
+        (0x068 => rtccalicfg: ReadWrite<u32, RTCCALICFG::Register>),
+        (0x06C => rtccalicfg1: ReadWrite<u32, RTCCALICFG1::Register>),
+
+        (0x070 => _reserved2),
+        (0x098 => int_ena: ReadWrite<u32, INT::Register>),
+        (0x09C => int_raw: ReadWrite<u32, INT::Register>),
+        (0x0A0 => int_st: ReadWrite<u32, INT::Register>),
+        (0x0A4 => int_clr: ReadWrite<u32, INT::Register>),
+        (0x0A8 => @END),
+    }
+}
+
+register_bitfields![u32,
+    CONFIG [
+        ALARM_EN OFFSET(10) NUMBITS(1) [],
+        LEVEL_INT_EN OFFSET(11) NUMBITS(1) [],
+        EDGE_INT_EN OFFSET(12) NUMBITS(1) [],
+        DIVIDER OFFSET(13) NUMBITS(16) [],
+        AUTORELOAD OFFSET(29) NUMBITS(1) [],
+        INCREATE OFFSET(30) NUMBITS(1) [],
+        EN OFFSET(31) NUMBITS(1) [],
+    ],
+    WDTCONFIG0 [
+        FLASHBOOT_MOD_EN OFFSET(14) NUMBITS(1) [],
+        SYS_RESET_LENGTH OFFSET(15) NUMBITS(3) [],
+        CPU_RESET_LENGTH OFFSET(18) NUMBITS(3) [],
+        LEVEL_INT_EN OFFSET(21) NUMBITS(1) [],
+        EDGE_INT_EN OFFSET(22) NUMBITS(1) [],
+        STG3 OFFSET(23) NUMBITS(2) [],
+        STG2 OFFSET(25) NUMBITS(2) [],
+        STG1 OFFSET(27) NUMBITS(2) [],
+        STG0 OFFSET(29) NUMBITS(2) [],
+        EN OFFSET(31) NUMBITS(1) [],
+    ],
+    WDTCONFIG1 [
+        CLK_PRESCALE OFFSET(16) NUMBITS(16) [],
+    ],
+    RTCCALICFG [
+        START_CYCLING OFFSET(12) NUMBITS(1) [],
+        CLK_SEL OFFSET(13) NUMBITS(2) [],
+        RDY OFFSET(15) NUMBITS(1) [],
+        MAX OFFSET(16) NUMBITS(15) [],
+        START OFFSET(31) NUMBITS(1) [],
+    ],
+    RTCCALICFG1 [
+        VALUE OFFSET(7) NUMBITS(25) [],
+    ],
+    INT [
+        T0 OFFSET(0) NUMBITS(1) [],
+        T1 OFFSET(1) NUMBITS(1) [],
+        WDT OFFSET(2) NUMBITS(1) [],
+    ],
+];
+
+pub struct TimG<'a> {
+    registers: StaticRef<TimgRegisters>,
+    alarm_client: OptionalCell<&'a dyn time::AlarmClient>,
+}
+
+impl TimG<'_> {
+    pub const fn new(base: StaticRef<TimgRegisters>) -> Self {
+        TimG {
+            registers: base,
+            alarm_client: OptionalCell::empty(),
+        }
+    }
+
+    pub fn handle_interrupt(&self) {
+        let _ = self.stop();
+        self.alarm_client.map(|client| {
+            client.alarm();
+        });
+    }
+
+    pub fn disable_wdt(&self) {
+        self.registers
+            .wdtconfig0
+            .modify(WDTCONFIG0::EN::CLEAR + WDTCONFIG0::FLASHBOOT_MOD_EN::CLEAR);
+
+        if self.registers.wdtconfig0.is_set(WDTCONFIG0::EN)
+            || self
+                .registers
+                .wdtconfig0
+                .is_set(WDTCONFIG0::FLASHBOOT_MOD_EN)
+        {
+            panic!("Can't disable TIMG WDT");
+        }
+    }
+}
+
+impl time::Time for TimG<'_> {
+    type Frequency = Freq80MHz;
+    type Ticks = Ticks64;
+
+    fn now(&self) -> Self::Ticks {
+        self.registers.t0update.set(0xABC);
+        Self::Ticks::from(
+            self.registers.t0lo.get() as u64 + ((self.registers.t0hi.get() as u64) << 32),
+        )
+    }
+}
+
+impl<'a> Counter<'a> for TimG<'a> {
+    fn set_overflow_client(&'a self, _client: &'a dyn time::OverflowClient) {
+        // We have no way to know when this happens
+    }
+
+    fn start(&self) -> Result<(), ErrorCode> {
+        self.registers.t0config.write(CONFIG::EN::SET);
+
+        Ok(())
+    }
+
+    fn stop(&self) -> Result<(), ErrorCode> {
+        self.registers.t0config.write(CONFIG::EN::CLEAR);
+
+        Ok(())
+    }
+
+    fn reset(&self) -> Result<(), ErrorCode> {
+        Err(ErrorCode::FAIL)
+    }
+
+    fn is_running(&self) -> bool {
+        self.registers.t0config.is_set(CONFIG::EN)
+    }
+}
+
+impl<'a> Alarm<'a> for TimG<'a> {
+    fn set_alarm_client(&self, client: &'a dyn time::AlarmClient) {
+        self.alarm_client.set(client);
+    }
+
+    fn set_alarm(&self, _reference: Self::Ticks, _dt: Self::Ticks) {
+        panic!("Unimplemented");
+    }
+
+    fn get_alarm(&self) -> Self::Ticks {
+        panic!("Unimplemented");
+    }
+
+    fn disarm(&self) -> Result<(), ErrorCode> {
+        panic!("Unimplemented");
+    }
+
+    fn is_armed(&self) -> bool {
+        panic!("Unimplemented");
+    }
+
+    fn minimum_dt(&self) -> Self::Ticks {
+        Self::Ticks::from(1 as u64)
+    }
+}
+
+impl kernel::SchedulerTimer for TimG<'_> {
+    fn start(&self, _us: u32) {
+        panic!("Unimplemented");
+    }
+
+    fn reset(&self) {
+        panic!("Unimplemented");
+    }
+
+    fn arm(&self) {
+        panic!("Unimplemented");
+    }
+
+    fn disarm(&self) {
+        panic!("Unimplemented");
+    }
+
+    fn get_remaining_us(&self) -> Option<u32> {
+        panic!("Unimplemented");
+    }
+}

--- a/chips/esp32/src/uart.rs
+++ b/chips/esp32/src/uart.rs
@@ -1,0 +1,418 @@
+//! UART driver.
+
+use core::cell::Cell;
+use kernel::ErrorCode;
+
+use kernel::common::cells::OptionalCell;
+use kernel::common::cells::TakeCell;
+use kernel::common::registers::interfaces::{ReadWriteable, Readable, Writeable};
+use kernel::common::registers::{register_bitfields, register_structs, ReadWrite};
+use kernel::common::StaticRef;
+use kernel::hil;
+
+pub const UART0_BASE: StaticRef<UartRegisters> =
+    unsafe { StaticRef::new(0x6000_0000 as *const UartRegisters) };
+
+register_structs! {
+    pub UartRegisters {
+        (0x000 => fifo: ReadWrite<u32, FIFO::Register>),
+        (0x004 => int_raw: ReadWrite<u32, INT::Register>),
+        (0x008 => int_st: ReadWrite<u32, INT::Register>),
+        (0x00C => int_ena: ReadWrite<u32, INT::Register>),
+        (0x010 => int_clr: ReadWrite<u32, INT::Register>),
+        (0x014 => clkdiv: ReadWrite<u32, CLKDIV::Register>),
+        (0x018 => autobaud: ReadWrite<u32, AUTOBAUD::Register>),
+        (0x01C => status: ReadWrite<u32, STATUS::Register>),
+        (0x020 => conf0: ReadWrite<u32, CONF0::Register>),
+        (0x024 => conf1: ReadWrite<u32, CONF1::Register>),
+        (0x028 => lowpulse: ReadWrite<u32, LOWPULSE::Register>),
+        (0x02C => highpulse: ReadWrite<u32, HIGHPULSE::Register>),
+        (0x030 => rxd_cnt: ReadWrite<u32, RXD_CNT::Register>),
+        (0x034 => flow_config: ReadWrite<u32, FLOW_CONFIG::Register>),
+        (0x038 => sleep_conf: ReadWrite<u32, SLEEP_CONF::Register>),
+        (0x03C => swfc_conf: ReadWrite<u32, SWFC_CONF::Register>),
+        (0x040 => idle_conf: ReadWrite<u32, IDLE_CONF::Register>),
+        (0x044 => rs485_conf: ReadWrite<u32, RS485_CONF::Register>),
+        (0x048 => at_cmd_precnt: ReadWrite<u32, AT_CMD_PRECNT::Register>),
+        (0x04C => at_cmd_postcnt: ReadWrite<u32, AT_CMD_POSTCNT::Register>),
+        (0x050 => at_cmd_gaptout: ReadWrite<u32, AT_CMD_GAPTOUT::Register>),
+        (0x054 => at_cmd_char: ReadWrite<u32, AT_CMD_CHAR::Register>),
+        (0x058 => mem_conf: ReadWrite<u32, MEM_CONF::Register>),
+        (0x05C => _reserved0),
+        (0x064 => mem_cnt_status: ReadWrite<u32, MEM_CNT_STATUS::Register>),
+        (0x068 => pospulse: ReadWrite<u32, POSPULSE::Register>),
+        (0x06C => negpulse: ReadWrite<u32, NEGPULSE::Register>),
+        (0x070 => @END),
+    }
+}
+
+register_bitfields![u32,
+    FIFO [
+        RXFIFO_RD_BYTE OFFSET(0) NUMBITS(8) [],
+    ],
+    INT [
+        RXFIFO_FULL_INT OFFSET(0) NUMBITS(1) [],
+        TXFIFO_EMPTY_INT OFFSET(1) NUMBITS(1) [],
+        PARITY_ERR_INT OFFSET(2) NUMBITS(1) [],
+        FRM_ERR_INT OFFSET(3) NUMBITS(1) [],
+        RXFIFO_OVF_INT OFFSET(4) NUMBITS(1) [],
+        DSR_CHG_INT OFFSET(5) NUMBITS(1) [],
+        CTS_CHG_INT OFFSET(6) NUMBITS(1) [],
+        BRK_DET_INT OFFSET(7) NUMBITS(1) [],
+        RXFIFO_TOUT_INT OFFSET(8) NUMBITS(1) [],
+        SW_XON_INT OFFSET(9) NUMBITS(1) [],
+        SW_XOFF_INT OFFSET(10) NUMBITS(1) [],
+        GLITCH_DET_INT OFFSET(11) NUMBITS(1) [],
+        TX_BRK_DONE_INT OFFSET(12) NUMBITS(1) [],
+        TX_BRK_IDLE_DONE_INT OFFSET(13) NUMBITS(1) [],
+        TX_DONE_INT OFFSET(14) NUMBITS(1) [],
+        RS485_PARITY_ERR_INT OFFSET(15) NUMBITS(1) [],
+        RS485_FRM_ERR_INT OFFSET(16) NUMBITS(1) [],
+        RS485_CLASH_INT OFFSET(17) NUMBITS(1) [],
+        AT_CMD_CHAR_DET_INT OFFSET(18) NUMBITS(1) [],
+    ],
+    CLKDIV [
+        CLKDIV OFFSET(0) NUMBITS(20) [],
+        CLKDIV_FRAG OFFSET(20) NUMBITS(4) [],
+    ],
+    AUTOBAUD [
+        AUTOBAUD_EN OFFSET(0) NUMBITS(1) [],
+        GLITCH_FILT OFFSET(8) NUMBITS(8) [],
+    ],
+    STATUS [
+        RXFIFO_CNT OFFSET(0) NUMBITS(8) [],
+        ST_URX_OUT OFFSET(8) NUMBITS(4) [],
+        DSRN OFFSET(13) NUMBITS(1) [],
+        CTSN OFFSET(14) NUMBITS(1) [],
+        RXD OFFSET(15) NUMBITS(1) [],
+        TXFIFO_CNT OFFSET(16) NUMBITS(8) [],
+        ST_UTX_OUT OFFSET(24) NUMBITS(4) [],
+        DTRN OFFSET(29) NUMBITS(1) [],
+        RTSN OFFSET(30) NUMBITS(1) [],
+        TXD OFFSET(31) NUMBITS(1) [],
+    ],
+    CONF0 [
+        PARITY OFFSET(0) NUMBITS(1) [],
+        PARITY_EN OFFSET(1) NUMBITS(1) [],
+        BIT_NUM OFFSET(2) NUMBITS(2) [],
+        STOP_BIT_NUM OFFSET(4) NUMBITS(2) [],
+        SW_RTS OFFSET(6) NUMBITS(1) [],
+        SW_DTR OFFSET(7) NUMBITS(1) [],
+        TXD_BRK OFFSET(8) NUMBITS(1) [],
+        IRDA_DPLX OFFSET(9) NUMBITS(1) [],
+        IRDA_TX_EN OFFSET(10) NUMBITS(1) [],
+        IRDA_WCTL OFFSET(11) NUMBITS(1) [],
+        IRDA_TX_INV OFFSET(12) NUMBITS(1) [],
+        IRDA_RX_INV OFFSET(13) NUMBITS(1) [],
+        LOOPBACK OFFSET(14) NUMBITS(1) [],
+        TX_FLOW_EN OFFSET(15) NUMBITS(1) [],
+        IRDA_EN OFFSET(16) NUMBITS(1) [],
+        RXFIFO_RST OFFSET(17) NUMBITS(1) [],
+        TXFIFO_RST OFFSET(18) NUMBITS(1) [],
+        RXD_INV OFFSET(19) NUMBITS(1) [],
+        CTS_INV OFFSET(20) NUMBITS(1) [],
+        DSR_INV OFFSET(21) NUMBITS(1) [],
+        TXD_INV OFFSET(22) NUMBITS(1) [],
+        RTS_INV OFFSET(23) NUMBITS(1) [],
+        DTR_INV OFFSET(24) NUMBITS(1) [],
+        TICK_REF_ALWAYS_ON OFFSET(27) NUMBITS(1) [],
+    ],
+    CONF1 [
+        RXFIFO_FULL_THRHD OFFSET(0) NUMBITS(7) [],
+        TXFIFO_EMPTY_THRHD OFFSET(8) NUMBITS(6) [],
+        RX_FLOW_THRHD OFFSET(16) NUMBITS(6) [],
+        RX_FLOW_EN OFFSET(23) NUMBITS(1) [],
+        RX_TOUT_THRHD OFFSET(24) NUMBITS(7) [],
+        RX_TOUT_EN OFFSET(31) NUMBITS(1) [],
+    ],
+    LOWPULSE [
+        LOWPULSE_MIN_CNT OFFSET(0) NUMBITS(20) [],
+    ],
+    HIGHPULSE [
+        HIGHPULSE_MIN_CNT OFFSET(0) NUMBITS(20) []
+    ],
+    RXD_CNT [
+        RXD_EDGE_CNT OFFSET(0) NUMBITS(10) [],
+    ],
+    FLOW_CONFIG [
+        SW_FLOW_CON_EN OFFSET(0) NUMBITS(1) [],
+        XONOFF_DEL OFFSET(1) NUMBITS(1) [],
+        FORCE_XON OFFSET(2) NUMBITS(1) [],
+        FORCE_XOFF OFFSET(3) NUMBITS(1) [],
+        SEND_XON OFFSET(4) NUMBITS(1) [],
+        SEND_XOFF OFFSET(5) NUMBITS(1) [],
+    ],
+    SLEEP_CONF [
+        ACTIVE_THRESHOLD OFFSET(0) NUMBITS(10) [],
+    ],
+    SWFC_CONF [
+        XON_THRESHOLD OFFSET(0) NUMBITS(8) [],
+        XOFF_THRESHOLD OFFSET(8) NUMBITS(8) [],
+        XON_CHAR OFFSET(16) NUMBITS(8) [],
+        XOFF_CHAR OFFSET(24) NUMBITS(8) [],
+    ],
+    IDLE_CONF [
+        RX_IDLE_THRHD OFFSET(0) NUMBITS(10) [],
+        TX_IDLE_NUM OFFSET(10) NUMBITS(10) [],
+        TX_BRK_NUM OFFSET(20) NUMBITS(8) [],
+    ],
+    RS485_CONF [
+        RS485_EN OFFSET(0) NUMBITS(1) [],
+        DL0_EN OFFSET(1) NUMBITS(1) [],
+        DL1_EN OFFSET(2) NUMBITS(1) [],
+        RS485TX_RX_EN OFFSET(3) NUMBITS(1) [],
+        RS485RXBY_TX_EN OFFSET(4) NUMBITS(1) [],
+        RS485_RX_DLY_NUM OFFSET(5) NUMBITS(1) [],
+        RS485_TX_DLY_NUM OFFSET(6) NUMBITS(4) [],
+    ],
+    AT_CMD_PRECNT [
+        PRE_IDLE_NUM OFFSET(0) NUMBITS(24) [],
+    ],
+    AT_CMD_POSTCNT [
+        POST_IDLE_NUM OFFSET(0) NUMBITS(24) [],
+    ],
+    AT_CMD_GAPTOUT [
+        RX_GAP_TOUT OFFSET(0) NUMBITS(24) [],
+    ],
+    AT_CMD_CHAR [
+        AT_CMD_CHAR_REG OFFSET(0) NUMBITS(8) [],
+        CHAR_NUM OFFSET(8) NUMBITS(8) [],
+    ],
+    MEM_CONF [
+        MEM_PD OFFSET(0) NUMBITS(1) [],
+        RX_SIZE OFFSET(3) NUMBITS(4) [],
+        TX_SIZE OFFSET(7) NUMBITS(4) [],
+        RX_FLOW_THRHD_H3 OFFSET(15) NUMBITS(3) [],
+        RX_TOUT_THRHD_H3 OFFSET(18) NUMBITS(3) [],
+        XON_THRESHOLD_H2 OFFSET(21) NUMBITS(2) [],
+        XOFF_THRESHOLD_H2 OFFSET(23) NUMBITS(2) [],
+        RX_MEM_FULL_THRHD OFFSET(25) NUMBITS(3) [],
+        TX_MEM_EMPTY_THRHD OFFSET(28) NUMBITS(3) [],
+    ],
+    MEM_CNT_STATUS [
+        RX_MEM_CNT OFFSET(0) NUMBITS(3) [],
+        TX_MEM_CNT OFFSET(3) NUMBITS(3) [],
+    ],
+    POSPULSE [
+        POSEDGE_MIN_CNT OFFSET(0) NUMBITS(20) [],
+    ],
+    NEGPULSE [
+        NEGEDGE_MIN_CNT OFFSET(0) NUMBITS(20) [],
+    ],
+];
+
+pub struct Uart<'a> {
+    registers: StaticRef<UartRegisters>,
+    tx_client: OptionalCell<&'a dyn hil::uart::TransmitClient>,
+    rx_client: OptionalCell<&'a dyn hil::uart::ReceiveClient>,
+
+    tx_buffer: TakeCell<'static, [u8]>,
+    tx_len: Cell<usize>,
+    tx_index: Cell<usize>,
+
+    rx_buffer: TakeCell<'static, [u8]>,
+    rx_len: Cell<usize>,
+}
+
+#[derive(Copy, Clone)]
+pub struct UartParams {
+    pub baud_rate: u32,
+}
+
+impl<'a> Uart<'a> {
+    pub const fn new(base: StaticRef<UartRegisters>) -> Uart<'a> {
+        Uart {
+            registers: base,
+            tx_client: OptionalCell::empty(),
+            rx_client: OptionalCell::empty(),
+            tx_buffer: TakeCell::empty(),
+            tx_len: Cell::new(0),
+            tx_index: Cell::new(0),
+            rx_buffer: TakeCell::empty(),
+            rx_len: Cell::new(0),
+        }
+    }
+
+    fn enable_tx_interrupt(&self) {
+        let regs = self.registers;
+
+        regs.int_ena.modify(
+            INT::TXFIFO_EMPTY_INT::SET
+                + INT::TX_BRK_DONE_INT::SET
+                + INT::TX_BRK_IDLE_DONE_INT::SET
+                + INT::TX_DONE_INT::SET,
+        );
+    }
+
+    pub fn disable_tx_interrupt(&self) {
+        let regs = self.registers;
+
+        regs.int_clr.modify(
+            INT::TXFIFO_EMPTY_INT::SET
+                + INT::TX_BRK_DONE_INT::SET
+                + INT::TX_BRK_IDLE_DONE_INT::SET
+                + INT::TX_DONE_INT::SET,
+        );
+        regs.int_ena.modify(
+            INT::TXFIFO_EMPTY_INT::CLEAR
+                + INT::TX_BRK_DONE_INT::CLEAR
+                + INT::TX_BRK_IDLE_DONE_INT::CLEAR
+                + INT::TX_DONE_INT::CLEAR,
+        );
+    }
+
+    fn enable_rx_interrupt(&self) {
+        let regs = self.registers;
+
+        regs.int_ena.modify(
+            INT::RXFIFO_FULL_INT::SET + INT::RXFIFO_OVF_INT::SET + INT::RXFIFO_TOUT_INT::SET,
+        );
+    }
+
+    pub fn disable_rx_interrupt(&self) {
+        let regs = self.registers;
+
+        regs.int_clr.modify(
+            INT::RXFIFO_FULL_INT::SET + INT::RXFIFO_OVF_INT::SET + INT::RXFIFO_TOUT_INT::SET,
+        );
+        regs.int_ena.modify(
+            INT::RXFIFO_FULL_INT::CLEAR + INT::RXFIFO_OVF_INT::CLEAR + INT::RXFIFO_TOUT_INT::CLEAR,
+        );
+    }
+
+    fn tx_progress(&self) {
+        let regs = self.registers;
+        let idx = self.tx_index.get();
+        let len = self.tx_len.get();
+
+        if idx < len {
+            // If we are going to transmit anything, we first need to enable the
+            // TX interrupt. This ensures that we will get an interrupt, where
+            // we can either call the callback from, or continue transmitting
+            // bytes.
+            self.enable_tx_interrupt();
+
+            // Read from the transmit buffer and send bytes to the UART hardware
+            // until either the buffer is empty or the UART hardware is full.
+            self.tx_buffer.map(|tx_buf| {
+                let tx_len = len - idx;
+
+                for i in 0..tx_len {
+                    if regs.status.read(STATUS::TXFIFO_CNT) >= 127 {
+                        break;
+                    }
+                    let tx_idx = idx + i;
+                    regs.fifo
+                        .write(FIFO::RXFIFO_RD_BYTE.val(tx_buf[tx_idx] as u32));
+                    self.tx_index.set(tx_idx + 1)
+                }
+            });
+        }
+    }
+
+    pub fn handle_interrupt(&self) {
+        let regs = self.registers;
+        let intrs = regs.int_st.extract();
+
+        if intrs.is_set(INT::TXFIFO_EMPTY_INT) {
+            self.disable_tx_interrupt();
+
+            if self.tx_index.get() == self.tx_len.get() {
+                // We sent everything to the UART hardware, now from an
+                // interrupt callback we can issue the callback.
+                self.tx_client.map(|client| {
+                    self.tx_buffer.take().map(|tx_buf| {
+                        client.transmitted_buffer(tx_buf, self.tx_len.get(), Ok(()));
+                    });
+                });
+            } else {
+                // We have more to transmit, so continue in tx_progress().
+                self.tx_progress();
+            }
+        }
+    }
+
+    pub fn transmit_sync(&self, bytes: &[u8]) {
+        let regs = self.registers;
+        for b in bytes.iter() {
+            while regs.status.read(STATUS::TXFIFO_CNT) > 8 {}
+            regs.fifo.write(FIFO::RXFIFO_RD_BYTE.val(*b as u32));
+        }
+    }
+}
+
+impl hil::uart::Configure for Uart<'_> {
+    fn configure(&self, _params: hil::uart::Parameters) -> Result<(), ErrorCode> {
+        // Disable all interrupts for now
+        self.disable_rx_interrupt();
+        self.disable_tx_interrupt();
+
+        Ok(())
+    }
+}
+
+impl<'a> hil::uart::Transmit<'a> for Uart<'a> {
+    fn set_transmit_client(&self, client: &'a dyn hil::uart::TransmitClient) {
+        self.tx_client.set(client);
+    }
+
+    fn transmit_buffer(
+        &self,
+        tx_data: &'static mut [u8],
+        tx_len: usize,
+    ) -> Result<(), (ErrorCode, &'static mut [u8])> {
+        if tx_len == 0 || tx_len > tx_data.len() {
+            Err((ErrorCode::SIZE, tx_data))
+        } else if self.tx_buffer.is_some() {
+            Err((ErrorCode::BUSY, tx_data))
+        } else {
+            // Save the buffer so we can keep sending it.
+            self.tx_buffer.replace(tx_data);
+            self.tx_len.set(tx_len);
+            self.tx_index.set(0);
+
+            self.tx_progress();
+            Ok(())
+        }
+    }
+
+    fn transmit_abort(&self) -> Result<(), ErrorCode> {
+        Err(ErrorCode::FAIL)
+    }
+
+    fn transmit_word(&self, _word: u32) -> Result<(), ErrorCode> {
+        Err(ErrorCode::FAIL)
+    }
+}
+
+/* UART receive is not implemented yet, mostly due to a lack of tests avaliable */
+impl<'a> hil::uart::Receive<'a> for Uart<'a> {
+    fn set_receive_client(&self, client: &'a dyn hil::uart::ReceiveClient) {
+        self.rx_client.set(client);
+    }
+
+    fn receive_buffer(
+        &self,
+        rx_buffer: &'static mut [u8],
+        rx_len: usize,
+    ) -> Result<(), (ErrorCode, &'static mut [u8])> {
+        if rx_len == 0 || rx_len > rx_buffer.len() {
+            return Err((ErrorCode::SIZE, rx_buffer));
+        }
+
+        self.enable_rx_interrupt();
+
+        self.rx_buffer.replace(rx_buffer);
+        self.rx_len.set(rx_len);
+
+        Ok(())
+    }
+
+    fn receive_abort(&self) -> Result<(), ErrorCode> {
+        Err(ErrorCode::FAIL)
+    }
+
+    fn receive_word(&self) -> Result<(), ErrorCode> {
+        Err(ErrorCode::FAIL)
+    }
+}


### PR DESCRIPTION
### Pull Request Overview

The [ESP32-C3](https://www.espressif.com/en/news/ESP32_C3) is a MCU from Espressif that uses a custom ISA. The ISA is based on RISC-V and shares lots of features and functionality but does not follow the RISC-V spec. It is close enough though that we can run RISC-V Tock on the core.

This PR adds support for the ESP32-C3-DevKitM-1 v1.6 board.

### Testing Strategy

I have tested this on an engineering sample board that I have.

### TODO or Help Wanted

- [x] GPIO support

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
