### PR TITLE
build: change `$CI` to `$NOWARNINGS`

### DIFF
--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -88,7 +88,7 @@ RUSTC_FLAGS_TOCK ?= \
 # Disallow warnings only for continuous integration builds. Disallowing them
 # here using the `RUSTC_FLAGS_TOCK` variable ensures that warnings during
 # testing won't prevent compilation from succeeding.
-ifeq ($(CI),true)
+ifeq ($(NOWARNINGS),true)
   RUSTC_FLAGS_TOCK += -D warnings
 endif
 
@@ -336,7 +336,7 @@ debug-lst:  $(TARGET_PATH)/debug/$(PLATFORM).lst
 doc: | target
 	@# This mess is all to work around rustdoc giving no way to return an
 	@# error if there are warnings. This effectively simulates that.
-	$(Q)RUSTDOCFLAGS='-Z unstable-options --document-hidden-items -D warnings' $(CARGO) --color=always doc $(VERBOSE_FLAGS) --release --package $(PLATFORM) --target-dir=$(TARGET_DIRECTORY) 2>&1 | grep -C 9999 warning && (echo "Warnings detected during doc build" && if [[ $$CI == "true" ]]; then echo "Erroring due to CI context" && exit 33; fi) || if [ $$? -eq 33 ]; then exit 1; fi
+	$(Q)RUSTDOCFLAGS='-Z unstable-options --document-hidden-items -D warnings' $(CARGO) --color=always doc $(VERBOSE_FLAGS) --release --package $(PLATFORM) --target-dir=$(TARGET_DIRECTORY) 2>&1 | grep -C 9999 warning && (echo "Warnings detected during doc build" && if [[ $$NOWARNINGS == "true" ]]; then echo "Erroring due to CI context" && exit 33; fi) || if [ $$? -eq 33 ]; then exit 1; fi
 
 
 .PHONY: lst


### PR DESCRIPTION
Tock uses different flags in CI so that warnings throw errors, while during normal development warnings are OK. We used the CI env variable to control this, however, this conflates Tock's policy on warnings in CI with running in _any_ CI. That is, a fork of Tock also ends up using Tock's CI policy on warnings, because CI tools tend to set the $CI variable as well.

This patch renames our variable to be more clear of what our use is. In theory we can dissallow warnings while not being in CI.

Fixes #3050.




### Testing Strategy

travis


### TODO or Help Wanted

As noted in https://github.com/tock/tock/issues/3050#issuecomment-1145066328 we may be relying on the fact that github actions will set the CI variable even if we don't do it explicitly. Since we are changing the name in this PR, it's possible we will not be preventing warnings when we intend to.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
