### PR TITLE
opentitan: add watchdog/aon_timer

### DIFF
--- a/boards/opentitan/src/main.rs
+++ b/boards/opentitan/src/main.rs
@@ -155,6 +155,7 @@ struct EarlGrey {
     scheduler: &'static PrioritySched,
     scheduler_timer:
         &'static VirtualSchedulerTimer<VirtualMuxAlarm<'static, earlgrey::timer::RvTimer<'static>>>,
+    watchdog: &'static lowrisc::aon_timer::AonTimer,
 }
 
 /// Mapping of integer syscalls to objects that implement syscalls.
@@ -190,7 +191,7 @@ impl KernelResources<earlgrey::chip::EarlGrey<'static, EarlGreyDefaultPeripheral
     type Scheduler = PrioritySched;
     type SchedulerTimer =
         VirtualSchedulerTimer<VirtualMuxAlarm<'static, earlgrey::timer::RvTimer<'static>>>;
-    type WatchDog = ();
+    type WatchDog = lowrisc::aon_timer::AonTimer;
     type ContextSwitchCallback = ();
 
     fn syscall_driver_lookup(&self) -> &Self::SyscallDriverLookup {
@@ -209,7 +210,7 @@ impl KernelResources<earlgrey::chip::EarlGrey<'static, EarlGreyDefaultPeripheral
         &self.scheduler_timer
     }
     fn watchdog(&self) -> &Self::WatchDog {
-        &()
+        &self.watchdog
     }
     fn context_switch_callback(&self) -> &Self::ContextSwitchCallback {
         &()
@@ -691,6 +692,7 @@ unsafe fn setup() -> (
 
     let syscall_filter = static_init!(TbfHeaderFilterDefaultAllow, TbfHeaderFilterDefaultAllow {});
     let scheduler = components::sched::priority::PriorityComponent::new(board_kernel).finalize(());
+    let watchdog = &peripherals.watchdog;
 
     let earlgrey = static_init!(
         EarlGrey,
@@ -710,6 +712,7 @@ unsafe fn setup() -> (
             syscall_filter,
             scheduler,
             scheduler_timer,
+            watchdog,
         }
     );
 

--- a/chips/earlgrey/src/aon_timer.rs
+++ b/chips/earlgrey/src/aon_timer.rs
@@ -1,0 +1,7 @@
+use kernel::utilities::StaticRef;
+use lowrisc::aon_timer::AonTimerRegisters;
+
+// Refer: https://github.com/lowRISC/opentitan/blob/217a0168ba118503c166a9587819e3811eeb0c0c/hw/top_earlgrey/sw/autogen/top_earlgrey_memory.h#L247
+// This is based on the latest support commit of OpenTitan for Tock.
+pub const AON_TIMER_BASE: StaticRef<AonTimerRegisters> =
+    unsafe { StaticRef::new(0x4047_0000 as *const AonTimerRegisters) };

--- a/chips/earlgrey/src/chip.rs
+++ b/chips/earlgrey/src/chip.rs
@@ -35,6 +35,7 @@ pub struct EarlGreyDefaultPeripherals<'a> {
     pub spi_host1: lowrisc::spi_host::SpiHost,
     pub flash_ctrl: lowrisc::flash_ctrl::FlashCtrl<'a>,
     pub rng: lowrisc::csrng::CsRng<'a>,
+    pub watchdog: lowrisc::aon_timer::AonTimer,
 }
 
 impl<'a> EarlGreyDefaultPeripherals<'a> {
@@ -64,6 +65,10 @@ impl<'a> EarlGreyDefaultPeripherals<'a> {
             ),
 
             rng: lowrisc::csrng::CsRng::new(crate::csrng::CSRNG_BASE),
+            watchdog: lowrisc::aon_timer::AonTimer::new(
+                crate::aon_timer::AON_TIMER_BASE,
+                CONFIG.cpu_freq,
+            ),
         }
     }
 }
@@ -100,6 +105,8 @@ impl<'a> InterruptService<()> for EarlGreyDefaultPeripherals<'a> {
             interrupts::SPIHOST1_ERROR..=interrupts::SPIHOST1_SPIEVENT => {
                 self.spi_host1.handle_interrupt()
             }
+            interrupts::AON_TIMER_AON_WKUP_TIMER_EXPIRED
+                ..=interrupts::AON_TIMER_AON_WDOG_TIMER_BARK => self.watchdog.handle_interrupt(),
             _ => return false,
         }
         true

