### PR TITLE
component: update debug_* to new static

### DIFF
--- a/boards/acd52832/src/main.rs
+++ b/boards/acd52832/src/main.rs
@@ -339,7 +339,8 @@ pub unsafe fn main() {
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
-    components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
+    components::debug_writer::DebugWriterComponent::new(uart_mux)
+        .finalize(components::debug_writer_component_static!());
 
     //
     // I2C Devices

--- a/boards/arty_e21/src/main.rs
+++ b/boards/arty_e21/src/main.rs
@@ -252,7 +252,8 @@ pub unsafe fn main() {
     };
 
     // Create virtual device for kernel debug.
-    components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
+    components::debug_writer::DebugWriterComponent::new(uart_mux)
+        .finalize(components::debug_writer_component_static!());
 
     // arty_e21_chip::uart::UART0.initialize_gpio_pins(&peripherals.gpio_port[17], &peripherals.gpio_port[16]);
 

--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -498,7 +498,8 @@ pub unsafe fn main() {
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
-    components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
+    components::debug_writer::DebugWriterComponent::new(uart_mux)
+        .finalize(components::debug_writer_component_static!());
 
     //--------------------------------------------------------------------------
     // RANDOM NUMBERS

--- a/boards/components/src/debug_writer.rs
+++ b/boards/components/src/debug_writer.rs
@@ -40,7 +40,7 @@ const DEBUG_BUFFER_SPLIT: usize = 64;
 #[macro_export]
 macro_rules! debug_writer_component_static {
     () => {{
-        use components::debug_writer::DEBUG_BUFFER_KBYTE;
+        use $crate::debug_writer::DEBUG_BUFFER_KBYTE;
 
         let uart = kernel::static_buf!(capsules::virtual_uart::UartDevice);
         let ring = kernel::static_buf!(kernel::collections::ring_buffer::RingBuffer<'static, u8>);
@@ -55,7 +55,7 @@ macro_rules! debug_writer_component_static {
 #[macro_export]
 macro_rules! debug_writer_no_mux_component_static {
     () => {{
-        use component::debug_writer::DEBUG_BUFFER_KBYTE;
+        use $crate::debug_writer::DEBUG_BUFFER_KBYTE;
 
         let ring = kernel::static_buf!(kernel::collections::ring_buffer::RingBuffer<'static, u8>);
         let buffer = kernel::static_buf!([u8; 1024 * DEBUG_BUFFER_KBYTE]);

--- a/boards/components/src/debug_writer.rs
+++ b/boards/components/src/debug_writer.rs
@@ -7,7 +7,7 @@
 //! Usage
 //! -----
 //! ```rust
-//! DebugWriterComponent::new(uart_mux).finalize(());
+//! DebugWriterComponent::new(uart_mux).finalize(components::debug_writer_component_static!());
 //!
 //! components::debug_writer::DebugWriterNoMuxComponent::new(
 //!     &nrf52::uart::UARTE0,
@@ -19,23 +19,52 @@
 // Last modified: 11/07/2019
 
 use capsules::virtual_uart::{MuxUart, UartDevice};
+use core::mem::MaybeUninit;
 use kernel::capabilities;
 use kernel::collections::ring_buffer::RingBuffer;
 use kernel::component::Component;
 use kernel::hil;
 use kernel::hil::uart;
-use kernel::static_init;
 
 // The sum of the output_buf and internal_buf is set to a multiple of 1024 bytes in order to avoid excessive
 // padding between kernel memory and application memory (which often needs to be aligned to at
 // least a 1 KiB boundary). This is not _semantically_ critical, but helps keep buffers on 1 KiB
 // boundaries in some cases. Of course, these definitions are only advisory, and individual boards
 // can choose to pass in their own buffers with different lengths.
-const DEBUG_BUFFER_KBYTE: usize = 1;
+pub const DEBUG_BUFFER_KBYTE: usize = 1;
 
 // Bytes [0, DEBUG_BUFFER_SPLIT) are used for output_buf while bytes
 // [DEBUG_BUFFER_SPLIT, DEBUG_BUFFER_KBYTE * 1024) are used for internal_buf.
 const DEBUG_BUFFER_SPLIT: usize = 64;
+
+#[macro_export]
+macro_rules! debug_writer_component_static {
+    () => {{
+        use components::debug_writer::DEBUG_BUFFER_KBYTE;
+
+        let uart = kernel::static_buf!(capsules::virtual_uart::UartDevice);
+        let ring = kernel::static_buf!(kernel::collections::ring_buffer::RingBuffer<'static, u8>);
+        let buffer = kernel::static_buf!([u8; 1024 * DEBUG_BUFFER_KBYTE]);
+        let debug = kernel::static_buf!(kernel::debug::DebugWriter);
+        let debug_wrapper = kernel::static_buf!(kernel::debug::DebugWriterWrapper);
+
+        (uart, ring, buffer, debug, debug_wrapper)
+    };};
+}
+
+#[macro_export]
+macro_rules! debug_writer_no_mux_component_static {
+    () => {{
+        use component::debug_writer::DEBUG_BUFFER_KBYTE;
+
+        let ring = kernel::static_buf!(kernel::collections::ring_buffer::RingBuffer<'static, u8>);
+        let buffer = kernel::static_buf!([u8; 1024 * DEBUG_BUFFER_KBYTE]);
+        let debug = kernel::static_buf!(kernel::debug::DebugWriter);
+        let debug_wrapper = kernel::static_buf!(kernel::debug::DebugWriterWrapper);
+
+        (ring, buffer, debug, debug_wrapper)
+    };};
+}
 
 pub struct DebugWriterComponent {
     uart_mux: &'static MuxUart<'static>,
@@ -51,30 +80,32 @@ pub struct Capability;
 unsafe impl capabilities::ProcessManagementCapability for Capability {}
 
 impl Component for DebugWriterComponent {
-    type StaticInput = ();
+    type StaticInput = (
+        &'static mut MaybeUninit<UartDevice<'static>>,
+        &'static mut MaybeUninit<RingBuffer<'static, u8>>,
+        &'static mut MaybeUninit<[u8; 1024 * DEBUG_BUFFER_KBYTE]>,
+        &'static mut MaybeUninit<kernel::debug::DebugWriter>,
+        &'static mut MaybeUninit<kernel::debug::DebugWriterWrapper>,
+    );
     type Output = ();
 
-    unsafe fn finalize(self, _s: Self::StaticInput) -> Self::Output {
-        let buf = static_init!(
-            [u8; 1024 * DEBUG_BUFFER_KBYTE],
-            [0; 1024 * DEBUG_BUFFER_KBYTE]
-        );
+    unsafe fn finalize(self, s: Self::StaticInput) -> Self::Output {
+        let buf = s.2.write([0; 1024 * DEBUG_BUFFER_KBYTE]);
+
         let (output_buf, internal_buf) = buf.split_at_mut(DEBUG_BUFFER_SPLIT);
 
         // Create virtual device for kernel debug.
-        let debugger_uart = static_init!(UartDevice, UartDevice::new(self.uart_mux, false));
+        let debugger_uart = s.0.write(UartDevice::new(self.uart_mux, false));
         debugger_uart.setup();
-        let ring_buffer = static_init!(RingBuffer<'static, u8>, RingBuffer::new(internal_buf));
-        let debugger = static_init!(
-            kernel::debug::DebugWriter,
-            kernel::debug::DebugWriter::new(debugger_uart, output_buf, ring_buffer)
-        );
+        let ring_buffer = s.1.write(RingBuffer::new(internal_buf));
+        let debugger = s.3.write(kernel::debug::DebugWriter::new(
+            debugger_uart,
+            output_buf,
+            ring_buffer,
+        ));
         hil::uart::Transmit::set_transmit_client(debugger_uart, debugger);
 
-        let debug_wrapper = static_init!(
-            kernel::debug::DebugWriterWrapper,
-            kernel::debug::DebugWriterWrapper::new(debugger)
-        );
+        let debug_wrapper = s.4.write(kernel::debug::DebugWriterWrapper::new(debugger));
         kernel::debug::set_debug_writer_wrapper(debug_wrapper);
     }
 }
@@ -92,28 +123,28 @@ impl<U: uart::Uart<'static> + uart::Transmit<'static> + 'static> DebugWriterNoMu
 impl<U: uart::Uart<'static> + uart::Transmit<'static> + 'static> Component
     for DebugWriterNoMuxComponent<U>
 {
-    type StaticInput = ();
+    type StaticInput = (
+        &'static mut MaybeUninit<RingBuffer<'static, u8>>,
+        &'static mut MaybeUninit<[u8; 1024 * DEBUG_BUFFER_KBYTE]>,
+        &'static mut MaybeUninit<kernel::debug::DebugWriter>,
+        &'static mut MaybeUninit<kernel::debug::DebugWriterWrapper>,
+    );
     type Output = ();
 
-    unsafe fn finalize(self, _s: Self::StaticInput) -> Self::Output {
-        let buf = static_init!(
-            [u8; 1024 * DEBUG_BUFFER_KBYTE],
-            [0; 1024 * DEBUG_BUFFER_KBYTE]
-        );
+    unsafe fn finalize(self, s: Self::StaticInput) -> Self::Output {
+        let buf = s.1.write([0; 1024 * DEBUG_BUFFER_KBYTE]);
         let (output_buf, internal_buf) = buf.split_at_mut(DEBUG_BUFFER_SPLIT);
 
         // Create virtual device for kernel debug.
-        let ring_buffer = static_init!(RingBuffer<'static, u8>, RingBuffer::new(internal_buf));
-        let debugger = static_init!(
-            kernel::debug::DebugWriter,
-            kernel::debug::DebugWriter::new(self.uart, output_buf, ring_buffer)
-        );
+        let ring_buffer = s.0.write(RingBuffer::new(internal_buf));
+        let debugger = s.2.write(kernel::debug::DebugWriter::new(
+            self.uart,
+            output_buf,
+            ring_buffer,
+        ));
         hil::uart::Transmit::set_transmit_client(self.uart, debugger);
 
-        let debug_wrapper = static_init!(
-            kernel::debug::DebugWriterWrapper,
-            kernel::debug::DebugWriterWrapper::new(debugger)
-        );
+        let debug_wrapper = s.3.write(kernel::debug::DebugWriterWrapper::new(debugger));
         kernel::debug::set_debug_writer_wrapper(debug_wrapper);
 
         let _ = self.uart.configure(uart::Parameters {

--- a/boards/esp32-c3-devkitM-1/src/main.rs
+++ b/boards/esp32-c3-devkitM-1/src/main.rs
@@ -245,7 +245,8 @@ unsafe fn setup() -> (
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
-    components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
+    components::debug_writer::DebugWriterComponent::new(uart_mux)
+        .finalize(components::debug_writer_component_static!());
 
     // Create process printer for panic.
     let process_printer = components::process_printer::ProcessPrinterTextComponent::new()

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -312,7 +312,8 @@ pub unsafe fn main() {
     .finalize(components::process_console_component_static!(
         sam4l::ast::Ast<'static>
     ));
-    components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
+    components::debug_writer::DebugWriterComponent::new(uart_mux)
+        .finalize(components::debug_writer_component_static!());
 
     // Initialize USART3 for UART for the nRF serialization link.
     peripherals.usart3.set_mode(sam4l::usart::UsartMode::Uart);

--- a/boards/hifive1/src/main.rs
+++ b/boards/hifive1/src/main.rs
@@ -265,7 +265,8 @@ pub unsafe fn main() {
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
-    components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
+    components::debug_writer::DebugWriterComponent::new(uart_mux)
+        .finalize(components::debug_writer_component_static!());
 
     let lldb = components::lldb::LowLevelDebugComponent::new(
         board_kernel,

--- a/boards/hifive_inventor/src/main.rs
+++ b/boards/hifive_inventor/src/main.rs
@@ -244,7 +244,8 @@ pub unsafe fn main() {
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
-    components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
+    components::debug_writer::DebugWriterComponent::new(uart_mux)
+        .finalize(components::debug_writer_component_static!());
 
     let lldb = components::lldb::LowLevelDebugComponent::new(
         board_kernel,

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -379,7 +379,7 @@ pub unsafe fn main() {
         ));
     let console = ConsoleComponent::new(board_kernel, capsules::console::DRIVER_NUM, uart_mux)
         .finalize(components::console_component_static!());
-    DebugWriterComponent::new(uart_mux).finalize(());
+    DebugWriterComponent::new(uart_mux).finalize(components::debug_writer_component_static!());
 
     // Allow processes to communicate over BLE through the nRF51822
     peripherals.usart2.set_mode(sam4l::usart::UsartMode::Uart);

--- a/boards/imxrt1050-evkb/src/main.rs
+++ b/boards/imxrt1050-evkb/src/main.rs
@@ -332,7 +332,8 @@ pub unsafe fn main() {
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
-    components::debug_writer::DebugWriterComponent::new(lpuart_mux).finalize(());
+    components::debug_writer::DebugWriterComponent::new(lpuart_mux)
+        .finalize(components::debug_writer_component_static!());
 
     // LEDs
 

--- a/boards/litex/arty/src/main.rs
+++ b/boards/litex/arty/src/main.rs
@@ -509,7 +509,8 @@ pub unsafe fn main() {
     .finalize(components::console_component_static!());
 
     // Create the debugger object that handles calls to `debug!()`.
-    components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
+    components::debug_writer::DebugWriterComponent::new(uart_mux)
+        .finalize(components::debug_writer_component_static!());
 
     let lldb = components::lldb::LowLevelDebugComponent::new(
         board_kernel,

--- a/boards/litex/sim/src/main.rs
+++ b/boards/litex/sim/src/main.rs
@@ -581,7 +581,8 @@ pub unsafe fn main() {
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
-    components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
+    components::debug_writer::DebugWriterComponent::new(uart_mux)
+        .finalize(components::debug_writer_component_static!());
 
     let lldb = components::lldb::LowLevelDebugComponent::new(
         board_kernel,

--- a/boards/microbit_v2/src/main.rs
+++ b/boards/microbit_v2/src/main.rs
@@ -400,7 +400,8 @@ pub unsafe fn main() {
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
-    components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
+    components::debug_writer::DebugWriterComponent::new(uart_mux)
+        .finalize(components::debug_writer_component_static!());
 
     //--------------------------------------------------------------------------
     // RANDOM NUMBERS

--- a/boards/msp_exp432p401r/src/main.rs
+++ b/boards/msp_exp432p401r/src/main.rs
@@ -348,7 +348,8 @@ pub unsafe fn main() {
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
-    components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
+    components::debug_writer::DebugWriterComponent::new(uart_mux)
+        .finalize(components::debug_writer_component_static!());
 
     // Setup alarm
     let timer0 = &peripherals.timer_a0;

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -389,7 +389,8 @@ pub unsafe fn main() {
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
-    components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
+    components::debug_writer::DebugWriterComponent::new(uart_mux)
+        .finalize(components::debug_writer_component_static!());
 
     //--------------------------------------------------------------------------
     // RANDOM NUMBERS

--- a/boards/nano_rp2040_connect/src/main.rs
+++ b/boards/nano_rp2040_connect/src/main.rs
@@ -339,7 +339,8 @@ pub unsafe fn main() {
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
-    components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
+    components::debug_writer::DebugWriterComponent::new(uart_mux)
+        .finalize(components::debug_writer_component_static!());
 
     let gpio = GpioComponent::new(
         board_kernel,

--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -334,7 +334,8 @@ pub unsafe fn main() {
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
-    components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
+    components::debug_writer::DebugWriterComponent::new(uart_mux)
+        .finalize(components::debug_writer_component_static!());
 
     let ble_radio = nrf52_components::BLEComponent::new(
         board_kernel,

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -442,7 +442,8 @@ pub unsafe fn main() {
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
-    components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
+    components::debug_writer::DebugWriterComponent::new(uart_mux)
+        .finalize(components::debug_writer_component_static!());
 
     let ble_radio = nrf52_components::BLEComponent::new(
         board_kernel,

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -390,7 +390,8 @@ pub unsafe fn main() {
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
-    components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
+    components::debug_writer::DebugWriterComponent::new(uart_mux)
+        .finalize(components::debug_writer_component_static!());
 
     let ble_radio = nrf52_components::BLEComponent::new(
         board_kernel,

--- a/boards/nucleo_f429zi/src/main.rs
+++ b/boards/nucleo_f429zi/src/main.rs
@@ -346,7 +346,8 @@ pub unsafe fn main() {
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
-    components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
+    components::debug_writer::DebugWriterComponent::new(uart_mux)
+        .finalize(components::debug_writer_component_static!());
 
     // LEDs
 

--- a/boards/nucleo_f446re/src/main.rs
+++ b/boards/nucleo_f446re/src/main.rs
@@ -342,7 +342,8 @@ pub unsafe fn main() {
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
-    components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
+    components::debug_writer::DebugWriterComponent::new(uart_mux)
+        .finalize(components::debug_writer_component_static!());
 
     // LEDs
     let gpio_ports = &base_peripherals.gpio_ports;

--- a/boards/opentitan/src/main.rs
+++ b/boards/opentitan/src/main.rs
@@ -355,7 +355,8 @@ unsafe fn setup() -> (
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
-    components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
+    components::debug_writer::DebugWriterComponent::new(uart_mux)
+        .finalize(components::debug_writer_component_static!());
 
     let lldb = components::lldb::LowLevelDebugComponent::new(
         board_kernel,

--- a/boards/particle_boron/src/main.rs
+++ b/boards/particle_boron/src/main.rs
@@ -420,7 +420,8 @@ pub unsafe fn main() {
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
-    components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
+    components::debug_writer::DebugWriterComponent::new(uart_mux)
+        .finalize(components::debug_writer_component_static!());
 
     //--------------------------------------------------------------------------
     // WIRELESS

--- a/boards/pico_explorer_base/src/main.rs
+++ b/boards/pico_explorer_base/src/main.rs
@@ -344,7 +344,8 @@ pub unsafe fn main() {
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
-    components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
+    components::debug_writer::DebugWriterComponent::new(uart_mux)
+        .finalize(components::debug_writer_component_static!());
 
     let gpio = GpioComponent::new(
         board_kernel,

--- a/boards/qemu_rv32_virt/src/main.rs
+++ b/boards/qemu_rv32_virt/src/main.rs
@@ -232,7 +232,8 @@ pub unsafe fn main() {
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
-    components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
+    components::debug_writer::DebugWriterComponent::new(uart_mux)
+        .finalize(components::debug_writer_component_static!());
 
     let lldb = components::lldb::LowLevelDebugComponent::new(
         board_kernel,

--- a/boards/raspberry_pi_pico/src/main.rs
+++ b/boards/raspberry_pi_pico/src/main.rs
@@ -342,7 +342,8 @@ pub unsafe fn main() {
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
-    components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
+    components::debug_writer::DebugWriterComponent::new(uart_mux)
+        .finalize(components::debug_writer_component_static!());
 
     let gpio = GpioComponent::new(
         board_kernel,

--- a/boards/redboard_artemis_nano/src/main.rs
+++ b/boards/redboard_artemis_nano/src/main.rs
@@ -230,7 +230,8 @@ unsafe fn setup() -> (
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
-    components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
+    components::debug_writer::DebugWriterComponent::new(uart_mux)
+        .finalize(components::debug_writer_component_static!());
 
     // LEDs
     let led = components::led::LedsComponent::new().finalize(components::led_component_static!(

--- a/boards/redboard_redv/src/main.rs
+++ b/boards/redboard_redv/src/main.rs
@@ -238,7 +238,8 @@ pub unsafe fn main() {
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
-    components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
+    components::debug_writer::DebugWriterComponent::new(uart_mux)
+        .finalize(components::debug_writer_component_static!());
 
     let lldb = components::lldb::LowLevelDebugComponent::new(
         board_kernel,

--- a/boards/sma_q3/src/main.rs
+++ b/boards/sma_q3/src/main.rs
@@ -309,7 +309,8 @@ pub unsafe fn main() {
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
-    components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
+    components::debug_writer::DebugWriterComponent::new(uart_mux)
+        .finalize(components::debug_writer_component_static!());
 
     let ble_radio = nrf52_components::BLEComponent::new(
         board_kernel,

--- a/boards/stm32f3discovery/src/main.rs
+++ b/boards/stm32f3discovery/src/main.rs
@@ -435,7 +435,8 @@ pub unsafe fn main() {
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
-    components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
+    components::debug_writer::DebugWriterComponent::new(uart_mux)
+        .finalize(components::debug_writer_component_static!());
 
     // LEDs
 

--- a/boards/stm32f412gdiscovery/src/main.rs
+++ b/boards/stm32f412gdiscovery/src/main.rs
@@ -462,7 +462,8 @@ pub unsafe fn main() {
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
-    components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
+    components::debug_writer::DebugWriterComponent::new(uart_mux)
+        .finalize(components::debug_writer_component_static!());
 
     // LEDs
 

--- a/boards/stm32f429idiscovery/src/main.rs
+++ b/boards/stm32f429idiscovery/src/main.rs
@@ -352,7 +352,8 @@ pub unsafe fn main() {
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
-    components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
+    components::debug_writer::DebugWriterComponent::new(uart_mux)
+        .finalize(components::debug_writer_component_static!());
 
     // LEDs
 

--- a/boards/swervolf/src/main.rs
+++ b/boards/swervolf/src/main.rs
@@ -206,7 +206,8 @@ pub unsafe fn main() {
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
-    components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
+    components::debug_writer::DebugWriterComponent::new(uart_mux)
+        .finalize(components::debug_writer_component_static!());
 
     debug!("SweRVolf initialisation complete.");
     debug!("Entering main loop.");

--- a/boards/teensy40/src/main.rs
+++ b/boards/teensy40/src/main.rs
@@ -265,7 +265,8 @@ pub unsafe fn main() {
     )
     .finalize(components::uart_mux_component_static!());
     // Create the debugger object that handles calls to `debug!()`
-    components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
+    components::debug_writer::DebugWriterComponent::new(uart_mux)
+        .finalize(components::debug_writer_component_static!());
 
     // Setup the console
     let console = components::console::ConsoleComponent::new(

--- a/boards/weact_f401ccu6/src/main.rs
+++ b/boards/weact_f401ccu6/src/main.rs
@@ -300,7 +300,8 @@ pub unsafe fn main() {
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
-    components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
+    components::debug_writer::DebugWriterComponent::new(uart_mux)
+        .finalize(components::debug_writer_component_static!());
 
     // LEDs
     // Clock to Port A, B, C are enabled in `set_pin_primary_functions()`

--- a/kernel/src/debug.rs
+++ b/kernel/src/debug.rs
@@ -13,15 +13,15 @@
 //!     None,
 //! );
 //!
-//! components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(());
+//! components::debug_writer::DebugWriterComponent::new(uart_mux).finalize(components::debug_writer_component_static!());
 //! ```
 //!
 //! The debug queue is optional, if not set in the board it is just ignored.
 //! You can add one in the board file as follows:
 //!
 //! ```ignore
-//! let buf = static_init!([u8; 1024], [0; 1024]);
-//! components::debug_queue::DebugQueueComponent::new(buf).finalize(());
+//! components::debug_queue::DebugQueueComponent::new()
+//!     .finalize(components::debug_queue_component_static!());
 //! ```
 //!
 //! Example


### PR DESCRIPTION
### Pull Request Overview

This pull request updates the components for debug capsules. A lot of boards use these and the change is somewhat large.


### Testing Strategy

travis


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
