### PR TITLE
tbf: make length errors all NotEnoughFlash

### DIFF
--- a/libraries/tock-tbf/src/parse.rs
+++ b/libraries/tock-tbf/src/parse.rs
@@ -138,7 +138,10 @@ pub fn parse_tbf_header(
                 while remaining.len() > 0 {
                     // Get the T and L portions of the next header (if it is
                     // there).
-                    let tlv_header: types::TbfHeaderTlv = remaining.try_into()?;
+                    let tlv_header: types::TbfHeaderTlv = remaining
+                        .get(0..4)
+                        .ok_or(types::TbfParseError::NotEnoughFlash)?
+                        .try_into()?;
                     remaining = remaining
                         .get(4..)
                         .ok_or(types::TbfParseError::NotEnoughFlash)?;
@@ -152,7 +155,12 @@ pub fn parse_tbf_header(
                             // Otherwise, we fail to parse this TBF header and
                             // throw an error.
                             if tlv_header.length as usize == entry_len {
-                                main_pointer = Some(remaining.try_into()?);
+                                main_pointer = Some(
+                                    remaining
+                                        .get(0..entry_len)
+                                        .ok_or(types::TbfParseError::NotEnoughFlash)?
+                                        .try_into()?,
+                                );
                             } else {
                                 return Err(types::TbfParseError::BadTlvEntry(
                                     tlv_header.tipe as usize,
@@ -212,9 +220,14 @@ pub fn parse_tbf_header(
                         }
 
                         types::TbfHeaderTypes::TbfHeaderFixedAddresses => {
-                            let entry_len = 8;
+                            let entry_len = mem::size_of::<types::TbfHeaderV2FixedAddresses>();
                             if tlv_header.length as usize == entry_len {
-                                fixed_address_pointer = Some(remaining.try_into()?);
+                                fixed_address_pointer = Some(
+                                    remaining
+                                        .get(0..entry_len)
+                                        .ok_or(types::TbfParseError::NotEnoughFlash)?
+                                        .try_into()?,
+                                );
                             } else {
                                 return Err(types::TbfParseError::BadTlvEntry(
                                     tlv_header.tipe as usize,
@@ -231,9 +244,14 @@ pub fn parse_tbf_header(
                         }
 
                         types::TbfHeaderTypes::TbfHeaderKernelVersion => {
-                            let entry_len = 4;
+                            let entry_len = mem::size_of::<types::TbfHeaderV2KernelVersion>();
                             if tlv_header.length as usize == entry_len {
-                                kernel_version = Some(remaining.try_into()?);
+                                kernel_version = Some(
+                                    remaining
+                                        .get(0..entry_len)
+                                        .ok_or(types::TbfParseError::NotEnoughFlash)?
+                                        .try_into()?,
+                                );
                             } else {
                                 return Err(types::TbfParseError::BadTlvEntry(
                                     tlv_header.tipe as usize,

--- a/libraries/tock-tbf/src/types.rs
+++ b/libraries/tock-tbf/src/types.rs
@@ -376,11 +376,9 @@ impl<const L: usize> core::convert::TryFrom<&[u8]> for TbfHeaderV2Permissions<L>
     type Error = TbfParseError;
 
     fn try_from(b: &[u8]) -> Result<TbfHeaderV2Permissions<L>, Self::Error> {
-        let length = u16::from_le_bytes(
+        let number_perms = u16::from_le_bytes(
             b.get(0..2)
-                .ok_or(TbfParseError::BadTlvEntry(
-                    TbfHeaderTypes::TbfHeaderPermissions as usize,
-                ))?
+                .ok_or(TbfParseError::NotEnoughFlash)?
                 .try_into()?,
         );
 
@@ -390,15 +388,13 @@ impl<const L: usize> core::convert::TryFrom<&[u8]> for TbfHeaderV2Permissions<L>
             allowed_commands: 0,
         }; L];
 
-        for i in 0..length as usize {
+        for i in 0..number_perms as usize {
             let start = 2 + (i * size_of::<TbfHeaderDriverPermission>());
             let end = start + size_of::<TbfHeaderDriverPermission>();
             if let Some(perm) = perms.get_mut(i) {
                 *perm = b
                     .get(start..end as usize)
-                    .ok_or(TbfParseError::BadTlvEntry(
-                        TbfHeaderTypes::TbfHeaderPermissions as usize,
-                    ))?
+                    .ok_or(TbfParseError::NotEnoughFlash)?
                     .try_into()?;
             } else {
                 return Err(TbfParseError::BadTlvEntry(
@@ -407,7 +403,10 @@ impl<const L: usize> core::convert::TryFrom<&[u8]> for TbfHeaderV2Permissions<L>
             }
         }
 
-        Ok(TbfHeaderV2Permissions { length, perms })
+        Ok(TbfHeaderV2Permissions {
+            length: number_perms,
+            perms,
+        })
     }
 }
 
@@ -419,17 +418,13 @@ impl<const L: usize> core::convert::TryFrom<&[u8]> for TbfHeaderV2PersistentAcl<
 
         let write_id = u32::from_le_bytes(
             b.get(0..4)
-                .ok_or(TbfParseError::BadTlvEntry(
-                    TbfHeaderTypes::TbfHeaderPersistentAcl as usize,
-                ))?
+                .ok_or(TbfParseError::NotEnoughFlash)?
                 .try_into()?,
         );
 
         let read_length = u16::from_le_bytes(
             b.get(4..6)
-                .ok_or(TbfParseError::BadTlvEntry(
-                    TbfHeaderTypes::TbfHeaderPersistentAcl as usize,
-                ))?
+                .ok_or(TbfParseError::NotEnoughFlash)?
                 .try_into()?,
         );
 
@@ -440,9 +435,7 @@ impl<const L: usize> core::convert::TryFrom<&[u8]> for TbfHeaderV2PersistentAcl<
             if let Some(read_id) = read_ids.get_mut(i) {
                 *read_id = u32::from_le_bytes(
                     b.get(start..read_end as usize)
-                        .ok_or(TbfParseError::BadTlvEntry(
-                            TbfHeaderTypes::TbfHeaderPersistentAcl as usize,
-                        ))?
+                        .ok_or(TbfParseError::NotEnoughFlash)?
                         .try_into()?,
                 );
             } else {
@@ -454,9 +447,7 @@ impl<const L: usize> core::convert::TryFrom<&[u8]> for TbfHeaderV2PersistentAcl<
 
         let access_length = u16::from_le_bytes(
             b.get(read_end..(read_end + 2))
-                .ok_or(TbfParseError::BadTlvEntry(
-                    TbfHeaderTypes::TbfHeaderPersistentAcl as usize,
-                ))?
+                .ok_or(TbfParseError::NotEnoughFlash)?
                 .try_into()?,
         );
 
@@ -467,9 +458,7 @@ impl<const L: usize> core::convert::TryFrom<&[u8]> for TbfHeaderV2PersistentAcl<
             if let Some(access_id) = access_ids.get_mut(i) {
                 *access_id = u32::from_le_bytes(
                     b.get(start..access_end as usize)
-                        .ok_or(TbfParseError::BadTlvEntry(
-                            TbfHeaderTypes::TbfHeaderPersistentAcl as usize,
-                        ))?
+                        .ok_or(TbfParseError::NotEnoughFlash)?
                         .try_into()?,
                 );
             } else {


### PR DESCRIPTION


### Pull Request Overview

This pull request updates the TBF parsing code to consistently return `NotEnoughFlash` errors if the buffer passed to the parsing functions is not long enough for the expected types.

Before it was possible to get internal TBF errors even though the error was actually with not having enough flash (likely because the header length was incorrect).

I found after looking through the new footer parsing code and realizing that it is possible to get an internal error when the issue is in fact a poorly formed TBF.

This PR also updates the permission and acl code to be consistent, and replaces some constants with the corresponding memory size checks.

### Testing Strategy

This pull request was tested by hacking tockloader to flash an app with the `header_size` set incorrectly (to 20). This causes the `.get()` in parsing the tbf main header to fail, returning an internal error. With this PR the error is now correctly set to NotEnoughFlash.

before:
```
tock$ [INFO   ]  ----- Paused listen for another tockloader session...
[INFO   ]  ----- Resuming listen...
[INFO   ]  ----- Waiting for serial port to reconnect...
Initialization complete. Entering main loop
Loading processes from flash=0x00040000-0x0007FFFF into sram=0x20008000-0x2000FFFF
Error loading processes!
Error parsing TBF header
Internal kernel error. This is a bug.
```
after:

```
tock$ [INFO   ]  ----- Paused listen for another tockloader session...
[INFO   ]  ----- Resuming listen...
[INFO   ]  ----- Waiting for serial port to reconnect...
Initialization complete. Entering main loop
Loading processes from flash=0x00040000-0x0007FFFF into sram=0x20008000-0x2000FFFF
Error loading processes!
Error parsing TBF header
Buffer too short to parse TBF header
```


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
