### PR TITLE
litex-sim-ci: update Tockloader & libtock-c rev, change to rv32imc

### DIFF
--- a/.github/workflows/litex_sim.yml
+++ b/.github/workflows/litex_sim.yml
@@ -59,16 +59,16 @@ jobs:
         with:
           components: rustfmt, clippy
 
-      # Install elf2tabl to be able to build userspace apps
+      # Install elf2tab to be able to build userspace apps
       - name: Install elf2tab
         run: |
-          cargo install elf2tab@0.9.0
+          cargo install elf2tab@0.10.2
 
       # Install tockloader, which is used to prepare binaries with userspace
       # applications.
       - name: Install tockloader
         run: |
-          pip3 install "tockloader==1.8.0"
+          pip3 install tockloader==1.9.0
 
       # Clone tock-litex support repository under ./tock-litex, check out the
       # targeted release.
@@ -115,8 +115,8 @@ jobs:
           # bugs fixed in libtock-c, backwards-incompatible changes in
           # Tock or new tests this might need to be updated.
           #
-          # libtock-c of December 13, 2021, 2:18 PM GMT-5
-          ref: fb3ffa6234659a660bffc8fc33e938a30270576a
+          # libtock-c of Sep 8, 2022, 5:42 PM EDT
+          ref: ad372e599e5a9e664f12c7757576cb28c8b40412
           path: libtock-c
 
       - name: Build libtock-c apps
@@ -125,8 +125,8 @@ jobs:
           # memory addresses such that tockloader can place the non-PIC apps
           # into the kernel binary properly.
           export TOCK_TARGETS="\
-            rv32i|rv32i.0x00080060.0x40008000|0x00080060|0x40008000
-            rv32i|rv32i.0x00088060.0x40010000|0x00088060|0x40010000"
+            rv32imc|rv32imc.0x00080060.0x40008000|0x00080060|0x40008000
+            rv32imc|rv32imc.0x00088060.0x40010000|0x00088060|0x40010000"
           export LIBTOCK_C_APPS="\
             c_hello \
             tests/console_timeout \


### PR DESCRIPTION
### Pull Request Overview

This pull request updates pinned Tockloader, libtock-c and elf2tab revisions. It further changes the compiled LiteX Sim apps to be targeting `rv32imc`, as intended by the LiteX sim board definition and integrated VexRiscv support.


### Testing Strategy

This pull request was tested by CI.


### TODO or Help Wanted

N/A

### Documentation Updated

- [x] ~Updated the relevant files in `/docs`,~ or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
