### PR TITLE
Xt25f64b driver

### DIFF
--- a/boards/components/src/lib.rs
+++ b/boards/components/src/lib.rs
@@ -62,3 +62,4 @@ pub mod tickv;
 pub mod touch;
 pub mod udp_driver;
 pub mod udp_mux;
+pub mod xt25f64b;

--- a/boards/components/src/xt25f64b.rs
+++ b/boards/components/src/xt25f64b.rs
@@ -1,0 +1,142 @@
+//! Component for the XT25F64B block storage chip.
+//!
+//! Usage
+//! -----
+//! ```rust
+//! let xt25f64b = components::xt25f64b::Xt25f64bComponent::new(
+//!     &gpio_port[driver.write_protect_pin],
+//!     &gpio_port[driver.hold_pin],
+//!     &gpio_port[driver.chip_select] as &dyn kernel::hil::gpio::Pin,
+//!     mux_alarm,
+//!     mux_spi,
+//! )
+//! .finalize(components::xt25f64b_component_helper!(
+//!     nrf52::spi::SPIM,
+//!     nrf52::gpio::GPIOPin,
+//!     nrf52::rtc::Rtc,
+//! ));
+//! ```
+use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
+use capsules::virtual_spi::{MuxSpiMaster, VirtualSpiMasterDevice};
+use capsules::xt25f64b::XT25F64B;
+use core::mem::MaybeUninit;
+use kernel::component::Component;
+use kernel::hil;
+use kernel::hil::spi::SpiMasterDevice;
+use kernel::hil::time::Alarm;
+use kernel::static_init_half;
+
+// Setup static space for the objects.
+#[macro_export]
+macro_rules! xt25f64b_component_helper {
+    ($S:ty, $P:ty, $A:ty $(,)?) => {{
+        use capsules::virtual_alarm::VirtualMuxAlarm;
+        use capsules::virtual_spi::VirtualSpiMasterDevice;
+        use capsules::xt25f64b::XT25F64B;
+        use core::mem::MaybeUninit;
+        static mut BUF1: MaybeUninit<VirtualSpiMasterDevice<'static, $S>> = MaybeUninit::uninit();
+        static mut BUF2: MaybeUninit<VirtualMuxAlarm<'static, $A>> = MaybeUninit::uninit();
+        static mut BUF3: MaybeUninit<
+            XT25F64B<
+                'static,
+                VirtualSpiMasterDevice<'static, $S>,
+                $P,
+                VirtualMuxAlarm<'static, $A>,
+            >,
+        > = MaybeUninit::uninit();
+        (&mut BUF1, &mut BUF2, &mut BUF3)
+    };};
+}
+
+pub struct Xt25f64bComponent<
+    S: 'static + hil::spi::SpiMaster,
+    P: 'static + hil::gpio::Pin,
+    A: 'static + hil::time::Alarm<'static>,
+> {
+    write_protect_pin: Option<&'static P>,
+    hold_pin: Option<&'static P>,
+    chip_select: S::ChipSelect,
+    mux_alarm: &'static MuxAlarm<'static, A>,
+    mux_spi: &'static MuxSpiMaster<'static, S>,
+}
+
+impl<
+        S: 'static + hil::spi::SpiMaster,
+        P: 'static + hil::gpio::Pin,
+        A: 'static + hil::time::Alarm<'static>,
+    > Xt25f64bComponent<S, P, A>
+{
+    pub fn new(
+        write_protect_pin: Option<&'static P>,
+        hold_pin: Option<&'static P>,
+        chip_select: S::ChipSelect,
+        mux_alarm: &'static MuxAlarm<'static, A>,
+        mux_spi: &'static MuxSpiMaster<'static, S>,
+    ) -> Xt25f64bComponent<S, P, A> {
+        Xt25f64bComponent {
+            write_protect_pin,
+            hold_pin,
+            chip_select,
+            mux_alarm,
+            mux_spi,
+        }
+    }
+}
+
+impl<
+        S: 'static + hil::spi::SpiMaster,
+        P: 'static + hil::gpio::Pin,
+        A: 'static + hil::time::Alarm<'static>,
+    > Component for Xt25f64bComponent<S, P, A>
+{
+    type StaticInput = (
+        &'static mut MaybeUninit<VirtualSpiMasterDevice<'static, S>>,
+        &'static mut MaybeUninit<VirtualMuxAlarm<'static, A>>,
+        &'static mut MaybeUninit<
+            XT25F64B<'static, VirtualSpiMasterDevice<'static, S>, P, VirtualMuxAlarm<'static, A>>,
+        >,
+    );
+    type Output = &'static XT25F64B<
+        'static,
+        VirtualSpiMasterDevice<'static, S>,
+        P,
+        VirtualMuxAlarm<'static, A>,
+    >;
+
+    unsafe fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
+        let xt25f64b_spi = static_init_half!(
+            static_buffer.0,
+            VirtualSpiMasterDevice<'static, S>,
+            VirtualSpiMasterDevice::new(self.mux_spi, self.chip_select)
+        );
+        // Create an alarm for this chip.
+        let xt25f64b_virtual_alarm = static_init_half!(
+            static_buffer.1,
+            VirtualMuxAlarm<'static, A>,
+            VirtualMuxAlarm::new(self.mux_alarm)
+        );
+        xt25f64b_virtual_alarm.setup();
+
+        let xt25f64b = static_init_half!(
+            static_buffer.2,
+            capsules::xt25f64b::XT25F64B<
+                'static,
+                capsules::virtual_spi::VirtualSpiMasterDevice<'static, S>,
+                P,
+                VirtualMuxAlarm<'static, A>,
+            >,
+            capsules::xt25f64b::XT25F64B::new(
+                xt25f64b_spi,
+                xt25f64b_virtual_alarm,
+                &mut capsules::xt25f64b::TXBUFFER,
+                &mut capsules::xt25f64b::RXBUFFER,
+                self.write_protect_pin,
+                self.hold_pin,
+            )
+        );
+        xt25f64b_spi.setup();
+        xt25f64b_spi.set_client(xt25f64b);
+        xt25f64b_virtual_alarm.set_alarm_client(xt25f64b);
+        xt25f64b
+    }
+}

