### PR TITLE
sifive: fix RX interrupt disable clobbering TX

### DIFF
--- a/chips/sifive/src/uart.rs
+++ b/chips/sifive/src/uart.rs
@@ -165,7 +165,7 @@ impl<'a> Uart<'a> {
 
     fn disable_rx_interrupt(&self) {
         let regs = self.registers;
-        regs.ie.write(interrupt::rxwm::CLEAR);
+        regs.ie.modify(interrupt::rxwm::CLEAR);
     }
 
     fn disable_tx_interrupt(&self) {


### PR DESCRIPTION
### Pull Request Overview

The implementation of `chips::sifive::uart::Uart::disable_rx_interrupt` accidentally used `write` instead of `modify` when updating the interrupt enable UART register. This caused any time the RX interrupt was disabled in the code to also clobber and disable the TX interrupt, causing problems with transmit. Fix by using `modify` to clear RX interrupt bit.

Specifically, this bug manifests way more frequently, and even apparently deterministically, when using system clock rates above the default of 16MHz. I was experimenting with the PLL, and configured the board to run at 320MHz (while taking care to also update the UART code to compensate for the increased system clock frequency), and pressing ENTER a few times was enough to trigger the bug. The bug would manifest as the expected output missing from `tockloader listen`, unless one held down a key other than ENTER (effectively, firing the RX interrupt, which also let the TX handler portion run). I was not able to reproduce the issue at the default system clock of 16MHz.

### Testing Strategy

This was tested by flashing to a HiFive1 revB board and making sure that the pconsole worked fine by pressing ENTER repeatedly quickly (this was how I originally reproduced the bug, it would manifest as the `tock$` from the pconsole disappearing).

I additionally tested this PR by first increasing the system clock to 320MHz, adjusting the baud rate divider in the UART class to compensate for the faster system speed, and after building and flashing then pressing ENTER repeatedly to make sure the pconsole worked correctly.

### TODO or Help Wanted

It would be nice to test this with the other SiFive board (HiFive Inventor?) to make sure it works fine.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
