### PR TITLE
boards/opentitan/Makefile: add OT version check

### DIFF
--- a/boards/opentitan/README.md
+++ b/boards/opentitan/README.md
@@ -18,11 +18,13 @@ for more details.
 
 Programming
 -----------
+The latest supported version (commit SHA) of OpenTitan is specified in the [OPENTITAN_SUPPORTED_SHA](https://github.com/tock/tock/blob/master/boards/opentitan/earlgrey-cw310/Makefile) make variable found:
+>  boards/opentitan/earlgrey-cw310/Makefile
 
-Tock on OpenTitan requires
-lowRISC/opentitan@d072ac505f82152678d6e04be95c72b728a347b8. In
-general it is recommended that users start with the specified commit as newer
-versions have not been tested.
+In *general* it is recommended that users start with the commit specified by `OPENTITAN_SUPPORTED_SHA` as newer
+versions **have not been** tested.
+
+> Note: when building, you can pass in `SKIP_OT_VERSION_CHECK=yes` to skip the trivial OpenTitan version check, this maybe useful when developing or testing across multiple versions of OpenTitan.
 
 Unfortunately the OpenTitan documentation is out of sync with the Tock setup.
 For instructions that match the OpenTitan version Tock supports you will need

--- a/boards/opentitan/earlgrey-cw310/Makefile
+++ b/boards/opentitan/earlgrey-cw310/Makefile
@@ -10,6 +10,9 @@ QEMU ?= ../../../tools/qemu/build/qemu-system-riscv32
 # This offset is calculated (from the linker file) as:
 # ORIGIN(rom) + size_manifest = 0x20000000 + 0x400
 QEMU_ENTRY_POINT=0x20000400
+# Latest supported commmit of OpenTitan
+OPENTITAN_SUPPORTED_SHA := d072ac505f82152678d6e04be95c72b728a347b8
+
 
 include ../../Makefile.common
 
@@ -20,6 +23,26 @@ ifneq ($(BOARD_CONFIGURATION),)
 else
 	CARGO_FLAGS += --features=$(DEFAULT_BOARD_CONFIGURATION)
 endif
+
+.PHONY: ot-check
+OPENTITAN_ACTUAL_SHA := $(shell cd $(OPENTITAN_TREE); git show --pretty=format:"%H" --no-patch)
+# TODO: Theres mix and match of tab/space indenting in the block below,
+# should be changed to using `RECIPEPREFIX` make syntax when CI supports
+# make version > 3.81 (macos)
+ot-check:
+ifeq ($(OPENTITAN_TREE),)
+	$(error "Please ensure that OPENTITAN_TREE is set")
+endif
+ifneq ($(OPENTITAN_ACTUAL_SHA), $(OPENTITAN_SUPPORTED_SHA))
+    ifeq ($(SKIP_OT_VERSION_CHECK), yes)
+		$(warning Skipping trivial version check)
+    else
+		$(error Please ensure to build the correct version \
+		of OpenTitan, latest supported is <$(OPENTITAN_SUPPORTED_SHA)>, \
+		you are on <$(OPENTITAN_ACTUAL_SHA)>)
+    endif
+endif
+
 
 # Default target for installing the kernel.
 .PHONY: install
@@ -75,21 +98,17 @@ endif
 # Test layout should be removed so that following apps (non-test) load the correct layout.
 	$(Q)rm $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/layout.ld
 
-test-hardware:
-ifeq ($(OPENTITAN_TREE),)
-	$(error "Please ensure that OPENTITAN_TREE is set")
-endif
+test-hardware: ot-check
 	mkdir -p $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/
 	$(Q)cp test_layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/layout.ld
 	$(Q)cp ../../kernel_layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/
 	$(Q)RUSTFLAGS="$(RUSTC_FLAGS_TOCK)" $(CARGO) test $(CARGO_FLAGS_TOCK_NO_BUILD_STD) $(NO_RUN) --bin $(PLATFORM) --release --features=hardware_tests
 	$(Q)rm $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/layout.ld
 
-test-verilator:
-	$(call check_defined, OPENTITAN_TREE)
-
+test-verilator: ot-check
 	mkdir -p $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/
 	$(Q)cp test_layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/layout.ld
 	$(Q)cp ../../kernel_layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/
 	$(Q)RUSTFLAGS="$(RUSTC_FLAGS_TOCK)" VERILATOR="yes" OBJCOPY=${OBJCOPY} $(CARGO) test $(CARGO_FLAGS_TOCK_NO_BUILD_STD) $(NO_RUN) --bin $(PLATFORM) --release --features=hardware_tests --features sim_verilator
 	$(Q)rm $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/layout.ld
+


### PR DESCRIPTION
### Pull Request Overview

For running tests on HW/Verilator make sure we are testing only on a supported version of OpenTitan by default. This might be a little annoying to keep changing if we are jumping back and forth between versions (normally shouldn't need to do that though). But can save some time when developing on different versions of OT by ensuring the current tests are ran on the respective version (specially Verilator, where tests take hours only to fail on the last one because of a load fault 😪).  

### Testing Strategy

Trying to run tests when on an unsupported commit of OpenTitan. 


### TODO or Help Wanted

N/A

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
