### PR TITLE
Stored state

### DIFF
--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -589,6 +589,13 @@ pub trait Process {
     /// various process data structures.
     fn get_sizes(&self) -> ProcessSizes;
 
+    /// Write stored state as a binary blob into the `out` slice. Returns the number of bytes
+    /// written to `out` on success.
+    ///
+    /// Returns `ErrorCode::SIZE` if `out` is too short to hold the stored state binary
+    /// representation. Returns `ErrorCode::FAIL` on an internal error.
+    fn get_stored_state(&self, out: &mut [u8]) -> Result<usize, ErrorCode>;
+
     /// Print out the full state of the process: its memory map, its
     /// context, and the state of the memory protection unit (MPU).
     fn print_full_process(&self, writer: &mut dyn Write);
@@ -623,10 +630,6 @@ pub trait Process {
 
     /// Return the lowest recorded address of the process stack, if known.
     fn debug_stack_end(&self) -> Option<*const u8>;
-
-    /// Export stored state as a binary blob. Returns the number of items
-    /// written on success.
-    fn get_stored_state(&self, out: &mut [u8]) -> Result<usize, ErrorCode>;
 }
 
 /// Opaque identifier for custom grants allocated dynamically from a process's

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -623,6 +623,10 @@ pub trait Process {
 
     /// Return the lowest recorded address of the process stack, if known.
     fn debug_stack_end(&self) -> Option<*const u8>;
+
+    /// Export stored state as a binary blob. Returns the number of items
+    /// written on success.
+    fn get_stored_state(&self, out: &mut [u8]) -> Result<usize, ErrorCode>;
 }
 
 /// Opaque identifier for custom grants allocated dynamically from a process's

--- a/kernel/src/process_standard.rs
+++ b/kernel/src/process_standard.rs
@@ -1237,6 +1237,16 @@ impl<C: Chip> Process for ProcessStandard<'_, C> {
             }
         });
     }
+
+    fn get_stored_state(&self, out: &mut [u8]) -> Result<usize, ErrorCode> {
+        self.stored_state
+            .map(|stored_state| {
+                self.chip
+                    .userspace_kernel_boundary()
+                    .store_context(stored_state, out)
+            })
+            .unwrap_or(Err(ErrorCode::FAIL))
+    }
 }
 
 impl<C: 'static + Chip> ProcessStandard<'_, C> {

--- a/kernel/src/syscall.rs
+++ b/kernel/src/syscall.rs
@@ -648,4 +648,8 @@ pub trait UserspaceKernelBoundary {
         state: &Self::StoredState,
         writer: &mut dyn Write,
     );
+
+    /// Store architecture specific (e.g. CPU registers or status flags) data
+    /// for a process. On success returns the number of elements written to out.
+    fn store_context(&self, state: &Self::StoredState, out: &mut [u8]) -> Result<usize, ErrorCode>;
 }


### PR DESCRIPTION
### Pull Request Overview

This pull request adds/changes/fixes...
Adds the ability to to serialize StoredState. Along with PR #2822, this enables crash information to be exported and fetched on a later boot.

### Testing Strategy

This pull request was tested by...
Tested export, import, and print of RISC-V StoredState.


### TODO or Help Wanted

This pull request still needs...


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.
N/A?

### Formatting

- [x] Ran `make prepush`.
