### PR TITLE
Support aliasing of process-allowed memory

### DIFF
--- a/capsules/src/crc.rs
+++ b/capsules/src/crc.rs
@@ -82,7 +82,7 @@ use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::common::leasable_buffer::LeasableBuffer;
 use kernel::hil::crc::{Client, Crc, CrcAlgorithm, CrcOutput};
 use kernel::{CommandReturn, Driver, ErrorCode, Grant, ProcessId};
-use kernel::{Read, ReadOnlyAppSlice};
+use kernel::{ReadOnlyProcessBuffer, ReadableProcessBuffer, ReadableProcessSlice};
 
 /// Syscall driver number.
 use crate::driver;
@@ -92,7 +92,7 @@ pub const DEFAULT_CRC_BUF_LENGTH: usize = 256;
 /// An opaque value maintaining state for one application's request
 #[derive(Default)]
 pub struct App {
-    buffer: ReadOnlyAppSlice,
+    buffer: ReadOnlyProcessBuffer,
     // if Some, the process is waiting for the result of CRC
     // of len bytes using the given algorithm
     request: Option<(CrcAlgorithm, usize)>,
@@ -137,11 +137,11 @@ impl<'a, C: Crc<'a>> CrcDriver<'a, C> {
         }
     }
 
-    fn do_next_input(&self, data: &[u8], len: usize) -> usize {
+    fn do_next_input(&self, data: &ReadableProcessSlice, len: usize) -> usize {
         let count = self.crc_buffer.take().map_or(0, |kbuffer| {
             let copy_len = cmp::min(len, kbuffer.len());
             for i in 0..copy_len {
-                kbuffer[i] = data[i];
+                kbuffer[i] = data[i].get();
             }
             if copy_len > 0 {
                 let mut leasable = LeasableBuffer::new(kbuffer);
@@ -171,8 +171,9 @@ impl<'a, C: Crc<'a>> CrcDriver<'a, C> {
             let started = process.enter(|grant, upcalls| {
                 // If there's no buffer this means the process is dead, so
                 // no need to issue a callback on this error case.
-                let res: Result<(), ErrorCode> =
-                    grant.buffer.map_or(Err(ErrorCode::NOMEM), |buffer| {
+                let res: Result<(), ErrorCode> = grant
+                    .buffer
+                    .enter(|buffer| {
                         if let Some((algorithm, len)) = grant.request {
                             let copy_len = cmp::min(len, buffer.len());
                             if copy_len == 0 {
@@ -202,7 +203,8 @@ impl<'a, C: Crc<'a>> CrcDriver<'a, C> {
                             // no request
                             Err(ErrorCode::FAIL)
                         }
-                    });
+                    })
+                    .unwrap_or(Err(ErrorCode::NOMEM));
                 match res {
                     Ok(()) => Ok(()),
                     Err(e) => {
@@ -238,8 +240,8 @@ impl<'a, C: Crc<'a>> Driver for CrcDriver<'a, C> {
         &self,
         process_id: ProcessId,
         allow_num: usize,
-        mut slice: ReadOnlyAppSlice,
-    ) -> Result<ReadOnlyAppSlice, (ReadOnlyAppSlice, ErrorCode)> {
+        mut slice: ReadOnlyProcessBuffer,
+    ) -> Result<ReadOnlyProcessBuffer, (ReadOnlyProcessBuffer, ErrorCode)> {
         let res = match allow_num {
             // Provide user buffer to compute Crc over
             0 => self
@@ -445,12 +447,15 @@ impl<'a, C: Crc<'a>> Client for CrcDriver<'a, C> {
                                 }
                             } else {
                                 // More bytes: do the next input
-                                let amount = grant.buffer.map_or(0, |app_slice| {
-                                    self.do_next_input(
-                                        &app_slice[self.app_buffer_written.get()..],
-                                        remaining,
-                                    )
-                                });
+                                let amount = grant
+                                    .buffer
+                                    .enter(|app_slice| {
+                                        self.do_next_input(
+                                            &app_slice[self.app_buffer_written.get()..],
+                                            remaining,
+                                        )
+                                    })
+                                    .unwrap_or(0);
                                 if amount == 0 {
                                     grant.request = None;
                                     upcalls.schedule_upcall(

--- a/capsules/src/hmac.rs
+++ b/capsules/src/hmac.rs
@@ -28,14 +28,13 @@ use crate::driver;
 pub const DRIVER_NUM: usize = driver::NUM::Hmac as usize;
 
 use core::cell::Cell;
-use core::convert::TryInto;
 use core::mem;
 use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::common::leasable_buffer::LeasableBuffer;
 use kernel::hil::digest;
 use kernel::{
-    CommandReturn, Driver, ErrorCode, Grant, ProcessId, Read, ReadOnlyAppSlice, ReadWrite,
-    ReadWriteAppSlice,
+    CommandReturn, Driver, ErrorCode, Grant, ProcessId, ReadOnlyProcessBuffer,
+    ReadWriteProcessBuffer, ReadableProcessBuffer, WriteableProcessBuffer,
 };
 
 enum ShaOperation {
@@ -43,6 +42,11 @@ enum ShaOperation {
     Sha384,
     Sha512,
 }
+
+// Temporary buffer to copy the keys from userspace into
+//
+// Needs to be able to accomodate the largest key sizes, e.g. 512
+const TMP_KEY_BUFFER_SIZE: usize = 512 / 8;
 
 pub struct HmacDriver<'a, H: digest::Digest<'a, L>, const L: usize> {
     hmac: &'a H,
@@ -84,54 +88,64 @@ impl<
         self.appid.map_or(Err(ErrorCode::RESERVE), |appid| {
             self.apps
                 .enter(*appid, |app, _| {
-                    let ret = app.key.map_or(Err(ErrorCode::RESERVE), |k| {
-                        if let Some(op) = &app.sha_operation {
-                            match op {
-                                ShaOperation::Sha256 => self
-                                    .hmac
-                                    .set_mode_hmacsha256(k.as_ref().try_into().unwrap()),
-                                ShaOperation::Sha384 => self
-                                    .hmac
-                                    .set_mode_hmacsha384(k.as_ref().try_into().unwrap()),
-                                ShaOperation::Sha512 => self
-                                    .hmac
-                                    .set_mode_hmacsha512(k.as_ref().try_into().unwrap()),
+                    let ret = app
+                        .key
+                        .enter(|k| {
+                            if let Some(op) = &app.sha_operation {
+                                let mut tmp_key_buffer: [u8; TMP_KEY_BUFFER_SIZE] =
+                                    [0; TMP_KEY_BUFFER_SIZE];
+                                let key_len = core::cmp::max(k.len(), TMP_KEY_BUFFER_SIZE);
+                                k[..key_len].copy_to_slice(&mut tmp_key_buffer[..key_len]);
+
+                                match op {
+                                    ShaOperation::Sha256 => {
+                                        self.hmac.set_mode_hmacsha256(&tmp_key_buffer[..key_len])
+                                    }
+                                    ShaOperation::Sha384 => {
+                                        self.hmac.set_mode_hmacsha384(&tmp_key_buffer[..key_len])
+                                    }
+                                    ShaOperation::Sha512 => {
+                                        self.hmac.set_mode_hmacsha512(&tmp_key_buffer[..key_len])
+                                    }
+                                }
+                            } else {
+                                Err(ErrorCode::INVAL)
                             }
-                        } else {
-                            Err(ErrorCode::INVAL)
-                        }
-                    });
+                        })
+                        .unwrap_or(Err(ErrorCode::RESERVE));
                     if ret.is_err() {
                         return ret;
                     }
 
-                    app.data.map_or(Err(ErrorCode::RESERVE), |d| {
-                        let mut static_buffer_len = 0;
-                        self.data_buffer.map(|buf| {
-                            let data = d.as_ref();
+                    app.data
+                        .enter(|data| {
+                            let mut static_buffer_len = 0;
+                            self.data_buffer.map(|buf| {
+                                // Determine the size of the static buffer we have
+                                static_buffer_len = buf.len();
 
-                            // Determine the size of the static buffer we have
-                            static_buffer_len = buf.len();
+                                if static_buffer_len > data.len() {
+                                    static_buffer_len = data.len()
+                                }
 
-                            if static_buffer_len > data.len() {
-                                static_buffer_len = data.len()
+                                self.data_copied.set(static_buffer_len);
+
+                                // Copy the data into the static buffer
+                                data[..static_buffer_len]
+                                    .copy_to_slice(&mut buf[..static_buffer_len]);
+                            });
+
+                            // Add the data from the static buffer to the HMAC
+                            let mut lease_buf =
+                                LeasableBuffer::new(self.data_buffer.take().unwrap());
+                            lease_buf.slice(0..static_buffer_len);
+                            if let Err(e) = self.hmac.add_data(lease_buf) {
+                                self.data_buffer.replace(e.1);
+                                return Err(e.0);
                             }
-
-                            self.data_copied.set(static_buffer_len);
-
-                            // Copy the data into the static buffer
-                            buf[..static_buffer_len].copy_from_slice(&data[..static_buffer_len]);
-                        });
-
-                        // Add the data from the static buffer to the HMAC
-                        let mut lease_buf = LeasableBuffer::new(self.data_buffer.take().unwrap());
-                        lease_buf.slice(0..static_buffer_len);
-                        if let Err(e) = self.hmac.add_data(lease_buf) {
-                            self.data_buffer.replace(e.1);
-                            return Err(e.0);
-                        }
-                        Ok(())
-                    })
+                            Ok(())
+                        })
+                        .unwrap_or(Err(ErrorCode::RESERVE))
                 })
                 .unwrap_or_else(|err| Err(err.into()))
         })
@@ -192,28 +206,29 @@ impl<
                     self.data_buffer.replace(data);
 
                     self.data_buffer.map(|buf| {
-                        let ret = app.data.map_or(Err(ErrorCode::RESERVE), |d| {
-                            let data = d.as_ref();
+                        let ret = app
+                            .data
+                            .enter(|data| {
+                                // Determine the size of the static buffer we have
+                                static_buffer_len = buf.len();
+                                // Determine how much data we have already copied
+                                let copied_data = self.data_copied.get();
 
-                            // Determine the size of the static buffer we have
-                            static_buffer_len = buf.len();
-                            // Determine how much data we have already copied
-                            let copied_data = self.data_copied.get();
+                                data_len = data.len();
 
-                            data_len = data.len();
+                                if data_len > copied_data {
+                                    let remaining_data = &data[copied_data..];
+                                    let remaining_len = data_len - copied_data;
 
-                            if data_len > copied_data {
-                                let remaining_data = &d.as_ref()[copied_data..];
-                                let remaining_len = data_len - copied_data;
-
-                                if remaining_len < static_buffer_len {
-                                    buf[..remaining_len].copy_from_slice(remaining_data);
-                                } else {
-                                    buf.copy_from_slice(&remaining_data[..static_buffer_len]);
+                                    if remaining_len < static_buffer_len {
+                                        remaining_data.copy_to_slice(&mut buf[..remaining_len]);
+                                    } else {
+                                        remaining_data[..static_buffer_len].copy_to_slice(buf);
+                                    }
                                 }
-                            }
-                            Ok(())
-                        });
+                                Ok(())
+                            })
+                            .unwrap_or(Err(ErrorCode::RESERVE));
 
                         if ret == Err(ErrorCode::RESERVE) {
                             // No data buffer, clear the appid and data
@@ -281,10 +296,12 @@ impl<
                 .enter(*id, |app, upcalls| {
                     self.hmac.clear_data();
 
-                    let pointer = digest.as_ref()[0] as *mut u8;
+                    let pointer = digest[0] as *mut u8;
 
-                    app.dest.mut_map_or((), |dest| {
-                        dest.as_mut()[0..L].copy_from_slice(&digest.as_ref()[0..L]);
+                    let _ = app.dest.mut_enter(|dest| {
+                        dest[0..L].copy_from_slice(&digest[0..L]);
+
+                        dest.copy_from_slice(digest.as_ref());
                     });
 
                     match result {
@@ -339,8 +356,8 @@ impl<
         &self,
         appid: ProcessId,
         allow_num: usize,
-        mut slice: ReadWriteAppSlice,
-    ) -> Result<ReadWriteAppSlice, (ReadWriteAppSlice, ErrorCode)> {
+        mut slice: ReadWriteProcessBuffer,
+    ) -> Result<ReadWriteProcessBuffer, (ReadWriteProcessBuffer, ErrorCode)> {
         let res = match allow_num {
             // Pass buffer for the digest to be in.
             2 => self
@@ -365,8 +382,8 @@ impl<
         &self,
         appid: ProcessId,
         allow_num: usize,
-        mut slice: ReadOnlyAppSlice,
-    ) -> Result<ReadOnlyAppSlice, (ReadOnlyAppSlice, ErrorCode)> {
+        mut slice: ReadOnlyProcessBuffer,
+    ) -> Result<ReadOnlyProcessBuffer, (ReadOnlyProcessBuffer, ErrorCode)> {
         let res = match allow_num {
             // Pass buffer for the key to be in
             0 => self
@@ -624,7 +641,7 @@ pub struct App {
     pending_run_app: Option<ProcessId>,
     sha_operation: Option<ShaOperation>,
     op: Cell<Option<UserSpaceOp>>,
-    key: ReadOnlyAppSlice,
-    data: ReadOnlyAppSlice,
-    dest: ReadWriteAppSlice,
+    key: ReadOnlyProcessBuffer,
+    data: ReadOnlyProcessBuffer,
+    dest: ReadWriteProcessBuffer,
 }

--- a/capsules/src/screen.rs
+++ b/capsules/src/screen.rs
@@ -16,7 +16,10 @@ use core::mem;
 use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::hil;
 use kernel::hil::screen::{ScreenPixelFormat, ScreenRotation};
-use kernel::{CommandReturn, Driver, ErrorCode, Grant, ProcessId, Read, ReadOnlyAppSlice};
+use kernel::{
+    CommandReturn, Driver, ErrorCode, Grant, ProcessId, ReadOnlyProcessBuffer,
+    ReadableProcessBuffer,
+};
 
 /// Syscall driver number.
 use crate::driver;
@@ -83,7 +86,7 @@ fn pixels_in_bytes(pixels: usize, bits_per_pixel: usize) -> usize {
 
 pub struct App {
     pending_command: bool,
-    shared: ReadOnlyAppSlice,
+    shared: ReadOnlyProcessBuffer,
     write_position: usize,
     write_len: usize,
     command: ScreenCommand,
@@ -95,7 +98,7 @@ impl Default for App {
     fn default() -> App {
         App {
             pending_command: false,
-            shared: ReadOnlyAppSlice::default(),
+            shared: ReadOnlyProcessBuffer::default(),
             command: ScreenCommand::Nop,
             width: 0,
             height: 0,
@@ -405,23 +408,26 @@ impl<'a> Screen<'a> {
                             let mut pos = initial_pos;
                             match app.command {
                                 ScreenCommand::Write(_) => {
-                                    let res = app.shared.map_or(0, |s| {
-                                        let mut chunks = s.chunks(buffer_size);
-                                        if let Some(chunk) = chunks.nth(chunk_number) {
-                                            for (i, byte) in chunk.iter().enumerate() {
-                                                if pos < len {
-                                                    buffer[i] = *byte;
-                                                    pos = pos + 1
-                                                } else {
-                                                    break;
+                                    let res = app
+                                        .shared
+                                        .enter(|s| {
+                                            let mut chunks = s.chunks(buffer_size);
+                                            if let Some(chunk) = chunks.nth(chunk_number) {
+                                                for (i, byte) in chunk.iter().enumerate() {
+                                                    if pos < len {
+                                                        buffer[i] = byte.get();
+                                                        pos = pos + 1
+                                                    } else {
+                                                        break;
+                                                    }
                                                 }
+                                                app.write_len - initial_pos
+                                            } else {
+                                                // stop writing
+                                                0
                                             }
-                                            app.write_len - initial_pos
-                                        } else {
-                                            // stop writing
-                                            0
-                                        }
-                                    });
+                                        })
+                                        .unwrap_or(0);
                                     if res > 0 {
                                         app.write_position = pos;
                                     }
@@ -440,22 +446,24 @@ impl<'a> Screen<'a> {
                                     };
                                     app.write_position =
                                         app.write_position + write_len * bytes_per_pixel;
-                                    app.shared.map_or(0, |data| {
-                                        let mut bytes = data.iter();
-                                        // bytes per pixel
-                                        for i in 0..bytes_per_pixel {
-                                            if let Some(byte) = bytes.next() {
-                                                buffer[i] = *byte;
-                                            }
-                                        }
-                                        for i in 1..write_len {
+                                    app.shared
+                                        .enter(|data| {
+                                            let mut bytes = data.iter();
                                             // bytes per pixel
-                                            for j in 0..bytes_per_pixel {
-                                                buffer[bytes_per_pixel * i + j] = buffer[j]
+                                            for i in 0..bytes_per_pixel {
+                                                if let Some(byte) = bytes.next() {
+                                                    buffer[i] = byte.get();
+                                                }
                                             }
-                                        }
-                                        write_len * bytes_per_pixel
-                                    })
+                                            for i in 1..write_len {
+                                                // bytes per pixel
+                                                for j in 0..bytes_per_pixel {
+                                                    buffer[bytes_per_pixel * i + j] = buffer[j]
+                                                }
+                                            }
+                                            write_len * bytes_per_pixel
+                                        })
+                                        .unwrap_or(0)
                                 }
                                 _ => 0,
                             }
@@ -584,8 +592,8 @@ impl<'a> Driver for Screen<'a> {
         &self,
         process_id: ProcessId,
         allow_num: usize,
-        mut slice: ReadOnlyAppSlice,
-    ) -> Result<ReadOnlyAppSlice, (ReadOnlyAppSlice, ErrorCode)> {
+        mut slice: ReadOnlyProcessBuffer,
+    ) -> Result<ReadOnlyProcessBuffer, (ReadOnlyProcessBuffer, ErrorCode)> {
         match allow_num {
             // TODO should refuse allow while writing
             0 => {

--- a/capsules/src/sdcard.rs
+++ b/capsules/src/sdcard.rs
@@ -48,7 +48,9 @@ use kernel::common::cells::{OptionalCell, TakeCell};
 use kernel::hil;
 use kernel::ErrorCode;
 use kernel::{CommandReturn, Driver, Grant, ProcessId};
-use kernel::{Read, ReadOnlyAppSlice, ReadWrite, ReadWriteAppSlice};
+use kernel::{
+    ReadOnlyProcessBuffer, ReadWriteProcessBuffer, ReadableProcessBuffer, WriteableProcessBuffer,
+};
 
 /// Syscall driver number.
 use crate::driver;
@@ -1413,8 +1415,8 @@ pub struct SDCardDriver<'a, A: hil::time::Alarm<'a>> {
 /// Holds buffers and whatnot that the application has passed us.
 #[derive(Default)]
 pub struct App {
-    write_buffer: ReadOnlyAppSlice,
-    read_buffer: ReadWriteAppSlice,
+    write_buffer: ReadOnlyProcessBuffer,
+    read_buffer: ReadWriteProcessBuffer,
 }
 
 /// Buffer for SD card driver, assigned in board `main.rs` files
@@ -1468,19 +1470,21 @@ impl<'a, A: hil::time::Alarm<'a>> SDCardClient for SDCardDriver<'a, A> {
             let _ = self.grants.enter(*process_id, |app, upcalls| {
                 let mut read_len = 0;
                 self.kernel_buf.map(|data| {
-                    app.read_buffer.mut_map_or(0, |read_buffer| {
-                        let read_buffer = read_buffer;
-                        // copy bytes to user buffer
-                        // Limit to minimum length between read_buffer, data, and
-                        // len field
-                        for (read_byte, &data_byte) in
-                            read_buffer.iter_mut().zip(data.iter()).take(len)
-                        {
-                            *read_byte = data_byte;
-                        }
-                        read_len = cmp::min(read_buffer.len(), cmp::min(data.len(), len));
-                        read_len
-                    });
+                    app.read_buffer
+                        .mut_enter(|read_buffer| {
+                            let read_buffer = read_buffer;
+                            // copy bytes to user buffer
+                            // Limit to minimum length between read_buffer, data, and
+                            // len field
+                            for (read_byte, &data_byte) in
+                                read_buffer.iter().zip(data.iter()).take(len)
+                            {
+                                read_byte.set(data_byte);
+                            }
+                            read_len = cmp::min(read_buffer.len(), cmp::min(data.len(), len));
+                            read_len
+                        })
+                        .unwrap_or(0);
                 });
 
                 // perform callback
@@ -1516,8 +1520,8 @@ impl<'a, A: hil::time::Alarm<'a>> Driver for SDCardDriver<'a, A> {
         &self,
         process_id: ProcessId,
         allow_num: usize,
-        mut slice: ReadWriteAppSlice,
-    ) -> Result<ReadWriteAppSlice, (ReadWriteAppSlice, ErrorCode)> {
+        mut slice: ReadWriteProcessBuffer,
+    ) -> Result<ReadWriteProcessBuffer, (ReadWriteProcessBuffer, ErrorCode)> {
         let res = self
             .grants
             .enter(process_id, |grant, _| {
@@ -1542,8 +1546,8 @@ impl<'a, A: hil::time::Alarm<'a>> Driver for SDCardDriver<'a, A> {
         &self,
         process_id: ProcessId,
         allow_num: usize,
-        mut slice: ReadOnlyAppSlice,
-    ) -> Result<ReadOnlyAppSlice, (ReadOnlyAppSlice, ErrorCode)> {
+        mut slice: ReadOnlyProcessBuffer,
+    ) -> Result<ReadOnlyProcessBuffer, (ReadOnlyProcessBuffer, ErrorCode)> {
         let res = self
             .grants
             .enter(process_id, |grant, _| {
@@ -1615,23 +1619,24 @@ impl<'a, A: hil::time::Alarm<'a>> Driver for SDCardDriver<'a, A> {
                     .grants
                     .enter(process_id, |app, _| {
                         app.write_buffer
-                            .map_or(Err(ErrorCode::NOMEM), |write_buffer| {
+                            .enter(|write_buffer| {
                                 self.kernel_buf
                                     .take()
                                     .map_or(Err(ErrorCode::BUSY), |kernel_buf| {
                                         // copy over write data from application
                                         // Limit to minimum length between kernel_buf,
                                         // write_buffer, and 512 (block size)
-                                        for (kernel_byte, &write_byte) in
+                                        for (kernel_byte, ref write_byte) in
                                             kernel_buf.iter_mut().zip(write_buffer.iter()).take(512)
                                         {
-                                            *kernel_byte = write_byte;
+                                            *kernel_byte = write_byte.get();
                                         }
 
                                         // begin writing
                                         self.sdcard.write_blocks(kernel_buf, data as u32, 1)
                                     })
                             })
+                            .unwrap_or(Err(ErrorCode::NOMEM))
                     })
                     .unwrap_or(Err(ErrorCode::NOMEM));
                 CommandReturn::from(result)

--- a/capsules/src/spi_peripheral.rs
+++ b/capsules/src/spi_peripheral.rs
@@ -10,7 +10,9 @@ use kernel::hil::spi::ClockPhase;
 use kernel::hil::spi::ClockPolarity;
 use kernel::hil::spi::{SpiSlaveClient, SpiSlaveDevice};
 use kernel::{CommandReturn, Driver, ErrorCode, Grant, ProcessId};
-use kernel::{Read, ReadOnlyAppSlice, ReadWrite, ReadWriteAppSlice};
+use kernel::{
+    ReadOnlyProcessBuffer, ReadWriteProcessBuffer, ReadableProcessBuffer, WriteableProcessBuffer,
+};
 
 /// Syscall driver number.
 use crate::driver;
@@ -25,8 +27,8 @@ pub const DEFAULT_WRITE_BUF_LENGTH: usize = 1024;
 // that includes this new callback field.
 #[derive(Default)]
 pub struct PeripheralApp {
-    app_read: ReadWriteAppSlice,
-    app_write: ReadOnlyAppSlice,
+    app_read: ReadWriteProcessBuffer,
+    app_write: ReadOnlyProcessBuffer,
     len: usize,
     index: usize,
 }
@@ -66,16 +68,19 @@ impl<'a, S: SpiSlaveDevice> SpiPeripheral<'a, S> {
     fn do_next_read_write(&self, app: &mut PeripheralApp) {
         let write_len = self.kernel_write.map_or(0, |kwbuf| {
             let mut start = app.index;
-            let tmp_len = app.app_write.map_or(0, |src| {
-                let len = cmp::min(app.len - start, self.kernel_len.get());
-                let end = cmp::min(start + len, src.len());
-                start = cmp::min(start, end);
+            let tmp_len = app
+                .app_write
+                .enter(|src| {
+                    let len = cmp::min(app.len - start, self.kernel_len.get());
+                    let end = cmp::min(start + len, src.len());
+                    start = cmp::min(start, end);
 
-                for (i, c) in src.as_ref()[start..end].iter().enumerate() {
-                    kwbuf[i] = *c;
-                }
-                end - start
-            });
+                    for (i, c) in src[start..end].iter().enumerate() {
+                        kwbuf[i] = c.get();
+                    }
+                    end - start
+                })
+                .unwrap_or(0);
             app.index = start + tmp_len;
             tmp_len
         });
@@ -96,8 +101,8 @@ impl<S: SpiSlaveDevice> Driver for SpiPeripheral<'_, S> {
         &self,
         process_id: ProcessId,
         allow_num: usize,
-        mut slice: ReadWriteAppSlice,
-    ) -> Result<ReadWriteAppSlice, (ReadWriteAppSlice, ErrorCode)> {
+        mut slice: ReadWriteProcessBuffer,
+    ) -> Result<ReadWriteProcessBuffer, (ReadWriteProcessBuffer, ErrorCode)> {
         let res = self
             .grants
             .enter(process_id, |grant, _| match allow_num {
@@ -123,8 +128,8 @@ impl<S: SpiSlaveDevice> Driver for SpiPeripheral<'_, S> {
         &self,
         process_id: ProcessId,
         allow_num: usize,
-        mut slice: ReadOnlyAppSlice,
-    ) -> Result<ReadOnlyAppSlice, (ReadOnlyAppSlice, ErrorCode)> {
+        mut slice: ReadOnlyProcessBuffer,
+    ) -> Result<ReadOnlyProcessBuffer, (ReadOnlyProcessBuffer, ErrorCode)> {
         let res = self
             .grants
             .enter(process_id, |grant, _| match allow_num {
@@ -202,8 +207,8 @@ impl<S: SpiSlaveDevice> Driver for SpiPeripheral<'_, S> {
                     return CommandReturn::failure(ErrorCode::BUSY);
                 }
                 self.grants.enter(process_id, |app, _| {
-                    let mut mlen = app.app_write.map_or(0, |w| w.len());
-                    let rlen = app.app_read.map_or(mlen, |r| r.len());
+                    let mut mlen = app.app_write.enter(|w| w.len()).unwrap_or(0);
+                    let rlen = app.app_read.enter(|r| r.len()).unwrap_or(mlen);
                     mlen = cmp::min(mlen, rlen);
                     if mlen >= arg1 && arg1 > 0 {
                         app.len = arg1;
@@ -260,7 +265,7 @@ impl<S: SpiSlaveDevice> SpiSlaveClient for SpiPeripheral<'_, S> {
             let _ = self.grants.enter(*process_id, move |app, upcalls| {
                 let rbuf = readbuf.map(|src| {
                     let index = app.index;
-                    app.app_read.mut_map_or((), |dest| {
+                    let _ = app.app_read.mut_enter(|dest| {
                         // Need to be careful that app_read hasn't changed
                         // under us, so check all values against actual
                         // slice lengths.
@@ -277,11 +282,11 @@ impl<S: SpiSlaveDevice> SpiSlaveClient for SpiPeripheral<'_, S> {
                         // This results in a zero-length operation. -pal 12/9/20
                         let start = cmp::min(start, end);
 
-                        let dest_area = &mut dest[start..end];
+                        let dest_area = &dest[start..end];
                         let real_len = end - start;
 
                         for (i, c) in src[0..real_len].iter().enumerate() {
-                            dest_area[i] = *c;
+                            dest_area[i].set(*c);
                         }
                     });
                     src

--- a/kernel/src/driver.rs
+++ b/kernel/src/driver.rs
@@ -70,7 +70,7 @@
 //! encoding these types into the Tock system call ABI specification.
 
 use crate::errorcode::ErrorCode;
-use crate::mem::{ReadOnlyAppSlice, ReadWriteAppSlice};
+use crate::mem::{ReadOnlyProcessBuffer, ReadWriteProcessBuffer};
 use crate::process;
 use crate::process::ProcessId;
 use crate::syscall::SyscallReturn;
@@ -188,7 +188,7 @@ pub trait Driver {
         CommandReturn::failure(ErrorCode::NOSUPPORT)
     }
 
-    /// System call for a process to pass a buffer (a ReadWriteAppSlice) to
+    /// System call for a process to pass a buffer (a ReadWriteProcessBuffer) to
     /// the kernel that the kernel can either read or write. The kernel calls
     /// this method only after it checks that the entire buffer is
     /// within memory the process can both read and write.
@@ -196,13 +196,13 @@ pub trait Driver {
         &self,
         app: ProcessId,
         which: usize,
-        slice: ReadWriteAppSlice,
-    ) -> Result<ReadWriteAppSlice, (ReadWriteAppSlice, ErrorCode)> {
+        slice: ReadWriteProcessBuffer,
+    ) -> Result<ReadWriteProcessBuffer, (ReadWriteProcessBuffer, ErrorCode)> {
         Err((slice, ErrorCode::NOSUPPORT))
     }
 
     /// System call for a process to pass a read-only buffer (a
-    /// ReadOnlyAppSlice) to the kernel that the kernel can read.
+    /// ReadOnlyProcessBuffer) to the kernel that the kernel can read.
     /// The kernel calls this method only after it
     /// checks that that the entire buffer is within memory the
     /// process can read. This system call allows a process to pass
@@ -211,8 +211,8 @@ pub trait Driver {
         &self,
         app: ProcessId,
         which: usize,
-        slice: ReadOnlyAppSlice,
-    ) -> Result<ReadOnlyAppSlice, (ReadOnlyAppSlice, ErrorCode)> {
+        slice: ReadOnlyProcessBuffer,
+    ) -> Result<ReadOnlyProcessBuffer, (ReadOnlyProcessBuffer, ErrorCode)> {
         Err((slice, ErrorCode::NOSUPPORT))
     }
 

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -41,7 +41,7 @@
 //!    OS need to use them. However, generally only a very small interface is
 //!    exposed, and using that interface cannot compromise the overall system or
 //!    the core kernel. These functions are also marked `pub`. For example, the
-//!    `AppSlice` abstraction must be exposed to capsules to use shared memory
+//!    `ProcessBuffer` abstraction must be exposed to capsules to use shared memory
 //!    between a process and the kernel. However, the constructor is not public,
 //!    and the API exposed to capsules is very limited and confined by the Rust
 //!    type system. The constructor and other sensitive interfaces are
@@ -116,7 +116,10 @@ pub use crate::driver::{CommandReturn, Driver};
 pub use crate::errorcode::into_statuscode;
 pub use crate::errorcode::ErrorCode;
 pub use crate::grant::{Grant, ProcessGrant};
-pub use crate::mem::{Read, ReadOnlyAppSlice, ReadWrite, ReadWriteAppSlice};
+pub use crate::mem::{
+    ReadOnlyProcessBuffer, ReadWriteProcessBuffer, ReadableProcessBuffer, ReadableProcessByte,
+    ReadableProcessSlice, WriteableProcessBuffer, WriteableProcessSlice,
+};
 pub use crate::platform::scheduler_timer::{SchedulerTimer, VirtualSchedulerTimer};
 pub use crate::platform::watchdog;
 pub use crate::platform::{mpu, Chip, InterruptService, Platform};

--- a/kernel/src/mem.rs
+++ b/kernel/src/mem.rs
@@ -8,19 +8,29 @@
 //! allow_read_only() system calls.
 //!
 //! A read-write and read-only call is mapped to the high-level Rust
-//! types [`ReadWriteAppSlice`] and [`ReadOnlyAppSlice`]
+//! types [`ReadWriteProcessBuffer`] and [`ReadOnlyProcessBuffer`]
 //! respectively. The memory regions can be accessed through the
-//! [`Read`] and [`ReadWrite`] traits, implemented on the
-//! AppSlice-structs.
+//! [`ReadableProcessBuffer`] and [`WriteableProcessBuffer`] traits,
+//! implemented on the process buffer structs.
+//!
+//! Each access to the buffer structs requires a liveness check to ensure that the
+//! process memory is still valid. For a more traditional interface, users can convert
+//! buffers into [`ReadableProcessSlice`] or [`WriteableProcessSlice`] and use these
+//! for the lifetime of their operations. Users cannot hold live-lived references to
+//! these slices, however.
+
+use core::cell::Cell;
+use core::ops::{Index, Range, RangeFrom, RangeTo};
 
 use crate::capabilities;
-use crate::process::ProcessId;
+use crate::process::{self, ProcessId};
 
-/// Convert an AppSlice's internal representation to a Rust slice.
+/// Convert a process buffer's internal representation to a
+/// ReadableProcessSlice.
 ///
-/// This function will automatically convert zero-length AppSlices
-/// into valid zero-sized Rust slices regardless of the value of
-/// `ptr`.
+/// This function will automatically convert zero-length process
+/// buffers into valid zero-sized Rust slices regardless of the value
+/// of `ptr`.
 ///
 /// # Safety requirements
 ///
@@ -29,36 +39,49 @@ use crate::process::ProcessId;
 /// nonzero. This memory region must be mapped as _readable_, and
 /// optionally _writable_ and _executable_. It must be allocated
 /// within a single process' address space for the entire lifetime
-/// `'a`. No mutable slice pointing to an overlapping memory region
-/// may exist over the entire lifetime `'a`.
-unsafe fn raw_appslice_to_slice<'a>(ptr: *const u8, len: usize) -> &'a [u8] {
-    use core::ptr::NonNull;
-    use core::slice::from_raw_parts;
-
-    // Rust has very strict requirements on pointer validity[1] which
-    // also in part apply to accesses of length 0. We allow an
-    // application to supply arbitrary pointers if the buffer length is
-    // 0, but this is not allowed for Rust slices. For instance, a null
-    // pointer is _never_ valid, not even for accesses of size zero.
-    //
-    // To get a pointer which does not point to valid (allocated) memory, but
-    // is safe to construct for accesses of size zero, we must call
-    // NonNull::dangling(). The resulting pointer is guaranteed to be well-aligned
-    // and uphold the guarantees required for accesses of size zero.
-    //
-    // [1]: https://doc.rust-lang.org/core/ptr/index.html#safety
-    match len {
-        0 => from_raw_parts(NonNull::<u8>::dangling().as_ptr(), 0),
-        _ => from_raw_parts(ptr, len),
-    }
+/// `'a`.
+///
+/// It is sound for multiple overlapping [`ReadableProcessSlice`]s or
+/// [`WriteableProcessSlice`]s to be in scope at the same time.
+unsafe fn raw_processbuf_to_roprocessslice<'a>(
+    ptr: *const u8,
+    len: usize,
+) -> &'a ReadableProcessSlice {
+    // Transmute a reference to a slice of Cell<u8>s into a reference
+    // to a ReadableProcessSlice. This is possible as
+    // ReadableProcessSlice is a #[repr(transparent)] wrapper around a
+    // [ReadableProcessByte], which is a #[repr(transparent)] wrapper
+    // around a [Cell<u8>], which is a #[repr(transparent)] wrapper
+    // around an [UnsafeCell<u8>], which finally #[repr(transparent)]
+    // wraps a [u8]
+    core::mem::transmute::<&[u8], &ReadableProcessSlice>(
+        // Rust has very strict requirements on pointer validity[1]
+        // which also in part apply to accesses of length 0. We allow
+        // an application to supply arbitrary pointers if the buffer
+        // length is 0, but this is not allowed for Rust slices. For
+        // instance, a null pointer is _never_ valid, not even for
+        // accesses of size zero.
+        //
+        // To get a pointer which does not point to valid (allocated)
+        // memory, but is safe to construct for accesses of size zero,
+        // we must call NonNull::dangling(). The resulting pointer is
+        // guaranteed to be well-aligned and uphold the guarantees
+        // required for accesses of size zero.
+        //
+        // [1]: https://doc.rust-lang.org/core/ptr/index.html#safety
+        match len {
+            0 => core::slice::from_raw_parts(core::ptr::NonNull::<u8>::dangling().as_ptr(), 0),
+            _ => core::slice::from_raw_parts(ptr, len),
+        },
+    )
 }
 
-/// Convert an AppSlice's internal representation to a mutable Rust
-/// slice.
+/// Convert an process buffers's internal representation to a
+/// WriteableProcessSlice.
 ///
-/// This function will automatically convert zero-length appslices
-/// into valid zero-sized Rust slices regardless of the value of
-/// `ptr`.
+/// This function will automatically convert zero-length process
+/// buffers into valid zero-sized Rust slices regardless of the value
+/// of `ptr`.
 ///
 /// # Safety requirements
 ///
@@ -67,302 +90,190 @@ unsafe fn raw_appslice_to_slice<'a>(ptr: *const u8, len: usize) -> &'a [u8] {
 /// nonzero. This memory region must be mapped as _readable_ and
 /// _writable_, and optionally _executable_. It must be allocated
 /// within a single process' address space for the entire lifetime
-/// `'a`. No other mutable or immutable slice pointing to an
-/// overlapping memory region may exist over the entire lifetime `'a`.
-unsafe fn raw_appslice_to_slice_mut<'a>(ptr: *mut u8, len: usize) -> &'a mut [u8] {
-    use core::ptr::NonNull;
-    use core::slice::from_raw_parts_mut;
-
-    // See documentation on [`raw_appslice_to_slice`] for Rust slice &
-    // pointer validity requirements
-    match len {
-        0 => from_raw_parts_mut(NonNull::<u8>::dangling().as_ptr(), 0),
-        _ => from_raw_parts_mut(ptr, len),
-    }
+/// `'a`.
+///
+/// No other mutable or immutable Rust reference pointing to an
+/// overlapping memory region, which is not also created over
+/// `UnsafeCell`, may exist over the entire lifetime `'a`. Even though
+/// this effectively returns a slice of [`Cell`]s, writing to some
+/// memory through a [`Cell`] while another reference is in scope is
+/// unsound. Because a process is free to modify its memory, this is
+/// -- in a broader sense -- true for all process memory.
+///
+/// However, it is sound for multiple overlapping
+/// [`ReadableProcessSlice`]s or [`WriteableProcessSlice`]s to be in
+/// scope at the same time.
+unsafe fn raw_processbuf_to_rwprocessslice<'a>(
+    ptr: *mut u8,
+    len: usize,
+) -> &'a WriteableProcessSlice {
+    // Transmute a reference to a slice of Cell<u8>s into a reference
+    // to a ReadableProcessSlice. This is possible as
+    // ReadableProcessSlice is a #[repr(transparent)] wrapper around a
+    // [ReadableProcessByte], which is a #[repr(transparent)] wrapper
+    // around a [Cell<u8>], which is a #[repr(transparent)] wrapper
+    // around an [UnsafeCell<u8>], which finally #[repr(transparent)]
+    // wraps a [u8]
+    core::mem::transmute::<&[u8], &WriteableProcessSlice>(
+        // Rust has very strict requirements on pointer validity[1]
+        // which also in part apply to accesses of length 0. We allow
+        // an application to supply arbitrary pointers if the buffer
+        // length is 0, but this is not allowed for Rust slices. For
+        // instance, a null pointer is _never_ valid, not even for
+        // accesses of size zero.
+        //
+        // To get a pointer which does not point to valid (allocated)
+        // memory, but is safe to construct for accesses of size zero,
+        // we must call NonNull::dangling(). The resulting pointer is
+        // guaranteed to be well-aligned and uphold the guarantees
+        // required for accesses of size zero.
+        //
+        // [1]: https://doc.rust-lang.org/core/ptr/index.html#safety
+        match len {
+            0 => core::slice::from_raw_parts_mut(core::ptr::NonNull::<u8>::dangling().as_ptr(), 0),
+            _ => core::slice::from_raw_parts_mut(ptr, len),
+        },
+    )
 }
 
-/// A readable region of userspace memory.
+/// A readable region of userspace process memory.
 ///
 /// This trait can be used to gain read-only access to memory regions
-/// wrapped in an AppSlice type.
-pub trait Read {
+/// wrapped in either a [`ReadOnlyProcessBuffer`] or a
+/// [`ReadWriteProcessBuffer`] type.
+pub trait ReadableProcessBuffer {
     /// Length of the memory region.
     ///
     /// If the process is no longer alive and the memory has been
     /// reclaimed, this method must return 0.
     ///
-    /// # Default AppSlice
+    /// # Default Process Buffer
     ///
-    /// A default instance of an AppSlice must return 0.
+    /// A default instance of a process buffer must return 0.
     fn len(&self) -> usize;
 
     /// Pointer to the first byte of the userspace memory region.
     ///
     /// If the length of the initially shared memory region
-    /// (irrespective of the return value of [`len`](Read::len)) is 0,
-    /// this function returns a pointer to address `0x0`. This is
-    /// because processes may allow buffers with length 0 to share no
-    /// no memory with the kernel. Because these buffers have zero
-    /// length, they may have any pointer value. However, these
-    /// _dummy addresses_ should not be leaked, so this method returns
-    /// 0 for zero-length slices.
+    /// (irrespective of the return value of
+    /// [`len`](ReadableProcessBuffer::len)) is 0, this function returns
+    /// a pointer to address `0x0`. This is because processes may
+    /// allow buffers with length 0 to share no memory with the
+    /// kernel. Because these buffers have zero length, they may have
+    /// any pointer value. However, these _dummy addresses_ should not
+    /// be leaked, so this method returns 0 for zero-length slices.
     ///
-    /// # Default AppSlice
+    /// # Default Process Buffer
     ///
-    /// A default instance of an AppSlice must return a pointer to
-    /// address `0x0`.
+    /// A default instance of a process buffer must return a pointer
+    /// to address `0x0`.
     fn ptr(&self) -> *const u8;
 
-    /// Applies a function to the (read only) slice reference pointed
-    /// to by the AppSlice.
+    /// Applies a function to the (read only) process slice reference
+    /// pointed to by the process buffer.
     ///
     /// If the process is no longer alive and the memory has been
-    /// reclaimed, this method must return the default value.
+    /// reclaimed, this method must return
+    /// `Err(process::Error::NoSuchApp)`.
     ///
-    /// # Default AppSlice
+    /// # Default Process Buffer
     ///
-    /// A default instance of an AppSlice must return the passed
-    /// default value without executing the closure.
-    fn map_or<F, R>(&self, default: R, fun: F) -> R
+    /// A default instance of a process buffer must return
+    /// `Err(process::Error::NoSuchApp)` without executing the passed
+    /// closure.
+    fn enter<F, R>(&self, fun: F) -> Result<R, process::Error>
     where
-        F: FnOnce(&[u8]) -> R;
+        F: FnOnce(&ReadableProcessSlice) -> R;
 }
 
-/// A readable and writable region of userspace memory.
+/// A readable and writeable region of userspace process memory.
 ///
 /// This trait can be used to gain read-write access to memory regions
-/// wrapped in an AppSlice type.
+/// wrapped in a [`ReadWriteProcessBuffer`].
 ///
-/// This is a supertrait of [`Read`], which features further methods.
-pub trait ReadWrite: Read {
-    /// Applies a function to the mutable slice reference pointed to
-    /// by the AppSlice.
+/// This is a supertrait of [`ReadableProcessBuffer`], which features
+/// methods allowing mutable access.
+pub trait WriteableProcessBuffer: ReadableProcessBuffer {
+    /// Applies a function to the mutable process slice reference
+    /// pointed to by the [`ReadWriteProcessBuffer`].
     ///
     /// If the process is no longer alive and the memory has been
-    /// reclaimed, this method must return the default value.
+    /// reclaimed, this method must return
+    /// `Err(process::Error::NoSuchApp)`.
     ///
-    /// # Default AppSlice
+    /// # Default Process Buffer
     ///
-    /// A default instance of an AppSlice must return the passed
-    /// default value without executing the closure.
-    fn mut_map_or<F, R>(&mut self, default: R, fun: F) -> R
+    /// A default instance of a process buffer must return
+    /// `Err(process::Error::NoSuchApp)` without executing the passed
+    /// closure.
+    fn mut_enter<F, R>(&self, fun: F) -> Result<R, process::Error>
     where
-        F: FnOnce(&mut [u8]) -> R;
+        F: FnOnce(&WriteableProcessSlice) -> R;
 }
 
-/// Read-writable memory region of a process, shared with the kernel
-pub struct ReadWriteAppSlice {
-    ptr: *mut u8,
-    len: usize,
-    process_id: Option<ProcessId>,
-}
-
-impl ReadWriteAppSlice {
-    /// Construct a new [`ReadWriteAppSlice`] over a given pointer and
-    /// length.
-    ///
-    /// # Safety requirements
-    ///
-    /// Refer to the safety requirments of
-    /// [`ReadWriteAppSlice::new_external`].
-    pub(crate) unsafe fn new(ptr: *mut u8, len: usize, process_id: ProcessId) -> Self {
-        ReadWriteAppSlice {
-            ptr,
-            len,
-            process_id: Some(process_id),
-        }
-    }
-
-    /// Construct a new [`ReadWriteAppSlice`] over a given pointer and
-    /// length.
-    ///
-    /// Publicly accessible constructor, which requires the
-    /// [`capabilities::ExternalProcessCapability`] capability. This
-    /// is provided to allow implementations of the
-    /// [`Process`](crate::process::Process) trait outside of
-    /// the `kernel` crate.
-    ///
-    /// # Safety requirements
-    ///
-    /// In Rust, no two slices may point to the same memory location
-    /// if at least one is mutable. This constructor relies on the
-    /// fact that at most a single [`ReadWriteAppSlice`] or
-    /// [`ReadOnlyAppSlice`] will point to the memory region of `[ptr;
-    /// ptr + len)`, and no other slice in scope anywhere in the
-    /// kernel points to an overlapping memory region.
-    ///
-    /// If the length is `0`, an arbitrary pointer may be passed into
-    /// `ptr`. It does not necessarily have to point to allocated
-    /// memory, nor does it have to meet [Rust's pointer validity
-    /// requirements](https://doc.rust-lang.org/core/ptr/index.html#safety).
-    /// [`ReadWriteAppSlice`] must ensure that all Rust slices with a
-    /// length of `0` must be constructed over a valid (but not
-    /// necessarily allocated) base pointer.
-    ///
-    /// If the length is not `0`, the memory region of `[ptr; ptr +
-    /// len)` must be valid memory of the process of the given
-    /// [`ProcessId`]. It must be allocated and and accessible over the
-    /// entire lifetime of the [`ReadWriteAppSlice`]. It must not
-    /// point to memory outside of the process' accessible memory
-    /// range, or point (in part) to other processes or kernel
-    /// memory. The `ptr` must meet [Rust's requirements for pointer
-    /// validity](https://doc.rust-lang.org/core/ptr/index.html#safety),
-    /// in particular it must have a minimum alignment of
-    /// `core::mem::align_of::<u8>()` on the respective platform. It
-    /// must point to memory mapped as _readable_ and _writable_ and
-    /// optionally _executable_.
-    pub unsafe fn new_external(
-        ptr: *mut u8,
-        len: usize,
-        process_id: ProcessId,
-        _cap: &dyn capabilities::ExternalProcessCapability,
-    ) -> Self {
-        Self::new(ptr, len, process_id)
-    }
-
-    /// Consumes the ReadWriteAppSlice, returning its constituent
-    /// pointer and size. This ensures that there cannot simultaneously
-    /// be both a `ReadWriteAppSlice` and a pointer to its internal data.
-    ///
-    /// `consume` can be used when the kernel needs to pass the underlying
-    /// values across the kernel-to-user boundary (e.g., in return values to
-    /// system calls).
-    pub(crate) fn consume(self) -> (*mut u8, usize) {
-        (self.ptr, self.len)
-    }
-
-    /// This is a `const` version of `Default::default` with the same semantics.
-    ///
-    /// Having a const initializer allows initializing a fixed-size array with default values
-    /// without the struct being marked `Copy` as such:
-    ///
-    /// ```
-    /// use kernel::ReadWriteAppSlice;
-    /// const DEFAULT_RWAPPSLICE_VAL: ReadWriteAppSlice = ReadWriteAppSlice::const_default();
-    /// let my_array = [DEFAULT_RWAPPSLICE_VAL; 12];
-    /// ```
-    pub const fn const_default() -> Self {
-        Self {
-            ptr: 0x0 as *mut u8,
-            len: 0,
-            process_id: None,
-        }
-    }
-}
-
-impl Default for ReadWriteAppSlice {
-    fn default() -> Self {
-        Self::const_default()
-    }
-}
-
-impl ReadWrite for ReadWriteAppSlice {
-    fn mut_map_or<F, R>(&mut self, default: R, fun: F) -> R
-    where
-        F: FnOnce(&mut [u8]) -> R,
-    {
-        match self.process_id {
-            None => default,
-            Some(pid) => pid.kernel.process_map_or(default, pid, |_| {
-                // Safety: `kernel.process_map_or()` validates that the process still exists
-                // and its memory is still valid. `Process` tracks the "high water mark" of
-                // memory that the process has `allow`ed to the kernel, and will not permit
-                // the process to free any memory after it has been `allow`ed. This guarantees
-                // that the buffer is safe to convert into a slice here.
-                fun(unsafe { raw_appslice_to_slice_mut(self.ptr, self.len) })
-            }),
-        }
-    }
-}
-
-impl Read for ReadWriteAppSlice {
-    fn len(&self) -> usize {
-        self.process_id
-            .map_or(0, |pid| pid.kernel.process_map_or(0, pid, |_| self.len))
-    }
-
-    fn ptr(&self) -> *const u8 {
-        if self.len == 0 {
-            0x0 as *const u8
-        } else {
-            self.ptr
-        }
-    }
-
-    fn map_or<F, R>(&self, default: R, fun: F) -> R
-    where
-        F: FnOnce(&[u8]) -> R,
-    {
-        match self.process_id {
-            None => default,
-            Some(pid) => pid.kernel.process_map_or(default, pid, |_| {
-                // Safety: `kernel.process_map_or()` validates that the process still exists
-                // and its memory is still valid. `Process` tracks the "high water mark" of
-                // memory that the process has `allow`ed to the kernel, and will not permit
-                // the process to free any memory after it has been `allow`ed. This guarantees
-                // that the buffer is safe to convert into a slice here.
-                fun(unsafe { raw_appslice_to_slice(self.ptr, self.len) })
-            }),
-        }
-    }
-}
-
-/// Read-only memory region of a process, shared with the kernel
-pub struct ReadOnlyAppSlice {
+/// Read-only buffer shared by a userspace process
+///
+/// This struct is provided to capsules when a process `allow`s a
+/// particular section of its memory to the kernel and gives the
+/// kernel read access to this memory.
+///
+/// It can be used to obtain a [`ReadableProcessSlice`], which is
+/// based around a slice of [`Cell`]s. This is because a userspace can
+/// `allow` overlapping sections of memory into different
+/// [`ReadableProcessSlice`]. Having at least one mutable Rust slice
+/// along with read-only slices to overlapping memory in Rust violates
+/// Rust's aliasing rules. A slice of [`Cell`]s avoids this issue by
+/// explicitly supporting interior mutability. Still, a memory barrier
+/// prior to switching to userspace is required, as the compiler is
+/// free to reorder reads and writes, even through [`Cell`]s.
+pub struct ReadOnlyProcessBuffer {
     ptr: *const u8,
     len: usize,
     process_id: Option<ProcessId>,
 }
 
-impl ReadOnlyAppSlice {
-    /// Construct a new [`ReadOnlyAppSlice`] over a given pointer and
+impl ReadOnlyProcessBuffer {
+    /// Construct a new [`ReadOnlyProcessBuffer`] over a given pointer and
     /// length.
     ///
     /// # Safety requirements
     ///
     /// Refer to the safety requirments of
-    /// [`ReadOnlyAppSlice::new_external`].
+    /// [`ReadOnlyProcessBuffer::new_external`].
     pub(crate) unsafe fn new(ptr: *const u8, len: usize, process_id: ProcessId) -> Self {
-        ReadOnlyAppSlice {
+        ReadOnlyProcessBuffer {
             ptr,
             len,
             process_id: Some(process_id),
         }
     }
 
-    /// Construct a new [`ReadOnlyAppSlice`] over a given pointer and
-    /// length.
+    /// Construct a new [`ReadOnlyProcessBuffer`] over a given pointer
+    /// and length.
     ///
     /// Publicly accessible constructor, which requires the
     /// [`capabilities::ExternalProcessCapability`] capability. This
     /// is provided to allow implementations of the
-    /// [`Process`](crate::process::Process) trait outside of
-    /// the `kernel` crate.
+    /// [`Process`](crate::process::Process) trait outside of the
+    /// `kernel` crate.
     ///
     /// # Safety requirements
-    ///
-    /// In Rust, no two slices may point to the same memory location
-    /// if at least one is mutable. This constructor relies on the
-    /// fact that at most a single [`ReadWriteAppSlice`] or
-    /// [`ReadOnlyAppSlice`] will point to the memory region of `[ptr;
-    /// ptr + len)`, and no other slice in scope anywhere in the
-    /// kernel points to an overlapping memory region.
     ///
     /// If the length is `0`, an arbitrary pointer may be passed into
     /// `ptr`. It does not necessarily have to point to allocated
     /// memory, nor does it have to meet [Rust's pointer validity
     /// requirements](https://doc.rust-lang.org/core/ptr/index.html#safety).
-    /// [`ReadOnlyAppSlice`] must ensure that all Rust slices with a
-    /// length of `0` must be constructed over a valid (but not
+    /// [`ReadOnlyProcessBuffer`] must ensure that all Rust slices
+    /// with a length of `0` must be constructed over a valid (but not
     /// necessarily allocated) base pointer.
     ///
     /// If the length is not `0`, the memory region of `[ptr; ptr +
     /// len)` must be valid memory of the process of the given
-    /// [`ProcessId`]. It must be allocated and and accessible over the
-    /// entire lifetime of the [`ReadOnlyAppSlice`]. It must not point
-    /// to memory outside of the process' accessible memory range, or
-    /// point (in part) to other processes or kernel memory. The `ptr`
-    /// must meet [Rust's requirements for pointer
+    /// [`ProcessId`]. It must be allocated and and accessible over
+    /// the entire lifetime of the [`ReadOnlyProcessBuffer`]. It must
+    /// not point to memory outside of the process' accessible memory
+    /// range, or point (in part) to other processes or kernel
+    /// memory. The `ptr` must meet [Rust's requirements for pointer
     /// validity](https://doc.rust-lang.org/core/ptr/index.html#safety),
     /// in particular it must have a minimum alignment of
     /// `core::mem::align_of::<u8>()` on the respective platform. It
@@ -377,29 +288,20 @@ impl ReadOnlyAppSlice {
         Self::new(ptr, len, process_id)
     }
 
-    /// Consumes the ReadOnlyAppSlice, returning its constituent
-    /// pointer and size. This ensures that there cannot simultaneously
-    /// be both a `ReadOnlyAppSlice` and a pointer to its internal data.
+    /// Consumes the ReadOnlyProcessBuffer, returning its constituent
+    /// pointer and size. This ensures that there cannot
+    /// simultaneously be both a `ReadOnlyProcessBuffer` and a pointer
+    /// to its internal data.
     ///
-    /// `consume` can be used when the kernel needs to pass the underlying
-    /// values across the kernel-to-user boundary (e.g., in return values to
-    /// system calls).
+    /// `consume` can be used when the kernel needs to pass the
+    /// underlying values across the kernel-to-user boundary (e.g., in
+    /// return values to system calls).
     pub(crate) fn consume(self) -> (*const u8, usize) {
         (self.ptr, self.len)
     }
 }
 
-impl Default for ReadOnlyAppSlice {
-    fn default() -> Self {
-        ReadOnlyAppSlice {
-            ptr: 0x0 as *mut u8,
-            len: 0,
-            process_id: None,
-        }
-    }
-}
-
-impl Read for ReadOnlyAppSlice {
+impl ReadableProcessBuffer for ReadOnlyProcessBuffer {
     fn len(&self) -> usize {
         self.process_id
             .map_or(0, |pid| pid.kernel.process_map_or(0, pid, |_| self.len))
@@ -413,20 +315,545 @@ impl Read for ReadOnlyAppSlice {
         }
     }
 
-    fn map_or<F, R>(&self, default: R, fun: F) -> R
+    fn enter<F, R>(&self, fun: F) -> Result<R, process::Error>
     where
-        F: FnOnce(&[u8]) -> R,
+        F: FnOnce(&ReadableProcessSlice) -> R,
     {
         match self.process_id {
-            None => default,
-            Some(pid) => pid.kernel.process_map_or(default, pid, |_| {
-                // Safety: `kernel.process_map_or()` validates that the process still exists
-                // and its memory is still valid. `Process` tracks the "high water mark" of
-                // memory that the process has `allow`ed to the kernel, and will not permit
-                // the process to free any memory after it has been `allow`ed. This guarantees
-                // that the buffer is safe to convert into a slice here.
-                fun(unsafe { raw_appslice_to_slice(self.ptr, self.len) })
-            }),
+            None => Err(process::Error::NoSuchApp),
+            Some(pid) => pid
+                .kernel
+                .process_map_or(Err(process::Error::NoSuchApp), pid, |_| {
+                    // Safety: `kernel.process_map_or()` validates that
+                    // the process still exists and its memory is still
+                    // valid. In particular, `Process` tracks the "high water
+                    // mark" of memory that the process has `allow`ed to the
+                    // kernel. Because `Process` does not feature an API to
+                    // move the "high water mark" down again, which would be
+                    // called once a `ProcessBuffer` has been passed back into
+                    // the kernel, a given `Process` implementation must assume
+                    // that the memory described by a once-allowed
+                    // `ProcessBuffer` is still in use, and thus will not
+                    // permit the process to free any memory after it has
+                    // been `allow`ed to the kernel once. This guarantees
+                    // that the buffer is safe to convert into a slice
+                    // here. For more information, refer to the
+                    // comment and subsequent discussion on tock/tock#2632:
+                    // https://github.com/tock/tock/pull/2632#issuecomment-869974365
+                    Ok(fun(unsafe {
+                        raw_processbuf_to_roprocessslice(self.ptr, self.len)
+                    }))
+                }),
         }
+    }
+}
+
+impl Default for ReadOnlyProcessBuffer {
+    fn default() -> Self {
+        ReadOnlyProcessBuffer {
+            ptr: 0x0 as *mut u8,
+            len: 0,
+            process_id: None,
+        }
+    }
+}
+
+/// Read-writable buffer shared by a userspace process
+///
+/// This struct is provided to capsules when a process `allows` a
+/// particular section of its memory to the kernel and gives the
+/// kernel read and write access to this memory.
+///
+/// It can be used to obtain a [`WriteableProcessSlice`], which is
+/// based around a slice of [`Cell`]s. This is because a userspace can
+/// `allow` overlapping sections of memory into different
+/// [`WriteableProcessSlice`]. Having at least one mutable Rust slice
+/// along with read-only or other mutable slices to overlapping memory
+/// in Rust violates Rust's aliasing rules. A slice of [`Cell`]s
+/// avoids this issue by explicitly supporting interior
+/// mutability. Still, a memory barrier prior to switching to
+/// userspace is required, as the compiler is free to reorder reads
+/// and writes, even through [`Cell`]s.
+pub struct ReadWriteProcessBuffer {
+    ptr: *mut u8,
+    len: usize,
+    process_id: Option<ProcessId>,
+}
+
+impl ReadWriteProcessBuffer {
+    /// Construct a new [`ReadWriteProcessBuffer`] over a given
+    /// pointer and length.
+    ///
+    /// # Safety requirements
+    ///
+    /// Refer to the safety requirments of
+    /// [`ReadWriteProcessBuffer::new_external`].
+    pub(crate) unsafe fn new(ptr: *mut u8, len: usize, process_id: ProcessId) -> Self {
+        ReadWriteProcessBuffer {
+            ptr,
+            len,
+            process_id: Some(process_id),
+        }
+    }
+
+    /// Construct a new [`ReadWriteProcessBuffer`] over a given
+    /// pointer and length.
+    ///
+    /// Publicly accessible constructor, which requires the
+    /// [`capabilities::ExternalProcessCapability`] capability. This
+    /// is provided to allow implementations of the
+    /// [`Process`](crate::process::Process) trait outside of the
+    /// `kernel` crate.
+    ///
+    /// # Safety requirements
+    ///
+    /// If the length is `0`, an arbitrary pointer may be passed into
+    /// `ptr`. It does not necessarily have to point to allocated
+    /// memory, nor does it have to meet [Rust's pointer validity
+    /// requirements](https://doc.rust-lang.org/core/ptr/index.html#safety).
+    /// [`ReadWriteProcessBuffer`] must ensure that all Rust slices
+    /// with a length of `0` must be constructed over a valid (but not
+    /// necessarily allocated) base pointer.
+    ///
+    /// If the length is not `0`, the memory region of `[ptr; ptr +
+    /// len)` must be valid memory of the process of the given
+    /// [`ProcessId`]. It must be allocated and and accessible over
+    /// the entire lifetime of the [`ReadWriteProcessBuffer`]. It must
+    /// not point to memory outside of the process' accessible memory
+    /// range, or point (in part) to other processes or kernel
+    /// memory. The `ptr` must meet [Rust's requirements for pointer
+    /// validity](https://doc.rust-lang.org/core/ptr/index.html#safety),
+    /// in particular it must have a minimum alignment of
+    /// `core::mem::align_of::<u8>()` on the respective platform. It
+    /// must point to memory mapped as _readable_ and optionally
+    /// _writable_ and _executable_.
+    pub unsafe fn new_external(
+        ptr: *mut u8,
+        len: usize,
+        process_id: ProcessId,
+        _cap: &dyn capabilities::ExternalProcessCapability,
+    ) -> Self {
+        Self::new(ptr, len, process_id)
+    }
+
+    /// Consumes the ReadWriteProcessBuffer, returning its constituent
+    /// pointer and size. This ensures that there cannot
+    /// simultaneously be both a `ReadWriteProcessBuffer` and a pointer to
+    /// its internal data.
+    ///
+    /// `consume` can be used when the kernel needs to pass the
+    /// underlying values across the kernel-to-user boundary (e.g., in
+    /// return values to system calls).
+    pub(crate) fn consume(self) -> (*mut u8, usize) {
+        (self.ptr, self.len)
+    }
+
+    /// This is a `const` version of `Default::default` with the same
+    /// semantics.
+    ///
+    /// Having a const initializer allows initializing a fixed-size
+    /// array with default values without the struct being marked
+    /// `Copy` as such:
+    ///
+    /// ```
+    /// use kernel::ReadWriteProcessBuffer;
+    /// const DEFAULT_RWPROCBUF_VAL: ReadWriteProcessBuffer
+    ///     = ReadWriteProcessBuffer::const_default();
+    /// let my_array = [DEFAULT_RWPROCBUF_VAL; 12];
+    /// ```
+    pub const fn const_default() -> Self {
+        Self {
+            ptr: 0x0 as *mut u8,
+            len: 0,
+            process_id: None,
+        }
+    }
+}
+
+impl ReadableProcessBuffer for ReadWriteProcessBuffer {
+    fn len(&self) -> usize {
+        self.process_id
+            .map_or(0, |pid| pid.kernel.process_map_or(0, pid, |_| self.len))
+    }
+
+    fn ptr(&self) -> *const u8 {
+        if self.len == 0 {
+            0x0 as *const u8
+        } else {
+            self.ptr
+        }
+    }
+
+    fn enter<F, R>(&self, fun: F) -> Result<R, process::Error>
+    where
+        F: FnOnce(&ReadableProcessSlice) -> R,
+    {
+        match self.process_id {
+            None => Err(process::Error::NoSuchApp),
+            Some(pid) => pid
+                .kernel
+                .process_map_or(Err(process::Error::NoSuchApp), pid, |_| {
+                    // Safety: `kernel.process_map_or()` validates that
+                    // the process still exists and its memory is still
+                    // valid. In particular, `Process` tracks the "high water
+                    // mark" of memory that the process has `allow`ed to the
+                    // kernel. Because `Process` does not feature an API to
+                    // move the "high water mark" down again, which would be
+                    // called once a `ProcessBuffer` has been passed back into
+                    // the kernel, a given `Process` implementation must assume
+                    // that the memory described by a once-allowed
+                    // `ProcessBuffer` is still in use, and thus will not
+                    // permit the process to free any memory after it has
+                    // been `allow`ed to the kernel once. This guarantees
+                    // that the buffer is safe to convert into a slice
+                    // here. For more information, refer to the
+                    // comment and subsequent discussion on tock/tock#2632:
+                    // https://github.com/tock/tock/pull/2632#issuecomment-869974365
+                    Ok(fun(unsafe {
+                        raw_processbuf_to_roprocessslice(self.ptr, self.len)
+                    }))
+                }),
+        }
+    }
+}
+
+impl WriteableProcessBuffer for ReadWriteProcessBuffer {
+    fn mut_enter<F, R>(&self, fun: F) -> Result<R, process::Error>
+    where
+        F: FnOnce(&WriteableProcessSlice) -> R,
+    {
+        match self.process_id {
+            None => Err(process::Error::NoSuchApp),
+            Some(pid) => pid
+                .kernel
+                .process_map_or(Err(process::Error::NoSuchApp), pid, |_| {
+                    // Safety: `kernel.process_map_or()` validates that
+                    // the process still exists and its memory is still
+                    // valid. In particular, `Process` tracks the "high water
+                    // mark" of memory that the process has `allow`ed to the
+                    // kernel. Because `Process` does not feature an API to
+                    // move the "high water mark" down again, which would be
+                    // called once a `ProcessBuffer` has been passed back into
+                    // the kernel, a given `Process` implementation must assume
+                    // that the memory described by a once-allowed
+                    // `ProcessBuffer` is still in use, and thus will not
+                    // permit the process to free any memory after it has
+                    // been `allow`ed to the kernel once. This guarantees
+                    // that the buffer is safe to convert into a slice
+                    // here. For more information, refer to the
+                    // comment and subsequent discussion on tock/tock#2632:
+                    // https://github.com/tock/tock/pull/2632#issuecomment-869974365
+                    Ok(fun(unsafe {
+                        raw_processbuf_to_rwprocessslice(self.ptr, self.len)
+                    }))
+                }),
+        }
+    }
+}
+
+impl Default for ReadWriteProcessBuffer {
+    fn default() -> Self {
+        Self::const_default()
+    }
+}
+
+/// Read-only wrapper around a [`Cell`]
+///
+/// This type is used in providing the [`ReadableProcessSlice`]. The
+/// memory over which a [`ReadableProcessSlice`] exists must never be
+/// written to by the kernel. However, it may either exist in flash
+/// (read-only memory) or RAM (read-writeable memory). Consequently, a
+/// process may `allow` memory overlapping with a
+/// [`ReadOnlyProcessBuffer`] also simultaneously through a
+/// [`ReadWriteProcessBuffer`]. Hence, the kernel can have two
+/// references to the same memory, where one can lead to mutation of
+/// the memory contents. Therefore, the kernel must use [`Cell`]s
+/// around the bytes shared with userspace, to avoid violating Rust's
+/// aliasing rules.
+///
+/// This read-only wrapper around a [`Cell`] only exposes methods
+/// which are safe to call on a process-shared read-only `allow`
+/// memory.
+#[repr(transparent)]
+pub struct ReadableProcessByte {
+    cell: Cell<u8>,
+}
+
+impl ReadableProcessByte {
+    #[inline]
+    pub fn get(&self) -> u8 {
+        self.cell.get()
+    }
+}
+
+/// Readable and accessible slice of memory of a process buffer
+///
+///
+/// The only way to obtain this struct is through a
+/// [`ReadWriteProcessBuffer`] or [`ReadOnlyProcessBuffer`].
+///
+/// Slices provide a more convenient, traditional interface to process
+/// memory. These slices are transient, as the underlying buffer must
+/// be checked each time a slice is created. This is usually enforced
+/// by the anonymous lifetime defined by the creation of the slice.
+#[repr(transparent)]
+pub struct ReadableProcessSlice {
+    slice: [ReadableProcessByte],
+}
+
+impl ReadableProcessSlice {
+    /// Copy the contents of a [`ReadableProcessSlice`] into a mutable
+    /// slice reference.
+    ///
+    /// The length of `self` must be the same as `dest`. Subslicing
+    /// can be used to obtain a slice of matching length.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if `self.len() != dest.len()`.
+    pub fn copy_to_slice(&self, dest: &mut [u8]) {
+        // Method implemetation adopted from the
+        // core::slice::copy_from_slice method implementation:
+        // https://doc.rust-lang.org/src/core/slice/mod.rs.html#3034-3036
+
+        // The panic code path was put into a cold function to not
+        // bloat the call site.
+        #[inline(never)]
+        #[cold]
+        #[track_caller]
+        fn len_mismatch_fail(dst_len: usize, src_len: usize) -> ! {
+            panic!(
+                "source slice length ({}) does not match destination slice length ({})",
+                src_len, dst_len,
+            );
+        }
+
+        if self.len() != dest.len() {
+            len_mismatch_fail(dest.len(), self.len());
+        }
+
+        // _If_ this turns out to not be efficiently optimized, it
+        // should be possible to use a ptr::copy_nonoverlapping here
+        // given we have exclusive mutable access to the destination
+        // slice which will never be in process memory, and the layout
+        // of &[ReadableProcessByte] is guaranteed to be compatible to
+        // &[u8].
+        for (i, b) in self.slice.iter().enumerate() {
+            dest[i] = b.get();
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.slice.len()
+    }
+
+    pub fn iter(&self) -> core::slice::Iter<'_, ReadableProcessByte> {
+        self.slice.iter()
+    }
+
+    pub fn chunks(&self, chunk_size: usize) -> core::slice::Chunks<'_, ReadableProcessByte> {
+        self.slice.chunks(chunk_size)
+    }
+}
+
+impl Index<Range<usize>> for ReadableProcessSlice {
+    // Subslicing will still yield a ReadableProcessSlice reference
+    type Output = Self;
+
+    fn index(&self, idx: Range<usize>) -> &Self::Output {
+        // As ReadableProcessSlice is a transparent wrapper around
+        // its inner type, [ReadableProcessByte], we can use the
+        // regular slicing operator here with its usual
+        // semantics. However, we need to use mem::transmute to
+        // convert it back from a [ReadableProcessByte] to a
+        // ReadableProcessSlice.
+        unsafe {
+            core::mem::transmute::<&[ReadableProcessByte], &ReadableProcessSlice>(&self.slice[idx])
+        }
+    }
+}
+
+impl Index<RangeTo<usize>> for ReadableProcessSlice {
+    // Subslicing will still yield a ReadableProcessSlice reference
+    type Output = Self;
+
+    fn index(&self, idx: RangeTo<usize>) -> &Self::Output {
+        &self[0..idx.end]
+    }
+}
+
+impl Index<RangeFrom<usize>> for ReadableProcessSlice {
+    // Subslicing will still yield a ReadableProcessSlice reference
+    type Output = Self;
+
+    fn index(&self, idx: RangeFrom<usize>) -> &Self::Output {
+        &self[idx.start..self.len()]
+    }
+}
+
+impl Index<usize> for ReadableProcessSlice {
+    // Indexing into a ReadableProcessSlice must yield a
+    // ReadableProcessByte, to limit the API surface of the wrapped
+    // Cell to read-only operations
+    type Output = ReadableProcessByte;
+
+    fn index(&self, idx: usize) -> &Self::Output {
+        // As ReadableProcessSlice is a transparent wrapper around its
+        // inner type, [ReadableProcessByte], we can use the regular
+        // slicing operator here with its usual semantics.
+        &self.slice[idx]
+    }
+}
+
+/// Read-writeable and accessible slice of memory of a process buffer
+///
+/// The only way to obtain this struct is through a
+/// [`ReadWriteProcessBuffer`].
+///
+/// Slices provide a more convenient, traditional interface to process
+/// memory. These slices are transient, as the underlying buffer must
+/// be checked each time a slice is created. This is usually enforced
+/// by the anonymous lifetime defined by the creation of the slice.
+#[repr(transparent)]
+pub struct WriteableProcessSlice {
+    slice: [Cell<u8>],
+}
+
+impl WriteableProcessSlice {
+    /// Copy the contents of a [`WriteableProcessSlice`] into a mutable
+    /// slice reference.
+    ///
+    /// The length of `self` must be the same as `dest`. Subslicing
+    /// can be used to obtain a slice of matching length.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if `self.len() != dest.len()`.
+    pub fn copy_to_slice(&self, dest: &mut [u8]) {
+        // Method implemetation adopted from the
+        // core::slice::copy_from_slice method implementation:
+        // https://doc.rust-lang.org/src/core/slice/mod.rs.html#3034-3036
+
+        // The panic code path was put into a cold function to not
+        // bloat the call site.
+        #[inline(never)]
+        #[cold]
+        #[track_caller]
+        fn len_mismatch_fail(dst_len: usize, src_len: usize) -> ! {
+            panic!(
+                "source slice length ({}) does not match destination slice length ({})",
+                src_len, dst_len,
+            );
+        }
+
+        if self.len() != dest.len() {
+            len_mismatch_fail(dest.len(), self.len());
+        }
+
+        // _If_ this turns out to not be efficiently optimized, it
+        // should be possible to use a ptr::copy_nonoverlapping here
+        // given we have exclusive mutable access to the destination
+        // slice which will never be in process memory, and the layout
+        // of &[Cell<u8>] is guaranteed to be compatible to &[u8].
+        self.slice
+            .iter()
+            .zip(dest.iter_mut())
+            .for_each(|(src, dst)| *dst = src.get());
+    }
+
+    /// Copy the contents of a slice of bytes into a [`WriteableProcessSlice`].
+    ///
+    /// The length of `src` must be the same as `self`. Subslicing can
+    /// be used to obtain a slice of matching length.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if `src.len() != self.len()`.
+    pub fn copy_from_slice(&self, src: &[u8]) {
+        // Method implemetation adopted from the
+        // core::slice::copy_from_slice method implementation:
+        // https://doc.rust-lang.org/src/core/slice/mod.rs.html#3034-3036
+
+        // The panic code path was put into a cold function to not
+        // bloat the call site.
+        #[inline(never)]
+        #[cold]
+        #[track_caller]
+        fn len_mismatch_fail(dst_len: usize, src_len: usize) -> ! {
+            panic!(
+                "source slice length ({}) does not match destination slice length ({})",
+                src_len, dst_len,
+            );
+        }
+
+        if self.len() != src.len() {
+            len_mismatch_fail(self.len(), src.len());
+        }
+
+        // _If_ this turns out to not be efficiently optimized, it
+        // should be possible to use a ptr::copy_nonoverlapping here
+        // given we have exclusive mutable access to the destination
+        // slice which will never be in process memory, and the layout
+        // of &[Cell<u8>] is guaranteed to be compatible to &[u8].
+        src.iter()
+            .zip(self.slice.iter())
+            .for_each(|(src, dst)| dst.set(*src));
+    }
+
+    pub fn len(&self) -> usize {
+        self.slice.len()
+    }
+
+    pub fn iter(&self) -> core::slice::Iter<'_, Cell<u8>> {
+        self.slice.iter()
+    }
+
+    pub fn chunks(&self, chunk_size: usize) -> core::slice::Chunks<'_, Cell<u8>> {
+        self.slice.chunks(chunk_size)
+    }
+}
+
+impl Index<Range<usize>> for WriteableProcessSlice {
+    // Subslicing will still yield a WriteableProcessSlice reference
+    type Output = Self;
+
+    fn index(&self, idx: Range<usize>) -> &Self::Output {
+        // As WriteableProcessSlice is a transparent wrapper around
+        // its inner type, [Cell<u8>], we can use the regular slicing
+        // operator here with its usual semantics. However, we need to
+        // use mem::transmute to convert it back from a [Cell<u8>] to
+        // a WriteableProcessSlice.
+        unsafe { core::mem::transmute::<&[Cell<u8>], &WriteableProcessSlice>(&self.slice[idx]) }
+    }
+}
+
+impl Index<RangeTo<usize>> for WriteableProcessSlice {
+    // Subslicing will still yield a WriteableProcessSlice reference
+    type Output = Self;
+
+    fn index(&self, idx: RangeTo<usize>) -> &Self::Output {
+        &self[0..idx.end]
+    }
+}
+
+impl Index<RangeFrom<usize>> for WriteableProcessSlice {
+    // Subslicing will still yield a WriteableProcessSlice reference
+    type Output = Self;
+
+    fn index(&self, idx: RangeFrom<usize>) -> &Self::Output {
+        &self[idx.start..self.len()]
+    }
+}
+
+impl Index<usize> for WriteableProcessSlice {
+    // Indexing into a WriteableProcessSlice yields a Cell<u8>, as
+    // mutating the memory contents is allowed
+    type Output = Cell<u8>;
+
+    fn index(&self, idx: usize) -> &Self::Output {
+        // As WriteableProcessSlice is a transparent wrapper around
+        // its inner type, [Cell<u8>], we can use the regular slicing
+        // operator here with its usual semantics.
+        &self.slice[idx]
     }
 }

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -9,7 +9,7 @@ use core::str;
 use crate::capabilities;
 use crate::errorcode::ErrorCode;
 use crate::ipc;
-use crate::mem::{ReadOnlyAppSlice, ReadWriteAppSlice};
+use crate::mem::{ReadOnlyProcessBuffer, ReadWriteProcessBuffer};
 use crate::platform::mpu::{self};
 use crate::sched::Kernel;
 use crate::syscall::{self, Syscall, SyscallReturn};
@@ -317,13 +317,13 @@ pub trait Process {
     /// process memory brk.
     fn app_memory_break(&self) -> *const u8;
 
-    /// Creates a `ReadWriteAppSlice` from the given offset and size
-    /// in process memory.
+    /// Creates a [`ReadWriteProcessBuffer`] from the given offset and
+    /// size in process memory.
     ///
     /// ## Returns
     ///
     /// In case of success, this method returns the created
-    /// [`ReadWriteAppSlice`].
+    /// [`ReadWriteProcessBuffer`].
     ///
     /// In case of an error, an appropriate ErrorCode is returned:
     ///
@@ -333,19 +333,19 @@ pub trait Process {
     ///   accessible to the process), [`ErrorCode::INVAL`]
     /// - if the process is not active: [`ErrorCode::FAIL`]
     /// - for all other errors: [`ErrorCode::FAIL`]
-    fn build_readwrite_appslice(
+    fn build_readwrite_process_buffer(
         &self,
         buf_start_addr: *mut u8,
         size: usize,
-    ) -> Result<ReadWriteAppSlice, ErrorCode>;
+    ) -> Result<ReadWriteProcessBuffer, ErrorCode>;
 
-    /// Creates a [`ReadOnlyAppSlice`] from the given offset and size
-    /// in process memory.
+    /// Creates a [`ReadOnlyProcessBuffer`] from the given offset and
+    /// size in process memory.
     ///
     /// ## Returns
     ///
     /// In case of success, this method returns the created
-    /// [`ReadOnlyAppSlice`].
+    /// [`ReadOnlyProcessBuffer`].
     ///
     /// In case of an error, an appropriate ErrorCode is returned:
     ///
@@ -355,11 +355,11 @@ pub trait Process {
     ///   read-accessible to the process), [`ErrorCode::INVAL`]
     /// - if the process is not active: [`ErrorCode::FAIL`]
     /// - for all other errors: [`ErrorCode::FAIL`]
-    fn build_readonly_appslice(
+    fn build_readonly_process_buffer(
         &self,
         buf_start_addr: *const u8,
         size: usize,
-    ) -> Result<ReadOnlyAppSlice, ErrorCode>;
+    ) -> Result<ReadOnlyProcessBuffer, ErrorCode>;
 
     /// Set a single byte within the process address space at
     /// `addr` to `value`. Return true if `addr` is within the RAM

--- a/kernel/src/process_utilities.rs
+++ b/kernel/src/process_utilities.rs
@@ -113,7 +113,7 @@ impl fmt::Debug for ProcessLoadError {
 /// allocated number of processes are created. This buffer is a non-static slice,
 /// ensuring that this code cannot hold onto the slice past the end of this function
 /// (instead, processes store a pointer and length), which necessary for later
-/// creation of `AppSlice`'s in this memory region to be sound.
+/// creation of `ProcessBuffer`s in this memory region to be sound.
 /// A reference to each process is stored in the provided `procs` array.
 /// How process faults are handled by the
 /// kernel must be provided and is assigned to every created process.

--- a/kernel/src/syscall.rs
+++ b/kernel/src/syscall.rs
@@ -221,9 +221,10 @@ pub enum SyscallReturnVariant {
 /// [`encode_syscall_return`](SyscallReturn::encode_syscall_return)
 /// method.
 ///
-/// Capsules do not use this struct. Capsules use higher level Rust types
-/// (e.g. [`ReadWriteAppSlice`](crate::ReadWriteAppSlice) and
-/// `UpcallMemory`) or wrappers around this struct
+/// Capsules do not use this struct. Capsules use higher level Rust
+/// types
+/// (e.g. [`ReadWriteProcessBuffer`](crate::ReadWriteProcessBuffer)
+/// and `GrantUpcallTable`) or wrappers around this struct
 /// ([`CommandReturn`](crate::CommandReturn)) which limit the
 /// available constructors to safely constructable variants.
 #[derive(Copy, Clone, Debug)]
@@ -253,14 +254,13 @@ pub enum SyscallReturn {
     // These following types are used by the scheduler so that it can
     // return values to userspace in an architecture (pointer-width)
     // independent way. The kernel passes these types (rather than
-    // AppSlice or Upcall) for two reasons. First, since the
+    // ProcessBuffer or Upcall) for two reasons. First, since the
     // kernel/scheduler makes promises about the lifetime and safety
-    // of these types (e.g., an accepted allow does not overlap with
-    // an existing accepted AppSlice), it does not want to leak them
-    // to other code. Second, if subscribe or allow calls pass invalid
-    // values (pointers out of valid memory), the kernel cannot
-    // construct an AppSlice or Upcall type but needs to be able to
-    // return a failure. -pal 11/24/20
+    // of these types, it does not want to leak them to other
+    // code. Second, if subscribe or allow calls pass invalid values
+    // (pointers out of valid memory), the kernel cannot construct an
+    // ProcessBuffer or Upcall type but needs to be able to return a
+    // failure. -pal 11/24/20
     /// Read/Write allow success case, returns the previous allowed
     /// buffer and size to the process.
     AllowReadWriteSuccess(*mut u8, usize),


### PR DESCRIPTION
### Pull Request Overview

As of 8f66d98 ("Merge #2617"), it is explicitly permitted for Tock applications to _Allow_ overlapping memory regions to multiple Allow slots in both the same and different capsules simultaneously. This has the implication of making the current interface for accessing process memory (`AppSlice`) unsound.

This commit rewrites the interface for interacting with process memory, such that it is valid for the kernel to have multiple process buffers which can be both writeable and overlapping. This is achieved by developing an interface around `&[Cell<u8>]` (slice of Cells), which does permit interior mutability due to the usage of `UnsafeCell<u8>`.

It further adapts a consistent naming scheme:

- App -> Process, as potentially multiple processes of the same application can run simultaneously.

- AppSlice -> ProcessBuffer, as this is not really a slice, but rather represents a bounded memory region (buffer) within some process memory.

- introduction of new `ProcessSlice`s, which are `#[repr(transparent)]` wrappers around slices of Cells, providing convenient APIs and, in the case of read-only Allowed memory, limiting to read-only accesses.

- introduction of a `ReadableProcessByte`, which is a `#[repr(transparent)]` wrapper around a `Cell<u8>`, limiting to read-only accesses.

In general, this manages to provide a convenient interface for accessing userspace memory, while not directly operating on Rust slices of `u8`s with their inherent aliasing restrictions.

However, the `ProcessSlices` obtained are incompatible with regular Rust slices, which sometimes makes copying over an intermediate buffer necessary.

Usually, Rust slices only feature a `copy_from_slice` method, taking a mutable `&mut self` reference. However, given that a Rust slice cannot copy from a `ProcessSlice`, these feature an inverse method `copy_to_slice`, which can write the contents to a regular Rust slice.

### Testing Strategy

This pull request was tested by compiling. It needs more testing.


### TODO or Help Wanted

This pull request is a work on progress. Feedback in general, and especially regarding `mem.rs`'s contents is very welcome!

In particular, the CRC capsule is rather hard to port to this interface. This is because the HIL in it's current form is unsound if a DMA / asynchronous hardware is used, as it takes a slice reference with an anonymous lifetime. It will need to be fixed in a separate PR, as a precondition to merging this.

### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
