### PR TITLE
kernel: schedule upcall, bool -> Result

### DIFF
--- a/capsules/src/adc.rs
+++ b/capsules/src/adc.rs
@@ -703,12 +703,14 @@ impl<A: hil::adc::Adc + hil::adc::AdcHighSpeed> hil::adc::Client for AdcDedicate
                 self.apps
                     .enter(*id, |_app, upcalls| {
                         calledback = true;
-                        upcalls.schedule_upcall(
-                            0,
-                            AdcMode::SingleSample as usize,
-                            self.channel.get(),
-                            sample as usize,
-                        );
+                        upcalls
+                            .schedule_upcall(
+                                0,
+                                AdcMode::SingleSample as usize,
+                                self.channel.get(),
+                                sample as usize,
+                            )
+                            .ok();
                     })
                     .map_err(|err| {
                         if err == kernel::procs::Error::NoSuchApp
@@ -726,12 +728,14 @@ impl<A: hil::adc::Adc + hil::adc::AdcHighSpeed> hil::adc::Client for AdcDedicate
                 self.apps
                     .enter(*id, |_app, upcalls| {
                         calledback = true;
-                        upcalls.schedule_upcall(
-                            0,
-                            AdcMode::ContinuousSample as usize,
-                            self.channel.get(),
-                            sample as usize,
-                        );
+                        upcalls
+                            .schedule_upcall(
+                                0,
+                                AdcMode::ContinuousSample as usize,
+                                self.channel.get(),
+                                sample as usize,
+                            )
+                            .ok();
                     })
                     .map_err(|err| {
                         if err == kernel::procs::Error::NoSuchApp
@@ -995,12 +999,14 @@ impl<A: hil::adc::Adc + hil::adc::AdcHighSpeed> hil::adc::HighSpeedClient for Ad
                         if perform_callback {
                             // actually schedule the callback
                             let len_chan = ((buf_len / 2) << 8) | (self.channel.get() & 0xFF);
-                            upcalls.schedule_upcall(
-                                0,
-                                self.mode.get() as usize,
-                                len_chan,
-                                buf_ptr as usize,
-                            );
+                            upcalls
+                                .schedule_upcall(
+                                    0,
+                                    self.mode.get() as usize,
+                                    len_chan,
+                                    buf_ptr as usize,
+                                )
+                                .ok();
 
                             // if the mode is SingleBuffer, the operation is
                             // complete. Clean up state
@@ -1349,12 +1355,9 @@ impl<'a> hil::adc::Client for AdcVirtualized<'a> {
             let _ = self.apps.enter(appid, |app, upcalls| {
                 app.pending_command = false;
                 let channel = app.channel;
-                upcalls.schedule_upcall(
-                    0,
-                    AdcMode::SingleSample as usize,
-                    channel,
-                    sample as usize,
-                );
+                upcalls
+                    .schedule_upcall(0, AdcMode::SingleSample as usize, channel, sample as usize)
+                    .ok();
             });
         });
     }

--- a/capsules/src/alarm.rs
+++ b/capsules/src/alarm.rs
@@ -262,12 +262,14 @@ impl<'a, A: Alarm<'a>> time::AlarmClient for AlarmDriver<'a, A> {
                 ) {
                     alarm.expiration = Expiration::Disabled;
                     self.num_armed.set(self.num_armed.get() - 1);
-                    upcalls.schedule_upcall(
-                        ALARM_CALLBACK_NUM,
-                        now.into_u32() as usize,
-                        reference.wrapping_add(dt) as usize,
-                        0,
-                    );
+                    upcalls
+                        .schedule_upcall(
+                            ALARM_CALLBACK_NUM,
+                            now.into_u32() as usize,
+                            reference.wrapping_add(dt) as usize,
+                            0,
+                        )
+                        .ok();
                 }
             }
         });

--- a/capsules/src/ambient_light.rs
+++ b/capsules/src/ambient_light.rs
@@ -104,7 +104,7 @@ impl hil::sensors::AmbientLightClient for AmbientLight<'_> {
         self.apps.each(|_, app, upcalls| {
             if app.pending {
                 app.pending = false;
-                upcalls.schedule_upcall(0, lux, 0, 0);
+                upcalls.schedule_upcall(0, lux, 0, 0).ok();
             }
         });
     }

--- a/capsules/src/analog_comparator.rs
+++ b/capsules/src/analog_comparator.rs
@@ -172,7 +172,7 @@ impl<'a, A: hil::analog_comparator::AnalogComparator<'a>> hil::analog_comparator
     fn fired(&self, channel: usize) {
         self.current_process.map(|appid| {
             let _ = self.grants.enter(*appid, |_app, upcalls| {
-                upcalls.schedule_upcall(0, channel, 0, 0);
+                upcalls.schedule_upcall(0, channel, 0, 0).ok();
             });
         });
     }

--- a/capsules/src/app_flash_driver.rs
+++ b/capsules/src/app_flash_driver.rs
@@ -124,7 +124,7 @@ impl hil::nonvolatile_storage::NonvolatileStorageClient<'static> for AppFlash<'_
         // Notify the current application that the command finished.
         self.current_app.take().map(|appid| {
             let _ = self.apps.enter(appid, |_app, upcalls| {
-                upcalls.schedule_upcall(0, 0, 0, 0);
+                upcalls.schedule_upcall(0, 0, 0, 0).ok();
             });
         });
 

--- a/capsules/src/ble_advertising_driver.rs
+++ b/capsules/src/ble_advertising_driver.rs
@@ -470,12 +470,9 @@ where
                         .unwrap_or(false);
 
                     if success {
-                        upcalls.schedule_upcall(
-                            0,
-                            kernel::into_statuscode(result),
-                            len as usize,
-                            0,
-                        );
+                        upcalls
+                            .schedule_upcall(0, kernel::into_statuscode(result), len as usize, 0)
+                            .ok();
                     }
                 }
 

--- a/capsules/src/button.rs
+++ b/capsules/src/button.rs
@@ -226,7 +226,9 @@ impl<'a, P: gpio::InterruptPin<'a>> gpio::ClientWithValue for Button<'a, P> {
         self.apps.each(|_, cntr, upcalls| {
             if cntr.subscribe_map & (1 << pin_num) != 0 {
                 interrupt_count.set(interrupt_count.get() + 1);
-                upcalls.schedule_upcall(UPCALL_NUM, pin_num as usize, button_state as usize, 0);
+                upcalls
+                    .schedule_upcall(UPCALL_NUM, pin_num as usize, button_state as usize, 0)
+                    .ok();
             }
         });
 

--- a/capsules/src/buzzer_driver.rs
+++ b/capsules/src/buzzer_driver.rs
@@ -172,7 +172,7 @@ impl<'a, A: hil::time::Alarm<'a>> hil::time::AlarmClient for Buzzer<'a, A> {
         // Mark the active app as None and see if there is a callback.
         self.active_app.take().map(|app_id| {
             let _ = self.apps.enter(app_id, |_app, upcalls| {
-                upcalls.schedule_upcall(0, 0, 0, 0);
+                upcalls.schedule_upcall(0, 0, 0, 0).ok();
             });
         });
 

--- a/capsules/src/console.rs
+++ b/capsules/src/console.rs
@@ -309,7 +309,7 @@ impl uart::TransmitClient for Console<'_> {
                             // Go ahead and signal the application
                             let written = app.write_len;
                             app.write_len = 0;
-                            upcalls.schedule_upcall(1, written, 0, 0);
+                            upcalls.schedule_upcall(1, written, 0, 0).ok();
                         }
                     }
                     Err(return_code) => {
@@ -317,7 +317,9 @@ impl uart::TransmitClient for Console<'_> {
                         app.write_len = 0;
                         app.write_remaining = 0;
                         app.pending_write = false;
-                        upcalls.schedule_upcall(1, kernel::into_statuscode(return_code), 0, 0);
+                        upcalls
+                            .schedule_upcall(1, kernel::into_statuscode(return_code), 0, 0)
+                            .ok();
                     }
                 }
             })
@@ -338,12 +340,9 @@ impl uart::TransmitClient for Console<'_> {
                                 app.write_len = 0;
                                 app.write_remaining = 0;
                                 app.pending_write = false;
-                                upcalls.schedule_upcall(
-                                    1,
-                                    kernel::into_statuscode(return_code),
-                                    0,
-                                    0,
-                                );
+                                upcalls
+                                    .schedule_upcall(1, kernel::into_statuscode(return_code), 0, 0)
+                                    .ok();
                                 false
                             }
                         }
@@ -423,21 +422,25 @@ impl uart::ReceiveClient for Console<'_> {
                                     (rcode, rx_len)
                                 };
 
