### PR TITLE
Enable virtual function elimination by default for OpenTitan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,7 @@ package-lock.json
 
 # OpenTitan test build
 boards/opentitan/earlgrey-*/binary*
+boards/opentitan/earlgrey-*/verilator_build/
 
 # FuseSoC build files
 boards/swervolf/binary.hex

--- a/boards/Makefile.common
+++ b/boards/Makefile.common
@@ -267,8 +267,8 @@ else
 endif
 
 # virtual-function-elimination reduces the size of binaries, but is still
-# experimental and has some possible miscompilation issues. We don't use it
-# by default but expose it via the `VFUNC_ELIM=1 make` option.
+# experimental and has some possible miscompilation issues. This is only enabled
+# for some boards by default, but is exposed via the `VFUNC_ELIM=1` option.
 #
 # For details on virtual-function-elimination see: https://github.com/rust-lang/rust/pull/96285
 # See https://github.com/rust-lang/rust/issues/68262 for general tracking

--- a/boards/opentitan/earlgrey-cw310/Cargo.toml
+++ b/boards/opentitan/earlgrey-cw310/Cargo.toml
@@ -15,6 +15,8 @@ lowrisc = { path = "../../../chips/lowrisc" }
 tock-tbf = { path = "../../../libraries/tock-tbf" }
 
 [features]
+default = ["fpga_cw310"]
+
 # OpenTitan SoC design can be synthesized or compiled for different targets. A
 # target can be a specific FPGA board, an ASIC technology, or a simulation tool.
 # Please see: https://docs.opentitan.org/doc/ug/getting_started/ for further

--- a/boards/opentitan/earlgrey-cw310/Makefile
+++ b/boards/opentitan/earlgrey-cw310/Makefile
@@ -1,6 +1,5 @@
 # Makefile for building the tock kernel for the OpenTitan platform
 
-DEFAULT_BOARD_CONFIGURATION=fpga_cw310
 TARGET=riscv32imc-unknown-none-elf
 PLATFORM=earlgrey-cw310
 FLASHID=--dev-id="0403:6010"
@@ -20,8 +19,6 @@ include ../../Makefile.common
 # Cargo `--features`. Please see `Cargo.toml` for available options.
 ifneq ($(BOARD_CONFIGURATION),)
 	CARGO_FLAGS += --features=$(BOARD_CONFIGURATION)
-else
-	CARGO_FLAGS += --features=$(DEFAULT_BOARD_CONFIGURATION)
 endif
 
 # Build test crates with the `panic = "abort"` strategy. Tests use `unwind` by
@@ -112,4 +109,4 @@ test-verilator: ot-check
 	mkdir -p $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/
 	$(Q)cp test_layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/layout.ld
 	$(Q)cp ../../kernel_layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/
-	$(Q)RUSTFLAGS="$(RUSTC_FLAGS_TOCK)" VERILATOR="yes" OBJCOPY=${OBJCOPY} TOCK_ROOT_DIRECTORY=${TOCK_ROOT_DIRECTORY} TARGET=${TARGET} $(CARGO) test $(CARGO_FLAGS_TOCK) $(NO_RUN) --bin $(PLATFORM) --release --features=hardware_tests --features sim_verilator
+	$(Q)RUSTFLAGS="$(RUSTC_FLAGS_TOCK)" VERILATOR="yes" OBJCOPY=${OBJCOPY} TOCK_ROOT_DIRECTORY=${TOCK_ROOT_DIRECTORY} TARGET=${TARGET} $(CARGO) test $(CARGO_FLAGS_TOCK) $(NO_RUN) --bin $(PLATFORM) --release --no-default-features --features=hardware_tests,sim_verilator

--- a/boards/opentitan/earlgrey-cw310/Makefile
+++ b/boards/opentitan/earlgrey-cw310/Makefile
@@ -11,6 +11,8 @@ QEMU ?= ../../../tools/qemu/build/qemu-system-riscv32
 QEMU_ENTRY_POINT=0x20000400
 # Latest supported commmit of OpenTitan
 OPENTITAN_SUPPORTED_SHA := d072ac505f82152678d6e04be95c72b728a347b8
+# Enable virtual function elimination
+VFUNC_ELIM=1
 
 
 include ../../Makefile.common

--- a/boards/opentitan/earlgrey-cw310/Makefile
+++ b/boards/opentitan/earlgrey-cw310/Makefile
@@ -24,6 +24,10 @@ else
 	CARGO_FLAGS += --features=$(DEFAULT_BOARD_CONFIGURATION)
 endif
 
+# Build test crates with the `panic = "abort"` strategy. Tests use `unwind` by
+# default which causes incompatability with `core` built via `-Zbuild-std`.
+CARGO_FLAGS += -Zpanic-abort-tests
+
 .PHONY: ot-check
 OPENTITAN_ACTUAL_SHA := $(shell cd $(OPENTITAN_TREE); git show --pretty=format:"%H" --no-patch)
 # TODO: Theres mix and match of tab/space indenting in the block below,
