### PR TITLE
boards: update `let _` syntax

### DIFF
--- a/boards/esp32-c3-devkitM-1/src/main.rs
+++ b/boards/esp32-c3-devkitM-1/src/main.rs
@@ -290,7 +290,7 @@ unsafe fn setup() -> (
     .finalize(components::process_console_component_static!(
         esp32_c3::timg::TimG
     ));
-    let _ = process_console.start();
+    _ = process_console.start();
 
     let esp32_c3_board = static_init!(
         Esp32C3Board,

--- a/boards/opentitan/src/io.rs
+++ b/boards/opentitan/src/io.rs
@@ -91,7 +91,7 @@ pub unsafe extern "C" fn panic_fmt(pi: &PanicInfo) -> ! {
         &PROCESS_PRINTER,
     );
 
-    let _ = writeln!(writer, "{}", pi);
+    _ = writeln!(writer, "{}", pi);
     // Exit QEMU with a return code of 1
     crate::tests::semihost_command_exit_failure();
 }

--- a/boards/particle_boron/src/io.rs
+++ b/boards/particle_boron/src/io.rs
@@ -95,7 +95,7 @@ impl IoWrite for Writer {
                 STATIC_PANIC_BUF[..max].copy_from_slice(&buf[..max]);
                 let static_buf = &mut STATIC_PANIC_BUF;
                 cdc.set_transmit_client(&DUMMY);
-                let _ = cdc.transmit_buffer(static_buf, max);
+                _ = cdc.transmit_buffer(static_buf, max);
                 loop {
                     if let Some(interrupt) = cortexm4::nvic::next_pending() {
                         if interrupt == 39 {

--- a/boards/particle_boron/src/main.rs
+++ b/boards/particle_boron/src/main.rs
@@ -338,7 +338,7 @@ pub unsafe fn main() {
     //--------------------------------------------------------------------------
 
     let rtc = &base_peripherals.rtc;
-    let _ = rtc.start();
+    _ = rtc.start();
     let mux_alarm = components::alarm::AlarmMuxComponent::new(rtc)
         .finalize(components::alarm_mux_component_static!(nrf52840::rtc::Rtc));
     let alarm = components::alarm::AlarmDriverComponent::new(
@@ -608,7 +608,7 @@ pub unsafe fn main() {
     cdc.attach();
 
     debug!("Particle Boron: Initialization complete. Entering main loop\r");
-    let _ = platform.pconsole.start();
+    _ = platform.pconsole.start();
 
     //--------------------------------------------------------------------------
     // PROCESSES AND MAIN LOOP


### PR DESCRIPTION
### Pull Request Overview

Since rust 1.59, we can simplify the use of an unused return value from `let _ = bar()` to just `_ = bar()`.


### Testing Strategy

Compiling each target


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
