### PR TITLE
esp32-c3-devkit-m1 GPIO Fixes

### DIFF
--- a/boards/esp32-c3-devkitM-1/src/main.rs
+++ b/boards/esp32-c3-devkitM-1/src/main.rs
@@ -190,7 +190,8 @@ unsafe fn setup() -> (
             4 => &peripherals.gpio[4],
             5 => &peripherals.gpio[5],
             6 => &peripherals.gpio[6],
-            7 => &peripherals.gpio[15]
+            7 => &peripherals.gpio[7],
+            8 => &peripherals.gpio[15]
         ),
     )
     .finalize(components::gpio_component_static!(esp32::gpio::GpioPin));


### PR DESCRIPTION
### Pull Request Overview

This pull requests fixes GPIO pins 4-7 in the esp32-c3-devkit-m1 board. Consider the following toy libtock-c program:

```c
#include <stdio.h>
#include <console.h>
#include <gpio.h>
#include <timer.h>
#include <tock.h>

int main(void) {
  // Get all pins configured
  int num_pins = 0;
  gpio_count(&num_pins);

  // Enable them as outputs
  for (int i = 0; i < num_pins; i++) {
    gpio_enable_output(i);
  }

  // Do nonsense with all the pins forever
  while (1) {
    for (int i = 0; i < num_pins; i++) {
      printf("Begin test GPIO Pin %d\n", i);
      for (int j = 0; j < 1000; j++) {
        if (j % 2 == 0) {
          gpio_clear(i);
        } else {
          gpio_set(i);
        }
        delay_ms(1);
      }
      printf("Finish test GPIO Pin %d\n", i);
    }
    delay_ms(1000);
  }
  return 0;
}
```

GPIO pins 0-3 behave as expected and create pulses; however, GPIO pins 4-7 do nothing despite being included in the [set of usable GPIO pins](https://github.com/tock/tock/blob/master/boards/esp32-c3-devkitM-1/src/main.rs#L186-L193) for the boards kernel.

Looking at the [ESP32-C3 datasheet](https://www.espressif.com/sites/default/files/documentation/esp32-c3_technical_reference_manual_en.pdf) it appears Tock currently follows the notes in section 5.5.3 for using the `GPIO_OUT_W1TS` and `GPIO_OUT_W1TC` registers to toggle pins, which is the recommended "simple" way of getting GPIO output; however, the previous section mentions that the IO MUX function selector register (`IO_MUX_GPIOx_MCU_SEL`) needs to be changed to function 1 for this to work. 

Looking the IO MUX functions for all the pins (table 5-2), function 1 is GPIO only whereas the default function 0 maps to a variety of GPIO outputs or peripherals (which explains why 0-3 functioned, but 4-7 did not). This PR applies the advice listed in section 5.5.3, along with setting a field in the IO MUX configuration register to select function 1 when setting up a pin as a GPIO output.

### Testing Strategy

I tested using the libtock-c example above. Signals are emitted by all the correct pins now. 


### TODO or Help Wanted

One thing that confused me is originally in `main.rs` GPIO pin "7" really mapped to GPIO peripheral 15. I don't know why this is the case, but I am unsure why pin 7 should be avoided, so I added pin 7 as pin 7 and moved pin 15 to index 8.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
