### PR TITLE
Expose 64-bit timers to the userspace alarm capsule

### DIFF
--- a/capsules/src/alarm.rs
+++ b/capsules/src/alarm.rs
@@ -58,7 +58,7 @@ impl<'a, A: Alarm<'a>> AlarmDriver<'a, A> {
     // underlying alarm is wider than 32 bits.
     fn reset_active_alarm(&self) {
         let mut earliest_alarm = Expiration::Disabled;
-        let mut earliest_end: A::Ticks = A::Ticks::from(0);
+        let mut earliest_end: A::Ticks = A::Ticks::from(0u32);
         // Scale now down to a u32 since that is the width of the alarm;
         // otherwise for larger widths (e.g., u64) now can be outside of
         // the range of what an alarm can be set to.
@@ -140,7 +140,7 @@ impl<'a, A: Alarm<'a>> AlarmDriver<'a, A> {
                 // This uses the invariant that reference <= now.
                 if now_lower_bits.into_u32() < reference {
                     // Build 1<<32 in a way that just overflows to 0 if we are 32 bits
-                    let bit33 = A::Ticks::from(0xffffffff).wrapping_add(A::Ticks::from(0x1));
+                    let bit33 = A::Ticks::from(0xffffffffu32).wrapping_add(A::Ticks::from(0x1u32));
                     high_bits = high_bits.wrapping_sub(bit33);
                 }
                 let real_reference = high_bits.wrapping_add(A::Ticks::from(reference));

--- a/capsules/src/buzzer_pwm.rs
+++ b/capsules/src/buzzer_pwm.rs
@@ -102,7 +102,7 @@ impl<'a, A: hil::time::Alarm<'a>, P: hil::pwm::PwmPin> hil::buzzer::Buzzer<'a>
         // Disarm the current alarm and instantly fire another.
         self.alarm.disarm()?;
         // This method was used to reduce the size of the code.
-        self.alarm.set_alarm(self.alarm.now(), A::Ticks::from(0));
+        self.alarm.set_alarm(self.alarm.now(), A::Ticks::from(0u32));
         Ok(())
     }
 }

--- a/capsules/src/read_only_state.rs
+++ b/capsules/src/read_only_state.rs
@@ -73,7 +73,7 @@ impl<'a, T: Time> ContextSwitchCallback for ReadOnlyStateDriver<'a, T> {
                         buf[4..8].copy_from_slice(&(pending_tasks as u32).to_le_bytes());
                     }
                     if buf.len() >= 16 {
-                        let now = self.timer.now().into_usize() as u64;
+                        let now = self.timer.now().into_u64();
                         buf[8..16].copy_from_slice(&now.to_le_bytes());
                     }
                 });

--- a/capsules/src/test/alarm_edge_cases.rs
+++ b/capsules/src/test/alarm_edge_cases.rs
@@ -34,7 +34,7 @@ impl<'a, A: Alarm<'a>> TestAlarmEdgeCases<'a, A> {
         let counter = self.counter.get();
         let delay = self.alarm.ticks_from_ms(self.alarms[counter % 20]);
         let now = self.alarm.now();
