### PR TITLE
chips/sifive/clint: make generic over timebase `Frequency`

### DIFF
--- a/boards/arty_e21/src/main.rs
+++ b/boards/arty_e21/src/main.rs
@@ -49,7 +49,7 @@ struct ArtyE21 {
     gpio: &'static capsules::gpio::GPIO<'static, arty_e21_chip::gpio::GpioPin<'static>>,
     alarm: &'static capsules::alarm::AlarmDriver<
         'static,
-        VirtualMuxAlarm<'static, sifive::clint::Clint<'static>>,
+        VirtualMuxAlarm<'static, arty_e21_chip::chip::ArtyExxClint<'static>>,
     >,
     led: &'static capsules::led::LedDriver<
         'static,
@@ -176,7 +176,7 @@ pub unsafe fn main() {
     // Create a shared virtualization mux layer on top of a single hardware
     // alarm.
     let mux_alarm = static_init!(
-        MuxAlarm<'static, sifive::clint::Clint>,
+        MuxAlarm<'static, arty_e21_chip::chip::ArtyExxClint>,
         MuxAlarm::new(&peripherals.machinetimer)
     );
     hil::time::Alarm::set_alarm_client(&peripherals.machinetimer, mux_alarm);
@@ -187,16 +187,18 @@ pub unsafe fn main() {
         capsules::alarm::DRIVER_NUM,
         mux_alarm,
     )
-    .finalize(components::alarm_component_static!(sifive::clint::Clint));
+    .finalize(components::alarm_component_static!(
+        arty_e21_chip::chip::ArtyExxClint
+    ));
 
     // TEST for timer
     //
     // let virtual_alarm_test = static_init!(
-    //     VirtualMuxAlarm<'static, sifive::clint::Clint>,
+    //     VirtualMuxAlarm<'static, arty_e21_chip::chip::ArtyExxClint>,
     //     VirtualMuxAlarm::new(mux_alarm)
     // );
     // let timertest = static_init!(
-    //     timer_test::TimerTest<'static, VirtualMuxAlarm<'static, sifive::clint::Clint>>,
+    //     timer_test::TimerTest<'static, VirtualMuxAlarm<'static, arty_e21_chip::chip::ArtyExxClint>>,
     //     timer_test::TimerTest::new(virtual_alarm_test)
     // );
     // virtual_alarm_test.set_client(timertest);
@@ -267,7 +269,7 @@ pub unsafe fn main() {
     // Uncomment to run tests
     //timertest.start();
     /*components::test::multi_alarm_test::MultiAlarmTestComponent::new(mux_alarm)
-    .finalize(components::multi_alarm_test_component_buf!(sifive::clint::Clint))
+    .finalize(components::multi_alarm_test_component_buf!(arty_e21_chip::chip::ArtyExxClint))
     .run();*/
 
     // These symbols are defined in the linker script.

--- a/boards/hifive1/src/main.rs
+++ b/boards/hifive1/src/main.rs
@@ -62,11 +62,12 @@ struct HiFive1 {
     >,
     alarm: &'static capsules::alarm::AlarmDriver<
         'static,
-        VirtualMuxAlarm<'static, sifive::clint::Clint<'static>>,
+        VirtualMuxAlarm<'static, e310_g002::chip::E310xClint<'static>>,
     >,
     scheduler: &'static CooperativeSched<'static>,
-    scheduler_timer:
-        &'static VirtualSchedulerTimer<VirtualMuxAlarm<'static, sifive::clint::Clint<'static>>>,
+    scheduler_timer: &'static VirtualSchedulerTimer<
+        VirtualMuxAlarm<'static, e310_g002::chip::E310xClint<'static>>,
+    >,
 }
 
 /// Mapping of integer syscalls to objects that implement syscalls.
@@ -94,7 +95,7 @@ impl KernelResources<e310_g002::chip::E310x<'static, E310G002DefaultPeripherals<
     type CredentialsCheckingPolicy = ();
     type Scheduler = CooperativeSched<'static>;
     type SchedulerTimer =
-        VirtualSchedulerTimer<VirtualMuxAlarm<'static, sifive::clint::Clint<'static>>>;
+        VirtualSchedulerTimer<VirtualMuxAlarm<'static, e310_g002::chip::E310xClint<'static>>>;
     type WatchDog = ();
     type ContextSwitchCallback = ();
 
@@ -248,34 +249,37 @@ pub unsafe fn main() {
     );
 
     let hardware_timer = static_init!(
-        sifive::clint::Clint,
-        sifive::clint::Clint::new(&e310_g002::clint::CLINT_BASE)
+        e310_g002::chip::E310xClint,
+        e310_g002::chip::E310xClint::new(&e310_g002::clint::CLINT_BASE)
     );
 
     // Create a shared virtualization mux layer on top of a single hardware
     // alarm.
     let mux_alarm = static_init!(
-        MuxAlarm<'static, sifive::clint::Clint>,
+        MuxAlarm<'static, e310_g002::chip::E310xClint>,
         MuxAlarm::new(hardware_timer)
     );
     hil::time::Alarm::set_alarm_client(hardware_timer, mux_alarm);
 
     // Alarm
     let virtual_alarm_user = static_init!(
-        VirtualMuxAlarm<'static, sifive::clint::Clint>,
+        VirtualMuxAlarm<'static, e310_g002::chip::E310xClint>,
         VirtualMuxAlarm::new(mux_alarm)
     );
     virtual_alarm_user.setup();
 
     let systick_virtual_alarm = static_init!(
-        VirtualMuxAlarm<'static, sifive::clint::Clint>,
+        VirtualMuxAlarm<'static, e310_g002::chip::E310xClint>,
         VirtualMuxAlarm::new(mux_alarm)
     );
     systick_virtual_alarm.setup();
 
     let memory_allocation_cap = create_capability!(capabilities::MemoryAllocationCapability);
     let alarm = static_init!(
-        capsules::alarm::AlarmDriver<'static, VirtualMuxAlarm<'static, sifive::clint::Clint>>,
+        capsules::alarm::AlarmDriver<
+            'static,
+            VirtualMuxAlarm<'static, e310_g002::chip::E310xClint>,
+        >,
         capsules::alarm::AlarmDriver::new(
             virtual_alarm_user,
             board_kernel.create_grant(capsules::alarm::DRIVER_NUM, &memory_allocation_cap)
@@ -300,7 +304,7 @@ pub unsafe fn main() {
         process_printer,
     )
     .finalize(components::process_console_component_static!(
-        sifive::clint::Clint
+        e310_g002::chip::E310xClint
     ));
     let _ = process_console.start();
 
@@ -341,7 +345,7 @@ pub unsafe fn main() {
         .finalize(components::cooperative_component_static!(NUM_PROCS));
 
     let scheduler_timer = static_init!(
-        VirtualSchedulerTimer<VirtualMuxAlarm<'static, sifive::clint::Clint<'static>>>,
+        VirtualSchedulerTimer<VirtualMuxAlarm<'static, e310_g002::chip::E310xClint<'static>>>,
         VirtualSchedulerTimer::new(systick_virtual_alarm)
     );
 

--- a/boards/hifive_inventor/src/main.rs
+++ b/boards/hifive_inventor/src/main.rs
@@ -52,11 +52,12 @@ struct HiFiveInventor {
     >,
     alarm: &'static capsules::alarm::AlarmDriver<
         'static,
-        VirtualMuxAlarm<'static, sifive::clint::Clint<'static>>,
+        VirtualMuxAlarm<'static, e310_g003::chip::E310xClint<'static>>,
     >,
     scheduler: &'static CooperativeSched<'static>,
-    scheduler_timer:
-        &'static VirtualSchedulerTimer<VirtualMuxAlarm<'static, sifive::clint::Clint<'static>>>,
+    scheduler_timer: &'static VirtualSchedulerTimer<
+        VirtualMuxAlarm<'static, e310_g003::chip::E310xClint<'static>>,
+    >,
 }
 
 /// Mapping of integer syscalls to objects that implement syscalls.
@@ -83,7 +84,7 @@ impl KernelResources<e310_g003::chip::E310x<'static, E310G003DefaultPeripherals<
     type CredentialsCheckingPolicy = ();
     type Scheduler = CooperativeSched<'static>;
     type SchedulerTimer =
-        VirtualSchedulerTimer<VirtualMuxAlarm<'static, sifive::clint::Clint<'static>>>;
+        VirtualSchedulerTimer<VirtualMuxAlarm<'static, e310_g003::chip::E310xClint<'static>>>;
     type WatchDog = ();
     type ContextSwitchCallback = ();
 
@@ -178,33 +179,36 @@ pub unsafe fn main() {
     .finalize(components::uart_mux_component_static!());
 
     let hardware_timer = static_init!(
-        sifive::clint::Clint,
-        sifive::clint::Clint::new(&e310_g003::clint::CLINT_BASE)
+        e310_g003::chip::E310xClint,
+        e310_g003::chip::E310xClint::new(&e310_g003::clint::CLINT_BASE)
     );
 
     // Create a shared virtualization mux layer on top of a single hardware
     // alarm.
     let mux_alarm = static_init!(
-        MuxAlarm<'static, sifive::clint::Clint>,
+        MuxAlarm<'static, e310_g003::chip::E310xClint>,
         MuxAlarm::new(hardware_timer)
     );
     hil::time::Alarm::set_alarm_client(hardware_timer, mux_alarm);
 
     // Alarm
     let virtual_alarm_user = static_init!(
-        VirtualMuxAlarm<'static, sifive::clint::Clint>,
+        VirtualMuxAlarm<'static, e310_g003::chip::E310xClint>,
         VirtualMuxAlarm::new(mux_alarm)
     );
     virtual_alarm_user.setup();
 
     let systick_virtual_alarm = static_init!(
-        VirtualMuxAlarm<'static, sifive::clint::Clint>,
+        VirtualMuxAlarm<'static, e310_g003::chip::E310xClint>,
         VirtualMuxAlarm::new(mux_alarm)
     );
     systick_virtual_alarm.setup();
 
     let alarm = static_init!(
-        capsules::alarm::AlarmDriver<'static, VirtualMuxAlarm<'static, sifive::clint::Clint>>,
+        capsules::alarm::AlarmDriver<
+            'static,
+            VirtualMuxAlarm<'static, e310_g003::chip::E310xClint>,
+        >,
         capsules::alarm::AlarmDriver::new(
             virtual_alarm_user,
             board_kernel.create_grant(capsules::alarm::DRIVER_NUM, &memory_allocation_cap)
@@ -229,7 +233,7 @@ pub unsafe fn main() {
         process_printer,
     )
     .finalize(components::process_console_component_static!(
-        sifive::clint::Clint
+        e310_g003::chip::E310xClint
     ));
     let _ = process_console.start();
 
@@ -278,7 +282,7 @@ pub unsafe fn main() {
         .finalize(components::cooperative_component_static!(NUM_PROCS));
 
     let scheduler_timer = static_init!(
-        VirtualSchedulerTimer<VirtualMuxAlarm<'static, sifive::clint::Clint<'static>>>,
+        VirtualSchedulerTimer<VirtualMuxAlarm<'static, e310_g003::chip::E310xClint<'static>>>,
         VirtualSchedulerTimer::new(systick_virtual_alarm)
     );
 

--- a/boards/redboard_redv/src/main.rs
+++ b/boards/redboard_redv/src/main.rs
@@ -60,11 +60,12 @@ struct RedV {
     >,
     alarm: &'static capsules::alarm::AlarmDriver<
         'static,
-        VirtualMuxAlarm<'static, sifive::clint::Clint<'static>>,
+        VirtualMuxAlarm<'static, e310_g002::chip::E310xClint<'static>>,
     >,
     scheduler: &'static CooperativeSched<'static>,
-    scheduler_timer:
-        &'static VirtualSchedulerTimer<VirtualMuxAlarm<'static, sifive::clint::Clint<'static>>>,
+    scheduler_timer: &'static VirtualSchedulerTimer<
+        VirtualMuxAlarm<'static, e310_g002::chip::E310xClint<'static>>,
+    >,
 }
 
 /// Mapping of integer syscalls to objects that implement syscalls.
@@ -92,7 +93,7 @@ impl KernelResources<e310_g002::chip::E310x<'static, E310G002DefaultPeripherals<
     type CredentialsCheckingPolicy = ();
     type Scheduler = CooperativeSched<'static>;
     type SchedulerTimer =
-        VirtualSchedulerTimer<VirtualMuxAlarm<'static, sifive::clint::Clint<'static>>>;
+        VirtualSchedulerTimer<VirtualMuxAlarm<'static, e310_g002::chip::E310xClint<'static>>>;
     type WatchDog = ();
     type ContextSwitchCallback = ();
 
@@ -191,33 +192,36 @@ pub unsafe fn main() {
     );
 
     let hardware_timer = static_init!(
-        sifive::clint::Clint,
-        sifive::clint::Clint::new(&e310_g002::clint::CLINT_BASE)
+        e310_g002::chip::E310xClint,
+        e310_g002::chip::E310xClint::new(&e310_g002::clint::CLINT_BASE)
     );
 
     // Create a shared virtualization mux layer on top of a single hardware
     // alarm.
     let mux_alarm = static_init!(
-        MuxAlarm<'static, sifive::clint::Clint>,
+        MuxAlarm<'static, e310_g002::chip::E310xClint>,
         MuxAlarm::new(hardware_timer)
     );
     hil::time::Alarm::set_alarm_client(hardware_timer, mux_alarm);
 
     // Alarm
     let virtual_alarm_user = static_init!(
-        VirtualMuxAlarm<'static, sifive::clint::Clint>,
+        VirtualMuxAlarm<'static, e310_g002::chip::E310xClint>,
         VirtualMuxAlarm::new(mux_alarm)
     );
     virtual_alarm_user.setup();
 
     let systick_virtual_alarm = static_init!(
-        VirtualMuxAlarm<'static, sifive::clint::Clint>,
+        VirtualMuxAlarm<'static, e310_g002::chip::E310xClint>,
         VirtualMuxAlarm::new(mux_alarm)
     );
     systick_virtual_alarm.setup();
 
     let alarm = static_init!(
-        capsules::alarm::AlarmDriver<'static, VirtualMuxAlarm<'static, sifive::clint::Clint>>,
+        capsules::alarm::AlarmDriver<
+            'static,
+            VirtualMuxAlarm<'static, e310_g002::chip::E310xClint>,
+        >,
         capsules::alarm::AlarmDriver::new(
             virtual_alarm_user,
             board_kernel.create_grant(capsules::alarm::DRIVER_NUM, &memory_allocation_cap)
@@ -242,7 +246,7 @@ pub unsafe fn main() {
         process_printer,
     )
     .finalize(components::process_console_component_static!(
-        sifive::clint::Clint
+        e310_g002::chip::E310xClint
     ));
     let _ = process_console.start();
 
@@ -295,7 +299,7 @@ pub unsafe fn main() {
         .finalize(components::cooperative_component_static!(NUM_PROCS));
 
     let scheduler_timer = static_init!(
-        VirtualSchedulerTimer<VirtualMuxAlarm<'static, sifive::clint::Clint<'static>>>,
+        VirtualSchedulerTimer<VirtualMuxAlarm<'static, e310_g002::chip::E310xClint<'static>>>,
         VirtualSchedulerTimer::new(systick_virtual_alarm)
     );
 

--- a/chips/e310x/src/chip.rs
+++ b/chips/e310x/src/chip.rs
@@ -14,14 +14,17 @@ use crate::deferred_call_tasks::DeferredCallTask;
 use crate::plic::PLIC;
 use crate::uart::DEFERRED_CALLS;
 use kernel::deferred_call;
+use kernel::hil::time::Freq32KHz;
 use kernel::platform::chip::InterruptService;
 use sifive::plic::Plic;
+
+pub type E310xClint<'a> = sifive::clint::Clint<'a, Freq32KHz>;
 
 pub struct E310x<'a, I: InterruptService<DeferredCallTask> + 'a> {
     userspace_kernel_boundary: rv32i::syscall::SysCall,
     pmp: PMP<4>,
     plic: &'a Plic,
-    timer: &'a sifive::clint::Clint<'a>,
+    timer: &'a E310xClint<'a>,
     plic_interrupt_service: &'a I,
 }
 
@@ -68,7 +71,7 @@ impl<'a> InterruptService<DeferredCallTask> for E310xDefaultPeripherals<'a> {
 }
 
 impl<'a, I: InterruptService<DeferredCallTask> + 'a> E310x<'a, I> {
-    pub unsafe fn new(plic_interrupt_service: &'a I, timer: &'a sifive::clint::Clint<'a>) -> Self {
+    pub unsafe fn new(plic_interrupt_service: &'a I, timer: &'a E310xClint<'a>) -> Self {
         Self {
             userspace_kernel_boundary: rv32i::syscall::SysCall::new(),
             pmp: PMP::new(),

--- a/chips/qemu_rv32_virt_chip/src/chip.rs
+++ b/chips/qemu_rv32_virt_chip/src/chip.rs
@@ -4,6 +4,7 @@ use core::fmt::Write;
 
 use kernel;
 use kernel::debug;
+use kernel::hil::time::Freq10MHz;
 use kernel::platform::chip::{Chip, InterruptService};
 
 use kernel::utilities::registers::interfaces::{ReadWriteable, Readable};
@@ -19,11 +20,13 @@ use crate::interrupts;
 
 type QemuRv32VirtPMP = PMP<8>;
 
+pub type QemuRv32VirtClint<'a> = sifive::clint::Clint<'a, Freq10MHz>;
+
 pub struct QemuRv32VirtChip<'a, I: InterruptService<()> + 'a> {
     userspace_kernel_boundary: rv32i::syscall::SysCall,
     pmp: QemuRv32VirtPMP,
     plic: &'a Plic,
-    timer: &'a sifive::clint::Clint<'a>,
+    timer: &'a QemuRv32VirtClint<'a>,
     plic_interrupt_service: &'a I,
 }
 
@@ -56,7 +59,7 @@ impl<'a> InterruptService<()> for QemuRv32VirtDefaultPeripherals<'a> {
 }
 
 impl<'a, I: InterruptService<()> + 'a> QemuRv32VirtChip<'a, I> {
-    pub unsafe fn new(plic_interrupt_service: &'a I, timer: &'a sifive::clint::Clint<'a>) -> Self {
+    pub unsafe fn new(plic_interrupt_service: &'a I, timer: &'a QemuRv32VirtClint<'a>) -> Self {
         Self {
             userspace_kernel_boundary: rv32i::syscall::SysCall::new(),
             pmp: PMP::new(),

--- a/kernel/src/hil/time.rs
+++ b/kernel/src/hil/time.rs
@@ -316,21 +316,25 @@ pub trait Timer<'a>: Time {
     fn cancel(&self) -> Result<(), ErrorCode>;
 }
 
+// The following "frequencies" are represented as variant-less enums. Because
+// they can never be constructed, it forces them to be used purely as
+// type-markers which are guaranteed to be elided at runtime.
+
 /// 100MHz `Frequency`
 #[derive(Debug)]
-pub struct Freq100MHz;
+pub enum Freq100MHz {}
 impl Frequency for Freq100MHz {
     fn frequency() -> u32 {
-        100000000
+        100_000_000
     }
 }
 
 /// 16MHz `Frequency`
 #[derive(Debug)]
-pub struct Freq16MHz;
+pub enum Freq16MHz {}
 impl Frequency for Freq16MHz {
     fn frequency() -> u32 {
-        16000000
+        16_000_000
     }
 }
 
@@ -338,43 +342,43 @@ impl Frequency for Freq16MHz {
 pub enum Freq10MHz {}
 impl Frequency for Freq10MHz {
     fn frequency() -> u32 {
-        10000000
+        10_000_000
     }
 }
 
 /// 1MHz `Frequency`
 #[derive(Debug)]
-pub struct Freq1MHz;
+pub enum Freq1MHz {}
 impl Frequency for Freq1MHz {
     fn frequency() -> u32 {
-        1000000
+        1_000_000
     }
 }
 
-/// 32KHz `Frequency`
+/// 32.768KHz `Frequency`
 #[derive(Debug)]
-pub struct Freq32KHz;
+pub enum Freq32KHz {}
 impl Frequency for Freq32KHz {
     fn frequency() -> u32 {
-        32768
+        32_768
     }
 }
 
 /// 16KHz `Frequency`
 #[derive(Debug)]
-pub struct Freq16KHz;
+pub enum Freq16KHz {}
 impl Frequency for Freq16KHz {
     fn frequency() -> u32 {
-        16000
+        16_000
     }
 }
 
 /// 1KHz `Frequency`
 #[derive(Debug)]
-pub struct Freq1KHz;
+pub enum Freq1KHz {}
 impl Frequency for Freq1KHz {
     fn frequency() -> u32 {
-        1000
+        1_000
     }
 }
 

--- a/kernel/src/hil/time.rs
+++ b/kernel/src/hil/time.rs
@@ -334,6 +334,14 @@ impl Frequency for Freq16MHz {
     }
 }
 
+/// 10MHz `Frequency`
+pub enum Freq10MHz {}
+impl Frequency for Freq10MHz {
+    fn frequency() -> u32 {
+        10000000
+    }
+}
+
 /// 1MHz `Frequency`
 #[derive(Debug)]
 pub struct Freq1MHz;


### PR DESCRIPTION
### Pull Request Overview

It turns out that at least the QEMU emulated boards (`hifive1` and `qemu_rv32_virt`) provide a Clint timebase of 10MHz, whereas the previous implementation (and presumably physical chips) assumed a timebase of 32KHz. This forwards the frequency as a generic parameter over the `Clint` struct, such that the driver implementation can be shared between chips but the frequency adjusted to meet the actual underlying hardware. It furthermore corrects the `qemu_rv32_virt` board to use the proper 10MHz frequency.

While we're at it and introducing a new 10KHz `Frequency` into the time HIL, this further converts the existing `Frequency` structs into variant-less enums, which is best practice for marker-types which are not supposed to be used at runtime, and formats the frequency number literals for readability. 

### Testing Strategy

This pull request was tested by compiling and running in QEMU.


### TODO or Help Wanted

This doesn't solve the problem around the QEMU `hifive1` board, where there is a mismatch between the expected timebase frequency still. Presumably the 32KHz are correct (this [thread](https://forums.sifive.com/t/clint-and-sleep/2355) seems to indicate that), so maybe this should be changed in QEMU?

### Documentation Updated

- [x] ~Updated the relevant files in `/docs`,~ or no updates are required.

### Formatting

- [x] Ran `make prepush`.
