### PR TITLE
Move boards that have large main stack frames to get_peripherals

### DIFF
--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -207,7 +207,7 @@ unsafe fn set_pin_primary_functions(peripherals: &Sam4lDefaultPeripherals) {
 #[inline(never)]
 unsafe fn get_peripherals(
     pm: &'static sam4l::pm::PowerManager,
-) -> &'static mut Sam4lDefaultPeripherals {
+) -> &'static Sam4lDefaultPeripherals {
     static_init!(Sam4lDefaultPeripherals, Sam4lDefaultPeripherals::new(pm))
 }
 

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -201,6 +201,16 @@ unsafe fn set_pin_primary_functions(peripherals: &Sam4lDefaultPeripherals) {
     peripherals.pb[15].configure(None); //... D1
 }
 
+/// This is in a separate, inline(never) function so that its stack frame is
+/// removed when this function returns. Otherwise, the stack space used for
+/// these static_inits is wasted.
+#[inline(never)]
+unsafe fn get_peripherals(
+    pm: &'static sam4l::pm::PowerManager,
+) -> &'static mut Sam4lDefaultPeripherals {
+    static_init!(Sam4lDefaultPeripherals, Sam4lDefaultPeripherals::new(pm))
+}
+
 /// Board's main function.
 ///
 /// This is called from the reset handler after memory initialization is
