### PR TITLE
Rename appid and app_id to processid

### DIFF
--- a/arch/cortex-m/src/mpu.rs
+++ b/arch/cortex-m/src/mpu.rs
@@ -754,16 +754,16 @@ impl<const NUM_REGIONS: usize, const MIN_REGION_SIZE: usize> mpu::MPU
         Ok(())
     }
 
-    fn configure_mpu(&self, config: &Self::MpuConfig, app_id: &ProcessId) {
+    fn configure_mpu(&self, config: &Self::MpuConfig, processid: &ProcessId) {
         // If the hardware is already configured for this app and the app's MPU
         // configuration has not changed, then skip the hardware update.
-        if !self.hardware_is_configured_for.contains(app_id) || config.is_dirty.get() {
+        if !self.hardware_is_configured_for.contains(processid) || config.is_dirty.get() {
             // Set MPU regions
             for region in config.regions.iter() {
                 self.registers.rbar.write(region.base_address());
                 self.registers.rasr.write(region.attributes());
             }
-            self.hardware_is_configured_for.set(*app_id);
+            self.hardware_is_configured_for.set(*processid);
             config.is_dirty.set(false);
         }
     }

--- a/arch/rv32i/src/epmp.rs
+++ b/arch/rv32i/src/epmp.rs
@@ -741,11 +741,11 @@ impl<const MAX_AVAILABLE_REGIONS_OVER_TWO: usize> kernel::platform::mpu::MPU
         Ok(())
     }
 
-    fn configure_mpu(&self, config: &Self::MpuConfig, app_id: &ProcessId) {
+    fn configure_mpu(&self, config: &Self::MpuConfig, processid: &ProcessId) {
         // Is the PMP already configured for this app?
         let last_configured_for_this_app = self
             .last_configured_for
-            .map_or(false, |last_app_id| last_app_id == app_id);
+            .map_or(false, |last_processid| last_processid == processid);
 
         if !last_configured_for_this_app || config.is_dirty.get() {
             for (x, region) in config.regions.iter().enumerate() {
@@ -807,7 +807,7 @@ impl<const MAX_AVAILABLE_REGIONS_OVER_TWO: usize> kernel::platform::mpu::MPU
         }
 
         config.is_dirty.set(false);
-        self.last_configured_for.put(*app_id);
+        self.last_configured_for.put(*processid);
     }
 }
 

--- a/arch/rv32i/src/pmp.rs
+++ b/arch/rv32i/src/pmp.rs
@@ -507,11 +507,11 @@ impl<const MAX_AVAILABLE_REGIONS_OVER_TWO: usize> kernel::platform::mpu::MPU
         Ok(())
     }
 
-    fn configure_mpu(&self, config: &Self::MpuConfig, app_id: &ProcessId) {
+    fn configure_mpu(&self, config: &Self::MpuConfig, processid: &ProcessId) {
         // Is the PMP already configured for this app?
         let last_configured_for_this_app = self
             .last_configured_for
-            .map_or(false, |last_app_id| last_app_id == app_id);
+            .map_or(false, |last_processid| last_processid == processid);
 
         // Skip PMP configuration if it is already configured for this app and the MPU
         // configuration of this app has not changed.
@@ -545,7 +545,7 @@ impl<const MAX_AVAILABLE_REGIONS_OVER_TWO: usize> kernel::platform::mpu::MPU
                 };
             }
             config.is_dirty.set(false);
-            self.last_configured_for.put(*app_id);
+            self.last_configured_for.put(*processid);
         }
     }
 }

--- a/capsules/src/adc.rs
+++ b/capsules/src/adc.rs
@@ -88,7 +88,7 @@ pub struct AdcDedicated<'a, A: hil::adc::Adc + hil::adc::AdcHighSpeed> {
 
     // App state
     apps: Grant<App, UpcallCount<1>, AllowRoCount<0>, AllowRwCount<2>>,
-    appid: OptionalCell<ProcessId>,
+    processid: OptionalCell<ProcessId>,
     channel: Cell<usize>,
 
     // ADC buffers
