### PR TITLE
Have Grant::each() take FnMut instead of Fn

### DIFF
--- a/kernel/src/grant.rs
+++ b/kernel/src/grant.rs
@@ -1612,9 +1612,9 @@ impl<T: Default, Upcalls: UpcallSize, AllowROs: AllowRoSize, AllowRWs: AllowRwSi
     ///
     /// Calling this function when an `ProcessGrant` for a process is currently
     /// entered will result in a panic.
-    pub fn each<F>(&self, fun: F)
+    pub fn each<F>(&self, mut fun: F)
     where
-        F: Fn(ProcessId, &mut GrantData<T>, &GrantKernelData),
+        F: FnMut(ProcessId, &mut GrantData<T>, &GrantKernelData),
     {
         // Create a the iterator across `ProcessGrant`s for each process.
         for pg in self.iter() {


### PR DESCRIPTION


### Pull Request Overview

This restriction is a holdover from when all of the Grant functions took Fn closures, but there is no longer any reason to limit the functionality of the closures passed to this method.

### Testing Strategy

This pull request was tested by compiling the following closure:
```rust
        let mut next = Ticks64::max_value();
        self.apps.each(|_, app, kernel_data| {
            if let Some(deadline) = app.expiration {
                // We don't have to worry about rollover comparisons with 64-bit ms timer
                if deadline <= now {
                    // Schedule callback and remove this expiration
                    let _ = kernel_data.schedule_upcall(Sub::Fired as usize, (0, 0, 0));
                    app.expiration = None;
                } else {
                    next = next.min(deadline);
                }
            }
        });
```
which only compiles if each() accepts FnMut closures.

### TODO or Help Wanted

N/A


### Documentation Updated

- [x] No updates are required.

### Formatting

- [x] Ran `make prepush`.
