### PR TITLE
console: reserve first upcall parameter as status_code

### DIFF
--- a/capsules/src/console.rs
+++ b/capsules/src/console.rs
@@ -304,7 +304,12 @@ impl uart::TransmitClient for Console<'_> {
                             // Go ahead and signal the application
                             let written = app.write_len;
                             app.write_len = 0;
-                            upcalls.schedule_upcall(1, (written, 0, 0)).ok();
+                            upcalls
+                                .schedule_upcall(
+                                    1,
+                                    (kernel::errorcode::into_statuscode(Ok(())), written, 0),
+                                )
+                                .ok();
                         }
                     }
                     Err(return_code) => {

--- a/doc/syscalls/00001_console.md
+++ b/doc/syscalls/00001_console.md
@@ -76,9 +76,9 @@ share a buffer for every write transaction, even if it's the same buffer.
     **Description**: Subscribe to write transaction completion event. The
     callback will be called whenever a write transaction completes.
 
-    **Callback signature**: The callback receives a single argument, the number
-    of bytes written in the transaction. The value of the remaining arguments
-    is undefined.
+    **Callback signature**: The callback receives two arguments: the status
+    code and the number of bytes written in the transaction.
+    The value of the remaining argument is undefined.
 
     **Returns**: Ok(()) if the subscribe was successful or NOMEM if the
     driver failed to allocate memory for the transaction.
@@ -88,9 +88,9 @@ share a buffer for every write transaction, even if it's the same buffer.
     **Description**: Subscribe to read transaction completion event. The
     callback will be called whenever a read transaction completes.
 
-    **Callback signature**: The callback receives a single argument, the number
-    of bytes read in the transaction. The value of the remaining arguments
-    is undefined.
+    **Callback signature**: The callback receives two arguments, the status
+    code and the number of bytes read in the transaction. The value of the
+    remaining argument is undefined.
 
     **Returns**: Ok(()) if the subscribe was successful or NOMEM if the
     driver failed to allocate memory for the transaction.


### PR DESCRIPTION
Always use the first parameter of the upcall as the status code, and move the bytes written parameter to the second parameter. This means that success will look like `(0, bytes_written, 0)` and `NOMEM` failure will look like `(9, 0, 0)`.

This fixes #2833

### Documentation Updated

- [x] Updated the relevant files in `/docs`.

### Formatting

- [x] Ran `make prepush`.
