### PR TITLE
doc/reference/trd-uart: small fixes & suggestions in response to #3046

### DIFF
--- a/doc/reference/trd-uart.md
+++ b/doc/reference/trd-uart.md
@@ -270,7 +270,7 @@ The valid error codes for `transmit_buffer` are:
     (e.g., a USART has been configured to be a SPI).
   - `BUSY`: the UART is already transmitting and has not made a transmission
     complete callback yet.
-  - `SIZE`: `tx_len` is larger than the passed slice.
+  - `SIZE`: `tx_len` is larger than the passed slice or `tx_len == 0`.
   - `INVAL`: the device is configured for data widths larger than 8-bit.
   - `FAIL`: some other failure.
 
@@ -446,7 +446,7 @@ received, `rval` MUST be `Err`. Valid return values for
     UART communication (e.g., a USART is configured to be SPI).
   - `BUSY`: the UART is already receiving (a buffer or a word)
     and has not made a reception `received` callback yet.
-  - `SIZE`: `rx_len` is larger than the passed slice.
+  - `SIZE`: `rx_len` is larger than the passed slice or `rx_len == 0`.
   - `INVAL`: the device is configured for data widths larger than
     8-bit.
 

--- a/doc/reference/trd-uart.md
+++ b/doc/reference/trd-uart.md
@@ -121,7 +121,7 @@ pub trait Configuration {
     fn get_width(&self) -> Width;
     fn get_parity(&self) -> Parity;
     fn get_stop_bits(&self) -> StopBits;
-    fn get_flow_control(&self) -> bool;
+    fn get_hw_flow_control(&self) -> bool;
     fn get_configuration(&self) -> Configuration;
 }
 
@@ -130,7 +130,7 @@ pub trait Configure {
     fn set_width(&self, width: Width) -> Result<(), ErrorCode>;
     fn set_parity(&self, parity: Parity) -> Result<(), ErrorCode>;
     fn set_stop_bits(&self, stop: StopBits) -> Result<(), ErrorCode>;
-    fn set_flow_control(&self, on: bool) -> Result<(), ErrorCode>;
+    fn set_hw_flow_control(&self, on: bool) -> Result<(), ErrorCode>;
     fn configure(&self, params: Parameters) -> Result<(), ErrorCode>;
 }
 ```

--- a/doc/reference/trd-uart.md
+++ b/doc/reference/trd-uart.md
@@ -105,7 +105,7 @@ pub enum Width {
     Six = 6,
     Seven = 7,
     Eight = 8,
-	Nine = 9,
+    Nine = 9,
 }
 
 pub struct Parameters {
@@ -311,15 +311,15 @@ The `transmit_abort` method allows a UART implementation to terminate
 an outstanding call to `transmit_character` or `transmit_buffer` early. The
 result of `transmit_abort` indicates two things:
 
-  1. whether a callback will occur (there is an oustanding operation), and 
+  1. whether a callback will occur (there is an oustanding operation), and
   2. if a callback will occur, whether the operation is cancelled.
-  
+
 If `transmit_abort` returns `Callback`, there will be be a future
 callback for the completion of the outstanding request. If there is
 an outstanding `transmit_buffer` or `transmit_character` operation,
 `transmit_abort` MUST return `Callback`. If there is no outstanding
 `transmit_buffer` or `transmit_abort` operation, `transmit_abort` MUST
-return `NoCallback`. 
+return `NoCallback`.
 
 The three possible values of `AbortResult` have these meanings:
   - `Callback(true)`: there was an outstanding operation, which

--- a/doc/reference/trd-uart.md
+++ b/doc/reference/trd-uart.md
@@ -158,6 +158,13 @@ Methods in `Configure` can return the following error conditions:
     would be affected by a change of the respective parameter.
   - `FAIL`: Other failure condition.
 
+`Configuration::get_configuration` can be used to retrieve a copy of
+the current UART configuration, which can later be restored using the
+`Configure::configure` method. An implementation of the
+`Configure::configure` method must ensure that this configuration is
+applied atomically: either the configuration described by the passed
+`Parameters` is applied in its entirety or the device's configuration
+shall remain unchanged, with the respective check's error returned.
 
 The UART may be unable to set the precise baud rate specified. For
 example, the UART may be driven off a fixed clock with integer

--- a/doc/reference/trd-uart.md
+++ b/doc/reference/trd-uart.md
@@ -140,7 +140,7 @@ Methods in `Configure` can return the following error conditions:
     because it has not been initialized or in the case of a shared
     hardware USART controller because it is set up for SPI.
   - `INVAL`: Baud rate was set to 0.
-  - `ENOSUPPORT`: The underlying UART cannot satisfy this configuration.
+  - `NOSUPPORT`: The underlying UART cannot satisfy this configuration.
   - `FAIL`: Other failure condition.
 
 
@@ -328,7 +328,7 @@ The three possible values of `AbortResult` have these meanings:
   - `Callback(false)`: there was an outstanding operation, which
     has not been cancelled.  A callback will be made for that operation with
     a result other than `Err(CANCEL)`.
-  - `NoCallack`: there was no outstanding request and there will be no future
+  - `NoCallback`: there was no outstanding request and there will be no future
     callback.
 
 Note that the semantics of the boolean field in

--- a/doc/reference/trd-uart.md
+++ b/doc/reference/trd-uart.md
@@ -5,10 +5,10 @@ Universal Asynchronous Receiver Transmitter (UART)  HIL
 **Working Group:** Kernel<br/>
 **Type:** Documentary<br/>
 **Status:** Draft <br/>
-**Author:** Philip Levis <br/>
+**Author:** Philip Levis, Leon Schuermann <br/>
 **Draft-Created:** August 5, 2021<br/>
-**Draft-Modified:** October 24, 2021<br/>
-**Draft-Version:** 4<br/>
+**Draft-Modified:** June 5, 2022<br/>
+**Draft-Version:** 5<br/>
 **Draft-Discuss:** tock-dev@googlegroups.com</br>
 
 Abstract
@@ -566,4 +566,6 @@ Stanford University
 Stanford, CA 94305
 USA
 pal@cs.stanford.edu
+
+Leon Schuermann <leon@is.currently.online>
 ```

