### PR TITLE
hil: Add support for tiled displays

### DIFF
--- a/capsules/src/lpm013m126.rs
+++ b/capsules/src/lpm013m126.rs
@@ -15,7 +15,7 @@ use kernel::dynamic_deferred_call::{
     DeferredCallHandle, DynamicDeferredCall, DynamicDeferredCallClient,
 };
 use kernel::hil::gpio::Pin;
-use kernel::hil::screen::{Screen, ScreenClient, ScreenPixelFormat, ScreenRotation};
+use kernel::hil::screen::{Grid, PixelStreamFormat, Screen, ScreenClient, ScreenRotation};
 use kernel::hil::spi::{SpiMasterClient, SpiMasterDevice};
 use kernel::hil::time::{Alarm, AlarmClient, ConvertTicks};
 use kernel::utilities::cells::{OptionalCell, TakeCell};
@@ -391,8 +391,16 @@ where
         (176, 176)
     }
 
-    fn get_pixel_format(&self) -> ScreenPixelFormat {
-        ScreenPixelFormat::Mono
+    fn get_pixel_format(&self) -> (PixelStreamFormat, Grid) {
+        (
+            PixelStreamFormat::Mono_1H8,
+            Grid {
+                width: 8,
+                height: 1,
+                x_offset: 0,
+                y_offset: 0,
+            },
+        )
     }
 
     fn get_rotation(&self) -> ScreenRotation {
@@ -409,6 +417,11 @@ where
         let rows = 176;
         let columns = 176;
         if y >= rows || y + height > rows || x >= columns || x + width > columns {
+            return Err(ErrorCode::INVAL);
+        }
+
+        // Implied by stream format
+        if x % 8 != 0 || width % 8 != 0 {
             return Err(ErrorCode::INVAL);
         }
 

--- a/capsules/src/st77xx.rs
+++ b/capsules/src/st77xx.rs
@@ -38,7 +38,7 @@ use crate::bus::{self, Bus, BusWidth};
 use core::cell::Cell;
 use kernel::hil::gpio::Pin;
 use kernel::hil::screen::{
-    self, ScreenClient, ScreenPixelFormat, ScreenRotation, ScreenSetupClient,
+    self, Grid, PixelStreamFormat, ScreenClient, ScreenRotation, ScreenSetupClient,
 };
 use kernel::hil::time::{self, Alarm, ConvertTicks};
 use kernel::utilities::cells::{OptionalCell, TakeCell};
@@ -704,9 +704,9 @@ impl<'a, A: Alarm<'a>, B: Bus<'a>, P: Pin> screen::ScreenSetup for ST77XX<'a, A,
         }
     }
 
-    fn set_pixel_format(&self, depth: ScreenPixelFormat) -> Result<(), ErrorCode> {
+    fn set_pixel_format(&self, format: PixelStreamFormat) -> Result<(), ErrorCode> {
         if self.status.get() == Status::Idle {
-            if depth == ScreenPixelFormat::RGB_565 {
+            if format == PixelStreamFormat::RGB_565 {
                 self.setup_client
                     .map(|setup_client| setup_client.command_complete(Ok(())));
                 Ok(())
@@ -735,9 +735,9 @@ impl<'a, A: Alarm<'a>, B: Bus<'a>, P: Pin> screen::ScreenSetup for ST77XX<'a, A,
     fn get_num_supported_pixel_formats(&self) -> usize {
         1
     }
-    fn get_supported_pixel_format(&self, index: usize) -> Option<ScreenPixelFormat> {
+    fn get_supported_pixel_format(&self, index: usize) -> Option<PixelStreamFormat> {
         match index {
-            0 => Some(ScreenPixelFormat::RGB_565),
+            0 => Some(PixelStreamFormat::RGB_565),
             _ => None,
         }
     }
@@ -748,8 +748,16 @@ impl<'a, A: Alarm<'a>, B: Bus<'a>, P: Pin> screen::Screen for ST77XX<'a, A, B, P
         (self.width.get(), self.height.get())
     }
 
-    fn get_pixel_format(&self) -> ScreenPixelFormat {
-        ScreenPixelFormat::RGB_565
+    fn get_pixel_format(&self) -> (PixelStreamFormat, Grid) {
+        (
+            PixelStreamFormat::RGB_565,
+            Grid {
+                width: 1,
+                height: 1,
+                x_offset: 0,
+                y_offset: 0,
+            },
+        )
     }
 
     fn get_rotation(&self) -> ScreenRotation {

--- a/doc/syscalls/90001_screen.md
+++ b/doc/syscalls/90001_screen.md
@@ -195,12 +195,11 @@ may return OFF when power is not enabled (see screen HIL for details).
 
     **Argument 2**: unused
 
-    **Returns**: A single u32 value.
-    0: 8 pixels per byte monochromatic, pixels more to the left are more significant bits. 1 is light, 0 is dark.
-    1: RGB_233, 2-bit red channel, 3-bit green channel, 3-bit blue channel.
-    2: RGB_565, 5-bit red channel, 6-bit green channel, 5-bit blue channel.
-    3: RGB_888
-    4: ARGB_8888 (RGB with transparency)
+    **Returns**: A pair of (u64, u32).
+    The first value is the current pixel grid encoded as 4 u16 values.
+    In order from the highest to lowest bits:
+    width | height | x_offset | y_offset.
+    For the second value, see `capsules::screen::pixel_format_from`.
 
   * ### Command number: `26` 
 

--- a/kernel/src/hil/screen.rs
+++ b/kernel/src/hil/screen.rs
@@ -23,6 +23,9 @@ In situations where a parameter cannot be configured
 (e.g. fixed resolution), they return value may be hardcoded.
 Otherwise, the driver should query the hardware directly,
 and return OFF if it's not powered.
+
+Configuration sets cause a `command_complete` callback
+unless noted otherwise.
 */
 
 use crate::ErrorCode;


### PR DESCRIPTION
### Pull Request Overview

This pull request adds support for tiled displays to the screen HIL. "Tiled" as discussed in https://github.com/tock/tock/pull/3011 . The lpm013m126 is a tiled display, because the smallest unit that it can accept is a whole row of pixels. Currently, it's forced to hold a frame buffer, but after this change, it won't.

### Testing Strategy

This pull request was not tested or verified. lpm013m126 is in plans.

### TODO or Help Wanted

This pull request still needs verification and changes to the syscall driver.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
