### PR TITLE
boards/opentitan: Added make options for GDB -> QEMU debugging

### DIFF
--- a/boards/opentitan/README.md
+++ b/boards/opentitan/README.md
@@ -185,6 +185,51 @@ $ cd [TOCK_ROOT]/boards/opentitan
 $ make APP=[LIBTOCK-RS-DIR]/rv32imac.tbf qemu-app
 ```
 
+QEMU GDB Debugging [**earlgrey-cw310**]
+------------------
+
+GDB can be used for debugging with QEMU. This can be useful when debugging a particular application/kernel. 
+
+Start by installing the respective version of gdb.
+
+**Arch**:
+```shell
+$ sudo pacman -S riscv32-elf-gdb    
+```
+**Ubuntu**:
+```shell
+$ sudo apt-get install gdb-multiarch
+```
+
+In the board directory, QEMU can be started in a suspended state with gdb ready to be connected. 
+```shell
+$ make OPENTITAN_BOOT_ROM=<path_to_opentitan/sw/device/boot_rom/boot_rom_fpga_nexysvideo.elf> qemu-gdb
+```
+or with an app ready to be loaded.
+```shell
+$ make OPENTITAN_BOOT_ROM=<path_to_opentitan/sw/device/boot_rom/boot_rom_fpga_nexysvideo.elf> APP=/path/to/app.tbf qemu-app-gdb
+```
+In a seperate shell, start gdb
+
+**Arch**
+```shell
+$ riscv32-elf-gdb [/path/to/tock.elf]
+> target remote:9000            #9000 is the specified default port
+```
+
+**Ubuntu**
+```shell
+$ gdb-multiarch [/path/to/tock.elf]
+> set arch riscv
+> target remote:9000            #9000 is the specified default port
+```
+
+Once attached, standard gdb functionality is avaliable. Additional debug symbols can be added with.
+```
+add-symbol-file <tock.elf>
+add-symbol-file <app.elf>
+```
+
 Unit tests
 ----------
 The Tock OpenTitan boards include automated unit tests to test the kernel.

--- a/boards/opentitan/README.md
+++ b/boards/opentitan/README.md
@@ -214,14 +214,14 @@ In a seperate shell, start gdb
 **Arch**
 ```shell
 $ riscv32-elf-gdb [/path/to/tock.elf]
-> target remote:9000            #9000 is the specified default port
+> target remote:1234            #1234 is the specified default port
 ```
 
 **Ubuntu**
 ```shell
 $ gdb-multiarch [/path/to/tock.elf]
 > set arch riscv
-> target remote:9000            #9000 is the specified default port
+> target remote:1234            #1234 is the specified default port
 ```
 
 Once attached, standard gdb functionality is avaliable. Additional debug symbols can be added with.

--- a/boards/opentitan/earlgrey-cw310/Makefile
+++ b/boards/opentitan/earlgrey-cw310/Makefile
@@ -26,9 +26,18 @@ qemu: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
 	$(call check_defined, OPENTITAN_BOOT_ROM)
 	$(QEMU) -M opentitan -kernel $^ -bios $(OPENTITAN_BOOT_ROM) -nographic -serial mon:stdio
 
+
+qemu-gdb: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
+	$(call check_defined, OPENTITAN_BOOT_ROM)
+	$(QEMU) -gdb tcp:localhost:9000 -S -M opentitan -kernel $^ -bios $(OPENTITAN_BOOT_ROM) -nographic -serial mon:stdio
+
 qemu-app: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
 	$(call check_defined, OPENTITAN_BOOT_ROM)
 	$(QEMU) -M opentitan -kernel $^ -bios $(OPENTITAN_BOOT_ROM) -device loader,file=$(APP),addr=0x20030000 -nographic -serial mon:stdio
+
+qemu-app-gdb : $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
+	$(call check_defined, OPENTITAN_BOOT_ROM)
+	$(QEMU) -gdb tcp:localhost:9000 -S -M opentitan -kernel $^ -bios $(OPENTITAN_BOOT_ROM) -device loader,file=$(APP),addr=0x20030000 -nographic -serial mon:stdio
 
 flash: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin
 	$(OPENTITAN_TREE)/util/fpga/cw310_loader.py --firmware $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin

--- a/boards/opentitan/earlgrey-cw310/Makefile
+++ b/boards/opentitan/earlgrey-cw310/Makefile
@@ -29,7 +29,7 @@ qemu: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
 
 qemu-gdb: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
 	$(call check_defined, OPENTITAN_BOOT_ROM)
-	$(QEMU) -gdb tcp:localhost:9000 -S -M opentitan -kernel $^ -bios $(OPENTITAN_BOOT_ROM) -nographic -serial mon:stdio
+	$(QEMU) -s -S -M opentitan -kernel $^ -bios $(OPENTITAN_BOOT_ROM) -nographic -serial mon:stdio
 
 qemu-app: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
 	$(call check_defined, OPENTITAN_BOOT_ROM)
@@ -37,7 +37,7 @@ qemu-app: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
 
 qemu-app-gdb : $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
 	$(call check_defined, OPENTITAN_BOOT_ROM)
-	$(QEMU) -gdb tcp:localhost:9000 -S -M opentitan -kernel $^ -bios $(OPENTITAN_BOOT_ROM) -device loader,file=$(APP),addr=0x20030000 -nographic -serial mon:stdio
+	$(QEMU) -s -S -M opentitan -kernel $^ -bios $(OPENTITAN_BOOT_ROM) -device loader,file=$(APP),addr=0x20030000 -nographic -serial mon:stdio
 
 flash: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin
 	$(OPENTITAN_TREE)/util/fpga/cw310_loader.py --firmware $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin


### PR DESCRIPTION
### Pull Request Overview
Simplifies connecting GDB to QEMU, implemented for the earlgrey-cw310 board. Added make options to start QEMU in a suspended state, where GDB can be connected. 

Updated README to add usage instructions. 

### Testing Strategy
Tested on Arch with `riscv32-elf-gdb`, `gdb-multiarch` should work the same-way as per instructions, however, I have not tested on a Debian/Ubuntu based system.

### TODO or Help Wanted
Testing 'gdb-multiarch' on Debian/Ubuntu  (Pretty sure this should work)

Simplify the makefile options, maybe add flags?

### Documentation Updated
- [x] Updated the relevant files: `README`

### Formatting
N/A
