### PR TITLE
Restructure the USB stack to be more modular

### DIFF
--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -108,13 +108,13 @@ static mut NRF52_POWER: Option<&'static nrf52840::power::Power> = None;
 pub static mut STACK_MEMORY: [u8; 0x1000] = [0; 0x1000];
 
 // Function for the CDC/USB stack to use to enter the bootloader.
-fn baud_rate_reset_bootloader_enter() {
+/*fn baud_rate_reset_bootloader_enter() {
     unsafe {
         // 0x90 is the magic value the bootloader expects
         NRF52_POWER.unwrap().set_gpregret(0x90);
         cortexm4::scb::reset();
     }
-}
+}*/
 
 /// Supported drivers by the platform
 pub struct Platform {
@@ -332,21 +332,42 @@ pub unsafe fn main() {
     // Setup the CDC-ACM over USB driver that we will use for UART.
     // We use the Arduino Vendor ID and Product ID since the device is the same.
 
-    // Create the strings we include in the USB descriptor. We use the hardcoded
-    // DEVICEADDR register on the nRF52 to set the serial number.
-    let serial_number_buf = static_init!([u8; 17], [0; 17]);
-    let serial_number_string: &'static str =
-        nrf52::ficr::FICR_INSTANCE.address_str(serial_number_buf);
-    let strings = static_init!(
-        [&str; 3],
-        [
-            "Arduino",              // Manufacturer
-            "Nano 33 BLE - TockOS", // Product
-            serial_number_string,   // Serial number
-        ]
-    );
+    let bulk_simple = static_init!(capsules::usb::bulk_simple::BulkSimple<'static, nrf52::usbd::Usbd>,
+            capsules::usb::bulk_simple::BulkSimple::new(&nrf52840_peripherals.usbd));
+    let usb = {
+        use capsules::usb::{device, configuration};
+        // Create the strings we include in the USB descriptor. We use the hardcoded
+        // DEVICEADDR register on the nRF52 to set the serial number.
+        let serial_number_buf = static_init!([u8; 17], [0; 17]);
+        let serial_number_string: &'static str =
+            nrf52::ficr::FICR_INSTANCE.address_str(serial_number_buf);
 
-    let cdc = components::cdc::CdcAcmComponent::new(
+        let device_descriptor = device::DevDescriptor {
+            vendor_id: 0x6667,
+            product_id: 0xabcd,
+            manufacturer_string: "Arduino",
+            product_string: "Nano 33 BLE - TockOS",
+            serial_number_string: serial_number_string,
+            class: 0x2, // Class: CDC
+            usb_release: 0x0200,
+            subclass: 0,
+            protocol: 0,
+            device_release: 0x0001,
+        };
+
+        let configuration = configuration::SimpleConfiguration {
+            interfaces: [bulk_simple] as [&dyn configuration::Interface; 1],
+            is_self_powered: false,
+            supports_remote_wakeup: false,
+            max_power: 50,
+            _f: core::marker::PhantomData,
+        };
+        static_init!(
+            device::Device<'static, nrf52::usbd::Usbd, configuration::SimpleConfiguration<'static, [&'static dyn configuration::Interface; 1]>>,
+            device::Device::new(&nrf52840_peripherals.usbd, device_descriptor, configuration, 0x0409))
+    };
+    kernel::hil::usb::UsbController::set_client(&nrf52840_peripherals.usbd, usb);
+    /*let cdc = components::cdc::CdcAcmComponent::new(
         &nrf52840_peripherals.usbd,
         capsules::usb::cdc::MAX_CTRL_PACKET_SIZE_NRF52840,
         0x2341,
@@ -360,10 +381,10 @@ pub unsafe fn main() {
         nrf52::usbd::Usbd,
         nrf52::rtc::Rtc
     ));
-    CDC_REF_FOR_PANIC = Some(cdc); //for use by panic handler
+    CDC_REF_FOR_PANIC = Some(cdc); //for use by panic handler*/
 
     // Create a shared UART channel for the console and for kernel debug.
-    let uart_mux = components::console::UartMuxComponent::new(cdc, 115200, dynamic_deferred_caller)
+    let uart_mux = components::console::UartMuxComponent::new(bulk_simple, 115200, dynamic_deferred_caller)
         .finalize(());
 
     let pconsole = components::process_console::ProcessConsoleComponent::new(
@@ -641,8 +662,8 @@ pub unsafe fn main() {
     chip.mpu().clear_mpu();
 
     // Configure the USB stack to enable a serial port over CDC-ACM.
-    cdc.enable();
-    cdc.attach();
+    usb.enable();
+    usb.attach();
 
     //--------------------------------------------------------------------------
     // TESTS

--- a/capsules/src/usb/bulk_echo.rs
+++ b/capsules/src/usb/bulk_echo.rs
@@ -1,0 +1,161 @@
+use core::cell::Cell;
+use kernel::hil::usb::*;
+use kernel::utilities::cells::OptionalCell;
+use super::configuration::*;
+use super::descriptors::*;
+
+pub struct BulkEcho<'a, C> {
+    data_out: Endpoint,
+    data_in: Endpoint,
+    echo_buf: [Cell<u8>; 8], // Must be no larger than endpoint packet buffer
+    echo_len: Cell<usize>,
+    delayed_out: Cell<bool>,
+    controller: &'a C,
+}
+
+impl<'a, C: UsbController<'a>> BulkEcho<'a, C> {
+    pub fn new(controller: &'a C) -> Self {
+        Self {
+            controller,
+            data_out: Endpoint {
+                direction: TransferDirection::DeviceToHost,
+                transfer_type: TransferType::Bulk,
+                interval: 0,
+                buffer: Some(super::descriptors::Buffer64::empty()),
+                endpoint_number: OptionalCell::empty(),
+            },
+            data_in: Endpoint {
+                direction: TransferDirection::HostToDevice,
+                transfer_type: TransferType::Bulk,
+                interval: 0,
+                buffer: Some(super::descriptors::Buffer64::empty()),
+                endpoint_number: OptionalCell::empty(),
+            },
+            echo_buf: Default::default(),
+            echo_len: Cell::new(0),
+            delayed_out: Cell::new(false),
+        }
+    }
+
+    fn alert_full(&self) {
+        // Alert the controller that we now have data to send on the Bulk IN endpoint 1
+        if let Some(endpoint_number) = self.data_out.endpoint_number.extract() {
+            self.controller.endpoint_resume_in(endpoint_number as usize);
+        }
+    }
+
+    fn alert_empty(&self) {
+        if let Some(endpoint_number) = self.data_in.endpoint_number.extract() {
+            if self.delayed_out.take() {
+                self.controller.endpoint_resume_out(endpoint_number as usize);
+            }
+        }
+    }
+}
+
+impl<'a, C: UsbController<'a>> Interface for BulkEcho<'a, C> {
+    fn details(&self) -> InterfaceDetails {
+        InterfaceDetails {
+            interface_class: 0xff,    // vendor specific
+            interface_subclass: 0xab, // none
+            interface_protocol: 0x00, // none
+            alternate_setting: 0,
+            string_index: 0,
+            num_endpoints: 2,
+        }
+    }
+
+    fn class_descriptor(&self, _i: usize) -> Option<&dyn Descriptor> {
+        None
+    }
+
+    fn endpoint(&self, i: usize) -> Option<&Endpoint> {
+        match i {
+            0 => Some(&self.data_out),
+            1 => Some(&self.data_in),
+            _ => None,
+        }
+    }
+
+    /// Handle a Bulk/Interrupt IN transaction
+    fn packet_in(&self, transfer_type: TransferType, endpoint: usize) -> InResult {
+        match transfer_type {
+            TransferType::Interrupt => {
+                InResult::Error
+            }
+            TransferType::Bulk => {
+                // Write a packet into the endpoint buffer
+                let packet_bytes = self.echo_len.get();
+                if packet_bytes > 0 {
+                    // Copy the entire echo buffer into the packet
+                    let packet = self.data_out.buffer();
+                    for i in 0..packet_bytes {
+                        packet[i].set(self.echo_buf[i].get());
+                    }
+                    self.echo_len.set(0);
+
+                    // We can receive more now
+                    self.alert_empty();
+
+                    InResult::Packet(packet_bytes)
+                } else {
+                    // Nothing to send
+                    InResult::Delay
+                }
+            }
+            TransferType::Control | TransferType::Isochronous => unreachable!(),
+        }
+    }
+
+    /// Handle a Bulk/Interrupt OUT transaction
+    fn packet_out(
+        &self,
+        transfer_type: TransferType,
+        endpoint: usize,
+        packet_bytes: u32,
+    ) -> OutResult {
+        match transfer_type {
+            TransferType::Interrupt => {
+                OutResult::Error
+            }
+            TransferType::Bulk => {
+                // Consume a packet from the endpoint buffer
+                let new_len = packet_bytes as usize;
+                let current_len = self.echo_len.get();
+                let total_len = current_len + new_len as usize;
+
+                if total_len > self.echo_buf.len() {
+                    // The packet won't fit in our little buffer.  We'll have
+                    // to wait until it is drained
+                    self.delayed_out.set(true);
+                    OutResult::Delay
+                } else if new_len > 0 {
+                    // Copy the packet into our echo buffer
+                    let packet = self.data_in.buffer();
+                    for i in 0..new_len {
+                        self.echo_buf[current_len + i].set(packet[i].get());
+                    }
+                    self.echo_len.set(total_len);
+
+                    // We can start sending again
+                    self.alert_full();
+                    OutResult::Ok
+                } else {
+                    OutResult::Ok
+                }
+            }
+            TransferType::Control | TransferType::Isochronous => unreachable!(),
+        }
+    }
+
+    fn bus_reset(&self) {
+        // Should the client initiate reconfiguration here?
+        // For now, the hardware layer does it.
+
+        // Reset the state for our pair of debugging endpoints
+        self.echo_len.set(0);
+        self.delayed_out.set(false);
+    }
+
+}
+

--- a/capsules/src/usb/bulk_simple.rs
+++ b/capsules/src/usb/bulk_simple.rs
@@ -1,0 +1,320 @@
+use core::cell::Cell;
+use core::cmp;
+use kernel::hil::uart::{self, Configure, Transmit, TransmitClient, Receive, ReceiveClient, Parameters};
+use kernel::hil::usb::*;
+use kernel::ErrorCode;
+use kernel::utilities::cells::OptionalCell;
+use kernel::utilities::cells::TakeCell;
+use super::configuration::*;
+use super::descriptors::*;
+
+pub struct BulkSimple<'a, C> {
+    data_out: Endpoint,
+    data_in: Endpoint,
+    controller: &'a C,
+
+    /// A holder reference for the TX buffer we are transmitting from.
+    tx_buffer: TakeCell<'static, [u8]>,
+    /// The number of bytes the client has asked us to send. We track this so we
+    /// can pass it back to the client when the transmission has finished.
+    tx_len: Cell<usize>,
+    /// Where in the `tx_buffer` we need to start sending from when we continue.
+    tx_offset: Cell<usize>,
+    /// The TX client to use when transmissions finish.
+    tx_client: OptionalCell<&'a dyn TransmitClient>,
+
+    /// A holder for the buffer to receive bytes into. We use this as a flag as
+    /// well, if we have a buffer then we are actively doing a receive.
+    rx_buffer: TakeCell<'static, [u8]>,
+    /// How many bytes the client wants us to receive.
+    rx_len: Cell<usize>,
+    /// How many bytes we have received so far.
+    rx_offset: Cell<usize>,
+    /// The RX client to use when RX data is received.
+    rx_client: OptionalCell<&'a dyn ReceiveClient>,
+    reset: Cell<bool>,
+}
+
+impl<'a, C: UsbController<'a>> BulkSimple<'a, C> {
+    pub fn new(controller: &'a C) -> Self {
+        Self {
+            controller,
+            data_out: Endpoint {
+                direction: TransferDirection::DeviceToHost,
+                transfer_type: TransferType::Bulk,
+                interval: 0,
+                buffer: Some(super::descriptors::Buffer64::empty()),
+                endpoint_number: OptionalCell::empty(),
+            },
+            data_in: Endpoint {
+                direction: TransferDirection::HostToDevice,
+                transfer_type: TransferType::Bulk,
+                interval: 0,
+                buffer: Some(super::descriptors::Buffer64::empty()),
+                endpoint_number: OptionalCell::empty(),
+            },
+            tx_buffer: TakeCell::empty(),
+            tx_len: Cell::new(0),
+            tx_offset: Cell::new(0),
+            tx_client: OptionalCell::empty(),
+            rx_buffer: TakeCell::empty(),
+            rx_len: Cell::new(0),
+            rx_offset: Cell::new(0),
+            rx_client: OptionalCell::empty(),
+
+            reset: Cell::new(false),
+        }
+    }
+
+    fn alert_full(&self) {
+        // Alert the controller that we now have data to send on the Bulk IN endpoint 1
+        if let Some(endpoint_number) = self.data_out.endpoint_number.extract() {
+            self.controller.endpoint_resume_in(endpoint_number as usize);
+        }
+    }
+
+    fn alert_empty(&self) {
+        if let Some(endpoint_number) = self.data_in.endpoint_number.extract() {
+            self.controller.endpoint_resume_out(endpoint_number as usize);
+        }
+    }
+}
+
+impl<'a, C: UsbController<'a>> Interface for BulkSimple<'a, C> {
+    fn details(&self) -> InterfaceDetails {
+        InterfaceDetails {
+            interface_class: 0xff,    // vendor specific
+            interface_subclass: 0xab, // none
+            interface_protocol: 0x00, // none
+            alternate_setting: 0,
+            string_index: 0,
+            num_endpoints: 2,
+        }
+    }
+
+    fn class_descriptor(&self, _i: usize) -> Option<&dyn Descriptor> {
+        None
+    }
+
+    fn endpoint(&self, i: usize) -> Option<&Endpoint> {
+        match i {
+            0 => Some(&self.data_out),
+            1 => Some(&self.data_in),
+            _ => None,
+        }
+    }
+
+    /// Handle a Bulk/Interrupt IN transaction
+    fn packet_in(&self, transfer_type: TransferType, _endpoint: usize) -> InResult {
+        match transfer_type {
+            TransferType::Bulk => {
+                self.tx_buffer
+                    .take()
+                    .map_or(InResult::Delay, |tx_buf| {
+                        // Check if we have any bytes to send.
+                        let offset = self.tx_offset.get();
+                        let remaining = self.tx_len.get() - offset;
+                        if remaining > 0 {
+                            // We do, so we go ahead and send those.
+
+                            // Get packet that we have shared with the underlying
+                            // USB stack to copy the tx into.
+                            let packet = self.data_out.buffer();
+
+                            // Calculate how much more we can send.
+                            let to_send = cmp::min(packet.len(), remaining);
+
+                            // Copy from the TX buffer to the outgoing USB packet.
+                            for i in 0..to_send {
+                                packet[i].set(tx_buf[offset + i]);
+                            }
+
+                            // Update our state on how much more there is to send.
+                            self.tx_offset.set(offset + to_send);
+
+                            // Put the TX buffer back so we can keep sending from it.
+                            self.tx_buffer.replace(tx_buf);
+
+                            // Return that we have data to send.
+                            InResult::Packet(to_send)
+                        } else {
+                            // We don't have anything to send, so that means we are
+                            // ok to signal the callback.
+
+                            // Signal the callback and pass back the TX buffer.
+                            self.tx_client.map(move |tx_client| {
+                                tx_client.transmitted_buffer(tx_buf, self.tx_len.get(), Ok(()))
+                            });
+
+                            // Return that we have nothing else to do to the USB
+                            // driver.
+                            InResult::Delay
+                        }
+                    })
+            }
+            TransferType::Control | TransferType::Isochronous | TransferType::Interrupt => {
+                // Nothing to do for CDC ACM.
+                InResult::Delay
+            }
+        }
+    }
+
+    fn packet_transmitted(&self, _endpoint: usize) {
+        // Check if more to send.
+        self.tx_buffer.take().map(|tx_buf| {
+            // Check if we have any bytes to send.
+            let remaining = self.tx_len.get() - self.tx_offset.get();
+            if remaining > 0 {
+                // We do, so ask to send again.
+                self.tx_buffer.replace(tx_buf);
+                self.alert_full();
+            } else {
+                // We don't have anything to send, so that means we are
+                // ok to signal the callback.
+
+                // Signal the callback and pass back the TX buffer.
+                self.tx_client.map(move |tx_client| {
+                    tx_client.transmitted_buffer(tx_buf, self.tx_len.get(), Ok(()))
+                });
+            }
+        });
+    }
+
+    /// Handle a Bulk/Interrupt OUT transaction
+    fn packet_out(
+        &self,
+        transfer_type: TransferType,
+        _endpoint: usize,
+        packet_bytes: u32,
+    ) -> OutResult {
+        match transfer_type {
+            TransferType::Bulk => {
+                // Start by checking to see if we even care about this RX or
+                // not.
+                self.rx_buffer.take().map_or(OutResult::Delay, |rx_buf| {
+                    let rx_offset = self.rx_offset.get();
+
+                    // How many more bytes can we store in our RX buffer?
+                    let available_bytes = rx_buf.len() - rx_offset;
+                    let copy_length = cmp::min(packet_bytes as usize, available_bytes);
+
+                    // Do the copy into the RX buffer.
+                    let packet = self.data_in.buffer();
+                    for i in 0..copy_length {
+                        rx_buf[rx_offset + i] = packet[i].get();
+                    }
+
+                    // Keep track of how many bytes we have received so far.
+                    let total_received_bytes = rx_offset + copy_length;
+
+                    // Update how many bytes we have gotten.
+                    self.rx_offset.set(total_received_bytes);
+
+                    // Check if we have received at least as many bytes as the
+                    // client asked for.
+                    if total_received_bytes >= self.rx_len.get() {
+                        self.rx_client.map(move |client| {
+                            client.received_buffer(
+                                rx_buf,
+                                total_received_bytes,
+                                Ok(()),
+                                uart::Error::None,
+                            );
+                        });
+                    } else {
+                        // Make sure to put the RX buffer back.
+                        self.rx_buffer.replace(rx_buf);
+                    }
+                    OutResult::Ok
+                })
+
+                // No error cases to report to the USB.
+            }
+            TransferType::Control | TransferType::Isochronous | TransferType::Interrupt => {
+                // Nothing to do for CDC ACM.
+                OutResult::Ok
+            }
+        }
+    }
+
+    fn bus_reset(&self) {
+        self.reset.set(true);
+        if self.tx_buffer.is_some() {
+            self.alert_full();
+        }
+    }
+
+}
+
+impl<'a, C: UsbController<'a>> Transmit<'a> for BulkSimple<'a, C> {
+    fn set_transmit_client(&self, client: &'a (dyn TransmitClient + 'a)) {
+        self.tx_client.set(client);
+    }
+
+    fn transmit_buffer(&self, tx_buffer: &'static mut [u8], tx_len: usize) -> Result<(), (kernel::ErrorCode, &'static mut [u8])> {
+        if self.tx_buffer.is_some() {
+            // We are already handling a transmission, we cannot queue another
+            // request.
+            Err((ErrorCode::BUSY, tx_buffer))
+        } else if tx_len > tx_buffer.len() {
+            // Can't send more bytes than will fit in the buffer.
+            Err((ErrorCode::SIZE, tx_buffer))
+        } else {
+            // Ok, we can handle this transmission. Initialize all of our state
+            // for our TX state machine.
+            self.tx_len.set(tx_len);
+            self.tx_offset.set(0);
+            self.tx_buffer.replace(tx_buffer);
+
+            // Then signal to the lower layer that we are ready to do a TX
+            // by putting data in the IN endpoint.
+            if self.reset.get() {
+                self.alert_full();
+            }
+            Ok(())
+        }
+    }
+
+    fn transmit_abort(&self) -> Result<(), ErrorCode> {
+        Err(ErrorCode::FAIL)
+    }
+
+    fn transmit_word(&self, _word: u32) -> Result<(), ErrorCode> {
+        Err(ErrorCode::FAIL)
+    }
+}
+
+impl<'a, C: UsbController<'a>> Receive<'a> for BulkSimple<'a, C> {
+    fn set_receive_client(&self, client: &'a (dyn ReceiveClient + 'a)) {
+        self.rx_client.set(client);
+    }
+    fn receive_buffer(
+        &self,
+        rx_buffer: &'static mut [u8],
+        rx_len: usize,
+    ) -> Result<(), (ErrorCode, &'static mut [u8])> {
+        if self.rx_buffer.is_some() {
+            Err((ErrorCode::BUSY, rx_buffer))
+        } else if rx_len > rx_buffer.len() {
+            Err((ErrorCode::SIZE, rx_buffer))
+        } else {
+            self.rx_buffer.replace(rx_buffer);
+            self.rx_offset.set(0);
+            self.rx_len.set(rx_len);
+
+            Ok(())
+        }
+    }
+    fn receive_word(&self) -> Result<(), ErrorCode> {
+        Err(ErrorCode::FAIL)
+    }
+    fn receive_abort(&self) -> Result<(), kernel::ErrorCode> { Ok(()) }
+}
+
+impl<'a, C: UsbController<'a>> Configure for BulkSimple<'a, C> {
+    fn configure(&self, _parameters: Parameters) -> Result<(), ErrorCode> {
+        // Since this is not a real UART, we don't need to consider these
+        // parameters.
+        Ok(())
+    }
+}

