### PR TITLE
fixed broken hyperlinks to the "getting started" page

### DIFF
--- a/boards/clue_nrf52840/README.md
+++ b/boards/clue_nrf52840/README.md
@@ -7,7 +7,7 @@ The [Adafruit CLUE - nRF52840 Express with Bluetooth LE](https://www.adafruit.co
 board based on the Nordic nRF52840 SoC. It includes the
 following sensors:
 
-- 9 axis inertial LSM6DS33 + LIS3MDL sensor 
+- 9 axis inertial LSM6DS33 + LIS3MDL sensor
 - humidity and temperature sensor
 - barometric sensor
 - microphone
@@ -17,7 +17,7 @@ It has the same form factor with BBC:Microbit
 
 ## Getting Started
 
-First, follow the [Tock Getting Started guide](../../../doc/Getting_Started.md)
+First, follow the [Tock Getting Started guide](../../doc/Getting_Started.md)
 
 You will need Adafruit's nrfutil bootloader tool:
 

--- a/boards/microbit_v2/README.md
+++ b/boards/microbit_v2/README.md
@@ -15,7 +15,7 @@ following sensors:
 
 ## Getting Started
 
-First, follow the [Tock Getting Started guide](../../../doc/Getting_Started.md)
+First, follow the [Tock Getting Started guide](../../doc/Getting_Started.md)
 
 ## Bootloader
 
@@ -36,12 +36,12 @@ To build the bootloader yourself, please follow the instructions in the Tock Boo
 
 > **NOTE** Uploading the bootloader will not change any ability to upload software to the MicroBit. The microbit board has another bootloader in the debug chip that provides normal software upload capabilites and that will not be overwritten. All other software will work as expected.
 
-Connect then MicroBit to the computer. A USB drive labeled `MICROBIT` should show up. 
+Connect then MicroBit to the computer. A USB drive labeled `MICROBIT` should show up.
 
 Drag and drop the [tock-bootloader.microbit_v2.vv1.1.1.bin](https://github.com/tock/tock-bootloader/releases/download/microbit_v2-vv1.1.1/tock-bootloader.microbit_v2.vv1.1.1.bin) to the `MICROBIT` drive and wait for a few seconds.
 
 The board will reset and the bootloader should be running on it. To check whether it's working, press and hold the Button A while pressing the reset button. The Microphone LED should light up.
-### Using openocd 
+### Using openocd
 Use the `make flash-bootloader` command to flash [Tock Bootloader](https://github.com/tock/tock-bootloader) to the board.
 
 ```bash

--- a/boards/nano33ble/README.md
+++ b/boards/nano33ble/README.md
@@ -17,7 +17,7 @@ following sensors:
 
 ## Getting Started
 
-First, follow the [Tock Getting Started guide](../../../doc/Getting_Started.md).
+First, follow the [Tock Getting Started guide](../../doc/Getting_Started.md).
 
 The Nano 33 comes pre-installed with a
 [version](https://github.com/arduino/ArduinoCore-nRF528x-mbedos/tree/master/bootloaders/nano33ble)
@@ -98,12 +98,12 @@ back.
    will jump to the second, and the second will continue running if no kernel is installed.
    To reduce confusion, we can remove the second bootloader. To do this, we will overwrite
    the start of the bootloader with zeros.
-   
+
    First, double tap the reset button. This will cause the first bootloader to stay
    active. You should see the "ON" LED on.
-   
+
    Then, overwrite the second bootloader:
-   
+
     ```shell
     $ tockloader write 0x10000 512 0
     ```

--- a/boards/raspberry_pi_pico/README.md
+++ b/boards/raspberry_pi_pico/README.md
@@ -8,7 +8,7 @@ board developed by the Raspberry Pi Foundation and is based on the RP2040 chip.
 
 ## Getting Started
 
-First, follow the [Tock Getting Started guide](../../../doc/Getting_Started.md)
+First, follow the [Tock Getting Started guide](../../doc/Getting_Started.md)
 
 ## Flashing the kernel
 
@@ -75,4 +75,3 @@ $ make program
 ```
 
 This will generate a new ELF file that can be deployed on the Raspberry Pi Pico via gdb and OpenOCD as described in the [section above](#flash-the-tock-kernel).
-


### PR DESCRIPTION
### Pull Request Overview

Four README pages featured broken Hyperlinks to the [Tock Getting Started guide](https://github.com/tock/tock/blob/master/doc/Getting_Started.md) that were broken. this commit fixes that.


### Testing Strategy

This pull request was tested by clicking on the links and making sure i land on the correct page


### TODO or Help Wanted

all good


### Documentation Updated

 or no updates are required.

### Formatting

nothing done, as no code is affected
