### PR TITLE
rp2040: use deferred calls for abort uart tx/rx

### DIFF
--- a/chips/rp2040/src/deferred_call_tasks.rs
+++ b/chips/rp2040/src/deferred_call_tasks.rs
@@ -1,0 +1,32 @@
+//! Definition of Deferred Call tasks.
+//!
+//! Deferred calls also peripheral drivers to register pseudo interrupts.
+//! These are the definitions of which deferred calls this chip needs.
+
+use core::convert::Into;
+use core::convert::TryFrom;
+
+/// A type of task to defer a call for
+#[derive(Copy, Clone)]
+pub enum DeferredCallTask {
+    Uart0 = 0,
+    Uart1 = 1,
+}
+
+impl TryFrom<usize> for DeferredCallTask {
+    type Error = ();
+
+    fn try_from(value: usize) -> Result<DeferredCallTask, ()> {
+        match value {
+            0 => Ok(DeferredCallTask::Uart0),
+            1 => Ok(DeferredCallTask::Uart1),
+            _ => Err(()),
+        }
+    }
+}
+
+impl Into<usize> for DeferredCallTask {
+    fn into(self) -> usize {
+        self as usize
+    }
+}

--- a/chips/rp2040/src/lib.rs
+++ b/chips/rp2040/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod adc;
 pub mod chip;
 pub mod clocks;
+pub mod deferred_call_tasks;
 pub mod gpio;
 pub mod i2c;
 pub mod interrupts;


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes the uart for rp2040 (Raspberry Pi Pico) to use deferred calls when aborting uart tx/rx. Without this fix, abort functions wait for a transmit or receive interrupt to return after an abort. The `console_timeout` example issues the abort, but receives the partial data only when:

    there is any data received after the abort
    there is any data transmitted after the abort

as this is even the interrupt is triggered.fix


### Testing Strategy

This pull request was tested using a Raspberry Pi Pico and Pico Explorer Base.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
