### PR TITLE
Prevent adding duplicates to the list

### DIFF
--- a/kernel/src/collections/list.rs
+++ b/kernel/src/collections/list.rs
@@ -47,16 +47,26 @@ impl<'a, T: ?Sized + ListNode<'a, T>> List<'a, T> {
         self.head.0.get()
     }
 
+    pub fn in_list(&self, node: &'a T) -> bool {
+        self.iter()
+            .find(|list_node| *list_node as *const T == node as *const T)
+            .is_some()
+    }
+
     pub fn push_head(&self, node: &'a T) {
-        node.next().0.set(self.head.0.get());
-        self.head.0.set(Some(node));
+        if !self.in_list(node) {
+            node.next().0.set(self.head.0.get());
+            self.head.0.set(Some(node));
+        }
     }
 
     pub fn push_tail(&self, node: &'a T) {
-        node.next().0.set(None);
-        match self.iter().last() {
-            Some(last) => last.next().0.set(Some(node)),
-            None => self.push_head(node),
+        if !self.in_list(node) {
+            node.next().0.set(None);
+            match self.iter().last() {
+                Some(last) => last.next().0.set(Some(node)),
+                None => self.push_head(node),
+            }
         }
     }
 


### PR DESCRIPTION
### Pull Request Overview

This pull request adds a check to the linked list that prevents adding duplicates.

I was trying to get the Adafruit Clue board to work for some days now. The board connected to the USB, sent its information, but seemed to get stuck afterwards. It turned out that the error was due to an infinite loop in the SPI Mux. The SPI device got added twice to the list. I am preparing another pull request to update that.

I think it might be a good idea to prevent linked lists from adding the same item twice as this leads to an infinite and issues that are difficult to debug.

An improvement to this would be to move the previous instance of the item to the desired position.

### Testing Strategy

This pull request was tested using the double `setup` of SPI from the Adafruit CLUE.


### TODO or Help Wanted

N/A

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
