### PR TITLE
Propose a draft TRD for app completion codes

### DIFF
--- a/doc/reference/trd106-completion-codes.md
+++ b/doc/reference/trd106-completion-codes.md
@@ -7,7 +7,7 @@ Application Completion Codes
 **Status:** Draft<br/>
 **Author:** Alyssa Haroldsen<br/>
 **Draft-Created:** December 6, 2021<br/>
-**Draft-Modified:** December 6, 2021<br/>
+**Draft-Modified:** December 7, 2021<br/>
 **Draft-Version:** 1<br/>
 **Draft-Discuss:** tock-dev@googlegroups.com</br>
 
@@ -34,9 +34,9 @@ understandable to newcomers by following the principle of least astonishment.
 
 3 Design
 ===============================
-An application exiting normally via the `exit` syscall MUST use a completion
-code of `0` to indicate normal termination. A non-zero completion code SHOULD be
-used to indicate abnormal termination. A non-zero completion code MAY be the 
+A completion code of `0` passed to the `exit` syscall MUST indicate normal app
+termination. A non-zero completion code SHOULD be used to indicate abnormal
+termination. A completion code between `1` and `1024` inclusive SHOULD be the
 same value as one of the error codes specified in [TRD 104][error-codes].
 
 The kernel MAY treat zero and non-zero completion codes differently.
@@ -44,7 +44,7 @@ The kernel MAY treat zero and non-zero completion codes differently.
 | **Completion Code** | **Meaning** |
 | ------------------- | ----------- |
 | 0                   | Success     |
-| 1-1024              | MAY be a [TRD 104 error code][error-codes] |
+| 1-1024              | SHOULD be a [TRD 104 error code][error-codes] |
 | 1025-`u32::MAX`     | Not defined |
 
 4 Implementation

--- a/doc/reference/trd106-completion-codes.md
+++ b/doc/reference/trd106-completion-codes.md
@@ -68,12 +68,34 @@ to values.
 | ------------------- | --------------------------------------------- |
 | 0                   | Success                                       |
 | 1-1024              | SHOULD be a [TRD 104 error code][error-codes] |
-| 1025-`u32::MAX`     | Reserved                                      |
+| 1025-`u32::MAX`     | Not defined                                   |
 
 4 Implementation
 ===============================
 As of writing, libtock [currently implements][termination] this TRD via the
 `Termination` trait.
+
+```rust
+pub trait Termination {
+    fn complete<S: Syscalls>(self) -> !;
+}
+
+impl Termination for () {
+    fn complete<S: Syscalls>(self) -> ! {
+        S::exit_terminate(0)
+    }
+}
+
+impl Termination for Result<(), ErrorCode> {
+    fn complete<S: Syscalls>(self) -> ! {
+        let exit_code = match self {
+            Ok(()) => 0,
+            Err(ec) => ec as u32,
+        };
+        S::exit_terminate(exit_code);
+    }
+}
+```
 
 5 Author's Address
 ===============================

--- a/doc/reference/trd106-completion-codes.md
+++ b/doc/reference/trd106-completion-codes.md
@@ -13,8 +13,9 @@ Application Completion Codes
 
 Abstract
 -------------------------------
-This document describes the expected behavior of application completion codes
-when terminating via the `exit` syscall, as described in [TRD 104][exit-syscall].
+This advisory document describes the expected behavior of application completion
+codes when terminating via the `exit` syscall, as described in
+[TRD 104][exit-syscall].
 
 1 Introduction
 ===============================
@@ -28,9 +29,14 @@ platforms.
 
 2 Design Considerations
 ===============================
-When possible, Tock should follow existing conventions and terminology from
-other major platforms. This assists in helping the project be more
-understandable to newcomers by following the principle of least astonishment.
+When possible, Tock applications should follow existing conventions and
+terminology from other major platforms. This assists in helping the project be
+more understandable to newcomers by following the principle of least
+astonishment.
+
+This advisory document provides guidance for the ecosystem of Tock applications
+using the `exit` syscall, and does not define the behavior of the syscall
+itself.
 
 3 Design
 ===============================
