### PR TITLE
`static_buf!()`: Remove `StaticUninitializedBuffer` and `UninitializedBuffer` in favor of `MaybeUninit`, update component conventions to match

### DIFF
--- a/boards/opentitan/src/tests/flash_ctrl.rs
+++ b/boards/opentitan/src/tests/flash_ctrl.rs
@@ -68,26 +68,28 @@ impl<'a, F: hil::flash::Flash> hil::flash::Client<F> for FlashCtlCallBack {
     }
 }
 
-unsafe fn static_init_test() -> &'static FlashCtlCallBack {
-    let r_in_page = static_init!(
-        lowrisc::flash_ctrl::LowRiscPage,
-        lowrisc::flash_ctrl::LowRiscPage::default()
-    );
-    let w_in_page = static_init!(
-        lowrisc::flash_ctrl::LowRiscPage,
-        lowrisc::flash_ctrl::LowRiscPage::default()
-    );
-    let mut val: u8 = 0;
+macro_rules! static_init_test {
+    () => {{
+        let r_in_page = static_init!(
+            lowrisc::flash_ctrl::LowRiscPage,
+            lowrisc::flash_ctrl::LowRiscPage::default()
+        );
+        let w_in_page = static_init!(
+            lowrisc::flash_ctrl::LowRiscPage,
+            lowrisc::flash_ctrl::LowRiscPage::default()
+        );
+        let mut val: u8 = 0;
 
-    for i in 0..lowrisc::flash_ctrl::PAGE_SIZE {
-        val = val.wrapping_add(10);
-        r_in_page[i] = 0x00;
-        w_in_page[i] = 0xAA; // Arbitrary Data
-    }
-    static_init!(
-        FlashCtlCallBack,
-        FlashCtlCallBack::new(r_in_page, w_in_page)
-    )
+        for i in 0..lowrisc::flash_ctrl::PAGE_SIZE {
+            val = val.wrapping_add(10);
+            r_in_page[i] = 0x00;
+            w_in_page[i] = 0xAA; // Arbitrary Data
+        }
+        static_init!(
+            FlashCtlCallBack,
+            FlashCtlCallBack::new(r_in_page, w_in_page)
+        )
+    };};
 }
 
 /// Tests: Erase Page -> Write Page -> Read Page
