### PR TITLE
Add a Makefile rule to run cargo-bloat

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,12 @@ usage:
 	@echo "and usually 'make program' or 'make flash' to load Tock onto hardware."
 	@echo "Check out the README in your board's folder for more information."
 	@echo
+	@echo "There are a few helpful targets that can be run for all individual boards."
+	@echo "To run these, run 'make {target} from the board directory for any of the"
+	@echo "following targets:"
+	@echo "        cargobloat: Runs the cargo-bloat tool for attributing binary size"
+	@echo "        stack-analysis: Prints the 5 largest stack frames for the board"
+	@echo
 	@echo "This root Makefile has a few useful targets as well:"
 	@echo "        allaudit: Audit Cargo dependencies for all kernel sources"
 	@echo "       allboards: Compiles Tock for all supported boards"

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ usage:
 	@echo "Check out the README in your board's folder for more information."
 	@echo
 	@echo "There are a few helpful targets that can be run for all individual boards."
-	@echo "To run these, run 'make {target} from the board directory for any of the"
+	@echo "To run these, run 'make {target}' from the board directory for any of the"
 	@echo "following targets:"
 	@echo "        cargobloat: Runs the cargo-bloat tool for attributing binary size"
 	@echo "        stack-analysis: Prints the 5 largest stack frames for the board"

--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -191,6 +191,18 @@ ifneq (,$(findstring thumb,$(TARGET)))
   OBJDUMP_FLAGS += --arch-name=thumb
 endif
 
+# Additional flags that can be passed to cargo bloat via an
+# environment variable. Allows users to pass arbitrary flags
+# supported by cargo bloat to customize the output. By default,
+# pass an empty string.
+CARGO_BLOAT_FLAGS ?=
+
+
+# cargo bloat does not support -Z build-std, so we must remove it from cargo flags
+# see https://github.com/RazrFalcon/cargo-bloat/issues/62
+CARGO_FLAGS_TOCK_NO_BUILD_STD := $(filter-out -Z build-std=core,$(CARGO_FLAGS_TOCK))
+
+
 # Check whether the system already has a sha256sum application
 # present, if not use the custom shipped one
 ifeq (, $(shell sha256sum --version 2>/dev/null))
@@ -207,33 +219,35 @@ ifneq ($(V),)
   $(info *******************************************************)
   $(info TOCK KERNEL BUILD SYSTEM -- VERBOSE BUILD CONFIGURATION)
   $(info *******************************************************)
-  $(info MAKEFILE_COMMON_PATH = $(MAKEFILE_COMMON_PATH))
-  $(info TOCK_ROOT_DIRECTORY  = $(TOCK_ROOT_DIRECTORY))
-  $(info TARGET_DIRECTORY     = $(TARGET_DIRECTORY))
+  $(info MAKEFILE_COMMON_PATH          = $(MAKEFILE_COMMON_PATH))
+  $(info TOCK_ROOT_DIRECTORY           = $(TOCK_ROOT_DIRECTORY))
+  $(info TARGET_DIRECTORY              = $(TARGET_DIRECTORY))
   $(info )
-  $(info PLATFORM             = $(PLATFORM))
-  $(info TARGET               = $(TARGET))
-  $(info TOCK_KERNEL_VERSION  = $(TOCK_KERNEL_VERSION))
-  $(info RUSTC_FLAGS          = $(RUSTC_FLAGS))
-  $(info RUSTC_FLAGS_TOCK     = $(RUSTC_FLAGS_TOCK))
-  $(info MAKEFLAGS            = $(MAKEFLAGS))
-  $(info OBJDUMP_FLAGS        = $(OBJDUMP_FLAGS))
-  $(info OBJCOPY_FLAGS        = $(OBJCOPY_FLAGS))
-  $(info CARGO_FLAGS          = $(CARGO_FLAGS))
-  $(info CARGO_FLAGS_TOCK     = $(CARGO_FLAGS_TOCK))
-  $(info SIZE_FLAGS           = $(SIZE_FLAGS))
+  $(info PLATFORM                      = $(PLATFORM))
+  $(info TARGET                        = $(TARGET))
+  $(info TOCK_KERNEL_VERSION           = $(TOCK_KERNEL_VERSION))
+  $(info RUSTC_FLAGS                   = $(RUSTC_FLAGS))
+  $(info RUSTC_FLAGS_TOCK              = $(RUSTC_FLAGS_TOCK))
+  $(info MAKEFLAGS                     = $(MAKEFLAGS))
+  $(info OBJDUMP_FLAGS                 = $(OBJDUMP_FLAGS))
+  $(info OBJCOPY_FLAGS                 = $(OBJCOPY_FLAGS))
+  $(info CARGO_FLAGS                   = $(CARGO_FLAGS))
+  $(info CARGO_FLAGS_TOCK              = $(CARGO_FLAGS_TOCK))
+  $(info CARGO_FLAGS_TOCK_NO_BUILD_STD = $(CARGO_FLAGS_TOCK_NO_BUILD_STD))
+  $(info SIZE_FLAGS                    = $(SIZE_FLAGS))
+  $(info CARGO_BLOAT_FLAGS             = $(CARGO_BLOAT_FLAGS))
   $(info )
