### PR TITLE
ADC: Add set_client() to `AdcHighSpeed` trait

### DIFF
--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -454,7 +454,7 @@ pub unsafe fn main() {
             &mut capsules::adc::ADC_BUFFER3
         )
     );
-    peripherals.adc.set_client(adc);
+    hil::adc::AdcHighSpeed::set_client(&peripherals.adc, adc);
 
     // Setup RNG
     let rng = components::rng::RngComponent::new(

--- a/boards/imix/src/imix_components/adc.rs
+++ b/boards/imix/src/imix_components/adc.rs
@@ -19,6 +19,7 @@ use capsules::adc;
 use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
+use kernel::hil;
 use kernel::static_init;
 use sam4l::adc::Channel;
 
@@ -83,7 +84,7 @@ impl Component for AdcComponent {
                 &mut adc::ADC_BUFFER3
             )
         );
-        self.adc.set_client(adc);
+        hil::adc::AdcHighSpeed::set_client(self.adc, adc);
 
         adc
     }

--- a/boards/msp_exp432p401r/src/main.rs
+++ b/boards/msp_exp432p401r/src/main.rs
@@ -13,6 +13,7 @@ use kernel::capabilities;
 use kernel::component::Component;
 use kernel::dynamic_deferred_call::DynamicDeferredCall;
 use kernel::dynamic_deferred_call::DynamicDeferredCallClientState;
+use kernel::hil;
 use kernel::hil::gpio::Configure;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::scheduler::round_robin::RoundRobinSched;
@@ -409,8 +410,7 @@ pub unsafe fn main() {
             &mut capsules::adc::ADC_BUFFER3
         )
     );
-
-    peripherals.adc.set_client(adc);
+    hil::adc::AdcHighSpeed::set_client(&peripherals.adc, adc);
 
     // Set the reference voltage for the ADC to 2.5V
     peripherals

--- a/chips/msp432/src/adc.rs
+++ b/chips/msp432/src/adc.rs
@@ -486,6 +486,12 @@ register_bitfields![u32,
     ]
 ];
 
+#[derive(Clone, Copy)]
+enum EitherClient {
+    NormalClient(&'static dyn hil::adc::Client),
+    HighSpeedClient(&'static dyn hil::adc::HighSpeedClient),
+}
+
 pub struct Adc<'a> {
     registers: StaticRef<AdcRegisters>,
     resolution: AdcResolution,
@@ -498,7 +504,7 @@ pub struct Adc<'a> {
     dma_src: u8,
     buffer1: TakeCell<'static, [u16]>,
     buffer2: TakeCell<'static, [u16]>,
-    client: OptionalCell<&'static dyn hil::adc::HighSpeedClient>,
+    client: OptionalCell<EitherClient>,
 }
 
 impl Adc<'_> {
@@ -724,15 +730,17 @@ impl<'a> Adc<'a> {
 
                 // Stop sampling
                 self.registers.ctl0.modify(CTL0::ENC::CLEAR);
-
-                // Throw callback
-                self.client
-                    .map(move |client| client.sample_ready(self.get_sample(chan)));
-            } else if mode == AdcMode::Repeated {
-                // Throw callback
-                self.client
-                    .map(move |client| client.sample_ready(self.get_sample(chan)));
             }
+
+            // Throw callback
+            self.client.map(|either_client| match either_client {
+                EitherClient::NormalClient(client) => {
+                    client.sample_ready(self.get_sample(chan));
+                }
+                EitherClient::HighSpeedClient(client) => {
+                    client.sample_ready(self.get_sample(chan));
+                }
+            });
         } else {
             panic!("ADC: unhandled interrupt: channel {}", chan_nr);
         }
@@ -757,7 +765,12 @@ impl dma::DmaClient for Adc<'_> {
                 buf[i] <<= shift;
             }
 
-            self.client.map(move |cl| cl.samples_ready(buf, samples));
+            self.client.map(|either_client| match either_client {
+                EitherClient::NormalClient(_client) => {}
+                EitherClient::HighSpeedClient(client) => {
+                    client.samples_ready(buf, samples);
+                }
+            });
         }
     }
 }
@@ -887,8 +900,8 @@ impl hil::adc::Adc for Adc<'_> {
         self.ref_module.map(|ref_mod| ref_mod.ref_voltage_mv())
     }
 
-    fn set_client(&self, _client: &'static dyn hil::adc::Client) {
-        unimplemented!();
+    fn set_client(&self, client: &'static dyn hil::adc::Client) {
+        self.client.set(EitherClient::NormalClient(client));
     }
 }
 
@@ -990,6 +1003,6 @@ impl hil::adc::AdcHighSpeed for Adc<'_> {
     }
 
     fn set_client(&self, client: &'static dyn hil::adc::HighSpeedClient) {
-        self.client.set(client);
+        self.client.set(EitherClient::HighSpeedClient(client));
     }
 }

--- a/chips/msp432/src/adc.rs
+++ b/chips/msp432/src/adc.rs
@@ -486,11 +486,6 @@ register_bitfields![u32,
     ]
 ];
 
