### PR TITLE
tock_registers/test_fields: respect struct size padding w/ alignment

### DIFF
--- a/libraries/tock-register-interface/src/macros.rs
+++ b/libraries/tock-register-interface/src/macros.rs
@@ -179,7 +179,7 @@ macro_rules! test_fields {
     // Macro entry point.
     (@root $struct:ident $(<$life:lifetime>)? { $($input:tt)* } ) => {
         // Start recursion at offset 0.
-        $crate::test_fields!(@munch $struct $(<$life>)? ($($input)*) : 0);
+        $crate::test_fields!(@munch $struct $(<$life>)? ($($input)*) : (0, 0));
     };
 
     // Consume the ($size:expr => @END) field, which MUST be the last field in
@@ -197,15 +197,20 @@ macro_rules! test_fields {
             // evaluate the previous iterations' expressions for them to have an
             // effect anyways, so we can perform an internal sanity check on
             // this value as well.
-            const SUM: usize = $stmts;
+            const SUM_MAX_ALIGN: (usize, usize) = $stmts;
+            const SUM: usize = SUM_MAX_ALIGN.0;
+            const MAX_ALIGN: usize = SUM_MAX_ALIGN.1;
 
-            const fn struct_size $(<$life>)? () -> usize
-            {
-                core::mem::size_of::<$struct $(<$life>)?>()
-            }
+            // Internal sanity check. If we have reached this point and
+            // correctly iterated over the struct's fields, the current offset
+            // and the claimed end offset MUST be equal.
+            assert!(SUM == $size);
+
+            const STRUCT_SIZE: usize = core::mem::size_of::<$struct $(<$life>)?>();
+            const ALIGNMENT_CORRECTED_SIZE: usize = if $size % MAX_ALIGN != 0 { $size + (MAX_ALIGN - ($size % MAX_ALIGN)) } else { $size };
 
             assert!(
-                struct_size() == $size,
+                STRUCT_SIZE == ALIGNMENT_CORRECTED_SIZE,
                 "{}",
                 concat!(
                     "Invalid size for struct ",
@@ -215,11 +220,6 @@ macro_rules! test_fields {
                     ", actual struct size differs)",
                 ),
             );
-
-            // Internal sanity check. If we have reached this point and
-            // correctly iterated over the struct's fields, the current offset
-            // and the claimed end offset MUST be equal.
-            assert!(SUM == $size);
         };
     };
 
@@ -242,7 +242,9 @@ macro_rules! test_fields {
             ) : {
                 // Evaluate the previous iterations' expression to determine the
                 // current offset.
-                const SUM: usize = $output;
+                const SUM_MAX_ALIGN: (usize, usize) = $output;
+                const SUM: usize = SUM_MAX_ALIGN.0;
+                const MAX_ALIGN: usize = SUM_MAX_ALIGN.1;
 
                 // Validate the start offset of the current field. This check is
                 // mostly relevant for when this is the first field in the
@@ -263,7 +265,7 @@ macro_rules! test_fields {
                 // Validate that the start offset of the current field within
                 // the struct matches the type's minimum alignment constraint.
                 const ALIGN: usize = core::mem::align_of::<$ty>();
-                // Clippy can tell that (ALIGN - 1) is zero for some fields, so
+                // Clippy can tell that (align - 1) is zero for some fields, so
                 // we allow this lint and further encapsule the assert! as an
                 // expression, such that the allow attr can apply.
                 #[allow(clippy::bad_bit_mask)]
@@ -295,8 +297,13 @@ macro_rules! test_fields {
                     ),
                 );
 
-                // Provide the updated offset to the next iteration
-                NEW_SUM
+                // Determine the new maximum alignment. core::cmp::max(ALIGN,
+                // MAX_ALIGN) does not work here, as the function is not const.
+                const NEW_MAX_ALIGN: usize = if ALIGN > MAX_ALIGN { ALIGN } else { MAX_ALIGN };
+
+                // Provide the updated offset and alignment to the next
+                // iteration.
+                (NEW_SUM, NEW_MAX_ALIGN)
             }
         );
     };
@@ -320,7 +327,9 @@ macro_rules! test_fields {
             ) : {
                 // Evaluate the previous iterations' expression to determine the
                 // current offset.
-                const SUM: usize = $output;
+                const SUM_MAX_ALIGN: (usize, usize) = $output;
+                const SUM: usize = SUM_MAX_ALIGN.0;
+                const MAX_ALIGN: usize = SUM_MAX_ALIGN.1;
 
                 // Validate the start offset of the current padding field. This
                 // check is mostly relevant for when this is the first field in
@@ -339,7 +348,7 @@ macro_rules! test_fields {
 
                 // The padding field is automatically sized. Provide the start
                 // offset of the next field to the next iteration.
-                $offset_end
+                ($offset_end, MAX_ALIGN)
             }
         );
     };

