### PR TITLE
build with codegen-units = 1 to reduce code size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,3 +86,4 @@ panic = "abort"
 lto = true
 opt-level = "z"
 debug = true
+codegen-units = 1


### PR DESCRIPTION
### Pull Request Overview

This pull request modifies `Cargo.toml` to use `codegen-units = 1` for release builds. By default, Cargo uses 16 codegen units for each crate and LLVM processes them in parallel. This speeds up compilation but prevents LLVM from applying some optimizations which have to look at all of the units at once.

For Imix, adding this option reduces code size by 1.5 kB at the expense of compilation taking about 2 seconds longer.


### Testing Strategy

This pull request was tested by compiling


### TODO or Help Wanted

N/A

### Documentation Updated

- [x] No updates are required.

### Formatting

- [x] Ran `make prepush`.
