### PR TITLE
RFC: Replace `DynamicDeferredCall` with modified `DeferredCall` that supports capsules and peripherals

### DIFF
--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -13,6 +13,7 @@ use capsules::virtual_alarm::VirtualMuxAlarm;
 
 use kernel::capabilities;
 use kernel::component::Component;
+use kernel::deferred_call::DeferredCallManager;
 use kernel::dynamic_deferred_call::{DynamicDeferredCall, DynamicDeferredCallClientState};
 use kernel::hil::gpio::Interrupt;
 use kernel::hil::i2c::I2CMaster;
@@ -28,6 +29,7 @@ use kernel::scheduler::round_robin::RoundRobinSched;
 #[allow(unused_imports)]
 use kernel::{create_capability, debug, debug_gpio, debug_verbose, static_init};
 
+use nrf52::deferred_call_tasks::DeferredCallTask;
 use nrf52840::gpio::Pin;
 use nrf52840::interrupt_service::Nrf52840DefaultPeripherals;
 
@@ -236,10 +238,14 @@ impl KernelResources<nrf52::chip::NRF52<'static, Nrf52840DefaultPeripherals<'sta
 /// these static_inits is wasted.
 #[inline(never)]
 unsafe fn get_peripherals() -> &'static mut Nrf52840DefaultPeripherals<'static> {
+    let dc_mgr = static_init!(
+        DeferredCallManager<DeferredCallTask>,
+        DeferredCallManager::new()
+    );
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
-        Nrf52840DefaultPeripherals::new()
+        Nrf52840DefaultPeripherals::new(dc_mgr)
     );
 
     nrf52840_peripherals

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -14,6 +14,7 @@ use capsules::virtual_i2c::{I2CDevice, MuxI2C};
 use capsules::virtual_spi::VirtualSpiMasterDevice;
 use kernel::capabilities;
 use kernel::component::Component;
+use kernel::deferred_call::DeferredCallManager;
 use kernel::dynamic_deferred_call::{DynamicDeferredCall, DynamicDeferredCallClientState};
 use kernel::hil;
 use kernel::hil::i2c::I2CMaster;
@@ -25,6 +26,7 @@ use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::{create_capability, debug, debug_gpio, static_init};
 use sam4l::adc::Channel;
 use sam4l::chip::Sam4lDefaultPeripherals;
+use sam4l::deferred_call_tasks::Task;
 
 /// Support routines for debugging I/O.
 ///
@@ -216,7 +218,11 @@ unsafe fn set_pin_primary_functions(peripherals: &Sam4lDefaultPeripherals) {
 unsafe fn get_peripherals(
     pm: &'static sam4l::pm::PowerManager,
 ) -> &'static Sam4lDefaultPeripherals {
-    static_init!(Sam4lDefaultPeripherals, Sam4lDefaultPeripherals::new(pm))
+    let dc_mgr = static_init!(DeferredCallManager<Task>, DeferredCallManager::new());
+    static_init!(
+        Sam4lDefaultPeripherals,
+        Sam4lDefaultPeripherals::new(pm, dc_mgr)
+    )
 }
 
 /// Board's main function.

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -20,6 +20,7 @@ use capsules::virtual_spi::VirtualSpiMasterDevice;
 //use capsules::virtual_timer::MuxTimer;
 use kernel::capabilities;
 use kernel::component::Component;
+use kernel::deferred_call::DeferredCallManager;
 use kernel::dynamic_deferred_call::{DynamicDeferredCall, DynamicDeferredCallClientState};
 use kernel::hil::i2c::I2CMaster;
 use kernel::hil::radio;
@@ -297,7 +298,14 @@ unsafe fn set_pin_primary_functions(peripherals: &Sam4lDefaultPeripherals) {
 unsafe fn get_peripherals(
     pm: &'static sam4l::pm::PowerManager,
 ) -> &'static Sam4lDefaultPeripherals {
-    static_init!(Sam4lDefaultPeripherals, Sam4lDefaultPeripherals::new(pm))
+    let dc_mgr = static_init!(
+        DeferredCallManager<sam4l::deferred_call_tasks::Task>,
+        DeferredCallManager::new()
+    );
+    static_init!(
+        Sam4lDefaultPeripherals,
+        Sam4lDefaultPeripherals::new(pm, dc_mgr)
+    )
 }
 
 /// Main function.

--- a/boards/imix/src/test/mod.rs
+++ b/boards/imix/src/test/mod.rs
@@ -1,10 +1,10 @@
 pub(crate) mod aes_test;
-pub(crate) mod crc_test;
+//pub(crate) mod crc_test;
 pub(crate) mod i2c_dummy;
 pub(crate) mod icmp_lowpan_test;
 pub(crate) mod ipv6_lowpan_test;
