### PR TITLE
boards/litex: bump targeted tock-litex release

### DIFF
--- a/boards/litex/arty/README.md
+++ b/boards/litex/arty/README.md
@@ -41,7 +41,7 @@ Verilog files) can be obtained from the [Tock on LiteX companion
 repository
 releases](https://github.com/lschuermann/tock-litex/releases/). The
 current board definition has been verified to work with [release
-2021072001](https://github.com/lschuermann/tock-litex/releases/tag/2021072001). The
+2021081101](https://github.com/lschuermann/tock-litex/releases/tag/2021081101). The
 bitstream for this board is located in `digilent_arty_a7-35t.zip`
 under `gateware/digilent_arty.bit`.
 

--- a/boards/litex/sim/README.md
+++ b/boards/litex/sim/README.md
@@ -32,6 +32,14 @@ simply changing the variables in
 cores and perform further modifications, the `src/main.rs` file will
 have to be modified.
 
+This board makes assumptions about the generated LiteX SoC, such as
+CSR locations in memory. The companion repository
+[tock-litex](https://github.com/lschuermann/tock-litex) provides
+access to an environment with the required LiteX Python packages in
+their targeted versions. This board currently targets the release
+[2021081101](https://github.com/lschuermann/tock-litex/releases/tag/2021081101)
+of `tock-litex`.
+
 
 Building the SoC / Running the simulation
 -----------------------------------------


### PR DESCRIPTION
### Pull Request Overview

The previous release of the `tock-litex` companion repository updated the targeted version of the VexRiscv CPU. The PMP implementation of VexRiscv experienced a regression in that the TOR addressing mode is no longer supported. This collides with the expectations of the current PMP implementation in Tock. For Tock 2.0, this simply downgrades the VexRiscv CPU to an older version where TOR addressing is still supported. In the future, either the VexRiscv CPU will need to support TOR again, or an alternative PMP implementation for Tock needs to be written.


### Testing Strategy

This pull request was tested as part of the Tock 2.0 release testing.


### TODO or Help Wanted

N/A

### Documentation Updated

- [x] ~Updated the relevant files in `/docs`, or~ no updates are required.

### Formatting

- [x] Ran `make prepush`.
