### PR TITLE
component: add a variety of new components to remove some `static mut`

### DIFF
--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -589,18 +589,12 @@ pub unsafe fn main() {
         &nrf52840_peripherals.gpio_port[APDS9960_PIN],
     )
     .finalize(components::apds9960_component_static!());
-
-    let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
-
-    let proximity = static_init!(
-        capsules::proximity::ProximitySensor<'static>,
-        capsules::proximity::ProximitySensor::new(
-            apds9960,
-            board_kernel.create_grant(capsules::proximity::DRIVER_NUM, &grant_cap)
-        )
-    );
-
-    kernel::hil::sensors::ProximityDriver::set_client(apds9960, proximity);
+    let proximity = components::proximity::ProximityComponent::new(
+        apds9960,
+        board_kernel,
+        capsules::proximity::DRIVER_NUM,
+    )
+    .finalize(components::proximity_component_static!());
 
     let sht3x = components::sht3x::SHT3xComponent::new(
         sensors_i2c_bus,

--- a/boards/components/src/apds9960.rs
+++ b/boards/components/src/apds9960.rs
@@ -1,0 +1,60 @@
+//! Component for APDS9960 proximity sensor.
+
+use capsules::apds9960::APDS9960;
+use capsules::virtual_i2c::{I2CDevice, MuxI2C};
+use core::mem::MaybeUninit;
+use kernel::component::Component;
+use kernel::hil::gpio;
+
+#[macro_export]
+macro_rules! apds9960_component_static {
+    () => {{
+        let i2c_device = kernel::static_buf!(capsules::virtual_i2c::I2CDevice<'static>);
+        let apds9960 = kernel::static_buf!(capsules::apds9960::APDS9960<'static>);
+        let buffer = kernel::static_buf!([u8; capsules::apds9960::BUF_LEN]);
+
+        (i2c_device, apds9960, buffer)
+    };};
+}
+
+pub struct Apds9960Component {
+    i2c_mux: &'static MuxI2C<'static>,
+    i2c_address: u8,
+    interrupt_pin: &'static dyn gpio::InterruptPin<'static>,
+}
+
+impl Apds9960Component {
+    pub fn new(
+        i2c_mux: &'static MuxI2C<'static>,
+        i2c_address: u8,
+        interrupt_pin: &'static dyn gpio::InterruptPin<'static>,
+    ) -> Self {
+        Apds9960Component {
+            i2c_mux,
+            i2c_address,
+            interrupt_pin,
+        }
+    }
+}
+
+impl Component for Apds9960Component {
+    type StaticInput = (
+        &'static mut MaybeUninit<I2CDevice<'static>>,
+        &'static mut MaybeUninit<APDS9960<'static>>,
+        &'static mut MaybeUninit<[u8; capsules::apds9960::BUF_LEN]>,
+    );
+    type Output = &'static APDS9960<'static>;
+
+    unsafe fn finalize(self, s: Self::StaticInput) -> Self::Output {
+        let apds9960_i2c = s.0.write(I2CDevice::new(self.i2c_mux, self.i2c_address));
+
+        let buffer = s.2.write([0; capsules::apds9960::BUF_LEN]);
+
+        let apds9960 =
+            s.1.write(APDS9960::new(apds9960_i2c, self.interrupt_pin, buffer));
+        apds9960_i2c.set_client(apds9960);
+        self.interrupt_pin.set_client(apds9960);
+
+        apds9960
+    }
+}

--- a/boards/components/src/dac.rs
+++ b/boards/components/src/dac.rs
@@ -1,0 +1,39 @@
+//! Component for Digital to Analog Converters (DAC).
+//!
+//! Usage
+//! -----
+//! ```rust
+//! let dac = components::dac::DacComponent::new(&peripherals.dac)
+//!      .finalize(components::dac_component_static!());
+//! ```
+
+use capsules::dac::Dac;
+use core::mem::MaybeUninit;
+use kernel::component::Component;
+use kernel::hil;
+
+#[macro_export]
+macro_rules! dac_component_static {
+    () => {{
+        kernel::static_buf!(capsules::dac::Dac<'static>)
+    };};
+}
+
+pub struct DacComponent {
+    dac: &'static dyn hil::dac::DacChannel,
+}
+
+impl DacComponent {
+    pub fn new(dac: &'static dyn hil::dac::DacChannel) -> Self {
+        Self { dac }
+    }
+}
+
+impl Component for DacComponent {
+    type StaticInput = &'static mut MaybeUninit<Dac<'static>>;
+    type Output = &'static Dac<'static>;
+
+    unsafe fn finalize(self, s: Self::StaticInput) -> Self::Output {
+        s.write(Dac::new(self.dac))
+    }
+}

--- a/boards/components/src/fm25cl.rs
+++ b/boards/components/src/fm25cl.rs
@@ -1,0 +1,79 @@
+//! Components for the FM25CL FRAM chip.
+//!
+//! Uses a SPI Interface.
+//!
+//! Usage
+//! -----
+//! ```rust
+//! let fm25cl = components::fm25cl::Fm25clComponent::new(spi_mux, stm32f429zi::gpio::PinId::PE03)
+//!     .finalize(components::fm25cl_component_static!(stm32f429zi::spi::Spi));
+//! ```
+
+use capsules::fm25cl::FM25CL;
+use capsules::virtual_spi::{MuxSpiMaster, VirtualSpiMasterDevice};
+use core::mem::MaybeUninit;
+use kernel::component::Component;
+use kernel::hil::spi;
+use kernel::hil::spi::SpiMasterDevice;
+
+#[macro_export]
+macro_rules! fm25cl_component_static {
+    ($S:ty $(,)?) => {{
+        let txbuffer = kernel::static_buf!([u8; capsules::fm25cl::BUF_LEN]);
+        let rxbuffer = kernel::static_buf!([u8; capsules::fm25cl::BUF_LEN]);
+
+        let spi = kernel::static_buf!(capsules::virtual_spi::VirtualSpiMasterDevice<'static, $S>);
+        let fm25cl = kernel::static_buf!(
+            capsules::fm25cl::FM25CL<
+                'static,
+                capsules::virtual_spi::VirtualSpiMasterDevice<'static, $S>,
+            >
+        );
+
+        (spi, fm25cl, txbuffer, rxbuffer)
+    };};
+}
+
+pub struct Fm25clComponent<S: 'static + spi::SpiMaster> {
+    spi_mux: &'static MuxSpiMaster<'static, S>,
+    chip_select: S::ChipSelect,
+}
+
+impl<S: 'static + spi::SpiMaster> Fm25clComponent<S> {
+    pub fn new(
+        spi_mux: &'static MuxSpiMaster<'static, S>,
+        chip_select: S::ChipSelect,
+    ) -> Fm25clComponent<S> {
+        Fm25clComponent {
+            spi_mux,
+            chip_select,
+        }
+    }
+}
+
+impl<S: 'static + spi::SpiMaster> Component for Fm25clComponent<S> {
+    type StaticInput = (
+        &'static mut MaybeUninit<VirtualSpiMasterDevice<'static, S>>,
+        &'static mut MaybeUninit<FM25CL<'static, VirtualSpiMasterDevice<'static, S>>>,
+        &'static mut MaybeUninit<[u8; capsules::fm25cl::BUF_LEN]>,
+        &'static mut MaybeUninit<[u8; capsules::fm25cl::BUF_LEN]>,
+    );
+    type Output = &'static FM25CL<'static, VirtualSpiMasterDevice<'static, S>>;
+
+    unsafe fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
+        let spi_device = static_buffer
+            .0
+            .write(VirtualSpiMasterDevice::new(self.spi_mux, self.chip_select));
+        spi_device.setup();
+
+        let txbuffer = static_buffer.2.write([0; capsules::fm25cl::BUF_LEN]);
+        let rxbuffer = static_buffer.3.write([0; capsules::fm25cl::BUF_LEN]);
+
+        let fm25cl = static_buffer
+            .1
+            .write(FM25CL::new(spi_device, txbuffer, rxbuffer));
+        spi_device.set_client(fm25cl);
+
+        fm25cl
+    }
+}

--- a/boards/components/src/isl29035.rs
+++ b/boards/components/src/isl29035.rs
@@ -41,7 +41,10 @@ macro_rules! isl29035_component_static {
         let i2c_device = kernel::static_buf!(capsules::virtual_i2c::I2CDevice<'static>);
         let i2c_buffer = kernel::static_buf!([u8; capsules::isl29035::BUF_LEN]);
         let isl29035 = kernel::static_buf!(
-            capsules::isl29035::Isl29035<'static, VirtualMuxAlarm<'static, $A>>
+            capsules::isl29035::Isl29035<
+                'static,
+                capsules::virtual_alarm::VirtualMuxAlarm<'static, $A>,
+            >
         );
 
         (alarm, i2c_device, i2c_buffer, isl29035)

--- a/boards/components/src/lib.rs
+++ b/boards/components/src/lib.rs
@@ -50,6 +50,7 @@ pub mod nrf51822;
 pub mod panic_button;
 pub mod process_console;
 pub mod process_printer;
+pub mod proximity;
 pub mod rf233;
 pub mod rng;
 pub mod sched;

--- a/boards/components/src/lib.rs
+++ b/boards/components/src/lib.rs
@@ -16,6 +16,7 @@ pub mod cdc;
 pub mod console;
 pub mod crc;
 pub mod ctap;
+pub mod dac;
 pub mod debug_queue;
 pub mod debug_writer;
 pub mod digest;

--- a/boards/components/src/lib.rs
+++ b/boards/components/src/lib.rs
@@ -20,6 +20,7 @@ pub mod debug_queue;
 pub mod debug_writer;
 pub mod digest;
 pub mod flash;
+pub mod fm25cl;
 pub mod ft6x06;
 pub mod fxos8700;
 pub mod gpio;

--- a/boards/components/src/lib.rs
+++ b/boards/components/src/lib.rs
@@ -5,6 +5,7 @@ pub mod adc_microphone;
 pub mod air_quality;
 pub mod alarm;
 pub mod analog_comparator;
+pub mod apds9960;
 pub mod app_flash_driver;
 pub mod bme280;
 pub mod bmp280;

--- a/boards/components/src/lib.rs
+++ b/boards/components/src/lib.rs
@@ -37,6 +37,7 @@ pub mod led;
 pub mod led_matrix;
 pub mod lldb;
 pub mod lpm013m126;
+pub mod lps25hb;
 pub mod lsm303agr;
 pub mod lsm303dlhc;
 pub mod lsm6dsox;

--- a/boards/components/src/lib.rs
+++ b/boards/components/src/lib.rs
@@ -41,6 +41,7 @@ pub mod lps25hb;
 pub mod lsm303agr;
 pub mod lsm303dlhc;
 pub mod lsm6dsox;
+pub mod ltc294x;
 pub mod mlx90614;
 pub mod mx25r6435f;
 pub mod ninedof;

--- a/boards/components/src/lps25hb.rs
+++ b/boards/components/src/lps25hb.rs
@@ -1,0 +1,71 @@
+//! Component for LPS25HB pressure sensor.
+
+use capsules::lps25hb::LPS25HB;
+use capsules::virtual_i2c::{I2CDevice, MuxI2C};
+use core::mem::MaybeUninit;
+use kernel::capabilities;
+use kernel::component::Component;
+use kernel::create_capability;
+use kernel::hil::gpio;
+
+#[macro_export]
+macro_rules! lps25hb_component_static {
+    () => {{
+        let i2c_device = kernel::static_buf!(capsules::virtual_i2c::I2CDevice<'static>);
+        let lps25hb = kernel::static_buf!(capsules::lps25hb::LPS25HB<'static>);
+        let buffer = kernel::static_buf!([u8; capsules::lps25hb::BUF_LEN]);
+
+        (i2c_device, lps25hb, buffer)
+    };};
+}
+
+pub struct Lps25hbComponent {
+    i2c_mux: &'static MuxI2C<'static>,
+    i2c_address: u8,
+    interrupt_pin: &'static dyn gpio::InterruptPin<'static>,
+    board_kernel: &'static kernel::Kernel,
+    driver_num: usize,
+}
+
+impl Lps25hbComponent {
+    pub fn new(
+        i2c_mux: &'static MuxI2C<'static>,
+        i2c_address: u8,
+        interrupt_pin: &'static dyn gpio::InterruptPin<'static>,
+        board_kernel: &'static kernel::Kernel,
+        driver_num: usize,
+    ) -> Self {
+        Lps25hbComponent {
+            i2c_mux,
+            i2c_address,
+            interrupt_pin,
+            board_kernel,
+            driver_num,
+        }
+    }
+}
+
+impl Component for Lps25hbComponent {
+    type StaticInput = (
+        &'static mut MaybeUninit<I2CDevice<'static>>,
+        &'static mut MaybeUninit<LPS25HB<'static>>,
+        &'static mut MaybeUninit<[u8; capsules::lps25hb::BUF_LEN]>,
+    );
+    type Output = &'static LPS25HB<'static>;
+
+    unsafe fn finalize(self, s: Self::StaticInput) -> Self::Output {
+        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
+        let grant = self.board_kernel.create_grant(self.driver_num, &grant_cap);
+
+        let lps25hb_i2c = s.0.write(I2CDevice::new(self.i2c_mux, self.i2c_address));
+
+        let buffer = s.2.write([0; capsules::lps25hb::BUF_LEN]);
+
+        let lps25hb =
+            s.1.write(LPS25HB::new(lps25hb_i2c, self.interrupt_pin, buffer, grant));
+        lps25hb_i2c.set_client(lps25hb);
+        self.interrupt_pin.set_client(lps25hb);
+
+        lps25hb
+    }
+}

--- a/boards/components/src/ltc294x.rs
+++ b/boards/components/src/ltc294x.rs
@@ -1,0 +1,117 @@
+//! Component for LPS25HB pressure sensor.
+//!
+//! Usage
+//! -----
+//!
+//! ```rust
+//! let ltc294x = components::Ltc294xComponent::new(i2c_mux, 0x64, None)
+//!     .finalize(components::ltc294x_component_static!());
+//! let ltc294x_driver = components::Ltc294xDriverComponent::new(ltc294x, board_kernel, DRIVER_NUM)
+//!     .finalize(components::ltc294x_driver_component_static!());
+//! ```
+
+use capsules::ltc294x::LTC294XDriver;
+use capsules::ltc294x::LTC294X;
+use capsules::virtual_i2c::{I2CDevice, MuxI2C};
+use core::mem::MaybeUninit;
+use kernel::capabilities;
+use kernel::component::Component;
+use kernel::create_capability;
+use kernel::hil::gpio;
+
+#[macro_export]
+macro_rules! ltc294x_component_static {
+    () => {{
+        let i2c_device = kernel::static_buf!(capsules::virtual_i2c::I2CDevice<'static>);
+        let ltc294x = kernel::static_buf!(capsules::ltc294x::LTC294X<'static>);
+        let buffer = kernel::static_buf!([u8; capsules::ltc294x::BUF_LEN]);
+
+        (i2c_device, ltc294x, buffer)
+    };};
+}
+
+#[macro_export]
+macro_rules! ltc294x_driver_component_static {
+    () => {{
+        kernel::static_buf!(capsules::ltc294x::LTC294XDriver<'static>)
+    };};
+}
+
+pub struct Ltc294xComponent {
+    i2c_mux: &'static MuxI2C<'static>,
+    i2c_address: u8,
+    interrupt_pin: Option<&'static dyn gpio::InterruptPin<'static>>,
+}
+
+impl Ltc294xComponent {
+    pub fn new(
+        i2c_mux: &'static MuxI2C<'static>,
+        i2c_address: u8,
+        interrupt_pin: Option<&'static dyn gpio::InterruptPin<'static>>,
+    ) -> Self {
+        Ltc294xComponent {
+            i2c_mux,
+            i2c_address,
+            interrupt_pin,
+        }
+    }
+}
+
+impl Component for Ltc294xComponent {
+    type StaticInput = (
+        &'static mut MaybeUninit<I2CDevice<'static>>,
+        &'static mut MaybeUninit<LTC294X<'static>>,
+        &'static mut MaybeUninit<[u8; capsules::ltc294x::BUF_LEN]>,
+    );
+    type Output = &'static LTC294X<'static>;
+
+    unsafe fn finalize(self, s: Self::StaticInput) -> Self::Output {
+        let ltc294x_i2c = s.0.write(I2CDevice::new(self.i2c_mux, self.i2c_address));
+
+        let buffer = s.2.write([0; capsules::ltc294x::BUF_LEN]);
+
+        let ltc294x =
+            s.1.write(LTC294X::new(ltc294x_i2c, self.interrupt_pin, buffer));
+        ltc294x_i2c.set_client(ltc294x);
+        self.interrupt_pin.map(|pin| {
+            pin.set_client(ltc294x);
+        });
+
+        ltc294x
+    }
+}
+
+pub struct Ltc294xDriverComponent {
+    ltc294x: &'static LTC294X<'static>,
+    board_kernel: &'static kernel::Kernel,
+    driver_num: usize,
+}
+
+impl Ltc294xDriverComponent {
+    pub fn new(
+        ltc294x: &'static LTC294X<'static>,
+        board_kernel: &'static kernel::Kernel,
+        driver_num: usize,
+    ) -> Self {
+        Ltc294xDriverComponent {
+            ltc294x,
+            board_kernel,
+            driver_num,
+        }
+    }
+}
+
+impl Component for Ltc294xDriverComponent {
+    type StaticInput = &'static mut MaybeUninit<LTC294XDriver<'static>>;
+    type Output = &'static LTC294XDriver<'static>;
+
+    unsafe fn finalize(self, s: Self::StaticInput) -> Self::Output {
+        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
+        let grant = self.board_kernel.create_grant(self.driver_num, &grant_cap);
+
+        let ltc294x_driver = s.write(LTC294XDriver::new(self.ltc294x, grant));
+        self.ltc294x.set_client(ltc294x_driver);
+
+        ltc294x_driver
+    }
+}

--- a/boards/components/src/proximity.rs
+++ b/boards/components/src/proximity.rs
@@ -1,0 +1,57 @@
+//! Component for any proximity sensor.
+//!
+//! Usage
+//! -----
+//! ```rust
+//! let proximity = ProximityComponent::new(apds9960, board_kernel, capsules::proximity::DRIVER_NUM)
+//!     .finalize(components::proximity_component_static!());
+//! ```
+
+use capsules::proximity::ProximitySensor;
+use core::mem::MaybeUninit;
+use kernel::capabilities;
+use kernel::component::Component;
+use kernel::create_capability;
+use kernel::hil;
+
+#[macro_export]
+macro_rules! proximity_component_static {
+    () => {{
+        kernel::static_buf!(capsules::proximity::ProximitySensor<'static>)
+    };};
+}
+
+pub struct ProximityComponent<P: hil::sensors::ProximityDriver<'static> + 'static> {
+    sensor: &'static P,
+    board_kernel: &'static kernel::Kernel,
+    driver_num: usize,
+}
+
+impl<P: hil::sensors::ProximityDriver<'static>> ProximityComponent<P> {
+    pub fn new(
+        sensor: &'static P,
+        board_kernel: &'static kernel::Kernel,
+        driver_num: usize,
+    ) -> ProximityComponent<P> {
+        ProximityComponent {
+            board_kernel,
+            driver_num,
+            sensor,
+        }
+    }
+}
+
+impl<P: hil::sensors::ProximityDriver<'static>> Component for ProximityComponent<P> {
+    type StaticInput = &'static mut MaybeUninit<ProximitySensor<'static>>;
+    type Output = &'static ProximitySensor<'static>;
+
+    unsafe fn finalize(self, s: Self::StaticInput) -> Self::Output {
+        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
+        let grant = self.board_kernel.create_grant(self.driver_num, &grant_cap);
+
+        let proximity = s.write(ProximitySensor::new(self.sensor, grant));
+
+        hil::sensors::ProximityDriver::set_client(self.sensor, proximity);
+        proximity
+    }
+}

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -331,11 +331,9 @@ pub unsafe fn main() {
     )
     .finalize(components::nrf51822_component_static!());
 
-    let sensors_i2c = static_init!(
-        MuxI2C<'static>,
-        MuxI2C::new(&peripherals.i2c1, None, dynamic_deferred_caller)
-    );
-    peripherals.i2c1.set_master_client(sensors_i2c);
+    let sensors_i2c =
+        components::i2c::I2CMuxComponent::new(&peripherals.i2c1, None, dynamic_deferred_caller)
+            .finalize(components::i2c_mux_component_static!());
 
     // SI7021 Temperature / Humidity Sensor, address: 0x40
     let si7021 = components::si7021::SI7021Component::new(sensors_i2c, mux_alarm, 0x40)
@@ -486,10 +484,8 @@ pub unsafe fn main() {
     .finalize(components::crc_component_static!(sam4l::crccu::Crccu));
 
     // DAC
-    let dac = static_init!(
-        capsules::dac::Dac<'static>,
-        capsules::dac::Dac::new(&peripherals.dac)
-    );
+    let dac = components::dac::DacComponent::new(&peripherals.dac)
+        .finalize(components::dac_component_static!());
 
     // // DEBUG Restart All Apps
     // //

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -9,14 +9,10 @@
 #![cfg_attr(not(doc), no_main)]
 #![deny(missing_docs)]
 
-use capsules::virtual_alarm::VirtualMuxAlarm;
-use capsules::virtual_i2c::MuxI2C;
-use capsules::virtual_spi::VirtualSpiMasterDevice;
 use kernel::capabilities;
 use kernel::component::Component;
 use kernel::dynamic_deferred_call::{DynamicDeferredCall, DynamicDeferredCallClientState};
 use kernel::hil;
-use kernel::hil::i2c::I2CMaster;
 use kernel::hil::led::LedLow;
 use kernel::hil::Controller;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
@@ -57,7 +53,7 @@ struct Hail {
     gpio: &'static capsules::gpio::GPIO<'static, sam4l::gpio::GPIOPin<'static>>,
     alarm: &'static capsules::alarm::AlarmDriver<
         'static,
-        VirtualMuxAlarm<'static, sam4l::ast::Ast<'static>>,
+        capsules::virtual_alarm::VirtualMuxAlarm<'static, sam4l::ast::Ast<'static>>,
     >,
     ambient_light: &'static capsules::ambient_light::AmbientLight<'static>,
     temp: &'static capsules::temperature::TemperatureSensor<'static>,
@@ -65,7 +61,7 @@ struct Hail {
     humidity: &'static capsules::humidity::HumiditySensor<'static>,
     spi: &'static capsules::spi_controller::Spi<
         'static,
-        VirtualSpiMasterDevice<'static, sam4l::spi::SpiHw>,
+        capsules::virtual_spi::VirtualSpiMasterDevice<'static, sam4l::spi::SpiHw>,
     >,
     nrf51822: &'static capsules::nrf51822_serialization::Nrf51822Serialization<'static>,
     adc: &'static capsules::adc::AdcDedicated<'static, sam4l::adc::Adc>,

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -488,18 +488,12 @@ pub unsafe fn main() {
         &nrf52840_peripherals.gpio_port[APDS9960_PIN],
     )
     .finalize(components::apds9960_component_static!());
-
-    let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
-
-    let proximity = static_init!(
-        capsules::proximity::ProximitySensor<'static>,
-        capsules::proximity::ProximitySensor::new(
-            apds9960,
-            board_kernel.create_grant(capsules::proximity::DRIVER_NUM, &grant_cap)
-        )
-    );
-
-    kernel::hil::sensors::ProximityDriver::set_client(apds9960, proximity);
+    let proximity = components::proximity::ProximityComponent::new(
+        apds9960,
+        board_kernel,
+        capsules::proximity::DRIVER_NUM,
+    )
+    .finalize(components::proximity_component_static!());
 
     let hts221 = components::hts221::Hts221Component::new(sensors_i2c_bus, 0x5f)
         .finalize(components::hts221_component_static!());

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -12,7 +12,6 @@ use kernel::capabilities;
 use kernel::component::Component;
 use kernel::dynamic_deferred_call::{DynamicDeferredCall, DynamicDeferredCallClientState};
 use kernel::hil::gpio::Configure;
-use kernel::hil::gpio::Interrupt;
 use kernel::hil::gpio::Output;
 use kernel::hil::led::LedLow;
 use kernel::hil::time::Counter;
@@ -483,21 +482,12 @@ pub unsafe fn main() {
     let _ = &nrf52840_peripherals.gpio_port[I2C_PULLUP_PIN].make_output();
     let _ = &nrf52840_peripherals.gpio_port[I2C_PULLUP_PIN].set();
 
-    let apds9960_i2c = static_init!(
-        capsules::virtual_i2c::I2CDevice,
-        capsules::virtual_i2c::I2CDevice::new(sensors_i2c_bus, 0x39)
-    );
-
-    let apds9960 = static_init!(
-        capsules::apds9960::APDS9960<'static>,
-        capsules::apds9960::APDS9960::new(
-            apds9960_i2c,
-            &nrf52840_peripherals.gpio_port[APDS9960_PIN],
-            &mut capsules::apds9960::BUFFER
-        )
-    );
-    apds9960_i2c.set_client(apds9960);
-    nrf52840_peripherals.gpio_port[APDS9960_PIN].set_client(apds9960);
+    let apds9960 = components::apds9960::Apds9960Component::new(
+        sensors_i2c_bus,
+        0x39,
+        &nrf52840_peripherals.gpio_port[APDS9960_PIN],
+    )
+    .finalize(components::apds9960_component_static!());
 
     let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
 

--- a/capsules/src/apds9960.rs
+++ b/capsules/src/apds9960.rs
@@ -1,43 +1,42 @@
-//! Proximity SyscallDriver for the Adafruit APDS9960 gesture/ambient light/proximity sensor.
+//! Proximity SyscallDriver for the Adafruit APDS9960 gesture/ambient
+//! light/proximity sensor.
 //!
-//! <https://content.arduino.cc/assets/Nano_BLE_Sense_av02-4191en_ds_apds-9960.pdf>   <-- Datasheet
+//! Datasheet:
+//! <https://content.arduino.cc/assets/Nano_BLE_Sense_av02-4191en_ds_apds-9960.pdf>
 //!
-//! > The APDS-9960 device features advanced Gesture detection, Proximity detection, Digital Ambient Light Sense
-//! > (ALS) and Color Sense (RGBC). The slim modular package,
-//! > L 3.94 x W 2.36 x H 1.35 mm, incorporates an IR LED and
-//! > factory calibrated LED driver for drop-in compatibility
-//! > with existing footprints
+//! > The APDS-9960 device features advanced Gesture detection, Proximity
+//! > detection, Digital Ambient Light Sense (ALS) and Color Sense (RGBC). The
+//! > slim modular package, L 3.94 x W 2.36 x H 1.35 mm, incorporates an IR LED
+//! > and factory calibrated LED driver for drop-in compatibility with existing
+//! > footprints
 //!
 //! Usage
 //! -----
 //!
 //! ```rust
-//! # use kernel::static_init;
-//!
 //! let apds9960_i2c = static_init!(
 //!    capsules::virtual_i2c::I2CDevice,
 //!    capsules::virtual_i2c::I2CDevice::new(sensors_i2c_bus, 0x39)
-//!);
+//! );
 //!
-//!let apds9960 = static_init!(
+//! let apds9960 = static_init!(
 //!    capsules::apds9960::APDS9960<'static>,
 //!    capsules::apds9960::APDS9960::new(
 //!        apds9960_i2c,
 //!        &nrf52840::gpio::PORT[APDS9960_PIN],
 //!        &mut capsules::apds9960::BUFFER
 //!    )
-//!);
-//!apds9960_i2c.set_client(apds9960);
-//!nrf52840::gpio::PORT[APDS9960_PIN].set_client(apds9960);
-
-//!let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
+//! );
+//! apds9960_i2c.set_client(apds9960);
+//! nrf52840::gpio::PORT[APDS9960_PIN].set_client(apds9960);
 //!
-//!let proximity = static_init!(
+//! let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
+//!
+//! let proximity = static_init!(
 //!    capsules::proximity::ProximitySensor<'static>,
 //!    capsules::proximity::ProximitySensor::new(apds9960 , board_kernel.create_grant(&grant_cap)));
-
-//!kernel::hil::sensors::ProximityDriver::set_client(apds9960, proximity);
 //!
+//! kernel::hil::sensors::ProximityDriver::set_client(apds9960, proximity);
 //! ```
 
 use core::cell::Cell;
@@ -47,7 +46,7 @@ use kernel::utilities::cells::{OptionalCell, TakeCell};
 use kernel::ErrorCode;
 
 // I2C Buffer of 16 bytes
-pub static mut BUFFER: [u8; 16] = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 175];
+pub const BUF_LEN: usize = 16;
 
 // BUFFER Layout:  [0,...  ,   12                            , 13               ,                   14                ,   15]
 //                             ^take_meas() callback stored    ^take_meas_int callback stored       ^low thresh           ^high thresh

--- a/capsules/src/fm25cl.rs
+++ b/capsules/src/fm25cl.rs
@@ -46,11 +46,7 @@ use kernel::hil;
 use kernel::utilities::cells::{OptionalCell, TakeCell};
 use kernel::ErrorCode;
 
-pub static mut TXBUFFER: [u8; 512] = [0; 512];
-pub static mut RXBUFFER: [u8; 512] = [0; 512];
-
-pub static mut KERNEL_TXBUFFER: [u8; 512] = [0; 512];
-pub static mut KERNEL_RXBUFFER: [u8; 512] = [0; 512];
+pub const BUF_LEN: usize = 512;
 
 const SPI_SPEED: u32 = 4000000;
 

--- a/capsules/src/lps25hb.rs
+++ b/capsules/src/lps25hb.rs
@@ -6,14 +6,13 @@
 //! -----
 //!
 //! ```rust
-//! # use kernel::static_init;
-//!
+//! let buffer = static_init!([u8; capsules::lps25hb::BUF_LEN], [0; capsules::lps25hb::BUF_LEN]);
 //! let lps25hb_i2c = static_init!(I2CDevice, I2CDevice::new(i2c_bus, 0x5C));
 //! let lps25hb = static_init!(
 //!     capsules::lps25hb::LPS25HB<'static>,
 //!     capsules::lps25hb::LPS25HB::new(lps25hb_i2c,
 //!         &sam4l::gpio::PA[10],
-//!         &mut capsules::lps25hb::BUFFER));
+//!         buffer));
 //! lps25hb_i2c.set_client(lps25hb);
 //! sam4l::gpio::PA[10].set_client(lps25hb);
 //! ```
@@ -32,8 +31,8 @@ use kernel::{ErrorCode, ProcessId};
 use crate::driver;
 pub const DRIVER_NUM: usize = driver::NUM::Lps25hb as usize;
 
-// Buffer to use for I2C messages
-pub static mut BUFFER: [u8; 5] = [0; 5];
+// Expected buffer length.
+pub const BUF_LEN: usize = 5;
 
 /// Register values
 const REGISTER_AUTO_INCREMENT: u8 = 0x80;

--- a/capsules/src/ltc294x.rs
+++ b/capsules/src/ltc294x.rs
@@ -29,12 +29,13 @@
 //! ```rust
 //! # use kernel::static_init;
 //!
+//! let buffer = static_init!([u8; capsules::ltc294x::BUF_LEN], [0; capsules::ltc294x::BUF_LEN]);
 //! let ltc294x_i2c = static_init!(
 //!     capsules::virtual_i2c::I2CDevice,
 //!     capsules::virtual_i2c::I2CDevice::new(i2c_mux, 0x64));
 //! let ltc294x = static_init!(
 //!     capsules::ltc294x::LTC294X<'static>,
-//!     capsules::ltc294x::LTC294X::new(ltc294x_i2c, None, &mut capsules::ltc294x::BUFFER));
+//!     capsules::ltc294x::LTC294X::new(ltc294x_i2c, None, buffer));
 //! ltc294x_i2c.set_client(ltc294x);
 //!
 //! // Optionally create the object that provides an interface for the coulomb
@@ -58,7 +59,7 @@ use kernel::{ErrorCode, ProcessId};
 use crate::driver;
 pub const DRIVER_NUM: usize = driver::NUM::Ltc294x as usize;
 
-pub static mut BUFFER: [u8; 20] = [0; 20];
+pub const BUF_LEN: usize = 20;
 
 #[allow(dead_code)]
 enum Registers {


### PR DESCRIPTION
### Pull Request Overview

This pull request adds several components for two reasons:

- To remove `static_init!()` from hail and nano33 boards.
- To remove some `static mut` from the capsules crate.


### Testing Strategy

travis


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
