### PR TITLE
Auto implement Group Traits

### DIFF
--- a/capsules/src/rf233.rs
+++ b/capsules/src/rf233.rs
@@ -1162,8 +1162,6 @@ impl<'a, S: spi::SpiMasterDevice> RF233<'a, S> {
     }
 }
 
-impl<S: spi::SpiMasterDevice> radio::Radio for RF233<'_, S> {}
-
 impl<S: spi::SpiMasterDevice> radio::RadioConfig for RF233<'_, S> {
     fn initialize(
         &self,

--- a/capsules/src/segger_rtt.rs
+++ b/capsules/src/segger_rtt.rs
@@ -200,9 +200,6 @@ impl<'a, A: hil::time::Alarm<'a>> SeggerRtt<'a, A> {
     }
 }
 
-impl<'a, A: hil::time::Alarm<'a>> uart::Uart<'a> for SeggerRtt<'a, A> {}
-impl<'a, A: hil::time::Alarm<'a>> uart::UartData<'a> for SeggerRtt<'a, A> {}
-
 impl<'a, A: hil::time::Alarm<'a>> uart::Transmit<'a> for SeggerRtt<'a, A> {
     fn set_transmit_client(&self, client: &'a dyn uart::TransmitClient) {
         self.client.set(client);

--- a/capsules/src/usb/cdc.rs
+++ b/capsules/src/usb/cdc.rs
@@ -750,9 +750,3 @@ impl<'a, U: hil::usb::UsbController<'a>, A: 'a + Alarm<'a>> DynamicDeferredCallC
         }
     }
 }
-
-impl<'a, U: hil::usb::UsbController<'a>, A: 'a + Alarm<'a>> uart::Uart<'a> for CdcAcm<'a, U, A> {}
-impl<'a, U: hil::usb::UsbController<'a>, A: 'a + Alarm<'a>> uart::UartData<'a>
-    for CdcAcm<'a, U, A>
-{
-}

--- a/capsules/src/virtual_uart.rs
+++ b/capsules/src/virtual_uart.rs
@@ -338,8 +338,6 @@ pub struct UartDevice<'a> {
     tx_client: OptionalCell<&'a dyn uart::TransmitClient>,
 }
 
-impl<'a> uart::UartData<'a> for UartDevice<'a> {}
-
 impl<'a> UartDevice<'a> {
     pub const fn new(mux: &'a MuxUart<'a>, receiver: bool) -> UartDevice<'a> {
         UartDevice {

--- a/chips/apollo3/src/gpio.rs
+++ b/chips/apollo3/src/gpio.rs
@@ -732,6 +732,3 @@ impl<'a> gpio::Interrupt<'a> for GpioPin<'a> {
         regs.int0stat.get() | regs.int1stat.get() != 0
     }
 }
-
-impl<'a> gpio::Pin for GpioPin<'a> {}
-impl<'a> gpio::InterruptPin<'a> for GpioPin<'a> {}

--- a/chips/apollo3/src/uart.rs
+++ b/chips/apollo3/src/uart.rs
@@ -291,9 +291,6 @@ impl Uart<'_> {
     }
 }
 
-impl<'a> hil::uart::UartData<'a> for Uart<'a> {}
-impl<'a> hil::uart::Uart<'a> for Uart<'a> {}
-
 impl hil::uart::Configure for Uart<'_> {
     fn configure(&self, params: hil::uart::Parameters) -> Result<(), ErrorCode> {
         let regs = self.registers;

--- a/chips/imxrt10xx/src/gpio.rs
+++ b/chips/imxrt10xx/src/gpio.rs
@@ -680,9 +680,6 @@ impl<'a> Pin<'a> {
     }
 }
 
-impl hil::gpio::Pin for Pin<'_> {}
-impl<'a> hil::gpio::InterruptPin<'a> for Pin<'a> {}
-
 impl hil::gpio::Configure for Pin<'_> {
     fn make_output(&self) -> hil::gpio::Configuration {
         self.set_mode(Mode::Output);

--- a/chips/imxrt10xx/src/lpuart.rs
+++ b/chips/imxrt10xx/src/lpuart.rs
@@ -896,8 +896,6 @@ impl<'a> hil::uart::Receive<'a> for Lpuart<'a> {
     }
 }
 
