### PR TITLE
netlify: set TERM explicitly

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,2 +1,6 @@
 [[plugins]]
 package = "./tools/netlify-cache"
+
+# Suppress `tput` warnings by setting TERM
+[build]
+environment = { TERM = "dumb" }


### PR DESCRIPTION
### Pull Request Overview

This sets `TERM=dumb` so the netlify build logs aren't full of `tput` errors.

### Testing Strategy

This PR.

### TODO or Help Wanted

N/A

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
