### PR TITLE
boards/qemu_rv32_virt: document known issue around app support

### DIFF
--- a/boards/qemu_rv32_virt/README.md
+++ b/boards/qemu_rv32_virt/README.md
@@ -10,6 +10,14 @@ stable QEMU target for using Tock in a virtualized RISC-V environment. This can
 be useful for CI and other purposes. In the future, this target can be extended
 to support VirtIO peripherals.
 
+Known issues: Application Support
+---------------------------------
+
+Upstream QEMU currently contains a bug which makes it impossible to run
+userspace applications due to issues with the enforcement of memory protection
+(PMP). Tock issue [#3316](https://github.com/tock/tock/issues/3316) tracks these
+developments.
+
 Running QEMU
 ------------
 


### PR DESCRIPTION
### Pull Request Overview

This pull request documents a current issue around application support on the QEMU RISC-V 32-bit virt platform board.


### Testing Strategy

N/A


### TODO or Help Wanted

N/A

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
