### PR TITLE
PWM Syscall Driver

### DIFF
--- a/boards/components/src/lib.rs
+++ b/boards/components/src/lib.rs
@@ -53,6 +53,7 @@ pub mod panic_button;
 pub mod process_console;
 pub mod process_printer;
 pub mod proximity;
+pub mod pwm;
 pub mod rf233;
 pub mod rng;
 pub mod sched;

--- a/boards/components/src/pwm.rs
+++ b/boards/components/src/pwm.rs
@@ -1,0 +1,121 @@
+use capsules::virtual_pwm::{MuxPwm, PwmPinUser};
+use core::mem::MaybeUninit;
+use kernel::component::Component;
+use kernel::hil::pwm;
+use kernel::capabilities;
+use kernel::create_capability;
+use capsules::pwm::Pwm;
+
+#[macro_export]
+macro_rules! pwm_mux_component_static {
+    ($A:ty $(,)?) => {{
+        kernel::static_buf!(capsules::virtual_pwm::MuxPwm<'static, $A>)
+    };};
+}
+
+#[macro_export]
+macro_rules! pwm_component_static {
+    ($A:ty $(,)?) => {{
+        kernel::static_buf!(capsules::virtual_pwm::PwmPinUser<'static, $A>)
+    };};
+}
+
+#[macro_export]
+macro_rules! pwm_syscall_component_helper {
+    ($($P:expr),+ $(,)?) => {{
+        use kernel::count_expressions;
+        use kernel::static_init;
+        const NUM_DRIVERS: usize = count_expressions!($($P),+);
+
+        let drivers = static_init!(
+            [&'static dyn kernel::hil::pwm::PwmPin; NUM_DRIVERS],
+            [
+                $($P,)*
+            ]
+        );
+        let pwm = kernel::static_buf!(capsules::pwm::Pwm<'static, NUM_DRIVERS>);
+        (pwm, drivers)
+    };};
+}
+
+pub struct PwmMuxComponent<A: 'static + pwm::Pwm> {
+    pwm: &'static A,
+}
+
+impl<A: 'static + pwm::Pwm> PwmMuxComponent<A> {
+    pub fn new(pwm: &'static A) -> Self {
+        PwmMuxComponent { pwm: pwm }
+    }
+}
+
+impl<A: 'static + pwm::Pwm> Component for PwmMuxComponent<A> {
+    type StaticInput = &'static mut MaybeUninit<MuxPwm<'static, A>>;
+    type Output = &'static MuxPwm<'static, A>;
+
+    fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
+        let pwm_mux = static_buffer.write(MuxPwm::new(self.pwm));
+
+        pwm_mux
+    }
+}
+
+pub struct PwmPinComponent<A: 'static + pwm::Pwm> {
+    pwm_mux: &'static MuxPwm<'static, A>,
+    channel: A::Pin,
+}
+
+impl<A: 'static + pwm::Pwm> PwmPinComponent<A> {
+    pub fn new(mux: &'static MuxPwm<'static, A>, channel: A::Pin) -> Self {
+        PwmPinComponent {
+            pwm_mux: mux,
+            channel: channel,
+        }
+    }
+}
+
+impl<A: 'static + pwm::Pwm> Component for PwmPinComponent<A> {
+    type StaticInput = &'static mut MaybeUninit<PwmPinUser<'static, A>>;
+    type Output = &'static PwmPinUser<'static, A>;
+
+    fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
+        let pwm_pin = static_buffer.write(PwmPinUser::new(self.pwm_mux, self.channel));
+
+        pwm_pin.add_to_mux();
+
+        pwm_pin
+    }
+}
+
+pub struct PwmVirtualComponent<const NUM_PINS: usize> {
+    board_kernel: &'static kernel::Kernel,
+    driver_num: usize
+}
+
+impl<const NUM_PINS: usize> PwmVirtualComponent<NUM_PINS> {
+    pub fn new(board_kernel: &'static kernel::Kernel, driver_num: usize) -> PwmVirtualComponent<NUM_PINS> {
+        PwmVirtualComponent {
+            board_kernel: board_kernel,
+            driver_num: driver_num
+        }
+    }
+}
+
+impl<const NUM_PINS: usize> Component for PwmVirtualComponent<NUM_PINS> {
+    type StaticInput = (
+        &'static mut MaybeUninit<Pwm<'static, NUM_PINS>>,
+        &'static [&'static dyn kernel::hil::pwm::PwmPin; NUM_PINS]
+    );
+    type Output = &'static capsules::pwm::Pwm<'static, NUM_PINS>;
+
+    fn finalize(self, static_buffer: Self::StaticInput) -> Self::Output {
+        let grant_cap = create_capability!(capabilities::MemoryAllocationCapability);
+        let grant_adc = self.board_kernel.create_grant(self.driver_num, &grant_cap);
+
+        let pwm = static_buffer.0.write(capsules::pwm::Pwm::new(
+            static_buffer.1,
+            grant_adc,
+        ));
+
+        pwm
+    }
+}

