### PR TITLE
capsules: Add support for AES GCM

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ members = [
     "boards/qemu_rv32_virt",
     "boards/swervolf",
     "boards/weact_f401ccu6/",
+    "capsules/aes_gcm",
     "capsules/core",
     "capsules/extra",
     "chips/apollo3",

--- a/boards/opentitan/earlgrey-cw310/Cargo.toml
+++ b/boards/opentitan/earlgrey-cw310/Cargo.toml
@@ -19,6 +19,7 @@ tock-tbf = { path = "../../../libraries/tock-tbf" }
 
 capsules-core = { path = "../../../capsules/core" }
 capsules-extra = { path = "../../../capsules/extra" }
+capsules-aes-gcm = { path = "../../../capsules/aes_gcm" }
 
 
 [features]

--- a/boards/opentitan/src/tests/aes_test.rs
+++ b/boards/opentitan/src/tests/aes_test.rs
@@ -6,9 +6,11 @@
 
 use crate::tests::run_kernel_op;
 use crate::{AES, PERIPHERALS};
+use capsules_aes_gcm::aes_gcm::Aes128Gcm;
 use capsules_core::virtualizers::virtual_aes_ccm;
 use capsules_extra::test::aes::{TestAes128Cbc, TestAes128Ctr, TestAes128Ecb};
-use capsules_extra::test::aes_ccm::Test;
+use capsules_extra::test::aes_ccm;
+use capsules_extra::test::aes_gcm;
 use earlgrey::aes::Aes;
 use kernel::debug;
 use kernel::hil::symmetric_encryption::{AES128, AES128_BLOCK_SIZE, AES128_KEY_SIZE};
@@ -33,13 +35,55 @@ fn run_aes128_ccm() {
 }
 
 unsafe fn static_init_test_ccm(
-    aes: &'static virtual_aes_ccm::VirtualAES128CCM<'static, Aes>,
-) -> &'static Test<'static, virtual_aes_ccm::VirtualAES128CCM<'static, Aes<'static>>> {
+    aes: &'static Aes128Gcm<'static, virtual_aes_ccm::VirtualAES128CCM<'static, Aes<'static>>>,
+) -> &'static aes_ccm::Test<
+    'static,
+    Aes128Gcm<'static, virtual_aes_ccm::VirtualAES128CCM<'static, Aes<'static>>>,
+> {
     let buf = static_init!([u8; 4 * AES128_BLOCK_SIZE], [0; 4 * AES128_BLOCK_SIZE]);
 
     static_init!(
-        Test<'static, virtual_aes_ccm::VirtualAES128CCM<'static, Aes>>,
-        Test::new(aes, buf)
+        aes_ccm::Test<
+            'static,
+            Aes128Gcm<'static, virtual_aes_ccm::VirtualAES128CCM<'static, Aes<'static>>>,
+        >,
+        aes_ccm::Test::new(aes, buf)
+    )
+}
+
+#[test_case]
+fn run_aes128_gcm() {
+    debug!("check run AES128 GCM... ");
+    run_kernel_op(100);
+
+    unsafe {
+        let aes = AES.unwrap();
+
+        let t = static_init_test_gcm(&aes);
+        kernel::hil::symmetric_encryption::AES128GCM::set_client(aes, t);
+
+        #[cfg(feature = "hardware_tests")]
+        t.run();
+    }
+    run_kernel_op(10000);
+    debug!("    [ok]");
+    run_kernel_op(100);
+}
+
+unsafe fn static_init_test_gcm(
+    aes: &'static Aes128Gcm<'static, virtual_aes_ccm::VirtualAES128CCM<'static, Aes<'static>>>,
+) -> &'static aes_gcm::Test<
+    'static,
+    Aes128Gcm<'static, virtual_aes_ccm::VirtualAES128CCM<'static, Aes<'static>>>,
+> {
+    let buf = static_init!([u8; 9 * AES128_BLOCK_SIZE], [0; 9 * AES128_BLOCK_SIZE]);
+
+    static_init!(
+        aes_gcm::Test<
+            'static,
+            Aes128Gcm<'static, virtual_aes_ccm::VirtualAES128CCM<'static, Aes<'static>>>,
+        >,
+        aes_gcm::Test::new(aes, buf)
     )
 }
 

--- a/capsules/aes_gcm/Cargo.toml
+++ b/capsules/aes_gcm/Cargo.toml
@@ -1,0 +1,15 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Western Digital 2023.
+
+[package]
+name = "capsules-aes-gcm"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+
+[dependencies]
+kernel = { path = "../../kernel" }
+enum_primitive = { path = "../../libraries/enum_primitive" }
+tickv = { path = "../../libraries/tickv" }
+ghash = "0.4.4"

--- a/capsules/aes_gcm/README.md
+++ b/capsules/aes_gcm/README.md
@@ -1,0 +1,37 @@
+AES GCM Capsule
+===============
+
+This crate contains software support for
+[AES-GCM](https://en.wikipedia.org/wiki/AES-GCM-SIV).
+This capsule doesn't perform any AES operations, instead it relies on
+existing implmenetations to perform the AES operations and instead manages
+the operations and hashing to support GCM.
+
+This capsule uses the extenal
+[ghash crate](https://github.com/RustCrypto/universal-hashes/tree/master/ghash)
+as part of Rust-crypto to implement AES GCM on top of existing AES
+implementions.
+
+## Cargo tree
+
+```
+capsules-aes-gcm v0.1.0 (/var/mnt/scratch/alistair/software/tock/tock/capsules/aes_gcm)
+├── enum_primitive v0.1.0 (/var/mnt/scratch/alistair/software/tock/tock/libraries/enum_primitive)
+├── ghash v0.4.4
+│   ├── opaque-debug v0.3.0
+│   └── polyval v0.5.3
+│       ├── cfg-if v1.0.0
+│       ├── cpufeatures v0.2.7
+│       ├── opaque-debug v0.3.0
+│       └── universal-hash v0.4.1
+│           ├── generic-array v0.14.7
+│           │   └── typenum v1.16.0
+│           │   [build-dependencies]
+│           │   └── version_check v0.9.4
+│           └── subtle v2.4.1
+├── kernel v0.1.0 (/var/mnt/scratch/alistair/software/tock/tock/kernel)
+│   ├── tock-cells v0.1.0 (/var/mnt/scratch/alistair/software/tock/tock/libraries/tock-cells)
+│   ├── tock-registers v0.8.1 (/var/mnt/scratch/alistair/software/tock/tock/libraries/tock-register-interface)
+│   └── tock-tbf v0.1.0 (/var/mnt/scratch/alistair/software/tock/tock/libraries/tock-tbf)
+└── tickv v1.0.0 (/var/mnt/scratch/alistair/software/tock/tock/libraries/tickv)
+```

--- a/capsules/aes_gcm/src/aes_gcm.rs
+++ b/capsules/aes_gcm/src/aes_gcm.rs
@@ -1,0 +1,413 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Western Digital 2023.
+
+//! Implements an AES-GCM implementation using the underlying
+//! AES-CTR implementation.
+//!
+//! This capsule requires an AES-CTR implementation to support
+//! AES-GCM. The implementation relies on AES-CTR, AES-CBC, AES-ECB and
+//! AES-CCM to ensure that when this capsule is used it exposes
+//! all of supported AES operations in a single API.
+
+use core::cell::Cell;
+use ghash::universal_hash::NewUniversalHash;
+use ghash::universal_hash::UniversalHash;
+use ghash::GHash;
+use ghash::Key;
+use kernel::hil::symmetric_encryption;
+use kernel::hil::symmetric_encryption::{
+    AES128Ctr, AES128, AES128CBC, AES128CCM, AES128ECB, AES128_BLOCK_SIZE, AES128_KEY_SIZE,
+};
+use kernel::utilities::cells::{OptionalCell, TakeCell};
+use kernel::ErrorCode;
+
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+enum GCMState {
+    Idle,
+    GenerateHashKey,
+    CtrEncrypt,
+}
+
+pub struct Aes128Gcm<'a, A: AES128<'a> + AES128Ctr + AES128CBC + AES128ECB + AES128CCM<'a>> {
+    aes: &'a A,
+
+    mac: OptionalCell<GHash>,
+
+    crypt_buf: TakeCell<'static, [u8]>,
+
+    client: OptionalCell<&'a dyn symmetric_encryption::Client<'a>>,
+    ccm_client: OptionalCell<&'a dyn symmetric_encryption::CCMClient>,
+    gcm_client: OptionalCell<&'a dyn symmetric_encryption::GCMClient>,
+
+    state: Cell<GCMState>,
+    encrypting: Cell<bool>,
+
+    buf: TakeCell<'static, [u8]>,
+
+    pos: Cell<(usize, usize, usize)>,
+    key: Cell<[u8; AES128_KEY_SIZE]>,
+    iv: Cell<[u8; AES128_KEY_SIZE]>,
+}
+
+impl<'a, A: AES128<'a> + AES128Ctr + AES128CBC + AES128ECB + AES128CCM<'a>> Aes128Gcm<'a, A> {
+    pub fn new(aes: &'a A, crypt_buf: &'static mut [u8]) -> Aes128Gcm<'a, A> {
+        Aes128Gcm {
+            aes,
+
+            mac: OptionalCell::empty(),
+
+            crypt_buf: TakeCell::new(crypt_buf),
+
+            client: OptionalCell::empty(),
+            ccm_client: OptionalCell::empty(),
+            gcm_client: OptionalCell::empty(),
+
+            state: Cell::new(GCMState::Idle),
+            encrypting: Cell::new(false),
+
+            buf: TakeCell::empty(),
+            pos: Cell::new((0, 0, 0)),
+            key: Cell::new(Default::default()),
+            iv: Cell::new(Default::default()),
+        }
+    }
+
+    fn start_ctr_encrypt(&self) -> Result<(), ErrorCode> {
+        self.aes.set_mode_aes128ctr(self.encrypting.get())?;
+
+        let res = AES128::set_key(self.aes, &self.key.get());
+        if res != Ok(()) {
+            return res;
+        }
+
+        self.aes.set_iv(&self.iv.get()).unwrap();
+
+        self.aes.start_message();
+        let crypt_buf = self.crypt_buf.take().unwrap();
+        let (_aad_offset, message_offset, message_len) = self.pos.get();
+
+        match AES128::crypt(
+            self.aes,
+            None,
+            crypt_buf,
+            message_offset,
+            message_offset + message_len + AES128_BLOCK_SIZE,
+        ) {
+            None => {
+                self.state.set(GCMState::CtrEncrypt);
+                Ok(())
+            }
+            Some((res, _, crypt_buf)) => {
+                self.crypt_buf.replace(crypt_buf);
+                res
+            }
+        }
+    }
+
+    fn crypt_r(
+        &self,
+        buf: &'static mut [u8],
+        aad_offset: usize,
+        message_offset: usize,
+        message_len: usize,
+        encrypting: bool,
+    ) -> Result<(), (ErrorCode, &'static mut [u8])> {
+        if self.state.get() != GCMState::Idle {
+            return Err((ErrorCode::BUSY, buf));
+        }
+
+        self.encrypting.set(encrypting);
+
+        self.aes.set_mode_aes128ctr(self.encrypting.get()).unwrap();
+        AES128::set_key(self.aes, &self.key.get()).unwrap();
+        self.aes.set_iv(&[0; AES128_BLOCK_SIZE]).unwrap();
+
+        self.aes.start_message();
+        let crypt_buf = self.crypt_buf.take().unwrap();
+
+        for i in 0..AES128_BLOCK_SIZE {
+            crypt_buf[i] = 0;
+        }
+
+        match AES128::crypt(self.aes, None, crypt_buf, 0, AES128_BLOCK_SIZE) {
+            None => {
+                self.state.set(GCMState::GenerateHashKey);
+            }
+            Some((_res, _, crypt_buf)) => {
+                self.crypt_buf.replace(crypt_buf);
+            }
+        }
+
+        self.buf.replace(buf);
+        self.pos.set((aad_offset, message_offset, message_len));
+        Ok(())
+    }
+}
+
+impl<'a, A: AES128<'a> + AES128Ctr + AES128CBC + AES128ECB + AES128CCM<'a>>
+    symmetric_encryption::CCMClient for Aes128Gcm<'a, A>
+{
+    fn crypt_done(&self, buf: &'static mut [u8], res: Result<(), ErrorCode>, tag_is_valid: bool) {
+        self.ccm_client.map(move |client| {
+            client.crypt_done(buf, res, tag_is_valid);
+        });
+    }
+}
+
+impl<'a, A: AES128<'a> + AES128Ctr + AES128CBC + AES128ECB + AES128CCM<'a>>
+    symmetric_encryption::AES128GCM<'a> for Aes128Gcm<'a, A>
+{
+    fn set_client(&self, client: &'a dyn symmetric_encryption::GCMClient) {
+        self.gcm_client.set(client);
+    }
+
+    fn set_key(&self, key: &[u8]) -> Result<(), ErrorCode> {
+        if key.len() < AES128_KEY_SIZE {
+            Err(ErrorCode::INVAL)
+        } else {
+            let mut new_key = [0u8; AES128_KEY_SIZE];
+            new_key.copy_from_slice(key);
+            self.key.set(new_key);
+            Ok(())
+        }
+    }
+
+    fn set_iv(&self, nonce: &[u8]) -> Result<(), ErrorCode> {
+        let mut new_nonce = [0u8; AES128_KEY_SIZE];
+        let len = nonce.len().min(12);
+
+        new_nonce[0..len].copy_from_slice(&nonce[0..len]);
+        new_nonce[12..16].copy_from_slice(&[0, 0, 0, 1]);
+
+        self.iv.set(new_nonce);
+        Ok(())
+    }
+
+    fn crypt(
+        &self,
+        buf: &'static mut [u8],
+        aad_offset: usize,
+        message_offset: usize,
+        message_len: usize,
+        encrypting: bool,
+    ) -> Result<(), (ErrorCode, &'static mut [u8])> {
+        if self.state.get() != GCMState::Idle {
+            return Err((ErrorCode::BUSY, buf));
+        }
+
+        let _ = self
+            .crypt_r(buf, aad_offset, message_offset, message_len, encrypting)
+            .map_err(|(ecode, _)| {
+                self.buf.take().map(|buf| {
+                    self.gcm_client.map(move |client| {
+                        client.crypt_done(buf, Err(ecode), false);
+                    });
+                });
+            });
+
+        Ok(())
+    }
+}
+
+impl<'a, A: AES128<'a> + AES128Ctr + AES128CBC + AES128ECB + AES128CCM<'a>>
+    symmetric_encryption::AES128<'a> for Aes128Gcm<'a, A>
+{
+    fn enable(&self) {
+        self.aes.enable();
+    }
+
+    fn disable(&self) {
+        self.aes.disable();
+    }
+
+    fn set_client(&'a self, client: &'a dyn symmetric_encryption::Client<'a>) {
+        self.client.set(client);
+    }
+
+    fn set_key(&self, key: &[u8]) -> Result<(), ErrorCode> {
+        AES128::set_key(self.aes, key)
+    }
+
+    fn set_iv(&self, iv: &[u8]) -> Result<(), ErrorCode> {
+        self.aes.set_iv(iv)
+    }
+
+    fn start_message(&self) {
+        self.aes.start_message()
+    }
+
+    fn crypt(
+        &self,
+        source: Option<&'static mut [u8]>,
+        dest: &'static mut [u8],
+        start_index: usize,
+        stop_index: usize,
+    ) -> Option<(
+        Result<(), ErrorCode>,
+        Option<&'static mut [u8]>,
+        &'static mut [u8],
+    )> {
+        AES128::crypt(self.aes, source, dest, start_index, stop_index)
+    }
+}
+
+impl<'a, A: AES128<'a> + AES128Ctr + AES128CBC + AES128ECB + AES128CCM<'a> + AES128CCM<'a>>
+    symmetric_encryption::AES128CCM<'a> for Aes128Gcm<'a, A>
+{
+    fn set_client(&'a self, client: &'a dyn symmetric_encryption::CCMClient) {
+        self.ccm_client.set(client);
+    }
+
+    fn set_key(&self, key: &[u8]) -> Result<(), ErrorCode> {
+        AES128CCM::set_key(self.aes, key)
+    }
+
+    fn set_nonce(&self, nonce: &[u8]) -> Result<(), ErrorCode> {
+        self.aes.set_nonce(nonce)
+    }
+
+    fn crypt(
+        &self,
+        buf: &'static mut [u8],
+        a_off: usize,
+        m_off: usize,
+        m_len: usize,
+        mic_len: usize,
+        confidential: bool,
+        encrypting: bool,
+    ) -> Result<(), (ErrorCode, &'static mut [u8])> {
+        AES128CCM::crypt(
+            self.aes,
+            buf,
+            a_off,
+            m_off,
+            m_len,
+            mic_len,
+            confidential,
+            encrypting,
+        )
+    }
+}
+
+impl<'a, A: AES128<'a> + AES128Ctr + AES128CBC + AES128ECB + AES128CCM<'a>> AES128Ctr
+    for Aes128Gcm<'a, A>
+{
+    fn set_mode_aes128ctr(&self, encrypting: bool) -> Result<(), ErrorCode> {
+        self.aes.set_mode_aes128ctr(encrypting)
+    }
+}
+
+impl<'a, A: AES128<'a> + AES128Ctr + AES128CBC + AES128ECB + AES128CCM<'a>> AES128ECB
+    for Aes128Gcm<'a, A>
+{
+    fn set_mode_aes128ecb(&self, encrypting: bool) -> Result<(), ErrorCode> {
+        self.aes.set_mode_aes128ecb(encrypting)
+    }
+}
+
+impl<'a, A: AES128<'a> + AES128Ctr + AES128CBC + AES128ECB + AES128CCM<'a>> AES128CBC
+    for Aes128Gcm<'a, A>
+{
+    fn set_mode_aes128cbc(&self, encrypting: bool) -> Result<(), ErrorCode> {
+        self.aes.set_mode_aes128cbc(encrypting)
+    }
+}
+
+impl<'a, A: AES128<'a> + AES128Ctr + AES128CBC + AES128ECB + AES128CCM<'a>>
+    symmetric_encryption::Client<'a> for Aes128Gcm<'a, A>
+{
+    fn crypt_done(&self, _: Option<&'static mut [u8]>, crypt_buf: &'static mut [u8]) {
+        match self.state.get() {
+            GCMState::Idle => unreachable!(),
+            GCMState::GenerateHashKey => {
+                let (aad_offset, message_offset, message_len) = self.pos.get();
+
+                let mut mac = GHash::new(Key::from_slice(&crypt_buf[0..AES128_BLOCK_SIZE]));
+                let buf = self.buf.take().unwrap();
+
+                if self.encrypting.get() {
+                    mac.update_padded(&buf[aad_offset..message_offset]);
+
+                    crypt_buf[AES128_BLOCK_SIZE..(AES128_BLOCK_SIZE + message_len)]
+                        .copy_from_slice(&buf[message_offset..(message_offset + message_len)]);
+                    for i in 0..AES128_BLOCK_SIZE {
+                        crypt_buf[i] = 0;
+                    }
+
+                    self.mac.replace(mac);
+                } else {
+                    let copy_offset = (message_offset / AES128_BLOCK_SIZE) * AES128_BLOCK_SIZE;
+                    mac.update_padded(&buf[aad_offset..message_offset]);
+                    mac.update_padded(&buf[message_offset..(message_offset + message_len)]);
+
+                    let associated_data_bits = ((message_offset - aad_offset) as u64) * 8;
+                    let buffer_bits = (message_len as u64) * 8;
+
+                    let mut block = ghash::Block::default();
+                    block[..8].copy_from_slice(&associated_data_bits.to_be_bytes());
+                    block[8..].copy_from_slice(&buffer_bits.to_be_bytes());
+                    mac.update(&block);
+
+                    let mut tag = mac.finalize().into_bytes();
+
+                    for i in 0..AES128_BLOCK_SIZE {
+                        tag[i] = tag[i] ^ crypt_buf[copy_offset + i];
+                    }
+
+                    buf[0..AES128_BLOCK_SIZE].copy_from_slice(&tag);
+                }
+                self.crypt_buf.replace(crypt_buf);
+                self.buf.replace(buf);
+
+                self.start_ctr_encrypt().unwrap();
+            }
+            GCMState::CtrEncrypt => {
+                let buf = self.buf.take().unwrap();
+                let (aad_offset, message_offset, message_len) = self.pos.get();
+                let tag_offset = (message_offset / AES128_BLOCK_SIZE) * AES128_BLOCK_SIZE;
+                let copy_offset = (message_offset / AES128_BLOCK_SIZE).max(1) * AES128_BLOCK_SIZE;
+
+                if self.encrypting.get() {
+                    // Check the mac
+                    let mut mac = self.mac.take().unwrap();
+                    mac.update_padded(
+                        &crypt_buf[(message_offset + AES128_BLOCK_SIZE)
+                            ..(message_offset + message_len + AES128_BLOCK_SIZE)],
+                    );
+
+                    buf[0..message_len]
+                        .copy_from_slice(&crypt_buf[copy_offset..(copy_offset + message_len)]);
+
+                    let associated_data_bits = ((message_offset - aad_offset) as u64) * 8;
+                    let buffer_bits = (message_len as u64) * 8;
+
+                    let mut block = ghash::Block::default();
+                    block[..8].copy_from_slice(&associated_data_bits.to_be_bytes());
+                    block[8..].copy_from_slice(&buffer_bits.to_be_bytes());
+                    mac.update(&block);
+
+                    let mut tag = mac.finalize().into_bytes();
+
+                    for i in 0..AES128_BLOCK_SIZE {
+                        tag[i] = tag[i] ^ crypt_buf[tag_offset + i];
+                    }
+
+                    buf[(message_offset + message_len)
+                        ..(message_offset + message_len + AES128_BLOCK_SIZE)]
+                        .copy_from_slice(&tag);
+                } else {
+                    buf[0..message_len]
+                        .copy_from_slice(&crypt_buf[copy_offset..(copy_offset + message_len)]);
+                }
+
+                self.aes.disable();
+                self.crypt_buf.replace(crypt_buf);
+                self.state.set(GCMState::Idle);
+                self.gcm_client.map(move |client| {
+                    client.crypt_done(buf, Ok(()), true);
+                });
+            }
+        }
+    }
+}

--- a/capsules/aes_gcm/src/lib.rs
+++ b/capsules/aes_gcm/src/lib.rs
@@ -1,0 +1,8 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Western Digital 2023.
+
+#![forbid(unsafe_code)]
+#![no_std]
+
+pub mod aes_gcm;

--- a/capsules/extra/src/symmetric_encryption/aes.rs
+++ b/capsules/extra/src/symmetric_encryption/aes.rs
@@ -12,7 +12,8 @@ use core::cell::Cell;
 
 use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
 use kernel::hil::symmetric_encryption::{
-    AES128Ctr, CCMClient, Client, AES128, AES128CBC, AES128CCM, AES128ECB, AES128_BLOCK_SIZE,
+    AES128Ctr, CCMClient, Client, GCMClient, AES128, AES128CBC, AES128CCM, AES128ECB, AES128GCM,
+    AES128_BLOCK_SIZE,
 };
 use kernel::processbuffer::{ReadableProcessBuffer, WriteableProcessBuffer};
 use kernel::syscall::{CommandReturn, SyscallDriver};
@@ -35,7 +36,7 @@ mod rw_allow {
     pub const COUNT: u8 = 1;
 }
 
-pub struct AesDriver<'a, A: AES128<'a> + AES128CCM<'static>> {
+pub struct AesDriver<'a, A: AES128<'a> + AES128CCM<'static> + AES128GCM<'static>> {
     aes: &'a A,
 
     active: Cell<bool>,
@@ -53,8 +54,15 @@ pub struct AesDriver<'a, A: AES128<'a> + AES128CCM<'static>> {
     dest_buffer: TakeCell<'static, [u8]>,
 }
 
-impl<'a, A: AES128<'static> + AES128Ctr + AES128CBC + AES128ECB + AES128CCM<'static>>
-    AesDriver<'static, A>
+impl<
+        'a,
+        A: AES128<'static>
+            + AES128Ctr
+            + AES128CBC
+            + AES128ECB
+            + AES128CCM<'static>
+            + AES128GCM<'static>,
+    > AesDriver<'static, A>
 {
     pub fn new(
         aes: &'static A,
@@ -95,6 +103,7 @@ impl<'a, A: AES128<'static> + AES128Ctr + AES128CBC + AES128ECB + AES128CCM<'sta
                                 self.aes.set_mode_aes128ecb(*encrypt)
                             }
                             AesOperation::AES128CCM(_encrypt) => Ok(()),
+                            AesOperation::AES128GCM(_encrypt) => Ok(()),
                         }
                     } else {
                         Err(ErrorCode::INVAL)
@@ -136,6 +145,12 @@ impl<'a, A: AES128<'static> + AES128Ctr + AES128CBC + AES128ECB + AES128CCM<'sta
                                                 }
                                                 Ok(())
                                             }
