### PR TITLE
RFC: Restructure `DeferredCall` to not require atomics

### DIFF
--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -13,6 +13,7 @@ use capsules::virtual_alarm::VirtualMuxAlarm;
 
 use kernel::capabilities;
 use kernel::component::Component;
+use kernel::deferred_call::DeferredCallManager;
 use kernel::dynamic_deferred_call::{DynamicDeferredCall, DynamicDeferredCallClientState};
 use kernel::hil::gpio::Interrupt;
 use kernel::hil::i2c::I2CMaster;
@@ -28,6 +29,7 @@ use kernel::scheduler::round_robin::RoundRobinSched;
 #[allow(unused_imports)]
 use kernel::{create_capability, debug, debug_gpio, debug_verbose, static_init};
 
+use nrf52::deferred_call_tasks::DeferredCallTask;
 use nrf52840::gpio::Pin;
 use nrf52840::interrupt_service::Nrf52840DefaultPeripherals;
 
@@ -236,10 +238,14 @@ impl KernelResources<nrf52::chip::NRF52<'static, Nrf52840DefaultPeripherals<'sta
 /// these static_inits is wasted.
 #[inline(never)]
 unsafe fn get_peripherals() -> &'static mut Nrf52840DefaultPeripherals<'static> {
+    let dc_mgr = static_init!(
+        DeferredCallManager<DeferredCallTask>,
+        DeferredCallManager::new()
+    );
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
-        Nrf52840DefaultPeripherals::new()
+        Nrf52840DefaultPeripherals::new(dc_mgr)
     );
 
     nrf52840_peripherals

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -14,6 +14,7 @@ use capsules::virtual_i2c::{I2CDevice, MuxI2C};
 use capsules::virtual_spi::VirtualSpiMasterDevice;
 use kernel::capabilities;
 use kernel::component::Component;
+use kernel::deferred_call::DeferredCallManager;
 use kernel::dynamic_deferred_call::{DynamicDeferredCall, DynamicDeferredCallClientState};
 use kernel::hil;
 use kernel::hil::i2c::I2CMaster;
@@ -25,6 +26,7 @@ use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::{create_capability, debug, debug_gpio, static_init};
 use sam4l::adc::Channel;
 use sam4l::chip::Sam4lDefaultPeripherals;
+use sam4l::deferred_call_tasks::Task;
 
 /// Support routines for debugging I/O.
 ///
@@ -216,7 +218,11 @@ unsafe fn set_pin_primary_functions(peripherals: &Sam4lDefaultPeripherals) {
 unsafe fn get_peripherals(
     pm: &'static sam4l::pm::PowerManager,
 ) -> &'static Sam4lDefaultPeripherals {
-    static_init!(Sam4lDefaultPeripherals, Sam4lDefaultPeripherals::new(pm))
+    let dc_mgr = static_init!(DeferredCallManager<Task>, DeferredCallManager::new());
+    static_init!(
+        Sam4lDefaultPeripherals,
+        Sam4lDefaultPeripherals::new(pm, dc_mgr)
+    )
 }
 
 /// Board's main function.

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -20,6 +20,7 @@ use capsules::virtual_spi::VirtualSpiMasterDevice;
 //use capsules::virtual_timer::MuxTimer;
 use kernel::capabilities;
 use kernel::component::Component;
+use kernel::deferred_call::DeferredCallManager;
 use kernel::dynamic_deferred_call::{DynamicDeferredCall, DynamicDeferredCallClientState};
 use kernel::hil::i2c::I2CMaster;
 use kernel::hil::radio;
@@ -297,7 +298,14 @@ unsafe fn set_pin_primary_functions(peripherals: &Sam4lDefaultPeripherals) {
 unsafe fn get_peripherals(
     pm: &'static sam4l::pm::PowerManager,
 ) -> &'static Sam4lDefaultPeripherals {
-    static_init!(Sam4lDefaultPeripherals, Sam4lDefaultPeripherals::new(pm))
+    let dc_mgr = static_init!(
+        DeferredCallManager<sam4l::deferred_call_tasks::Task>,
+        DeferredCallManager::new()
+    );
+    static_init!(
+        Sam4lDefaultPeripherals,
+        Sam4lDefaultPeripherals::new(pm, dc_mgr)
+    )
 }
 
 /// Main function.

