### PR TITLE
process: make ProcessFault a generic parameter

### DIFF
--- a/boards/acd52832/src/main.rs
+++ b/boards/acd52832/src/main.rs
@@ -592,7 +592,7 @@ pub unsafe fn main() {
             &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
         ),
         &mut PROCESSES,
-        &FAULT_RESPONSE,
+        FAULT_RESPONSE,
         &process_management_capability,
     )
     .unwrap_or_else(|err| {

--- a/boards/arty_e21/src/main.rs
+++ b/boards/arty_e21/src/main.rs
@@ -282,7 +282,7 @@ pub unsafe fn main() {
             &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
         ),
         &mut PROCESSES,
-        &FAULT_RESPONSE,
+        FAULT_RESPONSE,
         &process_mgmt_cap,
     )
     .unwrap_or_else(|err| {

--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -663,7 +663,7 @@ pub unsafe fn main() {
             &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
         ),
         &mut PROCESSES,
-        &FAULT_RESPONSE,
+        FAULT_RESPONSE,
         &process_management_capability,
     )
     .unwrap_or_else(|err| {

--- a/boards/earlgrey-nexysvideo/src/main.rs
+++ b/boards/earlgrey-nexysvideo/src/main.rs
@@ -545,7 +545,7 @@ unsafe fn setup() -> (
             &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
         ),
         &mut PROCESSES,
-        &FAULT_RESPONSE,
+        FAULT_RESPONSE,
         &process_mgmt_cap,
     )
     .unwrap_or_else(|err| {

--- a/boards/esp32-c3-devkitM-1/src/main.rs
+++ b/boards/esp32-c3-devkitM-1/src/main.rs
@@ -278,7 +278,7 @@ unsafe fn setup() -> (
             &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
         ),
         &mut PROCESSES,
-        &FAULT_RESPONSE,
+        FAULT_RESPONSE,
         &process_mgmt_cap,
     )
     .unwrap_or_else(|err| {

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -486,12 +486,6 @@ pub unsafe fn main() {
     // );
     // peripherals.pa[16].set_client(debug_process_restart);
 
-    // Configure application fault policy
-    let fault_policy = static_init!(
-        kernel::process::ThresholdRestartThenPanicFaultPolicy,
-        kernel::process::ThresholdRestartThenPanicFaultPolicy::new(4)
-    );
-
     let scheduler = components::sched::round_robin::RoundRobinComponent::new(&PROCESSES)
         .finalize(components::rr_component_helper!(NUM_PROCS));
 
@@ -554,7 +548,7 @@ pub unsafe fn main() {
             &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
         ),
         &mut PROCESSES,
-        fault_policy,
+        kernel::process::ThresholdRestartThenPanicFaultPolicy::new(4),
         &process_management_capability,
     )
     .unwrap_or_else(|err| {

--- a/boards/hifive1/src/main.rs
+++ b/boards/hifive1/src/main.rs
@@ -289,7 +289,7 @@ pub unsafe fn main() {
             &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
         ),
         &mut PROCESSES,
-        &FAULT_RESPONSE,
+        FAULT_RESPONSE,
         &process_mgmt_cap,
     )
     .unwrap_or_else(|err| {

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -712,7 +712,7 @@ pub unsafe fn main() {
             &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
         ),
         &mut PROCESSES,
-        &FAULT_RESPONSE,
+        FAULT_RESPONSE,
         &process_mgmt_cap,
     )
     .unwrap_or_else(|err| {

--- a/boards/imxrt1050-evkb/src/main.rs
+++ b/boards/imxrt1050-evkb/src/main.rs
@@ -503,7 +503,7 @@ pub unsafe fn main() {
             &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
         ),
         &mut PROCESSES,
-        &FAULT_RESPONSE,
+        FAULT_RESPONSE,
         &process_management_capability,
     )
     .unwrap_or_else(|err| {

--- a/boards/litex/arty/src/main.rs
+++ b/boards/litex/arty/src/main.rs
@@ -514,7 +514,7 @@ pub unsafe fn main() {
             &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
         ),
         &mut PROCESSES,
-        &FAULT_RESPONSE,
+        FAULT_RESPONSE,
         &process_mgmt_cap,
     )
     .unwrap_or_else(|err| {

--- a/boards/litex/sim/src/main.rs
+++ b/boards/litex/sim/src/main.rs
@@ -466,7 +466,7 @@ pub unsafe fn main() {
             &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
         ),
         &mut PROCESSES,
-        &FAULT_RESPONSE,
+        FAULT_RESPONSE,
         &process_mgmt_cap,
     )
     .unwrap_or_else(|err| {

--- a/boards/microbit_v2/src/main.rs
+++ b/boards/microbit_v2/src/main.rs
@@ -640,7 +640,7 @@ pub unsafe fn main() {
             &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
         ),
         &mut PROCESSES,
-        &FAULT_RESPONSE,
+        FAULT_RESPONSE,
         &process_management_capability,
     )
     .unwrap_or_else(|err| {

--- a/boards/msp_exp432p401r/src/main.rs
+++ b/boards/msp_exp432p401r/src/main.rs
@@ -457,7 +457,7 @@ pub unsafe fn main() {
             &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
         ),
         &mut PROCESSES,
-        &FAULT_RESPONSE,
+        FAULT_RESPONSE,
         &process_management_capability,
     )
     .unwrap();

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -616,7 +616,7 @@ pub unsafe fn main() {
             &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
         ),
         &mut PROCESSES,
-        &FAULT_RESPONSE,
+        FAULT_RESPONSE,
         &process_management_capability,
     )
     .unwrap_or_else(|err| {

--- a/boards/nano_rp2040_connect/src/main.rs
+++ b/boards/nano_rp2040_connect/src/main.rs
@@ -478,7 +478,7 @@ pub unsafe fn main() {
             &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
         ),
         &mut PROCESSES,
-        &FAULT_RESPONSE,
+        FAULT_RESPONSE,
         &process_management_capability,
     )
     .unwrap_or_else(|err| {

--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -436,7 +436,7 @@ pub unsafe fn main() {
             &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
         ),
         &mut PROCESSES,
-        &FAULT_RESPONSE,
+        FAULT_RESPONSE,
         &process_management_capability,
     )
     .unwrap_or_else(|err| {

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -706,7 +706,7 @@ pub unsafe fn main() {
             &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
         ),
         &mut PROCESSES,
-        &FAULT_RESPONSE,
+        FAULT_RESPONSE,
         &process_management_capability,
     )
     .unwrap_or_else(|err| {

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -469,7 +469,7 @@ pub unsafe fn main() {
             &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
         ),
         &mut PROCESSES,
-        &FAULT_RESPONSE,
+        FAULT_RESPONSE,
         &process_management_capability,
     )
     .unwrap_or_else(|err| {

--- a/boards/nucleo_f429zi/src/main.rs
+++ b/boards/nucleo_f429zi/src/main.rs
@@ -625,7 +625,7 @@ pub unsafe fn main() {
             &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
         ),
         &mut PROCESSES,
-        &FAULT_RESPONSE,
+        FAULT_RESPONSE,
         &process_management_capability,
     )
     .unwrap_or_else(|err| {

--- a/boards/nucleo_f446re/src/main.rs
+++ b/boards/nucleo_f446re/src/main.rs
@@ -413,7 +413,7 @@ pub unsafe fn main() {
             &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
         ),
         &mut PROCESSES,
-        &FAULT_RESPONSE,
+        FAULT_RESPONSE,
         &process_management_capability,
     )
     .unwrap_or_else(|err| {

--- a/boards/pico_explorer_base/src/main.rs
+++ b/boards/pico_explorer_base/src/main.rs
@@ -547,7 +547,7 @@ pub unsafe fn main() {
             &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
         ),
         &mut PROCESSES,
-        &FAULT_RESPONSE,
+        FAULT_RESPONSE,
         &process_management_capability,
     )
     .unwrap_or_else(|err| {

--- a/boards/raspberry_pi_pico/src/main.rs
+++ b/boards/raspberry_pi_pico/src/main.rs
@@ -478,7 +478,7 @@ pub unsafe fn main() {
             &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
         ),
         &mut PROCESSES,
-        &FAULT_RESPONSE,
+        FAULT_RESPONSE,
         &process_management_capability,
     )
     .unwrap_or_else(|err| {

--- a/boards/redboard_artemis_nano/src/main.rs
+++ b/boards/redboard_artemis_nano/src/main.rs
@@ -305,7 +305,7 @@ pub unsafe fn main() {
             &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
         ),
         &mut PROCESSES,
-        &FAULT_RESPONSE,
+        FAULT_RESPONSE,
         &process_mgmt_cap,
     )
     .unwrap_or_else(|err| {

--- a/boards/stm32f3discovery/src/main.rs
+++ b/boards/stm32f3discovery/src/main.rs
@@ -834,7 +834,7 @@ pub unsafe fn main() {
             &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
         ),
         &mut PROCESSES,
-        &FAULT_RESPONSE,
+        FAULT_RESPONSE,
         &process_management_capability,
     )
     .unwrap_or_else(|err| {

--- a/boards/stm32f412gdiscovery/src/main.rs
+++ b/boards/stm32f412gdiscovery/src/main.rs
@@ -860,7 +860,7 @@ pub unsafe fn main() {
             &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
         ),
         &mut PROCESSES,
-        &FAULT_RESPONSE,
+        FAULT_RESPONSE,
         &process_management_capability,
     )
     .unwrap_or_else(|err| {

--- a/boards/swervolf/src/main.rs
+++ b/boards/swervolf/src/main.rs
@@ -233,7 +233,7 @@ pub unsafe fn main() {
             &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
         ),
         &mut PROCESSES,
-        &FAULT_RESPONSE,
+        FAULT_RESPONSE,
         &process_mgmt_cap,
     )
     .unwrap_or_else(|err| {

--- a/boards/teensy40/src/main.rs
+++ b/boards/teensy40/src/main.rs
@@ -348,7 +348,7 @@ pub unsafe fn main() {
             &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
         ),
         &mut PROCESSES,
-        &FAULT_RESPONSE,
+        FAULT_RESPONSE,
         &process_management_capability,
     )
     .unwrap();

--- a/boards/weact_f401ccu6/src/main.rs
+++ b/boards/weact_f401ccu6/src/main.rs
@@ -472,7 +472,7 @@ pub unsafe fn main() {
             &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
         ),
         &mut PROCESSES,
-        &FAULT_RESPONSE,
+        FAULT_RESPONSE,
         &process_management_capability,
     )
     .unwrap_or_else(|err| {

--- a/kernel/src/process_policies.rs
+++ b/kernel/src/process_policies.rs
@@ -11,13 +11,14 @@ use crate::process::Process;
 ///
 /// Implementations can use the `Process` reference to decide which action to
 /// take. Implementations can also use `debug!()` to print messages if desired.
-pub trait ProcessFaultPolicy {
+pub trait ProcessFaultPolicy: Copy {
     /// Decide which action the kernel should take in response to `process`
     /// faulting.
     fn action(&self, process: &dyn Process) -> process::FaultAction;
 }
 
 /// Simply panic the entire board if a process faults.
+#[derive(Copy, Clone)]
 pub struct PanicFaultPolicy {}
 
 impl ProcessFaultPolicy for PanicFaultPolicy {
@@ -27,6 +28,7 @@ impl ProcessFaultPolicy for PanicFaultPolicy {
 }
 
 /// Simply stop the process and no longer schedule it if a process faults.
+#[derive(Copy, Clone)]
 pub struct StopFaultPolicy {}
 
 impl ProcessFaultPolicy for StopFaultPolicy {
@@ -38,6 +40,7 @@ impl ProcessFaultPolicy for StopFaultPolicy {
 /// Stop the process and no longer schedule it if a process faults, but also
 /// print a debug message notifying the user that the process faulted and
 /// stopped.
+#[derive(Copy, Clone)]
 pub struct StopWithDebugFaultPolicy {}
 
 impl ProcessFaultPolicy for StopWithDebugFaultPolicy {
@@ -51,6 +54,7 @@ impl ProcessFaultPolicy for StopWithDebugFaultPolicy {
 }
 
 /// Always restart the process if it faults.
+#[derive(Copy, Clone)]
 pub struct RestartFaultPolicy {}
 
 impl ProcessFaultPolicy for RestartFaultPolicy {
@@ -63,6 +67,7 @@ impl ProcessFaultPolicy for RestartFaultPolicy {
 /// whether to restart a process when it faults. If the process has been
 /// restarted more times than the threshold then the process will be stopped
 /// and no longer scheduled.
+#[derive(Copy, Clone)]
 pub struct ThresholdRestartFaultPolicy {
     threshold: usize,
 }
@@ -86,6 +91,7 @@ impl ProcessFaultPolicy for ThresholdRestartFaultPolicy {
 /// Implementation of `ProcessFaultPolicy` that uses a threshold to decide
 /// whether to restart a process when it faults. If the process has been
 /// restarted more times than the threshold then the board will panic.
+#[derive(Copy, Clone)]
 pub struct ThresholdRestartThenPanicFaultPolicy {
     threshold: usize,
 }

--- a/kernel/src/process_utilities.rs
+++ b/kernel/src/process_utilities.rs
@@ -125,13 +125,13 @@ impl fmt::Debug for ProcessLoadError {
 /// Returns `Ok(())` if process discovery went as expected. Returns a
 /// `ProcessLoadError` if something goes wrong during TBF parsing or process
 /// creation.
-pub fn load_processes<C: Chip>(
+pub fn load_processes<C: Chip, PF: 'static + ProcessFaultPolicy>(
     kernel: &'static Kernel,
     chip: &'static C,
     app_flash: &'static [u8],
     app_memory: &mut [u8], // not static, so that process.rs cannot hold on to slice w/o unsafe
     procs: &'static mut [Option<&'static dyn Process>],
-    fault_policy: &'static dyn ProcessFaultPolicy,
+    fault_policy: PF,
     _capability: &dyn ProcessManagementCapability,
 ) -> Result<(), ProcessLoadError> {
     if config::CONFIG.debug_load_processes {


### PR DESCRIPTION
Instead of using dynamic dispatching for `ProcessFault`, use a generic parameter. Most times the `ProcessFault` struct is a 0-sized struct and will not take up any space. A few instances of `ProcessFault` have a usize field, which is still less than a trait object (2 words minimum).

Final images will only call load_process once, so we don't get bloat from monomorphism either.

### Documentation Updated

None

### Formatting

- [x] Ran `make prepush`.
