### PR TITLE
RFC: Moving some flags from Makefile to build.rs

### DIFF
--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -41,21 +41,10 @@ TARGET_DIRECTORY ?= $(TOCK_ROOT_DIRECTORY)target/
 # This will hopefully move into Cargo.toml (or Cargo.toml.local) eventually.
 #
 # - `relocation-model=static`: See https://github.com/tock/tock/pull/2853
-# - `-nmagic`: lld by default uses a default page size to align program
-#   sections. Tock expects that program sections are set back-to-back. `-nmagic`
-#   instructs the linker to not page-align sections.
-# - `-icf=all`: Identical Code Folding (ICF) set to all. This tells the linker
-#   to be more aggressive about removing duplicate code. The default is `safe`,
-#   and the downside to `all` is that different functions in the code can end up
-#   with the same address in the binary. However, it can save a fair bit of code
-#   size.
 RUSTC_FLAGS ?= \
-  -C link-arg=-Tlayout.ld \
   -C linker=rust-lld \
   -C linker-flavor=ld.lld \
   -C relocation-model=static \
-  -C link-arg=-nmagic \
-  -C link-arg=-icf=all \
 
 # RISC-V-specific flags.
 ifneq ($(findstring riscv32i, $(TARGET)),)

--- a/boards/common_build.rs
+++ b/boards/common_build.rs
@@ -1,0 +1,23 @@
+//! Shared build.rs options and flags.
+//!
+//! These are common
+//! [build.rs](https://doc.rust-lang.org/cargo/reference/build-scripts.html)
+//! configurations that Tock boards can use in their own build.rs.
+
+/// Standard linker arguments that boards typically pass to rustc.
+pub fn tock_default_linker_args() {
+    // Default name of the linker script.
+    println!("cargo:rustc-link-arg=-Tlayout.ld");
+
+    // lld by default uses a default page size to align program sections. Tock
+    //  expects that program sections are set back-to-back. `-nmagic` instructs
+    //  the linker to not page-align sections.
+    println!("cargo:rustc-link-arg=-nmagic");
+
+    // Identical Code Folding (ICF) set to all. This tells the linker to be more
+    // aggressive about removing duplicate code. The default is `safe`, and the
+    // downside to `all` is that different functions in the code can end up with
+    // the same address in the binary. However, it can save a fair bit of code
+    // size.
+    println!("cargo:rustc-link-arg=-icf=all");
+}

--- a/boards/hail/build.rs
+++ b/boards/hail/build.rs
@@ -1,5 +1,10 @@
+#[path = "../common_build.rs"]
+mod common_build;
+
 fn main() {
     println!("cargo:rerun-if-changed=layout.ld");
     println!("cargo:rerun-if-changed=chip_layout.ld");
     println!("cargo:rerun-if-changed=../kernel_layout.ld");
+
+    common_build::tock_default_linker_args();
 }


### PR DESCRIPTION
### Pull Request Overview

This pull request is a companion to #2962 and looks at what moving more flags from the Makefile to a common build.rs file could look at.

This is an initial implementation to get feedback. The [cargo build.rs instructions](https://doc.rust-lang.org/cargo/reference/build-scripts.html#outputs-of-the-build-script) are somewhat limited, so there isn't too much we can move (at least right now). 

I'm targeting build.rs because it is not a hidden file, and because we can use a shared common_build.rs.

### Testing Strategy

todo


### TODO or Help Wanted

Since we can't move too much out of Makefile right now, should we bother? Or is shrinking our custom Makefile and using standard rust infrastructure still a net improvement?

If we find a version we like it needs to be propagated to all boards.

### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
