### PR TITLE
make: update stack-analysis format

### DIFF
--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -108,9 +108,11 @@ TARGET_PATH := $(TARGET_DIRECTORY)$(TARGET)
 ifneq ($(V),)
   Q =
   VERBOSE = --verbose
+  DEVNULL =
 else
   Q = @
   VERBOSE =
+  DEVNULL = > /dev/null
 endif
 
 # Ask git what version of the Tock kernel we are compiling, so we can include
@@ -322,8 +324,8 @@ cargobloatnoinline:
 stack-analysis:
 	@$ echo $(PLATFORM)
 	@$ echo ----------------------
-	@$(MAKE) release RUSTC_FLAGS="$(RUSTC_FLAGS) -Z emit-stack-sizes" > /dev/null 2>&1
-	@$(TOCK_ROOT_DIRECTORY)/tools/stack_analysis.sh $(TARGET_PATH)/release/$(PLATFORM).elf
+	$(Q)$(MAKE) release RUSTC_FLAGS="$(RUSTC_FLAGS) -Z emit-stack-sizes" $(DEVNULL) 2>&1
+	$(Q)$(TOCK_ROOT_DIRECTORY)/tools/stack_analysis.sh $(TARGET_PATH)/release/$(PLATFORM).elf
 
 # Support rules
 

--- a/tools/stack_analysis.sh
+++ b/tools/stack_analysis.sh
@@ -4,13 +4,28 @@
 # size information, and is thus most easily called using the `make stack-analysis`
 # rule.
 
-# Print the stack frame size of `main`
-printf "main stack frame: \n"
-$(find $(rustc --print sysroot) -name llvm-readobj) --elf-output-style GNU --stack-sizes $1 | grep 'main'
+bold=$(tput bold)
+normal=$(tput sgr0)
 
+# Get a list of all stack frames and their sizes.
+frames=`$(find $(rustc --print sysroot) -name llvm-readobj) --elf-output-style GNU --stack-sizes $1`
+
+# Print the stack frame size of `main`
+printf "   main stack frame: \n"
+echo "$frames" | grep ' main' # Use a space before main to avoid functions with main in the name.
 printf "\n"
-printf "5 largest stack frames: \n"
 
 # Print the 5 largest stack frames
-$(find $(rustc --print sysroot) -name llvm-readobj) --elf-output-style GNU --stack-sizes $1 | sort -n -r | head -5
+printf "   5 largest stack frames: \n"
+echo "$frames" | sort -n -r | head -5
 printf "\n"
+
+# Check if main is the largest stack frame
+largest=`echo "$frames" | sort -n -r | head -1 | grep ' main'`
+largest_ret_val=$?
+
+# If it is, print a warning.
+if [ $largest_ret_val -eq 0 ]; then
+    echo "   ${bold}WARNING! main is the largest stack frame!${normal}"
+    printf "\n"
+fi

--- a/tools/stack_analysis.sh
+++ b/tools/stack_analysis.sh
@@ -27,5 +27,8 @@ largest_ret_val=$?
 # If it is, print a warning.
 if [ $largest_ret_val -eq 0 ]; then
     echo "   ${bold}WARNING! main is the largest stack frame!${normal}"
+    echo "   See https://github.com/tock/tock/issues/2425 for an explanation of"
+    echo "   why this is an issue, and https://github.com/tock/tock/pull/2715 for"
+    echo "   an example of how to fix it."
     printf "\n"
 fi


### PR DESCRIPTION
### Pull Request Overview

Two things:

1. Makes the `make allstack` easier to read:

```
$ make stack-analysis
imix
----------------------
   main stack frame:
         2048     main

   5 largest stack frames:
         2048     main
          720     _ZN104_$LT$capsules..process_console..ProcessConsole$LT$C$GT$$u20$as$u20$kernel..hil..uart..TransmitClient$GT$18transmitted_buffer17h4c3fef6f6a95d58fE
          632     _ZN8capsules15process_console23ProcessConsole$LT$C$GT$11write_state17hee14a9c17699800aE
          608     _ZN7cortexm24kernel_hardfault_arm_v7m17h8c7b48b27a33c005E
          600     _ZN98_$LT$capsules..ieee802154..framer..Framer$LT$M$C$A$GT$$u20$as$u20$kernel..hil..radio..RxClient$GT$7receive17h8a8322dd16823f26E

   **WARNING! main is the largest stack frame!**
```

2. Enables `make stack-analysis V=1` to work fully.


### Testing Strategy

Running `make stack-analysis`.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
