### PR TITLE
stm: increase stack size for stm3f303

### DIFF
--- a/boards/stm32f3discovery/src/main.rs
+++ b/boards/stm32f3discovery/src/main.rs
@@ -49,7 +49,7 @@ const FAULT_RESPONSE: kernel::process::PanicFaultPolicy = kernel::process::Panic
 /// Dummy buffer that causes the linker to reserve enough space for the stack.
 #[no_mangle]
 #[link_section = ".stack_buffer"]
-pub static mut STACK_MEMORY: [u8; 0x1400] = [0; 0x1400];
+pub static mut STACK_MEMORY: [u8; 0x1700] = [0; 0x1700];
 
 /// A structure representing this platform that holds references to all
 /// capsules for this platform.


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes the stack size for the STM3F303 Discovery board. Without this stack size, the kernel does not start.


### Testing Strategy

This pull request was tested using an STM3F303 Discovery


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
