### PR TITLE
kernel: don't use `static mut` when `const` would suffice

### DIFF
--- a/chips/msp432/src/cs.rs
+++ b/chips/msp432/src/cs.rs
@@ -325,7 +325,7 @@ impl<'a> PeripheralManagement<NoClockControl> for ClockSystem {
     }
 
     fn get_clock(&self) -> &NoClockControl {
-        unsafe { &kernel::platform::chip::NO_CLOCK_CONTROL }
+        &kernel::platform::chip::NO_CLOCK_CONTROL
     }
 
     fn before_peripheral_access(&self, _c: &NoClockControl, r: &Self::RegisterType) {

--- a/kernel/src/platform/chip.rs
+++ b/kernel/src/platform/chip.rs
@@ -130,4 +130,4 @@ impl ClockInterface for NoClockControl {
 
 /// Instance of NoClockControl for things that need references to
 /// `ClockInterface` objects.
-pub static mut NO_CLOCK_CONTROL: NoClockControl = NoClockControl {};
+pub const NO_CLOCK_CONTROL: NoClockControl = NoClockControl {};


### PR DESCRIPTION
### Pull Request Overview

This pull request removes an unnecessary `unsafe`.


### Testing Strategy

This pull request was tested by compiling.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
