### PR TITLE
Add a kernel config option to elide process printing code

### DIFF
--- a/kernel/src/config.rs
+++ b/kernel/src/config.rs
@@ -40,6 +40,27 @@ pub(crate) struct Config {
     /// into which SRAM addresses. This can be useful to debug whether the kernel could
     /// successfully load processes, and whether the allocated SRAM is as expected.
     pub(crate) debug_load_processes: bool,
+
+    /// Whether the kernel should output additional debug information on panics.
+    ///
+    /// If enabled, the kernel will include implementations of `Process::print_full_process()` and
+    /// `Process::print_memory_map()` that display the process's state in a human-readable
+    /// form.
+    // This config option is intended to allow for smaller kernel builds (in
+    // terms of code size) where printing code is removed from the kernel
+    // binary. Ideally, the compiler would automatically remove
+    // printing/debugging functions if they are never called, but due to
+    // limitations in Rust (as of Sep 2021) that does not happen if the
+    // functions are part of a trait (see
+    // https://github.com/tock/tock/issues/2594).
+    //
+    // Attempts to separate the printing/debugging code from the Process trait
+    // have only been moderately successful (see
+    // https://github.com/tock/tock/pull/2826 and
+    // https://github.com/tock/tock/pull/2759). Until a more complete solution
+    // is identified, using configuration constants is the most effective
+    // option.
+    pub(crate) debug_panics: bool,
 }
 
 /// A unique instance of `Config` where compile-time configuration options are defined. These
@@ -47,4 +68,5 @@ pub(crate) struct Config {
 pub(crate) const CONFIG: Config = Config {
     trace_syscalls: false,
     debug_load_processes: false,
+    debug_panics: true,
 };

--- a/kernel/src/process_standard.rs
+++ b/kernel/src/process_standard.rs
@@ -1067,6 +1067,9 @@ impl<C: Chip> Process for ProcessStandard<'_, C> {
     }
 
     fn print_memory_map(&self, writer: &mut dyn Write) {
+        if !config::CONFIG.debug_panics {
+            return;
+        }
         // Flash
         let flash_end = self.flash.as_ptr().wrapping_add(self.flash.len()) as usize;
         let flash_start = self.flash.as_ptr() as usize;
@@ -1226,6 +1229,9 @@ impl<C: Chip> Process for ProcessStandard<'_, C> {
     }
 
     fn print_full_process(&self, writer: &mut dyn Write) {
+        if !config::CONFIG.debug_panics {
+            return;
+        }
         self.print_memory_map(writer);
 
         self.stored_state.map(|stored_state| {
@@ -1316,6 +1322,8 @@ impl<C: Chip> Process for ProcessStandard<'_, C> {
     }
 }
 
+// Only used if debug_panics == true
+#[allow(unused)]
 fn exceeded_check(size: usize, allocated: usize) -> &'static str {
     if size > allocated {
         " EXCEEDED!"


### PR DESCRIPTION
### Pull Request Overview

This pull request adds a config option to disable printing exta process info in ProcessStandard in the event of a panic.
It does so by early-returning from `print_full_process()` and `print_memory_map()`. This is necessary because Rust cannot use  dead code elimination to remove uncalled functions from a binary if those functions are behind a trait object reference. Turning off this config option reduces code size by 7792 bytes on Imix.

I realize this sort of use of Config can be controversial so I am open to alternatives. But 8kB of overhead is a lot to be non-optional.

This can wait until after Tock 2.0.

### Testing Strategy

This pull request was tested by compiling with the option set to both true and false.


### TODO or Help Wanted

N/A

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
