### PR TITLE
tock-registers: release v0.8.1

### DIFF
--- a/libraries/tock-register-interface/CHANGELOG.md
+++ b/libraries/tock-register-interface/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## master
 
+## v0.8.1
+
+A point release to allow multiple invocations of `register_fields!` in
+the same module. See the PR and linked Issue for details.
+
+ - #3230: don't encapsulate test_fields! tests in mod
+
 ## v0.8
 
 `tock-registers` now supports stable Rust!

--- a/libraries/tock-register-interface/Cargo.toml
+++ b/libraries/tock-register-interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tock-registers"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
 description = "Memory-Mapped I/O and register interface developed for Tock."
 homepage = "https://www.tockos.org/"


### PR DESCRIPTION
### Pull Request Overview

This pull request prepares a patch release for tock-registers as requested in #3230.


### Testing Strategy

N/A.

### TODO or Help Wanted

N/A.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
