### PR TITLE
First step on SPI documentation

### DIFF
--- a/doc/reference/trd-spi.md
+++ b/doc/reference/trd-spi.md
@@ -6,9 +6,9 @@ Kernel Serial Peripheral Interface (SPI) HIL
 **Type:** Documentary<br/>
 **Status:** Draft <br/>
 **Author:** Philip Levis, Alexandru Radovici<br/>
-**Draft-Created:** 2021/08/02 <br/>
-**Draft-Modified:** 2021/08/02 <br/>
-**Draft-Version:** 1 <br/>
+**Draft-Created:** 2021/08/13 <br/>
+**Draft-Modified:** 2021/08/13 <br/>
+**Draft-Version:** 2 <br/>
 **Draft-Discuss:** tock-dev@googlegroups.com<br/>
 
 Abstract
@@ -26,44 +26,64 @@ of Tock -- this is a working document as the HIL is designed.
 1 Introduction
 ===============================
 
-The serial peripheral interface (SPI) is a standard bus design for processors 
-and microcontrollers to exchange data with sensors, I/O devices, and other 
-off-chip compoments. The bus is clocked. The device driving the clock is
-called a "master" or "controller" and the device whose clock is driven
-is called a "slave" or "peripheral". A SPI bus has three data lines: the clock (CLK), 
-data from the controller to the peripheral (MOSI) and data from the peripheral
-to the controller (MISO). A SPI bus does not have addressing. Instead, peripherals
-have a chip select (CS) pin. When a peripheral's chip select line is brought low,
-it receives data on MOSI and sends data on MISO. A controller can connect
-to CS pins on many different devices and share the bus between them by explicitly
-controlling which ones are active.
+The serial peripheral interface (SPI) is a standard bus design for
+processors and microcontrollers to exchange data with sensors, I/O
+devices, and other off-chip compoments. The bus is clocked. The device
+driving the clock is called a "master" or "controller" and the device
+whose clock is driven is called a "slave" or "peripheral". A SPI bus
+has three data lines: the clock (CLK), data from the controller to the
+peripheral (MOSI) and data from the peripheral to the controller
+(MISO). A SPI bus does not have addressing. Instead, peripherals have
+a chip select (CS) pin. When a peripheral's chip select line is
+brought low, it receives data on MOSI and sends data on MISO. A
+controller can connect to CS pins on many different devices and share
+the bus between them by explicitly controlling which ones are active.
 
 The SPI HIL is in the kernel crate, in module `hil::spi`. It provides seven main
 traits:
 
-  * `kernel::hil::spi::Configure`: provides an abstraction of configuring a SPI bus by setting its data rate, phase, and polarity.
-  * `kernel::hil::spi::Controller`: allows a client for a SPI in controller mode to send and receive data.
-  * `kernel::hil::spi::ControllerDevice`: combines `Configure` and `Controller` to provide an abstraction of a SPI bus in controller mode for a client that is bound to a specific chip select (e.g., a sensor driver). It allows a client to send and receive data as well as configure the bus for (only) its own operations.
-  * `kernel::hil::spi::ChipSelect`: allows a client to change which chip select is active on a SPI bus in controller mode.
-  * `kernel::hil::spi::ControllerBus`: combines `ControllerDevice` and `ChipSelect` to allow a client to issue SPI operations on any chip select. It also supports initializing the bus hardware. This trait is intended to be implemented by a chip implementation.
-  * `kernel::hil::spi::PeripheralDevice`: extends `Configure` and provides an abstraction of a SPI bus in peripheral mode. It allows a client to learn when it is selected, to send and receive data, and  configure the bus for its own operations.
-  * `kernel::hil::spi::PeripheralBus`: extends `PeripheralDevice` to support initializing the bus hardware. This trait is intended to be implemented by a chip peripheral implementation.
-  * `kernel::hil::spi::Bus`: represents a SPI bus that can be dynamically changed between controller and peripheral modes. This trait is intended to be implemented by a chip implementation.
+  * `kernel::hil::spi::Configure`: provides an abstraction of
+    configuring a SPI bus by setting its data rate, phase, and
+    polarity.
+  * `kernel::hil::spi::Controller`: allows a client for a SPI in
+    controller mode to send and receive data.
+  * `kernel::hil::spi::ControllerDevice`: combines `Configure` and
+    `Controller` to provide an abstraction of a SPI bus in controller
+    mode for a client that is bound to a specific chip select (e.g., a
+    sensor driver). It allows a client to send and receive data as
+    well as configure the bus for (only) its own operations.
+  * `kernel::hil::spi::ChipSelect`: allows a client to change which
+    chip select is active on a SPI bus incontroller mode.
+  * `kernel::hil::spi::ControllerBus`: combines `ControllerDevice` and
+    `ChipSelect` to allow a client to issue SPI operations on any chip
+    select. It also supports initializing the bus hardware. This trait
+    is intended to be implemented by a chip implementation.
+  * `kernel::hil::spi::PeripheralDevice`: extends `Configure` and
+    provides an abstraction of a SPI bus in peripheral mode. It allows
+    a client to learn when it is selected, to send and receive data,
+    and configure the bus for its own operations.
+  * `kernel::hil::spi::PeripheralBus`: extends `PeripheralDevice` to
+    support initializing the bus hardware. This trait is intended to
+    be implemented by a chip peripheral implementation.
+  * `kernel::hil::spi::Bus`: represents a SPI bus that can be
+    dynamically changed between controller and peripheral modes. This
+    trait is intended to be implemented by a chip implementation.
 
-A given board MUST NOT include an implementation of more than one of the 
-`ControllerBus`, `PeripheralBus`, and `Bus` traits for a given SPI bus. these
-traits are mutually exclusive.
+A given board MUST NOT include an implementation of more than one of
+the `ControllerBus`, `PeripheralBus`, and `Bus` traits for a given SPI
+bus. these traits are mutually exclusive.
 
 This document describes these traits and their semantics.
 
 2 `Configure` trait
 ===============================
 
