### PR TITLE
Add the required `.` at the end of copyright lines.

### DIFF
--- a/.lcignore
+++ b/.lcignore
@@ -1,7 +1,7 @@
 # Licensed under the Apache License, Version 2.0 or the MIT License.
 # SPDX-License-Identifier: Apache-2.0 OR MIT
-# Copyright Tock Contributors 2022
-# Copyright Google LLC 2022
+# Copyright Tock Contributors 2022.
+# Copyright Google LLC 2022.
 
 /.git/
 *.md

--- a/tools/license-checker/Cargo.toml
+++ b/tools/license-checker/Cargo.toml
@@ -1,7 +1,7 @@
 # Licensed under the Apache License, Version 2.0 or the MIT License.
 # SPDX-License-Identifier: Apache-2.0 OR MIT
-# Copyright Tock Contributors 2022
-# Copyright Google LLC 2022
+# Copyright Tock Contributors 2022.
+# Copyright Google LLC 2022.
 
 [package]
 name = "license-checker"

--- a/tools/license-checker/src/main.rs
+++ b/tools/license-checker/src/main.rs
@@ -1,7 +1,7 @@
 // Licensed under the Apache License, Version 2.0 or the MIT License.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-// Copyright Tock Contributors 2022
-// Copyright Google LLC 2022
+// Copyright Tock Contributors 2022.
+// Copyright Google LLC 2022.
 
 //! License-header checking tool for the Tock project.
 //!

--- a/tools/license-checker/src/parser.rs
+++ b/tools/license-checker/src/parser.rs
@@ -1,7 +1,7 @@
 // Licensed under the Apache License, Version 2.0 or the MIT License.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-// Copyright Tock Contributors 2022
-// Copyright Google LLC 2022
+// Copyright Tock Contributors 2022.
+// Copyright Google LLC 2022.
 
 //! A partial parser that parses source code files *just well enough* to find
 //! license headers.
