### PR TITLE
Process console: iterate each process on command `list`

### DIFF
--- a/capsules/src/process_console.rs
+++ b/capsules/src/process_console.rs
@@ -160,6 +160,7 @@ enum WriterState {
     ProcessStackUnused { process_id: ProcessId },
     ProcessFlash { process_id: ProcessId },
     ProcessProtected { process_id: ProcessId },
+    List { index: isize, total: isize },
 }
 
 impl Default for WriterState {
@@ -335,6 +336,18 @@ impl<'a, C: ProcessManagementCapability> ProcessConsole<'a, C> {
                 WriterState::ProcessProtected { process_id }
             }
             WriterState::ProcessProtected { process_id: _ } => WriterState::Empty,
+            WriterState::List { index, total } => {
+                // Next state just increments index, unless we are at end in
+                // which next state is just the empty state.
+                if index + 1 == total {
+                    WriterState::Empty
+                } else {
+                    WriterState::List {
+                        index: index + 1,
+                        total,
+                    }
+                }
+            }
             WriterState::Empty => WriterState::Empty,
         }
     }
@@ -758,6 +771,39 @@ impl<'a, C: ProcessManagementCapability> ProcessConsole<'a, C> {
                         }
                     });
             }
+            WriterState::List { index, total: _ } => {
+                let mut local_index = 0;
+                self.kernel
+                    .process_each_capability(&self.capability, |process| {
+                        // local_index += 1;
+                        // if local_index == index {
+                        let info: KernelInfo = KernelInfo::new(self.kernel);
+
+                        let pname = process.get_process_name();
+                        let process_id = process.processid();
+                        let (grants_used, grants_total) =
+                            info.number_app_grant_uses(process_id, &self.capability);
+                        let mut console_writer = ConsoleWriter::new();
+                        let _ = write(
+                            &mut console_writer,
+                            format_args!(
+                                "  {:?}\t{:<20}{:6}{:10}{:19}{:10}  {:?}{:5}/{}\n",
+                                process_id,
+                                pname,
+                                process.debug_timeslice_expiration_count(),
+                                process.debug_syscall_count(),
+                                process.debug_dropped_upcall_count(),
+                                process.get_restart_count(),
+                                process.get_state(),
+                                grants_used,
+                                grants_total
+                            ),
+                        );
+
+                        let _ = self.write_bytes(&(console_writer.buf)[..console_writer.size]);
+                        // }
+                    });
+            }
             _ => {}
         }
     }
@@ -853,37 +899,10 @@ impl<'a, C: ProcessManagementCapability> ProcessConsole<'a, C> {
                             let _ = self.write_bytes(b" PID    Name                Quanta  ");
                             let _ = self.write_bytes(b"Syscalls  Dropped Callbacks  ");
                             let _ = self.write_bytes(b"Restarts    State  Grants\n");
-                            // self.write_state(WriterState::ProcessStart {
-                            //     process_id: proc.processid(),
-                            // });
-                            self.kernel
-                                .process_each_capability(&self.capability, |proc| {
-                                    let info: KernelInfo = KernelInfo::new(self.kernel);
-
-                                    let pname = proc.get_process_name();
-                                    let process_id = proc.processid();
-                                    let (grants_used, grants_total) =
-                                        info.number_app_grant_uses(process_id, &self.capability);
-                                    let mut console_writer = ConsoleWriter::new();
-                                    let _ = write(
-                                        &mut console_writer,
-                                        format_args!(
-                                            "  {:?}\t{:<20}{:6}{:10}{:19}{:10}  {:?}{:5}/{}\n",
-                                            process_id,
-                                            pname,
-                                            proc.debug_timeslice_expiration_count(),
-                                            proc.debug_syscall_count(),
-                                            proc.debug_dropped_upcall_count(),
-                                            proc.get_restart_count(),
-                                            proc.get_state(),
-                                            grants_used,
-                                            grants_total
-                                        ),
-                                    );
-
-                                    let _ = self
-                                        .write_bytes(&(console_writer.buf)[..console_writer.size]);
-                                });
+                            self.write_state(WriterState::List {
+                                index: -1,
+                                total: 3,
+                            });
                         } else if clean_str.starts_with("status") {
                             let info: KernelInfo = KernelInfo::new(self.kernel);
                             let mut console_writer = ConsoleWriter::new();


### PR DESCRIPTION
### Pull Request Overview

If a board has many process loaded then the process console list command looks like:

```
list
 PID    Name                Quanta  Syscalls  Dropped Callbacks  Restarts    State  Grants
  0	blink                    0        66                  0         0  Yielded    1/14
  1	c_hello                  0         8                  0         0  Yielded    1/14
  2	buttons                  0         7                  0         0
```
because the buffer fills up and printing stops.

This PR attempts to move the `list` command to an async command and have each process print on its own UART tx callback cycle. To do that I had to update the logic a little, as it seemed to assume the callbacks would only be used for printing callback state.

Now it looks like:

```
list
 PID    Name                Quanta  Syscalls  Dropped Callbacks  Restarts    State  Grants
  0	blink                    0      1002                  0         0  Yielded    1/14
  1	c_hello                  0         8                  0         0  Yielded    1/14
  2	buttons                  0         7                  0         0  Yielded    1/14
  3	blink                    0      1002                  0         0  Yielded    1/14
```


### Testing Strategy

This pull request was tested by...


### TODO or Help Wanted

This pull request still needs...


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
