### PR TITLE
Tock registers v0.7

### DIFF
--- a/libraries/tock-register-interface/CHANGELOG.md
+++ b/libraries/tock-register-interface/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## master
 
+## v0.7
+
+ - #2642: Rename `IntLike` to `UIntLike` to match semantics
+ - #2618: Reorganize, document, and feature-gate modules and exports
+ - #2589: Upgrade nightly for `const_fn` -> `const_fn_trait_bound`
+ - #2517: Use traits for accessing / manipulating registers
+ - #2512: Fix `Copy` and `Clone` implementation on `Field`
+ - #2300: Add support for `usize`
+ - #2220: Remove duplicate code, make local register copy read-write
+ - #2210: Add `u128` to `IntLike`
+ - #2197: Accept trailing comma in bitfields and bitmasks
+
 ## v0.6
 
  - #2095: Fix syntax errors and inconsistencies in documentation

--- a/libraries/tock-register-interface/Cargo.toml
+++ b/libraries/tock-register-interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tock-registers"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
 description = "Memory-Mapped I/O and register interface developed for Tock."
 homepage = "https://www.tockos.org/"


### PR DESCRIPTION
### Pull Request Overview

This PR formally releases v0.7 of tock-registers.

This should be the final v0.x release, we anticipate a v1.0 release with (ideally) no changes in the near future. However, this will also likely include extracting tock-registers from this repository and pointing Tock to it as a vendored dependency, and thus will likely hold until post Tock-2.0.

#### v0.7 CHANGELOG

 - #2642: Rename `IntLike` to `UIntLike` to match semantics
 - #2618: Reorganize, document, and feature-gate modules and exports
 - #2589: Upgrade nightly for `const_fn` -> `const_fn_trait_bound`
 - #2517: Use traits for accessing / manipulating registers
 - #2512: Fix `Copy` and `Clone` implementation on `Field`
 - #2300: Add support for `usize`
 - #2220: Remove duplicate code, make local register copy read-write
 - #2210: Add `u128` to `IntLike`
 - #2197: Accept trailing comma in bitfields and bitmasks


### Testing Strategy

This pull request only increments the version number; it relies on prior PRs for testing.

### TODO or Help Wanted

This pull request needs #2642 to merge first.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
