### PR TITLE
kernel::collections: redesign linked-list interface and types 

### DIFF
--- a/boards/acd52832/src/main.rs
+++ b/boards/acd52832/src/main.rs
@@ -19,7 +19,6 @@ use kernel::hil::led::LedLow;
 use kernel::hil::rng::Rng;
 use kernel::hil::time::{Alarm, Counter};
 use kernel::platform::{KernelResources, SyscallDriverLookup};
-use kernel::scheduler::round_robin::RoundRobinSched;
 #[allow(unused_imports)]
 use kernel::{create_capability, debug, debug_gpio, static_init};
 use nrf52832::gpio::Pin;
@@ -86,7 +85,7 @@ pub struct Platform {
         'static,
         capsules::virtual_alarm::VirtualMuxAlarm<'static, nrf52832::rtc::Rtc<'static>>,
     >,
-    scheduler: &'static RoundRobinSched<'static>,
+    scheduler: &'static components::sched::round_robin::SchedulerType,
     systick: cortexm4::systick::SysTick,
 }
 
@@ -119,7 +118,7 @@ impl KernelResources<nrf52832::chip::NRF52<'static, Nrf52832DefaultPeripherals<'
     type SyscallDriverLookup = Self;
     type SyscallFilter = ();
     type ProcessFault = ();
-    type Scheduler = RoundRobinSched<'static>;
+    type Scheduler = components::sched::round_robin::SchedulerType;
     type SchedulerTimer = cortexm4::systick::SysTick;
     type WatchDog = ();
     type ContextSwitchCallback = ();

--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -24,7 +24,6 @@ use kernel::hil::usb::Client;
 use kernel::platform::chip::Chip;
 use kernel::platform::mpu::MPU;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
-use kernel::scheduler::round_robin::RoundRobinSched;
 #[allow(unused_imports)]
 use kernel::{create_capability, debug, debug_gpio, debug_verbose, static_init};
 
@@ -167,7 +166,7 @@ pub struct Platform {
     adc: &'static capsules::adc::AdcVirtualized<'static>,
     temperature: &'static capsules::temperature::TemperatureSensor<'static>,
     humidity: &'static capsules::humidity::HumiditySensor<'static>,
-    scheduler: &'static RoundRobinSched<'static>,
+    scheduler: &'static components::sched::round_robin::SchedulerType,
     systick: cortexm4::systick::SysTick,
 }
 
@@ -203,7 +202,7 @@ impl KernelResources<nrf52::chip::NRF52<'static, Nrf52840DefaultPeripherals<'sta
     type SyscallDriverLookup = Self;
     type SyscallFilter = ();
     type ProcessFault = ();
-    type Scheduler = RoundRobinSched<'static>;
+    type Scheduler = components::sched::round_robin::SchedulerType;
     type SchedulerTimer = cortexm4::systick::SysTick;
     type WatchDog = ();
     type ContextSwitchCallback = ();

--- a/boards/components/src/sched/priority.rs
+++ b/boards/components/src/sched/priority.rs
@@ -17,6 +17,8 @@ pub struct PriorityComponent {
     board_kernel: &'static kernel::Kernel,
 }
 
