### PR TITLE
chips/apollo3: IOM: A collection of fixes for I2C

### DIFF
--- a/chips/apollo3/src/iom.rs
+++ b/chips/apollo3/src/iom.rs
@@ -505,6 +505,7 @@ impl<'a> Iom<'_> {
             {
                 // Disable interrupts
                 regs.inten.set(0x00);
+                self.reset_fifo();
 
                 self.master_client.map(|client| {
                     self.buffer.take().map(|buffer| {

--- a/chips/apollo3/src/iom.rs
+++ b/chips/apollo3/src/iom.rs
@@ -506,7 +506,9 @@ impl<'a> Iom<'_> {
                 || (self.write_len.get() > 0 && self.write_index.get() == self.write_len.get())
             {
                 self.master_client.map(|client| {
-                    client.command_complete(self.buffer.take().unwrap(), Ok(()));
+                    self.buffer.take().map(|buffer| {
+                        client.command_complete(buffer, Ok(()));
+                    });
                 });
 
                 // Finished with SMBus


### PR DESCRIPTION
### Pull Request Overview

This is a small collection of fixes for the Apollo3 IOM

```
* 221abcf42 chips/apollo3: IOM: Ensure the status is idle (by Alistair Francis 9 days ago)
* 8f0f63ad1 chips/apollo3: IOM: Reset FIFO on completion (by Alistair Francis 9 days ago)
* 68b777142 chips/apollo3: IOM: Cleanup interrupt handling (by Alistair Francis 9 days ago)
* 798ff2b02 chips/apollo3: IOM: Remove unwrap() (by Alistair Francis 10 days ago)
```

### Testing Strategy

Running the BME280 and CCS811 sensor tests

### TODO or Help Wanted

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
