### PR TITLE
cortex-m: Add initial dwt and dcb support

### DIFF
--- a/arch/cortex-m/src/dcb.rs
+++ b/arch/cortex-m/src/dcb.rs
@@ -52,7 +52,7 @@ pub fn enable_debug_and_trace() {
 }
 
 /// Disable the Debug and Trace unit `DWT`
-pub unsafe fn disable_debug_and_trace() {
+pub fn disable_debug_and_trace() {
     DCB.demcr
         .modify(DebugExceptionAndMonitorControl::TRCENA::CLEAR);
 }

--- a/arch/cortex-m/src/dcb.rs
+++ b/arch/cortex-m/src/dcb.rs
@@ -1,6 +1,6 @@
-//! ARM Data Watchpoit and Trace Unit
+//! ARM Debug Control Block
 //!
-//! <https://developer.arm.com/documentation/100166/0001/Debug/Debug-configuration/Debug-register-summary?lang=en>
+//! <https://developer.arm.com/documentation/ddi0403/latest>
 
 use kernel::utilities::registers::interfaces::ReadWriteable;
 use kernel::utilities::registers::{register_bitfields, register_structs, ReadWrite};

--- a/arch/cortex-m/src/dcb.rs
+++ b/arch/cortex-m/src/dcb.rs
@@ -1,0 +1,58 @@
+//! ARM Data Watchpoit and Trace Unit
+//!
+//! <https://developer.arm.com/documentation/100166/0001/Debug/Debug-configuration/Debug-register-summary?lang=en>
+
+use kernel::utilities::registers::interfaces::ReadWriteable;
+use kernel::utilities::registers::{register_bitfields, register_structs, ReadWrite};
+use kernel::utilities::StaticRef;
+
+//TODO: Rest of the Registers
+register_structs! {
+    DcbRegisters{
+        (0x00 => demcr: ReadWrite<u32, DebugExceptionAndMonitorControl::Register>),
+
+        (0x04 => @END),
+    }
+}
+
+register_bitfields![u32,
+    DebugExceptionAndMonitorControl [
+        /// Write 1 to globally enable all DWT and ITM features.
+        /// RW.
+        TRCENA          OFFSET(24)  NUMBITS(1),
+
+        /// Debug monitor semaphore bit.
+        /// Monitor software defined.
+        /// RW.
+        MON_REQ         OFFSET(19)  NUMBITS(1),
+
+        /// Write 1 to make step request pending.
+        /// RW.
+        MON_STEP        OFFSET(18)  NUMBITS(1),
+/// Write 0 to clear the pending state of the DebugMonitor exception.
+        /// Writing 1 pends the exception.
+        /// RW.
+        MON_PEND        OFFSET(17)  NUMBITS(1),
+
+        /// Write 1 to enable DebugMonitor exception.
+        /// RW.
+        MON_EN        OFFSET(16)  NUMBITS(1),
+
+        //TODO: Rest
+    ],
+];
+
+const DCB: StaticRef<DcbRegisters> = unsafe { StaticRef::new(0xE000EDFC as *const DcbRegisters) };
+
+/// Enable the Debug and Trace unit `DWT`
+/// This has to be enabled before using any feature of the `DWT`
+pub fn enable_debug_and_trace() {
+    DCB.demcr
+        .modify(DebugExceptionAndMonitorControl::TRCENA::SET);
+}
+
+/// Disable the Debug and Trace unit `DWT`
+pub unsafe fn disable_debug_and_trace() {
+    DCB.demcr
+        .modify(DebugExceptionAndMonitorControl::TRCENA::CLEAR);
+}

--- a/arch/cortex-m/src/dcb.rs
+++ b/arch/cortex-m/src/dcb.rs
@@ -1,6 +1,7 @@
 //! ARM Debug Control Block
 //!
 //! <https://developer.arm.com/documentation/ddi0403/latest>
+//! Implementation matches `ARM DDI 0403E.e`
 
 use kernel::utilities::registers::interfaces::ReadWriteable;
 use kernel::utilities::registers::{register_bitfields, register_structs, ReadWrite};
@@ -9,33 +10,63 @@ use kernel::utilities::StaticRef;
 //TODO: Rest of the Registers
 register_structs! {
     DcbRegisters{
-        (0x00 => demcr: ReadWrite<u32, DebugExceptionAndMonitorControl::Register>),
+        (0x00 => dhcsr: ReadWrite<u32, DebugHaltingControlAndStatus::Register>),
 
-        (0x04 => @END),
+        (0x04 => dhrsr: Read<u32, DebugCoreSelectorData::Register>),
+
+        (0x08 => dcrdr: ReadWrite<u32, DebugCoreRegisterData::Register>),
+
+        (0x12 => demcr: ReadWrite<u32, DebugExceptionAndMonitorControl::Register>),
+
+        (0x16 => @END),
     }
 }
 
 register_bitfields![u32,
+    DebugHaltingControlAndStatus [
+        /// Debug key. 0xA05F must be written to enable write access to bits 15 through 0.
+        /// WO.
+        DBGKEY          OFFSET(16)  NUMBITS(16),
+
+        /// Is 1 if at least one reset happend since last read of this register. Is cleared to 0 on
+        /// read.
+        /// RO.
+        S_RESET_ST      OFFSET(25)  NUMBITS(1),
+
+        /// Is 1 if at least one instruction was retired since last read of this register.
+        /// It is cleared to 0 after a read of this register.
+        /// RO.
+        S_RETIRE_ST     OFFSET(24)  NUMBITS(1),
+
+        /// Is 1 when the processor is locked up doe tu an unrecoverable instruction.
+        /// RO.
+        S_LOCKUP        OFFSET(20)  NUMBITS(4),
+
+        /// Is 1 if processor is in debug state.
+        /// RO.
+        S_SLEEP         OFFSET(18)  NUMBITS(1),
+
+        /// Is used as a handshake flag for transfers through DCRDR. Writing to DCRSR clears this
+        /// bit to 0. Is 0 if there is a transfer that has not completed and 1 on completion of the DCRSR transfer.
+        ///
+        /// RW.
+        S_REGREADY      OFFSET(16)  NUMBITS(1),
+    ],
     DebugExceptionAndMonitorControl [
         /// Write 1 to globally enable all DWT and ITM features.
-        /// RW.
         TRCENA          OFFSET(24)  NUMBITS(1),
 
         /// Debug monitor semaphore bit.
         /// Monitor software defined.
-        /// RW.
         MON_REQ         OFFSET(19)  NUMBITS(1),
 
         /// Write 1 to make step request pending.
-        /// RW.
         MON_STEP        OFFSET(18)  NUMBITS(1),
 /// Write 0 to clear the pending state of the DebugMonitor exception.
         /// Writing 1 pends the exception.
-        /// RW.
         MON_PEND        OFFSET(17)  NUMBITS(1),
 
         /// Write 1 to enable DebugMonitor exception.
-        /// RW.
         MON_EN        OFFSET(16)  NUMBITS(1),
 
         //TODO: Rest

--- a/arch/cortex-m/src/dwt.rs
+++ b/arch/cortex-m/src/dwt.rs
@@ -1,0 +1,502 @@
+//! ARM Data Watchpoit and Trace Unit
+//!
+//! <https://developer.arm.com/documentation/100166/0001/Data-Watchpoint-and-Trace-Unit/DWT-Programmers--model?lang=en>
+
+use kernel::utilities::registers::interfaces::{ReadWriteable, Readable};
+use kernel::utilities::registers::{register_bitfields, register_structs, ReadOnly, ReadWrite};
+use kernel::utilities::StaticRef;
+use kernel::ErrorCode;
+
+register_structs! {
+    /// In an ARMv7-M processor, a System Control Block (SCB) in the SCS
+    /// provides key status information and control features for the processor.
+    DwtRegisters {
+        // Control Register
+        (0x00 => ctrl: ReadWrite<u32, Control::Register>),
+
+        // Cycle Count Register
+        (0x04 => cyccnt: ReadWrite<u32, CycleCount::Register>),
+
+        // CPI Count Register
+        (0x08 => cpicnt: ReadWrite<u32, CpiCount::Register>),
+
+        // Exception Overhead Register
+        (0x0C => exccnt: ReadWrite<u32, ExceptionOverheadCount::Register>),
+
+        // Sleep Count Register
+        (0x10 => sleepcnt: ReadWrite<u32, SleepCount::Register>),
+
+        // LSU Count Register
+        (0x14 => lsucnt: ReadWrite<u32, LsuCount::Register>),
+
+        // Folder-Instruction Count Register
+        (0x18 => foldcnt: ReadWrite<u32, FoldedInstructionCount::Register>),
+
+        // Program Count Sample Register
+        (0x1C => pcsr: ReadOnly<u32, ProgramCounterSample::Register>),
+
+        // Comparator Register0
+        (0x20 => comp0: ReadWrite<u32, Comparator0::Register>),
+
+        // Mask Regsiter0
+        // The maximum mask size is 32KB
+        (0x24 => mask0: ReadWrite<u32, Comparator0Mask::Register>),
+
+        // Function Register0
+        (0x28 => function0: ReadWrite<u32, Comparator0Function::Register>),
+
+        (0x2c => _reserved0),
+
+        // Comparator Register1
+        (0x30 => comp1: ReadWrite<u32, Comparator1::Register>),
+
+        // Mask Regsiter1
+        // The maximum mask size is 32KB
+        (0x34 => mask1: ReadWrite<u32, Comparator1Mask::Register>),
+
+        // Function Register1
+        (0x38 => function1: ReadWrite<u32, Comparator1Function::Register>),
+
+        (0x3c => _reserved1),
+
+        // Comparator Register2
+        (0x40 => comp2: ReadWrite<u32, Comparator2::Register>),
+
+        // Mask Regsiter2
+        // The maximum mask size is 32KB
+        (0x44 => mask2: ReadWrite<u32, Comparator2Mask::Register>),
+
+        // Function Register2
+        (0x48 => function2: ReadWrite<u32, Comparator2Function::Register>),
+
+        (0x4c => _reserved2),
+
+        // Comparator Register3
+        (0x50 => comp3: ReadWrite<u32, Comparator3::Register>),
+
+        // Mask Regsiter3
+        // The maximum mask size is 33KB
+        (0x54 => mask3: ReadWrite<u32, Comparator3Mask::Register>),
+
+        // Function Register3
+        (0x58 => function3: ReadWrite<u32, Comparator3Function::Register>),
+
+        (0x5c => @END),
+        /*
+        // TODO: register_bitfields
+        // Peripheral Identification Register 4
+        (0xFD0 => pid4: ReadOnly<u32, Pid4::Register>),
+
+        // Peripheral Identification Register 5
+        (0xFD4 => pid5: ReadOnly<u32, Pid5::Register>),
+
+        // Peripheral Identification Register 6
+        (0xFD8 => pid6: ReadOnly<u32, Pid6::Register>),
+
+        // Peripheral Identification Register 7
+        (0xFDC => pid7: ReadOnly<u32, Pid7::Register>),
+
+        // Peripheral Identification Register 0
+        (0xFE0 => pid0: ReadOnly<u32, Pid0::Register>),
+
+        // Peripheral Identification Register 1
+        (0xFE4 => pid1: ReadOnly<u32, Pid1::Register>),
+
+        // Peripheral Identification Register 2
+        (0xFE8 => pid2: ReadOnly<u32, Pid2::Register>),
+
+        // Peripheral Identification Register 3
+        (0xFEC => pid3: ReadOnly<u32, Pid3::Register>),
+
+        // Component Identification Register 0
+        (0xFF0 => cid0: ReadOnly<u32, Cid0::Register>),
+
+        // Component Identification Register 1
+        (0xFF4 => cid1: ReadOnly<u32, Cid1::Register>),
+
+        // Component Identification Register 2
+        (0xFF8 => cid2: ReadOnly<u32, Cid2::Register>),
+
+        // Component Identification Register 3
+        (0xFFC => cid3: ReadOnly<u32, Cid3::Register>),
+
+        (0x2000 => @END),
+*/
+    }
+}
+
+register_bitfields![u32,
+    Control [
+        /// Number of Camparators implemented.
+        /// RO.
+        NUMCOMP         OFFSET(28)  NUMBITS(4),
+
+        /// Shows if trace sampling and exception tracing is implemented
+        /// Is 0 if supported, is 1 if it is not.
+        /// RO
+        NOTRCPKT        OFFSET(27)  NUMBITS(1),
+
+        /// Shows if external match signals ([`CMPMATCH`]) are implemented
+        /// Is 0 if supported, is 1 if it is not.
+        /// RO
+        NOEXITTRIG      OFFSET(26)  NUMBITS(1),
+
+        /// Shows if the cycle counter is implemented
+        /// Is 0 if supported, is 1 if it is not.
+        /// RO
+        NOCYCCNT        OFFSET(25)  NUMBITS(1),
+
+        /// Shows if profiling counters are supported.
+        /// Is 0 if supported, is 1 if it is not.
+        /// RO
+        NOPERFCNT       OFFSET(24)  NUMBITS(1),
+
+        /// Writing 1 enables event counter packets generation if [`PCSAMPLENA`] is set to 0.
+        /// Defaults to 0b0 on reset.
+        /// WARN: This bit is UNKNOWN if `NOTPRCPKT` or `NOCYCCNT` is read as one.
+        /// RW
+        CYCEVTENA       OFFSET(22)  NUMBITS(1),
+
+        /// Writing 1 enables generation of folded instruction counter overflow event. Defaults to
+        /// 0b0 on reset.
+        /// WARN: This bit is UNKNOWN if `NOPERFCNT` reads as one.
+        /// RW
+        FOLDEVTENA      OFFSET(21)  NUMBITS(1),
+
+        /// Writing 1 enables generation of LSU counter overflow event.
+        /// Defaults to 0b0 on reset.
+        /// WARN: This bit is UNKNOWN if `NOPERFCNT` reads as one.
+        /// RW
+        LSUEVTENA       OFFSET(20)  NUMBITS(1),
+
+        /// Writing 1 enables generation of sleep counter overflow event.
+        /// Defaults to 0b0 on reset.
+        /// WARN: This bit is UNKNOWN if `NOPERFCNT` reads as one.
+        /// RW
+        SLEEPEVTENA     OFFSET(19)  NUMBITS(1),
+
+        /// Writing 1 enables generation of exception overhead counter overflow event.
+        /// Defaults to 0b0 on reset.
+        /// WARN: This bit is UNKNOWN if `NOPERFCNT` reads as one.
+        /// RW
+        EXCEVTENA       OFFSET(18)  NUMBITS(1),
+
+        /// Writing 1 enables generation of the CPI counter overlow event.
+        /// Defaults to 0b0 on reset.
+        /// WARN: This bit is UNKNOWN if `NOPERFCNT` reads as one.
+        /// RW
+        CPIEVTENA       OFFSET(17)  NUMBITS(1),
+
+        /// Writing 1 enables generation of exception trace.
+        /// Defaults to 0b0 on reset.
+        /// WARN: This bit is UNKNOWN if `NOTRCPKT` reads as one.
+        /// RW
+        EXCTRCENA       OFFSET(16)  NUMBITS(1),
+
+        /// Writing 1 enables use of [`POSTCNT`] counter as a timer for Periodic PC sample packet
+        /// generation.
+        /// Defaults to 0b0 on reset.
+        /// WARN: This bit is UNKNOWN if `NOTRCPKT` or `NOCYCCNT` read as one.
+        /// RW
+        PCSAMPLENA      OFFSET(12)  NUMBITS(1),
+
+        /// Determines the position of synchronisation packet counter tap on the `CYCCNT` counter
+        /// and thus the synchronisation packet rate.
+        /// Defaults to UNKNOWN on reset.
+        /// WARN: This bit is UNKNOWN if `NOCYCCNT` reads as one.
+        /// RW
+        SYNCTAP         OFFSET(10)  NUMBITS(2),
+
+        /// Determines the position of the `POSTCNT` tap on the `CYCCNT` counter.
+        /// Defaults to UNKNOWN on reset.
+        /// WARN: This bit is UNKNOWN if `NOCYCCNT` reads as one.
+        /// RW
+        CYCTAP          OFFSET(9)  NUMBITS(1),
+
+        /// Initial value for the `POSTCNT` counter.
+        /// Defaults to UNKNOWN on reset.
+        /// WARN: This bit is UNKNOWN if `NOCYCCNT` reads as one.
+        /// RW
+        POSTINIT        OFFSET(8)  NUMBITS(4),
+
+        /// Reload value for the `POSTCNT` counter.
+        /// Defaults to UNKNOWN on reset.
+        /// WARN: This bit is UNKNOWN if `NOCYCCNT` reads as one.
+        /// RW
+        POSTPRESET      OFFSET(1)  NUMBITS(4),
+
+        /// Writing 1 enables `CYCCNT`.
+        /// Defaults to 0b0 on reset.
+        /// WARN: This bit is UNKNOWN if `NOCYCCNT` reads as one.
+        /// RW
+        CYCNTENA       OFFSET(0)  NUMBITS(1),
+    ],
+
+    CycleCount[
+        /// When enabled, increases on each processor clock cycle when Control::CYCNTENA and
+        /// DEMCRL::TRCENA read as one.
+        /// Wraps to zero on overflow.
+        CYCCNT          OFFSET(0)   NUMBITS(32),
+    ],
+
+    CpiCount[
+        /// Base instruction overhead counter.
+        CPICNT          OFFSET(0)   NUMBITS(8),
+    ],
+
+    ExceptionOverheadCount[
+        /// Counts cycles spent in exception processing.
+        EXCCNT          OFFSET(0)   NUMBITS(8),
+    ],
+
+    SleepCount[
+        /// Counts each cycle the processor is sleeping.
+        SLEEPCNT        OFFSET(0)   NUMBITS(8),
+    ],
+
+    LsuCount[
+        /// Counts additional cycles required to excecute all load store instructions
+        LSUCNT          OFFSET(0)   NUMBITS(8),
+    ],
+
+    FoldedInstructionCount[
+        /// Increments by one for each instruction that takes 0 cycles to excecute.
+        FOLDCNT          OFFSET(0)   NUMBITS(8),
+    ],
+
+    ProgramCounterSample[
+        /// Samples current value of the program counter
+        /// RO.
+        EIASAMPLE       OFFSET(0)   NUMBITS(32),
+    ],
+
+    Comparator0[
+        /// Reference value for comparator 0.
+        COMP       OFFSET(0)   NUMBITS(32),
+    ],
+
+    Comparator0Mask[
+        /// Size of ignore mask aplied to the access address for address range matching by comparator 0.
+        /// WARN: Maximum Mask size is IMPLEMENTATION DEFINED.
+        MASK       OFFSET(0)   NUMBITS(5),
+    ],
+
+    Comparator0Function[
+        /// Is one if comparator matches. Reading the register clears it to 0.
+        /// RO.
+        MATCHED     OFFSET(24)   NUMBITS(1),
+
+        /// Second comparator number for linked address comparison.
+        /// Works, when `DATAVMATCH` and `LNK1ENA` read as one.
+        /// RW.
+        DATAVADDR1  OFFSET(16)   NUMBITS(4),
+
+        /// Comparator number for linked address comparison.
+        /// Works, when `DATAVMATCH` reads as one.
+        /// RW.
+        DATAVADDR0  OFFSET(12)   NUMBITS(4),
+
+        /// Size of data comparision (Byte, Halfword, Word).
+        /// RW.
+        DATAVSIZE   OFFSET(10)   NUMBITS(2),
+
+        /// Reads as one if a second linked comparator is supported.
+        LNK1ENA     OFFSET(9)    NUMBITS(1),
+
+        /// Enables data value comparison
+        /// When 0: Perform address comparison, when 1: data value comparison.
+        /// RW.
+        DATAVMATCH  OFFSET(8)    NUMBITS(1),
+
+        /// Enable cycle count comparision for comparator 0.
+        /// WARN: Only supported by FUNCTION0
+        /// RW.
+        CYCMATCH    OFFSET(7)    NUMBITS(1),
+
+        /// Write 1 to enable generation of data trace address packets.
+        /// WARN: If `Control::NOTRCPKT` reads as zero, this bit is UNKNOWN.
+        /// RW.
+        EMITRANGE   OFFSET(5)    NUMBITS(1),
+
+        /// Selects action taken on comparator match.
+        /// Resets to 0b0000.
+        /// RW.
+        FUNCTION    OFFSET(0)    NUMBITS(4),
+    ],
+
+    Comparator1[
+        /// Reference value for comparator 0.
+        COMP       OFFSET(0)   NUMBITS(32),
+    ],
+
+    Comparator1Mask[
+        /// Size of ignore mask aplied to the access address for address range matching by comparator 0.
+        /// WARN: Maximum Mask size is IMPLEMENTATION DEFINED.
+        MASK       OFFSET(0)   NUMBITS(5),
+    ],
+
+    Comparator1Function[
+        /// Is one if comparator matches. Reading the register clears it to 0.
+        /// RO.
+        MATCHED     OFFSET(24)   NUMBITS(1),
+
+        /// Second comparator number for linked address comparison.
+        /// Works, when `DATAVMATCH` and `LNK1ENA` read as one.
+        /// RW.
+        DATAVADDR1  OFFSET(16)   NUMBITS(4),
+
+        /// Comparator number for linked address comparison.
+        /// Works, when `DATAVMATCH` reads as one.
+        /// RW.
+        DATAVADDR0  OFFSET(12)   NUMBITS(4),
+
+        /// Size of data comparision (Byte, Halfword, Word).
+        /// RW.
+        DATAVSIZE   OFFSET(10)   NUMBITS(2),
+
+        /// Reads as one if a second linked comparator is supported.
+        LNK1ENA     OFFSET(9)    NUMBITS(1),
+
+        /// Enables data value comparison
+        /// When 0: Perform address comparison, when 1: data value comparison.
+        /// RW.
+        DATAVMATCH  OFFSET(8)    NUMBITS(1),
+
+        /// Write 1 to enable generation of data trace address packets.
+        /// WARN: If `Control::NOTRCPKT` reads as zero, this bit is UNKNOWN.
+        /// RW.
+        EMITRANGE   OFFSET(5)    NUMBITS(1),
+
+        /// Selects action taken on comparator match.
+        /// Resets to 0b0000.
+        /// RW.
+        FUNCTION    OFFSET(0)    NUMBITS(4),
+    ],
+
+    Comparator2[
+        /// Reference value for comparator 0.
+        COMP       OFFSET(0)   NUMBITS(32),
+    ],
+
+    Comparator2Mask[
+        /// Size of ignore mask aplied to the access address for address range matching by comparator 0.
+        /// WARN: Maximum Mask size is IMPLEMENTATION DEFINED.
+        MASK       OFFSET(0)   NUMBITS(5),
+    ],
+
+    Comparator2Function[
+        /// Is one if comparator matches. Reading the register clears it to 0.
+        /// RO.
+        MATCHED     OFFSET(24)   NUMBITS(1),
+
+        /// Second comparator number for linked address comparison.
+        /// Works, when `DATAVMATCH` and `LNK1ENA` read as one.
+        /// RW.
+        DATAVADDR1  OFFSET(16)   NUMBITS(4),
+
+        /// Comparator number for linked address comparison.
+        /// Works, when `DATAVMATCH` reads as one.
+        /// RW.
+        DATAVADDR0  OFFSET(12)   NUMBITS(4),
+
+        /// Size of data comparision (Byte, Halfword, Word).
+        /// RW.
+        DATAVSIZE   OFFSET(10)   NUMBITS(2),
+
+        /// Reads as one if a second linked comparator is supported.
+        LNK1ENA     OFFSET(9)    NUMBITS(1),
+
+        /// Enables data value comparison
+        /// When 0: Perform address comparison, when 1: data value comparison.
+        /// RW.
+        DATAVMATCH  OFFSET(8)    NUMBITS(1),
+
+        /// Write 1 to enable generation of data trace address packets.
+        /// WARN: If `Control::NOTRCPKT` reads as zero, this bit is UNKNOWN.
+        /// RW.
+        EMITRANGE   OFFSET(5)    NUMBITS(1),
+
+        /// Selects action taken on comparator match.
+        /// Resets to 0b0000.
+        /// RW.
+        FUNCTION    OFFSET(0)    NUMBITS(4),
+    ],
+
+    Comparator3[
+        /// Reference value for comparator 0.
+        COMP       OFFSET(0)   NUMBITS(32),
+    ],
+
+    Comparator3Mask[
+        /// Size of ignore mask aplied to the access address for address range matching by comparator 0.
+        /// WARN: Maximum Mask size is IMPLEMENTATION DEFINED.
+        MASK       OFFSET(0)   NUMBITS(5),
+    ],
+
+    Comparator3Function[
+        /// Is one if comparator matches. Reading the register clears it to 0.
+        /// RO.
+        MATCHED     OFFSET(24)   NUMBITS(1),
+
+        /// Second comparator number for linked address comparison.
+        /// Works, when `DATAVMATCH` and `LNK1ENA` read as one.
+        /// RW.
+        DATAVADDR1  OFFSET(16)   NUMBITS(4),
+
+        /// Comparator number for linked address comparison.
+        /// Works, when `DATAVMATCH` reads as one.
+        /// RW.
+        DATAVADDR0  OFFSET(12)   NUMBITS(4),
+
+        /// Size of data comparision (Byte, Halfword, Word).
+        /// RW.
+        DATAVSIZE   OFFSET(10)   NUMBITS(2),
+
+        /// Reads as one if a second linked comparator is supported.
+        LNK1ENA     OFFSET(9)    NUMBITS(1),
+
+        /// Enables data value comparison
+        /// When 0: Perform address comparison, when 1: data value comparison.
+        /// RW.
+        DATAVMATCH  OFFSET(8)    NUMBITS(1),
+
+        /// Write 1 to enable generation of data trace address packets.
+        /// WARN: If `Control::NOTRCPKT` reads as zero, this bit is UNKNOWN.
+        /// RW.
+        EMITRANGE   OFFSET(5)    NUMBITS(1),
+
+        /// Selects action taken on comparator match.
+        /// Resets to 0b0000.
+        /// RW.
+        FUNCTION    OFFSET(0)    NUMBITS(4),
+    ],
+
+];
+
+const DWT: StaticRef<DwtRegisters> = unsafe { StaticRef::new(0xE0001000 as *const DwtRegisters) };
+
+/// Enable the cycle counter
+/// [`DCB::enable_debug_and_trace()`] needs to be enabled for this to work
+pub fn enable_cycle_counter() {
+    DWT.ctrl.modify(Control::CYCNTENA::SET);
+}
+
+/// Disable the cycle counter
+pub unsafe fn disable_cycle_counter() {
+    DWT.ctrl.modify(Control::CYCNTENA::CLEAR);
+}
+
+/// Returns the current cycle count
+pub fn cycle_count() -> u32 {
+    DWT.cyccnt.read(CycleCount::CYCCNT)
+}
+
+/// Returns wether a cycle counter is present on the chip.
+/// Returns an Result<> type because CommandReturn::From supports it
+pub fn is_cycle_counter_present() -> Result<(), ErrorCode> {
+    if DWT.ctrl.read(Control::NOCYCCNT) == 0 {
+        Ok(())
+    } else {
+        Err(ErrorCode::NOSUPPORT)
+    }
+}

--- a/arch/cortex-m/src/dwt.rs
+++ b/arch/cortex-m/src/dwt.rs
@@ -1,4 +1,4 @@
-//! ARM Data Watchpoit and Trace Unit
+//! ARM Data Watchpoint and Trace Unit
 //!
 //! <https://developer.arm.com/documentation/100166/0001/Data-Watchpoint-and-Trace-Unit/DWT-Programmers--model?lang=en>
 

--- a/arch/cortex-m/src/dwt.rs
+++ b/arch/cortex-m/src/dwt.rs
@@ -2,6 +2,7 @@
 //!
 //! <https://developer.arm.com/documentation/100166/0001/Data-Watchpoint-and-Trace-Unit/DWT-Programmers--model?lang=en>
 
+use super::dcb;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable};
 use kernel::utilities::registers::{register_bitfields, register_structs, ReadOnly, ReadWrite};
 use kernel::utilities::StaticRef;
@@ -476,8 +477,8 @@ register_bitfields![u32,
 const DWT: StaticRef<DwtRegisters> = unsafe { StaticRef::new(0xE0001000 as *const DwtRegisters) };
 
 /// Enable the cycle counter
-/// [`DCB::enable_debug_and_trace()`] needs to be enabled for this to work
 pub fn enable_cycle_counter() {
+    dcb::enable_debug_and_trace();
     DWT.ctrl.modify(Control::CYCNTENA::SET);
 }
 

--- a/arch/cortex-m/src/lib.rs
+++ b/arch/cortex-m/src/lib.rs
@@ -8,6 +8,8 @@
 
 use core::fmt::Write;
 
+pub mod dcb;
+pub mod dwt;
 pub mod mpu;
 pub mod nvic;
 pub mod scb;

--- a/boards/nordic/nrf52840dk/Cargo.toml
+++ b/boards/nordic/nrf52840dk/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 components = { path = "../../components" }
 cortexm4 = { path = "../../../arch/cortex-m4" }
+cortexm = { path="../../../arch/cortex-m" }
 capsules = { path = "../../../capsules" }
 kernel = { path = "../../../kernel" }
 nrf52840 = { path = "../../../chips/nrf52840" }

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -75,6 +75,7 @@ use capsules::net::ipv6::ip_utils::IPAddr;
 use capsules::perf::Perf;
 use capsules::virtual_aes_ccm::MuxAES128CCM;
 use capsules::virtual_alarm::VirtualMuxAlarm;
+use cortexm::dwt;
 use kernel::component::Component;
 use kernel::dynamic_deferred_call::{DynamicDeferredCall, DynamicDeferredCallClientState};
 use kernel::hil::i2c::{I2CMaster, I2CSlave};
@@ -196,7 +197,7 @@ pub struct Platform {
     >,
     scheduler: &'static RoundRobinSched<'static>,
     systick: cortexm4::systick::SysTick,
-    perf: &'static Perf,
+    perf: &'static Perf<'static>,
 }
 
 impl SyscallDriverLookup for Platform {
@@ -666,7 +667,7 @@ pub unsafe fn main() {
     let scheduler = components::sched::round_robin::RoundRobinComponent::new(&PROCESSES)
         .finalize(components::rr_component_helper!(NUM_PROCS));
 
-    let perf = static_init!(capsules::perf::Perf, capsules::perf::Perf::new());
+    let perf = static_init!(capsules::perf::Perf<dwt::Dwt>, capsules::perf::Perf::new());
     let platform = Platform {
         button,
         ble_radio,

--- a/capsules/Cargo.toml
+++ b/capsules/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2021"
 kernel = { path = "../kernel" }
 enum_primitive = { path = "../libraries/enum_primitive" }
 tickv = { path = "../libraries/tickv" }
+cortexm = { path = "../arch/cortex-m" }

--- a/capsules/src/driver.rs
+++ b/capsules/src/driver.rs
@@ -79,5 +79,6 @@ pub enum NUM {
     Touch                 = 0x90002,
     TextScreen            = 0x90003,
     SevenSegment          = 0x90004,
+    Perf                  = 0x90005,
 }
 }

--- a/capsules/src/lib.rs
+++ b/capsules/src/lib.rs
@@ -66,6 +66,7 @@ pub mod nonvolatile_to_pages;
 pub mod nrf51822_serialization;
 pub mod panic_button;
 pub mod pca9544a;
+pub mod perf;
 pub mod process_console;
 pub mod proximity;
 pub mod public_key_crypto;

--- a/capsules/src/perf.rs
+++ b/capsules/src/perf.rs
@@ -1,0 +1,49 @@
+//! Provides a performance counter interface for userspace.
+//!
+//! Usage
+//! -----
+//!
+//! When loading this capsule, the required performance counters are activated.
+
+/// Syscall driver number.
+use crate::driver;
+pub const DRIVER_NUM: usize = driver::NUM::Perf as usize;
+
+use cortexm::{dcb, dwt};
+use kernel::{
+    syscall::{CommandReturn, SyscallDriver},
+    ErrorCode, ProcessId,
+};
+
+pub struct Perf;
+
+impl Perf {
+    pub fn new() -> Self {
+        dcb::enable_debug_and_trace();
+        dwt::enable_cycle_counter();
+        Perf {}
+    }
+}
+
+impl SyscallDriver for Perf {
+    /// Control the Perf system.
+    ///
+    /// ### `command_num`
+    ///
+    /// - `0`: Driver check.
+    /// - `1`: Get current cycle count.
+    fn command(&self, command_num: usize, _data: usize, _: usize, _: ProcessId) -> CommandReturn {
+        match command_num {
+            0 /* check if present */ => CommandReturn::from(dwt::is_cycle_counter_present()),
+
+            1  =>
+                CommandReturn::success_u32( dwt::cycle_count() ),
+
+            _ => CommandReturn::failure(ErrorCode::NOSUPPORT),
+        }
+    }
+
+    fn allocate_grant(&self, _processid: ProcessId) -> Result<(), kernel::process::Error> {
+        Ok(())
+    }
+}

--- a/capsules/src/perf.rs
+++ b/capsules/src/perf.rs
@@ -19,7 +19,6 @@ pub struct Perf;
 
 impl Perf {
     pub fn new() -> Self {
-        dcb::enable_debug_and_trace();
         dwt::enable_cycle_counter();
         Perf {}
     }

--- a/kernel/src/hil/debug.rs
+++ b/kernel/src/hil/debug.rs
@@ -1,0 +1,15 @@
+/// Interface for interacting with debug hardware integrated in various SoCs.
+/// Currently allows reading the cycle counter and can be expanded to allow
+/// access to other features in the future.
+use crate::ErrorCode;
+
+pub trait PerformanceCounters {
+    /// Enable the cycle counter. Returns an error, if the cycle counter is not present.
+    fn enable_cycle_counter() -> Result<(), ErrorCode>;
+
+    /// Disable the cycle counter. Returns an error, if the cycle counter is not present.
+    fn disable_cycle_counter() -> Result<(), ErrorCode>;
+
+    /// Return the current value of the cycle counter.
+    fn cycle_count() -> u32;
+}

--- a/kernel/src/hil/mod.rs
+++ b/kernel/src/hil/mod.rs
@@ -7,6 +7,7 @@ pub mod bus8080;
 pub mod buzzer;
 pub mod crc;
 pub mod dac;
+pub mod debug;
 pub mod digest;
 pub mod eic;
 pub mod entropy;


### PR DESCRIPTION
### Pull Request Overview

The DWT and DCB peripherals are used to access various debug functionality in the chip, such as various counters.
This commit adds register descriptions for most of the DWT and some of the DCB. It also adds a very simple capsule that allows reading the cycle counter from userspace.

### Testing Strategy

This pull request was tested by getting the cycle count and it checks out.


### TODO or Help Wanted

This pull request still needs the rest of the registers of some peripherals. 

The capsule needs to be added to every supported board and could be expanded to grant access to the other capabilities of the peripherals. We also need to consider security implications for allowing debug peripherals in userspace.


### Documentation Updated

- [ ] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