+pub type SchedulerType = PrioritySched;
+
 impl PriorityComponent {
     pub fn new(board_kernel: &'static kernel::Kernel) -> PriorityComponent {
         PriorityComponent { board_kernel }
@@ -25,10 +27,10 @@ impl PriorityComponent {
 
 impl Component for PriorityComponent {
     type StaticInput = ();
-    type Output = &'static mut PrioritySched;
+    type Output = &'static mut SchedulerType;
 
     unsafe fn finalize(self, _static_buffer: Self::StaticInput) -> Self::Output {
-        let scheduler = static_init!(PrioritySched, PrioritySched::new(self.board_kernel));
+        let scheduler = static_init!(SchedulerType, PrioritySched::new(self.board_kernel));
         scheduler
     }
 }

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -20,7 +20,6 @@ use kernel::hil::i2c::I2CMaster;
 use kernel::hil::led::LedLow;
 use kernel::hil::Controller;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
-use kernel::scheduler::round_robin::RoundRobinSched;
 #[allow(unused_imports)]
 use kernel::{create_capability, debug, debug_gpio, static_init};
 use sam4l::adc::Channel;
@@ -79,7 +78,7 @@ struct Hail {
     ipc: kernel::ipc::IPC<NUM_PROCS>,
     crc: &'static capsules::crc::CrcDriver<'static, sam4l::crccu::Crccu<'static>>,
     dac: &'static capsules::dac::Dac<'static>,
-    scheduler: &'static RoundRobinSched<'static>,
+    scheduler: &'static components::sched::round_robin::SchedulerType,
     systick: cortexm4::systick::SysTick,
 }
 
@@ -120,7 +119,7 @@ impl KernelResources<sam4l::chip::Sam4l<Sam4lDefaultPeripherals>> for Hail {
     type SyscallDriverLookup = Self;
     type SyscallFilter = ();
     type ProcessFault = ();
-    type Scheduler = RoundRobinSched<'static>;
+    type Scheduler = components::sched::round_robin::SchedulerType;
     type SchedulerTimer = cortexm4::systick::SysTick;
     type WatchDog = ();
     type ContextSwitchCallback = ();

--- a/boards/hifive1/src/main.rs
+++ b/boards/hifive1/src/main.rs
@@ -18,7 +18,6 @@ use kernel::hil;
 use kernel::hil::led::LedLow;
 use kernel::platform::scheduler_timer::VirtualSchedulerTimer;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
-use kernel::scheduler::cooperative::CooperativeSched;
 use kernel::utilities::registers::interfaces::ReadWriteable;
 use kernel::{create_capability, debug, static_init};
 use rv32i::csr;
@@ -62,7 +61,7 @@ struct HiFive1 {
         'static,
         VirtualMuxAlarm<'static, sifive::clint::Clint<'static>>,
     >,
-    scheduler: &'static CooperativeSched<'static>,
+    scheduler: &'static components::sched::cooperative::SchedulerType,
     scheduler_timer:
         &'static VirtualSchedulerTimer<VirtualMuxAlarm<'static, sifive::clint::Clint<'static>>>,
 }
@@ -87,7 +86,7 @@ impl KernelResources<e310x::chip::E310x<'static, E310xDefaultPeripherals<'static
     type SyscallDriverLookup = Self;
     type SyscallFilter = ();
     type ProcessFault = ();
-    type Scheduler = CooperativeSched<'static>;
+    type Scheduler = components::sched::cooperative::SchedulerType;
     type SchedulerTimer =
         VirtualSchedulerTimer<VirtualMuxAlarm<'static, sifive::clint::Clint<'static>>>;
     type WatchDog = ();

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -27,7 +27,6 @@ use kernel::hil::radio;
 use kernel::hil::radio::{RadioConfig, RadioData};
 use kernel::hil::symmetric_encryption::AES128;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
-use kernel::scheduler::round_robin::RoundRobinSched;
 //use kernel::hil::time::Alarm;
 use kernel::hil::led::LedHigh;
 use kernel::hil::Controller;
@@ -141,7 +140,7 @@ struct Imix {
     >,
     nrf51822: &'static capsules::nrf51822_serialization::Nrf51822Serialization<'static>,
     nonvolatile_storage: &'static capsules::nonvolatile_storage_driver::NonvolatileStorage<'static>,
-    scheduler: &'static RoundRobinSched<'static>,
+    scheduler: &'static components::sched::round_robin::SchedulerType,
     systick: cortexm4::systick::SysTick,
 }
 
@@ -192,7 +191,7 @@ impl KernelResources<sam4l::chip::Sam4l<Sam4lDefaultPeripherals>> for Imix {
     type SyscallDriverLookup = Self;
     type SyscallFilter = ();
     type ProcessFault = ();
-    type Scheduler = RoundRobinSched<'static>;
+    type Scheduler = components::sched::round_robin::SchedulerType;
     type SchedulerTimer = cortexm4::systick::SysTick;
     type WatchDog = ();
     type ContextSwitchCallback = ();

--- a/boards/imxrt1050-evkb/src/main.rs
+++ b/boards/imxrt1050-evkb/src/main.rs
@@ -15,7 +15,6 @@ use kernel::dynamic_deferred_call::{DynamicDeferredCall, DynamicDeferredCallClie
 use kernel::hil::gpio::Configure;
 use kernel::hil::led::LedLow;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
-use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::{create_capability, static_init};
 
 // use components::fxos8700::Fxos8700Component;
@@ -84,7 +83,7 @@ struct Imxrt1050EVKB {
     >,
     ninedof: &'static capsules::ninedof::NineDof<'static>,
 
-    scheduler: &'static RoundRobinSched<'static>,
+    scheduler: &'static components::sched::round_robin::SchedulerType,
     systick: cortexm7::systick::SysTick,
 }
 
@@ -113,7 +112,7 @@ impl KernelResources<imxrt1050::chip::Imxrt10xx<imxrt1050::chip::Imxrt10xxDefaul
     type SyscallDriverLookup = Self;
     type SyscallFilter = ();
     type ProcessFault = ();
-    type Scheduler = RoundRobinSched<'static>;
+    type Scheduler = components::sched::round_robin::SchedulerType;
     type SchedulerTimer = cortexm7::systick::SysTick;
     type WatchDog = ();
     type ContextSwitchCallback = ();

--- a/boards/litex/arty/src/main.rs
+++ b/boards/litex/arty/src/main.rs
@@ -14,7 +14,6 @@ use kernel::hil::time::{Alarm, Timer};
 use kernel::platform::chip::InterruptService;
 use kernel::platform::scheduler_timer::VirtualSchedulerTimer;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
-use kernel::scheduler::cooperative::CooperativeSched;
 use kernel::utilities::registers::interfaces::ReadWriteable;
 use kernel::utilities::StaticRef;
 use kernel::{create_capability, debug, static_init};
@@ -127,7 +126,7 @@ struct LiteXArty {
             >,
         >,
     >,
-    scheduler: &'static CooperativeSched<'static>,
+    scheduler: &'static components::sched::cooperative::SchedulerType,
     scheduler_timer: &'static VirtualSchedulerTimer<
         VirtualMuxAlarm<
             'static,
@@ -163,7 +162,7 @@ impl KernelResources<litex_vexriscv::chip::LiteXVexRiscv<LiteXArtyInterruptableP
     type SyscallDriverLookup = Self;
     type SyscallFilter = ();
     type ProcessFault = ();
-    type Scheduler = CooperativeSched<'static>;
+    type Scheduler = components::sched::cooperative::SchedulerType;
     type SchedulerTimer = VirtualSchedulerTimer<
         VirtualMuxAlarm<
             'static,

--- a/boards/litex/sim/src/main.rs
+++ b/boards/litex/sim/src/main.rs
@@ -14,7 +14,6 @@ use kernel::hil::time::{Alarm, Timer};
 use kernel::platform::chip::InterruptService;
 use kernel::platform::scheduler_timer::VirtualSchedulerTimer;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
-use kernel::scheduler::cooperative::CooperativeSched;
 use kernel::utilities::registers::interfaces::ReadWriteable;
 use kernel::utilities::StaticRef;
 use kernel::{create_capability, debug, static_init};
@@ -141,7 +140,7 @@ struct LiteXSim {
         >,
     >,
     ipc: kernel::ipc::IPC<NUM_PROCS>,
-    scheduler: &'static CooperativeSched<'static>,
+    scheduler: &'static components::sched::cooperative::SchedulerType,
     scheduler_timer: &'static VirtualSchedulerTimer<
         VirtualMuxAlarm<
             'static,
@@ -180,7 +179,7 @@ impl KernelResources<litex_vexriscv::chip::LiteXVexRiscv<LiteXSimInterruptablePe
     type SyscallDriverLookup = Self;
     type SyscallFilter = ();
     type ProcessFault = ();
-    type Scheduler = CooperativeSched<'static>;
+    type Scheduler = components::sched::cooperative::SchedulerType;
     type SchedulerTimer = VirtualSchedulerTimer<
         VirtualMuxAlarm<
             'static,

--- a/boards/microbit_v2/src/main.rs
+++ b/boards/microbit_v2/src/main.rs
@@ -13,7 +13,6 @@ use kernel::component::Component;
 use kernel::dynamic_deferred_call::{DynamicDeferredCall, DynamicDeferredCallClientState};
 use kernel::hil::time::Counter;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
-use kernel::scheduler::round_robin::RoundRobinSched;
 
 #[allow(unused_imports)]
 use kernel::{create_capability, debug, debug_gpio, debug_verbose, static_init};
@@ -110,7 +109,7 @@ pub struct MicroBit {
     app_flash: &'static capsules::app_flash_driver::AppFlash<'static>,
     sound_pressure: &'static capsules::sound_pressure::SoundPressureSensor<'static>,
 
-    scheduler: &'static RoundRobinSched<'static>,
+    scheduler: &'static components::sched::round_robin::SchedulerType,
     systick: cortexm4::systick::SysTick,
 }
 
@@ -146,7 +145,7 @@ impl KernelResources<nrf52833::chip::NRF52<'static, Nrf52833DefaultPeripherals<'
     type SyscallDriverLookup = Self;
     type SyscallFilter = ();
     type ProcessFault = ();
-    type Scheduler = RoundRobinSched<'static>;
+    type Scheduler = components::sched::round_robin::SchedulerType;
     type SchedulerTimer = cortexm4::systick::SysTick;
     type WatchDog = ();
     type ContextSwitchCallback = ();

--- a/boards/msp_exp432p401r/src/main.rs
+++ b/boards/msp_exp432p401r/src/main.rs
@@ -15,7 +15,6 @@ use kernel::dynamic_deferred_call::DynamicDeferredCall;
 use kernel::dynamic_deferred_call::DynamicDeferredCallClientState;
 use kernel::hil::gpio::Configure;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
-use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::{create_capability, debug, static_init};
 
 /// Support routines for debugging I/O.
@@ -60,7 +59,7 @@ struct MspExp432P401R {
     ipc: kernel::ipc::IPC<NUM_PROCS>,
     adc: &'static capsules::adc::AdcDedicated<'static, msp432::adc::Adc<'static>>,
     wdt: &'static msp432::wdt::Wdt,
-    scheduler: &'static RoundRobinSched<'static>,
+    scheduler: &'static components::sched::round_robin::SchedulerType,
     systick: cortexm4::systick::SysTick,
 }
 
@@ -70,7 +69,7 @@ impl KernelResources<msp432::chip::Msp432<'static, msp432::chip::Msp432DefaultPe
     type SyscallDriverLookup = Self;
     type SyscallFilter = ();
     type ProcessFault = ();
-    type Scheduler = RoundRobinSched<'static>;
+    type Scheduler = components::sched::round_robin::SchedulerType;
     type SchedulerTimer = cortexm4::systick::SysTick;
     type WatchDog = msp432::wdt::Wdt;
     type ContextSwitchCallback = ();

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -23,7 +23,6 @@ use kernel::hil::usb::Client;
 use kernel::platform::chip::Chip;
 use kernel::platform::mpu::MPU;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
-use kernel::scheduler::round_robin::RoundRobinSched;
 #[allow(unused_imports)]
 use kernel::{create_capability, debug, debug_gpio, debug_verbose, static_init};
 
@@ -147,7 +146,7 @@ pub struct Platform {
         capsules::virtual_alarm::VirtualMuxAlarm<'static, nrf52::rtc::Rtc<'static>>,
     >,
     udp_driver: &'static capsules::net::udp::UDPDriver<'static>,
-    scheduler: &'static RoundRobinSched<'static>,
+    scheduler: &'static components::sched::round_robin::SchedulerType,
     systick: cortexm4::systick::SysTick,
 }
 
@@ -181,7 +180,7 @@ impl KernelResources<nrf52::chip::NRF52<'static, Nrf52840DefaultPeripherals<'sta
     type SyscallDriverLookup = Self;
     type SyscallFilter = ();
     type ProcessFault = ();
-    type Scheduler = RoundRobinSched<'static>;
+    type Scheduler = components::sched::round_robin::SchedulerType;
     type SchedulerTimer = cortexm4::systick::SysTick;
     type WatchDog = ();
     type ContextSwitchCallback = ();

--- a/boards/nano_rp2040_connect/src/main.rs
+++ b/boards/nano_rp2040_connect/src/main.rs
@@ -20,7 +20,6 @@ use kernel::debug;
 use kernel::dynamic_deferred_call::{DynamicDeferredCall, DynamicDeferredCallClientState};
 use kernel::hil::led::LedHigh;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
-use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::syscall::SyscallDriver;
 use kernel::{capabilities, create_capability, static_init, Kernel};
 use rp2040;
@@ -78,7 +77,7 @@ pub struct NanoRP2040Connect {
     ninedof: &'static capsules::ninedof::NineDof<'static>,
     lsm6dsoxtr: &'static capsules::lsm6dsoxtr::Lsm6dsoxtrI2C<'static>,
 
-    scheduler: &'static RoundRobinSched<'static>,
+    scheduler: &'static components::sched::round_robin::SchedulerType,
     systick: cortexm0p::systick::SysTick,
 }
 
@@ -106,7 +105,7 @@ impl KernelResources<Rp2040<'static, Rp2040DefaultPeripherals<'static>>> for Nan
     type SyscallDriverLookup = Self;
     type SyscallFilter = ();
     type ProcessFault = ();
-    type Scheduler = RoundRobinSched<'static>;
+    type Scheduler = components::sched::round_robin::SchedulerType;
     type SchedulerTimer = cortexm0p::systick::SysTick;
     type WatchDog = ();
     type ContextSwitchCallback = ();

--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -17,7 +17,6 @@ use kernel::hil::led::LedLow;
 use kernel::hil::symmetric_encryption::AES128;
 use kernel::hil::time::Counter;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
-use kernel::scheduler::round_robin::RoundRobinSched;
 #[allow(unused_imports)]
 use kernel::{capabilities, create_capability, debug, debug_gpio, debug_verbose, static_init};
 use nrf52840::gpio::Pin;
@@ -103,7 +102,7 @@ pub struct Platform {
         'static,
         capsules::virtual_alarm::VirtualMuxAlarm<'static, nrf52840::rtc::Rtc<'static>>,
     >,
-    scheduler: &'static RoundRobinSched<'static>,
+    scheduler: &'static components::sched::round_robin::SchedulerType,
     systick: cortexm4::systick::SysTick,
 }
 
@@ -135,7 +134,7 @@ impl KernelResources<nrf52840::chip::NRF52<'static, Nrf52840DefaultPeripherals<'
     type SyscallDriverLookup = Self;
     type SyscallFilter = ();
     type ProcessFault = ();
-    type Scheduler = RoundRobinSched<'static>;
+    type Scheduler = components::sched::round_robin::SchedulerType;
     type SchedulerTimer = cortexm4::systick::SysTick;
     type WatchDog = ();
     type ContextSwitchCallback = ();

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -83,7 +83,6 @@ use kernel::hil::time::Counter;
 #[allow(unused_imports)]
 use kernel::hil::usb::Client;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
-use kernel::scheduler::round_robin::RoundRobinSched;
 #[allow(unused_imports)]
 use kernel::{capabilities, create_capability, debug, debug_gpio, debug_verbose, static_init};
 use nrf52840::gpio::Pin;
@@ -193,7 +192,7 @@ pub struct Platform {
         'static,
         capsules::virtual_spi::VirtualSpiMasterDevice<'static, nrf52840::spi::SPIM>,
     >,
-    scheduler: &'static RoundRobinSched<'static>,
+    scheduler: &'static components::sched::round_robin::SchedulerType,
     systick: cortexm4::systick::SysTick,
 }
 
@@ -243,7 +242,7 @@ impl KernelResources<nrf52840::chip::NRF52<'static, Nrf52840DefaultPeripherals<'
     type SyscallDriverLookup = Self;
     type SyscallFilter = ();
     type ProcessFault = ();
-    type Scheduler = RoundRobinSched<'static>;
+    type Scheduler = components::sched::round_robin::SchedulerType;
     type SchedulerTimer = cortexm4::systick::SysTick;
     type WatchDog = ();
     type ContextSwitchCallback = ();

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -72,7 +72,6 @@ use kernel::dynamic_deferred_call::{DynamicDeferredCall, DynamicDeferredCallClie
 use kernel::hil::led::LedLow;
 use kernel::hil::time::Counter;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
-use kernel::scheduler::round_robin::RoundRobinSched;
 #[allow(unused_imports)]
 use kernel::{capabilities, create_capability, debug, debug_gpio, debug_verbose, static_init};
 use nrf52832::gpio::Pin;
@@ -161,7 +160,7 @@ pub struct Platform {
         'static,
         capsules::virtual_alarm::VirtualMuxAlarm<'static, nrf52832::rtc::Rtc<'static>>,
     >,
-    scheduler: &'static RoundRobinSched<'static>,
+    scheduler: &'static components::sched::round_robin::SchedulerType,
     systick: cortexm4::systick::SysTick,
 }
 
@@ -192,7 +191,7 @@ impl KernelResources<nrf52832::chip::NRF52<'static, Nrf52832DefaultPeripherals<'
     type SyscallDriverLookup = Self;
     type SyscallFilter = ();
     type ProcessFault = ();
-    type Scheduler = RoundRobinSched<'static>;
+    type Scheduler = components::sched::round_robin::SchedulerType;
     type SchedulerTimer = cortexm4::systick::SysTick;
     type WatchDog = ();
     type ContextSwitchCallback = ();

--- a/boards/nucleo_f429zi/src/main.rs
+++ b/boards/nucleo_f429zi/src/main.rs
@@ -15,7 +15,6 @@ use kernel::component::Component;
 use kernel::dynamic_deferred_call::{DynamicDeferredCall, DynamicDeferredCallClientState};
 use kernel::hil::led::LedHigh;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
-use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::{create_capability, debug, static_init};
 
 use stm32f429zi::gpio::{AlternateFunction, Mode, PinId, PortId};
@@ -62,7 +61,7 @@ struct NucleoF429ZI {
     temperature: &'static capsules::temperature::TemperatureSensor<'static>,
     gpio: &'static capsules::gpio::GPIO<'static, stm32f429zi::gpio::Pin<'static>>,
 
-    scheduler: &'static RoundRobinSched<'static>,
+    scheduler: &'static components::sched::round_robin::SchedulerType,
     systick: cortexm4::systick::SysTick,
 }
 
@@ -97,7 +96,7 @@ impl
     type SyscallDriverLookup = Self;
     type SyscallFilter = ();
     type ProcessFault = ();
-    type Scheduler = RoundRobinSched<'static>;
+    type Scheduler = components::sched::round_robin::SchedulerType;
     type SchedulerTimer = cortexm4::systick::SysTick;
     type WatchDog = ();
     type ContextSwitchCallback = ();

--- a/boards/nucleo_f446re/src/main.rs
+++ b/boards/nucleo_f446re/src/main.rs
@@ -15,7 +15,6 @@ use kernel::dynamic_deferred_call::{DynamicDeferredCall, DynamicDeferredCallClie
 use kernel::hil::gpio::Configure;
 use kernel::hil::led::LedHigh;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
-use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::{create_capability, debug, static_init};
 use stm32f446re::interrupt_service::Stm32f446reDefaultPeripherals;
 
@@ -63,7 +62,7 @@ struct NucleoF446RE {
         VirtualMuxAlarm<'static, stm32f446re::tim2::Tim2<'static>>,
     >,
 
-    scheduler: &'static RoundRobinSched<'static>,
+    scheduler: &'static components::sched::round_robin::SchedulerType,
     systick: cortexm4::systick::SysTick,
 }
 
@@ -95,7 +94,7 @@ impl
     type SyscallDriverLookup = Self;
     type SyscallFilter = ();
     type ProcessFault = ();
-    type Scheduler = RoundRobinSched<'static>;
+    type Scheduler = components::sched::round_robin::SchedulerType;
     type SchedulerTimer = cortexm4::systick::SysTick;
     type WatchDog = ();
     type ContextSwitchCallback = ();

--- a/boards/pico_explorer_base/src/main.rs
+++ b/boards/pico_explorer_base/src/main.rs
@@ -21,7 +21,6 @@ use kernel::component::Component;
 use kernel::debug;
 use kernel::hil::led::LedHigh;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
-use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::{capabilities, create_capability, static_init, Kernel};
 use rp2040;
 
@@ -81,7 +80,7 @@ pub struct PicoExplorerBase {
     button: &'static capsules::button::Button<'static, RPGpioPin<'static>>,
     screen: &'static capsules::screen::Screen<'static>,
 
-    scheduler: &'static RoundRobinSched<'static>,
+    scheduler: &'static components::sched::round_robin::SchedulerType,
     systick: cortexm0p::systick::SysTick,
 }
 
@@ -111,7 +110,7 @@ impl KernelResources<Rp2040<'static, Rp2040DefaultPeripherals<'static>>> for Pic
     type SyscallDriverLookup = Self;
     type SyscallFilter = ();
     type ProcessFault = ();
-    type Scheduler = RoundRobinSched<'static>;
+    type Scheduler = components::sched::round_robin::SchedulerType;
     type SchedulerTimer = cortexm0p::systick::SysTick;
     type WatchDog = ();
     type ContextSwitchCallback = ();

--- a/boards/raspberry_pi_pico/src/main.rs
+++ b/boards/raspberry_pi_pico/src/main.rs
@@ -23,7 +23,6 @@ use kernel::hil::gpio::{Configure, FloatingState};
 use kernel::hil::i2c::I2CMaster;
 use kernel::hil::led::LedHigh;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
-use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::syscall::SyscallDriver;
 use kernel::{capabilities, create_capability, static_init, Kernel};
 
@@ -82,7 +81,7 @@ pub struct RaspberryPiPico {
     temperature: &'static capsules::temperature::TemperatureSensor<'static>,
     i2c: &'static capsules::i2c_master::I2CMasterDriver<'static, I2c<'static>>,
 
-    scheduler: &'static RoundRobinSched<'static>,
+    scheduler: &'static components::sched::round_robin::SchedulerType,
     systick: cortexm0p::systick::SysTick,
 }
 
@@ -109,7 +108,7 @@ impl KernelResources<Rp2040<'static, Rp2040DefaultPeripherals<'static>>> for Ras
     type SyscallDriverLookup = Self;
     type SyscallFilter = ();
     type ProcessFault = ();
-    type Scheduler = RoundRobinSched<'static>;
+    type Scheduler = components::sched::round_robin::SchedulerType;
     type SchedulerTimer = cortexm0p::systick::SysTick;
     type WatchDog = ();
     type ContextSwitchCallback = ();

--- a/boards/redboard_artemis_nano/src/main.rs
+++ b/boards/redboard_artemis_nano/src/main.rs
@@ -18,7 +18,6 @@ use kernel::hil::i2c::I2CMaster;
 use kernel::hil::led::LedHigh;
 use kernel::hil::time::Counter;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
-use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::{create_capability, debug, static_init};
 
 pub mod ble;
@@ -64,7 +63,7 @@ struct RedboardArtemisNano {
         apollo3::ble::Ble<'static>,
         VirtualMuxAlarm<'static, apollo3::stimer::STimer<'static>>,
     >,
-    scheduler: &'static RoundRobinSched<'static>,
+    scheduler: &'static components::sched::round_robin::SchedulerType,
     systick: cortexm4::systick::SysTick,
 }
 
@@ -90,7 +89,7 @@ impl KernelResources<apollo3::chip::Apollo3<Apollo3DefaultPeripherals>> for Redb
     type SyscallDriverLookup = Self;
     type SyscallFilter = ();
     type ProcessFault = ();
-    type Scheduler = RoundRobinSched<'static>;
+    type Scheduler = components::sched::round_robin::SchedulerType;
     type SchedulerTimer = cortexm4::systick::SysTick;
     type WatchDog = ();
     type ContextSwitchCallback = ();

--- a/boards/redboard_redv/src/main.rs
+++ b/boards/redboard_redv/src/main.rs
@@ -18,7 +18,6 @@ use kernel::hil;
 use kernel::hil::led::LedLow;
 use kernel::platform::scheduler_timer::VirtualSchedulerTimer;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
-use kernel::scheduler::cooperative::CooperativeSched;
 use kernel::utilities::registers::interfaces::ReadWriteable;
 use kernel::{create_capability, debug, static_init};
 use rv32i::csr;
@@ -62,7 +61,7 @@ struct RedV {
         'static,
         VirtualMuxAlarm<'static, sifive::clint::Clint<'static>>,
     >,
-    scheduler: &'static CooperativeSched<'static>,
+    scheduler: &'static components::sched::cooperative::SchedulerType,
     scheduler_timer:
         &'static VirtualSchedulerTimer<VirtualMuxAlarm<'static, sifive::clint::Clint<'static>>>,
 }
@@ -87,7 +86,7 @@ impl KernelResources<e310x::chip::E310x<'static, E310xDefaultPeripherals<'static
     type SyscallDriverLookup = Self;
     type SyscallFilter = ();
     type ProcessFault = ();
-    type Scheduler = CooperativeSched<'static>;
+    type Scheduler = components::sched::cooperative::SchedulerType;
     type SchedulerTimer =
         VirtualSchedulerTimer<VirtualMuxAlarm<'static, sifive::clint::Clint<'static>>>;
     type WatchDog = ();

--- a/boards/stm32f3discovery/src/main.rs
+++ b/boards/stm32f3discovery/src/main.rs
@@ -19,7 +19,6 @@ use kernel::hil::gpio::Output;
 use kernel::hil::led::LedHigh;
 use kernel::hil::time::Counter;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
-use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::{create_capability, debug, static_init};
 use stm32f303xc::chip::Stm32f3xxDefaultPeripherals;
 use stm32f303xc::wdt;
@@ -74,7 +73,7 @@ struct STM32F3Discovery {
     adc: &'static capsules::adc::AdcVirtualized<'static>,
     nonvolatile_storage: &'static capsules::nonvolatile_storage_driver::NonvolatileStorage<'static>,
 
-    scheduler: &'static RoundRobinSched<'static>,
+    scheduler: &'static components::sched::round_robin::SchedulerType,
     systick: cortexm4::systick::SysTick,
     watchdog: &'static wdt::WindoWdg<'static>,
 }
@@ -114,7 +113,7 @@ impl
     type SyscallDriverLookup = Self;
     type SyscallFilter = ();
     type ProcessFault = ();
-    type Scheduler = RoundRobinSched<'static>;
+    type Scheduler = components::sched::round_robin::SchedulerType;
     type SchedulerTimer = cortexm4::systick::SysTick;
     type WatchDog = wdt::WindoWdg<'static>;
     type ContextSwitchCallback = ();

--- a/boards/stm32f412gdiscovery/src/main.rs
+++ b/boards/stm32f412gdiscovery/src/main.rs
@@ -17,7 +17,6 @@ use kernel::hil::gpio;
 use kernel::hil::led::LedLow;
 use kernel::hil::screen::ScreenRotation;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
-use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::{create_capability, debug, static_init};
 use stm32f412g::interrupt_service::Stm32f412gDefaultPeripherals;
 
@@ -64,7 +63,7 @@ struct STM32F412GDiscovery {
     temperature: &'static capsules::temperature::TemperatureSensor<'static>,
     rng: &'static capsules::rng::RngDriver<'static>,
 
-    scheduler: &'static RoundRobinSched<'static>,
+    scheduler: &'static components::sched::round_robin::SchedulerType,
     systick: cortexm4::systick::SysTick,
 }
 
@@ -102,7 +101,7 @@ impl
     type SyscallDriverLookup = Self;
     type SyscallFilter = ();
     type ProcessFault = ();
-    type Scheduler = RoundRobinSched<'static>;
+    type Scheduler = components::sched::round_robin::SchedulerType;
     type SchedulerTimer = cortexm4::systick::SysTick;
     type WatchDog = ();
     type ContextSwitchCallback = ();

--- a/boards/stm32f429idiscovery/src/main.rs
+++ b/boards/stm32f429idiscovery/src/main.rs
@@ -15,7 +15,6 @@ use kernel::component::Component;
 use kernel::dynamic_deferred_call::{DynamicDeferredCall, DynamicDeferredCallClientState};
 use kernel::hil::led::LedHigh;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
-use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::{create_capability, debug, static_init};
 
 use stm32f429zi::gpio::{AlternateFunction, Mode, PinId, PortId};
@@ -62,7 +61,7 @@ struct STM32F429IDiscovery {
     temperature: &'static capsules::temperature::TemperatureSensor<'static>,
     gpio: &'static capsules::gpio::GPIO<'static, stm32f429zi::gpio::Pin<'static>>,
 
-    scheduler: &'static RoundRobinSched<'static>,
+    scheduler: &'static components::sched::round_robin::SchedulerType,
     systick: cortexm4::systick::SysTick,
 }
 
@@ -97,7 +96,7 @@ impl
     type SyscallDriverLookup = Self;
     type SyscallFilter = ();
     type ProcessFault = ();
-    type Scheduler = RoundRobinSched<'static>;
+    type Scheduler = components::sched::round_robin::SchedulerType;
     type SchedulerTimer = cortexm4::systick::SysTick;
     type WatchDog = ();
     type ContextSwitchCallback = ();

--- a/boards/swervolf/src/main.rs
+++ b/boards/swervolf/src/main.rs
@@ -14,7 +14,6 @@ use kernel::component::Component;
 use kernel::dynamic_deferred_call::{DynamicDeferredCall, DynamicDeferredCallClientState};
 use kernel::hil;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
-use kernel::scheduler::cooperative::CooperativeSched;
 use kernel::utilities::registers::interfaces::ReadWriteable;
 use kernel::{create_capability, debug, static_init};
 use rv32i::csr;
@@ -50,7 +49,7 @@ struct SweRVolf {
         'static,
         VirtualMuxAlarm<'static, swervolf_eh1::syscon::SysCon<'static>>,
     >,
-    scheduler: &'static CooperativeSched<'static>,
+    scheduler: &'static components::sched::cooperative::SchedulerType,
     scheduler_timer: &'static swerv::eh1_timer::Timer<'static>,
 }
 
@@ -74,7 +73,7 @@ impl KernelResources<swervolf_eh1::chip::SweRVolf<'static, SweRVolfDefaultPeriph
     type SyscallDriverLookup = Self;
     type SyscallFilter = ();
     type ProcessFault = ();
-    type Scheduler = CooperativeSched<'static>;
+    type Scheduler = components::sched::cooperative::SchedulerType;
     type SchedulerTimer = swerv::eh1_timer::Timer<'static>;
     type WatchDog = ();
     type ContextSwitchCallback = ();

--- a/boards/teensy40/src/main.rs
+++ b/boards/teensy40/src/main.rs
@@ -19,7 +19,6 @@ use kernel::dynamic_deferred_call::{DynamicDeferredCall, DynamicDeferredCallClie
 use kernel::hil::{gpio::Configure, led::LedHigh};
 use kernel::platform::chip::ClockInterface;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
-use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::{create_capability, static_init};
 
 /// Number of concurrent processes this platform supports
@@ -46,7 +45,7 @@ struct Teensy40 {
         capsules::virtual_alarm::VirtualMuxAlarm<'static, imxrt1060::gpt::Gpt1<'static>>,
     >,
 
-    scheduler: &'static RoundRobinSched<'static>,
+    scheduler: &'static components::sched::round_robin::SchedulerType,
     systick: cortexm7::systick::SysTick,
 }
 
@@ -71,7 +70,7 @@ impl KernelResources<imxrt1060::chip::Imxrt10xx<imxrt1060::chip::Imxrt10xxDefaul
     type SyscallDriverLookup = Self;
     type SyscallFilter = ();
     type ProcessFault = ();
-    type Scheduler = RoundRobinSched<'static>;
+    type Scheduler = components::sched::round_robin::SchedulerType;
     type SchedulerTimer = cortexm7::systick::SysTick;
     type WatchDog = ();
     type ContextSwitchCallback = ();

--- a/boards/weact_f401ccu6/src/main.rs
+++ b/boards/weact_f401ccu6/src/main.rs
@@ -15,7 +15,6 @@ use kernel::component::Component;
 use kernel::dynamic_deferred_call::{DynamicDeferredCall, DynamicDeferredCallClientState};
 use kernel::hil::led::LedLow;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
-use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::{create_capability, debug, static_init};
 
 use stm32f401cc::interrupt_service::Stm32f401ccDefaultPeripherals;
@@ -59,7 +58,7 @@ struct WeactF401CC {
         VirtualMuxAlarm<'static, stm32f401cc::tim2::Tim2<'static>>,
     >,
     gpio: &'static capsules::gpio::GPIO<'static, stm32f401cc::gpio::Pin<'static>>,
-    scheduler: &'static RoundRobinSched<'static>,
+    scheduler: &'static components::sched::round_robin::SchedulerType,
     systick: cortexm4::systick::SysTick,
 }
 
@@ -88,7 +87,7 @@ impl KernelResources<stm32f401cc::chip::Stm32f4xx<'static, Stm32f401ccDefaultPer
     type SyscallDriverLookup = Self;
     type SyscallFilter = ();
     type ProcessFault = ();
-    type Scheduler = RoundRobinSched<'static>;
+    type Scheduler = components::sched::round_robin::SchedulerType;
     type SchedulerTimer = cortexm4::systick::SysTick;
     type WatchDog = ();
     type ContextSwitchCallback = ();

--- a/capsules/src/virtual_hmac.rs
+++ b/capsules/src/virtual_hmac.rs
@@ -3,7 +3,8 @@
 
 use core::cell::Cell;
 
-use kernel::collections::list::{List, ListLink, ListNode};
+use kernel::collections::list::generic_linked_list::GenericLinkedList;
+use kernel::collections::list::{ListNode, ModifyableListNode, SinglyLinkedList};
 use kernel::hil::digest::{self, ClientHash, ClientVerify};
 use kernel::hil::digest::{ClientData, DigestData};
 use kernel::utilities::cells::{OptionalCell, TakeCell};
@@ -16,7 +17,7 @@ use crate::virtual_digest::{Mode, Operation};
 
 pub struct VirtualMuxHmac<'a, A: digest::Digest<'a, L>, const L: usize> {
     mux: &'a MuxHmac<'a, A, L>,
-    next: ListLink<'a, VirtualMuxHmac<'a, A, L>>,
+    next: Cell<Option<&'a VirtualMuxHmac<'a, A, L>>>,
     client: OptionalCell<&'a dyn digest::Client<L>>,
     key: TakeCell<'static, [u8]>,
     data: OptionalCell<LeasableBufferDynamic<'static, u8>>,
@@ -26,11 +27,23 @@ pub struct VirtualMuxHmac<'a, A: digest::Digest<'a, L>, const L: usize> {
     id: u32,
 }
 
-impl<'a, A: digest::Digest<'a, L>, const L: usize> ListNode<'a, VirtualMuxHmac<'a, A, L>>
+impl<'a, A: digest::Digest<'a, L>, const L: usize> ListNode<'a> for VirtualMuxHmac<'a, A, L> {
+    type Content = Self;
+
+    fn next(&self) -> Option<&'a Self> {
+        self.next.get()
+    }
+
+    fn content<'c>(&'c self) -> &'c Self::Content {
+        self
+    }
+}
+
+impl<'a, A: digest::Digest<'a, L>, const L: usize> ModifyableListNode<'a>
     for VirtualMuxHmac<'a, A, L>
 {
-    fn next(&self) -> &'a ListLink<VirtualMuxHmac<'a, A, L>> {
-        &self.next
+    fn set_next(&self, next: Option<&'a Self>) {
+        self.next.set(next)
     }
 }
 
@@ -44,7 +57,7 @@ impl<'a, A: digest::Digest<'a, L>, const L: usize> VirtualMuxHmac<'a, A, L> {
 
         VirtualMuxHmac {
             mux: mux_hmac,
-            next: ListLink::empty(),
+            next: Cell::new(None),
             client: OptionalCell::empty(),
             key: TakeCell::new(key),
             data: OptionalCell::empty(),
@@ -292,7 +305,7 @@ pub struct MuxHmac<'a, A: digest::Digest<'a, L>, const L: usize> {
     running: Cell<bool>,
     running_id: Cell<u32>,
     next_id: Cell<u32>,
-    users: List<'a, VirtualMuxHmac<'a, A, L>>,
+    users: GenericLinkedList<'a, VirtualMuxHmac<'a, A, L>>,
 }
 
 impl<
@@ -307,7 +320,7 @@ impl<
             running: Cell::new(false),
             running_id: Cell::new(0),
             next_id: Cell::new(0),
-            users: List::new(),
+            users: GenericLinkedList::new(),
         }
     }
 

--- a/kernel/src/collections/list.rs
+++ b/kernel/src/collections/list.rs
@@ -1,77 +1,425 @@
-//! Linked list implementation.
+//! Interfaces to and implementations of linked-list data structures.
+//!
+//! This module contains traits useful for manipulating linked-list
+//! data structures:
+//!
+//! - [`ListNode`], representing a single node in a singly-linked list
+//! - [`SinglyLinkedList`], containing a basic interface to manipulate
+//!   singly-linked list data structures
+//!
+//! Furthermore, it contains some implementations of linked-list data
+//! structures:
+//!
+//! - [`simple_linked_list::SimpleLinkedList`] is a singly-linked list
+//!   implementation which defines its own
+//!   [`SimpleLinkedListNode`](simple_linked_list::SimpleLinkedListNode) node
+//!   type. By defining its own node type it has full control over the list's
+//!   structure and can thereby enforce that the list contains no loops and the
+//!   list nodes cannot dynamically change the inherent list structure. It also
+//!   does not require implementations to provide their own list node type.
+//!
+//! - [`generic_linked_list::GenericLinkedList`] is a singly-list implementation
+//!   generic over the underlying list node type. It requires list nodes to
+//!   implement [`ModifyableListNode`]. Implementations are free to define the
+//!   inherent list behavior through custom implementations of the
+//!   [`ListNode::next`] operator. For example, this type allows to build lazily
+//!   evaluated lists or lists which change on the fly.
 
-use core::cell::Cell;
+/// Node of a singly-linked list.
+///
+/// The implementation of the [`next`](ListNode::next) method defines the
+/// inherent list structure. Thus implementors of this interface should be
+/// careful to avoid building loops in the list, if this is not desired
+/// behavior.
+pub trait ListNode<'a> {
+    type Content: ?Sized;
 
-pub struct ListLink<'a, T: 'a + ?Sized>(Cell<Option<&'a T>>);
+    /// Get a reference to the list node's content
+    ///
+    /// This method is provided for when the ListNode is a container type
+    /// distinct from the content type `C`. Implementations generic over the
+    /// `ListNode` container are thus expected to always call `content` to get a
+    /// reference of type `C`.
+    fn content<'c>(&'c self) -> &'c Self::Content;
 
-impl<'a, T: ?Sized> ListLink<'a, T> {
-    pub const fn empty() -> ListLink<'a, T> {
-        ListLink(Cell::new(None))
+    /// Get a reference to the next list node
+    ///
+    /// Implementors must be careful to avoid building loops in the list, if
+    /// this is not desired.
+    ///
+    /// The call to [`next`](ListNode::next) may be used to allocate the next
+    /// list element dynamically.
+    fn next(&'a self) -> Option<&'a Self>;
+}
+
+/// Modifyable node of a singly-linked list.
+///
+/// This trait is a subtrait of [`ListNode`]. It can be used to allow external
+/// modification of the list's structure.
+pub trait ModifyableListNode<'a>: ListNode<'a> {
+    /// Set the next list element.
+    ///
+    /// Implementations MUST ensure the that next list element (returned on the
+    /// call to [`next`](ListNode::next)) is the passed in reference, or `None`
+    /// if the supplied `next` is `None`.
+    fn set_next(&'a self, next: Option<&'a Self>);
+}
+
+/// Iterator over a list consisting of [`ListNode`]s.
+///
+/// Iterates over a chain of list nodes, returning their contents. Per
+/// iteration, this calls [`next`](ListNode::next) and
+/// [`content`](ListNode::content) for each visited list node.
+pub struct ListIterator<'a, L: ListNode<'a>> {
+    cur: Option<&'a L>,
+}
+
+impl<'a, L: ListNode<'a>> Iterator for ListIterator<'a, L> {
+    type Item = &'a L::Content;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(node) = self.cur {
+            self.cur = node.next();
+            Some(node.content())
+        } else {
+            None
+        }
     }
 }
 
-pub trait ListNode<'a, T: ?Sized> {
-    fn next(&'a self) -> &'a ListLink<'a, T>;
+/// Interface to a singly-linked list
+pub trait SinglyLinkedList<'a, L: ListNode<'a>> {
+    /// Get a reference to the first list element
+    ///
+    /// If the list is not empty, return a reference to the first list
+    /// node. Otherwise returns `None`.
+    fn head(&self) -> Option<&'a L>;
+
+    /// Construct a [`ListIterator`], starting with the list head
+    fn iter(&self) -> ListIterator<'a, L>;
+
+    /// Prepend a [`ListNode`] to the list
+    ///
+    /// Prepends the passed [`ListNode`] in front of the list's head.
+    ///
+    /// Implementations are free to refuse this call, for instance when it would
+    /// create a loop in the list. If the call is refused this method returns
+    /// `false`, otherwise `true`.
+    ///
+    /// This method may modify the passed [`ListNode`]'s `next` value, either
+    /// through an internal mechanism or through
+    /// [`ModifyableListNode::set_next`]. It will not modify the [`ListNode`]'s
+    /// `next` value if the call is refused, indicated by a return value of
+    /// `false.
+    ///
+    /// This method may walk the entire list by calling [`ListNode::next`] on
+    /// each element, to perform internal consistency checks.
+    fn push_head(&self, node: &'a L) -> bool;
+
+    /// Append a [`ListNode`] to the list.
+    ///
+    /// Appends the passed [`ListNode`] after the last list element. To find the
+    /// last list element, this method will walk the entire list by calling
+    /// [`ListNode::next`] on each element.
+    ///
+    /// Implementations are free to refuse this call, for instance when it would
+    /// create a loop in the list. If the call is refused this method returns
+    /// `false`, otherwise `true`.
+    ///
+    /// This method may modify the passed [`ListNode`]'s `next` value, either
+    /// through an internal mechanism or through
+    /// [`ModifyableListNode::set_next`]. It will not modify the [`ListNode`]'s
+    /// `next` value if the call is refused, indicated by a return value of
+    /// `false.
+    fn push_tail(&self, node: &'a L) -> bool;
+
+    /// Remove and return the first [`ListNode`].
+    ///
+    /// Removes the first [`ListNode`] in the list. Implementations should not
+    /// walk the list for this operation.
+    ///
+    /// Returns the removed [`ListNode`] if the list was not empty, otherwise
+    /// `None`.
+    fn pop_head(&self) -> Option<&'a L>;
 }
 
-pub struct List<'a, T: 'a + ?Sized + ListNode<'a, T>> {
-    head: ListLink<'a, T>,
-}
+pub mod generic_linked_list {
+    //! Module containing a singly-list implementation generic over the
+    //! underlying list node type. It requires list nodes to implement
+    //! [`ModifyableListNode`]. Implementations are free to define the inherent
+    //! list behavior through custom implementations of the
+    //! [`ListNode::next`](super::ListNode::next) operator. For example, this
+    //! type allows to build lazily evaluated lists or lists which change on the
+    //! fly.
 
-pub struct ListIterator<'a, T: 'a + ?Sized + ListNode<'a, T>> {
-    cur: Option<&'a T>,
-}
+    use core::cell::Cell;
 
-impl<'a, T: ?Sized + ListNode<'a, T>> Iterator for ListIterator<'a, T> {
-    type Item = &'a T;
+    use super::{ListIterator, ModifyableListNode, SinglyLinkedList};
 
-    fn next(&mut self) -> Option<&'a T> {
-        match self.cur {
-            Some(res) => {
-                self.cur = res.next().0.get();
-                Some(res)
+    /// Singly-linked list generic over the underlying [`ModifyableListNode`] type.
+    ///
+    /// This singly-linked list implementation can be used to build
+    /// highly-flexible linked-list like data structures. By being generic over
+    /// the underlying [`ListNode`](super::ListNode) type, implementations can,
+    /// for example, determine the list's structure dynamically at runtime or
+    /// lazily allocate and evaluate the list's contents.
+    ///
+    /// This list type requires it's nodes to implement
+    /// [`ModifyableListNode`]. This is required such that the
+    /// [`GenericLinkedList`] can manipulate the list structure through the
+    /// generic list nodes.
+    ///
+    /// This list type does not implement any internal consistency checks. Users
+    /// must be careful to avoid building loops if this is not desired. A call
+    /// to [`push_tail`](GenericLinkedList) will iterate over the entire
+    /// list. In case of a looping list structure, this may thus recurse
+    /// infinitely.
+    pub struct GenericLinkedList<'a, L: ModifyableListNode<'a>> {
+        head: Cell<Option<&'a L>>,
+    }
+
+    impl<'a, L: ModifyableListNode<'a>> GenericLinkedList<'a, L> {
+        pub const fn new() -> GenericLinkedList<'a, L> {
+            GenericLinkedList {
+                head: Cell::new(None),
             }
-            None => None,
+        }
+    }
+
+    impl<'a, L: ModifyableListNode<'a>> SinglyLinkedList<'a, L> for GenericLinkedList<'a, L> {
+        fn head(&self) -> Option<&'a L> {
+            self.head.get()
+        }
+
+        fn iter(&self) -> ListIterator<'a, L> {
+            ListIterator {
+                cur: self.head.get(),
+            }
+        }
+
+        fn push_head(&self, node: &'a L) -> bool {
+            node.set_next(self.head.get());
+            self.head.set(Some(node));
+            true
+        }
+
+        fn push_tail(&self, node: &'a L) -> bool {
+            if let Some(current_head) = self.head.get() {
+                let mut current_node = current_head;
+
+                // Iterate through all list nodes in the chain. Cheaper than a
+                // recursive implementation. This emulates a do-while loop,
+                // which isn't directly supported in Rust.
+                while {
+                    if let Some(next_node) = current_node.next() {
+                        current_node = next_node;
+                        true
+                    } else {
+                        false
+                    }
+                } {}
+
+                current_node.set_next(Some(node));
+            } else {
+                self.head.set(Some(node));
+            }
+
+            // This method will always succeed, there are no intern
+            true
+        }
+
+        fn pop_head(&self) -> Option<&'a L> {
+            if let Some(current_head) = self.head.get() {
+                self.head.set(current_head.next());
+                Some(current_head)
+            } else {
+                None
+            }
         }
     }
 }
 
-impl<'a, T: ?Sized + ListNode<'a, T>> List<'a, T> {
-    pub const fn new() -> List<'a, T> {
-        List {
-            head: ListLink(Cell::new(None)),
+pub mod simple_linked_list {
+    //! Module containing a simple singly-list implementation . It defines and
+    //! requires usage of its own [`SimpleLinkedListNode`], which help to
+    //! maintain internal consistency within the list. Thus, this implementation
+    //! does not support loops within the list, and the
+    //! [`ListNode::content`](super::ListNode::content) and
+    //! [`ListNode::next`](super::ListNode::content) methods cannot be
+    //! overwritten. These constraints make the behavior of this list
+    //! implementation very predictable.
+
+    use core::cell::Cell;
+
+    use super::{ListIterator, ListNode, SinglyLinkedList};
+
+    /// Outgoing link of a [`SimpleLinkedListNode`]
+    ///
+    /// This enum can represent that the list node is not currently part of any
+    /// list (`None`), it is the end of list of which it is a member (`End`), or
+    /// it is followed by a successor element `Some(ref)`.
+    enum SimpleLinkedListNodeLink<'a, C> {
+        None,
+        End,
+        Next(&'a SimpleLinkedListNode<'a, C>),
+    }
+
+    // #[derive(Copy, Clone)] does not work here, because that macro cannot
+    // infer that C: Clone + Copy is not a requirement for
+    // SimpleLinkedListNodeLink<'_, C>: Clone + Copy.
+    impl<'a, C> Clone for SimpleLinkedListNodeLink<'a, C> {
+        fn clone(&self) -> Self {
+            *self
+        }
+    }
+    impl<'a, C> Copy for SimpleLinkedListNodeLink<'a, C> {}
+
+    impl<'a, C> core::cmp::PartialEq for SimpleLinkedListNodeLink<'a, C> {
+        fn eq(&self, other: &Self) -> bool {
+            match (self, other) {
+                (SimpleLinkedListNodeLink::None, SimpleLinkedListNodeLink::None) => true,
+                (SimpleLinkedListNodeLink::End, SimpleLinkedListNodeLink::End) => true,
+                (SimpleLinkedListNodeLink::Next(ref_a), SimpleLinkedListNodeLink::Next(ref_b)) => {
+                    *ref_a as *const SimpleLinkedListNode<'a, C>
+                        == *ref_b as *const SimpleLinkedListNode<'a, C>
+                }
+                _ => false,
+            }
+        }
+    }
+    impl<'a, C> core::cmp::Eq for SimpleLinkedListNodeLink<'a, C> {}
+
+    /// Node of a [`SimpleLinkedList`]
+    ///
+    /// A node which can be part of a [`SimpleLinkedList`]. It holds an
+    /// arbitrary, sized generic type `C`. A reference to this value is provided
+    /// by calling [`ListNode::content`].
+    ///
+    /// The inner `link` field can only be modified through operations on the
+    /// [`SimpleLinkedList`].
+    pub struct SimpleLinkedListNode<'a, C> {
+        content: C,
+        link: Cell<SimpleLinkedListNodeLink<'a, C>>,
+    }
+
+    impl<'a, C> SimpleLinkedListNode<'a, C> {
+        pub fn new(content: C) -> SimpleLinkedListNode<'a, C> {
+            SimpleLinkedListNode {
+                content,
+                link: Cell::new(SimpleLinkedListNodeLink::None),
+            }
         }
     }
 
-    pub fn head(&self) -> Option<&'a T> {
-        self.head.0.get()
-    }
+    impl<'a, C> ListNode<'a> for SimpleLinkedListNode<'a, C> {
+        type Content = C;
 
-    pub fn push_head(&self, node: &'a T) {
-        node.next().0.set(self.head.0.get());
-        self.head.0.set(Some(node));
-    }
+        fn content<'c>(&'c self) -> &'c C {
+            &self.content
+        }
 
-    pub fn push_tail(&self, node: &'a T) {
-        node.next().0.set(None);
-        match self.iter().last() {
-            Some(last) => last.next().0.set(Some(node)),
-            None => self.push_head(node),
+        fn next(&'a self) -> Option<&'a Self> {
+            match self.link.get() {
+                SimpleLinkedListNodeLink::Next(next_node) => Some(next_node),
+                _ => None,
+            }
         }
     }
 
-    pub fn pop_head(&self) -> Option<&'a T> {
-        let remove = self.head.0.get();
-        match remove {
-            Some(node) => self.head.0.set(node.next().0.get()),
-            None => self.head.0.set(None),
-        }
-        remove
+    /// Simple singly-linked list.
+    ///
+    /// This type implements a conceptually simple linked-list data
+    /// structure. This is achieved by using a custom type for the list nodes,
+    /// which helps to maintain internal consistency of the list. Thus this
+    /// implementation does not allow loops within the list, and the
+    /// [`ListNode::content`](super::ListNode::content) and
+    /// [`ListNode::next`](super::ListNode::content) methods cannot be
+    /// overwritten.
+    ///
+    /// The internal consistency checks do require walking the list for every
+    /// `push` operation. The
+    /// [`GenericLinkedList`](super::generic_linked_list::GenericLinkedList) can
+    /// be used as an efficient and flexible alternative.
+    pub struct SimpleLinkedList<'a, C> {
+        head: Cell<Option<&'a SimpleLinkedListNode<'a, C>>>,
     }
 
-    pub fn iter(&self) -> ListIterator<'a, T> {
-        ListIterator {
-            cur: self.head.0.get(),
+    impl<'a, C> SimpleLinkedList<'a, C> {
+        pub const fn new() -> SimpleLinkedList<'a, C> {
+            SimpleLinkedList {
+                head: Cell::new(None),
+            }
+        }
+    }
+
+    impl<'a, C> SinglyLinkedList<'a, SimpleLinkedListNode<'a, C>> for SimpleLinkedList<'a, C> {
+        fn head(&self) -> Option<&'a SimpleLinkedListNode<'a, C>> {
+            self.head.get()
+        }
+
+        fn iter(&self) -> ListIterator<'a, SimpleLinkedListNode<'a, C>> {
+            ListIterator {
+                cur: self.head.get(),
+            }
+        }
+
+        fn push_head(&self, node: &'a SimpleLinkedListNode<'a, C>) -> bool {
+            // First, check whether this node is already part of some list
+            if node.link.get() != SimpleLinkedListNodeLink::None {
+                return false;
+            }
+
+            if let Some(current_head) = self.head.get() {
+                // Have a head-node already, prepend it and create a link to the
+                // previous head.
+                node.link.set(SimpleLinkedListNodeLink::Next(current_head));
+                self.head.set(Some(node));
+                true
+            } else {
+                // No head-node, mark this list node as the list end.
+                node.link.set(SimpleLinkedListNodeLink::End);
+                self.head.set(Some(node));
+                true
+            }
+        }
+
+        fn push_tail(&self, node: &'a SimpleLinkedListNode<'a, C>) -> bool {
+            // First, check whether this node is already part of some list
+            if node.link.get() != SimpleLinkedListNodeLink::None {
+                return false;
+            }
+
+            if let Some(mut iter_node) = self.head.get() {
+                // We have some head-element, walk the list to find the tail
+                // element:
+                while let SimpleLinkedListNodeLink::Next(next_node) = iter_node.link.get() {
+                    iter_node = next_node;
+                }
+
+                node.link.set(SimpleLinkedListNodeLink::End);
+                iter_node.link.set(SimpleLinkedListNodeLink::Next(node));
+                true
+            } else {
+                // No head-node, mark this list node as the list end.
+                node.link.set(SimpleLinkedListNodeLink::End);
+                self.head.set(Some(node));
+                true
+            }
+        }
+
+        fn pop_head(&self) -> Option<&'a SimpleLinkedListNode<'a, C>> {
+            if let Some(current_head) = self.head.get() {
+                if let SimpleLinkedListNodeLink::Next(next_head) = current_head.link.get() {
+                    self.head.set(Some(next_head));
+                } else {
+                    self.head.set(None);
+                }
+
+                current_head.link.set(SimpleLinkedListNodeLink::None);
+                Some(current_head)
+            } else {
+                None
+            }
         }
     }
 }


### PR DESCRIPTION
### Pull Request Overview

In an effort to fix the issues identified in #2773, this proposes a new, redesigned linked-list interface and types for Tock.

It appears that one major issue with the old linked-list interface is that, while it defines some proper types for manipulating and holding a linked list, it relies on a significant part of the implementation to be filled by the user of the list, through an implementation of the `ListNode` trait respectively.

This has both some major advantages and drawbacks: it allows the implementors of linked-list data structures to be very flexible in their design and reuse existing structures as nodes in their linked-list data structure. Take for example the UART virtualizer: the `MuxUart` holds a linked list of `UartDevice`s. However, instead of creating some list containers which hold the `UartDevice`s, the `UartDevice`s simply implement `ListNode` and thus can be used to build the list themselves. With respect to Tock's model around memory allocation, this can be very beneficial.

Furthermore, by making `ListNode::next` a trait method, the lists structure can be entirely determined at runtime. There is no guarantee and / or requirement that a first call to `next` on some `ListNode` has to return the same reference as a second call. This interface is even flexible enough to support lazy allocation and evaluation of list nodes. A potential use case for this could be building a list of processes by scanning over flash.

However, it also makes implementing basic consistency checks as proposed in #2773 impossible. For example, because the list is entirely dynamic and implementation dependent, and because nodes are not managed by the list itself, it's impossible to tell whether a list will, during runtime, result in a loop. This makes handling lists difficult, especially for simple cases where all of this flexibility is not needed.

Thus this PR contains a redesigned list interface. It still allows for all of the flexibility of the previous interface, but instead of mandating this for every list, it defines an interface (the `SinglyLinkedList` trait) for how manipulating singly-linked lists should work.

In addition to that, it features two list implementations: a `GenericLinkedList` which supports all the flexibility of the previous interface by being generic over the underlying `ModifyableListNode`s, and a `SimpleLinkedList` which contains internal consistency checks as proposed by #2773. It also gives users a choice, whether they would like to avoid the additional overhead associated with the consistency checks by switching to the `GenericLinkedList`.

### Testing Strategy

Not yet tested!


### TODO or Help Wanted

As an example, this PR switches the `schedulers` over to the `SimpleLinkedList` and the `virtual_uart` to the `GenericLinkedList`. There are a lot of usages of this interfaces in tree, I'll happily change them once there is some basic agreement that this looks promising.


### Documentation Updated

- [x] ~Updated the relevant files in `/docs`,~ or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
