### PR TITLE
allow size printing tool to be used on non-arm architectures

### DIFF
--- a/tools/github_actions_size_changes.sh
+++ b/tools/github_actions_size_changes.sh
@@ -13,7 +13,7 @@ set -e
 
 # Bench the current commit that was pushed. Requires navigating back to build directory
 make allboards > /dev/null 2>&1
-for elf in $(find . -maxdepth 8 | grep 'release' | egrep '\.elf$' | grep -v 'riscv'); do
+for elf in $(find . -maxdepth 8 | grep 'release' | egrep '\.elf$'); do
     tmp=${elf#*release/}
     b=${tmp%.elf}
     ./tools/print_tock_memory_usage.py -w ${elf} > current-benchmark-${b}
@@ -25,8 +25,7 @@ git checkout "$UPSTREAM_REMOTE_NAME"/"$GITHUB_BASE_REF" > /dev/null 2>&1
 make allboards > /dev/null 2>&1
 
 # Find elfs compiled for release (for use in analyzing binaries in CI),
-# ignore riscv binaries for now because size tool does not support RISC-V
-for elf in $(find . -maxdepth 8 | grep 'release' | egrep '\.elf$' | grep -v 'riscv'); do
+for elf in $(find . -maxdepth 8 | grep 'release' | egrep '\.elf$'); do
     tmp=${elf#*release/}
     b=${tmp%.elf}
     ./tools/print_tock_memory_usage.py -w ${elf} > previous-benchmark-${b}
@@ -35,7 +34,7 @@ done
 DIFF_DETECTED=0
 
 # now calculate diff for each board, and post status to github for each non-0 diff
-for elf in $(find . -maxdepth 8 | grep 'release' | egrep '\.elf$' | grep -v 'riscv'); do
+for elf in $(find . -maxdepth 8 | grep 'release' | egrep '\.elf$'); do
     tmp=${elf#*release/}
     b=${tmp%.elf}
     # Compute a summary suitable for GitHub.

--- a/tools/post_size_changes_to_github.sh
+++ b/tools/post_size_changes_to_github.sh
@@ -19,7 +19,7 @@ if [ -n "$TRAVIS_PULL_REQUEST_BRANCH" ]; then
     # Bench the current commit that was pushed. Requires navigating back to build directory
     cd ${TRAVIS_BUILD_DIR}
     make allboards
-    for elf in $(find . -maxdepth 8 | grep 'release' | egrep '\.elf$' | grep -v 'riscv'); do
+    for elf in $(find . -maxdepth 8 | grep 'release' | egrep '\.elf$'); do
         tmp=${elf#*release/}
         b=${tmp%.elf}
         ${TRAVIS_BUILD_DIR}/tools/print_tock_memory_usage.py -s ${elf} | tee ${TRAVIS_BUILD_DIR}/current-benchmark-${b}
@@ -46,8 +46,7 @@ if [ -n "$TRAVIS_PULL_REQUEST_BRANCH" ]; then
     make allboards
 
     # Find elfs compiled for release (for use in analyzing binaries in CI),
-    # ignore riscv binaries for now because Phil's tool does not support RISC-V
-    for elf in $(find . -maxdepth 8 | grep 'release' | egrep '\.elf$' | grep -v 'riscv'); do
+    for elf in $(find . -maxdepth 8 | grep 'release' | egrep '\.elf$'); do
         tmp=${elf#*release/}
         b=${tmp%.elf}
         ${TRAVIS_BUILD_DIR}/tools/print_tock_memory_usage.py -s ${elf} | tee ${TRAVIS_BUILD_DIR}/previous-benchmark-${b}
@@ -55,7 +54,7 @@ if [ -n "$TRAVIS_PULL_REQUEST_BRANCH" ]; then
 
     # now calculate diff for each board, and post status to github for each non-0 diff
     cd ${TRAVIS_BUILD_DIR}
-    for elf in $(find . -maxdepth 8 | grep 'release' | egrep '\.elf$' | grep -v 'riscv'); do
+    for elf in $(find . -maxdepth 8 | grep 'release' | egrep '\.elf$'); do
         tmp=${elf#*release/}
         b=${tmp%.elf}
         # Print a detailed by raw line-by-line diff. Can be useful to

--- a/tools/print_tock_memory_usage.py
+++ b/tools/print_tock_memory_usage.py
@@ -448,9 +448,6 @@ if __name__ == "__main__":
         hmatch = re.search('file format (\S+)', hline)
         if hmatch != None:
             arch = hmatch.group(1)
-            if arch != 'ELF32-arm-little':
-                usage(arch + " architecture not supported, only ELF32-arm-little supported")
-                sys.exit(-1)
 
     if arch == "UNKNOWN":
         usage("could not detect architecture of ELF")


### PR DESCRIPTION
### Pull Request Overview

This pull request removes the restriction that the size tool only be used on arm architectures. As far as I can tell, this restriction only existed because the tool used to use `arm-none-eabi-objdump`. Now that the tool uses `llvm-objdump` instead, there is no need for an architecture restriction.

It also updates the code size benchmarking tool to no longer ignore riscv boards, as that is no longer necessary. 


### Testing Strategy

This pull request was tested by running the tool on earlgrey-nexysvideo.elf and observing that the output looks sensible.


### TODO or Help Wanted

N/A

### Documentation Updated

- [x] No updates are required.

### Formatting

- [x] Ran `make prepush`.
