### PR TITLE
Use stabilized `MaybeUninit` interface in `static_init`

### DIFF
--- a/kernel/src/utilities/static_init.rs
+++ b/kernel/src/utilities/static_init.rs
@@ -113,7 +113,7 @@ pub struct StaticUninitializedBuffer<T: 'static> {
     buf: &'static mut UninitializedBuffer<T>,
 }
 
-impl<T> StaticUninitializedBuffer<T> {
+impl<T: 'static> StaticUninitializedBuffer<T> {
     /// This function is not intended to be called publicly. It's only meant to
     /// be called within `static_buf!` macro, but Rust's visibility rules
     /// require it to be public, so that the macro's body can be instantiated.
@@ -126,10 +126,8 @@ impl<T> StaticUninitializedBuffer<T> {
     /// allows for runtime initialization of `static` values that do not have a
     /// `const` constructor.
     pub unsafe fn initialize(self, value: T) -> &'static mut T {
-        self.buf.0.as_mut_ptr().write(value);
-        // TODO: use MaybeUninit::get_mut() once that is stabilized (see
-        // https://github.com/rust-lang/rust/issues/63568).
-        &mut *self.buf.0.as_mut_ptr() as &'static mut T
+        self.buf.0.write(value);
+        self.buf.0.assume_init_mut()
     }
 }
 


### PR DESCRIPTION
### Pull Request Overview

This pull request removes a comment referencing a now-stable nightly feature and simply adopts use of that feature instead. It also replaces a direct pointer write with the use of the interface exposed by `MaybeUninit` that achieves the same purpose.


### Testing Strategy

This pull request was tested by diffing the old/new generated binaries, there is no difference other than the git commit embedded within.


### TODO or Help Wanted

This PR stands on its own, but looking at it I am wondering how much we actually gain from `UninitializedBuffer` and `StaticUninitializedBuffer` now..


### Documentation Updated

- [x] None required

### Formatting

- [x] Ran `make prepush`.