@@ -179,7 +179,7 @@ impl<'a, A: hil::adc::Adc + hil::adc::AdcHighSpeed> AdcDedicated<'a, A> {
 
             // App state
             apps: grant,
-            appid: OptionalCell::empty(),
+            processid: OptionalCell::empty(),
             channel: Cell::new(0),
 
             // ADC buffers
@@ -332,7 +332,7 @@ impl<'a, A: hil::adc::Adc + hil::adc::AdcHighSpeed> AdcDedicated<'a, A> {
 
         // cannot sample a buffer without a buffer to sample into
         let mut app_buf_length = 0;
-        let exists = self.appid.map_or(false, |id| {
+        let exists = self.processid.map_or(false, |id| {
             self.apps
                 .enter(*id, |_, kernel_data| {
                     app_buf_length = kernel_data
@@ -345,7 +345,7 @@ impl<'a, A: hil::adc::Adc + hil::adc::AdcHighSpeed> AdcDedicated<'a, A> {
                     if err == kernel::process::Error::NoSuchApp
                         || err == kernel::process::Error::InactiveApp
                     {
-                        self.appid.clear();
+                        self.processid.clear();
                     }
                 })
                 .unwrap_or(false)
@@ -357,7 +357,7 @@ impl<'a, A: hil::adc::Adc + hil::adc::AdcHighSpeed> AdcDedicated<'a, A> {
         // save state for callback
         self.active.set(true);
         self.mode.set(AdcMode::SingleBuffer);
-        let ret = self.appid.map_or(Err(ErrorCode::NOMEM), |id| {
+        let ret = self.processid.map_or(Err(ErrorCode::NOMEM), |id| {
             self.apps
                 .enter(*id, |app, _| {
                     app.app_buf_offset.set(0);
@@ -405,7 +405,7 @@ impl<'a, A: hil::adc::Adc + hil::adc::AdcHighSpeed> AdcDedicated<'a, A> {
                     if err == kernel::process::Error::NoSuchApp
                         || err == kernel::process::Error::InactiveApp
                     {
-                        self.appid.clear();
+                        self.processid.clear();
                     }
                 })
                 .unwrap_or(Err(ErrorCode::NOMEM))
@@ -414,7 +414,7 @@ impl<'a, A: hil::adc::Adc + hil::adc::AdcHighSpeed> AdcDedicated<'a, A> {
             // failure, clear state
             self.active.set(false);
             self.mode.set(AdcMode::NoMode);
-            self.appid.map(|id| {
+            self.processid.map(|id| {
                 self.apps
                     .enter(*id, |app, _| {
                         app.samples_remaining.set(0);
@@ -424,7 +424,7 @@ impl<'a, A: hil::adc::Adc + hil::adc::AdcHighSpeed> AdcDedicated<'a, A> {
                         if err == kernel::process::Error::NoSuchApp
                             || err == kernel::process::Error::InactiveApp
                         {
-                            self.appid.clear();
+                            self.processid.clear();
                         }
                     })
             });
@@ -455,7 +455,7 @@ impl<'a, A: hil::adc::Adc + hil::adc::AdcHighSpeed> AdcDedicated<'a, A> {
         // cannot continuously sample without two buffers
         let mut app_buf_length = 0;
         let mut next_app_buf_length = 0;
-        let exists = self.appid.map_or(false, |id| {
+        let exists = self.processid.map_or(false, |id| {
             self.apps
                 .enter(*id, |_, kernel_data| {
                     app_buf_length = kernel_data
@@ -472,7 +472,7 @@ impl<'a, A: hil::adc::Adc + hil::adc::AdcHighSpeed> AdcDedicated<'a, A> {
                     if err == kernel::process::Error::NoSuchApp
                         || err == kernel::process::Error::InactiveApp
                     {
-                        self.appid.clear();
+                        self.processid.clear();
                     }
                 })
                 .unwrap_or(false)
@@ -485,7 +485,7 @@ impl<'a, A: hil::adc::Adc + hil::adc::AdcHighSpeed> AdcDedicated<'a, A> {
         self.active.set(true);
         self.mode.set(AdcMode::ContinuousBuffer);
 
-        let ret = self.appid.map_or(Err(ErrorCode::NOMEM), |id| {
+        let ret = self.processid.map_or(Err(ErrorCode::NOMEM), |id| {
             self.apps
                 .enter(*id, |app, _| {
                     app.app_buf_offset.set(0);
@@ -546,7 +546,7 @@ impl<'a, A: hil::adc::Adc + hil::adc::AdcHighSpeed> AdcDedicated<'a, A> {
                     if err == kernel::process::Error::NoSuchApp
                         || err == kernel::process::Error::InactiveApp
                     {
-                        self.appid.clear();
+                        self.processid.clear();
                     }
                 })
                 .unwrap_or(Err(ErrorCode::NOMEM))
@@ -555,7 +555,7 @@ impl<'a, A: hil::adc::Adc + hil::adc::AdcHighSpeed> AdcDedicated<'a, A> {
             // failure, clear state
             self.active.set(false);
             self.mode.set(AdcMode::NoMode);
-            self.appid.map(|id| {
+            self.processid.map(|id| {
                 self.apps
                     .enter(*id, |app, _| {
                         app.samples_remaining.set(0);
@@ -565,7 +565,7 @@ impl<'a, A: hil::adc::Adc + hil::adc::AdcHighSpeed> AdcDedicated<'a, A> {
                         if err == kernel::process::Error::NoSuchApp
                             || err == kernel::process::Error::InactiveApp
                         {
-                            self.appid.clear();
+                            self.processid.clear();
                         }
                     })
             });
@@ -584,7 +584,7 @@ impl<'a, A: hil::adc::Adc + hil::adc::AdcHighSpeed> AdcDedicated<'a, A> {
         }
 
         // clean up state
-        self.appid.map_or(Err(ErrorCode::FAIL), |id| {
+        self.processid.map_or(Err(ErrorCode::FAIL), |id| {
             self.apps
                 .enter(*id, |app, _| {
                     self.active.set(false);
@@ -615,7 +615,7 @@ impl<'a, A: hil::adc::Adc + hil::adc::AdcHighSpeed> AdcDedicated<'a, A> {
                     if err == kernel::process::Error::NoSuchApp
                         || err == kernel::process::Error::InactiveApp
                     {
-                        self.appid.clear();
+                        self.processid.clear();
                     }
                 })
                 .unwrap_or(Err(ErrorCode::FAIL))
@@ -652,13 +652,13 @@ impl<'a> AdcVirtualized<'a> {
         &self,
         command: Operation,
         channel: usize,
-        appid: ProcessId,
+        processid: ProcessId,
     ) -> Result<(), ErrorCode> {
         if channel < self.drivers.len() {
             self.apps
-                .enter(appid, |app, _| {
+                .enter(processid, |app, _| {
                     if self.current_app.is_none() {
-                        self.current_app.set(appid);
+                        self.current_app.set(processid);
                         let value = self.call_driver(command, channel);
                         if value != Ok(()) {
                             self.current_app.clear();
@@ -705,7 +705,7 @@ impl<A: hil::adc::Adc + hil::adc::AdcHighSpeed> hil::adc::Client for AdcDedicate
 
             // perform callback
 
-            self.appid.map(|id| {
+            self.processid.map(|id| {
                 self.apps
                     .enter(*id, |_app, upcalls| {
                         calledback = true;
@@ -724,7 +724,7 @@ impl<A: hil::adc::Adc + hil::adc::AdcHighSpeed> hil::adc::Client for AdcDedicate
                         if err == kernel::process::Error::NoSuchApp
                             || err == kernel::process::Error::InactiveApp
                         {
-                            self.appid.clear();
+                            self.processid.clear();
                         }
                     })
             });
@@ -732,7 +732,7 @@ impl<A: hil::adc::Adc + hil::adc::AdcHighSpeed> hil::adc::Client for AdcDedicate
             // sample ready in continuous sampling operation, keep state
 
             // perform callback
-            self.appid.map(|id| {
+            self.processid.map(|id| {
                 self.apps
                     .enter(*id, |_app, upcalls| {
                         calledback = true;
@@ -751,7 +751,7 @@ impl<A: hil::adc::Adc + hil::adc::AdcHighSpeed> hil::adc::Client for AdcDedicate
                         if err == kernel::process::Error::NoSuchApp
                             || err == kernel::process::Error::InactiveApp
                         {
-                            self.appid.clear();
+                            self.processid.clear();
                         }
                     })
             });
@@ -795,7 +795,7 @@ impl<A: hil::adc::Adc + hil::adc::AdcHighSpeed> hil::adc::HighSpeedClient for Ad
                 || self.mode.get() == AdcMode::ContinuousBuffer)
         {
             // we did expect a buffer. Determine the current application state
-            self.appid.map(|id| {
+            self.processid.map(|id| {
                 self.apps
                     .enter(*id, |app, kernel_data| {
                         // Get both buffers, this shouldn't ever fail since the grant was created
@@ -1056,7 +1056,7 @@ impl<A: hil::adc::Adc + hil::adc::AdcHighSpeed> hil::adc::HighSpeedClient for Ad
                         if err == kernel::process::Error::NoSuchApp
                             || err == kernel::process::Error::InactiveApp
                         {
-                            self.appid.clear();
+                            self.processid.clear();
                             unexpected_state = true;
                         }
                     })
@@ -1070,7 +1070,7 @@ impl<A: hil::adc::Adc + hil::adc::AdcHighSpeed> hil::adc::HighSpeedClient for Ad
             // state is consistent. No callback.
             self.active.set(false);
             self.mode.set(AdcMode::NoMode);
-            self.appid.map(|id| {
+            self.processid.map(|id| {
                 self.apps
                     .enter(*id, |app, _| {
                         app.app_buf_offset.set(0);
@@ -1079,7 +1079,7 @@ impl<A: hil::adc::Adc + hil::adc::AdcHighSpeed> hil::adc::HighSpeedClient for Ad
                         if err == kernel::process::Error::NoSuchApp
                             || err == kernel::process::Error::InactiveApp
                         {
-                            self.appid.clear();
+                            self.processid.clear();
                         }
                     })
             });
@@ -1107,18 +1107,18 @@ impl<A: hil::adc::Adc + hil::adc::AdcHighSpeed> SyscallDriver for AdcDedicated<'
     ///
     /// - `command_num` - which command call this is
     /// - `data` - value sent by the application, varying uses
-    /// - `_appid` - application identifier, unused
+    /// - `_processid` - application identifier, unused
     fn command(
         &self,
         command_num: usize,
         channel: usize,
         frequency: usize,
-        appid: ProcessId,
+        processid: ProcessId,
     ) -> CommandReturn {
         // Return true if this app already owns the ADC capsule, if no app owns
         // the ADC capsule, or if the app that is marked as owning the ADC
         // capsule no longer exists.
-        let match_or_empty_or_nonexistant = self.appid.map_or(true, |owning_app| {
+        let match_or_empty_or_nonexistant = self.processid.map_or(true, |owning_app| {
             // We have recorded that an app has ownership of the ADC.
 
             // If the ADC is still active, then we need to wait for the operation
@@ -1127,7 +1127,7 @@ impl<A: hil::adc::Adc + hil::adc::AdcHighSpeed> SyscallDriver for AdcDedicated<'
             // we need to verify that that application still exists, and remove
             // it as owner if not.
             if self.active.get() {
-                owning_app == &appid
+                owning_app == &processid
             } else {
                 // Check the app still exists.
                 //
@@ -1137,12 +1137,12 @@ impl<A: hil::adc::Adc + hil::adc::AdcHighSpeed> SyscallDriver for AdcDedicated<'
                 // longer exists and we return `true` to signify the
                 // "or_nonexistant" case.
                 self.apps
-                    .enter(*owning_app, |_, _| owning_app == &appid)
+                    .enter(*owning_app, |_, _| owning_app == &processid)
                     .unwrap_or(true)
             }
         });
         if match_or_empty_or_nonexistant {
-            self.appid.set(appid);
+            self.processid.set(processid);
         } else {
             return CommandReturn::failure(ErrorCode::NOMEM);
         }
@@ -1228,13 +1228,13 @@ impl SyscallDriver for AdcVirtualized<'_> {
     /// - `command_num` - which command call this is
     /// - `channel` - requested channel value
     /// - `_` - value sent by the application, unused
-    /// - `appid` - application identifier
+    /// - `processid` - application identifier
     fn command(
         &self,
         command_num: usize,
         channel: usize,
         _: usize,
-        appid: ProcessId,
+        processid: ProcessId,
     ) -> CommandReturn {
         match command_num {
             // This driver exists and return the number of channels
@@ -1242,7 +1242,7 @@ impl SyscallDriver for AdcVirtualized<'_> {
 
             // Single sample.
             1 => {
-                let res = self.enqueue_command(Operation::OneSample, channel, appid);
+                let res = self.enqueue_command(Operation::OneSample, channel, processid);
                 if res == Ok(()) {
                     CommandReturn::success()
                 } else {
@@ -1286,8 +1286,8 @@ impl SyscallDriver for AdcVirtualized<'_> {
 
 impl<'a> hil::adc::Client for AdcVirtualized<'a> {
     fn sample_ready(&self, sample: u16) {
-        self.current_app.take().map(|appid| {
-            let _ = self.apps.enter(appid, |app, upcalls| {
+        self.current_app.take().map(|processid| {
+            let _ = self.apps.enter(processid, |app, upcalls| {
                 app.pending_command = false;
                 let channel = app.channel;
                 upcalls

--- a/capsules/src/air_quality.rs
+++ b/capsules/src/air_quality.rs
@@ -66,9 +66,9 @@ impl<'a> AirQualitySensor<'a> {
         }
     }
 
-    fn enqueue_command(&self, appid: ProcessId, op: Operation) -> CommandReturn {
+    fn enqueue_command(&self, processid: ProcessId, op: Operation) -> CommandReturn {
         self.apps
-            .enter(appid, |app, _| {
+            .enter(processid, |app, _| {
                 if !self.busy.get() {
                     self.busy.set(true);
                     app.operation = op;
@@ -131,7 +131,13 @@ impl hil::sensors::AirQualityClient for AirQualitySensor<'_> {
 }
 
 impl SyscallDriver for AirQualitySensor<'_> {
-    fn command(&self, command_num: usize, _: usize, _: usize, appid: ProcessId) -> CommandReturn {
+    fn command(
+        &self,
+        command_num: usize,
+        _: usize,
+        _: usize,
+        processid: ProcessId,
+    ) -> CommandReturn {
         match command_num {
             // check whether the driver exists!!
             0 => CommandReturn::success(),
@@ -140,10 +146,10 @@ impl SyscallDriver for AirQualitySensor<'_> {
             1 => CommandReturn::failure(ErrorCode::NOSUPPORT),
 
             // read CO2
-            2 => self.enqueue_command(appid, Operation::CO2),
+            2 => self.enqueue_command(processid, Operation::CO2),
 
             // read TVOC
-            3 => self.enqueue_command(appid, Operation::TVOC),
+            3 => self.enqueue_command(processid, Operation::TVOC),
 
             _ => CommandReturn::failure(ErrorCode::NOSUPPORT),
         }

--- a/capsules/src/alarm.rs
+++ b/capsules/src/alarm.rs
@@ -241,8 +241,8 @@ impl<'a, A: Alarm<'a>> SyscallDriver for AlarmDriver<'a, A> {
             )
     }
 
-    fn allocate_grant(&self, appid: ProcessId) -> Result<(), kernel::process::Error> {
-        self.app_alarms.enter(appid, |_, _| {})
+    fn allocate_grant(&self, processid: ProcessId) -> Result<(), kernel::process::Error> {
+        self.app_alarms.enter(processid, |_, _| {})
     }
 }
 

--- a/capsules/src/ambient_light.rs
+++ b/capsules/src/ambient_light.rs
@@ -47,9 +47,9 @@ impl<'a> AmbientLight<'a> {
         }
     }
 
-    fn enqueue_sensor_reading(&self, appid: ProcessId) -> Result<(), ErrorCode> {
+    fn enqueue_sensor_reading(&self, processid: ProcessId) -> Result<(), ErrorCode> {
         self.apps
-            .enter(appid, |app, _| {
+            .enter(processid, |app, _| {
                 if app.pending {
                     Err(ErrorCode::NOMEM)
                 } else {
@@ -84,11 +84,17 @@ impl SyscallDriver for AmbientLight<'_> {
     ///
     /// - `0`: Check driver presence
     /// - `1`: Start a light sensor reading
-    fn command(&self, command_num: usize, _: usize, _: usize, appid: ProcessId) -> CommandReturn {
+    fn command(
+        &self,
+        command_num: usize,
+        _: usize,
+        _: usize,
+        processid: ProcessId,
+    ) -> CommandReturn {
         match command_num {
             0 /* check if present */ => CommandReturn::success(),
             1 => {
-                let _ = self.enqueue_sensor_reading(appid);
+                let _ = self.enqueue_sensor_reading(processid);
                 CommandReturn::success()
             }
             _ => CommandReturn::failure(ErrorCode::NOSUPPORT)

--- a/capsules/src/button.rs
+++ b/capsules/src/button.rs
@@ -145,7 +145,7 @@ impl<'a, P: gpio::InterruptPin<'a>> SyscallDriver for Button<'a, P> {
         command_num: usize,
         data: usize,
         _: usize,
-        appid: ProcessId,
+        processid: ProcessId,
     ) -> CommandReturn {
         let pins = self.pins;
         match command_num {
@@ -156,7 +156,7 @@ impl<'a, P: gpio::InterruptPin<'a>> SyscallDriver for Button<'a, P> {
             1 => {
                 if data < pins.len() {
                     self.apps
-                        .enter(appid, |cntr, _| {
+                        .enter(processid, |cntr, _| {
                             cntr.subscribe_map |= 1 << data;
                             let _ = pins[data]
                                 .0
@@ -176,7 +176,7 @@ impl<'a, P: gpio::InterruptPin<'a>> SyscallDriver for Button<'a, P> {
                 } else {
                     let res = self
                         .apps
-                        .enter(appid, |cntr, _| {
+                        .enter(processid, |cntr, _| {
                             cntr.subscribe_map &= !(1 << data);
                             CommandReturn::success()
                         })

--- a/capsules/src/humidity.rs
+++ b/capsules/src/humidity.rs
@@ -92,10 +92,10 @@ impl<'a> HumiditySensor<'a> {
         &self,
         command: HumidityCommand,
         arg1: usize,
-        appid: ProcessId,
+        processid: ProcessId,
     ) -> CommandReturn {
         self.apps
-            .enter(appid, |app, _| {
+            .enter(processid, |app, _| {
                 if !self.busy.get() {
                     app.subscribed = true;
                     self.busy.set(true);
@@ -135,14 +135,14 @@ impl SyscallDriver for HumiditySensor<'_> {
         command_num: usize,
         arg1: usize,
         _: usize,
-        appid: ProcessId,
+        processid: ProcessId,
     ) -> CommandReturn {
         match command_num {
             // check whether the driver exist!!
             0 => CommandReturn::success(),
 
             // single humidity measurement
-            1 => self.enqueue_command(HumidityCommand::ReadHumidity, arg1, appid),
+            1 => self.enqueue_command(HumidityCommand::ReadHumidity, arg1, processid),
 
             _ => CommandReturn::failure(ErrorCode::NOSUPPORT),
         }

--- a/capsules/src/nonvolatile_storage_driver.rs
+++ b/capsules/src/nonvolatile_storage_driver.rs
@@ -94,7 +94,7 @@ pub enum NonvolatileCommand {
 
 #[derive(Clone, Copy)]
 pub enum NonvolatileUser {
-    App { app_id: ProcessId },
+    App { processid: ProcessId },
     Kernel,
 }
 
@@ -198,7 +198,7 @@ impl<'a> NonvolatileStorage<'a> {
         command: NonvolatileCommand,
         offset: usize,
         length: usize,
-        app_id: Option<ProcessId>,
+        processid: Option<ProcessId>,
     ) -> Result<(), ErrorCode> {
         // Do bounds check.
         match command {
@@ -229,9 +229,9 @@ impl<'a> NonvolatileStorage<'a> {
         // or from the kernel.
         match command {
             NonvolatileCommand::UserspaceRead | NonvolatileCommand::UserspaceWrite => {
-                app_id.map_or(Err(ErrorCode::FAIL), |appid| {
+                processid.map_or(Err(ErrorCode::FAIL), |processid| {
                     self.apps
-                        .enter(appid, |app, kernel_data| {
+                        .enter(processid, |app, kernel_data| {
                             // Get the length of the correct allowed buffer.
                             let allow_buf_len = match command {
                                 NonvolatileCommand::UserspaceRead => kernel_data
@@ -257,8 +257,9 @@ impl<'a> NonvolatileStorage<'a> {
                             if self.current_user.is_none() {
                                 // No app is currently using the underlying storage.
                                 // Mark this app as active, and then execute the command.
-                                self.current_user
-                                    .set(NonvolatileUser::App { app_id: appid });
+                                self.current_user.set(NonvolatileUser::App {
+                                    processid: processid,
+                                });
 
                                 // Need to copy bytes if this is a write!
                                 if command == NonvolatileCommand::UserspaceWrite {
@@ -358,7 +359,7 @@ impl<'a> NonvolatileStorage<'a> {
                 // allowed are long enough.
                 let active_len = cmp::min(length, buffer.len());
 
-                // self.current_app.set(Some(appid));
+                // self.current_app.set(Some(processid));
                 match command {
                     NonvolatileCommand::UserspaceRead => {
                         self.driver.read(buffer, physical_address, active_len)
@@ -395,12 +396,13 @@ impl<'a> NonvolatileStorage<'a> {
         } else {
             // If the kernel is not requesting anything, check all of the apps.
             for cntr in self.apps.iter() {
-                let appid = cntr.processid();
+                let processid = cntr.processid();
                 let started_command = cntr.enter(|app, _| {
                     if app.pending_command {
                         app.pending_command = false;
-                        self.current_user
-                            .set(NonvolatileUser::App { app_id: appid });
+                        self.current_user.set(NonvolatileUser::App {
+                            processid: processid,
+                        });
                         if let Ok(()) =
                             self.userspace_call_driver(app.command, app.offset, app.length)
                         {
@@ -431,8 +433,8 @@ impl hil::nonvolatile_storage::NonvolatileStorageClient<'static> for Nonvolatile
                         client.read_done(buffer, length);
                     });
                 }
-                NonvolatileUser::App { app_id } => {
-                    let _ = self.apps.enter(app_id, move |_, kernel_data| {
+                NonvolatileUser::App { processid } => {
+                    let _ = self.apps.enter(processid, move |_, kernel_data| {
                         // Need to copy in the contents of the buffer
                         let _ = kernel_data
                             .get_readwrite_processbuffer(rw_allow::READ)
@@ -469,8 +471,8 @@ impl hil::nonvolatile_storage::NonvolatileStorageClient<'static> for Nonvolatile
                         client.write_done(buffer, length);
                     });
                 }
-                NonvolatileUser::App { app_id } => {
-                    let _ = self.apps.enter(app_id, move |_app, kernel_data| {
+                NonvolatileUser::App { processid } => {
+                    let _ = self.apps.enter(processid, move |_app, kernel_data| {
                         // Replace the buffer we used to do this write.
                         self.buffer.replace(buffer);
 
@@ -548,7 +550,7 @@ impl SyscallDriver for NonvolatileStorage<'_> {
         command_num: usize,
         offset: usize,
         length: usize,
-        appid: ProcessId,
+        processid: ProcessId,
     ) -> CommandReturn {
         match command_num {
             0 /* This driver exists. */ => {
@@ -566,7 +568,7 @@ impl SyscallDriver for NonvolatileStorage<'_> {
                         NonvolatileCommand::UserspaceRead,
                         offset,
                         length,
-                        Some(appid),
+                        Some(processid),
                     );
 
                 match res {
@@ -581,7 +583,7 @@ impl SyscallDriver for NonvolatileStorage<'_> {
                         NonvolatileCommand::UserspaceWrite,
                         offset,
                         length,
-                        Some(appid),
+                        Some(processid),
                     );
 
                 match res {

--- a/capsules/src/proximity.rs
+++ b/capsules/src/proximity.rs
@@ -109,11 +109,11 @@ impl<'a> ProximitySensor<'a> {
         command: ProximityCommand,
         arg1: usize,
         arg2: usize,
-        appid: ProcessId,
+        processid: ProcessId,
     ) -> CommandReturn {
-        // Enqueue command by saving command type, args, appid within app struct in grant region
+        // Enqueue command by saving command type, args, processid within app struct in grant region
         self.apps
-            .enter(appid, |app, _| {
+            .enter(processid, |app, _| {
                 // Return busy if same app attempts to enqueue second command before first one is "callbacked"
                 if app.subscribed {
                     return CommandReturn::failure(ErrorCode::BUSY);
@@ -296,21 +296,21 @@ impl SyscallDriver for ProximitySensor<'_> {
         command_num: usize,
         arg1: usize,
         arg2: usize,
-        appid: ProcessId,
+        processid: ProcessId,
     ) -> CommandReturn {
         match command_num {
             // check whether the driver exist!!
             0 => CommandReturn::success(),
 
             // Instantaneous proximity measurement
-            1 => self.enqueue_command(ProximityCommand::ReadProximity, arg1, arg2, appid),
+            1 => self.enqueue_command(ProximityCommand::ReadProximity, arg1, arg2, processid),
 
             // Upcall occurs only after interrupt is fired
             2 => self.enqueue_command(
                 ProximityCommand::ReadProximityOnInterrupt,
                 arg1,
                 arg2,
-                appid,
+                processid,
             ),
 
             _ => CommandReturn::failure(ErrorCode::NOSUPPORT),

--- a/capsules/src/read_only_state.rs
+++ b/capsules/src/read_only_state.rs
@@ -58,11 +58,11 @@ impl<'a, T: Time> ReadOnlyStateDriver<'a, T> {
 
 impl<'a, T: Time> ContextSwitchCallback for ReadOnlyStateDriver<'a, T> {
     fn context_switch_hook(&self, process: &dyn process::Process) {
-        let appid = process.processid();
+        let processid = process.processid();
         let pending_tasks = process.pending_tasks();
 
         self.apps
-            .enter(appid, |app, _| {
+            .enter(processid, |app, _| {
                 let count = app.count.get();
 
                 let _ = app.mem_region.mut_enter(|buf| {
@@ -93,12 +93,12 @@ impl<'a, T: Time> SyscallDriver for ReadOnlyStateDriver<'a, T> {
     ///        This should only be read by the app and written by the capsule.
     fn allow_userspace_readable(
         &self,
-        appid: ProcessId,
+        processid: ProcessId,
         which: usize,
         mut slice: UserspaceReadableProcessBuffer,
     ) -> Result<UserspaceReadableProcessBuffer, (UserspaceReadableProcessBuffer, ErrorCode)> {
         if which == 0 {
-            let res = self.apps.enter(appid, |data, _| {
+            let res = self.apps.enter(processid, |data, _| {
                 core::mem::swap(&mut data.mem_region, &mut slice);
             });
             match res {
@@ -120,7 +120,7 @@ impl<'a, T: Time> SyscallDriver for ReadOnlyStateDriver<'a, T> {
         command_number: usize,
         _target_id: usize,
         _: usize,
-        _appid: ProcessId,
+        _processid: ProcessId,
     ) -> CommandReturn {
         match command_number {
             // get version

--- a/capsules/src/rng.rs
+++ b/capsules/src/rng.rs
@@ -173,7 +173,7 @@ impl<'a> SyscallDriver for RngDriver<'a> {
         command_num: usize,
         data: usize,
         _: usize,
-        appid: ProcessId,
+        processid: ProcessId,
     ) -> CommandReturn {
         match command_num {
             0 /* Check if exists */ =>
@@ -183,7 +183,7 @@ impl<'a> SyscallDriver for RngDriver<'a> {
 
             1 /* Ask for a given number of random bytes */ => self
                 .apps
-                .enter(appid, |app, _| {
+                .enter(processid, |app, _| {
                     app.remaining = data;
                     app.idx = 0;
 

--- a/capsules/src/sound_pressure.rs
+++ b/capsules/src/sound_pressure.rs
@@ -87,9 +87,9 @@ impl<'a> SoundPressureSensor<'a> {
         }
     }
 
-    fn enqueue_command(&self, appid: ProcessId) -> CommandReturn {
+    fn enqueue_command(&self, processid: ProcessId) -> CommandReturn {
         self.apps
-            .enter(appid, |app, _| {
+            .enter(processid, |app, _| {
                 if !self.busy.get() {
                     app.subscribed = true;
                     self.busy.set(true);
@@ -140,19 +140,25 @@ impl hil::sensors::SoundPressureClient for SoundPressureSensor<'_> {
 }
 
 impl SyscallDriver for SoundPressureSensor<'_> {
-    fn command(&self, command_num: usize, _: usize, _: usize, appid: ProcessId) -> CommandReturn {
+    fn command(
+        &self,
+        command_num: usize,
+        _: usize,
+        _: usize,
+        processid: ProcessId,
+    ) -> CommandReturn {
         match command_num {
             // check whether the driver exists!!
             0 => CommandReturn::success(),
 
             // read sound_pressure
-            1 => self.enqueue_command(appid),
+            1 => self.enqueue_command(processid),
 
             // enable
             2 => {
                 let res = self
                     .apps
-                    .enter(appid, |app, _| {
+                    .enter(processid, |app, _| {
                         app.enable = true;
                         CommandReturn::success()
                     })
@@ -169,7 +175,7 @@ impl SyscallDriver for SoundPressureSensor<'_> {
             3 => {
                 let res = self
                     .apps
-                    .enter(appid, |app, _| {
+                    .enter(processid, |app, _| {
                         app.enable = false;
                         CommandReturn::success()
                     })

--- a/capsules/src/temperature.rs
+++ b/capsules/src/temperature.rs
@@ -87,9 +87,9 @@ impl<'a> TemperatureSensor<'a> {
         }
     }
 
-    fn enqueue_command(&self, appid: ProcessId) -> CommandReturn {
+    fn enqueue_command(&self, processid: ProcessId) -> CommandReturn {
         self.apps
-            .enter(appid, |app, _| {
+            .enter(processid, |app, _| {
                 if !self.busy.get() {
                     app.subscribed = true;
                     self.busy.set(true);
@@ -125,13 +125,19 @@ impl hil::sensors::TemperatureClient for TemperatureSensor<'_> {
 }
 
 impl SyscallDriver for TemperatureSensor<'_> {
-    fn command(&self, command_num: usize, _: usize, _: usize, appid: ProcessId) -> CommandReturn {
+    fn command(
+        &self,
+        command_num: usize,
+        _: usize,
+        _: usize,
+        processid: ProcessId,
+    ) -> CommandReturn {
         match command_num {
             // check whether the driver exists!!
             0 => CommandReturn::success(),
 
             // read temperature
-            1 => self.enqueue_command(appid),
+            1 => self.enqueue_command(processid),
             _ => CommandReturn::failure(ErrorCode::NOSUPPORT),
         }
     }

--- a/capsules/src/test/double_grant_entry.rs
+++ b/capsules/src/test/double_grant_entry.rs
@@ -83,7 +83,13 @@ impl TestGrantDoubleEntry {
 }
 
 impl SyscallDriver for TestGrantDoubleEntry {
-    fn command(&self, command_num: usize, _: usize, _: usize, appid: ProcessId) -> CommandReturn {
+    fn command(
+        &self,
+        command_num: usize,
+        _: usize,
+        _: usize,
+        processid: ProcessId,
+    ) -> CommandReturn {
         match command_num {
             0 => CommandReturn::success(),
 
@@ -97,7 +103,7 @@ impl SyscallDriver for TestGrantDoubleEntry {
                 // Enter the grant for the app.
                 let err = self
                     .grant
-                    .enter(appid, |appgrant, _| {
+                    .enter(processid, |appgrant, _| {
                         // We can now change the state of the app's grant
                         // region.
                         appgrant.pending = true;
@@ -131,12 +137,12 @@ impl SyscallDriver for TestGrantDoubleEntry {
                 let mut found_pending = false;
 
                 // Make sure the grant is allocated.
-                let _ = self.grant.enter(appid, |appgrant, _| {
+                let _ = self.grant.enter(processid, |appgrant, _| {
                     appgrant.pending = false;
                 });
 
                 for app in self.grant.iter() {
-                    let _ = self.grant.enter(appid, |appgrant, _| {
+                    let _ = self.grant.enter(processid, |appgrant, _| {
                         // Mark the field.
                         appgrant.pending = true;
 
@@ -165,10 +171,10 @@ impl SyscallDriver for TestGrantDoubleEntry {
                 // entered the same grant twice.
                 let mut found_pending = false;
 
-                let _ = self.grant.enter(appid, |appgrant, _| {
+                let _ = self.grant.enter(processid, |appgrant, _| {
                     appgrant.pending = true;
 
-                    let _ = self.grant.enter(appid, |appgrant2, _| {
+                    let _ = self.grant.enter(processid, |appgrant2, _| {
                         if appgrant2.pending {
                             found_pending = true;
                         }

--- a/capsules/src/text_screen.rs
+++ b/capsules/src/text_screen.rs
@@ -94,13 +94,13 @@ impl<'a> TextScreen<'a> {
         command: TextScreenCommand,
         data1: usize,
         data2: usize,
-        appid: ProcessId,
+        processid: ProcessId,
     ) -> CommandReturn {
         let res = self
             .apps
-            .enter(appid, |app, _| {
+            .enter(processid, |app, _| {
                 if self.current_app.is_none() {
-                    self.current_app.set(appid);
+                    self.current_app.set(processid);
                     app.data1 = data1;
                     app.data2 = data2;
                     app.command = command;
@@ -211,11 +211,11 @@ impl<'a> TextScreen<'a> {
     fn run_next_command(&self) {
         // Check for pending events.
         for app in self.apps.iter() {
-            let appid = app.processid();
+            let processid = app.processid();
             let current_command = app.enter(|app, _| {
                 if app.pending_command {
                     app.pending_command = false;
-                    self.current_app.set(appid);
+                    self.current_app.set(processid);
                     true
                 } else {
                     false
@@ -232,8 +232,8 @@ impl<'a> TextScreen<'a> {
     }
 
     fn schedule_callback(&self, data1: usize, data2: usize, data3: usize) {
-        self.current_app.take().map(|appid| {
-            let _ = self.apps.enter(appid, |app, kernel_data| {
+        self.current_app.take().map(|processid| {
+            let _ = self.apps.enter(processid, |app, kernel_data| {
                 app.pending_command = false;
                 kernel_data.schedule_upcall(0, (data1, data2, data3)).ok();
             });
@@ -247,33 +247,33 @@ impl<'a> SyscallDriver for TextScreen<'a> {
         command_num: usize,
         data1: usize,
         data2: usize,
-        appid: ProcessId,
+        processid: ProcessId,
     ) -> CommandReturn {
         match command_num {
             // This driver exists.
             0 => CommandReturn::success(),
             // Get Resolution
-            1 => self.enqueue_command(TextScreenCommand::GetResolution, data1, data2, appid),
+            1 => self.enqueue_command(TextScreenCommand::GetResolution, data1, data2, processid),
             // Display
-            2 => self.enqueue_command(TextScreenCommand::Display, data1, data2, appid),
+            2 => self.enqueue_command(TextScreenCommand::Display, data1, data2, processid),
             // No Display
-            3 => self.enqueue_command(TextScreenCommand::NoDisplay, data1, data2, appid),
+            3 => self.enqueue_command(TextScreenCommand::NoDisplay, data1, data2, processid),
             // Blink
-            4 => self.enqueue_command(TextScreenCommand::Blink, data1, data2, appid),
+            4 => self.enqueue_command(TextScreenCommand::Blink, data1, data2, processid),
             // No Blink
-            5 => self.enqueue_command(TextScreenCommand::NoBlink, data1, data2, appid),
+            5 => self.enqueue_command(TextScreenCommand::NoBlink, data1, data2, processid),
             // Show Cursor
-            6 => self.enqueue_command(TextScreenCommand::ShowCursor, data1, data2, appid),
+            6 => self.enqueue_command(TextScreenCommand::ShowCursor, data1, data2, processid),
             // No Cursor
-            7 => self.enqueue_command(TextScreenCommand::NoCursor, data1, data2, appid),
+            7 => self.enqueue_command(TextScreenCommand::NoCursor, data1, data2, processid),
             // Write
-            8 => self.enqueue_command(TextScreenCommand::Write, data1, data2, appid),
+            8 => self.enqueue_command(TextScreenCommand::Write, data1, data2, processid),
             // Clear
-            9 => self.enqueue_command(TextScreenCommand::Clear, data1, data2, appid),
+            9 => self.enqueue_command(TextScreenCommand::Clear, data1, data2, processid),
             // Home
-            10 => self.enqueue_command(TextScreenCommand::Home, data1, data2, appid),
+            10 => self.enqueue_command(TextScreenCommand::Home, data1, data2, processid),
             //Set Curosr
-            11 => self.enqueue_command(TextScreenCommand::SetCursor, data1, data2, appid),
+            11 => self.enqueue_command(TextScreenCommand::SetCursor, data1, data2, processid),
             // NOSUPPORT
             _ => CommandReturn::failure(ErrorCode::NOSUPPORT),
         }

--- a/capsules/src/touch.rs
+++ b/capsules/src/touch.rs
@@ -332,7 +332,7 @@ impl<'a> SyscallDriver for Touch<'a> {
         command_num: usize,
         _data1: usize,
         _data2: usize,
-        appid: ProcessId,
+        processid: ProcessId,
     ) -> CommandReturn {
         match command_num {
             0 =>
@@ -344,7 +344,7 @@ impl<'a> SyscallDriver for Touch<'a> {
             // touch enable
             1 => {
                 self.apps
-                    .enter(appid, |app, _| {
+                    .enter(processid, |app, _| {
                         app.touch_enable = true;
                     })
                     .unwrap_or(());
@@ -355,7 +355,7 @@ impl<'a> SyscallDriver for Touch<'a> {
             // touch disable
             2 => {
                 self.apps
-                    .enter(appid, |app, _| {
+                    .enter(processid, |app, _| {
                         app.touch_enable = false;
                     })
                     .unwrap_or(());
@@ -366,7 +366,7 @@ impl<'a> SyscallDriver for Touch<'a> {
             // multi touch ack
             10 => {
                 self.apps
-                    .enter(appid, |app, _| {
+                    .enter(processid, |app, _| {
                         app.ack = true;
                     })
                     .unwrap_or(());
@@ -376,7 +376,7 @@ impl<'a> SyscallDriver for Touch<'a> {
             // multi touch enable
             11 => {
                 self.apps
-                    .enter(appid, |app, _| {
+                    .enter(processid, |app, _| {
                         app.multi_touch_enable = true;
                     })
                     .unwrap_or(());
@@ -387,7 +387,7 @@ impl<'a> SyscallDriver for Touch<'a> {
             // multi touch disable
             12 => {
                 self.apps
-                    .enter(appid, |app, _| {
+                    .enter(processid, |app, _| {
                         app.multi_touch_enable = false;
                     })
                     .unwrap_or(());

--- a/capsules/src/usb/usb_user.rs
+++ b/capsules/src/usb/usb_user.rs
@@ -116,7 +116,7 @@ where
         command_num: usize,
         _arg: usize,
         _: usize,
-        appid: ProcessId,
+        processid: ProcessId,
     ) -> CommandReturn {
         match command_num {
             // This driver is present
@@ -126,7 +126,7 @@ where
             1 => {
                 let result = self
                     .apps
-                    .enter(appid, |app, _| {
+                    .enter(processid, |app, _| {
                         if app.awaiting.is_some() {
                             // Each app may make only one request at a time
                             Err(ErrorCode::BUSY)

--- a/kernel/src/grant.rs
+++ b/kernel/src/grant.rs
@@ -1336,7 +1336,7 @@ impl<'a, T: Default, Upcalls: UpcallSize, AllowROs: AllowRoSize, AllowRWs: Allow
                 // challenge is that calling `self.apps.iter()` is a common
                 // pattern in capsules to access the grant region of every app
                 // that is using the capsule, and sometimes it is intuitive to
-                // call that inside of a `self.apps.enter(app_id, |app| {...})`
+                // call that inside of a `self.apps.enter(processid, |app| {...})`
                 // closure. However, `.enter()` means that app's grant region is
                 // entered, and then a naive `.iter()` would re-enter the grant
                 // region and cause undefined behavior. We considered different

--- a/kernel/src/ipc.rs
+++ b/kernel/src/ipc.rs
@@ -125,7 +125,7 @@ impl<const NUM_PROCS: u8> SyscallDriver for IPC<NUM_PROCS> {
         command_number: usize,
         target_id: usize,
         _: usize,
-        appid: ProcessId,
+        processid: ProcessId,
     ) -> CommandReturn {
         match command_number {
             0 => CommandReturn::success(),
@@ -133,7 +133,7 @@ impl<const NUM_PROCS: u8> SyscallDriver for IPC<NUM_PROCS> {
             /* Discover */
             {
                 self.data
-                    .enter(appid, |_, kernel_data| {
+                    .enter(processid, |_, kernel_data| {
                         kernel_data
                             .get_readonly_processbuffer(ro_allow::SEARCH)
                             .and_then(|search| {
@@ -182,7 +182,7 @@ impl<const NUM_PROCS: u8> SyscallDriver for IPC<NUM_PROCS> {
                         CommandReturn::failure(ErrorCode::INVAL),
                         otherapp,
                         |target| {
-                            let ret = target.enqueue_task(process::Task::IPC((appid, cb_type)));
+                            let ret = target.enqueue_task(process::Task::IPC((processid, cb_type)));
                             match ret {
                                 Ok(()) => CommandReturn::success(),
                                 Err(e) => {
@@ -215,7 +215,7 @@ impl<const NUM_PROCS: u8> SyscallDriver for IPC<NUM_PROCS> {
                         CommandReturn::failure(ErrorCode::INVAL),
                         otherapp,
                         |target| {
-                            let ret = target.enqueue_task(process::Task::IPC((appid, cb_type)));
+                            let ret = target.enqueue_task(process::Task::IPC((processid, cb_type)));
                             match ret {
                                 Ok(()) => CommandReturn::success(),
                                 Err(e) => {

--- a/kernel/src/platform/mpu.rs
+++ b/kernel/src/platform/mpu.rs
@@ -277,9 +277,9 @@ pub trait MPU {
     /// # Arguments
     ///
     /// - `config`: MPU region configuration
-    /// - `app_id`: ProcessId of the process that the MPU is configured for
+    /// - `processid`: ProcessId of the process that the MPU is configured for
     #[allow(unused_variables)]
-    fn configure_mpu(&self, config: &Self::MpuConfig, app_id: &ProcessId) {}
+    fn configure_mpu(&self, config: &Self::MpuConfig, processid: &ProcessId) {}
 }
 
 /// Implement default MPU trait for unit.

--- a/kernel/src/upcall.rs
+++ b/kernel/src/upcall.rs
@@ -75,7 +75,7 @@ pub(crate) struct Upcall {
     pub(crate) appdata: usize,
 
     /// A pointer to the first instruction of a function in the app
-    /// associated with app_id.
+    /// associated with processid.
     ///
     /// If this value is `None`, this is a null upcall, which cannot actually be
     /// scheduled. An `Upcall` can be null when it is first created, or after an


### PR DESCRIPTION
### Pull Request Overview

This pull request renames the usage of `appid` and `app_id` of type `ProcessId` to `processid`. 

This is now useful as the `AppID` pull request was merged and the AppID now has a different meaning now from the ProcessId. Most usages of `appid` and `app_id` actually are referring `ProcessId`.

### Testing Strategy

N/A


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
