### PR TITLE
OpenTitan: Some SPI Host fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -516,7 +516,7 @@ ci-job-cargo-test-build:
 
 ### ci-runner-github-qemu jobs:
 
-QEMU_COMMIT_HASH=3bbe296c1c7a6ddce7a294e006b8c4a53b385292
+QEMU_COMMIT_HASH=9d662a6b22a0838a85c5432385f35db2488a33a5
 define ci_setup_qemu_riscv
 	$(call banner,CI-Setup: Build QEMU)
 	@# Use the latest QEMU as it has OpenTitan support

--- a/boards/opentitan/earlgrey-cw310/run.sh
+++ b/boards/opentitan/earlgrey-cw310/run.sh
@@ -24,8 +24,8 @@ if [[ "${VERILATOR}" == "yes" ]]; then
 		--meminit=flash,./"$BUILD_DIR"/binary.64.vmem \
 		--meminit=otp,${OPENTITAN_TREE}/build-out/sw/device/otp_img/otp_img_sim_verilator.vmem
 elif [[ "${OPENTITAN_TREE}" != "" ]]; then
-	${OBJCOPY} --update-section .apps=${APP} ${1} bundle.elf
-	${OBJCOPY} --output-target=binary bundle.elf binary
+	riscv64-linux-gnu-objcopy --update-section .apps=${APP} ${1} bundle.elf
+	riscv64-linux-gnu-objcopy --output-target=binary bundle.elf binary
 	${OPENTITAN_TREE}/util/fpga/cw310_loader.py --firmware binary
 else
 	../../../tools/qemu/build/qemu-system-riscv32 -M opentitan -bios ../../../tools/qemu-runner/opentitan-boot-rom.elf -nographic -serial stdio -monitor none -semihosting -kernel "${1}"

--- a/boards/opentitan/earlgrey-nexysvideo/run.sh
+++ b/boards/opentitan/earlgrey-nexysvideo/run.sh
@@ -24,7 +24,7 @@ if [[ "${VERILATOR}" == "yes" ]]; then
 		--meminit=flash,./"$BUILD_DIR"/binary.64.vmem \
 		--meminit=otp,${OPENTITAN_TREE}/build-out/sw/device/otp_img/otp_img_sim_verilator.vmem
 elif [[ "${OPENTITAN_TREE}" != "" ]]; then
-	${OBJCOPY} --output-target=binary ${1} binary
+	riscv64-linux-gnu-objcopy --output-target=binary ${1} binary
 	${OPENTITAN_TREE}/build-out/sw/host/spiflash/spiflash --dev-id=0403:6010 --input=binary
 else
 	../../../tools/qemu/build/qemu-system-riscv32 -M opentitan -bios ../../../tools/qemu-runner/opentitan-boot-rom.elf -nographic -serial stdio -monitor none -semihosting -kernel "${1}"

--- a/chips/lowrisc/src/spi_host.rs
+++ b/chips/lowrisc/src/spi_host.rs
@@ -358,8 +358,11 @@ impl SpiHost {
 
     /// Enable both event/err IRQ
     fn enable_interrupts(&self) {
-        let regs = self.registers;
-        regs.intr_enable
+        self.registers
+            .intr_state
+            .write(intr::ERROR::SET + intr::SPI_EVENT::SET);
+        self.registers
+            .intr_enable
             .modify(intr::ERROR::SET + intr::SPI_EVENT::SET);
     }
 

--- a/chips/lowrisc/src/spi_host.rs
+++ b/chips/lowrisc/src/spi_host.rs
@@ -485,23 +485,20 @@ impl hil::spi::SpiMaster for SpiHost {
         // upto-date base addresses of spi_host. Otherwise, a store-access
         // will occur in qemu-ci at board init.
         // This should be removed when qemu is patched.
-        #[cfg(feature = "skip")]
-        {
-            let regs = self.registers;
-            self.event_enable();
-            self.err_enable();
+        let regs = self.registers;
+        self.event_enable();
+        self.err_enable();
 
-            self.enable_interrupts();
+        self.enable_interrupts();
 
-            self.enable_spi_host();
+        self.enable_spi_host();
 
-            //TODO: I think this is bug in OT, where the `first` word written
-            // (while TXEMPTY) to TX_DATA is dropped/ignored and not added to TX_FIFO (TXQD = 0).
-            // The following write (0x00), works around this `bug`.
-            // Could be Verilator specific
-            regs.tx_data.write(tx_data::DATA.val(0x00));
-            assert_eq!(regs.status.read(status::TXQD), 0);
-        }
+        //TODO: I think this is bug in OT, where the `first` word written
+        // (while TXEMPTY) to TX_DATA is dropped/ignored and not added to TX_FIFO (TXQD = 0).
+        // The following write (0x00), works around this `bug`.
+        // Could be Verilator specific
+        regs.tx_data.write(tx_data::DATA.val(0x00));
+        assert_eq!(regs.status.read(status::TXQD), 0);
         Ok(())
     }
 


### PR DESCRIPTION
### Pull Request Overview

This PR includes a few fixes for the SPI host when running on hardware.

- Update the QEMU commit SHA used to avoid accesses errors for the spi addresses
- Remove the feature `skip` check
- Clear interrupts before we enable them
- Revert back to GCC's Objcopy to support the features that we want

### Testing Strategy

Run on the CW310

### TODO or Help Wanted

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
