### PR TITLE
Add a software hash to Tock and connect it to TicKV

### DIFF
--- a/boards/components/src/tickv.rs
+++ b/boards/components/src/tickv.rs
@@ -40,8 +40,8 @@ use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
 use kernel::hil;
-use kernel::hil::digest::Digest;
 use kernel::hil::flash::HasClient;
+use kernel::hil::hasher::Hasher;
 use kernel::static_init_half;
 
 // Setup static space for the objects.
@@ -61,7 +61,7 @@ macro_rules! tickv_component_helper {
 
 pub struct TicKVComponent<
     F: 'static + hil::flash::Flash + hil::flash::HasClient<'static, MuxFlash<'static, F>>,
-    H: 'static + Digest<'static, 8>,
+    H: 'static + Hasher<'static, 8>,
 > {
     mux_flash: &'static MuxFlash<'static, F>,
     hasher: &'static H,
@@ -73,7 +73,7 @@ pub struct TicKVComponent<
 
 impl<
         F: 'static + hil::flash::Flash + hil::flash::HasClient<'static, MuxFlash<'static, F>>,
-        H: Digest<'static, 8>,
+        H: Hasher<'static, 8>,
     > TicKVComponent<F, H>
 {
     pub fn new(
@@ -97,7 +97,7 @@ impl<
 
 impl<
         F: 'static + hil::flash::Flash + hil::flash::HasClient<'static, MuxFlash<'static, F>>,
-        H: 'static + Digest<'static, 8>,
+        H: 'static + Hasher<'static, 8>,
     > Component for TicKVComponent<F, H>
 {
     type StaticInput = (

--- a/boards/components/src/tickv.rs
+++ b/boards/components/src/tickv.rs
@@ -40,19 +40,20 @@ use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
 use kernel::hil;
+use kernel::hil::digest::Digest;
 use kernel::hil::flash::HasClient;
 use kernel::static_init_half;
 
 // Setup static space for the objects.
 #[macro_export]
 macro_rules! tickv_component_helper {
-    ($F:ty) => {{
+    ($F:ty, $H:ty) => {{
         use capsules::tickv::TicKVStore;
         use capsules::virtual_flash::FlashUser;
         use core::mem::MaybeUninit;
         use kernel::hil;
         static mut BUF1: MaybeUninit<FlashUser<'static, $F>> = MaybeUninit::uninit();
-        static mut BUF2: MaybeUninit<TicKVStore<'static, FlashUser<'static, $F>>> =
+        static mut BUF2: MaybeUninit<TicKVStore<'static, FlashUser<'static, $F>, $H>> =
             MaybeUninit::uninit();
         (&mut BUF1, &mut BUF2)
     };};
@@ -60,18 +61,23 @@ macro_rules! tickv_component_helper {
 
 pub struct TicKVComponent<
     F: 'static + hil::flash::Flash + hil::flash::HasClient<'static, MuxFlash<'static, F>>,
+    H: 'static + Digest<'static, 8>,
 > {
     mux_flash: &'static MuxFlash<'static, F>,
+    hasher: &'static H,
     region_offset: usize,
     flash_size: usize,
     tickfs_read_buf: &'static mut [u8; 64],
     flash_read_buffer: &'static mut F::Page,
 }
 
-impl<F: 'static + hil::flash::Flash + hil::flash::HasClient<'static, MuxFlash<'static, F>>>
-    TicKVComponent<F>
+impl<
+        F: 'static + hil::flash::Flash + hil::flash::HasClient<'static, MuxFlash<'static, F>>,
+        H: Digest<'static, 8>,
+    > TicKVComponent<F, H>
 {
     pub fn new(
+        hasher: &'static H,
         mux_flash: &'static MuxFlash<'static, F>,
         region_offset: usize,
         flash_size: usize,
@@ -79,6 +85,7 @@ impl<F: 'static + hil::flash::Flash + hil::flash::HasClient<'static, MuxFlash<'s
         flash_read_buffer: &'static mut F::Page,
     ) -> Self {
         Self {
+            hasher,
             mux_flash,
             region_offset,
             flash_size,
@@ -88,14 +95,16 @@ impl<F: 'static + hil::flash::Flash + hil::flash::HasClient<'static, MuxFlash<'s
     }
 }
 
-impl<F: 'static + hil::flash::Flash + hil::flash::HasClient<'static, MuxFlash<'static, F>>>
-    Component for TicKVComponent<F>
+impl<
+        F: 'static + hil::flash::Flash + hil::flash::HasClient<'static, MuxFlash<'static, F>>,
+        H: 'static + Digest<'static, 8>,
+    > Component for TicKVComponent<F, H>
 {
     type StaticInput = (
         &'static mut MaybeUninit<FlashUser<'static, F>>,
-        &'static mut MaybeUninit<TicKVStore<'static, FlashUser<'static, F>>>,
+        &'static mut MaybeUninit<TicKVStore<'static, FlashUser<'static, F>, H>>,
     );
-    type Output = &'static TicKVStore<'static, FlashUser<'static, F>>;
+    type Output = &'static TicKVStore<'static, FlashUser<'static, F>, H>;
 
     unsafe fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
         let _grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
@@ -108,9 +117,10 @@ impl<F: 'static + hil::flash::Flash + hil::flash::HasClient<'static, MuxFlash<'s
 
         let driver = static_init_half!(
             static_buffer.1,
-            TicKVStore<'static, FlashUser<'static, F>>,
+            TicKVStore<'static, FlashUser<'static, F>, H>,
             TicKVStore::new(
                 virtual_flash,
+                self.hasher,
                 self.tickfs_read_buf,
                 self.flash_read_buffer,
                 self.region_offset,

--- a/boards/opentitan/src/main.rs
+++ b/boards/opentitan/src/main.rs
@@ -22,6 +22,7 @@ use kernel::dynamic_deferred_call::{DynamicDeferredCall, DynamicDeferredCallClie
 use kernel::hil;
 use kernel::hil::digest::Digest;
 use kernel::hil::entropy::Entropy32;
+use kernel::hil::hasher::Hasher;
 use kernel::hil::i2c::I2CMaster;
 use kernel::hil::led::LedHigh;
 use kernel::hil::rng::Rng;

--- a/boards/opentitan/src/tests/mod.rs
+++ b/boards/opentitan/src/tests/mod.rs
@@ -51,4 +51,5 @@ mod csrng;
 mod hmac;
 mod multi_alarm;
 mod otbn;
+mod sip_hash;
 mod tickv_test;

--- a/boards/opentitan/src/tests/sip_hash.rs
+++ b/boards/opentitan/src/tests/sip_hash.rs
@@ -1,7 +1,7 @@
 use crate::tests::run_kernel_op;
 use crate::SIPHASH;
 use core::cell::Cell;
-use kernel::hil::digest::{self, Digest};
+use kernel::hil::hasher::{self, Hasher};
 use kernel::utilities::leasable_buffer::LeasableBuffer;
 use kernel::{debug, ErrorCode};
 
@@ -51,7 +51,7 @@ impl<'a> SipHashTestCallback {
     }
 }
 
-impl<'a> digest::Client<'a, 8> for SipHashTestCallback {
+impl<'a> hasher::Client<'a, 8> for SipHashTestCallback {
     fn add_data_done(&'a self, result: Result<(), ErrorCode>, _data: &'static mut [u8]) {
         assert_eq!(result, Ok(()));
         self.data_add_done.set(true);

--- a/boards/opentitan/src/tests/sip_hash.rs
+++ b/boards/opentitan/src/tests/sip_hash.rs
@@ -1,0 +1,102 @@
+use crate::tests::run_kernel_op;
+use crate::SIPHASH;
+use core::cell::Cell;
+use kernel::hil::digest::{self, Digest};
+use kernel::utilities::leasable_buffer::LeasableBuffer;
+use kernel::{debug, ErrorCode};
+
+static mut INPUT: [[u8; 8]; 20] = [
+    [0x31, 0x0e, 0x0e, 0xdd, 0x47, 0xdb, 0x6f, 0x72],
+    [0xfd, 0x67, 0xdc, 0x93, 0xc5, 0x39, 0xf8, 0x74],
+    [0x5a, 0x4f, 0xa9, 0xd9, 0x09, 0x80, 0x6c, 0x0d],
+    [0x2d, 0x7e, 0xfb, 0xd7, 0x96, 0x66, 0x67, 0x85],
+    [0xb7, 0x87, 0x71, 0x27, 0xe0, 0x94, 0x27, 0xcf],
+    [0x8d, 0xa6, 0x99, 0xcd, 0x64, 0x55, 0x76, 0x18],
+    [0xce, 0xe3, 0xfe, 0x58, 0x6e, 0x46, 0xc9, 0xcb],
+    [0x37, 0xd1, 0x01, 0x8b, 0xf5, 0x00, 0x02, 0xab],
+    [0x62, 0x24, 0x93, 0x9a, 0x79, 0xf5, 0xf5, 0x93],
+    [0xb0, 0xe4, 0xa9, 0x0b, 0xdf, 0x82, 0x00, 0x9e],
+    [0xf3, 0xb9, 0xdd, 0x94, 0xc5, 0xbb, 0x5d, 0x7a],
+    [0xa7, 0xad, 0x6b, 0x22, 0x46, 0x2f, 0xb3, 0xf4],
+    [0xfb, 0xe5, 0x0e, 0x86, 0xbc, 0x8f, 0x1e, 0x75],
+    [0x90, 0x3d, 0x84, 0xc0, 0x27, 0x56, 0xea, 0x14],
+    [0xee, 0xf2, 0x7a, 0x8e, 0x90, 0xca, 0x23, 0xf7],
+    [0xe5, 0x45, 0xbe, 0x49, 0x61, 0xca, 0x29, 0xa1],
+    [0xdb, 0x9b, 0xc2, 0x57, 0x7f, 0xcc, 0x2a, 0x3f],
+    [0x94, 0x47, 0xbe, 0x2c, 0xf5, 0xe9, 0x9a, 0x69],
+    [0x9c, 0xd3, 0x8d, 0x96, 0xf0, 0xb3, 0xc1, 0x4b],
+    [0x28, 0xef, 0x49, 0x5c, 0x53, 0xa3, 0x87, 0xad],
+];
+
+static mut OUTPUT: [u8; 8] = [0; 8];
+
+struct SipHashTestCallback {
+    data_add_done: Cell<bool>,
+    hash_done: Cell<bool>,
+}
+
+unsafe impl Sync for SipHashTestCallback {}
+
+impl<'a> SipHashTestCallback {
+    const fn new() -> Self {
+        SipHashTestCallback {
+            data_add_done: Cell::new(false),
+            hash_done: Cell::new(false),
+        }
+    }
+
+    fn reset(&self) {
+        self.data_add_done.set(false);
+        self.hash_done.set(false);
+    }
+}
+
+impl<'a> digest::Client<'a, 8> for SipHashTestCallback {
+    fn add_data_done(&'a self, result: Result<(), ErrorCode>, _data: &'static mut [u8]) {
+        assert_eq!(result, Ok(()));
+        self.data_add_done.set(true);
+    }
+
+    fn hash_done(&'a self, result: Result<(), ErrorCode>, digest: &'static mut [u8; 8]) {
+        let ret = u64::from_le_bytes(*digest);
+
+        assert_eq!(result, Ok(()));
+        // Value calculated from:
+        //    https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=08a45842acb9dc1abf9dbc303b5eaa50
+        assert_eq!(ret, 0x9ed5975598371f51);
+
+        self.hash_done.set(true);
+    }
+}
+
+static CALLBACK: SipHashTestCallback = SipHashTestCallback::new();
+
+#[test_case]
+fn sip_hasher_2_4() {
+    let sip_hasher = unsafe { SIPHASH.unwrap() };
+
+    debug!("check SipHash 2-4... ");
+    run_kernel_op(100);
+
+    sip_hasher.set_client(&CALLBACK);
+    CALLBACK.reset();
+
+    unsafe {
+        for i in 0..INPUT.len() {
+            assert_eq!(
+                sip_hasher.add_data(LeasableBuffer::new(&mut INPUT[i])),
+                Ok(8)
+            );
+            run_kernel_op(100);
+            assert_eq!(CALLBACK.data_add_done.get(), true);
+        }
+    }
+
+    assert_eq!(unsafe { sip_hasher.run(&mut OUTPUT) }, Ok(()));
+    run_kernel_op(100);
+    assert_eq!(CALLBACK.hash_done.get(), true);
+
+    run_kernel_op(100);
+    debug!("    [ok]");
+    run_kernel_op(100);
+}

--- a/boards/opentitan/src/tests/tickv_test.rs
+++ b/boards/opentitan/src/tests/tickv_test.rs
@@ -22,7 +22,11 @@ fn tickv_append_key() {
         let test = static_init!(
             KVSystemTest<
                 'static,
-                TicKVStore<'static, FlashUser<'static, lowrisc::flash_ctrl::FlashCtrl<'static>>>,
+                TicKVStore<
+                    'static,
+                    FlashUser<'static, lowrisc::flash_ctrl::FlashCtrl<'static>>,
+                    capsules::sip_hash::SipHasher24,
+                >,
                 TicKVKeyType,
             >,
             KVSystemTest::new(tickv, ret)

--- a/boards/opentitan/src/tests/tickv_test.rs
+++ b/boards/opentitan/src/tests/tickv_test.rs
@@ -6,7 +6,7 @@ use capsules::test::kv_system::KVSystemTest;
 use capsules::tickv::{TicKVKeyType, TicKVStore};
 use capsules::virtual_flash::FlashUser;
 use kernel::debug;
-use kernel::hil::digest::Digest;
+use kernel::hil::hasher::Hasher;
 use kernel::hil::kv_system::KVSystem;
 use kernel::static_init;
 

--- a/boards/opentitan/src/tests/tickv_test.rs
+++ b/boards/opentitan/src/tests/tickv_test.rs
@@ -1,11 +1,12 @@
 //! Test TicKV
 
 use crate::tests::run_kernel_op;
-use crate::TICKV;
+use crate::{SIPHASH, TICKV};
 use capsules::test::kv_system::KVSystemTest;
 use capsules::tickv::{TicKVKeyType, TicKVStore};
 use capsules::virtual_flash::FlashUser;
 use kernel::debug;
+use kernel::hil::digest::Digest;
 use kernel::hil::kv_system::KVSystem;
 use kernel::static_init;
 
@@ -15,7 +16,16 @@ fn tickv_append_key() {
 
     unsafe {
         let tickv = TICKV.unwrap();
-        let key = static_init!([u8; 8], [0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0]);
+        let sip_hasher = SIPHASH.unwrap();
+
+        let key_input = static_init!(
+            [u8; 16],
+            [
+                0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0, 0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC,
+                0xDE, 0xF0
+            ]
+        );
+        let key = static_init!([u8; 8], [0; 8]);
         let value = static_init!([u8; 3], [0x10, 0x20, 0x30]);
         let ret = static_init!([u8; 4], [0; 4]);
 
@@ -29,13 +39,14 @@ fn tickv_append_key() {
                 >,
                 TicKVKeyType,
             >,
-            KVSystemTest::new(tickv, ret)
+            KVSystemTest::new(tickv, value, ret)
         );
 
+        sip_hasher.set_client(tickv);
         tickv.set_client(test);
 
-        // Kick start the tests by adding a key
-        tickv.append_key(key, value).unwrap();
+        // Kick start the tests by generating a key
+        tickv.generate_key(key_input, key).unwrap();
     }
     run_kernel_op(100000);
 

--- a/capsules/src/lib.rs
+++ b/capsules/src/lib.rs
@@ -71,6 +71,7 @@ pub mod segger_rtt;
 pub mod sha;
 pub mod sht3x;
 pub mod si7021;
+pub mod sip_hash;
 pub mod sound_pressure;
 pub mod spi_controller;
 pub mod spi_peripheral;

--- a/capsules/src/sip_hash.rs
+++ b/capsules/src/sip_hash.rs
@@ -1,0 +1,289 @@
+//! Tock SipHash capsule.
+//!
+//! This is a async implementation of the SipHash.
+//!
+//! This capsule was originally written to be used as part of Tocks
+//! key/value store. SipHash was used as it is generally fast, while also
+//! being resilient against DOS attacks from userspace
+//! (unlike <https://github.com/servo/rust-fnv>).
+//!
+//! Read <https://github.com/veorq/SipHash/blob/master/README.md> for more
+//! details on SipHash.
+//!
+//! The implementation is based on the Rust implementation from
+//! rust-core, avaliable here: <https://github.com/jedisct1/rust-siphash>
+//!
+//! Copyright 2012-2016 The Rust Project Developers.
+//! Copyright 2016-2021 Frank Denis.
+//! Copyright 2021 Western Digital
+//!
+//! Licensed under the Apache License, Version 2.0 LICENSE-APACHE or
+//! <http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+//! LICENSE-MIT or <http://opensource.org/licenses/MIT>, at your
+//! option.
+
+use core::cell::Cell;
+use core::convert::TryInto;
+use core::{cmp, mem};
+use kernel::dynamic_deferred_call::{
+    DeferredCallHandle, DynamicDeferredCall, DynamicDeferredCallClient,
+};
+use kernel::hil::digest::{Client, Digest};
+use kernel::utilities::cells::{OptionalCell, TakeCell};
+use kernel::utilities::leasable_buffer::LeasableBuffer;
+use kernel::ErrorCode;
+
+pub struct SipHasher24<'a> {
+    client: OptionalCell<&'a dyn Client<'a, 8>>,
+
+    hasher: Cell<Hasher>,
+
+    add_data_deferred_call: Cell<bool>,
+    complete_deferred_call: Cell<bool>,
+    deferred_caller: &'static DynamicDeferredCall,
+    deferred_handle: OptionalCell<DeferredCallHandle>,
+
+    data_buffer: TakeCell<'static, [u8]>,
+    out_buffer: TakeCell<'static, [u8; 8]>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct Hasher {
+    k0: u64,
+    k1: u64,
+    length: usize, // how many bytes we've processed
+    state: State,  // hash State
+    tail: u64,     // unprocessed bytes le
+    ntail: usize,  // how many bytes in tail are valid
+}
+
+#[derive(Debug, Clone, Copy)]
+struct State {
+    // v0, v2 and v1, v3 show up in pairs in the algorithm,
+    // and simd implementations of SipHash will use vectors
+    // of v02 and v13. By placing them in this order in the struct,
+    // the compiler can pick up on just a few simd optimizations by itself.
+    v0: u64,
+    v2: u64,
+    v1: u64,
+    v3: u64,
+}
+
+impl<'a> SipHasher24<'a> {
+    pub const fn new(deferred_caller: &'static DynamicDeferredCall) -> Self {
+        let hasher = Hasher {
+            k0: 0,
+            k1: 0,
+            length: 0,
+            state: State {
+                v0: 0x736f6d6570736575,
+                v1: 0x646f72616e646f6d,
+                v2: 0x6c7967656e657261,
+                v3: 0x7465646279746573,
+            },
+            ntail: 0,
+            tail: 0,
+        };
+
+        Self {
+            client: OptionalCell::empty(),
+            hasher: Cell::new(hasher),
+            add_data_deferred_call: Cell::new(false),
+            complete_deferred_call: Cell::new(false),
+            deferred_caller,
+            deferred_handle: OptionalCell::empty(),
+            data_buffer: TakeCell::empty(),
+            out_buffer: TakeCell::empty(),
+        }
+    }
+
+    pub fn initialise(&self, deferred_call_handle: DeferredCallHandle) {
+        self.deferred_handle.set(deferred_call_handle);
+    }
+}
+
+macro_rules! compress {
+    ($state:expr) => {{
+        compress!($state.v0, $state.v1, $state.v2, $state.v3)
+    }};
+    ($v0:expr, $v1:expr, $v2:expr, $v3:expr) => {{
+        $v0 = $v0.wrapping_add($v1);
+        $v1 = $v1.rotate_left(13);
+        $v1 ^= $v0;
+        $v0 = $v0.rotate_left(32);
+        $v2 = $v2.wrapping_add($v3);
+        $v3 = $v3.rotate_left(16);
+        $v3 ^= $v2;
+        $v0 = $v0.wrapping_add($v3);
+        $v3 = $v3.rotate_left(21);
+        $v3 ^= $v0;
+        $v2 = $v2.wrapping_add($v1);
+        $v1 = $v1.rotate_left(17);
+        $v1 ^= $v2;
+        $v2 = $v2.rotate_left(32);
+    }};
+}
+
+fn read_le_u64(input: &[u8]) -> u64 {
+    let (int_bytes, _rest) = input.split_at(mem::size_of::<u64>());
+    u64::from_le_bytes(int_bytes.try_into().unwrap())
+}
+
+fn read_le_u16(input: &[u8]) -> u16 {
+    let (int_bytes, _rest) = input.split_at(mem::size_of::<u16>());
+    u16::from_le_bytes(int_bytes.try_into().unwrap())
+}
+
+#[inline]
+fn u8to64_le(buf: &[u8], start: usize, len: usize) -> u64 {
+    debug_assert!(len < 8);
+    let mut i = 0; // current byte index (from LSB) in the output u64
+    let mut out = 0;
+    if i + 3 < len {
+        out = read_le_u64(&buf[start + i..]);
+        i += 4;
+    }
+    if i + 1 < len {
+        out |= (read_le_u16(&buf[start + i..]) as u64) << (i * 8);
+        i += 2
+    }
+    if i < len {
+        out |= (*buf.get(start + i).unwrap() as u64) << (i * 8);
+        i += 1;
+    }
+    debug_assert_eq!(i, len);
+    out
+}
+
+impl<'a> Digest<'a, 8> for SipHasher24<'a> {
+    fn set_client(&'a self, client: &'a dyn Client<'a, 8>) {
+        self.client.set(client);
+    }
+
+    fn add_data(
+        &self,
+        data: LeasableBuffer<'static, u8>,
+    ) -> Result<usize, (ErrorCode, &'static mut [u8])> {
+        let length = data.len();
+        let msg = data.take();
+        let mut hasher = self.hasher.get();
+
+        hasher.length += length;
+
+        let mut needed = 0;
+
+        if hasher.ntail != 0 {
+            needed = 8 - hasher.ntail;
+            hasher.tail |= u8to64_le(msg, 0, cmp::min(length, needed)) << (8 * hasher.ntail);
+            if length < needed {
+                hasher.ntail += length;
+                return Ok(length);
+            } else {
+                hasher.state.v3 ^= hasher.tail;
+                compress!(&mut hasher.state);
+                compress!(&mut hasher.state);
+                hasher.state.v0 ^= hasher.tail;
+                hasher.ntail = 0;
+            }
+        }
+
+        // Buffered tail is now flushed, process new input.
+        let len = length - needed;
+        let left = len & 0x7;
+
+        let mut i = needed;
+        while i < len - left {
+            let mi = read_le_u64(&msg[i..]);
+
+            hasher.state.v3 ^= mi;
+            compress!(&mut hasher.state);
+            compress!(&mut hasher.state);
+            hasher.state.v0 ^= mi;
+
+            i += 8;
+        }
+
+        hasher.tail = u8to64_le(msg, i, left);
+        hasher.ntail = left;
+
+        self.hasher.set(hasher);
+        self.data_buffer.replace(msg);
+
+        self.add_data_deferred_call.set(true);
+        self.deferred_handle
+            .map(|handle| self.deferred_caller.set(*handle));
+
+        Ok(length)
+    }
+
+    fn run(
+        &'a self,
+        digest: &'static mut [u8; 8],
+    ) -> Result<(), (ErrorCode, &'static mut [u8; 8])> {
+        let mut hasher = self.hasher.get();
+
+        let b: u64 = ((hasher.length as u64 & 0xff) << 56) | hasher.tail;
+
+        hasher.state.v3 ^= b;
+        compress!(&mut hasher.state);
+        compress!(&mut hasher.state);
+        hasher.state.v0 ^= b;
+
+        hasher.state.v2 ^= 0xff;
+        compress!(&mut hasher.state);
+        compress!(&mut hasher.state);
+        compress!(&mut hasher.state);
+        compress!(&mut hasher.state);
+
+        self.hasher.set(hasher);
+        self.out_buffer.replace(digest);
+
+        self.complete_deferred_call.set(true);
+        self.deferred_handle
+            .map(|handle| self.deferred_caller.set(*handle));
+
+        Ok(())
+    }
+
+    fn clear_data(&self) {
+        let mut hasher = self.hasher.get();
+
+        hasher.length = 0;
+        hasher.state.v0 = hasher.k0 ^ 0x736f6d6570736575;
+        hasher.state.v1 = hasher.k1 ^ 0x646f72616e646f6d;
+        hasher.state.v2 = hasher.k0 ^ 0x6c7967656e657261;
+        hasher.state.v3 = hasher.k1 ^ 0x7465646279746573;
+        hasher.ntail = 0;
+
+        self.hasher.set(hasher);
+    }
+}
+
+impl<'a> DynamicDeferredCallClient for SipHasher24<'a> {
+    fn call(&self, _handle: DeferredCallHandle) {
+        if self.add_data_deferred_call.get() {
+            self.add_data_deferred_call.set(false);
+
+            self.client.map(|client| {
+                self.data_buffer.take().map(|buffer| {
+                    client.add_data_done(Ok(()), buffer);
+                });
+            });
+        }
+
+        if self.complete_deferred_call.get() {
+            self.complete_deferred_call.set(false);
+
+            self.client.map(|client| {
+                self.out_buffer.take().map(|buffer| {
+                    let state = self.hasher.get().state;
+
+                    let result = state.v0 ^ state.v1 ^ state.v2 ^ state.v3;
+                    buffer.copy_from_slice(&result.to_le_bytes());
+
+                    client.hash_done(Ok(()), buffer);
+                });
+            });
+        }
+    }
+}

--- a/capsules/src/sip_hash.rs
+++ b/capsules/src/sip_hash.rs
@@ -28,7 +28,7 @@ use core::{cmp, mem};
 use kernel::dynamic_deferred_call::{
     DeferredCallHandle, DynamicDeferredCall, DynamicDeferredCallClient,
 };
-use kernel::hil::digest::{Client, Digest};
+use kernel::hil::hasher::{Client, Hasher};
 use kernel::utilities::cells::{OptionalCell, TakeCell};
 use kernel::utilities::leasable_buffer::LeasableBuffer;
 use kernel::ErrorCode;
@@ -36,7 +36,7 @@ use kernel::ErrorCode;
 pub struct SipHasher24<'a> {
     client: OptionalCell<&'a dyn Client<'a, 8>>,
 
-    hasher: Cell<Hasher>,
+    hasher: Cell<SipHasher>,
 
     add_data_deferred_call: Cell<bool>,
     complete_deferred_call: Cell<bool>,
@@ -48,7 +48,7 @@ pub struct SipHasher24<'a> {
 }
 
 #[derive(Debug, Clone, Copy)]
-struct Hasher {
+struct SipHasher {
     k0: u64,
     k1: u64,
     length: usize, // how many bytes we've processed
@@ -71,7 +71,7 @@ struct State {
 
 impl<'a> SipHasher24<'a> {
     pub const fn new(deferred_caller: &'static DynamicDeferredCall) -> Self {
-        let hasher = Hasher {
+        let hasher = SipHasher {
             k0: 0,
             k1: 0,
             length: 0,
@@ -155,7 +155,7 @@ fn u8to64_le(buf: &[u8], start: usize, len: usize) -> u64 {
     out
 }
 
-impl<'a> Digest<'a, 8> for SipHasher24<'a> {
+impl<'a> Hasher<'a, 8> for SipHasher24<'a> {
     fn set_client(&'a self, client: &'a dyn Client<'a, 8>) {
         self.client.set(client);
     }

--- a/kernel/src/hil/hasher.rs
+++ b/kernel/src/hil/hasher.rs
@@ -1,0 +1,69 @@
+//! Interface for Hasher
+
+use crate::utilities::leasable_buffer::LeasableBuffer;
+use crate::ErrorCode;
+
+/// Implement this trait and use `set_client()` in order to receive callbacks.
+///
+/// 'L' is the length of the 'u8' array to store the hash output.
+pub trait Client<'a, const L: usize> {
+    /// This callback is called when the data has been added to the hash
+    /// engine.
+    /// On error or success `data` will contain a reference to the original
+    /// data supplied to `add_data()`.
+    /// The possible ErrorCodes are:
+    ///    - SIZE: The size of the `data` buffer is invalid
+    fn add_data_done(&'a self, result: Result<(), ErrorCode>, data: &'static mut [u8]);
+
+    /// This callback is called when a hash is computed.
+    /// On error or success `hash` will contain a reference to the original
+    /// data supplied to `run()`.
+    /// The possible ErrorCodes are:
+    ///    - SIZE: The size of the `data` buffer is invalid
+    fn hash_done(&'a self, result: Result<(), ErrorCode>, hash: &'static mut [u8; L]);
+}
+
+/// Computes a non-cryptographic hash over data
+///
+/// 'L' is the length of the 'u8' array to store the hash output.
+pub trait Hasher<'a, const L: usize> {
+    /// Set the client instance which will receive `hash_done()` and
+    /// `add_data_done()` callbacks.
+    /// This callback is called when the data has been added to the hash
+    /// engine.
+    /// The callback should follow the `Client` `add_data_done` callback.
+    fn set_client(&'a self, client: &'a dyn Client<'a, L>);
+
+    /// Add data to the hash block. This is the data that will be used
+    /// for the hash function.
+    /// Returns the number of bytes parsed on success
+    /// There is no guarantee the data has been written until the `add_data_done()`
+    /// callback is fired.
+    /// On error the return value will contain a return code and the original data
+    /// The possible ErrorCodes are:
+    ///    - BUSY: The system is busy performing an operation
+    ///            The caller should expect a callback
+    ///    - SIZE: The size of the `data` buffer is invalid
+    fn add_data(
+        &self,
+        data: LeasableBuffer<'static, u8>,
+    ) -> Result<usize, (ErrorCode, &'static mut [u8])>;
+
+    /// Request the implementation to generate a hash and stores the returned
+    /// hash in the memory location specified.
+    /// This doesn't return any data, instead the client needs to have
+    /// set a `hash_done` handler to determine when this is complete.
+    /// On error the return value will contain a return code and the original data
+    /// If there is data from the `add_data()` command asyncrously waiting to
+    /// be written it will be written before the operation starts.
+    /// The possible ErrorCodes are:
+    ///    - BUSY: The system is busy performing an operation
+    ///            The caller should expect a callback
+    ///    - SIZE: The size of the `data` buffer is invalid
+    fn run(&'a self, hash: &'static mut [u8; L]) -> Result<(), (ErrorCode, &'static mut [u8; L])>;
+
+    /// Clear the internal state of the engine.
+    /// This won't clear the buffers provided to this API, that is up to the
+    /// user to clear.
+    fn clear_data(&self);
+}

--- a/kernel/src/hil/hasher.rs
+++ b/kernel/src/hil/hasher.rs
@@ -67,3 +67,13 @@ pub trait Hasher<'a, const L: usize> {
     /// user to clear.
     fn clear_data(&self);
 }
+
+pub trait SipHash {
+    /// Optionaly call before `Hasher::run()` to specify the keys used
+    /// The possible ErrorCodes are:
+    ///    - BUSY: The system is busy
+    ///    - ALREADY: An operation is already on going
+    ///    - INVAL: An invalid parameter was supplied
+    ///    - NOSUPPORT: The operation is not supported
+    fn set_keys(&self, k0: u64, k1: u64) -> Result<(), ErrorCode>;
+}

--- a/kernel/src/hil/kv_system.rs
+++ b/kernel/src/hil/kv_system.rs
@@ -75,8 +75,8 @@ pub trait Client<K: KeyType> {
     fn generate_key_complete(
         &self,
         result: Result<(), ErrorCode>,
-        unhashed_key: &'static [u8],
-        key_buf: &'static K,
+        unhashed_key: &'static mut [u8],
+        key_buf: &'static mut K,
     );
 
     /// This callback is called when the append_key operation completes

--- a/kernel/src/hil/mod.rs
+++ b/kernel/src/hil/mod.rs
@@ -12,6 +12,7 @@ pub mod entropy;
 pub mod flash;
 pub mod gpio;
 pub mod gpio_async;
+pub mod hasher;
 pub mod i2c;
 pub mod kv_system;
 pub mod led;


### PR DESCRIPTION
### Pull Request Overview

This PR adds a software SipHash to the Tock kernel, this includes a test case to ensure it's working.

Then we connect the hash to TicKV to generate keys.

SipHash was selected as it is quick while also providing resilience to DOS attacks from untrusted applications. This is compared to FNV which although quicker for short strings, is not resilient against arbitrarily long input.

This applies on top of: https://github.com/tock/tock/pull/2804

Fixes: https://github.com/tock/tock/issues/2413

### Testing Strategy

OpenTitan unit tests.

### TODO or Help Wanted

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
