### PR TITLE
opentitan: Makefile: fixup test flash-layout

### DIFF
--- a/boards/opentitan/README.md
+++ b/boards/opentitan/README.md
@@ -224,13 +224,6 @@ usually located at `sw/device/boot_rom/boot_rom_fpga_nexysvideo.elf` in the
 OpenTitan build output. Note that the `make ci-setup-qemu` target will also
 download a ROM file.
 
-**Note**: when **unit testing** is done using `make test`, to ensure the correct flash layout is used for applications, be sure to:
-
-```shell
-make clean
-```
-Prior to loading an application using the steps below.
-
 QEMU can be started with Tock and a userspace app with the `qemu-app` make
 target:
 

--- a/boards/opentitan/earlgrey-cw310/Makefile
+++ b/boards/opentitan/earlgrey-cw310/Makefile
@@ -66,6 +66,8 @@ endif
 	$(Q)cp test_layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/layout.ld
 	$(Q)cp ../../kernel_layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/
 	$(Q)RUSTFLAGS="$(RUSTC_FLAGS_TOCK)" $(CARGO) test $(CARGO_FLAGS_TOCK_NO_BUILD_STD) $(NO_RUN) --bin $(PLATFORM) --release
+# Test layout should be removed so that following apps (non-test) load the correct layout.
+	$(Q)rm $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/layout.ld
 
 test-hardware:
 ifeq ($(OPENTITAN_TREE),)
@@ -75,6 +77,7 @@ endif
 	$(Q)cp test_layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/layout.ld
 	$(Q)cp ../../kernel_layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/
 	$(Q)RUSTFLAGS="$(RUSTC_FLAGS_TOCK)" $(CARGO) test $(CARGO_FLAGS_TOCK_NO_BUILD_STD) $(NO_RUN) --bin $(PLATFORM) --release --features=hardware_tests
+	$(Q)rm $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/layout.ld
 
 test-verilator:
 	$(call check_defined, OPENTITAN_TREE)
@@ -84,3 +87,4 @@ test-verilator:
 	$(Q)cp ../../kernel_layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/
 
 	$(Q)RUSTFLAGS="$(RUSTC_FLAGS_TOCK)" VERILATOR="yes" $(CARGO) test $(CARGO_FLAGS_TOCK_NO_BUILD_STD) $(NO_RUN) --bin $(PLATFORM) --release --features=hardware_tests
+	$(Q)rm $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/layout.ld

--- a/boards/opentitan/earlgrey-nexysvideo/Makefile
+++ b/boards/opentitan/earlgrey-nexysvideo/Makefile
@@ -57,6 +57,8 @@ endif
 	$(Q)cp test_layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/layout.ld
 	$(Q)cp ../../kernel_layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/
 	$(Q)RUSTFLAGS="$(RUSTC_FLAGS_TOCK)" $(CARGO) test $(CARGO_FLAGS_TOCK_NO_BUILD_STD) $(NO_RUN) --bin $(PLATFORM) --release
+# Test layout should be removed so that following apps (non-test) load the correct layout.
+	$(Q)rm $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/layout.ld
 
 test-hardware:
 ifeq ($(OPENTITAN_TREE),)
@@ -66,6 +68,7 @@ endif
 	$(Q)cp test_layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/layout.ld
 	$(Q)cp ../../kernel_layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/
 	$(Q)RUSTFLAGS="$(RUSTC_FLAGS_TOCK)" $(CARGO) test $(CARGO_FLAGS_TOCK_NO_BUILD_STD) $(NO_RUN) --bin $(PLATFORM) --release --features=hardware_tests
+	$(Q)rm $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/layout.ld
 
 test-verilator:
 	$(call check_defined, OPENTITAN_TREE)
@@ -75,3 +78,4 @@ test-verilator:
 	$(Q)cp ../../kernel_layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/
 
 	$(Q)RUSTFLAGS="$(RUSTC_FLAGS_TOCK)" VERILATOR="yes" $(CARGO) test $(CARGO_FLAGS_TOCK_NO_BUILD_STD) $(NO_RUN) --bin $(PLATFORM) --release --features=hardware_tests
+	$(Q)rm $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/layout.ld


### PR DESCRIPTION
### Pull Request Overview

This fixes a bug, where if an application is ran (i.e qemu-app) after
`make test`, the incorrect flash layout is loaded (in layout.ld). As a result
of `make test` copying the test layout over and this not being cleared
when an app is loaded, thus resulting in a hang after OT is initialized.

Is fixed by removing `layout.ld` after a test is run with no additional cost to
build time.

edit: Applied fix for nexysvideo Makefile

### Testing Strategy
`make test` ,  loading an application through qemu

### Documentation Updated

- [x ] Removed notice to run `make clean` between `make test` and `make app` (as this fixes the bug)

### Formatting

- [ x] Ran `make prepush`.

Signed-off-by: Wilfred Mallawa <wilfred.mallawa@wdc.com>
