### PR TITLE
arch: cortex-m: defend against large stack pointer

### DIFF
--- a/arch/cortex-m/src/syscall.rs
+++ b/arch/cortex-m/src/syscall.rs
@@ -103,10 +103,9 @@ impl kernel::syscall::UserspaceKernelBoundary for SysCall {
         // bottom the SVC structure on the stack)
 
         // First, we need to validate that this location is inside of the
-        // process's accessible memory.
+        // process's accessible memory. Alignment is guaranteed by hardware.
         if state.psp < accessible_memory_start as usize
             || state.psp.saturating_add(mem::size_of::<u32>() * 4) > app_brk as usize
-            || state.psp % 4 != 0
         {
             return Err(());
         }
@@ -156,11 +155,10 @@ impl kernel::syscall::UserspaceKernelBoundary for SysCall {
         state: &mut CortexMStoredState,
         callback: kernel::process::FunctionCall,
     ) -> Result<(), ()> {
-        // Ensure that [`state.psp`, `state.psp + SVC_FRAME_SIZE`] is
-        // within process-accessible memory.
+        // Ensure that [`state.psp`, `state.psp + SVC_FRAME_SIZE`] is within
+        // process-accessible memory. Alignment is guaranteed by hardware.
         if state.psp < accessible_memory_start as usize
             || state.psp.saturating_add(SVC_FRAME_SIZE) > app_brk as usize
-            || state.psp % 4 != 0
         {
             return Err(());
         }
@@ -192,10 +190,10 @@ impl kernel::syscall::UserspaceKernelBoundary for SysCall {
         state.psp = new_stack_pointer as usize;
 
         // We need to validate that the stack pointer and the SVC frame are
-        // within process accessible memory.
+        // within process accessible memory. Alignment is guaranteed by
+        // hardware.
         let invalid_stack_pointer = state.psp < accessible_memory_start as usize
-            || state.psp.saturating_add(SVC_FRAME_SIZE) > app_brk as usize
-            || state.psp % 4 != 0;
+            || state.psp.saturating_add(SVC_FRAME_SIZE) > app_brk as usize;
 
         // Determine why this returned and the process switched back to the
         // kernel.
@@ -261,10 +259,10 @@ impl kernel::syscall::UserspaceKernelBoundary for SysCall {
         state: &CortexMStoredState,
         writer: &mut dyn Write,
     ) {
-        // Check if the stored stack pointer is valid.
+        // Check if the stored stack pointer is valid. Alignment is guaranteed
+        // by hardware.
         let invalid_stack_pointer = state.psp < accessible_memory_start as usize
-            || state.psp.saturating_add(SVC_FRAME_SIZE) > app_brk as usize
-            || state.psp % 4 != 0;
+            || state.psp.saturating_add(SVC_FRAME_SIZE) > app_brk as usize;
 
         let stack_pointer = state.psp as *const usize;
 


### PR DESCRIPTION
If the stack pointer is really large the sp + frame_size arithmetic can overflow, negating the check. Use .saturating_add() instead.

In the print context function rather than returning we now use dummy values so the user still gets the register printout for what _is_ valid.

Also check for 4 byte alignment. I think that is a good idea.

I found this by playing with the new tockloader features: `tockloader tbf-delete-tlv 8` and `tockloader tbf-modify-tlv 1 init_fn_offset 53`. I found that if I corrupted the init fn offset in the right way I got a kernel crash.


### Testing Strategy

Running c_hello with a corrupted init fn offset and verifying the printout works as expected. Looks like:

```
Initialization complete. Entering main loop.
Kernel version: release-2.0-rc1
Welcome to the process console.
Valid commands are: help status list stop start fault process kernel

panicked at 'Process c_hello had a fault', kernel/src/process_standard.rs:323:17
	Kernel version release-2.0-rc1

---| No debug queue found. You can set it with the DebugQueue component.

---| Cortex-M Fault Status |---
Data Access Violation:              true
Memory Management Stacking Fault:   true
Bus Unstacking Fault:               true
Forced Hard Fault:                  true
Faulting Memory Address:            0xFFFFFFF8
Fault Status Register (CFSR):       0x00000892
Hard Fault Status Register (HFSR):  0x40000000

---| App Status |---
𝐀𝐩𝐩: c_hello   -   [Faulted]
 Events Queued: 0   Syscall Count: 3   Dropped Upcall Count: 0
 Restart Count: 5
 Last Syscall: Some(Memop { operand: 11, arg0: 536898052 })


 ╔═══════════╤══════════════════════════════════════════╗
 ║  Address  │ Region Name    Used | Allocated (bytes)  ║
 ╚0x20008000═╪══════════════════════════════════════════╝
             │ ▼ Grant        1120 |   1120
  0x20007BA0 ┼───────────────────────────────────────────
             │ Unused
  0x20006A04 ┼───────────────────────────────────────────
             │ ▲ Heap            0 |   4508               S
  0x20006A04 ┼─────────────────────────────────────────── R
             │ Data              ? |      ?               A
  ?????????? ┼─────────────────────────────────────────── M
             │ ▼ Stack           ? |      ?
  0x20006000 ┼───────────────────────────────────────────
             │ Unused
  0x20006000 ┴───────────────────────────────────────────
             .....
  0x00030800 ┬─────────────────────────────────────────── F
             │ App Flash      1996                        L
  0x00030034 ┼─────────────────────────────────────────── A
             │ Protected        52                        S
  0x00030000 ┴─────────────────────────────────────────── H

  R0 : 0xBAD00BAD    R6 : 0x00030034
  R1 : 0xBAD00BAD    R7 : 0x20006000
  R2 : 0xBAD00BAD    R8 : 0x00000000
  R3 : 0xBAD00BAD    R10: 0x00000000
  R4 : 0x00000000    R11: 0x00000000
  R5 : 0x00000000    R12: 0xBAD00BAD
  R9 : 0x20006800 (Static Base Register)
  SP : 0xFFFFFFE0 (Process Stack Pointer)
  LR : 0xBAD00BAD
  PC : 0xBAD00BAD
 YPC : 0x0003008E

 APSR: N 1 Z 0 C 1 V 1 Q 1
       GE 0 0 0 0
 EPSR: ICI.IT 0x42
       ThumbBit false !!ERROR - Cortex M Thumb only!

 Total number of grant regions defined: 14
  Grant  0 : --          Grant  5 : --          Grant 10 : --
  Grant  1 : --          Grant  6 : --          Grant 11 : --
  Grant  2 : --          Grant  7 : --          Grant 12 : --
  Grant  3 : --          Grant  8 : --          Grant 13 : --
  Grant  4 : --          Grant  9 : --

 Cortex-M MPU
  Region 0: [0x20006000:0x20008000], length: 8192 bytes; ReadWrite (0x3)
    Sub-region 0: [0x20006000:0x20006400], Enabled
    Sub-region 1: [0x20006400:0x20006800], Enabled
    Sub-region 2: [0x20006800:0x20006C00], Enabled
    Sub-region 3: [0x20006C00:0x20007000], Disabled
    Sub-region 4: [0x20007000:0x20007400], Disabled
    Sub-region 5: [0x20007400:0x20007800], Disabled
    Sub-region 6: [0x20007800:0x20007C00], Disabled
    Sub-region 7: [0x20007C00:0x20008000], Disabled
  Region 1: [0x00030000:0x00030800], length: 2048 bytes; UnprivilegedReadOnly (0x2)
    Sub-region 0: [0x00030000:0x00030100], Enabled
    Sub-region 1: [0x00030100:0x00030200], Enabled
    Sub-region 2: [0x00030200:0x00030300], Enabled
    Sub-region 3: [0x00030300:0x00030400], Enabled
    Sub-region 4: [0x00030400:0x00030500], Enabled
    Sub-region 5: [0x00030500:0x00030600], Enabled
    Sub-region 6: [0x00030600:0x00030700], Enabled
    Sub-region 7: [0x00030700:0x00030800], Enabled
  Region 2: Unused
  Region 3: Unused
  Region 4: Unused
  Region 5: Unused
  Region 6: Unused
  Region 7: Unused

To debug, run `make debug RAM_START=0x20006000 FLASH_INIT=0x30069`
in the app's folder and open the .lst file.
```


### TODO or Help Wanted

Should we check for 4 byte alignment?


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
