### PR TITLE
tock-registers: Implement From field enum value type for FieldValue.

### DIFF
--- a/libraries/tock-register-interface/README.md
+++ b/libraries/tock-register-interface/README.md
@@ -294,6 +294,9 @@ registers.cr.modify(Control::RANGE.val(2)); // Leaves EN, INT unchanged
 // Named constants can be used instead of the raw values:
 registers.cr.modify(Control::RANGE::VeryHigh);
 
+// Enum values can also be used:
+registers.cr.modify(Control::RANGE::Value::VeryHigh.into())
+
 // Another example of writing a field with a raw value:
 registers.cr.modify(Control::EN.val(0)); // Leaves RANGE, INT unchanged
 

--- a/libraries/tock-register-interface/src/fields.rs
+++ b/libraries/tock-register-interface/src/fields.rs
@@ -413,6 +413,12 @@ macro_rules! register_bitmasks {
                     }
                 }
             }
+
+            impl From<Value> for FieldValue<$valtype, $reg_desc> {
+                fn from(v: Value) -> Self {
+                    Self::new($crate::bitmask!($numbits), $offset, v as $valtype)
+                }
+            }
         }
     };
     {


### PR DESCRIPTION
### Pull Request Overview

This makes it easier to set a field based on the enum value.

Fixes #3012.

### Testing Strategy

This pull request was tested by `cargo test`.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