--- a/capsules/src/usb/configuration.rs
+++ b/capsules/src/usb/configuration.rs
@@ -1,0 +1,209 @@
+use core::cell::Cell;
+use super::descriptors::{Descriptor, ConfigurationAttributes, DescriptorType, TransferDirection, SetupData};
+use kernel::utilities::cells::{OptionalCell, VolatileCell};
+use kernel::hil::usb::{CtrlOutResult, CtrlSetupResult, TransferType};
+
+pub struct InterfaceIterator<'a, 'b, C: ?Sized> {
+    inner: &'a C,
+    idx: usize,
+    _marker: core::marker::PhantomData<&'b C>,
+}
+
+impl<'a: 'b, 'b, C: Configuration> Iterator for InterfaceIterator<'a, 'b, C> {
+    type Item = &'b dyn Interface;
+    
+    fn next(&mut self) -> Option<Self::Item> {
+        let prev = self.idx;
+        self.idx += 1;
+        self.inner.interface(prev)
+    }
+}
+
+pub struct ConfigurationDetails {
+    pub string_index: u8,
+    pub attributes: ConfigurationAttributes,
+    pub max_power: u8,
+    pub num_interfaces: usize,
+}
+
+pub trait Configuration {
+    fn details(&self) -> ConfigurationDetails;
+
+    // when generic_const_exprs is more stable, we can use the NUM_INTERFACES constant to return a
+    // fixed-sized array instead
+    fn interface(&self, i: usize) -> Option<&dyn Interface>;
+
+    fn interfaces<'a, 'b>(&'a self) -> InterfaceIterator<'a, 'b, Self> {
+        InterfaceIterator {
+            inner: self,
+            idx: 0,
+            _marker: core::marker::PhantomData,
+        }
+    }
+
+    fn size(&self) -> usize {
+        let mut total_size = 9;
+        let mut i = 0;
+        while let Some(interface) = self.interface(i) {
+            total_size += interface.size();
+            i += 1;
+        }
+        total_size
+    }
+
+    fn write_to(&self, configuration_num: u8, buf: &[Cell<u8>]) -> usize {
+        let details = self.details();
+        buf[0].set(9); // Size of descriptor
+        buf[1].set(DescriptorType::Configuration as u8);
+        put_u16(&buf[2..4], self.size() as u16);
+        buf[4].set(details.num_interfaces as u8);
+        buf[5].set(configuration_num);
+        buf[6].set(details.string_index);
+        buf[7].set(From::from(details.attributes));
+        buf[8].set(details.max_power);
+        9
+    }
+}
+
+pub struct SimpleConfiguration<'a, I: AsRef<[&'a dyn Interface]>> {
+    pub interfaces: I,
+    pub is_self_powered: bool,
+    pub supports_remote_wakeup: bool,
+    pub max_power: u8,
+    pub _f: core::marker::PhantomData<&'a ()>,
+}
+
+impl<'a, I: AsRef<[&'a dyn Interface]>> Configuration for SimpleConfiguration<'a, I> {
+    fn details(&self) -> ConfigurationDetails {
+        ConfigurationDetails {
+            string_index: 0,
+            attributes: ConfigurationAttributes::new(self.is_self_powered, self.supports_remote_wakeup),
+            max_power: self.max_power, // in 2ma units
+            num_interfaces: self.interfaces.as_ref().len(),
+        }
+    }
+
+    fn interface(&self, i: usize) -> Option<&dyn Interface> {
+        self.interfaces.as_ref().get(i).map(|x| *x)
+    }
+}
+
+pub struct InterfaceDetails {
+    pub alternate_setting: u8,
+    pub interface_class: u8,
+    pub interface_subclass: u8,
+    pub interface_protocol: u8,
+    pub string_index: u8,
+    pub num_endpoints: usize,
+}
+
+pub trait Interface {
+    fn details(&self) -> InterfaceDetails;
+    fn class_descriptor(&self, i: usize) -> Option<&dyn Descriptor>;
+    fn endpoint(&self, i: usize) -> Option<&Endpoint>;
+
+    fn size(&self) -> usize {
+        let mut total_size = 9;
+        let mut i = 0;
+        while let Some(cd) = self.class_descriptor(i) {
+            total_size += cd.size();
+            i += 1;
+        }
+        let mut i = 0;
+        while let Some(ep) = self.endpoint(i) {
+            total_size += ep.size();
+            i += 1;
+        }
+        total_size
+    }
+
+    fn write_to(&self, interface_num: u8, buf: &[Cell<u8>]) -> usize {
+        let details = self.details();
+        buf[0].set(9); // Size of descriptor
+        buf[1].set(DescriptorType::Interface as u8);
+        buf[2].set(interface_num);
+        buf[3].set(details.alternate_setting);
+        buf[4].set(details.num_endpoints as u8);
+        buf[5].set(details.interface_class);
+        buf[6].set(details.interface_subclass);
+        buf[7].set(details.interface_protocol);
+        buf[8].set(details.string_index);
+        9
+    }
+
+    fn ctrl_setup(&self, _setup_data: SetupData) -> CtrlSetupResult {
+        CtrlSetupResult::ErrGeneric
+    }
+
+    fn ctrl_out(&self, _buf: [VolatileCell<u8>; 64], _packet_bytes: u32) -> CtrlOutResult {
+        CtrlOutResult::Halted
+    }
+
+    fn ctrl_status_complete(&self, _endpoint: usize) {
+    }
+
+    fn packet_in(&self, _transfer_type: TransferType, _endpoint: usize) -> kernel::hil::usb::InResult {
+        kernel::hil::usb::InResult::Delay
+    }
+
+    fn packet_out(
+        &self,
+        _transfer_type: TransferType,
+        _endpoint: usize,
+        _packet_bytes: u32,
+    ) -> kernel::hil::usb::OutResult {
+        kernel::hil::usb::OutResult::Ok
+    }
+
+    fn packet_transmitted(&self, _endpoint: usize) {}
+
+    fn bus_reset(&self) {}
+}
+
+pub struct Endpoint {
+    pub direction: TransferDirection,
+    pub transfer_type: TransferType,
+    // Poll for device data every `interval` frames
+    pub interval: u8,
+    pub buffer: Option<super::descriptors::Buffer64>,
+    pub endpoint_number: OptionalCell<u8>,
+}
+
+impl Endpoint {
+    fn size(&self) -> usize {
+        7
+    }
+
+    pub fn buffer<'a>(&'a self) -> &'a [kernel::utilities::cells::VolatileCell<u8>] {
+        if let Some(ref buf) = self.buffer {
+            &buf.buf
+        } else {
+            &[]
+        }
+    }
+
+    pub fn write_to(&self, endpoint_number: u8, buf: &[Cell<u8>]) -> usize {
+        self.endpoint_number.set(endpoint_number);
+        let len = self.size();
+        buf[0].set(len as u8);
+        buf[1].set(DescriptorType::Endpoint as u8);
+        let address = endpoint_number & 0xf | match self.direction {
+            TransferDirection::HostToDevice => 0,
+            TransferDirection::DeviceToHost => 1,
+        } << 7;
+        buf[2].set(address);
+        // The below implicitly sets Synchronization Type to "No Synchronization" and
+        // Usage Type to "Data endpoint"
+        buf[3].set(self.transfer_type as u8);
+        put_u16(&buf[4..6], self.buffer.as_ref().map_or(0, |b| b.buf.len() as u16) & 0x7ff);
+        buf[6].set(self.interval);
+        len
+    }
+}
+
+
+/// Write a `u16` to a buffer for transmission on the bus
+pub(crate) fn put_u16<'a>(buf: &'a [Cell<u8>], n: u16) {
+    buf[0].set((n & 0xff) as u8);
+    buf[1].set((n >> 8) as u8);
+}

