### PR TITLE
capsules: lld: Copy only length of message

### DIFF
--- a/capsules/src/low_level_debug/mod.rs
+++ b/capsules/src/low_level_debug/mod.rs
@@ -80,7 +80,8 @@ impl<'u, U: Transmit<'u>> TransmitClient for LowLevelDebug<'u, U> {
         // debug entries.
         if self.grant_failed.take() {
             const MESSAGE: &[u8] = b"LowLevelDebug: grant init failed\n";
-            tx_buffer.copy_from_slice(MESSAGE);
+            tx_buffer[..MESSAGE.len()].copy_from_slice(MESSAGE);
+
             let _ = self.uart.transmit_buffer(tx_buffer, MESSAGE.len()).map_err(
                 |(_, returned_buffer)| {
                     self.buffer.set(Some(returned_buffer));


### PR DESCRIPTION
### Pull Request Overview

We know buffer will be long enough because the min BUF_LEN is longer than the const MESSAGE.

Resolves #2352.






### Testing Strategy

travis


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
