### PR TITLE
Convert Temperature Component to support multiple instances

### DIFF
--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -615,7 +615,7 @@ pub unsafe fn main() {
         capsules::temperature::DRIVER_NUM,
         sht3x,
     )
-    .finalize(());
+    .finalize(components::temperature_component_static!());
 
     let humidity = components::humidity::HumidityComponent::new(
         board_kernel,

--- a/boards/components/src/temperature.rs
+++ b/boards/components/src/temperature.rs
@@ -3,15 +3,23 @@
 //! Usage
 //! -----
 //! ```rust
-//! let temp = TemperatureComponent::new(board_kernel, nrf52::temperature::TEMP).finalize(());
+//! let temp = TemperatureComponent::new(board_kernel, nrf52::temperature::TEMP)
+//!     .finalize(components::temperature_component_static!());
 //! ```
 
 use capsules::temperature::TemperatureSensor;
+use core::mem::MaybeUninit;
 use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
 use kernel::hil;
-use kernel::static_init;
+
+#[macro_export]
+macro_rules! temperature_component_static {
+    () => {{
+        kernel::static_buf!(capsules::temperature::TemperatureSensor<'static>)
+    };};
+}
 
 pub struct TemperatureComponent<T: 'static + hil::sensors::TemperatureDriver<'static>> {
     board_kernel: &'static kernel::Kernel,
@@ -34,19 +42,16 @@ impl<T: 'static + hil::sensors::TemperatureDriver<'static>> TemperatureComponent
 }
 
 impl<T: 'static + hil::sensors::TemperatureDriver<'static>> Component for TemperatureComponent<T> {
-    type StaticInput = ();
+    type StaticInput = &'static mut MaybeUninit<TemperatureSensor<'static>>;
     type Output = &'static TemperatureSensor<'static>;
 
-    unsafe fn finalize(self, _s: Self::StaticInput) -> Self::Output {
+    unsafe fn finalize(self, s: Self::StaticInput) -> Self::Output {
         let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
 
-        let temp = static_init!(
-            TemperatureSensor<'static>,
-            TemperatureSensor::new(
-                self.temp_sensor,
-                self.board_kernel.create_grant(self.driver_num, &grant_cap)
-            )
-        );
+        let temp = s.write(TemperatureSensor::new(
+            self.temp_sensor,
+            self.board_kernel.create_grant(self.driver_num, &grant_cap),
+        ));
 
         hil::sensors::TemperatureDriver::set_client(self.temp_sensor, temp);
         temp

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -340,7 +340,7 @@ pub unsafe fn main() {
         capsules::temperature::DRIVER_NUM,
         si7021,
     )
-    .finalize(());
+    .finalize(components::temperature_component_static!());
     let humidity = components::si7021::HumidityComponent::new(
         board_kernel,
         capsules::humidity::DRIVER_NUM,

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -413,7 +413,7 @@ pub unsafe fn main() {
         capsules::temperature::DRIVER_NUM,
         si7021,
     )
-    .finalize(());
+    .finalize(components::temperature_component_static!());
     let humidity =
         HumidityComponent::new(board_kernel, capsules::humidity::DRIVER_NUM, si7021).finalize(());
     let ninedof = NineDofComponent::new(

--- a/boards/microbit_v2/src/main.rs
+++ b/boards/microbit_v2/src/main.rs
@@ -458,7 +458,7 @@ pub unsafe fn main() {
         capsules::temperature::DRIVER_NUM,
         &base_peripherals.temp,
     )
-    .finalize(());
+    .finalize(components::temperature_component_static!());
 
     //--------------------------------------------------------------------------
     // ADC

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -515,7 +515,7 @@ pub unsafe fn main() {
         capsules::temperature::DRIVER_NUM,
         hts221,
     )
-    .finalize(());
+    .finalize(components::temperature_component_static!());
     let humidity = components::humidity::HumidityComponent::new(
         board_kernel,
         capsules::humidity::DRIVER_NUM,

--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -370,7 +370,7 @@ pub unsafe fn main() {
         capsules::temperature::DRIVER_NUM,
         &base_peripherals.temp,
     )
-    .finalize(());
+    .finalize(components::temperature_component_static!());
 
     let rng = components::rng::RngComponent::new(
         board_kernel,

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -520,7 +520,7 @@ pub unsafe fn main() {
         capsules::temperature::DRIVER_NUM,
         &base_peripherals.temp,
     )
-    .finalize(());
+    .finalize(components::temperature_component_static!());
 
     let rng = components::rng::RngComponent::new(
         board_kernel,

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -403,7 +403,7 @@ pub unsafe fn main() {
         capsules::temperature::DRIVER_NUM,
         &base_peripherals.temp,
     )
-    .finalize(());
+    .finalize(components::temperature_component_static!());
 
     let rng = components::rng::RngComponent::new(
         board_kernel,

--- a/boards/particle_boron/src/main.rs
+++ b/boards/particle_boron/src/main.rs
@@ -464,7 +464,7 @@ pub unsafe fn main() {
         capsules::temperature::DRIVER_NUM,
         &base_peripherals.temp,
     )
-    .finalize(());
+    .finalize(components::temperature_component_static!());
 
     //--------------------------------------------------------------------------
     // RANDOM NUMBERS

--- a/boards/redboard_artemis_nano/src/main.rs
+++ b/boards/redboard_artemis_nano/src/main.rs
@@ -285,7 +285,7 @@ unsafe fn setup() -> (
         capsules::temperature::DRIVER_NUM,
         bme280,
     )
-    .finalize(());
+    .finalize(components::temperature_component_static!());
     let humidity = components::humidity::HumidityComponent::new(
         board_kernel,
         capsules::humidity::DRIVER_NUM,

--- a/boards/sma_q3/src/main.rs
+++ b/boards/sma_q3/src/main.rs
@@ -348,7 +348,7 @@ pub unsafe fn main() {
         capsules::temperature::DRIVER_NUM,
         &base_peripherals.temp,
     )
-    .finalize(());
+    .finalize(components::temperature_component_static!());
 
     let sensors_i2c_bus = static_init!(
         capsules::virtual_i2c::MuxI2C<'static>,
@@ -369,7 +369,7 @@ pub unsafe fn main() {
         capsules::temperature::DRIVER_NUM,
         bmp280,
     )
-    .finalize(());
+    .finalize(components::temperature_component_static!());
 
     let rng = components::rng::RngComponent::new(
         board_kernel,


### PR DESCRIPTION
### Pull Request Overview

Part of #3222 

I thought the temperature component is somewhat simple, so this PR converts the component to (hopefully) support being used multiple times by the same board. I'm hoping we can discuss this PR to get a template for converting all the rest.

The main change here is adding:

```rust
#[macro_export]
macro_rules! temperature_component_static_init {
    () => {{
        kernel::static_buf!(capsules::temperature::TemperatureSensor<'static>)
    };};
}
```
to the component.

I chose the name `temperature_component_static_init` as the purpose of adding this macro is to encapsulate the static_init!() portion which is what needs to be instantiated in the main.rs file itself, not in the finalize() function. The name is not `_helper`, as I created the "_helper" name because those macros helped me create some way to enable component sharing across microcontrollers. I didn't have a better name at the time.

I'm thinking we should revisit the naming convention for the macro. Perhaps we just use `X_static!()` for these macros, to signify this is where the static buf is defined?




### Testing Strategy

travis


### TODO or Help Wanted

Can we do better than this?


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
