### PR TITLE
led: change command 0 to always return success

### DIFF
--- a/doc/syscalls/00002_leds.md
+++ b/doc/syscalls/00002_leds.md
@@ -17,13 +17,13 @@ main file.
 
   * ### Command number: `0`
 
-    **Description**: How many LEDs are supported on this board.
+    **Description**: Check if there are LEDs on the board
 
     **Argument 1**: unused
 
     **Argument 2**: unused
 
-    **Returns**: The number of LEDs on the board, or `NODEVICE` if this driver
+    **Returns**: `Success` if board has LED support, or `NODEVICE` if this driver
     is not present on the board.
 
   * ### Command number: `1`
@@ -56,6 +56,17 @@ main file.
     **Argument 2**: unused
 
     **Returns**: `Ok(())` if the LED index is valid, `INVAL` otherwise.
+
+  * ### Command number: `4`
+
+    **Description**: How many LEDs are supported on this board.
+
+    **Argument 1**: unused
+
+    **Argument 2**: unused
+
+    **Returns**: The number of LEDs on the board, or `NODEVICE` if this driver
+    is not present on the board.
 
 ## Subscribe
 


### PR DESCRIPTION
command 0 now always returns Success and the led counting functionality has been moved into the new command 4.

### Pull Request Overview

This pull request changes command 0 in the LED capsule to return success (based on issue #3375).
The previous command 0 was checking for led existence as well as returning the number of LEDs
available and has been moved into the new command 4.


### Testing Strategy

This pull request was tested by compiling tock along with modified libtock-c and libtock-rs that have
corresponding changes and then running the example blink (libtock-c) and led (libtock-rs) programs
and witnessing their continued functionality.


### TODO or Help Wanted

This pull request still needs...Nothing, I hope. Please advise me.


### Documentation Updated

- [X] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [X] Ran `make prepush`.
