### PR TITLE
Rename `matches_any()` to `any_matching_bits_set()`, implement new `matches_any()`

### DIFF
--- a/chips/apollo3/src/stimer.rs
+++ b/chips/apollo3/src/stimer.rs
@@ -152,7 +152,7 @@ impl<'a> Counter<'a> for STimer<'a> {
 
     fn is_running(&self) -> bool {
         let regs = self.registers;
-        regs.stcfg.matches_any(STCFG::CLKSEL::XTAL_DIV2)
+        regs.stcfg.matches_any(&[STCFG::CLKSEL::XTAL_DIV2])
     }
 }
 

--- a/chips/e310x/src/chip.rs
+++ b/chips/e310x/src/chip.rs
@@ -147,7 +147,9 @@ impl<'a, I: InterruptService<DeferredCallTask> + 'a> kernel::platform::chip::Chi
                 }
             }
 
-            if !mip.matches_any(mip::mtimer::SET) && self.plic.get_saved_interrupts().is_none() {
+            if !mip.any_matching_bits_set(mip::mtimer::SET)
+                && self.plic.get_saved_interrupts().is_none()
+            {
                 break;
             }
         }

--- a/chips/litex/src/litex_registers.rs
+++ b/chips/litex/src/litex_registers.rs
@@ -186,7 +186,7 @@ pub trait Read<T: UIntLike> {
     fn is_set(&self, field: Field<T, Self::Reg>) -> bool;
 
     /// Check if any specified parts of a field match
-    fn matches_any(&self, field: FieldValue<T, Self::Reg>) -> bool;
+    fn any_matching_bits_set(&self, field: FieldValue<T, Self::Reg>) -> bool;
 
     /// Check if all specified parts of a field match
     fn matches_all(&self, field: FieldValue<T, Self::Reg>) -> bool;
@@ -273,8 +273,8 @@ where
     }
 
     #[inline]
