### PR TITLE
Component: Update bmX280 components

### DIFF
--- a/boards/components/src/bme280.rs
+++ b/boards/components/src/bme280.rs
@@ -4,19 +4,19 @@
 //! -----
 //! ```rust
 //!     let bme280 =
-//!         Bme280Component::new(mux_i2c, 0x77).finalize(components::bme280_component_helper!());
+//!         Bme280Component::new(mux_i2c, 0x77).finalize(components::bme280_component_static!());
 //!     let temperature = components::temperature::TemperatureComponent::new(
 //!         board_kernel,
 //!         capsules::temperature::DRIVER_NUM,
 //!         bme280,
 //!     )
-//!     .finalize(());
+//!     .finalize(components::temperature_component_static!());
 //!     let humidity = components::humidity::HumidityComponent::new(
 //!         board_kernel,
 //!         capsules::humidity::DRIVER_NUM,
 //!         bme280,
 //!     )
-//!     .finalize(());
+//!     .finalize(components::humidity_component_static!());
 //! ```
 
 use capsules::bme280::Bme280;

--- a/boards/components/src/bme280.rs
+++ b/boards/components/src/bme280.rs
@@ -23,16 +23,23 @@ use capsules::bme280::Bme280;
 use capsules::virtual_i2c::{I2CDevice, MuxI2C};
 use core::mem::MaybeUninit;
 use kernel::component::Component;
-use kernel::{static_init, static_init_half};
 
 // Setup static space for the objects.
 #[macro_export]
-macro_rules! bme280_component_helper {
+macro_rules! bme280_component_static {
     () => {{
-        use capsules::bme280::Bme280;
-        use core::mem::MaybeUninit;
-        static mut BUF1: MaybeUninit<Bme280<'static>> = MaybeUninit::uninit();
-        &mut BUF1
+        let i2c_device = kernel::static_buf!(capsules::virtual_i2c::I2CDevice<'static>);
+        let i2c_buffer = kernel::static_buf!([u8; 26]);
+        let bme280 = kernel::static_buf!(capsules::bme280::Bme280<'static>);
+
+        (i2c_device, i2c_buffer, bme280)
+    };};
+}
+
+#[macro_export]
+macro_rules! temperature_component_static {
+    () => {{
+        kernel::static_buf!(capsules::temperature::TemperatureSensor<'static>)
     };};
 }
 
@@ -50,19 +57,19 @@ impl Bme280Component {
     }
 }
 
-static mut I2C_BUF: [u8; 26] = [0; 26];
-
 impl Component for Bme280Component {
-    type StaticInput = &'static mut MaybeUninit<Bme280<'static>>;
+    type StaticInput = (
+        &'static mut MaybeUninit<I2CDevice<'static>>,
+        &'static mut MaybeUninit<[u8; 26]>,
+        &'static mut MaybeUninit<Bme280<'static>>,
+    );
     type Output = &'static Bme280<'static>;
 
-    unsafe fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
-        let bme280_i2c = static_init!(I2CDevice, I2CDevice::new(self.i2c_mux, self.i2c_address));
-        let bme280 = static_init_half!(
-            static_buffer,
-            Bme280<'static>,
-            Bme280::new(bme280_i2c, &mut I2C_BUF)
-        );
+    unsafe fn finalize(self, s: Self::StaticInput) -> Self::Output {
+        let bme280_i2c = s.0.write(I2CDevice::new(self.i2c_mux, self.i2c_address));
+        let i2c_buffer = s.1.write([0; 26]);
+
+        let bme280 = s.2.write(Bme280::new(bme280_i2c, i2c_buffer));
 
         bme280_i2c.set_client(bme280);
         bme280.startup();

--- a/boards/redboard_artemis_nano/src/main.rs
+++ b/boards/redboard_artemis_nano/src/main.rs
@@ -291,7 +291,7 @@ unsafe fn setup() -> (
             .finalize(components::i2c_mux_component_helper!());
 
     let bme280 =
-        Bme280Component::new(mux_i2c, 0x77).finalize(components::bme280_component_helper!());
+        Bme280Component::new(mux_i2c, 0x77).finalize(components::bme280_component_static!());
     let temperature = components::temperature::TemperatureComponent::new(
         board_kernel,
         capsules::temperature::DRIVER_NUM,

--- a/boards/sma_q3/src/main.rs
+++ b/boards/sma_q3/src/main.rs
@@ -14,8 +14,6 @@
 
 use capsules::virtual_aes_ccm::MuxAES128CCM;
 use capsules::virtual_alarm::VirtualMuxAlarm;
-use components::bmp280::Bmp280Component;
-use components::bmp280_component_helper;
 use kernel::component::Component;
 use kernel::dynamic_deferred_call::{DynamicDeferredCall, DynamicDeferredCallClientState};
 use kernel::hil::i2c::I2CMaster;
@@ -364,8 +362,14 @@ pub unsafe fn main() {
     );
     base_peripherals.twi1.set_master_client(sensors_i2c_bus);
 
-    let bmp280 = Bmp280Component::new(sensors_i2c_bus, mux_alarm)
-        .finalize(bmp280_component_helper!(nrf52840::rtc::Rtc<'static>));
+    let bmp280 = components::bmp280::Bmp280Component::new(
+        sensors_i2c_bus,
+        capsules::bmp280::BASE_ADDR,
+        mux_alarm,
+    )
+    .finalize(components::bmp280_component_static!(
+        nrf52840::rtc::Rtc<'static>
+    ));
 
     let temperature = components::temperature::TemperatureComponent::new(
         board_kernel,


### PR DESCRIPTION
### Pull Request Overview

Update these components to use _static macro, static_buf, and use new() for all configuration.


### Testing Strategy

travis


### TODO or Help Wanted

Any thoughts on components using other components? bmp280 was using the I2C component, but it's hard to update all components at once, so I just replicated the i2c init because it is pretty simple.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
