### PR TITLE
chips/lowrisc: spi_host: fixup rw1c functionality

### DIFF
--- a/chips/lowrisc/src/spi_host.rs
+++ b/chips/lowrisc/src/spi_host.rs
@@ -15,7 +15,7 @@ use kernel::ErrorCode;
 
 register_structs! {
     pub SpiHostRegisters {
-        //SPI: Interrupt State Register
+        //SPI: Interrupt State Register, type rw1c
         (0x000 => intr_state: ReadWrite<u32, intr::Register>),
         //SPI: Interrupt Enable Register
         (0x004 => intr_enable: ReadWrite<u32, intr::Register>),
@@ -39,7 +39,7 @@ register_structs! {
         (0x028 => tx_data: WriteOnly<u32, tx_data::Register>),
         //SPI: Controls which classes of errors raise an interrupt.
         (0x02c => err_en: ReadWrite<u32, err_en::Register>),
-        //SPI: Indicates that any errors that have occurred
+        //SPI: Indicates that any errors that have occurred, type rw1c
         (0x030 => err_status: ReadWrite<u32, err_status::Register>),
         //SPI: Controls which classes of SPI events raise an interrupt
         (0x034 => event_en: ReadWrite<u32, event_en::Register>),
@@ -376,21 +376,21 @@ impl SpiHost {
     /// Clear the error IRQ
     fn clear_err_interrupt(&self) {
         let regs = self.registers;
-        //Clear Error Masks
-        regs.err_status.modify(err_status::CMDBUSY::CLEAR);
-        regs.err_status.modify(err_status::OVERFLOW::CLEAR);
-        regs.err_status.modify(err_status::UNDERFLOW::CLEAR);
-        regs.err_status.modify(err_status::CMDINVAL::CLEAR);
-        regs.err_status.modify(err_status::CSIDINVAL::CLEAR);
-        regs.err_status.modify(err_status::ACCESSINVAL::CLEAR);
+        //Clear Error Masks (rw1c)
+        regs.err_status.modify(err_status::CMDBUSY::SET);
+        regs.err_status.modify(err_status::OVERFLOW::SET);
+        regs.err_status.modify(err_status::UNDERFLOW::SET);
+        regs.err_status.modify(err_status::CMDINVAL::SET);
+        regs.err_status.modify(err_status::CSIDINVAL::SET);
+        regs.err_status.modify(err_status::ACCESSINVAL::SET);
         //Clear Error IRQ
-        regs.intr_state.modify(intr::ERROR::CLEAR);
+        regs.intr_state.modify(intr::ERROR::SET);
     }
 
     /// Clear the event IRQ
     fn clear_event_interrupt(&self) {
         let regs = self.registers;
-        regs.intr_state.modify(intr::SPI_EVENT::CLEAR);
+        regs.intr_state.modify(intr::SPI_EVENT::SET);
     }
     /// Will generate a `test` interrupt on the error irq
     /// Note: Left to allow debug accessibility
@@ -484,10 +484,6 @@ impl hil::spi::SpiMaster for SpiHost {
     type ChipSelect = u32;
 
     fn init(&self) -> Result<(), ErrorCode> {
-        //TODO: Mainline Qemu needs to be patched to supported the
-        // upto-date base addresses of spi_host. Otherwise, a store-access
-        // will occur in qemu-ci at board init.
-        // This should be removed when qemu is patched.
         let regs = self.registers;
         self.event_enable();
         self.err_enable();


### PR DESCRIPTION
### Pull Request Overview

This patch fixes writes to the two `rw1c` status registers. As per OpenTitan, SPI_HOST spec [[1]](https://docs.opentitan.org/hw/ip/spi_host/doc/)

Additionally, removes an outdated comment regarding QEMU version. As the current 
commit hash of QEMU (used for tock) supports the desired functionality. 

### Testing Strategy

`make test` on boards/opentitan/earlgrey-cw310/

### TODO or Help Wanted

N/A

### Documentation Updated

- [x] N/A

### Formatting

- [x] Ran `make prepush`.
