### PR TITLE
use deferred calls to report aborted reception in sam4l uart

### DIFF
--- a/chips/sam4l/src/chip.rs
+++ b/chips/sam4l/src/chip.rs
@@ -229,6 +229,10 @@ impl InterruptService<Task> for Sam4lDefaultPeripherals {
         match task {
             crate::deferred_call_tasks::Task::Flashcalw => self.flash_controller.handle_interrupt(),
             crate::deferred_call_tasks::Task::CRCCU => self.crccu.handle_deferred_call(),
+            crate::deferred_call_tasks::Task::Usart0 => self.usart0.handle_deferred_call(),
+            crate::deferred_call_tasks::Task::Usart1 => self.usart1.handle_deferred_call(),
+            crate::deferred_call_tasks::Task::Usart2 => self.usart2.handle_deferred_call(),
+            crate::deferred_call_tasks::Task::Usart3 => self.usart3.handle_deferred_call(),
         }
         true
     }

--- a/chips/sam4l/src/deferred_call_tasks.rs
+++ b/chips/sam4l/src/deferred_call_tasks.rs
@@ -11,6 +11,10 @@ use core::convert::TryFrom;
 pub enum Task {
     Flashcalw = 0,
     CRCCU = 1,
+    Usart0 = 2,
+    Usart1 = 3,
+    Usart2 = 4,
+    Usart3 = 5,
 }
 
 impl TryFrom<usize> for Task {
@@ -20,6 +24,10 @@ impl TryFrom<usize> for Task {
         match value {
             0 => Ok(Task::Flashcalw),
             1 => Ok(Task::CRCCU),
+            2 => Ok(Task::Usart0),
+            3 => Ok(Task::Usart1),
+            4 => Ok(Task::Usart2),
+            5 => Ok(Task::Usart3),
             _ => Err(()),
         }
     }


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes the implementation of `abort_rx()` in `sam4l/src/usart.rs` to not call an upcall within a downcall. This fixes `console_timeout` to not panic. We had not hit this bug in the past because the console capsule only recently was modified to call `abort_rx` from within a grant region, as a code size optimization. Notably, `abort_tx` still calls an upcall in a downcall, but this does not break any of our existing applications, and I would prefer to let fixing that go through as part of the switch to the new UART HIL in https://github.com/tock/tock/pull/3046 . 

This PR fixes one of the two release-blocking failures I found as part of my initial Imix release testing.

This is the first time (I think?) that we have had to implement a deferred call for a peripheral with a single implementation for multiple hardware peripherals. This forced me to use a semi-hacky "match on the base address of the peripheral" approach for mapping deferred calls. Open to other suggestions on this element of this PR, but I think my approach is probably fine.


### Testing Strategy

This pull request was tested by running the libtock-c apps `console_timeout` and `console_recv_short` on Imix.


### TODO or Help Wanted

N/a


### Documentation Updated

- [x] No updates are required.

### Formatting

- [x] Ran `make prepush`.
