### PR TITLE
OpenTitan: Fixup the Verilator support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,8 +67,7 @@ package-lock.json
 .netlify
 
 # OpenTitan test build
-boards/opentitan/earlgrey-nexysvideo/binary
-boards/opentitan/earlgrey-cw310/binary
+boards/opentitan/earlgrey-*/binary*
 
 # FuseSoC build files
 boards/swervolf/binary.hex

--- a/boards/opentitan/README.md
+++ b/boards/opentitan/README.md
@@ -316,3 +316,11 @@ Finished garbage collection
 trivial assertion...
     [ok]
 ```
+
+The tests can also be run on Verilator with:
+
+```shell
+make BOARD_CONFIGURATION=sim_verilator test-verilator
+```
+
+Note that the Verilator tests can take hours to complete.

--- a/boards/opentitan/README.md
+++ b/boards/opentitan/README.md
@@ -109,22 +109,79 @@ export OPENTITAN_TREE=/home/opentitan/
 
 then you can run `make flash` or `make test-hardware` to use the board.
 
-### Compiling the Kernel for FPGA or Verilator
+Verilator
+---------
 
 Opentitan is supported on both an FPGA and in Verilator. Slightly different
 versions of the EarlGrey chip implementation are required for the different
-platforms. By default the kernel is compiled for the FPGA. To compile for
-Verilator, run:
+platforms. By default the kernel is compiled for the FPGA.
+
+## Setting up Verilator
+
+For a full guide see the official OpenTitan documentation: https://docs.opentitan.org/doc/ug/getting_started_verilator/
+
+A quick summary on how to do this is included below though
+
+### Build FuseSoc
+
+```shell
+git clone https://github.com/lowRISC/opentitan.git
+cd opentitan
+git checkout <OpenTitan_SHA>
+pip3 install --user -r python-requirements.txt
+
+LANG="en_US.UTF-8" fusesoc --cores-root . run --flag=fileset_top --target=sim --setup --build lowrisc:dv:chip_verilator_sim
+```
+
+### Test Verilator
+
+```shell
+build/lowrisc_dv_chip_verilator_sim_0.1/sim-verilator/Vchip_sim_tb \
+    --meminit=rom,./build-out/sw/device/boot_rom/boot_rom_sim_verilator.scr.39.vmem \
+    --meminit=otp,./build-bin/sw/device/otp_img/otp_img_sim_verilator.vmem
+
+# Read the output, you want to attach screen to UART
+screen /dev/pts/4
+
+# Wait a few minutes
+# You should eventually see messages in screen
+# Once you see "waiting for SPI input..." you know it works
+```
+
+### Build and Run Tock
+
+To compile Tock for Verilator, run:
 
 ```shell
 make BOARD_CONFIGURATION=sim_verilator
 ```
 
-To explicitly specify the FPGA, run:
+You will then need to generate a vmem file:
 
 ```shell
-make BOARD_CONFIGURATION=fpga_nexysvideo
+srec_cat \
+    target/riscv32imc-unknown-none-elf/release/earlgrey-cw310.bin \
+    --binary --offset 0 --byte-swap 8 --fill 0xff \
+    -within target/riscv32imc-unknown-none-elf/release/earlgrey-cw310.bin\
+    -binary -range-pad 8 --output binary.64.vmem --vmem 64
 ```
+
+And Verilator can be run with:
+
+```shell
+${OPENTITAN_TREE}/build/lowrisc_dv_chip_verilator_sim_0.1/sim-verilator/Vchip_sim_tb \
+    --meminit=rom,${OPENTITAN_TREE}/build-out/sw/device/boot_rom/boot_rom_sim_verilator.scr.39.vmem \
+    --meminit=flash,./binary.64.vmem \
+    --meminit=otp,${OPENTITAN_TREE}/build-bin/sw/device/otp_img/otp_img_sim_verilator.vmem
+````
+
+You can also use the Tock Make target to automatically build Tock and run it with Verilator
+
+```shell
+make BOARD_CONFIGURATION=sim_verilator verilator
+```
+
+In both cases expect Verilator to run for tens of minutes before you see anything.
 
 Programming Apps
 ----------------

