### PR TITLE
Re-add OpenTitan's VFUNC_ELIM flag

### DIFF
--- a/boards/opentitan/earlgrey-cw310/Makefile
+++ b/boards/opentitan/earlgrey-cw310/Makefile
@@ -11,6 +11,8 @@ QEMU ?= ../../../tools/qemu/build/qemu-system-riscv32
 QEMU_ENTRY_POINT=0x20000400
 # Latest supported commmit of OpenTitan
 OPENTITAN_SUPPORTED_SHA := 565e4af39760a123c59a184aa2f5812a961fde47
+# Enable virtual function elimination
+VFUNC_ELIM=1
 
 
 include ../../Makefile.common


### PR DESCRIPTION
### Pull Request Overview

This PR re-adds the `VFUNC_ELIM=1` flag back to OpenTitan's makefile.

The flag was deleted by https://github.com/tock/tock/pull/3359 presumably by mistake when fixing a conflict.

### Testing Strategy

Ran `make test` with the flag set.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
