### PR TITLE
Update Clue nRF52840

### DIFF
--- a/boards/clue_nrf52840/Makefile
+++ b/boards/clue_nrf52840/Makefile
@@ -21,25 +21,21 @@ KERNEL_WITH_APP=$(TOCK_ROOT_DIRECTORY)/target/$(TARGET)/debug/$(PLATFORM)-app.el
 install: program
 
 program: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/debug/$(PLATFORM).bin
-	ifndef PORT
-		$(error Please specify the serial port using the PORT variable)
-	endif
+ifeq ($(PORT),) 
+	$(error Please specify the serial port using the PORT variable)
+endif
 	adafruit-nrfutil dfu genpkg --dev-type 0x0052 --sd-req 0x00B6 --application $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/debug/$(PLATFORM).bin $(KERNEL).zip
-	echo "Trying to reset device"
-	stty -F $(PORT) 1200 && sleep 0.5 && stty -F $(PORT) 1200
-	adafruit-nrfutil --verbose dfu serial -pkg $(KERNEL).zip $(FLAGS) -b 115200 --singlebank
+	adafruit-nrfutil --verbose dfu serial -pkg $(KERNEL).zip $(FLAGS) -b 115200 --singlebank --touch 1200
 
 # Upload the kernel and apps using nrfutil
 program-apps: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/debug/$(PLATFORM).elf
-	ifndef PORT
-		$(error Please specify the serial port using the PORT variable)
-	endif
-	ifndef APP
-		$(error Please define the APP variable with the TBF file to flash an application)
-	endif
+ifeq ($(PORT),)
+	$(error Please specify the serial port using the PORT variable)
+endif
+ifeq ($(APP),)
+	$(error Please define the APP variable with the TBF file to flash an application)
+endif
 	arm-none-eabi-objcopy --update-section .apps=$(APP) $(KERNEL) $(KERNEL_WITH_APP)
 	arm-none-eabi-objcopy --output-target=binary -S $(KERNEL_WITH_APP) $(KERNEL_WITH_APP).bin
 	adafruit-nrfutil dfu genpkg --dev-type 0x0052 --sd-req 0x00B6 --application $(KERNEL_WITH_APP).bin $(KERNEL_WITH_APP).zip
-	echo "Trying to reset device"
-	stty -F $(PORT) 1200 && sleep 0.5 && stty -F $(PORT) 1200
-	adafruit-nrfutil --verbose dfu serial -pkg $(KERNEL_WITH_APP).zip $(FLAGS) -b 115200 --singlebank
+	adafruit-nrfutil --verbose dfu serial -pkg $(KERNEL_WITH_APP).zip $(FLAGS) -b 115200 --singlebank --touch 1200

--- a/boards/clue_nrf52840/src/io.rs
+++ b/boards/clue_nrf52840/src/io.rs
@@ -116,15 +116,15 @@ impl IoWrite for Writer {
     }
 }
 
-/// Default panic handler for the Nano 33 Board.
+/// Default panic handler for the Adafruit CLUE nRF52480 Express Board.
 ///
 /// We just use the standard default provided by the debug module in the kernel.
 #[cfg(not(test))]
 #[no_mangle]
 #[panic_handler]
 pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
-    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(Pin::P0_13);
-    let led = &mut led::LedLow::new(led_kernel_pin);
+    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(Pin::P1_01);
+    let led = &mut led::LedHigh::new(led_kernel_pin);
     let writer = &mut WRITER;
     debug::panic(
         &mut [led],


### PR DESCRIPTION
### Pull Request Overview

This pull request has resulted after testing for Tock 2.0:
  - use the correct panic LED
  - adds all the GPIO pins
  - adds ADC
  - sets the StopWithDebug fault policy
  - adds process console
  - adds the reset to nrf-bootloader functionallity
  - fixes the makefile to correclty verify the APP and PORT variables
  - fixes makefile to automatically reset to bbootloader



### Testing Strategy

This pull request was tested using an Adafruit Clue nRF52840 board


### TODO or Help Wanted

This pull request needs the uppdates from #2774

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
