### PR TITLE
[rfc] Comptibility header (v1)

### DIFF
--- a/doc/TockBinaryFormat.md
+++ b/doc/TockBinaryFormat.md
@@ -16,6 +16,7 @@
     + [`5` Fixed Addresses](#5-fixed-addresses)
     + [`6` Permissions](#6-permissions)
     + [`7` Persistent ACL](#7-persistent-acl)
+    + [`8` Compatibility](#8-compatibility)
 - [Code](#code)
 
 <!-- tocstop -->
@@ -167,6 +168,14 @@ struct TbfHeaderV2PersistentAcl {
     read_ids: [u32],
     access_length: u16,
     access_ids: [u32],
+
+// Compatibility
+struct TbfHeaderV2Compatibility {
+    base: TbfHeaderTlv,
+    length: u16,
+    abi_version: u16,
+    kernel_major: u8,
+    kernel_minor: u8
 }
 ```
 
@@ -430,3 +439,25 @@ but the specific address is determined by the platform. Code in the binary
 should be able to execute successfully at any address, e.g. using position
 independent code.
 
+#### `8` Compatibility
+
+The `compatibility` header is designed to prevent the kernel
+from running applications that are not compatible with it.
+
+It defins the following three items:
+* `ABI version` is the ABI (system call) version that the kernel provides. Tock 1.x 
+ provides ABI version 1 while Tock 2.0 provides ABI version 2. The ABI version is not
+ necessarly related to the kernel major number. The ABI version number increases 
+ each time the systm call numbers, systm call arguments or upcall parameters change.
+* `KM` is the kernel major number (for Tock 2.0, KM is 2)
+* `Km` is the kernel minor number (for Tock 2.0, Km is 0)
+
+Setting any of the `KM` or `Km` values to 0 indicates that the application
+works regadless of the actual value. The `ABI version` is required.
+
+```
+0             2             4             6             8
++-------------+-------------+---------------------------+
+| Type (7)    | Length (4)  | ABI version |  KM  |  Km  |
++-------------+-------------+---------------------------+
+```

--- a/doc/TockBinaryFormat.md
+++ b/doc/TockBinaryFormat.md
@@ -172,7 +172,6 @@ struct TbfHeaderV2PersistentAcl {
 // Kernel Version
 struct TbfHeaderV2KernelVersion {
     base: TbfHeaderTlv,
-    length: u16,
     major: u16,
     minor: u16
 }

--- a/doc/TockBinaryFormat.md
+++ b/doc/TockBinaryFormat.md
@@ -173,8 +173,8 @@ struct TbfHeaderV2PersistentAcl {
 struct TbfHeaderV2KernelVersion {
     base: TbfHeaderTlv,
     length: u16,
-    major: u8,
-    minor: u8
+    major: u16,
+    minor: u16
 }
 ```
 

--- a/doc/TockBinaryFormat.md
+++ b/doc/TockBinaryFormat.md
@@ -435,7 +435,7 @@ different regions.
 The `compatibility` header is designed to prevent the kernel
 from running applications that are not compatible with it.
 
-It defins the following two items:
+It defines the following two items:
 * `Kernel major` or `V` is the kernel major number (for Tock 2.0, it is 2)
 * `Kernel minor` or `v` is the kernel minor number (for Tock 2.0, it is 0)
 

--- a/doc/TockBinaryFormat.md
+++ b/doc/TockBinaryFormat.md
@@ -437,7 +437,7 @@ but the specific address is determined by the platform. Code in the binary
 should be able to execute successfully at any address, e.g. using position
 independent code.
 
-#### `8` Compatibility
+#### `8` Kernel Version
 
 The `compatibility` header is designed to prevent the kernel
 from running applications that are not compatible with it.
@@ -457,7 +457,7 @@ data between kernel and userspace and the the system call numbers.
 ```
 0             2             4             6             8
 +-------------+-------------+---------------------------+
-| Type (7)    | Length (4)  | Kernel major| Kernel minor|
+| Type (8)    | Length (4)  | Kernel major| Kernel minor|
 +-------------+-------------+---------------------------+
 ```
 

--- a/doc/TockBinaryFormat.md
+++ b/doc/TockBinaryFormat.md
@@ -444,7 +444,7 @@ Apps defining this header are compatible with kernel version ^V.v (>= V.v and < 
 The kernel version header refers only to the ABI and API exposed by the kernel 
 itself, it does not cover API changes within drivers. 
 
-A kernel major and minor version  guarantees the  ABI for exchanging 
+A kernel major and minor version guarantees the ABI for exchanging 
 data between kernel and userspace and the the system call numbers.
 
 ```

--- a/doc/TockBinaryFormat.md
+++ b/doc/TockBinaryFormat.md
@@ -448,6 +448,12 @@ It defins the following two items:
 
 Apps defining this header are compatible with kernel version ^V.v (>= V.v and < (V+1).0)
 
+The kernel version header refers only to the ABI and API exposed by the kernel 
+itself, it does not cover API changes within drivers. 
+
+A kernel major and minor version  guarantees the  ABI for exchanging 
+data between kernel and userspace and the the system call numbers.
+
 ```
 0             2             4             6             8
 +-------------+-------------+---------------------------+

--- a/doc/TockBinaryFormat.md
+++ b/doc/TockBinaryFormat.md
@@ -430,13 +430,6 @@ errors over the network, and once the reported errors are acked erases them
 from the log. In this case `access_ids` allow an app to erase multiple
 different regions.
 
-## Code
-
-The process code itself has no particular format. It will reside in flash,
-but the specific address is determined by the platform. Code in the binary
-should be able to execute successfully at any address, e.g. using position
-independent code.
-
 #### `8` Kernel Version
 
 The `compatibility` header is designed to prevent the kernel

--- a/doc/TockBinaryFormat.md
+++ b/doc/TockBinaryFormat.md
@@ -16,7 +16,7 @@
     + [`5` Fixed Addresses](#5-fixed-addresses)
     + [`6` Permissions](#6-permissions)
     + [`7` Persistent ACL](#7-persistent-acl)
-    + [`8` Compatibility](#8-compatibility)
+    + [`8` Kernel Version](#8-kernel-version)
 - [Code](#code)
 
 <!-- tocstop -->
@@ -169,13 +169,12 @@ struct TbfHeaderV2PersistentAcl {
     access_length: u16,
     access_ids: [u32],
 
-// Compatibility
-struct TbfHeaderV2Compatibility {
+// Kernel Version
+struct TbfHeaderV2KernelVersion {
     base: TbfHeaderTlv,
     length: u16,
-    abi_version: u16,
-    kernel_major: u8,
-    kernel_minor: u8
+    major: u8,
+    minor: u8
 }
 ```
 
@@ -444,20 +443,23 @@ independent code.
 The `compatibility` header is designed to prevent the kernel
 from running applications that are not compatible with it.
 
-It defins the following three items:
-* `ABI version` is the ABI (system call) version that the kernel provides. Tock 1.x 
- provides ABI version 1 while Tock 2.0 provides ABI version 2. The ABI version is not
- necessarly related to the kernel major number. The ABI version number increases 
- each time the systm call numbers, systm call arguments or upcall parameters change.
-* `KM` is the kernel major number (for Tock 2.0, KM is 2)
-* `Km` is the kernel minor number (for Tock 2.0, Km is 0)
+It defins the following two items:
+* `Kernel major` or `V` is the kernel major number (for Tock 2.0, it is 2)
+* `Kernel minor` or `v` is the kernel minor number (for Tock 2.0, it is 0)
 
-Setting any of the `KM` or `Km` values to 0 indicates that the application
-works regadless of the actual value. The `ABI version` is required.
+Apps defining this header are compatible with kernel version ^V.v (>= V.v and < (V+1).0)
 
 ```
 0             2             4             6             8
 +-------------+-------------+---------------------------+
-| Type (7)    | Length (4)  | ABI version |  KM  |  Km  |
+| Type (7)    | Length (4)  | Kernel major| Kernel minor|
 +-------------+-------------+---------------------------+
 ```
+
+
+## Code
+
+The process code itself has no particular format. It will reside in flash,
+but the specific address is determined by the platform. Code in the binary
+should be able to execute successfully at any address, e.g. using position
+independent code.

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -89,6 +89,10 @@
 #![warn(unreachable_pub)]
 #![no_std]
 
+// Define the kernel major and minor versions
+pub const MAJOR: u16 = 2;
+pub const MINOR: u16 = 0;
+
 pub mod capabilities;
 pub mod collections;
 pub mod component;

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -21,7 +21,7 @@ pub use crate::process_policies::{
     StopWithDebugFaultPolicy, ThresholdRestartFaultPolicy, ThresholdRestartThenPanicFaultPolicy,
 };
 pub use crate::process_standard::ProcessStandard;
-pub use crate::process_utilities::{load_processes, ProcessLoadError};
+pub use crate::process_utilities::{load_processes, load_processes_advanced, ProcessLoadError};
 
 /// Userspace process identifier.
 ///

--- a/kernel/src/process_standard.rs
+++ b/kernel/src/process_standard.rs
@@ -1411,7 +1411,7 @@ impl<C: 'static + Chip> ProcessStandard<'_, C> {
             }
         } else {
             if enforce_kernel_version {
-                // If enforing the kernel version is requested, and the `KernelVersion` header is not present,
+                // If enforcing the kernel version is requested, and the `KernelVersion` header is not present,
                 // we prevent the process from loading.
                 if config::CONFIG.debug_load_processes {
                     debug!(

--- a/kernel/src/process_standard.rs
+++ b/kernel/src/process_standard.rs
@@ -1398,18 +1398,14 @@ impl<C: 'static + Chip> ProcessStandard<'_, C> {
         if let Some((major, minor)) = tbf_header.get_kernel_version() {
             // If the `KernelVersion` header is present, we read the requested kernel version and compare it to
             // the running kernel version.
-            if crate::MAJOR != major {
+            if crate::MAJOR != major || crate::MINOR < minor {
                 // If the kernel major version is different, we prevent the process from being loaded.
-                if config::CONFIG.debug_load_processes {
-                    debug!("WARN process {:?} not loaded as it requires kernel version {} (running kernel {}.{})", process_name.unwrap_or("(no name)"), major, crate::MAJOR, crate::MINOR);
-                }
-                return Ok((None, remaining_memory));
-            } else if crate::MINOR < minor {
+                //
                 // If the kernel major version is the same, we compare the kernel minor version. The current
                 // running kernel minor version has to be greater or equal to the one that the process
                 // has requested. If not, we prevent the process from loading.
                 if config::CONFIG.debug_load_processes {
-                    debug!("WARN process {:?} not loaded as it requires kernel version at least {}.{}, (running kernel {}.{})", process_name.unwrap_or("(no name)"), major, minor, crate::MAJOR, crate::MINOR);
+                    debug!("WARN process {:?} not loaded as it requires kernel version >= {}.{} and < {}.0, (running kernel {}.{})", process_name.unwrap_or("(no name)"), major, minor, (major+1), crate::MAJOR, crate::MINOR);
                 }
                 return Ok((None, remaining_memory));
             }

--- a/kernel/src/process_standard.rs
+++ b/kernel/src/process_standard.rs
@@ -1407,7 +1407,9 @@ impl<C: 'static + Chip> ProcessStandard<'_, C> {
                 if config::CONFIG.debug_load_processes {
                     debug!("WARN process {:?} not loaded as it requires kernel version >= {}.{} and < {}.0, (running kernel {}.{})", process_name.unwrap_or("(no name)"), major, minor, (major+1), crate::MAJOR, crate::MINOR);
                 }
-                return Ok((None, remaining_memory));
+                return Err(ProcessLoadError::IncompatibleKernelVersion {
+                    version: Some((major, minor)),
+                });
             }
         } else {
             if enforce_kernel_version {
@@ -1419,7 +1421,7 @@ impl<C: 'static + Chip> ProcessStandard<'_, C> {
                             process_name.unwrap_or ("(no name")
                         );
                 }
-                return Ok((None, remaining_memory));
+                return Err(ProcessLoadError::IncompatibleKernelVersion { version: None });
             }
         }
 

--- a/kernel/src/process_standard.rs
+++ b/kernel/src/process_standard.rs
@@ -1412,7 +1412,7 @@ impl<C: 'static + Chip> ProcessStandard<'_, C> {
                 });
             }
         } else {
-            if enforce_kernel_version {
+            if require_kernel_version {
                 // If enforcing the kernel version is requested, and the `KernelVersion` header is not present,
                 // we prevent the process from loading.
                 if config::CONFIG.debug_load_processes {

--- a/kernel/src/process_standard.rs
+++ b/kernel/src/process_standard.rs
@@ -1340,6 +1340,7 @@ impl<C: 'static + Chip> ProcessStandard<'_, C> {
         app_version: u16,
         remaining_memory: &'a mut [u8],
         fault_policy: &'static dyn ProcessFaultPolicy,
+        enforce_kernel_version: bool,
         index: usize,
     ) -> Result<(Option<&'static dyn Process>, &'a mut [u8]), ProcessLoadError> {
         // Get a slice for just the app header.
@@ -1386,12 +1387,44 @@ impl<C: 'static + Chip> ProcessStandard<'_, C> {
                         "Process not enabled flash={:#010X}-{:#010X} process={:?}",
                         app_flash.as_ptr() as usize,
                         app_flash.as_ptr() as usize + app_flash.len() - 1,
-                        process_name
+                        process_name.unwrap_or("(no name)")
                     );
                 }
             }
             // Return no process and the full memory slice we were given.
             return Ok((None, remaining_memory));
+        }
+
+        if let Some((major, minor)) = tbf_header.get_kernel_version() {
+            // If the `KernelVersion` header is present, we read the requested kernel version and compare it to
+            // the running kernel version.
+            if crate::MAJOR != major {
+                // If the kernel major version is different, we prevent the process from being loaded.
+                if config::CONFIG.debug_load_processes {
+                    debug!("WARN process {:?} not loaded as it requires kernel version {} (running kernel {}.{})", process_name.unwrap_or("(no name)"), major, crate::MAJOR, crate::MINOR);
+                }
+                return Ok((None, remaining_memory));
+            } else if crate::MINOR < minor {
+                // If the kernel major version is the same, we compare the kernel minor version. The current
+                // running kernel minor version has to be greater or equal to the one that the process
+                // has requested. If not, we prevent the process from loading.
+                if config::CONFIG.debug_load_processes {
+                    debug!("WARN process {:?} not loaded as it requires kernel version at least {}.{}, (running kernel {}.{})", process_name.unwrap_or("(no name)"), major, minor, crate::MAJOR, crate::MINOR);
+                }
+                return Ok((None, remaining_memory));
+            }
+        } else {
+            if enforce_kernel_version {
+                // If enforing the kernel version is requested, and the `KernelVersion` header is not present,
+                // we prevent the process from loading.
+                if config::CONFIG.debug_load_processes {
+                    debug!(
+                            "WARN process {:?} not loaded as it has no kernel version header, please upgrade to elf2tab >= 0.8.0",
+                            process_name.unwrap_or ("(no name")
+                        );
+                }
+                return Ok((None, remaining_memory));
+            }
         }
 
         // Otherwise, actually load the app.

--- a/kernel/src/process_standard.rs
+++ b/kernel/src/process_standard.rs
@@ -1340,7 +1340,7 @@ impl<C: 'static + Chip> ProcessStandard<'_, C> {
         app_version: u16,
         remaining_memory: &'a mut [u8],
         fault_policy: &'static dyn ProcessFaultPolicy,
-        enforce_kernel_version: bool,
+        require_kernel_version: bool,
         index: usize,
     ) -> Result<(Option<&'static dyn Process>, &'a mut [u8]), ProcessLoadError> {
         // Get a slice for just the app header.

--- a/kernel/src/process_utilities.rs
+++ b/kernel/src/process_utilities.rs
@@ -125,13 +125,14 @@ impl fmt::Debug for ProcessLoadError {
 /// Returns `Ok(())` if process discovery went as expected. Returns a
 /// `ProcessLoadError` if something goes wrong during TBF parsing or process
 /// creation.
-pub fn load_processes<C: Chip>(
+pub fn load_processes_advanced<C: Chip>(
     kernel: &'static Kernel,
     chip: &'static C,
     app_flash: &'static [u8],
     app_memory: &mut [u8], // not static, so that process.rs cannot hold on to slice w/o unsafe
     procs: &'static mut [Option<&'static dyn Process>],
     fault_policy: &'static dyn ProcessFaultPolicy,
+    enforce_kernel_version: bool,
     _capability: &dyn ProcessManagementCapability,
 ) -> Result<(), ProcessLoadError> {
     if config::CONFIG.debug_load_processes {
@@ -218,6 +219,7 @@ pub fn load_processes<C: Chip>(
                     version,
                     remaining_memory,
                     fault_policy,
+                    enforce_kernel_version,
                     i,
                 )?
             };
@@ -246,4 +248,31 @@ pub fn load_processes<C: Chip>(
     }
 
     Ok(())
+}
+
+/// This is a wrapper function for `load_processes_advanced` that uses
+/// the default arguments that mainstream boards should provide.
+///
+/// Default arguments are:
+///  - `enforce_kernel_version`: prevent loading processes that do not provide a `KernelVersion`
+#[inline(always)]
+pub fn load_processes<C: Chip>(
+    kernel: &'static Kernel,
+    chip: &'static C,
+    app_flash: &'static [u8],
+    app_memory: &mut [u8], // not static, so that process.rs cannot hold on to slice w/o unsafe
+    procs: &'static mut [Option<&'static dyn Process>],
+    fault_policy: &'static dyn ProcessFaultPolicy,
+    capability: &dyn ProcessManagementCapability,
+) -> Result<(), ProcessLoadError> {
+    load_processes_advanced(
+        kernel,
+        chip,
+        app_flash,
+        app_memory,
+        procs,
+        fault_policy,
+        true,
+        capability,
+    )
 }

--- a/kernel/src/process_utilities.rs
+++ b/kernel/src/process_utilities.rs
@@ -45,12 +45,18 @@ pub enum ProcessLoadError {
         expected_address: u32,
     },
 
-    /// A process might provide a KernelVersion TBF header stating the
-    /// compatible kernel version (^major.minor). If `load_processes_advanced` is
-    /// called with `enforce_kernel_version` set to true, kernel will stop loading
-    /// processes when it encounters either:
-    ///    - a process that does not provide the KernelVersion TBF header
-    ///    - a process that requested an incompatible version of the kernel
+    /// A process requires a newer version of the kernel or did not specify
+    /// a required version. Processes can include the KernelVersion TBF header stating
+    /// their compatible kernel version (^major.minor).
+    ///
+    /// Boards may not require processes to include the KernelVersion TBF header, and
+    /// the kernel supports ignoring a missing KernelVersion TBF header. In that case,
+    /// this error will not be returned for a process missing a KernelVersion TBF
+    /// header.
+    ///
+    /// `version` is the `(major, minor)` kernel version the process indicates it
+    /// requires. If `version` is `None` then the process did not include the
+    /// KernelVersion TBF header.
     IncompatibleKernelVersion { version: Option<(u16, u16)> },
 
     /// Process loading error due (likely) to a bug in the kernel. If you get

--- a/kernel/src/process_utilities.rs
+++ b/kernel/src/process_utilities.rs
@@ -151,6 +151,7 @@ impl fmt::Debug for ProcessLoadError {
 /// Returns `Ok(())` if process discovery went as expected. Returns a
 /// `ProcessLoadError` if something goes wrong during TBF parsing or process
 /// creation.
+#[inline(always)]
 pub fn load_processes_advanced<C: Chip>(
     kernel: &'static Kernel,
     chip: &'static C,

--- a/kernel/src/process_utilities.rs
+++ b/kernel/src/process_utilities.rs
@@ -159,7 +159,7 @@ pub fn load_processes_advanced<C: Chip>(
     app_memory: &mut [u8], // not static, so that process.rs cannot hold on to slice w/o unsafe
     procs: &'static mut [Option<&'static dyn Process>],
     fault_policy: &'static dyn ProcessFaultPolicy,
-    enforce_kernel_version: bool,
+    require_kernel_version: bool,
     _capability: &dyn ProcessManagementCapability,
 ) -> Result<(), ProcessLoadError> {
     if config::CONFIG.debug_load_processes {
@@ -246,7 +246,7 @@ pub fn load_processes_advanced<C: Chip>(
                     version,
                     remaining_memory,
                     fault_policy,
-                    enforce_kernel_version,
+                    require_kernel_version,
                     i,
                 )?
             };
@@ -281,7 +281,7 @@ pub fn load_processes_advanced<C: Chip>(
 /// the default arguments that mainstream boards should provide.
 ///
 /// Default arguments are:
-///  - `enforce_kernel_version`: prevent loading processes that do not provide a `KernelVersion`
+///  - `require_kernel_version`: prevent loading processes that do not provide a `KernelVersion`
 #[inline(always)]
 pub fn load_processes<C: Chip>(
     kernel: &'static Kernel,

--- a/kernel/src/process_utilities.rs
+++ b/kernel/src/process_utilities.rs
@@ -109,7 +109,7 @@ impl fmt::Debug for ProcessLoadError {
             ProcessLoadError::IncompatibleKernelVersion { version } => match version {
                 Some((major, minor)) => write!(
                     f,
-                    "App is incomatible with the kernel. Running: {}.{}, Requested: {}.{}",
+                    "Process is incompatible with the kernel. Running: {}.{}, Requested: {}.{}",
                     crate::MAJOR,
                     crate::MINOR,
                     major,

--- a/kernel/src/process_utilities.rs
+++ b/kernel/src/process_utilities.rs
@@ -115,7 +115,7 @@ impl fmt::Debug for ProcessLoadError {
                     major,
                     minor
                 ),
-                None => write!(f, "App did not provide a TBF kernel version header"),
+                None => write!(f, "Process did not provide a TBF kernel version header"),
             },
 
             ProcessLoadError::InternalError => write!(f, "Error in kernel. Likely a bug."),

--- a/libraries/tock-tbf/src/parse.rs
+++ b/libraries/tock-tbf/src/parse.rs
@@ -130,6 +130,7 @@ pub fn parse_tbf_header(
                     Default::default();
                 let mut app_name_str = "";
                 let mut fixed_address_pointer: Option<types::TbfHeaderV2FixedAddresses> = None;
+                let mut kernel_version: Option<types::TbfHeaderV2KernelVersion> = None;
 
                 // Iterate the remainder of the header looking for TLV entries.
                 while remaining.len() > 0 {
@@ -219,6 +220,17 @@ pub fn parse_tbf_header(
                             }
                         }
 
+                        types::TbfHeaderTypes::TbfHeaderKernelVersion => {
+                            let entry_len = 4;
+                            if tlv_header.length as usize == entry_len {
+                                kernel_version = Some(remaining.try_into()?);
+                            } else {
+                                return Err(types::TbfParseError::BadTlvEntry(
+                                    tlv_header.tipe as usize,
+                                ));
+                            }
+                        }
+
                         _ => {}
                     }
 
@@ -236,6 +248,7 @@ pub fn parse_tbf_header(
                     package_name: Some(app_name_str),
                     writeable_regions: Some(wfr_pointer),
                     fixed_addresses: fixed_address_pointer,
+                    kernel_version: kernel_version,
                 };
 
                 Ok(types::TbfHeader::TbfHeaderV2(tbf_header))

--- a/libraries/tock-tbf/src/types.rs
+++ b/libraries/tock-tbf/src/types.rs
@@ -105,7 +105,7 @@ pub enum TbfHeaderTypes {
     TbfHeaderWriteableFlashRegions = 2,
     TbfHeaderPackageName = 3,
     TbfHeaderFixedAddresses = 5,
-    TbfHeaderKernelVersion = 7,
+    TbfHeaderKernelVersion = 8,
 
     /// Some field in the header that we do not understand. Since the TLV format
     /// specifies the length of each section, if we get a field we do not
@@ -216,7 +216,7 @@ impl core::convert::TryFrom<u16> for TbfHeaderTypes {
             2 => Ok(TbfHeaderTypes::TbfHeaderWriteableFlashRegions),
             3 => Ok(TbfHeaderTypes::TbfHeaderPackageName),
             5 => Ok(TbfHeaderTypes::TbfHeaderFixedAddresses),
-            7 => Ok(TbfHeaderTypes::TbfHeaderKernelVersion),
+            8 => Ok(TbfHeaderTypes::TbfHeaderKernelVersion),
             _ => Ok(TbfHeaderTypes::Unknown),
         }
     }

--- a/libraries/tock-tbf/src/types.rs
+++ b/libraries/tock-tbf/src/types.rs
@@ -463,6 +463,8 @@ impl TbfHeader {
         }
     }
 
+    /// Get the minimum compatible kernel version this process requires.
+    /// Returns `None` if the kernel compatibility header is not included.
     pub fn get_kernel_version(&self) -> Option<(u16, u16)> {
         match self {
             TbfHeader::TbfHeaderV2(hd) => match hd.kernel_version {


### PR DESCRIPTION
### Pull Request Overview

This pull request adds a compatibility header to the TBF. This is the first version of such a header.

The idea is to add the ability to the kernel to ignore and not load the processes that do not meet the kernel compatibility constraints defined in this header.

This defines a fixed header that contains:
- the exact kernel major version
- the minimum kernel minor version

Processes that provide a `KernelVersion` header state that the exact required kernel version and the
minimum required kernel minor version. For instance, if a process specifies kernel version 2.12, this means it requires a kernel
version that is >= 2.12 and < 3.0.

### Testing Strategy

This was tested using a Microbit v2 and libtock-c with the new elf2tab (https://github.com/tock/elf2tab/pull/30).

EDIT: Tockloader seems to send over to the board unknown TLV headers as this works with the unmodified tockloader.

### TODO or Help Wanted

1. I'm not sure where to define the running kernel version. For now this is defined as two constants in `kernel/src/lib.rs`. Another idea was to define them within the `Config` structure. The printed kernel version is taken from the git release, which, at least for the development tree, is difficult to parse
2. Improvement to the debug messages

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
