### PR TITLE
kernel: Add a shared allow syscall

### DIFF
--- a/doc/reference/trd104-syscalls.md
+++ b/doc/reference/trd104-syscalls.md
@@ -559,7 +559,7 @@ Read-Write Allow to reclaim the buffer, then call Read-Write Allow
 again to re-allow it with a different size. If userspace passes
 an overlapping buffer, the kernel MUST return a failure result with
 an error code of `INVALID`.
- 
+
 4.5 Read-Only Allow (Class ID: 4)
 ---------------------------------
 
@@ -689,6 +689,50 @@ The definition of these status codes is outside the scope of this document.
 If an exit syscall is successful, it does not return. Therefore, the return
 value of an exit syscall is always `Failure`. `exit-restart` and 
 `exit-terminate` MUST always succeed and so never return. 
+
+4.8 Shared Allow (Class ID: 7)
+---------------------------------
+The shared allow syscall follows the same expectations and requirements
+as described for the Read-Write syscall in section 4.4, with the exception
+that apps are explicity allowed to read/write buffers that have been passed
+to the kernel.
+
+The standard calling pattern for reading data from the Tock kernel is to
+  1. use `subscribe` to register a callback,
+  2. make a Read-Write Allow call to share a buffer with the kernel,
+  3. call a `command` to start an operation that writes the allowed buffer,
+  4. in the upcall that signals the operation completes, make another
+  Read-Write Allow call to reclaim the buffer shared with the kernel.
+
+In normal use, userspace does not access a buffer that
+has been shared with the kernel with a Read-Write Allow call. This
+reading restriction is because the contents of the buffer may be in an
+intermediate state and so not consistent with expected data
+models. Ensuring every system call driver maintains consistency in the
+presence of arbitrary userspace reads is too great a programming
+burden for an unintended use case.
+
+However, there can be cases when it is necessary for userspace to be
+able to read a buffer without first revoking it from the kernel with a
+Read-Write Allow. These cases are situations when the cost of a
+Read-Write Allow system call is an unacceptable overhead for
+accessing the data.
+
+This allows capsules that support the shared allow call to communicte with
+applications without buffers needing to be re-allowed. For example a capsule
+might want to report statistics to a userspace app. It could do this by letting
+the app perform a shared allow call to allocate a buffer. Then the capsule can
+write statistics to the buffer and at any time the app can read the statistics
+from the buffer.
+
+As simultaneous accesses to a buffer from both userspace and the kernel can
+cause issues if not implemented properly, each capsule using the Shared Allow
+mechanism MUST document, in a Draft or Final Documentary TRD, how consistency
+of the data exchanged through this shared memory region is achieved.
+Examples for mechanisms to ensure consistent data reads/writes can be driver state
+machines, precisely specifying when writes will be issued to the buffer by the
+kernel, or monotonically increasing counters along the data for userspace to ensure
+a read operation yielded consistent data.
 
 5 libtock-c Userspace Library Methods
 =================================

--- a/kernel/src/driver.rs
+++ b/kernel/src/driver.rs
@@ -16,6 +16,9 @@
 //!   * `allow_readwrite` provides the driver read-write access to an
 //!   application buffer.
 //!
+//!   * `allow_shared` provides the driver read-write access to an
+//!   application buffer that is still shared with the app.
+//!
 //!   * `allow_readonly` provides the driver read-only access to an
 //!   application buffer.
 //!