--- a/capsules/src/usb/descriptors.rs
+++ b/capsules/src/usb/descriptors.rs
@@ -23,6 +23,14 @@ pub struct Buffer64 {
     pub buf: [VolatileCell<u8>; 64],
 }
 
+impl Buffer64 {
+    pub const fn empty() -> Self {
+        Self {
+            buf: [VolatileCell::new(0); 64],
+        }
+    }
+}
+
 impl Default for Buffer64 {
     fn default() -> Self {
         Self {

--- a/capsules/src/usb/device.rs
+++ b/capsules/src/usb/device.rs
@@ -1,0 +1,492 @@
+//! A generic USB client layer managing control requests
+//!
+//! This layer responds to control requests and handles the state machine for
+//! implementing them.
+
+use super::descriptors::Buffer64;
+use super::descriptors::Descriptor;
+use super::descriptors::DescriptorType;
+use super::descriptors::LanguagesDescriptor;
+use super::descriptors::Recipient;
+use super::descriptors::SetupData;
+use super::descriptors::StandardRequest;
+use super::descriptors::StringDescriptor;
+use super::descriptors::TransferDirection;
+
+use core::cell::Cell;
+use core::cmp::min;
+
+use kernel::hil;
+use kernel::hil::usb::TransferType;
+
+const DESCRIPTOR_BUFLEN: usize = 128;
+
+pub struct DevDescriptor {
+    /// Valid values include 0x0100 (USB1.0), 0x0110 (USB1.1) and 0x0200 (USB2.0)
+    pub usb_release: u16,
+
+    /// 0x00 means each interface defines its own class.
+    /// 0xFF means the class behavior is defined by the vendor.
+    /// All other values have meaning assigned by USB-IF
+    pub class: u8,
+
+    /// Assigned by USB-IF if `class` is
+    pub subclass: u8,
+
+    /// Assigned by USB-IF if `class` is
+    pub protocol: u8,
+
+    /// Obtained from USB-IF
+    pub vendor_id: u16,
+
+    /// Together with `vendor_id`, this must be unique to the product
+    pub product_id: u16,
+
+    /// Device release number in binary coded decimal (BCD)
+    pub device_release: u16,
+
+    /// Index of the string descriptor describing manufacturer, or 0 if none
+    pub manufacturer_string: &'static str,
+
+    /// Index of the string descriptor describing product, or 0 if none
+    pub product_string: &'static str,
+
+    /// Index of the string descriptor giving device serial number, or 0 if none
+    pub serial_number_string: &'static str,
+}
+
+
+/// Handler for USB control endpoint requests.
+pub struct Device<'a, U: 'a, C: super::configuration::Configuration> {
+    /// The USB hardware controller.
+    controller: &'a U,
+
+    /// State of control endpoint (endpoint 0).
+    state: Cell<State>,
+
+    /// A 64-byte buffer for the control endpoint to be passed to the USB
+    /// driver.
+    pub ctrl_buffer: Buffer64,
+
+    descriptor: DevDescriptor,
+
+    configuration: C,
+
+    /// Storage for composing responses to device descriptor requests.
+    descriptor_storage: [Cell<u8>; DESCRIPTOR_BUFLEN],
+
+    /// Supported language (only one for now).
+    language: u16,
+}
+
+/// States for the individual endpoints.
+#[derive(Copy, Clone)]
+enum State {
+    Init,
+
+    /// We are doing a Control In transfer of some data in
+    /// self.descriptor_storage, with the given extent remaining to send.
+    CtrlIn(usize, usize),
+
+    /// We will accept data from the host.
+    CtrlOutInterface(u16),
+
+    SetAddress,
+}
+
+impl Default for State {
+    fn default() -> Self {
+        State::Init
+    }
+}
+
+impl<'a, U: hil::usb::UsbController<'a>, C: super::configuration::Configuration> Device<'a, U, C> {
+    pub fn new(
+        controller: &'a U,
+        descriptor: DevDescriptor,
+        configuration: C,
+        language: u16,
+    ) -> Self {
+        Device {
+            descriptor,
+            configuration,
+            controller: controller,
+            state: Default::default(),
+            // For the moment, the Default trait is not implemented for arrays
+            // of length > 32, and the Cell type is not Copy, so we have to
+            // initialize each element manually.
+            #[rustfmt::skip]
+            descriptor_storage: [
+                Cell::default(), Cell::default(), Cell::default(), Cell::default(),
+                Cell::default(), Cell::default(), Cell::default(), Cell::default(),
+                Cell::default(), Cell::default(), Cell::default(), Cell::default(),
+                Cell::default(), Cell::default(), Cell::default(), Cell::default(),
+                Cell::default(), Cell::default(), Cell::default(), Cell::default(),
+                Cell::default(), Cell::default(), Cell::default(), Cell::default(),
+                Cell::default(), Cell::default(), Cell::default(), Cell::default(),
+                Cell::default(), Cell::default(), Cell::default(), Cell::default(),
+                Cell::default(), Cell::default(), Cell::default(), Cell::default(),
+                Cell::default(), Cell::default(), Cell::default(), Cell::default(),
+                Cell::default(), Cell::default(), Cell::default(), Cell::default(),
+                Cell::default(), Cell::default(), Cell::default(), Cell::default(),
+                Cell::default(), Cell::default(), Cell::default(), Cell::default(),
+                Cell::default(), Cell::default(), Cell::default(), Cell::default(),
+                Cell::default(), Cell::default(), Cell::default(), Cell::default(),
+                Cell::default(), Cell::default(), Cell::default(), Cell::default(),
+                Cell::default(), Cell::default(), Cell::default(), Cell::default(),
+                Cell::default(), Cell::default(), Cell::default(), Cell::default(),
+                Cell::default(), Cell::default(), Cell::default(), Cell::default(),
+                Cell::default(), Cell::default(), Cell::default(), Cell::default(),
+                Cell::default(), Cell::default(), Cell::default(), Cell::default(),
+                Cell::default(), Cell::default(), Cell::default(), Cell::default(),
+                Cell::default(), Cell::default(), Cell::default(), Cell::default(),
+                Cell::default(), Cell::default(), Cell::default(), Cell::default(),
+                Cell::default(), Cell::default(), Cell::default(), Cell::default(),
+                Cell::default(), Cell::default(), Cell::default(), Cell::default(),
+                Cell::default(), Cell::default(), Cell::default(), Cell::default(),
+                Cell::default(), Cell::default(), Cell::default(), Cell::default(),
+                Cell::default(), Cell::default(), Cell::default(), Cell::default(),
+                Cell::default(), Cell::default(), Cell::default(), Cell::default(),
+                Cell::default(), Cell::default(), Cell::default(), Cell::default(),
+                Cell::default(), Cell::default(), Cell::default(), Cell::default(),
+            ],
+            ctrl_buffer: Buffer64::default(),
+            language,
+        }
+    }
+
+    fn write_device_descriptor(&self, buf: &[Cell<u8>]) -> usize {
+        use super::configuration::put_u16;
+        buf[0].set(18); // Size of descriptor
+        buf[1].set(DescriptorType::Device as u8);
+        put_u16(&buf[2..4], self.descriptor.usb_release);
+        buf[4].set(self.descriptor.class);
+        buf[5].set(self.descriptor.subclass);
+        buf[6].set(self.descriptor.protocol);
+        buf[7].set(U::MAX_CTRL_PACKET_SIZE);
+        put_u16(&buf[8..10], self.descriptor.vendor_id);
+        put_u16(&buf[10..12], self.descriptor.product_id);
+        put_u16(&buf[12..14], self.descriptor.device_release);
+        buf[14].set(1); // Manufacturer String
+        buf[15].set(2); // Product String
+        buf[16].set(3); // Serial Number String
+        buf[17].set(1); // NUM CONFIGURATIONS, change if we start supporting more than 1
+        18
+    }
+
+    #[inline]
+    pub fn controller(&self) -> &'a U {
+        self.controller
+    }
+
+    #[inline]
+    fn descriptor_buf(&'a self) -> &'a [Cell<u8>] {
+        &self.descriptor_storage
+    }
+
+    fn handle_standard_device_request(
+        &'a self,
+        endpoint: usize,
+        request: StandardRequest,
+    ) -> hil::usb::CtrlSetupResult {
+        match request {
+            StandardRequest::GetDescriptor {
+                descriptor_type,
+                descriptor_index,
+                lang_id,
+                requested_length,
+            } => {
+                match descriptor_type {
+                    DescriptorType::Device => match descriptor_index {
+                        0 => {
+                            let buf = self.descriptor_buf();
+                            let len = self.write_device_descriptor(buf);
+
+                            let end = min(len, requested_length as usize);
+
+                            self.state.set(State::CtrlIn(0, end));
+                            hil::usb::CtrlSetupResult::Ok
+                        }
+                        _ => hil::usb::CtrlSetupResult::ErrInvalidDeviceIndex,
+                    },
+                    DescriptorType::Configuration => {
+                        if descriptor_index == 0 {
+                            let buf = self.descriptor_buf();
+                            // 0-value configuration means deconfigure, so start from 1
+                            let mut len = self.configuration.write_to(descriptor_index + 1, buf);
+                            // endpoint 0 is the control endpoint, start from 1
+                            let mut endpoint_num = 1;
+                            for (interface_num, interface) in self.configuration.interfaces().enumerate() {
+                                len += interface.write_to(interface_num as u8, &buf[len..]);
+                                let mut cd_i = 0;
+                                while let Some(class_descriptor) = interface.class_descriptor(cd_i) {
+                                    len += class_descriptor.write_to(&buf[len..]);
+                                    cd_i += 1;
+                                }
+                                let mut j = 0;
+                                while let Some(endpoint) = interface.endpoint(j) {
+                                    len += endpoint.write_to(endpoint_num, &buf[len..]);
+                                    j += 1;
+                                    endpoint_num += 1;
+                                }
+                            }
+
+                            let end = min(len, requested_length as usize);
+                            self.state.set(State::CtrlIn(0, end));
+                            hil::usb::CtrlSetupResult::Ok
+                        } else {
+                            hil::usb::CtrlSetupResult::ErrInvalidConfigurationIndex
+                        }
+                    },
+                    DescriptorType::String => {
+                        if let Some(len) = match descriptor_index {
+                            0 => {
+                                let buf = self.descriptor_buf();
+                                let d = LanguagesDescriptor {
+                                    langs: &[self.language],
+                                };
+                                let len = d.write_to(buf);
+                                Some(len)
+                            }
+                            i@(1 ..= 3) => {
+                                if lang_id == self.language {
+                                    (match i {
+                                        1 => Some(self.descriptor.manufacturer_string),
+                                        2 => Some(self.descriptor.product_string),
+                                        3 => Some(self.descriptor.serial_number_string),
+                                        _ => None,
+                                    }).and_then(|s| {
+                                        let d = StringDescriptor {
+                                            string: s
+                                        };
+                                        let buf = self.descriptor_buf();
+                                        let len = d.write_to(buf);
+                                        Some(len)
+                                    })
+                                } else {
+                                    None
+                                }
+                            }
+                            _ => None,
+                        } {
+                            let end = min(len, requested_length as usize);
+                            self.state.set(State::CtrlIn(0, end));
+                            hil::usb::CtrlSetupResult::Ok
+                        } else {
+                            hil::usb::CtrlSetupResult::ErrInvalidStringIndex
+                        }
+                    }
+                    DescriptorType::DeviceQualifier => {
+                        // We are full-speed only, so we must
+                        // respond with a request error
+                        hil::usb::CtrlSetupResult::ErrNoDeviceQualifier
+                    }
+                    _ => hil::usb::CtrlSetupResult::ErrUnrecognizedDescriptorType,
+                } // match descriptor_type
+            }
+            StandardRequest::SetAddress { device_address } => {
+                // Load the address we've been assigned ...
+                self.controller.set_address(device_address);
+
+                // ... and when this request gets to the Status stage we will actually enable the
+                // address.
+                self.state.set(State::SetAddress);
+                hil::usb::CtrlSetupResult::OkSetAddress
+            }
+            StandardRequest::SetConfiguration { configuration_value } => {
+                if configuration_value == 1 {
+                    for interface in self.configuration.interfaces() {
+                        interface.bus_reset();
+                    }
+                } else {
+                    // TODO(alevy): Deconfigure (0) or no such configuration? What does deconfigure
+                    // mean though?
+                }
+
+                hil::usb::CtrlSetupResult::Ok
+            }
+            _ => hil::usb::CtrlSetupResult::ErrUnrecognizedRequestType,
+        }
+    }
+
+}
+
+impl<'a, U: hil::usb::UsbController<'a>, C: super::configuration::Configuration> hil::usb::Client<'a> for Device<'a, U, C> {
+    fn enable(&'a self) {
+        // Set up the default control endpoint
+        self.controller
+            .endpoint_set_ctrl_buffer(&self.ctrl_buffer.buf);
+        self.controller
+            .enable_as_device(hil::usb::DeviceSpeed::Full); // must be Full for Bulk transfers
+        self.controller
+            .endpoint_out_enable(TransferType::Control, 0);
+
+        let mut endpoint_num = 1;
+        for interface in self.configuration.interfaces() {
+            let mut j = 0;
+            while let Some(endpoint) = interface.endpoint(j) {
+                match endpoint.direction {
+                    TransferDirection::DeviceToHost => {
+                        let buffer = endpoint.buffer();
+                        if buffer.len() > 0 {
+                            self.controller.endpoint_set_in_buffer(endpoint_num, buffer);
+                        }
+                        self.controller().endpoint_in_enable(endpoint.transfer_type, endpoint_num);
+                    },
+                    TransferDirection::HostToDevice => {
+                        let buffer = endpoint.buffer();
+                        if buffer.len() > 0 {
+                            self.controller.endpoint_set_out_buffer(endpoint_num, buffer);
+                        }
+                        self.controller().endpoint_out_enable(endpoint.transfer_type, endpoint_num);
+                    },
+                }
+                j += 1;
+                endpoint_num += 1;
+            }
+        }
+    }
+
+    fn attach(&'a self) {
+        self.controller.attach();
+    }
+
+    fn bus_reset(&'a self) {
+
+    }
+
+    fn ctrl_setup(&'a self, endpoint: usize) -> hil::usb::CtrlSetupResult {
+        if endpoint != 0 {
+            // For now we only support the default Control endpoint
+            return hil::usb::CtrlSetupResult::ErrInvalidDeviceIndex;
+        }
+        SetupData::get(&self.ctrl_buffer.buf).map_or(hil::usb::CtrlSetupResult::ErrNoParse, |setup_data| {
+                let transfer_direction = setup_data.request_type.transfer_direction();
+                let recipient = setup_data.request_type.recipient();
+                match recipient {
+                    Recipient::Device => {
+                        setup_data.get_standard_request().map_or(hil::usb::CtrlSetupResult::ErrGeneric, |request|
+                            self.handle_standard_device_request(endpoint, request)
+                        )
+                    }
+                    Recipient::Interface => {
+                        //self.handle_standard_interface_request(endpoint, request),
+                        match transfer_direction {
+                            TransferDirection::HostToDevice => {
+                                self.state.set(State::CtrlOutInterface(setup_data.index));
+                            },
+                            TransferDirection::DeviceToHost => {
+                                self.state.set(State::CtrlOutInterface(setup_data.index));
+                            },
+                        }
+                        self.configuration.interface(setup_data.index as usize).map(|interface|
+                            interface.ctrl_setup(setup_data)
+                        ).unwrap_or(hil::usb::CtrlSetupResult::ErrGeneric)
+                    },
+                    _ => hil::usb::CtrlSetupResult::ErrGeneric,
+                }
+            })
+    }
+
+    /// Handle a Control In transaction
+    fn ctrl_in(&'a self, endpoint: usize) -> hil::usb::CtrlInResult {
+        match self.state.get() {
+            State::CtrlIn(start, end) => {
+                let len = end.saturating_sub(start);
+                if len > 0 {
+                    let packet_bytes = min(self.ctrl_buffer.buf.len(), len);
+                    let packet = &self.descriptor_storage[start..start + packet_bytes];
+
+                    // Copy a packet into the endpoint buffer
+                    for (b, p) in self.ctrl_buffer.buf.iter().zip(packet.iter()) {
+                        b.set(p.get());
+                    }
+
+                    let start = start + packet_bytes;
+                    let len = end.saturating_sub(start);
+                    let transfer_complete = len == 0;
+
+                    self.state.set(State::CtrlIn(start, end));
+
+                    hil::usb::CtrlInResult::Packet(packet_bytes, transfer_complete)
+                } else {
+                    hil::usb::CtrlInResult::Packet(0, true)
+                }
+            }
+            _ => hil::usb::CtrlInResult::Error,
+        }
+    }
+
+    fn ctrl_out(&'a self, endpoint: usize, packet_bytes: u32) -> hil::usb::CtrlOutResult {
+        match self.state.get() {
+            State::CtrlOutInterface(interface) => {
+                self.configuration.interface(interface as usize).map(|interface|
+                    interface.ctrl_out(self.ctrl_buffer.buf, packet_bytes)
+                ).unwrap_or(hil::usb::CtrlOutResult::Halted)
+            },
+            _ => hil::usb::CtrlOutResult::Halted
+        }
+    }
+
+    fn ctrl_status(&'a self, _endpoint: usize) {
+        // Entered Status stage
+    }
+
+    fn ctrl_status_complete(&'a self, endpoint: usize) {
+        // Control Read: IN request acknowledged
+        // Control Write: status sent
+
+        match self.state.get() {
+            State::SetAddress => {
+                self.controller.enable_address();
+            },
+            State::CtrlOutInterface(interface) => {
+                self.configuration.interface(interface as usize).map(|int| {
+                    int.ctrl_status_complete(endpoint);
+                });
+            },
+            _ => {}
+        };
+        self.state.set(State::Init);
+    }
+
+    fn packet_in(&'a self, transfer_type: TransferType, endpoint: usize) -> hil::usb::InResult {
+        let mut max_prev_endpoint = 1;
+        for interface in self.configuration.interfaces() {
+            let largest_endpoint = interface.details().num_endpoints + max_prev_endpoint;
+            if largest_endpoint > endpoint {
+                return interface.packet_in(transfer_type, endpoint - max_prev_endpoint);
+            }
+            max_prev_endpoint = largest_endpoint;
+        }
+        hil::usb::InResult::Error
+    }
+
+    fn packet_out(
+        &'a self,
+        transfer_type: TransferType,
+        endpoint: usize,
+        packet_bytes: u32,
+    ) -> hil::usb::OutResult {
+        let mut max_prev_endpoint = 1;
+        for interface in self.configuration.interfaces() {
+            let largest_endpoint = interface.details().num_endpoints + max_prev_endpoint;
+            if largest_endpoint > endpoint {
+                return interface.packet_out(transfer_type, endpoint - max_prev_endpoint, packet_bytes);
+            }
+            max_prev_endpoint = largest_endpoint;
+        }
+        hil::usb::OutResult::Error
+    }
+
+    fn packet_transmitted(&'a self, endpoint: usize) {
+        let mut max_prev_endpoint = 1;
+        for interface in self.configuration.interfaces() {
+            let largest_endpoint = interface.details().num_endpoints + max_prev_endpoint;
+            if largest_endpoint > endpoint {
+                return interface.packet_transmitted(endpoint);
+            }
+            max_prev_endpoint = largest_endpoint;
+        }
+    }
+}

--- a/capsules/src/usb/mod.rs
+++ b/capsules/src/usb/mod.rs
@@ -1,6 +1,10 @@
+pub mod bulk_echo;
+pub mod bulk_simple;
 pub mod cdc;
 pub mod ctap;
 pub mod descriptors;
+pub mod device;
+pub mod configuration;
 pub mod usb_user;
 pub mod usbc_client;
 pub mod usbc_client_ctrl;

--- a/chips/nrf52/src/usbd.rs
+++ b/chips/nrf52/src/usbd.rs
@@ -1059,6 +1059,7 @@ impl<'a> Usbd<'a> {
             8 => unimplemented!("isochronous endpoint"),
             _ => unreachable!("unexisting endpoint"),
         });
+        self.registers.size_epout[endpoint].set(0);
     }
 
     fn enable_in_out_endpoint_(&self, transfer_type: TransferType, endpoint: usize) {
@@ -1295,10 +1296,6 @@ impl<'a> Usbd<'a> {
                         in_state.map(|_| BulkInState::Init),
                         out_state.map(|_| BulkOutState::Init),
                     ));
