### PR TITLE
Dev/tock litex bump

### DIFF
--- a/boards/litex/arty/README.md
+++ b/boards/litex/arty/README.md
@@ -11,9 +11,9 @@ differ significantly depending on the LiteX release and configuration
 options used. This board definition currently targets and has been
 tested with
 - [the LiteX SoC generator, revision
-  e0d5a7bff5](https://github.com/enjoy-digital/litex/tree/e0d5a7bff55923)
+  c43132f81f1113](https://github.com/enjoy-digital/litex/tree/c43132f81f1113)
 - using the companion [target
-  file](https://github.com/litex-hub/litex-boards/blob/4b48f15265c902/litex_boards/targets/digilent_arty.py)
+  file](https://github.com/litex-hub/litex-boards/blob/f18b10d1edb4e1/litex_boards/targets/digilent_arty.py)
   from `litex-boards`
 - built around a VexRiscv-CPU with PMP, hardware multiplication and
   compressed instruction support (named `TockSecureIMC`)
@@ -30,20 +30,18 @@ tested with
 The `tock+secure+imc` is a custom VexRiscv CPU variant, based on the
 build infrastructure in
 [pythondata-cpu-vexriscv](https://github.com/litex-hub/pythondata-cpu-vexriscv),
-using a
-[patch](https://github.com/lschuermann/tock-litex/blob/7fcbefac7f17c2/pkgs/pythondata-cpu-vexriscv/0001-Add-TockSecureIMC-cpu-variant.patch)
-to introduce a CPU with physical memory protection, hardware
-multiplication and compressed instruction support (such that it is
-compatible with the `rv32imc` arch).
+which is patched to introduce a CPU with physical memory protection,
+hardware multiplication and compressed instruction support (such that
+it is compatible with the `rv32imc` arch).
 
 Prebuilt and tested bitstreams (including the generated VexRiscv CPU
 Verilog files) can be obtained from the [Tock on LiteX companion
 repository
 releases](https://github.com/lschuermann/tock-litex/releases/). The
 current board definition has been verified to work with [release
-2021081101](https://github.com/lschuermann/tock-litex/releases/tag/2021081101). The
-bitstream for this board is located in `digilent_arty_a7-35t.zip`
-under `gateware/digilent_arty.bit`.
+2021100501](https://github.com/lschuermann/tock-litex/releases/tag/2021100501). The
+bitstream for this board is located in `digilent_arty_a7-35t.zip` or
+`digilent_arty_a7-100t.zip` under `gateware/digilent_arty.bit`.
 
 Many bitstream customizations can be represented in the Tock board by
 simply changing the variables in

--- a/boards/litex/sim/Makefile
+++ b/boards/litex/sim/Makefile
@@ -1,7 +1,7 @@
 # Makefile for building the tock kernel for a LiteX SoC running in a
 # Verilated simulation
 
-TARGET=riscv32i-unknown-none-elf
+TARGET=riscv32imc-unknown-none-elf
 PLATFORM=litex_sim
 
 include ../../Makefile.common

--- a/boards/litex/sim/README.md
+++ b/boards/litex/sim/README.md
@@ -5,26 +5,39 @@ This board is targeting a
 [verilated](https://www.veripool.org/wiki/verilator) SoC bitstream
 built using [LiteX](https://github.com/enjoy-digital/litex).
 
-Since LiteX is a SoC builder, the individual generated bitstreams can
-differ significantly depending on the release and configuration
-options used. This board definition currently targets and has been
-tested with
+Since LiteX is a SoC builder, the individual generated SoCs can differ
+significantly depending on the release and configuration options
+used. This board definition currently targets and has been tested with
 - [the LiteX SoC generator, revision
-  e0d5a7bff5](https://github.com/enjoy-digital/litex/tree/e0d5a7bff55923)
+  c43132f81f1113](https://github.com/enjoy-digital/litex/tree/c43132f81f1113)
 - using the included
-  [lxsim](https://github.com/enjoy-digital/litex/blob/e0d5a7bff55923/litex/tools/litex_sim.py)
-- built around a VexRiscv-CPU
+  [`litex_sim`](https://github.com/enjoy-digital/litex/blob/c43132f81f1113/litex/tools/litex_sim.py)
+- built around a VexRiscv-CPU with PMP, hardware multiplication and
+  compressed instruction support (named `TockSecureIMC`)
 - featuring a TIMER0 with 64-bit wide hardware uptime
-- along with the following configuration options:
+- using the following configuration options:
 
   ```
   --csr-data-width=32
   --integrated-rom-size=0x100000
-  --cpu-variant=secure
+  --integrated-main-ram-size=0x10000000
+  --cpu-variant=tock+secure+imc
   --with-ethernet
   --timer-uptime
+  --with-gpio
   --rom-init $PATH_TO_TOCK_BINARY
   ```
+
+The `tock+secure+imc` is a custom VexRiscv CPU variant, based on the
+build infrastructure in
+[pythondata-cpu-vexriscv](https://github.com/litex-hub/pythondata-cpu-vexriscv),
+which is patched to introduce a CPU with physical memory protection,
+hardware multiplication and compressed instruction support (such that
+it is compatible with the `rv32imc` arch).
+
+The [`tock-litex`](https://github.com/lschuermann/tock-litex)
+repository contains helpful instructions for how to set up the local
+LiteX development and simulation environment.
 
 Many bitstream customizations can be represented in the Tock board by
 simply changing the variables in
@@ -37,7 +50,7 @@ CSR locations in memory. The companion repository
 [tock-litex](https://github.com/lschuermann/tock-litex) provides
 access to an environment with the required LiteX Python packages in
 their targeted versions. This board currently targets the release
-[2021081101](https://github.com/lschuermann/tock-litex/releases/tag/2021081101)
+[2021100501](https://github.com/lschuermann/tock-litex/releases/tag/2021100501)
 of `tock-litex`.
 
 

--- a/boards/litex/sim/src/litex_generated_constants.rs
+++ b/boards/litex/sim/src/litex_generated_constants.rs
@@ -25,6 +25,7 @@ pub const ETHMAC_RX_SLOTS: usize = 2;
 pub const ETHMAC_TX_SLOTS: usize = 2;
 pub const ETHMAC_SLOT_SIZE: usize = 2048;
 
+//pub const GPIO_INTERRUPT: usize = 3;
 pub const ETHMAC_INTERRUPT: usize = 2;
 pub const TIMER0_INTERRUPT: usize = 1;
 pub const UART_INTERRUPT: usize = 0;
@@ -34,9 +35,10 @@ pub const CSR_BASE: usize = 0xf0000000;
 pub const CSR_CTRL_BASE: usize = CSR_BASE + 0x0000;
 pub const CSR_ETHMAC_BASE: usize = CSR_BASE + 0x0800;
 pub const CSR_ETHPHY_BASE: usize = CSR_BASE + 0x1000;
-pub const CSR_IDENTIFIER_MEM_BASE: usize = CSR_BASE + 0x1800;
-pub const CSR_TIMER0_BASE: usize = CSR_BASE + 0x2000;
-pub const CSR_UART_BASE: usize = CSR_BASE + 0x2800;
+//pub const CSR_GPIO_BASE: usize = CSR_BASE + 0x1800;
+pub const CSR_IDENTIFIER_MEM_BASE: usize = CSR_BASE + 0x2000;
+pub const CSR_TIMER0_BASE: usize = CSR_BASE + 0x2800;
+pub const CSR_UART_BASE: usize = CSR_BASE + 0x3000;
 
 // constants defined in `generated/mem.h`
 pub const MEM_ETHMAC_BASE: usize = 0x80000000;


### PR DESCRIPTION
### Pull Request Overview

This pull request bumps the targeted tock-litex release for the LiteX boards in Tock. Most importantly, it allows us to use a recent version of the VexRiscv CPU again. The upstream VexRiscv CPU has changed its PMP implementation to only support NAPOT addressing. This makes the prebuilt `VexRiscv_Secure` target incompatible with the expectations of Tock. However, by patching in the old VexRiscv PMP implementation we can use TOR addressing again. As per a discussion with the VexRiscv author regarding these regressions, this older PMP version will also land in VexRiscv mainline. Along with the switch to the `VexRiscv_TockSecureIMC` custom CPU target for the simulation -- required because of the PMP changes -- we can further take advantage of the RISC-V IMC support of this CPU target.

Furthermore, this adds a GPIO core to the simulation in anticipation of the LiteX simulator-based CI workflow.

This unblocks pull requests #2821 and subsequently #2801.

### Testing Strategy

This pull request was tested by running the LiteX simulation CI. It will be tested on the proper Arty A7 board in a few hours.


### TODO or Help Wanted

This pull request still needs testing on the Arty A7 board.


### Documentation Updated

- [x] ~Updated the relevant files in `/docs`,~ or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
