### PR TITLE
Fix UartMux to be able to use multiple muxes

### DIFF
--- a/boards/acd52832/src/main.rs
+++ b/boards/acd52832/src/main.rs
@@ -326,7 +326,7 @@ pub unsafe fn main() {
 
     // Create a shared UART channel for the console and for kernel debug.
     let uart_mux = components::console::UartMuxComponent::new(rtt, 115200, dynamic_deferred_caller)
-        .finalize(());
+        .finalize(components::uart_mux_component_helper!(64));
 
     // Setup the console.
     let console = components::console::ConsoleComponent::new(

--- a/boards/acd52832/src/main.rs
+++ b/boards/acd52832/src/main.rs
@@ -326,7 +326,7 @@ pub unsafe fn main() {
 
     // Create a shared UART channel for the console and for kernel debug.
     let uart_mux = components::console::UartMuxComponent::new(rtt, 115200, dynamic_deferred_caller)
-        .finalize(components::uart_mux_component_helper!());
+        .finalize(components::uart_mux_component_static!());
 
     // Setup the console.
     let console = components::console::ConsoleComponent::new(
@@ -334,7 +334,7 @@ pub unsafe fn main() {
         capsules::console::DRIVER_NUM,
         uart_mux,
     )
-    .finalize(components::console_component_helper!());
+    .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
     components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
 

--- a/boards/acd52832/src/main.rs
+++ b/boards/acd52832/src/main.rs
@@ -326,7 +326,7 @@ pub unsafe fn main() {
 
     // Create a shared UART channel for the console and for kernel debug.
     let uart_mux = components::console::UartMuxComponent::new(rtt, 115200, dynamic_deferred_caller)
-        .finalize(components::uart_mux_component_helper!(64));
+        .finalize(components::uart_mux_component_helper!());
 
     // Setup the console.
     let console = components::console::ConsoleComponent::new(

--- a/boards/arty_e21/src/main.rs
+++ b/boards/arty_e21/src/main.rs
@@ -7,6 +7,7 @@
 
 use arty_e21_chip::chip::ArtyExxDefaultPeripherals;
 use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
+
 use kernel::capabilities;
 use kernel::component::Component;
 use kernel::dynamic_deferred_call::{DynamicDeferredCall, DynamicDeferredCallClientState};

--- a/boards/arty_e21/src/main.rs
+++ b/boards/arty_e21/src/main.rs
@@ -159,7 +159,7 @@ pub unsafe fn main() {
         115200,
         dynamic_deferred_caller,
     )
-    .finalize(components::uart_mux_component_helper!(64));
+    .finalize(components::uart_mux_component_helper!());
 
     let console = components::console::ConsoleComponent::new(
         board_kernel,

--- a/boards/arty_e21/src/main.rs
+++ b/boards/arty_e21/src/main.rs
@@ -160,14 +160,14 @@ pub unsafe fn main() {
         115200,
         dynamic_deferred_caller,
     )
-    .finalize(components::uart_mux_component_helper!());
+    .finalize(components::uart_mux_component_static!());
 
     let console = components::console::ConsoleComponent::new(
         board_kernel,
         capsules::console::DRIVER_NUM,
         uart_mux,
     )
-    .finalize(components::console_component_helper!());
+    .finalize(components::console_component_static!());
 
     // Create a shared virtualization mux layer on top of a single hardware
     // alarm.

--- a/boards/arty_e21/src/main.rs
+++ b/boards/arty_e21/src/main.rs
@@ -159,7 +159,7 @@ pub unsafe fn main() {
         115200,
         dynamic_deferred_caller,
     )
-    .finalize(());
+    .finalize(components::uart_mux_component_helper!(64));
 
     let console = components::console::ConsoleComponent::new(
         board_kernel,

--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -486,7 +486,7 @@ pub unsafe fn main() {
 
     // Create a shared UART channel for the console and for kernel debug.
     let uart_mux = components::console::UartMuxComponent::new(cdc, 115200, dynamic_deferred_caller)
-        .finalize(components::uart_mux_component_helper!());
+        .finalize(components::uart_mux_component_static!());
 
     // Setup the console.
     let console = components::console::ConsoleComponent::new(
@@ -494,7 +494,7 @@ pub unsafe fn main() {
         capsules::console::DRIVER_NUM,
         uart_mux,
     )
-    .finalize(components::console_component_helper!());
+    .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
     components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
 
@@ -733,7 +733,7 @@ pub unsafe fn main() {
         mux_alarm,
         process_printer,
     )
-    .finalize(components::process_console_component_helper!(
+    .finalize(components::process_console_component_static!(
         nrf52840::rtc::Rtc
     ));
     let _ = pconsole.start();

--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -486,7 +486,7 @@ pub unsafe fn main() {
 
     // Create a shared UART channel for the console and for kernel debug.
     let uart_mux = components::console::UartMuxComponent::new(cdc, 115200, dynamic_deferred_caller)
-        .finalize(());
+        .finalize(components::uart_mux_component_helper!(64));
 
     // Setup the console.
     let console = components::console::ConsoleComponent::new(

--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -486,7 +486,7 @@ pub unsafe fn main() {
 
     // Create a shared UART channel for the console and for kernel debug.
     let uart_mux = components::console::UartMuxComponent::new(cdc, 115200, dynamic_deferred_caller)
-        .finalize(components::uart_mux_component_helper!(64));
+        .finalize(components::uart_mux_component_helper!());
 
     // Setup the console.
     let console = components::console::ConsoleComponent::new(

--- a/boards/components/src/console.rs
+++ b/boards/components/src/console.rs
@@ -35,9 +35,14 @@ use capsules::console::DEFAULT_BUF_SIZE;
 #[macro_export]
 macro_rules! uart_mux_component_helper {
     () => {{
-        $crate::uart_mux_component_helper!(capsules::virtual_uart::RX_BUF_LEN)
+        use capsules::virtual_uart::MuxUart;
+        use core::mem::MaybeUninit;
+        use kernel::static_buf;
+        let UART_MUX = static_buf!(MuxUart<'static>);
+        let RX_BUF = static_buf!([u8; capsules::virtual_uart::RX_BUF_LEN]);
+        (UART_MUX, RX_BUF)
     }};
-    ($rx_buffer_len: expr) => {{
+    ($rx_buffer_len: literal) => {{
         use capsules::virtual_uart::MuxUart;
         use core::mem::MaybeUninit;
         use kernel::static_buf;

--- a/boards/components/src/console.rs
+++ b/boards/components/src/console.rs
@@ -42,7 +42,6 @@ macro_rules! uart_mux_component_static {
     }};
     ($rx_buffer_len: literal) => {{
         use capsules::virtual_uart::MuxUart;
-        use core::mem::MaybeUninit;
         use kernel::static_buf;
         let UART_MUX = static_buf!(MuxUart<'static>);
         let RX_BUF = static_buf!([u8; $rx_buffer_len]);

--- a/boards/components/src/console.rs
+++ b/boards/components/src/console.rs
@@ -35,7 +35,6 @@ use capsules::console::DEFAULT_BUF_SIZE;
 macro_rules! uart_mux_component_static {
     () => {{
         use capsules::virtual_uart::MuxUart;
-        use core::mem::MaybeUninit;
         use kernel::static_buf;
         let UART_MUX = static_buf!(MuxUart<'static>);
         let RX_BUF = static_buf!([u8; capsules::virtual_uart::RX_BUF_LEN]);

--- a/boards/components/src/console.rs
+++ b/boards/components/src/console.rs
@@ -12,7 +12,7 @@
 //! ```rust
 //! let uart_mux = UartMuxComponent::new(&sam4l::usart::USART3,
 //!                                      115200,
-//!                                      deferred_caller).finalize(components::uart_mux_component_helper!(64));
+//!                                      deferred_caller).finalize(components::uart_mux_component_helper!());
 //! let console = ConsoleComponent::new(board_kernel, uart_mux)
 //!    .finalize(console_component_helper!());
 //! ```
@@ -34,7 +34,10 @@ use capsules::console::DEFAULT_BUF_SIZE;
 
 #[macro_export]
 macro_rules! uart_mux_component_helper {
-    ($rx_buffer_len: literal) => {{
+    () => {{
+        $crate::uart_mux_component_helper!(capsules::virtual_uart::RX_BUF_LEN)
+    }};
+    ($rx_buffer_len: expr) => {{
         use capsules::virtual_uart::MuxUart;
         use core::mem::MaybeUninit;
         use kernel::static_buf;

--- a/boards/components/src/process_console.rs
+++ b/boards/components/src/process_console.rs
@@ -27,7 +27,7 @@ use kernel::process::ProcessPrinter;
 use kernel::{static_init, static_init_half};
 
 #[macro_export]
-macro_rules! process_console_component_helper {
+macro_rules! process_console_component_static {
     ($A: ty) => {{
         use capsules::process_console::ProcessConsole;
         use capsules::virtual_alarm::VirtualMuxAlarm;

--- a/boards/esp32-c3-devkitM-1/src/main.rs
+++ b/boards/esp32-c3-devkitM-1/src/main.rs
@@ -172,7 +172,7 @@ unsafe fn setup() -> (
         115200,
         dynamic_deferred_caller,
     )
-    .finalize(components::uart_mux_component_helper!(64));
+    .finalize(components::uart_mux_component_helper!());
 
     let gpio = components::gpio::GpioComponent::new(
         board_kernel,

--- a/boards/esp32-c3-devkitM-1/src/main.rs
+++ b/boards/esp32-c3-devkitM-1/src/main.rs
@@ -172,7 +172,7 @@ unsafe fn setup() -> (
         115200,
         dynamic_deferred_caller,
     )
-    .finalize(());
+    .finalize(components::uart_mux_component_helper!(64));
 
     let gpio = components::gpio::GpioComponent::new(
         board_kernel,

--- a/boards/esp32-c3-devkitM-1/src/main.rs
+++ b/boards/esp32-c3-devkitM-1/src/main.rs
@@ -172,7 +172,7 @@ unsafe fn setup() -> (
         115200,
         dynamic_deferred_caller,
     )
-    .finalize(components::uart_mux_component_helper!());
+    .finalize(components::uart_mux_component_static!());
 
     let gpio = components::gpio::GpioComponent::new(
         board_kernel,
@@ -243,7 +243,7 @@ unsafe fn setup() -> (
         capsules::console::DRIVER_NUM,
         uart_mux,
     )
-    .finalize(components::console_component_helper!());
+    .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
     components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
 
@@ -280,7 +280,7 @@ unsafe fn setup() -> (
         mux_alarm,
         process_printer,
     )
-    .finalize(components::process_console_component_helper!(
+    .finalize(components::process_console_component_static!(
         esp32_c3::timg::TimG
     ));
     let _ = process_console.start();

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -286,7 +286,7 @@ pub unsafe fn main() {
         115200,
         dynamic_deferred_caller,
     )
-    .finalize(());
+    .finalize(components::uart_mux_component_helper!(64));
     uart_mux.initialize();
 
     hil::uart::Transmit::set_transmit_client(&peripherals.usart0, uart_mux);

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -286,7 +286,7 @@ pub unsafe fn main() {
         115200,
         dynamic_deferred_caller,
     )
-    .finalize(components::uart_mux_component_helper!());
+    .finalize(components::uart_mux_component_static!());
     uart_mux.initialize();
 
     hil::uart::Transmit::set_transmit_client(&peripherals.usart0, uart_mux);
@@ -302,14 +302,14 @@ pub unsafe fn main() {
         capsules::console::DRIVER_NUM,
         uart_mux,
     )
-    .finalize(components::console_component_helper!());
+    .finalize(components::console_component_static!());
     let process_console = components::process_console::ProcessConsoleComponent::new(
         board_kernel,
         uart_mux,
         mux_alarm,
         process_printer,
     )
-    .finalize(components::process_console_component_helper!(
+    .finalize(components::process_console_component_static!(
         sam4l::ast::Ast<'static>
     ));
     components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -286,7 +286,7 @@ pub unsafe fn main() {
         115200,
         dynamic_deferred_caller,
     )
-    .finalize(components::uart_mux_component_helper!(64));
+    .finalize(components::uart_mux_component_helper!());
     uart_mux.initialize();
 
     hil::uart::Transmit::set_transmit_client(&peripherals.usart0, uart_mux);

--- a/boards/hifive1/src/main.rs
+++ b/boards/hifive1/src/main.rs
@@ -173,7 +173,7 @@ pub unsafe fn main() {
         115200,
         dynamic_deferred_caller,
     )
-    .finalize(());
+    .finalize(components::uart_mux_component_helper!(64));
 
     // LEDs
     let led = components::led::LedsComponent::new().finalize(components::led_component_helper!(

--- a/boards/hifive1/src/main.rs
+++ b/boards/hifive1/src/main.rs
@@ -173,7 +173,7 @@ pub unsafe fn main() {
         115200,
         dynamic_deferred_caller,
     )
-    .finalize(components::uart_mux_component_helper!(64));
+    .finalize(components::uart_mux_component_helper!());
 
     // LEDs
     let led = components::led::LedsComponent::new().finalize(components::led_component_helper!(

--- a/boards/hifive1/src/main.rs
+++ b/boards/hifive1/src/main.rs
@@ -243,7 +243,7 @@ pub unsafe fn main() {
         mux_alarm,
         process_printer,
     )
-    .finalize(components::process_console_component_helper!(
+    .finalize(components::process_console_component_static!(
         sifive::clint::Clint
     ));
     let _ = process_console.start();

--- a/boards/hifive1/src/main.rs
+++ b/boards/hifive1/src/main.rs
@@ -173,7 +173,7 @@ pub unsafe fn main() {
         115200,
         dynamic_deferred_caller,
     )
-    .finalize(components::uart_mux_component_helper!());
+    .finalize(components::uart_mux_component_static!());
 
     // LEDs
     let led = components::led::LedsComponent::new().finalize(components::led_component_helper!(
@@ -263,7 +263,7 @@ pub unsafe fn main() {
         capsules::console::DRIVER_NUM,
         uart_mux,
     )
-    .finalize(components::console_component_helper!());
+    .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
     components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
 

--- a/boards/hifive_inventor/src/main.rs
+++ b/boards/hifive_inventor/src/main.rs
@@ -169,7 +169,7 @@ pub unsafe fn main() {
         115200,
         dynamic_deferred_caller,
     )
-    .finalize(());
+    .finalize(components::uart_mux_component_static!());
 
     let hardware_timer = static_init!(
         sifive::clint::Clint,
@@ -242,7 +242,7 @@ pub unsafe fn main() {
         capsules::console::DRIVER_NUM,
         uart_mux,
     )
-    .finalize(components::console_component_helper!());
+    .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
     components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
 

--- a/boards/hifive_inventor/src/main.rs
+++ b/boards/hifive_inventor/src/main.rs
@@ -222,7 +222,7 @@ pub unsafe fn main() {
         mux_alarm,
         process_printer,
     )
-    .finalize(components::process_console_component_helper!(
+    .finalize(components::process_console_component_static!(
         sifive::clint::Clint
     ));
     let _ = process_console.start();

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -365,7 +365,7 @@ pub unsafe fn main() {
     // Create a shared UART channel for the consoles and for kernel debug.
     peripherals.usart3.set_mode(sam4l::usart::UsartMode::Uart);
     let uart_mux = UartMuxComponent::new(&peripherals.usart3, 115200, dynamic_deferred_caller)
-        .finalize(components::uart_mux_component_helper!());
+        .finalize(components::uart_mux_component_static!());
 
     // # TIMER
     let mux_alarm = AlarmMuxComponent::new(&peripherals.ast)
@@ -375,11 +375,11 @@ pub unsafe fn main() {
         .finalize(components::alarm_component_helper!(sam4l::ast::Ast));
 
     let pconsole = ProcessConsoleComponent::new(board_kernel, uart_mux, mux_alarm, process_printer)
-        .finalize(components::process_console_component_helper!(
+        .finalize(components::process_console_component_static!(
             sam4l::ast::Ast
         ));
     let console = ConsoleComponent::new(board_kernel, capsules::console::DRIVER_NUM, uart_mux)
-        .finalize(components::console_component_helper!());
+        .finalize(components::console_component_static!());
     DebugWriterComponent::new(uart_mux).finalize(());
 
     // Allow processes to communicate over BLE through the nRF51822

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -364,8 +364,8 @@ pub unsafe fn main() {
     // # CONSOLE
     // Create a shared UART channel for the consoles and for kernel debug.
     peripherals.usart3.set_mode(sam4l::usart::UsartMode::Uart);
-    let uart_mux =
-        UartMuxComponent::new(&peripherals.usart3, 115200, dynamic_deferred_caller).finalize(());
+    let uart_mux = UartMuxComponent::new(&peripherals.usart3, 115200, dynamic_deferred_caller)
+        .finalize(components::uart_mux_component_helper!(64));
 
     // # TIMER
     let mux_alarm = AlarmMuxComponent::new(&peripherals.ast)

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -365,7 +365,7 @@ pub unsafe fn main() {
     // Create a shared UART channel for the consoles and for kernel debug.
     peripherals.usart3.set_mode(sam4l::usart::UsartMode::Uart);
     let uart_mux = UartMuxComponent::new(&peripherals.usart3, 115200, dynamic_deferred_caller)
-        .finalize(components::uart_mux_component_helper!(64));
+        .finalize(components::uart_mux_component_helper!());
 
     // # TIMER
     let mux_alarm = AlarmMuxComponent::new(&peripherals.ast)

--- a/boards/imxrt1050-evkb/src/main.rs
+++ b/boards/imxrt1050-evkb/src/main.rs
@@ -314,7 +314,7 @@ pub unsafe fn main() {
         115200,
         dynamic_deferred_caller,
     )
-    .finalize(components::uart_mux_component_helper!(64));
+    .finalize(components::uart_mux_component_helper!());
     io::WRITER.set_initialized();
 
     // Create capabilities that the board needs to call certain protected kernel

--- a/boards/imxrt1050-evkb/src/main.rs
+++ b/boards/imxrt1050-evkb/src/main.rs
@@ -314,7 +314,7 @@ pub unsafe fn main() {
         115200,
         dynamic_deferred_caller,
     )
-    .finalize(());
+    .finalize(components::uart_mux_component_helper!(64));
     io::WRITER.set_initialized();
 
     // Create capabilities that the board needs to call certain protected kernel

--- a/boards/imxrt1050-evkb/src/main.rs
+++ b/boards/imxrt1050-evkb/src/main.rs
@@ -314,7 +314,7 @@ pub unsafe fn main() {
         115200,
         dynamic_deferred_caller,
     )
-    .finalize(components::uart_mux_component_helper!());
+    .finalize(components::uart_mux_component_static!());
     io::WRITER.set_initialized();
 
     // Create capabilities that the board needs to call certain protected kernel
@@ -330,7 +330,7 @@ pub unsafe fn main() {
         capsules::console::DRIVER_NUM,
         lpuart_mux,
     )
-    .finalize(components::console_component_helper!());
+    .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
     components::debug_writer::DebugWriterComponent::new(lpuart_mux).finalize(());
 
@@ -493,7 +493,7 @@ pub unsafe fn main() {
         mux_alarm,
         process_printer,
     )
-    .finalize(components::process_console_component_helper!(
+    .finalize(components::process_console_component_static!(
         imxrt1050::gpt::Gpt1
     ));
     let _ = process_console.start();

--- a/boards/litex/arty/src/main.rs
+++ b/boards/litex/arty/src/main.rs
@@ -408,7 +408,7 @@ pub unsafe fn main() {
         socc::UART_BAUDRATE,
         dynamic_deferred_caller,
     )
-    .finalize(components::uart_mux_component_helper!());
+    .finalize(components::uart_mux_component_static!());
 
     // ---------- ETHERNET ----------
 
@@ -491,7 +491,7 @@ pub unsafe fn main() {
         mux_alarm,
         process_printer,
     )
-    .finalize(components::process_console_component_helper!(
+    .finalize(components::process_console_component_static!(
         litex_vexriscv::timer::LiteXAlarm<
             'static,
             'static,
@@ -506,7 +506,7 @@ pub unsafe fn main() {
         capsules::console::DRIVER_NUM,
         uart_mux,
     )
-    .finalize(components::console_component_helper!());
+    .finalize(components::console_component_static!());
 
     // Create the debugger object that handles calls to `debug!()`.
     components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());

--- a/boards/litex/arty/src/main.rs
+++ b/boards/litex/arty/src/main.rs
@@ -7,6 +7,7 @@
 #![cfg_attr(not(doc), no_main)]
 
 use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
+
 use kernel::capabilities;
 use kernel::component::Component;
 use kernel::dynamic_deferred_call::{DynamicDeferredCall, DynamicDeferredCallClientState};
@@ -407,7 +408,7 @@ pub unsafe fn main() {
         socc::UART_BAUDRATE,
         dynamic_deferred_caller,
     )
-    .finalize(());
+    .finalize(components::uart_mux_component_helper!(64));
 
     // ---------- ETHERNET ----------
 

--- a/boards/litex/arty/src/main.rs
+++ b/boards/litex/arty/src/main.rs
@@ -408,7 +408,7 @@ pub unsafe fn main() {
         socc::UART_BAUDRATE,
         dynamic_deferred_caller,
     )
-    .finalize(components::uart_mux_component_helper!(64));
+    .finalize(components::uart_mux_component_helper!());
 
     // ---------- ETHERNET ----------
 

--- a/boards/litex/sim/src/main.rs
+++ b/boards/litex/sim/src/main.rs
@@ -385,7 +385,7 @@ pub unsafe fn main() {
     // verilated simulation.
     let uart_mux =
         components::console::UartMuxComponent::new(uart0, 115200, dynamic_deferred_caller)
-            .finalize(components::uart_mux_component_helper!());
+            .finalize(components::uart_mux_component_static!());
 
     // ---------- ETHERNET ----------
 
@@ -579,7 +579,7 @@ pub unsafe fn main() {
         capsules::console::DRIVER_NUM,
         uart_mux,
     )
-    .finalize(components::console_component_helper!());
+    .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
     components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
 

--- a/boards/litex/sim/src/main.rs
+++ b/boards/litex/sim/src/main.rs
@@ -385,7 +385,7 @@ pub unsafe fn main() {
     // verilated simulation.
     let uart_mux =
         components::console::UartMuxComponent::new(uart0, 115200, dynamic_deferred_caller)
-            .finalize(());
+            .finalize(components::uart_mux_component_helper!(64));
 
     // ---------- ETHERNET ----------
 

--- a/boards/litex/sim/src/main.rs
+++ b/boards/litex/sim/src/main.rs
@@ -385,7 +385,7 @@ pub unsafe fn main() {
     // verilated simulation.
     let uart_mux =
         components::console::UartMuxComponent::new(uart0, 115200, dynamic_deferred_caller)
-            .finalize(components::uart_mux_component_helper!(64));
+            .finalize(components::uart_mux_component_helper!());
 
     // ---------- ETHERNET ----------
 

--- a/boards/microbit_v2/src/main.rs
+++ b/boards/microbit_v2/src/main.rs
@@ -388,7 +388,7 @@ pub unsafe fn main() {
         115200,
         dynamic_deferred_caller,
     )
-    .finalize(components::uart_mux_component_helper!());
+    .finalize(components::uart_mux_component_static!());
 
     // Setup the console.
     let console = components::console::ConsoleComponent::new(
@@ -396,7 +396,7 @@ pub unsafe fn main() {
         capsules::console::DRIVER_NUM,
         uart_mux,
     )
-    .finalize(components::console_component_helper!());
+    .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
     components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
 
@@ -645,7 +645,7 @@ pub unsafe fn main() {
         mux_alarm,
         process_printer,
     )
-    .finalize(components::process_console_component_helper!(
+    .finalize(components::process_console_component_static!(
         nrf52833::rtc::Rtc
     ));
     let _ = _process_console.start();

--- a/boards/microbit_v2/src/main.rs
+++ b/boards/microbit_v2/src/main.rs
@@ -388,7 +388,7 @@ pub unsafe fn main() {
         115200,
         dynamic_deferred_caller,
     )
-    .finalize(components::uart_mux_component_helper!(64));
+    .finalize(components::uart_mux_component_helper!());
 
     // Setup the console.
     let console = components::console::ConsoleComponent::new(

--- a/boards/microbit_v2/src/main.rs
+++ b/boards/microbit_v2/src/main.rs
@@ -388,7 +388,7 @@ pub unsafe fn main() {
         115200,
         dynamic_deferred_caller,
     )
-    .finalize(());
+    .finalize(components::uart_mux_component_helper!(64));
 
     // Setup the console.
     let console = components::console::ConsoleComponent::new(

--- a/boards/msp_exp432p401r/src/main.rs
+++ b/boards/msp_exp432p401r/src/main.rs
@@ -338,7 +338,7 @@ pub unsafe fn main() {
         115200,
         dynamic_deferred_caller,
     )
-    .finalize(components::uart_mux_component_helper!(64));
+    .finalize(components::uart_mux_component_helper!());
 
     // Setup the console.
     let console = components::console::ConsoleComponent::new(

--- a/boards/msp_exp432p401r/src/main.rs
+++ b/boards/msp_exp432p401r/src/main.rs
@@ -338,7 +338,7 @@ pub unsafe fn main() {
         115200,
         dynamic_deferred_caller,
     )
-    .finalize(components::uart_mux_component_helper!());
+    .finalize(components::uart_mux_component_static!());
 
     // Setup the console.
     let console = components::console::ConsoleComponent::new(
@@ -346,7 +346,7 @@ pub unsafe fn main() {
         capsules::console::DRIVER_NUM,
         uart_mux,
     )
-    .finalize(components::console_component_helper!());
+    .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
     components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
 

--- a/boards/msp_exp432p401r/src/main.rs
+++ b/boards/msp_exp432p401r/src/main.rs
@@ -338,7 +338,7 @@ pub unsafe fn main() {
         115200,
         dynamic_deferred_caller,
     )
-    .finalize(());
+    .finalize(components::uart_mux_component_helper!(64));
 
     // Setup the console.
     let console = components::console::ConsoleComponent::new(

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -369,7 +369,7 @@ pub unsafe fn main() {
 
     // Create a shared UART channel for the console and for kernel debug.
     let uart_mux = components::console::UartMuxComponent::new(cdc, 115200, dynamic_deferred_caller)
-        .finalize(components::uart_mux_component_helper!());
+        .finalize(components::uart_mux_component_static!());
 
     let pconsole = components::process_console::ProcessConsoleComponent::new(
         board_kernel,
@@ -377,7 +377,7 @@ pub unsafe fn main() {
         mux_alarm,
         process_printer,
     )
-    .finalize(components::process_console_component_helper!(
+    .finalize(components::process_console_component_static!(
         nrf52::rtc::Rtc<'static>
     ));
 
@@ -387,7 +387,7 @@ pub unsafe fn main() {
         capsules::console::DRIVER_NUM,
         uart_mux,
     )
-    .finalize(components::console_component_helper!());
+    .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
     components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
 

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -369,7 +369,7 @@ pub unsafe fn main() {
 
     // Create a shared UART channel for the console and for kernel debug.
     let uart_mux = components::console::UartMuxComponent::new(cdc, 115200, dynamic_deferred_caller)
-        .finalize(components::uart_mux_component_helper!(64));
+        .finalize(components::uart_mux_component_helper!());
 
     let pconsole = components::process_console::ProcessConsoleComponent::new(
         board_kernel,

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -369,7 +369,7 @@ pub unsafe fn main() {
 
     // Create a shared UART channel for the console and for kernel debug.
     let uart_mux = components::console::UartMuxComponent::new(cdc, 115200, dynamic_deferred_caller)
-        .finalize(());
+        .finalize(components::uart_mux_component_helper!(64));
 
     let pconsole = components::process_console::ProcessConsoleComponent::new(
         board_kernel,

--- a/boards/nano_rp2040_connect/src/main.rs
+++ b/boards/nano_rp2040_connect/src/main.rs
@@ -329,7 +329,7 @@ pub unsafe fn main() {
         115200,
         dynamic_deferred_caller,
     )
-    .finalize(components::uart_mux_component_helper!());
+    .finalize(components::uart_mux_component_static!());
 
     // Setup the console.
     let console = components::console::ConsoleComponent::new(
@@ -337,7 +337,7 @@ pub unsafe fn main() {
         capsules::console::DRIVER_NUM,
         uart_mux,
     )
-    .finalize(components::console_component_helper!());
+    .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
     components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
 
@@ -488,7 +488,7 @@ pub unsafe fn main() {
         mux_alarm,
         process_printer,
     )
-    .finalize(components::process_console_component_helper!(RPTimer));
+    .finalize(components::process_console_component_static!(RPTimer));
     let _ = process_console.start();
 
     let scheduler = components::sched::round_robin::RoundRobinComponent::new(&PROCESSES)

--- a/boards/nano_rp2040_connect/src/main.rs
+++ b/boards/nano_rp2040_connect/src/main.rs
@@ -329,7 +329,7 @@ pub unsafe fn main() {
         115200,
         dynamic_deferred_caller,
     )
-    .finalize(components::uart_mux_component_helper!(64));
+    .finalize(components::uart_mux_component_helper!());
 
     // Setup the console.
     let console = components::console::ConsoleComponent::new(

--- a/boards/nano_rp2040_connect/src/main.rs
+++ b/boards/nano_rp2040_connect/src/main.rs
@@ -329,7 +329,7 @@ pub unsafe fn main() {
         115200,
         dynamic_deferred_caller,
     )
-    .finalize(());
+    .finalize(components::uart_mux_component_helper!(64));
 
     // Setup the console.
     let console = components::console::ConsoleComponent::new(

--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -312,7 +312,7 @@ pub unsafe fn main() {
     // Create a shared UART channel for the console and for kernel debug.
     let uart_mux =
         components::console::UartMuxComponent::new(channel, 115200, dynamic_deferred_caller)
-            .finalize(components::uart_mux_component_helper!());
+            .finalize(components::uart_mux_component_static!());
 
     let pconsole = components::process_console::ProcessConsoleComponent::new(
         board_kernel,
@@ -320,7 +320,7 @@ pub unsafe fn main() {
         mux_alarm,
         process_printer,
     )
-    .finalize(components::process_console_component_helper!(
+    .finalize(components::process_console_component_static!(
         nrf52840::rtc::Rtc<'static>
     ));
 
@@ -330,7 +330,7 @@ pub unsafe fn main() {
         capsules::console::DRIVER_NUM,
         uart_mux,
     )
-    .finalize(components::console_component_helper!());
+    .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
     components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
 

--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -312,7 +312,7 @@ pub unsafe fn main() {
     // Create a shared UART channel for the console and for kernel debug.
     let uart_mux =
         components::console::UartMuxComponent::new(channel, 115200, dynamic_deferred_caller)
-            .finalize(());
+            .finalize(components::uart_mux_component_helper!(64));
 
     let pconsole = components::process_console::ProcessConsoleComponent::new(
         board_kernel,

--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -312,7 +312,7 @@ pub unsafe fn main() {
     // Create a shared UART channel for the console and for kernel debug.
     let uart_mux =
         components::console::UartMuxComponent::new(channel, 115200, dynamic_deferred_caller)
-            .finalize(components::uart_mux_component_helper!(64));
+            .finalize(components::uart_mux_component_helper!());
 
     let pconsole = components::process_console::ProcessConsoleComponent::new(
         board_kernel,

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -420,7 +420,7 @@ pub unsafe fn main() {
     // Create a shared UART channel for the console and for kernel debug.
     let uart_mux =
         components::console::UartMuxComponent::new(channel, 115200, dynamic_deferred_caller)
-            .finalize(components::uart_mux_component_helper!(64));
+            .finalize(components::uart_mux_component_helper!());
 
     let pconsole = components::process_console::ProcessConsoleComponent::new(
         board_kernel,

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -420,7 +420,7 @@ pub unsafe fn main() {
     // Create a shared UART channel for the console and for kernel debug.
     let uart_mux =
         components::console::UartMuxComponent::new(channel, 115200, dynamic_deferred_caller)
-            .finalize(());
+            .finalize(components::uart_mux_component_helper!(64));
 
     let pconsole = components::process_console::ProcessConsoleComponent::new(
         board_kernel,

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -420,7 +420,7 @@ pub unsafe fn main() {
     // Create a shared UART channel for the console and for kernel debug.
     let uart_mux =
         components::console::UartMuxComponent::new(channel, 115200, dynamic_deferred_caller)
-            .finalize(components::uart_mux_component_helper!());
+            .finalize(components::uart_mux_component_static!());
 
     let pconsole = components::process_console::ProcessConsoleComponent::new(
         board_kernel,
@@ -428,7 +428,7 @@ pub unsafe fn main() {
         mux_alarm,
         process_printer,
     )
-    .finalize(components::process_console_component_helper!(
+    .finalize(components::process_console_component_static!(
         nrf52840::rtc::Rtc<'static>
     ));
 
@@ -438,7 +438,7 @@ pub unsafe fn main() {
         capsules::console::DRIVER_NUM,
         uart_mux,
     )
-    .finalize(components::console_component_helper!());
+    .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
     components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
 

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -370,7 +370,7 @@ pub unsafe fn main() {
     // Create a shared UART channel for the console and for kernel debug.
     let uart_mux =
         components::console::UartMuxComponent::new(channel, 115200, dynamic_deferred_caller)
-            .finalize(components::uart_mux_component_helper!(64));
+            .finalize(components::uart_mux_component_helper!());
 
     let pconsole = components::process_console::ProcessConsoleComponent::new(
         board_kernel,

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -370,7 +370,7 @@ pub unsafe fn main() {
     // Create a shared UART channel for the console and for kernel debug.
     let uart_mux =
         components::console::UartMuxComponent::new(channel, 115200, dynamic_deferred_caller)
-            .finalize(());
+            .finalize(components::uart_mux_component_helper!(64));
 
     let pconsole = components::process_console::ProcessConsoleComponent::new(
         board_kernel,

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -370,7 +370,7 @@ pub unsafe fn main() {
     // Create a shared UART channel for the console and for kernel debug.
     let uart_mux =
         components::console::UartMuxComponent::new(channel, 115200, dynamic_deferred_caller)
-            .finalize(components::uart_mux_component_helper!());
+            .finalize(components::uart_mux_component_static!());
 
     let pconsole = components::process_console::ProcessConsoleComponent::new(
         board_kernel,
@@ -378,7 +378,7 @@ pub unsafe fn main() {
         mux_alarm,
         process_printer,
     )
-    .finalize(components::process_console_component_helper!(Rtc<'static>));
+    .finalize(components::process_console_component_static!(Rtc<'static>));
 
     // Setup the console.
     let console = components::console::ConsoleComponent::new(
@@ -386,7 +386,7 @@ pub unsafe fn main() {
         capsules::console::DRIVER_NUM,
         uart_mux,
     )
-    .finalize(components::console_component_helper!());
+    .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
     components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
 

--- a/boards/nucleo_f429zi/src/main.rs
+++ b/boards/nucleo_f429zi/src/main.rs
@@ -327,7 +327,7 @@ pub unsafe fn main() {
         115200,
         dynamic_deferred_caller,
     )
-    .finalize(components::uart_mux_component_helper!(64));
+    .finalize(components::uart_mux_component_helper!());
 
     io::WRITER.set_initialized();
 

--- a/boards/nucleo_f429zi/src/main.rs
+++ b/boards/nucleo_f429zi/src/main.rs
@@ -327,7 +327,7 @@ pub unsafe fn main() {
         115200,
         dynamic_deferred_caller,
     )
-    .finalize(());
+    .finalize(components::uart_mux_component_helper!(64));
 
     io::WRITER.set_initialized();
 

--- a/boards/nucleo_f429zi/src/main.rs
+++ b/boards/nucleo_f429zi/src/main.rs
@@ -327,7 +327,7 @@ pub unsafe fn main() {
         115200,
         dynamic_deferred_caller,
     )
-    .finalize(components::uart_mux_component_helper!());
+    .finalize(components::uart_mux_component_static!());
 
     io::WRITER.set_initialized();
 
@@ -344,7 +344,7 @@ pub unsafe fn main() {
         capsules::console::DRIVER_NUM,
         uart_mux,
     )
-    .finalize(components::console_component_helper!());
+    .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
     components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
 
@@ -563,7 +563,7 @@ pub unsafe fn main() {
         mux_alarm,
         process_printer,
     )
-    .finalize(components::process_console_component_helper!(
+    .finalize(components::process_console_component_static!(
         stm32f429zi::tim2::Tim2
     ));
     let _ = process_console.start();

--- a/boards/nucleo_f446re/src/main.rs
+++ b/boards/nucleo_f446re/src/main.rs
@@ -321,7 +321,7 @@ pub unsafe fn main() {
         115200,
         dynamic_deferred_caller,
     )
-    .finalize(());
+    .finalize(components::uart_mux_component_helper!(64));
 
     // `finalize()` configures the underlying USART, so we need to
     // tell `send_byte()` not to configure the USART again.

--- a/boards/nucleo_f446re/src/main.rs
+++ b/boards/nucleo_f446re/src/main.rs
@@ -321,7 +321,7 @@ pub unsafe fn main() {
         115200,
         dynamic_deferred_caller,
     )
-    .finalize(components::uart_mux_component_helper!(64));
+    .finalize(components::uart_mux_component_helper!());
 
     // `finalize()` configures the underlying USART, so we need to
     // tell `send_byte()` not to configure the USART again.

--- a/boards/nucleo_f446re/src/main.rs
+++ b/boards/nucleo_f446re/src/main.rs
@@ -321,7 +321,7 @@ pub unsafe fn main() {
         115200,
         dynamic_deferred_caller,
     )
-    .finalize(components::uart_mux_component_helper!());
+    .finalize(components::uart_mux_component_static!());
 
     // `finalize()` configures the underlying USART, so we need to
     // tell `send_byte()` not to configure the USART again.
@@ -340,7 +340,7 @@ pub unsafe fn main() {
         capsules::console::DRIVER_NUM,
         uart_mux,
     )
-    .finalize(components::console_component_helper!());
+    .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
     components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
 
@@ -486,7 +486,7 @@ pub unsafe fn main() {
         mux_alarm,
         process_printer,
     )
-    .finalize(components::process_console_component_helper!(
+    .finalize(components::process_console_component_static!(
         stm32f446re::tim2::Tim2
     ));
     let _ = process_console.start();

--- a/boards/opentitan/src/main.rs
+++ b/boards/opentitan/src/main.rs
@@ -257,7 +257,7 @@ unsafe fn setup() -> (
         earlgrey::uart::UART0_BAUDRATE,
         dynamic_deferred_caller,
     )
-    .finalize(components::uart_mux_component_helper!());
+    .finalize(components::uart_mux_component_static!());
 
     // LEDs
     // Start with half on and half off
@@ -352,7 +352,7 @@ unsafe fn setup() -> (
         capsules::console::DRIVER_NUM,
         uart_mux,
     )
-    .finalize(components::console_component_helper!());
+    .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
     components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
 

--- a/boards/opentitan/src/main.rs
+++ b/boards/opentitan/src/main.rs
@@ -257,7 +257,7 @@ unsafe fn setup() -> (
         earlgrey::uart::UART0_BAUDRATE,
         dynamic_deferred_caller,
     )
-    .finalize(());
+    .finalize(components::uart_mux_component_helper!(64));
 
     // LEDs
     // Start with half on and half off

--- a/boards/opentitan/src/main.rs
+++ b/boards/opentitan/src/main.rs
@@ -257,7 +257,7 @@ unsafe fn setup() -> (
         earlgrey::uart::UART0_BAUDRATE,
         dynamic_deferred_caller,
     )
-    .finalize(components::uart_mux_component_helper!(64));
+    .finalize(components::uart_mux_component_helper!());
 
     // LEDs
     // Start with half on and half off

--- a/boards/particle_boron/src/main.rs
+++ b/boards/particle_boron/src/main.rs
@@ -398,7 +398,7 @@ pub unsafe fn main() {
 
     // Create a shared UART channel for the console and for kernel debug.
     let uart_mux = components::console::UartMuxComponent::new(cdc, 115200, dynamic_deferred_caller)
-        .finalize(());
+        .finalize(components::uart_mux_component_helper!());
 
     let pconsole = components::process_console::ProcessConsoleComponent::new(
         board_kernel,

--- a/boards/particle_boron/src/main.rs
+++ b/boards/particle_boron/src/main.rs
@@ -398,7 +398,7 @@ pub unsafe fn main() {
 
     // Create a shared UART channel for the console and for kernel debug.
     let uart_mux = components::console::UartMuxComponent::new(cdc, 115200, dynamic_deferred_caller)
-        .finalize(components::uart_mux_component_helper!());
+        .finalize(components::uart_mux_component_static!());
 
     let pconsole = components::process_console::ProcessConsoleComponent::new(
         board_kernel,
@@ -406,7 +406,7 @@ pub unsafe fn main() {
         mux_alarm,
         process_printer,
     )
-    .finalize(components::process_console_component_helper!(
+    .finalize(components::process_console_component_static!(
         nrf52::rtc::Rtc<'static>
     ));
 
@@ -416,7 +416,7 @@ pub unsafe fn main() {
         capsules::console::DRIVER_NUM,
         uart_mux,
     )
-    .finalize(components::console_component_helper!());
+    .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
     components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
 

--- a/boards/pico_explorer_base/src/main.rs
+++ b/boards/pico_explorer_base/src/main.rs
@@ -334,7 +334,7 @@ pub unsafe fn main() {
         115200,
         dynamic_deferred_caller,
     )
-    .finalize(components::uart_mux_component_helper!(64));
+    .finalize(components::uart_mux_component_helper!());
 
     // Setup the console.
     let console = components::console::ConsoleComponent::new(

--- a/boards/pico_explorer_base/src/main.rs
+++ b/boards/pico_explorer_base/src/main.rs
@@ -334,7 +334,7 @@ pub unsafe fn main() {
         115200,
         dynamic_deferred_caller,
     )
-    .finalize(components::uart_mux_component_helper!());
+    .finalize(components::uart_mux_component_static!());
 
     // Setup the console.
     let console = components::console::ConsoleComponent::new(
@@ -342,7 +342,7 @@ pub unsafe fn main() {
         capsules::console::DRIVER_NUM,
         uart_mux,
     )
-    .finalize(components::console_component_helper!());
+    .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
     components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
 
@@ -507,7 +507,7 @@ pub unsafe fn main() {
         mux_alarm,
         process_printer,
     )
-    .finalize(components::process_console_component_helper!(RPTimer));
+    .finalize(components::process_console_component_static!(RPTimer));
     let _ = process_console.start();
 
     let scheduler = components::sched::round_robin::RoundRobinComponent::new(&PROCESSES)

--- a/boards/pico_explorer_base/src/main.rs
+++ b/boards/pico_explorer_base/src/main.rs
@@ -334,7 +334,7 @@ pub unsafe fn main() {
         115200,
         dynamic_deferred_caller,
     )
-    .finalize(());
+    .finalize(components::uart_mux_component_helper!(64));
 
     // Setup the console.
     let console = components::console::ConsoleComponent::new(

--- a/boards/qemu_rv32_virt/src/main.rs
+++ b/boards/qemu_rv32_virt/src/main.rs
@@ -162,7 +162,7 @@ pub unsafe fn main() {
         115200,
         dynamic_deferred_caller,
     )
-    .finalize(());
+    .finalize(components::uart_mux_component_helper!(64));
 
     // Use the RISC-V machine timer timesource
     let hardware_timer = static_init!(

--- a/boards/qemu_rv32_virt/src/main.rs
+++ b/boards/qemu_rv32_virt/src/main.rs
@@ -162,7 +162,7 @@ pub unsafe fn main() {
         115200,
         dynamic_deferred_caller,
     )
-    .finalize(components::uart_mux_component_helper!());
+    .finalize(components::uart_mux_component_static!());
 
     // Use the RISC-V machine timer timesource
     let hardware_timer = static_init!(
@@ -230,7 +230,7 @@ pub unsafe fn main() {
         capsules::console::DRIVER_NUM,
         uart_mux,
     )
-    .finalize(components::console_component_helper!());
+    .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
     components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
 

--- a/boards/qemu_rv32_virt/src/main.rs
+++ b/boards/qemu_rv32_virt/src/main.rs
@@ -162,7 +162,7 @@ pub unsafe fn main() {
         115200,
         dynamic_deferred_caller,
     )
-    .finalize(components::uart_mux_component_helper!(64));
+    .finalize(components::uart_mux_component_helper!());
 
     // Use the RISC-V machine timer timesource
     let hardware_timer = static_init!(

--- a/boards/raspberry_pi_pico/src/main.rs
+++ b/boards/raspberry_pi_pico/src/main.rs
@@ -332,7 +332,7 @@ pub unsafe fn main() {
         115200,
         dynamic_deferred_caller,
     )
-    .finalize(components::uart_mux_component_helper!());
+    .finalize(components::uart_mux_component_static!());
 
     // Setup the console.
     let console = components::console::ConsoleComponent::new(
@@ -340,7 +340,7 @@ pub unsafe fn main() {
         capsules::console::DRIVER_NUM,
         uart_mux,
     )
-    .finalize(components::console_component_helper!());
+    .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
     components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
 
@@ -446,7 +446,7 @@ pub unsafe fn main() {
         mux_alarm,
         process_printer,
     )
-    .finalize(components::process_console_component_helper!(RPTimer));
+    .finalize(components::process_console_component_static!(RPTimer));
     let _ = process_console.start();
 
     let sda_pin = peripherals.pins.get_pin(RPGpio::GPIO4);

--- a/boards/raspberry_pi_pico/src/main.rs
+++ b/boards/raspberry_pi_pico/src/main.rs
@@ -332,7 +332,7 @@ pub unsafe fn main() {
         115200,
         dynamic_deferred_caller,
     )
-    .finalize(components::uart_mux_component_helper!(64));
+    .finalize(components::uart_mux_component_helper!());
 
     // Setup the console.
     let console = components::console::ConsoleComponent::new(

--- a/boards/raspberry_pi_pico/src/main.rs
+++ b/boards/raspberry_pi_pico/src/main.rs
@@ -332,7 +332,7 @@ pub unsafe fn main() {
         115200,
         dynamic_deferred_caller,
     )
-    .finalize(());
+    .finalize(components::uart_mux_component_helper!(64));
 
     // Setup the console.
     let console = components::console::ConsoleComponent::new(

--- a/boards/redboard_artemis_nano/src/main.rs
+++ b/boards/redboard_artemis_nano/src/main.rs
@@ -208,7 +208,7 @@ unsafe fn setup() -> (
         115200,
         dynamic_deferred_caller,
     )
-    .finalize(components::uart_mux_component_helper!());
+    .finalize(components::uart_mux_component_static!());
 
     // Setup the console.
     let console = components::console::ConsoleComponent::new(
@@ -216,7 +216,7 @@ unsafe fn setup() -> (
         capsules::console::DRIVER_NUM,
         uart_mux,
     )
-    .finalize(components::console_component_helper!());
+    .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
     components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
 

--- a/boards/redboard_artemis_nano/src/main.rs
+++ b/boards/redboard_artemis_nano/src/main.rs
@@ -208,7 +208,7 @@ unsafe fn setup() -> (
         115200,
         dynamic_deferred_caller,
     )
-    .finalize(components::uart_mux_component_helper!(64));
+    .finalize(components::uart_mux_component_helper!());
 
     // Setup the console.
     let console = components::console::ConsoleComponent::new(

--- a/boards/redboard_artemis_nano/src/main.rs
+++ b/boards/redboard_artemis_nano/src/main.rs
@@ -208,7 +208,7 @@ unsafe fn setup() -> (
         115200,
         dynamic_deferred_caller,
     )
-    .finalize(());
+    .finalize(components::uart_mux_component_helper!(64));
 
     // Setup the console.
     let console = components::console::ConsoleComponent::new(

--- a/boards/redboard_redv/src/main.rs
+++ b/boards/redboard_redv/src/main.rs
@@ -166,7 +166,7 @@ pub unsafe fn main() {
         115200,
         dynamic_deferred_caller,
     )
-    .finalize(components::uart_mux_component_helper!(64));
+    .finalize(components::uart_mux_component_helper!());
 
     // LEDs
     let led = components::led::LedsComponent::new().finalize(components::led_component_helper!(

--- a/boards/redboard_redv/src/main.rs
+++ b/boards/redboard_redv/src/main.rs
@@ -166,7 +166,7 @@ pub unsafe fn main() {
         115200,
         dynamic_deferred_caller,
     )
-    .finalize(components::uart_mux_component_helper!());
+    .finalize(components::uart_mux_component_static!());
 
     // LEDs
     let led = components::led::LedsComponent::new().finalize(components::led_component_helper!(
@@ -236,7 +236,7 @@ pub unsafe fn main() {
         capsules::console::DRIVER_NUM,
         uart_mux,
     )
-    .finalize(components::console_component_helper!());
+    .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
     components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
 

--- a/boards/redboard_redv/src/main.rs
+++ b/boards/redboard_redv/src/main.rs
@@ -166,7 +166,7 @@ pub unsafe fn main() {
         115200,
         dynamic_deferred_caller,
     )
-    .finalize(());
+    .finalize(components::uart_mux_component_helper!(64));
 
     // LEDs
     let led = components::led::LedsComponent::new().finalize(components::led_component_helper!(

--- a/boards/sma_q3/src/main.rs
+++ b/boards/sma_q3/src/main.rs
@@ -288,7 +288,7 @@ pub unsafe fn main() {
     // Create a shared UART channel for the console and for kernel debug.
     let uart_mux =
         components::console::UartMuxComponent::new(uart_channel, 115200, dynamic_deferred_caller)
-            .finalize(());
+            .finalize(components::uart_mux_component_helper!(64));
 
     let pconsole = components::process_console::ProcessConsoleComponent::new(
         board_kernel,

--- a/boards/sma_q3/src/main.rs
+++ b/boards/sma_q3/src/main.rs
@@ -288,7 +288,7 @@ pub unsafe fn main() {
     // Create a shared UART channel for the console and for kernel debug.
     let uart_mux =
         components::console::UartMuxComponent::new(uart_channel, 115200, dynamic_deferred_caller)
-            .finalize(components::uart_mux_component_helper!(64));
+            .finalize(components::uart_mux_component_helper!());
 
     let pconsole = components::process_console::ProcessConsoleComponent::new(
         board_kernel,

--- a/boards/sma_q3/src/main.rs
+++ b/boards/sma_q3/src/main.rs
@@ -288,7 +288,7 @@ pub unsafe fn main() {
     // Create a shared UART channel for the console and for kernel debug.
     let uart_mux =
         components::console::UartMuxComponent::new(uart_channel, 115200, dynamic_deferred_caller)
-            .finalize(components::uart_mux_component_helper!());
+            .finalize(components::uart_mux_component_static!());
 
     let pconsole = components::process_console::ProcessConsoleComponent::new(
         board_kernel,
@@ -296,7 +296,7 @@ pub unsafe fn main() {
         mux_alarm,
         process_printer,
     )
-    .finalize(components::process_console_component_helper!(
+    .finalize(components::process_console_component_static!(
         nrf52840::rtc::Rtc<'static>
     ));
 
@@ -306,7 +306,7 @@ pub unsafe fn main() {
         capsules::console::DRIVER_NUM,
         uart_mux,
     )
-    .finalize(components::console_component_helper!());
+    .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
     components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
 

--- a/boards/stm32f3discovery/src/main.rs
+++ b/boards/stm32f3discovery/src/main.rs
@@ -251,15 +251,15 @@ unsafe fn set_pin_primary_functions(
         pin.set_mode(stm32f303xc::gpio::Mode::AnalogMode);
     });
 
-    // channel 3
-    gpio_ports.get_pin(PinId::PA02).map(|pin| {
-        pin.set_mode(stm32f303xc::gpio::Mode::AnalogMode);
-    });
+    // // channel 3
+    // gpio_ports.get_pin(PinId::PA02).map(|pin| {
+    //     pin.set_mode(stm32f303xc::gpio::Mode::AnalogMode);
+    // });
 
-    // channel 4
-    gpio_ports.get_pin(PinId::PA03).map(|pin| {
-        pin.set_mode(stm32f303xc::gpio::Mode::AnalogMode);
-    });
+    // // channel 4
+    // gpio_ports.get_pin(PinId::PA03).map(|pin| {
+    //     pin.set_mode(stm32f303xc::gpio::Mode::AnalogMode);
+    // });
 
     // channel 5
     gpio_ports.get_pin(PinId::PF04).map(|pin| {
@@ -329,6 +329,8 @@ unsafe fn set_pin_primary_functions(
 unsafe fn setup_peripherals(tim2: &stm32f303xc::tim2::Tim2) {
     // USART1 IRQn is 37
     cortexm4::nvic::Nvic::new(stm32f303xc::nvic::USART1).enable();
+    // USART2 IRQn is 38
+    cortexm4::nvic::Nvic::new(stm32f303xc::nvic::USART2).enable();
 
     // TIM2 IRQn is 28
     tim2.enable_clock();
@@ -388,7 +390,7 @@ pub unsafe fn main() {
 
     let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
     let dynamic_deferred_call_clients =
-        static_init!([DynamicDeferredCallClientState; 3], Default::default());
+        static_init!([DynamicDeferredCallClientState; 4], Default::default());
     let dynamic_deferred_caller = static_init!(
         DynamicDeferredCall,
         DynamicDeferredCall::new(dynamic_deferred_call_clients)
@@ -405,12 +407,14 @@ pub unsafe fn main() {
 
     // Create a shared UART channel for kernel debug.
     peripherals.usart1.enable_clock();
+    peripherals.usart2.enable_clock();
+
     let uart_mux = components::console::UartMuxComponent::new(
         &peripherals.usart1,
         115200,
         dynamic_deferred_caller,
     )
-    .finalize(components::uart_mux_component_helper!(64));
+    .finalize(components::uart_mux_component_helper!());
 
     // `finalize()` configures the underlying USART, so we need to
     // tell `send_byte()` not to configure the USART again.

--- a/boards/stm32f3discovery/src/main.rs
+++ b/boards/stm32f3discovery/src/main.rs
@@ -410,7 +410,7 @@ pub unsafe fn main() {
         115200,
         dynamic_deferred_caller,
     )
-    .finalize(());
+    .finalize(components::uart_mux_component_helper!(64));
 
     // `finalize()` configures the underlying USART, so we need to
     // tell `send_byte()` not to configure the USART again.

--- a/boards/stm32f3discovery/src/main.rs
+++ b/boards/stm32f3discovery/src/main.rs
@@ -414,7 +414,7 @@ pub unsafe fn main() {
         115200,
         dynamic_deferred_caller,
     )
-    .finalize(components::uart_mux_component_helper!());
+    .finalize(components::uart_mux_component_static!());
 
     // `finalize()` configures the underlying USART, so we need to
     // tell `send_byte()` not to configure the USART again.
@@ -433,7 +433,7 @@ pub unsafe fn main() {
         capsules::console::DRIVER_NUM,
         uart_mux,
     )
-    .finalize(components::console_component_helper!());
+    .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
     components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
 
@@ -771,7 +771,7 @@ pub unsafe fn main() {
         mux_alarm,
         process_printer,
     )
-    .finalize(components::process_console_component_helper!(
+    .finalize(components::process_console_component_static!(
         stm32f303xc::tim2::Tim2
     ));
     let _ = process_console.start();

--- a/boards/stm32f3discovery/src/main.rs
+++ b/boards/stm32f3discovery/src/main.rs
@@ -251,15 +251,15 @@ unsafe fn set_pin_primary_functions(
         pin.set_mode(stm32f303xc::gpio::Mode::AnalogMode);
     });
 
-    // // channel 3
-    // gpio_ports.get_pin(PinId::PA02).map(|pin| {
-    //     pin.set_mode(stm32f303xc::gpio::Mode::AnalogMode);
-    // });
+    // channel 3
+    gpio_ports.get_pin(PinId::PA02).map(|pin| {
+        pin.set_mode(stm32f303xc::gpio::Mode::AnalogMode);
+    });
 
-    // // channel 4
-    // gpio_ports.get_pin(PinId::PA03).map(|pin| {
-    //     pin.set_mode(stm32f303xc::gpio::Mode::AnalogMode);
-    // });
+    // channel 4
+    gpio_ports.get_pin(PinId::PA03).map(|pin| {
+        pin.set_mode(stm32f303xc::gpio::Mode::AnalogMode);
+    });
 
     // channel 5
     gpio_ports.get_pin(PinId::PF04).map(|pin| {

--- a/boards/stm32f412gdiscovery/src/main.rs
+++ b/boards/stm32f412gdiscovery/src/main.rs
@@ -443,7 +443,7 @@ pub unsafe fn main() {
         115200,
         dynamic_deferred_caller,
     )
-    .finalize(components::uart_mux_component_helper!());
+    .finalize(components::uart_mux_component_static!());
 
     io::WRITER.set_initialized();
 
@@ -460,7 +460,7 @@ pub unsafe fn main() {
         capsules::console::DRIVER_NUM,
         uart_mux,
     )
-    .finalize(components::console_component_helper!());
+    .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
     components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
 
@@ -746,7 +746,7 @@ pub unsafe fn main() {
         mux_alarm,
         process_printer,
     )
-    .finalize(components::process_console_component_helper!(
+    .finalize(components::process_console_component_static!(
         stm32f412g::tim2::Tim2
     ));
     let _ = process_console.start();

--- a/boards/stm32f412gdiscovery/src/main.rs
+++ b/boards/stm32f412gdiscovery/src/main.rs
@@ -443,7 +443,7 @@ pub unsafe fn main() {
         115200,
         dynamic_deferred_caller,
     )
-    .finalize(());
+    .finalize(components::uart_mux_component_helper!(64));
 
     io::WRITER.set_initialized();
 

--- a/boards/stm32f412gdiscovery/src/main.rs
+++ b/boards/stm32f412gdiscovery/src/main.rs
@@ -443,7 +443,7 @@ pub unsafe fn main() {
         115200,
         dynamic_deferred_caller,
     )
-    .finalize(components::uart_mux_component_helper!(64));
+    .finalize(components::uart_mux_component_helper!());
 
     io::WRITER.set_initialized();
 

--- a/boards/stm32f429idiscovery/src/main.rs
+++ b/boards/stm32f429idiscovery/src/main.rs
@@ -333,7 +333,7 @@ pub unsafe fn main() {
         115200,
         dynamic_deferred_caller,
     )
-    .finalize(());
+    .finalize(components::uart_mux_component_helper!(64));
 
     io::WRITER.set_initialized();
 

--- a/boards/stm32f429idiscovery/src/main.rs
+++ b/boards/stm32f429idiscovery/src/main.rs
@@ -333,7 +333,7 @@ pub unsafe fn main() {
         115200,
         dynamic_deferred_caller,
     )
-    .finalize(components::uart_mux_component_helper!(64));
+    .finalize(components::uart_mux_component_helper!());
 
     io::WRITER.set_initialized();
 

--- a/boards/stm32f429idiscovery/src/main.rs
+++ b/boards/stm32f429idiscovery/src/main.rs
@@ -333,7 +333,7 @@ pub unsafe fn main() {
         115200,
         dynamic_deferred_caller,
     )
-    .finalize(components::uart_mux_component_helper!());
+    .finalize(components::uart_mux_component_static!());
 
     io::WRITER.set_initialized();
 
@@ -350,7 +350,7 @@ pub unsafe fn main() {
         capsules::console::DRIVER_NUM,
         uart_mux,
     )
-    .finalize(components::console_component_helper!());
+    .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
     components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
 
@@ -570,7 +570,7 @@ pub unsafe fn main() {
         mux_alarm,
         process_printer,
     )
-    .finalize(components::process_console_component_helper!(
+    .finalize(components::process_console_component_static!(
         stm32f429zi::tim2::Tim2
     ));
     let _ = process_console.start();

--- a/boards/swervolf/src/main.rs
+++ b/boards/swervolf/src/main.rs
@@ -138,7 +138,7 @@ pub unsafe fn main() {
         115200,
         dynamic_deferred_caller,
     )
-    .finalize(components::uart_mux_component_helper!(64));
+    .finalize(components::uart_mux_component_helper!());
 
     let mtimer = static_init!(
         swervolf_eh1::syscon::SysCon,

--- a/boards/swervolf/src/main.rs
+++ b/boards/swervolf/src/main.rs
@@ -138,7 +138,7 @@ pub unsafe fn main() {
         115200,
         dynamic_deferred_caller,
     )
-    .finalize(());
+    .finalize(components::uart_mux_component_helper!(64));
 
     let mtimer = static_init!(
         swervolf_eh1::syscon::SysCon,

--- a/boards/swervolf/src/main.rs
+++ b/boards/swervolf/src/main.rs
@@ -138,7 +138,7 @@ pub unsafe fn main() {
         115200,
         dynamic_deferred_caller,
     )
-    .finalize(components::uart_mux_component_helper!());
+    .finalize(components::uart_mux_component_static!());
 
     let mtimer = static_init!(
         swervolf_eh1::syscon::SysCon,
@@ -204,7 +204,7 @@ pub unsafe fn main() {
         capsules::console::DRIVER_NUM,
         uart_mux,
     )
-    .finalize(components::console_component_helper!());
+    .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
     components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
 

--- a/boards/teensy40/src/main.rs
+++ b/boards/teensy40/src/main.rs
@@ -263,7 +263,7 @@ pub unsafe fn main() {
         115_200,
         dynamic_deferred_caller,
     )
-    .finalize(components::uart_mux_component_helper!(64));
+    .finalize(components::uart_mux_component_helper!());
     // Create the debugger object that handles calls to `debug!()`
     components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
 

--- a/boards/teensy40/src/main.rs
+++ b/boards/teensy40/src/main.rs
@@ -263,7 +263,7 @@ pub unsafe fn main() {
         115_200,
         dynamic_deferred_caller,
     )
-    .finalize(components::uart_mux_component_helper!());
+    .finalize(components::uart_mux_component_static!());
     // Create the debugger object that handles calls to `debug!()`
     components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
 
@@ -273,7 +273,7 @@ pub unsafe fn main() {
         capsules::console::DRIVER_NUM,
         uart_mux,
     )
-    .finalize(components::console_component_helper!());
+    .finalize(components::console_component_static!());
 
     // LED
     let led = components::led::LedsComponent::new().finalize(components::led_component_helper!(

--- a/boards/teensy40/src/main.rs
+++ b/boards/teensy40/src/main.rs
@@ -263,7 +263,7 @@ pub unsafe fn main() {
         115_200,
         dynamic_deferred_caller,
     )
-    .finalize(());
+    .finalize(components::uart_mux_component_helper!(64));
     // Create the debugger object that handles calls to `debug!()`
     components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
 

--- a/boards/weact_f401ccu6/src/main.rs
+++ b/boards/weact_f401ccu6/src/main.rs
@@ -281,7 +281,7 @@ pub unsafe fn main() {
         115200,
         dynamic_deferred_caller,
     )
-    .finalize(components::uart_mux_component_helper!());
+    .finalize(components::uart_mux_component_static!());
 
     io::WRITER.set_initialized();
 
@@ -298,7 +298,7 @@ pub unsafe fn main() {
         capsules::console::DRIVER_NUM,
         uart_mux,
     )
-    .finalize(components::console_component_helper!());
+    .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
     components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
 
@@ -434,7 +434,7 @@ pub unsafe fn main() {
         mux_alarm,
         process_printer,
     )
-    .finalize(components::process_console_component_helper!(
+    .finalize(components::process_console_component_static!(
         stm32f401cc::tim2::Tim2
     ));
     let _ = process_console.start();

--- a/boards/weact_f401ccu6/src/main.rs
+++ b/boards/weact_f401ccu6/src/main.rs
@@ -281,7 +281,7 @@ pub unsafe fn main() {
         115200,
         dynamic_deferred_caller,
     )
-    .finalize(());
+    .finalize(components::uart_mux_component_helper!(64));
 
     io::WRITER.set_initialized();
 

--- a/boards/weact_f401ccu6/src/main.rs
+++ b/boards/weact_f401ccu6/src/main.rs
@@ -281,7 +281,7 @@ pub unsafe fn main() {
         115200,
         dynamic_deferred_caller,
     )
-    .finalize(components::uart_mux_component_helper!(64));
+    .finalize(components::uart_mux_component_helper!());
 
     io::WRITER.set_initialized();
 

--- a/capsules/src/virtual_uart.rs
+++ b/capsules/src/virtual_uart.rs
@@ -52,9 +52,6 @@ use kernel::hil::uart;
 use kernel::utilities::cells::{OptionalCell, TakeCell};
 use kernel::ErrorCode;
 
-const RX_BUF_LEN: usize = 64;
-pub static mut RX_BUF: [u8; RX_BUF_LEN] = [0; RX_BUF_LEN];
-
 pub struct MuxUart<'a> {
     uart: &'a dyn uart::Uart<'a>,
     speed: u32,

--- a/capsules/src/virtual_uart.rs
+++ b/capsules/src/virtual_uart.rs
@@ -52,6 +52,8 @@ use kernel::hil::uart;
 use kernel::utilities::cells::{OptionalCell, TakeCell};
 use kernel::ErrorCode;
 
+pub const RX_BUF_LEN: usize = 64;
+
 pub struct MuxUart<'a> {
     uart: &'a dyn uart::Uart<'a>,
     speed: u32,

--- a/chips/stm32f303xc/src/chip.rs
+++ b/chips/stm32f303xc/src/chip.rs
@@ -57,6 +57,8 @@ impl<'a> InterruptService<DeferredCallTask> for Stm32f3xxDefaultPeripherals<'a> 
     unsafe fn service_interrupt(&self, interrupt: u32) -> bool {
         match interrupt {
             nvic::USART1 => self.usart1.handle_interrupt(),
+            nvic::USART2 => self.usart2.handle_interrupt(),
+            nvic::USART3 => self.usart3.handle_interrupt(),
 
             nvic::TIM2 => self.tim2.handle_interrupt(),
 


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes the way in which `UartMux` is being instantiated. Before this PR:
- the `new` function from the `UartMuxComponent` would instantiate the `UartMux` using a `static_init!` macro. Due to this, instantiating two `UartMux` structures would result in the second instance overwriting the first one.
- the `RX_BUF` was defined within the `virtual_uart` capsule, meaning that two instances of `UartMux` would use the same buffer.

This PR:
- moves the instantiating of the `UartMux` in the `uart_mux_component_helper` macro.
- moves the instantiating of the `RX_BUF` in the `uart_mux_component_helper` macro.

#### Example

```rust
let uart_mux1 = components::console::UartMuxComponent::new(
    &peripherals.usart1,
    115200,
    dynamic_deferred_caller,
)
.finalize(components::uart_component_helper!(64));

let uart_mux2 = components::console::UartMuxComponent::new(
    &peripherals.usart2,
    115200,
    dynamic_deferred_caller,
)
.finalize(components::uart_component_helper!(64));
```

Without this PR `uart_mux2` overwrites `uart_mux1`, as the structure is allocated in the same memory space.

This PR enables the `usart2` for the STM32F3Discovery board.

This is similar to what the I2C and SPI components do.

### Testing Strategy

This pull request was tested using an STM32F3 Discovery board with two serial ports. One serial port was used for the kernel messages and process console, while the second one was used for applications.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
