### PR TITLE
Make `tools/` a cargo workspace.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,18 +81,7 @@ members = [
     "libraries/tock-register-interface",
     "libraries/tickv",
 ]
-exclude = [
-    "tools/alert_codes",
-    "tools/board-runner",
-    "tools/qemu",
-    "tools/litex-ci-runner",
-    "tools/qemu-runner",
-    "tools/sha256sum",
-    "tools/usb/bulk-echo",
-    "tools/usb/bulk-echo-fast",
-    "tools/usb/bulk-test",
-    "tools/usb/control-test",
-]
+exclude = ["tools/"]
 
 [workspace.package]
 version = "0.1.0"

--- a/Makefile
+++ b/Makefile
@@ -162,10 +162,7 @@ allstack stack stack-analysis:
 .PHONY: clean
 clean:
 	@echo "$$(tput bold)Clean top-level Cargo workspace" && cargo clean
-	@for f in `./tools/list_tools.sh`;\
-		do echo "$$(tput bold)Clean tools/$$f";\
-		cargo clean --manifest-path "tools/$$f/Cargo.toml" || exit 1;\
-		done
+	@echo "$$(tput bold)Clean tools Cargo workspace" && cargo clean --manifest-path tools/Cargo.toml
 	@echo "$$(tput bold)Clean rustdoc" && rm -rf doc/rustdoc
 	@echo "$$(tput bold)Clean ci-artifacts" && rm -rf tools/ci-artifacts
 
@@ -477,12 +474,8 @@ ci-setup-tools:
 
 define ci_job_tools
 	$(call banner,CI-Job: Tools)
-	@for tool in `./tools/list_tools.sh`;\
-		do echo "$$(tput bold)Build & Test $$tool";\
-		cd tools/$$tool;\
-		NOWARNINGS=true RUSTFLAGS="-D warnings" cargo build --all-targets || exit 1;\
-		cd - > /dev/null;\
-		done
+	@NOWARNINGS=true RUSTFLAGS="-D warnings" \
+		cargo build --all-targets --manifest-path=tools/Cargo.toml --workspace || exit 1
 endef
 
 .PHONY: ci-job-tools

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -1,0 +1,15 @@
+[workspace]
+members = [
+    "alert_codes",
+    "board-runner",
+    "litex-ci-runner",
+    "qemu-runner",
+    "sha256sum",
+    "usb/bulk-echo",
+    "usb/bulk-test",
+    "usb/control-test",
+]
+
+[workspace.package]
+authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+edition = "2021"

--- a/tools/alert_codes/Cargo.toml
+++ b/tools/alert_codes/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "alert_codes"
 version = "0.1.0"
-authors = ["jrvanwhy <jrvanwhy@google.com>"]
-edition = "2021"
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]

--- a/tools/board-runner/Cargo.toml
+++ b/tools/board-runner/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "board-runner"
 version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2021"
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
 rexpect = "0.4"

--- a/tools/list_tools.sh
+++ b/tools/list_tools.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-# Find tools built in rust based on folders with Cargo.toml
-for b in $(find tools -maxdepth 4 -name 'Cargo.toml'); do
-    b1=${b#tools/}
-    b2=${b1%/*}
-    echo $b2
-done

--- a/tools/litex-ci-runner/Cargo.toml
+++ b/tools/litex-ci-runner/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "litex-ci-runner"
 version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+authors.workspace = true
 edition = "2018"
 
 [dependencies]

--- a/tools/qemu-runner/Cargo.toml
+++ b/tools/qemu-runner/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "qemu-runner"
 version = "0.1.0"
-authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
-edition = "2021"
+authors.workspace = true
+edition.workspace = true
 
 [dependencies]
 rexpect = "0.4.0"

--- a/tools/usb/bulk-echo/Cargo.toml
+++ b/tools/usb/bulk-echo/Cargo.toml
@@ -2,6 +2,7 @@
 name = "bulk-echo"
 version = "0.1.0"
 authors = ["Daniel B Giffin <daniel@beech-grove.net>"]
+edition.workspace = true
 
 [dependencies]
 libusb = { git ="https://github.com/tock/libusb-rs" }

--- a/tools/usb/bulk-test/Cargo.toml
+++ b/tools/usb/bulk-test/Cargo.toml
@@ -2,6 +2,7 @@
 name = "bulk-test"
 version = "0.1.0"
 authors = ["Daniel B. Giffin <dbg@scs.stanford.edu>"]
+edition.workspace = true
 
 [dependencies]
 libusb = { git ="https://github.com/tock/libusb-rs" }

--- a/tools/usb/control-test/Cargo.toml
+++ b/tools/usb/control-test/Cargo.toml
@@ -2,6 +2,7 @@
 name = "control-test"
 version = "0.1.0"
 authors = ["Daniel B. Giffin <dbg@scs.stanford.edu>"]
+edition.workspace = true
 
 [dependencies]
 libusb = { git ="https://github.com/tock/libusb-rs" }


### PR DESCRIPTION
### Pull Request Overview

The root cargo workspace was created in PR #1714. #1714's description asked the question "Should `tools/` also be part of the workspace? Have their own workspace?", which doesn't appear to have been answered.

This PR makes `tools/` its own cargo workspace.

### Testing Strategy

Ran `cargo check --workspace --exclude litex-ci-runner` in `tools/` (I excluded `litex-ci-runner` as it requires a dependency I don't have installed).
Ran `cargo check` in the root of the repository.
Ran `make prepush`.

### Open Questions

Do we want to make `tools/` part of the root workspace rather than making it its own workspace? I made it a separate workspace because the compilation profiles in the root workspace are intended for embedded code, whereas `tools/` is host-side code, but I'm open to making it all one workspace. Building host-side tools with embedded profiles will make things a bit slower but shouldn't break anything (unless something relies on panic unwinding).

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.