-The `Configure` trait allows a client to set the data rate (clock frequency) of
-the SPI bus as well as its polarity and phase. Polarity controls whether the clock
-line is high or low when the bus is idle. Phase controls on which clock edges
-the bus clocks data in and out. It also allows configuring whether data is sent
-most significant bit first or least significant bit first.
+The `Configure` trait allows a client to set the data rate (clock
+frequency) of the SPI bus as well as its polarity and phase. Polarity
+controls whether the clock line is high or low when the bus is
+idle. Phase controls on which clock edges the bus clocks data in and
+out. It also allows configuring whether data is sent most significant
+bit first or least significant bit first.
 
 ```rust
 pub enum DataOrder {
@@ -98,17 +118,24 @@ pub trait Configure {
 
 All of the set methods in `Configure` can return an error. Valid errors are:
   - INVAL (`set_rate` only): the parameter is outside the allowed range
-  - NOSUPPORT (`set_polarity`, `set_phase`, `set_data_order`): the parameter provided cannot be supported. For example, a SPI bus that cannot have an `IdleHigh` polarity returns NOSUPPORT if a client tries to set it to have this polarity.
-  - OFF (all): the bus is currently powered down in a state that does not allow configuring it.
-  - BUSY (all): the bus is in the midst of an operation and cannot currently change its configuration.
+  - NOSUPPORT (`set_polarity`, `set_phase`, `set_data_order`): the
+    parameter provided cannot be supported. For example, a SPI bus
+    that cannot have an `IdleHigh` polarity returns NOSUPPORT if a
+    client tries to set it to have this polarity.
+  - OFF (all): the bus is currently powered down in a state that does
+    not allow configuring it.
+  - BUSY (all): the bus is in the midst of an operation and cannot
+    currently change its configuration.
   - FAIL (all): some other error occurred.
 
-The `set_rate` method returns a `u32` in its success case. This is the actual data
-rate set, which may differ from the one passed, e.g., due to clock precision or
-prescalars. The actual rate rate set MUST be less than the `rate` passed. If no
-rate can be set (e.g., the `rate` is too small), `set_rate` MUST return `Err(INVAL)`.
+The `set_rate` method returns a `u32` in its success case. This is the
+actual data rate set, which may differ from the one passed, e.g., due
+to clock precision or prescalars. The actual rate rate set MUST be
+less than the `rate` passed. If no rate can be set (e.g., the `rate`
+is too small), `set_rate` MUST return `Err(INVAL)`.
 
-The relationship of phase and polarity follows the standard SPI specification[1]:
+The relationship of phase and polarity follows the standard SPI
+specification[1]:
 
 +------------+------------------+-------------+----------------+----------------+
 |  Polarity  |      Phase       |  Idle Level |    Data Out    |     Data In    |
@@ -119,8 +146,9 @@ The relationship of phase and polarity follows the standard SPI specification[1]
 |  IdleHigh  |  SampleTrailing  |     High    |  Falling Edge  |  Falling Edge  |
 +------------+------------------+-------------+----------------+----------------+
 
-If the SPI bus is in the middle an outstanding operation (`Controller::read_write_bytes`
-or `Peripheral::read_write_bytes`), calls to `Configure` to set values MUST return BUSY.
+If the SPI bus is in the middle an outstanding operation
+(`Controller::read_write_bytes` or `Peripheral::read_write_bytes`),
+calls to `Configure` to set values MUST return BUSY.
 
 3 `Controller`, `ControllerDevice`, and `ControllerClient` traits
 ===============================
@@ -150,40 +178,39 @@ pub trait ControllerClient<'a> {
 }
 ```
 
-The `read_write_bytes` method always takes a buffer to write and has an 
-optional buffer to read into. For operations that do not need to read from
-the SPI peripheral, the `read_buffer` can be `None`.
+The `read_write_bytes` method always takes a buffer to write and has
+an optional buffer to read into. For operations that do not need to
+read from the SPI peripheral, the `read_buffer` can be `None`.
 
-The length of the SPI operation is the minimum of 3 values: the length of 
-`write_buffer`, the `len` argument and, the length of `read_buffer` argument if it is
-`Some`. If `read_buffer` is `None` it does not affect the length of the operation.
-
-If the call to `read_write_bytes` returns `Ok(())`, the implementation MUST issue
-a callback to the `SpiControllerClient` when it completes. If the call returns
-an `Err`, the implementation MUST NOT issue a callback, except if the `ErrorCode` is
-`BUSY`. In this case, the implementation issues a callback for the outstanding
-operation but does not issue a callback for the failed one. If it returns `Err`,
-the implementation MUST return the buffers passed in the call. Valid `ErrorCode`
-values for an `Err` result are:
-  - BUSY: the SPI is busy with another call to `read_write_bytes` and so cannot
-    complete the request.
+If the call to `read_write_bytes` returns `Ok(())`, the implementation
+MUST issue a callback to the `SpiControllerClient` when it
+completes. If the call returns an `Err`, the implementation MUST NOT
+issue a callback, except if the `ErrorCode` is `BUSY`. In this case,
+the implementation issues a callback for the outstanding operation but
+does not issue a callback for the failed one. If it returns `Err`, the
+implementation MUST return the buffers passed in the call. Valid
+`ErrorCode` values for an `Err` result are:
+  - BUSY: the SPI is busy with another call to `read_write_bytes` and
+    so cannot complete the request.
   - OFF: the SPI is off and cannot accept a request.
   - INVAL: the length value is 0, or one of the buffers passed has length 0.
   - RESERVE: there is no client for a callback.
+  - `SIZE`: one of the buffers passed is smaller than `len`: `len` bytes
+  cannot be transferred.
   - FAIL: some other failure condition.
 
-The `set_client` method sets which callback to invoke when a `read_write_bytes`
-call completes. The `read_write_done` callback MUST return the buffers passed
-in the call to `read_write_bytes`. The `len` argument is the number of bytes
-read/written: it may differ from the `len` argument in `read_write_bytes` if
-one of the buffers was smaller than the call argument. The `status` argument
-indicates whether the SPI operation completed successfully. It may return any
-of the `ErrorCode` values that can be returned by `read_write_bytes`: these
-represent asynchronous errors (e.g., due to queueing).
+The `set_client` method sets which callback to invoke when a
+`read_write_bytes` call completes. The `read_write_done` callback MUST
+return the buffers passed in the call to `read_write_bytes`. The `len`
+argument is the number of bytes read/written. The `status` argument
+indicates whether the SPI operation completed successfully. It may
+return any of the `ErrorCode` values that can be returned by
+`read_write_bytes`: these represent asynchronous errors (e.g., due to
+queueing).
 