-                    if out_state.is_some() {
-                        // Accept incoming OUT packets.
-                        self.registers.size_epout[ep].set(0);
-                    }
                 }
             }
             // Clear the DMA status.
@@ -1915,6 +1912,7 @@ impl<'a> power::PowerClient for Usbd<'a> {
 }
 
 impl<'a> hil::usb::UsbController<'a> for Usbd<'a> {
+    const MAX_CTRL_PACKET_SIZE: u8 = 64;
     fn set_client(&self, client: &'a dyn hil::usb::Client<'a>) {
         self.client.set(client);
     }

--- a/kernel/src/hil/usb.rs
+++ b/kernel/src/hil/usb.rs
@@ -4,6 +4,7 @@ use crate::utilities::cells::VolatileCell;
 
 /// USB controller interface
 pub trait UsbController<'a> {
+    const MAX_CTRL_PACKET_SIZE: u8;
     fn set_client(&self, client: &'a dyn Client<'a>);
 
     // Should be called before `enable_as_device()`


### PR DESCRIPTION
_NOTE: this PR includes relatively sweeping changes mostly in new files, though much of the code is borrowed from the modules it aims to replace. As a result, I recommend primarily reading the source tree itself rather than the diff. The relevant design is mostly encapsulated in `capsules/src/usb/{device,configuration,bulk_simple,bulk_echo}.rs` and any changes to other parts of the code are important for review, but mostly ancillary to the proposed design._

