### PR TITLE
BBC HiFive Inventor board ported to Tock

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,8 @@ members = [
     "capsules",
     "chips/apollo3",
     "chips/arty_e21_chip",
+    "chips/e310_g002",
+    "chips/e310_g003",
     "chips/e310x",
     "chips/earlgrey",
     "chips/esp32",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "boards/esp32-c3-devkitM-1",
     "boards/clue_nrf52840",
     "boards/hail",
+    "boards/hifive_inventor",
     "boards/hifive1",
     "boards/imix",
     "boards/imxrt1050-evkb",

--- a/boards/README.md
+++ b/boards/README.md
@@ -87,6 +87,7 @@ but the approximate definitions:
 | [ESP32-C3-DevKitM-1](esp32-c3-devkitM-1/README.md)                | RISC-V-ish RV32I | ESP32-C3       | custom     | custom                      | No            |
 | [i.MX RT 1052 Evaluation Kit](imxrt1050-evkb/README.md)           | ARM Cortex-M7    | i.MX RT 1052   | custom     | custom                      | No            |
 | [Teensy 4.0](teensy40/README.md)                                  | ARM Cortex-M7    | i.MX RT 1062   | custom     | custom                      | No            |
+| [BBC HiFive Inventor](hifive1/README.md)                         | RISC-V           | FE310-G003     | tockloader    | ?                  | No     |
 | [Digilent Arty A-7 100T](arty_e21/README.md)                      | RISC-V RV32IMAC  | SiFive E21     | openocd    | tockloader                  | No            |
 
 

--- a/boards/README.md
+++ b/boards/README.md
@@ -84,10 +84,10 @@ but the approximate definitions:
 | [WeAct F401CCU6 Core Board](weact_f401ccu6/README.md)             | ARM Cortex-M4    | STM32F401CCU6  | openocd    | custom                      | No            |
 | [SparkFun RedBoard Red-V](redboard_redv/README.md)                | RISC-V           | FE310-G002     | openocd    | tockloader                  | Yes (5.1)     |
 | [SiFive HiFive1 Rev B](hifive1/README.md)                         | RISC-V           | FE310-G002     | openocd    | tockloader                  | Yes (5.1)     |
+| [BBC HiFive Inventor](hifive1/README.md)                          | RISC-V           | FE310-G003     | tockloader | custom                      | No            |
 | [ESP32-C3-DevKitM-1](esp32-c3-devkitM-1/README.md)                | RISC-V-ish RV32I | ESP32-C3       | custom     | custom                      | No            |
 | [i.MX RT 1052 Evaluation Kit](imxrt1050-evkb/README.md)           | ARM Cortex-M7    | i.MX RT 1052   | custom     | custom                      | No            |
 | [Teensy 4.0](teensy40/README.md)                                  | ARM Cortex-M7    | i.MX RT 1062   | custom     | custom                      | No            |
-| [BBC HiFive Inventor](hifive1/README.md)                         | RISC-V           | FE310-G003     | tockloader    | ?                  | No     |
 | [Digilent Arty A-7 100T](arty_e21/README.md)                      | RISC-V RV32IMAC  | SiFive E21     | openocd    | tockloader                  | No            |
 
 

--- a/boards/hifive1/Cargo.toml
+++ b/boards/hifive1/Cargo.toml
@@ -10,5 +10,5 @@ components = { path = "../components" }
 rv32i = { path = "../../arch/rv32i" }
 capsules = { path = "../../capsules" }
 kernel = { path = "../../kernel" }
-e310x = { path = "../../chips/e310x" }
+e310_g002 = { path = "../../chips/e310_g002" }
 sifive = { path = "../../chips/sifive" }

--- a/boards/hifive1/src/io.rs
+++ b/boards/hifive1/src/io.rs
@@ -1,7 +1,7 @@
 use core::fmt::Write;
 use core::panic::PanicInfo;
 use core::str;
-use e310x;
+use e310_g002;
 use kernel::debug;
 use kernel::debug::IoWrite;
 use kernel::hil::gpio;
@@ -25,7 +25,7 @@ impl Write for Writer {
 
 impl IoWrite for Writer {
     fn write(&mut self, buf: &[u8]) {
-        let uart = sifive::uart::Uart::new(e310x::uart::UART0_BASE, 16_000_000);
+        let uart = sifive::uart::Uart::new(e310_g002::uart::UART0_BASE, 16_000_000);
         uart.transmit_sync(buf);
     }
 }
@@ -37,7 +37,7 @@ impl IoWrite for Writer {
 pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
     // turn off the non panic leds, just in case
     let led_green = sifive::gpio::GpioPin::new(
-        e310x::gpio::GPIO0_BASE,
+        e310_g002::gpio::GPIO0_BASE,
         sifive::gpio::pins::pin19,
         sifive::gpio::pins::pin19::SET,
         sifive::gpio::pins::pin19::CLEAR,
@@ -46,7 +46,7 @@ pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
     gpio::Output::set(&led_green);
 
     let led_blue = sifive::gpio::GpioPin::new(
-        e310x::gpio::GPIO0_BASE,
+        e310_g002::gpio::GPIO0_BASE,
         sifive::gpio::pins::pin21,
         sifive::gpio::pins::pin21::SET,
         sifive::gpio::pins::pin21::CLEAR,
@@ -55,7 +55,7 @@ pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
     gpio::Output::set(&led_blue);
 
     let led_red_pin = sifive::gpio::GpioPin::new(
-        e310x::gpio::GPIO0_BASE,
+        e310_g002::gpio::GPIO0_BASE,
         sifive::gpio::pins::pin22,
         sifive::gpio::pins::pin22::SET,
         sifive::gpio::pins::pin22::CLEAR,

--- a/boards/hifive1/src/main.rs
+++ b/boards/hifive1/src/main.rs
@@ -263,10 +263,10 @@ pub unsafe fn main() {
     )
     .finalize(());
 
-    // Need two debug!() calls to actually test with QEMU. QEMU seems to have
-    // a much larger UART TX buffer (or it transmits faster).
-    debug!("HiFive1 initialization complete.");
-    debug!("Entering main loop.");
+    // If you plan using this through QEMU, please consider using two debug!
+    // statements as there seems to be a QEMU issue, either having a much larger
+    // UART TX buffer (or it transmits faster).
+    debug!("HiFive1 initialization complete. Entering main loop.");
 
     // These symbols are defined in the linker script.
     extern "C" {

--- a/boards/hifive1/src/main.rs
+++ b/boards/hifive1/src/main.rs
@@ -10,7 +10,7 @@
 #![cfg_attr(not(doc), no_main)]
 
 use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
-use e310x::chip::E310xDefaultPeripherals;
+use e310_g002::interrupt_service::E310G002DefaultPeripherals;
 use kernel::capabilities;
 use kernel::component::Component;
 use kernel::dynamic_deferred_call::{DynamicDeferredCall, DynamicDeferredCallClientState};
@@ -33,7 +33,7 @@ static mut PROCESSES: [Option<&'static dyn kernel::process::Process>; NUM_PROCS]
     [None; NUM_PROCS];
 
 // Reference to the chip for panic dumps.
-static mut CHIP: Option<&'static e310x::chip::E310x<E310xDefaultPeripherals>> = None;
+static mut CHIP: Option<&'static e310_g002::chip::E310x<E310G002DefaultPeripherals>> = None;
 // Reference to the process printer for panic dumps.
 static mut PROCESS_PRINTER: Option<&'static kernel::process::ProcessPrinterText> = None;
 
@@ -83,7 +83,9 @@ impl SyscallDriverLookup for HiFive1 {
     }
 }
 
-impl KernelResources<e310x::chip::E310x<'static, E310xDefaultPeripherals<'static>>> for HiFive1 {
+impl KernelResources<e310_g002::chip::E310x<'static, E310G002DefaultPeripherals<'static>>>
+    for HiFive1
+{
     type SyscallDriverLookup = Self;
     type SyscallFilter = ();
     type ProcessFault = ();
@@ -125,19 +127,24 @@ pub unsafe fn main() {
     // only machine mode
     rv32i::configure_trap_handler(rv32i::PermissionMode::Machine);
 
-    let peripherals = static_init!(E310xDefaultPeripherals, E310xDefaultPeripherals::new());
+    let peripherals = static_init!(
+        E310G002DefaultPeripherals,
+        E310G002DefaultPeripherals::new()
+    );
 
     // initialize capabilities
     let process_mgmt_cap = create_capability!(capabilities::ProcessManagementCapability);
     let memory_allocation_cap = create_capability!(capabilities::MemoryAllocationCapability);
 
-    peripherals.watchdog.disable();
-    peripherals.rtc.disable();
-    peripherals.pwm0.disable();
-    peripherals.pwm1.disable();
-    peripherals.pwm2.disable();
+    peripherals.e310x.watchdog.disable();
+    peripherals.e310x.rtc.disable();
+    peripherals.e310x.pwm0.disable();
+    peripherals.e310x.pwm1.disable();
+    peripherals.e310x.pwm2.disable();
+    peripherals.e310x.uart1.disable();
 
     peripherals
+        .e310x
         .prci
         .set_clock_frequency(sifive::prci::ClockFrequency::Freq16Mhz);
 
@@ -155,14 +162,14 @@ pub unsafe fn main() {
 
     // Configure kernel debug gpios as early as possible
     kernel::debug::assign_gpios(
-        Some(&peripherals.gpio_port[22]), // Red
+        Some(&peripherals.e310x.gpio_port[22]), // Red
         None,
         None,
     );
 
     // Create a shared UART channel for the console and for kernel debug.
     let uart_mux = components::console::UartMuxComponent::new(
-        &peripherals.uart0,
+        &peripherals.e310x.uart0,
         115200,
         dynamic_deferred_caller,
     )
@@ -171,18 +178,23 @@ pub unsafe fn main() {
     // LEDs
     let led = components::led::LedsComponent::new().finalize(components::led_component_helper!(
         LedLow<'static, sifive::gpio::GpioPin>,
-        LedLow::new(&peripherals.gpio_port[22]), // Red
-        LedLow::new(&peripherals.gpio_port[19]), // Green
-        LedLow::new(&peripherals.gpio_port[21]), // Blue
+        LedLow::new(&peripherals.e310x.gpio_port[22]), // Red
+        LedLow::new(&peripherals.e310x.gpio_port[19]), // Green
+        LedLow::new(&peripherals.e310x.gpio_port[21]), // Blue
     ));
 
-    peripherals
-        .uart0
-        .initialize_gpio_pins(&peripherals.gpio_port[17], &peripherals.gpio_port[16]);
+    peripherals.e310x.uart0.initialize_gpio_pins(
+        &peripherals.e310x.gpio_port[17],
+        &peripherals.e310x.gpio_port[16],
+    );
+    peripherals.e310x.uart1.initialize_gpio_pins(
+        &peripherals.e310x.gpio_port[18],
+        &peripherals.e310x.gpio_port[23],
+    );
 
     let hardware_timer = static_init!(
         sifive::clint::Clint,
-        sifive::clint::Clint::new(&e310x::clint::CLINT_BASE)
+        sifive::clint::Clint::new(&e310_g002::clint::CLINT_BASE)
     );
 
     // Create a shared virtualization mux layer on top of a single hardware
@@ -216,8 +228,8 @@ pub unsafe fn main() {
     hil::time::Alarm::set_alarm_client(virtual_alarm_user, alarm);
 
     let chip = static_init!(
-        e310x::chip::E310x<E310xDefaultPeripherals>,
-        e310x::chip::E310x::new(peripherals, hardware_timer)
+        e310_g002::chip::E310x<E310G002DefaultPeripherals>,
+        e310_g002::chip::E310x::new(peripherals, hardware_timer)
     );
     CHIP = Some(chip);
 

--- a/boards/hifive1/src/main.rs
+++ b/boards/hifive1/src/main.rs
@@ -263,9 +263,6 @@ pub unsafe fn main() {
     )
     .finalize(());
 
-    // If you plan using this through QEMU, please consider using two debug!
-    // statements as there seems to be a QEMU issue, either having a much larger
-    // UART TX buffer (or it transmits faster).
     debug!("HiFive1 initialization complete. Entering main loop.");
 
     // These symbols are defined in the linker script.

--- a/boards/hifive_inventor/Cargo.toml
+++ b/boards/hifive_inventor/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "hifive1"
+version = "0.1.0"
+authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+build = "build.rs"
+edition = "2021"
+
+[dependencies]
+components = { path = "../components" }
+rv32i = { path = "../../arch/rv32i" }
+capsules = { path = "../../capsules" }
+kernel = { path = "../../kernel" }
+e310x = { path = "../../chips/e310x" }
+sifive = { path = "../../chips/sifive" }

--- a/boards/hifive_inventor/Cargo.toml
+++ b/boards/hifive_inventor/Cargo.toml
@@ -10,5 +10,5 @@ components = { path = "../components" }
 rv32i = { path = "../../arch/rv32i" }
 capsules = { path = "../../capsules" }
 kernel = { path = "../../kernel" }
-e310x = { path = "../../chips/e310x" }
+e310_g003 = { path = "../../chips/e310_g003" }
 sifive = { path = "../../chips/sifive" }

--- a/boards/hifive_inventor/Cargo.toml
+++ b/boards/hifive_inventor/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "hifive1"
+name = "hifive_inventor"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
 build = "build.rs"

--- a/boards/hifive_inventor/Makefile
+++ b/boards/hifive_inventor/Makefile
@@ -1,0 +1,31 @@
+# Makefile for building the tock kernel for the HiFive1 platform
+
+TARGET=riscv32imac-unknown-none-elf
+PLATFORM=hifive1
+QEMU ?= qemu-system-riscv32
+
+include ../Makefile.common
+
+# Default target for installing the kernel.
+.PHONY: install
+install: flash
+
+flash: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
+	openocd \
+		-c "source [find board/sifive-hifive1-revb.cfg]; program $<; resume 0x20000000; exit"
+
+qemu: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
+	$(QEMU) -M sifive_e,revb=true -kernel $^  -nographic
+
+qemu-app: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
+	$(QEMU) -M sifive_e,revb=true -kernel $^ -device loader,file=$(APP),addr=0x20040000 -nographic
+
+
+TOCKLOADER=tockloader
+TOCKLOADER_JTAG_FLAGS = --jlink --board hifive1b
+KERNEL_ADDRESS = 0x20010000
+
+# upload kernel over JTAG
+.PHONY: flash
+flash-jlink: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin
+	$(TOCKLOADER) $(TOCKLOADER_GENERAL_FLAGS) flash --address $(KERNEL_ADDRESS) $(TOCKLOADER_JTAG_FLAGS) $<

--- a/boards/hifive_inventor/Makefile
+++ b/boards/hifive_inventor/Makefile
@@ -1,31 +1,20 @@
-# Makefile for building the tock kernel for the HiFive1 platform
+# Makefile for building the tock kernel for the HiFive Inventor platform
 
 TARGET=riscv32imac-unknown-none-elf
-PLATFORM=hifive1
+PLATFORM=hifive_inventor
 QEMU ?= qemu-system-riscv32
 
 include ../Makefile.common
 
 # Default target for installing the kernel.
 .PHONY: install
-install: flash
-
-flash: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
-	openocd \
-		-c "source [find board/sifive-hifive1-revb.cfg]; program $<; resume 0x20000000; exit"
-
-qemu: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
-	$(QEMU) -M sifive_e,revb=true -kernel $^  -nographic
-
-qemu-app: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
-	$(QEMU) -M sifive_e,revb=true -kernel $^ -device loader,file=$(APP),addr=0x20040000 -nographic
-
+install: flash-jlink
 
 TOCKLOADER=tockloader
 TOCKLOADER_JTAG_FLAGS = --jlink --board hifive1b
 KERNEL_ADDRESS = 0x20010000
 
 # upload kernel over JTAG
-.PHONY: flash
+.PHONY: flash-jlink
 flash-jlink: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin
 	$(TOCKLOADER) $(TOCKLOADER_GENERAL_FLAGS) flash --address $(KERNEL_ADDRESS) $(TOCKLOADER_JTAG_FLAGS) $<

--- a/boards/hifive_inventor/README.md
+++ b/boards/hifive_inventor/README.md
@@ -1,0 +1,67 @@
+SiFive HiFive1 Rev B RISC-V Board
+==================================
+
+- https://www.sifive.com/boards/hifive1-rev-b
+
+Arduino-compatible dev board for RISC-V. This is the second release of this
+board ("Rev B").
+
+Programming
+-----------
+
+Running `make flash` should load the kernel onto the board. You will need a
+relatively new (i.e. from git) version of OpenOCD.
+
+The kernel also assumes there is the default HiFive1 software bootloader running
+on the chip.
+
+Running in QEMU
+---------------
+
+The HiFive1 application can be run in the QEMU emulation platform for RISC-V, allowing quick and easy testing.
+
+Unfortunately you need QEMU 5.1, which at the time of writing is unlikely to be avaliable in your distro. Luckily Tock can build QEMU for you. From the top level of the Tock source just run `make ci-setup-qemu` and follow the steps.
+
+QEMU can be started with Tock using the following arguments (in Tock's top-level directory):
+
+```bash
+$ qemu-system-riscv32 -M sifive_e,revb=true -kernel $TOCK_ROOT/target/riscv32imac-unknown-none-elf/release/hifive1.elf  -nographic
+```
+
+Or with the `qemu` make target:
+
+```bash
+$ make qemu
+```
+
+QEMU can be started with Tock and a userspace app using the following arguments (in Tock's top-level directory):
+
+```
+qemu-system-riscv32 -M sifive_e,revb=true -kernel $TOCK_ROOT/target/riscv32imac-unknown-none-elf/release/hifive1.elf -device loader,file=./examples/hello.tbf,addr=0x20040000 -nographic
+```
+Or with the `qemu-app` make target:
+
+```bash
+$ make APP=/path/to/app.tbf qemu-app
+```
+
+The TBF must be compiled for the HiFive board which is, at the time of writing,
+supported for Rust userland apps using libtock-rs. For example, you can build
+the Hello World exmple app from the libtock-rs repository by running:
+
+```
+$ cd [LIBTOCK-RS-DIR]
+$ make EXAMPLE=hello_world flash-hifive1
+$ tar xf target/riscv32imac-unknown-none-elf/tab/hifive1/hello_world.tab
+$ cd [TOCK_ROOT]/boards/hifive
+$ make APP=[LIBTOCK-RS-DIR]/rv32imac.tbf qemu-app
+```
+
+HiFive1 Revision A
+------------------
+
+Tock has dropped support for the older ("Rev A") version of this board. Since
+that version of the hardware is no longer being produced, Tock has decided to no
+longer maintain the older board file. If would like to run Tock on the rev A
+version, you should use the [version 1.5
+release](https://github.com/tock/tock/releases/tag/release-1.5) of Tock.

--- a/boards/hifive_inventor/README.md
+++ b/boards/hifive_inventor/README.md
@@ -12,7 +12,7 @@ peripherals:
 - LSM303AGR compass and accelerometer
 - Bluetooth and Wi-Fi connectivity co-processor
 
-**At present, the peripherals are not set up.** 
+**At present, the peripherals are not set up.** We are waiting for the schematic.
 
 ## Programming
 

--- a/boards/hifive_inventor/README.md
+++ b/boards/hifive_inventor/README.md
@@ -1,67 +1,39 @@
-SiFive HiFive1 Rev B RISC-V Board
-==================================
+# BBC HiFive Inventor - FE310-G003 RISC-V Board
 
-- https://www.sifive.com/boards/hifive1-rev-b
+<img src="https://www.hifiveinventor.com/image/hifive/support/gs-2-overview.png" width="35%">
 
-Arduino-compatible dev board for RISC-V. This is the second release of this
-board ("Rev B").
+The [BBC HiFive Inventor](https://www.hifiveinventor.com/) is a
+board based on the SiFive FE310-G003 chip built around the
+[E31 Core](https://www.sifive.com/cores/e31). It includes the following
+peripherals:
 
-Programming
------------
+- 6x8 RGB LED Matrix
+- Light Sensor
+- LSM303AGR compass and accelerometer
+- Bluetooth and Wi-Fi connectivity co-processor
 
-Running `make flash` should load the kernel onto the board. You will need a
-relatively new (i.e. from git) version of OpenOCD.
+**At present, the peripherals are not set up.** 
 
-The kernel also assumes there is the default HiFive1 software bootloader running
-on the chip.
+## Programming
 
-Running in QEMU
----------------
+### Using J-Link
 
-The HiFive1 application can be run in the QEMU emulation platform for RISC-V, allowing quick and easy testing.
+Running `make flash-jlink` should load the kernel onto the board. It requires
+you install [J-Link](https://www.segger.com/downloads/jlink#J-LinkSoftwareAndDocumentationPack).
+Make sure that the `JLinkExe` executable is accessible starting from your
+`PATH` variable.
 
-Unfortunately you need QEMU 5.1, which at the time of writing is unlikely to be avaliable in your distro. Luckily Tock can build QEMU for you. From the top level of the Tock source just run `make ci-setup-qemu` and follow the steps.
-
-QEMU can be started with Tock using the following arguments (in Tock's top-level directory):
-
-```bash
-$ qemu-system-riscv32 -M sifive_e,revb=true -kernel $TOCK_ROOT/target/riscv32imac-unknown-none-elf/release/hifive1.elf  -nographic
-```
-
-Or with the `qemu` make target:
+If need, use `gdb` to debug the kernel. Start a custom gdb server with
+`JLinkGDBServerExe`, or use the following configuration:
 
 ```bash
-$ make qemu
+$ JLinkGDBServerCLExe -select USB -device FE310 -endian little -if JTAG -speed 1200 -noir -noLocalhostOnly
 ```
 
-QEMU can be started with Tock and a userspace app using the following arguments (in Tock's top-level directory):
+### Other tools
 
-```
-qemu-system-riscv32 -M sifive_e,revb=true -kernel $TOCK_ROOT/target/riscv32imac-unknown-none-elf/release/hifive1.elf -device loader,file=./examples/hello.tbf,addr=0x20040000 -nographic
-```
-Or with the `qemu-app` make target:
+I would also like to note that `openocd` support is in developement.
+[A update](https://review.openocd.org/c/openocd/+/7135) for adding the flash
+ISSI IS25LQ040 chip is on it's way.
 
-```bash
-$ make APP=/path/to/app.tbf qemu-app
-```
-
-The TBF must be compiled for the HiFive board which is, at the time of writing,
-supported for Rust userland apps using libtock-rs. For example, you can build
-the Hello World exmple app from the libtock-rs repository by running:
-
-```
-$ cd [LIBTOCK-RS-DIR]
-$ make EXAMPLE=hello_world flash-hifive1
-$ tar xf target/riscv32imac-unknown-none-elf/tab/hifive1/hello_world.tab
-$ cd [TOCK_ROOT]/boards/hifive
-$ make APP=[LIBTOCK-RS-DIR]/rv32imac.tbf qemu-app
-```
-
-HiFive1 Revision A
-------------------
-
-Tock has dropped support for the older ("Rev A") version of this board. Since
-that version of the hardware is no longer being produced, Tock has decided to no
-longer maintain the older board file. If would like to run Tock on the rev A
-version, you should use the [version 1.5
-release](https://github.com/tock/tock/releases/tag/release-1.5) of Tock.
+Running in QEMU has not been tested, yet.

--- a/boards/hifive_inventor/build.rs
+++ b/boards/hifive_inventor/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    println!("cargo:rerun-if-changed=layout.ld");
+    println!("cargo:rerun-if-changed=../kernel_layout.ld");
+}

--- a/boards/hifive_inventor/layout.ld
+++ b/boards/hifive_inventor/layout.ld
@@ -1,0 +1,16 @@
+/* The HiFive1a board has 512 MB of flash. The first 0x400000 is reserved for
+ * the default bootloader provided by SiFive. We also reserve room for apps to
+ * make all of the linker files work, but don't really support them on this
+ * chip.
+ */
+
+MEMORY
+{
+  rom (rx)  : ORIGIN = 0x20010000, LENGTH = 0x30000
+  prog (rx) : ORIGIN = 0x20040000, LENGTH = 512M-0x430000
+  ram (rwx) : ORIGIN = 0x80000000, LENGTH = 0x4000
+}
+
+MPU_MIN_ALIGN = 1K;
+
+INCLUDE ../kernel_layout.ld

--- a/boards/hifive_inventor/layout.ld
+++ b/boards/hifive_inventor/layout.ld
@@ -1,14 +1,11 @@
-/* The HiFive1a board has 512 MB of flash. The first 0x400000 is reserved for
- * the default bootloader provided by SiFive. We also reserve room for apps to
- * make all of the linker files work, but don't really support them on this
- * chip.
+/* The HiFive inventor board has 512 MiB of flash and 64 KiB of RAM.
  */
 
 MEMORY
 {
   rom (rx)  : ORIGIN = 0x20010000, LENGTH = 0x30000
   prog (rx) : ORIGIN = 0x20040000, LENGTH = 512M-0x430000
-  ram (rwx) : ORIGIN = 0x80000000, LENGTH = 0x4000
+  ram (rwx) : ORIGIN = 0x80000000, LENGTH = 0x10000
 }
 
 MPU_MIN_ALIGN = 1K;

--- a/boards/hifive_inventor/src/io.rs
+++ b/boards/hifive_inventor/src/io.rs
@@ -1,0 +1,75 @@
+use core::fmt::Write;
+use core::panic::PanicInfo;
+use core::str;
+use e310x;
+use kernel::debug;
+use kernel::debug::IoWrite;
+use kernel::hil::gpio;
+use kernel::hil::led;
+use rv32i;
+
+use crate::CHIP;
+use crate::PROCESSES;
+use crate::PROCESS_PRINTER;
+
+struct Writer {}
+
+static mut WRITER: Writer = Writer {};
+
+impl Write for Writer {
+    fn write_str(&mut self, s: &str) -> ::core::fmt::Result {
+        self.write(s.as_bytes());
+        Ok(())
+    }
+}
+
+impl IoWrite for Writer {
+    fn write(&mut self, buf: &[u8]) {
+        let uart = sifive::uart::Uart::new(e310x::uart::UART0_BASE, 16_000_000);
+        uart.transmit_sync(buf);
+    }
+}
+
+/// Panic handler.
+#[cfg(not(test))]
+#[no_mangle]
+#[panic_handler]
+pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
+    // turn off the non panic leds, just in case
+    let led_green = sifive::gpio::GpioPin::new(
+        e310x::gpio::GPIO0_BASE,
+        sifive::gpio::pins::pin19,
+        sifive::gpio::pins::pin19::SET,
+        sifive::gpio::pins::pin19::CLEAR,
+    );
+    gpio::Configure::make_output(&led_green);
+    gpio::Output::set(&led_green);
+
+    let led_blue = sifive::gpio::GpioPin::new(
+        e310x::gpio::GPIO0_BASE,
+        sifive::gpio::pins::pin21,
+        sifive::gpio::pins::pin21::SET,
+        sifive::gpio::pins::pin21::CLEAR,
+    );
+    gpio::Configure::make_output(&led_blue);
+    gpio::Output::set(&led_blue);
+
+    let led_red_pin = sifive::gpio::GpioPin::new(
+        e310x::gpio::GPIO0_BASE,
+        sifive::gpio::pins::pin22,
+        sifive::gpio::pins::pin22::SET,
+        sifive::gpio::pins::pin22::CLEAR,
+    );
+    let led_red = &mut led::LedLow::new(&led_red_pin);
+    let writer = &mut WRITER;
+
+    debug::panic(
+        &mut [led_red],
+        writer,
+        pi,
+        &rv32i::support::nop,
+        &PROCESSES,
+        &CHIP,
+        &PROCESS_PRINTER,
+    )
+}

--- a/boards/hifive_inventor/src/main.rs
+++ b/boards/hifive_inventor/src/main.rs
@@ -242,10 +242,7 @@ pub unsafe fn main() {
     )
     .finalize(());
 
-    // Need two debug!() calls to actually test with QEMU. QEMU seems to have
-    // a much larger UART TX buffer (or it transmits faster).
-    debug!("HiFive1 initialization complete.");
-    debug!("Entering main loop.");
+    debug!("HiFive1 initialization complete. Entering main loop.");
 
     // These symbols are defined in the linker script.
     extern "C" {

--- a/boards/hifive_inventor/src/main.rs
+++ b/boards/hifive_inventor/src/main.rs
@@ -1,0 +1,309 @@
+//! Board file for SiFive HiFive1b RISC-V development platform.
+//!
+//! - <https://www.sifive.com/boards/hifive1-rev-b>
+//!
+//! This board file is only compatible with revision B of the HiFive1.
+
+#![no_std]
+// Disable this attribute when documenting, as a workaround for
+// https://github.com/rust-lang/rust/issues/62184.
+#![cfg_attr(not(doc), no_main)]
+
+use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
+use e310x::chip::E310xDefaultPeripherals;
+use kernel::capabilities;
+use kernel::component::Component;
+use kernel::dynamic_deferred_call::{DynamicDeferredCall, DynamicDeferredCallClientState};
+use kernel::hil;
+use kernel::hil::led::LedLow;
+use kernel::platform::scheduler_timer::VirtualSchedulerTimer;
+use kernel::platform::{KernelResources, SyscallDriverLookup};
+use kernel::scheduler::cooperative::CooperativeSched;
+use kernel::utilities::registers::interfaces::ReadWriteable;
+use kernel::{create_capability, debug, static_init};
+use rv32i::csr;
+
+pub mod io;
+
+pub const NUM_PROCS: usize = 4;
+//
+// Actual memory for holding the active process structures. Need an empty list
+// at least.
+static mut PROCESSES: [Option<&'static dyn kernel::process::Process>; NUM_PROCS] =
+    [None; NUM_PROCS];
+
+// Reference to the chip for panic dumps.
+static mut CHIP: Option<&'static e310x::chip::E310x<E310xDefaultPeripherals>> = None;
+// Reference to the process printer for panic dumps.
+static mut PROCESS_PRINTER: Option<&'static kernel::process::ProcessPrinterText> = None;
+
+// How should the kernel respond when a process faults.
+const FAULT_RESPONSE: kernel::process::PanicFaultPolicy = kernel::process::PanicFaultPolicy {};
+
+/// Dummy buffer that causes the linker to reserve enough space for the stack.
+#[no_mangle]
+#[link_section = ".stack_buffer"]
+pub static mut STACK_MEMORY: [u8; 0x900] = [0; 0x900];
+
+/// A structure representing this platform that holds references to all
+/// capsules for this platform. We've included an alarm and console.
+struct HiFive1 {
+    led: &'static capsules::led::LedDriver<
+        'static,
+        LedLow<'static, sifive::gpio::GpioPin<'static>>,
+        3,
+    >,
+    console: &'static capsules::console::Console<'static>,
+    lldb: &'static capsules::low_level_debug::LowLevelDebug<
+        'static,
+        capsules::virtual_uart::UartDevice<'static>,
+    >,
+    alarm: &'static capsules::alarm::AlarmDriver<
+        'static,
+        VirtualMuxAlarm<'static, sifive::clint::Clint<'static>>,
+    >,
+    scheduler: &'static CooperativeSched<'static>,
+    scheduler_timer:
+        &'static VirtualSchedulerTimer<VirtualMuxAlarm<'static, sifive::clint::Clint<'static>>>,
+}
+
+/// Mapping of integer syscalls to objects that implement syscalls.
+impl SyscallDriverLookup for HiFive1 {
+    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    where
+        F: FnOnce(Option<&dyn kernel::syscall::SyscallDriver>) -> R,
+    {
+        match driver_num {
+            capsules::led::DRIVER_NUM => f(Some(self.led)),
+            capsules::console::DRIVER_NUM => f(Some(self.console)),
+            capsules::alarm::DRIVER_NUM => f(Some(self.alarm)),
+            capsules::low_level_debug::DRIVER_NUM => f(Some(self.lldb)),
+            _ => f(None),
+        }
+    }
+}
+
+impl KernelResources<e310x::chip::E310x<'static, E310xDefaultPeripherals<'static>>> for HiFive1 {
+    type SyscallDriverLookup = Self;
+    type SyscallFilter = ();
+    type ProcessFault = ();
+    type Scheduler = CooperativeSched<'static>;
+    type SchedulerTimer =
+        VirtualSchedulerTimer<VirtualMuxAlarm<'static, sifive::clint::Clint<'static>>>;
+    type WatchDog = ();
+    type ContextSwitchCallback = ();
+
+    fn syscall_driver_lookup(&self) -> &Self::SyscallDriverLookup {
+        &self
+    }
+    fn syscall_filter(&self) -> &Self::SyscallFilter {
+        &()
+    }
+    fn process_fault(&self) -> &Self::ProcessFault {
+        &()
+    }
+    fn scheduler(&self) -> &Self::Scheduler {
+        self.scheduler
+    }
+    fn scheduler_timer(&self) -> &Self::SchedulerTimer {
+        &self.scheduler_timer
+    }
+    fn watchdog(&self) -> &Self::WatchDog {
+        &()
+    }
+    fn context_switch_callback(&self) -> &Self::ContextSwitchCallback {
+        &()
+    }
+}
+
+/// Main function.
+///
+/// This function is called from the arch crate after some very basic RISC-V
+/// setup and RAM initialization.
+#[no_mangle]
+pub unsafe fn main() {
+    // only machine mode
+    rv32i::configure_trap_handler(rv32i::PermissionMode::Machine);
+
+    let peripherals = static_init!(E310xDefaultPeripherals, E310xDefaultPeripherals::new());
+
+    // initialize capabilities
+    let process_mgmt_cap = create_capability!(capabilities::ProcessManagementCapability);
+    let memory_allocation_cap = create_capability!(capabilities::MemoryAllocationCapability);
+
+    peripherals.watchdog.disable();
+    peripherals.rtc.disable();
+    peripherals.pwm0.disable();
+    peripherals.pwm1.disable();
+    peripherals.pwm2.disable();
+
+    peripherals
+        .prci
+        .set_clock_frequency(sifive::prci::ClockFrequency::Freq16Mhz);
+
+    let main_loop_cap = create_capability!(capabilities::MainLoopCapability);
+
+    let board_kernel = static_init!(kernel::Kernel, kernel::Kernel::new(&PROCESSES));
+
+    let dynamic_deferred_call_clients =
+        static_init!([DynamicDeferredCallClientState; 2], Default::default());
+    let dynamic_deferred_caller = static_init!(
+        DynamicDeferredCall,
+        DynamicDeferredCall::new(dynamic_deferred_call_clients)
+    );
+    DynamicDeferredCall::set_global_instance(dynamic_deferred_caller);
+
+    // Configure kernel debug gpios as early as possible
+    kernel::debug::assign_gpios(
+        Some(&peripherals.gpio_port[22]), // Red
+        None,
+        None,
+    );
+
+    // Create a shared UART channel for the console and for kernel debug.
+    let uart_mux = components::console::UartMuxComponent::new(
+        &peripherals.uart0,
+        115200,
+        dynamic_deferred_caller,
+    )
+    .finalize(());
+
+    // LEDs
+    let led = components::led::LedsComponent::new().finalize(components::led_component_helper!(
+        LedLow<'static, sifive::gpio::GpioPin>,
+        LedLow::new(&peripherals.gpio_port[22]), // Red
+        LedLow::new(&peripherals.gpio_port[19]), // Green
+        LedLow::new(&peripherals.gpio_port[21]), // Blue
+    ));
+
+    peripherals
+        .uart0
+        .initialize_gpio_pins(&peripherals.gpio_port[17], &peripherals.gpio_port[16]);
+
+    let hardware_timer = static_init!(
+        sifive::clint::Clint,
+        sifive::clint::Clint::new(&e310x::clint::CLINT_BASE)
+    );
+
+    // Create a shared virtualization mux layer on top of a single hardware
+    // alarm.
+    let mux_alarm = static_init!(
+        MuxAlarm<'static, sifive::clint::Clint>,
+        MuxAlarm::new(hardware_timer)
+    );
+    hil::time::Alarm::set_alarm_client(hardware_timer, mux_alarm);
+
+    // Alarm
+    let virtual_alarm_user = static_init!(
+        VirtualMuxAlarm<'static, sifive::clint::Clint>,
+        VirtualMuxAlarm::new(mux_alarm)
+    );
+    virtual_alarm_user.setup();
+
+    let systick_virtual_alarm = static_init!(
+        VirtualMuxAlarm<'static, sifive::clint::Clint>,
+        VirtualMuxAlarm::new(mux_alarm)
+    );
+    systick_virtual_alarm.setup();
+
+    let alarm = static_init!(
+        capsules::alarm::AlarmDriver<'static, VirtualMuxAlarm<'static, sifive::clint::Clint>>,
+        capsules::alarm::AlarmDriver::new(
+            virtual_alarm_user,
+            board_kernel.create_grant(capsules::alarm::DRIVER_NUM, &memory_allocation_cap)
+        )
+    );
+    hil::time::Alarm::set_alarm_client(virtual_alarm_user, alarm);
+
+    let chip = static_init!(
+        e310x::chip::E310x<E310xDefaultPeripherals>,
+        e310x::chip::E310x::new(peripherals, hardware_timer)
+    );
+    CHIP = Some(chip);
+
+    let process_printer =
+        components::process_printer::ProcessPrinterTextComponent::new().finalize(());
+    PROCESS_PRINTER = Some(process_printer);
+
+    // Need to enable all interrupts for Tock Kernel
+    chip.enable_plic_interrupts();
+
+    // enable interrupts globally
+    csr::CSR
+        .mie
+        .modify(csr::mie::mie::mext::SET + csr::mie::mie::msoft::SET + csr::mie::mie::mtimer::SET);
+    csr::CSR.mstatus.modify(csr::mstatus::mstatus::mie::SET);
+
+    // Setup the console.
+    let console = components::console::ConsoleComponent::new(
+        board_kernel,
+        capsules::console::DRIVER_NUM,
+        uart_mux,
+    )
+    .finalize(components::console_component_helper!());
+    // Create the debugger object that handles calls to `debug!()`.
+    components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
+
+    let lldb = components::lldb::LowLevelDebugComponent::new(
+        board_kernel,
+        capsules::low_level_debug::DRIVER_NUM,
+        uart_mux,
+    )
+    .finalize(());
+
+    // Need two debug!() calls to actually test with QEMU. QEMU seems to have
+    // a much larger UART TX buffer (or it transmits faster).
+    debug!("HiFive1 initialization complete.");
+    debug!("Entering main loop.");
+
+    // These symbols are defined in the linker script.
+    extern "C" {
+        /// Beginning of the ROM region containing app images.
+        static _sapps: u8;
+        /// End of the ROM region containing app images.
+        static _eapps: u8;
+        /// Beginning of the RAM region for app memory.
+        static mut _sappmem: u8;
+        /// End of the RAM region for app memory.
+        static _eappmem: u8;
+    }
+
+    let scheduler = components::sched::cooperative::CooperativeComponent::new(&PROCESSES)
+        .finalize(components::coop_component_helper!(NUM_PROCS));
+
+    let scheduler_timer = static_init!(
+        VirtualSchedulerTimer<VirtualMuxAlarm<'static, sifive::clint::Clint<'static>>>,
+        VirtualSchedulerTimer::new(systick_virtual_alarm)
+    );
+
+    let hifive1 = HiFive1 {
+        console: console,
+        alarm: alarm,
+        lldb: lldb,
+        led,
+        scheduler,
+        scheduler_timer,
+    };
+
+    kernel::process::load_processes(
+        board_kernel,
+        chip,
+        core::slice::from_raw_parts(
+            &_sapps as *const u8,
+            &_eapps as *const u8 as usize - &_sapps as *const u8 as usize,
+        ),
+        core::slice::from_raw_parts_mut(
+            &mut _sappmem as *mut u8,
+            &_eappmem as *const u8 as usize - &_sappmem as *const u8 as usize,
+        ),
+        &mut PROCESSES,
+        &FAULT_RESPONSE,
+        &process_mgmt_cap,
+    )
+    .unwrap_or_else(|err| {
+        debug!("Error loading processes!");
+        debug!("{:?}", err);
+    });
+
+    board_kernel.kernel_loop(&hifive1, chip, None::<&kernel::ipc::IPC<0>>, &main_loop_cap);
+}

--- a/boards/hifive_inventor/src/main.rs
+++ b/boards/hifive_inventor/src/main.rs
@@ -43,7 +43,7 @@ const FAULT_RESPONSE: kernel::process::PanicFaultPolicy = kernel::process::Panic
 /// Dummy buffer that causes the linker to reserve enough space for the stack.
 #[no_mangle]
 #[link_section = ".stack_buffer"]
-pub static mut STACK_MEMORY: [u8; 0x900] = [0; 0x900];
+pub static mut STACK_MEMORY: [u8; 0x1500] = [0; 0x1500];
 
 /// A structure representing this platform that holds references to all
 /// capsules for this platform. We've included an alarm and console.
@@ -163,7 +163,7 @@ pub unsafe fn main() {
     // Create a shared UART channel for the console and for kernel debug.
     let uart_mux = components::console::UartMuxComponent::new(
         &peripherals.uart0,
-        115200,
+        19200,
         dynamic_deferred_caller,
     )
     .finalize(());

--- a/boards/hifive_inventor/src/main.rs
+++ b/boards/hifive_inventor/src/main.rs
@@ -44,7 +44,7 @@ pub static mut STACK_MEMORY: [u8; 0x1500] = [0; 0x1500];
 
 /// A structure representing this platform that holds references to all
 /// capsules for this platform. We've included an alarm and console.
-struct HiFive1 {
+struct HiFiveInventor {
     console: &'static capsules::console::Console<'static>,
     lldb: &'static capsules::low_level_debug::LowLevelDebug<
         'static,
@@ -60,7 +60,7 @@ struct HiFive1 {
 }
 
 /// Mapping of integer syscalls to objects that implement syscalls.
-impl SyscallDriverLookup for HiFive1 {
+impl SyscallDriverLookup for HiFiveInventor {
     fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
     where
         F: FnOnce(Option<&dyn kernel::syscall::SyscallDriver>) -> R,
@@ -75,7 +75,7 @@ impl SyscallDriverLookup for HiFive1 {
 }
 
 impl KernelResources<e310_g003::chip::E310x<'static, E310G003DefaultPeripherals<'static>>>
-    for HiFive1
+    for HiFiveInventor
 {
     type SyscallDriverLookup = Self;
     type SyscallFilter = ();
@@ -267,7 +267,7 @@ pub unsafe fn main() {
         VirtualSchedulerTimer::new(systick_virtual_alarm)
     );
 
-    let hifive1 = HiFive1 {
+    let hifive1 = HiFiveInventor {
         console: console,
         alarm: alarm,
         lldb: lldb,

--- a/chips/e310_g002/Cargo.toml
+++ b/chips/e310_g002/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "e310x"
+name = "e310_g002"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
 edition = "2021"
@@ -8,3 +8,4 @@ edition = "2021"
 sifive = { path = "../sifive" }
 rv32i = { path = "../../arch/rv32i" }
 kernel = { path = "../../kernel" }
+e310x = { path = "../e310x" }

--- a/chips/e310_g002/README.md
+++ b/chips/e310_g002/README.md
@@ -1,0 +1,4 @@
+HiFive Freedom E310-G002 MCU
+=======================
+
+- https://www.sifive.com/documentation -> Chips -> Freedom E310-G002

--- a/chips/e310_g002/src/interrupt_service.rs
+++ b/chips/e310_g002/src/interrupt_service.rs
@@ -1,0 +1,35 @@
+use crate::chip::E310xDefaultPeripherals;
+use crate::interrupts;
+
+#[repr(transparent)]
+pub struct E310G002DefaultPeripherals<'a> {
+    pub e310x: E310xDefaultPeripherals<'a>,
+}
+
+impl<'a> E310G002DefaultPeripherals<'a> {
+    pub unsafe fn new() -> Self {
+        Self {
+            e310x: E310xDefaultPeripherals::new(),
+        }
+    }
+}
+impl<'a> kernel::platform::chip::InterruptService<()> for E310G002DefaultPeripherals<'a> {
+    unsafe fn service_interrupt(&self, interrupt: u32) -> bool {
+        match interrupt {
+            interrupts::UART0 => self.e310x.uart0.handle_interrupt(),
+            interrupts::UART1 => self.e310x.uart1.handle_interrupt(),
+            int_pin @ interrupts::GPIO0..=interrupts::GPIO31 => {
+                let pin = &self.e310x.gpio_port[(int_pin - interrupts::GPIO0) as usize];
+                pin.handle_interrupt();
+            }
+
+            // put E310x specific interrupts here
+            _ => return self.e310x.service_interrupt(interrupt),
+        }
+        true
+    }
+
+    unsafe fn service_deferred_call(&self, task: ()) -> bool {
+        self.e310x.service_deferred_call(task)
+    }
+}

--- a/chips/e310_g002/src/interrupts.rs
+++ b/chips/e310_g002/src/interrupts.rs
@@ -1,4 +1,4 @@
-//! Named interrupts for the E310X chip.
+//! Named interrupts for the E310-G002 chip.
 
 #![allow(dead_code)]
 
@@ -7,8 +7,8 @@ pub const RTC: u32 = 2;
 pub const UART0: u32 = 3;
 pub const UART1: u32 = 4;
 pub const QSPI0: u32 = 5;
-pub const QSPI1: u32 = 6;
-pub const QSPI2: u32 = 7;
+pub const SPI1: u32 = 6;
+pub const SPI2: u32 = 7;
 pub const GPIO0: u32 = 8;
 pub const GPIO1: u32 = 9;
 pub const GPIO2: u32 = 10;
@@ -53,3 +53,4 @@ pub const PWM2CMP0: u32 = 48;
 pub const PWM2CMP1: u32 = 49;
 pub const PWM2CMP2: u32 = 50;
 pub const PWM2CMP3: u32 = 51;
+pub const I2C: u32 = 52;

--- a/chips/e310_g002/src/lib.rs
+++ b/chips/e310_g002/src/lib.rs
@@ -1,0 +1,10 @@
+//! Chip support for the E310-G002 from SiFive.
+
+#![no_std]
+#![crate_name = "e310_g002"]
+#![crate_type = "rlib"]
+
+pub use e310x::{chip, clint, gpio, plic, prci, pwm, rtc, uart, watchdog};
+
+pub mod interrupt_service;
+pub mod interrupts;

--- a/chips/e310_g002/src/lib.rs
+++ b/chips/e310_g002/src/lib.rs
@@ -7,4 +7,4 @@
 pub use e310x::{chip, clint, gpio, plic, prci, pwm, rtc, uart, watchdog};
 
 pub mod interrupt_service;
-pub mod interrupts;
+mod interrupts;

--- a/chips/e310_g003/Cargo.toml
+++ b/chips/e310_g003/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "e310x"
+name = "e310_g003"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
 edition = "2021"
@@ -8,3 +8,4 @@ edition = "2021"
 sifive = { path = "../sifive" }
 rv32i = { path = "../../arch/rv32i" }
 kernel = { path = "../../kernel" }
+e310x = { path = "../e310x" }

--- a/chips/e310_g003/README.md
+++ b/chips/e310_g003/README.md
@@ -1,0 +1,4 @@
+HiFive Freedom E310-G003 MCU
+=======================
+
+- https://www.sifive.com/documentation -> Chips -> Freedom E310-G003

--- a/chips/e310_g003/src/interrupt_service.rs
+++ b/chips/e310_g003/src/interrupt_service.rs
@@ -1,0 +1,35 @@
+use crate::chip::E310xDefaultPeripherals;
+use crate::interrupts;
+
+#[repr(transparent)]
+pub struct E310G003DefaultPeripherals<'a> {
+    pub e310x: E310xDefaultPeripherals<'a>,
+}
+
+impl<'a> E310G003DefaultPeripherals<'a> {
+    pub unsafe fn new() -> Self {
+        Self {
+            e310x: E310xDefaultPeripherals::new(),
+        }
+    }
+}
+impl<'a> kernel::platform::chip::InterruptService<()> for E310G003DefaultPeripherals<'a> {
+    unsafe fn service_interrupt(&self, interrupt: u32) -> bool {
+        match interrupt {
+            interrupts::UART0 => self.e310x.uart0.handle_interrupt(),
+            interrupts::UART1 => self.e310x.uart1.handle_interrupt(),
+            int_pin @ interrupts::GPIO0..=interrupts::GPIO31 => {
+                let pin = &self.e310x.gpio_port[(int_pin - interrupts::GPIO0) as usize];
+                pin.handle_interrupt();
+            }
+
+            // put E310x specific interrupts here
+            _ => return self.e310x.service_interrupt(interrupt),
+        }
+        true
+    }
+
+    unsafe fn service_deferred_call(&self, task: ()) -> bool {
+        self.e310x.service_deferred_call(task)
+    }
+}

--- a/chips/e310_g003/src/interrupts.rs
+++ b/chips/e310_g003/src/interrupts.rs
@@ -1,0 +1,56 @@
+//! Named interrupts for the E310-G003 chip.
+
+#![allow(dead_code)]
+
+pub const GPIO0: u32 = 1;
+pub const GPIO1: u32 = 2;
+pub const GPIO2: u32 = 3;
+pub const GPIO3: u32 = 4;
+pub const GPIO4: u32 = 5;
+pub const GPIO5: u32 = 6;
+pub const GPIO6: u32 = 7;
+pub const GPIO7: u32 = 8;
+pub const GPIO8: u32 = 9;
+pub const GPIO9: u32 = 10;
+pub const GPIO10: u32 = 11;
+pub const GPIO11: u32 = 12;
+pub const GPIO12: u32 = 13;
+pub const GPIO13: u32 = 14;
+pub const GPIO14: u32 = 15;
+pub const GPIO15: u32 = 16;
+pub const GPIO16: u32 = 17;
+pub const GPIO17: u32 = 18;
+pub const GPIO18: u32 = 19;
+pub const GPIO19: u32 = 20;
+pub const GPIO20: u32 = 21;
+pub const GPIO21: u32 = 22;
+pub const GPIO22: u32 = 23;
+pub const GPIO23: u32 = 24;
+pub const GPIO24: u32 = 25;
+pub const GPIO25: u32 = 26;
+pub const GPIO26: u32 = 27;
+pub const GPIO27: u32 = 28;
+pub const GPIO28: u32 = 29;
+pub const GPIO29: u32 = 30;
+pub const GPIO30: u32 = 31;
+pub const GPIO31: u32 = 32;
+pub const UART0: u32 = 33;
+pub const UART1: u32 = 34;
+pub const QSPI0: u32 = 35;
+pub const SPI1: u32 = 36;
+pub const SPI2: u32 = 37;
+pub const PWM0CMP0: u32 = 38;
+pub const PWM0CMP1: u32 = 39;
+pub const PWM0CMP2: u32 = 40;
+pub const PWM0CMP3: u32 = 41;
+pub const PWM1CMP0: u32 = 42;
+pub const PWM1CMP1: u32 = 43;
+pub const PWM1CMP2: u32 = 44;
+pub const PWM1CMP3: u32 = 45;
+pub const PWM2CMP0: u32 = 46;
+pub const PWM2CMP1: u32 = 47;
+pub const PWM2CMP2: u32 = 48;
+pub const PWM2CMP3: u32 = 49;
+pub const I2C: u32 = 50;
+pub const WATCHDOG: u32 = 51;
+pub const RTC: u32 = 52;

--- a/chips/e310_g003/src/lib.rs
+++ b/chips/e310_g003/src/lib.rs
@@ -1,0 +1,10 @@
+//! Chip support for the E310-G003 from SiFive.
+
+#![no_std]
+#![crate_name = "e310_g003"]
+#![crate_type = "rlib"]
+
+pub use e310x::{chip, clint, gpio, plic, prci, pwm, rtc, uart, watchdog};
+
+pub mod interrupt_service;
+pub mod interrupts;

--- a/chips/e310_g003/src/lib.rs
+++ b/chips/e310_g003/src/lib.rs
@@ -7,4 +7,4 @@
 pub use e310x::{chip, clint, gpio, plic, prci, pwm, rtc, uart, watchdog};
 
 pub mod interrupt_service;
-pub mod interrupts;
+mod interrupts;

--- a/chips/e310x/src/chip.rs
+++ b/chips/e310x/src/chip.rs
@@ -72,15 +72,21 @@ impl<'a, I: InterruptService<()> + 'a> E310x<'a, I> {
     }
 
     pub unsafe fn enable_plic_interrupts(&self) {
-        /* Manual, PLIC Chapter: A pending bit in the PLIC core can be cleared
+        /* E31 core manual
+         * https://sifive.cdn.prismic.io/sifive/c29f9c69-5254-4f9a-9e18-24ea73f34e81_e31_core_complex_manual_21G2.pdf
+         * PLIC Chapter 9.4 p.114: A pending bit in the PLIC core can be cleared
          * by setting the associated enable bit then performing a claim.
          */
+
+        // first disable interrupts globally
         let old_mie = csr::CSR
             .mstatus
             .read_and_clear_field(csr::mstatus::mstatus::mie);
 
         self.plic.enable_all();
         self.plic.clear_all_pending();
+
+        // restore the old external interrupt enable bit
         csr::CSR
             .mstatus
             .modify(csr::mstatus::mstatus::mie.val(old_mie));

--- a/chips/e310x/src/lib.rs
+++ b/chips/e310x/src/lib.rs
@@ -4,8 +4,6 @@
 #![crate_name = "e310x"]
 #![crate_type = "rlib"]
 
-mod interrupts;
-
 pub mod chip;
 pub mod clint;
 pub mod gpio;

--- a/chips/e310x/src/uart.rs
+++ b/chips/e310x/src/uart.rs
@@ -5,3 +5,6 @@ use sifive::uart::UartRegisters;
 
 pub const UART0_BASE: StaticRef<UartRegisters> =
     unsafe { StaticRef::new(0x1001_3000 as *const UartRegisters) };
+
+pub const UART1_BASE: StaticRef<UartRegisters> =
+    unsafe { StaticRef::new(0x1002_3000 as *const UartRegisters) };

--- a/chips/sifive/src/plic.rs
+++ b/chips/sifive/src/plic.rs
@@ -46,7 +46,13 @@ impl Plic {
         }
     }
 
-    /// Clear all pending interrupts. Calims each interrupt.
+    /// Clear all pending interrupts. The [`E31 core manual`] PLIC Chapter 9.8
+    /// p 117: A successful claim also atomically clears the corresponding
+    /// pending bit on the interrupt source.
+    /// Note that this function requires you call `enable_all()` first! (As ch.
+    /// 9.4 p.114 writes.)
+    ///
+    /// [`E31 core manual`]: https://sifive.cdn.prismic.io/sifive/c29f9c69-5254-4f9a-9e18-24ea73f34e81_e31_core_complex_manual_21G2.pdf
     pub fn clear_all_pending(&self) {
         let regs = self.registers;
 

--- a/chips/sifive/src/plic.rs
+++ b/chips/sifive/src/plic.rs
@@ -46,10 +46,16 @@ impl Plic {
         }
     }
 
-    /// Clear all pending interrupts.
+    /// Clear all pending interrupts. Calims each interrupt.
     pub fn clear_all_pending(&self) {
-        for pending in self.registers.pending.iter() {
-            pending.set(0);
+        let regs = self.registers;
+
+        loop {
+            let id = regs.claim.get();
+            if id == 0 {
+                break;
+            }
+            regs.claim.set(id);
         }
     }
 

--- a/chips/sifive/src/plic.rs
+++ b/chips/sifive/src/plic.rs
@@ -3,7 +3,7 @@
 use kernel::utilities::cells::VolatileCell;
 use kernel::utilities::registers::interfaces::{Readable, Writeable};
 use kernel::utilities::registers::LocalRegisterCopy;
-use kernel::utilities::registers::{register_bitfields, ReadWrite};
+use kernel::utilities::registers::{register_bitfields, ReadOnly, ReadWrite};
 use kernel::utilities::StaticRef;
 
 #[repr(C)]
@@ -13,7 +13,7 @@ pub struct PlicRegisters {
     priority: [ReadWrite<u32, priority::Register>; 51],
     _reserved1: [u8; 3888],
     /// Interrupt Pending Register
-    pending: [ReadWrite<u32>; 2],
+    pending: [ReadOnly<u32>; 2],
     _reserved2: [u8; 4088],
     /// Interrupt Enable Register
     enable: [ReadWrite<u32>; 2],

--- a/chips/sifive/src/uart.rs
+++ b/chips/sifive/src/uart.rs
@@ -106,9 +106,23 @@ impl<'a> Uart<'a> {
         regs.div.write(div::div.val(divisor));
     }
 
+    pub fn disable(&self) {
+        let regs = self.registers;
+        regs.txctrl.modify(txctrl::txen::CLEAR);
+        regs.rxctrl.modify(rxctrl::enable::CLEAR);
+
+        self.disable_rx_interrupt();
+        self.disable_tx_interrupt();
+    }
+
     fn enable_tx_interrupt(&self) {
         let regs = self.registers;
         regs.ie.modify(interrupt::txwm::SET);
+    }
+
+    fn disable_rx_interrupt(&self) {
+        let regs = self.registers;
+        regs.ie.write(interrupt::rxwm::CLEAR);
     }
 
     fn disable_tx_interrupt(&self) {


### PR DESCRIPTION
### Pull Request Overview

This pull request aims to port Tock to the [BBC HiFive Inventor board](https://www.hifiveinventor.com/).

The source is mostly copied from the SiFive HiFive1 Rev B board.

I followed an earlier [attempt](https://github.com/tock/tock/pull/3125), made by @TeodoraMiu, who tried to:

- increased ram size in `layout.ld`
- decreased baudrate for the serial interface

However the problems noticed with the UART speed were caused by a lack of configuration of the internal frequency. This was solved by [merge #3215](https://github.com/tock/tock/pull/3215). (The code is also commited here.)

Still there were some bugs in the original `sifive` crate. When trying to clear all pending PL-interrupts a read-only register is [overwritten](https://github.com/tock/tock/blob/93d50be711b959d5dceeb17f8d4b60c6cee3e2b3/chips/sifive/src/plic.rs#L50).
The manual states another way to clear interrupts, by reading the `claim` register and writing the (or a) value back. See this [commit](https://github.com/WyliodrinEmbeddedIoT/tock/commit/4dbafb6ab6572b274b87ed4c7fc144f89da6350c).

The new HiFive board featured a different chip which didn't use the same indexing of interrupt numbers. So implementing a different `InterruptService` for each chip was necessary. So the `e310x` chip implementation was split in two, `e310_g002` and `e310_g003`, which handle each interrupt number differently.

I also added the second UART peripheral in order to disable any unwanted interrupts from it.

### Testing Strategy

This pull request was tested by checking the serial output of the
`hifive_inventor` target and the `hifive1` qemu simulation.


### Help Wanted

This pull request still needs to be physically tested on a hifive1 board.

@gemarcano could you please do this?

### Documentation Updated

- [x] boards/README.md
- [x] boards/hifive_inventor/README.md
- [x] chips/e310_g002/README.md
- [x] chips/e310_g003/README.md

### Formatting

- [x] Ran `make prepush`.