-                                upcalls.schedule_upcall(
-                                    2,
-                                    kernel::into_statuscode(ret),
-                                    received_length,
-                                    0,
-                                );
+                                upcalls
+                                    .schedule_upcall(
+                                        2,
+                                        kernel::into_statuscode(ret),
+                                        received_length,
+                                        0,
+                                    )
+                                    .ok();
                             }
                             _ => {
                                 // Some UART error occurred
-                                upcalls.schedule_upcall(
-                                    2,
-                                    kernel::into_statuscode(Err(ErrorCode::FAIL)),
-                                    0,
-                                    0,
-                                );
+                                upcalls
+                                    .schedule_upcall(
+                                        2,
+                                        kernel::into_statuscode(Err(ErrorCode::FAIL)),
+                                        0,
+                                        0,
+                                    )
+                                    .ok();
                             }
                         }
                     })

--- a/capsules/src/crc.rs
+++ b/capsules/src/crc.rs
@@ -209,7 +209,9 @@ impl<'a, C: Crc<'a>> CrcDriver<'a, C> {
                     Ok(()) => Ok(()),
                     Err(e) => {
                         if grant.request.is_some() {
-                            upcalls.schedule_upcall(0, kernel::into_statuscode(Err(e)), 0, 0);
+                            upcalls
+                                .schedule_upcall(0, kernel::into_statuscode(Err(e)), 0, 0)
+                                .ok();
                             grant.request = None;
                         }
                         Err(e)
@@ -411,12 +413,14 @@ impl<'a, C: Crc<'a>> Client for CrcDriver<'a, C> {
                             // through a system call: regardless, the request is gone, so cancel
                             // the CRC.
                             if grant.request.is_none() {
-                                upcalls.schedule_upcall(
-                                    0,
-                                    kernel::into_statuscode(Err(ErrorCode::FAIL)),
-                                    0,
-                                    0,
-                                );
+                                upcalls
+                                    .schedule_upcall(
+                                        0,
+                                        kernel::into_statuscode(Err(ErrorCode::FAIL)),
+                                        0,
+                                        0,
+                                    )
+                                    .ok();
                                 return;
                             }
 
@@ -437,12 +441,14 @@ impl<'a, C: Crc<'a>> Client for CrcDriver<'a, C> {
                                     }
                                     Err(_) => {
                                         grant.request = None;
-                                        upcalls.schedule_upcall(
-                                            0,
-                                            kernel::into_statuscode(Err(ErrorCode::FAIL)),
-                                            0,
-                                            0,
-                                        );
+                                        upcalls
+                                            .schedule_upcall(
+                                                0,
+                                                kernel::into_statuscode(Err(ErrorCode::FAIL)),
+                                                0,
+                                                0,
+                                            )
+                                            .ok();
                                     }
                                 }
                             } else {
@@ -458,12 +464,14 @@ impl<'a, C: Crc<'a>> Client for CrcDriver<'a, C> {
                                     .unwrap_or(0);
                                 if amount == 0 {
                                     grant.request = None;
-                                    upcalls.schedule_upcall(
-                                        0,
-                                        kernel::into_statuscode(Err(ErrorCode::NOMEM)),
-                                        0,
-                                        0,
-                                    );
+                                    upcalls
+                                        .schedule_upcall(
+                                            0,
+                                            kernel::into_statuscode(Err(ErrorCode::NOMEM)),
+                                            0,
+                                            0,
+                                        )
+                                        .ok();
                                 } else {
                                     self.app_buffer_written.add(amount);
                                 }
@@ -480,12 +488,9 @@ impl<'a, C: Crc<'a>> Client for CrcDriver<'a, C> {
                             self.current_process.map(|pid| {
                                 let _res = self.grant.enter(*pid, |grant, upcalls| {
                                     grant.request = None;
-                                    upcalls.schedule_upcall(
-                                        0,
-                                        kernel::into_statuscode(Err(e)),
-                                        0,
-                                        0,
-                                    );
+                                    upcalls
+                                        .schedule_upcall(0, kernel::into_statuscode(Err(e)), 0, 0)
+                                        .ok();
                                 });
                             });
                         }
@@ -498,7 +503,9 @@ impl<'a, C: Crc<'a>> Client for CrcDriver<'a, C> {
                 self.current_process.map(|pid| {
                     let _res = self.grant.enter(*pid, |grant, upcalls| {
                         grant.request = None;
-                        upcalls.schedule_upcall(0, kernel::into_statuscode(Err(e)), 0, 0);
+                        upcalls
+                            .schedule_upcall(0, kernel::into_statuscode(Err(e)), 0, 0)
+                            .ok();
                     });
                 });
             }
@@ -519,15 +526,19 @@ impl<'a, C: Crc<'a>> Client for CrcDriver<'a, C> {
                 match result {
                     Ok(output) => {
                         let (val, user_int) = encode_upcall_crc_output(output);
-                        upcalls.schedule_upcall(
-                            0,
-                            kernel::into_statuscode(Ok(())),
-                            val as usize,
-                            user_int as usize,
-                        );
+                        upcalls
+                            .schedule_upcall(
+                                0,
+                                kernel::into_statuscode(Ok(())),
+                                val as usize,
+                                user_int as usize,
+                            )
+                            .ok();
                     }
                     Err(e) => {
-                        upcalls.schedule_upcall(0, kernel::into_statuscode(Err(e)), 0, 0);
+                        upcalls
+                            .schedule_upcall(0, kernel::into_statuscode(Err(e)), 0, 0)
+                            .ok();
                     }
                 }
             });

--- a/capsules/src/ctap.rs
+++ b/capsules/src/ctap.rs
@@ -140,7 +140,7 @@ impl<'a, U: usb_hid::UsbHid<'a, [u8; 64]>> usb_hid::Client<'a, [u8; 64]> for Cta
                         dest.copy_from_slice(buffer);
                     });
 
-                    upcalls.schedule_upcall(0, 0, 0, 0);
+                    upcalls.schedule_upcall(0, 0, 0, 0).ok();
                     app.can_receive.set(false);
                 })
                 .map_err(|err| {
@@ -162,7 +162,7 @@ impl<'a, U: usb_hid::UsbHid<'a, [u8; 64]>> usb_hid::Client<'a, [u8; 64]> for Cta
         self.appid.map(|id| {
             self.app
                 .enter(*id, |_app, upcalls| {
-                    upcalls.schedule_upcall(0, 1, 0, 0);
+                    upcalls.schedule_upcall(0, 1, 0, 0).ok();
                 })
                 .map_err(|err| {
                     if err == kernel::procs::Error::NoSuchApp

--- a/capsules/src/gpio.rs
+++ b/capsules/src/gpio.rs
@@ -143,7 +143,9 @@ impl<'a, IP: gpio::InterruptPin<'a>> gpio::ClientWithValue for GPIO<'a, IP> {
 
             // schedule callback with the pin number and value
             self.apps.each(|_, _, upcalls| {
-                upcalls.schedule_upcall(UPCALL_NUM, pin_num as usize, pin_state as usize, 0);
+                upcalls
+                    .schedule_upcall(UPCALL_NUM, pin_num as usize, pin_state as usize, 0)
+                    .ok();
             });
         }
     }

--- a/capsules/src/gpio_async.rs
+++ b/capsules/src/gpio_async.rs
@@ -93,7 +93,7 @@ impl<Port: hil::gpio_async::Port> hil::gpio_async::Client for GPIOAsync<'_, Port
     fn fired(&self, pin: usize, identifier: usize) {
         // schedule callback with the pin number and value for all apps
         self.grants.each(|_, _app, upcalls| {
-            upcalls.schedule_upcall(1, identifier, pin, 0);
+            upcalls.schedule_upcall(1, identifier, pin, 0).ok();
         });
     }
 
@@ -101,7 +101,7 @@ impl<Port: hil::gpio_async::Port> hil::gpio_async::Client for GPIOAsync<'_, Port
         // alert currently configuring app
         self.configuring_process.map(|pid| {
             let _ = self.grants.enter(*pid, |_app, upcalls| {
-                upcalls.schedule_upcall(0, 0, value, 0);
+                upcalls.schedule_upcall(0, 0, value, 0).ok();
             });
         });
         // then clear currently configuring app

--- a/capsules/src/hmac.rs
+++ b/capsules/src/hmac.rs
@@ -272,10 +272,12 @@ impl<
                     // If we get here we are ready to run the digest, reset the copied data
                     if app.op.get().unwrap() == UserSpaceOp::Run {
                         if let Err(e) = self.calculate_digest() {
-                            upcalls.schedule_upcall(0, kernel::into_statuscode(e.into()), 0, 0);
+                            upcalls
+                                .schedule_upcall(0, kernel::into_statuscode(e.into()), 0, 0)
+                                .ok();
                         }
                     } else {
-                        upcalls.schedule_upcall(0, 0, 0, 0);
+                        upcalls.schedule_upcall(0, 0, 0, 0).ok();
                     }
                 })
                 .map_err(|err| {
@@ -312,7 +314,8 @@ impl<
                             pointer as usize,
                             0,
                         ),
-                    };
+                    }
+                    .ok();
 
                     // Clear the current appid as it has finished running
                     self.appid.clear();
@@ -608,7 +611,9 @@ impl<
                     self.apps
                         .enter(appid, |_app, upcalls| {
                             if let Err(e) = self.calculate_digest() {
-                                upcalls.schedule_upcall(0, kernel::into_statuscode(e.into()), 0, 0);
+                                upcalls
+                                    .schedule_upcall(0, kernel::into_statuscode(e.into()), 0, 0)
+                                    .ok();
                             }
                         })
                         .unwrap();

--- a/capsules/src/humidity.rs
+++ b/capsules/src/humidity.rs
@@ -120,7 +120,7 @@ impl hil::sensors::HumidityClient for HumiditySensor<'_> {
                 if app.subscribed {
                     self.busy.set(false);
                     app.subscribed = false;
-                    upcalls.schedule_upcall(0, tmp_val, 0, 0);
+                    upcalls.schedule_upcall(0, tmp_val, 0, 0).ok();
                 }
             });
         }

