### PR TITLE
kernel: sched: priority: get correct proc index

### DIFF
--- a/kernel/src/scheduler/priority.rs
+++ b/kernel/src/scheduler/priority.rs
@@ -62,10 +62,11 @@ impl<C: Chip> Scheduler<C> for PrioritySched {
             || self
                 .kernel
                 .get_process_iter()
-                .position(|proc| proc.ready())
-                .map_or(false, |ready_idx| {
-                    self.running
-                        .map_or(false, |running| ready_idx < running.index)
+                .find(|proc| proc.ready())
+                .map_or(false, |ready_proc| {
+                    self.running.map_or(false, |running| {
+                        ready_proc.processid().index < running.index
+                    })
                 }))
     }
 


### PR DESCRIPTION
### Pull Request Overview

If using the priority scheduler with a padding app first in the app section followed by an actual app, the actual app would never run. This is because the priority scheduler calls `kernel.get_process_iter()` which filters for only valid processes, then uses the index in _that_ iter as the process index. The first entry in the processes array is `None` (because of the padding). So the actual app is detected at index 0, but when compared to its actual index (1) it looks like there is a higher priority app ready. But it's the same app.

Switch to `iter.find()` and then get the actual processes array index.


### Testing Strategy

Using a padding app on arty-e21.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
