### PR TITLE
litex-sim-ci: pin elf2tab to v0.9.0 to unbreak CI

### DIFF
--- a/.github/workflows/litex_sim.yml
+++ b/.github/workflows/litex_sim.yml
@@ -62,7 +62,7 @@ jobs:
       # Install elf2tabl to be able to build userspace apps
       - name: Install elf2tab
         run: |
-          cargo install elf2tab
+          cargo install elf2tab@0.9.0
 
       # Install tockloader, which is used to prepare binaries with userspace
       # applications.


### PR DESCRIPTION
### Pull Request Overview

elf2tab v0.10.0 has a bug which prevents correct calculation of an application's start address in certain cases. Pinning elf2tab to v0.9.0 for now fixes these issues in the CI workflow.


### Testing Strategy

This pull request was tested by CI?


### TODO or Help Wanted

N/A


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
