### PR TITLE
Fix: Replaced the cfg file with the rev B version.

### DIFF
--- a/boards/hifive1/Makefile
+++ b/boards/hifive1/Makefile
@@ -11,7 +11,7 @@ install: flash
 
 flash: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
 	openocd \
-		-c "source [find board/sifive-hifive1.cfg]; program $<; resume 0x20000000; exit"
+		-c "source [find board/sifive-hifive1-revb.cfg]; program $<; resume 0x20000000; exit"
 
 qemu: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
 	qemu-system-riscv32 -M sifive_e,revb=true -kernel $^  -nographic


### PR DESCRIPTION
### Pull Request Overview

This pull request Replaces the cfg file with the rev B version.
The former .cfg file implemented HiFive rev A version.
I verified that it works correctly on the actual device.

### Testing Strategy

This pull request was tested by...


### TODO or Help Wanted

This pull request still needs...


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
