### PR TITLE
fix MLFQ component after kernel reorg

### DIFF
--- a/boards/components/src/sched/mlfq.rs
+++ b/boards/components/src/sched/mlfq.rs
@@ -18,8 +18,8 @@ use kernel::static_init_half;
 macro_rules! mlfq_component_helper {
     ($A:ty, $N:expr $(,)?) => {{
         use core::mem::MaybeUninit;
+        use kernel::scheduler::mlfq::{MLFQProcessNode, MLFQSched};
         use kernel::static_init;
-        use kernel::{MLFQProcessNode, MLFQSched};
         static mut BUF1: MaybeUninit<VirtualMuxAlarm<'static, $A>> = MaybeUninit::uninit();
         static mut BUF2: MaybeUninit<MLFQSched<'static, VirtualMuxAlarm<'static, $A>>> =
             MaybeUninit::uninit();


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes the imports in the `mlfq_component_helper`. I found this while testing out different schedulers for Tock 2.0 testing. macros are not compiled by default unless they are called, so this went unnoticed when the kernel reorganization happened as no upstream boards use this scheduler.


### Testing Strategy

This pull request was tested by running 3 apps on Imix using the MLFQ scheduler.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] No updates are required.

### Formatting

- [x] Ran `make prepush`.
