### PR TITLE
Tock reg UIntLike

### DIFF
--- a/chips/litex/src/event_manager.rs
+++ b/chips/litex/src/event_manager.rs
@@ -4,7 +4,7 @@
 //! behave differently, can be found in the LiteX repository under
 //! [`litex/soc/interconnect/csr_eventmanager.py`](https://github.com/enjoy-digital/litex/blob/master/litex/soc/interconnect/csr_eventmanager.py).
 
-use crate::litex_registers::{IntLike, Read, ReadWrite};
+use crate::litex_registers::{Read, ReadWrite, UIntLike};
 use core::marker::PhantomData;
 
 /// LiteX event manager abstraction
@@ -19,7 +19,7 @@ use core::marker::PhantomData;
 /// peripheral's configuration status registers bank.
 pub struct LiteXEventManager<'a, T, S, P, E>
 where
-    T: IntLike,
+    T: UIntLike,
     S: Read<T>,
     P: ReadWrite<T>,
     E: ReadWrite<T>,
@@ -32,7 +32,7 @@ where
 
 impl<'a, T, S, P, E> LiteXEventManager<'a, T, S, P, E>
 where
-    T: IntLike,
+    T: UIntLike,
     S: Read<T>,
     P: ReadWrite<T>,
     E: ReadWrite<T>,

--- a/chips/litex/src/litex_registers.rs
+++ b/chips/litex/src/litex_registers.rs
@@ -37,47 +37,47 @@ pub use tock_registers::register_bitfields;
 use tock_registers::registers::{
     ReadOnly as TRReadOnly, ReadWrite as TRReadWrite, WriteOnly as TRWriteOnly,
 };
-use tock_registers::{IntLike as TRIntLike, LocalRegisterCopy, RegisterLongName};
+use tock_registers::{LocalRegisterCopy, RegisterLongName, UIntLike as TRUIntLike};
 
-/// Extension of the `tock_registers` `IntLike` trait.
+/// Extension of the `tock_registers` `UIntLike` trait.
 ///
-/// This extends the `IntLike` trait of `tock_registers` to also
+/// This extends the `UIntLike` trait of `tock_registers` to also
 /// provide the `1` and maximum (all bits set) values of the
 /// respective integer type
 ///
 /// This allows for peripherals to be written generic over the
 /// underlying CSR width (as in the case of event managers, LEDs,
 /// etc.), manipulating bitmaps
