### PR TITLE
boards/opentitan: Don't run nops when targetting Verilator

### DIFF
--- a/boards/opentitan/src/io.rs
+++ b/boards/opentitan/src/io.rs
@@ -48,9 +48,20 @@ pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
     );
     first_led_pin.make_output();
     let first_led = &mut led::LedLow::new(first_led_pin);
-
     let writer = &mut WRITER;
 
+    #[cfg(feature = "sim_verilator")]
+    debug::panic(
+        &mut [first_led],
+        writer,
+        pi,
+        &|| {},
+        &PROCESSES,
+        &CHIP,
+        &PROCESS_PRINTER,
+    );
+
+    #[cfg(not(feature = "sim_verilator"))]
     debug::panic(
         &mut [first_led],
         writer,
@@ -59,7 +70,7 @@ pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
         &PROCESSES,
         &CHIP,
         &PROCESS_PRINTER,
-    )
+    );
 }
 
 #[cfg(test)]
@@ -68,6 +79,9 @@ pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
 pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
     let writer = &mut WRITER;
 
+    #[cfg(feature = "sim_verilator")]
+    debug::panic_print(writer, pi, &|| {}, &PROCESSES, &CHIP, &PROCESS_PRINTER);
+    #[cfg(not(feature = "sim_verilator"))]
     debug::panic_print(
         writer,
         pi,


### PR DESCRIPTION
### Pull Request Overview

The `NOP` flush in the panic handler takes a **really** long time in a simulation.

This PR changes the `NOP` flush to be optional and then doesn't use it when running on the OpenTitan Verilator build.

### Testing Strategy

Running on Verilator

### TODO or Help Wanted

N/A

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
