### PR TITLE
kernel/hil/time: allow time to be a dyn trait object

### DIFF
--- a/boards/imix/src/test/icmp_lowpan_test.rs
+++ b/boards/imix/src/test/icmp_lowpan_test.rs
@@ -30,7 +30,7 @@ use kernel::capabilities::NetworkCapabilityCreationCapability;
 use kernel::create_capability;
 use kernel::debug;
 use kernel::hil::radio;
-use kernel::hil::time::{self, Alarm};
+use kernel::hil::time::{self, Alarm, ConvertTicks};
 use kernel::static_init;
 
 pub const SRC_ADDR: IPAddr = IPAddr([
@@ -191,7 +191,7 @@ impl<'a, A: time::Alarm<'a>> LowpanICMPTest<'a, A> {
     }
 
     fn schedule_next(&self) {
-        let delta = A::ticks_from_ms(TEST_DELAY_MS);
+        let delta = self.alarm.ticks_from_ms(TEST_DELAY_MS);
         let now = self.alarm.now();
         self.alarm.set_alarm(now, delta);
     }

--- a/boards/imix/src/test/ipv6_lowpan_test.rs
+++ b/boards/imix/src/test/ipv6_lowpan_test.rs
@@ -41,7 +41,7 @@ use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use core::cell::Cell;
 use kernel::debug;
 use kernel::hil::radio;
-use kernel::hil::time::{self, Alarm};
+use kernel::hil::time::{self, Alarm, ConvertTicks};
 use kernel::static_init;
 use kernel::ErrorCode;
 
@@ -233,7 +233,7 @@ impl<'a, A: time::Alarm<'a>> LowpanTest<'a, A> {
     }
 
     fn schedule_next(&self) {
-        let delay = A::ticks_from_ms(TEST_DELAY_MS);
+        let delay = self.alarm.ticks_from_ms(TEST_DELAY_MS);
         let now = self.alarm.now();
         self.alarm.set_alarm(now, delay);
     }

--- a/boards/imix/src/test/linear_log_test.rs
+++ b/boards/imix/src/test/linear_log_test.rs
@@ -20,7 +20,7 @@ use kernel::debug;
 use kernel::dynamic_deferred_call::DynamicDeferredCall;
 use kernel::hil::flash;
 use kernel::hil::log::{LogRead, LogReadClient, LogWrite, LogWriteClient};
-use kernel::hil::time::{Alarm, AlarmClient};
+use kernel::hil::time::{Alarm, AlarmClient, ConvertTicks};
 use kernel::static_init;
 use kernel::storage_volume;
 use kernel::utilities::cells::{NumericCellExt, TakeCell};
@@ -237,7 +237,7 @@ impl<A: Alarm<'static>> LogTest<A> {
     }
 
     fn wait(&self) {
-        let delay = A::ticks_from_ms(WAIT_MS);
+        let delay = self.alarm.ticks_from_ms(WAIT_MS);
         let now = self.alarm.now();
         self.alarm.set_alarm(now, delay);
     }

--- a/boards/imix/src/test/log_test.rs
+++ b/boards/imix/src/test/log_test.rs
@@ -33,7 +33,7 @@ use kernel::dynamic_deferred_call::DynamicDeferredCall;
 use kernel::hil::flash;
 use kernel::hil::gpio::{self, Interrupt};
 use kernel::hil::log::{LogRead, LogReadClient, LogWrite, LogWriteClient};
-use kernel::hil::time::{Alarm, AlarmClient};
+use kernel::hil::time::{Alarm, AlarmClient, ConvertTicks};
 use kernel::static_init;
 use kernel::storage_volume;
 use kernel::utilities::cells::{NumericCellExt, TakeCell};
@@ -430,7 +430,7 @@ impl<A: Alarm<'static>> LogTest<A> {
     }
 
     fn wait(&self) {
-        let delay = A::ticks_from_ms(WAIT_MS);
+        let delay = self.alarm.ticks_from_ms(WAIT_MS);
         let now = self.alarm.now();
         self.alarm.set_alarm(now, delay);
     }

--- a/boards/imix/src/test/udp_lowpan_test.rs
+++ b/boards/imix/src/test/udp_lowpan_test.rs
@@ -132,7 +132,7 @@ use kernel::capabilities::NetworkCapabilityCreationCapability;
 use kernel::component::Component;
 use kernel::create_capability;
 use kernel::debug;
-use kernel::hil::time::{self, Alarm};
+use kernel::hil::time::{self, Alarm, ConvertTicks};
 use kernel::static_init;
 use kernel::ErrorCode;
 
@@ -264,7 +264,7 @@ impl<'a, A: time::Alarm<'a>> LowpanTest<'a, A> {
     }
 
     fn schedule_next(&self) {
-        let delta = A::ticks_from_ms(TEST_DELAY_MS);
+        let delta = self.alarm.ticks_from_ms(TEST_DELAY_MS);
         let now = self.alarm.now();
         self.alarm.set_alarm(now, delta);
     }

--- a/boards/nano33ble/src/test/linear_log_test.rs
+++ b/boards/nano33ble/src/test/linear_log_test.rs
@@ -26,7 +26,7 @@ use kernel::debug_verbose;
 use kernel::dynamic_deferred_call::DynamicDeferredCall;
 use kernel::hil::flash;
 use kernel::hil::log::{LogRead, LogReadClient, LogWrite, LogWriteClient};
-use kernel::hil::time::{Alarm, AlarmClient};
+use kernel::hil::time::{Alarm, AlarmClient, ConvertTicks};
 use kernel::static_init;
 use kernel::storage_volume;
 use kernel::utilities::cells::{NumericCellExt, TakeCell};
