### PR TITLE
[up-keep] arch: fixup typos

### DIFF
--- a/arch/cortex-m/src/lib.rs
+++ b/arch/cortex-m/src/lib.rs
@@ -412,7 +412,7 @@ pub unsafe fn switch_to_user_arm_v7m(
     // SWITCH
     svc 0xff   // It doesn't matter which SVC number we use here as it has no
                // defined meaning for the Cortex-M syscall interface. Data being
-               // returned from a syscall is transfered on the app's stack.
+               // returned from a syscall is transferred on the app's stack.
 
     // When execution returns here we have switched back to the kernel from the
     // application.

--- a/arch/cortex-m/src/scb.rs
+++ b/arch/cortex-m/src/scb.rs
@@ -110,7 +110,7 @@ register_bitfields![u32,
         /// WO.
         PENDSTCLR       OFFSET(25)  NUMBITS(1),
 
-        /// Whether an excpetion will be serviced when existing debug state.
+        /// Whether an exception will be serviced when existing debug state.
         /// RO.
         ISRPREEMPT      OFFSET(23)  NUMBITS(1),
 

--- a/arch/rv32i/src/epmp.rs
+++ b/arch/rv32i/src/epmp.rs
@@ -60,7 +60,7 @@ pub struct PMP<const MAX_AVAILABLE_REGIONS_OVER_TWO: usize> {
     /// Each bit that is set in this mask indicates that the region is locked
     /// and cannot be used by Tock.
     locked_region_mask: Cell<u64>,
-    /// This is the total number of avaliable regions.
+    /// This is the total number of available regions.
     /// This will be between 0 and MAX_AVAILABLE_REGIONS_OVER_TWO * 2 depending
     /// on the hardware and previous boot stages.
     num_regions: usize,

--- a/arch/rv32i/src/pmp.rs
+++ b/arch/rv32i/src/pmp.rs
@@ -62,7 +62,7 @@ pub struct PMP<const MAX_AVAILABLE_REGIONS_OVER_TWO: usize> {
     /// Each bit that is set in this mask indicates that the region is locked
     /// and cannot be used by Tock.
     locked_region_mask: Cell<u64>,
-    /// This is the total number of avaliable regions.
+    /// This is the total number of available regions.
     /// This will be between 0 and MAX_AVAILABLE_REGIONS_OVER_TWO * 2 depending
     /// on the hardware and previous boot stages.
     num_regions: usize,
@@ -552,7 +552,7 @@ impl<const MAX_AVAILABLE_REGIONS_OVER_TWO: usize> kernel::platform::mpu::MPU
 /// This is still a useful implementation as it can be used to limit the
 /// kernels access, for example removing execute permission from regions
 /// we don't need to execute from and removing write permissions from
-/// executable reions.
+/// executable regions.
 impl<const MAX_AVAILABLE_REGIONS_OVER_TWO: usize> kernel::platform::mpu::KernelMPU
     for PMP<MAX_AVAILABLE_REGIONS_OVER_TWO>
 {


### PR DESCRIPTION
### Pull Request Overview

Fixup minor typos in `arch`

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
