### PR TITLE
Store Kernel Managed Grant Resource Counters in One usize Value

### DIFF
--- a/boards/acd52832/src/main.rs
+++ b/boards/acd52832/src/main.rs
@@ -74,7 +74,7 @@ pub struct Platform {
     >,
     rng: &'static capsules::rng::RngDriver<'static>,
     temp: &'static capsules::temperature::TemperatureSensor<'static>,
-    ipc: kernel::ipc::IPC<NUM_PROCS>,
+    ipc: kernel::ipc::IPC<{ NUM_PROCS as u8 }>,
     alarm: &'static capsules::alarm::AlarmDriver<
         'static,
         VirtualMuxAlarm<'static, nrf52832::rtc::Rtc<'static>>,

--- a/boards/arty_e21/src/main.rs
+++ b/boards/arty_e21/src/main.rs
@@ -295,10 +295,5 @@ pub unsafe fn main() {
         debug!("{:?}", err);
     });
 
-    board_kernel.kernel_loop(
-        &artye21,
-        chip,
-        None::<&kernel::ipc::IPC<NUM_PROCS>>,
-        &main_loop_cap,
-    );
+    board_kernel.kernel_loop(&artye21, chip, None::<&kernel::ipc::IPC<0>>, &main_loop_cap);
 }

