### PR TITLE
RFC: Fix cortex-m context switch bug with a custom flag for the SVC handler

### DIFF
--- a/arch/cortex-m/src/syscall.rs
+++ b/arch/cortex-m/src/syscall.rs
@@ -10,6 +10,15 @@ use kernel::errorcode::ErrorCode;
 
 use crate::CortexMVariant;
 
+/// This is used for determining if we are context switching from userspace to
+/// the kernel or from the kernel to userspace When set to 1 or anything other
+/// than 0 then we are switching from the kernel to userspace. Otherwise, we are
+/// switching from userspace to the kernel. Marked `pub` because it is used in
+/// the cortex-m* specific handler.
+#[no_mangle]
+#[used]
+pub static mut KERNEL_TO_USERSPACE: usize = 0;
+
 /// This is used in the syscall handler. When set to 1 this means the
 /// svc_handler was called. Marked `pub` because it is used in the cortex-m*
 /// specific handler.


### PR DESCRIPTION


### Pull Request Overview

This is related to #3109.

This PR adds a flag that tells the SVC handler if we are switching from userspace to the kernel or from the kernel to userspace. The flag is a global variable and called `KERNEL_TO_USERSPACE`.

The hypothesis underlying this PR is that the issue in #3109 is based on the idea that this check in the SVC handler:

https://github.com/tock/tock/blob/47664d8a9ce1fd8da11bf86610bc4e43964aeebd/arch/cortex-m/src/lib.rs#L162-L169

does not work in every situation. Namely, there is some execution where SVC handler runs with `LR==0xfffffff9`, even though the `svc` instruction was called by userspace. (Note, `0xfffffff9` is the cortex-m special EXC_RETURN value meaning privileged mode with the main stack). This could be from nested exceptions or tail-chained exceptions, but I don't know for sure.

So, instead of trying to use the LR and the built-in architectural support for what should happen when the SVC handler executes, this PR adds our flag that we set to determine the "direction" of the context switch.


### Testing Strategy

using apps on hail


### TODO or Help Wanted

This PR isn't necessarily what I think we should merge, but hopefully it helps us make progress on this issue. It might not even fix the issue since we don't have a way to reproduce the issue while making modifications to the kernel. Since this bug relies on a particular execution order with interrupts it is difficult to reproduce. We also don't know if it only happens on the SAM4L for some reason.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
