### PR TITLE
opentitan: Verilator fixup for ot bump

### DIFF
--- a/boards/opentitan/README.md
+++ b/boards/opentitan/README.md
@@ -132,13 +132,19 @@ pip3 install --user -r python-requirements.txt
 
 LANG="en_US.UTF-8" fusesoc --cores-root . run --flag=fileset_top --target=sim --setup --build lowrisc:dv:chip_verilator_sim
 ```
+### Build Boot Rom/OTP Image
+Build only the targets we care about.
+```shell
+ninja -C build-out sw/device/lib/testing/test_rom/test_rom_export_sim_verilator
+ninja -C build-out sw/device/otp_img/otp_img_sim_verilator.vmem
+```
 
 ### Test Verilator
 
 ```shell
 build/lowrisc_dv_chip_verilator_sim_0.1/sim-verilator/Vchip_sim_tb \
-    --meminit=rom,./build-out/sw/device/boot_rom/boot_rom_sim_verilator.scr.39.vmem \
-    --meminit=otp,./build-bin/sw/device/otp_img/otp_img_sim_verilator.vmem
+    --meminit=rom,./build-out/sw/device/lib/testing/test_rom/test_rom_sim_verilator.scr.39.vmem \
+    --meminit=otp,./build-out/sw/device/otp_img/otp_img_sim_verilator.vmem
 
 # Read the output, you want to attach screen to UART
 screen /dev/pts/4

--- a/boards/opentitan/earlgrey-cw310/Makefile
+++ b/boards/opentitan/earlgrey-cw310/Makefile
@@ -54,9 +54,9 @@ verilator: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin
 		-within $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin \
 		-binary -range-pad 8 --output binary.64.vmem --vmem 64
 	$(OPENTITAN_TREE)/build/lowrisc_dv_chip_verilator_sim_0.1/sim-verilator/Vchip_sim_tb \
-		--meminit=rom,$(OPENTITAN_TREE)/build-out/sw/device/boot_rom/boot_rom_sim_verilator.scr.39.vmem \
+		--meminit=rom,$(OPENTITAN_TREE)/build-out/sw/device/lib/testing/test_rom/test_rom_sim_verilator.scr.39.vmem \
 		--meminit=flash,./binary.64.vmem \
-		--meminit=otp,$(OPENTITAN_TREE)/build-bin/sw/device/otp_img/otp_img_sim_verilator.vmem
+		--meminit=otp,$(OPENTITAN_TREE)/build-out/sw/device/otp_img/otp_img_sim_verilator.vmem
 
 test:
 ifneq ($(OPENTITAN_TREE),)

--- a/boards/opentitan/earlgrey-cw310/run.sh
+++ b/boards/opentitan/earlgrey-cw310/run.sh
@@ -7,9 +7,9 @@ if [[ "${VERILATOR}" == "yes" ]]; then
 		-within binary \
 		-binary -range-pad 8 --output binary.64.vmem --vmem 64
 	${OPENTITAN_TREE}/build/lowrisc_dv_chip_verilator_sim_0.1/sim-verilator/Vchip_sim_tb \
-		--meminit=rom,${OPENTITAN_TREE}/build-out/sw/device/boot_rom/boot_rom_sim_verilator.scr.39.vmem \
+		--meminit=rom,${OPENTITAN_TREE}/build-out/sw/device/lib/testing/test_rom/test_rom_sim_verilator.scr.39.vmem \
 		--meminit=flash,./binary.64.vmem \
-		--meminit=otp,${OPENTITAN_TREE}/build-bin/sw/device/otp_img/otp_img_sim_verilator.vmem
+		--meminit=otp,${OPENTITAN_TREE}/build-out/sw/device/otp_img/otp_img_sim_verilator.vmem
 elif [[ "${OPENTITAN_TREE}" != "" ]]; then
 	riscv64-linux-gnu-objcopy --update-section .apps=${APP} ${1} bundle.elf
 	riscv64-linux-gnu-objcopy --output-target=binary bundle.elf binary

--- a/boards/opentitan/earlgrey-nexysvideo/Makefile
+++ b/boards/opentitan/earlgrey-nexysvideo/Makefile
@@ -45,9 +45,9 @@ verilator: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin
 		-within $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin \
 		-binary -range-pad 8 --output binary.64.vmem --vmem 64
 	$(OPENTITAN_TREE)/build/lowrisc_dv_chip_verilator_sim_0.1/sim-verilator/Vchip_sim_tb \
-		--meminit=rom,$(OPENTITAN_TREE)/build-out/sw/device/boot_rom/boot_rom_sim_verilator.scr.39.vmem \
+		--meminit=rom,$(OPENTITAN_TREE)/build-out/sw/device/lib/testing/test_rom/test_rom_sim_verilator.scr.39.vmem \
 		--meminit=flash,./binary.64.vmem \
-		--meminit=otp,$(OPENTITAN_TREE)/build-bin/sw/device/otp_img/otp_img_sim_verilator.vmem
+		--meminit=otp,$(OPENTITAN_TREE)/build-out/sw/device/otp_img/otp_img_sim_verilator.vmem
 
 test:
 ifneq ($(OPENTITAN_TREE),)

--- a/boards/opentitan/earlgrey-nexysvideo/run.sh
+++ b/boards/opentitan/earlgrey-nexysvideo/run.sh
@@ -7,9 +7,9 @@ if [[ "${VERILATOR}" == "yes" ]]; then
 		-within binary \
 		-binary -range-pad 8 --output binary.64.vmem --vmem 64
 	${OPENTITAN_TREE}/build/lowrisc_dv_chip_verilator_sim_0.1/sim-verilator/Vchip_sim_tb \
-		--meminit=rom,${OPENTITAN_TREE}/build-out/sw/device/boot_rom/boot_rom_sim_verilator.scr.39.vmem \
+		--meminit=rom,${OPENTITAN_TREE}/build-out/sw/device/lib/testing/test_rom/test_rom_sim_verilator.scr.39.vmem \
 		--meminit=flash,./binary.64.vmem \
-		--meminit=otp,${OPENTITAN_TREE}/build-bin/sw/device/otp_img/otp_img_sim_verilator.vmem
+		--meminit=otp,${OPENTITAN_TREE}/build-out/sw/device/otp_img/otp_img_sim_verilator.vmem
 elif [[ "${OPENTITAN_TREE}" != "" ]]; then
 	riscv64-linux-gnu-objcopy --output-target=binary ${1} binary
 	${OPENTITAN_TREE}/build-out/sw/host/spiflash/spiflash --dev-id=0403:6010 --input=binary


### PR DESCRIPTION
### Pull Request Overview

Updated the build-system for tock-verilator to match the changed target
(boot/otp images)
paths for the recent OT bump [1]. The path change is referenced here
[2]

Added specific target build instructions to README
as these targets are required, and since running
`ninja -C build-out all` will typically fail to complete. Also much
quicker to just build only the required targets.

[1] https://github.com/tock/tock/pull/2954
[2] https://github.com/lowRISC/opentitan/issues/9154

Signed-off-by: Wilfred Mallawa <wilfred.mallawa@wdc.com>

### Testing Strategy

Building the updated targets for both cw130 and nexysvideo


### TODO or Help Wanted
N/A

### Documentation Updated
- [x] Updated README 

### Formatting
- [x] Ran `make fmt`.
