### PR TITLE
boards: make: check for rustup

### DIFF
--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -139,7 +139,6 @@ ifeq ($(shell $(TOCK_ROOT_DIRECTORY)tools/semver.sh $(RUSTUP_VERSION) \< $(MINIM
   $(shell sleep 3s)
   DUMMY := $(shell $(RUSTUP) update)
 endif
-endif # $(NO_RUSTUP) ?
 
 # Verify that various required Rust components are installed. All of these steps
 # only have to be done once per Rust version, but will take some time when
@@ -154,6 +153,7 @@ endif
 ifneq ($(shell $(RUSTUP) target list | grep "$(TARGET) (installed)"),$(TARGET) (installed))
   $(shell $(RUSTUP) target add $(TARGET))
 endif
+endif # $(NO_RUSTUP) ?
 
 # If the user is using the standard toolchain we need to get the full path.
 # rustup should take care of this for us by putting in a proxy in .cargo/bin,

--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -16,7 +16,12 @@ TOCK_ROOT_DIRECTORY := $(dir $(abspath $(MAKEFILE_COMMON_PATH)))
 # Common defaults that specific boards can override, but likely do not need to.
 TOOLCHAIN ?= llvm
 CARGO     ?= cargo
+
+ifeq ($(NO_RUSTUP),)
 RUSTUP    ?= rustup
+else
+RUSTUP    ?= true
+endif
 
 # Default location of target directory (relative to board makefile)
 # passed to cargo --target_dir
@@ -113,6 +118,8 @@ endif
 # a set string which should be updated with every release.
 export TOCK_KERNEL_VERSION := $(shell git describe --tags --always 2> /dev/null || echo "1.4+")
 
+# Allow users to opt out of using rustup
+ifeq ($(NO_RUSTUP),)
 # Validate that rustup exists.
 RUSTUP_ERROR := $(shell $(RUSTUP) --version > /dev/null 2>&1; echo $$?)
 ifneq ($(RUSTUP_ERROR),0)
@@ -131,6 +138,7 @@ ifeq ($(shell $(TOCK_ROOT_DIRECTORY)tools/semver.sh $(RUSTUP_VERSION) \< $(MINIM
   $(shell sleep 3s)
   DUMMY := $(shell $(RUSTUP) update)
 endif
+endif # $(NO_RUSTUP) ?
 
 # Verify that various required Rust components are installed. All of these steps
 # only have to be done once per Rust version, but will take some time when

--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -113,6 +113,15 @@ endif
 # a set string which should be updated with every release.
 export TOCK_KERNEL_VERSION := $(shell git describe --tags --always 2> /dev/null || echo "1.4+")
 
+# Validate that rustup exists.
+RUSTUP_ERROR := $(shell $(RUSTUP) --version > /dev/null 2>&1; echo $$?)
+ifneq ($(RUSTUP_ERROR),0)
+    $(info Error! rustup not found.)
+    $(info Please follow the instructions at https://rustup.rs/ to install rustup.)
+    $(info )
+    $(error Rustup required to build Tock.)
+endif
+
 # Validate that rustup is new enough.
 MINIMUM_RUSTUP_VERSION := 1.11.0
 RUSTUP_VERSION := $(strip $(word 2, $(shell $(RUSTUP) --version 2> /dev/null)))

--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -125,6 +125,7 @@ RUSTUP_ERROR := $(shell $(RUSTUP) --version > /dev/null 2>&1; echo $$?)
 ifneq ($(RUSTUP_ERROR),0)
     $(info Error! rustup not found.)
     $(info Please follow the instructions at https://rustup.rs/ to install rustup.)
+    $(info Alternatively, install all required tools and Rust targets and set NO_RUSTUP to disable this check.)
     $(info )
     $(error Rustup required to build Tock.)
 endif

--- a/shell.nix
+++ b/shell.nix
@@ -55,6 +55,11 @@ in
 
     LD_LIBRARY_PATH="${stdenv.cc.cc.lib}/lib64:$LD_LIBRARY_PATH";
 
+    # Instruct the Tock gnumake-based build system to not check for
+    # rustup and assume all required tools are installed and available
+    # in the $PATH
+    NO_RUSTUP = "1";
+
     # The defaults "objcopy" and "objdump" are wrong (for x86), use
     # "llvm-obj{copy,dump}" as defined in the makefile
     shellHook = ''


### PR DESCRIPTION
### Pull Request Overview

Add a check for rustup to the main board makefile.

I'm setting up a new mac, and this is what happens if you run `make` to build a board:

```
$ make
/Users/bradjc/git/tock/tools/semver.sh: line 32: 10#< > 10#1: syntax error: operand expected (error token is "> 10#1")
/Users/bradjc/git/tock/tools/semver.sh: line 36: 10#< < 10#1: syntax error: operand expected (error token is "< 10#1")
bash: rustup: command not found
bash: rustup: command not found
bash: rustup: command not found
bash: rustup: command not found
bash: rustup: command not found
bash: rustup: command not found
bash: rustc: command not found
find: illegal option -- n
usage: find [-H | -L | -P] [-EXdsx] [-f path] path ... [expression]
       find [-H | -L | -P] [-EXdsx] -f path [path ...] [expression]
usage: dirname path
bash: cargo: command not found
make: *** [/Users/bradjc/git/tock/target/thumbv7em-none-eabi/release/hail] Error 127
```

without doing any setup steps. Not clear what the issue is. Now you get:

```
$ make
Error! rustup not found.
Please follow the instructions at https://rustup.rs/ to install rustup.

../Makefile.common:122: *** Rustup required to build Tock..  Stop.
```


### Testing Strategy

Running make before and after installing rustup.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
