### PR TITLE
HIL: Digest: Add SHA/HMAC verify

### DIFF
--- a/boards/opentitan/src/main.rs
+++ b/boards/opentitan/src/main.rs
@@ -20,7 +20,7 @@ use kernel::capabilities;
 use kernel::component::Component;
 use kernel::dynamic_deferred_call::{DynamicDeferredCall, DynamicDeferredCallClientState};
 use kernel::hil;
-use kernel::hil::digest::DigestData;
+use kernel::hil::digest::Digest;
 use kernel::hil::entropy::Entropy32;
 use kernel::hil::i2c::I2CMaster;
 use kernel::hil::led::LedHigh;

--- a/boards/opentitan/src/main.rs
+++ b/boards/opentitan/src/main.rs
@@ -20,7 +20,7 @@ use kernel::capabilities;
 use kernel::component::Component;
 use kernel::dynamic_deferred_call::{DynamicDeferredCall, DynamicDeferredCallClientState};
 use kernel::hil;
-use kernel::hil::digest::Digest;
+use kernel::hil::digest::DigestData;
 use kernel::hil::entropy::Entropy32;
 use kernel::hil::i2c::I2CMaster;
 use kernel::hil::led::LedHigh;

--- a/boards/opentitan/src/tests/hmac.rs
+++ b/boards/opentitan/src/tests/hmac.rs
@@ -1,36 +1,105 @@
 use crate::tests::run_kernel_op;
 use crate::PERIPHERALS;
-use kernel::hil::digest::{self, Digest};
+use core::cell::Cell;
+use kernel::hil::digest::{self, Digest, HMACSha256};
 use kernel::utilities::leasable_buffer::LeasableBuffer;
 use kernel::{debug, ErrorCode};
 
-static mut BUF: [u8; 32] = [0; 32];
+static KEY: [u8; 32] = [0xA1; 32];
+static mut INPUT: [u8; 32] = [32; 32];
+static mut DIGEST: [u8; 32] = [
+    0xdc, 0x55, 0x51, 0x5e, 0x30, 0xac, 0x50, 0xc7, 0x65, 0xbd, 0xe, 0x2, 0x82, 0xf7, 0x8b, 0xe1,
+    0xef, 0xd1, 0xb, 0xdc, 0xa8, 0xba, 0xe1, 0xfa, 0x11, 0x3f, 0xf6, 0xeb, 0xaf, 0x58, 0x57, 0x40,
+];
 
-struct HmacTestCallback {}
+struct HmacTestCallback {
+    add_data_done: Cell<bool>,
+    verification_done: Cell<bool>,
+}
+
+unsafe impl Sync for HmacTestCallback {}
+
+impl<'a> HmacTestCallback {
+    const fn new() -> Self {
+        HmacTestCallback {
+            add_data_done: Cell::new(false),
+            verification_done: Cell::new(false),
+        }
+    }
+
+    fn reset(&self) {
+        self.add_data_done.set(false);
+        self.verification_done.set(false);
+    }
+}
 
 impl<'a> digest::Client<'a, 32> for HmacTestCallback {
     fn add_data_done(&'a self, result: Result<(), ErrorCode>, _data: &'static mut [u8]) {
+        self.add_data_done.set(true);
         assert_eq!(result, Ok(()));
     }
 
     fn hash_done(&'a self, _result: Result<(), ErrorCode>, _digest: &'static mut [u8; 32]) {
         unimplemented!()
     }
+
+    fn verification_done(
+        &'a self,
+        result: Result<bool, ErrorCode>,
+        compare: &'static mut [u8; 32],
+    ) {
+        self.verification_done.set(true);
+        assert_eq!(result, Ok(true));
+    }
 }
 