-pub(crate) mod linear_log_test;
-pub(crate) mod log_test;
+//pub(crate) mod linear_log_test;
+//pub(crate) mod log_test;
 pub(crate) mod rng_test;
 pub(crate) mod sha256_test;
 pub(crate) mod spi_dummy;

--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -12,6 +12,7 @@
 use capsules::virtual_aes_ccm::MuxAES128CCM;
 use capsules::virtual_alarm::VirtualMuxAlarm;
 use kernel::component::Component;
+use kernel::deferred_call::DeferredCallManager;
 use kernel::dynamic_deferred_call::{DynamicDeferredCall, DynamicDeferredCallClientState};
 use kernel::hil::led::LedLow;
 use kernel::hil::symmetric_encryption::AES128;
@@ -20,6 +21,7 @@ use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::scheduler::round_robin::RoundRobinSched;
 #[allow(unused_imports)]
 use kernel::{capabilities, create_capability, debug, debug_gpio, debug_verbose, static_init};
+use nrf52840::deferred_call_tasks::DeferredCallTask;
 use nrf52840::gpio::Pin;
 use nrf52840::interrupt_service::Nrf52840DefaultPeripherals;
 use nrf52_components::{self, UartChannel, UartPins};
@@ -168,10 +170,14 @@ impl KernelResources<nrf52840::chip::NRF52<'static, Nrf52840DefaultPeripherals<'
 /// these static_inits is wasted.
 #[inline(never)]
 unsafe fn get_peripherals() -> &'static mut Nrf52840DefaultPeripherals<'static> {
+    let dc_mgr = static_init!(
+        DeferredCallManager<DeferredCallTask>,
+        DeferredCallManager::new()
+    );
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
-        Nrf52840DefaultPeripherals::new()
+        Nrf52840DefaultPeripherals::new(dc_mgr)
     );
 
     nrf52840_peripherals

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -75,6 +75,7 @@ use capsules::net::ipv6::ip_utils::IPAddr;
 use capsules::virtual_aes_ccm::MuxAES128CCM;
 use capsules::virtual_alarm::VirtualMuxAlarm;
 use kernel::component::Component;
+use kernel::deferred_call::DeferredCallManager;
 use kernel::dynamic_deferred_call::{DynamicDeferredCall, DynamicDeferredCallClientState};
 use kernel::hil::i2c::{I2CMaster, I2CSlave};
 use kernel::hil::led::LedLow;
@@ -86,6 +87,7 @@ use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::scheduler::round_robin::RoundRobinSched;
 #[allow(unused_imports)]
 use kernel::{capabilities, create_capability, debug, debug_gpio, debug_verbose, static_init};
+use nrf52840::deferred_call_tasks::DeferredCallTask;
 use nrf52840::gpio::Pin;
 use nrf52840::interrupt_service::Nrf52840DefaultPeripherals;
 use nrf52_components::{self, UartChannel, UartPins};
