### PR TITLE
OpenTitan: Flash fixes

### DIFF
--- a/boards/earlgrey-nexysvideo/layout.ld
+++ b/boards/earlgrey-nexysvideo/layout.ld
@@ -1,7 +1,11 @@
 MEMORY
 {
   rom   (rx)  : ORIGIN = 0x20000000, LENGTH = 0x30000
-  prog  (rx)  : ORIGIN = 0x20030000, LENGTH = 0x100000-0x30000
+  /* The Nexys video has half the amount of flash.
+   * So we only support up to 0x2006_0000 for apps
+   * and 0x2006_0000 to 0x2008_0000 is for flash storage.
+   */
+  prog  (rx)  : ORIGIN = 0x20030000, LENGTH = 0x30000
   ram   (!rx) : ORIGIN = 0x10000000, LENGTH = 0x10000
 }
 

--- a/boards/earlgrey-nexysvideo/src/main.rs
+++ b/boards/earlgrey-nexysvideo/src/main.rs
@@ -416,8 +416,8 @@ unsafe fn setup() -> (
     // TicKV
     let tickv = components::tickv::TicKVComponent::new(
         &mux_flash,                                  // Flash controller
-        0x20040000 / lowrisc::flash_ctrl::PAGE_SIZE, // Region offset (size / page_size)
-        0x40000,                                     // Region size
+        0x20060000 / lowrisc::flash_ctrl::PAGE_SIZE, // Region offset (size / page_size)
+        0x20000,                                     // Region size
         flash_ctrl_read_buf,                         // Buffer used internally in TicKV
         page_buffer,                                 // Buffer used with the flash controller
     )

--- a/capsules/src/tickv.rs
+++ b/capsules/src/tickv.rs
@@ -97,7 +97,7 @@ impl<'a, F: Flash> tickv::flash_controller::FlashController<64> for TickFSFlastC
 
         if self
             .flash
-            .write_page((0x20040000 + address) / 64, data_buf)
+            .write_page((0x20060000 + address) / 64, data_buf)
             .is_err()
         {
             return Err(tickv::error_codes::ErrorCode::WriteFail);

--- a/chips/lowrisc/src/flash_ctrl.rs
+++ b/chips/lowrisc/src/flash_ctrl.rs
@@ -422,11 +422,6 @@ impl<'a> FlashCtrl<'a> {
                     }
                 }
             } else if self.registers.control.matches_all(CONTROL::OP::ERASE) {
-                // Disable erase
-                self.registers
-                    .mp_bank_cfg
-                    .modify(MP_BANK_CFG::ERASE_EN_0::CLEAR + MP_BANK_CFG::ERASE_EN_1::CLEAR);
-
                 self.flash_client.map(move |client| {
                     client.erase_complete(hil::flash::Error::CommandComplete);
                 });
@@ -552,10 +547,10 @@ impl hil::flash::Flash for FlashCtrl<'_> {
             self.configure_info_partition(FlashBank::BANK0, self.region_num);
         }
 
-        // Enable erase
+        // Disable bank erase
         self.registers
             .mp_bank_cfg
-            .modify(MP_BANK_CFG::ERASE_EN_0::SET + MP_BANK_CFG::ERASE_EN_1::SET);
+            .modify(MP_BANK_CFG::ERASE_EN_0::CLEAR + MP_BANK_CFG::ERASE_EN_1::CLEAR);
 
         // Set the address
         self.registers.addr.write(ADDR::START.val(addr as u32));

--- a/chips/lowrisc/src/flash_ctrl.rs
+++ b/chips/lowrisc/src/flash_ctrl.rs
@@ -453,7 +453,7 @@ impl hil::flash::Flash for FlashCtrl<'_> {
 
         if !self.info_configured.get() {
             // If we aren't configured yet, configure now
-            self.configure_info_partition(FlashBank::BANK0, self.region_num);
+            self.configure_info_partition(FlashBank::BANK1, self.region_num);
         }
 
         // Enable interrupts and set the FIFO level
@@ -492,7 +492,7 @@ impl hil::flash::Flash for FlashCtrl<'_> {
 
         if !self.info_configured.get() {
             // If we aren't configured yet, configure now
-            self.configure_info_partition(FlashBank::BANK0, self.region_num);
+            self.configure_info_partition(FlashBank::BANK1, self.region_num);
         }
 
         // Set the address
@@ -544,7 +544,7 @@ impl hil::flash::Flash for FlashCtrl<'_> {
 
         if !self.info_configured.get() {
             // If we aren't configured yet, configure now
-            self.configure_info_partition(FlashBank::BANK0, self.region_num);
+            self.configure_info_partition(FlashBank::BANK1, self.region_num);
         }
 
         // Disable bank erase

--- a/tools/board-runner/src/earlgrey_nexysvideo.rs
+++ b/tools/board-runner/src/earlgrey_nexysvideo.rs
@@ -413,8 +413,8 @@ fn earlgrey_nexysvideo_sha_hmac_test() -> Result<(), Error> {
     p.exp_string("SHA Example Test")?;
 
     p.exp_string("Running HMAC...")?;
-    p.exp_string("0: 0xbb")?;
-    p.exp_string("10: 0x53")?;
+    p.exp_string("0: 0xeb")?;
+    p.exp_string("10: 0xde")?;
 
     p.exp_string("Running SHA...")?;
     p.exp_string("0: 0x68")?;


### PR DESCRIPTION
### Pull Request Overview

There was a bug in the OpenTitan flash controller where the app flash at and above 0x2004_0000 was erased (set to all 1s).

The problem is that this was really hard to fix.

It turns out that the flash on the Nexys Video FPGA board is cut in half (https://github.com/lowRISC/opentitan/issues/7730) so the address would wrap around.

This PR fixes the flash controller to not access the high addresses of flash to avoid the wrap around issue in hardware. This fixes all OT release tests.

### Testing Strategy

Run the release tests and kernel unit tests.

### TODO or Help Wanted

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
