### PR TITLE
stm32f412g: make user/kernel code boundary fall on flash sector boundary

### DIFF
--- a/boards/stm32f412gdiscovery/chip_layout.ld
+++ b/boards/stm32f412gdiscovery/chip_layout.ld
@@ -1,13 +1,13 @@
 /* Memory layout for the STM32F412G
  * rom = 1MB (LENGTH = 0x01000000)
- * kernel = 192KB
- * user = 832KB
+ * kernel = 256KB
+ * user = 744KB
  * ram = 256KB */
 
 MEMORY
 {
-  rom (rx)  : ORIGIN = 0x08000000, LENGTH = 0x00030000
-  prog (rx) : ORIGIN = 0x08030000, LENGTH = 0x000D0000
+  rom (rx)  : ORIGIN = 0x08000000, LENGTH = 0x00040000
+  prog (rx) : ORIGIN = 0x08040000, LENGTH = 0x000C0000
   ram (rwx) : ORIGIN = 0x20000000, LENGTH = 0x0003FFFF
 }
 


### PR DESCRIPTION
### Pull Request Overview

This pull request makes the user/kernel code boundary fall on flash sector boundary, which should hopefully enable tockloader to work with the `--bundle-apps flag.`


### Testing Strategy

@alexandruradovici can you test this with tockloader?


### TODO or Help Wanted

This pull request still needs testing


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
