### PR TITLE
MLFQSched: fixed invalid logic in redeem_all_procs

### DIFF
--- a/kernel/src/scheduler/mlfq.rs
+++ b/kernel/src/scheduler/mlfq.rs
@@ -91,12 +91,7 @@ impl<'a, A: 'static + time::Alarm<'static>> MLFQSched<'a, A> {
     }
 
     fn redeem_all_procs(&self) {
-        let mut first = true;
-        for queue in self.processes.iter() {
-            if first {
-                continue;
-            }
-            first = false;
+        for queue in self.processes.iter().skip(1) {
             match queue.pop_head() {
                 Some(proc) => self.processes[0].push_tail(proc),
                 None => continue,


### PR DESCRIPTION
fixed the bug described in issue #3389

### Pull Request Overview
This pull request changes the current [MLFQSched::redeem_all_procs](https://github.com/tock/tock/blob/cfd0cdb492f6414e990b15747f5be7434589dc9d/kernel/src/scheduler/mlfq.rs#L93-L105) function which i believe does not do what it was intended to (as mentioned in issue #3389)

### Testing Strategy
i did not test it.

### TODO or Help Wanted
i think a review would be great.

### Documentation Updated
nothing

### Formatting
no
