### PR TITLE
libraries/tickv: Remove space from keyword

### DIFF
--- a/libraries/tickv/Cargo.toml
+++ b/libraries/tickv/Cargo.toml
@@ -8,5 +8,5 @@ license = "MIT OR Apache-2.0"
 authors = ["Alistair Francis <alistair.francis@wdc.com>"]
 edition = "2021"
 readme = "README.md"
-keywords = ["flash", "key/value store"]
+keywords = ["flash", "key-value-store"]
 categories = ["database-implementations", "no-std"]


### PR DESCRIPTION
### Pull Request Overview

According to https://github.com/rust-lang/cargo/issues/8482 we can't
have spaces or slashes in the keywords.

Signed-off-by: Alistair Francis <alistair.francis@wdc.com>

### Testing Strategy

`cargo publish`

### TODO or Help Wanted

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
