### PR TITLE
Sifive uart receive

### DIFF
--- a/boards/README.md
+++ b/boards/README.md
@@ -84,7 +84,7 @@ but the approximate definitions:
 | [WeAct F401CCU6 Core Board](weact_f401ccu6/README.md)             | ARM Cortex-M4    | STM32F401CCU6  | openocd    | custom                      | No            |
 | [SparkFun RedBoard Red-V](redboard_redv/README.md)                | RISC-V           | FE310-G002     | openocd    | tockloader                  | Yes (5.1)     |
 | [SiFive HiFive1 Rev B](hifive1/README.md)                         | RISC-V           | FE310-G002     | openocd    | tockloader                  | Yes (5.1)     |
-| [BBC HiFive Inventor](hifive1/README.md)                          | RISC-V           | FE310-G003     | tockloader | custom                      | No            |
+| [BBC HiFive Inventor](hifive1/README.md)                          | RISC-V           | FE310-G003     | tockloader | tockloader                  | No            |
 | [ESP32-C3-DevKitM-1](esp32-c3-devkitM-1/README.md)                | RISC-V-ish RV32I | ESP32-C3       | custom     | custom                      | No            |
 | [i.MX RT 1052 Evaluation Kit](imxrt1050-evkb/README.md)           | ARM Cortex-M7    | i.MX RT 1052   | custom     | custom                      | No            |
 | [Teensy 4.0](teensy40/README.md)                                  | ARM Cortex-M7    | i.MX RT 1062   | custom     | custom                      | No            |

