### PR TITLE
RFC: remove kernel work counting optimization

### DIFF
--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -1,6 +1,5 @@
 //! Types for Tock-compatible processes.
 
-use core::cell::Cell;
 use core::fmt;
 use core::fmt::Write;
 use core::ptr::NonNull;
@@ -820,38 +819,6 @@ pub enum State {
     /// The Process failed verification: it was terminated before it was
     /// verified.
     CredentialsFailed,
-}
-
-/// A wrapper around `Cell<State>` is used by `Process` to prevent bugs arising
-/// from the state duplication in the kernel work tracking and process state
-/// tracking.
-pub(crate) struct ProcessStateCell<'a> {
-    state: Cell<State>,
-    kernel: &'a Kernel,
-}
-
-impl<'a> ProcessStateCell<'a> {
-    pub(crate) fn new(kernel: &'a Kernel) -> Self {
-        Self {
-            state: Cell::new(State::CredentialsUnchecked),
-            kernel,
-        }
-    }
-
-    pub(crate) fn get(&self) -> State {
-        self.state.get()
-    }
-
-    pub(crate) fn update(&self, new_state: State) {
-        let old_state = self.state.get();
-
-        if old_state == State::Running && new_state != State::Running {
-            self.kernel.decrement_work();
-        } else if new_state == State::Running && old_state != State::Running {
-            self.kernel.increment_work()
-        }
-        self.state.set(new_state);
-    }
 }
 
 /// The action the kernel should take when a process encounters a fault.

--- a/kernel/src/scheduler.rs
+++ b/kernel/src/scheduler.rs
@@ -9,7 +9,6 @@ use crate::dynamic_deferred_call::DynamicDeferredCall;
 use crate::kernel::StoppedExecutingReason;
 use crate::platform::chip::Chip;
 use crate::process::ProcessId;
-use crate::Kernel;
 
 /// Trait which any scheduler must implement.
 pub trait Scheduler<C: Chip> {
@@ -24,7 +23,7 @@ pub trait Scheduler<C: Chip> {
     /// process. If the timeslice is `None`, the process will be run
     /// cooperatively (i.e. without preemption). Otherwise the process will run
     /// with a timeslice set to the specified length.
-    fn next(&self, kernel: &Kernel) -> SchedulingDecision;
+    fn next(&self) -> SchedulingDecision;
 
     /// Inform the scheduler of why the last process stopped executing, and how
     /// long it executed for. Notably, `execution_time_us` will be `None`

--- a/kernel/src/scheduler/round_robin.rs
+++ b/kernel/src/scheduler/round_robin.rs
@@ -17,7 +17,7 @@
 use core::cell::Cell;
 
 use crate::collections::list::{List, ListLink, ListNode};
-use crate::kernel::{Kernel, StoppedExecutingReason};
+use crate::kernel::StoppedExecutingReason;
 use crate::platform::chip::Chip;
 use crate::process::Process;
 use crate::scheduler::{Scheduler, SchedulingDecision};
@@ -64,41 +64,48 @@ impl<'a> RoundRobinSched<'a> {
 }
 
 impl<'a, C: Chip> Scheduler<C> for RoundRobinSched<'a> {
-    fn next(&self, kernel: &Kernel) -> SchedulingDecision {
-        if kernel.processes_blocked() {
-            // No processes ready
-            SchedulingDecision::TrySleep
-        } else {
-            let mut next = None; // This will be replaced, bc a process is guaranteed
-                                 // to be ready if processes_blocked() is false
+    fn next(&self) -> SchedulingDecision {
+        let mut first_head = None;
+        let mut next = None;
 
-            // Find next ready process. Place any *empty* process slots, or not-ready
-            // processes, at the back of the queue.
-            for node in self.processes.iter() {
-                match node.proc {
-                    Some(proc) => {
-                        if proc.ready() {
-                            next = Some(proc.processid());
-                            break;
-                        }
-                        self.processes.push_tail(self.processes.pop_head().unwrap());
-                    }
-                    None => {
-                        self.processes.push_tail(self.processes.pop_head().unwrap());
+        // Find next ready process. Place any *empty* process slots, or not-ready
+        // processes, at the back of the queue.
+        for node in self.processes.iter() {
+            // Ensure we do not loop forever if all processes are not ready
+            match first_head {
+                None => first_head = Some(node),
+                Some(first_head) => {
+                    // We made a full iteration and nothing was ready. Try to sleep instead
+                    if core::ptr::eq(first_head, node) {
+                        return SchedulingDecision::TrySleep;
                     }
                 }
             }
-            let timeslice = if self.last_rescheduled.get() {
-                self.time_remaining.get()
-            } else {
-                // grant a fresh timeslice
-                self.time_remaining.set(Self::DEFAULT_TIMESLICE_US);
-                Self::DEFAULT_TIMESLICE_US
-            };
-            assert!(timeslice != 0);
-
-            SchedulingDecision::RunProcess((next.unwrap(), Some(timeslice)))
+            match node.proc {
+                Some(proc) => {
+                    if proc.ready() {
+                        next = Some(proc.processid());
+                        break;
+                    }
+                    self.processes.push_tail(self.processes.pop_head().unwrap());
+                }
+                None => {
+                    self.processes.push_tail(self.processes.pop_head().unwrap());
+                }
+            }
         }
+        let timeslice = if self.last_rescheduled.get() {
+            self.time_remaining.get()
+        } else {
+            // grant a fresh timeslice
+            self.time_remaining.set(Self::DEFAULT_TIMESLICE_US);
+            Self::DEFAULT_TIMESLICE_US
+        };
+        assert!(timeslice != 0);
+
+        // next will not be None, because if we make a full iteration and nothing
+        // is ready we return early
+        SchedulingDecision::RunProcess((next.unwrap(), Some(timeslice)))
     }
 
     fn result(&self, result: StoppedExecutingReason, execution_time_us: Option<u32>) {


### PR DESCRIPTION
### Pull Request Overview

This pull request removes the kernel work counter which tracked how many outstanding tasks were present in the kernel. Now, schedulers must determine whether any work is outstanding by iterating through all processes and calling `process.ready()`. For all of our currently implemented schedulers, we would ultimately iterate through processes until finding a ready one anyway, so this is not a significant performance hit. The only scenario in which this increases the amount of work done is when no processes are ready and the board is about to go to sleep -- in this scenario, it used to be the case that the scheduler could sleep immediately, but now the scheduler has to iterate through all processes before sleeping.

This PR reduces the size of the kernel by 176 bytes and simplifies the scheduling logic by not having kernel work tracked in two places (the work counter + the process state/process task lists). It also reduces the amount of work done for things like scheduling callbacks / removing callbacks since the work counter does not need to be incremented and decremented.

As a basic attempt to measure the performance impact of this change, I used the cortex-m DWT to measure the number of cycles between the first time the LED turns on and then back off when running the blink app, and found that with this change there were actually 1200 fewer total cycles (though this does seem to be a noisy measurement).

This PR fixes #3138 and obsoletes #3137 (cc @jettr )


### Testing Strategy

This pull request was tested by running a few combos of apps, such as blink and blink + whileone, and taking cycle measurements using the DWT.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
