### PR TITLE
Fix command 0 documentation: it is an existence check, and always returns Success.

### DIFF
--- a/capsules/src/l3gd20.rs
+++ b/capsules/src/l3gd20.rs
@@ -19,7 +19,7 @@
 //! #### command num
 //! - `0`: Returns Ok(())
 //!   - `data`: Unused.
-//!   - Return: 0
+//!   - Return: Success
 //! - `1`: Is Present
 //!   - `data`: unused
 //!   - Return: `Ok(())` if no other command is in progress, `BUSY` otherwise.

--- a/doc/syscalls/00008_low_level_debug.md
+++ b/doc/syscalls/00008_low_level_debug.md
@@ -21,7 +21,7 @@ driver is in capsules/src/low\_level\_debug.rs.
 
   * ### Command Number: 0
 
-    **Description**: Driver check.
+    **Description**: Existence check.
 
     **Argument 1**: Unused
 

--- a/doc/syscalls/30002_udp.md
+++ b/doc/syscalls/30002_udp.md
@@ -105,7 +105,7 @@ the driver.
 
   * ### Command Number: 0
 
-    **Description**: Driver check.
+    **Description**: Existence check.
 
     **Argument 1**: Unused
 

--- a/doc/syscalls/70005_l3gd20.md
+++ b/doc/syscalls/70005_l3gd20.md
@@ -20,7 +20,7 @@ Three axis gyroscope and temperature sensor.
 
     **Argument 2**: unused
 
-    **Returns**: 0
+    **Returns**: Success
 
   * ### Command number: `1`
 

--- a/doc/syscalls/70006_lsm303dlhc.md
+++ b/doc/syscalls/70006_lsm303dlhc.md
@@ -20,7 +20,7 @@ Three axis accelerometer, magnetometer and temperature sensor.
 
     **Argument 2**: unused
 
-    **Returns**: 0
+    **Returns**: Success
 
   * ### Command number: `1`
 


### PR DESCRIPTION
### Pull Request Overview

This PR was prompted by [this `libtock-rs` discussion](https://github.com/tock/libtock-rs/pull/345#discussion_r756462218).

The low level debug and UDP syscall drivers called it a "driver check", which may be interpreted as indicating that it should verify the driver is working. However, for both capsules, command 0 simply indicates LowLevelDebug is present, not necessarily that it is working. This is consistent with TRD 104, which [currently requires command 0 to always return Success](https://github.com/tock/tock/blob/master/doc/reference/trd104-syscalls.md#431-command-identifier-0). I changed the documentation to call the operation an "existence check" instead, to be more precise about what it is checking.

Also, the `l3gd20` and `lsm303dlhc` capsules are documented as returning `0` in response to command 0, which implies they return Success with u32, but they all return Success with no data. I changed the documentation to indicate they return Success.

### Alternative design

Alternatively, we could request that syscall drivers perform a self-test for command 0, and only return Success if the self tests passes. I think the primary behavior of the self test would be to allocate the capsule's grant region for the process.

I personally am against the alternative design, as it seems like it would be unnecessarily wasteful of code space. However, it may be worth changing TRD 104 to allow for capsules that perform a self-test for command 0, by allowing non-successful response values.

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
