### PR TITLE
kernel: utilities: Initial commit of mut_imut_buffer

### DIFF
--- a/kernel/src/utilities/mod.rs
+++ b/kernel/src/utilities/mod.rs
@@ -4,6 +4,7 @@ pub mod binary_write;
 pub mod helpers;
 pub mod leasable_buffer;
 pub mod math;
+pub mod mut_imut_buffer;
 pub mod peripheral_management;
 pub mod static_init;
 pub mod storage_volume;

--- a/kernel/src/utilities/mut_imut_buffer.rs
+++ b/kernel/src/utilities/mut_imut_buffer.rs
@@ -1,0 +1,54 @@
+//! An enum that can contain a reference to either a mutable or
+//! an immutable buffer.
+//!
+//! This type is intended for internal use in implementations of HILs
+//! or abstractions which need to handle both mutable and immutable
+//! buffers.
+//!
+//! One motivating use case is keys for public key
+//! cryptography. Public keys are often distributed as constant values
+//! in the flash of a kernel image (e.g., to verify signatures), which
+//! requires they be immutable.  Copying them to RAM is expensive
+//! because these keys can be very large (e.g., 512 bytes for a
+//! 4096-bit RSA key). At the same time, some clients may use
+//! dynamically generated or received keys, which are stored in
+//! mutable RAM. Requiring that keys be immutable would
+//! discard mut on this memory. An
+//! implementation can use this type to store either mutable and
+//! immutable buffers. The OTBN (OpenTitan Big Number accelerator) is
+//! one example use of MutImutBuffer.
+//!
+//! Because this type requires dynamic runtime checks that types
+//! match, it should not be used in any HILs or standard, external
+//! APIs. It is intended only for internal use in implementations.
+//!
+//! Author: Alistair Francis
+//!
+//! Usage
+//! -----
+//!
+//!  ```rust
+//! use kernel::utilities::mut_imut_buffer::MutImutBuffer;
+//!
+//! let mut mutable = ['a', 'b', 'c', 'd'];
+//! let immutable = ['e', 'f', 'g', 'h'];
+//!
+//! let shared_buf = MutImutBuffer::Mutable(&mut mutable);
+//! let shared_buf2 = MutImutBuffer::Immutable(&immutable);
+//!  ```
+
+/// An enum which can hold either a mutable or an immutable buffer
+pub enum MutImutBuffer<'a, T> {
+    Mutable(&'a mut [T]),
+    Immutable(&'a [T]),
+}
+
+impl<'a, T> MutImutBuffer<'a, T> {
+    /// Returns the length of the underlying buffer
+    pub fn len(&self) -> usize {
+        match self {
+            MutImutBuffer::Mutable(buf) => buf.len(),
+            MutImutBuffer::Immutable(buf) => buf.len(),
+        }
+    }
+}


### PR DESCRIPTION
### Pull Request Overview

There are a few times inside the Tock kernel where we want to support either a `'static mut` buffer or a `'static` buffer. Examples of this include the [RSA key support](https://github.com/tock/tock/pull/2839) but also the [OTBN](https://github.com/tock/tock/blob/master/chips/lowrisc/src/otbn.rs#L153).

In order to support both I have added a new enum called MutImutBuffer. This allows us to pass around either a mutable static buffer or an immutable static buffer. This can be passed all the way down to the chip driver which can then unpack the buffers and write the data to hardware.

### Testing Strategy

CI and RSA key implementation

### TODO or Help Wanted

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
