### PR TITLE
kernel/processbuffer: migrate ProcessSlices towards raw pointers

### DIFF
--- a/capsules/src/app_flash_driver.rs
+++ b/capsules/src/app_flash_driver.rs
@@ -26,7 +26,7 @@ use core::cmp;
 
 use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
 use kernel::hil;
-use kernel::processbuffer::ReadableProcessBuffer;
+use kernel::processbuffer::{ProcessSliceIndex, ReadableProcessBuffer};
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::utilities::cells::{OptionalCell, TakeCell};
 use kernel::{ErrorCode, ProcessId};
@@ -99,11 +99,11 @@ impl<'a> AppFlash<'a> {
                                     .take()
                                     .map_or(Err(ErrorCode::RESERVE), |buffer| {
                                         let length = cmp::min(buffer.len(), app_buffer.len());
-                                        let d = &app_buffer[0..length];
+                                        let d = &app_buffer.get(0..length).unwrap();
                                         for (i, c) in
                                             buffer.as_mut()[0..length].iter_mut().enumerate()
                                         {
-                                            *c = d[i].get();
+                                            *c = d.get(i).unwrap().get();
                                         }
 
                                         self.driver.write(buffer, flash_address, length)
@@ -159,11 +159,11 @@ impl hil::nonvolatile_storage::NonvolatileStorageClient<'static> for AppFlash<'_
                                     } else {
                                         // Copy contents to internal buffer and write it.
                                         let length = cmp::min(buffer.len(), app_buffer.len());
-                                        let d = &app_buffer[0..length];
+                                        let d = &app_buffer.get(0..length).unwrap();
                                         for (i, c) in
                                             buffer.as_mut()[0..length].iter_mut().enumerate()
                                         {
-                                            *c = d[i].get();
+                                            *c = d.get(i).unwrap().get();
                                         }
 
                                         if let Ok(()) =

--- a/capsules/src/console.rs
+++ b/capsules/src/console.rs
@@ -39,7 +39,7 @@
 
 use kernel::grant::{AllowRoCount, AllowRwCount, Grant, GrantKernelData, UpcallCount};
 use kernel::hil::uart;
-use kernel::processbuffer::{ReadableProcessBuffer, WriteableProcessBuffer};
+use kernel::processbuffer::{ProcessSliceIndex, ReadableProcessBuffer, WriteableProcessBuffer};
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::utilities::cells::{OptionalCell, TakeCell};
 use kernel::{ErrorCode, ProcessId};
@@ -161,7 +161,9 @@ impl<'a> Console<'a> {
                     .get_readonly_processbuffer(ro_allow::WRITE)
                     .and_then(|write| {
                         write.enter(|data| {
-                            for (i, c) in data[data.len() - app.write_remaining..data.len()]
+                            for (i, c) in data
+                                .get(data.len() - app.write_remaining..data.len())
+                                .unwrap()
                                 .iter()
                                 .enumerate()
                             {

--- a/capsules/src/crc.rs
+++ b/capsules/src/crc.rs
@@ -79,7 +79,7 @@ use core::cmp;
 
 use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
 use kernel::hil::crc::{Client, Crc, CrcAlgorithm, CrcOutput};
-use kernel::processbuffer::{ReadableProcessBuffer, ReadableProcessSlice};
+use kernel::processbuffer::{ProcessSliceIndex, ReadableProcessBuffer, ReadableProcessSlice};
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::utilities::cells::NumericCellExt;
 use kernel::utilities::cells::{OptionalCell, TakeCell};
@@ -145,11 +145,11 @@ impl<'a, C: Crc<'a>> CrcDriver<'a, C> {
         }
     }
 
-    fn do_next_input(&self, data: &ReadableProcessSlice, len: usize) -> usize {
+    fn do_next_input<'b>(&self, data: ReadableProcessSlice<'b>, len: usize) -> usize {
         let count = self.crc_buffer.take().map_or(0, |kbuffer| {
             let copy_len = cmp::min(len, kbuffer.len());
             for i in 0..copy_len {
-                kbuffer[i] = data[i].get();
+                kbuffer[i] = data.get(i).unwrap().get();
             }
             if copy_len > 0 {
                 let mut leasable = LeasableBuffer::new(kbuffer);
@@ -463,7 +463,9 @@ impl<'a, C: Crc<'a>> Client for CrcDriver<'a, C> {
                                     .and_then(|buffer| {
                                         buffer.enter(|app_slice| {
                                             self.do_next_input(
-                                                &app_slice[self.app_buffer_written.get()..],
+                                                app_slice
+                                                    .get(self.app_buffer_written.get()..)
+                                                    .unwrap(),
                                                 remaining,
                                             )
                                         })

--- a/capsules/src/ctap.rs
+++ b/capsules/src/ctap.rs
@@ -144,7 +144,7 @@ impl<'a, U: usb_hid::UsbHid<'a, [u8; 64]>> usb_hid::Client<'a, [u8; 64]> for Cta
                         .get_readwrite_processbuffer(rw_allow::RECV)
                         .and_then(|recv| {
                             recv.mut_enter(|dest| {
-                                dest.copy_from_slice(buffer);
+                                dest.copy_from_slice(buffer).unwrap();
                             })
                         });
 
@@ -239,7 +239,7 @@ impl<'a, U: usb_hid::UsbHid<'a, [u8; 64]>> SyscallDriver for CtapDriver<'a, U> {
                                         CommandReturn::failure(ErrorCode::RESERVE),
                                         |buf| {
                                             // Copy the data into the static buffer
-                                            data.copy_to_slice(buf);
+                                            data.copy_to_slice(buf).unwrap();
 
                                             let _ = usb.send_buffer(buf);
                                             CommandReturn::success()
@@ -359,7 +359,7 @@ impl<'a, U: usb_hid::UsbHid<'a, [u8; 64]>> SyscallDriver for CtapDriver<'a, U> {
                                                 CommandReturn::failure(ErrorCode::RESERVE),
                                                 |buf| {
                                                     // Copy the data into the static buffer
-                                                    data.copy_to_slice(buf);
+                                                    data.copy_to_slice(buf).unwrap();
 
                                                     let _ = usb.send_buffer(buf);
                                                     CommandReturn::success()

--- a/capsules/src/hmac.rs
+++ b/capsules/src/hmac.rs
@@ -48,7 +48,7 @@ use core::cell::Cell;
 
 use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
 use kernel::hil::digest;
-use kernel::processbuffer::{ReadableProcessBuffer, WriteableProcessBuffer};
+use kernel::processbuffer::{ProcessSliceIndex, ReadableProcessBuffer, WriteableProcessBuffer};
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::utilities::cells::{OptionalCell, TakeCell};
 use kernel::utilities::leasable_buffer::LeasableBuffer;
@@ -123,7 +123,10 @@ impl<
                                     let mut tmp_key_buffer: [u8; TMP_KEY_BUFFER_SIZE] =
                                         [0; TMP_KEY_BUFFER_SIZE];
                                     let key_len = core::cmp::min(k.len(), TMP_KEY_BUFFER_SIZE);
-                                    k[..key_len].copy_to_slice(&mut tmp_key_buffer[..key_len]);
+                                    k.get(..key_len)
+                                        .unwrap()
+                                        .copy_to_slice(&mut tmp_key_buffer[..key_len])
+                                        .unwrap();
 
                                     match op {
                                         ShaOperation::Sha256 => self
@@ -162,8 +165,10 @@ impl<
                                     self.data_copied.set(static_buffer_len);
 
                                     // Copy the data into the static buffer
-                                    data[..static_buffer_len]
-                                        .copy_to_slice(&mut buf[..static_buffer_len]);
+                                    data.get(..static_buffer_len)
+                                        .unwrap()
+                                        .copy_to_slice(&mut buf[..static_buffer_len])
+                                        .unwrap();
                                 });
 
                                 // Add the data from the static buffer to the HMAC
@@ -272,13 +277,19 @@ impl<
                                     data_len = data.len();
 
                                     if data_len > copied_data {
-                                        let remaining_data = &data[copied_data..];
+                                        let remaining_data = &data.get(copied_data..).unwrap();
                                         let remaining_len = data_len - copied_data;
 
                                         if remaining_len < static_buffer_len {
-                                            remaining_data.copy_to_slice(&mut buf[..remaining_len]);
+                                            remaining_data
+                                                .copy_to_slice(&mut buf[..remaining_len])
+                                                .unwrap();
                                         } else {
-                                            remaining_data[..static_buffer_len].copy_to_slice(buf);
+                                            remaining_data
+                                                .get(..static_buffer_len)
+                                                .unwrap()
+                                                .copy_to_slice(buf)
+                                                .unwrap();
                                         }
                                     }
                                     Ok(())
@@ -349,8 +360,11 @@ impl<
                                         self.data_copied.set(static_buffer_len);
 
                                         // Copy the data into the static buffer
-                                        compare[..static_buffer_len]
-                                            .copy_to_slice(&mut buf[..static_buffer_len]);
+                                        compare
+                                            .get(..static_buffer_len)
+                                            .unwrap()
+                                            .copy_to_slice(&mut buf[..static_buffer_len])
+                                            .unwrap();
                                     });
                                 })
                             });
@@ -398,9 +412,9 @@ impl<
                                 let len = dest.len();
 
                                 if len < L {
-                                    dest.copy_from_slice(&digest[0..len]);
+                                    dest.copy_from_slice(&digest[0..len]).unwrap();
                                 } else {
-                                    dest[0..L].copy_from_slice(digest);
+                                    dest.get(0..L).unwrap().copy_from_slice(digest).unwrap();
                                 }
                             })
                         });
@@ -715,8 +729,11 @@ impl<
                                             self.data_copied.set(static_buffer_len);
 
                                             // Copy the data into the static buffer
-                                            compare[..static_buffer_len]
-                                                .copy_to_slice(&mut buf[..static_buffer_len]);
+                                            compare
+                                                .get(..static_buffer_len)
+                                                .unwrap()
+                                                .copy_to_slice(&mut buf[..static_buffer_len])
+                                                .unwrap();
                                         });
                                     })
                                 });

