### PR TITLE
kernel: fix to follow the implied_bounds_entailment

### DIFF
--- a/kernel/src/scheduler/mlfq.rs
+++ b/kernel/src/scheduler/mlfq.rs
@@ -51,7 +51,7 @@ impl<'a> MLFQProcessNode<'a> {
 }
 
 impl<'a> ListNode<'a, MLFQProcessNode<'a>> for MLFQProcessNode<'a> {
-    fn next(&'a self) -> &'static ListLink<'a, MLFQProcessNode<'a>> {
+    fn next(&'a self) -> &'a ListLink<'a, MLFQProcessNode<'a>> {
         &self.next
     }
 }

--- a/kernel/src/utilities/static_ref.rs
+++ b/kernel/src/utilities/static_ref.rs
@@ -37,7 +37,7 @@ impl<T> Copy for StaticRef<T> {}
 
 impl<T> Deref for StaticRef<T> {
     type Target = T;
-    fn deref(&self) -> &'static T {
+    fn deref(&self) -> &T {
         unsafe { &*self.ptr }
     }
 }


### PR DESCRIPTION
### Pull Request Overview

This pull request (hopefully) fixes the implied `impl` bounds. It updates the `ListNode` impl for `MLFQProcessNode` and `Deref` impl for `StaticRef` following this [rust compiler update](https://github.com/rust-lang/rust/pull/106465). Without this fix, Tock cannot be built on newer Rust versions.


### Testing Strategy

Tock builds now, I think it should be right.


### TODO or Help Wanted

Feedback from someone understanding better the lifetime definitions would be great.


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
