### PR TITLE
Remove one use of `asm_const`

### DIFF
--- a/chips/litex_vexriscv/src/interrupt_controller.rs
+++ b/chips/litex_vexriscv/src/interrupt_controller.rs
@@ -108,7 +108,9 @@ mod vexriscv_irq_raw {
     pub unsafe fn irq_getmask() -> usize {
         let mask: usize;
         use core::arch::asm;
-        asm!("csrr {mask}, {csr}", mask = out(reg) mask, csr = const CSR_IRQ_MASK);
+        // TODO: If asm_const is stabilized, transition back to below
+        //asm!("csrr {mask}, {csr}", mask = out(reg) mask, csr = const CSR_IRQ_MASK);
+        asm!("csrr {mask}, 0xBC0", mask = out(reg) mask);
         mask
     }
 
@@ -118,7 +120,9 @@ mod vexriscv_irq_raw {
     #[cfg(all(target_arch = "riscv32", target_os = "none"))]
     pub unsafe fn irq_setmask(mask: usize) {
         use core::arch::asm;
-        asm!("csrw {csr}, {mask}", csr = const CSR_IRQ_MASK, mask = in(reg) mask);
+        // TODO: If asm_const is stabilized, transition back to below
+        //asm!("csrw {csr}, {mask}", csr = const CSR_IRQ_MASK, mask = in(reg) mask);
+        asm!("csrw 0xBC0, {mask}", mask = in(reg) mask);
     }
 
     #[cfg(not(any(target_arch = "riscv32", target_os = "none")))]
@@ -130,7 +134,9 @@ mod vexriscv_irq_raw {
     pub unsafe fn irq_pending() -> usize {
         let pending: usize;
         use core::arch::asm;
-        asm!("csrr {pending}, {csr}", pending = out(reg) pending, csr = const CSR_IRQ_PENDING);
+        // TODO: If asm_const is stabilized, transition back to below
+        //asm!("csrr {pending}, {csr}", pending = out(reg) pending, csr = const CSR_IRQ_PENDING);
+        asm!("csrr {pending}, 0xFC0", pending = out(reg) pending);
         pending
     }
 }

--- a/chips/litex_vexriscv/src/lib.rs
+++ b/chips/litex_vexriscv/src/lib.rs
@@ -1,6 +1,5 @@
 //! LiteX SoCs based around a VexRiscv CPU
 
-#![feature(asm_const)]
 #![no_std]
 #![crate_name = "litex_vexriscv"]
 #![crate_type = "rlib"]


### PR DESCRIPTION
### Pull Request Overview

This pull request removes one of our two remaining uses of `#![feature(asm_const)]`, at the low cost of a little readability. Our one remaining use is in `riscv_csr`. Removing that use is more complex, and would require going back to either the switch statement approach to CSRs (e.g. before https://github.com/tock/tock/pull/2472/files), or revisiting the macro-based approach that Alistair suggested (https://github.com/tock/tock/pull/2470/files).


### Testing Strategy

This pull request was tested by compiling.


### TODO or Help Wanted

N/A

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