@@ -228,10 +230,14 @@ impl SyscallDriverLookup for Platform {
 /// these static_inits is wasted.
 #[inline(never)]
 unsafe fn get_peripherals() -> &'static mut Nrf52840DefaultPeripherals<'static> {
+    let dc_mgr = static_init!(
+        DeferredCallManager<DeferredCallTask>,
+        DeferredCallManager::new()
+    );
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
-        Nrf52840DefaultPeripherals::new()
+        Nrf52840DefaultPeripherals::new(dc_mgr)
     );
 
     nrf52840_peripherals

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -68,6 +68,7 @@
 
 use capsules::virtual_alarm::VirtualMuxAlarm;
 use kernel::component::Component;
+use kernel::deferred_call::DeferredCallManager;
 use kernel::dynamic_deferred_call::{DynamicDeferredCall, DynamicDeferredCallClientState};
 use kernel::hil::led::LedLow;
 use kernel::hil::time::Counter;
@@ -75,6 +76,7 @@ use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::scheduler::round_robin::RoundRobinSched;
 #[allow(unused_imports)]
 use kernel::{capabilities, create_capability, debug, debug_gpio, debug_verbose, static_init};
+use nrf52832::deferred_call_tasks::DeferredCallTask;
 use nrf52832::gpio::Pin;
 use nrf52832::interrupt_service::Nrf52832DefaultPeripherals;
 use nrf52832::rtc::Rtc;
@@ -225,10 +227,14 @@ impl KernelResources<nrf52832::chip::NRF52<'static, Nrf52832DefaultPeripherals<'
 /// these static_inits is wasted.
 #[inline(never)]
 unsafe fn get_peripherals() -> &'static mut Nrf52832DefaultPeripherals<'static> {
+    let dc_mgr = static_init!(
+        DeferredCallManager<DeferredCallTask>,
+        DeferredCallManager::new()
+    );
     // Initialize chip peripheral drivers
     let nrf52832_peripherals = static_init!(
         Nrf52832DefaultPeripherals,
-        Nrf52832DefaultPeripherals::new()
+        Nrf52832DefaultPeripherals::new(dc_mgr)
     );
 
     nrf52832_peripherals

--- a/boards/nucleo_f429zi/src/main.rs
+++ b/boards/nucleo_f429zi/src/main.rs
@@ -12,12 +12,14 @@ use capsules::virtual_alarm::VirtualMuxAlarm;
 use components::gpio::GpioComponent;
 use kernel::capabilities;
 use kernel::component::Component;
+use kernel::deferred_call::DeferredCallManager;
 use kernel::dynamic_deferred_call::{DynamicDeferredCall, DynamicDeferredCallClientState};
 use kernel::hil::led::LedHigh;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::{create_capability, debug, static_init};
 
+use stm32f429zi::deferred_calls::DeferredCallTask;
 use stm32f429zi::gpio::{AlternateFunction, Mode, PinId, PortId};
 use stm32f429zi::interrupt_service::Stm32f429ziDefaultPeripherals;
 
@@ -273,10 +275,14 @@ unsafe fn get_peripherals() -> (
     );
     let dma1 = static_init!(stm32f429zi::dma::Dma1, stm32f429zi::dma::Dma1::new(rcc));
     let dma2 = static_init!(stm32f429zi::dma::Dma2, stm32f429zi::dma::Dma2::new(rcc));
+    let dc_mgr = static_init!(
+        DeferredCallManager<DeferredCallTask>,
+        DeferredCallManager::new()
+    );
 
     let peripherals = static_init!(
         Stm32f429ziDefaultPeripherals,
-        Stm32f429ziDefaultPeripherals::new(rcc, exti, dma1, dma2)
+        Stm32f429ziDefaultPeripherals::new(rcc, exti, dma1, dma2, dc_mgr)
     );
     (peripherals, syscfg, dma1)
 }

--- a/boards/nucleo_f446re/src/main.rs
+++ b/boards/nucleo_f446re/src/main.rs
@@ -11,12 +11,14 @@
 use capsules::virtual_alarm::VirtualMuxAlarm;
 use kernel::capabilities;
 use kernel::component::Component;
+use kernel::deferred_call::DeferredCallManager;
 use kernel::dynamic_deferred_call::{DynamicDeferredCall, DynamicDeferredCallClientState};
 use kernel::hil::gpio::Configure;
 use kernel::hil::led::LedHigh;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::{create_capability, debug, static_init};
+use stm32f446re::deferred_calls::DeferredCallTask;
 use stm32f446re::interrupt_service::Stm32f446reDefaultPeripherals;
 
 /// Support routines for debugging I/O.
@@ -226,9 +228,13 @@ unsafe fn get_peripherals() -> (
     let dma1 = static_init!(stm32f446re::dma::Dma1, stm32f446re::dma::Dma1::new(rcc));
     let dma2 = static_init!(stm32f446re::dma::Dma2, stm32f446re::dma::Dma2::new(rcc));
 
+    let dc_mgr = static_init!(
+        DeferredCallManager<DeferredCallTask>,
+        DeferredCallManager::new()
+    );
     let peripherals = static_init!(
         Stm32f446reDefaultPeripherals,
-        Stm32f446reDefaultPeripherals::new(rcc, exti, dma1, dma2)
+        Stm32f446reDefaultPeripherals::new(rcc, exti, dma1, dma2, dc_mgr)
     );
     (peripherals, syscfg, dma1)
 }

--- a/boards/stm32f3discovery/src/main.rs
+++ b/boards/stm32f3discovery/src/main.rs
@@ -13,6 +13,7 @@ use capsules::virtual_alarm::VirtualMuxAlarm;
 use components::gpio::GpioComponent;
 use kernel::capabilities;
 use kernel::component::Component;
+use kernel::deferred_call::DeferredCallManager;
 use kernel::dynamic_deferred_call::{DynamicDeferredCall, DynamicDeferredCallClientState};
 use kernel::hil::gpio::Configure;
 use kernel::hil::gpio::Output;
@@ -22,6 +23,7 @@ use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::{create_capability, debug, static_init};
 use stm32f303xc::chip::Stm32f3xxDefaultPeripherals;
+use stm32f303xc::deferred_call_tasks::DeferredCallTask;
 use stm32f303xc::wdt;
 
 /// Support routines for debugging I/O.
@@ -358,10 +360,14 @@ unsafe fn get_peripherals() -> (
         stm32f303xc::exti::Exti,
         stm32f303xc::exti::Exti::new(syscfg)
     );
+    let dc_mgr = static_init!(
+        DeferredCallManager<DeferredCallTask>,
+        DeferredCallManager::new()
+    );
 
     let peripherals = static_init!(
         Stm32f3xxDefaultPeripherals,
-        Stm32f3xxDefaultPeripherals::new(rcc, exti)
+        Stm32f3xxDefaultPeripherals::new(rcc, exti, dc_mgr)
     );
 
     (peripherals, syscfg, rcc)

--- a/boards/stm32f412gdiscovery/src/main.rs
+++ b/boards/stm32f412gdiscovery/src/main.rs
@@ -12,6 +12,7 @@ use components::gpio::GpioComponent;
 use components::rng::RngComponent;
 use kernel::capabilities;
 use kernel::component::Component;
+use kernel::deferred_call::DeferredCallManager;
 use kernel::dynamic_deferred_call::{DynamicDeferredCall, DynamicDeferredCallClientState};
 use kernel::hil::gpio;
 use kernel::hil::led::LedLow;
@@ -19,6 +20,7 @@ use kernel::hil::screen::ScreenRotation;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::{create_capability, debug, static_init};
+use stm32f412g::deferred_calls::DeferredCallTask;
 use stm32f412g::interrupt_service::Stm32f412gDefaultPeripherals;
 
 /// Support routines for debugging I/O.
@@ -384,10 +386,14 @@ unsafe fn get_peripherals() -> (
 
     let dma1 = static_init!(stm32f412g::dma::Dma1, stm32f412g::dma::Dma1::new(rcc));
     let dma2 = static_init!(stm32f412g::dma::Dma2, stm32f412g::dma::Dma2::new(rcc));
+    let dc_mgr = static_init!(
+        DeferredCallManager<DeferredCallTask>,
+        DeferredCallManager::new()
+    );
 
     let peripherals = static_init!(
         Stm32f412gDefaultPeripherals,
-        Stm32f412gDefaultPeripherals::new(rcc, exti, dma1, dma2)
+        Stm32f412gDefaultPeripherals::new(rcc, exti, dma1, dma2, dc_mgr)
     );
     (peripherals, syscfg, dma1)
 }

--- a/boards/stm32f429idiscovery/src/main.rs
+++ b/boards/stm32f429idiscovery/src/main.rs
@@ -12,12 +12,14 @@ use capsules::virtual_alarm::VirtualMuxAlarm;
 use components::gpio::GpioComponent;
 use kernel::capabilities;
 use kernel::component::Component;
+use kernel::deferred_call::DeferredCallManager;
 use kernel::dynamic_deferred_call::{DynamicDeferredCall, DynamicDeferredCallClientState};
 use kernel::hil::led::LedHigh;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::{create_capability, debug, static_init};
 
+use stm32f429zi::deferred_calls::DeferredCallTask;
 use stm32f429zi::gpio::{AlternateFunction, Mode, PinId, PortId};
 use stm32f429zi::interrupt_service::Stm32f429ziDefaultPeripherals;
 
@@ -277,9 +279,13 @@ unsafe fn get_peripherals() -> (
     );
     let dma1 = static_init!(stm32f429zi::dma::Dma1, stm32f429zi::dma::Dma1::new(rcc));
     let dma2 = static_init!(stm32f429zi::dma::Dma2, stm32f429zi::dma::Dma2::new(rcc));
+    let dc_mgr = static_init!(
+        DeferredCallManager<DeferredCallTask>,
+        DeferredCallManager::new()
+    );
     let peripherals = static_init!(
         Stm32f429ziDefaultPeripherals,
-        Stm32f429ziDefaultPeripherals::new(rcc, exti, dma1, dma2)
+        Stm32f429ziDefaultPeripherals::new(rcc, exti, dma1, dma2, dc_mgr)
     );
     (peripherals, syscfg, dma2)
 }

