### PR TITLE
Update command 0 comments on stabilized userspace drivers

### DIFF
--- a/capsules/core/src/adc.rs
+++ b/capsules/core/src/adc.rs
@@ -1188,6 +1188,9 @@ impl<A: hil::adc::Adc + hil::adc::AdcHighSpeed> SyscallDriver for AdcDedicated<'
         }
         match command_num {
             // check if present
+            // TODO(Tock 3.0): TRD104 specifies that Command 0 should return Success, not SuccessU32,
+            // but this driver is unchanged since it has been stabilized. It will be brought into
+            // compliance as part of the next major release of Tock.
             0 => CommandReturn::success_u32(self.channels.len() as u32),
 
             // Single sample on channel

--- a/capsules/core/src/button.rs
+++ b/capsules/core/src/button.rs
@@ -154,6 +154,9 @@ impl<'a, P: gpio::InterruptPin<'a>> SyscallDriver for Button<'a, P> {
         let pins = self.pins;
         match command_num {
             // return button count
+            // TODO(Tock 3.0): TRD104 specifies that Command 0 should return Success, not SuccessU32,
+            // but this driver is unchanged since it has been stabilized. It will be brought into
+            // compliance as part of the next major release of Tock.
             0 => CommandReturn::success_u32(pins.len() as u32),
 
             // enable interrupts for a button

--- a/capsules/core/src/led.rs
+++ b/capsules/core/src/led.rs
@@ -96,6 +96,9 @@ impl<L: led::Led, const NUM_LEDS: usize> SyscallDriver for LedDriver<'_, L, NUM_
     fn command(&self, command_num: usize, data: usize, _: usize, _: ProcessId) -> CommandReturn {
         match command_num {
             // get number of LEDs
+            // TODO(Tock 3.0): TRD104 specifies that Command 0 should return Success, not SuccessU32,
+            // but this driver is unchanged since it has been stabilized. It will be brought into
+            // compliance as part of the next major release of Tock.
             0 => CommandReturn::success_u32(NUM_LEDS as u32),
 
             // on


### PR DESCRIPTION
### Pull Request Overview

This pull request adds comments to the stabilized userspace drivers which return `CommandReturn::success_u32()` instead of `CommandReturn::success()` to note that they are out of sync with the requirements in TRD104 and should be updated whenever the next major release of Tock occurs.


### Testing Strategy

N/A


### TODO or Help Wanted

The following remaining capsules use `success_u32()`, but are not stabilized. I suppose that they should all be changed to be in compliance?

- gpio
- pwm
- analog_comparator
- seven_segment
- read_only_state


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
