### PR TITLE
hil/gpio: add Copy and Clone to enums

### DIFF
--- a/kernel/src/hil/gpio.rs
+++ b/kernel/src/hil/gpio.rs
@@ -12,7 +12,7 @@ pub enum FloatingState {
 }
 
 /// Enum for selecting which edge to trigger interrupts on.
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub enum InterruptEdge {
     RisingEdge,
     FallingEdge,
@@ -23,7 +23,7 @@ pub enum InterruptEdge {
 /// so this is a valid option. `Function` means the pin has been configured to
 /// a special function. Determining which function it outside the scope of the HIL,
 /// and should instead use a chip-specific API.
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub enum Configuration {
     /// Cannot be read or written or used; effectively inactive.
     LowPower,


### PR DESCRIPTION
Derive Copy and Clone on the remaining 2 out of 5 enums on the gpio hil trait.

We have some downstream code that puts these enums in a `Cell` so having `Copy` is very nice

### Documentation Updated

None

### Formatting

- [x] Ran `make prepush`.
