### PR TITLE
nrf: pwm: handle 0 hz case

### DIFF
--- a/chips/nrf52/src/pwm.rs
+++ b/chips/nrf52/src/pwm.rs
@@ -189,6 +189,11 @@ impl Pwm {
         frequency_hz: usize,
         duty_cycle: usize,
     ) -> Result<(), ErrorCode> {
+        // If frequency is 0, we can just stop the PWM and have it do nothing.
+        if frequency_hz == 0 {
+            return self.stop_pwm(pin);
+        }
+
         let prescaler = 0;
         let counter_top = (16000000 / frequency_hz) >> prescaler;
 


### PR DESCRIPTION
### Pull Request Overview

The nRF PWM driver would happily divide by zero, causing a crash. Since we shouldn't trust the capsule to call the API correctly (even though I'm not sure if setting a frequency of 0 is allowed), this check prevents the possibility of a crash.

The change will cancel any ongoing PWM, or is effectively a no-op if PWM isn't active.



### Testing Strategy

The libtock-c music app with REST notes.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
