### PR TITLE
WIP: Remove Dynamic Deferred Call w/o changing deferred call

### DIFF
--- a/kernel/src/capsule_deferred_call.rs
+++ b/kernel/src/capsule_deferred_call.rs
@@ -1,0 +1,57 @@
+//! Deferred call mechanism.
+//!
+//! This is a tool to allow capsules to schedule "interrupts"
+//! in the chip scheduler if the hardware doesn't support interrupts where
+//! they are needed.
+
+use crate::deferred_call::AtomicUsize;
+use core::convert::Into;
+use core::convert::TryFrom;
+use core::convert::TryInto;
+use core::marker::Copy;
+
+static CAPSULE_DEFERRED_CALL: AtomicUsize = AtomicUsize::new(0);
+
+/// Are there any pending `CapsuleDeferredCall`s?
+pub fn has_tasks() -> bool {
+    CAPSULE_DEFERRED_CALL.load_relaxed() != 0
+}
+
+/// Represents a way to generate an asynchronous call without a hardware
+/// interrupt. Supports up to 32 possible deferrable tasks.
+pub struct CapsuleDeferredCall<T>(T);
+
+impl<T: Into<usize> + TryFrom<usize> + Copy> CapsuleDeferredCall<T> {
+    /// Creates a new CapsuleDeferredCall
+    ///
+    /// Only create one per task, preferably in the module that it will be used
+    /// in.
+    pub const fn new(task: T) -> Self {
+        CapsuleDeferredCall(task)
+    }
+
+    /// Set the `CapsuleDeferredCall` as pending
+    pub fn set(&self) {
+        CAPSULE_DEFERRED_CALL.fetch_or_relaxed(1 << self.0.into() as usize);
+    }
+
+    /// Gets and clears the next pending `CapsuleDeferredCall`
+    pub fn next_pending() -> Option<T> {
+        let val = CAPSULE_DEFERRED_CALL.load_relaxed();
+        if val == 0 {
+            None
+        } else {
+            let bit = val.trailing_zeros() as usize;
+            let new_val = val & !(1 << bit);
+            CAPSULE_DEFERRED_CALL.store_relaxed(new_val);
+            bit.try_into().ok()
+        }
+    }
+}
+
+pub trait CapsuleTask: Into<usize> + TryFrom<usize> + Copy {}
+
+pub trait DeferredCallMapper {
+    type CAT: CapsuleTask;
+    fn service_deferred_call(&self, task: Self::CAT) -> bool;
+}

--- a/kernel/src/deferred_call.rs
+++ b/kernel/src/deferred_call.rs
@@ -18,7 +18,7 @@ use core::marker::Sync;
 ///
 /// Borrowed from https://github.com/japaric/heapless/blob/master/src/ring_buffer/mod.rs
 /// See: https://github.com/japaric/heapless/commit/37c8b5b63780ed8811173dc1ec8859cd99efa9ad
-struct AtomicUsize {
+pub(crate) struct AtomicUsize {
     v: UnsafeCell<usize>,
 }
 

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -94,6 +94,7 @@ pub const MAJOR: u16 = 2;
 pub const MINOR: u16 = 0;
 
 pub mod capabilities;
+pub mod capsule_deferred_call;
 pub mod collections;
 pub mod component;
 pub mod debug;

--- a/kernel/src/platform/chip.rs
+++ b/kernel/src/platform/chip.rs
@@ -1,5 +1,6 @@
 //! Interfaces for implementing microcontrollers in Tock.
 
+use crate::capsule_deferred_call::CapsuleTask;
 use crate::platform::mpu;
 use crate::syscall;
 use core::fmt::Write;
@@ -102,13 +103,16 @@ pub trait Chip {
 /// where the kernel instructs the `nrf52` crate to handle interrupts, and if
 /// there is an interrupt ready then that interrupt is passed through the
 /// InterruptService objects until something can service it.
-pub trait InterruptService<T> {
+pub trait InterruptService<CHT, CAT: CapsuleTask> {
     /// Service an interrupt, if supported by this chip. If this interrupt
     /// number is not supported, return false.
     unsafe fn service_interrupt(&self, interrupt: u32) -> bool;
 
     /// Service a deferred call. If this task is not supported, return false.
-    unsafe fn service_deferred_call(&self, task: T) -> bool;
+    unsafe fn service_deferred_call(&self, task: CHT) -> bool;
+
+    /// Service a capsule deferred call. If this task is not supported, return false.
+    unsafe fn service_capsule_deferred_call(&self, task: CAT) -> bool;
 }
 
 /// Generic operations that clock-like things are expected to support.


### PR DESCRIPTION
### Pull Request Overview

This pull request is another alternative to https://github.com/tock/tock/pull/3123 and #3086 . Rather than modify DefferredCall, it introduces a new type in the kernel, `CapsuleDeferredCall`, for use only by capsules.
This PR keeps the use of globals and atomics, allowing a less annoying API, at the expense of keeping us on nightly Rust until we reach an agreement about how to provide atomics without using LLVM intrinsics. This PR also seems to be a little smaller (~400 bytes) than #3123, and seems to produce about 100 bytes of savings per `DynamicDeferredCall` removed.

As with the other draft PRs, this is only implemented for Imix + the radio driver capsule.

### Testing Strategy

This pull request was tested by compiling


### TODO or Help Wanted

This pull request still needs implementations for more than the radio capsule, plus a lot of cleanups of names etc.


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
