### PR TITLE
Print allowed buffer's length in decimal

### DIFF
--- a/kernel/src/kernel.rs
+++ b/kernel/src/kernel.rs
@@ -1123,7 +1123,7 @@ impl Kernel {
 
                 if config::CONFIG.trace_syscalls {
                     debug!(
-                        "[{:?}] read-write allow({:#x}, {}, @{:#x}, {:#x}) = {:?}",
+                        "[{:?}] read-write allow({:#x}, {}, @{:#x}, {}) = {:?}",
                         process.processid(),
                         driver_number,
                         subdriver_number,
@@ -1196,7 +1196,7 @@ impl Kernel {
 
                 if config::CONFIG.trace_syscalls {
                     debug!(
-                        "[{:?}] userspace readable allow({:#x}, {}, @{:#x}, {:#x}) = {:?}",
+                        "[{:?}] userspace readable allow({:#x}, {}, @{:#x}, {}) = {:?}",
                         process.processid(),
                         driver_number,
                         subdriver_number,
@@ -1266,7 +1266,7 @@ impl Kernel {
 
                 if config::CONFIG.trace_syscalls {
                     debug!(
-                        "[{:?}] read-only allow({:#x}, {}, @{:#x}, {:#x}) = {:?}",
+                        "[{:?}] read-only allow({:#x}, {}, @{:#x}, {}) = {:?}",
                         process.processid(),
                         driver_number,
                         subdriver_number,


### PR DESCRIPTION
### Pull Request Overview

This pull request changes the `allow-*` syscall trace to print the buffer's length in decimal instead of hex. This makes the `allow-*` parameters print format consistent with the return value print format of `allow-*` (which is printed as `(0xn, n)`).


### Testing Strategy

This pull request was tested by...

### TODO or Help Wanted

N/A

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
