### PR TITLE
Documentation: Fix Typo in syscall reference doc

### DIFF
--- a/doc/reference/trd104-syscalls.md
+++ b/doc/reference/trd104-syscalls.md
@@ -568,7 +568,7 @@ a buffer by calling allow with the same pointer and a longer length
 and such a call is not required to return an error code of `INVALID`.
 Similarly, it is possible for userspace to allow the same buffer
 multiple times to the kernel. This means, in practice, that the kernel
-may have multiple writeable references to the same memory and MUST take
+may have multiple writeable references to the same memory and MUST 
 take precautions to ensure this does not violate safety within the
 kernel.
 


### PR DESCRIPTION
### Pull Request Overview

This pull request adds/changes/fixes...

a small typo in the reference documentation.
There was a duplicate "take" in the section about the "Read-Write Allow" systemcall

### Testing Strategy

This pull request was tested by...

nobody

### TODO or Help Wanted

This pull request still needs...

...

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
