### PR TITLE
[trivial] tock-registers: mark two methods as `const`

### DIFF
--- a/libraries/tock-register-interface/src/fields.rs
+++ b/libraries/tock-register-interface/src/fields.rs
@@ -172,7 +172,7 @@ impl<T: UIntLike, R: RegisterLongName> Copy for Field<T, R> {}
 macro_rules! Field_impl_for {
     ($type:ty) => {
         impl<R: RegisterLongName> Field<$type, R> {
-            pub fn val(&self, value: $type) -> FieldValue<$type, R> {
+            pub const fn val(&self, value: $type) -> FieldValue<$type, R> {
                 FieldValue::<$type, R>::new(self.mask, self.shift, value)
             }
         }

--- a/libraries/tock-register-interface/src/fields.rs
+++ b/libraries/tock-register-interface/src/fields.rs
@@ -241,7 +241,7 @@ impl<T: UIntLike, R: RegisterLongName> FieldValue<T, R> {
 
     /// Get the raw bitmask represented by this FieldValue.
     #[inline]
-    pub fn mask(&self) -> T {
+    pub const fn mask(&self) -> T {
         self.mask as T
     }
 


### PR DESCRIPTION
### Pull Request Overview

This trivial pull request marks two methods as `const` (without any other code changes).

Rationale: allow them to be used in the context of a `static_assert_eq!`.

### Testing Strategy

This pull request was tested by `cargo test`

### Documentation Updated

No updates are required.

### Formatting

No significant changes. 