@@ -254,7 +254,7 @@ impl<A: Alarm<'static>> LogTest<A> {
     }
 
     fn wait(&self) {
-        let delay = A::ticks_from_ms(WAIT_MS);
+        let delay = self.alarm.ticks_from_ms(WAIT_MS);
         let now = self.alarm.now();
         self.alarm.set_alarm(now, delay);
     }

--- a/boards/nano33ble/src/test/log_test.rs
+++ b/boards/nano33ble/src/test/log_test.rs
@@ -37,7 +37,7 @@ use kernel::dynamic_deferred_call::DynamicDeferredCall;
 use kernel::hil::flash;
 use kernel::hil::gpio::{self, Interrupt, InterruptEdge};
 use kernel::hil::log::{LogRead, LogReadClient, LogWrite, LogWriteClient};
-use kernel::hil::time::{Alarm, AlarmClient};
+use kernel::hil::time::{Alarm, AlarmClient, ConvertTicks};
 use kernel::static_init;
 use kernel::storage_volume;
 use kernel::utilities::cells::{NumericCellExt, TakeCell};
@@ -439,7 +439,7 @@ impl<A: Alarm<'static>> LogTest<A> {
     }
 
     fn wait(&self) {
-        let delay = A::ticks_from_ms(WAIT_MS);
+        let delay = self.alarm.ticks_from_ms(WAIT_MS);
         let now = self.alarm.now();
         self.alarm.set_alarm(now, delay);
     }

--- a/capsules/src/ieee802154/xmac.rs
+++ b/capsules/src/ieee802154/xmac.rs
@@ -83,7 +83,7 @@ use crate::net::ieee802154::{FrameType, FrameVersion, Header, MacAddress, PanID}
 use core::cell::Cell;
 use kernel::hil::radio;
 use kernel::hil::rng::{self, Rng};
-use kernel::hil::time::{self, Alarm, Ticks};
+use kernel::hil::time::{self, Alarm, ConvertTicks, Ticks};
 use kernel::utilities::cells::{OptionalCell, TakeCell};
 use kernel::ErrorCode;
 
@@ -210,7 +210,7 @@ impl<'a, R: radio::Radio, A: Alarm<'a>> XMac<'a, R, A> {
     // Sets the timer to fire a set number of milliseconds in the future based
     // on the current tick value.
     fn set_timer_ms(&self, ms: u32) {
-        let interval = A::ticks_from_ms(ms);
+        let interval = self.alarm.ticks_from_ms(ms);
         self.set_timer(interval);
     }
 

--- a/capsules/src/isl29035.rs
+++ b/capsules/src/isl29035.rs
@@ -31,7 +31,7 @@
 use core::cell::Cell;
 use kernel::hil::i2c::{Error, I2CClient, I2CDevice};
 use kernel::hil::sensors::{AmbientLight, AmbientLightClient};
-use kernel::hil::time;
+use kernel::hil::time::{self, ConvertTicks};
 use kernel::utilities::cells::{OptionalCell, TakeCell};
 use kernel::ErrorCode;
 
@@ -139,7 +139,7 @@ impl<'a, A: time::Alarm<'a>> I2CClient for Isl29035<'a, A> {
             State::Enabling => {
                 // Set a timer to wait for the conversion to be done.
                 // For 8 bits, thats 410 us (per Table 11 in the datasheet).
-                let interval = A::ticks_from_us(410);
+                let interval = self.alarm.ticks_from_us(410);
                 self.alarm.set_alarm(self.alarm.now(), interval);
 
                 // Now wait for timer to expire

--- a/capsules/src/led_matrix.rs
+++ b/capsules/src/led_matrix.rs
@@ -87,7 +87,7 @@ use kernel::{ErrorCode, ProcessId};
 
 use kernel::hil::gpio::{ActivationMode, Pin};
 use kernel::hil::led::Led;
-use kernel::hil::time::{Alarm, AlarmClient};
+use kernel::hil::time::{Alarm, AlarmClient, ConvertTicks};
 
 /// Syscall driver number.
 use crate::driver;
@@ -169,7 +169,7 @@ impl<'a, L: Pin, A: Alarm<'a>> LedMatrixDriver<'a, L, A> {
             }
         });
         self.row_set(self.rows[self.current_row.get()]);
-        let interval = A::ticks_from_ms(self.timing as u32);
+        let interval = self.alarm.ticks_from_ms(self.timing as u32);
         self.alarm.set_alarm(self.alarm.now(), interval);
     }
 

--- a/capsules/src/mx25r6435f.rs
+++ b/capsules/src/mx25r6435f.rs
@@ -52,6 +52,7 @@ use core::cell::Cell;
 use core::ops::{Index, IndexMut};
 use kernel::debug;
 use kernel::hil;
+use kernel::hil::time::ConvertTicks;
 use kernel::utilities::cells::OptionalCell;
 use kernel::utilities::cells::TakeCell;
 use kernel::ErrorCode;
@@ -405,7 +406,7 @@ impl<
                 self.txbuffer.replace(write_buffer);
                 // Datasheet says erase takes 58 ms on average. So we wait that
                 // long.
