### PR TITLE
Remove all uses of `expect("xx")`, replace with `unwrap()`

### DIFF
--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -676,9 +676,7 @@ pub unsafe fn main() {
     );
     base_peripherals.ecb.set_client(aes_mux);
     aes_mux.initialize_callback_handle(
-        dynamic_deferred_caller
-            .register(aes_mux)
-            .expect("no deferred call slot available for ccm mux"),
+        dynamic_deferred_caller.register(aes_mux).unwrap(), // Unwrap fail = no deferred call slot available for ccm mux
     );
 
     let serial_num = nrf52840::ficr::FICR_INSTANCE.address();

--- a/boards/components/src/cdc.rs
+++ b/boards/components/src/cdc.rs
@@ -116,9 +116,7 @@ impl<U: 'static + hil::usb::UsbController<'static>, A: 'static + Alarm<'static>>
         );
         self.usb.set_client(cdc);
         cdc.initialize_callback_handle(
-            self.deferred_caller
-                .register(cdc)
-                .expect("no deferred call slot available for USB-CDC"),
+            self.deferred_caller.register(cdc).unwrap(), // Unwrap fail = no deferred call slot available for USB-CDC
         );
         cdc_alarm.set_alarm_client(cdc);
 

--- a/boards/components/src/console.rs
+++ b/boards/components/src/console.rs
@@ -63,9 +63,7 @@ impl Component for UartMuxComponent {
             )
         );
         uart_mux.initialize_callback_handle(
-            self.deferred_caller
-                .register(uart_mux)
-                .expect("no deferred call slot available for uart mux"),
+            self.deferred_caller.register(uart_mux).unwrap(), // Unwrap fail = no deferred call slot available for uart mux
         );
 
         uart_mux.initialize();

--- a/boards/components/src/i2c.rs
+++ b/boards/components/src/i2c.rs
@@ -80,9 +80,7 @@ impl Component for I2CMuxComponent {
         );
 
         mux_i2c.initialize_callback_handle(
-            self.deferred_caller
-                .register(mux_i2c)
-                .expect("no deferred call slot available for I2C mux"),
+            self.deferred_caller.register(mux_i2c).unwrap(), // Unwrap fail = no deferred call slot available for I2C mux
         );
 
         self.i2c.set_master_client(mux_i2c);

--- a/boards/components/src/ieee802154.rs
+++ b/boards/components/src/ieee802154.rs
@@ -188,9 +188,7 @@ impl<
         userspace_mac.set_pan(self.pan_id);
         userspace_mac.set_address(self.short_addr);
         radio_driver.initialize_callback_handle(
-            self.deferred_caller
-                .register(radio_driver)
-                .expect("no deferred call slot available for ieee802154 driver"),
+            self.deferred_caller.register(radio_driver).unwrap(), // Unwrap fail = no deferred call slot available for ieee802154 driver
         );
 
         (radio_driver, mux_mac)

--- a/boards/components/src/spi.rs
+++ b/boards/components/src/spi.rs
@@ -141,9 +141,7 @@ impl<S: 'static + spi::SpiMaster> Component for SpiMuxComponent<S> {
         );
 
         mux_spi.initialize_callback_handle(
-            self.deferred_caller
-                .register(mux_spi)
-                .expect("no deferred call slot available for SPI mux"),
+            self.deferred_caller.register(mux_spi).unwrap(), // Unwrap fail = no deferred call slot available for SPI mux
         );
 
         self.spi.set_client(mux_spi);

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -529,9 +529,7 @@ pub unsafe fn main() {
     );
     peripherals.aes.set_client(aes_mux);
     aes_mux.initialize_callback_handle(
-        dynamic_deferred_caller
-            .register(aes_mux)
-            .expect("no deferred call slot available for ccm mux"),
+        dynamic_deferred_caller.register(aes_mux).unwrap(), // Unwrap fail = no deferred call slot available for ccm mux
     );
 
     // Can this initialize be pushed earlier, or into component? -pal

--- a/boards/litex/arty/src/main.rs
+++ b/boards/litex/arty/src/main.rs
@@ -377,9 +377,7 @@ pub unsafe fn main() {
         )
     );
     uart0.initialize(
-        dynamic_deferred_caller
-            .register(uart0)
-            .expect("dynamic deferred caller out of slots"),
+        dynamic_deferred_caller.register(uart0).unwrap(), // Unwrap fail = dynamic deferred caller out of slots
     );
 
     PANIC_REFERENCES.uart = Some(uart0);

--- a/boards/litex/sim/src/main.rs
+++ b/boards/litex/sim/src/main.rs
@@ -344,9 +344,7 @@ pub unsafe fn main() {
         )
     );
     uart0.initialize(
-        dynamic_deferred_caller
-            .register(uart0)
-            .expect("dynamic deferred caller out of slots"),
+        dynamic_deferred_caller.register(uart0).unwrap(), // Unwrap fail = dynamic deferred caller out of slots
     );
 
     PANIC_REFERENCES.uart = Some(uart0);

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -534,9 +534,7 @@ pub unsafe fn main() {
     );
     base_peripherals.ecb.set_client(aes_mux);
     aes_mux.initialize_callback_handle(
-        dynamic_deferred_caller
-            .register(aes_mux)
-            .expect("no deferred call slot available for ccm mux"),
+        dynamic_deferred_caller.register(aes_mux).unwrap(), // Unwrap fail = no deferred call slot available for ccm mux
     );
     use capsules::net::ieee802154::MacAddress;
     use capsules::virtual_alarm::VirtualMuxAlarm;

