### PR TITLE
chips/earlgrey: Don't use MIP::MTIMER bit

### DIFF
--- a/boards/opentitan/src/main.rs
+++ b/boards/opentitan/src/main.rs
@@ -319,9 +319,9 @@ unsafe fn setup() -> (
     // Need to enable all interrupts for Tock Kernel
     chip.enable_plic_interrupts();
     // enable interrupts globally
-    csr::CSR
-        .mie
-        .modify(csr::mie::mie::msoft::SET + csr::mie::mie::mtimer::SET + csr::mie::mie::mext::SET);
+    csr::CSR.mie.modify(
+        csr::mie::mie::msoft::SET + csr::mie::mie::mtimer::CLEAR + csr::mie::mie::mext::SET,
+    );
     csr::CSR.mstatus.modify(csr::mstatus::mstatus::mie::SET);
 
     // Setup the console.


### PR DESCRIPTION
### Pull Request Overview

The RISC-V specification provides the MIP:MTIMER bit to indicate when a
timer interrupt occurs. OpenTitan also provides a RVTIMERTIMEREXPIRED0_0
interrupt for the same functionality.

We should be only using one of the timer interrupt sources, currently we
report the MIP::MTIMER bit, but never act on it, instead handling the
interrupt generated from RVTIMERTIMEREXPIRED0_0.

This patch removes all of the MIP::MTIMER functionality and disables the
interrupt in MIE to ensure that we don't get double handle a timer
interrupt. We now only use the RVTIMERTIMEREXPIRED0_0 interrupt as
passed from the PLIC.

This issue was found by @thulithwilfred when he tried to use a delay in libtock-c
on the OpenTitan QEMU model.

### Testing Strategy

Running the test on OT FPGA hardware

### TODO or Help Wanted

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
