### PR TITLE
Add I2C slave support for nRF

### DIFF
--- a/boards/acd52832/src/main.rs
+++ b/boards/acd52832/src/main.rs
@@ -14,6 +14,7 @@ use kernel::hil;
 use kernel::hil::adc::Adc;
 use kernel::hil::entropy::Entropy32;
 use kernel::hil::gpio::{Configure, InterruptWithValue, Output};
+use kernel::hil::i2c::I2CMaster;
 use kernel::hil::led::LedLow;
 use kernel::hil::rng::Rng;
 use kernel::hil::time::{Alarm, Counter};
@@ -294,13 +295,13 @@ pub unsafe fn main() {
     // Create shared mux for the I2C bus
     let i2c_mux = static_init!(
         capsules::virtual_i2c::MuxI2C<'static>,
-        capsules::virtual_i2c::MuxI2C::new(&base_peripherals.twim0, None, dynamic_deferred_caller)
+        capsules::virtual_i2c::MuxI2C::new(&base_peripherals.twi0, None, dynamic_deferred_caller)
     );
-    base_peripherals.twim0.configure(
+    base_peripherals.twi0.configure(
         nrf52832::pinmux::Pinmux::new(21),
         nrf52832::pinmux::Pinmux::new(20),
     );
-    base_peripherals.twim0.set_client(i2c_mux);
+    base_peripherals.twi0.set_master_client(i2c_mux);
 
     // Configure the MCP23017. Device address 0x20.
     let mcp_pin0 = static_init!(

--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -380,13 +380,13 @@ pub unsafe fn main() {
 
     let sensors_i2c_bus = static_init!(
         capsules::virtual_i2c::MuxI2C<'static>,
-        capsules::virtual_i2c::MuxI2C::new(&base_peripherals.twim1, None, dynamic_deferred_caller)
+        capsules::virtual_i2c::MuxI2C::new(&base_peripherals.twi1, None, dynamic_deferred_caller)
     );
-    base_peripherals.twim1.configure(
+    base_peripherals.twi1.configure(
         nrf52840::pinmux::Pinmux::new(I2C_SCL_PIN as u32),
         nrf52840::pinmux::Pinmux::new(I2C_SDA_PIN as u32),
     );
-    base_peripherals.twim1.set_master_client(sensors_i2c_bus);
+    base_peripherals.twi1.set_master_client(sensors_i2c_bus);
 
     let apds9960_i2c = static_init!(
         capsules::virtual_i2c::I2CDevice,

--- a/boards/microbit_v2/src/main.rs
+++ b/boards/microbit_v2/src/main.rs
@@ -326,13 +326,13 @@ pub unsafe fn main() {
     // SENSORS
     //--------------------------------------------------------------------------
 
-    base_peripherals.twim0.configure(
+    base_peripherals.twi0.configure(
         nrf52833::pinmux::Pinmux::new(I2C_SCL_PIN as u32),
         nrf52833::pinmux::Pinmux::new(I2C_SDA_PIN as u32),
     );
 
     let sensors_i2c_bus = components::i2c::I2CMuxComponent::new(
-        &base_peripherals.twim0,
+        &base_peripherals.twi0,
         None,
         dynamic_deferred_caller,
     )

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -338,13 +338,13 @@ pub unsafe fn main() {
 
     let sensors_i2c_bus = static_init!(
         capsules::virtual_i2c::MuxI2C<'static>,
-        capsules::virtual_i2c::MuxI2C::new(&base_peripherals.twim0, None, dynamic_deferred_caller)
+        capsules::virtual_i2c::MuxI2C::new(&base_peripherals.twi0, None, dynamic_deferred_caller)
     );
-    base_peripherals.twim0.configure(
+    base_peripherals.twi0.configure(
         nrf52840::pinmux::Pinmux::new(I2C_SCL_PIN as u32),
         nrf52840::pinmux::Pinmux::new(I2C_SDA_PIN as u32),
     );
-    base_peripherals.twim0.set_master_client(sensors_i2c_bus);
+    base_peripherals.twi0.set_master_client(sensors_i2c_bus);
 
     &nrf52840_peripherals.gpio_port[I2C_PULLUP_PIN].make_output();
     &nrf52840_peripherals.gpio_port[I2C_PULLUP_PIN].set();

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -179,7 +179,7 @@ pub struct Platform {
     >,
     nonvolatile_storage: &'static capsules::nonvolatile_storage_driver::NonvolatileStorage<'static>,
     udp_driver: &'static capsules::net::udp::UDPDriver<'static>,
-    i2c_master: &'static capsules::i2c_master::I2CMasterDriver<'static, nrf52840::i2c::TWIM>,
+    i2c_master: &'static capsules::i2c_master::I2CMasterDriver<'static, nrf52840::i2c::TWI>,
 }
 
 impl kernel::Platform for Platform {
@@ -490,20 +490,20 @@ pub unsafe fn main() {
     ));
 
     let i2c_master = static_init!(
-        capsules::i2c_master::I2CMasterDriver<'static, nrf52840::i2c::TWIM>,
+        capsules::i2c_master::I2CMasterDriver<'static, nrf52840::i2c::TWI>,
         capsules::i2c_master::I2CMasterDriver::new(
-            &base_peripherals.twim1,
+            &base_peripherals.twi1,
             &mut capsules::i2c_master::BUF,
             board_kernel.create_grant(&memory_allocation_capability)
         )
     );
-    base_peripherals.twim1.configure(
+    base_peripherals.twi1.configure(
         nrf52840::pinmux::Pinmux::new(I2C_SCL_PIN as u32),
         nrf52840::pinmux::Pinmux::new(I2C_SDA_PIN as u32),
     );
-    base_peripherals.twim1.set_master_client(i2c_master);
-    base_peripherals.twim1.set_speed(nrf52840::i2c::Speed::K400);
-    base_peripherals.twim1.enable();
+    base_peripherals.twi1.set_master_client(i2c_master);
+    base_peripherals.twi1.set_speed(nrf52840::i2c::Speed::K400);
+    base_peripherals.twi1.enable();
 
     // Initialize AC using AIN5 (P0.29) as VIN+ and VIN- as AIN0 (P0.02)
     // These are hardcoded pin assignments specified in the driver

--- a/chips/nrf52/src/chip.rs
+++ b/chips/nrf52/src/chip.rs
@@ -43,9 +43,9 @@ pub struct Nrf52DefaultPeripherals<'a> {
     pub timer2: crate::timer::Timer,
     pub uarte0: crate::uart::Uarte<'a>,
     pub spim0: crate::spi::SPIM,
-    pub twim0: crate::i2c::TWIM,
+    pub twi0: crate::i2c::TWI,
     pub spim1: crate::spi::SPIM,
-    pub twim1: crate::i2c::TWIM,
+    pub twi1: crate::i2c::TWI,
     pub spim2: crate::spi::SPIM,
     pub adc: crate::adc::Adc,
     pub nvmc: crate::nvmc::Nvmc,
@@ -69,9 +69,9 @@ impl<'a> Nrf52DefaultPeripherals<'a> {
             timer2: crate::timer::Timer::new(2),
             uarte0: crate::uart::Uarte::new(),
             spim0: crate::spi::SPIM::new(0),
-            twim0: crate::i2c::TWIM::new_twim0(),
+            twi0: crate::i2c::TWI::new_twi0(),
             spim1: crate::spi::SPIM::new(1),
-            twim1: crate::i2c::TWIM::new_twim1(),
+            twi1: crate::i2c::TWI::new_twi1(),
             spim2: crate::spi::SPIM::new(2),
             adc: crate::adc::Adc::new(),
             nvmc: crate::nvmc::Nvmc::new(),
@@ -114,10 +114,10 @@ impl<'a> kernel::InterruptService<DeferredCallTask> for Nrf52DefaultPeripherals<
             crate::peripheral_interrupts::SPI0_TWI0 => {
                 // SPI0 and TWI0 share interrupts.
                 // Dispatch the correct handler.
-                match (self.spim0.is_enabled(), self.twim0.is_enabled()) {
+                match (self.spim0.is_enabled(), self.twi0.is_enabled()) {
                     (false, false) => (),
                     (true, false) => self.spim0.handle_interrupt(),
-                    (false, true) => self.twim0.handle_interrupt(),
+                    (false, true) => self.twi0.handle_interrupt(),
                     (true, true) => debug_assert!(
                         false,
                         "SPIM0 and TWIM0 cannot be \
@@ -128,10 +128,10 @@ impl<'a> kernel::InterruptService<DeferredCallTask> for Nrf52DefaultPeripherals<
             crate::peripheral_interrupts::SPI1_TWI1 => {
                 // SPI1 and TWI1 share interrupts.
                 // Dispatch the correct handler.
-                match (self.spim1.is_enabled(), self.twim1.is_enabled()) {
+                match (self.spim1.is_enabled(), self.twi1.is_enabled()) {
                     (false, false) => (),
                     (true, false) => self.spim1.handle_interrupt(),
-                    (false, true) => self.twim1.handle_interrupt(),
+                    (false, true) => self.twi1.handle_interrupt(),
                     (true, true) => debug_assert!(
                         false,
                         "SPIM1 and TWIM1 cannot be \

--- a/chips/nrf52/src/i2c.rs
+++ b/chips/nrf52/src/i2c.rs
@@ -1,39 +1,35 @@
 //! Implementation of I2C for nRF52 using EasyDMA.
 //!
-//! This module supports nRF52's two I2C master (`TWIM`) peripherals,
-//! but not I2C slave (`TWIS`).
-//!
-//! - Author: Jay Kickliter
-//! - Author: Andrew Thompson
-//! - Date: Nov 4, 2017
+//! This module supports nRF52's two I2C master (`TWI`) peripherals,
+//! and the I2C slave (`TWIS`).
 
 use kernel::common::cells::OptionalCell;
 use kernel::common::cells::TakeCell;
 use kernel::common::cells::VolatileCell;
-use kernel::common::registers::interfaces::{Readable, Writeable};
-use kernel::common::registers::{
-    register_bitfields, register_structs, ReadWrite, WriteOnly,
-};
+use kernel::common::registers::interfaces::{ReadWriteable, Readable, Writeable};
+use kernel::common::registers::{register_bitfields, register_structs, ReadWrite, WriteOnly};
 use kernel::common::StaticRef;
 use kernel::hil;
 use nrf5x::pinmux::Pinmux;
 
-/// Uninitialized `TWIM` instances.
-const INSTANCES: [StaticRef<TwimRegisters>; 2] = unsafe {
+/// Uninitialized `TWI` instances.
+const INSTANCES: [StaticRef<TwiRegisters>; 2] = unsafe {
     [
-        StaticRef::new(0x40003000 as *const TwimRegisters),
-        StaticRef::new(0x40004000 as *const TwimRegisters),
+        StaticRef::new(0x40003000 as *const TwiRegisters),
+        StaticRef::new(0x40004000 as *const TwiRegisters),
     ]
 };
 
 /// An I2C master device.
 ///
-/// A `TWIM` instance wraps a `registers::TWIM` together with
+/// A `TWI` instance wraps a `registers::TWI` together with
 /// additional data necessary to implement an asynchronous interface.
-pub struct TWIM {
-    registers: StaticRef<TwimRegisters>,
+pub struct TWI {
+    registers: StaticRef<TwiRegisters>,
     client: OptionalCell<&'static dyn hil::i2c::I2CHwMasterClient>,
+    slave_client: OptionalCell<&'static dyn hil::i2c::I2CHwSlaveClient>,
     buf: TakeCell<'static, [u8]>,
+    slave_read_buf: TakeCell<'static, [u8]>,
 }
 
 /// I2C bus speed.
@@ -44,29 +40,26 @@ pub enum Speed {
     K400 = 0x06400000,
 }
 
-impl TWIM {
-    const fn new(registers: StaticRef<TwimRegisters>) -> Self {
+impl TWI {
+    const fn new(registers: StaticRef<TwiRegisters>) -> Self {
         Self {
             registers,
             client: OptionalCell::empty(),
+            slave_client: OptionalCell::empty(),
             buf: TakeCell::empty(),
+            slave_read_buf: TakeCell::empty(),
         }
     }
 
-    pub const fn new_twim0() -> Self {
-        TWIM::new(INSTANCES[0])
+    pub const fn new_twi0() -> Self {
+        TWI::new(INSTANCES[0])
     }
 
-    pub const fn new_twim1() -> Self {
-        TWIM::new(INSTANCES[1])
+    pub const fn new_twi1() -> Self {
+        TWI::new(INSTANCES[1])
     }
 
-    pub fn set_client(&self, client: &'static dyn hil::i2c::I2CHwMasterClient) {
-        debug_assert!(self.client.is_none());
-        self.client.set(client);
-    }
-
-    /// Configures an already constructed `TWIM`.
+    /// Configures an already constructed `TWI`.
     pub fn configure(&self, scl: Pinmux, sda: Pinmux) {
         self.registers.psel_scl.set(scl);
         self.registers.psel_sda.set(sda);
@@ -79,45 +72,99 @@ impl TWIM {
     }
 
     /// Enables hardware TWIM peripheral.
-    pub fn enable(&self) {
+    fn enable_master(&self) {
         self.registers.enable.write(ENABLE::ENABLE::EnableMaster);
     }
 
-    /// Disables hardware TWIM peripheral.
-    pub fn disable(&self) {
+    /// Enables hardware TWIS peripheral.
+    fn enable_slave(&self) {
+        self.registers.enable.write(ENABLE::ENABLE::EnableSlave);
+    }
+
+    /// Disables hardware TWIM/TWIS peripheral.
+    fn disable(&self) {
         self.registers.enable.write(ENABLE::ENABLE::Disable);
     }
 
     pub fn handle_interrupt(&self) {
-        if self.registers.events_stopped.is_set(EVENT::EVENT) {
-            self.registers.events_stopped.write(EVENT::EVENT::CLEAR);
-            self.client.map(|client| match self.buf.take() {
-                None => (),
-                Some(buf) => {
-                    client.command_complete(buf, Ok(()));
-                }
-            });
-        }
+        if self.is_master_enabled() {
+            if self.registers.events_stopped.is_set(EVENT::EVENT) {
+                self.registers.events_stopped.write(EVENT::EVENT::CLEAR);
 
-        if self.registers.events_error.is_set(EVENT::EVENT) {
-            self.registers.events_error.write(EVENT::EVENT::CLEAR);
-            let errorsrc = self.registers.errorsrc.extract();
-            self.registers
-                .errorsrc
-                .write(ERRORSRC::ANACK::ErrorDidNotOccur + ERRORSRC::DNACK::ErrorDidNotOccur);
-            self.client.map(|client| match self.buf.take() {
-                None => (),
-                Some(buf) => {
-                    let status = if errorsrc.is_set(ERRORSRC::ANACK) {
-                        Err(hil::i2c::Error::AddressNak)
-                    } else if errorsrc.is_set(ERRORSRC::DNACK) {
-                        Err(hil::i2c::Error::DataNak)
-                    } else {
-                        Ok(())
-                    };
-                    client.command_complete(buf, status);
-                }
-            });
+                self.client.map(|client| match self.buf.take() {
+                    None => (),
+                    Some(buf) => {
+                        client.command_complete(buf, Ok(()));
+                    }
+                });
+            }
+
+            if self.registers.events_error.is_set(EVENT::EVENT) {
+                self.registers.events_error.write(EVENT::EVENT::CLEAR);
+                let errorsrc = self.registers.errorsrc_master.extract();
+                self.registers
+                    .errorsrc_master
+                    .write(ERRORSRC::ANACK::ErrorDidNotOccur + ERRORSRC::DNACK::ErrorDidNotOccur);
+                self.client.map(|client| match self.buf.take() {
+                    None => (),
+                    Some(buf) => {
+                        let status = if errorsrc.is_set(ERRORSRC::ANACK) {
+                            Err(hil::i2c::Error::AddressNak)
+                        } else if errorsrc.is_set(ERRORSRC::DNACK) {
+                            Err(hil::i2c::Error::DataNak)
+                        } else {
+                            Ok(())
+                        };
+                        client.command_complete(buf, status);
+                    }
+                });
+            }
+        } else {
+            self.registers.events_stopped.write(EVENT::EVENT::CLEAR);
+
+            // If RX started and we don't have a buffer then report
+            // read_expected()
+            if self.registers.events_rxstarted.is_set(EVENT::EVENT) {
+                self.registers.events_rxstarted.write(EVENT::EVENT::CLEAR);
+                self.slave_client
+                    .map(|client| match self.slave_read_buf.take() {
+                        None => {
+                            client.read_expected();
+                        }
+                        Some(_buf) => {}
+                    });
+            }
+
+            if self.registers.events_write.is_set(EVENT::EVENT) {
+                self.registers.events_write.write(EVENT::EVENT::CLEAR);
+                let length = self.registers.rxd_amount.read(AMOUNT::AMOUNT) as u8;
+                self.slave_client.map(|client| match self.buf.take() {
+                    None => (),
+                    Some(buf) => {
+                        client.command_complete(
+                            buf,
+                            length,
+                            hil::i2c::SlaveTransmissionType::Write,
+                        );
+                    }
+                });
+            }
+
+            if self.registers.events_read.is_set(EVENT::EVENT) {
+                self.registers.events_read.write(EVENT::EVENT::CLEAR);
+                let length = self.registers.txd_amount.read(AMOUNT::AMOUNT) as u8;
+                self.slave_client
+                    .map(|client| match self.slave_read_buf.take() {
+                        None => (),
+                        Some(buf) => {
+                            client.command_complete(
+                                buf,
+                                length,
+                                hil::i2c::SlaveTransmissionType::Read,
+                            );
+                        }
+                    });
+            }
         }
 
         // We can blindly clear the following events since we're not using them.
@@ -128,18 +175,29 @@ impl TWIM {
     }
 
     pub fn is_enabled(&self) -> bool {
+        self.is_master_enabled() || self.is_slave_enabled()
+    }
+
+    fn is_master_enabled(&self) -> bool {
         self.registers
             .enable
             .matches_all(ENABLE::ENABLE::EnableMaster)
     }
+
+    fn is_slave_enabled(&self) -> bool {
+        self.registers
+            .enable
+            .matches_all(ENABLE::ENABLE::EnableSlave)
+    }
 }
 
-impl hil::i2c::I2CMaster for TWIM {
+impl hil::i2c::I2CMaster for TWI {
     fn set_master_client(&self, client: &'static dyn hil::i2c::I2CHwMasterClient) {
-        self.set_client(client);
+        self.client.set(client);
     }
+
     fn enable(&self) {
-        self.enable();
+        self.enable_master();
     }
 
     fn disable(&self) {
@@ -154,13 +212,13 @@ impl hil::i2c::I2CMaster for TWIM {
         read_len: u8,
     ) -> Result<(), (hil::i2c::Error, &'static mut [u8])> {
         self.registers
-            .address
+            .address_0
             .write(ADDRESS::ADDRESS.val(addr as u32));
-        self.registers.txd_ptr.set(data.as_mut_ptr());
+        self.registers.txd_ptr.set(data.as_mut_ptr() as u32);
         self.registers
             .txd_maxcnt
             .write(MAXCNT::MAXCNT.val(write_len as u32));
-        self.registers.rxd_ptr.set(data.as_mut_ptr());
+        self.registers.rxd_ptr.set(data.as_mut_ptr() as u32);
         self.registers
             .rxd_maxcnt
             .write(MAXCNT::MAXCNT.val(read_len as u32));
@@ -187,9 +245,9 @@ impl hil::i2c::I2CMaster for TWIM {
         len: u8,
     ) -> Result<(), (hil::i2c::Error, &'static mut [u8])> {
         self.registers
-            .address
+            .address_0
             .write(ADDRESS::ADDRESS.val(addr as u32));
-        self.registers.txd_ptr.set(data.as_mut_ptr());
+        self.registers.txd_ptr.set(data.as_mut_ptr() as u32);
         self.registers
             .txd_maxcnt
             .write(MAXCNT::MAXCNT.val(len as u32));
@@ -214,9 +272,9 @@ impl hil::i2c::I2CMaster for TWIM {
         len: u8,
     ) -> Result<(), (hil::i2c::Error, &'static mut [u8])> {
         self.registers
-            .address
+            .address_0
             .write(ADDRESS::ADDRESS.val(addr as u32));
-        self.registers.rxd_ptr.set(buffer.as_mut_ptr());
+        self.registers.rxd_ptr.set(buffer.as_mut_ptr() as u32);
         self.registers
             .rxd_maxcnt
             .write(MAXCNT::MAXCNT.val(len as u32));
@@ -235,12 +293,82 @@ impl hil::i2c::I2CMaster for TWIM {
     }
 }
 
+impl hil::i2c::I2CSlave for TWI {
+    fn set_slave_client(&self, client: &'static dyn hil::i2c::I2CHwSlaveClient) {
+        self.slave_client.set(client);
+    }
+
+    fn enable(&self) {
+        self.enable_slave();
+    }
+
+    fn disable(&self) {
+        self.disable();
+    }
+
+    fn set_address(&self, addr: u8) -> Result<(), hil::i2c::Error> {
+        self.registers
+            .address_0
+            .write(ADDRESS::ADDRESS.val(addr as u32));
+        self.registers.config.modify(CONFIG::ADDRESS0::Enable);
+        Ok(())
+    }
+
+    fn write_receive(
+        &self,
+        data: &'static mut [u8],
+        max_len: u8,
+    ) -> Result<(), (hil::i2c::Error, &'static mut [u8])> {
+        self.registers.rxd_ptr.set(data.as_mut_ptr() as u32);
+        self.registers
+            .rxd_maxcnt
+            .write(MAXCNT::MAXCNT.val(max_len as u32));
+
+        self.registers
+            .intenset
+            .modify(INTE::STOPPED::Enable + INTE::ERROR::Enable);
+
+        self.buf.replace(data);
+
+        self.registers.tasks_preparerx.write(TASK::TASK::SET);
+
+        Ok(())
+    }
+
+    fn read_send(
+        &self,
+        data: &'static mut [u8],
+        max_len: u8,
+    ) -> Result<(), (hil::i2c::Error, &'static mut [u8])> {
+        self.registers.txd_ptr.set(data.as_mut_ptr() as u32);
+        self.registers
+            .txd_maxcnt
+            .write(MAXCNT::MAXCNT.val(max_len as u32));
+
+        self.registers
+            .intenset
+            .modify(INTE::STOPPED::Enable + INTE::ERROR::Enable + INTE::READ::Enable);
+
+        self.slave_read_buf.replace(data);
+
+        self.registers.tasks_preparetx.write(TASK::TASK::SET);
+
+        Ok(())
+    }
+
+    fn listen(&self) {
+        self.registers.tasks_preparerx.write(TASK::TASK::SET);
+    }
+}
+
+impl hil::i2c::I2CMasterSlave for TWI {}
+
 // The SPI0_TWI0 and SPI1_TWI1 interrupts are dispatched to the
 // correct handler by the service_pending_interrupts() routine in
 // chip.rs based on which peripheral is enabled.
 
 register_structs! {
-    pub TwimRegisters {
+    pub TwiRegisters {
         /// Start TWI receive sequence
         (0x00 => tasks_startrx: WriteOnly<u32, TASK::Register>),
         (0x04 => _reserved0),
@@ -255,12 +383,15 @@ register_structs! {
         /// Resume TWI transaction
         (0x20 => tasks_resume: WriteOnly<u32, TASK::Register>),
         (0x24 => _reserved3),
+        (0x30 => tasks_preparerx: WriteOnly<u32, TASK::Register>),
+        (0x34 => tasks_preparetx: WriteOnly<u32, TASK::Register>),
+        (0x38 => _reserved4),
         /// TWI stopped
         (0x104 => events_stopped: ReadWrite<u32, EVENT::Register>),
-        (0x108 => _reserved4),
+        (0x108 => _reserved5),
         /// TWI error
         (0x124 => events_error: ReadWrite<u32, EVENT::Register>),
-        (0x128 => _reserved5),
+        (0x128 => _reserved6),
         /// Last byte has been sent out after the SUSPEND task has been issued, TWI
         /// traffic is now suspended.
         (0x148 => events_suspended: ReadWrite<u32, EVENT::Register>),
@@ -268,56 +399,66 @@ register_structs! {
         (0x14C => events_rxstarted: ReadWrite<u32, EVENT::Register>),
         /// Transmit sequence started
         (0x150 => events_txstarted: ReadWrite<u32, EVENT::Register>),
-        (0x154 => _reserved6),
+        (0x154 => _reserved7),
         /// Byte boundary, starting to receive the last byte
         (0x15C => events_lastrx: ReadWrite<u32, EVENT::Register>),
         /// Byte boundary, starting to transmit the last byte
         (0x160 => events_lasttx: ReadWrite<u32, EVENT::Register>),
-        (0x164 => _reserved7),
+        (0x164 => events_write: ReadWrite<u32, EVENT::Register>),
+        (0x168 => events_read: ReadWrite<u32, EVENT::Register>),
+        (0x16C => _reserved8),
         /// Shortcut register
         (0x200 => shorts: ReadWrite<u32, SHORTS::Register>),
-        (0x204 => _reserved8),
+        (0x204 => _reserved9),
         /// Enable or disable interrupt
         (0x300 => inten: ReadWrite<u32, INTE::Register>),
         /// Enable interrupt
         (0x304 => intenset: ReadWrite<u32, INTE::Register>),
         /// Disable interrupt
         (0x308 => intenclr: ReadWrite<u32, INTE::Register>),
-        (0x30C => _reserved9),
+        (0x30C => _reserved10),
         /// Error source
-        (0x4C4 => errorsrc: ReadWrite<u32, ERRORSRC::Register>),
-        (0x4C8 => _reserved10),
+        (0x4C4 => errorsrc_master: ReadWrite<u32, ERRORSRC::Register>),
+        (0x4C8 => _reserved11),
+        (0x4D0 => errorsrc_slave: ReadWrite<u32, ERRORSRC::Register>),
+        (0x4D4 => match_reg: ReadWrite<u32>),
+        (0x4D8 => _reserved12),
         /// Enable TWI
         (0x500 => enable: ReadWrite<u32, ENABLE::Register>),
-        (0x504 => _reserved11),
+        (0x504 => _reserved13),
         /// Pin select for SCL signal
         (0x508 => psel_scl: VolatileCell<Pinmux>),
         /// Pin select for SDA signal
         (0x50C => psel_sda: VolatileCell<Pinmux>),
-        (0x510 => _reserved_12),
+        (0x510 => _reserved_14),
         /// TWI frequency
         (0x524 => frequency: ReadWrite<u32>),
-        (0x528 => _reserved13),
+        (0x528 => _reserved15),
         /// Data pointer
-        (0x534 => rxd_ptr: VolatileCell<*mut u8>),
+        (0x534 => rxd_ptr: ReadWrite<u32>),
         /// Maximum number of bytes in receive buffer
         (0x538 => rxd_maxcnt: ReadWrite<u32, MAXCNT::Register>),
         /// Number of bytes transferred in the last transaction
-        (0x53C => rxd_amount: ReadWrite<u32>),
+        (0x53C => rxd_amount: ReadWrite<u32, AMOUNT::Register>),
         /// EasyDMA list type
         (0x540 => rxd_list: ReadWrite<u32>),
         /// Data pointer
-        (0x544 => txd_ptr: VolatileCell<*mut u8>),
+        (0x544 => txd_ptr: ReadWrite<u32>),
         /// Maximum number of bytes in transmit buffer
         (0x548 => txd_maxcnt: ReadWrite<u32, MAXCNT::Register>),
         /// Number of bytes transferred in the last transaction
-        (0x54C => txd_amount: ReadWrite<u32>),
+        (0x54C => txd_amount: ReadWrite<u32, AMOUNT::Register>),
         /// EasyDMA list type
         (0x550 => txd_list: ReadWrite<u32>),
-        (0x554 => _reserved_14),
+        (0x554 => _reserved_16),
         /// Address used in the TWI transfer
-        (0x588 => address: ReadWrite<u32, ADDRESS::Register>),
-        (0x58C => @END),
+        (0x588 => address_0: ReadWrite<u32, ADDRESS::Register>),
+        (0x58C => address_1: ReadWrite<u32, ADDRESS::Register>),
+        (0x590 => _reserved_17),
+        (0x594 => config: ReadWrite<u32, CONFIG::Register>),
+        (0x598 => _reserved_18),
+        (0x5C0 => orc: ReadWrite<u32>),
+        (0x5C4 => @END),
     }
 }
 
@@ -401,7 +542,15 @@ register_bitfields![u32,
             Disable = 0,
             /// Enable
             Enable = 1
-        ]
+        ],
+        WRITE OFFSET(25) NUMBITS(1) [
+            Disable = 0,
+            Enable = 1
+        ],
+        READ OFFSET(26) NUMBITS(1) [
+            Disable = 0,
+            Enable = 1
+        ],
     ],
     ERRORSRC [
         /// NACK received after sending the address (write '1' to clear)
@@ -437,8 +586,22 @@ register_bitfields![u32,
         /// Maximum number of bytes in buffer
         MAXCNT OFFSET(0) NUMBITS(16)
     ],
+    AMOUNT [
+        AMOUNT OFFSET(0) NUMBITS(7),
+    ],
     ADDRESS [
         /// Address used in the TWI transfer
         ADDRESS OFFSET(0) NUMBITS(7)
-    ]
+    ],
+    CONFIG [
+        /// Address used in the TWI transfer
+        ADDRESS0 OFFSET(0) NUMBITS(1) [
+            Disable = 0,
+            Enable = 1,
+        ],
+        ADDRESS1 OFFSET(1) NUMBITS(1) [
+            Disable = 0,
+            Enable = 1,
+        ]
+    ],
 ];


### PR DESCRIPTION
### Pull Request Overview

This builds on top of https://github.com/tock/tock/pull/2612 by adding nRF I2C `master_slave_driver` support.

### Testing Strategy

Running I2C communication on the nRF

### TODO or Help Wanted

Nothing

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
