### PR TITLE
Core WG call notes, March 11th 2022

### DIFF
--- a/doc/wg/core/notes/core-notes-2022-03-11.md
+++ b/doc/wg/core/notes/core-notes-2022-03-11.md
@@ -25,7 +25,7 @@
  * (General digression about how English doesn't make sense)
 
 ### Tock publication
- * Hudson: An old writeup about Tock that we revived just got accepted at EuroSys. So I'll be presenting that there
+ * Hudson: An old writeup about Tock that we revived just got accepted at EuroSec, a workshop at Eurosys. So I'll be presenting that there
 
 ### General Tock PR State
  * Brad: Probably time to look at Pull Requests. We've been over two pages for a while now, which isn't good for a project of our size. No one ever looks at the second page and we don't want things to linger. We should either move forward or decline and maybe move to an issue.

--- a/doc/wg/core/notes/core-notes-2022-03-11.md
+++ b/doc/wg/core/notes/core-notes-2022-03-11.md
@@ -1,0 +1,33 @@
+# Tock Core Notes 2022-03-11
+
+## Attending
+
+- Hudson Ayers
+- Brad Campbell
+- Branden Ghena
+- Philip Levis
+- Leon Schuermann
+- Vadim Sukhomlinov
+- Johnathan Van Why
+- Alexandru Radovici
+- Pat Pannuto
+
+## Updates:
+ * Hudson: Missing a few key people for the active discussions, so just updates for today.
+
+### libtock-rs
+ * Johnathan: New contributor to libtock-rs! Someone who stumbled across it. Good time for us to notice weaknesses in documentation and improve
+
+### Stable Tock
+ * Brad: Another new feature was stabilized, so there should be a nightly soon that allows us to remove that feature. The feature was const-function-trait-bound.
+ * Leon: This should also let us move Tock-registers to stable. There were some people who are using it who want it to be on stable. So we should probably do a sub-release to add that.
+ * Hudson: My paper deadline got moved back a week, so I had to delay my work on that.
+ * (General digression about how English doesn't make sense)
+
+### Tock publication
+ * Hudson: An old writeup about Tock that we revived just got accepted at EuroSys. So I'll be presenting that there
+
+### General Tock PR State
+ * Brad: Probably time to look at Pull Requests. We've been over two pages for a while now, which isn't good for a project of our size. No one ever looks at the second page and we don't want things to linger. We should either move forward or decline and maybe move to an issue.
+ * Brad: No immediate action is needed, but generally take a look with a mind towards cleaning things up
+


### PR DESCRIPTION
### Pull Request Overview

Adds Core working group meeting notes from March 11th, 2022.

[Rendered](https://github.com/tock/tock/blob/45d0ae32a589a0ef22c28585a0c20abc5b3155e6/doc/wg/core/notes/core-notes-2022-03-11.md)


### Testing Strategy

Skimming and spellchecking


### TODO or Help Wanted

Should be good to go.


### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [N/A] Ran `make prepush`.
