### PR TITLE
ci: add component label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -36,3 +36,6 @@ kernel:
 # add documentation label only if all changes are in doc/
 documentation:
   - all: ['doc/**/*']
+
+component:
+  - boards/components/**/*


### PR DESCRIPTION
### Pull Request Overview

This pull request adds the `component` label to the automatic labeler.

This label will help with checking new components or changes to components to ensure they do not declare static buffers in the finalize() function.


### Testing Strategy

Haven't


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
