### PR TITLE
Fix LED Matrix message typo

### DIFF
--- a/capsules/src/led_matrix.rs
+++ b/capsules/src/led_matrix.rs
@@ -310,7 +310,7 @@ pub struct LedMatrixLed<'a, L: Pin, A: Alarm<'a>> {
 impl<'a, L: Pin, A: Alarm<'a>> LedMatrixLed<'a, L, A> {
     pub fn new(matrix: &'a LedMatrixDriver<'a, L, A>, col: usize, row: usize) -> Self {
         if col >= matrix.cols_len() || row >= matrix.rows_len() {
-            panic!("LET at position ({}, {}) does not exist", col, row);
+            panic!("LED at position ({}, {}) does not exist", col, row);
         }
         LedMatrixLed { matrix, col, row }
     }


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes a typo in an LED Matrix message.

### Testing Strategy

N/A

### TODO or Help Wanted

N/A

### Documentation Updated

- [x] No updates are required.

### Formatting

- [x] Ran `make prepush`.