--- a/boards/opentitan/earlgrey-cw310/Makefile
+++ b/boards/opentitan/earlgrey-cw310/Makefile
@@ -66,3 +66,12 @@ endif
 	$(Q)cp test_layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/layout.ld
 	$(Q)cp ../../kernel_layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/
 	$(Q)RUSTFLAGS="$(RUSTC_FLAGS_TOCK)" $(CARGO) test $(CARGO_FLAGS_TOCK_NO_BUILD_STD) $(NO_RUN) --bin $(PLATFORM) --release --features=hardware_tests
+
+test-verilator:
+	$(call check_defined, OPENTITAN_TREE)
+
+	mkdir -p $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/
+	$(Q)cp test_layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/layout.ld
+	$(Q)cp ../../kernel_layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/
+
+	$(Q)RUSTFLAGS="$(RUSTC_FLAGS_TOCK)" VERILATOR="yes" $(CARGO) test $(CARGO_FLAGS_TOCK_NO_BUILD_STD) $(NO_RUN) --bin $(PLATFORM) --release --features=hardware_tests

--- a/boards/opentitan/earlgrey-cw310/Makefile
+++ b/boards/opentitan/earlgrey-cw310/Makefile
@@ -38,6 +38,17 @@ flash-app: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
 	$(RISC_PREFIX)-objcopy --output-target=binary $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.elf $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.bin
 	$(OPENTITAN_TREE)/util/fpga/cw310_loader.py --firmware $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.bin
 
+verilator: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin
+	$(call check_defined, OPENTITAN_TREE)
+	srec_cat $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin \
+		--binary --offset 0 --byte-swap 8 --fill 0xff \
+		-within $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin \
+		-binary -range-pad 8 --output binary.64.vmem --vmem 64
+	$(OPENTITAN_TREE)/build/lowrisc_dv_chip_verilator_sim_0.1/sim-verilator/Vchip_sim_tb \
+		--meminit=rom,$(OPENTITAN_TREE)/build-out/sw/device/boot_rom/boot_rom_sim_verilator.scr.39.vmem \
+		--meminit=flash,./binary.64.vmem \
+		--meminit=otp,$(OPENTITAN_TREE)/build-bin/sw/device/otp_img/otp_img_sim_verilator.vmem
+
 test:
 ifneq ($(OPENTITAN_TREE),)
 	$(error "Running on QEMU, use test-hardware to run on hardware")

--- a/boards/opentitan/earlgrey-cw310/run.sh
+++ b/boards/opentitan/earlgrey-cw310/run.sh
@@ -1,10 +1,19 @@
 #!/bin/bash
 
-if [[ "${OPENTITAN_TREE}" != "" ]]; then
+if [[ "${VERILATOR}" == "yes" ]]; then
+	${OBJCOPY} --output-target=binary --strip-sections -S --remove-section .apps "${1}" binary
+	srec_cat binary \
+		--binary --offset 0 --byte-swap 8 --fill 0xff \
+		-within binary \
+		-binary -range-pad 8 --output binary.64.vmem --vmem 64
+	${OPENTITAN_TREE}/build/lowrisc_dv_chip_verilator_sim_0.1/sim-verilator/Vchip_sim_tb \
+		--meminit=rom,${OPENTITAN_TREE}/build-out/sw/device/boot_rom/boot_rom_sim_verilator.scr.39.vmem \
+		--meminit=flash,./binary.64.vmem \
+		--meminit=otp,${OPENTITAN_TREE}/build-bin/sw/device/otp_img/otp_img_sim_verilator.vmem
+elif [[ "${OPENTITAN_TREE}" != "" ]]; then
 	riscv64-linux-gnu-objcopy --update-section .apps=${APP} ${1} bundle.elf
 	riscv64-linux-gnu-objcopy --output-target=binary bundle.elf binary
 	${OPENTITAN_TREE}/util/fpga/cw310_loader.py --firmware binary
 else
 	../../../tools/qemu/build/qemu-system-riscv32 -M opentitan -bios ../../../tools/qemu-runner/opentitan-boot-rom.elf -nographic -serial stdio -monitor none -semihosting -kernel "${1}"
 fi
-

