### PR TITLE
libraries: tickv: Convert panics to errors

### DIFF
--- a/libraries/tickv/src/tickv.rs
+++ b/libraries/tickv/src/tickv.rs
@@ -558,18 +558,40 @@ impl<'a, C: FlashController<S>, const S: usize> TicKV<'a, C, S> {
 
                 // Copy in new header
                 // This is a little painful, but avoids any unsafe Rust
-                region_data[offset + VERSION_OFFSET] = header.version;
-                region_data[offset + LEN_OFFSET] =
+                *region_data
+                    .get_mut(offset + VERSION_OFFSET)
+                    .ok_or(ErrorCode::RegionFull)? = header.version;
+                *region_data
+                    .get_mut(offset + LEN_OFFSET)
+                    .ok_or(ErrorCode::RegionFull)? =
                     (header.len >> 8) as u8 & 0x0F | (header.flags << 4) & 0xF0;
-                region_data[offset + LEN_OFFSET + 1] = (header.len & 0xFF) as u8;
-                region_data[offset + HASH_OFFSET] = (header.hashed_key >> 56) as u8;
-                region_data[offset + HASH_OFFSET + 1] = (header.hashed_key >> 48) as u8;
-                region_data[offset + HASH_OFFSET + 2] = (header.hashed_key >> 40) as u8;
-                region_data[offset + HASH_OFFSET + 3] = (header.hashed_key >> 32) as u8;
-                region_data[offset + HASH_OFFSET + 4] = (header.hashed_key >> 24) as u8;
-                region_data[offset + HASH_OFFSET + 5] = (header.hashed_key >> 16) as u8;
-                region_data[offset + HASH_OFFSET + 6] = (header.hashed_key >> 8) as u8;
-                region_data[offset + HASH_OFFSET + 7] = (header.hashed_key) as u8;
+                *region_data
+                    .get_mut(offset + LEN_OFFSET + 1)
+                    .ok_or(ErrorCode::RegionFull)? = (header.len & 0xFF) as u8;
+                *region_data
+                    .get_mut(offset + HASH_OFFSET)
+                    .ok_or(ErrorCode::RegionFull)? = (header.hashed_key >> 56) as u8;
+                *region_data
+                    .get_mut(offset + HASH_OFFSET + 1)
+                    .ok_or(ErrorCode::RegionFull)? = (header.hashed_key >> 48) as u8;
+                *region_data
+                    .get_mut(offset + HASH_OFFSET + 2)
+                    .ok_or(ErrorCode::RegionFull)? = (header.hashed_key >> 40) as u8;
+                *region_data
+                    .get_mut(offset + HASH_OFFSET + 3)
+                    .ok_or(ErrorCode::RegionFull)? = (header.hashed_key >> 32) as u8;
+                *region_data
+                    .get_mut(offset + HASH_OFFSET + 4)
+                    .ok_or(ErrorCode::RegionFull)? = (header.hashed_key >> 24) as u8;
+                *region_data
+                    .get_mut(offset + HASH_OFFSET + 5)
+                    .ok_or(ErrorCode::RegionFull)? = (header.hashed_key >> 16) as u8;
+                *region_data
+                    .get_mut(offset + HASH_OFFSET + 6)
+                    .ok_or(ErrorCode::RegionFull)? = (header.hashed_key >> 8) as u8;
+                *region_data
+                    .get_mut(offset + HASH_OFFSET + 7)
+                    .ok_or(ErrorCode::RegionFull)? = (header.hashed_key) as u8;
 
                 // Hash the new header data
                 check_sum.update(

--- a/libraries/tickv/src/tickv.rs
+++ b/libraries/tickv/src/tickv.rs
@@ -733,10 +733,22 @@ impl<'a, C: FlashController<S>, const S: usize> TicKV<'a, C, S> {
                     let check_sum = check_sum.finalise();
                     let check_sum = check_sum.to_ne_bytes();
 
-                    if check_sum[3] != region_data[offset + total_length as usize - 1]
-                        || check_sum[2] != region_data[offset + total_length as usize - 2]
-                        || check_sum[1] != region_data[offset + total_length as usize - 3]
-                        || check_sum[0] != region_data[offset + total_length as usize - 4]
+                    if *check_sum.get(3).ok_or(ErrorCode::InvalidCheckSum)?
+                        != *region_data
+                            .get(offset + total_length as usize - 1)
+                            .ok_or(ErrorCode::InvalidCheckSum)?
+                        || *check_sum.get(2).ok_or(ErrorCode::InvalidCheckSum)?
+                            != *region_data
+                                .get(offset + total_length as usize - 2)
+                                .ok_or(ErrorCode::InvalidCheckSum)?
+                        || *check_sum.get(1).ok_or(ErrorCode::InvalidCheckSum)?
+                            != *region_data
+                                .get(offset + total_length as usize - 3)
+                                .ok_or(ErrorCode::InvalidCheckSum)?
+                        || *check_sum.get(0).ok_or(ErrorCode::InvalidCheckSum)?
+                            != *region_data
+                                .get(offset + total_length as usize - 4)
+                                .ok_or(ErrorCode::InvalidCheckSum)?
                     {
                         self.read_buffer.replace(Some(region_data));
                         return Err(ErrorCode::InvalidCheckSum);

--- a/libraries/tickv/src/tickv.rs
+++ b/libraries/tickv/src/tickv.rs
@@ -285,8 +285,15 @@ impl<'a, C: FlashController<S>, const S: usize> TicKV<'a, C, S> {
                 }
 
                 // Find this entries length
-                let total_length = ((region_data[offset + LEN_OFFSET] as u16) & !0xF0) << 8
-                    | region_data[offset + LEN_OFFSET + 1] as u16;
+                let total_length = ((*region_data
+                    .get(offset + LEN_OFFSET)
+                    .ok_or((false, ErrorCode::CorruptData))?
+                    as u16)
+                    & !0xF0)
+                    << 8
+                    | *region_data
+                        .get(offset + LEN_OFFSET + 1)
+                        .ok_or((false, ErrorCode::CorruptData))? as u16;
 
                 // Check to see if all fields are just 0
                 if total_length == 0 {
@@ -295,21 +302,50 @@ impl<'a, C: FlashController<S>, const S: usize> TicKV<'a, C, S> {
                 }
 
                 // Check to see if the entry has been deleted
-                if region_data[offset + LEN_OFFSET] & 0x80 != 0x80 {
+                if *region_data
+                    .get(offset + LEN_OFFSET)
+                    .ok_or((false, ErrorCode::CorruptData))?
+                    & 0x80
+                    != 0x80
+                {
                     // Increment our offset by the length and repeat the loop
                     offset += total_length as usize;
                     continue;
                 }
 
                 // We have found a valid entry, see if it is ours.
-                if region_data[offset + HASH_OFFSET] != hash[7]
-                    || region_data[offset + HASH_OFFSET + 1] != hash[6]
-                    || region_data[offset + HASH_OFFSET + 2] != hash[5]
-                    || region_data[offset + HASH_OFFSET + 3] != hash[4]
-                    || region_data[offset + HASH_OFFSET + 4] != hash[3]
-                    || region_data[offset + HASH_OFFSET + 5] != hash[2]
-                    || region_data[offset + HASH_OFFSET + 6] != hash[1]
-                    || region_data[offset + HASH_OFFSET + 7] != hash[0]
+                if *region_data
+                    .get(offset + HASH_OFFSET)
+                    .ok_or((false, ErrorCode::CorruptData))?
+                    != *hash.get(7).ok_or((false, ErrorCode::CorruptData))?
+                    || *region_data
+                        .get(offset + HASH_OFFSET + 1)
+                        .ok_or((false, ErrorCode::CorruptData))?
+                        != *hash.get(6).ok_or((false, ErrorCode::CorruptData))?
+                    || *region_data
+                        .get(offset + HASH_OFFSET + 2)
+                        .ok_or((false, ErrorCode::CorruptData))?
+                        != *hash.get(5).ok_or((false, ErrorCode::CorruptData))?
+                    || *region_data
+                        .get(offset + HASH_OFFSET + 3)
+                        .ok_or((false, ErrorCode::CorruptData))?
+                        != *hash.get(4).ok_or((false, ErrorCode::CorruptData))?
+                    || *region_data
+                        .get(offset + HASH_OFFSET + 4)
+                        .ok_or((false, ErrorCode::CorruptData))?
+                        != *hash.get(3).ok_or((false, ErrorCode::CorruptData))?
+                    || *region_data
+                        .get(offset + HASH_OFFSET + 5)
+                        .ok_or((false, ErrorCode::CorruptData))?
+                        != *hash.get(2).ok_or((false, ErrorCode::CorruptData))?
+                    || *region_data
+                        .get(offset + HASH_OFFSET + 6)
+                        .ok_or((false, ErrorCode::CorruptData))?
+                        != *hash.get(1).ok_or((false, ErrorCode::CorruptData))?
+                    || *region_data
+                        .get(offset + HASH_OFFSET + 7)
+                        .ok_or((false, ErrorCode::CorruptData))?
+                        != *hash.get(0).ok_or((false, ErrorCode::CorruptData))?
                 {
                     // Increment our offset by the length and repeat the loop
                     offset += total_length as usize;
@@ -433,8 +469,15 @@ impl<'a, C: FlashController<S>, const S: usize> TicKV<'a, C, S> {
                     }
 
                     // Find this entries length
-                    let total_length = ((region_data[offset + LEN_OFFSET] as u16) & !0xF0) << 8
-                        | region_data[offset + LEN_OFFSET + 1] as u16;
+                    let total_length = ((*region_data
+                        .get(offset + LEN_OFFSET)
+                        .ok_or(ErrorCode::CorruptData)?
+                        as u16)
+                        & !0xF0)
+                        << 8
+                        | *region_data
+                            .get(offset + LEN_OFFSET + 1)
+                            .ok_or(ErrorCode::CorruptData)? as u16;
 
                     // Increment our offset by the length and repeat the loop
                     offset += total_length as usize;
@@ -446,35 +489,67 @@ impl<'a, C: FlashController<S>, const S: usize> TicKV<'a, C, S> {
 
                 // Check to see if the entire header is 0xFFFF_FFFF_FFFF_FFFF
                 // To avoid operating on 64-bit values check every 8 bytes at a time
-                if region_data[offset + HASH_OFFSET] != 0xFF {
+                if *region_data
+                    .get(offset + HASH_OFFSET)
+                    .ok_or(ErrorCode::CorruptData)?
+                    != 0xFF
+                {
                     self.read_buffer.replace(Some(region_data));
                     return Err(ErrorCode::CorruptData);
                 }
-                if region_data[offset + HASH_OFFSET + 1] != 0xFF {
+                if *region_data
+                    .get(offset + HASH_OFFSET + 1)
+                    .ok_or(ErrorCode::CorruptData)?
+                    != 0xFF
+                {
                     self.read_buffer.replace(Some(region_data));
                     return Err(ErrorCode::CorruptData);
                 }
-                if region_data[offset + HASH_OFFSET + 2] != 0xFF {
+                if *region_data
+                    .get(offset + HASH_OFFSET + 2)
+                    .ok_or(ErrorCode::CorruptData)?
+                    != 0xFF
+                {
                     self.read_buffer.replace(Some(region_data));
                     return Err(ErrorCode::CorruptData);
                 }
-                if region_data[offset + HASH_OFFSET + 3] != 0xFF {
+                if *region_data
+                    .get(offset + HASH_OFFSET + 3)
+                    .ok_or(ErrorCode::CorruptData)?
+                    != 0xFF
+                {
                     self.read_buffer.replace(Some(region_data));
                     return Err(ErrorCode::CorruptData);
                 }
-                if region_data[offset + HASH_OFFSET + 4] != 0xFF {
+                if *region_data
+                    .get(offset + HASH_OFFSET + 4)
+                    .ok_or(ErrorCode::CorruptData)?
+                    != 0xFF
+                {
                     self.read_buffer.replace(Some(region_data));
                     return Err(ErrorCode::CorruptData);
                 }
-                if region_data[offset + HASH_OFFSET + 5] != 0xFF {
+                if *region_data
+                    .get(offset + HASH_OFFSET + 5)
+                    .ok_or(ErrorCode::CorruptData)?
+                    != 0xFF
+                {
                     self.read_buffer.replace(Some(region_data));
                     return Err(ErrorCode::CorruptData);
                 }
-                if region_data[offset + HASH_OFFSET + 6] != 0xFF {
+                if *region_data
+                    .get(offset + HASH_OFFSET + 6)
+                    .ok_or(ErrorCode::CorruptData)?
+                    != 0xFF
+                {
                     self.read_buffer.replace(Some(region_data));
                     return Err(ErrorCode::CorruptData);
                 }
-                if region_data[offset + HASH_OFFSET + 7] != 0xFF {
+                if *region_data
+                    .get(offset + HASH_OFFSET + 7)
+                    .ok_or(ErrorCode::CorruptData)?
+                    != 0xFF
+                {
                     self.read_buffer.replace(Some(region_data));
                     return Err(ErrorCode::CorruptData);
                 }
@@ -497,7 +572,11 @@ impl<'a, C: FlashController<S>, const S: usize> TicKV<'a, C, S> {
                 region_data[offset + HASH_OFFSET + 7] = (header.hashed_key) as u8;
 
                 // Hash the new header data
-                check_sum.update(&region_data[offset + VERSION_OFFSET..=offset + HASH_OFFSET + 7]);
+                check_sum.update(
+                    &region_data
+                        .get(offset + VERSION_OFFSET..=offset + HASH_OFFSET + 7)
+                        .ok_or(ErrorCode::CorruptData)?,
+                );
 
                 // Copy the value
                 let slice = region_data
@@ -614,8 +693,12 @@ impl<'a, C: FlashController<S>, const S: usize> TicKV<'a, C, S> {
 
                     // Copy in the value
                     for i in 0..(total_length as usize - HEADER_LENGTH - CHECK_SUM_LEN) {
-                        buf[i] = region_data[offset + HEADER_LENGTH + i];
-                        check_sum.update(&[buf[i]])
+                        *buf.get_mut(i).ok_or(ErrorCode::BufferTooSmall(
+                            total_length as usize - HEADER_LENGTH - CHECK_SUM_LEN,
+                        ))? = *region_data
+                            .get(offset + HEADER_LENGTH + i)
+                            .ok_or(ErrorCode::CorruptData)?;
+                        check_sum.update(&[*buf.get(i).ok_or(ErrorCode::CorruptData)?])
                     }
 
                     // Check the hash
@@ -700,7 +783,9 @@ impl<'a, C: FlashController<S>, const S: usize> TicKV<'a, C, S> {
             match self.find_key_offset(hash, region_data) {
                 Ok((offset, _data_len)) => {
                     // We found a key, let's delete it
-                    region_data[offset + LEN_OFFSET] &= !0x80;
+                    *region_data
+                        .get_mut(offset + LEN_OFFSET)
+                        .ok_or(ErrorCode::CorruptData)? &= !0x80;
 
                     if let Err(e) = self.controller.write(
                         S * new_region as usize + offset + LEN_OFFSET,
@@ -784,11 +869,22 @@ impl<'a, C: FlashController<S>, const S: usize> TicKV<'a, C, S> {
                 entry_found = true;
 
                 // Find this entries length
-                let total_length = ((region_data[offset + LEN_OFFSET] as u16) & !0xF0) << 8
-                    | region_data[offset + LEN_OFFSET + 1] as u16;
+                let total_length = ((*region_data
+                    .get(offset + LEN_OFFSET)
+                    .ok_or(ErrorCode::CorruptData)? as u16)
+                    & !0xF0)
+                    << 8
+                    | *region_data
+                        .get(offset + LEN_OFFSET + 1)
+                        .ok_or(ErrorCode::CorruptData)? as u16;
 
                 // Check to see if the entry has been deleted
-                if region_data[offset + LEN_OFFSET] & 0x80 != 0x80 {
+                if *region_data
+                    .get(offset + LEN_OFFSET)
+                    .ok_or(ErrorCode::CorruptData)?
+                    & 0x80
+                    != 0x80
+                {
                     // The entry has been deleted, this region might be ready
                     // for erasure.
                     // Increment our offset by the length and repeat the loop

--- a/libraries/tickv/src/tickv.rs
+++ b/libraries/tickv/src/tickv.rs
@@ -704,7 +704,13 @@ impl<'a, C: FlashController<S>, const S: usize> TicKV<'a, C, S> {
                         // The entire value is not going to fit,
                         // Let's still copy in what we can and return an error
                         for i in 0..buf.len() {
-                            buf[i] = region_data[offset + HEADER_LENGTH + i];
+                            *buf.get_mut(i).ok_or(ErrorCode::BufferTooSmall(
+                                total_length as usize - HEADER_LENGTH - CHECK_SUM_LEN,
+                            ))? = *region_data.get(offset + HEADER_LENGTH + i).ok_or(
+                                ErrorCode::BufferTooSmall(
+                                    total_length as usize - HEADER_LENGTH - CHECK_SUM_LEN,
+                                ),
+                            )?;
                         }
 
                         self.read_buffer.replace(Some(region_data));

--- a/libraries/tickv/src/tickv.rs
+++ b/libraries/tickv/src/tickv.rs
@@ -267,12 +267,20 @@ impl<'a, C: FlashController<S>, const S: usize> TicKV<'a, C, S> {
             }
 
             // Check to see if we have data
-            if region_data[offset + VERSION_OFFSET] != 0xFF {
+            if *region_data
+                .get(offset + VERSION_OFFSET)
+                .ok_or((false, ErrorCode::KeyNotFound))?
+                != 0xFF
+            {
                 // Mark that this region isn't empty
                 empty = false;
 
                 // We found a version, check that we support it
-                if region_data[offset + VERSION_OFFSET] != VERSION {
+                if *region_data
+                    .get(offset + VERSION_OFFSET)
+                    .ok_or((false, ErrorCode::KeyNotFound))?
+                    != VERSION
+                {
                     return Err((false, ErrorCode::UnsupportedVersion));
                 }
 
@@ -409,9 +417,17 @@ impl<'a, C: FlashController<S>, const S: usize> TicKV<'a, C, S> {
                 }
 
                 // Check to see if we have data
-                if region_data[offset + VERSION_OFFSET] != 0xFF {
+                if *region_data
+                    .get(offset + VERSION_OFFSET)
+                    .ok_or(ErrorCode::KeyNotFound)?
+                    != 0xFF
+                {
                     // We found a version, check that we support it
-                    if region_data[offset + VERSION_OFFSET] != VERSION {
+                    if *region_data
+                        .get(offset + VERSION_OFFSET)
+                        .ok_or(ErrorCode::KeyNotFound)?
+                        != VERSION
+                    {
                         self.read_buffer.replace(Some(region_data));
                         return Err(ErrorCode::UnsupportedVersion);
                     }
@@ -750,9 +766,17 @@ impl<'a, C: FlashController<S>, const S: usize> TicKV<'a, C, S> {
             }
 
             // Check to see if we have data
-            if region_data[offset + VERSION_OFFSET] != 0xFF {
+            if *region_data
+                .get(offset + VERSION_OFFSET)
+                .ok_or(ErrorCode::KeyNotFound)?
+                != 0xFF
+            {
                 // We found a version, check that we support it
-                if region_data[offset + VERSION_OFFSET] != VERSION {
+                if *region_data
+                    .get(offset + VERSION_OFFSET)
+                    .ok_or(ErrorCode::KeyNotFound)?
+                    != VERSION
+                {
                     self.read_buffer.replace(Some(region_data));
                     return Err(ErrorCode::UnsupportedVersion);
                 }


### PR DESCRIPTION
### Pull Request Overview

Convert existing panics to instead return a useful error

This should fix: https://github.com/tock/tock/issues/3081

### Testing Strategy

CI

### TODO or Help Wanted

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
