### PR TITLE
Process console command history

### DIFF
--- a/boards/components/src/process_console.rs
+++ b/boards/components/src/process_console.rs
@@ -41,8 +41,8 @@ macro_rules! process_console_component_static {
         let queue_buffer = kernel::static_buf!([u8; capsules::process_console::QUEUE_BUF_LEN]);
         let command_buffer = kernel::static_buf!([u8; capsules::process_console::COMMAND_BUF_LEN]);
         let command_history_buffer = kernel::static_buf!(
-            [capsules::process_console::Command<{ capsules::process_console::COMMAND_BUF_LEN }>;
-                capsules::process_console::COMMAND_HISTORY_LEN]
+            [capsules::process_console::Command;
+                capsules::process_console::DEFAULT_COMMAND_HISTORY_LEN]
         );
 
         (
@@ -107,8 +107,8 @@ impl<A: 'static + Alarm<'static>> Component for ProcessConsoleComponent<A> {
         &'static mut MaybeUninit<[u8; capsules::process_console::QUEUE_BUF_LEN]>,
         &'static mut MaybeUninit<[u8; capsules::process_console::COMMAND_BUF_LEN]>,
         &'static mut MaybeUninit<
-            [capsules::process_console::Command<{ capsules::process_console::COMMAND_BUF_LEN }>;
-                capsules::process_console::COMMAND_HISTORY_LEN],
+            [capsules::process_console::Command;
+                capsules::process_console::DEFAULT_COMMAND_HISTORY_LEN],
         >,
         &'static mut MaybeUninit<ProcessConsole<'static, VirtualMuxAlarm<'static, A>, Capability>>,
     );
@@ -154,8 +154,8 @@ impl<A: 'static + Alarm<'static>> Component for ProcessConsoleComponent<A> {
             .5
             .write([0; capsules::process_console::COMMAND_BUF_LEN]);
         let command_history_buffer = static_buffer.6.write(
-            [capsules::process_console::Command::<{ capsules::process_console::COMMAND_BUF_LEN }>::new();
-                capsules::process_console::COMMAND_HISTORY_LEN],
+            [capsules::process_console::Command::new();
+                capsules::process_console::DEFAULT_COMMAND_HISTORY_LEN],
         );
 
         let console = static_buffer.7.write(ProcessConsole::new(

--- a/boards/components/src/process_console.rs
+++ b/boards/components/src/process_console.rs
@@ -26,7 +26,7 @@ use kernel::process::ProcessPrinter;
 
 #[macro_export]
 macro_rules! process_console_component_static {
-    ($A: ty $(,)?, $COMMAND_HISTORY_LEN: expr) => {{
+    ($A: ty, $COMMAND_HISTORY_LEN: expr $(,)?) => {{
         let alarm = kernel::static_buf!(capsules::virtual_alarm::VirtualMuxAlarm<'static, $A>);
         let uart = kernel::static_buf!(capsules::virtual_uart::UartDevice);
         let pconsole = kernel::static_buf!(

--- a/boards/components/src/process_console.rs
+++ b/boards/components/src/process_console.rs
@@ -165,7 +165,7 @@ impl<const COMMAND_HISTORY_LEN: usize, A: 'static + Alarm<'static>> Component
             .write([0; capsules::process_console::COMMAND_BUF_LEN]);
         let command_history_buffer = static_buffer
             .6
-            .write([capsules::process_console::Command::new(); COMMAND_HISTORY_LEN]);
+            .write([capsules::process_console::Command::default(); COMMAND_HISTORY_LEN]);
 
         let console = static_buffer.7.write(ProcessConsole::new(
             console_uart,

--- a/boards/components/src/process_console.rs
+++ b/boards/components/src/process_console.rs
@@ -73,7 +73,7 @@ macro_rules! process_console_component_static {
         let queue_buffer = kernel::static_buf!([u8; capsules::process_console::QUEUE_BUF_LEN]);
         let command_buffer = kernel::static_buf!([u8; capsules::process_console::COMMAND_BUF_LEN]);
         let command_history_buffer = kernel::static_buf!(
-            [capsules::process_console::Command; capsules::process_console::$COMMAND_HISTORY_LEN]
+            [capsules::process_console::Command; $COMMAND_HISTORY_LEN]
         );
 
         (

--- a/boards/components/src/process_console.rs
+++ b/boards/components/src/process_console.rs
@@ -165,7 +165,7 @@ impl<const COMMAND_HISTORY_LEN: usize, A: 'static + Alarm<'static>> Component
             .write([0; capsules::process_console::COMMAND_BUF_LEN]);
         let command_history_buffer = static_buffer
             .6
-            .write([Default::default(); COMMAND_HISTORY_LEN]);
+            .write([capsules::process_console::Command::default(); COMMAND_HISTORY_LEN]);
 
         let console = static_buffer.7.write(ProcessConsole::new(
             console_uart,

--- a/boards/components/src/process_console.rs
+++ b/boards/components/src/process_console.rs
@@ -26,38 +26,7 @@ use kernel::process::ProcessPrinter;
 
 #[macro_export]
 macro_rules! process_console_component_static {
-    ($A: ty $(,)?) => {{
-        let alarm = kernel::static_buf!(capsules::virtual_alarm::VirtualMuxAlarm<'static, $A>);
-        let uart = kernel::static_buf!(capsules::virtual_uart::UartDevice);
-        let pconsole = kernel::static_buf!(
-            capsules::process_console::ProcessConsole<
-                { capsules::process_console::DEFAULT_COMMAND_HISTORY_LEN },
-                capsules::virtual_alarm::VirtualMuxAlarm<'static, $A>,
-                components::process_console::Capability,
-            >
-        );
-
-        let write_buffer = kernel::static_buf!([u8; capsules::process_console::WRITE_BUF_LEN]);
-        let read_buffer = kernel::static_buf!([u8; capsules::process_console::READ_BUF_LEN]);
-        let queue_buffer = kernel::static_buf!([u8; capsules::process_console::QUEUE_BUF_LEN]);
-        let command_buffer = kernel::static_buf!([u8; capsules::process_console::COMMAND_BUF_LEN]);
-        let command_history_buffer = kernel::static_buf!(
-            [capsules::process_console::Command;
-                capsules::process_console::DEFAULT_COMMAND_HISTORY_LEN]
-        );
-
-        (
-            alarm,
-            uart,
-            write_buffer,
-            read_buffer,
-            queue_buffer,
-            command_buffer,
-            command_history_buffer,
-            pconsole,
-        )
-    };};
-    ($A: ty $(,)?, $COMMAND_HISTORY_LEN: literal) => {{
+    ($A: ty $(,)?, $COMMAND_HISTORY_LEN: expr) => {{
         let alarm = kernel::static_buf!(capsules::virtual_alarm::VirtualMuxAlarm<'static, $A>);
         let uart = kernel::static_buf!(capsules::virtual_uart::UartDevice);
         let pconsole = kernel::static_buf!(
@@ -86,6 +55,9 @@ macro_rules! process_console_component_static {
             command_history_buffer,
             pconsole,
         )
+    };};
+    ($A: ty $(,)?) => {{
+        $crate::process_console_component_static!($A, { capsules::process_console::DEFAULT_COMMAND_HISTORY_LEN })
     };};
 }
 

--- a/boards/components/src/process_console.rs
+++ b/boards/components/src/process_console.rs
@@ -14,7 +14,7 @@
 // Author: Philip Levis <pal@cs.stanford.edu>
 // Last modified: 6/20/2018
 
-use capsules::process_console::{self, ProcessConsole};
+use capsules::process_console::{self, Command, ProcessConsole};
 use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use capsules::virtual_uart::{MuxUart, UartDevice};
 use core::mem::MaybeUninit;
@@ -41,7 +41,7 @@ macro_rules! process_console_component_static {
         let queue_buffer = kernel::static_buf!([u8; capsules::process_console::QUEUE_BUF_LEN]);
         let command_buffer = kernel::static_buf!([u8; capsules::process_console::COMMAND_BUF_LEN]);
         let command_history_buffer = kernel::static_buf!(
-            [[u8; capsules::process_console::COMMAND_BUF_LEN];
+            [Command<{ capsules::process_console::COMMAND_BUF_LEN }>;
                 capsules::process_console::COMMAND_HISTORY_LEN]
         );
 
@@ -107,7 +107,7 @@ impl<A: 'static + Alarm<'static>> Component for ProcessConsoleComponent<A> {
         &'static mut MaybeUninit<[u8; capsules::process_console::QUEUE_BUF_LEN]>,
         &'static mut MaybeUninit<[u8; capsules::process_console::COMMAND_BUF_LEN]>,
         &'static mut MaybeUninit<
-            [[u8; capsules::process_console::COMMAND_BUF_LEN];
+            [Command<{ capsules::process_console::COMMAND_BUF_LEN }>;
                 capsules::process_console::COMMAND_HISTORY_LEN],
         >,
         &'static mut MaybeUninit<ProcessConsole<'static, VirtualMuxAlarm<'static, A>, Capability>>,
@@ -154,7 +154,7 @@ impl<A: 'static + Alarm<'static>> Component for ProcessConsoleComponent<A> {
             .5
             .write([0; capsules::process_console::COMMAND_BUF_LEN]);
         let command_history_buffer = static_buffer.6.write(
-            [[0; capsules::process_console::COMMAND_BUF_LEN];
+            [Command::<{ capsules::process_console::COMMAND_BUF_LEN }>::new();
                 capsules::process_console::COMMAND_HISTORY_LEN],
         );
 

--- a/boards/components/src/process_console.rs
+++ b/boards/components/src/process_console.rs
@@ -165,7 +165,7 @@ impl<const COMMAND_HISTORY_LEN: usize, A: 'static + Alarm<'static>> Component
             .write([0; capsules::process_console::COMMAND_BUF_LEN]);
         let command_history_buffer = static_buffer
             .6
-            .write([capsules::process_console::Command::default(); COMMAND_HISTORY_LEN]);
+            .write([Default::default(); COMMAND_HISTORY_LEN]);
 
         let console = static_buffer.7.write(ProcessConsole::new(
             console_uart,

--- a/boards/components/src/process_console.rs
+++ b/boards/components/src/process_console.rs
@@ -73,9 +73,9 @@ impl<A: 'static + Alarm<'static>> ProcessConsoleComponent<A> {
         process_printer: &'static dyn ProcessPrinter,
     ) -> ProcessConsoleComponent<A> {
         ProcessConsoleComponent {
-            board_kernel: board_kernel,
-            uart_mux: uart_mux,
-            alarm_mux: alarm_mux,
+            board_kernel,
+            uart_mux,
+            alarm_mux,
             process_printer,
         }
     }

--- a/boards/components/src/process_console.rs
+++ b/boards/components/src/process_console.rs
@@ -14,7 +14,7 @@
 // Author: Philip Levis <pal@cs.stanford.edu>
 // Last modified: 6/20/2018
 
-use capsules::process_console::{self, Command, ProcessConsole};
+use capsules::process_console::{self, ProcessConsole};
 use capsules::virtual_alarm::{MuxAlarm, VirtualMuxAlarm};
 use capsules::virtual_uart::{MuxUart, UartDevice};
 use core::mem::MaybeUninit;
@@ -41,7 +41,7 @@ macro_rules! process_console_component_static {
         let queue_buffer = kernel::static_buf!([u8; capsules::process_console::QUEUE_BUF_LEN]);
         let command_buffer = kernel::static_buf!([u8; capsules::process_console::COMMAND_BUF_LEN]);
         let command_history_buffer = kernel::static_buf!(
-            [Command<{ capsules::process_console::COMMAND_BUF_LEN }>;
+            [capsules::process_console::Command<{ capsules::process_console::COMMAND_BUF_LEN }>;
                 capsules::process_console::COMMAND_HISTORY_LEN]
         );
 
@@ -107,7 +107,7 @@ impl<A: 'static + Alarm<'static>> Component for ProcessConsoleComponent<A> {
         &'static mut MaybeUninit<[u8; capsules::process_console::QUEUE_BUF_LEN]>,
         &'static mut MaybeUninit<[u8; capsules::process_console::COMMAND_BUF_LEN]>,
         &'static mut MaybeUninit<
-            [Command<{ capsules::process_console::COMMAND_BUF_LEN }>;
+            [capsules::process_console::Command<{ capsules::process_console::COMMAND_BUF_LEN }>;
                 capsules::process_console::COMMAND_HISTORY_LEN],
         >,
         &'static mut MaybeUninit<ProcessConsole<'static, VirtualMuxAlarm<'static, A>, Capability>>,
@@ -154,7 +154,7 @@ impl<A: 'static + Alarm<'static>> Component for ProcessConsoleComponent<A> {
             .5
             .write([0; capsules::process_console::COMMAND_BUF_LEN]);
         let command_history_buffer = static_buffer.6.write(
-            [Command::<{ capsules::process_console::COMMAND_BUF_LEN }>::new();
+            [capsules::process_console::Command::<{ capsules::process_console::COMMAND_BUF_LEN }>::new();
                 capsules::process_console::COMMAND_HISTORY_LEN],
         );
 

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -108,6 +108,7 @@ pub static mut STACK_MEMORY: [u8; 0x2000] = [0; 0x2000];
 struct Imix {
     pconsole: &'static capsules::process_console::ProcessConsole<
         'static,
+        { capsules::process_console::DEFAULT_COMMAND_HISTORY_LEN },
         capsules::virtual_alarm::VirtualMuxAlarm<'static, sam4l::ast::Ast<'static>>,
         components::process_console::Capability,
     >,

--- a/boards/litex/arty/src/main.rs
+++ b/boards/litex/arty/src/main.rs
@@ -114,6 +114,7 @@ struct LiteXArty {
     console: &'static capsules::console::Console<'static>,
     pconsole: &'static capsules::process_console::ProcessConsole<
         'static,
+        { capsules::process_console::DEFAULT_COMMAND_HISTORY_LEN },
         VirtualMuxAlarm<
             'static,
             litex_vexriscv::timer::LiteXAlarm<

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -123,6 +123,7 @@ pub struct Platform {
     console: &'static capsules::console::Console<'static>,
     pconsole: &'static capsules::process_console::ProcessConsole<
         'static,
+        { capsules::process_console::DEFAULT_COMMAND_HISTORY_LEN },
         capsules::virtual_alarm::VirtualMuxAlarm<'static, nrf52::rtc::Rtc<'static>>,
         components::process_console::Capability,
     >,

--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -82,6 +82,7 @@ pub struct Platform {
     button: &'static capsules::button::Button<'static, nrf52840::gpio::GPIOPin<'static>>,
     pconsole: &'static capsules::process_console::ProcessConsole<
         'static,
+        { capsules::process_console::DEFAULT_COMMAND_HISTORY_LEN },
         VirtualMuxAlarm<'static, nrf52840::rtc::Rtc<'static>>,
         components::process_console::Capability,
     >,

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -165,6 +165,7 @@ pub struct Platform {
     button: &'static capsules::button::Button<'static, nrf52840::gpio::GPIOPin<'static>>,
     pconsole: &'static capsules::process_console::ProcessConsole<
         'static,
+        { capsules::process_console::DEFAULT_COMMAND_HISTORY_LEN },
         VirtualMuxAlarm<'static, nrf52840::rtc::Rtc<'static>>,
         components::process_console::Capability,
     >,

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -72,7 +72,6 @@
 use capsules::i2c_master_slave_driver::I2CMasterSlaveDriver;
 use capsules::net::ieee802154::MacAddress;
 use capsules::net::ipv6::ip_utils::IPAddr;
-use capsules::process_console::Command;
 use capsules::virtual_aes_ccm::MuxAES128CCM;
 use capsules::virtual_alarm::VirtualMuxAlarm;
 use kernel::component::Component;

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -165,7 +165,7 @@ pub struct Platform {
     button: &'static capsules::button::Button<'static, nrf52840::gpio::GPIOPin<'static>>,
     pconsole: &'static capsules::process_console::ProcessConsole<
         'static,
-        { capsules::process_console::DEFAULT_COMMAND_HISTORY_LEN },
+        20,
         VirtualMuxAlarm<'static, nrf52840::rtc::Rtc<'static>>,
         components::process_console::Capability,
     >,
@@ -438,7 +438,8 @@ pub unsafe fn main() {
         process_printer,
     )
     .finalize(components::process_console_component_static!(
-        nrf52840::rtc::Rtc<'static>
+        nrf52840::rtc::Rtc<'static>,
+        20
     ));
 
     // Setup the console.

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -72,6 +72,7 @@
 use capsules::i2c_master_slave_driver::I2CMasterSlaveDriver;
 use capsules::net::ieee802154::MacAddress;
 use capsules::net::ipv6::ip_utils::IPAddr;
+use capsules::process_console::Command;
 use capsules::virtual_aes_ccm::MuxAES128CCM;
 use capsules::virtual_alarm::VirtualMuxAlarm;
 use kernel::component::Component;

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -165,7 +165,7 @@ pub struct Platform {
     button: &'static capsules::button::Button<'static, nrf52840::gpio::GPIOPin<'static>>,
     pconsole: &'static capsules::process_console::ProcessConsole<
         'static,
-        20,
+        { capsules::process_console::DEFAULT_COMMAND_HISTORY_LEN },
         VirtualMuxAlarm<'static, nrf52840::rtc::Rtc<'static>>,
         components::process_console::Capability,
     >,
@@ -438,8 +438,7 @@ pub unsafe fn main() {
         process_printer,
     )
     .finalize(components::process_console_component_static!(
-        nrf52840::rtc::Rtc<'static>,
-        20
+        nrf52840::rtc::Rtc<'static>
     ));
 
     // Setup the console.

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -141,6 +141,7 @@ pub struct Platform {
     button: &'static capsules::button::Button<'static, nrf52832::gpio::GPIOPin<'static>>,
     pconsole: &'static capsules::process_console::ProcessConsole<
         'static,
+        { capsules::process_console::DEFAULT_COMMAND_HISTORY_LEN },
         VirtualMuxAlarm<'static, Rtc<'static>>,
         components::process_console::Capability,
     >,

--- a/boards/particle_boron/src/main.rs
+++ b/boards/particle_boron/src/main.rs
@@ -102,6 +102,7 @@ pub struct Platform {
     button: &'static capsules::button::Button<'static, nrf52840::gpio::GPIOPin<'static>>,
     pconsole: &'static capsules::process_console::ProcessConsole<
         'static,
+        { capsules::process_console::DEFAULT_COMMAND_HISTORY_LEN },
         VirtualMuxAlarm<'static, nrf52840::rtc::Rtc<'static>>,
         components::process_console::Capability,
     >,

--- a/boards/sma_q3/src/main.rs
+++ b/boards/sma_q3/src/main.rs
@@ -80,6 +80,7 @@ pub struct Platform {
     button: &'static capsules::button::Button<'static, nrf52840::gpio::GPIOPin<'static>>,
     pconsole: &'static capsules::process_console::ProcessConsole<
         'static,
+        { capsules::process_console::DEFAULT_COMMAND_HISTORY_LEN },
         VirtualMuxAlarm<'static, nrf52840::rtc::Rtc<'static>>,
         components::process_console::Capability,
     >,

--- a/capsules/src/process_console.rs
+++ b/capsules/src/process_console.rs
@@ -162,9 +162,9 @@ impl Command {
         (&mut self.buf).copy_from_slice(buf);
     }
 
-    fn insert_byte(&mut self, byte: &u8) {
+    fn insert_byte(&mut self, byte: u8) {
         if self.len < COMMAND_BUF_LEN {
-            self.buf[self.len] = *byte;
+            self.buf[self.len] = byte;
             self.len = self.len + 1;
         }
     }
@@ -1050,10 +1050,13 @@ impl<'a, const COMMAND_HISTORY_LEN: usize, A: Alarm<'a>, C: ProcessManagementCap
                                 self.command_history.map(|cmd_arr| {
                                     if self.scrolled_in_history.get() {
                                         cmd_arr[0].clear();
+                                        for i in 0..(self.command_index.get() - 1) {
+                                            cmd_arr[0].insert_byte(command[i]);
+                                        }
                                         self.scrolled_in_history.set(false);
                                     }
 
-                                    cmd_arr[0].insert_byte(&read_buf[0]);
+                                    cmd_arr[0].insert_byte(read_buf[0]);
                                 });
                             }
                         }

--- a/capsules/src/process_console.rs
+++ b/capsules/src/process_console.rs
@@ -988,6 +988,3 @@ impl<'a, A: Alarm<'a>, C: ProcessManagementCapability> uart::ReceiveClient
         let _ = self.uart.receive_buffer(read_buf, 1);
     }
 }
-
-/*
-*/

--- a/capsules/src/process_console.rs
+++ b/capsules/src/process_console.rs
@@ -186,9 +186,11 @@ impl Default for Command {
 
 impl PartialEq<[u8; COMMAND_BUF_LEN]> for Command {
     fn eq(&self, other_buf: &[u8; COMMAND_BUF_LEN]) -> bool {
-        let mut bytes_iter = self.buf.iter().zip(other_buf.iter());
-        bytes_iter.all(|(a, b)| *a == *b && *a != TERMINATOR);
-        bytes_iter.next().eq(&Some((&TERMINATOR, &TERMINATOR)))
+        self.buf
+            .iter()
+            .zip(other_buf.iter())
+            .take_while(|(a, b)| **a != TERMINATOR || **b != TERMINATOR)
+            .all(|(a, b)| *a == *b)
     }
 }
 

--- a/capsules/src/process_console.rs
+++ b/capsules/src/process_console.rs
@@ -87,14 +87,14 @@ impl Command {
     /// Fill the buffer with the provided data.
     /// If the provided data's length is smaller than the buffer length,
     /// the left over bytes are not modified due to '\0' termination.
-    pub fn fill(&mut self, buf: &[u8l COMMND_BUF_LEN], terminator_idx: usize) {
+    pub fn fill(&mut self, buf: &[u8; COMMAND_BUF_LEN], terminator_idx: usize) {
         self.len = if terminator_idx >= COMMAND_BUF_LEN {
             COMMAND_BUF_LEN
         } else {
             terminator_idx
         };
 
-        (&self.buf).copy_from_slice(&buf);
+        (&mut self.buf).copy_from_slice(buf);
     }
 
     pub fn is_buffer_empty(&mut self) -> bool {
@@ -536,7 +536,7 @@ impl<'a, const COMMAND_HISTORY_LEN: usize, A: Alarm<'a>, C: ProcessManagementCap
                                         cmd_arr[i] = cmd_arr[i - 1];
                                     }
 
-                                    cmd_arr[0].fill(command, terminator);
+                                    cmd_arr[0].fill(&command_array, terminator);
                                 }
                             });
                         }

--- a/capsules/src/process_console.rs
+++ b/capsules/src/process_console.rs
@@ -87,7 +87,7 @@ impl Command {
     /// Fill the buffer with the provided data.
     /// If the provided data's length is smaller than the buffer length,
     /// the left over bytes are not modified due to '\0' termination.
-    pub fn fill(&mut self, buf: &[u8], terminator_idx: usize) {
+    pub fn fill(&mut self, buf: &[u8l COMMND_BUF_LEN], terminator_idx: usize) {
         self.len = if terminator_idx >= COMMAND_BUF_LEN {
             COMMAND_BUF_LEN
         } else {

--- a/capsules/src/process_console.rs
+++ b/capsules/src/process_console.rs
@@ -189,7 +189,8 @@ impl PartialEq<[u8; COMMAND_BUF_LEN]> for Command {
         self.buf
             .iter()
             .zip(other_buf.iter())
-            .all(|(a, b)| *a != TERMINATOR && *b != TERMINATOR && a == b)
+            .take_while(|(a, b)| **a != TERMINATOR || **b != TERMINATOR)
+            .all(|(a, b)| a == b)
     }
 }
 

--- a/capsules/src/process_console.rs
+++ b/capsules/src/process_console.rs
@@ -546,10 +546,7 @@ impl<'a, const COMMAND_HISTORY_LEN: usize, A: Alarm<'a>, C: ProcessManagementCap
                                     command_array.copy_from_slice(command);
 
                                     if cmd_arr[0] != command_array {
-                                        for i in (1..COMMAND_HISTORY_LEN).rev() {
-                                            cmd_arr[i] = cmd_arr[i - 1];
-                                        }
-
+                                        cmd_arr.rotate_right(1);
                                         cmd_arr[0].fill(&command_array, terminator);
                                     }
                                 });

--- a/capsules/src/process_console.rs
+++ b/capsules/src/process_console.rs
@@ -950,6 +950,7 @@ impl<'a, const COMMAND_HISTORY_LEN: usize, A: Alarm<'a>, C: ProcessManagementCap
                             {
                                 // Reset the sequence, when \r\n is received
                                 self.previous_byte.set(0);
+                                self.command_history_index.insert(None);
                             } else {
                                 self.execute.set(true);
                                 let _ = self.write_bytes(&['\r' as u8, '\n' as u8]);

--- a/capsules/src/process_console.rs
+++ b/capsules/src/process_console.rs
@@ -536,7 +536,7 @@ impl<'a, const COMMAND_HISTORY_LEN: usize, A: Alarm<'a>, C: ProcessManagementCap
                         let clean_str = s.trim();
 
                         // Try to add a new command to the history buffer
-                        if COMMAND_HISTORY_LEN > 0 {
+                        if clean_str.len() > 0 && COMMAND_HISTORY_LEN > 0 {
                             self.command_history.map(|cmd_arr| {
                                 if len == COMMAND_BUF_LEN {
                                     let mut command_array = [0; COMMAND_BUF_LEN];

--- a/capsules/src/process_console.rs
+++ b/capsules/src/process_console.rs
@@ -164,8 +164,8 @@ impl Command {
     }
 
     fn insert_byte(&mut self, byte: u8) {
-        if self.len < COMMAND_BUF_LEN {
-            self.buf[self.len] = byte;
+        if let Some(buf_byte) = self.buf.get_mut(self.len) {
+            *buf_byte = byte;
             self.len = self.len + 1;
         }
     }

--- a/capsules/src/process_console.rs
+++ b/capsules/src/process_console.rs
@@ -909,13 +909,17 @@ impl<'a, A: Alarm<'a>, C: ProcessManagementCapability> uart::ReceiveClient
                                             Some(i) => i + 1,
                                             None => 0,
                                         };
-                                        //check if there even is a command to move up to
-                                        self.command_history
-                                            .map(|cmd_arr| match cmd_arr[i][0] {
-                                                0 => None,
-                                                _ => Some(i),
-                                            })
-                                            .unwrap()
+                                        if i >= COMMAND_HISTORY_LEN {
+                                            None
+                                        } else {
+                                            //check if there even is a command to move up to
+                                            self.command_history
+                                                .map(|cmd_arr| match cmd_arr[i][0] {
+                                                    0 => None,
+                                                    _ => Some(i),
+                                                })
+                                                .unwrap()
+                                        }
                                     }
                                     //down arrow case
                                     b'B' => {

--- a/capsules/src/process_console.rs
+++ b/capsules/src/process_console.rs
@@ -171,9 +171,9 @@ impl Command {
     }
 
     fn delete_last_byte(&mut self) {
-        if self.len > 0 {
-            self.len -= 1;
-            self.buf[self.len] = EOL;
+        if let Some(buf_byte) = self.buf.get_mut(self.len - 1) {
+            *buf_byte = EOL;
+            self.len = self.len - 1;
         }
     }
 

--- a/capsules/src/process_console.rs
+++ b/capsules/src/process_console.rs
@@ -964,7 +964,9 @@ impl<'a, const COMMAND_HISTORY_LEN: usize, A: Alarm<'a>, C: ProcessManagementCap
                                 command[index - 1] = EOL;
                                 self.command_index.set(index - 1);
                             }
-                        } else if read_buf[0] == ESC || self.control_seq_in_progress.get() {
+                        } else if (COMMAND_HISTORY_LEN > 0)
+                            && (read_buf[0] == ESC || self.control_seq_in_progress.get())
+                        {
                             // Catch the Up and Down arrow keys
                             if read_buf[0] == ESC {
                                 // Signal that a control sequence has started and capture it

--- a/capsules/src/process_console.rs
+++ b/capsules/src/process_console.rs
@@ -34,7 +34,7 @@ pub const READ_BUF_LEN: usize = 4;
 /// characters, limiting arguments to 25 bytes or so seems fine for now.
 pub const COMMAND_BUF_LEN: usize = 32;
 
-pub const DEFAULT_COMMAND_HISTORY_LEN: usize = 11;
+pub const DEFAULT_COMMAND_HISTORY_LEN: usize = 10;
 
 /// List of valid commands for printing help. Consolidated as these are
 /// displayed in a few different cases.
@@ -162,8 +162,10 @@ impl Command {
     }
 
     fn insert_byte(&mut self, byte: &u8) {
-        self.buf[self.len] = *byte;
-        self.len = self.len + 1;
+        if self.len < COMMAND_BUF_LEN {
+            self.buf[self.len] = *byte;
+            self.len = self.len + 1;
+        }
     }
 
     fn clear(&mut self) {
@@ -1035,9 +1037,12 @@ impl<'a, const COMMAND_HISTORY_LEN: usize, A: Alarm<'a>, C: ProcessManagementCap
                             command[index] = read_buf[0];
                             self.command_index.set(index + 1);
                             command[index + 1] = 0;
-                            self.command_history.map(|cmd_arr| {
-                                (&mut cmd_arr[0]).insert_byte(&read_buf[0]);
-                            });
+
+                            if COMMAND_HISTORY_LEN > 1 {
+                                self.command_history.map(|cmd_arr| {
+                                    (&mut cmd_arr[0]).insert_byte(&read_buf[0]);
+                                });
+                            }
                         }
                     });
                 }

--- a/capsules/src/process_console.rs
+++ b/capsules/src/process_console.rs
@@ -526,19 +526,21 @@ impl<'a, const COMMAND_HISTORY_LEN: usize, A: Alarm<'a>, C: ProcessManagementCap
                         let clean_str = s.trim();
 
                         // Try to add a new command to the history buffer
-                        if clean_str.len() > 0 && COMMAND_HISTORY_LEN > 0 {
-                            self.command_history.map(|cmd_arr| {
-                                let mut command_array = [0; COMMAND_BUF_LEN];
-                                command_array.copy_from_slice(command);
+                        if COMMAND_HISTORY_LEN > 0 {
+                            if clean_str.len() > 0 {
+                                self.command_history.map(|cmd_arr| {
+                                    let mut command_array = [0; COMMAND_BUF_LEN];
+                                    command_array.copy_from_slice(command);
 
-                                if !cmd_arr[0].same_bytes(&command_array) {
-                                    for i in (1..COMMAND_HISTORY_LEN).rev() {
-                                        cmd_arr[i] = cmd_arr[i - 1];
+                                    if !cmd_arr[0].same_bytes(&command_array) {
+                                        for i in (1..COMMAND_HISTORY_LEN).rev() {
+                                            cmd_arr[i] = cmd_arr[i - 1];
+                                        }
+
+                                        cmd_arr[0].fill(&command_array, terminator);
                                     }
-
-                                    cmd_arr[0].fill(&command_array, terminator);
-                                }
-                            });
+                                });
+                            }
                         }
 
                         if clean_str.starts_with("help") {

--- a/capsules/src/process_console.rs
+++ b/capsules/src/process_console.rs
@@ -533,23 +533,25 @@ impl<'a, A: Alarm<'a>, C: ProcessManagementCapability> ProcessConsole<'a, A, C> 
                         let clean_str = s.trim();
 
                         // Try to add a new command to the history buffer
-                        self.command_history.map(|cmd_arr| {
-                            if !cmd_arr[0].same_bytes(command, terminator + 1) {
-                                for i in (1..DEFAULT_COMMAND_HISTORY_LEN).rev() {
-                                    cmd_arr[i] = cmd_arr[i - 1];
-                                }
+                        if DEFAULT_COMMAND_HISTORY_LEN > 0 {
+                            self.command_history.map(|cmd_arr| {
+                                if !cmd_arr[0].same_bytes(command, terminator + 1) {
+                                    for i in (1..DEFAULT_COMMAND_HISTORY_LEN).rev() {
+                                        cmd_arr[i] = cmd_arr[i - 1];
+                                    }
 
-                                match cmd_arr[0].fill(command, terminator + 1) {
-                                    Err(_) => {
-                                        let _ =
-                                            self.write_bytes(b"Error: input command too long.\r\n");
-                                    }
-                                    _ => {
-                                        // Ignore the Ok message
+                                    match cmd_arr[0].fill(command, terminator + 1) {
+                                        Err(_) => {
+                                            let _ = self
+                                                .write_bytes(b"Error: input command too long.\r\n");
+                                        }
+                                        _ => {
+                                            // Ignore the Ok message
+                                        }
                                     }
                                 }
-                            }
-                        });
+                            });
+                        }
 
                         if clean_str.starts_with("help") {
                             let _ = self.write_bytes(b"Welcome to the process console.\r\n");

--- a/capsules/src/process_console.rs
+++ b/capsules/src/process_console.rs
@@ -94,7 +94,7 @@ impl Command {
             terminator_idx
         };
 
-        self.buf[..self.len].copy_from_slice(&buf[..self.len]);
+        (&self.buf).copy_from_slice(&buf);
     }
 
     pub fn is_buffer_empty(&mut self) -> bool {

--- a/capsules/src/process_console.rs
+++ b/capsules/src/process_console.rs
@@ -186,11 +186,9 @@ impl Default for Command {
 
 impl PartialEq<[u8; COMMAND_BUF_LEN]> for Command {
     fn eq(&self, other_buf: &[u8; COMMAND_BUF_LEN]) -> bool {
-        self.buf
-            .iter()
-            .zip(other_buf.iter())
-            .take_while(|(a, b)| **a != TERMINATOR || **b != TERMINATOR)
-            .all(|(a, b)| a == b)
+        let mut bytes_iter = self.buf.iter().zip(other_buf.iter());
+        bytes_iter.all(|(a, b)| *a == *b && *a != TERMINATOR);
+        bytes_iter.next().eq(&Some((&TERMINATOR, &TERMINATOR)))
     }
 }
 

--- a/doc/Process_Console.md
+++ b/doc/Process_Console.md
@@ -604,11 +604,3 @@ tock$
       0x00040800 ┴─────────────────────────────────────────── H
 
 ```
-<<<<<<< HEAD
-=======
-
- ### `up and down arrows`
- - You can use the up and down arrows to scroll through the command history and to view the previous commands you have run.
- - If you inserted more commands than the command history can hold, the oldest commands will be overwritten.
- - You can view the commands in bidirectional order, `up arrow` for oldest commands and `down arrow` for newest.
->>>>>>> Copied the ProcessConsole from the upstream adnd added new documentation for the ProcessConsole using custom COMMAND_HISTORY_LEN

--- a/doc/Process_Console.md
+++ b/doc/Process_Console.md
@@ -43,10 +43,10 @@ Setup
     ));
  let _ = _process_console.start();
  ```
-> Note: Using the process console might require allocating more stack to the kernel. This is done by modifying the `STACK_MEMORY` variable from the board's `main.rs`.
-
- Using Process Console
- --------------------
+<<<<<<< HEAD
+=======
+ Here is how to add a custom size for the command `history` used by the ProcessConsole structure to keep track of the typed commands:
+ ```rust
 
  With this capsule properly added to a board's `main.rs` and the Tock kernel
  loaded to the board, make sure there is a serial connection to the board.
@@ -85,6 +85,10 @@ tock$
   - [`panic`](#panic) - causes the kernel to run the panic handler
   - [`kernel`](#kernel) - prints the kernel memory map
   - [`process n`](#process) - prints the memory map of process with name n
+<<<<<<< HEAD
+=======
+  - [`up and down arrows`](#up-and-down-arrows) - scroll through the command history
+>>>>>>> Copied the ProcessConsole from the upstream adnd added new documentation for the ProcessConsole using custom COMMAND_HISTORY_LEN
 
  For the examples below we will have 2 processes on the board: `blink` (which will blink all the LEDs that are 
  connected to the kernel), and `c_hello` (which prints 'Hello World' when the console is started). Also, a micro:bit v2 board was used as support for the commands, so the results may vary on other devices.
@@ -600,3 +604,11 @@ tock$
       0x00040800 ┴─────────────────────────────────────────── H
 
 ```
+<<<<<<< HEAD
+=======
+
+ ### `up and down arrows`
+ - You can use the up and down arrows to scroll through the command history and to view the previous commands you have run.
+ - If you inserted more commands than the command history can hold, the oldest commands will be overwritten.
+ - You can view the commands in bidirectional order, `up arrow` for oldest commands and `down arrow` for newest.
+>>>>>>> Copied the ProcessConsole from the upstream adnd added new documentation for the ProcessConsole using custom COMMAND_HISTORY_LEN

--- a/doc/Process_Console.md
+++ b/doc/Process_Console.md
@@ -609,6 +609,8 @@ tock$
  - If you inserted more commands than the command history can hold, oldest commands will be overwritten.
  - You can view the commands in bidirectional order, `up arrow` for oldest commands and `down arrow` for newest.
  - If the user custom size for the history is set to `0`, the history will be disabled and the rust compiler will be able to optimize the binary file by removing dead code.
+ - If you are typing a command and accidentally press the `up arrow` key, you can press `down arrow` in order to retrieve the command you were typing.
+ - If you scroll through the history and you want to edit a command and accidentally press the `up` or `down` arrow key, scroll to the bottom of the history and you will get back to the command you were typing.
 
   Here is how to add a custom size for the command `history` used by the ProcessConsole structure to keep track of the typed commands, in the `main.rs` of boards:
  ```rust
@@ -621,7 +623,7 @@ tock$
     
     pconsole: &'static capsules::process_console::ProcessConsole<
         'static,
-        { CUSTOM_HISTORY_LEN },
+        { COMMAND_HISTORY_LEN },
         // or { capsules::process_console::DEFAULT_COMMAND_HISTORY_LEN }
         // for the deafult behaviour
         VirtualMuxAlarm<'static, nrf52840::rtc::Rtc<'static>>,
@@ -646,4 +648,4 @@ tock$
 
   /// ...
  ```
-> Note: In order to disable any functionality for the command history set the `CUSTOM_HISTORY_LEN` as `0`.
+> Note: In order to disable any functionality for the command history set the `COMMAND_HISTORY_LEN` as `0`, also the history will be disabled for a size of `1`, because the first position from the command history is reserved for accidents by pressing `up` or `down` arrow key.

--- a/doc/Process_Console.md
+++ b/doc/Process_Console.md
@@ -648,4 +648,4 @@ tock$
 
   /// ...
  ```
-> Note: In order to disable any functionality for the command history set the `COMMAND_HISTORY_LEN` as `0`, also the history will be disabled for a size of `1`, because the first position from the command history is reserved for accidents by pressing `up` or `down` arrow key.
+> Note: In order to disable any functionality for the command history set the `COMMAND_HISTORY_LEN` to `0` or `1` (the history will be disabled for a size of `1`, because the first position from the command history is reserved for accidents by pressing `up` or `down` arrow key.

--- a/doc/Process_Console.md
+++ b/doc/Process_Console.md
@@ -646,4 +646,4 @@ tock$
 
   /// ...
  ```
-> Note: In order to disable any functionality for the command history set the `CUSTOM_HISTORY_LEN` as `0`. 
+> Note: In order to disable any functionality for the command history set the `CUSTOM_HISTORY_LEN` as `0`.

--- a/doc/Process_Console.md
+++ b/doc/Process_Console.md
@@ -614,7 +614,7 @@ tock$
 
   Here is how to add a custom size for the command `history` used by the ProcessConsole structure to keep track of the typed commands, in the `main.rs` of boards:
  ```rust
- const CUSTOM_HISTORY_LEN : usize = 30;
+ const COMMAND_HISTORY_LEN : usize = 30;
 
  /// ...
  
@@ -623,7 +623,7 @@ tock$
     
     pconsole: &'static capsules::process_console::ProcessConsole<
         'static,
-        { COMMAND_HISTORY_LEN },
+        COMMAND_HISTORY_LEN,
         // or { capsules::process_console::DEFAULT_COMMAND_HISTORY_LEN }
         // for the deafult behaviour
         VirtualMuxAlarm<'static, nrf52840::rtc::Rtc<'static>>,
@@ -643,7 +643,7 @@ tock$
       )
       .finalize(components::process_console_component_static!(
           nrf52833::rtc::Rtc,
-          CUSTOM_HISTORY_LEN // or nothing for the default behaviour
+          COMMAND_HISTORY_LEN // or nothing for the default behaviour
       ));
 
   /// ...


### PR DESCRIPTION
### Pull Request Overview

This pull request adds an easy-to-use Bash-like command history for the process console.

### Added features

   - User can enable/disable the command history from the board's `main.rs`.
   - If enabled, user can scroll `up` or `down` by pressing `up` and `down` arrow keys respectively.
   - Pressing on accident `up` or `down` arrow saves the unfinished command and can be fetched back by going to the bottom of command history. 
   - Modifying a command from history is also saved (if accidentally pressed `up` or `down` arrow).
   - Empty commands (whitespace-filled) don't get registered in the command history.
   - Invalid commands also are saved into the history structure.

### Code size for IMIX binary build with enabled/disabled command history:

| Build | .text | .data | .bss | .dec |
| ------------- | ------------- | ------------- | ------------- | ------------- |
| Tock master  | 174468  |  0 |  29592  | 204060  |
| Enabled with default size  | 175492  |  0  |  28944  |  204436  |
| Disabled  |  174292  | 0  |  28576  |  202868  |

If disabled, the code size decreases.

### Testing Strategy

The implementation of the command history was tested on the `nrf52840dk` and `esp32-c3-devkitM-1` boards.

### Files changed
`capsules/process_console.rs`
 ~ implementation for command history

`boards/components/process_console.rs`
 ~ added a new branch to process_console_component_static macro for easily enable/disable the command history

### Documentation Updated

Updated the documentation in `doc/Process_Console.md` accordingly : 
- Code support on how to enable/disable the command history
- How to use command history
- Support for selecting a custom size for the command history



### TODO or Help Wanted

Feedback is much appreciated.


### Documentation Updated

- [x] Updated the relevant files in `/docs`.

### Formatting

- [x] Ran `make prepush`.