### PR TITLE
stm: improve app programming

### DIFF
--- a/boards/nucleo_f429zi/Makefile
+++ b/boards/nucleo_f429zi/Makefile
@@ -8,6 +8,9 @@ include ../Makefile.common
 OPENOCD=openocd
 OPENOCD_OPTIONS=-f openocd.cfg
 
+KERNEL=$(TOCK_ROOT_DIRECTORY)/target/$(TARGET)/release/$(PLATFORM).elf
+KERNEL_WITH_APP=$(TOCK_ROOT_DIRECTORY)/target/$(TARGET)/release/$(PLATFORM)-app.elf
+
 # Default target for installing the kernel.
 .PHONY: install
 install: flash
@@ -21,5 +24,9 @@ flash: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
 	$(OPENOCD) $(OPENOCD_OPTIONS) -c "init; reset halt; flash write_image erase $<; verify_image $<; reset; shutdown"
 
 .PHONY: program
-program: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/debug/$(PLATFORM).elf
-	$(error See README.md and update this section accordingly)
+program: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
+ifeq ($(APP),)
+	$(error Please define the APP variable with the TBF file to flash an application) 
+endif
+	arm-none-eabi-objcopy --update-section .apps=$(APP) $(KERNEL) $(KERNEL_WITH_APP)
+	$(OPENOCD) $(OPENOCD_OPTIONS) -c "init; reset halt; flash write_image erase $(KERNEL_WITH_APP); verify_image $(KERNEL_WITH_APP); reset; shutdown"

--- a/boards/nucleo_f429zi/README.md
+++ b/boards/nucleo_f429zi/README.md
@@ -24,35 +24,14 @@ $ make flash-debug
 
 ## Flashing app
 
-Apps are built out-of-tree. Once an app is built, you can use
-`arm-none-eabi-objcopy` with `--update-section` to create an ELF image with the
-apps included.
-
-```bash
-$ arm-none-eabi-objcopy  \
-    --update-section .apps=../../../libtock-c/examples/c_hello/build/cortex-m4/cortex-m4.tbf \
-    target/thumbv7em-none-eabi/debug/nucleo_f429zi.elf \
-    target/thumbv7em-none-eabi/debug/nucleo_f429zi-app.elf
-```
-
-For example, you can update `Makefile` as follows.
-
-```
-APP=../../../libtock-c/examples/c_hello/build/cortex-m4/cortex-m4.tbf
-KERNEL=$(TOCK_ROOT_DIRECTORY)/target/$(TARGET)/debug/$(PLATFORM).elf
-KERNEL_WITH_APP=$(TOCK_ROOT_DIRECTORY)/target/$(TARGET)/debug/$(PLATFORM)-app.elf
-
-.PHONY: program
-program: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/debug/$(PLATFORM).elf
-	arm-none-eabi-objcopy --update-section .apps=$(APP) $(KERNEL) $(KERNEL_WITH_APP)
-	$(OPENOCD) $(OPENOCD_OPTIONS) -c "init; reset halt; flash write_image erase $(KERNEL_WITH_APP); verify_image $(KERNEL_WITH_APP); reset; shutdown"
-```
-
-After setting `APP`, `KERNEL`, `KERNEL_WITH_APP`, and `program` target
-dependency, you can do
-
+Apps are built out-of-tree. Once an app is built, you can add the path to it in the Makefile (APP variable), then run:
 ```bash
 $ make program
 ```
 
-to flash the image.
+or you can define the APP variable in the command line
+
+```bash
+$ make program APP=path_to_tbf
+```
+

--- a/boards/nucleo_f446re/Makefile
+++ b/boards/nucleo_f446re/Makefile
@@ -8,6 +8,9 @@ include ../Makefile.common
 OPENOCD=openocd
 OPENOCD_OPTIONS=-f openocd.cfg
 
+KERNEL=$(TOCK_ROOT_DIRECTORY)/target/$(TARGET)/release/$(PLATFORM).elf
+KERNEL_WITH_APP=$(TOCK_ROOT_DIRECTORY)/target/$(TARGET)/release/$(PLATFORM)-app.elf
+
 # Default target for installing the kernel.
 .PHONY: install
 install: flash
@@ -21,5 +24,9 @@ flash: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
 	$(OPENOCD) $(OPENOCD_OPTIONS) -c "init; reset halt; flash write_image erase $<; verify_image $<; reset; shutdown"
 
 .PHONY: program
