### PR TITLE
Updated lps25hb to handle i2c errors

### DIFF
--- a/capsules/src/lps25hb.rs
+++ b/capsules/src/lps25hb.rs
@@ -172,8 +172,8 @@ impl<'a> LPS25HB<'a> {
 }
 
 impl i2c::I2CClient for LPS25HB<'_> {
-    fn command_complete(&self, buffer: &'static mut [u8], _status: Result<(), i2c::Error>) {
-        if _status != Ok(()) {
+    fn command_complete(&self, buffer: &'static mut [u8], status: Result<(), i2c::Error>) {
+        if status != Ok(()) {
             self.state.set(State::Idle);
             self.buffer.replace(buffer);
             self.owning_process.map(|pid| {

--- a/capsules/src/lps25hb.rs
+++ b/capsules/src/lps25hb.rs
@@ -20,6 +20,7 @@
 
 use core::cell::Cell;
 
+use kernel::errorcode::into_statuscode;
 use kernel::grant::Grant;
 use kernel::hil::gpio;
 use kernel::hil::i2c;
@@ -205,12 +206,7 @@ impl i2c::I2CClient for LPS25HB<'_> {
                     self.owning_process.map(|pid| {
                         let _ = self.apps.enter(*pid, |_app, upcalls| {
                             upcalls
-                                .schedule_upcall(
-                                    0,
-                                    kernel::into_statuscode(Err(error.into())),
-                                    0,
-                                    0,
-                                )
+                                .schedule_upcall(0, into_statuscode(Err(error.into())), 0, 0)
                                 .ok();
                         });
                     });
@@ -225,12 +221,7 @@ impl i2c::I2CClient for LPS25HB<'_> {
                     self.owning_process.map(|pid| {
                         let _ = self.apps.enter(*pid, |_app, upcalls| {
                             upcalls
-                                .schedule_upcall(
-                                    kernel::into_statuscode(Err(error.into())),
-                                    0,
-                                    0,
-                                    0,
-                                )
+                                .schedule_upcall(into_statuscode(Err(error.into())), 0, 0, 0)
                                 .ok();
                         });
                     });
@@ -249,12 +240,7 @@ impl i2c::I2CClient for LPS25HB<'_> {
                     self.owning_process.map(|pid| {
                         let _ = self.apps.enter(*pid, |_app, upcalls| {
                             upcalls
-                                .schedule_upcall(
-                                    kernel::into_statuscode(Err(error.into())),
-                                    0,
-                                    0,
-                                    0,
-                                )
+                                .schedule_upcall(into_statuscode(Err(error.into())), 0, 0, 0)
                                 .ok();
                         });
                     });
@@ -269,12 +255,7 @@ impl i2c::I2CClient for LPS25HB<'_> {
                     self.owning_process.map(|pid| {
                         let _ = self.apps.enter(*pid, |_app, upcalls| {
                             upcalls
-                                .schedule_upcall(
-                                    kernel::into_statuscode(Err(error.into())),
-                                    0,
-                                    0,
-                                    0,
-                                )
+                                .schedule_upcall(into_statuscode(Err(error.into())), 0, 0, 0)
                                 .ok();
                         });
                     });
@@ -307,12 +288,7 @@ impl i2c::I2CClient for LPS25HB<'_> {
                     self.owning_process.map(|pid| {
                         let _ = self.apps.enter(*pid, |_app, upcalls| {
                             upcalls
-                                .schedule_upcall(
-                                    kernel::into_statuscode(Err(error.into())),
-                                    0,
-                                    0,
-                                    0,
-                                )
+                                .schedule_upcall(into_statuscode(Err(error.into())), 0, 0, 0)
                                 .ok();
                         });
                     });

--- a/capsules/src/lps25hb.rs
+++ b/capsules/src/lps25hb.rs
@@ -206,8 +206,8 @@ impl i2c::I2CClient for LPS25HB<'_> {
                         let _ = self.apps.enter(*pid, |_app, upcalls| {
                             upcalls
                                 .schedule_upcall(
-                                    kernel::into_statuscode(Err(error.into())),
                                     0,
+                                    kernel::into_statuscode(Err(error.into())),
                                     0,
                                     0,
                                 )


### PR DESCRIPTION
### Pull Request Overview

This pull request adds i2c error verification for the lps25hb drivers.

### Testing Strategy

This pull request was not tested as I do not own the sensor.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x]  No updates required.

### Formatting

- [x] Ran `make prepush`.
