### PR TITLE
boards/litex: update pinned tock-litex release to 2022081701

### DIFF
--- a/.github/workflows/litex_sim.yml
+++ b/.github/workflows/litex_sim.yml
@@ -76,13 +76,10 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: lschuermann/tock-litex
-          # Currently pointing to a fixed commit, switch to a tag on the next
-          # release with the Python requirements.txt included.
-          #
-          # Also, currently using the dev/litex-sim-ci branch, which
-          # pulls in a forked LiteX with GPIO support in the
-          # simulation and the simctrl modules
-          ref: da3f33968ae018c33dd10d705fd7e3ca04e5e056
+          # The pinned revision is different from the targeted release as
+          # documented in the LiteX boards, as the CI requires special patches
+          # to LiteX for interacting with the simulation:
+          ref: 2022081701-tock-ci-0
           path: tock-litex
 
       # Install all of the required Python packages from the tock-litex'
@@ -90,10 +87,13 @@ jobs:
       - name: Install Python packages pinned by the tock-litex revision
         run: |
           pushd tock-litex
-          # Unfortunately the valentyusb package fails to install because
-          # it does not have a setup.py. Thus ignore it, we don't need it
-          # here anyways (would need it for LiteX unit tests though).
-          sed -i '/valentyusb/d' ./requirements.txt
+          # Migen is the DSL which the LiteX ecosystem uses as its
+          # hardware-description language. It effectively provides a set of
+          # Python classes and constructs which can be translated into Verilog.
+          # It is not a package of the LiteX ecosystem, and thus not in the
+          # requirements.txt, but it is required to be present on the system.
+          # It should not require any specific or patched version.
+          pip3 install migen==0.9.2
           pip3 install -r requirements.txt
           popd
 