-        let start = now.wrapping_sub(A::Ticks::from(10));
+        let start = now.wrapping_sub(A::Ticks::from(10u32));
 
         debug!(
             "{}: Setting alarm to {} + {} = {}",

--- a/capsules/src/virtual_alarm.rs
+++ b/capsules/src/virtual_alarm.rs
@@ -53,7 +53,7 @@ impl<'a, A: Alarm<'a>> ListNode<'a, VirtualMuxAlarm<'a, A>> for VirtualMuxAlarm<
 impl<'a, A: Alarm<'a>> VirtualMuxAlarm<'a, A> {
     /// After calling new, always call setup()
     pub fn new(mux_alarm: &'a MuxAlarm<'a, A>) -> VirtualMuxAlarm<'a, A> {
-        let zero = A::Ticks::from(0);
+        let zero = A::Ticks::from(0u32);
         VirtualMuxAlarm {
             mux: mux_alarm,
             dt_reference: Cell::new(TickDtReference {
@@ -182,7 +182,7 @@ impl<'a, A: Alarm<'a>> Alarm<'a> for VirtualMuxAlarm<'a, A> {
         let extension = if dt_reference.extended {
             Self::Ticks::half_max_value()
         } else {
-            Self::Ticks::from(0)
+            Self::Ticks::from(0u32)
         };
         dt_reference.reference_plus_dt().wrapping_add(extension)
     }
@@ -521,7 +521,7 @@ mod tests {
 
         // Set the first alarm for 10 ticks in the future. This should then set the second alarm,
         // but not call fired for the second alarm until the timer gets to 100
-        v_alarms[0].set_alarm(0.into(), 10.into());
+        v_alarms[0].set_alarm(0u32.into(), 10u32.into());
         let still_armed = alarm.trigger_next_alarm();
 
         // Second alarm should not have triggered yet
@@ -570,15 +570,15 @@ mod tests {
 
         // Set one alarm to trigger immediately (at the hardware delay) and the other alarm to
         // trigger in the future by some large degree
-        let _ = v_alarms[0].set_alarm(now, 0.into());
-        let _ = v_alarms[1].set_alarm(now, 1_000.into());
+        let _ = v_alarms[0].set_alarm(now, 0u32.into());
+        let _ = v_alarms[1].set_alarm(now, 1_000u32.into());
 
         // Run the alarm long enough for every alarm but the longer alarm to fire, and all other
         // alarms should have fired once
-        alarm.run_for_ticks(Ticks32::from(750));
+        alarm.run_for_ticks(Ticks32::from(750u32));
         assert_eq!(client.count(), v_alarms.len() - 1);
         // Run the alarm long enough for the longer alarm to fire as well and verify count
-        alarm.run_for_ticks(Ticks32::from(750));
+        alarm.run_for_ticks(Ticks32::from(750u32));
         assert_eq!(client.count(), v_alarms.len());
     }
 }

--- a/capsules/src/virtual_timer.rs
+++ b/capsules/src/virtual_timer.rs
@@ -43,7 +43,7 @@ impl<'a, A: Alarm<'a>> ListNode<'a, VirtualTimer<'a, A>> for VirtualTimer<'a, A>
 impl<'a, A: Alarm<'a>> VirtualTimer<'a, A> {
     /// After calling new, always call setup()
     pub fn new(mux_timer: &'a MuxTimer<'a, A>) -> VirtualTimer<'a, A> {
-        let zero = A::Ticks::from(0);
+        let zero = A::Ticks::from(0u32);
         let v = VirtualTimer {
             mux: mux_timer,
             when: Cell::new(zero),

--- a/chips/apollo3/src/stimer.rs
+++ b/chips/apollo3/src/stimer.rs
@@ -221,6 +221,6 @@ impl<'a> Alarm<'a> for STimer<'a> {
     }
 
     fn minimum_dt(&self) -> Self::Ticks {
-        Self::Ticks::from(2)
+        Self::Ticks::from(2u32)
     }
 }

--- a/chips/imxrt10xx/src/gpt.rs
+++ b/chips/imxrt10xx/src/gpt.rs
@@ -405,7 +405,7 @@ impl<'a, F: hil::time::Frequency> hil::time::Alarm<'a> for Gpt<'a, F> {
     }
 
     fn minimum_dt(&self) -> Self::Ticks {
-        Self::Ticks::from(1)
+        Self::Ticks::from(1u32)
     }
 }
 

--- a/chips/nrf52/src/ieee802154_radio.rs
+++ b/chips/nrf52/src/ieee802154_radio.rs
@@ -808,7 +808,7 @@ impl<'p> Radio<'p> {
                 self.timer0
                     .unwrap_or_panic() // Unwrap fail = Missing timer reference for CSMA
                     .set_alarm(
-                        kernel::hil::time::Ticks32::from(0),
+                        kernel::hil::time::Ticks32::from(0u32),
                         kernel::hil::time::Ticks32::from(
                             backoff_periods * (IEEE802154_BACKOFF_PERIOD as u32),
                         ),

--- a/chips/nrf5x/src/rtc.rs
+++ b/chips/nrf5x/src/rtc.rs
@@ -196,6 +196,6 @@ impl<'a> Alarm<'a> for Rtc<'a> {
 
     fn minimum_dt(&self) -> Self::Ticks {
         // TODO: not tested, arbitrary value
-        Self::Ticks::from(10)
+        Self::Ticks::from(10u32)
     }
 }

--- a/chips/nrf5x/src/timer.rs
+++ b/chips/nrf5x/src/timer.rs
@@ -359,6 +359,6 @@ impl<'a> Alarm<'a> for TimerAlarm<'a> {
 
     fn minimum_dt(&self) -> Self::Ticks {
         // TODO: not tested, arbitrary value
-        Self::Ticks::from(10)
+        Self::Ticks::from(10u32)
     }
 }

--- a/chips/rp2040/src/timer.rs
+++ b/chips/rp2040/src/timer.rs
@@ -275,6 +275,6 @@ impl<'a> Alarm<'a> for RPTimer<'a> {
     }
 
     fn minimum_dt(&self) -> Self::Ticks {
-        Self::Ticks::from(50)
+        Self::Ticks::from(50u32)
     }
 }

