### PR TITLE
multiple boards: refactored GET_PERIPHERALS

### DIFF
--- a/boards/acd52832/src/main.rs
+++ b/boards/acd52832/src/main.rs
@@ -158,7 +158,7 @@ impl KernelResources<nrf52832::chip::NRF52<'static, Nrf52832DefaultPeripherals<'
 /// removed when this function returns. Otherwise, the stack space used for
 /// these static_inits is wasted.
 #[inline(never)]
-unsafe fn get_peripherals() -> &'static mut Nrf52832DefaultPeripherals<'static> {
+unsafe fn create_peripherals() -> &'static mut Nrf52832DefaultPeripherals<'static> {
     // Initialize chip peripheral drivers
     let nrf52832_peripherals = static_init!(
         Nrf52832DefaultPeripherals,
@@ -173,7 +173,7 @@ unsafe fn get_peripherals() -> &'static mut Nrf52832DefaultPeripherals<'static> 
 pub unsafe fn main() {
     nrf52832::init();
 
-    let nrf52832_peripherals = get_peripherals();
+    let nrf52832_peripherals = create_peripherals();
 
     // set up circular peripheral dependencies
     nrf52832_peripherals.init();

--- a/boards/clue_nrf52840/src/main.rs
+++ b/boards/clue_nrf52840/src/main.rs
@@ -242,7 +242,7 @@ impl KernelResources<nrf52::chip::NRF52<'static, Nrf52840DefaultPeripherals<'sta
 /// removed when this function returns. Otherwise, the stack space used for
 /// these static_inits is wasted.
 #[inline(never)]
-unsafe fn get_peripherals() -> &'static mut Nrf52840DefaultPeripherals<'static> {
+unsafe fn create_peripherals() -> &'static mut Nrf52840DefaultPeripherals<'static> {
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
@@ -257,7 +257,7 @@ unsafe fn get_peripherals() -> &'static mut Nrf52840DefaultPeripherals<'static> 
 pub unsafe fn main() {
     nrf52840::init();
 
-    let nrf52840_peripherals = get_peripherals();
+    let nrf52840_peripherals = create_peripherals();
 
     // set up circular peripheral dependencies
     nrf52840_peripherals.init();

--- a/boards/hail/src/main.rs
+++ b/boards/hail/src/main.rs
@@ -212,7 +212,7 @@ unsafe fn set_pin_primary_functions(peripherals: &Sam4lDefaultPeripherals) {
 /// removed when this function returns. Otherwise, the stack space used for
 /// these static_inits is wasted.
 #[inline(never)]
-unsafe fn get_peripherals(
+unsafe fn create_peripherals(
     pm: &'static sam4l::pm::PowerManager,
 ) -> &'static Sam4lDefaultPeripherals {
     static_init!(Sam4lDefaultPeripherals, Sam4lDefaultPeripherals::new(pm))
@@ -227,7 +227,7 @@ pub unsafe fn main() {
     sam4l::init();
 
     let pm = static_init!(sam4l::pm::PowerManager, sam4l::pm::PowerManager::new());
-    let peripherals = get_peripherals(pm);
+    let peripherals = create_peripherals(pm);
 
     pm.setup_system_clock(
         sam4l::pm::SystemClockSource::PllExternalOscillatorAt48MHz {

--- a/boards/imix/src/main.rs
+++ b/boards/imix/src/main.rs
@@ -304,7 +304,7 @@ unsafe fn set_pin_primary_functions(peripherals: &Sam4lDefaultPeripherals) {
 /// removed when this function returns. Otherwise, the stack space used for
 /// these static_inits is wasted.
 #[inline(never)]
-unsafe fn get_peripherals(
+unsafe fn create_peripherals(
     pm: &'static sam4l::pm::PowerManager,
 ) -> &'static Sam4lDefaultPeripherals {
     static_init!(Sam4lDefaultPeripherals, Sam4lDefaultPeripherals::new(pm))
@@ -317,7 +317,7 @@ unsafe fn get_peripherals(
 pub unsafe fn main() {
     sam4l::init();
     let pm = static_init!(sam4l::pm::PowerManager, sam4l::pm::PowerManager::new());
-    let peripherals = get_peripherals(pm);
+    let peripherals = create_peripherals(pm);
 
     pm.setup_system_clock(
         sam4l::pm::SystemClockSource::PllExternalOscillatorAt48MHz {

--- a/boards/imxrt1050-evkb/src/main.rs
+++ b/boards/imxrt1050-evkb/src/main.rs
@@ -223,7 +223,7 @@ unsafe fn setup_peripherals(peripherals: &imxrt1050::chip::Imxrt10xxDefaultPerip
 /// removed when this function returns. Otherwise, the stack space used for
 /// these static_inits is wasted.
 #[inline(never)]
-unsafe fn get_peripherals() -> &'static mut imxrt1050::chip::Imxrt10xxDefaultPeripherals {
+unsafe fn create_peripherals() -> &'static mut imxrt1050::chip::Imxrt10xxDefaultPeripherals {
     let ccm = static_init!(imxrt1050::ccm::Ccm, imxrt1050::ccm::Ccm::new());
     let peripherals = static_init!(
         imxrt1050::chip::Imxrt10xxDefaultPeripherals,
@@ -240,7 +240,7 @@ unsafe fn get_peripherals() -> &'static mut imxrt1050::chip::Imxrt10xxDefaultPer
 pub unsafe fn main() {
     imxrt1050::init();
 
-    let peripherals = get_peripherals();
+    let peripherals = create_peripherals();
     peripherals.ccm.set_low_power_mode();
     peripherals.lpuart1.disable_clock();
     peripherals.lpuart2.disable_clock();

--- a/boards/microbit_v2/src/main.rs
+++ b/boards/microbit_v2/src/main.rs
@@ -190,7 +190,7 @@ impl KernelResources<nrf52833::chip::NRF52<'static, Nrf52833DefaultPeripherals<'
 /// removed when this function returns. Otherwise, the stack space used for
 /// these static_inits is wasted.
 #[inline(never)]
-unsafe fn get_peripherals() -> &'static mut Nrf52833DefaultPeripherals<'static> {
+unsafe fn create_peripherals() -> &'static mut Nrf52833DefaultPeripherals<'static> {
     // Initialize chip peripheral drivers
     let nrf52833_peripherals = static_init!(
         Nrf52833DefaultPeripherals,
@@ -205,7 +205,7 @@ unsafe fn get_peripherals() -> &'static mut Nrf52833DefaultPeripherals<'static> 
 pub unsafe fn main() {
     nrf52833::init();
 
-    let nrf52833_peripherals = get_peripherals();
+    let nrf52833_peripherals = create_peripherals();
 
     // set up circular peripheral dependencies
     nrf52833_peripherals.init();

--- a/boards/msp_exp432p401r/src/main.rs
+++ b/boards/msp_exp432p401r/src/main.rs
@@ -187,7 +187,7 @@ unsafe fn setup_adc_pins(gpio: &msp432::gpio::GpioManager) {
 /// removed when this function returns. Otherwise, the stack space used for
 /// these static_inits is wasted.
 #[inline(never)]
-unsafe fn get_peripherals() -> &'static mut msp432::chip::Msp432DefaultPeripherals<'static> {
+unsafe fn create_peripherals() -> &'static mut msp432::chip::Msp432DefaultPeripherals<'static> {
     static_init!(
         msp432::chip::Msp432DefaultPeripherals,
         msp432::chip::Msp432DefaultPeripherals::new()
@@ -201,7 +201,7 @@ unsafe fn get_peripherals() -> &'static mut msp432::chip::Msp432DefaultPeriphera
 pub unsafe fn main() {
     startup_intilialisation();
 
-    let peripherals = get_peripherals();
+    let peripherals = create_peripherals();
     peripherals.init();
 
     // Setup the GPIO pins to use the HFXT (high frequency external) oscillator (48MHz)

--- a/boards/nano33ble/src/main.rs
+++ b/boards/nano33ble/src/main.rs
@@ -213,7 +213,7 @@ impl KernelResources<nrf52::chip::NRF52<'static, Nrf52840DefaultPeripherals<'sta
 /// removed when this function returns. Otherwise, the stack space used for
 /// these static_inits is wasted.
 #[inline(never)]
-unsafe fn get_peripherals() -> &'static mut Nrf52840DefaultPeripherals<'static> {
+unsafe fn create_peripherals() -> &'static mut Nrf52840DefaultPeripherals<'static> {
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
@@ -228,7 +228,7 @@ unsafe fn get_peripherals() -> &'static mut Nrf52840DefaultPeripherals<'static> 
 pub unsafe fn main() {
     nrf52840::init();
 
-    let nrf52840_peripherals = get_peripherals();
+    let nrf52840_peripherals = create_peripherals();
 
     // set up circular peripheral dependencies
     nrf52840_peripherals.init();

--- a/boards/nano_rp2040_connect/src/main.rs
+++ b/boards/nano_rp2040_connect/src/main.rs
@@ -237,7 +237,7 @@ fn init_clocks(peripherals: &Rp2040DefaultPeripherals) {
 /// removed when this function returns. Otherwise, the stack space used for
 /// these static_inits is wasted.
 #[inline(never)]
-unsafe fn get_peripherals() -> &'static mut Rp2040DefaultPeripherals<'static> {
+unsafe fn create_peripherals() -> &'static mut Rp2040DefaultPeripherals<'static> {
     static_init!(Rp2040DefaultPeripherals, Rp2040DefaultPeripherals::new())
 }
 
@@ -247,7 +247,7 @@ pub unsafe fn main() {
     // Loads relocations and clears BSS
     rp2040::init();
 
-    let peripherals = get_peripherals();
+    let peripherals = create_peripherals();
     peripherals.resolve_dependencies();
 
     // Set the UART used for panic

--- a/boards/nordic/nrf52840_dongle/src/main.rs
+++ b/boards/nordic/nrf52840_dongle/src/main.rs
@@ -171,7 +171,7 @@ impl KernelResources<nrf52840::chip::NRF52<'static, Nrf52840DefaultPeripherals<'
 /// removed when this function returns. Otherwise, the stack space used for
 /// these static_inits is wasted.
 #[inline(never)]
-unsafe fn get_peripherals() -> &'static mut Nrf52840DefaultPeripherals<'static> {
+unsafe fn create_peripherals() -> &'static mut Nrf52840DefaultPeripherals<'static> {
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
@@ -186,7 +186,7 @@ unsafe fn get_peripherals() -> &'static mut Nrf52840DefaultPeripherals<'static> 
 pub unsafe fn main() {
     nrf52840::init();
 
-    let nrf52840_peripherals = get_peripherals();
+    let nrf52840_peripherals = create_peripherals();
 
     // set up circular peripheral dependencies
     nrf52840_peripherals.init();

--- a/boards/nordic/nrf52840dk/src/main.rs
+++ b/boards/nordic/nrf52840dk/src/main.rs
@@ -227,7 +227,7 @@ impl SyscallDriverLookup for Platform {
 /// removed when this function returns. Otherwise, the stack space used for
 /// these static_inits is wasted.
 #[inline(never)]
-unsafe fn get_peripherals() -> &'static mut Nrf52840DefaultPeripherals<'static> {
+unsafe fn create_peripherals() -> &'static mut Nrf52840DefaultPeripherals<'static> {
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
@@ -280,7 +280,7 @@ impl KernelResources<nrf52840::chip::NRF52<'static, Nrf52840DefaultPeripherals<'
 pub unsafe fn main() {
     nrf52840::init();
 
-    let nrf52840_peripherals = get_peripherals();
+    let nrf52840_peripherals = create_peripherals();
 
     // set up circular peripheral dependencies
     nrf52840_peripherals.init();

--- a/boards/nordic/nrf52dk/src/main.rs
+++ b/boards/nordic/nrf52dk/src/main.rs
@@ -229,7 +229,7 @@ impl KernelResources<nrf52832::chip::NRF52<'static, Nrf52832DefaultPeripherals<'
 /// removed when this function returns. Otherwise, the stack space used for
 /// these static_inits is wasted.
 #[inline(never)]
-unsafe fn get_peripherals() -> &'static mut Nrf52832DefaultPeripherals<'static> {
+unsafe fn create_peripherals() -> &'static mut Nrf52832DefaultPeripherals<'static> {
     // Initialize chip peripheral drivers
     let nrf52832_peripherals = static_init!(
         Nrf52832DefaultPeripherals,
@@ -244,7 +244,7 @@ unsafe fn get_peripherals() -> &'static mut Nrf52832DefaultPeripherals<'static> 
 pub unsafe fn main() {
     nrf52832::init();
 
-    let nrf52832_peripherals = get_peripherals();
+    let nrf52832_peripherals = create_peripherals();
 
     // set up circular peripheral dependencies
     nrf52832_peripherals.init();

--- a/boards/nucleo_f429zi/src/main.rs
+++ b/boards/nucleo_f429zi/src/main.rs
@@ -281,7 +281,7 @@ unsafe fn setup_peripherals(
 /// removed when this function returns. Otherwise, the stack space used for
 /// these static_inits is wasted.
 #[inline(never)]
-unsafe fn get_peripherals() -> (
+unsafe fn create_peripherals() -> (
     &'static mut Stm32f429ziDefaultPeripherals<'static>,
     &'static stm32f429zi::syscfg::Syscfg<'static>,
     &'static stm32f429zi::dma::Dma1<'static>,
@@ -313,7 +313,7 @@ unsafe fn get_peripherals() -> (
 pub unsafe fn main() {
     stm32f429zi::init();
 
-    let (peripherals, syscfg, dma1) = get_peripherals();
+    let (peripherals, syscfg, dma1) = create_peripherals();
     peripherals.init();
     let base_peripherals = &peripherals.stm32f4;
 

--- a/boards/nucleo_f446re/src/main.rs
+++ b/boards/nucleo_f446re/src/main.rs
@@ -255,7 +255,7 @@ unsafe fn setup_peripherals(tim2: &stm32f446re::tim2::Tim2) {
 /// removed when this function returns. Otherwise, the stack space used for
 /// these static_inits is wasted.
 #[inline(never)]
-unsafe fn get_peripherals() -> (
+unsafe fn create_peripherals() -> (
     &'static mut Stm32f446reDefaultPeripherals<'static>,
     &'static stm32f446re::syscfg::Syscfg<'static>,
     &'static stm32f446re::dma::Dma1<'static>,
@@ -287,7 +287,7 @@ unsafe fn get_peripherals() -> (
 pub unsafe fn main() {
     stm32f446re::init();
 
-    let (peripherals, syscfg, dma1) = get_peripherals();
+    let (peripherals, syscfg, dma1) = create_peripherals();
     peripherals.init();
     let base_peripherals = &peripherals.stm32f4;
 

--- a/boards/particle_boron/src/main.rs
+++ b/boards/particle_boron/src/main.rs
@@ -190,7 +190,7 @@ impl KernelResources<nrf52840::chip::NRF52<'static, Nrf52840DefaultPeripherals<'
 /// removed when this function returns. Otherwise, the stack space used for
 /// these static_inits is wasted.
 #[inline(never)]
-unsafe fn get_peripherals() -> &'static mut Nrf52840DefaultPeripherals<'static> {
+unsafe fn create_peripherals() -> &'static mut Nrf52840DefaultPeripherals<'static> {
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
@@ -205,7 +205,7 @@ unsafe fn get_peripherals() -> &'static mut Nrf52840DefaultPeripherals<'static> 
 pub unsafe fn main() {
     nrf52840::init();
 
-    let nrf52840_peripherals = get_peripherals();
+    let nrf52840_peripherals = create_peripherals();
 
     // set up circular peripheral dependencies
     nrf52840_peripherals.init();

--- a/boards/pico_explorer_base/src/main.rs
+++ b/boards/pico_explorer_base/src/main.rs
@@ -242,7 +242,7 @@ fn init_clocks(peripherals: &Rp2040DefaultPeripherals) {
 /// removed when this function returns. Otherwise, the stack space used for
 /// these static_inits is wasted.
 #[inline(never)]
-unsafe fn get_peripherals() -> &'static mut Rp2040DefaultPeripherals<'static> {
+unsafe fn create_peripherals() -> &'static mut Rp2040DefaultPeripherals<'static> {
     static_init!(Rp2040DefaultPeripherals, Rp2040DefaultPeripherals::new())
 }
 
@@ -252,7 +252,7 @@ pub unsafe fn main() {
     // Loads relocations and clears BSS
     rp2040::init();
 
-    let peripherals = get_peripherals();
+    let peripherals = create_peripherals();
     peripherals.resolve_dependencies();
 
     // Set the UART used for panic

--- a/boards/raspberry_pi_pico/src/main.rs
+++ b/boards/raspberry_pi_pico/src/main.rs
@@ -250,7 +250,7 @@ fn init_clocks(peripherals: &Rp2040DefaultPeripherals) {
 /// removed when this function returns. Otherwise, the stack space used for
 /// these static_inits is wasted.
 #[inline(never)]
-unsafe fn get_peripherals() -> &'static mut Rp2040DefaultPeripherals<'static> {
+unsafe fn create_peripherals() -> &'static mut Rp2040DefaultPeripherals<'static> {
     static_init!(Rp2040DefaultPeripherals, Rp2040DefaultPeripherals::new())
 }
 
@@ -260,7 +260,7 @@ pub unsafe fn main() {
     // Loads relocations and clears BSS
     rp2040::init();
 
-    let peripherals = get_peripherals();
+    let peripherals = create_peripherals();
     peripherals.resolve_dependencies();
 
     // Reset all peripherals except QSPI (we might be booting from Flash), PLL USB and PLL SYS

--- a/boards/sma_q3/src/main.rs
+++ b/boards/sma_q3/src/main.rs
@@ -168,7 +168,7 @@ impl KernelResources<nrf52840::chip::NRF52<'static, Nrf52840DefaultPeripherals<'
 /// removed when this function returns. Otherwise, the stack space used for
 /// these static_inits is wasted.
 #[inline(never)]
-unsafe fn get_peripherals() -> &'static mut Nrf52840DefaultPeripherals<'static> {
+unsafe fn create_peripherals() -> &'static mut Nrf52840DefaultPeripherals<'static> {
     // Initialize chip peripheral drivers
     let nrf52840_peripherals = static_init!(
         Nrf52840DefaultPeripherals,
@@ -183,7 +183,7 @@ unsafe fn get_peripherals() -> &'static mut Nrf52840DefaultPeripherals<'static> 
 pub unsafe fn main() {
     nrf52840::init();
 
-    let nrf52840_peripherals = get_peripherals();
+    let nrf52840_peripherals = create_peripherals();
 
     // set up circular peripheral dependencies
     nrf52840_peripherals.init();

--- a/boards/stm32f3discovery/src/main.rs
+++ b/boards/stm32f3discovery/src/main.rs
@@ -348,7 +348,7 @@ unsafe fn setup_peripherals(tim2: &stm32f303xc::tim2::Tim2) {
 /// removed when this function returns. Otherwise, the stack space used for
 /// these static_inits is wasted.
 #[inline(never)]
-unsafe fn get_peripherals() -> (
+unsafe fn create_peripherals() -> (
     &'static mut Stm32f3xxDefaultPeripherals<'static>,
     &'static stm32f303xc::syscfg::Syscfg<'static>,
     &'static stm32f303xc::rcc::Rcc,
@@ -380,7 +380,7 @@ unsafe fn get_peripherals() -> (
 pub unsafe fn main() {
     stm32f303xc::init();
 
-    let (peripherals, syscfg, _rcc) = get_peripherals();
+    let (peripherals, syscfg, _rcc) = create_peripherals();
     peripherals.setup_circular_deps();
 
     set_pin_primary_functions(

--- a/boards/stm32f412gdiscovery/src/main.rs
+++ b/boards/stm32f412gdiscovery/src/main.rs
@@ -374,7 +374,7 @@ unsafe fn setup_peripherals(
 /// removed when this function returns. Otherwise, the stack space used for
 /// these static_inits is wasted.
 #[inline(never)]
-unsafe fn get_peripherals() -> (
+unsafe fn create_peripherals() -> (
     &'static mut Stm32f412gDefaultPeripherals<'static>,
     &'static stm32f412g::syscfg::Syscfg<'static>,
     &'static stm32f412g::dma::Dma1<'static>,
@@ -404,7 +404,7 @@ unsafe fn get_peripherals() -> (
 pub unsafe fn main() {
     stm32f412g::init();
 
-    let (peripherals, syscfg, dma1) = get_peripherals();
+    let (peripherals, syscfg, dma1) = create_peripherals();
     peripherals.init();
     let base_peripherals = &peripherals.stm32f4;
     setup_peripherals(

--- a/boards/stm32f429idiscovery/src/main.rs
+++ b/boards/stm32f429idiscovery/src/main.rs
@@ -264,7 +264,7 @@ unsafe fn setup_peripherals(tim2: &stm32f429zi::tim2::Tim2) {
 /// removed when this function returns. Otherwise, the stack space used for
 /// these static_inits is wasted.
 #[inline(never)]
-unsafe fn get_peripherals() -> (
+unsafe fn create_peripherals() -> (
     &'static mut Stm32f429ziDefaultPeripherals<'static>,
     &'static stm32f429zi::syscfg::Syscfg<'static>,
     &'static stm32f429zi::dma::Dma2<'static>,
@@ -295,7 +295,7 @@ unsafe fn get_peripherals() -> (
 pub unsafe fn main() {
     stm32f429zi::init();
 
-    let (peripherals, syscfg, dma2) = get_peripherals();
+    let (peripherals, syscfg, dma2) = create_peripherals();
     peripherals.init();
     let base_peripherals = &peripherals.stm32f4;
 

--- a/boards/teensy40/src/main.rs
+++ b/boards/teensy40/src/main.rs
@@ -133,7 +133,7 @@ mod dma_config {
 /// removed when this function returns. Otherwise, the stack space used for
 /// these static_inits is wasted.
 #[inline(never)]
-unsafe fn get_peripherals() -> &'static mut imxrt1060::chip::Imxrt10xxDefaultPeripherals {
+unsafe fn create_peripherals() -> &'static mut imxrt1060::chip::Imxrt10xxDefaultPeripherals {
     let ccm = static_init!(imxrt1060::ccm::Ccm, imxrt1060::ccm::Ccm::new());
     let peripherals = static_init!(
         imxrt1060::chip::Imxrt10xxDefaultPeripherals,
@@ -185,7 +185,7 @@ fn set_arm_clock(ccm: &imxrt1060::ccm::Ccm, ccm_analog: &imxrt1060::ccm_analog::
 pub unsafe fn main() {
     imxrt1060::init();
 
-    let peripherals = get_peripherals();
+    let peripherals = create_peripherals();
     peripherals.ccm.set_low_power_mode();
 
     peripherals.dcdc.clock().enable();

--- a/boards/weact_f401ccu6/src/main.rs
+++ b/boards/weact_f401ccu6/src/main.rs
@@ -214,7 +214,7 @@ unsafe fn setup_peripherals(tim2: &stm32f401cc::tim2::Tim2) {
 /// removed when this function returns. Otherwise, the stack space used for
 /// these static_inits is wasted.
 #[inline(never)]
-unsafe fn get_peripherals() -> (
+unsafe fn create_peripherals() -> (
     &'static mut Stm32f401ccDefaultPeripherals<'static>,
     &'static stm32f401cc::syscfg::Syscfg<'static>,
     &'static stm32f401cc::dma::Dma1<'static>,
@@ -246,7 +246,7 @@ unsafe fn get_peripherals() -> (
 pub unsafe fn main() {
     stm32f401cc::init();
 
-    let (peripherals, syscfg, dma1) = get_peripherals();
+    let (peripherals, syscfg, dma1) = create_peripherals();
     peripherals.init();
     let base_peripherals = &peripherals.stm32f4;
 


### PR DESCRIPTION
### Pull Request Overview

This pull request refactors all appearances of the `get_peripherals()` function to `create_peripherals()`.
Issue: https://github.com/tock/tock/issues/3270

### Testing Strategy

This pull request was not tested being only refactoring.

### TODO or Help Wanted

This pull request still needs feedback / code review.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
