### PR TITLE
RFC: `tock-registers` macros: avoid unsoundness, support tests

### DIFF
--- a/libraries/tock-register-interface/examples/register_structs.rs
+++ b/libraries/tock-register-interface/examples/register_structs.rs
@@ -1,0 +1,18 @@
+//! An example of using the `register_structs!` macro.
+
+use tock_registers::register_structs;
+
+register_structs! {
+    Foo {
+        (0x00 => ro_single: ReadOnly<u32, ()>),
+        (0x04 => ro_array: [ReadOnly<u32, ()>; 2]),
+        (0x0c => rw_single: ReadWrite<u32, ()>),
+        (0x10 => rw_array: [ReadWrite<u32, ()>; 3]),
+        (0x1c => wo_single: WriteOnly<u32, ()>),
+        //(0x20 => _padding),
+        (0x24 => wo_array: [WriteOnly<u32, ()>; 4]),
+        //(0x34 => @END),
+    }
+}
+
+fn main() {}

--- a/libraries/tock-register-interface/examples/registers.rs
+++ b/libraries/tock-register-interface/examples/registers.rs
@@ -1,0 +1,16 @@
+//! An example of using the `registers!` macro.
+
+use tock_registers::registers;
+
+registers! {
+    foo {
+        (0x00 => ro_single: ReadOnly<u32, ()>),
+        (0x04 => ro_array: [ReadOnly<u32, ()>; 2]),
+        (0x0c => rw_single: ReadWrite<u32, ()>),
+        (0x10 => rw_array: [ReadWrite<u32, ()>; 3]),
+        (0x1c => wo_single: WriteOnly<u32, ()>),
+        (0x20 => wo_array: [WriteOnly<u32, ()>; 4]),
+    }
+}
+
+fn main() {}

--- a/libraries/tock-register-interface/src/internal.rs
+++ b/libraries/tock-register-interface/src/internal.rs
@@ -1,0 +1,84 @@
+//! Module containing items used by `tock-registers` macros. These must be `pub`
+//! so the macros can use them, but are not intended to be part of
+//! `tock-registers`' API.
+//!
+//! In other words: don't use any of these outside this crate.
+
+use core::ptr::{read_volatile, write_volatile};
+use crate::{TooLargeIndex, WriteSuccess};
+
+// Reads a value from a MMIO non-array register.
+//
+// Safety:
+//     mmio must point to the beginning of the peripheral.
+//
+//     REL_ADDR must be the address of the register to read, relative to the
+//     beginning of the peripheral.
+//
+//     This register must be readable.
+#[inline]
+pub unsafe fn mmio_read<const REL_ADDR: usize, Mmio, T>(mmio: &Mmio) -> T
+{
+    // This is unsound under strict provenance. Under strict provenance, we
+    // should attach mmio's provenance to the resulting pointer. For now, we
+    // can't do that without enabling a nightly feature (which may be worth
+    // doing in Miri) or using the `sptr` crate.
+    let addr = (mmio as *const _ as usize + REL_ADDR) as *const T;
+    unsafe { read_volatile(addr) }
+}
+
+// Reads a value from a MMIO array register.
+//
+// Safety:
+//     mmio must point to the beginning of the peripheral.
+//
+//     REL_ADDR must be the address of the beginning of the register array,
+//     relative to the beginning of the peripheral.
+//
+//     This register must be readable.
+#[inline]
+pub unsafe fn mmio_read_array<const REL_ADDR: usize, const LEN: usize, Mmio, T>(mmio: &Mmio, idx: usize)
+    -> Result<T, TooLargeIndex>
+{
+    if idx >= LEN { return Err(TooLargeIndex); }
+    // See the comment in mmio_read about strict provenance.
+    let array_start = (mmio as *const _ as usize + REL_ADDR) as *const T;
+    Ok(unsafe { read_volatile(array_start.add(idx)) })
+}
+
+// Writes a value to a MMIO non-array register.
+//
+// Safety:
+//     mmio must point to the beginning of the peripheral.
+//
+//     REL_ADDR must be the address of the register to write, relative to the
+//     beginning of the peripheral.
+//
+//     This register must be writable.
+#[inline]
+pub unsafe fn mmio_write<const REL_ADDR: usize, Mmio, T>(mmio: &Mmio, value: T)
+{
+    // See the comment in mmio_read about strict provenance.
+    let addr = (mmio as *const _ as usize + REL_ADDR) as *mut T;
+    unsafe { write_volatile(addr, value) }
+}
+
+// Writes a value to a MMIO array register.
+//
+// Safety:
+//     mmio must point to the beginning of the peripheral.
+//
+//     REL_ADDR must be the address of the beginning of the register array,
+//     relative to the beginning of the peripheral.
+//
+//     This register must be writable.
+#[inline]
+pub unsafe fn mmio_write_array<const REL_ADDR: usize, const LEN: usize, Mmio, T>(mmio: &Mmio, value: T, idx: usize)
+    -> Result<WriteSuccess, TooLargeIndex>
+{
+    if idx >= LEN { return Err(TooLargeIndex); }
+    // See the comment in mmio_read about strict provenance.
+    let array_start = (mmio as *const _ as usize + REL_ADDR) as *mut T;
+    unsafe { write_volatile(array_start.add(idx), value) }
+    Ok(WriteSuccess)
+}

