### PR TITLE
Update to Rust 2021 edition

### DIFF
--- a/arch/cortex-m/Cargo.toml
+++ b/arch/cortex-m/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cortexm"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 kernel = { path = "../../kernel" }

--- a/arch/cortex-m0/Cargo.toml
+++ b/arch/cortex-m0/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cortexm0"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 kernel = { path = "../../kernel" }

--- a/arch/cortex-m0p/Cargo.toml
+++ b/arch/cortex-m0p/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cortexm0p"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 kernel = { path = "../../kernel" }

--- a/arch/cortex-m3/Cargo.toml
+++ b/arch/cortex-m3/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cortexm3"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 kernel = { path = "../../kernel" }

--- a/arch/cortex-m4/Cargo.toml
+++ b/arch/cortex-m4/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cortexm4"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 kernel = { path = "../../kernel" }

--- a/arch/cortex-m7/Cargo.toml
+++ b/arch/cortex-m7/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cortexm7"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 kernel = { path = "../../kernel" }

--- a/arch/riscv/Cargo.toml
+++ b/arch/riscv/Cargo.toml
@@ -2,7 +2,7 @@
 name = "riscv"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 kernel = { path = "../../kernel" }

--- a/arch/rv32i/Cargo.toml
+++ b/arch/rv32i/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rv32i"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 kernel = { path = "../../kernel" }

--- a/boards/acd52832/Cargo.toml
+++ b/boards/acd52832/Cargo.toml
@@ -3,7 +3,7 @@ name = "acd52832"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
 build = "build.rs"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 components = { path = "../components" }

--- a/boards/arty_e21/Cargo.toml
+++ b/boards/arty_e21/Cargo.toml
@@ -3,7 +3,7 @@ name = "arty_e21"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
 build = "build.rs"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 components = { path = "../components" }

--- a/boards/clue_nrf52840/Cargo.toml
+++ b/boards/clue_nrf52840/Cargo.toml
@@ -3,7 +3,7 @@ name = "clue_nrf52840"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
 build = "build.rs"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 cortexm4 = { path = "../../arch/cortex-m4" }

--- a/boards/components/Cargo.toml
+++ b/boards/components/Cargo.toml
@@ -2,7 +2,7 @@
 name = "components"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 capsules = { path = "../../capsules" }

--- a/boards/esp32-c3-devkitM-1/Cargo.toml
+++ b/boards/esp32-c3-devkitM-1/Cargo.toml
@@ -3,7 +3,7 @@ name = "esp32-c3-board"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
 build = "build.rs"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 components = { path = "../components" }

--- a/boards/hail/Cargo.toml
+++ b/boards/hail/Cargo.toml
@@ -3,7 +3,7 @@ name = "hail"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
 build = "build.rs"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 components = { path = "../components" }

--- a/boards/hifive1/Cargo.toml
+++ b/boards/hifive1/Cargo.toml
@@ -3,7 +3,7 @@ name = "hifive1"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
 build = "build.rs"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 components = { path = "../components" }

--- a/boards/imix/Cargo.toml
+++ b/boards/imix/Cargo.toml
@@ -3,7 +3,7 @@ name = "imix"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
 build = "build.rs"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 components = { path = "../components" }

--- a/boards/imxrt1050-evkb/Cargo.toml
+++ b/boards/imxrt1050-evkb/Cargo.toml
@@ -3,7 +3,7 @@ name = "imxrt1050-evkb"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
 build = "build.rs"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 components = { path = "../components" }

--- a/boards/litex/arty/Cargo.toml
+++ b/boards/litex/arty/Cargo.toml
@@ -3,7 +3,7 @@ name = "litex_arty"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
 build = "build.rs"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 components = { path = "../../components" }

--- a/boards/litex/sim/Cargo.toml
+++ b/boards/litex/sim/Cargo.toml
@@ -3,7 +3,7 @@ name = "litex_sim"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
 build = "build.rs"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 components = { path = "../../components" }

--- a/boards/microbit_v2/Cargo.toml
+++ b/boards/microbit_v2/Cargo.toml
@@ -3,7 +3,7 @@ name = "microbit_v2"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
 build = "build.rs"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 cortexm4 = { path = "../../arch/cortex-m4" }

--- a/boards/msp_exp432p401r/Cargo.toml
+++ b/boards/msp_exp432p401r/Cargo.toml
@@ -3,7 +3,7 @@ name = "msp-exp432p401r"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
 build = "build.rs"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 components = { path = "../components" }