--- a/capsules/src/i2c_master.rs
+++ b/capsules/src/i2c_master.rs
@@ -197,7 +197,7 @@ impl<'a, I: 'a + i2c::I2CMaster> i2c::I2CHwMasterClient for I2CMasterDriver<'a, 
                 }
 
                 // signal to driver that tx complete
-                upcalls.schedule_upcall(0, 0, 0, 0);
+                upcalls.schedule_upcall(0, 0, 0, 0).ok();
             })
         });
 

--- a/capsules/src/i2c_master_slave_driver.rs
+++ b/capsules/src/i2c_master_slave_driver.rs
@@ -92,7 +92,7 @@ impl hil::i2c::I2CHwMasterClient for I2CMasterSlaveDriver<'_> {
 
                 self.app.map(|app| {
                     let _ = self.apps.enter(*app, |_app, upcalls| {
-                        upcalls.schedule_upcall(0, 0, status, 0);
+                        upcalls.schedule_upcall(0, 0, status, 0).ok();
                     });
                 });
             }
@@ -119,7 +119,7 @@ impl hil::i2c::I2CHwMasterClient for I2CMasterSlaveDriver<'_> {
                                 0
                             })
                             .unwrap_or(0);
-                        upcalls.schedule_upcall(0, 1, status, 0);
+                        upcalls.schedule_upcall(0, 1, status, 0).ok();
                     });
                 });
             }
@@ -142,7 +142,7 @@ impl hil::i2c::I2CHwMasterClient for I2CMasterSlaveDriver<'_> {
                                 0
                             })
                             .unwrap_or(0);
-                        upcalls.schedule_upcall(0, 7, status, 0);
+                        upcalls.schedule_upcall(0, 7, status, 0).ok();
                     });
                 });
             }
@@ -195,7 +195,7 @@ impl hil::i2c::I2CHwSlaveClient for I2CMasterSlaveDriver<'_> {
                             })
                             .unwrap_or(0);
 
-                        upcalls.schedule_upcall(0, 3, length as usize, 0);
+                        upcalls.schedule_upcall(0, 3, length as usize, 0).ok();
                     });
                 });
             }
@@ -206,7 +206,7 @@ impl hil::i2c::I2CHwSlaveClient for I2CMasterSlaveDriver<'_> {
                 // Notify the app that the read finished
                 self.app.map(|app| {
                     let _ = self.apps.enter(*app, |_app, upcalls| {
-                        upcalls.schedule_upcall(0, 4, length as usize, 0);
+                        upcalls.schedule_upcall(0, 4, length as usize, 0).ok();
                     });
                 });
             }
@@ -221,7 +221,7 @@ impl hil::i2c::I2CHwSlaveClient for I2CMasterSlaveDriver<'_> {
                 // Ask the app to setup a read buffer. The app must call
                 // command 3 after it has setup the shared read buffer with
                 // the correct bytes.
-                upcalls.schedule_upcall(0, 2, 0, 0);
+                upcalls.schedule_upcall(0, 2, 0, 0).ok();
             });
         });
     }

--- a/capsules/src/l3gd20.rs
+++ b/capsules/src/l3gd20.rs
@@ -420,7 +420,9 @@ impl spi::SpiMasterClient for L3gd20Spi<'_> {
                         } else {
                             false
                         };
-                        upcalls.schedule_upcall(0, 1, if present { 1 } else { 0 }, 0);
+                        upcalls
+                            .schedule_upcall(0, 1, if present { 1 } else { 0 }, 0)
+                            .ok();
                         L3gd20Status::Idle
                     }
 
@@ -467,9 +469,9 @@ impl spi::SpiMasterClient for L3gd20Spi<'_> {
                             false
                         };
                         if values {
-                            upcalls.schedule_upcall(0, x, y, z);
+                            upcalls.schedule_upcall(0, x, y, z).ok();
                         } else {
-                            upcalls.schedule_upcall(0, 0, 0, 0);
+                            upcalls.schedule_upcall(0, 0, 0, 0).ok();
                         }
                         L3gd20Status::Idle
                     }
@@ -493,15 +495,15 @@ impl spi::SpiMasterClient for L3gd20Spi<'_> {
                             false
                         };
                         if value {
-                            upcalls.schedule_upcall(0, temperature, 0, 0);
+                            upcalls.schedule_upcall(0, temperature, 0, 0).ok();
                         } else {
-                            upcalls.schedule_upcall(0, 0, 0, 0);
+                            upcalls.schedule_upcall(0, 0, 0, 0).ok();
                         }
                         L3gd20Status::Idle
                     }
 
                     _ => {
-                        upcalls.schedule_upcall(0, 0, 0, 0);
+                        upcalls.schedule_upcall(0, 0, 0, 0).ok();
                         L3gd20Status::Idle
                     }
                 });

--- a/capsules/src/lps25hb.rs
+++ b/capsules/src/lps25hb.rs
@@ -203,7 +203,9 @@ impl i2c::I2CClient for LPS25HB<'_> {
 
                 self.owning_process.map(|pid| {
                     let _ = self.apps.enter(*pid, |_app, upcalls| {
-                        upcalls.schedule_upcall(0, pressure_ubar as usize, 0, 0);
+                        upcalls
+                            .schedule_upcall(0, pressure_ubar as usize, 0, 0)
+                            .ok();
                     });
                 });
 

--- a/capsules/src/lsm303agr.rs
+++ b/capsules/src/lsm303agr.rs
@@ -333,7 +333,9 @@ impl i2c::I2CClient for Lsm303agrI2C<'_> {
                 };
                 self.owning_process.map(|pid| {
                     let _res = self.apps.enter(*pid, |_app, upcalls| {
-                        upcalls.schedule_upcall(0, if present { 1 } else { 0 }, 0, 0);
+                        upcalls
+                            .schedule_upcall(0, if present { 1 } else { 0 }, 0, 0)
+                            .ok();
                     });
                 });
                 self.buffer.replace(buffer);
@@ -344,7 +346,9 @@ impl i2c::I2CClient for Lsm303agrI2C<'_> {
                 let set_power = status == Ok(());
                 self.owning_process.map(|pid| {
                     let _res = self.apps.enter(*pid, |_app, upcalls| {
-                        upcalls.schedule_upcall(0, if set_power { 1 } else { 0 }, 0, 0);
+                        upcalls
+                            .schedule_upcall(0, if set_power { 1 } else { 0 }, 0, 0)
+                            .ok();
                     });
                 });
                 self.buffer.replace(buffer);
@@ -361,12 +365,9 @@ impl i2c::I2CClient for Lsm303agrI2C<'_> {
                 let set_scale_and_resolution = status == Ok(());
                 self.owning_process.map(|pid| {
                     let _res = self.apps.enter(*pid, |_app, upcalls| {
-                        upcalls.schedule_upcall(
-                            0,
-                            if set_scale_and_resolution { 1 } else { 0 },
-                            0,
-                            0,
-                        );
+                        upcalls
+                            .schedule_upcall(0, if set_scale_and_resolution { 1 } else { 0 }, 0, 0)
+                            .ok();
                     });
                 });
                 self.buffer.replace(buffer);
@@ -412,9 +413,9 @@ impl i2c::I2CClient for Lsm303agrI2C<'_> {
                 self.owning_process.map(|pid| {
                     let _res = self.apps.enter(*pid, |_app, upcalls| {
                         if values {
-                            upcalls.schedule_upcall(0, x, y, z);
+                            upcalls.schedule_upcall(0, x, y, z).ok();
                         } else {
-                            upcalls.schedule_upcall(0, 0, 0, 0);
+                            upcalls.schedule_upcall(0, 0, 0, 0).ok();
                         }
                     });
                 });
