### PR TITLE
add redv board support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ members = [
     "boards/pico_explorer_base",
     "boards/raspberry_pi_pico",
     "boards/redboard_artemis_nano",
+    "boards/redboard_redv",
     "boards/stm32f3discovery",
     "boards/stm32f412gdiscovery",
     "boards/teensy40",

--- a/boards/README.md
+++ b/boards/README.md
@@ -22,6 +22,7 @@ that Tock supports.
 | [STM32F412G Discovery kit](stm32f412gdiscovery/README.md)            | ARM Cortex-M4   | STM32F412G     | openocd    | custom         | #1827         |
 | [WeAct F401CCU6 Core Board](weact_f401ccu6/README.md)                | ARM Cortex-M4   | STM32F401CCU6  | openocd    | custom         | No            |
 | [SparkFun RedBoard Artemis Nano](redboard_artemis_nano/README.md)    | ARM Cortex-M4   | Apollo3        | custom     | custom         | No            |
+| [SparkFun RedBoard Red-V](redboard_redv/README.md)                   | RISC-V          | FE310-G002     | openocd    | tockloader     | Yes (5.1)     |
 | [i.MX RT 1052 Evaluation Kit](imxrt1050-evkb/README.md)              | ARM Cortex-M7   | i.MX RT 1052   | custom     | custom         | No            |
 | [Teensy 4.0](teensy40/README.md)                                     | ARM Cortex-M7   | i.MX RT 1062   | custom     | custom         | No            |
 | [Pico Explorer Base](pico_explorer_base/README.md)                   | ARM Cortex-M0+  | RP2040         | openocd    | openocd        | No            |

--- a/boards/redboard_redv/Cargo.toml
+++ b/boards/redboard_redv/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "redboard_redv"
+version = "0.1.0"
+authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+build = "build.rs"
+edition = "2018"
+
+[dependencies]
+components = { path = "../components" }
+rv32i = { path = "../../arch/rv32i" }
+capsules = { path = "../../capsules" }
+kernel = { path = "../../kernel" }
+e310x = { path = "../../chips/e310x" }
+sifive = { path = "../../chips/sifive" }

--- a/boards/redboard_redv/Makefile
+++ b/boards/redboard_redv/Makefile
@@ -1,0 +1,31 @@
+# Makefile for building the tock kernel for the HiFive1 platform
+
+TARGET=riscv32imac-unknown-none-elf
+PLATFORM=hifive1
+QEMU ?= qemu-system-riscv32
+
+include ../Makefile.common
+
+# Default target for installing the kernel.
+.PHONY: install
+install: flash
+
+flash: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
+	openocd \
+		-c "source [find board/sifive-hifive1-revb.cfg]; program $<; resume 0x20000000; exit"
+
+qemu: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
+	$(QEMU) -M sifive_e,revb=true -kernel $^  -nographic
+
+qemu-app: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
+	$(QEMU) -M sifive_e,revb=true -kernel $^ -device loader,file=$(APP),addr=0x20040000 -nographic
+
+
+TOCKLOADER=tockloader
+TOCKLOADER_JTAG_FLAGS = --jlink --board hifive1b
+KERNEL_ADDRESS = 0x20010000
+
+# upload kernel over JTAG
+.PHONY: flash
+flash-jlink: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin
+	$(TOCKLOADER) $(TOCKLOADER_GENERAL_FLAGS) flash --address $(KERNEL_ADDRESS) $(TOCKLOADER_JTAG_FLAGS) $<

--- a/boards/redboard_redv/Makefile
+++ b/boards/redboard_redv/Makefile
@@ -1,7 +1,7 @@
-# Makefile for building the tock kernel for the HiFive1 platform
+# Makefile for building the tock kernel for the RedV platform
 
 TARGET=riscv32imac-unknown-none-elf
-PLATFORM=hifive1
+PLATFORM=redboard_redv
 QEMU ?= qemu-system-riscv32
 
 include ../Makefile.common
@@ -18,7 +18,7 @@ qemu: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
 	$(QEMU) -M sifive_e,revb=true -kernel $^  -nographic
 
 qemu-app: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
-	$(QEMU) -M sifive_e,revb=true -kernel $^ -device loader,file=$(APP),addr=0x20040000 -nographic
+	$(QEMU) -M sifive_e,revb=true -kernel $^ -device loader,file=$(APP),addr=0x20010000 -nographic
 
 
 TOCKLOADER=tockloader

--- a/boards/redboard_redv/README.md
+++ b/boards/redboard_redv/README.md
@@ -1,0 +1,62 @@
+Redboard Red-V B RISC-V Board
+==================================
+
+- https://www.sparkfun.com/products/15594
+
+Arduino-compatible dev board for RISC-V clone of the Hifive1.
+
+Programming
+-----------
+
+Running `make flash` should load the kernel onto the board. You will need a
+relatively new (i.e. from git) version of OpenOCD.
+
+The kernel also assumes there is the default HiFive1 software bootloader running
+on the chip.
+
+Running in QEMU
+---------------
+
+The HiFive1 application can be run in the QEMU emulation platform for RISC-V, allowing quick and easy testing.
+
+Unfortunately you need QEMU 5.1, which at the time of writing is unlikely to be avaliable in your distro. Luckily Tock can build QEMU for you. From the top level of the Tock source just run `make ci-setup-qemu` and follow the steps.
+
+QEMU can be started with Tock using the following arguments (in Tock's top-level directory):
+
+```bash
+$ qemu-system-riscv32 -M sifive_e,revb=true -kernel $TOCK_ROOT/target/riscv32imac-unknown-none-elf/release/hifive1.elf  -nographic
+```
+
+Or with the `qemu` make target:
+
+```bash
+$ make qemu
+```
+
+QEMU can be started with Tock and a userspace app using the following arguments (in Tock's top-level directory):
+
+```
+qemu-system-riscv32 -M sifive_e,revb=true -kernel $TOCK_ROOT/target/riscv32imac-unknown-none-elf/release/hifive1.elf -device loader,file=./examples/hello.tbf,addr=0x20040000 -nographic
+```
+Or with the `qemu-app` make target:
+
+```bash
+$ make APP=/path/to/app.tbf qemu-app
+```
+
+The TBF must be compiled for the HiFive board which is, at the time of writing,
+supported for Rust userland apps using libtock-rs. For example, you can build
+the Hello World exmple app from the libtock-rs repository by running:
+
+```
+$ cd [LIBTOCK-RS-DIR]
+$ make EXAMPLE=hello_world flash-hifive1
+$ tar xf target/riscv32imac-unknown-none-elf/tab/hifive1/hello_world.tab
+$ cd [TOCK_ROOT]/boards/hifive
+$ make APP=[LIBTOCK-RS-DIR]/rv32imac.tbf qemu-app
+```
+
+Changes between Red-V and Hifive1-RevB
+------------------
+
+Hifive1 contains a BT module. The LED layout has changed. The boards seem identical otherwise.

--- a/boards/redboard_redv/README.md
+++ b/boards/redboard_redv/README.md
@@ -8,8 +8,7 @@ Arduino-compatible dev board for RISC-V clone of the Hifive1.
 Programming
 -----------
 
-Running `make flash` should load the kernel onto the board. You will need a
-relatively new (i.e. from git) version of OpenOCD.
+Running `make flash` should load the kernel onto the board.
 
 The kernel also assumes there is the default HiFive1 software bootloader running
 on the chip.
@@ -18,8 +17,6 @@ Running in QEMU
 ---------------
 
 The HiFive1 application can be run in the QEMU emulation platform for RISC-V, allowing quick and easy testing.
-
-Unfortunately you need QEMU 5.1, which at the time of writing is unlikely to be avaliable in your distro. Luckily Tock can build QEMU for you. From the top level of the Tock source just run `make ci-setup-qemu` and follow the steps.
 
 QEMU can be started with Tock using the following arguments (in Tock's top-level directory):
 

--- a/boards/redboard_redv/build.rs
+++ b/boards/redboard_redv/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    println!("cargo:rerun-if-changed=layout.ld");
+    println!("cargo:rerun-if-changed=../kernel_layout.ld");
+}

--- a/boards/redboard_redv/layout.ld
+++ b/boards/redboard_redv/layout.ld
@@ -1,0 +1,16 @@
+/* The HiFive1a board has 512 MB of flash. The first 0x400000 is reserved for
+ * the default bootloader provided by SiFive. We also reserve room for apps to
+ * make all of the linker files work, but don't really support them on this
+ * chip.
+ */
+
+MEMORY
+{
+  rom (rx)  : ORIGIN = 0x20010000, LENGTH = 0x30000
+  prog (rx) : ORIGIN = 0x20040000, LENGTH = 512M-0x430000
+  ram (rwx) : ORIGIN = 0x80000000, LENGTH = 0x4000
+}
+
+MPU_MIN_ALIGN = 1K;
+
+INCLUDE ../kernel_layout.ld

--- a/boards/redboard_redv/layout.ld
+++ b/boards/redboard_redv/layout.ld
@@ -1,14 +1,13 @@
-/* The HiFive1a board has 512 MB of flash. The first 0x400000 is reserved for
+/* The RedV board has 4 MB of flash. The first 0x10000 is reserved for
  * the default bootloader provided by SiFive. We also reserve room for apps to
- * make all of the linker files work, but don't really support them on this
- * chip.
+ * make all of the linker files work.
  */
 
 MEMORY
 {
-  rom (rx)  : ORIGIN = 0x20010000, LENGTH = 0x30000
-  prog (rx) : ORIGIN = 0x20040000, LENGTH = 512M-0x430000
-  ram (rwx) : ORIGIN = 0x80000000, LENGTH = 0x4000
+  rom (rx)  : ORIGIN = 0x20010000, LENGTH = 192K
+  prog (rx) : ORIGIN = 0x20040000, LENGTH = 4M-192K
+  ram (rwx) : ORIGIN = 0x80000000, LENGTH = 16K
 }
 
 MPU_MIN_ALIGN = 1K;

--- a/boards/redboard_redv/src/io.rs
+++ b/boards/redboard_redv/src/io.rs
@@ -1,0 +1,73 @@
+use core::fmt::Write;
+use core::panic::PanicInfo;
+use core::str;
+use e310x;
+use kernel::debug;
+use kernel::debug::IoWrite;
+use kernel::hil::gpio;
+use kernel::hil::led;
+use rv32i;
+
+use crate::CHIP;
+use crate::PROCESSES;
+
+struct Writer {}
+
+static mut WRITER: Writer = Writer {};
+
+impl Write for Writer {
+    fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
+        self.write(s.as_bytes());
+        Ok(())
+    }
+}
+
+impl IoWrite for Writer {
+    fn write(&mut self, buf: &[u8]) {
+        let uart = sifive::uart::Uart::new(e310x::uart::UART0_BASE, 16_000_000);
+        uart.transmit_sync(buf);
+    }
+}
+
+/// Panic handler.
+#[cfg(not(test))]
+#[no_mangle]
+#[panic_handler]
+pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
+    // turn off the non panic leds, just in case
+    let led_green = sifive::gpio::GpioPin::new(
+        e310x::gpio::GPIO0_BASE,
+        sifive::gpio::pins::pin19,
+        sifive::gpio::pins::pin19::SET,
+        sifive::gpio::pins::pin19::CLEAR,
+    );
+    gpio::Configure::make_output(&led_green);
+    gpio::Output::set(&led_green);
+
+    let led_blue = sifive::gpio::GpioPin::new(
+        e310x::gpio::GPIO0_BASE,
+        sifive::gpio::pins::pin21,
+        sifive::gpio::pins::pin21::SET,
+        sifive::gpio::pins::pin21::CLEAR,
+    );
+    gpio::Configure::make_output(&led_blue);
+    gpio::Output::set(&led_blue);
+
+    let led_red_pin = sifive::gpio::GpioPin::new(
+        e310x::gpio::GPIO0_BASE,
+        sifive::gpio::pins::pin22,
+        sifive::gpio::pins::pin22::SET,
+        sifive::gpio::pins::pin22::CLEAR,
+    );
+    let led_red = &mut led::LedLow::new(&led_red_pin);
+    let writer = &mut WRITER;
+
+    debug::panic(
+        &mut [led_red],
+        writer,
+        pi,
+        &rv32i::support::nop,
+        &PROCESSES,
+        &CHIP,
+    )
+}

--- a/boards/redboard_redv/src/io.rs
+++ b/boards/redboard_redv/src/io.rs
@@ -10,6 +10,7 @@ use rv32i;
 
 use crate::CHIP;
 use crate::PROCESSES;
+use crate::PROCESS_PRINTER;
 
 struct Writer {}
 
@@ -69,5 +70,6 @@ pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
         &rv32i::support::nop,
         &PROCESSES,
         &CHIP,
+        &PROCESS_PRINTER,
     )
 }

