### PR TITLE
ADC: Add set_client() to AdcHighSpeed trait (take #2)

### DIFF
--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -451,7 +451,7 @@ pub unsafe fn main() {
         )
     );
     hil::adc::Adc::set_client(&peripherals.adc, adc);
-    hil::adc::AdcHighSpeed::set_client(&peripherals.adc, adc);
+    hil::adc::AdcHighSpeed::set_highspeed_client(&peripherals.adc, adc);
 
     // Setup RNG
     let rng = components::rng::RngComponent::new(

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -450,6 +450,7 @@ pub unsafe fn main() {
             &mut capsules::adc::ADC_BUFFER3
         )
     );
+    hil::adc::Adc::set_client(&peripherals.adc, adc);
     hil::adc::AdcHighSpeed::set_client(&peripherals.adc, adc);
 
     // Setup RNG

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -450,7 +450,7 @@ pub unsafe fn main() {
             &mut capsules::adc::ADC_BUFFER3
         )
     );
-    peripherals.adc.set_client(adc);
+    hil::adc::AdcHighSpeed::set_client(&peripherals.adc, adc);
 
     // Setup RNG
     let rng = components::rng::RngComponent::new(

--- a/boards/imix/src/imix_components/adc.rs
+++ b/boards/imix/src/imix_components/adc.rs
@@ -85,7 +85,7 @@ impl Component for AdcComponent {
             )
         );
         hil::adc::Adc::set_client(self.adc, adc);
-        hil::adc::AdcHighSpeed::set_client(self.adc, adc);
+        hil::adc::AdcHighSpeed::set_highspeed_client(self.adc, adc);
 
         adc
     }

--- a/boards/imix/src/imix_components/adc.rs
+++ b/boards/imix/src/imix_components/adc.rs
@@ -84,6 +84,7 @@ impl Component for AdcComponent {
                 &mut adc::ADC_BUFFER3
             )
         );
+        hil::adc::Adc::set_client(self.adc, adc);
         hil::adc::AdcHighSpeed::set_client(self.adc, adc);
 
         adc

--- a/boards/imix/src/imix_components/adc.rs
+++ b/boards/imix/src/imix_components/adc.rs
@@ -19,6 +19,7 @@ use capsules::adc;
 use kernel::capabilities;
 use kernel::component::Component;
 use kernel::create_capability;
+use kernel::hil;
 use kernel::static_init;
 use sam4l::adc::Channel;
 
@@ -83,7 +84,7 @@ impl Component for AdcComponent {
                 &mut adc::ADC_BUFFER3
             )
         );
-        self.adc.set_client(adc);
+        hil::adc::AdcHighSpeed::set_client(self.adc, adc);
 
         adc
     }

--- a/boards/msp_exp432p401r/src/main.rs
+++ b/boards/msp_exp432p401r/src/main.rs
@@ -13,6 +13,7 @@ use kernel::capabilities;
 use kernel::component::Component;
 use kernel::dynamic_deferred_call::DynamicDeferredCall;
 use kernel::dynamic_deferred_call::DynamicDeferredCallClientState;
+use kernel::hil;
 use kernel::hil::gpio::Configure;
 use kernel::platform::{KernelResources, SyscallDriverLookup};
 use kernel::scheduler::round_robin::RoundRobinSched;
@@ -413,8 +414,7 @@ pub unsafe fn main() {
             &mut capsules::adc::ADC_BUFFER3
         )
     );
-
-    peripherals.adc.set_client(adc);
+    hil::adc::AdcHighSpeed::set_client(&peripherals.adc, adc);
 
     // Set the reference voltage for the ADC to 2.5V
     peripherals

--- a/boards/msp_exp432p401r/src/main.rs
+++ b/boards/msp_exp432p401r/src/main.rs
@@ -415,7 +415,7 @@ pub unsafe fn main() {
         )
     );
     hil::adc::Adc::set_client(&peripherals.adc, adc);
-    hil::adc::AdcHighSpeed::set_client(&peripherals.adc, adc);
+    hil::adc::AdcHighSpeed::set_highspeed_client(&peripherals.adc, adc);
 
     // Set the reference voltage for the ADC to 2.5V
     peripherals

--- a/boards/msp_exp432p401r/src/main.rs
+++ b/boards/msp_exp432p401r/src/main.rs
@@ -414,6 +414,7 @@ pub unsafe fn main() {
             &mut capsules::adc::ADC_BUFFER3
         )
     );
+    hil::adc::Adc::set_client(&peripherals.adc, adc);
     hil::adc::AdcHighSpeed::set_client(&peripherals.adc, adc);
 
     // Set the reference voltage for the ADC to 2.5V

--- a/chips/msp432/src/adc.rs
+++ b/chips/msp432/src/adc.rs
@@ -990,7 +990,7 @@ impl hil::adc::AdcHighSpeed for Adc<'_> {
         }
     }
 
