### PR TITLE
Redesign CRC HIL & fix SAM4L implementation

### DIFF
--- a/boards/components/src/crc.rs
+++ b/boards/components/src/crc.rs
@@ -1,17 +1,18 @@
-//! Component for CRC syscall interface.
+//! Component for Crc syscall interface.
 //!
 //! This provides one Component, `CrcComponent`, which implements a
-//! userspace syscall interface to the CRC peripheral.
+//! userspace syscall interface to the Crc peripheral.
 //!
 //! Usage
 //! -----
 //! ```rust
-//! let crc = components::crc::CrcComponent::new(board_kernel, &sam4l::crccu::CRCCU)
+//! let crc = components::crc::CrcComponent::new(board_kernel, &sam4l::crccu::CrcCU)
 //!     .finalize(components::crc_component_helper!(sam4l::crccu::Crccu));
 //! ```
 
 // Author: Philip Levis <pal@cs.stanford.edu>
-// Last modified: 6/20/2018
+// Author: Leon Schuermann  <leon@is.currently.online>
+// Last modified: 6/2/2021
 
 use core::mem::MaybeUninit;
 
@@ -19,8 +20,8 @@ use capsules::crc;
 use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
-use kernel::hil;
-use kernel::static_init_half;
+use kernel::hil::crc::Crc;
+use kernel::{static_init, static_init_half};
 
 // Setup static space for the objects.
 #[macro_export]
@@ -28,18 +29,18 @@ macro_rules! crc_component_helper {
     ($C:ty $(,)?) => {{
         use capsules::crc;
         use core::mem::MaybeUninit;
-        static mut BUF: MaybeUninit<crc::Crc<'static, $C>> = MaybeUninit::uninit();
+        static mut BUF: MaybeUninit<crc::CrcDriver<'static, $C>> = MaybeUninit::uninit();
         &mut BUF
     };};
 }
 