--- a/boards/nano33ble/Cargo.toml
+++ b/boards/nano33ble/Cargo.toml
@@ -3,7 +3,7 @@ name = "nano33ble"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
 build = "build.rs"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 cortexm4 = { path = "../../arch/cortex-m4" }

--- a/boards/nano_rp2040_connect/Cargo.toml
+++ b/boards/nano_rp2040_connect/Cargo.toml
@@ -3,7 +3,7 @@ name = "nano_rp2040_connect"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
 build = "build.rs"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 cortexm0p = { path = "../../arch/cortex-m0p" }

--- a/boards/nordic/nrf52840_dongle/Cargo.toml
+++ b/boards/nordic/nrf52840_dongle/Cargo.toml
@@ -3,7 +3,7 @@ name = "nrf52840_dongle"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
 build = "build.rs"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 components = { path = "../../components" }

--- a/boards/nordic/nrf52840dk/Cargo.toml
+++ b/boards/nordic/nrf52840dk/Cargo.toml
@@ -3,7 +3,7 @@ name = "nrf52840dk"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
 build = "build.rs"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 components = { path = "../../components" }

--- a/boards/nordic/nrf52_components/Cargo.toml
+++ b/boards/nordic/nrf52_components/Cargo.toml
@@ -2,7 +2,7 @@
 name = "nrf52_components"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 components = { path = "../../components" }

--- a/boards/nordic/nrf52dk/Cargo.toml
+++ b/boards/nordic/nrf52dk/Cargo.toml
@@ -3,7 +3,7 @@ name = "nrf52dk"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
 build = "build.rs"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 components = { path = "../../components" }

--- a/boards/nucleo_f429zi/Cargo.toml
+++ b/boards/nucleo_f429zi/Cargo.toml
@@ -3,7 +3,7 @@ name = "nucleo_f429zi"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
 build = "build.rs"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 components = { path = "../components" }

--- a/boards/nucleo_f446re/Cargo.toml
+++ b/boards/nucleo_f446re/Cargo.toml
@@ -3,7 +3,7 @@ name = "nucleo_f446re"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
 build = "build.rs"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 components = { path = "../components" }

--- a/boards/opentitan/earlgrey-cw310/Cargo.toml
+++ b/boards/opentitan/earlgrey-cw310/Cargo.toml
@@ -3,7 +3,7 @@ name = "earlgrey-cw310"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
 build = "build.rs"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 components = { path = "../../components" }

--- a/boards/opentitan/earlgrey-nexysvideo/Cargo.toml
+++ b/boards/opentitan/earlgrey-nexysvideo/Cargo.toml
@@ -3,7 +3,7 @@ name = "earlgrey-nexysvideo"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
 build = "build.rs"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 components = { path = "../../components" }

--- a/boards/pico_explorer_base/Cargo.toml
+++ b/boards/pico_explorer_base/Cargo.toml
@@ -3,7 +3,7 @@ name = "pico_explorer_base"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
 build = "build.rs"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 cortexm0p = { path = "../../arch/cortex-m0p" }

--- a/boards/raspberry_pi_pico/Cargo.toml
+++ b/boards/raspberry_pi_pico/Cargo.toml
@@ -3,7 +3,7 @@ name = "raspberry_pi_pico"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
 build = "build.rs"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 cortexm0p = { path = "../../arch/cortex-m0p" }

--- a/boards/redboard_artemis_nano/Cargo.toml
+++ b/boards/redboard_artemis_nano/Cargo.toml
@@ -3,7 +3,7 @@ name = "redboard_artemis_nano"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
 build = "build.rs"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 components = { path = "../components" }

--- a/boards/stm32f3discovery/Cargo.toml
+++ b/boards/stm32f3discovery/Cargo.toml
@@ -3,7 +3,7 @@ name = "stm32f3discovery"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
 build = "build.rs"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 components = { path = "../components" }

--- a/boards/stm32f412gdiscovery/Cargo.toml
+++ b/boards/stm32f412gdiscovery/Cargo.toml
@@ -3,7 +3,7 @@ name = "stm32f412gdiscovery"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
 build = "build.rs"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 components = { path = "../components" }

