### PR TITLE
boards/nrf52840: fix button driver number in Grant allocation

### DIFF
--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -318,7 +318,7 @@ pub unsafe fn main() {
 
     let button = components::button::ButtonComponent::new(
         board_kernel,
-        capsules::alarm::DRIVER_NUM,
+        capsules::button::DRIVER_NUM,
         components::button_component_helper!(
             nrf52840::gpio::GPIOPin,
             (


### PR DESCRIPTION
### Pull Request Overview

The button driver as installed on the nRF52840DK board definition used an incorrect driver number for its Grant allocation. Change it to the correct one such that subscribe system calls will be handled properly.

### Testing Strategy

Run the `examples/buttons` app on the nRF52840DK without and with this fix.

### TODO or Help Wanted

N/A

### Documentation Updated

- [x] ~Updated the relevant files in `/docs`, or~ no updates are required.

### Formatting

- [x] Ran `make prepush`.
