### PR TITLE
Console: terminate write rather than panic if the Allow buffer is unexpectedly shortened.

### DIFF
--- a/doc/syscalls/00001_console.md
+++ b/doc/syscalls/00001_console.md
@@ -103,8 +103,7 @@ callback when the write has completed.
     the next write transaction. A shared buffer is released if it is replaced
     by a subsequent call and after a write transaction is completed. Replacing
     the buffer after beginning a write transaction but before receiving a
-    completion callback is undefined (most likely either the original buffer or
-    new buffer will be written in its entirety but not both).
+    completion callback is undefined.
 
     **Returns**: Ok(()) if the subscribe was successful or NOMEM if the
     driver failed to allocate memory for the transaction.
@@ -115,8 +114,7 @@ callback when the write has completed.
     transaction. A shared buffer is released in two cases: if it is replaced by
     a subsequent call or after a read transaction is completed. Replacing the
     buffer after beginning a read transaction but before receiving a completion
-    callback is undefined (most likely either the original buffer or new buffer
-    will be sent in its entirety but not both).
+    callback is undefined.
 
     **Returns**: Ok(()) if the subscribe was successful or NOMEM if the
     driver failed to allocate memory for the transaction.


### PR DESCRIPTION
### Pull Request Overview

Fixes #3007

With this PR, if a process starts a console write then replaces the write buffer with a shorter buffer, the Console capsule will terminate the write rather than panicing.

I removed the Console documentation's description of Console's likely behavior when handling a shortened buffer. It is no longer accurate, and is not relevant to users of Console because the actual behavior is explicitly undefined.

### Testing Strategy

This PR was tested by using a `libtock-rs` app that starts a large console write then replaces the buffer with an empty hardware. I was able to reproduce the bug on an NRF52840-DK, and have confirmed this change fixes the panic.

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
