### PR TITLE
process: allow ProcessBuffer sharing from apps for regions granted by MPU

### DIFF
--- a/kernel/src/platform/mpu.rs
+++ b/kernel/src/platform/mpu.rs
@@ -48,6 +48,12 @@ impl Region {
     pub fn size(&self) -> usize {
         self.size
     }
+
+    /// Returns true if the specified buffer is wholly contained within this region
+    pub fn contains(&self, other_address: *const u8, other_size: usize) -> bool {
+        self.start_address <= other_address
+            && other_address.wrapping_add(other_size) <= self.start_address.wrapping_add(self.size)
+    }
 }
 
 /// Null type for the default type of the `MpuConfig` type in an implementation


### PR DESCRIPTION
Let a process allow an RO or RW buffer to a memory location that it has MPU access to. This allows a application to re-share memory back to the kernel that the kernel originally shared with it.

In fully disclosure, this has a potential down side for kernel code that removes MPU regions. If the kernel allows a memory region via MPU, then an app can re-share that memory with the kernel -- everything is good so far. If the kernel then removes that MPU region, then the allowed process buffer should be revoked (or at least that is how I think it would work in an ideal world). This PR does not do that since it really isn't feasible with the current architecture.

There is no unsoundness introduced by the above downside, but logically a kernel driver could access a buffer on behalf of a app even if the original kernel-shared memory has been shared to another app.

Hopefully the RO/RW allow code will move from `SystemDriver` to kernel code similar to how subscribed moved. At that point, we will have enough information to revoke the ProcessBuffers that are within an MPU region

### Testing Strategy

 - [x] Tested on RISC-V system that a kernel buffer can be re-shared from the app back down to kernel


### Documentation Updated

- [x] None

### Formatting

- [x] Ran `make prepush`.
