### PR TITLE
rp2040: SysInfo peripheral

### DIFF
--- a/boards/raspberry_pi_pico/src/main.rs
+++ b/boards/raspberry_pi_pico/src/main.rs
@@ -33,6 +33,8 @@ use rp2040::resets::Peripheral;
 use rp2040::timer::RPTimer;
 mod io;
 
+use rp2040::sysinfo;
+
 mod flash_bootloader;
 
 /// Allocate memory for the stack
@@ -384,6 +386,17 @@ pub unsafe fn main() {
         temperature: temp,
         // monitor arm semihosting enable
     };
+
+    let platform_type = match peripherals.sysinfo.get_platform() {
+        sysinfo::Platform::Asic => "ASIC",
+        sysinfo::Platform::Fpga => "FPGA",
+    };
+
+    debug!(
+        "RP2040 Revision {} {}",
+        peripherals.sysinfo.get_revision(),
+        platform_type
+    );
     debug!("Initialization complete. Enter main loop");
 
     /// These symbols are defined in the linker script.

--- a/chips/rp2040/src/chip.rs
+++ b/chips/rp2040/src/chip.rs
@@ -10,6 +10,7 @@ use crate::clocks::Clocks;
 use crate::gpio::{RPPins, SIO};
 use crate::interrupts;
 use crate::resets::Resets;
+use crate::sysinfo;
 use crate::timer::RPTimer;
 use crate::uart::Uart;
 use crate::watchdog::Watchdog;
@@ -131,6 +132,7 @@ pub struct Rp2040DefaultPeripherals<'a> {
     pub pins: RPPins<'a>,
     pub uart0: Uart<'a>,
     pub adc: adc::Adc,
+    pub sysinfo: sysinfo::SysInfo,
 }
 
 impl Rp2040DefaultPeripherals<'_> {
@@ -145,6 +147,7 @@ impl Rp2040DefaultPeripherals<'_> {
             pins: RPPins::new(),
             uart0: Uart::new_uart0(),
             adc: adc::Adc::new(),
+            sysinfo: sysinfo::SysInfo::new(),
         }
     }
 }

--- a/chips/rp2040/src/lib.rs
+++ b/chips/rp2040/src/lib.rs
@@ -7,6 +7,7 @@ pub mod clocks;
 pub mod gpio;
 pub mod interrupts;
 pub mod resets;
+pub mod sysinfo;
 pub mod timer;
 pub mod uart;
 pub mod watchdog;

--- a/chips/rp2040/src/sysinfo.rs
+++ b/chips/rp2040/src/sysinfo.rs
@@ -1,0 +1,94 @@
+use kernel::common::registers::interfaces::Readable;
+use kernel::common::StaticRef;
+
+use kernel::common::registers::{register_bitfields, register_structs, ReadWrite};
+
+register_structs! {
+
+    SysInfoRegisters {
+
+        (0x000 => chip_id: ReadWrite<u32, CHIP_ID::Register>),
+
+        (0x004 => platform: ReadWrite<u32, PLATFORM::Register>),
+
+        (0x008 => _reserved1),
+
+        (0x040 => gitref_rp2040: ReadWrite<u32, GITREF_RP2040::Register>),
+
+        (0x440 => @END),
+    }
+}
+register_bitfields![u32,
+    CHIP_ID [
+
+        REVISION OFFSET(28) NUMBITS(4) [],
+
+        PART OFFSET(12) NUMBITS(16) [],
+
+        MANUFACTURER OFFSET(0) NUMBITS(12) []
+
+    ],
+    PLATFORM [
+        ASIC OFFSET(1) NUMBITS(1) [],
+
+        FPGA OFFSET(0) NUMBITS(1) []
+
+    ],
+    GITREF_RP2040 [
+        SOURCE_GIT_HASH OFFSET(0) NUMBITS(32) []
+    ]
+];
+
+const SYSINFO_BASE: StaticRef<SysInfoRegisters> =
+    unsafe { StaticRef::new(0x40000000 as *const SysInfoRegisters) };
+
+pub enum Platform {
+    Asic,
+    Fpga,
+}
+
+pub struct SysInfo {
+    registers: StaticRef<SysInfoRegisters>,
+}
+
+impl SysInfo {
+    pub const fn new() -> SysInfo {
+        SysInfo {
+            registers: SYSINFO_BASE,
+        }
+    }
+
+    pub fn get_revision(&self) -> u32 {
+        self.registers.chip_id.read(CHIP_ID::REVISION)
+    }
+
+    pub fn get_part(&self) -> u32 {
+        self.registers.chip_id.read(CHIP_ID::PART)
+    }
+
+    pub fn get_manufacturer_rp2040(&self) -> u32 {
+        self.registers.chip_id.read(CHIP_ID::MANUFACTURER)
+    }
+
+    pub fn get_asic(&self) -> u32 {
+        self.registers.platform.read(PLATFORM::ASIC)
+    }
+
+    pub fn get_fpga(&self) -> u32 {
+        self.registers.platform.read(PLATFORM::FPGA)
+    }
+
+    pub fn get_platform(&self) -> Platform {
+        if self.registers.platform.is_set(PLATFORM::ASIC) {
+            Platform::Asic
+        } else {
+            Platform::Fpga
+        }
+    }
+
+    pub fn get_git_ref(&self) -> u32 {
+        self.registers
+            .gitref_rp2040
+            .read(GITREF_RP2040::SOURCE_GIT_HASH)
+    }
+}

--- a/chips/rp2040/src/sysinfo.rs
+++ b/chips/rp2040/src/sysinfo.rs
@@ -15,7 +15,7 @@ register_structs! {
 
         (0x040 => gitref_rp2040: ReadWrite<u32, GITREF_RP2040::Register>),
 
-        (0x440 => @END),
+        (0x044 => @END),
     }
 }
 register_bitfields![u32,


### PR DESCRIPTION
### Pull Request Overview

This pull request adds the support for the SysInfo peripheral of RP2040


### Testing Strategy

This pull request was tested using raspberry pi pico. 


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
