### PR TITLE
syscall: Add missing TryInto import.

### DIFF
--- a/arch/cortex-m/src/syscall.rs
+++ b/arch/cortex-m/src/syscall.rs
@@ -1,6 +1,7 @@
 //! Implementation of the architecture-specific portions of the kernel-userland
 //! system call interface.
 
+use core::convert::TryInto;
 use core::fmt::Write;
 use core::mem::{self, size_of};
 use core::ops::Range;


### PR DESCRIPTION
### Pull Request Overview

This pull request adds/changes/fixes...
Add a missing TryInto import in cortex-m syscall. For some reason `make prepush` doesn't catch this on master but did catch in on our internal fork.


### Testing Strategy

This pull request was tested by...


### TODO or Help Wanted

This pull request still needs...


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
