### PR TITLE
Separate schedule_upcall number and values through Rust types

### DIFF
--- a/capsules/src/adc.rs
+++ b/capsules/src/adc.rs
@@ -708,9 +708,11 @@ impl<A: hil::adc::Adc + hil::adc::AdcHighSpeed> hil::adc::Client for AdcDedicate
                         upcalls
                             .schedule_upcall(
                                 0,
-                                AdcMode::SingleSample as usize,
-                                self.channel.get(),
-                                sample as usize,
+                                (
+                                    AdcMode::SingleSample as usize,
+                                    self.channel.get(),
+                                    sample as usize,
+                                ),
                             )
                             .ok();
                     })
@@ -733,9 +735,11 @@ impl<A: hil::adc::Adc + hil::adc::AdcHighSpeed> hil::adc::Client for AdcDedicate
                         upcalls
                             .schedule_upcall(
                                 0,
-                                AdcMode::ContinuousSample as usize,
-                                self.channel.get(),
-                                sample as usize,
+                                (
+                                    AdcMode::ContinuousSample as usize,
+                                    self.channel.get(),
+                                    sample as usize,
+                                ),
                             )
                             .ok();
                     })
@@ -1004,9 +1008,7 @@ impl<A: hil::adc::Adc + hil::adc::AdcHighSpeed> hil::adc::HighSpeedClient for Ad
                             upcalls
                                 .schedule_upcall(
                                     0,
-                                    self.mode.get() as usize,
-                                    len_chan,
-                                    buf_ptr as usize,
+                                    (self.mode.get() as usize, len_chan, buf_ptr as usize),
                                 )
                                 .ok();
 
@@ -1358,7 +1360,10 @@ impl<'a> hil::adc::Client for AdcVirtualized<'a> {
                 app.pending_command = false;
                 let channel = app.channel;
                 upcalls
-                    .schedule_upcall(0, AdcMode::SingleSample as usize, channel, sample as usize)
+                    .schedule_upcall(
+                        0,
+                        (AdcMode::SingleSample as usize, channel, sample as usize),
+                    )
                     .ok();
             });
         });

--- a/capsules/src/alarm.rs
+++ b/capsules/src/alarm.rs
@@ -268,9 +268,11 @@ impl<'a, A: Alarm<'a>> time::AlarmClient for AlarmDriver<'a, A> {
                     upcalls
                         .schedule_upcall(
                             ALARM_CALLBACK_NUM,
-                            now.into_u32() as usize,
-                            reference.wrapping_add(dt) as usize,
-                            0,
+                            (
+                                now.into_u32() as usize,
+                                reference.wrapping_add(dt) as usize,
+                                0,
+                            ),
                         )
                         .ok();
                 }

--- a/capsules/src/ambient_light.rs
+++ b/capsules/src/ambient_light.rs
@@ -106,7 +106,7 @@ impl hil::sensors::AmbientLightClient for AmbientLight<'_> {
         self.apps.each(|_, app, upcalls| {
             if app.pending {
                 app.pending = false;
-                upcalls.schedule_upcall(0, lux, 0, 0).ok();
+                upcalls.schedule_upcall(0, (lux, 0, 0)).ok();
             }
         });
     }

--- a/capsules/src/analog_comparator.rs
+++ b/capsules/src/analog_comparator.rs
@@ -176,7 +176,7 @@ impl<'a, A: hil::analog_comparator::AnalogComparator<'a>> hil::analog_comparator
     fn fired(&self, channel: usize) {
         self.current_process.map(|appid| {
             let _ = self.grants.enter(*appid, |_app, upcalls| {
-                upcalls.schedule_upcall(0, channel, 0, 0).ok();
+                upcalls.schedule_upcall(0, (channel, 0, 0)).ok();
             });
         });
     }

--- a/capsules/src/app_flash_driver.rs
+++ b/capsules/src/app_flash_driver.rs
@@ -125,7 +125,7 @@ impl hil::nonvolatile_storage::NonvolatileStorageClient<'static> for AppFlash<'_
         // Notify the current application that the command finished.
         self.current_app.take().map(|appid| {
             let _ = self.apps.enter(appid, |_app, upcalls| {
-                upcalls.schedule_upcall(0, 0, 0, 0).ok();
+                upcalls.schedule_upcall(0, (0, 0, 0)).ok();
             });
         });
 

--- a/capsules/src/ble_advertising_driver.rs
+++ b/capsules/src/ble_advertising_driver.rs
@@ -475,9 +475,7 @@ where
                         upcalls
                             .schedule_upcall(
                                 0,
-                                kernel::errorcode::into_statuscode(result),
-                                len as usize,
-                                0,
+                                (kernel::errorcode::into_statuscode(result), len as usize, 0),
                             )
                             .ok();
                     }

--- a/capsules/src/button.rs
+++ b/capsules/src/button.rs
@@ -230,7 +230,7 @@ impl<'a, P: gpio::InterruptPin<'a>> gpio::ClientWithValue for Button<'a, P> {
             if cntr.subscribe_map & (1 << pin_num) != 0 {
                 interrupt_count.set(interrupt_count.get() + 1);
                 upcalls
-                    .schedule_upcall(UPCALL_NUM, pin_num as usize, button_state as usize, 0)
+                    .schedule_upcall(UPCALL_NUM, (pin_num as usize, button_state as usize, 0))
                     .ok();
             }
         });

--- a/capsules/src/buzzer_driver.rs
+++ b/capsules/src/buzzer_driver.rs
@@ -174,7 +174,7 @@ impl<'a, A: hil::time::Alarm<'a>> hil::time::AlarmClient for Buzzer<'a, A> {
         // Mark the active app as None and see if there is a callback.
         self.active_app.take().map(|app_id| {
             let _ = self.apps.enter(app_id, |_app, upcalls| {
-                upcalls.schedule_upcall(0, 0, 0, 0).ok();
+                upcalls.schedule_upcall(0, (0, 0, 0)).ok();
             });
         });
 

--- a/capsules/src/console.rs
+++ b/capsules/src/console.rs
@@ -309,7 +309,7 @@ impl uart::TransmitClient for Console<'_> {
                             // Go ahead and signal the application
                             let written = app.write_len;
                             app.write_len = 0;
-                            upcalls.schedule_upcall(1, written, 0, 0).ok();
+                            upcalls.schedule_upcall(1, (written, 0, 0)).ok();
                         }
                     }
                     Err(return_code) => {
@@ -320,9 +320,7 @@ impl uart::TransmitClient for Console<'_> {
                         upcalls
                             .schedule_upcall(
                                 1,
-                                kernel::errorcode::into_statuscode(return_code),
-                                0,
-                                0,
+                                (kernel::errorcode::into_statuscode(return_code), 0, 0),
                             )
                             .ok();
                     }
@@ -348,9 +346,7 @@ impl uart::TransmitClient for Console<'_> {
                                 upcalls
                                     .schedule_upcall(
                                         1,
-                                        kernel::errorcode::into_statuscode(return_code),
-                                        0,
-                                        0,
+                                        (kernel::errorcode::into_statuscode(return_code), 0, 0),
                                     )
                                     .ok();
                                 false
@@ -435,9 +431,11 @@ impl uart::ReceiveClient for Console<'_> {
                                 upcalls
                                     .schedule_upcall(
                                         2,
-                                        kernel::errorcode::into_statuscode(ret),
-                                        received_length,
-                                        0,
+                                        (
+                                            kernel::errorcode::into_statuscode(ret),
+                                            received_length,
+                                            0,
+                                        ),
                                     )
                                     .ok();
                             }