@@ -426,7 +427,9 @@ impl i2c::I2CClient for Lsm303agrI2C<'_> {
                 let set_magneto_data_rate = status == Ok(());
                 self.owning_process.map(|pid| {
                     let _res = self.apps.enter(*pid, |_app, upcalls| {
-                        upcalls.schedule_upcall(0, if set_magneto_data_rate { 1 } else { 0 }, 0, 0);
+                        upcalls
+                            .schedule_upcall(0, if set_magneto_data_rate { 1 } else { 0 }, 0, 0)
+                            .ok();
                     });
                 });
                 self.buffer.replace(buffer);
@@ -440,7 +443,9 @@ impl i2c::I2CClient for Lsm303agrI2C<'_> {
                 let set_range = status == Ok(());
                 self.owning_process.map(|pid| {
                     let _res = self.apps.enter(*pid, |_app, upcalls| {
-                        upcalls.schedule_upcall(0, if set_range { 1 } else { 0 }, 0, 0);
+                        upcalls
+                            .schedule_upcall(0, if set_range { 1 } else { 0 }, 0, 0)
+                            .ok();
                     });
                 });
                 if self.config_in_progress.get() {
@@ -467,9 +472,9 @@ impl i2c::I2CClient for Lsm303agrI2C<'_> {
                 self.owning_process.map(|pid| {
                     let _res = self.apps.enter(*pid, |_app, upcalls| {
                         if values {
-                            upcalls.schedule_upcall(0, temp, 0, 0);
+                            upcalls.schedule_upcall(0, temp, 0, 0).ok();
                         } else {
-                            upcalls.schedule_upcall(0, 0, 0, 0);
+                            upcalls.schedule_upcall(0, 0, 0, 0).ok();
                         }
                     });
                 });
@@ -507,9 +512,9 @@ impl i2c::I2CClient for Lsm303agrI2C<'_> {
                 self.owning_process.map(|pid| {
                     let _res = self.apps.enter(*pid, |_app, upcalls| {
                         if values {
-                            upcalls.schedule_upcall(0, x, y, z);
+                            upcalls.schedule_upcall(0, x, y, z).ok();
                         } else {
-                            upcalls.schedule_upcall(0, 0, 0, 0);
+                            upcalls.schedule_upcall(0, 0, 0, 0).ok();
                         }
                     });
                 });

--- a/capsules/src/lsm303dlhc.rs
+++ b/capsules/src/lsm303dlhc.rs
@@ -334,7 +334,9 @@ impl i2c::I2CClient for Lsm303dlhcI2C<'_> {
 
                 self.current_process.map(|process_id| {
                     let _ = self.apps.enter(*process_id, |_grant, upcalls| {
-                        upcalls.schedule_upcall(0, if present { 1 } else { 0 }, 0, 0);
+                        upcalls
+                            .schedule_upcall(0, if present { 1 } else { 0 }, 0, 0)
+                            .ok();
                     });
                 });
 
@@ -347,7 +349,9 @@ impl i2c::I2CClient for Lsm303dlhcI2C<'_> {
 
                 self.current_process.map(|process_id| {
                     let _ = self.apps.enter(*process_id, |_grant, upcalls| {
-                        upcalls.schedule_upcall(0, if set_power { 1 } else { 0 }, 0, 0);
+                        upcalls
+                            .schedule_upcall(0, if set_power { 1 } else { 0 }, 0, 0)
+                            .ok();
                     });
                 });
 
@@ -366,12 +370,9 @@ impl i2c::I2CClient for Lsm303dlhcI2C<'_> {
 
                 self.current_process.map(|process_id| {
                     let _ = self.apps.enter(*process_id, |_grant, upcalls| {
-                        upcalls.schedule_upcall(
-                            0,
-                            if set_scale_and_resolution { 1 } else { 0 },
-                            0,
-                            0,
-                        );
+                        upcalls
+                            .schedule_upcall(0, if set_scale_and_resolution { 1 } else { 0 }, 0, 0)
+                            .ok();
                     });
                 });
 
@@ -422,9 +423,9 @@ impl i2c::I2CClient for Lsm303dlhcI2C<'_> {
                 self.current_process.map(|process_id| {
                     let _ = self.apps.enter(*process_id, |_grant, upcalls| {
                         if values {
-                            upcalls.schedule_upcall(0, x, y, z);
+                            upcalls.schedule_upcall(0, x, y, z).ok();
                         } else {
-                            upcalls.schedule_upcall(0, 0, 0, 0);
+                            upcalls.schedule_upcall(0, 0, 0, 0).ok();
                         }
                     });
                 });
@@ -438,16 +439,18 @@ impl i2c::I2CClient for Lsm303dlhcI2C<'_> {
 
                 self.current_process.map(|process_id| {
                     let _ = self.apps.enter(*process_id, |_grant, upcalls| {
-                        upcalls.schedule_upcall(
-                            0,
-                            if set_temperature_and_magneto_data_rate {
-                                1
-                            } else {
-                                0
-                            },
-                            0,
-                            0,
-                        );
+                        upcalls
+                            .schedule_upcall(
+                                0,
+                                if set_temperature_and_magneto_data_rate {
+                                    1
+                                } else {
+                                    0
+                                },
+                                0,
+                                0,
+                            )
+                            .ok();
                     });
                 });
 
@@ -463,7 +466,9 @@ impl i2c::I2CClient for Lsm303dlhcI2C<'_> {
 
                 self.current_process.map(|process_id| {
                     let _ = self.apps.enter(*process_id, |_grant, upcalls| {
-                        upcalls.schedule_upcall(0, if set_range { 1 } else { 0 }, 0, 0);
+                        upcalls
+                            .schedule_upcall(0, if set_range { 1 } else { 0 }, 0, 0)
+                            .ok();
                     });
                 });
 
@@ -492,9 +497,9 @@ impl i2c::I2CClient for Lsm303dlhcI2C<'_> {
                 self.current_process.map(|process_id| {
                     let _ = self.apps.enter(*process_id, |_grant, upcalls| {
                         if values {
-                            upcalls.schedule_upcall(0, temp, 0, 0);
+                            upcalls.schedule_upcall(0, temp, 0, 0).ok();
                         } else {
-                            upcalls.schedule_upcall(0, 0, 0, 0);
+                            upcalls.schedule_upcall(0, 0, 0, 0).ok();
                         }
                     });
                 });
@@ -534,9 +539,9 @@ impl i2c::I2CClient for Lsm303dlhcI2C<'_> {
                 self.current_process.map(|process_id| {
                     let _ = self.apps.enter(*process_id, |_grant, upcalls| {
                         if values {
-                            upcalls.schedule_upcall(0, x, y, z);
+                            upcalls.schedule_upcall(0, x, y, z).ok();
                         } else {
-                            upcalls.schedule_upcall(0, 0, 0, 0);
+                            upcalls.schedule_upcall(0, 0, 0, 0).ok();
                         }
                     });
                 });

--- a/capsules/src/ltc294x.rs
+++ b/capsules/src/ltc294x.rs
@@ -437,7 +437,7 @@ impl LTC294XClient for LTC294XDriver<'_> {
     fn interrupt(&self) {
         self.owning_process.map(|pid| {
             let _res = self.grants.enter(*pid, |_app, upcalls| {
-                upcalls.schedule_upcall(0, 0, 0, 0);
+                upcalls.schedule_upcall(0, 0, 0, 0).ok();
             });
         });
     }
@@ -457,7 +457,9 @@ impl LTC294XClient for LTC294XDriver<'_> {
             | ((accumulated_charge_overflow as usize) << 4);
         self.owning_process.map(|pid| {
             let _res = self.grants.enter(*pid, |_app, upcalls| {
-                upcalls.schedule_upcall(0, 1, ret, self.ltc294x.model.get() as usize);
+                upcalls
+                    .schedule_upcall(0, 1, ret, self.ltc294x.model.get() as usize)
+                    .ok();
             });
         });
     }
@@ -465,7 +467,7 @@ impl LTC294XClient for LTC294XDriver<'_> {
     fn charge(&self, charge: u16) {
         self.owning_process.map(|pid| {
             let _res = self.grants.enter(*pid, |_app, upcalls| {
-                upcalls.schedule_upcall(0, 2, charge as usize, 0);
+                upcalls.schedule_upcall(0, 2, charge as usize, 0).ok();
             });
         });
     }
@@ -473,7 +475,7 @@ impl LTC294XClient for LTC294XDriver<'_> {
     fn done(&self) {
         self.owning_process.map(|pid| {
             let _res = self.grants.enter(*pid, |_app, upcalls| {
-                upcalls.schedule_upcall(0, 3, 0, 0);
+                upcalls.schedule_upcall(0, 3, 0, 0).ok();
             });
         });
     }
