### PR TITLE
console: Give own buffers to each component

### DIFF
--- a/boards/acd52832/src/main.rs
+++ b/boards/acd52832/src/main.rs
@@ -329,7 +329,7 @@ pub unsafe fn main() {
         capsules::console::DRIVER_NUM,
         uart_mux,
     )
-    .finalize(());
+    .finalize(components::console_component_helper!());
     // Create the debugger object that handles calls to `debug!()`.
     components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
 

--- a/boards/arty_e21/src/main.rs
+++ b/boards/arty_e21/src/main.rs
@@ -167,7 +167,7 @@ pub unsafe fn main() {
         capsules::console::DRIVER_NUM,
         uart_mux,
     )
-    .finalize(());
+    .finalize(components::console_component_helper!());
 
     // Create a shared virtualization mux layer on top of a single hardware
     // alarm.

--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -470,7 +470,7 @@ pub unsafe fn main() {
         capsules::console::DRIVER_NUM,
         uart_mux,
     )
-    .finalize(());
+    .finalize(components::console_component_helper!());
     // Create the debugger object that handles calls to `debug!()`.
     components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
 

--- a/boards/esp32-c3-devkitM-1/src/main.rs
+++ b/boards/esp32-c3-devkitM-1/src/main.rs
@@ -243,7 +243,7 @@ unsafe fn setup() -> (
         capsules::console::DRIVER_NUM,
         uart_mux,
     )
-    .finalize(());
+    .finalize(components::console_component_helper!());
     // Create the debugger object that handles calls to `debug!()`.
     components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
 

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -302,7 +302,7 @@ pub unsafe fn main() {
         capsules::console::DRIVER_NUM,
         uart_mux,
     )