@@ -41,11 +47,11 @@ same value as one of the error codes specified in [TRD 104][error-codes].
 
 The kernel MAY treat zero and non-zero completion codes differently.
 
-| **Completion Code** | **Meaning** |
-| ------------------- | ----------- |
-| 0                   | Success     |
+| **Completion Code** | **Meaning**                                   |
+| ------------------- | --------------------------------------------- |
+| 0                   | Success                                       |
 | 1-1024              | SHOULD be a [TRD 104 error code][error-codes] |
-| 1025-`u32::MAX`     | Not defined |
+| 1025-`u32::MAX`     | Not defined                                   |
 
 4 Implementation
 ===============================

--- a/doc/reference/trd106-completion-codes.md
+++ b/doc/reference/trd106-completion-codes.md
@@ -7,7 +7,7 @@ Application Completion Codes
 **Status:** Draft<br/>
 **Author:** Alyssa Haroldsen<br/>
 **Draft-Created:** December 6, 2021<br/>
-**Draft-Modified:** December 7, 2021<br/>
+**Draft-Modified:** January 25, 2022<br/>
 **Draft-Version:** 1<br/>
 **Draft-Discuss:** tock-dev@googlegroups.com</br>
 
@@ -42,10 +42,27 @@ itself.
 ===============================
 A completion code of `0` passed to the `exit` syscall MUST indicate normal app
 termination. A non-zero completion code SHOULD be used to indicate abnormal
-termination. A completion code between `1` and `1024` inclusive SHOULD be the
-same value as one of the error codes specified in [TRD 104][error-codes].
+termination. This distinction is useful so that a Tock kernel can handle
+success/failure cases differently, e.g. by printing error messages,
+and so that kernel extensions (such as process exit handlers defined by a board)
+or external tools (such as a tool designed to parse the output from a kernel
+with *trace\_syscalls* enabled) can match on these two cases.
+This behavior also matches the convention for Unix exit codes, such that it
+likely matches the expectations for users coming from that domain.
 
-The kernel MAY treat zero and non-zero completion codes differently.
+A completion code between `1` and `1024` inclusive SHOULD be the
+same value as one of the error codes specified in [TRD 104][error-codes].
+This requirement is a SHOULD rather than a MUST because it is useful in the
+common case (it allows software to infer something about the cause of an
+error that led to an exit, and possibly print a useful message) but also
+allows a process to do something else if needed (e.g. for compatibility
+with some other standard of exit codes).
+
+Accordingly, the core kernel MUST NOT assume any semantic meaning for completion
+codes or take actions based on their values besides printing error messages.
+While there are common and conventional uses of certain values, applications
+are not required to follow these and may assign their own semantic meanings
+to values.
 
 | **Completion Code** | **Meaning**                                   |
 | ------------------- | --------------------------------------------- |

--- a/doc/reference/trd106-completion-codes.md
+++ b/doc/reference/trd106-completion-codes.md
@@ -68,7 +68,7 @@ to values.
 | ------------------- | --------------------------------------------- |
 | 0                   | Success                                       |
 | 1-1024              | SHOULD be a [TRD 104 error code][error-codes] |
-| 1025-`u32::MAX`     | Not defined                                   |
+| 1025-`u32::MAX`     | Reserved                                      |
 
 4 Implementation
 ===============================