--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -155,7 +155,7 @@ pub struct Platform {
     button: &'static capsules::button::Button<'static, nrf52::gpio::GPIOPin<'static>>,
     screen: &'static capsules::screen::Screen<'static>,
     rng: &'static capsules::rng::RngDriver<'static>,
-    ipc: kernel::ipc::IPC<NUM_PROCS>,
+    ipc: kernel::ipc::IPC<{ NUM_PROCS as u8 }>,
     alarm: &'static capsules::alarm::AlarmDriver<
         'static,
         capsules::virtual_alarm::VirtualMuxAlarm<'static, nrf52::rtc::Rtc<'static>>,

--- a/boards/esp32-c3-devkitM-1/src/main.rs
+++ b/boards/esp32-c3-devkitM-1/src/main.rs
@@ -337,7 +337,7 @@ pub unsafe fn main() {
         board_kernel.kernel_loop(
             esp32_c3_board,
             chip,
-            None::<&kernel::ipc::IPC<NUM_PROCS>>,
+            None::<&kernel::ipc::IPC<0>>,
             &main_loop_cap,
         );
     }

--- a/boards/esp32-c3-devkitM-1/src/tests/mod.rs
+++ b/boards/esp32-c3-devkitM-1/src/tests/mod.rs
@@ -11,7 +11,7 @@ fn run_kernel_op(loops: usize) {
             BOARD.unwrap().kernel_loop_operation(
                 PLATFORM.unwrap(),
                 CHIP.unwrap(),
-                None::<&kernel::ipc::IPC<NUM_PROCS>>,
+                None::<&kernel::ipc::IPC<0>>,
                 true,
                 MAIN_CAP.unwrap(),
             );

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -76,7 +76,7 @@ struct Hail {
     >,
     button: &'static capsules::button::Button<'static, sam4l::gpio::GPIOPin<'static>>,
     rng: &'static capsules::rng::RngDriver<'static>,
-    ipc: kernel::ipc::IPC<NUM_PROCS>,
+    ipc: kernel::ipc::IPC<{ NUM_PROCS as u8 }>,
     crc: &'static capsules::crc::CrcDriver<'static, sam4l::crccu::Crccu<'static>>,
     dac: &'static capsules::dac::Dac<'static>,
     scheduler: &'static RoundRobinSched<'static>,

--- a/boards/hifive1/src/main.rs
+++ b/boards/hifive1/src/main.rs
@@ -305,10 +305,5 @@ pub unsafe fn main() {
         debug!("{:?}", err);
     });
 
-    board_kernel.kernel_loop(
-        &hifive1,
-        chip,
-        None::<&kernel::ipc::IPC<NUM_PROCS>>,
-        &main_loop_cap,
-    );
+    board_kernel.kernel_loop(&hifive1, chip, None::<&kernel::ipc::IPC<0>>, &main_loop_cap);
 }

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -131,7 +131,7 @@ struct Imix {
         'static,
         VirtualSpiMasterDevice<'static, sam4l::spi::SpiHw>,
     >,
-    ipc: kernel::ipc::IPC<NUM_PROCS>,
+    ipc: kernel::ipc::IPC<{ NUM_PROCS as u8 }>,
     ninedof: &'static capsules::ninedof::NineDof<'static>,
     udp_driver: &'static capsules::net::udp::UDPDriver<'static>,
     crc: &'static capsules::crc::CrcDriver<'static, sam4l::crccu::Crccu<'static>>,

--- a/boards/imxrt1050-evkb/src/main.rs
+++ b/boards/imxrt1050-evkb/src/main.rs
@@ -76,7 +76,7 @@ struct Imxrt1050EVKB {
     button: &'static capsules::button::Button<'static, imxrt1050::gpio::Pin<'static>>,
     console: &'static capsules::console::Console<'static>,
     gpio: &'static capsules::gpio::GPIO<'static, imxrt1050::gpio::Pin<'static>>,
-    ipc: kernel::ipc::IPC<NUM_PROCS>,
+    ipc: kernel::ipc::IPC<{ NUM_PROCS as u8 }>,
     led: &'static capsules::led::LedDriver<
         'static,
         LedLow<'static, imxrt1050::gpio::Pin<'static>>,

--- a/boards/litex/arty/src/main.rs
+++ b/boards/litex/arty/src/main.rs
@@ -534,7 +534,7 @@ pub unsafe fn main() {
     board_kernel.kernel_loop(
         &litex_arty,
         chip,
-        None::<&kernel::ipc::IPC<NUM_PROCS>>,
+        None::<&kernel::ipc::IPC<0>>,
         &main_loop_cap,
     );
 }

--- a/boards/litex/sim/src/main.rs
+++ b/boards/litex/sim/src/main.rs
@@ -140,7 +140,7 @@ struct LiteXSim {
             >,
         >,
     >,
-    ipc: kernel::ipc::IPC<NUM_PROCS>,
+    ipc: kernel::ipc::IPC<{ NUM_PROCS as u8 }>,
     scheduler: &'static CooperativeSched<'static>,
     scheduler_timer: &'static VirtualSchedulerTimer<
         VirtualMuxAlarm<

--- a/boards/microbit_v2/src/main.rs
+++ b/boards/microbit_v2/src/main.rs
@@ -97,7 +97,7 @@ pub struct MicroBit {
     ninedof: &'static capsules::ninedof::NineDof<'static>,
     lsm303agr: &'static capsules::lsm303agr::Lsm303agrI2C<'static>,
     temperature: &'static capsules::temperature::TemperatureSensor<'static>,
-    ipc: kernel::ipc::IPC<NUM_PROCS>,
+    ipc: kernel::ipc::IPC<{ NUM_PROCS as u8 }>,
     adc: &'static capsules::adc::AdcVirtualized<'static>,
     alarm: &'static capsules::alarm::AlarmDriver<
         'static,

--- a/boards/msp_exp432p401r/src/main.rs
+++ b/boards/msp_exp432p401r/src/main.rs
@@ -57,7 +57,7 @@ struct MspExp432P401R {
         'static,
         capsules::virtual_alarm::VirtualMuxAlarm<'static, msp432::timer::TimerA<'static>>,
     >,
-    ipc: kernel::ipc::IPC<NUM_PROCS>,
+    ipc: kernel::ipc::IPC<{ NUM_PROCS as u8 }>,
     adc: &'static capsules::adc::AdcDedicated<'static, msp432::adc::Adc<'static>>,
     wdt: &'static msp432::wdt::Wdt,
     scheduler: &'static RoundRobinSched<'static>,

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -141,7 +141,7 @@ pub struct Platform {
     >,
     adc: &'static capsules::adc::AdcVirtualized<'static>,
     rng: &'static capsules::rng::RngDriver<'static>,
-    ipc: kernel::ipc::IPC<NUM_PROCS>,
+    ipc: kernel::ipc::IPC<{ NUM_PROCS as u8 }>,
     alarm: &'static capsules::alarm::AlarmDriver<
         'static,
         capsules::virtual_alarm::VirtualMuxAlarm<'static, nrf52::rtc::Rtc<'static>>,

--- a/boards/nano_rp2040_connect/src/main.rs
+++ b/boards/nano_rp2040_connect/src/main.rs
@@ -65,7 +65,7 @@ static mut PROCESS_PRINTER: Option<&'static kernel::process::ProcessPrinterText>
 
 /// Supported drivers by the platform
 pub struct NanoRP2040Connect {
-    ipc: kernel::ipc::IPC<NUM_PROCS>,
+    ipc: kernel::ipc::IPC<{ NUM_PROCS as u8 }>,
     console: &'static capsules::console::Console<'static>,
     alarm: &'static capsules::alarm::AlarmDriver<
         'static,

--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -94,7 +94,7 @@ pub struct Platform {
     >,
     rng: &'static capsules::rng::RngDriver<'static>,
     temp: &'static capsules::temperature::TemperatureSensor<'static>,
-    ipc: kernel::ipc::IPC<NUM_PROCS>,
+    ipc: kernel::ipc::IPC<{ NUM_PROCS as u8 }>,
     analog_comparator: &'static capsules::analog_comparator::AnalogComparator<
         'static,
         nrf52840::acomp::Comparator<'static>,

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -177,7 +177,7 @@ pub struct Platform {
     >,
     rng: &'static capsules::rng::RngDriver<'static>,
     temp: &'static capsules::temperature::TemperatureSensor<'static>,
-    ipc: kernel::ipc::IPC<NUM_PROCS>,
+    ipc: kernel::ipc::IPC<{ NUM_PROCS as u8 }>,
     analog_comparator: &'static capsules::analog_comparator::AnalogComparator<
         'static,
         nrf52840::acomp::Comparator<'static>,

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -152,7 +152,7 @@ pub struct Platform {
     >,
     rng: &'static capsules::rng::RngDriver<'static>,
     temp: &'static capsules::temperature::TemperatureSensor<'static>,
-    ipc: kernel::ipc::IPC<NUM_PROCS>,
+    ipc: kernel::ipc::IPC<{ NUM_PROCS as u8 }>,
     analog_comparator: &'static capsules::analog_comparator::AnalogComparator<
         'static,
         nrf52832::acomp::Comparator<'static>,

--- a/boards/nucleo_f429zi/src/main.rs
+++ b/boards/nucleo_f429zi/src/main.rs
@@ -47,7 +47,7 @@ pub static mut STACK_MEMORY: [u8; 0x2000] = [0; 0x2000];
 /// capsules for this platform.
 struct NucleoF429ZI {
     console: &'static capsules::console::Console<'static>,
-    ipc: kernel::ipc::IPC<NUM_PROCS>,
+    ipc: kernel::ipc::IPC<{ NUM_PROCS as u8 }>,
     led: &'static capsules::led::LedDriver<
         'static,
         LedHigh<'static, stm32f429zi::gpio::Pin<'static>>,

--- a/boards/nucleo_f446re/src/main.rs
+++ b/boards/nucleo_f446re/src/main.rs
@@ -51,7 +51,7 @@ pub static mut STACK_MEMORY: [u8; 0x2000] = [0; 0x2000];
 /// capsules for this platform.
 struct NucleoF446RE {
     console: &'static capsules::console::Console<'static>,
-    ipc: kernel::ipc::IPC<NUM_PROCS>,
+    ipc: kernel::ipc::IPC<{ NUM_PROCS as u8 }>,
     led: &'static capsules::led::LedDriver<
         'static,
         LedHigh<'static, stm32f446re::gpio::Pin<'static>>,

--- a/boards/opentitan/src/main.rs
+++ b/boards/opentitan/src/main.rs
@@ -796,12 +796,7 @@ pub unsafe fn main() {
 
         let main_loop_cap = create_capability!(capabilities::MainLoopCapability);
 
-        board_kernel.kernel_loop(
-            earlgrey,
-            chip,
-            None::<&kernel::ipc::IPC<NUM_PROCS>>,
-            &main_loop_cap,
-        );
+        board_kernel.kernel_loop(earlgrey, chip, None::<&kernel::ipc::IPC<0>>, &main_loop_cap);
     }
 }
 

--- a/boards/opentitan/src/tests/mod.rs
+++ b/boards/opentitan/src/tests/mod.rs
@@ -1,7 +1,6 @@
 use crate::BOARD;
 use crate::CHIP;
 use crate::MAIN_CAP;
-use crate::NUM_PROCS;
 use crate::PLATFORM;
 use kernel::debug;
 
@@ -27,7 +26,7 @@ fn run_kernel_op(loops: usize) {
             BOARD.unwrap().kernel_loop_operation(
                 PLATFORM.unwrap(),
                 CHIP.unwrap(),
-                None::<&kernel::ipc::IPC<NUM_PROCS>>,
+                None::<&kernel::ipc::IPC<0>>,
                 true,
                 MAIN_CAP.unwrap(),
             );

--- a/boards/pico_explorer_base/src/main.rs
+++ b/boards/pico_explorer_base/src/main.rs
@@ -67,7 +67,7 @@ static mut PROCESS_PRINTER: Option<&'static kernel::process::ProcessPrinterText>
 
 /// Supported drivers by the platform
 pub struct PicoExplorerBase {
-    ipc: kernel::ipc::IPC<NUM_PROCS>,
+    ipc: kernel::ipc::IPC<{ NUM_PROCS as u8 }>,
     console: &'static capsules::console::Console<'static>,
     alarm: &'static capsules::alarm::AlarmDriver<
         'static,

--- a/boards/raspberry_pi_pico/src/main.rs
+++ b/boards/raspberry_pi_pico/src/main.rs
@@ -70,7 +70,7 @@ static mut PROCESS_PRINTER: Option<&'static kernel::process::ProcessPrinterText>
 
 /// Supported drivers by the platform
 pub struct RaspberryPiPico {
-    ipc: kernel::ipc::IPC<NUM_PROCS>,
+    ipc: kernel::ipc::IPC<{ NUM_PROCS as u8 }>,
     console: &'static capsules::console::Console<'static>,
     alarm: &'static capsules::alarm::AlarmDriver<
         'static,

--- a/boards/redboard_artemis_nano/src/main.rs
+++ b/boards/redboard_artemis_nano/src/main.rs
@@ -391,7 +391,7 @@ pub unsafe fn main() {
         board_kernel.kernel_loop(
             esp32_c3_board,
             chip,
-            None::<&kernel::ipc::IPC<NUM_PROCS>>,
+            None::<&kernel::ipc::IPC<{ NUM_PROCS as u8 }>>,
             &main_loop_cap,
         );
     }

--- a/boards/redboard_redv/src/main.rs
+++ b/boards/redboard_redv/src/main.rs
@@ -304,7 +304,7 @@ pub unsafe fn main() {
     board_kernel.kernel_loop(
         &redv,
         chip,
-        None::<&kernel::ipc::IPC<NUM_PROCS>>,
+        None::<&kernel::ipc::IPC<{ NUM_PROCS as u8 }>>,
         &main_loop_cap,
     );
 }

--- a/boards/stm32f3discovery/src/main.rs
+++ b/boards/stm32f3discovery/src/main.rs
@@ -55,7 +55,7 @@ pub static mut STACK_MEMORY: [u8; 0x1400] = [0; 0x1400];
 /// capsules for this platform.
 struct STM32F3Discovery {
     console: &'static capsules::console::Console<'static>,
-    ipc: kernel::ipc::IPC<NUM_PROCS>,
+    ipc: kernel::ipc::IPC<{ NUM_PROCS as u8 }>,
     gpio: &'static capsules::gpio::GPIO<'static, stm32f303xc::gpio::Pin<'static>>,
     led: &'static capsules::led::LedDriver<
         'static,

--- a/boards/stm32f412gdiscovery/src/main.rs
+++ b/boards/stm32f412gdiscovery/src/main.rs
@@ -46,7 +46,7 @@ pub static mut STACK_MEMORY: [u8; 0x2000] = [0; 0x2000];
 /// capsules for this platform.
 struct STM32F412GDiscovery {
     console: &'static capsules::console::Console<'static>,
-    ipc: kernel::ipc::IPC<NUM_PROCS>,
+    ipc: kernel::ipc::IPC<{ NUM_PROCS as u8 }>,
     led: &'static capsules::led::LedDriver<
         'static,
         LedLow<'static, stm32f412g::gpio::Pin<'static>>,

--- a/boards/stm32f429idiscovery/src/main.rs
+++ b/boards/stm32f429idiscovery/src/main.rs
@@ -47,7 +47,7 @@ pub static mut STACK_MEMORY: [u8; 0x2000] = [0; 0x2000];
 /// capsules for this platform.
 struct STM32F429IDiscovery {
     console: &'static capsules::console::Console<'static>,
-    ipc: kernel::ipc::IPC<NUM_PROCS>,
+    ipc: kernel::ipc::IPC<{ NUM_PROCS as u8 }>,
     led: &'static capsules::led::LedDriver<
         'static,
         LedHigh<'static, stm32f429zi::gpio::Pin<'static>>,

--- a/boards/swervolf/src/main.rs
+++ b/boards/swervolf/src/main.rs
@@ -256,7 +256,7 @@ pub unsafe fn main() {
     board_kernel.kernel_loop(
         &swervolf,
         chip,
-        None::<&kernel::ipc::IPC<NUM_PROCS>>,
+        None::<&kernel::ipc::IPC<0>>,
         &main_loop_cap,
     );
 }

--- a/boards/teensy40/src/main.rs
+++ b/boards/teensy40/src/main.rs
@@ -40,7 +40,7 @@ struct Teensy40 {
         1,
     >,
     console: &'static capsules::console::Console<'static>,
-    ipc: kernel::ipc::IPC<NUM_PROCS>,
+    ipc: kernel::ipc::IPC<{ NUM_PROCS as u8 }>,
     alarm: &'static capsules::alarm::AlarmDriver<
         'static,
         capsules::virtual_alarm::VirtualMuxAlarm<'static, imxrt1060::gpt::Gpt1<'static>>,

--- a/boards/weact_f401ccu6/src/main.rs
+++ b/boards/weact_f401ccu6/src/main.rs
@@ -46,7 +46,7 @@ pub static mut STACK_MEMORY: [u8; 0x2000] = [0; 0x2000];
 /// capsules for this platform.
 struct WeactF401CC {
     console: &'static capsules::console::Console<'static>,
-    ipc: kernel::ipc::IPC<NUM_PROCS>,
+    ipc: kernel::ipc::IPC<{ NUM_PROCS as u8 }>,
     led: &'static capsules::led::LedDriver<
         'static,
         LedLow<'static, stm32f401cc::gpio::Pin<'static>>,

--- a/capsules/src/alarm.rs
+++ b/capsules/src/alarm.rs
@@ -24,7 +24,7 @@ pub struct AlarmData {
 }
 
 const ALARM_CALLBACK_NUM: usize = 0;
-const NUM_UPCALLS: usize = 1;
+const NUM_UPCALLS: u8 = 1;
 
 impl Default for AlarmData {
     fn default() -> AlarmData {

--- a/capsules/src/app_flash_driver.rs
+++ b/capsules/src/app_flash_driver.rs
@@ -39,7 +39,7 @@ pub const DRIVER_NUM: usize = driver::NUM::AppFlash as usize;
 mod ro_allow {
     pub const BUFFER: usize = 0;
     /// The number of allow buffers the kernel stores for this grant
-    pub const COUNT: usize = 1;
+    pub const COUNT: u8 = 1;
 }
 
 #[derive(Default)]

--- a/capsules/src/ble_advertising_driver.rs
+++ b/capsules/src/ble_advertising_driver.rs
@@ -123,14 +123,14 @@ pub const DRIVER_NUM: usize = driver::NUM::BleAdvertising as usize;
 mod ro_allow {
     pub const ADV_DATA: usize = 0;
     /// The number of allow buffers the kernel stores for this grant
-    pub const COUNT: usize = 1;
+    pub const COUNT: u8 = 1;
 }
 
 /// Ids for read-write allow buffers
 mod rw_allow {
     pub const SCAN_BUFFER: usize = 0;
     /// The number of allow buffers the kernel stores for this grant
-    pub const COUNT: usize = 1;
+    pub const COUNT: u8 = 1;
 }
 
 /// Advertisement Buffer

--- a/capsules/src/console.rs
+++ b/capsules/src/console.rs
@@ -59,7 +59,7 @@ mod ro_allow {
     /// we still use allow number 1 now.
     pub const WRITE: usize = 1;
     /// The number of allow buffers the kernel stores for this grant
-    pub const COUNT: usize = 2;
+    pub const COUNT: u8 = 2;
 }
 
 /// Ids for read-write allow buffers
@@ -69,7 +69,7 @@ mod rw_allow {
     /// we still use allow number 1 now.
     pub const READ: usize = 1;
     /// The number of allow buffers the kernel stores for this grant
-    pub const COUNT: usize = 2;
+    pub const COUNT: u8 = 2;
 }
 
 #[derive(Default)]

--- a/capsules/src/crc.rs
+++ b/capsules/src/crc.rs
@@ -95,7 +95,7 @@ pub const DEFAULT_CRC_BUF_LENGTH: usize = 256;
 mod ro_allow {
     pub const BUFFER: usize = 0;
     /// The number of allow buffers the kernel stores for this grant
-    pub const COUNT: usize = 1;
+    pub const COUNT: u8 = 1;
 }
 
 /// An opaque value maintaining state for one application's request

--- a/capsules/src/ctap.rs
+++ b/capsules/src/ctap.rs
@@ -46,7 +46,7 @@ mod rw_allow {
     pub const RECV: usize = 0;
     pub const SEND: usize = 1;
     /// The number of allow buffers the kernel stores for this grant
-    pub const COUNT: usize = 2;
+    pub const COUNT: u8 = 2;
 }
 
 pub struct App {

--- a/capsules/src/hmac.rs
+++ b/capsules/src/hmac.rs
@@ -34,14 +34,14 @@ mod ro_allow {
     pub const DATA: usize = 1;
     pub const COMPARE: usize = 2;
     /// The number of allow buffers the kernel stores for this grant
-    pub const COUNT: usize = 3;
+    pub const COUNT: u8 = 3;
 }
 
 /// Ids for read-write allow buffers
 mod rw_allow {
     pub const DEST: usize = 2;
     /// The number of allow buffers the kernel stores for this grant
-    pub const COUNT: usize = 3;
+    pub const COUNT: u8 = 3;
 }
 
 use core::cell::Cell;

--- a/capsules/src/i2c_master.rs
+++ b/capsules/src/i2c_master.rs
@@ -17,7 +17,7 @@ pub const DRIVER_NUM: usize = driver::NUM::I2cMaster as usize;
 mod rw_allow {
     pub const BUFFER: usize = 1;
     /// The number of allow buffers the kernel stores for this grant
-    pub const COUNT: usize = 2;
+    pub const COUNT: u8 = 2;
 }
 
 #[derive(Default)]

--- a/capsules/src/i2c_master_slave_driver.rs
+++ b/capsules/src/i2c_master_slave_driver.rs
@@ -35,7 +35,7 @@ mod ro_allow {
     pub const MASTER_TX: usize = 0;
     pub const SLAVE_TX: usize = 2;
     /// The number of allow buffers the kernel stores for this grant
-    pub const COUNT: usize = 3;
+    pub const COUNT: u8 = 3;
 }
 
 /// Ids for read-write allow buffers
@@ -43,7 +43,7 @@ mod rw_allow {
     pub const MASTER_RX: usize = 1;
     pub const SLAVE_RX: usize = 3;
     /// The number of allow buffers the kernel stores for this grant
-    pub const COUNT: usize = 4;
+    pub const COUNT: u8 = 4;
 }
 
 #[derive(Default)]

--- a/capsules/src/ieee802154/driver.rs
+++ b/capsules/src/ieee802154/driver.rs
@@ -27,7 +27,7 @@ const MAX_KEYS: usize = 4;
 mod ro_allow {
     pub const WRITE: usize = 0;
     /// The number of allow buffers the kernel stores for this grant
-    pub const COUNT: usize = 1;
+    pub const COUNT: u8 = 1;
 }
 
 /// Ids for read-write allow buffers
@@ -35,7 +35,7 @@ mod rw_allow {
     pub const READ: usize = 0;
     pub const CFG: usize = 1;
     /// The number of allow buffers the kernel stores for this grant
-    pub const COUNT: usize = 2;
+    pub const COUNT: u8 = 2;
 }
 
 use crate::driver;

--- a/capsules/src/kv_driver.rs
+++ b/capsules/src/kv_driver.rs
@@ -22,21 +22,21 @@ mod ro_allow {
     // input value
     pub const VALUE: usize = 1;
     /// The number of allow buffers the kernel stores for this grant
-    pub const COUNT: usize = 2;
+    pub const COUNT: u8 = 2;
 }
 
 /// Ids for read-write allow buffers
 mod rw_allow {
     pub const VALUE: usize = 0;
     /// The number of allow buffers the kernel stores for this grant
-    pub const COUNT: usize = 1;
+    pub const COUNT: u8 = 1;
 }
 
 /// Ids for upcalls
 mod upcalls {
     pub const VALUE: usize = 0;
     /// The number of allow buffers the kernel stores for this grant
-    pub const COUNT: usize = 1;
+    pub const COUNT: u8 = 1;
 }
 
 pub struct KVSystemDriver<

--- a/capsules/src/net/udp/driver.rs
+++ b/capsules/src/net/udp/driver.rs
@@ -38,7 +38,7 @@ pub const DRIVER_NUM: usize = driver::NUM::Udp as usize;
 mod ro_allow {
     pub const WRITE: usize = 0;
     /// The number of allow buffers the kernel stores for this grant
-    pub const COUNT: usize = 1;
+    pub const COUNT: u8 = 1;
 }
 
 /// Ids for read-write allow buffers
@@ -47,7 +47,7 @@ mod rw_allow {
     pub const CFG: usize = 1;
     pub const RX_CFG: usize = 2;
     /// The number of allow buffers the kernel stores for this grant
-    pub const COUNT: usize = 3;
+    pub const COUNT: u8 = 3;
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]

--- a/capsules/src/nonvolatile_storage_driver.rs
+++ b/capsules/src/nonvolatile_storage_driver.rs
@@ -72,14 +72,14 @@ pub const DRIVER_NUM: usize = driver::NUM::NvmStorage as usize;
 mod ro_allow {
     pub const WRITE: usize = 0;
     /// The number of allow buffers the kernel stores for this grant
-    pub const COUNT: usize = 1;
+    pub const COUNT: u8 = 1;
 }
 
 /// Ids for read-write allow buffers
 mod rw_allow {
     pub const READ: usize = 0;
     /// The number of allow buffers the kernel stores for this grant
-    pub const COUNT: usize = 1;
+    pub const COUNT: u8 = 1;
 }
 
 pub static mut BUFFER: [u8; 512] = [0; 512];

--- a/capsules/src/nrf51822_serialization.rs
+++ b/capsules/src/nrf51822_serialization.rs
@@ -38,14 +38,14 @@ pub const DRIVER_NUM: usize = driver::NUM::Nrf51822Serialization as usize;
 mod ro_allow {
     pub const TX: usize = 0;
     /// The number of allow buffers the kernel stores for this grant
-    pub const COUNT: usize = 1;
+    pub const COUNT: u8 = 1;
 }
 
 /// Ids for read-write allow buffers
 mod rw_allow {
     pub const RX: usize = 0;
     /// The number of allow buffers the kernel stores for this grant
-    pub const COUNT: usize = 1;
+    pub const COUNT: u8 = 1;
 }
 
 #[derive(Default)]

--- a/capsules/src/rng.rs
+++ b/capsules/src/rng.rs
@@ -40,7 +40,7 @@ pub const DRIVER_NUM: usize = driver::NUM::Rng as usize;
 mod rw_allow {
     pub const BUFFER: usize = 0;
     /// The number of allow buffers the kernel stores for this grant
-    pub const COUNT: usize = 1;
+    pub const COUNT: u8 = 1;
 }
 
 #[derive(Default)]

--- a/capsules/src/screen.rs
+++ b/capsules/src/screen.rs
@@ -29,7 +29,7 @@ pub const DRIVER_NUM: usize = driver::NUM::Screen as usize;
 mod ro_allow {
     pub const SHARED: usize = 0;
     /// The number of allow buffers the kernel stores for this grant
-    pub const COUNT: usize = 1;
+    pub const COUNT: u8 = 1;
 }
 
 fn screen_rotation_from(screen_rotation: usize) -> Option<ScreenRotation> {

--- a/capsules/src/sdcard.rs
+++ b/capsules/src/sdcard.rs
@@ -81,14 +81,14 @@ pub const DRIVER_NUM: usize = driver::NUM::SdCard as usize;
 mod ro_allow {
     pub const WRITE: usize = 0;
     /// The number of allow buffers the kernel stores for this grant
-    pub const COUNT: usize = 1;
+    pub const COUNT: u8 = 1;
 }
 
 /// Ids for read-write allow buffers
 mod rw_allow {
     pub const READ: usize = 0;
     /// The number of allow buffers the kernel stores for this grant
-    pub const COUNT: usize = 1;
+    pub const COUNT: u8 = 1;
 }
 
 /// Buffers used for SD card transactions, assigned in board `main.rs` files

--- a/capsules/src/sha.rs
+++ b/capsules/src/sha.rs
@@ -34,14 +34,14 @@ mod ro_allow {
     pub const DATA: usize = 1;
     pub const COMPARE: usize = 2;
     /// The number of allow buffers the kernel stores for this grant
-    pub const COUNT: usize = 3;
+    pub const COUNT: u8 = 3;
 }
 
 /// Ids for read-write allow buffers
 mod rw_allow {
     pub const DEST: usize = 2;
     /// The number of allow buffers the kernel stores for this grant
-    pub const COUNT: usize = 3;
+    pub const COUNT: u8 = 3;
 }
 
 use core::cell::Cell;

--- a/capsules/src/spi_controller.rs
+++ b/capsules/src/spi_controller.rs
@@ -21,14 +21,14 @@ pub const DRIVER_NUM: usize = driver::NUM::Spi as usize;
 mod ro_allow {
     pub const WRITE: usize = 0;
     /// The number of allow buffers the kernel stores for this grant
-    pub const COUNT: usize = 1;
+    pub const COUNT: u8 = 1;
 }
 
 /// Ids for read-write allow buffers
 mod rw_allow {
     pub const READ: usize = 0;
     /// The number of allow buffers the kernel stores for this grant
-    pub const COUNT: usize = 1;
+    pub const COUNT: u8 = 1;
 }
 
 /// Suggested length for the Spi read and write buffer

--- a/capsules/src/spi_peripheral.rs
+++ b/capsules/src/spi_peripheral.rs
@@ -21,14 +21,14 @@ pub const DRIVER_NUM: usize = driver::NUM::SpiPeripheral as usize;
 mod ro_allow {
     pub const WRITE: usize = 0;
     /// The number of allow buffers the kernel stores for this grant
-    pub const COUNT: usize = 1;
+    pub const COUNT: u8 = 1;
 }
 
 /// Ids for read-write allow buffers
 mod rw_allow {
     pub const READ: usize = 0;
     /// The number of allow buffers the kernel stores for this grant
-    pub const COUNT: usize = 1;
+    pub const COUNT: u8 = 1;
 }
 
 /// Suggested length for the SPI read and write buffer

--- a/capsules/src/symmetric_encryption/aes.rs
+++ b/capsules/src/symmetric_encryption/aes.rs
@@ -21,14 +21,14 @@ mod ro_allow {
     pub const IV: usize = 1;
     pub const SOURCE: usize = 2;
     /// The number of allow buffers the kernel stores for this grant
-    pub const COUNT: usize = 3;
+    pub const COUNT: u8 = 3;
 }
 
 /// Ids for read-write allow buffers
 mod rw_allow {
     pub const DEST: usize = 0;
     /// The number of allow buffers the kernel stores for this grant
-    pub const COUNT: usize = 1;
+    pub const COUNT: u8 = 1;
 }
 
 pub struct AesDriver<'a, A: AES128<'a> + AES128CCM<'static>> {

--- a/capsules/src/text_screen.rs
+++ b/capsules/src/text_screen.rs
@@ -29,7 +29,7 @@ pub const DRIVER_NUM: usize = driver::NUM::TextScreen as usize;
 mod ro_allow {
     pub const SHARED: usize = 0;
     /// The number of allow buffers the kernel stores for this grant
-    pub const COUNT: usize = 1;
+    pub const COUNT: u8 = 1;
 }
 
 #[derive(Clone, Copy, PartialEq)]

--- a/capsules/src/touch.rs
+++ b/capsules/src/touch.rs
@@ -37,7 +37,7 @@ mod rw_allow {
     // | Touch 0                                                                       | Touch 1 ...
     pub const EVENTS: usize = 2;
     /// The number of allow buffers the kernel stores for this grant
-    pub const COUNT: usize = 3;
+    pub const COUNT: u8 = 3;
 }
 
 fn touch_status_to_number(status: &TouchStatus) -> usize {

--- a/kernel/src/grant.rs
+++ b/kernel/src/grant.rs
@@ -277,8 +277,9 @@ impl KernelManagedLayout {
     ///
     /// # Safety
     ///
-    /// The incoming base pointer must be well aligned but cannot point to
-    /// initialized data. There must not be any other `KernelManagedLayout` for
+    /// The incoming base pointer must be well aligned and reference enough
+    /// memory to hold the entire kernel managed grant structure. There must
+    /// not be any other `KernelManagedLayout` for
     /// the given `base_ptr` at the same time, otherwise multiple mutable
     /// references to the same upcall/allow slices could be created.
     unsafe fn initialize_from_counts(
@@ -323,7 +324,7 @@ impl KernelManagedLayout {
         grant_t_align: GrantDataAlign,
     ) -> usize {
         let kernel_managed_size = size_of::<usize>()
-            + (upcalls_num.0 as usize * size_of::<SavedUpcall>())
+            + upcalls_num.0 as usize * size_of::<SavedUpcall>()
             + allow_ro_num.0 as usize * size_of::<SavedAllowRo>()
             + allow_rw_num.0 as usize * size_of::<SavedAllowRw>();
         // We know that grant_t_align is a power of 2, so we can make a mask

--- a/kernel/src/grant.rs
+++ b/kernel/src/grant.rs
@@ -183,37 +183,40 @@ impl<const NUM: usize> AllowRwSize for AllowRwCount<NUM> {
 /// ```text,ignore
 /// 0x003FFC8  ┌────────────────────────────────────┐
 ///            │   T                                |
-/// 0x003FFxx  ├  ───────────────────────── ┐       |
-///            │   Padding (ensure T aligns)|       |
-/// 0x003FF44  ├  ───────────────────────── |       |
-///            │   SavedAllowRwN            | K     |
+/// 0x003FFxx  ├  ───────────────────────── ┐ K     |
+///            │   Padding (ensure T aligns)| e     |
+/// 0x003FF44  ├  ───────────────────────── | r     |
+///            │   SavedAllowRwN            | n     |
 ///            │   ...                      | e     | G
-///            │   SavedAllowRw1            | r     | r
-///            │   SavedAllowRw0            | n     | a
-/// 0x003FF44  ├  ───────────────────────── | e     | n
-///            │   NumAllowRw (usize)       | l     | t
-/// 0x003FF40  ├  ───────────────────────── |       |
-///            │   SavedAllowRoN            | O     | M
-///            │   ...                      | w     | e
-///            │   SavedAllowRo1            | n     | m
-///            │   SavedAllowRo0            | e     | o
-/// 0x003FF30  ├  ───────────────────────── | d     | r
-///            │   NumAllowRo (usize)       |       | y
-/// 0x003FF2C  ├  ───────────────────────── | D     | 1
-///            │   SavedUpcallN             | a     |
-///            │   ...                      | t     |
-///            │   SavedUpcall1             | a     |
-///            │   SavedUpcall0             |       |
+///            │   SavedAllowRw1            | l     | r
+///            │   SavedAllowRw0            |       | a
+/// 0x003FF44  ├  ───────────────────────── | O     | n
+///            │   SavedAllowRoN            | w     | t
+///            │   ...                      | n     |
+///            │   SavedAllowRo1            | e     | M
+///            │   SavedAllowRo0            | d     | e
+/// 0x003FF30  ├  ───────────────────────── |       | m
+///            │   SavedUpcallN             | D     | o
+///            │   ...                      | a     | r
+///            │   SavedUpcall1             | t     | y
+///            │   SavedUpcall0             | a     |
 /// 0x003FF24  ├  ───────────────────────── |       |
-///            │   NumUpcalls (usize)       |       |
+///            │   Counters (usize)         |       |
 /// 0x003FF20  └────────────────────────────────────┘
 /// ```
+///
+/// The counters structure is composed as:
+///
+/// ```text,ignore
+/// 0             1             2             3         bytes
+/// |-------------|-------------|-------------|-------------|
+/// | # Upcalls   | # RO Allows | # RW Allows | [unused]    |
+/// |-------------|-------------|-------------|-------------|
+/// ```
 struct KernelManagedLayout {
-    upcalls_num: *mut usize,
+    counters_ptr: *mut usize,
     upcalls_array: *mut SavedUpcall,
-    allow_ro_num: *mut usize,
     allow_ro_array: *mut SavedAllowRo,
-    allow_rw_num: *mut usize,
     allow_rw_array: *mut SavedAllowRw,
 }
 
@@ -237,66 +240,81 @@ struct GrantDataSize(usize);
 struct GrantDataAlign(usize);
 
 impl KernelManagedLayout {
-    /// Reads the specified pointer as the base of the kernel owned grant
-    /// region.
+    /// Reads the specified pointer as the base of the kernel owned grant region
+    /// that has previously been initialized.
     ///
     /// # Safety
     ///
     /// The incoming base pointer must be well aligned and already contain
-    /// initialized data in the expected form.
+    /// initialized data in the expected form. There must not be any other
+    /// `KernelManagedLayout` for the given `base_ptr` at the same time,
+    /// otherwise multiple mutable references to the same upcall/allow slices
+    /// could be created.
     unsafe fn read_from_base(base_ptr: *mut u8) -> Self {
-        let upcalls_num = base_ptr as *mut usize;
-        let upcalls_array = upcalls_num.add(1) as *mut SavedUpcall;
+        let counters_ptr = base_ptr as *mut usize;
+        let counters_val = counters_ptr.read();
 
-        let allow_ro_num = upcalls_array.add(upcalls_num.read()) as *mut usize;
-        let allow_ro_array = allow_ro_num.add(1) as *mut SavedAllowRo;
+        // Parse the counters field for each of the fields
+        let upcalls_num = (counters_val & 0xFF) as u8;
+        let allow_ro_num = ((counters_val >> 8) & 0xFF) as u8;
 
-        let allow_rw_num = allow_ro_array.add(allow_ro_num.read()) as *mut usize;
-        let allow_rw_array = allow_rw_num.add(1) as *mut SavedAllowRw;
+        // Skip over the counter usize, then the stored array of `SavedAllowRo`
+        // items and `SavedAllowRw` items.
+        let upcalls_array = counters_ptr.add(1) as *mut SavedUpcall;
+        let allow_ro_array = upcalls_array.add(upcalls_num as usize) as *mut SavedAllowRo;
+        let allow_rw_array = allow_ro_array.add(allow_ro_num as usize) as *mut SavedAllowRw;
 
         Self {
-            upcalls_num,
+            counters_ptr,
             upcalls_array,
-            allow_ro_num,
             allow_ro_array,
-            allow_rw_num,
             allow_rw_array,
         }
     }
 
-    /// Creates a layout from the specified pointer and lengths of arrays.
+    /// Creates a layout from the specified pointer and lengths of arrays and
+    /// initializes the kernel owned portion of the layout.
     ///
     /// # Safety
     ///
-    /// The incoming base pointer must be well aligned but does not need to
-    /// point to initialized data.
-    unsafe fn from_counts(
+    /// The incoming base pointer must be well aligned but cannot point to
+    /// initialized data. There must not be any other `KernelManagedLayout` for
+    /// the given `base_ptr` at the same time, otherwise multiple mutable
+    /// references to the same upcall/allow slices could be created.
+    unsafe fn initialize_from_counts(
         base_ptr: *mut u8,
         upcalls_num_val: UpcallItems,
         allow_ro_num_val: AllowRoItems,
+        allow_rw_num_val: AllowRwItems,
     ) -> Self {
-        let upcalls_num = base_ptr as *mut usize;
-        let upcalls_array = upcalls_num.add(1) as *mut SavedUpcall;
+        let counters_ptr = base_ptr as *mut usize;
 
-        let allow_ro_num = upcalls_array.add(upcalls_num_val.0) as *mut usize;
-        let allow_ro_array = allow_ro_num.add(1) as *mut SavedAllowRo;
+        // Create the counters usize value by correctly packing the various
+        // counts into 8 bit fields.
+        let counter = (upcalls_num_val.0 & 0xFF)
+            | ((allow_ro_num_val.0 & 0xFF) << 8)
+            | ((allow_rw_num_val.0 & 0xFF) << 16);
 
-        let allow_rw_num = allow_ro_array.add(allow_ro_num_val.0) as *mut usize;
-        let allow_rw_array = allow_rw_num.add(1) as *mut SavedAllowRw;
+        let upcalls_array = counters_ptr.add(1) as *mut SavedUpcall;
+        let allow_ro_array = upcalls_array.add(upcalls_num_val.0) as *mut SavedAllowRo;
+        let allow_rw_array = allow_ro_array.add(allow_ro_num_val.0) as *mut SavedAllowRw;
+
+        counters_ptr.write(counter);
+        write_default_array(upcalls_array, upcalls_num_val.0);
+        write_default_array(allow_ro_array, allow_ro_num_val.0);
+        write_default_array(allow_rw_array, allow_rw_num_val.0);
 
         Self {
-            upcalls_num,
+            counters_ptr,
             upcalls_array,
-            allow_ro_num,
             allow_ro_array,
-            allow_rw_num,
             allow_rw_array,
         }
     }
 
-    /// Returns the entire grant size including the kernel own memory, padding,
-    /// and data for T. Requires that grant_t_align be a power of 2, which is
-    /// guaranteed from align_of rust calls.
+    /// Returns the entire grant size including the kernel owned memory,
+    /// padding, and data for T. Requires that grant_t_align be a power of 2,
+    /// which is guaranteed from align_of rust calls.
     fn grant_size(
         upcalls_num: UpcallItems,
         allow_ro_num: AllowRoItems,
@@ -304,14 +322,14 @@ impl KernelManagedLayout {
         grant_t_size: GrantDataSize,
         grant_t_align: GrantDataAlign,
     ) -> usize {
-        let kernel_managed_size = 3 * size_of::<usize>()
+        let kernel_managed_size = 1 * size_of::<usize>()
             + upcalls_num.0 * size_of::<SavedUpcall>()
             + allow_ro_num.0 * size_of::<SavedAllowRo>()
             + allow_rw_num.0 * size_of::<SavedAllowRw>();
         // We know that grant_t_align is a power of 2, so we can make a mask
         // that will save only the remainder bits.
         let grant_t_align_mask = grant_t_align.0 - 1;
-        // Determine padding to get to the next multipe of grant_t_align by
+        // Determine padding to get to the next multiple of grant_t_align by
         // taking the remainder and subtracting that from the alignment, then
         // ensuring a full alignment value maps to 0.
         let padding =
@@ -344,6 +362,92 @@ impl KernelManagedLayout {
         // grant region. Caller must verify that memory is accessible and well
         // aligned to T.
         NonNull::new_unchecked(base_ptr.add(grant_size - grant_t_size.0))
+    }
+
+    /// Read an 8 bit value from the counter field offset by the specified
+    /// number of bits. This is a helper function for reading the counter field.
+    fn get_counter_offset(&self, offset_bits: usize) -> usize {
+        // # Safety
+        //
+        // Creating a `KernelManagedLayout` object requires that the pointers
+        // are well aligned and point to valid memory.
+        let counters_val = unsafe { self.counters_ptr.read() };
+        (counters_val >> offset_bits) & 0xFF
+    }
+
+    /// Return the number of upcalls stored by the core kernel for this grant.
+    fn get_upcalls_number(&self) -> usize {
+        self.get_counter_offset(0)
+    }
+
+    /// Return the number of read-only allow buffers stored by the core kernel
+    /// for this grant.
+    fn get_allow_ro_number(&self) -> usize {
+        self.get_counter_offset(8)
+    }
+
+    /// Return the number of read-write allow buffers stored by the core kernel
+    /// for this grant.
+    fn get_allow_rw_number(&self) -> usize {
+        self.get_counter_offset(16)
+    }
+
+    /// Return mutable access to the slice of stored upcalls for this grant.
+    /// This is necessary for storing a new upcall.
+    fn get_upcalls_slice(&mut self) -> &mut [SavedUpcall] {
+        // # Safety
+        //
+        // Creating a `KernelManagedLayout` object ensures that the pointer to
+        // the upcall array is valid.
+        unsafe { slice::from_raw_parts_mut(self.upcalls_array, self.get_upcalls_number()) }
+    }
+
+    /// Return mutable access to the slice of stored read-only allow buffers for
+    /// this grant. This is necessary for storing a new read-only allow.
+    fn get_allow_ro_slice(&mut self) -> &mut [SavedAllowRo] {
+        // # Safety
+        //
+        // Creating a `KernelManagedLayout` object ensures that the pointer to
+        // the RO allow array is valid.
+        unsafe { slice::from_raw_parts_mut(self.allow_ro_array, self.get_allow_ro_number()) }
+    }
+
+    /// Return mutable access to the slice of stored read-write allow buffers
+    /// for this grant. This is necessary for storing a new read-write allow.
+    fn get_allow_rw_slice(&mut self) -> &mut [SavedAllowRw] {
+        // # Safety
+        //
+        // Creating a `KernelManagedLayout` object ensures that the pointer to
+        // the RW allow array is valid.
+        unsafe { slice::from_raw_parts_mut(self.allow_rw_array, self.get_allow_rw_number()) }
+    }
+
+    /// Return slices to the kernel managed upcalls and allow buffers. This
+    /// permits using upcalls and allow buffers when a capsule is accessing a
+    /// grant.
+    fn get_resource_slices(&self) -> (&[SavedUpcall], &[SavedAllowRo], &[SavedAllowRw]) {
+        // # Safety
+        //
+        // Creating a `KernelManagedLayout` object ensures that the pointer to
+        // the upcall array is valid.
+        let upcall_slice =
+            unsafe { slice::from_raw_parts(self.upcalls_array, self.get_upcalls_number()) };
+
+        // # Safety
+        //
+        // Creating a `KernelManagedLayout` object ensures that the pointer to
+        // the RO allow array is valid.
+        let allow_ro_slice =
+            unsafe { slice::from_raw_parts(self.allow_ro_array, self.get_allow_ro_number()) };
+
+        // # Safety
+        //
+        // Creating a `KernelManagedLayout` object ensures that the pointer to
+        // the RW allow array is valid.
+        let allow_rw_slice =
+            unsafe { slice::from_raw_parts(self.allow_rw_array, self.get_allow_rw_number()) };
+
+        (upcall_slice, allow_ro_slice, allow_rw_slice)
     }
 }
 
@@ -654,7 +758,7 @@ pub(crate) fn subscribe(
     upcall: Upcall,
 ) -> Result<Upcall, (Upcall, ErrorCode)> {
     // Enter grant and keep it open until _grant_open goes out of scope.
-    let (_grant_open, layout) =
+    let (_grant_open, mut layout) =
         match enter_grant_kernel_managed(process, upcall.upcall_id.driver_num) {
             Ok(val) => val,
             Err(e) => return Err((upcall, e)),
@@ -668,8 +772,7 @@ pub(crate) fn subscribe(
     // because we were able to enter the grant the grant region must be valid
     // and initialized. We are also holding the grant open until `_grant_open`
     // goes out of scope.
-    let saved_upcalls_slice =
-        unsafe { slice::from_raw_parts_mut(layout.upcalls_array, layout.upcalls_num.read()) };
+    let saved_upcalls_slice = layout.get_upcalls_slice();
 
     // Index into the saved upcall slice to get the old upcall. Use .get in case
     // userspace passed us a bad subscribe number.
@@ -704,7 +807,7 @@ pub(crate) fn allow_ro(
     buffer: ReadOnlyProcessBuffer,
 ) -> Result<ReadOnlyProcessBuffer, (ReadOnlyProcessBuffer, ErrorCode)> {
     // Enter grant and keep it open until `_grant_open` goes out of scope.
-    let (_grant_open, layout) = match enter_grant_kernel_managed(process, driver_num) {
+    let (_grant_open, mut layout) = match enter_grant_kernel_managed(process, driver_num) {
         Ok(val) => val,
         Err(e) => return Err((buffer, e)),
     };
@@ -717,8 +820,7 @@ pub(crate) fn allow_ro(
     // because we were able to enter the grant the grant region must be valid
     // and initialized. We are also holding the grant open until _grant_open
     // goes out of scope.
-    let saved_allow_ro_slice =
-        unsafe { slice::from_raw_parts_mut(layout.allow_ro_array, layout.allow_ro_num.read()) };
+    let saved_allow_ro_slice = layout.get_allow_ro_slice();
 
     // Index into the saved slice to get the old value. Use .get in case
     // userspace passed us a bad allow number.
@@ -753,7 +855,7 @@ pub(crate) fn allow_rw(
     buffer: ReadWriteProcessBuffer,
 ) -> Result<ReadWriteProcessBuffer, (ReadWriteProcessBuffer, ErrorCode)> {
     // Enter grant and keep it open until `_grant_open` goes out of scope.
-    let (_grant_open, layout) = match enter_grant_kernel_managed(process, driver_num) {
+    let (_grant_open, mut layout) = match enter_grant_kernel_managed(process, driver_num) {
         Ok(val) => val,
         Err(e) => return Err((buffer, e)),
     };
@@ -766,8 +868,7 @@ pub(crate) fn allow_rw(
     // because we were able to enter the grant the grant region must be valid
     // and initialized. We are also holding the grant open until `_grant_open`
     // goes out of scope.
-    let saved_allow_rw_slice =
-        unsafe { slice::from_raw_parts_mut(layout.allow_rw_array, layout.allow_rw_num.read()) };
+    let saved_allow_rw_slice = layout.get_allow_rw_slice();
 
     // Index into the saved slice to get the old value. Use .get in case
     // userspace passed us a bad allow number.
@@ -920,23 +1021,20 @@ impl<'a, T: Default, Upcalls: UpcallSize, AllowROs: AllowRoSize, AllowRWs: Allow
                     //
                     // # Safety
                     //
-                    // For all below calls:
-                    // - The pointers are well aligned, yet do not have
-                    //   initialized data.
+                    // - The grant base pointer is well aligned, yet does not
+                    //   have initialized data.
                     // - The pointer points to a large enough space to correctly
                     //   write to is guaranteed by alloc of size
                     //   `KernelManagedLayout::grant_size`.
                     // - There are no proper rust references that map to these
-                    //   addresses either
+                    //   addresses.
                     unsafe {
-                        let layout =
-                            KernelManagedLayout::from_counts(grant_ptr, num_upcalls, num_allow_ros);
-                        layout.upcalls_num.write(num_upcalls.0);
-                        write_default_array(layout.upcalls_array, num_upcalls.0);
-                        layout.allow_ro_num.write(num_allow_ros.0);
-                        write_default_array(layout.allow_ro_array, num_allow_ros.0);
-                        layout.allow_rw_num.write(num_allow_rws.0);
-                        write_default_array(layout.allow_rw_array, num_allow_rws.0);
+                        let _layout = KernelManagedLayout::initialize_from_counts(
+                            grant_ptr,
+                            num_upcalls,
+                            num_allow_ros,
+                            num_allow_rws,
+                        );
                     }
 
                     // # Safety
@@ -1263,18 +1361,12 @@ impl<'a, T: Default, Upcalls: UpcallSize, AllowROs: AllowRoSize, AllowRWs: Allow
             grant_t_align,
         );
 
-        // Determine layout of entire grant alloc
+        // Parse layout of entire grant allocation using the known base pointer.
         //
         // # Safety
         //
-        // Grant pointer is well aligned and points to well initialized data
-        let layout = unsafe {
-            KernelManagedLayout::from_counts(
-                grant_ptr,
-                UpcallItems(Upcalls::COUNT),
-                AllowRoItems(AllowROs::COUNT),
-            )
-        };
+        // Grant pointer is well aligned and points to initialized data.
+        let layout = unsafe { KernelManagedLayout::read_from_base(grant_ptr) };
 
         // Get references to all of the saved upcall data.
         //
@@ -1282,20 +1374,16 @@ impl<'a, T: Default, Upcalls: UpcallSize, AllowROs: AllowRoSize, AllowRWs: Allow
         //
         // - Pointer is well aligned and initialized with data from Self::new()
         //   call.
-        // - Data will not be modify external while this immutable reference is
-        //   alive.
+        // - Data will not be modified externally while this immutable reference
+        //   is alive.
         // - Data is accessible for the entire duration of this immutable
         //   reference.
         // - No other mutable reference to this memory exists concurrently.
         //   Mutable reference to this memory are only created through the
         //   kernel in the syscall interface which is serialized in time with
         //   this call.
-        let saved_upcalls_slice =
-            unsafe { slice::from_raw_parts(layout.upcalls_array, Upcalls::COUNT) };
-        let saved_allow_ro_slice =
-            unsafe { slice::from_raw_parts(layout.allow_ro_array, AllowROs::COUNT) };
-        let saved_allow_rw_slice =
-            unsafe { slice::from_raw_parts(layout.allow_rw_array, AllowRWs::COUNT) };
+        let (saved_upcalls_slice, saved_allow_ro_slice, saved_allow_rw_slice) =
+            layout.get_resource_slices();
         let grant_data = unsafe {
             KernelManagedLayout::offset_of_grant_data_t(grant_ptr, alloc_size, grant_t_size)
                 .cast()

--- a/kernel/src/grant.rs
+++ b/kernel/src/grant.rs
@@ -483,7 +483,17 @@ impl<'a> EnteredGrantKernelManagedLayout<'a> {
 // Ensure that we leave the grant once this goes out of scope.
 impl Drop for EnteredGrantKernelManagedLayout<'_> {
     fn drop(&mut self) {
-        self.process.leave_grant(self.grant_num);
+        // ### Safety
+        //
+        // To safely call this function we must ensure that no references will
+        // exist to the grant once `leave_grant()` returns. Because using a
+        // `EnteredGrantKernelManagedLayout` object is the only only way we
+        // access the actual memory of a grant, and we are calling
+        // `leave_grant()` from its `drop()` method, we are sure there will be
+        // no remaining references to the grant.
+        unsafe {
+            self.process.leave_grant(self.grant_num);
+        }
     }
 }
 

--- a/kernel/src/ipc.rs
+++ b/kernel/src/ipc.rs
@@ -18,8 +18,8 @@ pub const DRIVER_NUM: usize = 0x10000;
 /// Ids for read-only allow buffers
 mod ro_allow {
     pub(super) const SEARCH: usize = 0;
-    /// The number of allow buffers the kernel stores for this grant
-    pub(super) const COUNT: usize = 1;
+    /// The number of allow buffers the kernel stores for this grant.
+    pub(super) const COUNT: u8 = 1;
 }
 
 /// Enum to mark which type of upcall is scheduled for the IPC mechanism.
@@ -38,7 +38,7 @@ pub enum IPCUpcallType {
 struct IPCData;
 
 /// The IPC mechanism struct.
-pub struct IPC<const NUM_PROCS: usize> {
+pub struct IPC<const NUM_PROCS: u8> {
     /// The grant regions for each process that holds the per-process IPC data.
     data: Grant<
         IPCData,
@@ -48,7 +48,7 @@ pub struct IPC<const NUM_PROCS: usize> {
     >,
 }
 
-impl<const NUM_PROCS: usize> IPC<NUM_PROCS> {
+impl<const NUM_PROCS: u8> IPC<NUM_PROCS> {
     pub fn new(
         kernel: &'static Kernel,
         driver_num: usize,
@@ -98,7 +98,7 @@ impl<const NUM_PROCS: usize> IPC<NUM_PROCS> {
     }
 }
 
-impl<const NUM_PROCS: usize> SyscallDriver for IPC<NUM_PROCS> {
+impl<const NUM_PROCS: u8> SyscallDriver for IPC<NUM_PROCS> {
     /// command is how notify() is implemented.
     /// Notifying an IPC service is done by setting client_or_svc to 0,
     /// and notifying an IPC client is done by setting client_or_svc to 1.

--- a/kernel/src/kernel.rs
+++ b/kernel/src/kernel.rs
@@ -435,7 +435,7 @@ impl Kernel {
     /// This function has one configuration option: `no_sleep`. If that argument
     /// is set to true, the kernel will never attempt to put the chip to sleep,
     /// and this function can be called again immediately.
-    pub fn kernel_loop_operation<KR: KernelResources<C>, C: Chip, const NUM_PROCS: usize>(
+    pub fn kernel_loop_operation<KR: KernelResources<C>, C: Chip, const NUM_PROCS: u8>(
         &self,
         resources: &KR,
         chip: &C,
@@ -504,7 +504,7 @@ impl Kernel {
     ///
     /// Most of the behavior of this loop is controlled by the `Scheduler`
     /// implementation in use.
-    pub fn kernel_loop<KR: KernelResources<C>, C: Chip, const NUM_PROCS: usize>(
+    pub fn kernel_loop<KR: KernelResources<C>, C: Chip, const NUM_PROCS: u8>(
         &self,
         resources: &KR,
         chip: &C,
@@ -548,7 +548,7 @@ impl Kernel {
     /// cooperatively). Notably, time spent in this function by the kernel,
     /// executing system calls or merely setting up the switch to/from
     /// userspace, is charged to the process.
-    fn do_process<KR: KernelResources<C>, C: Chip, const NUM_PROCS: usize>(
+    fn do_process<KR: KernelResources<C>, C: Chip, const NUM_PROCS: u8>(
         &self,
         resources: &KR,
         chip: &C,

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -514,7 +514,15 @@ pub trait Process {
     /// invalid, this function will do nothing. If the process is inactive then
     /// grants are invalid and are not entered or not entered, and this function
     /// will do nothing.
-    fn leave_grant(&self, grant_num: usize);
+    ///
+    /// ### Safety
+    ///
+    /// The caller must ensure that no references to the memory inside the grant
+    /// exist after calling `leave_grant()`. Otherwise, it would be possible to
+    /// effectively enter the grant twice (once using the existing reference,
+    /// once with a new call to `enter_grant()`) which breaks the memory safety
+    /// requirements of grants.
+    unsafe fn leave_grant(&self, grant_num: usize);
 
     /// Return the count of the number of allocated grant pointers if the
     /// process is active. This does not count custom grants. This is used

--- a/kernel/src/process_standard.rs
+++ b/kernel/src/process_standard.rs
@@ -868,7 +868,7 @@ impl<C: Chip> Process for ProcessStandard<'_, C> {
         Ok(custom_grant_address as *mut u8)
     }
 
-    fn leave_grant(&self, grant_num: usize) {
+    unsafe fn leave_grant(&self, grant_num: usize) {
         // Do not modify an inactive process.
         if !self.is_active() {
             return;


### PR DESCRIPTION
### Pull Request Overview

Because the kernel manages the upcall array, read-only allow array, and read-write allow array for grants, it must keep track of the maximum number of upcalls and each allow type that there is allocated space for. This is necessary so the kernel can check on each allow() and subscribe() syscall if there is sufficient room to store the process-provided upcall or allowed buffer. These max numbers are also contained in the capsule that is using the grant, but the kernel has no access to those values when a syscall happens.

Currently, these maximum allocation number (or in practice array lengths) are each stored as a `usize` in the grant allocation. That means we use 12 bytes of RAM per allocated grant to store the array lengths. On a complex app (like the hail app), which uses 12 grant regions, that adds up to 144 bytes of memory.

However, it's hard to imagine a grant needing to store billions of upcalls or shared buffers. So, this PR merges the array lengths into a single `usize`, granting 8 bits to each value. The structure now looks like:

```text,ignore
0x003FFC8  ┌────────────────────────────────────┐
           │   T                                |
0x003FFxx  ├  ───────────────────────── ┐ K     |
           │   Padding (ensure T aligns)| e     |
0x003FF44  ├  ───────────────────────── | r     |
           │   SavedAllowRwN            | n     |
           │   ...                      | e     | G
           │   SavedAllowRw1            | l     | r
           │   SavedAllowRw0            |       | a
0x003FF44  ├  ───────────────────────── | O     | n
           │   SavedAllowRoN            | w     | t
           │   ...                      | n     |
           │   SavedAllowRo1            | e     | M
           │   SavedAllowRo0            | d     | e
0x003FF30  ├  ───────────────────────── |       | m
           │   SavedUpcallN             | D     | o
           │   ...                      | a     | r
           │   SavedUpcall1             | t     | y
           │   SavedUpcall0             | a     |
0x003FF24  ├  ───────────────────────── |       |
           │   Counters (usize)         |       |
0x003FF20  └────────────────────────────────────┘


Counters:

0             1             2             3         bytes
|-------------|-------------|-------------|-------------|
| # Upcalls   | # RO Allows | # RW Allows | [unused]    |
|-------------|-------------|-------------|-------------|
```

This reduces the RAM overhead per grant by 2/3, since only one `usize` is used rather than three.

#### Use of `u8`

Since the number of upcalls, read-only allows, and read-write allows per grant is now capped at 256, I changed the type for capsules to express the number they need from a `usize` to a `u8`. This causes many changes that are pretty inconsequential, but lead to a larger diff.

This change does propagate up to boards, however, because of how IPC is implemented. The max number of processes on the board is used to set the allow lengths. Maybe someone can take a look and see if there is a better way to handle this?




### Testing Strategy

hail app on hail.


### TODO or Help Wanted

I'm curious if there is a better way to handle the switch to u8 for IPC.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
