### PR TITLE
fixed i2c buffer len

### DIFF
--- a/capsules/src/bmp280.rs
+++ b/capsules/src/bmp280.rs
@@ -150,7 +150,7 @@ impl<'a> I2cWrapper<'a> {
         buffer[0] = addr as u8;
         buffer[1..][..COUNT].copy_from_slice(&data);
         self.i2c.enable();
-        self.i2c.write(buffer, COUNT as u8 + 1)
+        self.i2c.write(buffer, COUNT + 1)
     }
 
     /// Requests a read into buffer.
@@ -159,7 +159,7 @@ impl<'a> I2cWrapper<'a> {
         &self,
         buffer: &'static mut [u8],
         addr: Register,
-        count: u8,
+        count: usize,
     ) -> Result<(), (i2c::Error, &'static mut [u8])> {
         buffer[0] = addr as u8;
         self.i2c.enable();
@@ -304,7 +304,7 @@ impl<'a, A: Alarm<'a>> Bmp280<'a, A> {
 enum I2cOperation {
     Read {
         addr: Register,
-        count: u8,
+        count: usize,
         fail_state: State,
     },
     Write {

--- a/capsules/src/bus.rs
+++ b/capsules/src/bus.rs
@@ -315,7 +315,7 @@ impl<'a, I: I2CDevice> Bus<'a> for I2CMasterBus<'a, I> {
             debug!("write len {}", len);
             self.len.set(len);
             self.status.set(BusStatus::Write);
-            match self.i2c.write(buffer, (len * bytes) as u8) {
+            match self.i2c.write(buffer, len * bytes) {
                 Ok(()) => Ok(()),
                 Err((error, buffer)) => Err((error.into(), buffer)),
             }
@@ -336,7 +336,7 @@ impl<'a, I: I2CDevice> Bus<'a> for I2CMasterBus<'a, I> {
         if len & bytes < 255 && buffer.len() >= len * bytes {
             self.len.set(len);
             self.status.set(BusStatus::Read);
-            match self.i2c.read(buffer, (len * bytes) as u8) {
+            match self.i2c.read(buffer, len * bytes) {
                 Ok(()) => Ok(()),
                 Err((error, buffer)) => Err((error.into(), buffer)),
             }

--- a/capsules/src/i2c_master.rs
+++ b/capsules/src/i2c_master.rs
@@ -60,8 +60,8 @@ impl<'a, I: 'a + i2c::I2CMaster> I2CMasterDriver<'a, I> {
         kernel_data: &GrantKernelData,
         command: Cmd,
         addr: u8,
-        wlen: u8,
-        rlen: u8,
+        wlen: usize,
+        rlen: usize,
     ) -> Result<(), ErrorCode> {
         kernel_data
             .get_readwrite_processbuffer(rw_allow::BUFFER)
@@ -145,7 +145,7 @@ impl<'a, I: 'a + i2c::I2CMaster> SyscallDriver for I2CMasterDriver<'a, I> {
                     .enter(processid, |_, kernel_data| {
                         let addr = arg1 as u8;
                         let write_len = arg2;
-                        self.operation(processid, kernel_data, Cmd::Write, addr, write_len as u8, 0)
+                        self.operation(processid, kernel_data, Cmd::Write, addr, write_len, 0)
                             .into()
                     })
                     .unwrap_or_else(|err| err.into()),
@@ -154,7 +154,7 @@ impl<'a, I: 'a + i2c::I2CMaster> SyscallDriver for I2CMasterDriver<'a, I> {
                     .enter(processid, |_, kernel_data| {
                         let addr = arg1 as u8;
                         let read_len = arg2;
-                        self.operation(processid, kernel_data, Cmd::Read, addr, 0, read_len as u8)
+                        self.operation(processid, kernel_data, Cmd::Read, addr, 0, read_len)
                             .into()
                     })
                     .unwrap_or_else(|err| err.into()),
@@ -169,8 +169,8 @@ impl<'a, I: 'a + i2c::I2CMaster> SyscallDriver for I2CMasterDriver<'a, I> {
                                 kernel_data,
                                 Cmd::WriteRead,
                                 addr,
-                                write_len as u8,
-                                read_len as u8,
+                                write_len,
+                                read_len,
                             )
                             .into()
                         })

--- a/capsules/src/i2c_master_slave_driver.rs
+++ b/capsules/src/i2c_master_slave_driver.rs
@@ -189,7 +189,7 @@ impl hil::i2c::I2CHwSlaveClient for I2CMasterSlaveDriver<'_> {
     fn command_complete(
         &self,
         buffer: &'static mut [u8],
-        length: u8,
+        length: usize,
         transmission_type: hil::i2c::SlaveTransmissionType,
     ) {
         // Need to know if read or write
@@ -330,10 +330,7 @@ impl SyscallDriver for I2CMasterSlaveDriver<'_> {
                                     hil::i2c::I2CMaster::enable(self.i2c);
                                     // TODO verify errors
                                     let _ = hil::i2c::I2CMaster::write(
-                                        self.i2c,
-                                        address,
-                                        kernel_tx,
-                                        write_len as u8,
+                                        self.i2c, address, kernel_tx, write_len,
                                     );
                                 });
                                 0
@@ -375,10 +372,7 @@ impl SyscallDriver for I2CMasterSlaveDriver<'_> {
                                     hil::i2c::I2CMaster::enable(self.i2c);
                                     // TODO verify errors
                                     let _ = hil::i2c::I2CMaster::read(
-                                        self.i2c,
-                                        address,
-                                        kernel_tx,
-                                        read_len as u8,
+                                        self.i2c, address, kernel_tx, read_len,
                                     );
                                 });
                                 0
