### PR TITLE
doc: Fix broken link

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -43,4 +43,4 @@ Tock Guides
 ### Management of Tock
 - **[Working Groups](wg)** - Development groups for specific aspects of Tock.
 - **[Code Review Process](CodeReview.md)** - Process for pull request reviews.
-- **[Tock Management](Management.md)** - Management processes for Tock, including releases.
+- **[Tock Management](Maintenance.md)** - Management processes for Tock, including releases.


### PR DESCRIPTION
This was pointing to the wrong / nonexistent markdown file

### Pull Request Overview

Fixes link.

### Testing Strategy

N/A

### TODO or Help Wanted

N/A

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
