### PR TITLE
boards/opentitan: fix verilator app support

### DIFF
--- a/boards/opentitan/README.md
+++ b/boards/opentitan/README.md
@@ -205,7 +205,7 @@ Programming Apps
 Tock apps for OpenTitan must be included in the Tock binary file flashed with
 the steps mentioned above.
 
-Apps are built out of tree.
+**Apps are built out of tree.**
 
 The OpenTitan Makefile can also handle this process automatically. Follow
 the steps above but instead run the `flash-app` make target.
@@ -219,10 +219,44 @@ the LLVM one doesn't support updating sections.
 
 ### Programming Apps in Verilator
 
-An app can be bundled and loaded with the kernel into Verilator with:
+A **single app** in `.tbf (tock binary format)` can be bundled and loaded with the kernel into Verilator with:
 
 ```shell
 $ APP=<...> make BOARD_CONFIGURATION=sim_verilator verilator
+```
+
+### Libtock-C App Verilator Example
+
+To load a libtock-c app, we can do the following to load the `c_hello` sample app:
+
+**Build app:**
+```
+$ git clone https://github.com/tock/libtock-c.git
+$ cd libtock-c/examples/c_hello/
+$ make RISCV=1
+```
+**Load and Run:**
+
+Now, in the Opentitan board directory in tock (`tock/boards/opentitan/earlgrey-cw310`)
+```
+$ APP=<PATH_TO_LIBTOCK-C>/examples/c_hello/build/rv32imc/rv32imc.0x20030080.0x10005000.tbf make BOARD_CONFIGURATION=sim_verilator verilator
+```
+Note: be sure to use the correct `tbf` file here, that is,
+> use: `rv32imc.0x20030080.0x10005000.tbf`
+
+as this falls within the supported app flash region (0x20030080) and ram (0x10005000) regions for Opentitan.
+
+**App Output:**
+
+To see the output, when Verilator loads up it will show the endpoint for the
+pseudoterminal slave, something like `UART: Created /dev/pts/7 for uart0`.
+
+```
+$ screen /dev/pts/7
+.
+...
+OpenTitan initialisation complete. Entering main loop
+Hello World!
 ```
 
 Running in QEMU

--- a/boards/opentitan/earlgrey-cw310/Makefile
+++ b/boards/opentitan/earlgrey-cw310/Makefile
@@ -83,9 +83,9 @@ endif
 		-within $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM)_verilator.bin\
 		-binary -range-pad 8 --output binary.64.vmem --vmem 64
 	$(OPENTITAN_TREE)/bazel-out/k8-fastbuild/bin/hw/build.verilator_real/sim-verilator/Vchip_sim_tb \
-		--meminit=rom,$(OPENTITAN_TREE)/bazel-out/k8-fastbuild-ST-97f470ee3b14/bin/sw/device/lib/testing/test_rom/test_rom_sim_verilator.scr.39.vmem \
+		--meminit=rom,$(OPENTITAN_TREE)/bazel-out/k8-fastbuild-ST-2cc462681f62/bin/sw/device/lib/testing/test_rom/test_rom_sim_verilator.39.scr.vmem \
 		--meminit=flash,./binary.64.vmem \
-		--meminit=otp,$(OPENTITAN_TREE)/bazel-out/k8-fastbuild/bin/hw/ip/otp_ctrl/data/rma_image_verilator.vmem
+		--meminit=otp,$(OPENTITAN_TREE)/bazel-out/k8-fastbuild/bin/hw/ip/otp_ctrl/data/img_rma.24.vmem
 
 test:
 ifneq ($(OPENTITAN_TREE),)
@@ -95,20 +95,17 @@ endif
 	$(Q)cp test_layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/layout.ld
 	$(Q)cp ../../kernel_layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/
 	$(Q)RUSTFLAGS="$(RUSTC_FLAGS_TOCK)" QEMU_ENTRY_POINT=${QEMU_ENTRY_POINT} $(CARGO) test $(CARGO_FLAGS_TOCK_NO_BUILD_STD)  $(NO_RUN) --bin $(PLATFORM) --release
-# Test layout should be removed so that following apps (non-test) load the correct layout.
+# 	Test layout should be removed so that following apps (non-test) load the correct layout.
 	$(Q)rm $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/layout.ld
 
 test-hardware: ot-check
 	mkdir -p $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/
 	$(Q)cp test_layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/layout.ld
 	$(Q)cp ../../kernel_layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/