-    fn set_client(&self, client: &'static dyn hil::adc::HighSpeedClient) {
+    fn set_highspeed_client(&self, client: &'static dyn hil::adc::HighSpeedClient) {
         self.highspeed_client.set(client);
     }
 }

--- a/chips/msp432/src/adc.rs
+++ b/chips/msp432/src/adc.rs
@@ -486,11 +486,6 @@ register_bitfields![u32,
     ]
 ];
 
-/// Create a trait of both client types to allow a single client reference to
-/// act as both
-pub trait EverythingClient: hil::adc::Client + hil::adc::HighSpeedClient {}
-impl<C: hil::adc::Client + hil::adc::HighSpeedClient> EverythingClient for C {}
-
 pub struct Adc<'a> {
     registers: StaticRef<AdcRegisters>,
     resolution: AdcResolution,
@@ -503,7 +498,7 @@ pub struct Adc<'a> {
     dma_src: u8,
     buffer1: TakeCell<'static, [u16]>,
     buffer2: TakeCell<'static, [u16]>,
-    client: OptionalCell<&'static dyn EverythingClient>,
+    client: OptionalCell<&'static dyn hil::adc::HighSpeedClient>,
 }
 
 impl Adc<'_> {
@@ -710,10 +705,6 @@ impl<'a> Adc<'a> {
         self.ref_module.set(ref_module);
         self.timer.set(timer);
         self.dma.set(dma);
-    }
-
-    pub fn set_client(&self, client: &'static dyn EverythingClient) {
-        self.client.set(client);
     }
 
     pub fn handle_interrupt(&self) {
@@ -996,5 +987,9 @@ impl hil::adc::AdcHighSpeed for Adc<'_> {
         } else {
             Ok((self.buffer1.take(), self.buffer2.take()))
         }
+    }
+
+    fn set_client(&self, client: &'static dyn hil::adc::HighSpeedClient) {
+        self.client.set(client);
     }
 }

--- a/chips/sam4l/src/adc.rs
+++ b/chips/sam4l/src/adc.rs
@@ -965,7 +965,7 @@ impl hil::adc::AdcHighSpeed for Adc {
         }
     }
 
-    fn set_client(&self, client: &'static dyn hil::adc::HighSpeedClient) {
+    fn set_highspeed_client(&self, client: &'static dyn hil::adc::HighSpeedClient) {
         self.highspeed_client.set(client);
     }
 }

--- a/chips/stm32f303xc/src/adc.rs
+++ b/chips/stm32f303xc/src/adc.rs
@@ -10,9 +10,6 @@ use kernel::utilities::registers::{register_bitfields, ReadOnly, ReadWrite};
 use kernel::utilities::StaticRef;
 use kernel::ErrorCode;
 
-pub trait EverythingClient: hil::adc::Client + hil::adc::HighSpeedClient {}
-impl<C: hil::adc::Client + hil::adc::HighSpeedClient> EverythingClient for C {}
-
 #[repr(C)]
 struct AdcRegisters {
     isr: ReadWrite<u32, ISR::Register>,
@@ -774,4 +771,6 @@ impl hil::adc::AdcHighSpeed for Adc<'_> {
     ) -> Result<(Option<&'static mut [u16]>, Option<&'static mut [u16]>), ErrorCode> {
         Err(ErrorCode::NOSUPPORT)
     }
+
+    fn set_client(&self, _client: &'static dyn hil::adc::HighSpeedClient) {}
 }

--- a/chips/stm32f303xc/src/adc.rs
+++ b/chips/stm32f303xc/src/adc.rs
@@ -772,5 +772,5 @@ impl hil::adc::AdcHighSpeed for Adc<'_> {
         Err(ErrorCode::NOSUPPORT)
     }
 
-    fn set_client(&self, _client: &'static dyn hil::adc::HighSpeedClient) {}
+    fn set_highspeed_client(&self, _client: &'static dyn hil::adc::HighSpeedClient) {}
 }

--- a/chips/stm32f4xx/src/adc.rs
+++ b/chips/stm32f4xx/src/adc.rs
@@ -8,9 +8,6 @@ use kernel::utilities::registers::{register_bitfields, ReadOnly, ReadWrite};
 use kernel::utilities::StaticRef;
 use kernel::ErrorCode;
 
-pub trait EverythingClient: hil::adc::Client + hil::adc::HighSpeedClient {}
-impl<C: hil::adc::Client + hil::adc::HighSpeedClient> EverythingClient for C {}
-
 #[repr(C)]
 struct AdcRegisters {
     sr: ReadWrite<u32, SR::Register>,
@@ -478,4 +475,6 @@ impl hil::adc::AdcHighSpeed for Adc<'_> {
     ) -> Result<(Option<&'static mut [u16]>, Option<&'static mut [u16]>), ErrorCode> {
         Err(ErrorCode::NOSUPPORT)
     }
+
+    fn set_client(&self, _client: &'static dyn hil::adc::HighSpeedClient) {}
 }

--- a/chips/stm32f4xx/src/adc.rs
+++ b/chips/stm32f4xx/src/adc.rs
@@ -476,5 +476,5 @@ impl hil::adc::AdcHighSpeed for Adc<'_> {
         Err(ErrorCode::NOSUPPORT)
     }
 
