### PR TITLE
Quick fix elf2uf2 installation steps

### DIFF
--- a/boards/nano_rp2040_connect/README.md
+++ b/boards/nano_rp2040_connect/README.md
@@ -19,10 +19,11 @@ To install `elf2uf2`, run the commands:
 
 ```bash
 $ git clone https://github.com/raspberrypi/pico-sdk
-$ mkdir build
-$ cd mkdir
-$ cmake ..
+$ cd pico-sdk
 $ cd tools/elf2uf2
+$ mkdir build
+$ cd build
+$ cmake ..
 $ make
 $ sudo cp elf2uf2 /usr/local/bin
 ```


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes  the installation steps of the elf2uf2 utility which is needed for the Nano RP2040.


### Testing Strategy

N/A


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the /boards/nano_rp2040_connect README

### Formatting

- [x] Ran `make prepush`.
