### PR TITLE
chips/qemu_rv32_virt_chip: check mip.mtimer in pending IRQs

### DIFF
--- a/chips/qemu_rv32_virt_chip/src/chip.rs
+++ b/chips/qemu_rv32_virt_chip/src/chip.rs
@@ -120,6 +120,14 @@ impl<'a, I: InterruptService<()> + 'a> Chip for QemuRv32VirtChip<'a, I> {
     }
 
     fn has_pending_interrupts(&self) -> bool {
+        // First check if the global machine timer interrupt is set.
+        // We would also need to check for additional global interrupt bits
+        // if there were to be used for anything in the future.
+        if CSR.mip.is_set(mip::mtimer) {
+            return true;
+        }
+
+        // Then we can check the PLIC.
         self.plic.get_saved_interrupts().is_some()
     }
 


### PR DESCRIPTION
### Pull Request Overview

This is a fix identical to that of tock/tock#2571. It was not included in the qemu_rv32_virt board PR (#2516)  as that has been branched off before this fix was included in mainline.

### Testing Strategy

This pull request was tested by release tests (where before this change timer interrupts required pressing keys to trigger console interrupts, which are then registered as pending interrupts).


### TODO or Help Wanted

N/A

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
