### PR TITLE
Add support for syscall filtering

### DIFF
--- a/kernel/src/kernel.rs
+++ b/kernel/src/kernel.rs
@@ -799,6 +799,15 @@ impl Kernel {
                 {
                     process.set_syscall_return_value(SyscallReturn::Failure(response));
 
+                    if config::CONFIG.trace_syscalls {
+                        debug!(
+                            "[{:?}] Filtered: {:?} was rejected with {:?}",
+                            process.processid(),
+                            syscall,
+                            response
+                        );
+                    }
+
                     return;
                 }
             }

--- a/kernel/src/platform/mod.rs
+++ b/kernel/src/platform/mod.rs
@@ -14,3 +14,4 @@ pub use self::platform::KernelResources;
 pub use self::platform::ProcessFault;
 pub use self::platform::SyscallDriverLookup;
 pub use self::platform::SyscallFilter;
+pub use self::platform::TbfHeaderFilterDefaultAllow;

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -14,6 +14,7 @@ use crate::platform::mpu::{self};
 use crate::processbuffer::{ReadOnlyProcessBuffer, ReadWriteProcessBuffer};
 use crate::syscall::{self, Syscall, SyscallReturn};
 use crate::upcall::UpcallId;
+use tock_tbf::types::CommandPermissions;
 
 // Export all process related types via `kernel::process::`.
 pub use crate::process_policies::{
@@ -406,6 +407,12 @@ pub trait Process {
     /// potentially other state the kernel is storing on behalf of the process,
     /// and cannot be edited by the process.
     fn flash_non_protected_start(&self) -> *const u8;
+
+    fn get_command_permissions(
+        &self,
+        driver_num: usize,
+        offset: Option<usize>,
+    ) -> CommandPermissions;
 
     // mpu
 

--- a/kernel/src/process_standard.rs
+++ b/kernel/src/process_standard.rs
@@ -26,6 +26,7 @@ use crate::processbuffer::{ReadOnlyProcessBuffer, ReadWriteProcessBuffer};
 use crate::syscall::{self, Syscall, SyscallReturn, UserspaceKernelBoundary};
 use crate::upcall::UpcallId;
 use crate::utilities::cells::{MapCell, NumericCellExt, OptionalCell};
+use tock_tbf::types::CommandPermissions;
 
 /// State for helping with debugging apps.
 ///
@@ -418,6 +419,14 @@ impl<C: Chip> Process for ProcessStandard<'_, C> {
 
     fn flash_non_protected_start(&self) -> *const u8 {
         ((self.flash.as_ptr() as usize) + self.header.get_protected_size() as usize) as *const u8
+    }
+
+    fn get_command_permissions(
+        &self,
+        driver_num: usize,
+        offset: Option<usize>,
+    ) -> CommandPermissions {
+        self.header.get_command_permissions(driver_num, offset)
     }
 
     fn flash_end(&self) -> *const u8 {


### PR DESCRIPTION
### Pull Request Overview

This PR builds on the TBF header and adds support for syscall filtering.

This also adds a new filter implementation that filters syscalls based on the TBF header. Importantly this defaults to allow all if no header is specified, so we don't break any current users.

### Testing Strategy

Running apps on OT

### TODO or Help Wanted

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