--- a/boards/opentitan/earlgrey-nexysvideo/Makefile
+++ b/boards/opentitan/earlgrey-nexysvideo/Makefile
@@ -66,3 +66,12 @@ endif
 	$(Q)cp test_layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/layout.ld
 	$(Q)cp ../../kernel_layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/
 	$(Q)RUSTFLAGS="$(RUSTC_FLAGS_TOCK)" $(CARGO) test $(CARGO_FLAGS_TOCK_NO_BUILD_STD) $(NO_RUN) --bin $(PLATFORM) --release --features=hardware_tests
+
+test-verilator:
+	$(call check_defined, OPENTITAN_TREE)
+
+	mkdir -p $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/
+	$(Q)cp test_layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/layout.ld
+	$(Q)cp ../../kernel_layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/
+
+	$(Q)RUSTFLAGS="$(RUSTC_FLAGS_TOCK)" VERILATOR="yes" $(CARGO) test $(CARGO_FLAGS_TOCK_NO_BUILD_STD) $(NO_RUN) --bin $(PLATFORM) --release --features=hardware_tests

--- a/boards/opentitan/earlgrey-nexysvideo/Makefile
+++ b/boards/opentitan/earlgrey-nexysvideo/Makefile
@@ -38,6 +38,17 @@ flash-app: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
 	$(RISC_PREFIX)-objcopy --output-target=binary $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.elf $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.bin
 	$(OPENTITAN_TREE)/build-out/sw/host/spiflash/spiflash $(FLASHID) --input=$(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.bin
 
+verilator: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin
+	$(call check_defined, OPENTITAN_TREE)
+	srec_cat $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin \
+		--binary --offset 0 --byte-swap 8 --fill 0xff \
+		-within $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin \
+		-binary -range-pad 8 --output binary.64.vmem --vmem 64
+	$(OPENTITAN_TREE)/build/lowrisc_dv_chip_verilator_sim_0.1/sim-verilator/Vchip_sim_tb \
+		--meminit=rom,$(OPENTITAN_TREE)/build-out/sw/device/boot_rom/boot_rom_sim_verilator.scr.39.vmem \
+		--meminit=flash,./binary.64.vmem \
+		--meminit=otp,$(OPENTITAN_TREE)/build-bin/sw/device/otp_img/otp_img_sim_verilator.vmem
+
 test:
 ifneq ($(OPENTITAN_TREE),)
 	$(error "Running on QEMU, use test-hardware to run on hardware")

--- a/boards/opentitan/earlgrey-nexysvideo/run.sh
+++ b/boards/opentitan/earlgrey-nexysvideo/run.sh
@@ -1,6 +1,16 @@
 #!/bin/bash
 
-if [[ "${OPENTITAN_TREE}" != "" ]]; then
+if [[ "${VERILATOR}" == "yes" ]]; then
+	${OBJCOPY} --output-target=binary --strip-sections -S --remove-section .apps "${1}" binary
+	srec_cat binary \
+		--binary --offset 0 --byte-swap 8 --fill 0xff \
+		-within binary \
+		-binary -range-pad 8 --output binary.64.vmem --vmem 64
+	${OPENTITAN_TREE}/build/lowrisc_dv_chip_verilator_sim_0.1/sim-verilator/Vchip_sim_tb \
+		--meminit=rom,${OPENTITAN_TREE}/build-out/sw/device/boot_rom/boot_rom_sim_verilator.scr.39.vmem \
+		--meminit=flash,./binary.64.vmem \
+		--meminit=otp,${OPENTITAN_TREE}/build-bin/sw/device/otp_img/otp_img_sim_verilator.vmem
+elif [[ "${OPENTITAN_TREE}" != "" ]]; then
 	riscv64-linux-gnu-objcopy --output-target=binary ${1} binary
 	${OPENTITAN_TREE}/build-out/sw/host/spiflash/spiflash --dev-id=0403:6010 --input=binary
 else

--- a/chips/earlgrey/src/chip_config.rs
+++ b/chips/earlgrey/src/chip_config.rs
@@ -51,5 +51,5 @@ pub const CONFIG: Config = Config {
     name: "sim_verilator",
     cpu_freq: 500_000,
     peripheral_freq: 125_000,
-    uart_baudrate: 9600,
+    uart_baudrate: 7200,
 };


### PR DESCRIPTION
### Pull Request Overview

Verilator can be used to simulate Tock on OpenTitan without an FPGA board. Let's get it working and improve the documentation.

### Testing Strategy

Booting Tock on Verilator.

### TODO or Help Wanted

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
