### PR TITLE
Move `tock-registers` to stable Rust by removing some trait bounds.

### DIFF
--- a/libraries/tock-register-interface/src/fields.rs
+++ b/libraries/tock-register-interface/src/fields.rs
@@ -73,13 +73,17 @@ use crate::{RegisterLongName, UIntLike};
 /// Specific section of a register.
 ///
 /// For the Field, the mask is unshifted, ie. the LSB should always be set.
-pub struct Field<T: UIntLike, R: RegisterLongName> {
+///
+/// `T` should be a `UIntLike` and `R` should be a `RegisterLongName`. Because
+/// `new` is a `const` function, we cannot add type constraints for `T` and `R`
+/// until `feature(const_fn_trait_bound)` is stabilized.
+pub struct Field<T, R> {
     pub mask: T,
     pub shift: usize,
     associated_register: PhantomData<R>,
 }
 
-impl<T: UIntLike, R: RegisterLongName> Field<T, R> {
+impl<T, R> Field<T, R> {
     pub const fn new(mask: T, shift: usize) -> Field<T, R> {
         Field {
             mask: mask,
@@ -87,7 +91,9 @@ impl<T: UIntLike, R: RegisterLongName> Field<T, R> {
             associated_register: PhantomData,
         }
     }
+}
 
+impl<T: UIntLike, R: RegisterLongName> Field<T, R> {
     #[inline]
     pub fn read(self, val: T) -> T {
         (val & (self.mask << self.shift)) >> self.shift
@@ -190,8 +196,12 @@ Field_impl_for!(usize);
 ///
 /// For the FieldValue, the masks and values are shifted into their actual
 /// location in the register.
+///
+/// `T` should be a `UIntLike` and `R` should be a `RegisterLongName`. Because
+/// `new` is a `const` function, we cannot add type constraints for `T` and `R`
+/// until `feature(const_fn_trait_bound)` is stabilized.
 #[derive(Copy, Clone)]
-pub struct FieldValue<T: UIntLike, R: RegisterLongName> {
+pub struct FieldValue<T, R> {
     mask: T,
     pub value: T,
     associated_register: PhantomData<R>,
@@ -202,7 +212,7 @@ macro_rules! FieldValue_impl_for {
         // Necessary to split the implementation of new() out because the bitwise
         // math isn't treated as const when the type is generic.
         // Tracking issue: https://github.com/rust-lang/rfcs/pull/2632
-        impl<R: RegisterLongName> FieldValue<$type, R> {
+        impl<R> FieldValue<$type, R> {
             pub const fn new(mask: $type, shift: usize, value: $type) -> Self {
                 FieldValue {
                     mask: mask << shift,

--- a/libraries/tock-register-interface/src/lib.rs
+++ b/libraries/tock-register-interface/src/lib.rs
@@ -53,7 +53,6 @@
 //! ------
 //! - Shane Leonard <shanel@stanford.edu>
 
-#![feature(const_fn_trait_bound)]
 #![no_std]
 // If we don't build any actual register types, we don't need unsafe
 // code in this crate

--- a/libraries/tock-register-interface/src/local_register.rs
+++ b/libraries/tock-register-interface/src/local_register.rs
@@ -27,20 +27,26 @@ use crate::{RegisterLongName, UIntLike};
 /// implementing [`Readable`](crate::interfaces::Readable),
 /// [`Writeable`](crate::interfaces::Writeable) and
 /// [`ReadWriteable`](crate::interfaces::ReadWriteable).
+///
+/// `T` should be a `UIntLike` and `R` should be a `RegisterLongName`. Because
+/// `new` is a `const` function, we cannot add type constraints for `T` and `R`
+/// until `feature(const_fn_trait_bound)` is stabilized.
 #[derive(Copy, Clone)]
-pub struct LocalRegisterCopy<T: UIntLike, R: RegisterLongName = ()> {
+pub struct LocalRegisterCopy<T, R = ()> {
     value: T,
     associated_register: PhantomData<R>,
 }
 
-impl<T: UIntLike, R: RegisterLongName> LocalRegisterCopy<T, R> {
+impl<T, R> LocalRegisterCopy<T, R> {
     pub const fn new(value: T) -> Self {
         LocalRegisterCopy {
             value: value,
             associated_register: PhantomData,
         }
     }
+}
 
+impl<T: UIntLike, R: RegisterLongName> LocalRegisterCopy<T, R> {
     /// Get the raw register value
     #[inline]
     pub fn get(&self) -> T {

--- a/libraries/tock-register-interface/src/registers.rs
+++ b/libraries/tock-register-interface/src/registers.rs
@@ -145,15 +145,19 @@ impl<T: UIntLike, R: RegisterLongName, W: RegisterLongName> Writeable for Aliase
 /// [`Readable`], [`Writeable`] and
 /// [`ReadWriteable`](crate::interfaces::ReadWriteable) traits are
 /// implemented.
+///
+/// `T` should be a `UIntLike` and `R` should be a `RegisterLongName`. Because
+/// `new` is a `const` function, we cannot add type constraints for `T` and `R`
+/// until `feature(const_fn_trait_bound)` is stabilized.
 // To successfully alias this structure onto hardware registers in memory, this
 // struct must be exactly the size of the `T`.
 #[repr(transparent)]
-pub struct InMemoryRegister<T: UIntLike, R: RegisterLongName = ()> {
+pub struct InMemoryRegister<T, R = ()> {
     value: UnsafeCell<T>,
     associated_register: PhantomData<R>,
 }
 
-impl<T: UIntLike, R: RegisterLongName> InMemoryRegister<T, R> {
+impl<T, R> InMemoryRegister<T, R> {
     pub const fn new(value: T) -> Self {
         InMemoryRegister {
             value: UnsafeCell::new(value),


### PR DESCRIPTION
### Pull Request Overview

`tock-registers` depends on `feature(const_fn_trait_bound)`. This PR removes the dependency on `feature(const_fn_trait_bound)` by removing trait bounds on types with `const` functions.

I see two downsides to this PR:

1. Users can now use the `Field`, `FieldValue`, `InMemoryRegister`, and `LocalRegisterCopy` types with arbitrary generic arguments (in which case they will have no methods other than `new`).
2. Re-adding these trait bounds is a breaking change.

### Testing Strategy

`cargo check` and `make prepush`

### TODO or Help Wanted

**Question:** are the drawbacks of this PR worth the benefit of supporting stable Rust in `tock-registers`? Note that it looks like `const_fn_trait_bound` will likely be stabilized soon (i.e. Rust 1.61): https://github.com/rust-lang/rust/pull/93827

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.