### PR TITLE
boards/redboard_artemis: Workaround Hard Fault Exception

### DIFF
--- a/boards/redboard_artemis_nano/src/main.rs
+++ b/boards/redboard_artemis_nano/src/main.rs
@@ -151,14 +151,13 @@ impl KernelResources<apollo3::chip::Apollo3<Apollo3DefaultPeripherals>> for Redb
     }
 }
 
+#[inline(never)]
 unsafe fn setup() -> (
     &'static kernel::Kernel,
     &'static RedboardArtemisNano,
     &'static apollo3::chip::Apollo3<Apollo3DefaultPeripherals>,
     &'static Apollo3DefaultPeripherals,
 ) {
-    apollo3::init();
-
     let peripherals = static_init!(Apollo3DefaultPeripherals, Apollo3DefaultPeripherals::new());
 
     // No need to statically allocate mcu/pwr/clk_ctrl because they are only used in main!
@@ -394,6 +393,8 @@ unsafe fn setup() -> (
 /// setup and RAM initialization.
 #[no_mangle]
 pub unsafe fn main() {
+    apollo3::init();
+
     #[cfg(test)]
     test_main();
 

--- a/boards/redboard_artemis_nano/src/main.rs
+++ b/boards/redboard_artemis_nano/src/main.rs
@@ -151,6 +151,9 @@ impl KernelResources<apollo3::chip::Apollo3<Apollo3DefaultPeripherals>> for Redb
     }
 }
 
+// WARN: This is a short-term patch applied to allow this board to boot for the
+// 2.1 release. This `inline` will be removed immediately after the 2.1 release
+// pending the fixes to cortex-m context switching which should come in 2.2.
 #[inline(never)]
 unsafe fn setup() -> (
     &'static kernel::Kernel,
@@ -158,6 +161,13 @@ unsafe fn setup() -> (
     &'static apollo3::chip::Apollo3<Apollo3DefaultPeripherals>,
     &'static Apollo3DefaultPeripherals,
 ) {
+    // WARN: This is a short-term patch applied to allow this board to
+    // boot for the 2.1 release. This will be returned here immediately
+    // after the 2.1 release pending the fixes to cortex-m context switching
+    // which should come in 2.2.
+    //
+    // apollo3::init();
+
     let peripherals = static_init!(Apollo3DefaultPeripherals, Apollo3DefaultPeripherals::new());
 
     // No need to statically allocate mcu/pwr/clk_ctrl because they are only used in main!
@@ -393,6 +403,10 @@ unsafe fn setup() -> (
 /// setup and RAM initialization.
 #[no_mangle]
 pub unsafe fn main() {
+    // WARN: This is a short-term patch applied to allow this board to
+    // boot for the 2.1 release. `init` will be removed here immediately
+    // after the 2.1 release pending the fixes to cortex-m context switching
+    // which should come in 2.2.
     apollo3::init();
 
     #[cfg(test)]

--- a/chips/apollo3/src/lib.rs
+++ b/chips/apollo3/src/lib.rs
@@ -71,6 +71,7 @@ pub static IRQS: [unsafe extern "C" fn(); 32] = [CortexM4::GENERIC_ISR; 32];
 pub static PATCH: [unsafe extern "C" fn(); 16] = [unhandled_interrupt; 16];
 
 #[cfg(all(target_arch = "arm", target_os = "none"))]
+#[inline(always)]
 pub unsafe fn init() {
     use core::arch::asm;
     let cache_ctrl = crate::cachectrl::CacheCtrl::new();

--- a/chips/apollo3/src/lib.rs
+++ b/chips/apollo3/src/lib.rs
@@ -70,6 +70,10 @@ pub static IRQS: [unsafe extern "C" fn(); 32] = [CortexM4::GENERIC_ISR; 32];
 #[cfg_attr(all(target_arch = "arm", target_os = "none"), used)]
 pub static PATCH: [unsafe extern "C" fn(); 16] = [unhandled_interrupt; 16];
 
+// WARN: This is a short-term patch applied to allow this board to
+// boot for the 2.1 release. This `inline` will be removed immediately
+// after the 2.1 release pending the fixes to cortex-m context switching
+// which should come in 2.2.
 #[cfg(all(target_arch = "arm", target_os = "none"))]
 #[inline(always)]
 pub unsafe fn init() {


### PR DESCRIPTION
### Pull Request Overview

Fixup a hardfaul exception that is seen on every non-test boot of Tock.

This change ensures that the `svc` call in `apollo3::init()` is called 
inline with `main()`. I'm not clear why, but if the `svc` is called 
after a function call (a `push` op) we end up with a corrupted call 
stack.

We need to call the `svc` op to ensure the FPU is correctly disabled (as
the boot loader enables it).

While we are changing the inline let's also never inline `setup()` to 
reduce the stack size usage (see 
https://github.com/tock/tock/issues/2425).


```
panicked at 'Kernel HardFault.
        Kernel version release-2.1-rc1
        r0  0x10001ab8
        r1  0x10001da0
        r2  0x10000fe8
        r3  0x10001e08
        r12 0x10001acc
        lr  0x10001d70
        pc  0x0
        prs 0x0 [ N 0 Z 0 C 0 V 0 Q 0 GE 0000 ; ICI.IT 0 T false ; Exc 0-Thread Mode ]
        sp  0x10000f80
        top of stack     0x40008000
        bottom of stack  0x10000000
        SHCSR 0x0
        CFSR  0x20000
        HSFR  0x40000000
        Instruction Access Violation:       false
        Data Access Violation:              false
        Memory Management Unstacking Fault: false
        Memory Management Stacking Fault:   false
        Memory Management Lazy FP Fault:    false
        Instruction Bus Error:              false
        Precise Data Bus Error:             false
        Imprecise Data Bus Error:           false
        Bus Unstacking Fault:               false
        Bus Stacking Fault:                 false
        Bus Lazy FP Fault:                  false
        Undefined Instruction Usage Fault:  false
        Invalid State Usage Fault:          true
        Invalid PC Load Usage Fault:        false
        No Coprocessor Usage Fault:         false
        Unaligned Access Usage Fault:       false
        Divide By Zero:                     false
        Bus Fault on Vector Table Read:     false
        Forced Hard Fault:                  true
        Faulting Memory Address: (valid: false) 0xE000ED34
        Bus Fault Address:       (valid: false) 0xE000ED38
', arch/cortex-m/src/lib.rs:496:5
        Kernel version release-2.1-rc1
```

Fixes: e822de1742 "boards/redboard_artemis_nano: Setup initial tests"
Signed-off-by: Alistair Francis <alistair.francis@wdc.com>

### Testing Strategy

### TODO or Help Wanted

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