@@ -481,7 +483,7 @@ impl LTC294XClient for LTC294XDriver<'_> {
     fn voltage(&self, voltage: u16) {
         self.owning_process.map(|pid| {
             let _res = self.grants.enter(*pid, |_app, upcalls| {
-                upcalls.schedule_upcall(0, 4, voltage as usize, 0);
+                upcalls.schedule_upcall(0, 4, voltage as usize, 0).ok();
             });
         });
     }
@@ -489,7 +491,7 @@ impl LTC294XClient for LTC294XDriver<'_> {
     fn current(&self, current: u16) {
         self.owning_process.map(|pid| {
             let _res = self.grants.enter(*pid, |_app, upcalls| {
-                upcalls.schedule_upcall(0, 5, current as usize, 0);
+                upcalls.schedule_upcall(0, 5, current as usize, 0).ok();
             });
         });
     }

--- a/capsules/src/max17205.rs
+++ b/capsules/src/max17205.rs
@@ -410,7 +410,9 @@ impl MAX17205Client for MAX17205Driver<'_> {
     fn status(&self, status: u16, error: Result<(), ErrorCode>) {
         self.owning_process.map(|pid| {
             let _ = self.apps.enter(*pid, |_app, upcalls| {
-                upcalls.schedule_upcall(0, kernel::into_statuscode(error), status as usize, 0);
+                upcalls
+                    .schedule_upcall(0, kernel::into_statuscode(error), status as usize, 0)
+                    .ok();
             });
         });
     }
@@ -424,12 +426,14 @@ impl MAX17205Client for MAX17205Driver<'_> {
     ) {
         self.owning_process.map(|pid| {
             let _ = self.apps.enter(*pid, |_app, upcalls| {
-                upcalls.schedule_upcall(
-                    0,
-                    kernel::into_statuscode(error),
-                    percent as usize,
-                    (capacity as usize) << 16 | (full_capacity as usize),
-                );
+                upcalls
+                    .schedule_upcall(
+                        0,
+                        kernel::into_statuscode(error),
+                        percent as usize,
+                        (capacity as usize) << 16 | (full_capacity as usize),
+                    )
+                    .ok();
             });
         });
     }
@@ -437,12 +441,14 @@ impl MAX17205Client for MAX17205Driver<'_> {
     fn voltage_current(&self, voltage: u16, current: u16, error: Result<(), ErrorCode>) {
         self.owning_process.map(|pid| {
             let _ = self.apps.enter(*pid, |_app, upcalls| {
-                upcalls.schedule_upcall(
-                    0,
-                    kernel::into_statuscode(error),
-                    voltage as usize,
-                    current as usize,
-                );
+                upcalls
+                    .schedule_upcall(
+                        0,
+                        kernel::into_statuscode(error),
+                        voltage as usize,
+                        current as usize,
+                    )
+                    .ok();
             });
         });
     }
@@ -450,7 +456,9 @@ impl MAX17205Client for MAX17205Driver<'_> {
     fn coulomb(&self, coulomb: u16, error: Result<(), ErrorCode>) {
         self.owning_process.map(|pid| {
             let _ = self.apps.enter(*pid, |_app, upcalls| {
-                upcalls.schedule_upcall(0, kernel::into_statuscode(error), coulomb as usize, 0);
+                upcalls
+                    .schedule_upcall(0, kernel::into_statuscode(error), coulomb as usize, 0)
+                    .ok();
             });
         });
     }
@@ -458,12 +466,14 @@ impl MAX17205Client for MAX17205Driver<'_> {
     fn romid(&self, rid: u64, error: Result<(), ErrorCode>) {
         self.owning_process.map(|pid| {
             let _ = self.apps.enter(*pid, |_app, upcalls| {
-                upcalls.schedule_upcall(
-                    0,
-                    kernel::into_statuscode(error),
-                    (rid & 0xffffffff) as usize,
-                    (rid >> 32) as usize,
-                );
+                upcalls
+                    .schedule_upcall(
+                        0,
+                        kernel::into_statuscode(error),
+                        (rid & 0xffffffff) as usize,
+                        (rid >> 32) as usize,
+                    )
+                    .ok();
             });
         });
     }

--- a/capsules/src/mlx90614.rs
+++ b/capsules/src/mlx90614.rs
@@ -125,7 +125,9 @@ impl<'a> i2c::I2CClient for Mlx90614SMBus<'a> {
 
                 self.owning_process.map(|pid| {
                     let _ = self.apps.enter(*pid, |_app, upcalls| {
-                        upcalls.schedule_upcall(0, if present { 1 } else { 0 }, 0, 0);
+                        upcalls
+                            .schedule_upcall(0, if present { 1 } else { 0 }, 0, 0)
+                            .ok();
                     });
                 });
                 self.buffer.replace(buffer);
@@ -150,13 +152,13 @@ impl<'a> i2c::I2CClient for Mlx90614SMBus<'a> {
                 if values {
                     self.owning_process.map(|pid| {
                         let _ = self.apps.enter(*pid, |_app, upcalls| {
-                            upcalls.schedule_upcall(0, temp, 0, 0);
+                            upcalls.schedule_upcall(0, temp, 0, 0).ok();
                         });
                     });
                 } else {
                     self.owning_process.map(|pid| {
                         let _ = self.apps.enter(*pid, |_app, upcalls| {
-                            upcalls.schedule_upcall(0, 0, 0, 0);
+                            upcalls.schedule_upcall(0, 0, 0, 0).ok();
                         });
                     });
                 }

--- a/capsules/src/net/udp/driver.rs
+++ b/capsules/src/net/udp/driver.rs
@@ -168,7 +168,9 @@ impl<'a> UDPDriver<'a> {
         let result = self.perform_tx_sync(appid);
         if result != Ok(()) {
             let _ = self.apps.enter(appid, |_app, upcalls| {
-                upcalls.schedule_upcall(1, kernel::into_statuscode(result), 0, 0);
+                upcalls
+                    .schedule_upcall(1, kernel::into_statuscode(result), 0, 0)
+                    .ok();
             });
         }
     }
@@ -598,7 +600,9 @@ impl<'a> UDPSendClient for UDPDriver<'a> {
         self.kernel_buffer.replace(dgram);
         self.current_app.get().map(|appid| {
             let _ = self.apps.enter(appid, |_app, upcalls| {
-                upcalls.schedule_upcall(1, kernel::into_statuscode(result), 0, 0);
+                upcalls
+                    .schedule_upcall(1, kernel::into_statuscode(result), 0, 0)
+                    .ok();
             });
         });
         self.current_app.set(None);
@@ -642,7 +646,7 @@ impl<'a> UDPRecvClient for UDPDriver<'a> {
                             addr: src_addr,
                             port: src_port,
                         };
-                        upcalls.schedule_upcall(0, len, 0, 0);
+                        upcalls.schedule_upcall(0, len, 0, 0).ok();
                         const CFG_LEN: usize = 2 * size_of::<UDPEndpoint>();
                         let _ = app
                             .app_rx_cfg

--- a/capsules/src/ninedof.rs
+++ b/capsules/src/ninedof.rs
@@ -152,7 +152,7 @@ impl hil::sensors::NineDofClient for NineDof<'_> {
                 app.pending_command = false;
                 finished_command = app.command;
                 finished_command_arg = app.arg1;
-                upcalls.schedule_upcall(0, arg1, arg2, arg3);
+                upcalls.schedule_upcall(0, arg1, arg2, arg3).ok();
             });
         });
 
@@ -167,7 +167,7 @@ impl hil::sensors::NineDofClient for NineDof<'_> {
                     // Don't bother re-issuing this command, just use
                     // the existing result.
                     app.pending_command = false;
-                    upcalls.schedule_upcall(0, arg1, arg2, arg3);
+                    upcalls.schedule_upcall(0, arg1, arg2, arg3).ok();
                     false
                 } else if app.pending_command {
                     app.pending_command = false;

--- a/capsules/src/nonvolatile_storage_driver.rs
+++ b/capsules/src/nonvolatile_storage_driver.rs
@@ -419,7 +419,7 @@ impl hil::nonvolatile_storage::NonvolatileStorageClient<'static> for Nonvolatile
                         self.buffer.replace(buffer);
 
                         // And then signal the app.
-                        upcalls.schedule_upcall(0, length, 0, 0);
+                        upcalls.schedule_upcall(0, length, 0, 0).ok();
                     });
                 }
             }
@@ -443,7 +443,7 @@ impl hil::nonvolatile_storage::NonvolatileStorageClient<'static> for Nonvolatile
                         self.buffer.replace(buffer);
 
                         // And then signal the app.
-                        upcalls.schedule_upcall(1, length, 0, 0);
+                        upcalls.schedule_upcall(1, length, 0, 0).ok();
                     });
                 }
             }

