### PR TITLE
kernel/hil/flash: add memory protection, impl/connect/test for OpenTitan

### DIFF
--- a/boards/opentitan/earlgrey-cw310/layout.ld
+++ b/boards/opentitan/earlgrey-cw310/layout.ld
@@ -41,5 +41,5 @@ SECTIONS {
       /* size = 1024 bytes */
     } > rom
 }
-
+ASSERT (((_etext - _manifest) > 0), "Error: PMP and Flash protection setup assumes _etext follows _manifest");
 INCLUDE ../../kernel_layout.ld

--- a/boards/opentitan/earlgrey-cw310/test_layout.ld
+++ b/boards/opentitan/earlgrey-cw310/test_layout.ld
@@ -47,5 +47,5 @@ SECTIONS {
       /* size = 1024 bytes */
     } > rom
 }
-
+ASSERT (((_etext - _manifest) > 0), "Error: PMP and Flash protection setup assumes _etext follows _manifest");
 INCLUDE ../../kernel_layout.ld

--- a/capsules/src/log.rs
+++ b/capsules/src/log.rs
@@ -847,7 +847,7 @@ impl<'a, F: Flash + 'static> flash::Client<F> for Log<'a, F> {
                     _ => unreachable!(),
                 }
             }
-            flash::Error::FlashError => {
+            flash::Error::FlashError | flash::Error::FlashMemoryProtectionError => {
                 // Make client callback with FAIL return code.
                 self.pagebuffer.replace(pagebuffer);
                 match self.state.get() {
@@ -895,7 +895,7 @@ impl<'a, F: Flash + 'static> flash::Client<F> for Log<'a, F> {
                     }
                 }
             }
-            flash::Error::FlashError => {
+            flash::Error::FlashError | flash::Error::FlashMemoryProtectionError => {
                 self.error.set(Err(ErrorCode::FAIL));
                 self.client_callback();
             }

--- a/chips/lowrisc/src/flash_ctrl.rs
+++ b/chips/lowrisc/src/flash_ctrl.rs
@@ -2,14 +2,13 @@
 
 use core::cell::Cell;
 use core::ops::{Index, IndexMut};
+use kernel::hil;
 use kernel::utilities::cells::OptionalCell;
 use kernel::utilities::cells::TakeCell;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable, Writeable};
 use kernel::utilities::registers::{
     register_bitfields, register_structs, ReadOnly, ReadWrite, WriteOnly,
 };
-
-use kernel::hil;
 use kernel::utilities::StaticRef;
 use kernel::ErrorCode;
 
