### PR TITLE
stm32f4: use deferred tasks to return buffers

### DIFF
--- a/chips/stm32f4xx/src/chip.rs
+++ b/chips/stm32f4xx/src/chip.rs
@@ -134,6 +134,9 @@ impl<'a> InterruptService<DeferredCallTask> for Stm32f4xxDefaultPeripherals<'a> 
     unsafe fn service_deferred_call(&self, task: DeferredCallTask) -> bool {
         match task {
             DeferredCallTask::Fsmc => self.fsmc.handle_interrupt(),
+            DeferredCallTask::Usart1 => self.usart1.handle_deferred_task(),
+            DeferredCallTask::Usart2 => self.usart2.handle_deferred_task(),
+            DeferredCallTask::Usart3 => self.usart3.handle_deferred_task(),
         }
         true
     }

--- a/chips/stm32f4xx/src/deferred_calls.rs
+++ b/chips/stm32f4xx/src/deferred_calls.rs
@@ -10,6 +10,9 @@ use core::convert::TryFrom;
 #[derive(Copy, Clone)]
 pub enum DeferredCallTask {
     Fsmc = 0,
+    Usart1 = 1,
+    Usart2 = 2,
+    Usart3 = 3,
 }
 
 impl TryFrom<usize> for DeferredCallTask {
@@ -18,6 +21,9 @@ impl TryFrom<usize> for DeferredCallTask {
     fn try_from(value: usize) -> Result<DeferredCallTask, ()> {
         match value {
             0 => Ok(DeferredCallTask::Fsmc),
+            1 => Ok(DeferredCallTask::Usart1),
+            2 => Ok(DeferredCallTask::Usart2),
+            3 => Ok(DeferredCallTask::Usart3),
             _ => Err(()),
         }
     }

--- a/chips/stm32f4xx/src/usart.rs
+++ b/chips/stm32f4xx/src/usart.rs
@@ -383,7 +383,6 @@ impl<'a, DMA: dma::StreamServer<'a>> Usart<'a, DMA> {
 
     fn abort_tx(&self, rcode: Result<(), ErrorCode>) {
         self.disable_tx();
-        // self.usart_tx_state.set(USARTStateTX::Idle);
 
         // get buffer
         let (mut buffer, len) = self.tx_dma.map_or((None, 0), |tx_dma| {
@@ -417,7 +416,6 @@ impl<'a, DMA: dma::StreamServer<'a>> Usart<'a, DMA> {
 
     fn abort_rx(&self, rcode: Result<(), ErrorCode>, error: hil::uart::Error) {
         self.disable_rx();
-        // self.usart_rx_state.set(USARTStateRX::Idle);
 
         // get buffer
         let (mut buffer, len) = self.rx_dma.map_or((None, 0), |rx_dma| {


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes the USART for STM32 to use deferred tasks to return the buffers to the clients. Without this fix, the console driver panics upon trying to abort with `Attempted to re-enter a grant region.`.


### Testing Strategy

This pull request was tested using an STM32f412g Discovery Kit


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