-  $(info TOOLCHAIN            = $(TOOLCHAIN))
-  $(info SIZE                 = $(SIZE))
-  $(info OBJCOPY              = $(OBJCOPY))
-  $(info OBJDUMP              = $(OBJDUMP))
-  $(info CARGO                = $(CARGO))
-  $(info RUSTUP               = $(RUSTUP))
-  $(info SHA256SUM            = $(SHA256SUM))
+  $(info TOOLCHAIN                     = $(TOOLCHAIN))
+  $(info SIZE                          = $(SIZE))
+  $(info OBJCOPY                       = $(OBJCOPY))
+  $(info OBJDUMP                       = $(OBJDUMP))
+  $(info CARGO                         = $(CARGO))
+  $(info RUSTUP                        = $(RUSTUP))
+  $(info SHA256SUM                     = $(SHA256SUM))
   $(info )
-  $(info cargo --version      = $(shell $(CARGO) --version))
-  $(info rustc --version      = $(shell rustc --version))
-  $(info rustup --version     = $(shell $(RUSTUP) --version))
+  $(info cargo --version               = $(shell $(CARGO) --version))
+  $(info rustc --version               = $(shell rustc --version))
+  $(info rustup --version              = $(shell $(RUSTUP) --version))
   $(info *******************************************************)
   $(info )
 endif
@@ -281,6 +295,27 @@ lst: $(TARGET_PATH)/release/$(PLATFORM).lst
 show-target:
 	$(info $(TARGET))
 
+# This rule is a copy of the rule used to build the release target, but
+# `cargo rustc` has been replaced with `cargo bloat`. `cargo bloat` replicates the
+# interface of `cargo build`, rather than `cargo rustc`, so we need to move
+# `RUSTC_FLAGS_FOR_BIN` into the `RUSTFLAGS` environment variable. This only means
+# that cargo cannot reuse built dependencies built using `cargo bloat`.
+# See the discussion on `RUSTC_FLAGS_FOR_BIN` above for additional details.
+# To pass additional flags to `cargo bloat`, populate the
+# CARGO_BLOAT_FLAGS environment variable, e.g. call
+# `CARGO_BLOAT_FLAGS=--crates make cargobloat`
+.PHONY: cargobloat
+cargobloat:
+	$(Q) $(CARGO) install cargo-bloat > /dev/null 2>&1 ||  echo 'Error: Failed to install cargo-bloat'
+	$(Q)RUSTFLAGS="$(RUSTC_FLAGS_TOCK) $(RUSTC_FLAGS_FOR_BIN)" CARGO_FLAGS="-Z build-std=core" $(CARGO) bloat $(CARGO_FLAGS_TOCK_NO_BUILD_STD) --bin $(PLATFORM) --release $(CARGO_BLOAT_FLAGS)
+
+# To pass additional flags to `cargo bloat`, populate the
+# CARGO_BLOAT_FLAGS environment variable, e.g. call
+# `CARGO_BLOAT_FLAGS=--crates make cargobloatnoinline`
+.PHONY: cargobloatnoinline
+cargobloatnoinline:
+	$(Q) $(CARGO) install cargo-bloat > \dev\null 2>&1 ||  echo 'Error: Failed to install cargo-bloat'
+	$(Q)RUSTFLAGS="$(RUSTC_FLAGS_TOCK) -C inline-threshold=0 $(RUSTC_FLAGS_FOR_BIN)" $(CARGO) bloat $(CARGO_FLAGS_TOCK) --bin $(PLATFORM) --release $(CARGO_BLOAT_FLAGS)
 
 .PHONY: stack-analysis
 #stack_analysis: RUSTC_FLAGS_TOCK += -Z emit-stack-sizes


### PR DESCRIPTION
### Pull Request Overview

Now, cargo-bloat can be run by running `make cargobloat` from any
`boards/xx` directory. This is useful for identifying large functions
in the kernel binary. To pass additional flags to the invocation of
cargo-bloat, set the BLOAT_FLAGS environment variable. It also adds
a Makefile rule to run cargo-bloat on a binary built with inlining
disabled (as much as possible) which can allow for more accurate
attribution of size.