--- a/chips/stm32f303xc/src/tim2.rs
+++ b/chips/stm32f303xc/src/tim2.rs
@@ -440,7 +440,7 @@ impl<'a> Alarm<'a> for Tim2<'a> {
     }
 
     fn minimum_dt(&self) -> Self::Ticks {
-        Self::Ticks::from(1)
+        Self::Ticks::from(1u32)
     }
 }
 

--- a/chips/stm32f4xx/src/tim2.rs
+++ b/chips/stm32f4xx/src/tim2.rs
@@ -437,7 +437,7 @@ impl<'a> Alarm<'a> for Tim2<'a> {
     }
 
     fn minimum_dt(&self) -> Self::Ticks {
-        Self::Ticks::from(1)
+        Self::Ticks::from(1u32)
     }
 }
 

--- a/doc/syscalls/00000_alarm.md
+++ b/doc/syscalls/00000_alarm.md
@@ -49,7 +49,7 @@ The alarm's frequency is platform-specific, but must be _at least_ 1kHz.
 
     **Description**: Stop an outstanding alarm notification.
 
-    **Argument 1**: Alarm notification identifer as returned from command 4.
+    **Argument 1**: unused
 
     **Argument 2**: unused
 

--- a/doc/syscalls/00000_alarm.md
+++ b/doc/syscalls/00000_alarm.md
@@ -37,13 +37,13 @@ The alarm's frequency is platform-specific, but must be _at least_ 1kHz.
 
   * ### Command number: `2`
 
-    **Description**: Read the current counter tick value.
+    **Description**: Read the current counter tick value (deprecated).
 
     **Argument 1**: unused
 
     **Argument 2**: unused
 
-    **Returns**: The counter value in ticks.
+    **Returns**: The 32-bit representation of the counter value in ticks.
 
   * ### Command number: `3`
 
@@ -70,14 +70,25 @@ The alarm's frequency is platform-specific, but must be _at least_ 1kHz.
   * ### Command number: `6`
 
     **Description**: Set an alarm notification for an absolute counter value.
-    Notification invokes the callback set with subscribe.
+    Notification invokes the callback set with subscribe. This only supports a
+    32-bit current time. (deprecated)
 
-    **Argument 1**: The reference point tick value.
+    **Argument 1**: The reference point tick value, 32-bit only.
 
     **Argument 2**: Absolute tick value. Callback will be issued
     when it matches current tick value.
 
     **Returns**: Tick value when the callback will be called.
+
+  * ### Command number: `7`
+
+    **Description**: Read the current counter tick value.
+
+    **Argument 1**: unused
+
+    **Argument 2**: unused
+
+    **Returns**: The 64-bit representation of the counter value in ticks.
 
 ## Subscribe
 

--- a/kernel/src/hil/time.rs
+++ b/kernel/src/hil/time.rs
@@ -18,7 +18,7 @@ use core::fmt;
 /// An integer type defining the width of a time value, which allows
 /// clients to know when wraparound will occur.
 
