### PR TITLE
ESP32-C3: Perform minor improvements to documentation

### DIFF
--- a/arch/rv32i/src/syscall.rs
+++ b/arch/rv32i/src/syscall.rs
@@ -164,7 +164,7 @@ impl kernel::syscall::UserspaceKernelBoundary for SysCall {
         let (_, r) = state.regs.split_at_mut(R_A0);
 
         // This comes with the assumption that the respective
-        // registers are stored at monotonically increasing indicies
+        // registers are stored at monotonically increasing indices
         // in the register slice
         let (a0slice, r) = r.split_at_mut(R_A1 - R_A0);
         let (a1slice, r) = r.split_at_mut(R_A2 - R_A1);

--- a/boards/esp32-c3-devkitM-1/README.md
+++ b/boards/esp32-c3-devkitM-1/README.md
@@ -83,7 +83,7 @@ make -j8
 Note that the connection can be unreliable, commit
 5b67ad1b15938f524f133afb8ef652c990f570eb seems to work though.
 
-Then connect an [FDTI C232HM](https://ftdichip.com/products/c232hm-ddhsl-0-2/)
+Then connect an [FTDI C232HM](https://ftdichip.com/products/c232hm-ddhsl-0-2/)
 cable as described here:
 https://docs.espressif.com/projects/esp-idf/en/latest/esp32c3/api-guides/jtag-debugging/configure-other-jtag.html.
 

--- a/boards/esp32-c3-devkitM-1/src/main.rs
+++ b/boards/esp32-c3-devkitM-1/src/main.rs
@@ -98,10 +98,10 @@ impl KernelResources<esp32_c3::chip::Esp32C3<'static, Esp32C3DefaultPeripherals<
     type SyscallDriverLookup = Self;
     type SyscallFilter = ();
     type ProcessFault = ();
+    type ContextSwitchCallback = ();
     type Scheduler = PrioritySched;
     type SchedulerTimer = VirtualSchedulerTimer<esp32_c3::timg::TimG<'static>>;
     type WatchDog = ();
-    type ContextSwitchCallback = ();
 
     fn syscall_driver_lookup(&self) -> &Self::SyscallDriverLookup {
         &self

--- a/chips/esp32-c3/src/chip.rs
+++ b/chips/esp32-c3/src/chip.rs
@@ -110,14 +110,6 @@ impl<'a, I: InterruptService<()> + 'a> Chip for Esp32C3<'a, I> {
     type MPU = PMP<8>;
     type UserspaceKernelBoundary = SysCall;
 
-    fn mpu(&self) -> &Self::MPU {
-        &self.pmp
-    }
-
-    fn userspace_kernel_boundary(&self) -> &SysCall {
-        &self.userspace_kernel_boundary
-    }
-
     fn service_pending_interrupts(&self) {
         loop {
             if self.intc.get_saved_interrupts().is_some() {
@@ -136,6 +128,14 @@ impl<'a, I: InterruptService<()> + 'a> Chip for Esp32C3<'a, I> {
 
     fn has_pending_interrupts(&self) -> bool {
         self.intc.get_saved_interrupts().is_some()
+    }
+
+    fn mpu(&self) -> &Self::MPU {
+        &self.pmp
+    }
+
+    fn userspace_kernel_boundary(&self) -> &SysCall {
+        &self.userspace_kernel_boundary
     }
 
     fn sleep(&self) {

--- a/chips/esp32-c3/src/interrupts.rs
+++ b/chips/esp32-c3/src/interrupts.rs
@@ -1,4 +1,4 @@
-//! Named interrupts for the ESP32C3 chip.
+//! Named interrupts for the ESP32-C3 chip.
 //! This matches what the HAL uses
 
 #![allow(dead_code)]

--- a/chips/esp32/src/gpio.rs
+++ b/chips/esp32/src/gpio.rs
@@ -229,7 +229,7 @@ impl gpio::Configure for GpioPin<'_> {
     }
 
     fn disable_input(&self) -> gpio::Configuration {
-        /* We can't do this from the GPIO contorller.
+        /* We can't do this from the GPIO controller.
          * It does look like the IO Mux is capable of this
          * though.
          */

--- a/chips/esp32/src/uart.rs
+++ b/chips/esp32/src/uart.rs
@@ -436,7 +436,7 @@ impl<'a> hil::uart::Transmit<'a> for Uart<'a> {
     }
 }
 
-/* UART receive is not implemented yet, mostly due to a lack of tests avaliable */
+/* UART receive is not implemented yet, mostly due to a lack of tests available */
 impl<'a> hil::uart::Receive<'a> for Uart<'a> {
     fn set_receive_client(&self, client: &'a dyn hil::uart::ReceiveClient) {
         self.rx_client.set(client);

--- a/chips/esp32/src/uart.rs
+++ b/chips/esp32/src/uart.rs
@@ -427,11 +427,11 @@ impl<'a> hil::uart::Transmit<'a> for Uart<'a> {
         }
     }
 
-    fn transmit_abort(&self) -> Result<(), ErrorCode> {
+    fn transmit_word(&self, _word: u32) -> Result<(), ErrorCode> {
         Err(ErrorCode::FAIL)
     }
 
-    fn transmit_word(&self, _word: u32) -> Result<(), ErrorCode> {
+    fn transmit_abort(&self) -> Result<(), ErrorCode> {
         Err(ErrorCode::FAIL)
     }
 }
@@ -462,11 +462,11 @@ impl<'a> hil::uart::Receive<'a> for Uart<'a> {
         Ok(())
     }
 
-    fn receive_abort(&self) -> Result<(), ErrorCode> {
+    fn receive_word(&self) -> Result<(), ErrorCode> {
         Err(ErrorCode::FAIL)
     }
 
-    fn receive_word(&self) -> Result<(), ErrorCode> {
+    fn receive_abort(&self) -> Result<(), ErrorCode> {
         Err(ErrorCode::FAIL)
     }
 }


### PR DESCRIPTION
### Pull Request Overview

This PR intends to provide minor improvements to the ESP32-C3 port of Tock OS.
Most of them are documentation-related.
Others are just code reorganization to prevent warnings from IntelliJ Rust IDE.

### Testing Strategy

Flashed the binaries to the ESP32-C3-DevKitM-1 development board and executed the Process Console successfully.

### TODO or Help Wanted

Not applicable.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
