### PR TITLE
ci: labeler: update to new OT dir structure

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -25,8 +25,9 @@ tock-libraries:
   - libraries/**/*
 
 WG-OpenTitan:
-  - boards/earlgrey-nexysvideo/**/*
+  - boards/opentitan/**/*
   - chips/earlgrey/**/*
+  - chips/lowrisc/**/*
 
 # add kernel label unless already covered by hil label
 kernel:


### PR DESCRIPTION
### Pull Request Overview

This pull request updates labeler to the new OT directories. I noticed that obvious OT PRs were not getting tagged.


### Testing Strategy

I don't know how to.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