--- a/boards/weact_f401ccu6/src/main.rs
+++ b/boards/weact_f401ccu6/src/main.rs
@@ -12,12 +12,14 @@ use capsules::virtual_alarm::VirtualMuxAlarm;
 use components::gpio::GpioComponent;
 use kernel::capabilities;
 use kernel::component::Component;
+use kernel::deferred_call::DeferredCallManager;
 use kernel::dynamic_deferred_call::{DynamicDeferredCall, DynamicDeferredCallClientState};
 use kernel::hil::led::LedLow;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::scheduler::round_robin::RoundRobinSched;
 use kernel::{create_capability, debug, static_init};
 
+use stm32f401cc::deferred_calls::DeferredCallTask;
 use stm32f401cc::interrupt_service::Stm32f401ccDefaultPeripherals;
 
 /// Support routines for debugging I/O.
@@ -227,10 +229,14 @@ unsafe fn get_peripherals() -> (
     );
     let dma1 = static_init!(stm32f401cc::dma::Dma1, stm32f401cc::dma::Dma1::new(rcc));
     let dma2 = static_init!(stm32f401cc::dma::Dma2, stm32f401cc::dma::Dma2::new(rcc));
+    let dc_mgr = static_init!(
+        DeferredCallManager<DeferredCallTask>,
+        DeferredCallManager::new()
+    );
 
     let peripherals = static_init!(
         Stm32f401ccDefaultPeripherals,
-        Stm32f401ccDefaultPeripherals::new(rcc, exti, dma1, dma2)
+        Stm32f401ccDefaultPeripherals::new(rcc, exti, dma1, dma2, dc_mgr)
     );
     (peripherals, syscfg, dma1)
 }

