### PR TITLE
boards/redboard_artemis_nano: Fixup app loading

### DIFF
--- a/boards/redboard_artemis_nano/Makefile
+++ b/boards/redboard_artemis_nano/Makefile
@@ -23,7 +23,7 @@ flash-debug: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/debug/$(PLATFORM).bin
 
 .PHONY: flash-app
 flash-app:
-	python ambiq/ambiq_bin2board.py --bin $(APP) --load-address-blob 0x40000 -b 115200 -port $(PORT) -r 2 -v --magic-num 0xCB --version 0x0 --load-address-wired 0x40000 -i 6 --options 0x1
+	python ambiq/ambiq_bin2board.py --bin $(APP) --load-address-blob 0x60000 -b 115200 -port $(PORT) -r 2 -v --magic-num 0xCB --version 0x0 --load-address-wired 0x40000 -i 6 --options 0x1
 
 .PHONY: test
 test:


### PR DESCRIPTION
### Pull Request Overview

Ensure the app doesn't override Tock

The ROM seems to store some temporary data at the load-address-blob
address. In commit f8ceb22352da we increased the addresses, but didn't
correctly increase the load-address-blob of the application enough. This
means that the temporary data can override the Tock binary. Increase the
address to a larger one that works.

Fixes: f8ceb22352da "boards/redboard_artemis_nano: Increase the blob loading address"

### Testing Strategy

### TODO or Help Wanted

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
