### PR TITLE
boards/opentitan: fixup flash_ctrl test

### DIFF
--- a/boards/opentitan/src/tests/flash_ctrl.rs
+++ b/boards/opentitan/src/tests/flash_ctrl.rs
@@ -107,7 +107,7 @@ fn flash_ctl_read_write_page() {
 
     #[cfg(feature = "hardware_tests")]
     {
-        let page_num: usize = 5;
+        let page_num: usize = 511;
         run_kernel_op(100);
         // Lets do a page erase
         assert!(flash_ctl.erase_page(page_num).is_ok());
@@ -167,7 +167,7 @@ fn flash_ctl_erase_page() {
 
     #[cfg(feature = "hardware_tests")]
     {
-        let page_num: usize = 128;
+        let page_num: usize = 500;
         run_kernel_op(100);
         // Lets do a page erase
         assert!(flash_ctl.erase_page(page_num).is_ok());


### PR DESCRIPTION
### Pull Request Overview

Minor bug fix to the `flash_ctrl` tests to make sure we don't overwrite/erase important sections during testing.

Discovered: When running the entire test suite, ran into an illegal instruction with the instruction being `0xAAAA` which is the data we write into flash in this test (overwriting the code on page 5).

Flash distribution:
- Page Size: 2kiB
- Pages 0-255: Bank0
- Pages 256-511: Bank1

### Testing Strategy

Running the test suite on Verilator.

### TODO or Help Wanted

N/A

### Documentation Updated

- [x] No updates are required.

### Formatting

- [x] Ran `make prepush`.