--- a/capsules/src/nrf51822_serialization.rs
+++ b/capsules/src/nrf51822_serialization.rs
@@ -250,7 +250,7 @@ impl uart::TransmitClient for Nrf51822Serialization<'_> {
         self.active_app.map(|appid| {
             let _ = self.apps.enter(*appid, |_app, upcalls| {
                 // Call the callback after TX has finished
-                upcalls.schedule_upcall(0, 1, 0, 0);
+                upcalls.schedule_upcall(0, 1, 0, 0).ok();
             });
         });
     }
@@ -293,7 +293,7 @@ impl uart::ReceiveClient for Nrf51822Serialization<'_> {
                 // Note: This indicates how many bytes were received by
                 // hardware, regardless of how much space (if any) was
                 // available in the buffer provided by the app.
-                upcalls.schedule_upcall(0, 4, rx_len, len);
+                upcalls.schedule_upcall(0, 4, rx_len, len).ok();
             });
         });
 

--- a/capsules/src/pca9544a.rs
+++ b/capsules/src/pca9544a.rs
@@ -146,7 +146,9 @@ impl i2c::I2CClient for PCA9544A<'_> {
 
                 self.owning_process.map(|pid| {
                     let _ = self.apps.enter(*pid, |_app, upcalls| {
-                        upcalls.schedule_upcall(0, (field as usize) + 1, ret as usize, 0);
+                        upcalls
+                            .schedule_upcall(0, (field as usize) + 1, ret as usize, 0)
+                            .ok();
                     });
                 });
 
@@ -157,7 +159,7 @@ impl i2c::I2CClient for PCA9544A<'_> {
             State::Done => {
                 self.owning_process.map(|pid| {
                     let _ = self.apps.enter(*pid, |_app, upcalls| {
-                        upcalls.schedule_upcall(0, 0, 0, 0);
+                        upcalls.schedule_upcall(0, 0, 0, 0).ok();
                     });
                 });
 

--- a/capsules/src/proximity.rs
+++ b/capsules/src/proximity.rs
@@ -267,13 +267,13 @@ impl hil::sensors::ProximityClient for ProximitySensor<'_> {
                         if ((temp_val as u8) > app.upper_proximity)
                             || ((temp_val as u8) < app.lower_proximity)
                         {
-                            upcalls.schedule_upcall(0, temp_val as usize, 0, 0);
+                            upcalls.schedule_upcall(0, temp_val as usize, 0, 0).ok();
                             app.subscribed = false; // dequeue
                         }
                     } else {
                         // Case: ReadProximity
                         // Upcall to all apps waiting on read_proximity.
-                        upcalls.schedule_upcall(0, temp_val as usize, 0, 0);
+                        upcalls.schedule_upcall(0, temp_val as usize, 0, 0).ok();
                         app.subscribed = false; // dequeue
                     }
                 }

--- a/capsules/src/rng.rs
+++ b/capsules/src/rng.rs
@@ -132,7 +132,7 @@ impl rng::Client for RngDriver<'_> {
                     if app.remaining > 0 {
                         done = false;
                     } else {
-                        upcalls.schedule_upcall(0, 0, newidx, 0);
+                        upcalls.schedule_upcall(0, 0, newidx, 0).ok();
                     }
                 }
             });

--- a/capsules/src/screen.rs
+++ b/capsules/src/screen.rs
@@ -355,7 +355,7 @@ impl<'a> Screen<'a> {
             self.current_process.take().map(|process_id| {
                 let _ = self.apps.enter(process_id, |app, upcalls| {
                     app.pending_command = false;
-                    upcalls.schedule_upcall(0, data1, data2, data3);
+                    upcalls.schedule_upcall(0, data1, data2, data3).ok();
                 });
             });
         }

--- a/capsules/src/sdcard.rs
+++ b/capsules/src/sdcard.rs
@@ -1449,7 +1449,7 @@ impl<'a, A: hil::time::Alarm<'a>> SDCardClient for SDCardDriver<'a, A> {
     fn card_detection_changed(&self, installed: bool) {
         self.current_process.map(|process_id| {
             let _ = self.grants.enter(*process_id, |_app, upcalls| {
-                upcalls.schedule_upcall(0, 0, installed as usize, 0);
+                upcalls.schedule_upcall(0, 0, installed as usize, 0).ok();
             });
         });
     }
@@ -1458,7 +1458,9 @@ impl<'a, A: hil::time::Alarm<'a>> SDCardClient for SDCardDriver<'a, A> {
         self.current_process.map(|process_id| {
             let _ = self.grants.enter(*process_id, |_app, upcalls| {
                 let size_in_kb = ((total_size >> 10) & 0xFFFFFFFF) as usize;
-                upcalls.schedule_upcall(0, 1, block_size as usize, size_in_kb);
+                upcalls
+                    .schedule_upcall(0, 1, block_size as usize, size_in_kb)
+                    .ok();
             });
         });
     }
@@ -1490,7 +1492,7 @@ impl<'a, A: hil::time::Alarm<'a>> SDCardClient for SDCardDriver<'a, A> {
                 // perform callback
                 // Note that we are explicitly performing the callback even if no
                 // data was read or if the app's read_buffer doesn't exist
-                upcalls.schedule_upcall(0, 2, read_len, 0);
+                upcalls.schedule_upcall(0, 2, read_len, 0).ok();
             });
         });
     }
@@ -1500,7 +1502,7 @@ impl<'a, A: hil::time::Alarm<'a>> SDCardClient for SDCardDriver<'a, A> {
 
         self.current_process.map(|process_id| {
             let _ = self.grants.enter(*process_id, |_app, upcalls| {
-                upcalls.schedule_upcall(0, 3, 0, 0);
+                upcalls.schedule_upcall(0, 3, 0, 0).ok();
             });
         });
     }
@@ -1508,7 +1510,7 @@ impl<'a, A: hil::time::Alarm<'a>> SDCardClient for SDCardDriver<'a, A> {
     fn error(&self, error: u32) {
         self.current_process.map(|process_id| {
             let _ = self.grants.enter(*process_id, |_app, upcalls| {
-                upcalls.schedule_upcall(0, 4, error as usize, 0);
+                upcalls.schedule_upcall(0, 4, error as usize, 0).ok();
             });
         });
     }

--- a/capsules/src/sha.rs
+++ b/capsules/src/sha.rs
@@ -252,10 +252,12 @@ impl<
                     // If we get here we are ready to run the digest, reset the copied data
                     if app.op.get().unwrap() == UserSpaceOp::Run {
                         if let Err(e) = self.calculate_digest() {
-                            upcalls.schedule_upcall(0, kernel::into_statuscode(e.into()), 0, 0);
+                            upcalls
+                                .schedule_upcall(0, kernel::into_statuscode(e.into()), 0, 0)
+                                .ok();
                         }
                     } else {
-                        upcalls.schedule_upcall(0, 0, 0, 0);
+                        upcalls.schedule_upcall(0, 0, 0, 0).ok();
                     }
                 })
                 .map_err(|err| {
@@ -283,13 +285,15 @@ impl<
                     });
 
                     match result {
-                        Ok(_) => upcalls.schedule_upcall(0, 0, pointer as usize, 0),
-                        Err(e) => upcalls.schedule_upcall(
-                            0,
-                            kernel::into_statuscode(e.into()),
-                            pointer as usize,
-                            0,
-                        ),
+                        Ok(_) => upcalls.schedule_upcall(0, 0, pointer as usize, 0).ok(),
+                        Err(e) => upcalls
+                            .schedule_upcall(
+                                0,
+                                kernel::into_statuscode(e.into()),
+                                pointer as usize,
+                                0,
+                            )
+                            .ok(),
                     };
 
                     // Clear the current appid as it has finished running
@@ -555,7 +559,9 @@ impl<
                     self.apps
                         .enter(appid, |_app, upcalls| {
                             if let Err(e) = self.calculate_digest() {
-                                upcalls.schedule_upcall(0, kernel::into_statuscode(e.into()), 0, 0);
+                                upcalls
+                                    .schedule_upcall(0, kernel::into_statuscode(e.into()), 0, 0)
+                                    .ok();
                             }
                         })
                         .unwrap();

--- a/capsules/src/sound_pressure.rs
+++ b/capsules/src/sound_pressure.rs
@@ -129,7 +129,7 @@ impl hil::sensors::SoundPressureClient for SoundPressureSensor<'_> {
                     self.busy.set(false);
                     app.subscribed = false;
                     if ret == Ok(()) {
-                        upcalls.schedule_upcall(0, sound_val.into(), 0, 0);
+                        upcalls.schedule_upcall(0, sound_val.into(), 0, 0).ok();
                     }
                 }
             });

