### PR TITLE
tock-register-interface: replace register tests by const assertions

### DIFF
--- a/libraries/tock-register-interface/Cargo.toml
+++ b/libraries/tock-register-interface/Cargo.toml
@@ -15,14 +15,9 @@ edition = "2021"
 travis-ci = { repository = "tock/tock", branch = "master" }
 
 [features]
-default = [ "register_types", "std_unit_tests" ]
+default = [ "register_types" ]
 
 # Include actual register types (except LocalRegisterCopy). Disabling
 # the feature makes this an interface-only library and removes all
 # usage of unsafe code
 register_types = []
-
-# Feature flag to enable generation of unit tests for the
-# registers. Enabling this may break compilation in
-# `custom-test-frameworks` environments.
-std_unit_tests = []

--- a/libraries/tock-register-interface/README.md
+++ b/libraries/tock-register-interface/README.md
@@ -90,22 +90,16 @@ struct Registers {
 }
 ```
 
-By default, `std` unit tests for the struct are generated as well (that is,
-tests attributed with `#[test]`). The unit tests make sure that the offsets and
-padding are consistent with the actual fields in the struct, and that alignment
-is correct.
+This crate will generate additional, compile time (`const`) assertions
+to validate various invariants of the register structs, such as
 
-Since those tests would break compilation in `custom-test-frameworks`
-environments, it is possible to opt out of the test generation. To do
-so, disable the default feature set containing the `std_unit_tests`
-feature:
+- proper start offset of padding fields,
+- proper start and end offsets of actual fields,
+- invalid alignment of field types,
+- the `@END` marker matching the size of the struct.
 
-```toml
-[dependencies.tock-registers]
-version = "0.4.x"
-default-features = false
-features = ["register_types"]
-```
+For more information on the generated assertions, check out the [`test_fields!`
+macro documentation](https://docs.tockos.org/tock_registers/macro.test_fields.html).
 
 By default, the visibility of the generated structs and fields is private. You
 can make them public using the `pub` keyword, just before the struct name or the

--- a/libraries/tock-register-interface/src/macros.rs
+++ b/libraries/tock-register-interface/src/macros.rs
@@ -79,44 +79,152 @@ macro_rules! register_fields {
     };
 }
 
