### PR TITLE
OpenTitan: Update the HMAC Implementation

### DIFF
--- a/boards/components/src/hmac.rs
+++ b/boards/components/src/hmac.rs
@@ -26,7 +26,6 @@ use capsules;
 use capsules::hmac::HmacDriver;
 use capsules::virtual_hmac::MuxHmac;
 use capsules::virtual_hmac::VirtualMuxHmac;
-use core::marker::PhantomData;
 use core::mem::MaybeUninit;
 use kernel::capabilities;
 use kernel::component::Component;
@@ -37,42 +36,31 @@ use kernel::static_init_half;
 // Setup static space for the objects.
 #[macro_export]
 macro_rules! hmac_mux_component_helper {
-    ($A:ty, $T:ty $(,)?) => {{
+    ($A:ty, $L:expr $(,)?) => {{
         use capsules::virtual_hmac::MuxHmac;
         use capsules::virtual_hmac::VirtualMuxHmac;
         use core::mem::MaybeUninit;
-        static mut BUF1: MaybeUninit<MuxHmac<'static, $A, $T>> = MaybeUninit::uninit();
+        static mut BUF1: MaybeUninit<MuxHmac<'static, $A, $L>> = MaybeUninit::uninit();
         &mut BUF1
     };};
 }
 
-pub struct HmacMuxComponent<
-    A: 'static + digest::Digest<'static, T>,
-    T: 'static + digest::DigestType,
-> {
+pub struct HmacMuxComponent<A: 'static + digest::Digest<'static, L>, const L: usize> {
     hmac: &'static A,
-    phantom: PhantomData<&'static T>,
 }
 
-impl<A: 'static + digest::Digest<'static, T>, T: 'static + digest::DigestType>
-    HmacMuxComponent<A, T>
-{
-    pub fn new(hmac: &'static A) -> HmacMuxComponent<A, T> {
-        HmacMuxComponent {
-            hmac,
-            phantom: PhantomData,
-        }
+impl<A: 'static + digest::Digest<'static, L>, const L: usize> HmacMuxComponent<A, L> {
+    pub fn new(hmac: &'static A) -> HmacMuxComponent<A, L> {
+        HmacMuxComponent { hmac }
     }
 }
 
-impl<A: 'static + digest::Digest<'static, T>, T: 'static + digest::DigestType> Component
-    for HmacMuxComponent<A, T>
-{
-    type StaticInput = &'static mut MaybeUninit<MuxHmac<'static, A, T>>;
-    type Output = &'static MuxHmac<'static, A, T>;
+impl<A: 'static + digest::Digest<'static, L>, const L: usize> Component for HmacMuxComponent<A, L> {
+    type StaticInput = &'static mut MaybeUninit<MuxHmac<'static, A, L>>;
+    type Output = &'static MuxHmac<'static, A, L>;
 
     unsafe fn finalize(self, s: Self::StaticInput) -> Self::Output {
-        let mux_hmac = static_init_half!(s, MuxHmac<'static, A, T>, MuxHmac::new(self.hmac));
+        let mux_hmac = static_init_half!(s, MuxHmac<'static, A, L>, MuxHmac::new(self.hmac));
 
         mux_hmac
     }
@@ -81,39 +69,37 @@ impl<A: 'static + digest::Digest<'static, T>, T: 'static + digest::DigestType> C
 // Setup static space for the objects.
 #[macro_export]
 macro_rules! hmac_component_helper {
-    ($A:ty, $T:ty $(,)?) => {{
+    ($A:ty, $L:expr $(,)?) => {{
         use capsules::hmac::HmacDriver;
         use capsules::virtual_hmac::MuxHmac;
         use capsules::virtual_hmac::VirtualMuxHmac;
         use core::mem::MaybeUninit;
-        static mut BUF1: MaybeUninit<VirtualMuxHmac<'static, $A, $T>> = MaybeUninit::uninit();
-        static mut BUF2: MaybeUninit<HmacDriver<'static, VirtualMuxHmac<'static, $A, $T>, $T>> =
+        static mut BUF1: MaybeUninit<VirtualMuxHmac<'static, $A, $L>> = MaybeUninit::uninit();
+        static mut BUF2: MaybeUninit<HmacDriver<'static, VirtualMuxHmac<'static, $A, $L>, $L>> =
             MaybeUninit::uninit();
         (&mut BUF1, &mut BUF2)
     };};
 }
 
-pub struct HmacComponent<A: 'static + digest::Digest<'static, T>, T: 'static + digest::DigestType> {
+pub struct HmacComponent<A: 'static + digest::Digest<'static, L>, const L: usize> {
     board_kernel: &'static kernel::Kernel,
-    mux_hmac: &'static MuxHmac<'static, A, T>,
+    mux_hmac: &'static MuxHmac<'static, A, L>,
     data_buffer: &'static mut [u8],
-    dest_buffer: &'static mut T,
-    phantom: PhantomData<&'static T>,
+    dest_buffer: &'static mut [u8; L],
 }
 
-impl<A: 'static + digest::Digest<'static, T>, T: 'static + digest::DigestType> HmacComponent<A, T> {
+impl<A: 'static + digest::Digest<'static, L>, const L: usize> HmacComponent<A, L> {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
-        mux_hmac: &'static MuxHmac<'static, A, T>,
+        mux_hmac: &'static MuxHmac<'static, A, L>,
         data_buffer: &'static mut [u8],
-        dest_buffer: &'static mut T,
-    ) -> HmacComponent<A, T> {
+        dest_buffer: &'static mut [u8; L],
+    ) -> HmacComponent<A, L> {
         HmacComponent {
             board_kernel,
             mux_hmac,
             data_buffer,
             dest_buffer,
-            phantom: PhantomData,
         }
     }
 }
@@ -123,29 +109,29 @@ impl<
             + digest::HMACSha384
             + digest::HMACSha512
             + 'static
-            + digest::Digest<'static, T>,
-        T: 'static + digest::DigestType,
-    > Component for HmacComponent<A, T>
+            + digest::Digest<'static, L>,
+        const L: usize,
+    > Component for HmacComponent<A, L>
 {
     type StaticInput = (
-        &'static mut MaybeUninit<VirtualMuxHmac<'static, A, T>>,
-        &'static mut MaybeUninit<HmacDriver<'static, VirtualMuxHmac<'static, A, T>, T>>,
+        &'static mut MaybeUninit<VirtualMuxHmac<'static, A, L>>,
+        &'static mut MaybeUninit<HmacDriver<'static, VirtualMuxHmac<'static, A, L>, L>>,
     );
 
-    type Output = &'static HmacDriver<'static, VirtualMuxHmac<'static, A, T>, T>;
+    type Output = &'static HmacDriver<'static, VirtualMuxHmac<'static, A, L>, L>;
 
     unsafe fn finalize(self, s: Self::StaticInput) -> Self::Output {
         let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
 
         let virtual_hmac_user = static_init_half!(
             s.0,
-            VirtualMuxHmac<'static, A, T>,
+            VirtualMuxHmac<'static, A, L>,
             VirtualMuxHmac::new(self.mux_hmac)
         );
 
         let hmac = static_init_half!(
             s.1,
-            capsules::hmac::HmacDriver<'static, VirtualMuxHmac<'static, A, T>, T>,
+            capsules::hmac::HmacDriver<'static, VirtualMuxHmac<'static, A, L>, L>,
             capsules::hmac::HmacDriver::new(
                 virtual_hmac_user,
                 self.data_buffer,

--- a/boards/components/src/hmac.rs
+++ b/boards/components/src/hmac.rs
@@ -119,7 +119,11 @@ impl<A: 'static + digest::Digest<'static, T>, T: 'static + digest::DigestType> H
 }
 
 impl<
-        A: kernel::hil::digest::HMACSha256 + 'static + digest::Digest<'static, T>,
+        A: kernel::hil::digest::HMACSha256
+            + digest::HMACSha384
+            + digest::HMACSha512
+            + 'static
+            + digest::Digest<'static, T>,
         T: 'static + digest::DigestType,
     > Component for HmacComponent<A, T>
 {

--- a/boards/earlgrey-nexysvideo/src/main.rs
+++ b/boards/earlgrey-nexysvideo/src/main.rs
@@ -71,8 +71,8 @@ struct EarlGreyNexysVideo {
     >,
     hmac: &'static capsules::hmac::HmacDriver<
         'static,
-        VirtualMuxHmac<'static, lowrisc::hmac::Hmac<'static>, [u8; 32]>,
-        [u8; 32],
+        VirtualMuxHmac<'static, lowrisc::hmac::Hmac<'static>, 32>,
+        32,
     >,
     lldb: &'static capsules::low_level_debug::LowLevelDebug<
         'static,
@@ -236,7 +236,7 @@ pub unsafe fn main() {
     let hmac_dest_buffer = static_init!([u8; 32], [0; 32]);
 
     let mux_hmac = components::hmac::HmacMuxComponent::new(&peripherals.hmac).finalize(
-        components::hmac_mux_component_helper!(lowrisc::hmac::Hmac, [u8; 32]),
+        components::hmac_mux_component_helper!(lowrisc::hmac::Hmac, 32),
     );
 
     let hmac = components::hmac::HmacComponent::new(
@@ -245,10 +245,7 @@ pub unsafe fn main() {
         hmac_data_buffer,
         hmac_dest_buffer,
     )
-    .finalize(components::hmac_component_helper!(
-        lowrisc::hmac::Hmac,
-        [u8; 32]
-    ));
+    .finalize(components::hmac_component_helper!(lowrisc::hmac::Hmac, 32,));
 
     let i2c_master = static_init!(
         capsules::i2c_master::I2CMasterDriver<'static, lowrisc::i2c::I2c<'static>>,

--- a/capsules/src/hmac.rs
+++ b/capsules/src/hmac.rs
@@ -269,7 +269,7 @@ impl<
 
                     let pointer = digest.as_ref()[0] as *mut u8;
 
-                    app.data.mut_map_or((), |dest| {
+                    app.dest.mut_map_or((), |dest| {
                         dest.as_mut().copy_from_slice(digest.as_ref());
                     });
 

--- a/capsules/src/virtual_digest.rs
+++ b/capsules/src/virtual_digest.rs
@@ -124,6 +124,40 @@ impl<'a, A: digest::Digest<'a, T> + digest::HMACSha256, T: DigestType> digest::H
     }
 }
 
+impl<'a, A: digest::Digest<'a, T> + digest::HMACSha384, T: DigestType> digest::HMACSha384
+    for VirtualMuxDigest<'a, A, T>
+{
+    fn set_mode_hmacsha384(&self, key: &[u8]) -> Result<(), ErrorCode> {
+        // Check if any mux is enabled. If it isn't we enable it for us.
+        if self.mux.running.get() == false {
+            self.mux.running.set(true);
+            self.mux.running_id.set(self.id);
+            self.mux.digest.set_mode_hmacsha384(key)
+        } else if self.mux.running_id.get() == self.id {
+            self.mux.digest.set_mode_hmacsha384(key)
+        } else {
+            Err(ErrorCode::BUSY)
+        }
+    }
+}
+
+impl<'a, A: digest::Digest<'a, T> + digest::HMACSha512, T: DigestType> digest::HMACSha512
+    for VirtualMuxDigest<'a, A, T>
+{
+    fn set_mode_hmacsha512(&self, key: &[u8]) -> Result<(), ErrorCode> {
+        // Check if any mux is enabled. If it isn't we enable it for us.
+        if self.mux.running.get() == false {
+            self.mux.running.set(true);
+            self.mux.running_id.set(self.id);
+            self.mux.digest.set_mode_hmacsha512(key)
+        } else if self.mux.running_id.get() == self.id {
+            self.mux.digest.set_mode_hmacsha512(key)
+        } else {
+            Err(ErrorCode::BUSY)
+        }
+    }
+}
+
 /// Calling a 'set_mode*()' function from a `VirtualMuxDigest` will mark that
 /// `VirtualMuxDigest` as the one that has been enabled and running. Until that
 /// Mux calls `clear_data()` it will be the only `VirtualMuxDigest` that can

--- a/capsules/src/virtual_digest.rs
+++ b/capsules/src/virtual_digest.rs
@@ -110,7 +110,7 @@ impl<'a, A: digest::Digest<'a, T>, T: DigestType> digest::Client<'a, T>
 impl<'a, A: digest::Digest<'a, T> + digest::HMACSha256, T: DigestType> digest::HMACSha256
     for VirtualMuxDigest<'a, A, T>
 {
-    fn set_mode_hmacsha256(&self, key: &[u8; 32]) -> Result<(), ErrorCode> {
+    fn set_mode_hmacsha256(&self, key: &[u8]) -> Result<(), ErrorCode> {
         // Check if any mux is enabled. If it isn't we enable it for us.
         if self.mux.running.get() == false {
             self.mux.running.set(true);

--- a/capsules/src/virtual_digest.rs
+++ b/capsules/src/virtual_digest.rs
@@ -2,31 +2,29 @@
 //! Digest hardware peripheral.
 
 use core::cell::Cell;
-use core::marker::PhantomData;
 use kernel::common::cells::OptionalCell;
 use kernel::common::leasable_buffer::LeasableBuffer;
 use kernel::common::{ListLink, ListNode};
 use kernel::hil::digest;
-use kernel::hil::digest::DigestType;
 use kernel::ErrorCode;
 
-pub struct VirtualMuxDigest<'a, A: digest::Digest<'a, T>, T: DigestType> {
-    mux: &'a MuxDigest<'a, A, T>,
-    next: ListLink<'a, VirtualMuxDigest<'a, A, T>>,
-    client: OptionalCell<&'a dyn digest::Client<'a, T>>,
+pub struct VirtualMuxDigest<'a, A: digest::Digest<'a, L>, const L: usize> {
+    mux: &'a MuxDigest<'a, A, L>,
+    next: ListLink<'a, VirtualMuxDigest<'a, A, L>>,
+    client: OptionalCell<&'a dyn digest::Client<'a, L>>,
     id: u32,
 }
 
-impl<'a, A: digest::Digest<'a, T>, T: DigestType> ListNode<'a, VirtualMuxDigest<'a, A, T>>
-    for VirtualMuxDigest<'a, A, T>
+impl<'a, A: digest::Digest<'a, L>, const L: usize> ListNode<'a, VirtualMuxDigest<'a, A, L>>
+    for VirtualMuxDigest<'a, A, L>
 {
-    fn next(&self) -> &'a ListLink<VirtualMuxDigest<'a, A, T>> {
+    fn next(&self) -> &'a ListLink<VirtualMuxDigest<'a, A, L>> {
         &self.next
     }
 }
 
-impl<'a, A: digest::Digest<'a, T>, T: DigestType> VirtualMuxDigest<'a, A, T> {
-    pub fn new(mux_digest: &'a MuxDigest<'a, A, T>) -> VirtualMuxDigest<'a, A, T> {
+impl<'a, A: digest::Digest<'a, L>, const L: usize> VirtualMuxDigest<'a, A, L> {
+    pub fn new(mux_digest: &'a MuxDigest<'a, A, L>) -> VirtualMuxDigest<'a, A, L> {
         let id = mux_digest.next_id.get();
         mux_digest.next_id.set(id + 1);
 
@@ -39,12 +37,12 @@ impl<'a, A: digest::Digest<'a, T>, T: DigestType> VirtualMuxDigest<'a, A, T> {
     }
 }
 
-impl<'a, A: digest::Digest<'a, T>, T: DigestType> digest::Digest<'a, T>
-    for VirtualMuxDigest<'a, A, T>
+impl<'a, A: digest::Digest<'a, L>, const L: usize> digest::Digest<'a, L>
+    for VirtualMuxDigest<'a, A, L>
 {
     /// Set the client instance which will receive `add_data_done()` and
     /// `hash_done()` callbacks
-    fn set_client(&'a self, client: &'a dyn digest::Client<'a, T>) {
+    fn set_client(&'a self, client: &'a dyn digest::Client<'a, L>) {
         self.client.set(client);
     }
 
@@ -70,7 +68,10 @@ impl<'a, A: digest::Digest<'a, T>, T: DigestType> digest::Digest<'a, T>
     /// Request the hardware block to generate a Digest
     /// This doesn't return anything, instead the client needs to have
     /// set a `hash_done` handler.
-    fn run(&'a self, digest: &'static mut T) -> Result<(), (ErrorCode, &'static mut T)> {
+    fn run(
+        &'a self,
+        digest: &'static mut [u8; L],
+    ) -> Result<(), (ErrorCode, &'static mut [u8; L])> {
         // Check if any mux is enabled. If it isn't we enable it for us.
         if self.mux.running.get() == false {
             self.mux.running.set(true);
@@ -93,22 +94,22 @@ impl<'a, A: digest::Digest<'a, T>, T: DigestType> digest::Digest<'a, T>
     }
 }
 
-impl<'a, A: digest::Digest<'a, T>, T: DigestType> digest::Client<'a, T>
-    for VirtualMuxDigest<'a, A, T>
+impl<'a, A: digest::Digest<'a, L>, const L: usize> digest::Client<'a, L>
+    for VirtualMuxDigest<'a, A, L>
 {
     fn add_data_done(&'a self, result: Result<(), ErrorCode>, data: &'static mut [u8]) {
         self.client
             .map(move |client| client.add_data_done(result, data));
     }
 
-    fn hash_done(&'a self, result: Result<(), ErrorCode>, digest: &'static mut T) {
+    fn hash_done(&'a self, result: Result<(), ErrorCode>, digest: &'static mut [u8; L]) {
         self.client
             .map(move |client| client.hash_done(result, digest));
     }
 }
 
-impl<'a, A: digest::Digest<'a, T> + digest::HMACSha256, T: DigestType> digest::HMACSha256
-    for VirtualMuxDigest<'a, A, T>
+impl<'a, A: digest::Digest<'a, L> + digest::HMACSha256, const L: usize> digest::HMACSha256
+    for VirtualMuxDigest<'a, A, L>
 {
     fn set_mode_hmacsha256(&self, key: &[u8]) -> Result<(), ErrorCode> {
         // Check if any mux is enabled. If it isn't we enable it for us.
@@ -124,8 +125,8 @@ impl<'a, A: digest::Digest<'a, T> + digest::HMACSha256, T: DigestType> digest::H
     }
 }
 
-impl<'a, A: digest::Digest<'a, T> + digest::HMACSha384, T: DigestType> digest::HMACSha384
-    for VirtualMuxDigest<'a, A, T>
+impl<'a, A: digest::Digest<'a, L> + digest::HMACSha384, const L: usize> digest::HMACSha384
+    for VirtualMuxDigest<'a, A, L>
 {
     fn set_mode_hmacsha384(&self, key: &[u8]) -> Result<(), ErrorCode> {
         // Check if any mux is enabled. If it isn't we enable it for us.
@@ -141,8 +142,8 @@ impl<'a, A: digest::Digest<'a, T> + digest::HMACSha384, T: DigestType> digest::H
     }
 }
 
-impl<'a, A: digest::Digest<'a, T> + digest::HMACSha512, T: DigestType> digest::HMACSha512
-    for VirtualMuxDigest<'a, A, T>
+impl<'a, A: digest::Digest<'a, L> + digest::HMACSha512, const L: usize> digest::HMACSha512
+    for VirtualMuxDigest<'a, A, L>
 {
     fn set_mode_hmacsha512(&self, key: &[u8]) -> Result<(), ErrorCode> {
         // Check if any mux is enabled. If it isn't we enable it for us.
@@ -162,22 +163,20 @@ impl<'a, A: digest::Digest<'a, T> + digest::HMACSha512, T: DigestType> digest::H
 /// `VirtualMuxDigest` as the one that has been enabled and running. Until that
 /// Mux calls `clear_data()` it will be the only `VirtualMuxDigest` that can
 /// interact with the underlying device.
-pub struct MuxDigest<'a, A: digest::Digest<'a, T>, T: DigestType> {
+pub struct MuxDigest<'a, A: digest::Digest<'a, L>, const L: usize> {
     digest: &'a A,
     running: Cell<bool>,
     running_id: Cell<u32>,
     next_id: Cell<u32>,
-    phantom: PhantomData<&'a T>,
 }
 
-impl<'a, A: digest::Digest<'a, T>, T: DigestType> MuxDigest<'a, A, T> {
-    pub const fn new(digest: &'a A) -> MuxDigest<'a, A, T> {
+impl<'a, A: digest::Digest<'a, L>, const L: usize> MuxDigest<'a, A, L> {
+    pub const fn new(digest: &'a A) -> MuxDigest<'a, A, L> {
         MuxDigest {
             digest: digest,
             running: Cell::new(false),
             running_id: Cell::new(0),
             next_id: Cell::new(0),
-            phantom: PhantomData,
         }
     }
 }

--- a/capsules/src/virtual_hmac.rs
+++ b/capsules/src/virtual_hmac.rs
@@ -124,6 +124,40 @@ impl<'a, A: digest::Digest<'a, T> + digest::HMACSha256, T: DigestType> digest::H
     }
 }
 
+impl<'a, A: digest::Digest<'a, T> + digest::HMACSha384, T: DigestType> digest::HMACSha384
+    for VirtualMuxHmac<'a, A, T>
+{
+    fn set_mode_hmacsha384(&self, key: &[u8]) -> Result<(), ErrorCode> {
+        // Check if any mux is enabled. If it isn't we enable it for us.
+        if self.mux.running.get() == false {
+            self.mux.running.set(true);
+            self.mux.running_id.set(self.id);
+            self.mux.hmac.set_mode_hmacsha384(key)
+        } else if self.mux.running_id.get() == self.id {
+            self.mux.hmac.set_mode_hmacsha384(key)
+        } else {
+            Err(ErrorCode::BUSY)
+        }
+    }
+}
+
+impl<'a, A: digest::Digest<'a, T> + digest::HMACSha512, T: DigestType> digest::HMACSha512
+    for VirtualMuxHmac<'a, A, T>
+{
+    fn set_mode_hmacsha512(&self, key: &[u8]) -> Result<(), ErrorCode> {
+        // Check if any mux is enabled. If it isn't we enable it for us.
+        if self.mux.running.get() == false {
+            self.mux.running.set(true);
+            self.mux.running_id.set(self.id);
+            self.mux.hmac.set_mode_hmacsha512(key)
+        } else if self.mux.running_id.get() == self.id {
+            self.mux.hmac.set_mode_hmacsha512(key)
+        } else {
+            Err(ErrorCode::BUSY)
+        }
+    }
+}
+
 pub struct MuxHmac<'a, A: digest::Digest<'a, T>, T: DigestType> {
     hmac: &'a A,
     running: Cell<bool>,

--- a/capsules/src/virtual_hmac.rs
+++ b/capsules/src/virtual_hmac.rs
@@ -110,7 +110,7 @@ impl<'a, A: digest::Digest<'a, T>, T: DigestType> digest::Client<'a, T>
 impl<'a, A: digest::Digest<'a, T> + digest::HMACSha256, T: DigestType> digest::HMACSha256
     for VirtualMuxHmac<'a, A, T>
 {
-    fn set_mode_hmacsha256(&self, key: &[u8; 32]) -> Result<(), ErrorCode> {
+    fn set_mode_hmacsha256(&self, key: &[u8]) -> Result<(), ErrorCode> {
         // Check if any mux is enabled. If it isn't we enable it for us.
         if self.mux.running.get() == false {
             self.mux.running.set(true);

--- a/capsules/src/virtual_hmac.rs
+++ b/capsules/src/virtual_hmac.rs
@@ -2,31 +2,29 @@
 //! HMAC hardware peripheral.
 
 use core::cell::Cell;
-use core::marker::PhantomData;
 use kernel::common::cells::OptionalCell;
 use kernel::common::leasable_buffer::LeasableBuffer;
 use kernel::common::{ListLink, ListNode};
 use kernel::hil::digest;
-use kernel::hil::digest::DigestType;
 use kernel::ErrorCode;
 
-pub struct VirtualMuxHmac<'a, A: digest::Digest<'a, T>, T: DigestType> {
-    mux: &'a MuxHmac<'a, A, T>,
-    next: ListLink<'a, VirtualMuxHmac<'a, A, T>>,
-    client: OptionalCell<&'a dyn digest::Client<'a, T>>,
+pub struct VirtualMuxHmac<'a, A: digest::Digest<'a, L>, const L: usize> {
+    mux: &'a MuxHmac<'a, A, L>,
+    next: ListLink<'a, VirtualMuxHmac<'a, A, L>>,
+    client: OptionalCell<&'a dyn digest::Client<'a, L>>,
     id: u32,
 }
 
-impl<'a, A: digest::Digest<'a, T>, T: DigestType> ListNode<'a, VirtualMuxHmac<'a, A, T>>
-    for VirtualMuxHmac<'a, A, T>
+impl<'a, A: digest::Digest<'a, L>, const L: usize> ListNode<'a, VirtualMuxHmac<'a, A, L>>
+    for VirtualMuxHmac<'a, A, L>
 {
-    fn next(&self) -> &'a ListLink<VirtualMuxHmac<'a, A, T>> {
+    fn next(&self) -> &'a ListLink<VirtualMuxHmac<'a, A, L>> {
         &self.next
     }
 }
 
-impl<'a, A: digest::Digest<'a, T>, T: DigestType> VirtualMuxHmac<'a, A, T> {
-    pub fn new(mux_hmac: &'a MuxHmac<'a, A, T>) -> VirtualMuxHmac<'a, A, T> {
+impl<'a, A: digest::Digest<'a, L>, const L: usize> VirtualMuxHmac<'a, A, L> {
+    pub fn new(mux_hmac: &'a MuxHmac<'a, A, L>) -> VirtualMuxHmac<'a, A, L> {
         let id = mux_hmac.next_id.get();
         mux_hmac.next_id.set(id + 1);
 
@@ -39,12 +37,12 @@ impl<'a, A: digest::Digest<'a, T>, T: DigestType> VirtualMuxHmac<'a, A, T> {
     }
 }
 
-impl<'a, A: digest::Digest<'a, T>, T: DigestType> digest::Digest<'a, T>
-    for VirtualMuxHmac<'a, A, T>
+impl<'a, A: digest::Digest<'a, L>, const L: usize> digest::Digest<'a, L>
+    for VirtualMuxHmac<'a, A, L>
 {
     /// Set the client instance which will receive `add_data_done()` and
     /// `hash_done()` callbacks
-    fn set_client(&'a self, client: &'a dyn digest::Client<'a, T>) {
+    fn set_client(&'a self, client: &'a dyn digest::Client<'a, L>) {
         self.mux.hmac.set_client(client);
     }
 
@@ -70,7 +68,10 @@ impl<'a, A: digest::Digest<'a, T>, T: DigestType> digest::Digest<'a, T>
     /// Request the hardware block to generate a HMAC
     /// This doesn't return anything, instead the client needs to have
     /// set a `hash_done` handler.
-    fn run(&'a self, digest: &'static mut T) -> Result<(), (ErrorCode, &'static mut T)> {
+    fn run(
+        &'a self,
+        digest: &'static mut [u8; L],
+    ) -> Result<(), (ErrorCode, &'static mut [u8; L])> {
         // Check if any mux is enabled. If it isn't we enable it for us.
         if self.mux.running.get() == false {
             self.mux.running.set(true);
@@ -93,22 +94,22 @@ impl<'a, A: digest::Digest<'a, T>, T: DigestType> digest::Digest<'a, T>
     }
 }
 
-impl<'a, A: digest::Digest<'a, T>, T: DigestType> digest::Client<'a, T>
-    for VirtualMuxHmac<'a, A, T>
+impl<'a, A: digest::Digest<'a, L>, const L: usize> digest::Client<'a, L>
+    for VirtualMuxHmac<'a, A, L>
 {
     fn add_data_done(&'a self, result: Result<(), ErrorCode>, data: &'static mut [u8]) {
         self.client
             .map(move |client| client.add_data_done(result, data));
     }
 
-    fn hash_done(&'a self, result: Result<(), ErrorCode>, digest: &'static mut T) {
+    fn hash_done(&'a self, result: Result<(), ErrorCode>, digest: &'static mut [u8; L]) {
         self.client
             .map(move |client| client.hash_done(result, digest));
     }
 }
 
-impl<'a, A: digest::Digest<'a, T> + digest::HMACSha256, T: DigestType> digest::HMACSha256
-    for VirtualMuxHmac<'a, A, T>
+impl<'a, A: digest::Digest<'a, L> + digest::HMACSha256, const L: usize> digest::HMACSha256
+    for VirtualMuxHmac<'a, A, L>
 {
     fn set_mode_hmacsha256(&self, key: &[u8]) -> Result<(), ErrorCode> {
         // Check if any mux is enabled. If it isn't we enable it for us.
@@ -124,8 +125,8 @@ impl<'a, A: digest::Digest<'a, T> + digest::HMACSha256, T: DigestType> digest::H
     }
 }
 
-impl<'a, A: digest::Digest<'a, T> + digest::HMACSha384, T: DigestType> digest::HMACSha384
-    for VirtualMuxHmac<'a, A, T>
+impl<'a, A: digest::Digest<'a, L> + digest::HMACSha384, const L: usize> digest::HMACSha384
+    for VirtualMuxHmac<'a, A, L>
 {
     fn set_mode_hmacsha384(&self, key: &[u8]) -> Result<(), ErrorCode> {
         // Check if any mux is enabled. If it isn't we enable it for us.
@@ -141,8 +142,8 @@ impl<'a, A: digest::Digest<'a, T> + digest::HMACSha384, T: DigestType> digest::H
     }
 }
 
-impl<'a, A: digest::Digest<'a, T> + digest::HMACSha512, T: DigestType> digest::HMACSha512
-    for VirtualMuxHmac<'a, A, T>
+impl<'a, A: digest::Digest<'a, L> + digest::HMACSha512, const L: usize> digest::HMACSha512
+    for VirtualMuxHmac<'a, A, L>
 {
     fn set_mode_hmacsha512(&self, key: &[u8]) -> Result<(), ErrorCode> {
         // Check if any mux is enabled. If it isn't we enable it for us.
@@ -158,22 +159,20 @@ impl<'a, A: digest::Digest<'a, T> + digest::HMACSha512, T: DigestType> digest::H
     }
 }
 
-pub struct MuxHmac<'a, A: digest::Digest<'a, T>, T: DigestType> {
+pub struct MuxHmac<'a, A: digest::Digest<'a, L>, const L: usize> {
     hmac: &'a A,
     running: Cell<bool>,
     running_id: Cell<u32>,
     next_id: Cell<u32>,
-    phantom: PhantomData<&'a T>,
 }
 
-impl<'a, A: digest::Digest<'a, T>, T: DigestType> MuxHmac<'a, A, T> {
-    pub const fn new(hmac: &'a A) -> MuxHmac<'a, A, T> {
+impl<'a, A: digest::Digest<'a, L>, const L: usize> MuxHmac<'a, A, L> {
+    pub const fn new(hmac: &'a A) -> MuxHmac<'a, A, L> {
         MuxHmac {
             hmac,
             running: Cell::new(false),
             running_id: Cell::new(0),
             next_id: Cell::new(0),
-            phantom: PhantomData,
         }
     }
 }

--- a/chips/earlgrey/src/plic.rs
+++ b/chips/earlgrey/src/plic.rs
@@ -82,6 +82,30 @@ impl Plic {
         self.registers.threshold.write(priority::Priority.val(1));
     }
 
+    /// Disable specific interrupt.
+    pub fn disable(&self, index: u32) {
+        let offset = if index < 32 {
+            0
+        } else if index < 64 {
+            1
+        } else if index < 96 {
+            2
+        } else if index < 128 {
+            3
+        } else if index < 160 {
+            4
+        } else if index < 192 {
+            5
+        } else {
+            panic!("Invalid IRQ: {}", index);
+        };
+
+        let irq = index % 32;
+        let mask = !(1 << irq);
+
+        self.registers.enable[offset].set(self.registers.enable[offset].get() & mask);
+    }
+
     /// Disable all interrupts.
     pub fn disable_all(&self) {
         for enable in self.registers.enable.iter() {

--- a/chips/earlgrey/src/plic.rs
+++ b/chips/earlgrey/src/plic.rs
@@ -5,7 +5,6 @@ use kernel::common::registers::interfaces::{Readable, Writeable};
 use kernel::common::registers::LocalRegisterCopy;
 use kernel::common::registers::{register_bitfields, register_structs, ReadOnly, ReadWrite};
 use kernel::common::StaticRef;
-//use kernel::debug;
 
 pub const PLIC_BASE: StaticRef<PlicRegisters> =
     unsafe { StaticRef::new(0x4101_0000 as *const PlicRegisters) };

--- a/chips/lowrisc/src/hmac.rs
+++ b/chips/lowrisc/src/hmac.rs
@@ -273,3 +273,15 @@ impl hil::digest::HMACSha256 for Hmac<'_> {
         Ok(())
     }
 }
+
+impl hil::digest::HMACSha384 for Hmac<'_> {
+    fn set_mode_hmacsha384(&self, _key: &[u8]) -> Result<(), ErrorCode> {
+        Err(ErrorCode::NOSUPPORT)
+    }
+}
+
+impl hil::digest::HMACSha512 for Hmac<'_> {
+    fn set_mode_hmacsha512(&self, _key: &[u8]) -> Result<(), ErrorCode> {
+        Err(ErrorCode::NOSUPPORT)
+    }
+}

--- a/chips/lowrisc/src/hmac.rs
+++ b/chips/lowrisc/src/hmac.rs
@@ -68,7 +68,7 @@ register_bitfields![u32,
 pub struct Hmac<'a> {
     registers: StaticRef<HmacRegisters>,
 
-    client: OptionalCell<&'a dyn hil::digest::Client<'a, [u8; 32]>>,
+    client: OptionalCell<&'a dyn hil::digest::Client<'a, 32>>,
 
     data: Cell<Option<LeasableBuffer<'static, u8>>>,
     data_len: Cell<usize>,
@@ -190,8 +190,8 @@ impl Hmac<'_> {
     }
 }
 
-impl<'a> hil::digest::Digest<'a, [u8; 32]> for Hmac<'a> {
-    fn set_client(&'a self, client: &'a dyn digest::Client<'a, [u8; 32]>) {
+impl<'a> hil::digest::Digest<'a, 32> for Hmac<'a> {
+    fn set_client(&'a self, client: &'a dyn digest::Client<'a, 32>) {
         self.client.set(client);
     }
 

--- a/chips/lowrisc/src/hmac.rs
+++ b/chips/lowrisc/src/hmac.rs
@@ -248,8 +248,12 @@ impl<'a> hil::digest::Digest<'a, [u8; 32]> for Hmac<'a> {
 }
 
 impl hil::digest::HMACSha256 for Hmac<'_> {
-    fn set_mode_hmacsha256(&self, key: &[u8; 32]) -> Result<(), ErrorCode> {
+    fn set_mode_hmacsha256(&self, key: &[u8]) -> Result<(), ErrorCode> {
         let regs = self.registers;
+
+        if key.len() != 32 {
+            return Err(ErrorCode::NOSUPPORT);
+        }
 
         // Ensure the HMAC is setup
         regs.cfg

--- a/chips/lowrisc/src/hmac.rs
+++ b/chips/lowrisc/src/hmac.rs
@@ -89,12 +89,12 @@ impl Hmac<'_> {
         }
     }
 
-    fn data_progress(&self) {
+    fn data_progress(&self) -> bool {
         let regs = self.registers;
         let idx = self.data_index.get();
         let len = self.data_len.get();
 
-        self.data.take().map(|buf| {
+        self.data.take().map_or(false, |buf| {
             let slice = buf.take();
 
             if idx < len {
@@ -103,16 +103,7 @@ impl Hmac<'_> {
                 for i in 0..(data_len / 4) {
                     if regs.status.is_set(STATUS::FIFO_FULL) {
                         self.data.set(Some(LeasableBuffer::new(slice)));
-                        // Enable interrupts
-                        regs.intr_enable.modify(INTR_ENABLE::FIFO_EMPTY::SET);
-                        return;
-                    }
-
-                    if !regs.status.is_set(STATUS::FIFO_EMPTY) {
-                        self.data.set(Some(LeasableBuffer::new(slice)));
-                        // Enable interrupts
-                        regs.intr_enable.modify(INTR_ENABLE::FIFO_EMPTY::SET);
-                        return;
+                        return false;
                     }
 
                     let data_idx = idx + i * 4;
@@ -136,14 +127,9 @@ impl Hmac<'_> {
                     self.data_index.set(data_idx + 1)
                 }
             }
-
-            self.client.map(move |client| {
-                client.add_data_done(Ok(()), slice);
-            });
-        });
-
-        // Make sure we don't get any more FIFO empty interrupts
-        regs.intr_enable.modify(INTR_ENABLE::FIFO_EMPTY::CLEAR);
+            self.data.set(Some(LeasableBuffer::new(slice)));
+            true
+        })
     }
 
     pub fn handle_interrupt(&self) {
@@ -179,7 +165,20 @@ impl Hmac<'_> {
             // Clear the FIFO empty interrupt
             regs.intr_state.modify(INTR_STATE::FIFO_EMPTY::SET);
 
-            self.data_progress();
+            if self.data_progress() {
+                self.client.map(move |client| {
+                    self.data.take().map(|buf| {
+                        let slice = buf.take();
+                        client.add_data_done(Ok(()), slice);
+                    })
+                });
+
+                // Make sure we don't get any more FIFO empty interrupts
+                regs.intr_enable.modify(INTR_ENABLE::FIFO_EMPTY::CLEAR);
+            } else {
+                // Enable interrupts
+                regs.intr_enable.modify(INTR_ENABLE::FIFO_EMPTY::SET);
+            }
         } else if intrs.is_set(INTR_STATE::HMAC_ERR) {
             regs.intr_state.modify(INTR_STATE::HMAC_ERR::SET);
 
@@ -210,13 +209,20 @@ impl<'a> hil::digest::Digest<'a, 32> for Hmac<'a> {
         // Clear the FIFO empty interrupt
         regs.intr_state.modify(INTR_STATE::FIFO_EMPTY::SET);
 
+        // Enable interrupts
+        regs.intr_enable.modify(INTR_ENABLE::FIFO_EMPTY::SET);
+
         // Set the length and data index of the data to write
         self.data_len.set(data.len());
         self.data.set(Some(data));
         self.data_index.set(0);
 
         // Call the process function, this will start an async fill method
-        self.data_progress();
+        let ret = self.data_progress();
+
+        if ret {
+            regs.intr_test.modify(INTR_TEST::FIFO_EMPTY::SET);
+        }
 
         Ok(self.data_len.get())
     }
@@ -227,7 +233,9 @@ impl<'a> hil::digest::Digest<'a, 32> for Hmac<'a> {
     ) -> Result<(), (ErrorCode, &'static mut [u8; 32])> {
         let regs = self.registers;
 
-        // Enable interrrupts
+        // Enable interrupts
+        regs.intr_state
+            .modify(INTR_STATE::HMAC_DONE::SET + INTR_STATE::HMAC_ERR::SET);
         regs.intr_enable
             .modify(INTR_ENABLE::HMAC_DONE::SET + INTR_ENABLE::HMAC_ERR::SET);
 

--- a/kernel/src/hil/digest.rs
+++ b/kernel/src/hil/digest.rs
@@ -3,14 +3,10 @@
 use crate::common::leasable_buffer::LeasableBuffer;
 use crate::ErrorCode;
 
-/// The 'types' of digests, this should define the output size of the digest
-/// operations.
-pub trait DigestType: Eq + Copy + Clone + Sized + AsRef<[u8]> + AsMut<[u8]> {}
-
-impl DigestType for [u8; 32] {}
-
 /// Implement this trait and use `set_client()` in order to receive callbacks.
-pub trait Client<'a, T: DigestType> {
+///
+/// 'L' is the length of the 'u8' array to store the digest output.
+pub trait Client<'a, const L: usize> {
     /// This callback is called when the data has been added to the digest
     /// engine.
     /// On error or success `data` will contain a reference to the original
@@ -20,17 +16,19 @@ pub trait Client<'a, T: DigestType> {
     /// This callback is called when a digest is computed.
     /// On error or success `digest` will contain a reference to the original
     /// data supplied to `run()`.
-    fn hash_done(&'a self, result: Result<(), ErrorCode>, digest: &'static mut T);
+    fn hash_done(&'a self, result: Result<(), ErrorCode>, digest: &'static mut [u8; L]);
 }
 
 /// Computes a digest (cryptographic hash) over data
-pub trait Digest<'a, T: DigestType> {
+///
+/// 'L' is the length of the 'u8' array to store the digest output.
+pub trait Digest<'a, const L: usize> {
     /// Set the client instance which will receive `hash_done()` and
     /// `add_data_done()` callbacks.
     /// This callback is called when the data has been added to the digest
     /// engine.
     /// The callback should follow the `Client` `add_data_done` callback.
-    fn set_client(&'a self, client: &'a dyn Client<'a, T>);
+    fn set_client(&'a self, client: &'a dyn Client<'a, L>);
 
     /// Add data to the digest block. This is the data that will be used
     /// for the hash function.
@@ -56,7 +54,8 @@ pub trait Digest<'a, T: DigestType> {
     /// there is only one digest supported this should be used. If there is no
     /// suitable or obvious default option, the implementation can return an
     /// error with error code ENOSUPPORT.
-    fn run(&'a self, digest: &'static mut T) -> Result<(), (ErrorCode, &'static mut T)>;
+    fn run(&'a self, digest: &'static mut [u8; L])
+        -> Result<(), (ErrorCode, &'static mut [u8; L])>;
 
     /// Clear the keys and any other sensitive data.
     /// This won't clear the buffers provided to this API, that is up to the

--- a/kernel/src/hil/digest.rs
+++ b/kernel/src/hil/digest.rs
@@ -68,5 +68,5 @@ pub trait HMACSha256 {
     /// Call before `Digest::run()` to perform HMACSha256
     ///
     /// The key used for the HMAC is passed to this function.
-    fn set_mode_hmacsha256(&self, key: &[u8; 32]) -> Result<(), ErrorCode>;
+    fn set_mode_hmacsha256(&self, key: &[u8]) -> Result<(), ErrorCode>;
 }

--- a/kernel/src/hil/digest.rs
+++ b/kernel/src/hil/digest.rs
@@ -70,3 +70,17 @@ pub trait HMACSha256 {
     /// The key used for the HMAC is passed to this function.
     fn set_mode_hmacsha256(&self, key: &[u8]) -> Result<(), ErrorCode>;
 }
+
+pub trait HMACSha384 {
+    /// Call before `Digest::run()` to perform HMACSha384
+    ///
+    /// The key used for the HMAC is passed to this function.
+    fn set_mode_hmacsha384(&self, key: &[u8]) -> Result<(), ErrorCode>;
+}
+
+pub trait HMACSha512 {
+    /// Call before `Digest::run()` to perform HMACSha512
+    ///
+    /// The key used for the HMAC is passed to this function.
+    fn set_mode_hmacsha512(&self, key: &[u8]) -> Result<(), ErrorCode>;
+}


### PR DESCRIPTION
### Pull Request Overview

This PR does a few different things.

First I convert the key length to be unspecified. This means we can allow variable length keys.

Secondly I convert the HMAC digest to use const generics.

Then I have stared testing the HMAC capsule on OT after the 2.0 upgrade. This fixes some issues there, including double entering grants.

Finally some hardware related fixes.

### Testing Strategy

Run libtock-c hmac operation on OpenTitan FPGA.

### TODO or Help Wanted

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
