### PR TITLE
Update isl29035 to handle i2c errors

### DIFF
--- a/capsules/src/isl29035.rs
+++ b/capsules/src/isl29035.rs
@@ -128,8 +128,8 @@ impl<'a, A: time::Alarm<'a>> time::AlarmClient for Isl29035<'a, A> {
 }
 
 impl<'a, A: time::Alarm<'a>> I2CClient for Isl29035<'a, A> {
-    fn command_complete(&self, buffer: &'static mut [u8], _status: Result<(), Error>) {
-        if _status != Ok(()) {
+    fn command_complete(&self, buffer: &'static mut [u8], status: Result<(), Error>) {
+        if status.is_err() {
             self.state.set(State::Disabled);
             self.buffer.replace(buffer);
             self.client.map(|client| client.callback(0));

--- a/capsules/src/isl29035.rs
+++ b/capsules/src/isl29035.rs
@@ -65,9 +65,9 @@ impl<'a, A: time::Alarm<'a>> Isl29035<'a, A> {
         }
     }
 
-    pub fn start_read_lux(&self) {
+    pub fn start_read_lux(&self) -> Result<(), ErrorCode> {
         if self.state.get() == State::Disabled {
-            self.buffer.take().map(|buf| {
+            self.buffer.take().map_or(Err(ErrorCode::NOMEM), |buf| {
                 self.i2c.enable();
                 buf[0] = 0;
                 // CMD 1 Register:
@@ -82,22 +82,29 @@ impl<'a, A: time::Alarm<'a>> Isl29035<'a, A> {
                 // ADC resolution 8-bit (bits 2,3)
                 // Other bits are reserved
                 buf[2] = 0b00001001;
-                // TODO verify errors
-                let _ = self.i2c.write(buf, 3);
-                self.state.set(State::Enabling);
-            });
+
+                if let Err((error, buf)) = self.i2c.write(buf, 3) {
+                    self.buffer.replace(buf);
+                    self.i2c.disable();
+                    Err(error.into())
+                } else {
+                    self.state.set(State::Enabling);
+                    Ok(())
+                }
+            })
+        } else {
+            Err(ErrorCode::BUSY)
         }
     }
 }
 
 impl<'a, A: time::Alarm<'a>> AmbientLight<'a> for Isl29035<'a, A> {
     fn set_client(&self, client: &'a dyn AmbientLightClient) {
-        self.client.set(client);
+        self.client.set(client)
     }
 
     fn read_light_intensity(&self) -> Result<(), ErrorCode> {
-        self.start_read_lux();
-        Ok(())
+        self.start_read_lux()
     }
 }
 
@@ -108,16 +115,26 @@ impl<'a, A: time::Alarm<'a>> time::AlarmClient for Isl29035<'a, A> {
             self.i2c.enable();
 
             buffer[0] = 0x02 as u8;
-            // TODO verify errors
-            let _ = self.i2c.write_read(buffer, 1, 2);
-            self.state.set(State::ReadingLI);
+            if let Err((_error, buf)) = self.i2c.write_read(buffer, 1, 2) {
+                self.buffer.replace(buf);
+                self.i2c.disable();
+                self.state.set(State::Disabled);
+                self.client.map(|client| client.callback(0));
+            } else {
+                self.state.set(State::ReadingLI);
+            }
         });
     }
 }
 
 impl<'a, A: time::Alarm<'a>> I2CClient for Isl29035<'a, A> {
     fn command_complete(&self, buffer: &'static mut [u8], _status: Result<(), Error>) {
-        // TODO(alevy): handle I2C errors
+        if _status != Ok(()) {
+            self.state.set(State::Disabled);
+            self.buffer.replace(buffer);
+            self.client.map(|client| client.callback(0));
+            return;
+        }
         match self.state.get() {
             State::Enabling => {
                 // Set a timer to wait for the conversion to be done.
@@ -142,9 +159,14 @@ impl<'a, A: time::Alarm<'a>> I2CClient for Isl29035<'a, A> {
                 let lux = (data * 4000) >> 8;
 
                 buffer[0] = 0;
-                // TODO verify errors
-                let _ = self.i2c.write(buffer, 2);
-                self.state.set(State::Disabling(lux));
+
+                if let Err((_error, buffer)) = self.i2c.write(buffer, 2) {
+                    self.state.set(State::Disabled);
+                    self.buffer.replace(buffer);
+                    self.client.map(|client| client.callback(0));
+                } else {
+                    self.state.set(State::Disabling(lux));
+                }
             }
             State::Disabling(lux) => {
                 self.i2c.disable();


### PR DESCRIPTION
### Pull Request Overview

This pull request adds i2c error verification for the isl29035 drivers.


### Testing Strategy

This pull request was not tested.


### TODO or Help Wanted

N/A

### Documentation Updated

- [x] No updates required.

### Formatting

- [x] Ran `make prepush`.
