### PR TITLE
boards/Makefile: remove relative libtock-c path assumptions

### DIFF
--- a/boards/imxrt1050-evkb/Makefile
+++ b/boards/imxrt1050-evkb/Makefile
@@ -1,16 +1,7 @@
 # Makefile for building the tock kernel for the i.MX RT1052 platform
-#
-APP=../../../libtock-c/examples/c_hello/build/cortex-m7/cortex-m7.tbf
-# APP=../../../libtock-rs/target/thumbv7em-none-eabi/tab/imxrt1050/hello_world/cortex-m7.tbf
+
 TARGET=thumbv7em-none-eabi
 PLATFORM=imxrt1050-evkb
-
-D_KERNEL=$(TOCK_ROOT_DIRECTORY)/target/$(TARGET)/debug/$(PLATFORM).elf
-D_KERNEL_WITH_APP=$(TOCK_ROOT_DIRECTORY)/target/$(TARGET)/debug/$(PLATFORM)-app.axf
-R_KERNEL=$(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
-R_KERNEL_WITH_APP=$(TOCK_ROOT_DIRECTORY)/target/$(TARGET)/release/$(PLATFORM)-app.axf
-
-MCUX_IDE_BIN=/Applications/MCUXpressoIDE_11.1.1_3241/ide/plugins/com.nxp.mcuxpresso.tools.bin.macosx_11.1.0.202002241259/binaries/
 
 include ../Makefile.common
 
@@ -18,20 +9,19 @@ include ../Makefile.common
 .PHONY: install
 install: flash
 
-.PHONY: $(TOCK_ROOT_DIRECTORY)program
-program: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/debug/$(PLATFORM).elf
-	arm-none-eabi-objcopy --update-section .apps=$(APP) $(D_KERNEL) $(D_KERNEL_WITH_APP)
-	$(warning Tock OS was compiled. In order to flash it on the board, you will need MCUExpresso. See README.md for details.)
-
-.PHONY: $(TOCK_ROOT_DIRECTORY)flash-debug
-flash-debug: program
-	$(MCUX_IDE_BIN)/crt_emu_cm_redlink --flash-load-exec "$(D_KERNEL_WITH_APP)" -p MIMXRT1052xxxxB \
-		--ConnectScript RT1050_connect.scp --flash-driver= -x . \
-		--flash-dir $(MCUX_IDE_BIN)/Flash --flash-hashing
-
-.PHONY: $(TOCK_ROOT_DIRECTORY)flash
+.PHONY: flash
 flash: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
-	arm-none-eabi-objcopy --update-section .apps=$(APP) $(R_KERNEL) $(R_KERNEL_WITH_APP)
-	$(MCUX_IDE_BIN)/crt_emu_cm_redlink --flash-load-exec "$(R_KERNEL_WITH_APP)" -p MIMXRT1052xxxxB \
-		--ConnectScript RT1050_connect.scp --flash-driver= -x . \
-		--flash-dir $(MCUX_IDE_BIN)/Flash --flash-hashing
+	crt_emu_cm_redlink \
+		--flash-load-exec "$(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf" \
+		-p MIMXRT1052xxxxB --ConnectScript RT1050_connect.scp \
+		--flash-driver= -x . --flash-dir $(MCUX_IDE_BIN)/Flash --flash-hashing
+
+.PHONY: flash-app
+flash-app: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
+	@: $(if $(value APP),,$(error Please set APP to the path of a TBF file to program applications))
+	arm-none-eabi-objcopy --update-section .apps=$(APP) $< \
+		$(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-apps.elf
+	crt_emu_cm_redlink \
+		--flash-load-exec "$(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-apps.elf" \
+		-p MIMXRT1052xxxxB --ConnectScript RT1050_connect.scp \
+		--flash-driver= -x . --flash-dir $(MCUX_IDE_BIN)/Flash --flash-hashing

--- a/boards/microbit_v2/Makefile
+++ b/boards/microbit_v2/Makefile
@@ -11,10 +11,6 @@ OPENOCD_OPTIONS=-f openocd.cfg
 
 TOCKLOADER=tockloader
 
-APP=../../../libtock-c/examples/sensors/build/cortex-m4/cortex-m4.tbf
-KERNEL=$(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
-KERNEL_WITH_APP=$(TOCK_ROOT_DIRECTORY)/target/$(TARGET)/release/$(PLATFORM)-app.elf
-
 # Default target for installing the kernel.
 .PHONY: install
 install: flash
@@ -36,7 +32,7 @@ flash-app: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin
 	$(error Use tockloader to load applications)
 
 .PHONY: flash-bootloader
-flash-bootloader: 
+flash-bootloader:
 	curl -L --output /tmp/tock-bootloader.microbit_v2.vv1.1.1.bin https://github.com/tock/tock-bootloader/releases/download/microbit_v2-vv1.1.1/tock-bootloader.microbit_v2.vv1.1.1.bin
 	$(OPENOCD) $(OPENOCD_OPTIONS) -c "program /tmp/tock-bootloader.microbit_v2.vv1.1.1.bin; verify_image /tmp/tock-bootloader.microbit_v2.vv1.1.1.bin; reset; shutdown;"
 	rm /tmp/tock-bootloader.microbit_v2.vv1.1.1.bin

--- a/boards/teensy40/Makefile
+++ b/boards/teensy40/Makefile
@@ -18,18 +18,15 @@ kernel: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
 program: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).hex
 	$(Q)teensy_loader_cli --mcu=TEENSY40 -w -v $<
 
+.PHONY: program-app
+program-app: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
+	@: $(if $(value APP),,$(error Please set APP to the path of a TBF file to program applications))
+	$(Q)arm-none-eabi-objcopy --update-section .apps=$(APP) $< $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-apps.elf
+	$(Q)$(OBJCOPY) -O ihex $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-apps.elf $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-apps.hex
+	teensy_loader_cli --mcu=TEENSY40 -w -v $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-apps.hex
+
 # Unsupported; there's no easily-accessible JTAG interface
 .PHONY: flash
 flash:
 	echo "Use 'make program' to program the Teensy 4"
 	exit 1
-
-# For testing with a blinky LED
-BLINK=../../../libtock-c/examples/blink/build/cortex-m7/cortex-m7.tbf
-app.elf: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
-	$(Q)arm-none-eabi-objcopy --update-section .apps=$(BLINK) $< $@
-
-app: app.elf
-	$(Q)$(OBJCOPY) -O ihex $< $@
-	teensy_loader_cli --mcu=TEENSY40 -w -v $@
-	$(Q)rm $@ $<


### PR DESCRIPTION
### Pull Request Overview

Removes any assumptions about application TBFs or `libtock-c` trees using relative paths outside of the Tock repository. In the cases where Tockloader is not supported (yet), the TBF file to include should be passed using the `APP` variable instead, as done in `clue_nrf52840`.

### Testing Strategy

This pull request was tested by running make targets.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] ~Updated the relevant files in `/docs`,~ or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