--- a/boards/hifive1/src/main.rs
+++ b/boards/hifive1/src/main.rs
@@ -237,7 +237,7 @@ pub unsafe fn main() {
         components::process_printer::ProcessPrinterTextComponent::new().finalize(());
     PROCESS_PRINTER = Some(process_printer);
 
-    let _process_console = components::process_console::ProcessConsoleComponent::new(
+    let process_console = components::process_console::ProcessConsoleComponent::new(
         board_kernel,
         uart_mux,
         mux_alarm,
@@ -246,7 +246,7 @@ pub unsafe fn main() {
     .finalize(components::process_console_component_helper!(
         sifive::clint::Clint
     ));
-    let _ = _process_console.start();
+    let _ = process_console.start();
 
     // Need to enable all interrupts for Tock Kernel
     chip.enable_plic_interrupts();

--- a/boards/hifive1/src/main.rs
+++ b/boards/hifive1/src/main.rs
@@ -237,6 +237,17 @@ pub unsafe fn main() {
         components::process_printer::ProcessPrinterTextComponent::new().finalize(());
     PROCESS_PRINTER = Some(process_printer);
 
+    let _process_console = components::process_console::ProcessConsoleComponent::new(
+        board_kernel,
+        uart_mux,
+        mux_alarm,
+        process_printer,
+    )
+    .finalize(components::process_console_component_helper!(
+        sifive::clint::Clint
+    ));
+    let _ = _process_console.start();
+
     // Need to enable all interrupts for Tock Kernel
     chip.enable_plic_interrupts();
 

--- a/boards/hifive_inventor/README.md
+++ b/boards/hifive_inventor/README.md
@@ -16,6 +16,9 @@ peripherals:
 
 ## Programming
 
+When using `tockloader` use settings for board `hifive1b` since they are the
+same (same debugger, same kernel and program memory).
+
 ### Using J-Link
 
 Running `make flash-jlink` should load the kernel onto the board. It requires

--- a/boards/hifive_inventor/src/main.rs
+++ b/boards/hifive_inventor/src/main.rs
@@ -216,7 +216,7 @@ pub unsafe fn main() {
         components::process_printer::ProcessPrinterTextComponent::new().finalize(());
     PROCESS_PRINTER = Some(process_printer);
 
-    let _process_console = components::process_console::ProcessConsoleComponent::new(
+    let process_console = components::process_console::ProcessConsoleComponent::new(
         board_kernel,
         uart_mux,
         mux_alarm,
@@ -225,7 +225,7 @@ pub unsafe fn main() {
     .finalize(components::process_console_component_helper!(
         sifive::clint::Clint
     ));
-    let _ = _process_console.start();
+    let _ = process_console.start();
 
     // Need to enable all interrupts for Tock Kernel
     chip.enable_plic_interrupts();

--- a/boards/hifive_inventor/src/main.rs
+++ b/boards/hifive_inventor/src/main.rs
@@ -216,6 +216,17 @@ pub unsafe fn main() {
         components::process_printer::ProcessPrinterTextComponent::new().finalize(());
     PROCESS_PRINTER = Some(process_printer);
 
+    let _process_console = components::process_console::ProcessConsoleComponent::new(
+        board_kernel,
+        uart_mux,
+        mux_alarm,
+        process_printer,
+    )
+    .finalize(components::process_console_component_helper!(
+        sifive::clint::Clint
+    ));
+    let _ = _process_console.start();
+
     // Need to enable all interrupts for Tock Kernel
     chip.enable_plic_interrupts();
 

--- a/chips/sifive/src/uart.rs
+++ b/chips/sifive/src/uart.rs
@@ -1,6 +1,7 @@
 //! UART driver.
 
 use core::cell::Cell;
+use kernel::utilities::registers::FieldValue;
 use kernel::ErrorCode;
 
 use crate::gpio;
@@ -59,15 +60,37 @@ register_bitfields![u32,
     ]
 ];
 
+#[derive(Copy, Clone, PartialEq)]
+enum UARTStateTX {
+    Idle,
+    Transmitting,
+    AbortRequested,
+}
+
+#[derive(Copy, Clone, PartialEq)]
+enum UARTStateRX {
+    Idle,
+    Receiving,
+    AbortRequested,
+}
+
 pub struct Uart<'a> {
     registers: StaticRef<UartRegisters>,
     clock_frequency: u32,
+    stop_bits: Cell<hil::uart::StopBits>,
+
     tx_client: OptionalCell<&'a dyn hil::uart::TransmitClient>,
     rx_client: OptionalCell<&'a dyn hil::uart::ReceiveClient>,
-    stop_bits: Cell<hil::uart::StopBits>,
-    buffer: TakeCell<'static, [u8]>,
-    len: Cell<usize>,
-    index: Cell<usize>,
+
+    tx_buffer: TakeCell<'static, [u8]>,
+    tx_len: Cell<usize>,
+    tx_position: Cell<usize>,
+    tx_status: Cell<UARTStateTX>,
+
+    rx_buffer: TakeCell<'static, [u8]>,
+    rx_len: Cell<usize>,
+    rx_position: Cell<usize>,
+    rx_status: Cell<UARTStateRX>,
 }
 
 #[derive(Copy, Clone)]
@@ -80,12 +103,20 @@ impl<'a> Uart<'a> {
         Uart {
             registers: base,
             clock_frequency: clock_frequency,
+            stop_bits: Cell::new(hil::uart::StopBits::One),
+
             tx_client: OptionalCell::empty(),
             rx_client: OptionalCell::empty(),
-            stop_bits: Cell::new(hil::uart::StopBits::One),
-            buffer: TakeCell::empty(),
-            len: Cell::new(0),
-            index: Cell::new(0),
+
+            tx_buffer: TakeCell::empty(),
+            tx_len: Cell::new(0),
+            tx_position: Cell::new(0),
+            tx_status: Cell::new(UARTStateTX::Idle),
+
+            rx_buffer: TakeCell::empty(),
+            rx_len: Cell::new(0),
+            rx_position: Cell::new(0),
+            rx_status: Cell::new(UARTStateRX::Idle),
         }
     }
 
@@ -106,6 +137,13 @@ impl<'a> Uart<'a> {
         regs.div.write(div::div.val(divisor));
     }
 
+    fn get_stop_bits(&self) -> FieldValue<u32, txctrl::Register> {
+        match self.stop_bits.get() {
+            hil::uart::StopBits::One => txctrl::nstop::OneStopBit,
+            hil::uart::StopBits::Two => txctrl::nstop::TwoStopBits,
+        }
+    }
+
     pub fn disable(&self) {
         let regs = self.registers;
         regs.txctrl.modify(txctrl::txen::CLEAR);
@@ -120,6 +158,11 @@ impl<'a> Uart<'a> {
         regs.ie.modify(interrupt::txwm::SET);
     }
 
+    fn enable_rx_interrupt(&self) {
+        let regs = self.registers;
+        regs.ie.modify(interrupt::rxwm::SET);
+    }
+
     fn disable_rx_interrupt(&self) {
         let regs = self.registers;
         regs.ie.write(interrupt::rxwm::CLEAR);
@@ -130,6 +173,21 @@ impl<'a> Uart<'a> {
         regs.ie.modify(interrupt::txwm::CLEAR);
     }
 
+    fn uart_is_writable(&self) -> bool {
+        !self.registers.txdata.is_set(txdata::full)
+    }
+
+    fn fill_fifo(&self) {
+        while self.uart_is_writable() && self.tx_position.get() < self.tx_len.get() {
+            self.tx_buffer.map(|buf| {
+                self.registers
+                    .txdata
+                    .set(buf[self.tx_position.get()].into());
+                self.tx_position.replace(self.tx_position.get() + 1);
+            });
+        }
+    }
+
     pub fn handle_interrupt(&self) {
         let regs = self.registers;
 
@@ -137,44 +195,37 @@ impl<'a> Uart<'a> {
         let pending_interrupts = regs.ip.extract();
 
         // Determine why an interrupt occurred.
-        if pending_interrupts.is_set(interrupt::txwm) {
+        if self.tx_status.get() == UARTStateTX::Transmitting
+            && pending_interrupts.is_set(interrupt::txwm)
+        {
             // Got a TX interrupt which means the number of bytes in the FIFO
             // has fallen to zero. If there is more to send do that, otherwise
             // send a callback to the client.
-            if self.len.get() == self.index.get() {
+            if self.tx_len.get() == self.tx_position.get() {
                 // We are done.
                 regs.txctrl.write(txctrl::txen::CLEAR);
                 self.disable_tx_interrupt();
+                self.tx_status.set(UARTStateTX::Idle);
 
                 // Signal client write done
                 self.tx_client.map(|client| {
-                    self.buffer.take().map(|buffer| {
-                        client.transmitted_buffer(buffer, self.len.get(), Ok(()));
+                    self.tx_buffer.take().map(|buffer| {
+                        client.transmitted_buffer(buffer, self.tx_len.get(), Ok(()));
                     });
                 });
             } else {
-                // More to send. Fill the buffer until it is full.
-                self.buffer.map(|buffer| {
-                    for i in self.index.get()..self.len.get() {
-                        // Write the byte from the array to the tx register.
-                        regs.txdata.write(txdata::data.val(buffer[i] as u32));
-                        self.index.set(i + 1);
-                        // Check if the buffer is full
-                        if regs.txdata.is_set(txdata::full) {
-                            // If it is, break and wait for the TX interrupt.
-                            break;
-                        }
-                    }
-                });
+                self.fill_fifo();
             }
         }
     }
 
     pub fn transmit_sync(&self, bytes: &[u8]) {
         let regs = self.registers;
+
         // Make sure the UART is enabled.
         regs.txctrl
-            .write(txctrl::txen::SET + txctrl::nstop::OneStopBit + txctrl::txcnt.val(1));
+            .write(txctrl::txen::SET + self.get_stop_bits() + txctrl::txcnt.val(1));
+
         for b in bytes.iter() {
             while regs.txdata.is_set(txdata::full) {}
             regs.txdata.write(txdata::data.val(*b as u32));
@@ -209,44 +260,33 @@ impl<'a> hil::uart::Transmit<'a> for Uart<'a> {
 
     fn transmit_buffer(
         &self,
-        tx_data: &'static mut [u8],
+        tx_buffer: &'static mut [u8],
         tx_len: usize,
     ) -> Result<(), (ErrorCode, &'static mut [u8])> {
-        let regs = self.registers;
+        if self.tx_status.get() != UARTStateTX::Idle {
+            Err((ErrorCode::BUSY, tx_buffer))
+        } else if tx_len == 0 || tx_len > tx_buffer.len() {
+            Err((ErrorCode::SIZE, tx_buffer))
+        } else {
+            // self.disable_tx_interrupt();
+            self.tx_status.set(UARTStateTX::Transmitting);
 
-        if tx_len == 0 {
-            return Err((ErrorCode::SIZE, tx_data));
+            // Save the buffer so we can keep sending it.
+            self.tx_buffer.replace(tx_buffer);
+            self.tx_len.set(tx_len);
+            self.tx_position.set(0);
+
+            // Enable transmissions, and wait until the FIFO is empty before getting
+            // an interrupt.
+            self.registers
+                .txctrl
+                .write(txctrl::txen::SET + self.get_stop_bits() + txctrl::txcnt.val(1));
+
+            // Enable the interrupt so we know when we can keep writing.
+            self.enable_tx_interrupt();
+
+            Ok(())
         }
-
-        // Enable the interrupt so we know when we can keep writing.
-        self.enable_tx_interrupt();
-
-        // Fill the TX buffer until it reports full.
-        for i in 0..tx_len {
-            // Write the byte from the array to the tx register.
-            regs.txdata.write(txdata::data.val(tx_data[i] as u32));
-            self.index.set(i + 1);
-            // Check if the buffer is full
-            if regs.txdata.is_set(txdata::full) {
-                // If it is, break and wait for the TX interrupt.
-                break;
-            }
-        }
-
-        // Save the buffer so we can keep sending it.
-        self.buffer.replace(tx_data);
-        self.len.set(tx_len);
-
-        // Enable transmissions, and wait until the FIFO is empty before getting
-        // an interrupt.
-        let stop_bits = match self.stop_bits.get() {
-            hil::uart::StopBits::One => txctrl::nstop::OneStopBit,
-            hil::uart::StopBits::Two => txctrl::nstop::TwoStopBits,
-        };
-        regs.txctrl
-            .write(txctrl::txen::SET + stop_bits + txctrl::txcnt.val(1));
-
-        Ok(())
     }
 
     fn transmit_abort(&self) -> Result<(), ErrorCode> {


### PR DESCRIPTION
### Pull Request Overview

This pull request adds receive functionality to the UART HIL implementation for the SiFive chips.

This is done similarly to the `rp2040` chip. 

### Testing Strategy

By adding a `ProcessConsole` to both of the HiFive boards. (I tested the `hifive1` board in QEMU). On the Inventor I flashed the following [example](https://github.com/tock/libtock-c/tree/master/examples) applications from `libtock-c`:

- [x] `c_hello`
- [x] `console`
- [x] `console_recv_long`
- [x] `console_recv_short`

### Help Wanted

This pull request still needs to be tested, I think, with some applications on the `hifive1` board.

@gemarcano could you please do this?

### Documentation Updated

- [x] Updated the relevant files in `boards/README.md`

### Formatting

- [x] Ran `make prepush`.
