### PR TITLE
Added missing base frequency config for e310x

### DIFF
--- a/chips/sifive/src/prci.rs
+++ b/chips/sifive/src/prci.rs
@@ -1,5 +1,6 @@
 //! Power Reset Clock Interrupt controller driver.
 
+use kernel::utilities::registers::interfaces::ReadWriteable;
 use kernel::utilities::registers::{register_bitfields, ReadWrite};
 use kernel::utilities::StaticRef;
 
@@ -59,10 +60,17 @@ impl Prci {
     }
 
     pub fn set_clock_frequency(&self, frequency: ClockFrequency) {
-        let _regs = self.registers;
+        let regs = self.registers;
 
         match frequency {
-            ClockFrequency::Freq16Mhz => {}
+            ClockFrequency::Freq16Mhz => {
+                regs.pllcfg
+                    .modify(pllcfg::bypass::SET + pllcfg::refsel::SET);
+                regs.plloutdiv
+                    .modify(plloutdiv::divby1.val(1) + plloutdiv::div.val(0));
+                regs.pllcfg.modify(pllcfg::sel::SET);
+                regs.hfrosccfg.modify(hfrosccfg::enable::CLEAR);
+            }
         };
     }
 }


### PR DESCRIPTION
### Pull Request Overview

Currently the SiFive FE310X chips have do not configure any bits in the Power Reset Clock Interrupt controller driver.

There was a [commit](https://github.com/tock/tock/commit/54d8c9d5c5f2a39321614f3809369abd7fdd2389) trying to decouple the setup done in `main.rs` for a board implementation from what a bootloader configures. But this also assumes that the bootloader leaves the chip running at the external crystal oscilator frequency.

I have found that in the case of the [BBC HiFive Inventor](https://www.hifiveinventor.com/) the bootloader configures the chip to run off the PLL which is configured to give a 100MHz frequency.

So I made the following changes inspired by this [Zephyr template](https://github.com/sifive/zephyr-sifive-freedom-template/blob/master/clock.c)

- bypass and power off the PLL (bypass = 1)
- PLL input driven from external HFXOSC oscillator, then pllout is driven 
    directly by it (refsel = 1)
- set the frequency divider to 1
- drive the final hfclk with the PLL output, bypassed or otherwise (sel = 1)
- disable the ring oscillator

While I got working result only by setting bypass to 1, I thought that disabling the unused ring oscilator and choosing, instead of it, the PLL input the external oscillator to drive the PLL when it will be activated. See the Clock Generation chapther in any of the FE310 chips manual for more details.

### Help Wanted


The changes I made work for the SiFive FE310-G003 chip, but I cannot test them for the FE310-G002 which is featured on the [HiFive1 Rev B](https://www.sifive.com/boards/hifive1-rev-b) board.

@alistair23 could you please test this if it works?
