### PR TITLE
rp2040: fix spi busy

### DIFF
--- a/chips/rp2040/src/spi.rs
+++ b/chips/rp2040/src/spi.rs
@@ -507,7 +507,8 @@ impl<'a> SpiMaster for Spi<'a> {
     }
 
     fn is_busy(&self) -> bool {
-        self.registers.sspsr.is_set(SSPSR::BSY)
+        // self.registers.sspsr.is_set(SSPSR::BSY)
+        self.transfers.get() != SPI_IDLE
     }
 
     fn read_write_bytes(


### PR DESCRIPTION
### Pull Request Overview

This pull request (maybe) fixes an spi bug for the rp2040 (Raspberry Pi Pico).

The fix is related to the way in which the low level spi driver determines if it is busy or not. Before this fix, the driver would query one of the spi status registers.

```rust
fn is_busy(&self) -> bool {
    self.registers.sspsr.is_set(SSPSR::BSY)
}
```

It seems that if two writes (or a write followed by an spi configuration) are back to back (very close to each other), even though the spi has the disabled bit set, the status register of the spi still reports it is busy. The spi device documentation says that the `BSY` bit should be set if
- the spi has a transfer in progress
- the spi transmit fifo is not empty

Based on the spi driver's source, I don't think any of the two is met after the spi is disabled when a transfer is finished.

The PR changes the way in which the spi driver determines if the peripheral is busy. It uses the stored `transfers` status.

```rust
fn is_busy(&self) -> bool {
    self.transfers.get() != SPI_IDLE
}
```

### Testing Strategy

This pull request was tested using a Pico Explorer Base that has an LCD connected over spi.


### TODO or Help Wanted

A double check of the spi driver's source is welcome.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
