### PR TITLE
tock-tbf: Add support for parsing storage IDs and driver permissions

### DIFF
--- a/doc/TockBinaryFormat.md
+++ b/doc/TockBinaryFormat.md
@@ -102,6 +102,7 @@ enum TbfHeaderTypes {
     TbfHeaderFixedAddresses = 5,
     TbfHeaderPermissions = 6,
     TbfHeaderPersistent = 7,
+    TbfHeaderKernelVersion = 8,
 }
 
 // Type-length-value header to identify each struct.
@@ -168,6 +169,7 @@ struct TbfHeaderV2PersistentAcl {
     read_ids: [u32],
     access_length: u16,
     access_ids: [u32],
+}
 
 // Kernel Version
 struct TbfHeaderV2KernelVersion {

--- a/libraries/tock-tbf/src/parse.rs
+++ b/libraries/tock-tbf/src/parse.rs
@@ -130,6 +130,7 @@ pub fn parse_tbf_header(
                     Default::default();
                 let mut app_name_str = "";
                 let mut fixed_address_pointer: Option<types::TbfHeaderV2FixedAddresses> = None;
+                let mut permissions_pointer: Option<types::TbfHeaderV2Permissions<8>> = None;
                 let mut kernel_version: Option<types::TbfHeaderV2KernelVersion> = None;
 
                 // Iterate the remainder of the header looking for TLV entries.
@@ -220,7 +221,9 @@ pub fn parse_tbf_header(
                             }
                         }
 
-                        types::TbfHeaderTypes::TbfHeaderPermissions => {}
+                        types::TbfHeaderTypes::TbfHeaderPermissions => {
+                            permissions_pointer = Some(remaining.try_into()?);
+                        }
 
                         types::TbfHeaderTypes::TbfHeaderPersistentAcl => {}
 
@@ -252,6 +255,7 @@ pub fn parse_tbf_header(
                     package_name: Some(app_name_str),
                     writeable_regions: Some(wfr_pointer),
                     fixed_addresses: fixed_address_pointer,
+                    permissions: permissions_pointer,
                     kernel_version: kernel_version,
                 };
 

--- a/libraries/tock-tbf/src/parse.rs
+++ b/libraries/tock-tbf/src/parse.rs
@@ -131,6 +131,7 @@ pub fn parse_tbf_header(
                 let mut app_name_str = "";
                 let mut fixed_address_pointer: Option<types::TbfHeaderV2FixedAddresses> = None;
                 let mut permissions_pointer: Option<types::TbfHeaderV2Permissions<8>> = None;
+                let mut persistent_acls_pointer: Option<types::TbfHeaderV2PersistentAcl<8>> = None;
                 let mut kernel_version: Option<types::TbfHeaderV2KernelVersion> = None;
 
                 // Iterate the remainder of the header looking for TLV entries.
@@ -225,7 +226,9 @@ pub fn parse_tbf_header(
                             permissions_pointer = Some(remaining.try_into()?);
                         }
 
-                        types::TbfHeaderTypes::TbfHeaderPersistentAcl => {}
+                        types::TbfHeaderTypes::TbfHeaderPersistentAcl => {
+                            persistent_acls_pointer = Some(remaining.try_into()?);
+                        }
 
                         types::TbfHeaderTypes::TbfHeaderKernelVersion => {
                             let entry_len = 4;
@@ -256,6 +259,7 @@ pub fn parse_tbf_header(
                     writeable_regions: Some(wfr_pointer),
                     fixed_addresses: fixed_address_pointer,
                     permissions: permissions_pointer,
+                    persistent_acls: persistent_acls_pointer,
                     kernel_version: kernel_version,
                 };
 

--- a/libraries/tock-tbf/src/parse.rs
+++ b/libraries/tock-tbf/src/parse.rs
@@ -220,6 +220,10 @@ pub fn parse_tbf_header(
                             }
                         }
 
+                        types::TbfHeaderTypes::TbfHeaderPermissions => {}
+
+                        types::TbfHeaderTypes::TbfHeaderPersistentAcl => {}
+
                         types::TbfHeaderTypes::TbfHeaderKernelVersion => {
                             let entry_len = 4;
                             if tlv_header.length as usize == entry_len {

--- a/libraries/tock-tbf/src/types.rs
+++ b/libraries/tock-tbf/src/types.rs
@@ -105,6 +105,8 @@ pub enum TbfHeaderTypes {
     TbfHeaderWriteableFlashRegions = 2,
     TbfHeaderPackageName = 3,
     TbfHeaderFixedAddresses = 5,
+    TbfHeaderPermissions = 6,
+    TbfHeaderPersistentAcl = 7,
     TbfHeaderKernelVersion = 8,
 
     /// Some field in the header that we do not understand. Since the TLV format
@@ -216,6 +218,8 @@ impl core::convert::TryFrom<u16> for TbfHeaderTypes {
             2 => Ok(TbfHeaderTypes::TbfHeaderWriteableFlashRegions),
             3 => Ok(TbfHeaderTypes::TbfHeaderPackageName),
             5 => Ok(TbfHeaderTypes::TbfHeaderFixedAddresses),
+            6 => Ok(TbfHeaderTypes::TbfHeaderPermissions),
+            7 => Ok(TbfHeaderTypes::TbfHeaderPersistentAcl),
             8 => Ok(TbfHeaderTypes::TbfHeaderKernelVersion),
             _ => Ok(TbfHeaderTypes::Unknown),
         }


### PR DESCRIPTION
### Pull Request Overview

This PR implements parsing for the documented TBF headers for storage IDs and driver permission filtering.

### Testing Strategy

Parsing headers generated from: https://github.com/tock/elf2tab/pull/36

### TODO or Help Wanted

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
