### PR TITLE
debug_writer_component: make debug buffer size configurable; double default debug buffer size

### DIFF
--- a/boards/components/src/debug_writer.rs
+++ b/boards/components/src/debug_writer.rs
@@ -31,66 +31,79 @@ use kernel::hil::uart;
 // least a 1 KiB boundary). This is not _semantically_ critical, but helps keep buffers on 1 KiB
 // boundaries in some cases. Of course, these definitions are only advisory, and individual boards
 // can choose to pass in their own buffers with different lengths.
-pub const DEBUG_BUFFER_KBYTE: usize = 1;
+pub const DEFAULT_DEBUG_BUFFER_KBYTE: usize = 1;
 
 // Bytes [0, DEBUG_BUFFER_SPLIT) are used for output_buf while bytes
-// [DEBUG_BUFFER_SPLIT, DEBUG_BUFFER_KBYTE * 1024) are used for internal_buf.
+// [DEBUG_BUFFER_SPLIT, DEFAULT_DEBUG_BUFFER_KBYTE * 1024) are used for internal_buf.
 const DEBUG_BUFFER_SPLIT: usize = 64;
 
+/// The optional argument to this macro allows boards to specify the size of the in-RAM
+/// buffer used for storing debug messages. Increase this value to be able to send more debug
+/// messages in quick succession.
 #[macro_export]
 macro_rules! debug_writer_component_static {
-    () => {{
-        use $crate::debug_writer::DEBUG_BUFFER_KBYTE;
-
+    ($BUF_SIZE_KB:expr) => {{
         let uart = kernel::static_buf!(capsules::virtual_uart::UartDevice);
         let ring = kernel::static_buf!(kernel::collections::ring_buffer::RingBuffer<'static, u8>);
-        let buffer = kernel::static_buf!([u8; 1024 * DEBUG_BUFFER_KBYTE]);
+        let buffer = kernel::static_buf!([u8; 1024 * $BUF_SIZE_KB]);
         let debug = kernel::static_buf!(kernel::debug::DebugWriter);
         let debug_wrapper = kernel::static_buf!(kernel::debug::DebugWriterWrapper);
 
         (uart, ring, buffer, debug, debug_wrapper)
     };};
+    () => {{
+        $crate::debug_writer_component_static!($crate::debug_writer::DEFAULT_DEBUG_BUFFER_KBYTE)
+    };};
 }
 
+/// The optional argument to this macro allows boards to specify the size of the in-RAM
+/// buffer used for storing debug messages. Increase this value to be able to send more debug
+/// messages in quick succession.
 #[macro_export]
 macro_rules! debug_writer_no_mux_component_static {
-    () => {{
-        use $crate::debug_writer::DEBUG_BUFFER_KBYTE;
-
+    ($BUF_SIZE_KB:expr) => {{
         let ring = kernel::static_buf!(kernel::collections::ring_buffer::RingBuffer<'static, u8>);
-        let buffer = kernel::static_buf!([u8; 1024 * DEBUG_BUFFER_KBYTE]);
+        let buffer = kernel::static_buf!([u8; 1024 * $BUF_SIZE_KB]);
         let debug = kernel::static_buf!(kernel::debug::DebugWriter);
         let debug_wrapper = kernel::static_buf!(kernel::debug::DebugWriterWrapper);
 
         (ring, buffer, debug, debug_wrapper)
     };};
+    () => {{
+        use $crate::debug_writer::DEFAULT_DEBUG_BUFFER_KBYTE;
+        $crate::debug_writer_no_mux_component_static!(DEFAULT_DEBUG_BUFFER_KBYTE);
+    };};
 }
 
-pub struct DebugWriterComponent {
+pub struct DebugWriterComponent<const BUF_SIZE_BYTES: usize> {
     uart_mux: &'static MuxUart<'static>,
+    marker: core::marker::PhantomData<[u8; BUF_SIZE_BYTES]>,
 }
 
-impl DebugWriterComponent {
-    pub fn new(uart_mux: &'static MuxUart) -> DebugWriterComponent {
-        DebugWriterComponent { uart_mux: uart_mux }
+impl<const BUF_SIZE_BYTES: usize> DebugWriterComponent<BUF_SIZE_BYTES> {
+    pub fn new(uart_mux: &'static MuxUart) -> Self {
+        Self {
+            uart_mux,
+            marker: core::marker::PhantomData,
+        }
     }
 }
 
 pub struct Capability;
 unsafe impl capabilities::ProcessManagementCapability for Capability {}
 
-impl Component for DebugWriterComponent {
+impl<const BUF_SIZE_BYTES: usize> Component for DebugWriterComponent<BUF_SIZE_BYTES> {
     type StaticInput = (
         &'static mut MaybeUninit<UartDevice<'static>>,
         &'static mut MaybeUninit<RingBuffer<'static, u8>>,
-        &'static mut MaybeUninit<[u8; 1024 * DEBUG_BUFFER_KBYTE]>,
+        &'static mut MaybeUninit<[u8; BUF_SIZE_BYTES]>,
         &'static mut MaybeUninit<kernel::debug::DebugWriter>,
         &'static mut MaybeUninit<kernel::debug::DebugWriterWrapper>,
     );
     type Output = ();
 
     fn finalize(self, s: Self::StaticInput) -> Self::Output {
-        let buf = s.2.write([0; 1024 * DEBUG_BUFFER_KBYTE]);
+        let buf = s.2.write([0; BUF_SIZE_BYTES]);
 
         let (output_buf, internal_buf) = buf.split_at_mut(DEBUG_BUFFER_SPLIT);
 
@@ -112,29 +125,38 @@ impl Component for DebugWriterComponent {
     }
 }
 
-pub struct DebugWriterNoMuxComponent<U: uart::Uart<'static> + uart::Transmit<'static> + 'static> {
+pub struct DebugWriterNoMuxComponent<
+    U: uart::Uart<'static> + uart::Transmit<'static> + 'static,
+    const BUF_SIZE_BYTES: usize,
+> {
     uart: &'static U,
+    marker: core::marker::PhantomData<[u8; BUF_SIZE_BYTES]>,
 }
 
-impl<U: uart::Uart<'static> + uart::Transmit<'static> + 'static> DebugWriterNoMuxComponent<U> {
+impl<U: uart::Uart<'static> + uart::Transmit<'static> + 'static, const BUF_SIZE_BYTES: usize>
+    DebugWriterNoMuxComponent<U, BUF_SIZE_BYTES>
+{
     pub fn new(uart: &'static U) -> Self {
-        Self { uart }
+        Self {
+            uart,
+            marker: core::marker::PhantomData,
+        }
     }
 }
 
-impl<U: uart::Uart<'static> + uart::Transmit<'static> + 'static> Component
-    for DebugWriterNoMuxComponent<U>
+impl<U: uart::Uart<'static> + uart::Transmit<'static> + 'static, const BUF_SIZE_BYTES: usize>
+    Component for DebugWriterNoMuxComponent<U, BUF_SIZE_BYTES>
 {
     type StaticInput = (
         &'static mut MaybeUninit<RingBuffer<'static, u8>>,
-        &'static mut MaybeUninit<[u8; 1024 * DEBUG_BUFFER_KBYTE]>,
+        &'static mut MaybeUninit<[u8; BUF_SIZE_BYTES]>,
         &'static mut MaybeUninit<kernel::debug::DebugWriter>,
         &'static mut MaybeUninit<kernel::debug::DebugWriterWrapper>,
     );
     type Output = ();
 
     fn finalize(self, s: Self::StaticInput) -> Self::Output {
-        let buf = s.1.write([0; 1024 * DEBUG_BUFFER_KBYTE]);
+        let buf = s.1.write([0; BUF_SIZE_BYTES]);
         let (output_buf, internal_buf) = buf.split_at_mut(DEBUG_BUFFER_SPLIT);
 
         // Create virtual device for kernel debug.

--- a/boards/components/src/debug_writer.rs
+++ b/boards/components/src/debug_writer.rs
@@ -31,7 +31,7 @@ use kernel::hil::uart;
 // least a 1 KiB boundary). This is not _semantically_ critical, but helps keep buffers on 1 KiB
 // boundaries in some cases. Of course, these definitions are only advisory, and individual boards
 // can choose to pass in their own buffers with different lengths.
-pub const DEFAULT_DEBUG_BUFFER_KBYTE: usize = 1;
+pub const DEFAULT_DEBUG_BUFFER_KBYTE: usize = 2;
 
 // Bytes [0, DEBUG_BUFFER_SPLIT) are used for output_buf while bytes
 // [DEBUG_BUFFER_SPLIT, DEFAULT_DEBUG_BUFFER_KBYTE * 1024) are used for internal_buf.

--- a/boards/hifive1/src/main.rs
+++ b/boards/hifive1/src/main.rs
@@ -325,8 +325,9 @@ pub unsafe fn main() {
     )
     .finalize(components::console_component_static!());
     // Create the debugger object that handles calls to `debug!()`.
+    const DEBUG_BUFFER_KB: usize = 1;
     components::debug_writer::DebugWriterComponent::new(uart_mux)
-        .finalize(components::debug_writer_component_static!());
+        .finalize(components::debug_writer_component_static!(DEBUG_BUFFER_KB));
 
     let lldb = components::lldb::LowLevelDebugComponent::new(
         board_kernel,


### PR DESCRIPTION
### Pull Request Overview

This pull request makes the debug buffer size configurable via an optional macro argument, and doubles the default size of the buffer to 2kB. I modified the Hifive1 to use the configurable parameter so that it still uses a 1kB buffer, since it is highly RAM constrained.

This PR was inspired by https://github.com/tock/tock/pull/3327, which will ultimately require a much larger buffer (~8kB) for boards that use it.

### Testing Strategy

This pull request was tested by compiling.


### TODO or Help Wanted

Are any other boards sufficiently RAM constrained as to require a smaller buffer than 2kB?


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