-impl<'a> hil::uart::UartData<'a> for Lpuart<'a> {}
-impl<'a> hil::uart::Uart<'a> for Lpuart<'a> {}
 struct LpuartClock<'a>(ccm::PeripheralClock<'a>);
 
 impl ClockInterface for LpuartClock<'_> {

--- a/chips/litex/src/uart.rs
+++ b/chips/litex/src/uart.rs
@@ -523,9 +523,6 @@ impl<'a, R: LiteXSoCRegisterConfiguration> uart::Receive<'a> for LiteXUart<'a, R
     }
 }
 
-impl<'a, R: LiteXSoCRegisterConfiguration> uart::Uart<'a> for LiteXUart<'a, R> {}
-impl<'a, R: LiteXSoCRegisterConfiguration> uart::UartData<'a> for LiteXUart<'a, R> {}
-
 impl<'a, R: LiteXSoCRegisterConfiguration> DynamicDeferredCallClient for LiteXUart<'a, R> {
     fn call(&self, _handle: DeferredCallHandle) {
         // Are we currently in a TX or RX transaction?

--- a/chips/lowrisc/src/gpio.rs
+++ b/chips/lowrisc/src/gpio.rs
@@ -291,6 +291,3 @@ impl<'a> gpio::Interrupt<'a> for GpioPin<'a> {
         self.gpio_registers.intr_state.is_set(self.pin)
     }
 }
-
-impl<'a> gpio::Pin for GpioPin<'a> {}
-impl<'a> gpio::InterruptPin<'a> for GpioPin<'a> {}

--- a/chips/lowrisc/src/uart.rs
+++ b/chips/lowrisc/src/uart.rs
@@ -259,9 +259,6 @@ impl<'a> Uart<'a> {
     }
 }
 
-impl<'a> hil::uart::UartData<'a> for Uart<'a> {}
-impl<'a> hil::uart::Uart<'a> for Uart<'a> {}
-
 impl hil::uart::Configure for Uart<'_> {
     fn configure(&self, params: hil::uart::Parameters) -> Result<(), ErrorCode> {
         let regs = self.registers;

--- a/chips/msp432/src/gpio.rs
+++ b/chips/msp432/src/gpio.rs
@@ -425,8 +425,6 @@ macro_rules! pin_implementation {
             }
         }
 
-        impl<'a> gpio::Pin for $pin_type<'a> {}
-
         impl<'a> gpio::Input for $pin_type<'a> {
             fn read(&self) -> bool {
                 self.read_level()
@@ -607,8 +605,6 @@ impl<'a> gpio::Interrupt<'a> for IntPin<'a> {
         (self.registers.ifg[self.reg_idx].get() & (1 << self.pin)) > 0
     }
 }
