### PR TITLE
opentitan: verilator: fixup test build

### DIFF
--- a/boards/opentitan/earlgrey-cw310/Makefile
+++ b/boards/opentitan/earlgrey-cw310/Makefile
@@ -85,6 +85,5 @@ test-verilator:
 	mkdir -p $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/
 	$(Q)cp test_layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/layout.ld
 	$(Q)cp ../../kernel_layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/
-
-	$(Q)RUSTFLAGS="$(RUSTC_FLAGS_TOCK)" VERILATOR="yes" $(CARGO) test $(CARGO_FLAGS_TOCK_NO_BUILD_STD) $(NO_RUN) --bin $(PLATFORM) --release --features=hardware_tests
+	$(Q)RUSTFLAGS="$(RUSTC_FLAGS_TOCK)" VERILATOR="yes" OBJCOPY=${OBJCOPY} $(CARGO) test $(CARGO_FLAGS_TOCK_NO_BUILD_STD) $(NO_RUN) --bin $(PLATFORM) --release --features=hardware_tests --features sim_verilator
 	$(Q)rm $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/layout.ld

--- a/boards/opentitan/earlgrey-cw310/run.sh
+++ b/boards/opentitan/earlgrey-cw310/run.sh
@@ -1,18 +1,31 @@
 #!/bin/bash
 
+BUILD_DIR="verilator_build/"
+
 if [[ "${VERILATOR}" == "yes" ]]; then
