### PR TITLE
rp2040: fix adc number of bits

### DIFF
--- a/chips/rp2040/src/adc.rs
+++ b/chips/rp2040/src/adc.rs
@@ -182,7 +182,7 @@ impl Adc {
             }
             self.client.map(|client| {
                 self.disable_interrupt();
-                client.sample_ready(self.registers.fifo.read(FIFO::VAL) as u16)
+                client.sample_ready((self.registers.fifo.read(FIFO::VAL) << 4) as u16)
             });
         }
     }


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes the number of bits for the reported rp2040 adc value.


### Testing Strategy

This pull request was tested using a Raspberry Pi Pico.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
