### PR TITLE
raspberry_pi_pico: delete semihosting comment

### DIFF
--- a/boards/raspberry_pi_pico/src/main.rs
+++ b/boards/raspberry_pi_pico/src/main.rs
@@ -382,7 +382,6 @@ pub unsafe fn main() {
         console: console,
         adc: adc_syscall,
         temperature: temp,
-        // monitor arm semihosting enable
     };
     debug!("Initialization complete. Enter main loop");
 


### PR DESCRIPTION
### Pull Request Overview

This pull request deletes an unnecessary semihosting comment.


### Testing Strategy

N/A

### TODO or Help Wanted

N/A

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
