### PR TITLE
cargo: workspace: use package table

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,11 @@ exclude = [
     "tools/usb/control-test",
 ]
 
+[workspace.package]
+version = "0.1.0"
+authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+edition = "2021"
+
 [profile.dev]
 panic = "abort"
 lto = false

--- a/arch/cortex-m/Cargo.toml
+++ b/arch/cortex-m/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "cortexm"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
 kernel = { path = "../../kernel" }

--- a/arch/cortex-m0/Cargo.toml
+++ b/arch/cortex-m0/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "cortexm0"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
 kernel = { path = "../../kernel" }

--- a/arch/cortex-m0p/Cargo.toml
+++ b/arch/cortex-m0p/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "cortexm0p"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
 kernel = { path = "../../kernel" }

--- a/arch/cortex-m3/Cargo.toml
+++ b/arch/cortex-m3/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "cortexm3"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
 kernel = { path = "../../kernel" }

--- a/arch/cortex-m4/Cargo.toml
+++ b/arch/cortex-m4/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "cortexm4"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
 kernel = { path = "../../kernel" }

--- a/arch/cortex-m7/Cargo.toml
+++ b/arch/cortex-m7/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "cortexm7"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
 kernel = { path = "../../kernel" }

--- a/arch/riscv/Cargo.toml
+++ b/arch/riscv/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "riscv"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
 kernel = { path = "../../kernel" }

--- a/arch/rv32i/Cargo.toml
+++ b/arch/rv32i/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "rv32i"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
 kernel = { path = "../../kernel" }

--- a/boards/acd52832/Cargo.toml
+++ b/boards/acd52832/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "acd52832"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+version.workspace = true
+authors.workspace = true
 build = "build.rs"
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 components = { path = "../components" }

--- a/boards/apollo3/lora_things_plus/Cargo.toml
+++ b/boards/apollo3/lora_things_plus/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "lora_things_plus"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 build = "build.rs"
-edition = "2021"
+
 
 [dependencies]
 components = { path = "../../components" }

--- a/boards/apollo3/redboard_artemis_nano/Cargo.toml
+++ b/boards/apollo3/redboard_artemis_nano/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "redboard_artemis_nano"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 build = "build.rs"
-edition = "2021"
 
 [dependencies]
 components = { path = "../../components" }

--- a/boards/arty_e21/Cargo.toml
+++ b/boards/arty_e21/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "arty_e21"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+version.workspace = true
+authors.workspace = true
 build = "build.rs"
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 components = { path = "../components" }

--- a/boards/clue_nrf52840/Cargo.toml
+++ b/boards/clue_nrf52840/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "clue_nrf52840"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+version.workspace = true
+authors.workspace = true
 build = "build.rs"
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 cortexm4 = { path = "../../arch/cortex-m4" }

--- a/boards/components/Cargo.toml
+++ b/boards/components/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "components"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
 capsules = { path = "../../capsules" }

--- a/boards/esp32-c3-devkitM-1/Cargo.toml
+++ b/boards/esp32-c3-devkitM-1/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "esp32-c3-board"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+version.workspace = true
+authors.workspace = true
 build = "build.rs"
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 components = { path = "../components" }

--- a/boards/hail/Cargo.toml
+++ b/boards/hail/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "hail"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+version.workspace = true
+authors.workspace = true
 build = "build.rs"
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 components = { path = "../components" }

--- a/boards/hifive1/Cargo.toml
+++ b/boards/hifive1/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "hifive1"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+version.workspace = true
+authors.workspace = true
 build = "build.rs"
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 components = { path = "../components" }

--- a/boards/hifive_inventor/Cargo.toml
+++ b/boards/hifive_inventor/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "hifive_inventor"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+version.workspace = true
+authors.workspace = true
 build = "build.rs"
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 components = { path = "../components" }

--- a/boards/imix/Cargo.toml
+++ b/boards/imix/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "imix"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+version.workspace = true
+authors.workspace = true
 build = "build.rs"
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 components = { path = "../components" }

--- a/boards/imxrt1050-evkb/Cargo.toml
+++ b/boards/imxrt1050-evkb/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "imxrt1050-evkb"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+version.workspace = true
+authors.workspace = true
 build = "build.rs"
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 components = { path = "../components" }

