### PR TITLE
Revert "boards/redboard_artemis: Workaround Hard Fault Exception"

### DIFF
--- a/boards/redboard_artemis_nano/src/main.rs
+++ b/boards/redboard_artemis_nano/src/main.rs
@@ -151,22 +151,13 @@ impl KernelResources<apollo3::chip::Apollo3<Apollo3DefaultPeripherals>> for Redb
     }
 }
 
-// WARN: This is a short-term patch applied to allow this board to boot for the
-// 2.1 release. This `inline` will be removed immediately after the 2.1 release
-// pending the fixes to cortex-m context switching which should come in 2.2.
-#[inline(never)]
 unsafe fn setup() -> (
     &'static kernel::Kernel,
     &'static RedboardArtemisNano,
     &'static apollo3::chip::Apollo3<Apollo3DefaultPeripherals>,
     &'static Apollo3DefaultPeripherals,
 ) {
-    // WARN: This is a short-term patch applied to allow this board to
-    // boot for the 2.1 release. This will be returned here immediately
-    // after the 2.1 release pending the fixes to cortex-m context switching
-    // which should come in 2.2.
-    //
-    // apollo3::init();
+    apollo3::init();
 
     let peripherals = static_init!(Apollo3DefaultPeripherals, Apollo3DefaultPeripherals::new());
 
@@ -403,12 +394,6 @@ unsafe fn setup() -> (
 /// setup and RAM initialization.
 #[no_mangle]
 pub unsafe fn main() {
-    // WARN: This is a short-term patch applied to allow this board to
-    // boot for the 2.1 release. `init` will be removed here immediately
-    // after the 2.1 release pending the fixes to cortex-m context switching
-    // which should come in 2.2.
-    apollo3::init();
-
     #[cfg(test)]
     test_main();
 

--- a/chips/apollo3/src/lib.rs
+++ b/chips/apollo3/src/lib.rs
@@ -70,12 +70,7 @@ pub static IRQS: [unsafe extern "C" fn(); 32] = [CortexM4::GENERIC_ISR; 32];
 #[cfg_attr(all(target_arch = "arm", target_os = "none"), used)]
 pub static PATCH: [unsafe extern "C" fn(); 16] = [unhandled_interrupt; 16];
 
-// WARN: This is a short-term patch applied to allow this board to
-// boot for the 2.1 release. This `inline` will be removed immediately
-// after the 2.1 release pending the fixes to cortex-m context switching
-// which should come in 2.2.
 #[cfg(all(target_arch = "arm", target_os = "none"))]
-#[inline(always)]
 pub unsafe fn init() {
     use core::arch::asm;
     let cache_ctrl = crate::cachectrl::CacheCtrl::new();


### PR DESCRIPTION
This reverts commit 190f2146c267b0383ca060fd908e8db99d8dcf23, reversing changes made to c16260b0e25c79e6703dbc2111c42cd08ff7fb31.

Per #3139 


### Testing Strategy

n/a


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