+// TODO: All of the rustdoc tests below use a `should_fail` attribute instead of
+// `should_panic` because a const panic will result in a failure to evaluate a
+// constant value, and thus a compiler error. However, this means that these
+// examples could break for unrelated reasons, trigger a compiler error, but not
+// test the desired assertion any longer. This should be switched to a
+// `should_panic`-akin attribute which works for const panics, once that is
+// available.
+/// Statically validate the size and offsets of the fields defined
+/// within the register struct through the [`register_structs!`]
+/// macro.
+///
+/// This macro expands to an expression which contains static
+/// assertions about various parameters of the individual fields in
+/// the register struct definition. It will test for:
+///
+/// - Proper start offset of padding fields. It will fail in cases
+///   such as
+///
+///   ```should_fail
+///   # #[macro_use]
+///   # extern crate tock_registers;
+///   # use tock_registers::register_structs;
+///   # use tock_registers::registers::ReadWrite;
+///   register_structs! {
+///       UartRegisters {
+///           (0x04 => _reserved),
+///           (0x08 => foo: ReadWrite<u32>),
+///           (0x0C => @END),
+///       }
+///   }
+///   # // This is required for rustdoc to not place this code snipped into an
+///   # // fn main() {...} function.
+///   # fn main() { }
+///   ```
+///
+///   In this example, the start offset of `_reserved` should have been `0x00`
+///   instead of `0x04`.
+///
+/// - Correct start offset and end offset (start offset of next field) in actual
+///   fields. It will fail in cases such as
+///
+///   ```should_fail
+///   # #[macro_use]
+///   # extern crate tock_registers;
+///   # use tock_registers::register_structs;
+///   # use tock_registers::registers::ReadWrite;
+///   register_structs! {
+///       UartRegisters {
+///           (0x00 => foo: ReadWrite<u32>),
+///           (0x05 => bar: ReadWrite<u32>),
+///           (0x08 => @END),
+///       }
+///   }
+///   # // This is required for rustdoc to not place this code snipped into an
+///   # // fn main() {...} function.
+///   # fn main() { }
+///   ```
+///
+///   In this example, the start offset of `bar` and thus the end offset of
+///   `foo` should have been `0x04` instead of `0x05`.
+///
+/// - Invalid alignment of fields.
+///
+/// - That the end marker matches the actual generated struct size. This will
+///   fail in cases such as
+///
+///   ```should_fail
+///   # #[macro_use]
+///   # extern crate tock_registers;
+///   # use tock_registers::register_structs;
+///   # use tock_registers::registers::ReadWrite;
+///   register_structs! {
+///       UartRegisters {
+///           (0x00 => foo: ReadWrite<u32>),
+///           (0x04 => bar: ReadWrite<u32>),
+///           (0x10 => @END),
+///       }
+///   }
+///   # // This is required for rustdoc to not place this code snipped into an
+///   # // fn main() {...} function.
+///   # fn main() { }
+///   ```
 #[macro_export]
 macro_rules! test_fields {
+    // This macro works by iterating over all defined fields, until it hits an
+    // ($size:expr => @END) field. Each iteration generates an expression which,
+    // when evaluated, yields the current byte offset in the fields. Thus, when
+    // reading a field or padding, the field or padding length must be added to
+    // the returned size.
+    //
+    // By feeding this expression recursively into the macro, deeper invocations
+    // can continue validating fields through knowledge of the current offset
+    // and the remaining fields.
+    //
+    // The nested expression returned by this macro is guaranteed to be
+    // const-evaluable.
+
     // Macro entry point.
     (@root $struct:ident $(<$life:lifetime>)? { $($input:tt)* } ) => {
-        $crate::test_fields!(@munch $struct $(<$life>)? sum ($($input)*) -> {});
+        // Start recursion at offset 0.
+        $crate::test_fields!(@munch $struct $(<$life>)? ($($input)*) : 0);
     };
 
-    // Print the tests once all fields have been munched.
-    // We wrap the tests in a "detail" function that potentially takes a lifetime parameter, so that
-    // the lifetime is declared inside it - therefore all types using the lifetime are well-defined.
-    (@munch $struct:ident $(<$life:lifetime>)? $sum:ident
+    // Consume the ($size:expr => @END) field, which MUST be the last field in
+    // the register struct.
+    (@munch $struct:ident $(<$life:lifetime>)?
         (
             $(#[$attr_end:meta])*
             ($size:expr => @END),
         )
-        -> {$($stmts:block)*}
+        : $stmts:expr
     ) => {
-        {
-        fn detail $(<$life>)? ()
-        {
-            let mut $sum: usize = 0;
-            $($stmts)*
-            let size = core::mem::size_of::<$struct $(<$life>)?>();
-            assert!(
-                size == $size,
-                "Invalid size for struct {} (expected {:#X} but was {:#X})",
-                stringify!($struct),
-                $size,
-                size
-            );
-        }
+        const _: () = {
+            // We've reached the end! Normally it is sufficient to compare the
+            // struct's size to the reported end offet. However, we must
+            // evaluate the previous iterations' expressions for them to have an
+            // effect anyways, so we can perform an internal sanity check on
+            // this value as well.
+            const sum: usize = $stmts;
 
-        detail();
-        }
+            const fn struct_size $(<$life>)? () -> usize
+            {
+                core::mem::size_of::<$struct $(<$life>)?>()
+            }
+
+            assert!(
+                struct_size() == $size,
+                "{}",
+                concat!(
+                    "Invalid size for struct ",
+                    stringify!($struct),
+                    " (expected ",
+                    $size,
+                    ", actual struct size differs)",
+                ),
+            );
+
+            // Internal sanity check. If we have reached this point and
+            // correctly iterated over the struct's fields, the current offset
+            // and the claimed end offset MUST be equal.
+            assert!(sum == $size);
+        };
     };
 
-    // Munch field.
-    (@munch $struct:ident $(<$life:lifetime>)? $sum:ident
+    // Consume a proper ($offset:expr => $field:ident: $ty:ty) field.
+    (@munch $struct:ident $(<$life:lifetime>)?
         (
             $(#[$attr:meta])*
             ($offset_start:expr => $vis:vis $field:ident: $ty:ty),
@@ -124,46 +232,77 @@ macro_rules! test_fields {
             ($offset_end:expr => $($next:tt)*),
             $($after:tt)*
         )
-        -> {$($output:block)*}
+        : $output:expr
     ) => {
         $crate::test_fields!(
-            @munch $struct $(<$life>)? $sum (
+            @munch $struct $(<$life>)? (
                 $(#[$attr_next])*
                 ($offset_end => $($next)*),
                 $($after)*
-            ) -> {
-                $($output)*
+            ) : {
+                // Evaluate the previous iterations' expression to determine the
+                // current offset.
+                const sum: usize = $output;
+
+                // Validate the start offset of the current field. This check is
+                // mostly relevant for when this is the first field in the
+                // struct, as any subsequent start offset error will be detected
+                // by an end offset error of the previous field.
+                assert!(
+                    sum == $offset_start,
+                    "{}",
+                    concat!(
+                        "Invalid start offset for field ",
+                        stringify!($field),
+                        " (expected ",
+                        $offset_start,
+                        " but actual value differs)",
+                    ),
+                );
+
+                // Validate that the start offset of the current field within
+                // the struct matches the type's minimum alignment constraint.
+                const align: usize = core::mem::align_of::<$ty>();
+                // Clippy can tell that (align - 1) is zero for some fields, so
+                // we allow this lint and further encapsule the assert! as an
+                // expression, such that the allow attr can apply.
+                #[allow(clippy::bad_bit_mask)]
                 {
                     assert!(
-                        $sum == $offset_start,
-                        "Invalid start offset for field {} (expected {:#X} but was {:#X})",
-                        stringify!($field),
-                        $offset_start,
-                        $sum
-                    );
-                    let align = core::mem::align_of::<$ty>();
-                    assert!(
-                        $sum & (align - 1) == 0,
-                        "Invalid alignment for field {} (expected alignment of {:#X} but offset was {:#X})",
-                        stringify!($field),
-                        align,
-                        $sum
-                    );
-                    $sum += core::mem::size_of::<$ty>();
-                    assert!(
-                        $sum == $offset_end,
-                        "Invalid end offset for field {} (expected {:#X} but was {:#X})",
-                        stringify!($field),
-                        $offset_end,
-                        $sum
+                        sum & (align - 1) == 0,
+                        "{}",
+                        concat!(
+                            "Invalid alignment for field ",
+                            stringify!($field),
+                            " (offset differs from expected)",
+                        ),
                     );
                 }
+
+                // Add the current field's length to the offset and validate the
+                // end offset of the field based on the next field's claimed
+                // start offset.
+                const new_sum: usize = sum + core::mem::size_of::<$ty>();
+                assert!(
+                    new_sum == $offset_end,
+                    "{}",
+                    concat!(
+                        "Invalid end offset for field ",
+                        stringify!($field),
+                        " (expected ",
+                        $offset_end,
+                        " but actual value differs)",
+                    ),
+                );
+
+                // Provide the updated offset to the next iteration
+                new_sum
             }
         );
     };
 
-    // Munch padding.
-    (@munch $struct:ident $(<$life:lifetime>)? $sum:ident
+    // Consume a padding ($offset:expr => $padding:ident) field.
+    (@munch $struct:ident $(<$life:lifetime>)?
         (
             $(#[$attr:meta])*
             ($offset_start:expr => $padding:ident),
@@ -171,31 +310,41 @@ macro_rules! test_fields {
             ($offset_end:expr => $($next:tt)*),
             $($after:tt)*
         )
-        -> {$($output:block)*}
+        : $output:expr
     ) => {
         $crate::test_fields!(
-            @munch $struct $(<$life>)? $sum (
+            @munch $struct $(<$life>)? (
                 $(#[$attr_next])*
                 ($offset_end => $($next)*),
                 $($after)*
-            ) -> {
-                $($output)*
-                {
-                    assert!(
-                        $sum == $offset_start,
-                        "Invalid start offset for padding {} (expected {:#X} but was {:#X})",
+            ) : {
+                // Evaluate the previous iterations' expression to determine the
+                // current offset.
+                const sum: usize = $output;
+
+                // Validate the start offset of the current padding field. This
+                // check is mostly relevant for when this is the first field in
+                // the struct, as any subsequent start offset error will be
+                // detected by an end offset error of the previous field.
+                assert!(
+                    sum == $offset_start,
+                    concat!(
+                        "Invalid start offset for padding ",
                         stringify!($padding),
+                        " (expected ",
                         $offset_start,
-                        $sum
-                    );
-                    $sum = $offset_end;
-                }
+                        " but actual value differs)",
+                    ),
+                );
+
+                // The padding field is automatically sized. Provide the start
+                // offset of the next field to the next iteration.
+                $offset_end
             }
         );
     };
 }
 
-#[cfg(feature = "std_unit_tests")]
 #[macro_export]
 macro_rules! register_structs {
     {
@@ -208,33 +357,15 @@ macro_rules! register_structs {
     } => {
         $( $crate::register_fields!(@root $(#[$attr])* $vis_struct $name $(<$life>)? { $($fields)* } ); )*
 
-        #[cfg(test)]
-        mod test_register_structs {
+        mod static_validate_register_structs {
         $(
             #[allow(non_snake_case)]
             mod $name {
                 use super::super::*;
-                #[test]
-                fn test_offsets() {
-                    $crate::test_fields!(@root $name $(<$life>)? { $($fields)* } )
-                }
+
+                $crate::test_fields!(@root $name $(<$life>)? { $($fields)* } );
             }
         )*
         }
-    };
-}
-
-#[cfg(not(feature = "std_unit_tests"))]
-#[macro_export]
-macro_rules! register_structs {
-    {
-        $(
-            $(#[$attr:meta])*
-            $vis_struct:vis $name:ident $(<$life:lifetime>)? {
-                $( $fields:tt )*
-            }
-        ),*
-    } => {
-        $( $crate::register_fields!(@root $(#[$attr])* $vis_struct $name $(<$life>)? { $($fields)* } ); )*
     };
 }


### PR DESCRIPTION
### Pull Request Overview

This replaces the automatically generated tests for register structs defined through the `register_structs!` macro by static assertions evaluated at compile time.

This has some significant advantages over the current approach:

- errors in the struct offsets and violation of other invariants is detected immediately on compilation and not only when running tests. This increases developer ergonomics significantly and reduces the potential for errors and weird behavior at runtime.

- the crate no longer generates tests which rely on the standard library being present in the users' code. While the library itself still has tests which rely on the presence of the standard library, these tests are for internal validation only. In `no_std` environments, relying on the standard library even just for `#[test]` functions can be problematic. For developers, the choice has been to either use the standard library and have test, implement a workaround to provide the standard library when running tests but not otherwise, or not generate the tests at all. These changes enable us to make the library purely `#[no_std]` compatible and not impose any standard library requirements on user code.

It does not come without drawbacks though. Because Rust's const panic features, especially w.r.t. string formatting, are still very limited, the provided debug information is significantly reduced. For instance, it as of now seems impossible to interpolate any const variable content into the assertion message. This is likely to be resolved in the future, when Rust allows more elaborate string formatting techniques at compile time. As an additional consequence, the assertions code is less readable.

The generated error messages are quite prominent during the compilation process and easy to identify:


    error[E0080]: evaluation of constant value failed
      --> chips/lowrisc/src/uart.rs:16:1
       |
    16 | / register_structs! {
    17 | |     pub UartRegisters {
    18 | |         (0x00 => intr_state: ReadWrite<u32>),
    19 | |         (0x04 => intr_enable: ReadWrite<u32>),
    ...  |
    41 | |     }
    42 | | }
       | |_^ the evaluated program panicked at 'Invalid end offset for field val (expected 49 but actual value differs)', chips/lowrisc/src/uart.rs:16:1

### Testing Strategy

This pull request was tested by compiling.


### TODO or Help Wanted

- [x] Remove the `std_unit_tests` feature and only make the standard library available when the crate itself is tested.
- [x] Update the README.md documentation.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
