### PR TITLE
boards/litex: bump targeted tock-litex release

### DIFF
--- a/boards/litex/arty/README.md
+++ b/boards/litex/arty/README.md
@@ -11,11 +11,12 @@ differ significantly depending on the LiteX release and configuration
 options used. This board definition currently targets and has been
 tested with
 - [the LiteX SoC generator, revision
-  11f7416e36](https://github.com/enjoy-digital/litex/tree/11f7416e3603bf404a3c603902162cf02551e98c)
+  e0d5a7bff5](https://github.com/enjoy-digital/litex/tree/e0d5a7bff55923)
 - using the companion [target
-  file](https://github.com/litex-hub/litex-boards/blob/ef662035b13a65955e94b018621c327448f9105e/litex_boards/targets/arty.py) from `litex-boards`
+  file](https://github.com/litex-hub/litex-boards/blob/4b48f15265c902/litex_boards/targets/digilent_arty.py)
+  from `litex-boards`
 - built around a VexRiscv-CPU with PMP, hardware multiplication and
-  compressed instruction support
+  compressed instruction support (named `TockSecureIMC`)
 - along with the following configuration options:
 
   ```
@@ -23,7 +24,6 @@ tested with
   --cpu-variant=tock+secure+imc
   --csr-data-width=32
   --timer-uptime
-  --integrated-rom-size=0xb000
   --with-ethernet
   ```
 
@@ -31,7 +31,7 @@ The `tock+secure+imc` is a custom VexRiscv CPU variant, based on the
 build infrastructure in
 [pythondata-cpu-vexriscv](https://github.com/litex-hub/pythondata-cpu-vexriscv),
 using a
-[patch](https://github.com/lschuermann/tock-litex/blob/master/pkgs/pythondata-cpu-vexriscv/0001-Add-TockSecureIMC-cpu-variant.patch)
+[patch](https://github.com/lschuermann/tock-litex/blob/7fcbefac7f17c2/pkgs/pythondata-cpu-vexriscv/0001-Add-TockSecureIMC-cpu-variant.patch)
 to introduce a CPU with physical memory protection, hardware
 multiplication and compressed instruction support (such that it is
 compatible with the `rv32imc` arch).
@@ -41,14 +41,15 @@ Verilog files) can be obtained from the [Tock on LiteX companion
 repository
 releases](https://github.com/lschuermann/tock-litex/releases/). The
 current board definition has been verified to work with [release
-2021031601](https://github.com/lschuermann/tock-litex/releases/tag/2021031601). The
-bitstream for this board is located in `arty_a7-35t.zip` under
-`gateware/arty.bit`.
+2021072001](https://github.com/lschuermann/tock-litex/releases/tag/2021072001). The
+bitstream for this board is located in `digilent_arty_a7-35t.zip`
+under `gateware/digilent_arty.bit`.
 
 Many bitstream customizations can be represented in the Tock board by
-simply changing the variables in `src/litex_generated.rs`. To support
-a different set of FPGA cores and perform further modifications, the
-`src/main.rs` file will have to be modified.
+simply changing the variables in
+`src/litex_generated_constants.rs`. To support a different set of FPGA
+cores and perform further modifications, the `src/main.rs` file will
+have to be modified.
 
 
 Please note
@@ -78,24 +79,24 @@ Once LiteX and Xilinx Vivado is installed, building a bitstream should
 be as simple as:
 
 ```
-$ cd $PATH_TO_LITEX/litex/boards/targets
-$ ./arty.py <configuration options> --build
+$ cd $PATH_TO_LITEX_BOARDS/litex_boards/targets
+$ ./digilent_arty.py <configuration options> --build
 ```
 
-This will produce a folder `build/arty/gateware` containing the
-generated bitstream for the FPGA (`arty.bin`).
+This will produce a folder `build/digilent_arty/gateware` containing
+the generated bitstream for the FPGA (`arty.bin`).
 
-In addition to that, a folder `build/arty/software` will be included
-containing support code and the SoC bios stored in ROM. The individual
-SoC configuration options, interrupt assignments, register (LiteX
-configuration status registers) addresses, etc. relevant for Tock can
-be found in
-`build/arty/software/include/generated/{csr.h,regions.ld,soc.h}`.
+In addition to that, a folder `build/digilent_arty/software` will be
+included containing support code and the SoC bios stored in ROM. The
+individual SoC configuration options, interrupt assignments, register
+(LiteX configuration status registers) addresses, etc. relevant for
+Tock can be found in
+`build/digilent_arty/software/include/generated/{csr.h,regions.ld,soc.h}`.
 
 The bitstream can be programmed either by using Xilinx Vivado or running:
 
 ```
-$ ./arty.py <configuration options> --load
+$ ./digilent_arty.py <configuration options> --load
 ```
 
 To persistently write the bitstream to the included SPI flash, use the
@@ -111,9 +112,9 @@ Programming
 
 By default, the LiteX SoC will feature an integrated BIOS in ROM,
 which acts as a bootloader. The Tock kernel binary can be loaded
-either using `litex_term.py` (available as `lxterm`) via serial, or
-using TFTP via Ethernet. The uploaded image will be placed into the
-`main_ram` section and executed.
+either using `litex_term.py` (sometimes available as `lxterm`) via
+serial, or using TFTP via Ethernet. The uploaded image will be placed
+into the `main_ram` section and executed.
 
 ### Serial boot
 
@@ -188,7 +189,7 @@ Debugging
 
 LiteX makes it easy to generate vastly different SoCs. Prior to
 creating an issue on GitHub, please verify that all variables in
-`src/litex_generated.rs` correspond to the values provided to LiteX or
+`src/litex_generated_constants.rs` correspond to the values provided to LiteX or
 generated by it. The respective file paths for the source of each
 value is included as a comment.
 

--- a/boards/litex/arty/src/litex_generated_constants.rs
+++ b/boards/litex/arty/src/litex_generated_constants.rs
@@ -14,8 +14,8 @@ pub const CONFIG_CPU_HAS_INTERRUPT: bool = true;
 pub const CONFIG_CPU_RESET_ADDR: usize = 0;
 
 pub const CONFIG_CPU_TYPE: &str = "vexriscv";
-pub const CONFIG_CPU_VARIANT: &str = "full";
-pub const CONFIG_CPU_HUMAN_NAME: &str = "VexRiscv_Full";
+pub const CONFIG_CPU_VARIANT: &str = "tock";
+pub const CONFIG_CPU_HUMAN_NAME: &str = "VexRiscv_TockSecureIMC";
 pub const CONFIG_CPU_NOP: &str = "nop";
 pub const CONFIG_L2_SIZE: usize = 8192;
 
@@ -37,12 +37,14 @@ pub const UART_INTERRUPT: usize = 0;
 
 pub const CSR_BASE: usize = 0xf0000000;
 pub const CSR_CTRL_BASE: usize = CSR_BASE + 0x0000;
-pub const CSR_UART_PHY_BASE: usize = CSR_BASE + 0x1800;
-pub const CSR_UART_BASE: usize = CSR_BASE + 0x2000;
-pub const CSR_TIMER0_BASE: usize = CSR_BASE + 0x2800;
-pub const CSR_ETHPHY_BASE: usize = CSR_BASE + 0x4000;
-pub const CSR_ETHMAC_BASE: usize = CSR_BASE + 0x4800;
-pub const CSR_LEDS_BASE: usize = CSR_BASE + 0x5000;
+pub const CSR_DDRPHY_BASE: usize = CSR_BASE + 0x0800;
+pub const CSR_ETHMAC_BASE: usize = CSR_BASE + 0x1000;
+pub const CSR_ETHPHY_BASE: usize = CSR_BASE + 0x1800;
+pub const CSR_IDENTIFIER_MEM_BASE: usize = CSR_BASE + 0x2000;
+pub const CSR_LEDS_BASE: usize = CSR_BASE + 0x2800;
+pub const CSR_SDRAM_BASE: usize = CSR_BASE + 0x3000;
+pub const CSR_TIMER0_BASE: usize = CSR_BASE + 0x3800;
+pub const CSR_UART_BASE: usize = CSR_BASE + 0x4000;
 
 // constants defined in `generated/mem.h`
 pub const MEM_ETHMAC_BASE: usize = 0x80000000;

--- a/boards/litex/arty/src/main.rs
+++ b/boards/litex/arty/src/main.rs
@@ -10,7 +10,7 @@ use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use kernel::capabilities;
 use kernel::component::Component;
 use kernel::dynamic_deferred_call::{DynamicDeferredCall, DynamicDeferredCallClientState};
-use kernel::hil::time::{Alarm, Frequency, Timer};
+use kernel::hil::time::{Alarm, Timer};
 use kernel::platform::chip::InterruptService;
 use kernel::platform::scheduler_timer::VirtualSchedulerTimer;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
@@ -365,13 +365,10 @@ pub unsafe fn main() {
                 socc::CSR_UART_BASE
                     as *const litex_vexriscv::uart::LiteXUartRegisters<socc::SoCRegisterFmt>,
             ),
-            Some((
-                StaticRef::new(
-                    socc::CSR_UART_PHY_BASE
-                        as *const litex_vexriscv::uart::LiteXUartPhyRegisters<socc::SoCRegisterFmt>,
-                ),
-                socc::ClockFrequency::frequency()
-            )),
+            // No UART PHY CSR present, thus baudrate fixed in
+            // hardware. Change with --uart-baudrate during SoC
+            // generation. Fixed to 1MBd.
+            None,
             dynamic_deferred_caller,
         )
     );

--- a/boards/litex/sim/README.md
+++ b/boards/litex/sim/README.md
@@ -10,28 +10,31 @@ differ significantly depending on the release and configuration
 options used. This board definition currently targets and has been
 tested with
 - [the LiteX SoC generator, revision
-  11f7416e36](https://github.com/enjoy-digital/litex/tree/11f7416e3603bf404a3c603902162cf02551e98c)
-- using the included [lxsim](https://github.com/enjoy-digital/litex/blob/11f7416e3603bf404a3c603902162cf02551e98c/litex/tools/litex_sim.py)
+  e0d5a7bff5](https://github.com/enjoy-digital/litex/tree/e0d5a7bff55923)
+- using the included
+  [lxsim](https://github.com/enjoy-digital/litex/blob/e0d5a7bff55923/litex/tools/litex_sim.py)
 - built around a VexRiscv-CPU
 - featuring a TIMER0 with 64-bit wide hardware uptime
 - along with the following configuration options:
 
   ```
   --csr-data-width=32
-  --integrated-rom-size=1048576
+  --integrated-rom-size=0x100000
   --cpu-variant=secure
   --with-ethernet
+  --timer-uptime
   --rom-init $PATH_TO_TOCK_BINARY
   ```
 
 Many bitstream customizations can be represented in the Tock board by
-simply changing the variables in `src/litex_generated.rs`. To support
-a different set of FPGA cores and perform further modifications, the
-`src/main.rs` file will have to be modified.
+simply changing the variables in
+`src/litex_generated_constants.rs`. To support a different set of FPGA
+cores and perform further modifications, the `src/main.rs` file will
+have to be modified.
 
 
-Building the SoC / Programming the FPGA
----------------------------------------
+Building the SoC / Running the simulation
+-----------------------------------------
 
 Please refer to the [LiteX
 documentation](https://github.com/enjoy-digital/litex/wiki/) for

--- a/boards/litex/sim/src/litex_generated_constants.rs
+++ b/boards/litex/sim/src/litex_generated_constants.rs
@@ -4,16 +4,16 @@
 pub type SoCRegisterFmt = litex_vexriscv::litex_registers::LiteXSoCRegistersC32B32;
 
 // constants defined in `generated/soc.h`
+
 pub type ClockFrequency = kernel::hil::time::Freq1MHz;
 
 pub const CONFIG_CPU_HAS_INTERRUPT: bool = true;
 pub const CONFIG_CPU_RESET_ADDR: usize = 0;
 
 pub const CONFIG_CPU_TYPE: &str = "vexriscv";
-pub const CONFIG_CPU_VARIANT: &str = "full";
-pub const CONFIG_CPU_HUMAN_NAME: &str = "VexRiscv_Full";
+pub const CONFIG_CPU_VARIANT: &str = "secure";
+pub const CONFIG_CPU_HUMAN_NAME: &str = "VexRiscv_Secure";
 pub const CONFIG_CPU_NOP: &str = "nop";
-pub const CONFIG_L2_SIZE: usize = 8192;
 
 pub const CONFIG_CSR_DATA_WIDTH: usize = 32;
 pub const CONFIG_CSR_ALIGNMENT: usize = 32;
@@ -32,11 +32,12 @@ pub const UART_INTERRUPT: usize = 0;
 // constants defined in `generated/csr.h`
 pub const CSR_BASE: usize = 0xf0000000;
 pub const CSR_CTRL_BASE: usize = CSR_BASE + 0x0000;
-pub const CSR_UART_BASE: usize = CSR_BASE + 0x2000;
-pub const CSR_TIMER0_BASE: usize = CSR_BASE + 0x2800;
-pub const CSR_ETHPHY_BASE: usize = CSR_BASE + 0x3000;
-pub const CSR_ETHMAC_BASE: usize = CSR_BASE + 0x3800;
+pub const CSR_ETHMAC_BASE: usize = CSR_BASE + 0x0800;
+pub const CSR_ETHPHY_BASE: usize = CSR_BASE + 0x1000;
+pub const CSR_IDENTIFIER_MEM_BASE: usize = CSR_BASE + 0x1800;
+pub const CSR_TIMER0_BASE: usize = CSR_BASE + 0x2000;
+pub const CSR_UART_BASE: usize = CSR_BASE + 0x2800;
 
 // constants defined in `generated/mem.h`
-pub const MEM_ETHMAC_BASE: usize = 0xb0000000;
+pub const MEM_ETHMAC_BASE: usize = 0x80000000;
 pub const MEM_ETHMAC_SIZE: usize = 0x00002000;


### PR DESCRIPTION
### Pull Request Overview

This updates the targeted release of tock-litex, which pins LiteX package versions and contains prebuilt FPGA bitstreams for the LiteX boards supported in Tock.

Further, required changes due to the updated LiteX package revisions are applied accordingly.

### Testing Strategy

This pull request was tested by running some test applications on the hardware / in the simulation.


### TODO or Help Wanted

N/A

### Documentation Updated

- [x] ~Updated the relevant files in `/docs`,~ or no updates are required.

### Formatting

- [x] Ran `make prepush`.