--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -344,9 +344,7 @@ pub unsafe fn main() {
     );
     base_peripherals.ecb.set_client(aes_mux);
     aes_mux.initialize_callback_handle(
-        dynamic_deferred_caller
-            .register(aes_mux)
-            .expect("no deferred call slot available for ccm mux"),
+        dynamic_deferred_caller.register(aes_mux).unwrap(), // Unwrap fail = no deferred call slot available for ccm mux
     );
 
     let (ieee802154_radio, _mux_mac) = components::ieee802154::Ieee802154Component::new(

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -453,9 +453,7 @@ pub unsafe fn main() {
     );
     base_peripherals.ecb.set_client(aes_mux);
     aes_mux.initialize_callback_handle(
-        dynamic_deferred_caller
-            .register(aes_mux)
-            .expect("no deferred call slot available for ccm mux"),
+        dynamic_deferred_caller.register(aes_mux).unwrap(), // Unwrap fail = no deferred call slot available for ccm mux
     );
 
     let serial_num = nrf52840::ficr::FICR_INSTANCE.address();

--- a/boards/opentitan/src/main.rs
+++ b/boards/opentitan/src/main.rs
@@ -398,9 +398,7 @@ unsafe fn setup() -> (
     peripherals.i2c0.set_master_client(i2c_master);
 
     peripherals.aes.initialise(
-        dynamic_deferred_caller
-            .register(&peripherals.aes)
-            .expect("dynamic deferred caller out of slots"),
+        dynamic_deferred_caller.register(&peripherals.aes).unwrap(), // Unwrap fail = dynamic deferred caller out of slots
     );
 
     // USB support is currently broken in the OpenTitan hardware
@@ -462,9 +460,7 @@ unsafe fn setup() -> (
         .finalize(otbn_mux_component_helper!(1024));
 
     peripherals.otbn.initialise(
-        dynamic_deferred_caller
-            .register(&peripherals.otbn)
-            .expect("dynamic deferred caller out of slots"),
+        dynamic_deferred_caller.register(&peripherals.otbn).unwrap(), // Unwrap fail = dynamic deferred caller out of slots
     );
 
     // Convert hardware RNG to the Random interface.
@@ -494,9 +490,7 @@ unsafe fn setup() -> (
     );
     peripherals.aes.set_client(ccm_mux);
     ccm_mux.initialize_callback_handle(
-        dynamic_deferred_caller
-            .register(ccm_mux)
-            .expect("no deferred call slot available for ccm mux"),
+        dynamic_deferred_caller.register(ccm_mux).unwrap(), // Unwrap fail = no deferred call slot available for ccm mux
     );
 
     let crypt_buf1 = static_init!([u8; CRYPT_SIZE], [0x00; CRYPT_SIZE]);

--- a/boards/opentitan/src/otbn.rs
+++ b/boards/opentitan/src/otbn.rs
@@ -9,7 +9,7 @@
 //!     peripherals.otbn.initialise(
 //!         dynamic_deferred_caller
 //!             .register(&peripherals.otbn)
-//!             .expect("dynamic deferred caller out of slots"),
+//!             .unwrap(), // Unwrap fail = dynamic deferred caller out of slots
 //!     );
 //! ```
 

--- a/capsules/src/i2c_master_slave_driver.rs
+++ b/capsules/src/i2c_master_slave_driver.rs
@@ -326,7 +326,7 @@ impl SyscallDriver for I2CMasterSlaveDriver<'_> {
         } else {
             return CommandReturn::failure(ErrorCode::NOMEM);
         }
-        let app = self.app.expect("cannot fail");
+        let app = self.app.unwrap_or_panic(); // Unwrap fail = cannot fail
 
         match command_num {
             // Do a write to another I2C device

--- a/capsules/src/ieee802154/driver.rs
+++ b/capsules/src/ieee802154/driver.rs
@@ -469,13 +469,14 @@ impl DynamicDeferredCallClient for RadioDriver<'_> {
     fn call(&self, _handle: DeferredCallHandle) {
         let _ = self
             .apps
-            .enter(self.saved_appid.expect("missing appid"), |_app, upcalls| {
+            .enter(self.saved_appid.unwrap_or_panic(), |_app, upcalls| {
+                // Unwrap fail = missing appid
                 upcalls
                     .schedule_upcall(
                         1,
                         (
                             kernel::errorcode::into_statuscode(
-                                self.saved_result.expect("missing result"),
+                                self.saved_result.unwrap_or_panic(), // Unwrap fail = missing result
                             ),
                             0,
                             0,

--- a/capsules/src/led.rs
+++ b/capsules/src/led.rs
@@ -132,7 +132,7 @@ impl<L: led::Led> SyscallDriver for LedDriver<'_, L> {
                     _ => CommandReturn::failure(ErrorCode::NOSUPPORT),
                 }
             })
-            .expect("LEDs slice taken")
+            .unwrap() // Unwrap fail = LEDs slice taken
     }
 
     fn allocate_grant(&self, _processid: ProcessId) -> Result<(), kernel::process::Error> {

--- a/capsules/src/log.rs
+++ b/capsules/src/log.rs
@@ -60,7 +60,7 @@
 //!         )
 //!     );
 //!     kernel::hil::flash::HasClient::set_client(&sam4l::flashcalw::FLASH_CONTROLLER, log);
-//!     log.initialize_callback_handle(dynamic_deferred_caller.register(log).expect("no deferred call slot available for log storage"));
+//!     log.initialize_callback_handle(dynamic_deferred_caller.register(log).unwrap()); // Unwrap fail = no deferred call slot available for log storage
 //!
 //!     log.set_read_client(log_storage_read_client);
 //!     log.set_append_client(log_storage_append_client);

--- a/capsules/src/net/sixlowpan/sixlowpan_state.rs
+++ b/capsules/src/net/sixlowpan/sixlowpan_state.rs
@@ -772,7 +772,7 @@ impl<'a> RxState<'a> {
                 .map(|packet| {
                     client.receive(&packet, self.dgram_size.get() as usize, result);
                 })
-                .expect("Error: `packet` is None in call to end_receive.");
+                .unwrap(); // Unwrap fail = Error: `packet` is None in call to end_receive.
         });
     }
 }
@@ -927,10 +927,7 @@ impl<'a, A: time::Alarm<'a>, C: ContextStore> Sixlowpan<'a, A, C> {
             // The packet buffer should *always* be there; in particular,
             // since this state is not busy, it must have the packet buffer.
             // Otherwise, we are in an inconsistent state and can fail.
-            let mut packet = state.packet.take().expect(
-                "Error: `packet` in RxState struct is `None` \
-                 in call to `receive_single_packet`.",
-            );
+            let mut packet = state.packet.take().unwrap();
             if is_lowpan(payload) {
                 let decompressed = sixlowpan_compression::decompress(
                     &self.ctx_store,

--- a/capsules/src/net/udp/driver.rs
+++ b/capsules/src/net/udp/driver.rs
@@ -679,7 +679,7 @@ impl<'a> PortQuery for UDPDriver<'a> {
             app.enter(|other_app, _| {
                 if other_app.bound_port.is_some() {
                     let other_addr_opt = other_app.bound_port.clone();
-                    let other_addr = other_addr_opt.expect("Missing other_addr");
+                    let other_addr = other_addr_opt.unwrap(); // Unwrap fail = Missing other_addr
                     if other_addr.port == port {
                         port_bound = true;
                     }

--- a/capsules/src/nonvolatile_to_pages.rs
+++ b/capsules/src/nonvolatile_to_pages.rs
@@ -123,9 +123,7 @@ impl<'a, F: hil::flash::Flash> hil::nonvolatile_storage::NonvolatileStorage<'sta
                     Ok(()) => Ok(()),
                     Err((return_code, pagebuffer)) => {
                         self.pagebuffer.replace(pagebuffer);
-                        Err(return_code
-                            .try_into()
-                            .expect("Result<(), ErrorCode> success variant in error case"))
+                        Err(return_code.try_into().unwrap()) // Unwrap fail = Result<(), ErrorCode> success variant in error case
                     }
                 }
             })
@@ -167,9 +165,7 @@ impl<'a, F: hil::flash::Flash> hil::nonvolatile_storage::NonvolatileStorage<'sta
                         Ok(()) => Ok(()),
                         Err((return_code, pagebuffer)) => {
                             self.pagebuffer.replace(pagebuffer);
-                            Err(return_code
-                                .try_into()
-                                .expect("Result<(), ErrorCode> success variant in error case"))
+                            Err(return_code.try_into().unwrap()) // Unwrap fail = Result<(), ErrorCode> success variant in error case
                         }
                     }
                 } else {
@@ -183,9 +179,7 @@ impl<'a, F: hil::flash::Flash> hil::nonvolatile_storage::NonvolatileStorage<'sta
                         Ok(()) => Ok(()),
                         Err((return_code, pagebuffer)) => {
                             self.pagebuffer.replace(pagebuffer);
-                            Err(return_code
-                                .try_into()
-                                .expect("Result<(), ErrorCode> success variant in error case"))
+                            Err(return_code.try_into().unwrap()) // Unwrap fail = Result<(), ErrorCode> success variant in error case
                         }
                     }
                 }

--- a/capsules/src/virtual_aes_ccm.rs
+++ b/capsules/src/virtual_aes_ccm.rs
@@ -54,7 +54,7 @@
 //! ccm_mux.initialize_callback_handle(
 //!     dynamic_deferred_caller
 //!         .register(ccm_mux)
-//!         .expect("no deferred call slot available for ccm mux"),
+//!         .unwrap(), // Unwrap fail = no deferred call slot available for ccm mux
 //! );
 //! const CRYPT_SIZE: usize = 7 * AES128_BLOCK_SIZE;
 //! let crypt_buf1 = static_init!([u8; CRYPT_SIZE], [0x00; CRYPT_SIZE]);
@@ -163,7 +163,7 @@ impl<'a, A: AES128<'a> + AES128Ctr + AES128CBC + AES128ECB> MuxAES128CCM<'a, A> 
     /// ```rust
     /// mux.initialize_callback_handle(
     ///     dynamic_deferred_caller.register(mux)
-    ///     .expect("no deferred call slot available for ccm mux")
+    ///     .unwrap() // Unwrap fail = no deferred call slot available for ccm mux
     /// );
     /// ```
     /// after the creation of the mux

--- a/chips/litex/src/liteeth.rs
+++ b/chips/litex/src/liteeth.rs
@@ -215,8 +215,7 @@ impl<'a, R: LiteXSoCRegisterConfiguration> LiteEth<'a, R> {
 
                 // Get the slot buffer reference
                 let slot = unsafe {
-                    self.get_slot_buffer(false, slot_id)
-                        .expect("LiteEth: invalid RX slot id")
+                    self.get_slot_buffer(false, slot_id).unwrap() // Unwrap fail = LiteEth: invalid RX slot id
                 };
 
                 // Copy the packet into the buffer
@@ -250,7 +249,7 @@ impl<'a, R: LiteXSoCRegisterConfiguration> LiteEth<'a, R> {
             return Err((Err(ErrorCode::BUSY), packet));
         }
 
-        let slot = unsafe { self.get_slot_buffer(true, 0) }.expect("LiteEth: no TX slot");
+        let slot = unsafe { self.get_slot_buffer(true, 0) }.unwrap(); // Unwrap fail = LiteEth: no TX slot
         if slot.len() < len {
             return Err((Err(ErrorCode::SIZE), packet));
         }
@@ -287,10 +286,7 @@ impl<'a, R: LiteXSoCRegisterConfiguration> LiteEth<'a, R> {
         }
 
         // We use only one slot, so this event is unambiguous
-        let packet = self
-            .tx_packet
-            .take()
-            .expect("LiteEth: TakeCell empty in tx callback");
+        let packet = self.tx_packet.take().unwrap(); // Unwrap fail = LiteEth: TakeCell empty in tx callback
         self.client
             .map(move |client| client.tx_done(Ok(()), packet));
     }

--- a/chips/litex/src/timer.rs
+++ b/chips/litex/src/timer.rs
@@ -387,7 +387,7 @@ impl<'t, 'c, R: LiteXSoCRegisterConfiguration, F: Frequency> LiteXAlarm<'t, 'c, 
         // at least once (even if the alarm time has already passed).
 
         let reference = self.reference_time.get();
-        let alarm_time = self.alarm_time.expect("alarm not set");
+        let alarm_time = self.alarm_time.unwrap_or_panic(); // Unwrap fail = alarm not set
 
         if !self.now().within_range(reference, alarm_time) {
             // It's time, ring the alarm

--- a/chips/litex/src/uart.rs
+++ b/chips/litex/src/uart.rs
@@ -185,7 +185,7 @@ impl<'a, R: LiteXSoCRegisterConfiguration> LiteXUart<'a, R> {
     fn deferred_rx_abort(&self) {
         // The RX event has already been disabled
         // Just return the buffer to the client
-        let buffer = self.rx_buffer.take().expect("no rx buffer");
+        let buffer = self.rx_buffer.take().unwrap(); // Unwrap fail = no rx buffer
         let progress = self.rx_progress.get();
 
         self.rx_client.map(move |client| {
@@ -196,7 +196,7 @@ impl<'a, R: LiteXSoCRegisterConfiguration> LiteXUart<'a, R> {
     fn rx_data(&self) {
         // New data is available for reception
         let ev = self.uart_regs.ev();
-        let buffer = self.rx_buffer.take().expect("no rx buffer");
+        let buffer = self.rx_buffer.take().unwrap(); // Unwrap fail = no rx buffer
         let len = self.rx_len.get();
         let mut progress = self.rx_progress.get();
 
@@ -227,7 +227,7 @@ impl<'a, R: LiteXSoCRegisterConfiguration> LiteXUart<'a, R> {
     fn deferred_tx_abort(&self) {
         // The TX event has already been disabled
         // Just return the buffer to the client
-        let buffer = self.tx_buffer.take().expect("no tx buffer");
+        let buffer = self.tx_buffer.take().unwrap(); // Unwrap fail = no tx buffer
         let progress = self.tx_progress.get();
 
         self.tx_client
@@ -243,7 +243,7 @@ impl<'a, R: LiteXSoCRegisterConfiguration> LiteXUart<'a, R> {
 
         let len = self.tx_len.get();
         let mut progress = self.tx_progress.get();
-        let buffer = self.tx_buffer.take().expect("no tx buffer");
+        let buffer = self.tx_buffer.take().unwrap(); // Unwrap fail = no tx buffer
 
         // Try to transmit any remaining data
 

--- a/chips/lowrisc/src/usbdev.rs
+++ b/chips/lowrisc/src/usbdev.rs
@@ -420,7 +420,7 @@ impl<'a> Usb<'a> {
     }
 
     fn get_state(&self) -> State {
-        self.state.expect("get_state: state value is in use")
+        self.state.unwrap_or_panic() // Unwrap fail = get_state: state value is in use
     }
 
     fn set_state(&self, state: State) {
@@ -501,9 +501,7 @@ impl<'a> Usb<'a> {
 
     fn copy_slice_out_to_hw(&self, ep: usize, buf_id: usize, size: usize) {
         // Get the slice
-        let slice = self.descriptors[ep]
-            .slice_out
-            .expect("No OUT slice set for this descriptor");
+        let slice = self.descriptors[ep].slice_out.unwrap_or_panic(); // Unwrap fail = No OUT slice set for this descriptor
 
         let mut slice_start = 0;
 
@@ -542,9 +540,7 @@ impl<'a> Usb<'a> {
 
     fn copy_from_hw(&self, ep: usize, buf_id: usize, size: usize) {
         // Get the slice
-        let slice = self.descriptors[ep]
-            .slice_in
-            .expect("No IN slice set for this descriptor");
+        let slice = self.descriptors[ep].slice_in.unwrap_or_panic(); // Unwrap fail = No IN slice set for this descriptor
 
         // Read the date to the buffer
         // TODO: Handle long packets
@@ -579,7 +575,7 @@ impl<'a> Usb<'a> {
                 let length = hw_buf.read(BUFFER::LENGTH);
 
                 let ep_buf = &self.descriptors[ep].slice_out;
-                let ep_buf = ep_buf.expect("No OUT slice set for this descriptor");
+                let ep_buf = ep_buf.unwrap_or_panic(); // Unwrap fail = No OUT slice set for this descriptor
                 if ep_buf.len() < 8 {
                     panic!("EP0 DMA buffer length < 8");
                 }
@@ -686,7 +682,7 @@ impl<'a> Usb<'a> {
 
     fn ep_receive(&self, ep: usize, buf_id: usize, size: u32, _setup: u32) {
         let ep_buf = &self.descriptors[ep].slice_out;
-        let ep_buf = ep_buf.expect("No OUT slice set for this descriptor");
+        let ep_buf = ep_buf.unwrap_or_panic(); // Unwrap fail = No OUT slice set for this descriptor
         if ep_buf.len() < 8 {
             panic!("EP0 DMA buffer length < 8");
         }

--- a/chips/nrf52/src/ieee802154_radio.rs
+++ b/chips/nrf52/src/ieee802154_radio.rs
@@ -717,17 +717,11 @@ impl<'p> Radio<'p> {
         self.registers.event_ready.write(Event::READY::CLEAR);
 
         if self.transmitting.get() {
-            let tbuf = self
-                .tx_buf
-                .take()
-                .expect("Radio TX Buffer produced an invalid result when setting the DMA pointer.");
+            let tbuf = self.tx_buf.take().unwrap(); // Unwrap fail = Radio TX Buffer produced an invalid result when setting the DMA pointer.
 
             self.tx_buf.replace(self.set_dma_ptr(tbuf));
         } else {
-            let rbuf = self
-                .rx_buf
-                .take()
-                .expect("Radio RX Buffer produced an invalid result when setting the DMA pointer.");
+            let rbuf = self.rx_buf.take().unwrap(); // Unwrap fail = Radio RX Buffer produced an invalid result when setting the DMA pointer.
             self.rx_buf.replace(self.set_dma_ptr(rbuf));
         }
 
@@ -812,7 +806,7 @@ impl<'p> Radio<'p> {
                 self.cca_be.set(self.cca_be.get() + 1);
                 let backoff_periods = self.random_nonce() & ((1 << self.cca_be.get()) - 1);
                 self.timer0
-                    .expect("Missing timer reference for CSMA")
+                    .unwrap_or_panic() // Unwrap fail = Missing timer reference for CSMA
                     .set_alarm(
                         kernel::hil::time::Ticks32::from(0),
                         kernel::hil::time::Ticks32::from(
@@ -824,11 +818,10 @@ impl<'p> Radio<'p> {
                 //if we are transmitting, the CRCstatus check is always going to be an error
                 let result = Err(ErrorCode::BUSY);
                 //TODO: Acked is flagged as false until I get around to fixing it.
-                self.tx_client
-                    .map(|client| {
-                        let tbuf = self.tx_buf.take().expect("TX Buffer produced error when sending it back to the requestor after the channel was busy.");
-                        client.send_done(tbuf, false, result)
-                    });
+                self.tx_client.map(|client| {
+                    let tbuf = self.tx_buf.take().unwrap(); // Unwrap fail = TX Buffer produced error when sending it back to the requestor after the channel was busy.
+                    client.send_done(tbuf, false, result)
+                });
             }
 
             self.enable_interrupts();
@@ -853,11 +846,10 @@ impl<'p> Radio<'p> {
                     //if we are transmitting, the CRCstatus check is always going to be an error
                     let result = Ok(());
                     //TODO: Acked is flagged as false until I get around to fixing it.
-                    self.tx_client
-                        .map(|client|{
-                        let tbuf = self.tx_buf.take().expect("TX Buffer produced error when sending it back to the requestor after successful transmission.");
+                    self.tx_client.map(|client| {
+                        let tbuf = self.tx_buf.take().unwrap(); // Unwrap fail = TX Buffer produced error when sending it back to the requestor after successful transmission.
 
-                         client.send_done(tbuf, false, result)
+                        client.send_done(tbuf, false, result)
                     });
                 }
                 nrf5x::constants::RADIO_STATE_RXRU
@@ -865,9 +857,7 @@ impl<'p> Radio<'p> {
                 | nrf5x::constants::RADIO_STATE_RXDISABLE
                 | nrf5x::constants::RADIO_STATE_RX => {
                     self.rx_client.map(|client| {
-                        let rbuf = self.rx_buf.take().expect(
-                            "RX Buffer produced error when sending received packet to requestor",
-                        );
+                        let rbuf = self.rx_buf.take().unwrap(); // Unwrap fail = RX Buffer produced error when sending received packet to requestor
 
                         let frame_len = rbuf[MIMIC_PSDU_OFFSET as usize] as usize - radio::MFR_SIZE;
                         // Length is: S0 (0 Byte) + Length (1 Byte) + S1 (0 Bytes) + Payload

--- a/chips/nrf52/src/spi.rs
+++ b/chips/nrf52/src/spi.rs
@@ -433,8 +433,7 @@ impl hil::spi::SpiMaster for SPIM {
 
         // Reset value is a valid frequency (250kbps), so .expect
         // should be safe here
-        let f = Frequency::from_register(self.registers.frequency.get())
-            .expect("nrf52 unknown spi rate");
+        let f = Frequency::from_register(self.registers.frequency.get()).unwrap(); // Unwrap fail = nrf52 unknown spi rate
         f.into_spi_rate()
     }
 

--- a/chips/nrf52/src/usbd.rs
+++ b/chips/nrf52/src/usbd.rs
@@ -812,7 +812,7 @@ impl<'a> Usbd<'a> {
     }
 
     pub fn get_state(&self) -> UsbState {
-        self.state.expect("get_state: state value is in use")
+        self.state.unwrap_or_panic() // Unwrap fail = get_state: state value is in use
     }
 
     // Powers the USB PHY on
@@ -925,9 +925,7 @@ impl<'a> Usbd<'a> {
                 );
             }
         }
-        let power = self
-            .power
-            .expect("failed to initialize power reference for USB");
+        let power = self.power.unwrap_or_panic(); // Unwrap fail = failed to initialize power reference for USB
         if !power.is_vbus_present() {
             debug_info!("[!] VBUS power is not detected.");
             return;
@@ -1607,7 +1605,7 @@ impl<'a> Usbd<'a> {
                 // We are idle, and ready for any control transfer.
 
                 let ep_buf = &self.descriptors[endpoint].slice_out;
-                let ep_buf = ep_buf.expect("No OUT slice set for this descriptor");
+                let ep_buf = ep_buf.unwrap_or_panic(); // Unwrap fail = No OUT slice set for this descriptor
                 if ep_buf.len() < 8 {
                     panic!("EP0 DMA buffer length < 8");
                 }
@@ -1854,9 +1852,7 @@ impl<'a> Usbd<'a> {
     }
 
     fn start_dma_in(&self, endpoint: usize, size: usize) {
-        let slice = self.descriptors[endpoint]
-            .slice_in
-            .expect("No IN slice set for this descriptor");
+        let slice = self.descriptors[endpoint].slice_in.unwrap_or_panic(); // Unwrap fail = No IN slice set for this descriptor
         self.debug_in_packet(size, endpoint);
 
         // Start DMA transfer
@@ -1867,9 +1863,7 @@ impl<'a> Usbd<'a> {
     }
 
     fn start_dma_out(&self, endpoint: usize) {
-        let slice = self.descriptors[endpoint]
-            .slice_out
-            .expect("No OUT slice set for this descriptor");
+        let slice = self.descriptors[endpoint].slice_out.unwrap_or_panic(); // Unwrap fail = No OUT slice set for this descriptor
 
         // Start DMA transfer
         self.set_pending_dma();
@@ -1880,9 +1874,7 @@ impl<'a> Usbd<'a> {
 
     // Debug-only function
     fn debug_in_packet(&self, size: usize, endpoint: usize) {
-        let slice = self.descriptors[endpoint]
-            .slice_in
-            .expect("No IN slice set for this descriptor");
+        let slice = self.descriptors[endpoint].slice_in.unwrap_or_panic(); // Unwrap fail = No IN slice set for this descriptor
         if size > slice.len() {
             panic!("Packet is too large: {}", size);
         }
@@ -1897,9 +1889,7 @@ impl<'a> Usbd<'a> {
 
     // Debug-only function
     fn debug_out_packet(&self, size: usize, endpoint: usize) {
-        let slice = self.descriptors[endpoint]
-            .slice_out
-            .expect("No OUT slice set for this descriptor");
+        let slice = self.descriptors[endpoint].slice_out.unwrap_or_panic(); // Unwrap fail = No OUT slice set for this descriptor
         if size > slice.len() {
             panic!("Packet is too large: {}", size);
         }

--- a/chips/rp2040/src/i2c.rs
+++ b/chips/rp2040/src/i2c.rs
@@ -326,7 +326,7 @@ impl<'a> I2c<'a> {
         let freq_in = self
             .clocks
             .map(|clocks| clocks.get_frequency(clocks::Clock::System))
-            .expect("You should call resolve_dependencies before set_baudrate.");
+            .unwrap(); // Unwrap fail = You should call resolve_dependencies before set_baudrate.
 
         // TODO: as per the comments in the pico-sdk, this block is not 100% correct
         let period = (freq_in + baudrate / 2) / baudrate;
@@ -485,7 +485,7 @@ impl<'a> I2c<'a> {
         let byte = self
             .buf
             .map_or(None, |buf| Some(buf[idx as usize]))
-            .expect("I2C buffer was not set before a write.");
+            .unwrap(); // Unwrap fail = I2C buffer was not set before a write.
 
         let data_cmd = IC_DATA_CMD::DAT.val(byte as u32) + IC_DATA_CMD::RESTART::CLEAR;
         let data_cmd = {

--- a/chips/sam4l/src/crccu.rs
+++ b/chips/sam4l/src/crccu.rs
@@ -371,7 +371,7 @@ impl Crccu<'_> {
         // client
         let result = post_process(
             self.registers.sr.read(Status::CRC),
-            self.algorithm.expect("crccu deferred call: no algorithm"),
+            self.algorithm.unwrap_or_panic(), // Unwrap fail = crccu deferred call: no algorithm
         );
 
         // Reset the internal CRC state such that the next call to

--- a/chips/sam4l/src/i2c.rs
+++ b/chips/sam4l/src/i2c.rs
@@ -525,12 +525,12 @@ struct TWISClock {
 }
 impl ClockInterface for TWISClock {
     fn is_enabled(&self) -> bool {
-        let slave_clock = self.slave.expect("I2C: Use of slave with no clock");
+        let slave_clock = self.slave.unwrap(); // Unwrap fail = I2C: Use of slave with no clock
         slave_clock.is_enabled()
     }
 
     fn enable(&self) {
-        let slave_clock = self.slave.expect("I2C: Use of slave with no clock");
+        let slave_clock = self.slave.unwrap(); // Unwrap fail = I2C: Use of slave with no clock
         if self.master.is_enabled() {
             panic!("I2C: Request for slave clock, but master active");
         }
@@ -538,7 +538,7 @@ impl ClockInterface for TWISClock {
     }
 
     fn disable(&self) {
-        let slave_clock = self.slave.expect("I2C: Use of slave with no clock");
+        let slave_clock = self.slave.unwrap(); // Unwrap fail = I2C: Use of slave with no clock
         slave_clock.disable();
     }
 }
@@ -597,10 +597,7 @@ impl PeripheralManagement<TWISClock> for I2CHw {
     type RegisterType = TWISRegisters;
 
     fn get_registers<'a>(&'a self) -> &'a TWISRegisters {
-        &*self
-            .slave_mmio_address
-            .as_ref()
-            .expect("Access of non-existent slave")
+        &*self.slave_mmio_address.as_ref().unwrap() // Unwrap fail = Access of non-existent slave
     }
 
     fn get_clock(&self) -> &TWISClock {

--- a/chips/sam4l/src/usbc/mod.rs
+++ b/chips/sam4l/src/usbc/mod.rs
@@ -458,14 +458,14 @@ impl<'a> Usbc<'a> {
     where
         F: FnOnce(&mut State) -> R,
     {
-        let mut state = self.state.take().expect("map_state: state value is in use");
+        let mut state = self.state.take().unwrap(); // Unwrap fail = map_state: state value is in use
         let result = closure(&mut state);
         self.state.set(state);
         result
     }
 
     fn get_state(&self) -> State {
-        self.state.expect("get_state: state value is in use")
+        self.state.unwrap_or_panic() // Unwrap fail = get_state: state value is in use
     }
 
     fn set_state(&self, state: State) {

--- a/chips/stm32f303xc/src/gpio.rs
+++ b/chips/stm32f303xc/src/gpio.rs
@@ -749,7 +749,7 @@ impl<'a> Pin<'a> {
     }
 
     pub fn get_mode(&self) -> Mode {
-        let port = self.ports_ref.expect("Err").get_port(self.pinid);
+        let port = self.ports_ref.unwrap_or_panic().get_port(self.pinid); // Unwrap fail = Err
 
         let val = match self.pinid.get_pin_number() {
             0b0000 => port.registers.moder.read(MODER::MODER0),
@@ -775,7 +775,7 @@ impl<'a> Pin<'a> {
     }
 
     pub fn set_mode(&self, mode: Mode) {
-        let port = self.ports_ref.expect("").get_port(self.pinid);
+        let port = self.ports_ref.unwrap_or_panic().get_port(self.pinid); // Unwrap fail =
 
         match self.pinid.get_pin_number() {
             0b0000 => port.registers.moder.modify(MODER::MODER0.val(mode as u32)),
@@ -799,7 +799,7 @@ impl<'a> Pin<'a> {
     }
 
     pub fn set_alternate_function(&self, af: AlternateFunction) {
-        let port = self.ports_ref.expect("").get_port(self.pinid);
+        let port = self.ports_ref.unwrap_or_panic().get_port(self.pinid); // Unwrap fail =
 
         match self.pinid.get_pin_number() {
             0b0000 => port.registers.afrl.modify(AFRL::AFRL0.val(af as u32)),
@@ -837,7 +837,7 @@ impl<'a> Pin<'a> {
     }
 
     fn set_mode_output_pushpull(&self) {
-        let port = self.ports_ref.expect("").get_port(self.pinid);
+        let port = self.ports_ref.unwrap_or_panic().get_port(self.pinid); // Unwrap fail =
 
         match self.pinid.get_pin_number() {
             0b0000 => port.registers.otyper.modify(OTYPER::OT0::CLEAR),
@@ -861,7 +861,7 @@ impl<'a> Pin<'a> {
     }
 
     fn get_pullup_pulldown(&self) -> PullUpPullDown {
-        let port = self.ports_ref.expect("").get_port(self.pinid);
+        let port = self.ports_ref.unwrap_or_panic().get_port(self.pinid); // Unwrap fail =
 
         let val = match self.pinid.get_pin_number() {
             0b0000 => port.registers.pupdr.read(PUPDR::PUPDR0),
@@ -887,7 +887,7 @@ impl<'a> Pin<'a> {
     }
 
     fn set_pullup_pulldown(&self, pupd: PullUpPullDown) {
-        let port = self.ports_ref.expect("").get_port(self.pinid);
+        let port = self.ports_ref.unwrap_or_panic().get_port(self.pinid); // Unwrap fail =
 
         match self.pinid.get_pin_number() {
             0b0000 => port.registers.pupdr.modify(PUPDR::PUPDR0.val(pupd as u32)),
@@ -911,7 +911,7 @@ impl<'a> Pin<'a> {
     }
 
     fn set_output_high(&self) {
-        let port = self.ports_ref.expect("").get_port(self.pinid);
+        let port = self.ports_ref.unwrap_or_panic().get_port(self.pinid); // Unwrap fail =
 
         match self.pinid.get_pin_number() {
             0b0000 => port.registers.bsrr.write(BSRR::BS0::SET),
@@ -935,7 +935,7 @@ impl<'a> Pin<'a> {
     }
 
     fn set_output_low(&self) {
-        let port = self.ports_ref.expect("").get_port(self.pinid);
+        let port = self.ports_ref.unwrap_or_panic().get_port(self.pinid); // Unwrap fail =
 
         match self.pinid.get_pin_number() {
             0b0000 => port.registers.bsrr.write(BSRR::BR0::SET),
@@ -959,7 +959,7 @@ impl<'a> Pin<'a> {
     }
 
     fn is_output_high(&self) -> bool {
-        let port = self.ports_ref.expect("").get_port(self.pinid);
+        let port = self.ports_ref.unwrap_or_panic().get_port(self.pinid); // Unwrap fail =
 
         match self.pinid.get_pin_number() {
             0b0000 => port.registers.odr.is_set(ODR::ODR0),
@@ -993,7 +993,7 @@ impl<'a> Pin<'a> {
     }
 
     fn read_input(&self) -> bool {
-        let port = self.ports_ref.expect("").get_port(self.pinid);
+        let port = self.ports_ref.unwrap_or_panic().get_port(self.pinid); // Unwrap fail =
 
         match self.pinid.get_pin_number() {
             0b0000 => port.registers.idr.is_set(IDR::IDR0),

--- a/chips/stm32f4xx/src/gpio.rs
+++ b/chips/stm32f4xx/src/gpio.rs
@@ -788,7 +788,7 @@ impl<'a> Pin<'a> {
     }
 
     pub fn get_mode(&self) -> Mode {
-        let port = self.ports_ref.expect("").get_port(self.pinid);
+        let port = self.ports_ref.unwrap_or_panic().get_port(self.pinid); // Unwrap fail =
 
         let val = match self.pinid.get_pin_number() {
             0b0000 => port.registers.moder.read(MODER::MODER0),
@@ -814,7 +814,7 @@ impl<'a> Pin<'a> {
     }
 
     pub fn set_mode(&self, mode: Mode) {
-        let port = self.ports_ref.expect("").get_port(self.pinid);
+        let port = self.ports_ref.unwrap_or_panic().get_port(self.pinid); // Unwrap fail =
 
         match self.pinid.get_pin_number() {
             0b0000 => port.registers.moder.modify(MODER::MODER0.val(mode as u32)),
@@ -838,7 +838,7 @@ impl<'a> Pin<'a> {
     }
 
     pub fn set_alternate_function(&self, af: AlternateFunction) {
-        let port = self.ports_ref.expect("").get_port(self.pinid);
+        let port = self.ports_ref.unwrap_or_panic().get_port(self.pinid); // Unwrap fail =
 
         match self.pinid.get_pin_number() {
             0b0000 => port.registers.afrl.modify(AFRL::AFRL0.val(af as u32)),
@@ -876,7 +876,7 @@ impl<'a> Pin<'a> {
     }
 
     fn set_mode_output_pushpull(&self) {
-        let port = self.ports_ref.expect("").get_port(self.pinid);
+        let port = self.ports_ref.unwrap_or_panic().get_port(self.pinid); // Unwrap fail =
 
         match self.pinid.get_pin_number() {
             0b0000 => port.registers.otyper.modify(OTYPER::OT0::CLEAR),
@@ -900,7 +900,7 @@ impl<'a> Pin<'a> {
     }
 
     pub fn set_speed(&self) {
-        let port = self.ports_ref.expect("").get_port(self.pinid);
+        let port = self.ports_ref.unwrap_or_panic().get_port(self.pinid); // Unwrap fail =
 
         match self.pinid.get_pin_number() {
             0b0000 => port.registers.ospeedr.modify(OSPEEDR::OSPEEDR0.val(0b11)),
@@ -924,7 +924,7 @@ impl<'a> Pin<'a> {
     }
 
     pub fn set_mode_output_opendrain(&self) {
-        let port = self.ports_ref.expect("").get_port(self.pinid);
+        let port = self.ports_ref.unwrap_or_panic().get_port(self.pinid); // Unwrap fail =
 
         match self.pinid.get_pin_number() {
             0b0000 => port.registers.otyper.modify(OTYPER::OT0::SET),
@@ -948,7 +948,7 @@ impl<'a> Pin<'a> {
     }
 
     fn get_pullup_pulldown(&self) -> PullUpPullDown {
-        let port = self.ports_ref.expect("").get_port(self.pinid);
+        let port = self.ports_ref.unwrap_or_panic().get_port(self.pinid); // Unwrap fail =
 
         let val = match self.pinid.get_pin_number() {
             0b0000 => port.registers.pupdr.read(PUPDR::PUPDR0),
@@ -974,7 +974,7 @@ impl<'a> Pin<'a> {
     }
 
     fn set_pullup_pulldown(&self, pupd: PullUpPullDown) {
-        let port = self.ports_ref.expect("").get_port(self.pinid);
+        let port = self.ports_ref.unwrap_or_panic().get_port(self.pinid); // Unwrap fail =
 
         match self.pinid.get_pin_number() {
             0b0000 => port.registers.pupdr.modify(PUPDR::PUPDR0.val(pupd as u32)),
@@ -998,7 +998,7 @@ impl<'a> Pin<'a> {
     }
 
     fn set_output_high(&self) {
-        let port = self.ports_ref.expect("").get_port(self.pinid);
+        let port = self.ports_ref.unwrap_or_panic().get_port(self.pinid); // Unwrap fail =
 
         match self.pinid.get_pin_number() {
             0b0000 => port.registers.bsrr.write(BSRR::BS0::SET),
@@ -1022,7 +1022,7 @@ impl<'a> Pin<'a> {
     }
 
     fn set_output_low(&self) {
-        let port = self.ports_ref.expect("").get_port(self.pinid);
+        let port = self.ports_ref.unwrap_or_panic().get_port(self.pinid); // Unwrap fail =
 
         match self.pinid.get_pin_number() {
             0b0000 => port.registers.bsrr.write(BSRR::BR0::SET),
@@ -1046,7 +1046,7 @@ impl<'a> Pin<'a> {
     }
 
     fn is_output_high(&self) -> bool {
-        let port = self.ports_ref.expect("").get_port(self.pinid);
+        let port = self.ports_ref.unwrap_or_panic().get_port(self.pinid); // Unwrap fail =
 
         match self.pinid.get_pin_number() {
             0b0000 => port.registers.odr.is_set(ODR::ODR0),
@@ -1080,7 +1080,7 @@ impl<'a> Pin<'a> {
     }
 
     fn read_input(&self) -> bool {
-        let port = self.ports_ref.expect("").get_port(self.pinid);
+        let port = self.ports_ref.unwrap_or_panic().get_port(self.pinid); // Unwrap fail =
 
         match self.pinid.get_pin_number() {
             0b0000 => port.registers.idr.is_set(IDR::IDR0),

--- a/kernel/src/debug.rs
+++ b/kernel/src/debug.rs
@@ -376,7 +376,7 @@ unsafe fn try_get_debug_writer() -> Option<&'static mut DebugWriterWrapper> {
 }
 
 unsafe fn get_debug_writer() -> &'static mut DebugWriterWrapper {
-    try_get_debug_writer().expect("Must call `set_debug_writer_wrapper` in board initialization.")
+    try_get_debug_writer().unwrap() // Unwrap fail = Must call `set_debug_writer_wrapper` in board initialization.
 }
 
 /// Function used by board main.rs to set a reference to the writer.

--- a/kernel/src/dynamic_deferred_call.rs
+++ b/kernel/src/dynamic_deferred_call.rs
@@ -61,7 +61,7 @@
 //!     SomeCapsule::new(dynamic_deferred_call)
 //! ) };
 //! some_capsule.set_deferred_call_handle(
-//!     dynamic_deferred_call.register(some_capsule).expect("no deferred call slot available")
+//!     dynamic_deferred_call.register(some_capsule).unwrap() // Unwrap fail = no deferred call slot available
 //! );
 //! ```
 

--- a/libraries/tock-cells/src/optional_cell.rs
+++ b/libraries/tock-cells/src/optional_cell.rs
@@ -154,12 +154,14 @@ impl<T: Copy> OptionalCell<T> {
     }
 
     /// Returns the contained value or panics if contents is `None`.
-    pub fn expect(&self, msg: &str) -> T {
-        self.value.get().expect(msg)
+    /// We do not use the traditional name for this function -- `unwrap()`
+    /// -- because the Tock kernel discourages panicking, and this name
+    /// is intended to discourage users from casually adding calls to
+    /// `unwrap()` without careful consideration.
+    #[track_caller]
+    pub fn unwrap_or_panic(&self) -> T {
+        self.value.get().unwrap()
     }
-
-    // Note: Explicitly do not support unwrap, as we do not to encourage
-    // panic'ing in the Tock kernel.
 
     /// Returns the contained value or a default.
     pub fn unwrap_or(&self, default: T) -> T {


### PR DESCRIPTION
### Pull Request Overview

This PR removes all uses of `expect()` in non-test code. Now that `\#[track_caller]` is enabled by default, `expect()` is not necessary to make it possible to backtrace panics from calls to `unwrap()`. Continuing to use `expect()` has a code size cost, as these messages are embedded in the binary. Worse, even if you remove the panic handler, the strings remain embedded in the binary, making them a truly unavoidable cost.

One place where this is tricky is `OptionalCell` -- historically, Tock did not include an implementation of `unwrap()` on `OptionalCell` to discourage developers from writing code that would panic. This PR replaces `OptionalCell::expect()` with `OptionalCell::unwrap_or_panic()` in hopes that the non-canonical name will still discourage its use.

To prevent this change from removing useful comments, I embedded the strings passed to `expect()` in comments following the new call to `unwrap()`. The mechanism for this PR was as follows:

```shell
$ vim
:args **/*.rs
:argdo %s!expect("\(.*\)")\(.*\)$!unwrap()\2 // Unwrap fail = \1!g
:wall 
:qall
```

This PR reduces Imix code size by 372 bytes.

### Testing Strategy

This pull request was tested by compiling


### TODO or Help Wanted

N/A

### Documentation Updated

- [x] I will update the code size doc if this PR is accepted.

### Formatting

- [x] Ran `make prepush`.
