### PR TITLE
util: Add CopyOrErr trait for a non-panicing copy_from_slice.

### DIFF
--- a/capsules/src/ble_advertising_driver.rs
+++ b/capsules/src/ble_advertising_driver.rs
@@ -114,6 +114,7 @@ use kernel::processbuffer::{ReadOnlyProcessBuffer, ReadableProcessBuffer};
 use kernel::processbuffer::{ReadWriteProcessBuffer, WriteableProcessBuffer};
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::utilities::cells::OptionalCell;
+use kernel::utilities::copy_slice::CopyOrErr;
 use kernel::{ErrorCode, ProcessId};
 
 /// Syscall driver number.
@@ -272,7 +273,7 @@ impl App {
                             header[1] = (payload_len & 0x3f) as u8;
 
                             let (adva, data) = payload.split_at_mut(6);
-                            adva.copy_from_slice(&self.address);
+                            adva.copy_from_slice_or_err(&self.address)?;
                             adv_data_corrected.copy_to_slice(&mut data[..adv_data_len]);
                         }
                         let total_len = cmp::min(PACKET_LENGTH, payload_len + 2);
@@ -466,8 +467,9 @@ where
                     let success = app
                         .scan_buffer
                         .mut_enter(|userland| {
-                            userland[0..len as usize].copy_from_slice(&buf[0..len as usize]);
-                            true
+                            userland[0..len as usize]
+                                .copy_from_slice_or_err(&buf[0..len as usize])
+                                .is_ok()
                         })
                         .unwrap_or(false);
 

--- a/kernel/src/utilities/copy_slice.rs
+++ b/kernel/src/utilities/copy_slice.rs
@@ -1,0 +1,88 @@
+use crate::ErrorCode;
+use core::ptr;
+
+pub trait CopyOrErr {
+    /// Copies a nonoverlapping slice from src to self. Returns Err(ErrorCode) if source and self
+    /// are not the same length. This is a non-panicing version of slice::copy_from_slice.
+    fn copy_from_slice_or_err(&mut self, src: &Self) -> Result<(), ErrorCode>;
+}
+
+impl CopyOrErr for [u8] {
+    fn copy_from_slice_or_err(&mut self, src: &Self) -> Result<(), ErrorCode> {
+        if self.len() == src.len() {
+            // SAFETY: `self` is valid for `self.len()` elements by definition, and `src` was
+            // checked to have the same length. The slices cannot overlap because
+            // mutable references are exclusive.
+            unsafe {
+                ptr::copy_nonoverlapping(src.as_ptr(), self.as_mut_ptr(), self.len());
+            }
+            Ok(())
+        } else {
+            Err(ErrorCode::SIZE)
+        }
+    }
+}
+
+impl CopyOrErr for [u16] {
+    fn copy_from_slice_or_err(&mut self, src: &Self) -> Result<(), ErrorCode> {
+        if self.len() == src.len() {
+            // SAFETY: `self` is valid for `self.len()` elements by definition, and `src` was
+            // checked to have the same length. The slices cannot overlap because
+            // mutable references are exclusive.
+            unsafe {
+                ptr::copy_nonoverlapping(src.as_ptr(), self.as_mut_ptr(), self.len());
+            }
+            Ok(())
+        } else {
+            Err(ErrorCode::SIZE)
+        }
+    }
+}
+
+impl CopyOrErr for [u32] {
+    fn copy_from_slice_or_err(&mut self, src: &Self) -> Result<(), ErrorCode> {
+        if self.len() == src.len() {
+            // SAFETY: `self` is valid for `self.len()` elements by definition, and `src` was
+            // checked to have the same length. The slices cannot overlap because
+            // mutable references are exclusive.
+            unsafe {
+                ptr::copy_nonoverlapping(src.as_ptr(), self.as_mut_ptr(), self.len());
+            }
+            Ok(())
+        } else {
+            Err(ErrorCode::SIZE)
+        }
+    }
+}
+
+impl CopyOrErr for [u64] {
+    fn copy_from_slice_or_err(&mut self, src: &Self) -> Result<(), ErrorCode> {
+        if self.len() == src.len() {
+            // SAFETY: `self` is valid for `self.len()` elements by definition, and `src` was
+            // checked to have the same length. The slices cannot overlap because
+            // mutable references are exclusive.
+            unsafe {
+                ptr::copy_nonoverlapping(src.as_ptr(), self.as_mut_ptr(), self.len());
+            }
+            Ok(())
+        } else {
+            Err(ErrorCode::SIZE)
+        }
+    }
+}
+
+impl CopyOrErr for [usize] {
+    fn copy_from_slice_or_err(&mut self, src: &Self) -> Result<(), ErrorCode> {
+        if self.len() == src.len() {
+            // SAFETY: `self` is valid for `self.len()` elements by definition, and `src` was
+            // checked to have the same length. The slices cannot overlap because
+            // mutable references are exclusive.
+            unsafe {
+                ptr::copy_nonoverlapping(src.as_ptr(), self.as_mut_ptr(), self.len());
+            }
+            Ok(())
+        } else {
+            Err(ErrorCode::SIZE)
+        }
+    }
+}

--- a/kernel/src/utilities/mod.rs
+++ b/kernel/src/utilities/mod.rs
@@ -1,6 +1,7 @@
 //! Utility functions and macros provided by the kernel crate.
 
 pub mod binary_write;
+pub mod copy_slice;
 pub mod helpers;
 pub mod leasable_buffer;
 pub mod math;


### PR DESCRIPTION
Change-Id: I0b5217bef21553e4db976ecc4d1f816da690f329

### Pull Request Overview

This pull request adds/changes/fixes...
Adds copy_from_slice_or_err to process buffers and a trait to implement this on integer types.
Using this instead of copy_from_slice can reduce binary size by eliminating potential panics.


### Testing Strategy

This pull request was tested by...
Replacing instances in my own capsules and libraries with copy_from_slice_or_err


### TODO or Help Wanted

This pull request still needs...


### Documentation Updated
N/A?
- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