-program: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/debug/$(PLATFORM).elf
-	$(error See README.md and update this section accordingly)
+program: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
+ifeq ($(APP),)
+	$(error Please define the APP variable with the TBF file to flash an application) 
+endif
+	arm-none-eabi-objcopy --update-section .apps=$(APP) $(KERNEL) $(KERNEL_WITH_APP)
+	$(OPENOCD) $(OPENOCD_OPTIONS) -c "init; reset halt; flash write_image erase $(KERNEL_WITH_APP); verify_image $(KERNEL_WITH_APP); reset; shutdown"

--- a/boards/nucleo_f446re/README.md
+++ b/boards/nucleo_f446re/README.md
@@ -24,35 +24,14 @@ $ make flash-debug
 
 ## Flashing app
 
-Apps are built out-of-tree. Once an app is built, you can use
-`arm-none-eabi-objcopy` with `--update-section` to create an ELF image with the
-apps included.
-
-```bash
-$ arm-none-eabi-objcopy  \
-    --update-section .apps=../../../libtock-c/examples/c_hello/build/cortex-m4/cortex-m4.tbf \
-    target/thumbv7em-none-eabi/debug/nucleo_f446re.elf \
-    target/thumbv7em-none-eabi/debug/nucleo_f446re-app.elf
-```
-
-For example, you can update `Makefile` as follows.
-
-```
-APP=../../../libtock-c/examples/c_hello/build/cortex-m4/cortex-m4.tbf
-KERNEL=$(TOCK_ROOT_DIRECTORY)/target/$(TARGET)/debug/$(PLATFORM).elf
-KERNEL_WITH_APP=$(TOCK_ROOT_DIRECTORY)/target/$(TARGET)/debug/$(PLATFORM)-app.elf
-
-.PHONY: program
-program: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/debug/$(PLATFORM).elf
-	arm-none-eabi-objcopy --update-section .apps=$(APP) $(KERNEL) $(KERNEL_WITH_APP)
-	$(OPENOCD) $(OPENOCD_OPTIONS) -c "init; reset halt; flash write_image erase $(KERNEL_WITH_APP); verify_image $(KERNEL_WITH_APP); reset; shutdown"
-```
-
-After setting `APP`, `KERNEL`, `KERNEL_WITH_APP`, and `program` target
-dependency, you can do
-
+Apps are built out-of-tree. Once an app is built, you can add the path to it in the Makefile (APP variable), then run:
 ```bash
 $ make program
 ```
 
-to flash the image.
+or you can define the APP variable in the command line
+
+```bash
+$ make program APP=path_to_tbf
+```
+

--- a/boards/stm32f3discovery/Makefile
+++ b/boards/stm32f3discovery/Makefile
@@ -8,6 +8,9 @@ include ../Makefile.common
 OPENOCD=openocd
 OPENOCD_OPTIONS=-f openocd.cfg
 