-	${OBJCOPY} --output-target=binary --strip-sections -S --remove-section .apps "${1}" binary
-	srec_cat binary \
+		if [ -d "$BUILD_DIR" ]; then
+			# Cleanup before we build again
+			printf "\n[CW-130: Verilator Tests]: Cleaning up verilator_build...\n\n"
+			rm -R "$BUILD_DIR"/*
+		else
+			printf "\n[CW-130: Verilator Tests]: Setting up verilator_build...\n\n"
+			mkdir "$BUILD_DIR"
+		fi
+	# Copy in and covert from cargo test output to binary
+	${OBJCOPY} ${1} "$BUILD_DIR"/earlgrey-cw310-tests.elf
+	${OBJCOPY} --output-target=binary "$BUILD_DIR"/earlgrey-cw310-tests.elf "$BUILD_DIR"/earlgrey-cw310-tests.bin
+	# Create VMEM file from test binary
+	srec_cat "$BUILD_DIR"/earlgrey-cw310-tests.bin\
 		--binary --offset 0 --byte-swap 8 --fill 0xff \
-		-within binary \
-		-binary -range-pad 8 --output binary.64.vmem --vmem 64
+		-within "$BUILD_DIR"/earlgrey-cw310-tests.bin\
+		-binary -range-pad 8 --output "$BUILD_DIR"/binary.64.vmem --vmem 64
 	${OPENTITAN_TREE}/build/lowrisc_dv_chip_verilator_sim_0.1/sim-verilator/Vchip_sim_tb \
 		--meminit=rom,${OPENTITAN_TREE}/build-out/sw/device/lib/testing/test_rom/test_rom_sim_verilator.scr.39.vmem \
-		--meminit=flash,./binary.64.vmem \
+		--meminit=flash,./"$BUILD_DIR"/binary.64.vmem \
 		--meminit=otp,${OPENTITAN_TREE}/build-out/sw/device/otp_img/otp_img_sim_verilator.vmem
 elif [[ "${OPENTITAN_TREE}" != "" ]]; then
-	riscv64-linux-gnu-objcopy --update-section .apps=${APP} ${1} bundle.elf
-	riscv64-linux-gnu-objcopy --output-target=binary bundle.elf binary
+	${OBJCOPY} --update-section .apps=${APP} ${1} bundle.elf
+	${OBJCOPY} --output-target=binary bundle.elf binary
 	${OPENTITAN_TREE}/util/fpga/cw310_loader.py --firmware binary
 else
 	../../../tools/qemu/build/qemu-system-riscv32 -M opentitan -bios ../../../tools/qemu-runner/opentitan-boot-rom.elf -nographic -serial stdio -monitor none -semihosting -kernel "${1}"

--- a/boards/opentitan/earlgrey-nexysvideo/Makefile
+++ b/boards/opentitan/earlgrey-nexysvideo/Makefile
@@ -76,6 +76,5 @@ test-verilator:
 	mkdir -p $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/
 	$(Q)cp test_layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/layout.ld
 	$(Q)cp ../../kernel_layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/
-
-	$(Q)RUSTFLAGS="$(RUSTC_FLAGS_TOCK)" VERILATOR="yes" $(CARGO) test $(CARGO_FLAGS_TOCK_NO_BUILD_STD) $(NO_RUN) --bin $(PLATFORM) --release --features=hardware_tests
+	$(Q)RUSTFLAGS="$(RUSTC_FLAGS_TOCK)" VERILATOR="yes" OBJCOPY=${OBJCOPY} $(CARGO) test $(CARGO_FLAGS_TOCK_NO_BUILD_STD) $(NO_RUN) --bin $(PLATFORM) --release --features=hardware_tests --features sim_verilator
 	$(Q)rm $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/layout.ld

--- a/boards/opentitan/earlgrey-nexysvideo/run.sh
+++ b/boards/opentitan/earlgrey-nexysvideo/run.sh
@@ -1,17 +1,30 @@
 #!/bin/bash
 
+BUILD_DIR="verilator_build/"
+
 if [[ "${VERILATOR}" == "yes" ]]; then
-	${OBJCOPY} --output-target=binary --strip-sections -S --remove-section .apps "${1}" binary
-	srec_cat binary \
+		if [ -d "$BUILD_DIR" ]; then
+			# Cleanup before we build again
+			printf "\n[NexysVideo: Verilator Tests] Cleaning up verilator_build...\n\n"
+			rm -R "$BUILD_DIR"/*
+		else
+			printf "\n[NexysVideo: Verilator Tests] Setting up verilator_build...\n\n"
+			mkdir "$BUILD_DIR"
+		fi
+	# Copy in and covert from cargo test output to binary
+	${OBJCOPY} ${1} "$BUILD_DIR"/earlgrey-cw310-tests.elf
+	${OBJCOPY} --output-target=binary "$BUILD_DIR"/earlgrey-cw310-tests.elf "$BUILD_DIR"/earlgrey-cw310-tests.bin
+	# Create VMEM file from test binary
+	srec_cat "$BUILD_DIR"/earlgrey-cw310-tests.bin\
 		--binary --offset 0 --byte-swap 8 --fill 0xff \
-		-within binary \
-		-binary -range-pad 8 --output binary.64.vmem --vmem 64
+		-within "$BUILD_DIR"/earlgrey-cw310-tests.bin\
+		-binary -range-pad 8 --output "$BUILD_DIR"/binary.64.vmem --vmem 64
 	${OPENTITAN_TREE}/build/lowrisc_dv_chip_verilator_sim_0.1/sim-verilator/Vchip_sim_tb \
 		--meminit=rom,${OPENTITAN_TREE}/build-out/sw/device/lib/testing/test_rom/test_rom_sim_verilator.scr.39.vmem \
-		--meminit=flash,./binary.64.vmem \
+		--meminit=flash,./"$BUILD_DIR"/binary.64.vmem \
 		--meminit=otp,${OPENTITAN_TREE}/build-out/sw/device/otp_img/otp_img_sim_verilator.vmem
 elif [[ "${OPENTITAN_TREE}" != "" ]]; then
-	riscv64-linux-gnu-objcopy --output-target=binary ${1} binary
+	${OBJCOPY} --output-target=binary ${1} binary
 	${OPENTITAN_TREE}/build-out/sw/host/spiflash/spiflash --dev-id=0403:6010 --input=binary
 else
 	../../../tools/qemu/build/qemu-system-riscv32 -M opentitan -bios ../../../tools/qemu-runner/opentitan-boot-rom.elf -nographic -serial stdio -monitor none -semihosting -kernel "${1}"


### PR DESCRIPTION
### Pull Request Overview

Fixup an issue when `make test-verilator` is ran, the binary loaded to
Verilator is incorrect. It would load the `binary.64.vmem` file which
might have been previously created by `make
BOARD_CONFIGURATION=sim_verilator verilator` or not at all (error). Note that
a `.vmem` created by the previous command will not have been built for tests.

This PR updates the `makefile/run.sh` for cw130/nexysvideo  to ensure
that the `.vmem` created using the test binary is loaded into Verilator.

### Depends

This PR builds on: 
* https://github.com/tock/tock/pull/2955
* https://github.com/tock/tock/pull/2954
* https://github.com/tock/tock/pull/2953

All merged.

### Testing Strategy

`make test-verilator` for both boards. The test outputs observed over `screen dev/pts/x`.


### TODO or Help Wanted
To keep things tidy, I output all the Verilator test build files into `verilator_build/` within the current board directory. So you could easily just delete that after. What do you guys think about this implementation? 

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.


### Update
17/2 - Implemented OBJCOPY variable to be used for object copying. 