@@ -51,7 +50,7 @@ register_structs! {
         (0x16C => op_status: ReadWrite<u32, OP_STATUS::Register>),
         (0x170 => status: ReadOnly<u32, STATUS::Register>),
         (0x174 => debug_state: ReadOnly<u32>),
-        (0x178 => err_code: ReadOnly<u32>),
+        (0x178 => err_code: ReadWrite<u32, ERR_CODE::Register>),
         (0x17C => std_fault_status: ReadOnly<u32>),
         (0x180 => fault_status: ReadOnly<u32>),
         (0x184 => err_addr: ReadOnly<u32>),
@@ -110,6 +109,15 @@ register_bitfields![u32,
         INFO_SEL OFFSET(9) NUMBITS(2) [],
         NUM OFFSET(16) NUMBITS(12) []
     ],
+    ERR_CODE [
+        OP_ERR OFFSET(0) NUMBITS(1) [],
+        MP_ERR OFFSET(1) NUMBITS(1) [],
+        RD_ERR OFFSET(2) NUMBITS(1) [],
+        PROG_ERR OFFSET(3) NUMBITS(1) [],
+        PROG_WIN_ERR OFFSET(4) NUMBITS(1) [],
+        PROG_TYPE_ERR OFFSET(5) NUMBITS(1) [],
+        UPDATE_ERR OFFSET(6) NUMBITS(1) [],
+    ],
     PROG_TYPE_EN [
         NORMAL OFFSET(0) NUMBITS(1) [],
         REPAIR OFFSET(1) NUMBITS(1) [],
@@ -121,7 +129,12 @@ register_bitfields![u32,
         START OFFSET(0) NUMBITS(32) []
     ],
     REGION_CFG_REGWEN [
-        REGION OFFSET(0) NUMBITS(1) []
+        REGION OFFSET(0) NUMBITS(1) [
+            // Once locked, region cannot be modified till next reset
+            Locked = 0,
+            // Region can be configured.
+            Enabled = 1,
+        ]
     ],
     MP_REGION_CFG [
         // These config register fields require a special value of
@@ -157,7 +170,7 @@ register_bitfields![u32,
     ],
     MP_REGION [
         BASE OFFSET(0) NUMBITS(9) [],
-        SIZE OFFSET(9) NUMBITS(9) []
+        SIZE OFFSET(10) NUMBITS(10) []
     ],
     BANK_INFO_REGWEN [
         REGION OFFSET(0) NUMBITS(1) [
@@ -257,16 +270,38 @@ register_bitfields![u32,
 ];
 
 pub const PAGE_SIZE: usize = 2048;
+pub const FLASH_ADDR_OFFSET: usize = 0x20000000;
 pub const FLASH_WORD_SIZE: usize = 8;
 pub const FLASH_PAGES_PER_BANK: usize = 256;
 pub const FLASH_NUM_BANKS: usize = 2;
 pub const FLASH_MAX_PAGES: usize = FLASH_NUM_BANKS * FLASH_PAGES_PER_BANK;
 pub const FLASH_NUM_BUSWORDS_PER_BANK: usize = PAGE_SIZE / 4;
+pub const FLASH_MP_MAX_CFGS: usize = 8;
 // The programming windows size in words (32bit)
 pub const FLASH_PROG_WINDOW_SIZE: usize = 16;
 pub const FLASH_PROG_WINDOW_MASK: u32 = 0xFFFFFFF0;
 
 pub struct LowRiscPage(pub [u8; PAGE_SIZE as usize]);
+
+/// Defines region permissions for flash memory protection.
+/// To be used when requesting the flash controller to set
+/// specific permissions for a regions, or when reading
+/// the existing permission associated with a region.
+#[derive(PartialEq, Debug)]
+pub struct FlashMPConfig {
+    /// Region can be read.
+    pub read_en: bool,
+    /// Region can be programmed.
+    pub write_en: bool,
+    /// Region can be erased
+    pub erase_en: bool,
+    /// Region is scramble enabled
+    pub scramble_en: bool,
+    /// Region has ECC enabled
+    pub ecc_en: bool,
+    /// Region is high endurance enabled
+    pub he_en: bool,
+}
 
 impl Default for LowRiscPage {
     fn default() -> Self {
@@ -378,28 +413,13 @@ impl<'a> FlashCtrl<'a> {
         }
     }
 
-    fn configure_data_partition(&self, num: FlashRegion) {
+    fn configure_data_partition(&self) {
         self.registers.default_region.write(
             DEFAULT_REGION::RD_EN::Set
                 + DEFAULT_REGION::PROG_EN::Set
                 + DEFAULT_REGION::ERASE_EN::Set,
         );
 
-        self.registers.mp_region_cfg[num as usize].write(
-            MP_REGION_CFG::RD_EN::Set
-                + MP_REGION_CFG::PROG_EN::Set
-                + MP_REGION_CFG::ERASE_EN::Set
-                + MP_REGION_CFG::SCRAMBLE_EN::Clear
-                + MP_REGION_CFG::ECC_EN::Clear
-                + MP_REGION_CFG::EN::Clear,
-        );
-
-        // Size and base are stored in different registers
-        self.registers.mp_region[num as usize]
-            .write(MP_REGION::BASE.val(FLASH_PAGES_PER_BANK as u32) + MP_REGION::SIZE.val(0x1));
-
-        // Enable MP Region
-        self.registers.mp_region_cfg[num as usize].modify(MP_REGION_CFG::EN::Set);
         self.data_configured.set(true);
     }
 
@@ -430,19 +450,39 @@ impl<'a> FlashCtrl<'a> {
         self.info_configured.set(true);
     }
 
+    /// Reset the internal FIFOs, used for when recovering from
+    /// errors.
+    pub fn reset_fifos(&self) {
+        // This field is active high, and will hold the FIFO
+        // in reset for as long as it is held.
+        self.registers.fifo_rst.write(FIFO_RST::EN::SET);
+        self.registers.fifo_rst.write(FIFO_RST::EN::CLEAR);
+    }
+
     pub fn handle_interrupt(&self) {
         let irqs = self.registers.intr_state.extract();
+        // MP faults don't seem to trigger any errors in intr_state,
+        // so lets check for them here.
+        let mp_fault = self.registers.err_code.is_set(ERR_CODE::MP_ERR);
 
         self.disable_interrupts();
 
-        if irqs.is_set(INTR::OP_ERROR) {
+        if irqs.is_set(INTR::OP_ERROR) || mp_fault {
             self.registers.op_status.set(0);
+            // RW1C Clear any pending errors
+            self.registers.err_code.set(0xFFFF_FFFF);
+            self.reset_fifos();
 
             let read_buf = self.read_buf.take();
+            let error = if mp_fault {
+                hil::flash::Error::FlashMemoryProtectionError
+            } else {
+                hil::flash::Error::FlashError
+            };
             if let Some(buf) = read_buf {
                 // We were doing a read
                 self.flash_client.map(move |client| {
-                    client.read_complete(buf, hil::flash::Error::FlashError);
+                    client.read_complete(buf, error);
                 });
             }
 
@@ -450,7 +490,14 @@ impl<'a> FlashCtrl<'a> {
             if let Some(buf) = write_buf {
                 // We were doing a write
                 self.flash_client.map(move |client| {
-                    client.write_complete(buf, hil::flash::Error::FlashError);
+                    client.write_complete(buf, error);
+                });
+            }
+
+            if self.registers.control.matches_all(CONTROL::OP::ERASE) {
+                // We were doing an erase
+                self.flash_client.map(move |client| {
+                    client.erase_complete(error);
                 });
             }
         }
@@ -564,6 +611,282 @@ impl<'a> FlashCtrl<'a> {
             }
         }
     }
+
+    // *** Public API for interfacing to flash memory protection ***
+
+    /// Helper function to convert an address space into page numbers for the flash controller.
+    ///
+    /// Returns `Ok(start_page_num, n_pages_used)` on successful conversion
+    /// Returns `Returns [`NOSUPPORT`](ErrorCode::NOSUPPORT)` if address space is not supported
+    ///     or is out of supported bounds
+    ///
+    /// # Arguments
+    ///
+    /// * `start_addr`  - Starting address to be converted to a page number
+    ///                    Note: This is the absolute address, i.e `FLASH_ADDR_OFFSET` and onwards
+    /// * `end_addr`    - End address to be converted to a page number
+    ///                    Note: This is the absolute address, i.e `FLASH_ADDR_OFFSET` and onwards
+    fn mp_addr_to_page_range(
+        &self,
+        mut start_addr: usize,
+        mut end_addr: usize,
+    ) -> Result<(usize, usize), ErrorCode> {
+        if start_addr >= end_addr {
+            return Err(ErrorCode::NOSUPPORT);
+        }
+
+        // Offset Absolute addresses into flash relative addresses
+        // i.e 0x20000000 -> 0x00, where 0x00 is the first word in Bank 0, Page 0.
+        if let Some(addr) = start_addr.checked_sub(FLASH_ADDR_OFFSET) {
+            start_addr = addr;
+        } else {
+            return Err(ErrorCode::NOSUPPORT);
+        }
+        if let Some(addr) = end_addr.checked_sub(FLASH_ADDR_OFFSET) {
+            end_addr = addr;
+        } else {
+            return Err(ErrorCode::NOSUPPORT);
+        }
+
+        let start_page_num = start_addr.saturating_div(PAGE_SIZE);
+        let end_page_num = end_addr.saturating_div(PAGE_SIZE);
+
+        if start_page_num >= FLASH_MAX_PAGES || end_page_num >= FLASH_MAX_PAGES {
+            // The address space does not fall within the flash layout
+            return Err(ErrorCode::NOSUPPORT);
+        }
+
+        // Find the pages utilized by the addr space, at-least one
+        // page must be used, even if both start/end addresses fall on the same page.
+        let n_pages_used: usize = end_page_num.saturating_sub(start_page_num).max(1);
+
+        // Pages numbers are 0 indexed,
+        // For example, if start_page_num is 0 and n_pages_used is 1,
+        // then the mp region is defined by page 0.
+        // If start_page_num is 0 and n_pages_used is 2, then the region is defined by pages 0 and 1.
+        Ok((start_page_num, n_pages_used))
+    }
+
+    /// Setup the specified flash memory protection configuration
+    ///
+    /// Returns `Ok(())` on successfully applying the requested configuration
+    /// Returns `[`NOSUPPORT`](ErrorCode::NOSUPPORT)` if address space is not supported,
+    ///     or the `region_num` does not exist
+    ///
+    /// # Arguments
+    ///
+    /// * `start_addr`  - Starting address that bounds the start of this region.
+    ///                    Note: This is the absolute address, i.e `FLASH_ADDR_OFFSET` and onwards
+    /// * `end_addr`    - End address that bounds the end of this region
+    ///                    Note: This is the absolute address, i.e `FLASH_ADDR_OFFSET` and onwards
+    /// * `region_num`  - The configuration region number associated with this region.
+    ///                   This associates the specified permissions to a configuration region,
+    ///                   the number of simultaneous configs supported
+    ///                   should be requested by `mp_get_num_regions()`
+    /// * `mp_perms`    - Specifies the permissions to set
+    ///
+    /// # Examples
+    ///
+    /// Usage:
+    ///
+    /// ```ignore
+    /// peripherals
+    ///     .flash_ctrl
+    ///     .mp_set_region_perms(0x0, text_end_addr as usize, 5, &mp_cfg)
+    /// ```
+    ///
+    /// The snippet reads as:
+    /// Allow access controls as specified by mp_cfg, for the address space bounded by
+    /// `start_addr=0x0` to `end_addr=text_end_addr` and associate this cfg to `region_num=5`.
+    ///
+    /// If a user would want to modify this region (assuming it wasn't locked), you can index into it with the
+    /// associated `region_num`, in this case `5`.
+    pub fn mp_set_region_perms(
+        &self,
+        start_addr: usize,
+        end_addr: usize,
+        region_num: usize,
+        mp_perms: &FlashMPConfig,
+    ) -> Result<(), ErrorCode> {
+        let (page_number, num_pages) = self.mp_addr_to_page_range(start_addr, end_addr)?;
+
+        if region_num > FlashRegion::REGION7 as usize || page_number >= FLASH_MAX_PAGES {
+            return Err(ErrorCode::NOSUPPORT);
+        }
+
+        // Number of pages exceeds the number of remaining pages from `page_number`
+        if num_pages > FLASH_MAX_PAGES - page_number {
+            return Err(ErrorCode::NOSUPPORT);
+        }
+
+        let regs = self.registers;
+
+        if !regs.region_cfg_regwen[region_num].is_set(REGION_CFG_REGWEN::REGION) {
+            // Region locked, cannot modify until next reset
+            return Err(ErrorCode::NOSUPPORT);
+        }
+
+        // Clear any existing permissions (reset state)
+        self.registers.mp_region_cfg[region_num].write(
+            MP_REGION_CFG::EN::Clear
+                + MP_REGION_CFG::RD_EN::Clear
+                + MP_REGION_CFG::PROG_EN::Clear
+                + MP_REGION_CFG::ERASE_EN::Clear
+                + MP_REGION_CFG::SCRAMBLE_EN::Clear
+                + MP_REGION_CFG::ECC_EN::Clear
+                + MP_REGION_CFG::HE_EN::Clear,
+        );
+
+        // Set the specified permissions
+        if mp_perms.read_en {
+            self.registers.mp_region_cfg[region_num].modify(MP_REGION_CFG::RD_EN::Set);
+        }
+
+        if mp_perms.write_en {
+            self.registers.mp_region_cfg[region_num].modify(MP_REGION_CFG::PROG_EN::Set);
+        }
+
+        if mp_perms.erase_en {
+            self.registers.mp_region_cfg[region_num].modify(MP_REGION_CFG::ERASE_EN::Set);
+        }
+
+        if mp_perms.scramble_en {
+            self.registers.mp_region_cfg[region_num].modify(MP_REGION_CFG::SCRAMBLE_EN::Set);
+        }
+
+        if mp_perms.ecc_en {
+            self.registers.mp_region_cfg[region_num].modify(MP_REGION_CFG::ECC_EN::Set);
+        }
+
+        if mp_perms.he_en {
+            self.registers.mp_region_cfg[region_num].modify(MP_REGION_CFG::HE_EN::Set);
+        }
+
+        // Set the page-range for the cfg to be set
+        // For example, if base is 0 and size is 1, then the region is defined by page 0.
+        // If base is 0 and size is 2, then the region is defined by pages 0 and 1.
+        regs.mp_region[region_num]
+            .write(MP_REGION::BASE.val(page_number as u32) + MP_REGION::SIZE.val(num_pages as u32));
+
+        // Activate protection region with specified permissions
+        self.registers.mp_region_cfg[region_num].modify(MP_REGION_CFG::EN::Set);
+
+        Ok(())
+    }
+
+    /// Read the flash memory protection configuration bounded by the specified region
+    ///
+    /// Returns `[`FlashMPConfig`](lowrisc::flash_ctrl::FlashMPConfig)` on success, with the permissions
+    ///     specified by this region
+    /// Returns `[`NOSUPPORT`](ErrorCode::NOSUPPORT)` if the `region_num` does not exist
+    ///
+    /// # Arguments
+    ///
+    /// * `region_num`  - The configuration region number associated with this region.
+    ///                   This associates the specified permissions to a configuration region.
+    pub fn mp_read_region_perms(&self, region_num: usize) -> Result<FlashMPConfig, ErrorCode> {
+        if region_num > FlashRegion::REGION7 as usize {
+            return Err(ErrorCode::NOSUPPORT);
+        }
+
+        let mp_cfg = self.registers.mp_region_cfg[region_num].extract();
+
+        let mut cfg = FlashMPConfig {
+            read_en: false,
+            write_en: false,
+            erase_en: false,
+            scramble_en: false,
+            ecc_en: false,
+            he_en: false,
+        };
+
+        if mp_cfg.matches_all(MP_REGION_CFG::RD_EN::Set) {
+            cfg.read_en = true;
+        }
+
+        if mp_cfg.matches_all(MP_REGION_CFG::PROG_EN::Set) {
+            cfg.write_en = true;
+        }
+
+        if mp_cfg.matches_all(MP_REGION_CFG::ERASE_EN::Set) {
+            cfg.erase_en = true;
+        }
+
+        if mp_cfg.matches_all(MP_REGION_CFG::SCRAMBLE_EN::Set) {
+            cfg.scramble_en = true;
+        }
+
+        if mp_cfg.matches_all(MP_REGION_CFG::ECC_EN::Set) {
+            cfg.ecc_en = true;
+        }
+
+        if mp_cfg.matches_all(MP_REGION_CFG::HE_EN::Set) {
+            cfg.he_en = true;
+        }
+
+        Ok(cfg)
+    }
+
+    /// Get the number of configuration regions supported by this hardware
+    ///
+    /// Returns `Ok(FLASH_MP_MAX_CFGS)` where FLASH_MP_MAX_CFGS is the number of
+    ///     cfg regions supported
+    ///
+    /// Note: Indexing starts with 0, this returns the total
+    /// number of configuration registers.
+    pub fn mp_get_num_regions(&self) -> Result<u32, ErrorCode> {
+        Ok(FLASH_MP_MAX_CFGS as u32)
+    }
+
+    /// Check if the specified `region_num` is locked by hardware
+    ///
+    /// Returns `Ok(bool)` on success, if true the region is locked till next reset,
+    ///     if false, it is unlocked.
+    /// Returns `[`NOSUPPORT`](ErrorCode::NOSUPPORT)` if the `region_num` does not exist
+    ///
+    /// # Arguments
+    ///
+    /// * `region_num`  - The configuration region number associated with this region.
+    ///                   This associates the specified permissions to a configuration region.
+    pub fn mp_is_region_locked(&self, region_num: usize) -> Result<bool, ErrorCode> {
+        if region_num > FlashRegion::REGION7 as usize {
+            return Err(ErrorCode::NOSUPPORT);
+        }
+
+        if !self.registers.region_cfg_regwen[region_num].is_set(REGION_CFG_REGWEN::REGION) {
+            // Region locked until next reset
+            return Ok(true);
+        }
+        // Region enabled and can be modified
+        Ok(false)
+    }
+
+    /// Lock the configuration
+    /// Locks the config bounded by `region_num`
+    /// such that no further modifications can be made until the next system reset.
+    ///
+    /// Returns `[`NOSUPPORT`](ErrorCode::NOSUPPORT)` if the `region_num` does not exist
+    /// Returns `[`ALREADY`](ErrorCode::ALREADY)` if the `region_num` region is already locked
+    /// Returns `Ok(())` on successfully locking the region
+    ///
+    /// # Arguments
+    ///
+    /// * `region_num`  - The configuration region number associated with this region.
+    ///                   This associates the specified permissions to a configuration region.
+    pub fn mp_lock_region_cfg(&self, region_num: usize) -> Result<(), ErrorCode> {
+        if region_num > FlashRegion::REGION7 as usize {
+            return Err(ErrorCode::NOSUPPORT);
+        }
+
+        if !self.registers.region_cfg_regwen[region_num].is_set(REGION_CFG_REGWEN::REGION) {
+            // Region already locked
+            return Err(ErrorCode::ALREADY);
+        }
+
+        self.registers.region_cfg_regwen[region_num].write(REGION_CFG_REGWEN::REGION::Locked);
+
+        Ok(())
+    }
 }
 
 impl<C: hil::flash::Client<Self>> hil::flash::HasClient<'static, C> for FlashCtrl<'_> {
@@ -595,7 +918,12 @@ impl hil::flash::Flash for FlashCtrl<'_> {
 
         if !self.data_configured.get() {
             // If we aren't configured yet, configure now
-            self.configure_data_partition(self.region_num);
+            self.configure_data_partition();
+        }
+
+        // Check control status before we commit
+        if !self.registers.ctrl_regwen.is_set(CTRL_REGWEN::EN) {
+            return Err((ErrorCode::BUSY, buf));
         }
 
         // Enable interrupts and set the FIFO level
@@ -650,7 +978,7 @@ impl hil::flash::Flash for FlashCtrl<'_> {
 
         if !self.data_configured.get() {
             // If we aren't configured yet, configure now
-            self.configure_data_partition(self.region_num);
+            self.configure_data_partition();
         }
 
         // Check control status before we commit
@@ -727,12 +1055,17 @@ impl hil::flash::Flash for FlashCtrl<'_> {
 
         if !self.data_configured.get() {
             // If we aren't configured yet, configure now
-            self.configure_data_partition(self.region_num);
+            self.configure_data_partition();
         }
 
         if !self.info_configured.get() {
             // If we aren't configured yet, configure now
             self.configure_info_partition(FlashBank::BANK1, self.region_num);
+        }
+
+        // Check control status before we commit
+        if !self.registers.ctrl_regwen.is_set(CTRL_REGWEN::EN) {
+            return Err(ErrorCode::BUSY);
         }
 
         // Disable bank erase
@@ -755,7 +1088,6 @@ impl hil::flash::Flash for FlashCtrl<'_> {
                 + CONTROL::PARTITION_SEL::DATA
                 + CONTROL::START::SET,
         );
-
         Ok(())
     }
 }

--- a/kernel/src/hil/flash.rs
+++ b/kernel/src/hil/flash.rs
@@ -100,6 +100,9 @@ pub enum Error {
 
     /// An error occurred during the flash operation.
     FlashError,
+
+    /// A flash memory protection violation was detected.
+    FlashMemoryProtectionError,
 }
 
 pub trait HasClient<'a, C> {


### PR DESCRIPTION
### Pull Request Overview

This pull request adds a new `HIL` to interface flash memory protection (fmp). 

The hardware support for fmp may vary between vendors. For example, OpenTitan has ['advanced' control options](https://docs.opentitan.org/hw/ip/flash_ctrl/doc/#Reg_mp_region_cfg_0) but `nRF52840` only allows r/w control (see [section 6.3](https://infocenter.nordicsemi.com/pdf/nRF52840_PS_v1.0.pdf#%5B%7B%22num%22%3A153%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C85.039%2C123.823%2Cnull%5D)).

Since we don't want to limit the hardware functionality, this `HIL` adds a basic implementation which should work with hardware with basic functionality (i.e `nRF52840`) and an advanced `HIL` that extends the basic one (could be used by `OpenTitan` to allow full control of fmp.  An implementation example can be seen with the new additions to the OpenTitan flash controller in this PR. 

OpenTitan Specific Changes:

- Unit tests to test FMP functionality
- Driver implementation
- Add FMP rules to ROM/Kernel regions

Also, the addition of fmp to supported devices can address some of the concerns discussed in https://github.com/tock/tock/issues/3229

### Testing Strategy

Running the tests (new/old) on Verilator
```
�I00000 test_rom.c:81] Version:    earlgrey_silver_release_v5-5665-g217a0168b
Build Date: 2022-09-29, 14:35:47

I00001 test_rom.c:115] Test ROM complete, jumping to flash!
Unable to find otbn-rsa, disabling RSA support
OpenTitan initialisation complete. Entering main loop
[FLASH_CTRL] Test page read/write....
    [ok]
[FLASH_CTRL] Test page erase....
    [ok]
[FLASH_CTRL] Test memory protection basic....
    [ok]
[FLASH_CTRL] Test memory protection functionality....
    [ok]
trivial assertion... 
    [ok]
```

### TODO or Help Wanted

- RFC on HIL changes


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
