### PR TITLE
mpu: Load static apps in the middle of memory regions if needed

### DIFF
--- a/arch/cortex-m/src/mpu.rs
+++ b/arch/cortex-m/src/mpu.rs
@@ -548,6 +548,7 @@ impl<const NUM_REGIONS: usize, const MIN_REGION_SIZE: usize> mpu::MPU
         &self,
         unallocated_memory_start: *const u8,
         unallocated_memory_size: usize,
+        app_memory_start: Option<*const u8>,
         min_memory_size: usize,
         initial_app_memory_size: usize,
         initial_kernel_memory_size: usize,
@@ -579,15 +580,34 @@ impl<const NUM_REGIONS: usize, const MIN_REGION_SIZE: usize> mpu::MPU
             return None;
         }
 
-        // The region should start as close as possible to the start of the unallocated memory.
-        let mut region_start = unallocated_memory_start as usize;
+        // If the start and length don't align, alter region until it fits
+        let (mut region_start, mut region_size) = match app_memory_start {
+            Some(start) => {
+                // If the app needs a fixed start, put it within the region.
+                let start = start as usize;
+                // Need to take region size into account because it has a minimal size.
+                let region_start = start - (start % region_size);
+                math::extend_to_pow2(
+                    region_start,
+                    cmp::max(start + memory_size, region_start + region_size),
+                )
+            }
+            None => {
+                // The region should start as close as possible to the start of the unallocated memory.
+                // If the start and length don't align, move region towards the end
+                // until it does
+                let start = unallocated_memory_start as usize;
+                let region_start = if start % region_size != 0 {
+                    start + region_size - (start % region_size)
+                } else {
+                    start
+                };
+                (region_start, region_size)
+            }
+        };
 
-        // If the start and length don't align, move region up until it does
-        if region_start % region_size != 0 {
-            region_start += region_size - (region_start % region_size);
-        }
-
-        // We allocate an MPU region exactly over the process memory block, and we disable
+        // We allocate an MPU region starting before or exactly
+        // over the process memory block, and we disable
         // subregions at the end of this region to disallow access to the memory past the app
         // break. As the app break later increases, we will be able to linearly grow
         // the logical region covering app-owned memory by enabling more and more subregions.
@@ -599,7 +619,10 @@ impl<const NUM_REGIONS: usize, const MIN_REGION_SIZE: usize> mpu::MPU
             if initial_kernel_memory_size == 0 {
                 8
             } else {
-                initial_app_memory_size * 8 / region_size + 1
+                let app_start = app_memory_start.map_or(region_start, |a| a as usize);
+                let app_end = app_start + initial_app_memory_size;
+                let initial_size = app_end - region_start;
+                initial_size * 8 / region_size + 1
             }
         };
 
@@ -610,25 +633,54 @@ impl<const NUM_REGIONS: usize, const MIN_REGION_SIZE: usize> mpu::MPU
         let kernel_memory_break = region_start + region_size - initial_kernel_memory_size;
 
         // If the last subregion covering app-owned memory overlaps the start of kernel-owned
-        // memory, we make the entire process memory block twice as big so there is plenty of space
+        // memory, we push the region end forward so there is plenty of space
         // between app-owned and kernel-owned memory.
         if subregions_end > kernel_memory_break {
-            region_size *= 2;
+            match app_memory_start {
+                Some(start) => {
+                    // The region must include start.
+                    // Add one subregion to remove any overlapping.
+                    // More isn't needed because the region was already sized to
+                    // cover the app+kernel size.
+                    // This will get rounded to a multiple of the region size anyway.
+                    let minimum_region_end = region_start + region_size + subregion_size;
+                    let start = start as usize;
 
-            if region_start % region_size != 0 {
-                region_start += region_size - (region_start % region_size);
-            }
+                    // The MPU may place regions only when both ends
+                    // are multiples of the same power of 2.
+                    let (extended_start, extended_size) =
+                        math::extend_to_pow2(start, minimum_region_end);
+                    region_start = extended_start;
+                    region_size = extended_size;
+                }
+                None => {
+                    // The region may be placed anywhere.
+                    // Push the region end twice as far out,
+                    // follow up with the start if needed.
+                    region_size *= 2;
+                    if region_start % region_size != 0 {
+                        region_start += region_size - (region_start % region_size);
+                    }
+                }
+            };
 
             num_subregions_used = {
                 if initial_kernel_memory_size == 0 {
                     8
                 } else {
-                    initial_app_memory_size * 8 / region_size + 1
+                    let app_start = app_memory_start.map_or(region_start, |a| a as usize);
+                    let app_end = app_start + initial_app_memory_size;
+                    let initial_size = app_end - region_start;
+                    initial_size * 8 / region_size + 1
                 }
             };
         }
 
         // Make sure the region fits in the unallocated memory.