+                                            AesOperation::AES128GCM(_) => {
+                                                if let Err(e) = AES128GCM::set_key(self.aes, buf) {
+                                                    return Err(e);
+                                                }
+                                                Ok(())
+                                            }
                                         }
                                     } else {
                                         Err(ErrorCode::FAIL)
@@ -167,13 +182,23 @@ impl<'a, A: AES128<'static> + AES128Ctr + AES128CBC + AES128ECB + AES128CCM<'sta
                                             AesOperation::AES128Ctr(_)
                                             | AesOperation::AES128CBC(_)
                                             | AesOperation::AES128ECB(_) => {
-                                                if let Err(e) = self.aes.set_iv(buf) {
+                                                if let Err(e) = AES128::set_iv(self.aes, buf) {
                                                     return Err(e);
                                                 }
                                                 Ok(())
                                             }
                                             AesOperation::AES128CCM(_) => {
-                                                if let Err(e) = self.aes.set_nonce(&buf[0..13]) {
+                                                if let Err(e) =
+                                                    AES128CCM::set_nonce(self.aes, &buf[0..13])
+                                                {
+                                                    return Err(e);
+                                                }
+                                                Ok(())
+                                            }
+                                            AesOperation::AES128GCM(_) => {
+                                                if let Err(e) =
+                                                    AES128GCM::set_iv(self.aes, &buf[0..13])
+                                                {
                                                     return Err(e);
                                                 }
                                                 Ok(())
@@ -220,6 +245,28 @@ impl<'a, A: AES128<'static> + AES128Ctr + AES128CBC + AES128ECB + AES128CCM<'sta
                                             )?;
                                         }
                                         AesOperation::AES128CCM(_) => {
+                                            self.dest_buffer.map_or(
+                                                Err(ErrorCode::NOMEM),
+                                                |buf| {
+                                                    // Determine the size of the static buffer we have
+                                                    static_buffer_len = buf.len();
+
+                                                    if static_buffer_len > source.len() {
+                                                        static_buffer_len = source.len()
+                                                    }
+
+                                                    // Copy the data into the static buffer
+                                                    source[..static_buffer_len].copy_to_slice(
+                                                        &mut buf[..static_buffer_len],
+                                                    );
+
+                                                    self.data_copied.set(static_buffer_len);
+
+                                                    Ok(())
+                                                },
+                                            )?;
+                                        }
+                                        AesOperation::AES128GCM(_) => {
                                             self.dest_buffer.map_or(
                                                 Err(ErrorCode::NOMEM),
                                                 |buf| {
@@ -325,6 +372,22 @@ impl<'a, A: AES128<'static> + AES128Ctr + AES128CBC + AES128ECB + AES128CCM<'sta
                     return Err(ErrorCode::FAIL);
                 }
             }
+            AesOperation::AES128GCM(encrypting) => {
+                if let Some(buf) = self.dest_buffer.take() {
+                    if let Err((e, dest)) =
+                        AES128GCM::crypt(self.aes, buf, aoff, moff, mlen, *encrypting)
+                    {
+                        // Error, clear the appid and data
+                        self.aes.disable();
+                        self.processid.clear();
+                        self.dest_buffer.replace(dest);
+
+                        return Err(e);
+                    }
+                } else {
+                    return Err(ErrorCode::FAIL);
+                }
+            }
         }
 
         Ok(())
@@ -353,8 +416,15 @@ impl<'a, A: AES128<'static> + AES128Ctr + AES128CBC + AES128ECB + AES128CCM<'sta
     }
 }
 