-/// Create a trait of both client types to allow a single client reference to
-/// act as both
-pub trait EverythingClient: hil::adc::Client + hil::adc::HighSpeedClient {}
-impl<C: hil::adc::Client + hil::adc::HighSpeedClient> EverythingClient for C {}
-
 pub struct Adc<'a> {
     registers: StaticRef<AdcRegisters>,
     resolution: AdcResolution,
@@ -503,7 +498,7 @@ pub struct Adc<'a> {
     dma_src: u8,
     buffer1: TakeCell<'static, [u16]>,
     buffer2: TakeCell<'static, [u16]>,
-    client: OptionalCell<&'static dyn EverythingClient>,
+    client: OptionalCell<&'static dyn hil::adc::HighSpeedClient>,
 }
 
 impl Adc<'_> {
@@ -710,10 +705,6 @@ impl<'a> Adc<'a> {
         self.ref_module.set(ref_module);
         self.timer.set(timer);
         self.dma.set(dma);
-    }
-
-    pub fn set_client(&self, client: &'static dyn EverythingClient) {
-        self.client.set(client);
     }
 
     pub fn handle_interrupt(&self) {
@@ -996,5 +987,9 @@ impl hil::adc::AdcHighSpeed for Adc<'_> {
         } else {
             Ok((self.buffer1.take(), self.buffer2.take()))
         }
+    }
+
+    fn set_client(&self, client: &'static dyn hil::adc::HighSpeedClient) {
+        self.client.set(client);
     }
 }

--- a/chips/stm32f303xc/src/adc.rs
+++ b/chips/stm32f303xc/src/adc.rs
@@ -10,9 +10,6 @@ use kernel::utilities::registers::{register_bitfields, ReadOnly, ReadWrite};
 use kernel::utilities::StaticRef;
 use kernel::ErrorCode;
 
-pub trait EverythingClient: hil::adc::Client + hil::adc::HighSpeedClient {}
-impl<C: hil::adc::Client + hil::adc::HighSpeedClient> EverythingClient for C {}
-
 #[repr(C)]
 struct AdcRegisters {
     isr: ReadWrite<u32, ISR::Register>,
@@ -774,4 +771,6 @@ impl hil::adc::AdcHighSpeed for Adc<'_> {
     ) -> Result<(Option<&'static mut [u16]>, Option<&'static mut [u16]>), ErrorCode> {
         Err(ErrorCode::NOSUPPORT)
     }
+
+    fn set_client(&self, _client: &'static dyn hil::adc::HighSpeedClient) {}
 }

--- a/chips/stm32f4xx/src/adc.rs
+++ b/chips/stm32f4xx/src/adc.rs
@@ -8,9 +8,6 @@ use kernel::utilities::registers::{register_bitfields, ReadOnly, ReadWrite};
 use kernel::utilities::StaticRef;
 use kernel::ErrorCode;
 
-pub trait EverythingClient: hil::adc::Client + hil::adc::HighSpeedClient {}
-impl<C: hil::adc::Client + hil::adc::HighSpeedClient> EverythingClient for C {}
-
 #[repr(C)]
 struct AdcRegisters {
     sr: ReadWrite<u32, SR::Register>,
@@ -478,4 +475,6 @@ impl hil::adc::AdcHighSpeed for Adc<'_> {
     ) -> Result<(Option<&'static mut [u16]>, Option<&'static mut [u16]>), ErrorCode> {
         Err(ErrorCode::NOSUPPORT)
     }
+
+    fn set_client(&self, _client: &'static dyn hil::adc::HighSpeedClient) {}
 }

--- a/kernel/src/hil/adc.rs
+++ b/kernel/src/hil/adc.rs
@@ -97,10 +97,12 @@ pub trait AdcHighSpeed: Adc {
     fn retrieve_buffers(
         &self,
     ) -> Result<(Option<&'static mut [u16]>, Option<&'static mut [u16]>), ErrorCode>;
+
+    fn set_client(&self, client: &'static dyn HighSpeedClient);
 }
 
 /// Trait for handling callbacks from high-speed ADC calls.
-pub trait HighSpeedClient {
+pub trait HighSpeedClient: Client {
     /// Called when a buffer is full.
     /// The length provided will always be less than or equal to the length of
     /// the buffer. Expects an additional call to either provide another buffer


### PR DESCRIPTION
### Pull Request Overview

This pull request is an alternative to #3267.

The base changes are:
- Adds a `set_client()` function to the `adc::AdcHighSpeed` trait. This is standard practice that we expect HILs to follow.
- Makes the `adc::HighSpeedClient` also include the base `adc::Client` callback.
- Updates the chip ADC implementations to implement the `adc::HighSpeedClient::set_client()` function. 

The downside to just making those changes is that any chip that implements `adc::AdcHighSpeed` now _has_ to use the `adc::HighSpeedClient::set_client()` function. So it is feasible that a board/capsule could use the `adc::Adc` trait for a chip, and then the chip driver could be updated to support `adc::AdcHighSpeed`, and then that board/capsule would break because the client would no longer be used. To address this, this PR:

- Adds a `EitherClient` enum to the adc drivers.

This enables the sam4l and msp432 adc drivers to use either client depending on which `set_client()` was called.

The downside is this adds some complexity on the implementation of the ADC trait. It's also possible that the wrong `set_client()` is used, but I don't see this as a larger problem than forgetting to call `set_client()` at all.


### Testing Strategy

travis


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
