### PR TITLE
boards/litex: README upkeep (fix RISC-V extensions, mention & explain tockloader flash-file support)

### DIFF
--- a/boards/README.md
+++ b/boards/README.md
@@ -30,8 +30,8 @@ that Tock supports.
 | [SiFive HiFive1 Rev B](hifive1/README.md)                            | RISC-V          | FE310-G002     | openocd    | tockloader     | Yes (5.1)     |
 | [Digilent Arty A-7 100T](arty_e21/README.md)                         | RISC-V RV32IMAC | SiFive E21     | openocd    | tockloader     | No            |
 | [OpenTitan Earlgrey on CW310](opentitan/earlgrey-cw310/README.md)    | RISC-V RV32IMC  | EarlGrey       | custom     | custom         | Yes (5.1)     |
-| [LiteX on Digilent Arty A-7](litex/arty/README.md)                   | RISC-V RV32I    | LiteX+VexRiscV | custom     | custom         | No            |
-| [Verilated LiteX Simulation](litex/sim/README.md)                    | RISC-V RV32I    | LiteX+VexRiscv | custom     | custom         | No            |
+| [LiteX on Digilent Arty A-7](litex/arty/README.md)                   | RISC-V RV32IMC  | LiteX+VexRiscV | custom     | custom         | No            |
+| [Verilated LiteX Simulation](litex/sim/README.md)                    | RISC-V RV32IMC  | LiteX+VexRiscv | custom     | custom         | No            |
 | [ESP32-C3-DevKitM-1](esp32-c3-devkitM-1/README.md)                   | RISC-V-ish RV32I| ESP32-C3       | custom     | custom         | No            |
 
 # Out of Tree Boards

--- a/boards/README.md
+++ b/boards/README.md
@@ -4,35 +4,40 @@ Platforms Supported by Tock
 The `/boards` directory contains the physical hardware platforms
 that Tock supports.
 