-static CALLBACK: HmacTestCallback = HmacTestCallback {};
+static CALLBACK: HmacTestCallback = HmacTestCallback::new();
 
 #[test_case]
 fn hmac_check_load_binary() {
     let perf = unsafe { PERIPHERALS.unwrap() };
     let hmac = &perf.hmac;
-    let buf = unsafe { LeasableBuffer::new(&mut BUF) };
+    let buf = unsafe { LeasableBuffer::new(&mut INPUT) };
 
     debug!("check hmac load binary... ");
     run_kernel_op(100);
 
     hmac.set_client(&CALLBACK);
     assert_eq!(hmac.add_data(buf), Ok(32));
+
+    run_kernel_op(1000);
+    #[cfg(feature = "hardware_tests")]
+    assert_eq!(CALLBACK.add_data_done.get(), true);
+
+    run_kernel_op(100);
+    debug!("    [ok]");
+    run_kernel_op(100);
+}
+
+#[test_case]
+fn hmac_check_verify() {
+    let perf = unsafe { PERIPHERALS.unwrap() };
+    let hmac = &perf.hmac;
+    let buf = unsafe { LeasableBuffer::new(&mut INPUT) };
+
+    debug!("check hmac check verify... ");
+    run_kernel_op(100);
+
+    hmac.set_client(&CALLBACK);
+    hmac.set_mode_hmacsha256(&KEY).unwrap();
+    assert_eq!(hmac.add_data(buf), Ok(32));
+
+    run_kernel_op(1000);
+    #[cfg(feature = "hardware_tests")]
+    assert_eq!(CALLBACK.add_data_done.get(), true);
+
+    unsafe {
+        assert_eq!(hmac.verify(&mut DIGEST), Ok(()));
+    }
+
+    run_kernel_op(1000);
+    #[cfg(feature = "hardware_tests")]
+    assert_eq!(CALLBACK.verification_done.get(), true);
 
     run_kernel_op(100);
     debug!("    [ok]");

--- a/capsules/src/hmac.rs
+++ b/capsules/src/hmac.rs
@@ -24,6 +24,7 @@
 //! ```
 
 use crate::driver;
+use kernel::errorcode::into_statuscode;
 /// Syscall driver number.
 pub const DRIVER_NUM: usize = driver::NUM::Hmac as usize;
 
@@ -168,6 +169,21 @@ impl<
         Ok(())
     }
 
