### PR TITLE
Enable all storage on nRF52840-DK #3098

### DIFF
--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -567,10 +567,10 @@ pub unsafe fn main() {
         board_kernel,
         capsules::nonvolatile_storage_driver::DRIVER_NUM,
         mx25r6435f,
-        0x60000, // Start address for userspace accessible region
-        0x20000, // Length of userspace accessible region
-        0,       // Start address of kernel region
-        0x60000, // Length of kernel region
+        0x60000,   // Start address for userspace accessible region
+        0x3FA0000, // Length of userspace accessible region
+        0,         // Start address of kernel region
+        0x60000,   // Length of kernel region
     )
     .finalize(components::nv_storage_component_helper!(
         capsules::mx25r6435f::MX25R6435F<


### PR DESCRIPTION
### Pull Request Overview

This PR increases the userspace storage of the nRF52840-DK (re #3098) to use all of the available external flash on the board. New flash regions are as follows:

Kernel: 0-0x60000 (384 Kb)
Userspace: 0x60000-0x4000000 (63.625 Mb)
For a total of 64Mb.

### Testing Strategy

I built and installed the kernel on my nRF52740-DK, and used the  [nonvolatile storage test application](https://github.com/tock/libtock-c/tree/master/examples/tests/nonvolatile_storage) to see how much storage is reported. All tests suceeded, and the correct amount of storage (66715648 bytes, 63.625Mb) is reported.


### TODO or Help Wanted

Regarding testing, ideally there would be a test application to ensure all the flash is functioning correctly, instead of only 512 bytes. 

### Documentation Updated

- [x] N/A

### Formatting

- [x] Ran `make prepush`.
