### PR TITLE
doc: trd-hil: add tips from tock-book

### DIFF
--- a/doc/reference/trd-hil-design.md
+++ b/doc/reference/trd-hil-design.md
@@ -765,7 +765,7 @@ dispatch based on internal state, or perform some form of proxying. It
 also allows the client to disable callbacks (by passing an
 implementation of the trait that does nothing).
 
-Rule 13: Use a generic lifetimes, except for buffers in split-phase operations, which should be `'static`
+Rule 13: Use generic lifetimes, except for buffers in split-phase operations, which should be `'static`
 ===============================
 
 HIL implementations should use generic lifetimes whenever possible. This has
@@ -776,7 +776,7 @@ limitations, because mutably accessing `` `static `` variables is generally
 considered unsafe. 
 
 If possible, use a single lifetime unless there are compelling reasons or
-requirements to otherwise. The standard lifetime name in Tock code is `` `a``,
+requirements otherwise. The standard lifetime name in Tock code is `` `a``,
 although code can use other ones if they make sense.
 In practice today, these `` `a`` lifetimes are all bound to `` `static``. 
 However, by not using `` `static`` explicitly these HILs can be used with

--- a/doc/reference/trd-hil-design.md
+++ b/doc/reference/trd-hil-design.md
@@ -5,10 +5,10 @@ Design of Kernel Hardware Interface Layers (HILs)
 **Working Group:** Kernel<br/>
 **Type:** Best Current Practice<br/>
 **Status:** Draft <br/>
-**Author:** Philip Levis <br/>
+**Author:** Brad Campbell, Philip Levis <br/>
 **Draft-Created:** April 1, 2021<br/>
-**Draft-Modified:** April 22, 2021<br/>
-**Draft-Version:** 5<br/>
+**Draft-Modified:** May 27, 2021<br/>
+**Draft-Version:** 6<br/>
 **Draft-Discuss:** tock-dev@googlegroups.com</br>
 
 Abstract
@@ -805,4 +805,11 @@ Stanford, CA 94305
 email: Philip Levis <pal@cs.stanford.edu>
 phone: +1 650 725 9046
 
+Brad Campbell 
+Computer Science	
+241 Olsson	
+P.O. Box 400336
+Charlottesville, Virginia 22904 
+
+email: Brad Campbell <bradjc@virginia.edu>
 ```

--- a/doc/reference/trd-hil-design.md
+++ b/doc/reference/trd-hil-design.md
@@ -794,7 +794,7 @@ when application `AppSlice` buffers are passed to hardware). To avoid
 unnecessary copies, HILs should use `` `static`` lifetimes for buffers
 used in split-phase operations.
 
-Author Address
+Author Addresses
 =================================
 ```
 Philip Levis


### PR DESCRIPTION
### Pull Request Overview

This pull request adds the list of HIL tips from the tock book to the HIL info TRD. 


### Testing Strategy

docs


### TODO or Help Wanted

I can update the book to refer to this guide instead of trying to duplicate content.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
