### PR TITLE
Fix temperature sign in bme280 and bmp280 drivers

### DIFF
--- a/capsules/src/bme280.rs
+++ b/capsules/src/bme280.rs
@@ -108,7 +108,7 @@ pub struct Bme280<'a> {
     humidity_client: OptionalCell<&'a dyn HumidityClient>,
     state: Cell<DeviceState>,
     op: Cell<Operation>,
-    t_fine: Cell<usize>,
+    t_fine: Cell<i32>,
 }
 
 impl<'a> Bme280<'a> {
@@ -292,9 +292,13 @@ impl<'a> I2CClient for Bme280<'a> {
                     Operation::None => (),
                     Operation::Temp => {
                         let calib = self.calibration.get();
-                        let adc_temperature = (buffer[0] as usize) << 12
+
+                        // note: per datasheet, measurement is 20-bit two's complement
+                        let adc_temperature: i32 = (((buffer[0] as usize) << 12
                             | (buffer[1] as usize) << 4
-                            | (((buffer[2] as usize) >> 4) & 0x0F);
+                            | (((buffer[2] as usize) >> 4) & 0x0F) << 12)
+                            as i32)
+                            >> 12; // ensure sign extension
 
                         if adc_temperature == 0 {
                             // We got a misread, try again
@@ -304,28 +308,28 @@ impl<'a> I2CClient for Bme280<'a> {
                             return;
                         }
 
-                        let var1 = (((adc_temperature >> 3) - ((calib.temp1 as usize) << 1))
-                            * (calib.temp2 as usize))
+                        let var1 = (((adc_temperature >> 3) - ((calib.temp1 as i32) << 1))
+                            * (calib.temp2 as i32))
                             >> 11;
-                        let var2 = (((((adc_temperature >> 4) - (calib.temp1 as usize))
-                            * ((adc_temperature >> 4) - (calib.temp1 as usize)))
+                        let var2 = (((((adc_temperature >> 4) - (calib.temp1 as i32))
+                            * ((adc_temperature >> 4) - (calib.temp1 as i32)))
                             >> 12)
-                            * (calib.temp3 as usize))
+                            * (calib.temp3 as i32))
                             >> 14;
 
                         self.t_fine.set(var1 + var2);
 
-                        let temperature = ((self.t_fine.get() * 5 + 128) >> 8) / 100;
+                        let temperature = (self.t_fine.get() * 5 + 128) >> 8;
 
                         self.temperature_client
-                            .map(|client| client.callback(temperature));
+                            .map(|client| client.callback(temperature as usize));
                     }
                     Operation::Pressure => {
                         unimplemented!();
                     }
                     Operation::Humidity => {
                         let calib = self.calibration.get();
-                        let adc_hum = (buffer[0] as usize) << 8 | buffer[1] as usize;
+                        let adc_hum = (((buffer[0] as u32) << 8) | (buffer[1] as u32)) as i32;
 
                         if adc_hum == 0 {
                             // We got a misread, try again
@@ -339,23 +343,23 @@ impl<'a> I2CClient for Bme280<'a> {
 
                         // This is straight from the datasheet
                         let var1 = ((((adc_hum << 14)
-                            - ((calib.hum4 as usize) << 20)
-                            - ((calib.hum5 as usize) * t_fine_offset))
+                            - ((calib.hum4 as i32) << 20)
+                            - ((calib.hum5 as i32) * t_fine_offset))
                             + 16384)
                             >> 15)
-                            * (((((((t_fine_offset * (calib.hum6 as usize)) >> 10)
-                                * (((t_fine_offset * (calib.hum3 as usize)) >> 11) + 32768))
+                            * (((((((t_fine_offset * (calib.hum6 as i32)) >> 10)
+                                * (((t_fine_offset * (calib.hum3 as i32)) >> 11) + 32768))
                                 >> 10)
                                 + 2097152)
-                                * (calib.hum2 as usize)
+                                * (calib.hum2 as i32)
                                 + 8192)
                                 >> 14);
                         let var2 = var1
-                            - (((((var1 >> 15) * (var1 >> 15)) >> 7) * (calib.hum1 as usize)) >> 4);
+                            - (((((var1 >> 15) * (var1 >> 15)) >> 7) * (calib.hum1 as i32)) >> 4);
 
                         let var6 = if var2 > 419430400 { 419430400 } else { var2 };
 
-                        let hum = (var6 >> 12) / 1024;
+                        let hum = ((var6 >> 12) / 1024) as usize;
 
                         self.humidity_client.map(|client| client.callback(hum));
                     }

--- a/capsules/src/bmp280.rs
+++ b/capsules/src/bmp280.rs
@@ -73,7 +73,7 @@ impl CalibrationData {
         }
     }
 
-    fn temp_from_raw(&self, raw_temp: u32) -> i32 {
+    fn temp_from_raw(&self, raw_temp: i32) -> i32 {
         let temp = raw_temp as i32; // guaranteed to succeed because raw temp has only 20 significant bits maximum.
         let dig_t1 = self.dig_t1 as i32; // same, 16-bits
         let dig_t2 = self.dig_t2 as i32; // same, 16-bits
@@ -395,7 +395,8 @@ impl<'a, A: Alarm<'a>> i2c::I2CClient for Bmp280<'a, A> {
                     let msb = readout[0] as u32;
                     let lsb = readout[1] as u32;
                     let xlsb = readout[2] as u32;
-                    let raw_temp = (msb << 12) + (lsb << 4) + (xlsb >> 4);
+                    let raw_temp: i32 =
+                        ((((msb << 12) + (lsb << 4) + (xlsb >> 4)) << 12) as i32) >> 12; // ensure sign extention
                     temp_readout = Some(calibration.temp_from_raw(raw_temp));
                     State::Idle(calibration)
                 }


### PR DESCRIPTION

### Pull Request Overview

Temperature is a 20-bit, two's complement value in both the BME280 and BMP280 chips. Further,
the datasheets provide example code, which treats all units as signed,
32-bit values while doing math.

This came up when considering #2967 and looking through temperature sensor drivers and datasheets. I wanted to decouple it though, since it's chip-specific changes.

Functionally, this PR should make no difference except for temperatures
below zero Celsius. They still won't work right until #2867 lands, but that's an easy fix.


### Testing Strategy & Help Wanted

I don't have hardware for these sensors! @dcz-self and @alistair23 are you able to ensure I didn't break temperature readings?


### TODO or Help Wanted

- [ ] Test BME280
- [ ] Test BMP280

### Documentation Updated

- [N/A] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
