### PR TITLE
kernel: mpu: Cleanup the comment for the default config type

### DIFF
--- a/kernel/src/platform/mpu.rs
+++ b/kernel/src/platform/mpu.rs
@@ -51,11 +51,8 @@ impl Region {
 }
 
 /// Null type for the default type of the `MpuConfig` type in an implementation
-/// of the `MPU` trait. We need this to workaround a bug in the Rust compiler.
-///
-/// Depending how <https://github.com/rust-lang/rust/issues/65774> is resolved we
-/// may be able to remove this type, but only if a default `Display` is
-/// provided for the `()` type.
+/// of the `MPU` trait. This custom type allows us to implement `Display` with
+/// an empty implementation to meet the constraint on `type MpuConfig`.
 #[derive(Default)]
 pub struct MpuConfigDefault {}
 


### PR DESCRIPTION
Clean up comment now that https://github.com/rust-lang/rust/issues/65774 has been closed.




### Testing Strategy

I tried just using `()` and I got a compiler error this time.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
