### PR TITLE
NRF serialization: Handle restarted app in 2.0 world

### DIFF
--- a/capsules/src/nrf51822_serialization.rs
+++ b/capsules/src/nrf51822_serialization.rs
@@ -213,7 +213,7 @@ impl SyscallDriver for Nrf51822Serialization<'_> {
                     },
                     |appid| {
                         // The app is set, check if it still exists.
-                        if let Err(_err) = self.apps.enter(*appid, |_, _| {}) {
+                        if let Err(kernel::process::Error::NoSuchApp) = self.apps.enter(*appid, |_, _| {}) {
                             // The app we had as active no longer exists.
                             self.active_app.clear();
                             self.rx_buffer


### PR DESCRIPTION
### Pull Request Overview

I think somewhere in the 2.0 update the NRF serialization capsule no longer worked if an app faulted and restarted. This updates the capsule to support restarting an app using the nrf serialization.

The issue is with receive: if a second app (ie the new processid after the original app faulted and was restarted) calls receive, the capsule would see there is already an active app (the original app), and the kernel would return an error and everything would break at that point.

Now, we on a receive command we check: is there an active app? If so, does that app still exist? If so -> error. Otherwise, mark this new app as the active app.


### Testing Strategy

Using the process console to fault the hail app.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