-pub trait Ticks: Clone + Copy + From<u32> + fmt::Debug + Ord + PartialOrd + Eq {
+pub trait Ticks: Clone + Copy + From<u32> + From<u64> + fmt::Debug + Ord + PartialOrd + Eq {
     /// Converts the type into a `usize`, stripping the higher bits
     /// it if it is larger than `usize` and filling the higher bits
     /// with 0 if it is smaller than `usize`.
@@ -384,6 +384,12 @@ impl From<u32> for Ticks32 {
     }
 }
 
+impl From<u64> for Ticks32 {
+    fn from(val: u64) -> Self {
+        Ticks32(val as u32)
+    }
+}
+
 impl Ticks for Ticks32 {
     fn into_usize(self) -> usize {
         self.0 as usize
@@ -466,6 +472,12 @@ pub struct Ticks24(u32);
 impl From<u32> for Ticks24 {
     fn from(val: u32) -> Self {
         Ticks24(val)
+    }
+}
+
+impl From<u64> for Ticks24 {
+    fn from(val: u64) -> Self {
+        Ticks24(val as u32)
     }
 }
 
@@ -556,6 +568,12 @@ impl From<u16> for Ticks16 {
 
 impl From<u32> for Ticks16 {
     fn from(val: u32) -> Self {
+        Ticks16((val & 0xffff) as u16)
+    }
+}
+
+impl From<u64> for Ticks16 {
+    fn from(val: u64) -> Self {
         Ticks16((val & 0xffff) as u16)
     }
 }

--- a/kernel/src/hil/time.rs
+++ b/kernel/src/hil/time.rs
@@ -31,6 +31,10 @@ pub trait Ticks: Clone + Copy + From<u32> + fmt::Debug + Ord + PartialOrd + Eq {
     /// are 32 bits.
     fn into_u32(self) -> u32;
 
+    /// Converts the type into a `u64`, filling the higher bits
+    /// with 0 if it is smaller than `u64`.
+    fn into_u64(self) -> u64;
+
     /// Add two values, wrapping around on overflow using standard
     /// unsigned arithmetic.
     fn wrapping_add(self, other: Self) -> Self;
@@ -389,6 +393,10 @@ impl Ticks for Ticks32 {
         self.0
     }
 
+    fn into_u64(self) -> u64 {
+        self.0 as u64
+    }
+
     fn wrapping_add(self, other: Self) -> Self {
         Ticks32(self.0.wrapping_add(other.0))
     }
@@ -468,6 +476,10 @@ impl Ticks for Ticks24 {
 
     fn into_u32(self) -> u32 {
         self.0
+    }
+
+    fn into_u64(self) -> u64 {
+        self.0 as u64
     }
 
     fn wrapping_add(self, other: Self) -> Self {
@@ -563,6 +575,10 @@ impl Ticks for Ticks16 {
         self.0 as u32
     }
 
+    fn into_u64(self) -> u64 {
+        self.0 as u64
+    }
+
     fn wrapping_add(self, other: Self) -> Self {
         Ticks16(self.0.wrapping_add(other.0))
     }
@@ -629,12 +645,6 @@ impl Eq for Ticks16 {}
 #[derive(Clone, Copy, Debug)]
 pub struct Ticks64(u64);
 
-impl Ticks64 {
-    pub fn into_u64(self) -> u64 {
-        self.0
-    }
-}
-
 impl From<u32> for Ticks64 {
     fn from(val: u32) -> Self {
         Ticks64(val as u64)
@@ -654,6 +664,10 @@ impl Ticks for Ticks64 {
 
     fn into_u32(self) -> u32 {
         self.0 as u32
+    }
+
+    fn into_u64(self) -> u64 {
+        self.0 as u64
     }
 
     fn wrapping_add(self, other: Self) -> Self {

--- a/kernel/src/scheduler/mlfq.rs
+++ b/kernel/src/scheduler/mlfq.rs
@@ -74,8 +74,8 @@ impl<'a, A: 'static + time::Alarm<'static>> MLFQSched<'a, A> {
         Self {
             alarm,
             processes: [List::new(), List::new(), List::new()],
-            next_reset: Cell::new(A::Ticks::from(0)),
-            last_reset_check: Cell::new(A::Ticks::from(0)),
+            next_reset: Cell::new(A::Ticks::from(0u32)),
+            last_reset_check: Cell::new(A::Ticks::from(0u32)),
             last_timeslice: Cell::new(0),
             last_queue_idx: Cell::new(0),
         }


### PR DESCRIPTION
### Pull Request Overview

This builds on top of https://github.com/tock/tock/pull/3343 and exposes the 64-bit timers to userspace.

Currently a draft until https://github.com/tock/tock/pull/3343 is merged

### Testing Strategy

Running libtock-c timer applications

### TODO or Help Wanted

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