-    .finalize(());
+    .finalize(components::console_component_helper!());
     let process_console = components::process_console::ProcessConsoleComponent::new(
         board_kernel,
         uart_mux,

--- a/boards/hifive1/src/main.rs
+++ b/boards/hifive1/src/main.rs
@@ -240,7 +240,7 @@ pub unsafe fn main() {
         capsules::console::DRIVER_NUM,
         uart_mux,
     )
-    .finalize(());
+    .finalize(components::console_component_helper!());
     // Create the debugger object that handles calls to `debug!()`.
     components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
 

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -378,8 +378,8 @@ pub unsafe fn main() {
         .finalize(components::process_console_component_helper!(
             sam4l::ast::Ast
         ));
-    let console =
-        ConsoleComponent::new(board_kernel, capsules::console::DRIVER_NUM, uart_mux).finalize(());
+    let console = ConsoleComponent::new(board_kernel, capsules::console::DRIVER_NUM, uart_mux)
+        .finalize(components::console_component_helper!());
     DebugWriterComponent::new(uart_mux).finalize(());
 
     // Allow processes to communicate over BLE through the nRF51822

--- a/boards/imxrt1050-evkb/src/main.rs
+++ b/boards/imxrt1050-evkb/src/main.rs
@@ -330,7 +330,7 @@ pub unsafe fn main() {
         capsules::console::DRIVER_NUM,
         lpuart_mux,
     )
-    .finalize(());
+    .finalize(components::console_component_helper!());
     // Create the debugger object that handles calls to `debug!()`.
     components::debug_writer::DebugWriterComponent::new(lpuart_mux).finalize(());
 

--- a/boards/litex/arty/src/main.rs
+++ b/boards/litex/arty/src/main.rs
@@ -474,7 +474,7 @@ pub unsafe fn main() {
         capsules::console::DRIVER_NUM,
         uart_mux,
     )
-    .finalize(());
+    .finalize(components::console_component_helper!());
     // Create the debugger object that handles calls to `debug!()`.
     components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
 

--- a/boards/litex/sim/src/main.rs
+++ b/boards/litex/sim/src/main.rs
@@ -579,7 +579,7 @@ pub unsafe fn main() {
         capsules::console::DRIVER_NUM,
         uart_mux,
     )
-    .finalize(());
+    .finalize(components::console_component_helper!());
     // Create the debugger object that handles calls to `debug!()`.
     components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
 

--- a/boards/microbit_v2/src/main.rs
+++ b/boards/microbit_v2/src/main.rs
@@ -368,7 +368,7 @@ pub unsafe fn main() {
         capsules::console::DRIVER_NUM,
         uart_mux,
     )
-    .finalize(());
+    .finalize(components::console_component_helper!());
     // Create the debugger object that handles calls to `debug!()`.
     components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
 

--- a/boards/msp_exp432p401r/src/main.rs
+++ b/boards/msp_exp432p401r/src/main.rs
@@ -346,7 +346,7 @@ pub unsafe fn main() {
         capsules::console::DRIVER_NUM,
         uart_mux,
     )
-    .finalize(());
+    .finalize(components::console_component_helper!());
     // Create the debugger object that handles calls to `debug!()`.
     components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
 

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -387,7 +387,7 @@ pub unsafe fn main() {
         capsules::console::DRIVER_NUM,
         uart_mux,
     )
-    .finalize(());
+    .finalize(components::console_component_helper!());
     // Create the debugger object that handles calls to `debug!()`.
     components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
 

--- a/boards/nano_rp2040_connect/src/main.rs
+++ b/boards/nano_rp2040_connect/src/main.rs
@@ -337,7 +337,7 @@ pub unsafe fn main() {
         capsules::console::DRIVER_NUM,
         uart_mux,
     )
-    .finalize(());
+    .finalize(components::console_component_helper!());
     // Create the debugger object that handles calls to `debug!()`.
     components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
 

--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -330,7 +330,7 @@ pub unsafe fn main() {
         capsules::console::DRIVER_NUM,
         uart_mux,
     )
-    .finalize(());
+    .finalize(components::console_component_helper!());
     // Create the debugger object that handles calls to `debug!()`.
     components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
 

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -438,7 +438,7 @@ pub unsafe fn main() {
         capsules::console::DRIVER_NUM,
         uart_mux,
     )
-    .finalize(());
+    .finalize(components::console_component_helper!());
     // Create the debugger object that handles calls to `debug!()`.
     components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
 

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -386,7 +386,7 @@ pub unsafe fn main() {
         capsules::console::DRIVER_NUM,
         uart_mux,
     )
-    .finalize(());
+    .finalize(components::console_component_helper!());
     // Create the debugger object that handles calls to `debug!()`.
     components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
 

--- a/boards/nucleo_f429zi/src/main.rs
+++ b/boards/nucleo_f429zi/src/main.rs
@@ -344,7 +344,7 @@ pub unsafe fn main() {
         capsules::console::DRIVER_NUM,
         uart_mux,
     )
-    .finalize(());
+    .finalize(components::console_component_helper!());
     // Create the debugger object that handles calls to `debug!()`.
     components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
 

--- a/boards/nucleo_f446re/src/main.rs
+++ b/boards/nucleo_f446re/src/main.rs
@@ -297,7 +297,7 @@ pub unsafe fn main() {
         capsules::console::DRIVER_NUM,
         uart_mux,
     )
-    .finalize(());
+    .finalize(components::console_component_helper!());
     // Create the debugger object that handles calls to `debug!()`.
     components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
 

--- a/boards/opentitan/src/main.rs
+++ b/boards/opentitan/src/main.rs
@@ -346,7 +346,7 @@ unsafe fn setup() -> (
         capsules::console::DRIVER_NUM,
         uart_mux,
     )
-    .finalize(());
+    .finalize(components::console_component_helper!());
     // Create the debugger object that handles calls to `debug!()`.
     components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
 

--- a/boards/pico_explorer_base/src/main.rs
+++ b/boards/pico_explorer_base/src/main.rs
@@ -342,7 +342,7 @@ pub unsafe fn main() {
         capsules::console::DRIVER_NUM,
         uart_mux,
     )
-    .finalize(());
+    .finalize(components::console_component_helper!());
     // Create the debugger object that handles calls to `debug!()`.
     components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
 

--- a/boards/raspberry_pi_pico/src/main.rs
+++ b/boards/raspberry_pi_pico/src/main.rs
@@ -340,7 +340,7 @@ pub unsafe fn main() {
         capsules::console::DRIVER_NUM,
         uart_mux,
     )
-    .finalize(());
+    .finalize(components::console_component_helper!());
     // Create the debugger object that handles calls to `debug!()`.
     components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
 

--- a/boards/redboard_artemis_nano/src/main.rs
+++ b/boards/redboard_artemis_nano/src/main.rs
@@ -183,7 +183,7 @@ pub unsafe fn main() {
         capsules::console::DRIVER_NUM,
         uart_mux,
     )
-    .finalize(());
+    .finalize(components::console_component_helper!());
     // Create the debugger object that handles calls to `debug!()`.
     components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
 

--- a/boards/redboard_redv/src/main.rs
+++ b/boards/redboard_redv/src/main.rs
@@ -236,7 +236,7 @@ pub unsafe fn main() {
         capsules::console::DRIVER_NUM,
         uart_mux,
     )
-    .finalize(());
+    .finalize(components::console_component_helper!());
     // Create the debugger object that handles calls to `debug!()`.
     components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
 

--- a/boards/stm32f3discovery/src/main.rs
+++ b/boards/stm32f3discovery/src/main.rs
@@ -429,7 +429,7 @@ pub unsafe fn main() {
         capsules::console::DRIVER_NUM,
         uart_mux,
     )
-    .finalize(());
+    .finalize(components::console_component_helper!());
     // Create the debugger object that handles calls to `debug!()`.
     components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
 

--- a/boards/stm32f412gdiscovery/src/main.rs
+++ b/boards/stm32f412gdiscovery/src/main.rs
@@ -459,7 +459,7 @@ pub unsafe fn main() {
         capsules::console::DRIVER_NUM,
         uart_mux,
     )
-    .finalize(());
+    .finalize(components::console_component_helper!());
     // Create the debugger object that handles calls to `debug!()`.
     components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
 

--- a/boards/stm32f429idiscovery/src/main.rs
+++ b/boards/stm32f429idiscovery/src/main.rs
@@ -350,7 +350,7 @@ pub unsafe fn main() {
         capsules::console::DRIVER_NUM,
         uart_mux,
     )
-    .finalize(());
+    .finalize(components::console_component_helper!());
     // Create the debugger object that handles calls to `debug!()`.
     components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
 

--- a/boards/swervolf/src/main.rs
+++ b/boards/swervolf/src/main.rs
@@ -204,7 +204,7 @@ pub unsafe fn main() {
         capsules::console::DRIVER_NUM,
         uart_mux,
     )
-    .finalize(());
+    .finalize(components::console_component_helper!());
     // Create the debugger object that handles calls to `debug!()`.
     components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
 

--- a/boards/teensy40/src/main.rs
+++ b/boards/teensy40/src/main.rs
@@ -273,7 +273,7 @@ pub unsafe fn main() {
         capsules::console::DRIVER_NUM,
         uart_mux,
     )
-    .finalize(());
+    .finalize(components::console_component_helper!());
 
     // LED
     let led = components::led::LedsComponent::new().finalize(components::led_component_helper!(

--- a/boards/weact_f401ccu6/src/main.rs
+++ b/boards/weact_f401ccu6/src/main.rs
@@ -298,7 +298,7 @@ pub unsafe fn main() {
         capsules::console::DRIVER_NUM,
         uart_mux,
     )
-    .finalize(());
+    .finalize(components::console_component_helper!());
     // Create the debugger object that handles calls to `debug!()`.
     components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
 

--- a/capsules/src/console.rs
+++ b/capsules/src/console.rs
@@ -48,6 +48,10 @@ use kernel::{ErrorCode, ProcessId};
 use crate::driver;
 pub const DRIVER_NUM: usize = driver::NUM::Console as usize;
 
+/// Default size for the read and write buffers used by the console.
+/// Boards may pass different-size buffers if needed.
+pub const DEFAULT_BUF_SIZE: usize = 64;
+
 /// Ids for read-only allow buffers
 mod ro_allow {
     pub const WRITE: usize = 1;
@@ -69,9 +73,6 @@ pub struct App {
     pending_write: bool,
     read_len: usize,
 }
-
-pub static mut WRITE_BUF: [u8; 64] = [0; 64];
-pub static mut READ_BUF: [u8; 64] = [0; 64];
 
 pub struct Console<'a> {
     uart: &'a dyn uart::UartData<'a>,


### PR DESCRIPTION
Without this, naive attempts to create multiple Console instances using the component would result in all of them inoperable due to all using the same buffers.

### Pull Request Overview

This pull request makes it harder to end up with a broken console by making it easier to use ConsoleComponent correctly. Without this change, the user must be aware that all ConsoleComponents share the same set of read/write buffers (layering violation). With this change, each ConsoleComponent gets its own buffer, at the cost of having to call a helper macro – the user has to consciously make the mistake of reusing buffers if they insist.

ConsoleComponent has an explicit `device_num` parameter, which suggests that multiple instances were allowable, plus it's a decent interface to expose generic serial devices to the userspace.

To add weight to this problem, debugging it systematically is rather hard, because when multiple devices are created and the bug is triggered, then – drum roll – debug macros no longer work.

### Testing Strategy

This pull request was tested by running manually.


### TODO or Help Wanted

This pull request still needs review.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