-                let delay = A::ticks_from_ms(58);
+                let delay = self.alarm.ticks_from_ms(58);
                 self.alarm.set_alarm(self.alarm.now(), delay);
             }
             State::EraseSectorCheckDone { operation } => {
@@ -502,7 +503,7 @@ impl<
                 self.txbuffer.replace(write_buffer);
                 // Datasheet says write page takes 3.2 ms on average. So we wait
                 // that long.
-                let delay = A::ticks_from_us(3200);
+                let delay = self.alarm.ticks_from_us(3200);
                 self.alarm.set_alarm(self.alarm.now(), delay);
             }
             State::WriteSectorWaitDone {

--- a/capsules/src/net/ipv6/ipv6_send.rs
+++ b/capsules/src/net/ipv6/ipv6_send.rs
@@ -26,7 +26,7 @@ use crate::net::sixlowpan::sixlowpan_state::TxState;
 use core::cell::Cell;
 
 use kernel::debug;
-use kernel::hil::time;
+use kernel::hil::time::{self, ConvertTicks};
 use kernel::utilities::cells::{OptionalCell, TakeCell};
 use kernel::utilities::leasable_buffer::LeasableBuffer;
 use kernel::ErrorCode;
@@ -276,7 +276,7 @@ impl<'a, A: time::Alarm<'a>> TxClient for IP6SendStruct<'a, A> {
             // fragment, before passing the send_done callback back to the client. This
             // could be optimized by checking if it is the last fragment before setting the timer.
             self.alarm
-                .set_alarm(self.alarm.now(), A::ticks_from_ms(100));
+                .set_alarm(self.alarm.now(), self.alarm.ticks_from_ms(100));
         }
     }
 }

--- a/capsules/src/sdcard.rs
+++ b/capsules/src/sdcard.rs
@@ -46,6 +46,7 @@ use core::mem;
 
 use kernel::grant::Grant;
 use kernel::hil;
+use kernel::hil::time::ConvertTicks;
 use kernel::processbuffer::{ReadOnlyProcessBuffer, ReadableProcessBuffer};
 use kernel::processbuffer::{ReadWriteProcessBuffer, WriteableProcessBuffer};
 use kernel::syscall::{CommandReturn, SyscallDriver};
@@ -517,7 +518,7 @@ impl<'a, A: hil::time::Alarm<'a>> SDCard<'a, A> {
 
                     // try again after 10 ms
                     self.alarm_state.set(AlarmState::RepeatHCSInit);
-                    let delay = A::ticks_from_ms(10);
+                    let delay = self.alarm.ticks_from_ms(10);
                     self.alarm.set_alarm(self.alarm.now(), delay);
                 } else {
                     // error, send callback and quit
@@ -613,7 +614,7 @@ impl<'a, A: hil::time::Alarm<'a>> SDCard<'a, A> {
 
                     // try again after 10 ms
                     self.alarm_state.set(AlarmState::RepeatAppSpecificInit);
-                    let delay = A::ticks_from_ms(10);
+                    let delay = self.alarm.ticks_from_ms(10);
                     self.alarm.set_alarm(self.alarm.now(), delay);
                 } else {
                     // error, send callback and quit
@@ -651,7 +652,7 @@ impl<'a, A: hil::time::Alarm<'a>> SDCard<'a, A> {
 
                     // try again after 10 ms
                     self.alarm_state.set(AlarmState::RepeatGenericInit);
-                    let delay = A::ticks_from_ms(10);
+                    let delay = self.alarm.ticks_from_ms(10);
                     self.alarm.set_alarm(self.alarm.now(), delay);
                 } else {
                     // error, send callback and quit
@@ -793,7 +794,7 @@ impl<'a, A: hil::time::Alarm<'a>> SDCard<'a, A> {
 
                     // try again after 1 ms
                     self.alarm_state.set(AlarmState::WaitForDataBlock);
-                    let delay = A::ticks_from_ms(1);
+                    let delay = self.alarm.ticks_from_ms(1);
                     self.alarm.set_alarm(self.alarm.now(), delay);
                 } else {
                     // error, send callback and quit
@@ -851,7 +852,7 @@ impl<'a, A: hil::time::Alarm<'a>> SDCard<'a, A> {
                     // try again after 1 ms
                     self.alarm_state
                         .set(AlarmState::WaitForDataBlocks { count: count });
-                    let delay = A::ticks_from_ms(1);
+                    let delay = self.alarm.ticks_from_ms(1);
                     self.alarm.set_alarm(self.alarm.now(), delay);
                 } else {
                     // error, send callback and quit
@@ -1038,7 +1039,7 @@ impl<'a, A: hil::time::Alarm<'a>> SDCard<'a, A> {
 
                     // try again after 1 ms
                     self.alarm_state.set(AlarmState::WaitForWriteBusy);
-                    let delay = A::ticks_from_ms(1);
+                    let delay = self.alarm.ticks_from_ms(1);
                     self.alarm.set_alarm(self.alarm.now(), delay);
                 }
             }
@@ -1396,7 +1397,7 @@ impl<'a, A: hil::time::Alarm<'a>> hil::gpio::Client for SDCard<'a, A> {
 
         // run a timer for 500 ms in order to let the sd card settle
         self.alarm_state.set(AlarmState::DetectionChange);
-        let delay = A::ticks_from_ms(500);
+        let delay = self.alarm.ticks_from_ms(500);
         self.alarm.set_alarm(self.alarm.now(), delay);
     }
 }

--- a/capsules/src/segger_rtt.rs
+++ b/capsules/src/segger_rtt.rs
@@ -88,6 +88,7 @@
 use core::cell::Cell;
 use core::marker::PhantomData;
 use kernel::hil;
+use kernel::hil::time::ConvertTicks;
 use kernel::hil::uart;
 use kernel::utilities::cells::{OptionalCell, TakeCell, VolatileCell};
 use kernel::ErrorCode;
