### PR TITLE
ProcessSlice augmentation: add From<> [u8] impls and express chunks() iterator as &ProcessSlice instead of &[Cell<u8>]

### DIFF
--- a/kernel/src/processbuffer.rs
+++ b/kernel/src/processbuffer.rs
@@ -601,6 +601,28 @@ pub struct ReadableProcessSlice {
     slice: [ReadableProcessByte],
 }
 
+// Allow a u8 slice to be viewed as a ReadableProcessSlice to allow client code to be
+// authored once and accept either [u8] or ReadableProcessSlice
+impl<'a> From<&'a [u8]> for &'a ReadableProcessSlice {
+    fn from(val: &'a [u8]) -> Self {
+        // SAFETY: The layout of a [u8] and ReadableProcessSlice are guaranteed to be the same.
+        //         This also extends the lifetime of the buffer, so aliasing rules are
+        //         thus maintained properly.
+        unsafe { core::mem::transmute(val) }
+    }
+}
+
+// Allow a mutable u8 slice to be viewed as a ReadableProcessSlice to allow client code to be
+// authored once and accept either [u8] or ReadableProcessSlice
+impl<'a> From<&'a mut [u8]> for &'a ReadableProcessSlice {
+    fn from(val: &'a mut [u8]) -> Self {
+        // SAFETY: The layout of a [u8] and ReadableProcessSlice are guaranteed to be the same.
+        //         This also extends the mutable lifetime of the buffer, so aliasing rules are
+        //         thus maintained properly.
+        unsafe { core::mem::transmute(val) }
+    }
+}
+
 impl ReadableProcessSlice {
     /// Copy the contents of a [`ReadableProcessSlice`] into a mutable
     /// slice reference.
@@ -717,6 +739,17 @@ impl Index<usize> for ReadableProcessSlice {
 #[repr(transparent)]
 pub struct WriteableProcessSlice {
     slice: [Cell<u8>],
+}
+
+// Allow a mutable u8 slice to be viewed as a WritableProcessSlice to allow client code to be
+// authored once and accept either [u8] or WriteableProcessSlice
+impl<'a> From<&'a mut [u8]> for &'a WriteableProcessSlice {
+    fn from(val: &'a mut [u8]) -> Self {
+        // SAFETY: The layout of a [u8] and WriteableProcessSlice are guaranteed to be the same.
+        //         This also extends the mutable lifetime of the buffer, so aliasing rules are
+        //         thus maintained properly.
+        unsafe { core::mem::transmute(val) }
+    }
 }
 
 impl WriteableProcessSlice {


### PR DESCRIPTION
### Pull Request Overview

Drivers that should operate on either ...`ProcessSlice` buffers or `u8` slices
should be able to single source their implementations. To facilitate
this, add a safe conversion from a `u8` slice into the appropriate
...`ProcessSlice` structure. This limits how you can access the `u8` slice, but
every ...`ProcessSlice` accessor is still safe to perform on a normal slice.



### Testing Strategy

Manually verified that rust lifetime rules apply correctly. For example, the follow code snippet generates a compiler error

```rust
fn test(buf: &mut [u8]) {
   let slice: WriteableProcessSlice = buf.into();
   buf[0] = 1;
   slice[0].set(2);
}
```
This above snippet complains about multiple mutable references: `error[E0503]: cannot use *buf because it was mutably borrowed`


### Documentation Updated

- None

### Formatting

- [x] Ran `make prepush`.