--- a/chips/earlgrey/src/chip_config.rs
+++ b/chips/earlgrey/src/chip_config.rs
@@ -19,6 +19,8 @@ pub struct Config<'a> {
     pub cpu_freq: u32,
     /// The clock speed of the peripherals in Hz.
     pub peripheral_freq: u32,
+    /// The clock of the AON Timer
+    pub aon_timer_freq: u32,
     /// The baud rate for UART. This allows for a version of the chip that can
     /// support a faster baud rate to use it to help with debugging.
     pub uart_baudrate: u32,
@@ -30,6 +32,7 @@ pub const CONFIG: Config = Config {
     name: "fpga_cw310",
     cpu_freq: 10_000_000,
     peripheral_freq: 2_500_000,
+    aon_timer_freq: 250_000,
     uart_baudrate: 115200,
 };
 
@@ -39,5 +42,6 @@ pub const CONFIG: Config = Config {
     name: "sim_verilator",
     cpu_freq: 500_000,
     peripheral_freq: 125_000,
+    aon_timer_freq: 125_000,
     uart_baudrate: 7200,
 };

--- a/chips/earlgrey/src/lib.rs
+++ b/chips/earlgrey/src/lib.rs
@@ -9,6 +9,7 @@ pub mod chip_config;
 mod interrupts;
 
 pub mod aes;
+pub mod aon_timer;
 pub mod chip;
 pub mod csrng;
 pub mod flash_ctrl;

