### PR TITLE
kernel: util: static ref deref return type

### DIFF
--- a/kernel/src/utilities/static_ref.rs
+++ b/kernel/src/utilities/static_ref.rs
@@ -37,7 +37,7 @@ impl<T> Copy for StaticRef<T> {}
 
 impl<T> Deref for StaticRef<T> {
     type Target = T;
-    fn deref(&self) -> &'static T {
+    fn deref(&self) -> &T {
         unsafe { &*self.ptr }
     }
 }


### PR DESCRIPTION


### Pull Request Overview

I updated the Rust compiler to a February 2023 nightly, and encountered build errors. Specifically:


```
error: impl method assumes more implied bounds than the corresponding trait method
  --> kernel/src/utilities/static_ref.rs:40:24
   |
40 |     fn deref(&self) -> &'static T {
   |                        ^^^^^^^^^^ help: replace this type to make the impl signature compatible: `&T`
   |
   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
   = note: for more information, see issue #105572 <https://github.com/rust-lang/rust/issues/105572>
```

Again, this changes a very core file, which I don't think should be swept up in an "Update Nightly" pr. 

### Testing Strategy

This pull request was tested by travis.


### TODO or Help Wanted

n/a


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