+KERNEL=$(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
+KERNEL_WITH_APP=$(TOCK_ROOT_DIRECTORY)/target/$(TARGET)/release/$(PLATFORM)-app.elf
+
 # Default target for installing the kernel.
 .PHONY: install
 install: flash
@@ -22,4 +25,8 @@ flash: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
 
 .PHONY: program
 program: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
-	$(error See README.md and update this section accordingly)
+ifeq ($(APP),)
+	$(error Please define the APP variable with the TBF file to flash an application) 
+endif
+	arm-none-eabi-objcopy --update-section .apps=$(APP) $(KERNEL) $(KERNEL_WITH_APP)
+	$(OPENOCD) $(OPENOCD_OPTIONS) -c "init; reset halt; flash write_image erase $(KERNEL_WITH_APP); verify_image $(KERNEL_WITH_APP); reset; shutdown"

--- a/boards/stm32f3discovery/README.md
+++ b/boards/stm32f3discovery/README.md
@@ -24,35 +24,14 @@ $ make flash-debug
 
 ## Flashing app
 
-Apps are built out-of-tree. Once an app is built, you can use
-`arm-none-eabi-objcopy` with `--update-section` to create an ELF image with the
-apps included.
-
-```bash
-$ arm-none-eabi-objcopy  \
-    --update-section .apps=../../../libtock-c/examples/c_hello/build/cortex-m4/cortex-m4.tbf \
-    target/thumbv7em-none-eabi/release/stm32f3discovery.elf \
-    target/thumbv7em-none-eabi/release/stm32f3discovery-app.elf
-```
-
-For example, you can update `Makefile` as follows.
-
-```
-APP=../../../libtock-c/examples/c_hello/build/cortex-m4/cortex-m4.tbf
-KERNEL=$(TOCK_ROOT_DIRECTORY)/target/$(TARGET)/release/$(PLATFORM).elf
-KERNEL_WITH_APP=$(TOCK_ROOT_DIRECTORY)/target/$(TARGET)/release/$(PLATFORM)-app.elf
-
-.PHONY: program
-program: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
-	arm-none-eabi-objcopy --update-section .apps=$(APP) $(KERNEL) $(KERNEL_WITH_APP)
-	$(OPENOCD) $(OPENOCD_OPTIONS) -c "init; reset halt; flash write_image erase $(KERNEL_WITH_APP); verify_image $(KERNEL_WITH_APP); reset; shutdown"
-```
-
-After setting `APP`, `KERNEL`, `KERNEL_WITH_APP`, and `program` target
-dependency, you can do
-
+Apps are built out-of-tree. Once an app is built, you can add the path to it in the Makefile (APP variable), then run:
 ```bash
 $ make program
 ```
 
-to flash the image.
+or you can define the APP variable in the command line
+
+```bash
+$ make program APP=path_to_tbf
+```
+

--- a/boards/stm32f412gdiscovery/Makefile
+++ b/boards/stm32f412gdiscovery/Makefile
@@ -8,6 +8,9 @@ include ../Makefile.common
 OPENOCD=openocd
 OPENOCD_OPTIONS=-f openocd.cfg
 
+KERNEL=$(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
+KERNEL_WITH_APP=$(TOCK_ROOT_DIRECTORY)/target/$(TARGET)/release/$(PLATFORM)-app.elf
+
 # Default target for installing the kernel.
 .PHONY: install
 install: flash
@@ -22,4 +25,8 @@ flash: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
 
 .PHONY: program
 program: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
-	$(error See README.md and update this section accordingly)
+ifeq ($(APP),)
+	$(error Please define the APP variable with the TBF file to flash an application) 
+endif
+	arm-none-eabi-objcopy --update-section .apps=$(APP) $(KERNEL) $(KERNEL_WITH_APP)
+	$(OPENOCD) $(OPENOCD_OPTIONS) -c "init; reset halt; flash write_image erase $(KERNEL_WITH_APP); verify_image $(KERNEL_WITH_APP); reset; shutdown"

--- a/boards/stm32f412gdiscovery/README.md
+++ b/boards/stm32f412gdiscovery/README.md
@@ -24,38 +24,17 @@ $ make flash-debug
 
 ## Flashing app
 
-Apps are built out-of-tree. Once an app is built, you can use
-`arm-none-eabi-objcopy` with `--update-section` to create an ELF image with the
-apps included.
-
-```bash
-$ arm-none-eabi-objcopy  \
-    --update-section .apps=../../../libtock-c/examples/c_hello/build/cortex-m4/cortex-m4.tbf \
-    target/thumbv7em-none-eabi/release/discovery_f412g.elf \
-    target/thumbv7em-none-eabi/release/discovery_f412g-app.elf
-```
-
-For example, you can update `Makefile` as follows.
-
-```
-APP=../../../libtock-c/examples/c_hello/build/cortex-m4/cortex-m4.tbf
-KERNEL=$(TOCK_ROOT_DIRECTORY)/target/$(TARGET)/release/$(PLATFORM).elf
-KERNEL_WITH_APP=$(TOCK_ROOT_DIRECTORY)/target/$(TARGET)/release/$(PLATFORM)-app.elf
-
-.PHONY: program
-program: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
-	arm-none-eabi-objcopy --update-section .apps=$(APP) $(KERNEL) $(KERNEL_WITH_APP)
-	$(OPENOCD) $(OPENOCD_OPTIONS) -c "init; reset halt; flash write_image erase $(KERNEL_WITH_APP); verify_image $(KERNEL_WITH_APP); reset; shutdown"
-```
-
-After setting `APP`, `KERNEL`, `KERNEL_WITH_APP`, and `program` target
-dependency, you can do
-
+Apps are built out-of-tree. Once an app is built, you can add the path to it in the Makefile (APP variable), then run:
 ```bash
 $ make program
 ```
 
-to flash the image.
+or you can define the APP variable in the command line
+
+```bash
+$ make program APP=path_to_tbf
+```
+
 
 ## OpenOCD Note
 The release version of openocd does not fully support stm32412g discovery kit. Uploading seems to work

--- a/boards/stm32f429idiscovery/Makefile
+++ b/boards/stm32f429idiscovery/Makefile
@@ -8,6 +8,9 @@ include ../Makefile.common
 OPENOCD=openocd
 OPENOCD_OPTIONS=-f openocd.cfg
 
+KERNEL=$(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
+KERNEL_WITH_APP=$(TOCK_ROOT_DIRECTORY)/target/$(TARGET)/release/$(PLATFORM)-app.elf
+
 .PHONY: flash-debug
 flash-debug: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/debug/$(PLATFORM).elf
 	$(OPENOCD) $(OPENOCD_OPTIONS) -c "init; reset halt; flash write_image erase $<; verify_image $<; reset; shutdown"
@@ -16,12 +19,10 @@ flash-debug: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/debug/$(PLATFORM).elf
 flash: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
 	$(OPENOCD) $(OPENOCD_OPTIONS) -c "init; reset halt; flash write_image erase $<; verify_image $<; reset; shutdown"
 
-APP=../../../libtock-rs/target/thumbv7em-none-eabi/tab/stm32f429idiscovery/hello_world/cortex-m4.tbf
-#APP=../../../libtock-rs/target/thumbv7em-none-eabi/tab/stm32f429idiscovery/blink/cortex-m4.tbf
-KERNEL=$(TOCK_ROOT_DIRECTORY)/target/$(TARGET)/debug/$(PLATFORM).elf
-KERNEL_WITH_APP=$(TOCK_ROOT_DIRECTORY)/target/$(TARGET)/debug/$(PLATFORM)-app.elf
-
 .PHONY: program
-program: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/debug/$(PLATFORM).elf
+program: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
+ifeq ($(APP),)
+	$(error Please define the APP variable with the TBF file to flash an application) 
+endif
 	arm-none-eabi-objcopy --update-section .apps=$(APP) $(KERNEL) $(KERNEL_WITH_APP)
 	$(OPENOCD) $(OPENOCD_OPTIONS) -c "init; reset halt; flash write_image erase $(KERNEL_WITH_APP); verify_image $(KERNEL_WITH_APP); reset; shutdown"

--- a/boards/stm32f429idiscovery/README.md
+++ b/boards/stm32f429idiscovery/README.md
@@ -25,35 +25,13 @@ $ make flash-debug
 
 ## Flashing app
 
-Apps are built out-of-tree. Once an app is built, you can use
-`arm-none-eabi-objcopy` with `--update-section` to create an ELF image with the
-apps included.
-
-```bash
-$ arm-none-eabi-objcopy  \
-    --update-section .apps=../../../libtock-c/examples/c_hello/build/cortex-m4/cortex-m4.tbf \
-    target/thumbv7em-none-eabi/debug/stm32f429idiscovery.elf \
-    target/thumbv7em-none-eabi/debug/stm32f429idiscovery-app.elf
-```
-
-For example, you can update `Makefile` as follows.
-
-```
-APP=../../../libtock-c/examples/c_hello/build/cortex-m4/cortex-m4.tbf
-KERNEL=$(TOCK_ROOT_DIRECTORY)/target/$(TARGET)/debug/$(PLATFORM).elf
-KERNEL_WITH_APP=$(TOCK_ROOT_DIRECTORY)/target/$(TARGET)/debug/$(PLATFORM)-app.elf
-
-.PHONY: program
-program: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/debug/$(PLATFORM).elf
-        arm-none-eabi-objcopy --update-section .apps=$(APP) $(KERNEL) $(KERNEL_WITH_APP)
-        $(OPENOCD) $(OPENOCD_OPTIONS) -c "init; reset halt; flash write_image erase $(KERNEL_WITH_APP); verify_image $(KERNEL_WITH_APP); reset; shutdown"
-```
-
-After setting `APP`, `KERNEL`, `KERNEL_WITH_APP`, and `program` target
-dependency, you can do
-
+Apps are built out-of-tree. Once an app is built, you can add the path to it in the Makefile (APP variable), then run:
 ```bash
 $ make program
 ```
 
-to flash the image.
+or you can define the APP variable in the command line
+
+```bash
+$ make program APP=path_to_tbf
+```


### PR DESCRIPTION
### Pull Request Overview

This pull request changes the makefile and readme files for STM32 boards to improve the app programming.

It uses the same methods as used for the Raspberry Pi Pico board. It defines a command line variable `APP` that contains the path to a TBF.


### Testing Strategy

This pull request was tested using STM32F412g Discovery and Nucleo429zi boards.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
