### PR TITLE
OpenTitan: Convert the OTBN to use syncronous calls

### DIFF
--- a/boards/opentitan/src/main.rs
+++ b/boards/opentitan/src/main.rs
@@ -207,7 +207,7 @@ unsafe fn setup() -> (
     let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
 
     let dynamic_deferred_call_clients =
-        static_init!([DynamicDeferredCallClientState; 4], Default::default());
+        static_init!([DynamicDeferredCallClientState; 3], Default::default());
     let dynamic_deferred_caller = static_init!(
         DynamicDeferredCall,
         DynamicDeferredCall::new(dynamic_deferred_call_clients)
@@ -467,10 +467,6 @@ unsafe fn setup() -> (
     // OTBN is still connected though as it works on simulation runs
     let _mux_otbn = crate::otbn::AccelMuxComponent::new(&peripherals.otbn)
         .finalize(otbn_mux_component_helper!(1024));
-
-    peripherals.otbn.initialise(
-        dynamic_deferred_caller.register(&peripherals.otbn).unwrap(), // Unwrap fail = dynamic deferred caller out of slots
-    );
 
     // Convert hardware RNG to the Random interface.
     let entropy_to_random = static_init!(

--- a/boards/opentitan/src/tests/otbn.rs
+++ b/boards/opentitan/src/tests/otbn.rs
@@ -48,8 +48,6 @@ static EXPECTING: [u8; 256] = [
 ];
 
 struct OtbnTestCallback {
-    binary_load_done: Cell<bool>,
-    data_load_done: Cell<bool>,
     op_done: Cell<bool>,
 }
 
@@ -58,30 +56,16 @@ unsafe impl Sync for OtbnTestCallback {}
 impl<'a> OtbnTestCallback {
     const fn new() -> Self {
         OtbnTestCallback {
-            binary_load_done: Cell::new(false),
-            data_load_done: Cell::new(false),
             op_done: Cell::new(false),
         }
     }
 
     fn reset(&self) {
-        self.binary_load_done.set(false);
-        self.data_load_done.set(false);
         self.op_done.set(false);
     }
 }
 
 impl<'a> Client<'a> for OtbnTestCallback {
-    fn binary_load_done(&'a self, result: Result<(), ErrorCode>, _input: &'static mut [u8]) {
-        self.binary_load_done.set(true);
-        assert_eq!(result, Ok(()));
-    }
-
-    fn data_load_done(&'a self, result: Result<(), ErrorCode>, _data: &'static mut [u8]) {
-        self.data_load_done.set(true);
-        assert_eq!(result, Ok(()));
-    }
-
     fn op_done(&'a self, result: Result<(), ErrorCode>, output: &'static mut [u8]) {
         self.op_done.set(true);
         assert_eq!(result, Ok(()));
@@ -127,8 +111,6 @@ fn otbn_run_rsa_binary() {
         assert_eq!(otbn.load_binary(buf), Ok(()));
 
         run_kernel_op(1000);
-        #[cfg(feature = "hardware_tests")]
-        assert_eq!(CALLBACK.binary_load_done.get(), true);
 
         // BAD! This is not actually mutable!!
         // This is stored in flash which is not mutable.

--- a/chips/earlgrey/src/chip.rs
+++ b/chips/earlgrey/src/chip.rs
@@ -42,7 +42,7 @@ impl<'a> EarlGreyDefaultPeripherals<'a> {
             hmac: lowrisc::hmac::Hmac::new(crate::hmac::HMAC0_BASE),
             usb: lowrisc::usbdev::Usb::new(crate::usbdev::USB0_BASE),
             uart0: lowrisc::uart::Uart::new(crate::uart::UART0_BASE, CONFIG.peripheral_freq),
-            otbn: lowrisc::otbn::Otbn::new(crate::otbn::OTBN_BASE, deferred_caller),
+            otbn: lowrisc::otbn::Otbn::new(crate::otbn::OTBN_BASE),
             gpio_port: crate::gpio::Port::new(),
             i2c0: lowrisc::i2c::I2c::new(
                 crate::i2c::I2C0_BASE,

--- a/chips/lowrisc/src/otbn.rs
+++ b/chips/lowrisc/src/otbn.rs
@@ -2,7 +2,6 @@
 
 use core::cell::Cell;
 use kernel::utilities::cells::{OptionalCell, TakeCell};
-use kernel::utilities::leasable_buffer::LeasableBuffer;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
 use kernel::utilities::registers::{
     register_bitfields, register_structs, ReadOnly, ReadWrite, WriteOnly,
@@ -156,7 +155,7 @@ impl<'a> Otbn<'a> {
     /// This function can be called multiple times if multiple binary blobs
     /// are required.
     /// On error the return value will contain a return code and the original data
-    pub fn load_binary(&self, input: LeasableBuffer<'a, u8>) -> Result<(), ErrorCode> {
+    pub fn load_binary(&self, input: &[u8]) -> Result<(), ErrorCode> {
         if !self.registers.status.matches_all(STATUS::STATUS::IDLE) {
             // OTBN is performing an operation, we can't make any changes
             return Err(ErrorCode::BUSY);
@@ -181,7 +180,7 @@ impl<'a> Otbn<'a> {
     /// are required.
     /// On error the return value will contain a return code and the original data
     /// The `data` buffer should be in little endian
-    pub fn load_data(&self, address: usize, data: LeasableBuffer<'a, u8>) -> Result<(), ErrorCode> {
+    pub fn load_data(&self, address: usize, data: &[u8]) -> Result<(), ErrorCode> {
         if !self.registers.status.matches_all(STATUS::STATUS::IDLE) {
             // OTBN is performing an operation, we can't make any changes
             return Err(ErrorCode::BUSY);

--- a/chips/lowrisc/src/otbn.rs
+++ b/chips/lowrisc/src/otbn.rs
@@ -1,9 +1,6 @@
 //! OTBN Control
 
 use core::cell::Cell;
-use kernel::dynamic_deferred_call::{
-    DeferredCallHandle, DynamicDeferredCall, DynamicDeferredCallClient,
-};
 use kernel::utilities::cells::{OptionalCell, TakeCell};
 use kernel::utilities::leasable_buffer::LeasableBuffer;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
@@ -15,16 +12,6 @@ use kernel::ErrorCode;
 
 /// Implement this trait and use `set_client()` in order to receive callbacks.
 pub trait Client<'a> {
-    /// This callback is called when the binary has been loaded
-    /// On error or success `input` will contain a reference to the original
-    /// buffer supplied to `load_binary()`.
-    fn binary_load_done(&'a self, result: Result<(), ErrorCode>, input: &'static mut [u8]);
-
-    /// This callback is called when the data has been loaded
-    /// On error or success `data` will contain a reference to the original
-    /// buffer supplied to `load_data()`.
-    fn data_load_done(&'a self, result: Result<(), ErrorCode>, data: &'static mut [u8]);
-
     /// This callback is called when a operation is computed.
     /// On error or success `output` will contain a reference to the original
     /// data supplied to `run()`.
@@ -107,33 +94,18 @@ pub struct Otbn<'a> {
     registers: StaticRef<OtbnRegisters>,
     client: OptionalCell<&'a dyn Client<'a>>,
 
-    in_buffer: Cell<Option<LeasableBuffer<'static, u8>>>,
-    data_buffer: TakeCell<'static, [u8]>,
     out_buffer: TakeCell<'static, [u8]>,
 
     copy_address: Cell<usize>,
-
-    add_data_deferred_call: Cell<bool>,
-    deferred_caller: &'static DynamicDeferredCall,
-    deferred_handle: OptionalCell<DeferredCallHandle>,
 }
 
 impl<'a> Otbn<'a> {
-    pub const fn new(
-        base: StaticRef<OtbnRegisters>,
-        deferred_caller: &'static DynamicDeferredCall,
-    ) -> Self {
+    pub const fn new(base: StaticRef<OtbnRegisters>) -> Self {
         Otbn {
             registers: base,
             client: OptionalCell::empty(),
-            in_buffer: Cell::new(None),
-            data_buffer: TakeCell::empty(),
             out_buffer: TakeCell::empty(),
             copy_address: Cell::new(0),
-
-            add_data_deferred_call: Cell::new(false),
-            deferred_caller,
-            deferred_handle: OptionalCell::empty(),
         }
     }
 
@@ -172,10 +144,6 @@ impl<'a> Otbn<'a> {
         }
     }
 
-    pub fn initialise(&self, deferred_call_handle: DeferredCallHandle) {
-        self.deferred_handle.set(deferred_call_handle);
-    }
-
     /// Set the client instance which will receive
     pub fn set_client(&'a self, client: &'a dyn Client<'a>) {
         self.client.set(client);
@@ -187,16 +155,11 @@ impl<'a> Otbn<'a> {
     /// configure the accelerator.
     /// This function can be called multiple times if multiple binary blobs
     /// are required.
-    /// There is no guarantee the data has been written until the `binary_load_done()`
-    /// callback is fired.
     /// On error the return value will contain a return code and the original data
-    pub fn load_binary(
-        &self,
-        input: LeasableBuffer<'static, u8>,
-    ) -> Result<(), (ErrorCode, &'static mut [u8])> {
+    pub fn load_binary(&self, input: LeasableBuffer<'a, u8>) -> Result<(), ErrorCode> {
         if !self.registers.status.matches_all(STATUS::STATUS::IDLE) {
             // OTBN is performing an operation, we can't make any changes
-            return Err((ErrorCode::BUSY, input.take()));
+            return Err(ErrorCode::BUSY);
         }
 
         for i in 0..(input.len() / 4) {
@@ -210,32 +173,18 @@ impl<'a> Otbn<'a> {
             self.registers.imem[i].set(d);
         }
 
-        self.in_buffer.set(Some(input));
-
-        // Schedule a deferred call as there are no interrupts to monitor
-        // the binary loading.
-        self.add_data_deferred_call.set(true);
-        self.deferred_handle
-            .map(|handle| self.deferred_caller.set(*handle));
-
         Ok(())
     }
 
     /// Load the data into the accelerator
     /// This function can be called multiple times if multiple loads
     /// are required.
-    /// There is no guarantee the data has been written until the `data_load_done()`
-    /// callback is fired.
     /// On error the return value will contain a return code and the original data
     /// The `data` buffer should be in little endian
-    pub fn load_data(
-        &self,
-        address: usize,
-        data: LeasableBuffer<'static, u8>,
-    ) -> Result<(), (ErrorCode, &'static mut [u8])> {
+    pub fn load_data(&self, address: usize, data: LeasableBuffer<'a, u8>) -> Result<(), ErrorCode> {
         if !self.registers.status.matches_all(STATUS::STATUS::IDLE) {
             // OTBN is performing an operation, we can't make any changes
-            return Err((ErrorCode::BUSY, data.take()));
+            return Err(ErrorCode::BUSY);
         }
 
         for i in 0..(data.len() / 4) {
@@ -248,14 +197,6 @@ impl<'a> Otbn<'a> {
 
             self.registers.dmem[(address / 4) + i].set(d);
         }
-
-        self.data_buffer.replace(data.take());
-
-        // Schedule a deferred call as there are no interrupts to monitor
-        // the binary loading.
-        self.add_data_deferred_call.set(true);
-        self.deferred_handle
-            .map(|handle| self.deferred_caller.set(*handle));
 
         Ok(())
     }
@@ -300,23 +241,5 @@ impl<'a> Otbn<'a> {
     pub fn clear_data(&self) {
         self.registers.cmd.write(CMD::CMD::SEC_WIPE_DMEM);
         self.registers.cmd.write(CMD::CMD::SEC_WIPE_IMEM);
-    }
-}
-
-impl<'a> DynamicDeferredCallClient for Otbn<'a> {
-    fn call(&self, _handle: DeferredCallHandle) {
-        if self.add_data_deferred_call.get() {
-            self.add_data_deferred_call.set(false);
-
-            self.client.map(|client| {
-                self.in_buffer.take().map(|buffer| {
-                    client.binary_load_done(Ok(()), buffer.take());
-                });
-
-                self.data_buffer.take().map(|buffer| {
-                    client.data_load_done(Ok(()), buffer);
-                });
-            });
-        }
     }
 }

--- a/chips/lowrisc/src/virtual_otbn.rs
+++ b/chips/lowrisc/src/virtual_otbn.rs
@@ -5,7 +5,6 @@ use crate::otbn::{Client, Otbn};
 use core::cell::Cell;
 use kernel::collections::list::{ListLink, ListNode};
 use kernel::utilities::cells::OptionalCell;
-use kernel::utilities::leasable_buffer::LeasableBuffer;
 use kernel::ErrorCode;
 
 pub struct VirtualMuxAccel<'a> {
@@ -38,7 +37,7 @@ impl<'a> VirtualMuxAccel<'a> {
         self.client.set(client);
     }
 
-    pub fn load_binary(&self, input: LeasableBuffer<'a, u8>) -> Result<(), ErrorCode> {
+    pub fn load_binary(&self, input: &[u8]) -> Result<(), ErrorCode> {
         // Check if any mux is enabled. If it isn't we enable it for us.
         if self.mux.running.get() == false {
             self.mux.running.set(true);
@@ -51,7 +50,7 @@ impl<'a> VirtualMuxAccel<'a> {
         }
     }
 
-    pub fn load_data(&self, address: usize, data: LeasableBuffer<'a, u8>) -> Result<(), ErrorCode> {
+    pub fn load_data(&self, address: usize, data: &[u8]) -> Result<(), ErrorCode> {
         // Check if any mux is enabled. If it isn't we enable it for us.
         if self.mux.running.get() == false {
             self.mux.running.set(true);

--- a/chips/lowrisc/src/virtual_otbn.rs
+++ b/chips/lowrisc/src/virtual_otbn.rs
@@ -38,10 +38,7 @@ impl<'a> VirtualMuxAccel<'a> {
         self.client.set(client);
     }
 
-    pub fn load_binary(
-        &self,
-        input: LeasableBuffer<'static, u8>,
-    ) -> Result<(), (ErrorCode, &'static mut [u8])> {
+    pub fn load_binary(&self, input: LeasableBuffer<'a, u8>) -> Result<(), ErrorCode> {
         // Check if any mux is enabled. If it isn't we enable it for us.
         if self.mux.running.get() == false {
             self.mux.running.set(true);
@@ -50,15 +47,11 @@ impl<'a> VirtualMuxAccel<'a> {
         } else if self.mux.running_id.get() == self.id {
             self.mux.accel.load_binary(input)
         } else {
-            Err((ErrorCode::BUSY, input.take()))
+            Err(ErrorCode::BUSY)
         }
     }
 
-    pub fn load_data(
-        &self,
-        address: usize,
-        data: LeasableBuffer<'static, u8>,
-    ) -> Result<(), (ErrorCode, &'static mut [u8])> {
+    pub fn load_data(&self, address: usize, data: LeasableBuffer<'a, u8>) -> Result<(), ErrorCode> {
         // Check if any mux is enabled. If it isn't we enable it for us.
         if self.mux.running.get() == false {
             self.mux.running.set(true);
@@ -67,7 +60,7 @@ impl<'a> VirtualMuxAccel<'a> {
         } else if self.mux.running_id.get() == self.id {
             self.mux.accel.load_data(address, data)
         } else {
-            Err((ErrorCode::BUSY, data.take()))
+            Err(ErrorCode::BUSY)
         }
     }
 
@@ -99,16 +92,6 @@ impl<'a> VirtualMuxAccel<'a> {
 }
 
 impl<'a> Client<'a> for VirtualMuxAccel<'a> {
-    fn binary_load_done(&'a self, result: Result<(), ErrorCode>, input: &'static mut [u8]) {
-        self.client
-            .map(move |client| client.binary_load_done(result, input));
-    }
-
-    fn data_load_done(&'a self, result: Result<(), ErrorCode>, input: &'static mut [u8]) {
-        self.client
-            .map(move |client| client.data_load_done(result, input));
-    }
-
     fn op_done(&'a self, result: Result<(), ErrorCode>, output: &'static mut [u8]) {
         self.client
             .map(move |client| client.op_done(result, output));


### PR DESCRIPTION
### Pull Request Overview

Currently the OTBN load functions are asynchronous and the callback is triggered by a a deferred call. There is no need for the callback though as the entire operation happens synchronously anyway. The async part is left over from the original HIL implementation, but that was dropped in favour of just using `pub` functions for the `chip` driver.

This patch makes the data loading a synchronous operation. This means we don't need `'static mut` buffers and avoids the overhead of the callbacks.

### Testing Strategy

Run the unit tests on the CW310.

### TODO or Help Wanted

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