-The `ControllerDevice` trait combines `Controller` and `Configure` traits.
-It provides the abstraction of being able to read/write to the bus and
-adjust its configuration.
+The `ControllerDevice` trait combines `Controller` and `Configure`
+traits.  It provides the abstraction of being able to read/write to
+the bus and adjust its configuration.
 
 ```rust
 pub trait ControllerDevice<'a>: Controller<'a> + Configure<'a> {}
@@ -193,10 +220,11 @@ pub trait ControllerDevice<'a>: Controller<'a> + Configure<'a> {}
 ===============================
 
 The `ChipSelect` trait allows a client to change which chip select is
-active on the SPI bus. Because different SPI hardware can provide different
-numbers of chip selects, the actual chip select value is an associated
-type. This associated type is typically an `enum` so a chip implementation
-can statically verify that clients pass only valid chip select values.
+active on the SPI bus. Because different SPI hardware can provide
+different numbers of chip selects, the actual chip select value is an
+associated type. This associated type is typically an `enum` so a chip
+implementation can statically verify that clients pass only valid chip
+select values.
 
 ```rust
 pub trait ChipSelect {
@@ -206,12 +234,12 @@ pub trait ChipSelect {
 }
 ```
 
-The `ControllerBus` trait combines `ControllerDevice` and `ChipSelect` to
-provide the full abstraction of a SPI bus. It is the trait that chip
-SPI implementations provide. In addition to `ControllerDevice` and
-`ChipSelect`, `ControllerBus` includes an `init` method. This `init`
-method initializes the hardware to be a SPI controller and is typically
-called at boot.
+The `ControllerBus` trait combines `ControllerDevice` and `ChipSelect`
+to provide the full abstraction of a SPI bus. It is the trait that
+chip SPI implementations provide. In addition to `ControllerDevice`
+and `ChipSelect`, `ControllerBus` includes an `init` method. This
+`init` method initializes the hardware to be a SPI controller and is
+typically called at boot.
 
 ```rust
 pub trait ControllerBus<'a>: ControllerDevice<'a> + ChipSelect {
@@ -224,11 +252,11 @@ The `Err` result of `init` can return the following `ErrorCode` values:
   - RESERVE: no clock is configured yet.
   - FAIL: other failure condition.
 
-A client using a `ControllerBus` can exchange data with multiple SPI 
-peripherals, switching between them with `ChipSelect`. Calls to `Configure` 
-modify the configuration of the current chip select, which are stateful. 
-Changing the chip select uses the last configuration set for *that* chip select.
-For example,
+A client using a `ControllerBus` can exchange data with multiple SPI
+peripherals, switching between them with `ChipSelect`. Calls to
+`Configure` modify the configuration of the current chip select, which
+are stateful.  Changing the chip select uses the last configuration
+set for *that* chip select.  For example,
 
 ```rust
 bus.set_chip_select(1);
@@ -240,20 +268,22 @@ bus.read_write_bytes(...); // Uses SampleLeading
 ```
 
 will have a SampleLeading phase in the final `write_byte_bytes` call,
-because the configuration of chip select 1 is saved, and restored
-when chip select is set back to 1.
+because the configuration of chip select 1 is saved, and restored when
+chip select is set back to 1.
 
 5 `Peripheral` and `PeripheralClient` traits
 ===============================
 
-When a chip acts as a SPI peripheral, it does not drive the clock. Instead,
-it response to the clock of the controller. In some cases, the peripheral must
-be able to respond with a bit of data before it has even received one (e.g.,
-if phase is set to `SampleLeading`). As a result, a peripheral read/write request
-may never complete if the controller never issues a request of its own. The
-peripheral has to provide read and write buffers in anticipation of a controller
-request. Unlike a controller, which must always write data, a peripheral can only
-read, only write, or read and write.
+When a chip acts as a SPI peripheral, it does not drive the
+clock. Instead, it response to the clock of the controller. In some
+cases, the peripheral must be able to respond with a bit of data
+before it has even received one (e.g., if phase is set to
+`SampleLeading`). As a result, a peripheral read/write request may
+never complete if the controller never issues a request of its
+own. The peripheral has to provide read and write buffers in
+anticipation of a controller request. Unlike a controller, which must
+always write data, a peripheral can only read, only write, or read and
+write.
 
 ```rust
 pub trait Peripheral {
@@ -284,54 +314,60 @@ The `Peripheral` API differs from the `Controller` in three ways:
   - clients have a `chip_selected` callback, and
   - a peripheral can set its write as a single-byte value.
 
-When a controller brings the chip select line low, the implementation calls the
-`chip_selected` callback to inform the peripheral that an operation is starting. 
-Because a controller may begin clocking data almost immediately after the chip
-select is brought low (e.g., a SPI clock tick, so in some cases a few hundred 
-nanoseconds. Because this is faster than the `chip_selected` callback can typically
-be issued, the client SHOULD have already made a `read_write_bytes` or `set_write_byte`
-call, so the SPI hardware has a byte ready to send.
+When a controller brings the chip select line low, the implementation
+calls the `chip_selected` callback to inform the peripheral that an
+operation is starting.  Because a controller may begin clocking data
+almost immediately after the chip select is brought low (e.g., a SPI
+clock tick, so in some cases a few hundred nanoseconds. Because this
+is faster than the `chip_selected` callback can typically be issued,
+the client SHOULD have already made a `read_write_bytes` or
+`set_write_byte` call, so the SPI hardware has a byte ready to send.
 
-The `set_write_byte` call sets the byte that the SPI peripheral should write to the
-controller. The peripheral will write this byte on each SPI byte operation until
-the next call to `set_write_byte` or `read_write_bytes` with a write buffer argument. 
+The `set_write_byte` call sets the byte that the SPI peripheral should
+write to the controller. The peripheral will write this byte on each
+SPI byte operation until the next call to `set_write_byte` or
+`read_write_bytes` with a write buffer argument.
 
-The `read_write_bytes` method takes two `Option` types: one for the write buffer and
-one for the read buffer. The maximum length of the operation is the minumum of the 
-length of those buffers and the `len` parameter. The SPI peripheral will read bytes
-written by the controller into the read buffer, and will write out the bytes in the
-write buffer to the controller. If no write buffer is provided, the bytes the 
-peripheral will write are undefined. If `read_write_bytes` returns `Ok(())`,
-the request was accepted and the implementation MUST issue a callback when the
-request completes or has an error. The valid `ErrorCode` values for `read_write_bytes`
-are:
+The `read_write_bytes` method takes two `Option` types: one for the
+write buffer and one for the read buffer. The SPI peripheral will read
+bytes written by the controller into the read buffer, and will write
+out the bytes in the write buffer to the controller. If no write
+buffer is provided, the bytes the peripheral will write are
+undefined. If `read_write_bytes` returns `Ok(())`, the request was
+accepted and the implementation MUST issue a callback when the request
+completes or has an error. The valid `ErrorCode` values for
+`read_write_bytes` are:
  
-  - BUSY: the SPI is busy with another call to `read_write_bytes` and so cannot
-    complete the request.
+  - BUSY: the SPI is busy with another call to `read_write_bytes` and
+    so cannot complete the request.
   - OFF: the SPI is off and cannot accept a request.
-  - INVAL: the length value is 0, or one of the buffers passed has length 0.
+  - INVAL: the `len` parameter was 0 or both buffers were `None`.
   - RESERVE: there is no client for a callback.
+  - SIZE: one of the passed buffers is smaller than `len`.
 
-The `read_write_done` callback is called when the outstanding `read_write_bytes`
-request completes. The `len` argument is how many bytes were read/written. It
-may differ from the `len` passed to `read_write_bytes` if one of the buffers is
-is shorter, or if an error occured. It may return any
-of the `ErrorCode` values that can be returned by `read_write_bytes`: these
-represent asynchronous errors (e.g., due to arbitration).
+The `read_write_done` callback is called when the outstanding
+`read_write_bytes` request completes. The `len` argument is how many
+bytes were read/written. It may differ from the `len` passed to
+`read_write_bytes` if one of the buffers is is shorter, or if an error
+occured. It may return any of the `ErrorCode` values that can be
+returned by `read_write_bytes`: these represent asynchronous errors
+(e.g., due to arbitration).
 
 6 `PeripheralDevice` and `PeripheralBus` traits
 ===============================
 
-The `PeripheralDevice` trait represents the standard client abstraction of a
-SPI peripheral. It combines `Peripheral` and `Configure`:
+The `PeripheralDevice` trait represents the standard client
+abstraction of a SPI peripheral. It combines `Peripheral` and
+`Configure`:
 
 ```rust
 pub trait PeripheralDevice<'a>: Peripheral<'a> + Configure {}
 ```
 
-PeripheralBus represents the lowest-level hardware abstraction of a SPI peripheral.
-It is the trait that chip implementations typically implement. It is `PeripheralDevice`
-plus an `init()` method for initializing hardware to be a SPI peripheral:
+PeripheralBus represents the lowest-level hardware abstraction of a
+SPI peripheral.  It is the trait that chip implementations typically
+implement. It is `PeripheralDevice` plus an `init()` method for
+initializing hardware to be a SPI peripheral:
 
 ```rust
 pub trait PeripheralBus<'a>: PeripheralDevice<'a> {
@@ -345,15 +381,16 @@ The `Err` result of `init` can return the following `ErrorCode` values:
 7 `Bus` trait
 ===============================
 
-The `ControllerBus` and `PeripheralBus` traits are intended for use cases when
-a given SPI block is always used as either or a controller or always used as a
-peripheral. Some systems, however, require the bus to change between these roles.
-For example, a board might export the bus over an expansion header, and whether it
-behaves as a peripheral or controller depends on what it's plugged into and which
-userspace processes run.
+The `ControllerBus` and `PeripheralBus` traits are intended for use
+cases when a given SPI block is always used as either or a controller
+or always used as a peripheral. Some systems, however, require the bus
+to change between these roles.  For example, a board might export the
+bus over an expansion header, and whether it behaves as a peripheral
+or controller depends on what it's plugged into and which userspace
+processes run.
 
-The `Bus` trait allows software to dynamically change a SPI bus between controller
-and peripheral mode.
+The `Bus` trait allows software to dynamically change a SPI bus
+between controller and peripheral mode.
 
 ```rust
 pub trait Bus<'a>: PeripheralDevice<'a> + ControllerBus<'a> {
@@ -364,14 +401,15 @@ pub trait Bus<'a>: PeripheralDevice<'a> + ControllerBus<'a> {
 }
 ```
 
-If software invokes a `Peripheral` operation while the bus is in controller mode,
-the method MUST return OFF. If software invokes a `Controller` operation while the
-bus is in peripheral mode, the method MUST return off. Changing the controller
-chip select while the device is in peripheral mode changes the chip select configuration
-of the controller but MUST NOT have an effect on peripheral mode.
+If software invokes a `Peripheral` operation while the bus is in
+controller mode, the method MUST return OFF. If software invokes a
+`Controller` operation while the bus is in peripheral mode, the method
+MUST return off. Changing the controller chip select while the device
+is in peripheral mode changes the chip select configuration of the
+controller but MUST NOT have an effect on peripheral mode.
 
-When a `Bus` first starts and is initialized, it MUST be in controller mode, as
-the `init()` method is part of the `ControllerBus` trait.
+When a `Bus` first starts and is initialized, it MUST be in controller
+mode, as the `init()` method is part of the `ControllerBus` trait.
 
 8 Capsules
 ===============================

--- a/doc/reference/trd-spi.md
+++ b/doc/reference/trd-spi.md
@@ -1,0 +1,359 @@
+Kernel Serial Peripheral Interface (SPI) HIL
+========================================
+
+**TRD:** <br/>
+**Working Group:** Kernel<br/>
+**Type:** Documentary<br/>
+**Status:** Draft <br/>
+**Author:** Philip Levis, Alexandru Radovici<br/>
+**Draft-Created:** 2021/08/02 <br/>
+**Draft-Modified:** 2021/08/02 <br/>
+**Draft-Version:** 1 <br/>
+**Draft-Discuss:** tock-dev@googlegroups.com<br/>
+
+Abstract
+-------------------------------
+
+This document proposes hardware independent layer interface (HIL) for 
+a serial peripheral interface (SPI) bus in the Tock operating system 
+kernel. It describes the Rust traits and other
+definitions for this service as well as the reasoning behind them. This
+document is in full compliance with [TRD1](./trd1-trds.md).
+
+Note that this HIL has not been implemented yet in the master branch
+of Tock -- this is a working document as the HIL is designed.
+
+1 Introduction
+===============================
+
+The serial peripheral interface (SPI) is a standard bus design for processors 
+and microcontrollers to exchange data with sensors, I/O devices, and other 
+off-chip compoments. The bus is clocked. The device driving the clock is
+called a "master" or "controller" and the device whose clock is driven
+is called a "slave" or "peripheral". A SPI bus has three data lines: the clock (CLK), 
+data from the controller to the peripheral (MOSI) and data from the peripheral
+to the controller (MISO). A SPI bus does not have addressing. Instead, peripherals
+have a chip select (CS) pin. When a peripheral's chip select line is brought low,
+it receives data on MOSI and sends data on MISO. A controller can connect
+to CS pins on many different devices and share the bus between them by explicitly
+controlling which ones are active.
+
+The SPI HIL is in the kernel crate, in module `hil::spi`. It provides seven main
+traits:
+
+  * `kernel::hil::spi::Configure`: provides an abstraction of configuring a SPI bus by setting its data rate, phase, and polarity.
+  * `kernel::hil::spi::Controller`: allows a client for a SPI in controller mode to send and receive data.
+  * `kernel::hil::spi::ControllerDevice`: combines `Configure` and `Controller` to provide an abstraction of a SPI bus in controller mode for a client that is bound to a specific chip select (e.g., a sensor driver). It allows a client to send and receive data as well as configure the bus for (only) its own operations.
+  * `kernel::hil::spi::ChipSelect`: allows a client to change which chip select is active on a SPI bus in controller mode.
+  * `kernel::hil::spi::ControllerBus`: combines `ControllerDevice` and `ChipSelect` to allow a client to issue SPI operations on any chip select. It also supports initializing the bus hardware. This trait is intended to be implemented by a chip peripheral implementation.
+  * `kernel::hil::spi::PeripheralDevice`: extends `Configure` and provides an abstraction of a SPI bus in peripheral mode. It allows a client to learn when it is selected, to send and receive data, and  configure the bus for its own operations.
+  * `kernel::hil::spi::PeripheralBus`: extends `PeripheralDevice` to support initializing the bus hardware. This trait is intended to be implemented by a chip peripheral implementation.
+
+
+This document describes these traits and their semantics.
+
+2 `Configure` trait
+===============================
+
+The `Configure` trait allows a client to set the data rate (clock frequency) of
+the SPI bus as well as its polarity and phase. Polarity controls whether the clock
+line is high or low when the bus is idle. Phase controls on which clock edges
+the bus clocks data in and out. It also allows configuring whether data is sent
+most significant bit first or least significant bit first.
+
+```rust
+pub enum DataOrder {
+    MSBFirst,
+    LSBFirst,
+}
+
+pub enum ClockPolarity {
+    IdleLow,
+    IdleHigh,
+}
+
+pub enum ClockPhase {
+    SampleLeading,
+    SampleTrailing,
+}
+
+pub trait Configure {
+    fn set_rate(&self, rate: u32) -> Result<u32, ErrorCode>;
+    fn get_rate(&self) -> u32;
+
+    fn set_polarity(&self, polarity: ClockPolarity) -> Result<(), ErrorCode>;
+    fn get_polarity(&self) -> ClockPolarity;
+
+    fn set_phase(&self, phase: ClockPhase) -> Result<(), ErrorCode>;
+    fn get_phase(&self) -> ClockPhase;
+
+    fn set_data_order(&self, order: DataOrder) -> Result<(), ErrorCode>;
+    fn get_data_order(&self) -> DataOrder;
+}
+```
+
+All of the set methods in `Configure` can return an error. Valid errors are:
+  - INVAL (`set_rate` only): the parameter is outside the allowed range
+  - NOSUPPORT (`set_polarity`, `set_phase`, `set_data_order`): the parameter provided cannot be supported. For example, a SPI bus that cannot have an `IdleHigh` polarity returns NOSUPPORT if a client tries to set it to have this polarity.
+  - OFF (all): the bus is currently powered down in a state that does not allow configuring it.
+  - BUSY (all): the bus is in the midst of an operation and cannot currently change its configuration.
+  - FAIL (all): some other error occurred.
+
+The `set_rate` method returns a `u32` in its success case. This is the actual data
+rate set, which may differ from the one passed, e.g., due to clock precision or
+prescalars. The actual rate rate set MUST be less than the `rate` passed. If no
+rate can be set (e.g., the `rate` is too small), `set_rate` MUST return `Err(INVAL)`.
+
+The relationship of phase and polarity follows the standard SPI specification[1]:
+
++------------+------------------+-------------+----------------+----------------+
+|  Polarity  |      Phase       |  Idle Level |    Data Out    |     Data In    |
++------------+------------------+-------------+----------------+----------------+
+|  IdleLow   |  SampleLeading   |     Low     |  Rising Edge   |  Falling Edge  |
+|  IdleLow   |  SampleTrailing  |     Low     |  Falling Edge  |  Rising Edge   |
+|  IdleHigh  |  SampleLeading   |     High    |  Rising Edge   |  Rising Edge   |
+|  IdleHigh  |  SampleTrailing  |     High    |  Falling Edge  |  Falling Edge  |
++------------+------------------+-------------+----------------+----------------+
+
+
+3 `Controller`, `ControllerDevice`, and `ControllerClient` traits
+===============================
+
+The `Controller` trait allows a client to send and receive data on a SPI bus
+in controller mode:
+
+```rust
+pub trait Controller<'a> {
+    fn set_client(&self, client: &'a dyn ControllerClient);
+    fn read_write_bytes(
+        &self,
+        write_buffer: &'a mut [u8],
+        read_buffer: Option<&'a mut [u8]>,
+        len: usize,
+    ) -> Result<(), (ErrorCode, &'a mut [u8], Option<&'a mut [u8]>)>;
+}
+
+pub trait ControllerClient<'a> {
+    fn read_write_done(
+        &self,
+        write_buffer: &'a mut [u8],
+        read_buffer: Option<&'a mut [u8]>,
+        len: usize,
+        status: Result<(), ErrorCode>,
+    );
+}
+```
+
+The `read_write_bytes` method always takes a buffer to write and has an 
+optional buffer to read into. For operations that do not need to read from
+the SPI peripheral, the `read_buffer` can be `None`.
+
+The length of the SPI operation is the minimum of 3 values: the length of 
+`write_buffer`, the `len` argument and, the length of `read_buffer` argument if it is
+`Some`. If `read_buffer` is `None` it does not affect the length of the operation.
+
+If the call to `read_write_bytes` returns `Ok(())`, the implementation MUST issue
+a callback to the `SpiControllerClient` when it completes. If the call returns
+an `Err`, the implementation MUST NOT issue a callback, except if the `ErrorCode` is
+`BUSY`. In this case, the implementation issues a callback for the outstanding
+operation but does not issue a callback for the failed one. If it returns `Err`,
+the implementation MUST return the buffers passed in the call. Valid `ErrorCode`
+values for an `Err` result are:
+  - BUSY: the SPI is busy with another call to `read_write_bytes` and so cannot
+    complete the request.
+  - OFF: the SPI is off and cannot accept a request.
+  - INVAL: the length value is 0, or one of the buffers passed has length 0.
+  - RESERVE: there is no client for a callback.
+  - FAIL: some other failure condition.
+
+The `set_client` method sets which callback to invoke when a `read_write_bytes`
+call completes. The `read_write_done` callback MUST return the buffers passed
+in the call to `read_write_bytes`. The `len` argument is the number of bytes
+read/written: it may differ from the `len` argument in `read_write_bytes` if
+one of the buffers was smaller than the call argument. The `status` argument
+indicates whether the SPI operation completed successfully. It may return any
+of the `ErrorCode` values that can be returned by `read_write_bytes`: these
+represent asynchronous errors (e.g., due to queueing).
+
+The `ControllerDevice` trait combines `Controller` and `Configure` traits.
+It provides the abstraction of being able to read/write to the bus and
+adjust its configuration.
+
+```rust
+pub trait ControllerDevice<'a>: Controller<'a> + Configure<'a> {}
+```
+
+4 `ChipSelect` and `ControllerBus`
+===============================
+
+The `ChipSelect` trait allows a client to change which chip select is
+active on the SPI bus. Because different SPI hardware can provide different
+numbers of chip selects, the actual chip select value is an associated
+type. This associated type is typically an `enum` so a chip implementation
+can statically verify that clients pass only valid chip select values.
+
+```rust
+pub trait ChipSelect {
+  type Value: Copy;
+  fn set_chip_select(&self, cs: Self::Value) -> Result<(), ErrorCode>;
+  fn get_chip_select(&self) -> Self::Value);
+}
+```
+
+The `ControllerBus` trait combines `ControllerDevice` and `ChipSelect` to
+provide the full abstraction of a SPI bus. It is the trait that chip
+SPI implementations provide. In addition to `ControllerDevice` and
+`ChipSelect`, `ControllerBus` includes an `init` method. This `init`
+method initializes the hardware to be a SPI controller and is typically
+called at boot.
+
+```rust
+pub trait ControllerBus<'a>: ControllerDevice<'a> + ChipSelect {
+  fn init(&self) -> Result<(), ErrorCode>;
+}
+```
+
+The `Err` result of `init` can return the following `ErrorCode` values:
+  - OFF: not currently powered so can't be initialized.
+  - RESERVE: no clock is configured yet.
+  - FAIL: other failure condition.
+
+A client using a `ControllerBus` can exchange data with multiple SPI 
+peripherals, switching between them with `ChipSelect`. Calls to `Configure` 
+modify the configuration of the current chip select, which are stateful. 
+Changing the chip select uses the last configuration set for *that* chip select.
+For example,
+
+```rust
+bus.set_chip_select(1);
+bus.set_phase(SampleLeading);
+bus.set_chip_select(2);
+bus.set_phase(SampleTrailing);
+bus.set_chip_select(1);
+bus.read_write_bytes(...); // Uses SampleLeading
+```
+
+will have a SampleLeading phase in the final `write_byte_bytes` call,
+because the configuration of chip select 1 is saved, and restored
+when chip select is set back to 1.
+
+5 `Peripheral` and `PeripheralClient` traits
+===============================
+
+When a chip acts as a SPI peripheral, it does not drive the clock. Instead,
+it response to the clock of the controller. In some cases, the peripheral must
+be able to respond with a bit of data before it has even received one (e.g.,
+if phase is set to `SampleLeading`). As a result, a peripheral read/write request
+may never complete if the controller never issues a request of its own. The
+peripheral has to provide read and write buffers in anticipation of a controller
+request. Unlike a controller, which must always write data, a peripheral can only
+read, only write, or read and write.
+
+```rust
+pub trait Peripheral {
+    fn set_client(&self, client: &'static dyn PeripheralClient);
+
+    fn read_write_bytes(&self, write_buffer: Option<&'static mut [u8]>, read_buffer: Option<&'static mut [u8]>, len: usize,) -> Result<
+        (),
+        (ErrorCode, Option<&'static mut [u8]>, Option<&'static mut [u8]>,
+        ),
+    >;
+    fn set_write_byte(&self, write_byte: u8);
+}
+
+pub trait PeripheralClient {
+    fn chip_selected(&self);
+    fn read_write_done(
+        &self,
+        write_buffer: Option<&'static mut [u8]>,
+        read_buffer: Option<&'static mut [u8]>,
+        len: usize,
+        status: Result<(), ErrorCode>,
+    );
+}
+```
+
+The `Peripheral` API differs from the `Controller` in three ways:
+  - `read_write_bytes` has an optional write buffer,
+  - clients have a `chip_selected` callback, and
+  - a peripheral can set its write as a single-byte value.
+
+When a controller brings the chip select line low, the implementation calls the
+`chip_selected` callback to inform the peripheral that an operation is starting. 
+Because a controller may begin clocking data almost immediately after the chip
+select is brought low (e.g., a SPI clock tick, so in some cases a few hundred 
+nanoseconds. Because this is faster than the `chip_selected` callback can typically
+be issued, the client SHOULD have already made a `read_write_bytes` or `set_write_byte`
+call, so the SPI hardware has a byte ready to send.
+
+The `set_write_byte` call sets the byte that the SPI peripheral should write to the
+controller. The peripheral will write this byte on each SPI byte operation until
+the next call to `set_write_byte` or `read_write_bytes` with a write buffer argument. 
+
+The `read_write_bytes` method takes two `Option` types: one for the write buffer and
+one for the read buffer. The maximum length of the operation is the minumum of the 
+length of those buffers and the `len` parameter. The SPI peripheral will read bytes
+written by the controller into the read buffer, and will write out the bytes in the
+write buffer to the controller. If no write buffer is provided, the bytes the 
+peripheral will write are undefined. If `read_write_bytes` returns `Ok(())`,
+the request was accepted and the implementation MUST issue a callback when the
+request completes or has an error. The valid `ErrorCode` values for `read_write_bytes`
+are:
+ 
+  - BUSY: the SPI is busy with another call to `read_write_bytes` and so cannot
+    complete the request.
+  - OFF: the SPI is off and cannot accept a request.
+  - INVAL: the length value is 0, or one of the buffers passed has length 0.
+  - RESERVE: there is no client for a callback.
+
+The `read_write_done` callback is called when the outstanding `read_write_bytes`
+request completes. The `len` argument is how many bytes were read/written. It
+may differ from the `len` passed to `read_write_bytes` if one of the buffers is
+is shorter, or if an error occured. It may return any
+of the `ErrorCode` values that can be returned by `read_write_bytes`: these
+represent asynchronous errors (e.g., due to arbitration).
+
+6 `PeripheralDevice` and `PeripheralBus` traits
+===============================
+
+The `PeripheralDevice` trait represents the standard client abstraction of a
+SPI peripheral. It combines `Peripheral` and `Configure`:
+
+```rust
+pub trait PeripheralDevice<'a>: Peripheral<'a> + Configure {}
+```
+
+PeripheralBus represents the lowest-level hardware abstraction of a SPI peripheral.
+It is the trait that chip implementations typically implement. It is `PeripheralDevice`
+plus an `init()` method for initializing hardware to be a SPI peripheral:
+
+```rust
+pub trait PeripheralBus<'a>: PeripheralDevice<'a> {
+  fn init(&self) -> Result<(), ErrorCode>;
+}
+```
+The `Err` result of `init` can return the following `ErrorCode` values:
+  - OFF: not currently powered so can't be initialized.
+  - FAIL: other failure condition.
+
+
+7 Capsules
+===============================
+
+This section describes the standard Tock capsules for SPI communication.
+
+8 Implementation Considerations
+===============================
+
+9 Authors' Address
+=================================
+```
+Philip Levis
+409 Gates Hall
+Stanford University
+Stanford, CA 94305
+USA
+pal@cs.stanford.edu
+
+Alexandru Radovici <msg4alex@gmail.com>
+```

--- a/doc/reference/trd-spi.md
+++ b/doc/reference/trd-spi.md
@@ -365,7 +365,7 @@ pub trait Bus<'a>: PeripheralDevice<'a> + ControllerBus<'a> {
 ```
 
 If software invokes a `Peripheral` operation while the bus is in controller mode,
-the method MUST return OFF. If software invokes a Controller operation while the
+the method MUST return OFF. If software invokes a `Controller` operation while the
 bus is in peripheral mode, the method MUST return off. Changing the controller
 chip select while the device is in peripheral mode changes the chip select configuration
 of the controller but MUST NOT have an effect on peripheral mode.

--- a/kernel/src/hil/spi.rs
+++ b/kernel/src/hil/spi.rs
@@ -1,4 +1,4 @@
-//! Interfaces for SPI controller (master) and peripheral (slave) 
+//! Interfaces for SPI controller (master) and peripheral (slave)
 //! communication. We use the terms master/slave in some situations
 //! because the term peripheral can also refer to a hardware peripheral
 //! (e.g., memory-mapped I/O devices in ARM are called peripherals).
@@ -268,12 +268,12 @@ pub trait SpiMasterDevice {
     ) -> Result<(), (ErrorCode, &'static mut [u8], Option<&'static mut [u8]>)>;
 
     /// Set the clock/data rate for this chip select. Return values:
-    ///   - Ok(u32): the actual data rate set (limited by clock precision)
+    ///   - Ok(): set successfully. Note actual rate may differ, check with get_rate.
     ///   - Err(INVAL): a rate outside the bounds of the bus was passed
     ///   - Err(BUSY): the SPI bus is busy with a read_write_bytes
     ///     operation whose callback hasn't been called yet.
     ///   - Err(FAIL): other failure
-    fn set_rate(&self, rate: u32) -> Result<u32, ErrorCode>;
+    fn set_rate(&self, rate: u32) -> Result<(), ErrorCode>;
     /// Return the current chip select's clock rate.
     fn get_rate(&self) -> u32;
 
@@ -307,14 +307,14 @@ pub trait SpiMasterDevice {
 /// of them fills, at which point a `SpiSlaveClient::read_write_done`
 /// callback is called. If the client needs to read/write more it
 /// can call `SpiSlave::read_write_bytes` again. Note that there is
-/// no notification when the chip select line goes high. 
+/// no notification when the chip select line goes high.
 pub trait SpiSlaveClient {
     /// Notification that the chip select has been brought low.
     fn chip_selected(&self);
 
     /// Callback issued when the controller completes an SPI operation
     /// to this peripheral. `write_buffer` and `read_buffer` are
-    /// the values passed in the previous call to 
+    /// the values passed in the previous call to
     /// `SpiSlave::read_write_bytes`. The `len` parameter specifies
     /// how many bytes were written from/read into `Some` values of
     /// these buffers. `len` may be shorter than the size of these
@@ -366,7 +366,7 @@ pub trait SpiSlave {
     /// Return values:
     ///   - Ok(()): the SPI bus will read/write the provided buffers on
     ///     the next SPI operation requested by the controller.
-    ///   - Err(BUSY): the device is busy with an existing 
+    ///   - Err(BUSY): the device is busy with an existing
     ///     `read_write_bytes` operation.
     ///   - Err(INVAL): the `len` parameter is 0
     ///
@@ -393,7 +393,7 @@ pub trait SpiSlave {
     /// Return the current bus polarity.
     fn get_polarity(&self) -> ClockPolarity;
 
-    /// Set the bus phase (whether data is sent/received on leading or 
+    /// Set the bus phase (whether data is sent/received on leading or
     /// trailing edges).
     ///   - Ok(()): the phase was set.
     ///   - Err(BUSY): the SPI bus is busy with a `read_write_bytes`

--- a/kernel/src/hil/spi.rs
+++ b/kernel/src/hil/spi.rs
@@ -3,7 +3,7 @@
 use crate::ErrorCode;
 use core::option::Option;
 
-/// Data order defines the order of bits sent over the wire: most 
+/// Data order defines the order of bits sent over the wire: most
 /// significant first, or least significant first.
 #[derive(Copy, Clone, Debug)]
 pub enum DataOrder {
@@ -11,8 +11,8 @@ pub enum DataOrder {
     LSBFirst,
 }
 
-/// Clock polarity (CPOL) defines whether the SPI clock is high 
-/// or low when idle. 
+/// Clock polarity (CPOL) defines whether the SPI clock is high
+/// or low when idle.
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum ClockPolarity {
     IdleLow,
@@ -57,7 +57,7 @@ pub trait SpiMasterClient {
 /// 3b. Call set_chip_select to choose another peripheral,
 ///     go to step 1b or 2.
 ///
-/// The SPI configuration for a particular peripheral persists across 
+/// The SPI configuration for a particular peripheral persists across
 /// changes to the chip select. For example, this set of calls
 ///
 ///   specify_chip_select(1);
@@ -110,9 +110,9 @@ pub trait SpiMaster {
     /// completion is signaled by invoking SpiMasterClient on
     /// the client. Write-only operations may pass `None` for
     /// `read_buffer`, while read-write operations pass `Some`
-    /// for `read_buffer`. 
+    /// for `read_buffer`.
     ///
-    /// If `read_buffer` is `None`, the 
+    /// If `read_buffer` is `None`, the
     /// number of bytes written will be the mimumum of the length of
     /// `write_buffer` and the `len` argument. If `read_buffer`
     /// is `Some`, the number of bytes read/written will be the
@@ -145,7 +145,7 @@ pub trait SpiMaster {
     ///   - Err(FAIL): other failure
     fn write_byte(&self, val: u8) -> Result<(), ErrorCode>;
 
-    /// Synchronously write a 0 and read a single byte from the bus. 
+    /// Synchronously write a 0 and read a single byte from the bus.
     /// Not for general use because it is blocking: intended for debugging.
     /// Return values:
     ///   - Ok((u8)): the read byte
@@ -190,7 +190,7 @@ pub trait SpiMaster {
     /// Return the current bus polarity.
     fn get_polarity(&self) -> ClockPolarity;
 
-    /// Set the bus phase for the current chip select (whether data is 
+    /// Set the bus phase for the current chip select (whether data is
     /// sent/received on leading or trailing edges).
     ///   - Ok(()): the phase was set.
     ///   - Err(BUSY): the SPI bus is busy with a `read_write_bytes`
@@ -210,7 +210,7 @@ pub trait SpiMaster {
     // allow an application to manually control when the
     // CS line is high or low, such that it can issue longer
     // read/writes with multiple read_write_bytes calls.
-    
+
     /// Hold the chip select line low after a read_write_bytes completes.
     /// This allows a client to make one long SPI read/write with
     /// multiple calls to `read_write_bytes`.
@@ -220,7 +220,7 @@ pub trait SpiMaster {
     fn release_low(&self);
 }
 
-/// SPIMasterDevice provides a chip-select-specific interface to the SPI 
+/// SPIMasterDevice provides a chip-select-specific interface to the SPI
 /// Master hardware, such that a client cannot changethe chip select line.
 pub trait SpiMasterDevice {
     /// Set the callback for read_write operations.

--- a/kernel/src/hil/spi.rs
+++ b/kernel/src/hil/spi.rs
@@ -1,4 +1,13 @@
-//! Interfaces for SPI master and slave communication.
+//! Interfaces for SPI controller (master) and peripheral (slave) 
+//! communication. We use the terms master/slave in some situations
+//! because the term peripheral can also refer to a hardware peripheral
+//! (e.g., memory-mapped I/O devices in ARM are called peripherals).
+
+// Author: Alexandru Radovici <msg4alex@gmail.com>
+// Author: Philip Levis <pal@cs.stanford.edu>
+// Author: Hubert Teo <hubert.teo.hk@gmail.com>
+// Author: Brad Campbell <bradjc5@gmail.com>
+// Author: Amit Aryeh Levy <amit@amitlevy.com>
 
 use crate::ErrorCode;
 use core::option::Option;
@@ -290,11 +299,26 @@ pub trait SpiMasterDevice {
     fn get_phase(&self) -> ClockPhase;
 }
 
+/// Trait for SPI peripherals (slaves) to receive callbacks when the
+/// corresponding controller (master) issues operations. A SPI operation
+/// begins with a callback of `chip_selected`. If the client has
+/// provided buffers with `SpiSlave::read_write_bytes`, these buffers
+/// are written from and read into until the operation completes or one
+/// of them fills, at which point a `SpiSlaveClient::read_write_done`
+/// callback is called. If the client needs to read/write more it
+/// can call `SpiSlave::read_write_bytes` again. Note that there is
+/// no notification when the chip select line goes high. 
 pub trait SpiSlaveClient {
-    /// This is called whenever the slave is selected by the master
+    /// Notification that the chip select has been brought low.
     fn chip_selected(&self);
 
-    /// This is called as a DMA interrupt when a transfer has completed
+    /// Callback issued when the controller completes an SPI operation
+    /// to this peripheral. `write_buffer` and `read_buffer` are
+    /// the values passed in the previous call to 
+    /// `SpiSlave::read_write_bytes`. The `len` parameter specifies
+    /// how many bytes were written from/read into `Some` values of
+    /// these buffers. `len` may be shorter than the size of these
+    /// buffers if the operation did not fill them.
     fn read_write_done(
         &self,
         write_buffer: Option<&'static mut [u8]>,
@@ -304,14 +328,49 @@ pub trait SpiSlaveClient {
     );
 }
 
+/// Trait for SPI peripherals (slaves) to exchange data with a contoller
+/// (master). This is a low-level trait typically implemented by hardware:
+/// higher level software typically uses the `SpiSlaveDevice` trait,
+/// which is provided by a virtualizing/multiplexing layer.
 pub trait SpiSlave {
+    /// Initialize the SPI device to be in peripheral mode.
+    /// Return values:
+    ///   - Ok(()): the device is in peripheral mode
+    ///   - Err(BUSY): the device is busy with an operation and cannot
+    ///     be initialized
+    ///   - Err(FAIL): other failure condition
     fn init(&self) -> Result<(), ErrorCode>;
-    /// Returns true if there is a client.
+
+    /// Returns true if there is a client. Useful for verifying that
+    /// two software drivers do not both try to take control of the
+    /// device.
     fn has_client(&self) -> bool;
 
+    /// Set the callback for slave operations, passing `None` to
+    /// disable peripheral mode.
     fn set_client(&self, client: Option<&'static dyn SpiSlaveClient>);
 
+    /// Set a single byte to write in response to a read/write
+    /// operation from a controller. Useful for devices that always
+    /// send a status code in their first byte.
     fn set_write_byte(&self, write_byte: u8);
+
+    /// Provide buffers for the peripheral to write from and read
+    /// into when a controller performs a `read_write_bytes` operation.
+    /// The device will issue a callback when one of four things occurs:
+    ///   - The controller completes the operation by bringing the chip
+    ///     select high.
+    ///   - A `Some` write buffer is written.
+    ///   - A `Some` read buffer is filled.
+    ///   - `len` bytes are read/written
+    /// Return values:
+    ///   - Ok(()): the SPI bus will read/write the provided buffers on
+    ///     the next SPI operation requested by the controller.
+    ///   - Err(BUSY): the device is busy with an existing 
+    ///     `read_write_bytes` operation.
+    ///   - Err(INVAL): the `len` parameter is 0
+    ///
+    /// `Err` return values return the passed buffer `Option`s.
     fn read_write_bytes(
         &self,
         write_buffer: Option<&'static mut [u8]>,
@@ -325,28 +384,54 @@ pub trait SpiSlave {
             Option<&'static mut [u8]>,
         ),
     >;
-
+    /// Set the bus polarity (whether idle is high or low). Return values:
+    ///   - Ok(()): the polarity was set.
+    ///   - Err(BUSY): the SPI bus is busy with a `read_write_bytes`
+    ///     operation whose callback hasn't been called yet.
+    ///   - Err(FAIL): other failure
     fn set_polarity(&self, polarity: ClockPolarity) -> Result<(), ErrorCode>;
+    /// Return the current bus polarity.
     fn get_polarity(&self) -> ClockPolarity;
+
+    /// Set the bus phase (whether data is sent/received on leading or 
+    /// trailing edges).
+    ///   - Ok(()): the phase was set.
+    ///   - Err(BUSY): the SPI bus is busy with a `read_write_bytes`
+    ///     operation whose callback hasn't been called yet.
+    ///   - Err(FAIL): other failure
     fn set_phase(&self, phase: ClockPhase) -> Result<(), ErrorCode>;
+
+    /// Return the current bus phase.
     fn get_phase(&self) -> ClockPhase;
 }
 
-/// SPISlaveDevice provides a chip-specific interface to the SPI Slave
-/// hardware. The interface wraps the chip select line so that chip drivers
-/// cannot communicate with different SPI devices.
+/// SPISlaveDevice is an interface to a SPI bus in peripheral mode.
+/// It is the standard trait used by services within the kernel:
+/// `SpiSlave` is for lower-level access responsible for initializing
+/// hardware.
 pub trait SpiSlaveDevice {
-    /// Specify the callback of read_write operations:
+    /// Specify the callback of `read_write_bytes` operations:
     fn set_client(&self, client: &'static dyn SpiSlaveClient);
 
     /// Setup the SPI settings and speed of the bus.
     fn configure(&self, cpol: ClockPolarity, cpal: ClockPhase) -> Result<(), ErrorCode>;
 
-    /// Perform an asynchronous read/write operation, whose
-    /// completion is signaled by invoking SpiSlaveClient.read_write_done on
-    /// the provided client. Either write_buffer or read_buffer may be
-    /// None. If read_buffer is Some, the length of the operation is the
-    /// minimum of the size of the two buffers.
+    /// Provide buffers for the peripheral to write from and read
+    /// into when a controller performs a `read_write_bytes` operation.
+    /// The device will issue a callback when one of four things occurs:
+    ///   - The controller completes the operation by bringing the chip
+    ///     select high.
+    ///   - A `Some` write buffer is written.
+    ///   - A `Some` read buffer is filled.
+    ///   - `len` bytes are read/written
+    /// Return values:
+    ///   - Ok(()): the SPI bus will read/write the provided buffers on
+    ///     the next SPI operation requested by the controller.
+    ///   - Err(BUSY): the device is busy with an existing
+    ///     `read_write_bytes` operation.
+    ///   - Err(INVAL): the `len` parameter is 0
+    ///
+    /// `Err` return values return the passed buffer `Option`s.
     fn read_write_bytes(
         &self,
         write_buffer: Option<&'static mut [u8]>,
@@ -360,9 +445,23 @@ pub trait SpiSlaveDevice {
             Option<&'static mut [u8]>,
         ),
     >;
-
-    fn set_polarity(&self, cpol: ClockPolarity) -> Result<(), ErrorCode>;
+    /// Set the bus polarity (whether idle is high or low). Return values:
+    ///   - Ok(()): the polarity was set.
+    ///   - Err(BUSY): the SPI bus is busy with a `read_write_bytes`
+    ///     operation whose callback hasn't been called yet.
+    ///   - Err(FAIL): other failure
+    fn set_polarity(&self, polarity: ClockPolarity) -> Result<(), ErrorCode>;
+    /// Return the current bus polarity.
     fn get_polarity(&self) -> ClockPolarity;
-    fn set_phase(&self, cpal: ClockPhase) -> Result<(), ErrorCode>;
+
+    /// Set the bus phase (whether data is sent/received on leading or
+    /// trailing edges).
+    ///   - Ok(()): the phase was set.
+    ///   - Err(BUSY): the SPI bus is busy with a `read_write_bytes`
+    ///     operation whose callback hasn't been called yet.
+    ///   - Err(FAIL): other failure
+    fn set_phase(&self, phase: ClockPhase) -> Result<(), ErrorCode>;
+
+    /// Return the current bus phase.
     fn get_phase(&self) -> ClockPhase;
 }


### PR DESCRIPTION
### Pull Request Overview

This pull request updates the comments on `kernel::hil::spi` to document the current interface. It also adds a first draft for a SPI TRD, which has some significant changes to the interface. The first draft of the TRD is intended for starting the discussion towards defining a solid SPI API that follows modern Tock API design principles.


### Testing Strategy

This pull request was tested by compiling.

### TODO or Help Wanted

This pull request needs feedback on the SPI comments and a start of discussion around the SPI TRD.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