--- a/boards/litex/arty/README.md
+++ b/boards/litex/arty/README.md
@@ -11,9 +11,9 @@ differ significantly depending on the LiteX release and configuration
 options used. This board definition currently targets and has been
 tested with
 - [the LiteX SoC generator, revision
-  c43132f81f1113](https://github.com/enjoy-digital/litex/tree/c43132f81f1113)
+  c4e635ea5c91ca](https://github.com/enjoy-digital/litex/tree/c4e635ea5c91ca)
 - using the companion [target
-  file](https://github.com/litex-hub/litex-boards/blob/f18b10d1edb4e1/litex_boards/targets/digilent_arty.py)
+  file](https://github.com/litex-hub/litex-boards/blob/bf458e388efea4/litex_boards/targets/digilent_arty.py)
   from `litex-boards`
 - built around a VexRiscv-CPU with PMP, hardware multiplication and
   compressed instruction support (named `TockSecureIMC`)
@@ -35,13 +35,13 @@ hardware multiplication and compressed instruction support (such that
 it is compatible with the `rv32imc` arch).
 
 Prebuilt and tested bitstreams (including the generated VexRiscv CPU
-Verilog files) can be obtained from the [Tock on LiteX companion
-repository
+Verilog files and a patched LiteX version to support them) can be
+obtained from the [Tock on LiteX companion repository
 releases](https://github.com/lschuermann/tock-litex/releases/). The
 current board definition has been verified to work with [release
-2021100501](https://github.com/lschuermann/tock-litex/releases/tag/2021100501). The
-bitstream for this board is located in `digilent_arty_a7-35t.zip` or
-`digilent_arty_a7-100t.zip` under `gateware/digilent_arty.bit`.
+2022081701](https://github.com/lschuermann/tock-litex/releases/tag/2022081701).
+The bitstream for this board is located in `digilent_arty_a7-35t.zip`
+or `digilent_arty_a7-100t.zip` under `gateware/digilent_arty.bit`.
 
 Many bitstream customizations can be represented in the Tock board by
 simply changing the variables in

--- a/boards/litex/arty/README.md
+++ b/boards/litex/arty/README.md
@@ -120,8 +120,8 @@ To boot via serial run the LiteX-included `litex_term.py` (sometimes
 available as `lxterm`):
 ```
 $ ./litex/litex/tools/litex_term.py \
-    --speed 10000000 \
-	--serial-boot \
+    --speed 1000000 \
+    --serial-boot \
     --kernel $TOCK_BINARY \
     $SERIAL_PORT
 ```

--- a/boards/litex/arty/src/litex_generated_constants.rs
+++ b/boards/litex/arty/src/litex_generated_constants.rs
@@ -36,15 +36,18 @@ pub const UART_INTERRUPT: usize = 0;
 // constants defined in `generated/csr.h`
 
 pub const CSR_BASE: usize = 0xf0000000;
-pub const CSR_CTRL_BASE: usize = CSR_BASE + 0x0000;
-pub const CSR_DDRPHY_BASE: usize = CSR_BASE + 0x0800;
-pub const CSR_ETHMAC_BASE: usize = CSR_BASE + 0x1000;
-pub const CSR_ETHPHY_BASE: usize = CSR_BASE + 0x1800;
-pub const CSR_IDENTIFIER_MEM_BASE: usize = CSR_BASE + 0x2000;
-pub const CSR_LEDS_BASE: usize = CSR_BASE + 0x2800;
-pub const CSR_SDRAM_BASE: usize = CSR_BASE + 0x3000;
-pub const CSR_TIMER0_BASE: usize = CSR_BASE + 0x3800;
-pub const CSR_UART_BASE: usize = CSR_BASE + 0x4000;
+pub const CSR_BUTTONS_BASE: usize = CSR_BASE + 0x0000;
+pub const CSR_CTRL_BASE: usize = CSR_BASE + 0x0800;
+pub const CSR_DDRPHY_BASE: usize = CSR_BASE + 0x1000;
+pub const CSR_DNA_BASE: usize = CSR_BASE + 0x1800;
+pub const CSR_ETHMAC_BASE: usize = CSR_BASE + 0x2000;
+pub const CSR_ETHPHY_BASE: usize = CSR_BASE + 0x2800;
+pub const CSR_IDENTIFIER_MEM_BASE: usize = CSR_BASE + 0x3000;
+pub const CSR_LEDS_BASE: usize = CSR_BASE + 0x3800;
+pub const CSR_SDRAM_BASE: usize = CSR_BASE + 0x4000;
+pub const CSR_TIMER0_BASE: usize = CSR_BASE + 0x4800;
+pub const CSR_UART_BASE: usize = CSR_BASE + 0x5000;
+pub const CSR_XADC_BASE: usize = CSR_BASE + 0x5800;
 
 // constants defined in `generated/mem.h`
 pub const MEM_ETHMAC_BASE: usize = 0x80000000;

--- a/boards/litex/sim/README.md
+++ b/boards/litex/sim/README.md
@@ -9,9 +9,9 @@ Since LiteX is a SoC builder, the individual generated SoCs can differ
 significantly depending on the release and configuration options
 used. This board definition currently targets and has been tested with
 - [the LiteX SoC generator, revision
-  c43132f81f1113](https://github.com/enjoy-digital/litex/tree/c43132f81f1113)
+  c4e635ea5c91ca](https://github.com/enjoy-digital/litex/tree/c4e635ea5c91ca)
 - using the included
-  [`litex_sim`](https://github.com/enjoy-digital/litex/blob/c43132f81f1113/litex/tools/litex_sim.py)
+  [`litex_sim`](https://github.com/enjoy-digital/litex/blob/c4e635ea5c91ca/litex/tools/litex_sim.py)
 - built around a VexRiscv-CPU with PMP, hardware multiplication and
   compressed instruction support (named `TockSecureIMC`)
 - featuring a TIMER0 with 64-bit wide hardware uptime
@@ -26,15 +26,15 @@ used. This board definition currently targets and has been tested with
   --timer-uptime
   --with-gpio
   --rom-init $PATH_TO_TOCK_BINARY
-  --with-gpio
   ```
 
 The `tock+secure+imc` is a custom VexRiscv CPU variant, based on the
 build infrastructure in
 [pythondata-cpu-vexriscv](https://github.com/litex-hub/pythondata-cpu-vexriscv),
-which is patched to introduce a CPU with physical memory protection,
-hardware multiplication and compressed instruction support (such that
-it is compatible with the `rv32imc` arch).
+which is patched to introduce a CPU with a Physical Memory Protection
+(PMP) unit with Top of Range (TOR) addressing support, hardware
+multiplication and compressed instruction support (such that it is
+compatible with the `rv32imc` arch).
 
 The [`tock-litex`](https://github.com/lschuermann/tock-litex)
 repository contains helpful instructions for how to set up the local
@@ -51,7 +51,7 @@ CSR locations in memory. The companion repository
 [tock-litex](https://github.com/lschuermann/tock-litex) provides
 access to an environment with the required LiteX Python packages in
 their targeted versions. This board currently targets the release
-[2021100501](https://github.com/lschuermann/tock-litex/releases/tag/2021100501)
+[2022081701](https://github.com/lschuermann/tock-litex/releases/tag/2022081701)
 of `tock-litex`.
 
 


### PR DESCRIPTION
### Pull Request Overview

This updates the LiteX boards (sim & arty) to new hardware revisions, provided as part of the `tock-litex` companion repository. This includes pre-built bitstreams. It further updates the `litex-sim-ci` workflow to use a new `tock-litex` revision, based on the `2022081701` release, with patches for the CI workflow applied.

These changes reflect some restructuring in the way that the LiteX SoCs are built, which will contribute to making them easier to run on local systems and ultimately reproduce the `litex-sim-ci` Tock CI workflow. In particular, it reduces the number of dependencies on repository-forks carrying patches and provides more pre-built patched packages as part of the `tock-litex` releases.

Furthermore, this adds the process console component and IPC support to the LiteX Arty board, to make it a more useful general-purpose board and more applicable to the release test suite.

I have been running many of the release tests successfully with these changes and would appreciate if we can get this in prior to Tock 2.1.

### Testing Strategy

This pull request was tested by running CI & many release tests.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] ~Updated the relevant files in `/docs`,~ or no updates are required.

### Formatting

- [x] Ran `make prepush`.
