### PR TITLE
cortex-m: mpu: do not give all memory to process in certain case

### DIFF
--- a/arch/cortex-m/src/mpu.rs
+++ b/arch/cortex-m/src/mpu.rs
@@ -595,13 +595,8 @@ impl<const NUM_REGIONS: usize, const MIN_REGION_SIZE: usize> mpu::MPU
         // multiple of an eighth of the MPU region length.
 
         // Determine the number of subregions to enable.
-        let mut num_subregions_used = {
-            if initial_kernel_memory_size == 0 {
-                8
-            } else {
-                initial_app_memory_size * 8 / region_size + 1
-            }
-        };
+        // Want `round_up(app_memory_size / subregion_size)`.
+        let mut num_subregions_used = initial_app_memory_size * 8 / region_size + 1;
 
         let subregion_size = region_size / 8;
 
@@ -676,26 +671,13 @@ impl<const NUM_REGIONS: usize, const MIN_REGION_SIZE: usize> mpu::MPU
 
         // Number of bytes the process wants access to.
         let app_memory_size = app_memory_break - region_start;
-        // Number of bytes the kernel has reserved.
-        let kernel_memory_size = region_start + region_size - kernel_memory_break;
 
         // There are eight subregions for every region in the Cortex-M3/4 MPU.
         let subregion_size = region_size / 8;
 
         // Determine the number of subregions to enable.
-        let num_subregions_used = {
-            if kernel_memory_size == 0 {
-                // We can give all of the memory to the app, i.e. enable
-                // all eight subregions.
-                8
-            } else {
-                // Calculate the minimum number of subregions needed to cover
-                // the `app_memory_size`.
-                //
-                // Want `round_up(app_memory_size / subregion_size)`.
-                (app_memory_size + subregion_size - 1) / subregion_size
-            }
-        };
+        // Want `round_up(app_memory_size / subregion_size)`.
+        let num_subregions_used = (app_memory_size + subregion_size - 1) / subregion_size;
 
         let subregions_end = region_start + subregion_size * num_subregions_used;
 


### PR DESCRIPTION
The MPU should not make decisions about how much memory to give to a process, the kernel should decide.

It is not clear to me why this check if the kernel does not need any process memory then give the process all of the memory was included.




### Testing Strategy

Quickly using hail.


### TODO or Help Wanted

Does anyone know if this covers a specific use case? The caller should just request the full amount of RAM rather than relying on the MPU to make this decision.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