### Pull Request Overview

This pull request restructures the USB stack with a different division of responsibilities to allows for more modularity.

#### What's the problem?

Before this PR, the state of the USB stack is functional (thank you very much to those who contributed it, as getting it as functional as it is is no small feat!) but quite ad-hoc. Currently, the stack is structured something like this:

```
                  Board
                   ^
                   |
                   v
              Functional
                driver
                 |   ^
            |-----   |
            v        |
     ClientCtrl      |
         |           |
         v           |
         UsbController
```

A particular board initializes the chip's implementation of `UsbController` as well as a function-specific driver (e.g., CDC-ACM or CTAP, etc) and connects them. Because `UsbController` (correctly) is not virtualized,the functional driver "owns" the controller: it uses the global namespace for configuration, interface and endpoint numbers, it controls the device configuration itself (e.g. vendor/product id, etc).  The functionality to actually support USB enumeration is factored out into ClientCtr, but this is used as a library and because of the high-level structure, there is really no way to modularly construct a device composed of multiple functions (e.g. a device that both provides a serial interface and CTAP HID without writing a new driver that implements both).

A few ad-hoc additions to the stack over time have led to some other minor warts: HID report descriptors are handled by `ClientCtr` meaning even when there is no HID device the USB stacks suffers from the complexity and memory overhead of including that logic; via various copy-paste jobs boards generally claim to be self-powered via their configuration descriptor even though some are very much not (e.g. the nano33ble, which is powered exclusively over USB), and declare an impractically low max current draw.