--- a/libraries/tock-register-interface/src/macros.rs
+++ b/libraries/tock-register-interface/src/macros.rs
@@ -197,7 +197,7 @@ macro_rules! test_fields {
             // evaluate the previous iterations' expressions for them to have an
             // effect anyways, so we can perform an internal sanity check on
             // this value as well.
-            const sum: usize = $stmts;
+            const SUM: usize = $stmts;
 
             const fn struct_size $(<$life>)? () -> usize
             {
@@ -219,7 +219,7 @@ macro_rules! test_fields {
             // Internal sanity check. If we have reached this point and
             // correctly iterated over the struct's fields, the current offset
             // and the claimed end offset MUST be equal.
-            assert!(sum == $size);
+            assert!(SUM == $size);
         };
     };
 
@@ -242,14 +242,14 @@ macro_rules! test_fields {
             ) : {
                 // Evaluate the previous iterations' expression to determine the
                 // current offset.
-                const sum: usize = $output;
+                const SUM: usize = $output;
 
                 // Validate the start offset of the current field. This check is
                 // mostly relevant for when this is the first field in the
                 // struct, as any subsequent start offset error will be detected
                 // by an end offset error of the previous field.
                 assert!(
-                    sum == $offset_start,
+                    SUM == $offset_start,
                     "{}",
                     concat!(
                         "Invalid start offset for field ",
@@ -262,14 +262,14 @@ macro_rules! test_fields {
 
                 // Validate that the start offset of the current field within
                 // the struct matches the type's minimum alignment constraint.
-                const align: usize = core::mem::align_of::<$ty>();
-                // Clippy can tell that (align - 1) is zero for some fields, so
+                const ALIGN: usize = core::mem::align_of::<$ty>();
+                // Clippy can tell that (ALIGN - 1) is zero for some fields, so
                 // we allow this lint and further encapsule the assert! as an
                 // expression, such that the allow attr can apply.
                 #[allow(clippy::bad_bit_mask)]
                 {
                     assert!(
-                        sum & (align - 1) == 0,
+                        SUM & (ALIGN - 1) == 0,
                         "{}",
                         concat!(
                             "Invalid alignment for field ",
@@ -282,9 +282,9 @@ macro_rules! test_fields {
                 // Add the current field's length to the offset and validate the
                 // end offset of the field based on the next field's claimed
                 // start offset.
-                const new_sum: usize = sum + core::mem::size_of::<$ty>();
+                const NEW_SUM: usize = SUM + core::mem::size_of::<$ty>();
                 assert!(
-                    new_sum == $offset_end,
+                    NEW_SUM == $offset_end,
                     "{}",
                     concat!(
                         "Invalid end offset for field ",
@@ -296,7 +296,7 @@ macro_rules! test_fields {
                 );
 
                 // Provide the updated offset to the next iteration
-                new_sum
+                NEW_SUM
             }
         );
     };
@@ -320,14 +320,14 @@ macro_rules! test_fields {
             ) : {
                 // Evaluate the previous iterations' expression to determine the
                 // current offset.
-                const sum: usize = $output;
+                const SUM: usize = $output;
 
                 // Validate the start offset of the current padding field. This
                 // check is mostly relevant for when this is the first field in
                 // the struct, as any subsequent start offset error will be
                 // detected by an end offset error of the previous field.
                 assert!(
-                    sum == $offset_start,
+                    SUM == $offset_start,
                     concat!(
                         "Invalid start offset for padding ",
                         stringify!($padding),


### PR DESCRIPTION
### Pull Request Overview

As illustrated in tock/tock#3019, Rust causes a struct's size to be padded to a multiple of the largest field's alignment constraints.

The tock-register-interface crate contains some sanity checks which ensure that a struct is not missing any padding fields, all fields are generally well aligned, and that the fields are placed at their respective specified memory address. As of tock/tock#2922, these checks are no longer runtime tests, but static const assertions which cause proper compiler errors, should an assertion be violated.

Because the tock-registers-interface macros check invariants by iterating over the individual fields and accumulating their size, the above property of Rust structs has not been taken into account properly and caused compiler errors for register structs which contain fields of varying alignment and size.

This commit changes the iterative processing of register fields to also track the highest alignment constraint of any field encountered and, at the end of the struct, add the remaining alignment to the expected size of the struct. Thus the following register definition works now:

```rust
register_structs! {
    pub RegisterBlock {
	(0x00 => foo: ReadWrite<u64>),
	(0x08 => bar: ReadWrite<u32>),
	(0x0C => @END),
    }
}

fn test_struct_loc() {
    // Undefined behavior here, but sufficient for checking offsets
    let regs = unsafe { &*(0x0 as *const RegisterBlock) };
    assert!(regs as *const _ as usize == 0x0);
    assert!(&regs.foo as *const _ as usize == 0x0);
    assert!(&regs.bar as *const _ as usize == 0x8);
}
```

Fixes tock/tock#3019. Perhaps you can confirm, @jscatena88?

Signed-off-by: Leon Schuermann <leon@is.currently.online>

### Testing Strategy

This pull request was tested by the example provided in the commit message.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] ~Updated the relevant files in `/docs`,~ or no updates are required.

### Formatting

- [x] Ran `make prepush`.