--- a/capsules/src/lib.rs
+++ b/capsules/src/lib.rs
@@ -103,3 +103,4 @@ pub mod virtual_sha;
 pub mod virtual_spi;
 pub mod virtual_timer;
 pub mod virtual_uart;
+pub mod xt25f64b;

--- a/capsules/src/xt25f64b.rs
+++ b/capsules/src/xt25f64b.rs
@@ -1,0 +1,535 @@
+//! Block device driver for the XT25F64B flash chip.
+//!
+//! Compatible with [MX25R6435F](http://www.macronix.com/en-us/products/NOR-Flash/Serial-NOR-Flash/Pages/spec.aspx?p=MX25R6435F)
+//!
+//! From the datasheet:
+//!
+//! > XT25F64B is 64Mb bits Serial NOR Flash memory, which is configured as
+//! > 8,388,608 x 8 internally. When it is in four I/O mode, the structure
+//! > becomes 16,777,216 bits x 4 or 33,554,432 bits x 2. XT25F64B feature a
+//! > serial peripheral interface and software protocol allowing operation on a
+//! > simple 3-wire bus while it is in single I/O mode. The three bus signals
+//! > are a clock input (SCLK), a serial data input (SI), and a serial data
+//! > output (SO). Serial access to the device is enabled by CS# input.
+//!
+//! Usage with SMA_Q3 board (nRF52840)
+//! -----
+//!
+//! ```rust
+//! use kernel::hil::block_storage::BlockStorage;
+//! use kernel::hil::block_storage::HasClient;
+//!
+//! let flash = {
+//!     let mux_spi = components::spi::SpiMuxComponent::new(
+//!             &base_peripherals.spim0,
+//!             dynamic_deferred_caller,
+//!         )
+//!         .finalize(components::spi_mux_component_helper!(nrf52840::spi::SPIM));
+//!     
+//!     base_peripherals.spim0.configure(
+//!         nrf52840::pinmux::Pinmux::new(Pin::P0_15 as u32),
+//!         nrf52840::pinmux::Pinmux::new(Pin::P0_13 as u32),
+//!         nrf52840::pinmux::Pinmux::new(Pin::P0_16 as u32),
+//!     );
+//!     
+//!     components::xt25f64b::Xt25f64bComponent::new(
+//!         None,
+//!         None,
+//!         &nrf52840_peripherals.gpio_port[Pin::P0_14] as &dyn kernel::hil::gpio::Pin,
+//!         mux_alarm,
+//!         mux_spi,
+//!     )
+//!     .finalize(components::xt25f64b_component_helper!(
+//!         nrf52840::spi::SPIM,
+//!         nrf52840::gpio::GPIOPin,
+//!         nrf52840::rtc::Rtc,
+//!     ))
+//! };
+//!
+
+// This module is based on the mx25r6435f.rs driver.
+
+use core::cell::Cell;
+use kernel::debug;
+use kernel::hil;
+use kernel::hil::block_storage::{AddressRange, BlockIndex, ReadableStorage};
+use kernel::hil::time::ConvertTicks;
+use kernel::utilities::cells::OptionalCell;
+use kernel::utilities::cells::TakeCell;
+use kernel::ErrorCode;
+
+pub static mut TXBUFFER: [u8; PAGE_SIZE + 4] = [0; PAGE_SIZE + 4];
+pub static mut RXBUFFER: [u8; PAGE_SIZE + 4] = [0; PAGE_SIZE + 4];
+
+const SPI_SPEED: u32 = 8000000;
+pub const SECTOR_SIZE: usize = 4096;
+pub const PAGE_SIZE: usize = 256;
+
+#[allow(dead_code)]
+enum Opcodes {
+    WREN = 0x06, // Write Enable
+    WRDI = 0x04, // Write Disable
+    SE = 0x20,   // Sector Erase
+    READ = 0x03, // Normal Read
+    PP = 0x02,   // Page Program (write)
+    RDID = 0x9f, // Read Identification
+    RDSR = 0x05, // Read Status Register
+}
+
+#[derive(Clone, Copy, PartialEq)]
+enum State {
+    Idle,
+
+    ReadSector { page_index: BlockIndex<PAGE_SIZE> },
+
+    EraseSectorWriteEnable { sector_index: u32 },
+    EraseSectorErase,
+    EraseSectorCheckDone,
+    EraseSectorDone,
+
+    WriteSectorWriteEnable { region: BlockIndex<PAGE_SIZE> },
+    WriteSectorWrite { region: BlockIndex<PAGE_SIZE> },
+    WriteSectorCheckDone,
+    WriteSectorWaitDone,
+
+    ReadId,
+}
+
+pub struct XT25F64B<
+    'a,
+    S: hil::spi::SpiMasterDevice + 'a,
+    P: hil::gpio::Pin + 'a,
+    A: hil::time::Alarm<'a> + 'a,
+> {
+    spi: &'a S,
+    alarm: &'a A,
+    state: Cell<State>,
+    write_protect_pin: Option<&'a P>,
+    hold_pin: Option<&'a P>,
+    txbuffer: TakeCell<'static, [u8]>,
+    rxbuffer: TakeCell<'static, [u8]>,
+    client: OptionalCell<&'a (dyn hil::block_storage::Client)>,
+    client_sector: TakeCell<'static, [u8]>,
+}
+
+impl<
+        'a,
+        S: hil::spi::SpiMasterDevice + 'a,
+        P: hil::gpio::Pin + 'a,
+        A: hil::time::Alarm<'a> + 'a,
+    > XT25F64B<'a, S, P, A>
+{
+    pub fn new(
+        spi: &'a S,
+        alarm: &'a A,
+        txbuffer: &'static mut [u8],
+        rxbuffer: &'static mut [u8],
+        write_protect_pin: Option<&'a P>,
+        hold_pin: Option<&'a P>,
+    ) -> XT25F64B<'a, S, P, A> {
+        XT25F64B {
+            spi: spi,
+            alarm: alarm,
+            state: Cell::new(State::Idle),
+            write_protect_pin: write_protect_pin,
+            hold_pin: hold_pin,
+            txbuffer: TakeCell::new(txbuffer),
+            rxbuffer: TakeCell::new(rxbuffer),
+            client: OptionalCell::empty(),
+            client_sector: TakeCell::empty(),
+        }
+    }
+
+    /// Setup SPI for this chip
+    fn configure_spi(&self) -> Result<(), ErrorCode> {
+        self.hold_pin.map(|pin| {
+            pin.set();
+        });
+        self.spi.configure(
+            hil::spi::ClockPolarity::IdleLow,
+            hil::spi::ClockPhase::SampleLeading,
+            SPI_SPEED,
+        )
+    }
+
+    /// Requests the readout of a 24-bit identification number.
+    /// This command will cause a debug print when succeeded.
+    pub fn read_identification(&self) -> Result<(), ErrorCode> {
+        self.configure_spi()?;
+
+        self.txbuffer
+            .take()
+            .map_or(Err(ErrorCode::RESERVE), |txbuffer| {
+                self.rxbuffer
+                    .take()
+                    .map_or(Err(ErrorCode::RESERVE), move |rxbuffer| {
+                        txbuffer[0] = Opcodes::RDID as u8;
+
+                        self.state.set(State::ReadId);
+                        if let Err((err, txbuffer, rxbuffer)) =
+                            self.spi.read_write_bytes(txbuffer, Some(rxbuffer), 4)
+                        {
+                            self.txbuffer.replace(txbuffer);
+                            self.rxbuffer.replace(rxbuffer.unwrap());
+                            Err(err)
+                        } else {
+                            Ok(())
+                        }
+                    })
+            })
+    }
+
+    fn enable_write(&self) -> Result<(), ErrorCode> {
+        self.write_protect_pin.map(|pin| {
+            pin.set();
+        });
+        self.txbuffer
+            .take()
+            .map_or(Err(ErrorCode::RESERVE), |txbuffer| {
+                txbuffer[0] = Opcodes::WREN as u8;
+                if let Err((err, txbuffer, _)) = self.spi.read_write_bytes(txbuffer, None, 1) {
+                    self.txbuffer.replace(txbuffer);
+                    Err(err)
+                } else {
+                    Ok(())
+                }
+            })
+    }
+
+    fn erase_sector(&self, sector_index: u32) -> Result<(), ErrorCode> {
+        self.configure_spi()?;
+        self.state
+            .set(State::EraseSectorWriteEnable { sector_index });
+        self.enable_write()
+    }
+
+    fn read_page(
+        &self,
+        page_index: BlockIndex<PAGE_SIZE>,
+        sector: &'static mut [u8],
+    ) -> Result<(), (ErrorCode, &'static mut [u8])> {
+        match self.state.get() {
+            State::Idle => match self.configure_spi() {
+                Ok(()) => {
+                    let retval = self
+                        .txbuffer
+                        .take()
+                        .map_or(Err(ErrorCode::RESERVE), |txbuffer| {
+                            self.rxbuffer
+                                .take()
+                                .map_or(Err(ErrorCode::RESERVE), move |rxbuffer| {
+                                    let address =
+                                        AddressRange::from(page_index).start_address as u32;
+                                    // Setup the read instruction
+                                    txbuffer[0] = Opcodes::READ as u8;
+                                    txbuffer[1] = (address >> 16) as u8;
+                                    txbuffer[2] = (address >> 8) as u8;
+                                    txbuffer[3] = (address >> 0) as u8;
+                                    // Call the SPI driver to kick things off.
+                                    self.state.set(State::ReadSector { page_index });
+                                    if let Err((err, txbuffer, rxbuffer)) =
+                                        self.spi.read_write_bytes(
+                                            txbuffer,
+                                            Some(rxbuffer),
+                                            (PAGE_SIZE + 4) as usize,
+                                        )
+                                    {
+                                        self.txbuffer.replace(txbuffer);
+                                        self.rxbuffer.replace(rxbuffer.unwrap());
+                                        Err(err)
+                                    } else {
+                                        Ok(())
+                                    }
+                                })
+                        });
+
+                    match retval {
+                        Ok(()) => {
+                            self.client_sector.replace(sector);
+                            Ok(())
+                        }
+                        Err(ecode) => Err((ecode, sector)),
+                    }
+                }
+                Err(error) => Err((error, sector)),
+            },
+            _ => Err((ErrorCode::BUSY, sector)),
+        }
+    }
+
+    fn write_pages(
+        &self,
+        region: &BlockIndex<PAGE_SIZE>,
+        buffer: &'static mut [u8],
+    ) -> Result<(), (ErrorCode, &'static mut [u8])> {
+        if AddressRange::from(*region).length_bytes as usize > buffer.len() {
+            Err((ErrorCode::SIZE, buffer))
+        } else {
+            match self.configure_spi() {
+                Ok(()) => {
+                    self.state
+                        .set(State::WriteSectorWriteEnable { region: *region });
+                    let retval = self.enable_write();
+
+                    match retval {
+                        Ok(()) => {
+                            self.client_sector.replace(buffer);
+                            Ok(())
+                        }
+                        Err(ecode) => Err((ecode, buffer)),
+                    }
+                }
+                Err(error) => Err((error, buffer)),
+            }
+        }
+    }
+}
+
+impl<
+        'a,
+        S: hil::spi::SpiMasterDevice + 'a,
+        P: hil::gpio::Pin + 'a,
+        A: hil::time::Alarm<'a> + 'a,
+    > hil::spi::SpiMasterClient for XT25F64B<'a, S, P, A>
+{
+    fn read_write_done(
+        &self,
+        write_buffer: &'static mut [u8],
+        read_buffer: Option<&'static mut [u8]>,
+        len: usize,
+        read_write_status: Result<(), ErrorCode>,
+    ) {
+        match self.state.get() {
+            State::ReadId => {
+                self.txbuffer.replace(write_buffer);
+                read_buffer.map(|read_buffer| {
+                    debug!(
+                        "id 0x{:02x}{:02x}{:02x}",
+                        read_buffer[1], read_buffer[2], read_buffer[3]
+                    );
+                    self.rxbuffer.replace(read_buffer);
+                });
+            }
+            State::ReadSector { page_index: _ } => {
+                self.client_sector.take().map(|sector| {
+                    read_buffer.map(move |read_buffer| {
+                        // Copy read in bytes to user page
+                        for i in 0..PAGE_SIZE {
+                            // Skip the command and address bytes (hence the +4).
+                            sector[i] = read_buffer[i + 4];
+                        }
+
+                        self.state.set(State::Idle);
+                        self.txbuffer.replace(write_buffer);
+                        self.rxbuffer.replace(read_buffer);
+
+                        self.client.map(move |client| {
+                            client.read_complete(sector, Ok(()));
+                        });
+                    });
+                });
+            }
+            State::EraseSectorWriteEnable { sector_index } => {
+                self.state.set(State::EraseSectorErase);
+                let address = sector_index * SECTOR_SIZE as u32;
+                write_buffer[0] = Opcodes::SE as u8;
+                write_buffer[1] = (address >> 16) as u8;
+                write_buffer[2] = (address >> 8) as u8;
+                write_buffer[3] = (address >> 0) as u8;
+
+                // TODO verify SPI return value
+                let _ = self.spi.read_write_bytes(write_buffer, None, 4);
+            }
+            State::EraseSectorErase => {
+                self.state.set(State::EraseSectorCheckDone);
+                self.txbuffer.replace(write_buffer);
+                // XT25F64B-S Datasheet says erase typically takes 60ms,
+                // so we wait that long.
+                let delay = self.alarm.ticks_from_ms(60);
+                self.alarm.set_alarm(self.alarm.now(), delay);
+            }
+            State::EraseSectorCheckDone => {
+                read_buffer.map(move |read_buffer| {
+                    let status = read_buffer[1];
+
+                    // Check the status byte to see if the erase is done or not.
+                    if status & 0x01 == 0x01 {
+                        // Erase is still in progress.
+                        let _ = self
+                            .spi
+                            .read_write_bytes(write_buffer, Some(read_buffer), 2);
+                    } else {
+                        // Erase has finished, so jump to the next state.
+                        self.state.set(State::EraseSectorDone);
+                        self.rxbuffer.replace(read_buffer);
+                        self.read_write_done(write_buffer, None, len, read_write_status);
+                    }
+                });
+            }
+            State::EraseSectorDone => {
+                // No need to disable write, chip does it automatically.
+                self.state.set(State::Idle);
+                self.txbuffer.replace(write_buffer);
+                self.client.map(|client| {
+                    client.discard_complete(Ok(()));
+                });
+            }
+            State::WriteSectorWriteEnable { region } => {
+                self.state.set(State::WriteSectorWrite { region });
+                // Need to write enable before each PP
+                write_buffer[0] = Opcodes::WREN as u8;
+                // TODO verify SPI return value
+                let _ = self.spi.read_write_bytes(write_buffer, None, 1);
+            }
+            State::WriteSectorWrite { region } => {
+                self.state.set(State::WriteSectorCheckDone);
+                let address = AddressRange::from(region).start_address as u32;
+                write_buffer[0] = Opcodes::PP as u8;
+                write_buffer[1] = (address >> 16) as u8;
+                write_buffer[2] = (address >> 8) as u8;
+                write_buffer[3] = (address >> 0) as u8;
+
+                self.client_sector.map(|sector| {
+                    write_buffer[4..][..PAGE_SIZE].copy_from_slice(&sector[..PAGE_SIZE]);
+                });
+
+                let _ = self.spi.read_write_bytes(write_buffer, None, PAGE_SIZE);
+            }
+            State::WriteSectorCheckDone => {
+                self.state.set(State::WriteSectorWaitDone);
+                self.txbuffer.replace(write_buffer);
+                // XT25F64B-S Datasheet says program page typically takes 0.3ms,
+                // so we wait that long.
+                let delay = self.alarm.ticks_from_us(300);
+                self.alarm.set_alarm(self.alarm.now(), delay);
+            }
+            State::WriteSectorWaitDone => {
+                read_buffer.map(move |read_buffer| {
+                    let status = read_buffer[1];
+
+                    // Check the status byte to see if the write is done or not.
+                    if status & 0x01 == 0x01 {
+                        // Write is still in progress.
+                        let _ = self
+                            .spi
+                            .read_write_bytes(write_buffer, Some(read_buffer), 2);
+                    } else {
+                        // Finished
+                        self.state.set(State::Idle);
+                        self.txbuffer.replace(write_buffer);
+                        self.rxbuffer.replace(read_buffer);
+                        self.client.map(|client| {
+                            self.client_sector.take().map(|sector| {
+                                client.write_complete(sector, Ok(()));
+                            });
+                        });
+                    }
+                });
+            }
+            _ => {}
+        }
+    }
+}
+
+impl<
+        'a,
+        S: hil::spi::SpiMasterDevice + 'a,
+        P: hil::gpio::Pin + 'a,
+        A: hil::time::Alarm<'a> + 'a,
+    > hil::time::AlarmClient for XT25F64B<'a, S, P, A>
+{
+    fn alarm(&self) {
+        // After the timer expires we still have to check that the erase/write
+        // operation has finished.
+        self.txbuffer.take().map(|write_buffer| {
+            self.rxbuffer.take().map(move |read_buffer| {
+                write_buffer[0] = Opcodes::RDSR as u8;
+                let _ = self
+                    .spi
+                    .read_write_bytes(write_buffer, Some(read_buffer), 2);
+            });
+        });
+    }
+}
+
+impl<
+        'a,
+        S: hil::spi::SpiMasterDevice + 'a,
+        P: hil::gpio::Pin + 'a,
+        A: hil::time::Alarm<'a> + 'a,
+    > hil::block_storage::ReadableStorage<PAGE_SIZE> for XT25F64B<'a, S, P, A>
+{
+    fn read(
+        &self,
+        region: &BlockIndex<PAGE_SIZE>,
+        buf: &'static mut [u8],
+    ) -> Result<(), (ErrorCode, &'static mut [u8])> {
+        let errs = if buf.len() < AddressRange::from(*region).length_bytes as usize {
+            Err(ErrorCode::INVAL)
+        } else if AddressRange::from(*region).get_end_address() > self.get_size() {
+            Err(ErrorCode::INVAL)
+        } else {
+            Ok(())
+        };
+
+        match errs {
+            Ok(()) => self.read_page(*region, buf),
+            Err(e) => Err((e, buf)),
+        }
+    }
+
+    /// Returns the size of the device in bytes.
+    fn get_size(&self) -> u64 {
+        // TODO: it's probably a good idea to discover the size,
+        // for the sake of compatible devices.
+        8 * 1024 * 1024
+    }
+}
+
+impl<
+        'a,
+        S: hil::spi::SpiMasterDevice + 'a,
+        P: hil::gpio::Pin + 'a,
+        A: hil::time::Alarm<'a> + 'a,
+    > hil::block_storage::WriteableStorage<PAGE_SIZE, SECTOR_SIZE> for XT25F64B<'a, S, P, A>
+{
+    fn write(
+        &self,
+        region: &BlockIndex<PAGE_SIZE>,
+        buf: &'static mut [u8],
+    ) -> Result<(), (ErrorCode, &'static mut [u8])> {
+        let errs = if buf.len() < AddressRange::from(*region).length_bytes as usize {
+            Err(ErrorCode::INVAL)
+        } else if AddressRange::from(*region).get_end_address() > self.get_size() {
+            Err(ErrorCode::INVAL)
+        } else {
+            Ok(())
+        };
+
+        match errs {
+            Ok(()) => self.write_pages(region, buf),
+            Err(e) => Err((e, buf)),
+        }
+    }
+
+    fn discard(&self, region: &BlockIndex<SECTOR_SIZE>) -> Result<(), ErrorCode> {
+        if AddressRange::from(*region).get_end_address() > self.get_size() {
+            Err(ErrorCode::INVAL)
+        } else {
+            self.erase_sector(region.0)
+        }
+    }
+}
+
+impl<
+        'a,
+        S: hil::spi::SpiMasterDevice + 'a,
+        P: hil::gpio::Pin + 'a,
+        A: hil::time::Alarm<'a> + 'a,
+        C: hil::block_storage::Client,
+    > hil::block_storage::HasClient<'a, C> for XT25F64B<'a, S, P, A>
+{
+    fn set_client(&self, client: &'a C) {
+        self.client.set(client);
+    }
+}