-    fn set_client(&self, _client: &'static dyn hil::adc::HighSpeedClient) {}
+    fn set_highspeed_client(&self, _client: &'static dyn hil::adc::HighSpeedClient) {}
 }

--- a/doc/reference/trd102-adc.md
+++ b/doc/reference/trd102-adc.md
@@ -195,7 +195,7 @@ pub trait AdcHighSpeed: Adc {
                         -> (Result<(), ErrorCode>, Option<&'static mut [u16]>,
                             Option<&'static mut [u16]>);
 
-    fn set_client(&self, client: &'static dyn HighSpeedClient);
+    fn set_highspeed_client(&self, client: &'static dyn HighSpeedClient);
 }
 ```
 

--- a/doc/reference/trd102-adc.md
+++ b/doc/reference/trd102-adc.md
@@ -73,6 +73,8 @@ pub trait Adc {
     /// Can be used to stop any simple or high-speed sampling operation. No
     /// further callbacks will occur.
     fn stop_sampling(&self) -> Result<(), ErrorCode>;
+
+    fn set_client(&self, client: &'static dyn Client);
 }
 ```
 
@@ -192,6 +194,8 @@ pub trait AdcHighSpeed: Adc {
     fn retrieve_buffers(&self)
                         -> (Result<(), ErrorCode>, Option<&'static mut [u16]>,
                             Option<&'static mut [u16]>);
+
+    fn set_client(&self, client: &'static dyn HighSpeedClient);
 }
 ```
 
@@ -317,19 +321,16 @@ pub static mut CHANNEL_AD1: AdcChannel = AdcChannel::new(Channel::AD1);
 pub static mut CHANNEL_REFERENCE_GROUND: AdcChannel = AdcChannel::new(Channel::ReferenceGround);
 ```
 
-6.2 Client Type
+6.2 Client Handling
 ---------------------------------
 
-It is difficult in Rust to require a argument that implements two types.
-However, it is convenient for the implementation to expect a single client that
-implements both the `adc::Client` and `adc::HighSpeedClient` interfaces. It is
-possible to do so by defining a new trait that requires each.
+As ADC functionality is split between two traits, there are two callback traits.
+ADC driver implementations that use both `Adc` and `AdcHighSpeed` need two
+clients, which must both be set:
 
 ```
-/// Create a trait of both client types to allow a single client reference to
-/// act as both
-pub trait EverythingClient: hil::adc::Client + hil::adc::HighSpeedClient {}
-impl<C: hil::adc::Client + hil::adc::HighSpeedClient> EverythingClient for C {}
+hil::adc::Adc::set_client(&peripherals.adc, adc);
+hil::adc::AdcHighSpeed::set_client(&peripherals.adc, adc);
 ```
 
 6.3 Clock Initialization

--- a/kernel/src/hil/adc.rs
+++ b/kernel/src/hil/adc.rs
@@ -98,7 +98,7 @@ pub trait AdcHighSpeed: Adc {
         &self,
     ) -> Result<(Option<&'static mut [u16]>, Option<&'static mut [u16]>), ErrorCode>;
 
-    fn set_client(&self, client: &'static dyn HighSpeedClient);
+    fn set_highspeed_client(&self, client: &'static dyn HighSpeedClient);
 }
 
 /// Trait for handling callbacks from high-speed ADC calls.

--- a/kernel/src/hil/adc.rs
+++ b/kernel/src/hil/adc.rs
@@ -97,6 +97,8 @@ pub trait AdcHighSpeed: Adc {
     fn retrieve_buffers(
         &self,
     ) -> Result<(Option<&'static mut [u16]>, Option<&'static mut [u16]>), ErrorCode>;
+
+    fn set_client(&self, client: &'static dyn HighSpeedClient);
 }
 
 /// Trait for handling callbacks from high-speed ADC calls.


### PR DESCRIPTION
### Pull Request Overview

This pull request is an alternative to #3279 and #3267.

This adds a set client function to the `AdcHighSpeed` trait, and then treats the high speed and regular traits separately, requiring implementations that want to use both to have two clients. The users of the drivers then need to set both clients.

This seems like the most direct approach. It simply implements what we do with all HILs, and is the same if a chip driver wanted to support, for example, both I2C and SPI: it implements both traits and has both clients.


### Testing Strategy

travis


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
