### PR TITLE
boards: build.rs: make sure all files exist

### DIFF
--- a/boards/litex/arty/build.rs
+++ b/boards/litex/arty/build.rs
@@ -1,4 +1,4 @@
 fn main() {
     println!("cargo:rerun-if-changed=layout.ld");
-    println!("cargo:rerun-if-changed=../kernel_layout.ld");
+    println!("cargo:rerun-if-changed=../../kernel_layout.ld");
 }

--- a/boards/litex/sim/build.rs
+++ b/boards/litex/sim/build.rs
@@ -1,4 +1,4 @@
 fn main() {
     println!("cargo:rerun-if-changed=layout.ld");
-    println!("cargo:rerun-if-changed=../kernel_layout.ld");
+    println!("cargo:rerun-if-changed=../../kernel_layout.ld");
 }

--- a/boards/weact_f401ccu6/build.rs
+++ b/boards/weact_f401ccu6/build.rs
@@ -1,5 +1,4 @@
 fn main() {
     println!("cargo:rerun-if-changed=layout.ld");
-    println!("cargo:rerun-if-changed=chip_layout.ld");
     println!("cargo:rerun-if-changed=../kernel_layout.ld");
 }


### PR DESCRIPTION
### Pull Request Overview

Non-existent files in build.rs cause cargo to rebuild every time.



This fixes that for three boards.


### Testing Strategy

travis, and running `make` a lot.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