-
-impl<'a> gpio::InterruptPin<'a> for IntPin<'a> {}
 
 impl<'a> GpioManager<'a> {
     pub fn handle_interrupt(&self, port_idx: usize) {

--- a/chips/msp432/src/uart.rs
+++ b/chips/msp432/src/uart.rs
@@ -142,9 +142,6 @@ impl<'a> dma::DmaClient for Uart<'a> {
     }
 }
 
-impl<'a> hil::uart::UartData<'a> for Uart<'a> {}
-impl<'a> hil::uart::Uart<'a> for Uart<'a> {}
-
 impl<'a> hil::uart::Configure for Uart<'a> {
     fn configure(&self, params: hil::uart::Parameters) -> Result<(), ErrorCode> {
         // Disable module

--- a/chips/nrf52/src/i2c.rs
+++ b/chips/nrf52/src/i2c.rs
@@ -361,8 +361,6 @@ impl hil::i2c::I2CSlave for TWI {
     }
 }
 
-impl hil::i2c::I2CMasterSlave for TWI {}
-
 // The SPI0_TWI0 and SPI1_TWI1 interrupts are dispatched to the
 // correct handler by the service_pending_interrupts() routine in
 // chip.rs based on which peripheral is enabled.

--- a/chips/nrf52/src/ieee802154_radio.rs
+++ b/chips/nrf52/src/ieee802154_radio.rs
@@ -1016,8 +1016,6 @@ impl<'p> Radio<'p> {
     }
 }
 
-impl<'p> kernel::hil::radio::Radio for Radio<'p> {}
-
 impl<'p> kernel::hil::radio::RadioConfig for Radio<'p> {
     fn initialize(
         &self,

--- a/chips/nrf52/src/uart.rs
+++ b/chips/nrf52/src/uart.rs
@@ -436,9 +436,6 @@ impl<'a> Uarte<'a> {
     }
 }
 
-impl<'a> uart::UartData<'a> for Uarte<'a> {}
-impl<'a> uart::Uart<'a> for Uarte<'a> {}
-
 impl<'a> uart::Transmit<'a> for Uarte<'a> {
     fn set_transmit_client(&self, client: &'a dyn uart::TransmitClient) {
         self.tx_client.set(client);

--- a/chips/nrf5x/src/gpio.rs
+++ b/chips/nrf5x/src/gpio.rs
@@ -475,8 +475,6 @@ impl hil::gpio::Output for GPIOPin<'_> {
     }
 }
 
-impl hil::gpio::Pin for GPIOPin<'_> {}
-
 impl<'a> hil::gpio::Interrupt<'a> for GPIOPin<'a> {
     fn set_client(&self, client: &'a dyn hil::gpio::Client) {
         self.client.set(client);
@@ -515,8 +513,6 @@ impl<'a> hil::gpio::Interrupt<'a> for GPIOPin<'a> {
         }
     }
 }
-
-impl<'a> hil::gpio::InterruptPin<'a> for GPIOPin<'a> {}
 
 impl GPIOPin<'_> {
     /// Allocate a GPIOTE channel

--- a/chips/rp2040/src/gpio.rs
+++ b/chips/rp2040/src/gpio.rs
@@ -522,10 +522,6 @@ impl<'a> hil::gpio::Interrupt<'a> for RPGpioPin<'a> {
     }
 }
 
-impl<'a> hil::gpio::InterruptPin<'a> for RPGpioPin<'a> {}
-
-impl hil::gpio::Pin for RPGpioPin<'_> {}
-
 impl hil::gpio::Configure for RPGpioPin<'_> {
     fn configuration(&self) -> hil::gpio::Configuration {
         self.get_mode()

--- a/chips/rp2040/src/uart.rs
+++ b/chips/rp2040/src/uart.rs
@@ -6,7 +6,7 @@ use kernel::common::StaticRef;
 use kernel::hil;
 use kernel::hil::uart::ReceiveClient;
 use kernel::hil::uart::{
-    self, Configure, Parameters, Parity, Receive, StopBits, Transmit, TransmitClient, Width,
+    Configure, Parameters, Parity, Receive, StopBits, Transmit, TransmitClient, Width,
 };
 use kernel::ErrorCode;
 
@@ -722,5 +722,3 @@ impl<'a> Receive<'a> for Uart<'a> {
         }
     }
 }
-
-impl<'a> uart::Uart<'a> for Uart<'a> {}

--- a/chips/sam4l/src/gpio.rs
+++ b/chips/sam4l/src/gpio.rs
@@ -478,9 +478,6 @@ impl<'a> hil::Controller for GPIOPin<'a> {
     }
 }
 
-impl<'a> gpio::Pin for GPIOPin<'a> {}
-impl<'a> gpio::InterruptPin<'a> for GPIOPin<'a> {}
-
 impl<'a> gpio::Configure for GPIOPin<'a> {
     fn set_floating_state(&self, mode: gpio::FloatingState) {
         match mode {

--- a/chips/sam4l/src/i2c.rs
+++ b/chips/sam4l/src/i2c.rs
@@ -1501,5 +1501,3 @@ impl hil::i2c::I2CSlave for I2CHw {
         self.slave_listen();
     }
 }
-
-impl hil::i2c::I2CMasterSlave for I2CHw {}

--- a/chips/sam4l/src/usart.rs
+++ b/chips/sam4l/src/usart.rs
@@ -938,9 +938,6 @@ impl<'a> uart::Transmit<'a> for USART<'a> {
     }
 }
 
