### PR TITLE
ESP32-c3 Build Fixes, add docs for flashing apps

### DIFF
--- a/boards/esp32-c3-devkitM-1/Makefile
+++ b/boards/esp32-c3-devkitM-1/Makefile
@@ -19,7 +19,7 @@ ifeq ($(APP),)
 	$(error "Please specify an APP to be flashed")
 endif
 	$(RISC_PREFIX)-objcopy --update-section .apps=$(APP) $^ $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.elf
-	esptool.py --port /dev/ttyUSB0 --chip esp32c3 elf2image --use_segments --output binary.hex $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.elf
+	esptool.py --port /dev/ttyUSB0 --chip esp32c3 elf2image --use_segments --output binary.hex $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.elf --dont-append-digest
 	esptool.py --port /dev/ttyUSB0 --chip esp32c3 write_flash --flash_mode dio --flash_size detect --flash_freq 80m 0x0 binary.hex
 
 test:

--- a/boards/esp32-c3-devkitM-1/README.md
+++ b/boards/esp32-c3-devkitM-1/README.md
@@ -1,19 +1,18 @@
-ESP32-C3 Board
-==============
+# ESP32-C3 Board
 
 ESP32-C3 is a system on a chip that integrates the following features:
- * Wi-Fi (2.4 GHz band)
- * Bluetooth Low Energy
- * High performance 32-bit RISC-V-ish single-core processor
- * Multiple peripherals
- * Built-in security hardware
+
+- Wi-Fi (2.4 GHz band)
+- Bluetooth Low Energy
+- High performance 32-bit RISC-V-ish single-core processor
+- Multiple peripherals
+- Built-in security hardware
 
 Powered by 40 nm technology, ESP32-C3 provides a robust, highly integrated
 platform, which helps meet the continuous demands for efficient power usage,
 compact design, security, high performance, and reliability.
 
-Setup
------
+## Setup
 
 Install the ESP tool
 
@@ -67,8 +66,23 @@ Entering main loop.
 screen /dev/ttyUSB0  115200
 ```
 
-JTAG Debugging
---------------
+## Building and Flashing Applications
+
+Apps are built out-of-tree, for example:
+
+```bash
+$ cd libtock-c/examples/<app>
+$ make RISCV=1
+```
+
+Then to flash an app:
+
+```
+$ cd tock/boards/esp32-c3-devkitM-1
+$ make flash-app APP=../../../libtock-c/examples/<app>/build/rv32imac/rv32imac.0x403B0060.0x3FCC0000.tbf
+```
+
+## JTAG Debugging
 
 In order to use JTAG debugging you first need to build a fork of OpenOCD
 


### PR DESCRIPTION
### Pull Request Overview

This PR fixes the following warning from esptool when running `make flash-app`:

```
Warning: Image file at 0x0 is protected with a hash checksum, so not changing the flash mode setting. Use the --flash_mode=keep option instead of --flash_mode=dio in order to remove this warning, or use the --dont-append-digest option for the elf2image command in order to generate an image file without a hash checksum
```

It seems that the flashed apps seem to overwrite critical regions of flash, causing the board to enter a infinite loop of trying to boot tock and failing. In order to recover from this I had to re-flash the tock kernel and apps. 

Solution: add `--dont-append-digest` as the warning suggests, resolves issues with the boot loop. 

Additionally, I add some extra documentation detailing how to flash apps to the board. It should save others some time in the future.

To reproduce this issue:
- Build and flash tock kernel `make && make flash`
- Build an example app for RISCV target from libtock-c
- Flash example app to board `make flash-app APP=../../../libtock-c/examples/<some-app>/build/rv32imac/rv32imac.0x403B0060.0x3FCC0000.tbf`
- 
This results in an infinite loop of trying to boot tock and failing:
```
ESP-ROM:esp32c3-api1-20210207
Build:Feb  7 2021
rst:0x10 (RTCWDT_RTC_RST),boot:0xc (SPI_FAST_FLASH_BOOT)
SPIWP:0xee
mode:QIO, clock div:2
load:0x40380000,len:0x125c4
ets_loader.c 78 
... etc
```

### Testing Strategy

Repeat the reproduction steps, it should not result in the bootloader failing to boot Tock. 


### TODO or Help Wanted

Someone else to validate this would be nice


### Documentation Updated

- [x] Updated the readme for the ESP32-c3 board. 

### Formatting

- [x] Ran `make prepush`.
