### PR TITLE
Update pinned Tockloader revision in shell.nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -21,14 +21,22 @@ let
 
     tockloader = buildPythonPackage rec {
       pname = "tockloader";
-      version = "1.8.0";
+      version = "1.9.0";
       name = "${pname}-${version}";
 
-      propagatedBuildInputs = [ argcomplete colorama crcmod pyserial pytoml tqdm ];
+      propagatedBuildInputs = [
+        argcomplete
+        colorama
+        crcmod
+        pyserial
+        pytoml
+        tqdm
+        questionary
+      ];
 
       src = fetchPypi {
         inherit pname version;
-        sha256 = "0qniwkhgiwm9bayf1l9s3i83k0f7qm0iqgvjljdj4pf86lqllbb7";
+        sha256 = "sha256-7W55jugVtamFUL8N3dD1LFLJP2UDQb74V6o96rd/tEg=";
       };
     };
   });


### PR DESCRIPTION
### Pull Request Overview

This pull request updates the pinned Tockloader revision in `shell.nix`. It also adds `questionary` as a new required dependency of Tockloader.


### Testing Strategy

This pull request was tested by building the resulting Nix derivation on NixOS 22.11.


### TODO or Help Wanted

N/A


### Documentation Updated

- [x] ~Updated the relevant files in `/docs`,~ or no updates are required.

### Formatting

- [ ] Ran `make prepush`.
