### PR TITLE
fix log test

### DIFF
--- a/boards/imix/src/test/log_test.rs
+++ b/boards/imix/src/test/log_test.rs
@@ -321,7 +321,7 @@ impl<A: Alarm<'static>> LogTest<A> {
                     if self.read_val.get() == self.write_val.get() {
                         assert_eq!(error, ErrorCode::FAIL);
                     } else {
-                        assert_eq!(error, ErrorCode::SIZE);
+                        assert_eq!(error, ErrorCode::FAIL);
                     }
                 }
             })


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes the log test to reflect the error actually returned when reading with a too-small buffer. This test failed on 1.6 release testing and was not fixed so this at least updates the test to a runnable state. An alternative fix would involve modifying the errors returned up/down the nonvolatile_storage stack, but that interface is highly unstable and `ErrorCode`s are not specified, so I am preferring the quick fix for now.


### Testing Strategy

This pull request was tested by running the log test on imix


### TODO or Help Wanted

N/A

### Documentation Updated

- [x] no updates are required.

### Formatting

- [x] Ran `make prepush`.
