### PR TITLE
esp32c3: fixup Makefile bug

### DIFF
--- a/boards/esp32-c3-devkitM-1/Makefile
+++ b/boards/esp32-c3-devkitM-1/Makefile
@@ -11,7 +11,7 @@ include ../Makefile.common
 install: flash
 
 flash: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
-	esptool.py --port /dev/ttyUSB0 --chip esp32c3 elf2image --use_segments --output binary.hex $^
+	esptool.py --port /dev/ttyUSB0 --chip esp32c3 elf2image --use_segments --output binary.hex $^ --dont-append-digest
 	esptool.py --port /dev/ttyUSB0 --chip esp32c3 write_flash --flash_mode dio --flash_size detect --flash_freq 80m  0x0 binary.hex
 
 flash-app: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
@@ -19,7 +19,7 @@ ifeq ($(APP),)
 	$(error "Please specify an APP to be flashed")
 endif
 	$(RISC_PREFIX)-objcopy --update-section .apps=$(APP) $^ $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.elf
-	esptool.py --port /dev/ttyUSB0 --chip esp32c3 elf2image --use_segments --output binary.hex $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.elf
+	esptool.py --port /dev/ttyUSB0 --chip esp32c3 elf2image --use_segments --output binary.hex $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.elf --dont-append-digest
 	esptool.py --port /dev/ttyUSB0 --chip esp32c3 write_flash --flash_mode dio --flash_size detect --flash_freq 80m 0x0 binary.hex
 
 test:


### PR DESCRIPTION
### Pull Request Overview

With the latest version of esptool (v4.1 or 4.2-dev as of
19/06/22), using `elf2image` without `--dont-append-digest` causes the
`--flash_mode dio` argument to be ignored when flashing. As a result,
despite the flash completing, it defaults to flashing in qio, which
causes a bootloop. It seems that for now, the binary must be flashed
with dio.

This patch adds the `--dont-append-digest` arg where appropriate so that
flash mode is not set to default (`qio`) and the correct `dio` mode is
used.

### Reproduce

When building for this board with the latest `esptool` the following warning is presented 

- Warning: Image file at 0x0 is protected with a hash checksum, so not changing the flash mode setting. Use the --flash_mode=keep option instead of --flash_mode=dio in order to remove this warning, or use the --dont-append-digest option for the elf2image command in order to generate an image file without a hash checksum

However, flashing proceeds but causes a **boot loop** with the following output
```
ESP-ROM:esp32c3-api1-20210207
Build:Feb  7 2021
rst:0x7 (TG0WDT_SYS_RST),boot:0xc (SPI_FAST_FLASH_BOOT)
Saved PC:0x40049a42
SPIWP:0xee
mode:QIO, clock div:2
load:0x40380000,len:0x12064
ets_loader.c 78 
ESP-ROM:esp32c3-api1-20210207
Build:Feb  7 2021
rst:0x7 (TG0WDT_SYS_RST),boot:0xc (SPI_FAST_FLASH_BOOT)
Saved PC:0x40049a42
SPIWP:0xee
mode:QIO, clock div:2
load:0x40380000,len:0x12064
ets_loader.c �ESP-ROM:esp32c3-api1-20210207
Build:Feb  7 2021
rst:0x10 (RTCWDT_RTC_RST),boot:0xc (SPI_FAST_FLASH_BOOT)
SPIWP:0xee
mode:QIO, clock div:2
load:0x40380000,len:0x12064
ets_loader.c 78 
```

### Testing Strategy

Flashing with the above changes, boots into tock ok

```
ESP-ROM:esp32c3-api1-20210207
Build:Feb  7 2021
rst:0x1 (POWERON),boot:0xc (SPI_FAST_FLASH_BOOT)
SPIWP:0xee
mode:DIO, clock div:1
load:0x40380000,len:0x12064
load:0x40392064,len:0x8
load:0x403b0000,len:0x4
SHA-256 comparison failed:
Calculated: 6aeb50cdc3145f207b6e3f0296001160db919b2041ed98a2190a27696008a52d
Expected: ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
Attempting to boot anyway...
entry 0x40380000
ESP32-C3 initialisation complete.
Entering main loop.
tock$ 
```

### Documentation Updated

- [x] No updates are required.

### Formatting

- [x] Ran `make prepush`.