+    fn verify_digest(&self) -> Result<(), ErrorCode> {
+        self.data_copied.set(0);
+
+        if let Err(e) = self.hmac.verify(self.dest_buffer.take().unwrap()) {
+            // Error, clear the appid and data
+            self.hmac.clear_data();
+            self.appid.clear();
+            self.dest_buffer.replace(e.1);
+
+            return Err(e.0);
+        }
+
+        Ok(())
+    }
+
     fn check_queue(&self) {
         for appiter in self.apps.iter() {
             let started_command = appiter.enter(|app, _| {
@@ -275,10 +291,31 @@ impl<
                     if app.op.get().unwrap() == UserSpaceOp::Run {
                         if let Err(e) = self.calculate_digest() {
                             upcalls
-                                .schedule_upcall(
-                                    0,
-                                    (kernel::errorcode::into_statuscode(e.into()), 0, 0),
-                                )
+                                .schedule_upcall(0, (into_statuscode(e.into()), 0, 0))
+                                .ok();
+                        }
+                    } else if app.op.get().unwrap() == UserSpaceOp::Verify {
+                        let _ = app.compare.enter(|compare| {
+                            let mut static_buffer_len = 0;
+                            self.dest_buffer.map(|buf| {
+                                // Determine the size of the static buffer we have
+                                static_buffer_len = buf.len();
+
+                                if static_buffer_len > compare.len() {
+                                    static_buffer_len = compare.len()
+                                }
+
+                                self.data_copied.set(static_buffer_len);
+
+                                // Copy the data into the static buffer
+                                compare[..static_buffer_len]
+                                    .copy_to_slice(&mut buf[..static_buffer_len]);
+                            });
+                        });
+
+                        if let Err(e) = self.verify_digest() {
+                            upcalls
+                                .schedule_upcall(1, (into_statuscode(e.into()), 0, 0))
                                 .ok();
                         }
                     } else {
@@ -324,14 +361,8 @@ impl<
 
                     match result {
                         Ok(_) => upcalls.schedule_upcall(0, (0, pointer as usize, 0)),
-                        Err(e) => upcalls.schedule_upcall(
-                            0,
-                            (
-                                kernel::errorcode::into_statuscode(e.into()),
-                                pointer as usize,
-                                0,
-                            ),
-                        ),
+                        Err(e) => upcalls
+                            .schedule_upcall(0, (into_statuscode(e.into()), pointer as usize, 0)),
                     }
                     .ok();
 
@@ -358,12 +389,32 @@ impl<
         const L: usize,
     > digest::ClientVerify<'a, L> for HmacDriver<'a, H, L>
 {
-    fn verification_done(
-        &'a self,
-        _result: Result<bool, ErrorCode>,
-        _compare: &'static mut [u8; L],
-    ) {
-        unimplemented!();
+    fn verification_done(&'a self, result: Result<bool, ErrorCode>, compare: &'static mut [u8; L]) {
+        self.appid.map(|id| {
+            self.apps
+                .enter(*id, |_app, upcalls| {
+                    self.hmac.clear_data();
+
+                    match result {
+                        Ok(equal) => upcalls.schedule_upcall(1, (0, equal as usize, 0)),
+                        Err(e) => upcalls.schedule_upcall(1, (into_statuscode(e.into()), 0, 0)),
+                    }
+                    .ok();
+
+                    // Clear the current appid as it has finished running
+                    self.appid.clear();
+                })
+                .map_err(|err| {
+                    if err == kernel::process::Error::NoSuchApp
+                        || err == kernel::process::Error::InactiveApp
+                    {
+                        self.appid.clear();
+                    }
+                })
+        });
+
+        self.check_queue();
+        self.dest_buffer.replace(compare);
     }
 }
 
@@ -435,6 +486,15 @@ impl<
                 .apps
                 .enter(appid, |app, _| {
                     mem::swap(&mut app.data, &mut slice);
+                    Ok(())
+                })
+                .unwrap_or(Err(ErrorCode::FAIL)),
+
+            // Compare buffer for verify
+            2 => self
+                .apps
+                .enter(appid, |app, _| {
+                    mem::swap(&mut app.compare, &mut slice);
                     Ok(())
                 })
                 .unwrap_or(Err(ErrorCode::FAIL)),
@@ -661,6 +721,85 @@ impl<
                 }
             }
 
+            // veryify
+            // Use key and data to compute hash and comapre it against
+            // the digest
+            4 => {
+                if match_or_empty_or_nonexistant {
+                    self.appid.set(appid);
+                    let _ = self.apps.enter(appid, |app, _| {
+                        app.op.set(Some(UserSpaceOp::Verify));
+                    });
+                    let ret = self.run();
+
+                    if let Err(e) = ret {
+                        self.hmac.clear_data();
+                        self.appid.clear();
+                        self.check_queue();
+                        CommandReturn::failure(e)
+                    } else {
+                        CommandReturn::success()
+                    }
+                } else {
+                    // There is an active app, so queue this request (if possible).
+                    self.apps
+                        .enter(appid, |app, _| {
+                            // Some app is using the storage, we must wait.
+                            if app.pending_run_app.is_some() {
+                                // No more room in the queue, nowhere to store this
+                                // request.
+                                CommandReturn::failure(ErrorCode::NOMEM)
+                            } else {
+                                // We can store this, so lets do it.
+                                app.pending_run_app = Some(appid);
+                                app.op.set(Some(UserSpaceOp::Verify));
+                                CommandReturn::success()
+                            }
+                        })
+                        .unwrap_or_else(|err| err.into())
+                }
+            }
+
+            // verify_finish
+            // Use key and data to compute hash and comapre it against
+            // the digest, useful after a update command
+            5 => {
+                if app_match {
+                    self.apps
+                        .enter(appid, |app, upcalls| {
+                            let _ = app.compare.enter(|compare| {
+                                let mut static_buffer_len = 0;
+                                self.dest_buffer.map(|buf| {
+                                    // Determine the size of the static buffer we have
+                                    static_buffer_len = buf.len();
+
+                                    if static_buffer_len > compare.len() {
+                                        static_buffer_len = compare.len()
+                                    }
+
+                                    self.data_copied.set(static_buffer_len);
+
+                                    // Copy the data into the static buffer
+                                    compare[..static_buffer_len]
+                                        .copy_to_slice(&mut buf[..static_buffer_len]);
+                                });
+                            });
+
+                            if let Err(e) = self.verify_digest() {
+                                upcalls
+                                    .schedule_upcall(1, (into_statuscode(e.into()), 0, 0))
+                                    .ok();
+                            }
+                        })
+                        .unwrap();
+                    CommandReturn::success()
+                } else {
+                    // We don't queue this request, the user has to call
+                    // `update` first.
+                    CommandReturn::failure(ErrorCode::OFF)
+                }
+            }
+
             // default
             _ => CommandReturn::failure(ErrorCode::NOSUPPORT),
         }
@@ -675,6 +814,7 @@ impl<
 enum UserSpaceOp {
     Run,
     Update,
+    Verify,
 }
 
 #[derive(Default)]
@@ -685,4 +825,5 @@ pub struct App {
     key: ReadOnlyProcessBuffer,
     data: ReadOnlyProcessBuffer,
     dest: ReadWriteProcessBuffer,
+    compare: ReadOnlyProcessBuffer,
 }

--- a/capsules/src/hmac.rs
+++ b/capsules/src/hmac.rs
@@ -195,7 +195,7 @@ impl<
         'a,
         H: digest::Digest<'a, L> + digest::HMACSha256 + digest::HMACSha384 + digest::HMACSha512,
         const L: usize,
-    > digest::Client<'a, L> for HmacDriver<'a, H, L>
+    > digest::ClientData<'a, L> for HmacDriver<'a, H, L>
 {
     fn add_data_done(&'a self, _result: Result<(), ErrorCode>, data: &'static mut [u8]) {
         self.appid.map(move |id| {
@@ -296,7 +296,14 @@ impl<
 
         self.check_queue();
     }
+}
 
+impl<
+        'a,
+        H: digest::Digest<'a, L> + digest::HMACSha256 + digest::HMACSha384 + digest::HMACSha512,
+        const L: usize,
+    > digest::ClientHash<'a, L> for HmacDriver<'a, H, L>
+{
     fn hash_done(&'a self, result: Result<(), ErrorCode>, digest: &'static mut [u8; L]) {
         self.appid.map(|id| {
             self.apps
@@ -343,7 +350,14 @@ impl<
         self.check_queue();
         self.dest_buffer.replace(digest);
     }
+}
 
+impl<
+        'a,
+        H: digest::Digest<'a, L> + digest::HMACSha256 + digest::HMACSha384 + digest::HMACSha512,
+        const L: usize,
+    > digest::ClientVerify<'a, L> for HmacDriver<'a, H, L>
+{
     fn verification_done(
         &'a self,
         _result: Result<bool, ErrorCode>,

--- a/capsules/src/hmac.rs
+++ b/capsules/src/hmac.rs
@@ -343,6 +343,14 @@ impl<
         self.check_queue();
         self.dest_buffer.replace(digest);
     }
+
+    fn verification_done(
+        &'a self,
+        _result: Result<bool, ErrorCode>,
+        _compare: &'static mut [u8; L],
+    ) {
+        unimplemented!();
+    }
 }
 
 /// Specify memory regions to be used.

--- a/capsules/src/sha.rs
+++ b/capsules/src/sha.rs
@@ -24,6 +24,7 @@
 //! ```
 
 use crate::driver;
+use kernel::errorcode::into_statuscode;
 /// Syscall driver number.
 pub const DRIVER_NUM: usize = driver::NUM::Sha as usize;
 
@@ -168,6 +169,21 @@ impl<
 
         Ok(())
     }
+
+    fn verify_digest(&self) -> Result<(), ErrorCode> {
+        self.data_copied.set(0);
+
+        if let Err(e) = self.sha.verify(self.dest_buffer.take().unwrap()) {
+            // Error, clear the appid and data
+            self.sha.clear_data();
+            self.appid.clear();
+            self.dest_buffer.replace(e.1);
+
+            return Err(e.0);
+        }
+
+        Ok(())
+    }
 }
 
 impl<
@@ -255,10 +271,31 @@ impl<
                     if app.op.get().unwrap() == UserSpaceOp::Run {
                         if let Err(e) = self.calculate_digest() {
                             upcalls
-                                .schedule_upcall(
-                                    0,
-                                    (kernel::errorcode::into_statuscode(e.into()), 0, 0),
-                                )
+                                .schedule_upcall(0, (into_statuscode(e.into()), 0, 0))
+                                .ok();
+                        }
+                    } else if app.op.get().unwrap() == UserSpaceOp::Verify {
+                        let _ = app.compare.enter(|compare| {
+                            let mut static_buffer_len = 0;
+                            self.dest_buffer.map(|buf| {
+                                // Determine the size of the static buffer we have
+                                static_buffer_len = buf.len();
+
+                                if static_buffer_len > compare.len() {
+                                    static_buffer_len = compare.len()
+                                }
+
+                                self.data_copied.set(static_buffer_len);
+
+                                // Copy the data into the static buffer
+                                compare[..static_buffer_len]
+                                    .copy_to_slice(&mut buf[..static_buffer_len]);
+                            });
+                        });
+
+                        if let Err(e) = self.verify_digest() {
+                            upcalls
+                                .schedule_upcall(1, (into_statuscode(e.into()), 0, 0))
                                 .ok();
                         }
                     } else {
@@ -305,14 +342,7 @@ impl<
                     match result {
                         Ok(_) => upcalls.schedule_upcall(0, (0, pointer as usize, 0)).ok(),
                         Err(e) => upcalls
-                            .schedule_upcall(
-                                0,
-                                (
-                                    kernel::errorcode::into_statuscode(e.into()),
-                                    pointer as usize,
-                                    0,
-                                ),
-                            )
+                            .schedule_upcall(0, (into_statuscode(e.into()), pointer as usize, 0))
                             .ok(),
                     };
 
@@ -339,12 +369,32 @@ impl<
         const L: usize,
     > digest::ClientVerify<'a, L> for ShaDriver<'a, H, L>
 {
-    fn verification_done(
-        &'a self,
-        _result: Result<bool, ErrorCode>,
-        _compare: &'static mut [u8; L],
-    ) {
-        unimplemented!();
+    fn verification_done(&'a self, result: Result<bool, ErrorCode>, compare: &'static mut [u8; L]) {
+        self.appid.map(|id| {
+            self.apps
+                .enter(*id, |_app, upcalls| {
+                    self.sha.clear_data();
+
+                    match result {
+                        Ok(equal) => upcalls.schedule_upcall(1, (0, equal as usize, 0)),
+                        Err(e) => upcalls.schedule_upcall(1, (into_statuscode(e.into()), 0, 0)),
+                    }
+                    .ok();
+
+                    // Clear the current appid as it has finished running
+                    self.appid.clear();
+                })
+                .map_err(|err| {
+                    if err == kernel::process::Error::NoSuchApp
+                        || err == kernel::process::Error::InactiveApp
+                    {
+                        self.appid.clear();
+                    }
+                })
+        });
+
+        self.check_queue();
+        self.dest_buffer.replace(compare);
     }
 }
 
@@ -392,6 +442,15 @@ impl<
                 .apps
                 .enter(appid, |app, _| {
                     mem::swap(&mut app.data, &mut slice);
+                    Ok(())
+                })
+                .unwrap_or(Err(ErrorCode::FAIL)),
+
+            // Compare buffer for verify
+            2 => self
+                .apps
+                .enter(appid, |app, _| {
+                    mem::swap(&mut app.compare, &mut slice);
                     Ok(())
                 })
                 .unwrap_or(Err(ErrorCode::FAIL)),
@@ -595,10 +654,86 @@ impl<
                         .enter(appid, |_app, upcalls| {
                             if let Err(e) = self.calculate_digest() {
                                 upcalls
-                                    .schedule_upcall(
-                                        0,
-                                        (kernel::errorcode::into_statuscode(e.into()), 0, 0),
-                                    )
+                                    .schedule_upcall(0, (into_statuscode(e.into()), 0, 0))
+                                    .ok();
+                            }
+                        })
+                        .unwrap();
+                    CommandReturn::success()
+                } else {
+                    // We don't queue this request, the user has to call
+                    // `update` first.
+                    CommandReturn::failure(ErrorCode::OFF)
+                }
+            }
+
+            // veryify
+            // Use key and data to compute hash and comapre it against
+            // the digest
+            4 => {
+                if match_or_empty_or_nonexistant {
+                    self.appid.set(appid);
+                    let _ = self.apps.enter(appid, |app, _| {
+                        app.op.set(Some(UserSpaceOp::Verify));
+                    });
+                    let ret = self.run();
+
+                    if let Err(e) = ret {
+                        self.sha.clear_data();
+                        self.appid.clear();
+                        self.check_queue();
+                        CommandReturn::failure(e)
+                    } else {
+                        CommandReturn::success()
+                    }
+                } else {
+                    // There is an active app, so queue this request (if possible).
+                    self.apps
+                        .enter(appid, |app, _| {
+                            // Some app is using the storage, we must wait.
+                            if app.pending_run_app.is_some() {
+                                // No more room in the queue, nowhere to store this
+                                // request.
+                                CommandReturn::failure(ErrorCode::NOMEM)
+                            } else {
+                                // We can store this, so lets do it.
+                                app.pending_run_app = Some(appid);
+                                app.op.set(Some(UserSpaceOp::Verify));
+                                CommandReturn::success()
+                            }
+                        })
+                        .unwrap_or_else(|err| err.into())
+                }
+            }
+
+            // verify_finish
+            // Use key and data to compute hash and comapre it against
+            // the digest, useful after a update command
+            5 => {
+                if app_match {
+                    self.apps
+                        .enter(appid, |app, upcalls| {
+                            let _ = app.compare.enter(|compare| {
+                                let mut static_buffer_len = 0;
+                                self.dest_buffer.map(|buf| {
+                                    // Determine the size of the static buffer we have
+                                    static_buffer_len = buf.len();
+
+                                    if static_buffer_len > compare.len() {
+                                        static_buffer_len = compare.len()
+                                    }
+
+                                    self.data_copied.set(static_buffer_len);
+
+                                    // Copy the data into the static buffer
+                                    compare[..static_buffer_len]
+                                        .copy_to_slice(&mut buf[..static_buffer_len]);
+                                });
+                            });
+
+                            if let Err(e) = self.verify_digest() {
+                                upcalls
+                                    .schedule_upcall(1, (into_statuscode(e.into()), 0, 0))
                                     .ok();
                             }
                         })
@@ -625,6 +760,7 @@ impl<
 enum UserSpaceOp {
     Run,
     Update,
+    Verify,
 }
 
 #[derive(Default)]
@@ -634,4 +770,5 @@ pub struct App {
     op: Cell<Option<UserSpaceOp>>,
     data: ReadOnlyProcessBuffer,
     dest: ReadWriteProcessBuffer,
+    compare: ReadOnlyProcessBuffer,
 }

--- a/capsules/src/sha.rs
+++ b/capsules/src/sha.rs
@@ -174,7 +174,7 @@ impl<
         'a,
         H: digest::Digest<'a, L> + digest::Sha256 + digest::Sha384 + digest::Sha512,
         const L: usize,
-    > digest::Client<'a, L> for ShaDriver<'a, H, L>
+    > digest::ClientData<'a, L> for ShaDriver<'a, H, L>
 {
     fn add_data_done(&'a self, _result: Result<(), ErrorCode>, data: &'static mut [u8]) {
         self.appid.map(move |id| {
@@ -276,7 +276,14 @@ impl<
 
         self.check_queue();
     }
+}
 
+impl<
+        'a,
+        H: digest::Digest<'a, L> + digest::Sha256 + digest::Sha384 + digest::Sha512,
+        const L: usize,
+    > digest::ClientHash<'a, L> for ShaDriver<'a, H, L>
+{
     fn hash_done(&'a self, result: Result<(), ErrorCode>, digest: &'static mut [u8; L]) {
         self.appid.map(|id| {
             self.apps
@@ -324,7 +331,14 @@ impl<
         self.check_queue();
         self.dest_buffer.replace(digest);
     }
+}
 
+impl<
+        'a,
+        H: digest::Digest<'a, L> + digest::Sha256 + digest::Sha384 + digest::Sha512,
+        const L: usize,
+    > digest::ClientVerify<'a, L> for ShaDriver<'a, H, L>
+{
     fn verification_done(
         &'a self,
         _result: Result<bool, ErrorCode>,

--- a/capsules/src/sha.rs
+++ b/capsules/src/sha.rs
@@ -667,7 +667,7 @@ impl<
                 }
             }
 
-            // veryify
+            // verify
             // Use key and data to compute hash and comapre it against
             // the digest
             4 => {

--- a/capsules/src/sha.rs
+++ b/capsules/src/sha.rs
@@ -324,6 +324,14 @@ impl<
         self.check_queue();
         self.dest_buffer.replace(digest);
     }
+
+    fn verification_done(
+        &'a self,
+        _result: Result<bool, ErrorCode>,
+        _compare: &'static mut [u8; L],
+    ) {
+        unimplemented!();
+    }
 }
 
 impl<

--- a/capsules/src/virtual_digest.rs
+++ b/capsules/src/virtual_digest.rs
@@ -90,12 +90,6 @@ impl<'a, A: digest::Digest<'a, L>, const L: usize> VirtualMuxDigest<'a, A, L> {
 impl<'a, A: digest::Digest<'a, L>, const L: usize> digest::DigestData<'a, L>
     for VirtualMuxDigest<'a, A, L>
 {
-    /// Set the client instance which will receive `add_data_done()` and
-    /// `hash_done()` callbacks
-    fn set_client(&'a self, _client: &'a dyn digest::Client<'a, L>) {
-        unimplemented!()
-    }
-
     /// Add data to the digest IP.
     /// All data passed in is fed to the Digest hardware block.
     /// Returns the number of bytes written on success
@@ -180,6 +174,16 @@ impl<'a, A: digest::Digest<'a, L>, const L: usize> digest::DigestVerify<'a, L>
                 Err((ErrorCode::BUSY, compare))
             }
         }
+    }
+}
+
+impl<'a, A: digest::Digest<'a, L>, const L: usize> digest::Digest<'a, L>
+    for VirtualMuxDigest<'a, A, L>
+{
+    /// Set the client instance which will receive `add_data_done()` and
+    /// `hash_done()` callbacks
+    fn set_client(&'a self, _client: &'a dyn digest::Client<'a, L>) {
+        unimplemented!()
     }
 }
 

--- a/capsules/src/virtual_hmac.rs
+++ b/capsules/src/virtual_hmac.rs
@@ -58,16 +58,6 @@ impl<'a, A: digest::Digest<'a, L>, const L: usize> VirtualMuxHmac<'a, A, L> {
 impl<'a, A: digest::Digest<'a, L>, const L: usize> digest::DigestData<'a, L>
     for VirtualMuxHmac<'a, A, L>
 {
-    /// Set the client instance which will receive `add_data_done()` and
-    /// `hash_done()` callbacks
-    fn set_client(&'a self, client: &'a dyn digest::Client<'a, L>) {
-        let node = self.mux.users.iter().find(|node| node.id == self.id);
-        if node.is_none() {
-            self.mux.users.push_head(self);
-        }
-        self.mux.hmac.set_client(client);
-    }
-
     /// Add data to the hmac IP.
     /// All data passed in is fed to the HMAC hardware block.
     /// Returns the number of bytes written on success
@@ -150,6 +140,20 @@ impl<'a, A: digest::Digest<'a, L>, const L: usize> digest::DigestVerify<'a, L>
                 Err((ErrorCode::BUSY, compare))
             }
         }
+    }
+}
+
+impl<'a, A: digest::Digest<'a, L>, const L: usize> digest::Digest<'a, L>
+    for VirtualMuxHmac<'a, A, L>
+{
+    /// Set the client instance which will receive `add_data_done()` and
+    /// `hash_done()` callbacks
+    fn set_client(&'a self, client: &'a dyn digest::Client<'a, L>) {
+        let node = self.mux.users.iter().find(|node| node.id == self.id);
+        if node.is_none() {
+            self.mux.users.push_head(self);
+        }
+        self.mux.hmac.set_client(client);
     }
 }
 

--- a/capsules/src/virtual_hmac.rs
+++ b/capsules/src/virtual_hmac.rs
@@ -19,6 +19,7 @@ pub struct VirtualMuxHmac<'a, A: digest::Digest<'a, L>, const L: usize> {
     data: TakeCell<'static, [u8]>,
     data_len: Cell<usize>,
     digest: TakeCell<'static, [u8; L]>,
+    verify: Cell<bool>,
     mode: Cell<Mode>,
     id: u32,
 }
@@ -47,6 +48,7 @@ impl<'a, A: digest::Digest<'a, L>, const L: usize> VirtualMuxHmac<'a, A, L> {
             data: TakeCell::empty(),
             data_len: Cell::new(0),
             digest: TakeCell::empty(),
+            verify: Cell::new(false),
             mode: Cell::new(Mode::None),
             id: id,
         }
@@ -121,6 +123,26 @@ impl<'a, A: digest::Digest<'a, L>, const L: usize> digest::Digest<'a, L>
             self.mux.hmac.clear_data()
         }
     }
+
+    fn verify(
+        &self,
+        compare: &'static mut [u8; L],
+    ) -> Result<(), (ErrorCode, &'static mut [u8; L])> {
+        // Check if any mux is enabled
+        if self.mux.running_id.get() == self.id {
+            self.mux.hmac.verify(compare)
+        } else {
+            // Another app is already running, queue this app as long as we
+            // don't already have data queued.
+            if self.digest.is_none() {
+                self.digest.replace(compare);
+                self.verify.set(true);
+                Ok(())
+            } else {
+                Err((ErrorCode::BUSY, compare))
+            }
+        }
+    }
 }
 
 impl<
