### PR TITLE
Update components to use _static and static_buf!(): straightforward components

### DIFF
--- a/boards/acd52832/src/main.rs
+++ b/boards/acd52832/src/main.rs
@@ -232,7 +232,7 @@ pub unsafe fn main() {
     //
     // LEDs
     //
-    let led = components::led::LedsComponent::new().finalize(components::led_component_helper!(
+    let led = components::led::LedsComponent::new().finalize(components::led_component_static!(
         LedLow<'static, nrf52832::gpio::GPIOPin>,
         LedLow::new(&nrf52832_peripherals.gpio_port[LED1_PIN]),
         LedLow::new(&nrf52832_peripherals.gpio_port[LED2_PIN]),

--- a/boards/acd52832/src/main.rs
+++ b/boards/acd52832/src/main.rs
@@ -274,7 +274,9 @@ pub unsafe fn main() {
             )
         ),
     )
-    .finalize(components::button_component_buf!(nrf52832::gpio::GPIOPin));
+    .finalize(components::button_component_static!(
+        nrf52832::gpio::GPIOPin
+    ));
 
     //
     // RTC for Timers

--- a/boards/acd52832/src/main.rs
+++ b/boards/acd52832/src/main.rs
@@ -316,9 +316,10 @@ pub unsafe fn main() {
     //
 
     // RTT communication channel
-    let rtt_memory = components::segger_rtt::SeggerRttMemoryComponent::new().finalize(());
+    let rtt_memory = components::segger_rtt::SeggerRttMemoryComponent::new()
+        .finalize(components::segger_rtt_memory_component_static!());
     let rtt = components::segger_rtt::SeggerRttComponent::new(mux_alarm, rtt_memory)
-        .finalize(components::segger_rtt_component_helper!(nrf52832::rtc::Rtc));
+        .finalize(components::segger_rtt_component_static!(nrf52832::rtc::Rtc));
 
     //
     // Virtual UART

--- a/boards/arty_e21/src/main.rs
+++ b/boards/arty_e21/src/main.rs
@@ -217,7 +217,7 @@ pub unsafe fn main() {
             )
         ),
     )
-    .finalize(components::button_component_buf!(
+    .finalize(components::button_component_static!(
         arty_e21_chip::gpio::GpioPin
     ));
 

--- a/boards/arty_e21/src/main.rs
+++ b/boards/arty_e21/src/main.rs
@@ -197,7 +197,7 @@ pub unsafe fn main() {
     // virtual_alarm_test.set_client(timertest);
 
     // LEDs
-    let led = components::led::LedsComponent::new().finalize(components::led_component_helper!(
+    let led = components::led::LedsComponent::new().finalize(components::led_component_static!(
         hil::led::LedHigh<'static, arty_e21_chip::gpio::GpioPin>,
         hil::led::LedHigh::new(&peripherals.gpio_port[2]), // Red
         hil::led::LedHigh::new(&peripherals.gpio_port[1]), // Green

--- a/boards/arty_e21/src/main.rs
+++ b/boards/arty_e21/src/main.rs
@@ -149,8 +149,8 @@ pub unsafe fn main() {
         Some(&peripherals.gpio_port[8]),
     );
 
-    let process_printer =
-        components::process_printer::ProcessPrinterTextComponent::new().finalize(());
+    let process_printer = components::process_printer::ProcessPrinterTextComponent::new()
+        .finalize(components::process_printer_text_component_static!());
     PROCESS_PRINTER = Some(process_printer);
 
     // Create a shared UART channel for the console and for kernel debug.

--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -332,7 +332,7 @@ pub unsafe fn main() {
     // LEDs
     //--------------------------------------------------------------------------
 
-    let led = components::led::LedsComponent::new().finalize(components::led_component_helper!(
+    let led = components::led::LedsComponent::new().finalize(components::led_component_static!(
         LedHigh<'static, nrf52840::gpio::GPIOPin>,
         LedHigh::new(&nrf52840_peripherals.gpio_port[LED_RED_PIN]),
         LedHigh::new(&nrf52840_peripherals.gpio_port[LED_WHITE_PIN])

--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -682,7 +682,7 @@ pub unsafe fn main() {
         tft,
         Some(tft),
     )
-    .finalize(components::screen_buffer_size!(57600));
+    .finalize(components::screen_component_static!(57600));
 
     //--------------------------------------------------------------------------
     // WIRELESS

--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -723,8 +723,8 @@ pub unsafe fn main() {
         nrf52840::aes::AesECB<'static>
     ));
 
-    let process_printer =
-        components::process_printer::ProcessPrinterTextComponent::new().finalize(());
+    let process_printer = components::process_printer::ProcessPrinterTextComponent::new()
+        .finalize(components::process_printer_text_component_static!());
     PROCESS_PRINTER = Some(process_printer);
 
     let pconsole = components::process_console::ProcessConsoleComponent::new(

--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -622,7 +622,7 @@ pub unsafe fn main() {
         capsules::humidity::DRIVER_NUM,
         sht3x,
     )
-    .finalize(());
+    .finalize(components::humidity_component_static!());
 
     //--------------------------------------------------------------------------
     // TFT

--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -358,7 +358,9 @@ pub unsafe fn main() {
             ) // Right
         ),
     )
-    .finalize(components::button_component_buf!(nrf52840::gpio::GPIOPin));
+    .finalize(components::button_component_static!(
+        nrf52840::gpio::GPIOPin
+    ));
 
     //--------------------------------------------------------------------------
     // Deferred Call (Dynamic) Setup

--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -507,7 +507,7 @@ pub unsafe fn main() {
         capsules::rng::DRIVER_NUM,
         &base_peripherals.trng,
     )
-    .finalize(());
+    .finalize(components::rng_component_static!());
 
     //--------------------------------------------------------------------------
     // ADC

--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -480,7 +480,7 @@ pub unsafe fn main() {
         dynamic_deferred_caller,
         Some(&baud_rate_reset_bootloader_enter),
     )
-    .finalize(components::usb_cdc_acm_component_helper!(
+    .finalize(components::cdc_acm_component_static!(
         nrf52::usbd::Usbd,
         nrf52::rtc::Rtc
     ));

--- a/boards/components/src/air_quality.rs
+++ b/boards/components/src/air_quality.rs
@@ -3,15 +3,23 @@
 //! Usage
 //! -----
 //! ```rust
-//! let temp = AirQualityComponent::new(board_kernel, nrf52::temperature::TEMP).finalize(());
+//! let temp = AirQualityComponent::new(board_kernel, nrf52::temperature::TEMP)
+//!     .finalize(air_quality_component_static!());
 //! ```
 
 use capsules::air_quality::AirQualitySensor;
+use core::mem::MaybeUninit;
 use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
 use kernel::hil;
-use kernel::static_init;
+
+#[macro_export]
+macro_rules! air_quality_component_static {
+    () => {{
+        kernel::static_buf!(capsules::air_quality::AirQualitySensor<'static>)
+    };};
+}
 
 pub struct AirQualityComponent<T: 'static + hil::sensors::AirQualityDriver<'static>> {
     board_kernel: &'static kernel::Kernel,
@@ -34,21 +42,18 @@ impl<T: 'static + hil::sensors::AirQualityDriver<'static>> AirQualityComponent<T
 }
 
 impl<T: 'static + hil::sensors::AirQualityDriver<'static>> Component for AirQualityComponent<T> {
-    type StaticInput = ();
+    type StaticInput = &'static mut MaybeUninit<AirQualitySensor<'static>>;
     type Output = &'static AirQualitySensor<'static>;
 
-    unsafe fn finalize(self, _s: Self::StaticInput) -> Self::Output {
+    unsafe fn finalize(self, s: Self::StaticInput) -> Self::Output {
         let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
 
-        let temp = static_init!(
-            AirQualitySensor<'static>,
-            AirQualitySensor::new(
-                self.temp_sensor,
-                self.board_kernel.create_grant(self.driver_num, &grant_cap)
-            )
-        );
+        let air_quality = s.write(AirQualitySensor::new(
+            self.temp_sensor,
+            self.board_kernel.create_grant(self.driver_num, &grant_cap),
+        ));
 
-        hil::sensors::AirQualityDriver::set_client(self.temp_sensor, temp);
-        temp
+        hil::sensors::AirQualityDriver::set_client(self.temp_sensor, air_quality);
+        air_quality
     }
 }

--- a/boards/components/src/analog_comparator.rs
+++ b/boards/components/src/analog_comparator.rs
@@ -1,14 +1,14 @@
 //! Component for initializing an Analog Comparator.
 //!
-//! This provides one Component, AcComponent, which implements
-//! a userspace syscall interface to a passed analog comparator driver.
+//! This provides one Component, AcComponent, which implements a userspace
+//! syscall interface to a passed analog comparator driver.
 //!
 //! Usage
 //! -----
 //! ```rust
-//! let analog_comparator = components::analog_comparator::AcComponent::new(
+//! let analog_comparator = components::analog_comparator::AnalogComparatorComponent::new(
 //!     &sam4l::acifc::ACIFC,
-//!     components::acomp_component_helper!(
+//!     components::analog_comparator_component_helper!(
 //!         <sam4l::acifc::Acifc as kernel::hil::analog_comparator::AnalogComparator>::Channel,
 //!         &sam4l::acifc::CHANNEL_AC0,
 //!         &sam4l::acifc::CHANNEL_AC1,
@@ -16,21 +16,18 @@
 //!         &sam4l::acifc::CHANNEL_AC3
 //!     ),
 //! )
-//! .finalize(components::acomp_component_buf!(sam4l::acifc::Acifc));
+//! .finalize(components::analog_comparator_component_static!(sam4l::acifc::Acifc));
 //! ```
 
+use capsules::analog_comparator::AnalogComparator;
 use core::mem::MaybeUninit;
-
 use kernel;
 use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
-use kernel::static_init_half;
-
-use capsules::analog_comparator;
 
 #[macro_export]
-macro_rules! acomp_component_helper {
+macro_rules! analog_comparator_component_helper {
     ($Channel:ty, $($P:expr),+ $(,)?) => {{
         use kernel::count_expressions;
         use kernel::static_init;
@@ -46,23 +43,24 @@ macro_rules! acomp_component_helper {
 }
 
 #[macro_export]
-macro_rules! acomp_component_buf {
-    ($Comp:ty $(,)?) => {{
-        use capsules::analog_comparator::AnalogComparator;
-        use core::mem::MaybeUninit;
-        static mut BUF: MaybeUninit<AnalogComparator<'static, $Comp>> = MaybeUninit::uninit();
-        &mut BUF
+macro_rules! analog_comparator_component_static {
+    ($AC:ty $(,)?) => {{
+        kernel::static_buf!(capsules::analog_comparator::AnalogComparator<'static, $AC>)
     };};
 }
 
-pub struct AcComponent<AC: 'static + kernel::hil::analog_comparator::AnalogComparator<'static>> {
+pub struct AnalogComparatorComponent<
+    AC: 'static + kernel::hil::analog_comparator::AnalogComparator<'static>,
+> {
     comp: &'static AC,
     ac_channels: &'static [&'static AC::Channel],
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
 }
 
-impl<AC: 'static + kernel::hil::analog_comparator::AnalogComparator<'static>> AcComponent<AC> {
+impl<AC: 'static + kernel::hil::analog_comparator::AnalogComparator<'static>>
+    AnalogComparatorComponent<AC>
+{
     pub fn new(
         comp: &'static AC,
         ac_channels: &'static [&'static AC::Channel],
@@ -79,20 +77,17 @@ impl<AC: 'static + kernel::hil::analog_comparator::AnalogComparator<'static>> Ac
 }
 
 impl<AC: 'static + kernel::hil::analog_comparator::AnalogComparator<'static>> Component
-    for AcComponent<AC>
+    for AnalogComparatorComponent<AC>
 {
-    type StaticInput = &'static mut MaybeUninit<analog_comparator::AnalogComparator<'static, AC>>;
-    type Output = &'static analog_comparator::AnalogComparator<'static, AC>;
+    type StaticInput = &'static mut MaybeUninit<AnalogComparator<'static, AC>>;
+    type Output = &'static AnalogComparator<'static, AC>;
 
     unsafe fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
         let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
         let grant_ac = self.board_kernel.create_grant(self.driver_num, &grant_cap);
 
-        let analog_comparator = static_init_half!(
-            static_buffer,
-            analog_comparator::AnalogComparator<'static, AC>,
-            analog_comparator::AnalogComparator::new(self.comp, self.ac_channels, grant_ac)
-        );
+        let analog_comparator =
+            static_buffer.write(AnalogComparator::new(self.comp, self.ac_channels, grant_ac));
         self.comp.set_client(analog_comparator);
 
         analog_comparator

--- a/boards/components/src/button.rs
+++ b/boards/components/src/button.rs
@@ -3,11 +3,10 @@
 //! Usage
 //! -----
 //!
-//! The `button_component_helper!` macro takes 'static references to GPIO
-//! pins. When GPIO instances are owned values, the
-//! `button_component_helper_owned!` can be used, indicating that the passed
-//! values are owned values. This macro will perform static allocation of the
-//! passed in GPIO pins internally.
+//! The `button_component_helper!` macro takes 'static references to GPIO pins.
+//! When GPIO instances are owned values, the `button_component_helper_owned!`
+//! can be used, indicating that the passed values are owned values. This macro
+//! will perform static allocation of the passed in GPIO pins internally.
 //!
 //! ```rust
 //! let button = components::button::ButtonComponent::new(
@@ -21,13 +20,13 @@
 //!         )
 //!     ),
 //! )
-//! .finalize(button_component_buf!(sam4l::gpio::GPIOPin));
+//! .finalize(button_component_static!(sam4l::gpio::GPIOPin));
 //! ```
 //!
-//! Typically, `ActivationMode::ActiveLow` will be associated with `FloatingState::PullUp`
-//! whereas `ActivationMode::ActiveHigh` will be paired with `FloatingState::PullDown`.
-//! `FloatingState::None` will be used when the board provides external pull-up/pull-down
-//! resistors.
+//! Typically, `ActivationMode::ActiveLow` will be associated with
+//! `FloatingState::PullUp` whereas `ActivationMode::ActiveHigh` will be paired
+//! with `FloatingState::PullDown`. `FloatingState::None` will be used when the
+//! board provides external pull-up/pull-down resistors.
 
 use capsules::button::Button;
 use core::mem::MaybeUninit;
@@ -36,7 +35,6 @@ use kernel::component::Component;
 use kernel::create_capability;
 use kernel::hil::gpio;
 use kernel::hil::gpio::InterruptWithValue;
-use kernel::static_init_half;
 
 #[macro_export]
 macro_rules! button_component_helper_owned {
@@ -76,12 +74,9 @@ macro_rules! button_component_helper {
 }
 
 #[macro_export]
-macro_rules! button_component_buf {
+macro_rules! button_component_static {
     ($Pin:ty $(,)?) => {{
-        use capsules::button::Button;
-        use core::mem::MaybeUninit;
-        static mut BUF: MaybeUninit<Button<'static, $Pin>> = MaybeUninit::uninit();
-        &mut BUF
+        kernel::static_buf!(capsules::button::Button<'static, $Pin>)
     };};
 }
 
@@ -119,14 +114,10 @@ impl<IP: 'static + gpio::InterruptPin<'static>> Component for ButtonComponent<IP
 
     unsafe fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
         let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
-        let button = static_init_half!(
-            static_buffer,
-            capsules::button::Button<'static, IP>,
-            capsules::button::Button::new(
-                self.button_pins,
-                self.board_kernel.create_grant(self.driver_num, &grant_cap)
-            )
-        );
+        let button = static_buffer.write(capsules::button::Button::new(
+            self.button_pins,
+            self.board_kernel.create_grant(self.driver_num, &grant_cap),
+        ));
         for (pin, _, _) in self.button_pins.iter() {
             pin.set_client(button);
         }

--- a/boards/components/src/ccs811.rs
+++ b/boards/components/src/ccs811.rs
@@ -4,7 +4,7 @@
 //! -----
 //! ```rust
 //!     let ccs811 =
-//!         Ccs811Component::new(mux_i2c, 0x77).finalize(components::ccs811_component_helper!());
+//!         Ccs811Component::new(mux_i2c, 0x77).finalize(components::ccs811_component_static!());
 //!     let temperature = components::temperature::TemperatureComponent::new(
 //!         board_kernel,
 //!         capsules::temperature::DRIVER_NUM,
@@ -24,16 +24,16 @@ use capsules::virtual_i2c::{I2CDevice, MuxI2C};
 use core::mem::MaybeUninit;
 use kernel::component::Component;
 use kernel::dynamic_deferred_call::DynamicDeferredCall;
-use kernel::{static_init, static_init_half};
 
 // Setup static space for the objects.
 #[macro_export]
-macro_rules! ccs811_component_helper {
+macro_rules! ccs811_component_static {
     () => {{
-        use capsules::ccs811::Ccs811;
-        use core::mem::MaybeUninit;
-        static mut BUF1: MaybeUninit<Ccs811<'static>> = MaybeUninit::uninit();
-        &mut BUF1
+        let i2c_device = kernel::static_buf!(capsules::virtual_i2c::I2CDevice);
+        let buffer = kernel::static_buf!([u8; 6]);
+        let ccs811 = kernel::static_buf!(capsules::ccs811::Ccs811<'static>);
+
+        (i2c_device, buffer, ccs811)
     };};
 }
 
@@ -57,19 +57,22 @@ impl Ccs811Component {
     }
 }
 
-static mut I2C_BUF: [u8; 6] = [0; 6];
-
 impl Component for Ccs811Component {
-    type StaticInput = &'static mut MaybeUninit<Ccs811<'static>>;
+    type StaticInput = (
+        &'static mut MaybeUninit<I2CDevice<'static>>,
+        &'static mut MaybeUninit<[u8; 6]>,
+        &'static mut MaybeUninit<Ccs811<'static>>,
+    );
     type Output = &'static Ccs811<'static>;
 
     unsafe fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
-        let ccs811_i2c = static_init!(I2CDevice, I2CDevice::new(self.i2c_mux, self.i2c_address));
-        let ccs811 = static_init_half!(
-            static_buffer,
-            Ccs811<'static>,
-            Ccs811::new(ccs811_i2c, &mut I2C_BUF, self.deferred_caller)
-        );
+        let ccs811_i2c = static_buffer
+            .0
+            .write(I2CDevice::new(self.i2c_mux, self.i2c_address));
+        let buffer = static_buffer.1.write([0; 6]);
+        let ccs811 = static_buffer
+            .2
+            .write(Ccs811::new(ccs811_i2c, buffer, self.deferred_caller));
 
         ccs811_i2c.set_client(ccs811);
         ccs811.initialize_callback_handle(

--- a/boards/components/src/cdc.rs
+++ b/boards/components/src/cdc.rs
@@ -17,7 +17,7 @@
 //!     0x2341,
 //!     0x005a,
 //!     STRINGS)
-//! .finalize(components::usb_cdc_acm_component_helper!(nrf52::usbd::Usbd));
+//! .finalize(components::cdc_acm_component_static!(nrf52::usbd::Usbd));
 //! ```
 
 use core::mem::MaybeUninit;
@@ -27,19 +27,21 @@ use kernel::component::Component;
 use kernel::dynamic_deferred_call::DynamicDeferredCall;
 use kernel::hil;
 use kernel::hil::time::Alarm;
-use kernel::static_init_half;
 
 // Setup static space for the objects.
 #[macro_export]
-macro_rules! usb_cdc_acm_component_helper {
+macro_rules! cdc_acm_component_static {
     ($U:ty, $A:ty $(,)?) => {{
-        use capsules::virtual_alarm::VirtualMuxAlarm;
-        use core::mem::MaybeUninit;
-        static mut BUF0: MaybeUninit<VirtualMuxAlarm<'static, $A>> = MaybeUninit::uninit();
-        static mut BUF1: MaybeUninit<
-            capsules::usb::cdc::CdcAcm<'static, $U, VirtualMuxAlarm<'static, $A>>,
-        > = MaybeUninit::uninit();
-        (&mut BUF0, &mut BUF1)
+        let alarm = kernel::static_buf!(capsules::virtual_alarm::VirtualMuxAlarm<'static, $A>);
+        let cdc = kernel::static_buf!(
+            capsules::usb::cdc::CdcAcm<
+                'static,
+                $U,
+                capsules::virtual_alarm::VirtualMuxAlarm<'static, $A>,
+            >
+        );
+
+        (alarm, cdc)
     };};
 }
 
@@ -95,27 +97,19 @@ impl<U: 'static + hil::usb::UsbController<'static>, A: 'static + Alarm<'static>>
     type Output = &'static capsules::usb::cdc::CdcAcm<'static, U, VirtualMuxAlarm<'static, A>>;
 
     unsafe fn finalize(self, s: Self::StaticInput) -> Self::Output {
-        let cdc_alarm = static_init_half!(
-            s.0,
-            VirtualMuxAlarm<'static, A>,
-            VirtualMuxAlarm::new(self.alarm_mux)
-        );
+        let cdc_alarm = s.0.write(VirtualMuxAlarm::new(self.alarm_mux));
         cdc_alarm.setup();
 
-        let cdc = static_init_half!(
-            s.1,
-            capsules::usb::cdc::CdcAcm<'static, U, VirtualMuxAlarm<'static, A>>,
-            capsules::usb::cdc::CdcAcm::new(
-                self.usb,
-                self.max_ctrl_packet_size,
-                self.vendor_id,
-                self.product_id,
-                self.strings,
-                cdc_alarm,
-                self.deferred_caller,
-                self.host_initiated_function,
-            )
-        );
+        let cdc = s.1.write(capsules::usb::cdc::CdcAcm::new(
+            self.usb,
+            self.max_ctrl_packet_size,
+            self.vendor_id,
+            self.product_id,
+            self.strings,
+            cdc_alarm,
+            self.deferred_caller,
+            self.host_initiated_function,
+        ));
         self.usb.set_client(cdc);
         cdc.initialize_callback_handle(
             self.deferred_caller.register(cdc).unwrap(), // Unwrap fail = no deferred call slot available for USB-CDC

--- a/boards/components/src/crc.rs
+++ b/boards/components/src/crc.rs
@@ -7,30 +7,28 @@
 //! -----
 //! ```rust
 //! let crc = components::crc::CrcComponent::new(board_kernel, &sam4l::crccu::CrcCU)
-//!     .finalize(components::crc_component_helper!(sam4l::crccu::Crccu));
+//!     .finalize(components::crc_component_static!(sam4l::crccu::Crccu));
 //! ```
 
 // Author: Philip Levis <pal@cs.stanford.edu>
 // Author: Leon Schuermann  <leon@is.currently.online>
 // Last modified: 6/2/2021
 
+use capsules::crc::CrcDriver;
 use core::mem::MaybeUninit;
-
-use capsules::crc;
 use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
 use kernel::hil::crc::Crc;
-use kernel::{static_init, static_init_half};
 
 // Setup static space for the objects.
 #[macro_export]
-macro_rules! crc_component_helper {
+macro_rules! crc_component_static {
     ($C:ty $(,)?) => {{
-        use capsules::crc;
-        use core::mem::MaybeUninit;
-        static mut BUF: MaybeUninit<crc::CrcDriver<'static, $C>> = MaybeUninit::uninit();
-        &mut BUF
+        let buffer = kernel::static_buf!([u8; capsules::crc::DEFAULT_CRC_BUF_LENGTH]);
+        let crc = kernel::static_buf!(capsules::crc::CrcDriver<'static, $C>);
+
+        (crc, buffer)
     };};
 }
 
@@ -55,25 +53,23 @@ impl<C: 'static + Crc<'static>> CrcComponent<C> {
 }
 
 impl<C: 'static + Crc<'static>> Component for CrcComponent<C> {
-    type StaticInput = &'static mut MaybeUninit<crc::CrcDriver<'static, C>>;
-    type Output = &'static crc::CrcDriver<'static, C>;
+    type StaticInput = (
+        &'static mut MaybeUninit<CrcDriver<'static, C>>,
+        &'static mut MaybeUninit<[u8; capsules::crc::DEFAULT_CRC_BUF_LENGTH]>,
+    );
+    type Output = &'static CrcDriver<'static, C>;
 
     unsafe fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
         let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
-        let crc_buf = static_init!(
-            [u8; crc::DEFAULT_CRC_BUF_LENGTH],
-            [0; crc::DEFAULT_CRC_BUF_LENGTH]
-        );
+        let crc_buf = static_buffer
+            .1
+            .write([0; capsules::crc::DEFAULT_CRC_BUF_LENGTH]);
 
-        let crc = static_init_half!(
-            static_buffer,
-            crc::CrcDriver<'static, C>,
-            crc::CrcDriver::new(
-                self.crc,
-                crc_buf,
-                self.board_kernel.create_grant(self.driver_num, &grant_cap)
-            )
-        );
+        let crc = static_buffer.0.write(CrcDriver::new(
+            self.crc,
+            crc_buf,
+            self.board_kernel.create_grant(self.driver_num, &grant_cap),
+        ));
 
         self.crc.set_client(crc);
 

--- a/boards/components/src/ctap.rs
+++ b/boards/components/src/ctap.rs
@@ -1,7 +1,7 @@
 //! Component for CTAP HID over USB support.
 //!
 //! This provides a component for using the CTAP driver. This allows for
-//! Client to Authenticator Protool Authentication
+//! Client to Authenticator Protocol Authentication.
 //!
 //! Usage
 //! -----
@@ -11,8 +11,6 @@
 //!     "FIDO Key",      // Product
 //!     "Serial No. 5",  // Serial number
 //! ];
-//!     let ctap_send_buffer = static_init!([u8; 64], [0; 64]);
-//!     let ctap_recv_buffer = static_init!([u8; 64], [0; 64]);
 //!
 //!     let (ctap, ctap_driver) = components::ctap::CtapComponent::new(
 //!         &earlgrey::usbdev::USB,
@@ -23,7 +21,7 @@
 //!         ctap_send_buffer,
 //!         ctap_recv_buffer,
 //!     )
-//!     .finalize(components::usb_ctap_component_helper!(lowrisc::usbdev::Usb));
+//!     .finalize(components::ctap_component_static!(lowrisc::usbdev::Usb));
 //!
 //!     ctap.enable();
 //!     ctap.attach();
@@ -34,19 +32,19 @@ use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
 use kernel::hil;
-use kernel::static_init_half;
 
 // Setup static space for the objects.
 #[macro_export]
-macro_rules! usb_ctap_component_helper {
+macro_rules! ctap_component_static {
     ($U:ty $(,)?) => {{
-        use core::mem::MaybeUninit;
-        static mut BUF1: MaybeUninit<capsules::usb::ctap::CtapHid<'static, $U>> =
-            MaybeUninit::uninit();
-        static mut BUF2: MaybeUninit<
-            capsules::ctap::CtapDriver<'static, capsules::usb::ctap::CtapHid<'static, $U>>,
-        > = MaybeUninit::uninit();
-        (&mut BUF1, &mut BUF2)
+        let hid = kernel::static_buf!(capsules::usb::ctap::CtapHid<'static, $U>);
+        let driver = kernel::static_buf!(
+            capsules::ctap::CtapDriver<'static, capsules::usb::ctap::CtapHid<'static, $U>>
+        );
+        let send_buffer = kernel::static_buf!([u8; 64]);
+        let recv_buffer = kernel::static_buf!([u8; 64]);
+
+        (hid, driver, send_buffer, recv_buffer)
     };};
 }
 
@@ -57,8 +55,6 @@ pub struct CtapComponent<U: 'static + hil::usb::UsbController<'static>> {
     vendor_id: u16,
     product_id: u16,
     strings: &'static [&'static str; 3],
-    send_buffer: &'static mut [u8; 64],
-    recv_buffer: &'static mut [u8; 64],
 }
 
 impl<U: 'static + hil::usb::UsbController<'static>> CtapComponent<U> {
@@ -69,8 +65,6 @@ impl<U: 'static + hil::usb::UsbController<'static>> CtapComponent<U> {
         vendor_id: u16,
         product_id: u16,
         strings: &'static [&'static str; 3],
-        send_buffer: &'static mut [u8; 64],
-        recv_buffer: &'static mut [u8; 64],
     ) -> CtapComponent<U> {
         CtapComponent {
             board_kernel,
@@ -79,8 +73,6 @@ impl<U: 'static + hil::usb::UsbController<'static>> CtapComponent<U> {
             vendor_id,
             product_id,
             strings,
-            send_buffer,
-            recv_buffer,
         }
     }
 }
@@ -91,6 +83,8 @@ impl<U: 'static + hil::usb::UsbController<'static>> Component for CtapComponent<
         &'static mut MaybeUninit<
             capsules::ctap::CtapDriver<'static, capsules::usb::ctap::CtapHid<'static, U>>,
         >,
+        &'static mut MaybeUninit<[u8; 64]>,
+        &'static mut MaybeUninit<[u8; 64]>,
     );
     type Output = (
         &'static capsules::usb::ctap::CtapHid<'static, U>,
@@ -98,30 +92,25 @@ impl<U: 'static + hil::usb::UsbController<'static>> Component for CtapComponent<
     );
 
     unsafe fn finalize(self, s: Self::StaticInput) -> Self::Output {
-        let ctap = static_init_half!(
-            s.0,
-            capsules::usb::ctap::CtapHid<'static, U>,
-            capsules::usb::ctap::CtapHid::new(
-                self.usb,
-                self.vendor_id,
-                self.product_id,
-                self.strings
-            )
-        );
+        let ctap = s.0.write(capsules::usb::ctap::CtapHid::new(
+            self.usb,
+            self.vendor_id,
+            self.product_id,
+            self.strings,
+        ));
         self.usb.set_client(ctap);
 
         let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
 
-        let ctap_driver = static_init_half!(
-            s.1,
-            capsules::ctap::CtapDriver<'static, capsules::usb::ctap::CtapHid<'static, U>>,
-            capsules::ctap::CtapDriver::new(
-                Some(ctap),
-                self.send_buffer,
-                self.recv_buffer,
-                self.board_kernel.create_grant(self.driver_num, &grant_cap),
-            )
-        );
+        let send_buffer = s.2.write([0; 64]);
+        let recv_buffer = s.3.write([0; 64]);
+
+        let ctap_driver = s.1.write(capsules::ctap::CtapDriver::new(
+            Some(ctap),
+            send_buffer,
+            recv_buffer,
+            self.board_kernel.create_grant(self.driver_num, &grant_cap),
+        ));
 
         ctap.set_client(ctap_driver);
 

--- a/boards/components/src/flash.rs
+++ b/boards/components/src/flash.rs
@@ -1,15 +1,16 @@
 //! Component for Flash
 //!
-//! Provides `FlashMux` and `FlashUser` (virtual flash)
+//! Provides `FlashMux` and `FlashUser` (virtual flash).
+//!
 //! Usage
 //! -----
 //! ```rust
 //!    let mux_flash = components::flash::FlashMuxComponent::new(&base_peripherals.nvmc).finalize(
-//!       components::flash_mux_component_helper!(nrf52833::nvmc::Nvmc),
+//!       components::flash_mux_component_static!(nrf52833::nvmc::Nvmc),
 //!    );
 //!
 //!    let virtual_app_flash = components::flash::FlashUserComponent::new(mux_flash).finalize(
-//!       components::flash_user_component_helper!(nrf52833::nvmc::Nvmc),
+//!       components::flash_user_component_static!(nrf52833::nvmc::Nvmc),
 //!    );
 //! ```
 
@@ -18,26 +19,19 @@ use capsules::virtual_flash::MuxFlash;
 use core::mem::MaybeUninit;
 use kernel::component::Component;
 use kernel::hil::flash::{Flash, HasClient};
-use kernel::static_init_half;
 
 // Setup static space for the objects.
 #[macro_export]
-macro_rules! flash_user_component_helper {
+macro_rules! flash_user_component_static {
     ($F:ty) => {{
-        use capsules::virtual_flash::FlashUser;
-        use core::mem::MaybeUninit;
-        static mut BUF1: MaybeUninit<FlashUser<'static, $F>> = MaybeUninit::uninit();
-        &mut BUF1
+        kernel::static_buf!(capsules::virtual_flash::FlashUser<'static, $F>)
     };};
 }
 
 #[macro_export]
-macro_rules! flash_mux_component_helper {
+macro_rules! flash_mux_component_static {
     ($F:ty) => {{
-        use capsules::virtual_flash::MuxFlash;
-        use core::mem::MaybeUninit;
-        static mut BUF1: MaybeUninit<MuxFlash<'static, $F>> = MaybeUninit::uninit();
-        &mut BUF1
+        kernel::static_buf!(capsules::virtual_flash::MuxFlash<'static, $F>)
     };};
 }
 
@@ -58,7 +52,7 @@ impl<F: 'static + Flash + HasClient<'static, MuxFlash<'static, F>>> Component
     type Output = &'static MuxFlash<'static, F>;
 
     unsafe fn finalize(self, s: Self::StaticInput) -> Self::Output {
-        let mux_flash = static_init_half!(s, MuxFlash<'static, F>, MuxFlash::new(self.flash));
+        let mux_flash = s.write(MuxFlash::new(self.flash));
         HasClient::set_client(self.flash, mux_flash);
 
         mux_flash
@@ -82,9 +76,6 @@ impl<F: 'static + Flash + HasClient<'static, MuxFlash<'static, F>>> Component
     type Output = &'static FlashUser<'static, F>;
 
     unsafe fn finalize(self, s: Self::StaticInput) -> Self::Output {
-        let virtual_flash =
-            static_init_half!(s, FlashUser<'static, F>, FlashUser::new(self.mux_flash));
-
-        virtual_flash
+        s.write(FlashUser::new(self.mux_flash))
     }
 }

--- a/boards/components/src/hts221.rs
+++ b/boards/components/src/hts221.rs
@@ -4,26 +4,25 @@
 //! -----
 //! ```rust
 //! let hts221 = Hts221Component::new(mux_i2c, mux_alarm, 0x5f).finalize(
-//!     components::hts221!(sam4l::ast::Ast));
+//!     components::hts221_component_static!(sam4l::ast::Ast));
 //! let temperature = components::temperature::TemperatureComponent::new(board_kernel, hts221).finalize(());
 //! let humidity = components::humidity::HumidityComponent::new(board_kernel, hts221).finalize(());
 //! ```
 
-use core::mem::MaybeUninit;
-
 use capsules::hts221::Hts221;
 use capsules::virtual_i2c::{I2CDevice, MuxI2C};
+use core::mem::MaybeUninit;
 use kernel::component::Component;
-use kernel::{static_init, static_init_half};
 
 // Setup static space for the objects.
 #[macro_export]
-macro_rules! hts221_component_helper {
+macro_rules! hts221_component_static {
     () => {{
-        use capsules::hts221::Hts221;
-        use core::mem::MaybeUninit;
-        static mut BUF1: MaybeUninit<Hts221<'static>> = MaybeUninit::uninit();
-        &mut BUF1
+        let i2c_device = kernel::static_buf!(capsules::virtual_i2c::I2CDevice);
+        let buffer = kernel::static_buf!([u8; 17]);
+        let hts221 = kernel::static_buf!(capsules::hts221::Hts221<'static>);
+
+        (i2c_device, buffer, hts221)
     };};
 }
 
@@ -41,19 +40,20 @@ impl Hts221Component {
     }
 }
 
-static mut I2C_BUF: [u8; 17] = [0; 17];
-
 impl Component for Hts221Component {
-    type StaticInput = &'static mut MaybeUninit<Hts221<'static>>;
+    type StaticInput = (
+        &'static mut MaybeUninit<I2CDevice<'static>>,
+        &'static mut MaybeUninit<[u8; 17]>,
+        &'static mut MaybeUninit<Hts221<'static>>,
+    );
     type Output = &'static Hts221<'static>;
 
     unsafe fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
-        let hts221_i2c = static_init!(I2CDevice, I2CDevice::new(self.i2c_mux, self.i2c_address));
-        let hts221 = static_init_half!(
-            static_buffer,
-            Hts221<'static>,
-            Hts221::new(hts221_i2c, &mut I2C_BUF)
-        );
+        let hts221_i2c = static_buffer
+            .0
+            .write(I2CDevice::new(self.i2c_mux, self.i2c_address));
+        let buffer = static_buffer.1.write([0; 17]);
+        let hts221 = static_buffer.2.write(Hts221::new(hts221_i2c, buffer));
 
         hts221_i2c.set_client(hts221);
         hts221

--- a/boards/components/src/humidity.rs
+++ b/boards/components/src/humidity.rs
@@ -1,54 +1,59 @@
-//! Component for any Temperature sensor.
+//! Component for any humidity sensor.
 //!
 //! Usage
 //! -----
 //! ```rust
-//! let humidity = HumidityComponent::new(board_kernel, nrf52::humidity::TEMP).finalize(());
+//! let humidity = HumidityComponent::new(board_kernel, nrf52::humidity::TEMP)
+//!     .finalize(components::humidity_component_static!());
 //! ```
 
 use capsules::humidity::HumiditySensor;
+use core::mem::MaybeUninit;
 use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
 use kernel::hil;
-use kernel::static_init;
+
+#[macro_export]
+macro_rules! humidity_component_static {
+    () => {{
+        kernel::static_buf!(capsules::humidity::HumiditySensor<'static>)
+    };};
+}
 
 pub struct HumidityComponent<T: 'static + hil::sensors::HumidityDriver<'static>> {
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
-    temp_sensor: &'static T,
+    sensor: &'static T,
 }
 
 impl<T: 'static + hil::sensors::HumidityDriver<'static>> HumidityComponent<T> {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
         driver_num: usize,
-        temp_sensor: &'static T,
+        sensor: &'static T,
     ) -> HumidityComponent<T> {
         HumidityComponent {
             board_kernel,
             driver_num,
-            temp_sensor,
+            sensor,
         }
     }
 }
 
 impl<T: 'static + hil::sensors::HumidityDriver<'static>> Component for HumidityComponent<T> {
-    type StaticInput = ();
+    type StaticInput = &'static mut MaybeUninit<HumiditySensor<'static>>;
     type Output = &'static HumiditySensor<'static>;
 
-    unsafe fn finalize(self, _s: Self::StaticInput) -> Self::Output {
+    unsafe fn finalize(self, s: Self::StaticInput) -> Self::Output {
         let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
 
-        let humidity = static_init!(
-            HumiditySensor<'static>,
-            HumiditySensor::new(
-                self.temp_sensor,
-                self.board_kernel.create_grant(self.driver_num, &grant_cap)
-            )
-        );
+        let humidity = s.write(HumiditySensor::new(
+            self.sensor,
+            self.board_kernel.create_grant(self.driver_num, &grant_cap),
+        ));
 
-        hil::sensors::HumidityDriver::set_client(self.temp_sensor, humidity);
+        hil::sensors::HumidityDriver::set_client(self.sensor, humidity);
         humidity
     }
 }

--- a/boards/components/src/lldb.rs
+++ b/boards/components/src/lldb.rs
@@ -1,26 +1,44 @@
 //! Component for LowLevelDebug
 //!
-//! This provides one Component, LowLevelDebugComponent, which provides the LowLevelDebug
-//! driver---a driver that can prints messages to the serial port relying on only `command`s from
-//! userspace. It is particularly useful for board or runtime bringup when more complex operations
-//! (allow and subscribe) may still not be working.
+//! This provides one Component, LowLevelDebugComponent, which provides the
+//! LowLevelDebug driver---a driver that can prints messages to the serial port
+//! relying on only `command`s from userspace. It is particularly useful for
+//! board or runtime bringup when more complex operations (allow and subscribe)
+//! may still not be working.
 //!
 //! Usage
 //! -----
 //! ```rust
-//! let lldb = LowLevelDebugComponent::new(board_kernel, uart_mux).finalize(());
+//! let lldb = LowLevelDebugComponent::new(board_kernel, uart_mux)
+//!     .finalize(components::low_level_debug_component_static!());
 //! ```
 
 // Author: Amit Levy <amit@amitlevy.com>
 // Last modified: 12/04/2019
 
-use capsules::low_level_debug;
+use capsules::low_level_debug::LowLevelDebug;
 use capsules::virtual_uart::{MuxUart, UartDevice};
+use core::mem::MaybeUninit;
 use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
 use kernel::hil;
-use kernel::static_init;
+
+#[macro_export]
+macro_rules! low_level_debug_component_static {
+    () => {{
+        let uart = kernel::static_buf!(capsules::virtual_uart::UartDevice<'static>);
+        let buffer = kernel::static_buf!([u8; capsules::low_level_debug::BUF_LEN]);
+        let lldb = kernel::static_buf!(
+            capsules::low_level_debug::LowLevelDebug<
+                'static,
+                capsules::virtual_uart::UartDevice<'static>,
+            >
+        );
+
+        (uart, buffer, lldb)
+    };};
+}
 
 pub struct LowLevelDebugComponent {
     board_kernel: &'static kernel::Kernel,
@@ -43,26 +61,26 @@ impl LowLevelDebugComponent {
 }
 
 impl Component for LowLevelDebugComponent {
-    type StaticInput = ();
-    type Output = &'static low_level_debug::LowLevelDebug<'static, UartDevice<'static>>;
+    type StaticInput = (
+        &'static mut MaybeUninit<UartDevice<'static>>,
+        &'static mut MaybeUninit<[u8; capsules::low_level_debug::BUF_LEN]>,
+        &'static mut MaybeUninit<LowLevelDebug<'static, UartDevice<'static>>>,
+    );
+    type Output = &'static LowLevelDebug<'static, UartDevice<'static>>;
 
-    unsafe fn finalize(self, _s: Self::StaticInput) -> Self::Output {
+    unsafe fn finalize(self, s: Self::StaticInput) -> Self::Output {
         let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
 
-        // Create virtual device for console.
-        let lldb_uart = static_init!(UartDevice, UartDevice::new(self.uart_mux, true));
+        let lldb_uart = s.0.write(UartDevice::new(self.uart_mux, true));
         lldb_uart.setup();
 
-        static mut MYBUF: [u8; low_level_debug::BUF_LEN] = [0; low_level_debug::BUF_LEN];
+        let buffer = s.1.write([0; capsules::low_level_debug::BUF_LEN]);
 
-        let lldb = static_init!(
-            low_level_debug::LowLevelDebug<'static, UartDevice<'static>>,
-            low_level_debug::LowLevelDebug::new(
-                &mut MYBUF,
-                lldb_uart,
-                self.board_kernel.create_grant(self.driver_num, &grant_cap)
-            )
-        );
+        let lldb = s.2.write(LowLevelDebug::new(
+            buffer,
+            lldb_uart,
+            self.board_kernel.create_grant(self.driver_num, &grant_cap),
+        ));
         hil::uart::Transmit::set_transmit_client(lldb_uart, lldb);
 
         lldb

--- a/boards/components/src/mlx90614.rs
+++ b/boards/components/src/mlx90614.rs
@@ -3,15 +3,15 @@
 //! Usage
 //! -----
 //! ```rust
-//!    let mlx90614 = components::mlx90614::Mlx90614I2CComponent::new(mux_i2c, i2c_addr,
-//!    board_kernel)
-//!       .finalize(components::mlx90614_i2c_component_helper!());
+//! let mlx90614 = components::mlx90614::Mlx90614I2CComponent::new(mux_i2c, i2c_addr,
+//! board_kernel)
+//!    .finalize(components::mlx90614_component_static!());
 //!
-//!    let temp = static_init!(
-//!           capsules::temperature::TemperatureSensor<'static>,
-//!           capsules::temperature::TemperatureSensor::new(mlx90614,
-//!                                                    grant_temperature));
-//!    kernel::hil::sensors::TemperatureDriver::set_client(mlx90614, temp);
+//! let temp = static_init!(
+//!        capsules::temperature::TemperatureSensor<'static>,
+//!        capsules::temperature::TemperatureSensor::new(mlx90614,
+//!                                                 grant_temperature));
+//! kernel::hil::sensors::TemperatureDriver::set_client(mlx90614, temp);
 //! ```
 
 use capsules::mlx90614::Mlx90614SMBus;
@@ -20,16 +20,16 @@ use core::mem::MaybeUninit;
 use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
-use kernel::{static_init, static_init_half};
 
 // Setup static space for the objects.
 #[macro_export]
-macro_rules! mlx90614_component_helper {
+macro_rules! mlx90614_component_static {
     () => {{
-        use capsules::mlx90614::Mlx90614SMBus;
-        use core::mem::MaybeUninit;
-        static mut BUF: MaybeUninit<Mlx90614SMBus<'static>> = MaybeUninit::uninit();
-        &mut BUF
+        let i2c_device = kernel::static_buf!(capsules::virtual_i2c::SMBusDevice);
+        let buffer = kernel::static_buf!([u8; 14]);
+        let mlx90614 = kernel::static_buf!(capsules::mlx90614::Mlx90614SMBus<'static>);
+
+        (i2c_device, buffer, mlx90614)
     };};
 }
 
@@ -56,27 +56,25 @@ impl Mlx90614SMBusComponent {
     }
 }
 
-static mut I2C_BUF: [u8; 14] = [0; 14];
-
 impl Component for Mlx90614SMBusComponent {
-    type StaticInput = &'static mut MaybeUninit<Mlx90614SMBus<'static>>;
+    type StaticInput = (
+        &'static mut MaybeUninit<SMBusDevice<'static>>,
+        &'static mut MaybeUninit<[u8; 14]>,
+        &'static mut MaybeUninit<Mlx90614SMBus<'static>>,
+    );
     type Output = &'static Mlx90614SMBus<'static>;
 
     unsafe fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
-        let mlx90614_smbus = static_init!(
-            SMBusDevice,
-            SMBusDevice::new(self.i2c_mux, self.i2c_address)
-        );
+        let mlx90614_smbus = static_buffer
+            .0
+            .write(SMBusDevice::new(self.i2c_mux, self.i2c_address));
+        let buffer = static_buffer.1.write([0; 14]);
         let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
-        let mlx90614 = static_init_half!(
-            static_buffer,
-            Mlx90614SMBus<'static>,
-            Mlx90614SMBus::new(
-                mlx90614_smbus,
-                &mut I2C_BUF,
-                self.board_kernel.create_grant(self.driver_num, &grant_cap)
-            )
-        );
+        let mlx90614 = static_buffer.2.write(Mlx90614SMBus::new(
+            mlx90614_smbus,
+            buffer,
+            self.board_kernel.create_grant(self.driver_num, &grant_cap),
+        ));
 
         mlx90614_smbus.set_client(mlx90614);
         mlx90614

--- a/boards/components/src/nonvolatile_storage.rs
+++ b/boards/components/src/nonvolatile_storage.rs
@@ -1,7 +1,7 @@
 //! Component for non-volatile storage Drivers.
 //!
 //! This provides one component, NonvolatileStorageComponent, which provides
-//! a system call inteface to non-volatile storage.
+//! a system call interface to non-volatile storage.
 //!
 //! Usage
 //! -----
@@ -14,7 +14,7 @@
 //!     &_sstorage as *const u8 as usize,
 //!     &_estorage as *const u8 as usize,
 //! )
-//! .finalize(components::nv_storage_component_helper!(
+//! .finalize(components::nonvolatile_storage_component_static!(
 //!     sam4l::flashcalw::FLASHCALW
 //! ));
 //! ```
@@ -26,18 +26,19 @@ use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
 use kernel::hil;
-use kernel::{static_init, static_init_half};
 
 // Setup static space for the objects.
 #[macro_export]
-macro_rules! nv_storage_component_helper {
+macro_rules! nonvolatile_storage_component_static {
     ($F:ty $(,)?) => {{
-        use capsules::nonvolatile_to_pages::NonvolatileToPages;
-        use core::mem::MaybeUninit;
-        use kernel::hil;
-        static mut BUF1: MaybeUninit<<$F as hil::flash::Flash>::Page> = MaybeUninit::uninit();
-        static mut BUF2: MaybeUninit<NonvolatileToPages<'static, $F>> = MaybeUninit::uninit();
-        (&mut BUF1, &mut BUF2)
+        let page = kernel::static_buf!(<$F as kernel::hil::flash::Flash>::Page);
+        let ntp =
+            kernel::static_buf!(capsules::nonvolatile_to_pages::NonvolatileToPages<'static, $F>);
+        let ns =
+            kernel::static_buf!(capsules::nonvolatile_storage_driver::NonvolatileStorage<'static>);
+        let buffer = kernel::static_buf!([u8; capsules::nonvolatile_storage_driver::BUF_LEN]);
+
+        (page, ntp, ns, buffer)
     };};
 }
 
@@ -89,37 +90,36 @@ impl<
     type StaticInput = (
         &'static mut MaybeUninit<<F as hil::flash::Flash>::Page>,
         &'static mut MaybeUninit<NonvolatileToPages<'static, F>>,
+        &'static mut MaybeUninit<NonvolatileStorage<'static>>,
+        &'static mut MaybeUninit<[u8; capsules::nonvolatile_storage_driver::BUF_LEN]>,
     );
     type Output = &'static NonvolatileStorage<'static>;
 
     unsafe fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
         let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
 
-        let flash_pagebuffer = static_init_half!(
-            static_buffer.0,
-            <F as hil::flash::Flash>::Page,
-            <F as hil::flash::Flash>::Page::default()
-        );
+        let buffer = static_buffer
+            .3
+            .write([0; capsules::nonvolatile_storage_driver::BUF_LEN]);
 
-        let nv_to_page = static_init_half!(
-            static_buffer.1,
-            NonvolatileToPages<'static, F>,
-            NonvolatileToPages::new(self.flash, flash_pagebuffer)
-        );
+        let flash_pagebuffer = static_buffer
+            .0
+            .write(<F as hil::flash::Flash>::Page::default());
+
+        let nv_to_page = static_buffer
+            .1
+            .write(NonvolatileToPages::new(self.flash, flash_pagebuffer));
         hil::flash::HasClient::set_client(self.flash, nv_to_page);
 
-        let nonvolatile_storage = static_init!(
-            NonvolatileStorage<'static>,
-            NonvolatileStorage::new(
-                nv_to_page,
-                self.board_kernel.create_grant(self.driver_num, &grant_cap),
-                self.userspace_start, // Start address for userspace accessible region
-                self.userspace_length, // Length of userspace accessible region
-                self.kernel_start,    // Start address of kernel region
-                self.kernel_length,   // Length of kernel region
-                &mut capsules::nonvolatile_storage_driver::BUFFER
-            )
-        );
+        let nonvolatile_storage = static_buffer.2.write(NonvolatileStorage::new(
+            nv_to_page,
+            self.board_kernel.create_grant(self.driver_num, &grant_cap),
+            self.userspace_start, // Start address for userspace accessible region
+            self.userspace_length, // Length of userspace accessible region
+            self.kernel_start,    // Start address of kernel region
+            self.kernel_length,   // Length of kernel region
+            buffer,
+        ));
         hil::nonvolatile_storage::NonvolatileStorage::set_client(nv_to_page, nonvolatile_storage);
         nonvolatile_storage
     }

--- a/boards/components/src/panic_button.rs
+++ b/boards/components/src/panic_button.rs
@@ -1,7 +1,10 @@
 //! Component to cause a button press to trigger a kernel panic.
 //!
-//! This can be useful especially when developping or debugging console
+//! This can be useful especially when developing or debugging console
 //! capsules.
+//!
+//! Note: the process console has support for triggering a panic, which may be
+//! more convenient depending on the board.
 //!
 //! Usage
 //! -----
@@ -12,22 +15,18 @@
 //!     kernel::hil::gpio::ActivationMode::ActiveLow,
 //!     kernel::hil::gpio::FloatingState::PullUp
 //! )
-//! .finalize(panic_button_component_buf!(sam4l::gpio::GPIOPin));
+//! .finalize(components::panic_button_component_static!(sam4l::gpio::GPIOPin));
 //! ```
 
 use capsules::panic_button::PanicButton;
 use core::mem::MaybeUninit;
 use kernel::component::Component;
 use kernel::hil::gpio;
-use kernel::static_init_half;
 
 #[macro_export]
-macro_rules! panic_button_component_buf {
+macro_rules! panic_button_component_static {
     ($Pin:ty $(,)?) => {{
-        use capsules::button::PanicButton;
-        use core::mem::MaybeUninit;
-        static mut BUF: MaybeUninit<PanicButton<'static, $Pin>> = MaybeUninit::uninit();
-        &mut BUF
+        kernel::static_buf!(capsules::button::PanicButton<'static, $Pin>)
     };};
 }
 
@@ -56,11 +55,8 @@ impl<IP: 'static + gpio::InterruptPin<'static>> Component for PanicButtonCompone
     type Output = ();
 
     unsafe fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
-        let panic_button = static_init_half!(
-            static_buffer,
-            PanicButton<'static, IP>,
-            PanicButton::new(self.pin, self.mode, self.floating_state)
-        );
+        let panic_button =
+            static_buffer.write(PanicButton::new(self.pin, self.mode, self.floating_state));
         self.pin.set_client(panic_button);
     }
 }

--- a/boards/components/src/process_printer.rs
+++ b/boards/components/src/process_printer.rs
@@ -3,11 +3,19 @@
 //! Usage
 //! -----
 //! ```rust
-//! let process_printer = ProcessPrinterTextComponent::new().finalize(());
+//! let process_printer = ProcessPrinterTextComponent::new()
+//!     .finalize(components::process_printer_component_static!());
 //! ```
 
+use core::mem::MaybeUninit;
 use kernel::component::Component;
-use kernel::static_init;
+
+#[macro_export]
+macro_rules! process_printer_text_component_static {
+    () => {{
+        kernel::static_buf!(kernel::process::ProcessPrinterText)
+    };};
+}
 
 pub struct ProcessPrinterTextComponent {}
 
@@ -18,13 +26,10 @@ impl ProcessPrinterTextComponent {
 }
 
 impl Component for ProcessPrinterTextComponent {
-    type StaticInput = ();
+    type StaticInput = &'static mut MaybeUninit<kernel::process::ProcessPrinterText>;
     type Output = &'static kernel::process::ProcessPrinterText;
 
-    unsafe fn finalize(self, _static_buffer: Self::StaticInput) -> Self::Output {
-        static_init!(
-            kernel::process::ProcessPrinterText,
-            kernel::process::ProcessPrinterText::new()
-        )
+    unsafe fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
+        static_buffer.write(kernel::process::ProcessPrinterText::new())
     }
 }

--- a/boards/components/src/rng.rs
+++ b/boards/components/src/rng.rs
@@ -1,24 +1,35 @@
 //! Component for random number generator using `Entropy32ToRandom`.
 //!
-//! This provides one Component, RngComponent, which implements a
-//! userspace syscall interface to the RNG peripheral (TRNG).
+//! This provides one Component, RngComponent, which implements a userspace
+//! syscall interface to the RNG peripheral (TRNG).
 //!
 //! Usage
 //! -----
 //! ```rust
-//! let rng = components::rng::RngComponent::new(board_kernel, &sam4l::trng::TRNG).finalize(());
+//! let rng = components::rng::RngComponent::new(board_kernel, &sam4l::trng::TRNG)
+//!     .finalize(rng_component_static!());
 //! ```
 
 // Author: Hudson Ayers <hayers@cs.stanford.edu>
 // Last modified: 07/12/2019
 
 use capsules::rng;
+use core::mem::MaybeUninit;
 use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
 use kernel::hil::entropy::Entropy32;
 use kernel::hil::rng::Rng;
-use kernel::static_init;
+
+#[macro_export]
+macro_rules! rng_component_static {
+    () => {{
+        let etr = kernel::static_buf!(capsules::rng::Entropy32ToRandom<'static>);
+        let rng = kernel::static_buf!(capsules::rng::RngDriver<'static>);
+
+        (etr, rng)
+    };};
+}
 
 pub struct RngComponent {
     board_kernel: &'static kernel::Kernel,
@@ -41,23 +52,22 @@ impl RngComponent {
 }
 
 impl Component for RngComponent {
-    type StaticInput = ();
+    type StaticInput = (
+        &'static mut MaybeUninit<capsules::rng::Entropy32ToRandom<'static>>,
+        &'static mut MaybeUninit<capsules::rng::RngDriver<'static>>,
+    );
     type Output = &'static rng::RngDriver<'static>;
 
-    unsafe fn finalize(self, _static_buffer: Self::StaticInput) -> Self::Output {
+    unsafe fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
         let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
 
-        let entropy_to_random = static_init!(
-            rng::Entropy32ToRandom<'static>,
-            rng::Entropy32ToRandom::new(self.trng)
-        );
-        let rng = static_init!(
-            rng::RngDriver<'static>,
-            rng::RngDriver::new(
-                entropy_to_random,
-                self.board_kernel.create_grant(self.driver_num, &grant_cap)
-            )
-        );
+        let entropy_to_random = static_buffer
+            .0
+            .write(rng::Entropy32ToRandom::new(self.trng));
+        let rng = static_buffer.1.write(rng::RngDriver::new(
+            entropy_to_random,
+            self.board_kernel.create_grant(self.driver_num, &grant_cap),
+        ));
         self.trng.set_client(entropy_to_random);
         entropy_to_random.set_client(rng);
 

--- a/boards/components/src/screen.rs
+++ b/boards/components/src/screen.rs
@@ -16,42 +16,46 @@
 //! ```rust
 //! let screen =
 //!     components::screen::ScreenComponent::new(board_kernel, tft, None)
-//!         .finalize(components::screen_buffer_size!(40960));
+//!         .finalize(components::screen_component_static!(40960));
 //! ```
 //!
 //! // Screen with Setup
 //! ```rust
 //! let screen =
 //!     components::screen::ScreenComponent::new(board_kernel, tft, Some(tft))
-//!         .finalize(components::screen_buffer_size!(40960));
+//!         .finalize(components::screen_component_static!(40960));
 //! ```
+
+use capsules::screen::Screen;
+use core::mem::MaybeUninit;
 use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
-use kernel::static_init;
 
 #[macro_export]
-macro_rules! screen_buffer_size {
+macro_rules! screen_component_static {
     ($s:literal $(,)?) => {{
-        static mut BUFFER: [u8; $s] = [0; $s];
-        (&mut BUFFER)
-    }};
+        let buffer = kernel::static_buf!([u8; $s]);
+        let screen = kernel::static_buf!(capsules::screen::Screen);
+
+        (buffer, screen)
+    };};
 }
 
-pub struct ScreenComponent {
+pub struct ScreenComponent<const SCREEN_BUF_LEN: usize> {
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
     screen: &'static dyn kernel::hil::screen::Screen,
     screen_setup: Option<&'static dyn kernel::hil::screen::ScreenSetup>,
 }
 
-impl ScreenComponent {
+impl<const SCREEN_BUF_LEN: usize> ScreenComponent<SCREEN_BUF_LEN> {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
         driver_num: usize,
         screen: &'static dyn kernel::hil::screen::Screen,
         screen_setup: Option<&'static dyn kernel::hil::screen::ScreenSetup>,
-    ) -> ScreenComponent {
+    ) -> ScreenComponent<SCREEN_BUF_LEN> {
         ScreenComponent {
             board_kernel: board_kernel,
             driver_num: driver_num,
@@ -61,23 +65,25 @@ impl ScreenComponent {
     }
 }
 
-impl Component for ScreenComponent {
-    type StaticInput = &'static mut [u8];
-    type Output = &'static capsules::screen::Screen<'static>;
+impl<const SCREEN_BUF_LEN: usize> Component for ScreenComponent<SCREEN_BUF_LEN> {
+    type StaticInput = (
+        &'static mut MaybeUninit<[u8; SCREEN_BUF_LEN]>,
+        &'static mut MaybeUninit<Screen<'static>>,
+    );
+    type Output = &'static Screen<'static>;
 
     unsafe fn finalize(self, static_input: Self::StaticInput) -> Self::Output {
         let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
         let grant_screen = self.board_kernel.create_grant(self.driver_num, &grant_cap);
 
-        let screen = static_init!(
-            capsules::screen::Screen,
-            capsules::screen::Screen::new(
-                self.screen,
-                self.screen_setup,
-                static_input,
-                grant_screen
-            )
-        );
+        let buffer = static_input.0.write([0; SCREEN_BUF_LEN]);
+
+        let screen = static_input.1.write(Screen::new(
+            self.screen,
+            self.screen_setup,
+            buffer,
+            grant_screen,
+        ));
 
         kernel::hil::screen::Screen::set_client(self.screen, Some(screen));
         if let Some(screen_setup) = self.screen_setup {

--- a/boards/components/src/segger_rtt.rs
+++ b/boards/components/src/segger_rtt.rs
@@ -8,34 +8,46 @@
 //! Usage
 //! -----
 //! ```rust
-//! let rtt_memory = components::segger_rtt::SeggerRttMemoryComponent::new().finalize(());
+//! let rtt_memory = components::segger_rtt::SeggerRttMemoryComponent::new()
+//!     .finalize(components::segger_rtt_memory_component_static!());
 //! let rtt = components::segger_rtt::SeggerRttComponent::new(mux_alarm, rtt_memory)
-//!     .finalize(components::segger_rtt_component_helper!(nrf52832::rtc::Rtc));
+//!     .finalize(components::segger_rtt_component_static!(nrf52832::rtc::Rtc));
 //! ```
 
 // Author: Guillaume Endignoux <guillaumee@google.com>
 // Last modified: 07/02/2020
 
-use capsules::segger_rtt::{
-    SeggerRtt, SeggerRttMemory, DEFAULT_DOWN_BUFFER_LENGTH, DEFAULT_UP_BUFFER_LENGTH,
-};
+use capsules::segger_rtt::{SeggerRtt, SeggerRttMemory};
 use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use core::mem::MaybeUninit;
 use kernel::component::Component;
 use kernel::hil::time::{self, Alarm};
-use kernel::{static_init, static_init_half};
 
 // Setup static space for the objects.
 #[macro_export]
-macro_rules! segger_rtt_component_helper {
+macro_rules! segger_rtt_memory_component_static {
+    () => {{
+        let rtt_memory = kernel::static_buf!(capsules::segger_rtt::SeggerRttMemory);
+        let up_buffer = kernel::static_buf!([u8; capsules::segger_rtt::DEFAULT_UP_BUFFER_LENGTH]);
+        let down_buffer =
+            kernel::static_buf!([u8; capsules::segger_rtt::DEFAULT_DOWN_BUFFER_LENGTH]);
+
+        (rtt_memory, up_buffer, down_buffer)
+    };};
+}
+
+#[macro_export]
+macro_rules! segger_rtt_component_static {
     ($A:ty $(,)?) => {{
-        use capsules::segger_rtt::SeggerRtt;
-        use capsules::virtual_alarm::VirtualMuxAlarm;
-        use core::mem::MaybeUninit;
-        static mut BUF1: MaybeUninit<VirtualMuxAlarm<'static, $A>> = MaybeUninit::uninit();
-        static mut BUF2: MaybeUninit<SeggerRtt<'static, VirtualMuxAlarm<'static, $A>>> =
-            MaybeUninit::uninit();
-        (&mut BUF1, &mut BUF2)
+        let alarm = kernel::static_buf!(capsules::virtual_alarm::VirtualMuxAlarm<'static, $A>);
+        let rtt = kernel::static_buf!(
+            capsules::segger_rtt::SeggerRtt<
+                'static,
+                capsules::virtual_alarm::VirtualMuxAlarm<'static, $A>,
+            >
+        );
+
+        (alarm, rtt)
     };};
 }
 
@@ -60,33 +72,30 @@ impl SeggerRttMemoryComponent {
 }
 
 impl Component for SeggerRttMemoryComponent {
-    type StaticInput = ();
+    type StaticInput = (
+        &'static mut MaybeUninit<SeggerRttMemory<'static>>,
+        &'static mut MaybeUninit<[u8; capsules::segger_rtt::DEFAULT_UP_BUFFER_LENGTH]>,
+        &'static mut MaybeUninit<[u8; capsules::segger_rtt::DEFAULT_DOWN_BUFFER_LENGTH]>,
+    );
     type Output = SeggerRttMemoryRefs<'static>;
 
-    unsafe fn finalize(self, _s: Self::StaticInput) -> Self::Output {
+    unsafe fn finalize(self, s: Self::StaticInput) -> Self::Output {
         let name = b"Terminal\0";
         let up_buffer_name = name;
         let down_buffer_name = name;
-        let up_buffer = static_init!(
-            [u8; DEFAULT_UP_BUFFER_LENGTH],
-            [0; DEFAULT_UP_BUFFER_LENGTH]
-        );
-        let down_buffer = static_init!(
-            [u8; DEFAULT_DOWN_BUFFER_LENGTH],
-            [0; DEFAULT_DOWN_BUFFER_LENGTH]
-        );
+        let up_buffer =
+            s.1.write([0; capsules::segger_rtt::DEFAULT_UP_BUFFER_LENGTH]);
+        let down_buffer =
+            s.2.write([0; capsules::segger_rtt::DEFAULT_DOWN_BUFFER_LENGTH]);
 
-        let rtt_memory = static_init!(
-            SeggerRttMemory,
-            SeggerRttMemory::new_raw(
-                up_buffer_name,
-                up_buffer.as_ptr(),
-                up_buffer.len(),
-                down_buffer_name,
-                down_buffer.as_ptr(),
-                down_buffer.len()
-            )
-        );
+        let rtt_memory = s.0.write(SeggerRttMemory::new_raw(
+            up_buffer_name,
+            up_buffer.as_ptr(),
+            up_buffer.len(),
+            down_buffer_name,
+            down_buffer.as_ptr(),
+            down_buffer.len(),
+        ));
         SeggerRttMemoryRefs {
             rtt_memory,
             up_buffer,
@@ -120,24 +129,16 @@ impl<A: 'static + time::Alarm<'static>> Component for SeggerRttComponent<A> {
     type Output = &'static capsules::segger_rtt::SeggerRtt<'static, VirtualMuxAlarm<'static, A>>;
 
     unsafe fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
-        let virtual_alarm_rtt = static_init_half!(
-            static_buffer.0,
-            VirtualMuxAlarm<'static, A>,
-            VirtualMuxAlarm::new(self.mux_alarm)
-        );
+        let virtual_alarm_rtt = static_buffer.0.write(VirtualMuxAlarm::new(self.mux_alarm));
         virtual_alarm_rtt.setup();
 
         // RTT communication channel
-        let rtt = static_init_half!(
-            static_buffer.1,
-            SeggerRtt<'static, VirtualMuxAlarm<'static, A>>,
-            SeggerRtt::new(
-                virtual_alarm_rtt,
-                self.rtt_memory_refs.rtt_memory,
-                self.rtt_memory_refs.up_buffer,
-                self.rtt_memory_refs.down_buffer
-            )
-        );
+        let rtt = static_buffer.1.write(SeggerRtt::new(
+            virtual_alarm_rtt,
+            self.rtt_memory_refs.rtt_memory,
+            self.rtt_memory_refs.up_buffer,
+            self.rtt_memory_refs.down_buffer,
+        ));
 
         virtual_alarm_rtt.set_alarm_client(rtt);
 

--- a/boards/components/src/text_screen.rs
+++ b/boards/components/src/text_screen.rs
@@ -15,34 +15,38 @@
 //! ```rust
 //! let text_screen =
 //!     components::text_screen::TextScreenComponent::new(board_kernel, tft)
-//!         .finalize(components::screen_buffer_size!(40960));
+//!         .finalize(components::text_screen_component_static!(40960));
 //! ```
 //!
+
+use capsules::text_screen::TextScreen;
+use core::mem::MaybeUninit;
 use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
-use kernel::static_init;
 
 #[macro_export]
-macro_rules! text_screen_buffer_size {
-    ($s:literal) => {{
-        static mut BUFFER: [u8; $s] = [0; $s];
-        (&mut BUFFER)
-    }};
+macro_rules! text_screen_component_static {
+    ($s:literal $(,)?) => {{
+        let buffer = kernel::static_buf!([u8; $s]);
+        let screen = kernel::static_buf!(capsules::screen::TextScreen);
+
+        (buffer, screen)
+    };};
 }
 
-pub struct TextScreenComponent {
+pub struct TextScreenComponent<const SCREEN_BUF_LEN: usize> {
     board_kernel: &'static kernel::Kernel,
     driver_num: usize,
     text_screen: &'static dyn kernel::hil::text_screen::TextScreen<'static>,
 }
 
-impl TextScreenComponent {
+impl<const SCREEN_BUF_LEN: usize> TextScreenComponent<SCREEN_BUF_LEN> {
     pub fn new(
         board_kernel: &'static kernel::Kernel,
         driver_num: usize,
         text_screen: &'static dyn kernel::hil::text_screen::TextScreen<'static>,
-    ) -> TextScreenComponent {
+    ) -> TextScreenComponent<SCREEN_BUF_LEN> {
         TextScreenComponent {
             board_kernel: board_kernel,
             driver_num: driver_num,
@@ -51,22 +55,23 @@ impl TextScreenComponent {
     }
 }
 
-impl Component for TextScreenComponent {
-    type StaticInput = &'static mut [u8];
-    type Output = &'static capsules::text_screen::TextScreen<'static>;
+impl<const SCREEN_BUF_LEN: usize> Component for TextScreenComponent<SCREEN_BUF_LEN> {
+    type StaticInput = (
+        &'static mut MaybeUninit<[u8; SCREEN_BUF_LEN]>,
+        &'static mut MaybeUninit<TextScreen<'static>>,
+    );
+    type Output = &'static TextScreen<'static>;
 
     unsafe fn finalize(self, static_input: Self::StaticInput) -> Self::Output {
         let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
         let grant_text_screen = self.board_kernel.create_grant(self.driver_num, &grant_cap);
 
-        let text_screen = static_init!(
-            capsules::text_screen::TextScreen,
-            capsules::text_screen::TextScreen::new(
-                self.text_screen,
-                static_input,
-                grant_text_screen
-            )
-        );
+        let buffer = static_input.0.write([0; SCREEN_BUF_LEN]);
+
+        let text_screen =
+            static_input
+                .1
+                .write(TextScreen::new(self.text_screen, buffer, grant_text_screen));
 
         kernel::hil::text_screen::TextScreen::set_client(self.text_screen, Some(text_screen));
 

--- a/boards/components/src/tickv.rs
+++ b/boards/components/src/tickv.rs
@@ -16,7 +16,7 @@
 //!    );
 //!
 //!    let mux_flash = components::tickv::FlashMuxComponent::new(&peripherals.flash_ctrl).finalize(
-//!        components::flash_user_component_helper!(lowrisc::flash_ctrl::FlashCtrl),
+//!        components::flash_user_component_static!(lowrisc::flash_ctrl::FlashCtrl),
 //!    );
 //!
 //!    let kvstore = components::tickv::TicKVComponent::new(
@@ -26,7 +26,7 @@
 //!        flash_ctrl_read_buf,
 //!        page_buffer,
 //!    )
-//!    .finalize(components::tickv_component_helper!(
+//!    .finalize(components::tickv_component_static!(
 //!        lowrisc::flash_ctrl::FlashCtrl
 //!    ));
 //!    hil::flash::HasClient::set_client(&peripherals.flash_ctrl, mux_flash);
@@ -42,20 +42,21 @@ use kernel::create_capability;
 use kernel::hil;
 use kernel::hil::flash::HasClient;
 use kernel::hil::hasher::Hasher;
-use kernel::static_init_half;
 
 // Setup static space for the objects.
 #[macro_export]
-macro_rules! tickv_component_helper {
+macro_rules! tickv_component_static {
     ($F:ty, $H:ty) => {{
-        use capsules::tickv::TicKVStore;
-        use capsules::virtual_flash::FlashUser;
-        use core::mem::MaybeUninit;
-        use kernel::hil;
-        static mut BUF1: MaybeUninit<FlashUser<'static, $F>> = MaybeUninit::uninit();
-        static mut BUF2: MaybeUninit<TicKVStore<'static, FlashUser<'static, $F>, $H>> =
-            MaybeUninit::uninit();
-        (&mut BUF1, &mut BUF2)
+        let flash = kernel::static_buf!(capsules::virtual_flash::FlashUser<'static, $F>);
+        let tickv = kernel::static_buf!(
+            capsules::tickv::TicKVStore<
+                'static,
+                capsules::virtual_flash::FlashUser<'static, $F>,
+                $H,
+            >
+        );
+
+        (flash, tickv)
     };};
 }
 
@@ -109,24 +110,16 @@ impl<
     unsafe fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
         let _grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
 
-        let virtual_flash = static_init_half!(
-            static_buffer.0,
-            FlashUser<'static, F>,
-            FlashUser::new(self.mux_flash)
-        );
+        let virtual_flash = static_buffer.0.write(FlashUser::new(self.mux_flash));
 
-        let driver = static_init_half!(
-            static_buffer.1,
-            TicKVStore<'static, FlashUser<'static, F>, H>,
-            TicKVStore::new(
-                virtual_flash,
-                self.hasher,
-                self.tickfs_read_buf,
-                self.flash_read_buffer,
-                self.region_offset,
-                self.flash_size,
-            )
-        );
+        let driver = static_buffer.1.write(TicKVStore::new(
+            virtual_flash,
+            self.hasher,
+            self.tickfs_read_buf,
+            self.flash_read_buffer,
+            self.region_offset,
+            self.flash_size,
+        ));
         virtual_flash.set_client(driver);
         driver.initialise();
         driver

--- a/boards/components/src/touch.rs
+++ b/boards/components/src/touch.rs
@@ -9,12 +9,12 @@
 //! // Just Touch
 //! let touch =
 //!     components::touch::TouchComponent::new(board_kernel, ts, None, Some(screen))
-//!         .finalize(());
+//!         .finalize(components::touch_component_static!());
 //!
 //! // With Gesture
 //! let touch =
 //!     components::touch::TouchComponent::new(board_kernel, ts, Some(ts), Some(screen))
-//!         .finalize(());
+//!         .finalize(components::touch_component_static!());
 //! ```
 //!
 //! Multi Touch
@@ -23,17 +23,25 @@
 //! // Just Multi Touch
 //! let touch =
 //!     components::touch::MultiTouchComponent::new(board_kernel, ts, None, Some(screen))
-//!         .finalize(());
+//!         .finalize(components::touch_component_static!());
 //!
 //! // With Gesture
 //! let touch =
 //!     components::touch::MultiTouchComponent::new(board_kernel, ts, Some(ts), Some(screen))
-//!         .finalize(());
+//!         .finalize(components::touch_component_static!());
 //! ```
+use capsules::touch::Touch;
+use core::mem::MaybeUninit;
 use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
-use kernel::static_init;
+
+#[macro_export]
+macro_rules! touch_component_static {
+    () => {{
+        kernel::static_buf!(capsules::touch::Touch<'static>)
+    };};
+}
 
 pub struct TouchComponent {
     board_kernel: &'static kernel::Kernel,
@@ -62,17 +70,19 @@ impl TouchComponent {
 }
 
 impl Component for TouchComponent {
-    type StaticInput = ();
+    type StaticInput = &'static mut MaybeUninit<Touch<'static>>;
     type Output = &'static capsules::touch::Touch<'static>;
 
-    unsafe fn finalize(self, _static_input: Self::StaticInput) -> Self::Output {
+    unsafe fn finalize(self, static_input: Self::StaticInput) -> Self::Output {
         let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
         let grant_touch = self.board_kernel.create_grant(self.driver_num, &grant_cap);
 
-        let touch = static_init!(
-            capsules::touch::Touch,
-            capsules::touch::Touch::new(Some(self.touch), None, self.screen, grant_touch)
-        );
+        let touch = static_input.write(capsules::touch::Touch::new(
+            Some(self.touch),
+            None,
+            self.screen,
+            grant_touch,
+        ));
 
         kernel::hil::touch::Touch::set_client(self.touch, touch);
         if let Some(gesture) = self.gesture {
@@ -110,17 +120,19 @@ impl MultiTouchComponent {
 }
 
 impl Component for MultiTouchComponent {
-    type StaticInput = ();
+    type StaticInput = &'static mut MaybeUninit<Touch<'static>>;
     type Output = &'static capsules::touch::Touch<'static>;
 
-    unsafe fn finalize(self, _static_input: Self::StaticInput) -> Self::Output {
+    unsafe fn finalize(self, static_input: Self::StaticInput) -> Self::Output {
         let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
         let grant_touch = self.board_kernel.create_grant(self.driver_num, &grant_cap);
 
-        let touch = static_init!(
-            capsules::touch::Touch,
-            capsules::touch::Touch::new(None, Some(self.multi_touch), self.screen, grant_touch)
-        );
+        let touch = static_input.write(capsules::touch::Touch::new(
+            None,
+            Some(self.multi_touch),
+            self.screen,
+            grant_touch,
+        ));
 
         kernel::hil::touch::MultiTouch::set_client(self.multi_touch, touch);
         if let Some(gesture) = self.gesture {

--- a/boards/esp32-c3-devkitM-1/src/main.rs
+++ b/boards/esp32-c3-devkitM-1/src/main.rs
@@ -248,8 +248,8 @@ unsafe fn setup() -> (
     components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
 
     // Create process printer for panic.
-    let process_printer =
-        components::process_printer::ProcessPrinterTextComponent::new().finalize(());
+    let process_printer = components::process_printer::ProcessPrinterTextComponent::new()
+        .finalize(components::process_printer_text_component_static!());
     PROCESS_PRINTER = Some(process_printer);
 
     debug!("ESP32-C3 initialisation complete.");
@@ -269,8 +269,8 @@ unsafe fn setup() -> (
 
     let scheduler = components::sched::priority::PriorityComponent::new(board_kernel).finalize(());
 
-    let process_printer =
-        components::process_printer::ProcessPrinterTextComponent::new().finalize(());
+    let process_printer = components::process_printer::ProcessPrinterTextComponent::new()
+        .finalize(components::process_printer_text_component_static!());
     PROCESS_PRINTER = Some(process_printer);
 
     // PROCESS CONSOLE

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -324,7 +324,7 @@ pub unsafe fn main() {
         &peripherals.usart3,
         &peripherals.pa[17],
     )
-    .finalize(());
+    .finalize(components::nrf51822_component_static!());
 
     let sensors_i2c = static_init!(
         MuxI2C<'static>,

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -396,7 +396,7 @@ pub unsafe fn main() {
     .finalize(components::spi_syscall_component_helper!(sam4l::spi::SpiHw));
 
     // LEDs
-    let led = components::led::LedsComponent::new().finalize(components::led_component_helper!(
+    let led = components::led::LedsComponent::new().finalize(components::led_component_static!(
         LedLow<'static, sam4l::gpio::GPIOPin>,
         LedLow::new(&peripherals.pa[13]), // Red
         LedLow::new(&peripherals.pa[15]), // Green

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -416,7 +416,7 @@ pub unsafe fn main() {
             )
         ),
     )
-    .finalize(components::button_component_buf!(sam4l::gpio::GPIOPin));
+    .finalize(components::button_component_static!(sam4l::gpio::GPIOPin));
 
     // Setup ADC
     let adc_channels = static_init!(

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -462,7 +462,7 @@ pub unsafe fn main() {
         capsules::rng::DRIVER_NUM,
         &peripherals.trng,
     )
-    .finalize(());
+    .finalize(components::rng_component_static!());
 
     // set GPIO driver controlling remaining GPIO pins
     let gpio = components::gpio::GpioComponent::new(

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -484,7 +484,7 @@ pub unsafe fn main() {
         capsules::crc::DRIVER_NUM,
         &peripherals.crccu,
     )
-    .finalize(components::crc_component_helper!(sam4l::crccu::Crccu));
+    .finalize(components::crc_component_static!(sam4l::crccu::Crccu));
 
     // DAC
     let dac = static_init!(

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -273,8 +273,8 @@ pub unsafe fn main() {
     );
     DynamicDeferredCall::set_global_instance(dynamic_deferred_caller);
 
-    let process_printer =
-        components::process_printer::ProcessPrinterTextComponent::new().finalize(());
+    let process_printer = components::process_printer::ProcessPrinterTextComponent::new()
+        .finalize(components::process_printer_text_component_static!());
     PROCESS_PRINTER = Some(process_printer);
 
     // Initialize USART0 for Uart

--- a/boards/hifive1/src/main.rs
+++ b/boards/hifive1/src/main.rs
@@ -272,7 +272,7 @@ pub unsafe fn main() {
         capsules::low_level_debug::DRIVER_NUM,
         uart_mux,
     )
-    .finalize(());
+    .finalize(components::low_level_debug_component_static!());
 
     debug!("HiFive1 initialization complete. Entering main loop.");
 

--- a/boards/hifive1/src/main.rs
+++ b/boards/hifive1/src/main.rs
@@ -233,8 +233,8 @@ pub unsafe fn main() {
     );
     CHIP = Some(chip);
 
-    let process_printer =
-        components::process_printer::ProcessPrinterTextComponent::new().finalize(());
+    let process_printer = components::process_printer::ProcessPrinterTextComponent::new()
+        .finalize(components::process_printer_text_component_static!());
     PROCESS_PRINTER = Some(process_printer);
 
     let process_console = components::process_console::ProcessConsoleComponent::new(

--- a/boards/hifive1/src/main.rs
+++ b/boards/hifive1/src/main.rs
@@ -176,7 +176,7 @@ pub unsafe fn main() {
     .finalize(());
 
     // LEDs
-    let led = components::led::LedsComponent::new().finalize(components::led_component_helper!(
+    let led = components::led::LedsComponent::new().finalize(components::led_component_static!(
         LedLow<'static, sifive::gpio::GpioPin>,
         LedLow::new(&peripherals.e310x.gpio_port[22]), // Red
         LedLow::new(&peripherals.e310x.gpio_port[19]), // Green

--- a/boards/hifive_inventor/src/main.rs
+++ b/boards/hifive_inventor/src/main.rs
@@ -251,7 +251,7 @@ pub unsafe fn main() {
         capsules::low_level_debug::DRIVER_NUM,
         uart_mux,
     )
-    .finalize(());
+    .finalize(components::low_level_debug_component_static!());
 
     debug!("HiFive1 initialization complete. Entering main loop.");
 

--- a/boards/hifive_inventor/src/main.rs
+++ b/boards/hifive_inventor/src/main.rs
@@ -212,8 +212,8 @@ pub unsafe fn main() {
     );
     CHIP = Some(chip);
 
-    let process_printer =
-        components::process_printer::ProcessPrinterTextComponent::new().finalize(());
+    let process_printer = components::process_printer::ProcessPrinterTextComponent::new()
+        .finalize(components::process_printer_text_component_static!());
     PROCESS_PRINTER = Some(process_printer);
 
     let process_console = components::process_console::ProcessConsoleComponent::new(

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -390,7 +390,7 @@ pub unsafe fn main() {
         &peripherals.usart2,
         &peripherals.pb[07],
     )
-    .finalize(());
+    .finalize(components::nrf51822_component_static!());
 
     // # I2C and I2C Sensors
     let mux_i2c = static_init!(

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -357,8 +357,8 @@ pub unsafe fn main() {
     );
     DynamicDeferredCall::set_global_instance(dynamic_deferred_caller);
 
-    let process_printer =
-        components::process_printer::ProcessPrinterTextComponent::new().finalize(());
+    let process_printer = components::process_printer::ProcessPrinterTextComponent::new()
+        .finalize(components::process_printer_text_component_static!());
     PROCESS_PRINTER = Some(process_printer);
 
     // # CONSOLE

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -503,9 +503,9 @@ pub unsafe fn main() {
         sam4l::acifc::AcChannel,
         sam4l::acifc::AcChannel::new(sam4l::acifc::Channel::AC0)
     );
-    let analog_comparator = components::analog_comparator::AcComponent::new(
+    let analog_comparator = components::analog_comparator::AnalogComparatorComponent::new(
         &peripherals.acifc,
-        components::acomp_component_helper!(
+        components::analog_comparator_component_helper!(
             <sam4l::acifc::Acifc as kernel::hil::analog_comparator::AnalogComparator>::Channel,
             ac_0,
             ac_1,
@@ -515,7 +515,9 @@ pub unsafe fn main() {
         board_kernel,
         capsules::analog_comparator::DRIVER_NUM,
     )
-    .finalize(components::acomp_component_buf!(sam4l::acifc::Acifc));
+    .finalize(components::analog_comparator_component_static!(
+        sam4l::acifc::Acifc
+    ));
     let rng = RngComponent::new(board_kernel, capsules::rng::DRIVER_NUM, &peripherals.trng)
         .finalize(components::rng_component_static!());
 

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -485,7 +485,7 @@ pub unsafe fn main() {
     .finalize(components::button_component_buf!(sam4l::gpio::GPIOPin));
 
     let crc = CrcComponent::new(board_kernel, capsules::crc::DRIVER_NUM, &peripherals.crccu)
-        .finalize(components::crc_component_helper!(sam4l::crccu::Crccu));
+        .finalize(components::crc_component_static!(sam4l::crccu::Crccu));
 
     let ac_0 = static_init!(
         sam4l::acifc::AcChannel,

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -579,7 +579,7 @@ pub unsafe fn main() {
         &_sstorage as *const u8 as usize, //start address of kernel region
         &_estorage as *const u8 as usize - &_sstorage as *const u8 as usize, // length of kernel region
     )
-    .finalize(components::nv_storage_component_helper!(
+    .finalize(components::nonvolatile_storage_component_static!(
         sam4l::flashcalw::FLASHCALW
     ));
 

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -465,7 +465,7 @@ pub unsafe fn main() {
     )
     .finalize(components::gpio_component_buf!(sam4l::gpio::GPIOPin));
 
-    let led = LedsComponent::new().finalize(components::led_component_helper!(
+    let led = LedsComponent::new().finalize(components::led_component_static!(
         LedHigh<'static, sam4l::gpio::GPIOPin>,
         LedHigh::new(&peripherals.pc[10]),
     ));

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -516,8 +516,8 @@ pub unsafe fn main() {
         capsules::analog_comparator::DRIVER_NUM,
     )
     .finalize(components::acomp_component_buf!(sam4l::acifc::Acifc));
-    let rng =
-        RngComponent::new(board_kernel, capsules::rng::DRIVER_NUM, &peripherals.trng).finalize(());
+    let rng = RngComponent::new(board_kernel, capsules::rng::DRIVER_NUM, &peripherals.trng)
+        .finalize(components::rng_component_static!());
 
     // For now, assign the 802.15.4 MAC address on the device as
     // simply a 16-bit short address which represents the last 16 bits

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -482,7 +482,7 @@ pub unsafe fn main() {
             )
         ),
     )
-    .finalize(components::button_component_buf!(sam4l::gpio::GPIOPin));
+    .finalize(components::button_component_static!(sam4l::gpio::GPIOPin));
 
     let crc = CrcComponent::new(board_kernel, capsules::crc::DRIVER_NUM, &peripherals.crccu)
         .finalize(components::crc_component_static!(sam4l::crccu::Crccu));

--- a/boards/imxrt1050-evkb/src/main.rs
+++ b/boards/imxrt1050-evkb/src/main.rs
@@ -355,7 +355,7 @@ pub unsafe fn main() {
             )
         ),
     )
-    .finalize(components::button_component_buf!(imxrt1050::gpio::Pin));
+    .finalize(components::button_component_static!(imxrt1050::gpio::Pin));
 
     // ALARM
     let gpt1 = &peripherals.gpt1;

--- a/boards/imxrt1050-evkb/src/main.rs
+++ b/boards/imxrt1050-evkb/src/main.rs
@@ -337,7 +337,7 @@ pub unsafe fn main() {
     // LEDs
 
     // Clock to Port A is enabled in `set_pin_primary_functions()
-    let led = components::led::LedsComponent::new().finalize(components::led_component_helper!(
+    let led = components::led::LedsComponent::new().finalize(components::led_component_static!(
         LedLow<'static, imxrt1050::gpio::Pin<'static>>,
         LedLow::new(peripherals.ports.pin(imxrt1050::gpio::PinId::AdB0_09)),
     ));

--- a/boards/imxrt1050-evkb/src/main.rs
+++ b/boards/imxrt1050-evkb/src/main.rs
@@ -483,8 +483,8 @@ pub unsafe fn main() {
     //--------------------------------------------------------------------------
     // Process Console
     //---------------------------------------------------------------------------
-    let process_printer =
-        components::process_printer::ProcessPrinterTextComponent::new().finalize(());
+    let process_printer = components::process_printer::ProcessPrinterTextComponent::new()
+        .finalize(components::process_printer_text_component_static!());
     PROCESS_PRINTER = Some(process_printer);
 
     let process_console = components::process_console::ProcessConsoleComponent::new(

--- a/boards/litex/arty/src/main.rs
+++ b/boards/litex/arty/src/main.rs
@@ -515,7 +515,7 @@ pub unsafe fn main() {
         capsules::low_level_debug::DRIVER_NUM,
         uart_mux,
     )
-    .finalize(());
+    .finalize(components::low_level_debug_component_static!());
 
     let scheduler = components::sched::cooperative::CooperativeComponent::new(&PROCESSES)
         .finalize(components::coop_component_helper!(NUM_PROCS));

--- a/boards/litex/arty/src/main.rs
+++ b/boards/litex/arty/src/main.rs
@@ -469,8 +469,8 @@ pub unsafe fn main() {
 
     PANIC_REFERENCES.chip = Some(chip);
 
-    let process_printer =
-        components::process_printer::ProcessPrinterTextComponent::new().finalize(());
+    let process_printer = components::process_printer::ProcessPrinterTextComponent::new()
+        .finalize(components::process_printer_text_component_static!());
 
     PANIC_REFERENCES.process_printer = Some(process_printer);
 

--- a/boards/litex/arty/src/main.rs
+++ b/boards/litex/arty/src/main.rs
@@ -438,7 +438,7 @@ pub unsafe fn main() {
 
     // LEDs
     let led_driver =
-        components::led::LedsComponent::new().finalize(components::led_component_helper!(
+        components::led::LedsComponent::new().finalize(components::led_component_static!(
             litex_vexriscv::led_controller::LiteXLed<'static, socc::SoCRegisterFmt>,
             led0.get_led(0).unwrap(),
             led0.get_led(1).unwrap(),

--- a/boards/litex/sim/src/main.rs
+++ b/boards/litex/sim/src/main.rs
@@ -588,7 +588,7 @@ pub unsafe fn main() {
         capsules::low_level_debug::DRIVER_NUM,
         uart_mux,
     )
-    .finalize(());
+    .finalize(components::low_level_debug_component_static!());
 
     debug!("Verilated LiteX+VexRiscv: initialization complete, entering main loop.");
 

--- a/boards/litex/sim/src/main.rs
+++ b/boards/litex/sim/src/main.rs
@@ -472,7 +472,7 @@ pub unsafe fn main() {
     );
 
     let led_driver =
-        components::led::LedsComponent::new().finalize(components::led_component_helper!(
+        components::led::LedsComponent::new().finalize(components::led_component_static!(
             kernel::hil::led::LedHigh<GPIOPin>,
             LedHigh::new(&led_gpios[0]),
             LedHigh::new(&led_gpios[1]),

--- a/boards/litex/sim/src/main.rs
+++ b/boards/litex/sim/src/main.rs
@@ -533,7 +533,7 @@ pub unsafe fn main() {
             ),
         ),
     )
-    .finalize(components::button_component_buf!(GPIOPin));
+    .finalize(components::button_component_static!(GPIOPin));
 
     // ---------- INITIALIZE CHIP, ENABLE INTERRUPTS ----------
 

--- a/boards/litex/sim/src/main.rs
+++ b/boards/litex/sim/src/main.rs
@@ -559,8 +559,8 @@ pub unsafe fn main() {
 
     PANIC_REFERENCES.chip = Some(chip);
 
-    let process_printer =
-        components::process_printer::ProcessPrinterTextComponent::new().finalize(());
+    let process_printer = components::process_printer::ProcessPrinterTextComponent::new()
+        .finalize(components::process_printer_text_component_static!());
 
     PANIC_REFERENCES.process_printer = Some(process_printer);
 

--- a/boards/microbit_v2/src/main.rs
+++ b/boards/microbit_v2/src/main.rs
@@ -409,7 +409,7 @@ pub unsafe fn main() {
         capsules::rng::DRIVER_NUM,
         &base_peripherals.trng,
     )
-    .finalize(());
+    .finalize(components::rng_component_static!());
 
     //--------------------------------------------------------------------------
     // SENSORS

--- a/boards/microbit_v2/src/main.rs
+++ b/boards/microbit_v2/src/main.rs
@@ -279,7 +279,9 @@ pub unsafe fn main() {
             ), // Touch Logo
         ),
     )
-    .finalize(components::button_component_buf!(nrf52833::gpio::GPIOPin));
+    .finalize(components::button_component_static!(
+        nrf52833::gpio::GPIOPin
+    ));
 
     //--------------------------------------------------------------------------
     // Deferred Call (Dynamic) Setup

--- a/boards/microbit_v2/src/main.rs
+++ b/boards/microbit_v2/src/main.rs
@@ -524,7 +524,7 @@ pub unsafe fn main() {
         capsules::sound_pressure::DRIVER_NUM,
         adc_microphone,
     )
-    .finalize(());
+    .finalize(components::sound_pressure_component_static!());
 
     //--------------------------------------------------------------------------
     // STORAGE

--- a/boards/microbit_v2/src/main.rs
+++ b/boards/microbit_v2/src/main.rs
@@ -531,13 +531,13 @@ pub unsafe fn main() {
     //--------------------------------------------------------------------------
 
     let mux_flash = components::flash::FlashMuxComponent::new(&base_peripherals.nvmc).finalize(
-        components::flash_mux_component_helper!(nrf52833::nvmc::Nvmc),
+        components::flash_mux_component_static!(nrf52833::nvmc::Nvmc),
     );
 
     // App Flash
 
     let virtual_app_flash = components::flash::FlashUserComponent::new(mux_flash).finalize(
-        components::flash_user_component_helper!(nrf52833::nvmc::Nvmc),
+        components::flash_user_component_static!(nrf52833::nvmc::Nvmc),
     );
 
     let app_flash = components::app_flash_driver::AppFlashComponent::new(

--- a/boards/microbit_v2/src/main.rs
+++ b/boards/microbit_v2/src/main.rs
@@ -635,8 +635,8 @@ pub unsafe fn main() {
     //--------------------------------------------------------------------------
     // Process Console
     //--------------------------------------------------------------------------
-    let process_printer =
-        components::process_printer::ProcessPrinterTextComponent::new().finalize(());
+    let process_printer = components::process_printer::ProcessPrinterTextComponent::new()
+        .finalize(components::process_printer_text_component_static!());
     PROCESS_PRINTER = Some(process_printer);
 
     let _process_console = components::process_console::ProcessConsoleComponent::new(

--- a/boards/microbit_v2/src/main.rs
+++ b/boards/microbit_v2/src/main.rs
@@ -545,7 +545,7 @@ pub unsafe fn main() {
         capsules::app_flash_driver::DRIVER_NUM,
         virtual_app_flash,
     )
-    .finalize(components::app_flash_component_helper!(
+    .finalize(components::app_flash_component_static!(
         capsules::virtual_flash::FlashUser<'static, nrf52833::nvmc::Nvmc>,
         512
     ));

--- a/boards/msp_exp432p401r/src/main.rs
+++ b/boards/msp_exp432p401r/src/main.rs
@@ -256,7 +256,7 @@ pub unsafe fn main() {
     .finalize(components::button_component_static!(msp432::gpio::IntPin));
 
     // Setup LEDs
-    let leds = components::led::LedsComponent::new().finalize(components::led_component_helper!(
+    let leds = components::led::LedsComponent::new().finalize(components::led_component_static!(
         kernel::hil::led::LedHigh<'static, msp432::gpio::IntPin>,
         kernel::hil::led::LedHigh::new(
             &peripherals.gpio.int_pins[msp432::gpio::IntPinNr::P02_0 as usize]

--- a/boards/msp_exp432p401r/src/main.rs
+++ b/boards/msp_exp432p401r/src/main.rs
@@ -253,7 +253,7 @@ pub unsafe fn main() {
             )
         ),
     )
-    .finalize(components::button_component_buf!(msp432::gpio::IntPin));
+    .finalize(components::button_component_static!(msp432::gpio::IntPin));
 
     // Setup LEDs
     let leds = components::led::LedsComponent::new().finalize(components::led_component_helper!(

--- a/boards/msp_exp432p401r/src/main.rs
+++ b/boards/msp_exp432p401r/src/main.rs
@@ -422,8 +422,8 @@ pub unsafe fn main() {
     let scheduler = components::sched::round_robin::RoundRobinComponent::new(&PROCESSES)
         .finalize(components::rr_component_helper!(NUM_PROCS));
 
-    let process_printer =
-        components::process_printer::ProcessPrinterTextComponent::new().finalize(());
+    let process_printer = components::process_printer::ProcessPrinterTextComponent::new()
+        .finalize(components::process_printer_text_component_static!());
     PROCESS_PRINTER = Some(process_printer);
 
     let msp_exp432p4014 = MspExp432P401R {

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -400,7 +400,7 @@ pub unsafe fn main() {
         capsules::rng::DRIVER_NUM,
         &base_peripherals.trng,
     )
-    .finalize(());
+    .finalize(components::rng_component_static!());
 
     //--------------------------------------------------------------------------
     // ADC

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -521,7 +521,7 @@ pub unsafe fn main() {
         capsules::humidity::DRIVER_NUM,
         hts221,
     )
-    .finalize(());
+    .finalize(components::humidity_component_static!());
 
     //--------------------------------------------------------------------------
     // WIRELESS

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -509,7 +509,7 @@ pub unsafe fn main() {
     kernel::hil::sensors::ProximityDriver::set_client(apds9960, proximity);
 
     let hts221 = components::hts221::Hts221Component::new(sensors_i2c_bus, 0x5f)
-        .finalize(components::hts221_component_helper!());
+        .finalize(components::hts221_component_static!());
     let temperature = components::temperature::TemperatureComponent::new(
         board_kernel,
         capsules::temperature::DRIVER_NUM,

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -356,7 +356,7 @@ pub unsafe fn main() {
         dynamic_deferred_caller,
         Some(&baud_rate_reset_bootloader_enter),
     )
-    .finalize(components::usb_cdc_acm_component_helper!(
+    .finalize(components::cdc_acm_component_static!(
         nrf52::usbd::Usbd,
         nrf52::rtc::Rtc
     ));

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -363,8 +363,8 @@ pub unsafe fn main() {
     CDC_REF_FOR_PANIC = Some(cdc); //for use by panic handler
 
     // Process Printer for displaying process information.
-    let process_printer =
-        components::process_printer::ProcessPrinterTextComponent::new().finalize(());
+    let process_printer = components::process_printer::ProcessPrinterTextComponent::new()
+        .finalize(components::process_printer_text_component_static!());
     PROCESS_PRINTER = Some(process_printer);
 
     // Create a shared UART channel for the console and for kernel debug.

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -290,7 +290,7 @@ pub unsafe fn main() {
     // LEDs
     //--------------------------------------------------------------------------
 
-    let led = components::led::LedsComponent::new().finalize(components::led_component_helper!(
+    let led = components::led::LedsComponent::new().finalize(components::led_component_static!(
         LedLow<'static, nrf52840::gpio::GPIOPin>,
         LedLow::new(&nrf52840_peripherals.gpio_port[LED_RED_PIN]),
         LedLow::new(&nrf52840_peripherals.gpio_port[LED_GREEN_PIN]),

--- a/boards/nano_rp2040_connect/src/main.rs
+++ b/boards/nano_rp2040_connect/src/main.rs
@@ -477,8 +477,8 @@ pub unsafe fn main() {
                 adc_channel_3,
             ));
 
-    let process_printer =
-        components::process_printer::ProcessPrinterTextComponent::new().finalize(());
+    let process_printer = components::process_printer::ProcessPrinterTextComponent::new()
+        .finalize(components::process_printer_text_component_static!());
     PROCESS_PRINTER = Some(process_printer);
 
     // PROCESS CONSOLE

--- a/boards/nano_rp2040_connect/src/main.rs
+++ b/boards/nano_rp2040_connect/src/main.rs
@@ -384,7 +384,7 @@ pub unsafe fn main() {
     )
     .finalize(components::gpio_component_buf!(RPGpioPin<'static>));
 
-    let led = LedsComponent::new().finalize(components::led_component_helper!(
+    let led = LedsComponent::new().finalize(components::led_component_static!(
         LedHigh<'static, RPGpioPin<'static>>,
         LedHigh::new(&peripherals.pins.get_pin(RPGpio::GPIO6))
     ));

--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -377,7 +377,7 @@ pub unsafe fn main() {
         capsules::rng::DRIVER_NUM,
         &base_peripherals.trng,
     )
-    .finalize(());
+    .finalize(components::rng_component_static!());
 
     // Initialize AC using AIN5 (P0.29) as VIN+ and VIN- as AIN0 (P0.02)
     // These are hardcoded pin assignments specified in the driver

--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -239,7 +239,9 @@ pub unsafe fn main() {
             )
         ),
     )
-    .finalize(components::button_component_buf!(nrf52840::gpio::GPIOPin));
+    .finalize(components::button_component_static!(
+        nrf52840::gpio::GPIOPin
+    ));
 
     let led = components::led::LedsComponent::new().finalize(components::led_component_helper!(
         LedLow<'static, nrf52840::gpio::GPIOPin>,

--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -381,16 +381,16 @@ pub unsafe fn main() {
 
     // Initialize AC using AIN5 (P0.29) as VIN+ and VIN- as AIN0 (P0.02)
     // These are hardcoded pin assignments specified in the driver
-    let analog_comparator = components::analog_comparator::AcComponent::new(
+    let analog_comparator = components::analog_comparator::AnalogComparatorComponent::new(
         &base_peripherals.acomp,
-        components::acomp_component_helper!(
+        components::analog_comparator_component_helper!(
             nrf52840::acomp::Channel,
             &nrf52840::acomp::CHANNEL_AC0
         ),
         board_kernel,
         capsules::analog_comparator::DRIVER_NUM,
     )
-    .finalize(components::acomp_component_buf!(
+    .finalize(components::analog_comparator_component_static!(
         nrf52840::acomp::Comparator
     ));
 

--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -305,8 +305,8 @@ pub unsafe fn main() {
     );
     DynamicDeferredCall::set_global_instance(dynamic_deferred_caller);
 
-    let process_printer =
-        components::process_printer::ProcessPrinterTextComponent::new().finalize(());
+    let process_printer = components::process_printer::ProcessPrinterTextComponent::new()
+        .finalize(components::process_printer_text_component_static!());
     PROCESS_PRINTER = Some(process_printer);
 
     // Create a shared UART channel for the console and for kernel debug.

--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -243,7 +243,7 @@ pub unsafe fn main() {
         nrf52840::gpio::GPIOPin
     ));
 
-    let led = components::led::LedsComponent::new().finalize(components::led_component_helper!(
+    let led = components::led::LedsComponent::new().finalize(components::led_component_static!(
         LedLow<'static, nrf52840::gpio::GPIOPin>,
         LedLow::new(&nrf52840_peripherals.gpio_port[LED1_PIN]),
         LedLow::new(&nrf52840_peripherals.gpio_port[LED2_R_PIN]),

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -572,7 +572,7 @@ pub unsafe fn main() {
         0,         // Start address of kernel region
         0x60000,   // Length of kernel region
     )
-    .finalize(components::nv_storage_component_helper!(
+    .finalize(components::nonvolatile_storage_component_static!(
         capsules::mx25r6435f::MX25R6435F<
             'static,
             capsules::virtual_spi::VirtualSpiMasterDevice<'static, nrf52840::spi::SPIM>,

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -284,8 +284,8 @@ pub unsafe fn main() {
 
     let uart_channel = if USB_DEBUGGING {
         // Initialize early so any panic beyond this point can use the RTT memory object.
-        let mut rtt_memory_refs =
-            components::segger_rtt::SeggerRttMemoryComponent::new().finalize(());
+        let mut rtt_memory_refs = components::segger_rtt::SeggerRttMemoryComponent::new()
+            .finalize(components::segger_rtt_memory_component_static!());
 
         // XXX: This is inherently unsafe as it aliases the mutable reference to rtt_memory. This
         // aliases reference is only used inside a panic handler, which should be OK, but maybe we

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -557,7 +557,7 @@ pub unsafe fn main() {
         mux_alarm,
         mux_spi,
     )
-    .finalize(components::mx25r6435f_component_helper!(
+    .finalize(components::mx25r6435f_component_static!(
         nrf52840::spi::SPIM,
         nrf52840::gpio::GPIOPin,
         nrf52840::rtc::Rtc

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -527,7 +527,7 @@ pub unsafe fn main() {
         capsules::rng::DRIVER_NUM,
         &base_peripherals.trng,
     )
-    .finalize(());
+    .finalize(components::rng_component_static!());
 
     // SPI
     let mux_spi =

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -349,7 +349,9 @@ pub unsafe fn main() {
             ) //16
         ),
     )
-    .finalize(components::button_component_buf!(nrf52840::gpio::GPIOPin));
+    .finalize(components::button_component_static!(
+        nrf52840::gpio::GPIOPin
+    ));
 
     let led = components::led::LedsComponent::new().finalize(components::led_component_helper!(
         LedLow<'static, nrf52840::gpio::GPIOPin>,

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -353,7 +353,7 @@ pub unsafe fn main() {
         nrf52840::gpio::GPIOPin
     ));
 
-    let led = components::led::LedsComponent::new().finalize(components::led_component_helper!(
+    let led = components::led::LedsComponent::new().finalize(components::led_component_static!(
         LedLow<'static, nrf52840::gpio::GPIOPin>,
         LedLow::new(&nrf52840_peripherals.gpio_port[LED1_PIN]),
         LedLow::new(&nrf52840_peripherals.gpio_port[LED2_PIN]),

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -608,16 +608,16 @@ pub unsafe fn main() {
 
     // Initialize AC using AIN5 (P0.29) as VIN+ and VIN- as AIN0 (P0.02)
     // These are hardcoded pin assignments specified in the driver
-    let analog_comparator = components::analog_comparator::AcComponent::new(
+    let analog_comparator = components::analog_comparator::AnalogComparatorComponent::new(
         &base_peripherals.acomp,
-        components::acomp_component_helper!(
+        components::analog_comparator_component_helper!(
             nrf52840::acomp::Channel,
             &nrf52840::acomp::CHANNEL_AC0
         ),
         board_kernel,
         capsules::analog_comparator::DRIVER_NUM,
     )
-    .finalize(components::acomp_component_buf!(
+    .finalize(components::analog_comparator_component_static!(
         nrf52840::acomp::Comparator
     ));
 

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -413,8 +413,8 @@ pub unsafe fn main() {
     );
     DynamicDeferredCall::set_global_instance(dynamic_deferred_caller);
 
-    let process_printer =
-        components::process_printer::ProcessPrinterTextComponent::new().finalize(());
+    let process_printer = components::process_printer::ProcessPrinterTextComponent::new()
+        .finalize(components::process_printer_text_component_static!());
     PROCESS_PRINTER = Some(process_printer);
 
     // Create a shared UART channel for the console and for kernel debug.

--- a/boards/nordic/nrf52_components/src/startup.rs
+++ b/boards/nordic/nrf52_components/src/startup.rs
@@ -189,7 +189,7 @@ impl Component for UartChannelComponent {
             UartChannel::Rtt(rtt_memory) => {
                 let rtt =
                     components::segger_rtt::SeggerRttComponent::new(self.mux_alarm, rtt_memory)
-                        .finalize(components::segger_rtt_component_helper!(nrf52::rtc::Rtc));
+                        .finalize(components::segger_rtt_component_static!(nrf52::rtc::Rtc));
                 rtt
             }
         }

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -410,7 +410,7 @@ pub unsafe fn main() {
         capsules::rng::DRIVER_NUM,
         &base_peripherals.trng,
     )
-    .finalize(());
+    .finalize(components::rng_component_static!());
 
     // Initialize AC using AIN5 (P0.29) as VIN+ and VIN- as AIN0 (P0.02)
     // These are hardcoded pin assignments specified in the driver

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -414,16 +414,16 @@ pub unsafe fn main() {
 
     // Initialize AC using AIN5 (P0.29) as VIN+ and VIN- as AIN0 (P0.02)
     // These are hardcoded pin assignments specified in the driver
-    let analog_comparator = components::analog_comparator::AcComponent::new(
+    let analog_comparator = components::analog_comparator::AnalogComparatorComponent::new(
         &base_peripherals.acomp,
-        components::acomp_component_helper!(
+        components::analog_comparator_component_helper!(
             nrf52832::acomp::Channel,
             &nrf52832::acomp::CHANNEL_AC0
         ),
         board_kernel,
         capsules::analog_comparator::DRIVER_NUM,
     )
-    .finalize(components::acomp_component_buf!(
+    .finalize(components::analog_comparator_component_static!(
         nrf52832::acomp::Comparator
     ));
 

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -298,7 +298,9 @@ pub unsafe fn main() {
             ) //16
         ),
     )
-    .finalize(components::button_component_buf!(nrf52832::gpio::GPIOPin));
+    .finalize(components::button_component_static!(
+        nrf52832::gpio::GPIOPin
+    ));
 
     let led = components::led::LedsComponent::new().finalize(components::led_component_helper!(
         LedLow<'static, nrf52832::gpio::GPIOPin>,

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -363,8 +363,8 @@ pub unsafe fn main() {
     );
     DynamicDeferredCall::set_global_instance(dynamic_deferred_caller);
 
-    let process_printer =
-        components::process_printer::ProcessPrinterTextComponent::new().finalize(());
+    let process_printer = components::process_printer::ProcessPrinterTextComponent::new()
+        .finalize(components::process_printer_text_component_static!());
     PROCESS_PRINTER = Some(process_printer);
 
     // Create a shared UART channel for the console and for kernel debug.

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -302,7 +302,7 @@ pub unsafe fn main() {
         nrf52832::gpio::GPIOPin
     ));
 
-    let led = components::led::LedsComponent::new().finalize(components::led_component_helper!(
+    let led = components::led::LedsComponent::new().finalize(components::led_component_static!(
         LedLow<'static, nrf52832::gpio::GPIOPin>,
         LedLow::new(&nrf52832_peripherals.gpio_port[LED1_PIN]),
         LedLow::new(&nrf52832_peripherals.gpio_port[LED2_PIN]),

--- a/boards/nucleo_f429zi/src/main.rs
+++ b/boards/nucleo_f429zi/src/main.rs
@@ -544,8 +544,8 @@ pub unsafe fn main() {
                 adc_channel_4,
             ));
 
-    let process_printer =
-        components::process_printer::ProcessPrinterTextComponent::new().finalize(());
+    let process_printer = components::process_printer::ProcessPrinterTextComponent::new()
+        .finalize(components::process_printer_text_component_static!());
     PROCESS_PRINTER = Some(process_printer);
 
     // RNG

--- a/boards/nucleo_f429zi/src/main.rs
+++ b/boards/nucleo_f429zi/src/main.rs
@@ -353,7 +353,7 @@ pub unsafe fn main() {
     // Clock to Port A is enabled in `set_pin_primary_functions()`
     let gpio_ports = &base_peripherals.gpio_ports;
 
-    let led = components::led::LedsComponent::new().finalize(components::led_component_helper!(
+    let led = components::led::LedsComponent::new().finalize(components::led_component_static!(
         LedHigh<'static, stm32f429zi::gpio::Pin>,
         LedHigh::new(gpio_ports.get_pin(stm32f429zi::gpio::PinId::PB00).unwrap()),
         LedHigh::new(gpio_ports.get_pin(stm32f429zi::gpio::PinId::PB07).unwrap()),

--- a/boards/nucleo_f429zi/src/main.rs
+++ b/boards/nucleo_f429zi/src/main.rs
@@ -554,7 +554,7 @@ pub unsafe fn main() {
         capsules::rng::DRIVER_NUM,
         &peripherals.trng,
     )
-    .finalize(());
+    .finalize(components::rng_component_static!());
 
     // PROCESS CONSOLE
     let process_console = components::process_console::ProcessConsoleComponent::new(

--- a/boards/nucleo_f429zi/src/main.rs
+++ b/boards/nucleo_f429zi/src/main.rs
@@ -373,7 +373,7 @@ pub unsafe fn main() {
             )
         ),
     )
-    .finalize(components::button_component_buf!(stm32f429zi::gpio::Pin));
+    .finalize(components::button_component_static!(stm32f429zi::gpio::Pin));
 
     // ALARM
 

--- a/boards/nucleo_f446re/src/main.rs
+++ b/boards/nucleo_f446re/src/main.rs
@@ -366,7 +366,7 @@ pub unsafe fn main() {
             )
         ),
     )
-    .finalize(components::button_component_buf!(stm32f446re::gpio::Pin));
+    .finalize(components::button_component_static!(stm32f446re::gpio::Pin));
 
     // ALARM
     let tim2 = &base_peripherals.tim2;

--- a/boards/nucleo_f446re/src/main.rs
+++ b/boards/nucleo_f446re/src/main.rs
@@ -348,7 +348,7 @@ pub unsafe fn main() {
     let gpio_ports = &base_peripherals.gpio_ports;
 
     // Clock to Port A is enabled in `set_pin_primary_functions()`
-    let led = components::led::LedsComponent::new().finalize(components::led_component_helper!(
+    let led = components::led::LedsComponent::new().finalize(components::led_component_static!(
         LedHigh<'static, stm32f446re::gpio::Pin>,
         LedHigh::new(gpio_ports.get_pin(stm32f446re::gpio::PinId::PA05).unwrap()),
     ));

--- a/boards/nucleo_f446re/src/main.rs
+++ b/boards/nucleo_f446re/src/main.rs
@@ -439,8 +439,8 @@ pub unsafe fn main() {
                 adc_channel_5
             ));
 
-    let process_printer =
-        components::process_printer::ProcessPrinterTextComponent::new().finalize(());
+    let process_printer = components::process_printer::ProcessPrinterTextComponent::new()
+        .finalize(components::process_printer_text_component_static!());
     PROCESS_PRINTER = Some(process_printer);
 
     // GPIO

--- a/boards/opentitan/src/main.rs
+++ b/boards/opentitan/src/main.rs
@@ -508,7 +508,7 @@ unsafe fn setup() -> (
     TICKV = Some(tickv);
 
     let mux_kv = components::kv_system::KVStoreMuxComponent::new(tickv).finalize(
-        components::kv_store_mux_component_helper!(
+        components::kv_store_mux_component_static!(
             capsules::tickv::TicKVStore<
                 capsules::virtual_flash::FlashUser<lowrisc::flash_ctrl::FlashCtrl>,
                 capsules::sip_hash::SipHasher24<'static>,
@@ -517,31 +517,23 @@ unsafe fn setup() -> (
         ),
     );
 
-    let kv_store_key_buf = static_init!(capsules::tickv::TicKVKeyType, [0; 8]);
-    let header_buf = static_init!([u8; 9], [0; 9]);
-
-    let kv_store =
-        components::kv_system::KVStoreComponent::new(mux_kv, kv_store_key_buf, header_buf)
-            .finalize(components::kv_store_component_helper!(
-                capsules::tickv::TicKVStore<
-                    capsules::virtual_flash::FlashUser<lowrisc::flash_ctrl::FlashCtrl>,
-                    capsules::sip_hash::SipHasher24<'static>,
-                >,
-                capsules::tickv::TicKVKeyType,
-            ));
+    let kv_store = components::kv_system::KVStoreComponent::new(mux_kv).finalize(
+        components::kv_store_component_static!(
+            capsules::tickv::TicKVStore<
+                capsules::virtual_flash::FlashUser<lowrisc::flash_ctrl::FlashCtrl>,
+                capsules::sip_hash::SipHasher24<'static>,
+            >,
+            capsules::tickv::TicKVKeyType,
+        ),
+    );
     tickv.set_client(kv_store);
-
-    let kv_driver_data_buf = static_init!([u8; 32], [0; 32]);
-    let kv_driver_dest_buf = static_init!([u8; 48], [0; 48]);
 
     let kv_driver = components::kv_system::KVDriverComponent::new(
         kv_store,
         board_kernel,
         capsules::kv_driver::DRIVER_NUM,
-        kv_driver_data_buf,
-        kv_driver_dest_buf,
     )
-    .finalize(components::kv_driver_component_helper!(
+    .finalize(components::kv_driver_component_static!(
         capsules::tickv::TicKVStore<
             capsules::virtual_flash::FlashUser<lowrisc::flash_ctrl::FlashCtrl>,
             capsules::sip_hash::SipHasher24<'static>,

--- a/boards/opentitan/src/main.rs
+++ b/boards/opentitan/src/main.rs
@@ -361,7 +361,7 @@ unsafe fn setup() -> (
         capsules::low_level_debug::DRIVER_NUM,
         uart_mux,
     )
-    .finalize(());
+    .finalize(components::low_level_debug_component_static!());
 
     let mux_digest = components::digest::DigestMuxComponent::new(&peripherals.hmac).finalize(
         components::digest_mux_component_helper!(lowrisc::hmac::Hmac, 32),

--- a/boards/opentitan/src/main.rs
+++ b/boards/opentitan/src/main.rs
@@ -475,7 +475,7 @@ unsafe fn setup() -> (
     );
 
     let mux_flash = components::flash::FlashMuxComponent::new(&peripherals.flash_ctrl).finalize(
-        components::flash_mux_component_helper!(lowrisc::flash_ctrl::FlashCtrl),
+        components::flash_mux_component_static!(lowrisc::flash_ctrl::FlashCtrl),
     );
 
     // SipHash

--- a/boards/opentitan/src/main.rs
+++ b/boards/opentitan/src/main.rs
@@ -448,8 +448,8 @@ unsafe fn setup() -> (
         dynamic_deferred_caller.register(&peripherals.aes).unwrap(), // Unwrap fail = dynamic deferred caller out of slots
     );
 
-    let process_printer =
-        components::process_printer::ProcessPrinterTextComponent::new().finalize(());
+    let process_printer = components::process_printer::ProcessPrinterTextComponent::new()
+        .finalize(components::process_printer_text_component_static!());
     PROCESS_PRINTER = Some(process_printer);
 
     // USB support is currently broken in the OpenTitan hardware

--- a/boards/opentitan/src/main.rs
+++ b/boards/opentitan/src/main.rs
@@ -261,7 +261,7 @@ unsafe fn setup() -> (
 
     // LEDs
     // Start with half on and half off
-    let led = components::led::LedsComponent::new().finalize(components::led_component_helper!(
+    let led = components::led::LedsComponent::new().finalize(components::led_component_static!(
         LedHigh<'static, earlgrey::gpio::GpioPin>,
         LedHigh::new(&peripherals.gpio_port[8]),
         LedHigh::new(&peripherals.gpio_port[9]),

--- a/boards/opentitan/src/main.rs
+++ b/boards/opentitan/src/main.rs
@@ -499,7 +499,7 @@ unsafe fn setup() -> (
         flash_ctrl_read_buf,                         // Buffer used internally in TicKV
         page_buffer,                                 // Buffer used with the flash controller
     )
-    .finalize(components::tickv_component_helper!(
+    .finalize(components::tickv_component_static!(
         lowrisc::flash_ctrl::FlashCtrl,
         capsules::sip_hash::SipHasher24
     ));

--- a/boards/particle_boron/src/main.rs
+++ b/boards/particle_boron/src/main.rs
@@ -387,7 +387,7 @@ pub unsafe fn main() {
         dynamic_deferred_caller,
         None,
     )
-    .finalize(components::usb_cdc_acm_component_helper!(
+    .finalize(components::cdc_acm_component_static!(
         nrf52::usbd::Usbd,
         nrf52::rtc::Rtc
     ));

--- a/boards/particle_boron/src/main.rs
+++ b/boards/particle_boron/src/main.rs
@@ -305,7 +305,9 @@ pub unsafe fn main() {
             )
         ),
     )
-    .finalize(components::button_component_buf!(nrf52840::gpio::GPIOPin));
+    .finalize(components::button_component_static!(
+        nrf52840::gpio::GPIOPin
+    ));
 
     //--------------------------------------------------------------------------
     // LEDs

--- a/boards/particle_boron/src/main.rs
+++ b/boards/particle_boron/src/main.rs
@@ -313,7 +313,7 @@ pub unsafe fn main() {
     // LEDs
     //--------------------------------------------------------------------------
 
-    let led = components::led::LedsComponent::new().finalize(components::led_component_helper!(
+    let led = components::led::LedsComponent::new().finalize(components::led_component_static!(
         LedLow<'static, nrf52840::gpio::GPIOPin>,
         LedLow::new(&nrf52840_peripherals.gpio_port[LED_USR_PIN]),
         LedLow::new(&nrf52840_peripherals.gpio_port[LED2_R_PIN]),

--- a/boards/particle_boron/src/main.rs
+++ b/boards/particle_boron/src/main.rs
@@ -475,7 +475,7 @@ pub unsafe fn main() {
         capsules::rng::DRIVER_NUM,
         &base_peripherals.trng,
     )
-    .finalize(());
+    .finalize(components::rng_component_static!());
 
     //--------------------------------------------------------------------------
     // ADC

--- a/boards/particle_boron/src/main.rs
+++ b/boards/particle_boron/src/main.rs
@@ -392,8 +392,8 @@ pub unsafe fn main() {
     CDC_REF_FOR_PANIC = Some(cdc); //for use by panic handler
 
     // Process Printer for displaying process information.
-    let process_printer =
-        components::process_printer::ProcessPrinterTextComponent::new().finalize(());
+    let process_printer = components::process_printer::ProcessPrinterTextComponent::new()
+        .finalize(components::process_printer_text_component_static!());
     PROCESS_PRINTER = Some(process_printer);
 
     // Create a shared UART channel for the console and for kernel debug.

--- a/boards/pico_explorer_base/src/main.rs
+++ b/boards/pico_explorer_base/src/main.rs
@@ -470,7 +470,7 @@ pub unsafe fn main() {
             ), // Y
         ),
     )
-    .finalize(components::button_component_buf!(RPGpioPin));
+    .finalize(components::button_component_static!(RPGpioPin));
 
     let screen = components::screen::ScreenComponent::new(
         board_kernel,

--- a/boards/pico_explorer_base/src/main.rs
+++ b/boards/pico_explorer_base/src/main.rs
@@ -371,7 +371,7 @@ pub unsafe fn main() {
     )
     .finalize(components::gpio_component_buf!(RPGpioPin<'static>));
 
-    let led = LedsComponent::new().finalize(components::led_component_helper!(
+    let led = LedsComponent::new().finalize(components::led_component_static!(
         LedHigh<'static, RPGpioPin<'static>>,
         LedHigh::new(&peripherals.pins.get_pin(RPGpio::GPIO25))
     ));

--- a/boards/pico_explorer_base/src/main.rs
+++ b/boards/pico_explorer_base/src/main.rs
@@ -496,8 +496,8 @@ pub unsafe fn main() {
                 adc_channel_1,
                 adc_channel_2,
             ));
-    let process_printer =
-        components::process_printer::ProcessPrinterTextComponent::new().finalize(());
+    let process_printer = components::process_printer::ProcessPrinterTextComponent::new()
+        .finalize(components::process_printer_text_component_static!());
     PROCESS_PRINTER = Some(process_printer);
 
     // PROCESS CONSOLE

--- a/boards/pico_explorer_base/src/main.rs
+++ b/boards/pico_explorer_base/src/main.rs
@@ -478,7 +478,7 @@ pub unsafe fn main() {
         tft,
         Some(tft),
     )
-    .finalize(components::screen_buffer_size!(57600));
+    .finalize(components::screen_component_static!(57600));
 
     let adc_channel_0 = components::adc::AdcComponent::new(&adc_mux, Channel::Channel0)
         .finalize(components::adc_component_helper!(Adc));

--- a/boards/qemu_rv32_virt/src/main.rs
+++ b/boards/qemu_rv32_virt/src/main.rs
@@ -220,8 +220,8 @@ pub unsafe fn main() {
     // ---------- FINAL SYSTEM INITIALIZATION ----------
 
     // Create the process printer used in panic prints, etc.
-    let process_printer =
-        components::process_printer::ProcessPrinterTextComponent::new().finalize(());
+    let process_printer = components::process_printer::ProcessPrinterTextComponent::new()
+        .finalize(components::process_printer_text_component_static!());
     PROCESS_PRINTER = Some(process_printer);
 
     // Setup the console.

--- a/boards/qemu_rv32_virt/src/main.rs
+++ b/boards/qemu_rv32_virt/src/main.rs
@@ -239,7 +239,7 @@ pub unsafe fn main() {
         capsules::low_level_debug::DRIVER_NUM,
         uart_mux,
     )
-    .finalize(());
+    .finalize(components::low_level_debug_component_static!());
 
     debug!("QEMU RISC-V 32-bit \"virt\" machine, initialization complete.");
     debug!("Entering main loop.");

--- a/boards/raspberry_pi_pico/src/main.rs
+++ b/boards/raspberry_pi_pico/src/main.rs
@@ -388,7 +388,7 @@ pub unsafe fn main() {
     )
     .finalize(components::gpio_component_buf!(RPGpioPin<'static>));
 
-    let led = LedsComponent::new().finalize(components::led_component_helper!(
+    let led = LedsComponent::new().finalize(components::led_component_static!(
         LedHigh<'static, RPGpioPin<'static>>,
         LedHigh::new(&peripherals.pins.get_pin(RPGpio::GPIO25))
     ));

--- a/boards/raspberry_pi_pico/src/main.rs
+++ b/boards/raspberry_pi_pico/src/main.rs
@@ -436,8 +436,8 @@ pub unsafe fn main() {
                 adc_channel_3,
             ));
     // PROCESS CONSOLE
-    let process_printer =
-        components::process_printer::ProcessPrinterTextComponent::new().finalize(());
+    let process_printer = components::process_printer::ProcessPrinterTextComponent::new()
+        .finalize(components::process_printer_text_component_static!());
     PROCESS_PRINTER = Some(process_printer);
 
     let process_console = components::process_console::ProcessConsoleComponent::new(

--- a/boards/redboard_artemis_nano/src/main.rs
+++ b/boards/redboard_artemis_nano/src/main.rs
@@ -291,7 +291,7 @@ unsafe fn setup() -> (
         capsules::humidity::DRIVER_NUM,
         bme280,
     )
-    .finalize(());
+    .finalize(components::humidity_component_static!());
     BME280 = Some(bme280);
 
     let ccs811 = Ccs811Component::new(mux_i2c, 0x5B, dynamic_deferred_caller)

--- a/boards/redboard_artemis_nano/src/main.rs
+++ b/boards/redboard_artemis_nano/src/main.rs
@@ -257,8 +257,8 @@ unsafe fn setup() -> (
     ALARM = Some(mux_alarm);
 
     // Create a process printer for panic.
-    let process_printer =
-        components::process_printer::ProcessPrinterTextComponent::new().finalize(());
+    let process_printer = components::process_printer::ProcessPrinterTextComponent::new()
+        .finalize(components::process_printer_text_component_static!());
     PROCESS_PRINTER = Some(process_printer);
 
     // Init the I2C device attached via Qwiic

--- a/boards/redboard_artemis_nano/src/main.rs
+++ b/boards/redboard_artemis_nano/src/main.rs
@@ -295,7 +295,7 @@ unsafe fn setup() -> (
     BME280 = Some(bme280);
 
     let ccs811 = Ccs811Component::new(mux_i2c, 0x5B, dynamic_deferred_caller)
-        .finalize(components::ccs811_component_helper!());
+        .finalize(components::ccs811_component_static!());
     let air_quality = components::air_quality::AirQualityComponent::new(
         board_kernel,
         capsules::temperature::DRIVER_NUM,

--- a/boards/redboard_artemis_nano/src/main.rs
+++ b/boards/redboard_artemis_nano/src/main.rs
@@ -301,7 +301,7 @@ unsafe fn setup() -> (
         capsules::temperature::DRIVER_NUM,
         ccs811,
     )
-    .finalize(());
+    .finalize(components::air_quality_component_static!());
     CCS811 = Some(ccs811);
 
     // Setup BLE

--- a/boards/redboard_artemis_nano/src/main.rs
+++ b/boards/redboard_artemis_nano/src/main.rs
@@ -221,7 +221,7 @@ unsafe fn setup() -> (
     components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
 
     // LEDs
-    let led = components::led::LedsComponent::new().finalize(components::led_component_helper!(
+    let led = components::led::LedsComponent::new().finalize(components::led_component_static!(
         LedHigh<'static, apollo3::gpio::GpioPin>,
         LedHigh::new(&peripherals.gpio_port[19]),
     ));

--- a/boards/redboard_redv/src/main.rs
+++ b/boards/redboard_redv/src/main.rs
@@ -245,7 +245,7 @@ pub unsafe fn main() {
         capsules::low_level_debug::DRIVER_NUM,
         uart_mux,
     )
-    .finalize(());
+    .finalize(components::low_level_debug_component_static!());
 
     // Need two debug!() calls to actually test with QEMU. QEMU seems to have
     // a much larger UART TX buffer (or it transmits faster).

--- a/boards/redboard_redv/src/main.rs
+++ b/boards/redboard_redv/src/main.rs
@@ -217,8 +217,8 @@ pub unsafe fn main() {
     );
     CHIP = Some(chip);
 
-    let process_printer =
-        components::process_printer::ProcessPrinterTextComponent::new().finalize(());
+    let process_printer = components::process_printer::ProcessPrinterTextComponent::new()
+        .finalize(components::process_printer_text_component_static!());
     PROCESS_PRINTER = Some(process_printer);
 
     // Need to enable all interrupts for Tock Kernel

--- a/boards/redboard_redv/src/main.rs
+++ b/boards/redboard_redv/src/main.rs
@@ -169,7 +169,7 @@ pub unsafe fn main() {
     .finalize(());
 
     // LEDs
-    let led = components::led::LedsComponent::new().finalize(components::led_component_helper!(
+    let led = components::led::LedsComponent::new().finalize(components::led_component_static!(
         LedLow<'static, sifive::gpio::GpioPin>,
         LedLow::new(&peripherals.gpio_port[5]), // Blue
     ));

--- a/boards/sma_q3/src/main.rs
+++ b/boards/sma_q3/src/main.rs
@@ -377,7 +377,7 @@ pub unsafe fn main() {
         capsules::rng::DRIVER_NUM,
         &base_peripherals.trng,
     )
-    .finalize(());
+    .finalize(components::rng_component_static!());
 
     // Initialize AC using AIN5 (P0.29) as VIN+ and VIN- as AIN0 (P0.02)
     // These are hardcoded pin assignments specified in the driver

--- a/boards/sma_q3/src/main.rs
+++ b/boards/sma_q3/src/main.rs
@@ -381,16 +381,16 @@ pub unsafe fn main() {
 
     // Initialize AC using AIN5 (P0.29) as VIN+ and VIN- as AIN0 (P0.02)
     // These are hardcoded pin assignments specified in the driver
-    let analog_comparator = components::analog_comparator::AcComponent::new(
+    let analog_comparator = components::analog_comparator::AnalogComparatorComponent::new(
         &base_peripherals.acomp,
-        components::acomp_component_helper!(
+        components::analog_comparator_component_helper!(
             nrf52840::acomp::Channel,
             &nrf52840::acomp::CHANNEL_AC0
         ),
         board_kernel,
         capsules::analog_comparator::DRIVER_NUM,
     )
-    .finalize(components::acomp_component_buf!(
+    .finalize(components::analog_comparator_component_static!(
         nrf52840::acomp::Comparator
     ));
 

--- a/boards/sma_q3/src/main.rs
+++ b/boards/sma_q3/src/main.rs
@@ -216,7 +216,7 @@ pub unsafe fn main() {
         nrf52840::gpio::GPIOPin
     ));
 
-    let led = components::led::LedsComponent::new().finalize(components::led_component_helper!(
+    let led = components::led::LedsComponent::new().finalize(components::led_component_static!(
         LedHigh<'static, nrf52840::gpio::GPIOPin>,
         LedHigh::new(&nrf52840_peripherals.gpio_port[LED1_PIN]),
         LedHigh::new(&nrf52840_peripherals.gpio_port[VIBRA1_PIN]),

--- a/boards/sma_q3/src/main.rs
+++ b/boards/sma_q3/src/main.rs
@@ -274,7 +274,8 @@ pub unsafe fn main() {
     // Initialize early so any panic beyond this point can use the RTT memory object.
     let uart_channel = {
         // RTT communication channel
-        let mut rtt_memory = components::segger_rtt::SeggerRttMemoryComponent::new().finalize(());
+        let mut rtt_memory = components::segger_rtt::SeggerRttMemoryComponent::new()
+            .finalize(components::segger_rtt_memory_component_static!());
 
         // TODO: This is inherently unsafe as it aliases the mutable reference to rtt_memory. This
         // aliases reference is only used inside a panic handler, which should be OK, but maybe we
@@ -282,7 +283,7 @@ pub unsafe fn main() {
         self::io::set_rtt_memory(&mut *rtt_memory.get_rtt_memory_ptr());
 
         components::segger_rtt::SeggerRttComponent::new(mux_alarm, rtt_memory)
-            .finalize(components::segger_rtt_component_helper!(nrf52840::rtc::Rtc))
+            .finalize(components::segger_rtt_component_static!(nrf52840::rtc::Rtc))
     };
 
     // Create a shared UART channel for the console and for kernel debug.

--- a/boards/sma_q3/src/main.rs
+++ b/boards/sma_q3/src/main.rs
@@ -267,8 +267,8 @@ pub unsafe fn main() {
     );
     DynamicDeferredCall::set_global_instance(dynamic_deferred_caller);
 
-    let process_printer =
-        components::process_printer::ProcessPrinterTextComponent::new().finalize(());
+    let process_printer = components::process_printer::ProcessPrinterTextComponent::new()
+        .finalize(components::process_printer_text_component_static!());
     PROCESS_PRINTER = Some(process_printer);
 
     // Initialize early so any panic beyond this point can use the RTT memory object.

--- a/boards/sma_q3/src/main.rs
+++ b/boards/sma_q3/src/main.rs
@@ -212,7 +212,9 @@ pub unsafe fn main() {
             )
         ),
     )
-    .finalize(components::button_component_buf!(nrf52840::gpio::GPIOPin));
+    .finalize(components::button_component_static!(
+        nrf52840::gpio::GPIOPin
+    ));
 
     let led = components::led::LedsComponent::new().finalize(components::led_component_helper!(
         LedHigh<'static, nrf52840::gpio::GPIOPin>,

--- a/boards/stm32f3discovery/src/main.rs
+++ b/boards/stm32f3discovery/src/main.rs
@@ -437,7 +437,7 @@ pub unsafe fn main() {
 
     // Clock to Port E is enabled in `set_pin_primary_functions()`
 
-    let led = components::led::LedsComponent::new().finalize(components::led_component_helper!(
+    let led = components::led::LedsComponent::new().finalize(components::led_component_static!(
         LedHigh<'static, stm32f303xc::gpio::Pin<'static>>,
         LedHigh::new(
             &peripherals

--- a/boards/stm32f3discovery/src/main.rs
+++ b/boards/stm32f3discovery/src/main.rs
@@ -505,7 +505,7 @@ pub unsafe fn main() {
             )
         ),
     )
-    .finalize(components::button_component_buf!(
+    .finalize(components::button_component_static!(
         stm32f303xc::gpio::Pin<'static>
     ));
 

--- a/boards/stm32f3discovery/src/main.rs
+++ b/boards/stm32f3discovery/src/main.rs
@@ -756,8 +756,8 @@ pub unsafe fn main() {
         stm32f303xc::flash::Flash
     ));
 
-    let process_printer =
-        components::process_printer::ProcessPrinterTextComponent::new().finalize(());
+    let process_printer = components::process_printer::ProcessPrinterTextComponent::new()
+        .finalize(components::process_printer_text_component_static!());
     PROCESS_PRINTER = Some(process_printer);
 
     // PROCESS CONSOLE

--- a/boards/stm32f3discovery/src/main.rs
+++ b/boards/stm32f3discovery/src/main.rs
@@ -752,7 +752,7 @@ pub unsafe fn main() {
         &_sstorage as *const u8 as usize,
         &_estorage as *const u8 as usize - &_sstorage as *const u8 as usize,
     )
-    .finalize(components::nv_storage_component_helper!(
+    .finalize(components::nonvolatile_storage_component_static!(
         stm32f303xc::flash::Flash
     ));
 

--- a/boards/stm32f412gdiscovery/src/main.rs
+++ b/boards/stm32f412gdiscovery/src/main.rs
@@ -668,7 +668,7 @@ pub unsafe fn main() {
         Some(ft6x06),
         Some(tft),
     )
-    .finalize(());
+    .finalize(components::touch_component_static!());
 
     touch.set_screen_rotation_offset(ScreenRotation::Rotated90);
 

--- a/boards/stm32f412gdiscovery/src/main.rs
+++ b/boards/stm32f412gdiscovery/src/main.rs
@@ -659,7 +659,7 @@ pub unsafe fn main() {
         tft,
         Some(tft),
     )
-    .finalize(components::screen_buffer_size!(57600));
+    .finalize(components::screen_component_static!(57600));
 
     let touch = components::touch::MultiTouchComponent::new(
         board_kernel,

--- a/boards/stm32f412gdiscovery/src/main.rs
+++ b/boards/stm32f412gdiscovery/src/main.rs
@@ -601,8 +601,8 @@ pub unsafe fn main() {
     .finalize(components::gpio_component_buf!(stm32f412g::gpio::Pin));
 
     // RNG
-    let rng =
-        RngComponent::new(board_kernel, capsules::rng::DRIVER_NUM, &peripherals.trng).finalize(());
+    let rng = RngComponent::new(board_kernel, capsules::rng::DRIVER_NUM, &peripherals.trng)
+        .finalize(components::rng_component_static!());
 
     // FT6206
 

--- a/boards/stm32f412gdiscovery/src/main.rs
+++ b/boards/stm32f412gdiscovery/src/main.rs
@@ -468,7 +468,7 @@ pub unsafe fn main() {
 
     // Clock to Port A is enabled in `set_pin_primary_functions()`
 
-    let led = components::led::LedsComponent::new().finalize(components::led_component_helper!(
+    let led = components::led::LedsComponent::new().finalize(components::led_component_static!(
         LedLow<'static, stm32f412g::gpio::Pin>,
         LedLow::new(
             base_peripherals

--- a/boards/stm32f412gdiscovery/src/main.rs
+++ b/boards/stm32f412gdiscovery/src/main.rs
@@ -735,8 +735,8 @@ pub unsafe fn main() {
                 adc_channel_5
             ));
 
-    let process_printer =
-        components::process_printer::ProcessPrinterTextComponent::new().finalize(());
+    let process_printer = components::process_printer::ProcessPrinterTextComponent::new()
+        .finalize(components::process_printer_text_component_static!());
     PROCESS_PRINTER = Some(process_printer);
 
     // PROCESS CONSOLE

--- a/boards/stm32f412gdiscovery/src/main.rs
+++ b/boards/stm32f412gdiscovery/src/main.rs
@@ -549,7 +549,7 @@ pub unsafe fn main() {
             )
         ),
     )
-    .finalize(components::button_component_buf!(stm32f412g::gpio::Pin));
+    .finalize(components::button_component_static!(stm32f412g::gpio::Pin));
 
     // ALARM
 

--- a/boards/stm32f429idiscovery/src/main.rs
+++ b/boards/stm32f429idiscovery/src/main.rs
@@ -359,7 +359,7 @@ pub unsafe fn main() {
     // Clock to all GPIO Ports is enabled in `set_pin_primary_functions()`
     let gpio_ports = &base_peripherals.gpio_ports;
 
-    let led = components::led::LedsComponent::new().finalize(components::led_component_helper!(
+    let led = components::led::LedsComponent::new().finalize(components::led_component_static!(
         LedHigh<'static, stm32f429zi::gpio::Pin>,
         LedHigh::new(gpio_ports.get_pin(stm32f429zi::gpio::PinId::PG13).unwrap()),
         LedHigh::new(gpio_ports.get_pin(stm32f429zi::gpio::PinId::PG14).unwrap()),

--- a/boards/stm32f429idiscovery/src/main.rs
+++ b/boards/stm32f429idiscovery/src/main.rs
@@ -380,7 +380,7 @@ pub unsafe fn main() {
             )
         ),
     )
-    .finalize(components::button_component_buf!(stm32f429zi::gpio::Pin));
+    .finalize(components::button_component_static!(stm32f429zi::gpio::Pin));
 
     // ALARM
 

--- a/boards/stm32f429idiscovery/src/main.rs
+++ b/boards/stm32f429idiscovery/src/main.rs
@@ -559,8 +559,8 @@ pub unsafe fn main() {
                 adc_channel_5
             ));
 
-    let process_printer =
-        components::process_printer::ProcessPrinterTextComponent::new().finalize(());
+    let process_printer = components::process_printer::ProcessPrinterTextComponent::new()
+        .finalize(components::process_printer_text_component_static!());
     PROCESS_PRINTER = Some(process_printer);
 
     // PROCESS CONSOLE

--- a/boards/swervolf/src/main.rs
+++ b/boards/swervolf/src/main.rs
@@ -181,8 +181,8 @@ pub unsafe fn main() {
     CHIP = Some(chip);
 
     // Create a process printer for panic.
-    let process_printer =
-        components::process_printer::ProcessPrinterTextComponent::new().finalize(());
+    let process_printer = components::process_printer::ProcessPrinterTextComponent::new()
+        .finalize(components::process_printer_text_component_static!());
     PROCESS_PRINTER = Some(process_printer);
 
     // Need to enable all interrupts for Tock Kernel

--- a/boards/teensy40/src/main.rs
+++ b/boards/teensy40/src/main.rs
@@ -276,7 +276,7 @@ pub unsafe fn main() {
     .finalize(components::console_component_helper!());
 
     // LED
-    let led = components::led::LedsComponent::new().finalize(components::led_component_helper!(
+    let led = components::led::LedsComponent::new().finalize(components::led_component_static!(
         LedHigh<imxrt1060::gpio::Pin>,
         LedHigh::new(peripherals.ports.pin(PinId::B0_03))
     ));

--- a/boards/teensy40/src/main.rs
+++ b/boards/teensy40/src/main.rs
@@ -306,8 +306,8 @@ pub unsafe fn main() {
         &memory_allocation_capability,
     );
 
-    let process_printer =
-        components::process_printer::ProcessPrinterTextComponent::new().finalize(());
+    let process_printer = components::process_printer::ProcessPrinterTextComponent::new()
+        .finalize(components::process_printer_text_component_static!());
     PROCESS_PRINTER = Some(process_printer);
 
     let scheduler = components::sched::round_robin::RoundRobinComponent::new(&PROCESSES)

--- a/boards/weact_f401ccu6/src/main.rs
+++ b/boards/weact_f401ccu6/src/main.rs
@@ -423,8 +423,8 @@ pub unsafe fn main() {
                 adc_channel_5
             ));
 
-    let process_printer =
-        components::process_printer::ProcessPrinterTextComponent::new().finalize(());
+    let process_printer = components::process_printer::ProcessPrinterTextComponent::new()
+        .finalize(components::process_printer_text_component_static!());
     PROCESS_PRINTER = Some(process_printer);
 
     // PROCESS CONSOLE

--- a/boards/weact_f401ccu6/src/main.rs
+++ b/boards/weact_f401ccu6/src/main.rs
@@ -306,7 +306,7 @@ pub unsafe fn main() {
     // Clock to Port A, B, C are enabled in `set_pin_primary_functions()`
     let gpio_ports = &base_peripherals.gpio_ports;
 
-    let led = components::led::LedsComponent::new().finalize(components::led_component_helper!(
+    let led = components::led::LedsComponent::new().finalize(components::led_component_static!(
         LedLow<'static, stm32f401cc::gpio::Pin>,
         LedLow::new(gpio_ports.get_pin(stm32f401cc::gpio::PinId::PC13).unwrap()),
     ));

--- a/boards/weact_f401ccu6/src/main.rs
+++ b/boards/weact_f401ccu6/src/main.rs
@@ -324,7 +324,7 @@ pub unsafe fn main() {
             )
         ),
     )
-    .finalize(components::button_component_buf!(stm32f401cc::gpio::Pin));
+    .finalize(components::button_component_static!(stm32f401cc::gpio::Pin));
 
     // ALARM
 

--- a/capsules/src/mx25r6435f.rs
+++ b/capsules/src/mx25r6435f.rs
@@ -59,8 +59,8 @@ use kernel::utilities::cells::OptionalCell;
 use kernel::utilities::cells::TakeCell;
 use kernel::ErrorCode;
 
-pub static mut TXBUFFER: [u8; PAGE_SIZE as usize + 4] = [0; PAGE_SIZE as usize + 4];
-pub static mut RXBUFFER: [u8; PAGE_SIZE as usize + 4] = [0; PAGE_SIZE as usize + 4];
+pub const TX_BUF_LEN: usize = PAGE_SIZE as usize + 4;
+pub const RX_BUF_LEN: usize = PAGE_SIZE as usize + 4;
 
 const SPI_SPEED: u32 = 8000000;
 const SECTOR_SIZE: u32 = 4096;

--- a/capsules/src/nonvolatile_storage_driver.rs
+++ b/capsules/src/nonvolatile_storage_driver.rs
@@ -82,7 +82,7 @@ mod rw_allow {
     pub const COUNT: u8 = 1;
 }
 
-pub static mut BUFFER: [u8; 512] = [0; 512];
+pub const BUF_LEN: usize = 512;
 
 #[derive(Clone, Copy, PartialEq)]
 pub enum NonvolatileCommand {

--- a/capsules/src/nrf51822_serialization.rs
+++ b/capsules/src/nrf51822_serialization.rs
@@ -53,8 +53,8 @@ pub struct App;
 
 // Local buffer for passing data between applications and the underlying
 // transport hardware.
-pub static mut WRITE_BUF: [u8; 600] = [0; 600];
-pub static mut READ_BUF: [u8; 600] = [0; 600];
+pub const WRITE_BUF_LEN: usize = 600;
+pub const READ_BUF_LEN: usize = 600;
 
 // We need two resources: a UART HW driver and driver state for each
 // application.


### PR DESCRIPTION
### Pull Request Overview

This pull request updates components to the new format, and includes the changes that seemed fairly straightforward (i.e. mostly just changing static_init_half -> .write() and making sure all memory is statically defined in macros.

I can treat this like a "consent agenda" and move commits to their own PR as necessary (each component change is its own commit).


### Testing Strategy

travis


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
