### PR TITLE
Remove `#![feature(const_mut_refs)]`

### DIFF
--- a/capsules/src/sip_hash.rs
+++ b/capsules/src/sip_hash.rs
@@ -72,7 +72,7 @@ struct State {
 }
 
 impl<'a> SipHasher24<'a> {
-    pub const fn new(deferred_caller: &'static DynamicDeferredCall) -> Self {
+    pub fn new(deferred_caller: &'static DynamicDeferredCall) -> Self {
         let hasher = SipHasher {
             k0: 0,
             k1: 0,
@@ -99,11 +99,7 @@ impl<'a> SipHasher24<'a> {
         }
     }
 
-    pub const fn new_with_keys(
-        deferred_caller: &'static DynamicDeferredCall,
-        k0: u64,
-        k1: u64,
-    ) -> Self {
+    pub fn new_with_keys(deferred_caller: &'static DynamicDeferredCall, k0: u64, k1: u64) -> Self {
         let hasher = SipHasher {
             k0,
             k1,

--- a/capsules/src/virtual_flash.rs
+++ b/capsules/src/virtual_flash.rs
@@ -140,7 +140,7 @@ pub struct FlashUser<'a, F: hil::flash::Flash + 'static> {
 }
 
 impl<'a, F: hil::flash::Flash> FlashUser<'a, F> {
-    pub const fn new(mux: &'a MuxFlash<'a, F>) -> FlashUser<'a, F> {
+    pub fn new(mux: &'a MuxFlash<'a, F>) -> FlashUser<'a, F> {
         FlashUser {
             mux: mux,
             buffer: TakeCell::empty(),

--- a/capsules/src/virtual_i2c.rs
+++ b/capsules/src/virtual_i2c.rs
@@ -219,7 +219,7 @@ pub struct I2CDevice<'a> {
 }
 
 impl<'a> I2CDevice<'a> {
-    pub const fn new(mux: &'a MuxI2C<'a>, addr: u8) -> I2CDevice<'a> {
+    pub fn new(mux: &'a MuxI2C<'a>, addr: u8) -> I2CDevice<'a> {
         I2CDevice {
             mux: mux,
             addr: addr,

--- a/capsules/src/virtual_spi.rs
+++ b/capsules/src/virtual_spi.rs
@@ -41,10 +41,7 @@ impl<Spi: hil::spi::SpiMaster> hil::spi::SpiMasterClient for MuxSpiMaster<'_, Sp
 }
 
 impl<'a, Spi: hil::spi::SpiMaster> MuxSpiMaster<'a, Spi> {
-    pub const fn new(
-        spi: &'a Spi,
-        deferred_caller: &'a DynamicDeferredCall,
-    ) -> MuxSpiMaster<'a, Spi> {
+    pub fn new(spi: &'a Spi, deferred_caller: &'a DynamicDeferredCall) -> MuxSpiMaster<'a, Spi> {
         MuxSpiMaster {
             spi: spi,
             devices: List::new(),
@@ -182,7 +179,7 @@ pub struct VirtualSpiMasterDevice<'a, Spi: hil::spi::SpiMaster> {
 }
 
 impl<'a, Spi: hil::spi::SpiMaster> VirtualSpiMasterDevice<'a, Spi> {
-    pub const fn new(
+    pub fn new(
         mux: &'a MuxSpiMaster<'a, Spi>,
         chip_select: Spi::ChipSelect,
     ) -> VirtualSpiMasterDevice<'a, Spi> {

--- a/capsules/src/virtual_uart.rs
+++ b/capsules/src/virtual_uart.rs
@@ -339,7 +339,7 @@ pub struct UartDevice<'a> {
 }
 
 impl<'a> UartDevice<'a> {
-    pub const fn new(mux: &'a MuxUart<'a>, receiver: bool) -> UartDevice<'a> {
+    pub fn new(mux: &'a MuxUart<'a>, receiver: bool) -> UartDevice<'a> {
         UartDevice {
             state: Cell::new(UartDeviceReceiveState::Idle),
             mux: mux,

--- a/chips/apollo3/src/ble.rs
+++ b/chips/apollo3/src/ble.rs
@@ -268,7 +268,7 @@ pub struct Ble<'a> {
 }
 
 impl<'a> Ble<'a> {
-    pub const fn new() -> Self {
+    pub fn new() -> Self {
         Self {
             registers: BLE_BASE,
             rx_client: OptionalCell::empty(),

--- a/chips/apollo3/src/iom.rs
+++ b/chips/apollo3/src/iom.rs
@@ -275,7 +275,7 @@ pub struct Iom<'a> {
 }
 
 impl<'a> Iom<'_> {
-    pub const fn new0() -> Iom<'a> {
+    pub fn new0() -> Iom<'a> {
         Iom {
             registers: IOM0_BASE,
             master_client: OptionalCell::empty(),
@@ -287,7 +287,7 @@ impl<'a> Iom<'_> {
             smbus: Cell::new(false),
         }
     }
-    pub const fn new1() -> Iom<'a> {
+    pub fn new1() -> Iom<'a> {
         Iom {
             registers: IOM1_BASE,
             master_client: OptionalCell::empty(),
@@ -299,7 +299,7 @@ impl<'a> Iom<'_> {
             smbus: Cell::new(false),
         }
     }
-    pub const fn new2() -> Iom<'a> {
+    pub fn new2() -> Iom<'a> {
         Iom {
             registers: IOM2_BASE,
             master_client: OptionalCell::empty(),
@@ -311,7 +311,7 @@ impl<'a> Iom<'_> {
             smbus: Cell::new(false),
         }
     }
-    pub const fn new3() -> Iom<'a> {
+    pub fn new3() -> Iom<'a> {
         Iom {
             registers: IOM3_BASE,
             master_client: OptionalCell::empty(),
@@ -323,7 +323,7 @@ impl<'a> Iom<'_> {
             smbus: Cell::new(false),
         }
     }
-    pub const fn new4() -> Iom<'a> {
+    pub fn new4() -> Iom<'a> {
         Iom {
             registers: IOM4_BASE,
             master_client: OptionalCell::empty(),
@@ -335,7 +335,7 @@ impl<'a> Iom<'_> {
             smbus: Cell::new(false),
         }
     }
-    pub const fn new5() -> Iom<'a> {
+    pub fn new5() -> Iom<'a> {
         Iom {
             registers: IOM5_BASE,
             master_client: OptionalCell::empty(),

--- a/chips/apollo3/src/uart.rs
+++ b/chips/apollo3/src/uart.rs
@@ -177,7 +177,7 @@ pub struct UartParams {
 
 impl Uart<'_> {
     // unsafe bc of UART0_BASE usage, called twice would alias location
-    pub const fn new_uart_0() -> Self {
+    pub fn new_uart_0() -> Self {
         Self {
             registers: UART0_BASE,
             clock_frequency: 24_000_000,
@@ -190,7 +190,7 @@ impl Uart<'_> {
     }
 
     // unsafe bc of UART0_BASE usage, called twice would alias location
-    pub const fn new_uart_1() -> Self {
+    pub fn new_uart_1() -> Self {
         Self {
             registers: UART1_BASE,
             clock_frequency: 24_000_000,

--- a/chips/earlgrey/src/aes.rs
+++ b/chips/earlgrey/src/aes.rs
@@ -128,7 +128,7 @@ pub struct Aes<'a> {
 }
 
 impl<'a> Aes<'a> {
-    pub const fn new(deferred_caller: &'static DynamicDeferredCall) -> Aes<'a> {
+    pub fn new(deferred_caller: &'static DynamicDeferredCall) -> Aes<'a> {
         Aes {
             registers: AES_BASE,
             client: OptionalCell::empty(),

--- a/chips/esp32/src/uart.rs
+++ b/chips/esp32/src/uart.rs
@@ -221,7 +221,7 @@ pub struct UartParams {
 }
 
 impl<'a> Uart<'a> {
-    pub const fn new(base: StaticRef<UartRegisters>) -> Uart<'a> {
+    pub fn new(base: StaticRef<UartRegisters>) -> Uart<'a> {
         Uart {
             registers: base,
             tx_client: OptionalCell::empty(),

--- a/chips/imxrt10xx/src/chip.rs
+++ b/chips/imxrt10xx/src/chip.rs
@@ -39,7 +39,7 @@ pub struct Imxrt10xxDefaultPeripherals {
 }
 
 impl Imxrt10xxDefaultPeripherals {
-    pub const fn new(ccm: &'static crate::ccm::Ccm) -> Self {
+    pub fn new(ccm: &'static crate::ccm::Ccm) -> Self {
         Self {
             iomuxc: crate::iomuxc::Iomuxc::new(),
             iomuxc_snvs: crate::iomuxc_snvs::IomuxcSnvs::new(),

--- a/chips/imxrt10xx/src/lpi2c.rs
+++ b/chips/imxrt10xx/src/lpi2c.rs
@@ -463,13 +463,13 @@ enum Lpi2cStatus {
 }
 
 impl<'a> Lpi2c<'a> {
-    pub const fn new_lpi2c1(ccm: &'a ccm::Ccm) -> Self {
+    pub fn new_lpi2c1(ccm: &'a ccm::Ccm) -> Self {
         Lpi2c::new(
             LPI2C1_BASE,
             Lpi2cClock(ccm::PeripheralClock::ccgr2(ccm, ccm::HCLK2::LPI2C1)),
         )
     }
-    const fn new(base_addr: StaticRef<Lpi2cRegisters>, clock: Lpi2cClock<'a>) -> Self {
+    fn new(base_addr: StaticRef<Lpi2cRegisters>, clock: Lpi2cClock<'a>) -> Self {
         Self {
             registers: base_addr,
             clock,

--- a/chips/imxrt10xx/src/lpuart.rs
+++ b/chips/imxrt10xx/src/lpuart.rs
@@ -339,7 +339,7 @@ pub struct Lpuart<'a> {
 }
 
 impl<'a> Lpuart<'a> {
-    pub const fn new_lpuart1(ccm: &'a ccm::Ccm) -> Self {
+    pub fn new_lpuart1(ccm: &'a ccm::Ccm) -> Self {
         Lpuart::new(
             LPUART1_BASE,
             LpuartClock(ccm::PeripheralClock::ccgr5(ccm, ccm::HCLK5::LPUART1)),
@@ -348,7 +348,7 @@ impl<'a> Lpuart<'a> {
         )
     }
 
-    pub const fn new_lpuart2(ccm: &'a ccm::Ccm) -> Self {
+    pub fn new_lpuart2(ccm: &'a ccm::Ccm) -> Self {
         Lpuart::new(
             LPUART2_BASE,
             LpuartClock(ccm::PeripheralClock::ccgr0(ccm, ccm::HCLK0::LPUART2)),
@@ -357,7 +357,7 @@ impl<'a> Lpuart<'a> {
         )
     }
 
-    const fn new(
+    fn new(
         base_addr: StaticRef<LpuartRegisters>,
         clock: LpuartClock<'a>,
         tx_dma_source: dma::DmaHardwareSource,

--- a/chips/litex/src/uart.rs
+++ b/chips/litex/src/uart.rs
@@ -104,7 +104,7 @@ pub struct LiteXUart<'a, R: LiteXSoCRegisterConfiguration> {
 }
 
 impl<'a, R: LiteXSoCRegisterConfiguration> LiteXUart<'a, R> {
-    pub const fn new(
+    pub fn new(
         uart_base: StaticRef<LiteXUartRegisters<R>>,
         phy_args: Option<(StaticRef<LiteXUartPhyRegisters<R>>, u32)>,
         deferred_caller: &'static DynamicDeferredCall,

--- a/chips/lowrisc/src/flash_ctrl.rs
+++ b/chips/lowrisc/src/flash_ctrl.rs
@@ -251,7 +251,7 @@ pub struct FlashCtrl<'a> {
 }
 
 impl<'a> FlashCtrl<'a> {
-    pub const fn new(base: StaticRef<FlashCtrlRegisters>, region_num: FlashRegion) -> Self {
+    pub fn new(base: StaticRef<FlashCtrlRegisters>, region_num: FlashRegion) -> Self {
         FlashCtrl {
             registers: base,
             flash_client: OptionalCell::empty(),

--- a/chips/lowrisc/src/hmac.rs
+++ b/chips/lowrisc/src/hmac.rs
@@ -82,7 +82,7 @@ pub struct Hmac<'a> {
 }
 
 impl Hmac<'_> {
-    pub const fn new(base: StaticRef<HmacRegisters>) -> Self {
+    pub fn new(base: StaticRef<HmacRegisters>) -> Self {
         Hmac {
             registers: base,
             client: OptionalCell::empty(),

--- a/chips/lowrisc/src/i2c.rs
+++ b/chips/lowrisc/src/i2c.rs
@@ -145,7 +145,7 @@ pub struct I2c<'a> {
 }
 
 impl<'a> I2c<'_> {
-    pub const fn new(base: StaticRef<I2cRegisters>, clock_period_nanos: u32) -> I2c<'a> {
+    pub fn new(base: StaticRef<I2cRegisters>, clock_period_nanos: u32) -> I2c<'a> {
         I2c {
             registers: base,
             clock_period_nanos,

--- a/chips/lowrisc/src/lib.rs
+++ b/chips/lowrisc/src/lib.rs
@@ -1,7 +1,5 @@
 //! Implementations for generic LowRISC peripherals.
 
-// Feature required with newer versions of rustc (at least 2020-10-25).
-#![feature(const_mut_refs)]
 #![no_std]
 #![crate_name = "lowrisc"]
 #![crate_type = "rlib"]

--- a/chips/lowrisc/src/otbn.rs
+++ b/chips/lowrisc/src/otbn.rs
@@ -100,7 +100,7 @@ pub struct Otbn<'a> {
 }
 
 impl<'a> Otbn<'a> {
-    pub const fn new(base: StaticRef<OtbnRegisters>) -> Self {
+    pub fn new(base: StaticRef<OtbnRegisters>) -> Self {
         Otbn {
             registers: base,
             client: OptionalCell::empty(),

--- a/chips/lowrisc/src/spi_host.rs
+++ b/chips/lowrisc/src/spi_host.rs
@@ -149,7 +149,7 @@ const SPI_HOST_CMD_BIDIRECTIONAL: u32 = 3;
 const SPI_HOST_CMD_STANDARD_SPI: u32 = 0;
 
 impl SpiHost {
-    pub const fn new(base: StaticRef<SpiHostRegisters>, cpu_clk: u32) -> Self {
+    pub fn new(base: StaticRef<SpiHostRegisters>, cpu_clk: u32) -> Self {
         SpiHost {
             registers: base,
             client: OptionalCell::empty(),

--- a/chips/lowrisc/src/uart.rs
+++ b/chips/lowrisc/src/uart.rs
@@ -120,7 +120,7 @@ pub struct UartParams {
 }
 
 impl<'a> Uart<'a> {
-    pub const fn new(base: StaticRef<UartRegisters>, clock_frequency: u32) -> Uart<'a> {
+    pub fn new(base: StaticRef<UartRegisters>, clock_frequency: u32) -> Uart<'a> {
         Uart {
             registers: base,
             clock_frequency: clock_frequency,

--- a/chips/msp432/src/adc.rs
+++ b/chips/msp432/src/adc.rs
@@ -507,7 +507,7 @@ pub struct Adc<'a> {
 }
 
 impl Adc<'_> {
-    pub const fn new() -> Self {
+    pub fn new() -> Self {
         Self {
             registers: ADC_BASE,
             resolution: DEFAULT_ADC_RESOLUTION,

--- a/chips/msp432/src/dma.rs
+++ b/chips/msp432/src/dma.rs
@@ -654,7 +654,7 @@ impl DmaConfig {
 }
 
 impl<'a> DmaChannel<'a> {
-    pub const fn new(chan_nr: usize) -> DmaChannel<'a> {
+    pub fn new(chan_nr: usize) -> DmaChannel<'a> {
         DmaChannel {
             registers: DMA_BASE,
             chan_nr: chan_nr,

--- a/chips/msp432/src/i2c.rs
+++ b/chips/msp432/src/i2c.rs
@@ -33,7 +33,7 @@ pub struct I2c<'a> {
 }
 
 impl<'a> I2c<'a> {
-    pub const fn new(registers: StaticRef<UsciBRegisters>) -> Self {
+    pub fn new(registers: StaticRef<UsciBRegisters>) -> Self {
         Self {
             registers: registers,
             mode: Cell::new(OperatingMode::Unconfigured),

--- a/chips/nrf52/src/ble_radio.rs
+++ b/chips/nrf52/src/ble_radio.rs
@@ -539,7 +539,7 @@ pub struct Radio<'a> {
 }
 
 impl<'a> Radio<'a> {
-    pub const fn new() -> Radio<'a> {
+    pub fn new() -> Radio<'a> {
         Radio {
             registers: RADIO_BASE,
             tx_power: Cell::new(TxPower::ZerodBm),

--- a/chips/nrf52/src/i2c.rs
+++ b/chips/nrf52/src/i2c.rs
@@ -41,7 +41,7 @@ pub enum Speed {
 }
 
 impl TWI {
-    const fn new(registers: StaticRef<TwiRegisters>) -> Self {
+    fn new(registers: StaticRef<TwiRegisters>) -> Self {
         Self {
             registers,
             client: OptionalCell::empty(),
@@ -51,11 +51,11 @@ impl TWI {
         }
     }
 
-    pub const fn new_twi0() -> Self {
+    pub fn new_twi0() -> Self {
         TWI::new(INSTANCES[0])
     }
 
-    pub const fn new_twi1() -> Self {
+    pub fn new_twi1() -> Self {
         TWI::new(INSTANCES[1])
     }
 

--- a/chips/nrf52/src/ieee802154_radio.rs
+++ b/chips/nrf52/src/ieee802154_radio.rs
@@ -683,7 +683,7 @@ impl<'a> AlarmClient for Radio<'a> {
 }
 
 impl<'p> Radio<'p> {
-    pub const fn new() -> Self {
+    pub fn new() -> Self {
         Self {
             registers: RADIO_BASE,
             tx_power: Cell::new(TxPower::ZerodBm),

--- a/chips/nrf52/src/nvmc.rs
+++ b/chips/nrf52/src/nvmc.rs
@@ -209,7 +209,7 @@ pub struct Nvmc {
 }
 
 impl Nvmc {
-    pub const fn new() -> Nvmc {
+    pub fn new() -> Nvmc {
         Nvmc {
             registers: NVMC_BASE,
             client: OptionalCell::empty(),

--- a/chips/nrf52/src/spi.rs
+++ b/chips/nrf52/src/spi.rs
@@ -245,7 +245,7 @@ pub struct SPIM {
 }
 
 impl SPIM {
-    pub const fn new(instance: usize) -> SPIM {
+    pub fn new(instance: usize) -> SPIM {
         SPIM {
             registers: INSTANCES[instance],
             client: OptionalCell::empty(),

--- a/chips/nrf52/src/uart.rs
+++ b/chips/nrf52/src/uart.rs
@@ -180,7 +180,7 @@ pub struct UARTParams {
 impl<'a> Uarte<'a> {
     /// Constructor
     // This should only be constructed once
-    pub const fn new() -> Uarte<'a> {
+    pub fn new() -> Uarte<'a> {
         Uarte {
             registers: UARTE_BASE,
             tx_client: OptionalCell::empty(),

--- a/chips/nrf5x/src/aes.rs
+++ b/chips/nrf5x/src/aes.rs
@@ -134,7 +134,7 @@ pub struct AesECB<'a> {
 }
 
 impl<'a> AesECB<'a> {
-    pub const fn new() -> AesECB<'a> {
+    pub fn new() -> AesECB<'a> {
         AesECB {
             registers: AESECB_BASE,
             client: OptionalCell::empty(),

--- a/chips/rp2040/src/chip.rs
+++ b/chips/rp2040/src/chip.rs
@@ -128,7 +128,7 @@ pub struct Rp2040DefaultPeripherals<'a> {
 }
 
 impl<'a> Rp2040DefaultPeripherals<'a> {
-    pub const fn new() -> Self {
+    pub fn new() -> Self {
         Self {
             resets: Resets::new(),
             sio: SIO::new(),

--- a/chips/rp2040/src/i2c.rs
+++ b/chips/rp2040/src/i2c.rs
@@ -256,7 +256,7 @@ pub struct I2c<'a> {
 }
 
 impl<'a> I2c<'a> {
-    const fn new(instance_num: u8) -> Self {
+    fn new(instance_num: u8) -> Self {
         Self {
             instance_num,
             registers: INSTANCES[instance_num as usize],
@@ -276,11 +276,11 @@ impl<'a> I2c<'a> {
         }
     }
 
-    pub const fn new_i2c0() -> Self {
+    pub fn new_i2c0() -> Self {
         I2c::new(0)
     }
 
-    pub const fn new_i2c1() -> Self {
+    pub fn new_i2c1() -> Self {
         I2c::new(1)
     }
 

--- a/chips/rp2040/src/spi.rs
+++ b/chips/rp2040/src/spi.rs
@@ -248,7 +248,7 @@ pub struct Spi<'a> {
 }
 
 impl<'a> Spi<'a> {
-    pub const fn new_spi0() -> Self {
+    pub fn new_spi0() -> Self {
         Self {
             registers: SPI0_BASE,
             clocks: OptionalCell::empty(),
@@ -268,7 +268,7 @@ impl<'a> Spi<'a> {
         }
     }
 
-    pub const fn new_spi1() -> Self {
+    pub fn new_spi1() -> Self {
         Self {
             registers: SPI1_BASE,
             clocks: OptionalCell::empty(),

--- a/chips/rp2040/src/uart.rs
+++ b/chips/rp2040/src/uart.rs
@@ -392,7 +392,7 @@ pub struct Uart<'a> {
 }
 
 impl<'a> Uart<'a> {
-    pub const fn new_uart0() -> Self {
+    pub fn new_uart0() -> Self {
         Self {
             registers: UART0_BASE,
             clocks: OptionalCell::empty(),
@@ -411,7 +411,7 @@ impl<'a> Uart<'a> {
             rx_status: Cell::new(UARTStateRX::Idle),
         }
     }
-    pub const fn new_uart1() -> Self {
+    pub fn new_uart1() -> Self {
         Self {
             registers: UART1_BASE,
             clocks: OptionalCell::empty(),

--- a/chips/sam4l/src/adc.rs
+++ b/chips/sam4l/src/adc.rs
@@ -326,7 +326,7 @@ impl Adc {
     /// Create a new ADC driver.
     ///
     /// - `rx_dma_peripheral`: type used for DMA transactions
-    pub const fn new(rx_dma_peripheral: dma::DMAPeripheral, pm: &'static pm::PowerManager) -> Adc {
+    pub fn new(rx_dma_peripheral: dma::DMAPeripheral, pm: &'static pm::PowerManager) -> Adc {
         Adc {
             // pointer to memory mapped I/O registers
             registers: BASE_ADDRESS,

--- a/chips/sam4l/src/aes.rs
+++ b/chips/sam4l/src/aes.rs
@@ -162,7 +162,7 @@ pub struct Aes<'a> {
 }
 
 impl<'a> Aes<'a> {
-    pub const fn new() -> Aes<'a> {
+    pub fn new() -> Aes<'a> {
         Aes {
             registers: AES_BASE,
             client: OptionalCell::empty(),

--- a/chips/sam4l/src/dma.rs
+++ b/chips/sam4l/src/dma.rs
@@ -188,7 +188,7 @@ pub trait DMAClient {
 }
 
 impl DMAChannel {
-    pub const fn new(channel: DMAChannelNum) -> DMAChannel {
+    pub fn new(channel: DMAChannelNum) -> DMAChannel {
         DMAChannel {
             registers: unsafe {
                 StaticRef::new(

--- a/chips/sam4l/src/flashcalw.rs
+++ b/chips/sam4l/src/flashcalw.rs
@@ -435,11 +435,7 @@ const FREQ_PS1_FWS_0_MAX_FREQ: u32 = 8000000;
 const FREQ_PS2_FWS_0_MAX_FREQ: u32 = 24000000;
 
 impl FLASHCALW {
-    pub const fn new(
-        ahb_clk: pm::HSBClock,
-        hramc1_clk: pm::HSBClock,
-        pb_clk: pm::PBBClock,
-    ) -> FLASHCALW {
+    pub fn new(ahb_clk: pm::HSBClock, hramc1_clk: pm::HSBClock, pb_clk: pm::PBBClock) -> FLASHCALW {
         FLASHCALW {
             registers: FLASHCALW_ADDRESS,
             ahb_clock: pm::Clock::HSB(ahb_clk),

--- a/chips/sam4l/src/i2c.rs
+++ b/chips/sam4l/src/i2c.rs
@@ -630,7 +630,7 @@ const fn create_twims_clocks(
 // Need to implement the `new` function on the I2C device as a constructor.
 // This gets called from the device tree.
 impl I2CHw {
-    const fn new(
+    fn new(
         base_addr: StaticRef<TWIMRegisters>,
         slave_base_addr: Option<StaticRef<TWISRegisters>>,
         clocks: (TWIMClock, TWISClock),
@@ -661,7 +661,7 @@ impl I2CHw {
         }
     }
 
-    pub const fn new_i2c0(pm: &'static pm::PowerManager) -> Self {
+    pub fn new_i2c0(pm: &'static pm::PowerManager) -> Self {
         I2CHw::new(
             I2C_BASE_ADDRS[0],
             Some(I2C_SLAVE_BASE_ADDRS[0]),
@@ -675,7 +675,7 @@ impl I2CHw {
         )
     }
 
-    pub const fn new_i2c1(pm: &'static pm::PowerManager) -> Self {
+    pub fn new_i2c1(pm: &'static pm::PowerManager) -> Self {
         I2CHw::new(
             I2C_BASE_ADDRS[1],
             Some(I2C_SLAVE_BASE_ADDRS[1]),
@@ -689,7 +689,7 @@ impl I2CHw {
         )
     }
 
-    pub const fn new_i2c2(pm: &'static pm::PowerManager) -> Self {
+    pub fn new_i2c2(pm: &'static pm::PowerManager) -> Self {
         I2CHw::new(
             I2C_BASE_ADDRS[2],
             None,
@@ -700,7 +700,7 @@ impl I2CHw {
         )
     }
 
-    pub const fn new_i2c3(pm: &'static pm::PowerManager) -> Self {
+    pub fn new_i2c3(pm: &'static pm::PowerManager) -> Self {
         I2CHw::new(
             I2C_BASE_ADDRS[3],
             None,

--- a/chips/sifive/src/uart.rs
+++ b/chips/sifive/src/uart.rs
@@ -76,7 +76,7 @@ pub struct UartParams {
 }
 
 impl<'a> Uart<'a> {
-    pub const fn new(base: StaticRef<UartRegisters>, clock_frequency: u32) -> Uart<'a> {
+    pub fn new(base: StaticRef<UartRegisters>, clock_frequency: u32) -> Uart<'a> {
         Uart {
             registers: base,
             clock_frequency: clock_frequency,

--- a/chips/stm32f303xc/src/flash.rs
+++ b/chips/stm32f303xc/src/flash.rs
@@ -291,7 +291,7 @@ pub struct Flash {
 }
 
 impl Flash {
-    pub const fn new() -> Flash {
+    pub fn new() -> Flash {
         Flash {
             registers: FLASH_BASE,
             client: OptionalCell::empty(),

--- a/chips/stm32f303xc/src/i2c.rs
+++ b/chips/stm32f303xc/src/i2c.rs
@@ -258,7 +258,7 @@ enum I2CStatus {
 }
 
 impl<'a> I2C<'a> {
-    const fn new(base_addr: StaticRef<I2CRegisters>, clock: I2CClock<'a>) -> Self {
+    fn new(base_addr: StaticRef<I2CRegisters>, clock: I2CClock<'a>) -> Self {
         Self {
             registers: base_addr,
             clock,
@@ -278,7 +278,7 @@ impl<'a> I2C<'a> {
         }
     }
 
-    pub const fn new_i2c1(rcc: &'a rcc::Rcc) -> Self {
+    pub fn new_i2c1(rcc: &'a rcc::Rcc) -> Self {
         Self::new(
             I2C1_BASE,
             I2CClock(rcc::PeripheralClock::new(

--- a/chips/stm32f303xc/src/spi.rs
+++ b/chips/stm32f303xc/src/spi.rs
@@ -203,7 +203,7 @@ pub struct Spi<'a> {
 }
 
 impl<'a> Spi<'a> {
-    const fn new(base_addr: StaticRef<SpiRegisters>, clock: SpiClock<'a>) -> Self {
+    fn new(base_addr: StaticRef<SpiRegisters>, clock: SpiClock<'a>) -> Self {
         Self {
             registers: base_addr,
             clock,
@@ -225,7 +225,7 @@ impl<'a> Spi<'a> {
         }
     }
 
-    pub const fn new_spi1(rcc: &'a rcc::Rcc) -> Self {
+    pub fn new_spi1(rcc: &'a rcc::Rcc) -> Self {
         Self::new(
             SPI1_BASE,
             SpiClock(rcc::PeripheralClock::new(

--- a/chips/stm32f303xc/src/usart.rs
+++ b/chips/stm32f303xc/src/usart.rs
@@ -308,7 +308,7 @@ pub struct Usart<'a> {
 }
 
 impl<'a> Usart<'a> {
-    const fn new(base_addr: StaticRef<UsartRegisters>, clock: UsartClock<'a>) -> Self {
+    fn new(base_addr: StaticRef<UsartRegisters>, clock: UsartClock<'a>) -> Self {
         Self {
             registers: base_addr,
             clock: clock,
@@ -328,7 +328,7 @@ impl<'a> Usart<'a> {
         }
     }
 
-    pub const fn new_usart1(rcc: &'a rcc::Rcc) -> Self {
+    pub fn new_usart1(rcc: &'a rcc::Rcc) -> Self {
         Self::new(
             USART1_BASE,
             UsartClock(rcc::PeripheralClock::new(
@@ -338,7 +338,7 @@ impl<'a> Usart<'a> {
         )
     }
 
-    pub const fn new_usart2(rcc: &'a rcc::Rcc) -> Self {
+    pub fn new_usart2(rcc: &'a rcc::Rcc) -> Self {
         Self::new(
             USART2_BASE,
             UsartClock(rcc::PeripheralClock::new(
@@ -348,7 +348,7 @@ impl<'a> Usart<'a> {
         )
     }
 
-    pub const fn new_usart3(rcc: &'a rcc::Rcc) -> Self {
+    pub fn new_usart3(rcc: &'a rcc::Rcc) -> Self {
         Self::new(
             USART3_BASE,
             UsartClock(rcc::PeripheralClock::new(

--- a/chips/stm32f4xx/src/dma.rs
+++ b/chips/stm32f4xx/src/dma.rs
@@ -784,7 +784,7 @@ pub struct Stream<'a, DMA: StreamServer<'a>> {
 }
 
 impl<'a, DMA: StreamServer<'a>> Stream<'a, DMA> {
-    const fn new(streamid: StreamId, dma: &'a DMA) -> Self {
+    fn new(streamid: StreamId, dma: &'a DMA) -> Self {
         Self {
             streamid: streamid,
             buffer: TakeCell::empty(),

--- a/chips/stm32f4xx/src/fsmc.rs
+++ b/chips/stm32f4xx/src/fsmc.rs
@@ -173,7 +173,7 @@ pub struct Fsmc<'a> {
 }
 
 impl<'a> Fsmc<'a> {
-    pub const fn new(bank_addr: [Option<StaticRef<FsmcBank>>; 4], rcc: &'a rcc::Rcc) -> Self {
+    pub fn new(bank_addr: [Option<StaticRef<FsmcBank>>; 4], rcc: &'a rcc::Rcc) -> Self {
         Self {
             registers: FSMC_BASE,
             bank: bank_addr,

--- a/chips/stm32f4xx/src/i2c.rs
+++ b/chips/stm32f4xx/src/i2c.rs
@@ -206,7 +206,7 @@ enum I2CStatus {
 }
 
 impl<'a> I2C<'a> {
-    pub const fn new(rcc: &'a rcc::Rcc) -> Self {
+    pub fn new(rcc: &'a rcc::Rcc) -> Self {
         Self {
             registers: I2C1_BASE,
             clock: I2CClock(rcc::PeripheralClock::new(

--- a/chips/swervolf-eh1/src/uart.rs
+++ b/chips/swervolf-eh1/src/uart.rs
@@ -47,7 +47,7 @@ pub struct Uart<'a> {
 }
 
 impl<'a> Uart<'a> {
-    pub const fn new(base: StaticRef<UartRegisters>) -> Uart<'a> {
+    pub fn new(base: StaticRef<UartRegisters>) -> Uart<'a> {
         Uart {
             registers: base,
             tx_client: OptionalCell::empty(),

--- a/libraries/tock-cells/src/lib.rs
+++ b/libraries/tock-cells/src/lib.rs
@@ -1,7 +1,5 @@
 //! Tock Cell types.
 
-// Feature required with newer versions of rustc (at least 2020-10-25).
-#![feature(const_mut_refs)]
 #![no_std]
 
 pub mod map_cell;

--- a/libraries/tock-cells/src/take_cell.rs
+++ b/libraries/tock-cells/src/take_cell.rs
@@ -16,7 +16,7 @@ pub struct TakeCell<'a, T: 'a + ?Sized> {
 }
 
 impl<'a, T: ?Sized> TakeCell<'a, T> {
-    pub const fn empty() -> TakeCell<'a, T> {
+    pub fn empty() -> TakeCell<'a, T> {
         TakeCell {
             val: Cell::new(None),
         }


### PR DESCRIPTION
### Pull Request Overview

This PR removes the `const_mut_refs` unstable feature and all uses of it. For the most part, this just required making every const constructor that created a `TakeCell` no longer const, as a result of `TakeCell::empty()` no longer being const. Thanks to the updated peripheral instantation approach in https://github.com/tock/tock/pull/2069 and related PRs, this was very straightforward to perform, as peripherals no longer need to be created in const context.

### Testing Strategy

This pull request was tested by compiling, no functional changes are included.


### TODO or Help Wanted

N/A

### Documentation Updated

- [x] I will update https://github.com/tock/tock/issues/1654 if/when this is merged.

### Formatting

- [x] Ran `make prepush`.
