### PR TITLE
Add remove_mpu_region() functionality to mirror allocate_region()

### DIFF
--- a/arch/rv32i/src/epmp.rs
+++ b/arch/rv32i/src/epmp.rs
@@ -180,6 +180,12 @@ pub struct PMPRegion {
     cfg: registers::FieldValue<u8, pmpcfg::Register>,
 }
 
+impl PartialEq<mpu::Region> for PMPRegion {
+    fn eq(&self, other: &mpu::Region) -> bool {
+        self.location.0 == other.start_address() && self.location.1 == other.size()
+    }
+}
+
 impl fmt::Display for PMPRegion {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fn bit_str<'a>(reg: &PMPRegion, bit: u8, on_str: &'a str, off_str: &'a str) -> &'a str {
@@ -367,14 +373,7 @@ impl<const MAX_AVAILABLE_REGIONS_OVER_TWO: usize> PMPConfig<MAX_AVAILABLE_REGION
     /// Get the first unused region
     fn unused_region_number(&self, locked_region_mask: u64) -> Option<usize> {
         for (number, region) in self.regions.iter().enumerate() {
-            if self.app_memory_region.contains(&number) {
-                continue;
-            }
-            // This region exists, but is locked
-            if locked_region_mask & (1 << number) > 0 {
-                continue;
-            }
-            if region.is_none() {
+            if !self.is_index_locked_or_app(locked_region_mask, number) && region.is_none() {
                 return Some(number);
             }
         }
@@ -387,18 +386,16 @@ impl<const MAX_AVAILABLE_REGIONS_OVER_TWO: usize> PMPConfig<MAX_AVAILABLE_REGION
     fn unused_kernel_region_number(&self, locked_region_mask: u64) -> Option<usize> {
         for (num, region) in self.regions.iter().rev().enumerate() {
             let number = MAX_AVAILABLE_REGIONS_OVER_TWO - num - 1;
-            if self.app_memory_region.contains(&number) {
-                continue;
-            }
-            // This region exists, but is locked
-            if locked_region_mask & (1 << number) > 0 {
-                continue;
-            }
-            if region.is_none() {
+            if !self.is_index_locked_or_app(locked_region_mask, number) && region.is_none() {
                 return Some(number);
             }
         }
         None
+    }
+
+    /// Returns true is the specified index is either locked or corresponds to the app region
+    fn is_index_locked_or_app(&self, locked_region_mask: u64, number: usize) -> bool {
+        locked_region_mask & (1 << number) > 0 || self.app_memory_region.contains(&number)
     }
 }
 
@@ -541,6 +538,28 @@ impl<const MAX_AVAILABLE_REGIONS_OVER_TWO: usize> kernel::platform::mpu::MPU
         config.is_dirty.set(true);
 
         Some(mpu::Region::new(start as *const u8, size))
+    }
+
+    fn remove_memory_region(
+        &self,
+        region: mpu::Region,
+        config: &mut Self::MpuConfig,
+    ) -> Result<(), ()> {
+        let (index, _r) = config
+            .regions
+            .iter()
+            .enumerate()
+            .find(|(_idx, r)| r.map_or(false, |r| r == region))
+            .ok_or(())?;
+
+        if config.is_index_locked_or_app(self.locked_region_mask.get(), index) {
+            return Err(());
+        }
+
+        config.regions[index] = None;
+        config.is_dirty.set(true);
+
+        Ok(())
     }
 
     fn allocate_app_memory_region(

--- a/arch/rv32i/src/pmp.rs
+++ b/arch/rv32i/src/pmp.rs
@@ -127,6 +127,12 @@ pub struct PMPRegion {
     cfg: registers::FieldValue<u8, pmpcfg::Register>,
 }
 
+impl PartialEq<mpu::Region> for PMPRegion {
+    fn eq(&self, other: &mpu::Region) -> bool {
+        self.location.0 == other.start_address() && self.location.1 == other.size()
+    }
+}
+
 impl fmt::Display for PMPRegion {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fn bit_str<'a>(reg: &PMPRegion, bit: u8, on_str: &'a str, off_str: &'a str) -> &'a str {
@@ -247,14 +253,7 @@ impl<const MAX_AVAILABLE_REGIONS_OVER_TWO: usize> PMPConfig<MAX_AVAILABLE_REGION
     /// Get the first unused region
     fn unused_region_number(&self, locked_region_mask: u64) -> Option<usize> {
         for (number, region) in self.regions.iter().enumerate() {
-            if self.app_memory_region.contains(&number) {
-                continue;
-            }
-            // This region exists, but is locked
-            if locked_region_mask & (1 << number) > 0 {
-                continue;
-            }
-            if region.is_none() {
+            if !self.is_index_locked_or_app(locked_region_mask, number) && region.is_none() {
                 return Some(number);
             }
         }
@@ -268,18 +267,16 @@ impl<const MAX_AVAILABLE_REGIONS_OVER_TWO: usize> PMPConfig<MAX_AVAILABLE_REGION
         // It is important to enumerate first, then reverse otherwise the enumeration index
         // won't match the array index
         for (number, region) in self.regions.iter().enumerate().rev() {
-            if self.app_memory_region.contains(&number) {
-                continue;
-            }
-            // This region exists, but is locked
-            if locked_region_mask & (1 << number) > 0 {
-                continue;
-            }
-            if region.is_none() {
+            if !self.is_index_locked_or_app(locked_region_mask, number) && region.is_none() {
                 return Some(number);
             }
         }
         None
+    }
+
+    /// Returns true is the specified index is either locked or corresponds to the app region
+    fn is_index_locked_or_app(&self, locked_region_mask: u64, number: usize) -> bool {
+        locked_region_mask & (1 << number) > 0 || self.app_memory_region.contains(&number)
     }
 }
 
@@ -406,6 +403,28 @@ impl<const MAX_AVAILABLE_REGIONS_OVER_TWO: usize> kernel::platform::mpu::MPU
         config.is_dirty.set(true);
 
         Some(mpu::Region::new(start as *const u8, size))
+    }
+
+    fn remove_memory_region(
+        &self,
+        region: mpu::Region,
+        config: &mut Self::MpuConfig,
+    ) -> Result<(), ()> {
+        let (index, _r) = config
+            .regions
+            .iter()
+            .enumerate()
+            .find(|(_idx, r)| r.map_or(false, |r| r == region))
+            .ok_or(())?;
+
+        if config.is_index_locked_or_app(self.locked_region_mask.get(), index) {
+            return Err(());
+        }
+
+        config.regions[index] = None;
+        config.is_dirty.set(true);
+
+        Ok(())
     }
 
     fn allocate_app_memory_region(

--- a/kernel/src/platform/mpu.rs
+++ b/kernel/src/platform/mpu.rs
@@ -17,7 +17,7 @@ pub enum Permissions {
 /// MPU region.
 ///
 /// This is one contiguous address space protected by the MPU.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 pub struct Region {
     /// The memory address where the region starts.
     ///
@@ -156,6 +156,26 @@ pub trait MPU {
         } else {
             Some(Region::new(unallocated_memory_start, min_region_size))
         }
+    }
+
+    /// Removes an MPU region within app-owned memory.
+    ///
+    /// An implementation must remove the MPU region that matches the region parameter if it exists.
+    /// If there is not a region that matches exactly, then the implementation may return an Error.
+    /// Implementors should not remove the app_memory_region and should return an Error if that
+    /// region is supplied.
+    ///
+    /// # Arguments
+    ///
+    /// - `region`:    a region previously allocated with `allocate_region`
+    /// - `config`:    MPU region configuration
+    ///
+    /// # Return Value
+    ///
+    /// Returns an error if the specified region is not exactly mapped to the process as specified
+    #[allow(unused_variables)]
+    fn remove_memory_region(&self, region: Region, config: &mut Self::MpuConfig) -> Result<(), ()> {
+        Ok(())
     }
 
     /// Chooses the location for a process's memory, and allocates an MPU region

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -410,6 +410,13 @@ pub trait Process {
         min_region_size: usize,
     ) -> Option<mpu::Region>;
 
+    /// Removes an MPU region from the process that has been previouly added with
+    /// `add_mpu_region`.
+    ///
+    /// It is not valid to call this function when the process is inactive (i.e.
+    /// the process will not run again).
+    fn remove_mpu_region(&self, region: mpu::Region) -> Result<(), ErrorCode>;
+
     // grants
 
     /// Allocate memory from the grant region and store the reference in the


### PR DESCRIPTION
### Pull Request Overview

When a users maps a new mpu region to a process with `allocate_region`, they may want to later remove that region. This PR adds the appropriate removal function to the process interface and implements the new MPU helper function (`remove_memory_region`) for the MPU implementation that already implement `allocate_region`

This can wait until after Tock OS 2.0 release.

### Testing Strategy

- I have tested a variant of this code on 1.X systems. I unfortunately don't have a system to test this change on that is closer to the 2.0 kernel


### Help Wanted

 - [x] Test on RISCV with newer kernel
 - [x] Test on cortexM with newer kernel

### Documentation Updated

- None

### Formatting

- [x] Ran `make prepush`.
