### PR TITLE
[imxrt1050-evkb] Fix GPIO interrupts

### DIFF
--- a/chips/imxrt10xx/src/lib.rs
+++ b/chips/imxrt10xx/src/lib.rs
@@ -232,4 +232,6 @@ pub unsafe fn init() {
     cortexm7::scb::set_vector_table_offset(
         &BASE_VECTORS as *const [unsafe extern "C" fn(); 16] as *const (),
     );
+
+    cortexm7::nvic::enable_all();
 }


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes gpio interrupts on the i.MX RT 1052 EVKB.

While I was testing the buttons example on the i.MX RT 1052 EVKB, I discovered that the interrupts are not enabled by default. However, if I set up a delay of 1000 ms so that a different interrupt is triggered before the gpio one, the gpio interrupts will work. Therefore, in order to prevent this, we have to specifically enable the interrupt in the nvic. 

This seems to be a bug in the i.MX RT 1052 EVKB board and requires to manually enable the interrupts in the nvic.

### Testing Strategy

This pull request was tested using an iMX. RT 1052 EVKB board.


### TODO or Help Wanted

This pull request needs feedback.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