@@ -138,6 +160,15 @@ impl<
     fn hash_done(&'a self, result: Result<(), ErrorCode>, digest: &'static mut [u8; L]) {
         self.client
             .map(move |client| client.hash_done(result, digest));
+
+        // Forcefully clear the data to allow other apps to use the HMAC
+        self.clear_data();
+        self.mux.do_next_op();
+    }
+
+    fn verification_done(&'a self, result: Result<bool, ErrorCode>, digest: &'static mut [u8; L]) {
+        self.client
+            .map(move |client| client.verification_done(result, digest));
 
         // Forcefully clear the data to allow other apps to use the HMAC
         self.clear_data();
@@ -265,8 +296,14 @@ impl<
             }
 
             if node.digest.is_some() {
-                if let Err((err, data)) = self.hmac.run(node.digest.take().unwrap()) {
-                    node.hash_done(Err(err), data);
+                if node.verify.get() {
+                    if let Err((err, compare)) = self.hmac.verify(node.digest.take().unwrap()) {
+                        node.verification_done(Err(err), compare);
+                    }
+                } else {
+                    if let Err((err, data)) = self.hmac.run(node.digest.take().unwrap()) {
+                        node.hash_done(Err(err), data);
+                    }
                 }
             }
         });

--- a/capsules/src/virtual_sha.rs
+++ b/capsules/src/virtual_sha.rs
@@ -53,16 +53,6 @@ impl<'a, A: digest::Digest<'a, L>, const L: usize> VirtualMuxSha<'a, A, L> {
 impl<'a, A: digest::Digest<'a, L>, const L: usize> digest::DigestData<'a, L>
     for VirtualMuxSha<'a, A, L>
 {
-    /// Set the client instance which will receive `add_data_done()` and
-    /// `hash_done()` callbacks
-    fn set_client(&'a self, client: &'a dyn digest::Client<'a, L>) {
-        let node = self.mux.users.iter().find(|node| node.id == self.id);
-        if node.is_none() {
-            self.mux.users.push_head(self);
-        }
-        self.mux.sha.set_client(client);
-    }
-
     /// Add data to the sha IP.
     /// All data passed in is fed to the SHA hardware block.
     /// Returns the number of bytes written on success
@@ -145,6 +135,20 @@ impl<'a, A: digest::Digest<'a, L>, const L: usize> digest::DigestVerify<'a, L>
                 Err((ErrorCode::BUSY, compare))
             }
         }
