### PR TITLE
Add userspace support for the Key/Value System

### DIFF
--- a/boards/components/src/kv_system.rs
+++ b/boards/components/src/kv_system.rs
@@ -1,0 +1,194 @@
+//! Component for KV System Driver.
+//!
+//! Usage
+//! -----
+//! ```rust
+//!    let mux_kv = components::kv_system::KVStoreMuxComponent::new(tickv).finalize(
+//!        components::kv_store_mux_component_helper!(
+//!            capsules::tickv::TicKVStore<
+//!                capsules::virtual_flash::FlashUser<lowrisc::flash_ctrl::FlashCtrl>,
+//!            >,
+//!            capsules::tickv::TicKVKeyType,
+//!        ),
+//!    );
+//!
+//!    let kv_store = components::kv_system::KVStoreComponent::new(mux_kv).finalize(
+//!        components::kv_store_component_helper!(
+//!            capsules::tickv::TicKVStore<
+//!                capsules::virtual_flash::FlashUser<lowrisc::flash_ctrl::FlashCtrl>,
+//!            >,
+//!            capsules::tickv::TicKVKeyType,
+//!        ),
+//!    );
+//!
+//!    let kv_driver_data_buf = static_init!([u8; 32], [0; 32]);
+//!    let kv_driver_dest_buf = static_init!(capsules::tickv::TicKVKeyType, [0; 8]);
+//!
+//!    let kv_driver = components::kv_system::KVDriverComponent::new(
+//!        kv_store,
+//!        board_kernel,
+//!        capsules::kv_driver::DRIVER_NUM,
+//!        kv_driver_data_buf,
+//!        kv_driver_dest_buf,
+//!    )
+//!    .finalize(components::kv_driver_component_helper!(
+//!        // capsules::kv_store::KVStore<
+//!        capsules::tickv::TicKVStore<
+//!            capsules::virtual_flash::FlashUser<lowrisc::flash_ctrl::FlashCtrl>,
+//!        >,
+//!        capsules::tickv::TicKVKeyType,
+//!    ));
+//! ```
+
+use capsules::kv_driver::KVSystemDriver;
+use capsules::kv_store::{KVStore, MuxKVStore};
+use core::mem::MaybeUninit;
+use kernel::capabilities;
+use kernel::component::Component;
+use kernel::create_capability;
+use kernel::hil::kv_system::{KVSystem, KeyType};
+use kernel::static_init_half;
+
+// Setup static space for the objects.
+#[macro_export]
+macro_rules! kv_store_mux_component_helper {
+    ($K:ty, $T:ty $(,)?) => {{
+        use capsules::kv_store::MuxKVStore;
+        use core::mem::MaybeUninit;
+        static mut BUF1: MaybeUninit<MuxKVStore<'static, $K, $T>> = MaybeUninit::uninit();
+        &mut BUF1
+    };};
+}
+
+pub struct KVStoreMuxComponent<
+    K: 'static + KVSystem<'static> + KVSystem<'static, K = T>,
+    T: 'static + KeyType,
+> {
+    kv: &'static K,
+}
+
+impl<'a, K: 'static + KVSystem<'static> + KVSystem<'static, K = T>, T: 'static + KeyType>
+    KVStoreMuxComponent<K, T>
+{
+    pub fn new(kv: &'static K) -> KVStoreMuxComponent<K, T> {
+        Self { kv }
+    }
+}
+
+impl<K: 'static + KVSystem<'static> + KVSystem<'static, K = T>, T: 'static + KeyType> Component
+    for KVStoreMuxComponent<K, T>
+{
+    type StaticInput = &'static mut MaybeUninit<MuxKVStore<'static, K, T>>;
+    type Output = &'static MuxKVStore<'static, K, T>;
+
+    unsafe fn finalize(self, s: Self::StaticInput) -> Self::Output {
+        static_init_half!(s, MuxKVStore<'static, K, T>, MuxKVStore::new(self.kv))
+    }
+}
+
+// Setup static space for the objects.
+#[macro_export]
+macro_rules! kv_store_component_helper {
+    ($K:ty, $T:ty $(,)?) => {{
+        use capsules::kv_store::KVStore;
+        use core::mem::MaybeUninit;
+        static mut BUF1: MaybeUninit<KVStore<'static, $K, $T>> = MaybeUninit::uninit();
+        &mut BUF1
+    };};
+}
+
+pub struct KVStoreComponent<K: 'static + KVSystem<'static, K = T>, T: 'static + KeyType> {
+    kv_store: &'static MuxKVStore<'static, K, T>,
+    key_buf: &'static mut T,
+    header_buf: &'static mut [u8; 9],
+}
+
+impl<K: 'static + KVSystem<'static, K = T>, T: 'static + KeyType> KVStoreComponent<K, T> {
+    pub fn new(
+        kv_store: &'static MuxKVStore<'static, K, T>,
+        key_buf: &'static mut T,
+        header_buf: &'static mut [u8; 9],
+    ) -> Self {
+        Self {
+            kv_store,
+            key_buf,
+            header_buf,
+        }
+    }
+}
+
+impl<K: 'static + KVSystem<'static, K = T>, T: 'static + KeyType> Component
+    for KVStoreComponent<K, T>
+{
+    type StaticInput = &'static mut MaybeUninit<KVStore<'static, K, T>>;
+    type Output = &'static KVStore<'static, K, T>;
+
+    unsafe fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
+        static_init_half!(
+            static_buffer,
+            KVStore<'static, K, T>,
+            KVStore::new(self.kv_store, self.key_buf, self.header_buf)
+        )
+    }
+}
+
+// Setup static space for the objects.
+#[macro_export]
+macro_rules! kv_driver_component_helper {
+    ($K:ty, $T:ty $(,)?) => {{
+        use capsules::kv_driver::KVSystemDriver;
+        use core::mem::MaybeUninit;
+        static mut BUF1: MaybeUninit<KVSystemDriver<'static, $K, $T>> = MaybeUninit::uninit();
+        &mut BUF1
+    };};
+}
+
+pub struct KVDriverComponent<K: 'static + KVSystem<'static, K = T>, T: 'static + KeyType> {
+    kv: &'static KVStore<'static, K, T>,
+    board_kernel: &'static kernel::Kernel,
+    driver_num: usize,
+    data_buffer: &'static mut [u8],
+    dest_buffer: &'static mut [u8],
+}
+
+impl<K: 'static + KVSystem<'static, K = T>, T: 'static + KeyType> KVDriverComponent<K, T> {
+    pub fn new(
+        kv: &'static KVStore<'static, K, T>,
+        board_kernel: &'static kernel::Kernel,
+        driver_num: usize,
+        data_buffer: &'static mut [u8],
+        dest_buffer: &'static mut [u8],
+    ) -> Self {
+        Self {
+            kv,
+            board_kernel,
+            driver_num,
+            data_buffer,
+            dest_buffer,
+        }
+    }
+}
+
+impl<K: 'static + KVSystem<'static, K = T>, T: 'static + KeyType> Component
+    for KVDriverComponent<K, T>
+{
+    type StaticInput = &'static mut MaybeUninit<KVSystemDriver<'static, K, T>>;
+    type Output = &'static KVSystemDriver<'static, K, T>;
+
+    unsafe fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
+        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
+
+        let driver = static_init_half!(
+            static_buffer,
+            KVSystemDriver<'static, K, T>,
+            KVSystemDriver::new(
+                self.kv,
+                self.data_buffer,
+                self.dest_buffer,
+                self.board_kernel.create_grant(self.driver_num, &grant_cap)
+            )
+        );
+        self.kv.set_client(driver);
+        driver
+    }
+}

--- a/boards/components/src/lib.rs
+++ b/boards/components/src/lib.rs
@@ -25,6 +25,7 @@ pub mod humidity;
 pub mod i2c;
 pub mod ieee802154;
 pub mod isl29035;
+pub mod kv_system;
 pub mod l3gd20;
 pub mod led;
 pub mod led_matrix;

