### PR TITLE
ESP32-C3: Add support for running apps

### DIFF
--- a/boards/esp32-c3-devkitM-1/Makefile
+++ b/boards/esp32-c3-devkitM-1/Makefile
@@ -2,6 +2,7 @@
 
 TARGET=riscv32imc-unknown-none-elf
 PLATFORM=esp32-c3-board
+RISC_PREFIX = riscv64-linux-gnu
 
 include ../Makefile.common
 
@@ -12,6 +13,14 @@ install: flash
 flash: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
 	esptool.py --port /dev/ttyUSB0 --chip esp32c3 elf2image --use_segments --output binary.hex $^
 	esptool.py --port /dev/ttyUSB0 --chip esp32c3 write_flash --flash_mode dio --flash_size detect --flash_freq 80m  0x0 binary.hex
+
+flash-app: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
+ifeq ($(APP),)
+	$(error "Please specify an APP to be flashed")
+endif
+	$(RISC_PREFIX)-objcopy --update-section .apps=$(APP) $^ $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.elf
+	esptool.py --port /dev/ttyUSB0 --chip esp32c3 elf2image --use_segments --output binary.hex $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.elf
+	esptool.py --port /dev/ttyUSB0 --chip esp32c3 write_flash --flash_mode dio --flash_size detect --flash_freq 80m 0x0 binary.hex
 
 test:
 	mkdir -p $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/

--- a/boards/esp32-c3-devkitM-1/README.md
+++ b/boards/esp32-c3-devkitM-1/README.md
@@ -80,6 +80,9 @@ cd openocd-esp32
 make -j8
 ```
 
+Note that the connection can be unreliable, commit
+5b67ad1b15938f524f133afb8ef652c990f570eb seems to work though.
+
 Then connect an [FDTI C232HM](https://ftdichip.com/products/c232hm-ddhsl-0-2/)
 cable as described here:
 https://docs.espressif.com/projects/esp-idf/en/latest/esp32c3/api-guides/jtag-debugging/configure-other-jtag.html.

--- a/boards/esp32-c3-devkitM-1/layout.ld
+++ b/boards/esp32-c3-devkitM-1/layout.ld
@@ -1,8 +1,8 @@
 MEMORY
 {
   rom (rx)  : ORIGIN = 0x40380000, LENGTH = 0x30000
-  ram (rwx) : ORIGIN = 0x403B0000, LENGTH = 0x30000
-  prog (rx) : ORIGIN = 0x42000000, LENGTH = 0x80000
+  ram (rwx) : ORIGIN = 0x3FCA0000, LENGTH = 0x30000
+  prog (rx) : ORIGIN = 0x403B0000, LENGTH = 0x30000
 }
 
 MPU_MIN_ALIGN = 1K;


### PR DESCRIPTION
### Pull Request Overview

Add support for running Tock applications

### Testing Strategy

Run apps

### TODO or Help Wanted

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
