### PR TITLE
component: update ft6x06 to new static

### DIFF
--- a/boards/components/src/ft6x06.rs
+++ b/boards/components/src/ft6x06.rs
@@ -3,67 +3,78 @@
 //! Usage
 //! -----
 //! ```rust
-//! let ft6x06 = components::ft6x06::Ft6x06Component::new()
-//!    .finalize(components::ft6x06_i2c_component_helper!(mux_i2c));
+//! let ft6x06 = components::ft6x06::Ft6x06Component::new(
+//!    i2c_mux,
+//!    0x38,
+//!    base_peripherals.gpio_ports.get_pin(stm32f412g::gpio::PinId::PG05).unwrap()
+//! )
+//!    .finalize(components::ft6x06_component_static!(mux_i2c));
 //! ```
+
 use capsules::ft6x06::Ft6x06;
-use capsules::virtual_i2c::I2CDevice;
+use capsules::ft6x06::NO_TOUCH;
+use capsules::virtual_i2c::{I2CDevice, MuxI2C};
 use core::mem::MaybeUninit;
 use kernel::component::Component;
 use kernel::hil::gpio;
-use kernel::hil::touch;
-use kernel::static_init_half;
 
 // Setup static space for the objects.
 #[macro_export]
-macro_rules! ft6x06_i2c_component_helper {
-    ($i2c_mux:expr $(,)?) => {{
-        use capsules::ft6x06::Ft6x06;
-        use capsules::ft6x06::NO_TOUCH;
-        use capsules::virtual_i2c::I2CDevice;
-        use core::mem::MaybeUninit;
-        use kernel::hil::touch::TouchEvent;
-        // Buffer to use for I2C messages
-        static mut BUFFER: [u8; 17] = [0; 17];
-        pub static mut EVENTS_BUFFER: [TouchEvent; 2] = [NO_TOUCH, NO_TOUCH];
-        let i2c = components::i2c::I2CComponent::new($i2c_mux, 0x38)
-            .finalize(components::i2c_component_helper!());
-        static mut ft6x06: MaybeUninit<Ft6x06<'static>> = MaybeUninit::uninit();
-        (&i2c, &mut ft6x06, &mut BUFFER, &mut EVENTS_BUFFER)
+macro_rules! ft6x06_component_static {
+    () => {{
+        let i2c_device = kernel::static_buf!(capsules::virtual_i2c::I2CDevice);
+        let buffer = kernel::static_buf!([u8; 17]);
+        let events_buffer = kernel::static_buf!([kernel::hil::touch::TouchEvent; 2]);
+        let ft6x06 = kernel::static_buf!(capsules::ft6x06::Ft6x06<'static>);
+
+        (i2c_device, ft6x06, buffer, events_buffer)
     };};
 }
 
 pub struct Ft6x06Component {
+    i2c_mux: &'static MuxI2C<'static>,
+    i2c_address: u8,
     interrupt_pin: &'static dyn gpio::InterruptPin<'static>,
 }
 
 impl Ft6x06Component {
-    pub fn new(pin: &'static dyn gpio::InterruptPin) -> Ft6x06Component {
-        Ft6x06Component { interrupt_pin: pin }
+    pub fn new(
+        i2c_mux: &'static MuxI2C<'static>,
+        i2c_address: u8,
+        pin: &'static dyn gpio::InterruptPin,
+    ) -> Ft6x06Component {
+        Ft6x06Component {
+            i2c_mux,
+            i2c_address,
+            interrupt_pin: pin,
+        }
     }
 }
 
 impl Component for Ft6x06Component {
     type StaticInput = (
-        &'static I2CDevice<'static>,
+        &'static mut MaybeUninit<I2CDevice<'static>>,
         &'static mut MaybeUninit<Ft6x06<'static>>,
-        &'static mut [u8],
-        &'static mut [touch::TouchEvent; 2],
+        &'static mut MaybeUninit<[u8; 17]>,
+        &'static mut MaybeUninit<[kernel::hil::touch::TouchEvent; 2]>,
     );
     type Output = &'static Ft6x06<'static>;
 
     unsafe fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
-        let ft6x06 = static_init_half!(
-            static_buffer.1,
-            Ft6x06<'static>,
-            Ft6x06::new(
-                static_buffer.0,
-                self.interrupt_pin,
-                static_buffer.2,
-                static_buffer.3,
-            )
-        );
-        static_buffer.0.set_client(ft6x06);
+        let ft6x06_i2c = static_buffer
+            .0
+            .write(I2CDevice::new(self.i2c_mux, self.i2c_address));
+
+        let buffer = static_buffer.2.write([0; 17]);
+        let events_buffer = static_buffer.3.write([NO_TOUCH, NO_TOUCH]);
+
+        let ft6x06 = static_buffer.1.write(Ft6x06::new(
+            ft6x06_i2c,
+            self.interrupt_pin,
+            buffer,
+            events_buffer,
+        ));
+        ft6x06_i2c.set_client(ft6x06);
         self.interrupt_pin.set_client(ft6x06);
 
         ft6x06

--- a/boards/stm32f412gdiscovery/src/main.rs
+++ b/boards/stm32f412gdiscovery/src/main.rs
@@ -614,12 +614,14 @@ pub unsafe fn main() {
     .finalize(components::i2c_mux_component_helper!());
 
     let ft6x06 = components::ft6x06::Ft6x06Component::new(
+        mux_i2c,
+        0x38,
         base_peripherals
             .gpio_ports
             .get_pin(stm32f412g::gpio::PinId::PG05)
             .unwrap(),
     )
-    .finalize(components::ft6x06_i2c_component_helper!(mux_i2c));
+    .finalize(components::ft6x06_component_static!());
 
     let bus = components::bus::Bus8080BusComponent::new().finalize(
         components::bus8080_bus_component_helper!(


### PR DESCRIPTION
### Pull Request Overview

This pull request updates the ft6x06 component.

Some elements were passed to the macro, this moves them to the `new()` function.


### Testing Strategy

travis


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
