### PR TITLE
capsules: console: remove dead code

### DIFF
--- a/capsules/src/console.rs
+++ b/capsules/src/console.rs
@@ -99,18 +99,15 @@ impl<'a> Console<'a> {
         Ok(())
     }
 
-    /// Internal helper function for continuing a previously set up transaction
-    /// Returns true if this send is still active, or false if it has completed
-    fn send_continue(
-        &self,
-        app_id: ProcessId,
-        app: &mut App,
-    ) -> Result<bool, Result<(), ErrorCode>> {
+    /// Internal helper function for continuing a previously set up transaction.
+    /// Returns `true` if this send is still active, or `false` if it has
+    /// completed.
+    fn send_continue(&self, app_id: ProcessId, app: &mut App) -> bool {
         if app.write_remaining > 0 {
             self.send(app_id, app);
-            Ok(true)
+            true
         } else {
-            Ok(false)
+            false
         }
     }
 
@@ -299,25 +296,14 @@ impl uart::TransmitClient for Console<'_> {
         self.tx_in_progress.take().map(|appid| {
             self.apps.enter(appid, |app, upcalls| {
                 match self.send_continue(appid, app) {
-                    Ok(more_to_send) => {
-                        if !more_to_send {
-                            // Go ahead and signal the application
-                            let written = app.write_len;
-                            app.write_len = 0;
-                            upcalls.schedule_upcall(1, (written, 0, 0)).ok();
-                        }
+                    true => {
+                        // Still more to send. Wait to notify the process.
                     }
-                    Err(return_code) => {
-                        // XXX This shouldn't ever happen?
+                    false => {
+                        // Go ahead and signal the application
+                        let written = app.write_len;
                         app.write_len = 0;
-                        app.write_remaining = 0;
-                        app.pending_write = false;
-                        upcalls
-                            .schedule_upcall(
-                                1,
-                                (kernel::errorcode::into_statuscode(return_code), 0, 0),
-                            )
-                            .ok();
+                        upcalls.schedule_upcall(1, (written, 0, 0)).ok();
                     }
                 }
             })
@@ -328,25 +314,10 @@ impl uart::TransmitClient for Console<'_> {
         if self.tx_in_progress.is_none() {
             for cntr in self.apps.iter() {
                 let appid = cntr.processid();
-                let started_tx = cntr.enter(|app, upcalls| {
+                let started_tx = cntr.enter(|app, _upcalls| {
                     if app.pending_write {
                         app.pending_write = false;
-                        match self.send_continue(appid, app) {
-                            Ok(more_to_send) => more_to_send,
-                            Err(return_code) => {
-                                // XXX This shouldn't ever happen?
-                                app.write_len = 0;
-                                app.write_remaining = 0;
-                                app.pending_write = false;
-                                upcalls
-                                    .schedule_upcall(
-                                        1,
-                                        (kernel::errorcode::into_statuscode(return_code), 0, 0),
-                                    )
-                                    .ok();
-                                false
-                            }
-                        }
+                        self.send_continue(appid, app)
                     } else {
                         false
                     }


### PR DESCRIPTION
### Pull Request Overview

Over time the console capsule has been updated to queue, and the send_continue function never returns an error. Thus, we can simplify its return value and remove upcalls with error messages that are never triggered.

Fixes #2833





### Testing Strategy

printf_long app


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