-impl<'a> uart::UartAdvanced<'a> for USART<'a> {}
-impl<'a> uart::Uart<'a> for USART<'a> {}
-
 impl uart::Configure for USART<'_> {
     fn configure(&self, parameters: uart::Parameters) -> Result<(), ErrorCode> {
         if self.usart_mode.get() != UsartMode::Uart {

--- a/chips/sifive/src/gpio.rs
+++ b/chips/sifive/src/gpio.rs
@@ -297,6 +297,3 @@ impl<'a> hil::gpio::Interrupt<'a> for GpioPin<'a> {
         regs.rise_ip.is_set(self.pin) || regs.fall_ip.is_set(self.pin)
     }
 }
-
-impl hil::gpio::Pin for GpioPin<'_> {}
-impl<'a> hil::gpio::InterruptPin<'a> for GpioPin<'a> {}

--- a/chips/sifive/src/uart.rs
+++ b/chips/sifive/src/uart.rs
@@ -168,9 +168,6 @@ impl<'a> Uart<'a> {
     }
 }
 
-impl<'a> hil::uart::UartData<'a> for Uart<'a> {}
-impl<'a> hil::uart::Uart<'a> for Uart<'a> {}
-
 impl hil::uart::Configure for Uart<'_> {
     fn configure(&self, params: hil::uart::Parameters) -> Result<(), ErrorCode> {
         // This chip does not support these features.

--- a/chips/stm32f303xc/src/gpio.rs
+++ b/chips/stm32f303xc/src/gpio.rs
@@ -1011,9 +1011,6 @@ impl<'a> Pin<'a> {
     }
 }
 
-impl hil::gpio::Pin for Pin<'_> {}
-impl<'a> hil::gpio::InterruptPin<'a> for Pin<'a> {}
-
 impl hil::gpio::Configure for Pin<'_> {
     /// Output mode default is push-pull
     fn make_output(&self) -> hil::gpio::Configuration {

--- a/chips/stm32f303xc/src/usart.rs
+++ b/chips/stm32f303xc/src/usart.rs
@@ -624,9 +624,6 @@ impl<'a> hil::uart::Receive<'a> for Usart<'a> {
     }
 }
 
-impl<'a> hil::uart::UartData<'a> for Usart<'a> {}
-impl<'a> hil::uart::Uart<'a> for Usart<'a> {}
-
 struct UsartClock<'a>(rcc::PeripheralClock<'a>);
 
 impl ClockInterface for UsartClock<'_> {

--- a/chips/stm32f4xx/src/gpio.rs
+++ b/chips/stm32f4xx/src/gpio.rs
@@ -1098,9 +1098,6 @@ impl<'a> Pin<'a> {
     }
 }
 
-impl hil::gpio::Pin for Pin<'_> {}
-impl<'a> hil::gpio::InterruptPin<'a> for Pin<'a> {}
-
 impl hil::gpio::Configure for Pin<'_> {
     /// Output mode default is push-pull
     fn make_output(&self) -> hil::gpio::Configuration {

--- a/chips/stm32f4xx/src/usart.rs
+++ b/chips/stm32f4xx/src/usart.rs
@@ -504,9 +504,6 @@ impl<'a> hil::uart::Receive<'a> for Usart<'a> {
     }
 }
 
