### PR TITLE
[rp2040] Use clocks frequency to set UART baud rate

### DIFF
--- a/chips/rp2040/src/chip.rs
+++ b/chips/rp2040/src/chip.rs
@@ -144,6 +144,7 @@ impl<'a> Rp2040DefaultPeripherals<'a> {
 
     pub fn set_clocks(&'a self) {
         self.spi0.set_clocks(&self.clocks);
+        self.uart0.set_clocks(&self.clocks);
     }
 }
 


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes the RP2040's UART baud rate setup function so that it uses the clock speed instead of a constant value.

### Testing Strategy

N/A

### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