--- a/boards/litex/arty/Cargo.toml
+++ b/boards/litex/arty/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "litex_arty"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+version.workspace = true
+authors.workspace = true
 build = "build.rs"
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 components = { path = "../../components" }

--- a/boards/litex/sim/Cargo.toml
+++ b/boards/litex/sim/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "litex_sim"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+version.workspace = true
+authors.workspace = true
 build = "build.rs"
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 components = { path = "../../components" }

--- a/boards/microbit_v2/Cargo.toml
+++ b/boards/microbit_v2/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "microbit_v2"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+version.workspace = true
+authors.workspace = true
 build = "build.rs"
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 cortexm4 = { path = "../../arch/cortex-m4" }

--- a/boards/msp_exp432p401r/Cargo.toml
+++ b/boards/msp_exp432p401r/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "msp-exp432p401r"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+version.workspace = true
+authors.workspace = true
 build = "build.rs"
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 components = { path = "../components" }

--- a/boards/nano33ble/Cargo.toml
+++ b/boards/nano33ble/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "nano33ble"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+version.workspace = true
+authors.workspace = true
 build = "build.rs"
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 cortexm4 = { path = "../../arch/cortex-m4" }

--- a/boards/nano_rp2040_connect/Cargo.toml
+++ b/boards/nano_rp2040_connect/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "nano_rp2040_connect"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+version.workspace = true
+authors.workspace = true
 build = "build.rs"
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 cortexm0p = { path = "../../arch/cortex-m0p" }

--- a/boards/nordic/nrf52840_dongle/Cargo.toml
+++ b/boards/nordic/nrf52840_dongle/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "nrf52840_dongle"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+version.workspace = true
+authors.workspace = true
 build = "build.rs"
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 components = { path = "../../components" }

--- a/boards/nordic/nrf52840dk/Cargo.toml
+++ b/boards/nordic/nrf52840dk/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "nrf52840dk"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+version.workspace = true
+authors.workspace = true
 build = "build.rs"
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 components = { path = "../../components" }

--- a/boards/nordic/nrf52_components/Cargo.toml
+++ b/boards/nordic/nrf52_components/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "nrf52_components"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
 components = { path = "../../components" }

--- a/boards/nordic/nrf52dk/Cargo.toml
+++ b/boards/nordic/nrf52dk/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "nrf52dk"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+version.workspace = true
+authors.workspace = true
 build = "build.rs"
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 components = { path = "../../components" }

--- a/boards/nucleo_f429zi/Cargo.toml
+++ b/boards/nucleo_f429zi/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "nucleo_f429zi"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+version.workspace = true
+authors.workspace = true
 build = "build.rs"
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 components = { path = "../components" }

--- a/boards/nucleo_f446re/Cargo.toml
+++ b/boards/nucleo_f446re/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "nucleo_f446re"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+version.workspace = true
+authors.workspace = true
 build = "build.rs"
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 components = { path = "../components" }

--- a/boards/opentitan/earlgrey-cw310/Cargo.toml
+++ b/boards/opentitan/earlgrey-cw310/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "earlgrey-cw310"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+version.workspace = true
+authors.workspace = true
 build = "build.rs"
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 components = { path = "../../components" }

--- a/boards/particle_boron/Cargo.toml
+++ b/boards/particle_boron/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "particle_boron"
-version = "0.1.0"
+version.workspace = true
 authors = [
     "Tock Project Developers <tock-dev@googlegroups.com>",
     "Wilfred Mallawa <vindulawilfred@gmail.com>"
     ]
 build = "build.rs"
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 components = { path = "../components" }

--- a/boards/pico_explorer_base/Cargo.toml
+++ b/boards/pico_explorer_base/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "pico_explorer_base"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+version.workspace = true
+authors.workspace = true
 build = "build.rs"
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 cortexm0p = { path = "../../arch/cortex-m0p" }

--- a/boards/qemu_rv32_virt/Cargo.toml
+++ b/boards/qemu_rv32_virt/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "qemu_rv32_virt"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+version.workspace = true
+authors.workspace = true
 build = "build.rs"
 edition = "2018"
 