@@ -232,8 +232,8 @@ mod tests {
             Whitespace,
             Comment("Licensed under the Apache License, Version 2.0 or the MIT License."),
             Comment("SPDX-License-Identifier: Apache-2.0 OR MIT"),
-            Comment("Copyright Tock Contributors 2022"),
-            Comment("Copyright Google LLC 2022"),
+            Comment("Copyright Tock Contributors 2022."),
+            Comment("Copyright Google LLC 2022."),
             Whitespace,
             Other,
             Other,
@@ -259,8 +259,8 @@ mod tests {
         const EXPECTED: &[LineContents] = &[
             Comment("Licensed under the Apache License, Version 2.0 or the MIT License."),
             Comment("SPDX-License-Identifier: Apache-2.0 OR MIT"),
-            Comment("Copyright Tock Contributors 2022"),
-            Comment("Copyright Google LLC 2022"),
+            Comment("Copyright Tock Contributors 2022."),
+            Comment("Copyright Google LLC 2022."),
             Whitespace,
             Comment("Syntect should not be able to recognize this file's type."),
             Comment("Parser should adapt and automatically strip // and # comment prefixes."),
@@ -276,8 +276,8 @@ mod tests {
         const EXPECTED: &[LineContents] = &[
             Comment("Licensed under the Apache License, Version 2.0 or the MIT License."),
             Comment("SPDX-License-Identifier: Apache-2.0 OR MIT"),
-            Comment("Copyright Tock Contributors 2022"),
-            Comment("Copyright Google LLC 2022"),
+            Comment("Copyright Tock Contributors 2022."),
+            Comment("Copyright Google LLC 2022."),
             Whitespace,
             Comment("Syntect should recognize this file's type by extension."),
             Whitespace,

--- a/tools/license-checker/testdata/.lcignore
+++ b/tools/license-checker/testdata/.lcignore
@@ -1,7 +1,7 @@
 # Licensed under the Apache License, Version 2.0 or the MIT License.
 # SPDX-License-Identifier: Apache-2.0 OR MIT
-# Copyright Tock Contributors 2022
-# Copyright Google LLC 2022
+# Copyright Tock Contributors 2022.
+# Copyright Google LLC 2022.
 
 # These files are designed to produce license checker errors.
 /error_missing.rs

--- a/tools/license-checker/testdata/binary
+++ b/tools/license-checker/testdata/binary
@@ -1,8 +1,8 @@
 ÿ
 
 Licensed under the Apache License, Version 2.0 or the MIT License.
-Copyright Tock Contributors 2022
-Copyright Google LLC 2022
+Copyright Tock Contributors 2022.
+Copyright Google LLC 2022.
 SPDX-License-Identifier: Apache-2.0 OR MIT
 
 The first line of this file is invalid UTF-8, which results in

--- a/tools/license-checker/testdata/by_first_line
+++ b/tools/license-checker/testdata/by_first_line
@@ -2,8 +2,8 @@
 
 # Licensed under the Apache License, Version 2.0 or the MIT License.
 # SPDX-License-Identifier: Apache-2.0 OR MIT
-# Copyright Tock Contributors 2022
-# Copyright Google LLC 2022
+# Copyright Tock Contributors 2022.
+# Copyright Google LLC 2022.
 
 echo Syntect should be able to recognize this as a Bash script, even though it \
      lacks an extension.

--- a/tools/license-checker/testdata/error_missing.rs
+++ b/tools/license-checker/testdata/error_missing.rs
@@ -3,5 +3,5 @@
 
 // Licensed under the Apache License, Version 2.0 or the MIT License.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-// Copyright Tock Contributors 2022
-// Copyright Google LLC 2022
+// Copyright Tock Contributors 2022.
+// Copyright Google LLC 2022.

--- a/tools/license-checker/testdata/many_errors.rs
+++ b/tools/license-checker/testdata/many_errors.rs
@@ -1,7 +1,7 @@
 // Licensed under the Apache License, Version 2.0 or the MIT License. [*]
 // SPDX-License-Identifier: Apache-2.0 OR MIT [*]
-// Copyright Tock Contributors 2022
-// Copyright Google LLC 2022
+// Copyright Tock Contributors 2022.
+// Copyright Google LLC 2022.
 //
 // [*] This file is designed to generate the following errors in the license
 // checker: MissingBlank, WrongFirst, WrongSpdx.

--- a/tools/license-checker/testdata/no_copyright.rs
+++ b/tools/license-checker/testdata/no_copyright.rs
@@ -1,8 +1,8 @@
 // Licensed under the Apache License, Version 2.0 or the MIT License.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-// Copyright Tock Contributors 2022
-// Copyright Google LLC 2022
+// Copyright Tock Contributors 2022.
+// Copyright Google LLC 2022.
 
 // This file should generate a "missing copyright" error with the license
 // checker (the blank line should be interpreted as an early end to the header).

--- a/tools/license-checker/testdata/no_spdx.rs
+++ b/tools/license-checker/testdata/no_spdx.rs
@@ -1,8 +1,8 @@
 // Licensed under the Apache License, Version 2.0 or the MIT License.
 
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-// Copyright Tock Contributors 2022
-// Copyright Google LLC 2022
+// Copyright Tock Contributors 2022.
+// Copyright Google LLC 2022.
 
 // This file should generate a "missing spdx line" error in the license checker
 // (the blank line should be interpreted as an early end to the header).

--- a/tools/license-checker/testdata/source.unknown_file_type
+++ b/tools/license-checker/testdata/source.unknown_file_type
@@ -1,7 +1,7 @@
 Licensed under the Apache License, Version 2.0 or the MIT License.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-# Copyright Tock Contributors 2022
-# Copyright Google LLC 2022
+# Copyright Tock Contributors 2022.
+# Copyright Google LLC 2022.
 
 Syntect should not be able to recognize this file's type.
 Parser should adapt and automatically strip // and # comment prefixes.

--- a/tools/license-checker/testdata/variety.rs
+++ b/tools/license-checker/testdata/variety.rs
@@ -1,7 +1,7 @@
 // Licensed under the Apache License, Version 2.0 or the MIT License.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-// Copyright Tock Contributors 2022
-// Copyright Google LLC 2022
+// Copyright Tock Contributors 2022.
+// Copyright Google LLC 2022.
 
 // Syntect should recognize this file's type by extension.
 


### PR DESCRIPTION
### Pull Request Overview

When I implemented the license checker in #3345, I did not notice that `trd-legal.md` requires a period at the end of the copyright line. This PR adds that period to the license headers from #3345.

This begs the question: should I add logic to the license checker than checks the format of `Copyright` lines? I'm leaning towards "no" because they *should* be mostly copy-and-paste and minor punctuation errors don't seem very significant.

### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
