### PR TITLE
Adjust app's watermark only for memory buffers

### DIFF
--- a/kernel/src/process_standard.rs
+++ b/kernel/src/process_standard.rs
@@ -629,7 +629,7 @@ impl<C: Chip> Process for ProcessStandard<'_, C> {
             // TODO: Check for buffer aliasing here
 
             if self.in_app_owned_memory(buf_start_addr, size) {
-                // Valid buffer, if this is a memory buffer,
+                // Valid buffer, if this is not in a read-only (e.g. flash) memory section,
                 // we need to adjust the app's watermark
                 // note: in_app_owned_memory ensures this offset does not wrap
                 let buf_end_addr = buf_start_addr.wrapping_add(size);

--- a/kernel/src/process_standard.rs
+++ b/kernel/src/process_standard.rs
@@ -628,11 +628,14 @@ impl<C: Chip> Process for ProcessStandard<'_, C> {
         {
             // TODO: Check for buffer aliasing here
 
-            // Valid buffer, we need to adjust the app's watermark
-            // note: in_app_owned_memory ensures this offset does not wrap
-            let buf_end_addr = buf_start_addr.wrapping_add(size);
-            let new_water_mark = cmp::max(self.allow_high_water_mark.get(), buf_end_addr);
-            self.allow_high_water_mark.set(new_water_mark);
+            if self.in_app_owned_memory(buf_start_addr, size) {
+                // Valid buffer, if this is a memory buffer,
+                // we need to adjust the app's watermark
+                // note: in_app_owned_memory ensures this offset does not wrap
+                let buf_end_addr = buf_start_addr.wrapping_add(size);
+                let new_water_mark = cmp::max(self.allow_high_water_mark.get(), buf_end_addr);
+                self.allow_high_water_mark.set(new_water_mark);
+            }
 
             // Clippy complains that we're deferencing a pointer in a
             // public and safe function here. While we are not


### PR DESCRIPTION
### Pull Request Overview

This pull request prevents the change of the the app watermark if the read only shared buffers are in flash.

While @valexandru  was testing the iMXRT1052 EVKB board, he found an interesting behavior for the client-service examples.

Changing the watermark for flash buffers might prevent apps form further allocating memory if the flash memory is located at an address above the RAM memory.

Take as an example an app with the following code:
```c
int main()
{
  allow_readonly (driver_num, allow_num, &"hello", 5);
  printf ("hello\n");
}
```
This app will fault (due to a `printf` memory allocation error #2603) on boards like the iMXRT1052 EVKB where the flash region is at a higher address then the RAM. This is what happens:
1. allow_readonly will place the app watermark in flash
2. printf will not be able to allocate any memory as `memop (1, 0)` fails with `NOMEM` due to the app watermark that is set to a position in flash that is at a much higher address then the requested app break of `memop`. The kernel thinks the app wants to *shrink* its memory region.

Rewriting the code:

```c
int main()
{
  printf ("hello\n");
  allow_readonly (driver_num, allow_num, &"hello", 5);
  printf ("hello\n");
}
```

makes it work, as the second time `printf` is called, it does not perform any more `memop`s calls.

I think this affects all the boards where the flash region is at a higher address than the ram.

Both examples work on the Micro:bit as the flash region is at a lower address than the RAM and sharing a flash buffer does not change the app watermark.



### Testing Strategy

This pull request was tested using an iMXRT1052 EVKB board and a Microbit board.


### TODO or Help Wanted

Some feedback, I might have missed something.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