@@ -446,9 +444,13 @@ impl uart::ReceiveClient for Console<'_> {
                                 upcalls
                                     .schedule_upcall(
                                         2,
-                                        kernel::errorcode::into_statuscode(Err(ErrorCode::FAIL)),
-                                        0,
-                                        0,
+                                        (
+                                            kernel::errorcode::into_statuscode(Err(
+                                                ErrorCode::FAIL,
+                                            )),
+                                            0,
+                                            0,
+                                        ),
                                     )
                                     .ok();
                             }

--- a/capsules/src/crc.rs
+++ b/capsules/src/crc.rs
@@ -214,9 +214,7 @@ impl<'a, C: Crc<'a>> CrcDriver<'a, C> {
                             upcalls
                                 .schedule_upcall(
                                     0,
-                                    kernel::errorcode::into_statuscode(Err(e)),
-                                    0,
-                                    0,
+                                    (kernel::errorcode::into_statuscode(Err(e)), 0, 0),
                                 )
                                 .ok();
                             grant.request = None;
@@ -423,9 +421,13 @@ impl<'a, C: Crc<'a>> Client for CrcDriver<'a, C> {
                                 upcalls
                                     .schedule_upcall(
                                         0,
-                                        kernel::errorcode::into_statuscode(Err(ErrorCode::FAIL)),
-                                        0,
-                                        0,
+                                        (
+                                            kernel::errorcode::into_statuscode(Err(
+                                                ErrorCode::FAIL,
+                                            )),
+                                            0,
+                                            0,
+                                        ),
                                     )
                                     .ok();
                                 return;
@@ -451,11 +453,13 @@ impl<'a, C: Crc<'a>> Client for CrcDriver<'a, C> {
                                         upcalls
                                             .schedule_upcall(
                                                 0,
-                                                kernel::errorcode::into_statuscode(Err(
-                                                    ErrorCode::FAIL,
-                                                )),
-                                                0,
-                                                0,
+                                                (
+                                                    kernel::errorcode::into_statuscode(Err(
+                                                        ErrorCode::FAIL,
+                                                    )),
+                                                    0,
+                                                    0,
+                                                ),
                                             )
                                             .ok();
                                     }
@@ -476,11 +480,13 @@ impl<'a, C: Crc<'a>> Client for CrcDriver<'a, C> {
                                     upcalls
                                         .schedule_upcall(
                                             0,
-                                            kernel::errorcode::into_statuscode(Err(
-                                                ErrorCode::NOMEM,
-                                            )),
-                                            0,
-                                            0,
+                                            (
+                                                kernel::errorcode::into_statuscode(Err(
+                                                    ErrorCode::NOMEM,
+                                                )),
+                                                0,
+                                                0,
+                                            ),
                                         )
                                         .ok();
                                 } else {
@@ -502,9 +508,7 @@ impl<'a, C: Crc<'a>> Client for CrcDriver<'a, C> {
                                     upcalls
                                         .schedule_upcall(
                                             0,
-                                            kernel::errorcode::into_statuscode(Err(e)),
-                                            0,
-                                            0,
+                                            (kernel::errorcode::into_statuscode(Err(e)), 0, 0),
                                         )
                                         .ok();
                                 });
@@ -520,7 +524,7 @@ impl<'a, C: Crc<'a>> Client for CrcDriver<'a, C> {
                     let _res = self.grant.enter(*pid, |grant, upcalls| {
                         grant.request = None;
                         upcalls
-                            .schedule_upcall(0, kernel::errorcode::into_statuscode(Err(e)), 0, 0)
+                            .schedule_upcall(0, (kernel::errorcode::into_statuscode(Err(e)), 0, 0))
                             .ok();
                     });
                 });
@@ -545,15 +549,17 @@ impl<'a, C: Crc<'a>> Client for CrcDriver<'a, C> {
                         upcalls
                             .schedule_upcall(
                                 0,
-                                kernel::errorcode::into_statuscode(Ok(())),
-                                val as usize,
-                                user_int as usize,
+                                (
+                                    kernel::errorcode::into_statuscode(Ok(())),
+                                    val as usize,
+                                    user_int as usize,
+                                ),
                             )
                             .ok();
                     }
                     Err(e) => {
                         upcalls
-                            .schedule_upcall(0, kernel::errorcode::into_statuscode(Err(e)), 0, 0)
+                            .schedule_upcall(0, (kernel::errorcode::into_statuscode(Err(e)), 0, 0))
                             .ok();
                     }
                 }

--- a/capsules/src/ctap.rs
+++ b/capsules/src/ctap.rs
@@ -142,7 +142,7 @@ impl<'a, U: usb_hid::UsbHid<'a, [u8; 64]>> usb_hid::Client<'a, [u8; 64]> for Cta
                         dest.copy_from_slice(buffer);
                     });
 
-                    upcalls.schedule_upcall(0, 0, 0, 0).ok();
+                    upcalls.schedule_upcall(0, (0, 0, 0)).ok();
                     app.can_receive.set(false);
                 })
                 .map_err(|err| {
@@ -164,7 +164,7 @@ impl<'a, U: usb_hid::UsbHid<'a, [u8; 64]>> usb_hid::Client<'a, [u8; 64]> for Cta
         self.appid.map(|id| {
             self.app
                 .enter(*id, |_app, upcalls| {
-                    upcalls.schedule_upcall(0, 1, 0, 0).ok();
+                    upcalls.schedule_upcall(0, (1, 0, 0)).ok();
                 })
                 .map_err(|err| {
                     if err == kernel::process::Error::NoSuchApp

--- a/capsules/src/gpio.rs
+++ b/capsules/src/gpio.rs
@@ -146,7 +146,7 @@ impl<'a, IP: gpio::InterruptPin<'a>> gpio::ClientWithValue for GPIO<'a, IP> {
             // schedule callback with the pin number and value
             self.apps.each(|_, _, upcalls| {
                 upcalls
-                    .schedule_upcall(UPCALL_NUM, pin_num as usize, pin_state as usize, 0)
+                    .schedule_upcall(UPCALL_NUM, (pin_num as usize, pin_state as usize, 0))
                     .ok();
             });
         }

--- a/capsules/src/gpio_async.rs
+++ b/capsules/src/gpio_async.rs
@@ -95,7 +95,7 @@ impl<Port: hil::gpio_async::Port> hil::gpio_async::Client for GPIOAsync<'_, Port
     fn fired(&self, pin: usize, identifier: usize) {
         // schedule callback with the pin number and value for all apps
         self.grants.each(|_, _app, upcalls| {
-            upcalls.schedule_upcall(1, identifier, pin, 0).ok();
+            upcalls.schedule_upcall(1, (identifier, pin, 0)).ok();
         });
     }
 
@@ -103,7 +103,7 @@ impl<Port: hil::gpio_async::Port> hil::gpio_async::Client for GPIOAsync<'_, Port
         // alert currently configuring app
         self.configuring_process.map(|pid| {
             let _ = self.grants.enter(*pid, |_app, upcalls| {
-                upcalls.schedule_upcall(0, 0, value, 0).ok();
+                upcalls.schedule_upcall(0, (0, value, 0)).ok();
             });
         });
         // then clear currently configuring app

--- a/capsules/src/hmac.rs
+++ b/capsules/src/hmac.rs
@@ -277,14 +277,12 @@ impl<
                             upcalls
                                 .schedule_upcall(
                                     0,
-                                    kernel::errorcode::into_statuscode(e.into()),
-                                    0,
-                                    0,
+                                    (kernel::errorcode::into_statuscode(e.into()), 0, 0),
                                 )
                                 .ok();
                         }
                     } else {
-                        upcalls.schedule_upcall(0, 0, 0, 0).ok();
+                        upcalls.schedule_upcall(0, (0, 0, 0)).ok();
                     }
                 })
                 .map_err(|err| {
@@ -318,12 +316,14 @@ impl<
                     });
 
                     match result {
-                        Ok(_) => upcalls.schedule_upcall(0, 0, pointer as usize, 0),
+                        Ok(_) => upcalls.schedule_upcall(0, (0, pointer as usize, 0)),
                         Err(e) => upcalls.schedule_upcall(
                             0,
-                            kernel::errorcode::into_statuscode(e.into()),
-                            pointer as usize,
-                            0,
+                            (
+                                kernel::errorcode::into_statuscode(e.into()),
+                                pointer as usize,
+                                0,
+                            ),
                         ),
                     }
                     .ok();
@@ -625,9 +625,7 @@ impl<
                                 upcalls
                                     .schedule_upcall(
                                         0,
-                                        kernel::errorcode::into_statuscode(e.into()),
-                                        0,
-                                        0,
+                                        (kernel::errorcode::into_statuscode(e.into()), 0, 0),
                                     )
                                     .ok();
                             }

