### PR TITLE
shell.nix: add cxxfilt Python package

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -56,6 +56,9 @@ in
       rust_build
       llvm
       qemu
+
+      # Required for tools/print_tock_memory_usage.py
+      pythonPackages.cxxfilt
     ];
 
     LD_LIBRARY_PATH="${stdenv.cc.cc.lib}/lib64:$LD_LIBRARY_PATH";


### PR DESCRIPTION
### Pull Request Overview

This is required to demangle C++ / Rust symbols in scripts such as `tools/print_tock_memory_usage.py`.

Signed-off-by: Leon Schuermann <leon@is.currently.online>

### Testing Strategy

This pull request was tested by entering the Nix shell environment with a sufficiently recent nixpkgs version.


### TODO or Help Wanted

N/A

### Documentation Updated

- [X] ~Updated the relevant files in `/docs`, or~ no updates are required.

### Formatting

- [N/A] Ran `make prepush`.
