### PR TITLE
Flash components

### DIFF
--- a/boards/components/src/flash.rs
+++ b/boards/components/src/flash.rs
@@ -1,0 +1,90 @@
+//! Component for Flash
+//!
+//! Provides `FlashMux` and `FlashUser` (virtual flash)
+//! Usage
+//! -----
+//! ```rust
+//!    let mux_flash = components::flash::FlashMuxComponent::new(&base_peripherals.nvmc).finalize(
+//!       components::flash_mux_component_helper!(nrf52833::nvmc::Nvmc),
+//!    );
+//!
+//!    let virtual_app_flash = components::flash::FlashUserComponent::new(mux_flash).finalize(
+//!       components::flash_user_component_helper!(nrf52833::nvmc::Nvmc),
+//!    );
+//! ```
+
+use capsules::virtual_flash::FlashUser;
+use capsules::virtual_flash::MuxFlash;
+use core::mem::MaybeUninit;
+use kernel::component::Component;
+use kernel::hil::flash::{Flash, HasClient};
+use kernel::static_init_half;
+
+// Setup static space for the objects.
+#[macro_export]
+macro_rules! flash_user_component_helper {
+    ($F:ty) => {{
+        use capsules::virtual_flash::FlashUser;
+        use core::mem::MaybeUninit;
+        static mut BUF1: MaybeUninit<FlashUser<'static, $F>> = MaybeUninit::uninit();
+        &mut BUF1
+    };};
+}
+
+#[macro_export]
+macro_rules! flash_mux_component_helper {
+    ($F:ty) => {{
+        use capsules::virtual_flash::MuxFlash;
+        use core::mem::MaybeUninit;
+        static mut BUF1: MaybeUninit<MuxFlash<'static, $F>> = MaybeUninit::uninit();
+        &mut BUF1
+    };};
+}
+
+pub struct FlashMuxComponent<F: 'static + Flash + HasClient<'static, MuxFlash<'static, F>>> {
+    flash: &'static F,
+}
+
+impl<F: 'static + Flash + HasClient<'static, MuxFlash<'static, F>>> FlashMuxComponent<F> {
+    pub fn new(flash: &'static F) -> FlashMuxComponent<F> {
+        FlashMuxComponent { flash }
+    }
+}
+
+impl<F: 'static + Flash + HasClient<'static, MuxFlash<'static, F>>> Component
+    for FlashMuxComponent<F>
+{
+    type StaticInput = &'static mut MaybeUninit<MuxFlash<'static, F>>;
+    type Output = &'static MuxFlash<'static, F>;
+
+    unsafe fn finalize(self, s: Self::StaticInput) -> Self::Output {
+        let mux_flash = static_init_half!(s, MuxFlash<'static, F>, MuxFlash::new(self.flash));
+        HasClient::set_client(self.flash, mux_flash);
+
+        mux_flash
+    }
+}
+
+pub struct FlashUserComponent<F: 'static + Flash + HasClient<'static, MuxFlash<'static, F>>> {
+    mux_flash: &'static MuxFlash<'static, F>,
+}
+
+impl<F: 'static + Flash + HasClient<'static, MuxFlash<'static, F>>> FlashUserComponent<F> {
+    pub fn new(mux_flash: &'static MuxFlash<'static, F>) -> Self {
+        Self { mux_flash }
+    }
+}
+
+impl<F: 'static + Flash + HasClient<'static, MuxFlash<'static, F>>> Component
+    for FlashUserComponent<F>
+{
+    type StaticInput = &'static mut MaybeUninit<FlashUser<'static, F>>;
+    type Output = &'static FlashUser<'static, F>;
+
+    unsafe fn finalize(self, s: Self::StaticInput) -> Self::Output {
+        let virtual_flash =
+            static_init_half!(s, FlashUser<'static, F>, FlashUser::new(self.mux_flash));
+
+        virtual_flash
+    }
+}

--- a/boards/components/src/lib.rs
+++ b/boards/components/src/lib.rs
@@ -14,6 +14,7 @@ pub mod ctap;
 pub mod debug_queue;
 pub mod debug_writer;
 pub mod digest;
+pub mod flash;
 pub mod ft6x06;
 pub mod fxos8700;
 pub mod gpio;

--- a/boards/earlgrey-nexysvideo/src/main.rs
+++ b/boards/earlgrey-nexysvideo/src/main.rs
@@ -408,8 +408,8 @@ unsafe fn setup() -> (
         lowrisc::flash_ctrl::LowRiscPage::default()
     );
 
-    let mux_flash = components::tickv::FlashMuxComponent::new(&peripherals.flash_ctrl).finalize(
-        components::flash_user_component_helper!(lowrisc::flash_ctrl::FlashCtrl),
+    let mux_flash = components::flash::FlashMuxComponent::new(&peripherals.flash_ctrl).finalize(
+        components::flash_mux_component_helper!(lowrisc::flash_ctrl::FlashCtrl),
     );
 
     // TicKV

--- a/boards/microbit_v2/src/main.rs
+++ b/boards/microbit_v2/src/main.rs
@@ -494,15 +494,23 @@ pub unsafe fn main() {
     // STORAGE
     //--------------------------------------------------------------------------
 
+    let mux_flash = components::flash::FlashMuxComponent::new(&base_peripherals.nvmc).finalize(
+        components::flash_mux_component_helper!(nrf52833::nvmc::Nvmc),
+    );
+
     // App Flash
+
+    let virtual_app_flash = components::flash::FlashUserComponent::new(mux_flash).finalize(
+        components::flash_user_component_helper!(nrf52833::nvmc::Nvmc),
+    );
 
     let app_flash = components::app_flash_driver::AppFlashComponent::new(
         board_kernel,
         capsules::app_flash_driver::DRIVER_NUM,
-        &base_peripherals.nvmc,
+        virtual_app_flash,
     )
     .finalize(components::app_flash_component_helper!(
-        nrf52833::nvmc::Nvmc,
+        capsules::virtual_flash::FlashUser<'static, nrf52833::nvmc::Nvmc>,
         512
     ));
 


### PR DESCRIPTION
### Pull Request Overview

This pull request places the virtual flash components into a separate file `flash.rs` and adds a component for `FlashUser`.

Until now, the `FlashMux` component was in the `tickv.rs` file.

The virtual flash is added to the microbit.

### Testing Strategy

This pull request was tested using a Micro:bit v2.

### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
