### PR TITLE
Console: Refactor code to reduce size

### DIFF
--- a/capsules/src/console.rs
+++ b/capsules/src/console.rs
@@ -37,7 +37,6 @@
 //! the driver. Successive writes must call `allow` each time a buffer is to be
 //! written.
 
-use core::convert::TryFrom;
 use core::{cmp, mem};
 
 use kernel::grant::Grant;
@@ -251,37 +250,33 @@ impl SyscallDriver for Console<'_> {
     /// - `3`: Cancel any in progress receives and return (via callback)
     ///        what has been received so far.
     fn command(&self, cmd_num: usize, arg1: usize, _: usize, appid: ProcessId) -> CommandReturn {
-        let res = match cmd_num {
-            0 => Ok(Ok(())),
-            1 => {
-                // putstr
-                let len = arg1;
-                self.apps
-                    .enter(appid, |app, _| self.send_new(appid, app, len))
-                    .map_err(ErrorCode::from)
-            }
-            2 => {
-                // getnstr
-                let len = arg1;
-                self.apps
-                    .enter(appid, |app, _| self.receive_new(appid, app, len))
-                    .map_err(ErrorCode::from)
-            }
-            3 => {
-                // Abort RX
-                let _ = self.uart.receive_abort();
-                Ok(Ok(()))
-            }
-            _ => Err(ErrorCode::NOSUPPORT),
-        };
-        match res {
-            Ok(r) => {
-                let res = ErrorCode::try_from(r);
-                match res {
-                    Err(_) => CommandReturn::success(),
-                    Ok(e) => CommandReturn::failure(e),
+        let res = self
+            .apps
+            .enter(appid, |app, _| {
+                match cmd_num {
+                    0 => Ok(()),
+                    1 => {
+                        // putstr
+                        let len = arg1;
+                        self.send_new(appid, app, len)
+                    }
+                    2 => {
+                        // getnstr
+                        let len = arg1;
+                        self.receive_new(appid, app, len)
+                    }
+                    3 => {
+                        // Abort RX
+                        let _ = self.uart.receive_abort();
+                        Ok(())
+                    }
+                    _ => Err(ErrorCode::NOSUPPORT),
                 }
-            }
+            })
+            .map_err(ErrorCode::from);
+        match res {
+            Ok(Ok(())) => CommandReturn::success(),
+            Ok(Err(e)) => CommandReturn::failure(e),
             Err(e) => CommandReturn::failure(e),
         }
     }


### PR DESCRIPTION
### Pull Request Overview

By entering the grant in only one place instead of 2, we can remove any code that is duplicated each time grant-entry code is monomorphized. This also removes one duplicate of the error handling code (`ErrorCode::from`).

This change is functionally equivalent, but reduces code size on hail by 112 bytes.

### Testing Strategy

N/A.


### TODO or Help Wanted

N/A.


### Documentation Updated

- [x] No updates are required.

### Formatting

- [x] Ran `make prepush`.
