### PR TITLE
doc/TockBinaryFormat.md: Add the missing TbfHeaderV2Permissions length

### DIFF
--- a/doc/TockBinaryFormat.md
+++ b/doc/TockBinaryFormat.md
@@ -152,6 +152,7 @@ struct TbfHeaderDriverPermission {
 // A list of permissions for this app
 struct TbfHeaderV2Permissions {
     base: TbfHeaderTlv,
+    length: u16,
     perms: [TbfHeaderDriverPermission],
 }
 ```


### PR DESCRIPTION
### Pull Request Overview

The TbfHeaderV2Permissions should contain a length of the array. This is
already described in the structure in the Permissions section it's just
missing from the top struct.

### Testing Strategy

N/A

### TODO or Help Wanted

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