--- a/boards/raspberry_pi_pico/Cargo.toml
+++ b/boards/raspberry_pi_pico/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "raspberry_pi_pico"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+version.workspace = true
+authors.workspace = true
 build = "build.rs"
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 cortexm0p = { path = "../../arch/cortex-m0p" }

--- a/boards/redboard_redv/Cargo.toml
+++ b/boards/redboard_redv/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "redboard_redv"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+version.workspace = true
+authors.workspace = true
 build = "build.rs"
 edition = "2018"
 

--- a/boards/sma_q3/Cargo.toml
+++ b/boards/sma_q3/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "sma_q3"
-version = "0.1.0"
+version.workspace = true
 authors = [
     "Tock Project Developers <tock-dev@googlegroups.com>",
     "Dorota <gihu.dcz@porcupinefactory.org>"
 ]
 build = "build.rs"
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 components = { path = "../components" }

--- a/boards/stm32f3discovery/Cargo.toml
+++ b/boards/stm32f3discovery/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "stm32f3discovery"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+version.workspace = true
+authors.workspace = true
 build = "build.rs"
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 components = { path = "../components" }

--- a/boards/stm32f412gdiscovery/Cargo.toml
+++ b/boards/stm32f412gdiscovery/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "stm32f412gdiscovery"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+version.workspace = true
+authors.workspace = true
 build = "build.rs"
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 components = { path = "../components" }

--- a/boards/stm32f429idiscovery/Cargo.toml
+++ b/boards/stm32f429idiscovery/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stm32f429idiscovery"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+version.workspace = true
+authors.workspace = true
 build = "build.rs"
 edition = "2018"
 

--- a/boards/swervolf/Cargo.toml
+++ b/boards/swervolf/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "swervolf"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+version.workspace = true
+authors.workspace = true
 build = "build.rs"
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 components = { path = "../components" }

--- a/boards/teensy40/Cargo.toml
+++ b/boards/teensy40/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "teensy40"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+version.workspace = true
+authors.workspace = true
 build = "build.rs"
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 components = { path = "../components" }

--- a/boards/weact_f401ccu6/Cargo.toml
+++ b/boards/weact_f401ccu6/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "weact-f401ccu6"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+version.workspace = true
+authors.workspace = true
 build = "build.rs"
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 components = { path = "../components" }

--- a/capsules/Cargo.toml
+++ b/capsules/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "capsules"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
 kernel = { path = "../kernel" }

--- a/chips/apollo3/Cargo.toml
+++ b/chips/apollo3/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "apollo3"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
 cortexm4 = { path = "../../arch/cortex-m4" }

--- a/chips/arty_e21_chip/Cargo.toml
+++ b/chips/arty_e21_chip/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "arty_e21_chip"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
 sifive = { path = "../sifive" }

--- a/chips/e310_g002/Cargo.toml
+++ b/chips/e310_g002/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "e310_g002"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
 sifive = { path = "../sifive" }

--- a/chips/e310_g003/Cargo.toml
+++ b/chips/e310_g003/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "e310_g003"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
 sifive = { path = "../sifive" }

--- a/chips/e310x/Cargo.toml
+++ b/chips/e310x/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "e310x"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
 sifive = { path = "../sifive" }

--- a/chips/earlgrey/Cargo.toml
+++ b/chips/earlgrey/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "earlgrey"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [features]
 # Compiling this crate requires enabling one of these features, otherwise

--- a/chips/esp32-c3/Cargo.toml
+++ b/chips/esp32-c3/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "esp32-c3"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
 esp32 = { path = "../esp32" }

--- a/chips/esp32/Cargo.toml
+++ b/chips/esp32/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "esp32"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
 kernel = { path = "../../kernel" }

--- a/chips/imxrt10xx/Cargo.toml
+++ b/chips/imxrt10xx/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "imxrt10xx"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
 cortexm7 = { path = "../../arch/cortex-m7" }

--- a/chips/litex/Cargo.toml
+++ b/chips/litex/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "litex"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
 tock-registers = { path = "../../libraries/tock-register-interface" }

