### PR TITLE
Kernel: store a process's completion code

### DIFF
--- a/kernel/src/kernel.rs
+++ b/kernel/src/kernel.rs
@@ -1271,9 +1271,9 @@ impl Kernel {
                 completion_code,
             } => match which {
                 // The process called the `exit-terminate` system call.
-                0 => process.terminate(completion_code as u32),
+                0 => process.terminate(Some(completion_code as u32)),
                 // The process called the `exit-restart` system call.
-                1 => process.try_restart(completion_code as u32),
+                1 => process.try_restart(Some(completion_code as u32)),
                 // The process called an invalid variant of the Exit
                 // system call class.
                 _ => process.set_syscall_return_value(SyscallReturn::Failure(ErrorCode::NOSUPPORT)),

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -244,7 +244,7 @@ pub trait Process {
     /// restarted and run again. This function instead frees grants and any
     /// queued tasks for this process, but leaves the debug information about
     /// the process and other state intact.
-    fn terminate(&self, completion_code: u32);
+    fn terminate(&self, completion_code: Option<u32>);
 
     /// Terminates and attempts to restart the process. The process and current
     /// application always terminate. The kernel may, based on its own policy,
@@ -267,7 +267,7 @@ pub trait Process {
     /// After `restart()` runs the process will either be queued to run its the
     /// application's `_start` function, terminated, or queued to run a
     /// different application's `_start` function.
-    fn try_restart(&self, completion_code: u32);
+    fn try_restart(&self, completion_code: Option<u32>);
 
     // memop operations
 

--- a/kernel/src/process_standard.rs
+++ b/kernel/src/process_standard.rs
@@ -1122,6 +1122,7 @@ impl<C: Chip> Process for ProcessStandard<'_, C> {
         let last_syscall = self.debug.map(|debug| debug.last_syscall);
         let dropped_upcall_count = self.debug.map_or(0, |debug| debug.dropped_upcall_count);
         let restart_count = self.restart_count.get();
+        let completion_code = self.completion_code.extract();
 
         let _ = writer.write_fmt(format_args!(
             "\
@@ -1139,6 +1140,14 @@ impl<C: Chip> Process for ProcessStandard<'_, C> {
         let _ = match last_syscall {
             Some(syscall) => writer.write_fmt(format_args!(" Last Syscall: {:?}\r\n", syscall)),
             None => writer.write_str(" Last Syscall: None\r\n"),
+        };
+
+        let _ = match completion_code {
+            Some(opt_cc) => match opt_cc {
+                Some(cc) => writer.write_fmt(format_args!(" Completion Code: {}\r\n", cc)),
+                None => writer.write_str(" Completion Code: Faulted\r\n"),
+            },
+            None => writer.write_str(" Completion Code: None\r\n"),
         };
 
         let _ = writer.write_fmt(format_args!(

--- a/kernel/src/process_standard.rs
+++ b/kernel/src/process_standard.rs
@@ -24,10 +24,7 @@ use crate::process_utilities::ProcessLoadError;
 use crate::processbuffer::{ReadOnlyProcessBuffer, ReadWriteProcessBuffer};
 use crate::syscall::{self, Syscall, SyscallReturn, UserspaceKernelBoundary};
 use crate::upcall::UpcallId;
-use crate::utilities::cells::{MapCell, NumericCellExt};
-
-// The completion code for a process if it faulted.
-const COMPLETION_FAULT: u32 = 0xffffffff;
+use crate::utilities::cells::{MapCell, NumericCellExt, OptionalCell};
 
 /// State for helping with debugging apps.
 ///
@@ -202,6 +199,16 @@ pub struct ProcessStandard<'a, C: 'static + Chip> {
     /// determine if the process should be restarted or not.
     restart_count: Cell<usize>,
 
+    /// The completion code set by the process when it last exited, restarted,
+    /// or was terminated. If the process is has never terminated, then the
+    /// `OptionalCell` will be empty (i.e. `None`). If the process has exited,
+    /// restarted, or terminated, the `OptionalCell` will contain an optional 32
+    /// bit value. The option will be `None` if the process crashed or was
+    /// stopped by the kernel and there is no provided completion code. If the
+    /// process called the exit syscall then the provided completion code will
+    /// be stored as `Some(completion code)`.
+    completion_code: OptionalCell<Option<u32>>,
+
     /// Name of the app.
     process_name: &'static str,
 
@@ -323,7 +330,7 @@ impl<C: Chip> Process for ProcessStandard<'_, C> {
                 panic!("Process {} had a fault", self.process_name);
             }
             FaultAction::Restart => {
-                self.try_restart(COMPLETION_FAULT);
+                self.try_restart(None);
             }
             FaultAction::Stop => {
                 // This looks a lot like restart, except we just leave the app
@@ -331,13 +338,13 @@ impl<C: Chip> Process for ProcessStandard<'_, C> {
                 // all of the app's todo work it will not be scheduled, and
                 // clearing all of the grant regions will cause capsules to drop
                 // this app as well.
-                self.terminate(COMPLETION_FAULT);
+                self.terminate(None);
                 self.state.update(State::Faulted);
             }
         }
     }
 
-    fn try_restart(&self, completion_code: u32) {
+    fn try_restart(&self, completion_code: Option<u32>) {
         // Terminate the process, freeing its state and removing any
         // pending tasks from the scheduler's queue.
         self.terminate(completion_code);
@@ -350,7 +357,7 @@ impl<C: Chip> Process for ProcessStandard<'_, C> {
         // want to reclaim the process resources.
     }
 
-    fn terminate(&self, _completion_code: u32) {
+    fn terminate(&self, completion_code: Option<u32>) {
         // Remove the tasks that were scheduled for the app from the
         // amount of work queue.
         let tasks_len = self.tasks.map_or(0, |tasks| tasks.len());
@@ -367,6 +374,9 @@ impl<C: Chip> Process for ProcessStandard<'_, C> {
         unsafe {
             self.grant_ptrs_reset();
         }
+
+        // Save the completion code.
+        self.completion_code.set(completion_code);
 
         // Mark the app as stopped so the scheduler won't try to run it.
         self.state.update(State::Terminated);
@@ -1712,6 +1722,7 @@ impl<C: 'static + Chip> ProcessStandard<'_, C> {
         process.state = ProcessStateCell::new(process.kernel);
         process.fault_policy = fault_policy;
         process.restart_count = Cell::new(0);
+        process.completion_code = OptionalCell::empty();
 
         process.mpu_config = MapCell::new(mpu_config);
         process.mpu_regions = [


### PR DESCRIPTION
### Pull Request Overview

This is towards #2473.

This PR stores a process's completion code and adds it to the `print_memory_map()` debugging print function.

Also, rather than using a constant to denote a process which crashed, I am using an `Option` instead. That way a process that wants to use that completion code number won't alias to a faulted process.


### Testing Strategy

Running the exit app on hail, and causing an app to fault.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
