### PR TITLE
boards/*/openocd.cfg: Replace deprecated entry 'interface' by 'adapter driver'

### DIFF
--- a/boards/nucleo_f429zi/openocd.cfg
+++ b/boards/nucleo_f429zi/openocd.cfg
@@ -1,5 +1,5 @@
 #interface
-interface hla
+adapter driver hla
 hla_layout stlink
 hla_device_desc "ST-LINK/V2-1"
 hla_vid_pid 0x0483 0x374b

--- a/boards/nucleo_f446re/openocd.cfg
+++ b/boards/nucleo_f446re/openocd.cfg
@@ -1,5 +1,5 @@
 #interface
-interface hla
+adapter driver hla
 hla_layout stlink
 hla_device_desc "ST-LINK/V2-1"
 hla_vid_pid 0x0483 0x374b

--- a/boards/stm32f3discovery/openocd.cfg
+++ b/boards/stm32f3discovery/openocd.cfg
@@ -1,5 +1,5 @@
 #interface
-interface hla
+adapter driver hla
 hla_layout stlink
 hla_device_desc "ST-LINK/V2-1"
 hla_vid_pid 0x0483 0x374b

--- a/boards/stm32f412gdiscovery/openocd.cfg
+++ b/boards/stm32f412gdiscovery/openocd.cfg
@@ -1,5 +1,5 @@
 #interface
-interface hla
+adapter driver hla
 hla_layout stlink
 hla_device_desc "ST-LINK/V2-1"
 hla_vid_pid 0x0483 0x374b

--- a/boards/weact_f401ccu6/openocd.cfg
+++ b/boards/weact_f401ccu6/openocd.cfg
@@ -1,5 +1,5 @@
 #interface
-interface hla
+adapter driver hla
 hla_layout stlink
 hla_device_desc "ST-LINK/V2-1"
 hla_vid_pid 0x0483 0x374b


### PR DESCRIPTION
### Pull Request Overview

This pull request replaces deprecated entries `interface` in openocd configuration files by `adapter driver`. The later is now the recommended configuration entry name.

### Testing Strategy

This pull request was tested by me when flashing a nucleo-f446re board.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