--- a/boards/swervolf/Cargo.toml
+++ b/boards/swervolf/Cargo.toml
@@ -3,7 +3,7 @@ name = "swervolf"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
 build = "build.rs"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 components = { path = "../components" }

--- a/boards/teensy40/Cargo.toml
+++ b/boards/teensy40/Cargo.toml
@@ -3,7 +3,7 @@ name = "teensy40"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
 build = "build.rs"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 components = { path = "../components" }

--- a/boards/weact_f401ccu6/Cargo.toml
+++ b/boards/weact_f401ccu6/Cargo.toml
@@ -3,7 +3,7 @@ name = "weact-f401ccu6"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
 build = "build.rs"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 components = { path = "../components" }

--- a/capsules/Cargo.toml
+++ b/capsules/Cargo.toml
@@ -2,7 +2,7 @@
 name = "capsules"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 kernel = { path = "../kernel" }

--- a/capsules/src/test/kv_system.rs
+++ b/capsules/src/test/kv_system.rs
@@ -35,7 +35,7 @@
 //!
 //! You should then see the following output
 //!
-//! ```
+//! ```text
 //! ---Starting TicKV Tests---
 //! Key: [18, 52, 86, 120, 154, 188, 222, 240] with value [16, 32, 48] was added
 //! Now retriving the key

--- a/chips/apollo3/Cargo.toml
+++ b/chips/apollo3/Cargo.toml
@@ -2,7 +2,7 @@
 name = "apollo3"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 cortexm4 = { path = "../../arch/cortex-m4" }

--- a/chips/arty_e21_chip/Cargo.toml
+++ b/chips/arty_e21_chip/Cargo.toml
@@ -2,7 +2,7 @@
 name = "arty_e21_chip"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 sifive = { path = "../sifive" }

--- a/chips/e310x/Cargo.toml
+++ b/chips/e310x/Cargo.toml
@@ -2,7 +2,7 @@
 name = "e310x"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 sifive = { path = "../sifive" }

--- a/chips/earlgrey/Cargo.toml
+++ b/chips/earlgrey/Cargo.toml
@@ -2,7 +2,7 @@
 name = "earlgrey"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2018"
+edition = "2021"
 
 [features]
 # Compiling this crate requires enabling one of these features, otherwise

--- a/chips/esp32-c3/Cargo.toml
+++ b/chips/esp32-c3/Cargo.toml
@@ -2,7 +2,7 @@
 name = "esp32-c3"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 esp32 = { path = "../esp32" }

--- a/chips/esp32/Cargo.toml
+++ b/chips/esp32/Cargo.toml
@@ -2,7 +2,7 @@
 name = "esp32"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 kernel = { path = "../../kernel" }

--- a/chips/imxrt10xx/Cargo.toml
+++ b/chips/imxrt10xx/Cargo.toml
@@ -2,7 +2,7 @@
 name = "imxrt10xx"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 cortexm7 = { path = "../../arch/cortex-m7" }

--- a/chips/litex/Cargo.toml
+++ b/chips/litex/Cargo.toml
@@ -2,7 +2,7 @@
 name = "litex"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 tock-registers = { path = "../../libraries/tock-register-interface" }

--- a/chips/litex_vexriscv/Cargo.toml
+++ b/chips/litex_vexriscv/Cargo.toml
@@ -2,7 +2,7 @@
 name = "litex_vexriscv"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 rv32i = { path = "../../arch/rv32i" }

--- a/chips/lowrisc/Cargo.toml
+++ b/chips/lowrisc/Cargo.toml
@@ -2,7 +2,7 @@
 name = "lowrisc"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 rv32i = { path = "../../arch/rv32i" }

--- a/chips/msp432/Cargo.toml
+++ b/chips/msp432/Cargo.toml
@@ -2,7 +2,7 @@
 name = "msp432"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 cortexm4 = { path = "../../arch/cortex-m4" }

--- a/chips/nrf52/Cargo.toml
+++ b/chips/nrf52/Cargo.toml
@@ -2,7 +2,7 @@
 name = "nrf52"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 cortexm4 = { path = "../../arch/cortex-m4" }

--- a/chips/nrf52832/Cargo.toml
+++ b/chips/nrf52832/Cargo.toml
@@ -2,7 +2,7 @@
 name = "nrf52832"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 cortexm4 = { path = "../../arch/cortex-m4" }

