### PR TITLE
Fix `make allaudit`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ endef
 
 ## Aggregate targets
 .PHONY: allaudit
-audit:
+allaudit:
 	@for f in `./tools/list_lock.sh`;\
 		do echo "$$(tput bold)Auditing $$f";\
 		(cd "$$f" && cargo audit || exit 1);\
@@ -571,4 +571,3 @@ ci-job-rustdoc:
 ## End CI rules
 ##
 ###################################################################
-


### PR DESCRIPTION
### Pull Request Overview

This pull request fixs command name of allaudit.
`make usage` displays `allaudit: Audit Cargo dependencies for all kernel sources`, but Makefile is wrriten like `audit`


### Testing Strategy

This pull request was tested by...


### TODO or Help Wanted

This is my fiest PR. So, I didn't know how to made it.
If there is a mistake, please assist me.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
