### PR TITLE
Doc: Update DRIVER_CHECK system call for alarm capsule

### DIFF
--- a/doc/syscalls/00000_alarm.md
+++ b/doc/syscalls/00000_alarm.md
@@ -22,8 +22,7 @@ The alarm's frequency is platform-specific, but must be _at least_ 1kHz.
 
     **Argument 2**: unused
 
-    **Returns**: The number of concurrent notifications supported per process,
-    0 if unbounded, otherwise NODEVICE
+    **Returns**: Ok(()) if the driver exists, otherwise NODEVICE.
 
   * ### Command number: `1`
 


### PR DESCRIPTION
Previously, the documentation would still state a single u32 value as return value, the number of supported notifications. However, this is not  in sync with the Tock 2.x tree as only one concurrent timer is supported (at least for libtock-rs).

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
