### PR TITLE
[rp2040] Fixed gpio pin numbers in interrupt handler

### DIFF
--- a/chips/rp2040/src/gpio.rs
+++ b/chips/rp2040/src/gpio.rs
@@ -342,15 +342,15 @@ impl<'a> RPPins<'a> {
             for pin in 0..8 {
                 let l_low_reg_no = pin * 4;
                 if (current_val & enabled_val & (1 << l_low_reg_no)) != 0 {
-                    self.pins[pin * bank_no].handle_interrupt();
+                    self.pins[pin + bank_no * 8].handle_interrupt();
                 } else if (current_val & enabled_val & (1 << l_low_reg_no + 1)) != 0 {
-                    self.pins[pin * bank_no].handle_interrupt();
+                    self.pins[pin + bank_no * 8].handle_interrupt();
                 } else if (current_val & enabled_val & (1 << l_low_reg_no + 2)) != 0 {
                     self.gpio_registers.intr[bank_no].set(current_val & (1 << l_low_reg_no + 2));
-                    self.pins[pin * bank_no].handle_interrupt();
+                    self.pins[pin + bank_no * 8].handle_interrupt();
                 } else if (current_val & enabled_val & (1 << l_low_reg_no + 3)) != 0 {
                     self.gpio_registers.intr[bank_no].set(current_val & (1 << l_low_reg_no + 3));
-                    self.pins[pin * bank_no].handle_interrupt();
+                    self.pins[pin + bank_no * 8].handle_interrupt();
                 }
             }
         }


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes the pin number resolution within the interrupt handler. This issue showed up when testing the button example.


### Testing Strategy

This pull request was tested using the Pico Explorer Board.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
