### PR TITLE
Fix a bug in the SPI controller capsule.

### DIFF
--- a/capsules/src/spi_controller.rs
+++ b/capsules/src/spi_controller.rs
@@ -314,16 +314,17 @@ impl<S: SpiMasterDevice> SpiMasterClient for Spi<'_, S> {
                         // -pal 12/9/20
                         let end = index;
                         let start = index - length;
-                        let end = cmp::min(end, cmp::min(src.len(), dest.len()));
+                        let end = cmp::min(end, dest.len());
 
                         // If the new endpoint is earlier than our expected
                         // startpoint, we set the startpoint to be the same;
                         // This results in a zero-length operation. -pal 12/9/20
                         let start = cmp::min(start, end);
 
+                        // The amount to copy can't be longer than the size of the
+                        // read buffer. -pal 6/8/21
+                        let real_len = cmp::min(end - start, src.len());
                         let dest_area = &mut dest[start..end];
-                        let real_len = end - start;
-
                         for (i, c) in src[0..real_len].iter().enumerate() {
                             dest_area[i] = *c;
                         }


### PR DESCRIPTION
If userspace performed a read/write that was longer than
the static kernel read buffer, it would only read for the
size of the static kernel buffer. The bug was that the end
of the *total* read was truncated by this buffer length;
it should only be that the individual sub-read is truncated
by this value.

This bug probably went unnnoticed because the static kernel
buffer is 1024, so multi-read/write operations never occurred.

The bug fix is to move the cmp::min from calculating where
to copy into the userspace buffer to calculating where to
copy from the kernel buffer.

### Pull Request Overview

This pull request fixes a bug in the SPI controller capsule.


### Testing Strategy

This pull request was tested by writing buffers from userspace that are longer than the SPI static buffer.


### TODO or Help Wanted




### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
