### PR TITLE
libraries: cells: remove option_result_contains

### DIFF
--- a/libraries/tock-cells/src/lib.rs
+++ b/libraries/tock-cells/src/lib.rs
@@ -1,14 +1,6 @@
 //! Tock Cell types.
 
 #![feature(const_fn_trait_bound)]
-// Feature used to opt-in the new `core::Option::contains()` API.
-//
-// This feature can be removed if needed by manually reimplementing the
-// `contains` logic for `Option`.
-//
-// Tock expects this feature to stabilize in the near future.
-// Tracking: https://github.com/rust-lang/rust/issues/62358
-#![feature(option_result_contains)]
 // Feature required with newer versions of rustc (at least 2020-10-25).
 #![feature(const_mut_refs)]
 #![no_std]

--- a/libraries/tock-cells/src/optional_cell.rs
+++ b/libraries/tock-cells/src/optional_cell.rs
@@ -71,7 +71,10 @@ impl<T> OptionalCell<T> {
         T: PartialEq,
     {
         let value = self.value.take();
-        let out = value.contains(x);
+        let out = match &value {
+            Some(y) => y == x,
+            None => false,
+        };
         self.value.set(value);
         out
     }


### PR DESCRIPTION
Remove unstable feature and just implement the helper function (`contains()`) directly.

We don't need to strictly do this, but the tracking issue for stabilization (https://github.com/rust-lang/rust/issues/62358) took a bit of a downward turn and maybe we shouldn't wait around for it.


### Testing Strategy

travis


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
