### PR TITLE
arch/rv32i/e|pmp: return on addr unalignment 

### DIFF
--- a/arch/rv32i/src/epmp.rs
+++ b/arch/rv32i/src/epmp.rs
@@ -575,22 +575,13 @@ impl<const MAX_AVAILABLE_REGIONS_OVER_TWO: usize> kernel::platform::mpu::MPU
         let region_num = config.unused_region_number(self.locked_region_mask.get())?;
 
         // Logical region
-        let mut start = unallocated_memory_start as usize;
-        let mut size = min_region_size;
+        let start = unallocated_memory_start as usize;
+        let size = min_region_size;
 
-        // Region start always has to align to 4 bytes
-        if start % 4 != 0 {
-            start += 4 - (start % 4);
-        }
-
-        // Region size always has to align to 4 bytes
-        if size % 4 != 0 {
-            size += 4 - (size % 4);
-        }
-
-        // Regions must be at least 8 bytes
-        if size < 8 {
-            size = 8;
+        // Region start and size always has to align to 4 bytes
+        // and size must be at-least 8 bytes
+        if start % 4 != 0 || size % 4 != 0 || size < 8 {
+            return None;
         }
 
         let region = PMPRegion::new_app(start as *const u8, size, permissions);
@@ -903,22 +894,13 @@ impl<const MAX_AVAILABLE_REGIONS_OVER_TWO: usize> kernel::platform::mpu::KernelM
         let region_num = config.unused_kernel_region_number(self.locked_region_mask.get())?;
 
         // Logical region
-        let mut start = memory_start as usize;
-        let mut size = memory_size;
+        let start = memory_start as usize;
+        let size = memory_size;
 
-        // Region start always has to align to 4 bytes
-        if start % 4 != 0 {
-            start += 4 - (start % 4);
-        }
-
-        // Region size always has to align to 4 bytes
-        if size % 4 != 0 {
-            size += 4 - (size % 4);
-        }
-
-        // Regions must be at least 8 bytes
-        if size < 8 {
-            size = 8;
+        // Region start and size always has to align to 4 bytes
+        // and size must be at-least 8 bytes
+        if start % 4 != 0 || size % 4 != 0 || size < 8 {
+            return None;
         }
 
         let region = PMPRegion::new_kernel(start as *const u8, size, permissions);

--- a/arch/rv32i/src/pmp.rs
+++ b/arch/rv32i/src/pmp.rs
@@ -353,22 +353,13 @@ impl<const MAX_AVAILABLE_REGIONS_OVER_TWO: usize> kernel::platform::mpu::MPU
         let region_num = config.unused_region_number(self.locked_region_mask.get())?;
 
         // Logical region
-        let mut start = unallocated_memory_start as usize;
-        let mut size = min_region_size;
+        let start = unallocated_memory_start as usize;
+        let size = min_region_size;
 
-        // Region start always has to align to 4 bytes
-        if start % 4 != 0 {
-            start += 4 - (start % 4);
-        }
-
-        // Region size always has to align to 4 bytes
-        if size % 4 != 0 {
-            size += 4 - (size % 4);
-        }
-
-        // Regions must be at least 8 bytes
-        if size < 8 {
-            size = 8;
+        // Region start and size always has to align to 4 bytes
+        // and size must be at-least 8 bytes
+        if start % 4 != 0 || size % 4 != 0 || size < 8 {
+            return None;
         }
 
         let region = PMPRegion::new(start as *const u8, size, permissions);
@@ -580,22 +571,13 @@ impl<const MAX_AVAILABLE_REGIONS_OVER_TWO: usize> kernel::platform::mpu::KernelM
         let region_num = config.unused_kernel_region_number(self.locked_region_mask.get())?;
 
         // Logical region
-        let mut start = memory_start as usize;
-        let mut size = memory_size;
+        let start = memory_start as usize;
+        let size = memory_size;
 
-        // Region start always has to align to 4 bytes
-        if start % 4 != 0 {
-            start += 4 - (start % 4);
-        }
-
-        // Region size always has to align to 4 bytes
-        if size % 4 != 0 {
-            size += 4 - (size % 4);
-        }
-
-        // Regions must be at least 8 bytes
-        if size < 8 {
-            size = 8;
+        // Region start and size always has to align to 4 bytes
+        // and size must be at-least 8 bytes
+        if start % 4 != 0 || size % 4 != 0 || size < 8 {
+            return None;
         }
 
         let region = PMPRegion::new(start as *const u8, size, permissions);


### PR DESCRIPTION
### Pull Request Overview

Instead of rounding up an un-aligned e/pmp start address, lets return an
error specifying we can't carry out the specified work at this address,
so return `None`.

It is then upto the board to specify the correct aligned address to
configure a pmp region.

### Testing Strategy

Compile and load kernel on Verilator.

### TODO or Help Wanted

This pull request still needs...


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