--- a/boards/microbit_v2/src/main.rs
+++ b/boards/microbit_v2/src/main.rs
@@ -385,7 +385,9 @@ pub unsafe fn main() {
                 &mux_pwm,
                 nrf52833::pinmux::Pinmux::new(GPIO_P8 as u32)
             )
-            .finalize(components::pwm_pin_user_component_static!(nrf52833::pwm::Pwm))
+            .finalize(components::pwm_pin_user_component_static!(
+                nrf52833::pwm::Pwm
+            ))
         ));
 
     //--------------------------------------------------------------------------

--- a/boards/microbit_v2/src/main.rs
+++ b/boards/microbit_v2/src/main.rs
@@ -115,6 +115,7 @@ pub struct MicroBit {
             capsules::virtual_pwm::PwmPinUser<'static, nrf52833::pwm::Pwm>,
         >,
     >,
+    pwm: &'static capsules::pwm::Pwm<'static, 1>,
     app_flash: &'static capsules::app_flash_driver::AppFlash<'static>,
     sound_pressure: &'static capsules::sound_pressure::SoundPressureSensor<'static>,
 
@@ -140,6 +141,7 @@ impl SyscallDriverLookup for MicroBit {
             capsules::rng::DRIVER_NUM => f(Some(self.rng)),
             capsules::ble_advertising_driver::DRIVER_NUM => f(Some(self.ble_radio)),
             capsules::buzzer_driver::DRIVER_NUM => f(Some(self.buzzer_driver)),
+            capsules::pwm::DRIVER_NUM => f(Some(self.pwm)),
             capsules::app_flash_driver::DRIVER_NUM => f(Some(self.app_flash)),
             capsules::sound_pressure::DRIVER_NUM => f(Some(self.sound_pressure)),
             kernel::ipc::DRIVER_NUM => f(Some(&self.ipc)),
@@ -251,7 +253,8 @@ pub unsafe fn main() {
             // 0 => &nrf52833_peripherals.gpio_port[GPIO_P0],
             // 1 => &nrf52833_peripherals.gpio_port[_GPIO_P1],
             // 2 => &nrf52833_peripherals.gpio_port[_GPIO_P2],
-            8 => &nrf52833_peripherals.gpio_port[GPIO_P8],
+            // Used as PWM, comment them out in the PWM section to use them as GPIO
+            //8 => &nrf52833_peripherals.gpio_port[GPIO_P8], 
             9 => &nrf52833_peripherals.gpio_port[GPIO_P9],
             16 => &nrf52833_peripherals.gpio_port[GPIO_P16],
         ),
@@ -322,12 +325,11 @@ pub unsafe fn main() {
     use kernel::hil::buzzer::Buzzer;
     use kernel::hil::time::Alarm;
 
-    let mux_pwm = static_init!(
-        capsules::virtual_pwm::MuxPwm<'static, nrf52833::pwm::Pwm>,
-        capsules::virtual_pwm::MuxPwm::new(&base_peripherals.pwm0)
-    );
+    let mux_pwm = components::pwm::PwmMuxComponent::new(&base_peripherals.pwm0)
+        .finalize(components::pwm_mux_component_static!(nrf52833::pwm::Pwm));
+
     let virtual_pwm_buzzer = static_init!(
-        capsules::virtual_pwm::PwmPinUser<'static, nrf52833::pwm::Pwm>, //<
+        capsules::virtual_pwm::PwmPinUser<'static, nrf52833::pwm::Pwm>,
         capsules::virtual_pwm::PwmPinUser::new(
             mux_pwm,
             nrf52833::pinmux::Pinmux::new(SPEAKER_PIN as u32)
@@ -376,6 +378,15 @@ pub unsafe fn main() {
     pwm_buzzer.set_client(buzzer_driver);
 
     virtual_alarm_buzzer.set_alarm_client(pwm_buzzer);
+
+    let pwm = components::pwm::PwmVirtualComponent::new(board_kernel, capsules::pwm::DRIVER_NUM)
+        .finalize(components::pwm_syscall_component_helper!(
+            components::pwm::PwmPinComponent::new(
+                &mux_pwm,
+                nrf52833::pinmux::Pinmux::new(GPIO_P8 as u32)
+            )
+            .finalize(components::pwm_component_static!(nrf52833::pwm::Pwm))
+        ));
 
     //--------------------------------------------------------------------------
     // UART & CONSOLE & DEBUG
@@ -691,6 +702,7 @@ pub unsafe fn main() {
         lsm303agr,
         ninedof,
         buzzer_driver,
+        pwm,
         sound_pressure,
         adc: adc_syscall,
         alarm,

--- a/boards/microbit_v2/src/main.rs
+++ b/boards/microbit_v2/src/main.rs
@@ -385,7 +385,7 @@ pub unsafe fn main() {
                 &mux_pwm,
                 nrf52833::pinmux::Pinmux::new(GPIO_P8 as u32)
             )
-            .finalize(components::pwm_component_static!(nrf52833::pwm::Pwm))
+            .finalize(components::pwm_pin_user_component_static!(nrf52833::pwm::Pwm))
         ));
 
     //--------------------------------------------------------------------------

--- a/boards/microbit_v2/src/main.rs
+++ b/boards/microbit_v2/src/main.rs
@@ -254,7 +254,7 @@ pub unsafe fn main() {
             // 1 => &nrf52833_peripherals.gpio_port[_GPIO_P1],
             // 2 => &nrf52833_peripherals.gpio_port[_GPIO_P2],
             // Used as PWM, comment them out in the PWM section to use them as GPIO
-            //8 => &nrf52833_peripherals.gpio_port[GPIO_P8], 
+            //8 => &nrf52833_peripherals.gpio_port[GPIO_P8],
             9 => &nrf52833_peripherals.gpio_port[GPIO_P9],
             16 => &nrf52833_peripherals.gpio_port[GPIO_P16],
         ),

--- a/capsules/src/driver.rs
+++ b/capsules/src/driver.rs
@@ -18,6 +18,7 @@ pub enum NUM {
     AnalogComparator      = 0x00007,
     LowLevelDebug         = 0x00008,
     ReadOnlyState         = 0x00009,
+    Pwm                   = 0x00010,
 
     // Kernel
     Ipc                   = 0x10000,

--- a/capsules/src/lib.rs
+++ b/capsules/src/lib.rs
@@ -69,6 +69,7 @@ pub mod pca9544a;
 pub mod process_console;
 pub mod proximity;
 pub mod public_key_crypto;
+pub mod pwm;
 pub mod read_only_state;
 pub mod rf233;
 pub mod rf233_const;

--- a/capsules/src/pwm.rs
+++ b/capsules/src/pwm.rs
@@ -18,7 +18,7 @@ pub struct Pwm<'a, const NUM_PINS: usize> {
     /// Per-app state.
     apps: Grant<App, UpcallCount<1>, AllowRoCount<0>, AllowRwCount<0>>,
     /// An array of apps associated to their reserved pins.
-    active_app: [OptionalCell<ProcessId>; NUM_PINS],
+    active_process: [OptionalCell<ProcessId>; NUM_PINS],
 }
 
 impl<'a, const NUM_PINS: usize> Pwm<'a, NUM_PINS> {
@@ -31,15 +31,15 @@ impl<'a, const NUM_PINS: usize> Pwm<'a, NUM_PINS> {
         Pwm {
             pwm_pins: pwm_pins,
             apps: grant,
-            active_app: [EMPTY; NUM_PINS],
+            active_process: [EMPTY; NUM_PINS],
         }
     }
 
-    pub fn is_valid_app(&self, processid: ProcessId, pin: usize) -> bool {
+    pub fn claim_pin(&self, processid: ProcessId, pin: usize) -> bool {
         // Attempt to get the app that is using the pin.
-        self.active_app[pin].map_or(true, |id| {
-            // If the app is empty, that means that there is no app currently using the pins,
-            // therefore the pin is usable by the new app
+        self.active_process[pin].map_or(true, |id| {
+            // If the app is empty, that means that there is no app currently using this pin,
+            // therefore the pin could be usable by the new app
             if id == &processid {
                 // The same app is trying to access the pin it has access to, valid
                 true
@@ -59,7 +59,7 @@ impl<'a, const NUM_PINS: usize> SyscallDriver for Pwm<'a, NUM_PINS> {
     ///
     /// - `0`: Return number of PWM pins if this driver is included on the platform.
     /// - `1`: Start the PWM pin output. First 16 bits of `data1` are used for the duty cycle, as a
-    ///     percentage with 2 decimals, and the last 16 bits of `data2` are used for the PWM channel
+    ///     percentage with 2 decimals, and the last 16 bits of `data1` are used for the PWM channel
     ///     to be controlled. `data2` is used for the frequency in hertz. For the duty cycle, 100% is
     ///     the max duty cycle for this pin.
     /// - `2`: Stop the PWM output.
@@ -72,53 +72,61 @@ impl<'a, const NUM_PINS: usize> SyscallDriver for Pwm<'a, NUM_PINS> {
         processid: ProcessId,
     ) -> CommandReturn {
         match command_num {
-            // Check whether the driver exists, return number of usable PWM pins.
-            0 => CommandReturn::success_u32(NUM_PINS as u32),
+            // Check whether the driver exists.
+            0 => CommandReturn::success(),
+
+            // Return number of usable PWM pins.
+            1 => CommandReturn::success_u32(NUM_PINS as u32),
 
             // Start the pwm output.
-            1 => {
+
+            // data1 format  
+            // +------------------+---------------+
+            // | duty cycle (u16) | pwm pin (u16) |
+            // +------------------+---------------+
+            2 => {
                 let pin = data1 & ((1 << 16) - 1);
-                let duty_cycle = data1 & (((1 << 16) - 1) << 16);
+                let duty_cycle = data1 >> 16;
                 let frequency_hz = data2;
 
                 if pin >= NUM_PINS {
                     // App asked to use a pin that doesn't exist.
                     CommandReturn::failure(ErrorCode::INVAL)
                 } else {
-                    if !self.is_valid_app(processid, pin) {
-                        // App is invalid.
+                    if !self.claim_pin(processid, pin) {
+                        // App cannot claim pin.
                         CommandReturn::failure(ErrorCode::RESERVE)
                     } else {
-                        // App is valid, start pwm pin at given frequency and duty_cycle.
-                        self.active_app[pin].set(processid);
+                        // App can claim pin, start pwm pin at given frequency and duty_cycle.
+                        self.active_process[pin].set(processid);
                         self.pwm_pins[pin].start(frequency_hz, duty_cycle).into()
                     }
                 }
             }
 
             // Stop the PWM output.
-            2 => {
+            3 => {
                 let pin = data1;
                 if pin >= NUM_PINS {
                     // App asked to use a pin that doesn't exist.
                     CommandReturn::failure(ErrorCode::INVAL)
                 } else {
-                    if !self.is_valid_app(processid, pin) {
-                        // App is invalid.
+                    if !self.claim_pin(processid, pin) {
+                        // App cannot claim pin.
                         CommandReturn::failure(ErrorCode::RESERVE)
-                    } else if self.active_app[pin].is_none() {
+                    } else if self.active_process[pin].is_none() {
                         // If there is no active app, the pwm pin isn't in use.
                         CommandReturn::failure(ErrorCode::OFF)
                     } else {
-                        // Remove the current app and stop pwm output.
-                        self.active_app[pin].clear();
+                        // Release the pin and stop pwm output.
+                        self.active_process[pin].clear();
                         self.pwm_pins[pin].stop().into()
                     }
                 }
             }
 
             // Get max frequency of pin.
-            3 => {
+            4 => {
                 let pin = data1;
                 if pin >= NUM_PINS {
                     CommandReturn::failure(ErrorCode::INVAL)

--- a/capsules/src/pwm.rs
+++ b/capsules/src/pwm.rs
@@ -49,6 +49,11 @@ impl<'a, const NUM_PINS: usize> Pwm<'a, NUM_PINS> {
             }
         })
     }
+
+    pub fn release_pin(&self, pin: usize) {
+        // Release the claimed pin so that it can now be used by another process.
+        self.active_process[pin].clear();
+    }
 }
 
 /// Provide an interface for userland.
@@ -119,7 +124,7 @@ impl<'a, const NUM_PINS: usize> SyscallDriver for Pwm<'a, NUM_PINS> {
                         CommandReturn::failure(ErrorCode::OFF)
                     } else {
                         // Release the pin and stop pwm output.
-                        self.active_process[pin].clear();
+                        self.release_pin(pin);
                         self.pwm_pins[pin].stop().into()
                     }
                 }

--- a/capsules/src/pwm.rs
+++ b/capsules/src/pwm.rs
@@ -85,10 +85,13 @@ impl<'a, const NUM_PINS: usize> SyscallDriver for Pwm<'a, NUM_PINS> {
 
             // Start the pwm output.
 
-            // data1 format
-            // +------------------+---------------+
-            // | duty cycle (u16) | pwm pin (u16) |
-            // +------------------+---------------+
+            // data1 stores the duty cycle and the pin number in the format
+            // +------------------+------------------+
+            // | duty cycle (u16) |   pwm pin (u16)  |
+            // +------------------+------------------+
+            // This format was chosen because there are only 2 parameters in the command function that can be used for storing values,
+            // but in this case, 3 values are needed (pin, frequency, duty cycle), so data1 stores two of these values that can be
+            // represented using only 16 bits.
             2 => {
                 let pin = data1 & ((1 << 16) - 1);
                 let duty_cycle = data1 >> 16;

--- a/capsules/src/pwm.rs
+++ b/capsules/src/pwm.rs
@@ -80,7 +80,7 @@ impl<'a, const NUM_PINS: usize> SyscallDriver for Pwm<'a, NUM_PINS> {
 
             // Start the pwm output.
 
-            // data1 format  
+            // data1 format
             // +------------------+---------------+
             // | duty cycle (u16) | pwm pin (u16) |
             // +------------------+---------------+

--- a/capsules/src/pwm.rs
+++ b/capsules/src/pwm.rs
@@ -68,7 +68,7 @@ impl<'a, const NUM_PINS: usize> SyscallDriver for Pwm<'a, NUM_PINS> {
         &self,
         command_num: usize,
         data1: usize,
-        data2: usize, 
+        data2: usize,
         processid: ProcessId,
     ) -> CommandReturn {
         match command_num {

--- a/capsules/src/pwm.rs
+++ b/capsules/src/pwm.rs
@@ -1,0 +1,137 @@
+use kernel::grant::{AllowRoCount, AllowRwCount, Grant, UpcallCount};
+use kernel::hil;
+use kernel::syscall::{CommandReturn, SyscallDriver};
+use kernel::utilities::cells::OptionalCell;
+use kernel::{ErrorCode, ProcessId};
+
+/// Syscall driver number.
+use crate::driver;
+pub const DRIVER_NUM: usize = driver::NUM::Pwm as usize;
+
+// An empty app, for potential uses in future updates of the driver
+#[derive(Default)]
+pub struct App;
+
+pub struct Pwm<'a, const NUM_PINS: usize> {
+    /// The usable pwm pins.
+    pwm_pins: &'a [&'a dyn hil::pwm::PwmPin; NUM_PINS],
+    /// Per-app state.
+    apps: Grant<App, UpcallCount<1>, AllowRoCount<0>, AllowRwCount<0>>,
+    /// An array of apps associated to their reserved pins.
+    active_app: [OptionalCell<ProcessId>; NUM_PINS],
+}
+
+impl<'a, const NUM_PINS: usize> Pwm<'a, NUM_PINS> {
+    pub fn new(
+        pwm_pins: &'a [&'a dyn hil::pwm::PwmPin; NUM_PINS],
+        grant: Grant<App, UpcallCount<1>, AllowRoCount<0>, AllowRwCount<0>>,
+    ) -> Pwm<'a, NUM_PINS> {
+        assert!(NUM_PINS <= (u16::MAX as usize));
+        const EMPTY: OptionalCell<ProcessId> = OptionalCell::empty();
+        Pwm {
+            pwm_pins: pwm_pins,
+            apps: grant,
+            active_app: [EMPTY; NUM_PINS],
+        }
+    }
+
+    pub fn is_valid_app(&self, processid: ProcessId, pin: usize) -> bool {
+        // Attempt to get the app that is using the pin.
+        self.active_app[pin].map_or(true, |id| {
+            // If the app is empty, that means that there is no app currently using the pins,
+            // therefore the pin is usable by the new app
+            if id == &processid {
+                // The same app is trying to access the pin it has access to, valid
+                true
+            } else {
+                // An app is trying to access another app's pin, invalid
+                false
+            }
+        })
+    }
+}
+
+/// Provide an interface for userland.
+impl<'a, const NUM_PINS: usize> SyscallDriver for Pwm<'a, NUM_PINS> {
+    /// Command interface.
+    ///
+    /// ### `command_num`
+    ///
+    /// - `0`: Return number of PWM pins if this driver is included on the platform.
+    /// - `1`: Start the PWM pin output. First 16 bits of `data1` are used for the duty cycle, as a
+    ///     percentage with 2 decimals, and the last 16 bits of `data2` are used for the PWM channel
+    ///     to be controlled. `data2` is used for the frequency in hertz. For the duty cycle, 100% is
+    ///     the max duty cycle for this pin.
+    /// - `2`: Stop the PWM output.
+    /// - `3`: Return the maximum possible frequency for this pin.
+    fn command(
+        &self,
+        command_num: usize,
+        data1: usize,
+        data2: usize, 
+        processid: ProcessId,
+    ) -> CommandReturn {
+        match command_num {
+            // Check whether the driver exists, return number of usable PWM pins.
+            0 => CommandReturn::success_u32(NUM_PINS as u32),
+
+            // Start the pwm output.
+            1 => {
+                let pin = data1 & ((1 << 16) - 1);
+                let duty_cycle = data1 & (((1 << 16) - 1) << 16);
+                let frequency_hz = data2;
+
+                if pin >= NUM_PINS {
+                    // App asked to use a pin that doesn't exist.
+                    CommandReturn::failure(ErrorCode::INVAL)
+                } else {
+                    if !self.is_valid_app(processid, pin) {
+                        // App is invalid.
+                        CommandReturn::failure(ErrorCode::RESERVE)
+                    } else {
+                        // App is valid, start pwm pin at given frequency and duty_cycle.
+                        self.active_app[pin].set(processid);
+                        self.pwm_pins[pin].start(frequency_hz, duty_cycle).into()
+                    }
+                }
+            }
+
+            // Stop the PWM output.
+            2 => {
+                let pin = data1;
+                if pin >= NUM_PINS {
+                    // App asked to use a pin that doesn't exist.
+                    CommandReturn::failure(ErrorCode::INVAL)
+                } else {
+                    if !self.is_valid_app(processid, pin) {
+                        // App is invalid.
+                        CommandReturn::failure(ErrorCode::RESERVE)
+                    } else if self.active_app[pin].is_none() {
+                        // If there is no active app, the pwm pin isn't in use.
+                        CommandReturn::failure(ErrorCode::OFF)
+                    } else {
+                        // Remove the current app and stop pwm output.
+                        self.active_app[pin].clear();
+                        self.pwm_pins[pin].stop().into()
+                    }
+                }
+            }
+
+            // Get max frequency of pin.
+            3 => {
+                let pin = data1;
+                if pin >= NUM_PINS {
+                    CommandReturn::failure(ErrorCode::INVAL)
+                } else {
+                    CommandReturn::success_u32(self.pwm_pins[pin].get_maximum_frequency_hz() as u32)
+                }
+            }
+
+            _ => CommandReturn::failure(ErrorCode::NOSUPPORT),
+        }
+    }
+
+    fn allocate_grant(&self, processid: ProcessId) -> Result<(), kernel::process::Error> {
+        self.apps.enter(processid, |_, _| {})
+    }
+}

--- a/doc/syscalls/00010_pwm.md
+++ b/doc/syscalls/00010_pwm.md
@@ -36,7 +36,7 @@ The PWM pins are indexed in the array starting at 0. The order of the pins and t
 
     **Description**: Start the PWM output.
 
-    **Argument 1**: First 16 bits represent the duty cycle, as a percentage with 2 decimals (100% being the maximum possible duty cycle), and the last 16 bits represent the PWM pin to be controlled.
+    **Argument 1**: First 16 bits represent the duty cycle, as a percentage with 2 decimals (100% being the maximum possible duty cycle), and the last 16 bits represent the PWM pin to be controlled. This format was chosen because there are only 2 parameters in the command function that can be used for storing values, but in this case, 3 values are needed (pin, frequency, duty cycle), so data1 stores two of these values, which can be represented using only 16 bits.
 
     **Argument 2**: The frequency in hertz.
 

--- a/doc/syscalls/00010_pwm.md
+++ b/doc/syscalls/00010_pwm.md
@@ -1,0 +1,71 @@
+---
+driver number: 0x00010
+---
+
+# PWM
+
+## Overview
+
+The PWM driver provides userspace to control a specific PWM pin. The pin's frequency and duty cycle can be changed. 
+
+The PWM pins are indexed in the array starting at 0. The order of the pins and the mapping between indexes and the actual pins is set by the kernel in the board's main file.
+
+## Command
+
+  * ### Command number: `0`
+    
+    **Description**: Does this driver exist?
+
+    **Argument 1**: unused
+
+    **Argument 2**: unused
+
+    **Returns**: `Ok(())` if it exists, otherwise `NODEVICE`
+
+  * ### Command number: `1`
+
+    **Description**: How many PWM pins are supported on this board.
+
+    **Argument 1**: unused
+
+    **Argument 2**: unused
+
+    **Returns**: The number of PWM pins on this board.
+
+  * ### Command number: `2`
+
+    **Description**: Start the PWM output.
+
+    **Argument 1**: First 16 bits represent the duty cycle, as a percentage with 2 decimals (100% being the maximum possible duty cycle), and the last 16 bits represent the PWM pin to be controlled.
+
+    **Argument 2**: The frequency in hertz.
+
+    **Returns**: `Ok(())` if the start attempt was successful, `INVAL` if the pin is invalid, `RESERVE` if the app doesn't have permission to use this pin at this time.
+
+  * ### Command number: `3`
+
+    **Description**: Stop the PWM output.
+
+    **Argument 1**: The PWM pin to be stopped.
+
+    **Argument 2**: unused
+
+    **Returns**: `Ok(())` if the stop attempt was successful, `INVAL` if the pin is invalid, `RESERVE` if the app doesn't have permission to use this pin at this time, `OFF` if the requested pin is already off. 
+
+  * ### Command number: `4`
+
+    **Description**: Get the maximum frequency of the pin.
+
+    **Argument 1**: The PWM pin to get the maximum frequency from.
+
+    **Argument 2**: unused
+
+    **Returns**: The maximum frequency of the pin, `INVAL` if the pin is invalid.
+
+## Subscribe
+
+Unused for the PWM driver. Will always return `ENOSUPPORT`.
+
+## Allow
+
+Unused for the PWM driver. Will always return `ENOSUPPORT`.

--- a/doc/syscalls/00010_pwm.md
+++ b/doc/syscalls/00010_pwm.md
@@ -13,18 +13,8 @@ The PWM pins are indexed in the array starting at 0. The order of the pins and t
 ## Command
 
   * ### Command number: `0`
-    
-    **Description**: Does this driver exist?
 
-    **Argument 1**: unused
-
-    **Argument 2**: unused
-
-    **Returns**: `Ok(())` if it exists, otherwise `NODEVICE`
-
-  * ### Command number: `1`
-
-    **Description**: How many PWM pins are supported on this board.
+    **Description**: How many PWM pins are supported on this board, if the driver exists.
 
     **Argument 1**: unused
 
@@ -32,7 +22,7 @@ The PWM pins are indexed in the array starting at 0. The order of the pins and t
 
     **Returns**: The number of PWM pins on this board.
 
-  * ### Command number: `2`
+  * ### Command number: `1`
 
     **Description**: Start the PWM output.
 
@@ -42,7 +32,7 @@ The PWM pins are indexed in the array starting at 0. The order of the pins and t
 
     **Returns**: `Ok(())` if the start attempt was successful, `INVAL` if the pin is invalid, `RESERVE` if the app doesn't have permission to use this pin at this time.
 
-  * ### Command number: `3`
+  * ### Command number: `2`
 
     **Description**: Stop the PWM output.
 
@@ -52,7 +42,7 @@ The PWM pins are indexed in the array starting at 0. The order of the pins and t
 
     **Returns**: `Ok(())` if the stop attempt was successful, `INVAL` if the pin is invalid, `RESERVE` if the app doesn't have permission to use this pin at this time, `OFF` if the requested pin is already off. 
 
-  * ### Command number: `4`
+  * ### Command number: `3`
 
     **Description**: Get the maximum frequency of the pin.
 


### PR DESCRIPTION
### Pull Request Overview

This pull request adds a syscall driver for PWM, allowing driver users to control a PWM pin's frequency and duty cycle. 


### Testing Strategy

This pull request was tested with a Microbit.


### TODO or Help Wanted

Feedback is much appreciated.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
