### PR TITLE
chips: move arch config to function level

### DIFF
--- a/chips/rp2040/src/clocks.rs
+++ b/chips/rp2040/src/clocks.rs
@@ -1038,11 +1038,11 @@ impl Clocks {
         (((source_freq as u64) << 8) / freq as u64) as u32
     }
 
+    #[cfg(all(target_arch = "arm", target_os = "none"))]
     #[inline]
     fn loop_3_cycles(&self, clock: Clock) {
         if self.get_frequency(clock) > 0 {
             let _delay_cyc: u32 = self.get_frequency(Clock::System) / self.get_frequency(clock) + 1;
-            #[cfg(target_arch = "arm")]
             unsafe {
                 asm! (
                     "1:",
@@ -1052,6 +1052,11 @@ impl Clocks {
                 );
             }
         }
+    }
+
+    #[cfg(not(any(target_arch = "arm", target_os = "none")))]
+    fn loop_3_cycles(&self, _clock: Clock) {
+        unimplemented!()
     }
 
     pub fn configure_gpio_out(

--- a/chips/stm32f4xx/src/fsmc.rs
+++ b/chips/stm32f4xx/src/fsmc.rs
@@ -4,7 +4,7 @@ use kernel::deferred_call::DeferredCall;
 use kernel::hil::bus8080::{Bus8080, BusWidth, Client};
 use kernel::platform::chip::ClockInterface;
 use kernel::utilities::cells::{OptionalCell, TakeCell};
-use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
+use kernel::utilities::registers::interfaces::{ReadWriteable, Readable};
 use kernel::utilities::registers::{register_bitfields, ReadWrite};
 use kernel::utilities::StaticRef;
 use kernel::ErrorCode;
@@ -258,22 +258,34 @@ impl<'a> Fsmc<'a> {
         self.bank[bank as usize].map_or(None, |bank| Some(bank.ram.get()))
     }
 
+    #[cfg(all(target_arch = "arm", target_os = "none"))]
     #[inline]
     fn write_reg(&self, bank: FsmcBanks, addr: u16) {
+        use kernel::utilities::registers::interfaces::Writeable;
         self.bank[bank as usize].map(|bank| bank.reg.set(addr));
-        #[cfg(all(target_arch = "arm", target_os = "none"))]
         unsafe {
             asm!("dsb 0xf");
         }
     }
 
+    #[cfg(all(target_arch = "arm", target_os = "none"))]
     #[inline]
     fn write_data(&self, bank: FsmcBanks, data: u16) {
+        use kernel::utilities::registers::interfaces::Writeable;
         self.bank[bank as usize].map(|bank| bank.ram.set(data));
-        #[cfg(all(target_arch = "arm", target_os = "none"))]
         unsafe {
             asm!("dsb 0xf");
         }
+    }
+
+    #[cfg(not(any(target_arch = "arm", target_os = "none")))]
+    fn write_reg(&self, _bank: FsmcBanks, _addr: u16) {
+        unimplemented!()
+    }
+
+    #[cfg(not(any(target_arch = "arm", target_os = "none")))]
+    fn write_data(&self, _bank: FsmcBanks, _data: u16) {
+        unimplemented!()
     }
 }
 


### PR DESCRIPTION
### Pull Request Overview

In tock we use cfg()s based on architecture to hide assembly code when cargo builds tests. For consistency and clarity this PR moves a couple cfgs to the function level so we are not modifying the body of functions using compiler flags. Also, if there is some use case for running chip-specific code on host this will make it clear when certain functions are unimplemented.






### Testing Strategy

travis


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