--- a/chips/litex_vexriscv/Cargo.toml
+++ b/chips/litex_vexriscv/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "litex_vexriscv"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
 rv32i = { path = "../../arch/rv32i" }

--- a/chips/lowrisc/Cargo.toml
+++ b/chips/lowrisc/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "lowrisc"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
 rv32i = { path = "../../arch/rv32i" }

--- a/chips/msp432/Cargo.toml
+++ b/chips/msp432/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "msp432"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
 cortexm4 = { path = "../../arch/cortex-m4" }

--- a/chips/nrf52/Cargo.toml
+++ b/chips/nrf52/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "nrf52"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
 cortexm4 = { path = "../../arch/cortex-m4" }

--- a/chips/nrf52832/Cargo.toml
+++ b/chips/nrf52832/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "nrf52832"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
 cortexm4 = { path = "../../arch/cortex-m4" }

--- a/chips/nrf52833/Cargo.toml
+++ b/chips/nrf52833/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "nrf52833"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
 cortexm4 = { path = "../../arch/cortex-m4" }

--- a/chips/nrf52840/Cargo.toml
+++ b/chips/nrf52840/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "nrf52840"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
 cortexm4 = { path = "../../arch/cortex-m4" }

--- a/chips/nrf5x/Cargo.toml
+++ b/chips/nrf5x/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "nrf5x"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
 kernel = { path = "../../kernel" }

--- a/chips/qemu_rv32_virt_chip/Cargo.toml
+++ b/chips/qemu_rv32_virt_chip/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "qemu_rv32_virt_chip"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+version.workspace = true
+authors.workspace = true
 edition = "2018"
 
 [dependencies]

--- a/chips/rp2040/Cargo.toml
+++ b/chips/rp2040/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "rp2040"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
 cortexm0p = { path="../../arch/cortex-m0p" }

--- a/chips/sam4l/Cargo.toml
+++ b/chips/sam4l/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "sam4l"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
 cortexm4 = { path = "../../arch/cortex-m4" }

--- a/chips/sifive/Cargo.toml
+++ b/chips/sifive/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "sifive"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
 rv32i = { path = "../../arch/rv32i" }

--- a/chips/stm32f303xc/Cargo.toml
+++ b/chips/stm32f303xc/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "stm32f303xc"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
 cortexm4 = { path = "../../arch/cortex-m4" }

--- a/chips/stm32f401cc/Cargo.toml
+++ b/chips/stm32f401cc/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "stm32f401cc"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
 cortexm4 = { path = "../../arch/cortex-m4" }

--- a/chips/stm32f412g/Cargo.toml
+++ b/chips/stm32f412g/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "stm32f412g"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
 cortexm4 = { path = "../../arch/cortex-m4" }

--- a/chips/stm32f429zi/Cargo.toml
+++ b/chips/stm32f429zi/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "stm32f429zi"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
 cortexm4 = { path = "../../arch/cortex-m4" }

--- a/chips/stm32f446re/Cargo.toml
+++ b/chips/stm32f446re/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "stm32f446re"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
 cortexm4 = { path = "../../arch/cortex-m4" }

--- a/chips/stm32f4xx/Cargo.toml
+++ b/chips/stm32f4xx/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "stm32f4xx"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
 cortexm4 = { path = "../../arch/cortex-m4" }

--- a/chips/swerv/Cargo.toml
+++ b/chips/swerv/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "swerv"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
 tock-registers = { path = "../../libraries/tock-register-interface" }

--- a/chips/swervolf-eh1/Cargo.toml
+++ b/chips/swervolf-eh1/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "swervolf-eh1"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
 swerv = { path = "../swerv" }

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "kernel"
-version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
 tock-registers = { path = "../libraries/tock-register-interface" }


### PR DESCRIPTION


### Pull Request Overview
Use the package table feature from cargo to make it easier to update editions and versions for all of our crates.

https://doc.rust-lang.org/cargo/reference/workspaces.html#the-package-table

I skipped the libraries directory as we probably want to keep those standalone.


### Testing Strategy

travis


### TODO or Help Wanted

This is blocked on updating the rust nightly.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
