### PR TITLE
Update bus to prevent adding the SPI to the MUX twice

### DIFF
--- a/boards/components/src/bus.rs
+++ b/boards/components/src/bus.rs
@@ -128,7 +128,6 @@ impl<S: 'static + spi::SpiMaster> Component for SpiMasterBusComponent<S> {
             SpiMasterBus<'static, VirtualSpiMasterDevice<'static, S>>,
             SpiMasterBus::new(static_buffer.0, static_buffer.2)
         );
-        static_buffer.0.setup();
         static_buffer.0.set_client(bus);
 
         bus

--- a/boards/components/src/l3gd20.rs
+++ b/boards/components/src/l3gd20.rs
@@ -78,7 +78,6 @@ impl<S: 'static + spi::SpiMaster> Component for L3gd20SpiComponent<S> {
                 grant
             )
         );
-        static_buffer.0.setup();
         static_buffer.0.set_client(l3gd20);
 
         // TODO verify SPI return value


### PR DESCRIPTION
### Pull Request Overview

This pull request deletes the Spi `setup` function call from the Spi `bus` and ``l3gd20` component as it was added to the SPI component (#2566). This was leading to the infinite loop mentioned in #2773.

### Testing Strategy

This pull request was tested using an Adafruit Clue


### TODO or Help Wanted

N/A

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