-| Board                                                                | Architecture    | MCU            | Interface  | App deployment | QEMU Support? |
-|----------------------------------------------------------------------|-----------------|----------------|------------|----------------|---------------|
-| [Hail](hail/README.md)                                               | ARM Cortex-M4   | SAM4LC8BA      | Bootloader | tockloader     | No            |
-| [Imix](imix/README.md)                                               | ARM Cortex-M4   | SAM4LC8CA      | Bootloader | tockloader     | No            |
-| [Nordic nRF52-DK](nordic/nrf52dk/README.md)                          | ARM Cortex-M4   | nRF52832       | jLink      | tockloader     | No            |
-| [Nordic nRF52840-DK](nordic/nrf52840dk/README.md)                    | ARM Cortex-M4   | nRF52840       | jLink      | tockloader     | No            |
-| [Nordic nRF52840-Dongle](nordic/nrf52840_dongle/README.md)           | ARM Cortex-M4   | nRF52840       | jLink      | tockloader     | No            |
-| [ACD52832](acd52832/README.md)                                       | ARM Cortex-M4   | nRF52832       | jLink      | tockloader     | No            |
-| [Nano 33 BLE](nano33ble/README.md)                                   | ARM Cortex-M4   | nRF52840       | Bootloader | tockloader     | No            |
-| [Nano RP2040 Connect](nano_rp2040_connect/README.md)                 | ARM Cortex-M0+  | RP2040         | custom     | custom         | No            |
-| [Clue nRF52840](clue_nrf52840/README.md)                             | ARM Cortex-M4   | nRF52840       | Bootloader | tockloader     | No            |
-| [BBC Micro:bit v2](microbit_v2/README.md)                            | ARM Cortex-M4   | nRF52833       | openocd    | tockloader     | No            |
-| [ST Nucleo F446RE](nucleo_f446re/README.md)                          | ARM Cortex-M4   | STM32F446      | openocd    | custom         | #1827         |
-| [ST Nucleo F429ZI](nucleo_f429zi/README.md)                          | ARM Cortex-M4   | STM32F429      | openocd    | custom         | #1827         |
-| [STM32F3Discovery kit](stm32f3discovery/README.md)                   | ARM Cortex-M4   | STM32F303VCT6  | openocd    | custom         | #1827         |
-| [STM32F412G Discovery kit](stm32f412gdiscovery/README.md)            | ARM Cortex-M4   | STM32F412G     | openocd    | custom         | #1827         |
-| [WeAct F401CCU6 Core Board](weact_f401ccu6/README.md)                | ARM Cortex-M4   | STM32F401CCU6  | openocd    | custom         | No            |
-| [SparkFun RedBoard Artemis Nano](redboard_artemis_nano/README.md)    | ARM Cortex-M4   | Apollo3        | custom     | custom         | No            |
-| [SparkFun RedBoard Red-V](redboard_redv/README.md)                   | RISC-V          | FE310-G002     | openocd    | tockloader     | Yes (5.1)     |
-| [i.MX RT 1052 Evaluation Kit](imxrt1050-evkb/README.md)              | ARM Cortex-M7   | i.MX RT 1052   | custom     | custom         | No            |
-| [Teensy 4.0](teensy40/README.md)                                     | ARM Cortex-M7   | i.MX RT 1062   | custom     | custom         | No            |
-| [Pico Explorer Base](pico_explorer_base/README.md)                   | ARM Cortex-M0+  | RP2040         | openocd    | openocd        | No            |
-| [Raspberry Pi Pico](raspberry_pi_pico/README.md)                     | ARM Cortex-M0+  | RP2040         | openocd    | openocd        | No            |
-| [SiFive HiFive1 Rev B](hifive1/README.md)                            | RISC-V          | FE310-G002     | openocd    | tockloader     | Yes (5.1)     |
-| [Digilent Arty A-7 100T](arty_e21/README.md)                         | RISC-V RV32IMAC | SiFive E21     | openocd    | tockloader     | No            |
-| [OpenTitan Earlgrey on CW310](opentitan/earlgrey-cw310/README.md)    | RISC-V RV32IMC  | EarlGrey       | custom     | custom         | Yes (5.1)     |
-| [LiteX on Digilent Arty A-7](litex/arty/README.md)                   | RISC-V RV32IMC  | LiteX+VexRiscV | custom     | custom         | No            |
-| [Verilated LiteX Simulation](litex/sim/README.md)                    | RISC-V RV32IMC  | LiteX+VexRiscv | custom     | custom         | No            |
-| [ESP32-C3-DevKitM-1](esp32-c3-devkitM-1/README.md)                   | RISC-V-ish RV32I| ESP32-C3       | custom     | custom         | No            |
+| Board                                                             | Architecture     | MCU            | Interface  | App deployment              | QEMU Support? |
+|-------------------------------------------------------------------|------------------|----------------|------------|-----------------------------|---------------|
+| [Hail](hail/README.md)                                            | ARM Cortex-M4    | SAM4LC8BA      | Bootloader | tockloader                  | No            |
+| [Imix](imix/README.md)                                            | ARM Cortex-M4    | SAM4LC8CA      | Bootloader | tockloader                  | No            |
+| [Nordic nRF52-DK](nordic/nrf52dk/README.md)                       | ARM Cortex-M4    | nRF52832       | jLink      | tockloader                  | No            |
+| [Nordic nRF52840-DK](nordic/nrf52840dk/README.md)                 | ARM Cortex-M4    | nRF52840       | jLink      | tockloader                  | No            |
+| [Nordic nRF52840-Dongle](nordic/nrf52840_dongle/README.md)        | ARM Cortex-M4    | nRF52840       | jLink      | tockloader                  | No            |
+| [ACD52832](acd52832/README.md)                                    | ARM Cortex-M4    | nRF52832       | jLink      | tockloader                  | No            |
+| [Nano 33 BLE](nano33ble/README.md)                                | ARM Cortex-M4    | nRF52840       | Bootloader | tockloader                  | No            |
+| [Nano RP2040 Connect](nano_rp2040_connect/README.md)              | ARM Cortex-M0+   | RP2040         | custom     | custom                      | No            |
+| [Clue nRF52840](clue_nrf52840/README.md)                          | ARM Cortex-M4    | nRF52840       | Bootloader | tockloader                  | No            |
+| [BBC Micro:bit v2](microbit_v2/README.md)                         | ARM Cortex-M4    | nRF52833       | openocd    | tockloader                  | No            |
+| [ST Nucleo F446RE](nucleo_f446re/README.md)                       | ARM Cortex-M4    | STM32F446      | openocd    | custom                      | #1827         |
+| [ST Nucleo F429ZI](nucleo_f429zi/README.md)                       | ARM Cortex-M4    | STM32F429      | openocd    | custom                      | #1827         |
+| [STM32F3Discovery kit](stm32f3discovery/README.md)                | ARM Cortex-M4    | STM32F303VCT6  | openocd    | custom                      | #1827         |
+| [STM32F412G Discovery kit](stm32f412gdiscovery/README.md)         | ARM Cortex-M4    | STM32F412G     | openocd    | custom                      | #1827         |
+| [WeAct F401CCU6 Core Board](weact_f401ccu6/README.md)             | ARM Cortex-M4    | STM32F401CCU6  | openocd    | custom                      | No            |
+| [SparkFun RedBoard Artemis Nano](redboard_artemis_nano/README.md) | ARM Cortex-M4    | Apollo3        | custom     | custom                      | No            |
+| [SparkFun RedBoard Red-V](redboard_redv/README.md)                | RISC-V           | FE310-G002     | openocd    | tockloader                  | Yes (5.1)     |
+| [i.MX RT 1052 Evaluation Kit](imxrt1050-evkb/README.md)           | ARM Cortex-M7    | i.MX RT 1052   | custom     | custom                      | No            |
+| [Teensy 4.0](teensy40/README.md)                                  | ARM Cortex-M7    | i.MX RT 1062   | custom     | custom                      | No            |
+| [Pico Explorer Base](pico_explorer_base/README.md)                | ARM Cortex-M0+   | RP2040         | openocd    | openocd                     | No            |
+| [Raspberry Pi Pico](raspberry_pi_pico/README.md)                  | ARM Cortex-M0+   | RP2040         | openocd    | openocd                     | No            |
+| [SiFive HiFive1 Rev B](hifive1/README.md)                         | RISC-V           | FE310-G002     | openocd    | tockloader                  | Yes (5.1)     |
+| [Digilent Arty A-7 100T](arty_e21/README.md)                      | RISC-V RV32IMAC  | SiFive E21     | openocd    | tockloader                  | No            |
+| [OpenTitan Earlgrey on CW310](opentitan/earlgrey-cw310/README.md) | RISC-V RV32IMC   | EarlGrey       | custom     | custom                      | Yes (5.1)     |
+| [LiteX on Digilent Arty A-7](litex/arty/README.md)                | RISC-V RV32IMC   | LiteX+VexRiscV | custom     | tockloader (flash-file)[^1] | No            |
+| [Verilated LiteX Simulation](litex/sim/README.md)                 | RISC-V RV32IMC   | LiteX+VexRiscv | custom     | tockloader (flash-file)[^1] | No            |
+| [ESP32-C3-DevKitM-1](esp32-c3-devkitM-1/README.md)                | RISC-V-ish RV32I | ESP32-C3       | custom     | custom                      | No            |
+
+[^1]: Tockloader is not able to interact with this board directly, but
+      can be used to work on a flash-image of the board, which can in
+      turn be flashed onto / read from the board. For more specific
+      information, visit the board's README.
 
 # Out of Tree Boards
 