--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -12,6 +12,7 @@
 use capsules::virtual_aes_ccm::MuxAES128CCM;
 use capsules::virtual_alarm::VirtualMuxAlarm;
 use kernel::component::Component;
+use kernel::deferred_call::DeferredCallManager;
 use kernel::dynamic_deferred_call::{DynamicDeferredCall, DynamicDeferredCallClientState};
 use kernel::hil::led::LedLow;
 use kernel::hil::symmetric_encryption::AES128;
@@ -20,6 +21,7 @@ use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::scheduler::round_robin::RoundRobinSched;
 #[allow(unused_imports)]
 use kernel::{capabilities, create_capability, debug, debug_gpio, debug_verbose, static_init};
+use nrf52840::deferred_call_tasks::DeferredCallTask;
 use nrf52840::gpio::Pin;
 use nrf52840::interrupt_service::Nrf52840DefaultPeripherals;
 use nrf52_components::{self, UartChannel, UartPins};
@@ -168,10 +170,14 @@ impl KernelResources<nrf52840::chip::NRF52<'static, Nrf52840DefaultPeripherals<'
 /// these static_inits is wasted.
 #[inline(never)]
 unsafe fn get_peripherals() -> &'static mut Nrf52840DefaultPeripherals<'static> {
+    let dc_mgr = static_init!(
+        DeferredCallManager<DeferredCallTask>,
+        DeferredCallManager::new()
+    );
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
-        Nrf52840DefaultPeripherals::new()
+        Nrf52840DefaultPeripherals::new(dc_mgr)
     );
 
     nrf52840_peripherals

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -75,6 +75,7 @@ use capsules::net::ipv6::ip_utils::IPAddr;
 use capsules::virtual_aes_ccm::MuxAES128CCM;
 use capsules::virtual_alarm::VirtualMuxAlarm;
 use kernel::component::Component;
+use kernel::deferred_call::DeferredCallManager;
 use kernel::dynamic_deferred_call::{DynamicDeferredCall, DynamicDeferredCallClientState};
 use kernel::hil::i2c::{I2CMaster, I2CSlave};
 use kernel::hil::led::LedLow;
@@ -86,6 +87,7 @@ use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::scheduler::round_robin::RoundRobinSched;
 #[allow(unused_imports)]
 use kernel::{capabilities, create_capability, debug, debug_gpio, debug_verbose, static_init};
+use nrf52840::deferred_call_tasks::DeferredCallTask;
 use nrf52840::gpio::Pin;
 use nrf52840::interrupt_service::Nrf52840DefaultPeripherals;
 use nrf52_components::{self, UartChannel, UartPins};
