### PR TITLE
rfc: add low level driver capability

### DIFF
--- a/boards/nano_rp2040_connect/src/main.rs
+++ b/boards/nano_rp2040_connect/src/main.rs
@@ -220,13 +220,25 @@ fn init_clocks(peripherals: &Rp2040DefaultPeripherals) {
         .configure_peripheral(PeripheralAuxiliaryClockSource::System, 125000000);
 }
 
+/// This is in a separate, inline(never) function so that its stack frame is
+/// removed when this function returns. Otherwise, the stack space used for
+/// these static_inits is wasted.
+#[inline(never)]
+unsafe fn get_peripherals() -> &'static mut Rp2040DefaultPeripherals<'static> {
+    let low_level_capability = create_capability!(capabilities::LowLevelDriverCreationCapability);
+    static_init!(
+        Rp2040DefaultPeripherals,
+        Rp2040DefaultPeripherals::new(&low_level_capability)
+    )
+}
+
 /// Main function called after RAM initialized.
 #[no_mangle]
 pub unsafe fn main() {
     // Loads relocations and clears BSS
     rp2040::init();
 
-    let peripherals = static_init!(Rp2040DefaultPeripherals, Rp2040DefaultPeripherals::new());
+    let peripherals = get_peripherals();
 
     // Set the UART used for panic
     io::WRITER.set_uart(&peripherals.uart0);

--- a/boards/pico_explorer_base/src/io.rs
+++ b/boards/pico_explorer_base/src/io.rs
@@ -1,6 +1,8 @@
 use core::fmt::Write;
 use core::panic::PanicInfo;
 
+use kernel::capabilities::LowLevelDriverCreationCapability;
+use kernel::create_capability;
 use kernel::debug::{self, IoWrite};
 use kernel::hil::led::LedHigh;
 use kernel::utilities::cells::OptionalCell;
@@ -45,7 +47,8 @@ impl IoWrite for Writer {
         self.uart.map_or_else(
             || {
                 // If no UART is configured for panic print, use UART0
-                let uart0 = &Uart::new_uart0();
+                let capability = create_capability!(LowLevelDriverCreationCapability);
+                let uart0 = &Uart::new_uart0(&capability);
 
                 if !uart0.is_configured() {
                     let parameters = Parameters {
@@ -58,8 +61,8 @@ impl IoWrite for Writer {
                     //configure parameters of uart for sending bytes
                     let _result = uart0.configure(parameters);
                     //set RX and TX pins in UART mode
-                    let gpio_tx = RPGpioPin::new(RPGpio::GPIO0);
-                    let gpio_rx = RPGpioPin::new(RPGpio::GPIO1);
+                    let gpio_tx = RPGpioPin::new(RPGpio::GPIO0, &capability);
+                    let gpio_rx = RPGpioPin::new(RPGpio::GPIO1, &capability);
                     gpio_rx.set_function(GpioFunction::UART);
                     gpio_tx.set_function(GpioFunction::UART);
                 }
@@ -80,8 +83,9 @@ impl IoWrite for Writer {
 #[no_mangle]
 #[panic_handler]
 pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
+    let capability = create_capability!(LowLevelDriverCreationCapability);
     // LED is conneted to GPIO 25
-    let led_kernel_pin = &RPGpioPin::new(RPGpio::GPIO25);
+    let led_kernel_pin = &RPGpioPin::new(RPGpio::GPIO25, &capability);
     let led = &mut LedHigh::new(led_kernel_pin);
     let writer = &mut WRITER;
 

--- a/boards/pico_explorer_base/src/main.rs
+++ b/boards/pico_explorer_base/src/main.rs
@@ -233,7 +233,11 @@ fn init_clocks(peripherals: &Rp2040DefaultPeripherals) {
 /// these static_inits is wasted.
 #[inline(never)]
 unsafe fn get_peripherals() -> &'static mut Rp2040DefaultPeripherals<'static> {
-    static_init!(Rp2040DefaultPeripherals, Rp2040DefaultPeripherals::new())
+    let low_level_capability = create_capability!(capabilities::LowLevelDriverCreationCapability);
+    static_init!(
+        Rp2040DefaultPeripherals,
+        Rp2040DefaultPeripherals::new(&low_level_capability)
+    )
 }
 
 /// Main function called after RAM initialized.

--- a/boards/raspberry_pi_pico/src/main.rs
+++ b/boards/raspberry_pi_pico/src/main.rs
@@ -225,7 +225,11 @@ fn init_clocks(peripherals: &Rp2040DefaultPeripherals) {
 /// these static_inits is wasted.
 #[inline(never)]
 unsafe fn get_peripherals() -> &'static mut Rp2040DefaultPeripherals<'static> {
-    static_init!(Rp2040DefaultPeripherals, Rp2040DefaultPeripherals::new())
+    let low_level_capability = create_capability!(capabilities::LowLevelDriverCreationCapability);
+    static_init!(
+        Rp2040DefaultPeripherals,
+        Rp2040DefaultPeripherals::new(&low_level_capability)
+    )
 }
 
 /// Main function called after RAM initialized.

--- a/chips/rp2040/src/adc.rs
+++ b/chips/rp2040/src/adc.rs
@@ -1,4 +1,5 @@
 use core::cell::Cell;
+use kernel::capabilities::LowLevelDriverCreationCapability;
 use kernel::hil;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable};
 use kernel::utilities::registers::{register_bitfields, register_structs, ReadWrite};
@@ -145,7 +146,7 @@ pub struct Adc {
 }
 
 impl Adc {
-    pub const fn new() -> Self {
+    pub const fn new(_: &dyn LowLevelDriverCreationCapability) -> Self {
         Self {
             registers: ADC_BASE,
             status: Cell::new(ADCStatus::Idle),

--- a/chips/rp2040/src/chip.rs
+++ b/chips/rp2040/src/chip.rs
@@ -1,6 +1,7 @@
 //! Chip trait setup.
 
 use core::fmt::Write;
+use kernel::capabilities::LowLevelDriverCreationCapability;
 use kernel::deferred_call;
 use kernel::platform::chip::Chip;
 use kernel::platform::chip::InterruptService;
@@ -126,19 +127,19 @@ pub struct Rp2040DefaultPeripherals<'a> {
 }
 
 impl<'a> Rp2040DefaultPeripherals<'a> {
-    pub const fn new() -> Self {
+    pub const fn new(capability: &dyn LowLevelDriverCreationCapability) -> Self {
         Self {
-            resets: Resets::new(),
+            resets: Resets::new(capability),
             sio: SIO::new(),
-            clocks: Clocks::new(),
-            xosc: Xosc::new(),
-            timer: RPTimer::new(),
-            watchdog: Watchdog::new(),
-            pins: RPPins::new(),
-            uart0: Uart::new_uart0(),
-            adc: adc::Adc::new(),
-            spi0: spi::Spi::new_spi0(),
-            sysinfo: sysinfo::SysInfo::new(),
+            clocks: Clocks::new(capability),
+            xosc: Xosc::new(capability),
+            timer: RPTimer::new(capability),
+            watchdog: Watchdog::new(capability),
+            pins: RPPins::new(capability),
+            uart0: Uart::new_uart0(capability),
+            adc: adc::Adc::new(capability),
+            spi0: spi::Spi::new_spi0(capability),
+            sysinfo: sysinfo::SysInfo::new(capability),
         }
     }
 

--- a/chips/rp2040/src/clocks.rs
+++ b/chips/rp2040/src/clocks.rs
@@ -1,4 +1,5 @@
 use core::cell::Cell;
+use kernel::capabilities::LowLevelDriverCreationCapability;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
 use kernel::utilities::registers::{register_bitfields, register_structs, ReadOnly, ReadWrite};
 use kernel::utilities::StaticRef;
@@ -881,7 +882,7 @@ pub enum ClockAuxiliarySource {
 }
 
 impl Clocks {
-    pub const fn new() -> Self {
+    pub const fn new(_: &dyn LowLevelDriverCreationCapability) -> Self {
         Self {
             registers: CLOCKS_BASE,
             pll_registers: &[PLL_SYS_BASE, PLL_USB_BASE],

--- a/chips/rp2040/src/gpio.rs
+++ b/chips/rp2040/src/gpio.rs
@@ -5,6 +5,7 @@
 
 use enum_primitive::cast::FromPrimitive;
 use enum_primitive::enum_from_primitive;
+use kernel::capabilities::LowLevelDriverCreationCapability;
 use kernel::hil;
 use kernel::utilities::cells::OptionalCell;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
@@ -293,39 +294,39 @@ pub struct RPPins<'a> {
 }
 
 impl<'a> RPPins<'a> {
-    pub const fn new() -> Self {
+    pub const fn new(capability: &dyn LowLevelDriverCreationCapability) -> Self {
         Self {
             pins: [
-                RPGpioPin::new(RPGpio::GPIO0),
-                RPGpioPin::new(RPGpio::GPIO1),
-                RPGpioPin::new(RPGpio::GPIO2),
-                RPGpioPin::new(RPGpio::GPIO3),
-                RPGpioPin::new(RPGpio::GPIO4),
-                RPGpioPin::new(RPGpio::GPIO5),
-                RPGpioPin::new(RPGpio::GPIO6),
-                RPGpioPin::new(RPGpio::GPIO7),
-                RPGpioPin::new(RPGpio::GPIO8),
-                RPGpioPin::new(RPGpio::GPIO9),
-                RPGpioPin::new(RPGpio::GPIO10),
-                RPGpioPin::new(RPGpio::GPIO11),
-                RPGpioPin::new(RPGpio::GPIO12),
-                RPGpioPin::new(RPGpio::GPIO13),
-                RPGpioPin::new(RPGpio::GPIO14),
-                RPGpioPin::new(RPGpio::GPIO15),
-                RPGpioPin::new(RPGpio::GPIO16),
-                RPGpioPin::new(RPGpio::GPIO17),
-                RPGpioPin::new(RPGpio::GPIO18),
-                RPGpioPin::new(RPGpio::GPIO19),
-                RPGpioPin::new(RPGpio::GPIO20),
-                RPGpioPin::new(RPGpio::GPIO21),
-                RPGpioPin::new(RPGpio::GPIO22),
-                RPGpioPin::new(RPGpio::GPIO23),
-                RPGpioPin::new(RPGpio::GPIO24),
-                RPGpioPin::new(RPGpio::GPIO25),
-                RPGpioPin::new(RPGpio::GPIO26),
-                RPGpioPin::new(RPGpio::GPIO27),
-                RPGpioPin::new(RPGpio::GPIO28),
-                RPGpioPin::new(RPGpio::GPIO29),
+                RPGpioPin::new(RPGpio::GPIO0, capability),
+                RPGpioPin::new(RPGpio::GPIO1, capability),
+                RPGpioPin::new(RPGpio::GPIO2, capability),
+                RPGpioPin::new(RPGpio::GPIO3, capability),
+                RPGpioPin::new(RPGpio::GPIO4, capability),
+                RPGpioPin::new(RPGpio::GPIO5, capability),
+                RPGpioPin::new(RPGpio::GPIO6, capability),
+                RPGpioPin::new(RPGpio::GPIO7, capability),
+                RPGpioPin::new(RPGpio::GPIO8, capability),
+                RPGpioPin::new(RPGpio::GPIO9, capability),
+                RPGpioPin::new(RPGpio::GPIO10, capability),
+                RPGpioPin::new(RPGpio::GPIO11, capability),
+                RPGpioPin::new(RPGpio::GPIO12, capability),
+                RPGpioPin::new(RPGpio::GPIO13, capability),
+                RPGpioPin::new(RPGpio::GPIO14, capability),
+                RPGpioPin::new(RPGpio::GPIO15, capability),
+                RPGpioPin::new(RPGpio::GPIO16, capability),
+                RPGpioPin::new(RPGpio::GPIO17, capability),
+                RPGpioPin::new(RPGpio::GPIO18, capability),
+                RPGpioPin::new(RPGpio::GPIO19, capability),
+                RPGpioPin::new(RPGpio::GPIO20, capability),
+                RPGpioPin::new(RPGpio::GPIO21, capability),
+                RPGpioPin::new(RPGpio::GPIO22, capability),
+                RPGpioPin::new(RPGpio::GPIO23, capability),
+                RPGpioPin::new(RPGpio::GPIO24, capability),
+                RPGpioPin::new(RPGpio::GPIO25, capability),
+                RPGpioPin::new(RPGpio::GPIO26, capability),
+                RPGpioPin::new(RPGpio::GPIO27, capability),
+                RPGpioPin::new(RPGpio::GPIO28, capability),
+                RPGpioPin::new(RPGpio::GPIO29, capability),
             ],
             gpio_registers: GPIO_BASE,
         }
@@ -396,7 +397,7 @@ pub struct RPGpioPin<'a> {
 }
 
 impl<'a> RPGpioPin<'a> {
-    pub const fn new(pin: RPGpio) -> RPGpioPin<'a> {
+    pub const fn new(pin: RPGpio, _: &dyn LowLevelDriverCreationCapability) -> RPGpioPin<'a> {
         RPGpioPin {
             pin: pin as usize,
             client: OptionalCell::empty(),
@@ -637,7 +638,7 @@ pub struct SIO {
 }
 
 impl SIO {
-    pub const fn new() -> Self {
+    pub(crate) const fn new() -> Self {
         Self {
             registers: SIO_BASE,
         }

--- a/chips/rp2040/src/resets.rs
+++ b/chips/rp2040/src/resets.rs
@@ -1,3 +1,4 @@
+use kernel::capabilities::LowLevelDriverCreationCapability;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
 use kernel::utilities::registers::{register_bitfields, register_structs, FieldValue, ReadWrite};
 use kernel::utilities::StaticRef;
@@ -299,7 +300,7 @@ pub struct Resets {
 }
 
 impl Resets {
-    pub const fn new() -> Resets {
+    pub const fn new(_: &dyn LowLevelDriverCreationCapability) -> Resets {
         Resets {
             registers: RESETS_BASE,
         }

--- a/chips/rp2040/src/spi.rs
+++ b/chips/rp2040/src/spi.rs
@@ -1,6 +1,7 @@
 use crate::clocks;
 use core::cell::Cell;
 use core::cmp;
+use kernel::capabilities::LowLevelDriverCreationCapability;
 use kernel::hil;
 use kernel::hil::gpio::Output;
 use kernel::hil::spi::SpiMaster;
@@ -248,7 +249,7 @@ pub struct Spi<'a> {
 }
 
 impl<'a> Spi<'a> {
-    pub const fn new_spi0() -> Self {
+    pub const fn new_spi0(_: &dyn LowLevelDriverCreationCapability) -> Self {
         Self {
             registers: SPI0_BASE,
             clocks: OptionalCell::empty(),
@@ -268,7 +269,7 @@ impl<'a> Spi<'a> {
         }
     }
 
-    pub const fn new_spi1() -> Self {
+    pub const fn new_spi1(_: &dyn LowLevelDriverCreationCapability) -> Self {
         Self {
             registers: SPI1_BASE,
             clocks: OptionalCell::empty(),

--- a/chips/rp2040/src/sysinfo.rs
+++ b/chips/rp2040/src/sysinfo.rs
@@ -1,7 +1,7 @@
+use kernel::capabilities::LowLevelDriverCreationCapability;
 use kernel::utilities::registers::interfaces::Readable;
-use kernel::utilities::StaticRef;
-
 use kernel::utilities::registers::{register_bitfields, register_structs, ReadWrite};
+use kernel::utilities::StaticRef;
 
 register_structs! {
 
@@ -52,7 +52,7 @@ pub struct SysInfo {
 }
 
 impl SysInfo {
-    pub const fn new() -> SysInfo {
+    pub const fn new(_: &dyn LowLevelDriverCreationCapability) -> SysInfo {
         SysInfo {
             registers: SYSINFO_BASE,
         }

--- a/chips/rp2040/src/timer.rs
+++ b/chips/rp2040/src/timer.rs
@@ -1,5 +1,6 @@
 use cortexm0p;
 use cortexm0p::support::atomic;
+use kernel::capabilities::LowLevelDriverCreationCapability;
 use kernel::hil;
 use kernel::hil::time::{Alarm, Ticks, Ticks32, Time};
 use kernel::utilities::cells::OptionalCell;
@@ -173,7 +174,7 @@ pub struct RPTimer<'a> {
 }
 
 impl<'a> RPTimer<'a> {
-    pub const fn new() -> RPTimer<'a> {
+    pub const fn new(_: &dyn LowLevelDriverCreationCapability) -> RPTimer<'a> {
         RPTimer {
             registers: TIMER_BASE,
             client: OptionalCell::empty(),

--- a/chips/rp2040/src/uart.rs
+++ b/chips/rp2040/src/uart.rs
@@ -1,4 +1,5 @@
 use core::cell::Cell;
+use kernel::capabilities::LowLevelDriverCreationCapability;
 use kernel::hil;
 use kernel::hil::uart::ReceiveClient;
 use kernel::hil::uart::{
@@ -392,7 +393,7 @@ pub struct Uart<'a> {
 }
 
 impl<'a> Uart<'a> {
-    pub const fn new_uart0() -> Self {
+    pub const fn new_uart0(_: &dyn LowLevelDriverCreationCapability) -> Self {
         Self {
             registers: UART0_BASE,
             clocks: OptionalCell::empty(),
@@ -411,7 +412,7 @@ impl<'a> Uart<'a> {
             rx_status: Cell::new(UARTStateRX::Idle),
         }
     }
-    pub const fn new_uart1() -> Self {
+    pub const fn new_uart1(_: &dyn LowLevelDriverCreationCapability) -> Self {
         Self {
             registers: UART1_BASE,
             clocks: OptionalCell::empty(),

--- a/chips/rp2040/src/watchdog.rs
+++ b/chips/rp2040/src/watchdog.rs
@@ -1,3 +1,4 @@
+use kernel::capabilities::LowLevelDriverCreationCapability;
 use kernel::utilities::registers::interfaces::ReadWriteable;
 use kernel::utilities::registers::{register_bitfields, register_structs, ReadWrite};
 use kernel::utilities::StaticRef;
@@ -102,7 +103,7 @@ pub struct Watchdog {
 }
 
 impl Watchdog {
-    pub const fn new() -> Watchdog {
+    pub const fn new(_: &dyn LowLevelDriverCreationCapability) -> Watchdog {
         Watchdog {
             registers: WATCHDOG_BASE,
         }

--- a/chips/rp2040/src/xosc.rs
+++ b/chips/rp2040/src/xosc.rs
@@ -1,3 +1,4 @@
+use kernel::capabilities::LowLevelDriverCreationCapability;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable};
 use kernel::utilities::registers::{register_bitfields, register_structs, ReadWrite};
 use kernel::utilities::StaticRef;
@@ -81,7 +82,7 @@ pub struct Xosc {
 }
 
 impl Xosc {
-    pub const fn new() -> Self {
+    pub const fn new(_: &dyn LowLevelDriverCreationCapability) -> Self {
         Self {
             registers: XOSC_BASE,
         }

--- a/kernel/src/capabilities.rs
+++ b/kernel/src/capabilities.rs
@@ -90,3 +90,8 @@ pub unsafe trait CreatePortTableCapability {}
 /// of the networking stack. A capsule would never hold this capability although
 /// it may hold capabilities created via this capability.
 pub unsafe trait NetworkCapabilityCreationCapability {}
+
+/// The `LowLevelDriverCreationCapability` allows the creation of low level
+/// drivers, usually peripherals. This capability should be required by all
+/// low level drivers and should not be distributed to capsules.
+pub unsafe trait LowLevelDriverCreationCapability {}


### PR DESCRIPTION
### Pull Request Overview

This pull request adds the `LowLevelDriverCreationCapability`. While talking a look at Tock's source together with an industry partner, we realized that there is nothing much stopping a capsule from creating a certain peripheral and using it directly. Capsules would not be able to use interrupts, as they would not be registered with the kernel's infrastructure, but could use any synchronous interfaces.

So far I have modified the Raspberry Pi Pico just as a proof of concept.

### Testing Strategy

N/A

### TODO or Help Wanted

This pull request still needs feedback.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
