### PR TITLE
doc: Update alarm

### DIFF
--- a/doc/syscalls/00000_alarm.md
+++ b/doc/syscalls/00000_alarm.md
@@ -7,7 +7,7 @@ driver number: 0x00000
 ## Overview
 
 The alarm driver exposes a wrapping hardware counter to processes. An alarm can
-report the current tic value and notify via a callback when the counter reaches
+report the current tick value and notify via a callback when the counter reaches
 a certain value.
 
 The alarm's frequency is platform-specific, but must be _at least_ 1kHz.
@@ -37,13 +37,13 @@ The alarm's frequency is platform-specific, but must be _at least_ 1kHz.
 
   * ### Command number: `2`
 
-    **Description**: Read the current counter tic value.
+    **Description**: Read the current counter tick value.
 
     **Argument 1**: unused
 
     **Argument 2**: unused
 
-    **Returns**: The counter value in tics.
+    **Returns**: The counter value in ticks.
 
   * ### Command number: `3`
 
@@ -56,29 +56,28 @@ The alarm's frequency is platform-specific, but must be _at least_ 1kHz.
     **Returns**: INVAL if the notification identifier is invalid, ALREADY if
     the notification is already disabled, or Ok(()).
 
-  * ### Command number: `4`
-
-    **Description**: Set an alarm notification for a counter value.
-    Notification invokes the callback set with subscribe.
-
-    **Argument 1**: The counter tic value to notify.
-
-    **Argument 2**: unused
-
-    **Returns**: INVAL if the notification identifier is invalid, ALREADY if
-    the notification is already disabled, or Ok(()).
-
-  * ### Command number: `5` (experimental)
+  * ### Command number: `5`
 
     **Description**: Set an alarm notification for a counter value relative to the current value.
     Notification invokes the callback set with subscribe.
 
-    **Argument 1**: The relative counter tic value to notify.
+    **Argument 1**: The relative counter tick value to notify.
 
     **Argument 2**: unused
 
-    **Returns**: INVAL if the notification identifier is invalid, ALREADY if
-    the notification is already disabled, or Ok(()).
+    **Returns**: Tick value when the callback will be called.
+
+  * ### Command number: `6`
+
+    **Description**: Set an alarm notification for an absolute counter value.
+    Notification invokes the callback set with subscribe.
+
+    **Argument 1**: The reference point tick value.
+
+    **Argument 2**: Absolute tick value. Callback will be issued
+    when it matches current tick value.
+
+    **Returns**: Tick value when the callback will be called.
 
 ## Subscribe
 
@@ -87,8 +86,8 @@ The alarm's frequency is platform-specific, but must be _at least_ 1kHz.
     **Description**: Subscribe to alarm notifications.
 
     **Callback signature**: The callback recieves two arguments: the counter
-    tic value when the alarm notifiation expired and the notification
-    identifier returned from command 4. The value of the remaining argument is
+    tick value when the alarm notification expired and the reference
+    tick with which it was registered. The value of the remaining argument is
     undefined.
 
     **Returns**: Ok(()) if the subscribe was successful or NOMEM if the


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes the docs for the alarm syscall. They are severely outdated and inaccurate.

### Testing Strategy

This pull request was tested by comparing with the alarm capsule.

### TODO or Help Wanted

This pull request still needs an explanation of how the reference value is used, e.g. whether a reference in the past will cause the alarm to trigger at this or next cycle.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
