### PR TITLE
Increase the kernel flash space for Raspberry Pi Pico

### DIFF
--- a/boards/nano_rp2040_connect/layout.ld
+++ b/boards/nano_rp2040_connect/layout.ld
@@ -7,8 +7,8 @@ MEMORY
   ram (rwx) : ORIGIN = 0x20004000, LENGTH = 240K */
 
   /* boot from Flash */
-  rom (rx)  : ORIGIN = 0x10000000, LENGTH = 128K
-  prog (rx) : ORIGIN = 0x10020000, LENGTH = 512K
+  rom (rx)  : ORIGIN = 0x10000000, LENGTH = 256K
+  prog (rx) : ORIGIN = 0x10040000, LENGTH = 512K
   ram (rwx) : ORIGIN = 0x20000000, LENGTH = 264K
 }
 

--- a/boards/nano_rp2040_connect/layout.ld
+++ b/boards/nano_rp2040_connect/layout.ld
@@ -2,7 +2,7 @@ MEMORY
 {
   /* uncomment this to boot from RAM */
   /* reset (rx)  : ORIGIN = 0x20000000, LENGTH = 16K
-  rom (rx)  : ORIGIN = 0x20000100, LENGTH = 128K
+  rom (rx)  : ORIGIN = 0x20000100, LENGTH = 256K
   prog (rx) : ORIGIN = 0x20040000, LENGTH = 1K
   ram (rwx) : ORIGIN = 0x20004000, LENGTH = 240K */
 

--- a/boards/pico_explorer_base/layout.ld
+++ b/boards/pico_explorer_base/layout.ld
@@ -7,8 +7,8 @@ MEMORY
   ram (rwx) : ORIGIN = 0x20004000, LENGTH = 240K */
 
   /* boot from Flash */
-  rom (rx)  : ORIGIN = 0x10000000, LENGTH = 128K
-  prog (rx) : ORIGIN = 0x10020000, LENGTH = 256K
+  rom (rx)  : ORIGIN = 0x10000000, LENGTH = 256K
+  prog (rx) : ORIGIN = 0x10040000, LENGTH = 256K
   ram (rwx) : ORIGIN = 0x20000000, LENGTH = 264K
 }
 

--- a/boards/pico_explorer_base/layout.ld
+++ b/boards/pico_explorer_base/layout.ld
@@ -2,7 +2,7 @@ MEMORY
 {
   /* uncomment this to boot from RAM */
   /* reset (rx)  : ORIGIN = 0x20000000, LENGTH = 16K
-  rom (rx)  : ORIGIN = 0x20000100, LENGTH = 128K
+  rom (rx)  : ORIGIN = 0x20000100, LENGTH = 256K
   prog (rx) : ORIGIN = 0x20040000, LENGTH = 1K
   ram (rwx) : ORIGIN = 0x20004000, LENGTH = 240K */
 

--- a/boards/raspberry_pi_pico/layout.ld
+++ b/boards/raspberry_pi_pico/layout.ld
@@ -2,13 +2,13 @@ MEMORY
 {
   /* uncomment this to boot from RAM */
   /* reset (rx)  : ORIGIN = 0x20000000, LENGTH = 16K
-  rom (rx)  : ORIGIN = 0x20000100, LENGTH = 128K
+  rom (rx)  : ORIGIN = 0x20000100, LENGTH = 256K
   prog (rx) : ORIGIN = 0x20040000, LENGTH = 1K
   ram (rwx) : ORIGIN = 0x20004000, LENGTH = 240K */
 
   /* boot from Flash */
-  rom (rx)  : ORIGIN = 0x10000000, LENGTH = 128K
-  prog (rx) : ORIGIN = 0x10020000, LENGTH = 256K
+  rom (rx)  : ORIGIN = 0x10000000, LENGTH = 256K
+  prog (rx) : ORIGIN = 0x10040000, LENGTH = 256K
   ram (rwx) : ORIGIN = 0x20000000, LENGTH = 264K
 }
 


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes the Raspberry Pi Pico and similar boards kernel flash space. As several other peripherals were implemented, the kernel did not fit anymore.

This fixes #3313.


### Testing Strategy

N/A


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