--- a/capsules/src/driver.rs
+++ b/capsules/src/driver.rs
@@ -2,6 +2,7 @@
 
 use enum_primitive::cast::FromPrimitive;
 use enum_primitive::enum_from_primitive;
+use kernel::deferred_call::CapsuleTask;
 
 enum_from_primitive! {
 #[derive(Debug, PartialEq)]
@@ -79,3 +80,29 @@ pub enum NUM {
     TextScreen            = 0x90003,
 }
 }
+
+enum_from_primitive! {
+#[derive(PartialEq, Clone, Copy)]
+pub enum Task {
+    Radio = 0xffff,
+}
+}
+
+impl TryFrom<usize> for Task {
+    type Error = ();
+
+    fn try_from(value: usize) -> Result<Task, ()> {
+        match value {
+            0xffff => Ok(Task::Radio),
+            _ => Err(()),
+        }
+    }
+}
+
+impl Into<usize> for Task {
+    fn into(self) -> usize {
+        self as usize
+    }
+}
+
+impl CapsuleTask for Task {}

--- a/chips/nrf52832/src/interrupt_service.rs
+++ b/chips/nrf52832/src/interrupt_service.rs
@@ -1,4 +1,5 @@
 use crate::deferred_call_tasks::DeferredCallTask;
+use kernel::deferred_call::DeferredCallManager;
 use nrf52::chip::Nrf52DefaultPeripherals;
 
 /// This struct, when initialized, instantiates all peripheral drivers for the nrf52840.
