### PR TITLE
Remove 'a lifetime constraint on &self parameters in Timer & Counter hil

### DIFF
--- a/boards/imix/src/multi_timer_test.rs
+++ b/boards/imix/src/multi_timer_test.rs
@@ -29,6 +29,8 @@ unsafe fn static_init_multi_timer_test(
     mux: &'static MuxTimer<'static, Ast<'static>>,
 ) -> [&'static TestRandomTimer<'static, VirtualTimer<'static, Ast<'static>>>; 3] {
     let virtual_timer1 = static_init!(VirtualTimer<'static, Ast<'static>>, VirtualTimer::new(mux));
+    virtual_timer1.setup();
+
     let test1 = static_init!(
         TestRandomTimer<'static, VirtualTimer<'static, Ast<'static>>>,
         TestRandomTimer::new(virtual_timer1, 19, 'A')
@@ -36,6 +38,8 @@ unsafe fn static_init_multi_timer_test(
     virtual_timer1.set_timer_client(test1);
 
     let virtual_timer2 = static_init!(VirtualTimer<'static, Ast<'static>>, VirtualTimer::new(mux));
+    virtual_timer2.setup();
+
     let test2 = static_init!(
         TestRandomTimer<'static, VirtualTimer<'static, Ast<'static>>>,
         TestRandomTimer::new(virtual_timer2, 37, 'B')
@@ -43,6 +47,8 @@ unsafe fn static_init_multi_timer_test(
     virtual_timer2.set_timer_client(test2);
 
     let virtual_timer3 = static_init!(VirtualTimer<'static, Ast<'static>>, VirtualTimer::new(mux));
+    virtual_timer3.setup();
+
     let test3 = static_init!(
         TestRandomTimer<'static, VirtualTimer<'static, Ast<'static>>>,
         TestRandomTimer::new(virtual_timer3, 89, 'C')

--- a/chips/apollo3/src/stimer.rs
+++ b/chips/apollo3/src/stimer.rs
@@ -132,7 +132,7 @@ impl Time for STimer<'_> {
 }
 
 impl<'a> Counter<'a> for STimer<'a> {
-    fn set_overflow_client(&'a self, _client: &'a dyn OverflowClient) {
+    fn set_overflow_client(&self, _client: &'a dyn OverflowClient) {
         //self.overflow_client.set(client);
     }
 

--- a/chips/earlgrey/src/timer.rs
+++ b/chips/earlgrey/src/timer.rs
@@ -108,7 +108,7 @@ impl time::Time for RvTimer<'_> {
 }
 
 impl<'a> time::Counter<'a> for RvTimer<'a> {
-    fn set_overflow_client(&'a self, client: &'a dyn time::OverflowClient) {
+    fn set_overflow_client(&self, client: &'a dyn time::OverflowClient) {
         self.overflow_client.set(client);
     }
 

--- a/chips/esp32/src/timg.rs
+++ b/chips/esp32/src/timg.rs
@@ -157,7 +157,7 @@ impl time::Time for TimG<'_> {
 }
 
 impl<'a> Counter<'a> for TimG<'a> {
-    fn set_overflow_client(&'a self, _client: &'a dyn time::OverflowClient) {
+    fn set_overflow_client(&self, _client: &'a dyn time::OverflowClient) {
         // We have no way to know when this happens
     }
 

--- a/chips/msp432/src/timer.rs
+++ b/chips/msp432/src/timer.rs
@@ -336,7 +336,7 @@ impl<'a> Time for TimerA<'a> {
 }
 
 impl<'a> Counter<'a> for TimerA<'a> {
-    fn set_overflow_client(&'a self, _client: &'a dyn OverflowClient) {}
+    fn set_overflow_client(&self, _client: &'a dyn OverflowClient) {}
 
     fn start(&self) -> Result<(), ErrorCode> {
         self.setup_for_alarm();

--- a/chips/nrf5x/src/rtc.rs
+++ b/chips/nrf5x/src/rtc.rs
@@ -126,7 +126,7 @@ impl Time for Rtc<'_> {
 }
 
 impl<'a> time::Counter<'a> for Rtc<'a> {
-    fn set_overflow_client(&'a self, client: &'a dyn time::OverflowClient) {
+    fn set_overflow_client(&self, client: &'a dyn time::OverflowClient) {
         self.overflow_client.set(client);
         self.registers.intenset.write(Inte::OVRFLW::SET);
     }

--- a/chips/sam4l/src/ast.rs
+++ b/chips/sam4l/src/ast.rs
@@ -317,7 +317,7 @@ impl time::Time for Ast<'_> {
 }
 
 impl<'a> time::Counter<'a> for Ast<'a> {
-    fn set_overflow_client(&'a self, _client: &'a dyn time::OverflowClient) {}
+    fn set_overflow_client(&self, _client: &'a dyn time::OverflowClient) {}
 
     fn start(&self) -> Result<(), ErrorCode> {
         self.enable();

--- a/chips/stm32f303xc/src/tim2.rs
+++ b/chips/stm32f303xc/src/tim2.rs
@@ -373,7 +373,7 @@ impl Time for Tim2<'_> {
 }
 
 impl<'a> Counter<'a> for Tim2<'a> {
-    fn set_overflow_client(&'a self, _client: &'a dyn OverflowClient) {}
+    fn set_overflow_client(&self, _client: &'a dyn OverflowClient) {}
 
     // starts the timer
     fn start(&self) -> Result<(), ErrorCode> {

--- a/chips/stm32f4xx/src/tim2.rs
+++ b/chips/stm32f4xx/src/tim2.rs
@@ -371,7 +371,7 @@ impl Time for Tim2<'_> {
 }
 
 impl<'a> Counter<'a> for Tim2<'a> {
-    fn set_overflow_client(&'a self, _client: &'a dyn OverflowClient) {}
+    fn set_overflow_client(&self, _client: &'a dyn OverflowClient) {}
 
     // starts the timer
     fn start(&self) -> Result<(), ErrorCode> {

--- a/chips/swerv/src/eh1_timer.rs
+++ b/chips/swerv/src/eh1_timer.rs
@@ -85,7 +85,7 @@ impl time::Time for Timer<'_> {
 }
 
 impl<'a> Counter<'a> for Timer<'a> {
-    fn set_overflow_client(&'a self, _client: &'a dyn time::OverflowClient) {
+    fn set_overflow_client(&self, _client: &'a dyn time::OverflowClient) {
         // We have no way to know when this happens
     }
 

--- a/chips/swervolf-eh1/src/syscon.rs
+++ b/chips/swervolf-eh1/src/syscon.rs
@@ -111,7 +111,7 @@ impl time::Time for SysCon<'_> {
 }
 
 impl<'a> time::Counter<'a> for SysCon<'a> {
-    fn set_overflow_client(&'a self, client: &'a dyn time::OverflowClient) {
+    fn set_overflow_client(&self, client: &'a dyn time::OverflowClient) {
         self.overflow_client.set(client);
     }
 

--- a/doc/reference/trd105-time.md
+++ b/doc/reference/trd105-time.md
@@ -188,7 +188,7 @@ pub trait Counter<'a>: Time {
   fn stop(&self) -> Result<(), ErrorCode>;
   fn reset(&self) -> Result<(), ErrorCode>;
   fn is_running(&self) -> bool;
-  fn set_overflow_client(&'a self, &'a dyn OverflowClient);
+  fn set_overflow_client(&self, &'a dyn OverflowClient);
 }
 ```
 

--- a/doc/reference/trd105-time.md
+++ b/doc/reference/trd105-time.md
@@ -303,7 +303,7 @@ pub trait TimerClient {
 }
 
 pub trait Timer<'a>: Time {
-  fn set_timer_client(&'a self, &'a dyn TimerClient);
+  fn set_timer_client(&self, &'a dyn TimerClient);
   fn oneshot(&self, interval: Self::Ticks) -> Self::Ticks;
   fn repeating(&self, interval: Self::Ticks) -> Self::Ticks;
 

--- a/kernel/src/hil/time.rs
+++ b/kernel/src/hil/time.rs
@@ -162,7 +162,7 @@ pub trait Counter<'a>: Time {
     /// Specify the callback for when the counter overflows its maximum
     /// value (defined by `Ticks`). If there was a previously registered
     /// callback this call replaces it.
-    fn set_overflow_client(&'a self, client: &'a dyn OverflowClient);
+    fn set_overflow_client(&self, client: &'a dyn OverflowClient);
 
     /// Starts the free-running hardware counter. Valid `Result<(), ErrorCode>` values are:
     ///   - `Ok(())`: the counter is now running

--- a/kernel/src/hil/time.rs
+++ b/kernel/src/hil/time.rs
@@ -267,7 +267,7 @@ pub trait TimerClient {
 pub trait Timer<'a>: Time {
     /// Specify the callback to invoke when the timer interval expires.
     /// If there was a previously installed callback this call replaces it.    
-    fn set_timer_client(&'a self, client: &'a dyn TimerClient);
+    fn set_timer_client(&self, client: &'a dyn TimerClient);
 
     /// Start a one-shot timer that will invoke the callback at least
     /// `interval` ticks in the future. If there is a timer currently pending,
@@ -276,14 +276,14 @@ pub trait Timer<'a>: Time {
     /// unless a new timer is started (either with repeating or one shot).
     /// Returns the actual interval for the timer that was registered.
     /// This MUST NOT be smaller than `interval` but MAY be larger.
-    fn oneshot(&'a self, interval: Self::Ticks) -> Self::Ticks;
+    fn oneshot(&self, interval: Self::Ticks) -> Self::Ticks;
 
     /// Start a repeating timer that will invoke the callback every
     /// `interval` ticks in the future. If there is a timer currently
     /// pending, calling this cancels that previous timer.
     /// Returns the actual interval for the timer that was registered.
     /// This MUST NOT be smaller than `interval` but MAY be larger.
-    fn repeating(&'a self, interval: Self::Ticks) -> Self::Ticks;
+    fn repeating(&self, interval: Self::Ticks) -> Self::Ticks;
 
     /// Return the interval of the last requested timer.
     fn interval(&self) -> Option<Self::Ticks>;


### PR DESCRIPTION
### Pull Request Overview

Add a `setup()` function on `VirtualMuxTimer` that links that instance to the mux. We use new `setup` function instead of relying on `oneshot` or `repeating` to link the virtual timer to the mux. This allows us to remove the `'a` lifetime constraint on the timer hil, which was an artifact of the virtual timer implementation.

Also update the `Counter` hil in the same way. We just need to remove the `'a` constraint -- nothing was relying on it.

This completes the work for #2851

### Testing Strategy

Rely on compiler and CI

### Documentation Updated

- [x] Updated pending time TRD to remove `'a` lifetime on all appropriate functions

### Formatting

- [x] Ran `make prepush`.
