### PR TITLE
`licensecheck`: Allow an empty comment line after the header.

### DIFF
--- a/tools/license-checker/src/main.rs
+++ b/tools/license-checker/src/main.rs
@@ -137,6 +137,7 @@ fn check_file(cache: &Cache, path: &Path) -> Vec<ErrorInfo> {
             (NeedCopyright, Comment(comment)) if is_copyright(comment) => (WaitForEnd, None),
             (NeedCopyright, _) => (Done, Some(MissingCopyright)),
             (WaitForEnd, Comment(comment)) if is_copyright(comment) => (WaitForEnd, None),
+            (WaitForEnd, Comment("")) => (Done, None),
             (WaitForEnd, Whitespace) => (Done, None),
             (WaitForEnd, _) => (Done, Some(MissingBlank)),
             (Done, _) => unreachable!("Loop didn't end at EOF"),
@@ -196,6 +197,14 @@ fn main() {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn empty_trailing_comment() {
+        assert_eq!(
+            check_file(&Cache::default(), Path::new("testdata/blank_is_comment.rs")),
+            []
+        );
+    }
 
     #[test]
     fn many_errors() {

--- a/tools/license-checker/testdata/blank_is_comment.rs
+++ b/tools/license-checker/testdata/blank_is_comment.rs
@@ -1,0 +1,8 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright Tock Contributors 2023.
+// Copyright Google LLC 2023.
+//
+// This file has an empty comment line rather than a truly blank line after the
+// header. This should be accepted as well, as it makes sense when the Tock
+// license header is followed by an "Author: " comment.

--- a/tools/license-checker/testdata/many_errors.rs
+++ b/tools/license-checker/testdata/many_errors.rs
@@ -2,6 +2,5 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT [*]
 // Copyright Tock Contributors 2022.
 // Copyright Google LLC 2022.
-//
 // [*] This file is designed to generate the following errors in the license
 // checker: MissingBlank, WrongFirst, WrongSpdx.


### PR DESCRIPTION
### Pull Request Overview

`trd-legal.md` says:

> License and copyright information SHOULD have at least one (1) blank line separating it from any other content in the file.

When I implemented the license checker, I interpreted that as disallowing an empty comment. However, a few files in this repository have an empty comment line after the header instead. This changes the license checker to accept either a truly blank line or an empty comment line after the license header.

Closes #3383

### Testing Strategy

I deleted the `*` line in `/.lcignore`, enabling the comment checker on all files in the repository. I then ran it and used `grep` to filter out `license header missing` errors:

```
jrvanwhy@jrvanwhy:~/tock$ cargo build --manifest-path=tools/license-checker/Cargo.toml --release
    Finished release [optimized] target(s) in 0.05s
jrvanwhy@jrvanwhy:~/tock$ tools/target/release/license-checker 2>&1 | grep -v 'license header missing'
./COPYRIGHT:4: incorrect first line
./COPYRIGHT:5: missing SPDX line
./LICENSE-APACHE:192: incorrect first line
./LICENSE-APACHE:193: missing SPDX line
```

I verified that no `missing blank line after header` errors appeared.

### Open Question

Should I update `trd-legal.md` as well, and if so, what change should I make? I tried tweaking it to be clear but it just didn't flow well. I'm leaning towards leaving it alone.

### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.