--- a/chips/lowrisc/src/aon_timer.rs
+++ b/chips/lowrisc/src/aon_timer.rs
@@ -1,0 +1,232 @@
+//! AON/Watchdog Timer Driver
+
+use kernel::platform;
+use kernel::utilities::registers::interfaces::{Readable, Writeable};
+use kernel::utilities::registers::{register_bitfields, register_structs, ReadWrite, WriteOnly};
+use kernel::utilities::StaticRef;
+
+// Based on the latest commit of OpenTitan supported by tock:
+// Refer: https://github.com/lowRISC/opentitan/blob/217a0168ba118503c166a9587819e3811eeb0c0c/hw/ip/aon_timer/rtl/aon_timer_reg_pkg.sv#L136
+register_structs! {
+    pub AonTimerRegisters {
+        //AON_TIMER: Alert Test Register
+        (0x000 => alert_test: WriteOnly<u32, ALERT_TEST::Register>),
+        //AON_TIMER: Wakeup Timer Control Register
+        (0x004 => wkup_ctrl: ReadWrite<u32, WKUP_CTRL::Register>),
+        //AON_TIMER: Wakeup Timer Threshold Register
+        (0x008 => wkup_thold: ReadWrite<u32, THRESHOLD::Register>),
+        //AON_TIMER: Wakeup Timer Count Register
+        (0x00C => wkup_count: ReadWrite<u32, WKUP_COUNT::Register>),
+        //AON_TIMER:  Watchdog Timer Write Enable Register [rw0c]
+        (0x010 => wdog_regwen: ReadWrite<u32, WDOG_REGWEN::Register>),
+        //AON_TIMER: Watchdog Timer Control register
+        (0x014 => wdog_ctrl: ReadWrite<u32, WDOG_CTRL::Register>),
+        //AON_TIMER: Watchdog Timer Bark Threshold Register
+        (0x018 => wdog_bark_thold: ReadWrite<u32, THRESHOLD::Register>),
+        //AON_TIMER: Watchdog Timer Bite Threshold Register
+        (0x01C => wdog_bite_thold: ReadWrite<u32, THRESHOLD::Register>),
+        //AON_TIMER: Watchdog Timer Count Register
+        (0x020 => wdog_count: ReadWrite<u32, WDOG_COUNT::Register>),
+        //AON_TIMER: Interrupt State Register [rw1c]
+        (0x024 => intr_state: ReadWrite<u32, INTR::Register>),
+        //AON_TIMER: Interrupt Test Reigster
+        (0x028 => intr_test: WriteOnly<u32, INTR::Register>),
+        //AON_TIMER: Wakeup Request Status [rw0c]
+        (0x02C => wkup_cause: ReadWrite<u32, WKUP_CAUSE::Register>),
+        (0x030 => @END),
+    }
+}
+
+register_bitfields![u32,
+    ALERT_TEST[
+        FATAL_FAULT OFFSET(0) NUMBITS(1) []
+    ],
+    WKUP_CTRL[
+        ENABLE OFFSET(0) NUMBITS(1) [],
+        PRESCALER OFFSET(1) NUMBITS(12) []
+    ],
+    THRESHOLD[
+        THRESHOLD OFFSET(0) NUMBITS(32) []
+    ],
+    WKUP_COUNT[
+        COUNT OFFSET(0) NUMBITS(32) []
+    ],
+    WDOG_REGWEN[
+        REGWEN OFFSET(0) NUMBITS(1) []
+    ],
+    WDOG_CTRL[
+        ENABLE OFFSET(0) NUMBITS(1) [],
+        PAUSE_IN_SLEEP OFFSET(1) NUMBITS(1) []
+    ],
+    WDOG_COUNT[
+        COUNT OFFSET(0) NUMBITS(32) [],
+    ],
+    INTR[
+        WKUP_TIMER_EXPIRED OFFSET(0) NUMBITS(1) [],
+        WDOG_TIMER_BARK OFFSET(1) NUMBITS(1) []
+    ],
+    WKUP_CAUSE[
+        CAUSE OFFSET(0) NUMBITS(1) [],
+    ]
+];
+
+pub struct AonTimer {
+    registers: StaticRef<AonTimerRegisters>,
+    aon_clk_freq: u32, //Hz, this differs for FPGA/Verilator
+}
+
+impl AonTimer {
+    pub const fn new(base: StaticRef<AonTimerRegisters>, aon_clk_freq: u32) -> AonTimer {
+        AonTimer {
+            registers: base,
+            aon_clk_freq: aon_clk_freq,
+        }
+    }
+
+    /// Reset both watch dog and wake up timer count values.
+    fn reset_timers(&self) {
+        let regs = self.registers;
+        regs.wkup_count.set(0x00);
+        regs.wdog_count.set(0x00);
+    }
+
+    /// Start the watchdog counter with pause in sleep
+    /// i.e wdog timer is paused when system is sleeping
+    fn wdog_start_count(&self) {
+        self.registers
+            .wdog_ctrl
+            .write(WDOG_CTRL::ENABLE::SET + WDOG_CTRL::PAUSE_IN_SLEEP::SET);
+    }
+
+    /// Program the desired thresholds in WKUP_THOLD, WDOG_BARK_THOLD and WDOG_BITE_THOLD
+    fn set_wdog_thresh(&self) {
+        let regs = self.registers;
+        // Watchdog period may need to be revised with kernel changes/updates
+        // since the watchdog is `tickled()` at the start of every kernel loop
+        // see: https://github.com/tock/tock/blob/eb3f7ce59434b7ac1b77ef1ab7dd2afad1a62ac5/kernel/src/kernel.rs#L448
+        let bark_cycles = self.ms_to_cycles(500);
+        // ~1000ms bite period
+        let bite_cycles = bark_cycles.saturating_mul(2);
+
+        regs.wdog_bark_thold
+            .write(THRESHOLD::THRESHOLD.val(bark_cycles));
+        regs.wdog_bite_thold
+            .write(THRESHOLD::THRESHOLD.val(bite_cycles));
+    }
+
+    // Reset watch dog timer
+    fn wdog_pet(&self) {
+        self.registers.wdog_count.set(0x00);
+    }
+
+    fn wdog_suspend(&self) {
+        self.registers.wdog_ctrl.write(WDOG_CTRL::ENABLE::CLEAR);
+    }
+
+    fn wdog_resume(&self) {
+        self.registers.wdog_ctrl.write(WDOG_CTRL::ENABLE::SET);
+    }
+
+    /// Locks further config to WDOG until next system reset
+    fn lock_wdog_conf(&self) {
+        self.registers.wdog_regwen.write(WDOG_REGWEN::REGWEN::SET)
+    }
+
+    /// Convert microseconds to cycles
+    fn ms_to_cycles(&self, ms: u32) -> u32 {
+        // 250kHZ CW130 or 125kHz Verilator (as specified in chip config)
+        ms.saturating_mul(self.aon_clk_freq).saturating_div(1000)
+    }
+
+    /// Start the wake up counter
+    #[cfg(aon_wkup_timer)]
+    fn wkup_start_count(&self) {
+        self.registers.wkup_ctrl.write(WKUP_CTRL::ENABLE::SET);
+    }
+
+    /// Set wake-up prescaler, NOTE: Independant of the watchdog timer
+    /// A count starts at 0 and slowly ticks upwards
+    /// (one tick every N + 1 clock cycles, where N is the pre-scaler value)
+    #[cfg(aon_wkup_timer)]
+    fn set_wkup_prescaler(&self) {
+        // Ex: AON VerilatorClock ~125kHZ, (2^12)/125_000Hz ~= 32ms (per tick)
+        // NOTE: Arbitrarily chosen, update as necessary.
+        let prescaler = 0x1000; // 2^12
+        self.registers
+            .wkup_ctrl
+            .write(WKUP_CTRL::PRESCALER.val(prescaler));
+    }
+
+    /// Set threshold ticks for the wake-up interrupt,
+    /// Note: the timing here depends on the prescaler set in
+    /// `set_wkup_prescaler()`
+    #[cfg(aon_wkup_timer)]
+    fn set_wkup_thresh(&self) {
+        let regs = self.registers;
+        // 0xFF arbitrarily chosen.
+        regs.wkup_thold.write(THRESHOLD::THRESHOLD.val(0xFF));
+    }
+
+    fn reset_wkup_count(&self) {
+        self.registers.wkup_count.set(0x00);
+    }
+
+    pub fn handle_interrupt(&self) {
+        let regs = self.registers;
+        let intr = self.registers.intr_state.extract();
+
+        if intr.is_set(INTR::WKUP_TIMER_EXPIRED) {
+            // Wake up timer has expired, sw must ack and clear
+            regs.wkup_cause.set(0x00);
+            regs.wkup_count.set(0x00); // To avoid re-triggers
+            self.reset_wkup_count();
+            // RW1C, clear the interrupt
+            regs.intr_state.write(INTR::WKUP_TIMER_EXPIRED::SET);
+        }
+
+        if intr.is_set(INTR::WDOG_TIMER_BARK) {
+            // Clear the bark (RW1C) and pet doggo
+            regs.intr_state.write(INTR::WDOG_TIMER_BARK::SET);
+            self.wdog_pet();
+        }
+    }
+}
+
+impl platform::watchdog::WatchDog for AonTimer {
+    /// The always-on timer will run on a ~125KHz (Verilator) or ~250kHz clock.
+    /// The timers themselves are 32b wide, giving a maximum timeout
+    /// window of roughly ~6 hours. For the wakeup timer, the pre-scaler
+    /// extends the maximum timeout to ~1000 days.
+    ///
+    /// The AON HW_IP has a watchdog and a wake-up timer (counts independantly of eachother),
+    /// although struct `AonTimer` implements the wakeup timer functionality,
+    /// we only start and use the watchdog in the code below.
+    fn setup(&self) {
+        // 1. Clear Timers
+        self.reset_timers();
+
+        // 2. Set thresholds.
+        self.set_wdog_thresh();
+
+        // 3. Commence gaurd duty...
+        self.wdog_start_count();
+
+        // 4. Lock watchdog config
+        // Preventing firmware from accidentally or maliciously disabling the watchdog,
+        // until next system reset.
+        self.lock_wdog_conf();
+    }
+
+    fn tickle(&self) {
+        // Nothing to worry about, good dog...
+        self.wdog_pet();
+    }
+
+    fn suspend(&self) {
+        self.wdog_suspend();
+    }
+
+    fn resume(&self) {
+        self.wdog_resume();
+    }
+}