-    fn matches_any(&self, field: FieldValue<T, Self::Reg>) -> bool {
-        field.matches_any(self.get())
+    fn any_matching_bits_set(&self, field: FieldValue<T, Self::Reg>) -> bool {
+        field.any_matching_bits_set(self.get())
     }
 
     #[inline]

--- a/chips/nrf52/src/acomp.rs
+++ b/chips/nrf52/src/acomp.rs
@@ -231,7 +231,11 @@ impl<'a> Comparator<'a> {
     fn enable(&self) {
         // Checks if it's already enabled
         // Assumes no one else is writing to comp registers directly
-        if self.registers.enable.matches_any(Enable::ENABLE::Enabled) {
+        if self
+            .registers
+            .enable
+            .any_matching_bits_set(Enable::ENABLE::Enabled)
+        {
             return;
         }
 

--- a/chips/nrf5x/src/gpio.rs
+++ b/chips/nrf5x/src/gpio.rs
@@ -483,7 +483,7 @@ impl<'a> hil::gpio::Interrupt<'a> for GPIOPin<'a> {
     fn is_pending(&self) -> bool {
         if let Ok(channel) = self.find_channel(self.pin) {
             let ev = &self.gpiote_registers.event_in[channel];
-            ev.matches_any(EventsIn::EVENT::Ready)
+            ev.any_matching_bits_set(EventsIn::EVENT::Ready)
         } else {
             false
         }
@@ -576,7 +576,7 @@ impl<'a, const N: usize> Port<'a, N> {
         let pin_registers = self.pins[0].gpiote_registers;
 
         for (i, ev) in pin_registers.event_in.iter().enumerate() {
-            if ev.matches_any(EventsIn::EVENT::Ready) {
+            if ev.any_matching_bits_set(EventsIn::EVENT::Ready) {
                 ev.write(EventsIn::EVENT::NotReady);
                 // Get pin number for the event and `trigger` an interrupt manually on that pin
                 let pin = pin_registers.config[i].read(Config::PSEL) as usize;

--- a/chips/qemu_rv32_virt_chip/src/chip.rs
+++ b/chips/qemu_rv32_virt_chip/src/chip.rs
@@ -131,7 +131,9 @@ impl<'a, I: InterruptService<()> + 'a> Chip for QemuRv32VirtChip<'a, I> {
                 }
             }
 
-            if !mip.matches_any(mip::mtimer::SET) && self.plic.get_saved_interrupts().is_none() {
+            if !mip.any_matching_bits_set(mip::mtimer::SET)
+                && self.plic.get_saved_interrupts().is_none()
+            {
                 break;
             }
         }

--- a/chips/sam4l/src/i2c.rs
+++ b/chips/sam4l/src/i2c.rs
@@ -1027,7 +1027,7 @@ impl I2CHw {
             let interrupts = status.bitand(imr.get());
 
             // Check for errors.
-            if interrupts.matches_any(
+            if interrupts.any_matching_bits_set(
                 StatusSlave::BUSERR::SET
                     + StatusSlave::SMBPECERR::SET
                     + StatusSlave::SMBTOUT::SET

--- a/chips/sam4l/src/usart.rs
+++ b/chips/sam4l/src/usart.rs
@@ -330,7 +330,7 @@ impl<'a> USARTRegManager<'a> {
 impl Drop for USARTRegManager<'_> {
     fn drop(&mut self) {
         // Anything listening for RX or TX interrupts?
-        let ints_active = self.registers.imr.matches_any(
+        let ints_active = self.registers.imr.any_matching_bits_set(
             Interrupt::RXBUFF::SET
                 + Interrupt::TXEMPTY::SET
                 + Interrupt::TIMEOUT::SET

--- a/chips/swervolf-eh1/src/chip.rs
+++ b/chips/swervolf-eh1/src/chip.rs
@@ -145,7 +145,7 @@ impl<'a, I: InterruptService<()> + 'a> kernel::platform::chip::Chip for SweRVolf
                 }
             }
 
-            if !mip.matches_any(mip::mtimer::SET)
+            if !mip.any_matching_bits_set(mip::mtimer::SET)
                 && !unsafe { TIMER0_IRQ.get() }
                 && !unsafe { TIMER1_IRQ.get() }
                 && self.pic.get_saved_interrupts().is_none()
@@ -163,7 +163,7 @@ impl<'a, I: InterruptService<()> + 'a> kernel::platform::chip::Chip for SweRVolf
     fn has_pending_interrupts(&self) -> bool {
         let mip = CSR.mip.extract();
         self.pic.get_saved_interrupts().is_some()
-            || mip.matches_any(mip::mtimer::SET)
+            || mip.any_matching_bits_set(mip::mtimer::SET)
             || unsafe { TIMER0_IRQ.get() }
             || unsafe { TIMER1_IRQ.get() }
     }

--- a/libraries/tock-register-interface/src/fields.rs
+++ b/libraries/tock-register-interface/src/fields.rs
@@ -256,10 +256,12 @@ impl<T: UIntLike, R: RegisterLongName> FieldValue<T, R> {
         (val & !self.mask) | self.value
     }
 
-    /// Check if any specified parts of a field match
+    /// Check if any of the bits covered by the mask for this
+    /// `FieldValue` and set in the `FieldValue` are also set
+    /// in the passed value
     #[inline]
-    pub fn matches_any(&self, val: T) -> bool {
-        val & self.mask != T::zero()
+    pub fn any_matching_bits_set(&self, val: T) -> bool {
+        val & self.mask & self.value != T::zero()
     }
 
     /// Check if all specified parts of a field match
@@ -504,7 +506,6 @@ macro_rules! register_bitfields {
     }
 }
 
-#[cfg(feature = "std_unit_tests")]
 #[cfg(test)]
 mod tests {
     #[derive(Debug, PartialEq, Eq)]
@@ -679,22 +680,20 @@ mod tests {
         }
 
         #[test]
-        fn test_matches_any() {
+        fn test_any_matching_bits_set() {
             let field = Field::<u32, ()>::new(0xFF, 4);
-            assert_eq!(field.val(0x23).matches_any(0x1234), true);
-            assert_eq!(field.val(0x23).matches_any(0x5678), true);
-            assert_eq!(field.val(0x23).matches_any(0x5008), false);
+            assert_eq!(field.val(0x23).any_matching_bits_set(0x1234), true);
+            assert_eq!(field.val(0x23).any_matching_bits_set(0x5678), true);
+            assert_eq!(field.val(0x23).any_matching_bits_set(0x5008), false);
 
             for shift in 0..24 {
                 let field = Field::<u32, ()>::new(0xFF, shift);
-                for x in 0..=0xFF {
-                    let field_value = field.val(x);
-                    for y in 1..=0xFF {
-                        assert_eq!(field_value.matches_any(y << shift), true);
-                    }
-                    assert_eq!(field_value.matches_any(0), false);
-                    assert_eq!(field_value.matches_any(!(0xFF << shift)), false);
+                let field_value = field.val(0xff);
+                for y in 1..=0xff {
+                    assert_eq!(field_value.any_matching_bits_set(y << shift), true,);
                 }
+                assert_eq!(field_value.any_matching_bits_set(0), false);
+                assert_eq!(field_value.any_matching_bits_set(!(0xFF << shift)), false);
             }
         }
 
@@ -711,6 +710,35 @@ mod tests {
                     assert_eq!(field.val(x + 1).matches_all(x << shift), false);
                 }
             }
+        }
+
+        #[test]
+        fn test_matches_any() {
+            register_bitfields! {
+                u32,
+
+                TEST [
+                    FLAG OFFSET(18) NUMBITS(1) [],
+                    SIZE OFFSET(0) NUMBITS(2) [
+                        Byte = 0,
+                        Halfword = 1,
+                        Word = 2
+                    ],
+                ]
+            }
+
+            let value: crate::LocalRegisterCopy<u32, TEST::Register> =
+                crate::LocalRegisterCopy::new(2);
+            assert!(value.matches_any(&[TEST::SIZE::Word]));
+            assert!(!value.matches_any(&[TEST::SIZE::Halfword]));
+            assert!(!value.matches_any(&[TEST::SIZE::Byte]));
+            assert!(value.matches_any(&[TEST::SIZE::Word, TEST::FLAG::SET]));
+            assert!(value.matches_any(&[TEST::SIZE::Halfword, TEST::FLAG::CLEAR]));
+            assert!(!value.matches_any(&[TEST::SIZE::Halfword, TEST::FLAG::SET]));
+            let value: crate::LocalRegisterCopy<u32, TEST::Register> =
+                crate::LocalRegisterCopy::new(266241);
+            assert!(value.matches_any(&[TEST::FLAG::SET]));
+            assert!(!value.matches_any(&[TEST::FLAG::CLEAR]));
         }
 
         #[test]

--- a/libraries/tock-register-interface/src/interfaces.rs
+++ b/libraries/tock-register-interface/src/interfaces.rs
@@ -230,16 +230,29 @@ pub trait Readable {
         field.is_set(self.get())
     }
 
+    /// Check if any bits corresponding to the mask in the passed `FieldValue` are set.
+    /// This function is identical to `is_set()` but operates on a `FieldValue` rather
+    /// than a `Field`, allowing for checking if any bits are set across multiple,
+    /// non-contiguous portions of a bitfield.
     #[inline]
-    /// Check if any specified parts of a field match
-    fn matches_any(&self, field: FieldValue<Self::T, Self::R>) -> bool {
-        field.matches_any(self.get())
+    fn any_matching_bits_set(&self, field: FieldValue<Self::T, Self::R>) -> bool {
+        field.any_matching_bits_set(self.get())
     }
 
     #[inline]
     /// Check if all specified parts of a field match
     fn matches_all(&self, field: FieldValue<Self::T, Self::R>) -> bool {
         field.matches_all(self.get())
+    }
+
+    /// Check if any of the passed parts of a field exactly match the contained
+    /// value. This allows for matching on unset bits, or matching on specific values
+    /// in multi-bit fields.
+    #[inline]
+    fn matches_any(&self, fields: &[FieldValue<Self::T, Self::R>]) -> bool {
+        fields
+            .iter()
+            .any(|field| self.get() & field.mask() == field.value)
     }
 }
 

--- a/libraries/tock-register-interface/src/local_register.rs
+++ b/libraries/tock-register-interface/src/local_register.rs
@@ -83,16 +83,26 @@ impl<T: UIntLike, R: RegisterLongName> LocalRegisterCopy<T, R> {
         field.is_set(self.get())
     }
 
-    /// Check if any specified parts of a field match
+    /// Check if any bits corresponding to the mask in the passed `FieldValue` are set.
     #[inline]
-    pub fn matches_any(&self, field: FieldValue<T, R>) -> bool {
-        field.matches_any(self.get())
+    pub fn any_matching_bits_set(&self, field: FieldValue<T, R>) -> bool {
+        field.any_matching_bits_set(self.get())
     }
 
     /// Check if all specified parts of a field match
     #[inline]
     pub fn matches_all(&self, field: FieldValue<T, R>) -> bool {
         field.matches_all(self.get())
+    }
+
+    /// Check if any of the passed parts of a field exactly match the contained
+    /// value. This allows for matching on unset bits, or matching on specific values
+    /// in multi-bit fields.
+    #[inline]
+    pub fn matches_any(&self, fields: &[FieldValue<T, R>]) -> bool {
+        fields
+            .iter()
+            .any(|field| self.get() & field.mask() == field.value)
     }
 
     /// Do a bitwise AND operation of the stored value and the passed in value


### PR DESCRIPTION
### Pull Request Overview

The current implementation of `matches_any()` does not implement the functionality the name implies. This PR renames the existing implementation to a name which better describes its functionality, and introduces a new `matches_any()` function (with a different interface) that actually correctly implements the functionality suggested by the name. 

This PR also adds several tests to the tock-registers test suite to verify the new version works as expected, and removes a feature gate on a feature that no longer exists for the crate which was preventing some of the tock-registers test suite from being run as part of `cargo test`.

https://github.com/tock/tock/issues/3311#issuecomment-1328113050 contains a complete description of the issues with the current method.

Fixes https://github.com/tock/tock/issues/3311

### Testing Strategy

This pull request was tested by `cargo test`.


### TODO or Help Wanted

This pull request still needs feedback on method names


### Documentation Updated

- [x] `README.md` updated.

### Formatting

- [x] Ran `make prepush`.
