### PR TITLE
Change qemu-path to relative path.

### DIFF
--- a/boards/earlgrey-nexysvideo/Makefile
+++ b/boards/earlgrey-nexysvideo/Makefile
@@ -5,7 +5,7 @@ TARGET=riscv32imc-unknown-none-elf
 PLATFORM=earlgrey-nexysvideo
 FLASHID=--dev-id="0403:6010"
 RISC_PREFIX = riscv64-elf
-QEMU=../../tools/qemu/build/qemu-system-riscv32
+QEMU ?= ../../tools/qemu/build/qemu-system-riscv32
 
 
 include ../Makefile.common

--- a/boards/earlgrey-nexysvideo/Makefile
+++ b/boards/earlgrey-nexysvideo/Makefile
@@ -5,6 +5,7 @@ TARGET=riscv32imc-unknown-none-elf
 PLATFORM=earlgrey-nexysvideo
 FLASHID=--dev-id="0403:6010"
 RISC_PREFIX = riscv64-elf
+QEMU=../../tools/qemu/build/qemu-system-riscv32
 
 
 include ../Makefile.common
@@ -23,11 +24,11 @@ install: flash
 
 qemu: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
 	$(call check_defined, OPENTITAN_BOOT_ROM)
-	qemu-system-riscv32 -M opentitan -kernel $^ -bios $(OPENTITAN_BOOT_ROM) -nographic -serial mon:stdio
+	$(QEMU) -M opentitan -kernel $^ -bios $(OPENTITAN_BOOT_ROM) -nographic -serial mon:stdio
 
 qemu-app: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
 	$(call check_defined, OPENTITAN_BOOT_ROM)
-	qemu-system-riscv32 -M opentitan -kernel $^ -bios $(OPENTITAN_BOOT_ROM) -device loader,file=$(APP),addr=0x20030000 -nographic -serial mon:stdio
+	$(QEMU) -M opentitan -kernel $^ -bios $(OPENTITAN_BOOT_ROM) -device loader,file=$(APP),addr=0x20030000 -nographic -serial mon:stdio
 
 flash: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin
 	$(OPENTITAN_TREE)/build-out/sw/host/spiflash/spiflash $(FLASHID) --input=$(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin

--- a/boards/hifive1/Makefile
+++ b/boards/hifive1/Makefile
@@ -2,6 +2,7 @@
 
 TARGET=riscv32imac-unknown-none-elf
 PLATFORM=hifive1
+QEMU=../../tools/qemu/build/qemu-system-riscv32
 
 include ../Makefile.common
 
@@ -14,10 +15,10 @@ flash: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
 		-c "source [find board/sifive-hifive1.cfg]; program $<; resume 0x20000000; exit"
 
 qemu: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
-	qemu-system-riscv32 -M sifive_e,revb=true -kernel $^  -nographic
+	$(QEMU) -M sifive_e,revb=true -kernel $^  -nographic
 
 qemu-app: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
-	qemu-system-riscv32 -M sifive_e,revb=true -kernel $^ -device loader,file=$(APP),addr=0x20040000 -nographic
+	$(QEMU) -M sifive_e,revb=true -kernel $^ -device loader,file=$(APP),addr=0x20040000 -nographic
 
 
 TOCKLOADER=tockloader

--- a/boards/hifive1/Makefile
+++ b/boards/hifive1/Makefile
@@ -2,7 +2,7 @@
 
 TARGET=riscv32imac-unknown-none-elf
 PLATFORM=hifive1
-QEMU=../../tools/qemu/build/qemu-system-riscv32
+QEMU ?= qemu-system-riscv32
 
 include ../Makefile.common
 


### PR DESCRIPTION
### Pull Request Overview

This pull request changes qemu-path to relative path.
`make ci-setup-qemu` doesn't set `qemu-system-riscv32` to PATH.
So, define path/to/qemu as a var, and use it.


### Testing Strategy

This pull request was tested by...


### TODO or Help Wanted

Or, is there some reason using local `qemu-system-riscv32` ?


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
