### PR TITLE
lpm013m126: Implement turning off

### DIFF
--- a/capsules/src/lpm013m126.rs
+++ b/capsules/src/lpm013m126.rs
@@ -339,6 +339,33 @@ where
         }
     }
 
+    fn uninitialize(&self) -> Result<(), ErrorCode> {
+        match self.state.get() {
+            State::Off => Err(ErrorCode::ALREADY),
+            _ => {
+                // TODO: investigate clearing pixels asynchronously,
+                // like the datasheet asks.
+                // It seems to turn off fine without clearing, but
+                // perhaps the state of the buffer affects power draw when off.
+
+                // The following stops extcomin timer.
+                self.alarm.disarm()?;
+                self.disp.clear();
+                self.state.set(State::Off);
+
+                let scheduled =
+                    schedule_deferred(self.deferred_caller, &self.ready_callback, "ready");
+
+                if let Err(()) = scheduled {
+                    self.state.set(State::Bug);
+                    Err(ErrorCode::FAIL)
+                } else {
+                    Ok(())
+                }
+            }
+        }
+    }
+
     fn call_write_complete(&self, ret: Result<(), ErrorCode>) -> Option<bool> {
         if let Some((handle, None)) = self.write_complete_callback.extract() {
             self.write_complete_callback.set((handle, Some(ret)));
@@ -495,9 +522,7 @@ where
         let ret = if enable {
             self.initialize()
         } else {
-            // TODO: disable DISP, stop EXTCOMIN, clear pixels,
-            // set state to Off
-            Err(ErrorCode::ALREADY)
+            self.uninitialize()
         };
 
         // If the device is in the desired state by now,


### PR DESCRIPTION
Not turning off was technically against the contract of the screen HIL.

### Pull Request Overview

This pull request fixes the lpm display driver by adding turn off functionality.


### Testing Strategy

This pull request was tested by having it run in a private branch for a while (https://framagit.org/jazda/tock), from where it was manually picked.

It still neglects to clear the pixel memory, but that hasn't been necessary in my testing.

### TODO or Help Wanted

This pull request still needs a sanity check.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
