### PR TITLE
doc: Update Instructions: Building build.rs requires a host toolchain for linking

### DIFF
--- a/doc/Getting_Started.md
+++ b/doc/Getting_Started.md
@@ -30,8 +30,9 @@ developing Tock.
 
 1. [Rust](http://www.rust-lang.org/)
 2. [rustup](https://rustup.rs/) to install Rust (version >= 1.11.0)
-3. Command line utilities: make
-4. A supported board or QEMU configuration.
+3. Host toolchain (gcc, glibc)
+4. Command line utilities: make, find
+5. A supported board or QEMU configuration.
 
    If you are just starting to work with TockOS, you should look in
    the [`boards/` subdirectory](../boards/README.md) and choose one of
@@ -61,6 +62,7 @@ $ pip3 install --upgrade tockloader
 
 Ubuntu:
 ```
+$ apt install -y build-essential python3-pip curl
 $ curl https://sh.rustup.rs -sSf | sh
 $ pip3 install --upgrade tockloader --user
 $ grep -q dialout <(groups $(whoami)) || sudo usermod -a -G dialout $(whoami) # Note, will need to reboot if prompted for password


### PR DESCRIPTION
### Pull Request Overview

This fixes build instructions. After installing in a container, it turned out some more packages were required. Those were added. When the host toolchain is missing, the following errors appear, and don't seem to disappear after the toolchain is installed:

```
  = note: rust-lld: error: unable to find library -lgcc_s
          rust-lld: error: unable to find library -lutil
          rust-lld: error: unable to find library -lrt
          rust-lld: error: unable to find library -lpthread
          rust-lld: error: unable to find library -lm
          rust-lld: error: unable to find library -ldl
          rust-lld: error: unable to find library -lc
          rust-lld: error: cannot find linker script layout.ld
```

### Testing Strategy

This pull request was tested by typing the commands manually.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`. irrelevant?
