### PR TITLE
imix: fix driver num for humidity used for component

### DIFF
--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -415,7 +415,7 @@ pub unsafe fn main() {
     )
     .finalize(());
     let humidity =
-        HumidityComponent::new(board_kernel, capsules::ninedof::DRIVER_NUM, si7021).finalize(());
+        HumidityComponent::new(board_kernel, capsules::humidity::DRIVER_NUM, si7021).finalize(());
     let ninedof = NineDofComponent::new(
         board_kernel,
         capsules::ninedof::DRIVER_NUM,


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes how the humidity component is used for imix. Looks like a copy-paste error.


### Testing Strategy

travis


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