+    }
+}
+
+impl<'a, A: digest::Digest<'a, L>, const L: usize> digest::Digest<'a, L>
+    for VirtualMuxSha<'a, A, L>
+{
+    /// Set the client instance which will receive `add_data_done()` and
+    /// `hash_done()` callbacks
+    fn set_client(&'a self, client: &'a dyn digest::Client<'a, L>) {
+        let node = self.mux.users.iter().find(|node| node.id == self.id);
+        if node.is_none() {
+            self.mux.users.push_head(self);
+        }
+        self.mux.sha.set_client(client);
     }
 }
 

--- a/chips/lowrisc/src/hmac.rs
+++ b/chips/lowrisc/src/hmac.rs
@@ -221,10 +221,6 @@ impl Hmac<'_> {
 }
 
 impl<'a> hil::digest::DigestData<'a, 32> for Hmac<'a> {
-    fn set_client(&'a self, client: &'a dyn digest::Client<'a, 32>) {
-        self.client.set(client);
-    }
-
     fn add_data(
         &self,
         data: LeasableBuffer<'static, u8>,
@@ -292,6 +288,12 @@ impl<'a> hil::digest::DigestVerify<'a, 32> for Hmac<'a> {
         self.verify.set(true);
 
         self.run(compare)
+    }
+}
+
+impl<'a> hil::digest::Digest<'a, 32> for Hmac<'a> {
+    fn set_client(&'a self, client: &'a dyn digest::Client<'a, 32>) {
+        self.client.set(client);
     }
 }
 

