### PR TITLE
Add link to a Tock book

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ to learn about the hardware platforms Tock supports. Also check out the
 [Tock Book](https://book.tockos.org) for a step-by-step introduction to getting
 Tock up and running.
 
+A book on how to use Tock with the [micro:bit v2](boards/microbit_v2) and
+[Raspberry Pi Pico](boards/raspberry_pi_pico) boards is [Getting Started with Secure Embedded Systems](https://link.springer.com/book/10.1007/978-1-4842-7789-8).
+
 Find example applications that run on top of the Tock kernel written in both
 [Rust](https://github.com/tock/libtock-rs) and
 [C](https://github.com/tock/libtock-c).

--- a/boards/microbit_v2/README.md
+++ b/boards/microbit_v2/README.md
@@ -1,9 +1,9 @@
-BBC Micro:bit v2 - nRF52833 with Bluetooth LE
+BBC micro:bit v2 - nRF52833 with Bluetooth LE
 ==================================================
 
 <img src="https://cdn.sanity.io/images/ajwvhvgo/production/a7f49eb570ce06cf107dde7babaa5201411a41a1-660x720.jpg?q=80&fit=max&auto=format" width="35%">
 
-The [BBC Micro:bit v2 - nRF52833 with Bluetooth LE](https://microbit.org/new-microbit/) is a
+The [BBC micro:bit v2 - nRF52833 with Bluetooth LE](https://microbit.org/new-microbit/) is a
 board based on the Nordic nRF52833 SoC. It includes the
 following sensors:
 
@@ -130,6 +130,11 @@ $ tockloader install --openocd --board microbit_v2 --bundle-apps app.tab
 > ```bash
 > $ tockloader ... --page-size 512
 > ```
+
+## Book
+
+For furher details and exmaples about how to use Tock with the BBC micro:bit, you might
+want to check out the [Getting Started with Secure Embedded Systems](https://link.springer.com/book/10.1007/978-1-4842-7789-8) book.
 
 ## Troubleshooting
 

--- a/boards/microbit_v2/README.md
+++ b/boards/microbit_v2/README.md
@@ -133,7 +133,7 @@ $ tockloader install --openocd --board microbit_v2 --bundle-apps app.tab
 
 ## Book
 
-For furher details and exmaples about how to use Tock with the BBC micro:bit, you might
+For further details and examples about how to use Tock with the BBC micro:bit, you might
 want to check out the [Getting Started with Secure Embedded Systems](https://link.springer.com/book/10.1007/978-1-4842-7789-8) book.
 
 ## Troubleshooting

--- a/boards/raspberry_pi_pico/README.md
+++ b/boards/raspberry_pi_pico/README.md
@@ -78,5 +78,5 @@ This will generate a new ELF file that can be deployed on the Raspberry Pi Pico 
 
 ## Book
 
-For furher details and exmaples about how to use Tock with the Raspberry Pi Pico, you might
+For further details and examples about how to use Tock with the Raspberry Pi Pico, you might
 want to check out the [Getting Started with Secure Embedded Systems](https://link.springer.com/book/10.1007/978-1-4842-7789-8) book.

--- a/boards/raspberry_pi_pico/README.md
+++ b/boards/raspberry_pi_pico/README.md
@@ -75,3 +75,8 @@ $ make program
 ```
 
 This will generate a new ELF file that can be deployed on the Raspberry Pi Pico via gdb and OpenOCD as described in the [section above](#flash-the-tock-kernel).
+
+## Book
+
+For furher details and exmaples about how to use Tock with the Raspberry Pi Pico, you might
+want to check out the [Getting Started with Secure Embedded Systems](https://link.springer.com/book/10.1007/978-1-4842-7789-8) book.


### PR DESCRIPTION
### Pull Request Overview

The [Getting Started with Secure Embedded Systems](https://link.springer.com/book/10.1007/978-1-4842-7789-8) about using Tock with the micro:bit and Raspberry Pi Pico boards has been published. A big thank you to @brghena and @lschuermann for their reviews, their feedback has been very useful for us.

This pull request adds a link to the book in the main `readme` and the two board's `readme`s.

I know that it is not a free book, but I do think it might bring a lot of value to people that want to get started.


### Testing Strategy

N/A

### TODO or Help Wanted

I'm not sure that the place and message are the best, so any feedback is welcome.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
