### PR TITLE
Added troubleshooting for microbit v2 if openOCD could not find MEM-AP

### DIFF
--- a/boards/microbit_v2/README.md
+++ b/boards/microbit_v2/README.md
@@ -127,3 +127,21 @@ $ tockloader --openocd --board microbit_v2 --bundle-apps install app.tab
 ```
 
 > `--bundle-apps` seems to be needed due to an [openocd issue](https://github.com/tock/tockloader/issues/67)
+
+
+<br>
+
+Note:
+ If you get  `Could not find MEM-AP to control the core`  error when trying to connect to Micro:Bit with openOCD, you have [control access port](https://infocenter.nordicsemi.com/topic/com.nordic.infocenter.nrf52832.ps.v1.1/dif.html?cp=2_2_0_15_1#concept_udr_mns_1s) protection enabled. 
+
+Using openOCD, you can check if access protection is enabled by executing the command: `> dap apreg 1 0x0c`
+
+This command reads the register at address 0x0c in the access port at index 1 (the control access port's index). If it returns 0x0 then [access port protection is enabled](https://infocenter.nordicsemi.com/topic/com.nordic.infocenter.nrf52832.ps.v1.1/dif.html?cp=2_2_0_15_1_0_3#register.APPROTECTSTATUS).
+
+Unlock the chip by executing the command:
+
+`> dap apreg 1 0x04 0x01`
+
+and then resetting the device. Note that this will erase all Flash and RAM as this is the only way to disable CTRL-AP protection.
+
+Note: The easiest solution would be to use Nordic's [nrfjprog](https://infocenter.nordicsemi.com/topic/com.nordic.infocenter.tools/dita/tools/nrf5x_command_line_tools/nrf5x_command_line_tools_lpage.html) to unlock your chip via `$ nrfjprog -f NRF52 --recover`, but this requires the use of a JLink debugger (on-board nRF5 DKs or external).

--- a/boards/microbit_v2/README.md
+++ b/boards/microbit_v2/README.md
@@ -154,4 +154,4 @@ Reset the device.
 
 > Note that this will erase all Flash and RAM as this is the only way to disable CTRL-AP protection.
 
-> Another solution would be to use Nordic's [nrfjprog](https://infocenter.nordicsemi.com/topic/com.nordic.infocenter.tools/dita/tools/nrf5x_command_line_tools/nrf5x_command_line_tools_lpage.html) to unlock your chip via `$ nrfjprog -f NRF52 --recover`, but this requires the use of a JLink debugger (on-board nRF5 DKs or external).
+> Another solution would be to use Nordic's [nrfjprog](https://infocenter.nordicsemi.com/topic/com.nordic.infocenter.tools/dita/tools/nrf5x_command_line_tools/nrf5x_command_line_tools_lpage.html) to unlock your chip via `$ nrfjprog -f NRF52 --recover`, but this requires the use of a JLink debugger (on-board nRF52 DKs or external).

--- a/boards/microbit_v2/README.md
+++ b/boards/microbit_v2/README.md
@@ -131,7 +131,8 @@ $ tockloader --openocd --board microbit_v2 --bundle-apps install app.tab
 
 <br>
 
-Note:
+#### Note:
+<br>
  If you get  `Could not find MEM-AP to control the core`  error when trying to connect to Micro:Bit with openOCD, you have [control access port](https://infocenter.nordicsemi.com/topic/com.nordic.infocenter.nrf52832.ps.v1.1/dif.html?cp=2_2_0_15_1#concept_udr_mns_1s) protection enabled. 
 
 Using openOCD, you can check if access protection is enabled by executing the command: `> dap apreg 1 0x0c`

--- a/boards/microbit_v2/README.md
+++ b/boards/microbit_v2/README.md
@@ -128,21 +128,30 @@ $ tockloader --openocd --board microbit_v2 --bundle-apps install app.tab
 
 > `--bundle-apps` seems to be needed due to an [openocd issue](https://github.com/tock/tockloader/issues/67)
 
+## Troubleshooting
 
-<br>
+### Could not find MEM-AP to control the core
 
-#### Note:
-<br>
- If you get  `Could not find MEM-AP to control the core`  error when trying to connect to Micro:Bit with openOCD, you have [control access port](https://infocenter.nordicsemi.com/topic/com.nordic.infocenter.nrf52832.ps.v1.1/dif.html?cp=2_2_0_15_1#concept_udr_mns_1s) protection enabled. 
+OpenOCD displays `Could not find MEM-AP to control the core` error when trying to connect to Micro:Bit. This means that the Micro:boit has [control access port](https://infocenter.nordicsemi.com/topic/com.nordic.infocenter.nrf52832.ps.v1.1/dif.html?cp=2_2_0_15_1#concept_udr_mns_1s) protection enabled. 
 
-Using openOCD, you can check if access protection is enabled by executing the command: `> dap apreg 1 0x0c`
+Using openOCD, you can check if access protection is enabled by executing the command: 
+
+```bash
+$ openocd -f openocd.cfg -c "dap apreg 1 0x0c"
+``` 
 
 This command reads the register at address 0x0c in the access port at index 1 (the control access port's index). If it returns 0x0 then [access port protection is enabled](https://infocenter.nordicsemi.com/topic/com.nordic.infocenter.nrf52832.ps.v1.1/dif.html?cp=2_2_0_15_1_0_3#register.APPROTECTSTATUS).
 
+#### Solution
+
 Unlock the chip by executing the command:
 
-`> dap apreg 1 0x04 0x01`
+```bash
+$ openocd -f openocd.cfg -c "dap apreg 1 0x04 0x01"
+```
 
-and then resetting the device. Note that this will erase all Flash and RAM as this is the only way to disable CTRL-AP protection.
+Reset the device. 
 
-Note: The easiest solution would be to use Nordic's [nrfjprog](https://infocenter.nordicsemi.com/topic/com.nordic.infocenter.tools/dita/tools/nrf5x_command_line_tools/nrf5x_command_line_tools_lpage.html) to unlock your chip via `$ nrfjprog -f NRF52 --recover`, but this requires the use of a JLink debugger (on-board nRF5 DKs or external).
+> Note that this will erase all Flash and RAM as this is the only way to disable CTRL-AP protection.
+
+> Another solution would be to use Nordic's [nrfjprog](https://infocenter.nordicsemi.com/topic/com.nordic.infocenter.tools/dita/tools/nrf5x_command_line_tools/nrf5x_command_line_tools_lpage.html) to unlock your chip via `$ nrfjprog -f NRF52 --recover`, but this requires the use of a JLink debugger (on-board nRF5 DKs or external).

--- a/boards/microbit_v2/README.md
+++ b/boards/microbit_v2/README.md
@@ -132,7 +132,7 @@ $ tockloader --openocd --board microbit_v2 --bundle-apps install app.tab
 
 ### Could not find MEM-AP to control the core
 
-OpenOCD displays `Could not find MEM-AP to control the core` error when trying to connect to Micro:Bit. This means that the Micro:boit has [control access port](https://infocenter.nordicsemi.com/topic/com.nordic.infocenter.nrf52832.ps.v1.1/dif.html?cp=2_2_0_15_1#concept_udr_mns_1s) protection enabled. 
+OpenOCD displays `Could not find MEM-AP to control the core` error when trying to connect to Micro:bit. This means that the Micro:bit has [control access port](https://infocenter.nordicsemi.com/topic/com.nordic.infocenter.nrf52832.ps.v1.1/dif.html?cp=2_2_0_15_1#concept_udr_mns_1s) protection enabled. 
 
 Using openOCD, you can check if access protection is enabled by executing the command: 
 


### PR DESCRIPTION
### Pull Request Overview

This pull request adds troubleshooting section to the microbit v2 readme. Some of the microbits have a debugging protection active that prevents openOCD from controlling the chip.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
