### PR TITLE
LEDs array in LED Driver does not need to be mut

### DIFF
--- a/capsules/src/led.rs
+++ b/capsules/src/led.rs
@@ -61,13 +61,13 @@ pub const DRIVER_NUM: usize = driver::NUM::Led as usize;
 /// Holds the array of LEDs and implements a `Driver` interface to
 /// control them.
 pub struct LedDriver<'a, L: led::Led, const NUM_LEDS: usize> {
-    leds: &'a mut [&'a L; NUM_LEDS],
+    leds: &'a [&'a L; NUM_LEDS],
 }
 
 impl<'a, L: led::Led, const NUM_LEDS: usize> LedDriver<'a, L, NUM_LEDS> {
-    pub fn new(leds: &'a mut [&'a L; NUM_LEDS]) -> Self {
+    pub fn new(leds: &'a [&'a L; NUM_LEDS]) -> Self {
         // Initialize all LEDs and turn them off
-        for led in leds.iter_mut() {
+        for led in leds.iter() {
             led.init();
             led.off();
         }


### PR DESCRIPTION
### Pull Request Overview

The array of LEDs in LED Driver does not need to be a mutable reference.

The LEDs themselves were not mutable, only the array. But nothing should ever be changing to contents of that array, and the LED Driver does not do so. This seems to be legacy from when we used to have LEDs in a TakeCell.

### Testing Strategy

This pull request was tested by compiling all boards and testing the Blink app on an nRF52840DK.


### TODO or Help Wanted

Should be good to go.


### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
