### PR TITLE
Add attributes to shared buffers

### DIFF
--- a/kernel/src/grant.rs
+++ b/kernel/src/grant.rs
@@ -153,10 +153,10 @@ register_bitfields!(usize,
         /// An access is defined as the a call to
         /// one of the [`GrantKernelData::get_readonly_processbuffer`] or
         /// [`GrantKernelData::get_readwrite_process_buffer`] functions.
-        ACCESSED OFFSET(core::mem::size_of::<usize>()-1) NUMBITS(1) [],
+        ACCESSED OFFSET((core::mem::size_of::<usize>()*8)-1) NUMBITS(1) [],
 
         /// Stores the length of the shared buffer
-        LEN OFFSET(0) NUMBITS(core::mem::size_of::<usize>()-1) [],
+        LEN OFFSET(0) NUMBITS((core::mem::size_of::<usize>()*8)-1) [],
     ]
 );
 

--- a/kernel/src/grant.rs
+++ b/kernel/src/grant.rs
@@ -741,7 +741,7 @@ struct SavedUpcall {
 struct SavedAllowRo {
     ptr: *const u8,
     /// ```text,ignore
-    /// Bit  size_of::<usize>-1           0
+    /// Bit  (size_of::<usize>()*8)-1     0
     ///     +-+-------------------...------+
     ///     |A|            LEN             |
     ///     +------------------------------+
@@ -767,7 +767,7 @@ impl Default for SavedAllowRo {
 struct SavedAllowRw {
     ptr: *mut u8,
     /// ```text,ignore
-    /// Bit  size_of::<usize>-1           0
+    /// Bit  (size_of::<usize>()*8)-1     0
     ///     +-+-------------------...------+
     ///     |A|            LEN             |
     ///     +------------------------------+

--- a/kernel/src/process_standard.rs
+++ b/kernel/src/process_standard.rs
@@ -22,7 +22,9 @@ use crate::process::{FaultAction, ProcessCustomGrantIdentifer, ProcessId, Proces
 use crate::process::{ProcessAddresses, ProcessSizes};
 use crate::process_policies::ProcessFaultPolicy;
 use crate::process_utilities::ProcessLoadError;
-use crate::processbuffer::{ReadOnlyProcessBuffer, ReadWriteProcessBuffer};
+use crate::processbuffer::{
+    ProcessBufferAttributes, ReadOnlyProcessBuffer, ReadWriteProcessBuffer,
+};
 use crate::storage_permissions;
 use crate::syscall::{self, Syscall, SyscallReturn, UserspaceKernelBoundary};
 use crate::upcall::UpcallId;
@@ -588,7 +590,14 @@ impl<C: Chip> Process for ProcessStandard<'_, C> {
             // We specific a zero-length buffer, so the implementation of
             // `ReadWriteProcessBuffer` will handle any safety issues.
             // Therefore, we can encapsulate the unsafe.
-            Ok(unsafe { ReadWriteProcessBuffer::new(buf_start_addr, 0, self.processid()) })
+            Ok(unsafe {
+                ReadWriteProcessBuffer::new(
+                    buf_start_addr,
+                    0,
+                    ProcessBufferAttributes::const_default(),
+                    self.processid(),
+                )
+            })
         } else if self.in_app_owned_memory(buf_start_addr, size) {
             // TODO: Check for buffer aliasing here
 
@@ -617,7 +626,14 @@ impl<C: Chip> Process for ProcessStandard<'_, C> {
             // We encapsulate the unsafe here on the condition in the TODO
             // above, as we must ensure that this `ReadWriteProcessBuffer` will
             // be the only reference to this memory.
-            Ok(unsafe { ReadWriteProcessBuffer::new(buf_start_addr, size, self.processid()) })
+            Ok(unsafe {
+                ReadWriteProcessBuffer::new(
+                    buf_start_addr,
+                    size,
+                    ProcessBufferAttributes::const_default(),
+                    self.processid(),
+                )
+            })
         } else {
             Err(ErrorCode::INVAL)
         }
@@ -654,7 +670,14 @@ impl<C: Chip> Process for ProcessStandard<'_, C> {
             // We specific a zero-length buffer, so the implementation of
             // `ReadOnlyProcessBuffer` will handle any safety issues. Therefore,
             // we can encapsulate the unsafe.
-            Ok(unsafe { ReadOnlyProcessBuffer::new(buf_start_addr, 0, self.processid()) })
+            Ok(unsafe {
+                ReadOnlyProcessBuffer::new(
+                    buf_start_addr,
+                    0,
+                    ProcessBufferAttributes::const_default(),
+                    self.processid(),
+                )
+            })
         } else if self.in_app_owned_memory(buf_start_addr, size)
             || self.in_app_flash_memory(buf_start_addr, size)
         {
@@ -688,7 +711,14 @@ impl<C: Chip> Process for ProcessStandard<'_, C> {
             // We encapsulate the unsafe here on the condition in the TODO
             // above, as we must ensure that this `ReadOnlyProcessBuffer` will
             // be the only reference to this memory.
-            Ok(unsafe { ReadOnlyProcessBuffer::new(buf_start_addr, size, self.processid()) })
+            Ok(unsafe {
+                ReadOnlyProcessBuffer::new(
+                    buf_start_addr,
+                    size,
+                    ProcessBufferAttributes::const_default(),
+                    self.processid(),
+                )
+            })
         } else {
             Err(ErrorCode::INVAL)
         }


### PR DESCRIPTION
### Pull Request Overview

This pull request adds attributes to shared process buffers. It uses part of the `len` bits to encode them. This is a different approach to the issue described in https://github.com/tock/tock/pull/3252. It solves the problem of informing capsules about buffer swaps without giving them the possibility to start actions when this happens.

The pull request defines one single attribute, the `accessed` attribute. This single bit attribute states whether the capsule has tried to access the buffer since it has been shared. When an application shares a buffer, the `accessed` attribute is cleared. Whenever the capsule retrieves the buffer using `get_readonly_processbuffer` or `get_readwrite_processbuffer`, this attribute is set. All the buffers returned by subsequent calls to these functions will have this attribute set.

#### Restrictions
The buffer attributes are saved within the `len` field in the `SavedAllowRo` and `SavedAllowRw` structures. This implies that the maximum length of a shared buffer is reduced to `2^(size_of::<usize>()-1)`. Considering that Tock runs on MCUs, this should not be an issue.

#### The issue

This is the issue that led to this pull reqeuest.

As of Tock 2.1, drivers are not in charge of handling these system calls, but the kernel performs them in the driver's name. This makes drivers unaware of what happens with an application's upcalls and buffers. While most drivers do not need this information, some drivers might want to know when a an application swaps a buffer.

Applications are not allowed to access buffers while they are shared with a driver. In most cases, when an application swaps out a buffer (either unallows it, either provides a replacement for it) it means that the application is consuming the provided data. An example of such behavior is the `touch` driver. The driver receives touch events and places them into a readwrite allowed buffer and notifies the application using an upcall. When the application needs to consume the buffer, it has to swap it out with an empty one. The `accessed` attribute provides the means to inform the driver that the application has swapped the buffer and that the driver has a new buffer in which it can place a new set of events.

Without this attribute, the application had to issue a supplementary `command` system call to inform the driver about the consumption of the buffer. This leads to a data race, as there capsule might execute in between the application's `allow` and `command`.

### Testing Strategy

This pull request was not tested yet.


### TODO or Help Wanted

As this touches core grant architecture, a lot of feedback is welcome.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
