### PR TITLE
Fix temperature_stm driver to use 16 bits

### DIFF
--- a/capsules/src/temperature_stm.rs
+++ b/capsules/src/temperature_stm.rs
@@ -42,7 +42,7 @@ impl<'a> adc::Client for TemperatureSTM<'a> {
         self.status.set(Status::Idle);
         self.temperature_client.map(|client| {
             client.callback(
-                ((((self.v_25 - (sample as f32 * 3.3 / 4095.0)) * 1000.0 / self.slope) + 25.0)
+                ((((self.v_25 - (sample as f32 * 3.3 / 65535.0)) * 1000.0 / self.slope) + 25.0)
                     * 100.0) as usize,
             );
         });


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes temperature driver for STM to use the correct encoding (16 bits instead of 12). The driver was assuming that the received value was using 12 bits, but the value was using 16. 

This error was most probably due to a fix in the STM chip to comply with the adc trait.

### Testing Strategy

This pull request was tested using an STM32F412g Discovery Kit


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