-impl<'a, A: AES128<'static> + AES128Ctr + AES128CBC + AES128ECB + AES128CCM<'static>>
-    Client<'static> for AesDriver<'static, A>
+impl<
+        'a,
+        A: AES128<'static>
+            + AES128Ctr
+            + AES128CBC
+            + AES128ECB
+            + AES128CCM<'static>
+            + AES128GCM<'static>,
+    > Client<'static> for AesDriver<'static, A>
 {
     fn crypt_done(&'a self, source: Option<&'static mut [u8]>, destination: &'static mut [u8]) {
         if let Some(source_buf) = source {
@@ -504,8 +574,15 @@ impl<'a, A: AES128<'static> + AES128Ctr + AES128CBC + AES128ECB + AES128CCM<'sta
     }
 }
 
-impl<'a, A: AES128<'static> + AES128Ctr + AES128CBC + AES128ECB + AES128CCM<'static>> CCMClient
-    for AesDriver<'static, A>
+impl<
+        'a,
+        A: AES128<'static>
+            + AES128Ctr
+            + AES128CBC
+            + AES128ECB
+            + AES128CCM<'static>
+            + AES128GCM<'static>,
+    > CCMClient for AesDriver<'static, A>
 {
     fn crypt_done(&self, buf: &'static mut [u8], res: Result<(), ErrorCode>, tag_is_valid: bool) {
         self.dest_buffer.replace(buf);
@@ -575,8 +652,93 @@ impl<'a, A: AES128<'static> + AES128Ctr + AES128CBC + AES128ECB + AES128CCM<'sta
     }
 }
 
-impl<'a, A: AES128<'static> + AES128Ctr + AES128CBC + AES128ECB + AES128CCM<'static>> SyscallDriver
-    for AesDriver<'static, A>
+impl<
+        'a,
+        A: AES128<'static>
+            + AES128Ctr
+            + AES128CBC
+            + AES128ECB
+            + AES128CCM<'static>
+            + AES128GCM<'static>,
+    > GCMClient for AesDriver<'static, A>
+{
+    fn crypt_done(&self, buf: &'static mut [u8], res: Result<(), ErrorCode>, tag_is_valid: bool) {
+        self.dest_buffer.replace(buf);
+
+        self.processid.map(|id| {
+            self.apps
+                .enter(*id, |_, kernel_data| {
+                    let mut exit = false;
+
+                    if let Err(e) = res {
+                        kernel_data.schedule_upcall(0, (e as usize, 0, 0)).ok();
+                        return;
+                    }
+
+                    self.dest_buffer.map(|buf| {
+                        let ret = kernel_data
+                            .get_readwrite_processbuffer(rw_allow::DEST)
+                            .and_then(|dest| {
+                                dest.mut_enter(|dest| {
+                                    let offset = self.data_copied.get()
+                                        - (core::cmp::min(buf.len(), dest.len()));
+                                    let app_len = dest.len();
+                                    let static_len = buf.len();
+
+                                    if app_len < static_len {
+                                        if app_len - offset > 0 {
+                                            dest[offset..app_len]
+                                                .copy_from_slice(&buf[0..(app_len - offset)]);
+                                        }
+                                    } else {
+                                        if offset + static_len <= app_len {
+                                            dest[offset..(offset + static_len)]
+                                                .copy_from_slice(&buf[0..static_len]);
+                                        }
+                                    }
+                                })
+                            });
+
+                        if let Err(e) = ret {
+                            // No data buffer, clear the appid and data
+                            self.aes.disable();
+                            self.processid.clear();
+                            kernel_data.schedule_upcall(0, (e as usize, 0, 0)).ok();
+                            exit = true;
+                        }
+                    });
+
+                    if exit {
+                        return;
+                    }
+
+                    // AES GCM is online only we can't send any more data in, so
+                    // just report what we did to the app.
+                    kernel_data
+                        .schedule_upcall(0, (0, self.data_copied.get(), tag_is_valid as usize))
+                        .ok();
+                    self.data_copied.set(0);
+                })
+                .map_err(|err| {
+                    if err == kernel::process::Error::NoSuchApp
+                        || err == kernel::process::Error::InactiveApp
+                    {
+                        self.processid.clear();
+                    }
+                })
+        });
+    }
+}
+
+impl<
+        'a,
+        A: AES128<'static>
+            + AES128Ctr
+            + AES128CBC
+            + AES128ECB
+            + AES128CCM<'static>
+            + AES128GCM<'static>,
+    > SyscallDriver for AesDriver<'static, A>
 {
     fn command(
         &self,
@@ -672,6 +834,10 @@ impl<'a, A: AES128<'static> + AES128Ctr + AES128CBC + AES128ECB + AES128CCM<'sta
                         }
                         3 => {
                             app.aes_operation = Some(AesOperation::AES128CCM(data2 != 0));
+                            CommandReturn::success()
+                        }
+                        4 => {
+                            app.aes_operation = Some(AesOperation::AES128GCM(data2 != 0));
                             CommandReturn::success()
                         }
                         _ => CommandReturn::failure(ErrorCode::NOSUPPORT),
@@ -830,6 +996,7 @@ enum AesOperation {
     AES128CBC(bool),
     AES128ECB(bool),
     AES128CCM(bool),
+    AES128GCM(bool),
 }
 
 #[derive(Default)]

--- a/capsules/extra/src/test/aes_gcm.rs
+++ b/capsules/extra/src/test/aes_gcm.rs
@@ -25,7 +25,7 @@ pub struct Test<'a, A: AES128GCM<'a>> {
         &'static [u8],
         &'static [u8],
         &'static [u8],
-    ); 3],
+    ); 2],
 }
 
 impl<'a, A: AES128GCM<'a>> Test<'a, A> {