@@ -228,10 +230,14 @@ impl SyscallDriverLookup for Platform {
 /// these static_inits is wasted.
 #[inline(never)]
 unsafe fn get_peripherals() -> &'static mut Nrf52840DefaultPeripherals<'static> {
+    let dc_mgr = static_init!(
+        DeferredCallManager<DeferredCallTask>,
+        DeferredCallManager::new()
+    );
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
-        Nrf52840DefaultPeripherals::new()
+        Nrf52840DefaultPeripherals::new(dc_mgr)
     );
 
     nrf52840_peripherals

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -68,6 +68,7 @@
 
 use capsules::virtual_alarm::VirtualMuxAlarm;
 use kernel::component::Component;
+use kernel::deferred_call::DeferredCallManager;
 use kernel::dynamic_deferred_call::{DynamicDeferredCall, DynamicDeferredCallClientState};
 use kernel::hil::led::LedLow;
 use kernel::hil::time::Counter;
@@ -75,6 +76,7 @@ use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::scheduler::round_robin::RoundRobinSched;
 #[allow(unused_imports)]
 use kernel::{capabilities, create_capability, debug, debug_gpio, debug_verbose, static_init};
+use nrf52832::deferred_call_tasks::DeferredCallTask;
 use nrf52832::gpio::Pin;
 use nrf52832::interrupt_service::Nrf52832DefaultPeripherals;
 use nrf52832::rtc::Rtc;
@@ -225,10 +227,14 @@ impl KernelResources<nrf52832::chip::NRF52<'static, Nrf52832DefaultPeripherals<'
 /// these static_inits is wasted.
 #[inline(never)]
 unsafe fn get_peripherals() -> &'static mut Nrf52832DefaultPeripherals<'static> {
+    let dc_mgr = static_init!(
+        DeferredCallManager<DeferredCallTask>,
+        DeferredCallManager::new()
+    );
     // Initialize chip peripheral drivers
     let nrf52832_peripherals = static_init!(
         Nrf52832DefaultPeripherals,
-        Nrf52832DefaultPeripherals::new()
+        Nrf52832DefaultPeripherals::new(dc_mgr)
     );
 
     nrf52832_peripherals

--- a/boards/nucleo_f429zi/src/main.rs
+++ b/boards/nucleo_f429zi/src/main.rs
@@ -12,12 +12,14 @@ use capsules::virtual_alarm::VirtualMuxAlarm;
 use components::gpio::GpioComponent;
 use kernel::capabilities;
 use kernel::component::Component;
+use kernel::deferred_call::DeferredCallManager;
 use kernel::dynamic_deferred_call::{DynamicDeferredCall, DynamicDeferredCallClientState};
 use kernel::hil::led::LedHigh;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::{create_capability, debug, static_init};
 
+use stm32f429zi::deferred_calls::DeferredCallTask;
 use stm32f429zi::gpio::{AlternateFunction, Mode, PinId, PortId};
 use stm32f429zi::interrupt_service::Stm32f429ziDefaultPeripherals;
 
@@ -273,10 +275,14 @@ unsafe fn get_peripherals() -> (
     );
     let dma1 = static_init!(stm32f429zi::dma::Dma1, stm32f429zi::dma::Dma1::new(rcc));
     let dma2 = static_init!(stm32f429zi::dma::Dma2, stm32f429zi::dma::Dma2::new(rcc));
+    let dc_mgr = static_init!(
+        DeferredCallManager<DeferredCallTask>,
+        DeferredCallManager::new()
+    );
 
     let peripherals = static_init!(
         Stm32f429ziDefaultPeripherals,
-        Stm32f429ziDefaultPeripherals::new(rcc, exti, dma1, dma2)
+        Stm32f429ziDefaultPeripherals::new(rcc, exti, dma1, dma2, dc_mgr)
     );
     (peripherals, syscfg, dma1)
 }

--- a/boards/nucleo_f446re/src/main.rs
+++ b/boards/nucleo_f446re/src/main.rs
@@ -11,12 +11,14 @@
 use capsules::virtual_alarm::VirtualMuxAlarm;
 use kernel::capabilities;
 use kernel::component::Component;
+use kernel::deferred_call::DeferredCallManager;
 use kernel::dynamic_deferred_call::{DynamicDeferredCall, DynamicDeferredCallClientState};
 use kernel::hil::gpio::Configure;
 use kernel::hil::led::LedHigh;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::{create_capability, debug, static_init};
+use stm32f446re::deferred_calls::DeferredCallTask;
 use stm32f446re::interrupt_service::Stm32f446reDefaultPeripherals;
 
 /// Support routines for debugging I/O.
@@ -226,9 +228,13 @@ unsafe fn get_peripherals() -> (
     let dma1 = static_init!(stm32f446re::dma::Dma1, stm32f446re::dma::Dma1::new(rcc));
     let dma2 = static_init!(stm32f446re::dma::Dma2, stm32f446re::dma::Dma2::new(rcc));
 
+    let dc_mgr = static_init!(
+        DeferredCallManager<DeferredCallTask>,
+        DeferredCallManager::new()
+    );
     let peripherals = static_init!(
         Stm32f446reDefaultPeripherals,
-        Stm32f446reDefaultPeripherals::new(rcc, exti, dma1, dma2)
+        Stm32f446reDefaultPeripherals::new(rcc, exti, dma1, dma2, dc_mgr)
     );
     (peripherals, syscfg, dma1)
 }

--- a/boards/stm32f3discovery/src/main.rs
+++ b/boards/stm32f3discovery/src/main.rs
@@ -13,6 +13,7 @@ use capsules::virtual_alarm::VirtualMuxAlarm;
 use components::gpio::GpioComponent;
 use kernel::capabilities;
 use kernel::component::Component;
+use kernel::deferred_call::DeferredCallManager;
 use kernel::dynamic_deferred_call::{DynamicDeferredCall, DynamicDeferredCallClientState};
 use kernel::hil::gpio::Configure;
 use kernel::hil::gpio::Output;
@@ -22,6 +23,7 @@ use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::{create_capability, debug, static_init};
 use stm32f303xc::chip::Stm32f3xxDefaultPeripherals;
+use stm32f303xc::deferred_call_tasks::DeferredCallTask;
 use stm32f303xc::wdt;
 
 /// Support routines for debugging I/O.
@@ -358,10 +360,14 @@ unsafe fn get_peripherals() -> (
         stm32f303xc::exti::Exti,
         stm32f303xc::exti::Exti::new(syscfg)
     );
+    let dc_mgr = static_init!(
+        DeferredCallManager<DeferredCallTask>,
+        DeferredCallManager::new()
+    );
 
     let peripherals = static_init!(
         Stm32f3xxDefaultPeripherals,
-        Stm32f3xxDefaultPeripherals::new(rcc, exti)
+        Stm32f3xxDefaultPeripherals::new(rcc, exti, dc_mgr)
     );
 
     (peripherals, syscfg, rcc)

--- a/boards/stm32f412gdiscovery/src/main.rs
+++ b/boards/stm32f412gdiscovery/src/main.rs
@@ -12,6 +12,7 @@ use components::gpio::GpioComponent;
 use components::rng::RngComponent;
 use kernel::capabilities;
 use kernel::component::Component;
+use kernel::deferred_call::DeferredCallManager;
 use kernel::dynamic_deferred_call::{DynamicDeferredCall, DynamicDeferredCallClientState};
 use kernel::hil::gpio;
 use kernel::hil::led::LedLow;
@@ -19,6 +20,7 @@ use kernel::hil::screen::ScreenRotation;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::{create_capability, debug, static_init};
+use stm32f412g::deferred_calls::DeferredCallTask;
 use stm32f412g::interrupt_service::Stm32f412gDefaultPeripherals;
 
 /// Support routines for debugging I/O.
@@ -384,10 +386,14 @@ unsafe fn get_peripherals() -> (
 
     let dma1 = static_init!(stm32f412g::dma::Dma1, stm32f412g::dma::Dma1::new(rcc));
     let dma2 = static_init!(stm32f412g::dma::Dma2, stm32f412g::dma::Dma2::new(rcc));
+    let dc_mgr = static_init!(
+        DeferredCallManager<DeferredCallTask>,
+        DeferredCallManager::new()
+    );
 
     let peripherals = static_init!(
         Stm32f412gDefaultPeripherals,
-        Stm32f412gDefaultPeripherals::new(rcc, exti, dma1, dma2)
+        Stm32f412gDefaultPeripherals::new(rcc, exti, dma1, dma2, dc_mgr)
     );
     (peripherals, syscfg, dma1)
 }

--- a/boards/stm32f429idiscovery/src/main.rs
+++ b/boards/stm32f429idiscovery/src/main.rs
@@ -12,12 +12,14 @@ use capsules::virtual_alarm::VirtualMuxAlarm;
 use components::gpio::GpioComponent;
 use kernel::capabilities;
 use kernel::component::Component;
+use kernel::deferred_call::DeferredCallManager;
 use kernel::dynamic_deferred_call::{DynamicDeferredCall, DynamicDeferredCallClientState};
 use kernel::hil::led::LedHigh;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::{create_capability, debug, static_init};
 
+use stm32f429zi::deferred_calls::DeferredCallTask;
 use stm32f429zi::gpio::{AlternateFunction, Mode, PinId, PortId};
 use stm32f429zi::interrupt_service::Stm32f429ziDefaultPeripherals;
 
@@ -277,9 +279,13 @@ unsafe fn get_peripherals() -> (
     );
     let dma1 = static_init!(stm32f429zi::dma::Dma1, stm32f429zi::dma::Dma1::new(rcc));
     let dma2 = static_init!(stm32f429zi::dma::Dma2, stm32f429zi::dma::Dma2::new(rcc));
+    let dc_mgr = static_init!(
+        DeferredCallManager<DeferredCallTask>,
+        DeferredCallManager::new()
+    );
     let peripherals = static_init!(
         Stm32f429ziDefaultPeripherals,
-        Stm32f429ziDefaultPeripherals::new(rcc, exti, dma1, dma2)
+        Stm32f429ziDefaultPeripherals::new(rcc, exti, dma1, dma2, dc_mgr)
     );
     (peripherals, syscfg, dma2)
 }

