### PR TITLE
WIP: Getting Verilator working on Mac

### DIFF
--- a/boards/opentitan/README.md
+++ b/boards/opentitan/README.md
@@ -19,7 +19,7 @@ for more details.
 Programming
 -----------
 
-Tock on OpenTitan requires
+Tock on OpenTitan requires using OpenTitan_SHA
 lowRISC/opentitan@199d45626f8a7ae2aef5d9ff73793bf9a4233711 or newer. In
 general it is recommended that users start with the latest OpenTitan bitstream
 and if that results in issues try the one mentioned above.
@@ -127,7 +127,7 @@ A quick summary on how to do this is included below though
 ```shell
 git clone https://github.com/lowRISC/opentitan.git
 cd opentitan
-git checkout <OpenTitan_SHA>
+git checkout <OpenTitan_SHA>  # Changes, see current SHA at top of this README
 pip3 install --user -r python-requirements.txt
 
 LANG="en_US.UTF-8" fusesoc --cores-root . run --flag=fileset_top --target=sim --setup --build lowrisc:dv:chip_verilator_sim

--- a/boards/opentitan/README.md
+++ b/boards/opentitan/README.md
@@ -179,7 +179,21 @@ LANG="en_US.UTF-8" fusesoc --cores-root . run --flag=fileset_top --target=sim --
 </details>
 
 ### Build Boot Rom/OTP Image
+
+<details>
+  <summary>Modifications to build on OS X</summary>
+
+  OT build assumes old toolchains (i.e. `riscv32-*`), but homebrew only installs
+  binaries of `riscv64-*`. They're all multilib, so they work fine, just need to
+  add symlinks:
+
+  > `cd /usr/local/Cellar/riscv-gnu-toolchain/main/bin`
+  > `for f in $(ls); do ln -s $f riscv32-$(echo $f | cut -d'-' -f2-10); done`
+
+</details>
+
 Build only the targets we care about.
+
 ```shell
 ./meson_init.sh
 ninja -C build-out sw/device/lib/testing/test_rom/test_rom_export_sim_verilator


### PR DESCRIPTION
### Pull Request Overview

Was trying to play around with verilator and OT some today, but ran into several x-platform issues :(. It's a pretty high priority for me to try to keep Tock as cross-platform-friendly as possible, and I think I'm pretty close to getting this working, but I need to step away for a bit.

### Testing Strategy

Many many failed builds.

### TODO or Help Wanted

I believe the only thing missing at this stage is a version of the riscv32 toolchain that can build the rest of the firmware (OT demands a `riscv32-[...]` toolchain, while homebrew's prebuilt images only ship a `riscv64-[...]` toolchain, and [the riscv toolchain apparently doesn't build on Mac](https://github.com/riscv-software-src/riscv-tools/issues/353).

I think if I had a prebuilt `test_rom_sim_verilator.scr.39.vmem` and `otp_img_sim_verilator.vmem`, everything would be working.

### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
