### PR TITLE
microbit_v2: fixed openocd flashing script

### DIFF
--- a/boards/microbit_v2/Makefile
+++ b/boards/microbit_v2/Makefile
@@ -34,6 +34,6 @@ flash-app: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin
 .PHONY: flash-bootloader
 flash-bootloader:
 	curl -L --output /tmp/tock-bootloader.microbit_v2.vv1.1.1.bin https://github.com/tock/tock-bootloader/releases/download/microbit_v2-vv1.1.1/tock-bootloader.microbit_v2.vv1.1.1.bin
-	$(OPENOCD) $(OPENOCD_OPTIONS) -c "program /tmp/tock-bootloader.microbit_v2.vv1.1.1.bin; verify_image /tmp/tock-bootloader.microbit_v2.vv1.1.1.bin; reset; shutdown;"
+	$(OPENOCD) $(OPENOCD_OPTIONS) -c "program /tmp/tock-bootloader.microbit_v2.vv1.1.1.bin; verify_image /tmp/tock-bootloader.microbit_v2.vv1.1.1.bin; reset halt; shutdown;"
 	rm /tmp/tock-bootloader.microbit_v2.vv1.1.1.bin
 

--- a/boards/microbit_v2/openocd.cfg
+++ b/boards/microbit_v2/openocd.cfg
@@ -2,12 +2,11 @@ source [find interface/cmsis-dap.cfg]
 transport select swd
 source [find target/nrf52.cfg]
 
-set WORKAREASIZE 0x40000
-$_TARGETNAME configure -work-area-phys 0x20000000 -work-area-size $WORKAREASIZE -work-area-backup 0
+# necessary to be backward compatible with openocd 0.10
+if { [flash list] == "" } {
+    set WORKAREASIZE 0x40000
+    $_TARGETNAME configure -work-area-phys 0x20000000 -work-area-size $WORKAREASIZE -work-area-backup 0
 
-# catch is necessary to be backward compatible with openocd 0.10
-# this should be removed when 0.11 becomes more widely used
-
-catch { flash bank $_CHIPNAME.flash nrf51 0x00000000 0 1 1 $_TARGETNAME } err
-catch { flash bank $_CHIPNAME.uicr nrf51 0x10001000 0 1 1 $_TARGETNAME } err
-
+    flash bank $_CHIPNAME.flash nrf51 0x00000000 0 1 1 $_TARGETNAME
+    flash bank $_CHIPNAME.uicr nrf51 0x10001000 0 1 1 $_TARGETNAME
+}


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes seemingly transient errors which occurred when trying to either the bootloader or the kernel on the microbit_v2 board.

Because the openocd script tried to be backwards compatible to v0.10, it copied some of the configs that were added in v0.11. This resulted in errors like: `flash bank already exists` mentioned on this [ticket](https://sourceforge.net/p/openocd/tickets/356/).

Changing `reset` to `reset halt` in the Makefile was needed to avoid another error: `clearing lockup after double fault`. 

### Testing Strategy

This pull request was tested by trying combinations of removing my default user from the `dialout` and `plugdev` groups and commenting the openocd `udev` rules for CMSIS-DAP compatible adapters.