### PR TITLE
remove ADC `HighSpeedClient` trait

### DIFF
--- a/boards/imix/src/imix_components/adc.rs
+++ b/boards/imix/src/imix_components/adc.rs
@@ -19,6 +19,7 @@ use capsules::adc;
 use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
+use kernel::hil::adc::Adc;
 use kernel::static_init;
 use sam4l::adc::Channel;
 

--- a/capsules/src/adc.rs
+++ b/capsules/src/adc.rs
@@ -767,10 +767,8 @@ impl<A: hil::adc::Adc + hil::adc::AdcHighSpeed> hil::adc::Client for AdcDedicate
             let _ = self.adc.stop_sampling();
         }
     }
-}
 
-/// Callbacks from the High Speed ADC driver
-impl<A: hil::adc::Adc + hil::adc::AdcHighSpeed> hil::adc::HighSpeedClient for AdcDedicated<'_, A> {
+    /// Callback from the High Speed ADC driver
     /// Internal buffer has filled from a buffered sampling operation.
     /// Copies data over to application buffer, determines if more data is
     /// needed, and performs a callback to the application if ready. If
@@ -1299,4 +1297,7 @@ impl<'a> hil::adc::Client for AdcVirtualized<'a> {
             });
         });
     }
+
+    // AdcVirtualized does not support high speed sampling, so this callback will not be called
+    fn samples_ready(&self, _buf: &'static mut [u16], _length: usize) {}
 }

--- a/capsules/src/adc_microphone.rs
+++ b/capsules/src/adc_microphone.rs
@@ -104,4 +104,7 @@ impl<'a, P: gpio::Pin> adc::Client for AdcMicrophone<'a, P> {
             }
         }
     }
+
+    // This component does not currently support high speed ADC sampling
+    fn samples_ready(&self, _buf: &'static mut [u16], _length: usize) {}
 }

--- a/capsules/src/analog_sensor.rs
+++ b/capsules/src/analog_sensor.rs
@@ -49,6 +49,9 @@ impl<A: hil::adc::Adc> hil::adc::Client for AnalogLightSensor<'_, A> {
         };
         self.client.map(|client| client.callback(measurement));
     }
+
+    // This component does not currently support high speed ADC sampling
+    fn samples_ready(&self, _buf: &'static mut [u16], _length: usize) {}
 }
 
 impl<'a, A: hil::adc::Adc> hil::sensors::AmbientLight<'a> for AnalogLightSensor<'a, A> {
@@ -108,6 +111,9 @@ impl<A: hil::adc::Adc> hil::adc::Client for AnalogTemperatureSensor<'_, A> {
         };
         self.client.map(|client| client.callback(measurement));
     }
+
+    // This component does not currently support high speed ADC sampling
+    fn samples_ready(&self, _buf: &'static mut [u16], _length: usize) {}
 }
 
 impl<'a, A: hil::adc::Adc> hil::sensors::TemperatureDriver<'a> for AnalogTemperatureSensor<'a, A> {

--- a/capsules/src/temperature_rp2040.rs
+++ b/capsules/src/temperature_rp2040.rs
@@ -46,6 +46,9 @@ impl<'a> adc::Client for TemperatureRp2040<'a> {
                 * 100.0) as i32));
         });
     }
+
+    // This component does not currently support high speed ADC sampling
+    fn samples_ready(&self, _buf: &'static mut [u16], _length: usize) {}
 }
 
 impl<'a> sensors::TemperatureDriver<'a> for TemperatureRp2040<'a> {

--- a/capsules/src/temperature_stm.rs
+++ b/capsules/src/temperature_stm.rs
@@ -47,6 +47,9 @@ impl<'a> adc::Client for TemperatureSTM<'a> {
             ));
         });
     }
+
+    // This component does not currently support high speed ADC sampling
+    fn samples_ready(&self, _buf: &'static mut [u16], _length: usize) {}
 }
 
 impl<'a> sensors::TemperatureDriver<'a> for TemperatureSTM<'a> {

--- a/capsules/src/virtual_adc.rs
+++ b/capsules/src/virtual_adc.rs
@@ -29,6 +29,9 @@ impl<'a, A: hil::adc::Adc> hil::adc::Client for MuxAdc<'a, A> {
         });
         self.do_next_op();
     }
