### PR TITLE
restore UDP kernel_buffer in event of incorrect length error

### DIFF
--- a/capsules/src/net/udp/driver.rs
+++ b/capsules/src/net/udp/driver.rs
@@ -215,6 +215,7 @@ impl<'a> UDPDriver<'a> {
                             Err(ErrorCode::NOMEM),
                             |mut kernel_buffer| {
                                 if payload.len() > kernel_buffer.len() {
+                                    self.kernel_buffer.replace(kernel_buffer);
                                     return Err(ErrorCode::SIZE);
                                 }
                                 payload.copy_to_slice(&mut kernel_buffer[0..payload.len()]);


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes a bug where the UDP driver `kernel_buffer` was not replaced in the event of an incorrect length error.


### Testing Strategy

This bug was discovered as part of the release testing for 2.1. This PR fixes the in-kernel UDP tests which rely on flashing certain userspace UDP apps.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