--- a/capsules/src/humidity.rs
+++ b/capsules/src/humidity.rs
@@ -122,7 +122,7 @@ impl hil::sensors::HumidityClient for HumiditySensor<'_> {
                 if app.subscribed {
                     self.busy.set(false);
                     app.subscribed = false;
-                    upcalls.schedule_upcall(0, tmp_val, 0, 0).ok();
+                    upcalls.schedule_upcall(0, (tmp_val, 0, 0)).ok();
                 }
             });
         }

--- a/capsules/src/i2c_master.rs
+++ b/capsules/src/i2c_master.rs
@@ -199,7 +199,7 @@ impl<'a, I: 'a + i2c::I2CMaster> i2c::I2CHwMasterClient for I2CMasterDriver<'a, 
                 }
 
                 // signal to driver that tx complete
-                upcalls.schedule_upcall(0, 0, 0, 0).ok();
+                upcalls.schedule_upcall(0, (0, 0, 0)).ok();
             })
         });
 

--- a/capsules/src/i2c_master_slave_driver.rs
+++ b/capsules/src/i2c_master_slave_driver.rs
@@ -94,7 +94,7 @@ impl hil::i2c::I2CHwMasterClient for I2CMasterSlaveDriver<'_> {
 
                 self.app.map(|app| {
                     let _ = self.apps.enter(*app, |_app, upcalls| {
-                        upcalls.schedule_upcall(0, 0, status, 0).ok();
+                        upcalls.schedule_upcall(0, (0, status, 0)).ok();
                     });
                 });
             }
@@ -121,7 +121,7 @@ impl hil::i2c::I2CHwMasterClient for I2CMasterSlaveDriver<'_> {
                                 0
                             })
                             .unwrap_or(0);
-                        upcalls.schedule_upcall(0, 1, status, 0).ok();
+                        upcalls.schedule_upcall(0, (1, status, 0)).ok();
                     });
                 });
             }
@@ -144,7 +144,7 @@ impl hil::i2c::I2CHwMasterClient for I2CMasterSlaveDriver<'_> {
                                 0
                             })
                             .unwrap_or(0);
-                        upcalls.schedule_upcall(0, 7, status, 0).ok();
+                        upcalls.schedule_upcall(0, (7, status, 0)).ok();
                     });
                 });
             }
@@ -197,7 +197,7 @@ impl hil::i2c::I2CHwSlaveClient for I2CMasterSlaveDriver<'_> {
                             })
                             .unwrap_or(0);
 
-                        upcalls.schedule_upcall(0, 3, length as usize, 0).ok();
+                        upcalls.schedule_upcall(0, (3, length as usize, 0)).ok();
                     });
                 });
             }
@@ -208,7 +208,7 @@ impl hil::i2c::I2CHwSlaveClient for I2CMasterSlaveDriver<'_> {
                 // Notify the app that the read finished
                 self.app.map(|app| {
                     let _ = self.apps.enter(*app, |_app, upcalls| {
-                        upcalls.schedule_upcall(0, 4, length as usize, 0).ok();
+                        upcalls.schedule_upcall(0, (4, length as usize, 0)).ok();
                     });
                 });
             }
@@ -223,7 +223,7 @@ impl hil::i2c::I2CHwSlaveClient for I2CMasterSlaveDriver<'_> {
                 // Ask the app to setup a read buffer. The app must call
                 // command 3 after it has setup the shared read buffer with
                 // the correct bytes.
-                upcalls.schedule_upcall(0, 2, 0, 0).ok();
+                upcalls.schedule_upcall(0, (2, 0, 0)).ok();
             });
         });
     }

--- a/capsules/src/ieee802154/driver.rs
+++ b/capsules/src/ieee802154/driver.rs
@@ -473,11 +473,13 @@ impl DynamicDeferredCallClient for RadioDriver<'_> {
                 upcalls
                     .schedule_upcall(
                         1,
-                        kernel::errorcode::into_statuscode(
-                            self.saved_result.expect("missing result"),
+                        (
+                            kernel::errorcode::into_statuscode(
+                                self.saved_result.expect("missing result"),
+                            ),
+                            0,
+                            0,
                         ),
-                        0,
-                        0,
                     )
                     .ok();
             });
@@ -902,9 +904,11 @@ impl device::TxClient for RadioDriver<'_> {
                 upcalls
                     .schedule_upcall(
                         1,
-                        kernel::errorcode::into_statuscode(result),
-                        acked as usize,
-                        0,
+                        (
+                            kernel::errorcode::into_statuscode(result),
+                            acked as usize,
+                            0,
+                        ),
                     )
                     .ok();
             });
@@ -949,7 +953,7 @@ impl device::RxClient for RadioDriver<'_> {
                 let pans = encode_pans(&header.dst_pan, &header.src_pan);
                 let dst_addr = encode_address(&header.dst_addr);
                 let src_addr = encode_address(&header.src_addr);
-                upcalls.schedule_upcall(0, pans, dst_addr, src_addr).ok();
+                upcalls.schedule_upcall(0, (pans, dst_addr, src_addr)).ok();
             }
         });
     }

--- a/capsules/src/l3gd20.rs
+++ b/capsules/src/l3gd20.rs
@@ -424,7 +424,7 @@ impl spi::SpiMasterClient for L3gd20Spi<'_> {
                             false
                         };
                         upcalls
-                            .schedule_upcall(0, 1, if present { 1 } else { 0 }, 0)
+                            .schedule_upcall(0, (1, if present { 1 } else { 0 }, 0))
                             .ok();
                         L3gd20Status::Idle
                     }
@@ -472,9 +472,9 @@ impl spi::SpiMasterClient for L3gd20Spi<'_> {
                             false
                         };
                         if values {
-                            upcalls.schedule_upcall(0, x, y, z).ok();
+                            upcalls.schedule_upcall(0, (x, y, z)).ok();
                         } else {
-                            upcalls.schedule_upcall(0, 0, 0, 0).ok();
+                            upcalls.schedule_upcall(0, (0, 0, 0)).ok();
                         }
                         L3gd20Status::Idle
                     }
@@ -498,15 +498,15 @@ impl spi::SpiMasterClient for L3gd20Spi<'_> {
                             false
                         };
                         if value {
-                            upcalls.schedule_upcall(0, temperature, 0, 0).ok();
+                            upcalls.schedule_upcall(0, (temperature, 0, 0)).ok();
                         } else {
-                            upcalls.schedule_upcall(0, 0, 0, 0).ok();
+                            upcalls.schedule_upcall(0, (0, 0, 0)).ok();
                         }
                         L3gd20Status::Idle
                     }
 
                     _ => {
-                        upcalls.schedule_upcall(0, 0, 0, 0).ok();
+                        upcalls.schedule_upcall(0, (0, 0, 0)).ok();
                         L3gd20Status::Idle
                     }
                 });