@@ -236,7 +237,7 @@ impl<'a, A: hil::time::Alarm<'a>> uart::Transmit<'a> for SeggerRtt<'a, A> {
                     // board, passing buffers up to 1500 bytes from userspace. 100 micro-seconds
                     // was too short, even for buffers as small as 128 bytes. 1 milli-second seems to
                     // be reliable.
-                    let delay = A::ticks_from_us(1000);
+                    let delay = self.alarm.ticks_from_us(1000);
                     self.alarm.set_alarm(self.alarm.now(), delay);
                 })
             });

--- a/capsules/src/sht3x.rs
+++ b/capsules/src/sht3x.rs
@@ -8,7 +8,7 @@ use core::cell::Cell;
 use enum_primitive::cast::FromPrimitive;
 use enum_primitive::enum_from_primitive;
 use kernel::hil::i2c;
-use kernel::hil::time::{self, Alarm};
+use kernel::hil::time::{self, Alarm, ConvertTicks};
 use kernel::utilities::cells::{OptionalCell, TakeCell};
 use kernel::ErrorCode;
 
@@ -203,7 +203,7 @@ impl<'a, A: Alarm<'a>> i2c::I2CClient for SHT3x<'a, A> {
                     }
                     State::Read => {
                         self.buffer.replace(buffer);
-                        let interval = A::ticks_from_ms(20);
+                        let interval = self.alarm.ticks_from_ms(20);
                         self.alarm.set_alarm(self.alarm.now(), interval);
                     }
                     _ => {}

--- a/capsules/src/si7021.rs
+++ b/capsules/src/si7021.rs
@@ -38,7 +38,7 @@
 
 use core::cell::Cell;
 use kernel::hil::i2c;
-use kernel::hil::time;
+use kernel::hil::time::{self, ConvertTicks};
 use kernel::utilities::cells::{OptionalCell, TakeCell};
 use kernel::ErrorCode;
 
