### PR TITLE
Screen HIL: Fix set_brightness

### DIFF
--- a/capsules/src/lpm013m126.rs
+++ b/capsules/src/lpm013m126.rs
@@ -459,6 +459,7 @@ where
                 self.frame_buffer
                     .take()
                     .map_or(Err(ErrorCode::NOMEM), |mut frame_buffer| {
+                        // TODO: reject if buffer is shorter than frame
                         frame_buffer.blit(&buffer[..cmp::min(buffer.len(), len)], &frame);
                         let send_buf = FrameBuffer::with_raw_rows(
                             frame_buffer,
@@ -543,7 +544,7 @@ where
 
     fn set_brightness(&self, _brightness: usize) -> Result<(), ErrorCode> {
         // TODO: add LED PWM
-        Ok(())
+        Err(ErrorCode::NOSUPPORT)
     }
 
     fn set_invert(&self, _inverted: bool) -> Result<(), ErrorCode> {

--- a/capsules/src/lpm013m126.rs
+++ b/capsules/src/lpm013m126.rs
@@ -376,7 +376,7 @@ where
     }
 
     fn arm_alarm(&self) {
-        // Datasheet says 120Hz or more often flipping is required
+        // Datasheet says 2Hz or more often flipping is required
         // for transmissive mode.
         let delay = self.alarm.ticks_from_ms(500);
         self.alarm.set_alarm(self.alarm.now(), delay);
@@ -406,8 +406,7 @@ where
         width: usize,
         height: usize,
     ) -> Result<(), ErrorCode> {
-        let rows = 176;
-        let columns = 176;
+        let (columns, rows) = self.get_resolution();
         if y >= rows || y + height > rows || x >= columns || x + width > columns {
             return Err(ErrorCode::INVAL);
         }

--- a/kernel/src/hil/screen.rs
+++ b/kernel/src/hil/screen.rs
@@ -23,6 +23,9 @@ In situations where a parameter cannot be configured
 (e.g. fixed resolution), they return value may be hardcoded.
 Otherwise, the driver should query the hardware directly,
 and return OFF if it's not powered.
+
+Configuration sets cause a `command_complete` callback
+unless noted otherwise.
 */
 
 use crate::ErrorCode;


### PR DESCRIPTION
The set_brightness method was not causing a callback, confusing the syscall driver and revealing a design/documentation mistake.

### Pull Request Overview

This pull request fixes an oversight in Display HIL.

I put some non-functional improvements to LPM013M126 driver on top.


### Testing Strategy

This pull request was tested by applying to a privte branch and running on LPM013M126 display.


### TODO or Help Wanted

This pull request still needs review.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
