### PR TITLE
dont reuse numeric labels in asm

### DIFF
--- a/arch/cortex-m0/src/lib.rs
+++ b/arch/cortex-m0/src/lib.rs
@@ -77,7 +77,7 @@ pub unsafe extern "C" fn generic_isr() {
      *    NVIC.ICER[r0 / 32] = 1 << (r0 & 31)
      * */
     /* r3 = &NVIC.ICER[r0 / 32] */
-    ldr r2, 100f     /* r2 = &NVIC.ICER */
+    ldr r2, 101f      /* r2 = &NVIC.ICER */
     lsrs r3, r0, #5   /* r3 = r0 / 32 */
     lsls r3, r3, #2   /* ICER is word-sized, so multiply offset by 4 */
     adds r3, r3, r2   /* r3 = r2 + r3 */
@@ -105,7 +105,7 @@ pub unsafe extern "C" fn generic_isr() {
     bx lr /* return here since we have extra words in the assembly */
 
 .align 4
-100: // NVICICER
+101: // NVICICER
   .word 0xE000E180
 200: // MEXC_RETURN_MSP
   .word 0xFFFFFFF9


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes the cortex-m0 code to not reuse a label, which would make it easy to reference the wrong one.


### Testing Strategy

N/A


### TODO or Help Wanted

N/A

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
