### PR TITLE
boards/particle_boron: Add board support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ members = [
     "boards/sma_q3",
     "boards/nucleo_f429zi",
     "boards/nucleo_f446re",
+    "boards/particle_boron",
     "boards/pico_explorer_base",
     "boards/raspberry_pi_pico",
     "boards/redboard_artemis_nano",

--- a/boards/README.md
+++ b/boards/README.md
@@ -66,6 +66,7 @@ but the approximate definitions:
 |-------------------------------------------------------------------|------------------|----------------|------------|-----------------------------|---------------|
 | [Nordic nRF52-DK](nordic/nrf52dk/README.md)                       | ARM Cortex-M4    | nRF52832       | jLink      | tockloader                  | No            |
 | [Nordic nRF52840-Dongle](nordic/nrf52840_dongle/README.md)        | ARM Cortex-M4    | nRF52840       | jLink      | tockloader                  | No            |
+| [Particle Boron](particle_boron/README.md)                        | ARM Cortex-M4    | nRF52840       | jLink      | tockloader                  | No            |
 | [ACD52832](acd52832/README.md)                                    | ARM Cortex-M4    | nRF52832       | jLink      | tockloader                  | No            |
 | [ST Nucleo F446RE](nucleo_f446re/README.md)                       | ARM Cortex-M4    | STM32F446      | openocd    | custom                      | https://github.com/tock/tock/issues/1827 |
 | [ST Nucleo F429ZI](nucleo_f429zi/README.md)                       | ARM Cortex-M4    | STM32F429      | openocd    | custom                      | https://github.com/tock/tock/issues/1827 |

--- a/boards/particle_boron/Cargo.toml
+++ b/boards/particle_boron/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "particle_boron"
+version = "0.1.0"
+authors = [
+    "Tock Project Developers <tock-dev@googlegroups.com>",
+    "Wilfred Mallawa <vindulawilfred@gmail.com>"
+    ]
+build = "build.rs"
+edition = "2021"
+
+[dependencies]
+components = { path = "../components" }
+cortexm4 = { path = "../../arch/cortex-m4" }
+capsules = { path = "../../capsules" }
+kernel = { path = "../../kernel" }
+nrf52 = { path = "../../chips/nrf52" }
+nrf52840 = { path = "../../chips/nrf52840" }
+nrf52_components = { path = "../nordic/nrf52_components" }

--- a/boards/particle_boron/Makefile
+++ b/boards/particle_boron/Makefile
@@ -1,0 +1,24 @@
+# Makefile for building the tock kernel for the Particle Boron
+
+TARGET=thumbv7em-none-eabi
+PLATFORM=particle_boron
+
+include ../Makefile.common
+
+TOCKLOADER=tockloader
+
+# Where in the nrf52 flash to load the kernel with `tockloader`
+KERNEL_ADDRESS=0x00000
+
+# Can be flashed with nrf52dk config
+## TODO: Update board to particle_boron when tockloader supports
+TOCKLOADER_JTAG_FLAGS = --jlink --board nrf52dk
+
+# Default target for installing the kernel.
+.PHONY: install
+install: flash
+
+# Upload the kernel over JTAG
+.PHONY: flash
+flash: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin
+	$(TOCKLOADER) $(TOCKLOADER_GENERAL_FLAGS) flash --address $(KERNEL_ADDRESS) $(TOCKLOADER_JTAG_FLAGS) $<

--- a/boards/particle_boron/README.md
+++ b/boards/particle_boron/README.md
@@ -1,0 +1,104 @@
+Platform-Specific Instructions: Particle-Boron
+===================================
+
+## Particle Boron
+
+<img src="https://user-images.githubusercontent.com/36925352/188639324-e93fe4d7-9673-4bb3-a97e-1c08d330e683.png" width="720">
+</br> </br>
+
+The [Particle_Boron](https://docs.particle.io/reference/datasheets/b-series/boron-datasheet/) is development board based on the `nRF52840 SOC`. "The Boron is a powerful LTE Cat M1 or 2G/3G enabled development kit that supports cellular networks and Bluetooth LE (BLE). It is based on the Nordic nRF52840 and has built-in battery charging circuitry so it’s easy to connect a Li-Po and deploy your local network in minutes."
+
+To program the [Particle_Boron](https://docs.particle.io/reference/datasheets/b-series/boron-datasheet/) with Tock, you will need a JLink JTAG device and the
+appropriate cables.
+
+Then, follow the [Tock Getting Started guide](../../../doc/Getting_Started.md)
+
+## Programming the kernel
+
+Once you have all software installed, you should be able to simply run
+`make install` in this directory to install a fresh kernel. Make sure to install 
+the [tockloader](https://github.com/tock/tockloader).
+
+## Hardware Setup
+
+Required: 
+
+* Segger JLink 
+* USB Cable for power & Debugging
+
+Ensure JLink is connected and the Particle Boron is powered using either mUSB cable or a Li-Po battery. 
+
+## Software Setup
+
+To flash using JLink, make sure the segger software is installed on your machine. See [here](https://www.segger.com/downloads/jlink). You can test that it is installed properly by running the following command. 
+
+```bash
+$ JLinkExe
+```
+
+## Programming user-level applications
+
+You can program an application via JTAG using `tockloader`: 
+ 
+First clone libtock-c, more instructions [here](https://github.com/tock/libtock-c).
+
+Note: We currently use the `nrf52dk` (until tockloader supports) board alias for the Particle Boron to flash using the tockloader. 
+
+```bash
+$ git clone git@github.com:tock/libtock-c.git  
+$ cd libtock-c/examples/<app>
+$ make
+$ tockloader install --board nrf52dk --jlink blink/build/blink.tab
+```
+You should see the rgb-led light show on the board now!
+
+## Board Reset
+
+A reset on the baord can be performed by the **_RESET** push button, to reboot the kernel. 
+
+## Console output
+
+Console is interfaced using `USB cdc_acm`, so additional hardware is not required. Once the kernel is flashed, simply open up a serial port
+
+```bash
+$ screen /dev/ttyACM0 115200 
+.
+.
+.
+> tock$ help
+> Valid commands are: help status list stop start fault process kernel
+```
+
+OR
+
+```bash
+$ tockloader listen
+.
+.
+.
+[INFO   ] No device name specified. Using default name "tock".
+[INFO   ] Using "/dev/ttyACM0 - Boron - TockOS".
+[INFO   ] Listening for serial output.
+
+tock$ help
+Welcome to the process console.
+Valid commands are: help status list stop start fault process kernel
+tock$ list
+ PID    Name                Quanta  Syscalls  Dropped Upcalls  Restarts    State  Grants
+  0	buttons                  0        22                0         0  Yielded    1/11
+```
+
+## Tested LibTock-C Samples
+
+```
+* adc                       --  [OK]
+* ble_advertising           --  [OK]
+* ble_passive_scanning      --  [OK]
+* blink                     --  [OK]
+* buttons                   --  [OK]
+* c_hello                   --  [OK]
+```
+## Currently Unsupported Board Features
+
+* LTE [u-blox SARA-R410M-02B or R410M-03] or 2G/3G [u-blox SARA-U201 (2G/3G)] modem(s).
+* PMIC/Fuel Gauge (I2C device).

--- a/boards/particle_boron/build.rs
+++ b/boards/particle_boron/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    println!("cargo:rerun-if-changed=layout.ld");
+    println!("cargo:rerun-if-changed=../../kernel_layout.ld");
+}

--- a/boards/particle_boron/layout.ld
+++ b/boards/particle_boron/layout.ld
@@ -1,0 +1,2 @@
+INCLUDE ../nordic/nrf52840_chip_layout.ld
+INCLUDE ../kernel_layout.ld

--- a/boards/particle_boron/src/io.rs
+++ b/boards/particle_boron/src/io.rs
@@ -1,0 +1,141 @@
+use core::fmt::Write;
+use core::panic::PanicInfo;
+use kernel::ErrorCode;
+
+use cortexm4;
+use kernel::debug;
+use kernel::debug::IoWrite;
+use kernel::hil::led;
+use kernel::hil::uart::Transmit;
+use kernel::hil::uart::{self};
+use kernel::utilities::cells::VolatileCell;
+use nrf52840::gpio::Pin;
+
+use crate::CHIP;
+use crate::PROCESSES;
+use crate::PROCESS_PRINTER;
+
+struct Writer {
+    initialized: bool,
+}
+
+static mut WRITER: Writer = Writer { initialized: false };
+
+impl Write for Writer {
+    fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
+        self.write(s.as_bytes());
+        Ok(())
+    }
+}
+
+const BUF_LEN: usize = 512;
+static mut STATIC_PANIC_BUF: [u8; BUF_LEN] = [0; BUF_LEN];
+
+static mut DUMMY: DummyUsbClient = DummyUsbClient {
+    fired: VolatileCell::new(false),
+};
+
+struct DummyUsbClient {
+    fired: VolatileCell<bool>,
+}
+
+impl uart::TransmitClient for DummyUsbClient {
+    fn transmitted_buffer(&self, _: &'static mut [u8], _: usize, _: Result<(), ErrorCode>) {
+        self.fired.set(true);
+    }
+}
+
+impl IoWrite for Writer {
+    fn write(&mut self, buf: &[u8]) {
+        if !self.initialized {
+            self.initialized = true;
+        }
+        // Here we mimic a synchronous UART output by calling transmit_buffer
+        // on the CDC stack and then spinning on USB interrupts until the transaction
+        // is complete. If the USB or CDC stack panicked, this may fail. It will also
+        // fail if the panic occurred prior to the USB connection being initialized.
+        // In the latter case, the LEDs should still blink in the panic pattern.
+
+        // spin so that if any USB DMA is ongoing it will finish
+        // we should only need this on the first call to write()
+        let mut i = 0;
+        loop {
+            i += 1;
+            cortexm4::support::nop();
+            if i > 10000 {
+                break;
+            }
+        }
+
+        // copy_from_slice() requires equal length slices
+        // This will truncate any writes longer than BUF_LEN, but simplifies the
+        // code. In practice, BUF_LEN=512 always seems sufficient for the size of
+        // individual calls to write made by the panic handler.
+        let mut max = BUF_LEN;
+        if buf.len() < BUF_LEN {
+            max = buf.len();
+        }
+
+        unsafe {
+            // If CDC_REF_FOR_PANIC is not yet set we panicked very early,
+            // and not much we can do. Don't want to double fault,
+            // so just return.
+            super::CDC_REF_FOR_PANIC.map(|cdc| {
+                // Lots of unsafe dereferencing of global static mut objects here.
+                // However, this should be okay, because it all happens within
+                // a single thread, and:
+                // - This is the only place the global CDC_REF_FOR_PANIC is used, the logic is the same
+                //   as applies for the global CHIP variable used in the panic handler.
+                // - We do create multiple mutable references to the STATIC_PANIC_BUF, but we never
+                //   access the STATIC_PANIC_BUF after a slice of it is passed to transmit_buffer
+                //   until the slice has been returned in the uart callback.
+                // - Similarly, only this function uses the global DUMMY variable, and we do not
+                //   mutate it.
+                let usb = &mut cdc.controller();
+                STATIC_PANIC_BUF[..max].copy_from_slice(&buf[..max]);
+                let static_buf = &mut STATIC_PANIC_BUF;
+                cdc.set_transmit_client(&DUMMY);
+                let _ = cdc.transmit_buffer(static_buf, max);
+                loop {
+                    if let Some(interrupt) = cortexm4::nvic::next_pending() {
+                        if interrupt == 39 {
+                            usb.handle_interrupt();
+                        }
+                        let n = cortexm4::nvic::Nvic::new(interrupt);
+                        n.clear_pending();
+                        n.enable();
+                    }
+                    if DUMMY.fired.get() == true {
+                        // buffer finished transmitting, return so we can output additional
+                        // messages when requested by the panic handler.
+                        break;
+                    }
+                }
+                DUMMY.fired.set(false);
+            });
+        }
+    }
+}
+
+const LED2_R_PIN: Pin = Pin::P0_13;
+
+/// Default panic handler for the Particle Boron.
+///
+/// We just use the standard default provided by the debug module in the kernel.
+#[cfg(not(test))]
+#[no_mangle]
+#[panic_handler]
+pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
+    let led_kernel_pin = &nrf52840::gpio::GPIOPin::new(LED2_R_PIN);
+    let led = &mut led::LedLow::new(led_kernel_pin);
+    let writer = &mut WRITER;
+    debug::panic(
+        &mut [led],
+        writer,
+        pi,
+        &cortexm4::support::nop,
+        &PROCESSES,
+        &CHIP,
+        &PROCESS_PRINTER,
+    )
+}

--- a/boards/particle_boron/src/main.rs
+++ b/boards/particle_boron/src/main.rs
@@ -1,0 +1,640 @@
+//! Tock kernel for the Particle Boron.
+//!
+//! It is based on nRF52840 SoC (Cortex M4 core with a BLE transceiver) with
+//! many exported I/O and peripherals.
+
+#![no_std]
+// Disable this attribute when documenting, as a workaround for
+// https://github.com/rust-lang/rust/issues/62184.
+#![cfg_attr(not(doc), no_main)]
+#![deny(missing_docs)]
+
+use capsules::i2c_master_slave_driver::I2CMasterSlaveDriver;
+use capsules::virtual_aes_ccm::MuxAES128CCM;
+use capsules::virtual_alarm::VirtualMuxAlarm;
+use kernel::component::Component;
+use kernel::dynamic_deferred_call::{DynamicDeferredCall, DynamicDeferredCallClientState};
+use kernel::hil::i2c::{I2CMaster, I2CSlave};
+use kernel::hil::led::LedLow;
+use kernel::hil::symmetric_encryption::AES128;
+use kernel::hil::time::Counter;
+use kernel::hil::usb::Client;
+use kernel::platform::{KernelResources, SyscallDriverLookup};
+use kernel::scheduler::round_robin::RoundRobinSched;
+#[allow(unused_imports)]
+use kernel::{capabilities, create_capability, debug, debug_gpio, debug_verbose, static_init};
+use nrf52840::gpio::Pin;
+use nrf52840::interrupt_service::Nrf52840DefaultPeripherals;
+#[allow(unused_imports)]
+use nrf52_components::{self, UartChannel, UartPins};
+
+// The Particle Boron LEDs
+const LED_USR_PIN: Pin = Pin::P1_12;
+const LED2_R_PIN: Pin = Pin::P0_13;
+const LED2_G_PIN: Pin = Pin::P0_14;
+const LED2_B_PIN: Pin = Pin::P0_15;
+
+// The Particle Boron buttons
+const BUTTON_PIN: Pin = Pin::P0_11;
+const BUTTON_RST_PIN: Pin = Pin::P0_18;
+
+// UART Pins
+const _UART_RTS: Option<Pin> = Some(Pin::P0_30);
+const _UART_TXD: Pin = Pin::P0_06;
+const _UART_CTS: Option<Pin> = Some(Pin::P0_31);
+const _UART_RXD: Pin = Pin::P0_08;
+
+// SPI pins not currently in use, but left here for convenience
+const _SPI_MOSI: Pin = Pin::P1_13;
+const _SPI_MISO: Pin = Pin::P1_14;
+const _SPI_CLK: Pin = Pin::P1_15;
+
+// I2C Pins
+const I2C_SDA_PIN: Pin = Pin::P0_26;
+const I2C_SCL_PIN: Pin = Pin::P0_27;
+
+// Constants related to the configuration of the 15.4 network stack
+const SRC_MAC: u16 = 0xf00f;
+const PAN_ID: u16 = 0xABCD;
+
+/// UART Writer
+pub mod io;
+
+// How should the kernel respond when a process faults. For this board we choose
+// to stop the app and print a notice, but not immediately panic. This allows
+// users to debug their apps, but avoids issues with using the USB/CDC stack
+// synchronously for panic! too early after the board boots.
+const FAULT_RESPONSE: kernel::process::StopWithDebugFaultPolicy =
+    kernel::process::StopWithDebugFaultPolicy {};
+
+// Number of concurrent processes this platform supports.
+const NUM_PROCS: usize = 8;
+
+static mut PROCESSES: [Option<&'static dyn kernel::process::Process>; NUM_PROCS] =
+    [None; NUM_PROCS];
+
+// Static reference to chip for panic dumps
+static mut CHIP: Option<&'static nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>> = None;
+// Static reference to process printer for panic dumps
+static mut PROCESS_PRINTER: Option<&'static kernel::process::ProcessPrinterText> = None;
+static mut CDC_REF_FOR_PANIC: Option<
+    &'static capsules::usb::cdc::CdcAcm<
+        'static,
+        nrf52::usbd::Usbd,
+        capsules::virtual_alarm::VirtualMuxAlarm<'static, nrf52::rtc::Rtc>,
+    >,
+> = None;
+static mut NRF52_POWER: Option<&'static nrf52840::power::Power> = None;
+
+/// Dummy buffer that causes the linker to reserve enough space for the stack.
+#[no_mangle]
+#[link_section = ".stack_buffer"]
+pub static mut STACK_MEMORY: [u8; 0x1000] = [0; 0x1000];
+
+/// Supported drivers by the platform
+pub struct Platform {
+    ble_radio: &'static capsules::ble_advertising_driver::BLE<
+        'static,
+        nrf52840::ble_radio::Radio<'static>,
+        VirtualMuxAlarm<'static, nrf52840::rtc::Rtc<'static>>,
+    >,
+    ieee802154_radio: &'static capsules::ieee802154::RadioDriver<'static>,
+    button: &'static capsules::button::Button<'static, nrf52840::gpio::GPIOPin<'static>>,
+    pconsole: &'static capsules::process_console::ProcessConsole<
+        'static,
+        VirtualMuxAlarm<'static, nrf52840::rtc::Rtc<'static>>,
+        components::process_console::Capability,
+    >,
+    console: &'static capsules::console::Console<'static>,
+    gpio: &'static capsules::gpio::GPIO<'static, nrf52840::gpio::GPIOPin<'static>>,
+    led: &'static capsules::led::LedDriver<
+        'static,
+        LedLow<'static, nrf52840::gpio::GPIOPin<'static>>,
+        4,
+    >,
+    adc: &'static capsules::adc::AdcVirtualized<'static>,
+    rng: &'static capsules::rng::RngDriver<'static>,
+    temp: &'static capsules::temperature::TemperatureSensor<'static>,
+    ipc: kernel::ipc::IPC<{ NUM_PROCS as u8 }>,
+    i2c_master_slave: &'static capsules::i2c_master_slave_driver::I2CMasterSlaveDriver<'static>,
+    alarm: &'static capsules::alarm::AlarmDriver<
+        'static,
+        capsules::virtual_alarm::VirtualMuxAlarm<'static, nrf52840::rtc::Rtc<'static>>,
+    >,
+    scheduler: &'static RoundRobinSched<'static>,
+    systick: cortexm4::systick::SysTick,
+}
+
+impl SyscallDriverLookup for Platform {
+    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    where
+        F: FnOnce(Option<&dyn kernel::syscall::SyscallDriver>) -> R,
+    {
+        match driver_num {
+            capsules::console::DRIVER_NUM => f(Some(self.console)),
+            capsules::gpio::DRIVER_NUM => f(Some(self.gpio)),
+            capsules::alarm::DRIVER_NUM => f(Some(self.alarm)),
+            capsules::led::DRIVER_NUM => f(Some(self.led)),
+            capsules::button::DRIVER_NUM => f(Some(self.button)),
+            capsules::adc::DRIVER_NUM => f(Some(self.adc)),
+            capsules::rng::DRIVER_NUM => f(Some(self.rng)),
+            capsules::ble_advertising_driver::DRIVER_NUM => f(Some(self.ble_radio)),
+            capsules::ieee802154::DRIVER_NUM => f(Some(self.ieee802154_radio)),
+            capsules::temperature::DRIVER_NUM => f(Some(self.temp)),
+            kernel::ipc::DRIVER_NUM => f(Some(&self.ipc)),
+            capsules::i2c_master_slave_driver::DRIVER_NUM => f(Some(self.i2c_master_slave)),
+            _ => f(None),
+        }
+    }
+}
+
+impl KernelResources<nrf52840::chip::NRF52<'static, Nrf52840DefaultPeripherals<'static>>>
+    for Platform
+{
+    type SyscallDriverLookup = Self;
+    type SyscallFilter = ();
+    type ProcessFault = ();
+    type Scheduler = RoundRobinSched<'static>;
+    type SchedulerTimer = cortexm4::systick::SysTick;
+    type WatchDog = ();
+    type ContextSwitchCallback = ();
+
+    fn syscall_driver_lookup(&self) -> &Self::SyscallDriverLookup {
+        &self
+    }
+    fn syscall_filter(&self) -> &Self::SyscallFilter {
+        &()
+    }
+    fn process_fault(&self) -> &Self::ProcessFault {
+        &()
+    }
+    fn scheduler(&self) -> &Self::Scheduler {
+        self.scheduler
+    }
+    fn scheduler_timer(&self) -> &Self::SchedulerTimer {
+        &self.systick
+    }
+    fn watchdog(&self) -> &Self::WatchDog {
+        &()
+    }
+    fn context_switch_callback(&self) -> &Self::ContextSwitchCallback {
+        &()
+    }
+}
+
+/// This is in a separate, inline(never) function so that its stack frame is
+/// removed when this function returns. Otherwise, the stack space used for
+/// these static_inits is wasted.
+#[inline(never)]
+unsafe fn get_peripherals() -> &'static mut Nrf52840DefaultPeripherals<'static> {
+    // Initialize chip peripheral drivers
+    let nrf52840_peripherals = static_init!(
+        Nrf52840DefaultPeripherals,
+        Nrf52840DefaultPeripherals::new()
+    );
+
+    nrf52840_peripherals
+}
+
+/// Main function called after RAM initialized.
+#[no_mangle]
+pub unsafe fn main() {
+    nrf52840::init();
+
+    let nrf52840_peripherals = get_peripherals();
+
+    // set up circular peripheral dependencies
+    nrf52840_peripherals.init();
+    let base_peripherals = &nrf52840_peripherals.nrf52;
+
+    // Save a reference to the power module for resetting the board into the
+    // bootloader.
+    NRF52_POWER = Some(&base_peripherals.pwr_clk);
+
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
+
+    //--------------------------------------------------------------------------
+    // CAPABILITIES
+    //--------------------------------------------------------------------------
+
+    // Create capabilities that the board needs to call certain protected kernel
+    // functions.
+    let process_management_capability =
+        create_capability!(capabilities::ProcessManagementCapability);
+    let main_loop_capability = create_capability!(capabilities::MainLoopCapability);
+    let memory_allocation_capability = create_capability!(capabilities::MemoryAllocationCapability);
+
+    //--------------------------------------------------------------------------
+    // DEBUG GPIO
+    //--------------------------------------------------------------------------
+
+    let gpio_port = &nrf52840_peripherals.gpio_port;
+    // Configure kernel debug GPIOs as early as possible. These are used by the
+    // `debug_gpio!(0, toggle)` macro. We configure these early so that the
+    // macro is available during most of the setup code and kernel execution.
+    kernel::debug::assign_gpios(Some(&gpio_port[LED2_R_PIN]), None, None);
+
+    //--------------------------------------------------------------------------
+    // GPIO
+    //--------------------------------------------------------------------------
+
+    let gpio = components::gpio::GpioComponent::new(
+        board_kernel,
+        capsules::gpio::DRIVER_NUM,
+        components::gpio_component_helper!(
+            nrf52840::gpio::GPIOPin,
+            // Left Side pins on mesh feather
+            // A0 - ADC
+            // 0 => &nrf52840_peripherals.gpio_port[Pin::P0_03],
+            // A1 - ADC
+            // 1 => &nrf52840_peripherals.gpio_port[Pin::P0_04],
+            // A2 - ADC
+            // 2 => &nrf52840_peripherals.gpio_port[Pin::P0_28],
+            // A3 - ADC
+            // 3 => &nrf52840_peripherals.gpio_port[Pin::P0_29],
+            // A4 - ADC
+            // 4 => &nrf52840_peripherals.gpio_port[Pin::P0_30],
+            // A5 - ADC
+            // 5 => &nrf52840_peripherals.gpio_port[Pin::P0_31],
+            //D13
+            6 => &nrf52840_peripherals.gpio_port[Pin::P1_15],
+            //D12
+            7 => &nrf52840_peripherals.gpio_port[Pin::P1_13],
+            //D11
+            8 => &nrf52840_peripherals.gpio_port[Pin::P1_14],
+            //D10
+            9 => &nrf52840_peripherals.gpio_port[Pin::P0_08],
+            //D9
+            10 => &nrf52840_peripherals.gpio_port[Pin::P0_06],
+            // Right Side pins on mesh feather
+            //D8
+            11 => &nrf52840_peripherals.gpio_port[Pin::P1_03],
+            //D7: Bound to LED_USR_PIN (Active Low)
+            12 => &nrf52840_peripherals.gpio_port[Pin::P1_12],
+            //D6
+            13 => &nrf52840_peripherals.gpio_port[Pin::P1_11],
+            //D5
+            14 => &nrf52840_peripherals.gpio_port[Pin::P1_10],
+            //D4
+            15 => &nrf52840_peripherals.gpio_port[Pin::P1_08],
+            //D3
+            16 => &nrf52840_peripherals.gpio_port[Pin::P1_02],
+            //D2
+            17 => &nrf52840_peripherals.gpio_port[Pin::P0_01],
+            //D1
+            18 => &nrf52840_peripherals.gpio_port[Pin::P0_27],
+            //D0
+            19 => &nrf52840_peripherals.gpio_port[Pin::P0_26],
+        ),
+    )
+    .finalize(components::gpio_component_buf!(nrf52840::gpio::GPIOPin));
+
+    //--------------------------------------------------------------------------
+    // Buttons
+    //--------------------------------------------------------------------------
+
+    let button = components::button::ButtonComponent::new(
+        board_kernel,
+        capsules::button::DRIVER_NUM,
+        components::button_component_helper!(
+            nrf52840::gpio::GPIOPin,
+            (
+                &nrf52840_peripherals.gpio_port[BUTTON_PIN],
+                kernel::hil::gpio::ActivationMode::ActiveLow,
+                kernel::hil::gpio::FloatingState::PullUp
+            )
+        ),
+    )
+    .finalize(components::button_component_buf!(nrf52840::gpio::GPIOPin));
+
+    //--------------------------------------------------------------------------
+    // LEDs
+    //--------------------------------------------------------------------------
+
+    let led = components::led::LedsComponent::new().finalize(components::led_component_helper!(
+        LedLow<'static, nrf52840::gpio::GPIOPin>,
+        LedLow::new(&nrf52840_peripherals.gpio_port[LED_USR_PIN]),
+        LedLow::new(&nrf52840_peripherals.gpio_port[LED2_R_PIN]),
+        LedLow::new(&nrf52840_peripherals.gpio_port[LED2_G_PIN]),
+        LedLow::new(&nrf52840_peripherals.gpio_port[LED2_B_PIN]),
+    ));
+
+    nrf52_components::startup::NrfStartupComponent::new(
+        false,
+        BUTTON_RST_PIN,
+        nrf52840::uicr::Regulator0Output::V3_0,
+        &base_peripherals.nvmc,
+    )
+    .finalize(());
+
+    //--------------------------------------------------------------------------
+    // ALARM & TIMER
+    //--------------------------------------------------------------------------
+
+    let rtc = &base_peripherals.rtc;
+    let _ = rtc.start();
+    let mux_alarm = components::alarm::AlarmMuxComponent::new(rtc)
+        .finalize(components::alarm_mux_component_helper!(nrf52840::rtc::Rtc));
+    let alarm = components::alarm::AlarmDriverComponent::new(
+        board_kernel,
+        capsules::alarm::DRIVER_NUM,
+        mux_alarm,
+    )
+    .finalize(components::alarm_component_helper!(nrf52840::rtc::Rtc));
+
+    //--------------------------------------------------------------------------
+    // Deferred Call (Dynamic) Setup
+    //--------------------------------------------------------------------------
+
+    let dynamic_deferred_call_clients =
+        static_init!([DynamicDeferredCallClientState; 4], Default::default());
+    let dynamic_deferred_caller = static_init!(
+        DynamicDeferredCall,
+        DynamicDeferredCall::new(dynamic_deferred_call_clients)
+    );
+    DynamicDeferredCall::set_global_instance(dynamic_deferred_caller);
+
+    //--------------------------------------------------------------------------
+    // UART & CONSOLE & DEBUG
+    //--------------------------------------------------------------------------
+
+    // Setup the CDC-ACM over USB driver that we will use for UART.
+    // We use the Arduino Vendor ID and Product ID since the device is the same.
+
+    // Create the strings we include in the USB descriptor. We use the hardcoded
+    // DEVICEADDR register on the nRF52 to set the serial number.
+    let serial_number_buf = static_init!([u8; 17], [0; 17]);
+    let serial_number_string: &'static str =
+        nrf52::ficr::FICR_INSTANCE.address_str(serial_number_buf);
+    let strings = static_init!(
+        [&str; 3],
+        [
+            "Particle",           // Manufacturer
+            "Boron - TockOS",     // Product
+            serial_number_string, // Serial number
+        ]
+    );
+
+    let cdc = components::cdc::CdcAcmComponent::new(
+        &nrf52840_peripherals.usbd,
+        capsules::usb::cdc::MAX_CTRL_PACKET_SIZE_NRF52840,
+        0x0101, // Custom
+        0x0202, // Custom
+        strings,
+        mux_alarm,
+        dynamic_deferred_caller,
+        None,
+    )
+    .finalize(components::usb_cdc_acm_component_helper!(
+        nrf52::usbd::Usbd,
+        nrf52::rtc::Rtc
+    ));
+    CDC_REF_FOR_PANIC = Some(cdc); //for use by panic handler
+
+    // Process Printer for displaying process information.
+    let process_printer =
+        components::process_printer::ProcessPrinterTextComponent::new().finalize(());
+    PROCESS_PRINTER = Some(process_printer);
+
+    // Create a shared UART channel for the console and for kernel debug.
+    let uart_mux = components::console::UartMuxComponent::new(cdc, 115200, dynamic_deferred_caller)
+        .finalize(());
+
+    let pconsole = components::process_console::ProcessConsoleComponent::new(
+        board_kernel,
+        uart_mux,
+        mux_alarm,
+        process_printer,
+    )
+    .finalize(components::process_console_component_helper!(
+        nrf52::rtc::Rtc<'static>
+    ));
+
+    // Setup the console.
+    let console = components::console::ConsoleComponent::new(
+        board_kernel,
+        capsules::console::DRIVER_NUM,
+        uart_mux,
+    )
+    .finalize(components::console_component_helper!());
+    // Create the debugger object that handles calls to `debug!()`.
+    components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
+
+    //--------------------------------------------------------------------------
+    // WIRELESS
+    //--------------------------------------------------------------------------
+
+    let ble_radio = nrf52_components::BLEComponent::new(
+        board_kernel,
+        capsules::ble_advertising_driver::DRIVER_NUM,
+        &base_peripherals.ble_radio,
+        mux_alarm,
+    )
+    .finalize(());
+
+    let aes_mux = static_init!(
+        MuxAES128CCM<'static, nrf52840::aes::AesECB>,
+        MuxAES128CCM::new(&base_peripherals.ecb, dynamic_deferred_caller)
+    );
+    base_peripherals.ecb.set_client(aes_mux);
+    aes_mux.initialize_callback_handle(
+        dynamic_deferred_caller.register(aes_mux).unwrap(), // Unwrap fail = no deferred call slot available for ccm mux
+    );
+
+    let (ieee802154_radio, _mux_mac) = components::ieee802154::Ieee802154Component::new(
+        board_kernel,
+        capsules::ieee802154::DRIVER_NUM,
+        &base_peripherals.ieee802154_radio,
+        aes_mux,
+        PAN_ID,
+        SRC_MAC,
+        dynamic_deferred_caller,
+    )
+    .finalize(components::ieee802154_component_helper!(
+        nrf52840::ieee802154_radio::Radio,
+        nrf52840::aes::AesECB<'static>
+    ));
+
+    //--------------------------------------------------------------------------
+    // Sensor
+    //--------------------------------------------------------------------------
+
+    let temp = components::temperature::TemperatureComponent::new(
+        board_kernel,
+        capsules::temperature::DRIVER_NUM,
+        &base_peripherals.temp,
+    )
+    .finalize(());
+
+    //--------------------------------------------------------------------------
+    // RANDOM NUMBERS
+    //--------------------------------------------------------------------------
+
+    let rng = components::rng::RngComponent::new(
+        board_kernel,
+        capsules::rng::DRIVER_NUM,
+        &base_peripherals.trng,
+    )
+    .finalize(());
+
+    //--------------------------------------------------------------------------
+    // ADC
+    //--------------------------------------------------------------------------
+
+    base_peripherals.adc.calibrate();
+
+    let adc_mux = components::adc::AdcMuxComponent::new(&base_peripherals.adc)
+        .finalize(components::adc_mux_component_helper!(nrf52840::adc::Adc));
+
+    let adc_syscall =
+        components::adc::AdcVirtualComponent::new(board_kernel, capsules::adc::DRIVER_NUM)
+            .finalize(components::adc_syscall_component_helper!(
+                // BRD_A0
+                components::adc::AdcComponent::new(
+                    &adc_mux,
+                    nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput1)
+                )
+                .finalize(components::adc_component_helper!(nrf52840::adc::Adc)),
+                // BRD_A1
+                components::adc::AdcComponent::new(
+                    &adc_mux,
+                    nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput2)
+                )
+                .finalize(components::adc_component_helper!(nrf52840::adc::Adc)),
+                // BRD_A2
+                components::adc::AdcComponent::new(
+                    &adc_mux,
+                    nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput4)
+                )
+                .finalize(components::adc_component_helper!(nrf52840::adc::Adc)),
+                // BRD_A3
+                components::adc::AdcComponent::new(
+                    &adc_mux,
+                    nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput5)
+                )
+                .finalize(components::adc_component_helper!(nrf52840::adc::Adc)),
+                // BRD_A4
+                components::adc::AdcComponent::new(
+                    &adc_mux,
+                    nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput6)
+                )
+                .finalize(components::adc_component_helper!(nrf52840::adc::Adc)),
+                // BRD_A5
+                components::adc::AdcComponent::new(
+                    &adc_mux,
+                    nrf52840::adc::AdcChannelSetup::new(nrf52840::adc::AdcChannel::AnalogInput7)
+                )
+                .finalize(components::adc_component_helper!(nrf52840::adc::Adc)),
+            ));
+
+    //--------------------------------------------------------------------------
+    // I2C Master/Slave
+    //--------------------------------------------------------------------------
+
+    let i2c_master_buffer = static_init!([u8; 32], [0; 32]);
+    let i2c_slave_buffer1 = static_init!([u8; 32], [0; 32]);
+    let i2c_slave_buffer2 = static_init!([u8; 32], [0; 32]);
+
+    let i2c_master_slave = static_init!(
+        I2CMasterSlaveDriver,
+        I2CMasterSlaveDriver::new(
+            &base_peripherals.twi1,
+            i2c_master_buffer,
+            i2c_slave_buffer1,
+            i2c_slave_buffer2,
+            board_kernel.create_grant(
+                capsules::i2c_master_slave_driver::DRIVER_NUM,
+                &memory_allocation_capability
+            ),
+        )
+    );
+    base_peripherals.twi1.configure(
+        nrf52840::pinmux::Pinmux::new(I2C_SCL_PIN as u32),
+        nrf52840::pinmux::Pinmux::new(I2C_SDA_PIN as u32),
+    );
+    base_peripherals.twi1.set_master_client(i2c_master_slave);
+    base_peripherals.twi1.set_slave_client(i2c_master_slave);
+    base_peripherals.twi1.set_speed(nrf52840::i2c::Speed::K400);
+
+    //--------------------------------------------------------------------------
+    // FINAL SETUP AND BOARD BOOT
+    //--------------------------------------------------------------------------
+
+    nrf52_components::NrfClockComponent::new(&base_peripherals.clock).finalize(());
+
+    let scheduler = components::sched::round_robin::RoundRobinComponent::new(&PROCESSES)
+        .finalize(components::rr_component_helper!(NUM_PROCS));
+
+    let platform = Platform {
+        button,
+        ble_radio,
+        ieee802154_radio,
+        pconsole,
+        console,
+        led,
+        gpio,
+        adc: adc_syscall,
+        rng,
+        temp,
+        alarm,
+        ipc: kernel::ipc::IPC::new(
+            board_kernel,
+            kernel::ipc::DRIVER_NUM,
+            &memory_allocation_capability,
+        ),
+        i2c_master_slave,
+        scheduler,
+        systick: cortexm4::systick::SysTick::new_with_calibration(64000000),
+    };
+
+    let chip = static_init!(
+        nrf52840::chip::NRF52<Nrf52840DefaultPeripherals>,
+        nrf52840::chip::NRF52::new(nrf52840_peripherals)
+    );
+    CHIP = Some(chip);
+
+    // Configure the USB stack to enable a serial port over CDC-ACM.
+    cdc.enable();
+    cdc.attach();
+
+    debug!("Particle Boron: Initialization complete. Entering main loop\r");
+    let _ = platform.pconsole.start();
+
+    //--------------------------------------------------------------------------
+    // PROCESSES AND MAIN LOOP
+    //--------------------------------------------------------------------------
+
+    // These symbols are defined in the linker script.
+    extern "C" {
+        /// Beginning of the ROM region containing app images.
+        static _sapps: u8;
+        /// End of the ROM region containing app images.
+        static _eapps: u8;
+        /// Beginning of the RAM region for app memory.
+        static mut _sappmem: u8;
+        /// End of the RAM region for app memory.
+        static _eappmem: u8;
+    }
+
+    kernel::process::load_processes(
+        board_kernel,
+        chip,
+        core::slice::from_raw_parts(
+            &_sapps as *const u8,
+            &_eapps as *const u8 as usize - &_sapps as *const u8 as usize,
+        ),
+        core::slice::from_raw_parts_mut(
+            &mut _sappmem as *mut u8,
+            &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
+        ),
+        &mut PROCESSES,
+        &FAULT_RESPONSE,
+        &process_management_capability,
+    )
+    .unwrap_or_else(|err| {
+        debug!("Error loading processes!");
+        debug!("{:?}", err);
+    });
+
+    board_kernel.kernel_loop(&platform, chip, Some(&platform.ipc), &main_loop_capability);
+}