--- a/capsules/src/driver.rs
+++ b/capsules/src/driver.rs
@@ -46,6 +46,7 @@ pub enum NUM {
     AppFlash              = 0x50000,
     NvmStorage            = 0x50001,
     SdCard                = 0x50002,
+    KVSystem              = 0x50003,
 
     // Sensors
     Temperature           = 0x60000,

--- a/capsules/src/kv_driver.rs
+++ b/capsules/src/kv_driver.rs
@@ -1,0 +1,474 @@
+//! KV Driver
+//!
+
+use crate::driver;
+/// Syscall driver number.
+pub const DRIVER_NUM: usize = driver::NUM::KVSystem as usize;
+
+use crate::kv_store::KVStore;
+use core::cell::Cell;
+use kernel::grant::Grant;
+use kernel::grant::{AllowRoCount, AllowRwCount, UpcallCount};
+use kernel::hil::kv_system;
+use kernel::processbuffer::{ReadableProcessBuffer, WriteableProcessBuffer};
+use kernel::syscall::{CommandReturn, SyscallDriver};
+use kernel::utilities::cells::{OptionalCell, TakeCell};
+use kernel::{ErrorCode, ProcessId};
+
+/// Ids for read-only allow buffers
+mod ro_allow {
+    // unhashed key
+    pub const UNHASHED_KEY: usize = 0;
+    // input value
+    pub const VALUE: usize = 1;
+    /// The number of allow buffers the kernel stores for this grant
+    pub const COUNT: usize = 2;
+}
+
+/// Ids for read-write allow buffers
+mod rw_allow {
+    pub const VALUE: usize = 0;
+    /// The number of allow buffers the kernel stores for this grant
+    pub const COUNT: usize = 1;
+}
+
+/// Ids for upcalls
+mod upcalls {
+    pub const VALUE: usize = 0;
+    /// The number of allow buffers the kernel stores for this grant
+    pub const COUNT: usize = 1;
+}
+
+pub struct KVSystemDriver<
+    'a,
+    K: kv_system::KVSystem<'a> + kv_system::KVSystem<'a, K = T>,
+    T: 'static + kv_system::KeyType,
+> {
+    kv: &'a KVStore<'a, K, T>,
+
+    active: Cell<bool>,
+
+    apps: Grant<
+        App,
+        UpcallCount<{ upcalls::COUNT }>,
+        AllowRoCount<{ ro_allow::COUNT }>,
+        AllowRwCount<{ rw_allow::COUNT }>,
+    >,
+    appid: OptionalCell<ProcessId>,
+
+    data_buffer: TakeCell<'static, [u8]>,
+    dest_buffer: TakeCell<'static, [u8]>,
+}
+
+impl<'a, K: kv_system::KVSystem<'a, K = T>, T: kv_system::KeyType> KVSystemDriver<'a, K, T> {
+    pub fn new(
+        kv: &'a KVStore<'a, K, T>,
+        data_buffer: &'static mut [u8],
+        dest_buffer: &'static mut [u8],
+        grant: Grant<
+            App,
+            UpcallCount<{ upcalls::COUNT }>,
+            AllowRoCount<{ ro_allow::COUNT }>,
+            AllowRwCount<{ rw_allow::COUNT }>,
+        >,
+    ) -> KVSystemDriver<'a, K, T> {
+        KVSystemDriver {
+            kv,
+            active: Cell::new(false),
+            apps: grant,
+            appid: OptionalCell::empty(),
+            data_buffer: TakeCell::new(data_buffer),
+            dest_buffer: TakeCell::new(dest_buffer),
+        }
+    }
+
+    fn run(&self) -> Result<(), ErrorCode> {
+        self.appid.map_or(Err(ErrorCode::RESERVE), |appid| {
+            self.apps
+                .enter(*appid, |app, kernel_data| {
+                    if let Some(operation) = app.op.get() {
+                        match operation {
+                            UserSpaceOp::Get => {
+                                kernel_data
+                                    .get_readonly_processbuffer(ro_allow::UNHASHED_KEY)
+                                    .and_then(|buffer| {
+                                        buffer.enter(|unhashed_key| {
+                                            self.data_buffer.map_or(Err(ErrorCode::NOMEM), |buf| {
+                                                // Determine the size of the static buffer we have
+                                                let static_buffer_len =
+                                                    buf.len().min(unhashed_key.len());
+
+                                                // Copy the data into the static buffer
+                                                unhashed_key[..static_buffer_len]
+                                                    .copy_to_slice(&mut buf[..static_buffer_len]);
+
+                                                Ok(())
+                                            })
+                                        })
+                                    })
+                                    .unwrap_or(Err(ErrorCode::RESERVE))?;
+
+                                if let Some(Some(Err(e))) =
+                                    self.data_buffer.take().map(|data_buffer| {
+                                        self.dest_buffer.take().map(|dest_buffer| {
+                                            if let Err((data, dest, e)) = self.kv.get(
+                                                data_buffer,
+                                                dest_buffer,
+                                                &appid.get_read_ids().unwrap_or([0; 8]),
+                                                appid.num_read_ids().unwrap_or(0),
+                                            ) {
+                                                self.data_buffer.replace(data);
+                                                self.dest_buffer.replace(dest);
+                                                return Err(e);
+                                            }
+                                            Ok(())
+                                        })
+                                    })
+                                {
+                                    return e;
+                                }
+                            }
+                            UserSpaceOp::Set => {
+                                kernel_data
+                                    .get_readonly_processbuffer(ro_allow::UNHASHED_KEY)
+                                    .and_then(|buffer| {
+                                        buffer.enter(|unhashed_key| {
+                                            self.data_buffer.map_or(Err(ErrorCode::NOMEM), |buf| {
+                                                // Determine the size of the static buffer we have
+                                                let static_buffer_len =
+                                                    buf.len().min(unhashed_key.len());
+
+                                                // Copy the data into the static buffer
+                                                unhashed_key[..static_buffer_len]
+                                                    .copy_to_slice(&mut buf[..static_buffer_len]);
+
+                                                Ok(())
+                                            })
+                                        })
+                                    })
+                                    .unwrap_or(Err(ErrorCode::RESERVE))?;
+
+                                let mut static_buffer_len = 0;
+
+                                kernel_data
+                                    .get_readonly_processbuffer(ro_allow::VALUE)
+                                    .and_then(|buffer| {
+                                        buffer.enter(|value| {
+                                            self.dest_buffer.map_or(Err(ErrorCode::NOMEM), |buf| {
+                                                // Determine the size of the static buffer we have
+                                                static_buffer_len = buf.len().min(value.len());
+
+                                                // Copy the data into the static buffer
+                                                value[..static_buffer_len]
+                                                    .copy_to_slice(&mut buf[..static_buffer_len]);
+
+                                                Ok(())
+                                            })
+                                        })
+                                    })
+                                    .unwrap_or(Err(ErrorCode::RESERVE))?;
+
+                                if let Some(Some(Err(e))) =
+                                    self.data_buffer.take().map(|data_buffer| {
+                                        self.dest_buffer.take().map(|dest_buffer| {
+                                            if let Err((data, dest, e)) = self.kv.set(
+                                                data_buffer,
+                                                dest_buffer,
+                                                static_buffer_len,
+                                                appid.get_write_id().unwrap_or(0),
+                                            ) {
+                                                self.data_buffer.replace(data);
+                                                self.dest_buffer.replace(dest);
+                                                return Err(e);
+                                            }
+                                            Ok(())
+                                        })
+                                    })
+                                {
+                                    return e;
+                                }
+                            }
+                            UserSpaceOp::Delete => {
+                                kernel_data
+                                    .get_readonly_processbuffer(ro_allow::UNHASHED_KEY)
+                                    .and_then(|buffer| {
+                                        buffer.enter(|unhashed_key| {
+                                            self.data_buffer.map_or(Err(ErrorCode::NOMEM), |buf| {
+                                                // Determine the size of the static buffer we have
+                                                let static_buffer_len =
+                                                    buf.len().min(unhashed_key.len());
+
+                                                // Copy the data into the static buffer
+                                                unhashed_key[..static_buffer_len]
+                                                    .copy_to_slice(&mut buf[..static_buffer_len]);
+
+                                                Ok(())
+                                            })
+                                        })
+                                    })
+                                    .unwrap_or(Err(ErrorCode::RESERVE))?;
+
+                                if let Some(Err(e)) = self.data_buffer.take().map(|data_buffer| {
+                                    if let Err((data, e)) = self.kv.delete(
+                                        data_buffer,
+                                        &appid.get_access_ids().unwrap_or([0; 8]),
+                                        appid.num_access_ids().unwrap_or(0),
+                                    ) {
+                                        self.data_buffer.replace(data);
+                                        return Err(e);
+                                    }
+                                    Ok(())
+                                }) {
+                                    return e;
+                                }
+                            }
+                        }
+                    }
+
+                    Ok(())
+                })
+                .unwrap_or_else(|err| Err(err.into()))
+        })
+    }
+
+    fn check_queue(&self) {
+        for appiter in self.apps.iter() {
+            let started_command = appiter.enter(|app, _| {
+                // If an app is already running let it complete
+                if self.appid.is_some() {
+                    return true;
+                }
+
+                // If this app has a pending command let's use it.
+                app.pending_run_app.take().map_or(false, |appid| {
+                    // Mark this driver as being in use.
+                    self.appid.set(appid);
+                    // Actually make the buzz happen.
+                    self.run() == Ok(())
+                })
+            });
+            if started_command {
+                break;
+            }
+        }
+    }
+}
+
+impl<'a, K: kv_system::KVSystem<'a, K = T>, T: kv_system::KeyType> kv_system::StoreClient<T>
+    for KVSystemDriver<'a, K, T>
+{
+    fn get_complete(
+        &self,
+        result: Result<(), ErrorCode>,
+        key: &'static mut [u8],
+        ret_buf: &'static mut [u8],
+    ) {
+        self.data_buffer.replace(key);
+        self.dest_buffer.replace(ret_buf);
+
+        self.appid.map(move |id| {
+            self.apps.enter(*id, move |app, upcalls| {
+                if app.op.get().map(|op| op == UserSpaceOp::Get).is_some() {
+                    if let Err(e) = result {
+                        upcalls
+                            .schedule_upcall(
+                                upcalls::VALUE,
+                                (kernel::errorcode::into_statuscode(e.into()), 0, 0),
+                            )
+                            .ok();
+                    } else {
+                        self.dest_buffer.map(|buf| {
+                            let ret = upcalls
+                                .get_readwrite_processbuffer(rw_allow::VALUE)
+                                .and_then(|buffer| {
+                                    buffer.mut_enter(|data| {
+                                        // Determine the size of the static buffer we have
+                                        let static_buffer_len = buf.len();
+                                        let data_len = data.len();
+
+                                        if data_len < static_buffer_len {
+                                            data.copy_from_slice(&buf[..data_len]);
+                                        } else {
+                                            data[..static_buffer_len].copy_from_slice(&buf);
+                                        }
+                                        Ok(())
+                                    })
+                                })
+                                .unwrap_or(Err(ErrorCode::RESERVE));
+
+                            if ret == Err(ErrorCode::RESERVE) {
+                                upcalls
+                                    .schedule_upcall(
+                                        upcalls::VALUE,
+                                        (kernel::errorcode::into_statuscode(ret.into()), 0, 0),
+                                    )
+                                    .ok();
+                            } else {
+                                upcalls.schedule_upcall(upcalls::VALUE, (0, 0, 0)).ok();
+                            }
+                        });
+
+                        self.appid.clear();
+                    }
+                }
+            })
+        });
+    }
+
+    fn set_complete(
+        &self,
+        result: Result<(), ErrorCode>,
+        key: &'static mut [u8],
+        value: &'static mut [u8],
+    ) {
+        self.data_buffer.replace(key);
+        self.dest_buffer.replace(value);
+
+        self.appid.map(move |id| {
+            self.apps.enter(*id, move |app, upcalls| {
+                if app.op.get().map(|op| op == UserSpaceOp::Set).is_some() {
+                    if let Err(e) = result {
+                        upcalls
+                            .schedule_upcall(
+                                upcalls::VALUE,
+                                (kernel::errorcode::into_statuscode(e.into()), 0, 0),
+                            )
+                            .ok();
+                    } else {
+                        upcalls.schedule_upcall(upcalls::VALUE, (0, 0, 0)).ok();
+
+                        self.appid.clear();
+                    }
+                }
+            })
+        });
+    }
+
+    fn delete_complete(&self, result: Result<(), ErrorCode>, key: &'static mut [u8]) {
+        self.data_buffer.replace(key);
+
+        self.appid.map(move |id| {
+            self.apps.enter(*id, move |app, upcalls| {
+                if app.op.get().map(|op| op == UserSpaceOp::Delete).is_some() {
+                    if let Err(e) = result {
+                        upcalls
+                            .schedule_upcall(
+                                upcalls::VALUE,
+                                (kernel::errorcode::into_statuscode(e.into()), 0, 0),
+                            )
+                            .ok();
+                    } else {
+                        upcalls.schedule_upcall(upcalls::VALUE, (0, 0, 0)).ok();
+
+                        self.appid.clear();
+                    }
+                }
+            })
+        });
+    }
+}
+
+impl<'a, K: kv_system::KVSystem<'a, K = T>, T: kv_system::KeyType> SyscallDriver
+    for KVSystemDriver<'a, K, T>
+{
+    fn command(
+        &self,
+        command_num: usize,
+        _data1: usize,
+        _data2: usize,
+        appid: ProcessId,
+    ) -> CommandReturn {
+        let match_or_empty_or_nonexistant = self.appid.map_or(true, |owning_app| {
+            // We have recorded that an app has ownership of the KV Store.
+
+            // If the KV Store is still active, then we need to wait for the operation
+            // to finish and the app, whether it exists or not (it may have crashed),
+            // still owns this capsule. If the KV Store is not active, then
+            // we need to verify that that application still exists, and remove
+            // it as owner if not.
+            if self.active.get() {
+                owning_app == &appid
+            } else {
+                // Check the app still exists.
+                //
+                // If the `.enter()` succeeds, then the app is still valid, and
+                // we can check if the owning app matches the one that called
+                // the command. If the `.enter()` fails, then the owning app no
+                // longer exists and we return `true` to signify the
+                // "or_nonexistant" case.
+                self.apps
+                    .enter(*owning_app, |_, _| owning_app == &appid)
+                    .unwrap_or(true)
+            }
+        });
+
+        match command_num {
+            // check if present
+            0 => CommandReturn::success(),
+
+            // get, set, delete
+            1 | 2 | 3 => {
+                if match_or_empty_or_nonexistant {
+                    self.appid.set(appid);
+                    let _ = self.apps.enter(appid, |app, _| match command_num {
+                        1 => app.op.set(Some(UserSpaceOp::Get)),
+                        2 => app.op.set(Some(UserSpaceOp::Set)),
+                        3 => app.op.set(Some(UserSpaceOp::Delete)),
+                        _ => {}
+                    });
+                    let ret = self.run();
+
+                    if let Err(e) = ret {
+                        self.appid.clear();
+                        self.check_queue();
+                        CommandReturn::failure(e)
+                    } else {
+                        CommandReturn::success()
+                    }
+                } else {
+                    // There is an active app, so queue this request (if possible).
+                    self.apps
+                        .enter(appid, |app, _| {
+                            // Some app is using the storage, we must wait.
+                            if app.pending_run_app.is_some() {
+                                // No more room in the queue, nowhere to store this
+                                // request.
+                                CommandReturn::failure(ErrorCode::NOMEM)
+                            } else {
+                                // We can store this, so lets do it.
+                                app.pending_run_app = Some(appid);
+                                match command_num {
+                                    1 => app.op.set(Some(UserSpaceOp::Get)),
+                                    2 => app.op.set(Some(UserSpaceOp::Set)),
+                                    3 => app.op.set(Some(UserSpaceOp::Delete)),
+                                    _ => {}
+                                }
+                                CommandReturn::success()
+                            }
+                        })
+                        .unwrap_or_else(|err| err.into())
+                }
+            }
+
+            // default
+            _ => CommandReturn::failure(ErrorCode::NOSUPPORT),
+        }
+    }
+
+    fn allocate_grant(&self, processid: ProcessId) -> Result<(), kernel::process::Error> {
+        self.apps.enter(processid, |_, _| {})
+    }
+}
+
+#[derive(Copy, Clone, PartialEq)]
+enum UserSpaceOp {
+    Get,
+    Set,
+    Delete,
+}
+
+#[derive(Default)]
+pub struct App {
+    pending_run_app: Option<ProcessId>,
+    op: Cell<Option<UserSpaceOp>>,
+}

