### PR TITLE
boards/qemu_rv32_virt: set minimum reqd QEMU version to 7.2.0, fix Makefile rules, add documentation

### DIFF
--- a/boards/README.md
+++ b/boards/README.md
@@ -104,7 +104,7 @@ Virtual hardware platforms that are regulary tested as part of the CI.
 
 | Board                                                             | Architecture     | MCU            | Interface  | App deployment              | QEMU Support? |
 |-------------------------------------------------------------------|------------------|----------------|------------|-----------------------------|---------------|
-| [QEMU RISC-V 32 bit `virt` platform](qemu_rv32_virt/README.md)    | RISC-V RV32IMAC  | QEMU           | custom     | custom                      | Yes           |
+| [QEMU RISC-V 32 bit `virt` platform](qemu_rv32_virt/README.md)    | RISC-V RV32IMAC  | QEMU           | custom     | custom                      | Yes (7.2.0)   |
 | [LiteX on Digilent Arty A-7](litex/arty/README.md)                | RISC-V RV32IMC   | LiteX+VexRiscV | custom     | tockloader (flash-file)[^1] | No            |
 | [Verilated LiteX Simulation](litex/sim/README.md)                 | RISC-V RV32IMC   | LiteX+VexRiscv | custom     | tockloader (flash-file)[^1] | No            |
 

--- a/boards/qemu_rv32_virt/Makefile
+++ b/boards/qemu_rv32_virt/Makefile
@@ -21,6 +21,11 @@ WORKING_QEMU_VERSION := 7.2.0
 #   sockets. This option also accepts an optional NETDEV_SLIRP_ARGS
 #   which is appended to the provided string.
 #
+#   To forward TCP port 1234 on the emulated Tock device (having IP
+#   192.168.1.50) to the host port 5678, set the following variable:
+#
+#       NETDEV_SLIRP_ARGS=hostfwd=tcp::5678-192.168.1.50:1234
+#
 # - NETDEV: TAP
 #
 #   Creates a TAP network interface to act as a layer-2 Ethernet
@@ -29,16 +34,16 @@ WORKING_QEMU_VERSION := 7.2.0
 #   host. Use SUDO-TAP instead to run QEMU through `sudo`.
 NETDEV            ?= NONE
 ifneq ($(NETDEV_SLIRP_ARGS),)
-  NETDEV_SLIRP_ARGS := ,$(NETDEV_SLIRP_ARGS)
+  NETDEV_SLIRP_ARGS_INT := ,$(NETDEV_SLIRP_ARGS)
 else
-  NETDEV_SLIRP_ARGS :=
+  NETDEV_SLIRP_ARGS_INT :=
 endif
 
 ifeq ($(NETDEV),NONE)
   QEMU_NETDEV_CMDLINE = ""
 else ifeq ($(NETDEV),SLIRP)
   QEMU_NETDEV_CMDLINE = \
-    -netdev user,id=n0,net=192.168.1.0/24,dhcpstart=192.168.1.255$(NETDEV_SLIRP_ARGS) \
+    -netdev user,id=n0,net=192.168.1.0/24,dhcpstart=192.168.1.255$(NETDEV_SLIRP_ARGS_INT) \
     -device virtio-net-device,netdev=n0
 else ifneq (,$(filter $(NETDEV),TAP SUDO-TAP))
   QEMU_NETDEV_CMDLINE = \

--- a/boards/qemu_rv32_virt/Makefile
+++ b/boards/qemu_rv32_virt/Makefile
@@ -68,31 +68,29 @@ QEMU_BASE_CMDLINE := \
     $(QEMU_NETDEV_CMDLINE) \
     -nographic
 
-# Some helpful instructions & information. Requires that a qemu-riscv32-system
-# binary is in the user's PATH. The tested & verified QEMU version is printed
-# along with the one used. No actual version check is performed given the
-# simulation might work with different version, though should at leat work on
-# the tested one.
-.PHONY: qemu-usage-instructions
-qemu-usage-instructions:
-	@echo
-	@echo -e "Running $$(qemu-system-riscv32 --version | head -n1)" \
-	  "(tested: $(WORKING_QEMU_VERSION)) with\n" \
-          " - kernel $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf"
-	@test "\"$(APP)\" != \"\"" && echo -e "  - app $(APP)"
-	@echo "To exit type C-a x"
-	@echo
-
 # Run the kernel inside a qemu-riscv32-system "virt" machine type simulation
 .PHONY: run
