### PR TITLE
Update console system call docs to match implementation and use

### DIFF
--- a/doc/syscalls/00001_console.md
+++ b/doc/syscalls/00001_console.md
@@ -88,8 +88,9 @@ share a buffer for every write transaction, even if it's the same buffer.
     **Description**: Subscribe to read transaction completion event. The
     callback will be called whenever a read transaction completes.
 
-    **Callback signature**: The callback receives a single argument, the number
-    of bytes read in the transaction. The value of the remaining arguments
+    **Callback signature**: The callback receives two arguments. The first
+    is a statuscode, containing any error if one occurred. The second is the
+    number of bytes read in the transaction. The value of the remaining arguments
     is undefined.
 
     **Returns**: Ok(()) if the subscribe was successful or NOMEM if the


### PR DESCRIPTION
### Pull Request Overview

This pull request updates the console `subscribe(2)` system call docs to accurately reflect the types passed in the callback to userspace. The docs now match the code in the console driver (https://github.com/tock/tock/blob/master/capsules/src/console.rs#L401) and the way that the callback is used by libtock-c (https://github.com/tock/libtock-c/blob/c0ec4fba3d9fa150845e810c29f13bcbf80e0266/examples/tests/console_recv_short/main.c#L11 , among others). I verified that libtock-c expects the arguments that are in fact passed by the driver in every case where this system call is used. libtock-rs does not have a working 2.0 console implementation yet, and thus does not apply here.

My opinion on this change is that it is merely correcting a bug in the system call API docs, and thus does not require a version bump. This change cannot break user code, given that no code is changing, and it is hard to imagine any code exists that expects the API as it was originally documented, as code expecting that would not work on any version of the Tock kernel which has ever been released.

Thanks to @jettr for pointing out this documentation bug (https://github.com/tock/tock/pull/2834#issuecomment-954802685).


### Testing Strategy

N/A

### TODO or Help Wanted

N/A

### Documentation Updated

- [x] Updated the relevant files in `/docs`.

### Formatting

- [x] Ran `make prepush`.
