### PR TITLE
Earlgrey: Update rv_timer register layout

### DIFF
--- a/chips/earlgrey/src/timer.rs
+++ b/chips/earlgrey/src/timer.rs
@@ -27,17 +27,18 @@ register_structs! {
 
         (0x008 => _reserved),
 
-        (0x100 => config: ReadWrite<u32, config::Register>),
+        (0x100 => intr_enable: ReadWrite<u32, intr::Register>),
+        (0x104 => intr_state: ReadWrite<u32, intr::Register>),
+        (0x108 => intr_test: WriteOnly<u32, intr::Register>),
 
-        (0x104 => value_low: ReadWrite<u32>),
-        (0x108 => value_high: ReadWrite<u32>),
+        (0x10c => config: ReadWrite<u32, config::Register>),
 
-        (0x10c => compare_low: ReadWrite<u32>),
-        (0x110 => compare_high: ReadWrite<u32>),
+        (0x110 => value_low: ReadWrite<u32>),
+        (0x114 => value_high: ReadWrite<u32>),
 
-        (0x114 => intr_enable: ReadWrite<u32, intr::Register>),
-        (0x118 => intr_state: ReadWrite<u32, intr::Register>),
-        (0x11c => intr_test: WriteOnly<u32, intr::Register>),
+        (0x118 => compare_low: ReadWrite<u32>),
+        (0x11c => compare_high: ReadWrite<u32>),
+
         (0x120 => @END),
     }
 }
@@ -46,13 +47,13 @@ register_bitfields![u32,
     ctrl [
         enable OFFSET(0) NUMBITS(1) []
     ],
+    intr [
+        timer0 OFFSET(0) NUMBITS(1) []
+    ],
     config [
         prescale OFFSET(0) NUMBITS(12) [],
         step OFFSET(16) NUMBITS(8) []
     ],
-    intr [
-        timer0 OFFSET(0) NUMBITS(1) []
-    ]
 ];
 
 pub struct RvTimer<'a> {


### PR DESCRIPTION
### Pull Request Overview

Update the register layout for rv_timer to reflect the changes made in https://github.com/lowRISC/opentitan/pull/13914.


### Testing Strategy




### TODO or Help Wanted




### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