--- a/capsules/src/lps25hb.rs
+++ b/capsules/src/lps25hb.rs
@@ -179,7 +179,7 @@ impl i2c::I2CClient for LPS25HB<'_> {
             self.buffer.replace(buffer);
             self.owning_process.map(|pid| {
                 let _ = self.apps.enter(*pid, |_app, upcalls| {
-                    upcalls.schedule_upcall(0, 0, 0, 0).ok();
+                    upcalls.schedule_upcall(0, (0, 0, 0)).ok();
                 });
             });
             return;
@@ -206,7 +206,7 @@ impl i2c::I2CClient for LPS25HB<'_> {
                     self.owning_process.map(|pid| {
                         let _ = self.apps.enter(*pid, |_app, upcalls| {
                             upcalls
-                                .schedule_upcall(0, into_statuscode(Err(error.into())), 0, 0)
+                                .schedule_upcall(0, (into_statuscode(Err(error.into())), 0, 0))
                                 .ok();
                         });
                     });
@@ -221,7 +221,7 @@ impl i2c::I2CClient for LPS25HB<'_> {
                     self.owning_process.map(|pid| {
                         let _ = self.apps.enter(*pid, |_app, upcalls| {
                             upcalls
-                                .schedule_upcall(into_statuscode(Err(error.into())), 0, 0, 0)
+                                .schedule_upcall(0, (into_statuscode(Err(error.into())), 0, 0))
                                 .ok();
                         });
                     });
@@ -240,7 +240,7 @@ impl i2c::I2CClient for LPS25HB<'_> {
                     self.owning_process.map(|pid| {
                         let _ = self.apps.enter(*pid, |_app, upcalls| {
                             upcalls
-                                .schedule_upcall(into_statuscode(Err(error.into())), 0, 0, 0)
+                                .schedule_upcall(0, (into_statuscode(Err(error.into())), 0, 0))
                                 .ok();
                         });
                     });
@@ -255,7 +255,7 @@ impl i2c::I2CClient for LPS25HB<'_> {
                     self.owning_process.map(|pid| {
                         let _ = self.apps.enter(*pid, |_app, upcalls| {
                             upcalls
-                                .schedule_upcall(into_statuscode(Err(error.into())), 0, 0, 0)
+                                .schedule_upcall(0, (into_statuscode(Err(error.into())), 0, 0))
                                 .ok();
                         });
                     });
@@ -288,7 +288,7 @@ impl i2c::I2CClient for LPS25HB<'_> {
                     self.owning_process.map(|pid| {
                         let _ = self.apps.enter(*pid, |_app, upcalls| {
                             upcalls
-                                .schedule_upcall(into_statuscode(Err(error.into())), 0, 0, 0)
+                                .schedule_upcall(0, (into_statuscode(Err(error.into())), 0, 0))
                                 .ok();
                         });
                     });

--- a/capsules/src/lps25hb.rs
+++ b/capsules/src/lps25hb.rs
@@ -274,7 +274,7 @@ impl i2c::I2CClient for LPS25HB<'_> {
                 self.owning_process.map(|pid| {
                     let _ = self.apps.enter(*pid, |_app, upcalls| {
                         upcalls
-                            .schedule_upcall(0, pressure_ubar as usize, 0, 0)
+                            .schedule_upcall(0, (pressure_ubar as usize, 0, 0))
                             .ok();
                     });
                 });

--- a/capsules/src/lsm303agr.rs
+++ b/capsules/src/lsm303agr.rs
@@ -413,7 +413,7 @@ impl i2c::I2CClient for Lsm303agrI2C<'_> {
                 self.owning_process.map(|pid| {
                     let _res = self.apps.enter(*pid, |_app, upcalls| {
                         upcalls
-                            .schedule_upcall(0, if present { 1 } else { 0 }, 0, 0)
+                            .schedule_upcall(0, (if present { 1 } else { 0 }, 0, 0))
                             .ok();
                     });
                 });
@@ -426,7 +426,7 @@ impl i2c::I2CClient for Lsm303agrI2C<'_> {
                 self.owning_process.map(|pid| {
                     let _res = self.apps.enter(*pid, |_app, upcalls| {
                         upcalls
-                            .schedule_upcall(0, if set_power { 1 } else { 0 }, 0, 0)
+                            .schedule_upcall(0, (if set_power { 1 } else { 0 }, 0, 0))
                             .ok();
                     });
                 });
@@ -447,7 +447,10 @@ impl i2c::I2CClient for Lsm303agrI2C<'_> {
                 self.owning_process.map(|pid| {
                     let _res = self.apps.enter(*pid, |_app, upcalls| {
                         upcalls
-                            .schedule_upcall(0, if set_scale_and_resolution { 1 } else { 0 }, 0, 0)
+                            .schedule_upcall(
+                                0,
+                                (if set_scale_and_resolution { 1 } else { 0 }, 0, 0),
+                            )
                             .ok();
                     });
                 });
@@ -496,9 +499,9 @@ impl i2c::I2CClient for Lsm303agrI2C<'_> {
                 self.owning_process.map(|pid| {
                     let _res = self.apps.enter(*pid, |_app, upcalls| {
                         if values {
-                            upcalls.schedule_upcall(0, x, y, z).ok();
+                            upcalls.schedule_upcall(0, (x, y, z)).ok();
                         } else {
-                            upcalls.schedule_upcall(0, 0, 0, 0).ok();
+                            upcalls.schedule_upcall(0, (0, 0, 0)).ok();
                         }
                     });
                 });
@@ -511,7 +514,7 @@ impl i2c::I2CClient for Lsm303agrI2C<'_> {
                 self.owning_process.map(|pid| {
                     let _res = self.apps.enter(*pid, |_app, upcalls| {
                         upcalls
-                            .schedule_upcall(0, if set_magneto_data_rate { 1 } else { 0 }, 0, 0)
+                            .schedule_upcall(0, (if set_magneto_data_rate { 1 } else { 0 }, 0, 0))
                             .ok();
                     });
                 });
@@ -529,7 +532,7 @@ impl i2c::I2CClient for Lsm303agrI2C<'_> {
                 self.owning_process.map(|pid| {
                     let _res = self.apps.enter(*pid, |_app, upcalls| {
                         upcalls
-                            .schedule_upcall(0, if set_range { 1 } else { 0 }, 0, 0)
+                            .schedule_upcall(0, (if set_range { 1 } else { 0 }, 0, 0))
                             .ok();
                     });
                 });
@@ -557,9 +560,9 @@ impl i2c::I2CClient for Lsm303agrI2C<'_> {
                 self.owning_process.map(|pid| {
                     let _res = self.apps.enter(*pid, |_app, upcalls| {
                         if values {
-                            upcalls.schedule_upcall(0, temp, 0, 0).ok();
+                            upcalls.schedule_upcall(0, (temp, 0, 0)).ok();
                         } else {
-                            upcalls.schedule_upcall(0, 0, 0, 0).ok();
+                            upcalls.schedule_upcall(0, (0, 0, 0)).ok();
                         }
                     });
                 });
@@ -597,9 +600,9 @@ impl i2c::I2CClient for Lsm303agrI2C<'_> {
                 self.owning_process.map(|pid| {
                     let _res = self.apps.enter(*pid, |_app, upcalls| {
                         if values {
-                            upcalls.schedule_upcall(0, x, y, z).ok();
+                            upcalls.schedule_upcall(0, (x, y, z)).ok();
                         } else {
-                            upcalls.schedule_upcall(0, 0, 0, 0).ok();
+                            upcalls.schedule_upcall(0, (0, 0, 0)).ok();
                         }
                     });
                 });

--- a/capsules/src/lsm303dlhc.rs
+++ b/capsules/src/lsm303dlhc.rs
@@ -407,7 +407,7 @@ impl i2c::I2CClient for Lsm303dlhcI2C<'_> {
                 self.current_process.map(|process_id| {
                     let _ = self.apps.enter(*process_id, |_grant, upcalls| {
                         upcalls
-                            .schedule_upcall(0, if present { 1 } else { 0 }, 0, 0)
+                            .schedule_upcall(0, (if present { 1 } else { 0 }, 0, 0))
                             .ok();
                     });
                 });