@@ -99,7 +101,7 @@ fn flash_ctl_read_write_page() {
     let perf = unsafe { PERIPHERALS.unwrap() };
     let flash_ctl = &perf.flash_ctrl;
 
-    let cb = unsafe { static_init_test() };
+    let cb = unsafe { static_init_test!() };
     flash_ctl.set_client(cb);
     cb.reset();
 
@@ -159,7 +161,7 @@ fn flash_ctl_erase_page() {
     let perf = unsafe { PERIPHERALS.unwrap() };
     let flash_ctl = &perf.flash_ctrl;
 
-    let cb = unsafe { static_init_test() };
+    let cb = unsafe { static_init_test!() };
     cb.reset();
     flash_ctl.set_client(cb);
 

--- a/boards/opentitan/src/tests/hmac.rs
+++ b/boards/opentitan/src/tests/hmac.rs
@@ -72,21 +72,23 @@ impl<'a> digest::ClientVerify<32> for HmacTestCallback {
 
 /// Static init an HmacTestCallback, with
 /// respective buffers allocated for data fields.
-unsafe fn static_init_test_cb() -> &'static HmacTestCallback {
-    let input_data = static_init!([u8; 32], [32; 32]);
-    let digest_data = static_init!(
-        [u8; 32],
-        [
-            0xdc, 0x55, 0x51, 0x5e, 0x30, 0xac, 0x50, 0xc7, 0x65, 0xbd, 0xe, 0x2, 0x82, 0xf7, 0x8b,
-            0xe1, 0xef, 0xd1, 0xb, 0xdc, 0xa8, 0xba, 0xe1, 0xfa, 0x11, 0x3f, 0xf6, 0xeb, 0xaf,
-            0x58, 0x57, 0x40,
-        ]
-    );
+macro_rules! static_init_test_cb {
+    () => {{
+        let input_data = static_init!([u8; 32], [32; 32]);
+        let digest_data = static_init!(
+            [u8; 32],
+            [
+                0xdc, 0x55, 0x51, 0x5e, 0x30, 0xac, 0x50, 0xc7, 0x65, 0xbd, 0xe, 0x2, 0x82, 0xf7,
+                0x8b, 0xe1, 0xef, 0xd1, 0xb, 0xdc, 0xa8, 0xba, 0xe1, 0xfa, 0x11, 0x3f, 0xf6, 0xeb,
+                0xaf, 0x58, 0x57, 0x40,
+            ]
+        );
 
-    static_init!(
-        HmacTestCallback,
-        HmacTestCallback::new(input_data, digest_data)
-    )
+        static_init!(
+            HmacTestCallback,
+            HmacTestCallback::new(input_data, digest_data)
+        )
+    };};
 }
 
 #[test_case]
@@ -94,7 +96,7 @@ fn hmac_check_load_binary() {
     let perf = unsafe { PERIPHERALS.unwrap() };
     let hmac = &perf.hmac;
 
-    let callback = unsafe { static_init_test_cb() };
+    let callback = unsafe { static_init_test_cb!() };
     let _buf = LeasableMutableBuffer::new(callback.input_buffer.take().unwrap());
 
     debug!("check hmac load binary... ");
@@ -120,7 +122,7 @@ fn hmac_check_verify() {
     let perf = unsafe { PERIPHERALS.unwrap() };
     let hmac = &perf.hmac;
 
-    let callback = unsafe { static_init_test_cb() };
+    let callback = unsafe { static_init_test_cb!() };
 
     let _buf = LeasableMutableBuffer::new(callback.input_buffer.take().unwrap());
 

--- a/kernel/src/component.rs
+++ b/kernel/src/component.rs
@@ -1,38 +1,57 @@
-//! Components extend the functionality of the Tock kernel through a
-//! simple factory method interface.
+//! Components extend the functionality of the Tock kernel through a simple
+//! factory method interface.
 
 /// A component encapsulates peripheral-specific and capsule-specific
-/// initialization for the Tock OS kernel in a factory method,
-/// which reduces repeated code and simplifies the boot sequence.
+/// initialization for the Tock OS kernel in a factory method, which reduces
+/// repeated code and simplifies the boot sequence.
 ///
 /// The `Component` trait encapsulates all of the initialization and
-/// configuration of a kernel extension inside the `finalize()` function
-/// call. The `Output` type defines what type this component generates.
-/// Note that instantiating a component does not necessarily
-/// instantiate the underlying `Output` type; instead, it is typically
-/// instantiated in the `finalize()` method. If instantiating and
-/// initializing the `Output` type requires parameters, these should be
-/// passed in the component's `new()` function.
+/// configuration of a kernel extension inside the `finalize()` function call.
+/// The `Output` type defines what type this component generates. Note that
+/// instantiating a component does not instantiate the underlying `Output` type;
+/// instead, the memory is statically allocated and provided as an argument to
+/// the `finalize()` method, which correctly initializes the memory to
+/// instantiate the `Output` object. If instantiating and initializing the
+/// `Output` type requires parameters, these should be passed in the component's
+/// `new()` function.
+///
+/// Using a component is as follows:
+///
+/// ```rust,ignore
+/// let obj = CapsuleComponent::new(configuration, required_hw)
+///     .finalize(capsule_component_static!());
+/// ```
+///
+/// All required resources and configuration is passed via the constructor, and
+/// all required static memory is defined by the `[name]_component_static!()`
+/// macro and passed to the `finalize()` method.
 pub trait Component {
     /// An optional type to specify the chip or board specific static memory
     /// that a component needs to setup the output object(s). This is the memory
-    /// that `static_init!()` would normally setup, but generic components
-    /// cannot setup static buffers for types which are chip-dependent, so those
+    /// that `static_buf!()` would normally setup, but generic components cannot
+    /// setup static buffers for types which are chip-dependent, so those
     /// buffers have to be passed in manually, and the `StaticInput` type makes
     /// this possible.
     type StaticInput;
 
-    /// The type (e.g., capsule, peripheral) that this implementation
-    /// of Component produces via `finalize()`. This is typically a
-    /// static reference (`&'static`).
+    /// The type (e.g., capsule, peripheral) that this implementation of
+    /// Component produces via `finalize()`. This is typically a static
+    /// reference (`&'static`).
     type Output;
 
     /// A factory method that returns an instance of the Output type of this
-    /// Component implementation. This factory method may only be called once
-    /// per Component instance. Used in the boot sequence to instantiate and
-    /// initialize part of the Tock kernel. Some components need to use the
-    /// `static_memory` argument to allow the board initialization code to pass
-    /// in references to static memory that the component will use to setup the
-    /// Output type object.
+    /// Component implementation. This is used in the boot sequence to
+    /// instantiate and initialize part of the Tock kernel. This factory method
+    /// may only be called once per Component instance.
+    ///
+    /// To enable reusable (i.e. can be used on multiple boards with different
+    /// microcontrollers) and repeatable (i.e. can be instantiated multiple
+    /// times on the same board) components, all components must follow this
+    /// convention:
+    ///
+    /// - All statically allocated memory MUST be passed to `finalize()` via the
+    ///   `static_memory` argument. The `finalize()` method MUST NOT use
+    ///   `static_init!()` or `static_buf!()` directly. This restriction ensures
+    ///   that memory is not aliased if the component is used multiple times.
     unsafe fn finalize(self, static_memory: Self::StaticInput) -> Self::Output;
 }

--- a/kernel/src/utilities/static_init.rs
+++ b/kernel/src/utilities/static_init.rs
@@ -24,8 +24,22 @@ macro_rules! static_init {
     }};
 }
 
+/// An `#[inline(never)]` function that panics internally for use within
+/// the `static_buf!()` macro, which removes the size bloat of track_caller
+/// saving the location of every single call to `static_init!()`.
+/// If you hit this panic, you are either calling `static_buf!()` in
+/// a loop or calling a function multiple times which internally
+/// contains a call to `static_buf!()`. Typically, calls to
+/// `static_buf!()` are hidden within calls to `static_init!()` or
+/// component helper macros, so start your search there.
+#[inline(never)]
+pub fn static_buf_panic() -> ! {
+    panic!("Error! Single static_buf!() called twice.");
+}
+
 /// Allocates a statically-sized global array of memory for data structures but
-/// does not initialize the memory.
+/// does not initialize the memory. Checks that the buffer is not aliased and is
+/// only used once.
 ///
 /// This macro creates the static buffer, and returns a
 /// `StaticUninitializedBuffer` wrapper containing the buffer. The memory is
@@ -51,8 +65,24 @@ macro_rules! static_buf {
     ($T:ty $(,)?) => {{
         // Statically allocate a read-write buffer for the value without
         // actually writing anything.
-        static mut BUF: core::mem::MaybeUninit<$T> = core::mem::MaybeUninit::uninit();
-        &mut BUF
+        static mut BUF: (core::mem::MaybeUninit<$T>, bool) =
+            (core::mem::MaybeUninit::uninit(), false);
+
+        // Check if this `BUF` has already been declared and initialized. If it
+        // has, then this is a repeated `static_buf!()` call which is an error
+        // as it will alias the same `BUF`.
+        let used = BUF.1;
+        if used {
+            // panic, this buf has already been declared and initialized.
+            $crate::utilities::static_init::static_buf_panic();
+        } else {
+            // Otherwise, mark our uninitialized buffer as used.
+            BUF.1 = true;
+        }
+
+        // If we get to this point we can wrap our buffer to be eventually
+        // initialized.
+        &mut BUF.0
     }};
 }
 

--- a/kernel/src/utilities/static_init.rs
+++ b/kernel/src/utilities/static_init.rs
@@ -20,7 +20,7 @@
 macro_rules! static_init {
     ($T:ty, $e:expr $(,)?) => {{
         let mut buf = $crate::static_buf!($T);
-        buf.initialize($e)
+        buf.write($e)
     }};
 }
 
@@ -49,86 +49,11 @@ macro_rules! static_init {
 #[macro_export]
 macro_rules! static_buf {
     ($T:ty $(,)?) => {{
-        // Statically allocate a read-write buffer for the value, write our
-        // initial value into it (without dropping the initial zeros) and
-        // return a reference to it.
-        static mut BUF: $crate::utilities::static_init::UninitializedBuffer<$T> =
-            $crate::utilities::static_init::UninitializedBuffer::new();
-        $crate::utilities::static_init::StaticUninitializedBuffer::new(&mut BUF)
+        // Statically allocate a read-write buffer for the value without
+        // actually writing anything.
+        static mut BUF: core::mem::MaybeUninit<$T> = core::mem::MaybeUninit::uninit();
+        &mut BUF
     }};
-}
-
-use core::mem::MaybeUninit;
-
-/// The `UninitializedBuffer` type is designed to be statically allocated
-/// as a global buffer to hold data structures in Tock. As a static, global
-/// buffer the data structure can then be shared in the Tock kernel.
-///
-/// This type is implemented as a wrapper around a `MaybeUninit<T>` buffer.
-/// To enforce that the global static buffer is initialized exactly once,
-/// this wrapper type ensures that the underlying memory is uninitialized
-/// so that an `UninitializedBuffer` does not contain an initialized value.
-///
-/// The only way to initialize this buffer is to create a
-/// `StaticUninitializedBuffer`, pass the `UninitializedBuffer` to it, and call
-/// `initialize()`. This structure ensures that:
-///
-/// 1. The static buffer is not used while uninitialized. Since the only way to
-///    get the necessary `&'static mut T` is to call `initialize()`, the memory
-///    is guaranteed to be initialized.
-///
-/// 2. A static buffer is not initialized twice. Since the underlying memory is
-///    owned by `UninitializedBuffer` nothing else can initialize it. Also, once
-///    the memory is initialized via `StaticUninitializedBuffer.initialize()`,
-///    the internal buffer is consumed and `initialize()` cannot be called
-///    again.
-#[repr(transparent)]
-pub struct UninitializedBuffer<T>(MaybeUninit<T>);
-
-impl<T> UninitializedBuffer<T> {
-    /// The only way to construct an `UninitializedBuffer` is via this function,
-    /// which initializes it to `MaybeUninit::uninit()`. This guarantees the
-    /// invariant that `UninitializedBuffer` does not contain an initialized
-    /// value.
-    pub const fn new() -> Self {
-        UninitializedBuffer(MaybeUninit::uninit())
-    }
-}
-
-/// The `StaticUninitializedBuffer` type represents a statically allocated
-/// buffer that can be converted to another type once it has been initialized.
-/// Upon initialization, a static mutable reference is returned and the
-/// `StaticUninitializedBuffer` is consumed.
-///
-/// This type is implemented as a wrapper containing a static mutable reference to
-/// an `UninitializedBuffer`. This guarantees that the memory pointed to by the
-/// reference has not already been initialized.
-///
-/// `StaticUninitializedBuffer` provides one operation: `initialize()` that returns a
-/// `&'static mut T` reference. This is the only way to get the reference, and
-/// ensures that the underlying uninitialized buffer is properly initialized.
-/// The wrapper is also consumed when `initialize()` is called, ensuring that
-/// the underlying memory cannot be subsequently re-initialized.
-pub struct StaticUninitializedBuffer<T: 'static> {
-    buf: &'static mut UninitializedBuffer<T>,
-}
-
-impl<T: 'static> StaticUninitializedBuffer<T> {
-    /// This function is not intended to be called publicly. It's only meant to
-    /// be called within `static_buf!` macro, but Rust's visibility rules
-    /// require it to be public, so that the macro's body can be instantiated.
-    pub fn new(buf: &'static mut UninitializedBuffer<T>) -> Self {
-        Self { buf }
-    }
-
-    /// This function consumes an uninitialized static buffer, initializes it
-    /// to some value, and returns a static mutable reference to it. This
-    /// allows for runtime initialization of `static` values that do not have a
-    /// `const` constructor.
-    pub unsafe fn initialize(self, value: T) -> &'static mut T {
-        self.buf.0.write(value);
-        self.buf.0.assume_init_mut()
-    }
 }
 
 /// This macro is deprecated. You should migrate to using `static_buf!`