--- a/boards/litex/arty/README.md
+++ b/boards/litex/arty/README.md
@@ -122,8 +122,8 @@ available as `lxterm`):
 $ ./litex/litex/tools/litex_term.py \
     --speed 10000000 \
 	--serial-boot \
-	--kernel $TOCK_BINARY \
-	$SERIAL_PORT
+    --kernel $TOCK_BINARY \
+    $SERIAL_PORT
 ```
 , where `TOCK_BINARY` points to the board's binary (kernel, optionally
 including optionally applications), and `SERIAL_PORT` is the UART
@@ -181,6 +181,39 @@ $ cp $PATH_TO_TOCK/target/riscv32i-unknown-none-elf/release/litex_arty.bin \
 Make sure that the tftp server is running and the firewall is
 configured correctly.
 
+### Running Applications
+
+The LiteX Arty board does not currently expose or use any persistent storage,
+other than to hold the FPGA bistream containing the LiteX BIOS. For this reason,
+Tockloader is not able to interact with this board directly. However, Tockloader
+includes a flash-file support mode which supports operating on a binary file
+representing the device's flash. This can be used to combine the kernel and
+applications in a single binary, which can then be loaded onto the board using
+the above methods. An example of this is illustrated below:
+
+```
+$ tockloader flash \
+    --board litex_arty \
+    --flash-file ./litex_arty_flash.bin \
+	-a 0x0 \
+	./tock/target/riscv32imc-unknown-none-elf/release/litex_arty.bin
+[INFO   ] Operating on flash file "./litex_arty_flash.bin".
+[INFO   ] Limiting flash size to 0x8000000 bytes.
+[STATUS ] Flashing binary to board...
+[INFO   ] Finished in 0.000 seconds
+$ tockloader install \
+    --board litex_arty \
+    --arch rv32imc \
+    --flash-file ./litex_arty_flash.bin \
+    ./libtock-c/examples/c_hello/build/c_hello.tab
+[INFO   ] Using settings from KNOWN_BOARDS["litex_arty"]
+[INFO   ] Operating on flash file "./litex_arty_flash.bin".
+[INFO   ] Limiting flash size to 0x10000000 bytes.
+[STATUS ] Installing app on the board...
+[INFO   ] Found sort order:
+[INFO   ]   App "c_hello" at address 0x41000060
+[INFO   ] Finished in 0.002 seconds
+```
 
 Debugging
 ---------

--- a/boards/litex/arty/README.md
+++ b/boards/litex/arty/README.md
@@ -195,8 +195,8 @@ the above methods. An example of this is illustrated below:
 $ tockloader flash \
     --board litex_arty \
     --flash-file ./litex_arty_flash.bin \
-	-a 0x0 \
-	./tock/target/riscv32imc-unknown-none-elf/release/litex_arty.bin
+    -a 0x0 \
+    ./tock/target/riscv32imc-unknown-none-elf/release/litex_arty.bin
 [INFO   ] Operating on flash file "./litex_arty_flash.bin".
 [INFO   ] Limiting flash size to 0x8000000 bytes.
 [STATUS ] Flashing binary to board...

--- a/boards/litex/sim/README.md
+++ b/boards/litex/sim/README.md
@@ -86,6 +86,41 @@ If everything works you should be greeted by the Tock kernel:
 Verilated LiteX+VexRiscv: initialization complete, entering main loop.
 ```
 