@@ -422,7 +422,7 @@ impl i2c::I2CClient for Lsm303dlhcI2C<'_> {
                 self.current_process.map(|process_id| {
                     let _ = self.apps.enter(*process_id, |_grant, upcalls| {
                         upcalls
-                            .schedule_upcall(0, if set_power { 1 } else { 0 }, 0, 0)
+                            .schedule_upcall(0, (if set_power { 1 } else { 0 }, 0, 0))
                             .ok();
                     });
                 });
@@ -443,7 +443,10 @@ impl i2c::I2CClient for Lsm303dlhcI2C<'_> {
                 self.current_process.map(|process_id| {
                     let _ = self.apps.enter(*process_id, |_grant, upcalls| {
                         upcalls
-                            .schedule_upcall(0, if set_scale_and_resolution { 1 } else { 0 }, 0, 0)
+                            .schedule_upcall(
+                                0,
+                                (if set_scale_and_resolution { 1 } else { 0 }, 0, 0),
+                            )
                             .ok();
                     });
                 });
@@ -497,9 +500,9 @@ impl i2c::I2CClient for Lsm303dlhcI2C<'_> {
                 self.current_process.map(|process_id| {
                     let _ = self.apps.enter(*process_id, |_grant, upcalls| {
                         if values {
-                            upcalls.schedule_upcall(0, x, y, z).ok();
+                            upcalls.schedule_upcall(0, (x, y, z)).ok();
                         } else {
-                            upcalls.schedule_upcall(0, 0, 0, 0).ok();
+                            upcalls.schedule_upcall(0, (0, 0, 0)).ok();
                         }
                     });
                 });
@@ -516,13 +519,15 @@ impl i2c::I2CClient for Lsm303dlhcI2C<'_> {
                         upcalls
                             .schedule_upcall(
                                 0,
-                                if set_temperature_and_magneto_data_rate {
-                                    1
-                                } else {
-                                    0
-                                },
-                                0,
-                                0,
+                                (
+                                    if set_temperature_and_magneto_data_rate {
+                                        1
+                                    } else {
+                                        0
+                                    },
+                                    0,
+                                    0,
+                                ),
                             )
                             .ok();
                     });
@@ -543,7 +548,7 @@ impl i2c::I2CClient for Lsm303dlhcI2C<'_> {
                 self.current_process.map(|process_id| {
                     let _ = self.apps.enter(*process_id, |_grant, upcalls| {
                         upcalls
-                            .schedule_upcall(0, if set_range { 1 } else { 0 }, 0, 0)
+                            .schedule_upcall(0, (if set_range { 1 } else { 0 }, 0, 0))
                             .ok();
                     });
                 });
@@ -573,9 +578,9 @@ impl i2c::I2CClient for Lsm303dlhcI2C<'_> {
                 self.current_process.map(|process_id| {
                     let _ = self.apps.enter(*process_id, |_grant, upcalls| {
                         if values {
-                            upcalls.schedule_upcall(0, temp, 0, 0).ok();
+                            upcalls.schedule_upcall(0, (temp, 0, 0)).ok();
                         } else {
-                            upcalls.schedule_upcall(0, 0, 0, 0).ok();
+                            upcalls.schedule_upcall(0, (0, 0, 0)).ok();
                         }
                     });
                 });
@@ -615,9 +620,9 @@ impl i2c::I2CClient for Lsm303dlhcI2C<'_> {
                 self.current_process.map(|process_id| {
                     let _ = self.apps.enter(*process_id, |_grant, upcalls| {
                         if values {
-                            upcalls.schedule_upcall(0, x, y, z).ok();
+                            upcalls.schedule_upcall(0, (x, y, z)).ok();
                         } else {
-                            upcalls.schedule_upcall(0, 0, 0, 0).ok();
+                            upcalls.schedule_upcall(0, (0, 0, 0)).ok();
                         }
                     });
                 });

--- a/capsules/src/ltc294x.rs
+++ b/capsules/src/ltc294x.rs
@@ -440,7 +440,7 @@ impl LTC294XClient for LTC294XDriver<'_> {
     fn interrupt(&self) {
         self.owning_process.map(|pid| {
             let _res = self.grants.enter(*pid, |_app, upcalls| {
-                upcalls.schedule_upcall(0, 0, 0, 0).ok();
+                upcalls.schedule_upcall(0, (0, 0, 0)).ok();
             });
         });
     }
@@ -461,7 +461,7 @@ impl LTC294XClient for LTC294XDriver<'_> {
         self.owning_process.map(|pid| {
             let _res = self.grants.enter(*pid, |_app, upcalls| {
                 upcalls
-                    .schedule_upcall(0, 1, ret, self.ltc294x.model.get() as usize)
+                    .schedule_upcall(0, (1, ret, self.ltc294x.model.get() as usize))
                     .ok();
             });
         });
@@ -470,7 +470,7 @@ impl LTC294XClient for LTC294XDriver<'_> {
     fn charge(&self, charge: u16) {
         self.owning_process.map(|pid| {
             let _res = self.grants.enter(*pid, |_app, upcalls| {
-                upcalls.schedule_upcall(0, 2, charge as usize, 0).ok();
+                upcalls.schedule_upcall(0, (2, charge as usize, 0)).ok();
             });
         });
     }
@@ -478,7 +478,7 @@ impl LTC294XClient for LTC294XDriver<'_> {
     fn done(&self) {
         self.owning_process.map(|pid| {
             let _res = self.grants.enter(*pid, |_app, upcalls| {
-                upcalls.schedule_upcall(0, 3, 0, 0).ok();
+                upcalls.schedule_upcall(0, (3, 0, 0)).ok();
             });
         });
     }
@@ -486,7 +486,7 @@ impl LTC294XClient for LTC294XDriver<'_> {
     fn voltage(&self, voltage: u16) {
         self.owning_process.map(|pid| {
             let _res = self.grants.enter(*pid, |_app, upcalls| {
-                upcalls.schedule_upcall(0, 4, voltage as usize, 0).ok();
+                upcalls.schedule_upcall(0, (4, voltage as usize, 0)).ok();
             });
         });
     }
@@ -494,7 +494,7 @@ impl LTC294XClient for LTC294XDriver<'_> {
     fn current(&self, current: u16) {
         self.owning_process.map(|pid| {
             let _res = self.grants.enter(*pid, |_app, upcalls| {
-                upcalls.schedule_upcall(0, 5, current as usize, 0).ok();
+                upcalls.schedule_upcall(0, (5, current as usize, 0)).ok();
             });
         });
     }

--- a/capsules/src/max17205.rs
+++ b/capsules/src/max17205.rs
@@ -416,9 +416,11 @@ impl MAX17205Client for MAX17205Driver<'_> {
                 upcalls
                     .schedule_upcall(
                         0,
-                        kernel::errorcode::into_statuscode(error),
-                        status as usize,
-                        0,
+                        (
+                            kernel::errorcode::into_statuscode(error),
+                            status as usize,
+                            0,
+                        ),
                     )
                     .ok();
             });
@@ -437,9 +439,11 @@ impl MAX17205Client for MAX17205Driver<'_> {
                 upcalls
                     .schedule_upcall(
                         0,
-                        kernel::errorcode::into_statuscode(error),
-                        percent as usize,
-                        (capacity as usize) << 16 | (full_capacity as usize),
+                        (
+                            kernel::errorcode::into_statuscode(error),
+                            percent as usize,
+                            (capacity as usize) << 16 | (full_capacity as usize),
+                        ),
                     )
                     .ok();
             });