-run: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf qemu-usage-instructions
+run: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
+	@echo
+	@echo -e "Running $$(qemu-system-riscv32 --version | head -n1)"\
+	  "(tested: $(WORKING_QEMU_VERSION)) with\n"\
+          " - kernel $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf"
+	@echo "To exit type C-a x"
+	@echo
 	$(QEMU_BASE_CMDLINE) \
 	  -bios $<
 
 # Same as `run`, but load an application specified by $(APP) into the respective
 # memory location.
 .PHONY: run-app
-run-app: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf qemu-usage-instructions
+run-app: $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf
+	@echo
+	@echo -e "Running $$(qemu-system-riscv32 --version | head -n1)"\
+	  "(tested: $(WORKING_QEMU_VERSION)) with\n"\
+          " - kernel $(TOCK_ROOT_DIRECTORY)target/$(TARGET)/release/$(PLATFORM).elf\n"\
+	  " - app $(APP)"
+	@echo "To exit type C-a x"
+	@echo
 	$(QEMU_BASE_CMDLINE) \
 	  -bios $< \
 	  -device loader,file=$(APP),addr=0x80100000

--- a/boards/qemu_rv32_virt/Makefile
+++ b/boards/qemu_rv32_virt/Makefile
@@ -7,7 +7,7 @@ PLATFORM = qemu_rv32_virt
 include ../Makefile.common
 
 QEMU_CMD             := qemu-system-riscv32
-WORKING_QEMU_VERSION := 7.0.0
+WORKING_QEMU_VERSION := 7.2.0
 
 # Whether a VirtIO network device shall be attached to the QEMU
 # machine, and which backend should be used. The following options are

--- a/boards/qemu_rv32_virt/README.md
+++ b/boards/qemu_rv32_virt/README.md
@@ -1,22 +1,25 @@
 QEMU RISC-V 32 bit `virt` Platform
 ==================================
 
-This board crate targets the QEMU RISC-V 32 bit `virt` platform. While this
-platform should be generally stable, the board [`Makefile`](./Makefile)
-indicates a specific version of QEMU which this board has been tested against.
+This board crate targets the QEMU RISC-V 32 bit `virt` platform. It
+can utilize paravirtualized peripherals through the VirtIO
+transport. Currently supported periphals of this board are:
+
+- the primary 16550-compatible UART
+- VirtIO-based network adapters
+- VirtIO-based random number generators
 
 While this target does not feature many peripherals for now, it represents a
 stable QEMU target for using Tock in a virtualized RISC-V environment. This can
 be useful for CI and other purposes. In the future, this target can be extended
 to support VirtIO peripherals.
 