--- a/kernel/src/utilities/static_init.rs
+++ b/kernel/src/utilities/static_init.rs
@@ -113,7 +113,7 @@ pub struct StaticUninitializedBuffer<T: 'static> {
     buf: &'static mut UninitializedBuffer<T>,
 }
 
-impl<T> StaticUninitializedBuffer<T> {
+impl<T: 'static> StaticUninitializedBuffer<T> {
     /// This function is not intended to be called publicly. It's only meant to
     /// be called within `static_buf!` macro, but Rust's visibility rules
     /// require it to be public, so that the macro's body can be instantiated.
@@ -126,10 +126,8 @@ impl<T> StaticUninitializedBuffer<T> {
     /// allows for runtime initialization of `static` values that do not have a
     /// `const` constructor.
     pub unsafe fn initialize(self, value: T) -> &'static mut T {
-        self.buf.0.as_mut_ptr().write(value);
-        // TODO: use MaybeUninit::get_mut() once that is stabilized (see
-        // https://github.com/rust-lang/rust/issues/63568).
-        &mut *self.buf.0.as_mut_ptr() as &'static mut T
+        self.buf.0.write(value);
+        self.buf.0.assume_init_mut()
     }
 }
 


### PR DESCRIPTION
### Pull Request Overview

This pull request builds on top of #3219 , with some additional optimizations for size to reduce the overhead introduced in #3219. This PR removes `StaticUninitializedBuffer` and `UninitializedBuffer`, since I believe they now offer very little over `MaybeUninit` today (other than a slightly nicer name for `initialize()` vs `write()`.

