### PR TITLE
[stm32] Simplify enabling interrupts for gpio

### DIFF
--- a/boards/nucleo_f446re/src/main.rs
+++ b/boards/nucleo_f446re/src/main.rs
@@ -149,10 +149,9 @@ unsafe fn setup_dma(
 /// Helper function called during bring-up that configures multiplexed I/O.
 unsafe fn set_pin_primary_functions(
     syscfg: &stm32f446re::syscfg::Syscfg,
-    exti: &stm32f446re::exti::Exti,
+    _exti: &stm32f446re::exti::Exti,
     gpio_ports: &'static stm32f446re::gpio::GpioPorts<'static>,
 ) {
-    use stm32f446re::exti::LineId;
     use stm32f446re::gpio::{AlternateFunction, Mode, PinId, PortId};
 
     syscfg.enable_clock();
@@ -183,15 +182,8 @@ unsafe fn set_pin_primary_functions(
 
     // button is connected on pc13
     gpio_ports.get_pin(PinId::PC13).map(|pin| {
-        // By default, upon reset, the pin is in input mode, with no internal
-        // pull-up, no internal pull-down (i.e., floating).
-        //
-        // Only set the mapping between EXTI line and the Pin and let capsule do
-        // the rest.
-        exti.associate_line_gpiopin(LineId::Exti13, pin);
+        pin.enable_interrupt();
     });
-    // EXTI13 interrupts is delivered at IRQn 40 (EXTI15_10)
-    cortexm4::nvic::Nvic::new(stm32f446re::nvic::EXTI15_10).enable();
 }
 
 /// Helper function for miscellaneous peripheral functions

--- a/boards/stm32f3discovery/src/main.rs
+++ b/boards/stm32f3discovery/src/main.rs
@@ -139,12 +139,11 @@ impl
 /// Helper function called during bring-up that configures multiplexed I/O.
 unsafe fn set_pin_primary_functions(
     syscfg: &stm32f303xc::syscfg::Syscfg,
-    exti: &stm32f303xc::exti::Exti,
+    _exti: &stm32f303xc::exti::Exti,
     spi1: &stm32f303xc::spi::Spi,
     i2c1: &stm32f303xc::i2c::I2C,
     gpio_ports: &'static stm32f303xc::gpio::GpioPorts<'static>,
 ) {
-    use stm32f303xc::exti::LineId;
     use stm32f303xc::gpio::{AlternateFunction, Mode, PinId, PortId};
 
     syscfg.enable_clock();
@@ -183,14 +182,13 @@ unsafe fn set_pin_primary_functions(
 
     // button is connected on pa00
     gpio_ports.get_pin(PinId::PA00).map(|pin| {
-        // By default, upon reset, the pin is in input mode, with no internal
-        // pull-up, no internal pull-down (i.e., floating).
-        //
-        // Only set the mapping between EXTI line and the Pin and let capsule do
-        // the rest.
-        exti.associate_line_gpiopin(LineId::Exti0, &pin);
+        pin.enable_interrupt();
     });
-    cortexm4::nvic::Nvic::new(stm32f303xc::nvic::EXTI0).enable();
+
+    // enable interrupt for gpio 0
+    gpio_ports.get_pin(PinId::PC01).map(|pin| {
+        pin.enable_interrupt();
+    });
 
     // SPI1 has the l3gd20 sensor connected
     gpio_ports.get_pin(PinId::PA06).map(|pin| {

--- a/boards/stm32f412gdiscovery/src/main.rs
+++ b/boards/stm32f412gdiscovery/src/main.rs
@@ -155,12 +155,11 @@ unsafe fn setup_dma(
 /// Helper function called during bring-up that configures multiplexed I/O.
 unsafe fn set_pin_primary_functions(
     syscfg: &stm32f412g::syscfg::Syscfg,
-    exti: &stm32f412g::exti::Exti,
+    _exti: &stm32f412g::exti::Exti,
     i2c1: &stm32f412g::i2c::I2C,
     gpio_ports: &'static stm32f412g::gpio::GpioPorts<'static>,
 ) {
     use kernel::hil::gpio::Configure;
-    use stm32f412g::exti::LineId;
     use stm32f412g::gpio::{AlternateFunction, Mode, PinId, PortId};
 
     syscfg.enable_clock();
@@ -192,63 +191,33 @@ unsafe fn set_pin_primary_functions(
     // uncomment this if you do not plan to use the joystick up, as they both use Exti0
     // joystick selection is connected on pa00
     // gpio_ports.get_pin(PinId::PA00).map(|pin| {
-    //     // By default, upon reset, the pin is in input mode, with no internal
-    //     // pull-up, no internal pull-down (i.e., floating).
-    //     //
-    //     // Only set the mapping between EXTI line and the Pin and let capsule do
-    //     // the rest.
-    //     exti.associate_line_gpiopin(LineId::Exti0, pin);
+    //     pin.enable_interrupt();
     // });
-    // // EXTI0 interrupts is delivered at IRQn 6 (EXTI0)
-    // cortexm4::nvic::Nvic::new(stm32f412g::nvic::EXTI0).enable();
 
     // joystick down is connected on pg01
     gpio_ports.get_pin(PinId::PG01).map(|pin| {
-        // By default, upon reset, the pin is in input mode, with no internal
-        // pull-up, no internal pull-down (i.e., floating).
-        //
-        // Only set the mapping between EXTI line and the Pin and let capsule do
-        // the rest.
-        exti.associate_line_gpiopin(LineId::Exti1, pin);
+        pin.enable_interrupt();
     });
-    // EXTI1 interrupts is delivered at IRQn 7 (EXTI1)
-    cortexm4::nvic::Nvic::new(stm32f412g::nvic::EXTI1).enable();
 
     // joystick left is connected on pf15
     gpio_ports.get_pin(PinId::PF15).map(|pin| {
-        // By default, upon reset, the pin is in input mode, with no internal
-        // pull-up, no internal pull-down (i.e., floating).
-        //
-        // Only set the mapping between EXTI line and the Pin and let capsule do
-        // the rest.
-        exti.associate_line_gpiopin(LineId::Exti15, pin);
+        pin.enable_interrupt();
     });
-    // EXTI15_10 interrupts is delivered at IRQn 40 (EXTI15_10)
-    cortexm4::nvic::Nvic::new(stm32f412g::nvic::EXTI15_10).enable();
 
     // joystick right is connected on pf14
     gpio_ports.get_pin(PinId::PF14).map(|pin| {
-        // By default, upon reset, the pin is in input mode, with no internal
-        // pull-up, no internal pull-down (i.e., floating).
-        //
-        // Only set the mapping between EXTI line and the Pin and let capsule do
-        // the rest.
-        exti.associate_line_gpiopin(LineId::Exti14, pin);
+        pin.enable_interrupt();
     });
-    // EXTI15_10 interrupts is delivered at IRQn 40 (EXTI15_10)
-    cortexm4::nvic::Nvic::new(stm32f412g::nvic::EXTI15_10).enable();
 
     // joystick up is connected on pg00
     gpio_ports.get_pin(PinId::PG00).map(|pin| {
-        // By default, upon reset, the pin is in input mode, with no internal
-        // pull-up, no internal pull-down (i.e., floating).
-        //
-        // Only set the mapping between EXTI line and the Pin and let capsule do
-        // the rest.
-        exti.associate_line_gpiopin(LineId::Exti0, pin);
+        pin.enable_interrupt();
     });
-    // EXTI0 interrupts is delivered at IRQn 6 (EXTI0)
-    cortexm4::nvic::Nvic::new(stm32f412g::nvic::EXTI0).enable();
+
+    // enable interrupt for D0
+    gpio_ports.get_pin(PinId::PG09).map(|pin| {
+        pin.enable_interrupt();
+    });
 
     // Enable clocks for GPIO Ports
     // Disable some of them if you don't need some of the GPIOs
@@ -283,12 +252,7 @@ unsafe fn set_pin_primary_functions(
 
     // FT6206 interrupt
     gpio_ports.get_pin(PinId::PG05).map(|pin| {
-        // By default, upon reset, the pin is in input mode, with no internal
-        // pull-up, no internal pull-down (i.e., floating).
-        //
-        // Only set the mapping between EXTI line and the Pin and let capsule do
-        // the rest.
-        exti.associate_line_gpiopin(LineId::Exti5, pin);
+        pin.enable_interrupt();
     });
 
     // ADC

--- a/chips/stm32f303xc/src/gpio.rs
+++ b/chips/stm32f303xc/src/gpio.rs
@@ -9,7 +9,8 @@ use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeabl
 use kernel::utilities::registers::{register_bitfields, ReadOnly, ReadWrite, WriteOnly};
 use kernel::utilities::StaticRef;
 
-use crate::exti;
+use crate::exti::{self, LineId};
+use crate::nvic;
 use crate::rcc;
 
 /// General-purpose I/Os
@@ -824,6 +825,25 @@ impl<'a> Pin<'a> {
 
     pub fn get_pinid(&self) -> PinId {
         self.pinid
+    }
+
+    pub unsafe fn enable_interrupt(&'static self) {
+        let interrupt = match self.pinid.get_pin_number() {
+            0 => nvic::EXTI0,
+            1 => nvic::EXTI1,
+            2 => nvic::EXTI2,
+            3 => nvic::EXTI3,
+            4 => nvic::EXTI4,
+            5..=9 => nvic::EXTI9_5,
+            10..=15 => nvic::EXTI15_10,
+            _ => panic!("Pin {} is not valid", self.pinid.get_pin_number()),
+        };
+
+        let exti_line_id = LineId::from_u8(self.pinid.get_pin_number() as u8).unwrap();
+
+        self.exti.associate_line_gpiopin(exti_line_id, &self);
+        // enable interrupt
+        cortexm4::nvic::Nvic::new(interrupt).enable();
     }
 
     pub fn set_exti_lineid(&self, lineid: exti::LineId) {


### PR DESCRIPTION
enables interrupts for the first pin

### Pull Request Overview

This pull request adds a helper function to make enabling interrupts for gpio easier. The stm32 MCU does not provide a separate interrupt line for all the gpio pins. This makes enabling interrupts a little more difficult and requires some extra code in the board file. 

I am not the original author of the code for these boards, so I am not sure why this has been designed the way it is now.

This also enables interrupts for the first gpio exposed pin, allowing the `gpio` test to succeed.


### Testing Strategy

This pull request was tested using a nucleo F429ZI board


### TODO or Help Wanted

@yusefkarim please take a look if this works on your board.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