--- a/chips/lowrisc/src/lib.rs
+++ b/chips/lowrisc/src/lib.rs
@@ -4,6 +4,7 @@
 #![crate_name = "lowrisc"]
 #![crate_type = "rlib"]
 
+pub mod aon_timer;
 pub mod csrng;
 pub mod flash_ctrl;
 pub mod gpio;


### PR DESCRIPTION
### Pull Request Overview

Uses the `Always on timer` (AON_TIMER) for Opentitan [hw_ip](https://docs.opentitan.org/hw/ip/aon_timer/doc/), to implement watchdog for OpenTitan. 

This AON_TIMER has both a `watchdog` timer and a `wakeup` timer. The driver implemented has support for both hw functionality but only runs the watch dog timer for now  (unused code tagged with `#[cfg(aon_wkup_timer)]`, that should be (?) compiled out and is left for reference/use later.

The following patch for [qemu](https://www.mail-archive.com/qemu-devel@nongnu.org/msg907656.html) adds support to the watchdog, so we can use this in the future with qemu also. 

### Testing Strategy

Driver has been written to support to latest version of OpenTitan supported by TockOS, testing was done on Verilator on this https://github.com/tock/tock/pull/3056. 


### TODO

- Tested on Verilator, would be good to test on CW130  (since the AON_TIMER runs on different clock rates on both devices)
- Implement a WakeUp timer interface (?) and connect it to this driver.

### Documentation Updated

- [x] No updates are required.

### Formatting

- [x] Ran `make prepush`.
