### PR TITLE
stm: fix memory length for stm32f303

### DIFF
--- a/boards/stm32f3discovery/chip_layout.ld
+++ b/boards/stm32f3discovery/chip_layout.ld
@@ -2,13 +2,13 @@
  * rom = 256KB (LENGTH = 0x00040000)
  * kernel = 128KB
  * user = 128KB
- * ram = 48KB */
+ * ram = 40KB */
 
 MEMORY
 {
   rom (rx)  : ORIGIN = 0x08000000, LENGTH = 128K
   prog (rx) : ORIGIN = 0x08020000, LENGTH = 128K
-  ram (rwx) : ORIGIN = 0x20000000, LENGTH = 48K
+  ram (rwx) : ORIGIN = 0x20000000, LENGTH = 40K
 }
 
 MPU_MIN_ALIGN = 8K;


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes the memory length for the stm32f303 board.


### Testing Strategy

This pull request was tested using an STM32F3 Discovery board.


### TODO or Help Wanted

This pull request still needs...


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