@@ -435,9 +429,7 @@ impl SyscallDriver for I2CMasterSlaveDriver<'_> {
 
                                     // TODO verify errors
                                     let _ = hil::i2c::I2CSlave::read_send(
-                                        self.i2c,
-                                        kernel_tx,
-                                        read_len as u8,
+                                        self.i2c, kernel_tx, read_len,
                                     );
                                 });
                                 0
@@ -500,11 +492,7 @@ impl SyscallDriver for I2CMasterSlaveDriver<'_> {
                                     hil::i2c::I2CMaster::enable(self.i2c);
                                     // TODO verify errors
                                     let _ = hil::i2c::I2CMaster::write_read(
-                                        self.i2c,
-                                        address,
-                                        kernel_tx,
-                                        write_len as u8,
-                                        read_len as u8,
+                                        self.i2c, address, kernel_tx, write_len, read_len,
                                     );
                                 });
                             })

--- a/capsules/src/mcp230xx.rs
+++ b/capsules/src/mcp230xx.rs
@@ -308,7 +308,7 @@ impl<'a> MCP230xx<'a> {
             // we also want to set.
             buffer[i] = 0b00000010; // Make MCP230xx interrupt pin active high.
                                     // TODO verify errors
-            let _ = self.i2c.write(buffer, (i + 1) as u8);
+            let _ = self.i2c.write(buffer, i + 1);
             self.state.set(State::EnableInterruptSettings(pin_number));
 
             Ok(())

--- a/capsules/src/pca9544a.rs
+++ b/capsules/src/pca9544a.rs
@@ -107,7 +107,7 @@ impl<'a> PCA9544A<'a> {
                 }
 
                 // TODO verify errors
-                let _ = self.i2c.write(buffer, index as u8);
+                let _ = self.i2c.write(buffer, index);
                 self.state.set(State::Done);
 
                 CommandReturn::success()

--- a/capsules/src/virtual_i2c.rs
+++ b/capsules/src/virtual_i2c.rs
@@ -202,9 +202,9 @@ impl<'a> DynamicDeferredCallClient for MuxI2C<'a> {
 #[derive(Copy, Clone, PartialEq)]
 enum Op {
     Idle,
-    Write(u8),
-    Read(u8),
-    WriteRead(u8, u8),
+    Write(usize),
+    Read(usize),
+    WriteRead(usize, usize),
     CommandComplete(Result<(), Error>),
 }
 
@@ -269,8 +269,8 @@ impl i2c::I2CDevice for I2CDevice<'_> {
     fn write_read(
         &self,
         data: &'static mut [u8],
-        write_len: u8,
-        read_len: u8,
+        write_len: usize,
+        read_len: usize,
     ) -> Result<(), (Error, &'static mut [u8])> {
         if self.operation.get() == Op::Idle {
             self.buffer.replace(data);
@@ -282,7 +282,7 @@ impl i2c::I2CDevice for I2CDevice<'_> {
         }
     }
 
-    fn write(&self, data: &'static mut [u8], len: u8) -> Result<(), (Error, &'static mut [u8])> {
+    fn write(&self, data: &'static mut [u8], len: usize) -> Result<(), (Error, &'static mut [u8])> {
         if self.operation.get() == Op::Idle {
             self.buffer.replace(data);
             self.operation.set(Op::Write(len));
@@ -293,7 +293,11 @@ impl i2c::I2CDevice for I2CDevice<'_> {
         }
     }
 
-    fn read(&self, buffer: &'static mut [u8], len: u8) -> Result<(), (Error, &'static mut [u8])> {
+    fn read(
+        &self,
+        buffer: &'static mut [u8],
+        len: usize,
+    ) -> Result<(), (Error, &'static mut [u8])> {
         if self.operation.get() == Op::Idle {
             self.buffer.replace(buffer);
             self.operation.set(Op::Read(len));
@@ -370,8 +374,8 @@ impl<'a> i2c::I2CDevice for SMBusDevice<'a> {
     fn write_read(
         &self,
         data: &'static mut [u8],
-        write_len: u8,
-        read_len: u8,
+        write_len: usize,
+        read_len: usize,
     ) -> Result<(), (Error, &'static mut [u8])> {
         if self.operation.get() == Op::Idle {
             self.buffer.replace(data);
@@ -383,7 +387,7 @@ impl<'a> i2c::I2CDevice for SMBusDevice<'a> {
         }
     }
 
-    fn write(&self, data: &'static mut [u8], len: u8) -> Result<(), (Error, &'static mut [u8])> {
+    fn write(&self, data: &'static mut [u8], len: usize) -> Result<(), (Error, &'static mut [u8])> {
         if self.operation.get() == Op::Idle {
             self.buffer.replace(data);
             self.operation.set(Op::Write(len));
@@ -394,7 +398,11 @@ impl<'a> i2c::I2CDevice for SMBusDevice<'a> {
         }
     }
 
-    fn read(&self, buffer: &'static mut [u8], len: u8) -> Result<(), (Error, &'static mut [u8])> {
+    fn read(
+        &self,
+        buffer: &'static mut [u8],
+        len: usize,
+    ) -> Result<(), (Error, &'static mut [u8])> {
         if self.operation.get() == Op::Idle {
             self.buffer.replace(buffer);
             self.operation.set(Op::Read(len));
@@ -410,8 +418,8 @@ impl<'a> i2c::SMBusDevice for SMBusDevice<'a> {
     fn smbus_write_read(
         &self,
         data: &'static mut [u8],
-        write_len: u8,
-        read_len: u8,
+        write_len: usize,
+        read_len: usize,
     ) -> Result<(), (Error, &'static mut [u8])> {
         if self.operation.get() == Op::Idle {
             self.buffer.replace(data);
@@ -426,7 +434,7 @@ impl<'a> i2c::SMBusDevice for SMBusDevice<'a> {
     fn smbus_write(
         &self,
         data: &'static mut [u8],
-        len: u8,
+        len: usize,
     ) -> Result<(), (Error, &'static mut [u8])> {
         if self.operation.get() == Op::Idle {
             self.buffer.replace(data);
@@ -441,7 +449,7 @@ impl<'a> i2c::SMBusDevice for SMBusDevice<'a> {
     fn smbus_read(
         &self,
         buffer: &'static mut [u8],
-        len: u8,
+        len: usize,
     ) -> Result<(), (Error, &'static mut [u8])> {
         if self.operation.get() == Op::Idle {
             self.buffer.replace(buffer);

--- a/chips/apollo3/src/iom.rs
+++ b/chips/apollo3/src/iom.rs
@@ -690,8 +690,8 @@ impl<'a> Iom<'_> {
         &self,
         addr: u8,
         data: &'static mut [u8],
-        write_len: u8,
-        read_len: u8,
+        write_len: usize,
+        read_len: usize,
     ) -> Result<(), (i2c::Error, &'static mut [u8])> {
         let regs = self.registers;
         let mut offsetlo = 0;
@@ -755,7 +755,7 @@ impl<'a> Iom<'_> {
         &self,
         addr: u8,
         data: &'static mut [u8],
-        len: u8,
+        len: usize,
     ) -> Result<(), (i2c::Error, &'static mut [u8])> {
         let regs = self.registers;
 
@@ -801,7 +801,7 @@ impl<'a> Iom<'_> {
         &self,
         addr: u8,
         buffer: &'static mut [u8],
-        len: u8,
+        len: usize,
     ) -> Result<(), (i2c::Error, &'static mut [u8])> {
         let regs = self.registers;
 
@@ -898,8 +898,8 @@ impl<'a> hil::i2c::I2CMaster for Iom<'a> {
         &self,
         addr: u8,
         data: &'static mut [u8],
-        write_len: u8,
-        read_len: u8,
+        write_len: usize,
+        read_len: usize,
     ) -> Result<(), (hil::i2c::Error, &'static mut [u8])> {
         if self.op.get() != Operation::I2C {
             return Err((hil::i2c::Error::Busy, data));
@@ -914,7 +914,7 @@ impl<'a> hil::i2c::I2CMaster for Iom<'a> {
         &self,
         addr: u8,
         data: &'static mut [u8],
-        len: u8,
+        len: usize,
     ) -> Result<(), (hil::i2c::Error, &'static mut [u8])> {
         if self.op.get() != Operation::I2C {
             return Err((hil::i2c::Error::Busy, data));
@@ -929,7 +929,7 @@ impl<'a> hil::i2c::I2CMaster for Iom<'a> {
         &self,
         addr: u8,
         buffer: &'static mut [u8],
-        len: u8,
+        len: usize,
     ) -> Result<(), (hil::i2c::Error, &'static mut [u8])> {
         if self.op.get() != Operation::I2C {
             return Err((hil::i2c::Error::Busy, buffer));
@@ -946,8 +946,8 @@ impl<'a> hil::i2c::SMBusMaster for Iom<'a> {
         &self,
         addr: u8,
         data: &'static mut [u8],
-        write_len: u8,
-        read_len: u8,
+        write_len: usize,
+        read_len: usize,
     ) -> Result<(), (hil::i2c::Error, &'static mut [u8])> {
         let regs = self.registers;
 
@@ -974,7 +974,7 @@ impl<'a> hil::i2c::SMBusMaster for Iom<'a> {
         &self,
         addr: u8,
         data: &'static mut [u8],
-        len: u8,
+        len: usize,
     ) -> Result<(), (hil::i2c::Error, &'static mut [u8])> {
         let regs = self.registers;
 
@@ -1001,7 +1001,7 @@ impl<'a> hil::i2c::SMBusMaster for Iom<'a> {
         &self,
         addr: u8,
         buffer: &'static mut [u8],
-        len: u8,
+        len: usize,
     ) -> Result<(), (hil::i2c::Error, &'static mut [u8])> {
         let regs = self.registers;
 

--- a/chips/imxrt10xx/src/lpi2c.rs
+++ b/chips/imxrt10xx/src/lpi2c.rs
@@ -438,10 +438,10 @@ pub struct Lpi2c<'a> {
     master_client: OptionalCell<&'a dyn hil::i2c::I2CHwMasterClient>,
 
     buffer: TakeCell<'static, [u8]>,
-    tx_position: Cell<u8>,
-    rx_position: Cell<u8>,
-    tx_len: Cell<u8>,
-    rx_len: Cell<u8>,
+    tx_position: Cell<usize>,
+    rx_position: Cell<usize>,
+    tx_len: Cell<usize>,
+    rx_len: Cell<usize>,
 
     slave_address: Cell<u8>,
 
@@ -726,8 +726,8 @@ impl i2c::I2CMaster for Lpi2c<'_> {
         &self,
         addr: u8,
         data: &'static mut [u8],
-        write_len: u8,
-        read_len: u8,
+        write_len: usize,
+        read_len: usize,
     ) -> Result<(), (i2c::Error, &'static mut [u8])> {
         if self.status.get() == Lpi2cStatus::Idle {
             self.reset();
@@ -748,7 +748,7 @@ impl i2c::I2CMaster for Lpi2c<'_> {
         &self,
         addr: u8,
         data: &'static mut [u8],
-        len: u8,
+        len: usize,
     ) -> Result<(), (i2c::Error, &'static mut [u8])> {
         if self.status.get() == Lpi2cStatus::Idle {
             self.reset();
@@ -768,7 +768,7 @@ impl i2c::I2CMaster for Lpi2c<'_> {
         &self,
         addr: u8,
         buffer: &'static mut [u8],
-        len: u8,
+        len: usize,
     ) -> Result<(), (i2c::Error, &'static mut [u8])> {
         if self.status.get() == Lpi2cStatus::Idle {
             self.reset();

--- a/chips/lowrisc/src/i2c.rs
+++ b/chips/lowrisc/src/i2c.rs
@@ -396,8 +396,8 @@ impl<'a> hil::i2c::I2CMaster for I2c<'a> {
         &self,
         addr: u8,
         data: &'static mut [u8],
-        write_len: u8,
-        read_len: u8,
+        write_len: usize,
+        read_len: usize,
     ) -> Result<(), (hil::i2c::Error, &'static mut [u8])> {
         let regs = self.registers;
 
@@ -444,7 +444,7 @@ impl<'a> hil::i2c::I2CMaster for I2c<'a> {
         &self,
         addr: u8,
         data: &'static mut [u8],
-        len: u8,
+        len: usize,
     ) -> Result<(), (hil::i2c::Error, &'static mut [u8])> {
         let regs = self.registers;
 
@@ -481,7 +481,7 @@ impl<'a> hil::i2c::I2CMaster for I2c<'a> {
         &self,
         addr: u8,
         buffer: &'static mut [u8],
-        len: u8,
+        len: usize,
     ) -> Result<(), (hil::i2c::Error, &'static mut [u8])> {
         let regs = self.registers;
 

--- a/chips/msp432/src/i2c.rs
+++ b/chips/msp432/src/i2c.rs
@@ -25,9 +25,9 @@ enum OperatingMode {
 pub struct I2c<'a> {
     registers: StaticRef<UsciBRegisters>,
     mode: Cell<OperatingMode>,
-    read_len: Cell<u8>,
-    write_len: Cell<u8>,
-    buf_idx: Cell<u8>,
+    read_len: Cell<usize>,
+    write_len: Cell<usize>,
+    buf_idx: Cell<usize>,
     buffer: TakeCell<'static, [u8]>,
     master_client: OptionalCell<&'a dyn i2c::I2CHwMasterClient>,
 }
@@ -120,7 +120,7 @@ impl<'a> I2c<'a> {
         self.registers.ie.modify(usci::UCBxIE::UCTXIE0::CLEAR);
     }
 
-    fn set_byte_counter(&self, val: u8) {
+    fn set_byte_counter(&self, val: usize) {
         self.registers.tbcnt.set(val as u16);
     }
 
@@ -290,7 +290,7 @@ impl<'a> i2c::I2CMaster for I2c<'a> {
         &self,
         addr: u8,
         data: &'static mut [u8],
-        len: u8,
+        len: usize,
     ) -> Result<(), (Error, &'static mut [u8])> {
         if self.mode.get() != OperatingMode::Idle {
             // Module is busy or not activated
@@ -328,7 +328,7 @@ impl<'a> i2c::I2CMaster for I2c<'a> {
         &self,
         addr: u8,
         buffer: &'static mut [u8],
-        len: u8,
+        len: usize,
     ) -> Result<(), (Error, &'static mut [u8])> {
         if self.mode.get() != OperatingMode::Idle {
             // Module is busy or not activated
@@ -363,8 +363,8 @@ impl<'a> i2c::I2CMaster for I2c<'a> {
         &self,
         addr: u8,
         data: &'static mut [u8],
-        write_len: u8,
-        read_len: u8,
+        write_len: usize,
+        read_len: usize,
     ) -> Result<(), (Error, &'static mut [u8])> {
         if self.mode.get() != OperatingMode::Idle {
             // Module is busy or not activated

--- a/chips/nrf52/src/i2c.rs
+++ b/chips/nrf52/src/i2c.rs
@@ -137,7 +137,7 @@ impl TWI {
 
             if self.registers.events_write.is_set(EVENT::EVENT) {
                 self.registers.events_write.write(EVENT::EVENT::CLEAR);
-                let length = self.registers.rxd_amount.read(AMOUNT::AMOUNT) as u8;
+                let length = self.registers.rxd_amount.read(AMOUNT::AMOUNT) as usize;
                 self.slave_client.map(|client| match self.buf.take() {
                     None => (),
                     Some(buf) => {
@@ -152,7 +152,7 @@ impl TWI {
 
             if self.registers.events_read.is_set(EVENT::EVENT) {
                 self.registers.events_read.write(EVENT::EVENT::CLEAR);
-                let length = self.registers.txd_amount.read(AMOUNT::AMOUNT) as u8;
+                let length = self.registers.txd_amount.read(AMOUNT::AMOUNT) as usize;
                 self.slave_client
                     .map(|client| match self.slave_read_buf.take() {
                         None => (),
@@ -208,8 +208,8 @@ impl hil::i2c::I2CMaster for TWI {
         &self,
         addr: u8,
         data: &'static mut [u8],
-        write_len: u8,
-        read_len: u8,
+        write_len: usize,
+        read_len: usize,
     ) -> Result<(), (hil::i2c::Error, &'static mut [u8])> {
         self.registers
             .address_0
@@ -242,7 +242,7 @@ impl hil::i2c::I2CMaster for TWI {
         &self,
         addr: u8,
         data: &'static mut [u8],
-        len: u8,
+        len: usize,
     ) -> Result<(), (hil::i2c::Error, &'static mut [u8])> {
         self.registers
             .address_0
@@ -269,7 +269,7 @@ impl hil::i2c::I2CMaster for TWI {
         &self,
         addr: u8,
         buffer: &'static mut [u8],
-        len: u8,
+        len: usize,
     ) -> Result<(), (hil::i2c::Error, &'static mut [u8])> {
         self.registers
             .address_0
@@ -317,7 +317,7 @@ impl hil::i2c::I2CSlave for TWI {
     fn write_receive(
         &self,
         data: &'static mut [u8],
-        max_len: u8,
+        max_len: usize,
     ) -> Result<(), (hil::i2c::Error, &'static mut [u8])> {
         self.registers.rxd_ptr.set(data.as_mut_ptr() as u32);
         self.registers
@@ -338,7 +338,7 @@ impl hil::i2c::I2CSlave for TWI {
     fn read_send(
         &self,
         data: &'static mut [u8],
-        max_len: u8,
+        max_len: usize,
     ) -> Result<(), (hil::i2c::Error, &'static mut [u8])> {
         self.registers.txd_ptr.set(data.as_mut_ptr() as u32);
         self.registers

--- a/chips/rp2040/src/i2c.rs
+++ b/chips/rp2040/src/i2c.rs
@@ -411,8 +411,8 @@ impl<'a> I2c<'a> {
     fn write_then_read(
         &self,
         addr: u8,
-        write_len: u8,
-        read_len: u8,
+        write_len: usize,
+        read_len: usize,
     ) -> Result<(), hil::i2c::Error> {
         let state = self.state.get();
         assert!(state != State::Uninitialized);
@@ -527,7 +527,7 @@ impl<'a> I2c<'a> {
         self.rw_index.set(idx + 1);
     }
 
-    fn read(&self, addr: u8, len: u8) -> Result<(), hil::i2c::Error> {
+    fn read(&self, addr: u8, len: usize) -> Result<(), hil::i2c::Error> {
         let state = self.state.get();
         assert!(state != State::Uninitialized);
         if state != State::Idle {
@@ -703,8 +703,8 @@ impl<'a> hil::i2c::I2CMaster for I2c<'a> {
         &self,
         addr: u8,
         data: &'static mut [u8],
-        write_len: u8,
-        read_len: u8,
+        write_len: usize,
+        read_len: usize,
     ) -> Result<(), (hil::i2c::Error, &'static mut [u8])> {
         self.buf.put(Some(data));
 
@@ -720,7 +720,7 @@ impl<'a> hil::i2c::I2CMaster for I2c<'a> {
         &self,
         addr: u8,
         data: &'static mut [u8],
-        len: u8,
+        len: usize,
     ) -> Result<(), (hil::i2c::Error, &'static mut [u8])> {
         // Setting read_len to 0 will result in having just a write
         self.write_read(addr, data, len, 0)
@@ -730,7 +730,7 @@ impl<'a> hil::i2c::I2CMaster for I2c<'a> {
         &self,
         addr: u8,
         buffer: &'static mut [u8],
-        len: u8,
+        len: usize,
     ) -> Result<(), (hil::i2c::Error, &'static mut [u8])> {
         self.buf.put(Some(buffer));
 

--- a/chips/sam4l/src/i2c.rs
+++ b/chips/sam4l/src/i2c.rs
@@ -558,11 +558,11 @@ pub struct I2CHw {
     slave_enabled: Cell<bool>,
     my_slave_address: Cell<u8>,
     slave_read_buffer: TakeCell<'static, [u8]>,
-    slave_read_buffer_len: Cell<u8>,
-    slave_read_buffer_index: Cell<u8>,
+    slave_read_buffer_len: Cell<usize>,
+    slave_read_buffer_index: Cell<usize>,
     slave_write_buffer: TakeCell<'static, [u8]>,
-    slave_write_buffer_len: Cell<u8>,
-    slave_write_buffer_index: Cell<u8>,
+    slave_write_buffer_len: Cell<usize>,
+    slave_write_buffer_index: Cell<usize>,
     pm: &'static pm::PowerManager,
 }
 
@@ -879,7 +879,7 @@ impl I2CHw {
         chip: u8,
         flags: FieldValue<u32, Command::Register>,
         direction: FieldValue<u32, Command::Register>,
-        len: u8,
+        len: usize,
     ) {
         // disable before configuring
         twim.registers.cr.write(Control::MDIS::SET);
@@ -909,7 +909,7 @@ impl I2CHw {
         chip: u8,
         flags: FieldValue<u32, Command::Register>,
         direction: FieldValue<u32, Command::Register>,
-        len: u8,
+        len: usize,
     ) {
         // disable before configuring
         twim.registers.cr.write(Control::MDIS::SET);
@@ -936,7 +936,7 @@ impl I2CHw {
         chip: u8,
         flags: FieldValue<u32, Command::Register>,
         data: &'static mut [u8],
-        len: u8,
+        len: usize,
     ) -> Result<(), (hil::i2c::Error, &'static mut [u8])> {
         let twim = &TWIMRegisterManager::new(&self);
         if self.dma.is_some() {
@@ -958,7 +958,7 @@ impl I2CHw {
         chip: u8,
         flags: FieldValue<u32, Command::Register>,
         data: &'static mut [u8],
-        len: u8,
+        len: usize,
     ) -> Result<(), (hil::i2c::Error, &'static mut [u8])> {
         let twim = &TWIMRegisterManager::new(&self);
         if self.dma.is_some() {
@@ -979,8 +979,8 @@ impl I2CHw {
         &self,
         chip: u8,
         data: &'static mut [u8],
-        split: u8,
-        read_len: u8,
+        split: usize,
+        read_len: usize,
     ) -> Result<(), (hil::i2c::Error, &'static mut [u8])> {
         let twim = &TWIMRegisterManager::new(&self);
         if self.dma.is_some() {
@@ -1135,7 +1135,7 @@ impl I2CHw {
                             self.slave_read_buffer.take().map(|buffer| {
                                 client.command_complete(
                                     buffer,
-                                    nbytes as u8,
+                                    nbytes as usize,
                                     hil::i2c::SlaveTransmissionType::Read,
                                 );
                             });
@@ -1161,7 +1161,7 @@ impl I2CHw {
                             self.slave_write_buffer.take().map(|buffer| {
                                 client.command_complete(
                                     buffer,
-                                    nbytes as u8,
+                                    nbytes as usize,
                                     hil::i2c::SlaveTransmissionType::Write,
                                 );
                             });
@@ -1241,7 +1241,7 @@ impl I2CHw {
     fn slave_write_receive(
         &self,
         buffer: &'static mut [u8],
-        len: u8,
+        len: usize,
     ) -> Result<(), (hil::i2c::Error, &'static mut [u8])> {
         if self.slave_enabled.get() {
             if self.slave_mmio_address.is_some() {
@@ -1271,7 +1271,7 @@ impl I2CHw {
     fn slave_read_send(
         &self,
         buffer: &'static mut [u8],
-        len: u8,
+        len: usize,
     ) -> Result<(), (hil::i2c::Error, &'static mut [u8])> {
         if self.slave_enabled.get() {
             if self.slave_mmio_address.is_some() {
@@ -1388,7 +1388,7 @@ impl hil::i2c::I2CMaster for I2CHw {
         &self,
         addr: u8,
         data: &'static mut [u8],
-        len: u8,
+        len: usize,
     ) -> Result<(), (hil::i2c::Error, &'static mut [u8])> {
         I2CHw::write(
             self,
@@ -1403,7 +1403,7 @@ impl hil::i2c::I2CMaster for I2CHw {
         &self,
         addr: u8,
         data: &'static mut [u8],
-        len: u8,
+        len: usize,
     ) -> Result<(), (hil::i2c::Error, &'static mut [u8])> {
         I2CHw::read(
             self,
@@ -1418,8 +1418,8 @@ impl hil::i2c::I2CMaster for I2CHw {
         &self,
         addr: u8,
         data: &'static mut [u8],
-        write_len: u8,
-        read_len: u8,
+        write_len: usize,
+        read_len: usize,
     ) -> Result<(), (hil::i2c::Error, &'static mut [u8])> {
         I2CHw::write_read(self, addr, data, write_len, read_len)
     }
@@ -1483,7 +1483,7 @@ impl hil::i2c::I2CSlave for I2CHw {
     fn write_receive(
         &self,
         data: &'static mut [u8],
-        max_len: u8,
+        max_len: usize,
     ) -> Result<(), (hil::i2c::Error, &'static mut [u8])> {
         self.slave_write_receive(data, max_len)
     }
@@ -1491,7 +1491,7 @@ impl hil::i2c::I2CSlave for I2CHw {
     fn read_send(
         &self,
         data: &'static mut [u8],
-        max_len: u8,
+        max_len: usize,
     ) -> Result<(), (hil::i2c::Error, &'static mut [u8])> {
         self.slave_read_send(data, max_len)
     }

--- a/chips/stm32f303xc/src/i2c.rs
+++ b/chips/stm32f303xc/src/i2c.rs
@@ -238,10 +238,10 @@ pub struct I2C<'a> {
     master_client: OptionalCell<&'a dyn hil::i2c::I2CHwMasterClient>,
 
     buffer: TakeCell<'static, [u8]>,
-    tx_position: Cell<u8>,
-    rx_position: Cell<u8>,
-    tx_len: Cell<u8>,
-    rx_len: Cell<u8>,
+    tx_position: Cell<usize>,
+    rx_position: Cell<usize>,
+    tx_len: Cell<usize>,
+    rx_len: Cell<usize>,
 
     slave_address: Cell<u8>,
 
@@ -485,8 +485,8 @@ impl i2c::I2CMaster for I2C<'_> {
         &self,
         addr: u8,
         data: &'static mut [u8],
-        write_len: u8,
-        read_len: u8,
+        write_len: usize,
+        read_len: usize,
     ) -> Result<(), (Error, &'static mut [u8])> {
         if self.status.get() == I2CStatus::Idle {
             self.reset();
@@ -506,7 +506,7 @@ impl i2c::I2CMaster for I2C<'_> {
         &self,
         addr: u8,
         data: &'static mut [u8],
-        len: u8,
+        len: usize,
     ) -> Result<(), (Error, &'static mut [u8])> {
         if self.status.get() == I2CStatus::Idle {
             self.reset();
@@ -525,7 +525,7 @@ impl i2c::I2CMaster for I2C<'_> {
         &self,
         addr: u8,
         buffer: &'static mut [u8],
-        len: u8,
+        len: usize,
     ) -> Result<(), (Error, &'static mut [u8])> {
         if self.status.get() == I2CStatus::Idle {
             self.reset();

--- a/chips/stm32f4xx/src/i2c.rs
+++ b/chips/stm32f4xx/src/i2c.rs
@@ -187,10 +187,10 @@ pub struct I2C<'a> {
     master_client: OptionalCell<&'a dyn hil::i2c::I2CHwMasterClient>,
 
     buffer: TakeCell<'static, [u8]>,
-    tx_position: Cell<u8>,
-    rx_position: Cell<u8>,
-    tx_len: Cell<u8>,
-    rx_len: Cell<u8>,
+    tx_position: Cell<usize>,
+    rx_position: Cell<usize>,
+    tx_len: Cell<usize>,
+    rx_len: Cell<usize>,
 
     slave_address: Cell<u8>,
 
@@ -414,8 +414,8 @@ impl i2c::I2CMaster for I2C<'_> {
         &self,
         addr: u8,
         data: &'static mut [u8],
-        write_len: u8,
-        read_len: u8,
+        write_len: usize,
+        read_len: usize,
     ) -> Result<(), (Error, &'static mut [u8])> {
         if self.status.get() == I2CStatus::Idle {
             self.reset();
@@ -434,7 +434,7 @@ impl i2c::I2CMaster for I2C<'_> {
         &self,
         addr: u8,
         data: &'static mut [u8],
-        len: u8,
+        len: usize,
     ) -> Result<(), (Error, &'static mut [u8])> {
         if self.status.get() == I2CStatus::Idle {
             self.reset();
@@ -452,7 +452,7 @@ impl i2c::I2CMaster for I2C<'_> {
         &self,
         addr: u8,
         buffer: &'static mut [u8],
-        len: u8,
+        len: usize,
     ) -> Result<(), (Error, &'static mut [u8])> {
         if self.status.get() == I2CStatus::Idle {
             self.reset();

--- a/kernel/src/hil/i2c.rs
+++ b/kernel/src/hil/i2c.rs
@@ -74,20 +74,20 @@ pub trait I2CMaster {
         &self,
         addr: u8,
         data: &'static mut [u8],
-        write_len: u8,
-        read_len: u8,
+        write_len: usize,
+        read_len: usize,
     ) -> Result<(), (Error, &'static mut [u8])>;
     fn write(
         &self,
         addr: u8,
         data: &'static mut [u8],
-        len: u8,
+        len: usize,
     ) -> Result<(), (Error, &'static mut [u8])>;
     fn read(
         &self,
         addr: u8,
         buffer: &'static mut [u8],
-        len: u8,
+        len: usize,
     ) -> Result<(), (Error, &'static mut [u8])>;
 }
 
@@ -113,8 +113,8 @@ pub trait SMBusMaster: I2CMaster {
         &self,
         addr: u8,
         data: &'static mut [u8],
-        write_len: u8,
-        read_len: u8,
+        write_len: usize,
+        read_len: usize,
     ) -> Result<(), (Error, &'static mut [u8])>;
 
     /// Write data via the I2C Master device in an SMBus compatible way.
@@ -132,7 +132,7 @@ pub trait SMBusMaster: I2CMaster {
         &self,
         addr: u8,
         data: &'static mut [u8],
-        len: u8,
+        len: usize,
     ) -> Result<(), (Error, &'static mut [u8])>;
 
     /// Read data via the I2C Master device in an SMBus compatible way.
@@ -150,7 +150,7 @@ pub trait SMBusMaster: I2CMaster {
         &self,
         addr: u8,
         buffer: &'static mut [u8],
-        len: u8,
+        len: usize,
     ) -> Result<(), (Error, &'static mut [u8])>;
 }
 
@@ -163,12 +163,12 @@ pub trait I2CSlave {
     fn write_receive(
         &self,
         data: &'static mut [u8],
-        max_len: u8,
+        max_len: usize,
     ) -> Result<(), (Error, &'static mut [u8])>;
     fn read_send(
         &self,
         data: &'static mut [u8],
-        max_len: u8,
+        max_len: usize,
     ) -> Result<(), (Error, &'static mut [u8])>;
     fn listen(&self);
 }
@@ -192,7 +192,7 @@ pub trait I2CHwSlaveClient {
     fn command_complete(
         &self,
         buffer: &'static mut [u8],
-        length: u8,
+        length: usize,
         transmission_type: SlaveTransmissionType,
     );
 
@@ -220,11 +220,12 @@ pub trait I2CDevice {
     fn write_read(
         &self,
         data: &'static mut [u8],
-        write_len: u8,
-        read_len: u8,
+        write_len: usize,
+        read_len: usize,
     ) -> Result<(), (Error, &'static mut [u8])>;
-    fn write(&self, data: &'static mut [u8], len: u8) -> Result<(), (Error, &'static mut [u8])>;
-    fn read(&self, buffer: &'static mut [u8], len: u8) -> Result<(), (Error, &'static mut [u8])>;
+    fn write(&self, data: &'static mut [u8], len: usize) -> Result<(), (Error, &'static mut [u8])>;
+    fn read(&self, buffer: &'static mut [u8], len: usize)
+        -> Result<(), (Error, &'static mut [u8])>;
 }
 
 pub trait SMBusDevice: I2CDevice {
@@ -244,8 +245,8 @@ pub trait SMBusDevice: I2CDevice {
     fn smbus_write_read(
         &self,
         data: &'static mut [u8],
-        write_len: u8,
-        read_len: u8,
+        write_len: usize,
+        read_len: usize,
     ) -> Result<(), (Error, &'static mut [u8])>;
 
     /// Write data to a slave device in an SMBus compatible way.
@@ -261,7 +262,7 @@ pub trait SMBusDevice: I2CDevice {
     fn smbus_write(
         &self,
         data: &'static mut [u8],
-        len: u8,
+        len: usize,
     ) -> Result<(), (Error, &'static mut [u8])>;
 
     /// Read data from a slave device in an SMBus compatible way.
@@ -277,7 +278,7 @@ pub trait SMBusDevice: I2CDevice {
     fn smbus_read(
         &self,
         buffer: &'static mut [u8],
-        len: u8,
+        len: usize,
     ) -> Result<(), (Error, &'static mut [u8])>;
 }
 


### PR DESCRIPTION
### Pull Request Overview

This pull request changes the length of the buffer that can be read or written on the I2C bus to a `usize` variable. Currently the length is represented by a `u8`, but there are use cases in which an application needs to send more than 256 characters on the I2C bus at once. Is there any reason behind this limitation that I missed? 


### Testing Strategy

This pull request was tested by connecting an I2C peripheral to the `nucleo_429zi` board.


### TODO or Help Wanted

Any review or comment is welcome. 


### Documentation Updated

- [x] No updates are required.

### Formatting

- [x] Ran `make prepush`.