-pub struct CrcComponent<C: 'static + hil::crc::CRC<'static>> {
+pub struct CrcComponent<C: 'static + Crc<'static>> {
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
     crc: &'static C,
 }
 
-impl<C: 'static + hil::crc::CRC<'static>> CrcComponent<C> {
+impl<C: 'static + Crc<'static>> CrcComponent<C> {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
         driver_num: usize,
@@ -53,18 +54,23 @@ impl<C: 'static + hil::crc::CRC<'static>> CrcComponent<C> {
     }
 }
 
-impl<C: 'static + hil::crc::CRC<'static>> Component for CrcComponent<C> {
-    type StaticInput = &'static mut MaybeUninit<crc::Crc<'static, C>>;
-    type Output = &'static crc::Crc<'static, C>;
+impl<C: 'static + Crc<'static>> Component for CrcComponent<C> {
+    type StaticInput = &'static mut MaybeUninit<crc::CrcDriver<'static, C>>;
+    type Output = &'static crc::CrcDriver<'static, C>;
 
     unsafe fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
         let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
+        let crc_buf = static_init!(
+            [u8; crc::DEFAULT_CRC_BUF_LENGTH],
+            [0; crc::DEFAULT_CRC_BUF_LENGTH]
+        );
 
         let crc = static_init_half!(
             static_buffer,
-            crc::Crc<'static, C>,
-            crc::Crc::new(
+            crc::CrcDriver<'static, C>,
+            crc::CrcDriver::new(
                 self.crc,
+                crc_buf,
                 self.board_kernel.create_grant(self.driver_num, &grant_cap)
             )
         );

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -71,7 +71,7 @@ struct Hail {
     button: &'static capsules::button::Button<'static, sam4l::gpio::GPIOPin<'static>>,
     rng: &'static capsules::rng::RngDriver<'static>,
     ipc: kernel::ipc::IPC<NUM_PROCS, NUM_UPCALLS_IPC>,
-    crc: &'static capsules::crc::Crc<'static, sam4l::crccu::Crccu<'static>>,
+    crc: &'static capsules::crc::CrcDriver<'static, sam4l::crccu::Crccu<'static>>,
     dac: &'static capsules::dac::Dac<'static>,
 }
 

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -130,7 +130,7 @@ struct Imix {
     ipc: kernel::ipc::IPC<NUM_PROCS, NUM_UPCALLS_IPC>,
     ninedof: &'static capsules::ninedof::NineDof<'static>,
     udp_driver: &'static capsules::net::udp::UDPDriver<'static>,
-    crc: &'static capsules::crc::Crc<'static, sam4l::crccu::Crccu<'static>>,
+    crc: &'static capsules::crc::CrcDriver<'static, sam4l::crccu::Crccu<'static>>,
     usb_driver: &'static capsules::usb::usb_user::UsbSyscallDriver<
         'static,
         capsules::usb::usbc_client::Client<'static, sam4l::usbc::Usbc<'static>>,

--- a/boards/imix/src/test/crc_test.rs
+++ b/boards/imix/src/test/crc_test.rs
@@ -1,0 +1,39 @@
+//! Test that CRC is working properly.
+//!
+//! To test, add the following line to the imix boot sequence:
+//! ```
+//!     test::crc_test::run_crc();
+//! ```
+//! You should see the following output:
+//! ```
+//!     CRC32: 0xcbf43926
+//!     CRC32C: 0xe3069283
+//!     CRC16CITT: 0x89f6
+//!
+//! ```
+//!
+//! These results are for computing the CRC over the string
+//! "123456789" (not including the quotes). The result values were
+//! taken from
+//! <https://reveng.sourceforge.io/crc-catalogue/17plus.htm>
+
+use capsules::test::crc::TestCrc;
+use kernel::hil::crc::Crc;
+use kernel::static_init;
+use sam4l::crccu::Crccu;
+
+pub unsafe fn run_crc(crc: &'static Crccu) {
+    let t = static_init_crc(crc);
+    crc.set_client(t);
+
+    t.run();
+}
+
+unsafe fn static_init_crc(crc: &'static Crccu) -> &'static TestCrc<'static, Crccu<'static>> {
+    let data = static_init!([u8; 9], [0; 9]);
+
+    for i in 0..9 {
+        data[i] = i as u8 + ('1' as u8);
+    }
+    static_init!(TestCrc<'static, Crccu>, TestCrc::new(&crc, data))
+}

--- a/boards/imix/src/test/mod.rs
+++ b/boards/imix/src/test/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod aes_test;
+pub(crate) mod crc_test;
 pub(crate) mod i2c_dummy;
 pub(crate) mod icmp_lowpan_test;
 pub(crate) mod ipv6_lowpan_test;

--- a/capsules/src/crc.rs
+++ b/capsules/src/crc.rs
@@ -1,25 +1,32 @@
-//! Provides userspace access to a CRC unit.
+//! Provides userspace access to a Crc unit.
 //!
 //! ## Instantiation
 //!
 //! Instantiate the capsule for use as a system call driver with a hardware
 //! implementation and a `Grant` for the `App` type, and set the result as a
-//! client of the hardware implementation. For example, using the SAM4L's `CRCU`
+//! client of the hardware implementation. For example, using the SAM4L's `CrcU`
 //! driver:
 //!
 //! ```rust
 //! # use kernel::static_init;
 //!
+//! let crc_buffer = static_init!([u8; 64], [0; 64]);
+//!
 //! let crc = static_init!(
-//!     capsules::crc::Crc<'static, sam4l::crccu::Crccu<'static>>,
-//!     capsules::crc::Crc::new(&mut sam4l::crccu::CRCCU, board_kernel.create_grant(&grant_cap)));
+//!     capsules::crc::CrcDriver<'static, sam4l::crccu::Crccu<'static>>,
+//!     capsules::crc::CrcDriver::new(
+//!         &mut sam4l::crccu::CRCCU,
+//!         crc_buffer,
+//!         board_kernel.create_grant(&grant_cap)
+//!      )
+//! );
 //! sam4l::crccu::CRCCU.set_client(crc);
 //!
 //! ```
 //!
-//! ## CRC Algorithms
+//! ## Crc Algorithms
 //!
-//! The capsule supports two general purpose CRC algorithms, as well as a few
+//! The capsule supports two general purpose Crc algorithms, as well as a few
 //! hardware specific algorithms implemented on the Atmel SAM4L.
 //!
 //! In the values used to identify polynomials below, more-significant bits
@@ -27,26 +34,26 @@
 //! because it always equals one.  All algorithms listed here consume each input
 //! byte from most-significant bit to least-significant.
 //!
-//! ### CRC-32
+//! ### Crc-32
 //!
 //! __Polynomial__: `0x04C11DB7`
 //!
 //! This algorithm is used in Ethernet and many other applications. It bit-
 //! reverses and then bit-inverts the output.
 //!
-//! ### CRC-32C
+//! ### Crc-32C
 //!
 //! __Polynomial__: `0x1EDC6F41`
 //!
 //! Bit-reverses and then bit-inverts the output. It *may* be equivalent to
-//! various CRC functions using the same name.
+//! various Crc functions using the same name.
 //!
 //! ### SAM4L-16
 //!
 //! __Polynomial__: `0x1021`
 //!
 //! This algorithm does no post-processing on the output value. The sixteen-bit
-//! CRC result is placed in the low-order bits of the returned result value, and
+//! Crc result is placed in the low-order bits of the returned result value, and
 //! the high-order bits will all be set.  That is, result values will always be
 //! of the form `0xFFFFxxxx` for this algorithm.  It can be performed purely in
 //! hardware on the SAM4L.
@@ -55,7 +62,7 @@
 //!
 //! __Polynomial__: `0x04C11DB7`
 //!
-//! This algorithm uses the same polynomial as `CRC-32`, but does no post-
+//! This algorithm uses the same polynomial as `Crc-32`, but does no post-
 //! processing on the output value.  It can be perfomed purely in hardware on
 //! the SAM4L.
 //!
@@ -63,43 +70,49 @@
 //!
 //! __Polynomial__: `0x1EDC6F41`
 //!
-//! This algorithm uses the same polynomial as `CRC-32C`, but does no post-
+//! This algorithm uses the same polynomial as `Crc-32C`, but does no post-
 //! processing on the output value.  It can be performed purely in hardware on
 //! the SAM4L.
 
-use core::mem;
-use kernel::common::cells::OptionalCell;
-use kernel::hil;
-use kernel::hil::crc::CrcAlg;
+use core::cell::Cell;
+use core::{cmp, mem};
+use kernel;
+use kernel::common::cells::NumericCellExt;
+use kernel::common::cells::{OptionalCell, TakeCell};
+use kernel::common::leasable_buffer::LeasableBuffer;
+use kernel::hil::crc::{Client, Crc, CrcAlgorithm, CrcOutput};
 use kernel::{CommandReturn, Driver, ErrorCode, Grant, ProcessId};
 use kernel::{Read, ReadOnlyAppSlice};
 
 /// Syscall driver number.
 use crate::driver;
 pub const DRIVER_NUM: usize = driver::NUM::Crc as usize;
+pub const DEFAULT_CRC_BUF_LENGTH: usize = 256;
 
 /// An opaque value maintaining state for one application's request
 #[derive(Default)]
 pub struct App {
     buffer: ReadOnlyAppSlice,
-
-    // if Some, the application is awaiting the result of a CRC
-    //   using the given algorithm
-    waiting: Option<hil::crc::CrcAlg>,
+    // if Some, the process is waiting for the result of CRC
+    // of len bytes using the given algorithm
+    request: Option<(CrcAlgorithm, usize)>,
 }
 
-/// Struct that holds the state of the CRC driver and implements the `Driver` trait for use by
+/// Struct that holds the state of the Crc driver and implements the `Driver` trait for use by
 /// processes through the system call interface.
-pub struct Crc<'a, C: hil::crc::CRC<'a>> {
-    crc_unit: &'a C,
-    apps: Grant<App, 1>,
-    serving_app: OptionalCell<ProcessId>,
+pub struct CrcDriver<'a, C: Crc<'a>> {
+    crc: &'a C,
+    crc_buffer: TakeCell<'static, [u8]>,
+    grant: Grant<App, 1>,
+    current_process: OptionalCell<ProcessId>,
+    // We need to save our current
+    app_buffer_written: Cell<usize>,
 }
 
-impl<'a, C: hil::crc::CRC<'a>> Crc<'a, C> {
+impl<'a, C: Crc<'a>> CrcDriver<'a, C> {
     /// Create a `Crc` driver
     ///
-    /// The argument `crc_unit` must implement the abstract `CRC`
+    /// The argument `crc_unit` must implement the abstract `Crc`
     /// hardware interface.  The argument `apps` should be an empty
     /// kernel `Grant`, and will be used to track application
     /// requests.
@@ -107,80 +120,130 @@ impl<'a, C: hil::crc::CRC<'a>> Crc<'a, C> {
     /// ## Example
     ///
     /// ```rust
-    /// capsules::crc::Crc::new(&sam4l::crccu::CRCCU, board_kernel.create_grant(&grant_cap));
+    /// capsules::crc::Crc::new(&sam4l::crccu::CrcCU, board_kernel.create_grant(&grant_cap));
     /// ```
     ///
-    pub fn new(crc_unit: &'a C, apps: Grant<App, 1>) -> Crc<'a, C> {
-        Crc {
-            crc_unit: crc_unit,
-            apps: apps,
-            serving_app: OptionalCell::empty(),
+    pub fn new(
+        crc: &'a C,
+        crc_buffer: &'static mut [u8],
+        grant: Grant<App, 1>,
+    ) -> CrcDriver<'a, C> {
+        CrcDriver {
+            crc,
+            crc_buffer: TakeCell::new(crc_buffer),
+            grant,
+            current_process: OptionalCell::empty(),
+            app_buffer_written: Cell::new(0),
         }
     }
 
-    fn serve_waiting_apps(&self) {
-        if self.serving_app.is_some() {
-            // A computation is in progress
-            return;
-        }
+    fn do_next_input(&self, data: &[u8], len: usize) -> usize {
+        let count = self.crc_buffer.take().map_or(0, |kbuffer| {
+            let copy_len = cmp::min(len, kbuffer.len());
+            for i in 0..copy_len {
+                kbuffer[i] = data[i];
+            }
+            if copy_len > 0 {
+                let mut leasable = LeasableBuffer::new(kbuffer);
+                leasable.slice(0..copy_len);
+                let res = self.crc.input(leasable);
+                match res {
+                    Ok(()) => copy_len,
+                    Err((_err, leasable)) => {
+                        self.crc_buffer.put(Some(leasable.take()));
+                        0
+                    }
+                }
+            } else {
+                0
+            }
+        });
+        count
+    }
 
-        // Find a waiting app and start its requested computation
-        let mut found = false;
-        for app in self.apps.iter() {
-            let appid = app.processid();
-            app.enter(|app, upcalls| {
-                if let Some(alg) = app.waiting {
-                    let rcode = app
-                        .buffer
-                        .map_or(Err(ErrorCode::NOMEM), |buf| self.crc_unit.compute(buf, alg));
-
-                    if rcode == Ok(()) {
-                        // The unit is now computing a CRC for this app
-                        self.serving_app.set(appid);
-                        found = true;
-                    } else {
-                        // The app's request failed
-                        upcalls.schedule_upcall(0, kernel::into_statuscode(rcode), 0, 0);
-                        app.waiting = None;
+    // Start a new request. Return Ok(()) if one started, Err(FAIL) if not.
+    // Issue callbacks for any requests that are invalid, either because
+    // they are zero-length or requested an invalid algoritm.
+    fn next_request(&self) -> Result<(), ErrorCode> {
+        self.app_buffer_written.set(0);
+        for process in self.grant.iter() {
+            let process_id = process.processid();
+            let started = process.enter(|grant, upcalls| {
+                // If there's no buffer this means the process is dead, so
+                // no need to issue a callback on this error case.
+                let res: Result<(), ErrorCode> =
+                    grant.buffer.map_or(Err(ErrorCode::NOMEM), |buffer| {
+                        if let Some((algorithm, len)) = grant.request {
+                            let copy_len = cmp::min(len, buffer.len());
+                            if copy_len == 0 {
+                                // 0-length or 0-size buffer
+                                Err(ErrorCode::SIZE)
+                            } else {
+                                let res = self.crc.set_algorithm(algorithm);
+                                match res {
+                                    Ok(()) => {
+                                        let copy_len = self.do_next_input(buffer, copy_len);
+                                        if copy_len > 0 {
+                                            self.app_buffer_written.set(copy_len);
+                                            self.current_process.set(process_id);
+                                            Ok(())
+                                        } else {
+                                            // Next input failed
+                                            Err(ErrorCode::FAIL)
+                                        }
+                                    }
+                                    Err(_) => {
+                                        // Setting the algorithm failed
+                                        Err(ErrorCode::INVAL)
+                                    }
+                                }
+                            }
+                        } else {
+                            // no request
+                            Err(ErrorCode::FAIL)
+                        }
+                    });
+                match res {
+                    Ok(()) => Ok(()),
+                    Err(e) => {
+                        upcalls.schedule_upcall(0, kernel::into_statuscode(Err(e)), 0, 0);
+                        grant.request = None;
+                        Err(e)
                     }
                 }
             });
-            if found {
-                break;
+            if started.is_ok() {
+                return started;
             }
         }
-
-        if !found {
-            // Power down the CRC unit until next needed
-            self.crc_unit.disable();
-        }
+        Err(ErrorCode::FAIL)
     }
 }
 
-/// Processes can use the CRC system call driver to compute CRC redundancy checks over process
+/// Processes can use the Crc system call driver to compute Crc redundancy checks over process
 /// memory.
 ///
 /// At a high level, the client first provides a callback for the result of computations through
 /// the `subscribe` system call and `allow`s the driver access to the buffer over-which to compute.
-/// Then, it initiates a CRC computation using the `command` system call. See function-specific
+/// Then, it initiates a Crc computation using the `command` system call. See function-specific
 /// comments for details.
-impl<'a, C: hil::crc::CRC<'a>> Driver for Crc<'a, C> {
+impl<'a, C: Crc<'a>> Driver for CrcDriver<'a, C> {
     /// The `allow` syscall for this driver supports the single
     /// `allow_num` zero, which is used to provide a buffer over which
-    /// to compute a CRC computation.
+    /// to compute a Crc computation.
     ///
     fn allow_readonly(
         &self,
-        appid: ProcessId,
+        process_id: ProcessId,
         allow_num: usize,
         mut slice: ReadOnlyAppSlice,
     ) -> Result<ReadOnlyAppSlice, (ReadOnlyAppSlice, ErrorCode)> {
         let res = match allow_num {
-            // Provide user buffer to compute CRC over
+            // Provide user buffer to compute Crc over
             0 => self
-                .apps
-                .enter(appid, |app, _| {
-                    mem::swap(&mut app.buffer, &mut slice);
+                .grant
+                .enter(process_id, |grant, _| {
+                    mem::swap(&mut grant.buffer, &mut slice);
                 })
                 .map_err(ErrorCode::from),
             _ => Err(ErrorCode::NOSUPPORT),
@@ -194,7 +257,7 @@ impl<'a, C: hil::crc::CRC<'a>> Driver for Crc<'a, C> {
 
     // The `subscribe` syscall supports the single `subscribe_number`
     // zero, which is used to provide a callback that will receive the
-    // result of a CRC computation.  The signature of the callback is
+    // result of a Crc computation.  The signature of the callback is
     //
     // ```
     //
@@ -208,20 +271,21 @@ impl<'a, C: hil::crc::CRC<'a>> Driver for Crc<'a, C> {
     //     busy. The status `SIZE` indicates the provided buffer is
     //     too large for the unit to handle.
     //
-    //   * `result` is the result of the CRC computation when `status == BUSY`.
+    //   * `result` is the result of the Crc computation when `status == BUSY`.
+    //
 
     /// The command system call for this driver return meta-data about the driver and kicks off
-    /// CRC computations returned through callbacks.
+    /// Crc computations returned through callbacks.
     ///
     /// ### Command Numbers
     ///
     ///   *   `0`: Returns non-zero to indicate the driver is present.
     ///
-    ///   *   `2`: Requests that a CRC be computed over the buffer
+    ///   *   `2`: Requests that a Crc be computed over the buffer
     ///       previously provided by `allow`.  If none was provided,
     ///       this command will return `INVAL`.
     ///
-    ///       This command's driver-specific argument indicates what CRC
+    ///       This command's driver-specific argument indicates what Crc
     ///       algorithm to perform, as listed below.  If an invalid
     ///       algorithm specifier is provided, this command will return
     ///       `INVAL`.
@@ -234,110 +298,259 @@ impl<'a, C: hil::crc::CRC<'a>> Driver for Crc<'a, C> {
     ///       receive the result, this command will return `BUSY`.
     ///
     ///       When `Ok(())` is returned, this means the request has been
-    ///       queued and the callback will be invoked when the CRC
+    ///       queued and the callback will be invoked when the Crc
     ///       computation is complete.
     ///
     /// ### Algorithm
     ///
-    /// The CRC algorithms supported by this driver are listed below.  In
+    /// The Crc algorithms supported by this driver are listed below.  In
     /// the values used to identify polynomials, more-significant bits
     /// correspond to higher-order terms, and the most significant bit is
     /// omitted because it always equals one.  All algorithms listed here
     /// consume each input byte from most-significant bit to
     /// least-significant.
     ///
-    ///   * `0: CRC-32`  This algorithm is used in Ethernet and many other
+    ///   * `0: Crc-32`  This algorithm is used in Ethernet and many other
     ///   applications.  It uses polynomial 0x04C11DB7 and it bit-reverses
     ///   and then bit-inverts the output.
     ///
-    ///   * `1: CRC-32C`  This algorithm uses polynomial 0x1EDC6F41 (due
+    ///   * `1: Crc-32C`  This algorithm uses polynomial 0x1EDC6F41 (due
     ///   to Castagnoli) and it bit-reverses and then bit-inverts the
-    ///   output.  It *may* be equivalent to various CRC functions using
+    ///   output.  It *may* be equivalent to various Crc functions using
     ///   the same name.
     ///
     ///   * `2: SAM4L-16`  This algorithm uses polynomial 0x1021 and does
-    ///   no post-processing on the output value. The sixteen-bit CRC
+    ///   no post-processing on the output value. The sixteen-bit Crc
     ///   result is placed in the low-order bits of the returned result
     ///   value, and the high-order bits will all be set.  That is, result
     ///   values will always be of the form `0xFFFFxxxx` for this
     ///   algorithm.  It can be performed purely in hardware on the SAM4L.
     ///
     ///   * `3: SAM4L-32`  This algorithm uses the same polynomial as
-    ///   `CRC-32`, but does no post-processing on the output value.  It
+    ///   `Crc-32`, but does no post-processing on the output value.  It
     ///   can be perfomed purely in hardware on the SAM4L.
     ///
     ///   * `4: SAM4L-32C`  This algorithm uses the same polynomial as
-    ///   `CRC-32C`, but does no post-processing on the output value.  It
+    ///   `Crc-32C`, but does no post-processing on the output value.  It
     ///   can be performed purely in hardware on the SAM4L.
     fn command(
         &self,
         command_num: usize,
-        algorithm: usize,
-        _: usize,
-        appid: ProcessId,
+        algorithm_id: usize,
+        length: usize,
+        process_id: ProcessId,
     ) -> CommandReturn {
         match command_num {
             // This driver is present
             0 => CommandReturn::success(),
 
-            // Request a CRC computation
+            // Request a Crc computation
             2 => {
-                let result = if let Some(alg) = alg_from_user_int(algorithm) {
-                    self.apps
-                        .enter(appid, |app, _| {
-                            if app.waiting.is_some() {
-                                // Each app may make only one request at a time
-                                Err(ErrorCode::BUSY)
-                            } else {
-                                app.waiting = Some(alg);
-                                Ok(())
-                            }
-                        })
-                        .map_err(ErrorCode::from)
+                // Parse the user provided algorithm number
+                let algorithm = if let Some(alg) = alg_from_user_int(algorithm_id) {
+                    alg
                 } else {
-                    Err(ErrorCode::INVAL)
+                    return CommandReturn::failure(ErrorCode::INVAL);
                 };
+                let res = self
+                    .grant
+                    .enter(process_id, |grant, _| {
+                        if grant.request.is_some() {
+                            Err(ErrorCode::BUSY)
+                        } else if length > grant.buffer.len() {
+                            Err(ErrorCode::SIZE)
+                        } else {
+                            grant.request = Some((algorithm, length));
+                            Ok(())
+                        }
+                    })
+                    .unwrap_or_else(|e| Err(ErrorCode::from(e)));
 
-                if let Err(e) = result {
-                    CommandReturn::failure(e)
-                } else {
-                    self.serve_waiting_apps();
-                    CommandReturn::success()
+                match res {
+                    Ok(()) => {
+                        if self.current_process.is_none() {
+                            self.next_request().map_or_else(
+                                |e| CommandReturn::failure(ErrorCode::into(e)),
+                                |_| CommandReturn::success(),
+                            )
+                        } else {
+                            // Another request is ongoing. We've enqueued this one,
+                            // wait for it to be started when it's its turn.
+                            CommandReturn::success()
+                        }
+                    }
+                    Err(e) => CommandReturn::failure(e),
                 }
             }
-
             _ => CommandReturn::failure(ErrorCode::NOSUPPORT),
         }
     }
 
     fn allocate_grant(&self, processid: ProcessId) -> Result<(), kernel::procs::Error> {
-        self.apps.enter(processid, |_, _| {})
+        self.grant.enter(processid, |_, _| {})
     }
 }
 
-impl<'a, C: hil::crc::CRC<'a>> hil::crc::Client for Crc<'a, C> {
-    fn receive_result(&self, result: u32) {
-        self.serving_app.take().map(|appid| {
-            let _ = self
-                .apps
-                .enter(appid, |app, upcalls| {
-                    upcalls.schedule_upcall(0, kernel::into_statuscode(Ok(())), result as usize, 0);
-                    app.waiting = None;
-                    Ok(())
-                })
-                .unwrap_or_else(|err| err.into());
-            self.serve_waiting_apps();
+impl<'a, C: Crc<'a>> Client for CrcDriver<'a, C> {
+    fn input_done(&self, result: Result<(), ErrorCode>, buffer: LeasableBuffer<'static, u8>) {
+        // A call to `input` has finished. This can mean that either
+        // we have processed the entire buffer passed in, or it was
+        // truncated by the CRC unit as it was too large. In the first
+        // case, we can see whether there is more outstanding data
+        // from the app, whereas in the latter we need to advance the
+        // LeasableBuffer window and pass it in again.
+        let mut computing = false;
+        // There are three outcomes to this match:
+        //   - crc_buffer is not put back: input is ongoing
+        //   - crc_buffer is put back and computing is true: compute is ongoing
+        //   - crc_buffer is put back and computing is false: something failed, start a new request
+        match result {
+            Ok(()) => {
+                // Completed leasable buffer, either refill it or compute
+                if buffer.len() == 0 {
+                    // Put the kernel buffer back
+                    self.crc_buffer.replace(buffer.take());
+                    self.current_process.map(|pid| {
+                        let _res = self.grant.enter(*pid, |grant, upcalls| {
+                            // This shouldn't happen unless there's a way to clear out a request
+                            // through a system call: regardless, the request is gone, so cancel
+                            // the CRC.
+                            if grant.request.is_none() {
+                                upcalls.schedule_upcall(
+                                    0,
+                                    kernel::into_statuscode(Err(ErrorCode::FAIL)),
+                                    0,
+                                    0,
+                                );
+                                return;
+                            }
+
+                            // Compute how many remaining bytes to compute over
+                            let (alg, size) = grant.request.unwrap();
+                            grant.request = Some((alg, size));
+                            let size = cmp::min(size, grant.buffer.len());
+                            // If the buffer has shrunk, size might be less than
+                            // app_buffer_written: don't allow wraparound
+                            let remaining = size - cmp::min(self.app_buffer_written.get(), size);
+
+                            if remaining == 0 {
+                                // No more bytes to input: compute
+                                let res = self.crc.compute();
+                                match res {
+                                    Ok(()) => {
+                                        computing = true;
+                                    }
+                                    Err(_) => {
+                                        grant.request = None;
+                                        upcalls.schedule_upcall(
+                                            0,
+                                            kernel::into_statuscode(Err(ErrorCode::FAIL)),
+                                            0,
+                                            0,
+                                        );
+                                    }
+                                }
+                            } else {
+                                // More bytes: do the next input
+                                let amount = grant.buffer.map_or(0, |app_slice| {
+                                    self.do_next_input(
+                                        &app_slice[self.app_buffer_written.get()..],
+                                        remaining,
+                                    )
+                                });
+                                if amount == 0 {
+                                    grant.request = None;
+                                    upcalls.schedule_upcall(
+                                        0,
+                                        kernel::into_statuscode(Err(ErrorCode::NOMEM)),
+                                        0,
+                                        0,
+                                    );
+                                } else {
+                                    self.app_buffer_written.add(amount);
+                                }
+                            }
+                        });
+                    });
+                } else {
+                    // There's more in the leasable buffer: pass it to input again
+                    let res = self.crc.input(buffer);
+                    match res {
+                        Ok(()) => {}
+                        Err((e, returned_buffer)) => {
+                            self.crc_buffer.replace(returned_buffer.take());
+                            self.current_process.map(|pid| {
+                                let _res = self.grant.enter(*pid, |grant, upcalls| {
+                                    grant.request = None;
+                                    upcalls.schedule_upcall(
+                                        0,
+                                        kernel::into_statuscode(Err(e)),
+                                        0,
+                                        0,
+                                    );
+                                });
+                            });
+                        }
+                    }
+                }
+            }
+            Err(e) => {
+                // The callback returned an error, pass it back to userspace
+                self.crc_buffer.replace(buffer.take());
+                self.current_process.map(|pid| {
+                    let _res = self.grant.enter(*pid, |grant, upcalls| {
+                        grant.request = None;
+                        upcalls.schedule_upcall(0, kernel::into_statuscode(Err(e)), 0, 0);
+                    });
+                });
+            }
+        }
+        // The buffer was put back (there is no input ongoing) but computing is false,
+        // so no compute is ongoing. Start a new request if there is one.
+        if self.crc_buffer.is_some() && !computing {
+            let _ = self.next_request();
+        }
+    }
+
+    fn crc_done(&self, result: Result<CrcOutput, ErrorCode>) {
+        // First of all, inform the app about the finished operation /
+        // the result
+        self.current_process.take().map(|process_id| {
+            let _ = self.grant.enter(process_id, |grant, upcalls| {
+                grant.request = None;
+                match result {
+                    Ok(output) => {
+                        let (val, user_int) = encode_upcall_crc_output(output);
+                        upcalls.schedule_upcall(
+                            0,
+                            kernel::into_statuscode(Ok(())),
+                            val as usize,
+                            user_int as usize,
+                        );
+                    }
+                    Err(e) => {
+                        upcalls.schedule_upcall(0, kernel::into_statuscode(Err(e)), 0, 0);
+                    }
+                }
+            });
         });
+        let _ = self.next_request();
     }
 }
 
-fn alg_from_user_int(i: usize) -> Option<hil::crc::CrcAlg> {
+fn alg_from_user_int(i: usize) -> Option<CrcAlgorithm> {
     match i {
-        0 => Some(CrcAlg::Crc32),
-        1 => Some(CrcAlg::Crc32C),
-        2 => Some(CrcAlg::Sam4L16),
-        3 => Some(CrcAlg::Sam4L32),
-        4 => Some(CrcAlg::Sam4L32C),
+        0 => Some(CrcAlgorithm::Crc32),
+        1 => Some(CrcAlgorithm::Crc32C),
+        2 => Some(CrcAlgorithm::Crc16CCITT),
         _ => None,
+    }
+}
+
+fn encode_upcall_crc_output(output: CrcOutput) -> (u32, u32) {
+    match output {
+        CrcOutput::Crc32(val) => (val, 0),
+        CrcOutput::Crc32C(val) => (val, 1),
+        CrcOutput::Crc16CCITT(val) => ((val as u32) | 0xFFFF0000, 2),
     }
 }

--- a/capsules/src/test/crc.rs
+++ b/capsules/src/test/crc.rs
@@ -1,0 +1,90 @@
+//! Test the CRC hardware.
+
+use kernel::common::cells::TakeCell;
+use kernel::common::leasable_buffer::LeasableBuffer;
+use kernel::debug;
+use kernel::hil::crc::{Client, Crc, CrcAlgorithm, CrcOutput};
+use kernel::ErrorCode;
+
+pub struct TestCrc<'a, C: 'a> {
+    crc: &'a C,
+    data: TakeCell<'static, [u8]>,
+}
+
+impl<'a, C: Crc<'a>> TestCrc<'a, C> {
+    pub fn new(crc: &'a C, data: &'static mut [u8]) -> Self {
+        TestCrc {
+            crc: crc,
+            data: TakeCell::new(data),
+        }
+    }
+
+    pub fn run_test(&self, algorithm: CrcAlgorithm) {
+        let res = self.crc.set_algorithm(algorithm);
+        if res.is_err() {
+            debug!("CrcTest ERROR: failed to set algorithm to Crc32: {:?}", res);
+            return;
+        }
+        let leasable: LeasableBuffer<'static, u8> = LeasableBuffer::new(self.data.take().unwrap());
+
+        let res = self.crc.input(leasable);
+        if let Err((error, _buffer)) = res {
+            debug!(
+                "CrcTest ERROR: failed to start input processing: {:?}",
+                error
+            );
+        }
+    }
+
+    pub fn run(&self) {
+        self.run_test(CrcAlgorithm::Crc32);
+    }
+}
+
+impl<'a, C: Crc<'a>> Client for TestCrc<'a, C> {
+    fn input_done(&self, result: Result<(), ErrorCode>, buffer: LeasableBuffer<'static, u8>) {
+        if result.is_err() {
+            debug!("CrcTest ERROR: failed to process input: {:?}", result);
+            return;
+        }
+
+        if buffer.len() == 0 {
+            self.data.replace(buffer.take());
+            let res = self.crc.compute();
+            if res.is_err() {
+                debug!("CrcTest ERROR: failed to start CRC computation: {:?}", res);
+            }
+        } else {
+            let res = self.crc.input(buffer);
+            if let Err((error, _buffer)) = res {
+                debug!(
+                    "CrcTest ERROR: failed to start input processing: {:?}",
+                    error
+                );
+            }
+        }
+    }
+
+    /// Called when the CRC computation is finished.
+    fn crc_done(&self, result: Result<CrcOutput, ErrorCode>) {
+        if let Err(code) = result {
+            debug!("CrcTest ERROR: failed to compute CRC: {:?}", code);
+        } else {
+            if let Ok(output) = result {
+                match output {
+                    CrcOutput::Crc32(x) => {
+                        debug!("CRC32: {:#x}", x);
+                        self.run_test(CrcAlgorithm::Crc32C);
+                    }
+                    CrcOutput::Crc32C(x) => {
+                        debug!("CRC32C: {:#x}", x);
+                        self.run_test(CrcAlgorithm::Crc16CCITT);
+                    }
+                    CrcOutput::Crc16CCITT(x) => {
+                        debug!("CRC16CCITT: {:#x}", x);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/capsules/src/test/mod.rs
+++ b/capsules/src/test/mod.rs
@@ -2,6 +2,7 @@ pub mod aes;
 pub mod aes_ccm;
 pub mod alarm;
 pub mod alarm_edge_cases;
+pub mod crc;
 pub mod double_grant_entry;
 pub mod kv_system;
 pub mod random_alarm;

--- a/chips/sam4l/src/chip.rs
+++ b/chips/sam4l/src/chip.rs
@@ -230,6 +230,7 @@ impl kernel::InterruptService<Task> for Sam4lDefaultPeripherals {
     unsafe fn service_deferred_call(&self, task: Task) -> bool {
         match task {
             crate::deferred_call_tasks::Task::Flashcalw => self.flash_controller.handle_interrupt(),
+            crate::deferred_call_tasks::Task::CRCCU => self.crccu.handle_deferred_call(),
         }
         true
     }

--- a/chips/sam4l/src/chip.rs
+++ b/chips/sam4l/src/chip.rs
@@ -67,7 +67,7 @@ impl Sam4lDefaultPeripherals {
             adc: crate::adc::Adc::new(crate::dma::DMAPeripheral::ADCIFE_RX, pm),
             aes: crate::aes::Aes::new(),
             ast: crate::ast::Ast::new(),
-            crccu: crate::crccu::Crccu::new(),
+            crccu: crate::crccu::Crccu::new(crate::crccu::BASE_ADDRESS),
             dac: crate::dac::Dac::new(),
             dma_channels: [
                 DMAChannel::new(DMAChannelNum::DMAChannel00),

--- a/chips/sam4l/src/crccu.rs
+++ b/chips/sam4l/src/crccu.rs
@@ -58,11 +58,11 @@ use kernel::hil::crc::{self, CrcAlg};
 use kernel::ErrorCode;
 
 // Base address of CRCCU registers.  See "7.1 Product Mapping"
-const BASE_ADDRESS: StaticRef<CrccuRegisters> =
+pub const BASE_ADDRESS: StaticRef<CrccuRegisters> =
     unsafe { StaticRef::new(0x400A4000 as *const CrccuRegisters) };
 
 #[repr(C)]
-struct CrccuRegisters {
+pub struct CrccuRegisters {
     // From page 1005 of SAM4L manual
     dscr: ReadWrite<u32, DescriptorBaseAddress::Register>,
     _reserved0: u32,
@@ -239,9 +239,9 @@ pub struct Crccu<'a> {
 const DSCR_RESERVE: usize = 512 + 5 * 4;
 
 impl Crccu<'_> {
-    pub const fn new() -> Self {
+    pub const fn new(base_addr: StaticRef<CrccuRegisters>) -> Self {
         Crccu {
-            registers: BASE_ADDRESS,
+            registers: base_addr,
             client: OptionalCell::empty(),
             state: Cell::new(State::Invalid),
             alg: Cell::new(CrcAlg::Crc32C),

--- a/chips/sam4l/src/crccu.rs
+++ b/chips/sam4l/src/crccu.rs
@@ -48,6 +48,9 @@
 //
 // - Support continuous-mode CRC
 
+use kernel::debug;
+
+use crate::deferred_call_tasks::Task;
 use crate::pm::{disable_clock, enable_clock, Clock, HSBClock, PBBClock};
 use core::cell::Cell;
 use kernel::common::cells::OptionalCell;
@@ -55,13 +58,15 @@ use kernel::common::registers::interfaces::{Readable, Writeable};
 use kernel::common::registers::{
     register_bitfields, FieldValue, InMemoryRegister, ReadOnly, ReadWrite, WriteOnly,
 };
-use kernel::common::StaticRef;
-use kernel::hil::crc::{self, CrcAlg};
+use kernel::common::{deferred_call::DeferredCall, leasable_buffer::LeasableBuffer, StaticRef};
+use kernel::hil::crc::{Client, Crc, CrcAlgorithm, CrcOutput};
 use kernel::ErrorCode;
 
 // Base address of CRCCU registers.  See "7.1 Product Mapping"
 pub const BASE_ADDRESS: StaticRef<CrccuRegisters> =
     unsafe { StaticRef::new(0x400A4000 as *const CrccuRegisters) };
+
+static DEFERRED_CALL: DeferredCall<Task> = unsafe { DeferredCall::new(Task::CRCCU) };
 
 #[repr(C)]
 pub struct CrccuRegisters {
@@ -161,7 +166,7 @@ impl Descriptor {
     pub fn new() -> Descriptor {
         Descriptor {
             addr: InMemoryRegister::new(0),
-            ctrl: InMemoryRegister::new(0),
+            ctrl: InMemoryRegister::new(TCR::default().0),
             _res: [0; 2],
             crc: InMemoryRegister::new(0),
         }
@@ -192,23 +197,23 @@ impl TCR {
     }
 }
 
-fn poly_for_alg(alg: CrcAlg) -> FieldValue<u32, Mode::Register> {
+fn poly_for_alg(alg: CrcAlgorithm) -> FieldValue<u32, Mode::Register> {
     match alg {
-        CrcAlg::Crc32 => Mode::PTYPE::Ccit8023,
-        CrcAlg::Crc32C => Mode::PTYPE::Castagnoli,
-        CrcAlg::Sam4L16 => Mode::PTYPE::Ccit16,
-        CrcAlg::Sam4L32 => Mode::PTYPE::Ccit8023,
-        CrcAlg::Sam4L32C => Mode::PTYPE::Castagnoli,
+        CrcAlgorithm::Crc32 => Mode::PTYPE::Ccit8023,
+        CrcAlgorithm::Crc32C => Mode::PTYPE::Castagnoli,
+        CrcAlgorithm::Crc16CCITT => Mode::PTYPE::Ccit16,
+        // CrcAlg::Sam4L32 => Mode::PTYPE::Ccit8023,
+        // CrcAlg::Sam4L32C => Mode::PTYPE::Castagnoli,
     }
 }
 
-fn post_process(result: u32, alg: CrcAlg) -> u32 {
+fn post_process(result: u32, alg: CrcAlgorithm) -> CrcOutput {
     match alg {
-        CrcAlg::Crc32 => reverse_and_invert(result),
-        CrcAlg::Crc32C => reverse_and_invert(result),
-        CrcAlg::Sam4L16 => result,
-        CrcAlg::Sam4L32 => result,
-        CrcAlg::Sam4L32C => result,
+        CrcAlgorithm::Crc32 => CrcOutput::Crc32(reverse_and_invert(result)),
+        CrcAlgorithm::Crc32C => CrcOutput::Crc32C(reverse_and_invert(result)),
+        CrcAlgorithm::Crc16CCITT => CrcOutput::Crc16CCITT(result as u16),
+        // CrcAlg::Sam4L32 => result,
+        // CrcAlg::Sam4L32C => result,
     }
 }
 
@@ -243,9 +248,17 @@ enum State {
 /// State for managing the CRCCU
 pub struct Crccu<'a> {
     registers: StaticRef<CrccuRegisters>,
-    client: OptionalCell<&'a dyn crc::Client>,
+    client: OptionalCell<&'a dyn Client>,
     state: Cell<State>,
-    alg: Cell<CrcAlg>,
+    algorithm: OptionalCell<CrcAlgorithm>,
+
+    // This store the full leasable-buffer boundaries for
+    // reconstruction when a call to [`Crc::input`] finishes
+    current_full_buffer: Cell<(*mut u8, usize)>,
+
+    // Marker whether a "computation" (pending deferred call) is in
+    // progress
+    compute_requested: Cell<bool>,
 
     // CRC DMA descriptor
     //
@@ -260,7 +273,9 @@ impl Crccu<'_> {
             registers: base_addr,
             client: OptionalCell::empty(),
             state: Cell::new(State::Invalid),
-            alg: Cell::new(CrcAlg::Crc32C),
+            algorithm: OptionalCell::empty(),
+            current_full_buffer: Cell::new((0 as *mut u8, 0)),
+            compute_requested: Cell::new(false),
             descriptor: Descriptor::new(),
         }
     }
@@ -268,7 +283,7 @@ impl Crccu<'_> {
     fn init(&self) {
         if self.state.get() == State::Invalid {
             self.descriptor.addr.set(0);
-            self.descriptor.ctrl.set(0);
+            self.descriptor.ctrl.set(TCR::default().0);
             self.descriptor.crc.set(0);
             self.state.set(State::Initialized);
         }
@@ -277,7 +292,6 @@ impl Crccu<'_> {
     /// Enable the CRCCU's clocks and interrupt
     fn enable(&self) {
         if self.state.get() != State::Enabled {
-            self.init();
             // see "10.7.4 Clock Mask"
             enable_clock(Clock::HSB(HSBClock::CRCCU));
             enable_clock(Clock::PBB(PBBClock::CRCCU));
@@ -304,13 +318,21 @@ impl Crccu<'_> {
             // A DMA transfer has completed
 
             if TCR(self.descriptor.ctrl.get()).interrupt_enabled() {
-                self.client.map(|client| {
-                    let result = post_process(self.registers.sr.read(Status::CRC), self.alg.get());
-                    client.receive_result(result);
-                });
+                // We have the current temporary result ready, but
+                // wait for the client to finish the CRC computation
+                // by calling [`Crc::compute`]
+
+                // self.client.map(|client| {
+                //     let result = post_process(self.registers.sr.read(Status::CRC), self.alg.get());
+                //     client.receive_result(result);
+                // });
 
                 // Disable the unit
                 self.registers.mr.write(Mode::ENABLE::Disabled);
+
+                // Recover the window into the LeasableBuffer
+                let window_addr = self.descriptor.addr.get();
+                let window_len = TCR(self.descriptor.ctrl.get()).get_btsize() as usize;
 
                 // Reset CTRL.IEN (for our own statekeeping)
                 self.descriptor.addr.set(0);
@@ -322,30 +344,129 @@ impl Crccu<'_> {
 
                 // Disable DMA channel
                 self.registers.dmadis.write(DmaDisable::DMADIS::SET);
+
+                // Reconstruct the leasable buffer from stored
+                // information and slice into the proper window
+                let (full_buffer_addr, full_buffer_len) = self.current_full_buffer.get();
+                let mut data = LeasableBuffer::<'static, u8>::new(unsafe {
+                    core::slice::from_raw_parts_mut(full_buffer_addr, full_buffer_len)
+                });
+
+                // Must be strictly positive or zero
+                let start_offset = (window_addr as usize) - (full_buffer_addr as usize);
+                data.slice(start_offset..(start_offset + window_len));
+
+                // Pass the properly sliced and reconstructed buffer
+                // back to the client
+                self.client.map(move |client| {
+                    client.input_done(Ok(()), data);
+                });
             }
         }
+    }
+
+    pub fn handle_deferred_call(&self) {
+        // A deferred call is currently only issued on a call to
+        // compute, in which case we need to provide the CRC to the
+        // client
+        let result = post_process(
+            self.registers.sr.read(Status::CRC),
+            self.algorithm.expect("crccu deferred call: no algorithm"),
+        );
+
+        // Reset the internal CRC state such that the next call to
+        // input will start a new CRC
+        self.registers.cr.write(Control::RESET::SET);
+        self.descriptor.ctrl.set(TCR::default().0);
+        self.compute_requested.set(false);
+
+        self.client.map(|client| {
+            client.crc_done(Ok(result));
+        });
     }
 }
 
 // Implement the generic CRC interface with the CRCCU
-impl<'a> crc::CRC<'a> for Crccu<'a> {
+impl<'a> Crc<'a> for Crccu<'a> {
     /// Set a client to receive results from the CRCCU
-    fn set_client(&self, client: &'a dyn crc::Client) {
+    fn set_client(&self, client: &'a dyn Client) {
         self.client.set(client);
     }
 
-    fn compute(&self, data: &[u8], alg: CrcAlg) -> Result<(), ErrorCode> {
-        self.init();
+    fn algorithm_supported(&self, algorithm: CrcAlgorithm) -> bool {
+        // Deliberately has an exhaustive list here to avoid
+        // advertising support for added variants to CrcAlgorithm
+        match algorithm {
+            CrcAlgorithm::Crc32 => true,
+            CrcAlgorithm::Crc32C => true,
+            CrcAlgorithm::Crc16CCITT => true,
+        }
+    }
 
-        if TCR(self.descriptor.ctrl.get()).interrupt_enabled() {
+    fn set_algorithm(&self, algorithm: CrcAlgorithm) -> Result<(), ErrorCode> {
+        // If there currently is a DMA operation in progress, refuse
+        // to set the algorithm.
+        if TCR(self.descriptor.ctrl.get()).interrupt_enabled() || self.compute_requested.get() {
+            debug!(
+                "Algorithm fail: busy due to Interrupt: {}, compute: {}",
+                TCR(self.descriptor.ctrl.get()).interrupt_enabled(),
+                self.compute_requested.get()
+            );
             // A computation is already in progress
             return Err(ErrorCode::BUSY);
         }
 
-        if data.len() > 2usize.pow(16) - 1 {
-            // Buffer too long
-            // TODO: Chain CRCCU computations to handle large buffers
-            return Err(ErrorCode::SIZE);
+        self.init();
+        // Clear the descriptor contents
+        self.descriptor.addr.set(0);
+        self.descriptor.ctrl.set(TCR::default().0);
+        self.descriptor.crc.set(0);
+        self.algorithm.set(algorithm);
+
+        // Reset intermediate CRC value
+        self.registers.cr.write(Control::RESET::SET);
+
+        Ok(())
+    }
+
+    fn input(
+        &self,
+        mut data: LeasableBuffer<'static, u8>,
+    ) -> Result<(), (ErrorCode, LeasableBuffer<'static, u8>)> {
+        let algorithm = if let Some(algorithm) = self.algorithm.extract() {
+            algorithm
+        } else {
+            return Err((ErrorCode::RESERVE, data));
+        };
+
+        if TCR(self.descriptor.ctrl.get()).interrupt_enabled() || self.compute_requested.get() {
+            // A computation is already in progress
+            return Err((ErrorCode::BUSY, data));
+        }
+
+        // Need to initialize after checking business, because init will
+        // clear out interrupt state.
+        self.init();
+
+        // Initialize the descriptor, since it is used to track business
+        let len = data.len() as u16;
+        let ctrl = TCR::new(true, TrWidth::Byte, len);
+
+        // Make sure we don't try to process more data than the CRC
+        // DMA operation supports.
+        if data.len() > u16::MAX as usize {
+            // Restore the full slice, calculate the current
+            // window's start offset.
+            let window_ptr = data.as_ptr();
+            data.reset();
+            let start_ptr = data.as_ptr();
+            // Must be strictly positive or zero
+            let start_offset = unsafe { window_ptr.offset_from(start_ptr) } as usize;
+
+            // Reslice the buffer such that it start at the same
+            // position as the old window, but fits the size
+            // constraints
+            data.slice(start_offset..=(start_offset + u16::MAX as usize));
         }
 
         self.enable();
@@ -356,37 +477,68 @@ impl<'a> crc::CRC<'a> for Crccu<'a> {
         // Enable error interrupt
         self.registers.ier.write(Interrupt::ERR::SET);
 
-        // Reset intermediate CRC value
-        self.registers.cr.write(Control::RESET::SET);
-
-        // Configure the data transfer
-        let addr = data.as_ptr() as u32;
-        let len = data.len() as u16;
-        /*
-        // It's not clear under what circumstances a transfer width other than Byte will work
-        let tr_width = if addr % 4 == 0 && len % 4 == 0 { TrWidth::Word }
-                       else { if addr % 2 == 0 && len % 2 == 0 { TrWidth::HalfWord }
-                              else { TrWidth::Byte } };
-        */
-        let tr_width = TrWidth::Byte;
-        let ctrl = TCR::new(true, tr_width, len);
-        self.descriptor.addr.set(addr);
+        // Configure the data transfer descriptor
+        //
+        // The data length is guaranteed to be <= u16::MAX by the
+        // above LeasableBuffer resizing mechanism
+        self.descriptor.addr.set(data.as_ptr() as u32);
         self.descriptor.ctrl.set(ctrl.0);
-        self.descriptor.crc.set(0);
+        self.descriptor.crc.set(0); // this is the CRC compare field, not used
+
+        // Prior to starting the DMA operation, drop the
+        // LeasableBuffer slice. Otherwise we violate Rust's mutable
+        // aliasing rules.
+        let full_slice = data.take();
+        let full_slice_ptr_len = (full_slice.as_mut_ptr(), full_slice.len());
+        self.current_full_buffer.set(full_slice_ptr_len);
+
+        // Ensure the &'static mut slice reference goes out of scope
+        //
+        // We can't use mem::drop on a reference here, clippy will
+        // complain, even though it would be effective at making this
+        // 'static mut buffer inaccessible. For now, just make sure to
+        // not reference it below.
+        //
+        // TODO: this needs a proper type and is a broader issue. See
+        // tock/tock#2637 for more information.
+        //
+        // core::mem::drop(full_slice);
+
+        // Set the descriptor memory address accordingly
         self.registers
             .dscr
             .set(&self.descriptor as *const Descriptor as u32);
 
-        // Record what algorithm was requested
-        self.alg.set(alg);
-
         // Configure the unit to compute a checksum
         self.registers.mr.write(
-            Mode::DIVIDER.val(0) + poly_for_alg(alg) + Mode::COMPARE::CLEAR + Mode::ENABLE::Enabled,
+            Mode::DIVIDER.val(0)
+                + poly_for_alg(algorithm)
+                + Mode::COMPARE::CLEAR
+                + Mode::ENABLE::Enabled,
         );
 
         // Enable DMA channel
         self.registers.dmaen.write(DmaEnable::DMAEN::SET);
+
+        Ok(())
+    }
+
+    fn compute(&self) -> Result<(), ErrorCode> {
+        // In this hardware implementation, we compute the CRC in
+        // parallel to the DMA operations. Thus this can simply
+        // request the CR and reset the state in a deferred call.
+
+        if TCR(self.descriptor.ctrl.get()).interrupt_enabled() || self.compute_requested.get() {
+            // A computation is already in progress
+            return Err(ErrorCode::BUSY);
+        }
+
+        // Mark the device as busy
+        self.compute_requested.set(true);
+
+        // Request a deferred call such that we can provide the result
+        // back to the client
+        DEFERRED_CALL.set();
 
         Ok(())
     }

--- a/chips/sam4l/src/deferred_call_tasks.rs
+++ b/chips/sam4l/src/deferred_call_tasks.rs
@@ -10,6 +10,7 @@ use core::convert::TryFrom;
 #[derive(Copy, Clone)]
 pub enum Task {
     Flashcalw = 0,
+    CRCCU = 1,
 }
 
 impl TryFrom<usize> for Task {
@@ -18,6 +19,7 @@ impl TryFrom<usize> for Task {
     fn try_from(value: usize) -> Result<Task, ()> {
         match value {
             0 => Ok(Task::Flashcalw),
+            1 => Ok(Task::CRCCU),
             _ => Err(()),
         }
     }

--- a/kernel/src/hil/crc.rs
+++ b/kernel/src/hil/crc.rs
@@ -1,6 +1,21 @@
 //! Interface for CRC computation.
 
+use crate::common::leasable_buffer::LeasableBuffer;
 use crate::ErrorCode;
+
+/// Client for CRC algorithm implementations
+///
+/// Implement this trait and use [`Crc::set_client`] in order to
+/// receive callbacks from the CRC implementation.
+pub trait Client {
+    /// Called when the current data chunk has been processed by the
+    /// CRC engine. Further data may be supplied when this callback is
+    /// received.
+    fn input_done(&self, result: Result<(), ErrorCode>, buffer: LeasableBuffer<'static, u8>);
+
+    /// Called when the CRC computation is finished.
+    fn crc_done(&self, result: Result<CrcOutput, ErrorCode>);
+}
 
 /// CRC algorithms
 ///
@@ -10,32 +25,108 @@ use crate::ErrorCode;
 /// no software post-processing on platforms using it.
 ///
 #[derive(Copy, Clone)]
-pub enum CrcAlg {
-    /// Polynomial 0x04C11DB7, output reversed then inverted ("CRC-32")
+pub enum CrcAlgorithm {
+    /// Polynomial 0x04C11DB7, output reversed then inverted
+    /// ("CRC-32")
     Crc32,
-    /// Polynomial 0x1EDC6F41, output reversed then inverted ("CRC-32C" / "Castagnoli")
+    /// Polynomial 0x1EDC6F41, output reversed then inverted
+    /// ("CRC-32C" / "Castagnoli")
     Crc32C,
-
-    /// Polynomial 0x1021, no output post-processing
-    Sam4L16,
-    /// Polynomial 0x04C11DB7, no output post-processing
-    Sam4L32,
-    /// Polynomial 0x1EDC6F41, no output post-processing
-    Sam4L32C,
+    /// Polynomial 0x1021, no output post-processing ("CRC-16-CCITT")
+    Crc16CCITT,
 }
 
-pub trait CRC<'a> {
-    /// Set the client to be used for callbacks.
+/// CRC output type
+///
+/// Individual CRC algorithms can have different output lengths. This
+/// type represents the different [`CrcAlgorithm`] outputs
+/// respectively.
+#[derive(Copy, Clone)]
+pub enum CrcOutput {
+    /// Output of [`CrcAlgorithm::Crc32`]
+    Crc32(u32),
+    /// Output of [`CrcAlgorithm::Crc32C`]
+    Crc32C(u32),
+    /// Output of [`CrcAlgorithm::Crc16CCITT`]
+    Crc16CCITT(u16),
+}
+
+impl CrcOutput {
+    pub fn algorithm(&self) -> CrcAlgorithm {
+        match self {
+            CrcOutput::Crc32(_) => CrcAlgorithm::Crc32,
+            CrcOutput::Crc32C(_) => CrcAlgorithm::Crc32C,
+            CrcOutput::Crc16CCITT(_) => CrcAlgorithm::Crc16CCITT,
+        }
+    }
+}
+
+pub trait Crc<'a> {
+    /// Set the client to be used for callbacks of the CRC
+    /// implementation.
     fn set_client(&self, client: &'a dyn Client);
+    /// Check whether a given CRC algorithm is supported by a CRC
+    /// implementation.
+    ///
+    /// Returns true if the algorithm specified is supported.
+    fn algorithm_supported(&self, algorithm: CrcAlgorithm) -> bool;
 
-    /// Initiate a CRC calculation
-    fn compute(&self, data: &[u8], _: CrcAlg) -> Result<(), ErrorCode>;
+    /// Set the CRC algorithm to use.
+    ///
+    /// Calling this method may enable the CRC engine in case of a
+    /// physical unit.
+    ///
+    /// If the device is currently processing a chunk of data or
+    /// calculating a CRC, this operation will be refused, returning
+    /// [`ErrorCode::BUSY`]. If a CRC calculation currently has
+    /// pending data, it will be cancelled and the CRC engine's state
+    /// reset.
+    ///
+    /// [`ErrorCode::NOSUPPORT`] will be returned if the algorithm
+    /// requested is not supported. To non-invasively check whether a
+    /// given algorithm is supported by a CRC implementation, use
+    /// [`Crc::algorithm_supported`].
+    fn set_algorithm(&self, algorithm: CrcAlgorithm) -> Result<(), ErrorCode>;
 
-    /// Disable the CRC unit until compute() is next called
+    /// Input chunked data into the CRC implementation.
+    ///
+    /// Calling this method may enable the CRC engine in case of a
+    /// physical unit.
+    ///
+    /// If [`Crc::set_algorithm`] has not been invoked before, this
+    /// method must return [`ErrorCode::RESERVE`].
+    ///
+    /// If the device is currently already processing a chunk of data
+    /// or calculating a CRC, [`ErrorCode::BUSY`] must be returned.
+    ///
+    /// After the chunk of data has been processed,
+    /// [`Client::input_done`] is called.
+    ///
+    /// The implementation may only read a part of the passed
+    /// [`LeasableBuffer`]. It will return the bytes read and will
+    /// resize the returned [`LeasableBuffer`] appropriately prior to
+    /// passing it back through [`Client::input_done`].
+    fn input(
+        &self,
+        data: LeasableBuffer<'static, u8>,
+    ) -> Result<(), (ErrorCode, LeasableBuffer<'static, u8>)>;
+
+    /// Request calculation of the CRC.
+    ///
+    /// Calling this method may enable the CRC engine in case of a
+    /// physical unit.
+    ///
+    /// If [`Crc::set_algorithm`] has not been invoked before, this
+    /// method must return [`ErrorCode::RESERVE`].
+    ///
+    /// If the device is currently processing a chunk of data or
+    /// calculating a CRC, [`ErrorCode::BUSY`] must be returned.
+    ///
+    /// After the CRC has been calculated, [`Client::crc_done`] is
+    /// called.
+    fn compute(&self) -> Result<(), ErrorCode>;
+
+    /// Disable the CRC unit until susequent calls to methods which
+    /// will enable the CRC unit again.
     fn disable(&self);
-}
-
-pub trait Client {
-    /// Receive the successful result of a CRC calculation
-    fn receive_result(&self, _: u32);
 }


### PR DESCRIPTION
### Pull Request Overview

The current version of the CRC HIL fostered unsound implementations, in that it relies on asynchronous processing of input data, but only takes a read-only reference with an anonymous lifetime of the respective data buffer. When this buffer is used for a DMA operation, it may already have gone out of scope (for instance, when allocating on the stack). Therefore, this PR redesigns the CRC HIL interface in accordance with other current HILs and best practices as documented in the TRD for HIL design.

This is, perhaps most importantly, a prerequisite for trivially porting the changes of #2632 to the CRC driver.

### Testing Strategy

This pull request was not tested. It's not ready yet, only the HIL is done. I'd appreciate people testing with SAM4L boards as soon as this is ready.


### TODO or Help Wanted

This pull request still needs
- [x] porting the HIL changes to the SAM4L code
- [ ] porting the HIL changes to the capsule


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
