### PR TITLE
Updates to permissions TLV related code

### DIFF
--- a/kernel/src/platform/platform.rs
+++ b/kernel/src/platform/platform.rs
@@ -159,7 +159,7 @@ impl SyscallFilter for TbfHeaderFilterDefaultAllow {
                 subdriver_number: _,
                 upcall_ptr: _,
                 appdata: _,
-            } => match process.get_command_permissions(*driver_number, None) {
+            } => match process.get_command_permissions(*driver_number, 0) {
                 CommandPermissions::NoPermsAtAll => Ok(()),
                 CommandPermissions::NoPermsThisDriver => Err(errorcode::ErrorCode::NODEVICE),
                 CommandPermissions::Mask(_allowed) => Ok(()),
@@ -170,19 +170,17 @@ impl SyscallFilter for TbfHeaderFilterDefaultAllow {
                 subdriver_number,
                 arg0: _,
                 arg1: _,
-            } => {
-                match process.get_command_permissions(*driver_number, Some(subdriver_number / 64)) {
-                    CommandPermissions::NoPermsAtAll => Ok(()),
-                    CommandPermissions::NoPermsThisDriver => Err(errorcode::ErrorCode::NODEVICE),
-                    CommandPermissions::Mask(allowed) => {
-                        if (1 << (subdriver_number % 64)) & allowed > 0 {
-                            Ok(())
-                        } else {
-                            Err(errorcode::ErrorCode::NODEVICE)
-                        }
+            } => match process.get_command_permissions(*driver_number, subdriver_number / 64) {
+                CommandPermissions::NoPermsAtAll => Ok(()),
+                CommandPermissions::NoPermsThisDriver => Err(errorcode::ErrorCode::NODEVICE),
+                CommandPermissions::Mask(allowed) => {
+                    if (1 << (subdriver_number % 64)) & allowed > 0 {
+                        Ok(())
+                    } else {
+                        Err(errorcode::ErrorCode::NODEVICE)
                     }
                 }
-            }
+            },
 
             // Allow is allowed if any commands are
             syscall::Syscall::ReadWriteAllow {
@@ -190,7 +188,7 @@ impl SyscallFilter for TbfHeaderFilterDefaultAllow {
                 subdriver_number: _,
                 allow_address: _,
                 allow_size: _,
-            } => match process.get_command_permissions(*driver_number, None) {
+            } => match process.get_command_permissions(*driver_number, 0) {
                 CommandPermissions::NoPermsAtAll => Ok(()),
                 CommandPermissions::NoPermsThisDriver => Err(errorcode::ErrorCode::NODEVICE),
                 CommandPermissions::Mask(_allowed) => Ok(()),
@@ -202,7 +200,7 @@ impl SyscallFilter for TbfHeaderFilterDefaultAllow {
                 subdriver_number: _,
                 allow_address: _,
                 allow_size: _,
-            } => match process.get_command_permissions(*driver_number, None) {
+            } => match process.get_command_permissions(*driver_number, 0) {
                 CommandPermissions::NoPermsAtAll => Ok(()),
                 CommandPermissions::NoPermsThisDriver => Err(errorcode::ErrorCode::NODEVICE),
                 CommandPermissions::Mask(_allowed) => Ok(()),
@@ -214,7 +212,7 @@ impl SyscallFilter for TbfHeaderFilterDefaultAllow {
                 subdriver_number: _,
                 allow_address: _,
                 allow_size: _,
-            } => match process.get_command_permissions(*driver_number, None) {
+            } => match process.get_command_permissions(*driver_number, 0) {
                 CommandPermissions::NoPermsAtAll => Ok(()),
                 CommandPermissions::NoPermsThisDriver => Err(errorcode::ErrorCode::NODEVICE),
                 CommandPermissions::Mask(_allowed) => Ok(()),

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -392,6 +392,13 @@ pub trait Process {
     /// calling this function.
     unsafe fn set_byte(&self, addr: *mut u8, value: u8) -> bool;
 
+    /// Return the permissions for this process for a given `driver_num`.
+    ///
+    /// The returned `CommandPermissions` will indicate if any permissions for
+    /// individual command numbers are specified. If there are permissions set
+    /// they are returned as a 64 bit bitmask for sequential command numbers. To
+    /// request permissions for a starting command number other than 0, an
+    /// optional `offset` can be provided.
     fn get_command_permissions(
         &self,
         driver_num: usize,

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -396,14 +396,9 @@ pub trait Process {
     ///
     /// The returned `CommandPermissions` will indicate if any permissions for
     /// individual command numbers are specified. If there are permissions set
-    /// they are returned as a 64 bit bitmask for sequential command numbers. To
-    /// request permissions for a starting command number other than 0, an
-    /// optional `offset` can be provided.
-    fn get_command_permissions(
-        &self,
-        driver_num: usize,
-        offset: Option<usize>,
-    ) -> CommandPermissions;
+    /// they are returned as a 64 bit bitmask for sequential command numbers.
+    /// The offset indicates the multiple of 64 command numbers to get permissions for.
+    fn get_command_permissions(&self, driver_num: usize, offset: usize) -> CommandPermissions;
 
     // mpu
 

--- a/kernel/src/process_standard.rs
+++ b/kernel/src/process_standard.rs
@@ -405,11 +405,7 @@ impl<C: Chip> Process for ProcessStandard<'_, C> {
         self.tasks.map_or(0, |tasks| tasks.len())
     }
 
-    fn get_command_permissions(
-        &self,
-        driver_num: usize,
-        offset: Option<usize>,
-    ) -> CommandPermissions {
+    fn get_command_permissions(&self, driver_num: usize, offset: usize) -> CommandPermissions {
         self.header.get_command_permissions(driver_num, offset)
     }
 

--- a/libraries/tock-tbf/src/types.rs
+++ b/libraries/tock-tbf/src/types.rs
@@ -506,12 +506,17 @@ impl core::convert::TryFrom<&[u8]> for TbfHeaderV2KernelVersion {
     }
 }
 
-/// The command permissions speified by the TBF header
+/// The command permissions specified by the TBF header.
 ///
 /// Use the `get_command_permissions()` function to retrieve these.
 pub enum CommandPermissions {
+    /// The TBF header did not specify any permissions for any driver numbers.
     NoPermsAtAll,
+    /// The TBF header did specify permissions for at least one driver number,
+    /// but not for the requested driver number.
     NoPermsThisDriver,
+    /// The bitmask of allowed command numbers starting from the offset provided
+    /// when this enum was created.
     Mask(u64),
 }
 
@@ -659,16 +664,17 @@ impl TbfHeader {
 
     /// Get the permissions for a specified driver and offset.
     ///
-    /// `driver_num`: The driver to lookup
-    /// `offset`: The offset for the driver to find. `None` indicates any offset,
-    ///  while `Some` will specify the offset to find. An offset value of `Some(1)`
-    ///  will find a header with offset `1`, so the `allowed_commands` will cover
-    ///  command 64 to 127.
+    /// - `driver_num`: The driver to lookup
+    /// - `offset`: The offset for the driver to find. `None` indicates any
+    ///   offset, while `Some` will specify the offset to find. An offset value
+    ///   of `Some(1)` will find a header with offset `1`, so the
+    ///   `allowed_commands` will cover command 64 to 127.
     ///
     /// If the specified permissions are found, this function will return
-    /// `Some((true, allowed_command_mask))`. If there are permissions in the header
-    /// but no driver or offset match the function will return `Some((false, 0)).
-    /// If the process does not have any permissions specified, return `None`.
+    /// `Some((true, allowed_command_mask))`. If there are permissions in the
+    /// header but no driver or offset match the function will return
+    /// `Some((false, 0)). If the process does not have any permissions
+    /// specified, return `None`.
     pub fn get_command_permissions(
         &self,
         driver_num: usize,


### PR DESCRIPTION
### Pull Request Overview

This pull request:

- adds comments to the permissions related code
- changes the API for getting permissions from `Some(offset)` to just `offset`. This removes the possibility of a caller getting a permissions mask for an unknown offset, and potentially using that mask assuming it is at a certain offset. This would probably work in simple cases, but would lead to tricky bugs later on, say if the app TBF header is re-ordered.


### Testing Strategy

travis


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
