### PR TITLE
arch/cortex-m: Correct end stack printing

### DIFF
--- a/arch/cortex-m/src/lib.rs
+++ b/arch/cortex-m/src/lib.rs
@@ -556,7 +556,7 @@ unsafe fn kernel_hardfault_arm_v7m(faulting_stack: *mut u32) -> ! {
         exception_number,
         ipsr_isr_number_to_str(exception_number),
         faulting_stack as u32,
-        (_estack as *const ()) as u32,
+        (&_estack as *const u32) as u32,
         (&_sstack as *const u32) as u32,
         shcsr,
         cfsr,


### PR DESCRIPTION
### Pull Request Overview

Before this change I would see these values:

    top of stack     0x40008000

After this change I now see these values:

    top of stack     0x10001000

This patch converts the end stack pointing to match the start stack
address pointing. Now the printed values match the objdump values.

### Testing Strategy

Running on Artemis Nano

### TODO or Help Wanted

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
