### PR TITLE
sifive and hifive1: support 344MHz system clock

### DIFF
--- a/boards/hifive1/src/main.rs
+++ b/boards/hifive1/src/main.rs
@@ -131,10 +131,12 @@ impl KernelResources<e310_g002::chip::E310x<'static, E310G002DefaultPeripherals<
 /// Additionally, this function should only ever be called once, as it is declaring and
 /// initializing static memory for system peripherals.
 #[inline(never)]
-unsafe fn create_peripherals() -> &'static mut E310G002DefaultPeripherals<'static> {
+unsafe fn create_peripherals(
+    clock_frequency: u32,
+) -> &'static mut E310G002DefaultPeripherals<'static> {
     static_init!(
         E310G002DefaultPeripherals,
-        E310G002DefaultPeripherals::new()
+        E310G002DefaultPeripherals::new(clock_frequency)
     )
 }
 
@@ -194,7 +196,7 @@ pub unsafe fn main() {
     // only machine mode
     rv32i::configure_trap_handler(rv32i::PermissionMode::Machine);
 
-    let peripherals = create_peripherals();
+    let peripherals = create_peripherals(344_000_000);
 
     peripherals.e310x.watchdog.disable();
     peripherals.e310x.rtc.disable();
@@ -206,7 +208,7 @@ pub unsafe fn main() {
     peripherals
         .e310x
         .prci
-        .set_clock_frequency(sifive::prci::ClockFrequency::Freq16Mhz);
+        .set_clock_frequency(sifive::prci::ClockFrequency::Freq344Mhz);
 
     let main_loop_cap = create_capability!(capabilities::MainLoopCapability);
 

--- a/boards/hifive_inventor/src/main.rs
+++ b/boards/hifive_inventor/src/main.rs
@@ -127,7 +127,7 @@ pub unsafe fn main() {
 
     let peripherals = static_init!(
         E310G003DefaultPeripherals,
-        E310G003DefaultPeripherals::new()
+        E310G003DefaultPeripherals::new(16_000_000)
     );
 
     peripherals

--- a/boards/redboard_redv/src/main.rs
+++ b/boards/redboard_redv/src/main.rs
@@ -134,7 +134,7 @@ pub unsafe fn main() {
 
     let peripherals = static_init!(
         E310G002DefaultPeripherals,
-        E310G002DefaultPeripherals::new()
+        E310G002DefaultPeripherals::new(16_000_000)
     );
 
     // initialize capabilities

--- a/chips/e310_g002/src/interrupt_service.rs
+++ b/chips/e310_g002/src/interrupt_service.rs
@@ -8,9 +8,9 @@ pub struct E310G002DefaultPeripherals<'a> {
 }
 
 impl<'a> E310G002DefaultPeripherals<'a> {
-    pub unsafe fn new() -> Self {
+    pub unsafe fn new(clock_frequency: u32) -> Self {
         Self {
-            e310x: E310xDefaultPeripherals::new(),
+            e310x: E310xDefaultPeripherals::new(clock_frequency),
         }
     }
 }

--- a/chips/e310_g003/src/interrupt_service.rs
+++ b/chips/e310_g003/src/interrupt_service.rs
@@ -8,9 +8,9 @@ pub struct E310G003DefaultPeripherals<'a> {
 }
 
 impl<'a> E310G003DefaultPeripherals<'a> {
-    pub unsafe fn new() -> Self {
+    pub unsafe fn new(clock_frequency: u32) -> Self {
         Self {
-            e310x: E310xDefaultPeripherals::new(),
+            e310x: E310xDefaultPeripherals::new(clock_frequency),
         }
     }
 }

--- a/chips/e310x/src/chip.rs
+++ b/chips/e310x/src/chip.rs
@@ -41,10 +41,18 @@ pub struct E310xDefaultPeripherals<'a> {
 }
 
 impl<'a> E310xDefaultPeripherals<'a> {
-    pub fn new() -> Self {
+    pub fn new(clock_frequency: u32) -> Self {
         Self {
-            uart0: sifive::uart::Uart::new(crate::uart::UART0_BASE, 16_000_000, &DEFERRED_CALLS[0]),
-            uart1: sifive::uart::Uart::new(crate::uart::UART1_BASE, 16_000_000, &DEFERRED_CALLS[1]),
+            uart0: sifive::uart::Uart::new(
+                crate::uart::UART0_BASE,
+                clock_frequency,
+                &DEFERRED_CALLS[0],
+            ),
+            uart1: sifive::uart::Uart::new(
+                crate::uart::UART1_BASE,
+                clock_frequency,
+                &DEFERRED_CALLS[1],
+            ),
             gpio_port: crate::gpio::Port::new(),
             prci: sifive::prci::Prci::new(crate::prci::PRCI_BASE),
             pwm0: sifive::pwm::Pwm::new(crate::pwm::PWM0_BASE),

--- a/chips/sifive/src/prci.rs
+++ b/chips/sifive/src/prci.rs
@@ -1,8 +1,11 @@
 //! Power Reset Clock Interrupt controller driver.
 
+use core::cell::Cell;
 use kernel::utilities::registers::interfaces::ReadWriteable;
+use kernel::utilities::registers::interfaces::Readable;
 use kernel::utilities::registers::{register_bitfields, ReadWrite};
 use kernel::utilities::StaticRef;
+use rv32i::csr;
 
 #[repr(C)]
 pub struct PrciRegisters {
@@ -48,29 +51,111 @@ register_bitfields![u32,
 
 pub enum ClockFrequency {
     Freq16Mhz,
+    Freq344Mhz,
 }
 
 pub struct Prci {
     registers: StaticRef<PrciRegisters>,
+    current_frequency: Cell<ClockFrequency>,
 }
 
 impl Prci {
     pub const fn new(base: StaticRef<PrciRegisters>) -> Prci {
-        Prci { registers: base }
+        Prci {
+            registers: base,
+            current_frequency: Cell::new(ClockFrequency::Freq16Mhz),
+        }
+    }
+
+    pub fn switch_to_internal_clock(&self) {
+        let regs = self.registers;
+        // Enable internal high-frequency clock if it's not enabled
+        if regs.hfrosccfg.read(hfrosccfg::enable) == 0 {
+            regs.hfrosccfg.modify(hfrosccfg::enable::SET);
+        }
+        // ... Wait until the clock is ready
+        while regs.hfrosccfg.read(hfrosccfg::ready) == 0 {}
+        // ... and now actually switch
+        regs.pllcfg
+            .modify(pllcfg::sel::CLEAR + pllcfg::bypass::CLEAR);
+    }
+
+    pub fn set_internal_clock_default(&self) {
+        let regs = self.registers;
+        // Set to defaults, which according to data sheet should set to 14.4MHz +- 50%,
+        regs.hfrosccfg
+            .modify(hfrosccfg::div.val(4) + hfrosccfg::trim.val(0x10));
+    }
+
+    pub fn enable_external_clock(&self) {
+        let regs = self.registers;
+        // Make sure external crystal oscillator is enabled
+        if regs.hfxosccfg.read(hfxosccfg::enable) == 0 {
+            regs.hfxosccfg.modify(hfxosccfg::enable::SET);
+        }
+        // ... Wait until the clock is ready
+        while regs.hfxosccfg.read(hfxosccfg::ready) == 0 {}
     }
 
     pub fn set_clock_frequency(&self, frequency: ClockFrequency) {
         let regs = self.registers;
+        // According to someone affiliated with SiFive in forum post:
+        // https://forums.sifive.com/t/is-it-possible-to-brick-the-hifive-board/751/6,
+        // it is safe to adjust the internal high frequency clock while it
+        // is in use, but not the PLL output.
+        //
+        // So first switch to internal clock before doing any other clock manipulation
+
+        // Reset internal clock to defaults so we can estimate how long we're spinning for the PLL
+        // lock delay. At default, the frequency should be 14.4MHz +- 50%, so a maximum frequency
+        // of just under 22MHz
+        self.set_internal_clock_default();
+        self.switch_to_internal_clock();
+
+        // Make sure external clock subsystem is enabled before adjusting the PLL
+        self.enable_external_clock();
 
         match frequency {
             ClockFrequency::Freq16Mhz => {
+                // Bypass enabled, feeds clock directly from external clock. For HiFive1 revB, this
+                // is a 16 MHz clock
                 regs.pllcfg
                     .modify(pllcfg::bypass::SET + pllcfg::refsel::SET);
+                // ... configure final PLL divider to divide by 1
                 regs.plloutdiv
                     .modify(plloutdiv::divby1.val(1) + plloutdiv::div.val(0));
+                // ... and finally enable the output
                 regs.pllcfg.modify(pllcfg::sel::SET);
-                regs.hfrosccfg.modify(hfrosccfg::enable::CLEAR);
+            }
+            ClockFrequency::Freq344Mhz => {
+                // Disable bypass, and set external clock as source for PLL
+                // divide 16 MHz input by 2 (pllr(1)), times 86 (pllf(42)), divide by 2 (pllq(1))
+                // for a frequency of 344MHz
+                regs.pllcfg.modify(
+                    pllcfg::bypass::CLEAR
+                        + pllcfg::refsel::SET
+                        + pllcfg::pllr.val(1)
+                        + pllcfg::pllf.val(42)
+                        + pllcfg::pllq.val(1),
+                );
+                // Divide PLL output by 1
+                regs.plloutdiv
+                    .modify(plloutdiv::divby1.val(1) + plloutdiv::div.val(0));
+
+                // We need to wait for PLL to settle before checking if it's stable, which takes
+                // about 100 microseconds. Assuming internal clock is worst case of 22MHz (14.7 MHz
+                // +- 50%), that's about 2200 cycles.
+                let start = csr::CSR.mcycle.get();
+                while csr::CSR.mcycle.get() - start < 2200 {}
+                // ... and now wait for the PLL lock
+                while regs.pllcfg.read(pllcfg::lock) == 0 {}
+                // ... and finally switch to the PLL output
+                regs.pllcfg.modify(pllcfg::sel::SET);
             }
         };
+        self.current_frequency.set(frequency);
+
+        // Finally, disable internal clock as we've now switched to something else.
+        regs.hfrosccfg.modify(hfrosccfg::enable::CLEAR);
     }
 }


### PR DESCRIPTION
### Pull Request Overview

The SiFive FE310-G002 and FE310-G003 appear to have the same clock control hardware, and expose identical registers to manage the clocking of the system. This adds a ~~320MHz~~ (**edit: 344MHz**) clock frequency option, achieved by adjusting the PLL. Some additional code makes sure changing frequency is done safely.

~~UART needs to update its divider when the system clock changes to maintain a constant baud rate. A new function
`Uart::update_clock_frequency` handles this, and should be called after a system clock change. Additionally, now `Uart::set_baud_rate` is called on creation to make sure the internal baud rate and hardware state is consistent.~~

**Edit:** UART now takes in the desired system clock on creation, so that the `set_baud` calculations take that into account.

There is no need currently to do adjustments to the SPI peripheral serial clock divider. Default settings on the SPI peripheral divide the clock by 8, limiting the maximum frequency of the serial clock to 48MHz (maximum possible output from PLL peripheral is 384MHz). All QSPI chips listed as in use for HiFive boards support frequencies below 50MHz.

I am also looking for feedback on how to make it more flexible to choose semi-arbitrary clocks (there are over 100 valid unique clock outputs from the PLL block), or if this is something that is unnecessary, and whether we should just support a small set of frequencies.

A lot of the changes are comments just to make it easier to follow what is going on and why. I may have gone overboard, as I tend to err on the side of too much.

### Testing Strategy

I tested this on a HiFive1 revB. It actually helped me catch a bug in the SiFIve UART driver, which should be fixed by #3272.

I tested this by making sure UART communication happened, indicating that the baud rate was still properly clocked at 115200 even after adjusting the divider in the UART peripheral to account for the increased system clock. To confirm that the divider mattered, I removed the update logic to compensate for a change in the system clock, and I observed that UART communication was no longer possible (as expected).

### TODO or Help Wanted

I checked the documentation for the G003 chip, and I believe the registers are all the same, and possibly even the PLL peripheral, but it would be really good to have someone with a FE310-G003 to check (I think that's a HiFive Inventor???).

Additionally I have a few design questions, which I'll highlight in the comments.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
