### PR TITLE
boards/opentitan: App loading for Verilator

### DIFF
--- a/boards/opentitan/README.md
+++ b/boards/opentitan/README.md
@@ -215,6 +215,14 @@ $ make flash-app APP=<...> OPENTITAN_TREE=/home/opentitan/
 You will need to have the GCC version of [RISC-V 32-bit objcopy](https://github.com/riscv-collab/riscv-gnu-toolchain/blob/master/README.md) installed as
 the LLVM one doesn't support updating sections.
 
+### Programming Apps in Verilator
+
+An app can be bundled and loaded with the kernel into Verilator with:
+
+```shell
+$ APP=<...> make BOARD_CONFIGURATION=sim_verilator verilator
+```
+
 Running in QEMU
 ---------------
 
@@ -310,7 +318,7 @@ The Tock OpenTitan boards include automated unit tests to test the kernel.
 To run the unit tests on QEMU, just run:
 
 ```shell
-make test
+$ make test
 ```
 
 in the specific board directory.
@@ -318,8 +326,16 @@ in the specific board directory.
 To run the test on hardware use these commands to build the OTBN binary and run it on hardware:
 
 ```shell
-elf2tab --verbose -n "otbn-rsa" --kernel-minor 0 --kernel-major 2 --app-heap 0 --kernel-heap 0 --stack 0 ${OPENTITAN_TREE}/build-out/sw/otbn/rsa.elf
-OPENTITAN_TREE=<...> APP=${OPENTITAN_TREE}/build-out/sw/otbn/rsa.tbf make test-hardware
+$ elf2tab --verbose -n "otbn-rsa" --kernel-minor 0 --kernel-major 2 --app-heap 0 --kernel-heap 0 --stack 0 ${OPENTITAN_TREE}/build-out/sw/otbn/rsa.elf
+
+$ OPENTITAN_TREE=<...> APP=${OPENTITAN_TREE}/build-out/sw/otbn/rsa.tbf make test-hardware
+```
+### For Verilator
+To load the OTBN binary and run it on Verilator, use:
+```shell
+$ elf2tab --verbose -n "otbn-rsa" --kernel-minor 0 --kernel-major 2 --app-heap 0 --kernel-heap 0 --stack 0 ${OPENTITAN_TREE}/build-out/sw/otbn/rsa.elf
+
+$ APP=${OPENTITAN_TREE}/bazel-out/k8-fastbuild-ST-2cc462681f62/bin/sw/otbn/crypto/rsa.tbf make BOARD_CONFIGURATION=sim_verilator test-verilator
 ```
 
 The output on a CW310 should look something like this:
@@ -381,7 +397,7 @@ trivial assertion...
 The tests can also be run on Verilator with:
 
 ```shell
-make BOARD_CONFIGURATION=sim_verilator test-verilator
+$ make BOARD_CONFIGURATION=sim_verilator test-verilator
 ```
 
 Note that the Verilator tests can take hours to complete.

--- a/boards/opentitan/earlgrey-cw310/Makefile
+++ b/boards/opentitan/earlgrey-cw310/Makefile
@@ -4,7 +4,7 @@ DEFAULT_BOARD_CONFIGURATION=fpga_cw310
 TARGET=riscv32imc-unknown-none-elf
 PLATFORM=earlgrey-cw310
 FLASHID=--dev-id="0403:6010"
-RISC_PREFIX ?= riscv64-elf
+RISC_PREFIX ?= riscv64-linux-gnu
 QEMU ?= ../../../tools/qemu/build/qemu-system-riscv32
 
 
@@ -42,16 +42,24 @@ flash-app: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
 	$(RISC_PREFIX)-objcopy --output-target=binary $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.elf $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.bin
 	$(OPENTITAN_TREE)/util/fpga/cw310_loader.py --firmware $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)-app.bin
 
-verilator: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin
+verilator: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
 	$(call check_defined, OPENTITAN_TREE)
-	srec_cat $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin \
+#	Make a copy so we dont modify the original elf when linkng apps
+	$(RISC_PREFIX)-objcopy $^ $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)_verilator.elf
+ifneq ($(APP),)
+		$(info [CW-130: Verilator]: Linking App)
+		$(RISC_PREFIX)-objcopy --update-section .apps=$(APP) $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)_verilator.elf $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)_verilator.elf
+endif
+	$(info [CW-130: Verilator]: Starting)
+	$(RISC_PREFIX)-objcopy --output-target=binary $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)_verilator.elf $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)_verilator.bin
+	srec_cat $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)_verilator.bin \
 		--binary --offset 0 --byte-swap 8 --fill 0xff \
-		-within $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).bin \
+		-within $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)_verilator.bin\
 		-binary -range-pad 8 --output binary.64.vmem --vmem 64
