### PR TITLE
Console: Print the first N bytes of the write buffer, plus doc fixes.

### DIFF
--- a/capsules/src/console.rs
+++ b/capsules/src/console.rs
@@ -161,7 +161,7 @@ impl<'a> Console<'a> {
                     .get_readonly_processbuffer(ro_allow::WRITE)
                     .and_then(|write| {
                         write.enter(|data| {
-                            for (i, c) in data[data.len() - app.write_remaining..data.len()]
+                            for (i, c) in data[app.write_len - app.write_remaining..app.write_len]
                                 .iter()
                                 .enumerate()
                             {

--- a/doc/syscalls/00001_console.md
+++ b/doc/syscalls/00001_console.md
@@ -11,10 +11,6 @@ write a buffer, a process must share the buffer using `allow` then initiate the
 write using a `command` call. It may also using `subscribe` to receive a
 callback when the write has completed.
 
-Once the write has completed, the buffer shared with the driver is released, so
-can be deallocated by the process. This also means that it is necessary to
-share a buffer for every write transaction, even if it's the same buffer.
-
 ## Command
 
   * ### Command number: `0`
@@ -33,7 +29,10 @@ share a buffer for every write transaction, even if it's the same buffer.
     At the end of the transaction, a callback will be delivered if the process
     has `subscribed`.
 
-    **Argument 1**: The maximum number of bytes to write.
+    **Argument 1**: The maximum number of bytes to write. If this argument is
+    greater than or equal to the buffer's size, the entire buffer will be
+    written. Otherwise, the first N bytes of the buffer will be written, where N
+    is the value of this argument.
 
     **Argument 2**: unused
 


### PR DESCRIPTION
### Pull Request Overview

The console syscall driver's documentation did not say what happens when the number of bytes to write (which is passed to Command) is smaller than the size of the passed buffer. I think everyone reading the documentation assumed that console would write the first N bytes of the buffer, but it actually wrote the last N bytes. This PR alters console's behavior to print the first N bytes, and states that in the documentation.

While editing the documentation, I made a few other fixes:

1. It no longer has a paragraph about buffers being automatically released after use -- that behavior was specific to Tock 1.0.
2. I clarified that console will never perform partial writes. This is to clear up the ambiguity expressed at https://github.com/tock/libtock-rs/pull/395#discussion_r824693201.

### Testing Strategy

I write a `libtock-rs` app that tries to print `7` bytes of `"Hello,\nWorld!\n"`. I ran it (in QEMU on HiFive1) before this PR to confirm it printed `"World!\n"`, made this change, then ran it again with this PR and confirmed it printed `"Hello,\n"`.

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
