### PR TITLE
rp2040: Make peripherals construction functions unsafe

### DIFF
--- a/boards/nano_rp2040_connect/src/io.rs
+++ b/boards/nano_rp2040_connect/src/io.rs
@@ -46,7 +46,7 @@ impl IoWrite for Writer {
         self.uart.map_or_else(
             || {
                 // If no UART is configured for panic print, use UART0
-                let uart0 = &Uart::new_uart0();
+                let uart0 = unsafe { &Uart::new_uart0() };
 
                 if !uart0.is_configured() {
                     let parameters = Parameters {
@@ -59,8 +59,8 @@ impl IoWrite for Writer {
                     //configure parameters of uart for sending bytes
                     let _result = uart0.configure(parameters);
                     //set RX and TX pins in UART mode
-                    let gpio_tx = RPGpioPin::new(RPGpio::GPIO0);
-                    let gpio_rx = RPGpioPin::new(RPGpio::GPIO1);
+                    let gpio_tx = unsafe { RPGpioPin::new(RPGpio::GPIO0) };
+                    let gpio_rx = unsafe { RPGpioPin::new(RPGpio::GPIO1) };
                     gpio_rx.set_function(GpioFunction::UART);
                     gpio_tx.set_function(GpioFunction::UART);
                 }

--- a/boards/pico_explorer_base/src/io.rs
+++ b/boards/pico_explorer_base/src/io.rs
@@ -45,7 +45,7 @@ impl IoWrite for Writer {
         self.uart.map_or_else(
             || {
                 // If no UART is configured for panic print, use UART0
-                let uart0 = &Uart::new_uart0();
+                let uart0 = unsafe { &Uart::new_uart0() };
 
                 if !uart0.is_configured() {
                     let parameters = Parameters {
@@ -58,8 +58,8 @@ impl IoWrite for Writer {
                     //configure parameters of uart for sending bytes
                     let _result = uart0.configure(parameters);
                     //set RX and TX pins in UART mode
-                    let gpio_tx = RPGpioPin::new(RPGpio::GPIO0);
-                    let gpio_rx = RPGpioPin::new(RPGpio::GPIO1);
+                    let gpio_tx = unsafe { RPGpioPin::new(RPGpio::GPIO0) };
+                    let gpio_rx = unsafe { RPGpioPin::new(RPGpio::GPIO1) };
                     gpio_rx.set_function(GpioFunction::UART);
                     gpio_tx.set_function(GpioFunction::UART);
                 }

--- a/boards/raspberry_pi_pico/src/io.rs
+++ b/boards/raspberry_pi_pico/src/io.rs
@@ -46,7 +46,7 @@ impl IoWrite for Writer {
         self.uart.map_or_else(
             || {
                 // If no UART is configured for panic print, use UART0
-                let uart0 = &Uart::new_uart0();
+                let uart0 = unsafe { &Uart::new_uart0() };
 
                 if !uart0.is_configured() {
                     let parameters = Parameters {
@@ -59,8 +59,8 @@ impl IoWrite for Writer {
                     //configure parameters of uart for sending bytes
                     let _result = uart0.configure(parameters);
                     //set RX and TX pins in UART mode
-                    let gpio_tx = RPGpioPin::new(RPGpio::GPIO0);
-                    let gpio_rx = RPGpioPin::new(RPGpio::GPIO1);
+                    let gpio_tx = unsafe { RPGpioPin::new(RPGpio::GPIO0) };
+                    let gpio_rx = unsafe { RPGpioPin::new(RPGpio::GPIO1) };
                     gpio_rx.set_function(GpioFunction::UART);
                     gpio_tx.set_function(GpioFunction::UART);
                 }

--- a/chips/rp2040/src/adc.rs
+++ b/chips/rp2040/src/adc.rs
@@ -145,7 +145,7 @@ pub struct Adc {
 }
 
 impl Adc {
-    pub const fn new() -> Self {
+    pub const unsafe fn new() -> Self {
         Self {
             registers: ADC_BASE,
             status: Cell::new(ADCStatus::Idle),

--- a/chips/rp2040/src/chip.rs
+++ b/chips/rp2040/src/chip.rs
@@ -128,7 +128,7 @@ pub struct Rp2040DefaultPeripherals<'a> {
 }
 
 impl<'a> Rp2040DefaultPeripherals<'a> {
-    pub const fn new() -> Self {
+    pub const unsafe fn new() -> Self {
         Self {
             resets: Resets::new(),
             sio: SIO::new(),

--- a/chips/rp2040/src/clocks.rs
+++ b/chips/rp2040/src/clocks.rs
@@ -881,7 +881,7 @@ pub enum ClockAuxiliarySource {
 }
 
 impl Clocks {
-    pub const fn new() -> Self {
+    pub const unsafe fn new() -> Self {
         Self {
             registers: CLOCKS_BASE,
             pll_registers: &[PLL_SYS_BASE, PLL_USB_BASE],

--- a/chips/rp2040/src/gpio.rs
+++ b/chips/rp2040/src/gpio.rs
@@ -293,7 +293,7 @@ pub struct RPPins<'a> {
 }
 
 impl<'a> RPPins<'a> {
-    pub const fn new() -> Self {
+    pub const unsafe fn new() -> Self {
         Self {
             pins: [
                 RPGpioPin::new(RPGpio::GPIO0),
@@ -396,7 +396,7 @@ pub struct RPGpioPin<'a> {
 }
 
 impl<'a> RPGpioPin<'a> {
-    pub const fn new(pin: RPGpio) -> RPGpioPin<'a> {
+    pub const unsafe fn new(pin: RPGpio) -> RPGpioPin<'a> {
         RPGpioPin {
             pin: pin as usize,
             client: OptionalCell::empty(),
@@ -637,7 +637,7 @@ pub struct SIO {
 }
 
 impl SIO {
-    pub const fn new() -> Self {
+    pub const unsafe fn new() -> Self {
         Self {
             registers: SIO_BASE,
         }

--- a/chips/rp2040/src/i2c.rs
+++ b/chips/rp2040/src/i2c.rs
@@ -276,11 +276,11 @@ impl<'a> I2c<'a> {
         }
     }
 
-    pub const fn new_i2c0() -> Self {
+    pub const unsafe fn new_i2c0() -> Self {
         I2c::new(0)
     }
 
-    pub const fn new_i2c1() -> Self {
+    pub const unsafe fn new_i2c1() -> Self {
         I2c::new(1)
     }
 

--- a/chips/rp2040/src/resets.rs
+++ b/chips/rp2040/src/resets.rs
@@ -299,7 +299,7 @@ pub struct Resets {
 }
 
 impl Resets {
-    pub const fn new() -> Resets {
+    pub const unsafe fn new() -> Resets {
         Resets {
             registers: RESETS_BASE,
         }

--- a/chips/rp2040/src/spi.rs
+++ b/chips/rp2040/src/spi.rs
@@ -224,11 +224,12 @@ register_bitfields![u32,
     ]
 ];
 
-const SPI0_BASE: StaticRef<SpiRegisters> =
-    unsafe { StaticRef::new(0x4003C000 as *const SpiRegisters) };
-
-const SPI1_BASE: StaticRef<SpiRegisters> =
-    unsafe { StaticRef::new(0x40040000 as *const SpiRegisters) };
+const INSTANCES: [StaticRef<SpiRegisters>; 2] = unsafe {
+    [
+        StaticRef::new(0x4003C000 as *const SpiRegisters),
+        StaticRef::new(0x40040000 as *const SpiRegisters),
+    ]
+};
 
 pub struct Spi<'a> {
     registers: StaticRef<SpiRegisters>,
@@ -248,9 +249,9 @@ pub struct Spi<'a> {
 }
 
 impl<'a> Spi<'a> {
-    pub const fn new_spi0() -> Self {
+    const fn new(instance: u8) -> Self {
         Self {
-            registers: SPI0_BASE,
+            registers: INSTANCES[instance as usize],
             clocks: OptionalCell::empty(),
             master_client: OptionalCell::empty(),
             active_slave: OptionalCell::empty(),
@@ -268,24 +269,12 @@ impl<'a> Spi<'a> {
         }
     }
 
-    pub const fn new_spi1() -> Self {
-        Self {
-            registers: SPI1_BASE,
-            clocks: OptionalCell::empty(),
-            master_client: OptionalCell::empty(),
-            active_slave: OptionalCell::empty(),
+    pub const unsafe fn new_spi0() -> Self {
+        Spi::new(0)
+    }
 
-            tx_buffer: TakeCell::empty(),
-            tx_position: Cell::new(0),
-
-            rx_buffer: TakeCell::empty(),
-            rx_position: Cell::new(0),
-
-            len: Cell::new(0),
-
-            transfers: Cell::new(SPI_IDLE),
-            active_after: Cell::new(false),
-        }
+    pub const unsafe fn new_spi1() -> Self {
+        Spi::new(1)
     }
 
     pub fn set_clocks(&self, clocks: &'a clocks::Clocks) {

--- a/chips/rp2040/src/sysinfo.rs
+++ b/chips/rp2040/src/sysinfo.rs
@@ -1,7 +1,6 @@
 use kernel::utilities::registers::interfaces::Readable;
-use kernel::utilities::StaticRef;
-
 use kernel::utilities::registers::{register_bitfields, register_structs, ReadWrite};
+use kernel::utilities::StaticRef;
 
 register_structs! {
 
@@ -52,7 +51,7 @@ pub struct SysInfo {
 }
 
 impl SysInfo {
-    pub const fn new() -> SysInfo {
+    pub const unsafe fn new() -> SysInfo {
         SysInfo {
             registers: SYSINFO_BASE,
         }

--- a/chips/rp2040/src/timer.rs
+++ b/chips/rp2040/src/timer.rs
@@ -173,7 +173,7 @@ pub struct RPTimer<'a> {
 }
 
 impl<'a> RPTimer<'a> {
-    pub const fn new() -> RPTimer<'a> {
+    pub const unsafe fn new() -> RPTimer<'a> {
         RPTimer {
             registers: TIMER_BASE,
             client: OptionalCell::empty(),

--- a/chips/rp2040/src/watchdog.rs
+++ b/chips/rp2040/src/watchdog.rs
@@ -102,7 +102,7 @@ pub struct Watchdog {
 }
 
 impl Watchdog {
-    pub const fn new() -> Watchdog {
+    pub const unsafe fn new() -> Watchdog {
         Watchdog {
             registers: WATCHDOG_BASE,
         }

--- a/chips/rp2040/src/xosc.rs
+++ b/chips/rp2040/src/xosc.rs
@@ -81,7 +81,7 @@ pub struct Xosc {
 }
 
 impl Xosc {
-    pub const fn new() -> Self {
+    pub const unsafe fn new() -> Self {
         Self {
             registers: XOSC_BASE,
         }


### PR DESCRIPTION
### Pull Request Overview

Based on the discussion from #2800, it seems that for now this is the best solution. This pull request makes all the `new` functions from the RP2040 chip unsafe. I considered several solutions:
1. Use a capability, but the general idea is that it is not a good solution (#2800);
2. Make `new` function private to the crate, but this prevents the boards from creating single peripherals;
3. Make `new` functions unsafe, this at least prevents creating peripherals from capsules.

### Testing Strategy

N/A

### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
