### PR TITLE
mx25r6435f: Small improvements

### DIFF
--- a/boards/components/src/mx25r6435f.rs
+++ b/boards/components/src/mx25r6435f.rs
@@ -53,8 +53,8 @@ pub struct Mx25r6435fComponent<
     P: 'static + hil::gpio::Pin,
     A: 'static + hil::time::Alarm<'static>,
 > {
-    write_protect_pin: &'static P,
-    hold_pin: &'static P,
+    write_protect_pin: Option<&'static P>,
+    hold_pin: Option<&'static P>,
     chip_select: S::ChipSelect,
     mux_alarm: &'static MuxAlarm<'static, A>,
     mux_spi: &'static MuxSpiMaster<'static, S>,
@@ -67,8 +67,8 @@ impl<
     > Mx25r6435fComponent<S, P, A>
 {
     pub fn new(
-        write_protect_pin: &'static P,
-        hold_pin: &'static P,
+        write_protect_pin: Option<&'static P>,
+        hold_pin: Option<&'static P>,
         chip_select: S::ChipSelect,
         mux_alarm: &'static MuxAlarm<'static, A>,
         mux_spi: &'static MuxSpiMaster<'static, S>,
@@ -130,8 +130,8 @@ impl<
                 mx25r6435f_virtual_alarm,
                 &mut capsules::mx25r6435f::TXBUFFER,
                 &mut capsules::mx25r6435f::RXBUFFER,
-                Some(self.write_protect_pin),
-                Some(self.hold_pin)
+                self.write_protect_pin,
+                self.hold_pin,
             )
         );
         mx25r6435f_spi.setup();

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -551,8 +551,8 @@ pub unsafe fn main() {
     );
 
     let mx25r6435f = components::mx25r6435f::Mx25r6435fComponent::new(
-        &gpio_port[SPI_MX25R6435F_WRITE_PROTECT_PIN],
-        &gpio_port[SPI_MX25R6435F_HOLD_PIN],
+        Some(&gpio_port[SPI_MX25R6435F_WRITE_PROTECT_PIN]),
+        Some(&gpio_port[SPI_MX25R6435F_HOLD_PIN]),
         &gpio_port[SPI_MX25R6435F_CHIP_SELECT] as &dyn kernel::hil::gpio::Pin,
         mux_alarm,
         mux_spi,

--- a/capsules/src/mx25r6435f.rs
+++ b/capsules/src/mx25r6435f.rs
@@ -79,11 +79,17 @@ const PAGE_SIZE: u32 = 256;
 /// ```
 pub struct Mx25r6435fSector(pub [u8; SECTOR_SIZE as usize]);
 
-impl Default for Mx25r6435fSector {
-    fn default() -> Self {
+impl Mx25r6435fSector {
+    pub const fn new() -> Self {
         Self {
             0: [0; SECTOR_SIZE as usize],
         }
+    }
+}
+
+impl Default for Mx25r6435fSector {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -222,6 +228,8 @@ impl<
         )
     }
 
+    /// Requests the readout of a 24-bit identification number.
+    /// This command will cause a debug print when succeeded.
     pub fn read_identification(&self) -> Result<(), ErrorCode> {
         self.configure_spi()?;
 
@@ -369,7 +377,7 @@ impl<
                 self.txbuffer.replace(write_buffer);
                 read_buffer.map(|read_buffer| {
                     debug!(
-                        "id {:#x} {:#x} {:#x}",
+                        "id 0x{:02x}{:02x}{:02x}",
                         read_buffer[1], read_buffer[2], read_buffer[3]
                     );
                     self.rxbuffer.replace(read_buffer);


### PR DESCRIPTION
- a const `new` function added for easier initialization
- optional SPI pins made optional
- made the ID print more readable
- id print documented

### Pull Request Overview

See commit message.

### Testing Strategy

This pull request was tested by adding the capsule to a board and running that. https://github.com/dcz-self/tock/commit/206859aff1b9a88af71affd36874c077d6c99cfd

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
