### PR TITLE
kernel: hil: symmetric_encryption: Use static buffers for AES crypto

### DIFF
--- a/capsules/src/test/aes.rs
+++ b/capsules/src/test/aes.rs
@@ -13,8 +13,8 @@ pub struct TestAes128Ctr<'a, A: 'a> {
 
     key: TakeCell<'a, [u8]>,
     iv: TakeCell<'a, [u8]>,
-    source: TakeCell<'a, [u8]>,
-    data: TakeCell<'a, [u8]>,
+    source: TakeCell<'static, [u8]>,
+    data: TakeCell<'static, [u8]>,
 
     encrypting: Cell<bool>,
     use_source: Cell<bool>,
@@ -25,8 +25,8 @@ pub struct TestAes128Cbc<'a, A: 'a> {
 
     key: TakeCell<'a, [u8]>,
     iv: TakeCell<'a, [u8]>,
-    source: TakeCell<'a, [u8]>,
-    data: TakeCell<'a, [u8]>,
+    source: TakeCell<'static, [u8]>,
+    data: TakeCell<'static, [u8]>,
 
     encrypting: Cell<bool>,
     use_source: Cell<bool>,
@@ -36,8 +36,8 @@ pub struct TestAes128Ecb<'a, A: 'a> {
     aes: &'a A,
 
     key: TakeCell<'a, [u8]>,
-    source: TakeCell<'a, [u8]>,
-    data: TakeCell<'a, [u8]>,
+    source: TakeCell<'static, [u8]>,
+    data: TakeCell<'static, [u8]>,
 
     encrypting: Cell<bool>,
     use_source: Cell<bool>,
@@ -47,7 +47,12 @@ const DATA_OFFSET: usize = AES128_BLOCK_SIZE;
 const DATA_LEN: usize = 4 * AES128_BLOCK_SIZE;
 
 impl<'a, A: AES128<'a> + AES128ECB> TestAes128Ecb<'a, A> {
-    pub fn new(aes: &'a A, key: &'a mut [u8], source: &'a mut [u8], data: &'a mut [u8]) -> Self {
+    pub fn new(
+        aes: &'a A,
+        key: &'a mut [u8],
+        source: &'static mut [u8],
+        data: &'static mut [u8],
+    ) -> Self {
         TestAes128Ecb {
             aes: aes,
 
@@ -135,8 +140,8 @@ impl<'a, A: AES128<'a> + AES128Ctr> TestAes128Ctr<'a, A> {
         aes: &'a A,
         key: &'a mut [u8],
         iv: &'a mut [u8],
-        source: &'a mut [u8],
-        data: &'a mut [u8],
+        source: &'static mut [u8],
+        data: &'static mut [u8],
     ) -> Self {
         TestAes128Ctr {
             aes: aes,
@@ -232,7 +237,7 @@ impl<'a, A: AES128<'a> + AES128Ctr> TestAes128Ctr<'a, A> {
 }
 
 impl<'a, A: AES128<'a> + AES128Ctr> hil::symmetric_encryption::Client<'a> for TestAes128Ctr<'a, A> {
-    fn crypt_done(&'a self, source: Option<&'a mut [u8]>, dest: &'a mut [u8]) {
+    fn crypt_done(&'a self, source: Option<&'static mut [u8]>, dest: &'static mut [u8]) {
         if self.use_source.get() {
             // Take back the source buffer
             self.source.put(source);
@@ -287,8 +292,8 @@ impl<'a, A: AES128<'a> + AES128CBC> TestAes128Cbc<'a, A> {
         aes: &'a A,
         key: &'a mut [u8],
         iv: &'a mut [u8],
-        source: &'a mut [u8],
-        data: &'a mut [u8],
+        source: &'static mut [u8],
+        data: &'static mut [u8],
     ) -> Self {
         TestAes128Cbc {
             aes: aes,
@@ -385,7 +390,7 @@ impl<'a, A: AES128<'a> + AES128CBC> TestAes128Cbc<'a, A> {
 }
 
 impl<'a, A: AES128<'a> + AES128CBC> hil::symmetric_encryption::Client<'a> for TestAes128Cbc<'a, A> {
-    fn crypt_done(&'a self, source: Option<&'a mut [u8]>, dest: &'a mut [u8]) {
+    fn crypt_done(&'a self, source: Option<&'static mut [u8]>, dest: &'static mut [u8]) {
         if self.use_source.get() {
             // Take back the source buffer
             self.source.put(source);
@@ -440,7 +445,7 @@ impl<'a, A: AES128<'a> + AES128CBC> hil::symmetric_encryption::Client<'a> for Te
 }
 
 impl<'a, A: AES128<'a> + AES128ECB> hil::symmetric_encryption::Client<'a> for TestAes128Ecb<'a, A> {
-    fn crypt_done(&'a self, source: Option<&'a mut [u8]>, dest: &'a mut [u8]) {
+    fn crypt_done(&'a self, source: Option<&'static mut [u8]>, dest: &'static mut [u8]) {
         if self.use_source.get() {
             // Take back the source buffer
             self.source.put(source);

--- a/capsules/src/virtual_aes_ccm.rs
+++ b/capsules/src/virtual_aes_ccm.rs
@@ -225,7 +225,7 @@ impl<'a, A: AES128<'a> + AES128Ctr + AES128CBC + AES128ECB> DynamicDeferredCallC
 impl<'a, A: AES128<'a> + AES128Ctr + AES128CBC + AES128ECB> symmetric_encryption::Client<'a>
     for MuxAES128CCM<'a, A>
 {
-    fn crypt_done(&'a self, source: Option<&'a mut [u8]>, dest: &'a mut [u8]) {
+    fn crypt_done(&'a self, source: Option<&'static mut [u8]>, dest: &'static mut [u8]) {
         if self.inflight.is_none() {
             self.client.map(move |client| {
                 client.crypt_done(source, dest);
@@ -248,7 +248,7 @@ pub struct VirtualAES128CCM<'a, A: AES128<'a> + AES128Ctr + AES128CBC + AES128EC
     aes: &'a A,
     next: ListLink<'a, VirtualAES128CCM<'a, A>>,
 
-    crypt_buf: TakeCell<'a, [u8]>,
+    crypt_buf: TakeCell<'static, [u8]>,
     crypt_auth_len: Cell<usize>,
     crypt_enc_len: Cell<usize>,
     ccm_client: OptionalCell<&'a dyn symmetric_encryption::CCMClient>,
@@ -772,12 +772,16 @@ impl<'a, A: AES128<'a> + AES128Ctr + AES128CBC + AES128ECB> symmetric_encryption
     }
 
     fn crypt(
-        &'a self,
-        source: Option<&'a mut [u8]>,
-        dest: &'a mut [u8],
+        &self,
+        source: Option<&'static mut [u8]>,
+        dest: &'static mut [u8],
         start_index: usize,
         stop_index: usize,
-    ) -> Option<(Result<(), ErrorCode>, Option<&'a mut [u8]>, &'a mut [u8])> {
+    ) -> Option<(
+        Result<(), ErrorCode>,
+        Option<&'static mut [u8]>,
+        &'static mut [u8],
+    )> {
         if self.mux.inflight.is_none() {
             self.mux.aes.crypt(source, dest, start_index, stop_index)
         } else {
@@ -819,7 +823,7 @@ impl<'a, A: AES128<'a> + AES128Ctr + AES128CBC + AES128ECB> AES128CBC for Virtua
 impl<'a, A: AES128<'a> + AES128Ctr + AES128CBC + AES128ECB> symmetric_encryption::Client<'a>
     for VirtualAES128CCM<'a, A>
 {
-    fn crypt_done(&self, _: Option<&'a mut [u8]>, crypt_buf: &'a mut [u8]) {
+    fn crypt_done(&self, _: Option<&'static mut [u8]>, crypt_buf: &'static mut [u8]) {
         self.crypt_buf.replace(crypt_buf);
         match self.state.get() {
             CCMState::Idle => {}

--- a/chips/earlgrey/src/aes.rs
+++ b/chips/earlgrey/src/aes.rs
@@ -116,8 +116,8 @@ pub struct Aes<'a> {
     registers: StaticRef<AesRegisters>,
 
     client: OptionalCell<&'a dyn hil::symmetric_encryption::Client<'a>>,
-    source: TakeCell<'a, [u8]>,
-    dest: TakeCell<'a, [u8]>,
+    source: TakeCell<'static, [u8]>,
+    dest: TakeCell<'static, [u8]>,
     mode: Cell<Mode>,
 
     deferred_call: Cell<bool>,
@@ -375,12 +375,16 @@ impl<'a> hil::symmetric_encryption::AES128<'a> for Aes<'a> {
     fn start_message(&self) {}
 
     fn crypt(
-        &'a self,
-        source: Option<&'a mut [u8]>,
-        dest: &'a mut [u8],
+        &self,
+        source: Option<&'static mut [u8]>,
+        dest: &'static mut [u8],
         start_index: usize,
         stop_index: usize,
-    ) -> Option<(Result<(), ErrorCode>, Option<&'a mut [u8]>, &'a mut [u8])> {
+    ) -> Option<(
+        Result<(), ErrorCode>,
+        Option<&'static mut [u8]>,
+        &'static mut [u8],
+    )> {
         match stop_index.checked_sub(start_index) {
             None => return Some((Err(ErrorCode::INVAL), source, dest)),
             Some(s) => {

--- a/chips/nrf5x/src/aes.rs
+++ b/chips/nrf5x/src/aes.rs
@@ -124,8 +124,8 @@ pub struct AesECB<'a> {
     registers: StaticRef<AesEcbRegisters>,
     client: OptionalCell<&'a dyn kernel::hil::symmetric_encryption::Client<'a>>,
     /// Input either plaintext or ciphertext to be encrypted or decrypted.
-    input: TakeCell<'a, [u8]>,
-    output: TakeCell<'a, [u8]>,
+    input: TakeCell<'static, [u8]>,
+    output: TakeCell<'static, [u8]>,
     /// Keystream to be XOR'ed with the input.
     keystream: Cell<[u8; MAX_LENGTH]>,
     current_idx: Cell<usize>,
@@ -294,12 +294,16 @@ impl<'a> kernel::hil::symmetric_encryption::AES128<'a> for AesECB<'a> {
     // start_index and stop_index not used!!!
     // assuming that
     fn crypt(
-        &'a self,
-        source: Option<&'a mut [u8]>,
-        dest: &'a mut [u8],
+        &self,
+        source: Option<&'static mut [u8]>,
+        dest: &'static mut [u8],
         start_index: usize,
         stop_index: usize,
-    ) -> Option<(Result<(), ErrorCode>, Option<&'a mut [u8]>, &'a mut [u8])> {
+    ) -> Option<(
+        Result<(), ErrorCode>,
+        Option<&'static mut [u8]>,
+        &'static mut [u8],
+    )> {
         match source {
             None => Some((Err(ErrorCode::INVAL), source, dest)),
             Some(src) => {

--- a/chips/sam4l/src/aes.rs
+++ b/chips/sam4l/src/aes.rs
@@ -147,8 +147,8 @@ pub struct Aes<'a> {
     registers: StaticRef<AesRegisters>,
 
     client: OptionalCell<&'a dyn hil::symmetric_encryption::Client<'a>>,
-    source: TakeCell<'a, [u8]>,
-    dest: TakeCell<'a, [u8]>,
+    source: TakeCell<'static, [u8]>,
+    dest: TakeCell<'static, [u8]>,
 
     // An index into `source` (or `dest` if that does not exist),
     // marking how much data has been written to the AESA
@@ -468,12 +468,16 @@ impl<'a> hil::symmetric_encryption::AES128<'a> for Aes<'a> {
     }
 
     fn crypt(
-        &'a self,
-        source: Option<&'a mut [u8]>,
-        dest: &'a mut [u8],
+        &self,
+        source: Option<&'static mut [u8]>,
+        dest: &'static mut [u8],
         start_index: usize,
         stop_index: usize,
-    ) -> Option<(Result<(), ErrorCode>, Option<&'a mut [u8]>, &'a mut [u8])> {
+    ) -> Option<(
+        Result<(), ErrorCode>,
+        Option<&'static mut [u8]>,
+        &'static mut [u8],
+    )> {
         if self.busy() {
             Some((Err(ErrorCode::BUSY), source, dest))
         } else {

--- a/kernel/src/hil/symmetric_encryption.rs
+++ b/kernel/src/hil/symmetric_encryption.rs
@@ -7,7 +7,7 @@ use crate::ErrorCode;
 /// Implement this trait and use `set_client()` in order to receive callbacks from an `AES128`
 /// instance.
 pub trait Client<'a> {
-    fn crypt_done(&'a self, source: Option<&'a mut [u8]>, dest: &'a mut [u8]);
+    fn crypt_done(&'a self, source: Option<&'static mut [u8]>, dest: &'static mut [u8]);
 }
 
 /// The number of bytes used for AES block operations.  Keys and IVs must have this length,
@@ -78,12 +78,16 @@ pub trait AES128<'a> {
     /// across calls to `crypt()`.
     ///
     fn crypt(
-        &'a self,
-        source: Option<&'a mut [u8]>,
-        dest: &'a mut [u8],
+        &self,
+        source: Option<&'static mut [u8]>,
+        dest: &'static mut [u8],
         start_index: usize,
         stop_index: usize,
-    ) -> Option<(Result<(), ErrorCode>, Option<&'a mut [u8]>, &'a mut [u8])>;
+    ) -> Option<(
+        Result<(), ErrorCode>,
+        Option<&'static mut [u8]>,
+        &'static mut [u8],
+    )>;
 }
 
 pub trait AES128Ctr {


### PR DESCRIPTION
### Pull Request Overview

Use `'static` buffers for the AES crypto operations

### Testing Strategy

CI

### TODO or Help Wanted

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