--- a/boards/redboard_redv/src/main.rs
+++ b/boards/redboard_redv/src/main.rs
@@ -1,0 +1,301 @@
+//! Board file for SparkFun RedBoard Red-V development platform.
+//!
+//! - <https://www.sparkfun.com/products/15594>
+//!
+//! This board is a clone of the Hifive1-revB from SiFive with minor changes.
+
+#![no_std]
+// Disable this attribute when documenting, as a workaround for
+// https://github.com/rust-lang/rust/issues/62184.
+#![cfg_attr(not(doc), no_main)]
+
+use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
+use e310x::chip::E310xDefaultPeripherals;
+use kernel::capabilities;
+use kernel::component::Component;
+use kernel::dynamic_deferred_call::{DynamicDeferredCall, DynamicDeferredCallClientState};
+use kernel::hil;
+use kernel::hil::led::LedLow;
+use kernel::hil::time::Alarm;
+use kernel::platform::scheduler_timer::VirtualSchedulerTimer;
+use kernel::platform::{KernelResources, SyscallDriverLookup};
+use kernel::scheduler::cooperative::CooperativeSched;
+use kernel::utilities::registers::interfaces::ReadWriteable;
+use kernel::{create_capability, debug, static_init};
+use rv32i::csr;
+
+pub mod io;
+
+pub const NUM_PROCS: usize = 4;
+const NUM_UPCALLS_IPC: usize = NUM_PROCS + 1;
+//
+// Actual memory for holding the active process structures. Need an empty list
+// at least.
+static mut PROCESSES: [Option<&'static dyn kernel::process::Process>; NUM_PROCS] =
+    [None; NUM_PROCS];
+
+// Reference to the chip for panic dumps.
+static mut CHIP: Option<&'static e310x::chip::E310x<E310xDefaultPeripherals>> = None;
+
+// How should the kernel respond when a process faults.
+const FAULT_RESPONSE: kernel::process::PanicFaultPolicy = kernel::process::PanicFaultPolicy {};
+
+/// Dummy buffer that causes the linker to reserve enough space for the stack.
+#[no_mangle]
+#[link_section = ".stack_buffer"]
+pub static mut STACK_MEMORY: [u8; 0x900] = [0; 0x900];
+
+/// A structure representing this platform that holds references to all
+/// capsules for this platform. We've included an alarm and console.
+struct RedV {
+    led:
+        &'static capsules::led::LedDriver<'static, LedLow<'static, sifive::gpio::GpioPin<'static>>>,
+    console: &'static capsules::console::Console<'static>,
+    lldb: &'static capsules::low_level_debug::LowLevelDebug<
+        'static,
+        capsules::virtual_uart::UartDevice<'static>,
+    >,
+    alarm: &'static capsules::alarm::AlarmDriver<
+        'static,
+        VirtualMuxAlarm<'static, sifive::clint::Clint<'static>>,
+    >,
+    scheduler: &'static CooperativeSched<'static>,
+    scheduler_timer:
+        &'static VirtualSchedulerTimer<VirtualMuxAlarm<'static, sifive::clint::Clint<'static>>>,
+}
+
+/// Mapping of integer syscalls to objects that implement syscalls.
+impl SyscallDriverLookup for RedV {
+    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    where
+        F: FnOnce(Option<&dyn kernel::syscall::SyscallDriver>) -> R,
+    {
+        match driver_num {
+            capsules::led::DRIVER_NUM => f(Some(self.led)),
+            capsules::console::DRIVER_NUM => f(Some(self.console)),
+            capsules::alarm::DRIVER_NUM => f(Some(self.alarm)),
+            capsules::low_level_debug::DRIVER_NUM => f(Some(self.lldb)),
+            _ => f(None),
+        }
+    }
+}
+
+impl KernelResources<e310x::chip::E310x<'static, E310xDefaultPeripherals<'static>>> for RedV {
+    type SyscallDriverLookup = Self;
+    type SyscallFilter = ();
+    type ProcessFault = ();
+    type Scheduler = CooperativeSched<'static>;
+    type SchedulerTimer =
+        VirtualSchedulerTimer<VirtualMuxAlarm<'static, sifive::clint::Clint<'static>>>;
+    type WatchDog = ();
+
+    fn syscall_driver_lookup(&self) -> &Self::SyscallDriverLookup {
+        &self
+    }
+    fn syscall_filter(&self) -> &Self::SyscallFilter {
+        &()
+    }
+    fn process_fault(&self) -> &Self::ProcessFault {
+        &()
+    }
+    fn scheduler(&self) -> &Self::Scheduler {
+        self.scheduler
+    }
+    fn scheduler_timer(&self) -> &Self::SchedulerTimer {
+        &self.scheduler_timer
+    }
+    fn watchdog(&self) -> &Self::WatchDog {
+        &()
+    }
+}
+
+/// Main function.
+///
+/// This function is called from the arch crate after some very basic RISC-V
+/// setup and RAM initialization.
+#[no_mangle]
+pub unsafe fn main() {
+    // only machine mode
+    rv32i::configure_trap_handler(rv32i::PermissionMode::Machine);
+
+    let peripherals = static_init!(E310xDefaultPeripherals, E310xDefaultPeripherals::new());
+
+    // initialize capabilities
+    let process_mgmt_cap = create_capability!(capabilities::ProcessManagementCapability);
+    let memory_allocation_cap = create_capability!(capabilities::MemoryAllocationCapability);
+
+    peripherals.watchdog.disable();
+    peripherals.rtc.disable();
+    peripherals.pwm0.disable();
+    peripherals.pwm1.disable();
+    peripherals.pwm2.disable();
+
+    peripherals
+        .prci
+        .set_clock_frequency(sifive::prci::ClockFrequency::Freq16Mhz);
+
+    let main_loop_cap = create_capability!(capabilities::MainLoopCapability);
+
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
+
+    let dynamic_deferred_call_clients =
+        static_init!([DynamicDeferredCallClientState; 2], Default::default());
+    let dynamic_deferred_caller = static_init!(
+        DynamicDeferredCall,
+        DynamicDeferredCall::new(dynamic_deferred_call_clients)
+    );
+    DynamicDeferredCall::set_global_instance(dynamic_deferred_caller);
+
+    // Configure kernel debug gpios as early as possible
+    kernel::debug::assign_gpios(
+        Some(&peripherals.gpio_port[5]), // Blue/only LED
+        None,
+        None,
+    );
+
+    // Create a shared UART channel for the console and for kernel debug.
+    let uart_mux = components::console::UartMuxComponent::new(
+        &peripherals.uart0,
+        115200,
+        dynamic_deferred_caller,
+    )
+    .finalize(());
+
+    // LEDs
+    let led = components::led::LedsComponent::new(components::led_component_helper!(
+        LedLow<'static, sifive::gpio::GpioPin>,
+        LedLow::new(&peripherals.gpio_port[5]), // Blue
+    ))
+    .finalize(components::led_component_buf!(
+        LedLow<'static, sifive::gpio::GpioPin>
+    ));
+
+    peripherals
+        .uart0
+        .initialize_gpio_pins(&peripherals.gpio_port[17], &peripherals.gpio_port[16]);
+
+    let hardware_timer = static_init!(
+        sifive::clint::Clint,
+        sifive::clint::Clint::new(&e310x::clint::CLINT_BASE)
+    );
+
+    // Create a shared virtualization mux layer on top of a single hardware
+    // alarm.
+    let mux_alarm = static_init!(
+        MuxAlarm<'static, sifive::clint::Clint>,
+        MuxAlarm::new(hardware_timer)
+    );
+    hil::time::Alarm::set_alarm_client(hardware_timer, mux_alarm);
+
+    // Alarm
+    let virtual_alarm_user = static_init!(
+        VirtualMuxAlarm<'static, sifive::clint::Clint>,
+        VirtualMuxAlarm::new(mux_alarm)
+    );
+    let systick_virtual_alarm = static_init!(
+        VirtualMuxAlarm<'static, sifive::clint::Clint>,
+        VirtualMuxAlarm::new(mux_alarm)
+    );
+    let alarm = static_init!(
+        capsules::alarm::AlarmDriver<'static, VirtualMuxAlarm<'static, sifive::clint::Clint>>,
+        capsules::alarm::AlarmDriver::new(
+            virtual_alarm_user,
+            board_kernel.create_grant(capsules::alarm::DRIVER_NUM, &memory_allocation_cap)
+        )
+    );
+    hil::time::Alarm::set_alarm_client(virtual_alarm_user, alarm);
+
+    let chip = static_init!(
+        e310x::chip::E310x<E310xDefaultPeripherals>,
+        e310x::chip::E310x::new(peripherals, hardware_timer)
+    );
+    CHIP = Some(chip);
+
+    // Need to enable all interrupts for Tock Kernel
+    chip.enable_plic_interrupts();
+
+    // enable interrupts globally
+    csr::CSR
+        .mie
+        .modify(csr::mie::mie::mext::SET + csr::mie::mie::msoft::SET + csr::mie::mie::mtimer::SET);
+    csr::CSR.mstatus.modify(csr::mstatus::mstatus::mie::SET);
+
+    // Setup the console.
+    let console = components::console::ConsoleComponent::new(
+        board_kernel,
+        capsules::console::DRIVER_NUM,
+        uart_mux,
+    )
+    .finalize(());
+    // Create the debugger object that handles calls to `debug!()`.
+    components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
+
+    let lldb = components::lldb::LowLevelDebugComponent::new(
+        board_kernel,
+        capsules::low_level_debug::DRIVER_NUM,
+        uart_mux,
+    )
+    .finalize(());
+
+    // Need two debug!() calls to actually test with QEMU. QEMU seems to have
+    // a much larger UART TX buffer (or it transmits faster).
+    debug!("Red-V initialization complete.");
+    debug!("Entering main loop.");
+
+    /// These symbols are defined in the linker script.
+    extern "C" {
+        /// Beginning of the ROM region containing app images.
+        static _sapps: u8;
+        /// End of the ROM region containing app images.
+        static _eapps: u8;
+        /// Beginning of the RAM region for app memory.
+        static mut _sappmem: u8;
+        /// End of the RAM region for app memory.
+        static _eappmem: u8;
+    }
+
+    let scheduler = components::sched::cooperative::CooperativeComponent::new(&PROCESSES)
+        .finalize(components::coop_component_helper!(NUM_PROCS));
+
+    let scheduler_timer = static_init!(
+        VirtualSchedulerTimer<VirtualMuxAlarm<'static, sifive::clint::Clint<'static>>>,
+        VirtualSchedulerTimer::new(systick_virtual_alarm)
+    );
+    systick_virtual_alarm.set_alarm_client(scheduler_timer);
+
+    let redv = RedV {
+        console: console,
+        alarm: alarm,
+        lldb: lldb,
+        led,
+        scheduler,
+        scheduler_timer,
+    };
+
+    kernel::process::load_processes(
+        board_kernel,
+        chip,
+        core::slice::from_raw_parts(
+            &_sapps as *const u8,
+            &_eapps as *const u8 as usize - &_sapps as *const u8 as usize,
+        ),
+        core::slice::from_raw_parts_mut(
+            &mut _sappmem as *mut u8,
+            &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
+        ),
+        &mut PROCESSES,
+        &FAULT_RESPONSE,
+        &process_mgmt_cap,
+    )
+    .unwrap_or_else(|err| {
+        debug!("Error loading processes!");
+        debug!("{:?}", err);
+    });
+
+    board_kernel.kernel_loop(
+        &redv,
+        chip,
+        None::<&kernel::ipc::IPC<NUM_PROCS, NUM_UPCALLS_IPC>>,
+        &main_loop_cap,
+    );
+}


### PR DESCRIPTION
### Pull Request Overview

Adds support for the SparkFun Redboard Red-V board which is a clone of the Hifive1-RevB (with minor LED changes).

### Testing Strategy

I tested the flashing on a RedV board, but I'm currently unable to test `libtock-rs` since it's not yet on v2 support.

### TODO or Help Wanted

Check functionality of LEDs with [this libtock-rs PR](https://github.com/tock/libtock-rs/pull/336) once ready for v2.

### Documentation Updated

- [x] Updated `/boards/README.md`

### Formatting

- [x] Ran `make prepush`.
