### PR TITLE
Add "Kernel Loop Started" callback for main.rs

### DIFF
--- a/kernel/src/platform/mod.rs
+++ b/kernel/src/platform/mod.rs
@@ -9,6 +9,7 @@ pub mod watchdog;
 
 pub(crate) mod platform;
 
+pub use self::platform::KernelLoopStarted;
 pub use self::platform::KernelResources;
 pub use self::platform::ProcessFault;
 pub use self::platform::SyscallDriverLookup;

--- a/kernel/src/platform/platform.rs
+++ b/kernel/src/platform/platform.rs
@@ -15,6 +15,10 @@ use crate::platform::watchdog;
 ///
 /// This is the primary method for configuring the kernel for a specific board.
 pub trait KernelResources<C: Chip> {
+    /// The implementation of the kernel loop started even handler the kernel
+    /// will use.
+    type KernelLoopStarted: KernelLoopStarted;
+
     /// The implementation of the system call dispatch mechanism the kernel
     /// will use.
     type SyscallDriverLookup: SyscallDriverLookup;
@@ -37,6 +41,10 @@ pub trait KernelResources<C: Chip> {
     /// The implementation of the WatchDog timer used to monitor the running
     /// of the kernel.
     type WatchDog: watchdog::WatchDog;
+
+    /// Returns a reference to the implementation of the KernelLoopStarted this
+    /// platform will use to handle the kernel loop has started event.
+    fn kernel_loop_started(&self) -> &Self::KernelLoopStarted;
 
     /// Returns a reference to the implementation of the SyscallDriverLookup this
     /// platform will use to route syscalls.
@@ -61,6 +69,15 @@ pub trait KernelResources<C: Chip> {
     /// Returns a reference to the implementation of the WatchDog on this
     /// platform.
     fn watchdog(&self) -> &Self::WatchDog;
+}
+
+/// Trait for a hook function when the kernel loop starts running.
+///
+/// This hook can be used by boards to start operations after processes are
+/// loaded and the kernel loop is just about to start.
+pub trait KernelLoopStarted {
+    /// Hook function called when the kernel loop has just started.
+    fn kernel_loop_started(&self) {}
 }
 
 /// Configure the system call dispatch mapping.


### PR DESCRIPTION
### Pull Request Overview

Inspired from the discussion on #2785 (shell prompt for process console), this is an attempt to add effectively a standard deferred call for main.rs that triggers immediately before the main kernel loop runs.

It is implemented as a new type in the `KernelResources` trait which is how boards configure the kernel. If a board wants to use this callback it provides an implementation of `trait KernelLoopStart`.

Based on this discussion: https://github.com/tock/tock/pull/2817/files#diff-2e0027bb3b0984600afd938c50eb7070f2884dfdf945be8f66a75d96804f789aR55

#### Question

The baseline implementation is actually pretty simple: call `KR.kernel_loop_start()` at the beginning of `kernel.kernel_loop()`. However, this doesn't really accomplish anything, as there hasn't been an opportunity for any kernel work to finish from the queue. So

```rust

fn main()
  ...
  capsule.start(); // operation that would be good to run after kernel loop starts
  process_load();
  kernel_loop();
}
```
and
```rust
fn kernel_loop_start() {
  capsule.start();
}

fn main()
  ...
  process_load();
  kernel_loop();
}
```
end up being virtually the same.

So, in the following case (which is the case in the pconsole shell prompt pr):

```rust
fn kernel_loop_start() {
  capsule.start(); // operation that also prints on uart
}

fn main()
  ...
  debug!("init complete");
  process_load();
  kernel_loop();
}
```

Whether `capsule.start()` or `debug!("init complete")` prints first still comes down to the implementation of the uart mux, which I think defeats the point of having the `kernel_loop_start` hook callback in the first place.

So, instead I implemented kernel loop like:

```rust
fn kernel_loop () {
  // do all pending kernel work
  loop {
    if kernel_work() {
      do_kernel_work()
    } else {
      break;
    }
  }

  // do hook callback
  kernel_loop_start()

  loop {
    kernel_loop_operation();
  }
}
```

and wrote a comment to somewhat formalize the kernel loop startup procedure.

The question is: thoughts? Does this make sense?

I'm worried that this isn't _quite_ what we want, since there could be pending operations in flight that haven't interrupted yet. Ideally, (maybe), all of those would finish first, but this is a hard problem that we don't have any way to solve. So perhaps this is good enough?







### Testing Strategy

Switching the order of the pconsole and debug console init and verifying that the `debug!()` message still prints first on hail.


### TODO or Help Wanted

Is this the design we want?

If we converge then I can update the other boards.


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