--- a/libraries/tock-register-interface/src/lib.rs
+++ b/libraries/tock-register-interface/src/lib.rs
@@ -57,9 +57,11 @@
 // If we don't build any actual register types, we don't need unsafe
 // code in this crate
 #![cfg_attr(not(feature = "register_types"), forbid(unsafe_code))]
+#![deny(unsafe_op_in_unsafe_fn)]
 
 pub mod fields;
 pub mod interfaces;
+pub mod internal;
 pub mod macros;
 
 #[cfg(feature = "register_types")]
@@ -126,3 +128,9 @@ pub trait RegisterLongName {}
 // Useful implementation for when no RegisterLongName is required
 // (e.g. no fields need to be accessed, just the raw register values)
 impl RegisterLongName for () {}
+
+/// An array index was out of bounds.
+pub struct TooLargeIndex;
+
+/// Indicates a register write succeeded.
+pub struct WriteSuccess;

--- a/libraries/tock-register-interface/src/macros.rs
+++ b/libraries/tock-register-interface/src/macros.rs
@@ -1,380 +1,273 @@
 //! Macros for cleanly defining peripheral registers.
 
 #[macro_export]
-macro_rules! register_fields {
-    // Macro entry point.
-    (@root $(#[$attr_struct:meta])* $vis_struct:vis $name:ident $(<$life:lifetime>)? { $($input:tt)* } ) => {
-        $crate::register_fields!(
-            @munch (
-                $($input)*
-            ) -> {
-                $vis_struct struct $(#[$attr_struct])* $name $(<$life>)?
+macro_rules! registers {
+    (
+        $(
+            $(#[$mod_attr:meta])*
+            $vis:vis $name:ident {
+                $(
+                    $(#[$field_attr:meta])*
+                    ($offset:literal => $reg_name:ident: $($tokens:tt)*)
+                ),*
+                $(,)?
             }
-        );
-    };
-
-    // Print the struct once all fields have been munched.
-    (@munch
-        (
-            $(#[$attr_end:meta])*
-            ($offset:expr => @END),
-        )
-        -> {$vis_struct:vis struct $(#[$attr_struct:meta])* $name:ident $(<$life:lifetime>)? $(
-                $(#[$attr:meta])*
-                ($vis:vis $id:ident: $ty:ty)
-            )*}
+        )*
     ) => {
-        $(#[$attr_struct])*
-        #[repr(C)]
-        $vis_struct struct $name $(<$life>)? {
-            $(
-                $(#[$attr])*
-                $vis $id: $ty
-            ),*
-        }
-    };
-
-    // Munch field.
-    (@munch
-        (
-            $(#[$attr:meta])*
-            ($offset_start:expr => $vis:vis $field:ident: $ty:ty),
-            $($after:tt)*
-        )
-        -> {$($output:tt)*}
-    ) => {
-        $crate::register_fields!(
-            @munch (
-                $($after)*
-            ) -> {
-                $($output)*
-                $(#[$attr])*
-                ($vis $field: $ty)
-            }
-        );
-    };
-
-    // Munch padding.
-    (@munch
-        (
-            $(#[$attr:meta])*
-            ($offset_start:expr => $padding:ident),
-            $(#[$attr_next:meta])*
-            ($offset_end:expr => $($next:tt)*),
-            $($after:tt)*
-        )
-        -> {$($output:tt)*}
-    ) => {
-        $crate::register_fields!(
-            @munch (
-                $(#[$attr_next])*
-                ($offset_end => $($next)*),
-                $($after)*
-            ) -> {
-                $($output)*
-                $(#[$attr])*
-                ($padding: [u8; $offset_end - $offset_start])
-            }
-        );
-    };
-}
-
-// TODO: All of the rustdoc tests below use a `should_fail` attribute instead of
-// `should_panic` because a const panic will result in a failure to evaluate a
-// constant value, and thus a compiler error. However, this means that these
-// examples could break for unrelated reasons, trigger a compiler error, but not
-// test the desired assertion any longer. This should be switched to a
-// `should_panic`-akin attribute which works for const panics, once that is
-// available.
-/// Statically validate the size and offsets of the fields defined
-/// within the register struct through the `register_structs!()`
-/// macro.
-///
-/// This macro expands to an expression which contains static
-/// assertions about various parameters of the individual fields in
-/// the register struct definition. It will test for:
-///
-/// - Proper start offset of padding fields. It will fail in cases
-///   such as
-///
-///   ```should_fail
-///   # #[macro_use]
-///   # extern crate tock_registers;
-///   # use tock_registers::register_structs;
-///   # use tock_registers::registers::ReadWrite;
-///   register_structs! {
-///       UartRegisters {
-///           (0x04 => _reserved),
-///           (0x08 => foo: ReadWrite<u32>),
-///           (0x0C => @END),
-///       }
-///   }
-///   # // This is required for rustdoc to not place this code snipped into an
-///   # // fn main() {...} function.
-///   # fn main() { }
-///   ```
-///
-///   In this example, the start offset of `_reserved` should have been `0x00`
-///   instead of `0x04`.
-///
-/// - Correct start offset and end offset (start offset of next field) in actual
-///   fields. It will fail in cases such as
-///
-///   ```should_fail
-///   # #[macro_use]
-///   # extern crate tock_registers;
-///   # use tock_registers::register_structs;
-///   # use tock_registers::registers::ReadWrite;
-///   register_structs! {
-///       UartRegisters {
-///           (0x00 => foo: ReadWrite<u32>),
-///           (0x05 => bar: ReadWrite<u32>),
-///           (0x08 => @END),
-///       }
-///   }
-///   # // This is required for rustdoc to not place this code snipped into an
-///   # // fn main() {...} function.
-///   # fn main() { }
-///   ```
-///
-///   In this example, the start offset of `bar` and thus the end offset of
-///   `foo` should have been `0x04` instead of `0x05`.
-///
-/// - Invalid alignment of fields.
-///
-/// - That the end marker matches the actual generated struct size. This will
-///   fail in cases such as
-///
-///   ```should_fail
-///   # #[macro_use]
-///   # extern crate tock_registers;
-///   # use tock_registers::register_structs;
-///   # use tock_registers::registers::ReadWrite;
-///   register_structs! {
-///       UartRegisters {
-///           (0x00 => foo: ReadWrite<u32>),
-///           (0x04 => bar: ReadWrite<u32>),
-///           (0x10 => @END),
-///       }
-///   }
-///   # // This is required for rustdoc to not place this code snipped into an
-///   # // fn main() {...} function.
-///   # fn main() { }
-///   ```
-#[macro_export]
-macro_rules! test_fields {
-    // This macro works by iterating over all defined fields, until it hits an
-    // ($size:expr => @END) field. Each iteration generates an expression which,
-    // when evaluated, yields the current byte offset in the fields. Thus, when
-    // reading a field or padding, the field or padding length must be added to
-    // the returned size.
-    //
-    // By feeding this expression recursively into the macro, deeper invocations
-    // can continue validating fields through knowledge of the current offset
-    // and the remaining fields.
-    //
-    // The nested expression returned by this macro is guaranteed to be
-    // const-evaluable.
-
-    // Macro entry point.
-    (@root $struct:ident $(<$life:lifetime>)? { $($input:tt)* } ) => {
-        // Start recursion at offset 0.
-        $crate::test_fields!(@munch $struct $(<$life>)? ($($input)*) : (0, 0));
-    };
-
-    // Consume the ($size:expr => @END) field, which MUST be the last field in
-    // the register struct.
-    (@munch $struct:ident $(<$life:lifetime>)?
-        (
-            $(#[$attr_end:meta])*
-            ($size:expr => @END),
-        )
-        : $stmts:expr
-    ) => {
-        const _: () = {
-            // We've reached the end! Normally it is sufficient to compare the
-            // struct's size to the reported end offet. However, we must
-            // evaluate the previous iterations' expressions for them to have an
-            // effect anyways, so we can perform an internal sanity check on
-            // this value as well.
-            const SUM_MAX_ALIGN: (usize, usize) = $stmts;
-            const SUM: usize = SUM_MAX_ALIGN.0;
-            const MAX_ALIGN: usize = SUM_MAX_ALIGN.1;
-
-            // Internal sanity check. If we have reached this point and
-            // correctly iterated over the struct's fields, the current offset
-            // and the claimed end offset MUST be equal.
-            assert!(SUM == $size);
-
-            const STRUCT_SIZE: usize = core::mem::size_of::<$struct $(<$life>)?>();
-            const ALIGNMENT_CORRECTED_SIZE: usize = if $size % MAX_ALIGN != 0 { $size + (MAX_ALIGN - ($size % MAX_ALIGN)) } else { $size };
-
-            assert!(
-                STRUCT_SIZE == ALIGNMENT_CORRECTED_SIZE,
-                "{}",
-                concat!(
-                    "Invalid size for struct ",
-                    stringify!($struct),
-                    " (expected ",
-                    $size,
-                    ", actual struct size differs)",
-                ),
-            );
-        };
-    };
-
-    // Consume a proper ($offset:expr => $field:ident: $ty:ty) field.
-    (@munch $struct:ident $(<$life:lifetime>)?
-        (
-            $(#[$attr:meta])*
-            ($offset_start:expr => $vis:vis $field:ident: $ty:ty),
-            $(#[$attr_next:meta])*
-            ($offset_end:expr => $($next:tt)*),
-            $($after:tt)*
-        )
-        : $output:expr
-    ) => {
-        $crate::test_fields!(
-            @munch $struct $(<$life>)? (
-                $(#[$attr_next])*
-                ($offset_end => $($next)*),
-                $($after)*
-            ) : {
-                // Evaluate the previous iterations' expression to determine the
-                // current offset.
-                const SUM_MAX_ALIGN: (usize, usize) = $output;
-                const SUM: usize = SUM_MAX_ALIGN.0;
-                const MAX_ALIGN: usize = SUM_MAX_ALIGN.1;
-
-                // Validate the start offset of the current field. This check is
-                // mostly relevant for when this is the first field in the
-                // struct, as any subsequent start offset error will be detected
-                // by an end offset error of the previous field.
-                assert!(
-                    SUM == $offset_start,
-                    "{}",
-                    concat!(
-                        "Invalid start offset for field ",
-                        stringify!($field),
-                        " (expected ",
-                        $offset_start,
-                        " but actual value differs)",
-                    ),
-                );
-
-                // Validate that the start offset of the current field within
-                // the struct matches the type's minimum alignment constraint.
-                const ALIGN: usize = core::mem::align_of::<$ty>();
-                // Clippy can tell that (align - 1) is zero for some fields, so
-                // we allow this lint and further encapsule the assert! as an
-                // expression, such that the allow attr can apply.
-                #[allow(clippy::bad_bit_mask)]
-                {
-                    assert!(
-                        SUM & (ALIGN - 1) == 0,
-                        "{}",
-                        concat!(
-                            "Invalid alignment for field ",
-                            stringify!($field),
-                            " (offset differs from expected)",
-                        ),
-                    );
+        $(
+            $(#[$mod_attr])*
+            $vis mod $name {
+                pub trait ReadRegisters {
+                    $($crate::read_registers!{$reg_name: $($tokens)*})*
                 }
 
-                // Add the current field's length to the offset and validate the
-                // end offset of the field based on the next field's claimed
-                // start offset.
-                const NEW_SUM: usize = SUM + core::mem::size_of::<$ty>();
-                assert!(
-                    NEW_SUM == $offset_end,
-                    "{}",
-                    concat!(
-                        "Invalid end offset for field ",
-                        stringify!($field),
-                        " (expected ",
-                        $offset_end,
-                        " but actual value differs)",
-                    ),
-                );
+                pub trait WriteRegisters {
+                    $($crate::write_registers!{$reg_name: $($tokens)*})*
+                }
 
-                // Determine the new maximum alignment. core::cmp::max(ALIGN,
-                // MAX_ALIGN) does not work here, as the function is not const.
-                const NEW_MAX_ALIGN: usize = if ALIGN > MAX_ALIGN { ALIGN } else { MAX_ALIGN };
+                pub trait AccessRegisters: ReadRegisters + WriteRegisters {}
+                impl<T: ReadRegisters + WriteRegisters> AccessRegisters for T {}
 
-                // Provide the updated offset and alignment to the next
-                // iteration.
-                (NEW_SUM, NEW_MAX_ALIGN)
+                pub struct Mmio;
+
+                impl ReadRegisters for Mmio {
+                    $($crate::mmio_read!{$offset => $reg_name: $($tokens)*})*
+                }
+
+                impl WriteRegisters for Mmio {
+                    $($crate::mmio_write!{$offset => $reg_name: $($tokens)*})*
+                }
+
+                #[repr(C)]
+                pub struct Registers<A: AccessRegisters> {
+                    $(pub $reg_name: $reg_name<A>,)*
+
+                    access: A,
+                }
+
+                $($crate::register_type!{$reg_name})*
+                $($crate::field_impls!{$reg_name: $($tokens)*})*
             }
-        );
-    };
-
-    // Consume a padding ($offset:expr => $padding:ident) field.
-    (@munch $struct:ident $(<$life:lifetime>)?
-        (
-            $(#[$attr:meta])*
-            ($offset_start:expr => $padding:ident),
-            $(#[$attr_next:meta])*
-            ($offset_end:expr => $($next:tt)*),
-            $($after:tt)*
-        )
-        : $output:expr
-    ) => {
-        $crate::test_fields!(
-            @munch $struct $(<$life>)? (
-                $(#[$attr_next])*
-                ($offset_end => $($next)*),
-                $($after)*
-            ) : {
-                // Evaluate the previous iterations' expression to determine the
-                // current offset.
-                const SUM_MAX_ALIGN: (usize, usize) = $output;
-                const SUM: usize = SUM_MAX_ALIGN.0;
-                const MAX_ALIGN: usize = SUM_MAX_ALIGN.1;
-
-                // Validate the start offset of the current padding field. This
-                // check is mostly relevant for when this is the first field in
-                // the struct, as any subsequent start offset error will be
-                // detected by an end offset error of the previous field.
-                assert!(
-                    SUM == $offset_start,
-                    concat!(
-                        "Invalid start offset for padding ",
-                        stringify!($padding),
-                        " (expected ",
-                        $offset_start,
-                        " but actual value differs)",
-                    ),
-                );
-
-                // The padding field is automatically sized. Provide the start
-                // offset of the next field to the next iteration.
-                ($offset_end, MAX_ALIGN)
-            }
-        );
+        )*
     };
 }
 
 #[macro_export]
 macro_rules! register_structs {
+    // Pattern that matches a single register struct with an attached module
+    // name.
+    {
+        $(#[$attr:meta])*
+        $vis:vis $struct_name:ident, mod $mod_name:ident {
+            $($fields:tt)*
+        }
+    } => {
+        $crate::registers!{
+            $(#[$attr])*
+            $vis $mod_name {
+                $($fields)*
+            }
+        }
+
+        type $struct_name = $mod_name::Registers<$mod_name::Mmio>;
+    };
+    // Pattern that matches a single register struct with no attached module
+    // name. This recursively calls itself with a module name specified, which
+    // should be matched by the first pattern.
+    {
+        $(#[$attr:meta])*
+        $vis:vis $struct_name:ident {
+            $($fields:tt)*
+        }
+    } => {
+        $crate::register_structs! {
+            $(#[$attr])*
+            $vis $struct_name, mod register_structs {
+                $($fields)*
+            }
+        }
+    };
+    // Pattern that matches multiple register structs. At most one of the
+    // structs must specify a module name alongside the register name.
     {
         $(
             $(#[$attr:meta])*
-            $vis_struct:vis $name:ident $(<$life:lifetime>)? {
-                $( $fields:tt )*
+            $vis:vis $struct_name:ident$(, mod $mod_name:ident)? {
+                $($fields:tt)*
             }
         ),*
     } => {
-        $( $crate::register_fields!(@root $(#[$attr])* $vis_struct $name $(<$life>)? { $($fields)* } ); )*
-
-        mod static_validate_register_structs {
         $(
-            #[allow(non_snake_case)]
-            mod $name {
-                use super::super::*;
-
-                $crate::test_fields!(@root $name $(<$life>)? { $($fields)* } );
+            $crate::register_structs! {
+                $crate::register_structs! {
+                    $(#[$attr])*
+                    $vis $struct_name$(, mod $mod_name)? {
+                        $($fields)*
+                    }
+                }
             }
         )*
+    };
+}
+
+// -----------------------------------------------------------------------------
+// Macros below this line are for internal use only (they are used registers!).
+// -----------------------------------------------------------------------------
+
+/// For internal use by `tock-registers`.
+#[macro_export]
+macro_rules! read_registers {
+    ($name:ident: [ReadOnly<$reg_ty:ty, $long_ty:ty>; $len:literal]) => {
+        fn $name(&self, idx: usize) -> core::result::Result<$reg_ty, $crate::TooLargeIndex>;
+    };
+    ($name:ident: [ReadWrite<$reg_ty:ty, $long_ty:ty>; $len:literal]) => {
+        fn $name(&self, idx: usize) -> core::result::Result<$reg_ty, $crate::TooLargeIndex>;
+    };
+    ($name:ident: ReadOnly<$reg_ty:ty, $long_ty:ty>) => {
+        fn $name(&self) -> $reg_ty;
+    };
+    ($name:ident: ReadWrite<$reg_ty:ty, $long_ty:ty>) => {
+        fn $name(&self) -> $reg_ty;
+    };
+    ($($tokens:tt)*) => {};
+}
+
+/// For internal use by `tock-registers`.
+#[macro_export]
+macro_rules! write_registers {
+    ($name:ident: [ReadWrite<$reg_ty:ty, $long_ty:ty>; $len:literal]) => {
+        fn $name(&self, value: $reg_ty, idx: usize) -> core::result::Result<$crate::WriteSuccess, $crate::TooLargeIndex>;
+    };
+    ($name:ident: [WriteOnly<$reg_ty:ty, $long_ty:ty>; $len:literal]) => {
+        fn $name(&self, value: $reg_ty, idx: usize) -> core::result::Result<$crate::WriteSuccess, $crate::TooLargeIndex>;
+    };
+    ($name:ident: ReadWrite<$reg_ty:ty, $long_ty:ty>) => {
+        fn $name(&self, value: $reg_ty);
+    };
+    ($name:ident: WriteOnly<$reg_ty:ty, $long_ty:ty>) => {
+        fn $name(&self, value: $reg_ty);
+    };
+    ($($tokens:tt)*) => {};
+}
+
+/// For internal use by `tock-registers`.
+#[macro_export]
+macro_rules! mmio_read {
+    ($rel_addr:literal => $name:ident: [ReadOnly<$reg_ty:ty, $long_ty:ty>; $len:literal]) => {
+        fn $name(&self, idx: usize) -> core::result::Result<$reg_ty, $crate::TooLargeIndex> {
+            unsafe { $crate::internal::mmio_read_array::<$rel_addr, $len, _, _>(self, idx) }
+        }
+    };
+    ($rel_addr:literal => $name:ident: [ReadWrite<$reg_ty:ty, $long_ty:ty>; $len:literal]) => {
+        fn $name(&self, idx: usize) -> core::result::Result<$reg_ty, $crate::TooLargeIndex> {
+            unsafe { $crate::internal::mmio_read_array::<$rel_addr, $len, _, _>(self, idx) }
+        }
+    };
+    ($rel_addr:literal => $name:ident: ReadOnly<$reg_ty:ty, $long_ty:ty>) => {
+        fn $name(&self) -> $reg_ty {
+            unsafe { $crate::internal::mmio_read::<$rel_addr, _, _>(self) }
+        }
+    };
+    ($rel_addr:literal => $name:ident: ReadWrite<$reg_ty:ty, $long_ty:ty>) => {
+        fn $name(&self) -> $reg_ty {
+            unsafe { $crate::internal::mmio_read::<$rel_addr, _, _>(self) }
+        }
+    };
+    ($($tokens:tt)*) => {};
+}
+
+/// For internal use by `tock-registers`.
+#[macro_export]
+macro_rules! mmio_write {
+    ($rel_addr:literal => $name:ident: [WriteOnly<$reg_ty:ty, $long_ty:ty>; $len:literal]) => {
+        fn $name(&self, value: $reg_ty, idx: usize) -> core::result::Result<$crate::WriteSuccess, $crate::TooLargeIndex> {
+            unsafe { $crate::internal::mmio_write_array::<$rel_addr, $len, _, _>(self, value, idx) }
+        }
+    };
+    ($rel_addr:literal => $name:ident: [ReadWrite<$reg_ty:ty, $long_ty:ty>; $len:literal]) => {
+        fn $name(&self, value: $reg_ty, idx: usize) -> core::result::Result<$crate::WriteSuccess, $crate::TooLargeIndex> {
+            unsafe { $crate::internal::mmio_write_array::<$rel_addr, $len, _, _>(self, value, idx) }
+        }
+    };
+    ($rel_addr:literal => $name:ident: WriteOnly<$reg_ty:ty, $long_ty:ty>) => {
+        fn $name(&self, value: $reg_ty) {
+            unsafe { $crate::internal::mmio_write::<$rel_addr, _, _>(self, value) }
+        }
+    };
+    ($rel_addr:literal => $name:ident: ReadWrite<$reg_ty:ty, $long_ty:ty>) => {
+        fn $name(&self, value: $reg_ty) {
+            unsafe { $crate::internal::mmio_write::<$rel_addr, _, _>(self, value) }
+        }
+    };
+    ($($tokens:tt)*) => {};
+}
+
+/// For internal use by `tock-registers`.
+#[macro_export]
+macro_rules! register_type {
+    ($name:ident) => {
+        #[allow(non_camel_case_types)]
+        pub struct $name<A: AccessRegisters> {
+            _phantom: core::marker::PhantomData<*const A>,
+        }
+
+        impl<A: AccessRegisters> $name<A> {
+            fn access(&self) -> &A {
+                unsafe { &*(self as *const _ as *const A) }
+            }
+        }
+    };
+}
+
+/// For internal use by `tock-registers`.
+#[macro_export]
+macro_rules! field_impls {
+    ($name:ident: [ReadOnly<$reg_ty:ty, $long_ty:ty>; $len:literal]) => {
+        impl<A: AccessRegisters> $name<A> {
+            pub fn read(&self, idx: usize) -> core::result::Result<$reg_ty, $crate::TooLargeIndex> {
+                ReadRegisters::$name(self.access(), idx)
+            }
+        }
+    };
+    ($name:ident: [ReadWrite<$reg_ty:ty, $long_ty:ty>; $len:literal]) => {
+        impl<A: AccessRegisters> $name<A> {
+            pub fn read(&self, idx: usize) -> core::result::Result<$reg_ty, $crate::TooLargeIndex> {
+                ReadRegisters::$name(self.access(), idx)
+            }
+            pub fn write(&self, value: $reg_ty, idx: usize) -> core::result::Result<$crate::WriteSuccess, $crate::TooLargeIndex> {
+                WriteRegisters::$name(self.access(), value, idx)
+            }
+        }
+    };
+    ($name:ident: [WriteOnly<$reg_ty:ty, $long_ty:ty>; $len:literal]) => {
+        impl<A: AccessRegisters> $name<A> {
+            pub fn write(&self, value: $reg_ty, idx: usize) -> core::result::Result<$crate::WriteSuccess, $crate::TooLargeIndex> {
+                WriteRegisters::$name(self.access(), value, idx)
+            }
+        }
+    };
+    ($name:ident: ReadOnly<$reg_ty:ty, $long_ty:ty>) => {
+        impl<A: AccessRegisters> $name<A> {
+            pub fn read(&self) -> $reg_ty {
+                ReadRegisters::$name(self.access())
+            }
+        }
+    };
+    ($name:ident: ReadWrite<$reg_ty:ty, $long_ty:ty>) => {
+        impl<A: AccessRegisters> $name<A> {
+            pub fn read(&self) -> $reg_ty {
+                ReadRegisters::$name(self.access())
+            }
+            pub fn write(&self, value: $reg_ty) {
+                WriteRegisters::$name(self.access(), value);
+            }
+        }
+    };
+    ($name:ident: WriteOnly<$reg_ty:ty, $long_ty:ty>) => {
+        impl<A: AccessRegisters> $name<A> {
+            pub fn write(&self, value: $reg_ty) {
+                WriteRegisters::$name(self.access(), value);
+            }
         }
     };
 }


### PR DESCRIPTION
*This PR proposes a new design for the registers structs generated by `register_structs!` that attempts to resolve an existing bug while adding support for testing driver implementations.*

## Goals of this design

Here are the goals of this design, in order from most-important to least-important:

1. The current implementation allows the Rust compiler to insert spurious reads to MMIO registers.
2. We want to be able to unit test peripheral drivers, which requires providing a fake or mock implementation of the peripheral.
3. [`register_structs!` can hit recursion limits](https://github.com/tock/tock/issues/2941).
4. Minimize breaking changes.

### Spurious MMIO reads

There isn't an open issue for this problem, so I'll describe it here.

All Rust references, including `&UnsafeCell<_>`, have the LLVM `dereferenceable` attribute. `dereferenceable` allows LLVM to insert reads to the referenced memory whenever it wants to. Some peripherals take action when an MMIO register is read (see e.g. clear-on-read registers), so spurious reads are unacceptable. It is currently unclear to me whether a register that changes between subsequent reads will cause UB, but it's possible that is an issue too. There is more background at https://github.com/rust-lang/unsafe-code-guidelines/issues/33.

## Fixing the spurious reads requires breaking changes

I don't think it is practical to fix the spurious read issue without making some backwards-incompatible changes to `tock-registers`. To demonstrate my point, consider the following register definition:

```rust
(0x100 => iser: [ReadWrite<u32, NvicSetClear::Register>; 32])
```

This emits a field that is an array. I don't think it is practical to make a type that implements the entire slice API -- or track it as it changes -- so to keep backwards compatibility, we need a real slice.

The slice cannot be zero-sized, because then `tock-registers` cannot make the following work:

```rust
iser[3].set(3);
iser[7].set(8);
```

because `iser[3]` and `iser[7]` are indistinguishable (they have the same address and type).

The slice cannot have a nonzero size and be in the MMIO region, because then you have the spurious read issue I am trying to fix.

I don't think we want to put the slice anywhere else, because it would have to be in readable memory, which requires either putting it into flash or RAM. While that would technically be possible, some of these register arrays have hundreds of elements, and the flash/RAM cost would be unreasonable.

At the moment, the only way I see to fix the issue while supporting large array-registers is to create a new type that implements a subset of Rust's slice API.

If you have another idea on how to fix the spurious reads, let me know!

## Supporting fakes/mocks

To support unit tests, we need to allow users to replace the MMIO interface with an alternative implementation, such as fakes or mocks. We can do this by using generics. Given the following register definition:

```rust
register_structs! {
    Foo {
        (0x00 => rw_single: ReadWrite<u32>),
        (0x04 => rw_array: [ReadWrite<u32>; 4]),
    }
}
```

we need the following operations (I'm ignoring error handling here):

```rust
trait AccessRegisters {
    fn read_rw_single(&self) -> u32;
    fn write_rw_single(&self, value: u32);

    fn read_rw_array(&self, idx: usize) -> u32;
    fn write_rw_array(&self, value: u32, idx: usize);
}
```

However, a `macro_rules!` macro cannot prepend the `read_` and `write_` prefixes (see the [`concat_idents` tracking issue](https://github.com/rust-lang/rust/issues/29599) for more information), so instead we need two separate traits:

```rust
trait ReadRegisters {
    fn rw_single(&self) -> u32;
    fn rw_array(&self, idx: usize) -> u32;
}

trait WriteRegisters {
    fn rw_single(&self, value: u32);
    fn rw_array(&self, value: u32, idx: usize);
}

trait AccessRegisters: ReadRegisters + WriteRegisters {}
impl<T: ReadRegisters + WriteRegisters> AccessRegisters for T {}
```

## Providing backwards-compatible-ish access

Obviously, the `AccessRegisters` trait looks very different from the existing `register_structs!` API. Each register should become a struct field with getter and setter methods (such as `Readable` and `Writeable` implementations). These fields must call into the `AccessRegisters` implementation, so we make them generic over `AccessRegisters`:

```rust
struct Registers<A: AccessRegisters> {
    access: A,

    rw_single: RwSingle<A>,
    rw_array: RwArray<A>,
}
```

oh, except a `macro_rules!` macro can't re-capitalize an identifier, so unfortunately the types will have to be snake case:

```rust
struct Registers<A: AccessRegisters> {
    access: A,

    rw_single: rw_single<A>,
    rw_array: rw_array<A>,
}
```

There is an important unanswered question in this struct definition: how do `rw_single` and `rw_array` access the `access` member? We don't want them to contain pointers, as that would require a LOT of pointers. In fact, we need them to be zero-sized, else we will end up kilobytes of wasted RAM per board. Which means that the only non-zero-sized member of `Registers` is `access` (and we aren't even sure that `access` isn't a ZST!). Thus we can put all of `Registers`' fields at the same address:

```rust
#[repr(C)]
struct Registers<A: AccessRegisters> {
    rw_single: rw_single<A>,
    rw_array: rw_array<A>,

    // access must be last
    access: A,
}
```

Now `rw_single` and `rw_array` can call into `access` by casting `self` to a `&A`!

## Generate a module, not a struct

The above design generates multiple traits and many types. Therefore, I propose that the macro generates a module named after the peripheral, with mostly generic names inside:

```rust
mod foo_peripheral {
    #[repr(C)]
    struct Registers<A: AccessRegisters> { ... }

    trait ReadRegisters ...
    trait WriteRegisters ...
    trait AccessRegisters ...

    struct rw_single ...
    struct rw_array ...
}
```

For backwards compatibility, we should give the macro a new name. I suggest `registers!`.

To avoid maintaining two sets of macro implementations, I made `register_structs!` wrap `registers!` and re-export only the `Registers` type. Unfortunately, `registers!` requires distinct module names for each register struct it generates, and `register_structs!` isn't normally passed distinct module names. So instead, I tweaked `register_structs!` so that you can pass in a register name:

```rust
register_structs! {
    Foo, mod foo_registers {
        ...
    }
}
```

## Implementation details and remaining work

There is a lot of remaining work to do in this PR:

1. The "real" and "mock" implementations of `AccessRegisters`
1. The detailed macro chaining required to implement read and write methods for only registers that are readable and writable, respectively.
1. The API for accessing array registers, which do not fit into the `Readable` and `Writeable` traits.
1. Adding support for padding fields.
1. Implement tests to make sure there are not gaps/overlaps in the register addresses.
1. Figure out what should happen if the `register_types` feature is disabled, or remove that feature. @lschuermann, any input here?
1. Properly support `Aliased` registers (I kept forgetting about them while writing macros)

## Known Limitations

### Slice API subset

As mentioned above, our API for accessing arrays of registers can mimic a subset of Rust's slice API, but it isn't practical to implement the entire thing (and we can't use real slices).

### `ReadOnly`/`ReadWrite`/`WriteOnly`/`Aliased` pickiness

Most existing users of `tock-registers` put a subset of:

```rust
use tock_registers::registers::{Aliased, ReadOnly, ReadWrite, WriteOnly};
```

in the file in which they define their registers. This implementation assumes that, and matches on those register names directly. So the following will not work:

```rust
register_structs! {
    Foo {
        (0x0 => reg: tock_registers::registers::ReadWrite<u32>),
    }
}
```

and will have to be rewritten as:

```rust
register_structs! {
    Foo {
        (0x0 => reg: ReadWrite<u32>),
    }
}
```

### No lifetime parameters

This PR removes the support for lifetime parameters added in #1554. It's not clear to me how those parameters should be integrated into the trait design, and OpenSK appears to be dead so I'm not sure I'll get an answer.

### `register_structs!` needs module names

As mentioned previously, the new `register_structs!` implementation needs module names to be provided if there is more than one register struct in a single module.

## Key Question

In creating this PR, I really bent the implementation of `registers!` to fit the existing API, so that it could be as close to a drop-in replacement as possible. However, it is not perfectly backwards-compatible, as shown by the above known limitations. I'm concerned that I'm designing `tock-registers` into a corner, where we can't improve it or add necessary features without necessitating a backwards-incompatible redesign.

As mentioned above, I *think* that fixing the MMIO reference bug requires making backwards-incompatible changes. How do we want to fix that bug? We can fix it with fewer breaking changes by leaving out support for fake peripheral implementations (and use `cargo` features to implement an expectation/mocking API instead). We can fix it with even fewer breaking changes than that if we don't try to give `register_structs!` unit testing features.

Perhaps instead of trying to do everything in one API, we should just have two APIs? `v1` which is the current `register_structs!` (including its MMIO bug), and `v2` which is a completely redesigned API that is easier to test and expand.

I look forward to your input, if you have the time to look at this!

## Tips for reviewers

### `macros.rs`

I recommending reading the [new `macros.rs`](https://github.com/jrvanwhy/tock/blob/reg-macro-rfc/libraries/tock-register-interface/src/macros.rs) rather than looking at the diff, as the file has been completely rewritten.

### How to examine the generated code

I recommend installing [`cargo-expand`](https://crates.io/crates/cargo-expand) (if you haven't done so already) and running

```
cargo expand --example registers -p tock-registers
```

to see an example of the generated code. The source code for the example is libraries/tock-register-interface/examples/registers.rs.