--- a/boards/weact_f401ccu6/src/main.rs
+++ b/boards/weact_f401ccu6/src/main.rs
@@ -12,12 +12,14 @@ use capsules::virtual_alarm::VirtualMuxAlarm;
 use components::gpio::GpioComponent;
 use kernel::capabilities;
 use kernel::component::Component;
+use kernel::deferred_call::DeferredCallManager;
 use kernel::dynamic_deferred_call::{DynamicDeferredCall, DynamicDeferredCallClientState};
 use kernel::hil::led::LedLow;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::{create_capability, debug, static_init};
 
+use stm32f401cc::deferred_calls::DeferredCallTask;
 use stm32f401cc::interrupt_service::Stm32f401ccDefaultPeripherals;
 
 /// Support routines for debugging I/O.
@@ -227,10 +229,14 @@ unsafe fn get_peripherals() -> (
     );
     let dma1 = static_init!(stm32f401cc::dma::Dma1, stm32f401cc::dma::Dma1::new(rcc));
     let dma2 = static_init!(stm32f401cc::dma::Dma2, stm32f401cc::dma::Dma2::new(rcc));
+    let dc_mgr = static_init!(
+        DeferredCallManager<DeferredCallTask>,
+        DeferredCallManager::new()
+    );
 
     let peripherals = static_init!(
         Stm32f401ccDefaultPeripherals,
-        Stm32f401ccDefaultPeripherals::new(rcc, exti, dma1, dma2)
+        Stm32f401ccDefaultPeripherals::new(rcc, exti, dma1, dma2, dc_mgr)
     );
     (peripherals, syscfg, dma1)
 }

