### PR TITLE
Block_device syscall driver

### DIFF
--- a/boards/components/src/block_storage.rs
+++ b/boards/components/src/block_storage.rs
@@ -1,0 +1,78 @@
+//! Component for block storage drivers.
+//!
+//! This provides one component, BlockStorageComponent, which provides
+//! a system call inteface to block storage.
+//!
+//! Usage
+//! -----
+//! ```rust
+//! let block_storage = components::block_storage::BlockStorageComponent::new(
+//!     &flash_device,
+//! )
+//! .finalize(components::block_storage_component_helper!());
+//! ```
+
+use capsules::block_storage_driver;
+use core::mem::MaybeUninit;
+use kernel::capabilities;
+use kernel::component::Component;
+use kernel::create_capability;
+use kernel::hil;
+use kernel::static_init_half;
+
+/// Setup static space for the objects.
+/// B: the block device type.
+/// W: Write block size.
+/// E: Discard block size
+#[macro_export]
+macro_rules! block_storage_component_helper {
+    ($B:ty, $W: literal, $E: literal $(,)?) => {{
+        use capsules::block_storage_driver::BlockStorage;
+        use core::mem::MaybeUninit;
+        use kernel::hil;
+        static mut BUF2: MaybeUninit<[u8; $W]> = MaybeUninit::uninit();
+        static mut BUF3: MaybeUninit<BlockStorage<'static, $B, $W, $E>> = MaybeUninit::uninit();
+        (&mut BUF2, &mut BUF3)
+    };};
+}
+
+pub struct BlockStorageComponent<B, const W: usize, const E: usize>
+where
+    B: 'static + hil::block_storage::Storage<W, E>,
+{
+    pub board_kernel: &'static kernel::Kernel,
+    pub driver_num: usize,
+    pub device: &'static B,
+}
+
+impl<B, const W: usize, const E: usize> Component for BlockStorageComponent<B, W, E>
+where
+    B: 'static
+        + hil::block_storage::Storage<W, E>
+        + hil::block_storage::HasClient<'static, block_storage_driver::BlockStorage<'static, B, W, E>>,
+{
+    type StaticInput = (
+        &'static mut MaybeUninit<[u8; W]>,
+        &'static mut MaybeUninit<block_storage_driver::BlockStorage<'static, B, W, E>>,
+    );
+    type Output = &'static block_storage_driver::BlockStorage<'static, B, W, E>;
+
+    unsafe fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
+        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
+
+        let write_buffer = static_init_half!(static_buffer.0, [u8; W], [0; W],);
+
+        let syscall_driver = static_init_half!(
+            static_buffer.1,
+            block_storage_driver::BlockStorage<'static, B, W, E>,
+            block_storage_driver::BlockStorage::new(
+                self.device,
+                self.board_kernel.create_grant(self.driver_num, &grant_cap),
+                write_buffer,
+            )
+        );
+
+        hil::block_storage::HasClient::set_client(self.device, syscall_driver);
+        syscall_driver
+    }
+}

--- a/boards/components/src/lib.rs
+++ b/boards/components/src/lib.rs
@@ -5,6 +5,7 @@ pub mod adc_microphone;
 pub mod alarm;
 pub mod analog_comparator;
 pub mod app_flash_driver;
+pub mod block_storage;
 pub mod bmp280;
 pub mod bus;
 pub mod button;

