### PR TITLE
Rename allow's argument from slice to buffer

### DIFF
--- a/kernel/src/syscall_driver.rs
+++ b/kernel/src/syscall_driver.rs
@@ -204,9 +204,9 @@ pub trait SyscallDriver {
         &self,
         process_id: ProcessId,
         allow_num: usize,
-        slice: ReadWriteProcessBuffer,
+        buffer: ReadWriteProcessBuffer,
     ) -> Result<ReadWriteProcessBuffer, (ReadWriteProcessBuffer, ErrorCode)> {
-        Err((slice, ErrorCode::NOSUPPORT))
+        Err((buffer, ErrorCode::NOSUPPORT))
     }
 
     /// System call for a process to pass a read-only buffer (a
@@ -219,9 +219,9 @@ pub trait SyscallDriver {
         &self,
         process_id: ProcessId,
         allow_num: usize,
-        slice: ReadOnlyProcessBuffer,
+        buffer: ReadOnlyProcessBuffer,
     ) -> Result<ReadOnlyProcessBuffer, (ReadOnlyProcessBuffer, ErrorCode)> {
-        Err((slice, ErrorCode::NOSUPPORT))
+        Err((buffer, ErrorCode::NOSUPPORT))
     }
 
     /// Request to allocate a capsule's grant for a specific process.


### PR DESCRIPTION
### Pull Request Overview

This pull request changes the name of the `allow...`'s argument from `slice` to `buffer`. This better reflects the meaning of the argument as it is not a Rust slice, but a `buffer` shared by a process.

While teaching a Tock workshop and explaining the way that the `allow...` functions work, I realized that the name seems to confuse students, as it was not clear that the parameter is not a Rust slice, but an entry point to it.

Additionally, this pull request updates the porting documentation to reflect the new types.

### Testing Strategy

N/A

### TODO or Help Wanted

N/A

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
