### PR TITLE
Add I2C error verifications for lsm303

### DIFF
--- a/boards/microbit_v2/src/main.rs
+++ b/boards/microbit_v2/src/main.rs
@@ -366,7 +366,7 @@ pub unsafe fn main() {
     )
     .finalize(components::lsm303agr_i2c_component_helper!(sensors_i2c_bus));
 
-    lsm303agr.configure(
+    if let Err(error) = lsm303agr.configure(
         capsules::lsm303xx::Lsm303AccelDataRate::DataRate25Hz,
         false,
         capsules::lsm303xx::Lsm303Scale::Scale2G,
@@ -374,7 +374,9 @@ pub unsafe fn main() {
         true,
         capsules::lsm303xx::Lsm303MagnetoDataRate::DataRate3_0Hz,
         capsules::lsm303xx::Lsm303Range::Range1_9G,
-    );
+    ) {
+        debug!("Failed to configure LSM303AGR sensor ({:?})", error);
+    }
 
     let ninedof =
         components::ninedof::NineDofComponent::new(board_kernel, capsules::ninedof::DRIVER_NUM)

--- a/boards/stm32f3discovery/src/main.rs
+++ b/boards/stm32f3discovery/src/main.rs
@@ -642,7 +642,7 @@ pub unsafe fn main() {
     )
     .finalize(components::lsm303dlhc_i2c_component_helper!(mux_i2c));
 
-    lsm303dlhc.configure(
+    if let Err(error) = lsm303dlhc.configure(
         lsm303xx::Lsm303AccelDataRate::DataRate25Hz,
         false,
         lsm303xx::Lsm303Scale::Scale2G,
@@ -650,7 +650,9 @@ pub unsafe fn main() {
         true,
         lsm303xx::Lsm303MagnetoDataRate::DataRate3_0Hz,
         lsm303xx::Lsm303Range::Range1_9G,
-    );
+    ) {
+        debug!("Failed to configure LSM303DLHC sensor ({:?})", error);
+    }
 
     let ninedof =
         components::ninedof::NineDofComponent::new(board_kernel, capsules::ninedof::DRIVER_NUM)

--- a/capsules/src/lsm303agr.rs
+++ b/capsules/src/lsm303agr.rs
@@ -82,13 +82,10 @@
 use core::cell::Cell;
 use enum_primitive::cast::FromPrimitive;
 use enum_primitive::enum_from_primitive;
+use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::hil::i2c;
 use kernel::hil::sensors;
-use kernel::{
-    common::cells::{OptionalCell, TakeCell},
-    hil::i2c::I2CClient,
-};
-use kernel::{CommandReturn, Driver, ErrorCode, Grant, ProcessId, Upcall};
+use kernel::{CommandReturn, Driver, ErrorCode, Grant, ProcessId};
 
 use crate::driver;
 use crate::lsm303xx::{
@@ -195,7 +192,7 @@ impl<'a> Lsm303agrI2C<'a> {
         temperature: bool,
         mag_data_rate: Lsm303MagnetoDataRate,
         mag_range: Lsm303Range,
-    ) {
+    ) -> Result<(), ErrorCode> {
         if self.state.get() == State::Idle {
             self.config_in_progress.set(true);
 
@@ -207,26 +204,35 @@ impl<'a> Lsm303agrI2C<'a> {
             self.accel_data_rate.set(accel_data_rate);
             self.low_power.set(low_power);
 
-            self.set_power_mode(accel_data_rate, low_power);
+            self.set_power_mode(accel_data_rate, low_power)
+        } else {
+            Err(ErrorCode::BUSY)
         }
     }
 
-    fn is_present(&self) {
+    fn is_present(&self) -> Result<(), ErrorCode> {
         self.state.set(State::IsPresent);
-        self.buffer.take().map(|buf| {
+        self.buffer.take().map_or(Err(ErrorCode::NOMEM), |buf| {
             // turn on i2c to send commands
             buf[0] = 0x0F;
             self.i2c_magnetometer.enable();
             if let Err((error, buf)) = self.i2c_magnetometer.write_read(buf, 1, 1) {
-                self.command_complete(buf, Err(error));
+                self.buffer.replace(buf);
+                Err(error.into())
+            } else {
+                Ok(())
             }
-        });
+        })
     }
 
-    fn set_power_mode(&self, data_rate: Lsm303AccelDataRate, low_power: bool) {
+    fn set_power_mode(
+        &self,
+        data_rate: Lsm303AccelDataRate,
+        low_power: bool,
+    ) -> Result<(), ErrorCode> {
         if self.state.get() == State::Idle {
             self.state.set(State::SetPowerMode);
-            self.buffer.take().map(|buf| {
+            self.buffer.take().map_or(Err(ErrorCode::NOMEM), |buf| {
                 buf[0] = AccelerometerRegisters::CTRL_REG1 as u8;
                 buf[1] = (CTRL_REG1::ODR.val(data_rate as u8)
                     + CTRL_REG1::LPEN.val(low_power as u8)
@@ -236,19 +242,28 @@ impl<'a> Lsm303agrI2C<'a> {
                     .value;
                 self.i2c_accelerometer.enable();
                 if let Err((error, buf)) = self.i2c_accelerometer.write(buf, 2) {
-                    self.command_complete(buf, Err(error));
+                    self.buffer.replace(buf);
+                    Err(error.into())
+                } else {
+                    Ok(())
                 }
-            });
+            })
+        } else {
+            Err(ErrorCode::BUSY)
         }
     }
 
-    fn set_scale_and_resolution(&self, scale: Lsm303Scale, high_resolution: bool) {
+    fn set_scale_and_resolution(
+        &self,
+        scale: Lsm303Scale,
+        high_resolution: bool,
+    ) -> Result<(), ErrorCode> {
         if self.state.get() == State::Idle {
             self.state.set(State::SetScaleAndResolution);
             // TODO move these in completed
             self.accel_scale.set(scale);
             self.accel_high_resolution.set(high_resolution);
-            self.buffer.take().map(|buf| {
+            self.buffer.take().map_or(Err(ErrorCode::NOMEM), |buf| {
                 buf[0] = AccelerometerRegisters::CTRL_REG4 as u8;
                 buf[1] = (CTRL_REG4::FS.val(scale as u8)
                     + CTRL_REG4::HR.val(high_resolution as u8)
@@ -256,78 +271,108 @@ impl<'a> Lsm303agrI2C<'a> {
                     .value;
                 self.i2c_accelerometer.enable();
                 if let Err((error, buf)) = self.i2c_accelerometer.write(buf, 2) {
-                    self.command_complete(buf, Err(error));
+                    self.buffer.replace(buf);
+                    Err(error.into())
+                } else {
+                    Ok(())
                 }
-            });
+            })
+        } else {
+            Err(ErrorCode::BUSY)
         }
     }
 
-    fn read_acceleration_xyz(&self) {
+    fn read_acceleration_xyz(&self) -> Result<(), ErrorCode> {
         if self.state.get() == State::Idle {
             self.state.set(State::ReadAccelerationXYZ);
-            self.buffer.take().map(|buf| {
+            self.buffer.take().map_or(Err(ErrorCode::NOMEM), |buf| {
                 buf[0] = AccelerometerRegisters::OUT_X_L_A as u8 | REGISTER_AUTO_INCREMENT;
                 self.i2c_accelerometer.enable();
                 if let Err((error, buf)) = self.i2c_accelerometer.write_read(buf, 1, 6) {
-                    self.command_complete(buf, Err(error));
+                    self.buffer.replace(buf);
+                    Err(error.into())
+                } else {
+                    Ok(())
                 }
-            });
+            })
+        } else {
+            Err(ErrorCode::BUSY)
         }
     }
 
-    fn set_magneto_data_rate(&self, data_rate: Lsm303MagnetoDataRate) {
+    fn set_magneto_data_rate(&self, data_rate: Lsm303MagnetoDataRate) -> Result<(), ErrorCode> {
         if self.state.get() == State::Idle {
             self.state.set(State::SetDataRate);
-            self.buffer.take().map(|buf| {
+            self.buffer.take().map_or(Err(ErrorCode::NOMEM), |buf| {
                 buf[0] = MagnetometerRegisters::CRA_REG_M as u8;
                 buf[1] = ((data_rate as u8) << 2) | 1 << 7;
                 self.i2c_magnetometer.enable();
-                // TODO verify errors
-                let _ = self.i2c_magnetometer.write(buf, 2);
-            });
+                if let Err((error, buf)) = self.i2c_magnetometer.write(buf, 2) {
+                    self.buffer.replace(buf);
+                    Err(error.into())
+                } else {
+                    Ok(())
+                }
+            })
+        } else {
+            Err(ErrorCode::BUSY)
         }
     }
 
-    fn set_range(&self, range: Lsm303Range) {
+    fn set_range(&self, range: Lsm303Range) -> Result<(), ErrorCode> {
         if self.state.get() == State::Idle {
             self.state.set(State::SetRange);
-            // TODO move these in completed
             self.mag_range.set(range);
-            self.buffer.take().map(|buf| {
+            self.buffer.take().map_or(Err(ErrorCode::NOMEM), |buf| {
                 buf[0] = MagnetometerRegisters::CRB_REG_M as u8;
                 buf[1] = (range as u8) << 5;
                 buf[2] = 0;
                 self.i2c_magnetometer.enable();
                 if let Err((error, buf)) = self.i2c_magnetometer.write(buf, 3) {
-                    self.command_complete(buf, Err(error));
+                    self.buffer.replace(buf);
+                    Err(error.into())
+                } else {
+                    Ok(())
                 }
-            });
+            })
+        } else {
+            Err(ErrorCode::BUSY)
         }
     }
 
-    fn read_temperature(&self) {
+    fn read_temperature(&self) -> Result<(), ErrorCode> {
         if self.state.get() == State::Idle {
             self.state.set(State::ReadTemperature);
-            self.buffer.take().map(|buf| {
+            self.buffer.take().map_or(Err(ErrorCode::NOMEM), |buf| {
                 buf[0] = AgrAccelerometerRegisters::TEMP_OUT_H_A as u8;
                 self.i2c_accelerometer.enable();
                 if let Err((error, buf)) = self.i2c_accelerometer.write_read(buf, 1, 2) {
-                    self.command_complete(buf, Err(error));
+                    self.buffer.replace(buf);
+                    Err(error.into())
+                } else {
+                    Ok(())
                 }
-            });
+            })
+        } else {
+            Err(ErrorCode::BUSY)
         }
     }
 
-    fn read_magnetometer_xyz(&self) {
+    fn read_magnetometer_xyz(&self) -> Result<(), ErrorCode> {
         if self.state.get() == State::Idle {
             self.state.set(State::ReadMagnetometerXYZ);
-            self.buffer.take().map(|buf| {
+            self.buffer.take().map_or(Err(ErrorCode::NOMEM), |buf| {
                 buf[0] = MagnetometerRegisters::OUT_X_H_M as u8;
                 self.i2c_magnetometer.enable();
                 if let Err((error, buf)) = self.i2c_magnetometer.write_read(buf, 1, 6) {
-                    self.command_complete(buf, Err(error));
+                    self.buffer.replace(buf);
+                    Err(error.into())
+                } else {
+                    Ok(())
                 }
-            });
+            })
+        } else {
+            Err(ErrorCode::BUSY)
         }
     }
 }
@@ -365,7 +410,7 @@ impl i2c::I2CClient for Lsm303agrI2C<'_> {
                 self.i2c_accelerometer.disable();
                 self.state.set(State::Idle);
                 if self.config_in_progress.get() {
-                    self.set_scale_and_resolution(
+                    let _ = self.set_scale_and_resolution(
                         self.accel_scale.get(),
                         self.accel_high_resolution.get(),
                     );
@@ -384,7 +429,7 @@ impl i2c::I2CClient for Lsm303agrI2C<'_> {
                 self.i2c_accelerometer.disable();
                 self.state.set(State::Idle);
                 if self.config_in_progress.get() {
-                    self.set_magneto_data_rate(self.mag_data_rate.get());
+                    let _ = self.set_magneto_data_rate(self.mag_data_rate.get());
                 }
             }
             State::ReadAccelerationXYZ => {
@@ -446,7 +491,7 @@ impl i2c::I2CClient for Lsm303agrI2C<'_> {
                 self.i2c_magnetometer.disable();
                 self.state.set(State::Idle);
                 if self.config_in_progress.get() {
-                    self.set_range(self.mag_range.get());
+                    let _ = self.set_range(self.mag_range.get());
                 }
             }
             State::SetRange => {
@@ -570,8 +615,10 @@ impl Driver for Lsm303agrI2C<'_> {
             // Check is sensor is correctly connected
             1 => {
                 if self.state.get() == State::Idle {
-                    self.is_present();
-                    CommandReturn::success()
+                    match self.is_present() {
+                        Ok(()) => CommandReturn::success(),
+                        Err(error) => CommandReturn::failure(error),
+                    }
                 } else {
                     CommandReturn::failure(ErrorCode::BUSY)
                 }
@@ -580,8 +627,11 @@ impl Driver for Lsm303agrI2C<'_> {
             2 => {
                 if self.state.get() == State::Idle {
                     if let Some(data_rate) = Lsm303AccelDataRate::from_usize(data1) {
-                        self.set_power_mode(data_rate, if data2 != 0 { true } else { false });
-                        CommandReturn::success()
+                        match self.set_power_mode(data_rate, if data2 != 0 { true } else { false })
+                        {
+                            Ok(()) => CommandReturn::success(),
+                            Err(error) => CommandReturn::failure(error),
+                        }
                     } else {
                         CommandReturn::failure(ErrorCode::INVAL)
                     }
@@ -593,8 +643,12 @@ impl Driver for Lsm303agrI2C<'_> {
             3 => {
                 if self.state.get() == State::Idle {
                     if let Some(scale) = Lsm303Scale::from_usize(data1) {
-                        self.set_scale_and_resolution(scale, if data2 != 0 { true } else { false });
-                        CommandReturn::success()
+                        match self
+                            .set_scale_and_resolution(scale, if data2 != 0 { true } else { false })
+                        {
+                            Ok(()) => CommandReturn::success(),
+                            Err(error) => CommandReturn::failure(error),
+                        }
                     } else {
                         CommandReturn::failure(ErrorCode::INVAL)
                     }
@@ -606,8 +660,10 @@ impl Driver for Lsm303agrI2C<'_> {
             4 => {
                 if self.state.get() == State::Idle {
                     if let Some(data_rate) = Lsm303MagnetoDataRate::from_usize(data1) {
-                        self.set_magneto_data_rate(data_rate);
-                        CommandReturn::success()
+                        match self.set_magneto_data_rate(data_rate) {
+                            Ok(()) => CommandReturn::success(),
+                            Err(error) => CommandReturn::failure(error),
+                        }
                     } else {
                         CommandReturn::failure(ErrorCode::INVAL)
                     }
@@ -619,38 +675,13 @@ impl Driver for Lsm303agrI2C<'_> {
             5 => {
                 if self.state.get() == State::Idle {
                     if let Some(range) = Lsm303Range::from_usize(data1) {
-                        self.set_range(range);
-                        CommandReturn::success()
+                        match self.set_range(range) {
+                            Ok(()) => CommandReturn::success(),
+                            Err(error) => CommandReturn::failure(error),
+                        }
                     } else {
                         CommandReturn::failure(ErrorCode::INVAL)
                     }
-                } else {
-                    CommandReturn::failure(ErrorCode::BUSY)
-                }
-            }
-            // Read Acceleration XYZ
-            6 => {
-                if self.state.get() == State::Idle {
-                    self.read_acceleration_xyz();
-                    CommandReturn::success()
-                } else {
-                    CommandReturn::failure(ErrorCode::BUSY)
-                }
-            }
-            // Read Temperature
-            7 => {
-                if self.state.get() == State::Idle {
-                    self.read_temperature();
-                    CommandReturn::success()
-                } else {
-                    CommandReturn::failure(ErrorCode::BUSY)
-                }
-            }
-            // Read Mangetometer XYZ
-            8 => {
-                if self.state.get() == State::Idle {
-                    self.read_magnetometer_xyz();
-                    CommandReturn::success()
                 } else {
                     CommandReturn::failure(ErrorCode::BUSY)
                 }
@@ -671,21 +702,11 @@ impl<'a> sensors::NineDof<'a> for Lsm303agrI2C<'a> {
     }
 
     fn read_accelerometer(&self) -> Result<(), ErrorCode> {
-        if self.state.get() == State::Idle {
-            self.read_acceleration_xyz();
-            Ok(())
-        } else {
-            Err(ErrorCode::BUSY)
-        }
+        self.read_acceleration_xyz()
     }
 
     fn read_magnetometer(&self) -> Result<(), ErrorCode> {
-        if self.state.get() == State::Idle {
-            self.read_magnetometer_xyz();
-            Ok(())
-        } else {
-            Err(ErrorCode::BUSY)
-        }
+        self.read_magnetometer_xyz()
     }
 }
 
@@ -695,11 +716,6 @@ impl<'a> sensors::TemperatureDriver<'a> for Lsm303agrI2C<'a> {
     }
 
     fn read_temperature(&self) -> Result<(), ErrorCode> {
-        if self.state.get() == State::Idle {
-            self.read_temperature();
-            Ok(())
-        } else {
-            Err(ErrorCode::BUSY)
-        }
+        self.read_temperature()
     }
 }

--- a/capsules/src/lsm303dlhc.rs
+++ b/capsules/src/lsm303dlhc.rs
@@ -82,7 +82,7 @@ use core::cell::Cell;
 use enum_primitive::cast::FromPrimitive;
 use enum_primitive::enum_from_primitive;
 use kernel::common::cells::{OptionalCell, TakeCell};
-use kernel::hil::i2c;
+use kernel::hil::i2c::{self, I2CClient};
 use kernel::hil::sensors;
 use kernel::{CommandReturn, Driver, ErrorCode, Grant, ProcessId};
 
@@ -211,8 +211,9 @@ impl<'a> Lsm303dlhcI2C<'a> {
             // turn on i2c to send commands
             buf[0] = 0x0F;
             self.i2c_magnetometer.enable();
-            // TODO verify errors
-            let _ = self.i2c_magnetometer.write_read(buf, 1, 1);
+            if let Err((error, buf)) = self.i2c_magnetometer.write_read(buf, 1, 1) {
+                self.command_complete(buf, Err(error));
+            }
         });
     }
 
@@ -228,8 +229,9 @@ impl<'a> Lsm303dlhcI2C<'a> {
                     + CTRL_REG1::XEN::SET)
                     .value;
                 self.i2c_accelerometer.enable();
-                // TODO verify errors
-                let _ = self.i2c_accelerometer.write(buf, 2);
+                if let Err((error, buf)) = self.i2c_accelerometer.write(buf, 2) {
+                    self.command_complete(buf, Err(error));
+                }
             });
         }
     }
@@ -246,8 +248,9 @@ impl<'a> Lsm303dlhcI2C<'a> {
                     + CTRL_REG4::HR.val(high_resolution as u8))
                 .value;
                 self.i2c_accelerometer.enable();
-                // TODO verify errors
-                let _ = self.i2c_accelerometer.write(buf, 2);
+                if let Err((error, buf)) = self.i2c_accelerometer.write(buf, 2) {
+                    self.command_complete(buf, Err(error));
+                }
             });
         }
     }
@@ -258,8 +261,9 @@ impl<'a> Lsm303dlhcI2C<'a> {
             self.buffer.take().map(|buf| {
                 buf[0] = AccelerometerRegisters::OUT_X_L_A as u8 | REGISTER_AUTO_INCREMENT;
                 self.i2c_accelerometer.enable();
-                // TODO verify errors
-                let _ = self.i2c_accelerometer.write_read(buf, 1, 6);
+                if let Err((error, buf)) = self.i2c_accelerometer.write_read(buf, 1, 6) {
+                    self.command_complete(buf, Err(error));
+                }
             });
         }
     }
@@ -275,8 +279,9 @@ impl<'a> Lsm303dlhcI2C<'a> {
                 buf[0] = MagnetometerRegisters::CRA_REG_M as u8;
                 buf[1] = ((data_rate as u8) << 2) | if temperature { 1 << 7 } else { 0 };
                 self.i2c_magnetometer.enable();
-                // TODO verify errors
-                let _ = self.i2c_magnetometer.write(buf, 2);
+                if let Err((error, buf)) = self.i2c_magnetometer.write(buf, 2) {
+                    self.command_complete(buf, Err(error));
+                }
             });
         }
     }
@@ -291,8 +296,9 @@ impl<'a> Lsm303dlhcI2C<'a> {
                 buf[1] = (range as u8) << 5;
                 buf[2] = 0;
                 self.i2c_magnetometer.enable();
-                // TODO verify errors
-                let _ = self.i2c_magnetometer.write(buf, 3);
+                if let Err((error, buf)) = self.i2c_magnetometer.write(buf, 3) {
+                    self.command_complete(buf, Err(error));
+                }
             });
         }
     }
@@ -303,8 +309,9 @@ impl<'a> Lsm303dlhcI2C<'a> {
             self.buffer.take().map(|buf| {
                 buf[0] = MagnetometerRegisters::TEMP_OUT_H_M as u8;
                 self.i2c_magnetometer.enable();
-                // TODO verify errors
-                let _ = self.i2c_magnetometer.write_read(buf, 1, 2);
+                if let Err((error, buf)) = self.i2c_magnetometer.write_read(buf, 1, 2) {
+                    self.command_complete(buf, Err(error));
+                }
             });
         }
     }
@@ -315,8 +322,9 @@ impl<'a> Lsm303dlhcI2C<'a> {
             self.buffer.take().map(|buf| {
                 buf[0] = MagnetometerRegisters::OUT_X_H_M as u8;
                 self.i2c_magnetometer.enable();
-                // TODO verify errors
-                let _ = self.i2c_magnetometer.write_read(buf, 1, 6);
+                if let Err((error, buf)) = self.i2c_magnetometer.write_read(buf, 1, 6) {
+                    self.command_complete(buf, Err(error));
+                }
             });
         }
     }

--- a/capsules/src/lsm303dlhc.rs
+++ b/capsules/src/lsm303dlhc.rs
@@ -82,7 +82,7 @@ use core::cell::Cell;
 use enum_primitive::cast::FromPrimitive;
 use enum_primitive::enum_from_primitive;
 use kernel::common::cells::{OptionalCell, TakeCell};
-use kernel::hil::i2c::{self, I2CClient};
+use kernel::hil::i2c;
 use kernel::hil::sensors;
 use kernel::{CommandReturn, Driver, ErrorCode, Grant, ProcessId};
 
@@ -189,7 +189,7 @@ impl<'a> Lsm303dlhcI2C<'a> {
         temperature: bool,
         mag_data_rate: Lsm303MagnetoDataRate,
         mag_range: Lsm303Range,
-    ) {
+    ) -> Result<(), ErrorCode> {
         if self.state.get() == State::Idle {
             self.config_in_progress.set(true);
 
@@ -201,26 +201,35 @@ impl<'a> Lsm303dlhcI2C<'a> {
             self.accel_data_rate.set(accel_data_rate);
             self.low_power.set(low_power);
 
-            self.set_power_mode(accel_data_rate, low_power);
+            self.set_power_mode(accel_data_rate, low_power)
+        } else {
+            Err(ErrorCode::BUSY)
         }
     }
 
-    fn is_present(&self) {
+    fn is_present(&self) -> Result<(), ErrorCode> {
         self.state.set(State::IsPresent);
-        self.buffer.take().map(|buf| {
+        self.buffer.take().map_or(Err(ErrorCode::NOMEM), |buf| {
             // turn on i2c to send commands
             buf[0] = 0x0F;
             self.i2c_magnetometer.enable();
             if let Err((error, buf)) = self.i2c_magnetometer.write_read(buf, 1, 1) {
-                self.command_complete(buf, Err(error));
+                self.buffer.replace(buf);
+                Err(error.into())
+            } else {
+                Ok(())
             }
-        });
+        })
     }
 
-    fn set_power_mode(&self, data_rate: Lsm303AccelDataRate, low_power: bool) {
+    fn set_power_mode(
+        &self,
+        data_rate: Lsm303AccelDataRate,
+        low_power: bool,
+    ) -> Result<(), ErrorCode> {
         if self.state.get() == State::Idle {
             self.state.set(State::SetPowerMode);
-            self.buffer.take().map(|buf| {
+            self.buffer.take().map_or(Err(ErrorCode::NOMEM), |buf| {
                 buf[0] = AccelerometerRegisters::CTRL_REG1 as u8;
                 buf[1] = (CTRL_REG1::ODR.val(data_rate as u8)
                     + CTRL_REG1::LPEN.val(low_power as u8)
@@ -230,41 +239,60 @@ impl<'a> Lsm303dlhcI2C<'a> {
                     .value;
                 self.i2c_accelerometer.enable();
                 if let Err((error, buf)) = self.i2c_accelerometer.write(buf, 2) {
-                    self.command_complete(buf, Err(error));
+                    self.buffer.replace(buf);
+                    Err(error.into())
+                } else {
+                    Ok(())
                 }
-            });
+            })
+        } else {
+            Err(ErrorCode::BUSY)
         }
     }
 
-    fn set_scale_and_resolution(&self, scale: Lsm303Scale, high_resolution: bool) {
+    fn set_scale_and_resolution(
+        &self,
+        scale: Lsm303Scale,
+        high_resolution: bool,
+    ) -> Result<(), ErrorCode> {
         if self.state.get() == State::Idle {
             self.state.set(State::SetScaleAndResolution);
             // TODO move these in completed
             self.accel_scale.set(scale);
             self.accel_high_resolution.set(high_resolution);
-            self.buffer.take().map(|buf| {
+            self.buffer.take().map_or(Err(ErrorCode::NOMEM), |buf| {
                 buf[0] = AccelerometerRegisters::CTRL_REG4 as u8;
                 buf[1] = (CTRL_REG4::FS.val(scale as u8)
                     + CTRL_REG4::HR.val(high_resolution as u8))
                 .value;
                 self.i2c_accelerometer.enable();
                 if let Err((error, buf)) = self.i2c_accelerometer.write(buf, 2) {
-                    self.command_complete(buf, Err(error));
+                    self.buffer.replace(buf);
+                    Err(error.into())
+                } else {
+                    Ok(())
                 }
-            });
+            })
+        } else {
+            Err(ErrorCode::BUSY)
         }
     }
 
-    fn read_acceleration_xyz(&self) {
+    fn read_acceleration_xyz(&self) -> Result<(), ErrorCode> {
         if self.state.get() == State::Idle {
             self.state.set(State::ReadAccelerationXYZ);
-            self.buffer.take().map(|buf| {
+            self.buffer.take().map_or(Err(ErrorCode::NOMEM), |buf| {
                 buf[0] = AccelerometerRegisters::OUT_X_L_A as u8 | REGISTER_AUTO_INCREMENT;
                 self.i2c_accelerometer.enable();
                 if let Err((error, buf)) = self.i2c_accelerometer.write_read(buf, 1, 6) {
-                    self.command_complete(buf, Err(error));
+                    self.buffer.replace(buf);
+                    Err(error.into())
+                } else {
+                    Ok(())
                 }
-            });
+            })
+        } else {
+            Err(ErrorCode::BUSY)
         }
     }
 
@@ -272,60 +300,80 @@ impl<'a> Lsm303dlhcI2C<'a> {
         &self,
         temperature: bool,
         data_rate: Lsm303MagnetoDataRate,
-    ) {
+    ) -> Result<(), ErrorCode> {
         if self.state.get() == State::Idle {
             self.state.set(State::SetTemperatureDataRate);
-            self.buffer.take().map(|buf| {
+            self.buffer.take().map_or(Err(ErrorCode::NOMEM), |buf| {
                 buf[0] = MagnetometerRegisters::CRA_REG_M as u8;
                 buf[1] = ((data_rate as u8) << 2) | if temperature { 1 << 7 } else { 0 };
                 self.i2c_magnetometer.enable();
                 if let Err((error, buf)) = self.i2c_magnetometer.write(buf, 2) {
-                    self.command_complete(buf, Err(error));
+                    self.buffer.replace(buf);
+                    Err(error.into())
+                } else {
+                    Ok(())
                 }
-            });
+            })
+        } else {
+            Err(ErrorCode::BUSY)
         }
     }
 
-    fn set_range(&self, range: Lsm303Range) {
+    fn set_range(&self, range: Lsm303Range) -> Result<(), ErrorCode> {
         if self.state.get() == State::Idle {
             self.state.set(State::SetRange);
             // TODO move these in completed
             self.mag_range.set(range);
-            self.buffer.take().map(|buf| {
+            self.buffer.take().map_or(Err(ErrorCode::NOMEM), |buf| {
                 buf[0] = MagnetometerRegisters::CRB_REG_M as u8;
                 buf[1] = (range as u8) << 5;
                 buf[2] = 0;
                 self.i2c_magnetometer.enable();
                 if let Err((error, buf)) = self.i2c_magnetometer.write(buf, 3) {
-                    self.command_complete(buf, Err(error));
+                    self.buffer.replace(buf);
+                    Err(error.into())
+                } else {
+                    Ok(())
                 }
-            });
+            })
+        } else {
+            Err(ErrorCode::BUSY)
         }
     }
 
-    fn read_temperature(&self) {
+    fn read_temperature(&self) -> Result<(), ErrorCode> {
         if self.state.get() == State::Idle {
             self.state.set(State::ReadTemperature);
-            self.buffer.take().map(|buf| {
+            self.buffer.take().map_or(Err(ErrorCode::NOMEM), |buf| {
                 buf[0] = MagnetometerRegisters::TEMP_OUT_H_M as u8;
                 self.i2c_magnetometer.enable();
                 if let Err((error, buf)) = self.i2c_magnetometer.write_read(buf, 1, 2) {
-                    self.command_complete(buf, Err(error));
+                    self.buffer.replace(buf);
+                    Err(error.into())
+                } else {
+                    Ok(())
                 }
-            });
+            })
+        } else {
+            Err(ErrorCode::BUSY)
         }
     }
 
-    fn read_magnetometer_xyz(&self) {
+    fn read_magnetometer_xyz(&self) -> Result<(), ErrorCode> {
         if self.state.get() == State::Idle {
             self.state.set(State::ReadMagnetometerXYZ);
-            self.buffer.take().map(|buf| {
+            self.buffer.take().map_or(Err(ErrorCode::NOMEM), |buf| {
                 buf[0] = MagnetometerRegisters::OUT_X_H_M as u8;
                 self.i2c_magnetometer.enable();
                 if let Err((error, buf)) = self.i2c_magnetometer.write_read(buf, 1, 6) {
-                    self.command_complete(buf, Err(error));
+                    self.buffer.replace(buf);
+                    Err(error.into())
+                } else {
+                    Ok(())
                 }
-            });
+            })
+        } else {
+            Err(ErrorCode::BUSY)
         }
     }
 }
@@ -367,7 +415,7 @@ impl i2c::I2CClient for Lsm303dlhcI2C<'_> {
                 self.i2c_accelerometer.disable();
                 self.state.set(State::Idle);
                 if self.config_in_progress.get() {
-                    self.set_scale_and_resolution(
+                    let _ = self.set_scale_and_resolution(
                         self.accel_scale.get(),
                         self.accel_high_resolution.get(),
                     );
@@ -388,7 +436,7 @@ impl i2c::I2CClient for Lsm303dlhcI2C<'_> {
                 self.i2c_accelerometer.disable();
                 self.state.set(State::Idle);
                 if self.config_in_progress.get() {
-                    self.set_temperature_and_magneto_data_rate(
+                    let _ = self.set_temperature_and_magneto_data_rate(
                         self.temperature.get(),
                         self.mag_data_rate.get(),
                     );
@@ -466,7 +514,7 @@ impl i2c::I2CClient for Lsm303dlhcI2C<'_> {
                 self.i2c_magnetometer.disable();
                 self.state.set(State::Idle);
                 if self.config_in_progress.get() {
-                    self.set_range(self.mag_range.get());
+                    let _ = self.set_range(self.mag_range.get());
                 }
             }
             State::SetRange => {
@@ -599,8 +647,10 @@ impl Driver for Lsm303dlhcI2C<'_> {
             // Check is sensor is correctly connected
             1 => {
                 if self.state.get() == State::Idle {
-                    self.is_present();
-                    CommandReturn::success()
+                    match self.is_present() {
+                        Ok(()) => CommandReturn::success(),
+                        Err(error) => CommandReturn::failure(error),
+                    }
                 } else {
                     CommandReturn::failure(ErrorCode::BUSY)
                 }
@@ -609,8 +659,11 @@ impl Driver for Lsm303dlhcI2C<'_> {
             2 => {
                 if self.state.get() == State::Idle {
                     if let Some(data_rate) = Lsm303AccelDataRate::from_usize(data1) {
-                        self.set_power_mode(data_rate, if data2 != 0 { true } else { false });
-                        CommandReturn::success()
+                        match self.set_power_mode(data_rate, if data2 != 0 { true } else { false })
+                        {
+                            Ok(()) => CommandReturn::success(),
+                            Err(error) => CommandReturn::failure(error),
+                        }
                     } else {
                         CommandReturn::failure(ErrorCode::INVAL)
                     }
@@ -622,8 +675,12 @@ impl Driver for Lsm303dlhcI2C<'_> {
             3 => {
                 if self.state.get() == State::Idle {
                     if let Some(scale) = Lsm303Scale::from_usize(data1) {
-                        self.set_scale_and_resolution(scale, if data2 != 0 { true } else { false });
-                        CommandReturn::success()
+                        match self
+                            .set_scale_and_resolution(scale, if data2 != 0 { true } else { false })
+                        {
+                            Ok(()) => CommandReturn::success(),
+                            Err(error) => CommandReturn::failure(error),
+                        }
                     } else {
                         CommandReturn::failure(ErrorCode::INVAL)
                     }
@@ -635,11 +692,13 @@ impl Driver for Lsm303dlhcI2C<'_> {
             4 => {
                 if self.state.get() == State::Idle {
                     if let Some(data_rate) = Lsm303MagnetoDataRate::from_usize(data1) {
-                        self.set_temperature_and_magneto_data_rate(
+                        match self.set_temperature_and_magneto_data_rate(
                             if data2 != 0 { true } else { false },
                             data_rate,
-                        );
-                        CommandReturn::success()
+                        ) {
+                            Ok(()) => CommandReturn::success(),
+                            Err(error) => CommandReturn::failure(error),
+                        }
                     } else {
                         CommandReturn::failure(ErrorCode::INVAL)
                     }
@@ -651,38 +710,13 @@ impl Driver for Lsm303dlhcI2C<'_> {
             5 => {
                 if self.state.get() == State::Idle {
                     if let Some(range) = Lsm303Range::from_usize(data1) {
-                        self.set_range(range);
-                        CommandReturn::success()
+                        match self.set_range(range) {
+                            Ok(()) => CommandReturn::success(),
+                            Err(error) => CommandReturn::failure(error),
+                        }
                     } else {
                         CommandReturn::failure(ErrorCode::INVAL)
                     }
-                } else {
-                    CommandReturn::failure(ErrorCode::BUSY)
-                }
-            }
-            // Read Acceleration XYZ
-            6 => {
-                if self.state.get() == State::Idle {
-                    self.read_acceleration_xyz();
-                    CommandReturn::success()
-                } else {
-                    CommandReturn::failure(ErrorCode::BUSY)
-                }
-            }
-            // Read Temperature
-            7 => {
-                if self.state.get() == State::Idle {
-                    self.read_temperature();
-                    CommandReturn::success()
-                } else {
-                    CommandReturn::failure(ErrorCode::BUSY)
-                }
-            }
-            // Read Mangetometer XYZ
-            8 => {
-                if self.state.get() == State::Idle {
-                    self.read_magnetometer_xyz();
-                    CommandReturn::success()
                 } else {
                     CommandReturn::failure(ErrorCode::BUSY)
                 }
@@ -703,21 +737,11 @@ impl<'a> sensors::NineDof<'a> for Lsm303dlhcI2C<'a> {
     }
 
     fn read_accelerometer(&self) -> Result<(), ErrorCode> {
-        if self.state.get() == State::Idle {
-            self.read_acceleration_xyz();
-            Ok(())
-        } else {
-            Err(ErrorCode::BUSY)
-        }
+        self.read_acceleration_xyz()
     }
 
     fn read_magnetometer(&self) -> Result<(), ErrorCode> {
-        if self.state.get() == State::Idle {
-            self.read_magnetometer_xyz();
-            Ok(())
-        } else {
-            Err(ErrorCode::BUSY)
-        }
+        self.read_magnetometer_xyz()
     }
 }
 
@@ -727,11 +751,6 @@ impl<'a> sensors::TemperatureDriver<'a> for Lsm303dlhcI2C<'a> {
     }
 
     fn read_temperature(&self) -> Result<(), ErrorCode> {
-        if self.state.get() == State::Idle {
-            self.read_temperature();
-            Ok(())
-        } else {
-            Err(ErrorCode::BUSY)
-        }
+        self.read_temperature()
     }
 }


### PR DESCRIPTION
### Pull Request Overview

This pull request adds i2c error verification for the lsm303 drivers.

### Testing Strategy

This pull request was tested using a microbit v2.

### TODO or Help Wanted

This pull request requires #2538 

### Documentation Updated

- [x] No updates are required.

### Formatting

- [x] Ran `make prepush`.