--- a/capsules/src/block_storage_driver.rs
+++ b/capsules/src/block_storage_driver.rs
@@ -1,0 +1,366 @@
+//! This provides userspace access to block storage.
+//!
+//! This is a basic implementation that gives total control of the storage
+//! to the userspace.
+//!
+//! Example instantiation:
+//!
+//! ```rust
+//! # use kernel::static_init;
+//!
+//! ```
+
+use core::cell::Cell;
+use core::cmp;
+
+use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
+use kernel::hil;
+use kernel::hil::block_storage::BlockIndex;
+use kernel::processbuffer::{ReadableProcessBuffer, WriteableProcessBuffer};
+use kernel::syscall::{CommandReturn, SyscallDriver};
+use kernel::utilities::cells::TakeCell;
+use kernel::{ErrorCode, ProcessId};
+
+use crate::driver;
+pub const DRIVER_NUM: usize = driver::NUM::BlockStorage as usize;
+
+#[allow(non_camel_case_types)]
+enum Command {
+    CHECK = 0,
+    /// device size in bytes
+    SIZE = 1,
+    /// Size of write, discard blocks.
+    /// Separate from size because doesn't fit in one return call.
+    GEOMETRY = 2,
+    /// Read an arbitrary range from an arbitrary address.
+    READ_RANGE = 3,
+    /// Read a single write block at given block index.
+    READ = 4,
+    /// Discard a single discard block at given block index.
+    DISCARD = 5,
+    /// Write a single write block at given block index.
+    WRITE = 6,
+}
+
+impl TryFrom<usize> for Command {
+    type Error = ();
+    fn try_from(v: usize) -> Result<Self, Self::Error> {
+        match v {
+            0 => Ok(Command::CHECK),
+            1 => Ok(Command::SIZE),
+            2 => Ok(Command::GEOMETRY),
+            3 => Ok(Command::READ_RANGE),
+            4 => Ok(Command::READ),
+            5 => Ok(Command::DISCARD),
+            6 => Ok(Command::WRITE),
+            _ => Err(()),
+        }
+    }
+}
+
+/// Ids for read-only allow buffers
+mod ro_allow {
+    pub const WRITE: usize = 0;
+    /// The number of allow buffers the kernel stores for this grant
+    pub const COUNT: usize = 1;
+}
+
+/// Ids for read-write allow buffers
+mod rw_allow {
+    pub const READ: usize = 0;
+    /// The number of allow buffers the kernel stores for this grant
+    pub const COUNT: usize = 1;
+}
+
+enum Upcall {
+    READ = 0,
+    DISCARD = 1,
+    WRITE = 2,
+}
+
+const UPCALL_COUNT: usize = 3;
+
+/// Stores the state of an operation in flight
+#[derive(Clone, Copy)]
+enum Operation {
+    None,
+    Requested(ProcessId),
+}
+
+#[derive(Clone, Copy)]
+struct State {
+    read: Operation,
+    discard: Operation,
+    write: Operation,
+}
+
+/// Userspace interface for `hil::block_storage::Storage`.
+///
+/// Supports only one command of a given type at a time
+/// (but may support only one command in flight at all,
+/// if that's what the underlying device does).
+///
+/// Requires a bounce buffer of size at least `W` bytes.
+///
+/// `W` is the size of a write block, `E` is the discard block size.
+pub struct BlockStorage<'a, T, const W: usize, const E: usize>
+where
+    T: hil::block_storage::Storage<W, E>,
+{
+    /// The underlying physical storage device.
+    device: &'a T,
+    /// Per-app state.
+    apps: Grant<
+        (),
+        UpcallCount<UPCALL_COUNT>,
+        AllowRoCount<{ ro_allow::COUNT }>,
+        AllowRwCount<{ rw_allow::COUNT }>,
+    >,
+    state: Cell<State>,
+    /// Bounce buffer because using userspace buffers for DMA is impossible
+    buffer: TakeCell<'static, [u8]>,
+}
+
+impl<T, const W: usize, const E: usize> BlockStorage<'static, T, W, E>
+where
+    T: hil::block_storage::Storage<W, E>,
+{
+    pub fn new(
+        device: &'static T,
+        grant: Grant<
+            (),
+            UpcallCount<UPCALL_COUNT>,
+            AllowRoCount<{ ro_allow::COUNT }>,
+            AllowRwCount<{ rw_allow::COUNT }>,
+        >,
+        buffer: &'static mut [u8],
+    ) -> Self {
+        Self {
+            device,
+            apps: grant,
+            state: Cell::new(State {
+                read: Operation::None,
+                discard: Operation::None,
+                write: Operation::None,
+            }),
+            buffer: TakeCell::new(buffer),
+        }
+    }
+
+    fn start_read(&self, region: &BlockIndex<W>, appid: ProcessId) -> Result<(), ErrorCode> {
+        let state = self.state.get();
+        match state.read {
+            Operation::Requested(..) => Err(ErrorCode::BUSY),
+            Operation::None => self.buffer.take().map_or_else(
+                || Err(ErrorCode::NOMEM),
+                |buffer| match self.device.read(region, buffer) {
+                    Ok(()) => {
+                        self.state.set(State {
+                            read: Operation::Requested(appid),
+                            ..state
+                        });
+                        Ok(())
+                    }
+                    Err((e, buf)) => {
+                        self.buffer.replace(buf);
+                        Err(e)
+                    }
+                },
+            ),
+        }
+    }
+
+    fn start_discard(&self, region: &BlockIndex<E>, appid: ProcessId) -> Result<(), ErrorCode> {
+        let state = self.state.get();
+        match state.discard {
+            Operation::Requested(..) => Err(ErrorCode::BUSY),
+            Operation::None => self.device.discard(region).map(|()| {
+                self.state.set(State {
+                    discard: Operation::Requested(appid),
+                    ..state
+                });
+            }),
+        }
+    }
+
+    fn start_write(&self, region: &BlockIndex<W>, app_id: ProcessId) -> Result<(), ErrorCode> {
+        let state = self.state.get();
+        match state.write {
+            Operation::Requested(..) => Err(ErrorCode::BUSY),
+            Operation::None => self.buffer.take().map_or_else(
+                || Err(ErrorCode::NOMEM),
+                |buffer| {
+                    let ret = self.apps.enter(app_id, |_, kernel_data| {
+                        kernel_data
+                            .get_readonly_processbuffer(ro_allow::WRITE)
+                            .and_then(|write| {
+                                write.enter(|app_buffer| {
+                                    let write_len = cmp::min(app_buffer.len(), W as usize);
+
+                                    let app_buffer = &app_buffer[0..(write_len)];
+                                    app_buffer.copy_to_slice(&mut buffer[0..write_len]);
+                                })
+                            })
+                    });
+                    let ret = match ret {
+                        // Failed to enter
+                        Err(e) => Err((ErrorCode::from(e), buffer)),
+                        // Failed to get buffer
+                        Ok(Err(e)) => Err((e.into(), buffer)),
+                        Ok(Ok(())) => match self.device.write(region, buffer) {
+                            Ok(()) => {
+                                self.state.set(State {
+                                    write: Operation::Requested(app_id),
+                                    ..state
+                                });
+                                Ok(())
+                            }
+                            e => e,
+                        },
+                    };
+                    ret.map_err(|(e, buf)| {
+                        self.buffer.replace(buf);
+                        e
+                    })
+                },
+            ),
+        }
+    }
+}
+
+impl<T, const W: usize, const E: usize> hil::block_storage::ReadableClient
+    for BlockStorage<'_, T, W, E>
+where
+    T: hil::block_storage::Storage<W, E>,
+{
+    fn read_complete(&self, read_buffer: &'static mut [u8], ret: Result<(), ErrorCode>) {
+        let state = self.state.get();
+        match state.read {
+            Operation::Requested(app_id) => {
+                self.apps
+                    .enter(app_id, move |_, kernel_data| {
+                        let ret = match ret {
+                            Ok(()) => {
+                                // Need to copy in the contents of the buffer
+                                kernel_data
+                                    .get_readwrite_processbuffer(rw_allow::READ)
+                                    .and_then(|read| {
+                                        read.mut_enter(|app_buffer| {
+                                            let read_len = cmp::min(app_buffer.len(), W as usize);
+
+                                            let d = &app_buffer[0..(read_len)];
+                                            d.copy_from_slice(&read_buffer[0..read_len]);
+                                        })
+                                    })
+                                    .map_err(ErrorCode::from)
+                            }
+                            Err(e) => Err(e),
+                        };
+
+                        // Replace the buffer we used to do this read.
+                        self.buffer.replace(read_buffer);
+                        self.state.set(State {
+                            read: Operation::None,
+                            ..state
+                        });
+
+                        // And then signal the app.
+                        let upcall_data = ret.map_or_else(|e| (1, e.into(), 0), |()| (0, 0, 0));
+                        kernel_data
+                            .schedule_upcall(Upcall::READ as usize, upcall_data)
+                            .unwrap_or_else(|e| kernel::debug!("Can't upcall: {:?}", e))
+                    })
+                    .unwrap_or_else(|e| kernel::debug!("Can't get grant: {:?}", e))
+            }
+            _ => kernel::debug!("Unexpected read reply"),
+        }
+    }
+}
+
+impl<T, const W: usize, const E: usize> hil::block_storage::WriteableClient
+    for BlockStorage<'_, T, W, E>
+where
+    T: hil::block_storage::Storage<W, E>,
+{
+    /// Block write complete.
+    ///
+    /// This will be called when the write operation is complete.
+    fn write_complete(&self, write_buffer: &'static mut [u8], ret: Result<(), ErrorCode>) {
+        let state = self.state.get();
+        match state.write {
+            Operation::Requested(app_id) => {
+                self.apps
+                    .enter(app_id, move |_, kernel_data| {
+                        self.state.set(State {
+                            write: Operation::None,
+                            ..state
+                        });
+                        self.buffer.replace(write_buffer);
+
+                        // And then signal the app.
+                        let upcall_data = ret.map_or_else(|e| (1, e.into(), 0), |()| (0, 0, 0));
+                        kernel_data
+                            .schedule_upcall(Upcall::WRITE as usize, upcall_data)
+                            .unwrap_or_else(|e| kernel::debug!("Can't upcall: {:?}", e))
+                    })
+                    .unwrap_or_else(|e| kernel::debug!("Can't get grant: {:?}", e))
+            }
+            _ => kernel::debug!("Unexpected read reply"),
+        }
+    }
+
+    /// Block discard complete.
+    ///
+    /// This will be called when the discard operation is complete.
+    fn discard_complete(&self, ret: Result<(), ErrorCode>) {
+        let state = self.state.get();
+        match state.discard {
+            Operation::Requested(app_id) => {
+                self.apps
+                    .enter(app_id, move |_, kernel_data| {
+                        self.state.set(State {
+                            discard: Operation::None,
+                            ..state
+                        });
+
+                        // And then signal the app.
+                        let upcall_data = ret.map_or_else(|e| (1, e.into(), 0), |()| (0, 0, 0));
+                        kernel_data
+                            .schedule_upcall(Upcall::DISCARD as usize, upcall_data)
+                            .unwrap_or_else(|e| kernel::debug!("Can't upcall: {:?}", e))
+                    })
+                    .unwrap_or_else(|e| kernel::debug!("Can't get grant: {:?}", e))
+            }
+            _ => kernel::debug!("Unexpected read reply"),
+        }
+    }
+}
+
+impl<T, const W: usize, const E: usize> SyscallDriver for BlockStorage<'static, T, W, E>
+where
+    T: hil::block_storage::Storage<W, E>,
+{
+    fn command(
+        &self,
+        command_num: usize,
+        offset: usize,
+        _length: usize,
+        appid: ProcessId,
+    ) -> CommandReturn {
+        kernel::debug!("cmd {} of {} len {}", command_num, offset, _length);
+        match Command::try_from(command_num) {
+            Ok(Command::CHECK) => CommandReturn::success(),
+            Ok(Command::SIZE) => CommandReturn::success_u64(self.device.get_size()),
+            Ok(Command::GEOMETRY) => CommandReturn::success_u32_u32(W as u32, E as u32),
+            Ok(Command::READ_RANGE) => CommandReturn::failure(ErrorCode::NOSUPPORT),
+            Ok(Command::READ) => self.start_read(&BlockIndex(offset as u32), appid).into(),
+            Ok(Command::DISCARD) => self.start_discard(&BlockIndex(offset as u32), appid).into(),
+            Ok(Command::WRITE) => self.start_write(&BlockIndex(offset as u32), appid).into(),
+            Err(()) => CommandReturn::failure(ErrorCode::NOSUPPORT),
+        }
+    }
+
+    fn allocate_grant(&self, processid: ProcessId) -> Result<(), kernel::process::Error> {
+        self.apps.enter(processid, |_, _| {})
+    }
+}

