### PR TITLE
Console: Add a way to cancel ongoing console writes.

### DIFF
--- a/doc/syscalls/00001_console.md
+++ b/doc/syscalls/00001_console.md
@@ -40,6 +40,11 @@ callback when the write has completed.
     shared, or NOMEM if the driver failed to allocate memory for the
     transaction.
 
+    **Additional notes:** A process may call this command with a write size of
+    `0` to cancel a write transaction, if one is ongoing. Unless an error
+    occurs, this will generate a write transaction completed event, regardless
+    of whether or not a write transaction was already in progress.
+
   * ### Command number: `2`
 
     **Description**: Initiate a read transaction into a buffer shared using `allow`.


### PR DESCRIPTION
`libtock-rs`'s panic handlers want to print a panic message regardless of whether or not the panic occurred with a write in progress. Printing the panic message without corruption requires a way to wait for the console to become available, and the console API does not currently have a documented way to do so.

This PR adds a way to cancel any ongoing transactions to the stable console API. It does so by documenting an exiting behavior: that calling the "start write" command with a length of `0` bytes will cancel ongoing transactions and trigger an upcall.

An alternative possibility is to add a new "cancel write" command to the API.

[Rendered](https://github.com/jrvanwhy/tock/blob/console-cancel/doc/syscalls/00001_console.md)