### PR TITLE
[arm] Cortex M0+ region

### DIFF
--- a/arch/cortex-m/src/mpu.rs
+++ b/arch/cortex-m/src/mpu.rs
@@ -1,4 +1,4 @@
-//! Implementation of the memory protection unit for the Cortex-M3,
+//! Implementation of the memory protection unit for the Cortex-M0+, Cortex-M3,
 //! Cortex-M4, and Cortex-M7
 
 use core::cell::Cell;
@@ -129,7 +129,7 @@ const MPU_BASE_ADDRESS: StaticRef<MpuRegisters> =
 ///
 /// There should only be one instantiation of this object as it represents
 /// real hardware.
-pub struct MPU<const NUM_REGIONS: usize> {
+pub struct MPU<const NUM_REGIONS: usize, const MIN_REGION_SIZE: usize> {
     /// MMIO reference to MPU registers.
     registers: StaticRef<MpuRegisters>,
     /// Optimization logic. This is used to indicate which application the MPU
@@ -138,7 +138,7 @@ pub struct MPU<const NUM_REGIONS: usize> {
     hardware_is_configured_for: OptionalCell<ProcessId>,
 }
 
-impl<const NUM_REGIONS: usize> MPU<NUM_REGIONS> {
+impl<const NUM_REGIONS: usize, const MIN_REGION_SIZE: usize> MPU<NUM_REGIONS, MIN_REGION_SIZE> {
     pub const unsafe fn new() -> Self {
         Self {
             registers: MPU_BASE_ADDRESS,
@@ -360,7 +360,9 @@ impl CortexMRegion {
     }
 }
 
-impl<const NUM_REGIONS: usize> mpu::MPU for MPU<NUM_REGIONS> {
+impl<const NUM_REGIONS: usize, const MIN_REGION_SIZE: usize> mpu::MPU
+    for MPU<NUM_REGIONS, MIN_REGION_SIZE>
+{
     type MpuConfig = CortexMConfig<NUM_REGIONS>;
 
     fn clear_mpu(&self) {
@@ -406,14 +408,14 @@ impl<const NUM_REGIONS: usize> mpu::MPU for MPU<NUM_REGIONS> {
         let mut start = unallocated_memory_start as usize;
         let mut size = min_region_size;
 
-        // Region start always has to align to 32 bytes
-        if start % 32 != 0 {
-            start += 32 - (start % 32);
+        // Region start always has to align to minimum region size bytes
+        if start % MIN_REGION_SIZE != 0 {
+            start += MIN_REGION_SIZE - (start % MIN_REGION_SIZE);
         }
 
-        // Regions must be at least 32 bytes
-        if size < 32 {
-            size = 32;
+        // Regions must be at least minimum region size bytes
+        if size < MIN_REGION_SIZE {
+            size = MIN_REGION_SIZE;
         }
 
         // Physical MPU region (might be larger than logical region if some subregions are disabled)

--- a/arch/cortex-m0p/src/lib.rs
+++ b/arch/cortex-m0p/src/lib.rs
@@ -5,7 +5,7 @@
 #![no_std]
 
 pub mod mpu {
-    pub type MPU = cortexm::mpu::MPU<8>;
+    pub type MPU = cortexm::mpu::MPU<8, 256>;
 }
 
 // Re-export the base generic cortex-m functions here as they are

--- a/arch/cortex-m3/src/lib.rs
+++ b/arch/cortex-m3/src/lib.rs
@@ -5,7 +5,7 @@
 #![no_std]
 
 pub mod mpu {
-    pub type MPU = cortexm::mpu::MPU<8>;
+    pub type MPU = cortexm::mpu::MPU<8, 32>;
 }
 
 // Re-export the base generic cortex-m functions here as they are

--- a/arch/cortex-m4/src/lib.rs
+++ b/arch/cortex-m4/src/lib.rs
@@ -5,7 +5,7 @@
 #![no_std]
 
 pub mod mpu {
-    pub type MPU = cortexm::mpu::MPU<8>;
+    pub type MPU = cortexm::mpu::MPU<8, 32>;
 }
 
 // Re-export the base generic cortex-m functions here as they are

--- a/arch/cortex-m7/src/lib.rs
+++ b/arch/cortex-m7/src/lib.rs
@@ -5,7 +5,7 @@
 #![no_std]
 
 pub mod mpu {
-    pub type MPU = cortexm::mpu::MPU<16>; // Cortex-M7 MPU has 16 regions
+    pub type MPU = cortexm::mpu::MPU<16, 32>; // Cortex-M7 MPU has 16 regions
 }
 
 // Re-export the base generic cortex-m functions here as they are


### PR DESCRIPTION
### Pull Request Overview

This pull request adds the ability to set the Cortex-M MPU minimum region size.

According to the [Cortex M0+ MPU documentation](https://developer.arm.com/documentation/dui0662/b/Cortex-M0--Peripherals/Memory-Protection-Unit/MPU-Region-Attribute-and-Size-Register?lang=en) the minimum region size is 256B as opposed to Cortex-M3, M4 and M7 where the minimum size is 32B.


### Testing Strategy

Still testing

### TODO or Help Wanted

I'm not sure about the region alignment requirements, I think the minimum alignment should be 256 for Cortex M0+, as regions have to be aligned to the base address.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
