### PR TITLE
rv32i: use inline asm in/out register specs for semihosting

### DIFF
--- a/arch/rv32i/src/lib.rs
+++ b/arch/rv32i/src/lib.rs
@@ -437,9 +437,10 @@ pub extern "C" fn _start_trap() {
 /// as suggested by the RISC-V developers:
 /// https://groups.google.com/a/groups.riscv.org/g/isa-dev/c/XKkYacERM04/m/CdpOcqtRAgAJ
 #[cfg(all(target_arch = "riscv32", target_os = "none"))]
-pub unsafe extern "C" fn semihost_command(_command: usize, _arg0: usize, _arg1: usize) {
+pub unsafe fn semihost_command(command: usize, arg0: usize, arg1: usize) -> usize {
+    let res;
     asm!(
-        "
+    "
       .option push
       .option norelax
       .option norvc
@@ -447,13 +448,18 @@ pub unsafe extern "C" fn semihost_command(_command: usize, _arg0: usize, _arg1: 
       ebreak
       srai x0, x0, 7
       .option pop
-      "
+      ",
+    in("a0") command,
+    in("a1") arg0,
+    in("a2") arg1,
+    lateout("a0") res,
     );
+    res
 }
 
 // Mock implementation for tests on Travis-CI.
 #[cfg(not(any(target_arch = "riscv32", target_os = "none")))]
-pub unsafe extern "C" fn semihost_command(_command: usize, _arg0: usize, _arg1: usize) {
+pub unsafe fn semihost_command(_command: usize, _arg0: usize, _arg1: usize) -> usize {
     unimplemented!()
 }
 


### PR DESCRIPTION
### Pull Request Overview

[RISC-V semihosting](1) requires a specific sequence of instructions to be issued, with the arguments and return values of the semihosting command being placed in a defined set of registers.

While these argument and return value registers correspond to the C function call ABI as defined for RISC-V, it is not sufficient to simply mark the function as being exposed using a C ABI (through `extern "C"`) as [initially suggested](https://github.com/tock/tock/pull/2599#discussion_r653801325). While `extern "C"` will cause a symbol to be defined with the right ABI, it does not prevent rustc from inlining the function. When inlined, rustc does not have conform to the C ABI, which will cause the arguments to be placed in incorrect registers.

This is exactly what happened when I tried to use semihosting in the context of the QEMU rv32i virt machine port (tock/tock#2516). Because the function is only used once in the panic handler, it is being inlined:

    800037bc <rust_begin_unwind>:
    800037bc:   712d                    addi    sp,sp,-288
    800037be:   10112e23                sw      ra,284(sp)
    ...
    80003cdc:   8652                    mv      a2,s4
    80003cde:   9682                    jalr    a3
    80003ce0:   0421                    addi    s0,s0,8
    80003ce2:   ff3413e3                bne     s0,s3,80003cc8 <rust_begin_unwind+0x50c>
    80003ce6:   01f01013                slli    zero,zero,0x1f
    80003cea:   00100073                ebreak
    80003cee:   40705013                srai    zero,zero,0x7
    80003cf2:   a001                    j       80003cf2 <rust_begin_unwind+0x536>

This manifests in QEMU not being able to understand the semihosting command argument as a SWI semihosting command:

    ---| App Status |---
    qemu: Unsupported SemiHosting SWI 0x00
     pc       80003cea
     mhartid  00000000
     mstatus  00000088
     mstatush  00000000
     mip      00000000
     mie      00000888
     mideleg  00000000
     medeleg  00000000
     mtvec    80000100
     stvec    00000000
     mepc     800040f0
     sepc     00000000
     mcause   8000000b
     scause   00000000
     mtval  00000000
     stval  00000000
     x0/zero 00000000 x1/ra 80003cae x2/sp 80201a00 x3/gp 80202800
     x4/tp 00000000 x5/t0 80201955 x6/t1 800068ca x7/t2 00002710
     x8/s0 00000020 x9/s1 80202010 x10/a0 00000000 x11/a1 80009588
     x12/a2 10000000 x13/a3 0000000f x14/a4 0000000a x15/a5 802019f7
     x16/a6 802018f0 x17/a7 00000270 x18/s2 80202010 x19/s3 00000020
     x20/s4 80009558 x21/s5 80201a14 x22/s6 80201a10 x23/s7 80201a50
     x24/s8 80201af0 x25/s9 80201a00 x26/s10 00000007 x27/s11 00000000
     x28/t3 8000afa2 x29/t4 80808080 x30/t5 00000004 x31/t6 00000003
    make: *** [Makefile:33: run] Aborted (core dumped)

Thus this changes the `semihosting_command` function to no longer be exported with a C ABI, but instead use proper inline-asm syntax to place the arguments in the correct registers.

It furthermore adds a return value, as defined in the [specification](1).

[1]: https://github.com/riscv/riscv-semihosting-spec/blob/main/riscv-semihosting-spec.adoc

### Testing Strategy

This pull request was tested by integrating RISC-V semihosting commands with the QEMU rv32i virt machine PR.


### TODO or Help Wanted

I'm not sure whether the `arg1` passed in `a2` is correct. As per the specification it does not seem as passing more than one parameter is defined. It does not hurt safety though.


### Documentation Updated

- [X] ~Updated the relevant files in `/docs`,~ or no updates are required.

### Formatting

- [X] Ran `make prepush`.
