### PR TITLE
fix broken error handling in allow for udp

### DIFF
--- a/capsules/src/net/udp/driver.rs
+++ b/capsules/src/net/udp/driver.rs
@@ -358,10 +358,10 @@ impl<'a> SyscallDriver for UDPDriver<'a> {
             _ => Err(ErrorCode::NOSUPPORT),
         };
 
-        if let Err(e) = res {
-            Err((slice, e))
-        } else {
-            Ok(slice)
+        match res {
+            Err(e) => Err((slice, e)),
+            Ok(Err(e)) => Err((slice, e)),
+            Ok(Ok(())) => Ok(slice),
         }
     }
 


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes incorrect error handling in the body of `allow_readwrite()` for the UDP driver. This mistake seems quite easy to make as a result of having two implementations of `From` for `Error` -> `ErrorCode` and `Error` -> `Result<(), ErrorCode>`. I plan to submit a followup PR that checks other drivers for this issue and restructures the interface somehow to make mistakes like this one more difficult, but this is a band-aid to allow us to finish release testing.


### Testing Strategy

This pull request was tested by running the UDP virtualization test apps that force allow failures and confirm they fail.


### TODO or Help Wanted

N/A

### Documentation Updated

- [x] No updates are required.

### Formatting

- [ ] Ran `make prepush`.
