### PR TITLE
kernel: use mutable closure on `process_each` and `process_each_capability`

### DIFF
--- a/kernel/src/kernel.rs
+++ b/kernel/src/kernel.rs
@@ -186,9 +186,9 @@ impl Kernel {
 
     /// Run a closure on every valid process. This will iterate the array of
     /// processes and call the closure on every process that exists.
-    pub(crate) fn process_each<F>(&self, closure: F)
+    pub(crate) fn process_each<F>(&self, mut closure: F)
     where
-        F: Fn(&dyn process::Process),
+        F: FnMut(&dyn process::Process),
     {
         for process in self.processes.iter() {
             match process {
@@ -224,9 +224,9 @@ impl Kernel {
     pub fn process_each_capability<F>(
         &'static self,
         _capability: &dyn capabilities::ProcessManagementCapability,
-        closure: F,
+        mut closure: F,
     ) where
-        F: Fn(&dyn process::Process),
+        F: FnMut(&dyn process::Process),
     {
         for process in self.processes.iter() {
             match process {


### PR DESCRIPTION
### Pull Request Overview

I do not know the implications of this change, but it is necessary for #2720 so that the closure can modify local variables outside of the closure in each iteration.


### Testing Strategy

Working on the process console.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