--- a/capsules/src/spi_controller.rs
+++ b/capsules/src/spi_controller.rs
@@ -326,7 +326,7 @@ impl<S: SpiMasterDevice> SpiMasterClient for Spi<'_, S> {
                     let len = app.len;
                     app.len = 0;
                     app.index = 0;
-                    upcalls.schedule_upcall(0, len, 0, 0);
+                    upcalls.schedule_upcall(0, len, 0, 0).ok();
                 } else {
                     self.do_next_read_write(app);
                 }

--- a/capsules/src/spi_peripheral.rs
+++ b/capsules/src/spi_peripheral.rs
@@ -300,7 +300,7 @@ impl<S: SpiSlaveDevice> SpiSlaveClient for SpiPeripheral<'_, S> {
                     let len = app.len;
                     app.len = 0;
                     app.index = 0;
-                    upcalls.schedule_upcall(0, len, 0, 0);
+                    upcalls.schedule_upcall(0, len, 0, 0).ok();
                 } else {
                     self.do_next_read_write(app);
                 }
@@ -313,7 +313,7 @@ impl<S: SpiSlaveDevice> SpiSlaveClient for SpiPeripheral<'_, S> {
         self.current_process.map(|process_id| {
             let _ = self.grants.enter(*process_id, move |app, upcalls| {
                 let len = app.len;
-                upcalls.schedule_upcall(1, len, 0, 0);
+                upcalls.schedule_upcall(1, len, 0, 0).ok();
             });
         });
     }

--- a/capsules/src/temperature.rs
+++ b/capsules/src/temperature.rs
@@ -112,7 +112,7 @@ impl hil::sensors::TemperatureClient for TemperatureSensor<'_> {
                 if app.subscribed {
                     self.busy.set(false);
                     app.subscribed = false;
-                    upcalls.schedule_upcall(0, temp_val, 0, 0);
+                    upcalls.schedule_upcall(0, temp_val, 0, 0).ok();
                 }
             });
         }

--- a/capsules/src/text_screen.rs
+++ b/capsules/src/text_screen.rs
@@ -202,7 +202,7 @@ impl<'a> TextScreen<'a> {
         self.current_app.take().map(|appid| {
             let _ = self.apps.enter(appid, |app, upcalls| {
                 app.pending_command = false;
-                upcalls.schedule_upcall(0, data1, data2, data3);
+                upcalls.schedule_upcall(0, data1, data2, data3).ok();
             });
         });
     }

--- a/capsules/src/touch.rs
+++ b/capsules/src/touch.rs
@@ -179,12 +179,14 @@ impl<'a> hil::touch::TouchClient for Touch<'a> {
                         Some(size) => size as usize,
                         None => 0,
                     };
-                    upcalls.schedule_upcall(
-                        0,
-                        event_status,
-                        (event.x as usize) << 16 | event.y as usize,
-                        pressure_size,
-                    );
+                    upcalls
+                        .schedule_upcall(
+                            0,
+                            event_status,
+                            (event.x as usize) << 16 | event.y as usize,
+                            pressure_size,
+                        )
+                        .ok();
                 }
             });
         }
@@ -252,12 +254,14 @@ impl<'a> hil::touch::MultiTouchClient for Touch<'a> {
                     let dropped_events = app.dropped_events;
                     if num > 0 {
                         app.ack = false;
-                        upcalls.schedule_upcall(
-                            2,
-                            num,
-                            dropped_events,
-                            if num < len { len - num } else { 0 },
-                        );
+                        upcalls
+                            .schedule_upcall(
+                                2,
+                                num,
+                                dropped_events,
+                                if num < len { len - num } else { 0 },
+                            )
+                            .ok();
                     }
 
                 // app.ack == false;
@@ -282,7 +286,7 @@ impl<'a> hil::touch::GestureClient for Touch<'a> {
                     GestureEvent::ZoomIn => 5,
                     GestureEvent::ZoomOut => 6,
                 };
-                upcalls.schedule_upcall(1, gesture_id, 0, 0);
+                upcalls.schedule_upcall(1, gesture_id, 0, 0).ok();
             });
         }
     }

--- a/capsules/src/tsl2561.rs
+++ b/capsules/src/tsl2561.rs
@@ -422,7 +422,7 @@ impl i2c::I2CClient for TSL2561<'_> {
 
                 self.owning_process.map(|pid| {
                     let _ = self.apps.enter(*pid, |_, upcalls| {
-                        upcalls.schedule_upcall(0, 0, lux, 0);
+                        upcalls.schedule_upcall(0, 0, lux, 0).ok();
                     });
                 });
 

--- a/capsules/src/usb/usb_user.rs
+++ b/capsules/src/usb/usb_user.rs
@@ -75,7 +75,9 @@ where
                             self.usbc_client.attach();
 
                             // Schedule a callback immediately
-                            upcalls.schedule_upcall(0, kernel::into_statuscode(Ok(())), 0, 0);
+                            upcalls
+                                .schedule_upcall(0, kernel::into_statuscode(Ok(())), 0, 0)
+                                .ok();
                             app.awaiting = None;
                         }
                     }

--- a/kernel/src/ipc.rs
+++ b/kernel/src/ipc.rs
@@ -126,20 +126,25 @@ impl<const NUM_PROCS: usize, const NUM_UPCALLS: usize> IPC<NUM_PROCS, NUM_UPCALL
                                                 )
                                             },
                                         );
-                                        my_upcalls.schedule_upcall(
-                                            to_schedule,
-                                            called_from.id() + 1,
-                                            crate::mem::ReadableProcessBuffer::len(slice),
-                                            crate::mem::ReadableProcessBuffer::ptr(slice) as usize,
-                                        );
+                                        my_upcalls
+                                            .schedule_upcall(
+                                                to_schedule,
+                                                called_from.id() + 1,
+                                                crate::mem::ReadableProcessBuffer::len(slice),
+                                                crate::mem::ReadableProcessBuffer::ptr(slice)
+                                                    as usize,
+                                            )
+                                            .ok();
                                     }
                                     None => {
-                                        my_upcalls.schedule_upcall(
-                                            to_schedule,
-                                            called_from.id() + 1,
-                                            0,
-                                            0,
-                                        );
+                                        my_upcalls
+                                            .schedule_upcall(
+                                                to_schedule,
+                                                called_from.id() + 1,
+                                                0,
+                                                0,
+                                            )
+                                            .ok();
                                     }
                                 }
                             }

--- a/kernel/src/ipc.rs
+++ b/kernel/src/ipc.rs
@@ -226,12 +226,14 @@ impl<const NUM_PROCS: usize, const NUM_UPCALLS: usize> Driver for IPC<NUM_PROCS,
                             CommandReturn::failure(ErrorCode::INVAL),
                             otherapp,
                             |target| {
-                                let ret = target
-                                    .enqueue_task(process::Task::IPC((appid, cb_type)))
-                                    .is_ok();
+                                let ret = target.enqueue_task(process::Task::IPC((appid, cb_type)));
                                 match ret {
-                                    true => CommandReturn::success(),
-                                    false => CommandReturn::failure(ErrorCode::FAIL),
+                                    Ok(()) => CommandReturn::success(),
+                                    Err(e) => match e {
+                                        // The other side has a null upcall, choosing to ignore
+                                        ErrorCode::OFF => CommandReturn::success(),
+                                        _ => CommandReturn::failure(e),
+                                    },
                                 }
                             },
                         )
@@ -251,12 +253,14 @@ impl<const NUM_PROCS: usize, const NUM_UPCALLS: usize> Driver for IPC<NUM_PROCS,
                             CommandReturn::failure(ErrorCode::INVAL),
                             otherapp,
                             |target| {
-                                let ret = target
-                                    .enqueue_task(process::Task::IPC((appid, cb_type)))
-                                    .is_ok();
+                                let ret = target.enqueue_task(process::Task::IPC((appid, cb_type)));
                                 match ret {
-                                    true => CommandReturn::success(),
-                                    false => CommandReturn::failure(ErrorCode::FAIL),
+                                    Ok(()) => CommandReturn::success(),
+                                    Err(e) => match e {
+                                        // The other side has a null upcall, choosing to ignore
+                                        ErrorCode::OFF => CommandReturn::success(),
+                                        _ => CommandReturn::failure(e),
+                                    },
                                 }
                             },
                         )

