### PR TITLE
Add a license checking tool.

### DIFF
--- a/.lcignore
+++ b/.lcignore
@@ -8,7 +8,7 @@
 
 # TODO: This disables the license checker over most of the repository, enabling
 # it on a handful of files for demonstration purposes. The next few lines should
-# be removed when license headers are removed.
+# be removed when license headers are added.
 *
 !/.lcignore
 !/tools/

--- a/.lcignore
+++ b/.lcignore
@@ -1,0 +1,7 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2022
+# Copyright Google LLC 2022
+
+/.git/
+*.md

--- a/.lcignore
+++ b/.lcignore
@@ -5,3 +5,12 @@
 
 /.git/
 *.md
+
+# TODO: This disables the license checker over most of the repository, enabling
+# it on a handful of files for demonstration purposes. The next few lines should
+# be removed when license headers are removed.
+*
+!/.lcignore
+!/tools/
+!/tools/license-checker/
+!/tools/license-checker/**

--- a/Makefile
+++ b/Makefile
@@ -157,6 +157,9 @@ allstack stack stack-analysis:
 		do $(MAKE) --no-print-directory -C "boards/$$f" stack-analysis || exit 1;\
 		done
 
+.PHONY: licensecheck
+licensecheck:
+	@cargo run --manifest-path=tools/license-checker/Cargo.toml --release
 
 ## Commands
 .PHONY: clean
@@ -209,7 +212,8 @@ ci-nosetup:
 prepush:\
 	format\
 	ci-job-clippy\
-	ci-job-syntax
+	ci-job-syntax\
+	licensecheck
 	$(call banner,Pre-Push checks all passed!)
 	# Note: Tock runs additional and more intense CI checks on all PRs.
 	# If one of these error, you can run `make ci-job-NAME` to test locally.
@@ -334,7 +338,7 @@ ci-runner-netlify:\
 
 ### ci-runner-github-format jobs:
 .PHONY: ci-job-format
-ci-job-format:
+ci-job-format: licensecheck
 	$(call banner,CI-Job: Format Check)
 	@NOWARNINGS=true TOCK_FORMAT_MODE=diff $(MAKE) format
 
@@ -475,7 +479,7 @@ ci-setup-tools:
 define ci_job_tools
 	$(call banner,CI-Job: Tools)
 	@NOWARNINGS=true RUSTFLAGS="-D warnings" \
-		cargo build --all-targets --manifest-path=tools/Cargo.toml --workspace || exit 1
+		cargo test --all-targets --manifest-path=tools/Cargo.toml --workspace || exit 1
 endef
 
 .PHONY: ci-job-tools

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "alert_codes",
     "board-runner",
+    "license-checker",
     "litex-ci-runner",
     "qemu-runner",
     "sha256sum",

--- a/tools/license-checker/Cargo.toml
+++ b/tools/license-checker/Cargo.toml
@@ -1,0 +1,19 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2022
+# Copyright Google LLC 2022
+
+[package]
+name = "license-checker"
+version = "0.1.0"
+authors.workspace = true
+edition.workspace = true
+
+[dependencies]
+ignore = "0.4"
+thiserror = "1.0.37"
+
+[dependencies.syntect]
+default-features = false
+features = ["default-syntaxes", "regex-onig"]
+version = "5.0.0"

--- a/tools/license-checker/Cargo.toml
+++ b/tools/license-checker/Cargo.toml
@@ -10,6 +10,7 @@ authors.workspace = true
 edition.workspace = true
 
 [dependencies]
+clap = { features = ["derive"], version = "4.0.29" }
 ignore = "0.4"
 thiserror = "1.0.37"
 

--- a/tools/license-checker/src/main.rs
+++ b/tools/license-checker/src/main.rs
@@ -37,6 +37,13 @@ fn is_copyright(comment: &str) -> bool {
     comment.starts_with("Copyright ")
 }
 
+#[derive(clap::Parser)]
+struct Args {
+    /// Enable verbose debugging output
+    #[arg(long, short)]
+    verbose: bool,
+}
+
 #[derive(Debug, thiserror::Error, PartialEq)]
 enum LicenseError {
     #[error("license header missing")]
@@ -147,6 +154,8 @@ fn check_file(cache: &Cache, path: &Path) -> Vec<ErrorInfo> {
 }
 
 fn main() {
+    use clap::Parser as _;
+    let args = Args::parse();
     let cache = &Cache::default();
     let fs_walk = WalkBuilder::new("./")
         .add_custom_ignore_filename(".lcignore")
@@ -162,6 +171,9 @@ fn main() {
         let file_type = dir_entry.file_type().expect("File type read failed");
         if !file_type.is_file() {
             continue;
+        }
+        if args.verbose {
+            println!("Checking {}", dir_entry.path().display());
         }
         for error_info in check_file(cache, dir_entry.path()) {
             failed = true;

--- a/tools/license-checker/src/main.rs
+++ b/tools/license-checker/src/main.rs
@@ -1,0 +1,258 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2022
+// Copyright Google LLC 2022
+
+//! License-header checking tool for the Tock project.
+//!
+//! # Description
+//! This tool recursively traverses through the current working directory,
+//! verifying that every source code file inside has a Tock project license
+//! header.
+//!
+//! # Ignore files
+//! This tool respects gitignore files with the following names (ordered from
+//! highest-precedence to lowest-precedence):
+//! 1. .lcignore
+//! 2. .ignore
+//! 3. .gitignore
+
+use ignore::WalkBuilder;
+use std::path::{Path, PathBuf};
+use std::process::exit;
+
+mod parser;
+use parser::{Cache, LineContents, ParseError, Parser};
+
+const LICENSED_LINE: &str = "Licensed under the Apache License, Version 2.0 or the MIT License.";
+const SPDX_LINE: &str = "SPDX-License-Identifier: Apache-2.0 OR MIT";
+
+fn is_first(comment: &str) -> bool {
+    comment.starts_with("Licensed under ")
+}
+fn is_spdx(comment: &str) -> bool {
+    comment.starts_with("SPDX-License-Identifier:")
+}
+fn is_copyright(comment: &str) -> bool {
+    comment.starts_with("Copyright ")
+}
+
+#[derive(Debug, thiserror::Error, PartialEq)]
+enum LicenseError {
+    #[error("license header missing")]
+    Missing,
+
+    #[error("missing blank line after header")]
+    MissingBlank,
+
+    #[error("missing copyright line")]
+    MissingCopyright,
+
+    #[error("missing SPDX line")]
+    MissingSpdx,
+
+    #[error("incorrect first line")]
+    WrongFirst,
+
+    #[error("wrong SPDX line")]
+    WrongSpdx,
+}
+
+#[derive(Debug, PartialEq)]
+struct ErrorInfo {
+    file: PathBuf,
+    line_num: u64,
+    error: LicenseError,
+}
+
+#[derive(PartialEq)]
+enum State {
+    /// We need a blank line before the header can start. This state is entered
+    /// if there is a non-blank, non-license-header line before the license
+    /// header.
+    NeedBlank,
+
+    /// We have not yet found a header, and are ready for one. This is the
+    /// starting (top-of-file) state, and is re-entered after a blank line if a
+    /// header has not been found.
+    ReadyForHeader,
+
+    /// We have found the first line of the header and the next must be the SPDX
+    /// line.
+    NeedSpdx,
+
+    /// We have found the first and SPDX line and now need a copyright line.
+    NeedCopyright,
+
+    /// We have found at least one copyright and are now waiting for the header
+    /// to end.
+    WaitForEnd,
+
+    /// The complete header (with or without errors) has been found, and we do
+    /// not need to continue processing this file.
+    Done,
+}
+
+fn check_file(cache: &Cache, path: &Path) -> Vec<ErrorInfo> {
+    use LicenseError::*;
+    use LineContents::*;
+    use State::*;
+
+    let mut license_errors = vec![];
+    let mut parser = match Parser::new(cache, path) {
+        Err(ParseError::Binary) => return vec![],
+        Err(error) => panic!("{}: {}", path.display(), error),
+        Ok(parser) => parser,
+    };
+    let mut line_num = 0;
+    let mut state = ReadyForHeader;
+    while state != Done {
+        line_num += 1;
+        let line_contents = match parser.next() {
+            Err(ParseError::Binary) => return vec![],
+            // Coerce end-of-file into Other, as they are treated identically.
+            Err(ParseError::Eof) => Other,
+            Err(error) => panic!("Parse error at {}:{}: {}", path.display(), line_num, error),
+            Ok(contents) => contents,
+        };
+        let (new_state, error) = match (state, line_contents) {
+            (NeedBlank, Comment(_)) => (NeedBlank, None),
+            (NeedBlank, Whitespace) => (ReadyForHeader, None),
+            (NeedBlank, Other) => (Done, Some(Missing)),
+            (ReadyForHeader, Comment(comment)) if !is_first(comment) => (NeedBlank, None),
+            (ReadyForHeader, Comment(comment)) if comment == LICENSED_LINE => (NeedSpdx, None),
+            (ReadyForHeader, Comment(_)) => (NeedSpdx, Some(WrongFirst)),
+            (ReadyForHeader, Whitespace) => (ReadyForHeader, None),
+            (ReadyForHeader, Other) => (Done, Some(Missing)),
+            (NeedSpdx, Comment(comment)) if comment == SPDX_LINE => (NeedCopyright, None),
+            (NeedSpdx, Comment(comment)) if is_spdx(comment) => (NeedCopyright, Some(WrongSpdx)),
+            (NeedSpdx, _) => (Done, Some(MissingSpdx)),
+            (NeedCopyright, Comment(comment)) if is_copyright(comment) => (WaitForEnd, None),
+            (NeedCopyright, _) => (Done, Some(MissingCopyright)),
+            (WaitForEnd, Comment(comment)) if is_copyright(comment) => (WaitForEnd, None),
+            (WaitForEnd, Whitespace) => (Done, None),
+            (WaitForEnd, _) => (Done, Some(MissingBlank)),
+            (Done, _) => unreachable!("Loop didn't end at EOF"),
+        };
+        state = new_state;
+        if let Some(error) = error {
+            license_errors.push(ErrorInfo {
+                file: path.to_owned(),
+                line_num,
+                error,
+            });
+        }
+    }
+    license_errors
+}
+
+fn main() {
+    let cache = &Cache::default();
+    let fs_walk = WalkBuilder::new("./")
+        .add_custom_ignore_filename(".lcignore")
+        .git_exclude(false)
+        .git_global(false)
+        .hidden(false)
+        .require_git(false)
+        .build();
+
+    let mut failed = false;
+    for result in fs_walk {
+        let dir_entry = result.expect("Directory walk failed");
+        let file_type = dir_entry.file_type().expect("File type read failed");
+        if !file_type.is_file() {
+            continue;
+        }
+        for error_info in check_file(cache, dir_entry.path()) {
+            failed = true;
+            eprintln!(
+                "{}:{}: {}",
+                error_info.file.display(),
+                error_info.line_num,
+                error_info.error
+            );
+        }
+    }
+
+    if !failed {
+        println!("License check passed.");
+        return;
+    }
+    exit(1);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn many_errors() {
+        assert_eq!(
+            check_file(&Cache::default(), Path::new("testdata/many_errors.rs")),
+            [
+                ErrorInfo {
+                    file: "testdata/many_errors.rs".into(),
+                    line_num: 1,
+                    error: LicenseError::WrongFirst,
+                },
+                ErrorInfo {
+                    file: "testdata/many_errors.rs".into(),
+                    line_num: 2,
+                    error: LicenseError::WrongSpdx,
+                },
+                ErrorInfo {
+                    file: "testdata/many_errors.rs".into(),
+                    line_num: 5,
+                    error: LicenseError::MissingBlank,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn missing() {
+        assert_eq!(
+            check_file(&Cache::default(), Path::new("testdata/error_missing.rs")),
+            [ErrorInfo {
+                file: "testdata/error_missing.rs".into(),
+                line_num: 1,
+                error: LicenseError::Missing
+            }]
+        );
+    }
+
+    #[test]
+    fn missing_copyright() {
+        assert_eq!(
+            check_file(&Cache::default(), Path::new("testdata/no_copyright.rs")),
+            [ErrorInfo {
+                file: "testdata/no_copyright.rs".into(),
+                line_num: 3,
+                error: LicenseError::MissingCopyright
+            }]
+        );
+    }
+
+    #[test]
+    fn missing_spdx() {
+        assert_eq!(
+            check_file(&Cache::default(), Path::new("testdata/no_spdx.rs")),
+            [ErrorInfo {
+                file: "testdata/no_spdx.rs".into(),
+                line_num: 2,
+                error: LicenseError::MissingSpdx
+            }]
+        );
+    }
+
+    /// Run check_file on a file that should have a valid header. Note this file
+    /// has a shebang line, so it will have to search past the first line to
+    /// find the header.
+    #[test]
+    fn successful() {
+        assert_eq!(
+            check_file(&Cache::default(), Path::new("testdata/by_first_line")),
+            []
+        );
+    }
+}

--- a/tools/license-checker/src/parser.rs
+++ b/tools/license-checker/src/parser.rs
@@ -1,0 +1,300 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2022
+// Copyright Google LLC 2022
+
+//! A partial parser that parses source code files *just well enough* to find
+//! license headers.
+//!
+//! `Parser` needs some slow-to-initialize resources, so each `Parser` must be
+//! initialized with a reference to a `Cache` instance.
+
+// It is not obvious how we should handle having multiple comments on one line,
+// e.g.:
+//
+//     /* Comment A */ /* Comment B */ // Comment C
+//
+// To avoid answering that question, this parser only recognizes line comments.
+// That effectively requires license headers to be before any block comments. If
+// that is an issue, we can adapt this parser to read block comments as well.
+
+use std::fs::File;
+use std::io::{self, BufRead, BufReader, ErrorKind};
+use std::path::Path;
+use std::str::FromStr;
+use syntect::easy::ScopeRangeIterator;
+use syntect::highlighting::ScopeSelector;
+use syntect::parsing::{ParseState, ParsingError, ScopeError, ScopeStack, SyntaxSet};
+
+pub struct Cache {
+    is_comment: ScopeSelector,
+    is_punctuation: ScopeSelector,
+    syntax_set: SyntaxSet,
+}
+
+impl Default for Cache {
+    fn default() -> Self {
+        const COMMENT_SELECTOR: &str = "comment.line - comment.line.documentation";
+        Self {
+            is_comment: ScopeSelector::from_str(COMMENT_SELECTOR).unwrap(),
+            is_punctuation: ScopeSelector::from_str("punctuation").unwrap(),
+            syntax_set: SyntaxSet::load_defaults_newlines(),
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ParseError {
+    /// Returned when we discover the file is binary (not valid UTF-8)
+    #[error("binary file")]
+    Binary,
+
+    /// Returned at the end of the file.
+    #[error("end-of-file")]
+    Eof,
+
+    #[error("bad byte span")]
+    BadSpan,
+
+    #[error("io error {0}")]
+    IoError(#[from] io::Error),
+
+    #[error("parse error {0}")]
+    ParsingError(#[from] ParsingError),
+
+    #[error("scope error {0}")]
+    ScopeError(#[from] ScopeError),
+}
+
+impl PartialEq for ParseError {
+    fn eq(&self, rhs: &Self) -> bool {
+        use ParseError::*;
+        match (self, rhs) {
+            (Binary, Binary) => true,
+            (Eof, Eof) => true,
+            (BadSpan, BadSpan) => true,
+            _ => false,
+        }
+    }
+}
+
+/// Indicates what a particular line of source code contains.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum LineContents<'l> {
+    /// This line of code consists only of whitespace and comments. The
+    /// contained string slice points to the contents of the comment with
+    /// whitespace trimmed away.
+    Comment(&'l str),
+
+    /// This line only contains whitespace.
+    Whitespace,
+
+    /// This line contains something that is not a comment or whitespace.
+    Other,
+}
+
+pub struct Parser<'cache> {
+    cache: &'cache Cache,
+    line: String,
+    parse_state: Option<ParseState>,
+    reader: BufReader<File>,
+    scopes: ScopeStack,
+}
+
+impl<'cache> Parser<'cache> {
+    /// Creates a new `Parser` that reads the specified file. Will return None
+    /// if the file is binary.
+    pub fn new(cache: &'cache Cache, path: &Path) -> Result<Self, ParseError> {
+        let syntax = match cache.syntax_set.find_syntax_for_file(path) {
+            Err(error) if error.kind() == ErrorKind::InvalidData => return Err(ParseError::Binary),
+            Err(error) => return Err(error.into()),
+            Ok(syntax) => syntax,
+        };
+
+        Ok(Self {
+            cache,
+            line: String::new(),
+            parse_state: syntax.map(ParseState::new),
+            reader: BufReader::new(File::open(path)?),
+            scopes: ScopeStack::new(),
+        })
+    }
+
+    /// Parses the next line and returns its contents. Returns None at EOF.
+    pub fn next(&mut self) -> Result<LineContents, ParseError> {
+        self.line.clear();
+        let bytes_read = match self.reader.read_line(&mut self.line) {
+            Err(error) if error.kind() == ErrorKind::InvalidData => return Err(ParseError::Binary),
+            Err(error) => return Err(error.into()),
+            Ok(bytes) => bytes,
+        };
+        if bytes_read == 0 {
+            // End of file.
+            return Err(ParseError::Eof);
+        }
+
+        // Manual comment extraction for file types syntect doesn't recognize.
+        let Some(ref mut parse_state) = self.parse_state else {
+            return Ok(parse_unknown(&self.line));
+        };
+
+        let cache = self.cache;
+        let ops = parse_state.parse_line(&self.line, &cache.syntax_set)?;
+        let mut contents = None;
+        let mut has_comment = false;
+
+        for (byte_span, op) in ScopeRangeIterator::new(&ops, &self.line) {
+            self.scopes.apply(op)?;
+            // Shortcut execution when we've already classified this line.
+            if contents.is_some() {
+                continue;
+            }
+
+            // Syntaxes sometimes push and pop spurious scopes; don't bother
+            // checking the scopes until we have a non-empty span.
+            if byte_span.is_empty() {
+                continue;
+            }
+
+            let scopes = self.scopes.as_slice();
+            let span = self.line.get(byte_span).ok_or(ParseError::BadSpan)?;
+            if cache.is_comment.does_match(scopes).is_none() {
+                if !span.chars().all(char::is_whitespace) {
+                    contents = Some(LineContents::Other);
+                }
+                continue;
+            }
+            has_comment = true;
+            // Skip the comment's punctuation (e.g. "//")
+            if cache.is_punctuation.does_match(scopes).is_some() {
+                continue;
+            }
+
+            contents = Some(LineContents::Comment(span.trim()));
+        }
+
+        Ok(match (contents, has_comment) {
+            (None, false) => LineContents::Whitespace,
+            (None, true) => LineContents::Comment(""),
+            (Some(contents), _) => contents,
+        })
+    }
+}
+
+// Backup parser for file types that syntect doesn't recognize. Strips "# " and
+// "// " comment prefixes and assumes every no-whitespace line is a comment.
+fn parse_unknown(line: &str) -> LineContents {
+    let trimmed = line.trim();
+    if trimmed.is_empty() {
+        return LineContents::Whitespace;
+    }
+    LineContents::Comment(if let Some(comment) = trimmed.strip_prefix("# ") {
+        comment
+    } else if let Some(comment) = trimmed.strip_prefix("// ") {
+        comment
+    } else {
+        trimmed
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use LineContents::*;
+
+    // Test function that confirms the parser produces a particular sequence of
+    // LineContents.
+    #[track_caller]
+    fn assert_produces(parser: Result<Parser, ParseError>, sequence: &[LineContents]) {
+        let mut parser = parser.unwrap();
+        for &expected in sequence {
+            assert_eq!(parser.next(), Ok(expected));
+        }
+        assert_eq!(parser.next(), Err(ParseError::Eof));
+    }
+
+    // Test with a file that causes SyntaxSet::find_syntax_for_file to return an
+    // invalid data error (which binary files can cause).
+    #[test]
+    fn binary() {
+        use ParseError::Binary;
+        let binary = Path::new("testdata/binary");
+        let cache = &Cache::default();
+        assert!(matches!(Parser::new(cache, binary), Err(Binary)));
+    }
+
+    // Confirm Parser correctly processes files identified by their shebang
+    // lines if their extension is unknown.
+    #[test]
+    fn by_first_line() {
+        const EXPECTED: &[LineContents] = &[
+            Comment("!/bin/bash"),
+            Whitespace,
+            Comment("Licensed under the Apache License, Version 2.0 or the MIT License."),
+            Comment("SPDX-License-Identifier: Apache-2.0 OR MIT"),
+            Comment("Copyright Tock Contributors 2022"),
+            Comment("Copyright Google LLC 2022"),
+            Whitespace,
+            Other,
+            Other,
+        ];
+        let by_first_line = Path::new("testdata/by_first_line");
+        assert_produces(Parser::new(&Cache::default(), by_first_line), EXPECTED);
+    }
+
+    #[test]
+    fn fallback_parser() {
+        assert_eq!(parse_unknown(" \t "), Whitespace);
+        assert_eq!(parse_unknown("# Hash comment \n"), Comment("Hash comment"));
+        assert_eq!(
+            parse_unknown("// Slashes comment \n"),
+            Comment("Slashes comment")
+        );
+        assert_eq!(parse_unknown("Plain text \n"), Comment("Plain text"));
+    }
+
+    // Test with a file type that syntect doesn't recognize.
+    #[test]
+    fn unknown_file_type() {
+        const EXPECTED: &[LineContents] = &[
+            Comment("Licensed under the Apache License, Version 2.0 or the MIT License."),
+            Comment("SPDX-License-Identifier: Apache-2.0 OR MIT"),
+            Comment("Copyright Tock Contributors 2022"),
+            Comment("Copyright Google LLC 2022"),
+            Whitespace,
+            Comment("Syntect should not be able to recognize this file's type."),
+            Comment("Parser should adapt and automatically strip // and # comment prefixes."),
+        ];
+        let path = Path::new("testdata/source.unknown_file_type");
+        assert_produces(Parser::new(&Cache::default(), path), EXPECTED);
+    }
+
+    // Test Parser with a variety of line types. This also confirms that syntect
+    // can identify a file type by extension.
+    #[test]
+    fn various_line_types() {
+        const EXPECTED: &[LineContents] = &[
+            Comment("Licensed under the Apache License, Version 2.0 or the MIT License."),
+            Comment("SPDX-License-Identifier: Apache-2.0 OR MIT"),
+            Comment("Copyright Tock Contributors 2022"),
+            Comment("Copyright Google LLC 2022"),
+            Whitespace,
+            Comment("Syntect should recognize this file's type by extension."),
+            Whitespace,
+            Other,
+            Comment(""),
+            Whitespace,
+            Other,
+            Other,
+            Comment(""),
+            Whitespace,
+            Other,
+            Other,
+            Whitespace,
+            Whitespace,
+            Other,
+        ];
+        let path = Path::new("testdata/variety.rs");
+        assert_produces(Parser::new(&Cache::default(), path), EXPECTED);
+    }
+}

--- a/tools/license-checker/testdata/.lcignore
+++ b/tools/license-checker/testdata/.lcignore
@@ -1,0 +1,10 @@
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2022
+# Copyright Google LLC 2022
+
+# These files are designed to produce license checker errors.
+/error_missing.rs
+/many_errors.rs
+/no_copyright.rs
+/no_spdx.rs

--- a/tools/license-checker/testdata/binary
+++ b/tools/license-checker/testdata/binary
@@ -1,0 +1,10 @@
+ÿ
+
+Licensed under the Apache License, Version 2.0 or the MIT License.
+Copyright Tock Contributors 2022
+Copyright Google LLC 2022
+SPDX-License-Identifier: Apache-2.0 OR MIT
+
+The first line of this file is invalid UTF-8, which results in
+find_syntax_for_file returning an error. The license checker should treat this
+file as binary.

--- a/tools/license-checker/testdata/by_first_line
+++ b/tools/license-checker/testdata/by_first_line
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Licensed under the Apache License, Version 2.0 or the MIT License.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2022
+# Copyright Google LLC 2022
+
+echo Syntect should be able to recognize this as a Bash script, even though it \
+     lacks an extension.

--- a/tools/license-checker/testdata/error_missing.rs
+++ b/tools/license-checker/testdata/error_missing.rs
@@ -1,0 +1,7 @@
+//! This test file should result in a "license missing" error, as the tool sees
+//! a doc comment before the license header.
+
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2022
+// Copyright Google LLC 2022

--- a/tools/license-checker/testdata/many_errors.rs
+++ b/tools/license-checker/testdata/many_errors.rs
@@ -1,0 +1,7 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License. [*]
+// SPDX-License-Identifier: Apache-2.0 OR MIT [*]
+// Copyright Tock Contributors 2022
+// Copyright Google LLC 2022
+//
+// [*] This file is designed to generate the following errors in the license
+// checker: MissingBlank, WrongFirst, WrongSpdx.

--- a/tools/license-checker/testdata/no_copyright.rs
+++ b/tools/license-checker/testdata/no_copyright.rs
@@ -1,0 +1,8 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// Copyright Tock Contributors 2022
+// Copyright Google LLC 2022
+
+// This file should generate a "missing copyright" error with the license
+// checker (the blank line should be interpreted as an early end to the header).

--- a/tools/license-checker/testdata/no_spdx.rs
+++ b/tools/license-checker/testdata/no_spdx.rs
@@ -1,0 +1,8 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2022
+// Copyright Google LLC 2022
+
+// This file should generate a "missing spdx line" error in the license checker
+// (the blank line should be interpreted as an early end to the header).

--- a/tools/license-checker/testdata/source.unknown_file_type
+++ b/tools/license-checker/testdata/source.unknown_file_type
@@ -1,0 +1,7 @@
+Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright Tock Contributors 2022
+# Copyright Google LLC 2022
+
+Syntect should not be able to recognize this file's type.
+Parser should adapt and automatically strip // and # comment prefixes.

--- a/tools/license-checker/testdata/variety.rs
+++ b/tools/license-checker/testdata/variety.rs
@@ -1,0 +1,19 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2022
+// Copyright Google LLC 2022
+
+// Syntect should recognize this file's type by extension.
+
+/// Single-line doc comment. The next line is a comment with no contents.
+//
+
+/* Multi-line comment. The next comment contains only whitespace.
+ */
+//     
+
+/** Multi-line doc comment. The line after this comment contains whitespace.
+  */
+    
+
+#![rustfmt::skip]  // This line should be considered "other" (i.e. code)


### PR DESCRIPTION
### Pull Request Overview

This pull request adds a tool that checks for license headers as specified in #3318.

### Testing Strategy

I adapted `ci-job-tools` to run tests in the `tools/` workspace, and ran the tool by hand to verify it reports errors + success correctly.

### TODO or Help Wanted

#3318 is undergoing revision.

I currently have the license checker disabled on all files *except new files added in this PR*, because otherwise it does its job and fails CI.

Also, after license headers are added, I need to evaluate the speed of the tool. It currently runs in 100 milliseconds, which seems fast enough, but it may slow down when license headers are added (it may also speed up). If it slows down too much (e.g. takes over a second), I'll revert to a simpler -- but less accurate -- parsing implementation.

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
