### PR TITLE
[st77xx] make reset pin as optional

### DIFF
--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -496,7 +496,7 @@ pub unsafe fn main() {
             // dc
             Some(&nrf52840_peripherals.gpio_port[ST7789H2_DC]),
             // reset
-            &nrf52840_peripherals.gpio_port[ST7789H2_RESET]
+            Some(&nrf52840_peripherals.gpio_port[ST7789H2_RESET])
         ),
     );
 

--- a/boards/components/src/st77xx.rs
+++ b/boards/components/src/st77xx.rs
@@ -33,7 +33,7 @@
 //!         // dc
 //!         Some(&nrf52840::gpio::PORT[GPIO_D3]),
 //!         // reset
-//!         &nrf52840::gpio::PORT[GPIO_D2]
+//!         Some(&nrf52840::gpio::PORT[GPIO_D2])
 //!     ),
 //! );
 //! ```
@@ -106,7 +106,7 @@ impl<A: 'static + time::Alarm<'static>, B: 'static + bus::Bus<'static>, P: 'stat
         &'static B,
         &'static mut MaybeUninit<VirtualMuxAlarm<'static, A>>,
         Option<&'static P>,
-        &'static P,
+        Option<&'static P>,
         &'static mut MaybeUninit<ST77XX<'static, VirtualMuxAlarm<'static, A>, B, P>>,
         &'static ST77XXScreen,
         &'static mut [u8],

--- a/boards/stm32f412gdiscovery/src/main.rs
+++ b/boards/stm32f412gdiscovery/src/main.rs
@@ -664,10 +664,12 @@ pub unsafe fn main() {
             // dc pin (optional)
             None,
             // reset pin
-            base_peripherals
-                .gpio_ports
-                .get_pin(stm32f412g::gpio::PinId::PD11)
-                .unwrap()
+            Some(
+                base_peripherals
+                    .gpio_ports
+                    .get_pin(stm32f412g::gpio::PinId::PD11)
+                    .unwrap()
+            )
         ),
     );
 

--- a/boards/stm32f412gdiscovery/src/main.rs
+++ b/boards/stm32f412gdiscovery/src/main.rs
@@ -664,12 +664,9 @@ pub unsafe fn main() {
             // dc pin (optional)
             None,
             // reset pin
-            Some(
-                base_peripherals
-                    .gpio_ports
-                    .get_pin(stm32f412g::gpio::PinId::PD11)
-                    .unwrap()
-            )
+            base_peripherals
+                .gpio_ports
+                .get_pin(stm32f412g::gpio::PinId::PD11)
         ),
     );
 


### PR DESCRIPTION
### Pull Request Overview

This pull request changes the st77xx driver to make the reset pin optional. Some screens' reset pin, as the one for the Pico Explorer Base (https://magpi.raspberrypi.org/articles/review-pico-explorer-base), is connected to the boards reset pin instead of a gpio pin.

### Testing Strategy

This pull request was tested using a Pico Explorer Base.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
