### PR TITLE
Fix process console

### DIFF
--- a/capsules/src/process_console.rs
+++ b/capsules/src/process_console.rs
@@ -770,8 +770,7 @@ impl<'a, const COMMAND_HISTORY_LEN: usize, A: Alarm<'a>, C: ProcessManagementCap
                             // Prints kernel memory by moving the writer to the
                             // start state.
                             self.writer_state.replace(WriterState::KernelStart);
-                        }
-                        if clean_str.starts_with("reset") {
+                        } else if clean_str.starts_with("reset") {
                             self.reset_function.map_or_else(
                                 || {
                                     let _ = self.write_bytes(b"Reset function is not implemented");


### PR DESCRIPTION
### Pull Request Overview

This pull request fixes the process console by adding a missing `else` statement in between the commands. This bug was introduced when adding the `reset` command https://github.com/tock/tock/pull/3398. Without this fix, the process console always prints the list of commands.


### Testing Strategy

N/A

### TODO or Help Wanted

N/A


### Documentation Updated

- [x] Updated the relevant files in `/docs`, or no updates are required.

### Formatting

- [x] Ran `make prepush`.
