### PR TITLE
stm: use rng peripherals for all stm32f4xx

### DIFF
--- a/boards/nucleo_f446re/src/main.rs
+++ b/boards/nucleo_f446re/src/main.rs
@@ -62,6 +62,7 @@ struct NucleoF446RE {
         'static,
         VirtualMuxAlarm<'static, stm32f446re::tim2::Tim2<'static>>,
     >,
+    rng: &'static capsules::rng::RngDriver<'static>,
 
     scheduler: &'static RoundRobinSched<'static>,
     systick: cortexm4::systick::SysTick,
@@ -79,6 +80,7 @@ impl SyscallDriverLookup for NucleoF446RE {
             capsules::button::DRIVER_NUM => f(Some(self.button)),
             capsules::alarm::DRIVER_NUM => f(Some(self.alarm)),
             kernel::ipc::DRIVER_NUM => f(Some(&self.ipc)),
+            capsules::rng::DRIVER_NUM => f(Some(self.rng)),
             _ => f(None),
         }
     }
@@ -192,7 +194,7 @@ unsafe fn set_pin_primary_functions(
 }
 
 /// Helper function for miscellaneous peripheral functions
-unsafe fn setup_peripherals(tim2: &stm32f446re::tim2::Tim2) {
+unsafe fn setup_peripherals(tim2: &stm32f446re::tim2::Tim2, trng: &stm32f446re::trng::Trng) {
     // USART2 IRQn is 38
     cortexm4::nvic::Nvic::new(stm32f446re::nvic::USART2).enable();
 
@@ -200,6 +202,9 @@ unsafe fn setup_peripherals(tim2: &stm32f446re::tim2::Tim2) {
     tim2.enable_clock();
     tim2.start();
     cortexm4::nvic::Nvic::new(stm32f446re::nvic::TIM2).enable();
+
+    // RNG
+    trng.enable_clock();
 }
 
 /// Statically initialize the core peripherals for the chip.
@@ -244,7 +249,7 @@ pub unsafe fn main() {
     peripherals.init();
     let base_peripherals = &peripherals.stm32f4;
 
-    setup_peripherals(&base_peripherals.tim2);
+    setup_peripherals(&base_peripherals.tim2, &base_peripherals.trng);
 
     set_pin_primary_functions(syscfg, &base_peripherals.gpio_ports);
 
@@ -342,6 +347,14 @@ pub unsafe fn main() {
         components::process_printer::ProcessPrinterTextComponent::new().finalize(());
     PROCESS_PRINTER = Some(process_printer);
 
+    // RNG
+    let rng = components::rng::RngComponent::new(
+        board_kernel,
+        capsules::rng::DRIVER_NUM,
+        &base_peripherals.trng,
+    )
+    .finalize(());
+
     // PROCESS CONSOLE
     let process_console = components::process_console::ProcessConsoleComponent::new(
         board_kernel,
@@ -367,6 +380,7 @@ pub unsafe fn main() {
         led: led,
         button: button,
         alarm: alarm,
+        rng: rng,
 
         scheduler,
         systick: cortexm4::systick::SysTick::new(),

--- a/boards/stm32f412gdiscovery/src/main.rs
+++ b/boards/stm32f412gdiscovery/src/main.rs
@@ -360,6 +360,7 @@ unsafe fn setup_peripherals(
     // FSMC
     fsmc.enable();
 
+    // RNG
     trng.enable_clock();
 }
 
@@ -405,7 +406,7 @@ pub unsafe fn main() {
     setup_peripherals(
         &base_peripherals.tim2,
         &base_peripherals.fsmc,
-        &peripherals.trng,
+        &base_peripherals.trng,
     );
 
     // We use the default HSI 16Mhz clock
@@ -600,8 +601,12 @@ pub unsafe fn main() {
     .finalize(components::gpio_component_buf!(stm32f412g::gpio::Pin));
 
     // RNG
-    let rng =
-        RngComponent::new(board_kernel, capsules::rng::DRIVER_NUM, &peripherals.trng).finalize(());
+    let rng = RngComponent::new(
+        board_kernel,
+        capsules::rng::DRIVER_NUM,
+        &base_peripherals.trng,
+    )
+    .finalize(());
 
     // FT6206
 

--- a/chips/stm32f412g/src/interrupt_service.rs
+++ b/chips/stm32f412g/src/interrupt_service.rs
@@ -5,7 +5,6 @@ use stm32f4xx::deferred_calls::DeferredCallTask;
 pub struct Stm32f412gDefaultPeripherals<'a> {
     pub stm32f4: Stm32f4xxDefaultPeripherals<'a>,
     // Once implemented, place Stm32f412g specific peripherals here
-    pub trng: stm32f4xx::trng::Trng<'a>,
 }
 
 impl<'a> Stm32f412gDefaultPeripherals<'a> {
@@ -17,7 +16,6 @@ impl<'a> Stm32f412gDefaultPeripherals<'a> {
     ) -> Self {
         Self {
             stm32f4: Stm32f4xxDefaultPeripherals::new(rcc, exti, dma1, dma2),
-            trng: stm32f4xx::trng::Trng::new(rcc),
         }
     }
     // Necessary for setting up circular dependencies
@@ -31,10 +29,6 @@ impl<'a> kernel::platform::chip::InterruptService<DeferredCallTask>
     unsafe fn service_interrupt(&self, interrupt: u32) -> bool {
         match interrupt {
             // put Stm32f412g specific interrupts here
-            stm32f412g_nvic::RNG => {
-                self.trng.handle_interrupt();
-                true
-            }
             _ => self.stm32f4.service_interrupt(interrupt),
         }
     }

--- a/chips/stm32f412g/src/interrupt_service.rs
+++ b/chips/stm32f412g/src/interrupt_service.rs
@@ -1,4 +1,3 @@
-use crate::stm32f412g_nvic;
 use stm32f4xx::chip::Stm32f4xxDefaultPeripherals;
 use stm32f4xx::deferred_calls::DeferredCallTask;
 

--- a/chips/stm32f412g/src/stm32f412g_nvic.rs
+++ b/chips/stm32f412g/src/stm32f412g_nvic.rs
@@ -1,6 +1,5 @@
 //! Named constants for NVIC ids specific to this chip
 
-pub const RNG: u32 = 80;
 pub const FPU: u32 = 81;
 pub const SPI4: u32 = 84;
 pub const SPI5: u32 = 85;

--- a/chips/stm32f429zi/src/lib.rs
+++ b/chips/stm32f429zi/src/lib.rs
@@ -2,7 +2,7 @@
 
 use cortexm4::{CortexM4, CortexMVariant};
 
-pub use stm32f4xx::{adc, chip, dbg, dma, exti, gpio, nvic, rcc, spi, syscfg, tim2, usart};
+pub use stm32f4xx::{adc, chip, dbg, dma, exti, gpio, nvic, rcc, spi, syscfg, tim2, trng, usart};
 
 pub mod interrupt_service;
 pub mod stm32f429zi_nvic;

--- a/chips/stm32f446re/src/lib.rs
+++ b/chips/stm32f446re/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 
-pub use stm32f4xx::{chip, dbg, dma, exti, gpio, nvic, rcc, spi, syscfg, tim2, usart};
+pub use stm32f4xx::{chip, dbg, dma, exti, gpio, nvic, rcc, spi, syscfg, tim2, trng, usart};
 
 pub mod interrupt_service;
 pub mod stm32f446re_nvic;

--- a/chips/stm32f4xx/src/chip.rs
+++ b/chips/stm32f4xx/src/chip.rs
@@ -30,6 +30,7 @@ pub struct Stm32f4xxDefaultPeripherals<'a> {
     pub usart3: crate::usart::Usart<'a, dma::Dma1<'a>>,
     pub gpio_ports: crate::gpio::GpioPorts<'a>,
     pub fsmc: crate::fsmc::Fsmc<'a>,
+    pub trng: crate::trng::Trng<'a>,
 }
 
 impl<'a> Stm32f4xxDefaultPeripherals<'a> {
@@ -68,6 +69,7 @@ impl<'a> Stm32f4xxDefaultPeripherals<'a> {
                 ],
                 rcc,
             ),
+            trng: crate::trng::Trng::new(rcc),
         }
     }
 
@@ -125,6 +127,8 @@ impl<'a> InterruptService<DeferredCallTask> for Stm32f4xxDefaultPeripherals<'a> 
             nvic::EXTI15_10 => self.exti.handle_interrupt(),
 
             nvic::TIM2 => self.tim2.handle_interrupt(),
+
+            nvic::RNG => self.trng.handle_interrupt(),
 
             _ => return false,
         }

--- a/chips/stm32f4xx/src/nvic.rs
+++ b/chips/stm32f4xx/src/nvic.rs
@@ -79,6 +79,7 @@ pub const OTG_HS_EP1_IN: u32 = 75;
 pub const OTG_HS_WKUP: u32 = 76;
 pub const OTG_HS: u32 = 77;
 pub const DCMI: u32 = 78;
+pub const RNG: u32 = 80;
 pub const FPU: u32 = 81;
 pub const SPI4: u32 = 84;
 pub const SAI1: u32 = 87;


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes the use of the rng peripheral for the stm32f4xx.

While the peripheral implementation was written in the `st32f4xx` crate, its interrupt handling was written in the  `stm32f412g`. crate. This PR moves the interrupt handling to the correct crate so that all the `st32f4xx` chips can use it.

### Testing Strategy

This pull request was tested using the Nucleo429zi board.


### TODO or Help Wanted

N/A

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