+        if region_start < unallocated_memory_start as usize {
+            return None;
+        }
+
         if region_start + region_size
             > (unallocated_memory_start as usize) + unallocated_memory_size
         {

--- a/arch/rv32i/src/epmp.rs
+++ b/arch/rv32i/src/epmp.rs
@@ -537,6 +537,7 @@ impl<const MAX_AVAILABLE_REGIONS_OVER_TWO: usize> kernel::platform::mpu::MPU
         &self,
         unallocated_memory_start: *const u8,
         unallocated_memory_size: usize,
+        app_memory_start: Option<*const u8>,
         min_memory_size: usize,
         initial_app_memory_size: usize,
         initial_kernel_memory_size: usize,
@@ -580,7 +581,7 @@ impl<const MAX_AVAILABLE_REGIONS_OVER_TWO: usize> kernel::platform::mpu::MPU
         }
 
         // The region should start as close as possible to the start of the unallocated memory.
-        let region_start = unallocated_memory_start as usize;
+        let region_start = app_memory_start.unwrap_or(unallocated_memory_start) as usize;
 
         // Make sure the region fits in the unallocated memory.
         if region_start + region_size

--- a/arch/rv32i/src/pmp.rs
+++ b/arch/rv32i/src/pmp.rs
@@ -401,6 +401,7 @@ impl<const MAX_AVAILABLE_REGIONS_OVER_TWO: usize> kernel::platform::mpu::MPU
         &self,
         unallocated_memory_start: *const u8,
         unallocated_memory_size: usize,
+        app_memory_start: Option<*const u8>,
         min_memory_size: usize,
         initial_app_memory_size: usize,
         initial_kernel_memory_size: usize,
@@ -444,7 +445,7 @@ impl<const MAX_AVAILABLE_REGIONS_OVER_TWO: usize> kernel::platform::mpu::MPU
         }
 
         // The region should start as close as possible to the start of the unallocated memory.
-        let region_start = unallocated_memory_start as usize;
+        let region_start = app_memory_start.unwrap_or(unallocated_memory_start) as usize;
 
         // Make sure the region fits in the unallocated memory.
         if region_start + region_size

--- a/kernel/src/utilities/math.rs
+++ b/kernel/src/utilities/math.rs
@@ -131,4 +131,33 @@ pub fn log10(x: f32) -> f32 {
     value_ln * fract_base_ln
 }
 
+/// Finds the smallest range where `start` and `end` lie within
+/// one power of 2 of each other.
+/// Returns the start of the region and the power.
+pub fn extend_to_pow2(start: usize, end: usize) -> (usize, usize) {
+    // The highest bit that differs is the smallest possible power of 2
+    // separating the numbers.
+    let diff = start ^ end;
+    let size = if diff.is_power_of_two() {
+        diff
+    } else {
+        closest_power_of_two(diff as u32) as usize
+    };
+    // Clearing lowest bits aligns with the power of 2
+    let start = start & !(size - 1);
+    (start, size)
+}
+
 //-----------------------------------------------------------
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    #[test]
+    fn extend() {
+        assert_eq!(extend_to_pow2(0, 0x36), (0, 0x40));
+        assert_eq!(extend_to_pow2(0x1f, 0x36), (0, 0x40));
+        assert_eq!(extend_to_pow2(0x21, 0x36), (0x20, 0x20));
+        assert_eq!(extend_to_pow2(0xff, 0x101), (0x0, 0x200));
+    }
+}


### PR DESCRIPTION
Static processes have a hard-coded RAM placement. Before this change, they would be rejected if the start placement did not lie on a MPU access boundary.

In the case of cortex-m, the boundary is dependent on total RAM size, and that, in turn, on the stack size declared in the tbf header. As a result, changing stack size could turn a working application into a permanently rejected one.

This change adds some padding before the actual application start, to align the memory region with the application size.

### Pull Request Overview

This pull request fixes loading static applications.

Solved: ~~It still fails on making `stack_size!` value too high, so this goes only halfway to fixing the stack problem. It seems that the application neither adjusts the application break automatically, nor does the kernel preemptively set the stack higher.~~

~~As a result, an application with a stack that's above the 1st memory subregion (0x2000 works like a charm) will invariably trigger a fault the moment it tries to use the stack (or at least that's my best guess).~~

~~**I think this MR is still complete even without the above problem being solved.**~~

### Testing Strategy

This pull request was tested by installing various libtock-rust applications on a nrf52840. Tested starts like 0x20006010 and changed application size using elf2tab's `--stack 8192`, and other values.

### TODO or Help Wanted

This pull request still needs testing on risc-v (some things modified), ~~and maybe aswering the question of how to tell the kernel what the stack size is.~~ (solved)

EDIT: I'm also not sure how to test resetting.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
