### PR TITLE
boards/opentitan/README: qol update to app loading

### DIFF
--- a/boards/opentitan/README.md
+++ b/boards/opentitan/README.md
@@ -167,6 +167,13 @@ usually located at `sw/device/boot_rom/boot_rom_fpga_nexysvideo.elf` in the
 OpenTitan build output. Note that the `make ci-setup-qemu` target will also
 download a ROM file.
 
+**Note**: when **unit testing** is done using `make test`, to ensure the correct flash layout is used for applications, be sure to:
+
+```shell
+make clean
+```
+Prior to loading an application using the steps below.
+
 QEMU can be started with Tock and a userspace app with the `qemu-app` make
 target:
 


### PR DESCRIPTION
Signed-off-by: Wilfred Mallawa <wilfred.mallawa@wdc.com>

### Pull Request Overview
A minor qol update to the README, indicating to
run `make clean` when unit testing is done and an application is
to be loaded. Ensures the correct flash layout gets used for
the app.


### Testing Strategy
N/A


### TODO or Help Wanted
N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