#### The solution in this PR

This PR proposed a new design of the USB stack that follows a more typical multiplexing stack in Tock and solves most of the existing issues.
```
         Board
        /     \
    Console  Mouse
       ^       ^
      /         \
     v           v
Interface     Interface
       ^       ^
        \      /
         \    /
          \  /
           v
     Configuration   
           ^
           |
           v
        Device
           ^
           |
           v
      UsbController
```

This PR introduces four new components:

  - The `Device` struct, which replaces the `ClientCtl` library but is now the main `usb::Client` that interacts directly with the low-level USB controller. It also now _holds_ information such as the vendor/product ID, strings table, etc and is configured directly from the board (rather than indirectly via function-specific drivers).
  - The `Configuration` trait, which implements "contains" one or more interfaces and is responsible for encoding the configuration descriptor. It's expected that most configurations will simply use the provided `SimpleConfiguration` struct which more or less wraps a slice of `Interfaces`, but it's left as a trait for flexibility (tbd if this is actually necessary). In principle USB supports multiple configurations that the host can switch between (only one can be active at a time), and this design could support that functionality, but in practice it's not clear this is useful enough to implement (for example, I'm not sure if Linux ever chooses anything but the first configuration).
  - The `Interface` trait implements a USB interface (a collection of related endpoints) and is where developers are expected to implement function-specific drivers. The interface trait includes upcalls similar to `usb::Client` with slightly different signatures and semantics. Most notably, endpoint numbers _never_ refer to the absolute endpoint numbers but rather relative indeces in the interface (the `Device` performs this translation).
  - The `Endpoint` struct, which contains an optional buffer (which the `Device` will configure as a buffer for the endpoint during enumeration) and endpoint number (which is determined and written to by the `Device` during enumeration) as well as other meta-data (direction, type, etc).