-impl<'a> hil::uart::UartData<'a> for Usart<'a> {}
-impl<'a> hil::uart::Uart<'a> for Usart<'a> {}
-
 impl dma1::StreamClient for Usart<'_> {
     fn transfer_done(&self, pid: dma1::Dma1Peripheral) {
         if pid == self.tx_dma_pid {

--- a/chips/swervolf-eh1/src/uart.rs
+++ b/chips/swervolf-eh1/src/uart.rs
@@ -94,9 +94,6 @@ impl<'a> Uart<'a> {
     }
 }
 
-impl<'a> hil::uart::UartData<'a> for Uart<'a> {}
-impl<'a> hil::uart::Uart<'a> for Uart<'a> {}
-
 impl hil::uart::Configure for Uart<'_> {
     fn configure(&self, params: hil::uart::Parameters) -> Result<(), ErrorCode> {
         // This chip does not support these features.

--- a/kernel/src/hil/gpio.rs
+++ b/kernel/src/hil/gpio.rs
@@ -69,6 +69,12 @@ pub trait InterruptPin<'a>: Pin + Interrupt<'a> {}
 /// either input or output and also to source interrupts which
 /// pass a value.
 pub trait InterruptValuePin<'a>: Pin + InterruptWithValue<'a> {}
+
+// Provide blanket implementations for all trait groups
+impl<T: Input + Output + Configure> Pin for T {}
+impl<'a, T: Pin + Interrupt<'a>> InterruptPin<'a> for T {}
+impl<'a, T: Pin + InterruptWithValue<'a>> InterruptValuePin<'a> for T {}
+
 /// Control and configure a GPIO pin.
 pub trait Configure {
     /// Return the current pin configuration.
@@ -363,9 +369,6 @@ impl<'a, IP: InterruptPin<'a>> Output for InterruptValueWrapper<'a, IP> {
         self.source.toggle()
     }
 }
-
-impl<'a, IP: InterruptPin<'a>> InterruptValuePin<'a> for InterruptValueWrapper<'a, IP> {}
-impl<'a, IP: InterruptPin<'a>> Pin for InterruptValueWrapper<'a, IP> {}
 
 impl<'a, IP: InterruptPin<'a>> Client for InterruptValueWrapper<'a, IP> {
     fn fired(&self) {

--- a/kernel/src/hil/i2c.rs
+++ b/kernel/src/hil/i2c.rs
@@ -176,6 +176,8 @@ pub trait I2CSlave {
 /// Convenience type for capsules that need hardware that supports both
 /// Master and Slave modes.
 pub trait I2CMasterSlave: I2CMaster + I2CSlave {}
+// Provide blanket implementations for trait group
+impl<T: I2CMaster + I2CSlave> I2CMasterSlave for T {}
 
 /// Client interface for capsules that use I2CMaster devices.
 pub trait I2CHwMasterClient {

--- a/kernel/src/hil/radio.rs
+++ b/kernel/src/hil/radio.rs
@@ -63,6 +63,8 @@ pub const MAX_BUF_SIZE: usize = PSDU_OFFSET + MAX_MTU;
 pub const MIN_PAYLOAD_OFFSET: usize = PSDU_OFFSET + MIN_MHR_SIZE;
 
 pub trait Radio: RadioConfig + RadioData {}
+// Provide blanket implementations for trait group
+impl<T: RadioConfig + RadioData> Radio for T {}
 
 /// Configure the 802.15.4 radio.
 pub trait RadioConfig {

--- a/kernel/src/hil/screen.rs
+++ b/kernel/src/hil/screen.rs
@@ -221,6 +221,8 @@ pub trait Screen {
 }
 
 pub trait ScreenAdvanced: Screen + ScreenSetup {}
+// Provide blanket implementations for trait group
+impl<T: Screen + ScreenSetup> ScreenAdvanced for T {}
 
 pub trait ScreenSetupClient {
     /// The screen will call this function to notify that a command has finished.

--- a/kernel/src/hil/uart.rs
+++ b/kernel/src/hil/uart.rs
@@ -63,6 +63,12 @@ pub trait UartData<'a>: Transmit<'a> + Receive<'a> {}
 pub trait UartAdvanced<'a>: Configure + Transmit<'a> + ReceiveAdvanced<'a> {}
 pub trait Client: ReceiveClient + TransmitClient {}
 
+// Provide blanket implementations for all trait groups
+impl<'a, T: Configure + Transmit<'a> + Receive<'a>> Uart<'a> for T {}
+impl<'a, T: Transmit<'a> + Receive<'a>> UartData<'a> for T {}
+impl<'a, T: Configure + Transmit<'a> + ReceiveAdvanced<'a>> UartAdvanced<'a> for T {}
+impl<T: ReceiveClient + TransmitClient> Client for T {}
+
 /// Trait for configuring a UART.
 pub trait Configure {
     /// Returns Ok(()), or


### PR DESCRIPTION
### Pull Request Overview

Instead of each object providing an empty implementation for a group trait, auto implement the group trait if the object has all of the necessary sub-traits.


### Testing Strategy

`cargo check` on each CL


### Documentation Updated

- No documnetation update

### Formatting

- [x] Ran `make prepush`.