### PR DESCRIPTION
### Pull Request Overview

Add board support for the [Particle Boron](https://docs.particle.io/boron/).
<img src="https://user-images.githubusercontent.com/36925352/188639324-e93fe4d7-9673-4bb3-a97e-1c08d330e683.png" width="480">

## Tested Features

- Onboard buttons/All RGBs Leds
- BLE (Minimal testing with scanning/advertising)
- ADC
- Console (USB CDC_ACM)
- Process Console
- GPIO

Note: Many features have been copied from existing platforms, the following were used for references:

- USB: https://github.com/tock/tock/blob/master/boards/nano33ble/src/io.rs
- Platform: https://github.com/tock/tock/blob/master/boards/nordic/nrf52840dk/src/main.rs

### Testing Strategy

Flashing the kernel on to the board using Tockloader (with the `nrf52dk` board alias), waiting on https://github.com/tock/tockloader/pull/92 for the correct board name. 

Flashing the following `libtock-c` apps for functionality verification.

```
* adc                       --  [OK]
* ble_advertising           --  [OK]
* ble_passive_scanning      --  [OK]
* blink                     --  [OK]
* buttons                   --  [OK]
* c_hello                   --  [OK]
```

### Future...

- Add support for the onboard PMIC (I2C)
- Add support for the LTE modem (maybe...?)

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
