### PR TITLE
[cortex-m0+] Enable unprivileged mode and fix fault handler

### DIFF
--- a/arch/cortex-m0/src/lib.rs
+++ b/arch/cortex-m0/src/lib.rs
@@ -367,11 +367,17 @@ unsafe extern "C" fn hard_fault_handler_continued(faulting_stack: *mut u32, kern
             /* http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dai0321a/BIHFJCAC.html */
 
             ldr r0, FEXC_RETURN_MSP
-            bx r0
+            mov lr, r0
+            b freturn
     .align 4
     FEXC_RETURN_MSP:
       .word 0xFFFFFFF9
-        "
+    freturn:
+        ",
+            out("r1") _,
+            out("r0") _,
+            out("r2") _,
+            options(nostack),
         );
     }
 }

--- a/arch/cortex-m0p/src/lib.rs
+++ b/arch/cortex-m0p/src/lib.rs
@@ -2,6 +2,8 @@
 
 #![crate_name = "cortexm0p"]
 #![crate_type = "rlib"]
+#![feature(asm)]
+#![feature(naked_functions)]
 #![no_std]
 
 pub mod mpu {
@@ -16,12 +18,12 @@ pub use cortexm::initialize_ram_jump_to_main;
 pub use cortexm::interrupt_mask;
 pub use cortexm::nvic;
 pub use cortexm::print_cortexm_state as print_cortexm0_state;
+pub use cortexm::scb;
 pub use cortexm::syscall;
 pub use cortexm::systick;
 pub use cortexm::unhandled_interrupt;
 pub use cortexm0::generic_isr;
 pub use cortexm0::hard_fault_handler;
-pub use cortexm0::svc_handler;
 pub use cortexm0::systick_handler;
 
 // Mock implementation for tests on Travis-CI.
@@ -31,4 +33,46 @@ pub unsafe extern "C" fn switch_to_user(
     _process_regs: &mut [usize; 8],
 ) -> *mut u8 {
     unimplemented!()
+}
+
+// Mock implementation for tests on Travis-CI.
+#[cfg(not(any(target_arch = "arm", target_os = "none")))]
+pub unsafe extern "C" fn svc_handler() {
+    unimplemented!()
+}
+
+#[cfg(all(target_arch = "arm", target_os = "none"))]
+#[naked]
+pub unsafe extern "C" fn svc_handler() {
+    asm!(
+        "
+  ldr r0, EXC_RETURN_MSP
+  cmp lr, r0
+  bne to_kernel
+  
+  // If we get here, then this is a context switch from the kernel to the
+  // application. Set thread mode to unprivileged to run the application.
+  movs r0, #1
+  msr CONTROL, r0
+  ldr r1, EXC_RETURN_PSP
+  bx r1
+
+to_kernel:
+  ldr r0, =SYSCALL_FIRED
+  movs r1, #1
+  str r1, [r0, #0]
+  // Set thread mode to privileged as we switch back to the kernel.
+  movs r0, #0
+  msr CONTROL, r0
+  ldr r1, EXC_RETURN_MSP
+  bx r1
+
+.align 4
+EXC_RETURN_MSP:
+  .word 0xFFFFFFF9
+EXC_RETURN_PSP:
+  .word 0xFFFFFFFD
+  ",
+        options(noreturn)
+    );
 }


### PR DESCRIPTION
### Pull Request Overview

This pull request:

- enables unprivileged mode for Cortex-M0+
- fixes the fault handler

The same `svc_handler` function was used for both m0 and m0+. As m0 has no unprivileged mode, use space was running in privileged mode.

### Testing Strategy

This pull request was tested using an Arduino Nano RP2040 Connect

### TODO or Help Wanted

N/A

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