@@ -452,9 +456,11 @@ impl MAX17205Client for MAX17205Driver<'_> {
                 upcalls
                     .schedule_upcall(
                         0,
-                        kernel::errorcode::into_statuscode(error),
-                        voltage as usize,
-                        current as usize,
+                        (
+                            kernel::errorcode::into_statuscode(error),
+                            voltage as usize,
+                            current as usize,
+                        ),
                     )
                     .ok();
             });
@@ -467,9 +473,11 @@ impl MAX17205Client for MAX17205Driver<'_> {
                 upcalls
                     .schedule_upcall(
                         0,
-                        kernel::errorcode::into_statuscode(error),
-                        coulomb as usize,
-                        0,
+                        (
+                            kernel::errorcode::into_statuscode(error),
+                            coulomb as usize,
+                            0,
+                        ),
                     )
                     .ok();
             });
@@ -482,9 +490,11 @@ impl MAX17205Client for MAX17205Driver<'_> {
                 upcalls
                     .schedule_upcall(
                         0,
-                        kernel::errorcode::into_statuscode(error),
-                        (rid & 0xffffffff) as usize,
-                        (rid >> 32) as usize,
+                        (
+                            kernel::errorcode::into_statuscode(error),
+                            (rid & 0xffffffff) as usize,
+                            (rid >> 32) as usize,
+                        ),
                     )
                     .ok();
             });

--- a/capsules/src/mlx90614.rs
+++ b/capsules/src/mlx90614.rs
@@ -131,7 +131,7 @@ impl<'a> i2c::I2CClient for Mlx90614SMBus<'a> {
                 self.owning_process.map(|pid| {
                     let _ = self.apps.enter(*pid, |_app, upcalls| {
                         upcalls
-                            .schedule_upcall(0, if present { 1 } else { 0 }, 0, 0)
+                            .schedule_upcall(0, (if present { 1 } else { 0 }, 0, 0))
                             .ok();
                     });
                 });
@@ -157,13 +157,13 @@ impl<'a> i2c::I2CClient for Mlx90614SMBus<'a> {
                 if values {
                     self.owning_process.map(|pid| {
                         let _ = self.apps.enter(*pid, |_app, upcalls| {
-                            upcalls.schedule_upcall(0, temp, 0, 0).ok();
+                            upcalls.schedule_upcall(0, (temp, 0, 0)).ok();
                         });
                     });
                 } else {
                     self.owning_process.map(|pid| {
                         let _ = self.apps.enter(*pid, |_app, upcalls| {
-                            upcalls.schedule_upcall(0, 0, 0, 0).ok();
+                            upcalls.schedule_upcall(0, (0, 0, 0)).ok();
                         });
                     });
                 }

--- a/capsules/src/net/udp/driver.rs
+++ b/capsules/src/net/udp/driver.rs
@@ -173,7 +173,7 @@ impl<'a> UDPDriver<'a> {
         if result != Ok(()) {
             let _ = self.apps.enter(appid, |_app, upcalls| {
                 upcalls
-                    .schedule_upcall(1, kernel::errorcode::into_statuscode(result), 0, 0)
+                    .schedule_upcall(1, (kernel::errorcode::into_statuscode(result), 0, 0))
                     .ok();
             });
         }
@@ -605,7 +605,7 @@ impl<'a> UDPSendClient for UDPDriver<'a> {
         self.current_app.get().map(|appid| {
             let _ = self.apps.enter(appid, |_app, upcalls| {
                 upcalls
-                    .schedule_upcall(1, kernel::errorcode::into_statuscode(result), 0, 0)
+                    .schedule_upcall(1, (kernel::errorcode::into_statuscode(result), 0, 0))
                     .ok();
             });
         });
@@ -650,7 +650,7 @@ impl<'a> UDPRecvClient for UDPDriver<'a> {
                             addr: src_addr,
                             port: src_port,
                         };
-                        upcalls.schedule_upcall(0, len, 0, 0).ok();
+                        upcalls.schedule_upcall(0, (len, 0, 0)).ok();
                         const CFG_LEN: usize = 2 * size_of::<UDPEndpoint>();
                         let _ = app
                             .app_rx_cfg

--- a/capsules/src/ninedof.rs
+++ b/capsules/src/ninedof.rs
@@ -154,7 +154,7 @@ impl hil::sensors::NineDofClient for NineDof<'_> {
                 app.pending_command = false;
                 finished_command = app.command;
                 finished_command_arg = app.arg1;
-                upcalls.schedule_upcall(0, arg1, arg2, arg3).ok();
+                upcalls.schedule_upcall(0, (arg1, arg2, arg3)).ok();
             });
         });
 
@@ -169,7 +169,7 @@ impl hil::sensors::NineDofClient for NineDof<'_> {
                     // Don't bother re-issuing this command, just use
                     // the existing result.
                     app.pending_command = false;
-                    upcalls.schedule_upcall(0, arg1, arg2, arg3).ok();
+                    upcalls.schedule_upcall(0, (arg1, arg2, arg3)).ok();
                     false
                 } else if app.pending_command {
                     app.pending_command = false;

--- a/capsules/src/nonvolatile_storage_driver.rs
+++ b/capsules/src/nonvolatile_storage_driver.rs
@@ -420,7 +420,7 @@ impl hil::nonvolatile_storage::NonvolatileStorageClient<'static> for Nonvolatile
                         self.buffer.replace(buffer);
 
                         // And then signal the app.
-                        upcalls.schedule_upcall(0, length, 0, 0).ok();
+                        upcalls.schedule_upcall(0, (length, 0, 0)).ok();
                     });
                 }
             }
@@ -444,7 +444,7 @@ impl hil::nonvolatile_storage::NonvolatileStorageClient<'static> for Nonvolatile
                         self.buffer.replace(buffer);
 
                         // And then signal the app.
-                        upcalls.schedule_upcall(1, length, 0, 0).ok();
+                        upcalls.schedule_upcall(1, (length, 0, 0)).ok();
                     });
                 }
             }

--- a/capsules/src/nrf51822_serialization.rs
+++ b/capsules/src/nrf51822_serialization.rs
@@ -251,7 +251,7 @@ impl uart::TransmitClient for Nrf51822Serialization<'_> {
         self.active_app.map(|appid| {
             let _ = self.apps.enter(*appid, |_app, upcalls| {
                 // Call the callback after TX has finished
-                upcalls.schedule_upcall(0, 1, 0, 0).ok();
+                upcalls.schedule_upcall(0, (1, 0, 0)).ok();
             });
         });
     }
@@ -294,7 +294,7 @@ impl uart::ReceiveClient for Nrf51822Serialization<'_> {
                 // Note: This indicates how many bytes were received by
                 // hardware, regardless of how much space (if any) was
                 // available in the buffer provided by the app.
-                upcalls.schedule_upcall(0, 4, rx_len, len).ok();
+                upcalls.schedule_upcall(0, (4, rx_len, len)).ok();
             });
         });
 

--- a/capsules/src/pca9544a.rs
+++ b/capsules/src/pca9544a.rs
@@ -150,7 +150,7 @@ impl i2c::I2CClient for PCA9544A<'_> {
                 self.owning_process.map(|pid| {
                     let _ = self.apps.enter(*pid, |_app, upcalls| {
                         upcalls
-                            .schedule_upcall(0, (field as usize) + 1, ret as usize, 0)
+                            .schedule_upcall(0, (field as usize + 1, ret as usize, 0))
                             .ok();
                     });
                 });
