### PR TITLE
kernel: sched: mlfq

### DIFF
--- a/kernel/src/scheduler/mlfq.rs
+++ b/kernel/src/scheduler/mlfq.rs
@@ -51,7 +51,7 @@ impl<'a> MLFQProcessNode<'a> {
 }
 
 impl<'a> ListNode<'a, MLFQProcessNode<'a>> for MLFQProcessNode<'a> {
-    fn next(&'a self) -> &'static ListLink<'a, MLFQProcessNode<'a>> {
+    fn next(&'a self) -> &'a ListLink<'a, MLFQProcessNode<'a>> {
         &self.next
     }
 }


### PR DESCRIPTION


### Pull Request Overview

I updated the Rust compiler to a February 2023 nightly, and encountered build errors. Specifically:

```
error: impl method assumes more implied bounds than the corresponding trait method
  --> kernel/src/scheduler/mlfq.rs:54:26
   |
54 |     fn next(&'a self) -> &'static ListLink<'a, MLFQProcessNode<'a>> {
   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace this type to make the impl signature compatible: `&'a ListLink<'a, MLFQProcessNode<'a>>`
   |
   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
   = note: for more information, see issue #105572 <https://github.com/rust-lang/rust/issues/105572>
   = note: `#[deny(implied_bounds_entailment)]` on by default
```
This implements the proposed change.

We need to fix this before we will be able to update to a new nightly. However, this seemed perhaps more substantial that the typical fixes needed to update nightlies, so I thought it was worth making a dedicated PR.

### Testing Strategy

compiling


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
