### PR TITLE
processbuffer: Add non-panicking get with range functions.

### DIFF
--- a/capsules/src/ble_advertising_driver.rs
+++ b/capsules/src/ble_advertising_driver.rs
@@ -255,7 +255,8 @@ impl App {
                     .map_or(Err(ErrorCode::FAIL), |kernel_tx| {
                         let adv_data_len =
                             cmp::min(kernel_tx.len() - PACKET_ADDR_LEN - 2, adv_data.len());
-                        let adv_data_corrected = &adv_data[..adv_data_len];
+                        let adv_data_corrected =
+                            adv_data.get_to(..adv_data_len).ok_or(ErrorCode::SIZE)?;
                         let payload_len = adv_data_corrected.len() + PACKET_ADDR_LEN;
                         {
                             let (header, payload) = kernel_tx.split_at_mut(2);

--- a/kernel/src/processbuffer.rs
+++ b/kernel/src/processbuffer.rs
@@ -698,6 +698,30 @@ impl ReadableProcessSlice {
             .chunks(chunk_size)
             .map(cast_byte_slice_to_process_slice)
     }
+
+    pub fn get(&self, range: Range<usize>) -> Option<&ReadableProcessSlice> {
+        if let Some(slice) = self.slice.get(range) {
+            Some(cast_byte_slice_to_process_slice(slice))
+        } else {
+            None
+        }
+    }
+
+    pub fn get_from(&self, range: RangeFrom<usize>) -> Option<&ReadableProcessSlice> {
+        if let Some(slice) = self.slice.get(range) {
+            Some(cast_byte_slice_to_process_slice(slice))
+        } else {
+            None
+        }
+    }
+
+    pub fn get_to(&self, range: RangeTo<usize>) -> Option<&ReadableProcessSlice> {
+        if let Some(slice) = self.slice.get(range) {
+            Some(cast_byte_slice_to_process_slice(slice))
+        } else {
+            None
+        }
+    }
 }
 
 impl Index<Range<usize>> for ReadableProcessSlice {
@@ -868,6 +892,30 @@ impl WriteableProcessSlice {
         self.slice
             .chunks(chunk_size)
             .map(cast_cell_slice_to_process_slice)
+    }
+
+    pub fn get(&self, range: Range<usize>) -> Option<&WriteableProcessSlice> {
+        if let Some(slice) = self.slice.get(range) {
+            Some(cast_cell_slice_to_process_slice(slice))
+        } else {
+            None
+        }
+    }
+
+    pub fn get_from(&self, range: RangeFrom<usize>) -> Option<&WriteableProcessSlice> {
+        if let Some(slice) = self.slice.get(range) {
+            Some(cast_cell_slice_to_process_slice(slice))
+        } else {
+            None
+        }
+    }
+
+    pub fn get_to(&self, range: RangeTo<usize>) -> Option<&WriteableProcessSlice> {
+        if let Some(slice) = self.slice.get(range) {
+            Some(cast_cell_slice_to_process_slice(slice))
+        } else {
+            None
+        }
     }
 }
 


### PR DESCRIPTION
Change-Id: I4d3d85ffd718b760d40216f31248e6c19444aa62

### Pull Request Overview

This pull request adds/changes/fixes...
Adds non-panicing `get()` to `ProcessSlices`.

Unfortunately, core::slice::[T]::get uses SliceIndex which relies on internal compiler functions. Because of that, I had to add get, get_from, and get_to for Range, RangeFrom, and RangeTo respectively.

### Testing Strategy

This pull request was tested by...
Adding a use in the ble driver. Please let me know if there are other places I should change to ensure all ranges get used.


### TODO or Help Wanted

This pull request still needs...


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.
N/A?

### Formatting

- [x] Ran `make prepush`.
