### PR TITLE
capsules: sha256: reset total_length on init

### DIFF
--- a/capsules/src/sha256.rs
+++ b/capsules/src/sha256.rs
@@ -102,6 +102,7 @@ impl<'a> Sha256Software<'a> {
         self.state.set(new_state);
 
         self.buffered_length.set(0);
+        self.total_length.set(0);
         self.data_buffer.map(|b| {
             for i in 0..SHA_BLOCK_LEN_BYTES {
                 b[i] = 0;


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes the sha256 capsule so that multiple hashes work. The stored `total_length` value wasn't being reset between hashes.


### Testing Strategy

Loading multiple credentialed apps on imix.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