@@ -36,7 +36,6 @@ impl<'a, A: AES128GCM<'a>> Test<'a, A> {
             current_test: Cell::new(0),
             encrypting: Cell::new(true),
             tests: [
-                (&KEY_128_ZERO, &IV_128_ZERO, &[], &[], &[], &TAG_128_ZERO),
                 (
                     &KEY_128_TWELVE,
                     &IV_128_TWELVE,
@@ -190,18 +189,6 @@ impl<'a, A: AES128GCM<'a>> GCMClient for Test<'a, A> {
         }
     }
 }
-
-static KEY_128_ZERO: [u8; AES128_KEY_SIZE] = [
-    0x11, 0x75, 0x4c, 0xd7, 0x2a, 0xec, 0x30, 0x9b, 0xf5, 0x2f, 0x76, 0x87, 0x21, 0x2e, 0x89, 0x57,
-];
-
-static IV_128_ZERO: [u8; 12] = [
-    0x3c, 0x81, 0x9d, 0x9a, 0x9b, 0xed, 0x08, 0x76, 0x15, 0x03, 0x0b, 0x65,
-];
-
-static TAG_128_ZERO: [u8; AES128_KEY_SIZE] = [
-    0x25, 0x03, 0x27, 0xc6, 0x74, 0xaa, 0xf4, 0x77, 0xae, 0xf2, 0x67, 0x57, 0x48, 0xcf, 0x69, 0x71,
-];
 
 static KEY_128_TWELVE: [u8; AES128_KEY_SIZE] = [
     0x26, 0x73, 0x0f, 0x1a, 0xd2, 0x4b, 0x76, 0xd6, 0x6f, 0x7a, 0xb8, 0x45, 0x9d, 0xdc, 0xd1, 0x17,


### PR DESCRIPTION
### Pull Request Overview

This PR adds a new aes_gcm capsule. This capsule exposes [AES-GCM](https://en.wikipedia.org/wiki/AES-GCM-SIV) support if the hardware doesn't actually have it.

We implement AES GCM using other supported AES operations and with a software implementation of ghash.

This is similar to the existing virtual_aes_ccm capsule, except without virtulisation.

AES-GCM is commonly used in [TLS](https://blog.mozilla.org/security/2017/09/29/improving-aes-gcm-performance/). It isn't commonly used in embedded systems, but it's still a good example I think.

### Testing Strategy

Running the OpenTitan tests

### TODO or Help Wanted

This PR adds an external dependency!

This PR adds a dependency on the [ghash crate](https://github.com/RustCrypto/universal-hashes/tree/master/ghash) as part of Rust-crypto.

We are seeing more and more requirements for cryptographic operations in Tock, which means we are also seeing more and more software implementations of them.

Tock already has a SHA256 and CRC32 software implementation. It's not unreasonable that RSA becomes more common with the cryptographic app IDs as well.

I wanted to start the discussion about allowing Rust-crypto crates as capsules. Re-implementing a crypto library ourselves seem very risky, so if we do want software implementations Rust-crypto would be the way to go. I'm not convinced one way or the other, I just wanted to get some feedback on how people feel.

The Rust-crypto crates are well respected, have been audited and match the Tock software license

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
