### PR TITLE
tock-register-interface: Provide `none` method for FieldValue type.

### DIFF
--- a/libraries/tock-register-interface/src/fields.rs
+++ b/libraries/tock-register-interface/src/fields.rs
@@ -190,7 +190,7 @@ Field_impl_for!(usize);
 ///
 /// For the FieldValue, the masks and values are shifted into their actual
 /// location in the register.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Default, Eq, PartialEq)]
 pub struct FieldValue<T: UIntLike, R: RegisterLongName> {
     mask: T,
     pub value: T,

--- a/libraries/tock-register-interface/src/fields.rs
+++ b/libraries/tock-register-interface/src/fields.rs
@@ -390,6 +390,7 @@ macro_rules! register_bitmasks {
 
             #[allow(dead_code)]
             #[allow(non_camel_case_types)]
+            #[derive(Copy, Clone, Eq, PartialEq)]
             #[repr($valtype)] // so that values larger than isize::MAX can be stored
             $(#[$outer])*
             pub enum Value {

--- a/libraries/tock-register-interface/src/fields.rs
+++ b/libraries/tock-register-interface/src/fields.rs
@@ -190,7 +190,7 @@ Field_impl_for!(usize);
 ///
 /// For the FieldValue, the masks and values are shifted into their actual
 /// location in the register.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct FieldValue<T: UIntLike, R: RegisterLongName> {
     mask: T,
     pub value: T,

--- a/libraries/tock-register-interface/src/fields.rs
+++ b/libraries/tock-register-interface/src/fields.rs
@@ -190,7 +190,7 @@ Field_impl_for!(usize);
 ///
 /// For the FieldValue, the masks and values are shifted into their actual
 /// location in the register.
-#[derive(Copy, Clone, Default, Eq, PartialEq)]
+#[derive(Copy, Clone, Eq, PartialEq)]
 pub struct FieldValue<T: UIntLike, R: RegisterLongName> {
     mask: T,
     pub value: T,
@@ -230,6 +230,15 @@ FieldValue_impl_for!(u128);
 FieldValue_impl_for!(usize);
 
 impl<T: UIntLike, R: RegisterLongName> FieldValue<T, R> {
+    #[inline]
+    pub fn none() -> Self {
+        Self {
+            mask: T::zero(),
+            value: T::zero(),
+            associated_register: PhantomData,
+        }
+    }
+
     /// Get the raw bitmask represented by this FieldValue.
     #[inline]
     pub fn mask(&self) -> T {


### PR DESCRIPTION
### Pull Request Overview

`Default` is useful to construct a `FieldValue` which can be passed to
`modify` as a no-op or used as an additive identity when combining other
`FieldValue`s.

`Eq` and `PartialEq` are useful for assertions in testing.

### Testing Strategy

This pull request was tested by `cargo test`.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