--- a/chips/nrf52833/Cargo.toml
+++ b/chips/nrf52833/Cargo.toml
@@ -2,7 +2,7 @@
 name = "nrf52833"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 cortexm4 = { path = "../../arch/cortex-m4" }

--- a/chips/nrf52840/Cargo.toml
+++ b/chips/nrf52840/Cargo.toml
@@ -2,7 +2,7 @@
 name = "nrf52840"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 cortexm4 = { path = "../../arch/cortex-m4" }

--- a/chips/nrf5x/Cargo.toml
+++ b/chips/nrf5x/Cargo.toml
@@ -2,7 +2,7 @@
 name = "nrf5x"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 kernel = { path = "../../kernel" }

--- a/chips/rp2040/Cargo.toml
+++ b/chips/rp2040/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rp2040"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 cortexm0p = { path="../../arch/cortex-m0p" }

--- a/chips/sam4l/Cargo.toml
+++ b/chips/sam4l/Cargo.toml
@@ -2,7 +2,7 @@
 name = "sam4l"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 cortexm4 = { path = "../../arch/cortex-m4" }

--- a/chips/sifive/Cargo.toml
+++ b/chips/sifive/Cargo.toml
@@ -2,7 +2,7 @@
 name = "sifive"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 rv32i = { path = "../../arch/rv32i" }

--- a/chips/stm32f303xc/Cargo.toml
+++ b/chips/stm32f303xc/Cargo.toml
@@ -2,7 +2,7 @@
 name = "stm32f303xc"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 cortexm4 = { path = "../../arch/cortex-m4" }

--- a/chips/stm32f401cc/Cargo.toml
+++ b/chips/stm32f401cc/Cargo.toml
@@ -2,7 +2,7 @@
 name = "stm32f401cc"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 cortexm4 = { path = "../../arch/cortex-m4" }

--- a/chips/stm32f412g/Cargo.toml
+++ b/chips/stm32f412g/Cargo.toml
@@ -2,7 +2,7 @@
 name = "stm32f412g"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 cortexm4 = { path = "../../arch/cortex-m4" }

--- a/chips/stm32f429zi/Cargo.toml
+++ b/chips/stm32f429zi/Cargo.toml
@@ -2,7 +2,7 @@
 name = "stm32f429zi"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 cortexm4 = { path = "../../arch/cortex-m4" }

--- a/chips/stm32f446re/Cargo.toml
+++ b/chips/stm32f446re/Cargo.toml
@@ -2,7 +2,7 @@
 name = "stm32f446re"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 cortexm4 = { path = "../../arch/cortex-m4" }

--- a/chips/stm32f4xx/Cargo.toml
+++ b/chips/stm32f4xx/Cargo.toml
@@ -2,7 +2,7 @@
 name = "stm32f4xx"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 cortexm4 = { path = "../../arch/cortex-m4" }

--- a/chips/swerv/Cargo.toml
+++ b/chips/swerv/Cargo.toml
@@ -2,7 +2,7 @@
 name = "swerv"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 tock-registers = { path = "../../libraries/tock-register-interface" }

--- a/chips/swervolf-eh1/Cargo.toml
+++ b/chips/swervolf-eh1/Cargo.toml
@@ -2,7 +2,7 @@
 name = "swervolf-eh1"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 swerv = { path = "../swerv" }

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -2,7 +2,7 @@
 name = "kernel"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 tock-registers = { path = "../libraries/tock-register-interface" }

--- a/kernel/src/dynamic_deferred_call.rs
+++ b/kernel/src/dynamic_deferred_call.rs
@@ -37,7 +37,7 @@
 //!     DynamicDeferredCall,
 //!     DynamicDeferredCall::new(dynamic_deferred_call_clients)
 //! ) };
-//! assert!(unsafe { DynamicDeferredCall::set_global_instance(dynamic_deferred_call) }, true);
+//! assert!(unsafe { DynamicDeferredCall::set_global_instance(dynamic_deferred_call) } == true);
 //!
 //! # struct SomeCapsule;
 //! # impl SomeCapsule {

--- a/kernel/src/hil/entropy.rs
+++ b/kernel/src/hil/entropy.rs
@@ -48,7 +48,7 @@
 //! use kernel::ErrorCode;
 //!
 //! struct EntropyTest<'a, A: 'a + Alarm<'a>> {
-//!     entropy: &'a Entropy32 <'a>,
+//!     entropy: &'a dyn Entropy32 <'a>,
 //!     alarm: &'a A
 //! }
 //!
