### PR TITLE
Add process console shell prompt

### DIFF
--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -699,9 +699,14 @@ pub unsafe fn main() {
         nrf52840::aes::AesECB<'static>
     ));
 
-    let pconsole =
-        components::process_console::ProcessConsoleComponent::new(board_kernel, uart_mux)
-            .finalize(());
+    let pconsole = components::process_console::ProcessConsoleComponent::new(
+        board_kernel,
+        uart_mux,
+        mux_alarm,
+    )
+    .finalize(components::process_console_component_helper!(
+        nrf52840::rtc::Rtc
+    ));
     let _ = pconsole.start();
 
     //--------------------------------------------------------------------------

--- a/boards/components/src/process_console.rs
+++ b/boards/components/src/process_console.rs
@@ -13,26 +13,53 @@
 // Author: Philip Levis <pal@cs.stanford.edu>
 // Last modified: 6/20/2018
 
-use capsules::process_console;
+use core::marker::PhantomData;
+use core::mem::MaybeUninit;
+
+use capsules::process_console::{self, ProcessConsole};
+use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use capsules::virtual_uart::{MuxUart, UartDevice};
 use kernel::capabilities;
 use kernel::component::Component;
 use kernel::hil;
-use kernel::static_init;
+use kernel::hil::time::Alarm;
+use kernel::{static_init, static_init_half};
 
