### PR TITLE
Prevent rustfmt from searching parent directories for config files.

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,6 @@
+# Tock uses rustfmt's default configuration.
+#
+# This empty configuration file exists so that when rustfmt is run within this
+# repository, it does not search parent directories for a rustfmt.toml file.
+# This allows projects with their own rustfmt.toml file to include tock as a
+# submodule without changing the behavior of `make prepush`.


### PR DESCRIPTION
### Pull Request Overview

This PR adds an empty `rustfmt.toml` file, which prevents `rustfmt` (as invoked by `make prepush`) from searching `tock`'s parent directories for config files. This allows `make prepush` to work correctly in `tock` repositories that are submodules of other projects that have their own `rustfmt` configs.

### Testing Strategy

This pull request was tested by running `make prepush` in `libtock-rs`' `tock` submodule (`libtock-rs` has a non-empty `rustfmt.toml`).

### Formatting

- [X] Ran `make prepush`.