@@ -10,9 +11,9 @@ pub struct Nrf52832DefaultPeripherals<'a> {
     pub gpio_port: crate::gpio::Port<'a, { crate::gpio::NUM_PINS }>,
 }
 impl<'a> Nrf52832DefaultPeripherals<'a> {
-    pub unsafe fn new() -> Self {
+    pub unsafe fn new(dc_mgr: &'static DeferredCallManager<DeferredCallTask>) -> Self {
         Self {
-            nrf52: Nrf52DefaultPeripherals::new(),
+            nrf52: Nrf52DefaultPeripherals::new(dc_mgr),
             gpio_port: crate::gpio::nrf52832_gpio_create(),
         }
     }

--- a/chips/nrf52833/src/interrupt_service.rs
+++ b/chips/nrf52833/src/interrupt_service.rs
@@ -1,4 +1,5 @@
 use crate::deferred_call_tasks::DeferredCallTask;
+use kernel::deferred_call::DeferredCallManager;
 use nrf52::chip::Nrf52DefaultPeripherals;
 
 /// This struct, when initialized, instantiates all peripheral drivers for the nrf52840.
@@ -10,9 +11,9 @@ pub struct Nrf52833DefaultPeripherals<'a> {
     pub gpio_port: crate::gpio::Port<'a, { crate::gpio::NUM_PINS }>,
 }
 impl<'a> Nrf52833DefaultPeripherals<'a> {
-    pub unsafe fn new() -> Self {
+    pub unsafe fn new(dc_mgr: &'static DeferredCallManager<DeferredCallTask>) -> Self {
         Self {
-            nrf52: Nrf52DefaultPeripherals::new(),
+            nrf52: Nrf52DefaultPeripherals::new(dc_mgr),
             gpio_port: crate::gpio::nrf52833_gpio_create(),
         }
     }

--- a/chips/nrf52840/src/interrupt_service.rs
+++ b/chips/nrf52840/src/interrupt_service.rs
@@ -1,4 +1,5 @@
 use crate::deferred_call_tasks::DeferredCallTask;
+use kernel::deferred_call::DeferredCallManager;
 use nrf52::chip::Nrf52DefaultPeripherals;
 
 /// This struct, when initialized, instantiates all peripheral drivers for the nrf52840.
@@ -13,9 +14,9 @@ pub struct Nrf52840DefaultPeripherals<'a> {
 }
 
 impl<'a> Nrf52840DefaultPeripherals<'a> {
-    pub unsafe fn new() -> Self {
+    pub unsafe fn new(dc_mgr: &'static DeferredCallManager<DeferredCallTask>) -> Self {
         Self {
-            nrf52: Nrf52DefaultPeripherals::new(),
+            nrf52: Nrf52DefaultPeripherals::new(dc_mgr),
             usbd: crate::usbd::Usbd::new(),
             gpio_port: crate::gpio::nrf52840_gpio_create(),
         }

--- a/chips/rp2040/src/chip.rs
+++ b/chips/rp2040/src/chip.rs
@@ -1,7 +1,6 @@
 //! Chip trait setup.
 
 use core::fmt::Write;
-use kernel::deferred_call;
 use kernel::platform::chip::Chip;
 use kernel::platform::chip::InterruptService;
 
@@ -83,7 +82,7 @@ impl<'a, I: InterruptService<()>> Chip for Rp2040<'a, I> {
             Processor::Processor0 => self.processor0_interrupt_mask,
             Processor::Processor1 => self.processor1_interrupt_mask,
         };
-        unsafe { cortexm0p::nvic::has_pending_with_mask(mask) || deferred_call::has_tasks() }
+        unsafe { cortexm0p::nvic::has_pending_with_mask(mask) }
     }
 
     fn mpu(&self) -> &Self::MPU {

--- a/chips/sam4l/src/deferred_call_tasks.rs
+++ b/chips/sam4l/src/deferred_call_tasks.rs
@@ -1,16 +1,17 @@
-//! Definition of Deferred Call tasks.
+//! Definition of Deferred Call tasks for SAM4L chip peripherals.
 //!
 //! Deferred calls allow peripheral drivers to register pseudo interrupts.
 //! These are the definitions of which deferred calls this chip needs.
 
 use core::convert::Into;
 use core::convert::TryFrom;
+use kernel::deferred_call::PeripheralTask;
 
 /// A type of task to defer a call for
 #[derive(Copy, Clone)]
 pub enum Task {
-    Flashcalw = 0,
-    CRCCU = 1,
+    Flashcalw = 0xf0000,
+    CRCCU = 0xf0001,
 }
 
 impl TryFrom<usize> for Task {
@@ -18,8 +19,8 @@ impl TryFrom<usize> for Task {
 
     fn try_from(value: usize) -> Result<Task, ()> {
         match value {
-            0 => Ok(Task::Flashcalw),
-            1 => Ok(Task::CRCCU),
+            0xf0000 => Ok(Task::Flashcalw),
+            0xf0001 => Ok(Task::CRCCU),
             _ => Err(()),
         }
     }
@@ -30,3 +31,5 @@ impl Into<usize> for Task {
         self as usize
     }
 }
+
+impl PeripheralTask for Task {}

--- a/chips/sam4l/src/pm.rs
+++ b/chips/sam4l/src/pm.rs
@@ -2,11 +2,13 @@
 
 use crate::bpm;
 use crate::bscif;
+use crate::deferred_call_tasks::Task;
 use crate::flashcalw;
 use crate::gpio;
 use crate::scif;
 use core::cell::Cell;
 use core::sync::atomic::Ordering;
+use kernel::deferred_call::DeferredCallMapper;
 use kernel::platform::chip::ClockInterface;
 use kernel::utilities::registers::interfaces::{Readable, Writeable};
 use kernel::utilities::registers::{
@@ -585,10 +587,10 @@ impl PowerManager {
 impl PowerManager {
     /// Sets up the system clock. This should be called as one of the first
     /// lines in the `main()` function within the platform's `main.rs`.
-    pub unsafe fn setup_system_clock(
+    pub unsafe fn setup_system_clock<M: DeferredCallMapper<PT = Task> + 'static>(
         &self,
         clock_source: SystemClockSource,
-        flash_controller: &flashcalw::FLASHCALW,
+        flash_controller: &flashcalw::FLASHCALW<M>,
     ) {
         if !self.system_initial_configs.get() {
             // For now, always go to PS2 as it enables all core speeds
@@ -812,10 +814,10 @@ impl PowerManager {
 
     // Changes the system clock to the clock passed in as clock_source and disables
     // the previous system clock
-    pub unsafe fn change_system_clock(
+    pub unsafe fn change_system_clock<M: DeferredCallMapper<PT = Task> + 'static>(
         &self,
         clock_source: SystemClockSource,
-        flash_controller: &flashcalw::FLASHCALW,
+        flash_controller: &flashcalw::FLASHCALW<M>,
     ) {
         // If the clock you want to switch to is the current system clock, do nothing
         let prev_clock_source = self.system_clock_source.get();

--- a/chips/stm32f303xc/src/lib.rs
+++ b/chips/stm32f303xc/src/lib.rs
@@ -7,7 +7,7 @@
 #![no_std]
 
 pub mod chip;
-mod deferred_call_tasks;
+pub mod deferred_call_tasks;
 pub mod nvic;
 
 // Peripherals

--- a/chips/stm32f401cc/src/interrupt_service.rs
+++ b/chips/stm32f401cc/src/interrupt_service.rs
@@ -1,3 +1,4 @@
+use kernel::deferred_call::DeferredCallManager;
 use stm32f4xx::chip::Stm32f4xxDefaultPeripherals;
 use stm32f4xx::deferred_calls::DeferredCallTask;
 
@@ -12,9 +13,10 @@ impl<'a> Stm32f401ccDefaultPeripherals<'a> {
         exti: &'a crate::exti::Exti<'a>,
         dma1: &'a crate::dma::Dma1<'a>,
         dma2: &'a crate::dma::Dma2<'a>,
+        dc_mgr: &'static DeferredCallManager<DeferredCallTask>,
     ) -> Self {
         Self {
-            stm32f4: Stm32f4xxDefaultPeripherals::new(rcc, exti, dma1, dma2),
+            stm32f4: Stm32f4xxDefaultPeripherals::new(rcc, exti, dma1, dma2, dc_mgr),
         }
     }
     // Necessary for setting up circular dependencies

--- a/chips/stm32f401cc/src/lib.rs
+++ b/chips/stm32f401cc/src/lib.rs
@@ -2,7 +2,9 @@
 
 use cortexm4::{generic_isr, unhandled_interrupt};
 
-pub use stm32f4xx::{adc, chip, dbg, dma, exti, gpio, nvic, rcc, spi, syscfg, tim2, usart};
+pub use stm32f4xx::{
+    adc, chip, dbg, deferred_calls, dma, exti, gpio, nvic, rcc, spi, syscfg, tim2, usart,
+};
 
 pub mod interrupt_service;
 

--- a/chips/stm32f412g/src/interrupt_service.rs
+++ b/chips/stm32f412g/src/interrupt_service.rs
@@ -1,4 +1,5 @@
 use crate::stm32f412g_nvic;
+use kernel::deferred_call::DeferredCallManager;
 use stm32f4xx::chip::Stm32f4xxDefaultPeripherals;
 use stm32f4xx::deferred_calls::DeferredCallTask;
 
@@ -14,9 +15,10 @@ impl<'a> Stm32f412gDefaultPeripherals<'a> {
         exti: &'a crate::exti::Exti<'a>,
         dma1: &'a crate::dma::Dma1<'a>,
         dma2: &'a crate::dma::Dma2<'a>,
+        dc_mgr: &'static DeferredCallManager<DeferredCallTask>,
     ) -> Self {
         Self {
-            stm32f4: Stm32f4xxDefaultPeripherals::new(rcc, exti, dma1, dma2),
+            stm32f4: Stm32f4xxDefaultPeripherals::new(rcc, exti, dma1, dma2, dc_mgr),
             trng: stm32f4xx::trng::Trng::new(rcc),
         }
     }

--- a/chips/stm32f412g/src/lib.rs
+++ b/chips/stm32f412g/src/lib.rs
@@ -3,7 +3,8 @@
 use cortexm4::generic_isr;
 
 pub use stm32f4xx::{
-    adc, chip, dbg, dma, exti, fsmc, gpio, i2c, nvic, rcc, spi, syscfg, tim2, trng, usart,
+    adc, chip, dbg, deferred_calls, dma, exti, fsmc, gpio, i2c, nvic, rcc, spi, syscfg, tim2, trng,
+    usart,
 };
 
 pub mod interrupt_service;

--- a/chips/stm32f429zi/src/interrupt_service.rs
+++ b/chips/stm32f429zi/src/interrupt_service.rs
@@ -1,3 +1,4 @@
+use kernel::deferred_call::DeferredCallManager;
 use stm32f4xx::chip::Stm32f4xxDefaultPeripherals;
 use stm32f4xx::deferred_calls::DeferredCallTask;
 
@@ -12,9 +13,10 @@ impl<'a> Stm32f429ziDefaultPeripherals<'a> {
         exti: &'a crate::exti::Exti<'a>,
         dma1: &'a crate::dma::Dma1<'a>,
         dma2: &'a crate::dma::Dma2<'a>,
+        dc_mgr: &'static DeferredCallManager<DeferredCallTask>,
     ) -> Self {
         Self {
-            stm32f4: Stm32f4xxDefaultPeripherals::new(rcc, exti, dma1, dma2),
+            stm32f4: Stm32f4xxDefaultPeripherals::new(rcc, exti, dma1, dma2, dc_mgr),
         }
     }
     // Necessary for setting up circular dependencies

--- a/chips/stm32f429zi/src/lib.rs
+++ b/chips/stm32f429zi/src/lib.rs
@@ -2,7 +2,9 @@
 
 use cortexm4::generic_isr;
 
-pub use stm32f4xx::{adc, chip, dbg, dma, exti, gpio, nvic, rcc, spi, syscfg, tim2, usart};
+pub use stm32f4xx::{
+    adc, chip, dbg, deferred_calls, dma, exti, gpio, nvic, rcc, spi, syscfg, tim2, usart,
+};
 
 pub mod interrupt_service;
 pub mod stm32f429zi_nvic;

--- a/chips/stm32f446re/src/interrupt_service.rs
+++ b/chips/stm32f446re/src/interrupt_service.rs
@@ -1,3 +1,4 @@
+use kernel::deferred_call::DeferredCallManager;
 use stm32f4xx::chip::Stm32f4xxDefaultPeripherals;
 use stm32f4xx::deferred_calls::DeferredCallTask;
 
@@ -12,9 +13,10 @@ impl<'a> Stm32f446reDefaultPeripherals<'a> {
         exti: &'a crate::exti::Exti<'a>,
         dma1: &'a crate::dma::Dma1<'a>,
         dma2: &'a crate::dma::Dma2<'a>,
+        dc_mgr: &'static DeferredCallManager<DeferredCallTask>,
     ) -> Self {
         Self {
-            stm32f4: Stm32f4xxDefaultPeripherals::new(rcc, exti, dma1, dma2),
+            stm32f4: Stm32f4xxDefaultPeripherals::new(rcc, exti, dma1, dma2, dc_mgr),
         }
     }
     // Necessary for setting up circular dependencies

--- a/chips/stm32f446re/src/lib.rs
+++ b/chips/stm32f446re/src/lib.rs
@@ -1,6 +1,8 @@
 #![no_std]
 
-pub use stm32f4xx::{chip, dbg, dma, exti, gpio, nvic, rcc, spi, syscfg, tim2, usart};
+pub use stm32f4xx::{
+    chip, dbg, deferred_calls, dma, exti, gpio, nvic, rcc, spi, syscfg, tim2, usart,
+};
 
 pub mod interrupt_service;
 pub mod stm32f446re_nvic;

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -85,7 +85,6 @@
 //!    this use case. It is likely we will have to create new interfaces as new
 //!    use cases are discovered.
 
-#![feature(core_intrinsics)]
 #![warn(unreachable_pub)]
 #![no_std]
 

--- a/kernel/src/platform/chip.rs
+++ b/kernel/src/platform/chip.rs
@@ -102,26 +102,20 @@ pub trait Chip {
 /// where the kernel instructs the `nrf52` crate to handle interrupts, and if
 /// there is an interrupt ready then that interrupt is passed through the
 /// InterruptService objects until something can service it.
-pub trait InterruptService<T> {
+pub trait InterruptService {
     /// Service an interrupt, if supported by this chip. If this interrupt
     /// number is not supported, return false.
     unsafe fn service_interrupt(&self, interrupt: u32) -> bool;
 
-    /// Service a deferred call. If this task is not supported, return false.
-    unsafe fn service_deferred_call(&self, task: T) -> bool;
+    /// Service a deferred call. If the next pending deferred call cannot be serviced,
+    /// return false.
+    unsafe fn service_next_pending_deferred_call(&self) -> bool;
 
     /// Returns true if any deferred call tasks are pending, otherwise returns false.
     /// Default implementation just returns false, and should be overriden by chips that require
     /// defferred calls.
     fn has_deferred_call_tasks(&self) -> bool {
         false
-    }
-
-    /// Returns the next pending deferred call task, if any.
-    /// Default implementation just returns None, and should be overriden by chips that require
-    /// deferred calls
-    fn next_pending_deferred_call(&self) -> Option<T> {
-        None
     }
 }
 

--- a/kernel/src/platform/chip.rs
+++ b/kernel/src/platform/chip.rs
@@ -109,6 +109,20 @@ pub trait InterruptService<T> {
 
     /// Service a deferred call. If this task is not supported, return false.
     unsafe fn service_deferred_call(&self, task: T) -> bool;
+
+    /// Returns true if any deferred call tasks are pending, otherwise returns false.
+    /// Default implementation just returns false, and should be overriden by chips that require
+    /// defferred calls.
+    fn has_deferred_call_tasks(&self) -> bool {
+        false
+    }
+
+    /// Returns the next pending deferred call task, if any.
+    /// Default implementation just returns None, and should be overriden by chips that require
+    /// deferred calls
+    fn next_pending_deferred_call(&self) -> Option<T> {
+        None
+    }
 }
 
 /// Generic operations that clock-like things are expected to support.


### PR DESCRIPTION
### Pull Request Overview

This pull request builds upon the work in https://github.com/tock/tock/pull/3086 to construct a version of `DeferredCall` that can be used by both capsules and chip peripherals, obsoleting `DynamicDeferredCall`. So far, I have ported this approach to the two sam4l peripherals with deferred calls (`CRCCU` and `FLASHCALW`) and to one capsule with a dynamic deferred call (`ieee802154/driver.rs`)

The major downside of this approach is that all capsules which use deferred calls add a generic parameter they did not previously have. It also adds some verbosity to main.rs, where boards have to define the mapping of `DeferredCallTask`s --> callback functions.

Otherwise, this approach seems pretty beneficial: it does not use any trait object dispatch, eliminating vtables and speeding the time to set a deferred call. It reduces code size compared to `DynamicDeferredCall`, at least for the radio case. It reduces the number of fields needed on capsules to store a deferred call, replacing `DynamicDeferredCaller` and `DeferredCallHandle` with a single `DeferredCall` struct, and removing the need for a `initialize_callback_handle()` function.


### Testing Strategy

This pull request was tested by compiling.


### TODO or Help Wanted

This pull request still needs to port of all capsules except the ieee802154 driver.


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
