### PR TITLE
HIL: Make TemperatureClient receive Result<i32, ErrorCode> values

### DIFF
--- a/capsules/src/l3gd20.rs
+++ b/capsules/src/l3gd20.rs
@@ -488,17 +488,17 @@ impl spi::SpiMasterClient for L3gd20Spi<'_> {
                     }
 
                     L3gd20Status::ReadTemperature => {
-                        let mut temperature: usize = 0;
+                        let mut temperature = 0;
                         let value = if let Some(ref buf) = read_buffer {
                             if len >= 2 {
-                                temperature = (buf[1] as i8) as usize;
+                                temperature = buf[1] as i32;
                                 self.temperature_client.map(|client| {
-                                    client.callback(temperature * 100);
+                                    client.callback(Ok(temperature * 100));
                                 });
                                 true
                             } else {
                                 self.temperature_client.map(|client| {
-                                    client.callback(0);
+                                    client.callback(Err(ErrorCode::FAIL));
                                 });
                                 false
                             }
@@ -506,7 +506,9 @@ impl spi::SpiMasterClient for L3gd20Spi<'_> {
                             false
                         };
                         if value {
-                            upcalls.schedule_upcall(0, (temperature, 0, 0)).ok();
+                            upcalls
+                                .schedule_upcall(0, (temperature as usize, 0, 0))
+                                .ok();
                         } else {
                             upcalls.schedule_upcall(0, (0, 0, 0)).ok();
                         }

--- a/capsules/src/lsm303agr.rs
+++ b/capsules/src/lsm303agr.rs
@@ -544,23 +544,17 @@ impl i2c::I2CClient for Lsm303agrI2C<'_> {
                 self.state.set(State::Idle);
             }
             State::ReadTemperature => {
-                let mut temp: usize = 0;
-                let values = if status == Ok(()) {
-                    temp = (buffer[1] as u16 as i16 | ((buffer[0] as i16) << 8)) as usize;
-                    self.temperature_client.map(|client| {
-                        client.callback((temp as i16 / 8) as usize);
-                    });
-                    true
-                } else {
-                    self.temperature_client.map(|client| {
-                        client.callback(usize::MAX);
-                    });
-                    false
+                let values = match status {
+                    Ok(()) => Ok((buffer[1] as u16 as i16 | ((buffer[0] as i16) << 8)) as i32 / 8),
+                    Err(i2c_err) => Err(i2c_err.into()),
                 };
+                self.temperature_client.map(|client| {
+                    client.callback(values);
+                });
                 self.owning_process.map(|pid| {
                     let _res = self.apps.enter(*pid, |_app, upcalls| {
-                        if values {
-                            upcalls.schedule_upcall(0, (temp, 0, 0)).ok();
+                        if let Ok(temp) = values {
+                            upcalls.schedule_upcall(0, (temp as usize, 0, 0)).ok();
                         } else {
                             upcalls.schedule_upcall(0, (0, 0, 0)).ok();
                         }

--- a/capsules/src/si7021.rs
+++ b/capsules/src/si7021.rs
@@ -205,9 +205,9 @@ impl<'a, A: time::Alarm<'a>> i2c::I2CClient for SI7021<'a, A> {
             State::GotTempMeasurement => {
                 // Temperature in hundredths of degrees centigrade
                 let temp_raw = (((buffer[0] as u32) << 8) | (buffer[1] as u32)) as u32;
-                let temp = (((temp_raw * 17572) / 65536) - 4685) as i16;
+                let temp = ((temp_raw * 17572) / 65536) as i32 - 4685;
 
-                self.temp_callback.map(|cb| cb.callback(temp as usize));
+                self.temp_callback.map(|cb| cb.callback(Ok(temp)));
 
                 match self.on_deck.get() {
                     OnDeck::Humidity => {

--- a/capsules/src/temperature.rs
+++ b/capsules/src/temperature.rs
@@ -108,15 +108,18 @@ impl<'a> TemperatureSensor<'a> {
 }
 
 impl hil::sensors::TemperatureClient for TemperatureSensor<'_> {
-    fn callback(&self, temp_val: usize) {
-        for cntr in self.apps.iter() {
-            cntr.enter(|app, upcalls| {
-                if app.subscribed {
-                    self.busy.set(false);
-                    app.subscribed = false;
-                    upcalls.schedule_upcall(0, (temp_val, 0, 0)).ok();
-                }
-            });
+    fn callback(&self, temp_val: Result<i32, ErrorCode>) {
+        if let Ok(temp_val) = temp_val {
+            // TODO: forward error conditions
+            for cntr in self.apps.iter() {
+                cntr.enter(|app, upcalls| {
+                    if app.subscribed {
+                        self.busy.set(false);
+                        app.subscribed = false;
+                        upcalls.schedule_upcall(0, (temp_val as usize, 0, 0)).ok();
+                    }
+                });
+            }
         }
     }
 }

--- a/capsules/src/temperature_rp2040.rs
+++ b/capsules/src/temperature_rp2040.rs
@@ -41,10 +41,9 @@ impl<'a> adc::Client for TemperatureRp2040<'a> {
     fn sample_ready(&self, sample: u16) {
         self.status.set(Status::Idle);
         self.temperature_client.map(|client| {
-            client.callback(
-                ((27.0 - (((sample as f32 * 3.3 / 4095.0) - self.v_27) * 1000.0 / self.slope))
-                    * 100.0) as usize,
-            );
+            client.callback(Ok(((27.0
+                - (((sample as f32 * 3.3 / 4095.0) - self.v_27) * 1000.0 / self.slope))
+                * 100.0) as i32));
         });
     }
 }

--- a/capsules/src/temperature_stm.rs
+++ b/capsules/src/temperature_stm.rs
@@ -41,10 +41,10 @@ impl<'a> adc::Client for TemperatureSTM<'a> {
     fn sample_ready(&self, sample: u16) {
         self.status.set(Status::Idle);
         self.temperature_client.map(|client| {
-            client.callback(
+            client.callback(Ok(
                 ((((self.v_25 - (sample as f32 * 3.3 / 65535.0)) * 1000.0 / self.slope) + 25.0)
-                    * 100.0) as usize,
-            );
+                    * 100.0) as i32,
+            ));
         });
     }
 }

--- a/chips/nrf5x/src/temperature.rs
+++ b/chips/nrf5x/src/temperature.rs
@@ -125,7 +125,7 @@ impl<'a> Temp<'a> {
 
         // get temperature
         // Result of temperature measurement in °C, 2's complement format, 0.25 °C
-        let temp = (self.registers.temp.get() / 4) * 100;
+        let temp = (self.registers.temp.get() as i32 / 4) * 100;
 
         // stop measurement
         self.registers.task_stop.write(Task::ENABLE::SET);
@@ -134,7 +134,7 @@ impl<'a> Temp<'a> {
         self.disable_interrupts();
 
         // trigger callback with temperature
-        self.client.map(|client| client.callback(temp as usize));
+        self.client.map(|client| client.callback(Ok(temp)));
     }
 
     fn enable_interrupts(&self) {

--- a/kernel/src/hil/sensors.rs
+++ b/kernel/src/hil/sensors.rs
@@ -13,8 +13,8 @@ pub trait TemperatureClient {
     /// Called when a temperature reading has completed.
     ///
     /// - `value`: the most recently read temperature in hundredths of degrees
-    /// centigrate.
-    fn callback(&self, value: usize);
+    /// centigrade (centiCelsius), or Err on failure.
+    fn callback(&self, value: Result<i32, ErrorCode>);
 }
 
 /// A basic interface for a humidity sensor


### PR DESCRIPTION
`usize` values on the Celsius scales are unable to represent negative temperatures.

### Pull Request Overview

Fixes this issue: https://github.com/tock/tock/issues/2965 , where the HIL cannot represent temperatures below 273K.

While modifying the code, I decided to use `i32::MIN` as the "unavailable" value, which some drivers needed. They returned `usize::MAX` before. `i32::MIN` is outside of the Celsius scale, so that should be OK. However, perhaps there is a need for another API change to explcitly represent failures.

I also ended up converting to `usize`s for `upcall` calls, whatever those are.

### Testing Strategy

Not meaningfully tested, touches several drivers.

### TODO or Help Wanted

This pull request still needs review and testing.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