Enumeration is handled in the Device struct, but deferred to the supplied Configuration for enumerating interfaces, endpoints and any ancillary descriptors (such as Class descriptors or HID reports descriptors). It also handles allocating configuration, interface, and endpoint numbers and routing post-enumeration requests/responses to the appropriate `Interface`.

Most of the existing stack is left in-tact in this PR. The new stack is implemented alongside it along with two actual Interface implementations: BulkSimple and BulkEcho. Both implement Linux's very simple serial interface for prototypes. `BulkSimple` also implements `UartData` and can be used as a UART device (e.g. in the console) while `BulkEcho` implements the echo server implemented for the previous stack in `usbc_client.rs`. Note that both implementations are fairly basic. For example, `BulkSimple` does not drop TX transmissions if USB hasn't connected so, in practice, the caller will block until the host starts reading transmissions over USB. In other words, these implementations are not for production use (unless that's the functionality you want for some reason).

#### Known Warts

The current implementation of this design has some outstanding warts that likely ought to be resolved either before or shortly after merging.

First, `Interface` implementations typically need to signal to the host when an endpoint is either ready to send or receive more data after it returns a `Delay`. Since this might happen out-of-bound of a USB transaction (e.g. when a process gives it a new buffer to send), it needs a reference to something that allows it to do so. For now, BulkSimple accomplishes this by simply requiring an instance of `UsbController` (the same instance as is passed to `Device`) and uses `Endpoint#endpoint_number` as a dynamic argument to `UsbController#resume_{in,out}_endpoint`. This works, but is not very satisfying and probably encourages fairly brittle code since the Interface actually _does_ have full control of the low-level device if it wants. A specialized struct which is provided by `Device` and wraps the particular Endpoint is probably close to the right solution.

Second, there is currently no way to handle CDC-ACM, which has a very unique requirement: a CDC-ACM device actually uses _two_ interfaces (this is required by the USB CDC specification) that are related to each other, where the "control" interface's class descriptors include two descriptors that need to refer to the absolute interface value of the two interfaces (the union descriptor and call management descriptors). I have not yet come up with a clean way to model this without dramatically complicated the stack solely for supporting this edge (as far as I can tell) case. 

### Testing Strategy

The second commit in this PR modifies the nano33ble board to use the new USB stack with multiple BulkSimple instances: one used for process_console and the debug writer via a UartMux and the other used for the console driver. These show up as separate `/dev/ttyUSB*` devices on Linux. You can run `tockloader listen` twice, selecting either device, and they will operate independently.

For this to work, you need to, first, enable the generic usb serial driver:

```
$ sudo modprobe usbserial
```

Then tell it that you want to interpret your device as a usbserial by supplying the vendor and product id (set in the board configuration to 0x6667 and 0xabcd):

```
$ echo 6667 abcd | sudo tee /sys/bus/usb-serial/drivers/generic/new_id
```

I have not tested but very much doubt this will work on any other host operating system. The generic serial driver is meant for prototyping only (https://www.kernel.org/doc/html/latest/usb/usb-serial.html#generic-serial-driver) and I don't think there are equivalents on other OSs.

### TODO or Help Wanted

- [ ] Document, document, document
- [ ] Remove the demonstration commit
- [ ] Solve or avoid the CDC-ACM problem
- [ ] ...

### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
