### PR TITLE
Wrap VolatileCell around Cell; save the world

### DIFF
--- a/capsules/src/usb/descriptors.rs
+++ b/capsules/src/usb/descriptors.rs
@@ -26,7 +26,7 @@ pub struct Buffer64 {
 impl Default for Buffer64 {
     fn default() -> Self {
         Self {
-            buf: [VolatileCell::default(); 64],
+            buf: [(); 64].map(|_| VolatileCell::default()),
         }
     }
 }

--- a/libraries/tock-cells/src/volatile_cell.rs
+++ b/libraries/tock-cells/src/volatile_cell.rs
@@ -1,29 +1,81 @@
 //! Implementation of a type for accessing MCU registers.
 
+use core::cell::UnsafeCell;
 use core::ptr;
 
 /// `VolatileCell` provides a wrapper around unsafe volatile pointer reads
 /// and writes. This is particularly useful for accessing microcontroller
-/// registers.
-// Source: https://github.com/hackndev/zinc/tree/master/volatile_cell
-#[derive(Copy, Clone, Default)]
-#[repr(C)]
-pub struct VolatileCell<T> {
-    value: T,
+/// registers by (unsafely) casting a pointer to the register into a `VolatileCell`.
+///
+/// ```
+/// use tock_cells::volatile_cell::VolatileCell;
+/// let myptr: *const usize = 0xdeadbeef as *const usize;
+/// let myregister: &VolatileCell<usize> = unsafe { core::mem::transmute(myptr) };
+/// ```
+// Originally modified from: https://github.com/hackndev/zinc/tree/master/volatile_cell
+#[derive(Default)]
+#[repr(transparent)]
+pub struct VolatileCell<T: ?Sized + Copy> {
+    value: UnsafeCell<T>,
 }
 
-impl<T> VolatileCell<T> {
+impl<T: Copy> Clone for VolatileCell<T> {
+    #[inline]
+    fn clone(&self) -> Self {
+        VolatileCell::new(self.get())
+    }
+}
+
+impl<T: Copy> VolatileCell<T> {
     pub const fn new(value: T) -> Self {
-        VolatileCell { value }
+        VolatileCell {
+            value: UnsafeCell::new(value),
+        }
     }
 
     #[inline]
-    pub fn get(&self) -> T {
-        unsafe { ptr::read_volatile(&self.value) }
-    }
-
-    #[inline]
+    /// Performs a memory write with the provided value.
+    ///
+    /// # Side-Effects
+    ///
+    /// `set` _always_ performs a memory write on the underlying location. If
+    /// this location is a memory-mapped I/O register, the side-effects of
+    /// performing the write are register-specific.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tock_cells::volatile_cell::VolatileCell;
+    ///
+    /// let vc = VolatileCell::new(123);
+    /// vc.set(432);
+    /// ```
     pub fn set(&self, value: T) {
-        unsafe { ptr::write_volatile(&self.value as *const T as *mut T, value) }
+        // `set` does not read the value currently inside the `VolatileCell`
+        // and, therefore, does not `drop` it, but because `T` is `Copy`, there
+        // cannot be a destructor anyway.
+        unsafe { ptr::write_volatile(self.value.get(), value) }
+    }
+
+    #[inline]
+    /// Performs a memory read and returns a copy of the value represented by
+    /// the cell.
+    ///
+    /// # Side-Effects
+    ///
+    /// `get` _always_ performs a memory read on the underlying location. If
+    /// this location is a memory-mapped I/O register, the side-effects of
+    /// performing the write are register-specific.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tock_cells::volatile_cell::VolatileCell;
+    ///
+    /// let vc = VolatileCell::new(5);
+    /// let five = vc.get();
+    /// ```
+    pub fn get(&self) -> T {
+        unsafe { ptr::read_volatile(self.value.get()) }
     }
 }

--- a/libraries/tock-cells/src/volatile_cell.rs
+++ b/libraries/tock-cells/src/volatile_cell.rs
@@ -65,7 +65,7 @@ impl<T: Copy> VolatileCell<T> {
     ///
     /// `get` _always_ performs a memory read on the underlying location. If
     /// this location is a memory-mapped I/O register, the side-effects of
-    /// performing the write are register-specific.
+    /// performing the read are register-specific.
     ///
     /// # Examples
     ///


### PR DESCRIPTION


# Pull Request Overview

Uses `Cell` as a wrapper around the value stored in a `VolatileCell`
(and thus inheriting an `UnsafeCell`). This prevents triggering
undefined behavior when sharing a `VolatileCell` immutably when,
internally, it might change.

A consequence is that we have to remove the `Copy` marker, but that was
only used in one place to make initializing a large array easier, so I
changed that call site to simply initialize the array explicitly. More
source code, no more compiled code.

/cc @kupiakos


# Testing Strategy

The changes in this PR are all static refactoring, so it was tested by simply compiling all boards.


# TODO or Help Wanted


# Documentation Updated

-   [ ] <del>Updated the relevant files in `/docs`, or no updates are
    required.</del>


# Formatting

-   [X] Ran `make prepush`.
