### PR TITLE
Remove the threat model's "not yet implemented" note.

### DIFF
--- a/doc/threat_model/README.md
+++ b/doc/threat_model/README.md
@@ -1,11 +1,6 @@
 Tock Threat Model
 =================
 
-
-**Note: This threat model is not descriptive of Tock's current implementation.
-It describes how we intend Tock to work as of some future release, perhaps
-2.0.**
-
 ## Overview
 
 Tock provides hardware-based isolation between processes as well as


### PR DESCRIPTION
This note predates Tock 2.0, and is no longer correct. Tock 2.0 implements the threat model as written.

### Testing Strategy

Looked at the [rendered](https://github.com/jrvanwhy/tock/tree/rm-threat-model-warning/doc/threat_model) document.

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
