### PR TITLE
chips/lowrisc: small refactor / reduce some bloat

### DIFF
--- a/chips/lowrisc/src/i2c.rs
+++ b/chips/lowrisc/src/i2c.rs
@@ -270,7 +270,8 @@ impl<'a> I2c<'_> {
                     break;
                 }
                 // Send the data
-                regs.fdata.write(FDATA::FBYTE.val(buf[i as usize] as u32));
+                regs.fdata
+                    .write(FDATA::FBYTE.val(*buf.get(i).unwrap_or(&0) as u32));
                 data_pushed = i;
             }
 
@@ -278,7 +279,7 @@ impl<'a> I2c<'_> {
             if regs.status.read(STATUS::FMTFULL) == 0 && data_pushed == (len - 1) {
                 // Send the last byte with the stop signal
                 regs.fdata
-                    .write(FDATA::FBYTE.val(buf[len as usize] as u32) + FDATA::STOP::SET);
+                    .write(FDATA::FBYTE.val(*buf.get(len).unwrap_or(&0) as u32) + FDATA::STOP::SET);
 
                 data_pushed = len;
             }
@@ -317,7 +318,8 @@ impl<'a> I2c<'_> {
                     break;
                 }
                 // Send the data
-                regs.fdata.write(FDATA::FBYTE.val(buf[i as usize] as u32));
+                regs.fdata
+                    .write(FDATA::FBYTE.val(*buf.get(i).unwrap_or(&0) as u32));
                 data_pushed = i;
             }
 
@@ -325,7 +327,7 @@ impl<'a> I2c<'_> {
             if regs.status.read(STATUS::FMTFULL) == 0 && data_pushed == (len - 1) {
                 // Send the last byte with the stop signal
                 regs.fdata
-                    .write(FDATA::FBYTE.val(buf[len as usize] as u32) + FDATA::STOP::SET);
+                    .write(FDATA::FBYTE.val(*buf.get(len).unwrap_or(&0) as u32) + FDATA::STOP::SET);
 
                 data_pushed = len;
             }

--- a/chips/lowrisc/src/uart.rs
+++ b/chips/lowrisc/src/uart.rs
@@ -200,7 +200,8 @@ impl<'a> Uart<'a> {
                         break;
                     }
                     let tx_idx = idx + i;
-                    regs.wdata.write(wdata::data.val(tx_buf[tx_idx] as u32));
+                    let data: u32 = *tx_buf.get(tx_idx).unwrap_or(&0) as u32;
+                    regs.wdata.write(wdata::data.val(data));
                     self.tx_index.set(tx_idx + 1)
                 }
             });


### PR DESCRIPTION
### Pull Request Overview

Trim a little bit of the bloat...
```
For hmac.rs:
    0.0%   0.2%     266B         lowrisc <lowrisc::hmac::Hmac as kernel::hil::digest::HmacSha256>::set_mode_hmacsha256
->  0.0%   0.2%     236B         lowrisc <lowrisc::hmac::Hmac as kernel::hil::digest::HmacSha256>::set_mode_hmacsha256

For uart.rs:
   0.0%   0.1%     102B         lowrisc lowrisc::uart::Uart::tx_progress
-> 0.0%   0.1%      84B         lowrisc lowrisc::uart::Uart::tx_progress

For i2c.rs
   0.0%   0.2%     276B         lowrisc lowrisc::i2c::I2c::write_data
-> 0.0%   0.2%     266B         lowrisc lowrisc::i2c::I2c::write_data

   0.0%   0.2%     244B         lowrisc lowrisc::i2c::I2c::write_read_data
-> 0.0%   0.2%     232B         lowrisc lowrisc::i2c::I2c::read_data

   0.0%   0.2%     232B         lowrisc lowrisc::i2c::I2c::read_data
-> 0.0%   0.2%     224B         lowrisc lowrisc::i2c::I2c::  write_read_data

For flash.rs
   0.0%   0.0%      60B         lowrisc lowrisc::flash_ctrl::FlashCtrl::configure_data_partition
-> 0.0%   0.0%      56B         lowrisc lowrisc::flash_ctrl::FlashCtrl::configure_data_partition

   0.0%   0.0%      46B         lowrisc lowrisc::flash_ctrl::FlashCtrl::configure_info_partition
-> 0.0%   0.0%      42B         lowrisc lowrisc::flash_ctrl::FlashCtrl::configure_info_partition

Total: ~86B
```

### Testing Strategy

Running the `hmac`, `flash` tests on Verilator, `i2c` was **NOT** tested.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