@@ -68,7 +68,7 @@
 //!
 //! impl<'a, A: Alarm<'a>> Client32 for EntropyTest<'a, A> {
 //!     fn entropy_available(&self,
-//!                          entropy: &mut Iterator<Item = u32>,
+//!                          entropy: &mut dyn Iterator<Item = u32>,
 //!                          error: Result<(), ErrorCode>) -> hil::entropy::Continue {
 //!         match entropy.next() {
 //!             Some(val) => {

--- a/kernel/src/hil/rng.rs
+++ b/kernel/src/hil/rng.rs
@@ -55,7 +55,7 @@
 //! use kernel::ErrorCode;
 //!
 //! struct RngTest<'a, A: 'a + hil::time::Alarm<'a>> {
-//!     rng: &'a hil::rng::Rng<'a>,
+//!     rng: &'a dyn hil::rng::Rng<'a>,
 //!     alarm: &'a A
 //! }
 //!
@@ -75,7 +75,7 @@
 //!
 //! impl<'a, A: hil::time::Alarm<'a>> hil::rng::Client for RngTest<'a, A> {
 //!     fn randomness_available(&self,
-//!                             randomness: &mut Iterator<Item = u32>,
+//!                             randomness: &mut dyn Iterator<Item = u32>,
 //!                             error: Result<(), ErrorCode>) -> hil::rng::Continue {
 //!         match randomness.next() {
 //!             Some(random) => {

--- a/libraries/riscv-csr/Cargo.toml
+++ b/libraries/riscv-csr/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 keywords = ["tock", "embedded", "riscv", "bare-metal"]
 categories = ["data-structures", "embedded", "no-std"]
 license = "MIT/Apache-2.0"
-edition = "2018"
+edition = "2021"
 
 [badges]
 travis-ci = { repository = "tock/tock", branch = "master" }

--- a/libraries/tickv/Cargo.toml
+++ b/libraries/tickv/Cargo.toml
@@ -3,5 +3,5 @@ name = "tickv"
 repository = "https://github.com/tock/tock"
 version = "0.1.0"
 authors = ["Alistair Francis <alistair.francis@wdc.com>"]
-edition = "2018"
+edition = "2021"
 readme = "README.md"

--- a/libraries/tock-register-interface/Cargo.toml
+++ b/libraries/tock-register-interface/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 keywords = ["tock", "embedded", "registers", "mmio", "bare-metal"]
 categories = ["data-structures", "embedded", "no-std"]
 license = "MIT/Apache-2.0"
-edition = "2018"
+edition = "2021"
 
 [badges]
 travis-ci = { repository = "tock/tock", branch = "master" }

--- a/libraries/tock-tbf/Cargo.toml
+++ b/libraries/tock-tbf/Cargo.toml
@@ -2,4 +2,4 @@
 name = "tock-tbf"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2018"
+edition = "2021"

--- a/tools/alert_codes/Cargo.toml
+++ b/tools/alert_codes/Cargo.toml
@@ -2,6 +2,6 @@
 name = "alert_codes"
 version = "0.1.0"
 authors = ["jrvanwhy <jrvanwhy@google.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]

--- a/tools/board-runner/Cargo.toml
+++ b/tools/board-runner/Cargo.toml
@@ -2,7 +2,7 @@
 name = "board-runner"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 rexpect = "0.4"

--- a/tools/qemu-runner/Cargo.toml
+++ b/tools/qemu-runner/Cargo.toml
@@ -2,7 +2,7 @@
 name = "qemu-runner"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 rexpect = "0.4.0"

--- a/tools/sha256sum/Cargo.toml
+++ b/tools/sha256sum/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/RustCrypto/hashes"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 sha2 = "0.8.1"


### PR DESCRIPTION

### Pull Request Overview

This pull request updates us to use the Rust 2021 edition. I ran cargo fix --edition with the appropriate additional target flags etc. for several boards (Imix, OT, hail) and no changes were needed anywhere. Somewhat surprisingly, this change increases code size on Imix by 3kB and OT by 1.5kB. On an out-of-tree Risc-v board, I observed that it decreased code size by 1.5 kB.


### Testing Strategy

This pull request was tested by compiling.


### TODO or Help Wanted

N/A

### Documentation Updated

- [x] No updates are required.

### Formatting

- [x] Ran `make prepush`.
