### PR TITLE
kernel: fix typo in handle_syscall filtering comment

### DIFF
--- a/kernel/src/kernel.rs
+++ b/kernel/src/kernel.rs
@@ -777,7 +777,7 @@ impl Kernel {
         // process.
         //
         // Filtering a syscall (i.e. blocking the syscall from running) does not
-        // cause the process to loose its timeslice. The error will be returned
+        // cause the process to lose its timeslice. The error will be returned
         // immediately (assuming the process has not already exhausted its
         // timeslice) allowing the process to decide how to handle the error.
         match syscall {


### PR DESCRIPTION
### Pull Request Overview

This pull request adds/changes/fixes...

Noticed what appears to be a typo in a comment explaining the filtering behaviour in `Kernel::handle_syscall`, fixed it here.

### Testing Strategy

This pull request was tested by...


### TODO or Help Wanted

This pull request still needs...


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