-	$(OPENTITAN_TREE)/build/lowrisc_dv_chip_verilator_sim_0.1/sim-verilator/Vchip_sim_tb \
+	$(OPENTITAN_TREE)/bazel-out/k8-fastbuild/bin/hw/build.verilator_real/sim-verilator/Vchip_sim_tb \
 		--meminit=rom,$(OPENTITAN_TREE)/bazel-out/k8-fastbuild-ST-97f470ee3b14/bin/sw/device/lib/testing/test_rom/test_rom_sim_verilator.scr.39.vmem \
 		--meminit=flash,./binary.64.vmem \
-		--meminit=otp,$(OPENTITAN_TREE)/bazel-out/k8-fastbuild/bin/sw/device/tests/otp_ctrl_smoketest_sim_verilator.runfiles/lowrisc_opentitan/hw/ip/otp_ctrl/data/rma_image_verilator.vmem
+		--meminit=otp,$(OPENTITAN_TREE)/bazel-out/k8-fastbuild/bin/hw/ip/otp_ctrl/data/rma_image_verilator.vmem
 
 test:
 ifneq ($(OPENTITAN_TREE),)

--- a/boards/opentitan/earlgrey-cw310/run.sh
+++ b/boards/opentitan/earlgrey-cw310/run.sh
@@ -13,6 +13,11 @@ if [[ "${VERILATOR}" == "yes" ]]; then
 		fi
 	# Copy in and covert from cargo test output to binary
 	${OBJCOPY} ${1} "$BUILD_DIR"/earlgrey-cw310-tests.elf
+	if [[ "${APP}" != "" ]]; then
+		# An app was specified, copy it in
+		printf "[CW-130: Verilator Tests]: Linking APP...\n\n"
+		riscv64-linux-gnu-objcopy --update-section .apps=${APP} "$BUILD_DIR"/earlgrey-cw310-tests.elf "$BUILD_DIR"/earlgrey-cw310-tests.elf
+	fi
 	${OBJCOPY} --output-target=binary "$BUILD_DIR"/earlgrey-cw310-tests.elf "$BUILD_DIR"/earlgrey-cw310-tests.bin
 	# Create VMEM file from test binary
 	srec_cat "$BUILD_DIR"/earlgrey-cw310-tests.bin\
@@ -22,7 +27,7 @@ if [[ "${VERILATOR}" == "yes" ]]; then
 	${OPENTITAN_TREE}/bazel-out/k8-fastbuild/bin/hw/build.verilator_real/sim-verilator/Vchip_sim_tb \
 		--meminit=rom,${OPENTITAN_TREE}/bazel-out/k8-fastbuild-ST-97f470ee3b14/bin/sw/device/lib/testing/test_rom/test_rom_sim_verilator.scr.39.vmem \
 		--meminit=flash,./"$BUILD_DIR"/binary.64.vmem \
-		--meminit=otp,${OPENTITAN_TREE}/bazel-out/k8-fastbuild/bin/sw/device/tests/otp_ctrl_smoketest_sim_verilator.runfiles/lowrisc_opentitan/hw/ip/otp_ctrl/data/rma_image_verilator.vmem
+		--meminit=otp,${OPENTITAN_TREE}/bazel-out/k8-fastbuild/bin/hw/ip/otp_ctrl/data/rma_image_verilator.vmem
 elif [[ "${OPENTITAN_TREE}" != "" ]]; then
 	riscv64-linux-gnu-objcopy --update-section .apps=${APP} ${1} bundle.elf
 	riscv64-linux-gnu-objcopy --output-target=binary bundle.elf binary


### PR DESCRIPTION
### Pull Request Overview

-  Adds a way to bundle a single app with the kernel for Verilator. 

- Update OpenTitan paths to match the artifact locations created by the commands in README.

Usage (example loading OTBN binary): 

>$ APP=$OPENTITAN_TREE/bazel-out/k8-fastbuild-ST-2cc462681f62/bin/sw/otbn/crypto/rsa.tbf make BOARD_CONFIGURATION=sim_verilator verilator

Or for when testing:

>$ APP=$OPENTITAN_TREE/bazel-out/k8-fastbuild-ST-2cc462681f62/bin/sw/otbn/crypto/rsa.tbf make BOARD_CONFIGURATION=sim_verilator test-verilator

### Testing Strategy

By loading the OTBN Binary and checking that Tock detects it at board init.


### TODO or Help Wanted

Although, we can get the OTBN loaded and detected (in both test/non-test cases), I was unable to get a `libtock-c` app to run. Testing with `c-hello` produced no output after Tock loaded (after `OpenTitan initialisation complete. Entering main loop`). Any ideas ?

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
