### PR TITLE
kernel: process: fmt, spell chk, & update comments

### DIFF
--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -95,8 +95,8 @@ impl fmt::Debug for ProcessId {
 }
 
 impl ProcessId {
-    /// Create a new `ProcessId` object based on the app identifier and its index
-    /// in the processes array.
+    /// Create a new `ProcessId` object based on the app identifier and its
+    /// index in the processes array.
     pub(crate) fn new(kernel: &'static Kernel, identifier: usize, index: usize) -> ProcessId {
         ProcessId {
             kernel: kernel,
@@ -105,8 +105,8 @@ impl ProcessId {
         }
     }
 
-    /// Create a new `ProcessId` object based on the app identifier and its index
-    /// in the processes array.
+    /// Create a new `ProcessId` object based on the app identifier and its
+    /// index in the processes array.
     ///
     /// This constructor is public but protected with a capability so that
     /// external implementations of `Process` can use it.
@@ -125,9 +125,9 @@ impl ProcessId {
 
     /// Get the location of this app in the processes array.
     ///
-    /// This will return `Some(index)` if the identifier stored in this `ProcessId`
-    /// matches the app saved at the known index. If the identifier does not
-    /// match then `None` will be returned.
+    /// This will return `Some(index)` if the identifier stored in this
+    /// `ProcessId` matches the app saved at the known index. If the identifier
+    /// does not match then `None` will be returned.
     pub(crate) fn index(&self) -> Option<usize> {
         // Do a lookup to make sure that the index we have is correct.
         if self.kernel.processid_is_valid(self) {
@@ -326,8 +326,8 @@ pub trait Process {
     /// process memory brk.
     fn app_memory_break(&self) -> *const u8;
 
-    /// Creates a [`ReadWriteProcessBuffer`] from the given offset and
-    /// size in process memory.
+    /// Creates a [`ReadWriteProcessBuffer`] from the given offset and size in
+    /// process memory.
     ///
     /// ## Returns
     ///
@@ -336,20 +336,20 @@ pub trait Process {
     ///
     /// In case of an error, an appropriate ErrorCode is returned:
     ///
-    /// - if the memory is not contained in the process-accessible
-    ///   memory space / `buf_start_addr` and `size` are not a valid
-    ///   read-write buffer (any byte in the range is not read/write
-    ///   accessible to the process), [`ErrorCode::INVAL`]
-    /// - if the process is not active: [`ErrorCode::FAIL`]
-    /// - for all other errors: [`ErrorCode::FAIL`]
+    /// - If the memory is not contained in the process-accessible memory space
+    ///   / `buf_start_addr` and `size` are not a valid read-write buffer (any
+    ///   byte in the range is not read/write accessible to the process),
+    ///   [`ErrorCode::INVAL`].
+    /// - If the process is not active: [`ErrorCode::FAIL`].
+    /// - For all other errors: [`ErrorCode::FAIL`].
     fn build_readwrite_process_buffer(
         &self,
         buf_start_addr: *mut u8,
         size: usize,
     ) -> Result<ReadWriteProcessBuffer, ErrorCode>;
 
-    /// Creates a [`ReadOnlyProcessBuffer`] from the given offset and
-    /// size in process memory.
+    /// Creates a [`ReadOnlyProcessBuffer`] from the given offset and size in
+    /// process memory.
     ///
     /// ## Returns
     ///
@@ -358,22 +358,22 @@ pub trait Process {
     ///
     /// In case of an error, an appropriate ErrorCode is returned:
     ///
-    /// - if the memory is not contained in the process-accessible
-    ///   memory space / `buf_start_addr` and `size` are not a valid
-    ///   read-only buffer (any byte in the range is not
-    ///   read-accessible to the process), [`ErrorCode::INVAL`]
-    /// - if the process is not active: [`ErrorCode::FAIL`]
-    /// - for all other errors: [`ErrorCode::FAIL`]
+    /// - If the memory is not contained in the process-accessible memory space
+    ///   / `buf_start_addr` and `size` are not a valid read-only buffer (any
+    ///   byte in the range is not read-accessible to the process),
+    ///   [`ErrorCode::INVAL`].
+    /// - If the process is not active: [`ErrorCode::FAIL`].
+    /// - For all other errors: [`ErrorCode::FAIL`].
     fn build_readonly_process_buffer(
         &self,
         buf_start_addr: *const u8,
         size: usize,
     ) -> Result<ReadOnlyProcessBuffer, ErrorCode>;
 
-    /// Set a single byte within the process address space at
-    /// `addr` to `value`. Return true if `addr` is within the RAM
-    /// bounds currently exposed to the process (thereby writable
-    /// by the process itself) and the value was set, false otherwise.
+    /// Set a single byte within the process address space at `addr` to `value`.
+    /// Return true if `addr` is within the RAM bounds currently exposed to the
+    /// process (thereby writable by the process itself) and the value was set,
+    /// false otherwise.
     ///
     /// ### Safety
     ///
@@ -490,8 +490,8 @@ pub trait Process {
     /// Useful for debugging/inspecting the system.
     fn grant_allocated_count(&self) -> Option<usize>;
 
-    /// Get the grant number (grant_num) associated with a given driver number if there is a grant
-    /// associated with that driver_num.
+    /// Get the grant number (grant_num) associated with a given driver number
+    /// if there is a grant associated with that driver_num.
     fn lookup_grant_from_driver_num(&self, driver_num: usize) -> Result<usize, Error>;
 
     // subscribe
@@ -511,8 +511,8 @@ pub trait Process {
     /// It is not valid to call this function when the process is inactive (i.e.
     /// the process will not run again).
     ///
-    /// This can fail, if the UKB implementation cannot correctly set the return value. An
-    /// example of how this might occur:
+    /// This can fail, if the UKB implementation cannot correctly set the return
+    /// value. An example of how this might occur:
     ///
     /// 1. The UKB implementation uses the process's stack to transfer values
     ///    between kernelspace and userspace.
@@ -592,8 +592,14 @@ pub struct ProcessCustomGrantIdentifer {
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Error {
+    /// The process has been removed and no longer exists. For example, the
+    /// kernel could stop a process and re-claim its resources.
     NoSuchApp,
+    /// The process does not have enough memory to complete the requested
+    /// operation.
     OutOfMemory,
+    /// The provided memory address is not accessible or not valid for the
+    /// process.
     AddressOutOfBounds,
     /// The process is inactive (likely in a fault or exit state) and the
     /// attempted operation is therefore invalid.
@@ -662,19 +668,20 @@ pub enum State {
     /// The process faulted and cannot be run.
     Faulted,
 
-    /// The process exited with the `exit-terminate` system call and
-    /// cannot be run.
+    /// The process exited with the `exit-terminate` system call and cannot be
+    /// run.
     Terminated,
 
     /// The process has never actually been executed. This of course happens
     /// when the board first boots and the kernel has not switched to any
-    /// processes yet. It can also happen if an process is terminated and all
-    /// of its state is reset as if it has not been executed yet.
+    /// processes yet. It can also happen if an process is terminated and all of
+    /// its state is reset as if it has not been executed yet.
     Unstarted,
 }
 
-/// A wrapper around `Cell<State>` is used by `Process` to prevent bugs arising from
-/// the state duplication in the kernel work tracking and process state tracking.
+/// A wrapper around `Cell<State>` is used by `Process` to prevent bugs arising
+/// from the state duplication in the kernel work tracking and process state
+/// tracking.
 pub(crate) struct ProcessStateCell<'a> {
     state: Cell<State>,
     kernel: &'a Kernel,

--- a/kernel/src/process_standard.rs
+++ b/kernel/src/process_standard.rs
@@ -426,8 +426,8 @@ impl<C: Chip> Process for ProcessStandard<'_, C> {
             self.debug.map(|debug| {
                 debug.app_stack_start_pointer = Some(stack_pointer);
 
-                // We also reset the minimum stack pointer because whatever value
-                // we had could be entirely wrong by now.
+                // We also reset the minimum stack pointer because whatever
+                // value we had could be entirely wrong by now.
                 debug.app_stack_min_pointer = Some(stack_pointer);
             });
         }
@@ -531,28 +531,26 @@ impl<C: Chip> Process for ProcessStandard<'_, C> {
             return Err(ErrorCode::FAIL);
         }
 
-        // A process is allowed to pass any pointer if the buffer
-        // length is 0, as to revoke kernel access to a memory region
-        // without granting access to another one
+        // A process is allowed to pass any pointer if the buffer length is 0,
+        // as to revoke kernel access to a memory region without granting access
+        // to another one
         if size == 0 {
-            // Clippy complains that we're deferencing a pointer in a
-            // public and safe function here. While we are not
-            // dereferencing the pointer here, we pass it along to an
-            // unsafe function, which is as dangerous (as it is likely
-            // to be dereferenced down the line).
+            // Clippy complains that we're dereferencing a pointer in a public
+            // and safe function here. While we are not dereferencing the
+            // pointer here, we pass it along to an unsafe function, which is as
+            // dangerous (as it is likely to be dereferenced down the line).
             //
             // Relevant discussion:
             // https://github.com/rust-lang/rust-clippy/issues/3045
             //
-            // It should be fine to ignore the lint here, as a buffer
-            // of length 0 will never allow dereferencing any memory
-            // in a safe manner.
+            // It should be fine to ignore the lint here, as a buffer of length
+            // 0 will never allow dereferencing any memory in a safe manner.
             //
             // ### Safety
             //
             // We specific a zero-length buffer, so the implementation of
-            // `ReadWriteProcessBuffer` will handle any safety issues. Therefore, we
-            // can encapsulate the unsafe.
+            // `ReadWriteProcessBuffer` will handle any safety issues.
+            // Therefore, we can encapsulate the unsafe.
             Ok(unsafe { ReadWriteProcessBuffer::new(buf_start_addr, 0, self.processid()) })
         } else if self.in_app_owned_memory(buf_start_addr, size) {
             // TODO: Check for buffer aliasing here
@@ -563,26 +561,25 @@ impl<C: Chip> Process for ProcessStandard<'_, C> {
             let new_water_mark = cmp::max(self.allow_high_water_mark.get(), buf_end_addr);
             self.allow_high_water_mark.set(new_water_mark);
 
-            // Clippy complains that we're deferencing a pointer in a
-            // public and safe function here. While we are not
-            // deferencing the pointer here, we pass it along to an
-            // unsafe function, which is as dangerous (as it is likely
-            // to be deferenced down the line).
+            // Clippy complains that we're dereferencing a pointer in a public
+            // and safe function here. While we are not dereferencing the
+            // pointer here, we pass it along to an unsafe function, which is as
+            // dangerous (as it is likely to be dereferenced down the line).
             //
             // Relevant discussion:
             // https://github.com/rust-lang/rust-clippy/issues/3045
             //
-            // It should be fine to ignore the lint here, as long as
-            // we make sure that we're pointing towards userspace
-            // memory (verified using `in_app_owned_memory`) and
-            // respect alignment and other constraints of the Rust
-            // references created by ReadWriteProcessBuffer.
+            // It should be fine to ignore the lint here, as long as we make
+            // sure that we're pointing towards userspace memory (verified using
+            // `in_app_owned_memory`) and respect alignment and other
+            // constraints of the Rust references created by
+            // ReadWriteProcessBuffer.
             //
             // ### Safety
             //
             // We encapsulate the unsafe here on the condition in the TODO
-            // above, as we must ensure that this `ReadWriteProcessBuffer` will be
-            // the only reference to this memory.
+            // above, as we must ensure that this `ReadWriteProcessBuffer` will
+            // be the only reference to this memory.
             Ok(unsafe { ReadWriteProcessBuffer::new(buf_start_addr, size, self.processid()) })
         } else {
             Err(ErrorCode::INVAL)
@@ -600,28 +597,26 @@ impl<C: Chip> Process for ProcessStandard<'_, C> {
             return Err(ErrorCode::FAIL);
         }
 
-        // A process is allowed to pass any pointer if the buffer
-        // length is 0, as to revoke kernel access to a memory region
-        // without granting access to another one
+        // A process is allowed to pass any pointer if the buffer length is 0,
+        // as to revoke kernel access to a memory region without granting access
+        // to another one
         if size == 0 {
-            // Clippy complains that we're deferencing a pointer in a
-            // public and safe function here. While we are not
-            // deferencing the pointer here, we pass it along to an
-            // unsafe function, which is as dangerous (as it is likely
-            // to be deferenced down the line).
+            // Clippy complains that we're dereferencing a pointer in a public
+            // and safe function here. While we are not dereferencing the
+            // pointer here, we pass it along to an unsafe function, which is as
+            // dangerous (as it is likely to be dereferenced down the line).
             //
             // Relevant discussion:
             // https://github.com/rust-lang/rust-clippy/issues/3045
             //
-            // It should be fine to ignore the lint here, as a buffer
-            // of length 0 will never allow dereferencing any memory
-            // in a safe manner.
+            // It should be fine to ignore the lint here, as a buffer of length
+            // 0 will never allow dereferencing any memory in a safe manner.
             //
             // ### Safety
             //
             // We specific a zero-length buffer, so the implementation of
-            // `ReadOnlyProcessBuffer` will handle any safety issues. Therefore, we
-            // can encapsulate the unsafe.
+            // `ReadOnlyProcessBuffer` will handle any safety issues. Therefore,
+            // we can encapsulate the unsafe.
             Ok(unsafe { ReadOnlyProcessBuffer::new(buf_start_addr, 0, self.processid()) })
         } else if self.in_app_owned_memory(buf_start_addr, size)
             || self.in_app_flash_memory(buf_start_addr, size)
@@ -629,35 +624,33 @@ impl<C: Chip> Process for ProcessStandard<'_, C> {
             // TODO: Check for buffer aliasing here
 
             if self.in_app_owned_memory(buf_start_addr, size) {
-                // Valid buffer, if this is not in a read-only (e.g. flash) memory section,
-                // we need to adjust the app's watermark
-                // note: in_app_owned_memory ensures this offset does not wrap
+                // Valid buffer, and since this is in read-write memory (i.e.
+                // not flash), we need to adjust the process's watermark. Note:
+                // `in_app_owned_memory()` ensures this offset does not wrap.
                 let buf_end_addr = buf_start_addr.wrapping_add(size);
                 let new_water_mark = cmp::max(self.allow_high_water_mark.get(), buf_end_addr);
                 self.allow_high_water_mark.set(new_water_mark);
             }
 
-            // Clippy complains that we're deferencing a pointer in a
-            // public and safe function here. While we are not
-            // deferencing the pointer here, we pass it along to an
-            // unsafe function, which is as dangerous (as it is likely
-            // to be deferenced down the line).
+            // Clippy complains that we're dereferencing a pointer in a public
+            // and safe function here. While we are not dereferencing the
+            // pointer here, we pass it along to an unsafe function, which is as
+            // dangerous (as it is likely to be dereferenced down the line).
             //
             // Relevant discussion:
             // https://github.com/rust-lang/rust-clippy/issues/3045
             //
-            // It should be fine to ignore the lint here, as long as
-            // we make sure that we're pointing towards userspace
-            // memory (verified using `in_app_owned_memory` or
-            // `in_app_flash_memory`) and respect alignment and other
-            // constraints of the Rust references created by
+            // It should be fine to ignore the lint here, as long as we make
+            // sure that we're pointing towards userspace memory (verified using
+            // `in_app_owned_memory` or `in_app_flash_memory`) and respect
+            // alignment and other constraints of the Rust references created by
             // ReadWriteProcessBuffer.
             //
             // ### Safety
             //
             // We encapsulate the unsafe here on the condition in the TODO
-            // above, as we must ensure that this `ReadOnlyProcessBuffer` will be
-            // the only reference to this memory.
+            // above, as we must ensure that this `ReadOnlyProcessBuffer` will
+            // be the only reference to this memory.
             Ok(unsafe { ReadOnlyProcessBuffer::new(buf_start_addr, size, self.processid()) })
         } else {
             Err(ErrorCode::INVAL)
@@ -684,8 +677,8 @@ impl<C: Chip> Process for ProcessStandard<'_, C> {
 
         // Update the grant pointer to the address of the new allocation.
         self.grant_pointers.map_or(None, |grant_pointers| {
-            // Implement `grant_pointers[grant_num]` without a
-            // chance of a panic.
+            // Implement `grant_pointers[grant_num]` without a chance of a
+            // panic.
             grant_pointers
                 .get(grant_num)
                 .map_or(None, |grant_entry| Some(!grant_entry.grant_ptr.is_null()))
@@ -722,8 +715,8 @@ impl<C: Chip> Process for ProcessStandard<'_, C> {
         let exists = self.grant_pointers.map_or(false, |grant_pointers| {
             // Check our list of grant pointers if the driver number is used.
             grant_pointers.iter().any(|grant_entry| {
-                // Check if the grant is both allocated (its grant pointer
-                // is non null) and the driver number matches.
+                // Check if the grant is both allocated (its grant pointer is
+                // non null) and the driver number matches.
                 (!grant_entry.grant_ptr.is_null()) && grant_entry.driver_num == driver_num
             })
         });
@@ -1417,14 +1410,17 @@ impl<C: 'static + Chip> ProcessStandard<'_, C> {
         }
 
         if let Some((major, minor)) = tbf_header.get_kernel_version() {
-            // If the `KernelVersion` header is present, we read the requested kernel version and compare it to
-            // the running kernel version.
+            // If the `KernelVersion` header is present, we read the requested
+            // kernel version and compare it to the running kernel version.
             if crate::MAJOR != major || crate::MINOR < minor {
-                // If the kernel major version is different, we prevent the process from being loaded.
+                // If the kernel major version is different, we prevent the
+                // process from being loaded.
                 //
-                // If the kernel major version is the same, we compare the kernel minor version. The current
-                // running kernel minor version has to be greater or equal to the one that the process
-                // has requested. If not, we prevent the process from loading.
+                // If the kernel major version is the same, we compare the
+                // kernel minor version. The current running kernel minor
+                // version has to be greater or equal to the one that the
+                // process has requested. If not, we prevent the process from
+                // loading.
                 if config::CONFIG.debug_load_processes {
                     debug!("WARN process {:?} not loaded as it requires kernel version >= {}.{} and < {}.0, (running kernel {}.{})", process_name.unwrap_or("(no name)"), major, minor, (major+1), crate::MAJOR, crate::MINOR);
                 }
@@ -1434,13 +1430,12 @@ impl<C: 'static + Chip> ProcessStandard<'_, C> {
             }
         } else {
             if require_kernel_version {
-                // If enforcing the kernel version is requested, and the `KernelVersion` header is not present,
-                // we prevent the process from loading.
+                // If enforcing the kernel version is requested, and the
+                // `KernelVersion` header is not present, we prevent the process
+                // from loading.
                 if config::CONFIG.debug_load_processes {
-                    debug!(
-                            "WARN process {:?} not loaded as it has no kernel version header, please upgrade to elf2tab >= 0.8.0",
-                            process_name.unwrap_or ("(no name")
-                        );
+                    debug!("WARN process {:?} not loaded as it has no kernel version header, please upgrade to elf2tab >= 0.8.0",
+                           process_name.unwrap_or ("(no name"));
                 }
                 return Err(ProcessLoadError::IncompatibleKernelVersion { version: None });
             }
@@ -1478,9 +1473,9 @@ impl<C: 'static + Chip> ProcessStandard<'_, C> {
             return Err(ProcessLoadError::MpuInvalidFlashLength);
         }
 
-        // Determine how much space we need in the application's
-        // memory space just for kernel and grant state. We need to make
-        // sure we allocate enough memory just for that.
+        // Determine how much space we need in the application's memory space
+        // just for kernel and grant state. We need to make sure we allocate
+        // enough memory just for that.
 
         // Make room for grant pointers.
         let grant_ptr_size = mem::size_of::<GrantPointerEntry>();
@@ -1496,8 +1491,8 @@ impl<C: 'static + Chip> ProcessStandard<'_, C> {
         // By default we start with the initial size of process-accessible
         // memory set to 0. This maximizes the flexibility that processes have
         // to allocate their memory as they see fit. If a process needs more
-        // accessible memory it must use the `brk` memop syscalls to request more
-        // memory.
+        // accessible memory it must use the `brk` memop syscalls to request
+        // more memory.
         //
         // We must take into account any process-accessible memory required by
         // the context switching implementation and allocate at least that much
@@ -1786,15 +1781,15 @@ impl<C: 'static + Chip> ProcessStandard<'_, C> {
         Ok((Some(process), unused_memory))
     }
 
-    /// Restart the process, resetting all of its state and re-initializing
-    /// it to start running.  Assumes the process is not running but is still in flash
-    /// and still has its memory region allocated to it. This implements
+    /// Restart the process, resetting all of its state and re-initializing it
+    /// to start running.  Assumes the process is not running but is still in
+    /// flash and still has its memory region allocated to it. This implements
     /// the mechanism of restart.
     fn restart(&self) -> Result<(), ErrorCode> {
         // We need a new process identifier for this process since the restarted
         // version is in effect a new process. This is also necessary to
-        // invalidate any stored `ProcessId`s that point to the old version of the
-        // process. However, the process has not moved locations in the
+        // invalidate any stored `ProcessId`s that point to the old version of
+        // the process. However, the process has not moved locations in the
         // processes array, so we copy the existing index.
         let old_index = self.process_id.get().index;
         let new_identifier = self.kernel.create_process_identifier();
@@ -1819,9 +1814,11 @@ impl<C: 'static + Chip> ProcessStandard<'_, C> {
         };
 
         // Reset MPU region configuration.
-        // TODO: ideally, this would be moved into a helper function used by both
-        // create() and reset(), but process load debugging complicates this.
-        // We just want to create new config with only flash and memory regions.
+        //
+        // TODO: ideally, this would be moved into a helper function used by
+        // both create() and reset(), but process load debugging complicates
+        // this. We just want to create new config with only flash and memory
+        // regions.
         let mut mpu_config: <<C as Chip>::MPU as MPU>::MpuConfig = Default::default();
         // Allocate MPU region for flash.
         let app_mpu_flash = self.chip.mpu().allocate_region(
@@ -1841,8 +1838,9 @@ impl<C: 'static + Chip> ProcessStandard<'_, C> {
 
         // RAM
 
-        // Re-determine the minimum amount of RAM the kernel must allocate to the process
-        // based on the specific requirements of the syscall implementation.
+        // Re-determine the minimum amount of RAM the kernel must allocate to
+        // the process based on the specific requirements of the syscall
+        // implementation.
         let min_process_memory_size = self
             .chip
             .userspace_kernel_boundary()
@@ -1908,12 +1906,11 @@ impl<C: 'static + Chip> ProcessStandard<'_, C> {
         match ukb_init_process {
             Ok(()) => {}
             Err(_) => {
-                // We couldn't initialize the architecture-specific
-                // state for this process. This shouldn't happen since
-                // the app was able to be started before, but at this
-                // point the app is no longer valid. The best thing we
-                // can do now is leave the app as still faulted and not
-                // schedule it.
+                // We couldn't initialize the architecture-specific state for
+                // this process. This shouldn't happen since the app was able to
+                // be started before, but at this point the app is no longer
+                // valid. The best thing we can do now is leave the app as still
+                // faulted and not schedule it.
                 return Err(ErrorCode::RESERVE);
             }
         };
@@ -1947,10 +1944,10 @@ impl<C: 'static + Chip> ProcessStandard<'_, C> {
     }
 
     /// Checks if the buffer represented by the passed in base pointer and size
-    /// is within the RAM bounds currently exposed to the processes (i.e.
-    /// ending at `app_break`). If this method returns `true`, the buffer
-    /// is guaranteed to be accessible to the process and to not overlap with
-    /// the grant region.
+    /// is within the RAM bounds currently exposed to the processes (i.e. ending
+    /// at `app_break`). If this method returns `true`, the buffer is guaranteed
+    /// to be accessible to the process and to not overlap with the grant
+    /// region.
     fn in_app_owned_memory(&self, buf_start_addr: *const u8, size: usize) -> bool {
         let buf_end_addr = buf_start_addr.wrapping_add(size);
 
@@ -1960,9 +1957,9 @@ impl<C: 'static + Chip> ProcessStandard<'_, C> {
     }
 
     /// Checks if the buffer represented by the passed in base pointer and size
-    /// are within the readable region of an application's flash
-    /// memory.  If this method returns true, the buffer
-    /// is guaranteed to be readable to the process.
+    /// are within the readable region of an application's flash memory.  If
+    /// this method returns true, the buffer is guaranteed to be readable to the
+    /// process.
     fn in_app_flash_memory(&self, buf_start_addr: *const u8, size: usize) -> bool {
         let buf_end_addr = buf_start_addr.wrapping_add(size);
 
@@ -1991,9 +1988,9 @@ impl<C: 'static + Chip> ProcessStandard<'_, C> {
     /// allocation, then this will return `None`.
     fn allocate_in_grant_region_internal(&self, size: usize, align: usize) -> Option<NonNull<u8>> {
         self.mpu_config.and_then(|mut config| {
-            // First, compute the candidate new pointer. Note that at this
-            // point we have not yet checked whether there is space for
-            // this allocation or that it meets alignment requirements.
+            // First, compute the candidate new pointer. Note that at this point
+            // we have not yet checked whether there is space for this
+            // allocation or that it meets alignment requirements.
             let new_break_unaligned = self.kernel_memory_break.get().wrapping_sub(size);
 
             // Our minimum alignment requirement is two bytes, so that the
@@ -2004,8 +2001,8 @@ impl<C: 'static + Chip> ProcessStandard<'_, C> {
             let align = cmp::max(align, 2);
 
             // The alignment must be a power of two, 2^a. The expression
-            // `!(align - 1)` then returns a mask with leading ones,
-            // followed by `a` trailing zeros.
+            // `!(align - 1)` then returns a mask with leading ones, followed by
+            // `a` trailing zeros.
             let alignment_mask = !(align - 1);
             let new_break = (new_break_unaligned as usize & alignment_mask) as *const u8;
 


### PR DESCRIPTION
### Pull Request Overview

This pull request does some periodic maintenance on comment formatting in process_standard.rs and process.rs. Spell check, formatting, punctuation, capitalization. I also added comments for the three remaining `Error` types.


### Testing Strategy

just comments


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
