### PR TITLE
kernel: add common KernelResult type

### DIFF
--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -129,6 +129,9 @@ pub use crate::sched::round_robin::{RoundRobinProcessNode, RoundRobinSched};
 pub use crate::sched::{Kernel, Scheduler};
 pub use crate::upcall::Upcall;
 
+/// Standard kernel result that uses [`ErrorCode`] as the error.
+pub type KernelResult<T = ()> = Result<T, ErrorCode>;
+
 // Export only select items from the process module. To remove the name conflict
 // this cannot be called `process`, so we use a shortened version. These
 // functions and types are used by board files to setup the platform and setup


### PR DESCRIPTION
Add a helper type that we can use instead of `Result<(), ErrorCode>` in most places in the kernel.


### Testing Strategy

Used new `KernelResult` in downstream code with success.

### TODO

- If this seems good, I will go through and change `Result<(), ErrorCode> ` to `KernelResult` in the existing code before submitting PR

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.