@@ -136,7 +136,7 @@ impl<'a, A: time::Alarm<'a>> SI7021<'a, A> {
     }
 
     fn init_measurement(&self, buffer: &'static mut [u8]) {
-        let delay = A::ticks_from_ms(20);
+        let delay = self.alarm.ticks_from_ms(20);
         self.alarm.set_alarm(self.alarm.now(), delay);
 
         // Now wait for timer to expire

--- a/capsules/src/st77xx.rs
+++ b/capsules/src/st77xx.rs
@@ -40,7 +40,7 @@ use kernel::hil::gpio::Pin;
 use kernel::hil::screen::{
     self, ScreenClient, ScreenPixelFormat, ScreenRotation, ScreenSetupClient,
 };
-use kernel::hil::time::{self, Alarm};
+use kernel::hil::time::{self, Alarm, ConvertTicks};
 use kernel::utilities::cells::{OptionalCell, TakeCell};
 use kernel::ErrorCode;
 
@@ -656,7 +656,7 @@ impl<'a, A: Alarm<'a>, B: Bus<'a>, P: Pin> ST77XX<'a, A, B, P> {
     ///  self.set_delay(10, Status::Idle);
     fn set_delay(&self, timer: u32, next_status: Status) {
         self.status.set(next_status);
-        let interval = A::ticks_from_ms(timer);
+        let interval = self.alarm.ticks_from_ms(timer);
         self.alarm.set_alarm(self.alarm.now(), interval);
     }
 }

--- a/capsules/src/test/alarm_edge_cases.rs
+++ b/capsules/src/test/alarm_edge_cases.rs
@@ -6,7 +6,7 @@
 //! Last Modified: 6/17/2020
 use core::cell::Cell;
 use kernel::debug;
-use kernel::hil::time::{Alarm, AlarmClient, Ticks};
+use kernel::hil::time::{Alarm, AlarmClient, ConvertTicks, Ticks};
 
 pub struct TestAlarmEdgeCases<'a, A: 'a> {
     alarm: &'a A,
@@ -32,7 +32,7 @@ impl<'a, A: Alarm<'a>> TestAlarmEdgeCases<'a, A> {
 
     fn set_next_alarm(&self) {
         let counter = self.counter.get();
-        let delay = A::ticks_from_ms(self.alarms[counter % 20]);
+        let delay = self.alarm.ticks_from_ms(self.alarms[counter % 20]);
         let now = self.alarm.now();
         let start = now.wrapping_sub(A::Ticks::from(10));
 

--- a/capsules/src/test/random_alarm.rs
+++ b/capsules/src/test/random_alarm.rs
@@ -7,7 +7,7 @@
 
 use core::cell::Cell;
 
-use kernel::hil::time::{Alarm, AlarmClient, Ticks};
+use kernel::hil::time::{Alarm, AlarmClient, ConvertTicks, Ticks};
 
 pub struct TestRandomAlarm<'a, A: Alarm<'a>> {
     alarm: &'a A,
@@ -21,7 +21,7 @@ impl<'a, A: Alarm<'a>> TestRandomAlarm<'a, A> {
         TestRandomAlarm {
             alarm: alarm,
             counter: Cell::new(value),
-            expected: Cell::new(A::ticks_from_seconds(0)),
+            expected: Cell::new(alarm.ticks_from_seconds(0)),
             _id: ch,
         }
     }
@@ -37,7 +37,7 @@ impl<'a, A: Alarm<'a>> TestRandomAlarm<'a, A> {
             // Try delays of zero in 1 of 11 cases
             us = 0;
         }
-        let delay = A::ticks_from_us(us);
+        let delay = self.alarm.ticks_from_us(us);
         let now = self.alarm.now();
         // Subtract 0-9 so we are always asking from the past.
         // If the delay is already 0, don't subtract anything.

--- a/capsules/src/test/random_timer.rs
+++ b/capsules/src/test/random_timer.rs
@@ -9,7 +9,7 @@
 use core::cell::Cell;
 
 use kernel::debug;
-use kernel::hil::time::{Ticks, Timer, TimerClient};
+use kernel::hil::time::{ConvertTicks, Ticks, Timer, TimerClient};
 
 pub struct TestRandomTimer<'a, T: 'a> {
     timer: &'a T,
@@ -46,7 +46,7 @@ impl<'a, T: Timer<'a>> TestRandomTimer<'a, T> {
                 // Try delays of zero in 1 of 11 cases
                 us = 0;
             }
-            let new_interval = T::ticks_from_us(us);
+            let new_interval = self.timer.ticks_from_us(us);
             self.interval.set(new_interval.into_u32());
             if us % 7 == 0 {
                 let new_counter = 2 + self.interval.get() * 23 % 13;

--- a/capsules/src/usb/cdc.rs
+++ b/capsules/src/usb/cdc.rs
@@ -18,7 +18,7 @@ use kernel::dynamic_deferred_call::{
     DeferredCallHandle, DynamicDeferredCall, DynamicDeferredCallClient,
 };
 use kernel::hil;
-use kernel::hil::time::{Alarm, AlarmClient};
+use kernel::hil::time::{Alarm, AlarmClient, ConvertTicks};
 use kernel::hil::uart;
 use kernel::hil::usb::TransferType;
 use kernel::utilities::cells::OptionalCell;
@@ -360,7 +360,7 @@ impl<'a, U: hil::usb::UsbController<'a>, A: 'a + Alarm<'a>> hil::usb::Client<'a>
 
         self.timeout_alarm.set_alarm(
             self.timeout_alarm.now(),
-            A::ticks_from_ms(CDC_BUFFER_TIMEOUT_MS),
+            self.timeout_alarm.ticks_from_ms(CDC_BUFFER_TIMEOUT_MS),
         );
     }
 

--- a/capsules/src/virtual_alarm.rs
+++ b/capsules/src/virtual_alarm.rs
@@ -35,7 +35,7 @@ impl<'a, A: Alarm<'a>> ListNode<'a, VirtualMuxAlarm<'a, A>> for VirtualMuxAlarm<
 
 impl<'a, A: Alarm<'a>> VirtualMuxAlarm<'a, A> {
     pub fn new(mux_alarm: &'a MuxAlarm<'a, A>) -> VirtualMuxAlarm<'a, A> {
-        let zero = A::ticks_from_seconds(0);
+        let zero = A::Ticks::from(0);
         VirtualMuxAlarm {
             mux: mux_alarm,
             reference: Cell::new(zero),

--- a/capsules/src/virtual_timer.rs
+++ b/capsules/src/virtual_timer.rs
@@ -43,7 +43,7 @@ impl<'a, A: Alarm<'a>> ListNode<'a, VirtualTimer<'a, A>> for VirtualTimer<'a, A>
 
 impl<'a, A: Alarm<'a>> VirtualTimer<'a, A> {
     pub fn new(mux_timer: &'a MuxTimer<'a, A>) -> VirtualTimer<'a, A> {
-        let zero = A::ticks_from_seconds(0);
+        let zero = A::Ticks::from(0);
         let v = VirtualTimer {
             mux: mux_timer,
             when: Cell::new(zero),

--- a/chips/sifive/src/clint.rs
+++ b/chips/sifive/src/clint.rs
@@ -1,6 +1,6 @@
 //! Create a timer using the Machine Timer registers.
 
-use kernel::hil::time::{self, Alarm, Freq32KHz, Frequency, Ticks, Ticks64, Time};
+use kernel::hil::time::{self, Alarm, ConvertTicks, Freq32KHz, Frequency, Ticks, Ticks64, Time};
 use kernel::utilities::cells::OptionalCell;
 use kernel::utilities::registers::interfaces::Writeable;
 use kernel::utilities::registers::{register_structs, ReadWrite};
@@ -97,7 +97,7 @@ impl<'a> time::Alarm<'a> for Clint<'a> {
 impl kernel::platform::scheduler_timer::SchedulerTimer for Clint<'_> {
     fn start(&self, us: u32) {
         let now = self.now();
-        let tics = Self::ticks_from_us(us);
+        let tics = self.ticks_from_us(us);
         self.set_alarm(now, tics);
     }
 

--- a/chips/swerv/src/eh1_timer.rs
+++ b/chips/swerv/src/eh1_timer.rs
@@ -1,7 +1,7 @@
 //! Internal Timer
 
 use kernel::hil::time;
-use kernel::hil::time::{Alarm, Counter, Ticks, Ticks32, Time};
+use kernel::hil::time::{Alarm, ConvertTicks, Counter, Ticks, Ticks32, Time};
 use kernel::utilities::cells::OptionalCell;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
 use kernel::utilities::registers::register_bitfields;
@@ -183,7 +183,7 @@ impl<'a> Alarm<'a> for Timer<'a> {
 impl kernel::platform::scheduler_timer::SchedulerTimer for Timer<'_> {
     fn start(&self, us: u32) {
         let now = self.now();
-        let tics = Self::ticks_from_us(us);
+        let tics = self.ticks_from_us(us);
         self.set_alarm(now, tics);
     }
 

--- a/kernel/src/hil/entropy.rs
+++ b/kernel/src/hil/entropy.rs
@@ -42,6 +42,7 @@
 //! use kernel::hil::entropy::Entropy32;
 //! use kernel::hil::entropy::Client32;
 //! use kernel::hil::time::Alarm;
+//! use kernel::hil::time::ConvertTicks;
 //! use kernel::hil::time::Frequency;
 //! use kernel::hil::time::AlarmClient;
 //! use kernel::ErrorCode;
@@ -54,7 +55,7 @@
 //! impl<'a, A: Alarm<'a>> EntropyTest<'a, A> {
 //!     pub fn initialize(&self) {
 //!         let now = self.alarm.now();
-//!         let dt = <A>::ticks_from_seconds(1);
+//!         let dt = self.alarm.ticks_from_seconds(1);
 //!         self.alarm.set_alarm(now, dt);
 //!     }
 //! }
@@ -73,7 +74,7 @@
 //!             Some(val) => {
 //!                 println!("Entropy {}", val);
 //!                 let now = self.alarm.now();
-//!                 let dt = <A>::ticks_from_seconds(1);
+//!                 let dt = self.alarm.ticks_from_seconds(1);
 //!                 self.alarm.set_alarm(now, dt);
 //!                 hil::entropy::Continue::Done
 //!             },

--- a/kernel/src/hil/rng.rs
+++ b/kernel/src/hil/rng.rs
@@ -49,6 +49,7 @@
 //!
 //! ```
 //! use kernel::hil;
+//! use kernel::hil::time::ConvertTicks;
 //! use kernel::hil::time::Frequency;
 //! use kernel::hil::time::Time;
 //! use kernel::ErrorCode;
@@ -61,7 +62,7 @@
 //! impl<'a, A: hil::time::Alarm<'a>> RngTest<'a, A> {
 //!     pub fn initialize(&self) {
 //!         let now = self.alarm.now();
-//!         let dt = <A>::ticks_from_seconds(1);
+//!         let dt = self.alarm.ticks_from_seconds(1);
 //!         self.alarm.set_alarm(now, dt);
 //!     }
 //! }
@@ -80,7 +81,7 @@
 //!             Some(random) => {
 //!                 println!("Rand {}", random);
 //!                 let now = self.alarm.now();
-//!                 let dt = <A>::ticks_from_seconds(1);
+//!                 let dt = self.alarm.ticks_from_seconds(1);
 //!
 //!                 self.alarm.set_alarm(now, dt);
 //!                 hil::rng::Continue::Done

--- a/kernel/src/hil/time.rs
+++ b/kernel/src/hil/time.rs
@@ -47,6 +47,14 @@ pub trait Ticks: Clone + Copy + From<u32> + fmt::Debug + Ord + PartialOrd + Eq {
 
     /// Returns the maximum value of this type, which should be (2^width)-1.
     fn max_value() -> Self;
+
+    /// Coverts the specified val into this type if it fits otherwise the
+    /// `max_value()` is returned
+    fn from_or_max(val: u64) -> Self;
+
+    /// Scales the ticks by the specified numerator and denominator. If the resulting value would
+    /// be greater than u32,`u32::MAX` is returned instead
+    fn saturating_scale(self, numerator: u32, denominator: u32) -> u32;
 }
 
 /// Represents a clock's frequency in Hz, allowing code to transform
@@ -70,37 +78,69 @@ pub trait Time {
     /// it being constant or changing it should use `Timestamp`
     /// or `Counter`.
     fn now(&self) -> Self::Ticks;
+}
 
+pub trait ConvertTicks<T: Ticks> {
     /// Returns the number of ticks in the provided number of seconds,
     /// rounding down any fractions. If the value overflows Ticks it
     /// returns `Ticks::max_value()`.
-    fn ticks_from_seconds(s: u32) -> Self::Ticks {
-        let val: u64 = Self::Frequency::frequency() as u64 * s as u64;
-        ticks_from_val(val)
-    }
+    fn ticks_from_seconds(&self, s: u32) -> T;
 
     /// Returns the number of ticks in the provided number of milliseconds,
     /// rounding down any fractions. If the value overflows Ticks it
     /// returns `Ticks::max_value()`.
-    fn ticks_from_ms(ms: u32) -> Self::Ticks {
-        let val: u64 = Self::Frequency::frequency() as u64 * ms as u64;
-        ticks_from_val(val / 1000)
-    }
+
+    fn ticks_from_ms(&self, ms: u32) -> T;
 
     /// Returns the number of ticks in the provided number of microseconds,
     /// rounding down any fractions. If the value overflows Ticks it
     /// returns `Ticks::max_value()`.
-    fn ticks_from_us(us: u32) -> Self::Ticks {
-        let val: u64 = Self::Frequency::frequency() as u64 * us as u64;
-        ticks_from_val(val / 1_000_000)
-    }
+    fn ticks_from_us(&self, us: u32) -> T;
+
+    /// Returns the number of seconds in the provided number of ticks,
+    /// rounding down any fractions. If the value overflows u32, `u32::MAX`
+    /// is returned,
+    fn ticks_to_seconds(&self, tick: T) -> u32;
+
+    /// Returns the number of milliseconds in the provided number of ticks,
+    /// rounding down any fractions. If the value overflows u32, `u32::MAX`
+    /// is returned,
+    fn ticks_to_ms(&self, tick: T) -> u32;
+
+    /// Returns the number of microseconds in the provided number of ticks,
+    /// rounding down any fractions. If the value overflows u32, `u32::MAX`
+    /// is returned,
+    fn ticks_to_us(&self, tick: T) -> u32;
 }
 
-fn ticks_from_val<T: Ticks>(val: u64) -> T {
-    if val <= T::max_value().into_u32() as u64 {
-        T::from(val as u32)
-    } else {
-        T::max_value()
+impl<T: Time + ?Sized> ConvertTicks<<T as Time>::Ticks> for T {
+    #[inline]
+    fn ticks_from_seconds(&self, s: u32) -> <T as Time>::Ticks {
+        let val = <T as Time>::Frequency::frequency() as u64 * s as u64;
+        <T as Time>::Ticks::from_or_max(val)
+    }
+    #[inline]
+    fn ticks_from_ms(&self, ms: u32) -> <T as Time>::Ticks {
+        let val = <T as Time>::Frequency::frequency() as u64 * ms as u64;
+        <T as Time>::Ticks::from_or_max(val / 1_000)
+    }
+    #[inline]
+    fn ticks_from_us(&self, us: u32) -> <T as Time>::Ticks {
+        let val = <T as Time>::Frequency::frequency() as u64 * us as u64;
+        <T as Time>::Ticks::from_or_max(val / 1_000_000)
+    }
+
+    #[inline]
+    fn ticks_to_seconds(&self, tick: <T as Time>::Ticks) -> u32 {
+        tick.saturating_scale(1, <T as Time>::Frequency::frequency())
+    }
+    #[inline]
+    fn ticks_to_ms(&self, tick: <T as Time>::Ticks) -> u32 {
+        tick.saturating_scale(1_000, <T as Time>::Frequency::frequency())
+    }
+    #[inline]
+    fn ticks_to_us(&self, tick: <T as Time>::Ticks) -> u32 {
+        tick.saturating_scale(1_000_000, <T as Time>::Frequency::frequency())
     }
 }
 
@@ -362,6 +402,25 @@ impl Ticks for Ticks32 {
     fn max_value() -> Self {
         Ticks32(0xFFFFFFFF)
     }
+
+    #[inline]
+    fn from_or_max(val: u64) -> Self {
+        if val < Self::max_value().0 as u64 {
+            Self::from(val as u32)
+        } else {
+            Self::max_value()
+        }
+    }
+
+    #[inline]
+    fn saturating_scale(self, numerator: u32, denominator: u32) -> u32 {
+        let scaled = self.0 as u64 * numerator as u64 / denominator as u64;
+        if scaled < u32::MAX as u64 {
+            scaled as u32
+        } else {
+            u32::MAX
+        }
+    }
 }
 
 impl PartialOrd for Ticks32 {
@@ -418,6 +477,25 @@ impl Ticks for Ticks24 {
     /// Returns the maximum value of this type, which should be (2^width)-1.
     fn max_value() -> Self {
         Ticks24(0x00FFFFFF)
+    }
+
+    #[inline]
+    fn from_or_max(val: u64) -> Self {
+        if val < Self::max_value().0 as u64 {
+            Self::from(val as u32)
+        } else {
+            Self::max_value()
+        }
+    }
+
+    #[inline]
+    fn saturating_scale(self, numerator: u32, denominator: u32) -> u32 {
+        let scaled = self.0 as u64 * numerator as u64 / denominator as u64;
+        if scaled < u32::MAX as u64 {
+            scaled as u32
+        } else {
+            u32::MAX
+        }
     }
 }
 
@@ -488,6 +566,25 @@ impl Ticks for Ticks16 {
     fn max_value() -> Self {
         Ticks16(0xFFFF)
     }
+
+    #[inline]
+    fn from_or_max(val: u64) -> Self {
+        if val < Self::max_value().0 as u64 {
+            Self::from(val as u32)
+        } else {
+            Self::max_value()
+        }
+    }
+
+    #[inline]
+    fn saturating_scale(self, numerator: u32, denominator: u32) -> u32 {
+        let scaled = self.0 as u64 * numerator as u64 / denominator as u64;
+        if scaled < u32::MAX as u64 {
+            scaled as u32
+        } else {
+            u32::MAX
+        }
+    }
 }
 
 impl PartialOrd for Ticks16 {
@@ -557,6 +654,21 @@ impl Ticks for Ticks64 {
     fn max_value() -> Self {
         Ticks64(!0u64)
     }
+
+    #[inline]
+    fn from_or_max(val: u64) -> Self {
+        Self(val)
+    }
+
+    #[inline]
+    fn saturating_scale(self, num: u32, den: u32) -> u32 {
+        let scaled = self.0.saturating_mul(num as u64) / den as u64;
+        if scaled < u32::MAX as u64 {
+            scaled as u32
+        } else {
+            u32::MAX
+        }
+    }
 }
 
 impl PartialOrd for Ticks64 {
@@ -578,3 +690,133 @@ impl PartialEq for Ticks64 {
 }
 
 impl Eq for Ticks64 {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct Test1MHz64();
+    impl Time for Test1MHz64 {
+        type Frequency = Freq1MHz;
+        type Ticks = Ticks64;
+
+        fn now(&self) -> Self::Ticks {
+            0u32.into()
+        }
+    }
+
+    #[test]
+    fn test_from_ticks64() {
+        let s = Test1MHz64().ticks_to_seconds(1_000_000u32.into());
+        assert_eq!(s, 1);
+
+        let ms = Test1MHz64().ticks_to_ms(1_000_000u32.into());
+        assert_eq!(ms, 1_000);
+
+        let us = Test1MHz64().ticks_to_us(1_000_000u32.into());
+        assert_eq!(us, 1_000_000);
+
+        let s = Test1MHz64().ticks_to_seconds((1_000_000u64 << 31).into());
+        assert_eq!(s, 1 << 31);
+
+        let ms = Test1MHz64().ticks_to_ms((1_000_000u64 << 31).into());
+        assert_eq!(ms, !0u32);
+
+        let us = Test1MHz64().ticks_to_us((1_000_000u64 << 31).into());
+        assert_eq!(us, !0u32);
+    }
+
+    #[test]
+    fn test_to_ticks64() {
+        let t = Test1MHz64().ticks_from_seconds(1);
+        assert_eq!(t.into_u32(), 1_000_000);
+
+        let t = Test1MHz64().ticks_from_ms(1);
+        assert_eq!(t.into_u32(), 1_000);
+
+        let t = Test1MHz64().ticks_from_us(1);
+        assert_eq!(t.into_u32(), 1);
+
+        let t = Test1MHz64().ticks_from_seconds(1 << 31);
+        assert_eq!(t.into_u64(), 1_000_000u64 << 31);
+    }
+
+    struct Test1KHz16();
+    impl Time for Test1KHz16 {
+        type Frequency = Freq1KHz;
+        type Ticks = Ticks16;
+
+        fn now(&self) -> Self::Ticks {
+            0u32.into()
+        }
+    }
+
+    #[test]
+    fn test_from_ticks16() {
+        let s = Test1KHz16().ticks_to_seconds(1_000u32.into());
+        assert_eq!(s, 1);
+
+        let ms = Test1KHz16().ticks_to_ms(1_000u32.into());
+        assert_eq!(ms, 1_000);
+
+        let us = Test1KHz16().ticks_to_us(1_000u32.into());
+        assert_eq!(us, 1_000_000);
+    }
+
+    #[test]
+    fn test_to_ticks16() {
+        let t = Test1KHz16().ticks_from_seconds(1);
+        assert_eq!(t.into_u32(), 1_000);
+
+        let t = Test1KHz16().ticks_from_seconds(u32::MAX);
+        assert_eq!(t.into_u32(), u16::MAX as u32);
+
+        let t = Test1KHz16().ticks_from_seconds(66);
+        assert_eq!(t.into_u32(), u16::MAX as u32);
+
+        let t = Test1KHz16().ticks_from_seconds(65);
+        assert_eq!(t.into_u32(), 65_000);
+
+        let t = Test1KHz16().ticks_from_ms(1);
+        assert_eq!(t.into_u32(), 1);
+
+        let t = Test1KHz16().ticks_from_us(1);
+        assert_eq!(t.into_u32(), 0);
+    }
+
+    struct Test1KHz24();
+    impl Time for Test1KHz24 {
+        type Frequency = Freq1KHz;
+        type Ticks = Ticks24;
+
+        fn now(&self) -> Self::Ticks {
+            0u32.into()
+        }
+    }
+
+    #[test]
+    fn test_ticks24() {
+        let s = Test1KHz24().ticks_to_seconds(5_000_000u32.into());
+        assert_eq!(s, 5_000);
+
+        let ms = Test1KHz24().ticks_to_ms(5_000_000u32.into());
+        assert_eq!(ms, 5_000_000);
+
+        let us = Test1KHz24().ticks_to_us(5_000_000u32.into());
+        assert_eq!(us, u32::MAX);
+    }
+
+    #[test]
+    fn test_dyn_object() {
+        let time: &dyn Time<Frequency = Freq1KHz, Ticks = Ticks24> = &Test1KHz24();
+
+        let s = time.ticks_to_seconds(5_000_000u32.into());
+        assert_eq!(s, 5_000);
+
+        let ms = time.ticks_to_ms(5_000_000u32.into());
+        assert_eq!(ms, 5_000_000);
+
+        let us = time.ticks_to_us(5_000_000u32.into());
+        assert_eq!(us, u32::MAX);
+    }
+}

--- a/kernel/src/scheduler/mlfq.rs
+++ b/kernel/src/scheduler/mlfq.rs
@@ -20,8 +20,7 @@
 use core::cell::Cell;
 
 use crate::collections::list::{List, ListLink, ListNode};
-use crate::hil::time;
-use crate::hil::time::Ticks;
+use crate::hil::time::{self, ConvertTicks, Ticks};
 use crate::kernel::{Kernel, StoppedExecutingReason};
 use crate::platform::chip::Chip;
 use crate::process::Process;
@@ -150,8 +149,9 @@ impl<'a, A: 'static + time::Alarm<'static>, C: Chip> Scheduler<C> for MLFQSched<
             // alarm wraps around
             if !now.within_range(last_reset_check, next_reset) {
                 // Promote all processes to highest priority queue
-                self.next_reset
-                    .set(now.wrapping_add(A::ticks_from_ms(Self::PRIORITY_REFRESH_PERIOD_MS)));
+                self.next_reset.set(
+                    now.wrapping_add(self.alarm.ticks_from_ms(Self::PRIORITY_REFRESH_PERIOD_MS)),
+                );
                 self.redeem_all_procs();
             }
             self.last_reset_check.set(now);


### PR DESCRIPTION
### Pull Request Overview

Move the tick conversion functions to a separate auto-implemented
trait. This allows `dyn` on `Time`, `Alarm`, and `Timer` which is helpful since
these traits are normally abstracted with a VirtualMux.

Add the inverse conversion of tick to time functions as well.


### Testing Strategy

Added unit tests

### Documentation Updated

- Updated time TRD in PR #2688 

### Formatting

- [x] Ran `make prepush`.
