### PR TITLE
boards/opentitan: bump OT commit sha

### DIFF
--- a/boards/opentitan/earlgrey-cw310/Makefile
+++ b/boards/opentitan/earlgrey-cw310/Makefile
@@ -11,7 +11,7 @@ QEMU ?= ../../../tools/qemu/build/qemu-system-riscv32
 # ORIGIN(rom) + size_manifest = 0x20000000 + 0x400
 QEMU_ENTRY_POINT=0x20000400
 # Latest supported commmit of OpenTitan
-OPENTITAN_SUPPORTED_SHA := d072ac505f82152678d6e04be95c72b728a347b8
+OPENTITAN_SUPPORTED_SHA := 86a7c5ed3949c531a322d736965a042d833a9794
 
 
 include ../../Makefile.common


### PR DESCRIPTION
### Pull Request Overview

Bumps to the latest supported RTL commit sha, with this update, we didn't need to make any adjustments to Tock. Aim of this is to keep Tock upto date with upstream OpenTitan, so that it is easier to bisect changes when we run in to RTL changes later.

### Testing Strategy

Functionality was tested by running the OpenTitan unit tests on Verilator. Everything seems to be passing.
 
### TODO or Help Wanted

Need to do testing on hardware, @alistair23 when you get some time.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
