### PR TITLE
rv32i: force semihosting insn sequence to be contained in single page

### DIFF
--- a/arch/rv32i/src/lib.rs
+++ b/arch/rv32i/src/lib.rs
@@ -444,6 +444,7 @@ pub unsafe fn semihost_command(command: usize, arg0: usize, arg1: usize) -> usiz
     let res;
     asm!(
     "
+      .balign 16
       .option push
       .option norelax
       .option norvc


### PR DESCRIPTION
As specified in the RISC-V Semihosting discussion document[1], the semihosting instruction sequence must be fully contained in a single memory page. This can be accomplished through 16-byte alignment of the instruction sequence. However, in contrast to the trap function example provided in the document, we need to perform the aligment before setting `norvc`. The preceding instruction may have been a compressed instruction and ended on a 2-byte boundary. In this case, a compressed nop instruction needs to be used to restore proper alignment, which would be forbidden by the use of `norvc`, generating an error such as the following:

    LLVM ERROR: unable to write nop sequence of 2 bytes

[1]: https://github.com/riscv-software-src/riscv-semihosting/blob/f2e0eaf46d34a54ebbc1799c9a8879c4cc544fe4/riscv-semihosting-spec.adoc

### Pull Request Overview

As specified in the RISC-V Semihosting discussion document[1], the semihosting instruction sequence must be fully contained in a single memory page. This can be accomplished through 16-byte alignment of the instruction sequence. However, in contrast to the trap function example provided in the document, we need to perform the aligment before setting `norvc`. The preceding instruction may have been a compressed instruction and ended on a 2-byte boundary. In this case, a compressed nop instruction needs to be used to restore proper alignment, which would be forbidden by the use of `norvc`, generating an error such as the following:

    LLVM ERROR: unable to write nop sequence of 2 bytes

[1]: https://github.com/riscv-software-src/riscv-semihosting/blob/f2e0eaf46d34a54ebbc1799c9a8879c4cc544fe4/riscv-semihosting-spec.adoc

### Testing Strategy

This pull request was tested by running it with the QEMU RISC-V 32-bit `virt` target and forcing a panic.

### TODO or Help Wanted

N/A


### Documentation Updated

- [x] ~Updated the relevant files in `/docs`,~ or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