@@ -206,6 +209,23 @@ pub trait Driver {
     /// this method only after it checks that the entire buffer is
     /// within memory the process can both read and write.
     fn allow_readwrite(
+        &self,
+        app: ProcessId,
+        which: usize,
+        slice: ReadWriteAppSlice,
+    ) -> Result<ReadWriteAppSlice, (ReadWriteAppSlice, ErrorCode)> {
+        Err((slice, ErrorCode::NOSUPPORT))
+    }
+
+    /// System call for a process to pass a buffer (a ReadWriteAppSlice) to
+    /// the kernel that the kernel can either read or write. The kernel calls
+    /// this method only after it checks that the entire buffer is
+    /// within memory the process can both read and write.
+    ///
+    /// This is different to `allow_readwrite()` in that the app is allowed
+    /// to read/write the buffer once it has been passed to the kernel.
+    /// For more details on how this can be done safely see TRD104.
+    fn allow_shared(
         &self,
         app: ProcessId,
         which: usize,

--- a/kernel/src/syscall.rs
+++ b/kernel/src/syscall.rs
@@ -37,6 +37,7 @@ pub enum SyscallClass {
     ReadOnlyAllow = 4,
     Memop = 5,
     Exit = 6,
+    SharedAllow = 7,
 }
 
 /// Enumeration of the yield system calls based on the Yield identifier
@@ -62,6 +63,7 @@ impl TryFrom<u8> for SyscallClass {
             4 => Ok(SyscallClass::ReadOnlyAllow),
             5 => Ok(SyscallClass::Memop),
             6 => Ok(SyscallClass::Exit),
+            7 => Ok(SyscallClass::SharedAllow),
             i => Err(i),
         }
     }
@@ -100,6 +102,17 @@ pub enum Syscall {
     /// the buffer identifier, `allow_address` is the address, and `allow_size`
     /// is the size.
     ReadWriteAllow {
+        driver_number: usize,
+        subdriver_number: usize,
+        allow_address: *mut u8,
+        allow_size: usize,
+    },
+
+    /// Structure representing an invocation of the ReadWriteAllow system call
+    /// class, but with shared kernel and app access. `driver_number` is the
+    /// driver identifier, `subdriver_number` is the buffer identifier,
+    // `allow_address` is the address, and `allow_size` is the size.
+    SharedAllow {
         driver_number: usize,
         subdriver_number: usize,
         allow_address: *mut u8,
@@ -165,6 +178,12 @@ impl Syscall {
                 arg1: r3,
             }),
             Ok(SyscallClass::ReadWriteAllow) => Some(Syscall::ReadWriteAllow {
+                driver_number: r0,
+                subdriver_number: r1,
+                allow_address: r2 as *mut u8,
+                allow_size: r3,
+            }),
+            Ok(SyscallClass::SharedAllow) => Some(Syscall::ReadWriteAllow {
                 driver_number: r0,
                 subdriver_number: r1,
                 allow_address: r2 as *mut u8,
@@ -268,6 +287,13 @@ pub enum SyscallReturn {
     /// buffer and size to the process.
     AllowReadWriteFailure(ErrorCode, *mut u8, usize),
 
+    /// Shared Read/Write allow success case, returns the previous allowed
+    /// buffer and size to the process.
+    SharedAllowSuccess(*mut u8, usize),
+    /// Shared Read/Write allow failure case, returns the passed allowed
+    /// buffer and size to the process.
+    SharedAllowFailure(ErrorCode, *mut u8, usize),
+
     /// Read only allow success case, returns the previous allowed
     /// buffer and size to the process.
     AllowReadOnlySuccess(*const u8, usize),
@@ -359,7 +385,18 @@ impl SyscallReturn {
                 *a1 = ptr as u32;
                 *a2 = len as u32;
             }
+            &SyscallReturn::SharedAllowSuccess(ptr, len) => {
+                *a0 = SyscallReturnVariant::SuccessU32U32 as u32;
+                *a1 = ptr as u32;
+                *a2 = len as u32;
+            }
             &SyscallReturn::AllowReadWriteFailure(err, ptr, len) => {
+                *a0 = SyscallReturnVariant::FailureU32U32 as u32;
+                *a1 = usize::from(err) as u32;
+                *a2 = ptr as u32;
+                *a3 = len as u32;
+            }
+            &SyscallReturn::SharedAllowFailure(err, ptr, len) => {
                 *a0 = SyscallReturnVariant::FailureU32U32 as u32;
                 *a1 = usize::from(err) as u32;
                 *a2 = ptr as u32;


### PR DESCRIPTION
### Pull Request Overview

This is a look at what a shared allow syscall would look like. This is based on https://github.com/tock/tock/pull/2590#issuecomment-854259226

Some of the TRD update is borrowed from: https://github.com/tock/tock/blob/trd104-buffer-reading/doc/reference/trd104-syscalls.md

The idea of these syscalls is to handle capsules that expect userspce to access a buffer while the kernel has access. [ROS](https://github.com/tock/tock/pull/2381) would use this (it needs to be rebased once this is merged) and there are some other users.

Add a shared allow that is similar to read/write allow except that the
app is expected to be able to access the buffer.

This is different to `allow_readwrite()` in that the app is allowed
to read/write the buffer once it has been passed to the kernel.
For more details on how this can be done safely see TRD104.

### Testing Strategy

None

### TODO or Help Wanted

This needs to be tested, TRD updated and libtock-c supported added.

The other question is do we allow userspace write access or is it only read access?

### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
