### PR TITLE
docs: Clarify allow usage

### DIFF
--- a/capsules/src/console.rs
+++ b/capsules/src/console.rs
@@ -50,6 +50,9 @@ pub const DRIVER_NUM: usize = driver::NUM::Console as usize;
 
 /// Ids for read-only allow buffers
 mod ro_allow {
+    /// Before the allow syscall was handled by the kernel,
+    /// console used allow number "1", so to preserve compatibility
+    /// we still use allow number 1 now.
     pub const WRITE: usize = 1;
     /// The number of allow buffers the kernel stores for this grant
     pub const COUNT: usize = 2;
@@ -57,6 +60,9 @@ mod ro_allow {
 
 /// Ids for read-write allow buffers
 mod rw_allow {
+    /// Before the allow syscall was handled by the kernel,
+    /// console used allow number "1", so to preserve compatibility
+    /// we still use allow number 1 now.
     pub const READ: usize = 1;
     /// The number of allow buffers the kernel stores for this grant
     pub const COUNT: usize = 2;

--- a/doc/Syscalls.md
+++ b/doc/Syscalls.md
@@ -35,6 +35,19 @@ kernel. The kernel then uses the values in registers and the stack at the time
 of the interrupt call to determine how to route the system call and which
 driver function to call with which data values.
 
+The system calls in Tock fall into 7 classes,
+described in detail in the [TRD104](reference/trd104-syscalls.md):
+
+| Syscall Class    | Syscall Class Number |
+|------------------|----------------------|
+| Yield            |           0          |
+| Subscribe        |           1          |
+| Command          |           2          |
+| Read-Write Allow |           3          |
+| Read-Only Allow  |           4          |
+| Memop            |           5          |
+| Exit             |           6          |
+
 Using system calls has three advantages. First, the act of triggering a service
 call interrupt can be used to change the processor state. Rather than being in
 unprivileged mode (as applications are run) and limited by the Memory

--- a/doc/reference/trd104-syscalls.md
+++ b/doc/reference/trd104-syscalls.md
@@ -5,10 +5,10 @@ System Calls
 **Working Group:** Kernel<br/>
 **Type:** Documentary<br/>
 **Status:** Draft <br/>
-**Author:** Hudson Ayers, Guillaume Endignoux, Jon Flatley, Philip Levis, Amit Levy, Leon Schuermann, Johnathan Van Why <br/>
+**Author:** Hudson Ayers, Guillaume Endignoux, Jon Flatley, Philip Levis, Amit Levy, Leon Schuermann, Johnathan Van Why, dcz <br/>
 **Draft-Created:** August 31, 2020<br/>
-**Draft-Modified:** November 23, 2021<br/>
-**Draft-Version:** 6<br/>
+**Draft-Modified:** March 9, 2022<br/>
+**Draft-Version:** 7<br/>
 **Draft-Discuss:** tock-dev@googlegroups.com</br>
 
 Abstract
@@ -245,7 +245,7 @@ call drivers, which can be added and removed in different kernel
 builds. The full set of valid system calls a kernel supports therefore
 depends on what system call drivers it has installed.
 
-The 6 classes are:
+The 7 classes are:
 
 | Syscall Class    | Syscall Class Number |
 |------------------|----------------------|
@@ -518,10 +518,16 @@ on RISC-V.
 | Argument         | Register |
 |------------------|----------|
 | Driver number    | r0       |
-| Buffer number    | r1       |
+| Allow number     | r1       |
 | Address          | r2       |
 | Size             | r3       |
 
+The *allow number* argument is an ordinal number (index) of the buffer.
+When Read-Write Allow is called, the provided buffer
+SHALL get assigned to the provided *allow number*,
+replacing the previous buffer assigned to that *allow number*,
+if there was one.
+The supported *allow number*s are defined by the driver.
 
 The Tock kernel MUST check that the passed buffer is contained within
 the calling process's writeable address space. Every byte of a passed
@@ -529,8 +535,6 @@ buffer must be readable and writeable by the process. Zero-length
 buffers may therefore have arbitrary addresses. If the passed buffer is
 not complete within the calling process's writeable address space, the
 kernel MUST return a failure result with an error code of `INVALID`.
-The buffer number specifies which buffer this is. A driver may
-support multiple allowed buffers.
 
 The return variants for Read-Write Allow system calls are `Failure
 with 2 u32` and `Success with 2 u32`.  In both cases, `Argument 0`
@@ -547,7 +551,7 @@ If the kernel cannot access the grant region for this process, `NOMEM`
 will be returned. This can be caused by either running out a space in
 the grant region of RAM for the process, or the grant was never registered
 with the kernel during capsule creation at board startup. If the specified
-buffer number is not supported by the driver, the kernel will return `INVALID`.
+allow number is not supported by the driver, the kernel will return `INVALID`.
 
 The standard access model for allowed buffers is that userspace does
 not read or write a buffer that has been allowed: access to the memory
@@ -649,11 +653,13 @@ the buffer).
 ---------------------------------
 
 The Read-Only Allow class is very similar to the Read-Write Allow
-class. It differs in two ways:
+class. It differs in some ways:
 
 1. The buffer it passes to the kernel is read-only, and the process MAY
    freely read the buffer.
 2. The kernel MUST NOT write to a buffer shared with a Read-Only Allow.
+3. The *allow number*s in the Read-Only Allow
+   are independent from those in the Read-Write Allow.
 
 The semantics and calling conventions of Read-Only Allow are otherwise
 identical to Read-Write Allow: a userspace API MUST NOT depend on

--- a/doc/syscalls/00001_console.md
+++ b/doc/syscalls/00001_console.md
@@ -47,7 +47,7 @@ share a buffer for every write transaction, even if it's the same buffer.
     At the end of the transaction, a callback will be delivered if the process
     has `subscribed` to read events using `subscribe number` 2.
 
-    **Argument 1**: The maximum number of bytes to write.
+    **Argument 1**: The maximum number of bytes to read.
 
     **Argument 2**: unused
 

--- a/doc/syscalls/00001_console.md
+++ b/doc/syscalls/00001_console.md
@@ -96,7 +96,7 @@ share a buffer for every write transaction, even if it's the same buffer.
     **Returns**: Ok(()) if the subscribe was successful or NOMEM if the
     driver failed to allocate memory for the transaction.
 
-## Allow
+## Read-Only Allow
 
   * ### Allow number: `1`
 
@@ -110,7 +110,8 @@ share a buffer for every write transaction, even if it's the same buffer.
     **Returns**: Ok(()) if the subscribe was successful or NOMEM if the
     driver failed to allocate memory for the transaction.
 
-  * ### Allow number: `2`
+## Read-Write Allow
+  * ### Allow number: `1`
 
     **Description**: Sets a shared buffer to be read into by the next read
     transaction. A shared buffer is released in two cases: if it is replaced by

--- a/kernel/src/syscall_driver.rs
+++ b/kernel/src/syscall_driver.rs
@@ -179,9 +179,10 @@ impl From<process::Error> for CommandReturn {
 /// and what they represents) are specific to the peripheral system call
 /// driver.
 ///
-/// Note about subscribe: upcall subscriptions are handled entirely by the core
-/// kernel, and therefore there is no subscribe function for capsules to
-/// implement.
+/// Note about **subscribe**, **read-only allow**, and *read-write allow**
+/// syscalls:
+/// those are handled entirely by the core kernel, and there is no
+/// corresponding function for capsules to implement.
 #[allow(unused_variables)]
 pub trait SyscallDriver {
     /// System call for a process to perform a short synchronous operation


### PR DESCRIPTION
Includes a fix to the docs of the console driver.

### Pull Request Overview

This pull request fixes pieces of documentation regarding the allow syscall.

### Testing Strategy

This pull request was tested by manual reading.

### TODO or Help Wanted

A future update should describe the `UserspaceReadableAllow` syscall. I don't know anything about it, so I skipped it.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
