### PR TITLE
boards/opentitan: tests: otbn: Improve failure output

### DIFF
--- a/boards/opentitan/src/tests/otbn.rs
+++ b/boards/opentitan/src/tests/otbn.rs
@@ -86,6 +86,8 @@ fn otbn_run_rsa_binary() {
     let perf = unsafe { PERIPHERALS.unwrap() };
     let otbn = &perf.otbn;
 
+    debug!("check otbn run binary...");
+
     if let Ok((imem_start, imem_length, dmem_start, dmem_length)) = unsafe {
         crate::otbn::find_app(
             "otbn-rsa",
@@ -97,7 +99,6 @@ fn otbn_run_rsa_binary() {
     } {
         let slice = unsafe { core::slice::from_raw_parts(imem_start as *const u8, imem_length) };
 
-        debug!("check otbn run binary...");
         run_kernel_op(100);
 
         CALLBACK.reset();
@@ -153,7 +154,7 @@ fn otbn_run_rsa_binary() {
         debug!("    [ok]");
         run_kernel_op(100);
     } else {
-        debug!("    [FAIL]");
+        debug!("    [FAIL] No OTBN binary");
         run_kernel_op(100);
     }
 }


### PR DESCRIPTION
### Pull Request Overview

If the OTBN tests case fails we previously just printed:

```
   [FAIL]
```

Without even specifying the test case.

This patch fixes that so we print the test case no matter what and then
explain the failure.

### Testing Strategy

`make test`

### TODO or Help Wanted

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
