### PR TITLE
stm: fix usart baud

### DIFF
--- a/boards/stm32f3discovery/src/io.rs
+++ b/boards/stm32f3discovery/src/io.rs
@@ -46,7 +46,7 @@ impl IoWrite for Writer {
             self.initialized = true;
 
             let _ = uart.configure(uart::Parameters {
-                baud_rate: 11500,
+                baud_rate: 115200,
                 stop_bits: uart::StopBits::One,
                 parity: uart::Parity::None,
                 hw_flow_control: false,


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes the usart baud rate used for the panic print.


### Testing Strategy

This pull request was tested by...


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