-	$(Q)RUSTFLAGS="$(RUSTC_FLAGS_TOCK)" $(CARGO) test $(CARGO_FLAGS_TOCK_NO_BUILD_STD) $(NO_RUN) --bin $(PLATFORM) --release --features=hardware_tests
-	$(Q)rm $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/layout.ld
+	$(Q)RUSTFLAGS="$(RUSTC_FLAGS_TOCK)" OBJCOPY=${OBJCOPY} TOCK_ROOT_DIRECTORY=${TOCK_ROOT_DIRECTORY} TARGET=${TARGET} $(CARGO) test $(CARGO_FLAGS_TOCK_NO_BUILD_STD) $(NO_RUN) --bin $(PLATFORM) --release --features=hardware_tests
 
 test-verilator: ot-check
 	mkdir -p $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/
 	$(Q)cp test_layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/layout.ld
 	$(Q)cp ../../kernel_layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/
-	$(Q)RUSTFLAGS="$(RUSTC_FLAGS_TOCK)" VERILATOR="yes" OBJCOPY=${OBJCOPY} $(CARGO) test $(CARGO_FLAGS_TOCK_NO_BUILD_STD) $(NO_RUN) --bin $(PLATFORM) --release --features=hardware_tests --features sim_verilator
-	$(Q)rm $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/layout.ld
-
+	$(Q)RUSTFLAGS="$(RUSTC_FLAGS_TOCK)" VERILATOR="yes" OBJCOPY=${OBJCOPY} TOCK_ROOT_DIRECTORY=${TOCK_ROOT_DIRECTORY} TARGET=${TARGET} $(CARGO) test $(CARGO_FLAGS_TOCK_NO_BUILD_STD) $(NO_RUN) --bin $(PLATFORM) --release --features=hardware_tests --features sim_verilator

--- a/boards/opentitan/earlgrey-cw310/run.sh
+++ b/boards/opentitan/earlgrey-cw310/run.sh
@@ -2,6 +2,9 @@
 
 BUILD_DIR="verilator_build/"
 
+# Preemptively cleanup layout (incase this was a test) so that following apps (non-tests) load the correct layout.
+rm $TOCK_ROOT_DIRECTORY/target/$TARGET/release/deps/layout.ld
+
 if [[ "${VERILATOR}" == "yes" ]]; then
 		if [ -d "$BUILD_DIR" ]; then
 			# Cleanup before we build again
@@ -16,7 +19,7 @@ if [[ "${VERILATOR}" == "yes" ]]; then
 	if [[ "${APP}" != "" ]]; then
 		# An app was specified, copy it in
 		printf "[CW-130: Verilator Tests]: Linking APP...\n\n"
-		riscv64-linux-gnu-objcopy --update-section .apps=${APP} "$BUILD_DIR"/earlgrey-cw310-tests.elf "$BUILD_DIR"/earlgrey-cw310-tests.elf
+		${OBJCOPY} --update-section .apps=${APP} "$BUILD_DIR"/earlgrey-cw310-tests.elf "$BUILD_DIR"/earlgrey-cw310-tests.elf
 	fi
 	${OBJCOPY} --output-target=binary "$BUILD_DIR"/earlgrey-cw310-tests.elf "$BUILD_DIR"/earlgrey-cw310-tests.bin
 	# Create VMEM file from test binary
@@ -29,8 +32,8 @@ if [[ "${VERILATOR}" == "yes" ]]; then
 		--meminit=flash,./"$BUILD_DIR"/binary.64.vmem \
 		--meminit=otp,${OPENTITAN_TREE}/bazel-out/k8-fastbuild/bin/hw/ip/otp_ctrl/data/img_rma.24.vmem
 elif [[ "${OPENTITAN_TREE}" != "" ]]; then
-	riscv64-linux-gnu-objcopy --update-section .apps=${APP} ${1} bundle.elf
-	riscv64-linux-gnu-objcopy --output-target=binary bundle.elf binary
+	${OBJCOPY} --update-section .apps=${APP} ${1} bundle.elf
+	${OBJCOPY} --output-target=binary bundle.elf binary
 
 	${OPENTITAN_TREE}/bazel-bin/sw/host/opentitantool/opentitantool.runfiles/lowrisc_opentitan/sw/host/opentitantool/opentitantool --interface=cw310 bootstrap binary
 else


### PR DESCRIPTION
### Pull Request Overview

Fixes loading of the correct address layout when building an app for Verilator. Added more instructions for building and running a `libtock-c` app on Verilator.

### Testing Strategy

Compiling and running on Verilator.


### TODO or Help Wanted

N/A

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
