### PR TITLE
Makefile: update qemu commit hash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -515,7 +515,7 @@ ci-job-cargo-test-build:
 
 ### ci-runner-github-qemu jobs:
 
-QEMU_COMMIT_HASH=9d662a6b22a0838a85c5432385f35db2488a33a5
+QEMU_COMMIT_HASH=0ebf76aae58324b8f7bf6af798696687f5f4c2a9
 define ci_setup_qemu_riscv
 	$(call banner,CI-Setup: Build QEMU)
 	@# Use the latest QEMU as it has OpenTitan support


### PR DESCRIPTION
### Pull Request Overview

The current hash fails to build (with a warning treated as an error), bumped to the latest commit hash.
Builds okay now when running `make ci-setup-qemu`

### Testing Strategy

By running `make test` on boards/opentitan/earlgrey-cw310/ 
Qemu tests all ran ok

### TODO or Help Wanted

N/A

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
