### PR TITLE
capsules: sha: Support a shorter destination buffer

### DIFF
--- a/capsules/src/sha.rs
+++ b/capsules/src/sha.rs
@@ -281,7 +281,13 @@ impl<
                     let pointer = digest.as_ref()[0] as *mut u8;
 
                     let _ = app.dest.mut_enter(|dest| {
-                        dest.copy_from_slice(digest);
+                        let len = dest.len();
+
+                        if len < L {
+                            dest.copy_from_slice(&digest[0..len]);
+                        } else {
+                            dest[0..L].copy_from_slice(digest);
+                        }
                     });
 
                     match result {


### PR DESCRIPTION
### Pull Request Overview

Add support to the SHA capsule for an app supplying a shorter (or longer) buffer.

### Testing Strategy

Running a SHA app.

### TODO or Help Wanted

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
