### PR TITLE
rv32i/pmp: add clarifying comment to enumeration

### DIFF
--- a/arch/rv32i/src/pmp.rs
+++ b/arch/rv32i/src/pmp.rs
@@ -265,8 +265,9 @@ impl<const MAX_AVAILABLE_REGIONS_OVER_TWO: usize> PMPConfig<MAX_AVAILABLE_REGION
     /// The app regions need to be lower then the kernel to ensure they
     /// match before the kernel ones.
     fn unused_kernel_region_number(&self, locked_region_mask: u64) -> Option<usize> {
-        for (num, region) in self.regions.iter().rev().enumerate() {
-            let number = MAX_AVAILABLE_REGIONS_OVER_TWO - num - 1;
+        // It is important to enumerate first, then reverse otherwise the enumeration index
+        // won't match the array index
+        for (number, region) in self.regions.iter().enumerate().rev() {
             if self.app_memory_region.contains(&number) {
                 continue;
             }


### PR DESCRIPTION
### Pull Request Overview

It is subtle that calling enumerate() on a rev() iterator does not
produce values in a backwards order. However, we can call enumerate,
then rev to get index values that match the array indexes.

This also closes #2727 

See the [rust playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=1b66e17de3c22e49cb855dde854cce09) for a demonstration.

### Documentation Updated

- None

### Formatting

- [x] Ran `make prepush`.
