### PR TITLE
Update `VolatileCell` using the `vcell` crate's `VolatileCell`.

### DIFF
--- a/libraries/tock-cells/src/volatile_cell.rs
+++ b/libraries/tock-cells/src/volatile_cell.rs
@@ -9,7 +9,6 @@
 
 #![deny(missing_docs)]
 #![deny(warnings)]
-#![no_std]
 
 use core::cell::UnsafeCell;
 use core::ptr;
@@ -18,6 +17,7 @@ use core::ptr;
 ///
 /// [`Cell`]: https://doc.rust-lang.org/std/cell/struct.Cell.html
 /// [volatile]: https://doc.rust-lang.org/std/ptr/fn.read_volatile.html
+#[derive(Default)]
 #[repr(transparent)]
 pub struct VolatileCell<T> {
     value: UnsafeCell<T>,
@@ -26,13 +26,16 @@ pub struct VolatileCell<T> {
 impl<T> VolatileCell<T> {
     /// Creates a new `VolatileCell` containing the given value
     pub const fn new(value: T) -> Self {
-        VolatileCell { value: UnsafeCell::new(value) }
+        VolatileCell {
+            value: UnsafeCell::new(value),
+        }
     }
 
     /// Returns a copy of the contained value
     #[inline(always)]
     pub fn get(&self) -> T
-        where T: Copy
+    where
+        T: Copy,
     {
         unsafe { ptr::read_volatile(self.value.get()) }
     }
@@ -40,7 +43,8 @@ impl<T> VolatileCell<T> {
     /// Sets the contained value
     #[inline(always)]
     pub fn set(&self, value: T)
-        where T: Copy
+    where
+        T: Copy,
     {
         unsafe { ptr::write_volatile(self.value.get(), value) }
     }

--- a/libraries/tock-cells/src/volatile_cell.rs
+++ b/libraries/tock-cells/src/volatile_cell.rs
@@ -1,81 +1,56 @@
-//! Implementation of a type for accessing MCU registers.
+// This file was vendored into Tock. It comes from
+// https://github.com/japaric/vcell, commit
+// ef556474203e93b3f45f0f8cd8dea3210aa7f844, path src/lib.rs.
+
+//! Just like [`Cell`] but with [volatile] read / write operations
+//!
+//! [`Cell`]: https://doc.rust-lang.org/std/cell/struct.Cell.html
+//! [volatile]: https://doc.rust-lang.org/std/ptr/fn.read_volatile.html
+
+#![deny(missing_docs)]
+#![deny(warnings)]
+#![no_std]
 
 use core::cell::UnsafeCell;
 use core::ptr;
 
-/// `VolatileCell` provides a wrapper around unsafe volatile pointer reads
-/// and writes. This is particularly useful for accessing microcontroller
-/// registers by (unsafely) casting a pointer to the register into a `VolatileCell`.
+/// Just like [`Cell`] but with [volatile] read / write operations
 ///
-/// ```
-/// use tock_cells::volatile_cell::VolatileCell;
-/// let myptr: *const usize = 0xdeadbeef as *const usize;
-/// let myregister: &VolatileCell<usize> = unsafe { core::mem::transmute(myptr) };
-/// ```
-// Originally modified from: https://github.com/hackndev/zinc/tree/master/volatile_cell
-#[derive(Default)]
+/// [`Cell`]: https://doc.rust-lang.org/std/cell/struct.Cell.html
+/// [volatile]: https://doc.rust-lang.org/std/ptr/fn.read_volatile.html
 #[repr(transparent)]
-pub struct VolatileCell<T: ?Sized + Copy> {
+pub struct VolatileCell<T> {
     value: UnsafeCell<T>,
 }
 
-impl<T: Copy> Clone for VolatileCell<T> {
-    #[inline]
-    fn clone(&self) -> Self {
-        VolatileCell::new(self.get())
-    }
-}
-
-impl<T: Copy> VolatileCell<T> {
+impl<T> VolatileCell<T> {
+    /// Creates a new `VolatileCell` containing the given value
     pub const fn new(value: T) -> Self {
-        VolatileCell {
-            value: UnsafeCell::new(value),
-        }
+        VolatileCell { value: UnsafeCell::new(value) }
     }
 
-    #[inline]
-    /// Performs a memory write with the provided value.
-    ///
-    /// # Side-Effects
-    ///
-    /// `set` _always_ performs a memory write on the underlying location. If
-    /// this location is a memory-mapped I/O register, the side-effects of
-    /// performing the write are register-specific.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use tock_cells::volatile_cell::VolatileCell;
-    ///
-    /// let vc = VolatileCell::new(123);
-    /// vc.set(432);
-    /// ```
-    pub fn set(&self, value: T) {
-        // `set` does not read the value currently inside the `VolatileCell`
-        // and, therefore, does not `drop` it, but because `T` is `Copy`, there
-        // cannot be a destructor anyway.
+    /// Returns a copy of the contained value
+    #[inline(always)]
+    pub fn get(&self) -> T
+        where T: Copy
+    {
+        unsafe { ptr::read_volatile(self.value.get()) }
+    }
+
+    /// Sets the contained value
+    #[inline(always)]
+    pub fn set(&self, value: T)
+        where T: Copy
+    {
         unsafe { ptr::write_volatile(self.value.get(), value) }
     }
 
-    #[inline]
-    /// Performs a memory read and returns a copy of the value represented by
-    /// the cell.
-    ///
-    /// # Side-Effects
-    ///
-    /// `get` _always_ performs a memory read on the underlying location. If
-    /// this location is a memory-mapped I/O register, the side-effects of
-    /// performing the read are register-specific.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use tock_cells::volatile_cell::VolatileCell;
-    ///
-    /// let vc = VolatileCell::new(5);
-    /// let five = vc.get();
-    /// ```
-    pub fn get(&self) -> T {
-        unsafe { ptr::read_volatile(self.value.get()) }
+    /// Returns a raw pointer to the underlying data in the cell
+    #[inline(always)]
+    pub fn as_ptr(&self) -> *mut T {
+        self.value.get()
     }
 }
+
+// NOTE implicit because of `UnsafeCell`
+// unsafe impl<T> !Sync for VolatileCell<T> {}

--- a/libraries/tock-cells/src/volatile_cell.rs
+++ b/libraries/tock-cells/src/volatile_cell.rs
@@ -85,12 +85,6 @@ impl<T> VolatileCell<T> {
     {
         unsafe { ptr::write_volatile(self.value.get(), value) }
     }
-
-    /// Returns a raw pointer to the underlying data in the cell
-    #[inline(always)]
-    pub fn as_ptr(&self) -> *mut T {
-        self.value.get()
-    }
 }
 
 // NOTE implicit because of `UnsafeCell`


### PR DESCRIPTION
### Pull Request Overview

Tock's `VolatileCell` originally came from the [zinc.rs](https://github.com/hackndev/zinc) project. zinc.rs is no longer maintained. This updates `VolatileCell` by switching to the version from the [vcell](https://github.com/japaric/vcell) crate, which appears to still be maintained.

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
