### PR TITLE
lora-phy: Add support for a LoRa capsule

### DIFF
--- a/boards/apollo3/lora_things_plus/README.md
+++ b/boards/apollo3/lora_things_plus/README.md
@@ -40,7 +40,7 @@ The SVL can always be re-flashed if you want to.
 ## Debugging the board
 
 The SparkFun LoRa Thing Plus exposes JTAG via the small headers in the middle of
-the board. See the [SparkFun hookup guide](https://learn.sparkfun.com/tutorials/sparkfun-explorable-hookup-guide) for a picture of this.
+the board. See the [SparkFun hookup guide](https://learn.sparkfun.com/tutorials/sparkfun-explorable-hookup-guide/all) for a picture of this.
 
 SparkFun sell accessories you can use to connecting to this. It appears
 something like the J-Link BASE will work, but that hasn't been tested by Tock.
@@ -63,3 +63,41 @@ attach 1
 ```
 
 You can then use GDB to debug the board
+
+## Using LoRa with the board
+
+There is a work in progress port of a userspace LoRa library. This is based on
+the Semtech library. You can find the code for this at:
+https://github.com/alistair23/LoRaMac-node
+
+You can build the application by running the following in the `LoRaMac-node`
+directory:
+
+```shell
+$ mkdir build
+$ cd build
+$ cmake -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_TOOLCHAIN_FILE="../cmake/toolchain-arm-none-eabi.cmake" \
+        -DAPPLICATION="ping-pong" \
+        -DMODULATION="LORA" \
+        -DREGION_EU868="OFF" \
+        -DREGION_US915="OFF" \
+        -DREGION_CN779="OFF" \
+        -DREGION_EU433="OFF" \
+        -DREGION_AU915="ON" \
+        -DREGION_AS923="OFF" \
+        -DREGION_CN470="OFF" \
+        -DREGION_KR920="OFF" \
+        -DREGION_IN865="OFF" \
+        -DREGION_RU864="OFF" \
+        -DBOARD="Tock" \
+        -DUSE_RADIO_DEBUG="ON" ..
+$ make
+$ elf2tab -n ping-pong --stack 2048 --app-heap 1024 --kernel-heap 1024 --kernel-major 2 --kernel-minor 1 -v ./src/apps/ping-pong/ping-pong
+```
+
+Then in the Tock repo you can flash the app with:
+
+```shell
+$ make flash; APP=LoRaMac-node/build/src/apps/ping-pong//ping-pong.tbf make flash-app
+```

--- a/capsules/core/src/driver.rs
+++ b/capsules/core/src/driver.rs
@@ -39,6 +39,8 @@ pub enum NUM {
     BleAdvertising        = 0x30000,
     Ieee802154            = 0x30001,
     Udp                   = 0x30002,
+    LoRaPhySPI            = 0x30003,
+    LoRaPhyGPIO           = 0x30004,
 
     // Cryptography
     Rng                   = 0x40001,

--- a/capsules/extra/README.md
+++ b/capsules/extra/README.md
@@ -69,6 +69,8 @@ Support for wireless radios.
 - **[RF233](src/rf233.rs)**: Driver for RF233 radio.
 - **[BLE Advertising](src/ble_advertising_driver.rs)**: Driver for sending BLE
   advertisements.
+- **[LoRa Phy]**: Support for exposing Semtech devices to userspace
+  See the lora_things_plus board for an example
 
 Libraries
 ---------

--- a/chips/apollo3/src/gpio.rs
+++ b/chips/apollo3/src/gpio.rs
@@ -155,6 +155,96 @@ impl Port<'_> {
         }
     }
 
+    /// This function configures some GPIO pins on the Apollo3 to allow
+    /// communication with a SX1262 LoRa module.
+    ///
+    /// The pin mapping is setup to match what is used by the NM180100 SoC (shown below)
+    ///
+    /// IOM3: Semtech SX1262
+    ///     Apollo 3 Pin Number | Apollo 3 Name | SX1262 Pin Number | SX1262 Name | SX1262 Description
+    ///                      H6 |       GPIO 36 |                19 |  NSS        | SPI slave select
+    ///                      J6 |       GPIO 38 |                17 |  MOSI       | SPI slave input
+    ///                      J5 |       GPIO 43 |                16 |  MISO       | SPI slave output
+    ///                      H5 |       GPIO 42 |                18 |  SCK        | SPI clock input
+    ///                      J8 |       GPIO 39 |                14 |  BUSY       | Radio busy indicator
+    ///                      J9 |       GPIO 40 |                13 |  DIO1       | Multipurpose digital I/O
+    ///                      H9 |       GPIO 47 |                6  |  DIO3       | Multipurpose digital I/O
+    ///                      J7 |       GPIO 44 |                15 |  NRESET     | Radio reset signal, active low
+    ///
+    /// This should be used by the lora_things_plus board or any other board using
+    /// the Apollo3 based NM180100 SoC. This function would also work for any
+    /// Apollo3 board using the same pins and IOM as specified above.
+    pub fn enable_sx1262_radio_pins(&self) {
+        let regs = GPIO_BASE;
+
+        regs.padkey.set(115);
+
+        // Pin 36 NSS
+        regs.padreg[9].modify(
+            PADREG::PAD0PULL::CLEAR + PADREG::PAD0INPEN::CLEAR + PADREG::PAD0FNCSEL.val(0x1),
+        );
+        regs.cfg[4].modify(CFG::GPIO4INCFG.val(0x00) + CFG::GPIO4OUTCFG.val(0x00));
+        regs.altpadcfgj
+            .modify(ALTPADCFG::PAD0_DS1::CLEAR + ALTPADCFG::PAD0_SR::CLEAR);
+
+        // Pin 39 Busy
+        regs.padreg[9].modify(
+            PADREG::PAD3INPEN::SET
+                + PADREG::PAD3STRNG::CLEAR
+                + PADREG::PAD3FNCSEL.val(0x3)
+                + PADREG::PAD3RSEL.val(0x0),
+        );
+        regs.cfg[4].modify(
+            CFG::GPIO7INCFG.val(0x00) + CFG::GPIO7OUTCFG.val(0x00) + CFG::GPIO7INTD.val(0x00),
+        );
+        regs.altpadcfgj
+            .modify(ALTPADCFG::PAD3_DS1::CLEAR + ALTPADCFG::PAD3_SR::CLEAR);
+
+        // Pin 40 DIO1
+        regs.padreg[10].modify(
+            PADREG::PAD0PULL::CLEAR
+                + PADREG::PAD0INPEN::SET
+                + PADREG::PAD0STRING::CLEAR
+                + PADREG::PAD0FNCSEL.val(0x3)
+                + PADREG::PAD0RSEL.val(0x0),
+        );
+        regs.cfg[5].modify(
+            CFG::GPIO0INCFG.val(0x00) + CFG::GPIO0OUTCFG.val(0x00) + CFG::GPIO0INTD.val(0x00),
+        );
+        regs.altpadcfgk
+            .modify(ALTPADCFG::PAD0_DS1::CLEAR + ALTPADCFG::PAD0_SR::CLEAR);
+
+        // Pin 47 DIO3
+        regs.padreg[11].modify(
+            PADREG::PAD3PULL::CLEAR
+                + PADREG::PAD3INPEN::SET
+                + PADREG::PAD3STRNG::CLEAR
+                + PADREG::PAD3FNCSEL.val(0x3)
+                + PADREG::PAD3RSEL.val(0x0),
+        );
+        regs.cfg[5].modify(
+            CFG::GPIO7INCFG.val(0x00) + CFG::GPIO7OUTCFG.val(0x00) + CFG::GPIO7INTD.val(0x00),
+        );
+        regs.altpadcfgl
+            .modify(ALTPADCFG::PAD3_DS1::CLEAR + ALTPADCFG::PAD3_SR::CLEAR);
+
+        // Pin 44 NReset
+        regs.padreg[11].modify(
+            PADREG::PAD0PULL::CLEAR
+                + PADREG::PAD0INPEN::CLEAR
+                + PADREG::PAD0STRING::CLEAR
+                + PADREG::PAD0FNCSEL.val(0x3)
+                + PADREG::PAD0RSEL.val(0x0),
+        );
+        regs.cfg[5].modify(
+            CFG::GPIO4INCFG.val(0x00) + CFG::GPIO4OUTCFG.val(0x00) + CFG::GPIO4INTD.val(0x00),
+        );
+        regs.altpadcfgl
+            .modify(ALTPADCFG::PAD0_DS1::CLEAR + ALTPADCFG::PAD0_SR::CLEAR);
+
+        regs.padkey.set(0x00);
+    }
+
     pub fn enable_i2c(&self, sda: &GpioPin, scl: &GpioPin) {
         let regs = GPIO_BASE;
 

--- a/chips/apollo3/src/iom.rs
+++ b/chips/apollo3/src/iom.rs
@@ -1281,7 +1281,7 @@ impl<'a> SpiMaster for Iom<'a> {
     }
 
     fn set_rate(&self, rate: u32) -> Result<u32, ErrorCode> {
-        if self.op.get() != Operation::SPI {
+        if self.op.get() != Operation::SPI && self.op.get() != Operation::None {
             return Err(ErrorCode::BUSY);
         }
 
@@ -1347,7 +1347,7 @@ impl<'a> SpiMaster for Iom<'a> {
     }
 
     fn set_polarity(&self, polarity: ClockPolarity) -> Result<(), ErrorCode> {
-        if self.op.get() != Operation::SPI {
+        if self.op.get() != Operation::SPI && self.op.get() != Operation::None {
             return Err(ErrorCode::BUSY);
         }
 
@@ -1369,7 +1369,7 @@ impl<'a> SpiMaster for Iom<'a> {
     }
 
     fn set_phase(&self, phase: ClockPhase) -> Result<(), ErrorCode> {
-        if self.op.get() != Operation::SPI {
+        if self.op.get() != Operation::SPI && self.op.get() != Operation::None {
             return Err(ErrorCode::BUSY);
         }
 


### PR DESCRIPTION
### Pull Request Overview

This builds on top of https://github.com/tock/tock/pull/3330 and adds a LoRa capsule.

The capsule is pretty simple and mostly just exposes the SPI device and some GPIO pins. This could pretty much all be done with the current SPI and GPIO capsules, but this has a few advantages.

 * It allows us to expose other SPI busses to userspace
 * It hides the GPIO numbering so that it doesn't change per board. This allows the userspace code to be board independent

With this PR, support in libtock-c and LoRaMac-node we can run LoRa code on Tock

### Testing Strategy

I have tested communicating and interfacing with the LoRa device, using [libtock-c](https://github.com/tock/libtock-c/pull/317)

### TODO or Help Wanted

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
