### PR TITLE
kernel: remove duplicate address functions

### DIFF
--- a/kernel/src/memop.rs
+++ b/kernel/src/memop.rs
@@ -54,26 +54,26 @@ pub(crate) fn memop(process: &dyn Process, op_type: usize, r1: usize) -> Syscall
         },
 
         // Op Type 2: Process memory start
-        2 => SyscallReturn::SuccessU32(process.mem_start() as u32),
+        2 => SyscallReturn::SuccessU32(process.get_addresses().sram_start as u32),
 
         // Op Type 3: Process memory end
-        3 => SyscallReturn::SuccessU32(process.mem_end() as u32),
+        3 => SyscallReturn::SuccessU32(process.get_addresses().sram_end as u32),
 
         // Op Type 4: Process flash start
-        4 => SyscallReturn::SuccessU32(process.flash_start() as u32),
+        4 => SyscallReturn::SuccessU32(process.get_addresses().flash_start as u32),
 
         // Op Type 5: Process flash end
-        5 => SyscallReturn::SuccessU32(process.flash_end() as u32),
+        5 => SyscallReturn::SuccessU32(process.get_addresses().flash_end as u32),
 
         // Op Type 6: Grant region begin
-        6 => SyscallReturn::SuccessU32(process.kernel_memory_break() as u32),
+        6 => SyscallReturn::SuccessU32(process.get_addresses().sram_grant_start as u32),
 
         // Op Type 7: Number of defined writeable regions in the TBF header.
         7 => SyscallReturn::SuccessU32(process.number_writeable_flash_regions() as u32),
 
         // Op Type 8: The start address of the writeable region indexed by r1.
         8 => {
-            let flash_start = process.flash_start() as u32;
+            let flash_start = process.get_addresses().flash_start as u32;
             let (offset, size) = process.get_writeable_flash_region(r1);
             if size == 0 {
                 SyscallReturn::Failure(ErrorCode::FAIL)
@@ -86,7 +86,7 @@ pub(crate) fn memop(process: &dyn Process, op_type: usize, r1: usize) -> Syscall
         // Returns (void*) -1 on failure, meaning the selected writeable region
         // does not exist.
         9 => {
-            let flash_start = process.flash_start() as u32;
+            let flash_start = process.get_addresses().flash_start as u32;
             let (offset, size) = process.get_writeable_flash_region(r1);
             if size == 0 {
                 SyscallReturn::Failure(ErrorCode::FAIL)

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -163,9 +163,8 @@ impl ProcessId {
     /// or any space that the kernel is using for any potential bookkeeping.
     pub fn get_editable_flash_range(&self) -> (usize, usize) {
         self.kernel.process_map_or((0, 0), *self, |process| {
-            let start = process.flash_non_protected_start() as usize;
-            let end = process.flash_end() as usize;
-            (start, end)
+            let addresses = process.get_addresses();
+            (addresses.flash_non_protected_start, addresses.flash_end)
         })
     }
 }
@@ -319,22 +318,6 @@ pub trait Process {
     /// the memory pointers is not valid at this point.
     fn sbrk(&self, increment: isize) -> Result<*const u8, Error>;
 
-    /// The start address of allocated RAM for this process.
-    fn mem_start(&self) -> *const u8;
-
-    /// The first address after the end of the allocated RAM for this process.
-    fn mem_end(&self) -> *const u8;
-
-    /// The start address of the flash region allocated for this process.
-    fn flash_start(&self) -> *const u8;
-
-    /// The first address after the end of the flash region allocated for this
-    /// process.
-    fn flash_end(&self) -> *const u8;
-
-    /// The lowest address of the grant region for the process.
-    fn kernel_memory_break(&self) -> *const u8;
-
     /// How many writeable flash regions defined in the TBF header for this
     /// process.
     fn number_writeable_flash_regions(&self) -> usize;
@@ -351,12 +334,6 @@ pub trait Process {
     /// Debug function to update the kernel on where the process heap starts.
     /// Also optional.
     fn update_heap_start_pointer(&self, heap_pointer: *const u8);
-
-    // additional memop like functions
-
-    /// Return the highest address the process has access to, or the current
-    /// process memory brk.
-    fn app_memory_break(&self) -> *const u8;
 
     /// Creates a [`ReadWriteProcessBuffer`] from the given offset and size in
     /// process memory.
@@ -414,12 +391,6 @@ pub trait Process {
     /// to ensure that no other references exist to the process's memory before
     /// calling this function.
     unsafe fn set_byte(&self, addr: *mut u8, value: u8) -> bool;
-
-    /// Get the first address of process's flash that isn't protected by the
-    /// kernel. The protected range of flash contains the TBF header and
-    /// potentially other state the kernel is storing on behalf of the process,
-    /// and cannot be edited by the process.
-    fn flash_non_protected_start(&self) -> *const u8;
 
     fn get_command_permissions(
         &self,
@@ -614,15 +585,6 @@ pub trait Process {
     /// Return the last syscall the process called. Returns `None` if the
     /// process has not called any syscalls or the information is unknown.
     fn debug_syscall_last(&self) -> Option<Syscall>;
-
-    /// Return the address of the start of the process heap, if known.
-    fn debug_heap_start(&self) -> Option<*const u8>;
-
-    /// Return the address of the start of the process stack, if known.
-    fn debug_stack_start(&self) -> Option<*const u8>;
-
-    /// Return the lowest recorded address of the process stack, if known.
-    fn debug_stack_end(&self) -> Option<*const u8>;
 }
 
 /// Opaque identifier for custom grants allocated dynamically from a process's

--- a/kernel/src/process_standard.rs
+++ b/kernel/src/process_standard.rs
@@ -405,36 +405,12 @@ impl<C: Chip> Process for ProcessStandard<'_, C> {
         self.tasks.map_or(0, |tasks| tasks.len())
     }
 
-    fn mem_start(&self) -> *const u8 {
-        self.memory_start
-    }
-
-    fn mem_end(&self) -> *const u8 {
-        self.memory_start.wrapping_add(self.memory_len)
-    }
-
-    fn flash_start(&self) -> *const u8 {
-        self.flash.as_ptr()
-    }
-
-    fn flash_non_protected_start(&self) -> *const u8 {
-        ((self.flash.as_ptr() as usize) + self.header.get_protected_size() as usize) as *const u8
-    }
-
     fn get_command_permissions(
         &self,
         driver_num: usize,
         offset: Option<usize>,
     ) -> CommandPermissions {
         self.header.get_command_permissions(driver_num, offset)
-    }
-
-    fn flash_end(&self) -> *const u8 {
-        self.flash.as_ptr().wrapping_add(self.flash.len())
-    }
-
-    fn kernel_memory_break(&self) -> *const u8 {
-        self.kernel_memory_break.get()
     }
 
     fn number_writeable_flash_regions(&self) -> usize {
@@ -463,10 +439,6 @@ impl<C: Chip> Process for ProcessStandard<'_, C> {
                 debug.app_heap_start_pointer = Some(heap_pointer);
             });
         }
-    }
-
-    fn app_memory_break(&self) -> *const u8 {
-        self.app_break.get()
     }
 
     fn setup_mpu(&self) {
@@ -1099,21 +1071,6 @@ impl<C: Chip> Process for ProcessStandard<'_, C> {
 
     fn debug_syscall_last(&self) -> Option<Syscall> {
         self.debug.map_or(None, |debug| debug.last_syscall)
-    }
-
-    fn debug_heap_start(&self) -> Option<*const u8> {
-        self.debug
-            .map_or(None, |debug| debug.app_heap_start_pointer.map(|p| p))
-    }
-
-    fn debug_stack_start(&self) -> Option<*const u8> {
-        self.debug
-            .map_or(None, |debug| debug.app_stack_start_pointer.map(|p| p))
-    }
-
-    fn debug_stack_end(&self) -> Option<*const u8> {
-        self.debug
-            .map_or(None, |debug| debug.app_stack_min_pointer.map(|p| p))
     }
 
     fn get_addresses(&self) -> ProcessAddresses {
@@ -1981,5 +1938,45 @@ impl<C: 'static + Chip> ProcessStandard<'_, C> {
     fn is_active(&self) -> bool {
         let current_state = self.state.get();
         current_state != State::Terminated && current_state != State::Faulted
+    }
+
+    /// The start address of allocated RAM for this process.
+    fn mem_start(&self) -> *const u8 {
+        self.memory_start
+    }
+
+    /// The first address after the end of the allocated RAM for this process.
+    fn mem_end(&self) -> *const u8 {
+        self.memory_start.wrapping_add(self.memory_len)
+    }
+
+    /// The start address of the flash region allocated for this process.
+    fn flash_start(&self) -> *const u8 {
+        self.flash.as_ptr()
+    }
+
+    /// Get the first address of process's flash that isn't protected by the
+    /// kernel. The protected range of flash contains the TBF header and
+    /// potentially other state the kernel is storing on behalf of the process,
+    /// and cannot be edited by the process.
+    fn flash_non_protected_start(&self) -> *const u8 {
+        ((self.flash.as_ptr() as usize) + self.header.get_protected_size() as usize) as *const u8
+    }
+
+    /// The first address after the end of the flash region allocated for this
+    /// process.
+    fn flash_end(&self) -> *const u8 {
+        self.flash.as_ptr().wrapping_add(self.flash.len())
+    }
+
+    /// The lowest address of the grant region for the process.
+    fn kernel_memory_break(&self) -> *const u8 {
+        self.kernel_memory_break.get()
+    }
+
+    /// Return the highest address the process has access to, or the current
+    /// process memory brk.
+    fn app_memory_break(&self) -> *const u8 {
+        self.app_break.get()
     }
 }

--- a/kernel/src/process_utilities.rs
+++ b/kernel/src/process_utilities.rs
@@ -253,13 +253,14 @@ pub fn load_processes_advanced<C: Chip>(
             };
             process_option.map(|process| {
                 if config::CONFIG.debug_load_processes {
+                    let addresses = process.get_addresses();
                     debug!(
                         "Loaded process[{}] from flash={:#010X}-{:#010X} into sram={:#010X}-{:#010X} = {:?}",
                         index,
                         entry_flash.as_ptr() as usize,
                         entry_flash.as_ptr() as usize + entry_flash.len() - 1,
-                        process.mem_start() as usize,
-                        process.mem_end() as usize - 1,
+                        addresses.sram_start,
+                        addresses.sram_end - 1,
                         process.get_process_name()
                     );
                 }


### PR DESCRIPTION
No longer need individual functions since `get_addresses()` provides them all.

This PR might look familiar since it was merged before, but not into master. #2862


### Testing Strategy

travis


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
