### PR TITLE
tock-register-interface: don't encapsulate test_fields! tests in mod

### DIFF
--- a/libraries/tock-register-interface/src/macros.rs
+++ b/libraries/tock-register-interface/src/macros.rs
@@ -365,16 +365,6 @@ macro_rules! register_structs {
         ),*
     } => {
         $( $crate::register_fields!(@root $(#[$attr])* $vis_struct $name $(<$life>)? { $($fields)* } ); )*
-
-        mod static_validate_register_structs {
-        $(
-            #[allow(non_snake_case)]
-            mod $name {
-                use super::super::*;
-
-                $crate::test_fields!(@root $name $(<$life>)? { $($fields)* } );
-            }
-        )*
-        }
+        $( $crate::test_fields!(@root $name $(<$life>)? { $($fields)* } ); )*
     };
 }


### PR DESCRIPTION
### Pull Request Overview

This allows users of tock-registers to have multiple invocations of `register_fields!` in the same module. Prior to this change, `rustc` would not have allowed the module to compile as it would contain colliding definitions for the `static_validate_register_structs` module. See https://github.com/tock/tock/issues/3228.

### Testing Strategy

This pull request was tested by compiling with two invocations of `register_structs!` in the same module and looking at the expanded source.


### TODO or Help Wanted

Perhaps this should be followed up with a patch release of tock-registers for downstream users?

### Documentation Updated

- [x] ~Updated the relevant files in `/docs`,~ or no updates are required.

### Formatting

- [x] Ran `make prepush`.
