### PR TITLE
make: remove rustup nonsense with make V=1

### DIFF
--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -247,7 +247,7 @@ ifneq ($(V),)
   $(info )
   $(info cargo --version               = $(shell $(CARGO) --version))
   $(info rustc --version               = $(shell rustc --version))
-  $(info rustup --version              = $(shell $(RUSTUP) --version))
+  $(info rustup --version              = $(shell $(RUSTUP) --version 2>/dev/null))
   $(info *******************************************************)
   $(info )
 endif


### PR DESCRIPTION
### Pull Request Overview

Before:

```
*******************************************************
TOCK KERNEL BUILD SYSTEM -- VERBOSE BUILD CONFIGURATION
*******************************************************
MAKEFILE_COMMON_PATH          = /Users/bradjc/git/tock/boards/
TOCK_ROOT_DIRECTORY           = /Users/bradjc/git/tock/
TARGET_DIRECTORY              = /Users/bradjc/git/tock/target/

PLATFORM                      = hail
TARGET                        = thumbv7em-none-eabi
TOCK_KERNEL_VERSION           = release-1.6-2069-g7faa5231c
RUSTC_FLAGS                   = -C link-arg=-Tlayout.ld -C linker=rust-lld -C linker-flavor=ld.lld -C relocation-model=dynamic-no-pic -C link-arg=-nmagic -C link-arg=-icf=all
RUSTC_FLAGS_TOCK              = -C link-arg=-Tlayout.ld -C linker=rust-lld -C linker-flavor=ld.lld -C relocation-model=dynamic-no-pic -C link-arg=-nmagic -C link-arg=-icf=all  --remap-path-prefix=/Users/bradjc/git/tock/=
MAKEFLAGS                     =  -r -R
OBJDUMP_FLAGS                 = --disassemble-all --source --section-headers --demangle --arch-name=thumb
OBJCOPY_FLAGS                 = --strip-sections -S --remove-section .apps
CARGO_FLAGS                   =
CARGO_FLAGS_TOCK              = --verbose --target=thumbv7em-none-eabi --package hail --target-dir=/Users/bradjc/git/tock/target/
CARGO_FLAGS_TOCK_NO_BUILD_STD = --verbose --target=thumbv7em-none-eabi --package hail --target-dir=/Users/bradjc/git/tock/target/
SIZE_FLAGS                    =
CARGO_BLOAT_FLAGS             =

TOOLCHAIN                     = "/Users/bradjc/.rustup/toolchains/nightly-2021-05-27-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/bin/llvm"
SIZE                          = "/Users/bradjc/.rustup/toolchains/nightly-2021-05-27-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/bin/llvm"-size
OBJCOPY                       = "/Users/bradjc/.rustup/toolchains/nightly-2021-05-27-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/bin/llvm"-objcopy
OBJDUMP                       = "/Users/bradjc/.rustup/toolchains/nightly-2021-05-27-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/bin/llvm"-objdump
CARGO                         = cargo
RUSTUP                        = rustup
SHA256SUM                     = cargo run --manifest-path /Users/bradjc/git/tock/tools/sha256sum/Cargo.toml -- 2>/dev/null

cargo --version               = cargo 1.54.0-nightly (e931e4796 2021-05-24)
rustc --version               = rustc 1.54.0-nightly (9111b8ae9 2021-05-26)
info: This is the version for the rustup toolchain manager, not the rustc compiler.
info: The currently active `rustc` version is `rustc 1.54.0-nightly (9111b8ae9 2021-05-26)`
rustup --version              = rustup 1.24.3 (ce5817a94 2021-05-31)
*******************************************************
```

After:

```
*******************************************************
TOCK KERNEL BUILD SYSTEM -- VERBOSE BUILD CONFIGURATION
*******************************************************
MAKEFILE_COMMON_PATH          = /Users/bradjc/git/tock/boards/
TOCK_ROOT_DIRECTORY           = /Users/bradjc/git/tock/
TARGET_DIRECTORY              = /Users/bradjc/git/tock/target/

PLATFORM                      = hail
TARGET                        = thumbv7em-none-eabi
TOCK_KERNEL_VERSION           = release-1.6-2069-g7faa5231c
RUSTC_FLAGS                   = -C link-arg=-Tlayout.ld -C linker=rust-lld -C linker-flavor=ld.lld -C relocation-model=dynamic-no-pic -C link-arg=-nmagic -C link-arg=-icf=all
RUSTC_FLAGS_TOCK              = -C link-arg=-Tlayout.ld -C linker=rust-lld -C linker-flavor=ld.lld -C relocation-model=dynamic-no-pic -C link-arg=-nmagic -C link-arg=-icf=all  --remap-path-prefix=/Users/bradjc/git/tock/=
MAKEFLAGS                     =  -r -R
OBJDUMP_FLAGS                 = --disassemble-all --source --section-headers --demangle --arch-name=thumb
OBJCOPY_FLAGS                 = --strip-sections -S --remove-section .apps
CARGO_FLAGS                   =
CARGO_FLAGS_TOCK              = --verbose --target=thumbv7em-none-eabi --package hail --target-dir=/Users/bradjc/git/tock/target/
CARGO_FLAGS_TOCK_NO_BUILD_STD = --verbose --target=thumbv7em-none-eabi --package hail --target-dir=/Users/bradjc/git/tock/target/
SIZE_FLAGS                    =
CARGO_BLOAT_FLAGS             =

TOOLCHAIN                     = "/Users/bradjc/.rustup/toolchains/nightly-2021-05-27-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/bin/llvm"
SIZE                          = "/Users/bradjc/.rustup/toolchains/nightly-2021-05-27-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/bin/llvm"-size
OBJCOPY                       = "/Users/bradjc/.rustup/toolchains/nightly-2021-05-27-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/bin/llvm"-objcopy
OBJDUMP                       = "/Users/bradjc/.rustup/toolchains/nightly-2021-05-27-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/bin/llvm"-objdump
CARGO                         = cargo
RUSTUP                        = rustup
SHA256SUM                     = cargo run --manifest-path /Users/bradjc/git/tock/tools/sha256sum/Cargo.toml -- 2>/dev/null

cargo --version               = cargo 1.54.0-nightly (e931e4796 2021-05-24)
rustc --version               = rustc 1.54.0-nightly (9111b8ae9 2021-05-26)
rustup --version              = rustup 1.24.3 (ce5817a94 2021-05-31)
*******************************************************
```

### Testing Strategy

This pull request was tested by...


### TODO or Help Wanted

This pull request still needs...


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