-pub struct ProcessConsoleComponent {
-    board_kernel: &'static kernel::Kernel,
-    uart_mux: &'static MuxUart<'static>,
+#[macro_export]
+macro_rules! process_console_component_helper {
+    ($A: ty) => {{
+        use capsules::process_console::ProcessConsole;
+        use capsules::virtual_alarm::VirtualMuxAlarm;
+        use components::process_console::Capability;
+        use core::mem::MaybeUninit;
+
+        static mut BUFFER: MaybeUninit<ProcessConsole<VirtualMuxAlarm<'static, $A>, Capability>> =
+            MaybeUninit::uninit();
+
+        static mut ALARM: MaybeUninit<VirtualMuxAlarm<'static, $A>> = MaybeUninit::uninit();
+
+        (&mut BUFFER, &mut ALARM)
+    }};
 }
 
-impl ProcessConsoleComponent {
+pub struct ProcessConsoleComponent<A: 'static + Alarm<'static>> {
+    board_kernel: &'static kernel::Kernel,
+    uart_mux: &'static MuxUart<'static>,
+    alarm_mux: &'static MuxAlarm<'static, A>,
+    _alarm: PhantomData<A>,
+}
+
+impl<A: 'static + Alarm<'static>> ProcessConsoleComponent<A> {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
         uart_mux: &'static MuxUart,
-    ) -> ProcessConsoleComponent {
+        alarm_mux: &'static MuxAlarm<'static, A>,
+    ) -> ProcessConsoleComponent<A> {
         ProcessConsoleComponent {
             board_kernel: board_kernel,
             uart_mux: uart_mux,
+            alarm_mux: alarm_mux,
+            _alarm: PhantomData,
         }
     }
 }
@@ -54,11 +81,15 @@ extern "C" {
 pub struct Capability;
 unsafe impl capabilities::ProcessManagementCapability for Capability {}
 
-impl Component for ProcessConsoleComponent {
-    type StaticInput = ();
-    type Output = &'static process_console::ProcessConsole<'static, Capability>;
+impl<A: 'static + Alarm<'static>> Component for ProcessConsoleComponent<A> {
+    type StaticInput = (
+        &'static mut MaybeUninit<ProcessConsole<'static, VirtualMuxAlarm<'static, A>, Capability>>,
+        &'static mut MaybeUninit<VirtualMuxAlarm<'static, A>>,
+    );
+    type Output =
+        &'static process_console::ProcessConsole<'static, VirtualMuxAlarm<'static, A>, Capability>;
 
-    unsafe fn finalize(self, _s: Self::StaticInput) -> Self::Output {
+    unsafe fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
         // Create virtual device for console.
         let console_uart = static_init!(UartDevice, UartDevice::new(self.uart_mux, true));
         console_uart.setup();
@@ -77,10 +108,18 @@ impl Component for ProcessConsoleComponent {
             bss_end: &_ezero as *const u8,
         };
 
-        let console = static_init!(
-            process_console::ProcessConsole<'static, Capability>,
-            process_console::ProcessConsole::new(
+        let console_alarm = static_init_half!(
+            static_buffer.1,
+            VirtualMuxAlarm<'static, A>,
+            VirtualMuxAlarm::new(self.alarm_mux)
+        );
+
+        let console = static_init_half!(
+            static_buffer.0,
+            ProcessConsole<'static, VirtualMuxAlarm<'static, A>, Capability>,
+            ProcessConsole::new(
                 console_uart,
+                console_alarm,
                 &mut process_console::WRITE_BUF,
                 &mut process_console::READ_BUF,
                 &mut process_console::QUEUE_BUF,
@@ -92,6 +131,7 @@ impl Component for ProcessConsoleComponent {
         );
         hil::uart::Transmit::set_transmit_client(console_uart, console);
         hil::uart::Receive::set_receive_client(console_uart, console);
+        console_alarm.set_alarm_client(console);
 
         console
     }

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -106,6 +106,7 @@ pub static mut STACK_MEMORY: [u8; 0x2000] = [0; 0x2000];
 struct Imix {
     pconsole: &'static capsules::process_console::ProcessConsole<
         'static,
+        capsules::virtual_alarm::VirtualMuxAlarm<'static, sam4l::ast::Ast<'static>>,
         components::process_console::Capability,
     >,
     console: &'static capsules::console::Console<'static>,
@@ -359,7 +360,16 @@ pub unsafe fn main() {
     let uart_mux =
         UartMuxComponent::new(&peripherals.usart3, 115200, dynamic_deferred_caller).finalize(());
 
-    let pconsole = ProcessConsoleComponent::new(board_kernel, uart_mux).finalize(());
+    // # TIMER
+    let mux_alarm = AlarmMuxComponent::new(&peripherals.ast)
+        .finalize(components::alarm_mux_component_helper!(sam4l::ast::Ast));
+    peripherals.ast.configure(mux_alarm);
+    let alarm = AlarmDriverComponent::new(board_kernel, capsules::alarm::DRIVER_NUM, mux_alarm)
+        .finalize(components::alarm_component_helper!(sam4l::ast::Ast));
+
+    let pconsole = ProcessConsoleComponent::new(board_kernel, uart_mux, mux_alarm).finalize(
+        components::process_console_component_helper!(sam4l::ast::Ast),
+    );
     let console =
         ConsoleComponent::new(board_kernel, capsules::console::DRIVER_NUM, uart_mux).finalize(());
     DebugWriterComponent::new(uart_mux).finalize(());
@@ -373,13 +383,6 @@ pub unsafe fn main() {
         &peripherals.pb[07],
     )
     .finalize(());
-
-    // # TIMER
-    let mux_alarm = AlarmMuxComponent::new(&peripherals.ast)
-        .finalize(components::alarm_mux_component_helper!(sam4l::ast::Ast));
-    peripherals.ast.configure(mux_alarm);
-    let alarm = AlarmDriverComponent::new(board_kernel, capsules::alarm::DRIVER_NUM, mux_alarm)
-        .finalize(components::alarm_component_helper!(sam4l::ast::Ast));
 
     // # I2C and I2C Sensors
     let mux_i2c = static_init!(

--- a/boards/imxrt1050-evkb/src/main.rs
+++ b/boards/imxrt1050-evkb/src/main.rs
@@ -482,9 +482,14 @@ pub unsafe fn main() {
     //--------------------------------------------------------------------------
     // Process Console
     //---------------------------------------------------------------------------
-    let process_console =
-        components::process_console::ProcessConsoleComponent::new(board_kernel, lpuart_mux)
-            .finalize(());
+    let process_console = components::process_console::ProcessConsoleComponent::new(
+        board_kernel,
+        lpuart_mux,
+        mux_alarm,
+    )
+    .finalize(components::process_console_component_helper!(
+        imxrt1050::gpt::Gpt1
+    ));
     let _ = process_console.start();
 
     debug!("Tock OS initialization complete. Entering main loop");

--- a/boards/microbit_v2/src/main.rs
+++ b/boards/microbit_v2/src/main.rs
@@ -563,10 +563,15 @@ pub unsafe fn main() {
     //--------------------------------------------------------------------------
     // Process Console
     //--------------------------------------------------------------------------
-    let process_console =
-        components::process_console::ProcessConsoleComponent::new(board_kernel, uart_mux)
-            .finalize(());
-    let _ = process_console.start();
+    let _process_console = components::process_console::ProcessConsoleComponent::new(
+        board_kernel,
+        uart_mux,
+        mux_alarm,
+    )
+    .finalize(components::process_console_component_helper!(
+        nrf52833::rtc::Rtc
+    ));
+    let _ = _process_console.start();
 
     //--------------------------------------------------------------------------
     // FINAL SETUP AND BOARD BOOT

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -127,6 +127,7 @@ pub struct Platform {
     console: &'static capsules::console::Console<'static>,
     pconsole: &'static capsules::process_console::ProcessConsole<
         'static,
+        capsules::virtual_alarm::VirtualMuxAlarm<'static, nrf52::rtc::Rtc<'static>>,
         components::process_console::Capability,
     >,
     proximity: &'static capsules::proximity::ProximitySensor<'static>,
@@ -364,9 +365,14 @@ pub unsafe fn main() {
     let uart_mux = components::console::UartMuxComponent::new(cdc, 115200, dynamic_deferred_caller)
         .finalize(());
 
-    let pconsole =
-        components::process_console::ProcessConsoleComponent::new(board_kernel, uart_mux)
-            .finalize(());
+    let pconsole = components::process_console::ProcessConsoleComponent::new(
+        board_kernel,
+        uart_mux,
+        mux_alarm,
+    )
+    .finalize(components::process_console_component_helper!(
+        nrf52::rtc::Rtc<'static>
+    ));
 
     // Setup the console.
     let console = components::console::ConsoleComponent::new(

--- a/boards/nano_rp2040_connect/src/main.rs
+++ b/boards/nano_rp2040_connect/src/main.rs
@@ -421,9 +421,12 @@ pub unsafe fn main() {
                 adc_channel_3,
             ));
     // PROCESS CONSOLE
-    let process_console =
-        components::process_console::ProcessConsoleComponent::new(board_kernel, uart_mux)
-            .finalize(());
+    let process_console = components::process_console::ProcessConsoleComponent::new(
+        board_kernel,
+        uart_mux,
+        mux_alarm,
+    )
+    .finalize(components::process_console_component_helper!(RPTimer));
     let _ = process_console.start();
 
     let scheduler = components::sched::round_robin::RoundRobinComponent::new(&PROCESSES)

--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -81,6 +81,7 @@ pub struct Platform {
     button: &'static capsules::button::Button<'static, nrf52840::gpio::GPIOPin<'static>>,
     pconsole: &'static capsules::process_console::ProcessConsole<
         'static,
+        VirtualMuxAlarm<'static, nrf52840::rtc::Rtc<'static>>,
         components::process_console::Capability,
     >,
     console: &'static capsules::console::Console<'static>,
@@ -310,9 +311,14 @@ pub unsafe fn main() {
         components::console::UartMuxComponent::new(channel, 115200, dynamic_deferred_caller)
             .finalize(());
 
-    let pconsole =
-        components::process_console::ProcessConsoleComponent::new(board_kernel, uart_mux)
-            .finalize(());
+    let pconsole = components::process_console::ProcessConsoleComponent::new(
+        board_kernel,
+        uart_mux,
+        mux_alarm,
+    )
+    .finalize(components::process_console_component_helper!(
+        nrf52840::rtc::Rtc<'static>
+    ));
 
     // Setup the console.
     let console = components::console::ConsoleComponent::new(

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -165,6 +165,7 @@ pub struct Platform {
     button: &'static capsules::button::Button<'static, nrf52840::gpio::GPIOPin<'static>>,
     pconsole: &'static capsules::process_console::ProcessConsole<
         'static,
+        VirtualMuxAlarm<'static, nrf52840::rtc::Rtc<'static>>,
         components::process_console::Capability,
     >,
     console: &'static capsules::console::Console<'static>,
@@ -419,9 +420,14 @@ pub unsafe fn main() {
         components::console::UartMuxComponent::new(channel, 115200, dynamic_deferred_caller)
             .finalize(());
 
-    let pconsole =
-        components::process_console::ProcessConsoleComponent::new(board_kernel, uart_mux)
-            .finalize(());
+    let pconsole = components::process_console::ProcessConsoleComponent::new(
+        board_kernel,
+        uart_mux,
+        mux_alarm,
+    )
+    .finalize(components::process_console_component_helper!(
+        nrf52840::rtc::Rtc<'static>
+    ));
 
     // Setup the console.
     let console = components::console::ConsoleComponent::new(

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -140,6 +140,7 @@ pub struct Platform {
     button: &'static capsules::button::Button<'static, nrf52832::gpio::GPIOPin<'static>>,
     pconsole: &'static capsules::process_console::ProcessConsole<
         'static,
+        VirtualMuxAlarm<'static, Rtc<'static>>,
         components::process_console::Capability,
     >,
     console: &'static capsules::console::Console<'static>,
@@ -369,9 +370,12 @@ pub unsafe fn main() {
         components::console::UartMuxComponent::new(channel, 115200, dynamic_deferred_caller)
             .finalize(());
 
-    let pconsole =
-        components::process_console::ProcessConsoleComponent::new(board_kernel, uart_mux)
-            .finalize(());
+    let pconsole = components::process_console::ProcessConsoleComponent::new(
+        board_kernel,
+        uart_mux,
+        mux_alarm,
+    )
+    .finalize(components::process_console_component_helper!(Rtc<'static>));
 
     // Setup the console.
     let console = components::console::ConsoleComponent::new(

--- a/boards/nucleo_f429zi/src/main.rs
+++ b/boards/nucleo_f429zi/src/main.rs
@@ -550,9 +550,15 @@ pub unsafe fn main() {
             ));
 
     // PROCESS CONSOLE
-    let _process_console =
-        components::process_console::ProcessConsoleComponent::new(board_kernel, uart_mux)
-            .finalize(());
+    let process_console = components::process_console::ProcessConsoleComponent::new(
+        board_kernel,
+        uart_mux,
+        mux_alarm,
+    )
+    .finalize(components::process_console_component_helper!(
+        stm32f429zi::tim2::Tim2
+    ));
+    let _ = process_console.start();
 
     let scheduler = components::sched::round_robin::RoundRobinComponent::new(&PROCESSES)
         .finalize(components::rr_component_helper!(NUM_PROCS));
@@ -581,7 +587,6 @@ pub unsafe fn main() {
     // virtual_uart_rx_test::run_virtual_uart_receive(mux_uart);
 
     debug!("Initialization complete. Entering main loop");
-    let _ = _process_console.start();
 
     /// These symbols are defined in the linker script.
     extern "C" {

--- a/boards/nucleo_f446re/src/main.rs
+++ b/boards/nucleo_f446re/src/main.rs
@@ -338,9 +338,15 @@ pub unsafe fn main() {
     .finalize(components::alarm_component_helper!(stm32f446re::tim2::Tim2));
 
     // PROCESS CONSOLE
-    let _process_console =
-        components::process_console::ProcessConsoleComponent::new(board_kernel, uart_mux)
-            .finalize(());
+    let process_console = components::process_console::ProcessConsoleComponent::new(
+        board_kernel,
+        uart_mux,
+        mux_alarm,
+    )
+    .finalize(components::process_console_component_helper!(
+        stm32f446re::tim2::Tim2
+    ));
+    let _ = process_console.start();
 
     let scheduler = components::sched::round_robin::RoundRobinComponent::new(&PROCESSES)
         .finalize(components::rr_component_helper!(NUM_PROCS));
@@ -366,7 +372,6 @@ pub unsafe fn main() {
     // virtual_uart_rx_test::run_virtual_uart_receive(mux_uart);
 
     debug!("Initialization complete. Entering main loop");
-    let _ = _process_console.start();
 
     /// These symbols are defined in the linker script.
     extern "C" {

--- a/boards/pico_explorer_base/src/main.rs
+++ b/boards/pico_explorer_base/src/main.rs
@@ -498,9 +498,12 @@ pub unsafe fn main() {
                 adc_channel_2,
             ));
     // PROCESS CONSOLE
-    let process_console =
-        components::process_console::ProcessConsoleComponent::new(board_kernel, uart_mux)
-            .finalize(());
+    let process_console = components::process_console::ProcessConsoleComponent::new(
+        board_kernel,
+        uart_mux,
+        mux_alarm,
+    )
+    .finalize(components::process_console_component_helper!(RPTimer));
     let _ = process_console.start();
 
     let scheduler = components::sched::round_robin::RoundRobinComponent::new(&PROCESSES)

--- a/boards/raspberry_pi_pico/src/main.rs
+++ b/boards/raspberry_pi_pico/src/main.rs
@@ -437,9 +437,12 @@ pub unsafe fn main() {
                 adc_channel_3,
             ));
     // PROCESS CONSOLE
-    let process_console =
-        components::process_console::ProcessConsoleComponent::new(board_kernel, uart_mux)
-            .finalize(());
+    let process_console = components::process_console::ProcessConsoleComponent::new(
+        board_kernel,
+        uart_mux,
+        mux_alarm,
+    )
+    .finalize(components::process_console_component_helper!(RPTimer));
     let _ = process_console.start();
 
     let sda_pin = peripherals.pins.get_pin(RPGpio::GPIO4);

--- a/boards/stm32f3discovery/src/main.rs
+++ b/boards/stm32f3discovery/src/main.rs
@@ -758,9 +758,15 @@ pub unsafe fn main() {
     ));
 
     // PROCESS CONSOLE
-    let _process_console =
-        components::process_console::ProcessConsoleComponent::new(board_kernel, uart_mux)
-            .finalize(());
+    let process_console = components::process_console::ProcessConsoleComponent::new(
+        board_kernel,
+        uart_mux,
+        mux_alarm,
+    )
+    .finalize(components::process_console_component_helper!(
+        stm32f303xc::tim2::Tim2
+    ));
+    let _ = process_console.start();
 
     let scheduler = components::sched::round_robin::RoundRobinComponent::new(&PROCESSES)
         .finalize(components::rr_component_helper!(NUM_PROCS));
@@ -794,7 +800,6 @@ pub unsafe fn main() {
     // virtual_uart_rx_test::run_virtual_uart_receive(mux_uart);
 
     debug!("Initialization complete. Entering main loop");
-    let _ = _process_console.start();
 
     /// These symbols are defined in the linker script.
     extern "C" {

--- a/boards/stm32f412gdiscovery/src/main.rs
+++ b/boards/stm32f412gdiscovery/src/main.rs
@@ -733,9 +733,15 @@ pub unsafe fn main() {
             ));
 
     // PROCESS CONSOLE
-    let _process_console =
-        components::process_console::ProcessConsoleComponent::new(board_kernel, uart_mux)
-            .finalize(());
+    let process_console = components::process_console::ProcessConsoleComponent::new(
+        board_kernel,
+        uart_mux,
+        mux_alarm,
+    )
+    .finalize(components::process_console_component_helper!(
+        stm32f412g::tim2::Tim2
+    ));
+    let _ = process_console.start();
 
     let scheduler = components::sched::round_robin::RoundRobinComponent::new(&PROCESSES)
         .finalize(components::rr_component_helper!(NUM_PROCS));
@@ -769,7 +775,6 @@ pub unsafe fn main() {
     // debug!("id {}", base_peripherals.fsmc.read(0x05));
 
     debug!("Initialization complete. Entering main loop");
-    let _ = _process_console.start();
 
     extern "C" {
         /// Beginning of the ROM region containing app images.

--- a/boards/weact_f401ccu6/src/main.rs
+++ b/boards/weact_f401ccu6/src/main.rs
@@ -424,9 +424,15 @@ pub unsafe fn main() {
             ));
 
     // PROCESS CONSOLE
-    let _process_console =
-        components::process_console::ProcessConsoleComponent::new(board_kernel, uart_mux)
-            .finalize(());
+    let process_console = components::process_console::ProcessConsoleComponent::new(
+        board_kernel,
+        uart_mux,
+        mux_alarm,
+    )
+    .finalize(components::process_console_component_helper!(
+        stm32f401cc::tim2::Tim2
+    ));
+    let _ = process_console.start();
 
     let scheduler = components::sched::round_robin::RoundRobinComponent::new(&PROCESSES)
         .finalize(components::rr_component_helper!(NUM_PROCS));
@@ -448,7 +454,6 @@ pub unsafe fn main() {
     };
 
     debug!("Initialization complete. Entering main loop");
-    let _ = _process_console.start();
 
     /// These symbols are defined in the linker script.
     extern "C" {

--- a/capsules/src/process_console.rs
+++ b/capsules/src/process_console.rs
@@ -195,8 +195,6 @@ pub struct ProcessConsole<'a, A: Alarm<'a>, C: ProcessManagementCapability> {
     command_buffer: TakeCell<'static, [u8]>,
     command_index: Cell<usize>,
 
-    first_prompt_shown: Cell<bool>,
-
     /// Flag to mark that the process console is active and has called receive
     /// from the underlying UART.
     running: Cell<bool>,
@@ -272,7 +270,7 @@ impl<'a, A: Alarm<'a>, C: ProcessManagementCapability> ProcessConsole<'a, A, C> 
             rx_buffer: TakeCell::new(rx_buffer),
             command_buffer: TakeCell::new(cmd_buffer),
             command_index: Cell::new(0),
-            first_prompt_shown: Cell::new(false),
+
             running: Cell::new(false),
             execute: Cell::new(false),
             kernel: kernel,
@@ -1025,7 +1023,6 @@ impl<'a, A: Alarm<'a>, C: ProcessManagementCapability> ProcessConsole<'a, A, C> 
     }
 
     fn prompt(&self) {
-        self.first_prompt_shown.set(true);
         let _ = self.write_bytes(b"tock$ ");
     }
 

--- a/capsules/src/process_console.rs
+++ b/capsules/src/process_console.rs
@@ -112,10 +112,12 @@ use core::fmt;
 use core::fmt::write;
 use core::str;
 use kernel::capabilities::ProcessManagementCapability;
+use kernel::hil::time::ConvertTicks;
 use kernel::utilities::cells::TakeCell;
 use kernel::ProcessId;
 
 use kernel::debug;
+use kernel::hil::time::{Alarm, AlarmClient};
 use kernel::hil::uart;
 use kernel::introspection::KernelInfo;
 use kernel::ErrorCode;
@@ -180,8 +182,9 @@ pub struct KernelAddresses {
     pub bss_end: *const u8,
 }
 
-pub struct ProcessConsole<'a, C: ProcessManagementCapability> {
+pub struct ProcessConsole<'a, A: Alarm<'a>, C: ProcessManagementCapability> {
     uart: &'a dyn uart::UartData<'a>,
+    alarm: &'a A,
     tx_in_progress: Cell<bool>,
     tx_buffer: TakeCell<'static, [u8]>,
     queue_buffer: TakeCell<'static, [u8]>,
@@ -191,6 +194,8 @@ pub struct ProcessConsole<'a, C: ProcessManagementCapability> {
     rx_buffer: TakeCell<'static, [u8]>,
     command_buffer: TakeCell<'static, [u8]>,
     command_index: Cell<usize>,
+
+    first_prompt_shown: Cell<bool>,
 
     /// Flag to mark that the process console is active and has called receive
     /// from the underlying UART.
@@ -243,9 +248,10 @@ fn exceeded_check(size: usize, allocated: usize) -> &'static str {
     }
 }
 
-impl<'a, C: ProcessManagementCapability> ProcessConsole<'a, C> {
+impl<'a, A: Alarm<'a>, C: ProcessManagementCapability> ProcessConsole<'a, A, C> {
     pub fn new(
         uart: &'a dyn uart::UartData<'a>,
+        alarm: &'a A,
         tx_buffer: &'static mut [u8],
         rx_buffer: &'static mut [u8],
         queue_buffer: &'static mut [u8],
@@ -253,9 +259,10 @@ impl<'a, C: ProcessManagementCapability> ProcessConsole<'a, C> {
         kernel: &'static Kernel,
         kernel_addresses: KernelAddresses,
         capability: C,
-    ) -> ProcessConsole<'a, C> {
+    ) -> ProcessConsole<'a, A, C> {
         ProcessConsole {
             uart: uart,
+            alarm: alarm,
             tx_in_progress: Cell::new(false),
             tx_buffer: TakeCell::new(tx_buffer),
             queue_buffer: TakeCell::new(queue_buffer),
@@ -265,6 +272,7 @@ impl<'a, C: ProcessManagementCapability> ProcessConsole<'a, C> {
             rx_buffer: TakeCell::new(rx_buffer),
             command_buffer: TakeCell::new(cmd_buffer),
             command_index: Cell::new(0),
+            first_prompt_shown: Cell::new(false),
             running: Cell::new(false),
             execute: Cell::new(false),
             kernel: kernel,
@@ -276,11 +284,9 @@ impl<'a, C: ProcessManagementCapability> ProcessConsole<'a, C> {
     /// Start the process console listening for user commands.
     pub fn start(&self) -> Result<(), ErrorCode> {
         if self.running.get() == false {
-            self.rx_buffer.take().map(|buffer| {
-                self.rx_in_progress.set(true);
-                let _ = self.uart.receive_buffer(buffer, 1);
-                self.running.set(true);
-            });
+            self.alarm
+                .set_alarm(self.alarm.now(), self.alarm.ticks_from_ms(100));
+            self.running.set(true);
         }
         Ok(())
     }
@@ -302,8 +308,10 @@ impl<'a, C: ProcessManagementCapability> ProcessConsole<'a, C> {
         let _ = write(
             &mut console_writer,
             format_args!(
-                "Kernel version: {}\r\n",
-                option_env!("TOCK_KERNEL_VERSION").unwrap_or("unknown")
+                "Kernel version: {}.{} (build {})\r\n",
+                kernel::MAJOR,
+                kernel::MINOR,
+                option_env!("TOCK_KERNEL_VERSION").unwrap_or("unknown"),
             ),
         );
         let _ = self.write_bytes(&(console_writer.buf)[..console_writer.size]);
@@ -311,6 +319,7 @@ impl<'a, C: ProcessManagementCapability> ProcessConsole<'a, C> {
         let _ = self.write_bytes(b"Welcome to the process console.\n");
         let _ = self
             .write_bytes(b"Valid commands are: help status list stop start fault process kernel\n");
+        self.prompt();
     }
 
     /// Simple state machine helper function that identifies the next state for
@@ -793,7 +802,7 @@ impl<'a, C: ProcessManagementCapability> ProcessConsole<'a, C> {
                             let _ = write(
                                 &mut console_writer,
                                 format_args!(
-                                    "  {:?}\t{:<20}{:6}{:10}{:19}{:10}  {:?}{:5}/{}\n",
+                                    "  {:?}\t{:<20}{:6}{:10}{:17}{:10}  {:?}{:5}/{}\n",
                                     process_id,
                                     pname,
                                     process.debug_timeslice_expiration_count(),
@@ -809,6 +818,9 @@ impl<'a, C: ProcessManagementCapability> ProcessConsole<'a, C> {
                             let _ = self.write_bytes(&(console_writer.buf)[..console_writer.size]);
                         }
                     });
+            }
+            WriterState::Empty => {
+                self.prompt();
             }
             _ => {}
         }
@@ -903,7 +915,7 @@ impl<'a, C: ProcessManagementCapability> ProcessConsole<'a, C> {
                             });
                         } else if clean_str.starts_with("list") {
                             let _ = self.write_bytes(b" PID    Name                Quanta  ");
-                            let _ = self.write_bytes(b"Syscalls  Dropped Callbacks  ");
+                            let _ = self.write_bytes(b"Syscalls  Dropped Upcalls  ");
                             let _ = self.write_bytes(b"Restarts    State  Grants\n");
 
                             // Count the number of current processes.
@@ -912,11 +924,13 @@ impl<'a, C: ProcessManagementCapability> ProcessConsole<'a, C> {
                                 count += 1;
                             });
 
-                            // Start the state machine to print each separately.
-                            self.write_state(WriterState::List {
-                                index: -1,
-                                total: count,
-                            });
+                            if count > 0 {
+                                // Start the state machine to print each separately.
+                                self.write_state(WriterState::List {
+                                    index: -1,
+                                    total: count,
+                                });
+                            }
                         } else if clean_str.starts_with("status") {
                             let info: KernelInfo = KernelInfo::new(self.kernel);
                             let mut console_writer = ConsoleWriter::new();
@@ -972,7 +986,9 @@ impl<'a, C: ProcessManagementCapability> ProcessConsole<'a, C> {
                             let _ = write(
                                 &mut console_writer,
                                 format_args!(
-                                    "Kernel version: {}\r\n",
+                                    "Kernel version: {}.{} (build {})\r\n",
+                                    kernel::MAJOR,
+                                    kernel::MINOR,
                                     option_env!("TOCK_KERNEL_VERSION").unwrap_or("unknown")
                                 ),
                             );
@@ -1003,6 +1019,14 @@ impl<'a, C: ProcessManagementCapability> ProcessConsole<'a, C> {
             command[0] = 0;
         });
         self.command_index.set(0);
+        if self.writer_state.get() == WriterState::Empty {
+            self.prompt();
+        }
+    }
+
+    fn prompt(&self) {
+        self.first_prompt_shown.set(true);
+        let _ = self.write_bytes(b"tock$ ");
     }
 
     /// Start or iterate the state machine for an asynchronous write operation
@@ -1096,7 +1120,19 @@ impl<'a, C: ProcessManagementCapability> ProcessConsole<'a, C> {
     }
 }
 
-impl<'a, C: ProcessManagementCapability> uart::TransmitClient for ProcessConsole<'a, C> {
+impl<'a, A: Alarm<'a>, C: ProcessManagementCapability> AlarmClient for ProcessConsole<'a, A, C> {
+    fn alarm(&self) {
+        self.prompt();
+        self.rx_buffer.take().map(|buffer| {
+            self.rx_in_progress.set(true);
+            let _ = self.uart.receive_buffer(buffer, 1);
+        });
+    }
+}
+
+impl<'a, A: Alarm<'a>, C: ProcessManagementCapability> uart::TransmitClient
+    for ProcessConsole<'a, A, C>
+{
     fn transmitted_buffer(
         &self,
         buffer: &'static mut [u8],
@@ -1129,7 +1165,10 @@ impl<'a, C: ProcessManagementCapability> uart::TransmitClient for ProcessConsole
         }
     }
 }
-impl<'a, C: ProcessManagementCapability> uart::ReceiveClient for ProcessConsole<'a, C> {
+
+impl<'a, A: Alarm<'a>, C: ProcessManagementCapability> uart::ReceiveClient
+    for ProcessConsole<'a, A, C>
+{
     fn received_buffer(
         &self,
         read_buf: &'static mut [u8],
@@ -1146,12 +1185,14 @@ impl<'a, C: ProcessManagementCapability> uart::ReceiveClient for ProcessConsole<
                         if read_buf[0] == ('\n' as u8) || read_buf[0] == ('\r' as u8) {
                             self.execute.set(true);
                             let _ = self.write_bytes(&['\r' as u8, '\n' as u8]);
-                        } else if read_buf[0] == ('\x08' as u8) && index > 0 {
-                            // Backspace, echo and remove last byte
-                            // Note echo is '\b \b' to erase
-                            let _ = self.write_bytes(&['\x08' as u8, ' ' as u8, '\x08' as u8]);
-                            command[index - 1] = '\0' as u8;
-                            self.command_index.set(index - 1);
+                        } else if read_buf[0] == ('\x08' as u8) {
+                            if index > 0 {
+                                // Backspace, echo and remove last byte
+                                // Note echo is '\b \b' to erase
+                                let _ = self.write_bytes(&['\x08' as u8, ' ' as u8, '\x08' as u8]);
+                                command[index - 1] = '\0' as u8;
+                                self.command_index.set(index - 1);
+                            }
                         } else if index < (command.len() - 1) && read_buf[0] < 128 {
                             // For some reason, sometimes reads return > 127 but no error,
                             // which causes utf-8 decoding failure, so check byte is < 128. -pal


### PR DESCRIPTION
### Pull Request Overview

This pull request adds a shell prompt to the process console. Many users have no idea that the process console exists.

This pull request modifies it in the following way:
1. the `start` function displays the *Press any key ...* message using `debug!` and should be called after the board's `debug!` message
2. it waits for a key to be pressed and displays the welcome message and the prompt. This first key is not taken into account
3. it prints the kernel version using the `MAJOR` and `MINOR` values. The value from the environment variable is now considered the `build`.

This fixes:
- a bug that allowed users to delete more characters than they have written as the \b character was printed even if the command buffer is empty.
- the kernel print, the Bss region information was not printed as it was in the same buffer with the version and was overflowing the write buffer

I renamed the variable holding the reference to the process console with an _ to be able to disable it only by commenting out the `start` function call. The compiler complains otherwise that the variable is not used.

This is how it looks like now

```
Initialization complete. Entering main loop
Press any key to start the process console...
Hello World!
Kernel version: 2.0 (build release-2.0-rc2-64-g3c0d323b8)
Welcome to the process console.
Valid commands are: help status list stop start fault process kernel
tock$ 
tock$ list

 PID    Name                Quanta  Syscalls  Dropped Callbacks  Restarts    State  Grants
  0	blink                   27       133                  0         0  Yielded    1/10
  1	c_hello                  2         8                  0         0  Yielded    1/10
  2	buttons                  3        11                  0         0  Yielded    1/10
tock$ list

 PID    Name                Quanta  Syscalls  Dropped Callbacks  Restarts    State  Grants
  0	blink                   39       193                  0         0  Yielded    1/10
  1	c_hello                  2         8                  0         0  Yielded    1/10
  2	buttons                  3        11                  0         0  Yielded    1/10
tock$ kernel

Kernel version: 2.0 (build release-2.0-rc2-64-g3c0d323b8)

 ╔═══════════╤══════════════════════════════╗
 ║  Address  │ Region Name    Used (bytes)  ║
 ╚0x20011FC0═╪══════════════════════════════╝
             │   Bss         10720
  0x20002028 ┼─────────────────────────────── S
             │   Relocate       40            R
  0x20002000 ┼─────────────────────────────── A
             │ ▼ Stack        8192            M
  0x20000000 ┼───────────────────────────────
             .....
  0x08025550 ┼─────────────────────────────── F
             │   RoData      41380            L
  0x0801B3AC ┼─────────────────────────────── A
             │   Code       111532            S
  0x08000000 ┼─────────────────────────────── H

tock$ list

 PID    Name                Quanta  Syscalls  Dropped Callbacks  Restarts    State  Grants
  0	blink                   95       473                  0         0  Yielded    1/10
  1	c_hello                  2         8                  0         0  Yielded    1/10
  2	buttons                  3        11                  0         0  Yielded    1/10
tock$ process buttons


 ╔═══════════╤══════════════════════════════════════════╗
 ║  Address  │ Region Name    Used | Allocated (bytes)  ║
 ╚0x20018000═╪══════════════════════════════════════════╝
             │ ▼ Grant        1108 |   1108          
  0x20017BAC ┼───────────────────────────────────────────
             │ Unused
  0x200169F0 ┼───────────────────────────────────────────
             │ ▲ Heap            0 |   4540               S
  0x200169F0 ┼─────────────────────────────────────────── R
             │ Data            496 |    496               A
  0x20016800 ┼─────────────────────────────────────────── M
             │ ▼ Stack        2048 |   2048          
  0x20016000 ┼───────────────────────────────────────────
             │ Unused
  0x20016000 ┴───────────────────────────────────────────
             .....
  0x08031800 ┬─────────────────────────────────────────── F
             │ App Flash      1996                        L
  0x08031034 ┼─────────────────────────────────────────── A
             │ Protected        52                        S
  0x08031000 ┴─────────────────────────────────────────── H
tock$ 
```

### Testing Strategy

This pull request was tested using a stm32 board and a microbit.


### TODO or Help Wanted

This pull request still needs...


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