+
+    // This component does not currently support high speed ADC sampling
+    fn samples_ready(&self, _buf: &'static mut [u16], _length: usize) {}
 }
 
 impl<'a, A: hil::adc::Adc> MuxAdc<'a, A> {

--- a/chips/stm32f303xc/src/adc.rs
+++ b/chips/stm32f303xc/src/adc.rs
@@ -3,15 +3,13 @@
 use crate::rcc;
 use core::cell::Cell;
 use kernel::hil;
+use kernel::hil::adc::Client;
 use kernel::platform::chip::ClockInterface;
 use kernel::utilities::cells::OptionalCell;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable};
 use kernel::utilities::registers::{register_bitfields, ReadOnly, ReadWrite};
 use kernel::utilities::StaticRef;
 use kernel::ErrorCode;
-
-pub trait EverythingClient: hil::adc::Client + hil::adc::HighSpeedClient {}
-impl<C: hil::adc::Client + hil::adc::HighSpeedClient> EverythingClient for C {}
 
 #[repr(C)]
 struct AdcRegisters {

--- a/chips/stm32f4xx/src/adc.rs
+++ b/chips/stm32f4xx/src/adc.rs
@@ -1,15 +1,13 @@
 use crate::rcc;
 use core::cell::Cell;
 use kernel::hil;
+use kernel::hil::adc::Client;
 use kernel::platform::chip::ClockInterface;
 use kernel::utilities::cells::OptionalCell;
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable};
 use kernel::utilities::registers::{register_bitfields, ReadOnly, ReadWrite};
 use kernel::utilities::StaticRef;
 use kernel::ErrorCode;
-
-pub trait EverythingClient: hil::adc::Client + hil::adc::HighSpeedClient {}
-impl<C: hil::adc::Client + hil::adc::HighSpeedClient> EverythingClient for C {}
 
 #[repr(C)]
 struct AdcRegisters {

--- a/kernel/src/hil/adc.rs
+++ b/kernel/src/hil/adc.rs
@@ -41,10 +41,19 @@ pub trait Adc {
     fn set_client(&self, client: &'static dyn Client);
 }
 
-/// Trait for handling callbacks from simple ADC calls.
+/// Trait for handling callbacks from ADC calls.
 pub trait Client {
     /// Called when a sample is ready.
     fn sample_ready(&self, sample: u16);
+
+    /// Called when a buffer is full as part of a high speed ADC read.
+    /// The length provided will always be less than or equal to the length of
+    /// the buffer. Expects an additional call to either provide another buffer
+    /// or stop sampling.
+    /// This callback will only ever be called in response to a high speed
+    /// ADC sample request, so clients that only need simple ADC sampling
+    /// can leave this callback empty.
+    fn samples_ready(&self, buf: &'static mut [u16], length: usize);
 }
 
 // *** Interfaces for high-speed, buffered ADC sampling ***
@@ -97,15 +106,6 @@ pub trait AdcHighSpeed: Adc {
     fn retrieve_buffers(
         &self,
     ) -> Result<(Option<&'static mut [u16]>, Option<&'static mut [u16]>), ErrorCode>;
-}
-
-/// Trait for handling callbacks from high-speed ADC calls.
-pub trait HighSpeedClient {
-    /// Called when a buffer is full.
-    /// The length provided will always be less than or equal to the length of
-    /// the buffer. Expects an additional call to either provide another buffer
-    /// or stop sampling
-    fn samples_ready(&self, buf: &'static mut [u16], length: usize);
 }
 
 pub trait AdcChannel {


### PR DESCRIPTION
### Pull Request Overview

This pull request removes the ADC `HighSpeedClient` trait and moves the callback it contained into the basic adc `Client` trait. The reasoning behind this is that having two separate Client traits is not compatible with the use of generic components. 

Today, all chips which support high speed sampling do so by creating an "EverythingClient" trait which is a supertrait of `Client`+`HighSpeedClient`. Each chip ADC then creates a normal, non-trait method `set_client(client: &'static dyn EverythingClient){...}`. However, there is no way for a component to know that such a method will exist if it is not part of any ADC trait. Currently, there is only a component for `AdcVirtualized`, which does not support high speed sampling. Creating a component for `AdcDedicated`, which does support high speed sampling, is impossible without this PR. Attempting to create one without this PR (as @bradjc did in https://github.com/tock/tock/pull/3231/commits/744ed25fdce58a07863c5385fbba5d8cf3c14125) would lead you into a very very subtle bug, where previously working code would not work once copied into the component, because within the component `adc_peripheral.set_client(client)` resolves to the `set_client()` method on the Adc trait, instead of the `set_client()` that accepts an `EverythingClient`. 

With this change, implementations that do not support high speed sampling should simply leave this callback unimplemented.


### Testing Strategy

This pull request has not been tested.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated TRD102

### Formatting

- [x] Ran `make prepush`.