+### Running with Applications
+
+By its nature, this simulated board does not feature any persistent storage. For
+this reason, Tockloader is not able to interact with a running LiteX Simulator
+instance directly. However, Tockloader includes a flash-file support mode which
+supports operating on a binary file representing a device's flash. This can be
+used to combine the kernel and applications in a single binary, which can then
+be loaded into the simulation using the above method (passed to the `--rom-init`
+parameter). An example of this is illustrated below:
+
+```
+$ tockloader flash \
+    --board litex_sim \
+    --flash-file ./litex_sim_flash.bin \
+    -a 0x0 \
+    ./tock/target/riscv32imc-unknown-none-elf/release/litex_sim.bin
+[INFO   ] Using settings from KNOWN_BOARDS["litex_sim"]
+[INFO   ] Operating on flash file "./litex_sim_flash.bin".
+[INFO   ] Limiting flash size to 0x100000 bytes.
+[STATUS ] Flashing binary to board...
+[INFO   ] Finished in 0.000 seconds
+$ tockloader install \
+    --board litex_sim \
+    --arch rv32imc \
+    --flash-file ./litex_sim_flash.bin \
+    ./libtock-c/examples/c_hello/build/c_hello.tab
+[INFO   ] Using settings from KNOWN_BOARDS["litex_sim"]
+[INFO   ] Operating on flash file "./litex_sim_flash.bin".
+[INFO   ] Limiting flash size to 0x100000 bytes.
+[STATUS ] Installing app on the board...
+[INFO   ] Found sort order:
+[INFO   ]   App "c_hello" at address 0x80060
+[INFO   ] Finished in 0.002 seconds
+```
+
 Debugging
 ---------
 


### PR DESCRIPTION
### Pull Request Overview

This pull request

- fixes the boards overview (platform) README table to show the correct RISC-V extensions for the LiteX boards,
- explicitly mentions tockloader flash-file support both in the boards overview (platform) README, and in both LiteX board READMEs with an example on how to use that,
- and finally removes some tab characters from the LiteX Arty README which must've gotten in there accidentally.


### Testing Strategy

N/A

### TODO or Help Wanted

N/A

### Documentation Updated

- [x] ~Updated the relevant files in `/docs`,~ or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
