### PR TITLE
Warn about driver allocating a wrong grant

### DIFF
--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -1009,7 +1009,12 @@ impl Kernel {
                                                 Ok(old_upcall) => {
                                                     old_upcall.into_subscribe_success()
                                                 }
-                                                Err((new_upcall, err)) => {
+                                                Err((new_upcall, ErrorCode::NOMEM)) => {
+                                                    // Special case the handling of ErrorCode::NOMEM,
+                                                    // as it indicates a missing Grant allocation.
+                                                    // Depending on the kernel configuration, we
+                                                    // inform the user about the root cause of this
+                                                    // issue.
                                                     if config::CONFIG.trace_syscalls {
                                                         // It appears the Grant is still not allocated.
                                                         // Based on whether the number of allocated
@@ -1032,6 +1037,13 @@ impl Kernel {
                                                                 }
                                                             }
                                                     }
+                                                    new_upcall.into_subscribe_failure(ErrorCode::NOMEM)
+                                                }
+                                                Err((new_upcall, err)) => {
+                                                    // Handler for all errors other than
+                                                    // ErrorCode::NOMEM, for example when
+                                                    // the subscribe number exceeds the
+                                                    // number of Upcalls in the Grant region.
                                                     new_upcall.into_subscribe_failure(err)
                                                 }
                                             }

--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -974,11 +974,14 @@ impl Kernel {
                                 // grant.
                                 platform.with_driver(driver_number, |driver| match driver {
                                     Some(d) => {
-                                        // We just want the number of grants
-                                        // if the process is not active, 0 is just a placeholder
-                                        // as we will have nothing to compare it to
+                                        // For debugging purposes, query the number of allocated
+                                        // grants of the process. This can be used to determine
+                                        // whether the driver has allocated its Grant region
+                                        // correctly as requested. If the process is not active,
+                                        // we use 0 as a default value. This should never happen
+                                        // on a subscribe system call.
                                         //
-                                        // If `tracy_syscalls` is set to `false`, 
+                                        // If `trace_syscalls` is set to `false`,
                                         // hopefuly the compiler will optimize it out
                                         let allocated_grants_count = if config::CONFIG.trace_syscalls {
                                             process.grant_allocated_count().unwrap_or(0)
@@ -1008,15 +1011,26 @@ impl Kernel {
                                                 }
                                                 Err((new_upcall, err)) => {
                                                     if config::CONFIG.trace_syscalls {
-                                                        if let Some(currently_allocated_grants_count) = process.grant_allocated_count() {
-                                                            if currently_allocated_grants_count > allocated_grants_count {
-                                                                debug! ("[{:?}] error driver {} allocated wrong grant for upcalls", process.processid(), driver_number);
+                                                        // It appears the Grant is still not allocated.
+                                                        // Based on whether the number of allocated
+                                                        // Grants, we can determine whether the driver
+                                                        // has allocated an additional, unrelated Grant
+                                                        // region (with a different driver_num), or
+                                                        // none at all. Inform the developer accordingly.
+                                                        if let Some(currently_allocated_grants_count) =
+                                                            process.grant_allocated_count() {
+                                                                if currently_allocated_grants_count
+                                                                    > allocated_grants_count
+                                                                {
+                                                                    debug!("[{:?}] ERROR driver {} allocated wrong grant for upcalls",
+                                                                           process.processid(), driver_number);
+                                                                }
+                                                                else
+                                                                {
+                                                                    debug!("[{:?}] WARN driver {} did not allocate grant for upcalls",
+                                                                           process.processid(), driver_number);
+                                                                }
                                                             }
-                                                            else
-                                                            {
-                                                                debug! ("[{:?}] warn driver {} did not allocate grant for upcalls", process.processid(), driver_number);
-                                                            }
-                                                        }
                                                     }
                                                     new_upcall.into_subscribe_failure(err)
                                                 }

--- a/kernel/src/sched.rs
+++ b/kernel/src/sched.rs
@@ -974,6 +974,19 @@ impl Kernel {
                                 // grant.
                                 platform.with_driver(driver_number, |driver| match driver {
                                     Some(d) => {
+                                        // We just want the number of grants
+                                        // if the process is not active, 0 is just a placeholder
+                                        // as we will have nothing to compare it to
+                                        //
+                                        // If `tracy_syscalls` is set to `false`, 
+                                        // hopefuly the compiler will optimize it out
+                                        let allocated_grants_count = if config::CONFIG.trace_syscalls {
+                                            process.grant_allocated_count().unwrap_or(0)
+                                        }
+                                        else
+                                        {
+                                            0
+                                        };
                                         if d.allocate_grant(process.processid()).is_err() {
                                             // If the capsule errors on allocation
                                             // we assume it is because the grant
@@ -994,6 +1007,17 @@ impl Kernel {
                                                     old_upcall.into_subscribe_success()
                                                 }
                                                 Err((new_upcall, err)) => {
+                                                    if config::CONFIG.trace_syscalls {
+                                                        if let Some(currently_allocated_grants_count) = process.grant_allocated_count() {
+                                                            if currently_allocated_grants_count > allocated_grants_count {
+                                                                debug! ("[{:?}] error driver {} allocated wrong grant for upcalls", process.processid(), driver_number);
+                                                            }
+                                                            else
+                                                            {
+                                                                debug! ("[{:?}] warn driver {} did not allocate grant for upcalls", process.processid(), driver_number);
+                                                            }
+                                                        }
+                                                    }
                                                     new_upcall.into_subscribe_failure(err)
                                                 }
                                             }


### PR DESCRIPTION
### Pull Request Overview

This pull request tries to show a warning or an error if a driver does not allocate a grant or seems to allocate the wrong grant through `allocate_grant`.

The idea is simple: count the number of allocated grants before calling `allocate_grant`. If `allocate_grant` returns success but subscribe does not work, the reason is one of the two:
  1. the driver did not allocate a grant, in this case the number of allocated grants stays the same
  2. the driver allocated the wrong grant, a grant having a different driver number, in this case the number of grants is grater the the original number of grants

These actions are performed only If `trace_syscalls` is set to `true`.

### Testing Strategy


### TODO or Help Wanted


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