@@ -162,7 +162,7 @@ impl i2c::I2CClient for PCA9544A<'_> {
             State::Done => {
                 self.owning_process.map(|pid| {
                     let _ = self.apps.enter(*pid, |_app, upcalls| {
-                        upcalls.schedule_upcall(0, 0, 0, 0).ok();
+                        upcalls.schedule_upcall(0, (0, 0, 0)).ok();
                     });
                 });
 

--- a/capsules/src/proximity.rs
+++ b/capsules/src/proximity.rs
@@ -269,13 +269,13 @@ impl hil::sensors::ProximityClient for ProximitySensor<'_> {
                         if ((temp_val as u8) > app.upper_proximity)
                             || ((temp_val as u8) < app.lower_proximity)
                         {
-                            upcalls.schedule_upcall(0, temp_val as usize, 0, 0).ok();
+                            upcalls.schedule_upcall(0, (temp_val as usize, 0, 0)).ok();
                             app.subscribed = false; // dequeue
                         }
                     } else {
                         // Case: ReadProximity
                         // Upcall to all apps waiting on read_proximity.
-                        upcalls.schedule_upcall(0, temp_val as usize, 0, 0).ok();
+                        upcalls.schedule_upcall(0, (temp_val as usize, 0, 0)).ok();
                         app.subscribed = false; // dequeue
                     }
                 }

--- a/capsules/src/rng.rs
+++ b/capsules/src/rng.rs
@@ -133,7 +133,7 @@ impl rng::Client for RngDriver<'_> {
                     if app.remaining > 0 {
                         done = false;
                     } else {
-                        upcalls.schedule_upcall(0, 0, newidx, 0).ok();
+                        upcalls.schedule_upcall(0, (0, newidx, 0)).ok();
                     }
                 }
             });

--- a/capsules/src/screen.rs
+++ b/capsules/src/screen.rs
@@ -372,7 +372,7 @@ impl<'a> Screen<'a> {
             self.current_process.take().map(|process_id| {
                 let _ = self.apps.enter(process_id, |app, upcalls| {
                     app.pending_command = false;
-                    upcalls.schedule_upcall(0, data1, data2, data3).ok();
+                    upcalls.schedule_upcall(0, (data1, data2, data3)).ok();
                 });
             });
         }

--- a/capsules/src/sdcard.rs
+++ b/capsules/src/sdcard.rs
@@ -1449,7 +1449,7 @@ impl<'a, A: hil::time::Alarm<'a>> SDCardClient for SDCardDriver<'a, A> {
     fn card_detection_changed(&self, installed: bool) {
         self.current_process.map(|process_id| {
             let _ = self.grants.enter(*process_id, |_app, upcalls| {
-                upcalls.schedule_upcall(0, 0, installed as usize, 0).ok();
+                upcalls.schedule_upcall(0, (0, installed as usize, 0)).ok();
             });
         });
     }
@@ -1459,7 +1459,7 @@ impl<'a, A: hil::time::Alarm<'a>> SDCardClient for SDCardDriver<'a, A> {
             let _ = self.grants.enter(*process_id, |_app, upcalls| {
                 let size_in_kb = ((total_size >> 10) & 0xFFFFFFFF) as usize;
                 upcalls
-                    .schedule_upcall(0, 1, block_size as usize, size_in_kb)
+                    .schedule_upcall(0, (1, block_size as usize, size_in_kb))
                     .ok();
             });
         });
@@ -1492,7 +1492,7 @@ impl<'a, A: hil::time::Alarm<'a>> SDCardClient for SDCardDriver<'a, A> {
                 // perform callback
                 // Note that we are explicitly performing the callback even if no
                 // data was read or if the app's read_buffer doesn't exist
-                upcalls.schedule_upcall(0, 2, read_len, 0).ok();
+                upcalls.schedule_upcall(0, (2, read_len, 0)).ok();
             });
         });
     }
@@ -1502,7 +1502,7 @@ impl<'a, A: hil::time::Alarm<'a>> SDCardClient for SDCardDriver<'a, A> {
 
         self.current_process.map(|process_id| {
             let _ = self.grants.enter(*process_id, |_app, upcalls| {
-                upcalls.schedule_upcall(0, 3, 0, 0).ok();
+                upcalls.schedule_upcall(0, (3, 0, 0)).ok();
             });
         });
     }
@@ -1510,7 +1510,7 @@ impl<'a, A: hil::time::Alarm<'a>> SDCardClient for SDCardDriver<'a, A> {
     fn error(&self, error: u32) {
         self.current_process.map(|process_id| {
             let _ = self.grants.enter(*process_id, |_app, upcalls| {
-                upcalls.schedule_upcall(0, 4, error as usize, 0).ok();
+                upcalls.schedule_upcall(0, (4, error as usize, 0)).ok();
             });
         });
     }

--- a/capsules/src/sha.rs
+++ b/capsules/src/sha.rs
@@ -257,14 +257,12 @@ impl<
                             upcalls
                                 .schedule_upcall(
                                     0,
-                                    kernel::errorcode::into_statuscode(e.into()),
-                                    0,
-                                    0,
+                                    (kernel::errorcode::into_statuscode(e.into()), 0, 0),
                                 )
                                 .ok();
                         }
                     } else {
-                        upcalls.schedule_upcall(0, 0, 0, 0).ok();
+                        upcalls.schedule_upcall(0, (0, 0, 0)).ok();
                     }
                 })
                 .map_err(|err| {
@@ -298,13 +296,15 @@ impl<
                     });
 
                     match result {
-                        Ok(_) => upcalls.schedule_upcall(0, 0, pointer as usize, 0).ok(),
+                        Ok(_) => upcalls.schedule_upcall(0, (0, pointer as usize, 0)).ok(),
                         Err(e) => upcalls
                             .schedule_upcall(
                                 0,
-                                kernel::errorcode::into_statuscode(e.into()),
-                                pointer as usize,
-                                0,
+                                (
+                                    kernel::errorcode::into_statuscode(e.into()),
+                                    pointer as usize,
+                                    0,
+                                ),
                             )
                             .ok(),
                     };
@@ -575,9 +575,7 @@ impl<
                                 upcalls
                                     .schedule_upcall(
                                         0,
-                                        kernel::errorcode::into_statuscode(e.into()),
-                                        0,
-                                        0,
+                                        (kernel::errorcode::into_statuscode(e.into()), 0, 0),
                                     )
                                     .ok();
                             }

--- a/capsules/src/sound_pressure.rs
+++ b/capsules/src/sound_pressure.rs
@@ -131,7 +131,7 @@ impl hil::sensors::SoundPressureClient for SoundPressureSensor<'_> {
                     self.busy.set(false);
                     app.subscribed = false;
                     if ret == Ok(()) {
-                        upcalls.schedule_upcall(0, sound_val.into(), 0, 0).ok();
+                        upcalls.schedule_upcall(0, (sound_val.into(), 0, 0)).ok();
                     }
                 }
             });

--- a/capsules/src/spi_controller.rs
+++ b/capsules/src/spi_controller.rs
@@ -328,7 +328,7 @@ impl<S: SpiMasterDevice> SpiMasterClient for Spi<'_, S> {
                     let len = app.len;
                     app.len = 0;
                     app.index = 0;
-                    upcalls.schedule_upcall(0, len, 0, 0).ok();
+                    upcalls.schedule_upcall(0, (len, 0, 0)).ok();
                 } else {
                     self.do_next_read_write(app);
                 }

--- a/capsules/src/spi_peripheral.rs
+++ b/capsules/src/spi_peripheral.rs
@@ -301,7 +301,7 @@ impl<S: SpiSlaveDevice> SpiSlaveClient for SpiPeripheral<'_, S> {
                     let len = app.len;
                     app.len = 0;
                     app.index = 0;
-                    upcalls.schedule_upcall(0, len, 0, 0).ok();
+                    upcalls.schedule_upcall(0, (len, 0, 0)).ok();
                 } else {
                     self.do_next_read_write(app);
                 }