This combination of changes makes it no longer `unsafe` to call `static_init!()` or `static_buf!()`. A logical followup change is to remove `unsafe` from `static_buf!()` and make `Component::finalize()` safe. This change should allow us to remove >90% of the unsafe code in `main.rs`, a big jump forward for validating memory safety in Tock.

On Imix, this brings the overhead of #3219 down to 1104 bytes. Notably, once Brad finishes porting uses of `static_init_half!()` to `static_buf!()`, this overhead will increase.

Apologies for the weird commit ordering, where #3219 comes after my changes -- I implemented my changes first and then pulled in the #3219 changes in a squashed commit. Ultimately I think that #3219 should just be closed in favor of this PR.

This PR also defines the expected process for a component: _all_ statically declared memory is created in a macro and passed in to `finalize()`. That macro has a naming convention of `[name]_component_static!()`. No memory is statically allocated in `finalize()` (i.e. no static_init! or static_buf! in the finalize function). That macro _only_ statically declares memory.

### Testing Strategy

This pull request was tested by compiling.


### TODO or Help Wanted

~~After this PR is merged, Brad's various component PRs will need to be rebased to use `MaybeUninit` as the `StaticInput` to components.~~


### Documentation Updated

- [x]  Updated.

### Formatting

- [x] Ran `make prepush`.
