### PR TITLE
boards/opentitan: Enable SPI tests for QEMU

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -512,7 +512,7 @@ ci-job-cargo-test-build:
 
 ### ci-runner-github-qemu jobs:
 
-QEMU_COMMIT_HASH=dbc4f48b5ab3e6d85f78aa4df6bd6ad561c3d152
+QEMU_COMMIT_HASH=6dffbe36af79e26a4d23f94a9a1c1201de99c261
 define ci_setup_qemu_riscv
 	$(call banner,CI-Setup: Build QEMU)
 	@# Use the latest QEMU as it has OpenTitan support

--- a/boards/opentitan/src/tests/spi_host.rs
+++ b/boards/opentitan/src/tests/spi_host.rs
@@ -140,26 +140,24 @@ fn spi_host_transfer_partial() {
     spi_host.set_client(cb);
     cb.reset();
 
-    #[cfg(feature = "hardware_tests")]
-    {
-        let tx = cb.tx_data.take().unwrap();
-        let rx = cb.rx_data.take().unwrap();
-        cb.tx_len.set(tx.len());
+    let tx = cb.tx_data.take().unwrap();
+    let rx = cb.rx_data.take().unwrap();
+    cb.tx_len.set(tx.len());
 
-        //Set SPI_HOST0 Configs
-        spi_host.specify_chip_select(0).ok();
-        spi_host.set_rate(100000).ok();
-        spi_host.set_polarity(ClockPolarity::IdleLow).ok();
-        spi_host.set_phase(ClockPhase::SampleLeading).ok();
+    //Set SPI_HOST0 Configs
+    spi_host.specify_chip_select(0).ok();
+    spi_host.set_rate(100000).ok();
+    spi_host.set_polarity(ClockPolarity::IdleLow).ok();
+    spi_host.set_phase(ClockPhase::SampleLeading).ok();
 
-        assert_eq!(
-            spi_host.read_write_bytes(tx, Some(rx), cb.tx_len.get()),
-            Ok(())
-        );
-        run_kernel_op(5000);
+    assert_eq!(
+        spi_host.read_write_bytes(tx, Some(rx), cb.tx_len.get()),
+        Ok(())
+    );
+    run_kernel_op(5000);
 
-        assert_eq!(cb.transfer_done.get(), true);
-    }
+    assert_eq!(cb.transfer_done.get(), true);
+
     run_kernel_op(100);
     debug!("    [ok]");
     run_kernel_op(100);
@@ -180,26 +178,23 @@ fn spi_host_transfer_single() {
     spi_host.set_client(cb);
     cb.reset();
 
-    #[cfg(feature = "hardware_tests")]
-    {
-        let tx = cb.tx_data.take().unwrap();
-        let rx = cb.rx_data.take().unwrap();
-        cb.tx_len.set(tx.len());
+    let tx = cb.tx_data.take().unwrap();
+    let rx = cb.rx_data.take().unwrap();
+    cb.tx_len.set(tx.len());
 
-        //Set SPI_HOST0 Configs
-        spi_host.specify_chip_select(0).ok();
-        spi_host.set_rate(100000).ok();
-        spi_host.set_polarity(ClockPolarity::IdleLow).ok();
-        spi_host.set_phase(ClockPhase::SampleLeading).ok();
+    //Set SPI_HOST0 Configs
+    spi_host.specify_chip_select(0).ok();
+    spi_host.set_rate(100000).ok();
+    spi_host.set_polarity(ClockPolarity::IdleLow).ok();
+    spi_host.set_phase(ClockPhase::SampleLeading).ok();
 
-        assert_eq!(
-            spi_host.read_write_bytes(tx, Some(rx), cb.tx_len.get()),
-            Ok(())
-        );
-        run_kernel_op(5000);
+    assert_eq!(
+        spi_host.read_write_bytes(tx, Some(rx), cb.tx_len.get()),
+        Ok(())
+    );
+    run_kernel_op(5000);
 
-        assert_eq!(cb.transfer_done.get(), true);
-    }
+    assert_eq!(cb.transfer_done.get(), true);
 
     run_kernel_op(100);
     debug!("    [ok]");
@@ -210,20 +205,18 @@ fn spi_host_transfer_single() {
 
     cb.reset();
 
-    #[cfg(feature = "hardware_tests")]
-    {
-        let tx2 = cb.tx_data.take().unwrap();
-        let rx2 = cb.rx_data.take().unwrap();
-        cb.tx_len.set(tx2.len());
+    let tx2 = cb.tx_data.take().unwrap();
+    let rx2 = cb.rx_data.take().unwrap();
+    cb.tx_len.set(tx2.len());
 
-        assert_eq!(
-            spi_host.read_write_bytes(tx2, Some(rx2), cb.tx_len.get()),
-            Ok(())
-        );
-        run_kernel_op(5000);
+    assert_eq!(
+        spi_host.read_write_bytes(tx2, Some(rx2), cb.tx_len.get()),
+        Ok(())
+    );
+    run_kernel_op(5000);
 
-        assert_eq!(cb.transfer_done.get(), true);
-    }
+    assert_eq!(cb.transfer_done.get(), true);
+
     run_kernel_op(100);
     debug!("    [ok]");
     run_kernel_op(100);


### PR DESCRIPTION
### Pull Request Overview

- Bump QEMU to the latest version with new fixes for the `ibex_spi` model.
- Enable `opentitan/spi_host` tests to run on QEMU. 

### Testing Strategy

Removing the old qemu folder in tock (`tools/qemu`), then:

`make ci-setup-qemu`
`make test`

### TODO or Help Wanted

N/A

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