--- a/chips/nrf52832/src/interrupt_service.rs
+++ b/chips/nrf52832/src/interrupt_service.rs
@@ -1,4 +1,5 @@
 use crate::deferred_call_tasks::DeferredCallTask;
+use kernel::deferred_call::DeferredCallManager;
 use nrf52::chip::Nrf52DefaultPeripherals;
 
 /// This struct, when initialized, instantiates all peripheral drivers for the nrf52840.
@@ -10,9 +11,9 @@ pub struct Nrf52832DefaultPeripherals<'a> {
     pub gpio_port: crate::gpio::Port<'a, { crate::gpio::NUM_PINS }>,
 }
 impl<'a> Nrf52832DefaultPeripherals<'a> {
-    pub unsafe fn new() -> Self {
+    pub unsafe fn new(dc_mgr: &'static DeferredCallManager<DeferredCallTask>) -> Self {
         Self {
-            nrf52: Nrf52DefaultPeripherals::new(),
+            nrf52: Nrf52DefaultPeripherals::new(dc_mgr),
             gpio_port: crate::gpio::nrf52832_gpio_create(),
         }
     }

--- a/chips/nrf52833/src/interrupt_service.rs
+++ b/chips/nrf52833/src/interrupt_service.rs
@@ -1,4 +1,5 @@
 use crate::deferred_call_tasks::DeferredCallTask;
+use kernel::deferred_call::DeferredCallManager;
 use nrf52::chip::Nrf52DefaultPeripherals;
 
 /// This struct, when initialized, instantiates all peripheral drivers for the nrf52840.
@@ -10,9 +11,9 @@ pub struct Nrf52833DefaultPeripherals<'a> {
     pub gpio_port: crate::gpio::Port<'a, { crate::gpio::NUM_PINS }>,
 }
 impl<'a> Nrf52833DefaultPeripherals<'a> {
-    pub unsafe fn new() -> Self {
+    pub unsafe fn new(dc_mgr: &'static DeferredCallManager<DeferredCallTask>) -> Self {
         Self {
-            nrf52: Nrf52DefaultPeripherals::new(),
+            nrf52: Nrf52DefaultPeripherals::new(dc_mgr),
             gpio_port: crate::gpio::nrf52833_gpio_create(),
         }
     }

--- a/chips/nrf52840/src/interrupt_service.rs
+++ b/chips/nrf52840/src/interrupt_service.rs
@@ -1,4 +1,5 @@
 use crate::deferred_call_tasks::DeferredCallTask;
+use kernel::deferred_call::DeferredCallManager;
 use nrf52::chip::Nrf52DefaultPeripherals;
 
 /// This struct, when initialized, instantiates all peripheral drivers for the nrf52840.
@@ -13,9 +14,9 @@ pub struct Nrf52840DefaultPeripherals<'a> {
 }
 
 impl<'a> Nrf52840DefaultPeripherals<'a> {
-    pub unsafe fn new() -> Self {
+    pub unsafe fn new(dc_mgr: &'static DeferredCallManager<DeferredCallTask>) -> Self {
         Self {
-            nrf52: Nrf52DefaultPeripherals::new(),
+            nrf52: Nrf52DefaultPeripherals::new(dc_mgr),
             usbd: crate::usbd::Usbd::new(),
             gpio_port: crate::gpio::nrf52840_gpio_create(),
         }

--- a/chips/rp2040/src/chip.rs
+++ b/chips/rp2040/src/chip.rs
@@ -1,7 +1,6 @@
 //! Chip trait setup.
 
 use core::fmt::Write;
-use kernel::deferred_call;
 use kernel::platform::chip::Chip;
 use kernel::platform::chip::InterruptService;
 
@@ -83,7 +82,7 @@ impl<'a, I: InterruptService<()>> Chip for Rp2040<'a, I> {
             Processor::Processor0 => self.processor0_interrupt_mask,
             Processor::Processor1 => self.processor1_interrupt_mask,
         };
-        unsafe { cortexm0p::nvic::has_pending_with_mask(mask) || deferred_call::has_tasks() }
+        unsafe { cortexm0p::nvic::has_pending_with_mask(mask) }
     }
 
     fn mpu(&self) -> &Self::MPU {

--- a/chips/stm32f303xc/src/lib.rs
+++ b/chips/stm32f303xc/src/lib.rs
@@ -7,7 +7,7 @@
 #![no_std]
 
 pub mod chip;
-mod deferred_call_tasks;
+pub mod deferred_call_tasks;
 pub mod nvic;
 
 // Peripherals

--- a/chips/stm32f401cc/src/interrupt_service.rs
+++ b/chips/stm32f401cc/src/interrupt_service.rs
@@ -1,3 +1,4 @@
+use kernel::deferred_call::DeferredCallManager;
 use stm32f4xx::chip::Stm32f4xxDefaultPeripherals;
 use stm32f4xx::deferred_calls::DeferredCallTask;
 
@@ -12,9 +13,10 @@ impl<'a> Stm32f401ccDefaultPeripherals<'a> {
         exti: &'a crate::exti::Exti<'a>,
         dma1: &'a crate::dma::Dma1<'a>,
         dma2: &'a crate::dma::Dma2<'a>,
+        dc_mgr: &'static DeferredCallManager<DeferredCallTask>,
     ) -> Self {
         Self {
-            stm32f4: Stm32f4xxDefaultPeripherals::new(rcc, exti, dma1, dma2),
+            stm32f4: Stm32f4xxDefaultPeripherals::new(rcc, exti, dma1, dma2, dc_mgr),
         }
     }
     // Necessary for setting up circular dependencies

--- a/chips/stm32f401cc/src/lib.rs
+++ b/chips/stm32f401cc/src/lib.rs
@@ -2,7 +2,9 @@
 
 use cortexm4::{generic_isr, unhandled_interrupt};
 
-pub use stm32f4xx::{adc, chip, dbg, dma, exti, gpio, nvic, rcc, spi, syscfg, tim2, usart};
+pub use stm32f4xx::{
+    adc, chip, dbg, deferred_calls, dma, exti, gpio, nvic, rcc, spi, syscfg, tim2, usart,
+};
 
 pub mod interrupt_service;
 

--- a/chips/stm32f412g/src/interrupt_service.rs
+++ b/chips/stm32f412g/src/interrupt_service.rs
@@ -1,4 +1,5 @@
 use crate::stm32f412g_nvic;
+use kernel::deferred_call::DeferredCallManager;
 use stm32f4xx::chip::Stm32f4xxDefaultPeripherals;
 use stm32f4xx::deferred_calls::DeferredCallTask;
 
@@ -14,9 +15,10 @@ impl<'a> Stm32f412gDefaultPeripherals<'a> {
         exti: &'a crate::exti::Exti<'a>,
         dma1: &'a crate::dma::Dma1<'a>,
         dma2: &'a crate::dma::Dma2<'a>,
+        dc_mgr: &'static DeferredCallManager<DeferredCallTask>,
     ) -> Self {
         Self {
-            stm32f4: Stm32f4xxDefaultPeripherals::new(rcc, exti, dma1, dma2),
+            stm32f4: Stm32f4xxDefaultPeripherals::new(rcc, exti, dma1, dma2, dc_mgr),
             trng: stm32f4xx::trng::Trng::new(rcc),
         }
     }

--- a/chips/stm32f412g/src/lib.rs
+++ b/chips/stm32f412g/src/lib.rs
@@ -3,7 +3,8 @@
 use cortexm4::generic_isr;
 
 pub use stm32f4xx::{
-    adc, chip, dbg, dma, exti, fsmc, gpio, i2c, nvic, rcc, spi, syscfg, tim2, trng, usart,
+    adc, chip, dbg, deferred_calls, dma, exti, fsmc, gpio, i2c, nvic, rcc, spi, syscfg, tim2, trng,
+    usart,
 };
 
 pub mod interrupt_service;

--- a/chips/stm32f429zi/src/interrupt_service.rs
+++ b/chips/stm32f429zi/src/interrupt_service.rs
@@ -1,3 +1,4 @@
+use kernel::deferred_call::DeferredCallManager;
 use stm32f4xx::chip::Stm32f4xxDefaultPeripherals;
 use stm32f4xx::deferred_calls::DeferredCallTask;
 
@@ -12,9 +13,10 @@ impl<'a> Stm32f429ziDefaultPeripherals<'a> {
         exti: &'a crate::exti::Exti<'a>,
         dma1: &'a crate::dma::Dma1<'a>,
         dma2: &'a crate::dma::Dma2<'a>,
+        dc_mgr: &'static DeferredCallManager<DeferredCallTask>,
     ) -> Self {
         Self {
-            stm32f4: Stm32f4xxDefaultPeripherals::new(rcc, exti, dma1, dma2),
+            stm32f4: Stm32f4xxDefaultPeripherals::new(rcc, exti, dma1, dma2, dc_mgr),
         }
     }
     // Necessary for setting up circular dependencies

--- a/chips/stm32f429zi/src/lib.rs
+++ b/chips/stm32f429zi/src/lib.rs
@@ -2,7 +2,9 @@
 
 use cortexm4::generic_isr;
 
-pub use stm32f4xx::{adc, chip, dbg, dma, exti, gpio, nvic, rcc, spi, syscfg, tim2, usart};
+pub use stm32f4xx::{
+    adc, chip, dbg, deferred_calls, dma, exti, gpio, nvic, rcc, spi, syscfg, tim2, usart,
+};
 
 pub mod interrupt_service;
 pub mod stm32f429zi_nvic;

--- a/chips/stm32f446re/src/interrupt_service.rs
+++ b/chips/stm32f446re/src/interrupt_service.rs
@@ -1,3 +1,4 @@
+use kernel::deferred_call::DeferredCallManager;
 use stm32f4xx::chip::Stm32f4xxDefaultPeripherals;
 use stm32f4xx::deferred_calls::DeferredCallTask;
 
@@ -12,9 +13,10 @@ impl<'a> Stm32f446reDefaultPeripherals<'a> {
         exti: &'a crate::exti::Exti<'a>,
         dma1: &'a crate::dma::Dma1<'a>,
         dma2: &'a crate::dma::Dma2<'a>,
+        dc_mgr: &'static DeferredCallManager<DeferredCallTask>,
     ) -> Self {
         Self {
-            stm32f4: Stm32f4xxDefaultPeripherals::new(rcc, exti, dma1, dma2),
+            stm32f4: Stm32f4xxDefaultPeripherals::new(rcc, exti, dma1, dma2, dc_mgr),
         }
     }
     // Necessary for setting up circular dependencies

--- a/chips/stm32f446re/src/lib.rs
+++ b/chips/stm32f446re/src/lib.rs
@@ -1,6 +1,8 @@
 #![no_std]
 
-pub use stm32f4xx::{chip, dbg, dma, exti, gpio, nvic, rcc, spi, syscfg, tim2, usart};
+pub use stm32f4xx::{
+    chip, dbg, deferred_calls, dma, exti, gpio, nvic, rcc, spi, syscfg, tim2, usart,
+};
 
 pub mod interrupt_service;
 pub mod stm32f446re_nvic;

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -85,7 +85,6 @@
 //!    this use case. It is likely we will have to create new interfaces as new
 //!    use cases are discovered.
 
-#![feature(core_intrinsics)]
 #![warn(unreachable_pub)]
 #![no_std]
 

--- a/kernel/src/platform/chip.rs
+++ b/kernel/src/platform/chip.rs
@@ -109,6 +109,20 @@ pub trait InterruptService<T> {
 
     /// Service a deferred call. If this task is not supported, return false.
     unsafe fn service_deferred_call(&self, task: T) -> bool;
+
+    /// Returns true if any deferred call tasks are pending, otherwise returns false.
+    /// Default implementation just returns false, and should be overriden by chips that require
+    /// defferred calls.
+    fn has_deferred_call_tasks(&self) -> bool {
+        false
+    }
+
+    /// Returns the next pending deferred call task, if any.
+    /// Default implementation just returns None, and should be overriden by chips that require
+    /// deferred calls
+    fn next_pending_deferred_call(&self) -> Option<T> {
+        None
+    }
 }
 
 /// Generic operations that clock-like things are expected to support.


### PR DESCRIPTION
### Pull Request Overview

This PR restructures `DeferredCall` to not require atomics, instead relying on a `DeferredCallManager` structure which is simply a wrapper around `Cell<usize>` and is held by the `Chip` struct. This allows us to remove the perma-unstable `#![feature(core_intrinsics)]` from the Tock kernel, and removes some unsafe code. This change is safe because we only ever touch the Manager from the main kernel thread (not interrupt context) so we never really needed atomics anyway. In theory, using a `static mut` global usize would have worked just as well and allowed us to more closely retain the existing API, but given the documented issues with safe/correct use of `static mut` I prefer this approach.

This change comes at the expense of about ~300 bytes of code size on platforms with multiple deferred calls -- however deferred calls are actually rarely used, with only 3 of Tock's supported chips requiring any (in contrast to dynamic deferred calls which are more widely used).

~~So far, I have only implemented this for Imix, as I would like feedback before implementing it for the remaining chips.~~
I have implemented this for all chips/boards now.

### Testing Strategy

This pull request was tested by compiling.


### TODO or Help Wanted

N/A

### Documentation Updated

- [x] No updates are required.

### Formatting

- [x] Ran `make prepush`.