--- a/capsules/src/ieee802154/framer.rs
+++ b/capsules/src/ieee802154/framer.rs
@@ -146,15 +146,17 @@ impl Frame {
 
     /// Appends payload bytes from a process slice into the frame if
     /// possible
-    pub fn append_payload_process(
+    pub fn append_payload_process<'a>(
         &mut self,
-        payload_buf: &ReadableProcessSlice,
+        payload_buf: ReadableProcessSlice<'a>,
     ) -> Result<(), ErrorCode> {
         if payload_buf.len() > self.remaining_data_capacity() {
             return Err(ErrorCode::NOMEM);
         }
         let begin = radio::PSDU_OFFSET + self.info.unsecured_length();
-        payload_buf.copy_to_slice(&mut self.buf[begin..begin + payload_buf.len()]);
+        payload_buf
+            .copy_to_slice(&mut self.buf[begin..begin + payload_buf.len()])
+            .unwrap();
         self.info.data_len += payload_buf.len();
 
         Ok(())

--- a/capsules/src/net/udp/driver.rs
+++ b/capsules/src/net/udp/driver.rs
@@ -25,7 +25,7 @@ use core::{cmp, mem};
 use kernel::capabilities::UdpDriverCapability;
 use kernel::debug;
 use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
-use kernel::processbuffer::{ReadableProcessBuffer, WriteableProcessBuffer};
+use kernel::processbuffer::{ProcessSliceIndex, ReadableProcessBuffer, WriteableProcessBuffer};
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::utilities::cells::MapCell;
 use kernel::utilities::leasable_buffer::LeasableBuffer;
@@ -217,7 +217,9 @@ impl<'a> UDPDriver<'a> {
                                 if payload.len() > kernel_buffer.len() {
                                     return Err(ErrorCode::SIZE);
                                 }
-                                payload.copy_to_slice(&mut kernel_buffer[0..payload.len()]);
+                                payload
+                                    .copy_to_slice(&mut kernel_buffer[0..payload.len()])
+                                    .unwrap();
                                 kernel_buffer.slice(0..payload.len());
                                 match self.sender.driver_send_to(
                                     dst_addr,
@@ -404,8 +406,10 @@ impl<'a> SyscallDriver for UDPDriver<'a> {
                                         cmp::min(arg1, self.interface_list.len());
                                     let iface_size = size_of::<IPAddr>();
                                     for i in 0..n_ifaces_to_copy {
-                                        cfg[i * iface_size..(i + 1) * iface_size]
-                                            .copy_from_slice(&self.interface_list[i].0);
+                                        cfg.get(i * iface_size..(i + 1) * iface_size)
+                                            .unwrap()
+                                            .copy_from_slice(&self.interface_list[i].0)
+                                            .unwrap();
                                     }
                                     // Returns total number of interfaces
                                     CommandReturn::success_u32(self.interface_list.len() as u32)
@@ -439,7 +443,7 @@ impl<'a> SyscallDriver for UDPDriver<'a> {
 
                                     let mut tmp_cfg_buffer: [u8; size_of::<UDPEndpoint>() * 2] =
                                         [0; size_of::<UDPEndpoint>() * 2];
-                                    cfg.copy_to_slice(&mut tmp_cfg_buffer);
+                                    cfg.copy_to_slice(&mut tmp_cfg_buffer).unwrap();
 
                                     if let (Some(dst), Some(src)) = (
                                         self.parse_ip_port_pair(
@@ -489,8 +493,10 @@ impl<'a> SyscallDriver for UDPDriver<'a> {
                                     } else {
                                         let mut tmp_endpoint: [u8; mem::size_of::<UDPEndpoint>()] =
                                             [0; mem::size_of::<UDPEndpoint>()];
-                                        cfg[mem::size_of::<UDPEndpoint>()..]
-                                            .copy_to_slice(&mut tmp_endpoint);
+                                        cfg.get(mem::size_of::<UDPEndpoint>()..)
+                                            .unwrap()
+                                            .copy_to_slice(&mut tmp_endpoint)
+                                            .unwrap();
 
                                         if let Some(local_iface) =
                                             self.parse_ip_port_pair(&tmp_endpoint)
@@ -601,7 +607,10 @@ impl<'a> UDPRecvClient for UDPDriver<'a> {
                         .and_then(|read| {
                             read.mut_enter(|rbuf| {
                                 if rbuf.len() >= len {
-                                    rbuf[..len].copy_from_slice(&payload[..len]);
+                                    rbuf.get(..len)
+                                        .unwrap()
+                                        .copy_from_slice(&payload[..len])
+                                        .unwrap();
                                     Ok(())
                                 } else {
                                     Err(ErrorCode::SIZE) //packet does not fit
@@ -626,7 +635,7 @@ impl<'a> UDPRecvClient for UDPDriver<'a> {
                                     }
                                     let mut tmp_cfg_buffer: [u8; CFG_LEN] = [0; CFG_LEN];
                                     sender_addr.encode(&mut tmp_cfg_buffer, 0);
-                                    cfg.copy_from_slice(&tmp_cfg_buffer);
+                                    cfg.copy_from_slice(&tmp_cfg_buffer).unwrap();
                                     Ok(())
                                 })
                             })

--- a/capsules/src/nonvolatile_storage_driver.rs
+++ b/capsules/src/nonvolatile_storage_driver.rs
@@ -59,7 +59,7 @@ use core::cmp;
 
 use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
 use kernel::hil;
-use kernel::processbuffer::{ReadableProcessBuffer, WriteableProcessBuffer};
+use kernel::processbuffer::{ProcessSliceIndex, ReadableProcessBuffer, WriteableProcessBuffer};
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::utilities::cells::{OptionalCell, TakeCell};
 use kernel::{ErrorCode, ProcessId};
@@ -272,12 +272,12 @@ impl<'a> NonvolatileStorage<'a> {
                                                     let write_len =
                                                         cmp::min(active_len, kernel_buffer.len());
 
-                                                    let d = &app_buffer[0..write_len];
+                                                    let d = &app_buffer.get(0..write_len).unwrap();
                                                     for (i, c) in kernel_buffer[0..write_len]
                                                         .iter_mut()
                                                         .enumerate()
                                                     {
-                                                        *c = d[i].get();
+                                                        *c = d.get(i).unwrap().get();
                                                     }
                                                 });
                                             })
@@ -440,9 +440,9 @@ impl hil::nonvolatile_storage::NonvolatileStorageClient<'static> for Nonvolatile
                                 read.mut_enter(|app_buffer| {
                                     let read_len = cmp::min(app_buffer.len(), length);
 
-                                    let d = &app_buffer[0..(read_len as usize)];
+                                    let d = &app_buffer.get(0..(read_len as usize)).unwrap();
                                     for (i, c) in buffer[0..read_len].iter().enumerate() {
-                                        d[i].set(*c);
+                                        d.get(i).unwrap().set(*c);
                                     }
                                 })
                             });

--- a/capsules/src/nrf51822_serialization.rs
+++ b/capsules/src/nrf51822_serialization.rs
@@ -25,7 +25,7 @@ use core::cmp;
 use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
 use kernel::hil;
 use kernel::hil::uart;
-use kernel::processbuffer::{ReadableProcessBuffer, WriteableProcessBuffer};
+use kernel::processbuffer::{ProcessSliceIndex, ReadableProcessBuffer, WriteableProcessBuffer};
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::utilities::cells::{OptionalCell, TakeCell};
 use kernel::{ErrorCode, ProcessId};
@@ -255,7 +255,7 @@ impl uart::ReceiveClient for Nrf51822Serialization<'_> {
                             // Copy over data to app buffer.
                             self.rx_buffer.map_or(0, |buffer| {
                                 for idx in 0..max_len {
-                                    rb[idx].set(buffer[idx]);
+                                    rb.get(idx).unwrap().set(buffer[idx]);
                                 }
                                 max_len
                             })

--- a/capsules/src/read_only_state.rs
+++ b/capsules/src/read_only_state.rs
@@ -32,7 +32,9 @@ use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
 use kernel::hil::time::{Ticks, Time};
 use kernel::platform::ContextSwitchCallback;
 use kernel::process::{self, ProcessId};
-use kernel::processbuffer::{UserspaceReadableProcessBuffer, WriteableProcessBuffer};
+use kernel::processbuffer::{
+    ProcessSliceIndex, UserspaceReadableProcessBuffer, WriteableProcessBuffer,
+};
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::ErrorCode;
 
@@ -66,14 +68,23 @@ impl<'a, T: Time> ContextSwitchCallback for ReadOnlyStateDriver<'a, T> {
 
                 let _ = app.mem_region.mut_enter(|buf| {
                     if buf.len() >= 4 {
-                        buf[0..4].copy_from_slice(&count.to_le_bytes());
+                        buf.get(0..4)
+                            .unwrap()
+                            .copy_from_slice(&count.to_le_bytes())
+                            .unwrap();
                     }
                     if buf.len() >= 8 {
-                        buf[4..8].copy_from_slice(&(pending_tasks as u32).to_le_bytes());
+                        buf.get(4..8)
+                            .unwrap()
+                            .copy_from_slice(&(pending_tasks as u32).to_le_bytes())
+                            .unwrap();
                     }
                     if buf.len() >= 16 {
                         let now = self.timer.now().into_usize() as u64;
-                        buf[8..16].copy_from_slice(&now.to_le_bytes());
+                        buf.get(8..16)
+                            .unwrap()
+                            .copy_from_slice(&now.to_le_bytes())
+                            .unwrap();
                     }
                 });
 

--- a/capsules/src/rng.rs
+++ b/capsules/src/rng.rs
@@ -27,7 +27,7 @@ use kernel::hil::entropy;
 use kernel::hil::entropy::{Entropy32, Entropy8};
 use kernel::hil::rng;
 use kernel::hil::rng::{Client, Continue, Random, Rng};
-use kernel::processbuffer::WriteableProcessBuffer;
+use kernel::processbuffer::{ProcessSliceIndex, WriteableProcessBuffer};
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::utilities::cells::OptionalCell;
 use kernel::{ErrorCode, ProcessId};
@@ -103,7 +103,7 @@ impl rng::Client for RngDriver<'_> {
                                 // Add all available and requested randomness to the app buffer.
 
                                 // 1. Slice buffer to start from current idx
-                                let buf = &buffer[idx..(idx + remaining)];
+                                let buf = &buffer.get(idx..(idx + remaining)).unwrap();
                                 // 2. Take at most as many random samples as needed to fill the buffer
                                 //    (if app.remaining is not word-sized, take an extra one).
                                 let remaining_ints = if remaining % 4 == 0 {

--- a/capsules/src/spi_controller.rs
+++ b/capsules/src/spi_controller.rs
@@ -8,7 +8,7 @@ use kernel::grant::{AllowRoCount, AllowRwCount, Grant, GrantKernelData, UpcallCo
 use kernel::hil::spi::ClockPhase;
 use kernel::hil::spi::ClockPolarity;
 use kernel::hil::spi::{SpiMasterClient, SpiMasterDevice};
-use kernel::processbuffer::{ReadableProcessBuffer, WriteableProcessBuffer};
+use kernel::processbuffer::{ProcessSliceIndex, ReadableProcessBuffer, WriteableProcessBuffer};
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::utilities::cells::{OptionalCell, TakeCell};
 use kernel::{ErrorCode, ProcessId};
@@ -106,7 +106,7 @@ impl<'a, S: SpiMasterDevice> Spi<'a, S> {
                         let end = cmp::min(start + len, src.len());
                         start = cmp::min(start, end);
 
-                        for (i, c) in src[start..end].iter().enumerate() {
+                        for (i, c) in src.get(start..end).unwrap().iter().enumerate() {
                             kwbuf[i] = c.get();
                         }
                         end - start
@@ -309,9 +309,9 @@ impl<S: SpiMasterDevice> SpiMasterClient for Spi<'_, S> {
                                 // The amount to copy can't be longer than the size of the
                                 // read buffer. -pal 6/8/21
                                 let real_len = cmp::min(end - start, src.len());
-                                let dest_area = &dest[start..end];
+                                let dest_area = &dest.get(start..end).unwrap();
                                 for (i, c) in src[0..real_len].iter().enumerate() {
-                                    dest_area[i].set(*c);
+                                    dest_area.get(i).unwrap().set(*c);
                                 }
                             })
                         });

--- a/capsules/src/spi_peripheral.rs
+++ b/capsules/src/spi_peripheral.rs
@@ -8,7 +8,7 @@ use kernel::grant::{AllowRoCount, AllowRwCount, Grant, GrantKernelData, UpcallCo
 use kernel::hil::spi::ClockPhase;
 use kernel::hil::spi::ClockPolarity;
 use kernel::hil::spi::{SpiSlaveClient, SpiSlaveDevice};
-use kernel::processbuffer::{ReadableProcessBuffer, WriteableProcessBuffer};
+use kernel::processbuffer::{ProcessSliceIndex, ReadableProcessBuffer, WriteableProcessBuffer};
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::utilities::cells::{OptionalCell, TakeCell};
 use kernel::{ErrorCode, ProcessId};
@@ -100,7 +100,7 @@ impl<'a, S: SpiSlaveDevice> SpiPeripheral<'a, S> {
                         let end = cmp::min(start + len, src.len());
                         start = cmp::min(start, end);
 
-                        for (i, c) in src[start..end].iter().enumerate() {
+                        for (i, c) in src.get(start..end).unwrap().iter().enumerate() {
                             kwbuf[i] = c.get();
                         }
                         end - start
@@ -284,11 +284,11 @@ impl<S: SpiSlaveDevice> SpiSlaveClient for SpiPeripheral<'_, S> {
                                 // This results in a zero-length operation. -pal 12/9/20
                                 let start = cmp::min(start, end);
 
-                                let dest_area = &dest[start..end];
+                                let dest_area = &dest.get(start..end).unwrap();
                                 let real_len = end - start;
 
                                 for (i, c) in src[0..real_len].iter().enumerate() {
-                                    dest_area[i].set(*c);
+                                    dest_area.get(i).unwrap().set(*c);
                                 }
                             })
                         });

--- a/capsules/src/symmetric_encryption/aes.rs
+++ b/capsules/src/symmetric_encryption/aes.rs
@@ -10,7 +10,7 @@ use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
 use kernel::hil::symmetric_encryption::{
     AES128Ctr, CCMClient, Client, AES128, AES128CBC, AES128CCM, AES128ECB, AES128_BLOCK_SIZE,
 };
-use kernel::processbuffer::{ReadableProcessBuffer, WriteableProcessBuffer};
+use kernel::processbuffer::{ProcessSliceIndex, ReadableProcessBuffer, WriteableProcessBuffer};
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::utilities::cells::{OptionalCell, TakeCell};
 use kernel::{ErrorCode, ProcessId};
@@ -113,8 +113,10 @@ impl<'a, A: AES128<'static> + AES128Ctr + AES128CBC + AES128ECB + AES128CCM<'sta
                                     }
 
                                     // Copy the data into the static buffer
-                                    key[..static_buffer_len]
-                                        .copy_to_slice(&mut buf[..static_buffer_len]);
+                                    key.get(..static_buffer_len)
+                                        .unwrap()
+                                        .copy_to_slice(&mut buf[..static_buffer_len])
+                                        .unwrap();
 
                                     if let Some(op) = app.aes_operation.as_ref() {
                                         match op {
@@ -155,8 +157,10 @@ impl<'a, A: AES128<'static> + AES128Ctr + AES128CBC + AES128ECB + AES128CCM<'sta
                                     }
 
                                     // Copy the data into the static buffer
-                                    iv[..static_buffer_len]
-                                        .copy_to_slice(&mut buf[..static_buffer_len]);
+                                    iv.get(..static_buffer_len)
+                                        .unwrap()
+                                        .copy_to_slice(&mut buf[..static_buffer_len])
+                                        .unwrap();
 
                                     if let Some(op) = app.aes_operation.as_ref() {
                                         match op {
@@ -205,9 +209,13 @@ impl<'a, A: AES128<'static> + AES128Ctr + AES128CBC + AES128ECB + AES128CCM<'sta
                                                     }
 
                                                     // Copy the data into the static buffer
-                                                    source[..static_buffer_len].copy_to_slice(
-                                                        &mut buf[..static_buffer_len],
-                                                    );
+                                                    source
+                                                        .get(..static_buffer_len)
+                                                        .unwrap()
+                                                        .copy_to_slice(
+                                                            &mut buf[..static_buffer_len],
+                                                        )
+                                                        .unwrap();
 
                                                     self.data_copied.set(static_buffer_len);
 
@@ -227,9 +235,13 @@ impl<'a, A: AES128<'static> + AES128Ctr + AES128CBC + AES128ECB + AES128CCM<'sta
                                                     }
 
                                                     // Copy the data into the static buffer
-                                                    source[..static_buffer_len].copy_to_slice(
-                                                        &mut buf[..static_buffer_len],
-                                                    );
+                                                    source
+                                                        .get(..static_buffer_len)
+                                                        .unwrap()
+                                                        .copy_to_slice(
+                                                            &mut buf[..static_buffer_len],
+                                                        )
+                                                        .unwrap();
 
                                                     self.data_copied.set(static_buffer_len);
 
@@ -386,13 +398,17 @@ impl<'a, A: AES128<'static> + AES128Ctr + AES128CBC + AES128ECB + AES128CCM<'sta
 
                                     if app_len < static_len {
                                         if app_len - offset > 0 {
-                                            dest[offset..app_len]
-                                                .copy_from_slice(&buf[0..(app_len - offset)]);
+                                            dest.get(offset..app_len)
+                                                .unwrap()
+                                                .copy_from_slice(&buf[0..(app_len - offset)])
+                                                .unwrap();
                                         }
                                     } else {
                                         if offset + static_len <= app_len {
-                                            dest[offset..(offset + static_len)]
-                                                .copy_from_slice(&buf[0..static_len]);
+                                            dest.get(offset..(offset + static_len))
+                                                .unwrap()
+                                                .copy_from_slice(&buf[0..static_len])
+                                                .unwrap();
                                         }
                                     }
                                 })
@@ -424,13 +440,19 @@ impl<'a, A: AES128<'static> + AES128Ctr + AES128CBC + AES128ECB + AES128CCM<'sta
                                     data_len = source.len();
 
                                     if data_len > copied_data {
-                                        let remaining_data = &source[copied_data..];
+                                        let remaining_data = &source.get(copied_data..).unwrap();
                                         let remaining_len = data_len - copied_data;
 
                                         if remaining_len < static_buffer_len {
-                                            remaining_data.copy_to_slice(&mut buf[..remaining_len]);
+                                            remaining_data
+                                                .copy_to_slice(&mut buf[..remaining_len])
+                                                .unwrap();
                                         } else {
-                                            remaining_data[..static_buffer_len].copy_to_slice(buf);
+                                            remaining_data
+                                                .get(..static_buffer_len)
+                                                .unwrap()
+                                                .copy_to_slice(buf)
+                                                .unwrap();
                                         }
                                     }
                                     Ok(())
@@ -528,13 +550,17 @@ impl<'a, A: AES128<'static> + AES128Ctr + AES128CBC + AES128ECB + AES128CCM<'sta
 
                                     if app_len < static_len {
                                         if app_len - offset > 0 {
-                                            dest[offset..app_len]
-                                                .copy_from_slice(&buf[0..(app_len - offset)]);
+                                            dest.get(offset..app_len)
+                                                .unwrap()
+                                                .copy_from_slice(&buf[0..(app_len - offset)])
+                                                .unwrap();
                                         }
                                     } else {
                                         if offset + static_len <= app_len {
-                                            dest[offset..(offset + static_len)]
-                                                .copy_from_slice(&buf[0..static_len]);
+                                            dest.get(offset..(offset + static_len))
+                                                .unwrap()
+                                                .copy_from_slice(&buf[0..static_len])
+                                                .unwrap();
                                         }
                                     }
                                 })
@@ -711,8 +737,11 @@ impl<'a, A: AES128<'static> + AES128Ctr + AES128CBC + AES128ECB + AES128CCM<'sta
                                                 }
 
                                                 // Copy the data into the static buffer
-                                                source[..static_buffer_len]
-                                                    .copy_to_slice(&mut buf[..static_buffer_len]);
+                                                source
+                                                    .get(..static_buffer_len)
+                                                    .unwrap()
+                                                    .copy_to_slice(&mut buf[..static_buffer_len])
+                                                    .unwrap();
 
                                                 self.data_copied.set(static_buffer_len);
 

--- a/capsules/src/text_screen.rs
+++ b/capsules/src/text_screen.rs
@@ -16,7 +16,7 @@ use core::convert::From;
 
 use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
 use kernel::hil;
-use kernel::processbuffer::ReadableProcessBuffer;
+use kernel::processbuffer::{ProcessSliceIndex, ReadableProcessBuffer};
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::utilities::cells::{OptionalCell, TakeCell};
 use kernel::{ErrorCode, ProcessId};
@@ -171,7 +171,7 @@ impl<'a> TextScreen<'a> {
                                         self.buffer.take().map_or(Err(ErrorCode::BUSY), |buffer| {
                                             let len = cmp::min(app.write_len, buffer.len());
                                             for n in 0..len {
-                                                buffer[n] = to_write_buffer[n].get();
+                                                buffer[n] = to_write_buffer.get(n).unwrap().get();
                                             }
                                             match self.text_screen.print(buffer, len) {
                                                 Ok(()) => Ok(()),

--- a/capsules/src/touch.rs
+++ b/capsules/src/touch.rs
@@ -18,7 +18,7 @@ use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
 use kernel::hil;
 use kernel::hil::screen::ScreenRotation;
 use kernel::hil::touch::{GestureEvent, TouchClient, TouchEvent, TouchStatus};
-use kernel::processbuffer::WriteableProcessBuffer;
+use kernel::processbuffer::{ProcessSliceIndex, WriteableProcessBuffer};
 use kernel::syscall::{CommandReturn, SyscallDriver};
 use kernel::{ErrorCode, ProcessId};
 
@@ -261,20 +261,32 @@ impl<'a> hil::touch::MultiTouchClient for Touch<'a> {
                                         // one touch entry is 8 bytes long
                                         let offset = event_index * 8;
                                         if buffer.len() > event_index + 8 {
-                                            buffer[offset].set(event.id as u8);
-                                            buffer[offset + 1].set(event_status as u8);
-                                            buffer[offset + 2].set((event.x & 0xFF) as u8);
-                                            buffer[offset + 3].set(((event.x & 0xFFFF) >> 8) as u8);
-                                            buffer[offset + 4].set((event.y & 0xFF) as u8);
-                                            buffer[offset + 5].set(((event.y & 0xFFFF) >> 8) as u8);
-                                            buffer[offset + 6].set(
+                                            buffer.get(offset).unwrap().set(event.id as u8);
+                                            buffer.get(offset + 1).unwrap().set(event_status as u8);
+                                            buffer
+                                                .get(offset + 2)
+                                                .unwrap()
+                                                .set((event.x & 0xFF) as u8);
+                                            buffer
+                                                .get(offset + 3)
+                                                .unwrap()
+                                                .set(((event.x & 0xFFFF) >> 8) as u8);
+                                            buffer
+                                                .get(offset + 4)
+                                                .unwrap()
+                                                .set((event.y & 0xFF) as u8);
+                                            buffer
+                                                .get(offset + 5)
+                                                .unwrap()
+                                                .set(((event.y & 0xFFFF) >> 8) as u8);
+                                            buffer.get(offset + 6).unwrap().set(
                                                 if let Some(size) = event.size {
                                                     size as u8
                                                 } else {
                                                     0
                                                 },
                                             );
-                                            buffer[offset + 7].set(
+                                            buffer.get(offset + 7).unwrap().set(
                                                 if let Some(pressure) = event.pressure {
                                                     pressure as u8
                                                 } else {

--- a/kernel/src/processbuffer.rs
+++ b/kernel/src/processbuffer.rs
@@ -1,17 +1,17 @@
 //! Data structures for passing application memory to the kernel.
 //!
-//! A Tock process can pass read-write or read-only buffers into the
-//! kernel for it to use. The kernel checks that read-write buffers
-//! exist within a process's RAM address space, and that read-only
-//! buffers exist either within its RAM or flash address space. These
-//! buffers are shared with the allow_read_write() and
-//! allow_read_only() system calls.
+//! A Tock process can pass read-write or read-only buffers into the kernel for
+//! it to use. The kernel checks that read-write buffers exist within a
+//! process's RAM address space, and that read-only buffers exist either within
+//! its RAM or flash address space. These buffers are shared with the
+//! `allow_readwrite()` and `allow_readonly()` system calls. Refer to [TRD 104
+//! -- Syscalls][1] for more information.
 //!
-//! A read-write and read-only call is mapped to the high-level Rust
-//! types [`ReadWriteProcessBuffer`] and [`ReadOnlyProcessBuffer`]
-//! respectively. The memory regions can be accessed through the
-//! [`ReadableProcessBuffer`] and [`WriteableProcessBuffer`] traits,
-//! implemented on the process buffer structs.
+//! A read-write and read-only call is mapped to the high-level Rust types
+//! [`ReadWriteProcessBuffer`] and [`ReadOnlyProcessBuffer`] respectively. The
+//! memory regions can be accessed through the [`ReadableProcessBuffer`] and
+//! [`WriteableProcessBuffer`] traits, implemented on the process buffer
+//! structs.
 //!
 //! Each access to the buffer structs requires a liveness check to ensure that
 //! the process memory is still valid. For a more traditional interface, users
@@ -19,136 +19,29 @@
 //! [`WriteableProcessSlice`] and use these for the lifetime of their
 //! operations. Users cannot hold live-lived references to these slices,
 //! however.
+//!
+//! [1]: https://github.com/tock/tock/blob/master/doc/reference/trd104-syscalls.md
 
-use core::cell::Cell;
+use core::iter::Iterator;
 use core::marker::PhantomData;
-use core::ops::{Deref, Index, Range, RangeFrom, RangeTo};
+use core::ops::{Deref, Range, RangeFrom, RangeTo};
+use core::ptr::NonNull;
 
 use crate::capabilities;
 use crate::process::{self, ProcessId};
 use crate::ErrorCode;
 
-/// Convert a process buffer's internal representation to a
-/// ReadableProcessSlice.
-///
-/// This function will automatically convert zero-length process
-/// buffers into valid zero-sized Rust slices regardless of the value
-/// of `ptr`.
-///
-/// # Safety requirements
-///
-/// In the case of `len != 0`, the memory `[ptr; ptr + len)` must be
-/// within a single process' address space, and `ptr` must be
-/// nonzero. This memory region must be mapped as _readable_, and
-/// optionally _writable_ and _executable_. It must be allocated
-/// within a single process' address space for the entire lifetime
-/// `'a`.
-///
-/// It is sound for multiple overlapping [`ReadableProcessSlice`]s or
-/// [`WriteableProcessSlice`]s to be in scope at the same time.
-unsafe fn raw_processbuf_to_roprocessslice<'a>(
-    ptr: *const u8,
-    len: usize,
-) -> &'a ReadableProcessSlice {
-    // Transmute a reference to a slice of Cell<u8>s into a reference
-    // to a ReadableProcessSlice. This is possible as
-    // ReadableProcessSlice is a #[repr(transparent)] wrapper around a
-    // [ReadableProcessByte], which is a #[repr(transparent)] wrapper
-    // around a [Cell<u8>], which is a #[repr(transparent)] wrapper
-    // around an [UnsafeCell<u8>], which finally #[repr(transparent)]
-    // wraps a [u8]
-    core::mem::transmute::<&[u8], &ReadableProcessSlice>(
-        // Rust has very strict requirements on pointer validity[1]
-        // which also in part apply to accesses of length 0. We allow
-        // an application to supply arbitrary pointers if the buffer
-        // length is 0, but this is not allowed for Rust slices. For
-        // instance, a null pointer is _never_ valid, not even for
-        // accesses of size zero.
-        //
-        // To get a pointer which does not point to valid (allocated)
-        // memory, but is safe to construct for accesses of size zero,
-        // we must call NonNull::dangling(). The resulting pointer is
-        // guaranteed to be well-aligned and uphold the guarantees
-        // required for accesses of size zero.
-        //
-        // [1]: https://doc.rust-lang.org/core/ptr/index.html#safety
-        match len {
-            0 => core::slice::from_raw_parts(core::ptr::NonNull::<u8>::dangling().as_ptr(), 0),
-            _ => core::slice::from_raw_parts(ptr, len),
-        },
-    )
-}
-
-/// Convert an process buffers's internal representation to a
-/// WriteableProcessSlice.
-///
-/// This function will automatically convert zero-length process
-/// buffers into valid zero-sized Rust slices regardless of the value
-/// of `ptr`.
-///
-/// # Safety requirements
-///
-/// In the case of `len != 0`, the memory `[ptr; ptr + len)` must be
-/// within a single process' address space, and `ptr` must be
-/// nonzero. This memory region must be mapped as _readable_ and
-/// _writable_, and optionally _executable_. It must be allocated
-/// within a single process' address space for the entire lifetime
-/// `'a`.
-///
-/// No other mutable or immutable Rust reference pointing to an
-/// overlapping memory region, which is not also created over
-/// `UnsafeCell`, may exist over the entire lifetime `'a`. Even though
-/// this effectively returns a slice of [`Cell`]s, writing to some
-/// memory through a [`Cell`] while another reference is in scope is
-/// unsound. Because a process is free to modify its memory, this is
-/// -- in a broader sense -- true for all process memory.
-///
-/// However, it is sound for multiple overlapping
-/// [`ReadableProcessSlice`]s or [`WriteableProcessSlice`]s to be in
-/// scope at the same time.
-unsafe fn raw_processbuf_to_rwprocessslice<'a>(
-    ptr: *mut u8,
-    len: usize,
-) -> &'a WriteableProcessSlice {
-    // Transmute a reference to a slice of Cell<u8>s into a reference
-    // to a ReadableProcessSlice. This is possible as
-    // ReadableProcessSlice is a #[repr(transparent)] wrapper around a
-    // [ReadableProcessByte], which is a #[repr(transparent)] wrapper
-    // around a [Cell<u8>], which is a #[repr(transparent)] wrapper
-    // around an [UnsafeCell<u8>], which finally #[repr(transparent)]
-    // wraps a [u8]
-    core::mem::transmute::<&[u8], &WriteableProcessSlice>(
-        // Rust has very strict requirements on pointer validity[1]
-        // which also in part apply to accesses of length 0. We allow
-        // an application to supply arbitrary pointers if the buffer
-        // length is 0, but this is not allowed for Rust slices. For
-        // instance, a null pointer is _never_ valid, not even for
-        // accesses of size zero.
-        //
-        // To get a pointer which does not point to valid (allocated)
-        // memory, but is safe to construct for accesses of size zero,
-        // we must call NonNull::dangling(). The resulting pointer is
-        // guaranteed to be well-aligned and uphold the guarantees
-        // required for accesses of size zero.
-        //
-        // [1]: https://doc.rust-lang.org/core/ptr/index.html#safety
-        match len {
-            0 => core::slice::from_raw_parts_mut(core::ptr::NonNull::<u8>::dangling().as_ptr(), 0),
-            _ => core::slice::from_raw_parts_mut(ptr, len),
-        },
-    )
-}
+// ---------- PROCESS BUFFER TRAITS --------------------------------------------
 
 /// A readable region of userspace process memory.
 ///
-/// This trait can be used to gain read-only access to memory regions
-/// wrapped in either a [`ReadOnlyProcessBuffer`] or a
-/// [`ReadWriteProcessBuffer`] type.
+/// This trait can be used to gain read-only access to memory regions wrapped in
+/// either a [`ReadOnlyProcessBuffer`] or a [`ReadWriteProcessBuffer`] type.
 pub trait ReadableProcessBuffer {
     /// Length of the memory region.
     ///
-    /// If the process is no longer alive and the memory has been
-    /// reclaimed, this method must return 0.
+    /// If the process is no longer alive and the memory has been reclaimed,
+    /// this method must return 0.
     ///
     /// # Default Process Buffer
     ///
@@ -157,14 +50,13 @@ pub trait ReadableProcessBuffer {
 
     /// Pointer to the first byte of the userspace memory region.
     ///
-    /// If the length of the initially shared memory region
-    /// (irrespective of the return value of
-    /// [`len`](ReadableProcessBuffer::len)) is 0, this function returns
-    /// a pointer to address `0x0`. This is because processes may
-    /// allow buffers with length 0 to share no memory with the
-    /// kernel. Because these buffers have zero length, they may have
-    /// any pointer value. However, these _dummy addresses_ should not
-    /// be leaked, so this method returns 0 for zero-length slices.
+    /// If the length of the initially shared memory region (irrespective of the
+    /// return value of [`len`](ReadableProcessBuffer::len)) is 0, this function
+    /// returns a pointer to address `0x0`. This is because processes may allow
+    /// buffers with length 0 to share no memory with the kernel. Because these
+    /// buffers have zero length, they may have any pointer value. However,
+    /// these _dummy addresses_ should not be leaked, so this method returns 0
+    /// for zero-length slices.
     ///
     /// # Default Process Buffer
     ///
@@ -172,63 +64,62 @@ pub trait ReadableProcessBuffer {
     /// to address `0x0`.
     fn ptr(&self) -> *const u8;
 
-    /// Applies a function to the (read only) process slice reference
-    /// pointed to by the process buffer.
+    /// Applies a function to the (read only) process slice reference pointed to
+    /// by the process buffer.
     ///
-    /// If the process is no longer alive and the memory has been
-    /// reclaimed, this method must return
-    /// `Err(process::Error::NoSuchApp)`.
+    /// If the process is no longer alive and the memory has been reclaimed,
+    /// this method must return `Err(process::Error::NoSuchApp)`.
     ///
     /// # Default Process Buffer
     ///
     /// A default instance of a process buffer must return
-    /// `Err(process::Error::NoSuchApp)` without executing the passed
-    /// closure.
-    fn enter<F, R>(&self, fun: F) -> Result<R, process::Error>
+    /// `Err(process::Error::NoSuchApp)` without executing the passed closure.
+    fn enter<'a, F, R>(&'a self, fun: F) -> Result<R, process::Error>
     where
-        F: FnOnce(&ReadableProcessSlice) -> R;
+        F: FnOnce(ReadableProcessSlice<'a>) -> R;
 }
 
 /// A readable and writeable region of userspace process memory.
 ///
-/// This trait can be used to gain read-write access to memory regions
-/// wrapped in a [`ReadWriteProcessBuffer`].
+/// This trait can be used to gain read-write access to memory regions wrapped
+/// in a [`ReadWriteProcessBuffer`].
 ///
-/// This is a supertrait of [`ReadableProcessBuffer`], which features
-/// methods allowing mutable access.
+/// This is a supertrait of [`ReadableProcessBuffer`], which features methods
+/// allowing mutable access.
 pub trait WriteableProcessBuffer: ReadableProcessBuffer {
-    /// Applies a function to the mutable process slice reference
-    /// pointed to by the [`ReadWriteProcessBuffer`].
+    /// Applies a function to the mutable process slice reference pointed to by
+    /// the [`ReadWriteProcessBuffer`].
     ///
-    /// If the process is no longer alive and the memory has been
-    /// reclaimed, this method must return
-    /// `Err(process::Error::NoSuchApp)`.
+    /// If the process is no longer alive and the memory has been reclaimed,
+    /// this method must return `Err(process::Error::NoSuchApp)`.
     ///
     /// # Default Process Buffer
     ///
     /// A default instance of a process buffer must return
-    /// `Err(process::Error::NoSuchApp)` without executing the passed
-    /// closure.
-    fn mut_enter<F, R>(&self, fun: F) -> Result<R, process::Error>
+    /// `Err(process::Error::NoSuchApp)` without executing the passed closure.
+    fn mut_enter<'a, F, R>(&'a self, fun: F) -> Result<R, process::Error>
     where
-        F: FnOnce(&WriteableProcessSlice) -> R;
+        F: FnOnce(WriteableProcessSlice<'a>) -> R;
 }
 
-/// Read-only buffer shared by a userspace process
+// ---------- PROCESS BUFFER TYPES ---------------------------------------------
+
+/// Read-only buffer shared by a userspace process.
 ///
-/// This struct is provided to capsules when a process `allow`s a
-/// particular section of its memory to the kernel and gives the
-/// kernel read access to this memory.
+/// This struct is provided to capsules when a process `allow`s a particular
+/// section of its memory to the kernel and gives the kernel read access to this
+/// memory.
 ///
-/// It can be used to obtain a [`ReadableProcessSlice`], which is
-/// based around a slice of [`Cell`]s. This is because a userspace can
-/// `allow` overlapping sections of memory into different
-/// [`ReadableProcessSlice`]. Having at least one mutable Rust slice
-/// along with read-only slices to overlapping memory in Rust violates
-/// Rust's aliasing rules. A slice of [`Cell`]s avoids this issue by
-/// explicitly supporting interior mutability. Still, a memory barrier
-/// prior to switching to userspace is required, as the compiler is
-/// free to reorder reads and writes, even through [`Cell`]s.
+/// It can be used to obtain a [`ReadableProcessSlice`], which uses operations
+/// on raw pointers to access the covered memory. This is because a userspace
+/// can `allow` overlapping sections of memory into different
+/// [`ReadableProcessSlice`]. Having at least one mutable Rust slice along with
+/// read-only slices to overlapping memory in Rust violates Rust's aliasing
+/// rules. Raw pointer accesses avoid this issue, as Rust cannot statically
+/// determine two pointers to be within the same allocation and apply aliasing
+/// optimizations. Still, a memory barrier prior to switching to userspace is
+/// required, as the compiler is free to reorder reads and writes, even through
+/// raw pointer operations.
 pub struct ReadOnlyProcessBuffer {
     ptr: *const u8,
     len: usize,
@@ -243,6 +134,10 @@ impl ReadOnlyProcessBuffer {
     ///
     /// Refer to the safety requirements of
     /// [`ReadOnlyProcessBuffer::new_external`].
+    // TODO: refactor this method to return an Option<Self>, enforcing the
+    // required invariant of `ptr != 0 || len == 0`. This is currently enforced
+    // through ProcessStandard::build_readonly_process_buffer, but is better to
+    // be encoded in the type system when constructing this struct.
     pub(crate) unsafe fn new(ptr: *const u8, len: usize, process_id: ProcessId) -> Self {
         ReadOnlyProcessBuffer {
             ptr,
@@ -255,33 +150,33 @@ impl ReadOnlyProcessBuffer {
     /// and length.
     ///
     /// Publicly accessible constructor, which requires the
-    /// [`capabilities::ExternalProcessCapability`] capability. This
-    /// is provided to allow implementations of the
-    /// [`Process`](crate::process::Process) trait outside of the
-    /// `kernel` crate.
+    /// [`capabilities::ExternalProcessCapability`] capability. This is provided
+    /// to allow implementations of the [`Process`](crate::process::Process)
+    /// trait outside of the `kernel` crate.
     ///
     /// # Safety requirements
     ///
-    /// If the length is `0`, an arbitrary pointer may be passed into
-    /// `ptr`. It does not necessarily have to point to allocated
-    /// memory, nor does it have to meet [Rust's pointer validity
+    /// If the length is `0`, an arbitrary pointer may be passed into `ptr`. It
+    /// does not necessarily have to point to allocated memory, nor does it have
+    /// to meet [Rust's pointer validity
     /// requirements](https://doc.rust-lang.org/core/ptr/index.html#safety).
-    /// [`ReadOnlyProcessBuffer`] must ensure that all Rust slices
-    /// with a length of `0` must be constructed over a valid (but not
-    /// necessarily allocated) base pointer.
+    /// [`ReadOnlyProcessBuffer`] will ensure that all [`ReadableProcessSlice`]s
+    /// with a length of `0` be constructed over a valid (but not necessarily
+    /// allocated) base pointer.
     ///
-    /// If the length is not `0`, the memory region of `[ptr; ptr +
-    /// len)` must be valid memory of the process of the given
-    /// [`ProcessId`]. It must be allocated and and accessible over
-    /// the entire lifetime of the [`ReadOnlyProcessBuffer`]. It must
-    /// not point to memory outside of the process' accessible memory
-    /// range, or point (in part) to other processes or kernel
-    /// memory. The `ptr` must meet [Rust's requirements for pointer
-    /// validity](https://doc.rust-lang.org/core/ptr/index.html#safety),
-    /// in particular it must have a minimum alignment of
-    /// `core::mem::align_of::<u8>()` on the respective platform. It
-    /// must point to memory mapped as _readable_ and optionally
-    /// _writable_ and _executable_.
+    /// If the length is not `0`, the memory region of `[ptr; ptr + len)` must
+    /// be valid memory of the process of the given [`ProcessId`]. The memory
+    /// region must not contain address `0`, wrap the memory space or be larger
+    /// than `isize::MAX`. It must be allocated and and accessible over the
+    /// entire lifetime of the [`ReadOnlyProcessBuffer`]. It must not point to
+    /// memory outside of the process' accessible memory range, or point (in
+    /// part) to other processes or kernel memory. The `ptr` must meet [Rust's
+    /// requirements for pointer
+    /// validity](https://doc.rust-lang.org/core/ptr/index.html#safety), in
+    /// particular it must have a minimum alignment of
+    /// `core::mem::align_of::<u8>()` on the respective platform. It must point
+    /// to memory mapped as _readable_ and optionally _writable_ and
+    /// _executable_.
     pub unsafe fn new_external(
         ptr: *const u8,
         len: usize,
@@ -291,14 +186,13 @@ impl ReadOnlyProcessBuffer {
         Self::new(ptr, len, process_id)
     }
 
-    /// Consumes the ReadOnlyProcessBuffer, returning its constituent
-    /// pointer and size. This ensures that there cannot
-    /// simultaneously be both a `ReadOnlyProcessBuffer` and a pointer
-    /// to its internal data.
+    /// Consumes the ReadOnlyProcessBuffer, returning its constituent pointer
+    /// and size. This ensures that there cannot simultaneously be both a
+    /// `ReadOnlyProcessBuffer` and a pointer to its internal data.
     ///
-    /// `consume` can be used when the kernel needs to pass the
-    /// underlying values across the kernel-to-user boundary (e.g., in
-    /// return values to system calls).
+    /// `consume` can be used when the kernel needs to pass the underlying
+    /// values across the kernel-to-user boundary (e.g., in return values to
+    /// system calls).
     pub(crate) fn consume(self) -> (*const u8, usize) {
         (self.ptr, self.len)
     }
@@ -318,39 +212,78 @@ impl ReadableProcessBuffer for ReadOnlyProcessBuffer {
         }
     }
 
-    fn enter<F, R>(&self, fun: F) -> Result<R, process::Error>
+    fn enter<'a, F, R>(&'a self, fun: F) -> Result<R, process::Error>
     where
-        F: FnOnce(&ReadableProcessSlice) -> R,
+        F: FnOnce(ReadableProcessSlice<'a>) -> R,
     {
         match self.process_id {
             None => Err(process::Error::NoSuchApp),
             Some(pid) => pid
                 .kernel
                 .process_map_or(Err(process::Error::NoSuchApp), pid, |_| {
-                    // Safety: `kernel.process_map_or()` validates that
-                    // the process still exists and its memory is still
-                    // valid. In particular, `Process` tracks the "high water
-                    // mark" of memory that the process has `allow`ed to the
-                    // kernel. Because `Process` does not feature an API to
-                    // move the "high water mark" down again, which would be
-                    // called once a `ProcessBuffer` has been passed back into
-                    // the kernel, a given `Process` implementation must assume
-                    // that the memory described by a once-allowed
-                    // `ProcessBuffer` is still in use, and thus will not
-                    // permit the process to free any memory after it has
-                    // been `allow`ed to the kernel once. This guarantees
-                    // that the buffer is safe to convert into a slice
-                    // here. For more information, refer to the
-                    // comment and subsequent discussion on tock/tock#2632:
-                    // https://github.com/tock/tock/pull/2632#issuecomment-869974365
-                    Ok(fun(unsafe {
-                        raw_processbuf_to_roprocessslice(self.ptr, self.len)
-                    }))
+                    // ## Safety
+                    //
+                    // While the ReadOnlyProcessBuffer must refuse construction
+                    // with a null-pointer and a non-zero length, it may still
+                    // contain a null-pointer. This is because it must be able
+                    // to represent all valid read-only allow buffer
+                    // descriptions passed from userspace. Nonetheless, a Rust
+                    // slice (or any Rust allocation) cannot be located at
+                    // address zero, even zero-sized types, and especially not a
+                    // NonNull. Thus, apply the following rules:
+                    //
+                    // 1. if the buffer is of non-zero length, it must have a
+                    //    non-null pointer (refer to
+                    //    ReadableProcessBuffer::new_external). Construct a
+                    //    NonNull based on that pointer.
+                    //
+                    // 2. if the buffer is of zero-length, it may have a null
+                    //    pointer. Regardless, in the spirit of the
+                    //    ReadableProcessSlice::ptr method, we don't have to
+                    //    expose the proper pointer provided by the application,
+                    //    as this does not have any meaning for a zero-sized
+                    //    slice (not bounds checked, etc.). Thus, always return
+                    //    a NonNull::dangling in this case.
+                    //
+                    // Through the basic assumption of non zero-length buffer
+                    // having a properly aligned, non-null pointer, the
+                    // following use of NonNull::new_unchecked is safe here:
+                    let ptr = if self.len > 0 {
+                        unsafe { NonNull::new_unchecked(self.ptr as *mut u8) }
+                    } else {
+                        NonNull::dangling()
+                    };
+
+                    // ## Safety
+                    //
+                    // `kernel.process_map_or()` validates that the process
+                    // still exists and its memory is still valid. In
+                    // particular, `Process` tracks the "high water mark" of
+                    // memory that the process has `allow`ed to the
+                    // kernel. Because `Process` does not feature an API to move
+                    // the "high water mark" down again, which would be called
+                    // once a `ProcessBuffer` has been passed back into the
+                    // kernel, a given `Process` implementation must assume that
+                    // the memory described by a once-allowed `ProcessBuffer` is
+                    // still in use, and thus will not permit the process to
+                    // free any memory after it has been `allow`ed to the kernel
+                    // once. This guarantees that the memory pointed to by the
+                    // buffer is safe to dereference here. For more information,
+                    // refer to the comment and subsequent discussion on
+                    // tock/tock#2632[1].
+                    //
+                    // [1]: https://github.com/tock/tock/pull/2632#issuecomment-869974365
+                    Ok(fun(unsafe { ReadableProcessSlice::new(ptr, self.len) }))
                 }),
         }
     }
 }
 
+// TODO: remove, along with making the ProcessId non-optional and moving it to
+// the front. This should save us a usize in some cases (e.g.
+// Option<ReadOnlyProcessBuffer>), as ProcessId must start with a non-null field
+// (&'static Kernel) and thus ReadOnlyProcessBuffer will also start with a
+// non-null field.
 impl Default for ReadOnlyProcessBuffer {
     fn default() -> Self {
         ReadOnlyProcessBuffer {
@@ -362,7 +295,8 @@ impl Default for ReadOnlyProcessBuffer {
 }
 
 /// Provides access to a ReadOnlyProcessBuffer with a restricted lifetime.
-/// This automatically dereferences into a ReadOnlyProcessBuffer
+///
+/// This automatically dereferences into a ReadOnlyProcessBuffer.
 pub struct ReadOnlyProcessBufferRef<'a> {
     buf: ReadOnlyProcessBuffer,
     _phantom: PhantomData<&'a ()>,
@@ -375,9 +309,9 @@ impl ReadOnlyProcessBufferRef<'_> {
     /// # Safety requirements
     ///
     /// Refer to the safety requirements of
-    /// [`ReadOnlyProcessBuffer::new_external`]. The derived lifetime can
-    /// help enforce the invariant that this incoming pointer may only
-    /// be access for a certain duration.
+    /// [`ReadOnlyProcessBuffer::new_external`]. The derived lifetime can help
+    /// enforce the invariant that this incoming pointer may only be access for
+    /// a certain duration.
     pub(crate) unsafe fn new(ptr: *const u8, len: usize, process_id: ProcessId) -> Self {
         Self {
             buf: ReadOnlyProcessBuffer::new(ptr, len, process_id),
@@ -393,22 +327,22 @@ impl Deref for ReadOnlyProcessBufferRef<'_> {
     }
 }
 
-/// Read-writable buffer shared by a userspace process
+/// Read-writable buffer shared by a userspace process.
 ///
-/// This struct is provided to capsules when a process `allows` a
-/// particular section of its memory to the kernel and gives the
-/// kernel read and write access to this memory.
+/// This struct is provided to capsules when a process `allows` a particular
+/// section of its memory to the kernel and gives the kernel read and write
+/// access to this memory.
 ///
-/// It can be used to obtain a [`WriteableProcessSlice`], which is
-/// based around a slice of [`Cell`]s. This is because a userspace can
-/// `allow` overlapping sections of memory into different
-/// [`WriteableProcessSlice`]. Having at least one mutable Rust slice
-/// along with read-only or other mutable slices to overlapping memory
-/// in Rust violates Rust's aliasing rules. A slice of [`Cell`]s
-/// avoids this issue by explicitly supporting interior
-/// mutability. Still, a memory barrier prior to switching to
-/// userspace is required, as the compiler is free to reorder reads
-/// and writes, even through [`Cell`]s.
+/// It can be used to obtain a [`WriteableProcessSlice`], which uses operations
+/// on raw pointers to access the covered memory. This is because a userspace
+/// can `allow` overlapping sections of memory into different
+/// [`ReadableProcessSlice`]. Having at least one mutable Rust slice along with
+/// read-only or other mutable slices to overlapping memory in Rust violates
+/// Rust's aliasing rules. Raw pointer accesses avoid this issue, as Rust cannot
+/// statically determine two pointers to be within the same allocation and apply
+/// aliasing optimizations. Still, a memory barrier prior to switching to
+/// userspace is required, as the compiler is free to reorder reads and writes,
+/// even through raw pointer operations.
 pub struct ReadWriteProcessBuffer {
     ptr: *mut u8,
     len: usize,
@@ -423,6 +357,10 @@ impl ReadWriteProcessBuffer {
     ///
     /// Refer to the safety requirements of
     /// [`ReadWriteProcessBuffer::new_external`].
+    // TODO: refactor this method to return an Option<Self>, enforcing the
+    // required invariant of `ptr != 0 || len == 0`. This is currently enforced
+    // through ProcessStandard::build_readonly_process_buffer, but is better to
+    // be encoded in the type system when constructing this struct.
     pub(crate) unsafe fn new(ptr: *mut u8, len: usize, process_id: ProcessId) -> Self {
         ReadWriteProcessBuffer {
             ptr,
@@ -435,33 +373,34 @@ impl ReadWriteProcessBuffer {
     /// pointer and length.
     ///
     /// Publicly accessible constructor, which requires the
-    /// [`capabilities::ExternalProcessCapability`] capability. This
-    /// is provided to allow implementations of the
-    /// [`Process`](crate::process::Process) trait outside of the
-    /// `kernel` crate.
+    /// [`capabilities::ExternalProcessCapability`] capability. This is provided
+    /// to allow implementations of the [`Process`](crate::process::Process)
+    /// trait outside of the `kernel` crate.
     ///
     /// # Safety requirements
     ///
-    /// If the length is `0`, an arbitrary pointer may be passed into
-    /// `ptr`. It does not necessarily have to point to allocated
-    /// memory, nor does it have to meet [Rust's pointer validity
+    /// If the length is `0`, an arbitrary pointer may be passed into `ptr`. It
+    /// does not necessarily have to point to allocated memory, nor does it have
+    /// to meet [Rust's pointer validity
     /// requirements](https://doc.rust-lang.org/core/ptr/index.html#safety).
-    /// [`ReadWriteProcessBuffer`] must ensure that all Rust slices
-    /// with a length of `0` must be constructed over a valid (but not
-    /// necessarily allocated) base pointer.
+    /// [`ReadWriteProcessBuffer`] will ensure that all
+    /// [`ReadableProcessSlice`]s and [`WriteableProcessSlice`]s with a length
+    /// of `0` be constructed over a valid (but not necessarily allocated) base
+    /// pointer.
     ///
-    /// If the length is not `0`, the memory region of `[ptr; ptr +
-    /// len)` must be valid memory of the process of the given
-    /// [`ProcessId`]. It must be allocated and and accessible over
-    /// the entire lifetime of the [`ReadWriteProcessBuffer`]. It must
-    /// not point to memory outside of the process' accessible memory
-    /// range, or point (in part) to other processes or kernel
-    /// memory. The `ptr` must meet [Rust's requirements for pointer
-    /// validity](https://doc.rust-lang.org/core/ptr/index.html#safety),
-    /// in particular it must have a minimum alignment of
-    /// `core::mem::align_of::<u8>()` on the respective platform. It
-    /// must point to memory mapped as _readable_ and optionally
-    /// _writable_ and _executable_.
+    /// If the length is not `0`, the memory region of `[ptr; ptr + len)` must
+    /// be valid memory of the process of the given [`ProcessId`]. The memory
+    /// region must not contain address `0`, wrap the memory space or be larger
+    /// than `isize::MAX`. It must be allocated and and accessible over the
+    /// entire lifetime of the [`ReadWriteProcessBuffer`]. It must not point to
+    /// memory outside of the process' accessible memory range, or point (in
+    /// part) to other processes or kernel memory. The `ptr` must meet [Rust's
+    /// requirements for pointer
+    /// validity](https://doc.rust-lang.org/core/ptr/index.html#safety), in
+    /// particular it must have a minimum alignment of
+    /// `core::mem::align_of::<u8>()` on the respective platform. It must point
+    /// to memory mapped as _readable_ and _writable_ and optionally
+    /// _executable_.
     pub unsafe fn new_external(
         ptr: *mut u8,
         len: usize,
@@ -471,14 +410,13 @@ impl ReadWriteProcessBuffer {
         Self::new(ptr, len, process_id)
     }
 
-    /// Consumes the ReadWriteProcessBuffer, returning its constituent
-    /// pointer and size. This ensures that there cannot
-    /// simultaneously be both a `ReadWriteProcessBuffer` and a pointer to
-    /// its internal data.
+    /// Consumes the ReadWriteProcessBuffer, returning its constituent pointer
+    /// and size. This ensures that there cannot simultaneously be both a
+    /// `ReadWriteProcessBuffer` and a pointer to its internal data.
     ///
-    /// `consume` can be used when the kernel needs to pass the
-    /// underlying values across the kernel-to-user boundary (e.g., in
-    /// return values to system calls).
+    /// `consume` can be used when the kernel needs to pass the underlying
+    /// values across the kernel-to-user boundary (e.g., in return values to
+    /// system calls).
     pub(crate) fn consume(self) -> (*mut u8, usize) {
         (self.ptr, self.len)
     }
@@ -486,9 +424,8 @@ impl ReadWriteProcessBuffer {
     /// This is a `const` version of `Default::default` with the same
     /// semantics.
     ///
-    /// Having a const initializer allows initializing a fixed-size
-    /// array with default values without the struct being marked
-    /// `Copy` as such:
+    /// Having a const initializer allows initializing a fixed-size array with
+    /// default values without the struct being marked `Copy` as such:
     ///
     /// ```
     /// use kernel::processbuffer::ReadWriteProcessBuffer;
@@ -519,73 +456,146 @@ impl ReadableProcessBuffer for ReadWriteProcessBuffer {
         }
     }
 
-    fn enter<F, R>(&self, fun: F) -> Result<R, process::Error>
+    fn enter<'a, F, R>(&'a self, fun: F) -> Result<R, process::Error>
     where
-        F: FnOnce(&ReadableProcessSlice) -> R,
+        F: FnOnce(ReadableProcessSlice<'a>) -> R,
     {
         match self.process_id {
             None => Err(process::Error::NoSuchApp),
             Some(pid) => pid
                 .kernel
                 .process_map_or(Err(process::Error::NoSuchApp), pid, |_| {
-                    // Safety: `kernel.process_map_or()` validates that
-                    // the process still exists and its memory is still
-                    // valid. In particular, `Process` tracks the "high water
-                    // mark" of memory that the process has `allow`ed to the
-                    // kernel. Because `Process` does not feature an API to
-                    // move the "high water mark" down again, which would be
-                    // called once a `ProcessBuffer` has been passed back into
-                    // the kernel, a given `Process` implementation must assume
-                    // that the memory described by a once-allowed
-                    // `ProcessBuffer` is still in use, and thus will not
-                    // permit the process to free any memory after it has
-                    // been `allow`ed to the kernel once. This guarantees
-                    // that the buffer is safe to convert into a slice
-                    // here. For more information, refer to the
-                    // comment and subsequent discussion on tock/tock#2632:
-                    // https://github.com/tock/tock/pull/2632#issuecomment-869974365
-                    Ok(fun(unsafe {
-                        raw_processbuf_to_roprocessslice(self.ptr, self.len)
-                    }))
+                    // ## Safety
+                    //
+                    // While the ReadWriteProcessBuffer must refuse construction
+                    // with a null-pointer and a non-zero length, it may still
+                    // contain a null-pointer. This is because it must be able
+                    // to represent all valid read-only allow buffer
+                    // descriptions passed from userspace. Nonetheless, a Rust
+                    // slice (or any Rust allocation) cannot be located at
+                    // address zero, even zero-sized types, and especially not a
+                    // NonNull. Thus, apply the following rules:
+                    //
+                    // 1. if the buffer is of non-zero length, it must have a
+                    //    non-null pointer (refer to
+                    //    ReadableProcessBuffer::new_external). Construct a
+                    //    NonNull based on that pointer.
+                    //
+                    // 2. if the buffer is of zero-length, it may have a null
+                    //    pointer. Regardless, in the spirit of the
+                    //    ReadableProcessSlice::ptr method, we don't have to
+                    //    expose the proper pointer provided by the application,
+                    //    as this does not have any meaning for a zero-sized
+                    //    slice (not bounds checked, etc.). Thus, always return
+                    //    a NonNull::dangling in this case.
+                    //
+                    // Through the basic assumption of non zero-length buffer
+                    // having a properly aligned, non-null pointer, the
+                    // following use of NonNull::new_unchecked is safe here:
+                    let ptr = if self.len > 0 {
+                        unsafe { NonNull::new_unchecked(self.ptr) }
+                    } else {
+                        NonNull::dangling()
+                    };
+
+                    // ## Safety
+                    //
+                    // `kernel.process_map_or()` validates that the process
+                    // still exists and its memory is still valid. In
+                    // particular, `Process` tracks the "high water mark" of
+                    // memory that the process has `allow`ed to the
+                    // kernel. Because `Process` does not feature an API to move
+                    // the "high water mark" down again, which would be called
+                    // once a `ProcessBuffer` has been passed back into the
+                    // kernel, a given `Process` implementation must assume that
+                    // the memory described by a once-allowed `ProcessBuffer` is
+                    // still in use, and thus will not permit the process to
+                    // free any memory after it has been `allow`ed to the kernel
+                    // once. This guarantees that the memory pointed to by the
+                    // buffer is safe to dereference here. For more information,
+                    // refer to the comment and subsequent discussion on
+                    // tock/tock#2632[1].
+                    //
+                    // [1]: https://github.com/tock/tock/pull/2632#issuecomment-869974365
+                    Ok(fun(unsafe { ReadableProcessSlice::new(ptr, self.len) }))
                 }),
         }
     }
 }
 
 impl WriteableProcessBuffer for ReadWriteProcessBuffer {
-    fn mut_enter<F, R>(&self, fun: F) -> Result<R, process::Error>
+    fn mut_enter<'a, F, R>(&'a self, fun: F) -> Result<R, process::Error>
     where
-        F: FnOnce(&WriteableProcessSlice) -> R,
+        F: FnOnce(WriteableProcessSlice<'a>) -> R,
     {
         match self.process_id {
             None => Err(process::Error::NoSuchApp),
             Some(pid) => pid
                 .kernel
                 .process_map_or(Err(process::Error::NoSuchApp), pid, |_| {
-                    // Safety: `kernel.process_map_or()` validates that
-                    // the process still exists and its memory is still
-                    // valid. In particular, `Process` tracks the "high water
-                    // mark" of memory that the process has `allow`ed to the
-                    // kernel. Because `Process` does not feature an API to
-                    // move the "high water mark" down again, which would be
-                    // called once a `ProcessBuffer` has been passed back into
-                    // the kernel, a given `Process` implementation must assume
-                    // that the memory described by a once-allowed
-                    // `ProcessBuffer` is still in use, and thus will not
-                    // permit the process to free any memory after it has
-                    // been `allow`ed to the kernel once. This guarantees
-                    // that the buffer is safe to convert into a slice
-                    // here. For more information, refer to the
-                    // comment and subsequent discussion on tock/tock#2632:
-                    // https://github.com/tock/tock/pull/2632#issuecomment-869974365
-                    Ok(fun(unsafe {
-                        raw_processbuf_to_rwprocessslice(self.ptr, self.len)
-                    }))
+                    // ## Safety
+                    //
+                    // While the ReadWriteProcessBuffer must refuse construction
+                    // with a null-pointer and a non-zero length, it may still
+                    // contain a null-pointer. This is because it must be able
+                    // to represent all valid read-only allow buffer
+                    // descriptions passed from userspace. Nonetheless, a Rust
+                    // slice (or any Rust allocation) cannot be located at
+                    // address zero, even zero-sized types, and especially not a
+                    // NonNull. Thus, apply the following rules:
+                    //
+                    // 1. if the buffer is of non-zero length, it must have a
+                    //    non-null pointer (refer to
+                    //    ReadableProcessBuffer::new_external). Construct a
+                    //    NonNull based on that pointer.
+                    //
+                    // 2. if the buffer is of zero-length, it may have a null
+                    //    pointer. Regardless, in the spirit of the
+                    //    ReadableProcessSlice::ptr method, we don't have to
+                    //    expose the proper pointer provided by the application,
+                    //    as this does not have any meaning for a zero-sized
+                    //    slice (not bounds checked, etc.). Thus, always return
+                    //    a NonNull::dangling in this case.
+                    //
+                    // Through the basic assumption of non zero-length buffer
+                    // having a properly aligned, non-null pointer, the
+                    // following use of NonNull::new_unchecked is safe here:
+                    let ptr = if self.len > 0 {
+                        unsafe { NonNull::new_unchecked(self.ptr) }
+                    } else {
+                        NonNull::dangling()
+                    };
+
+                    // ## Safety
+                    //
+                    // `kernel.process_map_or()` validates that the process
+                    // still exists and its memory is still valid. In
+                    // particular, `Process` tracks the "high water mark" of
+                    // memory that the process has `allow`ed to the
+                    // kernel. Because `Process` does not feature an API to move
+                    // the "high water mark" down again, which would be called
+                    // once a `ProcessBuffer` has been passed back into the
+                    // kernel, a given `Process` implementation must assume that
+                    // the memory described by a once-allowed `ProcessBuffer` is
+                    // still in use, and thus will not permit the process to
+                    // free any memory after it has been `allow`ed to the kernel
+                    // once. This guarantees that the memory pointed to by the
+                    // buffer is safe to dereference here. For more information,
+                    // refer to the comment and subsequent discussion on
+                    // tock/tock#2632[1].
+                    //
+                    // [1]: https://github.com/tock/tock/pull/2632#issuecomment-869974365
+                    Ok(fun(unsafe { WriteableProcessSlice::new(ptr, self.len) }))
                 }),
         }
     }
 }
 
+// TODO: remove, along with making the ProcessId non-optional and moving it to
+// the front. This should save us a usize in some cases (e.g.
+// Option<ReadWriteProcessBuffer>), as ProcessId must start with a non-null field
+// (&'static Kernel) and thus ReadWriteProcessBuffer will also start with a
+// non-null field.
 impl Default for ReadWriteProcessBuffer {
     fn default() -> Self {
         Self::const_default()
@@ -593,7 +603,8 @@ impl Default for ReadWriteProcessBuffer {
 }
 
 /// Provides access to a ReadWriteProcessBuffer with a restricted lifetime.
-/// This automatically dereferences into a ReadWriteProcessBuffer
+///
+/// This automatically dereferences into a ReadWriteProcessBuffer.
 pub struct ReadWriteProcessBufferRef<'a> {
     buf: ReadWriteProcessBuffer,
     _phantom: PhantomData<&'a ()>,
@@ -606,9 +617,9 @@ impl ReadWriteProcessBufferRef<'_> {
     /// # Safety requirements
     ///
     /// Refer to the safety requirements of
-    /// [`ReadWriteProcessBuffer::new_external`]. The derived lifetime can
-    /// help enforce the invariant that this incoming pointer may only
-    /// be access for a certain duration.
+    /// [`ReadWriteProcessBuffer::new_external`]. The derived lifetime can help
+    /// enforce the invariant that this incoming pointer may only be access for
+    /// a certain duration.
     pub(crate) unsafe fn new(ptr: *mut u8, len: usize, process_id: ProcessId) -> Self {
         Self {
             buf: ReadWriteProcessBuffer::new(ptr, len, process_id),
@@ -626,126 +637,189 @@ impl Deref for ReadWriteProcessBufferRef<'_> {
 
 /// A shareable region of userspace memory.
 ///
-/// This trait can be used to gain read-write access to memory regions
-/// wrapped in a ProcessBuffer type.
+/// This trait can be used to gain read-write access to memory regions wrapped
+/// in a ProcessBuffer type.
 // We currently don't need any special functionality in the kernel for this
 // type so we alias it as `ReadWriteProcessBuffer`.
 pub type UserspaceReadableProcessBuffer = ReadWriteProcessBuffer;
 
-/// Read-only wrapper around a [`Cell`]
+// --------- PROCESS SLICES ----------------------------------------------------
+
+/// Indexing operations on [`ReadableProcessSlice`]s and
+/// [`WriteableProcessSlice`]s.
 ///
-/// This type is used in providing the [`ReadableProcessSlice`]. The
-/// memory over which a [`ReadableProcessSlice`] exists must never be
-/// written to by the kernel. However, it may either exist in flash
-/// (read-only memory) or RAM (read-writeable memory). Consequently, a
-/// process may `allow` memory overlapping with a
-/// [`ReadOnlyProcessBuffer`] also simultaneously through a
-/// [`ReadWriteProcessBuffer`]. Hence, the kernel can have two
-/// references to the same memory, where one can lead to mutation of
-/// the memory contents. Therefore, the kernel must use [`Cell`]s
-/// around the bytes shared with userspace, to avoid violating Rust's
-/// aliasing rules.
+/// Because process slices are not proper Rust slice references, constituent of
+/// a pointer and length, but rather structs containing this data, the Rust
+/// index operator along with the [`Index`](core::ops::Index) trait cannot be
+/// used, as it fundamentally requires an indexing operation to return a
+/// reference.
 ///
-/// This read-only wrapper around a [`Cell`] only exposes methods
-/// which are safe to call on a process-shared read-only `allow`
-/// memory.
-#[repr(transparent)]
-pub struct ReadableProcessByte {
-    cell: Cell<u8>,
+/// Thus, provide a custom trait, used to implement a common `get` method to
+/// subslice or index into process buffers.
+pub trait ProcessSliceIndex<I> {
+    type Output;
+
+    fn get(&self, idx: I) -> Option<Self::Output>;
 }
 
-impl ReadableProcessByte {
+/// Safe abstraction over a readable byte in process memory.
+///
+/// The memory made accessible through a [`ReadableProcessByte`] must never be
+/// written to by the kernel, over the entire lifetime of this
+/// instance. However, it may either exist in flash (read-only memory) or RAM
+/// (read-writeable memory). Consequently, a process may `allow` memory
+/// overlapping with a [`ReadOnlyProcessBuffer`] also simultaneously through a
+/// [`ReadWriteProcessBuffer`]. Hence, the kernel can have two references to the
+/// same memory, where one can lead to mutation of the memory
+/// contents. Therefore, the kernel must use raw pointer operations to
+/// dereference this memory, to avoid violating Rust's aliasing rules.
+///
+/// This wrapper is transient, as the underlying buffer must be checked to point
+/// to valid process memory each time an instance is created. This is enforced
+/// through the associated lifetime.
+pub struct ReadableProcessByte<'a> {
+    ptr: NonNull<u8>,
+    _lt: PhantomData<&'a ()>,
+}
+
+impl<'a> ReadableProcessByte<'a> {
+    unsafe fn new(ptr: NonNull<u8>) -> Self {
+        ReadableProcessByte {
+            ptr,
+            _lt: PhantomData,
+        }
+    }
+
+    /// Retrieve the contents of the [`ReadableProcessByte`].
     #[inline]
     pub fn get(&self) -> u8 {
-        self.cell.get()
+        unsafe { core::ptr::read(self.ptr.as_ptr()) }
     }
 }
 
-/// Readable and accessible slice of memory of a process buffer
+/// Readable and accessible slice of memory of a process buffer.
 ///
+/// The only way to obtain this struct is through a [`ReadWriteProcessBuffer`]
+/// or [`ReadOnlyProcessBuffer`], or based on an immutably borrowed Rust `&[u8]`
+/// slice reference through the trait implementations of `From<&[u8]>` and
+/// `From<&mut [u8]>`.
 ///
-/// The only way to obtain this struct is through a
-/// [`ReadWriteProcessBuffer`] or [`ReadOnlyProcessBuffer`].
+/// Slices provide a convenient, traditional interface to process memory. These
+/// slices are transient, as the underlying buffer must be checked to point to
+/// valid process memory each time a slice is created. This is enforced through
+/// the associated lifetime.
 ///
-/// Slices provide a more convenient, traditional interface to process
-/// memory. These slices are transient, as the underlying buffer must
-/// be checked each time a slice is created. This is usually enforced
-/// by the anonymous lifetime defined by the creation of the slice.
-#[repr(transparent)]
-pub struct ReadableProcessSlice {
-    slice: [ReadableProcessByte],
+/// The memory over which a [`ReadableProcessSlice`] exists must never be
+/// written to by the kernel. However, it may either exist in flash (read-only
+/// memory) or RAM (read-writeable memory). Consequently, a process may `allow`
+/// memory overlapping with a [`ReadOnlyProcessBuffer`] also simultaneously
+/// through a [`ReadWriteProcessBuffer`]. Hence, the kernel can have two
+/// references to the same memory, where one can lead to mutation of the memory
+/// contents. Therefore, the kernel must use raw pointer operations to
+/// dereference this memory, to avoid violating Rust's aliasing rules.
+pub struct ReadableProcessSlice<'a> {
+    ptr: NonNull<u8>,
+    len: usize,
+    _lt: PhantomData<&'a ()>,
 }
 
-fn cast_byte_slice_to_process_slice<'a>(
-    byte_slice: &'a [ReadableProcessByte],
-) -> &'a ReadableProcessSlice {
-    // As ReadableProcessSlice is a transparent wrapper around its inner type,
-    // [ReadableProcessByte], we can safely transmute a reference to the inner
-    // type as a reference to the outer type with the same lifetime.
-    unsafe { core::mem::transmute::<&[ReadableProcessByte], &ReadableProcessSlice>(byte_slice) }
-}
-
-// Allow a u8 slice to be viewed as a ReadableProcessSlice to allow client code
-// to be authored once and accept either [u8] or ReadableProcessSlice.
-impl<'a> From<&'a [u8]> for &'a ReadableProcessSlice {
+impl<'a> From<&'a [u8]> for ReadableProcessSlice<'a> {
+    /// Borrow an immutable slice reference `&[u8]` into a
+    /// `ReadableProcessSlice`.
+    ///
+    /// Allow an immutable slice reference `&[u8]` of lifetime `'a` to be
+    /// borrowed into a `ReadableProcessSlice` of lifetime `'a`. This is to
+    /// allow client code to be authored once and accept either `&'a [u8]` or
+    /// `ReadableProcessBuffer<'a>`.
     fn from(val: &'a [u8]) -> Self {
         // # Safety
         //
-        // The layout of a [u8] and ReadableProcessSlice are guaranteed to be
-        // the same. This also extends the lifetime of the buffer, so aliasing
-        // rules are thus maintained properly.
-        unsafe { core::mem::transmute(val) }
-    }
-}
-
-// Allow a mutable u8 slice to be viewed as a ReadableProcessSlice to allow
-// client code to be authored once and accept either [u8] or
-// ReadableProcessSlice.
-impl<'a> From<&'a mut [u8]> for &'a ReadableProcessSlice {
-    fn from(val: &'a mut [u8]) -> Self {
-        // # Safety
+        // This function immutably borrows `val` for the lifetime 'a, which is
+        // further attached to the returned [`ReadableProcessSlice`]. As a
+        // consequence, the original aliasing rules and lifetime constraints of
+        // the slice hold.
         //
-        // The layout of a [u8] and ReadableProcessSlice are guaranteed to be
-        // the same. This also extends the mutable lifetime of the buffer, so
-        // aliasing rules are thus maintained properly.
-        unsafe { core::mem::transmute(val) }
+        // Furthermore, the provided Rust slice is guaranteed to have a non-null
+        // pointer which is must to be valid for reads of the slice length *
+        // mem::size_of::<u8>(), (based on the safety requirements of
+        // `core::slice::from_raw_parts_mut`). Thus using NonNull::new_unchecked
+        // is safe to use here.
+        //
+        // In addition to that, this function must adhere to all safety
+        // requirements of [`ReadableProcessSlice::new_external`]:
+        //
+        // - By mutably borrowing `val` for the entire lifetime of the returned
+        //   [`ReadableProcessSlice`] it is ensured that no other accessible
+        //   Rust allocation is overlapping with the slice's memory region.
+        //
+        // - As documented with [core::slice::from_raw_parts], the entire memory
+        //   range covered by a slice must be contained within a single
+        //   allocated object, which in Rust cannot wrap around the address
+        //   space. TODO: source!
+        //
+        //   Furthermore, Rust slices are, as are all other Rust allocations,
+        //   limited to contain `isize::MAX` elements. Even more strict, slices
+        //   are limited to contain `isize::MAX` _bytes_.
+        //
+        // For these reasons, the supplied `ptr` and `len` arguments satisfy the
+        // constraints imposed by [`ReadableProcessSlice::new_external`].
+        ReadableProcessSlice {
+            ptr: unsafe { NonNull::new_unchecked(val.as_ptr() as *mut u8) },
+            len: val.len(),
+            _lt: PhantomData,
+        }
     }
 }
 
-impl ReadableProcessSlice {
-    /// Copy the contents of a [`ReadableProcessSlice`] into a mutable
-    /// slice reference.
+impl<'a> From<&'a mut [u8]> for ReadableProcessSlice<'a> {
+    /// Borrow a mutable slice reference `&mut [u8]` into a
+    /// `ReadableProcessSlice`.
     ///
-    /// The length of `self` must be the same as `dest`. Subslicing
-    /// can be used to obtain a slice of matching length.
-    ///
-    /// # Panics
-    ///
-    /// This function will panic if `self.len() != dest.len()`.
-    pub fn copy_to_slice(&self, dest: &mut [u8]) {
-        // The panic code path was put into a cold function to not
-        // bloat the call site.
-        #[inline(never)]
-        #[cold]
-        #[track_caller]
-        fn len_mismatch_fail(dst_len: usize, src_len: usize) -> ! {
-            panic!(
-                "source slice length ({}) does not match destination slice length ({})",
-                src_len, dst_len,
-            );
-        }
+    /// Allow an mutable slice reference `&mut [u8]` of lifetime `'a` to be
+    /// borrowed into a `ReadableProcessSlice` of lifetime `'a`. This is to
+    /// allow client code to be authored once and accept either `&'a mut [u8]`
+    /// or `ReadableProcessBuffer<'a>`.
+    #[inline]
+    fn from(val: &'a mut [u8]) -> Self {
+        ReadableProcessSlice::from(val as &'a [u8])
+    }
+}
 
-        if self.copy_to_slice_or_err(dest).is_err() {
-            len_mismatch_fail(dest.len(), self.len());
+impl<'a> ReadableProcessSlice<'a> {
+    /// Construct a new [`ReadableProcessSlice`] of lifetime `'a`.
+    ///
+    /// This is a fundamentally unsafe operation.
+    ///
+    /// # Safety
+    ///
+    /// The constructed [`ReadableProcessSlice`] will make any memory in the
+    /// bounds of `[ptr, ptr + len)` read-accessible through the returned
+    /// object. Callers must ensure that no Rust aliasing rules be violated, in
+    /// particular that no other accessible Rust allocation (e.g. through a
+    /// mutable reference) is overlapping with this memory region.
+    ///
+    /// The provided length cannot overflow an isize, for reasons outlined in
+    /// [`ptr::offset`](https://doc.rust-lang.org/stable/core/primitive.pointer.html#method.offset).
+    /// If this condition is violated, the construction of a
+    /// [`ReadableProcessSlice`] can lead to undefined behavior. Furthermore,
+    /// the memory region must not wrap the address space, that is the address
+    /// resulting from a wrapping-addition of `ptr + len` must always be
+    /// strictly greater or equal than that of `ptr`.
+    unsafe fn new(ptr: NonNull<u8>, len: usize) -> ReadableProcessSlice<'a> {
+        ReadableProcessSlice {
+            ptr,
+            len,
+            _lt: PhantomData,
         }
     }
 
     /// Copy the contents of a [`ReadableProcessSlice`] into a mutable
     /// slice reference.
     ///
-    /// The length of `self` must be the same as `dest`. Subslicing
-    /// can be used to obtain a slice of matching length.
-    pub fn copy_to_slice_or_err(&self, dest: &mut [u8]) -> Result<(), ErrorCode> {
+    /// The length of `self` must be the same as `dest`, otherwise an error of
+    /// `ErrorCode::SIZE` is returned. Subslicing can be used to obtain a slice
+    /// of matching length.
+    pub fn copy_to_slice(&self, dest: &mut [u8]) -> Result<(), ErrorCode> {
         // Method implemetation adopted from the
         // core::slice::copy_from_slice method implementation:
         // https://doc.rust-lang.org/src/core/slice/mod.rs.html#3034-3036
@@ -759,167 +833,316 @@ impl ReadableProcessSlice {
             // slice which will never be in process memory, and the layout
             // of &[ReadableProcessByte] is guaranteed to be compatible to
             // &[u8].
-            for (i, b) in self.slice.iter().enumerate() {
+            for (i, b) in self.iter().enumerate() {
                 dest[i] = b.get();
             }
             Ok(())
         }
     }
 
+    /// Length of the [`WriteableProcessSlice`] memory region, in bytes.
     pub fn len(&self) -> usize {
-        self.slice.len()
+        self.len
     }
 
-    pub fn iter(&self) -> core::slice::Iter<'_, ReadableProcessByte> {
-        self.slice.iter()
+    /// Iterate over the [`ReadableProcessSlice`] memory region bytes.
+    pub fn iter(&self) -> impl Iterator<Item = ReadableProcessByte<'a>> {
+        unsafe { ReadableProcessSliceIter::new(self.ptr, self.len) }
     }
 
-    pub fn chunks(
-        &self,
-        chunk_size: usize,
-    ) -> impl core::iter::Iterator<Item = &ReadableProcessSlice> {
-        self.slice
-            .chunks(chunk_size)
-            .map(cast_byte_slice_to_process_slice)
+    /// Iterate over chunks the [`ReadableProcessSlice`] memory region bytes.
+    ///
+    /// `chunk_size` specifies the maximum number of bytes provided in each
+    /// iteration. The last iteration may yield only a partial chunk, holding
+    /// less than `chunk_size` bytes.
+    pub fn chunks(&self, chunk_size: usize) -> impl Iterator<Item = ReadableProcessSlice<'a>> {
+        unsafe { ReadableProcessSliceChunks::new(self.ptr, self.len, chunk_size) }
     }
+}
 
-    pub fn get(&self, range: Range<usize>) -> Option<&ReadableProcessSlice> {
-        if let Some(slice) = self.slice.get(range) {
-            Some(cast_byte_slice_to_process_slice(slice))
-        } else {
-            None
-        }
-    }
+impl<'a> ProcessSliceIndex<usize> for ReadableProcessSlice<'a> {
+    type Output = ReadableProcessByte<'a>;
 
-    pub fn get_from(&self, range: RangeFrom<usize>) -> Option<&ReadableProcessSlice> {
-        if let Some(slice) = self.slice.get(range) {
-            Some(cast_byte_slice_to_process_slice(slice))
-        } else {
-            None
-        }
-    }
-
-    pub fn get_to(&self, range: RangeTo<usize>) -> Option<&ReadableProcessSlice> {
-        if let Some(slice) = self.slice.get(range) {
-            Some(cast_byte_slice_to_process_slice(slice))
+    #[inline]
+    fn get(&self, idx: usize) -> Option<Self::Output> {
+        // This is essentially a copy of the implementation of
+        // <SliceIndex<[T]> for usize>::get()
+        if idx < self.len {
+            Some(unsafe {
+                ReadableProcessByte::new(NonNull::new_unchecked(self.ptr.as_ptr().add(idx)))
+            })
         } else {
             None
         }
     }
 }
 
-impl Index<Range<usize>> for ReadableProcessSlice {
-    // Subslicing will still yield a ReadableProcessSlice reference
-    type Output = Self;
+impl<'a> ProcessSliceIndex<Range<usize>> for ReadableProcessSlice<'a> {
+    type Output = ReadableProcessSlice<'a>;
 
-    fn index(&self, idx: Range<usize>) -> &Self::Output {
-        cast_byte_slice_to_process_slice(&self.slice[idx])
+    #[inline]
+    fn get(&self, range: Range<usize>) -> Option<Self::Output> {
+        // This is essentially a copy of the implementation of
+        // <SliceIndex<[T]> for Range<usize>>::get()
+        if range.start > range.end || range.end > self.len {
+            None
+        } else {
+            Some(ReadableProcessSlice {
+                ptr: unsafe { NonNull::new_unchecked(self.ptr.as_ptr().add(range.start)) },
+                len: range.end - range.start,
+                _lt: PhantomData,
+            })
+        }
     }
 }
 
-impl Index<RangeTo<usize>> for ReadableProcessSlice {
-    // Subslicing will still yield a ReadableProcessSlice reference
-    type Output = Self;
+impl<'a> ProcessSliceIndex<RangeFrom<usize>> for ReadableProcessSlice<'a> {
+    type Output = ReadableProcessSlice<'a>;
 
-    fn index(&self, idx: RangeTo<usize>) -> &Self::Output {
-        &self[0..idx.end]
+    #[inline]
+    fn get(&self, range: RangeFrom<usize>) -> Option<Self::Output> {
+        ProcessSliceIndex::<Range<usize>>::get(self, range.start..self.len)
     }
 }
 
-impl Index<RangeFrom<usize>> for ReadableProcessSlice {
-    // Subslicing will still yield a ReadableProcessSlice reference
-    type Output = Self;
+impl<'a> ProcessSliceIndex<RangeTo<usize>> for ReadableProcessSlice<'a> {
+    type Output = ReadableProcessSlice<'a>;
 
-    fn index(&self, idx: RangeFrom<usize>) -> &Self::Output {
-        &self[idx.start..self.len()]
+    #[inline]
+    fn get(&self, range: RangeTo<usize>) -> Option<Self::Output> {
+        ProcessSliceIndex::<Range<usize>>::get(self, 0..range.end)
     }
 }
 
-impl Index<usize> for ReadableProcessSlice {
-    // Indexing into a ReadableProcessSlice must yield a
-    // ReadableProcessByte, to limit the API surface of the wrapped
-    // Cell to read-only operations
-    type Output = ReadableProcessByte;
-
-    fn index(&self, idx: usize) -> &Self::Output {
-        // As ReadableProcessSlice is a transparent wrapper around its
-        // inner type, [ReadableProcessByte], we can use the regular
-        // slicing operator here with its usual semantics.
-        &self.slice[idx]
-    }
-}
-
-/// Read-writeable and accessible slice of memory of a process buffer
+/// Iterator over bytes of a [`ReadableProcessSlice`].
 ///
-/// The only way to obtain this struct is through a
-/// [`ReadWriteProcessBuffer`].
+/// Obtainable through [`ReadableProcessSlice::iter`]. Use subslicing with
+/// [`ProcessSliceIndex`] to adjust the range of bytes iterated over.
+pub struct ReadableProcessSliceIter<'a> {
+    current: NonNull<u8>,
+    remaining: usize,
+    _lt: PhantomData<&'a ()>,
+}
+
+impl<'a> ReadableProcessSliceIter<'a> {
+    unsafe fn new(base_ptr: NonNull<u8>, len: usize) -> Self {
+        ReadableProcessSliceIter {
+            current: base_ptr,
+            remaining: len,
+            _lt: PhantomData,
+        }
+    }
+}
+
+impl<'a> Iterator for ReadableProcessSliceIter<'a> {
+    type Item = ReadableProcessByte<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.remaining != 0 {
+            let byte_handle = unsafe { ReadableProcessByte::new(self.current) };
+
+            // Move the pointer forward, and decrement the number of remaining
+            // iterations.
+            self.current = unsafe { NonNull::new_unchecked(self.current.as_ptr().add(1)) };
+            self.remaining -= 1;
+
+            Some(byte_handle)
+        } else {
+            None
+        }
+    }
+}
+
+/// Iterator over chunks of bytes of a [`ReadableProcessSlice`].
 ///
-/// Slices provide a more convenient, traditional interface to process
-/// memory. These slices are transient, as the underlying buffer must
-/// be checked each time a slice is created. This is usually enforced
-/// by the anonymous lifetime defined by the creation of the slice.
-#[repr(transparent)]
-pub struct WriteableProcessSlice {
-    slice: [Cell<u8>],
+/// Obtainable through [`ReadableProcessSlice::chunks`]. Use subslicing with
+/// [`ProcessSliceIndex`] to adjust the range of bytes iterated over.
+///
+/// Each iteration will yield either a `None` or a `Some(ReadableProcessSlice)`,
+/// containing `chunk_size` elements as specified in the
+/// [`chunks`](ReadableProcessSlice::chunks) invocation. The last iteration may
+/// yield a partial chunk, containing less than `chunk_size` elements.
+pub struct ReadableProcessSliceChunks<'a> {
+    current_ptr: NonNull<u8>,
+    remaining: usize,
+    chunk_size: usize,
+    _lt: PhantomData<&'a ()>,
 }
 
-fn cast_cell_slice_to_process_slice<'a>(cell_slice: &'a [Cell<u8>]) -> &'a WriteableProcessSlice {
-    // # Safety
-    //
-    // As WriteableProcessSlice is a transparent wrapper around its inner type,
-    // [Cell<u8>], we can safely transmute a reference to the inner type as the
-    // outer type with the same lifetime.
-    unsafe { core::mem::transmute(cell_slice) }
+impl<'a> ReadableProcessSliceChunks<'a> {
+    unsafe fn new(base_ptr: NonNull<u8>, len: usize, chunk_size: usize) -> Self {
+        ReadableProcessSliceChunks {
+            current_ptr: base_ptr,
+            remaining: len,
+            chunk_size,
+            _lt: PhantomData,
+        }
+    }
 }
 
-// Allow a mutable u8 slice to be viewed as a WritableProcessSlice to allow
-// client code to be authored once and accept either [u8] or
-// WriteableProcessSlice.
-impl<'a> From<&'a mut [u8]> for &'a WriteableProcessSlice {
+impl<'a> Iterator for ReadableProcessSliceChunks<'a> {
+    type Item = ReadableProcessSlice<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.remaining != 0 {
+            let current_chunk_size = core::cmp::min(self.chunk_size, self.remaining);
+            let current_chunk =
+                unsafe { ReadableProcessSlice::new(self.current_ptr, current_chunk_size) };
+
+            // Move the pointer forward, and decrement the number of remaining
+            // iterations.
+            self.current_ptr = unsafe {
+                NonNull::new_unchecked(self.current_ptr.as_ptr().add(current_chunk_size))
+            };
+            self.remaining -= current_chunk_size;
+
+            Some(current_chunk)
+        } else {
+            None
+        }
+    }
+}
+
+/// Safe abstraction over a writeable byte in process memory.
+///
+/// A process may `allow` memory overlapping with a [`ReadWriteProcessBuffer`]
+/// also simultaneously through a second [`ReadWriteProcessBuffer`]. Hence, the
+/// kernel can have two references to the same memory, where one can lead to
+/// mutation of the memory contents. Therefore, the kernel must use raw pointer
+/// operations to dereference this memory, to avoid violating Rust's aliasing
+/// rules.
+///
+/// This wrapper is transient, as the underlying buffer must be checked to point
+/// to valid process memory each time an instance is created. This is enforced
+/// through the associated lifetime.
+pub struct WriteableProcessByte<'a> {
+    ptr: NonNull<u8>,
+    _lt: PhantomData<&'a ()>,
+}
+
+impl<'a> WriteableProcessByte<'a> {
+    unsafe fn new(ptr: NonNull<u8>) -> Self {
+        WriteableProcessByte {
+            ptr,
+            _lt: PhantomData,
+        }
+    }
+
+    /// Retrieve the contents of the [`WriteableProcessByte`].
+    #[inline]
+    pub fn get(&self) -> u8 {
+        unsafe { core::ptr::read(self.ptr.as_ptr()) }
+    }
+
+    /// Set the value of the [`WriteableProcessByte`].
+    #[inline]
+    pub fn set(&self, val: u8) {
+        unsafe { core::ptr::write(self.ptr.as_ptr(), val) }
+    }
+}
+
+/// Read-writeable and accessible slice of memory of a process buffer.
+///
+/// The only way to obtain this struct is through a [`ReadWriteProcessBuffer`],
+/// or based on a mutably borrowed Rust `&mut [u8]` slice reference through the
+/// trait implementations `From<&mut [u8]>`.
+///
+/// Slices provide a convenient, traditional interface to process memory. These
+/// slices are transient, as the underlying buffer must be checked to point to
+/// valid process memory each time a slice is created. This is enforced through
+/// the associated lifetime.
+///
+/// A process may `allow` memory overlapping with a [`ReadWriteProcessBuffer`]
+/// also simultaneously through a second [`ReadWriteProcessBuffer`]. Hence, the
+/// kernel can have two references to the same memory, where one can lead to
+/// mutation of the memory contents. Therefore, the kernel must use raw pointer
+/// operations to dereference this memory, to avoid violating Rust's aliasing
+/// rules.
+pub struct WriteableProcessSlice<'a> {
+    ptr: NonNull<u8>,
+    len: usize,
+    _lt: PhantomData<&'a ()>,
+}
+
+impl<'a> From<&'a mut [u8]> for WriteableProcessSlice<'a> {
+    /// Borrow a mutable slice reference `&mut [u8]` into a
+    /// `WriteableProcessSlice`.
+    ///
+    /// Allow a mutable slice reference `&mut [u8]` of lifetime `'a` to be
+    /// borrowed into a `WriteableProcessSlice` of lifetime `'a`. This is to
+    /// allow client code to be authored once and accept either `&'a mut [u8]`
+    /// or `WriteableProcessBuffer<'a>`.
     fn from(val: &'a mut [u8]) -> Self {
         // # Safety
         //
-        // The layout of a [u8] and WriteableProcessSlice are guaranteed to be
-        // the same. This also extends the mutable lifetime of the buffer, so
-        // aliasing rules are thus maintained properly.
-        unsafe { core::mem::transmute(val) }
+        // This function mutably borrows `val` for the lifetime 'a, which is
+        // further attached to the returned [`WriteableProcessSlice`]. As a
+        // consequence the original aliasing rules and lifetime constraints of
+        // the slice hold.
+        //
+        // Furthermore, the provided Rust slice is guaranteed to have a non-null
+        // pointer which is must to be valid for reads of the slice length *
+        // mem::size_of::<u8>(), (based on the safety requirements of
+        // `core::slice::from_raw_parts_mut`). Thus using NonNull::new_unchecked
+        // is safe to use here.
+        //
+        // In addition to that, this function must adhere to all safety
+        // requirements of [`WriteableProcessSlice::new_external`]:
+        //
+        // - By mutably borrowing `val` for the entire lifetime of the returned
+        //   [`WriteableProcessSlice`] it is ensured that no other accessible
+        //   Rust allocation is overlapping with the slice's memory region.
+        //
+        // - As documented with [core::slice::from_raw_parts], the entire memory
+        //   range covered by a slice must be contained within a single
+        //   allocated object, which in Rust cannot wrap around the address
+        //   space. TODO: source!
+        //
+        //   Furthermore, Rust slices are, as are all other Rust allocations,
+        //   limited to contain `isize::MAX` elements. Even more strict, slices
+        //   are limited to contain `isize::MAX` _bytes_.
+        //
+        // For these reasons, the supplied `ptr` and `len` arguments satisfy the
+        // constraints imposed by [`WriteableProcessSlice::new_external`].
+        unsafe { WriteableProcessSlice::new(NonNull::new_unchecked(val.as_mut_ptr()), val.len()) }
     }
 }
 
-impl WriteableProcessSlice {
-    /// Copy the contents of a [`WriteableProcessSlice`] into a mutable
-    /// slice reference.
+impl<'a> WriteableProcessSlice<'a> {
+    /// Construct a new [`WriteableProcessSlice`] of lifetime `'a`.
     ///
-    /// The length of `self` must be the same as `dest`. Subslicing
-    /// can be used to obtain a slice of matching length.
+    /// This is a fundamentally unsafe operation.
     ///
-    /// # Panics
+    /// # Safety
     ///
-    /// This function will panic if `self.len() != dest.len()`.
-    pub fn copy_to_slice(&self, dest: &mut [u8]) {
-        // The panic code path was put into a cold function to not
-        // bloat the call site.
-        #[inline(never)]
-        #[cold]
-        #[track_caller]
-        fn len_mismatch_fail(dst_len: usize, src_len: usize) -> ! {
-            panic!(
-                "source slice length ({}) does not match destination slice length ({})",
-                src_len, dst_len,
-            );
-        }
-
-        if self.copy_to_slice_or_err(dest).is_err() {
-            len_mismatch_fail(dest.len(), self.len());
+    /// The constructed [`WriteableProcessSlice`] will make any memory in the
+    /// bounds of `[ptr, ptr + len)` write-accessible through the returned
+    /// object. Callers must ensure that no Rust aliasing rules be violated, in
+    /// particular that no other accessible Rust allocation (e.g. through an
+    /// immutable or mutable reference) is overlapping with this memory region.
+    ///
+    /// The provided length cannot overflow an isize, for reasons outlined in
+    /// [`ptr::offset`](https://doc.rust-lang.org/stable/core/primitive.pointer.html#method.offset).
+    /// If this condition is violated, the construction of a
+    /// [`WriteableProcessSlice`] can lead to undefined behavior. Furthermore,
+    /// the memory region must not wrap the address space, that is the address
+    /// resulting from a wrapping-addition of `ptr + len` must always be
+    /// strictly greater or equal than that of `ptr`.
+    unsafe fn new(ptr: NonNull<u8>, len: usize) -> WriteableProcessSlice<'a> {
+        WriteableProcessSlice {
+            ptr,
+            len,
+            _lt: PhantomData,
         }
     }
 
     /// Copy the contents of a [`WriteableProcessSlice`] into a mutable
     /// slice reference.
     ///
-    /// The length of `self` must be the same as `dest`. Subslicing
-    /// can be used to obtain a slice of matching length.
-    pub fn copy_to_slice_or_err(&self, dest: &mut [u8]) -> Result<(), ErrorCode> {
+    /// The length of `self` must be the same as `dest`, otherwise an error of
+    /// `ErrorCode::SIZE` is returned. Subslicing can be used to obtain a slice
+    /// of matching length.
+    pub fn copy_to_slice(&self, dest: &mut [u8]) -> Result<(), ErrorCode> {
         // Method implemetation adopted from the
         // core::slice::copy_from_slice method implementation:
         // https://doc.rust-lang.org/src/core/slice/mod.rs.html#3034-3036
@@ -932,8 +1155,7 @@ impl WriteableProcessSlice {
             // given we have exclusive mutable access to the destination
             // slice which will never be in process memory, and the layout
             // of &[Cell<u8>] is guaranteed to be compatible to &[u8].
-            self.slice
-                .iter()
+            self.iter()
                 .zip(dest.iter_mut())
                 .for_each(|(src, dst)| *dst = src.get());
             Ok(())
@@ -942,39 +1164,10 @@ impl WriteableProcessSlice {
 
     /// Copy the contents of a slice of bytes into a [`WriteableProcessSlice`].
     ///
-    /// The length of `src` must be the same as `self`. Subslicing can
-    /// be used to obtain a slice of matching length.
-    ///
-    /// # Panics
-    ///
-    /// This function will panic if `src.len() != self.len()`.
-    pub fn copy_from_slice(&self, src: &[u8]) {
-        // Method implemetation adopted from the
-        // core::slice::copy_from_slice method implementation:
-        // https://doc.rust-lang.org/src/core/slice/mod.rs.html#3034-3036
-
-        // The panic code path was put into a cold function to not
-        // bloat the call site.
-        #[inline(never)]
-        #[cold]
-        #[track_caller]
-        fn len_mismatch_fail(dst_len: usize, src_len: usize) -> ! {
-            panic!(
-                "source slice length ({}) does not match destination slice length ({})",
-                src_len, dst_len,
-            );
-        }
-
-        if self.copy_from_slice_or_err(src).is_err() {
-            len_mismatch_fail(self.len(), src.len());
-        }
-    }
-
-    /// Copy the contents of a slice of bytes into a [`WriteableProcessSlice`].
-    ///
-    /// The length of `src` must be the same as `self`. Subslicing can
-    /// be used to obtain a slice of matching length.
-    pub fn copy_from_slice_or_err(&self, src: &[u8]) -> Result<(), ErrorCode> {
+    /// The length of `src` must be the same as `self`, otherwise an error of
+    /// `ErrorCode::SIZE` is returned. Subslicing can be used to obtain a slice
+    /// of matching length.
+    pub fn copy_from_slice(&self, src: &[u8]) -> Result<(), ErrorCode> {
         // Method implemetation adopted from the
         // core::slice::copy_from_slice method implementation:
         // https://doc.rust-lang.org/src/core/slice/mod.rs.html#3034-3036
@@ -988,90 +1181,179 @@ impl WriteableProcessSlice {
             // slice which will never be in process memory, and the layout
             // of &[Cell<u8>] is guaranteed to be compatible to &[u8].
             src.iter()
-                .zip(self.slice.iter())
+                .zip(self.iter())
                 .for_each(|(src, dst)| dst.set(*src));
             Ok(())
         }
     }
 
+    /// Length of the [`WriteableProcessSlice`] memory region, in bytes.
     pub fn len(&self) -> usize {
-        self.slice.len()
+        self.len
     }
 
-    pub fn iter(&self) -> core::slice::Iter<'_, Cell<u8>> {
-        self.slice.iter()
+    /// Iterate over the [`WriteableProcessSlice`] memory region bytes.
+    pub fn iter(&self) -> impl Iterator<Item = WriteableProcessByte> {
+        unsafe { WriteableProcessSliceIter::new(self.ptr, self.len) }
     }
 
+    /// Iterate over chunks the [`WriteableProcessSlice`] memory region bytes.
+    ///
+    /// `chunk_size` specifies the maximum number of bytes provided in each
+    /// iteration. The last iteration may yield only a partial chunk, holding
+    /// less than `chunk_size` bytes.
     pub fn chunks(
         &self,
         chunk_size: usize,
-    ) -> impl core::iter::Iterator<Item = &WriteableProcessSlice> {
-        self.slice
-            .chunks(chunk_size)
-            .map(cast_cell_slice_to_process_slice)
+    ) -> impl core::iter::Iterator<Item = WriteableProcessSlice<'a>> {
+        unsafe { WriteableProcessSliceChunks::new(self.ptr, self.len, chunk_size) }
     }
+}
 
-    pub fn get(&self, range: Range<usize>) -> Option<&WriteableProcessSlice> {
-        if let Some(slice) = self.slice.get(range) {
-            Some(cast_cell_slice_to_process_slice(slice))
-        } else {
-            None
-        }
-    }
+impl<'a> ProcessSliceIndex<usize> for WriteableProcessSlice<'a> {
+    type Output = WriteableProcessByte<'a>;
 
-    pub fn get_from(&self, range: RangeFrom<usize>) -> Option<&WriteableProcessSlice> {
-        if let Some(slice) = self.slice.get(range) {
-            Some(cast_cell_slice_to_process_slice(slice))
-        } else {
-            None
-        }
-    }
-
-    pub fn get_to(&self, range: RangeTo<usize>) -> Option<&WriteableProcessSlice> {
-        if let Some(slice) = self.slice.get(range) {
-            Some(cast_cell_slice_to_process_slice(slice))
+    #[inline]
+    fn get(&self, idx: usize) -> Option<Self::Output> {
+        // This is essentially a copy of the implementation of
+        // <SliceIndex<[T]> for usize>::get_mut()
+        if idx < self.len {
+            Some(unsafe {
+                WriteableProcessByte::new(NonNull::new_unchecked(self.ptr.as_ptr().add(idx)))
+            })
         } else {
             None
         }
     }
 }
 
-impl Index<Range<usize>> for WriteableProcessSlice {
-    // Subslicing will still yield a WriteableProcessSlice reference.
-    type Output = Self;
+impl<'a> ProcessSliceIndex<Range<usize>> for WriteableProcessSlice<'a> {
+    type Output = WriteableProcessSlice<'a>;
 
-    fn index(&self, idx: Range<usize>) -> &Self::Output {
-        cast_cell_slice_to_process_slice(&self.slice[idx])
+    #[inline]
+    fn get(&self, range: Range<usize>) -> Option<Self::Output> {
+        // This is essentially a copy of the implementation of
+        // <SliceIndex<[T]> for Range<usize>>::get_mut()
+        if range.start > range.end || range.end > self.len {
+            None
+        } else {
+            Some(WriteableProcessSlice {
+                ptr: unsafe { NonNull::new_unchecked(self.ptr.as_ptr().add(range.start)) },
+                len: range.end - range.start,
+                _lt: PhantomData,
+            })
+        }
     }
 }
 
-impl Index<RangeTo<usize>> for WriteableProcessSlice {
-    // Subslicing will still yield a WriteableProcessSlice reference.
-    type Output = Self;
+impl<'a> ProcessSliceIndex<RangeFrom<usize>> for WriteableProcessSlice<'a> {
+    type Output = WriteableProcessSlice<'a>;
 
-    fn index(&self, idx: RangeTo<usize>) -> &Self::Output {
-        &self[0..idx.end]
+    #[inline]
+    fn get(&self, range: RangeFrom<usize>) -> Option<Self::Output> {
+        ProcessSliceIndex::<Range<usize>>::get(self, range.start..self.len)
     }
 }
 
-impl Index<RangeFrom<usize>> for WriteableProcessSlice {
-    // Subslicing will still yield a WriteableProcessSlice reference.
-    type Output = Self;
+impl<'a> ProcessSliceIndex<RangeTo<usize>> for WriteableProcessSlice<'a> {
+    type Output = WriteableProcessSlice<'a>;
 
-    fn index(&self, idx: RangeFrom<usize>) -> &Self::Output {
-        &self[idx.start..self.len()]
+    #[inline]
+    fn get(&self, range: RangeTo<usize>) -> Option<Self::Output> {
+        ProcessSliceIndex::<Range<usize>>::get(self, 0..range.end)
     }
 }
 
-impl Index<usize> for WriteableProcessSlice {
-    // Indexing into a WriteableProcessSlice yields a Cell<u8>, as
-    // mutating the memory contents is allowed.
-    type Output = Cell<u8>;
+/// Iterator over bytes of a [`ReadableProcessSlice`].
+///
+/// Obtainable through [`ReadableProcessSlice::iter`]. Use subslicing with
+/// [`ProcessSliceIndex`] to adjust the range of bytes iterated over.
+pub struct WriteableProcessSliceIter<'a> {
+    current: NonNull<u8>,
+    remaining: usize,
+    _lt: PhantomData<&'a ()>,
+}
 
-    fn index(&self, idx: usize) -> &Self::Output {
-        // As WriteableProcessSlice is a transparent wrapper around
-        // its inner type, [Cell<u8>], we can use the regular slicing
-        // operator here with its usual semantics.
-        &self.slice[idx]
+impl<'a> WriteableProcessSliceIter<'a> {
+    unsafe fn new(base_ptr: NonNull<u8>, len: usize) -> Self {
+        WriteableProcessSliceIter {
+            current: base_ptr,
+            remaining: len,
+            _lt: PhantomData,
+        }
+    }
+}
+
+impl<'a> Iterator for WriteableProcessSliceIter<'a> {
+    type Item = WriteableProcessByte<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.remaining != 0 {
+            let byte_handle = unsafe { WriteableProcessByte::new(self.current) };
+
+            // Move the pointer forward, and decrement the number of remaining
+            // iterations.
+            //
+            // # Safety
+            //
+            // TODO
+            self.current = unsafe { NonNull::new_unchecked(self.current.as_ptr().add(1)) };
+            self.remaining -= 1;
+
+            Some(byte_handle)
+        } else {
+            None
+        }
+    }
+}
+
+/// Iterator over chunks of bytes of a [`WriteableProcessSlice`].
+///
+/// Obtainable through [`WriteableProcessSlice::chunks`]. Use subslicing with
+/// [`ProcessSliceIndex`] to adjust the range of bytes iterated over.
+///
+/// Each iteration will yield either a `None` or a
+/// `Some(WriteableProcessSlice)`, containing `chunk_size` elements as specified
+/// in the [`chunks`](WriteableProcessSlice::chunks) invocation. The last
+/// iteration may yield a partial chunk, containing less than `chunk_size`
+/// elements.
+pub struct WriteableProcessSliceChunks<'a> {
+    current_ptr: NonNull<u8>,
+    remaining: usize,
+    chunk_size: usize,
+    _lt: PhantomData<&'a ()>,
+}
+
+impl<'a> WriteableProcessSliceChunks<'a> {
+    unsafe fn new(base_ptr: NonNull<u8>, len: usize, chunk_size: usize) -> Self {
+        WriteableProcessSliceChunks {
+            current_ptr: base_ptr,
+            remaining: len,
+            chunk_size,
+            _lt: PhantomData,
+        }
+    }
+}
+
+impl<'a> Iterator for WriteableProcessSliceChunks<'a> {
+    type Item = WriteableProcessSlice<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.remaining != 0 {
+            let current_chunk_size = core::cmp::min(self.chunk_size, self.remaining);
+            let current_chunk =
+                unsafe { WriteableProcessSlice::new(self.current_ptr, current_chunk_size) };
+
+            // Move the pointer forward, and decrement the number of remaining
+            // iterations.
+            self.current_ptr = unsafe {
+                NonNull::new_unchecked(self.current_ptr.as_ptr().add(current_chunk_size))
+            };
+            self.remaining -= current_chunk_size;
+
+            Some(current_chunk)
+        } else {
+            None
+        }
     }
 }


### PR DESCRIPTION
### Pull Request Overview

This commit migrates the ProcessSlice interface in Tock to work on raw pointers instead of slices of `Cell`s. Most notably, this prevents usage of Rust's `Index` operator, which has been replaced by a `ProcessSliceIndex` trait and `get` method. Furthermore, this commit addresses

- removal of all panicing methods in relation to process buffers / process slices,

- documentation of the new safety requirements and invariants for the raw-pointer based process slice interface,

- revision of previous documentation, alignment to 80 char line width,

- adaption of capsules to this new interface, in the form of a straightforward translation. This adds a substantial amount of `unwrap()` calls in capsules, and does not apply trivial cleanups such as converting manually implemented for-loops for copying between slices with the appropriate `copy_from_slice` / `copy_to_slice` calls. This is done for easy validation of the proposed changes. Subsequent commits should clean up this code, and demonstrate an implementation with reduced panics on select capsules.

All of the above are deeply interwoven, thus they could not be separated into different commits.

##### Motivation

In short, the previous interface was unsound. Because fundamentally processes may allow overlapping memory regions to the kernel, and (mutable) aliasing of memory is unsound when used with Rust primitives (such as `&[u8]` slice references), the previous approach used a construct which allows mutable aliasing of memory: instead of holding onto a slice of bytes, it provided a slice of `Cell`s of bytes. Containing an `UnsafeCell`, these constructs allow mutable aliasing (that is, holding multiple mutable references to their contents simultaneously).

This approach has two issues: because `Cell` is a construct allowing mutation of the underlying value, it is unsound to use it over hardware-immutable memory. The exact consequences of writing to read-only memory are implementation dependant. For potentially hardware read-only memory, the previous implementation used a wrapper around `Cell`, exposing only a subset of the operations possible through `Cell`, explicitly excluding operations which mutate the underlying value. Nonetheless, wrapping such memory in `Cell` is unsound.

Furthermore, it is desirable to be able to treat immutable Rust slices (`&[u8]`) as `ReadableProcessBuffer`s to pass both through common interfaces. However, transmuting an immutable `&[u8]` Rust slice into `&[Cell<u8>]` is an unsound operation, for the same reasons as outlined above. For more information, refer to [1].

##### Approach

This commit changes the underlying structure of `ReadableProcessSlice` and `WriteableProcessSlice` to no longer be a `#[repr(transparent)]` wrapper over a slice of `Cell`s, but instead store a non-null pointer and a length to describe a given shared memory region. This is fundamentally identical to the in-memory representation of slice references. However, based on this information, raw pointer-based methods can be used to dereference the covered memory, for which Rust's aliasing rules do not apply as long as they can not access other Rust allocations.

At the same time, it introduces a significant amount of unsafe code, as many convenience methods of Rust slices can no longer be used. Thus this code requires especially careful vetting.

Fixes #2882.

[1]: https://github.com/tock/tock/issues/2882

### Testing Strategy

This pull request was tested by CI (the LiteX simulation tests a few allow operations). Needs much more testing, also in the form of unit tests.


### TODO or Help Wanted

This pull request still needs
- cleanup of some capsule code. Currently, the process slice accesses have a lot of `unwrap()` calls. While this PR can't get rid of any panics, I'm going to do at least one pass over the affected capsules and see what can be trivially optimized. For instances, many manually implemented for-loops can be replaced by their `copy_from_slice` / `copy_to_slice` equivalents.
- converting one capsule to avoid usage of `unwrap()` (probably console). This can demonstrate how the new API enables and encourages writing panic-free or panic-reduced capsule code.
- Extensive testing.
- Vetting of all new unsafe code introduced.

This code contains some TODOs regarding future code removals. I plan to follow this PR with one which cleans up some aspects of the ProcessBuffer kernel-internal interfaces, as there are some leftovers from the migration to kernel-managed allows. I wanted to avoid polluting this PR, which should be limited to only the process slice changes, to allow careful review of those.

### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
