### PR TITLE
stm: use deferred tasks to abort uart tx/rx

### DIFF
--- a/chips/stm32f303xc/src/chip.rs
+++ b/chips/stm32f303xc/src/chip.rs
@@ -83,6 +83,9 @@ impl<'a> InterruptService<DeferredCallTask> for Stm32f3xxDefaultPeripherals<'a> 
     unsafe fn service_deferred_call(&self, task: DeferredCallTask) -> bool {
         match task {
             DeferredCallTask::Flash => self.flash.handle_interrupt(),
+            DeferredCallTask::Usart1 => self.usart1.handle_deferred_task(),
+            DeferredCallTask::Usart2 => self.usart2.handle_deferred_task(),
+            DeferredCallTask::Usart3 => self.usart3.handle_deferred_task(),
         }
         true
     }

--- a/chips/stm32f303xc/src/deferred_call_tasks.rs
+++ b/chips/stm32f303xc/src/deferred_call_tasks.rs
@@ -10,6 +10,9 @@ use core::convert::TryFrom;
 #[derive(Copy, Clone)]
 pub enum DeferredCallTask {
     Flash = 0,
+    Usart1 = 1,
+    Usart2 = 2,
+    Usart3 = 3,
 }
 
 impl TryFrom<usize> for DeferredCallTask {
@@ -18,6 +21,9 @@ impl TryFrom<usize> for DeferredCallTask {
     fn try_from(value: usize) -> Result<DeferredCallTask, ()> {
         match value {
             0 => Ok(DeferredCallTask::Flash),
+            1 => Ok(DeferredCallTask::Usart1),
+            2 => Ok(DeferredCallTask::Usart2),
+            3 => Ok(DeferredCallTask::Usart3),
             _ => Err(()),
         }
     }

--- a/chips/stm32f303xc/src/usart.rs
+++ b/chips/stm32f303xc/src/usart.rs
@@ -450,17 +450,6 @@ impl<'a> Usart<'a> {
                         }
                     });
                 }
-            } else if self.tx_status.get() == USARTStateTX::AbortRequested {
-                self.tx_status.replace(USARTStateTX::Idle);
-                self.tx_client.map(|client| {
-                    if let Some(buf) = self.tx_buffer.take() {
-                        client.transmitted_buffer(
-                            buf,
-                            self.tx_position.get(),
-                            Err(ErrorCode::CANCEL),
-                        );
-                    }
-                });
             }
         }
 
@@ -495,18 +484,6 @@ impl<'a> Usart<'a> {
                         }
                     });
                 }
-            } else if self.rx_status.get() == USARTStateRX::AbortRequested {
-                self.rx_status.replace(USARTStateRX::Idle);
-                self.rx_client.map(|client| {
-                    if let Some(buf) = self.rx_buffer.take() {
-                        client.received_buffer(
-                            buf,
-                            self.rx_position.get(),
-                            Err(ErrorCode::CANCEL),
-                            hil::uart::Error::Aborted,
-                        );
-                    }
-                });
             }
         }
 


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes the uart abort for stm32f303. Without this fix, abort functions wait for a transmit or receive interrupt to return after an abort. The `console_timeout` example issues the abort, but receives the partial data only when:
- there is any data received after the abort
- there is any data transmitted after the abort 

as this is even the interrupt is triggered.


### Testing Strategy

This pull request was tested using an STM32F3 Discovery


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
