### PR TITLE
components/{gpio,button}: support both referenced and owned GPIO pins

### DIFF
--- a/boards/components/src/button.rs
+++ b/boards/components/src/button.rs
@@ -2,6 +2,13 @@
 //!
 //! Usage
 //! -----
+//!
+//! The `button_component_helper!` macro takes 'static references to GPIO
+//! pins. When GPIO instances are owned values, the
+//! `button_component_helper_owned!` can be used, indicating that the passed
+//! values are owned values. This macro will perform static allocation of the
+//! passed in GPIO pins internally.
+//!
 //! ```rust
 //! let button = components::button::ButtonComponent::new(
 //!     board_kernel,
@@ -30,6 +37,20 @@ use kernel::create_capability;
 use kernel::hil::gpio;
 use kernel::hil::gpio::InterruptWithValue;
 use kernel::static_init_half;
+
+#[macro_export]
+macro_rules! button_component_helper_owned {
+    ($Pin:ty, $(($P:expr, $M:expr, $F:expr)),+ $(,)?) => {
+        $crate::button_component_helper!(
+            $Pin,
+            $((
+                static_init!($Pin, $P),
+                $M,
+                $F
+            ),)*
+        )
+    };
+}
 
 #[macro_export]
 macro_rules! button_component_helper {

--- a/boards/components/src/gpio.rs
+++ b/boards/components/src/gpio.rs
@@ -3,6 +3,13 @@
 //!
 //! Usage
 //! -----
+//!
+//! The `gpio_component_helper!` macro takes 'static references to
+//! GPIO pins. When GPIO instances are owned values, the
+//! `gpio_component_helper_owned!` can be used, indicating that the
+//! passed values are owned values. This macro will perform static
+//! allocation of the passed in GPIO pins internally.
+//!
 //! ```rust
 //! let gpio = components::gpio::GpioComponent::new(
 //!     board_kernel,
@@ -53,6 +60,21 @@ macro_rules! gpio_component_helper_max_pin {
     () => { 0usize };
     ($a:expr, $b:expr, $($tail:expr),* $(,)?) => { $crate::gpio_component_helper_max_pin! (max ($a, $b), $($tail,)*) };
     ($a:expr $(,)?) => { $a };
+}
+
+#[macro_export]
+macro_rules! gpio_component_helper_owned {
+    (
+        $Pin:ty,
+        $($nr:literal => $pin:expr),* $(,)?
+    ) => {
+        $crate::gpio_component_helper!(
+            $Pin,
+            $(
+                $nr => static_init!($Pin, $pin),
+            )*
+        )
+    };
 }
 
 #[macro_export]


### PR DESCRIPTION
### Pull Request Overview

Before this change the `gpio_component_helper!` and `button_component_helper!` macros could only take references to GPIO pins. This works fine for most boards, which will have a fixed number of GPIO pins which are statically allocated within the respective chip crate.

However, it is also useful for the `{gpio,button}_component_helper!` macro to support passing in owned GPIO pins, which are then internally allocated through `static_init!`. Specifically, dynamic platfoms such as LiteX do not have a fixed number of GPIOs on every board or even in different configurations. Thus it is not trivial to preallocate all GPIO pins within the board crate and take a reference to them. Instead, GPIO pin instances are created on the fly and passed to the caller as owned objects (holding a reference to the GPIO controller). This can also reduce resource usage, as unused GPIO pins will not consume a significant amount of memory.

To support easy instantiation of a GPIO or button driver using such owned GPIO pin structs, this adds support to indicate whether the passed GPIO instances are references or owned values. This is done by placing the `ref` keyword before the GPIO pin type information, in case references are being passed in. For owned values, the `{gpio,button}_component_helper!` will allocate memory to store them internally.


### Testing Strategy

This pull request was tested by compiling all boards


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] ~Updated the relevant files in `/docs`,~ or no updates are required.

### Formatting

- [x] Ran `make prepush`.