The new `CARGO_FLAGS_TOCK_NO_BUILD_STD` variable ensures that
cargo-bloat works even when this rule is called from an out-of-tree
board that passes the `-Z build-std` flag to `CARGO_FLAGS_TOCK`. This is
necessary because cargo-bloat does not support that flag.

This change automatically installs cargo-bloat when this rule is run. As a result the first invocation might take awhile.

Example outputs for Imix:
```
hudsonayers: ~/upstream_tock/tock/boards/imix (cargo-bloat) $ make cargobloat
    Finished release [optimized + debuginfo] target(s) in 0.04s
    Analyzing target/thumbv7em-none-eabi/release/imix

File  .text     Size      Crate Name
0.2%   4.7%   8.2KiB  [Unknown] main
0.2%   4.1%   7.3KiB     kernel kernel::sched::Kernel::kernel_loop
0.1%   1.5%   2.6KiB   capsules capsules::net::ipv6::ipv6_send::IP6SendStruct<A>::send_next_fragment
0.1%   1.4%   2.6KiB  capsules? <capsules::adc::AdcDedicated<A> as kernel::driver::Driver>::command
0.1%   1.4%   2.5KiB   capsules capsules::net::sixlowpan::sixlowpan_compression::decompress
0.0%   1.2%   2.2KiB components capsules::process_console::ProcessConsole<C>::write_state
0.0%   1.2%   2.1KiB components <capsules::process_console::ProcessConsole<C> as kernel::hil::uart::TransmitClient>::transmitted_buffer
0.0%   1.2%   2.0KiB     kernel kernel::process_utilities::load_processes
0.0%   1.1%   2.0KiB   capsules capsules::net::ieee802154::Header::decode
0.0%   1.1%   1.9KiB   capsules <capsules::ieee802154::framer::Framer<M,A> as capsules::ieee802154::device::MacDevice>::prepare_data_frame
0.0%   1.1%   1.9KiB   capsules <capsules::net::udp::driver::UDPDriver as kernel::driver::Driver>::command
0.0%   1.0%   1.8KiB  capsules? <capsules::rf233::RF233<S> as kernel::hil::spi::SpiMasterClient>::read_write_done
0.0%   1.0%   1.7KiB   capsules <capsules::net::sixlowpan::sixlowpan_state::Sixlowpan<A,C> as capsules::ieee802154::device::RxClient>::receive
0.0%   0.8%   1.4KiB     kernel kernel::debug::panic_print
0.0%   0.7%   1.3KiB  capsules? <capsules::virtual_aes_ccm::MuxAES128CCM<A> as kernel::hil::symmetric_encryption::Client>::crypt_done
0.0%   0.7%   1.2KiB  capsules? <capsules::usb::usbc_client::Client<C> as kernel::hil::usb::Client>::ctrl_setup
0.0%   0.7%   1.2KiB        std <char as core::fmt::Debug>::fmt
0.0%   0.7%   1.2KiB  capsules? <capsules::adc::AdcDedicated<A> as kernel::hil::adc::HighSpeedClient>::samples_ready
0.0%   0.6%   1.0KiB     kernel <kernel::process_standard::ProcessStandard<C> as kernel::process::Process>::print_full_process
0.0%   0.6%   1.0KiB   capsules <capsules::net::ipv6::ipv6_recv::IP6RecvStruct as capsules::net::sixlowpan::sixlowpan_state::SixlowpanRxClient>::receive
2.1%  51.7%  91.0KiB            And 1058 smaller methods. Use -n N to show more.
4.0% 100.0% 176.2KiB            .text section size, the file size is 4.3MiB
```

```
hudsonayers: ~/upstream_tock/tock/boards/imix (cargo-bloat) $ BLOAT_FLAGS='--crates' make cargobloat
    Finished release [optimized + debuginfo] target(s) in 0.04s
    Analyzing target/thumbv7em-none-eabi/release/imix

File  .text     Size Crate
1.5%  38.6%  68.0KiB capsules
0.5%  13.2%  23.2KiB kernel
0.3%   7.8%  13.8KiB std
0.3%   7.2%  12.6KiB [Unknown]
0.2%   5.2%   9.1KiB sam4l
0.2%   4.4%   7.7KiB components
0.1%   1.5%   2.7KiB cortexm
0.0%   0.5%     876B imix
0.0%   0.1%     262B tock_cells
0.0%   0.1%     104B tock_tbf
4.0% 100.0% 176.2KiB .text section size, the file size is 4.3MiB

Note: numbers above are a result of guesswork. They are not 100% correct and never will be.
```

### Testing Strategy

This pull request was tested by running `make cargobloat` in the Imix/ directory.


### TODO or Help Wanted

N/A

### Documentation Updated

- [x] No updates are required.

### Formatting

- [x] Ran `make prepush`.