@@ -208,8 +218,9 @@ unsafe fn set_pin_primary_functions(peripherals: &Sam4lDefaultPeripherals) {
 #[no_mangle]
 pub unsafe fn main() {
     sam4l::init();
+
     let pm = static_init!(sam4l::pm::PowerManager, sam4l::pm::PowerManager::new());
-    let peripherals = static_init!(Sam4lDefaultPeripherals, Sam4lDefaultPeripherals::new(pm));
+    let peripherals = get_peripherals(pm);
 
     pm.setup_system_clock(
         sam4l::pm::SystemClockSource::PllExternalOscillatorAt48MHz {

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -285,6 +285,16 @@ unsafe fn set_pin_primary_functions(peripherals: &Sam4lDefaultPeripherals) {
     peripherals.pc[31].configure(None); //... D2          -- GPIO Pin
 }
 
+/// This is in a separate, inline(never) function so that its stack frame is
+/// removed when this function returns. Otherwise, the stack space used for
+/// these static_inits is wasted.
+#[inline(never)]
+unsafe fn get_peripherals(
+    pm: &'static sam4l::pm::PowerManager,
+) -> &'static mut Sam4lDefaultPeripherals {
+    static_init!(Sam4lDefaultPeripherals, Sam4lDefaultPeripherals::new(pm))
+}
+
 /// Main function.
 ///
 /// This is called after RAM initialization is complete.
@@ -292,7 +302,7 @@ unsafe fn set_pin_primary_functions(peripherals: &Sam4lDefaultPeripherals) {
 pub unsafe fn main() {
     sam4l::init();
     let pm = static_init!(sam4l::pm::PowerManager, sam4l::pm::PowerManager::new());
-    let peripherals = static_init!(Sam4lDefaultPeripherals, Sam4lDefaultPeripherals::new(pm));
+    let peripherals = get_peripherals(pm);
 
     pm.setup_system_clock(
         sam4l::pm::SystemClockSource::PllExternalOscillatorAt48MHz {

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -291,7 +291,7 @@ unsafe fn set_pin_primary_functions(peripherals: &Sam4lDefaultPeripherals) {
 #[inline(never)]
 unsafe fn get_peripherals(
     pm: &'static sam4l::pm::PowerManager,
-) -> &'static mut Sam4lDefaultPeripherals {
+) -> &'static Sam4lDefaultPeripherals {
     static_init!(Sam4lDefaultPeripherals, Sam4lDefaultPeripherals::new(pm))
 }
 

--- a/boards/msp_exp432p401r/src/main.rs
+++ b/boards/msp_exp432p401r/src/main.rs
@@ -176,6 +176,17 @@ unsafe fn setup_adc_pins(gpio: &msp432::gpio::GpioManager) {
     // gpio.pins[PinNr::P08_2 as usize].enable_tertiary_function(); // A23
 }
 
+/// This is in a separate, inline(never) function so that its stack frame is
+/// removed when this function returns. Otherwise, the stack space used for
+/// these static_inits is wasted.
+#[inline(never)]
+unsafe fn get_peripherals() -> &'static mut msp432::chip::Msp432DefaultPeripherals<'static> {
+    static_init!(
+        msp432::chip::Msp432DefaultPeripherals,
+        msp432::chip::Msp432DefaultPeripherals::new()
+    )
+}
+
 /// Main function.
 ///
 /// This is called after RAM initialization is complete.
@@ -183,10 +194,7 @@ unsafe fn setup_adc_pins(gpio: &msp432::gpio::GpioManager) {
 pub unsafe fn main() {
     startup_intilialisation();
 
-    let peripherals = static_init!(
-        msp432::chip::Msp432DefaultPeripherals,
-        msp432::chip::Msp432DefaultPeripherals::new()
-    );
+    let peripherals = get_peripherals();
     peripherals.init();
 
     // Setup the GPIO pins to use the HFXT (high frequency external) oscillator (48MHz)

--- a/boards/pico_explorer_base/src/main.rs
+++ b/boards/pico_explorer_base/src/main.rs
@@ -228,13 +228,21 @@ fn init_clocks(peripherals: &Rp2040DefaultPeripherals) {
         .configure_peripheral(PeripheralAuxiliaryClockSource::System, 125000000);
 }
 
+/// This is in a separate, inline(never) function so that its stack frame is
+/// removed when this function returns. Otherwise, the stack space used for
+/// these static_inits is wasted.
+#[inline(never)]
+unsafe fn get_peripherals() -> &'static mut Rp2040DefaultPeripherals<'static> {
+    static_init!(Rp2040DefaultPeripherals, Rp2040DefaultPeripherals::new())
+}
+
 /// Main function called after RAM initialized.
 #[no_mangle]
 pub unsafe fn main() {
     // Loads relocations and clears BSS
     rp2040::init();
 
-    let peripherals = static_init!(Rp2040DefaultPeripherals, Rp2040DefaultPeripherals::new());
+    let peripherals = get_peripherals();
     peripherals.set_clocks();
 
     // Set the UART used for panic

--- a/boards/raspberry_pi_pico/src/main.rs
+++ b/boards/raspberry_pi_pico/src/main.rs
@@ -220,13 +220,21 @@ fn init_clocks(peripherals: &Rp2040DefaultPeripherals) {
         .configure_peripheral(PeripheralAuxiliaryClockSource::System, 125000000);
 }
 
+/// This is in a separate, inline(never) function so that its stack frame is
+/// removed when this function returns. Otherwise, the stack space used for
+/// these static_inits is wasted.
+#[inline(never)]
+unsafe fn get_peripherals() -> &'static mut Rp2040DefaultPeripherals<'static> {
+    static_init!(Rp2040DefaultPeripherals, Rp2040DefaultPeripherals::new())
+}
+
 /// Main function called after RAM initialized.
 #[no_mangle]
 pub unsafe fn main() {
     // Loads relocations and clears BSS
     rp2040::init();
 
-    let peripherals = static_init!(Rp2040DefaultPeripherals, Rp2040DefaultPeripherals::new());
+    let peripherals = get_peripherals();
 
     // Set the UART used for panic
     io::WRITER.set_uart(&peripherals.uart0);


### PR DESCRIPTION
### Pull Request Overview

Found using `make allstack`.


### Testing Strategy

compile


### TODO or Help Wanted

The RPi boards still have large main stack frames (although they are now the second largest).


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