--- a/doc/reference/trd106-completion-codes.md
+++ b/doc/reference/trd106-completion-codes.md
@@ -1,0 +1,57 @@
+Application Completion Codes
+========================================
+
+**TRD:** 106 <br/>
+**Working Group:** Kernel<br/>
+**Type:** Documentary<br/>
+**Status:** Draft<br/>
+**Author:** Alyssa Haroldsen<br/>
+**Draft-Created:** December 6, 2021<br/>
+**Draft-Modified:** December 6, 2021<br/>
+**Draft-Version:** 1<br/>
+**Draft-Discuss:** tock-dev@googlegroups.com</br>
+
+Abstract
+-------------------------------
+This document describes the expected behavior of application completion codes
+when terminating via the `exit` syscall, as described in [TRD 104][exit-syscall].
+
+1 Introduction
+===============================
+When an application exits via the [`exit` syscall][exit-syscall], it can specify
+a **completion code**, an unsigned 32-bit number which indicates status. This
+information can be stored in the kernel and used in management or policy
+decisions.
+
+This number is called an "exit status", "exit code", or "result code" on other
+platforms.
+
+2 Design Considerations
+===============================
+When possible, Tock should follow existing conventions and terminology from
+other major platforms. This assists in helping the project be more
+understandable to newcomers by following the principle of least astonishment.
+
+3 Design
+===============================
+An application exiting normally via the `exit` syscall MUST use a completion
+code of `0` to indicate normal termination. A non-zero completion code SHOULD be
+used to indicate abnormal termination. A non-zero completion code MAY be the 
+same value as one of the error codes specified in [TRD 104][error-codes].
+
+The kernel MAY treat zero and non-zero completion codes differently.
+
+4 Implementation
+===============================
+libtock 1.0 [currently implements][termination] this TRD via the
+`Termination` trait.
+
+5 Author's Address
+===============================
+```
+Alyssa Haroldsen <kupiakos@google.com>
+```
+
+[error-codes]: https://github.com/tock/tock/blob/master/doc/reference/trd104-syscalls.md#33-error-codes
+[exit-syscall]: https://github.com/tock/tock/blob/master/doc/reference/trd104-syscalls.md#47-exit-class-id-6
+[termination]: https://github.com/tock/libtock-rs/blob/030e5450c9480beb8b62674e1d6795f4e1697b19/platform/src/termination.rs

--- a/doc/reference/trd106-completion-codes.md
+++ b/doc/reference/trd106-completion-codes.md
@@ -41,9 +41,15 @@ same value as one of the error codes specified in [TRD 104][error-codes].
 
 The kernel MAY treat zero and non-zero completion codes differently.
 
+| **Completion Code** | **Meaning** |
+| ------------------- | ----------- |
+| 0                   | Success     |
+| 1-1024              | MAY be a [TRD 104 error code][error-codes] |
+| 1025-`u32::MAX`     | Not defined |
+
 4 Implementation
 ===============================
-libtock 1.0 [currently implements][termination] this TRD via the
+As of writing, libtock [currently implements][termination] this TRD via the
 `Termination` trait.
 
 5 Author's Address

--- a/doc/reference/trd106-completion-codes.md
+++ b/doc/reference/trd106-completion-codes.md
@@ -101,6 +101,7 @@ impl Termination for Result<(), ErrorCode> {
 ===============================
 ```
 Alyssa Haroldsen <kupiakos@google.com>
+Hudson Ayers <hayers@stanford.edu>
 ```
 
 [error-codes]: https://github.com/tock/tock/blob/master/doc/reference/trd104-syscalls.md#33-error-codes

--- a/doc/reference/trd106-completion-codes.md
+++ b/doc/reference/trd106-completion-codes.md
@@ -59,7 +59,14 @@ allows a process to do something else if needed (e.g. for compatibility
 with some other standard of exit codes).
 
 Accordingly, the core kernel MUST NOT assume any semantic meaning for completion
-codes or take actions based on their values besides printing error messages.
+codes or take actions based on their values besides printing error messages
+unless
+
+- there is a specification of a particular application's completion code space
+  written in a TRD, and
+
+- the kernel can reliably identify that application and associate it with this
+  specification.
 While there are common and conventional uses of certain values, applications
 are not required to follow these and may assign their own semantic meanings
 to values.


### PR DESCRIPTION
Based on discussion in https://github.com/tock/libtock-rs/pull/347. This aims to define little about the `exit` syscall other than the common convention that zero indicates success, and non-zero indicates some sort of failure.

[Rendered](https://github.com/kupiakos/tock/blob/trd106/doc/reference/trd106-completion-codes.md)