### PR TITLE
capsules: pconsole: fix kernel print

### DIFF
--- a/capsules/src/process_console.rs
+++ b/capsules/src/process_console.rs
@@ -987,7 +987,7 @@ impl<'a, C: ProcessManagementCapability> ProcessConsole<'a, C> {
 
                             // Prints kernel memory by moving the writer to the
                             // start state.
-                            self.write_state(WriterState::KernelStart);
+                            self.writer_state.replace(WriterState::KernelStart);
                         } else {
                             let _ = self.write_bytes(b"Valid commands are: ");
                             let _ = self


### PR DESCRIPTION
### Pull Request Overview

I happened to redebug one issue from #2785. Rather than add a new null state, this just updates the state and waits for the next iteration to start the memory map.

Before:

```
Kernel version: release-2.0-rc2-102-gb63200579

 ╔═══════════╤══════════════════════════════╗
 ║  Address  │ Region Name    Used (bytes)  ║
 ╚0x20004438═╪══════════════════════════════
  0x20001000 ┼─────────────────────────────── S
             │   Relocate        0            R
  0x20001000 ┼─────────────────────────────── A
             │ ▼ Stack        4096            M
  0x20000000 ┼───────────────────────────────
             .....
  0x0002C008 ┼─────────────────────────────── F
             │   RoData      28052            L
  0x00025274 ┼─────────────────────────────── A
             │   Code        86644            S
  0x00010000 ┼─────────────────────────────── H
```

After:

```
kernel ble-uart
Kernel version: release-2.0-rc2-102-gb63200579

 ╔═══════════╤══════════════════════════════╗
 ║  Address  │ Region Name    Used (bytes)  ║
 ╚0x20004438═╪══════════════════════════════╝
             │   Bss         13368
  0x20001000 ┼─────────────────────────────── S
             │   Relocate        0            R
  0x20001000 ┼─────────────────────────────── A
             │ ▼ Stack        4096            M
  0x20000000 ┼───────────────────────────────
             .....
  0x0002C008 ┼─────────────────────────────── F
             │   RoData      28046            L
  0x0002527A ┼─────────────────────────────── A
             │   Code        86650            S
  0x00010000 ┼─────────────────────────────── H
```

The underlying issue is the queue is only 300 bytes and that overflows with the first kernel memory map print. By waiting until the next iteration we avoid using the queue.

### Testing Strategy

Trying it on hail.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