--- a/chips/lowrisc/src/hmac.rs
+++ b/chips/lowrisc/src/hmac.rs
@@ -253,6 +253,13 @@ impl<'a> hil::digest::Digest<'a, 32> for Hmac<'a> {
         regs.cmd.modify(CMD::START::CLEAR);
         regs.wipe_secret.set(1 as u32);
     }
+
+    fn verify(
+        &'a self,
+        compare: &'static mut [u8; 32],
+    ) -> Result<(), (ErrorCode, &'static mut [u8; 32])> {
+        Err((ErrorCode::NOSUPPORT, compare))
+    }
 }
 
 impl hil::digest::HMACSha256 for Hmac<'_> {

--- a/chips/lowrisc/src/hmac.rs
+++ b/chips/lowrisc/src/hmac.rs
@@ -193,7 +193,7 @@ impl Hmac<'_> {
     }
 }
 
-impl<'a> hil::digest::Digest<'a, 32> for Hmac<'a> {
+impl<'a> hil::digest::DigestData<'a, 32> for Hmac<'a> {
     fn set_client(&'a self, client: &'a dyn digest::Client<'a, 32>) {
         self.client.set(client);
     }
@@ -227,6 +227,15 @@ impl<'a> hil::digest::Digest<'a, 32> for Hmac<'a> {
         Ok(self.data_len.get())
     }
 
+    fn clear_data(&self) {
+        let regs = self.registers;
+
+        regs.cmd.modify(CMD::START::CLEAR);
+        regs.wipe_secret.set(1 as u32);
+    }
+}
+
+impl<'a> hil::digest::DigestHash<'a, 32> for Hmac<'a> {
     fn run(
         &'a self,
         digest: &'static mut [u8; 32],
@@ -246,14 +255,9 @@ impl<'a> hil::digest::Digest<'a, 32> for Hmac<'a> {
 
         Ok(())
     }
+}
 
-    fn clear_data(&self) {
-        let regs = self.registers;
-
-        regs.cmd.modify(CMD::START::CLEAR);
-        regs.wipe_secret.set(1 as u32);
-    }
-
+impl<'a> hil::digest::DigestVerify<'a, 32> for Hmac<'a> {
     fn verify(
         &'a self,
         compare: &'static mut [u8; 32],


### PR DESCRIPTION
### Pull Request Overview

This PR adds to the SHA HIL a `verify()` option. This allows users to check that a result matches what they expect.

This is beneficial as it avoids having to copy the data around when a user just wants to check if the digest matches a known value.

### Testing Strategy

Running HMAC tests on OpenTitan.

### TODO or Help Wanted

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
