### PR TITLE
tools: rustdocs: replace images with tock logos

### DIFF
--- a/tools/build-all-docs.sh
+++ b/tools/build-all-docs.sh
@@ -21,8 +21,19 @@ else
 fi
 rm -f _COW _COW2
 
-# Make the documentation for all the boards and move it to doc/rustdoc.
+# Make the documentation for all the boards.
 make alldoc
+
+# Replace the default rust logo with our own Tock logo and the favicon with our
+# own favicon. Note, it is also possible to set this using a `#[doc]` attribute
+# (https://doc.rust-lang.org/rustdoc/the-doc-attribute.html#html_logo_url) but
+# doing it this way avoids having to set the attribute for every crate.
+curl https://www.tockos.org/assets/img/tocklogo.png --output target/doc/rust-logo.png
+curl https://www.tockos.org/assets/img/icons/favicon-32x32.png --output target/doc/favicon-32x32.png
+curl https://www.tockos.org/assets/img/icons/favicon-16x16.png --output target/doc/favicon-16x16.png
+curl https://www.tockos.org/assets/img/icons/safari-pinned-tab.svg --output target/doc/favicon.svg
+
+# Move the docs to doc/rustdoc.
 $CP_COW -r target/doc doc/rustdoc
 
 # Temporary redirect rule


### PR DESCRIPTION
### Pull Request Overview

This pull request adds to the build all docs script a few curl calls to download tock logos to replace the default rustdoc logos.

Using the `#[doc]` approach would be hard because we would have to include it in all crates, so this hack is a little easier.

Fixes #1864.


### Testing Strategy

Waiting on travis...


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
