### PR TITLE
Fix nano33 panic by incrementing number of deferred call clients

### DIFF
--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -302,7 +302,7 @@ pub unsafe fn main() {
     //--------------------------------------------------------------------------
 
     let dynamic_deferred_call_clients =
-        static_init!([DynamicDeferredCallClientState; 4], Default::default());
+        static_init!([DynamicDeferredCallClientState; 5], Default::default());
     let dynamic_deferred_caller = static_init!(
         DynamicDeferredCall,
         DynamicDeferredCall::new(dynamic_deferred_call_clients)


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes a panic-at-boot on the nano33 caused by https://github.com/tock/tock/commit/bab2b62ae8c1924fe0e2a66fa9b639bc93e0bb85 . The original implementation did not correctly initialize the i2c stack, presumably causing issues for whatever sensor uses i2c. Switching to the component fixed this bug but did not increment the number of deferred call clients leading to a panic at boot, which is a pain to detect on the nano33 because CDC is not setup yet that early so panic prints do not work.


### Testing Strategy

This pull request was tested on my nano33


### TODO or Help Wanted

N/A

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
