### PR TITLE
[stm32] Update stm32 boards

### DIFF
--- a/boards/nucleo_f446re/src/main.rs
+++ b/boards/nucleo_f446re/src/main.rs
@@ -149,10 +149,8 @@ unsafe fn setup_dma(
 /// Helper function called during bring-up that configures multiplexed I/O.
 unsafe fn set_pin_primary_functions(
     syscfg: &stm32f446re::syscfg::Syscfg,
-    exti: &stm32f446re::exti::Exti,
     gpio_ports: &'static stm32f446re::gpio::GpioPorts<'static>,
 ) {
-    use stm32f446re::exti::LineId;
     use stm32f446re::gpio::{AlternateFunction, Mode, PinId, PortId};
 
     syscfg.enable_clock();
@@ -183,15 +181,8 @@ unsafe fn set_pin_primary_functions(
 
     // button is connected on pc13
     gpio_ports.get_pin(PinId::PC13).map(|pin| {
-        // By default, upon reset, the pin is in input mode, with no internal
-        // pull-up, no internal pull-down (i.e., floating).
-        //
-        // Only set the mapping between EXTI line and the Pin and let capsule do
-        // the rest.
-        exti.associate_line_gpiopin(LineId::Exti13, pin);
+        pin.enable_interrupt();
     });
-    // EXTI13 interrupts is delivered at IRQn 40 (EXTI15_10)
-    cortexm4::nvic::Nvic::new(stm32f446re::nvic::EXTI15_10).enable();
 }
 
 /// Helper function for miscellaneous peripheral functions
@@ -247,7 +238,7 @@ pub unsafe fn main() {
 
     setup_peripherals(&base_peripherals.tim2);
 
-    set_pin_primary_functions(syscfg, &base_peripherals.exti, &base_peripherals.gpio_ports);
+    set_pin_primary_functions(syscfg, &base_peripherals.gpio_ports);
 
     setup_dma(
         dma1,
@@ -302,26 +293,6 @@ pub unsafe fn main() {
     // Create the debugger object that handles calls to `debug!()`.
     components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
 
-    // // Setup the process inspection console
-    // let process_console_uart = static_init!(UartDevice, UartDevice::new(mux_uart, true));
-    // process_console_uart.setup();
-    // pub struct ProcessConsoleCapability;
-    // unsafe impl capabilities::ProcessManagementCapability for ProcessConsoleCapability {}
-    // let process_console = static_init!(
-    //     capsules::process_console::ProcessConsole<'static, ProcessConsoleCapability>,
-    //     capsules::process_console::ProcessConsole::new(
-    //         process_console_uart,
-    //         &mut capsules::process_console::WRITE_BUF,
-    //         &mut capsules::process_console::READ_BUF,
-    //         &mut capsules::process_console::COMMAND_BUF,
-    //         board_kernel,
-    //         ProcessConsoleCapability,
-    //     )
-    // );
-    // hil::uart::Transmit::set_transmit_client(process_console_uart, process_console);
-    // hil::uart::Receive::set_receive_client(process_console_uart, process_console);
-    // process_console.start();
-
     // LEDs
     let gpio_ports = &base_peripherals.gpio_ports;
 
@@ -362,6 +333,11 @@ pub unsafe fn main() {
     )
     .finalize(components::alarm_component_helper!(stm32f446re::tim2::Tim2));
 
+    // PROCESS CONSOLE
+    let _process_console =
+        components::process_console::ProcessConsoleComponent::new(board_kernel, uart_mux)
+            .finalize(());
+
     let scheduler = components::sched::round_robin::RoundRobinComponent::new(&PROCESSES)
         .finalize(components::rr_component_helper!(NUM_PROCS));
 
@@ -386,6 +362,7 @@ pub unsafe fn main() {
     // virtual_uart_rx_test::run_virtual_uart_receive(mux_uart);
 
     debug!("Initialization complete. Entering main loop");
+    let _ = _process_console.start();
 
     /// These symbols are defined in the linker script.
     extern "C" {

--- a/boards/stm32f3discovery/Makefile
+++ b/boards/stm32f3discovery/Makefile
@@ -21,5 +21,5 @@ flash: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
 	$(OPENOCD) $(OPENOCD_OPTIONS) -c "init; reset halt; flash write_image erase $<; verify_image $<; reset; shutdown"
 
 .PHONY: program
-program: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/debug/$(PLATFORM).elf
+program: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
 	$(error See README.md and update this section accordingly)

--- a/boards/stm32f3discovery/README.md
+++ b/boards/stm32f3discovery/README.md
@@ -31,19 +31,19 @@ apps included.
 ```bash
 $ arm-none-eabi-objcopy  \
     --update-section .apps=../../../libtock-c/examples/c_hello/build/cortex-m4/cortex-m4.tbf \
-    target/thumbv7em-none-eabi/debug/stm32f3discovery.elf \
-    target/thumbv7em-none-eabi/debug/stm32f3discovery-app.elf
+    target/thumbv7em-none-eabi/release/stm32f3discovery.elf \
+    target/thumbv7em-none-eabi/release/stm32f3discovery-app.elf
 ```
 
 For example, you can update `Makefile` as follows.
 
 ```
 APP=../../../libtock-c/examples/c_hello/build/cortex-m4/cortex-m4.tbf
-KERNEL=$(TOCK_ROOT_DIRECTORY)/target/$(TARGET)/debug/$(PLATFORM).elf
-KERNEL_WITH_APP=$(TOCK_ROOT_DIRECTORY)/target/$(TARGET)/debug/$(PLATFORM)-app.elf
+KERNEL=$(TOCK_ROOT_DIRECTORY)/target/$(TARGET)/release/$(PLATFORM).elf
+KERNEL_WITH_APP=$(TOCK_ROOT_DIRECTORY)/target/$(TARGET)/release/$(PLATFORM)-app.elf
 
 .PHONY: program
-program: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/debug/$(PLATFORM).elf
+program: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
 	arm-none-eabi-objcopy --update-section .apps=$(APP) $(KERNEL) $(KERNEL_WITH_APP)
 	$(OPENOCD) $(OPENOCD_OPTIONS) -c "init; reset halt; flash write_image erase $(KERNEL_WITH_APP); verify_image $(KERNEL_WITH_APP); reset; shutdown"
 ```

--- a/boards/stm32f3discovery/chip_layout.ld
+++ b/boards/stm32f3discovery/chip_layout.ld
@@ -6,8 +6,8 @@
 
 MEMORY
 {
-  rom (rx)  : ORIGIN = 0x08000000, LENGTH = 0x00020000
-  prog (rx) : ORIGIN = 0x08020000, LENGTH = 0x00020000
+  rom (rx)  : ORIGIN = 0x08000000, LENGTH = 128K
+  prog (rx) : ORIGIN = 0x08020000, LENGTH = 128K
   ram (rwx) : ORIGIN = 0x20000000, LENGTH = 48K
 }
 

--- a/boards/stm32f3discovery/src/main.rs
+++ b/boards/stm32f3discovery/src/main.rs
@@ -48,7 +48,7 @@ const FAULT_RESPONSE: kernel::process::PanicFaultPolicy = kernel::process::Panic
 /// Dummy buffer that causes the linker to reserve enough space for the stack.
 #[no_mangle]
 #[link_section = ".stack_buffer"]
-pub static mut STACK_MEMORY: [u8; 0x1000] = [0; 0x1000];
+pub static mut STACK_MEMORY: [u8; 0x1400] = [0; 0x1400];
 
 /// A structure representing this platform that holds references to all
 /// capsules for this platform.
@@ -139,12 +139,10 @@ impl
 /// Helper function called during bring-up that configures multiplexed I/O.
 unsafe fn set_pin_primary_functions(
     syscfg: &stm32f303xc::syscfg::Syscfg,
-    exti: &stm32f303xc::exti::Exti,
     spi1: &stm32f303xc::spi::Spi,
     i2c1: &stm32f303xc::i2c::I2C,
     gpio_ports: &'static stm32f303xc::gpio::GpioPorts<'static>,
 ) {
-    use stm32f303xc::exti::LineId;
     use stm32f303xc::gpio::{AlternateFunction, Mode, PinId, PortId};
 
     syscfg.enable_clock();
@@ -183,14 +181,13 @@ unsafe fn set_pin_primary_functions(
 
     // button is connected on pa00
     gpio_ports.get_pin(PinId::PA00).map(|pin| {
-        // By default, upon reset, the pin is in input mode, with no internal
-        // pull-up, no internal pull-down (i.e., floating).
-        //
-        // Only set the mapping between EXTI line and the Pin and let capsule do
-        // the rest.
-        exti.associate_line_gpiopin(LineId::Exti0, &pin);
+        pin.enable_interrupt();
     });
-    cortexm4::nvic::Nvic::new(stm32f303xc::nvic::EXTI0).enable();
+
+    // enable interrupt for gpio 0
+    gpio_ports.get_pin(PinId::PC01).map(|pin| {
+        pin.enable_interrupt();
+    });
 
     // SPI1 has the l3gd20 sensor connected
     gpio_ports.get_pin(PinId::PA06).map(|pin| {
@@ -238,80 +235,85 @@ unsafe fn set_pin_primary_functions(
     });
 
     // ADC1
-    gpio_ports.get_pin(PinId::PA00).map(|pin| {
-        pin.set_mode(stm32f303xc::gpio::Mode::AnalogMode);
-    });
+    // channel 1 - shared with button
+    // gpio_ports.get_pin(PinId::PA00).map(|pin| {
+    //     pin.set_mode(stm32f303xc::gpio::Mode::AnalogMode);
+    // });
 
+    // channel 2
     gpio_ports.get_pin(PinId::PA01).map(|pin| {
         pin.set_mode(stm32f303xc::gpio::Mode::AnalogMode);
     });
 
+    // channel 3
     gpio_ports.get_pin(PinId::PA02).map(|pin| {
         pin.set_mode(stm32f303xc::gpio::Mode::AnalogMode);
     });
 
+    // channel 4
     gpio_ports.get_pin(PinId::PA03).map(|pin| {
         pin.set_mode(stm32f303xc::gpio::Mode::AnalogMode);
     });
 
+    // channel 5
     gpio_ports.get_pin(PinId::PF04).map(|pin| {
         pin.set_mode(stm32f303xc::gpio::Mode::AnalogMode);
     });
 
     // ADC2
-    gpio_ports.get_pin(PinId::PA04).map(|pin| {
-        pin.set_mode(stm32f303xc::gpio::Mode::AnalogMode);
-    });
+    // gpio_ports.get_pin(PinId::PA04).map(|pin| {
+    //     pin.set_mode(stm32f303xc::gpio::Mode::AnalogMode);
+    // });
 
-    gpio_ports.get_pin(PinId::PA05).map(|pin| {
-        pin.set_mode(stm32f303xc::gpio::Mode::AnalogMode);
-    });
+    // gpio_ports.get_pin(PinId::PA05).map(|pin| {
+    //     pin.set_mode(stm32f303xc::gpio::Mode::AnalogMode);
+    // });
 
-    gpio_ports.get_pin(PinId::PA06).map(|pin| {
-        pin.set_mode(stm32f303xc::gpio::Mode::AnalogMode);
-    });
+    // gpio_ports.get_pin(PinId::PA06).map(|pin| {
+    //     pin.set_mode(stm32f303xc::gpio::Mode::AnalogMode);
+    // });
 
-    gpio_ports.get_pin(PinId::PA07).map(|pin| {
-        pin.set_mode(stm32f303xc::gpio::Mode::AnalogMode);
-    });
+    // gpio_ports.get_pin(PinId::PA07).map(|pin| {
+    //     pin.set_mode(stm32f303xc::gpio::Mode::AnalogMode);
+    // });
 
     // ADC3
-    gpio_ports.get_pin(PinId::PB01).map(|pin| {
-        pin.set_mode(stm32f303xc::gpio::Mode::AnalogMode);
-    });
+    // gpio_ports.get_pin(PinId::PB01).map(|pin| {
+    //     pin.set_mode(stm32f303xc::gpio::Mode::AnalogMode);
+    // });
 
-    gpio_ports.get_pin(PinId::PE09).map(|pin| {
-        pin.set_mode(stm32f303xc::gpio::Mode::AnalogMode);
-    });
+    // gpio_ports.get_pin(PinId::PE09).map(|pin| {
+    //     pin.set_mode(stm32f303xc::gpio::Mode::AnalogMode);
+    // });
 
-    gpio_ports.get_pin(PinId::PE13).map(|pin| {
-        pin.set_mode(stm32f303xc::gpio::Mode::AnalogMode);
-    });
+    // gpio_ports.get_pin(PinId::PE13).map(|pin| {
+    //     pin.set_mode(stm32f303xc::gpio::Mode::AnalogMode);
+    // });
 
-    gpio_ports.get_pin(PinId::PB13).map(|pin| {
-        pin.set_mode(stm32f303xc::gpio::Mode::AnalogMode);
-    });
+    // gpio_ports.get_pin(PinId::PB13).map(|pin| {
+    //     pin.set_mode(stm32f303xc::gpio::Mode::AnalogMode);
+    // });
 
     // ADC4
-    gpio_ports.get_pin(PinId::PE14).map(|pin| {
-        pin.set_mode(stm32f303xc::gpio::Mode::AnalogMode);
-    });
+    // gpio_ports.get_pin(PinId::PE14).map(|pin| {
+    //     pin.set_mode(stm32f303xc::gpio::Mode::AnalogMode);
+    // });
 
-    gpio_ports.get_pin(PinId::PE15).map(|pin| {
-        pin.set_mode(stm32f303xc::gpio::Mode::AnalogMode);
-    });
+    // gpio_ports.get_pin(PinId::PE15).map(|pin| {
+    //     pin.set_mode(stm32f303xc::gpio::Mode::AnalogMode);
+    // });
 
-    gpio_ports.get_pin(PinId::PB12).map(|pin| {
-        pin.set_mode(stm32f303xc::gpio::Mode::AnalogMode);
-    });
+    // gpio_ports.get_pin(PinId::PB12).map(|pin| {
+    //     pin.set_mode(stm32f303xc::gpio::Mode::AnalogMode);
+    // });
 
-    gpio_ports.get_pin(PinId::PB14).map(|pin| {
-        pin.set_mode(stm32f303xc::gpio::Mode::AnalogMode);
-    });
+    // gpio_ports.get_pin(PinId::PB14).map(|pin| {
+    //     pin.set_mode(stm32f303xc::gpio::Mode::AnalogMode);
+    // });
 
-    gpio_ports.get_pin(PinId::PB15).map(|pin| {
-        pin.set_mode(stm32f303xc::gpio::Mode::AnalogMode);
-    });
+    // gpio_ports.get_pin(PinId::PB15).map(|pin| {
+    //     pin.set_mode(stm32f303xc::gpio::Mode::AnalogMode);
+    // });
 
     i2c1.enable_clock();
     i2c1.set_speed(stm32f303xc::i2c::I2CSpeed::Speed400k, 8);
@@ -355,6 +357,7 @@ unsafe fn get_peripherals() -> (
         Stm32f3xxDefaultPeripherals,
         Stm32f3xxDefaultPeripherals::new(rcc, exti)
     );
+
     (peripherals, syscfg, rcc)
 }
 
@@ -366,16 +369,16 @@ pub unsafe fn main() {
     stm32f303xc::init();
 
     let (peripherals, syscfg, _rcc) = get_peripherals();
+    peripherals.setup_circular_deps();
+
     set_pin_primary_functions(
         syscfg,
-        &peripherals.exti,
         &peripherals.spi1,
         &peripherals.i2c1,
         &peripherals.gpio_ports,
     );
 
     setup_peripherals(&peripherals.tim2);
-    peripherals.setup_circular_deps();
 
     let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
     let dynamic_deferred_call_clients =
@@ -423,26 +426,6 @@ pub unsafe fn main() {
     .finalize(());
     // Create the debugger object that handles calls to `debug!()`.
     components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
-
-    // // Setup the process inspection console
-    // let process_console_uart = static_init!(UartDevice, UartDevice::new(mux_uart, true));
-    // process_console_uart.setup();
-    // pub struct ProcessConsoleCapability;
-    // unsafe impl capabilities::ProcessManagementCapability for ProcessConsoleCapability {}
-    // let process_console = static_init!(
-    //     capsules::process_console::ProcessConsole<'static, ProcessConsoleCapability>,
-    //     capsules::process_console::ProcessConsole::new(
-    //         process_console_uart,
-    //         &mut capsules::process_console::WRITE_BUF,
-    //         &mut capsules::process_console::READ_BUF,
-    //         &mut capsules::process_console::COMMAND_BUF,
-    //         board_kernel,
-    //         ProcessConsoleCapability,
-    //     )
-    // );
-    // hil::uart::Transmit::set_transmit_client(process_console_uart, process_console);
-    // hil::uart::Receive::set_receive_client(process_console_uart, process_console);
-    // process_console.start();
 
     // LEDs
 
@@ -719,13 +702,10 @@ pub unsafe fn main() {
     // );
     // kernel::hil::sensors::TemperatureDriver::set_client(temp_sensor, temp);
 
-    let adc_channel_0 =
-        components::adc::AdcComponent::new(&adc_mux, stm32f303xc::adc::Channel::Channel0)
-            .finalize(components::adc_component_helper!(stm32f303xc::adc::Adc));
-
-    let adc_channel_1 =
-        components::adc::AdcComponent::new(&adc_mux, stm32f303xc::adc::Channel::Channel1)
-            .finalize(components::adc_component_helper!(stm32f303xc::adc::Adc));
+    // shared with button
+    // let adc_channel_1 =
+    //     components::adc::AdcComponent::new(&adc_mux, stm32f303xc::adc::Channel::Channel1)
+    //         .finalize(components::adc_component_helper!(stm32f303xc::adc::Adc));
 
     let adc_channel_2 =
         components::adc::AdcComponent::new(&adc_mux, stm32f303xc::adc::Channel::Channel2)
@@ -746,12 +726,10 @@ pub unsafe fn main() {
     let adc_syscall =
         components::adc::AdcVirtualComponent::new(board_kernel, capsules::adc::DRIVER_NUM)
             .finalize(components::adc_syscall_component_helper!(
-                adc_channel_0,
-                adc_channel_1,
                 adc_channel_2,
                 adc_channel_3,
                 adc_channel_4,
-                adc_channel_5
+                adc_channel_5,
             ));
 
     // Kernel storage region, allocated with the storage_volume!
@@ -774,6 +752,11 @@ pub unsafe fn main() {
     .finalize(components::nv_storage_component_helper!(
         stm32f303xc::flash::Flash
     ));
+
+    // PROCESS CONSOLE
+    let _process_console =
+        components::process_console::ProcessConsoleComponent::new(board_kernel, uart_mux)
+            .finalize(());
 
     let scheduler = components::sched::round_robin::RoundRobinComponent::new(&PROCESSES)
         .finalize(components::rr_component_helper!(NUM_PROCS));
@@ -807,6 +790,7 @@ pub unsafe fn main() {
     // virtual_uart_rx_test::run_virtual_uart_receive(mux_uart);
 
     debug!("Initialization complete. Entering main loop");
+    let _ = _process_console.start();
 
     /// These symbols are defined in the linker script.
     extern "C" {

--- a/boards/stm32f412gdiscovery/Makefile
+++ b/boards/stm32f412gdiscovery/Makefile
@@ -21,5 +21,5 @@ flash: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
 	$(OPENOCD) $(OPENOCD_OPTIONS) -c "init; reset halt; flash write_image erase $<; verify_image $<; reset; shutdown"
 
 .PHONY: program
-program: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/debug/$(PLATFORM).elf
+program: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
 	$(error See README.md and update this section accordingly)

--- a/boards/stm32f412gdiscovery/README.md
+++ b/boards/stm32f412gdiscovery/README.md
@@ -31,19 +31,19 @@ apps included.
 ```bash
 $ arm-none-eabi-objcopy  \
     --update-section .apps=../../../libtock-c/examples/c_hello/build/cortex-m4/cortex-m4.tbf \
-    target/thumbv7em-none-eabi/debug/discovery_f412g.elf \
-    target/thumbv7em-none-eabi/debug/discovery_f412g-app.elf
+    target/thumbv7em-none-eabi/release/discovery_f412g.elf \
+    target/thumbv7em-none-eabi/release/discovery_f412g-app.elf
 ```
 
 For example, you can update `Makefile` as follows.
 
 ```
 APP=../../../libtock-c/examples/c_hello/build/cortex-m4/cortex-m4.tbf
-KERNEL=$(TOCK_ROOT_DIRECTORY)/target/$(TARGET)/debug/$(PLATFORM).elf
-KERNEL_WITH_APP=$(TOCK_ROOT_DIRECTORY)/target/$(TARGET)/debug/$(PLATFORM)-app.elf
+KERNEL=$(TOCK_ROOT_DIRECTORY)/target/$(TARGET)/release/$(PLATFORM).elf
+KERNEL_WITH_APP=$(TOCK_ROOT_DIRECTORY)/target/$(TARGET)/release/$(PLATFORM)-app.elf
 
 .PHONY: program
-program: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/debug/$(PLATFORM).elf
+program: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
 	arm-none-eabi-objcopy --update-section .apps=$(APP) $(KERNEL) $(KERNEL_WITH_APP)
 	$(OPENOCD) $(OPENOCD_OPTIONS) -c "init; reset halt; flash write_image erase $(KERNEL_WITH_APP); verify_image $(KERNEL_WITH_APP); reset; shutdown"
 ```

--- a/chips/stm32f303xc/src/adc.rs
+++ b/chips/stm32f303xc/src/adc.rs
@@ -590,7 +590,8 @@ impl<'a> Adc<'a> {
             // Clear interrupt
             self.registers.ier.modify(IER::EOCIE::CLEAR);
             let data = self.registers.dr.read(DR::RDATA);
-            self.client.map(|client| client.sample_ready(data as u16));
+            self.client
+                .map(|client| client.sample_ready((data as u16) << 4));
             if self.status.get() == ADCStatus::Continuous {
                 self.registers.ier.modify(IER::EOCIE::SET);
             }

--- a/chips/stm32f303xc/src/gpio.rs
+++ b/chips/stm32f303xc/src/gpio.rs
@@ -9,7 +9,7 @@ use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeabl
 use kernel::utilities::registers::{register_bitfields, ReadOnly, ReadWrite, WriteOnly};
 use kernel::utilities::StaticRef;
 
-use crate::exti;
+use crate::exti::{self, LineId};
 use crate::rcc;
 
 /// General-purpose I/Os
@@ -824,6 +824,12 @@ impl<'a> Pin<'a> {
 
     pub fn get_pinid(&self) -> PinId {
         self.pinid
+    }
+
+    pub unsafe fn enable_interrupt(&'static self) {
+        let exti_line_id = LineId::from_u8(self.pinid.get_pin_number() as u8).unwrap();
+
+        self.exti.associate_line_gpiopin(exti_line_id, &self);
     }
 
     pub fn set_exti_lineid(&self, lineid: exti::LineId) {

--- a/chips/stm32f303xc/src/lib.rs
+++ b/chips/stm32f303xc/src/lib.rs
@@ -155,4 +155,5 @@ pub static IRQS: [unsafe extern "C" fn(); 82] = [
 pub unsafe fn init() {
     cortexm4::nvic::disable_all();
     cortexm4::nvic::clear_all_pending();
+    cortexm4::nvic::enable_all();
 }

--- a/chips/stm32f4xx/src/adc.rs
+++ b/chips/stm32f4xx/src/adc.rs
@@ -347,7 +347,7 @@ impl<'a> Adc<'a> {
                 self.status.set(ADCStatus::Idle);
             }
             self.client
-                .map(|client| client.sample_ready(self.registers.dr.read(DR::DATA) as u16));
+                .map(|client| client.sample_ready((self.registers.dr.read(DR::DATA) as u16) << 4));
         }
     }
 

--- a/chips/stm32f4xx/src/gpio.rs
+++ b/chips/stm32f4xx/src/gpio.rs
@@ -9,7 +9,7 @@ use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeabl
 use kernel::utilities::registers::{register_bitfields, ReadOnly, ReadWrite, WriteOnly};
 use kernel::utilities::StaticRef;
 
-use crate::exti;
+use crate::exti::{self, LineId};
 use crate::rcc;
 
 /// General-purpose I/Os
@@ -863,6 +863,12 @@ impl<'a> Pin<'a> {
 
     pub fn get_pinid(&self) -> PinId {
         self.pinid
+    }
+
+    pub unsafe fn enable_interrupt(&'static self) {
+        let exti_line_id = LineId::from_u8(self.pinid.get_pin_number() as u8).unwrap();
+
+        self.exti.associate_line_gpiopin(exti_line_id, &self);
     }
 
     pub fn set_exti_lineid(&self, lineid: exti::LineId) {

--- a/chips/stm32f4xx/src/lib.rs
+++ b/chips/stm32f4xx/src/lib.rs
@@ -66,4 +66,5 @@ pub static BASE_VECTORS: [unsafe extern "C" fn(); 16] = [
 pub unsafe fn init() {
     cortexm4::nvic::disable_all();
     cortexm4::nvic::clear_all_pending();
+    cortexm4::nvic::enable_all();
 }


### PR DESCRIPTION
### Pull Request Overview

This pull request updates the stm32 boards:
- adds the process console
- simplifies setting pin interrupts
- fixes the adc to return 16 bit values

This pull request adds a helper function to make enabling interrupts for gpio easier. The stm32 MCU does not provide a separate interrupt line for all the gpio pins. This makes enabling interrupts a little more difficult and requires some extra code in the board file.

I am not the original author of the code for these boards, so I am not sure why this has been designed the way it is now.

This also enables interrupts for the first gpio exposed pin, allowing the gpio test to succeed.

### Testing Strategy

This pull request was tested using a nucleo F429ZI and an STM32F4g Discovery board


### TODO or Help Wanted

N/A

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
