### PR TITLE
screen HIL: Add separate set_power

### DIFF
--- a/capsules/src/screen.rs
+++ b/capsules/src/screen.rs
@@ -57,6 +57,7 @@ fn screen_pixel_format_from(screen_pixel_format: usize) -> Option<ScreenPixelFor
 enum ScreenCommand {
     Nop,
     SetBrightness(usize),
+    SetPower(bool),
     InvertOn,
     InvertOff,
     GetSupportedResolutionModes,
@@ -183,6 +184,7 @@ impl<'a> Screen<'a> {
     fn call_screen(&self, command: ScreenCommand, process_id: ProcessId) -> Result<(), ErrorCode> {
         match command {
             ScreenCommand::SetBrightness(brighness) => self.screen.set_brightness(brighness),
+            ScreenCommand::SetPower(enabled) => self.screen.set_power(enabled),
             ScreenCommand::InvertOn => self.screen.invert_on(),
             ScreenCommand::InvertOff => self.screen.invert_off(),
             ScreenCommand::SetRotation(rotation) => {
@@ -557,6 +559,8 @@ impl<'a> SyscallDriver for Screen<'a> {
             }
             // Does it have the screen setup
             1 => CommandReturn::success_u32(self.screen_setup.is_some() as u32),
+            // Set power
+            2 => self.enqueue_command(ScreenCommand::SetPower(data1 != 0), process_id),
             // Set Brightness
             3 => self.enqueue_command(ScreenCommand::SetBrightness(data1), process_id),
             // Invert On

--- a/capsules/src/st77xx.rs
+++ b/capsules/src/st77xx.rs
@@ -838,8 +838,12 @@ impl<'a, A: Alarm<'a>, B: Bus<'a>, P: Pin> screen::Screen for ST77XX<'a, A, B, P
         }
     }
 
-    fn set_brightness(&self, brightness: usize) -> Result<(), ErrorCode> {
-        if brightness > 0 {
+    fn set_brightness(&self, _brightness: usize) -> Result<(), ErrorCode> {
+        Ok(())
+    }
+
+    fn set_power(&self, enabled: bool) -> Result<(), ErrorCode> {
+        if enabled {
             self.display_on()
         } else {
             self.display_off()

--- a/doc/syscalls/90001_screen.md
+++ b/doc/syscalls/90001_screen.md
@@ -30,11 +30,26 @@ The screen driver allows the process to write data to a framebuffer of a screen.
 
     **Returns**: SUCCESS_U32 with 1 if yes, and 0 if no
 
+  * ### Command number: `2`
+
+    **Description**: Set power
+
+    **Argument 1**: 0 if off, nonzero if on.
+
+    **Argument 2**: unused
+
+    **Returns**: Ok(()) followed by the ready callback if the command was successful,
+    BUSY if another command is in progress,
+
   * ### Command number: `3`
 
     **Description**: Set brightness
 
-    **Argument 1**: Percent of brightness, 0% should turn off the screen, greater than 0% should turn it on.
+    **Argument 1**: Lightness value, relative to minimum and maximum supported.
+    0 should turn off the light if available, greater than 0 should set it to minimum.
+    65535 and above turn lightness to the maximum supported.
+    Intermediate values approximate intermediate lightness levels.
+    May take effect only after power is set (e.g. for LED displays).
 
     **Argument 2**: unused
 


### PR DESCRIPTION
### Pull Request Overview

This pull request adds a separate set_power call to the Screen HIL.

The brightness value also got an explanation: it's lightness, not percent.

Since the screen HIL package seems to be stalled https://github.com/tock/tock/pull/3011, I decided to sneak in the changes piecewise instead.

### Testing Strategy

This pull request was not really tested. I don't have the hardware for the driver I modified here, and brightness wasn't used there either.

### TODO or Help Wanted

This pull request still needs testing/review.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