--- a/kernel/src/ipc.rs
+++ b/kernel/src/ipc.rs
@@ -226,7 +226,9 @@ impl<const NUM_PROCS: usize, const NUM_UPCALLS: usize> Driver for IPC<NUM_PROCS,
                             CommandReturn::failure(ErrorCode::INVAL),
                             otherapp,
                             |target| {
-                                let ret = target.enqueue_task(process::Task::IPC((appid, cb_type)));
+                                let ret = target
+                                    .enqueue_task(process::Task::IPC((appid, cb_type)))
+                                    .is_ok();
                                 match ret {
                                     true => CommandReturn::success(),
                                     false => CommandReturn::failure(ErrorCode::FAIL),
@@ -249,7 +251,9 @@ impl<const NUM_PROCS: usize, const NUM_UPCALLS: usize> Driver for IPC<NUM_PROCS,
                             CommandReturn::failure(ErrorCode::INVAL),
                             otherapp,
                             |target| {
-                                let ret = target.enqueue_task(process::Task::IPC((appid, cb_type)));
+                                let ret = target
+                                    .enqueue_task(process::Task::IPC((appid, cb_type)))
+                                    .is_ok();
                                 match ret {
                                     true => CommandReturn::success(),
                                     false => CommandReturn::failure(ErrorCode::FAIL),

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -130,6 +130,7 @@ pub use crate::sched::mlfq::{MLFQProcessNode, MLFQSched};
 pub use crate::sched::priority::PrioritySched;
 pub use crate::sched::round_robin::{RoundRobinProcessNode, RoundRobinSched};
 pub use crate::sched::{Kernel, Scheduler};
+pub use crate::upcall::UpcallError;
 
 // Export only select items from the process module. To remove the name conflict
 // this cannot be called `process`, so we use a shortened version. These

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -170,13 +170,14 @@ pub trait Process {
     /// buffer and executed by the scheduler. `Task`s are some function the app
     /// should run, for example a upcall or an IPC call.
     ///
-    /// This function returns `true` if the `Task` was successfully enqueued,
-    /// and `false` otherwise. This is represented as a simple `bool` because
-    /// this is passed to the capsule that tried to schedule the `Task`.
-    ///
-    /// This will fail if the process is no longer active, and therefore cannot
-    /// execute any new tasks.
-    fn enqueue_task(&self, task: Task) -> bool;
+    /// This function returns `Ok(())` if the `Task` was successfully
+    /// enqueued. If the process is no longer alive,
+    /// `Err(ErrorCode::NODEVICE)` is returned. If the task could not
+    /// be enqueued because there is insufficient space in the
+    /// internal task queue, `Err(ErrorCode::NOMEM)` is
+    /// returned. Other return values must be treated as
+    /// kernel-internal errors.
+    fn enqueue_task(&self, task: Task) -> Result<(), ErrorCode>;
 
     /// Returns whether this process is ready to execute.
     fn ready(&self) -> bool;

--- a/kernel/src/upcall.rs
+++ b/kernel/src/upcall.rs
@@ -80,14 +80,16 @@ impl Upcall {
         r2: usize,
     ) -> bool {
         let res = self.fn_ptr.map_or(false, |fp| {
-            process.enqueue_task(process::Task::FunctionCall(process::FunctionCall {
-                source: process::FunctionCallSource::Driver(self.upcall_id),
-                argument0: r0,
-                argument1: r1,
-                argument2: r2,
-                argument3: self.appdata,
-                pc: fp.as_ptr() as usize,
-            }))
+            process
+                .enqueue_task(process::Task::FunctionCall(process::FunctionCall {
+                    source: process::FunctionCallSource::Driver(self.upcall_id),
+                    argument0: r0,
+                    argument1: r1,
+                    argument2: r2,
+                    argument3: self.appdata,
+                    pc: fp.as_ptr() as usize,
+                }))
+                .is_ok()
         });
 
         if config::CONFIG.trace_syscalls {

--- a/kernel/src/upcall.rs
+++ b/kernel/src/upcall.rs
@@ -18,6 +18,47 @@ pub struct UpcallId {
     pub subscribe_num: usize,
 }
 
+/// Errors which can occur when scheduling a process Upcall.
+///
+/// Scheduling a null-Upcall (which will not be delivered to a process) is
+/// deliberately not an error, given that a null-Upcall is a well-defined Upcall
+/// to be set by a process. It behaves essentially the same as if the process
+/// would set a proper Upcall, and would ignore all invocations, with the
+/// benefit that no task is inserted in the process' task queue.
+#[derive(Copy, Clone, Debug)]
+pub enum UpcallError {
+    /// The passed `subscribe_num` exceeds the number of Upcalls
+    /// available for this process.
+    ///
+    /// For a [`Grant`](crate::grant::Grant) with `n` `NUM_UPCALLS`,
+    /// this error is returned when
+    /// `GrantUpcallTable::schedule_upcall` is invoked with
+    /// `subscribe_num >= n`.
+    ///
+    /// No Upcall has been scheduled, the call to
+    /// `GrantUpcallTable::schedule_upcall` had no observable effects.
+    ///
+    InvalidSubscribeNum,
+    /// The process' task queue is full.
+    ///
+    /// This error can occur when too many tasks (for example,
+    /// Upcalls) have been scheduled for a process, without that
+    /// process yielding or having a chance to resume execution.
+    ///
+    /// No Upcall has been scheduled, the call to
+    /// `GrantUpcallTable::schedule_upcall` had no observable effects.
+    QueueFull,
+    /// A kernel-internal invariant has been violated.
+    ///
+    /// This error should never happen. It can be returned if the
+    /// process is inactive (which should be caught by
+    /// [`Grant::enter`](crate::grant::Grant::enter)) or
+    /// `process.tasks` was taken.
+    ///
+    /// These cases cannot be reasonably handled.
+    KernelError,
+}
+
 /// Type for calling an upcall in a process.
 ///
 /// This is essentially a wrapper around a function pointer with
@@ -78,23 +119,47 @@ impl Upcall {
         r0: usize,
         r1: usize,
         r2: usize,
-    ) -> bool {
-        let res = self.fn_ptr.map_or(false, |fp| {
-            process
-                .enqueue_task(process::Task::FunctionCall(process::FunctionCall {
-                    source: process::FunctionCallSource::Driver(self.upcall_id),
-                    argument0: r0,
-                    argument1: r1,
-                    argument2: r2,
-                    argument3: self.appdata,
-                    pc: fp.as_ptr() as usize,
-                }))
-                .is_ok()
-        });
+    ) -> Result<(), UpcallError> {
+        let res = self.fn_ptr.map_or(
+            // A null-Upcall is treated as being delivered to
+            // the process and ignored
+            Ok(()),
+            |fp| {
+                let enqueue_res =
+                    process.enqueue_task(process::Task::FunctionCall(process::FunctionCall {
+                        source: process::FunctionCallSource::Driver(self.upcall_id),
+                        argument0: r0,
+                        argument1: r1,
+                        argument2: r2,
+                        argument3: self.appdata,
+                        pc: fp.as_ptr() as usize,
+                    }));
+
+                match enqueue_res {
+                    Ok(()) => Ok(()),
+                    Err(ErrorCode::NODEVICE) => {
+                        // There should be no code path to schedule an
+                        // Upcall on a process that is no longer
+                        // alive. Indicate a kernel-internal error.
+                        Err(UpcallError::KernelError)
+                    }
+                    Err(ErrorCode::NOMEM) => {
+                        // No space left in the process' task queue.
+                        Err(UpcallError::QueueFull)
+                    }
+                    Err(_) => {
+                        // All other errors returned by
+                        // `Process::enqueue_task` must be treated as
+                        // kernel-internal errors
+                        Err(UpcallError::KernelError)
+                    }
+                }
+            },
+        );
 
         if config::CONFIG.trace_syscalls {
             debug!(
-                "[{:?}] schedule[{:#x}:{}] @{:#x}({:#x}, {:#x}, {:#x}, {:#x}) = {}",
+                "[{:?}] schedule[{:#x}:{}] @{:#x}({:#x}, {:#x}, {:#x}, {:#x}) = {:?}",
                 self.process_id,
                 self.upcall_id.driver_num,
                 self.upcall_id.subscribe_num,


### PR DESCRIPTION
### Pull Request Overview

Following up on https://github.com/tock/tock/pull/2639#discussion_r664131701, this looks at changing the signature of scheduling upcalls to return a `Result` rather than a simple `bool`.

To start, this just looks at the kernel interfaces (i.e. this introduces 110 "unused Result" warnings in capsule code right now).

One interesting thing surfaced is that IPC does use the result of upcall scheduling to report to the IPC sender whether the receiver was scheduled successfully or not. Previously, this treated scheduling the null upcall as a failure. I'm not 100% sure that's right though -- a receiver has every right (although it would be odd) to ignore notifications. I used the new error code granularity to separate out this case right now; though maybe the best solution is to simply bubble up the error all the way to userspace for IPC.

---

This commit just changes the kernel interfaces, it does not address
all of the new unused Result warnings at all of the capsule scheduling
call sites.

### Testing Strategy

N/A yet [compiling]

### TODO or Help Wanted

Do these error code assignments make sense?

Should IPC treat scheduling a null upcall as an error or success?

Should I move forward with the rest of the capsules?

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [] Ran `make prepush`.