-Known issues: Application Support
----------------------------------
-
-Upstream QEMU currently contains a bug which makes it impossible to run
-userspace applications due to issues with the enforcement of memory protection
-(PMP). Tock issue [#3316](https://github.com/tock/tock/issues/3316) tracks these
-developments.
+Starting from at least QEMU v7.0.0 up to and including v7.1.0, QEMU cotained a
+bug which caused spurious memory access faults raised by the emulated Physical
+Memory Protection (PMP), part of the emulated RISC-V CPU core. Therefore, **this
+board requires at least QEMU v7.2.0** to function properly. Symptomps of the
+aforementioned bug are crashes of userspace processes with a memory-access fault
+reported by the kernel.
 
 Running QEMU
 ------------
@@ -27,35 +30,62 @@ passing `-bios $TOCK_KERNEL.bin`, such that it runs in RISC-V machine mode and
 has full control over the virtual board. `-nographic` can be used to suppress
 QEMU's graphical interface.
 
-The [`Makefile`] further contains two targets for running QEMU with a standalone
-kernel, or with a single app. These can be executed as
+The [`Makefile`] further contains two targets for running this board's kernel in
+QEMU standalone, or with a single app. These can be executed through the
+**`run`** and **`run-app`** targets, respectively.
 
-```
-tock/boards/qemu_rv32_virt $ make run
-    Finished release [optimized + debuginfo] target(s) in 0.05s
-   text    data     bss     dec     hex filename
-  64880      12   11248   76140   1296c tock/target/riscv32imac-unknown-none-elf/release/qemu_rv32_virt
-a9de4df9486d724e6bf6a3423af669903dfd2bd1fd65c1dd867ddf9d7bcbec9b  tock/target/riscv32imac-unknown-none-elf/release/qemu_rv32_virt.bin
+- **`run`**: Start Tock on an emulated QEMU board without an app:
 
-Running QEMU emulator version 7.0.0 (tested: 7.0.0) with
-  - kernel tock/target/riscv32imac-unknown-none-elf/release/qemu_rv32_virt.bin
-To exit type C-a x
+  ```
+  tock/boards/qemu_rv32_virt $ make run
+      Finished release [optimized + debuginfo] target(s) in 0.05s
+     text    data     bss     dec     hex filename
+    64880      12   11248   76140   1296c tock/target/riscv32imac-unknown-none-elf/release/qemu_rv32_virt
+  a9de4df9486d724e6bf6a3423af669903dfd2bd1fd65c1dd867ddf9d7bcbec9b  tock/target/riscv32imac-unknown-none-elf/release/qemu_rv32_virt.bin
 
-qemu-system-riscv32 \
-  -machine virt \
-  -bios tock/target/riscv32imac-unknown-none-elf/release/qemu_rv32_virt.bin \
-  -global virtio-mmio.force-legacy=false \
-  -device virtio-rng-device \
-  -nographic
-QEMU RISC-V 32-bit "virt" machine, initialization complete.
-Entering main loop.
-```
+  Running QEMU emulator version 7.0.0 (tested: 7.0.0) with
+    - kernel tock/target/riscv32imac-unknown-none-elf/release/qemu_rv32_virt.bin
+  To exit type C-a x
 
-and
+  qemu-system-riscv32 \
+    -machine virt \
+    -bios tock/target/riscv32imac-unknown-none-elf/release/qemu_rv32_virt.bin \
+    -global virtio-mmio.force-legacy=false \
+    -device virtio-rng-device \
+    -nographic
+  QEMU RISC-V 32-bit "virt" machine, initialization complete.
+  Entering main loop.
+  ```
 
-```
-tock/boards/qemu_rv32_virt $ make run-app APP=$PATH_TO_APP.tbf
-```
+- **`run`**: Start Tock on an emulated QEMU board without an app:
 
-respectively.
+  ```
+  tock/boards/qemu_rv32_virt $ make run-app APP=$PATH_TO_APP.tbf
+  ```
 
+Through the **`NETDEV`** environment variable, QEMU can be instructed to attach
+a VirtIO-based network adapter to the target. The following options are available:
+
+- `NETDEV=NONE` (default): Do not expose a network adapter to the guest.
+
+- `NETDEV=SLIRP`: Use QEMU's userspace networking capabilities (through
+  `libslirp`), which provides the target with an emulated network and a gateway
+  bridging outgoing TCP and UDP connections onto sockets of the host operating
+  system. `NETDEV_SLIRP_ARGS` can be used to pass further arguments to the
+  `netdev`, for instance to forward ports from host to guest. For example, to
+  forward the TCP port `8080` to the guest at `192.168.1.50:80`, use the
+  following command line:
+
+  ```
+  $ make run NETDEV=SLIRP NETDEV_SLIRP_ARGS=hostfwd=tcp::8080-192.168.1.50:80
+  ```
+
+- `NETDEV=TAP`: Create a TAP network device on the host and expose the
+  corresponding remote end to the guest's VirtIO network card. This establishes
+  a layer-2 link between the host and guest. This option assumes that QEMU has
+  the necessary permissions to use (or create) the device on the host. The
+  interface will be unconfigured and needs to be made active and be assigned an
+  IP address manually.
+
+- `NETDEV=SUDO-TAP`: Like `TAP`, but run QEMU as root through `sudo`. This will
+  likely prompt for a password.


### PR DESCRIPTION
### Pull Request Overview

This pull request
- changes the minimum required QEMU version for the `qemu_rv32_virt` board to 7.2.0, as that contains fixes containing the Tiny Code Generator (TCG) reading guest memory and these accesses causing an instruction access fault in the guest. Fixes #3316.

  The Makefile also prints a tested QEMU version. This should make it easy for users to identify that they are running on an unsupported (or at least untested) QEMU release when experiencing issues.

- it fixes an issue introduced in #3110, where passing a non-empty `NETDEV_SLIRP_ARGS` variable (for instance to forward TCP & UDP ports from the guest to the host) generates an incorrect argument string for the QEMU netdev.

- it fixes an issue introduced in #3110, where executing the `run` Makefile target would print that the board is running an app based solely on whether the `APP` envrionment variable was set. This should rather depend on whether the `run` or `run-app` target is executed.

- updates the board's documentation accordingly.

### Testing Strategy

This pull request was tested by running the board with apps in QEMU 7.2.0, and testing the various Makefile targets and environment variables.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] ~Updated the relevant files in `/docs`,~ or no updates are required.

### Formatting

- [x] Ran `make prepush`.
