### PR TITLE
kernel: hil: rsa_math: Fixup the mutable Client

### DIFF
--- a/kernel/src/hil/public_key_crypto/rsa_math.rs
+++ b/kernel/src/hil/public_key_crypto/rsa_math.rs
@@ -91,8 +91,8 @@ pub trait ClientMut<'a> {
 }
 
 pub trait RsaCryptoBaseMut<'a> {
-    /// Set the `Client` client to be called on completion.
-    fn set_client(&'a self, client: &'a dyn Client<'a>);
+    /// Set the `ClientMut` client to be called on completion.
+    fn set_client(&'a self, client: &'a dyn ClientMut<'a>);
 
     /// Clear any confidential data.
     fn clear_data(&self);


### PR DESCRIPTION
### Pull Request Overview

The RsaCryptoBaseMut trait has the incorrect client type for `set_client()`. We should be using `ClientMut` instead of `Client`.

### Testing Strategy

### TODO or Help Wanted

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
