### PR TITLE
Fix Imix to not require process credential checking by default

### DIFF
--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -145,7 +145,8 @@ struct Imix {
     nonvolatile_storage: &'static capsules::nonvolatile_storage_driver::NonvolatileStorage<'static>,
     scheduler: &'static RoundRobinSched<'static>,
     systick: cortexm4::systick::SysTick,
-    credentials_checking_policy: &'static AppCheckerSha256,
+    credentials_checking_policy: &'static (),
+    //credentials_checking_policy: &'static AppCheckerSha256,
 }
 
 // The RF233 radio stack requires our buffers for its SPI operations:
@@ -196,7 +197,8 @@ impl KernelResources<sam4l::chip::Sam4l<Sam4lDefaultPeripherals>> for Imix {
     type SyscallDriverLookup = Self;
     type SyscallFilter = ();
     type ProcessFault = ();
-    type CredentialsCheckingPolicy = AppCheckerSha256;
+    type CredentialsCheckingPolicy = ();
+    //type CredentialsCheckingPolicy = AppCheckerSha256;
     type Scheduler = RoundRobinSched<'static>;
     type SchedulerTimer = cortexm4::systick::SysTick;
     type WatchDog = ();
@@ -688,7 +690,8 @@ pub unsafe fn main() {
         nonvolatile_storage,
         scheduler,
         systick: cortexm4::systick::SysTick::new(),
-        credentials_checking_policy: checker,
+        //credentials_checking_policy: checker,
+        credentials_checking_policy: &(),
     };
 
     // Need to initialize the UART for the nRF51 serialization.


### PR DESCRIPTION
### Pull Request Overview

Imix currently cannot run any apps when using tock master / libtock-c master / tockloader master / elf2tab master.
This is because https://github.com/tock/tock/pull/2809/ switched Imix to use `AppCheckerSha256` by default, but it seems that apps are not signed by default yet in `libtock-c`, so there is no straightforward way for app signatures to be validated. This PR reverts Imix to use no-checking, just like other boards.


### Testing Strategy

This pull request was tested by running blink


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