--- a/doc/reference/trd-uart.md
+++ b/doc/reference/trd-uart.md
@@ -96,6 +96,12 @@ operations. Refer to [3 `Transmit` and `TransmitClient`
 ](#3-transmit-and-transmitclient) and [4 `Receive` and `ReceiveClient`
 ](#4-receive-and-receiveclient-traits) respectively.
 
+Any configuration-change must not apply to operations started before
+this change. The UART implementation is free to accept a configuration
+change and apply it with the next operation, or refuse an otherwise
+valid configuration request because of an ongoing operation by
+returning `ErrorCode::BUSY`.
+
 ```rust
 pub enum StopBits {
     One = 1,
@@ -148,6 +154,8 @@ Methods in `Configure` can return the following error conditions:
     hardware USART controller because it is set up for SPI.
   - `INVAL`: Baud rate was set to 0.
   - `NOSUPPORT`: The underlying UART cannot satisfy this configuration.
+  - `BUSY`: The UART is currently busy processing an operation which
+    would be affected by a change of the respective parameter.
   - `FAIL`: Other failure condition.
 
 


### PR DESCRIPTION
### Pull Request Overview

This pull request contains some small fixes, suggestions and additions to the UART draft TRD I noticed while implementing it for the `sifive` chips as part of #3046, namely:

- some indetation, whitespace, spelling fixes, renaming `{set,get}_flow_control` to `{set,get}_hw_flow_control` to be consistent with the `Parameters` struct field.

- [disable bulk transfers with width >= 9](https://github.com/tock/tock/commit/8327c3b91a7d118f968d5f81c8050b3509deca51) 

  The TRD mentions that `transmit_buffer` and `receive_buffer` are not supported for transfers with data-width configured to larger than 8-bit, but does not explicitly document what happens when these methods are invoked in this configuration. This changes the text to enforce these methods must return `ErrorCode::INVAL` in such a configuration.

  It furthermore extends section 3 (`Configuration` and `Configure`) to describe both the case of Width < 8-bit and Width > 8-bit.

- [apply config changes only to new operations](https://github.com/tock/tock/commit/03207fdb2eaace9f1e7b951e574c8dfc129141de) 

  It does not seem like a good idea to allow UART configuration changes mid-flight, and conceivably some hardware might not support this at all (e.g. fix parameters on the start of the DMA operation or raise an exception when changing them mid-flight).

  To unify the behavior of different implementations, it seems most sensible to define that configuration changes apply only to new operations and a device is free to refuse changing its configuration when an operation is currently ongoing.

- [ensure configuration changes are atomic](https://github.com/tock/tock/commit/516f93d79f51f32c9d56daae57506f0e87040c5e) 

  The utility of `Configure::configure` is quite limited currently, considering that other methods in the `Configure` allow setting all parameters contained in the passed `Parameters` struct already. What would make it significantly more useful is to have all changes applied through that interface be atomic: if only a single requested parameter is not supported by the underlying device, do not apply any of the passed parameters. One particularly convincing usecase for this might be a parameter change following a device-negotation: either the negotiated parameters can be used, or communication can continue in the original configuration.

- [return an error on `{tx,rx}_len == 0`](https://github.com/tock/tock/commit/7cf4ca2fc22981234d3b4d30ac3f08d00b04720b) 

  If transmissions or receptions of zero length must be supported as proper operations, they will need to result in a callback which must be generated as part of a different call stack. If a UART device does not support generating hardware interrupts for the completion of zero-length transmissions, a device driver implementation has to use a deferred call mechanism in order to be compliant with the API specified in this HIL.

  To avoid employing a deferred call for this edge case when it would otherwise not be required, avoid supporting zero-length operations.

### Testing Strategy

N/A


### TODO or Help Wanted

This pull request still needs feedback on whether these are actually changes we'd like to include.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
