### PR TITLE
Grant: Enter grants before initializing their contents

### DIFF
--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -453,7 +453,7 @@ pub trait Process {
     /// actual app_brk, as MPU alignment and size constraints may result in the
     /// MPU enforced region differing from the app_brk.
     ///
-    /// This will return `None` and fail if:
+    /// This will return `false` and fail if:
     /// - The process is inactive, or
     /// - There is not enough available memory to do the allocation, or
     /// - The grant_num is invalid, or
@@ -464,7 +464,7 @@ pub trait Process {
         driver_num: usize,
         size: usize,
         align: usize,
-    ) -> Option<NonNull<u8>>;
+    ) -> bool;
 
     /// Check if a given grant for this process has been allocated.
     ///
@@ -495,7 +495,7 @@ pub trait Process {
     /// is invalid, if the grant has not been allocated, or if the grant is
     /// already entered. If this returns `Ok()` then the pointer points to the
     /// previously allocated memory for this grant.
-    fn enter_grant(&self, grant_num: usize) -> Result<*mut u8, Error>;
+    fn enter_grant(&self, grant_num: usize) -> Result<NonNull<u8>, Error>;
 
     /// Enter a custom grant based on the `identifier`.
     ///

--- a/kernel/src/process_standard.rs
+++ b/kernel/src/process_standard.rs
@@ -728,22 +728,22 @@ impl<C: Chip> Process for ProcessStandard<'_, C> {
         driver_num: usize,
         size: usize,
         align: usize,
-    ) -> Option<NonNull<u8>> {
+    ) -> bool {
         // Do not modify an inactive process.
         if !self.is_active() {
-            return None;
+            return false;
         }
 
         // Verify the grant_num is valid.
         if grant_num >= self.kernel.get_grant_count_and_finalize() {
-            return None;
+            return false;
         }
 
         // Verify that the grant is not already allocated. If the pointer is not
         // null then the grant is already allocated.
         if let Some(is_allocated) = self.grant_is_allocated(grant_num) {
             if is_allocated {
-                return None;
+                return false;
             }
         }
 
@@ -760,30 +760,30 @@ impl<C: Chip> Process for ProcessStandard<'_, C> {
         // If we find a match, then the driver_num must already be used and the
         // grant allocation fails.
         if exists {
-            return None;
+            return false;
         }
 
         // Use the shared grant allocator function to actually allocate memory.
         // Returns `None` if the allocation cannot be created.
         if let Some(grant_ptr) = self.allocate_in_grant_region_internal(size, align) {
             // Update the grant pointer to the address of the new allocation.
-            self.grant_pointers.map_or(None, |grant_pointers| {
+            self.grant_pointers.map_or(false, |grant_pointers| {
                 // Implement `grant_pointers[grant_num] = grant_ptr` without a
                 // chance of a panic.
                 grant_pointers
                     .get_mut(grant_num)
-                    .map_or(None, |grant_entry| {
+                    .map_or(false, |grant_entry| {
                         // Actually set the driver num and grant pointer.
                         grant_entry.driver_num = driver_num;
                         grant_entry.grant_ptr = grant_ptr.as_ptr() as *mut u8;
 
-                        // If all of this worked, return the allocated pointer.
-                        Some(grant_ptr)
+                        // If all of this worked, return true.
+                        true
                     })
             })
         } else {
             // Could not allocate the memory for the grant region.
-            None
+            false
         }
     }
 
@@ -811,7 +811,7 @@ impl<C: Chip> Process for ProcessStandard<'_, C> {
         }
     }
 
-    fn enter_grant(&self, grant_num: usize) -> Result<*mut u8, Error> {
+    fn enter_grant(&self, grant_num: usize) -> Result<NonNull<u8>, Error> {
         // Do not try to access the grant region of inactive process.
         if !self.is_active() {
             return Err(Error::InactiveApp);
@@ -843,7 +843,7 @@ impl<C: Chip> Process for ProcessStandard<'_, C> {
 
                             // And we return the grant pointer to the entered
                             // grant.
-                            Ok(grant_ptr)
+                            Ok(unsafe { NonNull::new_unchecked(grant_ptr) })
                         }
                     }
                     None => Err(Error::AddressOutOfBounds),


### PR DESCRIPTION
### Pull Request Overview

This pull request is ~~just a single commit that builds on #2958 and should not be reviewed until #2958 is merged~~ is ready for review.

This pull request modifies the grant code and process interface in two ways. First, it modifies `Process::enter_grant()` to return a `NonNull<u8>`, since a null grant pointer should not be possible. Second, it modifies `allocate_grant()` to no longer return a pointer, and instead return a `bool` indicating success or failure. This requires the code which allocates and initializes grants to actually enter the grant before it initializes its contents. This is important because otherwise dropping the `EnterGrantKernelManagedLayout` struct after initializing causes a call to `leave_grant()` for a grant that has not been entered at all, which does not make sense.


### Testing Strategy

This PR works fine, except for a specific app (analog_comparator) when flashed from a Linux host, but I am pretty confident that bug is unrelated to this PR.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