@@ -314,7 +314,7 @@ impl<S: SpiSlaveDevice> SpiSlaveClient for SpiPeripheral<'_, S> {
         self.current_process.map(|process_id| {
             let _ = self.grants.enter(*process_id, move |app, upcalls| {
                 let len = app.len;
-                upcalls.schedule_upcall(1, len, 0, 0).ok();
+                upcalls.schedule_upcall(1, (len, 0, 0)).ok();
             });
         });
     }

--- a/capsules/src/temperature.rs
+++ b/capsules/src/temperature.rs
@@ -114,7 +114,7 @@ impl hil::sensors::TemperatureClient for TemperatureSensor<'_> {
                 if app.subscribed {
                     self.busy.set(false);
                     app.subscribed = false;
-                    upcalls.schedule_upcall(0, temp_val, 0, 0).ok();
+                    upcalls.schedule_upcall(0, (temp_val, 0, 0)).ok();
                 }
             });
         }

--- a/capsules/src/text_screen.rs
+++ b/capsules/src/text_screen.rs
@@ -143,12 +143,8 @@ impl<'a> TextScreen<'a> {
                     TextScreenCommand::GetResolution => {
                         let (x, y) = self.text_screen.get_size();
                         app.pending_command = false;
-                        let _ = upcalls.schedule_upcall(
-                            0,
-                            kernel::errorcode::into_statuscode(Ok(())),
-                            x,
-                            y,
-                        );
+                        let _ = upcalls
+                            .schedule_upcall(0, (kernel::errorcode::into_statuscode(Ok(())), x, y));
                         run_next = true;
                         Ok(())
                     }
@@ -230,7 +226,7 @@ impl<'a> TextScreen<'a> {
         self.current_app.take().map(|appid| {
             let _ = self.apps.enter(appid, |app, upcalls| {
                 app.pending_command = false;
-                upcalls.schedule_upcall(0, data1, data2, data3).ok();
+                upcalls.schedule_upcall(0, (data1, data2, data3)).ok();
             });
         });
     }

--- a/capsules/src/touch.rs
+++ b/capsules/src/touch.rs
@@ -183,9 +183,11 @@ impl<'a> hil::touch::TouchClient for Touch<'a> {
                     upcalls
                         .schedule_upcall(
                             0,
-                            event_status,
-                            (event.x as usize) << 16 | event.y as usize,
-                            pressure_size,
+                            (
+                                event_status,
+                                (event.x as usize) << 16 | event.y as usize,
+                                pressure_size,
+                            ),
                         )
                         .ok();
                 }
@@ -258,9 +260,7 @@ impl<'a> hil::touch::MultiTouchClient for Touch<'a> {
                         upcalls
                             .schedule_upcall(
                                 2,
-                                num,
-                                dropped_events,
-                                if num < len { len - num } else { 0 },
+                                (num, dropped_events, if num < len { len - num } else { 0 }),
                             )
                             .ok();
                     }
@@ -287,7 +287,7 @@ impl<'a> hil::touch::GestureClient for Touch<'a> {
                     GestureEvent::ZoomIn => 5,
                     GestureEvent::ZoomOut => 6,
                 };
-                upcalls.schedule_upcall(1, gesture_id, 0, 0).ok();
+                upcalls.schedule_upcall(1, (gesture_id, 0, 0)).ok();
             });
         }
     }

--- a/capsules/src/tsl2561.rs
+++ b/capsules/src/tsl2561.rs
@@ -425,7 +425,7 @@ impl i2c::I2CClient for TSL2561<'_> {
 
                 self.owning_process.map(|pid| {
                     let _ = self.apps.enter(*pid, |_, upcalls| {
-                        upcalls.schedule_upcall(0, 0, lux, 0).ok();
+                        upcalls.schedule_upcall(0, (0, lux, 0)).ok();
                     });
                 });
 

--- a/capsules/src/usb/usb_user.rs
+++ b/capsules/src/usb/usb_user.rs
@@ -80,9 +80,7 @@ where
                             upcalls
                                 .schedule_upcall(
                                     0,
-                                    kernel::errorcode::into_statuscode(Ok(())),
-                                    0,
-                                    0,
+                                    (kernel::errorcode::into_statuscode(Ok(())), 0, 0),
                                 )
                                 .ok();
                             app.awaiting = None;

--- a/doc/Porting_v1_Capsules_to_v2.md
+++ b/doc/Porting_v1_Capsules_to_v2.md
@@ -311,7 +311,7 @@ replaced with code like:
 
 ```rust
 self.apps.enter(appid, |app, upcalls| {
-    upcalls.schedule_upcall(upcall_number,(r0, r1, r2));
+    upcalls.schedule_upcall(upcall_number, (r0, r1, r2));
 });
 ```
 

--- a/doc/Porting_v1_Capsules_to_v2.md
+++ b/doc/Porting_v1_Capsules_to_v2.md
@@ -311,7 +311,7 @@ replaced with code like:
 
 ```rust
 self.apps.enter(appid, |app, upcalls| {
-    upcalls.schedule_upcall(upcall_number, r0, r1, r2);
+    upcalls.schedule_upcall(upcall_number,(r0, r1, r2));
 });
 ```
 

--- a/kernel/src/grant.rs
+++ b/kernel/src/grant.rs
@@ -218,9 +218,7 @@ impl<'a> GrantUpcallTable<'a> {
     pub fn schedule_upcall(
         &self,
         subscribe_num: usize,
-        r0: usize,
-        r1: usize,
-        r2: usize,
+        r: (usize, usize, usize),
     ) -> Result<(), UpcallError> {
         // Implement `self.upcalls[subscribe_num]` without a chance of a panic.
         self.upcalls.get(subscribe_num).map_or(
@@ -238,7 +236,7 @@ impl<'a> GrantUpcallTable<'a> {
                     saved_upcall.appdata,
                     saved_upcall.fn_ptr,
                 );
-                upcall.schedule(self.process, r0, r1, r2)
+                upcall.schedule(self.process, r.0, r.1, r.2)
             },
         )
     }

--- a/kernel/src/ipc.rs
+++ b/kernel/src/ipc.rs
@@ -128,9 +128,11 @@ impl<const NUM_PROCS: usize, const NUM_UPCALLS: usize> IPC<NUM_PROCS, NUM_UPCALL
                                         my_upcalls
                                             .schedule_upcall(
                                                 to_schedule,
-                                                called_from.id() + 1,
-                                                ReadableProcessBuffer::len(slice),
-                                                ReadableProcessBuffer::ptr(slice) as usize,
+                                                (
+                                                    called_from.id() + 1,
+                                                    ReadableProcessBuffer::len(slice),
+                                                    ReadableProcessBuffer::ptr(slice) as usize,
+                                                ),
                                             )
                                             .ok();
                                     }
@@ -138,9 +140,7 @@ impl<const NUM_PROCS: usize, const NUM_UPCALLS: usize> IPC<NUM_PROCS, NUM_UPCALL
                                         my_upcalls
                                             .schedule_upcall(
                                                 to_schedule,
-                                                called_from.id() + 1,
-                                                0,
-                                                0,
+                                                (called_from.id() + 1, 0, 0),
                                             )
                                             .ok();
                                     }


### PR DESCRIPTION
### Pull Request Overview

This pull request groups the values returned by `schedule_upcall` into a tuple to prevent wrongly placing a value instead of the upcall number.

```rust
pub fn schedule_upcall(
        &self,
        subscribe_num: usize,
        r: (usize, usize, usize),
    ) -> Result<(), UpcallError> 
```

This tries to use Rust's type system to clearly separate the upcall number and the values. The `schedule_upcall` takes four `usize` parameters, the first one being the upcall number and the following three the values returned to the application. As all four parameters have the same type, it is easy to forget that the first parameter is the upcall number, not the first value. The compiler has no way of protecting against this error. 

This is inspired from the error within #2698.

There should be no impact in size or performance.

### Testing Strategy

N/A

### TODO or Help Wanted

N/A

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
