### PR TITLE
msp432/adc: document safety invariants on &[u8] to &[u16] conversion

### DIFF
--- a/chips/msp432/src/adc.rs
+++ b/chips/msp432/src/adc.rs
@@ -573,12 +573,22 @@ enum AdcMode {
     Disabled,
 }
 
-/// This function converts an u8-array to an u16-array.
-/// The provivided reference to the buffer must have an even length, otherwise the function will
-/// panic because the conversion from u8 to u16 would end up in undefined behavior if the last word
-/// of the buffer converted is accessed!
-/// This function is necessary since the DMA returns only u8-buffers whereas the ADC-traits only
-/// work with u16 buffers.
+/// This function converts a `&'static mut [u8]` slice reference to a
+/// `&'static mut [u16]` slice.
+///
+/// ## Safety
+///
+/// It is a necessary condition for the passed buffer to have an even
+/// length, otherwise the function will panic because the conversion
+/// from `u8` to `u16` would end up in undefined behavior if the last
+/// word of the buffer converted is accessed!
+///
+/// Furthermore, this function assumes that the passed buffer is well
+/// aligned, to `core::mem::align_of::<u16>()`. Improper alignment of
+/// the passed buffer will result in undefined behavior.
+///
+/// This function is necessary since the DMA returns only `u8`-buffers
+/// whereas the ADC-traits only work with `u16`-buffers.
 unsafe fn buf_u8_to_buf_u16(buf: &'static mut [u8]) -> &'static mut [u16] {
     if (buf.len() % 2) > 0 {
         panic!("ADC: cannot convert an u8 array with an odd length to an u16 array");
@@ -588,9 +598,11 @@ unsafe fn buf_u8_to_buf_u16(buf: &'static mut [u8]) -> &'static mut [u16] {
     slice::from_raw_parts_mut(buf_ptr, buf.len() / 2)
 }
 
-/// This function converts an u16-array to an u8-array.
-/// Since the DMA only accepts only u8-buffers and the ADC-traits use u16-buffers, they have to be
-/// converted.
+/// This function converts a `&'static mut [u16]` slice reference to a
+/// `&'static mut [u8]` slice reference.
+///
+/// Since the DMA only accepts only `u8`-buffers and the ADC-traits
+/// use `u16`-buffers, they have to be converted.
 unsafe fn buf_u16_to_buf_u8(buf: &'static mut [u16]) -> &'static mut [u8] {
     let buf_ptr = mem::transmute::<*mut u16, *mut u8>(buf.as_mut_ptr());
     slice::from_raw_parts_mut(buf_ptr, buf.len() * 2)


### PR DESCRIPTION


### Pull Request Overview

To support ADC operations on `&'static mut [u16]` slice references, while at the same time using DMA over `&'static mut [u8]` slice references, the MSP432's ADC implementation features conversion helpers. While these are unsafe and check some of the required invariants, these checks and the documentation have been insufficient.

In particular, it is not guaranteed that a given `u8` will be well-aligned to the alignment constraints of a `u16`. Thus, simply transmuting a `*mut u8` to a `*mut 16` and converting this back to a slice can cause undefined behavior.

This does not add additional checks on these functions given they are already unsafe. Furthermore, this issue likely does not affect the existing codebase, given that only buffers which were `&'static mut [u16]` slice references get converted to `&'static mut [u8]`, and back to `&'static mut [u16]` again. Nonetheless, the presence of checks for some of the required invariants could be interpreted as a function which is safe to use, even though it is marked unsafe.

Instead, this PR adds a clear indication of the required invariants and the consequences of a violation of any given requirement.

### Testing Strategy

This pull request was tested by proofreading.


### TODO or Help Wanted

This code seems weird. Also, is a conversion from `&'static mut [u16]` to `&'static mut [u8]` unsound in any case? If not, we shouldn't mark it unsafe.


### Documentation Updated

- [x] ~Updated the relevant files in `/docs`,~ or no updates are required.

### Formatting

- [x] Ran `make prepush`.


@lebakassemmerl 