### PR TITLE
Initial VirtIO support for VirtIO Net & RNG on `qemu_rv32_virt` target

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ members = [
     "chips/stm32f4xx",
     "chips/swerv",
     "chips/swervolf-eh1",
+    "chips/virtio",
     "kernel",
     "libraries/enum_primitive",
     "libraries/riscv-csr",

--- a/boards/qemu_rv32_virt/Makefile
+++ b/boards/qemu_rv32_virt/Makefile
@@ -31,6 +31,7 @@ run: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin
 	@echo
 	qemu-system-riscv32 \
 	  -machine virt \
+	  -semihosting \
 	  -bios $^ \
 	  -global virtio-mmio.force-legacy=false \
 	  -device virtio-rng-device \
@@ -52,6 +53,7 @@ run-app: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
 	@echo
 	qemu-system-riscv32 \
 	  -machine virt \
+	  -semihosting \
 	  -bios $^ \
 	  -global virtio-mmio.force-legacy=false \
 	  -device virtio-rng-device \

--- a/boards/qemu_rv32_virt/Makefile
+++ b/boards/qemu_rv32_virt/Makefile
@@ -1,61 +1,93 @@
 # Makefile for building the Tock kernel for the qemu-system-riscv32 `virt`
 # platform / machine type.
 
-TARGET=riscv32imac-unknown-none-elf
-PLATFORM=qemu_rv32_virt
+TARGET   = riscv32imac-unknown-none-elf
+PLATFORM = qemu_rv32_virt
 
 include ../Makefile.common
 
-WORKING_QEMU_VERSION=7.0.0
+QEMU_CMD             := qemu-system-riscv32
+WORKING_QEMU_VERSION := 7.0.0
 
-# Run the kernel inside a qemu-riscv32-system "virt" machine type simulation
+# Whether a VirtIO network device shall be attached to the QEMU
+# machine, and which backend should be used. The following options are
+# available:
 #
+# - NETDEV: SLIRP
+#
+#   Use the QEMU userspace slirp network backend. This causes QEMU to
+#   behave as a NAT-router and gateway to the VM, transparently
+#   routing any outgoing traffic through the host's userspace network
+#   sockets. This option also accepts an optional NETDEV_SLIRP_ARGS
+#   which is appended to the provided string.
+#
+# - NETDEV: TAP
+#
+#   Creates a TAP network interface to act as a layer-2 Ethernet
+#   connection between the guest interface and the host. Must have the
+#   proper permissions to let QEMU create the tap interface on the
+#   host. Use SUDO-TAP instead to run QEMU through `sudo`.
+NETDEV            ?= NONE
+ifneq ($(NETDEV_SLIRP_ARGS),)
+  NETDEV_SLIRP_ARGS := ,$(NETDEV_SLIRP_ARGS)
+else
+  NETDEV_SLIRP_ARGS :=
+endif
+
+ifeq ($(NETDEV),NONE)
+  QEMU_NETDEV_CMDLINE = ""
+else ifeq ($(NETDEV),SLIRP)
+  QEMU_NETDEV_CMDLINE = \
+    -netdev user,id=n0,net=192.168.1.0/24,dhcpstart=192.168.1.255$(NETDEV_SLIRP_ARGS) \
+    -device virtio-net-device,netdev=n0
+else ifneq (,$(filter $(NETDEV),TAP SUDO-TAP))
+  QEMU_NETDEV_CMDLINE = \
+    -netdev tap,id=n0,script=no,downscript=no \
+    -device virtio-net-device,netdev=n0
+  ifeq ($(NETDEV),SUDO-TAP)
+    QEMU_CMD := sudo $(QEMU_CMD)
+  endif
+else
+  $(error Invalid argument provided for variable NETDEV)
+endif
+
 # Peripherals attached by default:
 # - 16550 UART (attached to stdio by default)
 # - VirtIO EntropySource (default backend /dev/random)
-#
-# By default a VirtIO NetworkCard is _not_ attached, since creating a TAP device
-# on the host will require root or further system configuration. The
-# configuration options to enable the network card are included as comments.
-#
-# Requires that a qemu-riscv32-system binary is in the user's PATH. The tested &
-# verified QEMU version is printed along with the one used. No actual version
-# check is performed given the simulation might work with different version,
-# though should at leat work on the tested one.
-.PHONY: run
-run: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin
+QEMU_BASE_CMDLINE := \
+  $(QEMU_CMD) \
+    -machine virt \
+    -semihosting \
+    -global virtio-mmio.force-legacy=false \
+    -device virtio-rng-device \
+    $(QEMU_NETDEV_CMDLINE) \
+    -nographic
+
+# Some helpful instructions & information. Requires that a qemu-riscv32-system
+# binary is in the user's PATH. The tested & verified QEMU version is printed
+# along with the one used. No actual version check is performed given the
+# simulation might work with different version, though should at leat work on
+# the tested one.
+.PHONY: qemu-usage-instructions
+qemu-usage-instructions:
 	@echo
 	@echo -e "Running $$(qemu-system-riscv32 --version | head -n1)" \
-	  "(tested: $(WORKING_QEMU_VERSION)) with\n  - kernel $^"
+	  "(tested: $(WORKING_QEMU_VERSION)) with\n" \
+          " - kernel $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf"
+	@test "\"$(APP)\" != \"\"" && echo -e "  - app $(APP)"
 	@echo "To exit type C-a x"
 	@echo
-	qemu-system-riscv32 \
-	  -machine virt \
-	  -semihosting \
-	  -bios $^ \
-	  -global virtio-mmio.force-legacy=false \
-	  -device virtio-rng-device \
-	  -nographic
-	  @# attaching a TAP network device requires proper permissions
-	  @# to create a tuntap device or access to an existing device
-	  @# -netdev tap,id=n0,script=no,downscript=no
-	  @# -device virtio-net-device,netdev=n0
+
+# Run the kernel inside a qemu-riscv32-system "virt" machine type simulation
+.PHONY: run
+run: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf qemu-usage-instructions
+	$(QEMU_BASE_CMDLINE) \
+	  -bios $<
 
 # Same as `run`, but load an application specified by $(APP) into the respective
 # memory location.
 .PHONY: run-app
-run-app: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
-	@echo
-	@echo -e "Running $$(qemu-system-riscv32 --version | head -n1)" \
-	  "(tested: $(WORKING_QEMU_VERSION))"\
-	  "with\n  - kernel $^\n  - app $(APP)"
-	@echo "To exit type C-a x"
-	@echo
-	qemu-system-riscv32 \
-	  -machine virt \
-	  -semihosting \
-	  -bios $^ \
-	  -global virtio-mmio.force-legacy=false \
-	  -device virtio-rng-device \
-	  -device loader,file=$(APP),addr=0x80100000 \
-	  -nographic
+run-app: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf qemu-usage-instructions
+	$(QEMU_BASE_CMDLINE) \
+	  -bios $< \
+	  -device loader,file=$(APP),addr=0x80100000

--- a/boards/qemu_rv32_virt/src/main.rs
+++ b/boards/qemu_rv32_virt/src/main.rs
@@ -40,7 +40,7 @@ const FAULT_RESPONSE: kernel::process::PanicFaultPolicy = kernel::process::Panic
 /// Dummy buffer that causes the linker to reserve enough space for the stack.
 #[no_mangle]
 #[link_section = ".stack_buffer"]
-pub static mut STACK_MEMORY: [u8; 0x2000] = [0; 0x2000];
+pub static mut STACK_MEMORY: [u8; 0x8000] = [0; 0x8000];
 
 /// A structure representing this platform that holds references to all
 /// capsules for this platform. We've included an alarm and console.
@@ -59,6 +59,7 @@ struct QemuRv32VirtPlatform {
     scheduler_timer: &'static VirtualSchedulerTimer<
         VirtualMuxAlarm<'static, qemu_rv32_virt_chip::chip::QemuRv32VirtClint<'static>>,
     >,
+    virtio_rng: Option<&'static capsules::rng::RngDriver<'static>>,
 }
 
 /// Mapping of integer syscalls to objects that implement syscalls.
@@ -71,6 +72,13 @@ impl SyscallDriverLookup for QemuRv32VirtPlatform {
             capsules::console::DRIVER_NUM => f(Some(self.console)),
             capsules::alarm::DRIVER_NUM => f(Some(self.alarm)),
             capsules::low_level_debug::DRIVER_NUM => f(Some(self.lldb)),
+            capsules::rng::DRIVER_NUM => {
+                if let Some(rng_driver) = self.virtio_rng {
+                    f(Some(rng_driver))
+                } else {
+                    f(None)
+                }
+            }
             kernel::ipc::DRIVER_NUM => f(Some(&self.ipc)),
             _ => f(None),
         }
@@ -210,7 +218,180 @@ pub unsafe fn main() {
     );
     hil::time::Alarm::set_alarm_client(virtual_alarm_user, alarm);
 
+    // ---------- VIRTIO PERIPHERAL DISCOVERY ----------
+    //
+    // This board has 8 virtio-mmio (v2 personality required!) devices
+    //
+    // Collect supported VirtIO peripheral indicies and initialize them if they
+    // are found. If there are two instances of a supported peripheral, the one
+    // on a higher-indexed VirtIO transport is used.
+    let (mut virtio_net_idx, mut virtio_rng_idx) = (None, None);
+    for (i, virtio_device) in peripherals.virtio_mmio.iter().enumerate() {
+        use qemu_rv32_virt_chip::virtio::devices::VirtIODeviceType;
+        match virtio_device.query() {
+            Some(VirtIODeviceType::NetworkCard) => {
+                virtio_net_idx = Some(i);
+            }
+            Some(VirtIODeviceType::EntropySource) => {
+                virtio_rng_idx = Some(i);
+            }
+            _ => (),
+        }
+    }
+
+    // If there is a VirtIO EntropySource present, use the appropriate VirtIORng
+    // driver and expose it to userspace though the RngDriver
+    let virtio_rng_driver: Option<&'static capsules::rng::RngDriver<'static>> =
+        if let Some(rng_idx) = virtio_rng_idx {
+            use kernel::hil::rng::Rng;
+            use qemu_rv32_virt_chip::virtio::devices::virtio_rng::VirtIORng;
+            use qemu_rv32_virt_chip::virtio::queues::split_queue::{
+                SplitVirtqueue, VirtqueueAvailableRing, VirtqueueDescriptors, VirtqueueUsedRing,
+            };
+            use qemu_rv32_virt_chip::virtio::queues::Virtqueue;
+            use qemu_rv32_virt_chip::virtio::transports::VirtIOTransport;
+
+            // EntropySource requires a single Virtqueue for retrieved entropy
+            let descriptors =
+                static_init!(VirtqueueDescriptors<1>, VirtqueueDescriptors::default(),);
+            let available_ring =
+                static_init!(VirtqueueAvailableRing<1>, VirtqueueAvailableRing::default(),);
+            let used_ring = static_init!(VirtqueueUsedRing<1>, VirtqueueUsedRing::default(),);
+            let queue = static_init!(
+                SplitVirtqueue<1>,
+                SplitVirtqueue::new(descriptors, available_ring, used_ring),
+            );
+            queue.set_transport(&peripherals.virtio_mmio[rng_idx]);
+
+            // VirtIO EntropySource device driver instantiation
+            let rng = static_init!(VirtIORng, VirtIORng::new(queue, dynamic_deferred_caller));
+            rng.set_deferred_call_handle(
+                dynamic_deferred_caller
+                    .register(rng)
+                    .expect("no deferred call slot available for VirtIO RNG"),
+            );
+            queue.set_client(rng);
+
+            // Register the queues and driver with the transport, so interrupts
+            // are routed properly
+            let mmio_queues = static_init!([&'static dyn Virtqueue; 1], [queue; 1]);
+            peripherals.virtio_mmio[rng_idx]
+                .initialize(rng, mmio_queues)
+                .unwrap();
+
+            // Provide an internal randomness buffer
+            let rng_buffer = static_init!([u8; 64], [0; 64]);
+            rng.provide_buffer(rng_buffer)
+                .expect("rng: providing initial buffer failed");
+
+            // Userspace RNG driver over the VirtIO EntropySource
+            let rng_driver: &'static mut capsules::rng::RngDriver = static_init!(
+                capsules::rng::RngDriver,
+                capsules::rng::RngDriver::new(
+                    rng,
+                    board_kernel.create_grant(capsules::rng::DRIVER_NUM, &memory_allocation_cap),
+                ),
+            );
+            rng.set_client(rng_driver);
+
+            Some(rng_driver as &'static capsules::rng::RngDriver)
+        } else {
+            // No VirtIO EntropySource discovered
+            None
+        };
+
+    // If there is a VirtIO NetworkCard present, use the appropriate VirtIONet
+    // driver. Currently this is not used, as work on the userspace network
+    // driver and kernel network stack is in progress.
+    //
+    // A template dummy driver is provided to verify basic functionality of this
+    // interface.
+    let _virtio_net_if: Option<
+        &'static qemu_rv32_virt_chip::virtio::devices::virtio_net::VirtIONet<'static>,
+    > = if let Some(net_idx) = virtio_net_idx {
+        use qemu_rv32_virt_chip::virtio::devices::virtio_net::VirtIONet;
+        use qemu_rv32_virt_chip::virtio::queues::split_queue::{
+            SplitVirtqueue, VirtqueueAvailableRing, VirtqueueDescriptors, VirtqueueUsedRing,
+        };
+        use qemu_rv32_virt_chip::virtio::queues::Virtqueue;
+        use qemu_rv32_virt_chip::virtio::transports::VirtIOTransport;
+
+        // A VirtIO NetworkCard requires 2 Virtqueues:
+        // - a TX Virtqueue with buffers for outgoing packets
+        // - a RX Virtqueue where incoming packet buffers are
+        //   placed and filled by the device
+
+        // TX Virtqueue
+        let tx_descriptors =
+            static_init!(VirtqueueDescriptors<2>, VirtqueueDescriptors::default(),);
+        let tx_available_ring =
+            static_init!(VirtqueueAvailableRing<2>, VirtqueueAvailableRing::default(),);
+        let tx_used_ring = static_init!(VirtqueueUsedRing<2>, VirtqueueUsedRing::default(),);
+        let tx_queue = static_init!(
+            SplitVirtqueue<2>,
+            SplitVirtqueue::new(tx_descriptors, tx_available_ring, tx_used_ring),
+        );
+        tx_queue.set_transport(&peripherals.virtio_mmio[net_idx]);
+
+        // RX Virtqueue
+        let rx_descriptors =
+            static_init!(VirtqueueDescriptors<2>, VirtqueueDescriptors::default(),);
+        let rx_available_ring =
+            static_init!(VirtqueueAvailableRing<2>, VirtqueueAvailableRing::default(),);
+        let rx_used_ring = static_init!(VirtqueueUsedRing<2>, VirtqueueUsedRing::default(),);
+        let rx_queue = static_init!(
+            SplitVirtqueue<2>,
+            SplitVirtqueue::new(rx_descriptors, rx_available_ring, rx_used_ring),
+        );
+        rx_queue.set_transport(&peripherals.virtio_mmio[net_idx]);
+
+        // Incoming and outgoing packets are prefixed by a 12-byte
+        // VirtIO specific header
+        let tx_header_buf = static_init!([u8; 12], [0; 12]);
+        let rx_header_buf = static_init!([u8; 12], [0; 12]);
+
+        // Currently, provide a single receive buffer to write
+        // incoming packets into
+        let rx_buffer = static_init!([u8; 1526], [0; 1526]);
+
+        // Instantiate the VirtIONet (NetworkCard) driver and set
+        // the queues
+        let virtio_net = static_init!(
+            VirtIONet<'static>,
+            VirtIONet::new(
+                0,
+                tx_queue,
+                tx_header_buf,
+                rx_queue,
+                rx_header_buf,
+                rx_buffer,
+            ),
+        );
+        tx_queue.set_client(virtio_net);
+        rx_queue.set_client(virtio_net);
+
+        // Register the queues and driver with the transport, so
+        // interrupts are routed properly
+        let mmio_queues = static_init!([&'static dyn Virtqueue; 2], [rx_queue, tx_queue]);
+        peripherals.virtio_mmio[net_idx]
+            .initialize(virtio_net, mmio_queues)
+            .unwrap();
+
+        // Don't forget to enable RX once when integrating this into a
+        // proper Ethernet stack:
+        // virtio_net.enable_rx();
+
+        // TODO: When we have a proper Ethernet driver available for userspace,
+        // return that. For now, just return a reference to the raw VirtIONet
+        // driver:
+        Some(virtio_net as &'static VirtIONet)
+    } else {
+        // No VirtIO NetworkCard discovered
+        None
+    };
+
     // ---------- INITIALIZE CHIP, ENABLE INTERRUPTS ---------
+
     let chip = static_init!(
         QemuRv32VirtChip<QemuRv32VirtDefaultPeripherals>,
         QemuRv32VirtChip::new(peripherals, hardware_timer),
@@ -282,6 +463,7 @@ pub unsafe fn main() {
         lldb,
         scheduler,
         scheduler_timer,
+        virtio_rng: virtio_rng_driver,
         ipc: kernel::ipc::IPC::new(
             board_kernel,
             kernel::ipc::DRIVER_NUM,

--- a/chips/qemu_rv32_virt_chip/Cargo.toml
+++ b/chips/qemu_rv32_virt_chip/Cargo.toml
@@ -6,5 +6,6 @@ edition = "2018"
 
 [dependencies]
 sifive = { path = "../sifive" }
+virtio = { path = "../virtio" }
 rv32i = { path = "../../arch/rv32i" }
 kernel = { path = "../../kernel" }

--- a/chips/qemu_rv32_virt_chip/src/chip.rs
+++ b/chips/qemu_rv32_virt_chip/src/chip.rs
@@ -18,6 +18,8 @@ use sifive::plic::Plic;
 
 use crate::interrupts;
 
+use virtio::transports::mmio::VirtIOMMIODevice;
+
 type QemuRv32VirtPMP = PMP<8>;
 
 pub type QemuRv32VirtClint<'a> = sifive::clint::Clint<'a, Freq10MHz>;
@@ -32,12 +34,23 @@ pub struct QemuRv32VirtChip<'a, I: InterruptService<()> + 'a> {
 
 pub struct QemuRv32VirtDefaultPeripherals<'a> {
     pub uart0: crate::uart::Uart16550<'a>,
+    pub virtio_mmio: [VirtIOMMIODevice; 8],
 }
 
 impl<'a> QemuRv32VirtDefaultPeripherals<'a> {
     pub fn new() -> Self {
         Self {
             uart0: crate::uart::Uart16550::new(crate::uart::UART0_BASE),
+            virtio_mmio: [
+                VirtIOMMIODevice::new(crate::virtio_mmio::VIRTIO_MMIO_0_BASE),
+                VirtIOMMIODevice::new(crate::virtio_mmio::VIRTIO_MMIO_1_BASE),
+                VirtIOMMIODevice::new(crate::virtio_mmio::VIRTIO_MMIO_2_BASE),
+                VirtIOMMIODevice::new(crate::virtio_mmio::VIRTIO_MMIO_3_BASE),
+                VirtIOMMIODevice::new(crate::virtio_mmio::VIRTIO_MMIO_4_BASE),
+                VirtIOMMIODevice::new(crate::virtio_mmio::VIRTIO_MMIO_5_BASE),
+                VirtIOMMIODevice::new(crate::virtio_mmio::VIRTIO_MMIO_6_BASE),
+                VirtIOMMIODevice::new(crate::virtio_mmio::VIRTIO_MMIO_7_BASE),
+            ],
         }
     }
 }
@@ -45,9 +58,15 @@ impl<'a> QemuRv32VirtDefaultPeripherals<'a> {
 impl<'a> InterruptService<()> for QemuRv32VirtDefaultPeripherals<'a> {
     unsafe fn service_interrupt(&self, interrupt: u32) -> bool {
         match interrupt {
-            interrupts::UART0 => {
-                self.uart0.handle_interrupt();
-            }
+            interrupts::UART0 => self.uart0.handle_interrupt(),
+            interrupts::VIRTIO_MMIO_0 => self.virtio_mmio[0].handle_interrupt(),
+            interrupts::VIRTIO_MMIO_1 => self.virtio_mmio[1].handle_interrupt(),
+            interrupts::VIRTIO_MMIO_2 => self.virtio_mmio[2].handle_interrupt(),
+            interrupts::VIRTIO_MMIO_3 => self.virtio_mmio[3].handle_interrupt(),
+            interrupts::VIRTIO_MMIO_4 => self.virtio_mmio[4].handle_interrupt(),
+            interrupts::VIRTIO_MMIO_5 => self.virtio_mmio[5].handle_interrupt(),
+            interrupts::VIRTIO_MMIO_6 => self.virtio_mmio[6].handle_interrupt(),
+            interrupts::VIRTIO_MMIO_7 => self.virtio_mmio[7].handle_interrupt(),
             _ => return false,
         }
         true

--- a/chips/qemu_rv32_virt_chip/src/lib.rs
+++ b/chips/qemu_rv32_virt_chip/src/lib.rs
@@ -4,7 +4,10 @@
 #![crate_name = "qemu_rv32_virt_chip"]
 #![crate_type = "rlib"]
 
+pub use virtio;
+
 mod interrupts;
+pub mod virtio_mmio;
 
 pub mod chip;
 pub mod clint;

--- a/chips/qemu_rv32_virt_chip/src/virtio_mmio.rs
+++ b/chips/qemu_rv32_virt_chip/src/virtio_mmio.rs
@@ -1,0 +1,21 @@
+//! QEMU VirtIO MMIO instantiation
+
+use kernel::utilities::StaticRef;
+use virtio::transports::mmio::VirtIOMMIODeviceRegisters;
+
+pub const VIRTIO_MMIO_0_BASE: StaticRef<VirtIOMMIODeviceRegisters> =
+    unsafe { StaticRef::new(0x1000_1000 as *const VirtIOMMIODeviceRegisters) };
+pub const VIRTIO_MMIO_1_BASE: StaticRef<VirtIOMMIODeviceRegisters> =
+    unsafe { StaticRef::new(0x1000_2000 as *const VirtIOMMIODeviceRegisters) };
+pub const VIRTIO_MMIO_2_BASE: StaticRef<VirtIOMMIODeviceRegisters> =
+    unsafe { StaticRef::new(0x1000_3000 as *const VirtIOMMIODeviceRegisters) };
+pub const VIRTIO_MMIO_3_BASE: StaticRef<VirtIOMMIODeviceRegisters> =
+    unsafe { StaticRef::new(0x1000_4000 as *const VirtIOMMIODeviceRegisters) };
+pub const VIRTIO_MMIO_4_BASE: StaticRef<VirtIOMMIODeviceRegisters> =
+    unsafe { StaticRef::new(0x1000_5000 as *const VirtIOMMIODeviceRegisters) };
+pub const VIRTIO_MMIO_5_BASE: StaticRef<VirtIOMMIODeviceRegisters> =
+    unsafe { StaticRef::new(0x1000_6000 as *const VirtIOMMIODeviceRegisters) };
+pub const VIRTIO_MMIO_6_BASE: StaticRef<VirtIOMMIODeviceRegisters> =
+    unsafe { StaticRef::new(0x1000_7000 as *const VirtIOMMIODeviceRegisters) };
+pub const VIRTIO_MMIO_7_BASE: StaticRef<VirtIOMMIODeviceRegisters> =
+    unsafe { StaticRef::new(0x1000_8000 as *const VirtIOMMIODeviceRegisters) };

--- a/chips/virtio/Cargo.toml
+++ b/chips/virtio/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "virtio"
+version.workspace = true
+authors.workspace = true
+edition = "2021"
+
+[dependencies]
+kernel = { path = "../../kernel" }

--- a/chips/virtio/src/devices/mod.rs
+++ b/chips/virtio/src/devices/mod.rs
@@ -1,0 +1,138 @@
+use kernel::ErrorCode;
+
+/// VirtIO Device Types.
+///
+/// VirtIO is a flexible bus which can be used to expose various kinds of
+/// virtual devices, such as network drivers, serial consoles, block devices or
+/// random number generators. A VirtIO bus endpoint announces which type of
+/// device it represents (and hence also which rules and semantics the VirtIO
+/// driver should follow).
+///
+/// This enum maps the VirtIO device IDs to human-readable variants of an enum,
+/// which can be used throughout the code base. Users should not rely on this
+/// enum not being extended. Whenever an official device ID is missing, it can
+/// be added to this enumeration.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[repr(u32)]
+#[non_exhaustive]
+pub enum VirtIODeviceType {
+    NetworkCard = 1,
+    BlockDevice = 2,
+    Console = 3,
+    EntropySource = 4,
+    TraditionalMemoryBallooning = 5,
+    IoMemory = 6,
+    RPMSG = 7,
+    SCSIHost = 8,
+    Transport9P = 9,
+    Mac80211Wlan = 10,
+    RPROCSerial = 11,
+    VirtIOCAIF = 12,
+    MemoryBalloon = 13,
+    GPUDevice = 14,
+    TimerClockDevice = 15,
+    InputDevice = 16,
+    SocketDevice = 17,
+    CryptoDevice = 18,
+    SignalDistributionModule = 19,
+    PstoreDevice = 20,
+    IOMMUDevice = 21,
+    MemoryDevice = 22,
+}
+
+impl VirtIODeviceType {
+    /// Try to create a [`VirtIODeviceType`] enum variant from a supplied
+    /// numeric device ID.
+    pub fn from_device_id(id: u32) -> Option<VirtIODeviceType> {
+        use VirtIODeviceType as DT;
+
+        match id {
+            1 => Some(DT::NetworkCard),
+            2 => Some(DT::BlockDevice),
+            3 => Some(DT::Console),
+            4 => Some(DT::EntropySource),
+            5 => Some(DT::TraditionalMemoryBallooning),
+            6 => Some(DT::IoMemory),
+            7 => Some(DT::RPMSG),
+            8 => Some(DT::SCSIHost),
+            9 => Some(DT::Transport9P),
+            10 => Some(DT::Mac80211Wlan),
+            11 => Some(DT::RPROCSerial),
+            12 => Some(DT::VirtIOCAIF),
+            13 => Some(DT::MemoryBalloon),
+            14 => Some(DT::GPUDevice),
+            15 => Some(DT::TimerClockDevice),
+            16 => Some(DT::InputDevice),
+            17 => Some(DT::SocketDevice),
+            18 => Some(DT::CryptoDevice),
+            19 => Some(DT::SignalDistributionModule),
+            20 => Some(DT::PstoreDevice),
+            21 => Some(DT::IOMMUDevice),
+            22 => Some(DT::MemoryDevice),
+            _ => None,
+        }
+    }
+
+    /// Convert a [`VirtIODeviceType`] variant to its corresponding device ID.
+    pub fn to_device_id(device_type: VirtIODeviceType) -> u32 {
+        device_type as u32
+    }
+}
+
+/// VirtIO Device Driver.
+///
+/// This trait is to be implemented by drivers for exposed VirtIO devices, using
+/// the transports provided in [`crate::transports`] and queues in
+/// [`crate::queues`] to communicate with VirtIO devices.
+pub trait VirtIODeviceDriver {
+    /// VirtIO feature negotiation.
+    ///
+    /// This function is passed all driver-specific feature bits which the
+    /// device exposes. Based on this function, the driver can select which
+    /// features to enable through the return value of this function. This
+    /// function is executed through the VirtIO transport, potentially before
+    /// the device is initialized. As such, implementations of this function
+    /// should be pure and only depend on the `offered_features` input
+    /// parameter.
+    fn negotiate_features(&self, offered_features: u64) -> Option<u64>;
+
+    /// VirtIO device type which the driver supports.
+    ///
+    /// This function must return the VirtIO device type that the driver is able
+    /// to drive. Implementations of this function must be pure and return a
+    /// constant value.
+    fn device_type(&self) -> VirtIODeviceType;
+
+    /// Hook called before the transport indicates `DRIVER_OK` to the device.
+    ///
+    /// Because this trait must be object safe, a device cannot convey arbitrary
+    /// errors through this interface. When this function returns an error, the
+    /// transport will indicate `FAILED` to the device and return the error to
+    /// the caller of
+    /// [`VirtIOTransport::initialize`](super::transports::VirtIOTransport::initialize).
+    /// The driver can store a more elaborate error internally and expose it
+    /// through a custom interface.
+    ///
+    /// A default implementation of this function is provided which does nothing
+    /// and returns `Ok(())`.
+    fn pre_device_initialization(&self) -> Result<(), ErrorCode> {
+        Ok(())
+    }
+
+    /// Hook called after the transport indicated `DRIVER_OK` to the device.
+    ///
+    /// Because this trait must be object safe, a device cannot convey arbitrary
+    /// errors through this interface. When this function returns an error, the
+    /// transport will **NOT** indicate `FAILED` to the device, but return the
+    /// error to the caller of
+    /// [`VirtIOTransport::initialize`](super::transports::VirtIOTransport::initialize).
+    /// The driver can store a more elaborate error internally and expose it
+    /// through a custom interface. The driver remains responsible for any
+    /// deinitialization of the device as a result of this error.
+    ///
+    /// A default implementation of this function is provided which does nothing
+    /// and returns `Ok(())`.
+    fn device_initialized(&self) -> Result<(), ErrorCode> {
+        Ok(())
+    }
+}

--- a/chips/virtio/src/devices/mod.rs
+++ b/chips/virtio/src/devices/mod.rs
@@ -1,5 +1,7 @@
 use kernel::ErrorCode;
 
+pub mod virtio_rng;
+
 /// VirtIO Device Types.
 ///
 /// VirtIO is a flexible bus which can be used to expose various kinds of

--- a/chips/virtio/src/devices/mod.rs
+++ b/chips/virtio/src/devices/mod.rs
@@ -1,5 +1,6 @@
 use kernel::ErrorCode;
 
+pub mod virtio_net;
 pub mod virtio_rng;
 
 /// VirtIO Device Types.

--- a/chips/virtio/src/devices/virtio_net.rs
+++ b/chips/virtio/src/devices/virtio_net.rs
@@ -1,0 +1,243 @@
+use core::cell::Cell;
+
+use kernel::utilities::cells::OptionalCell;
+use kernel::utilities::registers::{register_bitfields, LocalRegisterCopy};
+use kernel::ErrorCode;
+
+use super::super::devices::{VirtIODeviceDriver, VirtIODeviceType};
+use super::super::queues::split_queue::{SplitVirtqueue, SplitVirtqueueClient, VirtqueueBuffer};
+
+register_bitfields![u64,
+    VirtIONetFeatures [
+        VirtIONetFCsum OFFSET(0) NUMBITS(1),
+        VirtIONetFGuestCsum OFFSET(1) NUMBITS(1),
+        VirtIONetFCtrlGuestOffloads OFFSET(2) NUMBITS(1),
+        VirtIONetFMtu OFFSET(3) NUMBITS(1),
+        VirtIONetFMac OFFSET(5) NUMBITS(1),
+        VirtIONetFGuestTso4 OFFSET(7) NUMBITS(1),
+        VirtIONetFGuestTso6 OFFSET(8) NUMBITS(1),
+        VirtIONetFGuestEcn OFFSET(9) NUMBITS(1),
+        VirtIONetFGuestUfo OFFSET(10) NUMBITS(1),
+        VirtIONetFHostTso4 OFFSET(11) NUMBITS(1),
+        VirtIONetFHostTso6 OFFSET(12) NUMBITS(1),
+        VirtIONetFHostEcn OFFSET(13) NUMBITS(1),
+        VirtIONetFHostUfo OFFSET(14) NUMBITS(1),
+        VirtIONetFMrgRxbuf OFFSET(15) NUMBITS(1),
+        VirtIONetFStatus OFFSET(16) NUMBITS(1),
+        VirtIONetFCtrlVq OFFSET(17) NUMBITS(1),
+        VirtIONetFCtrlRx OFFSET(18) NUMBITS(1),
+        VirtIONetFCtrlVlan OFFSET(19) NUMBITS(1),
+        VirtIONetFGuestAnnounce OFFSET(21) NUMBITS(1),
+        VirtIONetFMq OFFSET(22) NUMBITS(1),
+        VirtIONetFCtrlMacAddr OFFSET(23) NUMBITS(1),
+        // these feature bits would not be passed through the driver, as
+        // they are in a region reserved for future extensions?
+        VirtIONetFRscExt OFFSET(61) NUMBITS(1),
+        VirtIONetFStandby OFFSET(62) NUMBITS(1),
+    ]
+];
+
+pub struct VirtIONet<'a> {
+    id: Cell<usize>,
+    rxqueue: &'a SplitVirtqueue<'static, 'static, 2>,
+    txqueue: &'a SplitVirtqueue<'static, 'static, 2>,
+    tx_header: OptionalCell<&'static mut [u8; 12]>,
+    rx_header: OptionalCell<&'static mut [u8]>,
+    rx_buffer: OptionalCell<&'static mut [u8]>,
+    client: OptionalCell<&'a dyn VirtIONetClient>,
+}
+
+impl<'a> VirtIONet<'a> {
+    pub fn new(
+        id: usize,
+        txqueue: &'a SplitVirtqueue<'static, 'static, 2>,
+        tx_header: &'static mut [u8; 12],
+        rxqueue: &'a SplitVirtqueue<'static, 'static, 2>,
+        rx_header: &'static mut [u8],
+        rx_buffer: &'static mut [u8],
+    ) -> VirtIONet<'a> {
+        txqueue.enable_used_callbacks();
+        rxqueue.enable_used_callbacks();
+
+        VirtIONet {
+            id: Cell::new(id),
+            rxqueue,
+            txqueue,
+            tx_header: OptionalCell::new(tx_header),
+            client: OptionalCell::empty(),
+            rx_header: OptionalCell::new(rx_header),
+            rx_buffer: OptionalCell::new(rx_buffer),
+        }
+    }
+
+    pub fn id(&self) -> usize {
+        self.id.get()
+    }
+
+    pub fn set_client(&self, client: &'a dyn VirtIONetClient) {
+        self.client.set(client);
+    }
+
+    // This is not executed as part of the `device_initialized` hook to avoid
+    // missing any packets if a client has not been registered, and because this
+    // device can be used in a transmit-only fashion before invoking this
+    // function.
+    pub fn enable_rx(&self) {
+        // To start operation, put the receive buffers into the device initially
+        let rx_buffer = self.rx_buffer.take().unwrap();
+        let rx_buffer_len = rx_buffer.len();
+
+        let mut buffer_chain = [
+            Some(VirtqueueBuffer {
+                buf: self.rx_header.take().unwrap(),
+                len: 12,
+                device_writeable: true,
+            }),
+            Some(VirtqueueBuffer {
+                buf: rx_buffer,
+                len: rx_buffer_len,
+                device_writeable: true,
+            }),
+        ];
+
+        self.rxqueue
+            .provide_buffer_chain(&mut buffer_chain)
+            .unwrap();
+    }
+
+    pub fn return_rx_buffer(&self, buf: &'static mut [u8]) {
+        assert!(self.rx_buffer.is_none());
+        assert!(self.rx_header.is_some());
+        self.rx_buffer.replace(buf);
+
+        // Re-register the RX buffer with the Virtqueue:
+        self.enable_rx();
+    }
+
+    pub fn send_packet(
+        &self,
+        packet: &'static mut [u8],
+        packet_len: usize,
+    ) -> Result<(), (&'static mut [u8], ErrorCode)> {
+        // Try to get a hold of the header buffer
+        //
+        // Otherwise, the device is currently busy transmissing a buffer
+        //
+        // TODO: Implement simultaneous transmissions
+        let mut packet_buf = Some(VirtqueueBuffer {
+            buf: packet,
+            len: packet_len,
+            device_writeable: false,
+        });
+
+        let header_buf = self
+            .tx_header
+            .take()
+            .ok_or(ErrorCode::BUSY)
+            .map_err(|ret| (packet_buf.take().unwrap().buf, ret))?;
+
+        // Write the header
+        //
+        // TODO: Can this be done more elegantly using a struct of registers?
+        header_buf[0] = 0; // flags -> we don't want checksumming
+        header_buf[1] = 0; // gso -> no checksumming or fragmentation
+        header_buf[2] = 0; // hdr_len_low
+        header_buf[3] = 0; // hdr_len_high
+        header_buf[4] = 0; // gso_size
+        header_buf[5] = 0; // gso_size
+        header_buf[6] = 0; // csum_start
+        header_buf[7] = 0; // csum_start
+        header_buf[8] = 0; // csum_offset
+        header_buf[9] = 0; // csum_offsetb
+        header_buf[10] = 0; // num_buffers
+        header_buf[11] = 0; // num_buffers
+
+        let mut buffer_chain = [
+            Some(VirtqueueBuffer {
+                buf: header_buf,
+                len: 12,
+                device_writeable: false,
+            }),
+            packet_buf.take(),
+        ];
+
+        self.txqueue
+            .provide_buffer_chain(&mut buffer_chain)
+            .map_err(move |ret| (buffer_chain[1].take().unwrap().buf, ret))?;
+
+        Ok(())
+    }
+}
+
+impl<'a> SplitVirtqueueClient<'static> for VirtIONet<'a> {
+    fn buffer_chain_ready(
+        &self,
+        queue_number: u32,
+        buffer_chain: &mut [Option<VirtqueueBuffer<'static>>],
+        bytes_used: usize,
+    ) {
+        if queue_number == self.rxqueue.queue_number().unwrap() {
+            // Received a packet
+
+            let rx_header = buffer_chain[0].take().expect("No header buffer").buf;
+            // TODO: do something with the header
+            self.rx_header.replace(rx_header);
+
+            let rx_buffer = buffer_chain[1].take().expect("No rx content buffer").buf;
+            self.client.map(move |client| {
+                client.packet_received(self.id.get(), rx_buffer, bytes_used - 12)
+            });
+        } else if queue_number == self.txqueue.queue_number().unwrap() {
+            // Sent a packet
+
+            let header_buf = buffer_chain[0].take().expect("No header buffer").buf;
+            self.tx_header.replace(header_buf.try_into().unwrap());
+
+            let packet_buf = buffer_chain[1].take().expect("No packet buffer").buf;
+            self.client
+                .map(move |client| client.packet_sent(self.id.get(), packet_buf));
+        } else {
+            panic!("Callback from unknown queue");
+        }
+    }
+}
+
+impl<'a> VirtIODeviceDriver for VirtIONet<'a> {
+    fn negotiate_features(&self, offered_features: u64) -> Option<u64> {
+        let offered_features =
+            LocalRegisterCopy::<u64, VirtIONetFeatures::Register>::new(offered_features);
+        let mut negotiated_features = LocalRegisterCopy::<u64, VirtIONetFeatures::Register>::new(0);
+
+        if offered_features.is_set(VirtIONetFeatures::VirtIONetFMac) {
+            // VIRTIO_NET_F_MAC offered, which means that the device has a MAC
+            // address. Accept this feature, which is required for this driver
+            // for now.
+            negotiated_features.modify(VirtIONetFeatures::VirtIONetFMac::SET);
+        } else {
+            return None;
+        }
+
+        // TODO: QEMU doesn't offer this, but don't we need it? Does QEMU
+        // implicitly provide the feature but not offer it? Find out!
+        // if offered_features & (1 << 15) != 0 {
+        //     // VIRTIO_NET_F_MRG_RXBUF
+        //     //
+        //     // accept
+        //     negotiated_features |= 1 << 15;
+        // } else {
+        //     panic!("Missing NET_F_MRG_RXBUF");
+        // }
+
+        // Ignore everything else
+        Some(negotiated_features.get())
+    }
+
+    fn device_type(&self) -> VirtIODeviceType {
+        VirtIODeviceType::NetworkCard
+    }
+}
+
+pub trait VirtIONetClient {
+    fn packet_sent(&self, id: usize, buffer: &'static mut [u8]);
+    fn packet_received(&self, id: usize, buffer: &'static mut [u8], len: usize);
+}

--- a/chips/virtio/src/devices/virtio_rng.rs
+++ b/chips/virtio/src/devices/virtio_rng.rs
@@ -1,0 +1,215 @@
+use core::cell::Cell;
+
+use kernel::dynamic_deferred_call::{
+    DeferredCallHandle, DynamicDeferredCall, DynamicDeferredCallClient,
+};
+use kernel::hil::rng::{Client as RngClient, Continue as RngCont, Rng};
+use kernel::utilities::cells::OptionalCell;
+use kernel::ErrorCode;
+
+use super::super::devices::{VirtIODeviceDriver, VirtIODeviceType};
+use super::super::queues::split_queue::{SplitVirtqueue, SplitVirtqueueClient, VirtqueueBuffer};
+
+pub struct VirtIORng<'a, 'b> {
+    virtqueue: &'a SplitVirtqueue<'a, 'b, 1>,
+    buffer_capacity: Cell<usize>,
+    callback_pending: Cell<bool>,
+    deferred_caller: &'a DynamicDeferredCall,
+    deferred_call_handle: OptionalCell<DeferredCallHandle>,
+    client: OptionalCell<&'a dyn RngClient>,
+}
+
+impl<'a, 'b> VirtIORng<'a, 'b> {
+    pub fn new(
+        virtqueue: &'a SplitVirtqueue<'a, 'b, 1>,
+        deferred_caller: &'a DynamicDeferredCall,
+    ) -> VirtIORng<'a, 'b> {
+        VirtIORng {
+            virtqueue,
+            buffer_capacity: Cell::new(0),
+            callback_pending: Cell::new(false),
+            deferred_caller,
+            deferred_call_handle: OptionalCell::empty(),
+            client: OptionalCell::empty(),
+        }
+    }
+
+    pub fn set_deferred_call_handle(&self, handle: DeferredCallHandle) {
+        self.deferred_call_handle.set(handle);
+    }
+
+    pub fn provide_buffer(&self, buf: &'b mut [u8]) -> Result<usize, (&'b mut [u8], ErrorCode)> {
+        let len = buf.len();
+        if len < 4 {
+            // We don't yet support merging of randomness of multiple buffers
+            //
+            // Allowing a buffer with less than 4 elements will cause
+            // the callback to never be called, while the buffer is
+            // reinserted into the queue
+            return Err((buf, ErrorCode::INVAL));
+        }
+
+        let mut buffer_chain = [Some(VirtqueueBuffer {
+            buf,
+            len,
+            device_writeable: true,
+        })];
+
+        let res = self.virtqueue.provide_buffer_chain(&mut buffer_chain);
+
+        match res {
+            Err(ErrorCode::NOMEM) => {
+                // Hand back the buffer, the queue MUST NOT write partial
+                // buffer chains
+                let buf = buffer_chain[0].take().unwrap().buf;
+                Err((buf, ErrorCode::NOMEM))
+            }
+            Err(e) => panic!("Unexpected error {:?}", e),
+            Ok(()) => {
+                let mut cap = self.buffer_capacity.get();
+                cap += len;
+                self.buffer_capacity.set(cap);
+                Ok(cap)
+            }
+        }
+    }
+
+    fn buffer_chain_callback(
+        &self,
+        buffer_chain: &mut [Option<VirtqueueBuffer<'b>>],
+        bytes_used: usize,
+    ) {
+        // Disable further callbacks, until we're sure we need them
+        //
+        // The used buffers should stay in the queue until a client is
+        // ready to consume them
+        self.virtqueue.disable_used_callbacks();
+
+        // We only have buffer chains of a single buffer
+        let buf = buffer_chain[0].take().unwrap().buf;
+
+        // We have taken out a buffer, hence decrease the available capacity
+        assert!(self.buffer_capacity.get() >= buf.len());
+
+        // It could've happened that we don't require the callback any
+        // more, hence check beforehand
+        let cont = if self.callback_pending.get() {
+            // The callback is no longer pending
+            self.callback_pending.set(false);
+
+            let mut u32randiter = buf[0..bytes_used].chunks(4).filter_map(|slice| {
+                if slice.len() < 4 {
+                    None
+                } else {
+                    Some(u32::from_le_bytes([slice[0], slice[1], slice[2], slice[3]]))
+                }
+            });
+
+            // For now we don't use left-over randomness and assume the
+            // client has consumed the entire iterator
+            self.client
+                .map(|client| client.randomness_available(&mut u32randiter, Ok(())))
+                .unwrap_or(RngCont::Done)
+        } else {
+            RngCont::Done
+        };
+
+        if let RngCont::More = cont {
+            // Returning more is the equivalent of calling .get() on
+            // the Rng trait.
+
+            // TODO: what if this call fails?
+            let _ = self.get();
+        }
+
+        // In any case, reinsert the buffer for further processing
+        self.provide_buffer(buf).expect("Buffer reinsertion failed");
+    }
+}
+
+impl<'a, 'b> Rng<'a> for VirtIORng<'a, 'b> {
+    fn get(&self) -> Result<(), ErrorCode> {
+        // Minimum buffer capacity must be 4 bytes for a single 32-bit
+        // word
+        if self.buffer_capacity.get() < 4 {
+            Err(ErrorCode::FAIL)
+        } else if self.client.is_none() {
+            Err(ErrorCode::FAIL)
+        } else if self.callback_pending.get() {
+            Err(ErrorCode::OFF)
+        } else if self.virtqueue.used_descriptor_chains_count() < 1 {
+            // There is no buffer ready in the queue, so let's rely
+            // purely on queue callbacks to notify us of the next
+            // incoming one
+            self.callback_pending.set(true);
+            self.virtqueue.enable_used_callbacks();
+            Ok(())
+        } else if self.deferred_call_handle.is_none() {
+            Err(ErrorCode::FAIL)
+        } else {
+            // There is a buffer in the virtqueue, get it and return
+            // it to a client in a deferred call
+            self.callback_pending.set(true);
+            self.deferred_call_handle
+                .map(|handle| self.deferred_caller.set(*handle));
+            Ok(())
+        }
+    }
+
+    fn cancel(&self) -> Result<(), ErrorCode> {
+        // Cancel by setting the callback_pending flag to false which
+        // MUST be checked prior to every callback
+        self.callback_pending.set(false);
+
+        // For efficiency reasons, also unsubscribe from the virtqueue
+        // callbacks, which will let the buffers remain in the queue
+        // for future use
+        self.virtqueue.disable_used_callbacks();
+
+        Ok(())
+    }
+
+    fn set_client(&self, client: &'a dyn RngClient) {
+        self.client.set(client);
+    }
+}
+
+impl<'a, 'b> SplitVirtqueueClient<'b> for VirtIORng<'a, 'b> {
+    fn buffer_chain_ready(
+        &self,
+        _queue_number: u32,
+        buffer_chain: &mut [Option<VirtqueueBuffer<'b>>],
+        bytes_used: usize,
+    ) {
+        self.buffer_chain_callback(buffer_chain, bytes_used)
+    }
+}
+
+impl<'a, 'b> DynamicDeferredCallClient for VirtIORng<'a, 'b> {
+    fn call(&self, _handle: DeferredCallHandle) {
+        // Try to extract a descriptor chain
+        if let Some((mut chain, bytes_used)) = self.virtqueue.pop_used_buffer_chain() {
+            self.buffer_chain_callback(&mut chain, bytes_used)
+        } else {
+            // If we don't get a buffer, this must be a race condition
+            // which should not occur
+            //
+            // Prior to setting a deferred call, all virtqueue
+            // interrupts must be disabled so that no used buffer is
+            // removed before the deferred call callback
+            panic!("VirtIO RNG: deferred call callback with empty queue");
+        }
+    }
+}
+
+impl<'a, 'b> VirtIODeviceDriver for VirtIORng<'a, 'b> {
+    fn negotiate_features(&self, _offered_features: u64) -> Option<u64> {
+        // We don't support any special features and do not care about
+        // what the device offers.
+        Some(0)
+    }
+
+    fn device_type(&self) -> VirtIODeviceType {
+        VirtIODeviceType::EntropySource
+    }
+}

--- a/chips/virtio/src/lib.rs
+++ b/chips/virtio/src/lib.rs
@@ -1,0 +1,9 @@
+//! VirtIO support for Tock.
+
+#![no_std]
+#![crate_name = "virtio"]
+#![crate_type = "rlib"]
+
+pub mod devices;
+pub mod queues;
+pub mod transports;

--- a/chips/virtio/src/queues/mod.rs
+++ b/chips/virtio/src/queues/mod.rs
@@ -1,0 +1,94 @@
+//! VirtIO Virtqueues.
+//!
+//! This module and its submodules provide abstractions for and
+//! implementations of VirtIO Virtqueues. For more information, see
+//! the documentation of the [`Virtqueue`] trait.
+
+pub mod split_queue;
+
+/// A set of addresses representing a Virtqueue in memory.
+pub struct VirtqueueAddresses {
+    pub descriptor_area: u64,
+    pub driver_area: u64,
+    pub device_area: u64,
+}
+
+/// A VirtIO Virtqueue.
+///
+/// Virtqueues are VirtIO's mechanism to exchange data between a host and a
+/// guest. Each queue instance provides a bidirectional communication channel to
+/// send data from the guest (VirtIO driver) to the host (VirtIO device) and
+/// back. Typically, a given Virtqueue is only used for communication in a
+/// single direction. A VirtIO device can support multiple Virtqueues.
+///
+/// Fundamentally, every Virtqueue refers to three distinct regions in memory:
+///
+/// - the **descriptor area**: this memory region contains an array of so-called
+///   Virtqueue descriptors. Each descriptor is a data structure containing
+///   metadata concerning a buffer shared by the guest (VirtIO driver) into the
+///   Virtqueue, such as its guest-physical address in memory and
+///   length. Multiple shared buffers in distinct memory locations can be
+///   chained into a single buffer.
+///
+/// - the **available ring**: this available ring is a data structure maintained
+///   by the guest (VirtIO driver). It contains a ring-buffer which is used for
+///   the guest to share descriptors (as maintained in the _descriptor area_)
+///   with the host (VirtIO device).
+///
+/// - the **used ring**: buffers shared with the host (VirtIO device) will
+///   eventually be returned to the guest (VirtIO driver) by the device placing
+///   them into the used ring. The host will further issue an interrupt, which
+///   shall be routed to the Virtqueue by means of the
+///   [`Virtqueue::used_interrupt`] method.
+pub trait Virtqueue {
+    /// Negotiate the number of used descriptors in the Virtqueue.
+    ///
+    /// The method is presented with the maximum number of queue elements the
+    /// intended device can support. The method must return a value smaller or
+    /// equal than `device_max_elements`. The device's addresses as returned by
+    /// [`Virtqueue::physical_addresses`] after Virtqueue initialization must
+    /// have a memory layout adhering to the [Virtual I/O Device (VIRTIO)
+    /// Specification, Version
+    /// 1.1](https://docs.oasis-open.org/virtio/virtio/v1.1/csprd01/virtio-v1.1-csprd01.html),
+    /// for at least the returned number of queue elements.
+    ///
+    /// This method may be called any number of times before initialization of
+    /// the [`Virtqueue`]. Only its latest returned value is valid and must be
+    /// passed to [`Virtqueue::initialize`].
+    fn negotiate_queue_size(&self, device_max_elements: usize) -> usize;
+
+    /// Initialize the Virtqueue.
+    ///
+    /// This method must bring the Virtqueue into a state where it can be
+    /// exposed to a VirtIO transport based on the return value of
+    /// [`Virtqueue::physical_addresses`]. A Virtqueue must refuse operations
+    /// which require it to be initialized until this method has been called.
+    ///
+    /// The passed `queue_number` must identify the queue to the device. After
+    /// returning from [`Virtqueue::initialize`], calls into the Virtqueue
+    /// (except for [`Virtqueue::physical_addresses`]) may attempt to
+    /// communicate with the VirtIO device referencing this passed
+    /// `queue_number`. In practice, this means that the VirtIO device should be
+    /// made aware of this [`Virtqueue`] promptly after calling this method, at
+    /// least before invoking [`Virtqueue::used_interrupt`].
+    ///
+    /// The provided `queue_elements` is the latest negotiated queue size, as
+    /// returned by [`Virtqueue::negotiate_queue_size`].
+    fn initialize(&self, queue_number: u32, queue_elements: usize);
+
+    /// The physical addresses of the Virtqueue descriptors, available and used ring.
+    ///
+    /// The returned addresses and their memory contents must adhere to the
+    /// [Virtual I/O Device (VIRTIO) Specification, Version
+    /// 1.1](https://docs.oasis-open.org/virtio/virtio/v1.1/csprd01/virtio-v1.1-csprd01.html)
+    ///
+    /// This method must not be called before the Virtqueue has been
+    /// initialized.
+    fn physical_addresses(&self) -> VirtqueueAddresses;
+
+    /// Interrupt indicating that a VirtIO device may have placed a buffer into
+    /// this Virtqueue's used ring.
+    ///
+    /// A [`Virtqueue`] must be tolerant of spurious calls to this method.
+    fn used_interrupt(&self);
+}

--- a/chips/virtio/src/queues/split_queue.rs
+++ b/chips/virtio/src/queues/split_queue.rs
@@ -1,0 +1,911 @@
+//! VirtIO Split Virtqueue implementation.
+//!
+//! This module contains an implementation of a Split Virtqueue, as defined in
+//! 2.6 Split Virtqueues of the [Virtual I/O Device (VIRTIO) Specification,
+//! Version
+//! 1.1](https://docs.oasis-open.org/virtio/virtio/v1.1/csprd01/virtio-v1.1-csprd01.html).
+//! This implementation can be used in conjunction with the VirtIO transports
+//! defined in [`transports`](`super::super::transports`) and
+//! [`devices`](`super::super::devices`) to interact with VirtIO-compatible
+//! devices.
+
+use core::cell::Cell;
+use core::cmp;
+use core::marker::PhantomData;
+use core::ptr::NonNull;
+use core::slice;
+
+use kernel::utilities::cells::OptionalCell;
+use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
+use kernel::utilities::registers::{register_bitfields, InMemoryRegister};
+use kernel::ErrorCode;
+
+use super::super::queues::{Virtqueue, VirtqueueAddresses};
+use super::super::transports::VirtIOTransport;
+
+pub const DESCRIPTOR_ALIGNMENT: usize = 16;
+pub const AVAILABLE_RING_ALIGNMENT: usize = 2;
+pub const USED_RING_ALIGNMENT: usize = 4;
+
+register_bitfields![u16,
+    DescriptorFlags [
+        Next OFFSET(0) NUMBITS(1) [],
+        WriteOnly OFFSET(1) NUMBITS(1) [],
+        Indirect OFFSET(2) NUMBITS(1) []
+    ],
+    AvailableRingFlags [
+        NoInterrupt OFFSET(0) NUMBITS(1) []
+    ],
+    UsedRingFlags [
+        NoNotify OFFSET(0) NUMBITS(1) []
+    ],
+];
+
+// This is an unsafe workaround of an unsafe workaround.
+//
+// Unfortunately, the Rust core library defines defaults on arrays not in a
+// generic way, but only for arrays up to 32 elements. Hence, for arrays using a
+// const-generic argument for their length, `Default::<[$SOMETHING_NON_DEFAULT;
+// CONST_GENERIC_USIZE]>::default()` does not work in Rust (as of
+// 2022-11-26). Instead, we need to use this horrible and unsafe hack as
+// documented here, which initializes an array of `MaybeUninit`s and transmutes:
+// (https://doc.rust-lang.org/stable/std/mem/union.MaybeUninit.html#initializing-an-array-element-by-element)
+//
+// However, Rust is also unable to transmute from a `MaybeUninit<T>` to a
+// generic `T`, even though the former is explicitly layout-compatible with the
+// latter. Hence, we have to use another hack described in the following
+// comment:
+// https://github.com/rust-lang/rust/issues/62875#issuecomment-513834029
+//
+// This function encapsulates all of this unsafe code and should be safe to use
+// until Rust adds support for constructing arrays over a const-generic length
+// from the contained types' default values.
+//
+// In large parts, this function is a verbatim copy of Rust's example for
+// element-wise array initialization using `MaybeUninit`:
+// https://doc.rust-lang.org/stable/std/mem/union.MaybeUninit.html#initializing-an-array-element-by-element
+fn init_constgeneric_default_array<const N: usize, T: Default>() -> [T; N] {
+    // Create an uninitialized array of `MaybeUninit`. The `assume_init` is safe
+    // because the type we are claiming to have initialized here is a bunch of
+    // `MaybeUninit`s, which do not require initialization.
+    let mut uninit_arr: [core::mem::MaybeUninit<T>; N] =
+        unsafe { core::mem::MaybeUninit::uninit().assume_init() };
+
+    // Dropping a `MaybeUninit` does nothing, so if there is a panic during this
+    // loop, we have a memory leak, but there is no memory safety issue.
+    for elem in &mut uninit_arr[..] {
+        elem.write(T::default());
+    }
+
+    // Everything is initialized. We'd like to transmute the `[MaybeUnit<T>; N]`
+    // array into a `[T; N]`, but transmuting `MaybeUninit<T>` to `T` (where T
+    // is generic) is not (yet) supported. Hence we need to take a pointer to
+    // this array, cast it to the correct type, read the pointer back and forget
+    // the original `[MaybeUnit<T>; N]` array, as described here:
+    // https://github.com/rust-lang/rust/issues/62875#issuecomment-513834029
+    let uninit_arr_ptr: *mut [core::mem::MaybeUninit<T>; N] = &mut uninit_arr as *mut _;
+    core::mem::forget(uninit_arr);
+    let transmuted: [T; N] = unsafe { core::ptr::read(uninit_arr_ptr as *mut [T; N]) };
+
+    // With the original value forgotten and new value recreated from its
+    // pointer, return it:
+    transmuted
+}
+
+/// A single Virtqueue descriptor.
+///
+/// Implements the memory layout of a single Virtqueue descriptor of a
+/// split-virtqueue, to be placed into the queue's descriptor table, as defined
+/// in section 2.6.5 of the spec.
+#[repr(C)]
+pub struct VirtqueueDescriptor {
+    /// Guest physical address of the buffer to share
+    addr: InMemoryRegister<u64>,
+    /// Length of the shared buffer
+    len: InMemoryRegister<u32>,
+    /// Descriptor flags
+    flags: InMemoryRegister<u16, DescriptorFlags::Register>,
+    /// Pointer to the next entry in the descriptor queue (if two
+    /// buffers are chained)
+    next: InMemoryRegister<u16>,
+}
+
+impl Default for VirtqueueDescriptor {
+    fn default() -> VirtqueueDescriptor {
+        VirtqueueDescriptor {
+            addr: InMemoryRegister::new(0),
+            len: InMemoryRegister::new(0),
+            flags: InMemoryRegister::new(0),
+            next: InMemoryRegister::new(0),
+        }
+    }
+}
+
+/// The Virtqueue descriptor table.
+///
+/// This table is provided to the VirtIO device (host) as a means to communicate
+/// information about shared buffers, maintained in the individual
+/// [`VirtqueueDescriptor`] elements. Elements in this table are referenced by
+/// the [`VirtqueueAvailableRing`] and [`VirtqueueUsedRing`] for exposing them
+/// to the VirtIO device in order, and receiving exposed ("used") buffers back
+/// from the device.
+///
+/// Multiple entries of the descriptor table can be chained in order to treat
+/// disjoint regions of memory as a single buffer through the
+/// `VirtqueueDescriptor::next` field, where the value of this field indexes
+/// into this table.
+#[repr(C, align(16))]
+pub struct VirtqueueDescriptors<const MAX_QUEUE_SIZE: usize>([VirtqueueDescriptor; MAX_QUEUE_SIZE]);
+
+impl<const MAX_QUEUE_SIZE: usize> Default for VirtqueueDescriptors<MAX_QUEUE_SIZE> {
+    fn default() -> Self {
+        VirtqueueDescriptors(init_constgeneric_default_array())
+    }
+}
+
+// This is required to be able to implement Default and hence to
+// initialize an entire array of default values with size specified by
+// a constant.
+#[repr(transparent)]
+pub struct VirtqueueAvailableElement(InMemoryRegister<u16>);
+
+/// The Virtqueue available ring.
+///
+/// This struct is exposed to the VirtIO device as a means to share buffers
+/// (pointed to by descriptors of the [`VirtqueueDescriptors`] descriptors
+/// table) with the VirtIO device (host). It avoids the need for explicit
+/// locking by using two distinct rings, each undirectionally exchanging
+/// information about used buffers. When a new buffer is placed into the
+/// available ring, the VirtIO driver (guest) must increment `idx` to the index
+/// where it would place the next available descriptor pointer in the ring
+/// field. After such an update, the queue must inform the device about this
+/// change through a call to [`VirtIOTransport::queue_notify`]. Given that
+/// volatile writes cannot be reordered with respect to each other, changes to
+/// the available ring are guaranteed to be visible to the VirtIO device (host).
+#[repr(C, align(2))]
+pub struct VirtqueueAvailableRing<const MAX_QUEUE_SIZE: usize> {
+    /// Virtqueue available ring flags.
+    flags: InMemoryRegister<u16, AvailableRingFlags::Register>,
+    /// Incrementing index, pointing to where the driver would put the next
+    /// descriptor entry in the ring (modulo the queue size).
+    ///
+    /// The driver must not decrement this field. There is no way to "unexpose"
+    /// buffers.
+    idx: InMemoryRegister<u16>,
+    /// Ring containing the shared buffers (indices into the
+    /// [`VirtqueueDescriptors`] descriptor table).
+    ring: [VirtqueueAvailableElement; MAX_QUEUE_SIZE],
+    /// "Used event" queue notification suppression mechanism.
+    ///
+    /// This field is only honored by the VirtIO device if the EventIdx feature
+    /// was negotiated.
+    ///
+    /// The driver can set this field to a target `idx` value of the
+    /// [`VirtqueueUsedRing`] to indicate to the device that notifications are
+    /// unnecessary until the device writes a buffer with the corresponding
+    /// index into the used ring.
+    used_event: InMemoryRegister<u16>,
+}
+
+impl Default for VirtqueueAvailableElement {
+    fn default() -> VirtqueueAvailableElement {
+        VirtqueueAvailableElement(InMemoryRegister::new(0))
+    }
+}
+
+impl<const MAX_QUEUE_SIZE: usize> Default for VirtqueueAvailableRing<MAX_QUEUE_SIZE> {
+    fn default() -> Self {
+        VirtqueueAvailableRing {
+            flags: InMemoryRegister::new(0),
+            idx: InMemoryRegister::new(0),
+            ring: init_constgeneric_default_array(),
+            used_event: InMemoryRegister::new(0),
+        }
+    }
+}
+
+/// The Virtqueue used ring.
+///
+/// This struct is exposed to the VirtIO device for the device to indicate which
+/// shared buffers (through the [`VirtqueueAvailableRing`] have been processed.
+/// It works similar to the available ring, but must never be written by the
+/// VirtIO driver (guest) after it has been shared with the device, and as long
+/// as the device is initialized.
+#[repr(C, align(4))]
+pub struct VirtqueueUsedRing<const MAX_QUEUE_SIZE: usize> {
+    /// Virtqueue used ring flags.
+    flags: InMemoryRegister<u16, UsedRingFlags::Register>,
+    /// Incrementing index, pointing to where the device would put the next
+    /// descriptor entry in the ring (modulo the queue size).
+    ///
+    /// The device must not decrement this field. There is no way to "take back"
+    /// buffers.
+    idx: InMemoryRegister<u16>,
+    /// Ring containing the used buffers (indices into the
+    /// [`VirtqueueDescriptors`] descriptor table).
+    ring: [VirtqueueUsedElement; MAX_QUEUE_SIZE],
+    /// "Available event" queue notification suppression mechanism.
+    ///
+    /// This field must only be honored by the VirtIO driver if the EventIdx
+    /// feature was negotiated.
+    ///
+    /// The device can set this field to a target `idx` value of the
+    /// [`VirtqueueAvailableRing`] to indicate to the driver that notifications
+    /// are unnecessary until the driver writes a buffer with the corresponding
+    /// index into the available ring.
+    avail_event: InMemoryRegister<u16>,
+}
+
+impl<const MAX_QUEUE_SIZE: usize> Default for VirtqueueUsedRing<MAX_QUEUE_SIZE> {
+    fn default() -> Self {
+        VirtqueueUsedRing {
+            flags: InMemoryRegister::new(0),
+            idx: InMemoryRegister::new(0),
+            ring: init_constgeneric_default_array(),
+            avail_event: InMemoryRegister::new(0),
+        }
+    }
+}
+
+/// A single element of the [`VirtqueueUsedRing`].
+#[repr(C)]
+pub struct VirtqueueUsedElement {
+    /// Index into the [`VirtqueueDescriptors`] descriptor table indicating the
+    /// head element of the returned descriptor chain.
+    id: InMemoryRegister<u32>,
+    /// Total length of the descriptor chain which was used by the device.
+    ///
+    /// Commonly this is used as a mechanism to communicate how much data the
+    /// device has written to a shared buffer.
+    len: InMemoryRegister<u32>,
+}
+
+impl Default for VirtqueueUsedElement {
+    fn default() -> VirtqueueUsedElement {
+        VirtqueueUsedElement {
+            id: InMemoryRegister::new(0),
+            len: InMemoryRegister::new(0),
+        }
+    }
+}
+
+/// A helper struct to manage the state of the Virtqueue available ring.
+///
+/// This struct reduces the complexity of the [`SplitVirtqueue`] implementation
+/// by encapsulating operations which depend on and modify the state of the
+/// driver-controlled available ring of the Virtqueue. It is essentially a
+/// glorified ring-buffer state machine, following the semantics as defined by
+/// VirtIO for the Virtqueue's available ring.
+struct AvailableRingHelper {
+    max_elements: Cell<usize>,
+    start: Cell<u16>,
+    end: Cell<u16>,
+    empty: Cell<bool>,
+}
+
+impl AvailableRingHelper {
+    pub fn new(max_elements: usize) -> AvailableRingHelper {
+        AvailableRingHelper {
+            max_elements: Cell::new(max_elements),
+            start: Cell::new(0),
+            end: Cell::new(0),
+            empty: Cell::new(true),
+        }
+    }
+
+    fn ring_wrapping_add(&self, a: u16, b: u16) -> u16 {
+        if self.max_elements.get() - (a as usize) - 1 < (b as usize) {
+            b - (self.max_elements.get() - a as usize) as u16
+        } else {
+            a + b
+        }
+    }
+
+    /// Reset the state of the available ring.
+    ///
+    /// This must be called before signaling to the device that the driver is
+    /// initialized. It takes the maximum queue elements as the `max_elements`
+    /// parameter, as negotiated with the device.
+    pub fn reset(&self, max_elements: usize) {
+        self.max_elements.set(max_elements);
+        self.start.set(0);
+        self.end.set(0);
+        self.empty.set(true);
+    }
+
+    /// Whether the available ring of the Virtqueue is empty.
+    pub fn is_empty(&self) -> bool {
+        self.empty.get()
+    }
+
+    /// Whether the available ring of the Virtqueue is full.
+    pub fn is_full(&self) -> bool {
+        !self.empty.get() && self.start.get() == self.end.get()
+    }
+
+    /// Try to insert an element into the Virtqueue available ring.
+    ///
+    /// If there is space in the Virtqueue's available ring, this increments the
+    /// internal state and returns the index of the element to be
+    /// written. Otherwise, it returns `None`.
+    pub fn insert(&self) -> Option<u16> {
+        if !self.is_full() {
+            let pos = self.end.get();
+            self.end.set(self.ring_wrapping_add(pos, 1));
+            self.empty.set(false);
+            Some(pos)
+        } else {
+            None
+        }
+    }
+
+    /// Try to remove an element from the Virtqueue available ring.
+    ///
+    /// If there is an element in the Virtqueue's available ring, this removes
+    /// it from its internal state and returns the index of that element.
+    pub fn pop(&self) -> Option<u16> {
+        if !self.is_empty() {
+            let pos = self.start.get();
+            self.start.set(self.ring_wrapping_add(pos, 1));
+            if self.start.get() == self.end.get() {
+                self.empty.set(true);
+            }
+            Some(pos)
+        } else {
+            None
+        }
+    }
+}
+
+/// Internal representation of a slice of memory passed held in the Virtqueue.
+///
+/// Because of Tock's architecture combined with Rust's reference lifetime
+/// rules, buffers are generally passed around as `&mut [u8]` slices with a
+/// `'static` lifetime. Thus, clients pass a mutable static reference into the
+/// Virtqueue, losing access. When the device has processed the provided buffer,
+/// access is restored by passing the slice back to the client.
+///
+/// However, clients may not wish to expose the full slice length to the
+/// device. They cannot simply subslice the slice, as that would mean that
+/// clients loose access to the "sliced off" portion of the slice. Instead,
+/// clients pass a seperate `length` parameter when inserting a buffer into a
+/// virtqueue, by means of the [`VirtqueueBuffer`] struct. This information is
+/// then written to the VirtIO descriptor.
+///
+/// Yet, to be able to reconstruct the entire buffer and hand it back to the
+/// client, information such as the original length must be recorded. We cannot
+/// retain the `&'static mut [u8]` in scope though, as the VirtIO device (host)
+/// writing to it would violate Rust's memory aliasing rules. Thus, we convert a
+/// slice into this struct (converting the slice into its raw parts) for
+/// safekeeping, until we reconstruct a byte-slice from it to hand it back to
+/// the client.
+///
+/// While we technically retain an identical pointer in the
+/// [`VirtqueueDescriptors`] descriptor table, we record it here nonetheless, as
+/// a method to sanity check internal buffer management consistency.
+struct SharedDescriptorBuffer<'b> {
+    ptr: NonNull<u8>,
+    len: usize,
+    _lt: PhantomData<&'b mut [u8]>,
+}
+
+impl<'b> SharedDescriptorBuffer<'b> {
+    pub fn from_slice(slice: &'b mut [u8]) -> SharedDescriptorBuffer<'b> {
+        SharedDescriptorBuffer {
+            ptr: NonNull::new(slice.as_mut_ptr()).unwrap(),
+            len: slice.len(),
+            _lt: PhantomData,
+        }
+    }
+
+    pub fn into_slice(self) -> &'b mut [u8] {
+        unsafe { slice::from_raw_parts_mut(self.ptr.as_ptr(), self.len) }
+    }
+}
+
+/// A slice of memory to be shared with a VirtIO device.
+///
+/// The [`VirtqueueBuffer`] allows to limit the portion of the passed slice to
+/// be shared with the device through the `len` field. Furthermore, the device
+/// can be asked to not write to the shared buffer by setting `device_writeable`
+/// to `false`.
+///
+/// The [`SplitVirtqueue`] does not actually enfore that a VirtIO device adheres
+/// to the `device_writeable` flag, although compliant devices should.
+pub struct VirtqueueBuffer<'b> {
+    pub buf: &'b mut [u8],
+    pub len: usize,
+    pub device_writeable: bool,
+}
+
+/// A VirtIO split Virtqueue.
+///
+/// For documentation on Virtqueues in general, please see the [`Virtqueue`
+/// trait documentation](Virtqueue).
+///
+/// A split Virtqueue is split into separate memory areas, namely:
+///
+/// - a **descriptor table** (VirtIO driver / guest writeable,
+///   [`VirtqueueDescriptors`])
+///
+/// - an **available ring** (VirtIO driver / guest writeable,
+///   [`VirtqueueAvailableRing`])
+///
+/// - a **used ring** (VirtIO device / host writeable, [`VirtqueueUsedRing`])
+///
+/// Each of these areas must be located physically-contiguous in guest-memory
+/// and have different alignment constraints.
+///
+/// This is in constrast to _packed Virtqueues_, which use memory regions that
+/// are read and written by both the VirtIO device (host) and VirtIO driver
+/// (guest).
+pub struct SplitVirtqueue<'a, 'b, const MAX_QUEUE_SIZE: usize> {
+    descriptors: &'a mut VirtqueueDescriptors<MAX_QUEUE_SIZE>,
+    available_ring: &'a mut VirtqueueAvailableRing<MAX_QUEUE_SIZE>,
+    used_ring: &'a mut VirtqueueUsedRing<MAX_QUEUE_SIZE>,
+
+    available_ring_state: AvailableRingHelper,
+    last_used_idx: Cell<u16>,
+
+    transport: OptionalCell<&'a dyn VirtIOTransport>,
+
+    initialized: Cell<bool>,
+    queue_number: Cell<u32>,
+    max_elements: Cell<usize>,
+
+    descriptor_buffers: [OptionalCell<SharedDescriptorBuffer<'b>>; MAX_QUEUE_SIZE],
+
+    client: OptionalCell<&'a dyn SplitVirtqueueClient<'b>>,
+    used_callbacks_enabled: Cell<bool>,
+}
+
+impl<'a, 'b, const MAX_QUEUE_SIZE: usize> SplitVirtqueue<'a, 'b, MAX_QUEUE_SIZE> {
+    pub fn new(
+        descriptors: &'a mut VirtqueueDescriptors<MAX_QUEUE_SIZE>,
+        available_ring: &'a mut VirtqueueAvailableRing<MAX_QUEUE_SIZE>,
+        used_ring: &'a mut VirtqueueUsedRing<MAX_QUEUE_SIZE>,
+    ) -> Self {
+        assert!(descriptors as *const _ as usize % DESCRIPTOR_ALIGNMENT == 0);
+        assert!(available_ring as *const _ as usize % AVAILABLE_RING_ALIGNMENT == 0);
+        assert!(used_ring as *const _ as usize % USED_RING_ALIGNMENT == 0);
+
+        SplitVirtqueue {
+            descriptors,
+            available_ring,
+            used_ring,
+
+            available_ring_state: AvailableRingHelper::new(MAX_QUEUE_SIZE),
+            last_used_idx: Cell::new(0),
+
+            transport: OptionalCell::empty(),
+
+            initialized: Cell::new(false),
+            queue_number: Cell::new(0),
+            max_elements: Cell::new(MAX_QUEUE_SIZE),
+
+            descriptor_buffers: init_constgeneric_default_array(),
+
+            client: OptionalCell::empty(),
+            used_callbacks_enabled: Cell::new(false),
+        }
+    }
+
+    /// Set the [`SplitVirtqueueClient`].
+    pub fn set_client(&self, client: &'a dyn SplitVirtqueueClient<'b>) {
+        self.client.set(client);
+    }
+
+    /// Set the underlying [`VirtIOTransport`]. This must be done prior to
+    /// initialization.
+    pub fn set_transport(&self, transport: &'a dyn VirtIOTransport) {
+        assert!(self.initialized.get() == false);
+        self.transport.set(transport);
+    }
+
+    /// Get the queue number associated with this Virtqueue.
+    ///
+    /// Prior to initialization the SplitVirtqueue does not have an associated
+    /// queue number and will return `None`.
+    pub fn queue_number(&self) -> Option<u32> {
+        if self.initialized.get() {
+            Some(self.queue_number.get())
+        } else {
+            None
+        }
+    }
+
+    /// Get the number of free descriptor slots in the descriptor table.
+    ///
+    /// This takes into account the negotiated maximum queue length.
+    pub fn free_descriptor_count(&self) -> usize {
+        assert!(self.initialized.get());
+        self.descriptor_buffers
+            .iter()
+            .take(self.max_elements.get())
+            .fold(0, |count, descbuf_entry| {
+                if descbuf_entry.is_none() {
+                    count + 1
+                } else {
+                    count
+                }
+            })
+    }
+
+    /// Get the number of (unprocessed) descriptor chains in the Virtqueue's
+    /// used ring.
+    pub fn used_descriptor_chains_count(&self) -> usize {
+        let pending_chains = self
+            .used_ring
+            .idx
+            .get()
+            .wrapping_sub(self.last_used_idx.get());
+
+        // If we ever have more than max_elements pending descriptors,
+        // the used ring increased too fast and has overwritten data
+        assert!(pending_chains as usize <= self.max_elements.get());
+
+        pending_chains as usize
+    }
+
+    /// Remove an element from the Virtqueue's used ring.q
+    ///
+    /// If `self.last_used_idx.get() == self.used_ring.idx.get()` (e.g. we don't
+    /// have an unprocessed used buffer chain) this will return
+    /// `None`. Otherwise it will return the remove ring element's index, as
+    /// well as the number of processed bytes as reported by the VirtIO device.
+    ///
+    /// This will update `self.last_used_idx`.
+    ///
+    /// The caller is responsible for keeping the available ring in sync,
+    /// freeing one entry if a used buffer was removed through this method.
+    fn remove_used_chain(&self) -> Option<(usize, usize)> {
+        assert!(self.initialized.get());
+
+        let pending_chains = self.used_descriptor_chains_count();
+
+        if pending_chains > 0 {
+            let last_used_idx = self.last_used_idx.get();
+
+            // Remove the element one below the index (as 0 indicates
+            // _no_ buffer has been written), hence the index points
+            // to the next element to be written
+            let ring_pos = (last_used_idx as usize) % self.max_elements.get();
+            let chain_top_idx = self.used_ring.ring[ring_pos].id.get();
+            let written_len = self.used_ring.ring[ring_pos].len.get();
+
+            // Increment our local idx counter
+            self.last_used_idx.set(last_used_idx.wrapping_add(1));
+
+            Some((chain_top_idx as usize, written_len as usize))
+        } else {
+            None
+        }
+    }
+
+    /// Add an element to the available queue.
+    ///
+    /// Returns either the inserted ring index or `None` if the Virtqueue's
+    /// available ring is fully occupied.
+    ///
+    /// This will update the available ring's `idx` field.
+    ///
+    /// The caller is responsible for notifying the device about any inserted
+    /// available buffers.
+    fn add_available_descriptor(&self, descriptor_chain_head: usize) -> Option<usize> {
+        assert!(self.initialized.get());
+
+        if let Some(element_pos) = self.available_ring_state.insert() {
+            // Write the element
+            self.available_ring.ring[element_pos as usize]
+                .0
+                .set(descriptor_chain_head as u16);
+
+            // TODO: Perform a suitable memory barrier using a method exposed by
+            // the transport. For now, we don't negotiate
+            // VIRTIO_F_ORDER_PLATFORM, which means that any device which
+            // requires proper memory barriers (read: not implemented in
+            // software, like QEMU) should refuse operation. We use volatile
+            // memory accesses, so read/write reordering by the compiler is not
+            // an issue.
+
+            // Update the idx
+            self.available_ring
+                .idx
+                .set(self.available_ring.idx.get().wrapping_add(1));
+
+            Some(element_pos as usize)
+        } else {
+            None
+        }
+    }
+
+    fn add_descriptor_chain(
+        &self,
+        buffer_chain: &mut [Option<VirtqueueBuffer<'b>>],
+    ) -> Result<usize, ErrorCode> {
+        assert!(self.initialized.get());
+
+        // Get size of actual chain, until the first None
+        let queue_length = buffer_chain
+            .iter()
+            .take_while(|elem| elem.is_some())
+            .count();
+
+        // Make sure we have sufficient space available
+        //
+        // This takes into account the negotiated max size and will
+        // only list free iterators within that range
+        if self.free_descriptor_count() < queue_length {
+            return Err(ErrorCode::NOMEM);
+        }
+
+        // Walk over the descriptor table & buffer chain in parallel,
+        // inserting where empty
+        //
+        // We don't need to do any bounds checking here, if we run
+        // over the boundary it's safe to panic as something is
+        // seriously wrong with `free_descriptor_count`
+        let mut i = 0;
+        let mut previous_descriptor: Option<usize> = None;
+        let mut head = None;
+        let queuebuf_iter = buffer_chain.iter_mut().peekable();
+        for queuebuf in queuebuf_iter.take_while(|queuebuf| queuebuf.is_some()) {
+            // Take the queuebuf out of the caller array
+            let taken_queuebuf = queuebuf.take().expect("queuebuf is None");
+
+            // Sanity check the buffer: the subslice length may never
+            // exceed the slice length
+            assert!(taken_queuebuf.buf.len() >= taken_queuebuf.len);
+
+            while self.descriptor_buffers[i].is_some() {
+                i += 1;
+
+                // We should never run over the end, as we should have
+                // sufficient free descriptors
+                assert!(i < self.descriptor_buffers.len());
+            }
+
+            // Alright, we found a slot to insert the descriptor
+            //
+            // Check if it's the first one and store it's index as head
+            if head.is_none() {
+                head = Some(i);
+            }
+
+            // Write out the descriptor
+            let desc = &self.descriptors.0[i];
+            desc.len.set(taken_queuebuf.len as u32);
+            assert!(desc.len.get() > 0);
+            desc.addr.set(taken_queuebuf.buf.as_ptr() as u64);
+            desc.flags.write(if taken_queuebuf.device_writeable {
+                DescriptorFlags::WriteOnly::SET
+            } else {
+                DescriptorFlags::WriteOnly::CLEAR
+            });
+
+            // Now that we know our descriptor position, check whether
+            // we must chain ourself to a previous descriptor
+            if let Some(prev_index) = previous_descriptor {
+                self.descriptors.0[prev_index]
+                    .flags
+                    .modify(DescriptorFlags::Next::SET);
+                self.descriptors.0[prev_index].next.set(i as u16);
+            }
+
+            // Finally, store the full slice for reference. We don't store a
+            // proper Rust slice reference, as this would violate aliasing
+            // requirements: while the buffer is in the chain, it may be written
+            // by the VirtIO device.
+            //
+            // This can be changed to something slightly more elegant, once the
+            // NonNull functions around slices have been stabilized:
+            // https://doc.rust-lang.org/stable/std/ptr/struct.NonNull.html#method.slice_from_raw_parts
+            self.descriptor_buffers[i]
+                .replace(SharedDescriptorBuffer::from_slice(taken_queuebuf.buf));
+
+            // Set ourself as the previous descriptor, as we know the position
+            // of `next` only in the next loop iteration.
+            previous_descriptor = Some(i);
+
+            // Increment the counter to not check the current
+            // descriptor entry again
+            i += 1;
+        }
+
+        Ok(head.expect("No head added to the descriptor table"))
+    }
+
+    fn remove_descriptor_chain(
+        &self,
+        top_descriptor_index: usize,
+    ) -> [Option<VirtqueueBuffer<'b>>; MAX_QUEUE_SIZE] {
+        assert!(self.initialized.get());
+
+        let mut res: [Option<VirtqueueBuffer<'b>>; MAX_QUEUE_SIZE] =
+            init_constgeneric_default_array();
+
+        let mut i = 0;
+        let mut next_index: Option<usize> = Some(top_descriptor_index);
+
+        while let Some(current_index) = next_index.clone() {
+            // Get a reference over the current descriptor
+            let current_desc = &self.descriptors.0[current_index];
+
+            // Check whether we have a chained descriptor and store that in next_index
+            if current_desc.flags.is_set(DescriptorFlags::Next) {
+                next_index = Some(current_desc.next.get() as usize);
+            } else {
+                next_index = None;
+            }
+
+            // Recover the slice originally associated with this
+            // descriptor & delete it from the buffers array
+            //
+            // The caller may have provided us a larger Rust slice,
+            // but indicated to only provide a subslice to VirtIO,
+            // hence we'll use the stored original slice and also
+            // return the subslice length
+            let supplied_slice = self.descriptor_buffers[current_index]
+                .take()
+                .expect("Virtqueue descriptors and slices out of sync")
+                .into_slice();
+            assert!(supplied_slice.as_mut_ptr() as u64 == current_desc.addr.get());
+
+            // Reconstruct the input VirtqueueBuffer to hand it back
+            res[i] = Some(VirtqueueBuffer {
+                buf: supplied_slice,
+                len: current_desc.len.get() as usize,
+                device_writeable: current_desc.flags.is_set(DescriptorFlags::WriteOnly),
+            });
+
+            // Zero the descriptor
+            current_desc.addr.set(0);
+            current_desc.len.set(0);
+            current_desc.flags.set(0);
+            current_desc.next.set(0);
+
+            // Increment the loop iterator
+            i += 1;
+        }
+
+        res
+    }
+
+    /// Provide a single chain of buffers to the device.
+    ///
+    /// This method will iterate over the passed slice until it encounters the
+    /// first `None`. It will first validate that the number of buffers can be
+    /// inserted into its descriptor table, and if not return
+    /// `Err(ErrorCode::NOMEM)`. If sufficient space is available, it takes the
+    /// passed buffers out of the provided `Option`s until encountering the
+    /// first `None` and shares this buffer chain with the device.
+    ///
+    /// When the device has finished processing the passed buffer chain, it is
+    /// returned to the client either through the
+    /// [`SplitVirtqueueClient::buffer_chain_ready`] callback, or can be
+    /// retrieved through the [`SplitVirtqueue::pop_used_buffer_chain`] method.
+    pub fn provide_buffer_chain(
+        &self,
+        buffer_chain: &mut [Option<VirtqueueBuffer<'b>>],
+    ) -> Result<(), ErrorCode> {
+        assert!(self.initialized.get());
+
+        // Try to add the chain into the descriptor array
+        let descriptor_chain_head = self.add_descriptor_chain(buffer_chain)?;
+
+        // Now make it available to the device. If there was sufficient space
+        // available to add the chain's descriptors (of which there may be
+        // multiple), there should also be sufficient space in the available
+        // ring (where a multi-descriptor chain will occupy only one elements).
+        self.add_available_descriptor(descriptor_chain_head)
+            .expect("Insufficient space in available ring");
+
+        // Notify the queue. This must not fail, given that the SplitVirtqueue
+        // requires a transport to be set prior to initialization.
+        self.transport
+            .map(|t| t.queue_notify(self.queue_number.get()))
+            .unwrap();
+
+        Ok(())
+    }
+
+    /// Attempt to take a buffer chain out of the Virtqueue used ring.
+    ///
+    /// Returns `None` if the used ring is empty.
+    pub fn pop_used_buffer_chain(
+        &self,
+    ) -> Option<([Option<VirtqueueBuffer<'b>>; MAX_QUEUE_SIZE], usize)> {
+        assert!(self.initialized.get());
+
+        self.remove_used_chain()
+            .map(|(descriptor_idx, bytes_used)| {
+                // Get the descriptor chain
+                let chain = self.remove_descriptor_chain(descriptor_idx);
+
+                // Remove the first entry of the available ring, since we
+                // got a single buffer back and can therefore make another
+                // buffer available to the device without risking an
+                // overflow of the used ring
+                self.available_ring_state.pop();
+
+                (chain, bytes_used)
+            })
+    }
+
+    /// Disable callback delivery for the
+    /// [`SplitVirtqueueClient::buffer_chain_ready`] method on the registered
+    /// client.
+    pub fn enable_used_callbacks(&self) {
+        self.used_callbacks_enabled.set(true);
+    }
+
+    /// Enable callback delivery for the
+    /// [`SplitVirtqueueClient::buffer_chain_ready`] method on the registered
+    /// client.
+    ///
+    /// Callback delivery is enabled by default. If this is not desired, call
+    /// this method prior to registering a client.
+    pub fn disable_used_callbacks(&self) {
+        self.used_callbacks_enabled.set(false);
+    }
+}
+
+impl<'a, 'b, const MAX_QUEUE_SIZE: usize> Virtqueue for SplitVirtqueue<'a, 'b, MAX_QUEUE_SIZE> {
+    fn used_interrupt(&self) {
+        assert!(self.initialized.get());
+        // A buffer MAY have been put into the used in by the device
+        //
+        // Try to extract all pending used buffers and return them to
+        // the clients via callbacks
+
+        while self.used_callbacks_enabled.get() {
+            if let Some((mut chain, bytes_used)) = self.pop_used_buffer_chain() {
+                self.client.map(move |client| {
+                    client.buffer_chain_ready(self.queue_number.get(), chain.as_mut(), bytes_used)
+                });
+            } else {
+                break;
+            }
+        }
+    }
+
+    fn physical_addresses(&self) -> VirtqueueAddresses {
+        VirtqueueAddresses {
+            descriptor_area: self.descriptors as *const _ as u64,
+            driver_area: self.available_ring as *const _ as u64,
+            device_area: self.used_ring as *const _ as u64,
+        }
+    }
+
+    fn negotiate_queue_size(&self, max_elements: usize) -> usize {
+        assert!(self.initialized.get() == false);
+        let negotiated = cmp::min(MAX_QUEUE_SIZE, max_elements);
+        self.max_elements.set(negotiated);
+        self.available_ring_state.reset(negotiated);
+        negotiated
+    }
+
+    fn initialize(&self, queue_number: u32, _queue_elements: usize) {
+        assert!(self.initialized.get() == false);
+
+        // The transport must be set prior to initialization:
+        assert!(self.transport.is_some());
+
+        // TODO: Zero the queue
+        //
+        // For now we assume all passed queue buffers are already
+        // zeroed
+
+        self.queue_number.set(queue_number);
+        self.initialized.set(true);
+    }
+}
+
+pub trait SplitVirtqueueClient<'b> {
+    fn buffer_chain_ready(
+        &self,
+        queue_number: u32,
+        buffer_chain: &mut [Option<VirtqueueBuffer<'b>>],
+        bytes_used: usize,
+    );
+}

--- a/chips/virtio/src/queues/split_queue.rs
+++ b/chips/virtio/src/queues/split_queue.rs
@@ -399,6 +399,10 @@ impl<'b> SharedDescriptorBuffer<'b> {
     }
 
     pub fn into_slice(self) -> &'b mut [u8] {
+        // SAFETY: This is guaranteed to be safe because this struct can only be
+        // using the `from_slice()` constructor, `ptr` and `len` cannot be
+        // modified after this struct is created, and this method consumes the
+        // struct.
         unsafe { slice::from_raw_parts_mut(self.ptr.as_ptr(), self.len) }
     }
 }

--- a/chips/virtio/src/transports/mmio.rs
+++ b/chips/virtio/src/transports/mmio.rs
@@ -1,0 +1,408 @@
+//! VirtIO memory mapped device driver
+
+use kernel::utilities::cells::OptionalCell;
+use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
+use kernel::utilities::registers::{
+    register_bitfields, InMemoryRegister, ReadOnly, ReadWrite, WriteOnly,
+};
+use kernel::utilities::StaticRef;
+
+use super::super::devices::{VirtIODeviceDriver, VirtIODeviceType};
+use super::super::queues::Virtqueue;
+use super::super::transports::{VirtIOInitializationError, VirtIOTransport};
+
+// Magic string "virt" every device has to expose
+const VIRTIO_MAGIC_VALUE: [u8; 4] = [0x76, 0x69, 0x72, 0x74];
+
+#[repr(C)]
+pub struct VirtIOMMIODeviceRegisters {
+    /// 0x000 Magic string "virt" for identification
+    magic_value: ReadOnly<u32>,
+    /// 0x004 Device version number
+    device_version: ReadOnly<u32>,
+    /// 0x008 VirtIO Subsystem Device ID
+    device_id: ReadOnly<u32>,
+    /// 0x00C VirtIO Subsystem Vendor ID
+    vendor_id: ReadOnly<u32>,
+    /// 0x010 Flags representing features the device supports
+    device_features: ReadOnly<u32, DeviceFeatures::Register>,
+    /// 0x014 Device (host) features word selection
+    device_features_sel: WriteOnly<u32, DeviceFeatures::Register>,
+    // 0x018 - 0x01C: reserved
+    _reversed0: [u32; 2],
+    /// 0x020 Flags representing features understood and activated by the driver
+    driver_features: WriteOnly<u32>,
+    /// 0x024 Activated (guest) features word selection
+    driver_features_sel: WriteOnly<u32>,
+    // 0x028 - 0x02C: reserved
+    _reserved1: [u32; 2],
+    /// 0x030 Virtual queue index
+    queue_sel: WriteOnly<u32>,
+    /// 0x034 Maximum virtual queue size
+    queue_num_max: ReadOnly<u32>,
+    /// 0x038 Virtual queue size
+    queue_num: WriteOnly<u32>,
+    // 0x03C - 0x40: reserved
+    _reserved2: [u32; 2],
+    /// 0x044 Virtual queue ready bit
+    queue_ready: ReadWrite<u32>,
+    // 0x048 - 0x04C: reserved
+    _reserved3: [u32; 2],
+    /// 0x050 Queue notifier
+    queue_notify: WriteOnly<u32>,
+    // 0x054 - 0x05C: reserved
+    _reserved4: [u32; 3],
+    /// 0x060 Interrupt status
+    interrupt_status: ReadOnly<u32, InterruptStatus::Register>,
+    /// 0x064 Interrupt acknowledge
+    interrupt_ack: WriteOnly<u32, InterruptStatus::Register>,
+    // 0x068 - 0x06C: reserved
+    _reserved5: [u32; 2],
+    /// 0x070 Device status
+    device_status: ReadWrite<u32, DeviceStatus::Register>,
+    // 0x074 - 0x07C: reserved
+    _reserved6: [u32; 3],
+    /// 0x080 - 0x084 Virtual queue's Descriptor Area 64-bit long physical address
+    queue_desc_low: WriteOnly<u32>,
+    queue_desc_high: WriteOnly<u32>,
+    // 0x088 - 0x08C: reserved
+    _reserved7: [u32; 2],
+    /// 0x090 - 0x094 Virtual queue's Driver Area 64-bit long physical address
+    queue_driver_low: WriteOnly<u32>,
+    queue_driver_high: WriteOnly<u32>,
+    // 0x098 - 0x09C: reserved
+    _reserved8: [u32; 2],
+    /// 0x0A0 - 0x0A4 Virtual queue's Device Area 64-bit long physical address
+    queue_device_low: WriteOnly<u32>,
+    queue_device_high: WriteOnly<u32>,
+    // 0x0A8 - 0x0AC: reserved
+    _reserved9: [u32; 21],
+    /// 0x0FC Configuration atomicity value
+    config_generation: ReadOnly<u32>,
+    /// 0x100 - 0x19C device configuration space
+    ///
+    /// This is individually defined per device, with a variable
+    /// size. TODO: How to address this properly? Just hand around
+    /// addresses to this?
+    config: [u32; 40],
+}
+
+register_bitfields![u32,
+    DeviceStatus [
+        Acknowledge OFFSET(0) NUMBITS(1) [],
+        Driver OFFSET(1) NUMBITS(1) [],
+        Failed OFFSET(7) NUMBITS(1) [],
+        FeaturesOk OFFSET(3) NUMBITS(1) [],
+        DriverOk OFFSET(2) NUMBITS(1) [],
+        DeviceNeedsReset OFFSET(6) NUMBITS(1) []
+    ],
+    DeviceFeatures [
+        // TODO
+        Dummy OFFSET(0) NUMBITS(1) []
+    ],
+    InterruptStatus [
+        UsedBuffer OFFSET(0) NUMBITS(1) [],
+        ConfigChange OFFSET(1) NUMBITS(1) []
+    ]
+];
+
+register_bitfields![u64,
+    TransportFeatures [
+        RingIndirectDesc OFFSET(28) NUMBITS(1) [],
+        RingEventIdx OFFSET(29) NUMBITS(1) [],
+        Version1 OFFSET(32) NUMBITS(1) [],
+        AccessPlatform OFFSET(33) NUMBITS(1) [],
+        RingPacked OFFSET(34) NUMBITS(1) [],
+        InOrder OFFSET(35) NUMBITS(1) [],
+        OrderPlatform OFFSET(36) NUMBITS(1) [],
+        SRIOV OFFSET(37) NUMBITS(1) []
+    ]
+];
+
+pub struct VirtIOMMIODevice {
+    regs: StaticRef<VirtIOMMIODeviceRegisters>,
+    device_type: OptionalCell<VirtIODeviceType>,
+    queues: OptionalCell<&'static [&'static dyn Virtqueue]>,
+}
+
+impl VirtIOMMIODevice {
+    pub const fn new(regs: StaticRef<VirtIOMMIODeviceRegisters>) -> VirtIOMMIODevice {
+        VirtIOMMIODevice {
+            regs,
+            device_type: OptionalCell::empty(),
+            queues: OptionalCell::empty(),
+        }
+    }
+
+    pub fn handle_interrupt(&self) {
+        assert!(self.queues.is_some());
+
+        let isr = self.regs.interrupt_status.extract();
+        // Acknowledge all interrupts immediately so that the interrupts is deasserted
+        self.regs.interrupt_ack.set(isr.get());
+
+        if isr.is_set(InterruptStatus::UsedBuffer) {
+            // Iterate over all queues, checking for new buffers in
+            // the used ring
+            self.queues.map(|queues| {
+                for queue in queues.iter() {
+                    queue.used_interrupt();
+                }
+            });
+        }
+
+        if isr.is_set(InterruptStatus::ConfigChange) {
+            // TODO: this should probably be handled?
+        }
+    }
+
+    /// Partial initialization routine as per 4.2.3.1 MMIO-specific
+    /// device initialization
+    ///
+    /// This can be used to query the VirtIO transport information
+    /// (e.g. whether it's a supported transport and the attached
+    /// device)
+    pub fn query(&self) -> Option<VirtIODeviceType> {
+        // Verify that we are talking to a VirtIO MMIO device...
+        if self.regs.magic_value.get() != u32::from_le_bytes(VIRTIO_MAGIC_VALUE) {
+            panic!("Not a VirtIO MMIO device");
+        }
+
+        // with version 2
+        if self.regs.device_version.get() != 0x0002 {
+            panic!(
+                "Unknown VirtIO MMIO device version: {}",
+                self.regs.device_version.get()
+            );
+        }
+
+        // Extract the device type
+        VirtIODeviceType::from_device_id(self.regs.device_id.get())
+    }
+}
+
+impl VirtIOTransport for VirtIOMMIODevice {
+    fn initialize(
+        &self,
+        driver: &dyn VirtIODeviceDriver,
+        queues: &'static [&'static dyn Virtqueue],
+    ) -> Result<VirtIODeviceType, VirtIOInitializationError> {
+        // Initialization routine as per 4.2.3.1 MMIO-specific device
+        // initialization
+
+        // Verify that we are talking to a VirtIO MMIO device...
+        if self.regs.magic_value.get() != u32::from_le_bytes(VIRTIO_MAGIC_VALUE) {
+            return Err(VirtIOInitializationError::NotAVirtIODevice);
+        }
+
+        // with version 2
+        if self.regs.device_version.get() != 0x0002 {
+            return Err(VirtIOInitializationError::InvalidTransportVersion);
+        }
+
+        // Extract the device type, which will later function as an indicator
+        // for initialized
+        let device_id = self.regs.device_id.get();
+        let device_type = VirtIODeviceType::from_device_id(device_id)
+            .ok_or(VirtIOInitializationError::UnknownDeviceType(device_id))?;
+
+        if device_type != driver.device_type() {
+            return Err(VirtIOInitializationError::IncompatibleDriverDeviceType(
+                device_type,
+            ));
+        }
+
+        // All further initialization as per 3.1 Device Initialization
+
+        // 1. Reset the device (by writing 0x0 to the device status register)
+        self.regs.device_status.set(0x0000);
+
+        // 2. Set the ACKNOWLEDGE status bit: the guest OS has noticed the
+        // device
+        self.regs
+            .device_status
+            .modify(DeviceStatus::Acknowledge::SET);
+
+        // 3. Set the DRIVER status bit: the guest OS knows how to drive the
+        // device
+        //
+        // TODO: Maybe not always the case?
+        self.regs.device_status.modify(DeviceStatus::Driver::SET);
+
+        // 4. Read device feature bits, write the subset of feature bits
+        // understood by OS & driver to the device
+        //
+        // Feature bits 0-23 are for the driver, 24-37 for the transport &
+        // queue, 38 and above reserved. The caller may therefore only negotiate
+        // bits 0-23 using the supplied closure, others are possibly initialized
+        // by us.
+        //
+        // The features must be read 32 bits at a time, which are chosen using
+        // DeviceFeaturesSel.
+
+        // Read the virtual 64-bit register
+        //
+        // This is guaranteed to be consistent, the device MUST NOT change
+        // its features during operation
+        self.regs.device_features_sel.set(0);
+        let mut device_features_reg: u64 = self.regs.device_features.get() as u64;
+        self.regs.device_features_sel.set(1);
+        device_features_reg |= (self.regs.device_features.get() as u64) << 32;
+
+        // Negotiate the transport features
+        let offered_transport_features: InMemoryRegister<u64, TransportFeatures::Register> =
+            InMemoryRegister::new(device_features_reg);
+        let selected_transport_features: InMemoryRegister<u64, TransportFeatures::Register> =
+            InMemoryRegister::new(0x0000000000000000);
+
+        // Sanity check: Version1 must be offered AND accepted
+        if !offered_transport_features.is_set(TransportFeatures::Version1) {
+            return Err(VirtIOInitializationError::InvalidVirtIOVersion);
+        } else {
+            selected_transport_features.modify(TransportFeatures::Version1::SET);
+        }
+
+        // Negotiate the driver features. The driver can only select feature
+        // bits for the specific device type, which are assigned to be bits with
+        // indices in the range of 0 to 23.
+        let driver_negotiated =
+            if let Some(nf) = driver.negotiate_features(device_features_reg & 0xFFF) {
+                // Mask the driver's response by the device-specific feature bits.
+                nf & 0xFFF
+            } else {
+                // The driver does not like the offered features, indicate this
+                // failure to the device and report an error:
+                self.regs.device_status.modify(DeviceStatus::Failed::SET);
+                return Err(VirtIOInitializationError::FeatureNegotiationFailed {
+                    offered: offered_transport_features.get(),
+                    accepted: None,
+                });
+            };
+
+        let selected_features = selected_transport_features.get() | driver_negotiated;
+
+        // Write the virtual 64-bit register
+        self.regs.driver_features_sel.set(0);
+        self.regs
+            .driver_features
+            .set((selected_features & 0xFFFF) as u32);
+        self.regs.driver_features_sel.set(1);
+        self.regs
+            .driver_features
+            .set((selected_features >> 32 & 0xFFFF) as u32);
+
+        // 5. Set the FEATURES_OK status bit. We MUST NOT accept new feature
+        // bits after this step.
+        self.regs
+            .device_status
+            .modify(DeviceStatus::FeaturesOk::SET);
+
+        // 6. Re-read device status to ensure that FEATURES_OK is still set,
+        // otherwise the drive does not support the subset of features & is
+        // unusable.
+        if !self.regs.device_status.is_set(DeviceStatus::FeaturesOk) {
+            // The device does not like the accepted features, indicate
+            // this failure to the device and report an error:
+            self.regs.device_status.modify(DeviceStatus::Failed::SET);
+            return Err(VirtIOInitializationError::FeatureNegotiationFailed {
+                offered: offered_transport_features.get(),
+                accepted: Some(selected_features),
+            });
+        }
+
+        // 7. Perform device specific setup
+        //
+        // A device has a number of virtqueues it supports. We try to initialize
+        // all virtqueues passed in as the `queues` parameter, and ignore others
+        // potentially required by the device. If the `queues` parameter
+        // provides more queues than the device can take, abort and fail the
+        // configuration. The device should not use the queues until fully
+        // configured.
+        //
+        // Implementation of the algorithms of 4.2.3.2
+        for (index, queue) in queues.iter().enumerate() {
+            // Select the queue
+            self.regs.queue_sel.set(index as u32);
+
+            // Verify that the queue is not already in use (shouldn't be, since
+            // we've just reset)
+            if self.regs.queue_ready.get() != 0 {
+                self.regs.device_status.modify(DeviceStatus::Failed::SET);
+                return Err(VirtIOInitializationError::DeviceError);
+            }
+
+            // Read the maximum queue size (number of elements) from
+            // QueueNumMax. If the returned value is zero, the queue is not
+            // available
+            let queue_num_max = self.regs.queue_num_max.get() as usize;
+            if queue_num_max == 0 {
+                self.regs.device_status.modify(DeviceStatus::Failed::SET);
+                return Err(VirtIOInitializationError::VirtqueueNotAvailable(index));
+            }
+
+            // Negotiate the queue size, choosing a value fit for QueueNumMax
+            // and the buffer sizes of the passed in queue. This sets the
+            // negotiated value in the queue for later operation.
+            let queue_num = queue.negotiate_queue_size(queue_num_max);
+
+            // Zero the queue memory
+            queue.initialize(index as u32, queue_num);
+
+            // Notify the device about the queue size
+            self.regs.queue_num.set(queue_num as u32);
+
+            // Write the physical queue addresses
+            let addrs = queue.physical_addresses();
+            self.regs.queue_desc_low.set(addrs.descriptor_area as u32);
+            self.regs
+                .queue_desc_high
+                .set((addrs.descriptor_area >> 32) as u32);
+            self.regs.queue_driver_low.set(addrs.driver_area as u32);
+            self.regs
+                .queue_driver_high
+                .set((addrs.driver_area >> 32) as u32);
+            self.regs.queue_device_low.set(addrs.device_area as u32);
+            self.regs
+                .queue_device_high
+                .set((addrs.device_area >> 32) as u32);
+
+            // Set queue to ready
+            self.regs.queue_ready.set(0x0001);
+        }
+
+        // Store the queue references for later usage
+        self.queues.set(queues);
+
+        // Call the hook pre "device-initialization" (setting DRIVER_OK).
+        driver
+            .pre_device_initialization()
+            .map_err(VirtIOInitializationError::DriverPreInitializationError)?;
+
+        // 8. Set the DRIVER_OK status bit
+        self.regs.device_status.modify(DeviceStatus::DriverOk::SET);
+
+        // The device is now "live"
+        self.device_type.set(device_type);
+
+        driver.device_initialized().map_err(|err| {
+            VirtIOInitializationError::DriverInitializationError(device_type, err)
+        })?;
+
+        Ok(device_type)
+    }
+
+    fn queue_notify(&self, queue_id: u32) {
+        // TODO: better way to report an error here? This shouldn't usually be
+        // triggered.
+        assert!(
+            queue_id
+                < self
+                    .queues
+                    .extract()
+                    .expect("VirtIO transport not initialized")
+                    .len() as u32
+        );
+
+        self.regs.queue_notify.set(queue_id);
+    }
+}

--- a/chips/virtio/src/transports/mod.rs
+++ b/chips/virtio/src/transports/mod.rs
@@ -1,0 +1,95 @@
+//! VirtIO transports.
+//!
+//! This module and its submodules provide abstractions for and implementations
+//! of VirtIO transports. For more information, see the documentation of the
+//! [`VirtIOTransport`] trait.
+
+use kernel::ErrorCode;
+
+use super::devices::{VirtIODeviceDriver, VirtIODeviceType};
+use super::queues::Virtqueue;
+
+pub mod mmio;
+
+#[derive(Debug, Copy, Clone)]
+pub enum VirtIOInitializationError {
+    /// Device does not identify itself or can be recognized as a VirtIO device.
+    NotAVirtIODevice,
+    /// An unknown or incompatible VirtIO standard version.
+    InvalidVirtIOVersion,
+    /// An unknown or incompatible VirtIO transport device version.
+    InvalidTransportVersion,
+    /// Unknown VirtIO device type (as defined by the [`VirtIODeviceType`] enum).
+    UnknownDeviceType(u32),
+    /// Driver does not support driving the recognized device type.
+    IncompatibleDriverDeviceType(VirtIODeviceType),
+    /// Feature negotiation between the device and transport + device driver has
+    /// failed.
+    ///
+    /// The device offered the `offered` features, the driver has either not
+    /// accepted this feature set `accepted == None` or has responded with the
+    /// `accepted` feature bitset, which the device has subsequently not
+    /// acknowledged.
+    FeatureNegotiationFailed { offered: u64, accepted: Option<u64> },
+    /// The requested [`Virtqueue`] with respective index is not available with
+    /// this VirtIO device.
+    VirtqueueNotAvailable(usize),
+    /// An error was reported by the
+    /// [`VirtIODeviceDriver::pre_device_initialization`] function. The device
+    /// has been put into the `FAILED` state.
+    DriverPreInitializationError(ErrorCode),
+    /// An error was reported by the [`VirtIODeviceDriver::device_initialized`]
+    /// function. The device status has been previously indicated as `DRIVER_OK`
+    /// and the transport has **NOT** put it into the `FAILED` state, although
+    /// the driver might have. The initialization has continued as usual,
+    /// despite reporting this error, hence it also carries the device type.
+    DriverInitializationError(VirtIODeviceType, ErrorCode),
+    /// An invariant was violated by the device. This error should not occur
+    /// assuming a compliant device, transport and driver implementation.
+    DeviceError,
+}
+
+/// VirtIO transports.
+///
+/// VirtIO can be used over multiple different transports, such as over a PCI
+/// bus, an MMIO device or channel IO. This trait provides a basic abstraction
+/// over such transports.
+pub trait VirtIOTransport {
+    /// Initialize the VirtIO transport using a device driver instance.
+    ///
+    /// This function is expected to run the basic initialization routine as
+    /// defined for the various VirtIO transports. As part of this routine, it
+    /// shall
+    ///
+    /// - negotiate device features,
+    /// - invoke the driver `pre_device_initialization` hook before and
+    ///   `device_initialized` hook after announcing the `DRIVER_OK` device
+    ///   status flag to the device,
+    /// - register the passed [`Virtqueue`]s with the device, calling the
+    ///   [`Virtqueue::initialize`] function with the registered queue ID
+    ///   _before_ registration,
+    /// - as well as perform any other required initialization of the VirtIO
+    ///   transport.
+    ///
+    /// The passed [`Virtqueue`]s are registered with a queue ID matching their
+    /// offset in the supplied slice.
+    ///
+    /// If the initialization fails, it shall report this condition to the
+    /// device _(setting `FAILED`) if_ it has started initializing the device
+    /// (setting the `ACKNOWLEDGE` device status flag), and return an
+    /// appropriate [`VirtIOInitializationError`]. Otherwise, it shall return
+    /// the type of device connected to this VirtIO transport.
+    fn initialize(
+        &self,
+        driver: &dyn VirtIODeviceDriver,
+        queues: &'static [&'static dyn Virtqueue],
+    ) -> Result<VirtIODeviceType, VirtIOInitializationError>;
+
+    /// Notify the device of a changed [`Virtqueue`].
+    ///
+    /// Whenever a queue has been updated (e.g. move descriptors from the used
+    /// to available ring) and these updates shall be made visible to the
+    /// driver, the queue can invoke this function, passing its own respective
+    /// queue ID.
+    fn queue_notify(&self, queue_id: u32);
+}


### PR DESCRIPTION
### Pull Request Overview

This PR adds VirtIO support for the VirtIO `NetworkCard` and `EntropySource` device types, running on the `qemu_rv32_virt` board to be introduced with #2516. Next to the LiteX boards, VirtIO is yet another way towards Ethernet support within Tock. Along with LiteX and probably one other board (perhaps the i.MX RT1060 EVK) it can serve as an example for what Ethernet controllers can look like, to define an Ethernet device HIL in the near term.

Apart from that, VirtIO seems to be generally useful as a standardized interface towards virtualized (and even some non-virtualized!) peripherals and is portable between different emulators and simulation environments. Together with the QEMU RISC-V 32bit `virt` target, it can serve as a stable base to improve on Tock's virtualized board support and is likely very useful in testing. Furthermore, QEMU also defines an ARM `virt` target, which has VirtIO devices mapped in an identical fashion.

As a follow-up to this PR, I am preparing a "TAP" driver PR for delivering Ethernet frames to userspace and implementing basic IP networking support in userspace using LwIP (web-server working locally with both QEMU and the physical LiteX FPGA board).

### Testing Strategy

This pull request was tested by running a small Ethernet "switch" (really more of a two-port hub) demo in kernel to test the `NetworkCard`, integrating this codebase with the WIP Tock Ethernet infrastructure on the `tock-ethernet` branch, and the randomness test app to test the `EntropySource`.


### TODO or Help Wanted

This pull request still needs some work in the following areas:

- [x] Generally improving code quality. I have written much of this over two years ago; some parts have not aged well.
- [x] Writing more documentation. While the VirtIO MMIO transport is reasonably well documented, some traits and especially the entire `split_queue.rs` file require more extensive documentation.
- [x] ~Safety & soundness checks. While almost all of the VirtIO support is implemented through capsules (and VirtIO device drivers in `capsules::virtio::devices` can definitely stay this way, how awesome is that?), the VirtIO transports and queues might need to move. While these parts do not use any `unsafe` code directly currently, they should not be kept in capsules given they interact with device registers through `StaticRef`s passed to them, or by having VirtIO devices write to `&mut [u8]` slices (the former might be problematic from a safety and isolation perspective, while the latter is straight up unsound and needs to use raw pointer operations).~ VirtIO support has been moved to its own chip crate, where it does use some unsafe to ensure that we're not violating Rust's memory aliasing requirements.
- [x] Removing the dummy Ethernet implementation from the `qemu_rv32_virt` board initialization and revert the Makefile hacks to instantiate two TAP network interfaces on the host for this demo.
- [x] ~Writing components for the VirtIO peripherals.~ Components postponed. Presumably we'll only have one chip supporting this, at least in the short term?
- [x] Write a primitve auto-discovery mechanism to retrieve VirtIO transports offering a specific device type to assign devices to drivers. (Users should not have to assign VirtIO devices to specific VirtIO MMIO transports exposed through QEMU)

### Documentation Updated

- [x] ~Updated the relevant files in `/docs`,~ or no updates are required.

### Formatting

- [x] Ran `make prepush`.
