### PR TITLE
Display driver number in hex for allocation warning

### DIFF
--- a/kernel/src/kernel.rs
+++ b/kernel/src/kernel.rs
@@ -942,10 +942,10 @@ impl Kernel {
                                                                 if currently_allocated_grants_count
                                                                     > allocated_grants_count
                                                                 {
-                                                                    debug!("[{:?}] ERROR driver {} allocated wrong grant for upcalls",
+                                                                    debug!("[{:?}] ERROR driver {:x} allocated wrong grant for upcalls",
                                                                            process.processid(), driver_number);
                                                                 } else {
-                                                                    debug!("[{:?}] WARN driver {} did not allocate grant for upcalls",
+                                                                    debug!("[{:?}] WARN driver {:x} did not allocate grant for upcalls",
                                                                            process.processid(), driver_number);
                                                                 }
                                                             }

--- a/kernel/src/kernel.rs
+++ b/kernel/src/kernel.rs
@@ -945,7 +945,7 @@ impl Kernel {
                                                                     debug!("[{:?}] ERROR driver {:x} allocated wrong grant for upcalls",
                                                                            process.processid(), driver_number);
                                                                 } else {
-                                                                    debug!("[{:?}] WARN driver {:x} did not allocate grant for upcalls",
+                                                                    debug!("[{:?}] WARN driver {#:x} did not allocate grant for upcalls",
                                                                            process.processid(), driver_number);
                                                                 }
                                                             }

--- a/kernel/src/kernel.rs
+++ b/kernel/src/kernel.rs
@@ -942,10 +942,10 @@ impl Kernel {
                                                                 if currently_allocated_grants_count
                                                                     > allocated_grants_count
                                                                 {
-                                                                    debug!("[{:?}] ERROR driver {#:x} allocated wrong grant for upcalls",
+                                                                    debug!("[{:?}] ERROR driver #{:x} allocated wrong grant for upcalls",
                                                                            process.processid(), driver_number);
                                                                 } else {
-                                                                    debug!("[{:?}] WARN driver {#:x} did not allocate grant for upcalls",
+                                                                    debug!("[{:?}] WARN driver #{:x} did not allocate grant for upcalls",
                                                                            process.processid(), driver_number);
                                                                 }
                                                             }

--- a/kernel/src/kernel.rs
+++ b/kernel/src/kernel.rs
@@ -942,7 +942,7 @@ impl Kernel {
                                                                 if currently_allocated_grants_count
                                                                     > allocated_grants_count
                                                                 {
-                                                                    debug!("[{:?}] ERROR driver {:x} allocated wrong grant for upcalls",
+                                                                    debug!("[{:?}] ERROR driver {#:x} allocated wrong grant for upcalls",
                                                                            process.processid(), driver_number);
                                                                 } else {
                                                                     debug!("[{:?}] WARN driver {#:x} did not allocate grant for upcalls",


### PR DESCRIPTION
### Pull Request Overview

This pull request changes the way the driver number is displayed within the allocation warnings. It now follows the rest of the debug messages and displays the number in hex instead of decimal.

### Testing Strategy

N/A

### TODO or Help Wanted

N/A

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