--- a/capsules/src/kv_driver.rs
+++ b/capsules/src/kv_driver.rs
@@ -114,8 +114,7 @@ impl<'a, K: kv_system::KVSystem<'a, K = T>, T: kv_system::KeyType> KVSystemDrive
                                             if let Err((data, dest, e)) = self.kv.get(
                                                 data_buffer,
                                                 dest_buffer,
-                                                &appid.get_read_ids().unwrap_or([0; 8]),
-                                                appid.num_read_ids().unwrap_or(0),
+                                                appid.get_read_permissions(),
                                             ) {
                                                 self.data_buffer.replace(data);
                                                 self.dest_buffer.replace(dest);
@@ -175,7 +174,7 @@ impl<'a, K: kv_system::KVSystem<'a, K = T>, T: kv_system::KeyType> KVSystemDrive
                                                 data_buffer,
                                                 dest_buffer,
                                                 static_buffer_len,
-                                                appid.get_write_id().unwrap_or(0),
+                                                appid.get_write_permissions(),
                                             ) {
                                                 self.data_buffer.replace(data);
                                                 self.dest_buffer.replace(dest);
@@ -209,11 +208,9 @@ impl<'a, K: kv_system::KVSystem<'a, K = T>, T: kv_system::KeyType> KVSystemDrive
                                     .unwrap_or(Err(ErrorCode::RESERVE))?;
 
                                 if let Some(Err(e)) = self.data_buffer.take().map(|data_buffer| {
-                                    if let Err((data, e)) = self.kv.delete(
-                                        data_buffer,
-                                        &appid.get_access_ids().unwrap_or([0; 8]),
-                                        appid.num_access_ids().unwrap_or(0),
-                                    ) {
+                                    if let Err((data, e)) =
+                                        self.kv.delete(data_buffer, appid.get_write_permissions())
+                                    {
                                         self.data_buffer.replace(data);
                                         return Err(e);
                                     }

--- a/capsules/src/kv_store.rs
+++ b/capsules/src/kv_store.rs
@@ -1,0 +1,445 @@
+//! Tock TicKV capsule.
+//!
+//! This capsule implements the TicKV library in Tock. This is done
+//! using the TicKV library (libraries/tickv).
+//!
+//! This capsule interfaces with flash and exposes the Tock `hil::kv_system`
+//! interface to others. This capsule is also required to enforce permission
+//! checks.
+//!
+//! +-----------------------+
+//! |                       |
+//! |  Capsule using K-V    |
+//! |                       |
+//! +-----------------------+
+//!
+//!    capsules::kv_store
+//!
+//! +-----------------------+
+//! |                       |
+//! | K-V store (this file)|
+//! |                       |
+//! +-----------------------+
+//!
+//!    hil::kv_system
+//!
+//! +-----------------------+
+//! |                       |
+//! |  K-V library          |
+//! |                       |
+//! +-----------------------+
+//!
+//!    hil::flash
+
+use core::cell::Cell;
+use kernel::collections::list::{List, ListLink, ListNode};
+use kernel::hil::kv_system::{self, KVSystem};
+use kernel::utilities::cells::{OptionalCell, TakeCell};
+use kernel::ErrorCode;
+
+#[derive(Clone, Copy, PartialEq)]
+enum Operation {
+    Get,
+    Set,
+    Delete,
+}
+
+pub struct KVStore<'a, K: KVSystem<'a> + KVSystem<'a, K = T>, T: 'static + kv_system::KeyType> {
+    mux_kv: &'a MuxKVStore<'a, K, T>,
+    next: ListLink<'a, KVStore<'a, K, T>>,
+
+    client: OptionalCell<&'a dyn kv_system::StoreClient<T>>,
+
+    next_operation: OptionalCell<Operation>,
+
+    hashed_key: TakeCell<'static, T>,
+    unhashed_key: TakeCell<'static, [u8]>,
+    value: TakeCell<'static, [u8]>,
+}
+
+impl<'a, K: KVSystem<'a, K = T>, T: kv_system::KeyType> ListNode<'a, KVStore<'a, K, T>>
+    for KVStore<'a, K, T>
+{
+    fn next(&self) -> &'a ListLink<KVStore<'a, K, T>> {
+        &self.next
+    }
+}
+
+impl<'a, K: KVSystem<'a, K = T>, T: kv_system::KeyType> KVStore<'a, K, T> {
+    pub fn new(mux_kv: &'a MuxKVStore<'a, K, T>, key: &'static mut T) -> KVStore<'a, K, T> {
+        Self {
+            mux_kv,
+            next: ListLink::empty(),
+            client: OptionalCell::empty(),
+            next_operation: OptionalCell::empty(),
+            hashed_key: TakeCell::new(key),
+            unhashed_key: TakeCell::empty(),
+            value: TakeCell::empty(),
+        }
+    }
+
+    pub fn set_client(&self, client: &'a dyn kv_system::StoreClient<T>) {
+        self.client.set(client);
+    }
+
+    pub fn get(
+        &self,
+        unhashed_key: &'static mut [u8],
+        value: &'static mut [u8],
+    ) -> Result<(), (&'static mut [u8], &'static mut [u8], Result<(), ErrorCode>)> {
+        if self.mux_kv.operation.is_none() {
+            self.mux_kv.operation.set(Operation::Get);
+
+            if self.hashed_key.is_none() {
+                return Err((unhashed_key, value, Err(ErrorCode::NOMEM)));
+            }
+
+            if let Some(Err((unhashed_key, e))) = self.hashed_key.take().map(|buf| {
+                if let Err((unhashed_key, hashed_key, e)) =
+                    self.mux_kv.kv.generate_key(unhashed_key, buf)
+                {
+                    self.hashed_key.replace(hashed_key);
+                    self.mux_kv.operation.clear();
+                    return Err((unhashed_key, e));
+                }
+
+                Ok(())
+            }) {
+                return Err((unhashed_key, value, e));
+            }
+
+            self.value.replace(value);
+            Ok(())
+        } else {
+            // Another app is already running, queue this app as long as we
+            // don't already have data queued.
+            if self.next_operation.is_none() {
+                self.next_operation.set(Operation::Get);
+                self.unhashed_key.replace(unhashed_key);
+                self.value.replace(value);
+                Ok(())
+            } else {
+                Err((unhashed_key, value, Err(ErrorCode::BUSY)))
+            }
+        }
+    }
+
+    pub fn set(
+        &self,
+        unhashed_key: &'static mut [u8],
+        value: &'static mut [u8],
+    ) -> Result<(), (&'static mut [u8], &'static mut [u8], Result<(), ErrorCode>)> {
+        if self.mux_kv.operation.is_none() {
+            self.mux_kv.operation.set(Operation::Set);
+
+            if self.hashed_key.is_none() {
+                return Err((unhashed_key, value, Err(ErrorCode::NOMEM)));
+            }
+
+            if let Some(Err((unhashed_key, e))) = self.hashed_key.take().map(|buf| {
+                if let Err((unhashed_key, hashed_key, e)) =
+                    self.mux_kv.kv.generate_key(unhashed_key, buf)
+                {
+                    self.hashed_key.replace(hashed_key);
+                    self.mux_kv.operation.clear();
+                    return Err((unhashed_key, e));
+                }
+
+                Ok(())
+            }) {
+                return Err((unhashed_key, value, e));
+            }
+            self.value.replace(value);
+            Ok(())
+        } else {
+            // Another app is already running, queue this app as long as we
+            // don't already have data queued.
+            if self.next_operation.is_none() {
+                self.next_operation.set(Operation::Set);
+                self.unhashed_key.replace(unhashed_key);
+                self.value.replace(value);
+                Ok(())
+            } else {
+                Err((unhashed_key, value, Err(ErrorCode::BUSY)))
+            }
+        }
+    }
+
+    pub fn delete(
+        &self,
+        unhashed_key: &'static mut [u8],
+    ) -> Result<(), (&'static mut [u8], Result<(), ErrorCode>)> {
+        if self.mux_kv.operation.is_none() {
+            self.mux_kv.operation.set(Operation::Delete);
+
+            if self.hashed_key.is_none() {
+                return Err((unhashed_key, Err(ErrorCode::NOMEM)));
+            }
+
+            if let Some(Err((unhashed_key, e))) = self.hashed_key.take().map(|buf| {
+                if let Err((unhashed_key, hashed_key, e)) =
+                    self.mux_kv.kv.generate_key(unhashed_key, buf)
+                {
+                    self.hashed_key.replace(hashed_key);
+                    self.mux_kv.operation.clear();
+                    return Err((unhashed_key, e));
+                }
+
+                Ok(())
+            }) {
+                return Err((unhashed_key, e));
+            }
+            Ok(())
+        } else {
+            // Another app is already running, queue this app as long as we
+            // don't already have data queued.
+            if self.next_operation.is_none() {
+                self.next_operation.set(Operation::Delete);
+                self.unhashed_key.replace(unhashed_key);
+                Ok(())
+            } else {
+                Err((unhashed_key, Err(ErrorCode::BUSY)))
+            }
+        }
+    }
+}
+
+impl<'a, K: KVSystem<'a, K = T>, T: kv_system::KeyType + core::fmt::Debug> kv_system::Client<T>
+    for KVStore<'a, K, T>
+{
+    fn generate_key_complete(
+        &self,
+        result: Result<(), ErrorCode>,
+        unhashed_key: &'static mut [u8],
+        hashed_key: &'static mut T,
+    ) {
+        self.unhashed_key.replace(unhashed_key);
+
+        self.mux_kv.operation.map(|op| {
+            if result.is_err() {
+                self.hashed_key.replace(hashed_key);
+
+                self.unhashed_key.take().map(|unhashed_key| match op {
+                    Operation::Get => {
+                        self.value.take().map(|value| {
+                            self.client.map(move |cb| {
+                                cb.get_complete(result, unhashed_key, value);
+                            });
+                        });
+                    }
+                    Operation::Set => {
+                        self.value.take().map(|value| {
+                            self.client.map(move |cb| {
+                                cb.set_complete(result, unhashed_key, value);
+                            });
+                        });
+                    }
+                    Operation::Delete => {
+                        self.client.map(move |cb| {
+                            cb.delete_complete(result, unhashed_key);
+                        });
+                    }
+                });
+            } else {
+                match op {
+                    Operation::Get => {
+                        self.value.take().map(|value| {
+                            if let Err((key, value, e)) =
+                                self.mux_kv.kv.get_value(hashed_key, value)
+                            {
+                                self.unhashed_key.take().map(|unhashed_key| {
+                                    self.hashed_key.replace(key);
+                                    self.client.map(move |cb| {
+                                        cb.get_complete(e, unhashed_key, value);
+                                    });
+                                });
+                            }
+                        });
+                    }
+                    Operation::Set => {
+                        self.value.take().map(|value| {
+                            if let Err((key, value, e)) =
+                                self.mux_kv.kv.append_key(hashed_key, value)
+                            {
+                                self.hashed_key.replace(key);
+                                self.unhashed_key.take().map(|unhashed_key| {
+                                    self.client.map(move |cb| {
+                                        cb.set_complete(e, unhashed_key, value);
+                                    });
+                                });
+                            }
+                        });
+                    }
+                    Operation::Delete => {
+                        if let Err((key, e)) = self.mux_kv.kv.invalidate_key(hashed_key) {
+                            self.hashed_key.replace(key);
+                            self.unhashed_key.take().map(|unhashed_key| {
+                                self.client.map(move |cb| {
+                                    cb.delete_complete(e, unhashed_key);
+                                });
+                            });
+                        }
+                    }
+                }
+            }
+        });
+
+        self.mux_kv.do_next_op();
+    }
+
+    fn append_key_complete(
+        &self,
+        result: Result<(), ErrorCode>,
+        key: &'static mut T,
+        value: &'static mut [u8],
+    ) {
+        self.hashed_key.replace(key);
+        self.value.replace(value);
+
+        self.mux_kv.operation.map(|op| match op {
+            Operation::Get | Operation::Delete => {}
+            Operation::Set => {
+                self.unhashed_key.take().map(|unhashed_key| {
+                    self.value.take().map(|value| {
+                        self.client.map(move |cb| {
+                            cb.set_complete(result, unhashed_key, value);
+                        });
+                    });
+                });
+                self.mux_kv.operation.clear();
+            }
+        });
+
+        self.mux_kv.do_next_op();
+    }
+
+    fn get_value_complete(
+        &self,
+        result: Result<(), ErrorCode>,
+        key: &'static mut T,
+        ret_buf: &'static mut [u8],
+    ) {
+        self.hashed_key.replace(key);
+
+        self.mux_kv.operation.map(|op| match op {
+            Operation::Set | Operation::Delete => {}
+            Operation::Get => {
+                self.unhashed_key.take().map(|unhashed_key| {
+                    self.client.map(move |cb| {
+                        cb.get_complete(result, unhashed_key, ret_buf);
+                    });
+                });
+                self.mux_kv.operation.clear();
+            }
+        });
+
+        self.mux_kv.do_next_op();
+    }
+
+    fn invalidate_key_complete(&self, result: Result<(), ErrorCode>, key: &'static mut T) {
+        self.hashed_key.replace(key);
+
+        self.mux_kv.operation.map(|op| match op {
+            Operation::Set | Operation::Get => {}
+            Operation::Delete => {
+                self.unhashed_key.take().map(|unhashed_key| {
+                    self.client.map(move |cb| {
+                        cb.delete_complete(result, unhashed_key);
+                    });
+                });
+                self.mux_kv.operation.clear();
+            }
+        });
+
+        self.mux_kv.perform_cleanup.set(true);
+        self.mux_kv.do_next_op();
+    }
+
+    fn garbage_collect_complete(&self, _result: Result<(), ErrorCode>) {
+        self.mux_kv.perform_cleanup.set(false);
+        self.mux_kv.do_next_op();
+    }
+}
+
+pub struct MuxKVStore<'a, K: KVSystem<'a> + KVSystem<'a, K = T>, T: 'static + kv_system::KeyType> {
+    kv: &'a K,
+    operation: OptionalCell<Operation>,
+    perform_cleanup: Cell<bool>,
+    users: List<'a, KVStore<'a, K, T>>,
+}
+
+impl<'a, K: KVSystem<'a> + KVSystem<'a, K = T>, T: 'static + kv_system::KeyType>
+    MuxKVStore<'a, K, T>
+{
+    pub const fn new(kv: &'a K) -> MuxKVStore<'a, K, T> {
+        Self {
+            kv,
+            operation: OptionalCell::empty(),
+            perform_cleanup: Cell::new(false),
+            users: List::new(),
+        }
+    }
+
+    fn do_next_op(&self) {
+        if self.operation.is_some() {
+            return;
+        }
+
+        let mnode = self.users.iter().find(|node| node.next_operation.is_some());
+
+        let ret = mnode.map_or(Err(ErrorCode::NODEVICE), |node| {
+            node.next_operation.map(|op| {
+                self.operation.set(op.clone());
+
+                node.unhashed_key.take().map(|unhashed_key| {
+                    node.hashed_key.take().map(|hashed_key| {
+                        match op {
+                            Operation::Get => {
+                                if let Err((unhashed_key, hashed_key, e)) =
+                                    self.kv.generate_key(unhashed_key, hashed_key)
+                                {
+                                    node.hashed_key.replace(hashed_key);
+                                    node.value.take().map(|value| {
+                                        node.client.map(move |cb| {
+                                            cb.get_complete(e, unhashed_key, value);
+                                        });
+                                    });
+                                }
+                            }
+                            Operation::Set => {
+                                if let Err((unhashed_key, hashed_key, e)) =
+                                    self.kv.generate_key(unhashed_key, hashed_key)
+                                {
+                                    node.hashed_key.replace(hashed_key);
+                                    node.value.take().map(|value| {
+                                        node.client.map(move |cb| {
+                                            cb.set_complete(e, unhashed_key, value);
+                                        });
+                                    });
+                                }
+                            }
+                            Operation::Delete => {
+                                if let Err((unhashed_key, hashed_key, e)) =
+                                    self.kv.generate_key(unhashed_key, hashed_key)
+                                {
+                                    node.hashed_key.replace(hashed_key);
+                                    node.client.map(move |cb| {
+                                        cb.delete_complete(e, unhashed_key);
+                                    });
+                                }
+                            }
+                        };
+                    });
+                });
+            });
+            Ok(())
+        });
+
+        // If we have nothing scheduled, run a garbage collect
+        if ret == Err(ErrorCode::NODEVICE) && self.perform_cleanup.get() {
+            // We have no way to report this error, and even if we could, what
+            // would a user do?
+            let _ = self.kv.garbage_collect();
+        }
+    }
+}

--- a/capsules/src/lib.rs
+++ b/capsules/src/lib.rs
@@ -38,6 +38,7 @@ pub mod i2c_master;
 pub mod i2c_master_slave_driver;
 pub mod ieee802154;
 pub mod isl29035;
+pub mod kv_driver;
 pub mod kv_store;
 pub mod l3gd20;
 pub mod led;

--- a/capsules/src/lib.rs
+++ b/capsules/src/lib.rs
@@ -38,6 +38,7 @@ pub mod i2c_master;
 pub mod i2c_master_slave_driver;
 pub mod ieee802154;
 pub mod isl29035;
+pub mod kv_store;
 pub mod l3gd20;
 pub mod led;
 pub mod led_matrix;

--- a/capsules/src/test/kv_system.rs
+++ b/capsules/src/test/kv_system.rs
@@ -114,7 +114,7 @@ impl<'a, S: KVSystem<'static, K = T>, T: KeyType + core::fmt::Debug> kv_system::
         &self,
         result: Result<(), ErrorCode>,
         key: &'static mut T,
-        value: &'static [u8],
+        value: &'static mut [u8],
     ) {
         match result {
             Ok(()) => {

--- a/doc/TockBinaryFormat.md
+++ b/doc/TockBinaryFormat.md
@@ -404,20 +404,18 @@ The data is stored in the `TbfHeaderV2PersistentAcl` field, which includes a
 `write_id` indicates the id that all new persistent data is written with.
 All new data created will be stored with permissions from the `write_id`
 field. For existing data see the `access_ids` section below.
-Only apps with the same id listed in the `read_ids` can read the data.
-Apps with the same `access_ids` or `write_id` can overwrite the data.
 `write_id` does not need to be unique, that is multiple apps can have the
 same id.
 A `write_id` of `0x00` indicates that the app can not perform write operations.
 
 `read_ids` list all of the ids that this app has permission to read. The
-`read_length` specifiies the length of the `read_ids` in elements (not bytes).
+`read_length` specifies the length of the `read_ids` in elements (not bytes).
 `read_length` can be `0` indicating that there are no `read_ids`.
 
 `access_ids` list all of the ids that this app has permission to write.
 `access_ids` are different to `write_id` in that `write_id` applies to new data
 while `access_ids` allows modification of existing data.
-The `access_length` specifiies the length of the `access_ids` in elements (not bytes).
+The `access_length` specifies the length of the `access_ids` in elements (not bytes).
 `access_length` can be `0` indicating that there are no `access_ids`.
 
 For example an app has a `write_id` of `1`, `read_ids` of `2, 3` and

--- a/kernel/src/hil/kv_system.rs
+++ b/kernel/src/hil/kv_system.rs
@@ -88,7 +88,7 @@ pub trait Client<K: KeyType> {
         &self,
         result: Result<(), ErrorCode>,
         key: &'static mut K,
-        value: &'static [u8],
+        value: &'static mut [u8],
     );
 
     /// This callback is called when the get_value operation completes
@@ -160,8 +160,15 @@ pub trait KVSystem<'a> {
     fn append_key(
         &self,
         key: &'static mut Self::K,
-        value: &'static [u8],
-    ) -> Result<(), (&'static mut Self::K, &'static [u8], Result<(), ErrorCode>)>;
+        value: &'static mut [u8],
+    ) -> Result<
+        (),
+        (
+            &'static mut Self::K,
+            &'static mut [u8],
+            Result<(), ErrorCode>,
+        ),
+    >;
 
     /// Retrieves the value from a specified key.
     ///

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -108,6 +108,7 @@ pub mod platform;
 pub mod process;
 pub mod processbuffer;
 pub mod scheduler;
+pub mod storage_permissions;
 pub mod syscall;
 pub mod upcall;
 pub mod utilities;

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -167,6 +167,41 @@ impl ProcessId {
             (addresses.flash_non_protected_start, addresses.flash_end)
         })
     }
+
+    /// Get the process `write_id`.
+    /// Returns `None` if a `write_id` is not included.
+    pub fn get_write_id(&self) -> Option<u32> {
+        self.kernel
+            .process_map_or(None, *self, |process| process.get_write_id())
+    }
+
+    /// Get the `read_ids`.
+    /// Returns `None` if a `read_ids` is not included.
+    pub fn get_read_ids(&self) -> Option<[u32; 8]> {
+        self.kernel
+            .process_map_or(None, *self, |process| process.get_read_ids())
+    }
+
+    /// Get the number of `read_ids`.
+    /// Returns `None` if a `read_ids` is not included.
+    pub fn num_read_ids(&self) -> Option<usize> {
+        self.kernel
+            .process_map_or(None, *self, |process| process.num_read_ids())
+    }
+
+    /// Get the `access_ids`.
+    /// Returns `None` if a `access_ids` is not included.
+    pub fn get_access_ids(&self) -> Option<[u32; 8]> {
+        self.kernel
+            .process_map_or(None, *self, |process| process.get_access_ids())
+    }
+
+    /// Get the number of `access_ids`.
+    /// Returns `None` if a `access_ids` is not included.
+    pub fn num_access_ids(&self) -> Option<usize> {
+        self.kernel
+            .process_map_or(None, *self, |process| process.num_access_ids())
+    }
 }
 
 /// This trait represents a generic process that the Tock scheduler can
@@ -399,6 +434,26 @@ pub trait Process {
     /// they are returned as a 64 bit bitmask for sequential command numbers.
     /// The offset indicates the multiple of 64 command numbers to get permissions for.
     fn get_command_permissions(&self, driver_num: usize, offset: usize) -> CommandPermissions;
+
+    /// Get the process `write_id`.
+    /// Returns `None` if a `write_id` is not included.
+    fn get_write_id(&self) -> Option<u32>;
+
+    /// Get the `read_ids`.
+    /// Returns `None` if a `read_ids` is not included.
+    fn get_read_ids(&self) -> Option<[u32; 8]>;
+
+    /// Get the number of `read_ids`.
+    /// Returns `None` if a `read_ids` is not included.
+    fn num_read_ids(&self) -> Option<usize>;
+
+    /// Get the `access_ids`.
+    /// Returns `None` if a `access_ids` is not included.
+    fn get_access_ids(&self) -> Option<[u32; 8]>;
+
+    /// Get the number of `access_ids`.
+    /// Returns `None` if a `access_ids` is not included.
+    fn num_access_ids(&self) -> Option<usize>;
 
     // mpu
 

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -410,6 +410,8 @@ pub trait Process {
     fn get_command_permissions(&self, driver_num: usize, offset: usize) -> CommandPermissions;
 
     /// Get the storage permissions for the process.
+    ///
+    /// Returns `None` if the process has no storage permissions.
     fn get_storage_permissions(&self) -> Option<storage_permissions::StoragePermissions>;
 
     // mpu

--- a/kernel/src/process_standard.rs
+++ b/kernel/src/process_standard.rs
@@ -416,7 +416,7 @@ impl<C: Chip> Process for ProcessStandard<'_, C> {
             .get_persistent_acl_read_ids()
             .unwrap_or((0, [0; 8]));
 
-        let (write_count, write_storage_ids) = self
+        let (access_count, access_storage_ids) = self
             .header
             .get_persistent_acl_access_ids()
             .unwrap_or((0, [0; 8]));
@@ -426,8 +426,8 @@ impl<C: Chip> Process for ProcessStandard<'_, C> {
         Some(storage_permissions::StoragePermissions::new(
             read_count,
             read_storage_ids,
-            write_count,
-            write_storage_ids,
+            access_count,
+            access_storage_ids,
             write_id,
         ))
     }

--- a/kernel/src/process_standard.rs
+++ b/kernel/src/process_standard.rs
@@ -409,6 +409,36 @@ impl<C: Chip> Process for ProcessStandard<'_, C> {
         self.header.get_command_permissions(driver_num, offset)
     }
 
+    /// Get the process `write_id`.
+    /// Returns `None` if a `write_id` is not included.
+    fn get_write_id(&self) -> Option<u32> {
+        self.header.get_write_id()
+    }
+
+    /// Get the `read_ids`.
+    /// Returns `None` if a `read_ids` is not included.
+    fn get_read_ids(&self) -> Option<[u32; 8]> {
+        self.header.get_read_ids()
+    }
+
+    /// Get the number of `read_ids`.
+    /// Returns `None` if a `read_ids` is not included.
+    fn num_read_ids(&self) -> Option<usize> {
+        self.header.num_read_ids()
+    }
+
+    /// Get the `access_ids`.
+    /// Returns `None` if a `access_ids` is not included.
+    fn get_access_ids(&self) -> Option<[u32; 8]> {
+        self.header.get_access_ids()
+    }
+
+    /// Get the number of `access_ids`.
+    /// Returns `None` if a `access_ids` is not included.
+    fn num_access_ids(&self) -> Option<usize> {
+        self.header.num_access_ids()
+    }
+
     fn number_writeable_flash_regions(&self) -> usize {
         self.header.number_writeable_flash_regions()
     }

--- a/kernel/src/storage_permissions.rs
+++ b/kernel/src/storage_permissions.rs
@@ -1,0 +1,77 @@
+//! Mechanism for managing storage read & write permissions.
+
+use core::cmp;
+
+/// List of storage permissions for a storage user.
+///
+/// These identifiers signify what permissions a storage user has. The storage
+/// mechanism defines how the identifiers are assigned and how they relate to
+/// stored objects.
+///
+/// For simplicity, a we store to eight read and eight write permissions. The
+/// first `count` `u32` values in `permissions` are valid.
+///
+/// Mar, 2022: This interface is considered experimental and for initial
+/// prototyping. As we learn more about how these permissions are set and used
+/// we may want to revamp this interface.
+#[derive(Clone, Copy)]
+pub struct StoragePermissions {
+    // How many entries in the `read_permissions` slice are valid, starting at
+    // index 0.
+    read_count: usize,
+    // Up to eight 32 bit identifiers of storage items the process has read
+    // access to.
+    read_permissions: [u32; 8],
+    // How many entries in the `write_permissions` slice are valid, starting at
+    // index 0.
+    write_count: usize,
+    // Up to eight 32 bit identifiers of storage items the process has write
+    // (update) access to.
+    write_permissions: [u32; 8],
+    // The identifier for this storage user when creating new objects. If `None`
+    // there is no `write_id` for these permissions.
+    write_id: Option<u32>,
+}
+
+impl StoragePermissions {
+    pub(crate) fn new(
+        read_count: usize,
+        read_permissions: [u32; 8],
+        write_count: usize,
+        write_permissions: [u32; 8],
+        write_id: Option<u32>,
+    ) -> Self {
+        let read_count_capped = cmp::min(read_count, 8);
+        let write_count_capped = cmp::min(write_count, 8);
+        StoragePermissions {
+            read_count: read_count_capped,
+            read_permissions,
+            write_count: write_count_capped,
+            write_permissions,
+            write_id,
+        }
+    }
+
+    /// Check if this permission object grants read access to the specified
+    /// `storage_id`. Returns `true` if access is permitted, `false` otherwise.
+    pub fn check_read_permission(&self, storage_id: u32) -> bool {
+        self.read_permissions
+            .get(0..self.read_count)
+            .unwrap_or(&[])
+            .contains(&storage_id)
+    }
+
+    /// Check if this permission object grants write access to the specified
+    /// `storage_id`. Returns `true` if access is permitted, `false` otherwise.
+    pub fn check_write_permission(&self, storage_id: u32) -> bool {
+        self.write_permissions
+            .get(0..self.write_count)
+            .unwrap_or(&[])
+            .contains(&storage_id)
+    }
+
+    /// Get the `write_id` for saving items to the storage.
+    pub fn get_write_id(&self) -> Option<u32> {
+        self.write_id
+    }
+}

--- a/libraries/tickv/src/async_ops.rs
+++ b/libraries/tickv/src/async_ops.rs
@@ -343,11 +343,11 @@ impl<'a, C: FlashController<S>, const S: usize> AsyncTicKV<'a, C, S> {
     }
 }
 
-/// Tests using a flash controller that can store data
 #[cfg(test)]
 mod tests {
     #![allow(unsafe_code)]
 
+    /// Tests using a flash controller that can store data
     mod store_flast_ctrl {
         use crate::async_ops::AsyncTicKV;
         use crate::error_codes::ErrorCode;

--- a/libraries/tickv/src/async_ops.rs
+++ b/libraries/tickv/src/async_ops.rs
@@ -100,11 +100,11 @@
 //! // when appending a key:
 //!
 //! // Add a key
-//! static VALUE: [u8; 32] = [0x23; 32];
-//! let ret = unsafe { tickv.append_key(get_hashed_key(b"ONE"), &VALUE) };
+//! static mut VALUE: [u8; 32] = [0x23; 32];
+//! let ret = unsafe { tickv.append_key(get_hashed_key(b"ONE"), &mut VALUE) };
 //!
 //! match ret {
-//!     Err(ErrorCode::ReadNotReady(reg)) => {
+//!     Err((_buf, ErrorCode::ReadNotReady(reg))) => {
 //!         // There is no actual delay in the test, just continue now
 //!         tickv.set_read_buffer(&tickv.tickv.controller.buf.borrow()[reg]);
 //!         tickv
@@ -142,7 +142,7 @@ pub struct AsyncTicKV<'a, C: FlashController<S>, const S: usize> {
     /// The main TicKV struct
     pub tickv: TicKV<'a, C, S>,
     key: Cell<Option<u64>>,
-    value: Cell<Option<&'static [u8]>>,
+    value: Cell<Option<&'static mut [u8]>>,
     buf: Cell<Option<&'static mut [u8]>>,
 }
 
@@ -185,14 +185,23 @@ impl<'a, C: FlashController<S>, const S: usize> AsyncTicKV<'a, C, S> {
     ///
     /// On success nothing will be returned.
     /// On error a `ErrorCode` will be returned.
-    pub fn append_key(&self, hash: u64, value: &'static [u8]) -> Result<SuccessCode, ErrorCode> {
+    pub fn append_key(
+        &self,
+        hash: u64,
+        value: &'static mut [u8],
+    ) -> Result<SuccessCode, (Option<&'static mut [u8]>, ErrorCode)> {
         match self.tickv.append_key(hash, value) {
             Ok(code) => Ok(code),
-            Err(e) => {
-                self.key.replace(Some(hash));
-                self.value.replace(Some(value));
-                Err(e)
-            }
+            Err(e) => match e {
+                ErrorCode::ReadNotReady(_)
+                | ErrorCode::EraseNotReady(_)
+                | ErrorCode::WriteNotReady(_) => {
+                    self.key.replace(Some(hash));
+                    self.value.replace(Some(value));
+                    Err((None, e))
+                }
+                _ => Err((Some(value), e)),
+            },
         }
     }
 
@@ -266,7 +275,7 @@ impl<'a, C: FlashController<S>, const S: usize> AsyncTicKV<'a, C, S> {
 
     /// Get the `value` buffer that was passed in by previous
     /// commands.
-    pub fn get_stored_value_buffer(&self) -> Option<&'static [u8]> {
+    pub fn get_stored_value_buffer(&self) -> Option<&'static mut [u8]> {
         self.value.take()
     }
 
@@ -294,9 +303,12 @@ impl<'a, C: FlashController<S>, const S: usize> AsyncTicKV<'a, C, S> {
     pub fn continue_operation(&self) -> ContinueReturn {
         let ret = match self.tickv.state.get() {
             State::Init(_) => self.tickv.initalise(self.key.get().unwrap()),
-            State::AppendKey(_) => self
-                .tickv
-                .append_key(self.key.get().unwrap(), self.value.get().unwrap()),
+            State::AppendKey(_) => {
+                let value = self.value.take().unwrap();
+                let ret = self.tickv.append_key(self.key.get().unwrap(), value);
+                self.value.replace(Some(value));
+                ret
+            }
             State::GetKey(_) => {
                 let buf = self.buf.take().unwrap();
                 let ret = self.tickv.get_key(self.key.get().unwrap(), buf);
@@ -333,533 +345,535 @@ impl<'a, C: FlashController<S>, const S: usize> AsyncTicKV<'a, C, S> {
 
 /// Tests using a flash controller that can store data
 #[cfg(test)]
-mod store_flast_ctrl {
-    use crate::async_ops::AsyncTicKV;
-    use crate::error_codes::ErrorCode;
-    use crate::flash_controller::FlashController;
-    use crate::tickv::{HASH_OFFSET, LEN_OFFSET, MAIN_KEY, VERSION, VERSION_OFFSET};
-    use core::hash::{Hash, Hasher};
-    use std::cell::Cell;
-    use std::cell::RefCell;
-    use std::collections::hash_map::DefaultHasher;
+mod tests {
+    #![allow(unsafe_code)]
 
-    fn check_region_main(buf: &[u8]) {
-        // Check the version
-        assert_eq!(buf[VERSION_OFFSET], VERSION);
+    mod store_flast_ctrl {
+        use crate::async_ops::AsyncTicKV;
+        use crate::error_codes::ErrorCode;
+        use crate::flash_controller::FlashController;
+        use crate::tickv::{HASH_OFFSET, LEN_OFFSET, MAIN_KEY, VERSION, VERSION_OFFSET};
+        use core::hash::{Hash, Hasher};
+        use std::cell::Cell;
+        use std::cell::RefCell;
+        use std::collections::hash_map::DefaultHasher;
 
-        // Check the length
-        assert_eq!(buf[LEN_OFFSET], 0x80);
-        assert_eq!(buf[LEN_OFFSET + 1], 15);
+        fn check_region_main(buf: &[u8]) {
+            // Check the version
+            assert_eq!(buf[VERSION_OFFSET], VERSION);
 
-        // Check the hash
-        assert_eq!(buf[HASH_OFFSET + 0], 0x7b);
-        assert_eq!(buf[HASH_OFFSET + 1], 0xc9);
-        assert_eq!(buf[HASH_OFFSET + 2], 0xf7);
-        assert_eq!(buf[HASH_OFFSET + 3], 0xff);
-        assert_eq!(buf[HASH_OFFSET + 4], 0x4f);
-        assert_eq!(buf[HASH_OFFSET + 5], 0x76);
-        assert_eq!(buf[HASH_OFFSET + 6], 0xf2);
-        assert_eq!(buf[HASH_OFFSET + 7], 0x44);
+            // Check the length
+            assert_eq!(buf[LEN_OFFSET], 0x80);
+            assert_eq!(buf[LEN_OFFSET + 1], 15);
 
-        // Check the check hash
-        assert_eq!(buf[HASH_OFFSET + 8], 0x55);
-        assert_eq!(buf[HASH_OFFSET + 9], 0xb5);
-        assert_eq!(buf[HASH_OFFSET + 10], 0xd8);
-        assert_eq!(buf[HASH_OFFSET + 11], 0xe4);
-    }
+            // Check the hash
+            assert_eq!(buf[HASH_OFFSET + 0], 0x7b);
+            assert_eq!(buf[HASH_OFFSET + 1], 0xc9);
+            assert_eq!(buf[HASH_OFFSET + 2], 0xf7);
+            assert_eq!(buf[HASH_OFFSET + 3], 0xff);
+            assert_eq!(buf[HASH_OFFSET + 4], 0x4f);
+            assert_eq!(buf[HASH_OFFSET + 5], 0x76);
+            assert_eq!(buf[HASH_OFFSET + 6], 0xf2);
+            assert_eq!(buf[HASH_OFFSET + 7], 0x44);
 
-    fn check_region_one(buf: &[u8]) {
-        // Check the version
-        assert_eq!(buf[VERSION_OFFSET], VERSION);
-
-        // Check the length
-        assert_eq!(buf[LEN_OFFSET], 0x80);
-        assert_eq!(buf[LEN_OFFSET + 1], 47);
-
-        // Check the hash
-        assert_eq!(buf[HASH_OFFSET + 0], 0x81);
-        assert_eq!(buf[HASH_OFFSET + 1], 0x13);
-        assert_eq!(buf[HASH_OFFSET + 2], 0x7e);
-        assert_eq!(buf[HASH_OFFSET + 3], 0x95);
-        assert_eq!(buf[HASH_OFFSET + 4], 0x9e);
-        assert_eq!(buf[HASH_OFFSET + 5], 0x93);
-        assert_eq!(buf[HASH_OFFSET + 6], 0xaa);
-        assert_eq!(buf[HASH_OFFSET + 7], 0x3d);
-
-        // Check the value
-        assert_eq!(buf[HASH_OFFSET + 8], 0x23);
-        assert_eq!(buf[28], 0x23);
-        assert_eq!(buf[42], 0x23);
-
-        // Check the check hash
-        assert_eq!(buf[43], 0xf7);
-        assert_eq!(buf[44], 0x1d);
-        assert_eq!(buf[45], 0xb3);
-        assert_eq!(buf[46], 0xe9);
-    }
-
-    fn check_region_two(buf: &[u8]) {
-        // Check the version
-        assert_eq!(buf[VERSION_OFFSET], VERSION);
-
-        // Check the length
-        assert_eq!(buf[LEN_OFFSET], 0x80);
-        assert_eq!(buf[LEN_OFFSET + 1], 47);
-
-        // Check the hash
-        assert_eq!(buf[HASH_OFFSET + 0], 0x9d);
-        assert_eq!(buf[HASH_OFFSET + 1], 0xd3);
-        assert_eq!(buf[HASH_OFFSET + 2], 0x71);
-        assert_eq!(buf[HASH_OFFSET + 3], 0x45);
-        assert_eq!(buf[HASH_OFFSET + 4], 0x05);
-        assert_eq!(buf[HASH_OFFSET + 5], 0xc2);
-        assert_eq!(buf[HASH_OFFSET + 6], 0xf8);
-        assert_eq!(buf[HASH_OFFSET + 7], 0x66);
-
-        // Check the value
-        assert_eq!(buf[HASH_OFFSET + 8], 0x23);
-        assert_eq!(buf[28], 0x23);
-        assert_eq!(buf[42], 0x23);
-
-        // Check the check hash
-        assert_eq!(buf[43], 0x11);
-        assert_eq!(buf[44], 0x6a);
-        assert_eq!(buf[45], 0xba);
-        assert_eq!(buf[46], 0xba);
-    }
-
-    fn get_hashed_key(unhashed_key: &[u8]) -> u64 {
-        let mut hash_function = DefaultHasher::new();
-        unhashed_key.hash(&mut hash_function);
-        hash_function.finish()
-    }
-
-    // An example FlashCtrl implementation
-    struct FlashCtrl {
-        buf: RefCell<[[u8; 1024]; 64]>,
-        run: Cell<u8>,
-        async_read_region: Cell<usize>,
-        async_erase_region: Cell<usize>,
-    }
-
-    impl FlashCtrl {
-        fn new() -> Self {
-            Self {
-                buf: RefCell::new([[0xFF; 1024]; 64]),
-                run: Cell::new(0),
-                async_read_region: Cell::new(100),
-                async_erase_region: Cell::new(100),
-            }
-        }
-    }
-
-    impl FlashController<1024> for FlashCtrl {
-        fn read_region(
-            &self,
-            region_number: usize,
-            offset: usize,
-            buf: &mut [u8; 1024],
-        ) -> Result<(), ErrorCode> {
-            println!("Read from region: {}", region_number);
-
-            if self.async_read_region.get() != region_number {
-                // Pretend that we aren't ready
-                self.async_read_region.set(region_number);
-                println!("  Not ready");
-                return Err(ErrorCode::ReadNotReady(region_number));
-            }
-
-            for (i, b) in buf.iter_mut().enumerate() {
-                *b = self.buf.borrow()[region_number][offset + i]
-            }
-
-            // println!("  buf: {:#x?}", self.buf.borrow()[region_number]);
-
-            Ok(())
+            // Check the check hash
+            assert_eq!(buf[HASH_OFFSET + 8], 0x55);
+            assert_eq!(buf[HASH_OFFSET + 9], 0xb5);
+            assert_eq!(buf[HASH_OFFSET + 10], 0xd8);
+            assert_eq!(buf[HASH_OFFSET + 11], 0xe4);
         }
 
-        fn write(&self, address: usize, buf: &[u8]) -> Result<(), ErrorCode> {
-            println!(
-                "Write to address: {:#x}, region: {}",
-                address,
-                address / 1024
-            );
+        fn check_region_one(buf: &[u8]) {
+            // Check the version
+            assert_eq!(buf[VERSION_OFFSET], VERSION);
 
-            for (i, d) in buf.iter().enumerate() {
-                self.buf.borrow_mut()[address / 1024][(address % 1024) + i] = *d;
-            }
+            // Check the length
+            assert_eq!(buf[LEN_OFFSET], 0x80);
+            assert_eq!(buf[LEN_OFFSET + 1], 47);
 
-            // Check to see if we are adding a key
-            if buf.len() > 1 {
-                if self.run.get() == 0 {
-                    println!("Writing main key: {:#x?}", buf);
-                    check_region_main(buf);
-                } else if self.run.get() == 1 {
-                    println!("Writing key ONE: {:#x?}", buf);
-                    check_region_one(buf);
-                } else if self.run.get() == 2 {
-                    println!("Writing key TWO: {:#x?}", buf);
-                    check_region_two(buf);
+            // Check the hash
+            assert_eq!(buf[HASH_OFFSET + 0], 0x81);
+            assert_eq!(buf[HASH_OFFSET + 1], 0x13);
+            assert_eq!(buf[HASH_OFFSET + 2], 0x7e);
+            assert_eq!(buf[HASH_OFFSET + 3], 0x95);
+            assert_eq!(buf[HASH_OFFSET + 4], 0x9e);
+            assert_eq!(buf[HASH_OFFSET + 5], 0x93);
+            assert_eq!(buf[HASH_OFFSET + 6], 0xaa);
+            assert_eq!(buf[HASH_OFFSET + 7], 0x3d);
+
+            // Check the value
+            assert_eq!(buf[HASH_OFFSET + 8], 0x23);
+            assert_eq!(buf[28], 0x23);
+            assert_eq!(buf[42], 0x23);
+
+            // Check the check hash
+            assert_eq!(buf[43], 0xf7);
+            assert_eq!(buf[44], 0x1d);
+            assert_eq!(buf[45], 0xb3);
+            assert_eq!(buf[46], 0xe9);
+        }
+
+        fn check_region_two(buf: &[u8]) {
+            // Check the version
+            assert_eq!(buf[VERSION_OFFSET], VERSION);
+
+            // Check the length
+            assert_eq!(buf[LEN_OFFSET], 0x80);
+            assert_eq!(buf[LEN_OFFSET + 1], 47);
+
+            // Check the hash
+            assert_eq!(buf[HASH_OFFSET + 0], 0x9d);
+            assert_eq!(buf[HASH_OFFSET + 1], 0xd3);
+            assert_eq!(buf[HASH_OFFSET + 2], 0x71);
+            assert_eq!(buf[HASH_OFFSET + 3], 0x45);
+            assert_eq!(buf[HASH_OFFSET + 4], 0x05);
+            assert_eq!(buf[HASH_OFFSET + 5], 0xc2);
+            assert_eq!(buf[HASH_OFFSET + 6], 0xf8);
+            assert_eq!(buf[HASH_OFFSET + 7], 0x66);
+
+            // Check the value
+            assert_eq!(buf[HASH_OFFSET + 8], 0x23);
+            assert_eq!(buf[28], 0x23);
+            assert_eq!(buf[42], 0x23);
+
+            // Check the check hash
+            assert_eq!(buf[43], 0x11);
+            assert_eq!(buf[44], 0x6a);
+            assert_eq!(buf[45], 0xba);
+            assert_eq!(buf[46], 0xba);
+        }
+
+        fn get_hashed_key(unhashed_key: &[u8]) -> u64 {
+            let mut hash_function = DefaultHasher::new();
+            unhashed_key.hash(&mut hash_function);
+            hash_function.finish()
+        }
+
+        // An example FlashCtrl implementation
+        struct FlashCtrl {
+            buf: RefCell<[[u8; 1024]; 64]>,
+            run: Cell<u8>,
+            async_read_region: Cell<usize>,
+            async_erase_region: Cell<usize>,
+        }
+
+        impl FlashCtrl {
+            fn new() -> Self {
+                Self {
+                    buf: RefCell::new([[0xFF; 1024]; 64]),
+                    run: Cell::new(0),
+                    async_read_region: Cell::new(100),
+                    async_erase_region: Cell::new(100),
                 }
             }
-
-            self.run.set(self.run.get() + 1);
-
-            Ok(())
         }
 
-        fn erase_region(&self, region_number: usize) -> Result<(), ErrorCode> {
-            println!("Erase region: {}", region_number);
+        impl FlashController<1024> for FlashCtrl {
+            fn read_region(
+                &self,
+                region_number: usize,
+                offset: usize,
+                buf: &mut [u8; 1024],
+            ) -> Result<(), ErrorCode> {
+                println!("Read from region: {}", region_number);
 
-            if self.async_erase_region.get() != region_number {
-                // Pretend that we aren't ready
-                self.async_erase_region.set(region_number);
-                return Err(ErrorCode::EraseNotReady(region_number));
+                if self.async_read_region.get() != region_number {
+                    // Pretend that we aren't ready
+                    self.async_read_region.set(region_number);
+                    println!("  Not ready");
+                    return Err(ErrorCode::ReadNotReady(region_number));
+                }
+
+                for (i, b) in buf.iter_mut().enumerate() {
+                    *b = self.buf.borrow()[region_number][offset + i]
+                }
+
+                // println!("  buf: {:#x?}", self.buf.borrow()[region_number]);
+
+                Ok(())
             }
 
-            let mut local_buf = self.buf.borrow_mut()[region_number];
-
-            for d in local_buf.iter_mut() {
-                *d = 0xFF;
-            }
-
-            Ok(())
-        }
-    }
-
-    #[test]
-    fn test_simple_append() {
-        let mut read_buf: [u8; 1024] = [0; 1024];
-        let mut hash_function = DefaultHasher::new();
-        MAIN_KEY.hash(&mut hash_function);
-
-        let tickv = AsyncTicKV::<FlashCtrl, 1024>::new(FlashCtrl::new(), &mut read_buf, 0x1000);
-
-        let mut ret = tickv.initalise(hash_function.finish());
-        while ret.is_err() {
-            // There is no actual delay in the test, just continue now
-            let (r, _buf) = tickv.continue_operation();
-            ret = r;
-        }
-
-        static VALUE: [u8; 32] = [0x23; 32];
-
-        let ret = tickv.append_key(get_hashed_key(b"ONE"), &VALUE);
-        match ret {
-            Err(ErrorCode::ReadNotReady(reg)) => {
-                // There is no actual delay in the test, just continue now
-                tickv.set_read_buffer(&tickv.tickv.controller.buf.borrow()[reg]);
-                tickv.continue_operation().0.unwrap();
-            }
-            Ok(_) => {}
-            _ => unreachable!(),
-        }
-
-        let ret = tickv.append_key(get_hashed_key(b"TWO"), &VALUE);
-        match ret {
-            Err(ErrorCode::ReadNotReady(reg)) => {
-                // There is no actual delay in the test, just continue now
-                tickv.set_read_buffer(&tickv.tickv.controller.buf.borrow()[reg]);
-                tickv.continue_operation().0.unwrap();
-            }
-            Ok(_) => {}
-            _ => unreachable!(),
-        }
-    }
-
-    #[test]
-    fn test_double_append() {
-        let mut read_buf: [u8; 1024] = [0; 1024];
-        let mut hash_function = DefaultHasher::new();
-        MAIN_KEY.hash(&mut hash_function);
-
-        let tickv = AsyncTicKV::<FlashCtrl, 1024>::new(FlashCtrl::new(), &mut read_buf, 0x10000);
-
-        let mut ret = tickv.initalise(hash_function.finish());
-        while ret.is_err() {
-            // There is no actual delay in the test, just continue now
-            let (r, _buf) = tickv.continue_operation();
-            ret = r;
-        }
-
-        static VALUE: [u8; 32] = [0x23; 32];
-        static mut BUF: [u8; 32] = [0; 32];
-
-        println!("Add key ONE");
-        let ret = tickv.append_key(get_hashed_key(b"ONE"), &VALUE);
-        match ret {
-            Err(ErrorCode::ReadNotReady(reg)) => {
-                // There is no actual delay in the test, just continue now
-                tickv.set_read_buffer(&tickv.tickv.controller.buf.borrow()[reg]);
-                tickv.continue_operation().0.unwrap();
-            }
-            Ok(_) => {}
-            _ => unreachable!(),
-        }
-
-        println!("Get key ONE");
-        #[allow(unsafe_code)]
-        unsafe {
-            tickv.get_key(get_hashed_key(b"ONE"), &mut BUF).unwrap();
-        }
-
-        println!("Get non-existant key TWO");
-        #[allow(unsafe_code)]
-        let ret = unsafe { tickv.get_key(get_hashed_key(b"TWO"), &mut BUF) };
-        match ret {
-            Err((_, ErrorCode::ReadNotReady(reg))) => {
-                // There is no actual delay in the test, just continue now
-                tickv.set_read_buffer(&tickv.tickv.controller.buf.borrow()[reg]);
-                assert_eq!(tickv.continue_operation().0, Err(ErrorCode::KeyNotFound));
-            }
-            Err((_, ErrorCode::KeyNotFound)) => {}
-            _ => unreachable!(),
-        }
-
-        println!("Add key ONE again");
-        let ret = tickv.append_key(get_hashed_key(b"ONE"), &VALUE);
-        match ret {
-            Err(ErrorCode::ReadNotReady(reg)) => {
-                // There is no actual delay in the test, just continue now
-                tickv.set_read_buffer(&tickv.tickv.controller.buf.borrow()[reg]);
-                assert_eq!(
-                    tickv.continue_operation().0,
-                    Err(ErrorCode::KeyAlreadyExists)
+            fn write(&self, address: usize, buf: &[u8]) -> Result<(), ErrorCode> {
+                println!(
+                    "Write to address: {:#x}, region: {}",
+                    address,
+                    address / 1024
                 );
-            }
-            Err(ErrorCode::KeyAlreadyExists) => {}
-            _ => unreachable!(),
-        }
 
-        println!("Add key TWO");
-        let ret = tickv.append_key(get_hashed_key(b"TWO"), &VALUE);
-        match ret {
-            Err(ErrorCode::ReadNotReady(reg)) => {
-                // There is no actual delay in the test, just continue now
-                tickv.set_read_buffer(&tickv.tickv.controller.buf.borrow()[reg]);
-                tickv.continue_operation().0.unwrap();
-            }
-            Ok(_) => {}
-            _ => unreachable!(),
-        }
-
-        println!("Get key ONE");
-        #[allow(unsafe_code)]
-        let ret = unsafe { tickv.get_key(get_hashed_key(b"ONE"), &mut BUF) };
-        match ret {
-            Err((_, ErrorCode::ReadNotReady(reg))) => {
-                // There is no actual delay in the test, just continue now
-                tickv.set_read_buffer(&tickv.tickv.controller.buf.borrow()[reg]);
-                tickv.continue_operation().0.unwrap();
-            }
-            Ok(_) => {}
-            _ => unreachable!(),
-        }
-
-        println!("Get key TWO");
-        #[allow(unsafe_code)]
-        let ret = unsafe { tickv.get_key(get_hashed_key(b"TWO"), &mut BUF) };
-        match ret {
-            Err((_, ErrorCode::ReadNotReady(reg))) => {
-                // There is no actual delay in the test, just continue now
-                tickv.set_read_buffer(&tickv.tickv.controller.buf.borrow()[reg]);
-                tickv.continue_operation().0.unwrap();
-            }
-            Ok(_) => {}
-            _ => unreachable!(),
-        }
-
-        println!("Get non-existant key THREE");
-        #[allow(unsafe_code)]
-        let ret = unsafe { tickv.get_key(get_hashed_key(b"THREE"), &mut BUF) };
-        match ret {
-            Err((_, ErrorCode::ReadNotReady(reg))) => {
-                // There is no actual delay in the test, just continue now
-                tickv.set_read_buffer(&tickv.tickv.controller.buf.borrow()[reg]);
-                assert_eq!(tickv.continue_operation().0, Err(ErrorCode::KeyNotFound));
-            }
-            _ => unreachable!(),
-        }
-
-        #[allow(unsafe_code)]
-        unsafe {
-            match tickv.get_key(get_hashed_key(b"THREE"), &mut BUF) {
-                Err((_, ErrorCode::KeyNotFound)) => {}
-                _ => {
-                    panic!("Expected ErrorCode::KeyNotFound");
+                for (i, d) in buf.iter().enumerate() {
+                    self.buf.borrow_mut()[address / 1024][(address % 1024) + i] = *d;
                 }
-            }
-        }
-    }
 
-    #[test]
-    fn test_append_and_delete() {
-        let mut read_buf: [u8; 1024] = [0; 1024];
-        let mut hash_function = DefaultHasher::new();
-        MAIN_KEY.hash(&mut hash_function);
-
-        let tickv = AsyncTicKV::<FlashCtrl, 1024>::new(FlashCtrl::new(), &mut read_buf, 0x10000);
-
-        let mut ret = tickv.initalise(hash_function.finish());
-        while ret.is_err() {
-            // There is no actual delay in the test, just continue now
-            let (r, _buf) = tickv.continue_operation();
-            ret = r;
-        }
-
-        static VALUE: [u8; 32] = [0x23; 32];
-        static mut BUF: [u8; 32] = [0; 32];
-
-        println!("Add key ONE");
-        let ret = tickv.append_key(get_hashed_key(b"ONE"), &VALUE);
-        match ret {
-            Err(ErrorCode::ReadNotReady(reg)) => {
-                // There is no actual delay in the test, just continue now
-                tickv.set_read_buffer(&tickv.tickv.controller.buf.borrow()[reg]);
-                tickv.continue_operation().0.unwrap();
-            }
-            Ok(_) => {}
-            _ => unreachable!(),
-        }
-
-        println!("Get key ONE");
-        #[allow(unsafe_code)]
-        unsafe {
-            tickv.get_key(get_hashed_key(b"ONE"), &mut BUF).unwrap();
-        }
-
-        println!("Delete Key ONE");
-        tickv.invalidate_key(get_hashed_key(b"ONE")).unwrap();
-
-        println!("Get non-existant key ONE");
-        #[allow(unsafe_code)]
-        unsafe {
-            match tickv.get_key(get_hashed_key(b"ONE"), &mut BUF) {
-                Err((_, ErrorCode::KeyNotFound)) => {}
-                _ => {
-                    panic!("Expected ErrorCode::KeyNotFound");
+                // Check to see if we are adding a key
+                if buf.len() > 1 {
+                    if self.run.get() == 0 {
+                        println!("Writing main key: {:#x?}", buf);
+                        check_region_main(buf);
+                    } else if self.run.get() == 1 {
+                        println!("Writing key ONE: {:#x?}", buf);
+                        check_region_one(buf);
+                    } else if self.run.get() == 2 {
+                        println!("Writing key TWO: {:#x?}", buf);
+                        check_region_two(buf);
+                    }
                 }
+
+                self.run.set(self.run.get() + 1);
+
+                Ok(())
+            }
+
+            fn erase_region(&self, region_number: usize) -> Result<(), ErrorCode> {
+                println!("Erase region: {}", region_number);
+
+                if self.async_erase_region.get() != region_number {
+                    // Pretend that we aren't ready
+                    self.async_erase_region.set(region_number);
+                    return Err(ErrorCode::EraseNotReady(region_number));
+                }
+
+                let mut local_buf = self.buf.borrow_mut()[region_number];
+
+                for d in local_buf.iter_mut() {
+                    *d = 0xFF;
+                }
+
+                Ok(())
             }
         }
 
-        println!("Try to delete Key ONE Again");
-        assert_eq!(
-            tickv.invalidate_key(get_hashed_key(b"ONE")),
-            Err(ErrorCode::KeyNotFound)
-        );
-    }
+        #[test]
+        fn test_simple_append() {
+            let mut read_buf: [u8; 1024] = [0; 1024];
+            let mut hash_function = DefaultHasher::new();
+            MAIN_KEY.hash(&mut hash_function);
 
-    #[test]
-    fn test_garbage_collect() {
-        let mut read_buf: [u8; 1024] = [0; 1024];
-        let mut hash_function = DefaultHasher::new();
-        MAIN_KEY.hash(&mut hash_function);
+            let tickv = AsyncTicKV::<FlashCtrl, 1024>::new(FlashCtrl::new(), &mut read_buf, 0x1000);
 
-        let tickv = AsyncTicKV::<FlashCtrl, 1024>::new(FlashCtrl::new(), &mut read_buf, 0x10000);
-
-        let mut ret = tickv.initalise(hash_function.finish());
-        while ret.is_err() {
-            // There is no actual delay in the test, just continue now
-            let (r, _buf) = tickv.continue_operation();
-            ret = r;
-        }
-
-        static VALUE: [u8; 32] = [0x23; 32];
-        static mut BUF: [u8; 32] = [0; 32];
-
-        println!("Garbage collect empty flash");
-        let mut ret = tickv.garbage_collect();
-        while ret.is_err() {
-            // There is no actual delay in the test, just continue now
-            ret = match tickv.continue_operation().0 {
-                Ok(_) => Ok(0),
-                Err(e) => Err(e),
-            };
-        }
-
-        println!("Add key ONE");
-        let ret = tickv.append_key(get_hashed_key(b"ONE"), &VALUE);
-        match ret {
-            Err(ErrorCode::ReadNotReady(reg)) => {
+            let mut ret = tickv.initalise(hash_function.finish());
+            while ret.is_err() {
                 // There is no actual delay in the test, just continue now
-                tickv.set_read_buffer(&tickv.tickv.controller.buf.borrow()[reg]);
-                tickv.continue_operation().0.unwrap();
+                let (r, _buf) = tickv.continue_operation();
+                ret = r;
             }
-            Ok(_) => {}
-            _ => unreachable!(),
-        }
 
-        println!("Garbage collect flash with valid key");
-        let mut ret = tickv.garbage_collect();
-        while ret.is_err() {
+            static mut VALUE: [u8; 32] = [0x23; 32];
+
+            let ret = unsafe { tickv.append_key(get_hashed_key(b"ONE"), &mut VALUE) };
             match ret {
-                Err(ErrorCode::ReadNotReady(reg)) => {
+                Err((_buf, ErrorCode::ReadNotReady(reg))) => {
                     // There is no actual delay in the test, just continue now
                     tickv.set_read_buffer(&tickv.tickv.controller.buf.borrow()[reg]);
-                    ret = match tickv.continue_operation().0 {
-                        Ok(_) => Ok(0),
-                        Err(e) => Err(e),
-                    };
+                    tickv.continue_operation().0.unwrap();
                 }
-                Ok(num) => {
-                    assert_eq!(num, 0);
+                Ok(_) => {}
+                _ => unreachable!(),
+            }
+
+            let ret = unsafe { tickv.append_key(get_hashed_key(b"TWO"), &mut VALUE) };
+            match ret {
+                Err((_buf, ErrorCode::ReadNotReady(reg))) => {
+                    // There is no actual delay in the test, just continue now
+                    tickv.set_read_buffer(&tickv.tickv.controller.buf.borrow()[reg]);
+                    tickv.continue_operation().0.unwrap();
                 }
+                Ok(_) => {}
                 _ => unreachable!(),
             }
         }
 
-        println!("Delete Key ONE");
-        let ret = tickv.invalidate_key(get_hashed_key(b"ONE"));
-        match ret {
-            Err(ErrorCode::ReadNotReady(reg)) => {
+        #[test]
+        fn test_double_append() {
+            let mut read_buf: [u8; 1024] = [0; 1024];
+            let mut hash_function = DefaultHasher::new();
+            MAIN_KEY.hash(&mut hash_function);
+
+            let tickv =
+                AsyncTicKV::<FlashCtrl, 1024>::new(FlashCtrl::new(), &mut read_buf, 0x10000);
+
+            let mut ret = tickv.initalise(hash_function.finish());
+            while ret.is_err() {
                 // There is no actual delay in the test, just continue now
-                tickv.set_read_buffer(&tickv.tickv.controller.buf.borrow()[reg]);
-                tickv.continue_operation().0.unwrap();
+                let (r, _buf) = tickv.continue_operation();
+                ret = r;
             }
-            Ok(_) => {}
-            _ => unreachable!("ret: {:?}", ret),
+
+            static mut VALUE: [u8; 32] = [0x23; 32];
+            static mut BUF: [u8; 32] = [0; 32];
+
+            println!("Add key ONE");
+            let ret = unsafe { tickv.append_key(get_hashed_key(b"ONE"), &mut VALUE) };
+            match ret {
+                Err((_buf, ErrorCode::ReadNotReady(reg))) => {
+                    // There is no actual delay in the test, just continue now
+                    tickv.set_read_buffer(&tickv.tickv.controller.buf.borrow()[reg]);
+                    tickv.continue_operation().0.unwrap();
+                }
+                Ok(_) => {}
+                _ => unreachable!(),
+            }
+
+            println!("Get key ONE");
+            unsafe {
+                tickv.get_key(get_hashed_key(b"ONE"), &mut BUF).unwrap();
+            }
+
+            println!("Get non-existant key TWO");
+            let ret = unsafe { tickv.get_key(get_hashed_key(b"TWO"), &mut BUF) };
+            match ret {
+                Err((_, ErrorCode::ReadNotReady(reg))) => {
+                    // There is no actual delay in the test, just continue now
+                    tickv.set_read_buffer(&tickv.tickv.controller.buf.borrow()[reg]);
+                    assert_eq!(tickv.continue_operation().0, Err(ErrorCode::KeyNotFound));
+                }
+                Err((_, ErrorCode::KeyNotFound)) => {}
+                _ => unreachable!(),
+            }
+
+            println!("Add key ONE again");
+            let ret = unsafe { tickv.append_key(get_hashed_key(b"ONE"), &mut VALUE) };
+            match ret {
+                Err((_buf, ErrorCode::ReadNotReady(reg))) => {
+                    // There is no actual delay in the test, just continue now
+                    tickv.set_read_buffer(&tickv.tickv.controller.buf.borrow()[reg]);
+                    assert_eq!(
+                        tickv.continue_operation().0,
+                        Err(ErrorCode::KeyAlreadyExists)
+                    );
+                }
+                Err((_buf, ErrorCode::KeyAlreadyExists)) => {}
+                _ => unreachable!(),
+            }
+
+            println!("Add key TWO");
+            let ret = unsafe { tickv.append_key(get_hashed_key(b"TWO"), &mut VALUE) };
+            match ret {
+                Err((_buf, ErrorCode::ReadNotReady(reg))) => {
+                    // There is no actual delay in the test, just continue now
+                    tickv.set_read_buffer(&tickv.tickv.controller.buf.borrow()[reg]);
+                    tickv.continue_operation().0.unwrap();
+                }
+                Ok(_) => {}
+                _ => unreachable!(),
+            }
+
+            println!("Get key ONE");
+            let ret = unsafe { tickv.get_key(get_hashed_key(b"ONE"), &mut BUF) };
+            match ret {
+                Err((_, ErrorCode::ReadNotReady(reg))) => {
+                    // There is no actual delay in the test, just continue now
+                    tickv.set_read_buffer(&tickv.tickv.controller.buf.borrow()[reg]);
+                    tickv.continue_operation().0.unwrap();
+                }
+                Ok(_) => {}
+                _ => unreachable!(),
+            }
+
+            println!("Get key TWO");
+            let ret = unsafe { tickv.get_key(get_hashed_key(b"TWO"), &mut BUF) };
+            match ret {
+                Err((_, ErrorCode::ReadNotReady(reg))) => {
+                    // There is no actual delay in the test, just continue now
+                    tickv.set_read_buffer(&tickv.tickv.controller.buf.borrow()[reg]);
+                    tickv.continue_operation().0.unwrap();
+                }
+                Ok(_) => {}
+                _ => unreachable!(),
+            }
+
+            println!("Get non-existant key THREE");
+            let ret = unsafe { tickv.get_key(get_hashed_key(b"THREE"), &mut BUF) };
+            match ret {
+                Err((_, ErrorCode::ReadNotReady(reg))) => {
+                    // There is no actual delay in the test, just continue now
+                    tickv.set_read_buffer(&tickv.tickv.controller.buf.borrow()[reg]);
+                    assert_eq!(tickv.continue_operation().0, Err(ErrorCode::KeyNotFound));
+                }
+                _ => unreachable!(),
+            }
+
+            unsafe {
+                match tickv.get_key(get_hashed_key(b"THREE"), &mut BUF) {
+                    Err((_, ErrorCode::KeyNotFound)) => {}
+                    _ => {
+                        panic!("Expected ErrorCode::KeyNotFound");
+                    }
+                }
+            }
         }
 
-        println!("Garbage collect flash with deleted key");
-        let mut ret = tickv.garbage_collect();
-        while ret.is_err() {
+        #[test]
+        fn test_append_and_delete() {
+            let mut read_buf: [u8; 1024] = [0; 1024];
+            let mut hash_function = DefaultHasher::new();
+            MAIN_KEY.hash(&mut hash_function);
+
+            let tickv =
+                AsyncTicKV::<FlashCtrl, 1024>::new(FlashCtrl::new(), &mut read_buf, 0x10000);
+
+            let mut ret = tickv.initalise(hash_function.finish());
+            while ret.is_err() {
+                // There is no actual delay in the test, just continue now
+                let (r, _buf) = tickv.continue_operation();
+                ret = r;
+            }
+
+            static mut VALUE: [u8; 32] = [0x23; 32];
+            static mut BUF: [u8; 32] = [0; 32];
+
+            println!("Add key ONE");
+            let ret = unsafe { tickv.append_key(get_hashed_key(b"ONE"), &mut VALUE) };
+            match ret {
+                Err((_buf, ErrorCode::ReadNotReady(reg))) => {
+                    // There is no actual delay in the test, just continue now
+                    tickv.set_read_buffer(&tickv.tickv.controller.buf.borrow()[reg]);
+                    tickv.continue_operation().0.unwrap();
+                }
+                Ok(_) => {}
+                _ => unreachable!(),
+            }
+
+            println!("Get key ONE");
+            unsafe {
+                tickv.get_key(get_hashed_key(b"ONE"), &mut BUF).unwrap();
+            }
+
+            println!("Delete Key ONE");
+            tickv.invalidate_key(get_hashed_key(b"ONE")).unwrap();
+
+            println!("Get non-existant key ONE");
+            unsafe {
+                match tickv.get_key(get_hashed_key(b"ONE"), &mut BUF) {
+                    Err((_, ErrorCode::KeyNotFound)) => {}
+                    _ => {
+                        panic!("Expected ErrorCode::KeyNotFound");
+                    }
+                }
+            }
+
+            println!("Try to delete Key ONE Again");
+            assert_eq!(
+                tickv.invalidate_key(get_hashed_key(b"ONE")),
+                Err(ErrorCode::KeyNotFound)
+            );
+        }
+
+        #[test]
+        fn test_garbage_collect() {
+            let mut read_buf: [u8; 1024] = [0; 1024];
+            let mut hash_function = DefaultHasher::new();
+            MAIN_KEY.hash(&mut hash_function);
+
+            let tickv =
+                AsyncTicKV::<FlashCtrl, 1024>::new(FlashCtrl::new(), &mut read_buf, 0x10000);
+
+            let mut ret = tickv.initalise(hash_function.finish());
+            while ret.is_err() {
+                // There is no actual delay in the test, just continue now
+                let (r, _buf) = tickv.continue_operation();
+                ret = r;
+            }
+
+            static mut VALUE: [u8; 32] = [0x23; 32];
+            static mut BUF: [u8; 32] = [0; 32];
+
+            println!("Garbage collect empty flash");
+            let mut ret = tickv.garbage_collect();
+            while ret.is_err() {
+                // There is no actual delay in the test, just continue now
+                ret = match tickv.continue_operation().0 {
+                    Ok(_) => Ok(0),
+                    Err(e) => Err(e),
+                };
+            }
+
+            println!("Add key ONE");
+            let ret = unsafe { tickv.append_key(get_hashed_key(b"ONE"), &mut VALUE) };
+            match ret {
+                Err((_buf, ErrorCode::ReadNotReady(reg))) => {
+                    // There is no actual delay in the test, just continue now
+                    tickv.set_read_buffer(&tickv.tickv.controller.buf.borrow()[reg]);
+                    tickv.continue_operation().0.unwrap();
+                }
+                Ok(_) => {}
+                _ => unreachable!(),
+            }
+
+            println!("Garbage collect flash with valid key");
+            let mut ret = tickv.garbage_collect();
+            while ret.is_err() {
+                match ret {
+                    Err(ErrorCode::ReadNotReady(reg)) => {
+                        // There is no actual delay in the test, just continue now
+                        tickv.set_read_buffer(&tickv.tickv.controller.buf.borrow()[reg]);
+                        ret = match tickv.continue_operation().0 {
+                            Ok(_) => Ok(0),
+                            Err(e) => Err(e),
+                        };
+                    }
+                    Ok(num) => {
+                        assert_eq!(num, 0);
+                    }
+                    _ => unreachable!(),
+                }
+            }
+
+            println!("Delete Key ONE");
+            let ret = tickv.invalidate_key(get_hashed_key(b"ONE"));
             match ret {
                 Err(ErrorCode::ReadNotReady(reg)) => {
                     // There is no actual delay in the test, just continue now
                     tickv.set_read_buffer(&tickv.tickv.controller.buf.borrow()[reg]);
-                    ret = match tickv.continue_operation().0 {
-                        Ok(_) => Ok(0),
-                        Err(e) => Err(e),
-                    };
+                    tickv.continue_operation().0.unwrap();
                 }
-                Err(ErrorCode::EraseNotReady(_reg)) => {
-                    // There is no actual delay in the test, just continue now
-                    ret = match tickv.continue_operation().0 {
-                        Ok(_) => Ok(0),
-                        Err(e) => Err(e),
-                    };
-                }
-                Ok(num) => {
-                    assert_eq!(num, 1024);
-                }
+                Ok(_) => {}
                 _ => unreachable!("ret: {:?}", ret),
             }
-        }
 
-        println!("Get non-existant key ONE");
-        #[allow(unsafe_code)]
-        let ret = unsafe { tickv.get_key(get_hashed_key(b"ONE"), &mut BUF) };
-        match ret {
-            Err((_, ErrorCode::ReadNotReady(reg))) => {
-                // There is no actual delay in the test, just continue now
-                tickv.set_read_buffer(&tickv.tickv.controller.buf.borrow()[reg]);
-                assert_eq!(tickv.continue_operation().0, Err(ErrorCode::KeyNotFound));
+            println!("Garbage collect flash with deleted key");
+            let mut ret = tickv.garbage_collect();
+            while ret.is_err() {
+                match ret {
+                    Err(ErrorCode::ReadNotReady(reg)) => {
+                        // There is no actual delay in the test, just continue now
+                        tickv.set_read_buffer(&tickv.tickv.controller.buf.borrow()[reg]);
+                        ret = match tickv.continue_operation().0 {
+                            Ok(_) => Ok(0),
+                            Err(e) => Err(e),
+                        };
+                    }
+                    Err(ErrorCode::EraseNotReady(_reg)) => {
+                        // There is no actual delay in the test, just continue now
+                        ret = match tickv.continue_operation().0 {
+                            Ok(_) => Ok(0),
+                            Err(e) => Err(e),
+                        };
+                    }
+                    Ok(num) => {
+                        assert_eq!(num, 1024);
+                    }
+                    _ => unreachable!("ret: {:?}", ret),
+                }
             }
-            Err((_, ErrorCode::KeyNotFound)) => {}
-            _ => unreachable!("ret: {:?}", ret),
-        }
 
-        println!("Add Key ONE");
-        tickv.append_key(get_hashed_key(b"ONE"), &VALUE).unwrap();
+            println!("Get non-existant key ONE");
+            let ret = unsafe { tickv.get_key(get_hashed_key(b"ONE"), &mut BUF) };
+            match ret {
+                Err((_, ErrorCode::ReadNotReady(reg))) => {
+                    // There is no actual delay in the test, just continue now
+                    tickv.set_read_buffer(&tickv.tickv.controller.buf.borrow()[reg]);
+                    assert_eq!(tickv.continue_operation().0, Err(ErrorCode::KeyNotFound));
+                }
+                Err((_, ErrorCode::KeyNotFound)) => {}
+                _ => unreachable!("ret: {:?}", ret),
+            }
+
+            println!("Add Key ONE");
+            unsafe {
+                tickv
+                    .append_key(get_hashed_key(b"ONE"), &mut VALUE)
+                    .unwrap();
+            }
+        }
     }
 }

--- a/libraries/tickv/src/tickv.rs
+++ b/libraries/tickv/src/tickv.rs
@@ -577,6 +577,12 @@ impl<'a, C: FlashController<S>, const S: usize> TicKV<'a, C, S> {
 
                     // Make sure if will fit in the buffer
                     if buf.len() < (total_length as usize - HEADER_LENGTH - CHECK_SUM_LEN) {
+                        // The entire value is not going to fit,
+                        // Let's still copy in what we can and return an error
+                        for i in 0..buf.len() {
+                            buf[i] = region_data[offset + HEADER_LENGTH + i];
+                        }
+
                         self.read_buffer.replace(Some(region_data));
                         return Err(ErrorCode::BufferTooSmall(
                             total_length as usize - HEADER_LENGTH - CHECK_SUM_LEN,

--- a/libraries/tock-tbf/src/types.rs
+++ b/libraries/tock-tbf/src/types.rs
@@ -4,6 +4,8 @@ use core::convert::TryInto;
 use core::fmt;
 use core::mem::size_of;
 
+const NUM_PERSISTENT_ACLS: usize = 8;
+
 /// Error when parsing just the beginning of the TBF header. This is only used
 /// when establishing the linked list structure of apps installed in flash.
 pub enum InitialTbfParseError {
@@ -533,7 +535,7 @@ pub struct TbfHeaderV2 {
     pub(crate) writeable_regions: Option<[Option<TbfHeaderV2WriteableFlashRegion>; 4]>,
     pub(crate) fixed_addresses: Option<TbfHeaderV2FixedAddresses>,
     pub(crate) permissions: Option<TbfHeaderV2Permissions<8>>,
-    pub(crate) persistent_acls: Option<TbfHeaderV2PersistentAcl<8>>,
+    pub(crate) persistent_acls: Option<TbfHeaderV2PersistentAcl<NUM_PERSISTENT_ACLS>>,
     pub(crate) kernel_version: Option<TbfHeaderV2KernelVersion>,
 }
 
@@ -699,6 +701,66 @@ impl TbfHeader {
                 _ => CommandPermissions::NoPermsAtAll,
             },
             _ => CommandPermissions::NoPermsAtAll,
+        }
+    }
+
+    /// Get the process `write_id`.
+    /// Returns `None` if a `write_id` is not included.
+    pub fn get_write_id(&self) -> Option<u32> {
+        match self {
+            TbfHeader::TbfHeaderV2(hd) => match hd.persistent_acls {
+                Some(persistent_acls) => Some(persistent_acls.write_id),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+
+    /// Get the number of `read_ids`.
+    /// Returns `None` if a `read_ids` is not included.
+    pub fn num_read_ids(&self) -> Option<usize> {
+        match self {
+            TbfHeader::TbfHeaderV2(hd) => match hd.persistent_acls {
+                Some(persistent_acls) => Some(persistent_acls.read_length.into()),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+
+    /// Get the `read_ids`.
+    /// Returns `None` if a `read_ids` is not included.
+    pub fn get_read_ids(&self) -> Option<[u32; NUM_PERSISTENT_ACLS]> {
+        match self {
+            TbfHeader::TbfHeaderV2(hd) => match hd.persistent_acls {
+                Some(persistent_acls) => Some(persistent_acls.read_ids),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+
+    /// Get the number of `access_ids`.
+    /// Returns `None` if a `access_ids` is not included.
+    pub fn num_access_ids(&self) -> Option<usize> {
+        match self {
+            TbfHeader::TbfHeaderV2(hd) => match hd.persistent_acls {
+                Some(persistent_acls) => Some(persistent_acls.access_length.into()),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+
+    /// Get the `access_ids`.
+    /// Returns `None` if a `access_ids` is not included.
+    pub fn get_access_ids(&self) -> Option<[u32; NUM_PERSISTENT_ACLS]> {
+        match self {
+            TbfHeader::TbfHeaderV2(hd) => match hd.persistent_acls {
+                Some(persistent_acls) => Some(persistent_acls.access_ids),
+                _ => None,
+            },
+            _ => None,
         }
     }
 

--- a/libraries/tock-tbf/src/types.rs
+++ b/libraries/tock-tbf/src/types.rs
@@ -706,7 +706,7 @@ impl TbfHeader {
 
     /// Get the process `write_id`.
     /// Returns `None` if a `write_id` is not included.
-    pub fn get_write_id(&self) -> Option<u32> {
+    pub fn get_persistent_acl_write_id(&self) -> Option<u32> {
         match self {
             TbfHeader::TbfHeaderV2(hd) => match hd.persistent_acls {
                 Some(persistent_acls) => Some(persistent_acls.write_id),
@@ -716,48 +716,29 @@ impl TbfHeader {
         }
     }
 
-    /// Get the number of `read_ids`.
+    /// Get the number of valid `read_ids` and the `read_ids`.
     /// Returns `None` if a `read_ids` is not included.
-    pub fn num_read_ids(&self) -> Option<usize> {
+    pub fn get_persistent_acl_read_ids(&self) -> Option<(usize, [u32; NUM_PERSISTENT_ACLS])> {
         match self {
             TbfHeader::TbfHeaderV2(hd) => match hd.persistent_acls {
-                Some(persistent_acls) => Some(persistent_acls.read_length.into()),
+                Some(persistent_acls) => {
+                    Some((persistent_acls.read_length.into(), persistent_acls.read_ids))
+                }
                 _ => None,
             },
             _ => None,
         }
     }
 
-    /// Get the `read_ids`.
-    /// Returns `None` if a `read_ids` is not included.
-    pub fn get_read_ids(&self) -> Option<[u32; NUM_PERSISTENT_ACLS]> {
-        match self {
-            TbfHeader::TbfHeaderV2(hd) => match hd.persistent_acls {
-                Some(persistent_acls) => Some(persistent_acls.read_ids),
-                _ => None,
-            },
-            _ => None,
-        }
-    }
-
-    /// Get the number of `access_ids`.
+    /// Get the number of valid `access_ids` and the `access_ids`.
     /// Returns `None` if a `access_ids` is not included.
-    pub fn num_access_ids(&self) -> Option<usize> {
+    pub fn get_persistent_acl_access_ids(&self) -> Option<(usize, [u32; NUM_PERSISTENT_ACLS])> {
         match self {
             TbfHeader::TbfHeaderV2(hd) => match hd.persistent_acls {
-                Some(persistent_acls) => Some(persistent_acls.access_length.into()),
-                _ => None,
-            },
-            _ => None,
-        }
-    }
-
-    /// Get the `access_ids`.
-    /// Returns `None` if a `access_ids` is not included.
-    pub fn get_access_ids(&self) -> Option<[u32; NUM_PERSISTENT_ACLS]> {
-        match self {
-            TbfHeader::TbfHeaderV2(hd) => match hd.persistent_acls {
-                Some(persistent_acls) => Some(persistent_acls.access_ids),
+                Some(persistent_acls) => Some((
+                    persistent_acls.access_length.into(),
+                    persistent_acls.access_ids,
+                )),
                 _ => None,
             },
             _ => None,


### PR DESCRIPTION
### Pull Request Overview

This exposes Tock's Key/value system to userspace.

### Testing Strategy

Running the libtock-c example app on OpenTitan.

### TODO or Help Wanted

- [x] Enforce permissions

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
