### PR TITLE
kernel: process: Split panic debug functions to their own trait

### DIFF
--- a/kernel/src/debug.rs
+++ b/kernel/src/debug.rs
@@ -58,7 +58,7 @@ use crate::collections::queue::Queue;
 use crate::collections::ring_buffer::RingBuffer;
 use crate::hil;
 use crate::platform::chip::Chip;
-use crate::process::Process;
+use crate::process::ProcessDebug;
 use crate::utilities::cells::NumericCellExt;
 use crate::utilities::cells::{MapCell, TakeCell};
 use crate::ErrorCode;
@@ -103,7 +103,7 @@ pub unsafe fn panic_print<W: Write + IoWrite, C: Chip>(
     writer: &mut W,
     panic_info: &PanicInfo,
     nop: &dyn Fn(),
-    processes: &'static [Option<&'static dyn Process>],
+    processes: &'static [Option<&'static dyn ProcessDebug>],
     chip: &'static Option<&'static C>,
 ) {
     panic_begin(nop);
@@ -122,7 +122,7 @@ pub unsafe fn panic<L: hil::led::Led, W: Write + IoWrite, C: Chip>(
     writer: &mut W,
     panic_info: &PanicInfo,
     nop: &dyn Fn(),
-    processes: &'static [Option<&'static dyn Process>],
+    processes: &'static [Option<&'static dyn ProcessDebug>],
     chip: &'static Option<&'static C>,
 ) -> ! {
     // Call `panic_print` first which will print out the panic
@@ -177,7 +177,7 @@ pub unsafe fn panic_cpu_state<W: Write, C: Chip>(
 ///
 /// **NOTE:** The supplied `writer` must be synchronous.
 pub unsafe fn panic_process_info<W: Write>(
-    procs: &'static [Option<&'static dyn Process>],
+    procs: &'static [Option<&'static dyn ProcessDebug>],
     writer: &mut W,
 ) {
     // print data about each process

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -168,9 +168,11 @@ impl ProcessId {
     }
 }
 
+pub trait Process: ProcessMain + ProcessDebug {}
+
 /// This trait represents a generic process that the Tock scheduler can
 /// schedule.
-pub trait Process {
+pub trait ProcessMain {
     /// Returns the process's identifier.
     fn processid(&self) -> ProcessId;
 
@@ -536,14 +538,6 @@ pub trait Process {
     /// switched to.
     fn switch_to(&self) -> Option<syscall::ContextSwitchReason>;
 
-    /// Print out the memory map (Grant region, heap, stack, program
-    /// memory, BSS, and data sections) of this process.
-    fn print_memory_map(&self, writer: &mut dyn Write);
-
-    /// Print out the full state of the process: its memory map, its
-    /// context, and the state of the memory protection unit (MPU).
-    fn print_full_process(&self, writer: &mut dyn Write);
-
     // debug
 
     /// Returns how many syscalls this app has called.
@@ -570,6 +564,16 @@ pub trait Process {
 
     /// Return the lowest recorded address of the process stack, if known.
     fn debug_stack_end(&self) -> Option<*const u8>;
+}
+
+pub trait ProcessDebug {
+    /// Print out the memory map (Grant region, heap, stack, program
+    /// memory, BSS, and data sections) of this process.
+    fn print_memory_map(&self, writer: &mut dyn Write);
+
+    /// Print out the full state of the process: its memory map, its
+    /// context, and the state of the memory protection unit (MPU).
+    fn print_full_process(&self, writer: &mut dyn Write);
 }
 
 /// Opaque identifier for custom grants allocated dynamically from a process's

--- a/kernel/src/process_standard.rs
+++ b/kernel/src/process_standard.rs
@@ -17,8 +17,9 @@ use crate::errorcode::ErrorCode;
 use crate::kernel::Kernel;
 use crate::platform::chip::Chip;
 use crate::platform::mpu::{self, MPU};
-use crate::process::{Error, FunctionCall, FunctionCallSource, Process, State, Task};
+use crate::process::{Error, FunctionCall, FunctionCallSource, State, Task};
 use crate::process::{FaultAction, ProcessCustomGrantIdentifer, ProcessId, ProcessStateCell};
+use crate::process::{Process, ProcessDebug, ProcessMain};
 use crate::process_policies::ProcessFaultPolicy;
 use crate::process_utilities::ProcessLoadError;
 use crate::processbuffer::{ReadOnlyProcessBuffer, ReadWriteProcessBuffer};
@@ -209,7 +210,8 @@ pub struct ProcessStandard<'a, C: 'static + Chip> {
     debug: MapCell<ProcessStandardDebug>,
 }
 
-impl<C: Chip> Process for ProcessStandard<'_, C> {
+impl<C: Chip> Process for ProcessStandard<'_, C> {}
+impl<C: Chip> ProcessMain for ProcessStandard<'_, C> {
     fn processid(&self) -> ProcessId {
         self.process_id.get()
     }
@@ -1065,7 +1067,8 @@ impl<C: Chip> Process for ProcessStandard<'_, C> {
         self.debug
             .map_or(None, |debug| debug.app_stack_min_pointer.map(|p| p))
     }
-
+}
+impl<C: Chip> ProcessDebug for ProcessStandard<'_, C> {
     fn print_memory_map(&self, writer: &mut dyn Write) {
         // Flash
         let flash_end = self.flash.as_ptr().wrapping_add(self.flash.len()) as usize;


### PR DESCRIPTION
### Pull Request Overview

Split process print functions into their own trait so that Rust will elide them if the trait is never used.

I spent 6 minutes on this as a rough proof of concept. Was going alright until:

```
$ make
   Compiling kernel v0.1.0 (/Users/bradjc/git/tock/kernel)
   Compiling cortexm v0.1.0 (/Users/bradjc/git/tock/arch/cortex-m)
   Compiling capsules v0.1.0 (/Users/bradjc/git/tock/capsules)
   Compiling cortexm4 v0.1.0 (/Users/bradjc/git/tock/arch/cortex-m4)
   Compiling sam4l v0.1.0 (/Users/bradjc/git/tock/chips/sam4l)
   Compiling components v0.1.0 (/Users/bradjc/git/tock/boards/components)
   Compiling hail v0.1.0 (/Users/bradjc/git/tock/boards/hail)
error[E0308]: mismatched types
  --> boards/hail/src/io.rs:73:9
   |
73 |         &PROCESSES,
   |         ^^^^^^^^^^ expected slice, found array of 20 elements
   |
   = note: expected reference `&'static [Option<&'static (dyn ProcessDebug + 'static)>]`
              found reference `&[Option<&'static (dyn Process + 'static)>; 20]`

error: aborting due to previous error

For more information about this error, try `rustc --explain E0308`.
error: could not compile `hail`
```


### Testing Strategy

This pull request was tested by...


### TODO or Help Wanted

This pull request still needs...


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
