### PR TITLE
cortex-m: cleanup linker constants

### DIFF
--- a/arch/cortex-m/src/lib.rs
+++ b/arch/cortex-m/src/lib.rs
@@ -15,6 +15,17 @@ pub mod support;
 pub mod syscall;
 pub mod systick;
 
+// These constants are defined in the linker script.
+extern "C" {
+    static _estack: *const u32;
+    static _sstack: *const u32;
+    static _szero: *const u32;
+    static _ezero: *const u32;
+    static _etext: *const u32;
+    static _srelocate: *const u32;
+    static _erelocate: *const u32;
+}
+
 /// Trait to encapsulate differences in between Cortex-M variants
 ///
 /// This trait contains functions and other associated data (constants) which
@@ -98,17 +109,6 @@ pub trait CortexMVariant {
     ///
     /// This is generally used after a `panic!()` to aid debugging.
     unsafe fn print_cortexm_state(writer: &mut dyn Write);
-}
-
-// These constants are defined in the linker script.
-extern "C" {
-    static _estack: u32;
-    static mut _sstack: u32;
-    static mut _szero: u32;
-    static mut _ezero: u32;
-    static mut _etext: u32;
-    static mut _srelocate: u32;
-    static mut _erelocate: u32;
 }
 
 /// ARMv7-M systick handler function.
@@ -556,8 +556,8 @@ unsafe fn kernel_hardfault_arm_v7m(faulting_stack: *mut u32) -> ! {
         exception_number,
         ipsr_isr_number_to_str(exception_number),
         faulting_stack as u32,
-        (&_estack as *const u32) as u32,
-        (&_sstack as *const u32) as u32,
+        _estack as u32,
+        _sstack as u32,
         shcsr,
         cfsr,
         hfsr,

--- a/arch/cortex-m0/src/lib.rs
+++ b/arch/cortex-m0/src/lib.rs
@@ -14,18 +14,6 @@ pub use cortexm::support;
 pub use cortexm::nvic;
 pub use cortexm::syscall;
 
-extern "C" {
-    // _estack is not really a function, but it makes the types work
-    // You should never actually invoke it!!
-    fn _estack();
-    static mut _sstack: u32;
-    static mut _szero: u32;
-    static mut _ezero: u32;
-    static mut _etext: u32;
-    static mut _srelocate: u32;
-    static mut _erelocate: u32;
-}
-
 #[cfg(all(target_arch = "arm", target_os = "none"))]
 struct HardFaultStackedRegisters {
     r0: u32,


### PR DESCRIPTION
### Pull Request Overview

This is the follow-on to #3147 that does the real fix here. I still think #3147 should go in for 2.1 as a quick-fix, and then this can come in after as the better fix.

This fixes the type imports from the linker script to match reality (they're const pointers). I think this was just some real legacy stuff that predated our understanding of Rust.

### Testing Strategy

Todo: will test on HW when I'm in the office next week.

### TODO or Help Wanted

^see above

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