--- a/capsules/src/driver.rs
+++ b/capsules/src/driver.rs
@@ -47,6 +47,7 @@ pub enum NUM {
     NvmStorage            = 0x50001,
     SdCard                = 0x50002,
     KVSystem              = 0x50003,
+    BlockStorage            = 0x50004,
 
     // Sensors
     Temperature           = 0x60000,

--- a/capsules/src/lib.rs
+++ b/capsules/src/lib.rs
@@ -15,6 +15,7 @@ pub mod analog_sensor;
 pub mod apds9960;
 pub mod app_flash_driver;
 pub mod ble_advertising_driver;
+pub mod block_storage_driver;
 pub mod bmp280;
 pub mod bus;
 pub mod button;

--- a/doc/syscalls/50004_block_storage.md
+++ b/doc/syscalls/50004_block_storage.md
@@ -1,0 +1,148 @@
+---
+driver number: 0x50004
+---
+
+# Block storage
+
+## Overview
+
+Exposes a block-based nonvolatile storage device.
+
+The device is formed from equally-sized storage blocks,
+which are arranged one after another, without gaps or overlaps,
+to form a linear storage of bytes.
+
+The device is split into blocks in two ways, into:
+- discard blocks, which are the smallest unit of space
+that can be discarded
+- write blocks, which are the smallest unit of space that can be written
+
+Every byte on the device belongs to exactly one discard block,
+and to exactly one write block at the same time.
+
+Blocks must be discarded before every write.
+
+## Command
+
+  * ### Command number: `0`
+
+    **Description**: Does the driver exist?
+
+    **Argument 1**: unused
+
+    **Argument 2**: unused
+
+    **Returns**: Ok(()) if it exists, otherwise NODEVICE
+
+  * ### Command number: `1`
+
+    **Description**: Returns device size in bytes.
+
+    **Argument 1**: unused
+
+    **Argument 2**: unused
+
+    **Returns**: SUCCESS_U64 with size.
+
+  * ### Command number: `2`
+
+    **Description**: Returns geometry.
+
+    **Argument 1**: unused
+
+    **Argument 2**: unused
+
+    **Returns**: A pair of u32 values: first being the size in bytes of the read/write block, the second being the size in bytes of the discard block.
+
+  * ### Command number: `3`
+
+    **Description**: Reads bytes from the given address range into the READ AllowRW buffer. Calls back the READ subscriber.
+
+    **Argument 1**: Start address
+
+    **Argument 2**: Number of bytes to read
+
+    **Returns**: Ok(()) followed by the callback if the requested bytes lie within the device, INVAL if not, BUSY if another command is in progress.
+
+  * ### Command number: `4`
+
+    **Description**: Reads bytes from the given block into the READ AllowRW buffer. Calls back the READ subscriber.
+
+    **Argument 1**: Read/write block number
+
+    **Argument 2**: unused
+
+    **Returns**: Ok(()) followed by the callback if the requested block lies within the device, INVAL if not, BUSY if another command is in progress.
+  
+  * ### Command number: `5`
+
+    **Description**: Discards the given block. Calls back the DISCARD subscriber.
+
+    **Argument 1**: Discard block index
+
+    **Argument 2**: unused
+
+    **Returns**: Ok(()) followed by the callback if the requested block lies within the device, INVAL if not, BUSY if another command is in progress.
+
+  * ### Command number: `6` 
+
+    **Description**: Writes bytes from the WRITE AllowRO buffer into the given block. Calls back the WRITE subscriber.
+
+    **Argument 1**: Read/write block index
+
+    **Argument 2**: unused
+
+    **Returns**: Ok(()) followed by the callback if the requested block lies within the device, INVAL if not, BUSY if another command is in progress.
+
+## Subscribe
+
+The first argument of all callbacks is equal to `1` on errors, `0` on success.
+Error code, if applicable, is stored in the second argument.
+
+  * ### READ, number: `0`
+
+    **Description**: Read completion notifications.
+
+    **Callback signature**: Result<(), ErrorCode>
+
+    **Returns**: Ok(()) if the subscribe was successful.
+    
+* ### DISCARD, number: `1`
+
+    **Description**: Discard completion notifications.
+
+    **Callback signature**: Result<(), ErrorCode>
+
+    **Returns**: Ok(()) if the subscribe was successful.
+
+* ### WRITE, number: `2`
+
+    **Description**: Write completion notifications.
+
+    **Callback signature**: Result<(), ErrorCode>
+
+    **Returns**: Ok(()) if the subscribe was successful.
+    
+## Allow ReadOnly
+
+  * ### WRITE, number: `0`
+
+    **Description**: Sets a shared buffer to be used as the source of data for
+    the next write transaction. A shared buffer is released if it is replaced
+    by a subsequent call and after a write transaction is completed. Replacing
+    the buffer after beginning a write transaction but before receiving a
+    completion callback is undefined.
+
+    **Returns**: Ok(()) if the allow was successful.
+
+## Allow ReadWrite
+
+  * ### READ, number: `0`
+
+    **Description**: Sets a shared buffer to be used as the destination for data from
+    the next read transaction. A shared buffer is released if it is replaced
+    by a subsequent call and after a read transaction is completed. Replacing
+    the buffer after beginning a read transaction but before receiving a
+    completion callback is undefined.
+
+    **Returns**: Ok(()) if the allow was successful.

--- a/kernel/src/hil/block_storage.rs
+++ b/kernel/src/hil/block_storage.rs
@@ -1,0 +1,247 @@
+//! Interface for reading, writing, and erasing storage blocks
+//! on devices without a Flash Translation Layer.
+//!
+//! Operates on discardable and writeable blocks, where areas must be
+//! discarded before overwriting.
+//!
+//! Here's an example implementation for a raw flash chip:
+//!
+//! ```rust,ignore
+//! use kernel::hil;
+//! use kernel::ErrorCode;
+//!
+//! const WRITE_BLOCK_BYTES: usize = 256;
+//! const DISCARD_BLOCK_BYTES: usize = 4096;
+//!
+//! struct RawFlashChip {};
+//!
+//! type WriteBlockIndex = hil::block_storage::BlockIndex<WRITE_BLOCK_BYTES>;
+//! type DiscardBlockIndex = hil::block_storage::BlockIndex<DISCARD_BLOCK_BYTES>;
+//!
+//! impl hil::block_storage::BlockStorage<WRITE_BLOCK_BYTES, DISCARD_BLOCK_BYTES> for RawFlashChip {
+//!     //(implement associated functions here)
+//! }
+//! ```
+use crate::ErrorCode;
+use core::ops::Add;
+
+/// An index to a block within device composed of `S`-sized blocks.
+/// Stores the number of blocks from the start of the device.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct BlockIndex<const S: usize>(pub u32);
+
+impl<const S: usize> BlockIndex<S> {
+    /// Returns the index that contains the address.
+    pub fn new_containing(address: u64) -> Self {
+        Self((address / S as u64) as u32)
+    }
+
+    /// Returns the index starting at the given address, if any.
+    pub fn new_starting_at(address: u64) -> Option<Self> {
+        if address % S as u64 == 0 {
+            Some(Self::new_containing(address))
+        } else {
+            None
+        }
+    }
+}
+
+impl<const S: usize> From<BlockIndex<S>> for u64 {
+    fn from(index: BlockIndex<S>) -> Self {
+        index.0 as u64 * S as u64
+    }
+}
+
+impl<const S: usize> Add<u32> for BlockIndex<S> {
+    type Output = Self;
+    fn add(self, other: u32) -> Self {
+        BlockIndex(self.0 + other)
+    }
+}
+
+/// Readable persistent block storage device.
+///
+/// The device is formed from equally-sized storage blocks,
+/// which are arranged one after another, without gaps or overlaps,
+/// to form a linear storage of bytes.
+///
+/// Every byte on the device belongs to exactly one block.
+///
+/// `R`: The size of a read block in bytes.
+pub trait ReadableStorage<const R: usize> {
+    /// Read data from a block, and into the buffer.
+    ///
+    /// `ErrorCode::INVAL` will be returned if
+    /// - `region` exceeds the end of the device, or
+    /// - `buf` is shorter than `region`.
+    ///
+    /// Returns `ErrorCode::BUSY` when another operation is in progress.
+    ///
+    /// On success, triggers `ReadableClient::read_complete` once.
+    fn read(
+        &self,
+        region: &BlockIndex<R>,
+        buf: &'static mut [u8],
+    ) -> Result<(), (ErrorCode, &'static mut [u8])>;
+
+    /// Returns the size of the device in bytes.
+    fn get_size(&self) -> u64;
+}
+
+/// Writeable persistent block storage device.
+///
+/// The device is formed from equally-sized storage blocks,
+/// which are arranged one after another, without gaps or overlaps,
+/// to form a linear storage of bytes.
+///
+/// The device is split into blocks in two ways, into:
+/// - discard blocks, which are the smallest unit of space
+/// that can be discarded (see `BlockStorage::discard`)
+/// - write blocks, which are the smallest unit of space that can be written
+///
+/// Every byte on the device belongs to exactly one discard block,
+/// and to exactly one write block at the same time.
+///
+/// `W`: The size of a write block in bytes.
+/// `D`: The size of a discard block in bytes.
+pub trait WriteableStorage<const W: usize, const D: usize> {
+    /// Write data from a buffer to storage.
+    ///
+    /// This function writes the contents of `buf` to memory,
+    /// at the chosen `region`.
+    ///
+    /// `ErrorCode::INVAL` will be returned if
+    /// - `region` exceeds the end of the device, or
+    /// - `buf` is shorter than `region`.
+    ///
+    /// This function SHALL NOT discard the block first.
+    /// The user of this function MUST ensure that the relevant block
+    /// has been successfully discarded first (see `discard`).
+    ///
+    /// Once a byte has been written as part of a write block,
+    /// it MUST NOT be written again until it's discarded
+    /// as part of a discard block.
+    /// Multiple consecutive writes to the same block
+    /// are forbidden by this trait, but the restriction is not enforced.
+    ///
+    /// **Note** about raw flash devices: writes can turn bits from `1` to `0`.
+    /// To change a bit from `0` to `1`, a region must be erased (discarded).
+    ///
+    /// Returns `ErrorCode::BUSY` when another operation is in progress.
+    ///
+    /// On success, triggers `WriteableClient::write_complete` once.
+    fn write(
+        &self,
+        region: &BlockIndex<W>,
+        buf: &'static mut [u8],
+    ) -> Result<(), (ErrorCode, &'static mut [u8])>;
+
+    /// Makes a region ready for writing.
+    ///
+    /// This corresponds roughly to the erase operation on raw flash devices.
+    ///
+    /// A successful `discard` leaves bytes in the selected `region` undefined.
+    /// The user of this API must not assume any property
+    /// of the discarded bytes.
+    ///
+    /// If `region` exceeds the size of the device, returns `ErrorCode::INVAL`.
+    ///
+    /// Returns `ErrorCode::BUSY` when another operation is in progress.
+    ///
+    /// On success, triggers `WriteableClient::discard_complete` once.
+    fn discard(&self, region: &BlockIndex<D>) -> Result<(), ErrorCode>;
+}
+
+pub trait Storage<const W: usize, const D: usize>:
+    ReadableStorage<W> + WriteableStorage<W, D>
+{
+}
+
+impl<const W: usize, const D: usize, T: ReadableStorage<W> + WriteableStorage<W, D>> Storage<W, D>
+    for T
+{
+}
+
+/// Specifies a storage area with byte granularity.
+pub struct AddressRange {
+    /// Offset from the beginning of the storage device.
+    pub start_address: u64,
+    /// Length of the range.
+    pub length_bytes: u32,
+}
+
+impl AddressRange {
+    pub fn get_end_address(&self) -> u64 {
+        self.start_address + self.length_bytes as u64
+    }
+}
+
+impl<const C: usize> From<BlockIndex<C>> for AddressRange {
+    fn from(region: BlockIndex<C>) -> Self {
+        AddressRange {
+            start_address: region.0 as u64 * C as u64,
+            length_bytes: C as u32,
+        }
+    }
+}
+
+/// Devices which can read arbitrary byte-indexed ranges.
+pub trait ReadRange {
+    /// Read data from storage into a buffer.
+    ///
+    /// This function will read data stored in storage at `range` into `buf`.
+    ///
+    /// `ErrorCode::INVAL` will be returned if
+    /// - `range` exceeds the end of the device, or
+    /// - `buf` is shorter than `range`.
+    ///
+    /// Returns `ErrorCode::BUSY` when another operation is in progress.
+    ///
+    /// On success, triggers `ReadableClient::read_complete` once.
+    fn read_range(
+        &self,
+        range: &AddressRange,
+        buf: &'static mut [u8],
+    ) -> Result<(), (ErrorCode, &'static mut [u8])>;
+}
+
+pub trait HasClient<'a, C> {
+    /// Set the client for this peripheral. The client will be called
+    /// when operations complete.
+    fn set_client(&'a self, client: &'a C);
+}
+
+/// Implement this to receive callbacks from `ReadableStorage` and `ReadRange`.
+pub trait ReadableClient {
+    /// This will be called when a read operation is complete.
+    ///
+    /// If the device is unable to read the region, returns `ErrorCode::FAIL`.
+    ///
+    /// On errors, the buffer contents are undefined.
+    fn read_complete(&self, read_buffer: &'static mut [u8], ret: Result<(), ErrorCode>);
+}
+
+/// Implement this to receive callbacks from `ReadableStorage`.
+pub trait WriteableClient {
+    /// This will be called when the write operation is complete.
+    ///
+    /// If the device is unable to write to the region,
+    /// returns `ErrorCode::FAIL`.
+    ///
+    /// On errors, the contents of the storage region are undefined,
+    /// and the region must be considered written.
+    fn write_complete(&self, write_buffer: &'static mut [u8], ret: Result<(), ErrorCode>);
+
+    /// This will be called when the discard operation is complete.
+    ///
+    /// If the device is unable to discard the region,
+    /// returns `ErrorCode::FAIL`.
+    ///
+    /// On errors, the contents of the storage region are undefined,
+    /// and the region's discarded status must be considered unchanged.
+    fn discard_complete(&self, ret: Result<(), ErrorCode>);
+}
+
+pub trait Client: WriteableClient + ReadableClient {}
+
+impl<T: WriteableClient + ReadableClient> Client for T {}

--- a/kernel/src/hil/mod.rs
+++ b/kernel/src/hil/mod.rs
@@ -3,6 +3,7 @@
 pub mod adc;
 pub mod analog_comparator;
 pub mod ble_advertising;
+pub mod block_storage;
 pub mod bus8080;
 pub mod crc;
 pub mod dac;


### PR DESCRIPTION
### Pull Request Overview

This pull request adds a syscall driver for the block_device HIL https://github.com/tock/tock/pull/2993

I reserved the 0x50004 ID for the syscalls.

### Testing Strategy

This pull request was tested with the Xt25f64b driver https://github.com/tock/tock/pull/3161 on the SMA Q3 board by running a rudimentary libtock-rs example. Then the changes were cherry-picked back here.

### TODO or Help Wanted

This pull request is based on another one (https://github.com/tock/tock/pull/2993) and needs that one to be merged first. This pull request still needs a userspace component published to be useful.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