@@ -94,7 +98,7 @@ endif
 	mkdir -p $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/
 	$(Q)cp test_layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/layout.ld
 	$(Q)cp ../../kernel_layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/
-	$(Q)RUSTFLAGS="$(RUSTC_FLAGS_TOCK)" QEMU_ENTRY_POINT=${QEMU_ENTRY_POINT} $(CARGO) test $(CARGO_FLAGS_TOCK_NO_BUILD_STD)  $(NO_RUN) --bin $(PLATFORM) --release
+	$(Q)RUSTFLAGS="$(RUSTC_FLAGS_TOCK)" QEMU_ENTRY_POINT=${QEMU_ENTRY_POINT} $(CARGO) test $(CARGO_FLAGS_TOCK) $(NO_RUN) --bin $(PLATFORM) --release
 # 	Test layout should be removed so that following apps (non-test) load the correct layout.
 	$(Q)rm $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/layout.ld
 
@@ -102,10 +106,10 @@ test-hardware: ot-check
 	mkdir -p $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/
 	$(Q)cp test_layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/layout.ld
 	$(Q)cp ../../kernel_layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/
-	$(Q)RUSTFLAGS="$(RUSTC_FLAGS_TOCK)" OBJCOPY=${OBJCOPY} TOCK_ROOT_DIRECTORY=${TOCK_ROOT_DIRECTORY} TARGET=${TARGET} $(CARGO) test $(CARGO_FLAGS_TOCK_NO_BUILD_STD) $(NO_RUN) --bin $(PLATFORM) --release --features=hardware_tests
+	$(Q)RUSTFLAGS="$(RUSTC_FLAGS_TOCK)" OBJCOPY=${OBJCOPY} TOCK_ROOT_DIRECTORY=${TOCK_ROOT_DIRECTORY} TARGET=${TARGET} $(CARGO) test $(CARGO_FLAGS_TOCK) $(NO_RUN) --bin $(PLATFORM) --release --features=hardware_tests
 
 test-verilator: ot-check
 	mkdir -p $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/
 	$(Q)cp test_layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/deps/layout.ld
 	$(Q)cp ../../kernel_layout.ld $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/
-	$(Q)RUSTFLAGS="$(RUSTC_FLAGS_TOCK)" VERILATOR="yes" OBJCOPY=${OBJCOPY} TOCK_ROOT_DIRECTORY=${TOCK_ROOT_DIRECTORY} TARGET=${TARGET} $(CARGO) test $(CARGO_FLAGS_TOCK_NO_BUILD_STD) $(NO_RUN) --bin $(PLATFORM) --release --features=hardware_tests --features sim_verilator
+	$(Q)RUSTFLAGS="$(RUSTC_FLAGS_TOCK)" VERILATOR="yes" OBJCOPY=${OBJCOPY} TOCK_ROOT_DIRECTORY=${TOCK_ROOT_DIRECTORY} TARGET=${TARGET} $(CARGO) test $(CARGO_FLAGS_TOCK) $(NO_RUN) --bin $(PLATFORM) --release --features=hardware_tests --features sim_verilator


### PR DESCRIPTION
### Pull Request Overview

This PR:
* Updates OpenTitan's tests to use `-Zbuild-std`, fixing `VFUNC_ELIM=1 make test`.
* Enables the `VFUNC_ELIM=1` option by default for OpenTitan's earlgrey board.
* Moves the default board configuration into the Cargo manifest, fixing `make test-verilator`.

Virtual function elimination (`VFUNC_ELIM`) currently miscompiles if crates built without VFE are mixed into the LTO unit. This includes the pre-built `core`, which creates and uses trait objects (virtual functions). Building `core` from source enables VFE.

Moving the default board configuration (`fpga_cw310`) into the Cargo manifest makes it easier to disable when running Verilator tests. Configurations are mutually exclusive and conflict. Previously, `BOARD_CONFIGURATION=sim_verilator` had to be set to enable `make test-verilator`.

### Testing Strategy

Running tests for `opentitan/earlgrey-cw310`:
1. `make test`.
2. `VFUNC_ELIM=1 make test` (was previously failing to link).
3. `make test-verilator` (previously required `BOARD_CONFIGURATION=sim_verilator`).

### TODO or Help Wanted

Should other boards be updated to use `-Zbuild-std` for tests too?

- [ ] `apollo3/redboard_artemis`.
- [ ] `apollo3/lora_things_plus`.
- [ ] `esp32-c3-devkitM-1`.

### Documentation Updated

The `-Zpanic-abort-tests` flag's purpose is documented in the `Makefile`.

### Formatting

- [x] Ran `make prepush`.
