### PR TITLE
boards/opentitan/tests: fixup macro syntax

### DIFF
--- a/boards/opentitan/src/tests/flash_ctrl.rs
+++ b/boards/opentitan/src/tests/flash_ctrl.rs
@@ -89,7 +89,7 @@ macro_rules! static_init_test {
             FlashCtlCallBack,
             FlashCtlCallBack::new(r_in_page, w_in_page)
         )
-    };};
+    }};
 }
 
 /// Tests: Erase Page -> Write Page -> Read Page

--- a/boards/opentitan/src/tests/hmac.rs
+++ b/boards/opentitan/src/tests/hmac.rs
@@ -88,7 +88,7 @@ macro_rules! static_init_test_cb {
             HmacTestCallback,
             HmacTestCallback::new(input_data, digest_data)
         )
-    };};
+    }};
 }
 
 #[test_case]


### PR DESCRIPTION
### Pull Request Overview

The following changes address the compiler warning generated [1] when building tests:

Since: https://github.com/tock/tock/pull/3239

[1]: `warning: trailing semicolon in macro used in expression position`

The exact warning: 
```
warning: trailing semicolon in macro used in expression position
   --> boards/opentitan/earlgrey-cw310/src/tests/flash_ctrl.rs:92:6
    |
92  |     };};
    |      ^
...
104 |     let cb = unsafe { static_init_test!() };
    |                       ------------------- in this macro invocation
    |
    = note: `#[warn(semicolon_in_expressions_from_macros)]` on by default
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #79813 <https://github.com/rust-lang/rust/issues/79813>
    = note: macro invocations at the end of a block are treated as expressions
    = note: to ignore the value produced by the macro, add a semicolon after the invocation of `static_init_test`
    = note: this warning originates in the macro `static_init_test` (in Nightly builds, run with -Z macro-backtrace for more info)
```

### Testing Strategy

Compiling and testing on Verilator

### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
