### PR TITLE
Kernel panic debug: Add grant region breakdown

### DIFF
--- a/kernel/src/process_standard.rs
+++ b/kernel/src/process_standard.rs
@@ -1135,9 +1135,7 @@ impl<C: Chip> Process for ProcessStandard<'_, C> {
              \r\n ║  Address  │ Region Name    Used | Allocated (bytes)  ║\
              \r\n ╚{:#010X}═╪══════════════════════════════════════════╝\
              \r\n             │ Grant Ptrs   {:6}\
-             \r\n  {:#010X} ┼───────────────────────────────────────────\
              \r\n             │ Upcalls      {:6}\
-             \r\n  {:#010X} ┼───────────────────────────────────────────\
              \r\n             │ Process      {:6}\
              \r\n  {:#010X} ┼───────────────────────────────────────────\
              \r\n             │ ▼ Grant      {:6} | {:6}{}\
@@ -1146,9 +1144,7 @@ impl<C: Chip> Process for ProcessStandard<'_, C> {
              \r\n  {:#010X} ┼───────────────────────────────────────────",
             sram_end,
             sram_grant_pointers_size,
-            sram_grant_pointers_start,
             sram_upcall_list_size,
-            sram_upcall_list_start,
             sram_process_struct_size,
             process_struct_memory_location,
             sram_grant_size,

--- a/kernel/src/process_standard.rs
+++ b/kernel/src/process_standard.rs
@@ -1074,8 +1074,16 @@ impl<C: Chip> Process for ProcessStandard<'_, C> {
         let flash_app_start = flash_start + flash_protected_size;
         let flash_app_size = flash_end - flash_app_start;
 
+        // Grant pointers size.
+        let grant_ptr_size = mem::size_of::<GrantPointerEntry>();
+        let grant_ptrs_num = self.kernel.get_grant_count_and_finalize();
+        let sram_grant_pointers_size = grant_ptrs_num * grant_ptr_size;
+
         // SRAM addresses
         let sram_end = self.mem_end() as usize;
+        let sram_grant_pointers_start = sram_end - sram_grant_pointers_size;
+        let sram_upcall_list_start = sram_grant_pointers_start - Self::CALLBACKS_OFFSET;
+        let process_struct_memory_location = sram_upcall_list_start - Self::PROCESS_STRUCT_OFFSET;
         let sram_grant_start = self.kernel_memory_break.get() as usize;
         let sram_heap_end = self.app_break.get() as usize;
         let sram_heap_start: Option<usize> = self.debug.map_or(None, |debug| {
@@ -1090,8 +1098,10 @@ impl<C: Chip> Process for ProcessStandard<'_, C> {
         let sram_start = self.mem_start() as usize;
 
         // SRAM sizes
-        let sram_grant_size = sram_end - sram_grant_start;
-        let sram_grant_allocated = sram_end - sram_grant_start;
+        let sram_upcall_list_size = Self::CALLBACKS_OFFSET;
+        let sram_process_struct_size = Self::PROCESS_STRUCT_OFFSET;
+        let sram_grant_size = process_struct_memory_location - sram_grant_start;
+        let sram_grant_allocated = process_struct_memory_location - sram_grant_start;
 
         // application statistics
         let events_queued = self.tasks.map_or(0, |tasks| tasks.len());
@@ -1124,11 +1134,23 @@ impl<C: Chip> Process for ProcessStandard<'_, C> {
              \r\n ╔═══════════╤══════════════════════════════════════════╗\
              \r\n ║  Address  │ Region Name    Used | Allocated (bytes)  ║\
              \r\n ╚{:#010X}═╪══════════════════════════════════════════╝\
+             \r\n             │ Grant Ptrs   {:6}\
+             \r\n  {:#010X} ┼───────────────────────────────────────────\
+             \r\n             │ Upcalls      {:6}\
+             \r\n  {:#010X} ┼───────────────────────────────────────────\
+             \r\n             │ Process      {:6}\
+             \r\n  {:#010X} ┼───────────────────────────────────────────\
              \r\n             │ ▼ Grant      {:6} | {:6}{}\
              \r\n  {:#010X} ┼───────────────────────────────────────────\
              \r\n             │ Unused\
              \r\n  {:#010X} ┼───────────────────────────────────────────",
             sram_end,
+            sram_grant_pointers_size,
+            sram_grant_pointers_start,
+            sram_upcall_list_size,
+            sram_upcall_list_start,
+            sram_process_struct_size,
+            process_struct_memory_location,
             sram_grant_size,
             sram_grant_allocated,
             exceeded_check(sram_grant_size, sram_grant_allocated),


### PR DESCRIPTION
### Pull Request Overview

This updates the process panic!() printout to look like:

```
...
 ╔═══════════╤══════════════════════════════════════════╗
 ║  Address  │ Region Name    Used | Allocated (bytes)  ║
 ╚0x20008000═╪══════════════════════════════════════════╝
             │ Grant Ptrs      112
             │ Upcalls         360
             │ Process         652
  0x20007B9C ┼───────────────────────────────────────────
             │ ▼ Grant          20 |     20
  0x20007B88 ┼───────────────────────────────────────────
             │ Unused
  0x200069F8 ┼───────────────────────────────────────────
             │ ▲ Heap            0 |   4496               S
  0x200069F8 ┼─────────────────────────────────────────── R
             │ Data            504 |    504               A
  0x20006800 ┼─────────────────────────────────────────── M
             │ ▼ Stack        2048 |   2048
  0x20006000 ┼───────────────────────────────────────────
             │ Unused
  0x20006000 ┴───────────────────────────────────────────
             .....
  0x00030800 ┬─────────────────────────────────────────── F
             │ App Flash      1992                        L
  0x00030038 ┼─────────────────────────────────────────── A
             │ Protected        56                        S
  0x00030000 ┴─────────────────────────────────────────── H
...
```

Notice the increased detail in the "grant" region.


### Testing Strategy

Running crash dummy on hail.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
