### PR TITLE
Add "Squared" Capsule

### DIFF
--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -79,6 +79,7 @@ struct Hail {
     ipc: kernel::ipc::IPC<{ NUM_PROCS as u8 }>,
     crc: &'static capsules::crc::CrcDriver<'static, sam4l::crccu::Crccu<'static>>,
     dac: &'static capsules::dac::Dac<'static>,
+    // squared: &'static capsules::squared::Squared,
     scheduler: &'static RoundRobinSched<'static>,
     systick: cortexm4::systick::SysTick,
 }
@@ -109,7 +110,7 @@ impl SyscallDriverLookup for Hail {
             capsules::crc::DRIVER_NUM => f(Some(self.crc)),
 
             capsules::dac::DRIVER_NUM => f(Some(self.dac)),
-
+            // capsules::squared::DRIVER_NUM => f(Some(self.squared)),
             kernel::ipc::DRIVER_NUM => f(Some(&self.ipc)),
             _ => f(None),
         }
@@ -512,6 +513,9 @@ pub unsafe fn main() {
     // );
     // peripherals.pa[16].set_client(debug_process_restart);
 
+    // // DEBUG syscall return types with the squared capsule.
+    // let squared = static_init!(capsules::squared::Squared, capsules::squared::Squared {});
+
     // Configure application fault policy
     let fault_policy = static_init!(
         kernel::process::ThresholdRestartThenPanicFaultPolicy,
@@ -542,6 +546,7 @@ pub unsafe fn main() {
         ),
         crc,
         dac,
+        // squared,
         scheduler,
         systick: cortexm4::systick::SysTick::new(),
     };

--- a/capsules/src/driver.rs
+++ b/capsules/src/driver.rs
@@ -79,5 +79,6 @@ pub enum NUM {
     Touch                 = 0x90002,
     TextScreen            = 0x90003,
     SevenSegment          = 0x90004,
+    Squared               = 0x90005,
 }
 }

--- a/capsules/src/lib.rs
+++ b/capsules/src/lib.rs
@@ -84,6 +84,7 @@ pub mod sip_hash;
 pub mod sound_pressure;
 pub mod spi_controller;
 pub mod spi_peripheral;
+pub mod squared;
 pub mod st77xx;
 pub mod symmetric_encryption;
 pub mod temperature;

--- a/capsules/src/squared.rs
+++ b/capsules/src/squared.rs
@@ -1,0 +1,41 @@
+//! Provide userspace service to calculate the square of a number.
+//!
+//! This uses the U32U64 command return type.
+
+use kernel::syscall::{CommandReturn, SyscallDriver};
+use kernel::ErrorCode;
+use kernel::ProcessId;
+
+/// Syscall driver number.
+use crate::driver;
+pub const DRIVER_NUM: usize = driver::NUM::Squared as usize;
+
+pub struct Squared {}
+
+impl SyscallDriver for Squared {
+    fn command(
+        &self,
+        command_type: usize,
+        arg1: usize,
+        _: usize,
+        _appid: ProcessId,
+    ) -> CommandReturn {
+        match command_type {
+            0 => CommandReturn::success(),
+
+            // Square a number.
+            1 => {
+                let multiplicand: u64 = arg1 as u64;
+                let multiplier: u64 = arg1 as u64;
+                let product = multiplicand * multiplier;
+
+                CommandReturn::success_u32_u64(0, product)
+            }
+
+            _ => CommandReturn::failure(ErrorCode::NOSUPPORT),
+        }
+    }
+    fn allocate_grant(&self, _: ProcessId) -> Result<(), kernel::process::Error> {
+        Ok(())
+    }
+}


### PR DESCRIPTION
### Pull Request Overview

This pull request adds a capsule for squaring a number. It's actual purpose is to support testing the U32U64 command return type.


### Testing Strategy

Writing a userspace app and verifying the squared value comes back successfully.


### TODO or Help Wanted

This isn't the most...useful capsule. However to test the userspace side as well we need a capsule that implements the less common return types. 


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
