### PR TITLE
Print prompt after the "process" command

### DIFF
--- a/capsules/src/process_console.rs
+++ b/capsules/src/process_console.rs
@@ -487,6 +487,10 @@ impl<'a, A: Alarm<'a>, C: ProcessManagementCapability> ProcessConsole<'a, A, C> 
                                 });
                             } else {
                                 self.writer_state.replace(WriterState::Empty);
+                                // As setting the next state here to Empty does not
+                                // go through this match again before reading a new command,
+                                // we have to print the prompt here.
+                                self.prompt();
                             }
                         }
                     });


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes the missing prompt print for the `process` command within the process console.

The issue surfaced due to the addition of the process printer which seems to handle process printing with its
own internal states. When it finishes, the process console loop does not go through the `Empty` state, and does
not print the prompt.


### Testing Strategy

This pull request was tested using an esp c3 devkit m1.


### TODO or Help Wanted

N/A

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
