### PR TITLE
boards/opentitan: fixup tickv & flash: add safegaurds

### DIFF
--- a/boards/opentitan/src/main.rs
+++ b/boards/opentitan/src/main.rs
@@ -493,11 +493,12 @@ unsafe fn setup() -> (
     // TicKV
     let tickv = components::tickv::TicKVComponent::new(
         sip_hash,
-        &mux_flash,                                  // Flash controller
-        0x2007F800 / lowrisc::flash_ctrl::PAGE_SIZE, // Region offset (size / page_size)
-        0x7F800,                                     // Region size
-        flash_ctrl_read_buf,                         // Buffer used internally in TicKV
-        page_buffer,                                 // Buffer used with the flash controller
+        &mux_flash,                                    // Flash controller
+        lowrisc::flash_ctrl::FLASH_PAGES_PER_BANK - 1, // Region offset (End of Bank0/Use Bank1)
+        // Region Size
+        lowrisc::flash_ctrl::FLASH_PAGES_PER_BANK * lowrisc::flash_ctrl::PAGE_SIZE,
+        flash_ctrl_read_buf, // Buffer used internally in TicKV
+        page_buffer,         // Buffer used with the flash controller
     )
     .finalize(components::tickv_component_helper!(
         lowrisc::flash_ctrl::FlashCtrl,


### PR DESCRIPTION
### Pull Request Overview

Update the TickV setup to match the new updates to the flash controller.
    
Before these changes, the TickV capsule (during testing) would invoke the flash driver with an address (perhaps an 'invalid page number'), which worked since the address would overflow the address register and still map to one of the pages.
    
This patch makes TicKV use Bank1 and TicKV capsule calls the underlying driver with the correct page numbers.
    
Ex. Erase at Page 256 -> Bank1 Page0
Erase at Page 257 -> Bank1 Page1

Additionally, add some minor safeguards to the flash controller.

### Testing Strategy

Running the TickV and FlashController tests for OpenTitan on Verilator


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] No updates are required.

### Formatting

- [x] Ran `make prepush`.