--- a/kernel/src/hil/block_storage.rs
+++ b/kernel/src/hil/block_storage.rs
@@ -1,0 +1,247 @@
+//! Interface for reading, writing, and erasing storage blocks
+//! on devices without a Flash Translation Layer.
+//!
+//! Operates on discardable and writeable blocks, where areas must be
+//! discarded before overwriting.
+//!
+//! Here's an example implementation for a raw flash chip:
+//!
+//! ```rust,ignore
+//! use kernel::hil;
+//! use kernel::ErrorCode;
+//!
+//! const WRITE_BLOCK_BYTES: usize = 256;
+//! const DISCARD_BLOCK_BYTES: usize = 4096;
+//!
+//! struct RawFlashChip {};
+//!
+//! type WriteBlockIndex = hil::block_storage::BlockIndex<WRITE_BLOCK_BYTES>;
+//! type DiscardBlockIndex = hil::block_storage::BlockIndex<DISCARD_BLOCK_BYTES>;
+//!
+//! impl hil::block_storage::BlockStorage<WRITE_BLOCK_BYTES, DISCARD_BLOCK_BYTES> for RawFlashChip {
+//!     //(implement associated functions here)
+//! }
+//! ```
+use crate::ErrorCode;
+use core::ops::Add;
+
+/// An index to a block within device composed of `S`-sized blocks.
+/// Stores the number of blocks from the start of the device.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct BlockIndex<const S: usize>(pub u32);
+
+impl<const S: usize> BlockIndex<S> {
+    /// Returns the index that contains the address.
+    pub fn new_containing(address: u64) -> Self {
+        Self((address / S as u64) as u32)
+    }
+
+    /// Returns the index starting at the given address, if any.
+    pub fn new_starting_at(address: u64) -> Option<Self> {
+        if address % S as u64 == 0 {
+            Some(Self::new_containing(address))
+        } else {
+            None
+        }
+    }
+}
+
+impl<const S: usize> From<BlockIndex<S>> for u64 {
+    fn from(index: BlockIndex<S>) -> Self {
+        index.0 as u64 * S as u64
+    }
+}
+
+impl<const S: usize> Add<u32> for BlockIndex<S> {
+    type Output = Self;
+    fn add(self, other: u32) -> Self {
+        BlockIndex(self.0 + other)
+    }
+}
+
+/// Readable persistent block storage device.
+///
+/// The device is formed from equally-sized storage blocks,
+/// which are arranged one after another, without gaps or overlaps,
+/// to form a linear storage of bytes.
+///
+/// Every byte on the device belongs to exactly one block.
+///
+/// `R`: The size of a read block in bytes.
+pub trait ReadableStorage<const R: usize> {
+    /// Read data from a block, and into the buffer.
+    ///
+    /// `ErrorCode::INVAL` will be returned if
+    /// - `region` exceeds the end of the device, or
+    /// - `buf` is shorter than `region`.
+    ///
+    /// Returns `ErrorCode::BUSY` when another operation is in progress.
+    ///
+    /// On success, triggers `ReadableClient::read_complete` once.
+    fn read(
+        &self,
+        region: &BlockIndex<R>,
+        buf: &'static mut [u8],
+    ) -> Result<(), (ErrorCode, &'static mut [u8])>;
+
+    /// Returns the size of the device in bytes.
+    fn get_size(&self) -> u64;
+}
+
+/// Writeable persistent block storage device.
+///
+/// The device is formed from equally-sized storage blocks,
+/// which are arranged one after another, without gaps or overlaps,
+/// to form a linear storage of bytes.
+///
+/// The device is split into blocks in two ways, into:
+/// - discard blocks, which are the smallest unit of space
+/// that can be discarded (see `BlockStorage::discard`)
+/// - write blocks, which are the smallest unit of space that can be written
+///
+/// Every byte on the device belongs to exactly one discard block,
+/// and to exactly one write block at the same time.
+///
+/// `W`: The size of a write block in bytes.
+/// `D`: The size of a discard block in bytes.
+pub trait WriteableStorage<const W: usize, const D: usize> {
+    /// Write data from a buffer to storage.
+    ///
+    /// This function writes the contents of `buf` to memory,
+    /// at the chosen `region`.
+    ///
+    /// `ErrorCode::INVAL` will be returned if
+    /// - `region` exceeds the end of the device, or
+    /// - `buf` is shorter than `region`.
+    ///
+    /// This function SHALL NOT discard the block first.
+    /// The user of this function MUST ensure that the relevant block
+    /// has been successfully discarded first (see `discard`).
+    ///
+    /// Once a byte has been written as part of a write block,
+    /// it MUST NOT be written again until it's discarded
+    /// as part of a discard block.
+    /// Multiple consecutive writes to the same block
+    /// are forbidden by this trait, but the restriction is not enforced.
+    ///
+    /// **Note** about raw flash devices: writes can turn bits from `1` to `0`.
+    /// To change a bit from `0` to `1`, a region must be erased (discarded).
+    ///
+    /// Returns `ErrorCode::BUSY` when another operation is in progress.
+    ///
+    /// On success, triggers `WriteableClient::write_complete` once.
+    fn write(
+        &self,
+        region: &BlockIndex<W>,
+        buf: &'static mut [u8],
+    ) -> Result<(), (ErrorCode, &'static mut [u8])>;
+
+    /// Makes a region ready for writing.
+    ///
+    /// This corresponds roughly to the erase operation on raw flash devices.
+    ///
+    /// A successful `discard` leaves bytes in the selected `region` undefined.
+    /// The user of this API must not assume any property
+    /// of the discarded bytes.
+    ///
+    /// If `region` exceeds the size of the device, returns `ErrorCode::INVAL`.
+    ///
+    /// Returns `ErrorCode::BUSY` when another operation is in progress.
+    ///
+    /// On success, triggers `WriteableClient::discard_complete` once.
+    fn discard(&self, region: &BlockIndex<D>) -> Result<(), ErrorCode>;
+}
+
+pub trait Storage<const W: usize, const D: usize>:
+    ReadableStorage<W> + WriteableStorage<W, D>
+{
+}
+
+impl<const W: usize, const D: usize, T: ReadableStorage<W> + WriteableStorage<W, D>> Storage<W, D>
+    for T
+{
+}
+
+/// Specifies a storage area with byte granularity.
+pub struct AddressRange {
+    /// Offset from the beginning of the storage device.
+    pub start_address: u64,
+    /// Length of the range.
+    pub length_bytes: u32,
+}
+
+impl AddressRange {
+    pub fn get_end_address(&self) -> u64 {
+        self.start_address + self.length_bytes as u64
+    }
+}
+
+impl<const C: usize> From<BlockIndex<C>> for AddressRange {
+    fn from(region: BlockIndex<C>) -> Self {
+        AddressRange {
+            start_address: region.0 as u64 * C as u64,
+            length_bytes: C as u32,
+        }
+    }
+}
+
+/// Devices which can read arbitrary byte-indexed ranges.
+pub trait ReadRange {
+    /// Read data from storage into a buffer.
+    ///
+    /// This function will read data stored in storage at `range` into `buf`.
+    ///
+    /// `ErrorCode::INVAL` will be returned if
+    /// - `range` exceeds the end of the device, or
+    /// - `buf` is shorter than `range`.
+    ///
+    /// Returns `ErrorCode::BUSY` when another operation is in progress.
+    ///
+    /// On success, triggers `ReadableClient::read_complete` once.
+    fn read_range(
+        &self,
+        range: &AddressRange,
+        buf: &'static mut [u8],
+    ) -> Result<(), (ErrorCode, &'static mut [u8])>;
+}
+
+pub trait HasClient<'a, C> {
+    /// Set the client for this peripheral. The client will be called
+    /// when operations complete.
+    fn set_client(&'a self, client: &'a C);
+}
+
+/// Implement this to receive callbacks from `ReadableStorage` and `ReadRange`.
+pub trait ReadableClient {
+    /// This will be called when a read operation is complete.
+    ///
+    /// If the device is unable to read the region, returns `ErrorCode::FAIL`.
+    ///
+    /// On errors, the buffer contents are undefined.
+    fn read_complete(&self, read_buffer: &'static mut [u8], ret: Result<(), ErrorCode>);
+}
+
+/// Implement this to receive callbacks from `ReadableStorage`.
+pub trait WriteableClient {
+    /// This will be called when the write operation is complete.
+    ///
+    /// If the device is unable to write to the region,
+    /// returns `ErrorCode::FAIL`.
+    ///
+    /// On errors, the contents of the storage region are undefined,
+    /// and the region must be considered written.
+    fn write_complete(&self, write_buffer: &'static mut [u8], ret: Result<(), ErrorCode>);
+
+    /// This will be called when the discard operation is complete.
+    ///
+    /// If the device is unable to discard the region,
+    /// returns `ErrorCode::FAIL`.
+    ///
+    /// On errors, the contents of the storage region are undefined,
+    /// and the region's discarded status must be considered unchanged.
+    fn discard_complete(&self, ret: Result<(), ErrorCode>);
+}
+
+pub trait Client: WriteableClient + ReadableClient {}
+
+impl<T: WriteableClient + ReadableClient> Client for T {}

--- a/kernel/src/hil/mod.rs
+++ b/kernel/src/hil/mod.rs
@@ -3,6 +3,7 @@
 pub mod adc;
 pub mod analog_comparator;
 pub mod ble_advertising;
+pub mod block_storage;
 pub mod bus8080;
 pub mod crc;
 pub mod dac;


### PR DESCRIPTION
### Pull Request Overview

This pull request adds a driver exposing the block_storage HIL. It's compatible with the mx25r6435f device and based on the existing driver, except that driver targets the older Flash HIL. Because someone might be relying on the old driver exposing the old interface, it's easier to create a new driver with the new interface. Creating a driver exposing both interfaces would likely incur more bloat and maintenance effort as well.

### Testing Strategy

This pull request was tested by erasing a sector, then writing a value, then reading it back. Using SMA_Q3 hardware, commit 248ce0f0504442fd5e45f3588523ecb3d38beb80 on https://github.com/dcz-self/tock/tree/flash_test

### TODO or Help Wanted

This pull request is based on another one (https://github.com/tock/tock/pull/2993) and needs that one to be merged first. This pull request still needs review.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
