### PR TITLE
capsules/low_level_debug: source DRIVER_NUM from driver::NUM

### DIFF
--- a/capsules/src/driver.rs
+++ b/capsules/src/driver.rs
@@ -16,6 +16,7 @@ pub enum NUM {
     Adc                   = 0x00005,
     Dac                   = 0x00006,
     AnalogComparator      = 0x00007,
+    LowLevelDebug         = 0x00008,
 
     // Kernel
     Ipc                   = 0x10000,

--- a/capsules/src/low_level_debug/mod.rs
+++ b/capsules/src/low_level_debug/mod.rs
@@ -13,7 +13,7 @@ use kernel::{ErrorCode, ProcessId};
 // LowLevelDebug requires a &mut [u8] buffer of length at least BUF_LEN.
 pub use fmt::BUF_LEN;
 
-pub const DRIVER_NUM: usize = 0x8;
+pub const DRIVER_NUM: usize = crate::driver::NUM::LowLevelDebug as usize;
 
 pub struct LowLevelDebug<'u, U: Transmit<'u>> {
     buffer: Cell<Option<&'static mut [u8]>>,


### PR DESCRIPTION
### Pull Request Overview

Adds the low level debug driver num to the capsules::driver::NUM enum,
which makes it obvious that driver num 0x00008 is allocated when
adding a new driver.

Noticed this during a review of #2381.


### Testing Strategy

N/A


### TODO or Help Wanted

N/A

### Documentation Updated

- [x] ~Updated the relevant files in `/docs`,~ or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
