### PR TITLE
process_console: Handle DEL char as backspace

### DIFF
--- a/capsules/src/process_console.rs
+++ b/capsules/src/process_console.rs
@@ -920,7 +920,7 @@ impl<'a, A: Alarm<'a>, C: ProcessManagementCapability> uart::ReceiveClient
                                 self.execute.set(true);
                                 let _ = self.write_bytes(&['\r' as u8, '\n' as u8]);
                             }
-                        } else if read_buf[0] == ('\x08' as u8) {
+                        } else if read_buf[0] == ('\x08' as u8) || read_buf[0] == ('\x7F' as u8) {
                             if index > 0 {
                                 // Backspace, echo and remove last byte
                                 // Note echo is '\b \b' to erase


### PR DESCRIPTION
### Pull Request Overview

This PR intends to provide a fix to the handling of the BACKSPACE key when interfacing via serial port on Linux.
Currently, pressing the BACKSPACE key is a no-op, since the terminal outputs a `DEL` char through the serial port, which is not handled by the Process Console.

### Testing Strategy

Tested with the **ESP32-C3-DevKitM-1** development board under **Ubuntu Linux 21.10**. Verified that the BACKSPACE key now behaves as expected.

### TODO or Help Wanted

Not applicable.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