-pub trait IntLike: TRIntLike {
+pub trait UIntLike: TRUIntLike {
     fn one() -> Self;
     fn max() -> Self {
         !Self::zero()
     }
 }
 
-// Implement the custom IntLike trait for all required base integer
+// Implement the custom UIntLike trait for all required base integer
 // types
-impl IntLike for u8 {
+impl UIntLike for u8 {
     fn one() -> Self {
         1
     }
 }
-impl IntLike for u16 {
+impl UIntLike for u16 {
     fn one() -> Self {
         1
     }
 }
-impl IntLike for u32 {
+impl UIntLike for u32 {
     fn one() -> Self {
         1
     }
 }
-impl IntLike for u64 {
+impl UIntLike for u64 {
     fn one() -> Self {
         1
     }
 }
-impl IntLike for u128 {
+impl UIntLike for u128 {
     fn one() -> Self {
         1
     }
@@ -91,7 +91,7 @@ impl IntLike for u128 {
 /// This must be public to prevent generating a `private_in_public`
 /// but really should not be used directly. Use `Read` instead, which
 /// also incorporates this functionality.
-pub trait BaseReadableRegister<T: IntLike> {
+pub trait BaseReadableRegister<T: UIntLike> {
     type Reg: RegisterLongName;
     const REG_WIDTH: usize;
 
@@ -107,7 +107,7 @@ pub trait BaseReadableRegister<T: IntLike> {
 /// This must be public to prevent generating a `private_in_public`
 /// but really should not be used directly. Use `Write` instead, which
 /// also incorporates this functionality.
-pub trait BaseWriteableRegister<T: IntLike> {
+pub trait BaseWriteableRegister<T: UIntLike> {
     type Reg: RegisterLongName;
     const REG_WIDTH: usize;
 
@@ -121,7 +121,7 @@ pub trait BaseWriteableRegister<T: IntLike> {
 /// `tock_registers::registers::{ReadOnly, ReadWrite}` types
 ///
 /// It is automatically implemented for all `BaseReadableRegister`s
-pub trait Read<T: IntLike> {
+pub trait Read<T: UIntLike> {
     type Reg: RegisterLongName;
     const REG_WIDTH: usize;
 
@@ -156,7 +156,7 @@ pub trait Read<T: IntLike> {
 /// `tock_registers::registers::{WriteOnly, ReadWrite}` types
 ///
 /// It is automatically implemented for all `BaseWriteableRegister`s
-pub trait Write<T: IntLike> {
+pub trait Write<T: UIntLike> {
     type Reg: RegisterLongName;
     const REG_WIDTH: usize;
 
@@ -175,7 +175,7 @@ pub trait Write<T: IntLike> {
 ///
 /// It is automatically implemented for all types that are both
 /// `BaseReadableRegister` and `BaseWriteableRegister`s
-pub trait ReadWrite<T: IntLike>: Read<T> + Write<T> {
+pub trait ReadWrite<T: UIntLike>: Read<T> + Write<T> {
     const REG_WIDTH: usize;
 
     /// Write the value of one or more fields, leaving the other
@@ -195,7 +195,7 @@ pub trait ReadWrite<T: IntLike>: Read<T> + Write<T> {
 // Implement the [`Read`] trait (providing high-level methods to read
 // specific fields of a register) for every type implementing the
 // [`BaseReadableRegister`] trait.
-impl<R, T: IntLike> Read<T> for R
+impl<R, T: UIntLike> Read<T> for R
 where
     R: BaseReadableRegister<T>,
 {
@@ -244,7 +244,7 @@ where
 // Implement the [`Write`] trait (providing high-level methods to set
 // specific fields of a register) for every type implementing the
 // [`BaseWritableRegister`] trait.
-impl<R, T: IntLike> Write<T> for R
+impl<R, T: UIntLike> Write<T> for R
 where
     R: BaseWriteableRegister<T>,
 {
@@ -265,7 +265,7 @@ where
 // Implement the [`ReadWrite`] trait (providing high-level methods to
 // update specific fields of a register) for every type implementing
 // both the [`Read`] and [`Write`] trait.
-impl<R, T: IntLike> ReadWrite<T> for R
+impl<R, T: UIntLike> ReadWrite<T> for R
 where
     R: Read<T> + Write<T>,
 {
@@ -431,19 +431,19 @@ impl LiteXSoCRegisterConfiguration for LiteXSoCRegistersC32B32 {
 /// [`RegisterLongName`] until generic associated types stabilize in
 /// Rust. Please see the [`LiteXSoCRegisterConfiguration`]
 /// documentation for more information.
-pub struct ReadRegWrapper<'a, T: IntLike, N: RegisterLongName, R: BaseReadableRegister<T>>(
+pub struct ReadRegWrapper<'a, T: UIntLike, N: RegisterLongName, R: BaseReadableRegister<T>>(
     &'a R,
     PhantomData<T>,
     PhantomData<N>,
 );
-impl<'a, T: IntLike, N: RegisterLongName, R: BaseReadableRegister<T>> ReadRegWrapper<'a, T, N, R> {
+impl<'a, T: UIntLike, N: RegisterLongName, R: BaseReadableRegister<T>> ReadRegWrapper<'a, T, N, R> {
     #[inline]
     pub fn wrap(reg: &'a R) -> Self {
         ReadRegWrapper(reg, PhantomData, PhantomData)
     }
 }
 
-impl<T: IntLike, N: RegisterLongName, R: BaseReadableRegister<T>> BaseReadableRegister<T>
+impl<T: UIntLike, N: RegisterLongName, R: BaseReadableRegister<T>> BaseReadableRegister<T>
     for ReadRegWrapper<'_, T, N, R>
 {
     type Reg = N;
@@ -462,12 +462,12 @@ impl<T: IntLike, N: RegisterLongName, R: BaseReadableRegister<T>> BaseReadableRe
 /// [`RegisterLongName`] until generic associated types stabilize in
 /// Rust. Please see the [`LiteXSoCRegisterConfiguration`]
 /// documentation for more information.
-pub struct WriteRegWrapper<'a, T: IntLike, N: RegisterLongName, R: BaseWriteableRegister<T>>(
+pub struct WriteRegWrapper<'a, T: UIntLike, N: RegisterLongName, R: BaseWriteableRegister<T>>(
     &'a R,
     PhantomData<T>,
     PhantomData<N>,
 );
-impl<'a, T: IntLike, N: RegisterLongName, R: BaseWriteableRegister<T>>
+impl<'a, T: UIntLike, N: RegisterLongName, R: BaseWriteableRegister<T>>
     WriteRegWrapper<'a, T, N, R>
 {
     #[inline]
@@ -476,7 +476,7 @@ impl<'a, T: IntLike, N: RegisterLongName, R: BaseWriteableRegister<T>>
     }
 }
 
-impl<T: IntLike, N: RegisterLongName, R: BaseWriteableRegister<T>> BaseWriteableRegister<T>
+impl<T: UIntLike, N: RegisterLongName, R: BaseWriteableRegister<T>> BaseWriteableRegister<T>
     for WriteRegWrapper<'_, T, N, R>
 {
     type Reg = N;
@@ -497,13 +497,13 @@ impl<T: IntLike, N: RegisterLongName, R: BaseWriteableRegister<T>> BaseWriteable
 /// documentation for more information.
 pub struct ReadWriteRegWrapper<
     'a,
-    T: IntLike,
+    T: UIntLike,
     N: RegisterLongName,
     R: BaseReadableRegister<T> + BaseWriteableRegister<T>,
 >(&'a R, PhantomData<T>, PhantomData<N>);
 impl<
         'a,
-        T: IntLike,
+        T: UIntLike,
         N: RegisterLongName,
         R: BaseReadableRegister<T> + BaseWriteableRegister<T>,
     > ReadWriteRegWrapper<'a, T, N, R>
@@ -514,7 +514,7 @@ impl<
     }
 }
 
-impl<T: IntLike, N: RegisterLongName, R: BaseReadableRegister<T> + BaseWriteableRegister<T>>
+impl<T: UIntLike, N: RegisterLongName, R: BaseReadableRegister<T> + BaseWriteableRegister<T>>
     BaseReadableRegister<T> for ReadWriteRegWrapper<'_, T, N, R>
 {
     type Reg = N;
@@ -526,7 +526,7 @@ impl<T: IntLike, N: RegisterLongName, R: BaseReadableRegister<T> + BaseWriteable
     }
 }
 
-impl<T: IntLike, N: RegisterLongName, R: BaseReadableRegister<T> + BaseWriteableRegister<T>>
+impl<T: UIntLike, N: RegisterLongName, R: BaseReadableRegister<T> + BaseWriteableRegister<T>>
     BaseWriteableRegister<T> for ReadWriteRegWrapper<'_, T, N, R>
 {
     type Reg = N;

--- a/libraries/riscv-csr/src/csr.rs
+++ b/libraries/riscv-csr/src/csr.rs
@@ -4,7 +4,7 @@ use core::marker::PhantomData;
 
 use tock_registers::fields::Field;
 use tock_registers::interfaces::{Readable, Writeable};
-use tock_registers::{IntLike, RegisterLongName};
+use tock_registers::{RegisterLongName, UIntLike};
 
 pub const MINSTRETH: usize = 0xB82;
 pub const MINSTRET: usize = 0xB02;
@@ -105,17 +105,17 @@ pub const PMPADDR63: usize = 0x3EF;
 
 /// Read/Write registers.
 #[derive(Copy, Clone)]
-pub struct ReadWriteRiscvCsr<T: IntLike, R: RegisterLongName, const V: usize> {
+pub struct ReadWriteRiscvCsr<T: UIntLike, R: RegisterLongName, const V: usize> {
     associated_register: PhantomData<R>,
     associated_length: PhantomData<T>,
 }
 
 // morally speaking, these should be implemented; however not yet needed
-//pub struct WriteOnlyRiscvCsr<T: IntLike, R: RegisterLongName = ()> {
+//pub struct WriteOnlyRiscvCsr<T: UIntLike, R: RegisterLongName = ()> {
 //value: T,
 //associated_register: PhantomData<R>}
 
-//pub struct ReadOnlyRiscvCsr<T: IntLike, R: RegisterLongName = ()> {
+//pub struct ReadOnlyRiscvCsr<T: UIntLike, R: RegisterLongName = ()> {
 //value: T,
 //associated_register: PhantomData<R>}
 

--- a/libraries/tock-register-interface/README.md
+++ b/libraries/tock-register-interface/README.md
@@ -204,7 +204,7 @@ methods, through the implementations of the `Readable`, `Writeable`
 and `ReadWriteable` traits respectively:
 
 ```rust
-ReadOnly<T: IntLike, R: RegisterLongName = ()>: Readable
+ReadOnly<T: UIntLike, R: RegisterLongName = ()>: Readable
 .get() -> T                                    // Get the raw register value
 .read(field: Field<T, R>) -> T                 // Read the value of the given field
 .read_as_enum<E>(field: Field<T, R>) -> Option<E> // Read value of the given field as a enum member
@@ -213,11 +213,11 @@ ReadOnly<T: IntLike, R: RegisterLongName = ()>: Readable
 .matches_all(value: FieldValue<T, R>) -> bool  // Check if all specified parts of a field match
 .extract() -> LocalRegisterCopy<T, R>          // Make local copy of register
 
-WriteOnly<T: IntLike, R: RegisterLongName = ()>: Writeable
+WriteOnly<T: UIntLike, R: RegisterLongName = ()>: Writeable
 .set(value: T)                                 // Set the raw register value
 .write(value: FieldValue<T, R>)                // Write the value of one or more fields,
                                                //  overwriting other fields to zero
-ReadWrite<T: IntLike, R: RegisterLongName = ()>: Readable + Writeable + ReadWriteable
+ReadWrite<T: UIntLike, R: RegisterLongName = ()>: Readable + Writeable + ReadWriteable
 .get() -> T                                    // Get the raw register value
 .set(value: T)                                 // Set the raw register value
 .read(field: Field<T, R>) -> T                 // Read the value of the given field
@@ -234,7 +234,7 @@ ReadWrite<T: IntLike, R: RegisterLongName = ()>: Readable + Writeable + ReadWrit
 .matches_all(value: FieldValue<T, R>) -> bool  // Check if all specified parts of a field match
 .extract() -> LocalRegisterCopy<T, R>          // Make local copy of register
 
-Aliased<T: IntLike, R: RegisterLongName = (), W: RegisterLongName = ()>: Readable + Writeable
+Aliased<T: UIntLike, R: RegisterLongName = (), W: RegisterLongName = ()>: Readable + Writeable
 .get() -> T                                    // Get the raw register value
 .set(value: T)                                 // Set the raw register value
 .read(field: Field<T, R>) -> T                 // Read the value of the given field
@@ -250,7 +250,7 @@ Aliased<T: IntLike, R: RegisterLongName = (), W: RegisterLongName = ()>: Readabl
 The `Aliased` type represents cases where read-only and write-only registers,
 with different meanings, are aliased to the same memory location.
 
-The first type parameter (the `IntLike` type) is `u8`, `u16`, `u32`,
+The first type parameter (the `UIntLike` type) is `u8`, `u16`, `u32`,
 `u64`, `u128` or `usize`.
 
 ## Example: Using registers and bitfields

--- a/libraries/tock-register-interface/src/fields.rs
+++ b/libraries/tock-register-interface/src/fields.rs
@@ -9,7 +9,7 @@
 //!
 //! A specific section (bitfield) in a register is described by the
 //! [`Field`] type, consisting of an unshifted bitmask over the base
-//! register [`IntLike`](crate::IntLike) type, and a shift
+//! register [`UIntLike`](crate::UIntLike) type, and a shift
 //! parameter. It is further associated with a specific
 //! [`RegisterLongName`], which can prevent its use with incompatible
 //! registers.
@@ -68,18 +68,18 @@
 use core::marker::PhantomData;
 use core::ops::{Add, AddAssign};
 
-use crate::{IntLike, RegisterLongName};
+use crate::{RegisterLongName, UIntLike};
 
 /// Specific section of a register.
 ///
 /// For the Field, the mask is unshifted, ie. the LSB should always be set.
-pub struct Field<T: IntLike, R: RegisterLongName> {
+pub struct Field<T: UIntLike, R: RegisterLongName> {
     pub mask: T,
     pub shift: usize,
     associated_register: PhantomData<R>,
 }
 
-impl<T: IntLike, R: RegisterLongName> Field<T, R> {
+impl<T: UIntLike, R: RegisterLongName> Field<T, R> {
     pub const fn new(mask: T, shift: usize) -> Field<T, R> {
         Field {
             mask: mask,
@@ -113,7 +113,7 @@ impl<T: IntLike, R: RegisterLongName> Field<T, R> {
 //
 //    #[automatically_derived]
 //    #[allow(unused_qualifications)]
-//    impl<T: ::core::marker::Copy + IntLike,
+//    impl<T: ::core::marker::Copy + UIntLike,
 //         R: ::core::marker::Copy + RegisterLongName>
 //            ::core::marker::Copy for Field<T, R> {}
 //
@@ -122,7 +122,7 @@ impl<T: IntLike, R: RegisterLongName> Field<T, R> {
 // Manually implementing Clone and Copy works around this issue.
 //
 // Relevant Rust issue: https://github.com/rust-lang/rust/issues/26925
-impl<T: IntLike, R: RegisterLongName> Clone for Field<T, R> {
+impl<T: UIntLike, R: RegisterLongName> Clone for Field<T, R> {
     fn clone(&self) -> Self {
         Field {
             mask: self.mask,
@@ -131,7 +131,7 @@ impl<T: IntLike, R: RegisterLongName> Clone for Field<T, R> {
         }
     }
 }
-impl<T: IntLike, R: RegisterLongName> Copy for Field<T, R> {}
+impl<T: UIntLike, R: RegisterLongName> Copy for Field<T, R> {}
 
 macro_rules! Field_impl_for {
     ($type:ty) => {
@@ -155,7 +155,7 @@ Field_impl_for!(usize);
 /// For the FieldValue, the masks and values are shifted into their actual
 /// location in the register.
 #[derive(Copy, Clone)]
-pub struct FieldValue<T: IntLike, R: RegisterLongName> {
+pub struct FieldValue<T: UIntLike, R: RegisterLongName> {
     mask: T,
     pub value: T,
     associated_register: PhantomData<R>,
@@ -193,7 +193,7 @@ FieldValue_impl_for!(u64);
 FieldValue_impl_for!(u128);
 FieldValue_impl_for!(usize);
 
-impl<T: IntLike, R: RegisterLongName> FieldValue<T, R> {
+impl<T: UIntLike, R: RegisterLongName> FieldValue<T, R> {
     /// Get the raw bitmask represented by this FieldValue.
     #[inline]
     pub fn mask(&self) -> T {
@@ -225,7 +225,7 @@ impl<T: IntLike, R: RegisterLongName> FieldValue<T, R> {
 }
 
 // Combine two fields with the addition operator
-impl<T: IntLike, R: RegisterLongName> Add for FieldValue<T, R> {
+impl<T: UIntLike, R: RegisterLongName> Add for FieldValue<T, R> {
     type Output = Self;
 
     #[inline]
@@ -239,7 +239,7 @@ impl<T: IntLike, R: RegisterLongName> Add for FieldValue<T, R> {
 }
 
 // Combine two fields with the += operator
-impl<T: IntLike, R: RegisterLongName> AddAssign for FieldValue<T, R> {
+impl<T: UIntLike, R: RegisterLongName> AddAssign for FieldValue<T, R> {
     #[inline]
     fn add_assign(&mut self, rhs: FieldValue<T, R>) {
         self.mask |= rhs.mask;

--- a/libraries/tock-register-interface/src/interfaces.rs
+++ b/libraries/tock-register-interface/src/interfaces.rs
@@ -7,7 +7,7 @@
 //!
 //! Each trait has two associated type parameters, namely:
 //!
-//! - `T`: [`IntLike`](crate::IntLike), indicating the underlying
+//! - `T`: [`UIntLike`](crate::UIntLike), indicating the underlying
 //!   integer type used to represent the register's raw contents.
 //!
 //! - `R`: [`RegisterLongName`](crate::RegisterLongName), functioning
@@ -148,7 +148,7 @@
 //! ```
 
 use crate::fields::{Field, FieldValue, TryFromValue};
-use crate::{IntLike, LocalRegisterCopy, RegisterLongName};
+use crate::{LocalRegisterCopy, RegisterLongName, UIntLike};
 
 /// Readable register
 ///
@@ -161,7 +161,7 @@ use crate::{IntLike, LocalRegisterCopy, RegisterLongName};
 /// [`Readable`] is the same as that of [`Writeable`] (i.e. not for
 /// [`Aliased`](crate::registers::Aliased) registers).
 pub trait Readable {
-    type T: IntLike;
+    type T: UIntLike;
     type R: RegisterLongName;
 
     /// Get the raw register value
@@ -218,7 +218,7 @@ pub trait Readable {
 /// [`Readable`] is the same as that of [`Writeable`] (i.e. not for
 /// [`Aliased`](crate::registers::Aliased) registers).
 pub trait Writeable {
-    type T: IntLike;
+    type T: UIntLike;
     type R: RegisterLongName;
 
     /// Set the raw register value
@@ -252,14 +252,14 @@ pub trait Writeable {
 /// and [`Writeable`], as long as [`Readable::R`] == [`Writeable::R`]
 /// (i.e. not for [`Aliased`](crate::registers::Aliased) registers).
 pub trait ReadWriteable {
-    type T: IntLike;
+    type T: UIntLike;
     type R: RegisterLongName;
 
     /// Write the value of one or more fields, leaving the other fields unchanged
     fn modify(&self, field: FieldValue<Self::T, Self::R>);
 }
 
-impl<T: IntLike, R: RegisterLongName, S> ReadWriteable for S
+impl<T: UIntLike, R: RegisterLongName, S> ReadWriteable for S
 where
     S: Readable<T = T, R = R> + Writeable<T = T, R = R>,
 {

--- a/libraries/tock-register-interface/src/lib.rs
+++ b/libraries/tock-register-interface/src/lib.rs
@@ -73,14 +73,14 @@ use core::ops::{BitAnd, BitOr, BitOrAssign, Not, Shl, Shr};
 
 /// Trait representing the base type of registers.
 ///
-/// IntLike defines basic properties of types required to
+/// UIntLike defines basic properties of types required to
 /// read/write/modify a register through its methods and supertrait
 /// requirements.
 ///
-/// It features a range of default implementations for common integer
-/// types, such as [`u8`], [`u16`], [`u32`], [`u64`], [`u128`] and
-/// [`usize`].
-pub trait IntLike:
+/// It features a range of default implementations for common unsigned
+/// integer types, such as [`u8`], [`u16`], [`u32`], [`u64`], [`u128`],
+/// and [`usize`].
+pub trait UIntLike:
     BitAnd<Output = Self>
     + BitOr<Output = Self>
     + BitOrAssign
@@ -94,19 +94,19 @@ pub trait IntLike:
     /// Return the representation of the value `0` in the implementing
     /// type.
     ///
-    /// This can be used to acquire values of the [`IntLike`] type,
+    /// This can be used to acquire values of the [`UIntLike`] type,
     /// even in generic implementations. For instance, to get the
-    /// value `1`, one can use `<T as IntLike>::zero() + 1`. To get
+    /// value `1`, one can use `<T as UIntLike>::zero() + 1`. To get
     /// the largest representable value, use a bitwise negation: `~(<T
-    /// as IntLike>::zero())`.
+    /// as UIntLike>::zero())`.
     fn zero() -> Self;
 }
 
-// Helper macro for implementing the IntLike trait on differrent
+// Helper macro for implementing the UIntLike trait on differrent
 // types.
-macro_rules! IntLike_impl_for {
+macro_rules! UIntLike_impl_for {
     ($type:ty) => {
-        impl IntLike for $type {
+        impl UIntLike for $type {
             fn zero() -> Self {
                 0
             }
@@ -114,12 +114,12 @@ macro_rules! IntLike_impl_for {
     };
 }
 
-IntLike_impl_for!(u8);
-IntLike_impl_for!(u16);
-IntLike_impl_for!(u32);
-IntLike_impl_for!(u64);
-IntLike_impl_for!(u128);
-IntLike_impl_for!(usize);
+UIntLike_impl_for!(u8);
+UIntLike_impl_for!(u16);
+UIntLike_impl_for!(u32);
+UIntLike_impl_for!(u64);
+UIntLike_impl_for!(u128);
+UIntLike_impl_for!(usize);
 
 /// Descriptive name for each register.
 pub trait RegisterLongName {}

--- a/libraries/tock-register-interface/src/local_register.rs
+++ b/libraries/tock-register-interface/src/local_register.rs
@@ -5,7 +5,7 @@ use core::fmt;
 use core::marker::PhantomData;
 
 use crate::fields::{Field, FieldValue, TryFromValue};
-use crate::{IntLike, RegisterLongName};
+use crate::{RegisterLongName, UIntLike};
 
 /// A read-write copy of register contents.
 ///
@@ -28,12 +28,12 @@ use crate::{IntLike, RegisterLongName};
 /// [`Writeable`](crate::interfaces::Writeable) and
 /// [`ReadWriteable`](crate::interfaces::ReadWriteable).
 #[derive(Copy, Clone)]
-pub struct LocalRegisterCopy<T: IntLike, R: RegisterLongName = ()> {
+pub struct LocalRegisterCopy<T: UIntLike, R: RegisterLongName = ()> {
     value: T,
     associated_register: PhantomData<R>,
 }
 
-impl<T: IntLike, R: RegisterLongName> LocalRegisterCopy<T, R> {
+impl<T: UIntLike, R: RegisterLongName> LocalRegisterCopy<T, R> {
     pub const fn new(value: T) -> Self {
         LocalRegisterCopy {
             value: value,
@@ -103,14 +103,14 @@ impl<T: IntLike, R: RegisterLongName> LocalRegisterCopy<T, R> {
     }
 }
 
-impl<T: IntLike + fmt::Debug, R: RegisterLongName> fmt::Debug for LocalRegisterCopy<T, R> {
+impl<T: UIntLike + fmt::Debug, R: RegisterLongName> fmt::Debug for LocalRegisterCopy<T, R> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{:?}", self.value)
     }
 }
 
-// Helper macro to implement From<LocalRegisterCopy<T: IntLike>, R>>
-// for <T: IntLike>
+// Helper macro to implement From<LocalRegisterCopy<T: UIntLike>, R>>
+// for <T: UIntLike>
 macro_rules! From_impl_for {
     ($type:ty) => {
         impl<R: RegisterLongName> From<LocalRegisterCopy<$type, R>> for $type {

--- a/libraries/tock-register-interface/src/registers.rs
+++ b/libraries/tock-register-interface/src/registers.rs
@@ -20,7 +20,7 @@ use core::cell::UnsafeCell;
 use core::marker::PhantomData;
 
 use crate::interfaces::{Readable, Writeable};
-use crate::{IntLike, RegisterLongName};
+use crate::{RegisterLongName, UIntLike};
 
 /// Read/Write registers.
 ///
@@ -31,11 +31,11 @@ use crate::{IntLike, RegisterLongName};
 // To successfully alias this structure onto hardware registers in memory, this
 // struct must be exactly the size of the `T`.
 #[repr(transparent)]
-pub struct ReadWrite<T: IntLike, R: RegisterLongName = ()> {
+pub struct ReadWrite<T: UIntLike, R: RegisterLongName = ()> {
     value: UnsafeCell<T>,
     associated_register: PhantomData<R>,
 }
-impl<T: IntLike, R: RegisterLongName> Readable for ReadWrite<T, R> {
+impl<T: UIntLike, R: RegisterLongName> Readable for ReadWrite<T, R> {
     type T = T;
     type R = R;
 
@@ -44,7 +44,7 @@ impl<T: IntLike, R: RegisterLongName> Readable for ReadWrite<T, R> {
         unsafe { ::core::ptr::read_volatile(self.value.get()) }
     }
 }
-impl<T: IntLike, R: RegisterLongName> Writeable for ReadWrite<T, R> {
+impl<T: UIntLike, R: RegisterLongName> Writeable for ReadWrite<T, R> {
     type T = T;
     type R = R;
 
@@ -61,11 +61,11 @@ impl<T: IntLike, R: RegisterLongName> Writeable for ReadWrite<T, R> {
 // To successfully alias this structure onto hardware registers in memory, this
 // struct must be exactly the size of the `T`.
 #[repr(transparent)]
-pub struct ReadOnly<T: IntLike, R: RegisterLongName = ()> {
+pub struct ReadOnly<T: UIntLike, R: RegisterLongName = ()> {
     value: T,
     associated_register: PhantomData<R>,
 }
-impl<T: IntLike, R: RegisterLongName> Readable for ReadOnly<T, R> {
+impl<T: UIntLike, R: RegisterLongName> Readable for ReadOnly<T, R> {
     type T = T;
     type R = R;
 
@@ -82,11 +82,11 @@ impl<T: IntLike, R: RegisterLongName> Readable for ReadOnly<T, R> {
 // To successfully alias this structure onto hardware registers in memory, this
 // struct must be exactly the size of the `T`.
 #[repr(transparent)]
-pub struct WriteOnly<T: IntLike, R: RegisterLongName = ()> {
+pub struct WriteOnly<T: UIntLike, R: RegisterLongName = ()> {
     value: UnsafeCell<T>,
     associated_register: PhantomData<R>,
 }
-impl<T: IntLike, R: RegisterLongName> Writeable for WriteOnly<T, R> {
+impl<T: UIntLike, R: RegisterLongName> Writeable for WriteOnly<T, R> {
     type T = T;
     type R = R;
 
@@ -112,11 +112,11 @@ impl<T: IntLike, R: RegisterLongName> Writeable for WriteOnly<T, R> {
 // To successfully alias this structure onto hardware registers in memory, this
 // struct must be exactly the size of the `T`.
 #[repr(transparent)]
-pub struct Aliased<T: IntLike, R: RegisterLongName = (), W: RegisterLongName = ()> {
+pub struct Aliased<T: UIntLike, R: RegisterLongName = (), W: RegisterLongName = ()> {
     value: UnsafeCell<T>,
     associated_register: PhantomData<(R, W)>,
 }
-impl<T: IntLike, R: RegisterLongName, W: RegisterLongName> Readable for Aliased<T, R, W> {
+impl<T: UIntLike, R: RegisterLongName, W: RegisterLongName> Readable for Aliased<T, R, W> {
     type T = T;
     type R = R;
 
@@ -125,7 +125,7 @@ impl<T: IntLike, R: RegisterLongName, W: RegisterLongName> Readable for Aliased<
         unsafe { ::core::ptr::read_volatile(self.value.get()) }
     }
 }
-impl<T: IntLike, R: RegisterLongName, W: RegisterLongName> Writeable for Aliased<T, R, W> {
+impl<T: UIntLike, R: RegisterLongName, W: RegisterLongName> Writeable for Aliased<T, R, W> {
     type T = T;
     type R = W;
 
@@ -148,12 +148,12 @@ impl<T: IntLike, R: RegisterLongName, W: RegisterLongName> Writeable for Aliased
 // To successfully alias this structure onto hardware registers in memory, this
 // struct must be exactly the size of the `T`.
 #[repr(transparent)]
-pub struct InMemoryRegister<T: IntLike, R: RegisterLongName = ()> {
+pub struct InMemoryRegister<T: UIntLike, R: RegisterLongName = ()> {
     value: UnsafeCell<T>,
     associated_register: PhantomData<R>,
 }
 
-impl<T: IntLike, R: RegisterLongName> InMemoryRegister<T, R> {
+impl<T: UIntLike, R: RegisterLongName> InMemoryRegister<T, R> {
     pub const fn new(value: T) -> Self {
         InMemoryRegister {
             value: UnsafeCell::new(value),
@@ -161,7 +161,7 @@ impl<T: IntLike, R: RegisterLongName> InMemoryRegister<T, R> {
         }
     }
 }
-impl<T: IntLike, R: RegisterLongName> Readable for InMemoryRegister<T, R> {
+impl<T: UIntLike, R: RegisterLongName> Readable for InMemoryRegister<T, R> {
     type T = T;
     type R = R;
 
@@ -170,7 +170,7 @@ impl<T: IntLike, R: RegisterLongName> Readable for InMemoryRegister<T, R> {
         unsafe { ::core::ptr::read_volatile(self.value.get()) }
     }
 }
-impl<T: IntLike, R: RegisterLongName> Writeable for InMemoryRegister<T, R> {
+impl<T: UIntLike, R: RegisterLongName> Writeable for InMemoryRegister<T, R> {
     type T = T;
     type R = R;
 


### PR DESCRIPTION
### Pull Request Overview

tock-registers: Rename `IntLike` to `UIntLike`

This better captures the semantics of this interfaces.

Closes #2641.

Depends on #2618.


### Testing Strategy

This pull request was tested by compiling.


### TODO or Help Wanted

N/A.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
