### PR TITLE
arch/rv32i: pmp/ePMP: Fixup PMP comparision

### DIFF
--- a/arch/rv32i/src/epmp.rs
+++ b/arch/rv32i/src/epmp.rs
@@ -306,6 +306,10 @@ impl PMPRegion {
         self.location
     }
 
+    /// Check if the PMP regions specified by `other_start` and `other_size`
+    /// overlaps with the current region.
+    /// Matching the RISC-V spec this checks pmpaddr[i-i] <= y < pmpaddr[i] for
+    /// TOR ranges.
     fn overlaps(&self, other_start: *const u8, other_size: usize) -> bool {
         let other_start = other_start as usize;
         let other_end = other_start + other_size;
@@ -318,7 +322,9 @@ impl PMPRegion {
             (region_start, region_end)
         };
 
-        if region_start < other_end && other_start < region_end {
+        // PMP addresses are not inclusive on the high end, that is
+        //     pmpaddr[i-i] <= y < pmpaddr[i]
+        if region_start < (other_end - 4) && other_start < (region_end - 4) {
             true
         } else {
             false

--- a/arch/rv32i/src/pmp.rs
+++ b/arch/rv32i/src/pmp.rs
@@ -185,6 +185,10 @@ impl PMPRegion {
         self.location
     }
 
+    /// Check if the PMP regions specified by `other_start` and `other_size`
+    /// overlaps with the current region.
+    /// Matching the RISC-V spec this checks pmpaddr[i-i] <= y < pmpaddr[i] for
+    /// TOR ranges.
     fn overlaps(&self, other_start: *const u8, other_size: usize) -> bool {
         let other_start = other_start as usize;
         let other_end = other_start + other_size;
@@ -197,7 +201,9 @@ impl PMPRegion {
             (region_start, region_end)
         };
 
-        if region_start < other_end && other_start < region_end {
+        // PMP addresses are not inclusive on the high end, that is
+        //     pmpaddr[i-i] <= y < pmpaddr[i]
+        if region_start < (other_end - 4) && other_start < (region_end - 4) {
             true
         } else {
             false


### PR DESCRIPTION
### Pull Request Overview

PMP addresses are not inclusive on the high end, that is
```
pmpaddr[i-i] <= y < pmpaddr[i]
```

So let's change the `overlaps()` logic to take that into account. This 
fixes PMP errors when two regions are right next to each other.

### Testing Strategy

OT FPGA

### TODO or Help Wanted

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
