### PR TITLE
[spi] Update virtual_spi to report errors

### DIFF
--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -606,16 +606,19 @@ pub unsafe fn main() {
         nrf52840::pinmux::Pinmux::new(ST7789H2_SCK as u32),
     );
 
-    let bus = components::bus::SpiMasterBusComponent::new().finalize(
-        components::spi_bus_component_helper!(
-            // spi type
-            nrf52840::spi::SPIM,
-            // chip select
-            &nrf52840_peripherals.gpio_port[ST7789H2_CS],
-            // spi mux
-            spi_mux
-        ),
-    );
+    let bus = components::bus::SpiMasterBusComponent::new(
+        16_000_000,
+        kernel::hil::spi::ClockPhase::SampleLeading,
+        kernel::hil::spi::ClockPolarity::IdleLow,
+    )
+    .finalize(components::spi_bus_component_helper!(
+        // spi type
+        nrf52840::spi::SPIM,
+        // chip select
+        &nrf52840_peripherals.gpio_port[ST7789H2_CS],
+        // spi mux
+        spi_mux
+    ));
 
     let tft = components::st77xx::ST77XXComponent::new(mux_alarm).finalize(
         components::st77xx_component_helper!(

--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -607,7 +607,7 @@ pub unsafe fn main() {
     );
 
     let bus = components::bus::SpiMasterBusComponent::new(
-        16_000_000,
+        20_000_000,
         kernel::hil::spi::ClockPhase::SampleLeading,
         kernel::hil::spi::ClockPolarity::IdleLow,
     )

--- a/boards/pico_explorer_base/src/main.rs
+++ b/boards/pico_explorer_base/src/main.rs
@@ -405,16 +405,19 @@ pub unsafe fn main() {
     let mux_spi = components::spi::SpiMuxComponent::new(&peripherals.spi0, dynamic_deferred_caller)
         .finalize(components::spi_mux_component_helper!(Spi));
 
-    let bus = components::bus::SpiMasterBusComponent::new().finalize(
-        components::spi_bus_component_helper!(
-            // spi type
-            Spi,
-            // chip select
-            &peripherals.pins.get_pin(RPGpio::GPIO17),
-            // spi mux
-            mux_spi
-        ),
-    );
+    let bus = components::bus::SpiMasterBusComponent::new(
+        16_000_000,
+        kernel::hil::spi::ClockPhase::SampleLeading,
+        kernel::hil::spi::ClockPolarity::IdleLow,
+    )
+    .finalize(components::spi_bus_component_helper!(
+        // spi type
+        Spi,
+        // chip select
+        &peripherals.pins.get_pin(RPGpio::GPIO17),
+        // spi mux
+        mux_spi
+    ));
 
     let tft = components::st77xx::ST77XXComponent::new(mux_alarm).finalize(
         components::st77xx_component_helper!(

--- a/boards/pico_explorer_base/src/main.rs
+++ b/boards/pico_explorer_base/src/main.rs
@@ -406,7 +406,7 @@ pub unsafe fn main() {
         .finalize(components::spi_mux_component_helper!(Spi));
 
     let bus = components::bus::SpiMasterBusComponent::new(
-        16_000_000,
+        20_000_000,
         kernel::hil::spi::ClockPhase::SampleLeading,
         kernel::hil::spi::ClockPolarity::IdleLow,
     )

--- a/capsules/src/virtual_spi.rs
+++ b/capsules/src/virtual_spi.rs
@@ -109,7 +109,6 @@ impl<'a, Spi: hil::spi::SpiMaster> MuxSpiMaster<'a, Spi> {
         } else {
             self.inflight.map(|node| {
                 let op = node.operation.get();
-                // Need to set idle here in case callback changes state
                 node.operation.set(Op::Idle);
                 match op {
                     // we have to report an error

--- a/capsules/src/virtual_spi.rs
+++ b/capsules/src/virtual_spi.rs
@@ -148,7 +148,7 @@ impl<'a, Spi: hil::spi::SpiMaster> DynamicDeferredCallClient for MuxSpiMaster<'a
     }
 }
 
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Copy, Clone, PartialEq)]
 enum Op {
     Idle,
     ReadWriteBytes(usize),

--- a/capsules/src/virtual_spi.rs
+++ b/capsules/src/virtual_spi.rs
@@ -108,8 +108,7 @@ impl<'a, Spi: hil::spi::SpiMaster> MuxSpiMaster<'a, Spi> {
             });
         } else {
             self.inflight.map(|node| {
-                let op = node.operation.get();
-                match op {
+                match node.operation.get() {
                     // we have to report an error
                     Op::ReadWriteDone(status, len) => {
                         node.txbuffer.take().map(|write_buffer| {

--- a/capsules/src/virtual_spi.rs
+++ b/capsules/src/virtual_spi.rs
@@ -112,13 +112,14 @@ impl<'a, Spi: hil::spi::SpiMaster> MuxSpiMaster<'a, Spi> {
                 // Need to set idle here in case callback changes state
                 node.operation.set(Op::Idle);
                 match op {
+                    // we have to report an error
                     Op::ReadWriteDone(status, len) => {
                         node.txbuffer.take().map(|write_buffer| {
                             let read_buffer = node.rxbuffer.take();
                             self.read_write_done(write_buffer, read_buffer, len, status);
                         });
                     }
-                    _ => {} // Can't get here ...
+                    _ => {} // Something is really in flight
                 }
             });
         }

--- a/capsules/src/virtual_spi.rs
+++ b/capsules/src/virtual_spi.rs
@@ -109,7 +109,6 @@ impl<'a, Spi: hil::spi::SpiMaster> MuxSpiMaster<'a, Spi> {
         } else {
             self.inflight.map(|node| {
                 let op = node.operation.get();
-                node.operation.set(Op::Idle);
                 match op {
                     // we have to report an error
                     Op::ReadWriteDone(status, len) => {


### PR DESCRIPTION
### Pull Request Overview

This pull request updates the virtual spi driver to report back errors. In case of errors, the virtual spi driver was setting the `op` variable to `ReadWriteDone` and was calling `do_next_op_async`. The next time `do_next_op` was run, it was not doing anything as it thought the mix was in flight.

It also:
- adds error reporting to the bus library
- fixes the screen driver to report errors
- updates the bus component to take the spi to accept the spi configuration as arguments

### Testing Strategy

This pull request was tested using a Pico Explorer Base


### TODO or Help Wanted

- [x] test using the Adafruit Clue nRF52840

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
